### PR TITLE
Issue 5889 - Struct literal/construction should be rvalue

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3883,19 +3883,6 @@ int StructLiteralExp::getFieldIndex(Type *type, unsigned offset)
     return -1;
 }
 
-#if DMDV2
-int StructLiteralExp::isLvalue()
-{
-    return 1;
-}
-#endif
-
-Expression *StructLiteralExp::toLvalue(Scope *sc, Expression *e)
-{
-    return this;
-}
-
-
 void StructLiteralExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring(sd->toChars());
@@ -7852,11 +7839,14 @@ Lcheckargs:
 #if DMDV2
 int CallExp::isLvalue()
 {
-//    if (type->toBasetype()->ty == Tstruct)
-//      return 1;
     Type *tb = e1->type->toBasetype();
     if (tb->ty == Tfunction && ((TypeFunction *)tb)->isref)
+    {
+        if (e1->op == TOKdotvar)
+            if (((DotVarExp *)e1)->var->isCtorDeclaration())
+                return 0;
         return 1;               // function returns a reference
+    }
     return 0;
 }
 #endif

--- a/src/expression.h
+++ b/src/expression.h
@@ -490,8 +490,6 @@ struct StructLiteralExp : Expression
     Expression *optimize(int result);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     dt_t **toDt(dt_t **pdt);
-    int isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
     MATCH implicitConvTo(Type *t);
 
     int inlineCost3(InlineCostState *ics);

--- a/src/func.c
+++ b/src/func.c
@@ -2420,7 +2420,7 @@ MATCH FuncDeclaration::leastAsSpecialized(FuncDeclaration *g)
             e->type = p->type;
         }
         else
-            e = p->type->defaultInit();
+            e = p->type->defaultInitLiteral();
         args.tdata()[u] = e;
     }
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1287,7 +1287,8 @@ void bar5258(int n, ref Foo5258 fong) {
         fong.x++;
 }
 int bug5258() {
-    bar5258(1, Foo5258());
+    Foo5258 foo5258 = Foo5258();
+    bar5258(1, foo5258);
     return 45;
 }
 static assert(bug5258()==45);

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -367,6 +367,63 @@ void test5885()
 }
 
 /********************************************/
+// 5889
+
+struct S5889a { int n; }
+struct S5889b { this(int n){} }
+
+bool isLvalue(S)(auto ref S s){ return __traits(isRef, s); }
+
+int foo(ref S5889a s) { return 1; }
+int foo(    S5889a s) { return 2; }
+int foo(ref S5889b s) { return 1; }
+int foo(    S5889b s) { return 2; }
+
+int goo(ref const(S5889a) s) { return 1; }
+int goo(    const(S5889a) s) { return 2; }
+int goo(ref const(S5889b) s) { return 1; }
+int goo(    const(S5889b) s) { return 2; }
+
+int too(S)(ref S s) { return 1; }
+int too(S)(    S s) { return 2; }
+
+S makeRvalue(S)(){ S s; return s; }
+
+void test5889()
+{
+    S5889a sa;
+    S5889b sb;
+
+    assert( isLvalue(sa));
+    assert( isLvalue(sb));
+    assert(!isLvalue(S5889a(0)));
+    assert(!isLvalue(S5889b(0)));
+    assert(!isLvalue(makeRvalue!S5889a()));
+    assert(!isLvalue(makeRvalue!S5889b()));
+
+    assert(foo(sa) == 1);
+    assert(foo(sb) == 1);
+    assert(foo(S5889a(0)) == 2);
+    assert(foo(S5889b(0)) == 2);
+    assert(foo(makeRvalue!S5889a()) == 2);
+    assert(foo(makeRvalue!S5889b()) == 2);
+
+    assert(goo(sa) == 1);
+    assert(goo(sb) == 1);
+    assert(goo(S5889a(0)) == 2);
+    assert(goo(S5889b(0)) == 2);
+    assert(goo(makeRvalue!S5889a()) == 2);
+    assert(goo(makeRvalue!S5889b()) == 2);
+
+    assert(too(sa) == 1);
+    assert(too(sb) == 1);
+    assert(too(S5889a(0)) == 2);
+    assert(too(S5889b(0)) == 2);
+    assert(too(makeRvalue!S5889a()) == 2);
+    assert(too(makeRvalue!S5889b()) == 2);
+}
+
+/********************************************/
 
 int main()
 {
@@ -385,6 +442,7 @@ int main()
     test13();
     test3198and1914();
     test5885();
+    test5889();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5889
This change might not be enhancement, but breaks existing code.

By current dmd implementation, struct literal/construction is make lvalue.
The rule "implicit conversion from rvalue to lvalue" is correct. But struct literal/construct itself should be rvalue, not lvalue.
It seems to me that is implementation error, so I post this patch.
(see testcase at http://d.puremagic.com/issues/show_bug.cgi?id=5889)

I think this fix is need for resource management type like typecons.Unique.
Once I tried to write new Unique type (see https://github.com/9rnsr/scrap/blob/master/typecons/unique.d), but failed to separate struct rvalue from lvalue by this bug.

CAUTION: It is necessary to apply changes to phobos and dmd at the same time.
See https://github.com/D-Programming-Language/phobos/pull/120

requires: druntime git://github.com/9rnsr/druntime.git rvalue-struct-literal
requires: phobos git://github.com/9rnsr/phobos.git rvalue-struct-literal
