### PR TITLE
Issue 1471 - Linker error on template function. Error 42: Symbol Undefined

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4458,7 +4458,7 @@ elem *SliceExp::toElem(IRState *irs)
             }
             else if (t1->ty == Tarray)
             {
-                if (lengthVar)
+                if (lengthVar && !(lengthVar->storage_class & STCconst))
                     elength = el_var(lengthVar->toSymbol());
                 else
                 {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3146,6 +3146,16 @@ static assert(!is(typeof(Bar4258.init += 1)));
 static assert(!is(typeof(1 + Baz4258.init)));
 
 /***************************************************/
+// 1471
+
+void test1471()
+{
+	int n;
+	string bar = "BOOM"[n..$-1];
+	assert(bar == "BOO");
+}
+
+/***************************************************/
 
 int main()
 {
@@ -3306,6 +3316,7 @@ int main()
     test155();
     test156();
     test4258();
+    test1471();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=1471
When array was constant (like "BOOM"), its $ was declared as static const variable but did not have its storage. Therefore it had occur link error.
