### PR TITLE
Issue 3273 - Regression(2.031): struct invariant + dtor fails to compile (no line number)

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3592,15 +3592,6 @@ Statement *ReturnStatement::semantic(Scope *sc)
 
     if (exp)
     {
-        if (fd->returnLabel && tbret->ty != Tvoid)
-        {
-            assert(fd->vresult);
-            VarExp *v = new VarExp(0, fd->vresult);
-
-            exp = new ConstructExp(loc, v, exp);
-            exp = exp->semantic(sc);
-        }
-
         if (((TypeFunction *)fd->type)->isref && !fd->isCtorDeclaration())
         {   // Function returns a reference
             if (tbret->isMutable())
@@ -3615,6 +3606,15 @@ Statement *ReturnStatement::semantic(Scope *sc)
             //exp->dump(0);
             //exp->print();
             exp->checkEscape();
+        }
+
+        if (fd->returnLabel && tbret->ty != Tvoid)
+        {
+            assert(fd->vresult);
+            VarExp *v = new VarExp(0, fd->vresult);
+
+            exp = new ConstructExp(loc, v, exp);
+            exp = exp->semantic(sc);
         }
     }
 

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -192,6 +192,35 @@ void test5()
 }
 
 /*******************************************/
+// 3273
+
+// original case
+struct Bug3273
+{
+    ~this() {}
+    invariant() {}
+}
+
+// simplest case
+ref int func3273()
+out(r)
+{
+	// Regression check of issue 3390
+	static assert(!__traits(compiles, r = 1));
+}
+body
+{
+	static int dummy;
+	return dummy;
+}
+
+void test6()
+{
+	func3273() = 1;
+	assert(func3273() == 1);
+}
+
+/*******************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3273
On ref function with out contract, returned exp should be converted to modifiable lvalue BEFORE being assigned to vresult.
