### PR TITLE
Issue 6145 - Meaningless second error message for complex size of static 

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3366,6 +3366,9 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
         dim = dim->optimize(WANTvalue);
         dinteger_t d2 = dim->toInteger();
 
+        if (dim->op == TOKerror)
+            goto Lerror;
+
         if (d1 != d2)
             goto Loverflow;
 


### PR DESCRIPTION
Issue 6145 - Meaningless second error message for complex size of static array

TypeSArray::semantic continues to use dim after implicitly converting to size_t has failed.
