### PR TITLE
Issue 6097 - SSSE3 not working with MMX instructions

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -225,6 +225,8 @@ int cod3_EA(code *c)
     unsigned op1 = c->Iop & 0xFF;
     if (op1 == ESCAPE)
         ins = 0;
+    else if ((c->Iop & 0xFFFD00) == 0x0F3800)
+        ins = inssize2[(c->Iop >> 8) & 0xFF];
     else if ((c->Iop & 0xFF00) == 0x0F00)
         ins = inssize2[op1];
     else
@@ -2772,7 +2774,9 @@ void assignaddrc(code *c)
         if (code_next(c) && code_next(code_next(c)) == c)
             assert(0);
 #endif
-        if ((c->Iop & 0xFF00) == 0x0F00)
+        if ((c->Iop & 0xFFFD00) == 0x0F3800)
+            ins = inssize2[(c->Iop >> 8) & 0xFF];
+        else if ((c->Iop & 0xFF00) == 0x0F00)
             ins = inssize2[c->Iop & 0xFF];
         else if ((c->Iop & 0xFF) == ESCAPE)
         {
@@ -3151,7 +3155,9 @@ void pinholeopt(code *c,block *b)
   {
     L1:
         op = c->Iop;
-        if ((op & 0xFF00) == 0x0F00)
+        if ((op & 0xFFFD00) == 0x0F3800)
+            ins = inssize2[(op >> 8) & 0xFF];
+        else if ((op & 0xFF00) == 0x0F00)
             ins = inssize2[op & 0xFF];
         else
             ins = inssize[op & 0xFF];
@@ -3776,17 +3782,27 @@ unsigned calccodsize(code *c)
 #endif
     iflags = c->Iflags;
     op = c->Iop;
-    if ((op & 0xFF00) == 0x0F00)
+    if ((op & 0xFF00) == 0x0F00 || (op & 0xFFFD00) == 0x0F3800)
         op = 0x0F;
     else
         op &= 0xFF;
     switch (op)
     {
         case 0x0F:
-            ins = inssize2[c->Iop & 0xFF];
-            size = ins & 7;
-            if (c->Iop & 0xFF0000 || (c->Iop & 0xFFFFFF) == 0x000F38) // Opcode 0F_38_00 PSHUFB ( ssse3 )
-                size++;
+            if ((c->Iop & 0xFFFD00) == 0x0F3800)
+            {   // 3 byte op ( 0F38-- or 0F3A-- )
+                ins = inssize2[(c->Iop >> 8) & 0xFF];
+                size = ins & 7;
+                if (c->Iop & 0xFF000000)
+                  size++;
+            }
+            else
+            {   // 2 byte op ( 0F-- )
+                ins = inssize2[c->Iop & 0xFF];
+                size = ins & 7;
+                if (c->Iop & 0xFF0000)
+                  size++;
+            }
             break;
 
         case NOP:
@@ -3972,7 +3988,11 @@ int code_match(code *c1,code *c2)
         goto nomatch;
 
     ins = inssize[cs1.Iop & 0xFF];
-    if ((cs1.Iop & 0xFF00) == 0x0F00)
+    if ((cs1.Iop & 0xFFFD00) == 0x0F3800)
+    {
+        ins = inssize2[(cs1.Iop >> 8) & 0xFF];
+    }
+    else if ((cs1.Iop & 0xFF00) == 0x0F00)
     {
         ins = inssize2[cs1.Iop & 0xFF];
     }
@@ -4198,16 +4218,29 @@ unsigned codout(code *c)
 
         if (op > 0xFF)
         {
-            if ((op & 0xFF00) == 0x0F00)
+            if ((op & 0xFFFD00) == 0x0F3800)
+                ins = inssize2[(op >> 8) & 0xFF];
+            else if ((op & 0xFF00) == 0x0F00)
                 ins = inssize2[op & 0xFF];
+
             if (op & 0xFF000000)
             {
-                if (c->Irex)
-                    GEN(c->Irex | REX);
-                GEN(op >> 24);
+                unsigned char op1 = op >> 24;
+                if (op1 == 0xF2 || op1 == 0xF3 || op1 == 0x66)
+                {
+                    GEN(op1);
+                    if (c->Irex)
+                        GEN(c->Irex | REX);
+                }
+                else
+                {
+                    if (c->Irex)
+                        GEN(c->Irex | REX);
+                    GEN(op1);
+                }
+                GEN((op >> 16) & 0xFF);
                 GEN((op >> 8) & 0xFF);
                 GEN(op & 0xFF);
-                GEN((op >> 16) & 0xFF);         // yes, this is out of order. For 0x660F3A41 & 40
             }
             else if (op & 0xFF0000)
             {
@@ -4963,7 +4996,9 @@ void code_hydrate(code **pc)
     while (*pc)
     {
         c = (code *) ph_hydrate(pc);
-        if ((c->Iop & 0xFF00) == 0x0F00)
+        if ((c->Iop & 0xFFFD00) == 0x0F3800)
+            ins = inssize2[(c->Iop >> 8) & 0xFF];
+        else if ((c->Iop & 0xFF00) == 0x0F00)
             ins = inssize2[c->Iop & 0xFF];
         else
             ins = inssize[c->Iop & 0xFF];
@@ -5129,7 +5164,9 @@ void code_dehydrate(code **pc)
     {
         ph_dehydrate(pc);
 
-        if ((c->Iop & 0xFF00) == 0x0F00)
+        if ((c->Iop & 0xFFFD00) == 0x0F3800)
+            ins = inssize2[(c->Iop >> 8) & 0xFF];
+        else if ((c->Iop & 0xFF00) == 0x0F00)
             ins = inssize2[c->Iop & 0xFF];
         else
             ins = inssize[c->Iop & 0xFF];
@@ -5301,7 +5338,9 @@ void code::print()
     }
 
     unsigned op = c->Iop;
-    if ((c->Iop & 0xFF00) == 0x0F00)
+    if ((c->Iop & 0xFFFD00) == 0x0F3800)
+        ins = inssize2[(op >> 8) & 0xFF];
+    else if ((c->Iop & 0xFF00) == 0x0F00)
         ins = inssize2[op & 0xFF];
     else
         ins = inssize[op & 0xFF];

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -1406,10 +1406,8 @@ L386_WARNING2:
         unsigned usOpcode = ptb.pptb0->usOpcode;
 
         pc->Iop = usOpcode;
-        if ((usOpcode & 0xFFFFFF00) == 0x660F3A00 ||    // SSE4
-            (usOpcode & 0xFFFFFF00) == 0x660F3800)      // SSE4
+        if ((usOpcode & 0xFFFD00) == 0x0F3800)    // SSSE3, SSE4
         {
-            pc->Iop = 0x66000F00 | ((usOpcode >> 8) & 0xFF) | ((usOpcode & 0xFF) << 16);
             goto L3;
         }
         switch (usOpcode & 0xFF0000)

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -4104,24 +4104,173 @@ void bar56()
 
 /* ======================= SSSE3 ======================= */
 
-/*
-palignr
-phaddd
-phaddw
-phaddsw
-phsubd
-phsubw
-phsubsw
-pmaddubsw
-pmulhrsw
-pshufb
-pabsb
-pabsd
-pabsw
-psignb
-psignd
-psignw
-*/
+void test57()
+{
+    ubyte* p;
+    M64  m64;
+    M128 m128;
+    static ubyte data[] =
+    [
+        0x0F, 0x3A, 0x0F, 0xCA,       0x03,    // palignr   MM1,  MM2, 3
+  0x66, 0x0F, 0x3A, 0x0F, 0xCA,       0x03,    // palignr  XMM1, XMM2, 3
+        0x0F, 0x3A, 0x0F, 0x5D, 0xD8, 0x03,    // palignr   MM3, -0x28[EBP], 3
+  0x66, 0x0F, 0x3A, 0x0F, 0x5D, 0xE0, 0x03,    // palignr  XMM3, -0x20[EBP], 3
+        0x0F, 0x38, 0x02, 0xCA,                // phaddd    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x02, 0xCA,                // phaddd   XMM1, XMM2
+        0x0F, 0x38, 0x02, 0x5D, 0xD8,          // phaddd    MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x02, 0x5D, 0xE0,          // phaddd   XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x01, 0xCA,                // phaddw    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x01, 0xCA,                // phaddw   XMM1, XMM2
+        0x0F, 0x38, 0x01, 0x5D, 0xD8,          // phaddw    MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x01, 0x5D, 0xE0,          // phaddw   XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x03, 0xCA,                // phaddsw   MM1,  MM2
+  0x66, 0x0F, 0x38, 0x03, 0xCA,                // phaddsw  XMM1, XMM2
+        0x0F, 0x38, 0x03, 0x5D, 0xD8,          // phaddsw   MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x03, 0x5D, 0xE0,          // phaddsw  XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x06, 0xCA,                // phsubd    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x06, 0xCA,                // phsubd   XMM1, XMM2
+        0x0F, 0x38, 0x06, 0x5D, 0xD8,          // phsubd    MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x06, 0x5D, 0xE0,          // phsubd   XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x05, 0xCA,                // phsubw    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x05, 0xCA,                // phsubw   XMM1, XMM2
+        0x0F, 0x38, 0x05, 0x5D, 0xD8,          // phsubw    MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x05, 0x5D, 0xE0,          // phsubw   XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x07, 0xCA,                // phsubsw   MM1,  MM2
+  0x66, 0x0F, 0x38, 0x07, 0xCA,                // phsubsw  XMM1, XMM2
+        0x0F, 0x38, 0x07, 0x5D, 0xD8,          // phsubsw   MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x07, 0x5D, 0xE0,          // phsubsw  XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x04, 0xCA,                // pmaddubsw  MM1,  MM2
+  0x66, 0x0F, 0x38, 0x04, 0xCA,                // pmaddubsw XMM1, XMM2
+        0x0F, 0x38, 0x04, 0x5D, 0xD8,          // pmaddubsw  MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x04, 0x5D, 0xE0,          // pmaddubsw XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x0B, 0xCA,                // pmulhrsw  MM1,  MM2
+  0x66, 0x0F, 0x38, 0x0B, 0xCA,                // pmulhrsw XMM1, XMM2
+        0x0F, 0x38, 0x0B, 0x5D, 0xD8,          // pmulhrsw  MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x0B, 0x5D, 0xE0,          // pmulhrsw XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x00, 0xCA,                // pshufb    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x00, 0xCA,                // pshufb   XMM1, XMM2
+        0x0F, 0x38, 0x00, 0x5D, 0xD8,          // pshufb    MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x00, 0x5D, 0xE0,          // pshufb   XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x1C, 0xCA,                // pabsb     MM1,  MM2
+  0x66, 0x0F, 0x38, 0x1C, 0xCA,                // pabsb    XMM1, XMM2
+        0x0F, 0x38, 0x1C, 0x5D, 0xD8,          // pabsb     MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x1C, 0x5D, 0xE0,          // pabsb    XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x1E, 0xCA,                // pabsd     MM1,  MM2
+  0x66, 0x0F, 0x38, 0x1E, 0xCA,                // pabsd    XMM1, XMM2
+        0x0F, 0x38, 0x1E, 0x5D, 0xD8,          // pabsd     MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x1E, 0x5D, 0xE0,          // pabsd    XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x1D, 0xCA,                // pabsw     MM1,  MM2
+  0x66, 0x0F, 0x38, 0x1D, 0xCA,                // pabsw    XMM1, XMM2
+        0x0F, 0x38, 0x1D, 0x5D, 0xD8,          // pabsw     MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x1D, 0x5D, 0xE0,          // pabsw    XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x08, 0xCA,                // psignb    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x08, 0xCA,                // psignb   XMM1, XMM2
+        0x0F, 0x38, 0x08, 0x5D, 0xD8,          // psignb    MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x08, 0x5D, 0xE0,          // psignb   XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x0A, 0xCA,                // psignd    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x0A, 0xCA,                // psignd   XMM1, XMM2
+        0x0F, 0x38, 0x0A, 0x5D, 0xD8,          // psignd    MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x0A, 0x5D, 0xE0,          // psignd   XMM3, -0x20[EBP]
+        0x0F, 0x38, 0x09, 0xCA,                // psignw    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x09, 0xCA,                // psignw   XMM1, XMM2
+        0x0F, 0x38, 0x09, 0x5D, 0xD8,          // psignw    MM3, -0x28[EBP]
+  0x66, 0x0F, 0x38, 0x09, 0x5D, 0xE0,          // psignw   XMM3, -0x20[EBP]
+    ];
+
+    asm
+    {
+        call  L1;
+
+        palignr     MM1,  MM2, 3;
+        palignr    XMM1, XMM2, 3;
+        palignr     MM3, m64 , 3;
+        palignr    XMM3, m128, 3;
+
+        phaddd      MM1,  MM2;
+        phaddd     XMM1, XMM2;
+        phaddd      MM3,  m64;
+        phaddd     XMM3, m128;
+
+        phaddw      MM1,  MM2;
+        phaddw     XMM1, XMM2;
+        phaddw      MM3,  m64;
+        phaddw     XMM3, m128;
+
+        phaddsw     MM1,  MM2;
+        phaddsw    XMM1, XMM2;
+        phaddsw     MM3,  m64;
+        phaddsw    XMM3, m128;
+
+        phsubd      MM1,  MM2;
+        phsubd     XMM1, XMM2;
+        phsubd      MM3,  m64;
+        phsubd     XMM3, m128;
+
+        phsubw      MM1,  MM2;
+        phsubw     XMM1, XMM2;
+        phsubw      MM3,  m64;
+        phsubw     XMM3, m128;
+
+        phsubsw     MM1,  MM2;
+        phsubsw    XMM1, XMM2;
+        phsubsw     MM3,  m64;
+        phsubsw    XMM3, m128;
+
+        pmaddubsw   MM1,  MM2;
+        pmaddubsw  XMM1, XMM2;
+        pmaddubsw   MM3,  m64;
+        pmaddubsw  XMM3, m128;
+
+        pmulhrsw    MM1,  MM2;
+        pmulhrsw   XMM1, XMM2;
+        pmulhrsw    MM3,  m64;
+        pmulhrsw   XMM3, m128;
+
+        pshufb      MM1,  MM2;
+        pshufb     XMM1, XMM2;
+        pshufb      MM3,  m64;
+        pshufb     XMM3, m128;
+
+        pabsb       MM1,  MM2;
+        pabsb      XMM1, XMM2;
+        pabsb       MM3,  m64;
+        pabsb      XMM3, m128;
+
+        pabsd       MM1,  MM2;
+        pabsd      XMM1, XMM2;
+        pabsd       MM3,  m64;
+        pabsd      XMM3, m128;
+
+        pabsw       MM1,  MM2;
+        pabsw      XMM1, XMM2;
+        pabsw       MM3,  m64;
+        pabsw      XMM3, m128;
+
+        psignb      MM1,  MM2;
+        psignb     XMM1, XMM2;
+        psignb      MM3,  m64;
+        psignb     XMM3, m128;
+
+        psignd      MM1,  MM2;
+        psignd     XMM1, XMM2;
+        psignd      MM3,  m64;
+        psignd     XMM3, m128;
+
+        psignw      MM1,  MM2;
+        psignw     XMM1, XMM2;
+        psignw      MM3,  m64;
+        psignw     XMM3, m128;
+
+L1:     pop     EAX;
+        mov     p[EBP],EAX;
+    }
+
+    foreach (i,b; data)
+    {
+        //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+        assert(p[i] == b);
+    }
+}
 
 /****************************************************/
 
@@ -4189,6 +4338,7 @@ int main()
     test54();
     test55();
     test56();
+    test57();
   }
     printf("Success\n");
     return 0;

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -4176,24 +4176,173 @@ void bar56()
 
 /* ======================= SSSE3 ======================= */
 
-/*
-palignr
-phaddd
-phaddw
-phaddsw
-phsubd
-phsubw
-phsubsw
-pmaddubsw
-pmulhrsw
-pshufb
-pabsb
-pabsd
-pabsw
-psignb
-psignd
-psignw
-*/
+void test57()
+{
+    ubyte* p;
+    M64  m64;
+    M128 m128;
+    static ubyte data[] =
+    [
+        0x0F, 0x3A, 0x0F, 0xCA,       0x03,    // palignr   MM1,  MM2, 3
+  0x66, 0x0F, 0x3A, 0x0F, 0xCA,       0x03,    // palignr  XMM1, XMM2, 3
+        0x0F, 0x3A, 0x0F, 0x5D, 0xC8, 0x03,    // palignr   MM3, -0x38[RBP], 3
+  0x66, 0x0F, 0x3A, 0x0F, 0x5D, 0xD0, 0x03,    // palignr  XMM3, -0x30[RBP], 3
+        0x0F, 0x38, 0x02, 0xCA,                // phaddd    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x02, 0xCA,                // phaddd   XMM1, XMM2
+        0x0F, 0x38, 0x02, 0x5D, 0xC8,          // phaddd    MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x02, 0x5D, 0xD0,          // phaddd   XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x01, 0xCA,                // phaddw    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x01, 0xCA,                // phaddw   XMM1, XMM2
+        0x0F, 0x38, 0x01, 0x5D, 0xC8,          // phaddw    MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x01, 0x5D, 0xD0,          // phaddw   XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x03, 0xCA,                // phaddsw   MM1,  MM2
+  0x66, 0x0F, 0x38, 0x03, 0xCA,                // phaddsw  XMM1, XMM2
+        0x0F, 0x38, 0x03, 0x5D, 0xC8,          // phaddsw   MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x03, 0x5D, 0xD0,          // phaddsw  XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x06, 0xCA,                // phsubd    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x06, 0xCA,                // phsubd   XMM1, XMM2
+        0x0F, 0x38, 0x06, 0x5D, 0xC8,          // phsubd    MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x06, 0x5D, 0xD0,          // phsubd   XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x05, 0xCA,                // phsubw    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x05, 0xCA,                // phsubw   XMM1, XMM2
+        0x0F, 0x38, 0x05, 0x5D, 0xC8,          // phsubw    MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x05, 0x5D, 0xD0,          // phsubw   XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x07, 0xCA,                // phsubsw   MM1,  MM2
+  0x66, 0x0F, 0x38, 0x07, 0xCA,                // phsubsw  XMM1, XMM2
+        0x0F, 0x38, 0x07, 0x5D, 0xC8,          // phsubsw   MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x07, 0x5D, 0xD0,          // phsubsw  XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x04, 0xCA,                // pmaddubsw  MM1,  MM2
+  0x66, 0x0F, 0x38, 0x04, 0xCA,                // pmaddubsw XMM1, XMM2
+        0x0F, 0x38, 0x04, 0x5D, 0xC8,          // pmaddubsw  MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x04, 0x5D, 0xD0,          // pmaddubsw XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x0B, 0xCA,                // pmulhrsw  MM1,  MM2
+  0x66, 0x0F, 0x38, 0x0B, 0xCA,                // pmulhrsw XMM1, XMM2
+        0x0F, 0x38, 0x0B, 0x5D, 0xC8,          // pmulhrsw  MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x0B, 0x5D, 0xD0,          // pmulhrsw XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x00, 0xCA,                // pshufb    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x00, 0xCA,                // pshufb   XMM1, XMM2
+        0x0F, 0x38, 0x00, 0x5D, 0xC8,          // pshufb    MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x00, 0x5D, 0xD0,          // pshufb   XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x1C, 0xCA,                // pabsb     MM1,  MM2
+  0x66, 0x0F, 0x38, 0x1C, 0xCA,                // pabsb    XMM1, XMM2
+        0x0F, 0x38, 0x1C, 0x5D, 0xC8,          // pabsb     MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x1C, 0x5D, 0xD0,          // pabsb    XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x1E, 0xCA,                // pabsd     MM1,  MM2
+  0x66, 0x0F, 0x38, 0x1E, 0xCA,                // pabsd    XMM1, XMM2
+        0x0F, 0x38, 0x1E, 0x5D, 0xC8,          // pabsd     MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x1E, 0x5D, 0xD0,          // pabsd    XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x1D, 0xCA,                // pabsw     MM1,  MM2
+  0x66, 0x0F, 0x38, 0x1D, 0xCA,                // pabsw    XMM1, XMM2
+        0x0F, 0x38, 0x1D, 0x5D, 0xC8,          // pabsw     MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x1D, 0x5D, 0xD0,          // pabsw    XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x08, 0xCA,                // psignb    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x08, 0xCA,                // psignb   XMM1, XMM2
+        0x0F, 0x38, 0x08, 0x5D, 0xC8,          // psignb    MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x08, 0x5D, 0xD0,          // psignb   XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x0A, 0xCA,                // psignd    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x0A, 0xCA,                // psignd   XMM1, XMM2
+        0x0F, 0x38, 0x0A, 0x5D, 0xC8,          // psignd    MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x0A, 0x5D, 0xD0,          // psignd   XMM3, -0x30[RBP]
+        0x0F, 0x38, 0x09, 0xCA,                // psignw    MM1,  MM2
+  0x66, 0x0F, 0x38, 0x09, 0xCA,                // psignw   XMM1, XMM2
+        0x0F, 0x38, 0x09, 0x5D, 0xC8,          // psignw    MM3, -0x38[RBP]
+  0x66, 0x0F, 0x38, 0x09, 0x5D, 0xD0,          // psignw   XMM3, -0x30[RBP]
+    ];
+
+    asm
+    {
+        call  L1;
+
+        palignr     MM1,  MM2, 3;
+        palignr    XMM1, XMM2, 3;
+        palignr     MM3, m64 , 3;
+        palignr    XMM3, m128, 3;
+
+        phaddd      MM1,  MM2;
+        phaddd     XMM1, XMM2;
+        phaddd      MM3,  m64;
+        phaddd     XMM3, m128;
+
+        phaddw      MM1,  MM2;
+        phaddw     XMM1, XMM2;
+        phaddw      MM3,  m64;
+        phaddw     XMM3, m128;
+
+        phaddsw     MM1,  MM2;
+        phaddsw    XMM1, XMM2;
+        phaddsw     MM3,  m64;
+        phaddsw    XMM3, m128;
+
+        phsubd      MM1,  MM2;
+        phsubd     XMM1, XMM2;
+        phsubd      MM3,  m64;
+        phsubd     XMM3, m128;
+
+        phsubw      MM1,  MM2;
+        phsubw     XMM1, XMM2;
+        phsubw      MM3,  m64;
+        phsubw     XMM3, m128;
+
+        phsubsw     MM1,  MM2;
+        phsubsw    XMM1, XMM2;
+        phsubsw     MM3,  m64;
+        phsubsw    XMM3, m128;
+
+        pmaddubsw   MM1,  MM2;
+        pmaddubsw  XMM1, XMM2;
+        pmaddubsw   MM3,  m64;
+        pmaddubsw  XMM3, m128;
+
+        pmulhrsw    MM1,  MM2;
+        pmulhrsw   XMM1, XMM2;
+        pmulhrsw    MM3,  m64;
+        pmulhrsw   XMM3, m128;
+
+        pshufb      MM1,  MM2;
+        pshufb     XMM1, XMM2;
+        pshufb      MM3,  m64;
+        pshufb     XMM3, m128;
+
+        pabsb       MM1,  MM2;
+        pabsb      XMM1, XMM2;
+        pabsb       MM3,  m64;
+        pabsb      XMM3, m128;
+
+        pabsd       MM1,  MM2;
+        pabsd      XMM1, XMM2;
+        pabsd       MM3,  m64;
+        pabsd      XMM3, m128;
+
+        pabsw       MM1,  MM2;
+        pabsw      XMM1, XMM2;
+        pabsw       MM3,  m64;
+        pabsw      XMM3, m128;
+
+        psignb      MM1,  MM2;
+        psignb     XMM1, XMM2;
+        psignb      MM3,  m64;
+        psignb     XMM3, m128;
+
+        psignd      MM1,  MM2;
+        psignd     XMM1, XMM2;
+        psignd      MM3,  m64;
+        psignd     XMM3, m128;
+
+        psignw      MM1,  MM2;
+        psignw     XMM1, XMM2;
+        psignw      MM3,  m64;
+        psignw     XMM3, m128;
+
+L1:     pop     RAX;
+        mov     p[RBP],RAX;
+    }
+
+    foreach (i,b; data)
+    {
+        //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+        assert(p[i] == b);
+    }
+}
 
 /****************************************************/
 
@@ -4256,6 +4405,7 @@ int main()
     test54();
     test55();
     test56();
+    test57();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Kai's original patch adds two 256 byte lookuptables ( inssize3_38, inssize3_3A ).
However, so far all 3 byte opcodes have the same instruction size ( 0F38 = (M|4), 0F3A = (M|T|E|5) )

Note: previously 3 byte ops using XMM registers had bytes 1,2,3 rotated as a lookup optimisation
This patch undoes that.
