### PR TITLE
Isue 4424 & 6216 Relax opAssign signature

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -130,7 +130,7 @@ enum PROT Declaration::prot()
 
 #if DMDV2
 
-void Declaration::checkModify(Loc loc, Scope *sc, Type *t)
+int Declaration::checkModify(Loc loc, Scope *sc, Type *t)
 {
     if (sc->incontract && isParameter())
         error(loc, "cannot modify parameter '%s' in contract", toChars());
@@ -141,27 +141,15 @@ void Declaration::checkModify(Loc loc, Scope *sc, Type *t)
     if (isCtorinit() && !t->isMutable() ||
         (storage_class & STCnodefaultctor))
     {   // It's only modifiable if inside the right constructor
-        modifyFieldVar(loc, sc, isVarDeclaration(), NULL);
+        return modifyFieldVar(loc, sc, isVarDeclaration(), NULL);
     }
     else
     {
         VarDeclaration *v = isVarDeclaration();
-        if (v && v->canassign == 0)
-        {
-            const char *p = NULL;
-            if (isConst())
-                p = "const";
-            else if (isImmutable())
-                p = "immutable";
-            else if (isWild())
-                p = "inout";
-            else if (storage_class & STCmanifest)
-                p = "enum";
-            if (p)
-            {   error(loc, "cannot modify %s", p);
-            }
-        }
+        if (v && v->canassign)
+            return TRUE;
     }
+    return FALSE;
 }
 #endif
 

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -157,8 +157,6 @@ void Declaration::checkModify(Loc loc, Scope *sc, Type *t)
                 p = "inout";
             else if (storage_class & STCmanifest)
                 p = "enum";
-            else if (!t->isAssignable())
-                p = "struct with immutable members";
             if (p)
             {   error(loc, "cannot modify %s", p);
             }

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -135,7 +135,7 @@ struct Declaration : Dsymbol
     void semantic(Scope *sc);
     const char *kind();
     unsigned size(Loc loc);
-    void checkModify(Loc loc, Scope *sc, Type *t);
+    int checkModify(Loc loc, Scope *sc, Type *t);
 
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -79,7 +79,7 @@ Expression *fromConstInitializer(int result, Expression *e);
 int arrayExpressionCanThrow(Expressions *exps, bool mustNotThrow);
 TemplateDeclaration *getFuncTemplateDecl(Dsymbol *s);
 void valueNoDtor(Expression *e);
-void modifyFieldVar(Loc loc, Scope *sc, VarDeclaration *var, Expression *e1);
+int modifyFieldVar(Loc loc, Scope *sc, VarDeclaration *var, Expression *e1);
 #if DMDV2
 Expression *resolveAliasThis(Scope *sc, Expression *e);
 Expression *callCpCtor(Loc loc, Scope *sc, Expression *e, int noscope);
@@ -151,6 +151,8 @@ struct Expression : Object
     void checkPurity(Scope *sc, FuncDeclaration *f);
     void checkPurity(Scope *sc, VarDeclaration *v, Expression *e1);
     void checkSafety(Scope *sc, FuncDeclaration *f);
+    void checkModifiable(Scope *sc);
+    virtual int checkCtorInit(Scope *sc);
     virtual Expression *checkToBoolean(Scope *sc);
     virtual Expression *addDtorHook(Scope *sc);
     Expression *checkToPointer();
@@ -636,6 +638,7 @@ struct VarExp : SymbolExp
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void checkEscape();
     void checkEscapeRef();
+    int checkCtorInit(Scope *sc);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
@@ -891,6 +894,7 @@ struct DotVarExp : UnaExp
 
     DotVarExp(Loc loc, Expression *e, Declaration *var, int hasOverloads = 0);
     Expression *semantic(Scope *sc);
+    int checkCtorInit(Scope *sc);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
@@ -987,8 +991,9 @@ struct PtrExp : UnaExp
     PtrExp(Loc loc, Expression *e);
     PtrExp(Loc loc, Expression *e, Type *t);
     Expression *semantic(Scope *sc);
-    int isLvalue();
     void checkEscapeRef();
+    int checkCtorInit(Scope *sc);
+    int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -1120,6 +1125,7 @@ struct SliceExp : UnaExp
     Expression *semantic(Scope *sc);
     void checkEscape();
     void checkEscapeRef();
+    int checkCtorInit(Scope *sc);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
@@ -1187,6 +1193,7 @@ struct CommaExp : BinExp
     Expression *semantic(Scope *sc);
     void checkEscape();
     void checkEscapeRef();
+    int checkCtorInit(Scope *sc);
     IntRange getIntRange();
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -1208,6 +1215,7 @@ struct IndexExp : BinExp
     IndexExp(Loc loc, Expression *e1, Expression *e2);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
+    int checkCtorInit(Scope *sc);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
@@ -1632,6 +1640,7 @@ struct CondExp : BinExp
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void checkEscape();
     void checkEscapeRef();
+    int checkCtorInit(Scope *sc);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);

--- a/src/func.c
+++ b/src/func.c
@@ -712,32 +712,6 @@ void FuncDeclaration::semantic(Scope *sc)
         }
     }
 
-    if (ident == Id::assign && (sd || cd))
-    {   // Disallow identity assignment operator.
-
-        // opAssign(...)
-        if (nparams == 0)
-        {   if (f->varargs == 1)
-                goto Lassignerr;
-        }
-        else
-        {
-            Parameter *arg0 = Parameter::getNth(f->parameters, 0);
-            Type *t0 = arg0->type->toBasetype();
-            Type *tb = sd ? sd->type : cd->type;
-            if (arg0->type->implicitConvTo(tb) ||
-                (sd && t0->ty == Tpointer && t0->nextOf()->implicitConvTo(tb))
-               )
-            {
-                if (nparams == 1)
-                    goto Lassignerr;
-                Parameter *arg1 = Parameter::getNth(f->parameters, 1);
-                if (arg1->defaultArg)
-                    goto Lassignerr;
-            }
-        }
-    }
-
     if (isVirtual() && semanticRun != PASSsemanticdone)
     {
         /* Rewrite contracts as nested functions, then call them.
@@ -803,14 +777,6 @@ Ldone:
     scope = new Scope(*sc);
     scope->setNoFree();
     return;
-
-Lassignerr:
-    if (sd)
-    {
-        sd->hasIdentityAssign = 1;      // don't need to generate it
-        goto Ldone;
-    }
-    error("identity assignment operator overload is illegal");
 }
 
 void FuncDeclaration::semantic2(Scope *sc)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1749,7 +1749,7 @@ int Type::isString()
  *      a = b;
  * ?
  */
-int Type::isAssignable()
+int Type::isAssignable(int blit)
 {
     return TRUE;
 }
@@ -7323,9 +7323,9 @@ int TypeEnum::isscalar()
     return sym->memtype->isscalar();
 }
 
-int TypeEnum::isAssignable()
+int TypeEnum::isAssignable(int blit)
 {
-    return sym->memtype->isAssignable();
+    return sym->memtype->isAssignable(blit);
 }
 
 int TypeEnum::checkBoolean()
@@ -7532,9 +7532,9 @@ int TypeTypedef::isscalar()
     return sym->basetype->isscalar();
 }
 
-int TypeTypedef::isAssignable()
+int TypeTypedef::isAssignable(int blit)
 {
-    return sym->basetype->isAssignable();
+    return sym->basetype->isAssignable(blit);
 }
 
 int TypeTypedef::checkBoolean()
@@ -8045,8 +8045,18 @@ int TypeStruct::needsDestruction()
     return sym->dtor != NULL;
 }
 
-int TypeStruct::isAssignable()
+int TypeStruct::isAssignable(int blit)
 {
+    if (!blit)
+    {
+        if (sym->hasIdentityAssign)
+            return TRUE;
+
+        // has non-identity opAssign
+        if (search_function(sym, Id::assign))
+            return FALSE;
+    }
+
     int assignable = TRUE;
     unsigned offset;
 
@@ -8072,7 +8082,7 @@ int TypeStruct::isAssignable()
             if (!assignable)
                 return FALSE;
         }
-        assignable = v->type->isMutable() && v->type->isAssignable();
+        assignable = v->type->isMutable() && v->type->isAssignable(blit);
         offset = v->offset;
         //printf(" -> assignable = %d\n", assignable);
     }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -252,7 +252,7 @@ struct Type : Object
     virtual int isunsigned();
     virtual int isscope();
     virtual int isString();
-    virtual int isAssignable();
+    virtual int isAssignable(int blit = 0);
     virtual int checkBoolean(); // if can be converted to boolean value
     virtual void checkDeprecated(Loc loc, Scope *sc);
     int isConst()       { return mod & MODconst; }
@@ -770,7 +770,7 @@ struct TypeStruct : Type
     Expression *defaultInitLiteral(Loc loc);
     Expression *voidInitLiteral(VarDeclaration *var);
     int isZeroInit(Loc loc);
-    int isAssignable();
+    int isAssignable(int blit = 0);
     int checkBoolean();
     int needsDestruction();
     dt_t **toDt(dt_t **pdt);
@@ -812,7 +812,7 @@ struct TypeEnum : Type
     int isscalar();
     int isunsigned();
     int checkBoolean();
-    int isAssignable();
+    int isAssignable(int blit = 0);
     int needsDestruction();
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
@@ -854,7 +854,7 @@ struct TypeTypedef : Type
     int isscalar();
     int isunsigned();
     int checkBoolean();
-    int isAssignable();
+    int isAssignable(int blit = 0);
     int needsDestruction();
     Type *toBasetype();
     MATCH implicitConvTo(Type *to);

--- a/src/statement.c
+++ b/src/statement.c
@@ -3992,11 +3992,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
     {
         if (((TypeFunction *)fd->type)->isref && !fd->isCtorDeclaration())
         {   // Function returns a reference
-            if (tret->isMutable())
-                exp = exp->modifiableLvalue(sc, exp);
-            else
-                exp = exp->toLvalue(sc, exp);
-
+            exp = exp->toLvalue(sc, exp);
             exp->checkEscapeRef();
         }
         else

--- a/src/struct.c
+++ b/src/struct.c
@@ -638,7 +638,7 @@ void StructDeclaration::semantic(Scope *sc)
     postblit = buildPostBlit(sc2);
     cpctor = buildCpCtor(sc2);
 
-    buildOpAssign(sc2);
+    hasIdentityAssign = (buildOpAssign(sc2) != NULL);
     hasIdentityEquals = (buildOpEquals(sc2) != NULL);
 
     xeq = buildXopEquals(sc2);

--- a/test/fail_compilation/class1.d
+++ b/test/fail_compilation/class1.d
@@ -1,0 +1,5 @@
+class C
+{
+    // Non-templated identity opAssign
+    void opAssign(C rhs){}
+}

--- a/test/fail_compilation/class2.d
+++ b/test/fail_compilation/class2.d
@@ -1,0 +1,5 @@
+class C
+{
+    // Templated identity opAssign
+    void opAssign(T)(T rhs){}
+}

--- a/test/fail_compilation/fail7695.d
+++ b/test/fail_compilation/fail7695.d
@@ -1,9 +1,0 @@
-struct Bar {
-    const int t;
-}
-
-void main( ) {
-    int[Bar] a;
-    int n = a.length;
-}
-

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -222,6 +222,744 @@ void test4424()
 }
 
 /***************************************************/
+// 6174
+
+struct TestCtor1_6174
+{
+    const int num;
+
+    const int[2] sa1;
+    const int[2][1] sa2;
+    const int[][2] sa3;
+
+    const int[] da1;
+    const int[2][] da2;
+
+    this(int _dummy)
+    {
+        static assert( __traits(compiles, { num         = 1;        }));    // OK
+
+        auto pnum = &num;
+        static assert(!__traits(compiles, { *pnum       = 1;        }));    // NG
+        static assert( __traits(compiles, { *&num       = 1;        }));    // OK
+
+        static assert( __traits(compiles, { sa1         = [1,2];    }));    // OK
+        static assert( __traits(compiles, { sa1[0]      = 1;        }));    // OK
+        static assert( __traits(compiles, { sa1[]       = 1;        }));    // OK
+        static assert( __traits(compiles, { sa1[][]     = 1;        }));    // OK
+
+        static assert( __traits(compiles, { sa2         = [[1,2]];  }));    // OK
+        static assert( __traits(compiles, { sa2[0][0]   = 1;        }));    // OK
+        static assert( __traits(compiles, { sa2[][0][]  = 1;        }));    // OK
+        static assert( __traits(compiles, { sa2[0][][0] = 1;        }));    // OK
+
+        static assert( __traits(compiles, { sa3         = [[1],[]]; }));    // OK
+        static assert( __traits(compiles, { sa3[0]      = [1,2];    }));    // OK
+        static assert(!__traits(compiles, { sa3[0][0]   = 1;        }));    // NG
+        static assert( __traits(compiles, { sa3[]       = [1];      }));    // OK
+        static assert( __traits(compiles, { sa3[][0]    = [1];      }));    // OK
+        static assert(!__traits(compiles, { sa3[][0][0] = 1;        }));    // NG
+
+        static assert( __traits(compiles, { da1         = [1,2];    }));    // OK
+        static assert(!__traits(compiles, { da1[0]      = 1;        }));    // NG
+        static assert(!__traits(compiles, { da1[]       = 1;        }));    // NG
+
+        static assert( __traits(compiles, { da2         = [[1,2]];  }));    // OK
+        static assert(!__traits(compiles, { da2[0][0]   = 1;        }));    // NG
+        static assert(!__traits(compiles, { da2[]       = [1,2];    }));    // NG
+        static assert(!__traits(compiles, { da2[][0]    = 1;        }));    // NG
+        static assert(!__traits(compiles, { da2[0][]    = 1;        }));    // NG
+    }
+    void func()
+    {
+        static assert(!__traits(compiles, { num         = 1;        }));    // NG
+
+        auto pnum = &num;
+        static assert(!__traits(compiles, { *pnum       = 1;        }));    // NG
+        static assert(!__traits(compiles, { *&num       = 1;        }));    // NG
+
+        static assert(!__traits(compiles, { sa1         = [1,2];    }));    // NG
+        static assert(!__traits(compiles, { sa1[0]      = 1;        }));    // NG
+        static assert(!__traits(compiles, { sa1[]       = 1;        }));    // NG
+        static assert(!__traits(compiles, { sa1[][]     = 1;        }));    // NG
+
+        static assert(!__traits(compiles, { sa2         = [[1,2]];  }));    // NG
+        static assert(!__traits(compiles, { sa2[0][0]   = 1;        }));    // NG
+        static assert(!__traits(compiles, { sa2[][0][]  = 1;        }));    // NG
+        static assert(!__traits(compiles, { sa2[0][][0] = 1;        }));    // NG
+
+        static assert(!__traits(compiles, { sa3         = [[1],[]]; }));    // NG
+        static assert(!__traits(compiles, { sa3[0]      = [1,2];    }));    // NG
+        static assert(!__traits(compiles, { sa3[0][0]   = 1;        }));    // NG
+        static assert(!__traits(compiles, { sa3[]       = [1];      }));    // NG
+        static assert(!__traits(compiles, { sa3[][0]    = [1];      }));    // NG
+        static assert(!__traits(compiles, { sa3[][0][0] = 1;        }));    // NG
+
+        static assert(!__traits(compiles, { da1         = [1,2];    }));    // NG
+        static assert(!__traits(compiles, { da1[0]      = 1;        }));    // NG
+        static assert(!__traits(compiles, { da1[]       = 1;        }));    // NG
+
+        static assert(!__traits(compiles, { da2         = [[1,2]];  }));    // NG
+        static assert(!__traits(compiles, { da2[0][0]   = 1;        }));    // NG
+        static assert(!__traits(compiles, { da2[]       = [1,2];    }));    // NG
+        static assert(!__traits(compiles, { da2[][0]    = 1;        }));    // NG
+        static assert(!__traits(compiles, { da2[0][]    = 1;        }));    // NG
+    }
+}
+
+struct TestCtor2_6174
+{
+    static struct Data
+    {
+        const int x;
+        int y;
+    }
+    const Data data;
+
+    const Data[2] sa1;
+    const Data[2][1] sa2;
+    const Data[][2] sa3;
+
+    const Data[] da1;
+    const Data[2][] da2;
+
+    this(int _dummy)
+    {
+        Data a;
+        static assert( __traits(compiles, { data        = a;        }));    // OK
+        static assert( __traits(compiles, { data.x      = 1;        }));    // OK
+        static assert( __traits(compiles, { data.y      = 2;        }));    // OK
+
+        auto pdata = &data;
+        static assert(!__traits(compiles, { *pdata      = a;        }));    // NG
+        static assert( __traits(compiles, { *&data      = a;        }));    // OK
+
+        static assert( __traits(compiles, { sa1         = [a,a];    }));    // OK
+        static assert( __traits(compiles, { sa1[0]      = a;        }));    // OK
+        static assert( __traits(compiles, { sa1[]       = a;        }));    // OK
+        static assert( __traits(compiles, { sa1[][]     = a;        }));    // OK
+
+        static assert( __traits(compiles, { sa2         = [[a,a]];  }));    // OK
+        static assert( __traits(compiles, { sa2[0][0]   = a;        }));    // OK
+        static assert( __traits(compiles, { sa2[][0][]  = a;        }));    // OK
+        static assert( __traits(compiles, { sa2[0][][0] = a;        }));    // OK
+
+        static assert( __traits(compiles, { sa3         = [[a],[]]; }));    // OK
+        static assert( __traits(compiles, { sa3[0]      = [a,a];    }));    // OK
+        static assert(!__traits(compiles, { sa3[0][0]   = a;        }));    // NG
+        static assert( __traits(compiles, { sa3[]       = [a];      }));    // OK
+        static assert( __traits(compiles, { sa3[][0]    = [a];      }));    // OK
+        static assert(!__traits(compiles, { sa3[][0][0] = a;        }));    // NG
+
+        static assert( __traits(compiles, { da1         = [a,a];    }));    // OK
+        static assert(!__traits(compiles, { da1[0]      = a;        }));    // NG
+        static assert(!__traits(compiles, { da1[]       = a;        }));    // NG
+
+        static assert( __traits(compiles, { da2         = [[a,a]];  }));    // OK
+        static assert(!__traits(compiles, { da2[0][0]   = a;        }));    // NG
+        static assert(!__traits(compiles, { da2[]       = [a,a];    }));    // NG
+        static assert(!__traits(compiles, { da2[][0]    = a;        }));    // NG
+        static assert(!__traits(compiles, { da2[0][]    = a;        }));    // NG
+    }
+    void func()
+    {
+        Data a;
+        static assert(!__traits(compiles, { data        = a;        }));    // NG
+        static assert(!__traits(compiles, { data.x      = 1;        }));    // NG
+        static assert(!__traits(compiles, { data.y      = 2;        }));    // NG
+
+        auto pdata = &data;
+        static assert(!__traits(compiles, { *pdata      = a;        }));    // NG
+        static assert(!__traits(compiles, { *&data      = a;        }));    // NG
+
+        static assert(!__traits(compiles, { sa1         = [a,a];    }));    // NG
+        static assert(!__traits(compiles, { sa1[0]      = a;        }));    // NG
+        static assert(!__traits(compiles, { sa1[]       = a;        }));    // NG
+        static assert(!__traits(compiles, { sa1[][]     = a;        }));    // NG
+
+        static assert(!__traits(compiles, { sa2         = [[a,a]];  }));    // NG
+        static assert(!__traits(compiles, { sa2[0][0]   = a;        }));    // NG
+        static assert(!__traits(compiles, { sa2[][0][]  = a;        }));    // NG
+        static assert(!__traits(compiles, { sa2[0][][0] = a;        }));    // NG
+
+        static assert(!__traits(compiles, { sa3         = [[a],[]]; }));    // NG
+        static assert(!__traits(compiles, { sa3[0]      = [a,a];    }));    // NG
+        static assert(!__traits(compiles, { sa3[0][0]   = a;        }));    // NG
+        static assert(!__traits(compiles, { sa3[]       = [a];      }));    // NG
+        static assert(!__traits(compiles, { sa3[][0]    = [a];      }));    // NG
+        static assert(!__traits(compiles, { sa3[][0][0] = a;        }));    // NG
+
+        static assert(!__traits(compiles, { da1         = [a,a];    }));    // NG
+        static assert(!__traits(compiles, { da1[0]      = a;        }));    // NG
+        static assert(!__traits(compiles, { da1[]       = a;        }));    // NG
+
+        static assert(!__traits(compiles, { da2         = [[a,a]];  }));    // NG
+        static assert(!__traits(compiles, { da2[0][0]   = a;        }));    // NG
+        static assert(!__traits(compiles, { da2[]       = [a,a];    }));    // NG
+        static assert(!__traits(compiles, { da2[][0]    = a;        }));    // NG
+        static assert(!__traits(compiles, { da2[0][]    = a;        }));    // NG
+    }
+}
+
+const char gc6174;
+const char[1] ga6174;
+static this()
+{
+    gc6174 = 'a';    // OK
+    ga6174[0] = 'a'; // line 5, Err
+}
+struct Foo6174
+{
+    const char cc;
+    const char[1] array;
+    this(char c)
+    {
+        cc = c;       // OK
+        array = [c];  // line 12, Err
+        array[0] = c; // line 12, Err
+    }
+}
+void test6174a()
+{
+    auto foo = Foo6174('c');
+}
+
+/***************************************************/
+
+void test6174Int()
+{
+    printf("## TestInt\n");
+
+    static struct Test1
+    {
+        int x;
+        this(int _)
+        {
+            x = 100;
+        }
+        void func()
+        {
+            x = 100;
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, x = 100));
+        }
+    }
+    static struct Test2
+    {
+        const int x;
+        this(int _)
+        {
+            x = 100;
+        }
+        void func()
+        {
+            static assert(!__traits(compiles, x = 100));
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, x = 100));
+        }
+    }
+}
+
+void test6174FA()   // field assignable
+{
+    printf("## TestFA\n");
+
+    static struct D
+    {
+        int x;
+        int y;
+    }
+    static struct Test1
+    {
+        D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+    static struct Test2
+    {
+        const D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+}
+
+void test6174FN()   // field not assignable
+{
+    printf("## TestFN\n");
+
+    static struct D
+    {
+        const int x;
+        int y;
+    }
+    static struct Test1
+    {
+        D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            d.y = 100;
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+    static struct Test2
+    {
+        const D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+}
+
+void test6174IAFA() // identity assignable & field assignable
+{
+    printf("## TestIAFA\n");
+
+    static struct D
+    {
+        int x;
+        int y;
+        void opAssign(typeof(this) rhs){}
+    }
+    static struct Test1
+    {
+        D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+    static struct Test2
+    {
+        const D d;
+        this(int _)
+        {
+            static assert(!__traits(compiles, d = D.init)); // operator overloading cannot bypass type check even if inside constructor
+            d.x = 100;
+            d.y = 100;
+        }
+        void opAssign(){}   // dummy for reject built-in opAssign (this.d = p.d)
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+}
+
+void test6174IAFN() // identity assignable & field not assignable
+{
+    printf("## TestIAFN\n");
+
+    static struct D
+    {
+        const int x;
+        int y;
+        void opAssign(typeof(this) rhs){}
+    }
+    static struct Test1
+    {
+        D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            d = D.init;
+            static assert(!__traits(compiles, d.x = 100));
+            d.y = 100;
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+    static struct Test2
+    {
+        const D d;
+        this(int _)
+        {
+            static assert(!__traits(compiles, d = D.init)); // operator overloading cannot bypass type check even if inside constructor
+            d.x = 100;
+            d.y = 100;
+        }
+        void opAssign(){}   // dummy for reject built-in opAssign (this.d = p.d)
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+}
+
+void test6174INFA() // identity assignable & field assignable
+{
+    printf("## TestINFA\n");
+
+    static struct D
+    {
+        int x;
+        int y;
+        void opAssign(int dummy){}
+    }
+    static struct Test1
+    {
+        D d;
+        this(int _)
+        {
+            static assert(!__traits(compiles, d = D.init));
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            d.x = 100;
+            d.y = 100;
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+    static struct Test2
+    {
+        const D d;
+        this(int _)
+        {
+            static assert(!__traits(compiles, d = D.init)); // operator overloading cannot bypass type check even if inside constructor
+            d.x = 100;
+            d.y = 100;
+        }
+        void opAssign(){}   // dummy for reject built-in opAssign (this.d = p.d)
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+}
+
+void test6174INFN() // identity assignable & field not assignable
+{
+    printf("## TestINFN\n");
+
+    static struct D
+    {
+        const int x;
+        int y;
+        void opAssign(int dummy){}
+    }
+    static struct Test1
+    {
+        D d;
+        this(int _)
+        {
+            static assert(!__traits(compiles, d = D.init));
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            d.y = 100;
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+    static struct Test2
+    {
+        const D d;
+        this(int _)
+        {
+            static assert(!__traits(compiles, d = D.init)); // operator overloading cannot bypass type check even if inside constructor
+            d.x = 100;
+            d.y = 100;
+        }
+        void opAssign(){}   // dummy for reject built-in opAssign (this.d = p.d)
+        void func()
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+        void func() const
+        {
+            static assert(!__traits(compiles, d = D.init));
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+}
+
+void test6174ICFA() // const identity assignable & field assignable
+{
+    printf("## TestICFA\n");
+
+    static struct D
+    {
+        int x;
+        int y;
+        void opAssign(typeof(this) rhs) const {}
+    }
+    static struct Test1
+    {
+        D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func() const
+        {
+            d = D.init;
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+    static struct Test2
+    {
+        const D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void opAssign(){}   // dummy for reject built-in opAssign (this.d = p.d)
+        void func()
+        {
+            d = D.init;
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+        void func() const
+        {
+            d = D.init;
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+}
+
+void test6174ICFN() // const identity assignable & field not assignable
+{
+    printf("## TestICFN\n");
+
+    static struct D
+    {
+        const int x;
+        int y;
+        void opAssign(typeof(this) rhs) const {}
+    }
+    static struct Test1
+    {
+        D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void func()
+        {
+            d = D.init;
+            static assert(!__traits(compiles, d.x = 100));
+            d.y = 100;
+        }
+        void func() const
+        {
+            d = D.init;
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+    static struct Test2
+    {
+        const D d;
+        this(int _)
+        {
+            d = D.init;
+            d.x = 100;
+            d.y = 100;
+        }
+        void opAssign(){}   // dummy for reject built-in opAssign (this.d = p.d)
+        void func()
+        {
+            d = D.init;
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+        void func() const
+        {
+            d = D.init;
+            static assert(!__traits(compiles, d.x = 100));
+            static assert(!__traits(compiles, d.y = 100));
+        }
+    }
+}
+
+void test6174b()
+{
+    test6174Int();
+    test6174FA();
+    test6174FN();
+    test6174IAFA();
+    test6174IAFN();
+    test6174INFA();
+    test6174INFN();
+    test6174ICFA();
+    test6174ICFN();
+}
+
+void test6174c()
+{
+    static assert(!is(typeof({
+        int func1a(int n)
+        in{ n = 10; }
+        body { return n; }
+    })));
+    static assert(!is(typeof({
+        int func1b(int n)
+        out(r){ r = 20; }
+        body{ return n; }
+    })));
+
+    struct DataX
+    {
+        int x;
+    }
+    static assert(!is(typeof({
+        DataX func2a(DataX n)
+        in{ n.x = 10; }
+        body { return n; }
+    })));
+    static assert(!is(typeof({
+        DataX func2b(DataX n)
+        in{}
+        out(r){ r.x = 20; }
+        body{ return n; }
+    })));
+}
+
+/***************************************************/
 // 6216
 
 void test6216a()
@@ -392,6 +1130,9 @@ int main()
     test4();
     test5();
     test4424();
+    test6174a();
+    test6174b();
+    test6174c();
     test6216a();
     test6216b();
     test6216c();

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -210,6 +210,18 @@ void test5()
 }
 
 /***************************************************/
+// 4424
+
+void test4424()
+{
+    static struct S
+    {
+        this(this) {}
+        void opAssign(T)(T rhs) if (!is(T == S)) {}
+    }
+}
+
+/***************************************************/
 // 6216
 
 void test6216a()
@@ -350,6 +362,7 @@ int main()
     test3();
     test4();
     test5();
+    test4424();
     test6216a();
     test6216b();
     test6216c();

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -354,6 +354,35 @@ void test6286()
 }
 
 /***************************************************/
+// 6336
+
+void test6336()
+{
+    // structs aren't identity assignable
+    static struct S1
+    {
+        immutable int n;
+    }
+    static struct S2
+    {
+        void opAssign(int n){ assert(0); }
+    }
+
+    S1 s1;
+    S2 s2;
+
+    void f(S)(out S s){}
+    static assert(!__traits(compiles, f(s1)));
+    f(s2);
+    // Out parameters refuse only S1 because it isn't blit assignable
+
+    ref S g(S)(ref S s){ return s; }
+    g(s1);
+    g(s2);
+    // Allow return by ref both S1 and S2
+}
+
+/***************************************************/
 
 int main()
 {
@@ -367,6 +396,7 @@ int main()
     test6216b();
     test6216c();
     test6286();
+    test6336();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
<del>This change is based on #94 (already merged).</del>


<a href="http://d.puremagic.com/issues/show_bug.cgi?id=4424">Issue 4424</a> - Copy constructor and templated opAssign cannot coexist
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6174">Issue 6174</a> - Initialize const fixed-size array in constructor
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6216">Issue 6216</a> - Built-in opAssign implicitly defined should call field's opAssign
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6336">Issue 6336</a> - Can't return ref T where T has const/immutable members

Following is removed from this pull request:
<del><a href="http://d.puremagic.com/issues/show_bug.cgi?id=4596">Issue 4596</a></del> - [tdpl] Rebinding _this_ in class method compiles
