### PR TITLE
@property

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -206,8 +206,11 @@ Expression *resolveProperties(Scope *sc, Expression *e)
         if (t->ty == Tfunction || e->op == TOKoverloadset)
         {
 #if 1
-            if (t->ty == Tfunction && !((TypeFunction *)t)->isproperty)
+            if (t->ty == Tfunction && !((TypeFunction *)t)->isproperty &&
+                global.params.enforcePropertySyntax)
+            {
                 error(e->loc, "not a property %s\n", e->toChars());
+            }
 #endif
             e = new CallExp(e->loc, e);
             e = e->semantic(sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -205,7 +205,7 @@ Expression *resolveProperties(Scope *sc, Expression *e)
 
         if (t->ty == Tfunction || e->op == TOKoverloadset)
         {
-#if 0
+#if 1
             if (t->ty == Tfunction && !((TypeFunction *)t)->isproperty)
                 error(e->loc, "not a property %s\n", e->toChars());
 #endif

--- a/src/func.c
+++ b/src/func.c
@@ -167,7 +167,7 @@ void FuncDeclaration::semantic(Scope *sc)
     {
         sc = sc->push();
         sc->stc |= storage_class & (STCref | STCnothrow | STCpure | STCdisable
-            | STCsafe | STCtrusted | STCsystem);      // forward to function type
+            | STCsafe | STCtrusted | STCsystem | STCproperty);      // forward to function type
 
         if (isCtorDeclaration())
             sc->flags |= SCOPEctor;

--- a/src/mars.c
+++ b/src/mars.c
@@ -276,6 +276,7 @@ Usage:\n\
   --help         print help\n\
   -Ipath         where to look for imports\n\
   -ignore        ignore unsupported pragmas\n\
+  -property      enforce property syntax\n\
   -inline        do function inlining\n\
   -Jpath         where to look for string imports\n\
   -Llinkerflag   pass linkerflag to link\n\
@@ -582,6 +583,8 @@ int main(int argc, char *argv[])
             }
             else if (strcmp(p + 1, "ignore") == 0)
                 global.params.ignoreUnsupportedPragmas = 1;
+            else if (strcmp(p + 1, "property") == 0)
+                global.params.enforcePropertySyntax = 1;
             else if (strcmp(p + 1, "inline") == 0)
                 global.params.useInline = 1;
             else if (strcmp(p + 1, "lib") == 0)

--- a/src/mars.h
+++ b/src/mars.h
@@ -165,6 +165,7 @@ struct Param
     char nofloat;       // code should not pull in floating point support
     char Dversion;      // D version number
     char ignoreUnsupportedPragmas;      // rather than error on them
+    char enforcePropertySyntax;
 
     char *argv0;        // program name
     Array *imppath;     // array of char*'s of where to look for import modules

--- a/src/parse.c
+++ b/src/parse.c
@@ -427,8 +427,10 @@ Dsymbols *Parser::parseDeclDefs(int once)
                 if (token.value == TOKidentifier &&
                     (tk = peek(&token))->value == TOKlparen &&
                     skipParens(tk, &tk) &&
-                    (peek(tk)->value == TOKlparen ||
-                     peek(tk)->value == TOKlcurly)
+                    ((tk = peek(tk)), 1) &&
+                    skipAttributes(tk, &tk) &&
+                    (tk->value == TOKlparen ||
+                     tk->value == TOKlcurly)
                    )
                 {
                     a = parseDeclarations(storageClass, comment);
@@ -4899,6 +4901,61 @@ int Parser::skipParens(Token *t, Token **pt)
     return 1;
 
   Lfalse:
+    return 0;
+}
+
+/*******************************************
+ * Skip attributes.
+ * Input:
+ *      t is on a candidate attribute
+ * Output:
+ *      *pt is set to first non-attribute token on success
+ * Returns:
+ *      !=0     successful
+ *      0       some parsing error
+ */
+
+int Parser::skipAttributes(Token *t, Token **pt)
+{
+    while (1)
+    {
+        switch (t->value)
+        {
+            case TOKconst:
+            case TOKinvariant:
+            case TOKimmutable:
+            case TOKshared:
+            case TOKwild:
+            case TOKfinal:
+            case TOKauto:
+            case TOKscope:
+            case TOKoverride:
+            case TOKabstract:
+            case TOKsynchronized:
+            case TOKdeprecated:
+            case TOKnothrow:
+            case TOKpure:
+            case TOKref:
+            case TOKtls:
+            case TOKgshared:
+            //case TOKmanifest:
+                break;
+            case TOKat:
+                if (parseAttribute() == STCundefined)
+                    break;
+                goto Lerror;
+            default:
+                goto Ldone;
+        }
+        t = peek(t);
+    }
+
+  Ldone:
+    if (*pt)
+        *pt = t;
+    return 1;
+    
+  Lerror:
     return 0;
 }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -124,6 +124,7 @@ struct Parser : Lexer
     int isExpression(Token **pt);
     int isTemplateInstance(Token *t, Token **pt);
     int skipParens(Token *t, Token **pt);
+    int skipAttributes(Token *t, Token **pt);
 
     Expression *parseExpression();
     Expression *parsePrimaryExp();

--- a/src/statement.c
+++ b/src/statement.c
@@ -1715,7 +1715,7 @@ Lagain:
 
             // __r.next
             e = new VarExp(loc, r);
-            Expression *increment = new DotIdExp(loc, e, idnext);
+            Expression *increment = new CallExp(loc, new DotIdExp(loc, e, idnext));
 
             /* Declaration statement for e:
              *    auto e = __r.idhead;

--- a/test/compilable/auto_postfixattr.d
+++ b/test/compilable/auto_postfixattr.d
@@ -1,0 +1,7 @@
+// PERMUTE_ARGS:
+
+// postfix attributes not playing well with auto return type
+
+int test1() pure nothrow { return 1; }
+auto test2() pure nothrow { return 1; }
+auto ref test3() pure nothrow { return 1; }

--- a/test/compilable/property_auto_return.d
+++ b/test/compilable/property_auto_return.d
@@ -1,0 +1,11 @@
+// PERMUTE_ARGS:
+
+// Checking that @property storage class is applied correctly to function with
+// deduced return type. If not applied, will cause an error complaining about
+// property and non-prooperty functions beging overloaded.
+
+@property int test() { return 1; }
+@property auto test(int i) { return i; }
+
+@property int test2() { return 1; }
+@property auto ref test2(int i) { return i; }

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -172,7 +172,7 @@ string genTempFilename()
     foreach (ref e; 0 .. 8)
     {  
         formattedWrite(a, "%x", rndGen.front);
-        rndGen.popFront;
+        rndGen.popFront();
     }
 
     return a.data;


### PR DESCRIPTION
Implements basic enforcement of property syntax at the call site. Enforcement is done only when using the added -property switch to allow a testing and transition period.
http://d.puremagic.com/issues/show_bug.cgi?id=5823

Also seems like commits 247a40a0 and 2ae23a0d (included in the pull request) should fix those bugs (some are duplicates):
http://d.puremagic.com/issues/show_bug.cgi?id=3359
http://d.puremagic.com/issues/show_bug.cgi?id=4040
http://d.puremagic.com/issues/show_bug.cgi?id=4706
http://d.puremagic.com/issues/show_bug.cgi?id=4865
http://d.puremagic.com/issues/show_bug.cgi?id=5867
