### PR TITLE
Issue 2780 - Regression(2.027) ref Return Allows modification of immutable data

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3509,7 +3509,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
         else if (tbret->ty != Tvoid)
         {
             exp = exp->implicitCastTo(sc, tret);
-            exp = exp->optimize(WANTvalue);
+            if (!((TypeFunction *)fd->type)->isref)
+                exp = exp->optimize(WANTvalue);
         }
     }
     else if (fd->inferRetType)

--- a/test/fail_compilation/fail351.d
+++ b/test/fail_compilation/fail351.d
@@ -1,0 +1,14 @@
+// 2780
+
+struct Immutable {
+    immutable uint[2] num;
+
+    ref uint opIndex(uint index) immutable {
+        return num[index];
+    }
+}
+
+void main() {
+    immutable Immutable foo;
+    //foo[0]++;
+}


### PR DESCRIPTION
When ((Typefunction *)fd->type)->isref is true, we should refuse calling optimize() that removes CastExp.
