### PR TITLE
Cleanup bit rotten parts of the backend

### DIFF
--- a/src/backend/blockopt.c
+++ b/src/backend/blockopt.c
@@ -1034,7 +1034,7 @@ STATIC void brrear()
                                 bt->Btry == list_block(bt->Bsucc)->Btry &&
 #endif
 
-                               ++iter < T68000(numblks) T80x86(10))
+                               ++iter < 10)
                         {
                                 list_ptr(bl) = list_ptr(bt->Bsucc);
                                 if (bt->Bsrcpos.Slinnum && !b->Bsrcpos.Slinnum)

--- a/src/backend/blockopt.c
+++ b/src/backend/blockopt.c
@@ -31,11 +31,7 @@
 #include        "go.h"
 #include        "code.h"
 #if SCPP
-#if TX86
 #include        "iasm.h"
-#else
-#include        "TG.h"
-#endif
 #endif
 
 static char __file__[] = __FILE__;      /* for tassert.h                */

--- a/src/backend/blockopt.c
+++ b/src/backend/blockopt.c
@@ -993,9 +993,6 @@ STATIC void bropt()
                         list_free(&b->Bsucc,FPNULL);
                         list_append(&b->Bsucc,db);
                         b->BC = BCgoto;
-#if !HOST_THINK
-                        MEM_PH_FREE(b->BS.Bswitch);
-#endif
                         b->Belem = doptelem(b->Belem,GOALnone | GOALagain);
                         cmes("CHANGE: switch (const)\n");
                         changes++;
@@ -1676,9 +1673,6 @@ STATIC void bltailmerge()
                     if (bnew->BC == BCswitch)
                     {
                         bnew->BS.Bswitch = b->BS.Bswitch;
-#if !HOST_THINK
-                        MEM_PH_FREE(bn->BS.Bswitch);
-#endif
                         b->BS.Bswitch = NULL;
                         bn->BS.Bswitch = NULL;
                     }

--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -506,11 +506,6 @@ typedef struct block
         #define BFLehcode     0x10      // set when we need to load exception code
         #define BFLunwind     0x1000    // do local_unwind following block
 #endif
-#if TARGET_POWERPC
-        #define BFLstructret  0x10      /* Set if a struct return is changed to
-                                           block type BCret.  This is done to avoid
-                                           error messages */
-#endif
         #define BFLnomerg      0x20     // do not merge with other blocks
 #if TX86
         #define BFLprolog      0x80     // generate function prolog
@@ -1128,10 +1123,6 @@ typedef struct STRUCT
 #define list_symbol(l)          ((Symbol *) list_ptr(l))
 #define list_setsymbol(l,s)     list_ptr(l) = (s)
 #define list_Classsym(l)        ((Classsym *) list_ptr(l))
-
-#if TARGET_POWERPC
-#pragma SC align 4
-#endif
 
 struct Symbol
 {

--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1590,12 +1590,10 @@ typedef struct Filename
     unsigned idx;                       // # used in array
 } Filename;
 
-//
 // NOTE: In order to save the full settings of all of the options,
 // the following will need to be saved:
 //
 // config
-// PCrel_option
 // tysize[TYldouble]
 // war_to_msg_enable[]  - Array of warnings that are enabled/disabled 0 = enabled, 1 = disabled
 

--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1336,9 +1336,6 @@ struct Symbol
     vec_t       Slvreg;         // when symbol is in register
     targ_size_t Ssize;          // tyfunc: size of function
     targ_size_t Soffset;        // variables: offset of Symbol in its storage class
-#if TARGET_MAC
-#define Smemoff Soffset
-#endif
 
     // CPP || OPTIMIZER
     SYMIDX Ssymnum;             // Symbol number (index into globsym.tab[])

--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -338,11 +338,6 @@ typedef struct Pstate
 #endif
     block *STbtry;              // current try block
     block *STgotolist;          // threaded goto scoping list
-#if MPW_OBJ && TARGET_68K
-    short STpush_value;
-    short STpop_value;
-    char  STdo_push;
-#endif
 #if !TX86
     char STdo_pop;
     char STprogressShown;       // true if func_body() has already shown progress info
@@ -1607,9 +1602,6 @@ typedef struct Filename
 struct SAVED_OPTIONS
 {
         struct Config config;
-#if TARGET_68K
-        short PCrel_option;
-#endif
         mftype mfoptim;
         signed char tysizeTYldouble;
         unsigned char war_to_msg_enable[40];    // Assumes that the max warning number is 40

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -165,7 +165,6 @@ One and only one of these macros must be set by the makefile:
 #define TX86            1               // target is Intel 80X86 processor
 #define TARGET_68K      0               // target is a 68K processor
 #define TARGET_POWERPC  0               // target is a PPC processor
-#define TARGET_MAC      0               // target is a macintosh
 
 // Set to 1 using the makefile
 #ifndef TARGET_LINUX

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -339,8 +339,6 @@ One and only one of these macros must be set by the makefile:
 #endif
 #define ARG_TRUE
 #define ARG_FALSE
-#define T68000(x)
-#define T80x86(x)       x
 
 // For Share MEM_ macros - default to mem_xxx package
 // PH           precompiled header

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -163,7 +163,6 @@ One and only one of these macros must be set by the makefile:
  */
 
 #define TX86            1               // target is Intel 80X86 processor
-#define TARGET_68K      0               // target is a 68K processor
 
 // Set to 1 using the makefile
 #ifndef TARGET_LINUX

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -45,14 +45,6 @@
         DOS16RM         Rational Systems 286 DOS extender
         _MSDOS          MSDOS
 
-Host systems no longer supported:
-
-        HOST_THINK
-        HOST_RAINBOW
-        HOST_MPW        Macintosh Programmers' Workbench
-        HOST_UNIX       Unix systems other than linux
-        HOST_MAC
-
 One and only one of these macros must be set by the makefile:
 
         SPP             Build C/C++ preprocessor

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -164,7 +164,6 @@ One and only one of these macros must be set by the makefile:
 
 #define TX86            1               // target is Intel 80X86 processor
 #define TARGET_68K      0               // target is a 68K processor
-#define TARGET_POWERPC  0               // target is a PPC processor
 
 // Set to 1 using the makefile
 #ifndef TARGET_LINUX

--- a/src/backend/cgcs.c
+++ b/src/backend/cgcs.c
@@ -170,10 +170,6 @@ STATIC void ecom(elem **pe)
   switch (op)
   {
     case OPconst:
-#if TARGET_MAC
-        if (tyfloating(tym) || C_S8_VAL(e->EV.Vlong))
-            return;             /* don't cse small constants or SANE consts */
-#endif
     case OPvar:
     case OPrelconst:
 #if TARGET_68K
@@ -378,9 +374,6 @@ STATIC void ecom(elem **pe)
     case OPu32_64: case OPlngllng: case OP64_32: case OPmsw:
     case OPu64_128: case OPs64_128: case OP128_64:
     case OPd_s64: case OPs64_d: case OPd_u64: case OPu64_d:
-#if TARGET_MAC
-    case OPsfltdbl: OPcase OPdblsflt:
-#endif
     case OPstrctor: case OPu16_d: case OPdbluns:
     case OPptrlptr: case OPtofar16: case OPfromfar16: case OParrow:
     case OPvoid: case OPnullcheck:
@@ -498,13 +491,8 @@ STATIC void addhcstab(elem *e,int hash)
   if (h >= hcsmax)                      /* need to reallocate table     */
   {
         assert(h == hcsmax);
-#if TARGET_MAC
-        hcsmax += (hcsmax + 64);        /* This space is not returned */
-                                        /* multiple reallocs costly */
-#else
         // With 32 bit compiles, we've got memory to burn
         hcsmax += (__INTSIZE == 4) ? (hcsmax + 128) : 100;
-#endif
         assert(h < hcsmax);
 #if TX86
         hcstab = (hcs *) util_realloc(hcstab,hcsmax,sizeof(hcs));
@@ -541,10 +529,6 @@ STATIC void touchlvalue(elem *e)
 
   for (i = hcstop; --i >= 0;)
   {     if (hcstab[i].Helem &&
-#if TARGET_MAC  // Vsym should be valid before compare
-            !EOP(hcstab[i].Helem) &&
-            hcstab[i].Helem->Eoper != OPconst &&
-#endif
             hcstab[i].Helem->EV.sp.Vsym == e->EV.sp.Vsym)
                 hcstab[i].Helem = NULL;
   }

--- a/src/backend/cgcs.c
+++ b/src/backend/cgcs.c
@@ -172,10 +172,6 @@ STATIC void ecom(elem **pe)
     case OPconst:
     case OPvar:
     case OPrelconst:
-#if TARGET_68K
-        if (tyfloating(tym) && !config.inline68881)
-            return;                     /* don't cse float vars for SANE */
-#endif
         break;
     case OPstreq:
     case OPpostinc:
@@ -390,9 +386,6 @@ STATIC void ecom(elem **pe)
   if (tym == TYstruct ||
       tym == TYvoid ||
       e->Ety & mTYvolatile
-#if TARGET_68K
-      || (tyfloating(tym) && !config.inline68881)
-#endif
 #if TX86
     // don't CSE doubles if inline 8087 code (code generator can't handle it)
       || (tyfloating(tym) && config.inline8087)

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -570,23 +570,6 @@ STATIC elem * elstring(elem *e)
 /************************
  */
 
-#if (TARGET_POWERPC)
-
-STATIC elem * elmemconst(elem *e)
-{
-    tym_t       tym;
-
-    assert(e->Eoper == OPconst);
-    tym = tybasic(typemask(e));
-    if (tyfloating(tym))
-    {
-        el_convconst(e);        // convert float | double consts to OPrelconst
-    }
-    return e;
-}
-
-#endif
-
 #if TX86
 
 /************************
@@ -4012,16 +3995,6 @@ beg:
     op = e->Eoper;
     if (OTleaf(op))                     // if not an operator node
     {
-#if 0
-        if (
-#if TARGET_POWERPC
-            // this is to change float and double consts to OPrelconst
-            // as in OPstring
-            || op == OPconst
-#endif
-           )
-            goto L1;
-#endif
         if (goal || OTsideff(op) || e->Ety & mTYvolatile)
         {
             return e;
@@ -4343,16 +4316,10 @@ beg:
         e1 = e->E1 = optelem(e->E1,TRUE);
         if (e1->Eoper == OPconst)
         {
-#if TARGET_POWERPC
-                // this is to make sure that if the evalu8ed const is a float it will be properly
-                // generated as an initialized static var
-                return optelem(evalu8(e), goal);
-#else
 #if TX86
             if (!(op == OPptrlptr && el_tolong(e1) != 0))
 #endif
                 return evalu8(e);
-#endif
         }
         e2 = NULL;
   }

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -164,14 +164,6 @@ int elemisone(elem *e)
             case TYdouble:
             case TYidouble:
             case TYdouble_alias:
-#if HOST_THINK
-                if (PCrel_option & PC_THINKC_DBL) {
-                    if (e->EV.Vldouble != 1)
-                        goto nomatch;
-                    break;
-                }
-                // - fall through -
-#endif
                 if (e->EV.Vdouble != 1)
                         goto nomatch;
                 break;
@@ -238,14 +230,6 @@ int elemisnegone(elem *e)
             case TYdouble:
             //case TYidouble:
             case TYdouble_alias:
-#if HOST_THINK
-                if (PCrel_option & PC_THINKC_DBL) {
-                    if (e->EV.Vldouble != -1)
-                        goto nomatch;
-                    break;
-                }
-                // - fall through -
-#endif
                 if (e->EV.Vdouble != -1)
                         goto nomatch;
                 break;

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -34,11 +34,6 @@ STATIC elem * eldiv(elem *);
 
 CEXTERN elem * evalu8(elem *);
 
-#if TX86
-STATIC void sdconst(elem *);
-extern targ_size_t dfuncptr();
-#endif
-
 static int expgoal;
 static int again;
 static int cgelem_goal;
@@ -346,7 +341,6 @@ STATIC elem *fixconvop(elem *e)
         tym_t tycop,tym,tyme;
         static char invconvtab[] =
         {
-#if TX86
                 OPbool,         // OPb_8
                 OPs32_d,        // OPd_s32
                 OPd_s32,        // OPs32_d
@@ -383,9 +377,6 @@ STATIC elem *fixconvop(elem *e)
                 OPd_ld,         // OPld_d
                 OPld_d,         // OPd_ld
                 OPu64_d,        // OPld_u64
-#else
-        TARGET_INVERS_CONV
-#endif
         };
 
 //dbg_printf("fixconvop before\n");

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -3946,9 +3946,6 @@ STATIC elem * elparam(elem *e)
 STATIC elem * optelem(elem *e,HINT goal)
 { elem *e1,*e2;
   unsigned op;
-#if TX86
-  static
-#endif
 #include "elxxx.c"                      /* jump table                   */
 
 beg:

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -686,7 +686,7 @@ STATIC elem * elmemxxx(elem *e)
                     elem *enbytes = e->E2->E1;
                     elem *evalue = e->E2->E2;
 
-#if MARS && (TX86 || TARGET_68K)
+#if MARS && TX86
                     if (enbytes->Eoper == OPconst && evalue->Eoper == OPconst
                         /* && tybasic(e->E1->Ety) == TYstruct*/)
                     {   tym_t tym;
@@ -1452,11 +1452,7 @@ STATIC elem * elnot(elem *e)
             {
                   /* Find the logical negation of the operator  */
                   op = rel_not(op);
-                  if (!tyfloating(e1->E1->Ety)
-#if TARGET_68K
-                                T68000(|| !config.inline68881)
-#endif
-                     )
+                  if (!tyfloating(e1->E1->Ety))
                   {   op = rel_integral(op);
                       assert(OTrel(op));
                   }
@@ -2479,8 +2475,7 @@ CEXTERN elem * elstruct(elem *e)
     if (e->ET)
     switch ((int) type_size(e->ET))
     {
-#if TX86 || TARGET_68K
-        // powerPC rtm structs are always in memory
+#if TX86
         case CHARSIZE:  tym = TYchar;   goto L1;
         case SHORTSIZE: tym = TYshort;  goto L1;
         case LONGSIZE:  tym = TYlong;   goto L1;

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -157,7 +157,6 @@ int elemisone(elem *e)
                 break;
             case TYldouble:
             case TYildouble:
-            T68000(case TYcomp:)
                 if (e->EV.Vldouble != 1)
                     goto nomatch;
                 break;
@@ -223,7 +222,6 @@ int elemisnegone(elem *e)
                 break;
             case TYldouble:
             //case TYildouble:
-            T68000(case TYcomp:)
                 if (e->EV.Vldouble != -1)
                     goto nomatch;
                 break;
@@ -888,7 +886,6 @@ L1:
                 e = el_una((tysize[ety] > tysize[e11ty]) ? OPptrlptr : OPoffset,
                             e->Ety,e);
                 e->E1->Ety = e1->Ety;
-                T68000(return optelem(e,TRUE);)
             }
 #endif
         }
@@ -1133,7 +1130,7 @@ L1:
   /* for floating or far or huge pointers!                              */
   if (e1->Eoper == OPadd && e2->Eoper == OPadd &&
       cnst(e1->E2) && cnst(e2->E2) &&
-      (tyintegral(tym) T80x86(|| tybasic(tym) == TYjhandle || tybasic(tym) == TYnptr || tybasic(tym) == TYsptr) ))
+      (tyintegral(tym) || tybasic(tym) == TYjhandle || tybasic(tym) == TYnptr || tybasic(tym) == TYsptr ))
   {     elem *tmp;
 
         e->Eoper = OPadd;
@@ -2156,7 +2153,6 @@ STATIC elem * elandand(elem *e)
             el_free(e->E2);
             e->E2 = el_int(t,0);
         }
-        T68000(return elcomma(e);)
     }
     else
         goto L1;
@@ -2313,7 +2309,6 @@ STATIC elem * eladdr(elem *e)
     case OPvar:
         e1->Eoper = OPrelconst;
         e1->EV.sp.Vsym->Sflags &= ~(SFLunambig | GTregcand);
-        T68000(e1->EV.sp.Vsym->Sflags |= GTadrof;)
         e1->Ety = tym;
         e = optelem(el_selecte1(e),TRUE);
         break;
@@ -3413,7 +3408,6 @@ STATIC elem * elvptrfptr(elem *e)
 STATIC elem * ellngsht(elem *e)
 { elem *e1;
   tym_t ty;
-  T68000(unsigned short op = e->Eoper;)
 
   ty = e->Ety;
   e1 = e->E1;
@@ -3472,25 +3466,21 @@ STATIC elem * ellngsht(elem *e)
             switch (e->Eoper)
             {   case OPint8:
                     /* Make sure e1->E1 is of the type we're converting from */
-                    if (tysize(ty1) <= T80x86(intsize) T68000(SHORTSIZE))
+                    if (tysize(ty1) <= intsize)
                     {
                         ty1 = (tyuns(ty1) ? TYuchar : TYschar) |
                                     (ty1 & ~mTYbasic);
                         e1->E1 = el_una(e->Eoper,ty1,e1->E1);
-                        T68000(e1->E1 = ellngsht(e1->E1));
-                                        // eliminate conversion op if possible here
                     }
                     /* Rvalue may be an int if it is a shift operator */
                     if (OTbinary(e1->Eoper))
                     {   tym_t ty2 = e1->E2->Ety;
 
-                        if (tysize(ty2) <= T80x86(intsize) T68000(SHORTSIZE))
+                        if (tysize(ty2) <= intsize)
                         {
                             ty2 = (tyuns(ty2) ? TYuchar : TYschar) |
                                         (ty2 & ~mTYbasic);
                             e1->E2 = el_una(e->Eoper,ty2,e1->E2);
-                            T68000(e1->E2 = ellngsht(e1->E2));
-                                        // eliminate conversion op if possible here
                         }
                     }
                     break;
@@ -3525,8 +3515,6 @@ STATIC elem * ellngsht(elem *e)
                     {
                         ty1 = (tyuns(ty1) ? TYushort : TYshort) | (ty1 & ~mTYbasic);
                         e1->E1 = el_una(e->Eoper,ty1,e1->E1);
-                        T68000(e1->E1 = ellngsht(e1->E1));
-                                        // eliminate conversion op if possible here
                     }
                     /* Rvalue may be an int if it is a shift operator */
                     if (OTbinary(e1->Eoper))
@@ -3537,8 +3525,6 @@ STATIC elem * ellngsht(elem *e)
                             ty2 = (tyuns(ty2) ? TYushort : TYshort) |
                                         (ty2 & ~mTYbasic);
                             e1->E2 = el_una(e->Eoper,ty2,e1->E2);
-                            T68000(e1->E2 = ellngsht(e1->E2));
-                                        // eliminate conversion op if possible here
                         }
                     }
                     break;

--- a/src/backend/cpp.h
+++ b/src/backend/cpp.h
@@ -105,7 +105,6 @@ int cpp_ctor(Classsym *stag);
 int cpp_dtor(type *tclass);
 void cpp_fixdestructor(symbol *s_dtor);
 elem *cpp_structcopy(elem *e);
-elem *cpp_hdlptr(elem *e);
 void cpp_fixmain(void);
 int cpp_needInvariant(type *tclass);
 void cpp_fixinvariant(symbol *s_dtor);

--- a/src/backend/cpp.h
+++ b/src/backend/cpp.h
@@ -121,13 +121,6 @@ symbol *cpp_lookformatch(symbol *sfunc , type *tthis , list_t arglist,
                 unsigned flags, symbol *sfunc2, type *tthis2, symbol *stagfriend = NULL);
 #endif
 
-#if TARGET_MAC
-elem *cpp_hdlptr(elem *e);
-#define M68HDL(e)       cpp_hdlptr(e)
-#else
-#define M68HDL(e)       (e)
-#endif
-
 struct OPTABLE
 {   unsigned char tokn;         /* token(TKxxxx)                */
     unsigned char oper;         /* corresponding operator(OPxxxx) */

--- a/src/backend/cppman.c
+++ b/src/backend/cppman.c
@@ -30,12 +30,6 @@
 #include        "cpp.h"
 #include        "filespec.h"
 
-
-#if __POWERPC && TARGET_68K
-#undef DDRT
-#define DDRT 1          // turn ddrt on
-#endif
-
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
@@ -607,11 +601,7 @@ char *template_mangle(symbol *s,param_t *arglist)
                         L1:
                             a[1] = 0;
                             n = cpp_catname(n,a);
-#if TARGET_68K
-                            p = (char *)&e->EV.Vldouble;
-#else
                             p = (char *)&e->EV.Vdouble;
-#endif
 
 #elif !NEW_UNMANGLER
                         case TYfloat:

--- a/src/backend/cppman.c
+++ b/src/backend/cppman.c
@@ -625,11 +625,7 @@ char *template_mangle(symbol *s,param_t *arglist)
                                 p = (char *)&e->EV.Vdouble;
                             else
                             {
-#if DDRT
-                                d = Xxtod(e->EV.Vldouble);
-#else
                                 d = e->EV.Vldouble;
-#endif
                             }
                             p = (char *)&d;
 //                          ni = tysize[TYdouble];
@@ -656,13 +652,7 @@ char *template_mangle(symbol *s,param_t *arglist)
                         case TYldouble: if (config.flags & CFGldblisdbl)
                                             d = e->EV.Vdouble;
                                         else
-                                        {
-#if DDRT
-                                            d = Xxtod(e->EV.Vldouble);
-#else
                                             d = e->EV.Vldouble;
-#endif
-                                        }
                         L1: char buf[32];
                             n = cpp_catname(n,"N");
                             ni = sprintf(buf, "%g", d);

--- a/src/backend/cppman.c
+++ b/src/backend/cppman.c
@@ -212,7 +212,6 @@ char *cpp_mangle(symbol *s)
     if (!CPP)
         return s->Sident;
 
-    T68000(short pasobj = FALSE;)
     ssymbol = s;
 
     symbol_debug(s);
@@ -671,7 +670,6 @@ char *template_mangle(symbol *s,param_t *arglist)
                             {   char buf[sizeof(long) * 3 + 1];
                                 sprintf(buf,"%lu",el_tolong(e));
                                 cpp_catname(n,buf);
-                                T68000(n = cpp_catname(n,"_");)
                                 break;
                             }
                             assert(0);

--- a/src/backend/cppman.c
+++ b/src/backend/cppman.c
@@ -242,10 +242,6 @@ char *cpp_mangle(symbol *s)
     s->Sfunc && s->Sfunc->Fflags & Ftypesafe)
     {   if (!s->Sscope)
             p = cpp_catname(p,"__");
-#if HOST_MPW
-        if (pasobj && s->Sfunc->Fflags&Foperator)
-            p = cpp_catname(p,"S");
-#endif
         p = cpp_typetostring(s->Stype,p);
     }
     /*dbg_printf("cpp_mangle(%s)\n",p);*/

--- a/src/backend/debug.c
+++ b/src/backend/debug.c
@@ -67,9 +67,6 @@ void WROP(unsigned oper)
   if (oper >= OPMAX)
   {     dbg_printf("op = x%x, OPMAX = %d\n",oper,OPMAX);
         assert(0);
-#if TARGET_MAC
-        return;                         /* try to keep on after assert, for now */
-#endif
   }
   ferr(debtab[oper]);
   ferr(" ");
@@ -93,14 +90,6 @@ void WRTYxx(tym_t t)
         dbg_printf("mTYconst|");
     if (t & mTYvolatile)
         dbg_printf("mTYvolatile|");
-#if TARGET_MAC
-    if (t & mTYpasret)
-        dbg_printf("mTYpasret|");
-    if (t & mTYmachdl)
-        dbg_printf("mTYmachdl|");
-    if (t & mTYpasobj)
-        dbg_printf("mTYpasobj|");
-#endif
 #if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun&&__SVR4
     if (t & mTYtransu)
         dbg_printf("mTYtransu|");
@@ -232,16 +221,6 @@ void WReqn(elem *e)
                         dbg_printf(".%ld",(long)e->Eoffset);
                 break;
             case OPasm:
-#if TARGET_MAC
-                if (e->Eflags & EFsmasm)
-                    {
-                    if (e->EV.mac.Vasmdat[1])
-                        dbg_printf("\"%c%c\"",e->EV.mac.Vasmdat[0],e->EV.mac.Vasmdat[1]);
-                    else
-                        dbg_printf("\"%c\"",e->EV.mac.Vasmdat[0]);
-                    break;
-                    };
-#endif
             case OPstring:
                 dbg_printf("\"%s\"",e->EV.ss.Vstring);
                 if (e->EV.ss.Voffset)
@@ -301,9 +280,6 @@ void WRFL(enum FL fl)
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
          "got   ","gotoff",
 #endif
-#endif
-#if TARGET_MAC
-         TARGET_enumFL_names
 #endif
         };
 

--- a/src/backend/dt.h
+++ b/src/backend/dt.h
@@ -94,9 +94,6 @@ enum
 dt_t *dt_calloc(char dtx);
 void dt_free(dt_t *);
 void dt_term(void);
-#elif TARGET_MAC
-dt_t *dt_calloc(void);
-void dt_free(dt_t *);
 #endif
 
 dt_t **dtnbytes(dt_t **,targ_size_t,const char *);

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -19,10 +19,6 @@
 #include        <time.h>
 #include        <stdarg.h>
 
-#if DDRT
-#include        "paccfp.h"
-#endif
-
 #include        "cc.h"
 #include        "type.h"
 #include        "el.h"
@@ -2450,7 +2446,6 @@ L1:
                             goto nomatch;
                         break;
 #endif
-#if !DDRT
                         /* Compare bit patterns w/o worrying about
                            exceptions, unordered comparisons, etc.
                          */
@@ -2498,19 +2493,6 @@ L1:
 #endif
                             goto nomatch;
                         break;
-#else /* DDRT */
-                    case TYfloat:
-                        if (memcmp(&n1->EV.Vfloat,&n2->EV.Vfloat,FLOATSIZE))
-                            goto nomatch;
-                        break;
-                    case TYdouble:
-                        if (memcmp(&n1->EV.Vdouble,&n2->EV.Vdouble,DOUBLESIZE))
-                            goto nomatch;
-                    case TYldouble:
-                        if (memcmp(&n1->EV.Vldouble,&n2->EV.Vldouble,LNGDBLSIZE))
-                                goto nomatch;
-                        break;
-#endif /* DDRT */
                     case TYvoid:
                         break;                  // voids always match
 #if SCPP
@@ -2755,11 +2737,7 @@ L1:
         case TYcldouble:
         case TYcdouble:
         case TYcfloat:
-#if !DDRT
             result = (targ_llong)el_toldouble(e);
-#else
-            result = Xxtoi(el_toldouble(e));
-#endif
             break;
 
 #if SCPP
@@ -2864,7 +2842,6 @@ targ_ldouble el_toldouble(elem *e)
             break;
     }
 #else
-#if !DDRT
     switch (tysize[tybasic(typemask(e))])
     {
     case FLOATSIZE:             // TYfloat
@@ -2882,23 +2859,6 @@ targ_ldouble el_toldouble(elem *e)
         break;
 #endif
     }
-#else /* DDRT */
-    switch (tysize[tybasic(typemask(e))])
-    {
-        case FLOATSIZE:         // TYfloat
-            result = Xftox(e->EV.Vfloat);
-            break;
-        case DOUBLESIZE:        // TYdouble
-            result = Xdtox(e->EV.Vdouble);
-            break;
-        case LNGDBLSIZE:        // TYldouble
-#ifdef LNGHDBLSIZE
-        case LNGHDBLSIZE:
-#endif
-                result = e->EV.Vldouble;
-            break;
-    }
-#endif /* DDRT */
 #endif
     return result;
 }

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -246,10 +246,7 @@ L1:
             break;
         case OPstring:
         case OPasm:
-#if HOST_MPW
-            if ( !(e->Eflags&EFsmasm) )
-#endif
-#if TX86 || HOST_MPW
+#if TX86
                 // never free; it's alloc'd from temp mem in most (all?) cases
             MEM_PH_FREE(e->EV.ss.Vstring);
 #endif

--- a/src/backend/el.h
+++ b/src/backend/el.h
@@ -19,10 +19,6 @@
 #ifndef EL_H
 #define EL_H    1
 
-#if TARGET_MAC
-#include "TGel.h"
-#endif
-
 /******************************************
  * Elems:
  *      Elems are the basic tree element. They can be either

--- a/src/backend/el.h
+++ b/src/backend/el.h
@@ -111,14 +111,6 @@ struct elem
                                         // first, intermediate, and last references
                                         // to a CSE)
             #define Ecomsub _EU._EC.Ecomsub_
-
-#if TARGET_POWERPC
-            unsigned char Gflags;
-            #define     GFLassrval      1               // element is rvalue of an assign
-            #define     GFLsignok       2               // element does not need sign extend
-            #define     GFLstrthis_fixed        4       // strthis child elem has been fixed
-                                                        // on first pass, do not do it again
-#endif
         }_EC;
     }_EU;
 
@@ -238,11 +230,6 @@ elem *el_convstring(elem *);
 elem *el_convert(elem *e);
 int el_isdependent(elem *);
 unsigned el_alignsize(elem *);
-
-#if  (TARGET_POWERPC)
-// convert float | double constants to memory constants
-void el_convconst(elem *);
-#endif
 
 void elem_print(elem *);
 void el_hydrate(elem **);

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -574,12 +574,7 @@ elem * evalu8(elem *e)
 {   elem *e1,*e2;
     tym_t tym,tym2,uns;
     unsigned op;
-#if TARGET_MAC
-    targ_short i1,i2;
-    targ_char c1,c2;
-#else
     targ_int i1,i2;
-#endif
     int i;
     targ_llong l1,l2;
     targ_ldouble d1,d2;
@@ -625,11 +620,6 @@ elem * evalu8(elem *e)
     }
     else
         return e;
-
-#if TARGET_MAC
-    c1 = i1;
-    c2 = i2;
-#endif
 
     /* if left or right leaf is unsigned, this is an unsigned operation */
     uns = tyuns(tym) | tyuns(tym2);
@@ -1651,13 +1641,6 @@ elem * evalu8(elem *e)
 #if 1
         switch (tym)
         {
-#if TARGET_MAC
-            case TYdouble:
-            case TYfloat:
-            case TYldouble:
-                e->EV.Vldouble = fabs(d1);
-                break;
-#else
             case TYdouble:
             case TYidouble:
             case TYdouble_alias:
@@ -1684,7 +1667,6 @@ elem * evalu8(elem *e)
             case TYcldouble:
                 e->EV.Vldouble = Complex_ld::abs(e1->EV.Vcldouble);
                 break;
-#endif
             default:
                 e->EV.Vllong = labs(l1);
                 break;
@@ -1713,21 +1695,12 @@ elem * evalu8(elem *e)
     case OPle:
         if (uns)
         {
-#if TARGET_MAC
-            if (tybyte(tym))
-                i ^= ((targ_uns) c1) <= ((targ_uns) c2);
-            else
-#endif
             i ^= ((targ_ullong) l1) <= ((targ_ullong) l2);
         }
         else
         {
             if (tyfloating(tym))
                 i ^= d1 <= d2;
-#if TARGET_MAC
-            else if (tybyte(tym))
-                i ^= c1 <= c2;
-#endif
             else
                 i ^= l1 <= l2;
         }
@@ -1749,21 +1722,12 @@ elem * evalu8(elem *e)
     case OPlt:
         if (uns)
         {
-#if TARGET_MAC
-            if (tybyte(tym))
-                i ^= ((targ_uns) c1) < ((targ_uns) c2);
-            else
-#endif
             i ^= ((targ_ullong) l1) < ((targ_ullong) l2);
         }
         else
         {
             if (tyfloating(tym))
                 i ^= d1 < d2;
-#if TARGET_MAC
-            else if (tybyte(tym))
-                i ^= c1 < c2;
-#endif
             else
                 i ^= l1 < l2;
         }
@@ -1807,12 +1771,6 @@ elem * evalu8(elem *e)
             }
             //printf("%Lg + %Lgi, %Lg + %Lgi\n", e1->EV.Vcldouble.re, e1->EV.Vcldouble.im, e2->EV.Vcldouble.re, e2->EV.Vcldouble.im);
         }
-#if TARGET_MAC
-        else if (tybyte(tym))
-            i ^= c1 == c2;
-        else if (tyshort(tym))
-            i ^= i1 == i2;
-#endif
         else
             i ^= l1 == l2;
         e->EV.Vint = i;
@@ -1893,60 +1851,6 @@ elem * evalu8(elem *e)
     case OPu16_32:
         e->EV.Vulong = (targ_ushort) i1;
         break;
-#if TARGET_MAC
-    case OPd_s32:
-        e->EV.Vlong = d1;
-        break;
-    case OPd_u32:
-        e->EV.Vulong = d1;
-        break;
-    case OPs32_d:
-        e->EV.Vldouble = l1;
-        break;
-    case OPu32_d:
-#if HOST_THINK
-        if (PCrel_option & PC_THINKC_DBL) {
-            e->EV.Vldouble = (unsigned long) l1;
-        }
-        else
-#endif
-        e->EV.Vldouble = (unsigned) l1;
-        break;
-    case OPd_s16:
-        e->EV.Vint = d1;
-        break;
-    case OPs16_d:
-        e->EV.Vldouble = i1;
-        break;
-    case OPdbluns:
-        e->EV.Vuns = d1;
-        break;
-    case OPu16_d:
-        e->EV.Vldouble = (targ_uns) i1;
-        break;
-    case OPd_f:
-#if HOST_THINK
-        if (PCrel_option & PC_THINKC_DBL) {
-            e->EV.Vldouble = d1;
-        }
-        else
-#endif
-        e->EV.Vdouble = d1;
-        break;
-    case OPf_d:
-        e->EV.Vldouble = e1->EV.Vdouble;
-        break;
-    case OPdblsflt:
-        e->EV.Vfloat = d1;
-        break;
-    case OPsfltdbl:
-        e->EV.Vldouble = e1->EV.Vfloat;
-        break;
-    case OPcompdbl:
-    case OPdblcomp:
-        e->EV.Vldouble = e1->EV.Vldouble;
-        break;
-#else
     case OPd_u32:
         e->EV.Vulong = (targ_ulong)d1;
         //printf("OPd_u32: dbl = %g, ulng = x%lx\n",d1,e->EV.Vulong);
@@ -2026,7 +1930,6 @@ elem * evalu8(elem *e)
                 assert(0);
         }
         break;
-#endif
     case OPs8int:
         e->EV.Vint = (targ_schar) i1;
         break;

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -667,13 +667,6 @@ elem * evalu8(elem *e)
                 {
                     case TYdouble:
                     case TYdouble_alias:
-                    #if HOST_THINK
-                        // if this is true, then our "double" is really an ldouble
-                        if (PCrel_option & PC_THINKC_DBL) {
-                            e->EV.Vldouble = d1 + d2;
-                        }
-                        else
-                    #endif
                             e->EV.Vdouble = e1->EV.Vdouble + e2->EV.Vdouble;
                         break;
                     case TYidouble:
@@ -869,14 +862,7 @@ elem * evalu8(elem *e)
                 {
                     case TYdouble:
                     case TYdouble_alias:
-                    #if HOST_THINK
-                        // if this is true, then our "double" is really an ldouble
-                        if (PCrel_option & PC_THINKC_DBL) {
-                            e->EV.Vldouble = d1 - d2;
-                        }
-                        else
-                    #endif
-                            e->EV.Vdouble = e1->EV.Vdouble - e2->EV.Vdouble;
+                        e->EV.Vdouble = e1->EV.Vdouble - e2->EV.Vdouble;
                         break;
                     case TYidouble:
                         e->EV.Vcdouble.re =  e1->EV.Vdouble;
@@ -1062,12 +1048,6 @@ elem * evalu8(elem *e)
                     {
                         case TYdouble:
                         case TYdouble_alias:
-#if HOST_THINK
-                            if (PCrel_option & PC_THINKC_DBL) {
-                                e->EV.Vldouble = d1 * d2;
-                            }
-                            else
-#endif
                         case TYidouble:
                             e->EV.Vdouble = e1->EV.Vdouble * e2->EV.Vdouble;
                             break;
@@ -1245,12 +1225,6 @@ elem * evalu8(elem *e)
                     {
                         case TYdouble:
                         case TYdouble_alias:
-#if HOST_THINK
-                            if (PCrel_option & PC_THINKC_DBL) {
-                                e->EV.Vldouble = d1 / d2;
-                            }
-                            else
-#endif
                             e->EV.Vdouble = e1->EV.Vdouble / e2->EV.Vdouble;
                             break;
                         case TYidouble:
@@ -1616,12 +1590,6 @@ elem * evalu8(elem *e)
         switch (tym)
         {   case TYdouble:
             T68000(case TYcomp:)
-#if HOST_THINK
-                if (PCrel_option & PC_THINKC_DBL) {
-                    e->EV.Vldouble = -d1;
-                }
-                else
-#endif
                 e->EV.Vdouble = -e1->EV.Vdouble;
                 break;
             case TYfloat:

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1636,7 +1636,6 @@ elem * evalu8(elem *e)
         }
 #endif
         break;
-#if !(TARGET_POWERPC)
     case OPabs:
 #if 1
         switch (tym)
@@ -1679,7 +1678,6 @@ elem * evalu8(elem *e)
     case OPcos:
     case OPrint:
         return e;
-#endif
     case OPngt:
         i++;
     case OPgt:

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -159,7 +159,6 @@ HINT boolres(elem *e)
                 case TYdouble_alias:
                 case TYildouble:
                 case TYldouble:
-                T68000(case TYcomp:)
                 {   targ_ldouble ld = el_toldouble(e);
 
                     if (isnan((double)ld))
@@ -597,14 +596,14 @@ elem * evalu8(elem *e)
             elem_debug(e2);
             if (e2->Eoper == OPconst)
             {
-                T68000(c2 =) i2 = l2 = el_tolong(e2);
+                i2 = l2 = el_tolong(e2);
                 d2 = el_toldouble(e2);
             }
             else
                 return e;
             tym2 = tybasic(typemask(e2));
         }
-        T68000(c1 =) i1 = l1 = el_tolong(e1);
+        i1 = l1 = el_tolong(e1);
         d1 = el_toldouble(e1);
         tym = tybasic(typemask(e1));    /* type of op is type of left child */
 
@@ -1589,7 +1588,6 @@ elem * evalu8(elem *e)
 #else
         switch (tym)
         {   case TYdouble:
-            T68000(case TYcomp:)
                 e->EV.Vdouble = -e1->EV.Vdouble;
                 break;
             case TYfloat:

--- a/src/backend/gdag.c
+++ b/src/backend/gdag.c
@@ -551,13 +551,6 @@ L1:     e = *pe;
                     tyfloating(e->Ety) && !config.inline68881 && e->Ecount)
                         e = delcse(pe); /* don't force vars to SANE frame or cse consts*/
 #endif
-#if TARGET_POWERPC
-                if ((op == OPconst) && !(tyfloating(e->Ety)) &&
-                        ((e->EV.Vlong < 32767) && (e->EV.Vlong > -32768)) && e->Ecount && (e->Ecount < 3))
-                {
-                        e = delcse(pe);
-                }
-#endif
                 return;
         }
         pe = &(e->E1);

--- a/src/backend/gdag.c
+++ b/src/backend/gdag.c
@@ -523,13 +523,6 @@ L1:     e = *pe;
             else if (op == OPushtlng && !I32 && e->Ecount)
                 e = delcse(pe);
 #endif
-#if TARGET_68K
-            // Remove size conversions of float vars
-            else if (OTconv(op) && (e->E1->Eoper == OPvar) &&
-                flt_881mixtype[convidx(op)] && !config.inline68881 && e->Ecount)
-                e = delcse(pe);
-
-#endif
         }
         else if (OTbinary(op))
         {
@@ -546,11 +539,6 @@ L1:     e = *pe;
         }
         else /* leaf node */
         {
-#if TARGET_68K
-                if ((op == OPconst || op == OPvar) &&
-                    tyfloating(e->Ety) && !config.inline68881 && e->Ecount)
-                        e = delcse(pe); /* don't force vars to SANE frame or cse consts*/
-#endif
                 return;
         }
         pe = &(e->E1);

--- a/src/backend/gflow.c
+++ b/src/backend/gflow.c
@@ -139,7 +139,7 @@ STATIC void rdgenkill()
 
 #if TX86
         util_free(defnod);              /* free existing junk           */
-#elif !(TARGET_MAC)     /* might be from previous memory pool */
+#else                                   /* might be from previous memory pool */
         MEM_BEF_FREE(defnod);           /* free existing junk           */
 #endif
         defnod = NULL;
@@ -480,7 +480,7 @@ STATIC void aecpgenkill()
 
 #if TX86
         util_free(expnod);              /* dump any existing one        */
-#elif !(TARGET_MAC)     /* might be from previous memory pool */
+#else                                   /* might be from previous memory pool */
         MEM_BEF_FREE(expnod);           /* dump any existing one        */
 #endif
         expnod = NULL;
@@ -508,9 +508,7 @@ STATIC void aecpgenkill()
                 ? (block **) util_calloc(sizeof(block *),exptop) : NULL;
 #else
         expnod = (elem **) MEM_BEF_CALLOC(sizeof(elem *) * exptop);
-#if !(TARGET_MAC)       /* might be from previous memory pool */
         MEM_BEF_FREE(expblk);
-#endif
         expblk = (flowxx == VBE)
                 ? (block **) MEM_BEF_CALLOC(sizeof(block *) * exptop) : NULL;
 #endif
@@ -838,11 +836,6 @@ void main()
                     case OPvptrfptr:
                     case OPcvptrfptr:
                         vec_setbit(i,vptrkill);
-#if TARGET_MAC          /* implied 'starred' ref */
-                        vec_setbit(i,defkill);
-                        vec_setbit(i,starkill);
-                        break;
-#endif
                         goto Lunary;
 
                     default:

--- a/src/backend/global.h
+++ b/src/backend/global.h
@@ -320,9 +320,6 @@ void freesymtab(Symbol **stab, SYMIDX n1, SYMIDX n2);
 Symbol * symbol_copy(Symbol *s);
 Symbol * symbol_searchlist(symlist_t sl, const char *vident);
 
-#if TARGET_MAC
-#include "CGproto.h"
-#else
 
 // cg87.c
 void cg87_reset();
@@ -394,9 +391,6 @@ void objfile_term();
 /* cod3.c */
 void cod3_thunk(Symbol *sthunk,Symbol *sfunc,unsigned p,tym_t thisty,
         targ_size_t d,int i,targ_size_t d2);
-
-#endif /* !TARGET_68000 */
-
 
 /* out.c */
 void outfilename(char *name,int linnum);
@@ -558,9 +552,5 @@ void  lnx_funcdecl(symbol *,enum SC,enum_SC,int);
 int  lnx_attributes(int hinttype,const void *hint, type **ptyp, tym_t *ptym,int *pattrtype);
 #endif
 
-
-#if TARGET_MAC
-#include "TGglobal.h"
-#endif
-
 #endif /* GLOBAL_H */
+

--- a/src/backend/glocal.c
+++ b/src/backend/glocal.c
@@ -64,10 +64,6 @@ STATIC void local_ambigdef(void);
 STATIC void local_symref(symbol *s);
 STATIC void local_symdef(symbol *s);
 
-#if TARGET_POWERPC
-static  bool    computing_params = FALSE;
-#endif
-
 #if !TX86
 static  bool    fcall_seen = FALSE;
 #endif
@@ -106,9 +102,6 @@ void localize()
              */
             !b->Btry)
         {
-#if TARGET_POWERPC
-            fcall_seen = FALSE;
-#endif
             local_exp(b->Belem,0);
         }
     }
@@ -132,12 +125,6 @@ Loop:
     {   case OPcomma:
             local_exp(e->E1,0);
             e = e->E2;
-#if TARGET_POWERPC
-            if (!goal)
-            {
-                fcall_seen = FALSE;
-            }
-#endif
             goto Loop;
 
         case OPandand:
@@ -341,13 +328,7 @@ Loop:
         case OPcall:
         case OPcallns:
         {
-#if TARGET_POWERPC
-            bool cp_save = computing_params;
             local_exp(e->E2,1);
-            computing_params = cp_save;
-#else
-            local_exp(e->E2,1);
-#endif
         }
         case OPstrctor:
         case OPucall:
@@ -395,9 +376,7 @@ Loop:
                         em = loctab[u].e;
                         if (em->E1->EV.sp.Vsym == s &&
                             (em->Eoper == OPeq || em->Eoper == OPstreq)
-#if TARGET_POWERPC
-                                && !(computing_params && (em->Nflags & NFLfcall))
-#elif !TX86
+#if !TX86
                                 && !(em->Nflags & NFLfcall)
 #endif
                                 )
@@ -484,15 +463,6 @@ Loop:
         case_bin:
             if (EBIN(e))
             {   local_exp(e->E1,1);
-#if TARGET_POWERPC
-// for powerPC localize only the rightmost parameter otherwise this could potentially  cause
-// unnecessary spills set this to true only after the rigtmost parameter has already been
-// computed
-                if (e->Eoper ==  OPparam)
-                {
-                        computing_params = TRUE;
-                }
-#endif
                 goal = 1;
                 e = e->E2;
                 goto Loop;

--- a/src/backend/glocal.c
+++ b/src/backend/glocal.c
@@ -363,12 +363,7 @@ Loop:
             {   unsigned u;
 
                 // If potential candidate for replacement
-#if TARGET_68K
-                if (s->Sflags & SFLunambig &&
-                   (config.inline68881 & CFG68881 || !(tyfloating(s->Sty))) )
-#else
                 if (s->Sflags & SFLunambig)
-#endif
                 {
                     for (u = 0; u < loctop; u++)
                     {   elem *em;
@@ -415,11 +410,7 @@ Loop:
             s = e->E1->EV.sp.Vsym;
             if (loctop)
             {
-                if (s->Sflags & SFLunambig
-#if TARGET_68K
-                   && (config.inline68881 & CFG68881 || !(tyfloating(s->Sty)))
-#endif
-                   )
+                if (s->Sflags & SFLunambig)
                     local_symref(s);
                 else
                     local_ambigref();           // ambiguous reference

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1097,8 +1097,6 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPbsf:
         case OPbsr:
         case OPbswap:
-#else
-        case OPsfltdbl: case OPdblsflt:
 #endif
                 markinvar(n->E1,rd);
                 if (isLI(n->E1))        /* if child is LI               */

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -140,10 +140,6 @@ static  bool addblk;                    /* if TRUE, then we added a block */
 /****************************
  */
 
-#if !(TARGET_MAC)
-/* These routines are not used for the Mac compiler build */
-
-
 void famlist::print()
 {
 #ifdef DEBUG
@@ -173,12 +169,9 @@ void Iv::print()
 #endif
 }
 
-#endif  /* !(TARGET_MAC) */
-
 /***********************
  * Write loop.
  */
-
 
 void loop::print()
 {
@@ -1027,10 +1020,6 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPvoid:
         case OPstrlen:
         case OPinp:
-#endif
-#if TARGET_MAC
-        case OPvptrfptr:
-        case OPcvptrfptr:
 #endif
                 markinvar(n->E1,rd);
                 break;
@@ -2943,10 +2932,6 @@ STATIC bool funcprev(Iv *biv,famlist *fl)
                     continue;           /* can't increase size of var   */
 #endif
                 flse1 = el_var(fls->FLtemp);
-#if TARGET_MAC
-                if (tysize(fl->FLty) > tysize(flse1->Ety))
-                    goto L1;            /* can't increase size of var   */
-#endif
                 flse1->Ety = fl->FLty;
                 goto L2;
         }

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1103,14 +1103,12 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPs64_128:
         case OPu64_128:
 #endif
-#if !(TARGET_POWERPC)
         case OPabs:
         case OPsqrt:
         case OPrndtol:
         case OPsin:
         case OPcos:
         case OPrint:
-#endif
 #if TX86
         case OPvptrfptr: /* BUG for MacHandles */
         case OPtofar16: case OPfromfar16: case OPoffset: case OPptrlptr:
@@ -2796,39 +2794,6 @@ STATIC void intronvars(loop *l)
             /* of a previous induction variable, skip it.                */
             if (funcprev(biv,fl))
                 continue;
-
-#if TARGET_POWERPC
- extern INT32 numbitsset(UINT32);
-
-            if (!fl->c1) {
-                fl->FLtemp = FLELIM;
-                continue;
-
-            }
-
-
-
-
-            if (cnst(fl->c1))
-            {
-                elem * ec1 = fl->c1;
-                if (tyfloating(tybasic(ec1->Ety)))
-                        goto create_temp;
-
-                {
-                targ_llong v = el_tolong(ec1);
-                if (numbitsset((UINT32) v) != 1)
-                    goto create_temp;
-
-                fl->FLtemp = FLELIM;
-
-                continue;
-                }
-            }
-
-create_temp:
-
-#endif
 
             ty = fl->FLty;
             T = el_alloctmp(ty);        /* allocate temporary T          */

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -753,7 +753,6 @@ restart:
     addblk = FALSE;                     /* assume no blocks added        */
     for (l = startloop; l; l = l->Lnext)/* for each loop                 */
     {
-        T68000(file_progress();)
 #ifdef DEBUG
         //if (debugc) l->print();
 #endif

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1073,25 +1073,6 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPu16_d:   case OPdbluns:
         case OPs8int:   case OPint8:
         case OPd_u32:   case OPu32_d:
-#if TARGET_68K
-        case OPacos:
-        case OPasin:
-        case OPatan:
-        case OPatanh:
-        case OPcos:
-        case OPcosh:
-        case OPexp:
-        case OPexp1:
-        case OPexp10:
-        case OPlog:
-        case OPlog10:
-        case OPlog2:
-        case OPsin:
-        case OPsincos:
-        case OPsinh:
-        case OPtan:
-        case OPtanh:
-#endif
 
 #if LONGLONG
         case OPlngllng: case OPu32_64:
@@ -2069,18 +2050,8 @@ STATIC famlist * newfamlist(tym_t ty)
                 c.Vdouble = 1;
                 break;
             case TYldouble:
-#if TARGET_68K && __POWERPC
-                c.Vldouble = Xone();
-#else
                 c.Vldouble = 1;
-#endif
                 break;
-#if TARGET_68K && !__POWERPC
-            case TYcomp:
-                c.Vldouble = 1;
-                ty = TYldouble;
-                break;
-#endif
 #if _MSDOS || __OS2__ || _WIN32         // if no byte ordering problems
             case TYsptr:
             case TYcptr:
@@ -3137,11 +3108,7 @@ STATIC void elimbasivs(register loop *l)
                  */
                 if (!tyuns(ty) &&
                     (tyintegral(ty) && el_tolong(fl->c1) < 0 ||
-#if TARGET_68K && __POWERPC
-                     tyfloating(ty) && Xlt(el_toldouble(fl->c1),Xzero()) ))
-#else
                      tyfloating(ty) && el_toldouble(fl->c1) < 0.0))
-#endif
                         refEoper = swaprel(refEoper);
 
                 /* Replace (X relop e) with (X relop (short)e)
@@ -3530,13 +3497,8 @@ STATIC famlist * flcmp(famlist *f1,famlist *f2)
                         goto Lf2;
                 break;
             case TYldouble:
-#if TARGET_68K && __POWERPC
-                if (Xis1(t2->Vldouble) ||
-                    !(Xis1(t2->Vldouble)) && Xis0(f2->c2->EV.Vldouble) )
-#else
                 if (t2->Vldouble == 1.0 ||
                     t1->Vldouble != 1.0 && f2->c2->EV.Vldouble == 0)
-#endif
                         goto Lf2;
                 break;
             case TYllong:

--- a/src/backend/go.c
+++ b/src/backend/go.c
@@ -24,10 +24,6 @@
 #include        "go.h"
 #include        "type.h"
 
-#if TARGET_MAC
-#include        "TG.h"
-#endif
-
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 

--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -519,11 +519,6 @@ STATIC elem * chkprop(elem *n,list_t rdlist)
 
         if (d->E2->Eoper == OPconst || d->E2->Eoper == OPrelconst)
         {
-#if TARGET_68K
-        if (d->E2->Eoper == OPrelconst)
-            if(tyfunc(d->E2->Esym->ty()))
-                goto noprop;            /* ruins relocation information */
-#endif
             if (foundelem)              /* already found one            */
             {                           /* then they must be the same   */
                 if (!el_match(foundelem,d->E2))

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -18,10 +18,6 @@
 #ifndef OPER_H
 #define OPER_H  1
 
-#if TARGET_MAC
-#include "TGoper.h"
-#endif
-
 enum OPER
 {
         OPunde,                 /* place holder for undefined operator  */

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -297,10 +297,6 @@ TARGET_CONVERSION_OPS
         TARGET_INLINEFUNC_OPS
 #endif
 
-#if (TARGET_POWERPC)
-        OPeieio,
-#endif
-
         OPMAX                   /* 1 past last operator         */
 };
 typedef enum OPER OPER;         /* needed for optabgen          */

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -135,8 +135,6 @@ enum OPER
 
 // parallel array inconvtab[] in cgelem.c)
 
-#if TX86
-
 /* Convert from conversion operator to conversion index         */
 #define convidx(op)     ((int)(op) - CNVOPMIN)
 
@@ -176,8 +174,6 @@ enum OPER
         OPu64_128,
         OPs64_128,
         OP128_64,
-#define OPsfltdbl       OPunde
-#define OPdblsflt       OPunde
         OPoffset,       // get offset of far pointer
         OPnp_fp,        // convert near pointer to far
         OPnp_f16p,      // from 0:32 to 16:16
@@ -185,9 +181,6 @@ enum OPER
         OPld_d,
         OPd_ld,
         OPld_u64,
-#else
-TARGET_CONVERSION_OPS
-#endif
 
 #define CNVOPMAX        (OPc_r-1)
 #define convidx(op)     ((int)(op) - CNVOPMIN)
@@ -216,8 +209,6 @@ TARGET_CONVERSION_OPS
 #define OPint8          OP16_8          // short to 8 bits
 #define OPlngllng       OPs32_64        // long to long long
 #define OPllnglng       OP64_32         // long long to long
-#define OPsfltdbl       OPunde
-#define OPdblsflt       OPunde
 #define OPoffset        OPoffset        // get offset of far pointer
 #define OPptrlptr       OPnp_fp         // convert near pointer to far
 #define OPtofar16       OPnp_f16p       // from 0:32 to 16:16

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -56,9 +56,6 @@ int _unary[] =
          OPu32_64,OPlngllng,OP64_32,OPmsw,
          OPd_s64,OPs64_d,OPd_u64,OPu64_d,OPld_u64,
          OP128_64,OPs64_128,OPu64_128,
-#if TARGET_MAC
-         OPsfltdbl,OPdblsflt,
-#endif
          OPucall,OPucallns,OPstrpar,OPstrctor,OPu16_d,OPdbluns,
          OPinp,OPptrlptr,OPtofar16,OPfromfar16,OParrow,OPnegass,
          OPctor,OPdtor,OPsetjmp,OPvoid,OParraylength,
@@ -131,9 +128,6 @@ int _ae[] = {OPvar,OPconst,OPrelconst,OPneg,
                 OPu32_64,OPlngllng,OP64_32,OPmsw,
                 OPd_s64,OPs64_d,OPd_u64,OPu64_d,OPld_u64,
                 OP128_64,OPs64_128,OPu64_128,
-#if TARGET_MAC
-                OPsfltdbl,OPdblsflt,
-#endif
                 OPsizeof,OParray,OPfield,OPinstanceof,OPfinalinstanceof,OPcheckcast,OParraylength,
                 OPcallns,OPucallns,OPnullcheck,OPpair,OPrpair,
                 OPbsf,OPbsr,OPbt,OPbswap,OPb_8,
@@ -155,9 +149,6 @@ int _exp[] = {OPvar,OPconst,OPrelconst,OPneg,OPabs,OPsqrt,OPrndtol,OPrint,
                 OPu32_64,OPlngllng,OP64_32,OPmsw,
                 OPd_s64,OPs64_d,OPd_u64,OPu64_d,OPld_u64,
                 OP128_64,OPs64_128,OPu64_128,
-#if TARGET_MAC
-                OPsfltdbl,OPdblsflt,
-#endif
                 OPbit,OPind,OPucall,OPucallns,OPnullcheck,
                 OParray,OPfield,OPinstanceof,OPfinalinstanceof,OPcheckcast,OParraylength,OPhstring,
                 OPcall,OPcallns,OPeq,OPstreq,OPpostinc,OPpostdec,
@@ -172,9 +163,6 @@ int _boolnop[] = {OPuadd,OPbool,OPs16_32,OPu16_32,
                 OPd_ld, OPld_d,
                 OPu32_64,OPlngllng,/*OP64_32,OPmsw,*/
                 OPs64_128,OPu64_128,
-#if TARGET_MAC
-                OPsfltdbl,OPdblsflt,
-#endif
                 OPu16_d,OPptrlptr,OPb_8,
                 OPnullptr,
                 };
@@ -579,10 +567,6 @@ void dotab()
         case OPd_u64:   X("d_u64",      evalu8, cdcnvt);
         case OPu64_d:   X("u64_d",      evalu8, cdcnvt);
         case OPld_u64:  X("ld_u64",     evalu8, cdcnvt);
-#if TARGET_MAC
-        case OPsfltdbl: X("sfltdbl",    evalu8, cdcnvt);
-        case OPdblsflt: X("dblsflt",    evalu8, cdcnvt);
-#endif
         case OPparam:   X("param",      elparam, cderr);
         case OPsizeof:  X("sizeof",     elzot,  cderr);
         case OParrow:   X("->",         elzot,  cderr);
@@ -718,16 +702,11 @@ void fltables()
                 case FLgot:     segfl[i] = -1;  break;
                 case FLgotoff:  segfl[i] = -1;  break;
 #endif
-#if TARGET_MAC
-                case FLsf:      segfl[i] = -1;  break;
-                case FLpaspara: segfl[i] = -1;  break;
-#else
                 case FLlocalsize: segfl[i] = -1;        break;
                 case FLtlsdata: segfl[i] = -1;  break;
                 case FLframehandler:    segfl[i] = -1;  break;
                 case FLasm:     segfl[i] = -1;  break;
                 case FLallocatmp:       segfl[i] = SS;  break;
-#endif
                 default:
                         printf("error in segfl[%d]\n", i);
                         exit(1);
@@ -776,14 +755,9 @@ void dotytab()
                                  TYlong,TYulong,TYllong,TYullong,TYdchar,
                                  TYchar16, TYcent, TYucent };
     static tym_t _ref[]      = { TYnref,TYfref,TYref };
-#if TARGET_MAC
-    static tym_t _func[]     = { TYnfunc,TYffunc,TYnpfunc,TYfpfunc,TYpsfunc,
-                                 TYnsfunc,TYfsfunc };
-#else
     static tym_t _func[]     = { TYnfunc,TYffunc,TYnpfunc,TYfpfunc,TYf16func,
                                  TYnsfunc,TYfsfunc,TYifunc,TYmfunc,TYjfunc,
                                  TYnsysfunc,TYfsysfunc, TYhfunc };
-#endif
     static tym_t _uns[]     = { TYuchar,TYushort,TYuint,TYulong,
 #if MARS
                                 TYwchar_t,
@@ -797,13 +771,8 @@ void dotytab()
 #if TARGET_WINDOS
     static tym_t _farfunc[] = { TYffunc,TYfpfunc,TYfsfunc,TYfsysfunc };
 #endif
-#if TARGET_MAC
-    static tym_t _pasfunc[] = { TYnpfunc,TYfpfunc,TYpsfunc,TYnsfunc,TYfsfunc };
-    static tym_t _revfunc[] = { TYnpfunc,TYfpfunc,TYpsfunc };
-#else
     static tym_t _pasfunc[] = { TYnpfunc,TYfpfunc,TYf16func,TYnsfunc,TYfsfunc,TYmfunc,TYjfunc };
     static tym_t _revfunc[] = { TYnpfunc,TYfpfunc,TYf16func,TYjfunc };
-#endif
     static tym_t _short[]     = { TYbool,TYchar,TYschar,TYuchar,TYshort,
                                   TYwchar_t,TYushort,TYchar16 };
     static tym_t _aggregate[] = { TYstruct,TYarray };
@@ -879,15 +848,9 @@ void dotytab()
 "member func",  TYmfunc,        TYmfunc,   TYmfunc,     -1,     0x64,   0,
 "D func",        TYjfunc,       TYjfunc,   TYjfunc,     -1,     0x74,   0,
 "interrupt func", TYifunc,      TYifunc,   TYifunc,     -1,     0x64,   0,
-#if TARGET_MAC
-"near Cpp func", TYnpfunc,      TYnpfunc,  TYnpfunc,    -1,     0x74,   0,
-"far Cpp func",  TYfpfunc,      TYfpfunc,  TYfpfunc,    -1,     0x73,   0,
-"far pascal func",  TYpsfunc,   TYpsfunc,  TYpsfunc,    -1,     0x75,   0,
-#else
 "_far16 Pascal func", TYf16func, TYf16func, TYf16func,  -1,     0x63,   0,
 "Pascal func",  TYnpfunc,       TYnpfunc,  TYnpfunc,    -1,     0x74,   0,
 "far Pascal func",  TYfpfunc,   TYfpfunc,  TYfpfunc,    -1,     0x73,   0,
-#endif
 "void",         TYvoid,         TYvoid,    TYvoid,      -1,     0x85,   3,
 "memptr",       TYmemptr,       TYmemptr,  TYmemptr,    -1,     0,      0,
 "ident",        TYident,        TYident,   TYident,     -1,     0,      0,

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -621,7 +621,7 @@ void dotab()
   fclose(f);
 
   f = fopen("elxxx.c","w");
-  fprintf(f,"elem *(*elxxx[OPMAX]) (elem *) = \n\t{\n");
+  fprintf(f,"static elem *(*elxxx[OPMAX]) (elem *) = \n\t{\n");
   for (i = 0; i < OPMAX - 1; i++)
         fprintf(f,"\t%s,\n",elxxx[i]);
   fprintf(f,"\t%s\n\t};\n",elxxx[i]);

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -56,7 +56,7 @@ void out_extdef(symbol *s)
 
 #endif
 
-#if TX86 || (!HOST_THINK && (TARGET_68K))
+#if TX86
 #if SCPP
 /********************************
  * Put out code segment name record.

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -777,10 +777,10 @@ void out_regcand(symtab_t *psymtab)
 {
     block *b;
     SYMIDX si;
-    T80x86(int ifunc;)
+    int ifunc;
 
     //printf("out_regcand()\n");
-    T80x86(ifunc = (tybasic(funcsym_p->ty()) == TYifunc);)
+    ifunc = (tybasic(funcsym_p->ty()) == TYifunc);
     for (si = 0; si < psymtab->top; si++)
     {   symbol *s = psymtab->tab[si];
 

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -32,12 +32,6 @@
 #include        "el.h"
 #endif
 
-#if TARGET_POWERPC
-#include "cgobjxcoff.h"
-#include "xcoff.h"
-#include "cgfunc.h"
-#endif
-
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
@@ -924,9 +918,6 @@ STATIC void writefunc2(symbol *sfunc)
     targ_size_t coffsetsave;
     func_t *f = sfunc->Sfunc;
     tym_t tyf;
-#if TARGET_POWERPC
-    type *tyArr;
-#endif
 
     //printf("writefunc(%s)\n",sfunc->Sident);
     debug(debugy && dbg_printf("writefunc(%s)\n",sfunc->Sident));
@@ -985,24 +976,6 @@ STATIC void writefunc2(symbol *sfunc)
     assert(globsym.top == 0);
     memcpy(&globsym.tab[0],&f->Flocsym.tab[0],nsymbols * sizeof(symbol *));
     globsym.top = nsymbols;
-#if TARGET_POWERPC
-    //
-    // JTM: I moved the code in cgcntrl.c to here
-    // and made SpillSym a global
-    //
-    // Is it OK to add to globsym.tab here?  When will the memory for the _TMP symbol
-    // get freed?       We may need to add an explicit free of this symbol somewhere within
-    // this function
-    // Need to chat with PLS about this
-
-    // initialize the spill area symbol, fake it to be an array
-    tyArr = type_alloc(TYarray);        /* array of                     */
-    tyArr->Tdim = 1;
-    tyArr->Tnext = tslong;
-    SpillSym = symbol_generate(SCtmp, tyArr);
-    symbol_add(SpillSym);
-    SpillSym->Sfl = FLauto; // mark it as auto since it is the last in that area
-#endif
 
     assert(startblock == NULL);
     if (f->Fflags & Finline)            // if keep function around
@@ -1402,11 +1375,7 @@ STATIC void writefunc2(symbol *sfunc)
         if (p[0] == '_' && p[1] == 'S' && p[2] == 'T' &&
             (p[3] == 'I' || p[3] == 'D'))
 #endif
-#if !(TARGET_POWERPC)
             obj_funcptr(sfunc);
-#else
-                ;
-#endif
     }
 
 Ldone:

--- a/src/backend/parser.h
+++ b/src/backend/parser.h
@@ -185,9 +185,6 @@ struct BLKLST
 #if PRAGMA_ONCE
 #       define BLponce   0x10   /* pragma - only include this file once */
 #endif
-#if TARGET_MAC
-#       define BFpdef    0x20   /* pre-compilation definition block     */
-#endif
     char        BLtyp;          /* type of block (BLxxxx)               */
 #       define BLstr    2       /* string                               */
 #       define BLfile   3       /* a #include file                      */
@@ -297,7 +294,7 @@ CEXTERN UHINT egchar(void);
 void insblk(unsigned char *text,int typ,list_t aargs,int nargs,macro_t *m);
 void insblk2(unsigned char *text,int typ);
 
-#if TARGET_MAC || __GNUC__
+#if __GNUC__
 unsigned getreallinnum();
 CEXTERN void getcharnum(void);
 #endif
@@ -430,13 +427,6 @@ symbol *using_member_declaration(Classsym *stag);
 void scope_push_nspace(Nspacesym *sn);
 void nspace_checkEnclosing(symbol *s);
 int nspace_isSame(symbol *s1, symbol *s2);
-
-#if TARGET_MAC
-/* TGnwc.c */
-void ext_init(void);
-void ext_term(void);
-void nwc_chkmain(symbol *,enum SC);
-#endif
 
 /* nwc.c */
 void thunk_hydrate(struct Thunk **);
@@ -638,10 +628,6 @@ int template_match_expanded_type(type *ptyTemplate, param_t *ptpl, param_t *ptal
         type *ptyFormal );
 int template_classname(char *vident, Classsym *stag);
 void template_free_ptal(param_t *ptal);
-#if TARGET_MAC
-bool template_match_expanded_type(type *ptyTemplate, param_t *ptal, type *ptyActual,
-        type *ptyFormal );
-#endif
 int template_function_leastAsSpecialized(symbol *f1, symbol *f2, param_t *ptal);
 #if SCPP
 Match template_matchtype(type *tp,type *te,elem *ee,param_t *ptpl, param_t *ptal, int flags);

--- a/src/backend/parser.h
+++ b/src/backend/parser.h
@@ -101,9 +101,7 @@ struct Match
 /***************************
  * Macros.
  */
-#if TARGET_POWERPC
-#pragma ZTC align 4
-#elif !TX86
+#if !TX86
 #pragma ZTC align 1
 #endif
 

--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -31,10 +31,6 @@
 #include        "oper.h"                /* for OPMAX            */
 #include        "token.h"
 
-#if TARGET_MAC
-#include        "TG.h"
-#endif
-
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
@@ -835,10 +831,6 @@ void symbol_free(symbol *s)
                 list_free(&f->Fsymtree,(list_free_fp)symbol_free);
                 func_free(f);
             }
-#if TARGET_MAC
-            if (s->Sdirect && s->Sflags&SFLdirect && !(s->Sflags&SFLsmdir))
-                MEM_PH_FREE(s->Sdirect);
-#endif
             switch (s->Sclass)
             {
 #if SCPP
@@ -1272,18 +1264,7 @@ symbol *symbol_hydrate(symbol **ps)
                 list_hydrate(&f->Ffwdrefinstances,(list_free_fp)symbol_hydrate);
                 list_hydrate(&f->Fexcspec,(list_free_fp)type_hydrate);
             }
-#if TARGET_MAC
-            if (s->Sdirect && s->Sflags&SFLdirect && !(s->Sflags&SFLsmdir))
-                ph_hydrate(&s->Sdirect);
-#endif
         }
-#if (TARGET_MAC)
-        if(s->Sflags & SFLpasmeth)
-            {
-            symbol_hydrate(&s->Smethod);
-            //dbg_printf("SFLpasmeth symbol %s\n",s->Sident);
-            }
-#endif
         if (CPP)
             symbol_hydrate(&s->Sscope);
         switch (s->Sclass)
@@ -1498,18 +1479,7 @@ void symbol_dehydrate(symbol **ps)
             list_dehydrate(&f->Ffwdrefinstances,(list_free_fp)symbol_dehydrate);
             list_dehydrate(&f->Fexcspec,(list_free_fp)type_dehydrate);
             }
-#if TARGET_MAC
-            if (s->Sdirect && s->Sflags&SFLdirect && !(s->Sflags&SFLsmdir))
-                ph_dehydrate(&s->Sdirect);
-#endif
         }
-#if (TARGET_MAC)
-        if(s->Sflags & SFLpasmeth)
-            {
-            symbol_dehydrate(&s->Smethod);
-            //dbg_printf("SFLpasmeth %s\n",s->Sident);
-            }
-#endif
         if (CPP)
             ph_dehydrate(&s->Sscope);
         switch (s->Sclass)
@@ -1726,11 +1696,6 @@ void symbol_symdefs_hydrate(symbol **ps,symbol **parent,int flag)
             if (c == '_' &&  (strcmp(p,"__pasmeth") == 0))
                 continue;               // predefined struct, can't define twice
 #endif
-#if TARGET_MAC
-            if (c == '_' &&  ((strcmp(p,"__pasmeth") == 0)
-                || (strcmp(p, cpp_name_pasnew) == 0)))
-                continue;               // predefined names, can't define twice
-#endif
             }
             // Put symbol s into symbol table
 
@@ -1824,10 +1789,6 @@ void symbol_symdefs_hydrate(symbol **ps,symbol **parent,int flag)
  * Put symbol table s into parent symbol table.
  */
 
-#if TARGET_MAC
-extern char cpp_name_pasnew[];
-#endif
-
 void symboltable_hydrate(symbol *s,symbol **parent)
 {
     while (s)
@@ -1845,11 +1806,6 @@ void symboltable_hydrate(symbol *s,symbol **parent)
 #if HOST_MPW
         if(p[0] == '_' &&  (strcmp(p,"__pasmeth") == 0))
             goto L1;            /* predefined struct, can't define twice */
-#endif
-#if (TARGET_MAC)
-        if (p[0] == '_' &&  ((strcmp(p,"__pasmeth") == 0)
-            || (strcmp(p, cpp_name_pasnew) == 0)))
-            goto L1;            /* predefined names, can't define twice */
 #endif
 
         /* Put symbol s into symbol table       */
@@ -2212,10 +2168,6 @@ STATIC symbol * create_tree(int i, int lo, int hi)
 
 #if METRICS
 void symbol_table_metrics(void);
-#if TARGET_MAC
-pascal unsigned long TickCount(void)
-    = 0xA975;
-#endif
 #endif
 
 void symboltable_balance(symbol **ps)
@@ -2240,12 +2192,8 @@ void symboltable_balance(symbol **ps)
         goto Lret;
 #endif
 
-#if TARGET_MAC
-    balance.array = (symbol **) MEM_PARF_MALLOC(balance.nsyms * sizeof(symbol *));
-#else
     // Use malloc instead of mem because of pagesize limits
     balance.array = (symbol **) malloc(balance.nsyms * sizeof(symbol *));
-#endif
     if (!balance.array)
         goto Lret;                      // no error, just don't balance
 
@@ -2257,11 +2205,7 @@ void symboltable_balance(symbol **ps)
     T68000(release_temp_memory();)
     T80x86(free(balance.array);)
 #if METRICS
-#if TARGET_MAC
-    dbg_printf("time to balance: %.2f\n", (TickCount() - ticks) / 60.0);
-#else
     dbg_printf("time to balance: %ld\n", clock() - ticks);
-#endif
     dbg_printf("symbol table after balance:\n");
     symbol_table_metrics();
 #endif
@@ -2378,8 +2322,5 @@ void symbol_gendebuginfo()
 
 #endif
 
-#if TARGET_MAC
-#include "TGsymbol.c"
-#endif
-
 #endif /* !SPP */
+

--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -939,7 +939,7 @@ void symbol_free(symbol *s)
                 case SCfastpar:
                 case SCregister:
                 case SCtmp:
-                T80x86(case SCauto:)
+                case SCauto:
                     vec_free(s->Srange);
                     /* FALL-THROUGH */
 #if 0
@@ -1083,7 +1083,6 @@ symbol * symbol_copy(symbol *s)
     memcpy(scopy,s,sizeof(symbol) - sizeof(s->Sident));
     scopy->Sl = scopy->Sr = scopy->Snext = NULL;
     scopy->Ssymnum = -1;
-    T68000(scopy->Sidnum = 0;)
     if (scopy->Sdt)
         dtsymsize(scopy);
     if (scopy->Sflags & (SFLvalue | SFLdtorexp))
@@ -1214,7 +1213,6 @@ symbol *symbol_hydrate(symbol **ps)
 #if SOURCE_4SYMS
         s->Ssrcpos.Sfilnum += File_Hydrate_Num; /* file number relative header build */
 #endif
-        T68000(file_progress();)
         if (pstate.SThflag != FLAG_INPLACE && s->Sfl != FLreg)
             s->Sxtrnnum = 0;            // not written to .OBJ file yet
         type_hydrate(&s->Stype);
@@ -1417,7 +1415,6 @@ void symbol_dehydrate(symbol **ps)
         if (xsym_gen && ph_in_head(s))
             return;
 #endif
-        T68000(file_progress();)
         symbol_debug(s);
         t = s->Stype;
         if (isdehydrated(t))
@@ -2167,8 +2164,7 @@ void symboltable_balance(symbol **ps)
 
     dbg_printf("symbol table before balance:\n");
     symbol_table_metrics();
-    T68000(ticks = TickCount();)
-    T80x86(ticks = clock();)
+    ticks = clock();
 #endif
     balancesave = balance;              // so we can nest
     balance.nsyms = 0;
@@ -2191,8 +2187,7 @@ void symboltable_balance(symbol **ps)
 
     *ps = create_tree(balance.nsyms / 2, 0, balance.nsyms - 1);
 
-    T68000(release_temp_memory();)
-    T80x86(free(balance.array);)
+    free(balance.array);
 #if METRICS
     dbg_printf("time to balance: %ld\n", clock() - ticks);
     dbg_printf("symbol table after balance:\n");

--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -1012,7 +1012,7 @@ SYMIDX symbol_add(symbol *s)
     assert(sitop <= cstate.CSpsymtab->symmax);
     if (sitop == cstate.CSpsymtab->symmax)
     {
-#if defined(DEBUG) && !HOST_MPW
+#ifdef DEBUG
 #define SYMINC  1                       /* flush out reallocation bugs  */
 #else
 #define SYMINC  99
@@ -1690,13 +1690,7 @@ void symbol_symdefs_hydrate(symbol **ps,symbol **parent,int flag)
 
             p = s->Sident;
             c = *p;
-            if (CPP)
-            {
-#if HOST_MPW
-            if (c == '_' &&  (strcmp(p,"__pasmeth") == 0))
-                continue;               // predefined struct, can't define twice
-#endif
-            }
+
             // Put symbol s into symbol table
 
 #if MMFIO
@@ -1802,11 +1796,6 @@ void symboltable_hydrate(symbol *s,symbol **parent)
         p = s->Sident;
 
         //dbg_printf("symboltable_hydrate('%s')\n",p);
-
-#if HOST_MPW
-        if(p[0] == '_' &&  (strcmp(p,"__pasmeth") == 0))
-            goto L1;            /* predefined struct, can't define twice */
-#endif
 
         /* Put symbol s into symbol table       */
         {   symbol **ps;

--- a/src/backend/token.h
+++ b/src/backend/token.h
@@ -320,7 +320,7 @@ extern  token_t tok;
 extern  int ininclude;
 CEXTERN char tok_ident[];       // identifier
 extern  unsigned char _chartype[];
-#if TX86 || TARGET_MAC
+#if TX86
 extern token_t *toklist;
 #endif
 
@@ -347,16 +347,11 @@ Srcpos token_linnum(void);
 enum_TK token_peek();
 
 enum_TK rtoken(int);
-#if TARGET_MAC
-#define stoken ptoken
-extern void tok_retrieve(void);
-#else
 #if SPP
 #define stoken() rtoken(1)
 #else
 enum_TK stokenx(void);
 inline enum_TK stoken() { return toklist ? stokenx() : rtoken(1); }
-#endif
 #endif
 
 void token_init(void);

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -21,12 +21,9 @@
 #include "type.h"
 #include "el.h"
 #include "parser.h"
-#if TARGET_MAC
-#include "TG.h"
-#else
+
 #undef MEM_PH_MALLOC
 #define MEM_PH_MALLOC mem_fmalloc
-#endif
 
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
@@ -57,10 +54,6 @@ targ_size_t type_size(type *t)
 
     type_debug(t);
     tyb = tybasic(t->Tty);
-#if TARGET_MAC
-    if (!ANSI && tyb == TYenum)
-        tyb = tybasic(t->Tnext->Tty);
-#endif
 #ifdef DEBUG
     if (tyb >= TYMAX)
         /*type_print(t),*/
@@ -75,9 +68,6 @@ targ_size_t type_size(type *t)
             // in case program plays games with function pointers
             case TYffunc:
             case TYfpfunc:
-#if TARGET_MAC
-            case TYpsfunc:
-#endif
 #if TX86
             case TYnfunc:       /* in case program plays games with function pointers */
             case TYhfunc:
@@ -543,7 +533,7 @@ void type_init()
     type_num = 0;
     type_max = 0;
 #endif /* DEBUG */
-#endif /* TARGET_MACHINE */
+#endif /* TX86 */
 }
 
 /**********************************
@@ -947,12 +937,7 @@ void type_print(type *t)
   {     case TYstruct:
         case TYmemptr:
             dbg_printf(" Ttag=%p,'%s'",t->Ttag,t->Ttag->Sident);
-#if TARGET_MAC
-            dbg_printf(" Sfldlst=x%08lx Sflags=x%x",
-                            t->Ttag->Sstruct->Sfldlst,t->Ttag->Sstruct->Sflags);
-#else
             //dbg_printf(" Sfldlst=%p",t->Ttag->Sstruct->Sfldlst);
-#endif
             break;
         case TYarray:
             dbg_printf(" Tdim=%ld",t->Tdim);

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -455,16 +455,7 @@ void type_init()
     tsildouble  = type_allocbasic(TYildouble);
     tscldouble  = type_allocbasic(TYcldouble);
 #else
-#if TARGET_POWERPC
-// for powerPC the size of  long double is user determined
-    if (config.flags & CFGldblisdbl) {
-        tsldouble = type_allocbasic(TYdouble);  /* ldouble is same as double per user's request */
-    } else {
-        tsldouble = type_allocbasic(TYldouble);
-    }
-#else
     tsldouble = type_allocbasic(TYldouble);
-#endif
     tscomp = type_allocbasic(TYcomp);
     chartype = tschar;                          /* default is signed chars */
 #endif

--- a/src/backend/var.c
+++ b/src/backend/var.c
@@ -63,11 +63,6 @@ tym_t functypetab[LINK_MAXDIM] =
     TYnpfunc,
     TYnpfunc,
     TYnfunc,
-#elif TARGET_MAC
-    TYffunc,
-    TYfpfunc,
-    TYpsfunc,
-    TYpsfunc,
 #endif
 };
 #else
@@ -99,12 +94,6 @@ mangle_t funcmangletab[LINK_MAXDIM] =
     mTYman_sys,
     mTYman_std,
     mTYman_d,
-#endif
-#if TARGET_MAC
-    mTYman_c,
-    mTYman_c,
-    mTYman_c,
-    mTYman_c,
 #endif
 };
 


### PR DESCRIPTION
Remove bit rotten TARGET_[non x86-cpu stuff] and HOST_\* stuff.  I've barely dipped my toe into looking at the TX86 conditional to pull parts of it out to being unconditional.  That will be deferred until after this is pulled in case you want me to do more/less in this batch.

Please do review this fairly well even though we're now in code-freeze for the next release.  The pull can wait until after, but I'd like to do any cleanup sooner rather than waiting.
