### PR TITLE
Issue 5706 again: REX_B and REX_X also extend the SIB byte

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2513,14 +2513,17 @@ STATIC void asm_make_modrm_byte(
             else
             {
                 sib.sib.base = popnd->pregDisp1->val;
+                if (popnd->pregDisp1->val & NUM_MASKR)
+                    pc->Irex |= REX_B;
                 //
                 // This is to handle the special case
-                // of using the EBP register and no
+                // of using the EBP (or R13) register and no
                 // displacement.  You must put in an
                 // 8 byte displacement in order to
                 // get the correct opcodes.
                 //
-                if (popnd->pregDisp1->val == _EBP &&
+                if ((popnd->pregDisp1->val == _EBP ||
+                     popnd->pregDisp1->val == _R13) &&
                     (!popnd->disp && !s))
                 {
 #ifdef DEBUG
@@ -2534,6 +2537,9 @@ STATIC void asm_make_modrm_byte(
                 }
 
                 sib.sib.index = popnd->pregDisp2->val;
+                if (popnd->pregDisp2->val & NUM_MASKR)
+                    pc->Irex |= REX_X;
+
             }
             switch (popnd->uchMultiplier)
             {


### PR DESCRIPTION
before writing the code:
  lea     RAX, [RAX+R11];
DMD codegen outputs:
  lea     RAX, [RAX+RBX];

There are cases this patch does not fix such as "mov RAX [R9]"
Though DMD errors with "bad addr mode" rather than silently generating bad code.

-- Test Case code --

// Right
lea     RAX, [RAX+RAX];
lea     RAX, [RAX+RCX];
lea     RAX, [RAX+RDX];
lea     RAX, [RAX+RBX];
//lea   RAX, [RAX+RSP]; RSP can't be on the right
lea     RAX, [RAX+RBP];
lea     RAX, [RAX+RSI];
lea     RAX, [RAX+RDI];
lea     RAX, [RAX+R8];
lea     RAX, [RAX+R9];
lea     RAX, [RAX+R10];
lea     RAX, [RAX+R11];
lea     RAX, [RAX+R12];
lea     RAX, [RAX+R13];
lea     RAX, [RAX+R14];
lea     RAX, [RAX+R15];
// Left
lea     RAX, [RAX+RAX];
lea     RAX, [RCX+RAX];
lea     RAX, [RDX+RAX];
lea     RAX, [RBX+RAX];
lea     RAX, [RSP+RAX];
lea     RAX, [RBP+RAX]; // Good gets disp+8 correctly
lea     RAX, [RSI+RAX];
lea     RAX, [RDI+RAX];
lea     RAX, [R8+RAX];
lea     RAX, [R9+RAX];
lea     RAX, [R10+RAX];
lea     RAX, [R11+RAX];
lea     RAX, [R12+RAX];
lea     RAX, [R13+RAX]; // Good disp+8
lea     RAX, [R14+RAX];
lea     RAX, [R15+RAX];
// Right and Left
lea     RAX, [R12+R12];
lea     RAX, [R13+R12];
lea     RAX, [R14+R12];
lea     RAX, [R12+R13];
lea     RAX, [R13+R13];
lea     RAX, [R14+R13];
lea     RAX, [R12+R14];
lea     RAX, [R13+R14];
lea     RAX, [R14+R14];

// Disp8/32 checks
lea     RAX, [RCX+RAX+0x12];
lea     RAX, [RCX+RAX+0x1234];
lea     RAX, [RCX+RAX+0x1234_5678];
lea     RAX, [RBP+RAX+0x12];
lea     RAX, [RBP+RAX+0x1234];
lea     RAX, [RBP+RAX+0x1234_5678];
lea     RAX, [R13+RAX+0x12];
lea     RAX, [R13+RAX+0x1234];
lea     RAX, [R13+RAX+0x1234_5678];
