### PR TITLE
Issue 4170 - Missing line number on compile-time array index

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1229,7 +1229,7 @@ Expression *Index(Type *type, Expression *e1, Expression *e2)
         uinteger_t i = e2->toInteger();
 
         if (i >= length)
-        {   e2->error("array index %ju is out of bounds %s[0 .. %ju]", i, e1->toChars(), length);
+        {   e1->error("array index %ju is out of bounds %s[0 .. %ju]", i, e1->toChars(), length);
         }
         else if (e1->op == TOKarrayliteral)
         {   ArrayLiteralExp *ale = (ArrayLiteralExp *)e1;
@@ -1246,7 +1246,7 @@ Expression *Index(Type *type, Expression *e1, Expression *e2)
         if (e1->op == TOKarrayliteral)
         {   ArrayLiteralExp *ale = (ArrayLiteralExp *)e1;
             if (i >= ale->elements->dim)
-            {   e2->error("array index %ju is out of bounds %s[0 .. %u]", i, e1->toChars(), ale->elements->dim);
+            {   e1->error("array index %ju is out of bounds %s[0 .. %u]", i, e1->toChars(), ale->elements->dim);
             }
             else
             {   e = (Expression *)ale->elements->data[i];


### PR DESCRIPTION
In some circumstances e2 doesn't have a Loc attached, so use e1 instead.
