### PR TITLE
Issue 5551 - opUnary-opBinary conflict

### DIFF
--- a/src/opover.c
+++ b/src/opover.c
@@ -475,7 +475,11 @@ Expression *BinExp::op_overload(Scope *sc)
     Objects *targsi = NULL;
 #if DMDV2
     if (!s && !s_r && op != TOKequal && op != TOKnotequal && op != TOKassign)
-    {   /* Try the new D2 scheme, opBinary and opBinaryRight
+    {
+        if (op == TOKplusplus || op == TOKminusminus)
+            return NULL;
+
+        /* Try the new D2 scheme, opBinary and opBinaryRight
          */
         if (ad1)
             s = search_function(ad1, Id::opBinary);


### PR DESCRIPTION
When D1 opPostInc/opPostDec matching fails, do not fall-through to opBinary/opBinaryRight matching.
