### PR TITLE
Removed _DH preprocessor flag.

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -23,9 +23,7 @@ struct LabelDsymbol;
 struct Initializer;
 struct Module;
 struct Condition;
-#ifdef _DH
 struct HdrGenState;
-#endif
 
 /**************************************************************/
 

--- a/src/backend/strtold.c
+++ b/src/backend/strtold.c
@@ -537,7 +537,7 @@ long double strtold(const char *p,char **endp)
     L1:
         if (endp)
         {
-            *endp = (void *) p;
+            *endp = (char *) p;
         }
     L3:
 #if _WIN32

--- a/src/cond.c
+++ b/src/cond.c
@@ -20,10 +20,8 @@
 #include "module.h"
 #include "template.h"
 #include "lexer.h"
-#ifdef _DH
 #include "mtype.h"
 #include "scope.h"
-#endif
 
 int findCondition(Array *ids, Identifier *ident)
 {

--- a/src/cond.h
+++ b/src/cond.h
@@ -18,13 +18,9 @@ struct Module;
 struct Scope;
 struct ScopeDsymbol;
 struct DebugCondition;
-#ifdef _DH
 #include "lexer.h" // dmdhg
-#endif
 enum TOK;
-#ifdef _DH
 struct HdrGenState;
-#endif
 
 int findCondition(Array *ids, Identifier *ident);
 

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -254,10 +254,8 @@ TypedefDeclaration::TypedefDeclaration(Loc loc, Identifier *id, Type *basetype, 
     this->type = new TypeTypedef(this);
     this->basetype = basetype->toBasetype();
     this->init = init;
-#ifdef _DH
     this->htype = NULL;
     this->hbasetype = NULL;
-#endif
     this->loc = loc;
     this->sinit = NULL;
 }
@@ -273,7 +271,7 @@ Dsymbol *TypedefDeclaration::syntaxCopy(Dsymbol *s)
     assert(!s);
     TypedefDeclaration *st;
     st = new TypedefDeclaration(loc, ident, basetype, init);
-#ifdef _DH
+
     // Syntax copy for header file
     if (!htype)      // Don't overwrite original
     {   if (type)    // Make copy for both old and new instances
@@ -291,7 +289,7 @@ Dsymbol *TypedefDeclaration::syntaxCopy(Dsymbol *s)
     }
     else
         st->hbasetype = hbasetype->syntaxCopy();
-#endif
+
     return st;
 }
 
@@ -368,10 +366,8 @@ AliasDeclaration::AliasDeclaration(Loc loc, Identifier *id, Type *type)
     this->loc = loc;
     this->type = type;
     this->aliassym = NULL;
-#ifdef _DH
     this->htype = NULL;
     this->haliassym = NULL;
-#endif
     this->overnext = NULL;
     this->inSemantic = 0;
     assert(type);
@@ -385,10 +381,8 @@ AliasDeclaration::AliasDeclaration(Loc loc, Identifier *id, Dsymbol *s)
     this->loc = loc;
     this->type = NULL;
     this->aliassym = s;
-#ifdef _DH
     this->htype = NULL;
     this->haliassym = NULL;
-#endif
     this->overnext = NULL;
     this->inSemantic = 0;
     assert(s);
@@ -403,7 +397,7 @@ Dsymbol *AliasDeclaration::syntaxCopy(Dsymbol *s)
         sa = new AliasDeclaration(loc, ident, type->syntaxCopy());
     else
         sa = new AliasDeclaration(loc, ident, aliassym->syntaxCopy(NULL));
-#ifdef _DH
+
     // Syntax copy for header file
     if (!htype)     // Don't overwrite original
     {   if (type)       // Make copy for both old and new instances
@@ -421,7 +415,7 @@ Dsymbol *AliasDeclaration::syntaxCopy(Dsymbol *s)
     }
     else
         sa->haliassym = haliassym->syntaxCopy(s);
-#endif
+
     return sa;
 }
 
@@ -606,7 +600,7 @@ Dsymbol *AliasDeclaration::toAlias()
 void AliasDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("alias ");
-#if 0 && _DH
+#if 0
     if (hgs->hdrgen)
     {
         if (haliassym)
@@ -649,10 +643,8 @@ VarDeclaration::VarDeclaration(Loc loc, Type *type, Identifier *id, Initializer 
     assert(type || init);
     this->type = type;
     this->init = init;
-#ifdef _DH
     this->htype = NULL;
     this->hinit = NULL;
-#endif
     this->loc = loc;
     offset = 0;
     noscope = 0;
@@ -693,7 +685,7 @@ Dsymbol *VarDeclaration::syntaxCopy(Dsymbol *s)
         sv = new VarDeclaration(loc, type ? type->syntaxCopy() : NULL, ident, init);
         sv->storage_class = storage_class;
     }
-#ifdef _DH
+
     // Syntax copy for header file
     if (!htype)      // Don't overwrite original
     {   if (type)    // Make copy for both old and new instances
@@ -711,7 +703,7 @@ Dsymbol *VarDeclaration::syntaxCopy(Dsymbol *s)
     }
     else
         sv->hinit = hinit->syntaxCopy();
-#endif
+
     return sv;
 }
 

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -190,10 +190,8 @@ struct TypedefDeclaration : Declaration
     const char *kind();
     Type *getType();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-#ifdef _DH
     Type *htype;
     Type *hbasetype;
-#endif
 
     void toDocBuffer(OutBuffer *buf);
 
@@ -224,10 +222,8 @@ struct AliasDeclaration : Declaration
     Type *getType();
     Dsymbol *toAlias();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-#ifdef _DH
     Type *htype;
     Dsymbol *haliassym;
-#endif
 
     void toDocBuffer(OutBuffer *buf);
 
@@ -277,10 +273,8 @@ struct VarDeclaration : Declaration
     void semantic2(Scope *sc);
     const char *kind();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-#ifdef _DH
     Type *htype;
     Initializer *hinit;
-#endif
     AggregateDeclaration *isThis();
     int needThis();
     int isImportedSymbol();
@@ -857,9 +851,7 @@ struct DeleteDeclaration : FuncDeclaration
     int isVirtual();
     int addPreInvariant();
     int addPostInvariant();
-#ifdef _DH
     DeleteDeclaration *isDeleteDeclaration() { return this; }
-#endif
 };
 
 #endif /* DMD_DECLARATION_H */

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -154,10 +154,8 @@ struct Dsymbol : Object
     Dsymbol *search_correct(Identifier *id);
     Dsymbol *searchX(Loc loc, Scope *sc, Identifier *id);
     virtual int overloadInsert(Dsymbol *s);
-#ifdef _DH
     char *toHChars();
     virtual void toHBuffer(OutBuffer *buf, HdrGenState *hgs);
-#endif
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toDocBuffer(OutBuffer *buf);
     virtual void toJsonBuffer(OutBuffer *buf);
@@ -236,9 +234,7 @@ struct Dsymbol : Object
     virtual ArrayScopeSymbol *isArrayScopeSymbol() { return NULL; }
     virtual Import *isImport() { return NULL; }
     virtual EnumDeclaration *isEnumDeclaration() { return NULL; }
-#ifdef _DH
     virtual DeleteDeclaration *isDeleteDeclaration() { return NULL; }
-#endif
     virtual SymbolDeclaration *isSymbolDeclaration() { return NULL; }
     virtual AttribDeclaration *isAttribDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }

--- a/src/enum.h
+++ b/src/enum.h
@@ -21,9 +21,7 @@
 struct Identifier;
 struct Type;
 struct Expression;
-#ifdef _DH
 struct HdrGenState;
-#endif
 
 
 struct EnumDeclaration : ScopeDsymbol

--- a/src/expression.h
+++ b/src/expression.h
@@ -264,9 +264,7 @@ struct ComplexExp : Expression
     int isBool(int result);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
-#ifdef _DH
     OutBuffer hexp;
-#endif
     elem *toElem(IRState *irs);
     dt_t **toDt(dt_t **pdt);
 };

--- a/src/freebsd.mak
+++ b/src/freebsd.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_FREEBSD=1
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_FREEBSD=1
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h
@@ -174,7 +174,7 @@ builtin.o: builtin.c
 	$(CC) -c $(CFLAGS) $<
 
 cast.o: cast.c
-	$(CC) -c $(CFLAGS) $< 
+	$(CC) -c $(CFLAGS) $<
 
 cg.o: fltables.c $C/cg.c
 	$(CC) -c $(MFLAGS) -I. $C/cg.c
@@ -400,7 +400,7 @@ mars.o: mars.c
 
 rmem.o: $(ROOT)/rmem.c
 	$(CC) -c $(GFLAGS) -I$(ROOT) $(ROOT)/rmem.c
-	
+
 module.o: $(TOTALH) $C/html.h module.c
 	$(CC) -c $(CFLAGS) -I$C module.c
 

--- a/src/func.c
+++ b/src/func.c
@@ -1463,15 +1463,10 @@ void FuncDeclaration::semantic3(Scope *sc)
 
             // Merge contracts together with body into one compound statement
 
-#ifdef _DH
             if (frequire && global.params.useIn)
             {   frequire->incontract = 1;
                 a->push(frequire);
             }
-#else
-            if (frequire && global.params.useIn)
-                a->push(frequire);
-#endif
 
             // Precondition invariant
             if (addPreInvariant())

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -10,8 +10,6 @@
 
 // Routines to emit header files
 
-#ifdef _DH
-
 #define PRETTY_PRINT
 #define TEST_EMIT_ALL  0        // For Testing
 
@@ -100,5 +98,3 @@ void Dsymbol::toHBuffer(OutBuffer *buf, HdrGenState *hgs)
 
 
 /*************************************/
-
-#endif // #ifdef _DH

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -54,8 +54,6 @@
 #include        "iasm.h"
 #include        "cpp.h"
 
-#undef _DH
-
 // I32 isn't set correctly yet because this is the front end, and I32
 // is a backend flag
 #undef I16

--- a/src/identifier.h
+++ b/src/identifier.h
@@ -29,9 +29,7 @@ struct Identifier : Object
     int compare(Object *o);
     void print();
     char *toChars();
-#ifdef _DH
     char *toHChars();
-#endif
     const char *toHChars2();
     int dyncast();
 

--- a/src/import.h
+++ b/src/import.h
@@ -24,9 +24,7 @@ struct OutBuffer;
 struct Module;
 struct Package;
 struct AliasDeclaration;
-#ifdef _DH
 struct HdrGenState;
-#endif
 
 struct Import : Dsymbol
 {

--- a/src/init.h
+++ b/src/init.h
@@ -26,9 +26,8 @@ struct VoidInitializer;
 struct StructInitializer;
 struct ArrayInitializer;
 struct ExpInitializer;
-#ifdef _DH
 struct HdrGenState;
-#endif
+
 
 struct Initializer : Object
 {

--- a/src/linux.mak
+++ b/src/linux.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_LINUX=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_LINUX=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_LINUX=1
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_LINUX=1
 LDFLAGS = -lm -lstdc++ -lpthread
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
@@ -175,7 +175,7 @@ builtin.o: builtin.c
 	$(CC) -c $(CFLAGS) $<
 
 cast.o: cast.c
-	$(CC) -c $(CFLAGS) $< 
+	$(CC) -c $(CFLAGS) $<
 
 cg.o: fltables.c $C/cg.c
 	$(CC) -c $(MFLAGS) -I. $C/cg.c
@@ -401,7 +401,7 @@ mars.o: mars.c
 
 rmem.o: $(ROOT)/rmem.c
 	$(CC) -c $(GFLAGS) -I$(ROOT) $(ROOT)/rmem.c
-	
+
 module.o: $(TOTALH) $C/html.h module.c
 	$(CC) -c $(CFLAGS) -I$C module.c
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -546,7 +546,6 @@ int main(int argc, char *argv[])
                         goto Lerror;
                 }
             }
-#ifdef _DH
             else if (p[1] == 'H')
             {   global.params.doHdrGeneration = 1;
                 switch (p[2])
@@ -570,7 +569,6 @@ int main(int argc, char *argv[])
                         goto Lerror;
                 }
             }
-#endif
             else if (p[1] == 'X')
             {   global.params.doXGeneration = 1;
                 switch (p[2])
@@ -1154,7 +1152,6 @@ int main(int argc, char *argv[])
     }
     if (global.errors)
         fatal();
-#ifdef _DH
     if (global.params.doHdrGeneration)
     {
         /* Generate 'header' import files.
@@ -1172,7 +1169,6 @@ int main(int argc, char *argv[])
     }
     if (global.errors)
         fatal();
-#endif
 
     // load all unconditional imports for better symbol resolving
     for (i = 0; i < modules.dim; i++)

--- a/src/module.h
+++ b/src/module.h
@@ -132,9 +132,7 @@ struct Module : Package
     void semantic3();   // pass 3 semantic analysis
     void inlineScan();  // scan for functions to inline
     void setHdrfile();  // set hdrfile member
-#ifdef _DH
     void genhdrfile();  // generate D import file
-#endif
     void genobjfile(int multiobj);
     void gensymfile();
     void gendocfile();

--- a/src/openbsd.mak
+++ b/src/openbsd.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_OPENBSD=1
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_OPENBSD=1
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h
@@ -174,7 +174,7 @@ builtin.o: builtin.c
 	$(CC) -c $(CFLAGS) $<
 
 cast.o: cast.c
-	$(CC) -c $(CFLAGS) $< 
+	$(CC) -c $(CFLAGS) $<
 
 cg.o: fltables.c $C/cg.c
 	$(CC) -c $(MFLAGS) -I. $C/cg.c
@@ -400,7 +400,7 @@ mars.o: mars.c
 
 rmem.o: $(ROOT)/rmem.c
 	$(CC) -c $(GFLAGS) -I$(ROOT) $(ROOT)/rmem.c
-	
+
 module.o: $(TOTALH) $C/html.h module.c
 	$(CC) -c $(CFLAGS) -I$C module.c
 

--- a/src/osx.mak
+++ b/src/osx.mak
@@ -25,8 +25,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_OSX=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_OSX=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_OSX=1
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_OSX=1
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h

--- a/src/solaris.mak
+++ b/src/solaris.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_SOLARIS=1
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_SOLARIS=1
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h
@@ -174,7 +174,7 @@ builtin.o: builtin.c
 	$(CC) -c $(CFLAGS) $<
 
 cast.o: cast.c
-	$(CC) -c $(CFLAGS) $< 
+	$(CC) -c $(CFLAGS) $<
 
 cg.o: fltables.c $C/cg.c
 	$(CC) -c $(MFLAGS) -I. $C/cg.c
@@ -400,7 +400,7 @@ mars.o: mars.c
 
 rmem.o: $(ROOT)/rmem.c
 	$(CC) -c $(GFLAGS) -I$(ROOT) $(ROOT)/rmem.c
-	
+
 module.o: $(TOTALH) $C/html.h module.c
 	$(CC) -c $(CFLAGS) -I$C module.c
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -37,11 +37,9 @@ extern int os_critsecsize64();
 Statement::Statement(Loc loc)
     : loc(loc)
 {
-#ifdef _DH
     // If this is an in{} contract scope statement (skip for determining
     //  inlineStatus of a function body for header content)
     incontract = 0;
-#endif
 }
 
 Statement *Statement::syntaxCopy()

--- a/src/statement.h
+++ b/src/statement.h
@@ -92,9 +92,7 @@ struct Statement : Object
     void error(const char *format, ...);
     void warning(const char *format, ...);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-#ifdef _DH
     int incontract;
-#endif
     virtual ScopeStatement *isScopeStatement() { return NULL; }
     virtual Statement *semantic(Scope *sc);
     Statement *semanticScope(Scope *sc, Statement *sbreak, Statement *scontinue);

--- a/src/staticassert.h
+++ b/src/staticassert.h
@@ -18,9 +18,7 @@
 #include "dsymbol.h"
 
 struct Expression;
-#ifdef _DH
 struct HdrGenState;
-#endif
 
 struct StaticAssert : Dsymbol
 {

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -32,8 +32,8 @@ LFLAGS=
 
 LINKN=$(SCROOT)\bin\link /de
 
-CFLAGS=-I$(ROOT);$(INCLUDE) $(XFLG) $(OPT) $(DEBUG) -cpp -D_DH
-MFLAGS=-I$C;$(TK) -DMARS -cpp $(DEBUG) -e -wx -D_DH
+CFLAGS=-I$(ROOT);$(INCLUDE) $(XFLG) $(OPT) $(DEBUG) -cpp
+MFLAGS=-I$C;$(TK) -DMARS -cpp $(DEBUG) -e -wx
 
 # Makerules:
 .c.obj:


### PR DESCRIPTION
It was once used to enable .di generation, but as DMD doesn't even compile without it anymore, there is little point in leaving it in.
