### PR TITLE
Issue 1904 - wrong protection lookup for private template functions

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -632,6 +632,10 @@ Module *Dsymbol::getModule()
     Dsymbol *s;
 
     //printf("Dsymbol::getModule()\n");
+    TemplateDeclaration *td = getFuncTemplateDecl(this);
+    if (td)
+        return td->getModule();
+
     s = this;
     while (s)
     {

--- a/src/expression.h
+++ b/src/expression.h
@@ -71,6 +71,7 @@ void expandTuples(Expressions *exps);
 FuncDeclaration *hasThis(Scope *sc);
 Expression *fromConstInitializer(int result, Expression *e);
 int arrayExpressionCanThrow(Expressions *exps, bool mustNotThrow);
+TemplateDeclaration *getFuncTemplateDecl(Dsymbol *s);
 void valueNoDtor(Expression *e);
 
 /* Interpreter: what form of return value expression is required?

--- a/test/runnable/imports/testmod2a.d
+++ b/test/runnable/imports/testmod2a.d
@@ -1,0 +1,11 @@
+module imports.testmod2a;
+
+/**********************************/
+// bug 1904
+
+// testmod.d
+private void bar(alias a)() {}
+
+void foo(alias a)() {
+    .bar!(a)();
+}

--- a/test/runnable/testmod2.d
+++ b/test/runnable/testmod2.d
@@ -1,0 +1,12 @@
+// EXTRA_SOURCES: imports/testmod2a.d
+
+/**********************************/
+// bug 1904
+
+import imports.testmod2a;
+void main()
+{
+    void whatever() {}
+    foo!(whatever)();
+}
+


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=1904
If FuncDeclaration was instance of template function, Dsymbol::getModule() returns the module object of TemplateDeclaration enclosing it.
