### PR TITLE
Issue 1411 - ref Tuple should transform to Tuple of ref's

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5018,8 +5018,9 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                     size_t tdim = tt->arguments->dim;
                     for (size_t j = 0; j < tdim; j++)
                     {   Parameter *narg = (Parameter *)tt->arguments->data[j];
-                        narg->storageClass = fparam->storageClass;
+                        narg->storageClass |= fparam->storageClass;
                     }
+                    fparam->storageClass = 0;
                 }
 
                 /* Reset number of parameters, and back up one to do this fparam again,

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1390,6 +1390,17 @@ void test63()
 
 /***************************************/
 
+template Tuple1411(T ...) { alias T Tuple1411; }
+
+void test1411()
+{
+    int delegate(ref Tuple1411!(int, char[], real)) dg; // (*)
+    int f(ref int a, ref char[] b, ref real c) { return 77; }
+    dg = &f;
+}
+
+/***************************************/
+
 int main()
 {
     test1();
@@ -1455,6 +1466,7 @@ int main()
     test61();
     test62();
     test63();
+    test1411();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Add the Tuple's storage class to the storage classes of the Tuple's members, then remove it from the tuple itself.

http://d.puremagic.com/issues/show_bug.cgi?id=1411
