### PR TITLE
Issue 4785 & 5039 Allow auto return function with contracts

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -545,6 +545,7 @@ struct FuncDeclaration : Declaration
     Identifier *outId;                  // identifier for out statement
     VarDeclaration *vresult;            // variable corresponding to outId
     LabelDsymbol *returnLabel;          // where the return goes
+    Scope *scout;                       // out contract scope for vresult->semantic
 
     DsymbolTable *localsymtab;          // used to prevent symbols in different
                                         // scopes from having the same name
@@ -663,6 +664,7 @@ struct FuncDeclaration : Declaration
     void checkNestedReference(Scope *sc, Loc loc);
     int needsClosure();
     int hasNestedFrameRefs();
+    void buildResultVar();
     Statement *mergeFrequire(Statement *);
     Statement *mergeFensure(Statement *);
     Parameters *getParameters(int *pvarargs);

--- a/src/func.c
+++ b/src/func.c
@@ -49,6 +49,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     outId = NULL;
     vresult = NULL;
     returnLabel = NULL;
+    scout = NULL;
     fensure = NULL;
     fbody = NULL;
     localsymtab = NULL;
@@ -870,6 +871,12 @@ void FuncDeclaration::semantic3(Scope *sc)
     }
 #endif
 
+    if (!fbody && inferRetType && !type->nextOf())
+    {
+        error("has no function body with return type inference");
+        return;
+    }
+
     if (frequire)
     {
         for (int i = 0; i < foverrides.dim; i++)
@@ -1090,148 +1097,106 @@ void FuncDeclaration::semantic3(Scope *sc)
             }
         }
 
-        /* Do the semantic analysis on the [in] preconditions and
-         * [out] postconditions.
-         */
-        sc2->incontract++;
+        // Precondition invariant
+        Statement *fpreinv = NULL;
+        if (addPreInvariant())
+        {
+            Expression *e = NULL;
+            if (isDtorDeclaration())
+            {
+                // Call invariant directly only if it exists
+                InvariantDeclaration *inv = ad->inv;
+                ClassDeclaration *cd = ad->isClassDeclaration();
 
-        if (frequire)
-        {   /* frequire is composed of the [in] contracts
-             */
-            // BUG: need to error if accessing out parameters
-            // BUG: need to treat parameters as const
-            // BUG: need to disallow returns and throws
-            // BUG: verify that all in and ref parameters are read
-            frequire = frequire->semantic(sc2);
-            labtab = NULL;              // so body can't refer to labels
+                while (!inv && cd)
+                {
+                    cd = cd->baseClass;
+                    if (!cd)
+                        break;
+                    inv = cd->inv;
+                }
+                if (inv)
+                {
+                    e = new DsymbolExp(0, inv);
+                    e = new CallExp(0, e);
+                    e = e->semantic(sc2);
+                }
+            }
+            else
+            {   // Call invariant virtually
+                Expression *v = new ThisExp(0);
+                v->type = vthis->type;
+#if STRUCTTHISREF
+                if (ad->isStructDeclaration())
+                    v = v->addressOf(sc);
+#endif
+                Expression *se = new StringExp(0, (char *)"null this");
+                se = se->semantic(sc);
+                se->type = Type::tchar->arrayOf();
+                e = new AssertExp(loc, v, se);
+            }
+            if (e)
+                fpreinv = new ExpStatement(0, e);
+        }
+
+        // Postcondition invariant
+        Statement *fpostinv = NULL;
+        if (addPostInvariant())
+        {
+            Expression *e = NULL;
+            if (isCtorDeclaration())
+            {
+                // Call invariant directly only if it exists
+                InvariantDeclaration *inv = ad->inv;
+                ClassDeclaration *cd = ad->isClassDeclaration();
+
+                while (!inv && cd)
+                {
+                    cd = cd->baseClass;
+                    if (!cd)
+                        break;
+                    inv = cd->inv;
+                }
+                if (inv)
+                {
+                    e = new DsymbolExp(0, inv);
+                    e = new CallExp(0, e);
+                    e = e->semantic(sc2);
+                }
+            }
+            else
+            {   // Call invariant virtually
+                Expression *v = new ThisExp(0);
+                v->type = vthis->type;
+#if STRUCTTHISREF
+                if (ad->isStructDeclaration())
+                    v = v->addressOf(sc);
+#endif
+                e = new AssertExp(0, v);
+            }
+            if (e)
+                fpostinv = new ExpStatement(0, e);
         }
 
         if (fensure || addPostInvariant())
-        {   /* fensure is composed of the [out] contracts
-             */
-            if (!type->nextOf())                // if return type is inferred
-            {   /* This case:
-                 *   auto fp = function() out { } body { };
-                 * Can fix by doing semantic() onf fbody first.
-                 */
-                error("post conditions are not supported if the return type is inferred");
-                return;
+        {
+            if ((fensure && global.params.useOut) || fpostinv)
+            {   returnLabel = new LabelDsymbol(Id::returnLabel);
             }
 
+            // scope of out contract (need for vresult->semantic)
+            ScopeDsymbol *sym = new ScopeDsymbol();
+            sym->parent = sc2->scopesym;
+            scout = sc2->push(sym);
+        }
+
+        if (fbody)
+        {
             ScopeDsymbol *sym = new ScopeDsymbol();
             sym->parent = sc2->scopesym;
             sc2 = sc2->push(sym);
 
-            assert(type->nextOf());
-            if (type->nextOf()->ty == Tvoid)
-            {
-                if (outId)
-                    error("void functions have no result");
-            }
-            else
-            {
-                if (!outId)
-                    outId = Id::result;         // provide a default
-            }
-
-            if (outId)
-            {   // Declare result variable
-                Loc loc = this->loc;
-
-                if (fensure)
-                    loc = fensure->loc;
-
-                VarDeclaration *v = new VarDeclaration(loc, type->nextOf(), outId, NULL);
-                v->noscope = 1;
-                v->storage_class |= STCresult;
-#if DMDV2
-                if (!isVirtual())
-                    v->storage_class |= STCconst;
-                if (f->isref)
-                {
-                    v->storage_class |= STCref | STCforeach;
-                }
-#endif
-                sc2->incontract--;
-                v->semantic(sc2);
-                sc2->incontract++;
-                if (!sc2->insert(v))
-                    error("out result %s is already defined", v->toChars());
-                v->parent = this;
-                vresult = v;
-
-                // vresult gets initialized with the function return value
-                // in ReturnStatement::semantic()
-            }
-
-            // BUG: need to treat parameters as const
-            // BUG: need to disallow returns and throws
-            if (fensure)
-            {   fensure = fensure->semantic(sc2);
-                labtab = NULL;          // so body can't refer to labels
-            }
-
-            if (!global.params.useOut)
-            {   fensure = NULL;         // discard
-                vresult = NULL;
-            }
-
-            // Postcondition invariant
-            if (addPostInvariant())
-            {
-                Expression *e = NULL;
-                if (isCtorDeclaration())
-                {
-                    // Call invariant directly only if it exists
-                    InvariantDeclaration *inv = ad->inv;
-                    ClassDeclaration *cd = ad->isClassDeclaration();
-
-                    while (!inv && cd)
-                    {
-                        cd = cd->baseClass;
-                        if (!cd)
-                            break;
-                        inv = cd->inv;
-                    }
-                    if (inv)
-                    {
-                        e = new DsymbolExp(0, inv);
-                        e = new CallExp(0, e);
-                        e = e->semantic(sc2);
-                    }
-                }
-                else
-                {   // Call invariant virtually
-                    Expression *v = new ThisExp(0);
-                    v->type = vthis->type;
-#if STRUCTTHISREF
-                    if (ad->isStructDeclaration())
-                        v = v->addressOf(sc);
-#endif
-                    e = new AssertExp(0, v);
-                }
-                if (e)
-                {
-                    ExpStatement *s = new ExpStatement(0, e);
-                    if (fensure)
-                        fensure = new CompoundStatement(0, s, fensure);
-                    else
-                        fensure = s;
-                }
-            }
-
-            if (fensure)
-            {   returnLabel = new LabelDsymbol(Id::returnLabel);
-                LabelStatement *ls = new LabelStatement(0, Id::returnLabel, fensure);
-                returnLabel->statement = ls;
-            }
-            sc2 = sc2->pop();
-        }
-
-        sc2->incontract--;
-
-        if (fbody)
-        {   AggregateDeclaration *ad = isAggregateMember();
+            AggregateDeclaration *ad = isAggregateMember();
 
             /* If this is a class constructor
              */
@@ -1397,6 +1362,66 @@ void FuncDeclaration::semantic3(Scope *sc)
                     }
                 }
             }
+
+            sc2 = sc2->pop();
+        }
+
+        Statement *freq = frequire;
+        Statement *fens = fensure;
+
+        /* Do the semantic analysis on the [in] preconditions and
+         * [out] postconditions.
+         */
+        if (freq)
+        {   /* frequire is composed of the [in] contracts
+             */
+            ScopeDsymbol *sym = new ScopeDsymbol();
+            sym->parent = sc2->scopesym;
+            sc2 = sc2->push(sym);
+            sc2->incontract++;
+
+            // BUG: need to error if accessing out parameters
+            // BUG: need to treat parameters as const
+            // BUG: need to disallow returns and throws
+            // BUG: verify that all in and ref parameters are read
+            DsymbolTable *labtab_save = labtab;
+            labtab = NULL;              // so in contract can't refer to out/body labels
+            freq = freq->semantic(sc2);
+            labtab = labtab_save;
+
+            sc2->incontract--;
+            sc2 = sc2->pop();
+
+            if (!global.params.useIn)
+                freq = NULL;
+        }
+
+        if (fens)
+        {   /* fensure is composed of the [out] contracts
+             */
+            if (type->nextOf()->ty == Tvoid && outId)
+            {
+                error("void functions have no result");
+            }
+
+            if (type->nextOf()->ty != Tvoid)
+                buildResultVar();
+
+            sc2 = scout;    //push
+            sc2->incontract++;
+
+            // BUG: need to treat parameters as const
+            // BUG: need to disallow returns and throws
+            DsymbolTable *labtab_save = labtab;
+            labtab = NULL;              // so out contract can't refer to in/body labels
+            fens = fens->semantic(sc2);
+            labtab = labtab_save;
+
+            sc2->incontract--;
+            sc2 = sc2->pop();
+
+            if (!global.params.useOut)
+                fens = NULL;
         }
 
         {
@@ -1497,60 +1522,29 @@ void FuncDeclaration::semantic3(Scope *sc)
 
             // Merge contracts together with body into one compound statement
 
-            if (frequire && global.params.useIn)
-            {   frequire->incontract = 1;
-                a->push(frequire);
-            }
-
-            // Precondition invariant
-            if (addPreInvariant())
+            if (freq || fpreinv)
             {
-                Expression *e = NULL;
-                if (isDtorDeclaration())
-                {
-                    // Call invariant directly only if it exists
-                    InvariantDeclaration *inv = ad->inv;
-                    ClassDeclaration *cd = ad->isClassDeclaration();
+                if (!freq)
+                    freq = fpreinv;
+                else if (fpreinv)
+                    freq = new CompoundStatement(0, freq, fpreinv);
 
-                    while (!inv && cd)
-                    {
-                        cd = cd->baseClass;
-                        if (!cd)
-                            break;
-                        inv = cd->inv;
-                    }
-                    if (inv)
-                    {
-                        e = new DsymbolExp(0, inv);
-                        e = new CallExp(0, e);
-                        e = e->semantic(sc2);
-                    }
-                }
-                else
-                {   // Call invariant virtually
-                    Expression *v = new ThisExp(0);
-                    v->type = vthis->type;
-#if STRUCTTHISREF
-                    if (ad->isStructDeclaration())
-                        v = v->addressOf(sc);
-#endif
-                    Expression *se = new StringExp(0, (char *)"null this");
-                    se = se->semantic(sc);
-                    se->type = Type::tchar->arrayOf();
-                    e = new AssertExp(loc, v, se);
-                }
-                if (e)
-                {
-                    ExpStatement *s = new ExpStatement(0, e);
-                    a->push(s);
-                }
+                freq->incontract = 1;
+                a->push(freq);
             }
 
             if (fbody)
                 a->push(fbody);
 
-            if (fensure)
+            if (fens || fpostinv)
             {
+                if (!fens)
+                    fens = fpostinv;
+                else if (fpostinv)
+                    fens = new CompoundStatement(0, fpostinv, fens);
+
+                LabelStatement *ls = new LabelStatement(0, Id::returnLabel, fens);
+                returnLabel->statement = ls;
                 a->push(returnLabel->statement);
 
                 if (type->nextOf()->ty != Tvoid)
@@ -1817,6 +1811,48 @@ void FuncDeclaration::bodyToCBuffer(OutBuffer *buf, HdrGenState *hgs)
     {   buf->writeByte(';');
         buf->writenl();
     }
+}
+
+/****************************************************
+ * Declare result variable lazily.
+ */
+
+void FuncDeclaration::buildResultVar()
+{
+    if (vresult)
+        return;
+
+    assert(type->nextOf());
+    assert(type->nextOf()->toBasetype()->ty != Tvoid);
+    TypeFunction *tf = (TypeFunction *)(type);
+
+    Loc loc = this->loc;
+
+    if (fensure)
+        loc = fensure->loc;
+
+    if (!outId)
+        outId = Id::result;         // provide a default
+
+    VarDeclaration *v = new VarDeclaration(loc, type->nextOf(), outId, NULL);
+    v->noscope = 1;
+    v->storage_class |= STCresult;
+#if DMDV2
+    if (!isVirtual())
+        v->storage_class |= STCconst;
+    if (tf->isref)
+    {
+        v->storage_class |= STCref | STCforeach;
+    }
+#endif
+    v->semantic(scout);
+    if (!scout->insert(v))
+        error("out result %s is already defined", v->toChars());
+    v->parent = this;
+    vresult = v;
+
+    // vresult gets initialized with the function return value
+    // in ReturnStatement::semantic()
 }
 
 /****************************************************

--- a/src/parse.c
+++ b/src/parse.c
@@ -454,7 +454,10 @@ Dsymbols *Parser::parseDeclDefs(int once)
                     ((tk = peek(tk)), 1) &&
                     skipAttributes(tk, &tk) &&
                     (tk->value == TOKlparen ||
-                     tk->value == TOKlcurly)
+                     tk->value == TOKlcurly ||
+                     tk->value == TOKin ||
+                     tk->value == TOKout ||
+                     tk->value == TOKbody)
                    )
                 {
                     a = parseDeclarations(storageClass, comment);
@@ -2850,7 +2853,10 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, unsigned char *c
         ((tk = peek(tk)), 1) &&
         skipAttributes(tk, &tk) &&
         (tk->value == TOKlparen ||
-         tk->value == TOKlcurly)
+         tk->value == TOKlcurly ||
+         tk->value == TOKin ||
+         tk->value == TOKout ||
+         tk->value == TOKbody)
        )
     {
         ts = NULL;

--- a/src/statement.c
+++ b/src/statement.c
@@ -3768,7 +3768,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
 
         if (fd->returnLabel && tbret->ty != Tvoid)
         {
-            assert(fd->vresult);
+            fd->buildResultVar();
             VarExp *v = new VarExp(0, fd->vresult);
 
             assert(eorg);

--- a/test/fail_compilation/fail317.d
+++ b/test/fail_compilation/fail317.d
@@ -1,12 +1,6 @@
-void main() {
-    auto f1 = function() body { }; // fine
-    auto f2 = function() in { } body { }; // fine
-    auto f3 = function() out { } body { }; // error
-    auto f4 = function() in { } out { } body { }; // error
-/+
-    auto d1 = delegate() body { }; // fine
-    delegate() in { } body { }; // fine
-    delegate() out { } body { }; // error
-    delegate() in { } out { } body { }; // error
-+/
+interface I
+{
+    auto f()
+    in{}
+    out{}
 }

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -242,6 +242,31 @@ void test6()
 +/
 
 /*******************************************/
+// 4785
+
+int cnt;
+
+auto foo4785()
+in{
+	int r;
+	++cnt;
+}
+out(r){
+	assert(r == 10);
+	++cnt;
+}body{
+	++cnt;
+	int r = 10;
+	return r;
+}
+void test4785()
+{
+	cnt = 0;
+	assert(foo4785() == 10);
+	assert(cnt == 3);
+}
+
+/*******************************************/
 // 7218
 
 void test7218()
@@ -262,6 +287,7 @@ int main()
     test4();
     test5();
 //    test6();
+    test4785();
     test7218();
 
     printf("Success\n");

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -242,6 +242,68 @@ void test6()
 +/
 
 /*******************************************/
+
+auto test7foo()
+in{
+	++cnt;
+}body{
+	++cnt;
+	return "str";
+}
+
+void test7()
+{
+	cnt = 0;
+	assert(test7foo() == "str");
+	assert(cnt == 2);
+}
+
+/*******************************************/
+
+auto foo8()
+out(r){
+	++cnt;
+	assert(r == 10);
+}body{
+	++cnt;
+	return 10;
+}
+
+auto bar8()
+out{
+	++cnt;
+}body{
+	++cnt;
+}
+
+void test8()
+{
+	cnt = 0;
+	assert(foo8() == 10);
+	assert(cnt == 2);
+
+	cnt = 0;
+	bar8();
+	assert(cnt == 2);
+}
+
+/*******************************************/
+// from fail317
+
+void test9()
+{
+    auto f1 = function() body { }; // fine
+    auto f2 = function() in { } body { }; // fine
+    auto f3 = function() out { } body { }; // error
+    auto f4 = function() in { } out { } body { }; // error
+
+    auto d1 = delegate() body { }; // fine
+    auto d2 = delegate() in { } body { }; // fine
+    auto d3 = delegate() out { } body { }; // error
+    auto d4 = delegate() in { } out { } body { }; // error
+}
+
+/*******************************************/
 // 4785
 
 int cnt;
@@ -267,6 +329,21 @@ void test4785()
 }
 
 /*******************************************/
+// 5039
+
+class C5039 {
+    int x;
+
+    invariant() {
+        assert( x < int.max );
+    }
+
+    auto foo() {
+        return x;
+    }
+}
+
+/*******************************************/
 // 7218
 
 void test7218()
@@ -287,6 +364,9 @@ int main()
     test4();
     test5();
 //    test6();
+    test7();
+    test8();
+    test9();
     test4785();
     test7218();
 


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=4785">Issue 4785</a> - auto return of a function with in contract
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5039">Issue 5039</a> - Cannot use invariant() with auto methods
Fix parser and change function in/out/body semantic order.
