### PR TITLE
CTFE ref parameters and struct literals

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1235,17 +1235,19 @@ Expression *Index(Type *type, Expression *e1, Expression *e2)
         if (i >= length)
         {   e2->error("array index %ju is out of bounds %s[0 .. %ju]", i, e1->toChars(), length);
         }
-        else if (e1->op == TOKarrayliteral && !e1->checkSideEffect(2))
+        else if (e1->op == TOKarrayliteral)
         {   ArrayLiteralExp *ale = (ArrayLiteralExp *)e1;
             e = (Expression *)ale->elements->data[i];
             e->type = type;
+            if (e->checkSideEffect(2))
+                e = EXP_CANT_INTERPRET;
         }
     }
     else if (e1->type->toBasetype()->ty == Tarray && e2->op == TOKint64)
     {
         uinteger_t i = e2->toInteger();
 
-        if (e1->op == TOKarrayliteral && !e1->checkSideEffect(2))
+        if (e1->op == TOKarrayliteral)
         {   ArrayLiteralExp *ale = (ArrayLiteralExp *)e1;
             if (i >= ale->elements->dim)
             {   e2->error("array index %ju is out of bounds %s[0 .. %u]", i, e1->toChars(), ale->elements->dim);
@@ -1253,10 +1255,12 @@ Expression *Index(Type *type, Expression *e1, Expression *e2)
             else
             {   e = (Expression *)ale->elements->data[i];
                 e->type = type;
+                if (e->checkSideEffect(2))
+                    e = EXP_CANT_INTERPRET;
             }
         }
     }
-    else if (e1->op == TOKassocarrayliteral && !e1->checkSideEffect(2))
+    else if (e1->op == TOKassocarrayliteral)
     {
         AssocArrayLiteralExp *ae = (AssocArrayLiteralExp *)e1;
         /* Search the keys backwards, in case there are duplicate keys
@@ -1271,6 +1275,8 @@ Expression *Index(Type *type, Expression *e1, Expression *e2)
             if (ex->isBool(TRUE))
             {   e = (Expression *)ae->values->data[i];
                 e->type = type;
+                if (e->checkSideEffect(2))
+                    e = EXP_CANT_INTERPRET;
                 break;
             }
         }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2664,7 +2664,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
                     return newval;
             }
         }
-        else
+        else if (e1->op != TOKslice || newval->op != TOKslice)
         {
             newval = newval->interpret(istate);
             if (newval == EXP_CANT_INTERPRET)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2761,7 +2761,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
                 return EXP_CANT_INTERPRET;
             }
             if (v->getValue())
-                assignInPlace(v->getValue(), newval);
+                assignInPlace(v->getValue(), copyLiteral(newval));
             else
                 v->createRefValue(copyLiteral(newval));
         }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -244,7 +244,8 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
                 VarExp *ve = (VarExp *)earg;
                 VarDeclaration *v2 = ve->var->isVarDeclaration();
                 if (!v2)
-                {   cantInterpret = 1;
+                {
+                        error("cannot interpret %s as a ref parameter", ve->toChars());
                         return NULL;
                 }
                 v->setValueWithoutChecking(earg);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -163,8 +163,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
     Expressions vsave;          // place to save previous parameter values
     size_t dim = 0;
     if (needThis() && !thisarg)
-    {   cantInterpret = 1;
-        // error, no this. Prevent segfault.
+    {   // error, no this. Prevent segfault.
         error("need 'this' to access member %s", toChars());
         return NULL;
     }
@@ -227,9 +226,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
                 }
                 earg = earg->interpret(istate); // ? istate : &istatex);
                 if (earg == EXP_CANT_INTERPRET)
-                {   cantInterpret = 1;
                     return NULL;
-                }
             }
             eargs.data[i] = earg;
         }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -793,3 +793,92 @@ void oddity4001(int q)
 *******************************************/
 
 static const bug3779 = ["123"][0][$-1];
+
+
+/*******************************************
+    non-Cow struct literals
+*******************************************/
+
+struct Zadok
+{
+    int [3] z;
+    char [4] s = void;
+    ref int[] fog(ref int [] q) { return q; }
+    int bfg()
+    {
+        z[0] = 56;
+        fog(z[]) = [56, 6, 8];
+        assert(z[1] == 6);
+        assert(z[0] == 56);
+        return z[2];
+    }
+}
+
+struct Vug
+{
+    Zadok p;
+    int [] other;
+}
+
+int quop()
+{
+    int [] heap = new int[5];
+    heap[] = 738;
+    Zadok pong;
+    pong.z = 3;
+    int [] w = pong.z;
+    assert(w[0]==3);
+    Zadok phong;
+    phong.z = 61;
+    pong = phong;
+    assert(w[0]==61);
+    Vug b = Vug(Zadok(17, "abcd"));
+    b = Vug(Zadok(17, "abcd"), heap);
+    b.other[2] = 78;
+    assert(heap[2]==78);
+    char [] y = b.p.s;
+    assert(y[2]=='c');
+    phong.s = ['z','x','f', 'g'];
+    w = b.p.z;
+    assert(y[2]=='c');
+    assert(w[0]==17);
+    b.p = phong;
+    assert(y[2]=='f');
+
+    Zadok wok = Zadok(6, "xyzw");
+    b.p = wok;
+    assert(y[2]=='z');
+    b.p = phong;
+    assert(w[0] == 61);
+    Vug q;
+    q.p = pong;
+    return pong.bfg();
+}
+
+static assert(quop()==8);
+static assert(quop()==8); // check for clobbering
+
+/**************************************************
+   Bug 5682 Wrong CTFE with operator overloading
+**************************************************/
+
+struct A {
+    int n;
+    auto opBinary(string op : "*")(A rhs) {
+        return A(n * rhs.n);
+    }
+}
+
+A foo(A[] lhs, A[] rhs) {
+    A current;
+    for (size_t k = 0; k < rhs.length; ++k) {
+        current = lhs[k] * rhs[k];
+    }
+    return current;
+}
+
+auto test() {
+    return foo([A(1), A(2)], [A(3), A(4)]);
+}
+
+static assert(test().n == 8);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -882,3 +882,72 @@ auto test() {
 }
 
 static assert(test().n == 8);
+
+
+/**************************************************
+   Attempt to modify a read-only string literal
+**************************************************/
+struct Xarg
+{
+   char [] s;
+}
+int zfs()
+{
+    auto q = Xarg(cast(char[])"abc");
+    assert(q.s[1]=='b');
+    q.s[1] = 'p';
+    return 76;
+}
+
+static assert(!is(typeof(compiles!(zfs()))));
+
+/**************************************************
+   Variation of 5972 which caused segfault
+**************************************************/
+
+int bug5972crash()
+{
+  char [] z = "abc".dup;
+  char[] [] a = [null, null];
+  a[0]  = z[0..2];
+  a[0][1] = 'q';
+  return 56;
+}
+static assert(bug5972crash()==56);
+
+/**************************************************
+   String slice assignment through ref parameter
+**************************************************/
+
+void popft(A)(ref A a)
+{
+    a = a[1 .. $];
+}
+
+int sdfgasf()
+{
+    auto scp = "abc".dup;
+    popft(scp);
+    return 1;
+}
+static assert(sdfgasf() == 1);
+
+/**************************************************
+   Bug 6015
+**************************************************/
+
+struct Foo6015 {
+    string field;
+}
+
+bool func6015(string input){
+    Foo6015 foo;
+    foo.field = input[0..$];
+    assert(foo.field == "test");
+    foo.field = "test2";
+    assert(foo.field != "test");
+    assert(foo.field == "test2");
+    return true;
+}
+
+static assert(func6015("test"));

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -951,3 +951,85 @@ bool func6015(string input){
 }
 
 static assert(func6015("test"));
+
+/**************************************************
+   Bug 6001
+**************************************************/
+
+void bug6001e(ref int[] s) {
+    int[] r = s;
+    s ~= 0;
+}
+bool bug6001f() {
+    int[] s;
+    bug6001e(s);
+    return true;
+}
+static assert(bug6001f());
+
+// Assignment to AAs
+
+void blah(int[char] as)
+{
+    auto k = [6: as];
+    as = k[6];
+}
+int blaz()
+{
+    int[char] q;
+    blah(q);
+    return 67;
+}
+static assert(blaz()==67);
+
+void bug6001g(ref int[] w)
+{
+    w = [88];
+    bug6001e(w);
+    w[0] = 23;
+}
+
+bool bug6001h() {
+    int[] s;
+    bug6001g(s);
+    assert(s.length == 2);
+    assert(s[1]== 0);
+    assert(s[0]==23);
+    return true;
+}
+static assert(bug6001h());
+
+/**************************************************
+   Bug 4910
+**************************************************/
+
+int bug4910(int a)
+{
+    return a;
+}
+
+static int var4910;
+static assert(!is(typeof(Compiles!(bug4910(var4910)))));
+
+static assert(bug4910(123));
+
+/**************************************************
+    Bug 5845 - Regression(2.041)
+**************************************************/
+
+void test5845(ulong cols) {}
+
+uint solve(bool niv, ref ulong cols) {
+    if (niv)
+        solve(false, cols);
+    else
+        test5845(cols);
+    return 65;
+}
+
+ulong nqueen(int n) {
+    ulong cols    = 0;
+    return solve(true, cols);
+}
+
+static assert(nqueen(2) == 65);


### PR DESCRIPTION
This is the third and final fix to the fundamentals of the CTFE engine.
It completes the 'needLvalue' interpreting scheme, and applies it to struct literals and to parameters passed by ref. It is a significant simplification (the 'assign' function became 100 lines shorter).
Fixes the most severe CTFE bugs, including several which aren't in Bugzilla. The speed and memory use is also a bit better. Fixes these Bugzilla bugs:

4910 [CTFE] Cannot evaluate a function that has failed at once
5682 Wrong CTFE with operator overloading
5845 Regression(2.041) [CTFE] "stack overflow" with recursive ref argument
6001 CTFE: ICE(interpret.c) mutating array passed by ref
6015 [CTFE] Strange behavior of assignment appears in a situation
