### PR TITLE
Issue 4984 - Recursive template constraint results in dmd running out of memory

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -740,7 +740,7 @@ MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
     }
 
 #if DMDV2
-    if (m && constraint && !(flag & 1))
+    if (m && !(m == MATCHexact && flag == 2) && constraint && !(flag & 1))
     {   /* Check to see if constraint is satisfied.
          */
         makeParamNamesVisibleInConstraint(paramscope);
@@ -2879,7 +2879,8 @@ MATCH TemplateTypeParameter::matchArg(Scope *sc, Objects *tiargs,
     else
     {
         // So that matches with specializations are better
-        m = MATCHconvert;
+        if (!(flags & 1))
+            m = MATCHconvert;
 
         /* This is so that:
          *   template Foo(T), Foo!(const int), => ta == int

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -203,6 +203,25 @@ template _ElemType(T) {
 
 /**********************************/
 
+void bug4984a(int n)() if (n > 0 && is(typeof(bug4984a!(n-1) ()))) {
+}
+
+void bug4984a(int n : 0)() {
+}
+
+void bug4984b(U...)(U args) if ( is(typeof( bug4984b(args[1..$]) )) ) {
+}
+
+void bug4984b(U)(U u) {
+}
+
+void bug4984() {
+    bug4984a!400();
+    bug4984b(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+}
+
+/**********************************/
+
 int main()
 {
     test1();
@@ -214,6 +233,7 @@ int main()
     test7();
     test8();
     test9();
+    bug4984();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
When calling `TemplateDeclaration::matchWithInstance` from within `TemplateInstance::semantic` do not re-evaluate the constraint if the args are an exact match.  This also requires matchArg considering equal args to be an exact match when just checking the types, not deducing.
