### PR TITLE
Issue 2234 - __traits(allMembers) returns incorrect results for mixin and template alias members of an aggregate

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1006,6 +1006,8 @@ Dsymbol *ScopeDsymbol::getNth(Dsymbols *members, size_t nth, size_t *pn)
     for (size_t i = 0; i < members->dim; i++)
     {   Dsymbol *s = members->tdata()[i];
         AttribDeclaration *a = s->isAttribDeclaration();
+        TemplateMixin *tm = s->isTemplateMixin();
+        TemplateInstance *ti = s->isTemplateInstance();
 
         if (a)
         {
@@ -1013,6 +1015,14 @@ Dsymbol *ScopeDsymbol::getNth(Dsymbols *members, size_t nth, size_t *pn)
             if (s)
                 return s;
         }
+        else if (tm)
+        {
+            s = getNth(tm->members, nth - n, &n);
+            if (s)
+                return s;
+        }
+        else if (ti)
+            ;
         else if (n == nth)
             return s;
         else

--- a/src/traits.c
+++ b/src/traits.c
@@ -345,6 +345,8 @@ Expression *TraitsExp::semantic(Scope *sc)
             for (size_t i = 0; i < dim; i++)
             {
                 Dsymbol *sm = ScopeDsymbol::getNth(sd->members, i);
+                if (!sm)
+                    break;
                 //printf("\t[%i] %s %s\n", i, sm->kind(), sm->toChars());
                 if (sm->ident)
                 {

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -594,6 +594,18 @@ void test23()
 
 /********************************************************/
 
+template Foo2234(){ int x; }
+
+struct S2234a{ mixin Foo2234; }
+struct S2234b{ mixin Foo2234; mixin Foo2234; }
+struct S2234c{ alias Foo2234!() foo; }
+
+static assert([__traits(allMembers, S2234a)] == ["x"]);
+static assert([__traits(allMembers, S2234b)] == ["x"]);
+static assert([__traits(allMembers, S2234c)] == ["foo"]);
+
+/********************************************************/
+
 int main()
 {
     test1();


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=2234">Issue 2234</a>
See TemplateMixin members, and ignore TemplateInstance which added internally for getting called semantic routines.
