### PR TITLE
Remove most uses of __I86__

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -98,40 +98,9 @@ enum LANG
         LANGjapanese,
 };
 
-#if __I86__
-
 #include        "cdef.h"        // host and target compiler definition
 
 #define INITIALIZED_STATIC_DEF  static
-
-#else
-#include        "TGcc.h"
-#include        "str4.h"
-
-#if MULTI_FILE
-/* Make statics that require re-initialization available */
-#define INITIALIZED_STATIC_DEF
-#define INITIALIZED_STATIC_REF  extern
-#else
-#define INITIALIZED_STATIC_DEF  STATIC
-#define INITIALIZED_STATIC_REF  error
-#endif
-
-#ifndef PASCAL
-#define PASCAL pascal
-#endif
-
-#define TOOLKIT_H
-
-/* Segments     */
-#define CODE    1       /* code segment                 */
-#define DATA    2       /* initialized data             */
-#define CDATA   3       /* constant data                */
-#define UDATA   4       /* uninitialized data           */
-#ifndef UNKNOWN
-#define UNKNOWN -1      /* unknown segment              */
-#endif
-#endif
 
 #if MEMMODELS == 1
 #define LARGEDATA 0     /* don't want 48 bit pointers */

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -607,7 +607,7 @@ typedef int bool;
 #endif
 
 // gcc defines this for us, dmc doesn't, so look for it's __I86__
-#if defined(__I86__) || defined(i386)
+#if defined(__I86__) || defined(i386) || defined(__x86_64__)
 #define ITTLE_ENDIAN 1
 #else
 #error unknown platform, so unknown endianness

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -606,6 +606,13 @@ typedef int bool;
 #define __near
 #endif
 
+// gcc defines this for us, dmc doesn't, so look for it's __I86__
+#if defined(__I86__) || defined(i386)
+#define ITTLE_ENDIAN 1
+#else
+#error unknown platform, so unknown endianness
+#endif
+
 #if _WINDLL
 #define COPYRIGHT "Copyright © 2001 Digital Mars"
 #else

--- a/src/backend/mach.h
+++ b/src/backend/mach.h
@@ -289,21 +289,20 @@ struct relocation_info
 
 struct scattered_relocation_info
 {
-    #if __LITTLE_ENDIAN__ || __I86__ || __i386 || __i386__ || __x86_64__
+    #if LITTLE_ENDIAN
         uint32_t r_address:24,
         r_type:4,
         r_length:2,
         r_pcrel:1,
         r_scattered:1;
         int32_t r_value;
-    #elif __BIG_ENDIAN__
+    #elif BIG_ENDIAN
         uint32_t r_scattered:1,
         r_pcrel:1,
         r_length:2,
         r_type:4,
         r_address:24;
         int32_t r_value;
-    #else
     #endif
 };
 

--- a/src/freebsd.mak
+++ b/src/freebsd.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h

--- a/src/linux.mak
+++ b/src/linux.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_LINUX=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_LINUX=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_LINUX=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_LINUX=1 -D_DH
 LDFLAGS = -lm -lstdc++ -lpthread
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \

--- a/src/module.c
+++ b/src/module.c
@@ -380,7 +380,7 @@ void Module::read(Loc loc)
 
 inline unsigned readwordLE(unsigned short *p)
 {
-#if __I86__
+#if LITTLE_ENDIAN
     return *p;
 #else
     return (((unsigned char *)p)[1] << 8) | ((unsigned char *)p)[0];
@@ -394,7 +394,7 @@ inline unsigned readwordBE(unsigned short *p)
 
 inline unsigned readlongLE(unsigned *p)
 {
-#if __I86__
+#if LITTLE_ENDIAN
     return *p;
 #else
     return ((unsigned char *)p)[0] |

--- a/src/openbsd.mak
+++ b/src/openbsd.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h

--- a/src/osx.mak
+++ b/src/osx.mak
@@ -25,8 +25,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_OSX=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_OSX=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_OSX=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_OSX=1 -D_DH
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -1,0 +1,654 @@
+# NOTE: need to validate solaris behavior
+ifeq (,$(TARGET))
+    OS:=$(shell uname)
+    ifeq (Darwin,$(OS))
+        TARGET=OSX
+    else
+        ifeq (Linux,$(OS))
+            TARGET=LINUX
+        else
+            ifeq (FreeBSD,$(OS))
+                TARGET=FREEBSD
+            else
+                ifeq (OpenBSD,$(OS))
+                    TARGET=OPENBSD
+                else
+                    ifeq (Solaris,$(OS))
+                        TARGET=SOLARIS
+                    else
+                        $(error Unrecognized or unsupported OS for uname: $(OS))
+                    endif
+                endif
+            endif
+        endif
+    endif
+endif
+
+C=backend
+TK=tk
+ROOT=root
+
+MODEL=32
+
+ifeq (OSX,$(TARGET))
+    ## See: http://developer.apple.com/documentation/developertools/conceptual/cross_development/Using/chapter_3_section_2.html#//apple_ref/doc/uid/20002000-1114311-BABGCAAB
+    ENVP= MACOSX_DEPLOYMENT_TARGET=10.3
+    SDK=/Developer/SDKs/MacOSX10.4u.sdk #doesn't work because can't find <stdarg.h>
+    SDK=/Developer/SDKs/MacOSX10.5.sdk
+    #SDK=/Developer/SDKs/MacOSX10.6.sdk
+
+    TARGET_CFLAGS=-isysroot ${SDK}
+    LDFLAGS=-lstdc++ -isysroot ${SDK} -Wl,-syslibroot,${SDK} -framework CoreServices
+else
+    LDFLAGS=-lm -lstdc++ -lpthread
+endif
+
+CC=g++ -m$(MODEL) $(TARGET_CFLAGS)
+
+#OPT=-g -g3
+#OPT=-O2
+
+#COV=-fprofile-arcs -ftest-coverage
+
+WARNINGS=-Wno-deprecated -Wstrict-aliasing
+
+#GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
+GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
+
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_$(TARGET)=1 -D_DH
+
+CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
+	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h
+TOTALH=
+
+DMD_OBJS = \
+	access.o array.o attrib.o bcomplex.o bit.o blockopt.o \
+	cast.o code.o cg.o cg87.o cgcod.o cgcs.o cgelem.o cgen.o \
+	cgreg.o cgsched.o class.o cod1.o cod2.o cod3.o cod4.o cod5.o \
+	constfold.o irstate.o dchar.o cond.o debug.o \
+	declaration.o dsymbol.o dt.o dump.o e2ir.o ee.o eh.o el.o \
+	dwarf.o enum.o evalu8.o expression.o func.o gdag.o gflow.o \
+	glocal.o gloop.o glue.o gnuc.o go.o gother.o html.o iasm.o id.o \
+	identifier.o impcnvtab.o import.o inifile.o init.o inline.o \
+	lexer.o link.o lstring.o mangle.o mars.o rmem.o module.o msc.o mtype.o \
+	nteh.o cppmangle.o opover.o optimize.o os.o out.o outbuf.o \
+	parse.o ph.o ptrntab.o root.o rtlsym.o s2ir.o scope.o statement.o \
+	stringtable.o struct.o csymbol.o template.o tk.o tocsym.o todt.o \
+	type.o typinf.o util.o var.o version.o strtold.o utf.o staticassert.o \
+	unialpha.o toobj.o toctype.o toelfdebug.o entity.o doc.o macro.o \
+	hdrgen.o delegatize.o aa.o ti_achar.o toir.o interpret.o traits.o \
+	builtin.o clone.o aliasthis.o \
+	man.o arrayop.o port.o response.o async.o json.o speller.o aav.o unittests.o \
+	imphint.o argtypes.o ti_pvoid.o
+
+ifeq (OSX,$(TARGET))
+    DMD_OBJS += libmach.o machobj.o
+else
+    DMD_OBJS += libelf.o elfobj.o
+endif
+
+SRC = win32.mak linux.mak osx.mak freebsd.mak solaris.mak openbsd.mak \
+	mars.c enum.c struct.c dsymbol.c import.c idgen.c impcnvgen.c \
+	identifier.c mtype.c expression.c optimize.c template.h \
+	template.c lexer.c declaration.c cast.c cond.h cond.c link.c \
+	aggregate.h parse.c statement.c constfold.c version.h version.c \
+	inifile.c iasm.c module.c scope.c dump.c init.h init.c attrib.h \
+	attrib.c opover.c class.c mangle.c bit.c tocsym.c func.c inline.c \
+	access.c complex_t.h irstate.h irstate.c glue.c msc.c ph.c tk.c \
+	s2ir.c todt.c e2ir.c util.c identifier.h parse.h \
+	scope.h enum.h import.h mars.h module.h mtype.h dsymbol.h \
+	declaration.h lexer.h expression.h irstate.h statement.h eh.c \
+	utf.h utf.c staticassert.h staticassert.c unialpha.c \
+	typinf.c toobj.c toctype.c tocvdebug.c toelfdebug.c entity.c \
+	doc.h doc.c macro.h macro.c hdrgen.h hdrgen.c arraytypes.h \
+	delegatize.c toir.h toir.c interpret.c traits.c cppmangle.c \
+	builtin.c clone.c lib.h libomf.c libelf.c libmach.c arrayop.c \
+	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c \
+	argtypes.c \
+	$C/cdef.h $C/cc.h $C/oper.h $C/ty.h $C/optabgen.c \
+	$C/global.h $C/parser.h $C/code.h $C/type.h $C/dt.h $C/cgcv.h \
+	$C/el.h $C/iasm.h $C/rtlsym.h $C/html.h \
+	$C/bcomplex.c $C/blockopt.c $C/cg.c $C/cg87.c \
+	$C/cgcod.c $C/cgcs.c $C/cgcv.c $C/cgelem.c $C/cgen.c $C/cgobj.c \
+	$C/cgreg.c $C/var.c $C/strtold.c \
+	$C/cgsched.c $C/cod1.c $C/cod2.c $C/cod3.c $C/cod4.c $C/cod5.c \
+	$C/code.c $C/symbol.c $C/debug.c $C/dt.c $C/ee.c $C/el.c \
+	$C/evalu8.c $C/go.c $C/gflow.c $C/gdag.c \
+	$C/gother.c $C/glocal.c $C/gloop.c $C/html.c $C/newman.c \
+	$C/nteh.c $C/os.c $C/out.c $C/outbuf.c $C/ptrntab.c $C/rtlsym.c \
+	$C/type.c $C/melf.h $C/mach.h $C/bcomplex.h \
+	$C/cdeflnx.h $C/outbuf.h $C/token.h $C/tassert.h \
+	$C/elfobj.c $C/cv4.h $C/dwarf2.h $C/cpp.h $C/exh.h $C/go.h \
+	$C/dwarf.c $C/dwarf.h $C/aa.h $C/aa.c $C/tinfo.h $C/ti_achar.c \
+	$C/ti_pvoid.c \
+	$C/machobj.c \
+	$(TK)/filespec.h $(TK)/mem.h $(TK)/list.h $(TK)/vec.h \
+	$(TK)/filespec.c $(TK)/mem.c $(TK)/vec.c $(TK)/list.c \
+	$(ROOT)/dchar.h $(ROOT)/dchar.c $(ROOT)/lstring.h \
+	$(ROOT)/lstring.c $(ROOT)/root.h $(ROOT)/root.c $(ROOT)/array.c \
+	$(ROOT)/rmem.h $(ROOT)/rmem.c $(ROOT)/port.h $(ROOT)/port.c \
+	$(ROOT)/gnuc.h $(ROOT)/gnuc.c $(ROOT)/man.c \
+	$(ROOT)/stringtable.h $(ROOT)/stringtable.c \
+	$(ROOT)/response.c $(ROOT)/async.h $(ROOT)/async.c \
+	$(ROOT)/aav.h $(ROOT)/aav.c \
+	$(ROOT)/speller.h $(ROOT)/speller.c
+
+
+all: dmd
+
+dmd: $(DMD_OBJS)
+	$(ENVP) gcc -o dmd -m$(MODEL) $(COV) $(DMD_OBJS) $(LDFLAGS)
+
+clean:
+	rm -f $(DMD_OBJS) dmd optab.o id.o impcnvgen idgen id.c id.h \
+	impcnvtab.c optabgen debtab.c optab.c cdxxx.c elxxx.c fltables.c \
+	tytab.c core \
+	*.cov *.gcda *.gcno
+
+######## optabgen generates some source
+
+optabgen: $C/optabgen.c $C/cc.h $C/oper.h
+	$(ENVP) $(CC) $(MFLAGS) $< -o optabgen
+	./optabgen
+
+optabgen_output = debtab.c optab.c cdxxx.c elxxx.c fltables.c tytab.c
+$(optabgen_output) : optabgen
+
+######## idgen generates some source
+
+idgen_output = id.h id.c
+$(idgen_output) : idgen
+
+idgen : idgen.c
+	$(ENVP) $(CC) idgen.c -o idgen
+	./idgen
+
+######### impcnvgen generates some source
+
+impcnvtab_output = impcnvtab.c
+$(impcnvtab_output) : impcnvgen
+
+impcnvgen : mtype.h impcnvgen.c
+	$(ENVP) $(CC) $(CFLAGS) impcnvgen.c -o impcnvgen
+	./impcnvgen
+
+#########
+
+$(DMD_OBJS) : $(idgen_output) $(optabgen_output) $(impcnvgen_output)
+
+aa.o: $C/aa.h $C/tinfo.h $C/aa.c
+	$(CC) -c $(MFLAGS) -I. $C/aa.c
+
+aav.o: $(ROOT)/aav.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+access.o: access.c
+	$(CC) -c $(CFLAGS) $<
+
+aliasthis.o: aliasthis.c
+	$(CC) -c $(CFLAGS) $<
+
+argtypes.o: argtypes.c
+	$(CC) -c $(CFLAGS) $<
+
+array.o: $(ROOT)/array.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+arrayop.o: arrayop.c
+	$(CC) -c $(CFLAGS) $<
+
+async.o: $(ROOT)/async.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+attrib.o: attrib.c
+	$(CC) -c $(CFLAGS) $<
+
+bcomplex.o: $C/bcomplex.c
+	$(CC) -c $(MFLAGS) $<
+
+bit.o: expression.h bit.c
+	$(CC) -c -I$(ROOT) $(MFLAGS) bit.c
+
+blockopt.o: $C/blockopt.c
+	$(CC) -c $(MFLAGS) $C/blockopt.c
+
+builtin.o: builtin.c
+	$(CC) -c $(CFLAGS) $<
+
+cast.o: cast.c
+	$(CC) -c $(CFLAGS) $< 
+
+cg.o: fltables.c $C/cg.c
+	$(CC) -c $(MFLAGS) -I. $C/cg.c
+
+cg87.o: $C/cg87.c
+	$(CC) -c $(MFLAGS) $<
+
+cgcod.o: $C/cgcod.c
+	$(CC) -c $(MFLAGS) -I. $<
+
+cgcs.o: $C/cgcs.c
+	$(CC) -c $(MFLAGS) $<
+
+cgcv.o: $C/cgcv.c
+	$(CC) -c $(MFLAGS) $<
+
+cgelem.o: $C/rtlsym.h $C/cgelem.c
+	$(CC) -c $(MFLAGS) -I. $C/cgelem.c
+
+cgen.o: $C/rtlsym.h $C/cgen.c
+	$(CC) -c $(MFLAGS) $C/cgen.c
+
+cgobj.o: $C/cgobj.c
+	$(CC) -c $(MFLAGS) $<
+
+cgreg.o: $C/cgreg.c
+	$(CC) -c $(MFLAGS) $<
+
+cgsched.o: $C/rtlsym.h $C/cgsched.c
+	$(CC) -c $(MFLAGS) $C/cgsched.c
+
+class.o: class.c
+	$(CC) -c $(CFLAGS) $<
+
+clone.o: clone.c
+	$(CC) -c $(CFLAGS) $<
+
+cod1.o: $C/rtlsym.h $C/cod1.c
+	$(CC) -c $(MFLAGS) $C/cod1.c
+
+cod2.o: $C/rtlsym.h $C/cod2.c
+	$(CC) -c $(MFLAGS) $C/cod2.c
+
+cod3.o: $C/rtlsym.h $C/cod3.c
+	$(CC) -c $(MFLAGS) $C/cod3.c
+
+cod4.o: $C/cod4.c
+	$(CC) -c $(MFLAGS) $<
+
+cod5.o: $C/cod5.c
+	$(CC) -c $(MFLAGS) $<
+
+code.o: $C/code.c
+	$(CC) -c $(MFLAGS) $<
+
+constfold.o: constfold.c
+	$(CC) -c $(CFLAGS) $<
+
+irstate.o: irstate.h irstate.c
+	$(CC) -c $(MFLAGS) -I$(ROOT) irstate.c
+
+csymbol.o : $C/symbol.c
+	$(CC) -c $(MFLAGS) $C/symbol.c -o csymbol.o
+
+dchar.o: $(ROOT)/dchar.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+cond.o: cond.c
+	$(CC) -c $(CFLAGS) $<
+
+cppmangle.o: cppmangle.c
+	$(CC) -c $(CFLAGS) $<
+
+debug.o: $C/debug.c
+	$(CC) -c $(MFLAGS) -I. $<
+
+declaration.o: declaration.c
+	$(CC) -c $(CFLAGS) $<
+
+delegatize.o: delegatize.c
+	$(CC) -c $(CFLAGS) $<
+
+doc.o: doc.c
+	$(CC) -c $(CFLAGS) $<
+
+dsymbol.o: dsymbol.c
+	$(CC) -c $(CFLAGS) $<
+
+dt.o: $C/dt.h $C/dt.c
+	$(CC) -c $(MFLAGS) $C/dt.c
+
+dump.o: dump.c
+	$(CC) -c $(CFLAGS) $<
+
+dwarf.o: $C/dwarf.h $C/dwarf.c
+	$(CC) -c $(MFLAGS) -I. $C/dwarf.c
+
+e2ir.o: $C/rtlsym.h expression.h toir.h e2ir.c
+	$(CC) -c -I$(ROOT) $(MFLAGS) e2ir.c
+
+ee.o: $C/ee.c
+	$(CC) -c $(MFLAGS) $<
+
+eh.o : $C/cc.h $C/code.h $C/type.h $C/dt.h eh.c
+	$(CC) -c $(MFLAGS) eh.c
+
+el.o: $C/rtlsym.h $C/el.h $C/el.c
+	$(CC) -c $(MFLAGS) $C/el.c
+
+elfobj.o: $C/elfobj.c
+	$(CC) -c $(MFLAGS) $<
+
+entity.o: entity.c
+	$(CC) -c $(CFLAGS) $<
+
+enum.o: enum.c
+	$(CC) -c $(CFLAGS) $<
+
+evalu8.o: $C/evalu8.c
+	$(CC) -c $(MFLAGS) $<
+
+expression.o: expression.c
+	$(CC) -c $(CFLAGS) $<
+
+func.o: func.c
+	$(CC) -c $(CFLAGS) $<
+
+gdag.o: $C/gdag.c
+	$(CC) -c $(MFLAGS) $<
+
+gflow.o: $C/gflow.c
+	$(CC) -c $(MFLAGS) $<
+
+#globals.o: globals.c
+#	$(CC) -c $(CFLAGS) $<
+
+glocal.o: $C/rtlsym.h $C/glocal.c
+	$(CC) -c $(MFLAGS) $C/glocal.c
+
+gloop.o: $C/gloop.c
+	$(CC) -c $(MFLAGS) $<
+
+glue.o: $(CH) $(TOTALH) $C/rtlsym.h mars.h module.h glue.c
+	$(CC) -c $(MFLAGS) -I$(ROOT) glue.c
+
+gnuc.o: $(ROOT)/gnuc.h $(ROOT)/gnuc.c
+	$(CC) -c $(GFLAGS) $(ROOT)/gnuc.c
+
+go.o: $C/go.c
+	$(CC) -c $(MFLAGS) $<
+
+gother.o: $C/gother.c
+	$(CC) -c $(MFLAGS) $<
+
+hdrgen.o: hdrgen.c
+	$(CC) -c $(CFLAGS) $<
+
+html.o: $(CH) $(TOTALH) $C/html.h $C/html.c
+	$(CC) -c -I$(ROOT) $(MFLAGS) $C/html.c
+
+iasm.o : $(CH) $(TOTALH) $C/iasm.h iasm.c
+	$(CC) -c $(MFLAGS) -I$(ROOT) iasm.c
+
+id.o : id.h id.c
+	$(CC) -c $(CFLAGS) id.c
+
+identifier.o: identifier.c
+	$(CC) -c $(CFLAGS) $<
+
+impcnvtab.o: mtype.h impcnvtab.c
+	$(CC) -c $(CFLAGS) -I$(ROOT) impcnvtab.c
+
+imphint.o: imphint.c
+	$(CC) -c $(CFLAGS) $<
+
+import.o: import.c
+	$(CC) -c $(CFLAGS) $<
+
+inifile.o: inifile.c
+	$(CC) -c $(CFLAGS) $<
+
+init.o: init.c
+	$(CC) -c $(CFLAGS) $<
+
+inline.o: inline.c
+	$(CC) -c $(CFLAGS) $<
+
+interpret.o: interpret.c
+	$(CC) -c $(CFLAGS) $<
+
+json.o: json.c
+	$(CC) -c $(CFLAGS) $<
+
+lexer.o: lexer.c
+	$(CC) -c $(CFLAGS) $<
+
+libelf.o: libelf.c $C/melf.h
+	$(CC) -c $(CFLAGS) -I$C $<
+
+libmach.o: libmach.c $C/mach.h
+	$(CC) -c $(CFLAGS) -I$C $<
+
+link.o: link.c
+	$(CC) -c $(CFLAGS) $<
+
+lstring.o: $(ROOT)/lstring.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+machobj.o: $C/machobj.c
+	$(CC) -c $(MFLAGS) -I. $<
+
+macro.o: macro.c
+	$(CC) -c $(CFLAGS) $<
+
+man.o: $(ROOT)/man.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+mangle.o: mangle.c
+	$(CC) -c $(CFLAGS) $<
+
+mars.o: mars.c
+	$(CC) -c $(CFLAGS) $<
+
+rmem.o: $(ROOT)/rmem.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $(ROOT)/rmem.c
+	
+module.o: $(TOTALH) $C/html.h module.c
+	$(CC) -c $(CFLAGS) -I$C module.c
+
+msc.o: $(CH) mars.h msc.c
+	$(CC) -c $(MFLAGS) msc.c
+
+mtype.o: mtype.c
+	$(CC) -c $(CFLAGS) $<
+
+nteh.o: $C/rtlsym.h $C/nteh.c
+	$(CC) -c $(MFLAGS) $C/nteh.c
+
+opover.o: opover.c
+	$(CC) -c $(CFLAGS) $<
+
+optimize.o: optimize.c
+	$(CC) -c $(CFLAGS) $<
+
+os.o: $C/os.c
+	$(CC) -c $(MFLAGS) $<
+
+out.o: $C/out.c
+	$(CC) -c $(MFLAGS) $<
+
+outbuf.o : $C/outbuf.h $C/outbuf.c
+	$(CC) -c $(MFLAGS) $C/outbuf.c
+
+parse.o: parse.c
+	$(CC) -c $(CFLAGS) $<
+
+ph.o: ph.c
+	$(CC) -c $(MFLAGS) $<
+
+port.o: $(ROOT)/port.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+ptrntab.o: $C/iasm.h $C/ptrntab.c
+	$(CC) -c $(MFLAGS) $C/ptrntab.c
+
+response.o: $(ROOT)/response.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+root.o: $(ROOT)/root.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+rtlsym.o: $C/rtlsym.h $C/rtlsym.c
+	$(CC) -c $(MFLAGS) $C/rtlsym.c
+
+s2ir.o : $C/rtlsym.h statement.h s2ir.c
+	$(CC) -c -I$(ROOT) $(MFLAGS) s2ir.c
+
+scope.o: scope.c
+	$(CC) -c $(CFLAGS) $<
+
+speller.o: $(ROOT)/speller.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+statement.o: statement.c
+	$(CC) -c $(CFLAGS) $<
+
+staticassert.o: staticassert.h staticassert.c
+	$(CC) -c $(CFLAGS) staticassert.c
+
+stringtable.o: $(ROOT)/stringtable.c
+	$(CC) -c $(GFLAGS) -I$(ROOT) $<
+
+strtold.o: $C/strtold.c
+	gcc -m$(MODEL) -c $C/strtold.c
+
+struct.o: struct.c
+	$(CC) -c $(CFLAGS) $<
+
+template.o: template.c
+	$(CC) -c $(CFLAGS) $<
+
+ti_achar.o: $C/tinfo.h $C/ti_achar.c
+	$(CC) -c $(MFLAGS) -I. $C/ti_achar.c
+
+ti_pvoid.o: $C/tinfo.h $C/ti_pvoid.c
+	$(CC) -c $(MFLAGS) -I. $C/ti_pvoid.c
+
+tk.o: tk.c
+	$(CC) -c $(MFLAGS) tk.c
+
+tocsym.o: $(CH) $(TOTALH) mars.h module.h tocsym.c
+	$(CC) -c $(MFLAGS) -I$(ROOT) tocsym.c
+
+toctype.o: $(CH) $(TOTALH) $C/rtlsym.h mars.h module.h toctype.c
+	$(CC) -c $(MFLAGS) -I$(ROOT) toctype.c
+
+todt.o : mtype.h expression.h $C/dt.h todt.c
+	$(CC) -c -I$(ROOT) $(MFLAGS) todt.c
+
+toelfdebug.o: $(CH) $(TOTALH) mars.h toelfdebug.c
+	$(CC) -c $(MFLAGS) -I$(ROOT) toelfdebug.c
+
+toir.o: $C/rtlsym.h expression.h toir.h toir.c
+	$(CC) -c -I$(ROOT) $(MFLAGS) toir.c
+
+toobj.o: $(CH) $(TOTALH) mars.h module.h toobj.c
+	$(CC) -c $(MFLAGS) -I$(ROOT) toobj.c
+
+traits.o: $(TOTALH) traits.c
+	$(CC) -c $(CFLAGS) $<
+
+type.o: $C/type.c
+	$(CC) -c $(MFLAGS) $C/type.c
+
+typinf.o: $(CH) $(TOTALH) mars.h module.h mtype.h typinf.c
+	$(CC) -c $(MFLAGS) -I$(ROOT) typinf.c
+
+util.o: util.c
+	$(CC) -c $(MFLAGS) $<
+
+utf.o: utf.h utf.c
+	$(CC) -c $(CFLAGS) utf.c
+
+unialpha.o: unialpha.c
+	$(CC) -c $(CFLAGS) $<
+
+unittests.o: unittests.c
+	$(CC) -c $(CFLAGS) $<
+
+var.o: $C/var.c optab.c
+	$(CC) -c $(MFLAGS) -I. $C/var.c
+
+version.o: version.c
+	$(CC) -c $(CFLAGS) $<
+
+######################################################
+
+gcov:
+	gcov access.c
+	gcov aliasthis.c
+	gcov arrayop.c
+	gcov attrib.c
+	gcov bit.c
+	gcov builtin.c
+	gcov cast.c
+	gcov class.c
+	gcov clone.c
+	gcov cond.c
+	gcov constfold.c
+	gcov declaration.c
+	gcov delegatize.c
+	gcov doc.c
+	gcov dsymbol.c
+	gcov dump.c
+	gcov e2ir.c
+	gcov eh.c
+	gcov entity.c
+	gcov enum.c
+	gcov expression.c
+	gcov func.c
+	gcov glue.c
+	gcov iasm.c
+	gcov identifier.c
+	gcov imphint.c
+	gcov import.c
+	gcov inifile.c
+	gcov init.c
+	gcov inline.c
+	gcov interpret.c
+	gcov irstate.c
+	gcov json.c
+	gcov lexer.c
+ifeq (OSX,$(TARGET))
+	gcov libmach.c
+else
+	gcov libelf.c
+endif
+	gcov link.c
+	gcov macro.c
+	gcov mangle.c
+	gcov mars.c
+	gcov module.c
+	gcov msc.c
+	gcov mtype.c
+	gcov opover.c
+	gcov optimize.c
+	gcov parse.c
+	gcov ph.c
+	gcov scope.c
+	gcov statement.c
+	gcov staticassert.c
+	gcov s2ir.c
+	gcov struct.c
+	gcov template.c
+	gcov tk.c
+	gcov tocsym.c
+	gcov todt.c
+	gcov toobj.c
+	gcov toctype.c
+	gcov toelfdebug.c
+	gcov typinf.c
+	gcov unialpha.c
+	gcov utf.c
+	gcov util.c
+	gcov version.c
+
+#	gcov hdrgen.c
+#	gcov tocvdebug.c
+
+######################################################
+
+zip:
+	-rm -f dmdsrc.zip
+	zip dmdsrc $(SRC)

--- a/src/root/dchar.c
+++ b/src/root/dchar.c
@@ -327,7 +327,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             case 2:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += *(const uint16_t *)str;
 #else
                 hash += str[0] * 256 + str[1];
@@ -336,7 +336,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             case 3:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += (*(const uint16_t *)str << 8) +
                         ((const uint8_t *)str)[2];
 #else
@@ -346,7 +346,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             default:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += *(const uint32_t *)str;
 #else
                 hash += ((str[0] * 256 + str[1]) * 256 + str[2]) * 256 + str[3];
@@ -379,7 +379,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             case 2:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += *(const uint16_t *)str;
 #else
                 hash += str[0] * 256 + str[1];
@@ -388,7 +388,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             case 3:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += (*(const uint16_t *)str << 8) +
                         ((const uint8_t *)str)[2];
 #else
@@ -398,7 +398,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             default:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += *(const uint32_t *)str;
 #else
                 hash += ((str[0] * 256 + str[1]) * 256 + str[2]) * 256 + str[3];

--- a/src/solaris.mak
+++ b/src/solaris.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h


### PR DESCRIPTION
Switch from using **I86** as an endianness flag to a specific flag for it.  Remove always-false parts of backend/cc.h
