### PR TITLE
Issue 5327 & 2625 struct is assignable if all of fields are assignable

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8983,7 +8983,7 @@ Expression *IndexExp::modifiableLvalue(Scope *sc, Expression *e)
     modifiable = 1;
     if (e1->op == TOKstring)
         error("string literals are immutable");
-    if (type && !type->isMutable())
+    if (type && (!type->isMutable() || !type->isAssignable()))
         error("%s isn't mutable", e->toChars());
     Type *t1 = e1->type->toBasetype();
     if (t1->ty == Taarray)
@@ -9426,7 +9426,7 @@ Expression *AssignExp::semantic(Scope *sc)
     else if (e1->op == TOKslice)
     {
         Type *tn = e1->type->nextOf();
-        if (tn && !tn->isMutable() && op != TOKconstruct)
+        if (op == TOKassign && tn && (!tn->isMutable() || !tn->isAssignable()))
         {   error("slice %s is not mutable", e1->toChars());
             return new ErrorExp();
         }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7170,6 +7170,8 @@ int TypeStruct::isAssignable()
     {   VarDeclaration *v = (VarDeclaration *)sym->fields.data[i];
         if (v->isConst() || v->isImmutable())
             return FALSE;
+        if (!v->type->isAssignable())
+            return FALSE;
     }
     return TRUE;
 }

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -1,0 +1,146 @@
+import std.c.stdio;
+
+template TypeTuple(T...){ alias T TypeTuple; }
+
+/***************************************************/
+// 2625
+
+struct Pair {
+    immutable uint g1;
+    uint g2;
+}
+
+void test1() {
+    Pair[1] stuff;
+    static assert(!__traits(compiles, (stuff[0] = Pair(1, 2))));
+}
+
+/***************************************************/
+// 5327
+
+struct ID
+{
+    immutable int value;
+}
+
+struct Data
+{
+    ID id;
+}
+void test2()
+{
+    Data data = Data(ID(1));
+    immutable int* val = &data.id.value;
+    static assert(!__traits(compiles, data = Data(ID(2))));
+}
+
+/***************************************************/
+
+struct S31A
+{
+    union
+    {
+        immutable int field1;
+        immutable int field2;
+    }
+
+    enum result = false;
+}
+struct S31B
+{
+    union
+    {
+        immutable int field1;
+        int field2;
+    }
+
+    enum result = true;
+}
+struct S31C
+{
+    union
+    {
+        int field1;
+        immutable int field2;
+    }
+
+    enum result = true;
+}
+struct S31D
+{
+    union
+    {
+        int field1;
+        int field2;
+    }
+
+    enum result = true;
+}
+
+struct S32A
+{
+    int dummy0;
+    union
+    {
+        immutable int field1;
+        int field2;
+    }
+
+    enum result = true;
+}
+struct S32B
+{
+    immutable int dummy0;
+    union
+    {
+        immutable int field1;
+        int field2;
+    }
+
+    enum result = false;
+}
+
+
+struct S32C
+{
+    union
+    {
+        immutable int field1;
+        int field2;
+    }
+    int dummy1;
+
+    enum result = true;
+}
+struct S32D
+{
+    union
+    {
+        immutable int field1;
+        int field2;
+    }
+    immutable int dummy1;
+
+    enum result = false;
+}
+
+void test3()
+{
+    foreach (S; TypeTuple!(S31A,S31B,S31C,S31D, S32A,S32B,S32C,S32D))
+    {
+        S s;
+        static assert(__traits(compiles, s = s) == S.result);
+    }
+}
+
+/***************************************************/
+
+int main()
+{
+    test1();
+    test2();
+    test3();
+
+    printf("Success\n");
+    return 0;
+}


### PR DESCRIPTION
This fix
1. rejects whole struct reassignment breaking const correctness.
2. treats specially anonymous union has mixing mutable and immutable fields (like Rebindable).
  If some fields of anonymous union are assignable, then a struct enclosing it is assignable.
  Otherwise it is not assignable.
