### PR TITLE
Issue 2095 - arrays of classes should not implicitly convert to arrays of base classes

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3533,7 +3533,8 @@ MATCH TypeSArray::implicitConvTo(Type *to)
         if (next->equals(ta->next) ||
 //          next->implicitConvTo(ta->next) >= MATCHconst ||
             next->constConv(ta->next) != MATCHnomatch ||
-            (ta->next->isBaseOf(next, &offset) && offset == 0) ||
+            (ta->next->isBaseOf(next, &offset) && offset == 0 &&
+             !ta->next->isMutable()) ||
             ta->next->ty == Tvoid)
             return MATCHconvert;
         return MATCHnomatch;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3796,9 +3796,10 @@ MATCH TypeDArray::implicitConvTo(Type *to)
         }
 #endif
 
-        /* Conversion of array of derived to array of base
+        /* Conversion of array of derived to array of const(base)
          */
-        if (ta->next->isBaseOf(next, &offset) && offset == 0)
+        if (ta->next->isBaseOf(next, &offset) && offset == 0 &&
+            !ta->next->isMutable())
             return MATCHconvert;
     }
     return Type::implicitConvTo(to);

--- a/test/compilable/derivedarray.d
+++ b/test/compilable/derivedarray.d
@@ -3,7 +3,7 @@
 class C {}
 class D : C {}
 
-void main()
+void dynamicarrays()
 {
     C[] a;
     D[] b;
@@ -54,3 +54,77 @@ void main()
     static assert(!__traits(compiles, f = e));
     static assert( __traits(compiles, f = f));
 }
+
+
+void statictodynamicarrays()
+{
+    C[] a;
+    D[] b;
+    const(C)[] c;
+    const(D)[] d;
+    immutable(C)[] e;
+    immutable(D)[] f;
+
+    C[1] sa;
+    D[1] sb;
+    const(C)[1] sc = void;
+    const(D)[1] sd = void;
+    immutable(C)[1] se = void;
+    immutable(D)[1] sf = void;
+
+    static assert( __traits(compiles, a = sa));
+    static assert(!__traits(compiles, a = sb));
+    static assert(!__traits(compiles, a = sc));
+    static assert(!__traits(compiles, a = sd));
+    static assert(!__traits(compiles, a = se));
+    static assert(!__traits(compiles, a = sf));
+
+    static assert(!__traits(compiles, b = sa));
+    static assert( __traits(compiles, b = sb));
+    static assert(!__traits(compiles, b = sc));
+    static assert(!__traits(compiles, b = sd));
+    static assert(!__traits(compiles, b = se));
+    static assert(!__traits(compiles, b = sf));
+
+    static assert( __traits(compiles, c = sa));
+    static assert( __traits(compiles, c = sb));
+    static assert( __traits(compiles, c = sc));
+    static assert( __traits(compiles, c = sd));
+    static assert( __traits(compiles, c = se));
+    static assert( __traits(compiles, c = sf));
+
+    static assert(!__traits(compiles, d = sa));
+    static assert( __traits(compiles, d = sb));
+    static assert(!__traits(compiles, d = sc));
+    static assert( __traits(compiles, d = sd));
+    static assert(!__traits(compiles, d = se));
+    static assert( __traits(compiles, d = sf));
+
+    static assert(!__traits(compiles, e = sa));
+    static assert(!__traits(compiles, e = sb));
+    static assert(!__traits(compiles, e = sc));
+    static assert(!__traits(compiles, e = sd));
+    static assert( __traits(compiles, e = se));
+    static assert( __traits(compiles, e = sf));
+
+    static assert(!__traits(compiles, f = sa));
+    static assert(!__traits(compiles, f = sb));
+    static assert(!__traits(compiles, f = sc));
+    static assert(!__traits(compiles, f = sd));
+    static assert(!__traits(compiles, f = se));
+    static assert( __traits(compiles, f = sf));
+}
+
+void staticarrays()
+{
+    C[1] sa;
+    D[1] sb;
+
+    const(C)[1] sc = sa;
+    const(D)[1] sd = sb;
+
+    sa = sb;
+    static assert(!__traits(compiles, sb = sa));
+}
+
+void main() {}

--- a/test/compilable/derivedarray.d
+++ b/test/compilable/derivedarray.d
@@ -1,0 +1,56 @@
+// PERMUTE_ARGS:
+
+class C {}
+class D : C {}
+
+void main()
+{
+    C[] a;
+    D[] b;
+    const(C)[] c;
+    const(D)[] d;
+    immutable(C)[] e;
+    immutable(D)[] f;
+
+    static assert( __traits(compiles, a = a));
+    static assert(!__traits(compiles, a = b));
+    static assert(!__traits(compiles, a = c));
+    static assert(!__traits(compiles, a = d));
+    static assert(!__traits(compiles, a = e));
+    static assert(!__traits(compiles, a = f));
+
+    static assert(!__traits(compiles, b = a));
+    static assert( __traits(compiles, b = b));
+    static assert(!__traits(compiles, b = c));
+    static assert(!__traits(compiles, b = d));
+    static assert(!__traits(compiles, b = e));
+    static assert(!__traits(compiles, b = f));
+
+    static assert( __traits(compiles, c = a));
+    static assert( __traits(compiles, c = b));
+    static assert( __traits(compiles, c = c));
+    static assert( __traits(compiles, c = d));
+    static assert( __traits(compiles, c = e));
+    static assert( __traits(compiles, c = f));
+
+    static assert(!__traits(compiles, d = a));
+    static assert( __traits(compiles, d = b));
+    static assert(!__traits(compiles, d = c));
+    static assert( __traits(compiles, d = d));
+    static assert(!__traits(compiles, d = e));
+    static assert( __traits(compiles, d = f));
+
+    static assert(!__traits(compiles, e = a));
+    static assert(!__traits(compiles, e = b));
+    static assert(!__traits(compiles, e = c));
+    static assert(!__traits(compiles, e = d));
+    static assert( __traits(compiles, e = e));
+    static assert( __traits(compiles, e = f));
+
+    static assert(!__traits(compiles, f = a));
+    static assert(!__traits(compiles, f = b));
+    static assert(!__traits(compiles, f = c));
+    static assert(!__traits(compiles, f = d));
+    static assert(!__traits(compiles, f = e));
+    static assert( __traits(compiles, f = f));
+}

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -346,7 +346,7 @@ void test16()
 class A17 { }
 class B17 : A17 { }
 
-void foo17(A17[] a) { }
+void foo17(const(A17)[] a) { }
 
 void test17()
 {

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -798,8 +798,8 @@ void test37()
 
 class C38 { }
 
-Object[] foo38(C38[3] c)
-{   Object[] x = c;
+const(Object)[] foo38(C38[3] c)
+{   const(Object)[] x = c;
     return x.dup;
 }
 

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -379,7 +379,7 @@ void test20()
 //	uSar(sar);	// T[2] => U[2]
 //	uDar(sar);	// T[2] => U[]
 
-	uDar(dar);	// T[] => U[]
+	uDar(dar);	// T[] => const(U)[]
 	vPtr(ptr);	// T* => void*
 	vPtr(sar.ptr);
 	vPtr(dar.ptr);
@@ -392,7 +392,7 @@ void tPtr(T*t){}
 void tDar(T[]t){}
 void uPtr(U*u){}
 void uSar(U[2]u){}
-void uDar(U[]u){}
+void uDar(const(U)[]u){}
 void vPtr(void*v){}
 void vDar(void[]v){}
 


### PR DESCRIPTION
In the current compiler the following code is allowed:

class A {}
class B : A {}
B[] b = [new B()];
A[] a = b;
a[0] = new A();

This aliasing allow you to create an invalid array of B.

This is fixed by ensuring the element type of the target is not mutable.

http://d.puremagic.com/issues/show_bug.cgi?id=2095
