### PR TITLE
CTFE: allow pointer slicing

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -304,13 +304,13 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
     /* Save the values of the local variables used
      */
     Expressions valueSaves;
-    if (istate && !isNested())
+    if (istate)
     {
         //printf("saving local variables...\n");
         valueSaves.setDim(istate->vars.dim);
         for (size_t i = 0; i < istate->vars.dim; i++)
         {   VarDeclaration *v = (VarDeclaration *)istate->vars.data[i];
-            if (v)
+            if (v && v->parent == this)
             {
                 //printf("\tsaving [%d] %s = %s\n", i, v->toChars(), v->getValue() ? v->getValue()->toChars() : "");
                 valueSaves.data[i] = v->getValue();
@@ -358,14 +358,14 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
     if (vresult)
         vresult->setValueNull();
 
-    if (istate && !isNested())
+    if (istate)
     {
         /* Restore the variable values
          */
         //printf("restoring local variables...\n");
         for (size_t i = 0; i < istate->vars.dim; i++)
         {   VarDeclaration *v = (VarDeclaration *)istate->vars.data[i];
-            if (v)
+            if (v && v->parent == this)
             {   v->setValueWithoutChecking((Expression *)valueSaves.data[i]);
                 //printf("\trestoring [%d] %s = %s\n", i, v->toChars(), v->getValue() ? v->getValue()->toChars() : "");
             }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4261,10 +4261,7 @@ Expression *InExp::interpret(InterState *istate, CtfeGoal goal)
     if (e2 == EXP_CANT_INTERPRET)
         return e2;
     if (e2->op == TOKnull)
-    {
-        error("cannot use 'in' on a null associative array");
-        return EXP_CANT_INTERPRET;
-    }
+        return new NullExp(loc, type);
     if (e2->op != TOKassocarrayliteral)
     {
         error(" %s cannot be interpreted at compile time", toChars());

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4277,6 +4277,8 @@ Expression *CastExp::interpret(InterState *istate, CtfeGoal goal)
     {
         return new IntegerExp(loc, e1->op != TOKnull, to);
     }
+    if (e1->op == TOKnull)
+        return paintTypeOntoLiteral(to, e1);
 
     e = Cast(type, to, e1);
     if (e == EXP_CANT_INTERPRET)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2899,7 +2899,6 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         }
         else
             returnValue = newval;
-
         if (e1->op == TOKarraylength)
         {
             size_t oldlen = oldval->toInteger();
@@ -2929,7 +2928,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
                 size_t copylen = oldlen < newlen ? oldlen : newlen;
                 ArrayLiteralExp *ae = (ArrayLiteralExp *)oldval;
                 for (size_t i = 0; i < copylen; i++)
-                     elements->data[i] = ae->elements->data[i];
+                    elements->data[i] = ae->elements->data[i];
                 if (elemType->ty == Tstruct || elemType->ty == Tsarray)
                 {   /* If it is an aggregate literal representing a value type,
                      * we need to create a unique copy for each element
@@ -2945,6 +2944,9 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
                 ArrayLiteralExp *aae = new ArrayLiteralExp(0, elements);
                 aae->type = t;
                 newval = aae;
+                // We have changed it into a reference assignment
+                // Note that returnValue is still the new length.
+                wantRef = true;
             }
             else
             {
@@ -3009,8 +3011,9 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
 
     // ---------------------------------------
     //      Deal with reference assignment
+    // (We already have 'newval' for arraylength operations)
     // ---------------------------------------
-    if (wantRef)
+    if (wantRef && this->e1->op != TOKarraylength)
     {
         newval = this->e2->interpret(istate, ctfeNeedLvalue);
         if (newval == EXP_CANT_INTERPRET)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1758,3 +1758,14 @@ bool bug4065(string s) {
 static assert(!bug4065("xx"));
 static assert(bug4065("aa"));
 static assert(bug4065("bb"));
+
+/**************************************************
+    Pointers in ? :
+**************************************************/
+
+static assert(
+{
+    int[2] x;
+    int *p = &x[1];
+    return p ? true: false;
+}());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -704,6 +704,21 @@ auto bug5852(const(string) s) {
 static assert(bug5852("abc")==3);
 
 /*******************************************
+    Set array length
+*******************************************/
+
+static assert(
+{
+    struct W{ int [] z;}
+    W w;
+    w.z.length = 2;
+    assert(w.z.length == 2);
+    w.z.length = 6;
+    assert(w.z.length == 6);
+    return true;
+}());
+
+/*******************************************
              Bug 5671
 *******************************************/
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1769,3 +1769,27 @@ static assert(
     int *p = &x[1];
     return p ? true: false;
 }());
+
+/**************************************************
+    Pointer slicing
+**************************************************/
+
+int ptrSlice()
+{
+    auto arr = new int[5];
+    int * x = &arr[0];
+    int [] y = x[0..5];
+    x[1..3] = 6;
+    ++x;
+    x[1..3] = 14;
+    assert(arr[1]==6);
+    assert(arr[2]==14);
+    x[-1..4]= 5;
+    int [] z = arr[1..2];
+    z.length = 4;
+    z[$-1] = 17;
+    assert(arr.length ==5);
+    return 2;
+}
+
+static assert(ptrSlice()==2);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -238,7 +238,24 @@ struct Matrix5248 {
 
 static assert(Matrix5248().Compile());
 
-// Interpreter code coverage tests
+/**************************************************
+    Bug 6164
+**************************************************/
+
+int bug6164(){
+    int[] ctfe2(int n){
+        int[] r=[];
+        if(n!=0) r~=[1] ~ ctfe2(n-1);
+        return r;
+    }
+    return ctfe2(2).length;
+}
+static assert(bug6164()==2);
+
+/**************************************************
+    Interpreter code coverage tests
+**************************************************/
+
 int cov1(int a)
 {
    a %= 15382;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1751,6 +1751,8 @@ bool bug4065(string s) {
     else if (s=="bb")
         assert(*p == 2);
     else assert(!p);
+    int[string] zz;
+    assert(!("xx" in zz));
     bool c = !p;
     return cast(bool)(s in aa);
 }


### PR DESCRIPTION
Attempting to slice a pointer in CTFE was causing either an ICE, or wrong code.
This pull request also fixes   p ? a : b, where p is a pointer, and 'x in AA', where AA is null.
Also fixes
6164 [CTFE] Local arrays in a recursive local function behave funny
