### PR TITLE
Issue 2579 - Template function accepting a delegate with in argument doesn't compile

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -2156,6 +2156,15 @@ MATCH TypeFunction::deduceType(Scope *sc, Type *tparam, TemplateParameters *para
         size_t nfargs = Parameter::dim(this->parameters);
         size_t nfparams = Parameter::dim(tp->parameters);
 
+        // bug 2579 fix: Apply function parameter storage classes to parameter types
+        for (size_t i = 0; i < nfparams; i++)
+        {
+            Parameter *fparam = Parameter::getNth(tp->parameters, i);
+            fparam->type = fparam->type->addStorageClass(fparam->storageClass);
+        }
+        //printf("\t-> this   = %d, ", ty); print();
+        //printf("\t-> tparam = %d, ", tparam->ty); tparam->print();
+
         /* See if tuple match
          */
         if (nfparams > 0 && nfargs >= nfparams - 1)

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -258,6 +258,18 @@ void test2246(){
 }
 
 /**********************************/
+// 2579
+
+void foo2579(T)(T delegate(in Object) dlg)
+{
+}
+
+void test2579()
+{
+    foo2579( (in Object) { return 15; } );
+}
+
+/**********************************/
 
 int main()
 {
@@ -272,6 +284,7 @@ int main()
     test9();
     test6404();
     test2246();
+    test2579();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=2579
Applying parameter storage classes into parameter types before deduce template function matching.
