### PR TITLE
Issue 3731 - Can implicitly cast an immutable reference to a derived class

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8554,7 +8554,7 @@ MATCH TypeClass::implicitConvTo(Type *to)
     {
         if (cdto->scope)
             cdto->semantic(NULL);
-        if (cdto->isBaseOf(sym, NULL))
+        if (cdto->isBaseOf(sym, NULL) && MODimplicitConv(mod, to->mod))
         {   //printf("'to' is base\n");
             return MATCHconvert;
         }

--- a/test/fail_compilation/fail3731.d
+++ b/test/fail_compilation/fail3731.d
@@ -1,0 +1,8 @@
+
+void main()
+{
+    class C {}
+    class D : C {}
+    auto x = new immutable(D);
+    C y = x;
+}


### PR DESCRIPTION
Ensure the modifier conversion is valid before allowing an implicit conversion to a base class.

http://d.puremagic.com/issues/show_bug.cgi?id=3731
