### PR TITLE
Issue 3133 - Compiler does not check that static array casts are legal

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8427,7 +8427,9 @@ Expression *CastExp::semantic(Scope *sc)
         }
 
         // Struct casts are possible only when the sizes match
-        if (tob->ty == Tstruct || t1b->ty == Tstruct)
+        // Same with static array -> static array
+        if (tob->ty == Tstruct || t1b->ty == Tstruct ||
+            (tob->ty == Tsarray && t1b->ty == Tsarray))
         {
             size_t fromsize = t1b->size(loc);
             size_t tosize = tob->size(loc);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3557,6 +3557,18 @@ void test157()
 
 /***************************************************/
 
+
+void test3133()
+{
+    short[2] x = [1,2];
+    int[1] y = cast(int[1])x;
+
+    short[1] z = [1];
+    static assert(!__traits(compiles, y = cast(int[1])z));
+}
+
+/***************************************************/
+
 int main()
 {
     test1();
@@ -3686,6 +3698,7 @@ int main()
     test123();
     test124();
     test125();
+    test3133();
 
     test127();
     test128();


### PR DESCRIPTION
Treat casts between static arrays the same as casts between structs.

http://d.puremagic.com/issues/show_bug.cgi?id=3133
