### PR TITLE
Issue 6264 - ICE on testing opSlice in static if

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9600,22 +9600,9 @@ Expression *AssignExp::semantic(Scope *sc)
         }
         //error("cannot assign to static array %s", e1->toChars());
     }
-    else if (e1->op == TOKslice)
+    else if (e1->op == TOKslice && t2->toBasetype()->ty == Tarray &&
+        t2->toBasetype()->nextOf()->implicitConvTo(t1->nextOf()))
     {
-        /* This test is so we can do things like:
-         *    byte[] b; b[] = [1,2,3];
-         */
-        if (e2->op != TOKarrayliteral && e2->op != TOKstring)
-        {
-            Type *t1n = t1->toBasetype()->nextOf();
-            Type *t2n = t2->toBasetype()->nextOf();
-            assert(t1n && t2n);
-            if (!t2n->implicitConvTo(t1n))
-            {
-                error("cannot assign from %s to %s", t2->toChars(), t1->toChars());
-                return new ErrorExp();
-            }
-        }
         e2 = e2->implicitCastTo(sc, e1->type->constOf());
     }
     else

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3249,6 +3249,21 @@ void test6230() {
     assert(test6230pure());
 }
 
+/***************************************************/
+
+void test6264()
+{
+    struct S { auto opSlice() { return this; } }
+    int[] a;
+    S s;
+    static assert(!is(typeof(a[] = s[])));
+    int*[] b;
+    static assert(!is(typeof(b[] = [new immutable(int)])));
+    char[] c = new char[](5);
+    c[] = "hello";
+}
+
+/***************************************************/
 
 int main()
 {
@@ -3412,6 +3427,7 @@ int main()
     test4963();
     test4031();
     test6230();
+    test6264();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Only allow ignoring the constness of the element type when an implicit conversion is possible.
This fixes bugs introduced by the fix to 5284.

http://d.puremagic.com/issues/show_bug.cgi?id=6264
