### PR TITLE
Issue 4539 - Refuse assignment to string literal

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3188,19 +3188,6 @@ int StringExp::isBool(int result)
     return result ? TRUE : FALSE;
 }
 
-#if DMDV2
-int StringExp::isLvalue()
-{
-    return 1;
-}
-#endif
-
-Expression *StringExp::toLvalue(Scope *sc, Expression *e)
-{
-    //printf("StringExp::toLvalue(%s)\n", toChars());
-    return this;
-}
-
 unsigned StringExp::charAt(size_t i)
 {   unsigned value;
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -372,8 +372,6 @@ struct StringExp : Expression
     Expression *castTo(Scope *sc, Type *t);
     int compare(Object *obj);
     int isBool(int result);
-    int isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
     unsigned charAt(size_t i);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4038,7 +4038,8 @@ float parse(ref string p)
 void test230()
 {
     float f;
-    f = parse( "123e+2" );
+    auto s = "123e+2";
+    f = parse( s );
     //printf("f = %g\n", f);
     assert( f == 123e+2f );
 }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1223,7 +1223,8 @@ void digestToString(const ubyte[16] digest)
 
 void test69()
 {
-    digestToString69(cast(ubyte[16])x"c3fcd3d76192e4007dfb496cca67e13b");
+    auto d = cast(ubyte[16])x"c3fcd3d76192e4007dfb496cca67e13b";
+    digestToString69(d);
 }
 
 void digestToString69(ref const ubyte[16] digest)
@@ -1236,7 +1237,8 @@ void digestToString69(ref const ubyte[16] digest)
 
 void test70()
 {
-    digestToString70("1234567890123456");
+    char[16] s = "1234567890123456";
+    digestToString70(s);
 }
 
 void digestToString70(ref const char[16] digest)


### PR DESCRIPTION
This builds on https://github.com/D-Programming-Language/dmd/pull/46
and fixes http://d.puremagic.com/issues/show_bug.cgi?id=4539

Disable using string literals as lvalues and change the dmd tests that rely on this behavior.
