### PR TITLE
Issue 2553 - Excess attribute propagation for interfaces

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1299,15 +1299,15 @@ void InterfaceDeclaration::semantic(Scope *sc)
     }
 
     sc = sc->push(this);
-    sc->stc &= ~(STCfinal | STCauto | STCscope | STCstatic |
-                 STCabstract | STCdeprecated | STC_TYPECTOR | STCtls | STCgshared);
-    sc->stc |= storage_class & STC_TYPECTOR;
+    sc->stc &= STCsafe | STCtrusted | STCsystem;
     sc->parent = this;
     if (isCOMinterface())
         sc->linkage = LINKwindows;
     else if (isCPPinterface())
         sc->linkage = LINKcpp;
     sc->structalign = 8;
+    sc->protection = PROTpublic;
+    sc->explicitProtection = 0;
     structalign = sc->structalign;
     sc->offset = PTRSIZE * 2;
     inuse++;


### PR DESCRIPTION
Do not apply any attributes except @safe, @trusted or @system to interface members, following the behaviour for classes.
Force the default protection for interface members to be public.

This fixes a missing case from the solution to bug 5110.

http://d.puremagic.com/issues/show_bug.cgi?id=2553
