### PR TITLE
Issue 5785 - Lexing or Parsing issue with UFCS

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -5466,7 +5466,7 @@ Expression *Parser::parsePostExp(Expression *e)
                 {   Identifier *id = token.ident;
 
                     nextToken();
-                    if (token.value == TOKnot && peekNext() != TOKis)
+                    if (token.value == TOKnot && peekNext() != TOKis && peekNext() != TOKin)
                     {   // identifier!(template-argument-list)
                         TemplateInstance *tempinst = new TemplateInstance(loc, id);
                         Objects *tiargs;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2972,6 +2972,15 @@ void bar150(T)(T n) {  }
 
 /***************************************************/
 
+void test5785()
+{
+    static struct x { static int y; }
+    assert(x.y !is 1);
+    assert(x.y !in [1:0]);
+}
+
+/***************************************************/
+
 void bar151(T)(T n) {  }
 
 nothrow void test151()
@@ -3338,6 +3347,7 @@ int main()
     test69();
     test70();
 
+    test5785();
     test72();
     test73();
     test74();


### PR DESCRIPTION
Rainer Schuetze's fix from the bug report.
Allow `a.b !in x` to be parsed.

http://d.puremagic.com/issues/show_bug.cgi?id=5785
