### PR TITLE
Issue 3836 - [TDPL] obligatory override attribute

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -482,7 +482,7 @@ void FuncDeclaration::semantic(Scope *sc)
 
 #if DMDV2
                 if (!isOverride())
-                    warning(loc, "overrides base class function %s, but is not marked with 'override'", fdv->toPrettyChars());
+                    error(loc, "overrides base class function %s, but is not marked with 'override'", fdv->toPrettyChars());
 #endif
 
                 if (fdv->toParent() == parent)

--- a/test/compilable/imports/test67a.d
+++ b/test/compilable/imports/test67a.d
@@ -11,7 +11,7 @@ class Base
 
 class Derived : Base
 {
-    SubI create() {
+    override SubI create() {
         return null;
     }
 }

--- a/test/runnable/delegate.d
+++ b/test/runnable/delegate.d
@@ -13,7 +13,7 @@ class Foo
 
 class Bar : Foo
 {
-   int bar(int i, char[] s) { return 5; }
+   override int bar(int i, char[] s) { return 5; }
 }
 
 void test1()
@@ -72,9 +72,9 @@ class Foo3
 
 class Bar3 : Foo3
 {
-    int bar(int i, char[] s) { return 48; }
+    override int bar(int i, char[] s) { return 48; }
 
-    int result() { return 48; }
+    override int result() { return 48; }
 
     void test2()
     {
@@ -268,7 +268,7 @@ class A13
 
 class B13 : A13
 {
-    int f()
+    override int f()
     {
         return 2;
     }

--- a/test/runnable/imports/test13a.d
+++ b/test/runnable/imports/test13a.d
@@ -35,7 +35,7 @@ template TPair(T, U) {
         public U right() {
             return this._right;
         }
-        public boolean opEquals(Object obj) {
+        override public boolean opEquals(Object obj) {
             Pair other = cast(Pair) obj;
             if (other !is null) {
                 return (left() == other.left()) && (right() == other.right());

--- a/test/runnable/inner.d
+++ b/test/runnable/inner.d
@@ -473,7 +473,7 @@ void test14()
 
     C14 c = new class C14
 	{
-	    void foo()
+	    override void foo()
 	    {
 		printf("in inner class\n");
 		assert(m == 3);
@@ -506,7 +506,7 @@ void test15()
 		assert(j == 2);
 	    }
 
-	    void foo()
+	    override void foo()
 	    {
 		printf("in inner class\n");
 		assert(m == 3);
@@ -758,7 +758,7 @@ class C24  {
     }
     I24 bar(){
         auto i = new class() I24 {
-            public void callI() {
+            override public void callI() {
                 foo();
             }
         };

--- a/test/runnable/interface1.d
+++ b/test/runnable/interface1.d
@@ -13,11 +13,11 @@ class A : D {
 
 class B : A, D
 {
-	int foo() { return 2; }
+	override int foo() { return 2; }
 }
 
 class C : B, D {
-	int foo() { return 3; }
+	override int foo() { return 3; }
 }
 
 void test1()
@@ -56,11 +56,11 @@ class A2 : D2 {
 }
 
 class B2 : A2 {
-	int foo() { printf("B2\n"); return 2; }
+	override int foo() { printf("B2\n"); return 2; }
 }
 
 class C2 : B2, D2 {
-	int foo() { printf("C2\n"); return 3; }
+	override int foo() { printf("C2\n"); return 3; }
 }
 
 void test2()

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -182,7 +182,7 @@ class A7 : D7 { int foo() { return 1; } }
 
 class B7 : A7
 {
-    int foo() { return 2; }
+    override int foo() { return 2; }
     D7 me() { return this; }
 }
 
@@ -333,7 +333,7 @@ class B12 : A12
 {
     IA12 ia;
 
-    IA12 clone()	// covariant return value
+    override IA12 clone()	// covariant return value
     out (result)
     {
 	printf("B12.clone()\n");
@@ -373,7 +373,7 @@ class I13
 
 class IA13 : I13
 {
-    int foo() { return 1; }
+    override int foo() { return 1; }
 }
 
 class A13
@@ -387,7 +387,7 @@ class B13 : A13
 {
     IA13 ia;
 
-    IA13 clone()
+    override IA13 clone()
     out (result)
     {
 	printf("B13.clone()\n");
@@ -505,7 +505,7 @@ class B16 : A16, I16
 
     this(int d) { data = d; }
 
-    B16 foo()
+    override B16 foo()
     {
 	printf("Called B.foo\n");
 	return new B16(69);

--- a/test/runnable/interface3.d
+++ b/test/runnable/interface3.d
@@ -40,7 +40,7 @@ class Writer : IWriter
 
 class FlushWriter : Writer
 {
-        IWriter put (I1 x)
+        override IWriter put (I1 x)
         {
                // have superclass handle the I1
                 super.put (x);

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -73,7 +73,7 @@ class Bar3
 
 class Code3 : Bar3
 {
-    int func() { printf("Code3.func()\n"); return 2; }
+    override int func() { printf("Code3.func()\n"); return 2; }
 }
 
 void test3()

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -126,7 +126,7 @@ void test4()
 
 class A5
 {
-    bool opEquals(Object o)
+    override bool opEquals(Object o)
     {
         printf("A.opEquals!(%p)\n", o);
         return 1;
@@ -148,7 +148,7 @@ class A5
 
 class B5 : A5
 {
-    bool opEquals(Object o)
+    override bool opEquals(Object o)
     {
         printf("B.opEquals!(%p)\n", o);
         return 1;

--- a/test/runnable/template1.d
+++ b/test/runnable/template1.d
@@ -1293,7 +1293,7 @@ class Abstract(T) : Interface!(T)
 
 class Concrete(T) : Abstract!(T)
 {
-    void foo52() { printf("Concrete.foo52(this = %p)\n", this); }
+    override void foo52() { printf("Concrete.foo52(this = %p)\n", this); }
 }
 
 class Sub(T) : Concrete!(T)

--- a/test/runnable/test11.d
+++ b/test/runnable/test11.d
@@ -459,7 +459,7 @@ class Abc22
 
 class Def22 : Abc22
 {
-    Bar22 test() { return new Bar22; }
+    override Bar22 test() { return new Bar22; }
 }
 
 void testx22(Abc22 a)
@@ -1021,7 +1021,7 @@ class A52
 
 class B52 : A52
 {
-    char get() { return 'B'; }
+    override char get() { return 'B'; }
 }
 
 void test52()
@@ -1068,7 +1068,7 @@ class A54
 
 class B54 : A54
 {
-    void a()
+    override void a()
     {
 	printf("B54.a\n");
 	assert(0);
@@ -1113,7 +1113,7 @@ class A56
 
 class B56 : A56
 {
-    int foo(int x = 7)
+    override int foo(int x = 7)
     {
 	printf("B56.x = %d\n", x);
 	return x;

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -1010,7 +1010,7 @@ class B46 : A46
 
 class C46 : B46
 {
-    char foo() { return 'c'; }
+    override char foo() { return 'c'; }
     char bar()
     {
 	return B46.foo();

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -282,11 +282,11 @@ class B14 : A14 {
 }
 
 class C14 : B14 {
-    int show( CA14 a ) { printf("C::show( CA14 )\n"); return 3; }
+    override int show( CA14 a ) { printf("C::show( CA14 )\n"); return 3; }
     alias B14.show show;
 
     alias B14.boat boat;
-    int boat( CA14 a ) { printf("C::boat( CA14 )\n"); return 3; }
+    override int boat( CA14 a ) { printf("C::boat( CA14 )\n"); return 3; }
 }
 
 class D14 : C14  {
@@ -855,7 +855,7 @@ class Abstract : Interface
 
 class Concrete : Abstract
 {
-    void foo42() { printf("Concrete.foo42(this = %p)\n", this); }
+    override void foo42() { printf("Concrete.foo42(this = %p)\n", this); }
 }
 
 class Sub : Concrete
@@ -1127,7 +1127,7 @@ class MyWriter : Writer
 {
     alias Writer.put put;
 
-    int put (bool x){ return 3; }
+    override int put (bool x){ return 3; }
 }
 
 void test55()

--- a/test/runnable/test16.d
+++ b/test/runnable/test16.d
@@ -140,7 +140,7 @@ class B3 : A3
 
 class C3 : B3
 {
-    void foo()
+    override void foo()
     {
 	printf("C.foo \n" );
 	super.foo();

--- a/test/runnable/test23.d
+++ b/test/runnable/test23.d
@@ -640,7 +640,7 @@ class UA {
 }
 
 class UB : UA {
-    B29 f() { return null; }
+    override B29 f() { return null; }
 }
 
 class A29

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -287,11 +287,11 @@ void test17()
 abstract class Pen { int foo(); }
 
 class Penfold : Pen {
-    int foo() { return 1; }
+    override int foo() { return 1; }
 }
 
 class Pinky : Pen {
-    int foo() { return 2; }
+    override int foo() { return 2; }
 }
 
 class Printer {
@@ -339,7 +339,7 @@ class B19 : A19
 {
     alias A19.s s;
     static void s(int i) {}
-    void s() {}
+    override void s() {}
 }
 
 class C19

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -2303,7 +2303,7 @@ class A143
 
 class B143 : A143
 {
-    void fill() { }
+    override void fill() { }
 }
 
 void test143()
@@ -2650,8 +2650,8 @@ class A164
 
 abstract class B164 : A164
 {
-    final B164 foo() { return null; }
-    final B164 foo() const { return null; }
+    override final B164 foo() { return null; }
+    override final B164 foo() const { return null; }
 }
 
 /***************************************************/
@@ -2664,8 +2664,8 @@ class A165
 
 abstract class B165 : A165
 {
-    final B165 foo() { return null; }
-    final const(B165) foo() const { return null; }
+    override final B165 foo() { return null; }
+    override final const(B165) foo() const { return null; }
 }
 
 /***************************************************/
@@ -2732,7 +2732,7 @@ class Class171 : Address {
 
     struct FwdStruct  {  }
 
-    int nameLen()    { return 0; }
+    override int nameLen()    { return 0; }
 }
 
 void test171 ()

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -111,7 +111,7 @@ class Foo6
 
 class FooX6 : Foo6
 {
-	int bar() { return y + 5; }
+	override int bar() { return y + 5; }
 }
 
 void test6()
@@ -231,7 +231,7 @@ class A12
 
 class B12: A12
 {
-    void foo() { super.foo(); }
+    override void foo() { super.foo(); }
 }
 
 void test12()

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -211,7 +211,7 @@ class C18
 
 class D18 : C18
 {
-    char[] foo() { return null; }
+    override char[] foo() { return null; }
 }
 
 void test18()

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -29,7 +29,7 @@ class A
 
 class B : A
 {
-     int foo(int i)
+     override int foo(int i)
      in
      {
 	float f;
@@ -83,7 +83,7 @@ class A2
 
 class B2 : A2
 {
-     int foo(int i)
+     override int foo(int i)
      in
      {
 	float f;
@@ -105,7 +105,7 @@ class B2 : A2
 
 class C : B2
 {
-     int foo(int i)
+     override int foo(int i)
      in
      {
 	float f;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -587,7 +587,7 @@ class A31
 
 class B31 : A31
 {
-    void foo(scope int* p) { }
+    override void foo(scope int* p) { }
 }
 
 void test31()
@@ -2968,7 +2968,7 @@ class A2540
 class B2540 : A2540
 {
     int b;
-    super.X foo() { return 1; }
+    override super.X foo() { return 1; }
 
     alias this athis;
     alias this.b thisb;


### PR DESCRIPTION
Turn overrides without the override keyword into an error.
Update tests to use override.

http://d.puremagic.com/issues/show_bug.cgi?id=3836
