### PR TITLE
Slightly improve test to catch the case where the connect detects connect

### DIFF
--- a/test/runnable/testsocket.d
+++ b/test/runnable/testsocket.d
@@ -38,11 +38,17 @@ class Connection
 
 int main ()
 {
-	Connection ns;
-	ns = new Connection ();
-	ns.connect ("localhost", 80);
-	ns.poll ();
-	delete ns;
+	try
+	{
+	    Connection ns;
+	    ns = new Connection ();
+	    ns.connect ("localhost", 80);
+	    ns.poll ();
+	    delete ns;
+	}
+	catch(SocketException e)
+	{
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Fixes bug 6150.

Slightly improve test to catch the case where the connect detects connection refused synchronously and fails.

I'm not particularly fond of this fix, but given the state of std.socket and socketset, it's probably good enough without embarking on a replacement project.  The original bug that introduced this tests (268) was concerned with management of the file descriptor set inside socketset and resulting memory corruption and segfaults.  This change doesn't reduce that coverage.
