### PR TITLE
Issue 4460 - Regression(2.036) ICE(e2ir.c) when compiling foreach over associative array literal

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1849,7 +1849,7 @@ Lagain:
                 }
             }
 
-            if (tab->ty == Taarray)
+            if (taa)
             {
                 // Check types
                 Parameter *arg = (Parameter *)arguments->data[0];


### PR DESCRIPTION
Issue 4460 - Regression(2.036) ICE(e2ir.c) when compiling foreach over associative array literal

Fix bug where proper checks are not done on AA's in foreach, ending up with the wrong type.

http://d.puremagic.com/issues/show_bug.cgi?id=4460

This allows foreach over an array literal again, and re-enables some checks on the parameters.  AAs remain a huge mess, part template in object.d, most in rt\aaA.d, with two different interfaces and a lot of problems converting between `A[B]` and `AssociativeArray!(A, B)`.
