### PR TITLE
Removed lots of unused variables

### DIFF
--- a/src/backend/blockopt.c
+++ b/src/backend/blockopt.c
@@ -221,7 +221,6 @@ void block_goto(block *bgoto,block *bnew)
 
 void block_ptr()
 {   block *b;
-    unsigned i;
 
 /*    dbg_printf("block_ptr()\n");*/
 
@@ -293,10 +292,7 @@ void block_visit(block *b)
  */
 
 void block_compbcount()
-{   block *b;
-    list_t bl;
-    int again;
-
+{
     block_clearvisit();
     block_visit(startblock);                    // visit all reachable blocks
     elimblks();                                 // eliminate unvisited blocks
@@ -701,7 +697,7 @@ void brcombine()
             /* Replace with [(e1 && e2),e3]                             */
             bc = b->BC;
             if (bc == BCiftrue)
-            {   unsigned char bc2,bc3;
+            {   unsigned char bc2;
 
                 b2 = list_block(b->Bsucc);
                 b3 = list_block(list_next(b->Bsucc));
@@ -1093,7 +1089,7 @@ STATIC void brrear()
  */
 
 void compdfo()
-{ register block *b;
+{
   register int i;
 
   cmes("compdfo()\n");
@@ -1324,7 +1320,6 @@ STATIC int mergeblks()
 STATIC void blident()
 {   block *bn;
     block *bnext;
-    block *btry;
 
     cmes("blident()\n");
     assert(startblock);
@@ -1867,7 +1862,6 @@ STATIC void block_check()
 STATIC void brtailrecursion()
 {   block *b;
     block *bs;
-    list_t bl;
     elem **pe;
 
 #if SCPP
@@ -1980,7 +1974,6 @@ STATIC elem * assignparams(elem **pe,int *psi,elem **pe2)
         Symbol *sp;
         Symbol *s;
         int op;
-        unsigned numbytes;
         elem *es;
         type *t;
 

--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -1594,7 +1594,6 @@ code *loadComplex(elem *e)
 
 code *load87(elem *e,unsigned eoffset,regm_t *pretregs,elem *eleft,int op)
 {
-        elem *e1;
         code *ccomma,*c,*c2,*cpush;
         code cs;
         regm_t retregs;
@@ -1790,8 +1789,7 @@ code *load87(elem *e,unsigned eoffset,regm_t *pretregs,elem *eleft,int op)
                 break;
 
             case OPu16_d:
-            {   regm_t mswregs;
-
+            {
                 /* This opcode should never be generated        */
                 /* (probably shouldn't be for 16 bit code too)  */
                 assert(!I32);
@@ -2188,7 +2186,6 @@ code *cnvteq87(elem *e,regm_t *pretregs)
         code cs;
         unsigned op1;
         unsigned op2;
-        tym_t ty1;
 
         assert(e->Eoper == OPeq);
         assert(!*pretregs);
@@ -2373,7 +2370,6 @@ code *opass87(elem *e,regm_t *pretregs)
 code *opmod_complex87(elem *e,regm_t *pretregs)
 {
     regm_t retregs;
-    regm_t idxregs;
     code *cl,*cr,*c;
     code cs;
     tym_t ty1;
@@ -2765,7 +2761,6 @@ code *cdnegass87(elem *e,regm_t *pretregs)
 {   regm_t retregs;
     tym_t tyml;
     unsigned op;
-    targ_long val;
     code *cl,*cr,*c,cs;
     elem *e1;
     int sz;
@@ -3073,9 +3068,8 @@ code *cdrndtol(elem *e,regm_t *pretregs)
 {
         regm_t retregs;
         code *c1,*c2;
-        unsigned mf,reg;
+        unsigned reg;
         tym_t tym;
-        int clib;
         unsigned sz;
         unsigned char op1,op2;
 
@@ -3387,7 +3381,6 @@ __body
 
 code *fixresult_complex87(elem *e,regm_t retregs,regm_t *pretregs)
 {
-    regm_t regm;
     tym_t tym;
     code *c1,*c2;
     unsigned sz;
@@ -3541,7 +3534,6 @@ __body
     unsigned sz;
     unsigned char ldop;
     regm_t retregs;
-    symbol *s;
     int i;
 
     //printf("cload87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -607,6 +607,9 @@ void stackoffsets(int flags)
     targ_size_t Amax,sz;
     unsigned alignsize;
     int offi;
+#if AUTONEST
+    targ_size_t offstack[20];
+#endif
     vec_t tbl = NULL;
 
 

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -607,7 +607,6 @@ void stackoffsets(int flags)
     targ_size_t Amax,sz;
     unsigned alignsize;
     int offi;
-    targ_size_t offstack[20];
     vec_t tbl = NULL;
 
 
@@ -1733,8 +1732,6 @@ STATIC void resetEcomsub(elem *e)
 
 int isregvar(elem *e,regm_t *pregm,unsigned *preg)
 {   symbol *s;
-    unsigned u;
-    regm_t m;
     regm_t regm;
     unsigned reg;
 
@@ -2637,7 +2634,6 @@ elem_print(e);
 code *codelem(elem *e,regm_t *pretregs,bool constflag)
 { code *c;
   Symbol *s;
-  tym_t tym;
   unsigned op;
 
 #ifdef DEBUG

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -618,8 +618,7 @@ STATIC void eltonear(elem **pe)
  */
 
 STATIC elem * elstrcpy(elem *e)
-{   tym_t ty;
-
+{
     elem_debug(e);
     switch (e->E2->Eoper)
     {
@@ -1905,8 +1904,7 @@ L2:
                 ;
             if ((OTopeq(e2->Eoper)) &&
                 el_match(e1->E1,e2->E1))
-            {   elem *ex;
-
+            {
                 e->E1 = el_long(TYint,0);
                 e1->Eoper = opeqtoop(e1op);
                 e2->E2 = el_bin(opeqtoop(e2->Eoper),e2->Ety,e1,e2->E2);
@@ -1938,8 +1936,6 @@ STATIC elem * elremquo(elem *e)
 
 STATIC elem * elmod(elem *e)
 {
-    elem *e1;
-    elem *e2;
     tym_t tym;
 
     tym = e->E1->Ety;
@@ -2546,8 +2542,7 @@ STATIC elem * eladdr(elem *e)
     case OPstreq:
             //  & (v1 = e) => ((v1 = e), &v1)
             if (e1->E1->Eoper == OPvar)
-            {   elem *ex;
-
+            {
                 e->Eoper = OPcomma;
                 e->E2 = el_una(OPaddr,tym,el_copytree(e1->E1));
                 goto L1;
@@ -2786,10 +2781,7 @@ CEXTERN elem * elstruct(elem *e)
  */
 
 STATIC elem * eleq(elem *e)
-{   targ_ullong m;
-    unsigned t,w,b;
-    unsigned sz;
-    elem *l,*l2,*r,*r2,*e1,*eres;
+{   elem *e1;
     int wantres;
     tym_t tyl;
 
@@ -2884,7 +2876,6 @@ STATIC elem * eleq(elem *e)
             && op2 != OPdiv && op2 != OPmod
            )
         {   tym_t ty;
-            int op3;
 
             // Replace (e1 = e1 op e) with (e1 op= e)
             if (el_match(e1,e2->E1))
@@ -2926,8 +2917,7 @@ STATIC elem * eleq(elem *e)
         }
 
         if (op2 == OPneg && el_match(e1,e2->E1) && !el_sideeffect(e1))
-        {   int offset;
-
+        {
             tyl = tybasic(e1->Ety);
         Ldef:
             // Replace (i = -i) with (negass i)
@@ -3108,11 +3098,8 @@ STATIC elem * elnegass(elem *e)
  */
 
 STATIC elem * elopass(elem *e)
-{   targ_llong m;
-    unsigned w,b,op;
-    tym_t t;
-    tym_t tyl;
-    elem *l,*r,*e1,*l2,*l3,*op2,*eres;
+{
+    elem *e1;
     int wantres;
 
     wantres = expgoal;

--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -574,8 +574,7 @@ code *movregconst(code *c,unsigned reg,targ_size_t value,regm_t flags)
     targ_size_t regv = regcon.immed.value[reg];
 
     if (flags & 1)      // 8 bits
-    {   unsigned msk;
-
+    {
         value &= 0xFF;
         regm &= BYTEREGS;
 

--- a/src/backend/cgsched.c
+++ b/src/backend/cgsched.c
@@ -1795,7 +1795,7 @@ STATIC code * cnext(code *c)
 //                      if 2, then adjust ci1 as well as ci2
 
 STATIC int conflict(Cinfo *ci1,Cinfo *ci2,int fpsched)
-{   code *c;
+{
     code *c1;
     code *c2;
     unsigned r1,w1,a1;
@@ -2329,7 +2329,7 @@ int Schedule::insert(Cinfo *ci)
 
         clocks = conflict(cit,ci,1);
         if (clocks)
-        {   int k,j;
+        {   int j;
 
             ic = i;                     // where the conflict occurred
             clocks &= 0xFF;             // convert to delay count
@@ -2561,7 +2561,6 @@ int Schedule::stage(code *c)
     list_t l;
     list_t ln;
     int agi;
-    int op;
 
     //printf("stage: "); c->print();
     if (cinfomax == TBLMAX)             // if out of space
@@ -2838,7 +2837,7 @@ code *peephole(code *cstart,regm_t scratch)
     //  OP ?,r2
     // to improve pairing
     code *c;
-    code *c1,*c2,*c3;
+    code *c1;
     unsigned r1,r2;
     unsigned mod,reg,rm;
 

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -260,7 +260,6 @@ unsigned buildModregrm(int mod, int reg, int rm)
         m = modregrm(mod, reg, rm);
     else
     {
-        unsigned rex = 0;
         if ((rm & 7) == SP && mod != 3)
             m = (modregrm(0,4,SP) << 8) | modregrm(mod,reg & 7,4);
         else
@@ -980,7 +979,6 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
                         )
                 {
                     regm_t scratchm;
-                    int ss2;
 
 #if 0 && TARGET_LINUX
                     assert(f != FLgot && f != FLgotoff);
@@ -2011,7 +2009,6 @@ code *fixresult(elem *e,regm_t retregs,regm_t *pretregs)
                 if (sz == 8)
                     code_orrex(ce,REX_W);
                 // MOVSS/MOVSD XMMreg,floatreg
-                unsigned op = (sz == 4) ? 0xF30F10 : 0xF20F10;
                 ce = genfltreg(ce,0xF20F10,rreg - XMM0,0);
             }
             else
@@ -2631,7 +2628,6 @@ code *cdfunc(elem *e,regm_t *pretregs)
             }
 
             unsigned stackalign = REGSIZE;
-            tym_t tyf = tybasic(e->E1->Ety);
 
             // Figure out which parameters go in registers
             // Compute numpara, the total bytes pushed on the stack
@@ -3159,7 +3155,6 @@ code *params(elem *e,unsigned stackalign)
   elem *e1;
   elem *e2;
   symbol *s;
-  int fl;
 
   //printf("params(e = %p, stackalign = %d)\n", e, stackalign);
   cp = NULL;
@@ -3615,8 +3610,7 @@ code *params(elem *e,unsigned stackalign)
         targ_ullong *pl = (targ_ullong *)pi;
         i /= regsize;
         do
-        {   code *cp;
-
+        {
             if (i)                      /* be careful not to go negative */
                 i--;
             targ_size_t value = (regsize == 4) ? pi[i] : ps[i];

--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -1524,7 +1524,6 @@ code *cdcom(elem *e,regm_t *pretregs)
   tym = tybasic(e->Ety);
   sz = tysize[tym];
   unsigned rex = (I64 && sz == 8) ? REX_W : 0;
-  unsigned grex = rex << 16;
   possregs = (sz == 1) ? BYTEREGS : allregs;
   retregs = *pretregs & possregs;
   if (retregs == 0)
@@ -1561,11 +1560,10 @@ code *cdcom(elem *e,regm_t *pretregs)
  */
 
 code *cdbswap(elem *e,regm_t *pretregs)
-{   unsigned reg,op;
+{   unsigned reg;
     regm_t retregs;
     code *c,*c1,*cg;
     tym_t tym;
-    int sz;
 
     if (*pretregs == 0)
         return codelem(e->E1,pretregs,FALSE);
@@ -1593,7 +1591,6 @@ code *cdcond(elem *e,regm_t *pretregs)
   code *cc,*c,*c1,*cnop1,*c2,*cnop2;
   con_t regconold,regconsave;
   unsigned stackpushold,stackpushsave;
-  int ehindexold,ehindexsave;
   unsigned jop;
   unsigned op1;
   unsigned sz1;
@@ -2060,7 +2057,7 @@ code *cdshift(elem *e,regm_t *pretregs)
                     !(*pretregs & mPSW) &&
                     config.flags4 & CFG4speed
                    )
-                {   Symbol *s1 = e1->EV.sp.Vsym;
+                {
                     unsigned reg;
                     regm_t regm;
                     code cs;
@@ -2413,7 +2410,7 @@ code *cdind(elem *e,regm_t *pretregs)
 { code *c,*ce,cs;
   tym_t tym;
   regm_t idxregs,retregs;
-  unsigned reg,nreg,byte;
+  unsigned reg,byte;
   elem *e1;
   unsigned sz;
 
@@ -2768,7 +2765,7 @@ code *cdstrlen( elem *e, regm_t *pretregs)
  */
 
 code *cdstrcmp( elem *e, regm_t *pretregs)
-{   code *c1,*c1a,*c2,*c3,*c4;
+{   code *c1,*c2,*c3,*c4;
     char need_DS;
     int segreg;
 
@@ -3096,7 +3093,7 @@ code *cdstrcpy(elem *e,regm_t *pretregs)
  */
 
 code *cdmemcpy(elem *e,regm_t *pretregs)
-{   code *c1,*c2,*c3,*c4;
+{   code *c1,*c2,*c3;
     regm_t retregs1;
     regm_t retregs2;
     regm_t retregs3;
@@ -3238,14 +3235,13 @@ code *cdmemcpy(elem *e,regm_t *pretregs)
 
 #if 1
 code *cdmemset(elem *e,regm_t *pretregs)
-{   code *c1,*c2,*c3 = NULL,*c4;
+{   code *c1,*c2,*c3 = NULL;
     regm_t retregs1;
     regm_t retregs2;
     regm_t retregs3;
     unsigned reg,vreg;
     tym_t ty1;
     elem *e2,*e1;
-    int segreg;
     unsigned remainder;
     targ_uns numbytes,numwords;
     int op;
@@ -4143,7 +4139,6 @@ code *cdabs( elem *e, regm_t *pretregs)
   cg = getregs(retregs);                /* retregs will be destroyed    */
   if (sz <= REGSIZE)
   {     unsigned reg;
-        code *c2;
 
         /*      cwd
                 xor     AX,DX
@@ -4196,14 +4191,13 @@ code *cdabs( elem *e, regm_t *pretregs)
  */
 
 code *cdpost(elem *e,regm_t *pretregs)
-{ code cs,*c1,*c2,*c3,*c4,*c5,*c6;
+{ code cs,*c1,*c2,*c3,*c4,*c5;
   unsigned reg,op,byte;
   tym_t tyml;
   regm_t retregs,possregs,idxregs;
   targ_int n;
   elem *e2;
   int sz;
-  int stackpushsave;
 
   //printf("cdpost(pretregs = %s)\n", regm_str(*pretregs));
   retregs = *pretregs;

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -341,7 +341,7 @@ void cod3_align()
 void doswitch(block *b)
 {   code *cc,*c,*ce;
     regm_t retregs;
-    unsigned ncases,n,reg,reg2,rm;
+    unsigned ncases,n,reg,reg2;
     targ_llong vmax,vmin,val;
     targ_llong *p;
     list_t bl;
@@ -908,7 +908,7 @@ L1:
 void cod3_ptrchk(code **pc,code *pcs,regm_t keepmsk)
 {   code *c;
     code *cs2;
-    unsigned char rm,sib;
+    unsigned char rm;
     unsigned reg;
     unsigned flagsave;
     unsigned opsave;
@@ -1931,7 +1931,6 @@ Lcont:
         */
         targ_size_t voff = Aoff + BPoff + sv->Soffset;  // EBP offset of start of sv
         const int vregnum = 6;
-        const unsigned vsize = vregnum * 8 + 8 * 16;
         code *cv = CNIL;
 
         static unsigned char regs[vregnum] = { DI,SI,DX,CX,R8,R9 };
@@ -3122,7 +3121,6 @@ void pinholeopt(code *c,block *b)
   unsigned char ins;
   int usespace;
   int useopsize;
-  int space;
   block *bn;
 
 #ifdef DEBUG
@@ -4058,7 +4056,7 @@ STATIC void cod3_flush()
 
 unsigned codout(code *c)
 { unsigned op;
-  unsigned char rm,mod;
+  unsigned char rm;
   unsigned char ins;
   code *cn;
   unsigned flags;
@@ -4459,10 +4457,9 @@ unsigned codout(code *c)
 
 
 STATIC void do64bit(enum FL fl,union evc *uev,int flags)
-{   char *p;
+{
     symbol *s;
     targ_size_t ad;
-    long tmp;
 
     assert(I64);
     switch (fl)
@@ -4545,10 +4542,9 @@ STATIC void do64bit(enum FL fl,union evc *uev,int flags)
 
 
 STATIC void do32bit(enum FL fl,union evc *uev,int flags, targ_size_t val)
-{ char *p;
+{
   symbol *s;
   targ_size_t ad;
-  long tmp;
 
   //printf("do32bit(flags = x%x)\n", flags);
   switch (fl)
@@ -4655,7 +4651,7 @@ STATIC void do32bit(enum FL fl,union evc *uev,int flags, targ_size_t val)
 
 
 STATIC void do16bit(enum FL fl,union evc *uev,int flags)
-{ char *p;
+{
   symbol *s;
   targ_size_t ad;
 

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -323,8 +323,6 @@ code *cdeq(elem *e,regm_t *pretregs)
   int i;
   code *cl,*cr,*c,cs;
   elem *e11;
-  bool widen;                   /* TRUE means byte widen                */
-  int nwords;                   /* # of words to transfer               */
   bool regvar;                  /* TRUE means evaluate into register variable */
   regm_t varregm;
   unsigned varreg;
@@ -1287,7 +1285,6 @@ code *cdmulass(elem *e,regm_t *pretregs)
         else // /= or %=
         {   targ_size_t e2factor;
             int pow2;
-            targ_ulong m;
 
             assert(!byte);                      // should never happen
             assert(I16 || sz != SHORTSIZE);
@@ -1462,7 +1459,6 @@ code *cdshass(elem *e,regm_t *pretregs)
   assert(tysize(e2->Ety) <= REGSIZE);
 
     unsigned rex = (I64 && sz == 8) ? REX_W : 0;
-    unsigned grex = rex << 16;          // 64 bit operands
 
   // if our lvalue is a cse, make sure we evaluate for result in register
   if (e1->Ecount && !(*pretregs & (ALLREGS | mBP)) && !isregvar(e1,&retregs,&reg))
@@ -2788,7 +2784,7 @@ code *cdshtlng(elem *e,regm_t *pretregs)
  */
 
 code *cdbyteint(elem *e,regm_t *pretregs)
-{   code *c,*ce,*c0,*c1,*c2,*c3,*c4;
+{   code *c,*c0,*c1,*c2,*c3,*c4;
     regm_t retregs;
     unsigned reg;
     char op;
@@ -3181,7 +3177,6 @@ code *cdbt(elem *e, regm_t *pretregs)
     unsigned reg;
     unsigned char word;
     tym_t ty1;
-    targ_int i;
     int op;
     int mode;
 
@@ -3334,7 +3329,6 @@ code *cdpair(elem *e, regm_t *pretregs)
     regm_t retregs;
     regm_t regs1;
     regm_t regs2;
-    unsigned reg;
     code *cg;
     code *c1;
     code *c2;

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -821,10 +821,6 @@ void dwarf_termfile()
             unsigned address = 0;       // instruction address
             unsigned file = ld->filenumber;
             unsigned line = 1;          // line numbers beginning with 1
-            unsigned column = 0;        // column number, leftmost column is 1
-            int is_stmt = debugline.default_is_stmt;    // TRUE if beginning of a statement
-            int basic_block = FALSE;  // TRUE if start of basic block
-            int end_sequence = FALSE; // TRUE if address is after end of sequence
 
             linebuf->writeByte(DW_LNS_set_file);
             linebuf->writeuLEB128(file);
@@ -1580,7 +1576,6 @@ unsigned dwarf_typidx(type *t)
     if (idx)
         return idx;
 
-    const char *name;
     unsigned char ate;
     ate = tyuns(t->Tty) ? DW_ATE_unsigned : DW_ATE_signed;
     switch (tybasic(t->Tty))

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -2280,7 +2280,6 @@ void shrinkLongDoubleConstantIfPossible(elem *e)
          */
         volatile long double v = e->EV.Vldouble;
         volatile double vDouble;
-        volatile double z = v;
         *(&vDouble) = v;
         if (v == vDouble)       // This will fail if compiler does NaN incorrectly!
         {

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -2113,8 +2113,6 @@ elem * evalu8(elem *e)
         return e;
   }
 #if TX86
-    int flags;
-
     if (!ignore_exceptions &&
         (config.flags4 & CFG4fastfloat) == 0 &&
 #if __OpenBSD__

--- a/src/backend/gdag.c
+++ b/src/backend/gdag.c
@@ -294,8 +294,7 @@ STATIC void aewalk(register elem **pn,register vec_t ae)
         }
 
         if (OTdef(op))
-        {       int e1op;
-
+        {
                 assert(n->Eexp == 0);   // should not be an AE
                 /* remove all AEs that could be affected by this def    */
                 if (Eunambig(n))        // if unambiguous definition
@@ -645,7 +644,7 @@ void boolopt()
 
 STATIC void abewalk(elem *n,vec_t ae,vec_t aeval)
 {   vec_t aer,aerval;
-    unsigned i,op,e1op;
+    unsigned i,op;
     unsigned i1,i2;
     elem *t;
 

--- a/src/backend/gflow.c
+++ b/src/backend/gflow.c
@@ -262,7 +262,7 @@ STATIC void rdelem(vec_t *pgen,vec_t *pkill,                    /* where to put 
 
 STATIC void accumrd(vec_t GEN,vec_t KILL,elem *n)
 {       vec_t Gl,Kl,Gr,Kr;
-        unsigned op,i;
+        unsigned op;
 
         assert(GEN && KILL && n);
         op = n->Eoper;

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1619,7 +1619,6 @@ STATIC void movelis(elem *n,block *b,loop *l,int *pdomexit)
   register list_t nl;
   symbol *v;
   tym_t ty;
-  tym_t jty;
 
 Lnextlis:
   //if (isLI(n)) { printf("movelis("); WReqn(n); printf(")\n"); }
@@ -3414,11 +3413,11 @@ STATIC void elimbasivs(register loop *l)
  */
 
 STATIC void elimopeqs(register loop *l)
-{   famlist *fl;
+{
     Iv *biv;
     unsigned i;
     tym_t ty;
-    elem **pref,*fofe,*C2;
+    elem **pref;
     symbol *X;
     int refcount;
 

--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -197,7 +197,7 @@ STATIC void rd_compute()
  */
 
 STATIC void conpropwalk(elem *n,vec_t IN)
-{       register unsigned op,i;
+{       register unsigned op;
         Elemdata *pdata;
         vec_t L,R;
         elem *t;
@@ -271,8 +271,7 @@ STATIC void conpropwalk(elem *n,vec_t IN)
 
         // Collect data for subsequent optimizations
         if (OTbinary(op) && n->E1->Eoper == OPvar && n->E2->Eoper == OPconst)
-        {   Symbol *v = n->E1->EV.sp.Vsym;
-
+        {
             switch (op)
             {
                 case OPlt:
@@ -451,7 +450,6 @@ STATIC elem * chkprop(elem *n,list_t rdlist)
 {
     elem *foundelem = NULL;
     int unambig;
-    register unsigned i;
     symbol *sv;
     tym_t nty;
     unsigned nsize;
@@ -763,7 +761,6 @@ STATIC void intranges()
 
         // Check that all paths from rdinc to rdinc must pass through rdrel
         {   int i;
-            block *b;
 
             // ib:      block of increment
             // rb:      block of relational
@@ -1152,7 +1149,7 @@ void rmdeadass()
                 vec_orass(POSS,DEAD);   /* POSS |= DEAD                 */
                 foreach (j,asstop,POSS) /* for each possible dead asg.  */
                 {       symbol *v;      /* v = target of assignment     */
-                        register elem *n,*t,*nv;
+                        register elem *n,*nv;
 
                         n = assnod[j];
                         nv = Elvalue(n);

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -784,7 +784,7 @@ void obj_term()
         {   Relocation *r = (Relocation *)pseg->SDrel->buf;
             Relocation *rend = (Relocation *)(pseg->SDrel->buf + pseg->SDrel->size());
             for (; r != rend; r++)
-            {
+            {//   const char *rs = r->rtype == RELaddr ? "addr" : "rel";
                 symbol *s = r->targsym;
                 //printf("%d:x%04x : tseg %d tsym %p REL%s\n",
                     //seg, r->offset, r->targseg, s, rs);
@@ -1572,6 +1572,9 @@ void obj_alias(const char *n1,const char *n2)
     //printf("obj_alias(%s,%s)\n",n1,n2);
     assert(0);
 #if NOT_DONE
+    unsigned len;
+    char *buffer;
+
     buffer = (char *) alloca(strlen(n1) + strlen(n2) + 2 * ONS_OHD);
     len = obj_namestring(buffer,n1);
     len += obj_namestring(buffer + len,n2);

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -784,7 +784,7 @@ void obj_term()
         {   Relocation *r = (Relocation *)pseg->SDrel->buf;
             Relocation *rend = (Relocation *)(pseg->SDrel->buf + pseg->SDrel->size());
             for (; r != rend; r++)
-            {   const char *rs = r->rtype == RELaddr ? "addr" : "rel";
+            {
                 symbol *s = r->targsym;
                 //printf("%d:x%04x : tseg %d tsym %p REL%s\n",
                     //seg, r->offset, r->targseg, s, rs);
@@ -1568,9 +1568,7 @@ seg_data *obj_tlsseg_bss()
  */
 
 void obj_alias(const char *n1,const char *n2)
-{   unsigned len;
-    char *buffer;
-
+{
     //printf("obj_alias(%s,%s)\n",n1,n2);
     assert(0);
 #if NOT_DONE

--- a/src/backend/nteh.c
+++ b/src/backend/nteh.c
@@ -686,7 +686,6 @@ code *nteh_unwind(regm_t retregs,unsigned index)
     code cs;
     code *cs1;
     code *cs2;
-    int i;
     regm_t desregs;
     int reg;
     int local_unwind;
@@ -886,7 +885,6 @@ code *nteh_monitor_epilog(regm_t retregs)
     code *cs1;
     code *cs2;
     code *cpop;
-    int i;
     regm_t desregs;
     Symbol *s;
 

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -791,7 +791,6 @@ void dotytab()
                                 TYdchar,TYullong,TYucent,TYchar16 };
     static tym_t _mptr[]    = { TYmemptr };
     static tym_t _nullptr[] = { TYnullptr };
-    static tym_t _fv[]      = { TYfptr, TYvptr };
 #if TARGET_WINDOS
     static tym_t _farfunc[] = { TYffunc,TYfpfunc,TYfsfunc,TYfsysfunc };
 #endif

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -791,6 +791,9 @@ void dotytab()
                                 TYdchar,TYullong,TYucent,TYchar16 };
     static tym_t _mptr[]    = { TYmemptr };
     static tym_t _nullptr[] = { TYnullptr };
+#if OMFOBJ
+    static tym_t _fv[]      = { TYfptr, TYvptr };
+#endif
 #if TARGET_WINDOS
     static tym_t _farfunc[] = { TYffunc,TYfpfunc,TYfsfunc,TYfsysfunc };
 #endif

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -554,6 +554,9 @@ STATIC void outelem(elem *e)
     symbol *s;
     tym_t tym;
     elem *e1;
+#if SCPP
+    type *t;
+#endif
 
 again:
     assert(e);
@@ -1369,6 +1372,7 @@ STATIC void writefunc2(symbol *sfunc)
 #endif
 
 #if SCPP && _WIN32
+        char *id;
         // Determine which startup code to reference
         if (!CPP || !isclassmember(sfunc))              // if not member function
         {   static char *startup[] =

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -113,7 +113,6 @@ void outdata(symbol *s)
     int seg;
     targ_size_t offset;
     int flags;
-    char *p;
     tym_t ty;
     int tls;
 
@@ -553,9 +552,6 @@ void outcommon(symbol *s,targ_size_t n)
 STATIC void outelem(elem *e)
 {
     symbol *s;
-    char *p;
-    targ_size_t sz;
-    type *t;
     tym_t tym;
     elem *e1;
 
@@ -920,7 +916,7 @@ void writefunc(symbol *sfunc)
 }
 
 STATIC void writefunc2(symbol *sfunc)
-{   unsigned i,n;
+{
     block *b;
     unsigned nsymbols;
     SYMIDX si;
@@ -1367,8 +1363,6 @@ STATIC void writefunc2(symbol *sfunc)
         goto Ldone;
     if (sfunc->Sclass == SCglobal)
     {
-        char *id;
-
 #if OMFOBJ
         if (!(config.flags4 & CFG4allcomdat))
             objpubdef(cseg,sfunc,sfunc->Soffset);       // make a public definition

--- a/src/backend/outbuf.c
+++ b/src/backend/outbuf.c
@@ -262,8 +262,6 @@ void Outbuffer::setsize(unsigned size)
 
 void Outbuffer::writesLEB128(int value)
 {
-    int negative = (value < 0);
-
     while (1)
     {
         unsigned char b = value & 0x7F;

--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -3346,7 +3346,6 @@ const char *asm_opstr(OP *pop)
 
 OP *asm_op_lookup(const char *s)
 {
-    OP  *pop;
     int i;
     char szBuf[12];
 

--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -188,9 +188,9 @@ void symbol_keep(symbol *s)
  */
 
 char *symbol_ident(symbol *s)
-{   static char noname[] = "__unnamed";
-
+{
 #if SCPP
+    static char noname[] = "__unnamed";
     switch (s->Sclass)
     {   case SCstruct:
             if (s->Sstruct->Salias)

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -821,7 +821,7 @@ type *type_setdependent(type *t)
  */
 
 int type_isdependent(type *t)
-{   param_t *p;
+{
     Symbol *stempl;
     type *tstart;
 
@@ -1279,7 +1279,6 @@ unsigned param_t::length()
 
 param_t *param_t::createTal(param_t *ptali)
 {
-    param_t *ptalistart = ptali;
     param_t *ptal = NULL;
     param_t **pp = &ptal;
     param_t *p;

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -1279,6 +1279,9 @@ unsigned param_t::length()
 
 param_t *param_t::createTal(param_t *ptali)
 {
+#if SCPP
+    param_t *ptalistart = ptali;
+#endif
     param_t *ptal = NULL;
     param_t **pp = &ptal;
     param_t *p;

--- a/src/cast.c
+++ b/src/cast.c
@@ -32,8 +32,7 @@ Expression *Expression::implicitCastTo(Scope *sc, Type *t)
 
     MATCH match = implicitConvTo(t);
     if (match)
-    {   TY tyfrom = type->toBasetype()->ty;
-        TY tyto = t->toBasetype()->ty;
+    {
 #if DMDV1
         if (global.params.warnings &&
             Type::impcnvWarn[tyfrom][tyto] &&
@@ -437,8 +436,7 @@ MATCH StructLiteralExp::implicitConvTo(Type *t)
 #endif
 
 MATCH StringExp::implicitConvTo(Type *t)
-{   MATCH m;
-
+{
 #if 0
     printf("StringExp::implicitConvTo(this=%s, committed=%d, type=%s, t=%s)\n",
         toChars(), committed, type->toChars(), t->toChars());
@@ -679,8 +677,6 @@ MATCH DelegateExp::implicitConvTo(Type *t)
     if (result == MATCHnomatch)
     {
         // Look for pointers to functions where the functions are overloaded.
-        FuncDeclaration *f;
-
         t = t->toBasetype();
         if (type->ty == Tdelegate && type->nextOf()->ty == Tfunction &&
             t->ty == Tdelegate && t->nextOf()->ty == Tfunction)

--- a/src/cast.c
+++ b/src/cast.c
@@ -34,6 +34,8 @@ Expression *Expression::implicitCastTo(Scope *sc, Type *t)
     if (match)
     {
 #if DMDV1
+        TY tyfrom = type->toBasetype()->ty;
+        TY tyto = t->toBasetype()->ty;
         if (global.params.warnings &&
             Type::impcnvWarn[tyfrom][tyto] &&
             op != TOKint64)
@@ -501,6 +503,7 @@ MATCH StringExp::implicitConvTo(Type *t)
     }
     return Expression::implicitConvTo(t);
 #if 0
+    MATCH m;
     m = (MATCH)type->implicitConvTo(t);
     if (m)
     {

--- a/src/class.c
+++ b/src/class.c
@@ -241,7 +241,6 @@ Dsymbol *ClassDeclaration::syntaxCopy(Dsymbol *s)
 
 void ClassDeclaration::semantic(Scope *sc)
 {   int i;
-    unsigned offset;
 
     //printf("ClassDeclaration::semantic(%s), type = %p, sizeok = %d, this = %p\n", toChars(), type, sizeok, this);
     //printf("\tparent = %p, '%s'\n", sc->parent, sc->parent ? sc->parent->toChars() : "");

--- a/src/clone.c
+++ b/src/clone.c
@@ -51,7 +51,7 @@ int StructDeclaration::needOpAssign()
             continue;
         Type *tv = v->type->toBasetype();
         while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
+        {
             tv = tv->nextOf()->toBasetype();
         }
         if (tv->ty == Tstruct)
@@ -94,7 +94,7 @@ int StructDeclaration::needOpEquals()
             continue;
         Type *tv = v->type->toBasetype();
         while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
+        {
             tv = tv->nextOf()->toBasetype();
         }
         if (tv->ty == Tstruct)
@@ -398,7 +398,7 @@ FuncDeclaration *StructDeclaration::buildPostBlit(Scope *sc)
         Type *tv = v->type->toBasetype();
         size_t dim = (tv->ty == Tsarray ? 1 : 0);
         while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
+        {
             dim *= ((TypeSArray *)tv)->dim->toInteger();
             tv = tv->nextOf()->toBasetype();
         }
@@ -510,7 +510,7 @@ FuncDeclaration *AggregateDeclaration::buildDtor(Scope *sc)
         Type *tv = v->type->toBasetype();
         size_t dim = (tv->ty == Tsarray ? 1 : 0);
         while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
+        {
             dim *= ((TypeSArray *)tv)->dim->toInteger();
             tv = tv->nextOf()->toBasetype();
         }

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1327,7 +1327,7 @@ Expression *Slice(Type *type, Expression *e1, Expression *lwr, Expression *upr)
         if (iupr > es1->len || ilwr > iupr)
             e1->error("string slice [%ju .. %ju] is out of bounds", ilwr, iupr);
         else
-        {   dinteger_t value;
+        {
             void *s;
             size_t len = iupr - ilwr;
             int sz = es1->sz;

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1709,7 +1709,7 @@ Expression *VarDeclaration::callScopeDtor(Scope *sc)
     bool array = false;
     Type *tv = type->toBasetype();
     while (tv->ty == Tsarray)
-    {   TypeSArray *ta = (TypeSArray *)tv;
+    {
         array = true;
         tv = tv->nextOf()->toBasetype();
     }

--- a/src/doc.c
+++ b/src/doc.c
@@ -1013,8 +1013,7 @@ DocComment::DocComment()
 }
 
 DocComment *DocComment::parse(Scope *sc, Dsymbol *s, unsigned char *comment)
-{   unsigned idlen;
-
+{
     //printf("parse(%s): '%s'\n", s->toChars(), comment);
     if (sc->lastdc && isDitto(comment))
         return NULL;
@@ -1774,7 +1773,6 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
 
     int leadingBlank = 1;
     int inCode = 0;
-    int inComment = 0;                  // in <!-- ... --> comment
     unsigned iCodeStart;                // start of code section
 
     unsigned iLineStart = offset;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -198,7 +198,6 @@ const char *Dsymbol::toPrettyChars()
 char *Dsymbol::locToChars()
 {
     OutBuffer buf;
-    char *p;
 
     if (!loc.filename)  // avoid bug 5861.
     {

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -199,7 +199,6 @@ elem *callfunc(Loc loc,
 
     if (fd && fd->isMember2())
     {
-        InterfaceDeclaration *intd;
         Symbol *sfunc;
         AggregateDeclaration *ad;
 
@@ -1703,8 +1702,6 @@ elem *NewExp::toElem(IRState *irs)
 #if DMDV2
     else if (t->ty == Tpointer && t->nextOf()->toBasetype()->ty == Tstruct)
     {
-        Symbol *csym;
-
         t = newtype->toBasetype();
         assert(t->ty == Tstruct);
         TypeStruct *tclass = (TypeStruct *)(t);
@@ -1751,8 +1748,6 @@ elem *NewExp::toElem(IRState *irs)
         }
         else
         {
-            d_uns64 elemsize = cd->size(loc);
-
             // call _d_newarrayT(ti, 1)
             e = el_long(TYsize_t, 1);
             e = el_param(e, type->getTypeInfo(NULL)->toElem(irs));
@@ -1810,7 +1805,6 @@ elem *NewExp::toElem(IRState *irs)
         {   // Single dimension array allocations
             Expression *arg = (Expression *)arguments->data[0]; // gives array length
             e = arg->toElem(irs);
-            d_uns64 elemsize = tda->next->size();
 
             // call _d_newT(ti, arg)
             e = el_param(e, type->getTypeInfo(NULL)->toElem(irs));
@@ -1839,9 +1833,6 @@ elem *NewExp::toElem(IRState *irs)
     else if (t->ty == Tpointer)
     {
         TypePointer *tp = (TypePointer *)t;
-        d_uns64 elemsize = tp->next->size();
-        Expression *di = tp->next->defaultInit();
-        d_uns64 disize = di->type->size();
 
         // call _d_newarrayT(ti, 1)
         e = el_long(TYsize_t, 1);
@@ -2603,9 +2594,7 @@ elem *AssignExp::toElem(IRState *irs)
     // Look for array[]=n
     if (e1->op == TOKslice)
     {
-        SliceExp *are = (SliceExp *)(e1);
         Type *t1 = t1b;
-        Type *t2 = e2->type->toBasetype();
 
         // which we do if the 'next' types match
         if (ismemset)
@@ -2616,11 +2605,9 @@ elem *AssignExp::toElem(IRState *irs)
             elem *enbytes;
             elem *elength;
             elem *einit;
-            dinteger_t value;
             Type *ta = are->e1->type->toBasetype();
             Type *tb = ta->nextOf()->toBasetype();
             int sz = tb->size();
-            tym_t tym = type->totym();
 
             elem *n1 = are->e1->toElem(irs);
             elem *elwr = are->lwr ? are->lwr->toElem(irs) : NULL;
@@ -2856,9 +2843,6 @@ elem *AssignExp::toElem(IRState *irs)
 
     if (e1->op == TOKindex)
     {
-        elem *eb;
-        elem *ei;
-        elem *ev;
         TY ty;
         Type *ta;
 
@@ -3602,7 +3586,6 @@ elem *CallExp::toElem(IRState *irs)
 
 elem *AddrExp::toElem(IRState *irs)
 {   elem *e;
-    elem **pe;
 
     //printf("AddrExp::toElem('%s')\n", toChars());
 
@@ -3680,7 +3663,7 @@ elem *DeleteExp::toElem(IRState *irs)
             elem *et = NULL;
             Type *tv = tb->nextOf()->toBasetype();
             while (tv->ty == Tsarray)
-            {   TypeSArray *ta = (TypeSArray *)tv;
+            {
                 tv = tv->nextOf()->toBasetype();
             }
             if (tv->ty == Tstruct)

--- a/src/eh.c
+++ b/src/eh.c
@@ -312,7 +312,7 @@ void except_fillInEHTable(symbol *s)
     for (block *b = startblock; b; b = b->Bnext)
     {
         if (b->BC == BC_try)
-        {   block *bhandler;
+        {
             int nsucc;
 
             if (b->jcatchvar)                           // if try-catch

--- a/src/expression.c
+++ b/src/expression.c
@@ -3422,7 +3422,6 @@ Expression *AssocArrayLiteralExp::syntaxCopy()
 
 Expression *AssocArrayLiteralExp::semantic(Scope *sc)
 {
-
 #if LOGSEMANTIC
     printf("AssocArrayLiteralExp::semantic('%s')\n", toChars());
 #endif
@@ -4384,7 +4383,6 @@ int NewAnonClassExp::canThrow(bool mustNotThrow)
 
 void NewAnonClassExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
-
     if (thisexp)
     {   expToCBuffer(buf, hgs, thisexp, PREC_primary);
         buf->writeByte('.');
@@ -4500,7 +4498,6 @@ int VarExp::equals(Object *o)
 
 Expression *VarExp::semantic(Scope *sc)
 {
-
 #if LOGSEMANTIC
     printf("VarExp::semantic(%s)\n", toChars());
 #endif
@@ -4536,11 +4533,15 @@ Expression *VarExp::semantic(Scope *sc)
 #endif
     }
 #if 0
-    else if ((fd = var->isFuncLiteralDeclaration()) != NULL)
-    {   Expression *e;
-        e = new FuncExp(loc, fd);
-        e->type = type;
-        return e;
+    else
+    {
+        FuncLiteralDeclaration *fd;
+        if ((fd = var->isFuncLiteralDeclaration()) != NULL)
+        {   Expression *e;
+            e = new FuncExp(loc, fd);
+            e->type = type;
+            return e;
+        }
     }
 #endif
 
@@ -4692,7 +4693,6 @@ TupleExp::TupleExp(Loc loc, TupleDeclaration *tup)
 
 int TupleExp::equals(Object *o)
 {
-
     if (this == o)
         return 1;
     if (((Expression *)o)->op == TOKtuple)
@@ -9279,6 +9279,7 @@ Expression *AssignExp::semantic(Scope *sc)
 #if 0 // Turned off to allow rewriting (a[i]=value) to (a.opIndex(i)=value)
             else
             {
+                Identifier *id = Id::index;
                 // Rewrite (a[i] = value) to (a.opIndex(i, value))
                 if (search_function(ad, id))
                 {   Expression *e = new DotIdExp(loc, ae->e1, id);

--- a/src/expression.c
+++ b/src/expression.c
@@ -2480,7 +2480,6 @@ Lagain:
     FuncDeclaration *f;
     FuncLiteralDeclaration *fld;
     OverloadSet *o;
-    Declaration *d;
     ClassDeclaration *cd;
     ClassDeclaration *thiscd = NULL;
     Import *imp;
@@ -2707,7 +2706,6 @@ ThisExp::ThisExp(Loc loc)
 Expression *ThisExp::semantic(Scope *sc)
 {   FuncDeclaration *fd;
     FuncDeclaration *fdthis;
-    int nested = 0;
 
 #if LOGSEMANTIC
     printf("ThisExp::semantic()\n");
@@ -3423,7 +3421,7 @@ Expression *AssocArrayLiteralExp::syntaxCopy()
 }
 
 Expression *AssocArrayLiteralExp::semantic(Scope *sc)
-{   Expression *e;
+{
 
 #if LOGSEMANTIC
     printf("AssocArrayLiteralExp::semantic('%s')\n", toChars());
@@ -3959,7 +3957,7 @@ Expression *NewExp::syntaxCopy()
 
 
 Expression *NewExp::semantic(Scope *sc)
-{   int i;
+{
     Type *tb;
     ClassDeclaration *cdthis = NULL;
 
@@ -4310,7 +4308,7 @@ int NewExp::canThrow(bool mustNotThrow)
 #endif
 
 void NewExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{   int i;
+{
 
     if (thisexp)
     {   expToCBuffer(buf, hgs, thisexp, PREC_primary);
@@ -4385,7 +4383,7 @@ int NewAnonClassExp::canThrow(bool mustNotThrow)
 #endif
 
 void NewAnonClassExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{   int i;
+{
 
     if (thisexp)
     {   expToCBuffer(buf, hgs, thisexp, PREC_primary);
@@ -4501,7 +4499,7 @@ int VarExp::equals(Object *o)
 }
 
 Expression *VarExp::semantic(Scope *sc)
-{   FuncLiteralDeclaration *fd;
+{
 
 #if LOGSEMANTIC
     printf("VarExp::semantic(%s)\n", toChars());
@@ -4693,7 +4691,7 @@ TupleExp::TupleExp(Loc loc, TupleDeclaration *tup)
 }
 
 int TupleExp::equals(Object *o)
-{   TupleExp *ne;
+{
 
     if (this == o)
         return 1;
@@ -4906,7 +4904,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
         if (!sc->insert(s))
             error("declaration %s is already defined", s->toPrettyChars());
         else if (sc->func)
-        {   VarDeclaration *v = s->isVarDeclaration();
+        {
             if ( (s->isFuncDeclaration() || s->isTypedefDeclaration() ||
                 s->isAggregateDeclaration() || s->isEnumDeclaration() ||
                 s->isInterfaceDeclaration()) &&
@@ -6843,7 +6841,6 @@ Expression *CallExp::semantic(Scope *sc)
 {
     TypeFunction *tf;
     FuncDeclaration *f;
-    int i;
     Type *t1;
     int istemp;
     Objects *targsi = NULL;     // initial list of template arguments
@@ -7649,7 +7646,7 @@ Expression *CallExp::addDtorHook(Scope *sc)
 
     Type *tv = type->toBasetype();
     while (tv->ty == Tsarray)
-    {   TypeSArray *ta = (TypeSArray *)tv;
+    {
         tv = tv->nextOf()->toBasetype();
     }
     if (tv->ty == Tstruct)
@@ -8190,8 +8187,6 @@ Expression *CastExp::syntaxCopy()
 
 Expression *CastExp::semantic(Scope *sc)
 {   Expression *e;
-    BinExp *b;
-    UnaExp *u;
 
 #if LOGSEMANTIC
     printf("CastExp::semantic('%s')\n", toChars());
@@ -8931,8 +8926,6 @@ IndexExp::IndexExp(Loc loc, Expression *e1, Expression *e2)
 
 Expression *IndexExp::semantic(Scope *sc)
 {   Expression *e;
-    BinExp *b;
-    UnaExp *u;
     Type *t1;
     ScopeDsymbol *sym;
 
@@ -8985,10 +8978,10 @@ Expression *IndexExp::semantic(Scope *sc)
         {
             e2 = e2->implicitCastTo(sc, Type::tsize_t);
 
-            TypeSArray *tsa = (TypeSArray *)t1;
 
 #if 0   // Don't do now, because it might be short-circuit evaluated
             // Do compile time array bounds checking if possible
+            TypeSArray *tsa = (TypeSArray *)t1;
             e2 = e2->optimize(WANTvalue);
             if (e2->op == TOKint64)
             {
@@ -9092,7 +9085,7 @@ Expression *IndexExp::modifiableLvalue(Scope *sc, Expression *e)
         error("%s isn't mutable", e->toChars());
     Type *t1 = e1->type->toBasetype();
     if (t1->ty == Taarray)
-    {   TypeAArray *taa = (TypeAArray *)t1;
+    {
         Type *t2b = e2->type->toBasetype();
         if (t2b->ty == Tarray && t2b->nextOf()->isMutable())
             error("associative arrays can only be assigned values with immutable keys, not %s", e2->type->toChars());
@@ -9261,7 +9254,6 @@ Expression *AssignExp::semantic(Scope *sc)
     {
         ArrayExp *ae = (ArrayExp *)e1;
         AggregateDeclaration *ad;
-        Identifier *id = Id::index;
 
         ae->e1 = ae->e1->semantic(sc);
         Type *t1 = ae->e1->type->toBasetype();
@@ -9312,7 +9304,6 @@ Expression *AssignExp::semantic(Scope *sc)
     {   Type *t1;
         SliceExp *ae = (SliceExp *)e1;
         AggregateDeclaration *ad;
-        Identifier *id = Id::index;
 
         ae->e1 = ae->e1->semantic(sc);
         ae->e1 = resolveProperties(sc, ae->e1);
@@ -10719,7 +10710,6 @@ Expression *PowExp::semantic(Scope *sc)
         // For built-in numeric types, there are several cases.
         // TODO: backend support, especially for  e1 ^^ 2.
 
-        bool wantSqrt = false;
         e1 = e1->optimize(0);
         e2 = e2->optimize(0);
 

--- a/src/func.c
+++ b/src/func.c
@@ -372,6 +372,11 @@ void FuncDeclaration::semantic(Scope *sc)
     cd = parent->isClassDeclaration();
     if (cd)
     {   int vi;
+#if 0
+        CtorDelclaration *ctor;
+        DtorDeclaration *dtor;
+        InvariantDeclaration *inv;
+#endif
 
         if (isCtorDeclaration())
         {

--- a/src/func.c
+++ b/src/func.c
@@ -372,9 +372,6 @@ void FuncDeclaration::semantic(Scope *sc)
     cd = parent->isClassDeclaration();
     if (cd)
     {   int vi;
-        CtorDeclaration *ctor;
-        DtorDeclaration *dtor;
-        InvariantDeclaration *inv;
 
         if (isCtorDeclaration())
         {
@@ -2330,7 +2327,6 @@ MATCH FuncDeclaration::leastAsSpecialized(FuncDeclaration *g)
     TypeFunction *tf = (TypeFunction *)type;
     TypeFunction *tg = (TypeFunction *)g->type;
     size_t nfparams = Parameter::dim(tf->parameters);
-    size_t ngparams = Parameter::dim(tg->parameters);
     MATCH match = MATCHexact;
 
     /* If both functions have a 'this' pointer, and the mods are not
@@ -3432,8 +3428,6 @@ Dsymbol *StaticDtorDeclaration::syntaxCopy(Dsymbol *s)
 
 void StaticDtorDeclaration::semantic(Scope *sc)
 {
-    ClassDeclaration *cd = sc->scopesym->isClassDeclaration();
-
     if (!type)
         type = new TypeFunction(NULL, Type::tvoid, FALSE, LINKd);
 

--- a/src/glue.c
+++ b/src/glue.c
@@ -536,8 +536,6 @@ void Module::genobjfile(int multiobj)
 
 void FuncDeclaration::toObjFile(int multiobj)
 {
-    Symbol *senter;
-    Symbol *sexit;
     FuncDeclaration *func = this;
     ClassDeclaration *cd = func->parent->isClassDeclaration();
     int reverse;

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2138,7 +2138,7 @@ ILLEGAL_ADDRESS_ERROR:
  */
 
 STATIC void asm_merge_symbol(OPND *o1, Dsymbol *s)
-{   Type *ptype;
+{
     VarDeclaration *v;
     EnumMember *em;
 
@@ -3211,7 +3211,6 @@ STATIC unsigned asm_type_size(Type * ptype)
 STATIC code *asm_da_parse(OP *pop)
 {
     code *clst = NULL;
-    elem *e;
 
     while (1)
     {   code *c;
@@ -3707,7 +3706,6 @@ STATIC OPND *asm_rel_exp()
 STATIC OPND *asm_shift_exp()
 {
     OPND *o1,*o2;
-    int op;
     enum TOK tk;
 
     o1 = asm_add_exp();
@@ -3852,7 +3850,6 @@ STATIC OPND *asm_mul_exp()
 STATIC OPND *asm_br_exp()
 {
     OPND *o1,*o2;
-    Declaration *s;
 
     //printf("asm_br_exp()\n");
     o1 = asm_una_exp();
@@ -3892,9 +3889,7 @@ STATIC OPND *asm_br_exp()
 STATIC OPND *asm_una_exp()
 {
         OPND *o1;
-        int op;
         Type *ptype;
-        Type *ptypeSpec;
         ASM_JUMPTYPE ajt = ASM_JUMPTYPE_UNSPECIFIED;
         char bPtr = 0;
 
@@ -4064,11 +4059,9 @@ STATIC OPND *asm_primary_exp()
 {
         OPND *o1 = NULL;
         OPND *o2 = NULL;
-        Type *ptype;
         Dsymbol *s;
         Dsymbol *scopesym;
 
-        enum TOK tkOld;
         int global;
         REG *regp;
 
@@ -4405,10 +4398,6 @@ Statement *AsmStatement::semantic(Scope *sc)
     OPND *o1 = NULL,*o2 = NULL, *o3 = NULL;
     PTRNTAB ptb;
     unsigned usNumops;
-    unsigned char uchPrefix = 0;
-    unsigned char bAsmseen;
-    char *pszLabel = NULL;
-    code *c;
     FuncDeclaration *fd = sc->parent->isFuncDeclaration();
 
     assert(fd);

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3935,6 +3935,7 @@ STATIC OPND *asm_una_exp()
 
 #if 0
                 case TOKlparen:
+                    Type *ptypeSpec;
                     // stoken() is called directly here because we really
                     // want the INT token to be an INT.
                     stoken();

--- a/src/init.c
+++ b/src/init.c
@@ -508,7 +508,6 @@ Lerr:
 
 Expression *ArrayInitializer::toExpression()
 {   Expressions *elements;
-    Expression *e;
 
     //printf("ArrayInitializer::toExpression(), dim = %d\n", dim);
     //static int i; if (++i == 2) halt();

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -176,7 +176,6 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
     Type *tb = type->toBasetype();
     assert(tb->ty == Tfunction);
     TypeFunction *tf = (TypeFunction *)tb;
-    Type *tret = tf->next->toBasetype();
     if (tf->varargs && arguments &&
         ((parameters && arguments->dim != parameters->dim) || (!parameters && arguments->dim)))
     {   cantInterpret = 1;
@@ -1406,7 +1405,6 @@ Expression *SymOffExp::interpret(InterState *istate, CtfeGoal goal)
     Expression *val = getVarExp(loc, istate, var, goal);
     if (val->type->ty == Tarray || val->type->ty == Tsarray)
     {
-        TypeArray *tar = (TypeArray *)val->type;
         dinteger_t sz = pointee->size();
         dinteger_t indx = offset/sz;
         assert(sz * indx == offset);
@@ -2145,7 +2143,6 @@ Expression *pointerArithmetic(Loc loc, enum TOK op, Type *type,
     dinteger_t len = dollar->toInteger();
 
     Expression *val = agg1;
-    TypeArray *tar = (TypeArray *)val->type;
     dinteger_t indx = ofs1;
     if (op == TOKadd || op == TOKaddass)
         indx = indx + ofs2/sz;
@@ -2258,9 +2255,7 @@ Expression *comparePointers(Loc loc, enum TOK op, Type *type, Expression *e1, Ex
         ((StringExp *)agg1)->string == ((StringExp *)agg2)->string))
 
     {
-        dinteger_t cm = ofs1 - ofs2;
         dinteger_t n;
-        dinteger_t zero = 0;
         switch(op)
         {
         case TOKlt:          n = (ofs1 <  ofs2); break;
@@ -4262,7 +4257,6 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
         }
         assert(agg->op == TOKarrayliteral || agg->op == TOKstring);
         dinteger_t len = ArrayLength(Type::tsize_t, agg)->toInteger();
-        Type *pointee = ((TypePointer *)agg->type)->next;
         if ((ilwr + ofs) < 0 || (iupr+ofs) > (len + 1) || iupr < ilwr)
         {
             error("pointer slice [%jd..%jd] exceeds allocated memory block [0..%jd]",

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1983,7 +1983,6 @@ TOK Lexer::number(Token *t)
     };
     enum FLAGS flags = FLAGS_decimal;
 
-    int i;
     int base;
     unsigned c;
     unsigned char *start;

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -391,8 +391,6 @@ void Library::addObject(const char *module_name, void *buf, size_t buflen)
         unsigned offset = 8;
         char *symtab = NULL;
         unsigned symtab_size = 0;
-        char *filenametab = NULL;
-        unsigned filenametab_size = 0;
         unsigned mstart = objmodules.dim;
         while (offset < buflen)
         {

--- a/src/mars.c
+++ b/src/mars.c
@@ -101,7 +101,6 @@ Global::Global()
 char *Loc::toChars()
 {
     OutBuffer buf;
-    char *p;
 
     if (filename)
     {

--- a/src/module.c
+++ b/src/module.c
@@ -62,8 +62,6 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
         : Package(ident)
 {
     FileName *srcfilename;
-    FileName *cfilename;
-    FileName *hfilename;
     FileName *objfilename;
     FileName *symfilename;
 
@@ -1045,8 +1043,8 @@ void Module::runDeferredSemantic()
 int Module::imports(Module *m)
 {
     //printf("%s Module::imports(%s)\n", toChars(), m->toChars());
-    int aimports_dim = aimports.dim;
 #if 0
+    int aimports_dim = aimports.dim;
     for (int i = 0; i < aimports.dim; i++)
     {   Module *mi = (Module *)aimports.data[i];
         printf("\t[%d] %s\n", i, mi->toChars());

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5700,6 +5700,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
             return;
         }
 #if 0
+        FuncDeclaration *fd;
         fd = s->isFuncDeclaration();
         if (fd)
         {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -168,7 +168,6 @@ char Type::needThisPrefix()
 
 void Type::init()
 {   int i;
-    int j;
 
     Lexer::initKeywords();
 
@@ -5603,9 +5602,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
         Expression **pe, Type **pt, Dsymbol **ps)
 {
     VarDeclaration *v;
-    FuncDeclaration *fd;
     EnumMember *em;
-    TupleDeclaration *td;
     Expression *e;
 
 #if 0
@@ -6101,7 +6098,7 @@ void TypeTypeof::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
 }
 
 Type *TypeTypeof::semantic(Loc loc, Scope *sc)
-{   Expression *e;
+{
     Type *t;
 
     //printf("TypeTypeof::semantic() %s\n", toChars());
@@ -6921,8 +6918,7 @@ void TypeStruct::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
 }
 
 Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident)
-{   unsigned offset;
-
+{
     VarDeclaration *v;
     Dsymbol *s;
     DotVarExp *de;
@@ -7402,9 +7398,7 @@ void TypeClass::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
 }
 
 Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident)
-{   unsigned offset;
-
-    Expression *b;
+{
     VarDeclaration *v;
     Dsymbol *s;
 

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -153,7 +153,6 @@ Expression *fromConstInitializer(int result, Expression *e1)
     if (e1->op == TOKvar)
     {   VarExp *ve = (VarExp *)e1;
         VarDeclaration *v = ve->var->isVarDeclaration();
-        int fwdref = (v && !v->originalType && v->scope);
         e = expandVar(result, v);
         if (e)
         {

--- a/src/parse.c
+++ b/src/parse.c
@@ -692,7 +692,6 @@ StorageClass Parser::parsePostfix()
 Dsymbols *Parser::parseBlock()
 {
     Dsymbols *a = NULL;
-    Dsymbol *s;
 
     //printf("parseBlock()\n");
     switch (token.value)
@@ -911,8 +910,6 @@ Condition *Parser::parseVersionCondition()
 Condition *Parser::parseStaticIfCondition()
 {   Expression *exp;
     Condition *condition;
-    Array *aif;
-    Array *aelse;
     Loc loc = this->loc;
 
     nextToken();
@@ -1214,7 +1211,7 @@ Parameters *Parser::parseParameters(int *pvarargs)
 
     check(TOKlparen);
     while (1)
-    {   Type *tb;
+    {
         Identifier *ai = NULL;
         Type *at;
         Parameter *a;
@@ -2871,7 +2868,6 @@ L2:
         }
         else if (t->ty == Tfunction)
         {
-            TypeFunction *tf = (TypeFunction *)t;
             Expression *constraint = NULL;
 #if 0
             if (Parameter::isTPL(tf->parameters))
@@ -4354,9 +4350,6 @@ int Parser::isBasicType(Token **pt)
 {
     // This code parallels parseBasicType()
     Token *t = *pt;
-    Token *t2;
-    int parens;
-    int haveId = 0;
 
     switch (t->value)
     {
@@ -5463,7 +5456,6 @@ Expression *Parser::parsePostExp(Expression *e)
                     nextToken();
                     if (token.value == TOKnot && peekNext() != TOKis)
                     {   // identifier!(template-argument-list)
-                        TemplateInstance *tempinst = new TemplateInstance(loc, id);
                         Objects *tiargs;
                         nextToken();
                         if (token.value == TOKlparen)

--- a/src/parse.c
+++ b/src/parse.c
@@ -2870,6 +2870,7 @@ L2:
         {
             Expression *constraint = NULL;
 #if 0
+            TypeFunction *tf = (TypeFunction *)t;
             if (Parameter::isTPL(tf->parameters))
             {
                 if (!tpl)

--- a/src/ph.c
+++ b/src/ph.c
@@ -139,7 +139,6 @@ void ph_free(void *p)
 
 void * __cdecl ph_realloc(void *p,size_t nbytes)
 {   void *newp;
-    unsigned i;
 
     //dbg_printf("ph_realloc(%p,%d)\n",p,nbytes);
     if (!p)

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -35,7 +35,7 @@ ifeq (OSX,$(TARGET))
     ENVP= MACOSX_DEPLOYMENT_TARGET=10.3
     SDK=/Developer/SDKs/MacOSX10.4u.sdk #doesn't work because can't find <stdarg.h>
     SDK=/Developer/SDKs/MacOSX10.5.sdk
-    #SDK=/Developer/SDKs/MacOSX10.6.sdk
+    SDK=/Developer/SDKs/MacOSX10.6.sdk
 
     TARGET_CFLAGS=-isysroot ${SDK}
     LDFLAGS=-lstdc++ -isysroot ${SDK} -Wl,-syslibroot,${SDK} -framework CoreServices
@@ -50,10 +50,10 @@ CC=g++ -m$(MODEL) $(TARGET_CFLAGS)
 
 #COV=-fprofile-arcs -ftest-coverage
 
-WARNINGS=-Wno-deprecated -Wstrict-aliasing
+WARNINGS=-Wno-deprecated -Wstrict-aliasing -Wall
 
-#GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
-GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
+GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
+#GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
 CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1
 MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_$(TARGET)=1

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -35,7 +35,7 @@ ifeq (OSX,$(TARGET))
     ENVP= MACOSX_DEPLOYMENT_TARGET=10.3
     SDK=/Developer/SDKs/MacOSX10.4u.sdk #doesn't work because can't find <stdarg.h>
     SDK=/Developer/SDKs/MacOSX10.5.sdk
-    SDK=/Developer/SDKs/MacOSX10.6.sdk
+    #SDK=/Developer/SDKs/MacOSX10.6.sdk
 
     TARGET_CFLAGS=-isysroot ${SDK}
     LDFLAGS=-lstdc++ -isysroot ${SDK} -Wl,-syslibroot,${SDK} -framework CoreServices
@@ -50,10 +50,10 @@ CC=g++ -m$(MODEL) $(TARGET_CFLAGS)
 
 #COV=-fprofile-arcs -ftest-coverage
 
-WARNINGS=-Wno-deprecated -Wstrict-aliasing -Wall
+WARNINGS=-Wno-deprecated -Wstrict-aliasing
 
-GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
-#GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
+#GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
+GFLAGS = $(WARNINGS) -D__near= -D__pascal= -fno-exceptions -O2
 
 CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1
 MFLAGS = $(GFLAGS) -I$C -I$(TK) -DMARS=1 -DTARGET_$(TARGET)=1

--- a/src/statement.c
+++ b/src/statement.c
@@ -2232,6 +2232,7 @@ Statement *ForeachRangeStatement::semantic(Scope *sc)
     if (!arg->type->isscalar())
         error("%s is not a scalar type", arg->type->toChars());
 
+    ScopeDsymbol *sym;
     sym = new ScopeDsymbol();
     sym->parent = sc->scopesym;
     sc = sc->push(sym);

--- a/src/statement.c
+++ b/src/statement.c
@@ -2123,7 +2123,6 @@ Statement *ForeachRangeStatement::syntaxCopy()
 Statement *ForeachRangeStatement::semantic(Scope *sc)
 {
     //printf("ForeachRangeStatement::semantic() %p\n", this);
-    ScopeDsymbol *sym;
     Statement *s = this;
 
     lwr = lwr->semantic(sc);
@@ -2164,7 +2163,6 @@ Statement *ForeachRangeStatement::semantic(Scope *sc)
         else
         {
             AddExp ea(loc, lwr, upr);
-            Expression *e = ea.typeCombine(sc);
             arg->type = ea.type->mutableOf();
             lwr = ea.e1;
             upr = ea.e2;

--- a/src/template.c
+++ b/src/template.c
@@ -1348,7 +1348,6 @@ Lmatch:
          *  static assert(!is(typeof(foo(7))));
          * Recursive attempts are regarded as a constraint failure.
          */
-        int nmatches = 0;
         for (Previous *p = previous; p; p = p->prev)
         {
             if (arrayObjectMatch(p->dedargs, dedargs, this, sc))
@@ -2335,9 +2334,9 @@ MATCH TypeInstance::deduceType(Scope *sc,
             Dsymbol *s1 = isDsymbol(o1);
             Dsymbol *s2 = isDsymbol(o2);
 
+#if 0
             Tuple *v1 = isTuple(o1);
             Tuple *v2 = isTuple(o2);
-#if 0
             if (t1)     printf("t1 = %s\n", t1->toChars());
             if (t2)     printf("t2 = %s\n", t2->toChars());
             if (e1)     printf("e1 = %s\n", e1->toChars());
@@ -4229,7 +4228,6 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                 TupleDeclaration *d = sa->toAlias()->isTupleDeclaration();
                 if (d)
                 {
-                    size_t dim = d->objects->dim;
                     tiargs->remove(j);
                     tiargs->insert(j, d->objects);
                     j--;
@@ -4334,7 +4332,6 @@ TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc)
         Dsymbol *s;
         Dsymbol *scopesym;
         Identifier *id;
-        int i;
 
         id = name;
         s = sc->search(loc, id, &scopesym);
@@ -4699,8 +4696,6 @@ Identifier *TemplateInstance::genIdent(Objects *args)
         else if (ea)
         {
           Lea:
-            sinteger_t v;
-            real_t r;
             // Don't interpret it yet, it might actually be an alias
             ea = ea->optimize(WANTvalue);
             if (ea->op == TOKvar)

--- a/src/tk/filespec.c
+++ b/src/tk/filespec.c
@@ -116,6 +116,7 @@ char * filespecrootpath(char *filespec)
     cwd_t = (char *)getcwd(NULL, 256);
 #endif
 #if MSDOS || __OS2__ || __NT__ || _WIN32
+    char cwd[132];
     if (getcwd(cwd_d, sizeof(cwd_d)))
        cwd_t = cwd_d;
     else

--- a/src/tk/filespec.c
+++ b/src/tk/filespec.c
@@ -97,7 +97,7 @@ char * filespecrootpath(char *filespec)
 #define DIRCHAR ':'
 #endif
 
-    char *cwd, *cwd_t, cwd_d[132];
+    char *cwd, *cwd_t;
     char *p, *p2;
 
     if (!filespec)

--- a/src/tk/vec.c
+++ b/src/tk/vec.c
@@ -51,7 +51,7 @@ void vec_init()
 void vec_term()
 {
     if (--vec_initcount == 0)
-    {   int i;
+    {
 
 #ifdef DEBUG
         if (vec_count != 0)

--- a/src/tk/vec.c
+++ b/src/tk/vec.c
@@ -63,6 +63,7 @@ void vec_term()
         assert(vec_count == 0);
 #endif
 #if TERMCODE
+        int i;
         for (i = 0; i < VECMAX; i++)
         {   void **v;
             void **vn;

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -754,7 +754,6 @@ Symbol *TypeAArray::aaGetSymbol(const char *func, int flags)
     __body
 #endif
     {
-        int sz;
         char *id;
         type *t;
         Symbol *s;

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -764,6 +764,7 @@ Symbol *TypeAArray::aaGetSymbol(const char *func, int flags)
 
         //printf("aaGetSymbol(func = '%s', flags = %d, key = %p)\n", func, flags, key);
 #if 0
+        int sz;
         OutBuffer buf;
         key->toKeyBuffer(&buf);
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -47,16 +47,11 @@ void Module::genmoduleinfo()
     //printf("Module::genmoduleinfo() %s\n", toChars());
 
     Symbol *msym = toSymbol();
-    unsigned offset;
 #if DMDV2
     unsigned sizeof_ModuleInfo = 16 * PTRSIZE;
 #else
     unsigned sizeof_ModuleInfo = 14 * PTRSIZE;
 #endif
-#if !MODULEINFO_IS_STRUCT
-    sizeof_ModuleInfo -= 2 * PTRSIZE;
-#endif
-    //printf("moduleinfo size = x%x\n", sizeof_ModuleInfo);
 
     //////////////////////////////////////////////
 
@@ -918,7 +913,6 @@ unsigned ClassDeclaration::baseVtblOffset(BaseClass *bc)
 
 void InterfaceDeclaration::toObjFile(int multiobj)
 {   unsigned i;
-    Symbol *sinit;
     enum_SC scclass;
 
     //printf("InterfaceDeclaration::toObjFile('%s')\n", toChars());

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -519,8 +519,6 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
 
     FuncDeclaration *fd;
     FuncDeclaration *fdx;
-    TypeFunction *tf;
-    Type *ta;
     Dsymbol *s;
 
     static TypeFunction *tftohash;


### PR DESCRIPTION
This significantly cuts down on the number of warnings produced when compiling dmd with -Wall.
