### PR TITLE
Issue 2532 - '=' does not give a boolean result

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9511,7 +9511,7 @@ Expression *AssignExp::checkToBoolean(Scope *sc)
     //  if (a = b) ...
     // are usually mistakes.
 
-    error("'=' does not give a boolean result");
+    error("assignment cannot be used as a condition");
     return new ErrorExp();
 }
 


### PR DESCRIPTION
Changed to a better error message.

http://d.puremagic.com/issues/show_bug.cgi?id=2532
