### PR TITLE
Fix for win 32 compilation failure

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -245,7 +245,7 @@ typedef struct Farseg
 struct Linnum
 {
 #if MARS
-        char *filename;         // source file name
+        const char *filename;   // source file name
 #else
         Sfile *filptr;          // file pointer
 #endif


### PR DESCRIPTION
I haven't tested this -- no good access to a win32 build env right now, but it should fix it.
