### PR TITLE
Fix use of $ in CTFE

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -219,9 +219,9 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
 
             if (arg->storageClass & (STCout | STCref))
             {
-                if (!istate)
-                {
-                    earg->error("%s cannot be passed by reference at compile time", earg->toChars());
+                if (!istate && (arg->storageClass & STCout))
+                {   // initializing an out parameter involves writing to it.
+                    earg->error("global %s cannot be passed as an 'out' parameter at compile time", earg->toChars());
                     return NULL;
                 }
                 // Convert all reference arguments into lvalue references
@@ -270,8 +270,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
                 v->setValueWithoutChecking(earg);
                 /* Don't restore the value of v2 upon function return
                  */
-                assert(istate);
-                for (size_t i = 0; i < istate->vars.dim; i++)
+                for (size_t i = 0; i < (istate ? istate->vars.dim : 0); i++)
                 {   VarDeclaration *vx = (VarDeclaration *)istate->vars.data[i];
                     if (vx == v2)
                     {   istate->vars.data[i] = NULL;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4083,16 +4083,11 @@ Expression *ArrayLengthExp::interpret(InterState *istate, CtfeGoal goal)
     e1 = this->e1->interpret(istate);
     assert(e1);
     if (e1 == EXP_CANT_INTERPRET)
-        goto Lcant;
-    if (e1->op == TOKslice)
-        e1 = resolveSlice(e1);
-    if (e1->op == TOKstring || e1->op == TOKarrayliteral || e1->op == TOKassocarrayliteral)
+        return EXP_CANT_INTERPRET;
+    if (e1->op == TOKstring || e1->op == TOKarrayliteral || e1->op == TOKslice
+        || e1->op == TOKassocarrayliteral || e1->op == TOKnull)
     {
-        e = ArrayLength(type, e1);
-    }
-    else if (e1->op == TOKnull)
-    {
-        e = new IntegerExp(loc, 0, type);
+        e = new IntegerExp(loc, resolveArrayLength(e1), type);
     }
     else
     {
@@ -4100,9 +4095,6 @@ Expression *ArrayLengthExp::interpret(InterState *istate, CtfeGoal goal)
         return EXP_CANT_INTERPRET;
     }
     return e;
-
-Lcant:
-    return EXP_CANT_INTERPRET;
 }
 
 /*  Given an AA literal 'ae', and a key 'e2':

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -986,6 +986,21 @@ int zfs()
 static assert(!is(typeof(compiles!(zfs()))));
 
 /**************************************************
+        Use $ in a slice of a dotvar slice
+**************************************************/
+
+int sliceDollar()
+{
+    Xarg z;
+    z.s = new char[20];
+    z.s[] = 'b';
+    z.s = z.s[2..$-2];
+    z.s[$-2] = 'c';
+    return z.s[$-2];
+}
+static assert(sliceDollar()=='c');
+
+/**************************************************
    Variation of 5972 which caused segfault
 **************************************************/
 
@@ -1318,6 +1333,7 @@ int keyAssign()
     return 5;
 }
 static assert(keyAssign()==5);
+
 
 /**************************************************
     Bug 6054 -- AA literals


### PR DESCRIPTION
A huge speedup for array indexing and slicing. In many cases, those operations used to create a copy of the array, in the process of calculating $. This pull request changes CTFE array indexing from an O(n) operation into O(1).

Also fixes two unlisted bugs:
(1) $ in index expressions was wrong in some cases where the array being indexed was created from a slice of another array. It caused a "__dollar is undefined" error.
(2) couldn't use CTFE on struct literals opCmp/opEquals if they are passed by const ref from global scope (even though the same thing works if not in global scope);
