### PR TITLE
Issue 5403 - foreach requires front to be a function in a range

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1896,29 +1896,29 @@ Lagain:
                 goto Lapply;
 
         {   /* Look for range iteration, i.e. the properties
-             * .empty, .next, .retreat, .head and .rear
+             * .empty, .popFront, .popBack, .front and .back
              *    foreach (e; aggr) { ... }
              * translates to:
-             *    for (auto __r = aggr[]; !__r.empty; __r.next)
-             *    {   auto e = __r.head;
+             *    for (auto __r = aggr[]; !__r.empty; __r.popFront)
+             *    {   auto e = __r.front;
              *        ...
              *    }
              */
             AggregateDeclaration *ad = (tab->ty == Tclass)
                         ? (AggregateDeclaration *)((TypeClass  *)tab)->sym
                         : (AggregateDeclaration *)((TypeStruct *)tab)->sym;
-            Identifier *idhead;
-            Identifier *idnext;
+            Identifier *idfront;
+            Identifier *idpopFront;
             if (op == TOKforeach)
-            {   idhead = Id::Ffront;
-                idnext = Id::FpopFront;
+            {   idfront = Id::Ffront;
+                idpopFront = Id::FpopFront;
             }
             else
-            {   idhead = Id::Fback;
-                idnext = Id::FpopBack;
+            {   idfront = Id::Fback;
+                idpopFront = Id::FpopBack;
             }
-            Dsymbol *shead = search_function(ad, idhead);
-            if (!shead)
+            Dsymbol *sfront = ad->search(0, idfront, 0);
+            if (!sfront)
                 goto Lapply;
 
             /* Generate a temporary __r and initialize it with the aggregate.
@@ -1934,13 +1934,13 @@ Lagain:
 
             // __r.next
             e = new VarExp(loc, r);
-            Expression *increment = new CallExp(loc, new DotIdExp(loc, e, idnext));
+            Expression *increment = new CallExp(loc, new DotIdExp(loc, e, idpopFront));
 
             /* Declaration statement for e:
-             *    auto e = __r.idhead;
+             *    auto e = __r.idfront;
              */
             e = new VarExp(loc, r);
-            Expression *einit = new DotIdExp(loc, e, idhead);
+            Expression *einit = new DotIdExp(loc, e, idfront);
             Statement *makeargs, *forbody;
             if (dim == 1)
             {
@@ -1963,7 +1963,7 @@ Lagain:
                 makeargs = new ExpStatement(loc, de);
 
                 Expression *ve = new VarExp(loc, vd);
-                ve->type = shead->isDeclaration()->type;
+                ve->type = sfront->isDeclaration()->type;
                 if (ve->type->toBasetype()->ty == Tfunction)
                     ve->type = ve->type->toBasetype()->nextOf();
                 if (!ve->type || ve->type->ty == Terror)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1977,6 +1977,27 @@ void test101()
 
 /***************************************************/
 
+
+void test5403()
+{
+    struct S
+    {
+        static int front;
+        enum back = "yes!";
+        bool empty;
+        void popAny() { empty = true; }
+        alias popAny popFront;
+        alias popAny popBack;
+    }
+    S.front = 7;
+    foreach(int i; S()) assert(i == 7);
+    S.front = 2;
+    foreach(i; S()) assert(i == 2);
+    foreach_reverse(i; S()) assert(i == "yes!");
+}
+
+/***************************************************/
+
 static assert([1,2,3] == [1.0,2,3]);
 
 /***************************************************/
@@ -5232,6 +5253,7 @@ int main()
     test93();
     test94();
     test95();
+    test5403();
     test96();
     test97();
     test98();


### PR DESCRIPTION
Allow using any reasonable symbol as front/back/empty.
Remove references to the old range interface (head/toe/next/retreat)

http://d.puremagic.com/issues/show_bug.cgi?id=5403
