### PR TITLE
Issue 4031 - Should be able to access const value-type globals from pure 

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1297,6 +1297,7 @@ void Expression::checkPurity(Scope *sc, VarDeclaration *v, Expression *ethis)
         !(sc->flags & SCOPEdebug) && // allow violations inside debug conditionals
         v->ident != Id::ctfe &&      // magic variable never violates pure and safe
         !v->isImmutable() &&         // always safe and pure to access immutables...
+        !(v->isConst() && !v->type->hasPointers()) && // ...or const value types...
         !(v->storage_class & STCmanifest) // ...or manifest constants
        )
     {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3166,6 +3166,14 @@ static assert(!is(typeof(1 + Baz4258.init)));
 
 /***************************************************/
 
+pure int test4031()
+{
+    static const int x = 8;
+    return x;
+}
+
+/***************************************************/
+
 int main()
 {
     test1();
@@ -3325,6 +3333,7 @@ int main()
     test155();
     test156();
     test4258();
+    test4031();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Issue 4031 - Should be able to access const value-type globals from pure functions

Const value-type globals function the same as immutables, so allow them to be accessed from inside pure functions.

http://d.puremagic.com/issues/show_bug.cgi?id=4031
