### PR TITLE
Fixes for two important CTFE regressions

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1171,39 +1171,24 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
          * multiple times, it gets set only once.
          */
         if (!*pvar)             // if not already initialized
-        {   /* Create variable v and set it to the value of $,
-             * which will be a constant.
+        {   /* Create variable v and set it to the value of $
              */
             VarDeclaration *v = new VarDeclaration(loc, Type::tsize_t, Id::dollar, NULL);
-
-            if (ce->op == TOKvar)
-            {   // if ce is const, get its initializer
-                ce = fromConstInitializer(WANTvalue, ce);
-            }
-
-            if (ce->op == TOKstring)
-            {   /* It is for a string literal, so the
-                 * length will be a const.
-                 */
-                Expression *e = new IntegerExp(0, ((StringExp *)ce)->len, Type::tsize_t);
-                v->init = new ExpInitializer(0, e);
-                v->storage_class |= STCstatic | STCconst;
-            }
-            else if (ce->op == TOKarrayliteral)
-            {   /* It is for an array literal, so the
-                 * length will be a const.
-                 */
-                Expression *e = new IntegerExp(0, ((ArrayLiteralExp *)ce)->elements->dim, Type::tsize_t);
-                v->init = new ExpInitializer(0, e);
-                v->storage_class |= STCstatic | STCconst;
-            }
-            else if (ce->op == TOKtuple)
+            if (ce->op == TOKtuple)
             {   /* It is for an expression tuple, so the
                  * length will be a const.
                  */
                 Expression *e = new IntegerExp(0, ((TupleExp *)ce)->exps->dim, Type::tsize_t);
                 v->init = new ExpInitializer(0, e);
                 v->storage_class |= STCstatic | STCconst;
+            }
+            else
+            {   /* For arrays, $ will either be a compile-time constant
+                 * (in which case its value in set during constant-folding),
+                 * or a variable (in which case an expression is created in
+                 * toir.c).
+                 */
+                v->init = new VoidInitializer(0);
             }
             *pvar = v;
         }

--- a/src/inline.c
+++ b/src/inline.c
@@ -665,7 +665,7 @@ Expression *IndexExp::doInline(InlineDoState *ids)
         ids->from.push(vd);
         ids->to.push(vto);
 
-        if (vd->init)
+        if (vd->init && !vd->init->isVoidInitializer())
         {
             ie = vd->init->isExpInitializer();
             assert(ie);
@@ -702,7 +702,7 @@ Expression *SliceExp::doInline(InlineDoState *ids)
         ids->from.push(vd);
         ids->to.push(vto);
 
-        if (vd->init)
+        if (vd->init && !vd->init->isVoidInitializer())
         {
             ie = vd->init->isExpInitializer();
             assert(ie);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2684,7 +2684,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
                 return EXP_CANT_INTERPRET;
             }
             int se_indx = se3->getFieldIndex(e1->type, vv->offset);
-            (Expression *)se3->elements->data[se_indx] = newval;
+            se3->elements->data[se_indx] = newval;
             // Mark the parent variable as modified
             if (!destinationIsReference)
                 addVarToInterstate(istate, ultimateVar);

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -915,8 +915,10 @@ Expression *IdentityExp::optimize(int result)
  */
 void setLengthVarIfKnown(VarDeclaration *lengthVar, Expression *arr)
 {
-    if (!lengthVar || lengthVar->init)
+    if (!lengthVar)
         return;
+    if (lengthVar->init && !lengthVar->init->isVoidInitializer())
+        return; // we have previously calculated the length
     size_t len;
     if (arr->op == TOKstring)
         len = ((StringExp *)arr)->len;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -690,3 +690,42 @@ static assert(bug5852("abc")==3);
 *******************************************/
 
 static assert( ['a', 'b'] ~ "c" == "abc" );
+
+/*******************************************
+        Bug 5685
+*******************************************/
+
+string bug5685() {
+  return "xxx";
+}
+struct Bug5865 {
+    void test1(){
+        enum file2 = (bug5685())[0..$]  ;
+    }
+}
+
+/*******************************************
+        Bug 5840
+*******************************************/
+
+struct Bug5840 {
+    string g;
+    int w;
+}
+
+int bug5840(int u)
+{   // check for clobbering
+    Bug5840 x = void;
+    x.w = 4;
+    x.g = "3gs";
+    if (u==1) bug5840(2);
+    if (u==2) {
+        x.g = "abc";
+        x.w = 3465;
+    } else {
+        assert(x.g == "3gs");
+        assert(x.w == 4);
+    }
+    return 56;
+}
+static assert(bug5840(1)==56);


### PR DESCRIPTION
The first patch entirely removes the hackish, limited constant folding for $ from the initial semantic pass, into the constant folding pass where it belongs. (Incidentally, the comments for __dollar in the code were completely wrong -- it isn't always a constant!)

The second patch allows array reference assignment to members of structs, which in 2.052 would always compile, and occasionally generate correct code <g>. Now it should actually work.
