### PR TITLE
Remove most uses of __I86__

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -98,40 +98,9 @@ enum LANG
         LANGjapanese,
 };
 
-#if __I86__
-
 #include        "cdef.h"        // host and target compiler definition
 
 #define INITIALIZED_STATIC_DEF  static
-
-#else
-#include        "TGcc.h"
-#include        "str4.h"
-
-#if MULTI_FILE
-/* Make statics that require re-initialization available */
-#define INITIALIZED_STATIC_DEF
-#define INITIALIZED_STATIC_REF  extern
-#else
-#define INITIALIZED_STATIC_DEF  STATIC
-#define INITIALIZED_STATIC_REF  error
-#endif
-
-#ifndef PASCAL
-#define PASCAL pascal
-#endif
-
-#define TOOLKIT_H
-
-/* Segments     */
-#define CODE    1       /* code segment                 */
-#define DATA    2       /* initialized data             */
-#define CDATA   3       /* constant data                */
-#define UDATA   4       /* uninitialized data           */
-#ifndef UNKNOWN
-#define UNKNOWN -1      /* unknown segment              */
-#endif
-#endif
 
 #if MEMMODELS == 1
 #define LARGEDATA 0     /* don't want 48 bit pointers */

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -607,7 +607,7 @@ typedef int bool;
 #endif
 
 // gcc defines this for us, dmc doesn't, so look for it's __I86__
-#if defined(__I86__) || defined(i386)
+#if defined(__I86__) || defined(i386) || defined(__x86_64__)
 #define ITTLE_ENDIAN 1
 #else
 #error unknown platform, so unknown endianness

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -606,6 +606,13 @@ typedef int bool;
 #define __near
 #endif
 
+// gcc defines this for us, dmc doesn't, so look for it's __I86__
+#if defined(__I86__) || defined(i386)
+#define ITTLE_ENDIAN 1
+#else
+#error unknown platform, so unknown endianness
+#endif
+
 #if _WINDLL
 #define COPYRIGHT "Copyright © 2001 Digital Mars"
 #else

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -607,10 +607,12 @@ typedef int bool;
 #endif
 
 // gcc defines this for us, dmc doesn't, so look for it's __I86__
+#if ! (defined(LITTLE_ENDIAN) || defined(BIG_ENDIAN) )
 #if defined(__I86__) || defined(i386) || defined(__x86_64__)
-#define ITTLE_ENDIAN 1
+#define LITTLE_ENDIAN 1
 #else
 #error unknown platform, so unknown endianness
+#endif
 #endif
 
 #if _WINDLL

--- a/src/backend/mach.h
+++ b/src/backend/mach.h
@@ -289,21 +289,20 @@ struct relocation_info
 
 struct scattered_relocation_info
 {
-    #if __LITTLE_ENDIAN__ || __I86__ || __i386 || __i386__ || __x86_64__
+    #if LITTLE_ENDIAN
         uint32_t r_address:24,
         r_type:4,
         r_length:2,
         r_pcrel:1,
         r_scattered:1;
         int32_t r_value;
-    #elif __BIG_ENDIAN__
+    #elif BIG_ENDIAN
         uint32_t r_scattered:1,
         r_pcrel:1,
         r_length:2,
         r_type:4,
         r_address:24;
         int32_t r_value;
-    #else
     #endif
 };
 

--- a/src/freebsd.mak
+++ b/src/freebsd.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_FREEBSD=1 -D_DH
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h

--- a/src/linux.mak
+++ b/src/linux.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_LINUX=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_LINUX=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_LINUX=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_LINUX=1 -D_DH
 LDFLAGS = -lm -lstdc++ -lpthread
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \

--- a/src/module.c
+++ b/src/module.c
@@ -380,7 +380,7 @@ void Module::read(Loc loc)
 
 inline unsigned readwordLE(unsigned short *p)
 {
-#if __I86__
+#if LITTLE_ENDIAN
     return *p;
 #else
     return (((unsigned char *)p)[1] << 8) | ((unsigned char *)p)[0];
@@ -394,7 +394,7 @@ inline unsigned readwordBE(unsigned short *p)
 
 inline unsigned readlongLE(unsigned *p)
 {
-#if __I86__
+#if LITTLE_ENDIAN
     return *p;
 #else
     return ((unsigned char *)p)[0] |

--- a/src/openbsd.mak
+++ b/src/openbsd.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_OPENBSD=1 -D_DH
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h

--- a/src/osx.mak
+++ b/src/osx.mak
@@ -25,8 +25,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_OSX=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_OSX=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_OSX=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_OSX=1 -D_DH
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h

--- a/src/root/dchar.c
+++ b/src/root/dchar.c
@@ -327,7 +327,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             case 2:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += *(const uint16_t *)str;
 #else
                 hash += str[0] * 256 + str[1];
@@ -336,7 +336,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             case 3:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += (*(const uint16_t *)str << 8) +
                         ((const uint8_t *)str)[2];
 #else
@@ -346,7 +346,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             default:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += *(const uint32_t *)str;
 #else
                 hash += ((str[0] * 256 + str[1]) * 256 + str[2]) * 256 + str[3];
@@ -379,7 +379,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             case 2:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += *(const uint16_t *)str;
 #else
                 hash += str[0] * 256 + str[1];
@@ -388,7 +388,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             case 3:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += (*(const uint16_t *)str << 8) +
                         ((const uint8_t *)str)[2];
 #else
@@ -398,7 +398,7 @@ hash_t Dchar::calcHash(const dchar *str, size_t len)
 
             default:
                 hash *= 37;
-#if __I86__
+#if LITTLE_ENDIAN
                 hash += *(const uint32_t *)str;
 #else
                 hash += ((str[0] * 256 + str[1]) * 256 + str[2]) * 256 + str[3];

--- a/src/solaris.mak
+++ b/src/solaris.mak
@@ -17,8 +17,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -D__I86__=1 -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -D__I86__=1 -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_SOLARIS=1 -D_DH
 
 CH= $C/cc.h $C/global.h $C/parser.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/iasm.h


### PR DESCRIPTION
Switch from using __I86__ as an endianness flag to a specific flag for it.
Remove always-false parts of backend/cc.h.
