### PR TITLE
Issue 6279 - Regression(2.054 beta): array-vararg with pointer type not working in safe code

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -620,7 +620,7 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                         Identifier *id = Lexer::uniqueId("__arrayArg");
                         Type *t = new TypeSArray(((TypeArray *)tb)->next, new IntegerExp(nargs - i));
                         t = t->semantic(loc, sc);
-                        VarDeclaration *v = new VarDeclaration(loc, t, id, new VoidInitializer(loc));
+                        VarDeclaration *v = new VarDeclaration(loc, t, id, fd->isSafe() ? NULL : new VoidInitializer(loc));
                         v->storage_class |= STCctfe;
                         v->semantic(sc);
                         v->parent = sc->parent;

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -320,6 +320,13 @@ void structcast()
     static assert(!__traits(compiles, c = cast(C)a)); 
     static assert(!__traits(compiles, c = cast(C)b)); 
 } 
- 
+
+@safe
+void varargs()
+{
+    static void fun(string[] val...) {}
+    fun("a");
+}
+
 void main() { } 
 


### PR DESCRIPTION
Do not create a void initializer when inside a safe function, use a default initializer instead.

http://d.puremagic.com/issues/show_bug.cgi?id=6279
