### PR TITLE
CTFE array support. Fixes the biggest problems with CTFE.

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -665,8 +665,7 @@ VarDeclaration::VarDeclaration(Loc loc, Type *type, Identifier *id, Initializer 
     aliassym = NULL;
     onstack = 0;
     canassign = 0;
-    stackvalue = NULL;
-    literalvalue = NULL;
+    setValueNull();
 #if DMDV2
     rundtor = NULL;
     edtor = NULL;

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -665,7 +665,8 @@ VarDeclaration::VarDeclaration(Loc loc, Type *type, Identifier *id, Initializer 
     aliassym = NULL;
     onstack = 0;
     canassign = 0;
-    value = NULL;
+    stackvalue = NULL;
+    literalvalue = NULL;
 #if DMDV2
     rundtor = NULL;
     edtor = NULL;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -261,9 +261,22 @@ struct VarDeclaration : Declaration
     Expression *getValue() { return literalvalue; }
     void setValueNull() { literalvalue = NULL; stackvalue = NULL; }
     void restoreValue(Expression *newval) { literalvalue = newval; }
+    void createValue(Expression *newval)
+    {
+        assert(newval);
+        assert(!literalvalue);
+        if ((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) || 
+            (newval->op==TOKstring) || (newval->op == TOKassocarrayliteral)) {
+        } else printf("%s\n", newval->toChars());
+        assert((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) ||
+               (newval->op==TOKstring)|| (newval->op == TOKassocarrayliteral));
+        literalvalue = newval;
+    }
+
     void setValue(Expression *newval)
     {
         assert(newval);
+        assert(literalvalue);
         if ((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) || 
             (newval->op==TOKstring) || (newval->op == TOKassocarrayliteral)) {
         } else printf("%s\n", newval->toChars());
@@ -275,6 +288,15 @@ struct VarDeclaration : Declaration
     void setStackValue(Expression *newval)
     {
         assert(newval);
+        assert(literalvalue);
+        assert((newval->op !=TOKarrayliteral) && (newval->op!=TOKstructliteral) &&
+               (newval->op!=TOKstring) && (newval->op != TOKassocarrayliteral));
+        literalvalue = newval;
+    }
+    void createStackValue(Expression *newval)
+    {
+        assert(newval);
+        assert(!literalvalue);
         assert((newval->op !=TOKarrayliteral) && (newval->op!=TOKstructliteral) &&
                (newval->op!=TOKstring) && (newval->op != TOKassocarrayliteral));
         literalvalue = newval;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -259,7 +259,26 @@ struct VarDeclaration : Declaration
     Expression **stackvalue;    // for stack variables (int, float, or pointer)
     Expression *literalvalue;   // for struct/array literals
     Expression *getValue() { return literalvalue; }
-    void setValue(Expression *newval) { literalvalue = newval; }
+    void setValueNull() { literalvalue = NULL; stackvalue = NULL; }
+    void restoreValue(Expression *newval) { literalvalue = newval; }
+    void setValue(Expression *newval)
+    {
+        assert(newval);
+        if ((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) || 
+            (newval->op==TOKstring) || (newval->op == TOKassocarrayliteral)) {
+        } else printf("%s\n", newval->toChars());
+        assert((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) ||
+               (newval->op==TOKstring)|| (newval->op == TOKassocarrayliteral));
+        literalvalue = newval;
+    }
+
+    void setStackValue(Expression *newval)
+    {
+        assert(newval);
+        assert((newval->op !=TOKarrayliteral) && (newval->op!=TOKstructliteral) &&
+               (newval->op!=TOKstring) && (newval->op != TOKassocarrayliteral));
+        literalvalue = newval;
+    }
 
 #if DMDV2
     VarDeclaration *rundtor;    // if !NULL, rundtor is tested at runtime to see

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -266,10 +266,13 @@ struct VarDeclaration : Declaration
         assert(newval);
         assert(!literalvalue);
         if ((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) || 
-            (newval->op==TOKstring) || (newval->op == TOKassocarrayliteral)) {
+            (newval->op==TOKstring) || (newval->op == TOKassocarrayliteral) ||
+            (newval->op == TOKnull)
+            ) {
         } else printf("%s\n", newval->toChars());
         assert((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) ||
-               (newval->op==TOKstring)|| (newval->op == TOKassocarrayliteral));
+               (newval->op==TOKstring)|| (newval->op == TOKassocarrayliteral) ||
+               (newval->op == TOKnull));
         literalvalue = newval;
     }
 
@@ -278,10 +281,12 @@ struct VarDeclaration : Declaration
         assert(newval);
         assert(literalvalue);
         if ((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) || 
-            (newval->op==TOKstring) || (newval->op == TOKassocarrayliteral)) {
+            (newval->op==TOKstring) || (newval->op == TOKassocarrayliteral) ||
+            (newval->op == TOKnull)) {
         } else printf("%s\n", newval->toChars());
         assert((newval->op ==TOKarrayliteral) || ( newval->op==TOKstructliteral) ||
-               (newval->op==TOKstring)|| (newval->op == TOKassocarrayliteral));
+               (newval->op==TOKstring)|| (newval->op == TOKassocarrayliteral) || 
+               (newval->op == TOKnull));
         literalvalue = newval;
     }
 

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -252,8 +252,15 @@ struct VarDeclaration : Declaration
                                 // 2: on stack, run destructor anyway
     int canassign;              // it can be assigned to
     Dsymbol *aliassym;          // if redone as alias to another symbol
-    Expression *value;          // when interpreting, this is the value
-                                // (NULL if value not determinable)
+
+    // When interpreting, these hold the value (NULL if value not determinable)
+    // There always needs to be a level of indirection, since pointer/references
+    // may be pointing to this variable.
+    Expression **stackvalue;    // for stack variables (int, float, or pointer)
+    Expression *literalvalue;   // for struct/array literals
+    Expression *getValue() { return literalvalue; }
+    void setValue(Expression *newval) { literalvalue = newval; }
+
 #if DMDV2
     VarDeclaration *rundtor;    // if !NULL, rundtor is tested at runtime to see
                                 // if the destructor should be run. Used to prevent

--- a/src/expression.c
+++ b/src/expression.c
@@ -3507,7 +3507,7 @@ Expression *StructLiteralExp::getField(Type *type, unsigned offset)
             /* If type is a static array, and e is an initializer for that array,
              * then the field initializer should be an array literal of e.
              */
-            if (e->type != type && type->ty == Tsarray)
+            if (e->type->castMod(0) != type->castMod(0) && type->ty == Tsarray)
             {   TypeSArray *tsa = (TypeSArray *)type;
                 uinteger_t length = tsa->dim->toInteger();
                 Expressions *z = new Expressions;

--- a/src/expression.h
+++ b/src/expression.h
@@ -743,7 +743,8 @@ struct UnaExp : Expression
     Expression *optimize(int result);
     void dump(int indent);
     void scanForNestedRef(Scope *sc);
-    Expression *interpretCommon(InterState *istate, Expression *(*fp)(Type *, Expression *));
+    Expression *interpretCommon(InterState *istate, bool wantLvalue,
+        Expression *(*fp)(Type *, Expression *));
     int canThrow(bool mustNotThrow);
     Expression *resolveLoc(Loc loc, Scope *sc);
 
@@ -774,9 +775,12 @@ struct BinExp : Expression
     void incompatibleTypes();
     void dump(int indent);
     void scanForNestedRef(Scope *sc);
-    Expression *interpretCommon(InterState *istate, Expression *(*fp)(Type *, Expression *, Expression *));
-    Expression *interpretCommon2(InterState *istate, Expression *(*fp)(TOK, Type *, Expression *, Expression *));
-    Expression *interpretAssignCommon(InterState *istate, Expression *(*fp)(Type *, Expression *, Expression *), int post = 0);
+    Expression *interpretCommon(InterState *istate, bool wantLvalue,
+        Expression *(*fp)(Type *, Expression *, Expression *));
+    Expression *interpretCommon2(InterState *istate, bool wantLvalue,
+        Expression *(*fp)(TOK, Type *, Expression *, Expression *));
+    Expression *interpretAssignCommon(InterState *istate, bool wantLvalue,
+        Expression *(*fp)(Type *, Expression *, Expression *), int post = 0);
     int canThrow(bool mustNotThrow);
     Expression *arrayOp(Scope *sc);
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -72,6 +72,15 @@ FuncDeclaration *hasThis(Scope *sc);
 Expression *fromConstInitializer(int result, Expression *e);
 int arrayExpressionCanThrow(Expressions *exps, bool mustNotThrow);
 
+/* Interpreter: what form of return value expression is required?
+ */
+enum CtfeGoal
+{   ctfeNeedRvalue,   // Must return an Rvalue
+    ctfeNeedLvalue,   // Must return an Lvalue
+    ctfeNeedAnyValue, // Can return either an Rvalue or an Lvalue
+    ctfeNeedNothing   // The return value is not required
+};
+
 struct IntRange
 {   uinteger_t imin;
     uinteger_t imax;
@@ -142,7 +151,7 @@ struct Expression : Object
     #define WANTvalue   2
     #define WANTinterpret 4
 
-    virtual Expression *interpret(InterState *istate, bool wantLvalue = false);
+    virtual Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
 
     virtual int isConst();
     virtual int isBool(int result);
@@ -179,7 +188,7 @@ struct IntegerExp : Expression
     IntegerExp(dinteger_t value);
     int equals(Object *o);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     char *toChars();
     void dump(int indent);
     IntRange getIntRange();
@@ -214,7 +223,7 @@ struct RealExp : Expression
     RealExp(Loc loc, real_t value, Type *type);
     int equals(Object *o);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     char *toChars();
     dinteger_t toInteger();
     uinteger_t toUInteger();
@@ -237,7 +246,7 @@ struct ComplexExp : Expression
     ComplexExp(Loc loc, complex_t value, Type *type);
     int equals(Object *o);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     char *toChars();
     dinteger_t toInteger();
     uinteger_t toUInteger();
@@ -296,7 +305,7 @@ struct ThisExp : Expression
 
     ThisExp(Loc loc);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int isBool(int result);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int isLvalue();
@@ -334,7 +343,7 @@ struct NullExp : Expression
     void toMangleBuffer(OutBuffer *buf);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     elem *toElem(IRState *irs);
     dt_t **toDt(dt_t **pdt);
 };
@@ -354,7 +363,7 @@ struct StringExp : Expression
     int equals(Object *o);
     char *toChars();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     size_t length();
     StringExp *toUTF8(Scope *sc);
     Expression *implicitCastTo(Scope *sc, Type *t);
@@ -387,7 +396,7 @@ struct TupleExp : Expression
     void checkEscape();
     int checkSideEffect(int flag);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     Expression *castTo(Scope *sc, Type *t);
     elem *toElem(IRState *irs);
     int canThrow(bool mustNotThrow);
@@ -413,7 +422,7 @@ struct ArrayLiteralExp : Expression
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     dt_t **toDt(dt_t **pdt);
@@ -440,7 +449,7 @@ struct AssocArrayLiteralExp : Expression
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     int canThrow(bool mustNotThrow);
@@ -473,7 +482,7 @@ struct StructLiteralExp : Expression
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     dt_t **toDt(dt_t **pdt);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -535,7 +544,7 @@ struct NewExp : Expression
         Type *newtype, Expressions *arguments);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     Expression *optimize(int result);
     elem *toElem(IRState *irs);
     int checkSideEffect(int flag);
@@ -586,7 +595,7 @@ struct SymOffExp : SymbolExp
 
     SymOffExp(Loc loc, Declaration *var, unsigned offset, int hasOverloads = 0);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void checkEscape();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int isConst();
@@ -607,7 +616,7 @@ struct VarExp : SymbolExp
     int equals(Object *o);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void dump(int indent);
     char *toChars();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -646,7 +655,7 @@ struct FuncExp : Expression
     FuncExp(Loc loc, FuncLiteralDeclaration *fd);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void scanForNestedRef(Scope *sc);
     char *toChars();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -666,7 +675,7 @@ struct DeclarationExp : Expression
     DeclarationExp(Loc loc, Dsymbol *declaration);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int checkSideEffect(int flag);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     elem *toElem(IRState *irs);
@@ -743,7 +752,7 @@ struct UnaExp : Expression
     Expression *optimize(int result);
     void dump(int indent);
     void scanForNestedRef(Scope *sc);
-    Expression *interpretCommon(InterState *istate, bool wantLvalue,
+    Expression *interpretCommon(InterState *istate, CtfeGoal goal,
         Expression *(*fp)(Type *, Expression *));
     int canThrow(bool mustNotThrow);
     Expression *resolveLoc(Loc loc, Scope *sc);
@@ -775,11 +784,11 @@ struct BinExp : Expression
     void incompatibleTypes();
     void dump(int indent);
     void scanForNestedRef(Scope *sc);
-    Expression *interpretCommon(InterState *istate, bool wantLvalue,
+    Expression *interpretCommon(InterState *istate, CtfeGoal goal,
         Expression *(*fp)(Type *, Expression *, Expression *));
-    Expression *interpretCommon2(InterState *istate, bool wantLvalue,
+    Expression *interpretCommon2(InterState *istate, CtfeGoal goal,
         Expression *(*fp)(TOK, Type *, Expression *, Expression *));
-    Expression *interpretAssignCommon(InterState *istate, bool wantLvalue,
+    Expression *interpretAssignCommon(InterState *istate, CtfeGoal goal,
         Expression *(*fp)(Type *, Expression *, Expression *), int post = 0);
     int canThrow(bool mustNotThrow);
     Expression *arrayOp(Scope *sc);
@@ -834,7 +843,7 @@ struct AssertExp : UnaExp
     AssertExp(Loc loc, Expression *e, Expression *msg = NULL);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int checkSideEffect(int flag);
     int canThrow(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -876,7 +885,7 @@ struct DotVarExp : UnaExp
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void dump(int indent);
     elem *toElem(IRState *irs);
@@ -901,7 +910,7 @@ struct DelegateExp : UnaExp
 
     DelegateExp(Loc loc, Expression *e, FuncDeclaration *func, int hasOverloads = 0);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -933,7 +942,7 @@ struct CallExp : UnaExp
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int checkSideEffect(int flag);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void dump(int indent);
@@ -971,7 +980,7 @@ struct PtrExp : UnaExp
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     elem *toElem(IRState *irs);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
 
     // For operator overloading
     Identifier *opId();
@@ -982,7 +991,7 @@ struct NegExp : UnaExp
     NegExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1006,7 +1015,7 @@ struct ComExp : UnaExp
     ComExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1021,7 +1030,7 @@ struct NotExp : UnaExp
     NotExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int isBit();
     elem *toElem(IRState *irs);
 };
@@ -1031,7 +1040,7 @@ struct BoolExp : UnaExp
     BoolExp(Loc loc, Expression *e, Type *type);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int isBit();
     elem *toElem(IRState *irs);
 };
@@ -1059,7 +1068,7 @@ struct CastExp : UnaExp
     MATCH implicitConvTo(Type *t);
     IntRange getIntRange();
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int checkSideEffect(int flag);
     void checkEscape();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -1089,7 +1098,7 @@ struct SliceExp : UnaExp
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void dump(int indent);
     elem *toElem(IRState *irs);
     void scanForNestedRef(Scope *sc);
@@ -1106,7 +1115,7 @@ struct ArrayLengthExp : UnaExp
     ArrayLengthExp(Loc loc, Expression *e1);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     elem *toElem(IRState *irs);
 
@@ -1160,7 +1169,7 @@ struct CommaExp : BinExp
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     elem *toElem(IRState *irs);
 };
 
@@ -1176,7 +1185,7 @@ struct IndexExp : BinExp
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     Expression *doInline(InlineDoState *ids);
     void scanForNestedRef(Scope *sc);
 
@@ -1189,7 +1198,7 @@ struct PostExp : BinExp
 {
     PostExp(enum TOK op, Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Identifier *opId();    // For operator overloading
     elem *toElem(IRState *irs);
@@ -1210,7 +1219,7 @@ struct AssignExp : BinExp
     AssignExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *checkToBoolean(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     Identifier *opId();    // For operator overloading
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
@@ -1227,7 +1236,7 @@ struct op##AssignExp : BinAssignExp                             \
 {                                                               \
     op##AssignExp(Loc loc, Expression *e1, Expression *e2);     \
     Expression *semantic(Scope *sc);                            \
-    Expression *interpret(InterState *istate, bool wantLvalue = false);                  \
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);                  \
     X(void buildArrayIdent(OutBuffer *buf, Expressions *arguments);) \
     X(Expression *buildArrayLoop(Parameters *fparams);)         \
                                                                 \
@@ -1272,7 +1281,7 @@ struct AddExp : BinExp
     AddExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1289,7 +1298,7 @@ struct MinExp : BinExp
     MinExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1305,7 +1314,7 @@ struct CatExp : BinExp
     CatExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
 
     // For operator overloading
     Identifier *opId();
@@ -1319,7 +1328,7 @@ struct MulExp : BinExp
     MulExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1336,7 +1345,7 @@ struct DivExp : BinExp
     DivExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
     IntRange getIntRange();
@@ -1353,7 +1362,7 @@ struct ModExp : BinExp
     ModExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1381,7 +1390,7 @@ struct ShlExp : BinExp
     ShlExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     IntRange getIntRange();
 
     // For operator overloading
@@ -1396,7 +1405,7 @@ struct ShrExp : BinExp
     ShrExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     IntRange getIntRange();
 
     // For operator overloading
@@ -1411,7 +1420,7 @@ struct UshrExp : BinExp
     UshrExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     IntRange getIntRange();
 
     // For operator overloading
@@ -1426,7 +1435,7 @@ struct AndExp : BinExp
     AndExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
     IntRange getIntRange();
@@ -1444,7 +1453,7 @@ struct OrExp : BinExp
     OrExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
     MATCH implicitConvTo(Type *t);
@@ -1463,7 +1472,7 @@ struct XorExp : BinExp
     XorExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
     MATCH implicitConvTo(Type *t);
@@ -1484,7 +1493,7 @@ struct OrOrExp : BinExp
     Expression *checkToBoolean(Scope *sc);
     int isBit();
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int checkSideEffect(int flag);
     elem *toElem(IRState *irs);
 };
@@ -1496,7 +1505,7 @@ struct AndAndExp : BinExp
     Expression *checkToBoolean(Scope *sc);
     int isBit();
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int checkSideEffect(int flag);
     elem *toElem(IRState *irs);
 };
@@ -1506,7 +1515,7 @@ struct CmpExp : BinExp
     CmpExp(enum TOK op, Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int isBit();
 
     // For operator overloading
@@ -1544,7 +1553,7 @@ struct EqualExp : BinExp
     EqualExp(enum TOK op, Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     int isBit();
 
     // For operator overloading
@@ -1563,7 +1572,7 @@ struct IdentityExp : BinExp
     Expression *semantic(Scope *sc);
     int isBit();
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     elem *toElem(IRState *irs);
 };
 
@@ -1577,7 +1586,7 @@ struct CondExp : BinExp
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void checkEscape();
     void checkEscapeRef();
     int isLvalue();

--- a/src/expression.h
+++ b/src/expression.h
@@ -142,7 +142,7 @@ struct Expression : Object
     #define WANTvalue   2
     #define WANTinterpret 4
 
-    virtual Expression *interpret(InterState *istate);
+    virtual Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     virtual int isConst();
     virtual int isBool(int result);
@@ -179,7 +179,7 @@ struct IntegerExp : Expression
     IntegerExp(dinteger_t value);
     int equals(Object *o);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     char *toChars();
     void dump(int indent);
     IntRange getIntRange();
@@ -214,7 +214,7 @@ struct RealExp : Expression
     RealExp(Loc loc, real_t value, Type *type);
     int equals(Object *o);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     char *toChars();
     dinteger_t toInteger();
     uinteger_t toUInteger();
@@ -237,7 +237,7 @@ struct ComplexExp : Expression
     ComplexExp(Loc loc, complex_t value, Type *type);
     int equals(Object *o);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     char *toChars();
     dinteger_t toInteger();
     uinteger_t toUInteger();
@@ -296,7 +296,7 @@ struct ThisExp : Expression
 
     ThisExp(Loc loc);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int isBool(int result);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int isLvalue();
@@ -334,7 +334,7 @@ struct NullExp : Expression
     void toMangleBuffer(OutBuffer *buf);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     elem *toElem(IRState *irs);
     dt_t **toDt(dt_t **pdt);
 };
@@ -354,7 +354,7 @@ struct StringExp : Expression
     int equals(Object *o);
     char *toChars();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     size_t length();
     StringExp *toUTF8(Scope *sc);
     Expression *implicitCastTo(Scope *sc, Type *t);
@@ -387,7 +387,7 @@ struct TupleExp : Expression
     void checkEscape();
     int checkSideEffect(int flag);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     Expression *castTo(Scope *sc, Type *t);
     elem *toElem(IRState *irs);
     int canThrow(bool mustNotThrow);
@@ -413,7 +413,7 @@ struct ArrayLiteralExp : Expression
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     dt_t **toDt(dt_t **pdt);
@@ -440,7 +440,7 @@ struct AssocArrayLiteralExp : Expression
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     int canThrow(bool mustNotThrow);
@@ -473,7 +473,7 @@ struct StructLiteralExp : Expression
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     dt_t **toDt(dt_t **pdt);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -535,7 +535,7 @@ struct NewExp : Expression
         Type *newtype, Expressions *arguments);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     Expression *optimize(int result);
     elem *toElem(IRState *irs);
     int checkSideEffect(int flag);
@@ -586,7 +586,7 @@ struct SymOffExp : SymbolExp
 
     SymOffExp(Loc loc, Declaration *var, unsigned offset, int hasOverloads = 0);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void checkEscape();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int isConst();
@@ -607,7 +607,7 @@ struct VarExp : SymbolExp
     int equals(Object *o);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void dump(int indent);
     char *toChars();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -646,7 +646,7 @@ struct FuncExp : Expression
     FuncExp(Loc loc, FuncLiteralDeclaration *fd);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void scanForNestedRef(Scope *sc);
     char *toChars();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -666,7 +666,7 @@ struct DeclarationExp : Expression
     DeclarationExp(Loc loc, Dsymbol *declaration);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int checkSideEffect(int flag);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     elem *toElem(IRState *irs);
@@ -830,7 +830,7 @@ struct AssertExp : UnaExp
     AssertExp(Loc loc, Expression *e, Expression *msg = NULL);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int checkSideEffect(int flag);
     int canThrow(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -872,7 +872,7 @@ struct DotVarExp : UnaExp
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void dump(int indent);
     elem *toElem(IRState *irs);
@@ -897,7 +897,7 @@ struct DelegateExp : UnaExp
 
     DelegateExp(Loc loc, Expression *e, FuncDeclaration *func, int hasOverloads = 0);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -929,7 +929,7 @@ struct CallExp : UnaExp
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int checkSideEffect(int flag);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void dump(int indent);
@@ -967,7 +967,7 @@ struct PtrExp : UnaExp
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     elem *toElem(IRState *irs);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     // For operator overloading
     Identifier *opId();
@@ -978,7 +978,7 @@ struct NegExp : UnaExp
     NegExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1002,7 +1002,7 @@ struct ComExp : UnaExp
     ComExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1017,7 +1017,7 @@ struct NotExp : UnaExp
     NotExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int isBit();
     elem *toElem(IRState *irs);
 };
@@ -1027,7 +1027,7 @@ struct BoolExp : UnaExp
     BoolExp(Loc loc, Expression *e, Type *type);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int isBit();
     elem *toElem(IRState *irs);
 };
@@ -1055,7 +1055,7 @@ struct CastExp : UnaExp
     MATCH implicitConvTo(Type *t);
     IntRange getIntRange();
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int checkSideEffect(int flag);
     void checkEscape();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -1085,7 +1085,7 @@ struct SliceExp : UnaExp
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void dump(int indent);
     elem *toElem(IRState *irs);
     void scanForNestedRef(Scope *sc);
@@ -1102,7 +1102,7 @@ struct ArrayLengthExp : UnaExp
     ArrayLengthExp(Loc loc, Expression *e1);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     elem *toElem(IRState *irs);
 
@@ -1156,7 +1156,7 @@ struct CommaExp : BinExp
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     elem *toElem(IRState *irs);
 };
 
@@ -1172,7 +1172,7 @@ struct IndexExp : BinExp
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     Expression *doInline(InlineDoState *ids);
     void scanForNestedRef(Scope *sc);
 
@@ -1185,7 +1185,7 @@ struct PostExp : BinExp
 {
     PostExp(enum TOK op, Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Identifier *opId();    // For operator overloading
     elem *toElem(IRState *irs);
@@ -1206,7 +1206,7 @@ struct AssignExp : BinExp
     AssignExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *checkToBoolean(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     Identifier *opId();    // For operator overloading
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
@@ -1223,7 +1223,7 @@ struct op##AssignExp : BinAssignExp                             \
 {                                                               \
     op##AssignExp(Loc loc, Expression *e1, Expression *e2);     \
     Expression *semantic(Scope *sc);                            \
-    Expression *interpret(InterState *istate);                  \
+    Expression *interpret(InterState *istate, bool wantLvalue = false);                  \
     X(void buildArrayIdent(OutBuffer *buf, Expressions *arguments);) \
     X(Expression *buildArrayLoop(Parameters *fparams);)         \
                                                                 \
@@ -1268,7 +1268,7 @@ struct AddExp : BinExp
     AddExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1285,7 +1285,7 @@ struct MinExp : BinExp
     MinExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1301,7 +1301,7 @@ struct CatExp : BinExp
     CatExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     // For operator overloading
     Identifier *opId();
@@ -1315,7 +1315,7 @@ struct MulExp : BinExp
     MulExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1332,7 +1332,7 @@ struct DivExp : BinExp
     DivExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
     IntRange getIntRange();
@@ -1349,7 +1349,7 @@ struct ModExp : BinExp
     ModExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
 
@@ -1377,7 +1377,7 @@ struct ShlExp : BinExp
     ShlExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     IntRange getIntRange();
 
     // For operator overloading
@@ -1392,7 +1392,7 @@ struct ShrExp : BinExp
     ShrExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     IntRange getIntRange();
 
     // For operator overloading
@@ -1407,7 +1407,7 @@ struct UshrExp : BinExp
     UshrExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     IntRange getIntRange();
 
     // For operator overloading
@@ -1422,7 +1422,7 @@ struct AndExp : BinExp
     AndExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
     IntRange getIntRange();
@@ -1440,7 +1440,7 @@ struct OrExp : BinExp
     OrExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
     MATCH implicitConvTo(Type *t);
@@ -1459,7 +1459,7 @@ struct XorExp : BinExp
     XorExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
     MATCH implicitConvTo(Type *t);
@@ -1480,7 +1480,7 @@ struct OrOrExp : BinExp
     Expression *checkToBoolean(Scope *sc);
     int isBit();
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int checkSideEffect(int flag);
     elem *toElem(IRState *irs);
 };
@@ -1492,7 +1492,7 @@ struct AndAndExp : BinExp
     Expression *checkToBoolean(Scope *sc);
     int isBit();
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int checkSideEffect(int flag);
     elem *toElem(IRState *irs);
 };
@@ -1502,7 +1502,7 @@ struct CmpExp : BinExp
     CmpExp(enum TOK op, Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int isBit();
 
     // For operator overloading
@@ -1540,7 +1540,7 @@ struct EqualExp : BinExp
     EqualExp(enum TOK op, Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int isBit();
 
     // For operator overloading
@@ -1559,7 +1559,7 @@ struct IdentityExp : BinExp
     Expression *semantic(Scope *sc);
     int isBit();
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     elem *toElem(IRState *irs);
 };
 
@@ -1573,7 +1573,7 @@ struct CondExp : BinExp
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *optimize(int result);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void checkEscape();
     void checkEscapeRef();
     int isLvalue();

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2526,7 +2526,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
                     {
                         sexp->e1 = v2->getValue();
                         v->setValueNull();
-                        v->restoreValue(sexp);
+                        v->createValue(sexp);
                     }
                     else if (v2->getValue()->op == TOKslice)
                     {
@@ -2536,7 +2536,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
                         sexp->upr = new IntegerExp(loc, sexp->upr->toInteger()+sexp2->lwr->toInteger(), Type::tsize_t);
                         sexp->lwr = low;
                         v->setValueNull();
-                        v->restoreValue(sexp);
+                        v->createValue(sexp);
                     }
                     else
                     {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -330,7 +330,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
  *      !NULL   expression from return statement
  */
 
-Expression *Statement::interpret(InterState *istate)
+Expression *Statement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("Statement::interpret()\n");
@@ -340,7 +340,7 @@ Expression *Statement::interpret(InterState *istate)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *ExpStatement::interpret(InterState *istate)
+Expression *ExpStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("ExpStatement::interpret(%s)\n", exp ? exp->toChars() : "");
@@ -358,7 +358,7 @@ Expression *ExpStatement::interpret(InterState *istate)
     return NULL;
 }
 
-Expression *CompoundStatement::interpret(InterState *istate)
+Expression *CompoundStatement::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e = NULL;
 
 #if LOG
@@ -385,7 +385,7 @@ Expression *CompoundStatement::interpret(InterState *istate)
     return e;
 }
 
-Expression *UnrolledLoopStatement::interpret(InterState *istate)
+Expression *UnrolledLoopStatement::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e = NULL;
 
 #if LOG
@@ -416,7 +416,7 @@ Expression *UnrolledLoopStatement::interpret(InterState *istate)
     return e;
 }
 
-Expression *IfStatement::interpret(InterState *istate)
+Expression *IfStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("IfStatement::interpret(%s)\n", condition->toChars());
@@ -451,7 +451,7 @@ Expression *IfStatement::interpret(InterState *istate)
     return e;
 }
 
-Expression *ScopeStatement::interpret(InterState *istate)
+Expression *ScopeStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("ScopeStatement::interpret()\n");
@@ -609,7 +609,7 @@ Expression * replaceReturnReference(Expression *original, InterState *istate)
      return r;
 }
 
-Expression *ReturnStatement::interpret(InterState *istate)
+Expression *ReturnStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("ReturnStatement::interpret(%s)\n", exp ? exp->toChars() : "");
@@ -651,7 +651,7 @@ Expression *ReturnStatement::interpret(InterState *istate)
     return e;
 }
 
-Expression *BreakStatement::interpret(InterState *istate)
+Expression *BreakStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("BreakStatement::interpret()\n");
@@ -663,7 +663,7 @@ Expression *BreakStatement::interpret(InterState *istate)
         return EXP_BREAK_INTERPRET;
 }
 
-Expression *ContinueStatement::interpret(InterState *istate)
+Expression *ContinueStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("ContinueStatement::interpret()\n");
@@ -675,7 +675,7 @@ Expression *ContinueStatement::interpret(InterState *istate)
         return EXP_CONTINUE_INTERPRET;
 }
 
-Expression *WhileStatement::interpret(InterState *istate)
+Expression *WhileStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("WhileStatement::interpret()\n");
@@ -684,7 +684,7 @@ Expression *WhileStatement::interpret(InterState *istate)
     return NULL;
 }
 
-Expression *DoStatement::interpret(InterState *istate)
+Expression *DoStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("DoStatement::interpret()\n");
@@ -741,7 +741,7 @@ Expression *DoStatement::interpret(InterState *istate)
     return e;
 }
 
-Expression *ForStatement::interpret(InterState *istate)
+Expression *ForStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("ForStatement::interpret()\n");
@@ -814,7 +814,7 @@ Expression *ForStatement::interpret(InterState *istate)
     return e;
 }
 
-Expression *ForeachStatement::interpret(InterState *istate)
+Expression *ForeachStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if 1
     assert(0);                  // rewritten to ForStatement
@@ -906,7 +906,7 @@ Expression *ForeachStatement::interpret(InterState *istate)
 }
 
 #if DMDV2
-Expression *ForeachRangeStatement::interpret(InterState *istate)
+Expression *ForeachRangeStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if 1
     assert(0);                  // rewritten to ForStatement
@@ -996,7 +996,7 @@ Expression *ForeachRangeStatement::interpret(InterState *istate)
 }
 #endif
 
-Expression *SwitchStatement::interpret(InterState *istate)
+Expression *SwitchStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("SwitchStatement::interpret()\n");
@@ -1052,7 +1052,7 @@ Expression *SwitchStatement::interpret(InterState *istate)
     return e;
 }
 
-Expression *CaseStatement::interpret(InterState *istate)
+Expression *CaseStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("CaseStatement::interpret(%s) this = %p\n", exp->toChars(), this);
@@ -1065,7 +1065,7 @@ Expression *CaseStatement::interpret(InterState *istate)
         return NULL;
 }
 
-Expression *DefaultStatement::interpret(InterState *istate)
+Expression *DefaultStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("DefaultStatement::interpret()\n");
@@ -1078,7 +1078,7 @@ Expression *DefaultStatement::interpret(InterState *istate)
         return NULL;
 }
 
-Expression *GotoStatement::interpret(InterState *istate)
+Expression *GotoStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("GotoStatement::interpret()\n");
@@ -1089,7 +1089,7 @@ Expression *GotoStatement::interpret(InterState *istate)
     return EXP_GOTO_INTERPRET;
 }
 
-Expression *GotoCaseStatement::interpret(InterState *istate)
+Expression *GotoCaseStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("GotoCaseStatement::interpret()\n");
@@ -1100,7 +1100,7 @@ Expression *GotoCaseStatement::interpret(InterState *istate)
     return EXP_GOTO_INTERPRET;
 }
 
-Expression *GotoDefaultStatement::interpret(InterState *istate)
+Expression *GotoDefaultStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("GotoDefaultStatement::interpret()\n");
@@ -1111,7 +1111,7 @@ Expression *GotoDefaultStatement::interpret(InterState *istate)
     return EXP_GOTO_INTERPRET;
 }
 
-Expression *LabelStatement::interpret(InterState *istate)
+Expression *LabelStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("LabelStatement::interpret()\n");
@@ -1122,7 +1122,7 @@ Expression *LabelStatement::interpret(InterState *istate)
 }
 
 
-Expression *TryCatchStatement::interpret(InterState *istate)
+Expression *TryCatchStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("TryCatchStatement::interpret()\n");
@@ -1133,7 +1133,7 @@ Expression *TryCatchStatement::interpret(InterState *istate)
 }
 
 
-Expression *TryFinallyStatement::interpret(InterState *istate)
+Expression *TryFinallyStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("TryFinallyStatement::interpret()\n");
@@ -1143,7 +1143,7 @@ Expression *TryFinallyStatement::interpret(InterState *istate)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *ThrowStatement::interpret(InterState *istate)
+Expression *ThrowStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("ThrowStatement::interpret()\n");
@@ -1153,7 +1153,7 @@ Expression *ThrowStatement::interpret(InterState *istate)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *OnScopeStatement::interpret(InterState *istate)
+Expression *OnScopeStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("OnScopeStatement::interpret()\n");
@@ -1163,7 +1163,7 @@ Expression *OnScopeStatement::interpret(InterState *istate)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *WithStatement::interpret(InterState *istate)
+Expression *WithStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("WithStatement::interpret()\n");
@@ -1173,7 +1173,7 @@ Expression *WithStatement::interpret(InterState *istate)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *AsmStatement::interpret(InterState *istate)
+Expression *AsmStatement::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("AsmStatement::interpret()\n");
@@ -1185,7 +1185,7 @@ Expression *AsmStatement::interpret(InterState *istate)
 
 /******************************** Expression ***************************/
 
-Expression *Expression::interpret(InterState *istate)
+Expression *Expression::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("Expression::interpret() %s\n", toChars());
@@ -1196,7 +1196,7 @@ Expression *Expression::interpret(InterState *istate)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *ThisExp::interpret(InterState *istate)
+Expression *ThisExp::interpret(InterState *istate, bool wantLvalue)
 {
     if (istate && istate->localThis)
         return istate->localThis->interpret(istate);
@@ -1204,12 +1204,12 @@ Expression *ThisExp::interpret(InterState *istate)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *NullExp::interpret(InterState *istate)
+Expression *NullExp::interpret(InterState *istate, bool wantLvalue)
 {
     return this;
 }
 
-Expression *IntegerExp::interpret(InterState *istate)
+Expression *IntegerExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("IntegerExp::interpret() %s\n", toChars());
@@ -1217,7 +1217,7 @@ Expression *IntegerExp::interpret(InterState *istate)
     return this;
 }
 
-Expression *RealExp::interpret(InterState *istate)
+Expression *RealExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("RealExp::interpret() %s\n", toChars());
@@ -1225,12 +1225,12 @@ Expression *RealExp::interpret(InterState *istate)
     return this;
 }
 
-Expression *ComplexExp::interpret(InterState *istate)
+Expression *ComplexExp::interpret(InterState *istate, bool wantLvalue)
 {
     return this;
 }
 
-Expression *StringExp::interpret(InterState *istate)
+Expression *StringExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("StringExp::interpret() %s\n", toChars());
@@ -1238,7 +1238,7 @@ Expression *StringExp::interpret(InterState *istate)
     return this;
 }
 
-Expression *FuncExp::interpret(InterState *istate)
+Expression *FuncExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("FuncExp::interpret() %s\n", toChars());
@@ -1246,7 +1246,7 @@ Expression *FuncExp::interpret(InterState *istate)
     return this;
 }
 
-Expression *SymOffExp::interpret(InterState *istate)
+Expression *SymOffExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("SymOffExp::interpret() %s\n", toChars());
@@ -1259,7 +1259,7 @@ Expression *SymOffExp::interpret(InterState *istate)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *DelegateExp::interpret(InterState *istate)
+Expression *DelegateExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("DelegateExp::interpret() %s\n", toChars());
@@ -1391,7 +1391,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d)
     return e;
 }
 
-Expression *VarExp::interpret(InterState *istate)
+Expression *VarExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("VarExp::interpret() %s\n", toChars());
@@ -1399,7 +1399,7 @@ Expression *VarExp::interpret(InterState *istate)
     return getVarExp(loc, istate, var);
 }
 
-Expression *DeclarationExp::interpret(InterState *istate)
+Expression *DeclarationExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("DeclarationExp::interpret() %s\n", toChars());
@@ -1462,7 +1462,7 @@ Expression *DeclarationExp::interpret(InterState *istate)
     return e;
 }
 
-Expression *TupleExp::interpret(InterState *istate)
+Expression *TupleExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("TupleExp::interpret() %s\n", toChars());
@@ -1503,7 +1503,7 @@ Expression *TupleExp::interpret(InterState *istate)
     return this;
 }
 
-Expression *ArrayLiteralExp::interpret(InterState *istate)
+Expression *ArrayLiteralExp::interpret(InterState *istate, bool wantLvalue)
 {   Expressions *expsx = NULL;
 
 #if LOG
@@ -1553,7 +1553,7 @@ Lerror:
     return EXP_CANT_INTERPRET;
 }
 
-Expression *AssocArrayLiteralExp::interpret(InterState *istate)
+Expression *AssocArrayLiteralExp::interpret(InterState *istate, bool wantLvalue)
 {   Expressions *keysx = keys;
     Expressions *valuesx = values;
 
@@ -1640,7 +1640,7 @@ Lerr:
     return EXP_CANT_INTERPRET;
 }
 
-Expression *StructLiteralExp::interpret(InterState *istate)
+Expression *StructLiteralExp::interpret(InterState *istate, bool wantLvalue)
 {   Expressions *expsx = NULL;
 
 #if LOG
@@ -1736,7 +1736,7 @@ StringExp *createBlockDuplicatedStringLiteral(Type *type,
     return se;
 }
 
-Expression *NewExp::interpret(InterState *istate)
+Expression *NewExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("NewExp::interpret() %s\n", toChars());
@@ -1775,7 +1775,7 @@ Lcant:
 }
 
 #define UNA_INTERPRET(op) \
-Expression *op##Exp::interpret(InterState *istate)      \
+Expression *op##Exp::interpret(InterState *istate, bool wantLvalue)      \
 {                                                       \
     return interpretCommon(istate, &op);                \
 }
@@ -1816,7 +1816,7 @@ Lcant:
 }
 
 #define BIN_INTERPRET(op) \
-Expression *op##Exp::interpret(InterState *istate)      \
+Expression *op##Exp::interpret(InterState *istate, bool wantLvalue)      \
 {                                                       \
     return interpretCommon(istate, &op);                \
 }
@@ -1872,7 +1872,7 @@ Lcant:
 }
 
 #define BIN_INTERPRET2(op) \
-Expression *op##Exp::interpret(InterState *istate)      \
+Expression *op##Exp::interpret(InterState *istate, bool wantLvalue)      \
 {                                                       \
     return interpretCommon2(istate, &op);               \
 }
@@ -3092,13 +3092,13 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
     return e;
 }
 
-Expression *AssignExp::interpret(InterState *istate)
+Expression *AssignExp::interpret(InterState *istate, bool wantLvalue)
 {
     return interpretAssignCommon(istate, NULL);
 }
 
 #define BIN_ASSIGN_INTERPRET(op) \
-Expression *op##AssignExp::interpret(InterState *istate)        \
+Expression *op##AssignExp::interpret(InterState *istate, bool wantLvalue)        \
 {                                                               \
     return interpretAssignCommon(istate, &op);                  \
 }
@@ -3116,7 +3116,7 @@ BIN_ASSIGN_INTERPRET(And)
 BIN_ASSIGN_INTERPRET(Or)
 BIN_ASSIGN_INTERPRET(Xor)
 
-Expression *PostExp::interpret(InterState *istate)
+Expression *PostExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("PostExp::interpret() %s\n", toChars());
@@ -3133,7 +3133,7 @@ Expression *PostExp::interpret(InterState *istate)
     return e;
 }
 
-Expression *AndAndExp::interpret(InterState *istate)
+Expression *AndAndExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("AndAndExp::interpret() %s\n", toChars());
@@ -3162,7 +3162,7 @@ Expression *AndAndExp::interpret(InterState *istate)
     return e;
 }
 
-Expression *OrOrExp::interpret(InterState *istate)
+Expression *OrOrExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("OrOrExp::interpret() %s\n", toChars());
@@ -3192,7 +3192,7 @@ Expression *OrOrExp::interpret(InterState *istate)
 }
 
 
-Expression *CallExp::interpret(InterState *istate)
+Expression *CallExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e = EXP_CANT_INTERPRET;
 
 #if LOG
@@ -3365,7 +3365,7 @@ Expression *CallExp::interpret(InterState *istate)
     return e;
 }
 
-Expression *CommaExp::interpret(InterState *istate)
+Expression *CommaExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("CommaExp::interpret() %s\n", toChars());
@@ -3413,7 +3413,7 @@ Expression *CommaExp::interpret(InterState *istate)
     return e;
 }
 
-Expression *CondExp::interpret(InterState *istate)
+Expression *CondExp::interpret(InterState *istate, bool wantLvalue)
 {
 #if LOG
     printf("CondExp::interpret() %s\n", toChars());
@@ -3431,7 +3431,7 @@ Expression *CondExp::interpret(InterState *istate)
     return e;
 }
 
-Expression *ArrayLengthExp::interpret(InterState *istate)
+Expression *ArrayLengthExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e;
     Expression *e1;
 
@@ -3457,7 +3457,7 @@ Lcant:
     return EXP_CANT_INTERPRET;
 }
 
-Expression *IndexExp::interpret(InterState *istate)
+Expression *IndexExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e;
     Expression *e1;
     Expression *e2;
@@ -3497,7 +3497,7 @@ Lcant:
 }
 
 
-Expression *SliceExp::interpret(InterState *istate)
+Expression *SliceExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e;
     Expression *e1;
     Expression *lwr;
@@ -3548,7 +3548,7 @@ Lcant:
 }
 
 
-Expression *CatExp::interpret(InterState *istate)
+Expression *CatExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e;
     Expression *e1;
     Expression *e2;
@@ -3577,7 +3577,7 @@ Lcant:
 }
 
 
-Expression *CastExp::interpret(InterState *istate)
+Expression *CastExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e;
     Expression *e1;
 
@@ -3600,7 +3600,7 @@ Lcant:
 }
 
 
-Expression *AssertExp::interpret(InterState *istate)
+Expression *AssertExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e;
     Expression *e1;
 
@@ -3655,7 +3655,7 @@ Lcant:
     return EXP_CANT_INTERPRET;
 }
 
-Expression *PtrExp::interpret(InterState *istate)
+Expression *PtrExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e = EXP_CANT_INTERPRET;
 
 #if LOG
@@ -3714,7 +3714,7 @@ Expression *PtrExp::interpret(InterState *istate)
     return e;
 }
 
-Expression *DotVarExp::interpret(InterState *istate)
+Expression *DotVarExp::interpret(InterState *istate, bool wantLvalue)
 {   Expression *e = EXP_CANT_INTERPRET;
 
 #if LOG

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1358,7 +1358,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d)
         }
         else
         {   e = v->getValue();
-             if (!v->isCTFE() && v->isDataseg())
+            if (!v->isCTFE() && v->isDataseg())
             {   error(loc, "static variable %s cannot be read at compile time", v->toChars());
                 e = EXP_CANT_INTERPRET;
             }
@@ -2241,7 +2241,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
     // ----------------------------------------------------
     bool wantRef = false;
     Expression * newval = NULL;
-    if (!fp && (e1->type->toBasetype()->ty == Tarray || e1->type->toBasetype()->ty == Taarray))
+    if (!fp && (e1->type->toBasetype()->ty == Tarray || e1->type->toBasetype()->ty == Taarray) && e1->op != TOKslice)
     {
         // it's an assignment to a reference type
         if (this->e2->op == TOKvar) newval = this->e2;
@@ -3223,7 +3223,10 @@ Expression *SliceExp::interpret(InterState *istate)
      */
     e = ArrayLength(Type::tsize_t, e1);
     if (e == EXP_CANT_INTERPRET)
+    {
+        error("Cannot determine length of %s at compile time\n", e1->toChars());
         goto Lcant;
+    }
     if (lengthVar)
         lengthVar->createStackValue(e);
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2472,7 +2472,8 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
 
                 VarDeclaration *v2 = vv->var->isVarDeclaration();
                 assert(v2);
-                assert((v2->getValue()->op == TOKarrayliteral || v2->getValue()->op == TOKstring));
+                assert((v2->getValue()->op == TOKarrayliteral || v2->getValue()->op == TOKstring
+                    || v2->getValue()->op == TOKassocarrayliteral || v2->getValue()->op == TOKnull));
                 v->setValueNull();
                 v->createValue(v2->getValue());
             }
@@ -3660,8 +3661,11 @@ Expression *interpret_keys(InterState *istate, Expression *earg, FuncDeclaration
     earg = earg->interpret(istate);
     if (earg == EXP_CANT_INTERPRET)
         return NULL;
-    if (earg->op != TOKassocarrayliteral)
+    if (earg->op != TOKassocarrayliteral && earg->type->toBasetype()->ty != Taarray)
         return NULL;
+    if (earg->op == TOKnull)
+        return new NullExp(earg->loc);
+    assert(earg->op == TOKassocarrayliteral);
     AssocArrayLiteralExp *aae = (AssocArrayLiteralExp *)earg;
     Expression *e = new ArrayLiteralExp(aae->loc, aae->keys);
     assert(fd->type->ty == Tfunction);
@@ -3677,8 +3681,11 @@ Expression *interpret_values(InterState *istate, Expression *earg, FuncDeclarati
     earg = earg->interpret(istate);
     if (earg == EXP_CANT_INTERPRET)
         return NULL;
-    if (earg->op != TOKassocarrayliteral)
+    if (earg->op != TOKassocarrayliteral && earg->type->toBasetype()->ty != Taarray)
         return NULL;
+    if (earg->op == TOKnull)
+        return new NullExp(earg->loc);
+    assert(earg->op == TOKassocarrayliteral);
     AssocArrayLiteralExp *aae = (AssocArrayLiteralExp *)earg;
     Expression *e = new ArrayLiteralExp(aae->loc, aae->values);
     assert(fd->type->ty == Tfunction);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -99,8 +99,9 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
 
     if (semanticRun < PASSsemantic3 && scope)
     {
+        int olderrors = global.errors;
         semantic3(scope);
-        if (global.errors)      // if errors compiling this function
+        if (olderrors != global.errors)      // if errors compiling this function
             return NULL;
     }
     if (semanticRun < PASSsemantic3done)
@@ -1350,6 +1351,8 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, bool wantLval
         {   Expressions *exps = new Expressions();
             e = new StructLiteralExp(0, s->dsym, exps);
             e = e->semantic(NULL);
+            if (e->op == TOKerror)
+                e = EXP_CANT_INTERPRET;
         }
     }
     return e;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2863,10 +2863,28 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
                 return newval;
             }
             else if (t->nextOf()->ty == newval->type->ty && existingAE)
-            {   // Block slice assign
+            {   // Array block slice assign
                 for (size_t j = 0; j < upperbound-lowerbound; j++)
                 {
                     existingAE->elements->data[j+firstIndex] = newval;
+                }
+                return newval;
+            }
+            else if (t->nextOf()->ty == newval->type->ty && existingSE)
+            {   // String literal block slice assign
+                unsigned value = newval->toInteger();
+                unsigned char *s = (unsigned char *)existingSE->string;
+                for (size_t j = 0; j < upperbound-lowerbound; j++)
+                {
+                    switch (existingSE->sz)
+                    {
+                        case 1: s[j+firstIndex] = value; break;
+                        case 2: ((unsigned short *)s)[j+firstIndex] = value; break;
+                        case 4: ((unsigned *)s)[j+firstIndex] = value; break;
+                        default:
+                            assert(0);
+                            break;
+                    }
                 }
                 return newval;
             }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2241,6 +2241,12 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
 
     assert(istate);
 
+    if (!(e1->op == TOKarraylength || e1->op == TOKvar || e1->op == TOKdotvar
+        || e1->op == TOKindex || e1->op == TOKslice || e1->op == TOKcall || e1->op == TOKthis))
+        printf("CTFE internal error: unsupported assignment %s\n", toChars());
+    assert(e1->op == TOKarraylength || e1->op == TOKvar || e1->op == TOKdotvar
+        || e1->op == TOKindex || e1->op == TOKslice || e1->op == TOKcall || e1->op == TOKthis);
+
     // ----------------------------------------------------
     //  Deal with read-modify-write assignments.
     //  Set 'newval' to the final assignment value

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2126,6 +2126,14 @@ Expression *assignDotVar(ExpressionReverseIterator rvs, int depth, Expression *e
     return NULL;
 }
 
+// Make a copy of the ArrayLiteral, AALiteral, String, or StructLiteral.
+// This value will be used for in-place modification.
+Expression *copyLiteral(Expression *e)
+{
+    Expression *r = e->syntaxCopy();
+    r->type = e->type;
+    return r;
+}
 
 Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
 {
@@ -2278,7 +2286,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
     // only modifying part of the variable. So we need to make sure
     // that the parent variable exists.
     if (e1->op != TOKvar && ultimateVar && !ultimateVar->getValue())
-        ultimateVar->createValue(ultimateVar->type->defaultInitLiteral());
+        ultimateVar->createValue(copyLiteral(ultimateVar->type->defaultInitLiteral()));
 
     // ----------------------------------------
     //      Deal with dotvar expressions
@@ -2359,7 +2367,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
             newval->op == TOKstring || (newval->op == TOKassocarrayliteral))
         {
             if (!v->getValue())
-                v->createValue(newval);
+                v->createValue(copyLiteral(newval));
             else v->setValue(newval);
         }
         else

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2239,13 +2239,25 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
     if (e1 == EXP_CANT_INTERPRET)
         return e1;
 
-    assert(istate);
+    // First, deal with  this = e; and call() = e;
+    if (e1->op == TOKthis)
+    {
+        e1 = istate->localThis;
+    }
+    if (e1->op == TOKcall)
+    {
+        istate->awaitingLvalueReturn = true;
+        e1 = e1->interpret(istate);
+        istate->awaitingLvalueReturn = false;
+        if (e1 == EXP_CANT_INTERPRET)
+            return e1;
+    }
 
     if (!(e1->op == TOKarraylength || e1->op == TOKvar || e1->op == TOKdotvar
-        || e1->op == TOKindex || e1->op == TOKslice || e1->op == TOKcall || e1->op == TOKthis))
+        || e1->op == TOKindex || e1->op == TOKslice))
         printf("CTFE internal error: unsupported assignment %s\n", toChars());
     assert(e1->op == TOKarraylength || e1->op == TOKvar || e1->op == TOKdotvar
-        || e1->op == TOKindex || e1->op == TOKslice || e1->op == TOKcall || e1->op == TOKthis);
+        || e1->op == TOKindex || e1->op == TOKslice);
 
     // ----------------------------------------------------
     //  Deal with read-modify-write assignments.

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2274,8 +2274,9 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, bool wantLvalue, f
         }
     }
     bool wantRef = false;
-    if (!fp && this->e1->type->toBasetype() == this->e2->type->toBasetype()
-        && (e1->type->toBasetype()->ty == Tarray || e1->type->toBasetype()->ty == Taarray)
+    if (!fp && this->e1->type->toBasetype() == this->e2->type->toBasetype() &&
+        (e1->type->toBasetype()->ty == Tarray || e1->type->toBasetype()->ty == Taarray ||
+         e1->type->toBasetype()->ty == Tclass)
         )
     {
         wantRef = true;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1870,19 +1870,6 @@ void spliceElements(Expressions *oldelems, Expressions *newelems, size_t insertp
     }
 }
 
-/***************************************
- * Returns oldstr[0..insertpoint] ~ newstr ~ oldstr[insertpoint+newlen..$]
- */
-void spliceStringExp(StringExp *oldstr, StringExp *newstr, size_t insertpoint)
-{
-    assert(oldstr->sz==newstr->sz);
-    unsigned char *s = (unsigned char *)oldstr->string;
-    size_t oldlen = oldstr->len;
-    size_t newlen = newstr->len;
-    size_t sz = oldstr->sz;
-    memcpy(s + insertpoint * sz, newstr->string, newlen * sz);
-}
-
 /******************************
  * Create an array literal consisting of 'elem' duplicated 'dim' times.
  */
@@ -2830,7 +2817,11 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, fp_t fp, int post)
             }
             else if (newval->op == TOKstring && existingSE)
             {
-                spliceStringExp(existingSE, (StringExp *)newval, startIndexForSliceAssign);
+                StringExp * newstr = (StringExp *)newval;
+                unsigned char *s = (unsigned char *)existingSE->string;
+                size_t sz = existingSE->sz;
+                assert(sz == ((StringExp *)newval)->sz);
+                memcpy(s + startIndexForSliceAssign * sz, newstr->string, sz * newstr->len);
                 return newval;
             }
             else if (newval->op == TOKstring && existingAE)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1859,17 +1859,6 @@ Expressions *changeOneElement(Expressions *oldelems, size_t indexToChange, void 
     return expsx;
 }
 
-/***************************************
- * Returns oldelems[0..insertpoint] ~ newelems ~ oldelems[insertpoint+newelems.length..$]
- */
-void spliceElements(Expressions *oldelems, Expressions *newelems, size_t insertpoint)
-{
-    for (size_t j = 0; j < newelems->dim; j++)
-    {
-        oldelems->data[j+insertpoint] = newelems->data[j];
-    }
-}
-
 /******************************
  * Create an array literal consisting of 'elem' duplicated 'dim' times.
  */
@@ -1883,29 +1872,6 @@ ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Type *type,
     ArrayLiteralExp *ae = new ArrayLiteralExp(0, elements);
     ae->type = type;
     return ae;
-}
-
-/******************************
- * Create a string literal consisting of 'value' duplicated 'dim' times.
- */
-StringExp *createBlockDuplicatedStringLiteral(Type *type,
-        unsigned value, size_t dim, int sz)
-{
-    unsigned char *s;
-    s = (unsigned char *)mem.calloc(dim + 1, sz);
-    for (int elemi=0; elemi<dim; ++elemi)
-    {
-        switch (sz)
-        {
-            case 1:     s[elemi] = value; break;
-            case 2:     ((unsigned short *)s)[elemi] = value; break;
-            case 4:     ((unsigned *)s)[elemi] = value; break;
-            default:    assert(0);
-        }
-    }
-    StringExp *se = new StringExp(0, s, dim);
-    se->type = type;
-    return se;
 }
 
 /********************************

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2244,6 +2244,12 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, bool wantLvalue, f
     {
         wantRef = true;
     }
+    /* This happens inside compiler-generated foreach statements.
+     * It's another case where we need a reference
+     */
+    if (op==TOKconstruct && this->e1->op==TOKvar
+        && ((VarExp*)this->e1)->var->storage_class & STCref)
+        wantRef = true;
 
 
     if (fp)
@@ -2396,7 +2402,8 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, bool wantLvalue, f
     {
         //error("assignment to ref variable %s is not yet supported in CTFE", this->toChars());
         VarDeclaration *v = ((VarExp *)e1)->var->isVarDeclaration();
-        v->setValue(e2);
+        v->setValueNull();
+        v->createStackValue(e2);
         return e2;
     }
     bool destinationIsReference = false;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -330,7 +330,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
  *      !NULL   expression from return statement
  */
 
-Expression *Statement::interpret(InterState *istate, bool wantLvalue)
+Expression *Statement::interpret(InterState *istate)
 {
 #if LOG
     printf("Statement::interpret()\n");
@@ -340,7 +340,7 @@ Expression *Statement::interpret(InterState *istate, bool wantLvalue)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *ExpStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *ExpStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("ExpStatement::interpret(%s)\n", exp ? exp->toChars() : "");
@@ -358,7 +358,7 @@ Expression *ExpStatement::interpret(InterState *istate, bool wantLvalue)
     return NULL;
 }
 
-Expression *CompoundStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *CompoundStatement::interpret(InterState *istate)
 {   Expression *e = NULL;
 
 #if LOG
@@ -385,7 +385,7 @@ Expression *CompoundStatement::interpret(InterState *istate, bool wantLvalue)
     return e;
 }
 
-Expression *UnrolledLoopStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *UnrolledLoopStatement::interpret(InterState *istate)
 {   Expression *e = NULL;
 
 #if LOG
@@ -416,7 +416,7 @@ Expression *UnrolledLoopStatement::interpret(InterState *istate, bool wantLvalue
     return e;
 }
 
-Expression *IfStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *IfStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("IfStatement::interpret(%s)\n", condition->toChars());
@@ -451,7 +451,7 @@ Expression *IfStatement::interpret(InterState *istate, bool wantLvalue)
     return e;
 }
 
-Expression *ScopeStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *ScopeStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("ScopeStatement::interpret()\n");
@@ -609,7 +609,7 @@ Expression * replaceReturnReference(Expression *original, InterState *istate)
      return r;
 }
 
-Expression *ReturnStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *ReturnStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("ReturnStatement::interpret(%s)\n", exp ? exp->toChars() : "");
@@ -651,7 +651,7 @@ Expression *ReturnStatement::interpret(InterState *istate, bool wantLvalue)
     return e;
 }
 
-Expression *BreakStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *BreakStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("BreakStatement::interpret()\n");
@@ -663,7 +663,7 @@ Expression *BreakStatement::interpret(InterState *istate, bool wantLvalue)
         return EXP_BREAK_INTERPRET;
 }
 
-Expression *ContinueStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *ContinueStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("ContinueStatement::interpret()\n");
@@ -675,7 +675,7 @@ Expression *ContinueStatement::interpret(InterState *istate, bool wantLvalue)
         return EXP_CONTINUE_INTERPRET;
 }
 
-Expression *WhileStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *WhileStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("WhileStatement::interpret()\n");
@@ -684,7 +684,7 @@ Expression *WhileStatement::interpret(InterState *istate, bool wantLvalue)
     return NULL;
 }
 
-Expression *DoStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *DoStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("DoStatement::interpret()\n");
@@ -741,7 +741,7 @@ Expression *DoStatement::interpret(InterState *istate, bool wantLvalue)
     return e;
 }
 
-Expression *ForStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *ForStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("ForStatement::interpret()\n");
@@ -814,7 +814,7 @@ Expression *ForStatement::interpret(InterState *istate, bool wantLvalue)
     return e;
 }
 
-Expression *ForeachStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *ForeachStatement::interpret(InterState *istate)
 {
 #if 1
     assert(0);                  // rewritten to ForStatement
@@ -906,7 +906,7 @@ Expression *ForeachStatement::interpret(InterState *istate, bool wantLvalue)
 }
 
 #if DMDV2
-Expression *ForeachRangeStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *ForeachRangeStatement::interpret(InterState *istate)
 {
 #if 1
     assert(0);                  // rewritten to ForStatement
@@ -996,7 +996,7 @@ Expression *ForeachRangeStatement::interpret(InterState *istate, bool wantLvalue
 }
 #endif
 
-Expression *SwitchStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *SwitchStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("SwitchStatement::interpret()\n");
@@ -1052,7 +1052,7 @@ Expression *SwitchStatement::interpret(InterState *istate, bool wantLvalue)
     return e;
 }
 
-Expression *CaseStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *CaseStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("CaseStatement::interpret(%s) this = %p\n", exp->toChars(), this);
@@ -1065,7 +1065,7 @@ Expression *CaseStatement::interpret(InterState *istate, bool wantLvalue)
         return NULL;
 }
 
-Expression *DefaultStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *DefaultStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("DefaultStatement::interpret()\n");
@@ -1078,7 +1078,7 @@ Expression *DefaultStatement::interpret(InterState *istate, bool wantLvalue)
         return NULL;
 }
 
-Expression *GotoStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *GotoStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("GotoStatement::interpret()\n");
@@ -1089,7 +1089,7 @@ Expression *GotoStatement::interpret(InterState *istate, bool wantLvalue)
     return EXP_GOTO_INTERPRET;
 }
 
-Expression *GotoCaseStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *GotoCaseStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("GotoCaseStatement::interpret()\n");
@@ -1100,7 +1100,7 @@ Expression *GotoCaseStatement::interpret(InterState *istate, bool wantLvalue)
     return EXP_GOTO_INTERPRET;
 }
 
-Expression *GotoDefaultStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *GotoDefaultStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("GotoDefaultStatement::interpret()\n");
@@ -1111,7 +1111,7 @@ Expression *GotoDefaultStatement::interpret(InterState *istate, bool wantLvalue)
     return EXP_GOTO_INTERPRET;
 }
 
-Expression *LabelStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *LabelStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("LabelStatement::interpret()\n");
@@ -1122,7 +1122,7 @@ Expression *LabelStatement::interpret(InterState *istate, bool wantLvalue)
 }
 
 
-Expression *TryCatchStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *TryCatchStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("TryCatchStatement::interpret()\n");
@@ -1133,7 +1133,7 @@ Expression *TryCatchStatement::interpret(InterState *istate, bool wantLvalue)
 }
 
 
-Expression *TryFinallyStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *TryFinallyStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("TryFinallyStatement::interpret()\n");
@@ -1143,7 +1143,7 @@ Expression *TryFinallyStatement::interpret(InterState *istate, bool wantLvalue)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *ThrowStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *ThrowStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("ThrowStatement::interpret()\n");
@@ -1153,7 +1153,7 @@ Expression *ThrowStatement::interpret(InterState *istate, bool wantLvalue)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *OnScopeStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *OnScopeStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("OnScopeStatement::interpret()\n");
@@ -1163,7 +1163,7 @@ Expression *OnScopeStatement::interpret(InterState *istate, bool wantLvalue)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *WithStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *WithStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("WithStatement::interpret()\n");
@@ -1173,7 +1173,7 @@ Expression *WithStatement::interpret(InterState *istate, bool wantLvalue)
     return EXP_CANT_INTERPRET;
 }
 
-Expression *AsmStatement::interpret(InterState *istate, bool wantLvalue)
+Expression *AsmStatement::interpret(InterState *istate)
 {
 #if LOG
     printf("AsmStatement::interpret()\n");

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -52,7 +52,6 @@ Expression *interpret_length(InterState *istate, Expression *earg);
 Expression *interpret_keys(InterState *istate, Expression *earg, FuncDeclaration *fd);
 Expression *interpret_values(InterState *istate, Expression *earg, FuncDeclaration *fd);
 
-ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Type *type, Expression *elem, size_t dim);
 Expression * resolveReferences(Expression *e, Expression *thisval, bool *isReference = NULL);
 Expression *getVarExp(Loc loc, InterState *istate, Declaration *d);
 VarDeclaration *findParentVar(Expression *e, Expression *thisval);
@@ -1694,6 +1693,46 @@ Expression *StructLiteralExp::interpret(InterState *istate)
     return this;
 }
 
+/******************************
+ * Helper for NewExp
+ * Create an array literal consisting of 'elem' duplicated 'dim' times.
+ */
+ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Type *type,
+        Expression *elem, size_t dim)
+{
+    Expressions *elements = new Expressions();
+    elements->setDim(dim);
+    for (size_t i = 0; i < dim; i++)
+         elements->data[i] = elem;
+    ArrayLiteralExp *ae = new ArrayLiteralExp(0, elements);
+    ae->type = type;
+    return ae;
+}
+
+/******************************
+ * Helper for NewExp
+ * Create a string literal consisting of 'value' duplicated 'dim' times.
+ */
+StringExp *createBlockDuplicatedStringLiteral(Type *type,
+        unsigned value, size_t dim, int sz)
+{
+    unsigned char *s;
+    s = (unsigned char *)mem.calloc(dim + 1, sz);
+    for (int elemi=0; elemi<dim; ++elemi)
+    {
+        switch (sz)
+        {
+            case 1:     s[elemi] = value; break;
+            case 2:     ((unsigned short *)s)[elemi] = value; break;
+            case 4:     ((unsigned *)s)[elemi] = value; break;
+            default:    assert(0);
+        }
+    }
+    StringExp *se = new StringExp(0, s, dim);
+    se->type = type;
+    return se;
+}
+
 Expression *NewExp::interpret(InterState *istate)
 {
 #if LOG
@@ -1857,21 +1896,6 @@ Expressions *changeOneElement(Expressions *oldelems, size_t indexToChange, void 
             expsx->data[j] = oldelems->data[j];
     }
     return expsx;
-}
-
-/******************************
- * Create an array literal consisting of 'elem' duplicated 'dim' times.
- */
-ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Type *type,
-        Expression *elem, size_t dim)
-{
-    Expressions *elements = new Expressions();
-    elements->setDim(dim);
-    for (size_t i = 0; i < dim; i++)
-         elements->data[i] = elem;
-    ArrayLiteralExp *ae = new ArrayLiteralExp(0, elements);
-    ae->type = type;
-    return ae;
 }
 
 /********************************

--- a/src/statement.h
+++ b/src/statement.h
@@ -108,7 +108,7 @@ struct Statement : Object
     virtual int isEmpty();
     virtual Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
     virtual Statements *flatten(Scope *sc);
-    virtual Expression *interpret(InterState *istate, bool wantLvalue = false);
+    virtual Expression *interpret(InterState *istate);
 
     virtual int inlineCost(InlineCostState *ics);
     virtual Expression *doInline(InlineDoState *ids);
@@ -141,7 +141,7 @@ struct ExpStatement : Statement
     Statement *syntaxCopy();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
     int isEmpty();
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
@@ -182,7 +182,7 @@ struct CompoundStatement : Statement
     int isEmpty();
     Statements *flatten(Scope *sc);
     ReturnStatement *isReturnStatement();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     int inlineCost(InlineCostState *ics);
     Expression *doInline(InlineDoState *ids);
@@ -215,7 +215,7 @@ struct UnrolledLoopStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     int inlineCost(InlineCostState *ics);
@@ -240,7 +240,7 @@ struct ScopeStatement : Statement
     int blockExit(bool mustNotThrow);
     int comeFrom();
     int isEmpty();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -260,7 +260,7 @@ struct WhileStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -281,7 +281,7 @@ struct DoStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -305,7 +305,7 @@ struct ForStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -337,7 +337,7 @@ struct ForeachStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -365,7 +365,7 @@ struct ForeachRangeStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -386,7 +386,7 @@ struct IfStatement : Statement
     IfStatement(Loc loc, Parameter *arg, Expression *condition, Statement *ifbody, Statement *elsebody);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int usesEH();
     int blockExit(bool mustNotThrow);
@@ -463,7 +463,7 @@ struct SwitchStatement : Statement
     int hasBreak();
     int usesEH();
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -486,7 +486,7 @@ struct CaseStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -523,7 +523,7 @@ struct DefaultStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -538,7 +538,7 @@ struct GotoDefaultStatement : Statement
     GotoDefaultStatement(Loc loc);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -553,7 +553,7 @@ struct GotoCaseStatement : Statement
     GotoCaseStatement(Loc loc, Expression *exp);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -578,7 +578,7 @@ struct ReturnStatement : Statement
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     int inlineCost(InlineCostState *ics);
     Expression *doInline(InlineDoState *ids);
@@ -596,7 +596,7 @@ struct BreakStatement : Statement
     BreakStatement(Loc loc, Identifier *ident);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -610,7 +610,7 @@ struct ContinueStatement : Statement
     ContinueStatement(Loc loc, Identifier *ident);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -651,7 +651,7 @@ struct WithStatement : Statement
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int usesEH();
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -669,7 +669,7 @@ struct TryCatchStatement : Statement
     int hasBreak();
     int usesEH();
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -706,7 +706,7 @@ struct TryFinallyStatement : Statement
     int hasContinue();
     int usesEH();
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -725,7 +725,7 @@ struct OnScopeStatement : Statement
     Statement *semantic(Scope *sc);
     int usesEH();
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     void toIR(IRState *irs);
 };
@@ -739,7 +739,7 @@ struct ThrowStatement : Statement
     Statement *semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -772,7 +772,7 @@ struct GotoStatement : Statement
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     void toIR(IRState *irs);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -795,7 +795,7 @@ struct LabelStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -828,7 +828,7 @@ struct AsmStatement : Statement
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate, bool wantLvalue = false);
+    Expression *interpret(InterState *istate);
 
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual AsmStatement *isAsmStatement() { return this; }

--- a/src/statement.h
+++ b/src/statement.h
@@ -108,7 +108,7 @@ struct Statement : Object
     virtual int isEmpty();
     virtual Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
     virtual Statements *flatten(Scope *sc);
-    virtual Expression *interpret(InterState *istate);
+    virtual Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     virtual int inlineCost(InlineCostState *ics);
     virtual Expression *doInline(InlineDoState *ids);
@@ -141,7 +141,7 @@ struct ExpStatement : Statement
     Statement *syntaxCopy();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int blockExit(bool mustNotThrow);
     int isEmpty();
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
@@ -182,7 +182,7 @@ struct CompoundStatement : Statement
     int isEmpty();
     Statements *flatten(Scope *sc);
     ReturnStatement *isReturnStatement();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     int inlineCost(InlineCostState *ics);
     Expression *doInline(InlineDoState *ids);
@@ -215,7 +215,7 @@ struct UnrolledLoopStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     int inlineCost(InlineCostState *ics);
@@ -240,7 +240,7 @@ struct ScopeStatement : Statement
     int blockExit(bool mustNotThrow);
     int comeFrom();
     int isEmpty();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -260,7 +260,7 @@ struct WhileStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -281,7 +281,7 @@ struct DoStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -305,7 +305,7 @@ struct ForStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -337,7 +337,7 @@ struct ForeachStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -365,7 +365,7 @@ struct ForeachRangeStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -386,7 +386,7 @@ struct IfStatement : Statement
     IfStatement(Loc loc, Parameter *arg, Expression *condition, Statement *ifbody, Statement *elsebody);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int usesEH();
     int blockExit(bool mustNotThrow);
@@ -463,7 +463,7 @@ struct SwitchStatement : Statement
     int hasBreak();
     int usesEH();
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -486,7 +486,7 @@ struct CaseStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -523,7 +523,7 @@ struct DefaultStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -538,7 +538,7 @@ struct GotoDefaultStatement : Statement
     GotoDefaultStatement(Loc loc);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -553,7 +553,7 @@ struct GotoCaseStatement : Statement
     GotoCaseStatement(Loc loc, Expression *exp);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -578,7 +578,7 @@ struct ReturnStatement : Statement
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     int inlineCost(InlineCostState *ics);
     Expression *doInline(InlineDoState *ids);
@@ -596,7 +596,7 @@ struct BreakStatement : Statement
     BreakStatement(Loc loc, Identifier *ident);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -610,7 +610,7 @@ struct ContinueStatement : Statement
     ContinueStatement(Loc loc, Identifier *ident);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -651,7 +651,7 @@ struct WithStatement : Statement
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int usesEH();
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -669,7 +669,7 @@ struct TryCatchStatement : Statement
     int hasBreak();
     int usesEH();
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -706,7 +706,7 @@ struct TryFinallyStatement : Statement
     int hasContinue();
     int usesEH();
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -725,7 +725,7 @@ struct OnScopeStatement : Statement
     Statement *semantic(Scope *sc);
     int usesEH();
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     void toIR(IRState *irs);
 };
@@ -739,7 +739,7 @@ struct ThrowStatement : Statement
     Statement *semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     Statement *inlineScan(InlineScanState *iss);
 
@@ -772,7 +772,7 @@ struct GotoStatement : Statement
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     void toIR(IRState *irs);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -795,7 +795,7 @@ struct LabelStatement : Statement
     int usesEH();
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
@@ -828,7 +828,7 @@ struct AsmStatement : Statement
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
     int comeFrom();
-    Expression *interpret(InterState *istate);
+    Expression *interpret(InterState *istate, bool wantLvalue = false);
 
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual AsmStatement *isAsmStatement() { return this; }

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -469,7 +469,7 @@ import.obj : $(TOTALH) dsymbol.h import.h import.c
 inifile.obj : $(TOTALH) inifile.c
 init.obj : $(TOTALH) init.h init.c
 inline.obj : $(TOTALH) inline.c
-interpret.obj : $(TOTALH) interpret.c
+interpret.obj : $(TOTALH) interpret.c declaration.h expression.h
 json.obj : $(TOTALH) json.h json.c
 lexer.obj : $(TOTALH) lexer.c
 libomf.obj : $(TOTALH) lib.h libomf.c

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -8,7 +8,7 @@ int arrayRetTest(int z)
 {
   ArrayRet[6] w;
   int q = (w[3].x = z);
-  return q;  
+  return q;
 }
 
 static assert(arrayRetTest(51)==51);
@@ -17,7 +17,7 @@ static assert(arrayRetTest(51)==51);
 int ice3842(int z)
 {
    ArrayRet w;
-   return arrayRetTest((*(&w)).x);   
+   return arrayRetTest((*(&w)).x);
 }
 
 static assert(true || is(typeof(compiles!(ice3842(51)))));
@@ -47,7 +47,7 @@ int dotvar1()
 {
     DotVarTest w;
     w.z.x = 3;
-    return w.z.x; 
+    return w.z.x;
 }
 
 int dotvar2()
@@ -150,7 +150,7 @@ int retRefTest3()
     RetRefStruct b = RetRefStruct(0,'a');
     auto deleg = function (RetRefStruct a){ return a;};
     typeof(deleg)[3] z;
-    z[] = deleg;    
+    z[] = deleg;
     auto y = deleg(b).x + 27;
     b.x = 5;
     assert(y == 27);
@@ -340,22 +340,338 @@ static assert(!is(typeof(compiles!(badslice1([1,2])))));
 static assert(!is(typeof(compiles!(badslice2([1,2])))));
 static assert(!is(typeof(compiles!(badslice3([1,2,3])))));
 
-/*******************************************/ 
+/*******************************************/
 
-size_t bug5524(int x, int[] more...) 
-{ 
-    int[0] zz; 
-    assert(zz.length==0); 
-    return 7 + more.length + x; 
-} 
+size_t bug5524(int x, int[] more...)
+{
+    int[0] zz;
+    assert(zz.length==0);
+    return 7 + more.length + x;
+}
 
-//static assert(bug5524(3) == 10); 
+//static assert(bug5524(3) == 10);
 
 
-// 5722 
+// 5722
 
-static assert( ("" ~ "\&copy;"[0]).length == 1 ); 
-const char[] null5722 = null; 
-static assert( (null5722 ~ "\&copy;"[0]).length == 1 ); 
-static assert( ("\&copy;"[0] ~ null5722).length == 1 ); 
+static assert( ("" ~ "\&copy;"[0]).length == 1 );
+const char[] null5722 = null;
+static assert( (null5722 ~ "\&copy;"[0]).length == 1 );
+static assert( ("\&copy;"[0] ~ null5722).length == 1 );
 
+/*******************************************
+ * Tests for CTFE Array support.
+ * Including bugs 1330, 3801, 3835, 4050,
+ * 4051, 5147, and major functionality
+ *******************************************/
+
+char[] bug1330StringIndex()
+{
+    char [] blah = "foo".dup;
+    assert(blah == "foo");
+    char [] s = blah[0..2];
+    blah[0] = 'h';
+    assert(s== "ho");
+    s[0] = 'm';
+    return blah;
+}
+
+static assert(bug1330StringIndex()=="moo");
+static assert(bug1330StringIndex()=="moo"); // check we haven't clobbered any string literals
+
+int[] bug1330ArrayIndex()
+{
+    int [] blah = [1,2,3];
+    int [] s = blah;
+    s = blah[0..2];
+    int z = blah[0] = 6;
+    assert(z==6);
+    assert(blah[0]==6);
+    assert(s[0]==6);
+    assert(s== [6, 2]);
+    s[1] = 4;
+    assert(z==6);
+    return blah;
+}
+
+static assert(bug1330ArrayIndex()==[6,4,3]);
+static assert(bug1330ArrayIndex()==[6,4,3]); // check we haven't clobbered any literals
+
+char[] bug1330StringSliceAssign()
+{
+    char [] blah = "food".dup;
+    assert(blah == "food");
+    char [] s = blah[1..4];
+    blah[0..2] = "hc";
+    assert(s== "cod");
+    s[0..2] = ['a', 'b'];   // Mix string + array literal
+    assert(blah == "habd");
+    s[0..2] = "mq";
+    return blah;
+}
+
+static assert(bug1330StringSliceAssign()=="hmqd");
+static assert(bug1330StringSliceAssign()=="hmqd");
+
+int[] bug1330ArraySliceAssign()
+{
+    int [] blah = [1,2,3,4];
+    int [] s = blah[1..4];
+    blah[0..2] = [7, 9];
+    assert(s == [9,3,4]);
+    s[0..2] = [8, 15];
+    return blah;
+}
+
+static assert(bug1330ArraySliceAssign()==[7, 8, 15, 4]);
+
+int[] bug1330ArrayBlockAssign()
+{
+    int [] blah = [1,2,3,4,5];
+    int [] s = blah[1..4];
+    blah[0..2] = 17;
+    assert(s == [17,3,4]);
+    s[0..2] = 9;
+    return blah;
+}
+
+static assert(bug1330ArrayBlockAssign()==[17, 9, 9, 4, 5]);
+
+char[] bug1330StringBlockAssign()
+{
+    char [] blah = "abcde".dup;
+    char [] s = blah[1..4];
+    blah[0..2] = 'x';
+    assert(s == "xcd");
+    s[0..2] = 'y';
+    return blah;
+}
+
+static assert(bug1330StringBlockAssign() == "xyyde");
+
+int assignAA(int x) {
+    int[int] aa;
+    int[int] cc = aa;
+    assert(cc.values.length==0);
+    assert(cc.keys.length==0);
+    aa[1] = 2;
+    aa[x] = 6;
+    int[int] bb = aa;
+    assert(bb.keys.length==2);
+    assert(cc.keys.length==0); // cc is not affected to aa, because it is null
+    aa[500] = 65;
+    assert(bb.keys.length==3); // but bb is affected by changes to aa
+    return aa[1] + aa[x];
+}
+static assert(assignAA(12) == 8);
+
+template Compileable(int z) { bool OK;}
+
+int arraybounds(int j, int k)
+{
+    int [] xxx = [1, 2, 3, 4, 5];
+    int [] s = xxx[1..$];
+    s = s[j..k]; // slice of slice
+    return s[$-1];
+}
+
+int arraybounds2(int j, int k)
+{
+    int [] xxx = [1, 2, 3, 4, 5];
+    int [] s = xxx[j..k]; // direct slice
+    return 1;
+}
+static assert( !is(typeof(Compileable!(arraybounds(1, 14)))));
+static assert( !is(typeof(Compileable!(arraybounds(15, 3)))));
+static assert( arraybounds(2,4) == 5);
+static assert( !is(typeof(Compileable!(arraybounds2(1, 14)))));
+static assert( !is(typeof(Compileable!(arraybounds2(15, 3)))));
+static assert( arraybounds2(2,4) == 1);
+
+int bug5147a() {
+    int[1][2] a = 37;
+    return a[0][0];
+}
+
+static assert(bug5147a()==37);
+
+int bug5147b() {
+    int[4][2][3][17] a = 37;
+    return a[0][0][0][0];
+}
+
+static assert(bug5147b()==37);
+
+int setlen()
+{
+    int[][] zzz;
+    zzz.length = 2;
+    zzz[0].length = 10;
+    assert(zzz.length == 2);
+    assert(zzz[0].length==10);
+    assert(zzz[1].length==0);
+    return 2;
+}
+
+static assert(setlen()==2);
+
+int[1][1] bug5147() {
+    int[1][1] a = 1;
+    return a;
+}
+static assert(bug5147() == [[1]]);
+enum int[1][1] enum5147 = bug5147();
+static assert(enum5147 == [[1]]);
+immutable int[1][1] bug5147imm = bug5147();
+
+
+// Index referencing
+int[2][2] indexref() {
+    int[2][2] a = 2;
+    a[0]=7;
+
+    int[][] b = [null, null];
+    b[0..$] = a[0][0..2];
+    assert(b[0][0]==7);
+    assert(b[0][1]==7);
+    int [] w;
+    w = a[0];
+    assert(w[0]==7);
+    w[0..$] = 5;
+    assert(a[0]!=[7,7]);
+    assert(a[0]==[5,5]);
+    assert(b[0] == [5,5]);
+    return a;
+}
+int[2][2] indexref2() {
+    int[2][2] a = 2;
+    a[0]=7;
+
+    int[][2] b = null;
+    b[0..$] = a[0];
+    assert(b[0][0]==7);
+    assert(b[0][1]==7);
+    assert(b == [[7,7], [7,7]]);
+    int [] w;
+    w = a[0];
+    assert(w[0]==7);
+    w[0..$] = 5;
+    assert(a[0]!=[7,7]);
+    assert(a[0]==[5,5]);
+    assert(b[0] == [5,5]);
+    return a;
+}
+int[2][2] indexref3() {
+    int[2][2] a = 2;
+    a[0]=7;
+
+    int[][2] b = [null, null];
+    b[0..$] = a[0];
+    assert(b[0][0]==7);
+    assert(b[0][1]==7);
+    int [] w;
+    w = a[0];
+    assert(w[0]==7);
+    w[0..$] = 5;
+    assert(a[0]!=[7,7]);
+    assert(a[0]==[5,5]);
+    assert(b[0] == [5,5]);
+    return a;
+}
+int[2][2] indexref4() {
+    int[2][2] a = 2;
+    a[0]=7;
+
+    int[][2] b =[[1,2,3],[1,2,3]]; // wrong code
+    b[0] = a[0];
+    assert(b[0][0]==7);
+    assert(b[0][1]==7);
+    int [] w;
+    w = a[0]; //[0..$];
+    assert(w[0]==7);
+    w[0..$] = 5;
+    assert(a[0]!=[7,7]);
+    assert(a[0]==[5,5]);
+    assert(b[0] == [5,5]);
+    return a;
+}
+
+static assert(indexref() == [[5,5], [2,2]]);
+static assert(indexref2() == [[5,5], [2,2]]);
+static assert(indexref3() == [[5,5], [2,2]]);
+static assert(indexref4() == [[5,5], [2,2]]);
+
+int staticdynamic() {
+    int[2][1] a = 2;
+    assert( a == [[2,2]]);
+
+    int[][1] b = a[0][0..1];
+    assert(b[0] == [2]);
+    auto k = b[0];
+    auto m = a[0][0..1];
+    assert(k == [2]);
+    assert(m == k);
+    return 0;
+}
+static assert(staticdynamic() == 0);
+
+int[] crashing()
+{
+    int[12] cra;
+    return (cra[2..$]=3);
+}
+static assert(crashing()[9]==3);
+
+int chainassign()
+{
+    int[4] x = 6;
+    int[] y = new int[4];
+    auto k = (y[] = (x[] = 2));
+    return k[0];
+}
+static assert(chainassign()==2);
+
+// index assignment
+struct S3801 {
+char c;
+  int[3] arr;
+
+  this(int x, int y){
+    c = 'x';
+    arr[0] = x;
+    arr[1] = y;
+  }
+}
+
+int bug3801()
+{
+    S3801 xxx = S3801(17, 67);
+    int[] w = xxx.arr;
+    xxx.arr[1] = 89;
+    assert(xxx.arr[0]==17);
+    assert(w[1] == 89);
+    assert(w == [17, 89, 0]);
+    return xxx.arr[1];
+}
+
+enum : S3801 { bug3801e = S3801(17, 18) }
+static assert(bug3801e.arr == [17, 18, 0]);
+immutable S3801 bug3801u = S3801(17, 18);
+static assert(bug3801u.arr == [17, 18, 0]);
+static assert(bug3801()==89);
+
+int bug3835() {
+    int[4] arr;
+    arr[]=19;
+    arr[0] = 4;
+    int kk;
+    foreach (ref el; arr)
+    {
+        el += 10;
+        kk = el;
+    }
+    assert(arr[2]==29);
+    arr[0]+=3;
+    return arr[0];
+}
+static assert(bug3835() == 17);


### PR DESCRIPTION
There are two fundamental changes:
(1) Array literals (including strings and AAs) now use in-place modification instead of copy-on-write. (Note that the values in the array are still copy-on-write).
(2) Array variables value may now be a SliceExp. They slice an array literal. This allows two array variables to point to the same literal. Because of (1), any changes made through one array will be visible in the other one.
I have also added some infrastructure: interpret() for expressions now has a parameter stating if an Lvalue or Rvalue is required. This opens up huge optimization potential, almost none of which is used yet. The code could also be radically simplified now.

I believe that operations of arbitrary complexity will now work. The most effort, by far, involved block slice assignments ( eg, a[0..10]= 6), especially when the element type is a dynamic array.

I have also created a CTFE1 branch, which implements exactly the same thing for D1. The interpret.c file is identical for both D1 and D2.

These bugs are fixed:
1330 Array slicing does not work the same way in CTFE as at runtime
3801 CTFE: this.arr[i] cannot be evaluated at compile time for structs
3835 ref foreach does not work in CTFE
4050 [CTFE] array struct member slice update
4051 [CTFE] array struct member item update
5147 [CTFE] Return fixed-sized matrix

Apparently it also fixes this:
5708 Incorrect string constant folding with -inline

It also fixes a very large number of more obscure cases which aren't in Bugzilla.
