### PR TITLE
Issue 2361 - delete is allowed on invariant references

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8050,7 +8050,7 @@ Expression *DeleteExp::semantic(Scope *sc)
 
     UnaExp::semantic(sc);
     e1 = resolveProperties(sc, e1);
-    e1 = e1->toLvalue(sc, NULL);
+    e1 = e1->modifiableLvalue(sc, NULL);
     if (e1->op == TOKerror)
         return e1;
     type = Type::tvoid;

--- a/test/fail_compilation/fail2361.d
+++ b/test/fail_compilation/fail2361.d
@@ -1,0 +1,8 @@
+
+class C {}
+
+void main()
+{
+    immutable c = new immutable(C);
+    delete c;
+}


### PR DESCRIPTION
Prevent this by ensuring that the target of delete is a modifiable Lvalue, not just an Lvalue.

http://d.puremagic.com/issues/show_bug.cgi?id=2361
