### PR TITLE
Added __traits(moduleOf) to give the module of a given symbol.

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -312,6 +312,7 @@ Msgtable msgtable[] =
     { "isLazy" },
     { "hasMember" },
     { "identifier" },
+    { "moduleOf" },
     { "parent" },
     { "getMember" },
     { "getOverloads" },

--- a/src/traits.c
+++ b/src/traits.c
@@ -196,6 +196,21 @@ Expression *TraitsExp::semantic(Scope *sc)
         StringExp *se = new StringExp(loc, s->ident->toChars());
         return se->semantic(sc);
     }
+    else if (ident == Id::moduleOf)
+    {   // Get the module name for symbol as a string literal
+        if (dim != 1)
+            goto Ldimerror;
+        Object *o = (Object *)args->data[0];
+        Dsymbol *s = getDsymbol(o);
+        StringExp *se;
+        if (!s || !s->getModule()->md)
+        {
+            se = new StringExp(loc, s->getModule()->toChars());
+        }
+        else
+            se = new StringExp(loc, s->getModule()->md->toChars());
+        return se->semantic(sc);
+    }
     else if (ident == Id::parent)
     {
         if (dim != 1)


### PR DESCRIPTION
This trait allows you to get the fully qualified module name (if possible) of a given symbol. This is useful for templates in other packages which need a the fully qualified name for the symbol. Note that a combination of __traits(parent) and .stringof can't be used here, as this does not give a fully qualified name. A better solution may be __traits(fullyQualifiedName), I'm unsure how to implement this though, and I can achieve that using moduleOf and some templates anyway.
