### PR TITLE
Issue 5046 - Wrong type of implicit 'this' in struct/class templates

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -169,6 +169,25 @@ int match(Object *o1, Object *o2, TemplateDeclaration *tempdecl, Scope *sc)
      * we'll do that another day.
      */
 
+    if (s1)
+    {
+        VarDeclaration *v1 = s1->isVarDeclaration();
+        if (v1 && v1->storage_class & STCmanifest)
+        {   ExpInitializer *ei1 = v1->init->isExpInitializer();
+            if (ei1)
+                e1 = ei1->exp, s1 = NULL;
+        }
+    }
+    if (s2)
+    {
+        VarDeclaration *v2 = s2->isVarDeclaration();
+        if (v2 && v2->storage_class & STCmanifest)
+        {   ExpInitializer *ei2 = v2->init->isExpInitializer();
+            if (ei2)
+                e2 = ei2->exp, s2 = NULL;
+        }
+    }
+
     if (t1)
     {
         /* if t1 is an instance of ti, then give error
@@ -215,30 +234,7 @@ int match(Object *o1, Object *o2, TemplateDeclaration *tempdecl, Scope *sc)
     else if (s1)
     {
         if (!s2 || !s1->equals(s2) || s1->parent != s2->parent)
-        {
-            if (s2)
-            {
-                VarDeclaration *v1 = s1->isVarDeclaration();
-                VarDeclaration *v2 = s2->isVarDeclaration();
-                if (v1 && v2 && v1->storage_class & v2->storage_class & STCmanifest)
-                {   ExpInitializer *ei1 = v1->init->isExpInitializer();
-                    ExpInitializer *ei2 = v2->init->isExpInitializer();
-                    if (ei1 && ei2 && ei1->exp->equals(ei2->exp))
-                        goto Lmatch;
-                }
-            }
             goto Lnomatch;
-        }
-#if DMDV2
-        VarDeclaration *v1 = s1->isVarDeclaration();
-        VarDeclaration *v2 = s2->isVarDeclaration();
-        if (v1 && v2 && v1->storage_class & v2->storage_class & STCmanifest)
-        {   ExpInitializer *ei1 = v1->init->isExpInitializer();
-            ExpInitializer *ei2 = v2->init->isExpInitializer();
-            if (ei1 && ei2 && !ei1->exp->equals(ei2->exp))
-                goto Lnomatch;
-        }
-#endif
     }
     else if (v1)
     {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2943,6 +2943,26 @@ void test149()
  
 
 /***************************************************/
+// 5046
+
+void test5046()
+{
+    auto va = S5046!("", int)();
+    auto vb = makeS5046!("", int)();
+}
+
+struct S5046(alias p, T)
+{
+    T s;
+    T fun() { return s; }   // (10)
+}
+
+S5046!(p, T) makeS5046(alias p, T)()
+{
+    return typeof(return)();
+}
+
+/***************************************************/
 
 int main()
 {
@@ -3095,6 +3115,7 @@ int main()
     test147();
     test148();
     test149();
+    test5046();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5046
Template argument matching with manifest constant VarDeclaration and string expression was failed, but now it's ok.
