### PR TITLE
Issue 4251 - Hole in the const system: immutable values can be overwritten (const(T) is appendable to const(T)[]) 

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5223,6 +5223,14 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             if (targb->nextOf() && tparb->ty == Tsarray &&
                 !MODimplicitConv(targb->nextOf()->mod, tparb->nextOf()->mod))
                 goto Nomatch;
+
+            // Allow string literals to convert to ref static arrays
+            if (arg->op == TOKstring && tparb->ty == Tsarray)
+            {
+            }
+            /* Don't allow using ref where a pointer wouldn't work */
+            else if (!arg->type->pointerTo()->implicitConvTo(p->type->pointerTo()))
+                goto Nomatch;
         }
 
         if (p->storageClass & STClazy && p->type->ty == Tvoid &&

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5276,7 +5276,7 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             {
             }
             /* Don't allow using ref where a pointer wouldn't work */
-            else if (!arg->type->pointerTo()->implicitConvTo(p->type->pointerTo()))
+            else if (!arg->type->toBasetype()->pointerTo()->implicitConvTo(p->type->toBasetype()->pointerTo()))
                 goto Nomatch;
         }
 
@@ -6906,6 +6906,7 @@ TypeStruct::TypeStruct(StructDeclaration *sym)
         : Type(Tstruct)
 {
     this->sym = sym;
+    recursive = 0;
 }
 
 char *TypeStruct::toChars()
@@ -7407,6 +7408,10 @@ int TypeStruct::mutableHeadLength()
     if (!isMutable())
         return 0;
 
+    if (recursive)
+        return 1 << 16;
+    recursive = 1;
+
     int len = 0;
     for (size_t i = 0; i < sym->fields.dim; i++)
     {
@@ -7415,6 +7420,8 @@ int TypeStruct::mutableHeadLength()
         if (d && d->type->mutableHeadLength() > len)
             len = d->type->mutableHeadLength();
     }
+
+    recursive = 0;
     return len;
 }
 
@@ -7425,6 +7432,7 @@ TypeClass::TypeClass(ClassDeclaration *sym)
         : Type(Tclass)
 {
     this->sym = sym;
+    recursive = 0;
 }
 
 char *TypeClass::toChars()
@@ -7861,6 +7869,10 @@ int TypeClass::mutableHeadLength()
     if (!isMutable())
         return 0;
 
+    if (recursive)
+        return 1 << 16;
+    recursive = 1;
+
     int len = 0;
     for (size_t i = 0; i < sym->fields.dim; i++)
     {
@@ -7869,6 +7881,8 @@ int TypeClass::mutableHeadLength()
         if (d && d->type->mutableHeadLength() > len)
             len = d->type->mutableHeadLength();
     }
+
+    recursive = 0;
     return len + 1;
 }
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -324,6 +324,8 @@ struct Type : Object
 
     // For eliminating dynamic_cast
     virtual TypeBasic *isTypeBasic();
+
+    virtual int mutableHeadLength();
 };
 
 struct TypeError : Type
@@ -337,6 +339,8 @@ struct TypeError : Type
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
+
+    int mutableHeadLength();
 };
 
 struct TypeNext : Type
@@ -392,6 +396,8 @@ struct TypeBasic : Type
 
     // For eliminating dynamic_cast
     TypeBasic *isTypeBasic();
+
+    int mutableHeadLength();
 };
 
 struct TypeArray : TypeNext
@@ -435,6 +441,8 @@ struct TypeSArray : TypeArray
 
     type *toCtype();
     type *toCParamtype();
+
+    int mutableHeadLength();
 };
 
 // Dynamic array, no dimension
@@ -463,6 +471,7 @@ struct TypeDArray : TypeArray
 #endif
 
     type *toCtype();
+    int mutableHeadLength();
 };
 
 struct TypeAArray : TypeArray
@@ -499,6 +508,7 @@ struct TypeAArray : TypeArray
     Symbol *aaGetSymbol(const char *func, int flags);
 
     type *toCtype();
+    int mutableHeadLength();
 };
 
 struct TypePointer : TypeNext
@@ -520,6 +530,7 @@ struct TypePointer : TypeNext
 #endif
 
     type *toCtype();
+    int mutableHeadLength();
 };
 
 struct TypeReference : TypeNext
@@ -535,6 +546,7 @@ struct TypeReference : TypeNext
 #if CPP_MANGLE
     void toCppMangle(OutBuffer *buf, CppMangleState *cms);
 #endif
+    int mutableHeadLength();
 };
 
 enum RET
@@ -599,6 +611,7 @@ struct TypeFunction : TypeNext
     enum RET retStyle();
 
     unsigned totym();
+    int mutableHeadLength();
 };
 
 struct TypeDelegate : TypeNext
@@ -624,6 +637,7 @@ struct TypeDelegate : TypeNext
 #endif
 
     type *toCtype();
+    int mutableHeadLength();
 };
 
 struct TypeQualified : Type
@@ -730,6 +744,7 @@ struct TypeStruct : Type
 #endif
 
     type *toCtype();
+    int mutableHeadLength();
 };
 
 struct TypeEnum : Type
@@ -771,6 +786,7 @@ struct TypeEnum : Type
 #endif
 
     type *toCtype();
+    int mutableHeadLength();
 };
 
 struct TypeTypedef : Type
@@ -817,6 +833,7 @@ struct TypeTypedef : Type
 
     type *toCtype();
     type *toCParamtype();
+    int mutableHeadLength();
 };
 
 struct TypeClass : Type
@@ -855,6 +872,8 @@ struct TypeClass : Type
     type *toCtype();
 
     Symbol *toSymbol();
+
+    int mutableHeadLength();
 };
 
 struct TypeTuple : Type
@@ -874,6 +893,8 @@ struct TypeTuple : Type
     void toDecoBuffer(OutBuffer *buf, int flag);
     Expression *getProperty(Loc loc, Identifier *ident);
     TypeInfoDeclaration *getTypeInfoDeclaration();
+
+    int mutableHeadLength();
 };
 
 struct TypeSlice : TypeNext
@@ -886,6 +907,8 @@ struct TypeSlice : TypeNext
     Type *semantic(Loc loc, Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
+
+    int mutableHeadLength();
 };
 
 struct TypeNewArray : TypeNext

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -745,6 +745,7 @@ struct TypeStruct : Type
 
     type *toCtype();
     int mutableHeadLength();
+    int recursive;
 };
 
 struct TypeEnum : Type
@@ -874,6 +875,7 @@ struct TypeClass : Type
     Symbol *toSymbol();
 
     int mutableHeadLength();
+    int recursive;
 };
 
 struct TypeTuple : Type

--- a/src/template.c
+++ b/src/template.c
@@ -1577,8 +1577,8 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
             if (ti->inst == ti)
                 ti->tiargs = (Objects*)dedargs.copy();
 
-            if ((fd = ti->toAlias()->isFuncDeclaration()) &&
-                !((TypeFunction*)fd->type)->callMatch(ethis, fargs, flags))
+            fd = ti->toAlias()->isFuncDeclaration();
+            if (fd && !((TypeFunction*)fd->type)->callMatch(ethis, fargs, flags))
                 continue;
         }
 

--- a/src/template.c
+++ b/src/template.c
@@ -1570,6 +1570,18 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
         if (!m)                 // if no match
             continue;
 
+        if (m == MATCHconst)
+        {
+            ti = new TemplateInstance(loc, td, &dedargs);
+            ti->semantic(sc, fargs);
+            if (ti->inst == ti)
+                ti->tiargs = (Objects*)dedargs.copy();
+
+            if ((fd = ti->toAlias()->isFuncDeclaration()) &&
+                !((TypeFunction*)fd->type)->callMatch(ethis, fargs, flags))
+                continue;
+        }
+
         if (m < m_best)
             goto Ltd_best;
         if (m > m_best)
@@ -3889,6 +3901,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         // It's a match
         inst = ti;
         parent = ti->parent;
+        tiargs = ti->tiargs;
 #if LOG
         printf("\tit's a match with instance %p\n", inst);
 #endif

--- a/test/compilable/const.d
+++ b/test/compilable/const.d
@@ -39,3 +39,32 @@ static assert(6.0i % 3.0i == 0);
 static assert(6.0i % 4.0i == 2i);
 
 
+void checkconstref()
+{
+    void pfun(immutable(char)[]* a) {}
+    void rfun(ref immutable(char)[] a) {}
+
+    immutable char[] buf = "hello";
+    static assert(!__traits(compiles, rfun(buf)));
+    static assert(!__traits(compiles, pfun(buf)));
+
+    immutable char[5] buf2 = "hello";
+    static assert(!__traits(compiles, rfun(buf2)));
+    static assert(!__traits(compiles, pfun(buf2)));
+
+    void pcfun(const(char)[]* a) {}
+    void rcfun(ref const(char)[] a) {}
+
+    static assert(!__traits(compiles, rcfun(buf)));
+    static assert(!__traits(compiles, pcfun(buf)));
+    static assert(!__traits(compiles, rcfun(buf2)));
+    static assert(!__traits(compiles, pcfun(buf2)));
+
+    const char[] buf3 = "hello";
+    const char[5] buf4 = "hello";
+
+    static assert(!__traits(compiles, rcfun(buf3)));
+    static assert(!__traits(compiles, pcfun(buf3)));
+    static assert(!__traits(compiles, rcfun(buf4)));
+    static assert(!__traits(compiles, pcfun(buf4)));
+}


### PR DESCRIPTION
When implicitly converting types with indirections, only allow the following results:

> completely mutable
> completely non-mutable
> exactly one mutable indirection
> the same number of mutable indirections as before

eg.

> T**\* => const(T**_)   allowed, full const
> T**_ => const(T**)\*   allowed, tail const
> T**\* => const(T_)_\*   not allowed
> T**\* => const(T)**\*   not allowed
> T**\* => T**\*          allowed, same number of mutable indirections
> immutable(T_)_\* => const(T_)_\* allowed, same number of mutable indirections
> etc

Required a change to make deduceTypes check that the function declaration found really is callable.  This can be removed when deduceTypes is fixed to not match this type of pattern.

This pull request now includes:

Issue 5493 - Able to overwrite immutable data by passing through ref function parameter
Force ref parameters to follow the same rules as pointers by ensuring that the implicit conversion would work if you were using pointers instead. This allows future fixes to pointer const semantics to be automatically applied.
