### PR TITLE
Issue 5493 - Able to overwrite immutable data by passing through ref function parameter

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5223,6 +5223,14 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             if (targb->nextOf() && tparb->ty == Tsarray &&
                 !MODimplicitConv(targb->nextOf()->mod, tparb->nextOf()->mod))
                 goto Nomatch;
+
+            // Allow string literals to convert to ref static arrays
+            if (arg->op == TOKstring && tparb->ty == Tsarray)
+            {
+            }
+            /* Don't allow using ref where a pointer wouldn't work */
+            else if (!arg->type->pointerTo()->implicitConvTo(p->type->pointerTo()))
+                goto Nomatch;
         }
 
         if (p->storageClass & STClazy && p->type->ty == Tvoid &&

--- a/test/compilable/const.d
+++ b/test/compilable/const.d
@@ -39,3 +39,32 @@ static assert(6.0i % 3.0i == 0);
 static assert(6.0i % 4.0i == 2i);
 
 
+void checkconstref()
+{
+    void pfun(immutable(char)[]* a) {}
+    void rfun(ref immutable(char)[] a) {}
+
+    immutable char[] buf = "hello";
+    static assert(!__traits(compiles, rfun(buf)));
+    static assert(!__traits(compiles, pfun(buf)));
+
+    immutable char[5] buf2 = "hello";
+    static assert(!__traits(compiles, rfun(buf2)));
+    static assert(!__traits(compiles, pfun(buf2)));
+
+    void pcfun(const(char)[]* a) {}
+    void rcfun(ref const(char)[] a) {}
+
+    static assert(!__traits(compiles, rcfun(buf)));
+    static assert(!__traits(compiles, pcfun(buf)));
+    static assert(!__traits(compiles, rcfun(buf2)));
+    static assert(!__traits(compiles, pcfun(buf2)));
+
+    const char[] buf3 = "hello";
+    const char[5] buf4 = "hello";
+
+    static assert(!__traits(compiles, rcfun(buf3)));
+    static assert(!__traits(compiles, pcfun(buf3)));
+    static assert(!__traits(compiles, rcfun(buf4)));
+    static assert(!__traits(compiles, pcfun(buf4)));
+}


### PR DESCRIPTION
Force ref parameters to follow the same rules as pointers by ensuring that the implicit conversion would work if you were using pointers instead.  This allows future fixes to pointer const semantics to be automatically applied.
(eg 4251)
