### PR TITLE
Issue 2156 - [] and null should be accepted where a compile-time string is required

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -46,6 +46,7 @@ struct InterState;
 struct Symbol;          // back end symbol
 struct OverloadSet;
 struct Initializer;
+struct StringExp;
 
 enum TOK;
 
@@ -115,6 +116,7 @@ struct Expression : Object
     virtual real_t toReal();
     virtual real_t toImaginary();
     virtual complex_t toComplex();
+    virtual StringExp *toString(Scope *sc);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toMangleBuffer(OutBuffer *buf);
     virtual int isLvalue();
@@ -340,6 +342,7 @@ struct NullExp : Expression
     Expression *semantic(Scope *sc);
     int isBool(int result);
     int isConst();
+    StringExp *toString(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     MATCH implicitConvTo(Type *t);
@@ -366,6 +369,7 @@ struct StringExp : Expression
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     size_t length();
+    StringExp *toString(Scope *sc);
     StringExp *toUTF8(Scope *sc);
     Expression *implicitCastTo(Scope *sc, Type *t);
     MATCH implicitConvTo(Type *t);
@@ -419,6 +423,7 @@ struct ArrayLiteralExp : Expression
     int isBool(int result);
     elem *toElem(IRState *irs);
     int checkSideEffect(int flag);
+    StringExp *toString(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);

--- a/src/statement.c
+++ b/src/statement.c
@@ -403,11 +403,11 @@ Statements *CompileStatement::flatten(Scope *sc)
     exp = exp->optimize(WANTvalue | WANTinterpret);
     if (exp->op == TOKerror)
         return NULL;
-    if (exp->op != TOKstring)
+    StringExp *se = exp->toString(sc);
+    if (!se)
     {   error("argument to mixin must be a string, not (%s)", exp->toChars());
         return NULL;
     }
-    StringExp *se = (StringExp *)exp;
     se = se->toUTF8(sc);
     Parser p(sc->module, (unsigned char *)se->string, se->len, 0);
     p.loc = loc;

--- a/src/traits.c
+++ b/src/traits.c
@@ -227,11 +227,11 @@ Expression *TraitsExp::semantic(Scope *sc)
             goto Lfalse;
         }
         e = e->optimize(WANTvalue | WANTinterpret);
-        if (e->op != TOKstring)
+        StringExp *se = e->toString(sc);
+        if (!se || se->length == 0)
         {   error("string expected as second argument of __traits %s instead of %s", ident->toChars(), e->toChars());
             goto Lfalse;
         }
-        StringExp *se = (StringExp *)e;
         se = se->toUTF8(sc);
         if (se->sz != 1)
         {   error("string must be chars");

--- a/test/fail_compilation/fail234.d
+++ b/test/fail_compilation/fail234.d
@@ -1,6 +1,0 @@
-//bug1941 = 1158   attrib.c
-/*
-attribute argument to mixin must be a string, not (null)
-*/
-
-mixin(null);

--- a/test/runnable/mixin2.d
+++ b/test/runnable/mixin2.d
@@ -136,6 +136,22 @@ void test9()
 
 /*********************************************/
 
+void test10()
+{
+    pragma(msg, "hello");
+    pragma(msg, ['h', 'e', 'l', 'l', 'o']);
+    pragma(msg, "");
+    pragma(msg, []);
+    pragma(msg, null);
+    mixin("string hello;");
+    mixin(['i', 'n', 't', ' ', 'a', ';']);
+    mixin("");
+    mixin([]);
+    mixin(null);
+}
+
+/*********************************************/
+
 void main()
 {
     test1();
@@ -147,6 +163,7 @@ void main()
     test7();
     test8();
     test9();
+    test10();
 
     writeln("Success");
 }


### PR DESCRIPTION
Issue 2156 - [] and null should be accepted where a compile-time string is required

Instead of checking for TOKstring, use toString to check if a string, array literal or null literal can be used.

http://d.puremagic.com/issues/show_bug.cgi?id=2156
