### PR TITLE
Bug 4750

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -168,6 +168,7 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t)
             {
                 if (fieldi >= ad->fields.dim)
                 {   error(loc, "too many initializers for %s", ad->toChars());
+                    errors = 1;
                     field.remove(i);
                     i--;
                     continue;
@@ -184,6 +185,7 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t)
                 if (!s)
                 {
                     error(loc, "'%s' is not a member of '%s'", id->toChars(), t->toChars());
+                    errors = 1;
                     continue;
                 }
 
@@ -193,6 +195,7 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t)
                     if (fieldi >= ad->fields.dim)
                     {
                         s->error("is not a per-instance initializable field");
+                        errors = 1;
                         break;
                     }
                     if (s == (Dsymbol *)ad->fields.data[fieldi])

--- a/test/fail_compilation/fail225.d
+++ b/test/fail_compilation/fail225.d
@@ -1,11 +1,10 @@
-disabled until bug 4750 is fixed
-//struct Struct { 
-//        char* chptr; 
-//}
-//
-//void main()
-//{
-//        char ch = 'd';
-//        invariant Struct iStruct = {1, &ch};
-//}
+struct Struct { 
+        char* chptr; 
+}
+
+void main()
+{
+        char ch = 'd';
+        invariant Struct iStruct = {1, &ch};
+}
 


### PR DESCRIPTION
Several of the error paths in StructInitializer::semantic fail to set errors which can lead to continuing to work with half built objects.

I'm not sure this is the right fix, but it does fix the segv produced by the dmd failure test fail225.d and doesn't break any existing tests.
