### PR TITLE
Issue 3632 - modify float is float to do a bitwise compare

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -865,8 +865,29 @@ Expression *Identity(enum TOK op, Type *type, Expression *e1, Expression *e2)
         cmp = (es1->var == es2->var && es1->offset == es2->offset);
     }
     else if (e1->isConst() == 1 && e2->isConst() == 1)
-        return Equal((op == TOKidentity) ? TOKequal : TOKnotequal,
-                type, e1, e2);
+    {
+        if (e1->type->isreal())
+        {
+            real_t v1 = e1->toReal();
+            real_t v2 = e2->toReal();
+            cmp = !memcmp(&v1, &v2, sizeof(real_t));
+        }
+        else if (e1->type->isimaginary())
+        {
+            real_t v1 = e1->toImaginary();
+            real_t v2 = e2->toImaginary();
+            cmp = !memcmp(&v1, &v2, sizeof(real_t));
+        }
+        else if (e1->type->iscomplex())
+        {
+            complex_t v1 = e1->toComplex();
+            complex_t v2 = e2->toComplex();
+            cmp = !memcmp(&v1, &v2, sizeof(complex_t));
+        }
+        else
+            return Equal((op == TOKidentity) ? TOKequal : TOKnotequal,
+                    type, e1, e2);
+    }
     else
         assert(0);
     if (op == TOKnotidentity)

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2444,7 +2444,7 @@ elem *IdentityExp::toElem(IRState *irs)
 
     //printf("IdentityExp::toElem() %s\n", toChars());
 
-    if (t1->ty == Tstruct)
+    if (t1->ty == Tstruct || t1->isfloating())
     {   // Do bit compare of struct's
         elem *es1;
         elem *es2;


### PR DESCRIPTION
Currently floating point types are the only types where 'is' is not a bitwise comparison.  This patch make floating is floating perform a bitwise comparison, at runtime and compile-time.
