### PR TITLE
Bug 6109: 'nothrow' does not check slice indices

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8517,6 +8517,13 @@ void SliceExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     buf->writeByte(']');
 }
 
+int SliceExp::canThrow(bool mustNotThrow)
+{
+    return UnaExp::canThrow(mustNotThrow)
+        || (lwr != NULL && lwr->canThrow(mustNotThrow))
+        || (upr != NULL && upr->canThrow(mustNotThrow));
+}
+
 /********************** ArrayLength **************************************/
 
 ArrayLengthExp::ArrayLengthExp(Loc loc, Expression *e1)

--- a/src/expression.h
+++ b/src/expression.h
@@ -1111,6 +1111,7 @@ struct SliceExp : UnaExp
     void scanForNestedRef(Scope *sc);
     void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
     Expression *buildArrayLoop(Parameters *fparams);
+    int canThrow(bool mustNotThrow);
 
     int inlineCost(InlineCostState *ics);
     Expression *doInline(InlineDoState *ids);

--- a/test/fail_compilation/fail349.d
+++ b/test/fail_compilation/fail349.d
@@ -1,0 +1,11 @@
+// Error: bug6109throwing is not nothrow
+// Error: function fail349.bug6109noThrow 'bug6109noThrow' is nothrow yet may throw
+
+int bug6109throwing() {
+    throw new Exception("throws");
+}
+int bug6109noThrow() nothrow {
+    auto g = [4][0 .. bug6109throwing()];
+    return 0;
+}
+


### PR DESCRIPTION
See [bug 6109](http://d.puremagic.com/issues/show_bug.cgi?id=6109).
