### PR TITLE
Fix conversions between function pointers

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -687,8 +687,8 @@ MATCH DelegateExp::implicitConvTo(Type *t)
         FuncDeclaration *f;
 
         t = t->toBasetype();
-        if (type->ty == Tdelegate && type->nextOf()->ty == Tfunction &&
-            t->ty == Tdelegate && t->nextOf()->ty == Tfunction)
+        if (type->ty == Tdelegate &&
+            t->ty == Tdelegate)
         {
             if (func && func->overloadExactMatch(t->nextOf()))
                 result = MATCHexact;
@@ -1406,8 +1406,8 @@ Expression *DelegateExp::castTo(Scope *sc, Type *t)
         // Look for delegates to functions where the functions are overloaded.
         FuncDeclaration *f;
 
-        if (typeb->ty == Tdelegate && typeb->nextOf()->ty == Tfunction &&
-            tb->ty == Tdelegate && tb->nextOf()->ty == Tfunction)
+        if (typeb->ty == Tdelegate &&
+            tb->ty == Tdelegate)
         {
             if (func)
             {
@@ -1645,6 +1645,41 @@ Lagain:
             t = t2;
         else if (t2n->ty == Tvoid)
             ;
+        else if (t1n->ty == Tfunction && t2n->ty == Tfunction)
+        {
+            if (t1->implicitConvTo(t2))
+                goto Lt2;
+            if (t2->implicitConvTo(t1))
+                goto Lt1;
+
+            TypeFunction *tf1 = (TypeFunction *)t1n;
+            TypeFunction *tf2 = (TypeFunction *)t2n;
+            TypeFunction *d = (TypeFunction *)tf1->syntaxCopy();
+
+            if (tf1->purity != tf2->purity)
+                d->purity = PUREimpure;
+            assert(d->purity != PUREfwdref);
+
+            d->isnothrow = (tf1->isnothrow && tf2->isnothrow);
+
+            if (tf1->trust == tf2->trust)
+                d->trust = tf1->trust;
+            else if (tf1->trust <= TRUSTsystem || tf2->trust <= TRUSTsystem)
+                d->trust = TRUSTsystem;
+            else
+                d->trust = TRUSTtrusted;
+
+            Type *tx = d->pointerTo();
+
+            if (t1->implicitConvTo(tx) && t2->implicitConvTo(tx))
+            {
+                t = tx;
+                e1 = e1->castTo(sc, t);
+                e2 = e2->castTo(sc, t);
+                goto Lret;
+            }
+            goto Lincompatible;
+        }
         else if (t1n->mod != t2n->mod)
         {
             t1 = t1n->mutableOf()->constOf()->pointerTo();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -509,6 +509,7 @@ struct TypePointer : TypeNext
     d_uns64 size(Loc loc);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     MATCH implicitConvTo(Type *to);
+    MATCH constConv(Type *to);
     int isscalar();
     Expression *defaultInit(Loc loc);
     int isZeroInit(Loc loc);

--- a/test/compilable/testfptr.d
+++ b/test/compilable/testfptr.d
@@ -1,0 +1,203 @@
+// PERMUTE_ARGS:
+
+ref int frvv();
+class A {}
+class B : A {}
+
+B restrictedfunc(in const(int)) @safe pure nothrow;
+A relaxedfunc(in int);
+
+void bug3797()
+{
+    // Cannot convert if the return type or parameters are different
+
+    void function() vv;
+    void function(int) vi;
+    int function() iv;
+    const(int) function() cv;
+    immutable(int) function() xv;
+
+    static assert( is(typeof( vv = vv )));
+    static assert(!is(typeof( vv = vi )));
+    static assert(!is(typeof( vv = iv )));
+    static assert(!is(typeof( vv = cv )));
+    static assert(!is(typeof( vv = xv )));
+
+    static assert(!is(typeof( vi = vv )));
+    static assert( is(typeof( vi = vi )));
+    static assert(!is(typeof( vi = iv )));
+    static assert(!is(typeof( vi = cv )));
+    static assert(!is(typeof( vi = cx )));
+
+    static assert(!is(typeof( iv = vv )));
+    static assert(!is(typeof( iv = vi )));
+    static assert( is(typeof( iv = iv )));
+    static assert( is(typeof( iv = cv )));
+    static assert( is(typeof( iv = xv )));
+
+    static assert(!is(typeof( cv = vv )));
+    static assert( is(typeof( cv = iv )));
+    static assert(!is(typeof( cv = vi )));
+    static assert( is(typeof( cv = cv )));
+    static assert( is(typeof( cv = xv )));
+
+    static assert(!is(typeof( xv = vv )));
+    static assert( is(typeof( xv = iv )));
+    static assert(!is(typeof( xv = vi )));
+    static assert( is(typeof( xv = cv )));
+    static assert( is(typeof( xv = xv )));
+
+    int* function() ipfunc;
+    const(int*) function() cipfunc;
+
+    static assert( is(typeof( cipfunc = ipfunc )) );
+    static assert(!is(typeof( ipfunc = cipfunc )) );
+
+    // functions with different linkages can't convert
+
+    extern(C) void function() cfunc;
+    extern(D) void function() dfunc;
+
+    static assert(!is(typeof( cfunc = dfunc )));
+    static assert(!is(typeof( dfunc = cfunc )));
+
+    // ref return can't convert to non-ref return
+
+    typeof(&frvv) rvv;
+
+    static assert(!is(typeof( rvv = iv )));
+    static assert(!is(typeof( rvv = cv )));
+
+    static assert(!is(typeof( iv = rvv )));
+    static assert(!is(typeof( cv = rvv )));
+
+    // variadic functions don't mix
+
+    void function(...) vf;
+
+    static assert(!is(typeof( vf = vv )));
+    static assert(!is(typeof( vv = vf )));
+
+    // non-nothrow -> nothrow
+
+    void function() nothrow ntf;
+
+    static assert(!is(typeof( ntf = vv )));
+    static assert( is(typeof( vv = ntf )));
+
+    // @safe <-> @trusted -> @system
+
+    void function() @system systemfunc;
+    void function() @trusted trustedfunc;
+    void function() @safe safefunc;
+
+    static assert( is(typeof( trustedfunc = safefunc )));
+    static assert( is(typeof( systemfunc = trustedfunc )));
+    static assert( is(typeof( systemfunc = safefunc )));
+    static assert( is(typeof( safefunc = trustedfunc )));
+
+    static assert(!is(typeof( trustedfunc = systemfunc )));
+    static assert(!is(typeof( safefunc = systemfunc )));
+
+    // pure -> non-pure
+
+    void function() nonpurefunc;
+    void function() pure purefunc;
+
+    static assert(!is(typeof( purefunc = nonpurefunc )));
+    static assert( is(typeof( nonpurefunc = purefunc )));
+
+    // Cannot convert parameter storage classes (except const to in and in to const)
+
+    void function(const(int)) constfunc;
+    void function(in int) infunc;
+    void function(out int) outfunc;
+    void function(ref int) reffunc;
+    void function(lazy int) lazyfunc;
+
+    static assert(is(typeof( infunc = constfunc )));
+    static assert(is(typeof( constfunc = infunc )));
+
+    static assert(!is(typeof( infunc = outfunc )));
+    static assert(!is(typeof( infunc = reffunc )));
+    static assert(!is(typeof( infunc = lazyfunc )));
+
+    static assert(!is(typeof( outfunc = infunc )));
+    static assert(!is(typeof( outfunc = reffunc )));
+    static assert(!is(typeof( outfunc = lazyfunc )));
+
+    static assert(!is(typeof( reffunc = infunc )));
+    static assert(!is(typeof( reffunc = outfunc )));
+    static assert(!is(typeof( reffunc = lazyfunc )));
+
+    static assert(!is(typeof( lazyfunc = infunc )));
+    static assert(!is(typeof( lazyfunc = outfunc )));
+    static assert(!is(typeof( lazyfunc = reffunc )));
+
+    // Test class covariance
+
+    A function() afunc;
+    B function() bfunc;
+
+    static assert( is(typeof( afunc = bfunc )));
+    static assert(!is(typeof( bfunc = afunc )));
+
+    // Test all the conversions at once
+    typeof(&restrictedfunc) prestrictedfunc;
+    typeof(&relaxedfunc) prelaxedfunc = prestrictedfunc;
+}
+
+void bug3268()
+{
+    auto a = &bug3268;
+    const b = a;
+    assert(a == a);
+    assert(a == b);
+    assert(b == b);
+    immutable c = cast(immutable)a;
+    assert(a == c);
+    assert(b == c);
+    assert(c == c);
+
+    static assert(is(typeof(*a) == typeof(*b)));
+    static assert(is(typeof(*a) == typeof(*c)));
+}
+
+void bug3833()
+{
+    bool b;
+
+    void function() func;
+    void function() pure purefunc;
+    void function() nothrow nothrowfunc;
+    void function() @safe safefunc;
+    void function() @trusted trustedfunc;
+
+    static assert( is(typeof( b ? func : purefunc )     == typeof( func )));
+    static assert( is(typeof( b ? func : nothrowfunc )  == typeof( func )));
+    static assert( is(typeof( b ? func : safefunc )     == typeof( func )));
+    static assert( is(typeof( b ? func : trustedfunc )  == typeof( func )));
+
+    static assert( is(typeof( b ? purefunc : nothrowfunc )  == typeof( func )));
+    static assert( is(typeof( b ? purefunc : safefunc )     == typeof( func )));
+    static assert( is(typeof( b ? purefunc : trustedfunc )  == typeof( func )));
+
+    static assert( is(typeof( b ? nothrowfunc : safefunc )      == typeof( func )));
+    static assert( is(typeof( b ? nothrowfunc : trustedfunc )   == typeof( func )));
+
+    static assert( is(typeof( b ? safefunc : trustedfunc )      == typeof( trustedfunc )));
+
+    auto arr = [func, purefunc, nothrowfunc, safefunc, trustedfunc];
+
+    static assert( is(typeof( arr ) == typeof(func)[]) );
+}
+
+void main()
+{
+    static assert(is(typeof(&main) P : U*, U));
+    auto x = cast(void*)&main;
+
+    const void * p = &main;
+
+    __gshared void function() gp = null;
+}


### PR DESCRIPTION
This is a second attempt at pull 88.  It fixes bugs 3797 and 3268 and implements part of 3180 for function pointers.

When combined with https://github.com/klickverbot/druntime/tree/fp-types it passes the dmd, druntime and phobos tests.

While disallowing incorrect implicit conversions, this patch allows a bunch of sensible conversions for return types and attributes.

Thanks to David Nadlinger for the base conversion implementation and fixing the implicit conversion tests.

Fixes:
http://d.puremagic.com/issues/show_bug.cgi?id=3797
http://d.puremagic.com/issues/show_bug.cgi?id=3268
Partially fixes:
http://d.puremagic.com/issues/show_bug.cgi?id=3180
Requires:
https://github.com/D-Programming-Language/druntime/pull/26 (has been merged already)
