### PR TITLE
Bug 4969: nothrow check can't handle multiple catches

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -4219,8 +4219,7 @@ int TryCatchStatement::blockExit(bool mustNotThrow)
         /* If we're catching Object, then there is no throwing
          */
         Identifier *id = c->type->toBasetype()->isClassHandle()->ident;
-        if (i == 0 &&
-            (id == Id::Object || id == Id::Throwable || id == Id::Exception))
+        if (id == Id::Object || id == Id::Throwable || id == Id::Exception)
         {
             result &= ~BEthrow;
         }

--- a/test/compilable/test4969.d
+++ b/test/compilable/test4969.d
@@ -1,0 +1,30 @@
+// PERMUTE_ARGS:
+
+class MyException : Exception
+{
+    this()
+    {
+        super("An exception!");
+    }
+}
+
+void throwAway()
+{
+    throw new MyException;
+}
+
+void cantthrow() nothrow
+{
+    try
+        throwAway();
+    catch(MyException me)
+        assert(0);
+    catch(Exception e)
+        assert(0);
+}
+
+void main()
+{
+}
+
+


### PR DESCRIPTION
Fixes [bug 4969](http://d.puremagic.com/issues/show_bug.cgi?id=4969).
