### PR TITLE
bugfix for header generation

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1660,11 +1660,14 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
 
 void TemplateDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
-#if 0 // Should handle template functions
+#if 0 // Should handle template functions for doc generation
     if (onemember && onemember->isFuncDeclaration())
         buf->writestring("foo ");
 #endif
-    buf->writestring(kind());
+    if (hgs->ddoc)
+        buf->writestring(kind());
+    else
+        buf->writestring("template");
     buf->writeByte(' ');
     buf->writestring(ident->toChars());
     buf->writeByte('(');

--- a/test/compilable/extra-files/xheader.di
+++ b/test/compilable/extra-files/xheader.di
@@ -30,3 +30,23 @@ return 0;
 }
 
 }
+template foo3(T)
+{
+T foo3()
+{
+}
+}
+template Foo4(T)
+{
+struct Foo4
+{
+    T x;
+}
+}
+template C4(T)
+{
+class C4
+{
+    T x;
+}
+}

--- a/test/compilable/xheader.d
+++ b/test/compilable/xheader.d
@@ -29,4 +29,14 @@ struct Foo3
 
 class C3 { @property int get() { return 0; } }
 
+T foo3(T)() {}
 
+struct Foo4(T)
+{
+   T x;
+}
+
+class C4(T)
+{
+  T x;
+}


### PR DESCRIPTION
- struct Foo(T) {} was written out as
  struct Foo(T) { struct Foo {} }
- this broke recently due to the merge of a bugfix for #4107 (f8e7f05)
