### PR TITLE
Clarify tuple length error message

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2001,7 +2001,7 @@ ILLEGAL_ADDRESS_ERROR:
 
             size_t index = o2->disp;
             if (index >= tup->objects->dim)
-                error(asmstate.loc, "tuple index %u exceeds %u", index, tup->objects->dim);
+                error(asmstate.loc, "tuple index %u exceeds length %u", index, tup->objects->dim);
             else
             {
                 Object *o = (Object *)tup->objects->data[index];

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3266,7 +3266,7 @@ void TypeSArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
             sc = sc->pop();
 
             if (d >= td->objects->dim)
-            {   error(loc, "tuple index %ju exceeds %u", d, td->objects->dim);
+            {   error(loc, "tuple index %ju exceeds length %u", d, td->objects->dim);
                 goto Ldefault;
             }
             Object *o = (Object *)td->objects->data[(size_t)d];


### PR DESCRIPTION
Previously, there would be confusing messages like »tuple index 1 exceeds 1«. This change makes it clear that the second number in the message refers to the tuple length.
