### PR TITLE
Issue3268 - can't compare pointer to functions when one is const

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1938,8 +1938,8 @@ int arrayTypeCompatible(Loc loc, Type *t1, Type *t2)
     t1 = t1->toBasetype();
     t2 = t2->toBasetype();
 
-    if ((t1->ty == Tarray || t1->ty == Tsarray || t1->ty == Tpointer) &&
-        (t2->ty == Tarray || t2->ty == Tsarray || t2->ty == Tpointer))
+    if ((t1->ty == Tarray || t1->ty == Tsarray || (t1->ty == Tpointer && t1->nextOf()->ty != Tfunction)) &&
+        (t2->ty == Tarray || t2->ty == Tsarray || (t2->ty == Tpointer && t2->nextOf()->ty != Tfunction)))
     {
         if (t1->nextOf()->implicitConvTo(t2->nextOf()) < MATCHconst &&
             t2->nextOf()->implicitConvTo(t1->nextOf()) < MATCHconst &&

--- a/test/compilable/bug3268.d
+++ b/test/compilable/bug3268.d
@@ -1,0 +1,16 @@
+// PERMUTE_ARGS:
+
+void fun() {}
+
+void main()
+{
+    auto a = &fun;
+    const b = a;
+    assert(a == a);
+    assert(a == b);
+    assert(b == b);
+    immutable c = cast(immutable)&fun;
+    assert(a == c);
+    assert(b == c);
+    assert(c == c);
+}


### PR DESCRIPTION
Currently EqualExp::semantic calls arrayTypeCompatible, which incorrectly assumes that the function pointer can be converted to an array.
