### PR TITLE
Implement @safe for D2

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -202,6 +202,7 @@ struct ClassDeclaration : AggregateDeclaration
     static ClassDeclaration *object;
     static ClassDeclaration *classinfo;
     static ClassDeclaration *throwable;
+    static ClassDeclaration *exception;
 
     ClassDeclaration *baseClass;        // NULL only if this is Object
 #if DMDV1

--- a/src/class.c
+++ b/src/class.c
@@ -32,6 +32,7 @@
 ClassDeclaration *ClassDeclaration::classinfo;
 ClassDeclaration *ClassDeclaration::object;
 ClassDeclaration *ClassDeclaration::throwable;
+ClassDeclaration *ClassDeclaration::exception;
 
 ClassDeclaration::ClassDeclaration(Loc loc, Identifier *id, BaseClasses *baseclasses)
     : AggregateDeclaration(loc, id)
@@ -186,6 +187,12 @@ ClassDeclaration::ClassDeclaration(Loc loc, Identifier *id, BaseClasses *basecla
         {   if (throwable)
                 throwable->error("%s", msg);
             throwable = this;
+        }
+
+        if (id == Id::Exception)
+        {   if (exception)
+                exception->error("%s", msg);
+            exception = this;
         }
 
         //if (id == Id::ClassInfo)

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -804,17 +804,17 @@ void VarDeclaration::semantic(Scope *sc)
     //printf("storage_class = x%x\n", storage_class);
 
 #if DMDV2
-#if 1
-    if (storage_class & STCgshared && sc->func && sc->func->isSafe())
+    if (sc->func && sc->func->isSafe() && !sc->intypeof)
     {
-        error("__gshared not allowed in safe functions; use shared");
+        if (storage_class & STCgshared)
+        {
+            error("__gshared not allowed in safe functions; use shared");
+        }
+        if (init && init->isVoidInitializer() && type->hasPointers())
+        {
+            error("void initializers not allowed in safe functions");
+        }
     }
-#else
-    if (storage_class & STCgshared && global.params.safe && !sc->module->safe)
-    {
-        error("__gshared not allowed in safe mode; use shared");
-    }
-#endif
 #endif
 
     Dsymbol *parent = toParent();

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -814,6 +814,14 @@ void VarDeclaration::semantic(Scope *sc)
         {
             error("void initializers not allowed in safe functions");
         }
+        if (type->hasPointers() && type->toDsymbol(sc))
+        {
+            AggregateDeclaration* ad = type->toDsymbol(sc)->isAggregateDeclaration();
+            if (ad && ad->hasUnions)
+            {
+                error("unions containing pointers are not allowed in @safe functions");
+            }
+        }
     }
 #endif
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -8199,6 +8199,9 @@ Expression *CastExp::semantic(Scope *sc)
         if (t1b->implicitConvTo(tob))
             goto Lsafe;
 
+        if (!tob->hasPointers())
+            goto Lsafe;
+
         error("cast from %s to %s not allowed in safe code", e1->type->toChars(), to->toChars());
         return new ErrorExp();
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -6447,6 +6447,17 @@ Expression *DotVarExp::semantic(Scope *sc)
                 return e;
         }
     }
+
+    if (sc->func && sc->func->isSafe() && !sc->intypeof && e1->type->hasPointers() && e1->type->toDsymbol(sc))
+    {
+        AggregateDeclaration* ad = e1->type->toDsymbol(sc)->isAggregateDeclaration();
+        if (ad && ad->hasUnions)
+        {
+            error("unions containing pointers are not allowed in @safe functions");
+            goto Lerr;
+        }
+    }
+
     //printf("-DotVarExp::semantic('%s')\n", toChars());
     return this;
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -7685,6 +7685,14 @@ Expression *AddrExp::semantic(Scope *sc)
                 return new ErrorExp();
             }
 
+            if (sc->func && sc->func->isSafe() && !sc->intypeof && !v->isDataseg())
+            {
+                if (v->isParameter())
+                    error("cannot take address of parameters in safe functions");
+                else
+                    error("cannot take address of local variable in safe functions");
+            }
+
             FuncDeclaration *f = ve->var->isFuncDeclaration();
 
             if (f)

--- a/src/expression.c
+++ b/src/expression.c
@@ -9056,7 +9056,14 @@ Expression *PostExp::semantic(Scope *sc)
         e1->checkScalar();
         e1->checkNoBool();
         if (e1->type->ty == Tpointer)
+        {
+            if (sc->func && sc->func->isSafe() && !sc->intypeof)
+            {
+                error("pointer arithmetic not allowed in safe code");
+                return new ErrorExp();
+            }
             e = scaleFactor(sc);
+        }
         else
             e2 = e2->castTo(sc, e1->type);
         e->type = e1->type;
@@ -9544,7 +9551,14 @@ Expression *AddAssignExp::semantic(Scope *sc)
         e1->checkScalar();
         e1->checkNoBool();
         if (tb1->ty == Tpointer && tb2->isintegral())
+        {
+            if (sc->func && sc->func->isSafe() && !sc->intypeof)
+            {
+                error("pointer arithmetic not allowed in safe code");
+                return new ErrorExp();
+            }
             e = scaleFactor(sc);
+        }
         else if (tb1->ty == Tbit || tb1->ty == Tbool)
         {
 #if 0
@@ -9640,7 +9654,14 @@ Expression *MinAssignExp::semantic(Scope *sc)
     e1->checkScalar();
     e1->checkNoBool();
     if (e1->type->ty == Tpointer && e2->type->isintegral())
+    {
+        if (sc->func && sc->func->isSafe() && !sc->intypeof)
+        {
+            error("pointer arithmetic not allowed in safe code");
+            return new ErrorExp();
+        }
         e = scaleFactor(sc);
+    }
     else
     {
         e1 = e1->checkArithmetic();
@@ -10117,7 +10138,14 @@ Expression *AddExp::semantic(Scope *sc)
         }
         else if (tb1->ty == Tpointer && e2->type->isintegral() ||
             tb2->ty == Tpointer && e1->type->isintegral())
+        {
+            if (sc->func && sc->func->isSafe() && !sc->intypeof)
+            {
+                error("pointer arithmetic not allowed in safe code");
+                return new ErrorExp();
+            }
             e = scaleFactor(sc);
+        }
         else if (tb1->ty == Tpointer && tb2->ty == Tpointer)
         {
             incompatibleTypes();
@@ -10208,7 +10236,14 @@ Expression *MinExp::semantic(Scope *sc)
             return e;
         }
         else if (t2->isintegral())
+        {
+            if (sc->func && sc->func->isSafe() && !sc->intypeof)
+            {
+                error("pointer arithmetic not allowed in safe code");
+                return new ErrorExp();
+            }
             e = scaleFactor(sc);
+        }
         else
         {   error("incompatible types for minus");
             return new ErrorExp();

--- a/src/expression.c
+++ b/src/expression.c
@@ -8213,6 +8213,22 @@ Expression *CastExp::semantic(Scope *sc)
         if (!tob->hasPointers())
             goto Lsafe;
 
+        if (tob->ty == Tarray && t1b->ty == Tarray)
+        {
+            Type* tobn = tob->nextOf()->toBasetype();
+            Type* t1bn = t1b->nextOf()->toBasetype();
+            if (!tobn->hasPointers() && MODimplicitConv(t1bn->mod, tobn->mod))
+                goto Lsafe;
+        }
+        if (tob->ty == Tpointer && t1b->ty == Tpointer)
+        {
+            Type* tobn = tob->nextOf()->toBasetype();
+            Type* t1bn = t1b->nextOf()->toBasetype();
+            if (!tobn->hasPointers() && tobn->size() <= t1bn->size() &&
+                MODimplicitConv(t1bn->mod, tobn->mod))
+                goto Lsafe;
+        }
+
         error("cast from %s to %s not allowed in safe code", e1->type->toChars(), to->toChars());
         return new ErrorExp();
     }

--- a/src/statement.c
+++ b/src/statement.c
@@ -4302,6 +4302,13 @@ void Catch::semantic(Scope *sc)
             type = Type::terror;
         }
     }
+    else if (sc->func && sc->func->isSafe() && !sc->intypeof &&
+        (cd != ClassDeclaration::exception) &&
+        !ClassDeclaration::exception->isBaseOf(cd, NULL))
+    {
+        error(loc, "can only catch class objects derived from Exception in safe code, not '%s'", type->toChars());
+        type = Type::terror;
+    }
     else if (ident)
     {
         var = new VarDeclaration(loc, type, ident, NULL);

--- a/src/struct.c
+++ b/src/struct.c
@@ -706,6 +706,7 @@ const char *StructDeclaration::kind()
 UnionDeclaration::UnionDeclaration(Loc loc, Identifier *id)
     : StructDeclaration(loc, id)
 {
+    hasUnions = 1;
 }
 
 Dsymbol *UnionDeclaration::syntaxCopy(Dsymbol *s)

--- a/test/compilable/safetest.d
+++ b/test/compilable/safetest.d
@@ -12,9 +12,9 @@ void pointercast()
     static assert(!__traits(compiles, cast(int*)b));
     static assert(!__traits(compiles, cast(int*)b));
     static assert(!__traits(compiles, cast(short*)b));
-    static assert(!__traits(compiles, cast(byte*)b));
-    static assert(!__traits(compiles, cast(short*)a));
-    static assert(!__traits(compiles, cast(byte*)a));
+    static assert( __traits(compiles, cast(byte*)b));
+    static assert( __traits(compiles, cast(short*)a));
+    static assert( __traits(compiles, cast(byte*)a));
 }
 
 @safe
@@ -294,7 +294,9 @@ void arraycast()
     int[] x;
     void[] y = x;
     static assert( __traits(compiles, cast(void[])x));
-    static assert(!__traits(compiles, cast(int[])y));
+    static assert( __traits(compiles, cast(int[])y));
+    static assert(!__traits(compiles, cast(int*[])y));
+    static assert(!__traits(compiles, cast(void[][])y));
 
     int[3] a;
     int[] b = cast(int[])a;

--- a/test/compilable/safetest.d
+++ b/test/compilable/safetest.d
@@ -1,0 +1,322 @@
+// PERMUTE_ARGS:
+
+//http://d.puremagic.com/issues/show_bug.cgi?id=5415
+
+@safe
+void pointercast()
+{
+    int* a;
+    void* b;
+
+    static assert( __traits(compiles, cast(void*)a));
+    static assert(!__traits(compiles, cast(int*)b));
+    static assert(!__traits(compiles, cast(int*)b));
+    static assert(!__traits(compiles, cast(short*)b));
+    static assert(!__traits(compiles, cast(byte*)b));
+    static assert(!__traits(compiles, cast(short*)a));
+    static assert(!__traits(compiles, cast(byte*)a));
+}
+
+@safe
+void pointercast2()
+{
+    size_t a;
+    int b;
+    Object c;
+
+    static assert(!__traits(compiles, cast(void*)a));
+    static assert(!__traits(compiles, cast(void*)b));
+    static assert(!__traits(compiles, cast(void*)c));
+}
+
+@safe
+void pointerarithmetic()
+{//http://d.puremagic.com/issues/show_bug.cgi?id=4132
+    void* a;
+    int b;
+
+    static assert(!__traits(compiles, a + b));
+    static assert(!__traits(compiles, a - b));
+    static assert(!__traits(compiles, a += b));
+    static assert(!__traits(compiles, a -= b));
+    static assert(!__traits(compiles, a++));
+    static assert(!__traits(compiles, a--));
+    static assert(!__traits(compiles, ++a));
+    static assert(!__traits(compiles, --a));
+}
+
+
+
+union SafeUnion1
+{
+    int a;
+    struct
+    {
+        int b;
+        int* c;
+    }
+}
+union SafeUnion2
+{
+    int a;
+    struct
+    {
+        int b;
+        int c;
+    }
+}
+union UnsafeUnion1
+{
+    int a;
+    int* c;
+}
+union UnsafeUnion2
+{
+    int a;
+    align(1)
+    struct
+    {
+        byte b;
+        int* c;
+    }
+}
+union UnsafeUnion3
+{
+    int a;
+    Object c;
+}
+union UnsafeUnion4
+{
+    int a;
+    align(1)
+    struct
+    {
+        byte b;
+        Object c;
+    }
+}
+struct pwrapper
+{
+    int* a;
+}
+union UnsafeUnion5
+{
+    SafeUnion2 x;
+    pwrapper b;
+}
+
+SafeUnion1 su1;
+SafeUnion2 su2;
+UnsafeUnion1 uu1;
+UnsafeUnion2 uu2;
+UnsafeUnion3 uu3;
+UnsafeUnion4 uu4;
+UnsafeUnion5 uu5;
+
+union uA
+{
+    struct
+    {
+        int* a;
+        void* b;
+    }
+}
+struct uB
+{
+    uA a;
+}
+struct uC
+{
+    uB a;
+}
+struct uD
+{
+    uC a;
+}
+uD uud;
+
+@safe
+void safeunions()
+{
+    //static assert( __traits(compiles, { SafeUnion1 x; x.a = 7; }));
+    static assert( __traits(compiles, { SafeUnion2 x; x.a = 7; }));
+    static assert(!__traits(compiles, { UnsafeUnion1 x; x.a = 7; }));
+    static assert(!__traits(compiles, { UnsafeUnion2 x; x.a = 7; }));
+    static assert(!__traits(compiles, { UnsafeUnion3 x; x.a = 7; }));
+    static assert(!__traits(compiles, { UnsafeUnion4 x; x.a = 7; }));
+    static assert(!__traits(compiles, { UnsafeUnion5 x; }));
+
+    typeof(uu1.a) f;
+
+    //static assert( __traits(compiles, { su1.a = 7; }));
+    static assert( __traits(compiles, { su2.a = 7; }));
+    static assert(!__traits(compiles, { uu1.a = 7; }));
+    static assert(!__traits(compiles, { uu2.a = 7; }));
+    static assert(!__traits(compiles, { uu3.a = 7; }));
+    static assert(!__traits(compiles, { uu4.a = 7; }));
+    static assert(!__traits(compiles, { uu5.x.a = null; }));
+    static assert(!__traits(compiles, { uud.a.a.a.a = null; }));
+}
+
+
+
+void systemfunc() @system {}
+void function() @system sysfuncptr;
+void delegate() @system sysdelegate;
+
+@safe
+void callingsystem()
+{
+    static assert(!__traits(compiles, systemfunc()));
+    static assert(!__traits(compiles, sysfuncptr()));
+    static assert(!__traits(compiles, sysdelegate()));
+}
+
+@safe
+void safeexception()
+{
+    try {}
+    catch(Exception e) {}
+
+    static assert(!__traits(compiles, {
+        try {}
+        catch(Error e) {}
+    }));
+
+    static assert(!__traits(compiles, {
+        try {}
+        catch(Throwable e) {}
+    }));
+
+    static assert(!__traits(compiles, {
+        try {}
+        catch {}
+    }));
+}
+
+@safe
+void inlineasm()
+{
+    static assert(!__traits(compiles, { asm { int 3; } }() ));
+}
+
+@safe
+void multablecast()
+{
+    Object m;
+    const(Object) c;
+    immutable(Object) i;
+
+    static assert( __traits(compiles, cast(const(Object))m));
+    static assert( __traits(compiles, cast(const(Object))i));
+
+    static assert(!__traits(compiles, cast(immutable(Object))m));
+    static assert(!__traits(compiles, cast(immutable(Object))c));
+
+    static assert(!__traits(compiles, cast(Object)c));
+    static assert(!__traits(compiles, cast(Object)i));
+
+    void* mp;
+    const(void)* cp;
+    immutable(void)* ip;
+
+    static assert( __traits(compiles, cast(const(void)*)mp));
+    static assert( __traits(compiles, cast(const(void)*)ip));
+
+    static assert(!__traits(compiles, cast(immutable(void)*)mp));
+    static assert(!__traits(compiles, cast(immutable(void)*)cp));
+
+    static assert(!__traits(compiles, cast(void*)cp));
+    static assert(!__traits(compiles, cast(void*)ip));
+}
+
+@safe
+void sharedcast()
+{
+    Object local;
+    shared(Object) xshared;
+    immutable(Object) ishared;
+
+    static assert(!__traits(compiles, cast()xshared));
+    static assert(!__traits(compiles, cast(shared)local));
+
+    static assert(!__traits(compiles, cast(immutable)xshared));
+    static assert(!__traits(compiles, cast(shared)ishared));
+}
+
+int threadlocalvar;
+
+@safe
+void takeaddr()
+{
+    static assert(!__traits(compiles, (int x) { auto y = &x; } ));
+    static assert(!__traits(compiles, { int x; auto y = &x; } ));
+    static assert( __traits(compiles, { static int x; auto y = &x; } ));
+    static assert( __traits(compiles, { auto y = &threadlocalvar; } ));
+}
+
+__gshared int gsharedvar;
+
+@safe
+void use__gshared()
+{
+    static assert(!__traits(compiles, { int x = gsharedvar; } ));
+}
+
+@safe
+void voidinitializers()
+{//http://d.puremagic.com/issues/show_bug.cgi?id=4885
+    static assert(!__traits(compiles, { uint* ptr = void; } ));
+    static assert( __traits(compiles, { uint i = void; } ));
+    static assert( __traits(compiles, { uint[2] a = void; } ));
+
+    struct ValueStruct { int a; }
+    struct NonValueStruct { int* a; }
+    static assert( __traits(compiles, { ValueStruct a = void; } ));
+    static assert(!__traits(compiles, { NonValueStruct a = void; } ));
+
+    static assert(!__traits(compiles, { uint[] a = void; } ));
+    static assert(!__traits(compiles, { int** a = void; } ));
+    static assert(!__traits(compiles, { int[int] a = void; } ));
+}
+
+@safe
+void basiccast()
+{//http://d.puremagic.com/issues/show_bug.cgi?id=5088
+    auto a = cast(int)cast(const int)1;
+    auto b = cast(real)cast(const int)1;
+    auto c = cast(real)cast(const real)2.0;
+}
+
+@safe
+void arraycast()
+{
+    int[] x;
+    void[] y = x;
+    static assert( __traits(compiles, cast(void[])x));
+    static assert(!__traits(compiles, cast(int[])y));
+
+    int[3] a;
+    int[] b = cast(int[])a;
+    uint[3] c = cast(uint[3])a;
+}
+
+@safe
+void structcast()
+{
+    struct A { int x; }
+    struct B { uint x; }
+    struct C { void* x; }
+    A a;
+    B b;
+    C c;
+
+    static assert( __traits(compiles, a = cast(A)b));
+    static assert( __traits(compiles, a = cast(A)c));
+    static assert( __traits(compiles, b = cast(B)a));
+    static assert( __traits(compiles, b = cast(B)c));
+    static assert(!__traits(compiles, c = cast(C)a));
+    static assert(!__traits(compiles, c = cast(C)b));
+}
+
+void main() { }

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -211,11 +211,9 @@ void test11()
 
 void test12()
 {
-    class Exception { }
+    class ExceptioN { }
 
-    class ExceptioX { }
-
-    static assert(Exception.mangleof[0 ..$-1] == ExceptioX.mangleof[0 .. $-1]);
+    static assert(ExceptioN.mangleof[0 ..$-1] == ExceptioX.mangleof[0 .. $-1]);
 }
 
 /*******************************************/


### PR DESCRIPTION
This patch implements @safe as defined in
http://www.digitalmars.com/d/2.0/function.html#function-safety

The patch disallows:

> Casting T\* to U*, where U has indirections
> Casting non-pointers to pointers
> Pointer arithmetic (except p - p)
> Unions with pointer members
> Catching objects not derived from Exception
> Casting types with indirections to/from immutable
> Casting types with indirections to/from shared
> Casting types with indirections from const
> Casting types with indirections from inout to anything that isn't const
> Taking the address of local variables or parameters
> Void initializers on types with indirections
> Casting T[] to U[] where U is a type with indirections

The patch now allows:

> Casting between types with no indirections
> Casting modifiers of types with no indirections

The following things were already working:

> Calling @system functions
> Inline asm
> Accessing __gshared variables
> Casting to pointers to smaller value types
