### PR TITLE
Additional fix for issue 4499, disabled postblit

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -380,6 +380,22 @@ FuncDeclaration *StructDeclaration::buildCpCtor(Scope *sc)
 FuncDeclaration *StructDeclaration::buildPostBlit(Scope *sc)
 {
     //printf("StructDeclaration::buildPostBlit() %s\n", toChars());
+
+    /* If the struct disables postblit, ignore the postblits of members.
+    */
+    if (postblits.dim)
+    {
+        FuncDeclaration *userPostblit = (FuncDeclaration *)postblits.data[0];
+        if (userPostblit->storage_class & STCdisable)
+        {
+            /* Give it an empty body so that it will not cause linking errors
+             * when the copy constructor and aggregate postblits call it.*/
+            if (!userPostblit->fbody)
+                userPostblit->fbody = new ExpStatement(0, (Expression *)NULL);
+            return userPostblit;
+        }
+    }
+
     Expression *e = NULL;
     StorageClass stc = 0;
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1761,9 +1761,7 @@ void test94()
 
 struct T95
 {
-    @disable this(this)
-    {
-    }
+    @disable this(this);
 }
 
 struct S95


### PR DESCRIPTION
Previously the declaration

```
@disable this(this);
```

caused linking errors when no copying was attempted because the automatically generated copying functions call it. This patch fixes this.
When a postblit function is disabled, it is be given an empty body if it has none, and further analysis of member postblits is skipped. Tested on 32-bit Linux.
