### PR TITLE
restrict runnable/iasm.d to x86/32

### DIFF
--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -6,6 +6,9 @@
 
 import std.stdio;
 
+version (D_InlineAsm_X86)
+{
+
 struct M128 { int a,b,c,d; };
 struct M64 { int a,b; };
 
@@ -3922,3 +3925,10 @@ int main()
     printf("Success\n");
     return 0;
 }
+
+}
+else
+{
+    int main() { return 0; }
+}
+


### PR DESCRIPTION
Fix dmd test failures.  iasm.d is for 32 bits, iasm64.d is for 64 bits.

Alternative: should iasm.d be generic and 32bit specific parts be pulled into iasm32.d?
