### PR TITLE
turn on warnings with signed/unsigned comparisons.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -11183,6 +11183,21 @@ Expression *CmpExp::semantic(Scope *sc)
         return new ErrorExp();
     }
 
+    /* Disallow integer comparisons S>=U, S>U, S<=U and S<U
+     */
+    if (op == TOKge || op == TOKgt || op == TOKle || op == TOKlt)
+    {
+        if ((e1->op != TOKint64 && t1->isintegral() && e2->op != TOKint64 && t2->isintegral()) ||
+            (t1->isintegral() && e2->op == TOKint64 && e2->toInteger() < 0) ||
+            (t2->isintegral() && e1->op == TOKint64 && e1->toInteger() < 0))
+        {
+            if (t1->isunsigned() != t2->isunsigned())
+            {   warning("comparison between signed and unsigned integer expressions");
+                //return new ErrorExp();
+            }
+        }
+    }
+
     typeCombine(sc);
     type = Type::tboolean;
 


### PR DESCRIPTION
The specs on integral comparisons is defined as follows:
'''
  It is an error to have one operand be signed and the other unsigned for a <, <=, > or >= expression. Use casts to make both operands signed or both operands unsigned.
'''

So far, none of the D compilers have really enforced this yet.

This implementation comes with the following deviations from the wording of the D spec:
- Signed/unsigned comparison with positive integer literals will not trigger (although the difference is just one appended 'u' away).
- Whilst declared an error in the docs, will instead warn as it _will_ break a _lot_ of currently existing code, including that found in Phobos - and to be frank, to enforce any such restriction at this stage of development will cost a lot of time for users to fix their code.

Regards.
