### PR TITLE
Issue 4511 - Covariance problem

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3626,6 +3626,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
                 exp = exp->castTo(sc, exp->type->invariantOf());
             }
 
+            if (fd->tintro)
+                exp = exp->implicitCastTo(sc, fd->type->nextOf());
             exp = exp->implicitCastTo(sc, tret);
             if (!((TypeFunction *)fd->type)->isref)
                 exp = exp->optimize(WANTvalue);

--- a/test/fail_compilation/fail4511.d
+++ b/test/fail_compilation/fail4511.d
@@ -1,0 +1,16 @@
+void test72()
+{
+    class A {}
+    class B : A {}
+
+    class X
+    {
+        abstract A func();
+    }
+    class Y : X
+    {
+        B func() { return new A(); }
+    }
+}
+
+void main() {}


### PR DESCRIPTION
When returning an expression from an overriding function covariant, ensure the expression is castable to the derived type as well as the base type.

http://d.puremagic.com/issues/show_bug.cgi?id=4511
