### PR TITLE
Issue 5363 - const + alias this = wrong code 

### DIFF
--- a/src/mars.h
+++ b/src/mars.h
@@ -395,13 +395,25 @@ enum DYNCAST
 
 enum MATCH
 {
+#if DMDV2
+    MATCHnomatch            = 0,    // no match
+    MATCHfallbackconvert    = 1,    // through alias this, match with conversions
+    MATCHfallbackconst      = 2,    // through alias this, match with conversion to const
+    MATCHfallbackexact      = 3,    // through alias this, exact match
+    MATCHconvert            = 1<<2, // match with conversions
+    MATCHconst              = 2<<2, // match with conversion to const
+    MATCHexact              = 3<<2  // exact match
+#else
     MATCHnomatch,       // no match
     MATCHconvert,       // match with conversions
-#if DMDV2
-    MATCHconst,         // match with conversion to const
-#endif
     MATCHexact          // exact match
+#endif
 };
+
+inline MATCH fallbackMatch(MATCH m)
+{
+    return (MATCH)(m >> 2);
+}
 
 typedef uint64_t StorageClass;
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7544,7 +7544,7 @@ MATCH TypeStruct::implicitConvTo(Type *to)
         }
     }
     else if (sym->aliasthis)
-        m = aliasthisOf()->implicitConvTo(to);
+        m = fallbackMatch(aliasthisOf()->implicitConvTo(to));
     else
         m = MATCHnomatch;       // no match
     return m;
@@ -7966,7 +7966,7 @@ MATCH TypeClass::implicitConvTo(Type *to)
 
     m = MATCHnomatch;
     if (sym->aliasthis)
-        m = aliasthisOf()->implicitConvTo(to);
+        m = fallbackMatch(aliasthisOf()->implicitConvTo(to));
 
     return m;
 }

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -404,6 +404,32 @@ struct Derived2787
 }
 
 /***********************************/
+// 5363
+
+struct S5363
+{
+    int dummy;
+    alias dummy this;
+}
+
+int foo5363(int){ return 1; }
+int foo5363(const(S5363)){ return 2; }
+
+int bar5363(int){ return 1; }
+int bar5363(const(int)){ return 2; }
+
+void test5363()
+{
+          S5363  ms;
+    const(S5363) cs;
+
+    assert(foo5363(ms) == 2);
+
+    assert(bar5363(ms) == 1);
+    assert(bar5363(cs) == 2);
+}
+
+/***********************************/
 // 6508
 
 void test6508()
@@ -734,6 +760,7 @@ int main()
     test6736();
     test2777a();
     test2777b();
+    test5363();
     test6508();
     test6369a();
     test6369b();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5363

Alias this matchings are lower than normal matchings.
