### PR TITLE
Issue 546 - Error message for accessing a deprecated variable is doubled

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2493,9 +2493,10 @@ Lagain:
         return this;
     if (!s->isFuncDeclaration())        // functions are checked after overloading
         checkDeprecated(sc, s);
+    Dsymbol *olds = s;
     s = s->toAlias();
     //printf("s = '%s', s->kind = '%s', s->needThis() = %p\n", s->toChars(), s->kind(), s->needThis());
-    if (!s->isFuncDeclaration())
+    if (s != olds && !s->isFuncDeclaration())
         checkDeprecated(sc, s);
 
     if (sc->func)


### PR DESCRIPTION
Do not repeat the deprecation check if alias resolution does not give a different symbol

This is a simple doubled error message fix.

http://d.puremagic.com/issues/show_bug.cgi?id=546
