### PR TITLE
Suppress spurious _error messages +  six other bugfixes.

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -949,6 +949,8 @@ void PragmaDeclaration::semantic(Scope *sc)
             e = e->semantic(sc);
             e = e->optimize(WANTvalue | WANTinterpret);
             args->data[0] = (void *)e;
+            if (e->op == TOKerror)
+                goto Lnodecl;
             if (e->op != TOKstring)
                 error("string expected for library name, not '%s'", e->toChars());
             else if (global.params.verbose)

--- a/src/cast.c
+++ b/src/cast.c
@@ -775,6 +775,8 @@ Expression *Expression::castTo(Scope *sc, Type *t)
 #endif
     if (type == t)
         return this;
+    if (op == TOKerror)
+        return this;
     Expression *e = this;
     Type *tb = t->toBasetype();
     Type *typeb = type->toBasetype();

--- a/src/class.c
+++ b/src/class.c
@@ -831,15 +831,15 @@ int ClassDeclaration::isBaseOf(ClassDeclaration *cd, int *poffset)
         *poffset = 0;
     while (cd)
     {
-        if (this == cd->baseClass)
-            return 1;
-
         /* cd->baseClass might not be set if cd is forward referenced.
          */
         if (!cd->baseClass && cd->baseclasses->dim && !cd->isInterfaceDeclaration())
         {
-            cd->error("base class is forward referenced by %s", toChars());
+            cd->semantic(NULL);
         }
+
+        if (this == cd->baseClass)
+            return 1;
 
         cd = cd->baseClass;
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -3627,6 +3627,8 @@ Lagain:
             }
             //printf("sds = %s, '%s'\n", sds->kind(), sds->toChars());
         }
+        if (global.errors)
+            return new ErrorExp();
     }
     else
     {
@@ -5622,6 +5624,8 @@ Expression *CompileExp::semantic(Scope *sc)
 #endif
     UnaExp::semantic(sc);
     e1 = resolveProperties(sc, e1);
+    if (e1->op == TOKerror)
+        return e1;
     if (!e1->type->isString())
     {
         error("argument to mixin must be a string type, not %s\n", e1->type->toChars());
@@ -6364,6 +6368,8 @@ Expression *DotTemplateInstanceExp::semantic(Scope *sc)
     Expression *e = new DotIdExp(loc, e1, ti->name);
 L1:
     e = e->semantic(sc);
+    if (e->op == TOKerror)
+        return e;
     if (e->op == TOKdottd)
     {
         if (global.errors)
@@ -7685,6 +7691,8 @@ Expression *DeleteExp::semantic(Scope *sc)
     UnaExp::semantic(sc);
     e1 = resolveProperties(sc, e1);
     e1 = e1->toLvalue(sc, NULL);
+    if (e1->op == TOKerror)
+        return e1;
     type = Type::tvoid;
 
     tb = e1->type->toBasetype();

--- a/src/expression.c
+++ b/src/expression.c
@@ -3364,17 +3364,21 @@ Expression *StructLiteralExp::semantic(Scope *sc)
         else
         {
             if (v->init)
-            {   e = v->init->toExpression();
-                if (!e)
-                {   error("cannot make expression out of initializer for %s", v->toChars());
-                    return new ErrorExp();
-                }
-                else if (v->scope)
-                {   // Do deferred semantic analysis
-                    Initializer *i2 = v->init->syntaxCopy();
-                    i2 = i2->semantic(v->scope, v->type);
-                    e = i2->toExpression();
-                    v->scope = NULL;
+            {   if (v->init->isVoidInitializer())
+                    e = NULL;
+                else
+                {   e = v->init->toExpression();
+                    if (!e)
+                    {   error("cannot make expression out of initializer for %s", v->toChars());
+                        return new ErrorExp();
+                    }
+                    else if (v->scope)
+                    {   // Do deferred semantic analysis
+                        Initializer *i2 = v->init->syntaxCopy();
+                        i2 = i2->semantic(v->scope, v->type);
+                        e = i2->toExpression();
+                        v->scope = NULL;
+                    }
                 }
             }
             else

--- a/src/init.c
+++ b/src/init.c
@@ -168,6 +168,7 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t)
             {
                 if (fieldi >= ad->fields.dim)
                 {   error(loc, "too many initializers for %s", ad->toChars());
+                    errors = 1;
                     field.remove(i);
                     i--;
                     continue;
@@ -184,6 +185,7 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t)
                 if (!s)
                 {
                     error(loc, "'%s' is not a member of '%s'", id->toChars(), t->toChars());
+                    errors = 1;
                     continue;
                 }
 
@@ -193,6 +195,7 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t)
                     if (fieldi >= ad->fields.dim)
                     {
                         s->error("is not a per-instance initializable field");
+                        errors = 1;
                         break;
                     }
                     if (s == (Dsymbol *)ad->fields.data[fieldi])

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1266,7 +1266,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d)
         }
         else if ((v->isCTFE() || (!v->isDataseg() && istate)) && !v->value)
         {
-            if (v->init)
+            if (v->init && v->type->size() != 0)
             {
                 if (v->init->isVoidInitializer())
                 {
@@ -1338,6 +1338,10 @@ Expression *DeclarationExp::interpret(InterState *istate)
                 error("Declaration %s is not yet implemented in CTFE", toChars());
                 e = EXP_CANT_INTERPRET;
             }
+        }
+        else if (s == v && !v->init && v->type->size()==0)
+        {   // Zero-length arrays don't need an initializer
+            e = v->type->defaultInitLiteral(loc);
         }
 #if DMDV2
         else if (s == v && (v->isConst() || v->isImmutable()) && v->init)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5615,8 +5615,11 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                     *pe = e;
                 }
                 else
+                {
                   Lerror:
                     error(loc, "identifier '%s' of '%s' is not defined", id->toChars(), toChars());
+                    *pe = new ErrorExp();
+                }
                 return;
             }
         L2:
@@ -5715,6 +5718,7 @@ L1:
             else
                 error(loc, "undefined identifier %s", p);
         }
+        *pt = Type::terror;
     }
 }
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7083,7 +7083,11 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
         VarDeclaration *vd = (VarDeclaration *)(sym->fields.data[j]);
         Expression *e;
         if (vd->init)
-            e = vd->init->toExpression();
+        {   if (vd->init->isVoidInitializer())
+                e = NULL;
+            else
+                e = vd->init->toExpression();
+        }
         else
             e = vd->type->defaultInitLiteral();
         structelems->data[j] = e;

--- a/src/parse.c
+++ b/src/parse.c
@@ -482,10 +482,10 @@ Dsymbols *Parser::parseDeclDefs(int once)
                 if (token.value == TOKlparen)
                 {
                     nextToken();
-                    if (token.value == TOKint32v)
+                    if (token.value == TOKint32v && token.uns64value > 0)
                         n = (unsigned)token.uns64value;
                     else
-                    {   error("integer expected, not %s", token.toChars());
+                    {   error("positive integer expected, not %s", token.toChars());
                         n = 1;
                     }
                     nextToken();

--- a/src/statement.c
+++ b/src/statement.c
@@ -3409,7 +3409,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
             Type *tfret = tf->nextOf();
             if (tfret)
             {
-                if (!exp->type->equals(tfret))
+                if (tfret != Type::terror && !exp->type->equals(tfret))
                     error("mismatched function return type inference of %s and %s",
                         exp->type->toChars(), tfret->toChars());
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -321,6 +321,8 @@ Statements *CompileStatement::flatten(Scope *sc)
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
     exp = exp->optimize(WANTvalue | WANTinterpret);
+    if (exp->op == TOKerror)
+        return NULL;
     if (exp->op != TOKstring)
     {   error("argument to mixin must be a string, not (%s)", exp->toChars());
         return NULL;
@@ -1966,6 +1968,9 @@ Lagain:
             }
             break;
         }
+        case Terror:
+            s = NULL;
+            break;
 
         default:
             error("foreach: %s is not an aggregate type", aggr->type->toChars());
@@ -2957,7 +2962,7 @@ Statement *CaseStatement::semantic(Scope *sc)
             }
         }
 
-        if (exp->op != TOKstring && exp->op != TOKint64)
+        if (exp->op != TOKstring && exp->op != TOKint64 && exp->op != TOKerror)
         {
             error("case must be a string or an integral constant, not %s", exp->toChars());
             exp = new IntegerExp(0);
@@ -3067,6 +3072,9 @@ Statement *CaseRangeStatement::semantic(Scope *sc)
     last = last->implicitCastTo(sc, sw->condition->type);
     last = last->optimize(WANTvalue | WANTinterpret);
     uinteger_t lval = last->toInteger();
+
+    if (first->op == TOKerror || last->op == TOKerror)
+        return statement ? statement->semantic(sc) : NULL;
 
     if ( (first->type->isunsigned()  &&  fval > lval) ||
         (!first->type->isunsigned()  &&  (sinteger_t)fval > (sinteger_t)lval))
@@ -3982,6 +3990,8 @@ Statement *WithStatement::semantic(Scope *sc)
     //printf("WithStatement::semantic()\n");
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
+    if (exp->op == TOKerror)
+        return NULL;
     if (exp->op == TOKimport)
     {   ScopeExp *es = (ScopeExp *)exp;
 
@@ -4440,6 +4450,8 @@ Statement *ThrowStatement::semantic(Scope *sc)
 #endif
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
+    if (exp->op == TOKerror)
+        return this;
     ClassDeclaration *cd = exp->type->toBasetype()->isClassHandle();
     if (!cd || ((cd != ClassDeclaration::throwable) && !ClassDeclaration::throwable->isBaseOf(cd, NULL)))
         error("can only throw class objects derived from Throwable, not type %s", exp->type->toChars());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -339,3 +339,14 @@ static assert(is(typeof(compiles!(badassert1(5)))));
 static assert(!is(typeof(compiles!(badslice1([1,2])))));
 static assert(!is(typeof(compiles!(badslice2([1,2])))));
 static assert(!is(typeof(compiles!(badslice3([1,2,3])))));
+
+/*******************************************/
+
+int bug5524(int x, int[] more...)
+{
+    int[0] zz;
+    assert(zz.length==0);
+    return 7 + more.length + x;
+}
+
+static assert(bug5524(3) == 10);

--- a/test/compilable/test1537.d
+++ b/test/compilable/test1537.d
@@ -81,3 +81,16 @@ class Bug5349(T) // segfault D2.051
 }
 
 static assert(!is(typeof(Bug5349!(int))));
+
+/**************************************/
+
+class Bug4033 {}
+
+class Template4033(T) {
+    static assert(is(T : Bug4033));
+}
+
+
+alias Template4033!(Z4033) Bla;
+
+class Z4033 : Bug4033 { }

--- a/test/compilable/test1537.d
+++ b/test/compilable/test1537.d
@@ -90,7 +90,17 @@ class Template4033(T) {
     static assert(is(T : Bug4033));
 }
 
-
 alias Template4033!(Z4033) Bla;
 
 class Z4033 : Bug4033 { }
+
+/**************************************/
+
+struct Bug4322 {
+    int[1] a = void;
+}
+
+void bug4322() {
+    Bug4322 f = Bug4322();
+    Bug4322 g = Bug4322.init;
+}

--- a/test/fail_compilation/fail225.d
+++ b/test/fail_compilation/fail225.d
@@ -1,11 +1,10 @@
-disabled until bug 4750 is fixed
-//struct Struct { 
-//        char* chptr; 
-//}
-//
-//void main()
-//{
-//        char ch = 'd';
-//        invariant Struct iStruct = {1, &ch};
-//}
+struct Struct { 
+        char* chptr; 
+}
+
+void main()
+{
+        char ch = 'd';
+        invariant Struct iStruct = {1, &ch};
+}
 


### PR DESCRIPTION
The error message fix (bug 4329) is the big one. As well as dramatically improving error message quality, it should help a bit with stability, since it means less code is exposed to nonsense syntax trees. The other bugs are pretty simple.
These commits include test cases for the test suite, and also fixes for D1. So you need to pull from donc:dmd-1.x into dmd-1.x, as well.
This will probably be my last pull request from my master branch.

4033 Error: base class is forward referenced
4135 Regression(1.034): ICE(statement.c): mixin in bad foreach, D1 only
4322 "void initializer has no value" on struct/union members initialized to "void"
4329 Do not show error messages that refer to __error
4750 fail_compilation/fail225.d causes dmd to segv
5482 Crash with align(0)
5524 [CTFE] Trouble with typesafe variadic function
