### PR TITLE
Add more checking to sdtor test56 which would have caught bug 6241

### DIFF
--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1461,17 +1461,22 @@ int foo56()
 
 void test56()
 {
-   int i;
-   try
-   {
-       i = S56(1).x + foo56() + 1;
-   }
-   catch (Throwable o)
-   {
-	printf("caught\n");
-   }
-   printf("i = %d\n", i);
-   assert(i == 0);
+    int i;
+    int j;
+    try
+    {
+        j |= 1;
+        i = S56(1).x + foo56() + 1;
+        j |= 2;
+    }
+    catch (Throwable o)
+    {
+        printf("caught\n");
+        j |= 4;
+    }
+    printf("i = %d, j = %d\n", i, j);
+    assert(i == 0);
+    assert(j == 5);
 }
 
 /**********************************/


### PR DESCRIPTION
The 'j' related parts are new, the rest is just white space changes.
