### PR TITLE
Issue 6059 - Incompatible types in array literal shows __error and error

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1198,6 +1198,8 @@ Type *Type::toHeadMutable()
 
 Type *Type::pointerTo()
 {
+    if (ty == Terror)
+        return this;
     if (!pto)
     {   Type *t;
 
@@ -1209,6 +1211,8 @@ Type *Type::pointerTo()
 
 Type *Type::referenceTo()
 {
+    if (ty == Terror)
+        return this;
     if (!rto)
     {   Type *t;
 
@@ -1220,6 +1224,8 @@ Type *Type::referenceTo()
 
 Type *Type::arrayOf()
 {
+    if (ty == Terror)
+        return this;
     if (!arrayof)
     {   Type *t;
 


### PR DESCRIPTION
Propagate the _error_ type when using pointerTo, referenceTo or arrayOf.

http://d.puremagic.com/issues/show_bug.cgi?id=6059
