### PR TITLE
Bug 6265: Pure-inference failed when calling other pure functions

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -620,6 +620,7 @@ struct FuncDeclaration : Declaration
     int isCodeseg();
     int isOverloadable();
     enum PURE isPure();
+    enum PURE isPureBypassingInference();
     bool setImpure();
     int isSafe();
     int isTrusted();

--- a/src/expression.c
+++ b/src/expression.c
@@ -1250,14 +1250,14 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
         FuncDeclaration *outerfunc = sc->func;
         // Find the closest pure parent of the calling function
         while (outerfunc->toParent2() &&
-                !outerfunc->isPure() &&
+                !outerfunc->isPureBypassingInference() &&
                 outerfunc->toParent2()->isFuncDeclaration())
         {
             outerfunc = outerfunc->toParent2()->isFuncDeclaration();
         }
         // Find the closest pure parent of the called function
         FuncDeclaration *calledparent = f;
-        while (calledparent->toParent2() && !calledparent->isPure()
+        while (calledparent->toParent2() && !calledparent->isPureBypassingInference()
             && calledparent->toParent2()->isFuncDeclaration() )
         {
             calledparent = calledparent->toParent2()->isFuncDeclaration();

--- a/src/func.c
+++ b/src/func.c
@@ -2694,6 +2694,14 @@ enum PURE FuncDeclaration::isPure()
     return purity;
 }
 
+enum PURE FuncDeclaration::isPureBypassingInference()
+{
+    if (flags & FUNCFLAGpurityInprocess)
+        return PUREfwdref;
+    else
+        return isPure();
+}
+
 /**************************************
  * The function is doing something impure,
  * so mark it as impure.

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -1,0 +1,63 @@
+
+// 6265.
+
+pure nothrow @safe int h6265() {
+    return 1;
+}
+int f6265a(alias g)() {
+    return g();
+}
+pure nothrow @safe int i6265a() {
+    return f6265a!h6265();
+}
+
+int f6265b()() {
+    return h6265();
+}
+pure nothrow @safe int i6265b() {
+    return f6265b();
+}
+
+pure nothrow @safe int i6265c() {
+    return {
+        return h6265();
+    }();
+}
+
+// Make sure a function is not infered as pure if it isn't.
+
+int fNPa() {
+    return 1;
+}
+int gNPa()() {
+    return fNPa();
+}
+static assert( __traits(compiles, function int ()         { return gNPa(); }));
+static assert(!__traits(compiles, function int () pure    { return gNPa(); }));
+static assert(!__traits(compiles, function int () nothrow { return gNPa(); }));
+static assert(!__traits(compiles, function int () @safe   { return gNPa(); }));
+
+// Need to ensure the comment in Expression::checkPurity is not violated.
+
+void fECPa() {
+    void g()() {
+        void h() {
+        }
+        h();
+    }
+    static assert( is(typeof(&g!()) == void delegate() pure));
+    static assert(!is(typeof(&g!()) == void delegate()));
+}
+
+void fECPb() {
+    void g()() {
+        void h() {
+        }
+        fECPb();
+    }
+    static assert(!is(typeof(&g!()) == void delegate() pure));
+    static assert( is(typeof(&g!()) == void delegate()));
+}
+
+// Add more tests regarding inferences later.
+


### PR DESCRIPTION
Fixes [bug 6265](http://d.puremagic.com/issues/show_bug.cgi?id=6265). I'd argue that this fix is essential to say that pure inference works.
