### PR TITLE
Issue 5088 - Cannot cast const(int) to long in @safe function

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8191,7 +8191,11 @@ Expression *CastExp::semantic(Scope *sc)
     {   // Disallow unsafe casts
         Type *tob = to->toBasetype();
         Type *t1b = e1->type->toBasetype();
-        if (!t1b->isMutable() && tob->isMutable())
+
+        if (tob->isTypeBasic() && t1b->isTypeBasic())
+        {   // Allow casting between basic types
+        }
+        else if (!t1b->isMutable() && tob->isMutable())
         {   // Cast not mutable to mutable
           Lunsafe:
             error("cast from %s to %s not allowed in safe code", e1->type->toChars(), to->toChars());


### PR DESCRIPTION
Simply allow all conversions between basic types, regardless of modifiers.
