### PR TITLE
Issue 5399 - Return the result of a nonvoid function in a void function

### DIFF
--- a/src/delegatize.c
+++ b/src/delegatize.c
@@ -44,7 +44,11 @@ Expression *Expression::toDelegate(Scope *sc, Type *t)
 #else
     e = this->syntaxCopy();
 #endif
-    Statement *s = new ReturnStatement(loc, e);
+    Statement *s;
+    if (t->ty == Tvoid)
+        s = new ExpStatement(loc, e);
+    else
+        s = new ReturnStatement(loc, e);
     fld->fbody = s;
     e = new FuncExp(loc, fld);
     e = e->semantic(sc);

--- a/src/statement.c
+++ b/src/statement.c
@@ -3653,8 +3653,14 @@ Statement *ReturnStatement::semantic(Scope *sc)
          *      exp; return;
          */
         Statement *s = new ExpStatement(loc, exp);
-        exp = NULL;
         s = s->semantic(sc);
+
+        if (exp->type->ty != Tvoid)
+        {
+            error("cannot return non-void from void function");
+        }
+
+        exp = NULL;
         return new CompoundStatement(loc, s, this);
     }
 

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -1058,7 +1058,7 @@ int dummy()
 }
 
 void bar40(){
-	return dummy();
+	return cast(void)dummy();
 }
 
 int foo40()
@@ -1534,7 +1534,7 @@ float x59;
 
 void test59()
 {
-    return x59 = -x59;
+    return cast(void)(x59 = -x59);
 }
 
 


### PR DESCRIPTION
Make returning a non-void from a void function an error, and special case lazy void parameters to be re-written as '{ exp; }' instead of '{ return exp; }'.

http://d.puremagic.com/issues/show_bug.cgi?id=5399

This patch is a (preferred) alternative to https://github.com/D-Programming-Language/dmd/pull/121
