### PR TITLE
Issue 3194 - invariant should be checked at the beginning and end of protected functions

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -2679,7 +2679,7 @@ int FuncDeclaration::addPreInvariant()
     return (ad &&
             //ad->isClassDeclaration() &&
             global.params.useInvariants &&
-            (protection == PROTpublic || protection == PROTexport) &&
+            (protection == PROTprotected || protection == PROTpublic || protection == PROTexport) &&
             !naked &&
             ident != Id::cpctor);
 }
@@ -2691,7 +2691,7 @@ int FuncDeclaration::addPostInvariant()
             ad->inv &&
             //ad->isClassDeclaration() &&
             global.params.useInvariants &&
-            (protection == PROTpublic || protection == PROTexport) &&
+            (protection == PROTprotected || protection == PROTpublic || protection == PROTexport) &&
             !naked &&
             ident != Id::cpctor);
 }


### PR DESCRIPTION
Alter condition to emit invariant calls for protected functions.

According to Andrei's bug report, this is how it should be.

http://d.puremagic.com/issues/show_bug.cgi?id=3194
