### PR TITLE
CTFE: Support non-trivial ref parameters

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7518,6 +7518,8 @@ Expression *AddrExp::semantic(Scope *sc)
     {
         UnaExp::semantic(sc);
         e1 = e1->toLvalue(sc, NULL);
+        if (e1->op == TOKerror)
+            return e1;
         if (!e1->type)
         {
             error("cannot take address of %s", e1->toChars());

--- a/src/expression.h
+++ b/src/expression.h
@@ -78,6 +78,7 @@ enum CtfeGoal
 {   ctfeNeedRvalue,   // Must return an Rvalue
     ctfeNeedLvalue,   // Must return an Lvalue
     ctfeNeedAnyValue, // Can return either an Rvalue or an Lvalue
+    ctfeNeedLvalueRef,// Must return a reference to an Lvalue (for ref types)
     ctfeNeedNothing   // The return value is not required
 };
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -326,6 +326,10 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
         VarDeclaration *v = (VarDeclaration *)parameters->data[i];
         v->setValueWithoutChecking((Expression *)vsave.data[i]);
     }
+    /* Clear __result. (Bug 6049).
+     */
+    if (vresult)
+        vresult->setValueNull();
 
     if (istate && !isNested())
     {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -195,20 +195,10 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
                     earg->error("%s cannot be passed by reference at compile time", earg->toChars());
                     return NULL;
                 }
-                // Convert all reference arguments into lvalues
-                if (earg->op != TOKvar)
-                {
-                    earg = earg->interpret(istate, ctfeNeedLvalue);
-                    if (earg == EXP_CANT_INTERPRET)
-                        return NULL;
-                }
-                else
-                {   // Convert reference-to-reference into a reference
-                    VarExp *ve = (VarExp *)earg;
-                    VarDeclaration *vv = ve->var->isVarDeclaration();
-                    if (vv && vv->getValue() && vv->getValue()->op == TOKvar)
-                        earg = vv->getValue();
-                }
+                // Convert all reference arguments into lvalue references
+                earg = earg->interpret(istate, ctfeNeedLvalueRef);
+                if (earg == EXP_CANT_INTERPRET)
+                    return NULL;
             }
             else if (arg->storageClass & STClazy)
             {
@@ -295,7 +285,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
         {   VarDeclaration *v = (VarDeclaration *)istate->vars.data[i];
             if (v)
             {
-                //printf("\tsaving [%d] %s = %s\n", i, v->toChars(), v->value ? v->value->toChars() : "");
+                //printf("\tsaving [%d] %s = %s\n", i, v->toChars(), v->getValue() ? v->getValue()->toChars() : "");
                 valueSaves.data[i] = v->getValue();
                 v->setValueNull();
             }
@@ -1344,6 +1334,14 @@ Expression *VarExp::interpret(InterState *istate, CtfeGoal goal)
 #if LOG
     printf("VarExp::interpret() %s\n", toChars());
 #endif
+    if (goal == ctfeNeedLvalueRef)
+    {
+        // If it is a reference, return the thing it's pointing to.
+        VarDeclaration *v = var->isVarDeclaration();
+        if (v && v->getValue() && (v->storage_class & (STCref | STCout)))
+            return v->getValue();
+        return this;
+    }
     Expression *e = getVarExp(loc, istate, var, goal);
     // A VarExp may include an implicit cast. It must be done explicitly.
     if (e != EXP_CANT_INTERPRET && e->type != type
@@ -2622,7 +2620,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
          *  e.v = newval
          */
         Expression *exx = ((DotVarExp *)e1)->e1;
-        if (wantRef)
+        if (wantRef && exx->op != TOKstructliteral)
         {
             exx = exx->interpret(istate);
             if (exx == EXP_CANT_INTERPRET)
@@ -3459,8 +3457,10 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
         e1 = ((SliceExp *)e1)->e1;
         e2 = new IntegerExp(e2->loc, indx, e2->type);
     }
-    if (goal == ctfeNeedLvalue && type->ty != Taarray && type->ty != Tarray
+    if ((goal == ctfeNeedLvalue && type->ty != Taarray && type->ty != Tarray
         && type->ty != Tsarray && type->ty != Tstruct && type->ty != Tclass)
+        || (goal == ctfeNeedLvalueRef && type->ty != Tsarray && type->ty != Tstruct)
+        )
     {   // Pointer or reference of a scalar type
         e = new IndexExp(loc, e1, e2);
         e->type = type;
@@ -3501,7 +3501,7 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
 
     if (!this->lwr)
     {
-        if (goal == ctfeNeedLvalue)
+        if (goal == ctfeNeedLvalue || goal == ctfeNeedLvalueRef)
             return e1;
         e = e1->castTo(NULL, type);
         return e->interpret(istate);
@@ -3520,7 +3520,7 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
     else
     {
         e = e1;
-        if (goal == ctfeNeedLvalue && e->op != TOKstring)
+        if ((goal == ctfeNeedLvalue || goal == ctfeNeedLvalueRef) && e->op != TOKstring)
             e = e->interpret(istate, ctfeNeedRvalue);
         e = ArrayLength(Type::tsize_t, e);
     }
@@ -3554,7 +3554,7 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
         e1->error("slice [%ju..%ju] is out of bounds", ilwr, iupr);
         return EXP_CANT_INTERPRET;
     }
-    if (goal == ctfeNeedLvalue)
+    if (goal == ctfeNeedLvalue || goal == ctfeNeedLvalueRef)
     {
         if (e1->op == TOKslice)
         {
@@ -3790,7 +3790,7 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
             VarDeclaration *v = var->isVarDeclaration();
             if (v)
             {
-                if (goal == ctfeNeedLvalue)
+                if (goal == ctfeNeedLvalue || goal == ctfeNeedLvalueRef)
                 {
                     // We can't use getField, because it makes a copy
                     int i = se->getFieldIndex(type, v->offset);
@@ -3801,9 +3801,12 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
                     }
                     e = (Expression *)se->elements->data[i];
                     // If it is an lvalue literal, return it...
-                    if (e->op == TOKstructliteral || e->op == TOKarrayliteral ||
+                    if (e->op == TOKstructliteral)
+                        return e;
+                    if ((type->ty == Tsarray || goal == ctfeNeedLvalue) && (
+                        e->op == TOKarrayliteral ||
                         e->op == TOKassocarrayliteral || e->op == TOKstring ||
-                        e->op == TOKslice)
+                        e->op == TOKslice))
                         return e;
                     // ...Otherwise, just return the (simplified) dotvar expression
                     e = new DotVarExp(loc, ex, v);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1033,3 +1033,54 @@ ulong nqueen(int n) {
 }
 
 static assert(nqueen(2) == 65);
+
+/**************************************************
+    Bug 5258
+**************************************************/
+
+struct Foo5258 { int x; }
+void bar5258(int n, ref Foo5258 fong) {
+    if (n)
+        bar5258(n - 1, fong);
+    else
+        fong.x++;
+}
+int bug5258() {
+    bar5258(1, Foo5258());
+    return 45;
+}
+static assert(bug5258()==45);
+
+
+struct Foo5258b  { int[2] r; }
+void baqopY(int n, ref int[2] fongo) {
+    if (n)
+        baqopY(n - 1, fongo);
+    else
+        fongo[0]++;
+}
+int bug5258b() {
+    Foo5258b qq;
+    baqopY(1, qq.r);
+    return 618;
+}
+static assert(bug5258b()==618);
+
+// Notice that this case involving reassigning the dynamic array
+struct Foo5258c { int[] r; }
+void baqop(int n, ref int[] fongo) {
+    if (n)
+        baqop(n - 1, fongo);
+    else
+    {
+        fongo = new int[20];
+        fongo[0]++;
+    }
+}
+int bug5258c() {
+    Foo5258c qq;
+    qq.r = new int[30];
+    baqop(1, qq.r);
+    return qq.r.length;
+}
+static assert(bug5258c() == 20);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1084,3 +1084,17 @@ int bug5258c() {
     return qq.r.length;
 }
 static assert(bug5258c() == 20);
+
+/**************************************************
+    Bug 6049
+**************************************************/
+
+struct Bug6049 {
+    int m;
+    this(int x)  {  m = x; }
+    invariant() { }
+}
+
+const Bug6049[] foo6049 = [Bug6049(6),  Bug6049(17)];
+
+static assert(foo6049[0].m == 6);


### PR DESCRIPTION
These fixes allow you to pass a dynamic array by reference, and have it work correctly in CTFE (ie, you can reassign the array). Previously it caused a stack overflow...
(Unrelated: There's also a trivial fix for an unsuppressed __error message).
