### PR TITLE
Bug 5861 and 2180: Wrong filename in some error

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -200,10 +200,13 @@ char *Dsymbol::locToChars()
     OutBuffer buf;
     char *p;
 
-    Module *m = getModule();
+    if (!loc.filename)  // avoid bug 5861.
+    {
+        Module *m = getModule();
 
-    if (m && m->srcfile)
-        loc.filename = m->srcfile->toChars();
+        if (m && m->srcfile)
+            loc.filename = m->srcfile->toChars();
+    }
     return loc.toChars();
 }
 


### PR DESCRIPTION
Fixed [bug 2180](http://d.puremagic.com/issues/show_bug.cgi?id=2180) (for D1) and [bug 5861](http://d.puremagic.com/issues/show_bug.cgi?id=5861) (for D2), so that mismatched file and line number should not happen.
