### PR TITLE
Issue 4206 - type accepted as enum initializer

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -793,6 +793,9 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, int needInterpret)
     if (!global.gag && olderrors != global.errors)
         return this; // Failed, suppress duplicate error messages
 
+    if (exp->op == TOKtype)
+        error("initializer must be an expression, not '%s'", exp->toChars());
+
     // Make sure all pointers are constants
     if (needInterpret && hasNonConstPointers(exp))
     {

--- a/test/fail_compilation/fail4206.d
+++ b/test/fail_compilation/fail4206.d
@@ -1,0 +1,5 @@
+
+struct s {}
+enum var = s;
+
+void main() {}


### PR DESCRIPTION
Disable using an expression that evaluates to a type as a ExpInitializer.

http://d.puremagic.com/issues/show_bug.cgi?id=4206
