### PR TITLE
Issue 6242 - Disallow inoperant "in" contracts

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -840,6 +840,20 @@ void FuncDeclaration::semantic3(Scope *sc)
     frequire = mergeFrequire(frequire);
     fensure = mergeFensure(fensure);
 
+    if (frequire)
+    {
+        for (int i = 0; i < foverrides.dim; i++)
+        {
+            FuncDeclaration *fdv = (FuncDeclaration *)foverrides.data[i];
+
+            if (fdv->fbody && !fdv->frequire)
+            {
+                error("cannot have an in contract when overriden function %s does not have an in contract", fdv->toPrettyChars());
+                break;
+            }
+        }
+    }
+
     if (fbody || frequire || fensure)
     {
         /* Symbol table into which we place parameters and nested functions,

--- a/test/fail_compilation/fail6242.d
+++ b/test/fail_compilation/fail6242.d
@@ -1,0 +1,3 @@
+class A { void fun(int) {} }
+
+class B : A { void fun(int x) in { assert(x > 0); } body {} }


### PR DESCRIPTION
Disallow having an in condition on a function that overrides a function without one. (Unless that function is abstract)

http://d.puremagic.com/issues/show_bug.cgi?id=6242
