### PR TITLE
Fix some MAJOR constant-folding bugs

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -83,6 +83,8 @@ struct AggregateDeclaration : ScopeDsymbol
     static void alignmember(unsigned salign, unsigned size, unsigned *poffset);
     Type *getType();
     void addField(Scope *sc, VarDeclaration *v);
+    int firstFieldInUnion(int indx); // first field in union that includes indx
+    int numFieldsInUnion(int firstIndex); // #fields in union starting at index
     int isDeprecated();         // is aggregate deprecated?
     FuncDeclaration *buildDtor(Scope *sc);
     int isNested();

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1176,7 +1176,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
 
             if (ce->op == TOKvar)
             {   // if ce is const, get its initializer
-                ce = fromConstInitializer(WANTvalue | WANTinterpret, ce);
+                ce = fromConstInitializer(WANTvalue, ce);
             }
 
             if (ce->op == TOKstring)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3351,7 +3351,7 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
 
         dim = semanticLength(sc, tbn, dim);
 
-        dim = dim->optimize(WANTvalue | WANTinterpret);
+        dim = dim->optimize(WANTvalue);
         if (sc && sc->parameterSpecialization && dim->op == TOKvar &&
             ((VarExp *)dim)->var->storage_class & STCtemplateparameter)
         {
@@ -3360,6 +3360,7 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
              */
             return this;
         }
+        dim = dim->optimize(WANTvalue | WANTinterpret);
         dinteger_t d1 = dim->toInteger();
         dim = dim->implicitCastTo(sc, tsize_t);
         dim = dim->optimize(WANTvalue);

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -57,7 +57,6 @@ Expression *expandVar(int result, VarDeclaration *v)
             //error("ICE");
             return e;
         }
-
         Type *tb = v->type->toBasetype();
         if (result & WANTinterpret ||
             v->storage_class & STCmanifest ||
@@ -474,6 +473,10 @@ Expression *NewExp::optimize(int result)
             e = e->optimize(WANTvalue);
             arguments->data[i] = (void *)e;
         }
+    }
+    if (result & WANTinterpret)
+    {
+        error("cannot evaluate %s at compile time", toChars());
     }
     return this;
 }

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -889,6 +889,28 @@ Expression *IdentityExp::optimize(int result)
     return e;
 }
 
+/* It is possible for constant folding to change an array expression of
+ * unknown length, into one where the length is known.
+ * If the expression 'arr' is a literal, set lengthVar to be its length.
+ */
+void setLengthVarIfKnown(VarDeclaration *lengthVar, Expression *arr)
+{
+    if (!lengthVar || lengthVar->init)
+        return;
+    size_t len;
+    if (arr->op == TOKstring)
+        len = ((StringExp *)arr)->len;
+    else if (arr->op == TOKarrayliteral)
+        len = ((ArrayLiteralExp *)arr)->elements->dim;
+    else
+        return; // we don't know the length yet
+
+    Expression *dollar = new IntegerExp(0, len, Type::tsize_t);
+    lengthVar->init = new ExpInitializer(0, dollar);
+    lengthVar->storage_class |= STCstatic | STCconst;
+}
+
+
 Expression *IndexExp::optimize(int result)
 {   Expression *e;
 
@@ -905,12 +927,15 @@ Expression *IndexExp::optimize(int result)
             this->e1 = e1;
         }
     }
+    // We might know $ now
+    setLengthVarIfKnown(lengthVar, e1);
     e2 = e2->optimize(WANTvalue | (result & WANTinterpret));
     e = Index(type, e1, e2);
     if (e == EXP_CANT_INTERPRET)
         e = this;
     return e;
 }
+
 
 Expression *SliceExp::optimize(int result)
 {   Expression *e;
@@ -928,6 +953,8 @@ Expression *SliceExp::optimize(int result)
         return e;
     }
     e1 = fromConstInitializer(result, e1);
+    // We might know $ now
+    setLengthVarIfKnown(lengthVar, e1);
     lwr = lwr->optimize(WANTvalue | (result & WANTinterpret));
     upr = upr->optimize(WANTvalue | (result & WANTinterpret));
     e = Slice(type, e1, lwr, upr);

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -60,7 +60,7 @@ Expression *expandVar(int result, VarDeclaration *v)
         Type *tb = v->type->toBasetype();
         if (result & WANTinterpret ||
             v->storage_class & STCmanifest ||
-            (tb->ty != Tsarray && tb->ty != Tstruct)
+            v->type->toBasetype()->isscalar()
            )
         {
             if (v->init)

--- a/src/statement.c
+++ b/src/statement.c
@@ -2925,7 +2925,7 @@ Statement *CaseStatement::semantic(Scope *sc)
     if (sw)
     {
         exp = exp->implicitCastTo(sc, sw->condition->type);
-        exp = exp->optimize(WANTvalue | WANTinterpret);
+        exp = exp->optimize(WANTvalue);
 
         /* This is where variables are allowed as case expressions.
          */
@@ -2943,6 +2943,8 @@ Statement *CaseStatement::semantic(Scope *sc)
                 goto L1;
             }
         }
+        else
+            exp = exp->optimize(WANTvalue | WANTinterpret);
 
         if (exp->op != TOKstring && exp->op != TOKint64 && exp->op != TOKerror)
         {

--- a/src/struct.c
+++ b/src/struct.c
@@ -245,15 +245,24 @@ int AggregateDeclaration::isNested()
  */
 int AggregateDeclaration::firstFieldInUnion(int indx)
 {
+    if (isUnionDeclaration())
+        return 0;
     VarDeclaration * vd = (VarDeclaration *)fields.data[indx];
+    int firstNonZero = indx; // first index in the union with non-zero size
     for (; ;)
     {
         if (indx == 0)
-            return indx;
+            return firstNonZero;
         VarDeclaration * v = (VarDeclaration *)fields.data[indx - 1];
         if (v->offset != vd->offset)
-            return indx;
+            return firstNonZero;
         --indx;
+        /* If it is a zero-length field, it's ambiguous: we don't know if it is
+         * in the union unless we find an earlier non-zero sized field with the
+         * same offset.
+         */
+        if (v->size(loc) != 0)
+            firstNonZero = indx;
     }
 }
 
@@ -264,11 +273,17 @@ int AggregateDeclaration::firstFieldInUnion(int indx)
 int AggregateDeclaration::numFieldsInUnion(int firstIndex)
 {
     VarDeclaration * vd = (VarDeclaration *)fields.data[firstIndex];
+    /* If it is a zero-length field, AND we can't find an earlier non-zero
+     * sized field with the same offset, we assume it's not part of a union.
+     */
+    if (vd->size(loc) == 0 && !isUnionDeclaration() &&
+        firstFieldInUnion(firstIndex) == firstIndex)
+        return 1;
     int count = 1;
     for (int i = firstIndex+1; i < fields.dim; ++i)
     {
         VarDeclaration * v = (VarDeclaration *)fields.data[i];
-        // They are in a union if they have the same offset
+        // If offsets are different, they are not in the same union
         if (v->offset != vd->offset)
             break;
         ++count;

--- a/src/struct.c
+++ b/src/struct.c
@@ -239,6 +239,42 @@ int AggregateDeclaration::isNested()
     return isnested;
 }
 
+/****************************************
+ * If field[indx] is not part of a union, return indx.
+ * Otherwise, return the lowest field index of the union.
+ */
+int AggregateDeclaration::firstFieldInUnion(int indx)
+{
+    VarDeclaration * vd = (VarDeclaration *)fields.data[indx];
+    for (; ;)
+    {
+        if (indx == 0)
+            return indx;
+        VarDeclaration * v = (VarDeclaration *)fields.data[indx - 1];
+        if (v->offset != vd->offset)
+            return indx;
+        --indx;
+    }
+}
+
+/****************************************
+ * Count the number of fields starting at firstIndex which are part of the
+ * same union as field[firstIndex]. If not a union, return 1.
+ */
+int AggregateDeclaration::numFieldsInUnion(int firstIndex)
+{
+    VarDeclaration * vd = (VarDeclaration *)fields.data[firstIndex];
+    int count = 1;
+    for (int i = firstIndex+1; i < fields.dim; ++i)
+    {
+        VarDeclaration * v = (VarDeclaration *)fields.data[i];
+        // They are in a union if they have the same offset
+        if (v->offset != vd->offset)
+            break;
+        ++count;
+    }
+    return count;
+}
 
 /********************************* StructDeclaration ****************************/
 

--- a/test/runnable/interpret2.d
+++ b/test/runnable/interpret2.d
@@ -50,11 +50,96 @@ void test1()
     assert(z1 == 8194);
 }
 
+/***** Bug 2850 *********************************/
+
+struct Bug2850{
+ union
+ {
+     int c;
+     double d;
+ }
+ int b;
+ int a;
+}
+
+static assert(is(typeof(
+ () { enum Bug2850 w = {b:47, 714, d:4 }; return w;}
+)));
+static assert(is(typeof(
+ () { enum Bug2850 w = {b:47, d:4 }; return w;}
+)));
+// union not initialized
+static assert(!is(typeof(
+ () { enum Bug2850 w = {b:47, 4 }; return w;}
+)));
+// initializers for two fields in same union
+static assert(!is(typeof(
+() { enum Bug2850 w = {b:47, 4, c:5, 9}; return w;}
+)));
+
+enum Bug2850 test2850 = {b:47, 714, d:23.1e-17};
+
+struct Horrid2850 {
+    union {
+        int a;
+        int b;
+        struct {
+            int c;
+            int d;
+        }
+    }
+    int f;
+    double q;
+}
+
+enum Horrid2850 horrid2850 = {c:5,6};
+Horrid2850 m2850 = {47, f:6};
+Horrid2850 z2850 = {q:5, c:4, d:5};
+
+static assert(!is(typeof(
+() {
+    enum Horrid2850 w = {c:47, d:5, a:7}; return w;
+    }
+)));
+
+void test2(){
+    assert(test2850.a == 714);
+    assert(test2850.b == 47);
+    assert(test2850.d == 23.1e-17);
+    assert(test2850.c != 0);
+}
+
+/***** Bug 3779 *********************************/
+
+static const bug3779 = ["123"][0][$-1];
+
+/***** Bug 1880 *********************************/
+
+
+enum Property1880 {First=1,Second=2}
+
+struct CompileTimeCheck1880(Property1880 Prop)
+{
+    alias Prop prop;
+}
+Property1880 junkprop1880;
+static assert(!is(CompileTimeCheck1880!(junkprop1880)));
+
+/***** Bug 5678 *********************************/
+
+struct Bug5678 {
+    this(int) {}
+}
+static assert(!is(typeof(
+() { enum Bug5678* f = new Bug5678(0); return f; }
+)));
+
 /************************************************/
 
 int main()
 {
     test1();
+    test2();
 
     writeln("Success");
     return 0;


### PR DESCRIPTION
Sorry, I haven't made D1 versions of these commits yet. I'll work on that shortly.

Starts with a fix for struct static initializers with named arguments. A comprehensive fix, it deals properly with unions (even when those unions themselves contain structs, etc).
- 3779 ["123"][0][$-1] causes __dollar unresolved in compile-time.
  Simple, but surprisingly important; it fixes the general case of constant folding $. This enables the next two super commits.
- Ensure compile-time constants are not variables(!)
  This one is spectacular. Please read the commit comment for this one. It fixes at least 8 wrong-code bugs:
  1336 Inconsistent __traits usage
  1880 templates instantiated with non-constants should fail sooner
  2257 Template value parameters behave like alias parameters
  2414 enum is dynamically evaluated, yum
  2526 non-const initializer to constant accepted inside template
  2706 invalid template instantiation (and declaration?) is not rejected
  2733 Unclear semantics of template value parameters
  fixes the accepts-invalid case of 2841 char[] incorrectly accepted as a template value argument in D2
- 4298 Constant array translated to unnecessary array literal creation
  This fixes one of the biggest performance killers in DMD. Interestingly it also uncovered a Phobos bug.
