### PR TITLE
Issue 3483 - Eliminate read-modify-write operations for enums

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5708,6 +5708,15 @@ void BinExp::checkComplexAddAssign()
     }
 }
 
+// Disable +=, -= ++, -- etc on enum types
+void BinExp::checkEnumModifyAssign()
+{
+    if (type->ty == Tenum)
+    {
+        error("operator not allowed on enum expression %s", toChars());
+    }
+}
+
 void BinExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     expToCBuffer(buf, hgs, e1, precedence[op]);
@@ -5774,6 +5783,7 @@ Expression *BinAssignExp::commonSemanticAssign(Scope *sc)
             error("operator not allowed on bool expression %s", toChars());
             return new ErrorExp();
         }
+        checkEnumModifyAssign();
         typeCombine(sc);
         e1->checkArithmetic();
         e2->checkArithmetic();
@@ -5818,6 +5828,7 @@ Expression *BinAssignExp::commonSemanticAssignIntegral(Scope *sc)
         {
             e2 = e2->implicitCastTo(sc, type);
         }
+        checkEnumModifyAssign();
 
         typeCombine(sc);
         e1->checkIntegral();
@@ -9138,6 +9149,9 @@ Expression *PostExp::semantic(Scope *sc)
 
         e1 = e1->modifiableLvalue(sc, e1);
 
+        type = e1->type;
+        checkEnumModifyAssign();
+
         Type *t1 = e1->type->toBasetype();
         if (t1->ty == Tclass || t1->ty == Tstruct)
         {   /* Check for operator overloading,
@@ -9753,6 +9767,7 @@ Expression *AddAssignExp::semantic(Scope *sc)
             e1->checkArithmetic();
             e2->checkArithmetic();
             checkComplexAddAssign();
+            checkEnumModifyAssign();
             if (type->isreal() || type->isimaginary())
             {
                 assert(global.errors || e2->type->isfloating());
@@ -9808,6 +9823,7 @@ Expression *MinAssignExp::semantic(Scope *sc)
         e2 = e2->checkArithmetic();
         checkComplexAddAssign();
         type = e1->type;
+        checkEnumModifyAssign();
         typeCombine(sc);
         if (type->isreal() || type->isimaginary())
         {
@@ -9935,6 +9951,7 @@ Expression *MulAssignExp::semantic(Scope *sc)
     e1->checkArithmetic();
     e2->checkArithmetic();
     checkComplexMulAssign();
+    checkEnumModifyAssign();
     if (e2->type->isfloating())
     {   Type *t1;
         Type *t2;
@@ -10007,6 +10024,7 @@ Expression *DivAssignExp::semantic(Scope *sc)
     e1->checkArithmetic();
     e2->checkArithmetic();
     checkComplexMulAssign();
+    checkEnumModifyAssign();
     if (e2->type->isimaginary())
     {   Type *t1;
         Type *t2;
@@ -10089,6 +10107,7 @@ Expression *ShlAssignExp::semantic(Scope *sc)
     e1->checkScalar();
     e1->checkNoBool();
     type = e1->type;
+    checkEnumModifyAssign();
     typeCombine(sc);
     e1->checkIntegral();
     e2 = e2->checkIntegral();
@@ -10121,6 +10140,7 @@ Expression *ShrAssignExp::semantic(Scope *sc)
     e1->checkScalar();
     e1->checkNoBool();
     type = e1->type;
+    checkEnumModifyAssign();
     typeCombine(sc);
     e1->checkIntegral();
     e2 = e2->checkIntegral();
@@ -10153,6 +10173,7 @@ Expression *UshrAssignExp::semantic(Scope *sc)
     e1->checkScalar();
     e1->checkNoBool();
     type = e1->type;
+    checkEnumModifyAssign();
     typeCombine(sc);
     e1->checkIntegral();
     e2 = e2->checkIntegral();
@@ -10216,6 +10237,9 @@ Expression *PowAssignExp::semantic(Scope *sc)
 
     e1 = e1->modifiableLvalue(sc, e1);
     assert(e1->type && e2->type);
+
+    type = e1->type;
+    checkEnumModifyAssign();
 
     if ( (e1->type->isintegral() || e1->type->isfloating()) &&
          (e2->type->isintegral() || e2->type->isfloating()))

--- a/src/expression.h
+++ b/src/expression.h
@@ -777,6 +777,7 @@ struct BinExp : Expression
     int checkSideEffect(int flag);
     void checkComplexMulAssign();
     void checkComplexAddAssign();
+    void checkEnumModifyAssign();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *scaleFactor(Scope *sc);
     Expression *typeCombine(Scope *sc);

--- a/test/compilable/rmwenums.d
+++ b/test/compilable/rmwenums.d
@@ -1,0 +1,25 @@
+// PERMUTE_ARGS:
+
+enum X { a, b, c };
+
+void main()
+{
+    X x;
+    static assert(!__traits(compiles, x += 1));
+    static assert(!__traits(compiles, x -= 1));
+    static assert(!__traits(compiles, x *= 1));
+    static assert(!__traits(compiles, x /= 1));
+    static assert(!__traits(compiles, x %= 1));
+    static assert(!__traits(compiles, x <<= 1));
+    static assert(!__traits(compiles, x >>= 1));
+    static assert(!__traits(compiles, x >>>= 1));
+    static assert(!__traits(compiles, x &= 1));
+    static assert(!__traits(compiles, x |= 1));
+    static assert(!__traits(compiles, x ^= 1));
+    static assert(!__traits(compiles, x ~= 1));
+    static assert(!__traits(compiles, x ^^= 1));
+    static assert(!__traits(compiles, x++));
+    static assert(!__traits(compiles, x--));
+    static assert(!__traits(compiles, ++x));
+    static assert(!__traits(compiles, --x));
+}


### PR DESCRIPTION
Disable rmw operations for enums (+=, -=, *=, ++, --, etc)

http://d.puremagic.com/issues/show_bug.cgi?id=3483

The corresponding phobos pull request is: (already merged)
https://github.com/D-Programming-Language/phobos/pull/127
