### PR TITLE
5664 Cannot compile static synchronized member function.

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1578,7 +1578,7 @@ void FuncDeclaration::semantic3(Scope *sc)
             {   /* Wrap the entire function body in a synchronized statement
                  */
                 AggregateDeclaration *ad = isThis();
-                ClassDeclaration *cd = ad ? ad->isClassDeclaration() : NULL;
+                ClassDeclaration *cd = ad ? ad->isClassDeclaration() : parent->isClassDeclaration();
 
                 if (cd)
                 {


### PR DESCRIPTION
Fixes issue 5664, which was introduced by https://github.com/D-Programming-Language/dmd/commit/d19e57c3f0683ac3a0b290f5b73deb86aa1a6441, which was trying to fix issue 5105 - Member function template cannot be synchronized .

This patch successfully compiles test cases from both issues.
