### PR TITLE
Issue 1373 - typeof(func).stringof fails when func has parameters.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6172,7 +6172,8 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
     }
     else
     {
-        e1 = resolveProperties(sc, e1);
+        if (e1->op != TOKtype)
+            e1 = resolveProperties(sc, e1);
         eleft = NULL;
         eright = e1;
     }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1701,6 +1701,8 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
     {
         if (ty == Tvoid)
             error(loc, "void does not have an initializer");
+        if (ty == Tfunction)
+            error(loc, "function does not have an initializer");
         e = defaultInitLiteral(loc);
     }
     else if (ident == Id::mangleof)
@@ -5395,6 +5397,12 @@ bool TypeFunction::parameterEscapes(Parameter *p)
     /* Assume it escapes in the absence of better information.
      */
     return TRUE;
+}
+
+Expression *TypeFunction::defaultInit(Loc loc)
+{
+    error(loc, "function does not have a default initializer");
+    return new ErrorExp();
 }
 
 /***************************** TypeDelegate *****************************/

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -600,6 +600,8 @@ struct TypeFunction : TypeNext
     enum RET retStyle();
 
     unsigned totym();
+
+    Expression *defaultInit(Loc loc);
 };
 
 struct TypeDelegate : TypeNext

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2943,6 +2943,25 @@ void test149()
  
 
 /***************************************************/
+// 1373
+
+void func1373a(){}
+
+static assert(typeof(func1373a).stringof == "void()");
+static assert(typeof(func1373a).mangleof == "FZv");
+static assert(!__traits(compiles, typeof(func1373a).alignof));
+static assert(!__traits(compiles, typeof(func1373a).init));
+static assert(!__traits(compiles, typeof(func1373a).offsetof));
+
+void func1373b(int n){}
+
+static assert(typeof(func1373b).stringof == "void(int n)");
+static assert(typeof(func1373b).mangleof == "FiZv");
+static assert(!__traits(compiles, typeof(func1373b).alignof));
+static assert(!__traits(compiles, typeof(func1373b).init));
+static assert(!__traits(compiles, typeof(func1373b).offsetof));
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=1373
Do not call resolveProperties on TypeExp(type = Tfunction).
