### PR TITLE
Allow bool as type for AA keys.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3992,7 +3992,6 @@ printf("index->ito->ito = x%x\n", index->ito->ito);
 
     switch (index->toBasetype()->ty)
     {
-        case Tbool:
         case Tfunction:
         case Tvoid:
         case Tnone:


### PR DESCRIPTION
There doesn't really seem to be a reason why AA keys of type bool are not allowed, and the docs don't mention anything either. The restriction has been put in place back in the »bit« days, maybe there was a related limitation back then?

bool-key AAs probably wouldn't be too useful in practice, but it seems like a quite arbitrary and unexpected limitation to me – e.g. I would have to add special cases all over my Thrift map handling code.
