### PR TITLE
Module-level protection of user-defined types

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -436,6 +436,7 @@ void AliasDeclaration::semantic(Scope *sc)
 #endif
 
     storage_class |= sc->stc & STCdeprecated;
+    protection = sc->protection;
 
     // Given:
     //  alias foo.bar.abc def;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -31,6 +31,7 @@
 #include "import.h"
 #include "template.h"
 #include "attrib.h"
+#include "enum.h"
 
 /****************************** Dsymbol ******************************/
 
@@ -850,11 +851,27 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
 
         if (s)
         {
-            Declaration *d = s->isDeclaration();
-            if (d && d->protection == PROTprivate &&
-                !d->parent->isTemplateMixin() &&
-                !(flags & 2))
-                error(loc, "%s is private", d->toPrettyChars());
+            if (!(flags & 2))
+            {   Declaration *d = s->isDeclaration();
+                if (d && d->protection == PROTprivate &&
+                    !d->parent->isTemplateMixin())
+                    error(loc, "%s is private", d->toPrettyChars());
+
+                AggregateDeclaration *ad = s->isAggregateDeclaration();
+                if (ad && ad->protection == PROTprivate &&
+                    !ad->parent->isTemplateMixin())
+                    error(loc, "%s is private", ad->toPrettyChars());
+
+                EnumDeclaration *ed = s->isEnumDeclaration();
+                if (ed && ed->protection == PROTprivate &&
+                    !ed->parent->isTemplateMixin())
+                    error(loc, "%s is private", ed->toPrettyChars());
+
+                TemplateDeclaration *td = s->isTemplateDeclaration();
+                if (td && td->protection == PROTprivate &&
+                    !td->parent->isTemplateMixin())
+                    error(loc, "%s is private", td->toPrettyChars());
+            }
         }
     }
     return s;

--- a/src/enum.c
+++ b/src/enum.c
@@ -115,6 +115,7 @@ void EnumDeclaration::semantic(Scope *sc)
         isdeprecated = 1;
 
     parent = sc->parent;
+    protection = sc->protection;
 
     /* The separate, and distinct, cases are:
      *  1. enum { ... }

--- a/src/enum.h
+++ b/src/enum.h
@@ -29,6 +29,7 @@ struct EnumDeclaration : ScopeDsymbol
      */
     Type *type;                 // the TypeEnum
     Type *memtype;              // type of the members
+    enum PROT protection;
 
 #if DMDV1
     dinteger_t maxval;

--- a/src/template.c
+++ b/src/template.c
@@ -479,6 +479,8 @@ void TemplateDeclaration::semantic(Scope *sc)
     if (!parent)
         parent = sc->parent;
 
+    protection = sc->protection;
+
     if (global.params.doDocComments)
     {
         origParameters = new TemplateParameters();

--- a/src/template.h
+++ b/src/template.h
@@ -63,6 +63,7 @@ struct TemplateDeclaration : ScopeDsymbol
 
     int literal;                // this template declaration is a literal
     int ismixin;                // template declaration is only to be used as a mixin
+    enum PROT protection;
 
     struct Previous
     {   Previous *prev;

--- a/test/compilable/imports/protectionimp.d
+++ b/test/compilable/imports/protectionimp.d
@@ -1,0 +1,22 @@
+private
+{
+  class privC {}
+  struct privS {}
+  interface privI {}
+  union privU {}
+  enum privE { foo }
+  void privF() {}
+  mixin template privMT() {}
+
+  class privTC(T) {}
+  struct privTS(T) {}
+  interface privTI(T) {}
+  union privTU(T) {}
+  void privTF(T)() {}
+}
+
+void publF(T)() {}
+void publFA(alias A)() {}
+private alias privC privA;
+
+public mixin template publMT() {}

--- a/test/compilable/protection.d
+++ b/test/compilable/protection.d
@@ -1,0 +1,74 @@
+import protectionimp;
+
+private
+{
+  class localC {}
+  struct localS {}
+  union localU {}
+  interface localI {}
+  enum localE { foo }
+  void localF() {}
+  mixin template localMT() {}
+
+  class localTC(T) {}
+  struct localTS(T) {}
+  union localTU(T) {}
+  interface localTI(T) {}
+  void localTF(T)() {}
+}
+
+void main()
+{
+  // Private non-template declarations
+  static assert(!__traits(compiles, privF()));
+  static assert(!__traits(compiles, privC));
+  static assert(!__traits(compiles, privS));
+  static assert(!__traits(compiles, privU));
+  static assert(!__traits(compiles, privI));
+  static assert(!__traits(compiles, privE));
+  static assert(!__traits(compiles, privMT));
+
+  // Private local non-template declarations.
+  static assert(__traits(compiles, localF()));
+  static assert(__traits(compiles, localC));
+  static assert(__traits(compiles, localS));
+  static assert(__traits(compiles, localU));
+  static assert(__traits(compiles, localI));
+  static assert(__traits(compiles, localE));
+  static assert(__traits(compiles, localMT));
+
+  // Private template declarations.
+  static assert(!__traits(compiles, privTC!int));
+  static assert(!__traits(compiles, privTS!int));
+  static assert(!__traits(compiles, privTU!int));
+  static assert(!__traits(compiles, privTI!int));
+  static assert(!__traits(compiles, privTF!int()));
+
+  // Private local template declarations.
+  static assert(__traits(compiles, localTC!int));
+  static assert(__traits(compiles, localTS!int));
+  static assert(__traits(compiles, localTU!int));
+  static assert(__traits(compiles, localTI!int));
+  static assert(__traits(compiles, localTF!int()));
+
+  // Public template function with private type parameters.
+  static assert(!__traits(compiles, publF!privC()));
+  static assert(!__traits(compiles, publF!privS()));
+  static assert(!__traits(compiles, publF!privU()));
+  static assert(!__traits(compiles, publF!privI()));
+  static assert(!__traits(compiles, publF!privE()));
+
+  // Public template function with private alias parameters.
+  static assert(!__traits(compiles, publFA!privC()));
+  static assert(!__traits(compiles, publFA!privS()));
+  static assert(!__traits(compiles, publFA!privU()));
+  static assert(!__traits(compiles, publFA!privI()));
+  static assert(!__traits(compiles, publFA!privE()));
+
+  // Private alias.
+  static assert(!__traits(compiles, privA));
+
+  // Public template mixin.
+  static assert(__traits(compiles, publMT));
+}
+

--- a/test/compilable/protection.d
+++ b/test/compilable/protection.d
@@ -1,4 +1,4 @@
-import protectionimp;
+import imports.protectionimp;
 
 private
 {


### PR DESCRIPTION
This adds module level protection for user-defined types. Requires my druntime changes due to the selective imports bug (https://github.com/D-Programming-Language/druntime/pull/94)

Fixes:
http://d.puremagic.com/issues/show_bug.cgi?id=2775
http://d.puremagic.com/issues/show_bug.cgi?id=6013
http://d.puremagic.com/issues/show_bug.cgi?id=6180 (kind of, Andrej wants protection to be used in overload resolution as well, but my fix doesn't do that)
(Edit: another)
http://d.puremagic.com/issues/show_bug.cgi?id=2830
