### PR TITLE
Cleanup whitespace after fiddling with permuteArgs

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -119,7 +119,7 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     }
 
     // clean up extra spaces
-    testArgs.permuteArgs = replace(testArgs.permuteArgs, "  ", " ");
+    testArgs.permuteArgs = strip(replace(testArgs.permuteArgs, "  ", " "));
 
     findTestParameter(file, "EXECUTE_ARGS", testArgs.executeArgs);
 


### PR DESCRIPTION
This cuts the number of dmd tests in half (roughly) for win and freebsd.  There's an extra blank argument that gets into the combination of args, doubling them.
