### PR TITLE
Issue 6286 - Static arrays can not be assigned from const(T)[N] to T[N]

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9545,6 +9545,14 @@ Expression *AssignExp::semantic(Scope *sc)
         }
         else
         {
+            Type *t2 = e2->type->toBasetype();
+            // Convert e2 to e2[], unless e2-> e1[0]
+            if (t2->ty == Tsarray && !t2->implicitConvTo(t1->nextOf()))
+            {
+                e2 = new SliceExp(e2->loc, e2, NULL, NULL);
+                e2 = e2->semantic(sc);
+            }
+
             // Convert e1 to e1[]
             Expression *e = new SliceExp(e1->loc, e1, NULL, NULL);
             e1 = e->semantic(sc);

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -211,6 +211,19 @@ void test5()
 
 /***************************************************/
 
+void test6286()
+{
+    const(int)[4] src = [1, 2, 3, 4];
+    int[4] dst;
+    dst = src;
+    dst[] = src[];
+    dst = 4;
+    int[4][4] x;
+    x = dst;
+}
+
+/***************************************************/
+
 int main()
 {
     test1();
@@ -218,6 +231,7 @@ int main()
     test3();
     test4();
     test5();
+    test6286();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
when A and B are static arrays,
A = B should become A[] = B[] unless typeof(A[0]) is typeof(B).

http://d.puremagic.com/issues/show_bug.cgi?id=6286
