### PR TITLE
Issue 4661 - Array Literal Incompatible Type Error Msg Should Include Line Number

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -388,6 +388,7 @@ Expressions *arrayExpressionToCommonType(Scope *sc, Expressions *exps, Type **pt
                 condexp.type = NULL;
                 condexp.e1 = e0;
                 condexp.e2 = e;
+                condexp.loc = e->loc;
                 condexp.semantic(sc);
                 exps->data[j0] = (void *)condexp.e1;
                 e = condexp.e2;


### PR DESCRIPTION
Passing the Loc of the literal to arrayExpressionToCommonType and using it to create the CondExp fixes three cases where an error is displayed with no file/line information.

Error in array literal:
auto a = [0, null];

Error in aa literal keys:
auto a = [0 : 0, null : 0];

Error in aa literal values:
auto a = [0 : 0, 0 : null];
