### PR TITLE
CTFE: Fix D1 regression in test suite induced by CTFE pointer commits

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3489,7 +3489,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             return EXP_CANT_INTERPRET;
         }
         if (upperbound == lowerbound)
-            return returnValue;
+            return newval;
 
         Expression *aggregate = resolveReferences(((SliceExp *)e1)->e1, istate->localThis);
         int firstIndex = lowerbound;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1439,7 +1439,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
             if (e && e != EXP_CANT_INTERPRET)
                 v->setValueWithoutChecking(e);
         }
-        else if ((v->isCTFE() || (!v->isDataseg() && istate)) && !v->getValue())
+        else if (v->isCTFE() && !v->getValue())
         {
             if (v->init && v->type->size() != 0)
             {

--- a/src/statement.h
+++ b/src/statement.h
@@ -47,6 +47,7 @@ struct TryCatchStatement;
 struct TryFinallyStatement;
 struct CaseStatement;
 struct DefaultStatement;
+struct LabelStatement;
 struct HdrGenState;
 struct InterState;
 
@@ -122,6 +123,7 @@ struct Statement : Object
     virtual IfStatement *isIfStatement() { return NULL; }
     virtual CaseStatement *isCaseStatement() { return NULL; }
     virtual DefaultStatement *isDefaultStatement() { return NULL; }
+    virtual LabelStatement *isLabelStatement() { return NULL; }
 };
 
 struct PeelStatement : Statement
@@ -811,6 +813,7 @@ struct LabelStatement : Statement
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *inlineScan(InlineScanState *iss);
+    LabelStatement *isLabelStatement() { return this; }
 
     void toIR(IRState *irs);
 };


### PR DESCRIPTION
Also fixes:
4448 labeled break doesn't work in CTFE
5936 Invalid code with nested functions in CTFE

(The labelled break and continue support uses the simplest case of the existing CTFE 'goto' mechanism -- it just keeps breaking at each level, until it finds the gotoTarget).
