### PR TITLE
Issue 1339 - Invariant/const-ness is broken by built-in array properties 

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6495,9 +6495,10 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
         return e->type->dotExp(sc, e, ident);
     }
 #if DMDV2
-    else if (t1b->ty == Tarray ||
-             t1b->ty == Tsarray ||
-             t1b->ty == Taarray)
+    else if ((t1b->ty == Tarray || t1b->ty == Tsarray ||
+             t1b->ty == Taarray) &&
+             ident != Id::sort && ident != Id::reverse &&
+             ident != Id::dup && ident != Id::idup)
     {   /* If ident is not a valid property, rewrite:
          *   e1.ident
          * as:

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -1180,19 +1180,19 @@ void test56()
     string a = "abcd";
     string r;
 
-    r = a.idup.reverse;
+    r = a.dup.reverse.idup;
     writefln(r);
     assert(r == "dcba");
 
     a = "a\u1235\u1234c";
     writefln(a);
-    r = a.idup.reverse;
+    r = a.dup.reverse.idup;
     writefln(r);
     assert(r == "c\u1234\u1235a");
 
     a = "ab\u1234c";
     writefln(a);
-    r = a.idup.reverse;
+    r = a.dup.reverse.idup;
     writefln(r);
     assert(r == "c\u1234ba");
 }

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -347,7 +347,7 @@ void test18()
     str.sort;
 
     // This will crash the compiler
-    str[0].sort;
+    str[0] = str[0].dup.sort.idup;
 
     // This will give sintax error
     //str[0].sort();
@@ -367,7 +367,7 @@ void test19()
     string array = "foobar";
 
     array = array.idup;
-    array.sort;
+    array = array.dup.sort.idup;
     assert(array == "abfoor");
 }
 


### PR DESCRIPTION
Issue 1339 - Invariant/const-ness is broken by built-in array properties sort and reverse

Do not allow sort or reverse on an array with a non-mutable element type.
Do not allow dupping an array when it violates const/immutable.

Requires [druntime pull request 37](https://github.com/D-Programming-Language/druntime/pull/37) (merged)

http://d.puremagic.com/issues/show_bug.cgi?id=1339
http://d.puremagic.com/issues/show_bug.cgi?id=3550
http://d.puremagic.com/issues/show_bug.cgi?id=2737
