### PR TITLE
Issue 5963 - iasm does not accept 64bit integer literal

### DIFF
--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -332,6 +332,7 @@ union evc
     targ_int    Vint;           // also used for tmp numbers (FLtmp)
     targ_uns    Vuns;
     targ_long   Vlong;
+    targ_llong  Vllong;
     targ_size_t Vsize_t;
     struct
     {   targ_size_t Vpointer;
@@ -442,6 +443,7 @@ struct code
       #define IEVoffset2  IEV2.sp.Voffset
       #define IEVlsym2    IEV2.lab.Vsym
       #define IEVint2     IEV2.Vint
+      #define IEVllong2   IEV2.Vllong
     void print();               // pretty-printer
 
     code() { Irex = 0; Isib = 0; }      // constructor

--- a/src/backend/iasm.h
+++ b/src/backend/iasm.h
@@ -96,6 +96,7 @@ typedef unsigned opflag_t;
 #define _imm8   CONSTRUCT_FLAGS(_8, _imm, _normal, 0 )
 #define _imm16  CONSTRUCT_FLAGS(_16, _imm, _normal, 0)
 #define _imm32  CONSTRUCT_FLAGS(_32, _imm, _normal, 0)
+#define _imm64  CONSTRUCT_FLAGS(_64, _imm, _normal, 0)
 #define _rel8   CONSTRUCT_FLAGS(_8, _rel, _normal, 0)
 #define _rel16  CONSTRUCT_FLAGS(_16, _rel, _normal, 0)
 #define _rel32  CONSTRUCT_FLAGS(_32, _rel, _normal, 0)
@@ -178,7 +179,7 @@ typedef unsigned opflag_t;
 enum ASM_OPERAND_TYPE {
     _reg,           // _r8, _r16, _r32
     _m,             // _m8, _m16, _m32, _m48
-    _imm,           // _imm8, _imm16, _imm32
+    _imm,           // _imm8, _imm16, _imm32, _imm64
     _rel,           // _rel8, _rel16, _rel32
     _mnoi,          // _m1616, _m1632
     _p,             // _p1616, _p1632

--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -617,7 +617,7 @@ PTRNTAB2 aptb2MOV[] = /* MOV */ {
         { 0xb0, _rb,            _r8 | _plus_r,  _imm8           },
         { 0xb8, _rw | _16_bit,  _r16 | _plus_r, _imm16          },
         { 0xb8, _rd|_32_bit,    _r32 | _plus_r, _imm32          },
-        { 0xb8, _rd|_64_bit,    _r64 | _plus_r, _imm32          },
+        { 0xb8, _rd|_64_bit,    _r64 | _plus_r, _imm64          },
         { 0xc6, _cb,            _rm8,           _imm8           },
         { 0xc7, _cw|_16_bit,    _rm16,          _imm16          },
         { 0xc7, _cd|_32_bit,    _rm32,          _imm32          },

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -442,7 +442,7 @@ typedef struct opnd
         unsigned uchMultiplier; // register multiplier; valid values are 0,1,2,4,8
         opflag_t usFlags;
         Dsymbol *s;
-        long disp;
+        long long disp;
         long double real;
         Type *ptype;
         ASM_JUMPTYPE ajt;
@@ -1122,11 +1122,13 @@ STATIC opflag_t asm_determine_operand_flags(OPND *popnd)
             us = CONSTRUCT_FLAGS(sz, _imm, _normal, 0);
 
         else if (popnd->disp >= CHAR_MIN && popnd->disp <= UCHAR_MAX)
-            us = CONSTRUCT_FLAGS(_8 | _16 | _32, _imm, _normal, 0);
+            us = CONSTRUCT_FLAGS(  _8 | _16 | _32 | _64, _imm, _normal, 0);
         else if (popnd->disp >= SHRT_MIN && popnd->disp <= USHRT_MAX)
-            us = CONSTRUCT_FLAGS(_16 | _32, _imm, _normal, 0);
+            us = CONSTRUCT_FLAGS( _16 | _32 | _64, _imm, _normal, 0);
+        else if (popnd->disp >= INT_MIN && popnd->disp <= UINT_MAX)
+            us = CONSTRUCT_FLAGS( _32 | _64, _imm, _normal, 0);
         else
-            us = CONSTRUCT_FLAGS(_32, _imm, _normal, 0);
+            us = CONSTRUCT_FLAGS( _64, _imm, _normal, 0);
         return us;
 }
 
@@ -1541,6 +1543,7 @@ L1:
                         case _8:
                         case _16:
                         case _32:
+                        case _64:
                             if (popndTmp->s == asmstate.psLocalsize)
                             {
                                 pc->IFL2 = FLlocalsize;
@@ -1564,7 +1567,7 @@ L1:
                             }
                             else
                             {
-                                pc->IEVint2 = popndTmp->disp;
+                                pc->IEVllong2 = popndTmp->disp;
                                 pc->IFL2 = FLconst;
                             }
                             break;
@@ -4213,6 +4216,13 @@ STATIC OPND *asm_primary_exp()
             case TOKuns32v:
                 o1 = opnd_calloc();
                 o1->disp = asmtok->int32value;
+                asm_token();
+                break;
+
+            case TOKint64v:
+            case TOKuns64v:
+                o1 = opnd_calloc();
+                o1->disp = asmtok->int64value;
                 asm_token();
                 break;
 


### PR DESCRIPTION
as far as I can find, mov is the only instruction that can take a 64bit immediate operand. 

s̶o̶ ̶r̶a̶t̶h̶e̶r̶ ̶t̶h̶a̶n̶ ̶c̶h̶a̶n̶g̶e̶ ̶s̶t̶r̶u̶c̶t̶ ̶O̶P̶N̶D̶'̶s̶ ̶d̶i̶s̶p̶ ̶t̶o̶ ̶"̶l̶o̶n̶g̶ ̶l̶o̶n̶g̶"̶ ̶(̶ ̶s̶o̶ ̶a̶ ̶3̶2̶b̶i̶t̶ ̶d̶m̶d̶ ̶-̶m̶6̶4̶ ̶w̶i̶l̶l̶ ̶w̶o̶r̶k̶ ̶t̶h̶e̶ ̶s̶a̶m̶e̶ ̶a̶s̶ ̶a̶ ̶6̶4̶b̶i̶t̶ ̶b̶u̶i̶l̶d̶ ̶)̶ ̶I̶ ̶r̶e̶s̶o̶r̶t̶e̶d̶ ̶t̶o̶ ̶s̶t̶o̶r̶i̶n̶g̶ ̶i̶t̶ ̶i̶n̶ ̶"̶r̶e̶a̶l̶"̶ ̶

Edit: Sorry, I just extended OPND.disp to 64bits, it just makes the patch much cleaner.
