### PR TITLE
URGENT: Fix CTFE ICE in std.datetime

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2309,11 +2309,12 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
     }
     /* This happens inside compiler-generated foreach statements.
      * It's another case where we need a reference
+     * Note that a similar case, where e2 = 'this', occurs in
+     * construction of a struct with an invariant().
      */
-    if (op==TOKconstruct && this->e1->op==TOKvar
+    if (op==TOKconstruct && this->e1->op==TOKvar && this->e2->op != TOKthis
         && ((VarExp*)this->e1)->var->storage_class & STCref)
         wantRef = true;
-
 
     if (fp)
     {
@@ -2461,7 +2462,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
     }
 
     // This happens inside compiler-generated foreach statements.
-    if (op==TOKconstruct && this->e1->op==TOKvar
+    if (op==TOKconstruct && this->e1->op==TOKvar && this->e2->op != TOKthis
         && ((VarExp*)this->e1)->var->storage_class & STCref)
     {
         //error("assignment to ref variable %s is not yet supported in CTFE", this->toChars());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -729,3 +729,15 @@ int bug5840(int u)
     return 56;
 }
 static assert(bug5840(1)==56);
+
+/*******************************************
+    std.datetime ICE (30 April 2011)
+*******************************************/
+
+struct TimeOfDayZ
+{
+public:
+    this(int hour) { }
+    invariant() { }
+}
+const testTODsThrownZ = TimeOfDayZ(0);


### PR DESCRIPTION
There was a special case when a struct is constructed, which has an invariant(). Although it's marked as 'ref', it isn't actually a reference construction.
