### PR TITLE
Fix CTFE mutation of string literals

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2997,7 +2997,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
     Expression * newval = NULL;
 
     if (!wantRef)
-        // We need to treat pointers specially, because TOKsymoff can be used to
+    {    // We need to treat pointers specially, because TOKsymoff can be used to
         // return a value OR a pointer
         assert(e1);
         assert(e1->type);
@@ -3005,6 +3005,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             newval = this->e2->interpret(istate, ctfeNeedLvalue);
         else
             newval = this->e2->interpret(istate);
+    }
     if (newval == EXP_CANT_INTERPRET)
         return newval;
     // ----------------------------------------------------
@@ -3969,6 +3970,8 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
             e = e->interpret(istate);
             if (e != EXP_CANT_INTERPRET)
             {
+                if (e->op == TOKslice)
+                    e= resolveSlice(e);
                 e = expType(type, e);
                 e = copyLiteral(e);
             }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -986,6 +986,29 @@ int zfs()
 static assert(!is(typeof(compiles!(zfs()))));
 
 /**************************************************
+   .dup must protect string literals
+**************************************************/
+
+string mutateTheImmutable(immutable string _s)
+{
+   char[] s = _s.dup;
+   foreach(ref c; s)
+       c = 'x';
+   return s.idup;
+}
+
+string doharm(immutable string _name)
+{
+   return mutateTheImmutable(_name[2..$].idup);
+}
+
+enum victimLiteral = "CL_INVALID_CONTEXT";
+
+enum thug = doharm(victimLiteral);
+static assert(victimLiteral == "CL_INVALID_CONTEXT");
+
+
+/**************************************************
         Use $ in a slice of a dotvar slice
 **************************************************/
 


### PR DESCRIPTION
Fixes the wrong-code bug reported by Stephan Dilly on the dmdbeta mailing list.
Any string literal which is sliced and then duped, wasn't being duplicated.
