### PR TITLE
Bug6270: XMMREGS not preserved on indirect function call

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -2968,7 +2968,7 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
             ce = scodelem(e11,&retregs,keepmsk,TRUE);
             cgstate.stackclean--;
             /* Kill registers destroyed by an arbitrary function call */
-            ce = cat(ce,getregs((mBP | ALLREGS | mES) & ~fregsaved));
+            ce = cat(ce,getregs((mBP | ALLREGS | mES | XMMREGS) & ~fregsaved));
             if (e11ty == TYfptr)
             {   unsigned lsreg;
              LF1:
@@ -3001,7 +3001,7 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
                                                 // CALL [function]
             cs.Iflags = 0;
             cgstate.stackclean++;
-            ce = loadea(e11,&cs,0xFF,farfunc ? 3 : 2,0,keepmsk,(ALLREGS|mES|mBP) & ~fregsaved);
+            ce = loadea(e11,&cs,0xFF,farfunc ? 3 : 2,0,keepmsk,(mBP|ALLREGS|mES|XMMREGS) & ~fregsaved);
             cgstate.stackclean--;
             freenode(e11);
         }

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4234,6 +4234,28 @@ int test6229()
 }
 
 /***************************************************/
+// XMMBug
+
+class XMMPainter
+{
+  float call()
+  {
+    return sumFloats(0.0f, 0.0f);
+  }
+
+  static float sumFloats(float a, float b)
+  {
+    return a + b;
+  }
+}
+
+void test6270()
+{
+  auto painter = new XMMPainter;
+  assert(XMMPainter.sumFloats(20, painter.call()) == 20.0f);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -4459,6 +4481,7 @@ int main()
     test232();
     test233();
     bug6184();
+    test6270();
 
     writefln("Success");
     return 0;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4253,6 +4253,8 @@ void test6270()
 {
   auto painter = new XMMPainter;
   assert(XMMPainter.sumFloats(20, painter.call()) == 20.0f);
+  auto dg = () { return XMMPainter.sumFloats(0.0f, 0.0f); };
+  assert(XMMPainter.sumFloats(20, dg()) == 20.0f);
 }
 
 /***************************************************/

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4483,6 +4483,7 @@ int main()
     test232();
     test233();
     bug6184();
+    test6229();
     test6270();
 
     writefln("Success");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6270
- I also added a missing call in test42.d which is unrelated but would have created a merge conflict.
