### PR TITLE
Dwarf (64) fixes / Issue 5569

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1271,19 +1271,19 @@ void dwarf_func_term(Symbol *sfunc)
             debug_loc_buf->write32(funcoffset + 0);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 1);
-            debug_loc_buf->write32(0x04740002);
+            debug_loc_buf->write32(0x04740002);         // DW_OP_breg4: 4
 
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 1);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 3);
-            debug_loc_buf->write32(0x08740002);
+            debug_loc_buf->write32(0x08740002);         // DW_OP_breg4: 8
 
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 3);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + sfunc->Ssize);
-            debug_loc_buf->write32(0x08750002);
+            debug_loc_buf->write32(0x08750002);         // DW_OP_breg5: 8
 
             debug_loc_buf->write32(0);              // 2 words of 0 end it
             debug_loc_buf->write32(0);

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -438,7 +438,7 @@ void dwarf_initfile(const char *filename)
         unsigned char code_alignment_factor;
         unsigned char data_alignment_factor;
         unsigned char return_address_register;
-        unsigned char opcodes[11];
+        unsigned char opcodes[7];
     };
     #pragma pack()
     static DebugFrameHeader debugFrameHeader =
@@ -451,14 +451,13 @@ void dwarf_initfile(const char *filename)
         8,              // return address register
       {
         DW_CFA_def_cfa, 4,4,    // r4,4 [r7,8]
-        DW_CFA_offset   +8,1,   // r8,1 [r10,1]
+        DW_CFA_offset   +8,1,   // r8,1 [r16,1]
         DW_CFA_nop,
         DW_CFA_nop,
       }
     };
     if (I64)
-    {   debugFrameHeader.length = 20;
-        debugFrameHeader.data_alignment_factor = 0x78;          // (-8)
+    {   debugFrameHeader.data_alignment_factor = 0x78;          // (-8)
         debugFrameHeader.return_address_register = 16;
         debugFrameHeader.opcodes[1] = 7;                        // RSP
         debugFrameHeader.opcodes[2] = 8;

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -926,8 +926,14 @@ void dwarf_termfile()
     /* ================================================= */
 
     // Terminate by beg address/end address fields containing 0
-    debug_ranges_buf->write32(0);
-    debug_ranges_buf->write32(0);
+    if (I64)
+    {   debug_ranges_buf->write64(0);
+        debug_ranges_buf->write64(0);
+    }
+    else
+    {   debug_ranges_buf->write32(0);
+        debug_ranges_buf->write32(0);
+    }
 
     /* ================================================= */
 
@@ -1282,10 +1288,21 @@ void dwarf_func_term(Symbol *sfunc)
          * indicate this by adding to the debug_ranges
          */
         targ_size_t offset = debug_ranges_buf->size();
-        debug_ranges_buf->write32(funcoffset);                  // start of function
-        dwarf_addrel(debug_ranges_seg, offset, seg);
-        debug_ranges_buf->write32(funcoffset + sfunc->Ssize);   // end of function
-        dwarf_addrel(debug_ranges_seg, offset + 4, seg);
+
+        if (I64)
+        {
+            debug_ranges_buf->write64(funcoffset);                  // start of function
+            dwarf_addrel64(debug_ranges_seg, offset, seg, 0);
+            debug_ranges_buf->write64(funcoffset + sfunc->Ssize);   // end of function
+            dwarf_addrel64(debug_ranges_seg, offset + 8, seg, 0);
+        }
+        else
+        {
+            debug_ranges_buf->write32(funcoffset);                  // start of function
+            dwarf_addrel(debug_ranges_seg, offset, seg);
+            debug_ranges_buf->write32(funcoffset + sfunc->Ssize);   // end of function
+            dwarf_addrel(debug_ranges_seg, offset + 4, seg);
+        }
 
         /* ============= debug_loc =========================== */
 

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1289,6 +1289,9 @@ void dwarf_func_term(Symbol *sfunc)
 
         /* ============= debug_loc =========================== */
 
+        int op = 0;
+        assert(Poff >= 2 * REGSIZE);
+
         if (I64)
         {
             // set the entry for this function in .debug_loc segment
@@ -1296,19 +1299,25 @@ void dwarf_func_term(Symbol *sfunc)
             debug_loc_buf->write64(funcoffset + 0);
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + 1);
-            debug_loc_buf->write32(0x08770002);         // DW_OP_breg7: 8
+            op = (Poff - REGSIZE) << 24 | (DW_OP_breg0 + dwarf_regno(SP)) << 16
+              | 0x0002; // DW_OP_breg7: 8
+            debug_loc_buf->write32(op);
 
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + 1);
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + 3);
-            debug_loc_buf->write32(0x10770002);         // DW_OP_breg7: 16
+            op = Poff << 24 | (DW_OP_breg0 + dwarf_regno(SP)) << 16
+              | 0x0002; // DW_OP_breg7: 16
+            debug_loc_buf->write32(op);
 
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + 3);
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + sfunc->Ssize);
-            debug_loc_buf->write32(0x10760002);         // DW_OP_breg6: 16
+            op = Poff << 24 | (DW_OP_breg0 + dwarf_regno(BP)) << 16
+              | 0x0002; // DW_OP_breg6: 16
+            debug_loc_buf->write32(op);
 
             debug_loc_buf->write64(0);              // 2 words of 0 end it
             debug_loc_buf->write64(0);
@@ -1320,19 +1329,25 @@ void dwarf_func_term(Symbol *sfunc)
             debug_loc_buf->write32(funcoffset + 0);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 1);
-            debug_loc_buf->write32(0x04740002);         // DW_OP_breg4: 4
+            op = (Poff - REGSIZE) << 24 | (DW_OP_breg0 + dwarf_regno(SP)) << 16
+              | 0x0002; // DW_OP_breg7: 8
+            debug_loc_buf->write32(op);         // DW_OP_breg4: 4
 
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 1);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 3);
-            debug_loc_buf->write32(0x08740002);         // DW_OP_breg4: 8
+            op = Poff << 24 | (DW_OP_breg0 + dwarf_regno(SP)) << 16
+              | 0x0002; // DW_OP_breg4: 8
+            debug_loc_buf->write32(op);         // DW_OP_breg4: 8
 
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 3);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + sfunc->Ssize);
-            debug_loc_buf->write32(0x08750002);         // DW_OP_breg5: 8
+            op = Poff << 24 | (DW_OP_breg0 + dwarf_regno(BP)) << 16
+              | 0x0002; // DW_OP_breg5: 8
+            debug_loc_buf->write32(op);         // DW_OP_breg5: 8
 
             debug_loc_buf->write32(0);              // 2 words of 0 end it
             debug_loc_buf->write32(0);

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1298,7 +1298,6 @@ void dwarf_func_term(Symbol *sfunc)
 
         /* ============= debug_loc =========================== */
 
-        int op = 0;
         assert(Poff >= 2 * REGSIZE);
 
         if (I64)
@@ -1308,25 +1307,28 @@ void dwarf_func_term(Symbol *sfunc)
             debug_loc_buf->write64(funcoffset + 0);
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + 1);
-            op = (Poff - REGSIZE) << 24 | (DW_OP_breg0 + dwarf_regno(SP)) << 16
-              | 0x0002; // DW_OP_breg7: 8
-            debug_loc_buf->write32(op);
+            debug_loc_buf->writeByte(2);
+            debug_loc_buf->writeByte(0);
+            debug_loc_buf->writeByte(DW_OP_breg0 + dwarf_regno(SP));
+            debug_loc_buf->writesLEB128(Poff - REGSIZE);
 
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + 1);
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + 3);
-            op = Poff << 24 | (DW_OP_breg0 + dwarf_regno(SP)) << 16
-              | 0x0002; // DW_OP_breg7: 16
-            debug_loc_buf->write32(op);
+            debug_loc_buf->writeByte(2);
+            debug_loc_buf->writeByte(0);
+            debug_loc_buf->writeByte(DW_OP_breg0 + dwarf_regno(SP));
+            debug_loc_buf->writesLEB128(Poff);
 
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + 3);
             dwarf_addrel64(debug_loc_seg, debug_loc_buf->size(), seg, 0);
             debug_loc_buf->write64(funcoffset + sfunc->Ssize);
-            op = Poff << 24 | (DW_OP_breg0 + dwarf_regno(BP)) << 16
-              | 0x0002; // DW_OP_breg6: 16
-            debug_loc_buf->write32(op);
+            debug_loc_buf->writeByte(2);
+            debug_loc_buf->writeByte(0);
+            debug_loc_buf->writeByte(DW_OP_breg0 + dwarf_regno(BP));
+            debug_loc_buf->writesLEB128(Poff);
 
             debug_loc_buf->write64(0);              // 2 words of 0 end it
             debug_loc_buf->write64(0);
@@ -1338,25 +1340,28 @@ void dwarf_func_term(Symbol *sfunc)
             debug_loc_buf->write32(funcoffset + 0);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 1);
-            op = (Poff - REGSIZE) << 24 | (DW_OP_breg0 + dwarf_regno(SP)) << 16
-              | 0x0002; // DW_OP_breg7: 8
-            debug_loc_buf->write32(op);         // DW_OP_breg4: 4
+            debug_loc_buf->writeByte(2);
+            debug_loc_buf->writeByte(0);
+            debug_loc_buf->writeByte(DW_OP_breg0 + dwarf_regno(SP));
+            debug_loc_buf->writesLEB128(Poff - REGSIZE);
 
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 1);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 3);
-            op = Poff << 24 | (DW_OP_breg0 + dwarf_regno(SP)) << 16
-              | 0x0002; // DW_OP_breg4: 8
-            debug_loc_buf->write32(op);         // DW_OP_breg4: 8
+            debug_loc_buf->writeByte(2);
+            debug_loc_buf->writeByte(0);
+            debug_loc_buf->writeByte(DW_OP_breg0 + dwarf_regno(SP));
+            debug_loc_buf->writesLEB128(Poff);
 
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + 3);
             dwarf_addrel(debug_loc_seg, debug_loc_buf->size(), seg);
             debug_loc_buf->write32(funcoffset + sfunc->Ssize);
-            op = Poff << 24 | (DW_OP_breg0 + dwarf_regno(BP)) << 16
-              | 0x0002; // DW_OP_breg5: 8
-            debug_loc_buf->write32(op);         // DW_OP_breg5: 8
+            debug_loc_buf->writeByte(2);
+            debug_loc_buf->writeByte(0);
+            debug_loc_buf->writeByte(DW_OP_breg0 + dwarf_regno(BP));
+            debug_loc_buf->writesLEB128(Poff);
 
             debug_loc_buf->write32(0);              // 2 words of 0 end it
             debug_loc_buf->write32(0);

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1222,13 +1222,13 @@ void dwarf_func_term(Symbol *sfunc)
                             infobuf->writeByte(DW_OP_fbreg);
                             if (sa->Sclass == SCregpar ||
                                 sa->Sclass == SCparameter)
-                                infobuf->writesLEB128(Poff + sa->Soffset);
-                            else if (sa->Sclass == SCfastpar)
-                                infobuf->writesLEB128(Aoff + BPoff + sa->Soffset);
-                            else if (sa->Sclass == SCbprel)
                                 infobuf->writesLEB128(sa->Soffset);
+                            else if (sa->Sclass == SCfastpar)
+                                infobuf->writesLEB128(Aoff + BPoff - Poff + sa->Soffset);
+                            else if (sa->Sclass == SCbprel)
+                                infobuf->writesLEB128(-Poff + sa->Soffset);
                             else
-                                infobuf->writesLEB128(Aoff + BPoff + sa->Soffset);
+                                infobuf->writesLEB128(Aoff + BPoff - Poff + sa->Soffset);
                         }
                         infobuf->buf[soffset] = infobuf->size() - soffset - 1;
                         break;

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -874,6 +874,9 @@ void dwarf_termfile()
             linebuf->writeByte(0);
             linebuf->writeByte(1);
             linebuf->writeByte(1);
+
+            // reset linnum_data
+            ld->linoff_count = 0;
         }
     }
 

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -687,7 +687,7 @@ int dwarf_line_addfile(const char* filename)
         *pidx = infoFileName_table->length(); // assign newly computed idx
 
         linebuf->writeString(filename);
-        linebuf->writeByte(0);      // index
+        linebuf->writeByte(0);      // directory table index
         linebuf->writeByte(0);      // mtime
         linebuf->writeByte(0);      // length
     }
@@ -806,17 +806,15 @@ void dwarf_termfile()
 
             // Set address to start of segment with DW_LNE_set_address
             linebuf->writeByte(0);
+            linebuf->writeByte(NPTRSIZE + 1);
+            linebuf->writeByte(DW_LNE_set_address);
             if (I64)
             {
-                linebuf->writeByte(9);
-                linebuf->writeByte(2);
                 dwarf_addrel64(lineseg,linebuf->size(),seg,0);
                 linebuf->write64(0);
             }
             else
             {
-                linebuf->writeByte(5);
-                linebuf->writeByte(2);
                 dwarf_addrel(lineseg,linebuf->size(),seg);
                 linebuf->write32(0);
             }


### PR DESCRIPTION
- Made CFA state machine 64 aware
- debug ranges needed to be address size
- corrected frame_base calculation (also 32)
- correct line number information for multiobj (also 32)
