### PR TITLE
Bug 5750: Allow pure functions to have lazy arguments

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7440,7 +7440,10 @@ Lagain:
             tf = (TypeFunction *)(td->next);
             if (sc->func && !tf->purity && !(sc->flags & SCOPEdebug))
             {
-                if (sc->func->setImpure())
+                if (e1->op == TOKvar && ((VarExp *)e1)->var->storage_class & STClazy)
+                {   // lazy paramaters can be called without violating purity
+                    // since they are checked explicitly
+                } else if (sc->func->setImpure())
                     error("pure function '%s' cannot call impure delegate '%s'", sc->func->toChars(), e1->toChars());
             }
             if (sc->func && tf->trust <= TRUSTsystem)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5093,10 +5093,8 @@ void TypeFunction::purityLevel()
             {   Parameter *fparam = Parameter::getNth(tf->parameters, i);
                 if (fparam->storageClass & STClazy)
                 {
-                    /* We could possibly allow this by doing further analysis on the
-                     * lazy parameter to see if it's pure.
-                     */
-                    error(0, "cannot have lazy parameters to a pure function");
+                    tf->purity = PUREweak;
+                    break;
                 }
                 if (fparam->storageClass & STCout)
                 {

--- a/test/runnable/lazy.d
+++ b/test/runnable/lazy.d
@@ -187,6 +187,39 @@ void test6()
 
 /*********************************************************/
 
+struct Bug5750 { int a, b; }
+pure Bug5750 bug5750(lazy int y) {
+    Bug5750 retval;
+    retval.a = y;
+    retval.b = y;
+    return retval;
+}
+
+pure void test5750a() {
+    auto z1 = bug5750(3);
+    assert(z1 == Bug5750(3, 3));
+    auto z2 = bug5750(z1.a);
+    assert(z2 == Bug5750(3, 3));
+    auto z3 = bug5750(z1.a+z2.a+3);
+    assert(z3 == Bug5750(9, 9));
+    auto z4 = bug5750(++z1.a);    // expected???
+    assert(z4 == Bug5750(4, 5));
+    assert(z1 == Bug5750(5, 3));
+}
+
+int bug5750Global = 7;
+void test5750b() {
+    auto z4 = bug5750(bug5750Global);
+    assert(z4 == Bug5750(7, 7));
+    auto z5 = bug5750(++bug5750Global);
+    assert(z5 == Bug5750(8, 9));  // expected???
+    assert(bug5750Global == 9);
+}
+// Note: also need to make up some fail-compilation tests.
+
+/*********************************************************/
+
+
 int main()
 {
     test1();
@@ -195,6 +228,9 @@ int main()
     test4();
     test5();
     test6();
+
+    test5750a();
+    test5750b();    
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
This apply @donc's patch for [bug 5750](http://d.puremagic.com/issues/show_bug.cgi?id=5750). 
