### PR TITLE
Disallow accessing const globals containing indirections

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1297,7 +1297,7 @@ void Expression::checkPurity(Scope *sc, VarDeclaration *v, Expression *ethis)
         !(sc->flags & SCOPEdebug) && // allow violations inside debug conditionals
         v->ident != Id::ctfe &&      // magic variable never violates pure and safe
         !v->isImmutable() &&         // always safe and pure to access immutables...
-        !(v->isConst() && v->isDataseg()) && // const global data is immutable
+        !(v->isConst() && v->isDataseg() && !v->type->hasPointers()) && // const global value types are immutable
         !(v->storage_class & STCmanifest) // ...or manifest constants
        )
     {


### PR DESCRIPTION
This fixes a bug introduced by the fix for 4031
