### PR TITLE
Issue2521 - Not possible to return immutable value by ref

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3429,7 +3429,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
 
         exp = exp->semantic(sc);
         exp = resolveProperties(sc, exp);
-        exp = exp->optimize(WANTvalue);
+        if (!((TypeFunction *)fd->type)->isref)
+            exp = exp->optimize(WANTvalue);
 
         if (fd->nrvo_can && exp->op == TOKvar)
         {   VarExp *ve = (VarExp *)exp;
@@ -3511,7 +3512,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
         else if (tbret->ty != Tvoid)
         {
             exp = exp->implicitCastTo(sc, tret);
-            exp = exp->optimize(WANTvalue);
+            if (!((TypeFunction *)fd->type)->isref)
+                exp = exp->optimize(WANTvalue);
         }
     }
     else if (fd->inferRetType)

--- a/test/compilable/bug2521.d
+++ b/test/compilable/bug2521.d
@@ -1,0 +1,29 @@
+// PERMUTE_ARGS:
+
+immutable int val = 23;
+const int val2 = 23;
+
+ref immutable(int) func() {
+    return val;
+}
+ref immutable(int) func2() {
+    return *&val;
+}
+ref immutable(int) func3() {
+    return func;
+}
+ref const(int) func4() {
+    return val2;
+}
+ref const(int) func5() {
+    return val;
+}
+auto ref func6() {
+    return val;
+}
+ref func7() {
+    return val;
+}
+
+void main() {
+}

--- a/test/fail_compilation/fail351.d
+++ b/test/fail_compilation/fail351.d
@@ -1,0 +1,14 @@
+// 2780
+
+struct Immutable {
+    immutable uint[2] num;
+
+    ref uint opIndex(uint index) immutable {
+        return num[index];
+    }
+}
+
+void main() {
+    immutable Immutable foo;
+    //foo[0]++;
+}


### PR DESCRIPTION
The root cause of this bug is the fact that while running semantic on the return expression, the immutable variable's value is known at compile time, and is optimized without checking if the function returns an lvalue.

Two checks added to prevent optimizing away the VarExp when ref return is needed.

http://d.puremagic.com/issues/show_bug.cgi?id=2521
http://d.puremagic.com/issues/show_bug.cgi?id=2780
