### PR TITLE
Fix segfaults 5676 and 5693

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7714,6 +7714,8 @@ Expression *AddrExp::semantic(Scope *sc)
     if (!type)
     {
         UnaExp::semantic(sc);
+        if (e1->type == Type::terror)
+            return new ErrorExp();
         e1 = e1->toLvalue(sc, NULL);
         if (e1->op == TOKerror)
             return e1;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1726,6 +1726,15 @@ Expression *TupleExp::interpret(InterState *istate, CtfeGoal goal)
             return ex;
         }
 
+        // A tuple of assignments can contain void (Bug 5676).
+        if (goal == ctfeNeedNothing)
+            continue;
+        if (ex == EXP_VOID_INTERPRET)
+        {
+            error("ICE: void element %s in tuple", e->toChars());
+            assert(0);
+        }
+
         /* If any changes, do Copy On Write
          */
         if (ex != e)
@@ -4002,7 +4011,7 @@ Expression *CommaExp::interpret(InterState *istate, CtfeGoal goal)
             return e2;
         return e2->interpret(istate, goal);
     }
-    Expression *e = e1->interpret(istate, goal);
+    Expression *e = e1->interpret(istate, ctfeNeedNothing);
     if (e != EXP_CANT_INTERPRET)
         e = e2->interpret(istate, goal);
     return e;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -917,6 +917,33 @@ static assert(quop()==8);
 static assert(quop()==8); // check for clobbering
 
 /**************************************************
+   Bug 5676 tuple assign of struct that has void opAssign
+**************************************************/
+
+struct S5676
+{
+    int x;
+    void opAssign(S5676 rhs) { x = rhs.x;}
+}
+
+
+struct Tup5676(E...)
+{
+    E g;
+    void foo(E values) { g = values;   }
+}
+
+bool ice5676()
+{
+    Tup5676!(S5676) q;
+    q.foo( S5676(3) );
+    assert( q.g[0].x == 3);
+    return true;
+}
+
+static assert(ice5676());
+
+/**************************************************
    Bug 5682 Wrong CTFE with operator overloading
 **************************************************/
 
@@ -940,7 +967,6 @@ auto test() {
 }
 
 static assert(test().n == 8);
-
 
 /**************************************************
    Attempt to modify a read-only string literal

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS:
+// PERMUTE_ARGS: -inline
 
 struct ArrayRet{
    int x;
@@ -1392,6 +1392,18 @@ void c4825() {
         auto e = b4825();
     }
     static const int f = b4825();
+}
+
+/**************************************************
+    Bug 5708 -- failed with -inline
+**************************************************/
+string b5708(string s) { return s; }
+string a5708(string s) { return b5708(s); }
+
+void bug5708() {
+    void m() { a5708("lit"); }
+    static assert(a5708("foo") == "foo");
+    static assert(a5708("bar") == "bar");
 }
 
 /**************************************************


### PR DESCRIPTION
(This shouldn't be given high priority relative to some of the existing pull requests).

5676 [CTFE] segfault using tuple containing struct that has opAssign
5693 Segfault with address of template struct opCall
Also a test case for a bug which was unintentionally fixed in an earlier commit:
5708 [CTFE] Incorrect string constant folding with -inline
