### PR TITLE
Issue 3646 - Default values of function arguments are ignored when instantiating a template

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7743,6 +7743,8 @@ Expression *AddrExp::semantic(Scope *sc)
 
         type = e1->type->pointerTo();
 
+        type->stripDefaultArgs();
+
         // See if this should really be a delegate
         if (e1->op == TOKdotvar)
         {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2059,6 +2059,13 @@ uinteger_t Type::sizemask()
     return m;
 }
 
+
+void Type::stripDefaultArgs()
+{
+    assert(0);
+}
+
+
 /* ============================= TypeError =========================== */
 
 TypeError::TypeError()
@@ -2071,6 +2078,7 @@ void TypeError::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
     buf->writestring("_error_");
 }
 
+Type *TypeError::syntaxCopy() { return this; }
 d_uns64 TypeError::size(Loc loc) { return 1; }
 Expression *TypeError::getProperty(Loc loc, Identifier *ident) { return new ErrorExp(); }
 Expression *TypeError::dotExp(Scope *sc, Expression *e, Identifier *ident) { return new ErrorExp(); }
@@ -4393,6 +4401,15 @@ int TypePointer::hasPointers()
     return TRUE;
 }
 
+void TypePointer::stripDefaultArgs()
+{
+    if (next->ty == Tfunction)
+    {
+        next = next->syntaxCopy();
+        next->stripDefaultArgs();
+    }
+}
+
 
 /***************************** TypeReference *****************************/
 
@@ -5411,6 +5428,16 @@ Expression *TypeFunction::defaultInit(Loc loc)
     return new ErrorExp();
 }
 
+void TypeFunction::stripDefaultArgs()
+{
+    size_t nparams = Parameter::dim(parameters);
+    for (size_t i = 0; i < nparams; ++i)
+    {
+        Parameter *p = Parameter::getNth(parameters, i);
+        p->defaultArg = NULL;
+    }
+}
+
 /***************************** TypeDelegate *****************************/
 
 TypeDelegate::TypeDelegate(Type *t)
@@ -5545,6 +5572,11 @@ int TypeDelegate::hasPointers()
     return TRUE;
 }
 
+void TypeDelegate::stripDefaultArgs()
+{
+    next = next->syntaxCopy();
+    next->stripDefaultArgs();
+}
 
 
 /***************************** TypeQualified *****************************/

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -312,6 +312,7 @@ struct Type : Object
     virtual Type *nextOf();
     uinteger_t sizemask();
     virtual int needsDestruction();
+    virtual void stripDefaultArgs();
 
     static void error(Loc loc, const char *format, ...);
     static void warning(Loc loc, const char *format, ...);
@@ -333,6 +334,7 @@ struct TypeError : Type
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
 
     d_uns64 size(Loc loc);
+    Type *syntaxCopy();
     Expression *getProperty(Loc loc, Identifier *ident);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
     Expression *defaultInit(Loc loc);
@@ -515,6 +517,7 @@ struct TypePointer : TypeNext
     TypeInfoDeclaration *getTypeInfoDeclaration();
     int hasPointers();
     TypeTuple *toArgTypes();
+    void stripDefaultArgs();
 #if CPP_MANGLE
     void toCppMangle(OutBuffer *buf, CppMangleState *cms);
 #endif
@@ -594,6 +597,7 @@ struct TypeFunction : TypeNext
     void toCppMangle(OutBuffer *buf, CppMangleState *cms);
 #endif
     bool parameterEscapes(Parameter *p);
+    void stripDefaultArgs();
 
     int callMatch(Expression *ethis, Expressions *toargs, int flag = 0);
     type *toCtype();
@@ -622,6 +626,7 @@ struct TypeDelegate : TypeNext
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
     int hasPointers();
     TypeTuple *toArgTypes();
+    void stripDefaultArgs();
 #if CPP_MANGLE
     void toCppMangle(OutBuffer *buf, CppMangleState *cms);
 #endif

--- a/src/parse.h
+++ b/src/parse.h
@@ -99,7 +99,7 @@ struct Parser : Lexer
     UnitTestDeclaration *parseUnitTest();
     NewDeclaration *parseNew();
     DeleteDeclaration *parseDelete();
-    Parameters *parseParameters(int *pvarargs);
+    Parameters *parseParameters(int *pvarargs, int *phasdefault = NULL);
     EnumDeclaration *parseEnum();
     Dsymbol *parseAggregate();
     BaseClasses *parseBaseClasses();

--- a/test/compilable/defaultargs.d
+++ b/test/compilable/defaultargs.d
@@ -1,0 +1,22 @@
+// PERMUTE_ARGS:
+
+void main()
+{
+    static assert(!__traits(compiles, mixin(" { void delegate(int x = 123) Dg1; } ")));
+    static assert( __traits(compiles, mixin(" { void delegate(int x) Dg1; } ")));
+    static assert(!__traits(compiles, mixin(" { void function(int x = 123) Dg2; } ")));
+    static assert( __traits(compiles, mixin(" { void function(int x) Dg2; } ")));
+
+    static assert(!__traits(compiles, mixin(" delegate (int x = 7) {} ")));
+    static assert( __traits(compiles, mixin(" delegate (int x) {} ")));
+    static assert(!__traits(compiles, mixin(" function (int x = 7) {} ")));
+    static assert( __traits(compiles, mixin(" function (int x) {} ")));
+    static assert(!__traits(compiles, mixin("          (int x = 7) {} ")));
+    static assert( __traits(compiles, mixin("          (int x) {} ")));
+
+    static void x(int a = 7) {}
+    void y(int a = 7) {}
+
+    static assert(is(typeof(&x) == void function(int)));
+    static assert(is(typeof(&y) == void delegate(int)));
+}


### PR DESCRIPTION
Get rid of default arguments in delegates and function pointers entirely.

http://d.puremagic.com/issues/show_bug.cgi?id=3646
http://d.puremagic.com/issues/show_bug.cgi?id=3866
