### PR TITLE
Fix win32 dmd to not emit a map file unless asked for with -map

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -130,7 +130,7 @@ int runLINK()
 
         writeFilename(&cmdbuf, p);
     }
-    else if (global.params.run)
+    else
         cmdbuf.writestring("nul");
     cmdbuf.writeByte(',');
 


### PR DESCRIPTION
Ok, I must have only tested the first case of pull 6 with linux.  The default for the win32 dmd prior to this pull is to generate a map file all the time.  It's the only platform to do that.  This pull request turns that off.  To get a map file, you must specify -map now.
