### PR TITLE
Issue 6267 - Can't increment alias this'd struct from ref return

### DIFF
--- a/src/opover.c
+++ b/src/opover.c
@@ -474,11 +474,9 @@ Expression *BinExp::op_overload(Scope *sc)
 
     Objects *targsi = NULL;
 #if DMDV2
-    if (!s && !s_r && op != TOKequal && op != TOKnotequal && op != TOKassign)
+    if (!s && !s_r && op != TOKequal && op != TOKnotequal && op != TOKassign &&
+        op != TOKplusplus && op != TOKminusminus)
     {
-        if (op == TOKplusplus || op == TOKminusminus)
-            return NULL;
-
         /* Try the new D2 scheme, opBinary and opBinaryRight
          */
         if (ad1)

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -103,12 +103,25 @@ void test4()
 
 /**********************************************/
 
+void test5()
+{
+    static struct Double1 {
+        double val = 1;
+        alias val this;
+    }
+    static Double1 x() { return Double1(); }
+    x()++;
+}
+
+/**********************************************/
+
 int main()
 {
     test1();
     test2();
     test3();
     test4();
+    test5();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
The [fix for bug 5551](https://github.com/D-Programming-Language/dmd/commit/b3df2) was incorrect, it should only skip attempting to use `opBinary`/`opBinaryRight`, not the rest of op_overload.

http://d.puremagic.com/issues/show_bug.cgi?id=6267
