### PR TITLE
Issue 3722 - A method without an in contract should always succeed, even 

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1775,7 +1775,7 @@ Statement *FuncDeclaration::mergeFrequire(Statement *sf)
         }
 
         sf = fdv->mergeFrequire(sf);
-        if (fdv->fdrequire)
+        if (sf && fdv->fdrequire)
         {
             //printf("fdv->frequire: %s\n", fdv->frequire->toChars());
             /* Make the call:
@@ -1786,15 +1786,13 @@ Statement *FuncDeclaration::mergeFrequire(Statement *sf)
             Expression *e = new CallExp(loc, new VarExp(loc, fdv->fdrequire, 0), eresult);
             Statement *s2 = new ExpStatement(loc, e);
 
-            if (sf)
-            {   Catch *c = new Catch(loc, NULL, NULL, sf);
-                Array *catches = new Array();
-                catches->push(c);
-                sf = new TryCatchStatement(loc, s2, catches);
-            }
-            else
-                sf = s2;
+            Catch *c = new Catch(loc, NULL, NULL, sf);
+            Array *catches = new Array();
+            catches->push(c);
+            sf = new TryCatchStatement(loc, s2, catches);
         }
+        else
+            return NULL;
     }
     return sf;
 }

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -193,6 +193,25 @@ void test5()
 
 /*******************************************/
 
+// http://d.puremagic.com/issues/show_bug.cgi?id=3722
+
+class Bug3722A
+{
+    void fun() {}
+}
+class Bug3722B : Bug3722A
+{
+    override void fun() in { assert(false); } body {}
+}
+
+void test6()
+{
+    auto x = new Bug3722B();
+    x.fun();
+}
+
+/*******************************************/
+
 int main()
 {
     test1();
@@ -200,6 +219,7 @@ int main()
     test3();
     test4();
     test5();
+    test6();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Issue 3722 - A method without an in contract should always succeed, even if overridden

Do not generate the precondition if there are any functions in the hierarchy without in contracts.

http://d.puremagic.com/issues/show_bug.cgi?id=3722
