### PR TITLE
Issue 1567 - call to private super-constructor should not be allowed

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7260,6 +7260,8 @@ Lagain:
                     sc->callSuper |= CSXany_ctor | CSXsuper_ctor;
                 }
 
+                accessCheck(loc, sc, NULL, cd->baseClass->ctor->isDeclaration());
+
                 f = resolveFuncCall(sc, loc, cd->baseClass->ctor, NULL, NULL, arguments, 0);
                 checkDeprecated(sc, f);
 #if DMDV2


### PR DESCRIPTION
Current dmd allows you to call a private base class construction from a constructor in another class, in another module.

Added an access check when calling a base class constructor.

http://d.puremagic.com/issues/show_bug.cgi?id=1567
