### PR TITLE
Bug 6284: [Regression 2.054] 'pure' does not work with 'with' statement

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1331,6 +1331,23 @@ void Expression::checkPurity(Scope *sc, VarDeclaration *v, Expression *ethis)
                 {
                     goto L1;
                 }
+                if (ethis->op == TOKstar)
+                {   PtrExp *pe = (PtrExp *)ethis;
+                    VarExp *target = (VarExp *)pe->e1;
+                    if (target->op == TOKvar)
+                    {
+#if 1  // disable this to only allow (*__withSym).a to be pure
+                        ethis = target;
+#else
+                        VarDeclaration *wsym = target->var->isVarDeclaration();
+                        if (wsym && wsym->ident == Id::withSym)
+                        {
+                            checkPurity(sc, wsym, NULL);
+                            return;
+                        }
+#endif
+                    }
+                }
                 if (ethis->op == TOKvar)
                 {   VarExp *ve = (VarExp *)ethis;
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3265,6 +3265,47 @@ void test6264()
 
 /***************************************************/
 
+struct S6284 {
+    int a;
+}
+class C6284 {
+    int a;
+}
+pure int bug6284a() {
+    S6284 s = {4};
+    auto b = s.a;   // ok
+    with (s) {
+        b += a;     // should be ok.
+    }
+    return b;
+}
+pure int bug6284b() {
+    auto s = new S6284;
+    s.a = 4;
+    auto b = s.a;
+    with (*s) {
+        b += a;
+    }
+    return b;
+}
+pure int bug6284c() {
+    auto s = new C6284;
+    s.a = 4;
+    auto b = s.a;
+    with (s) {
+        b += a;
+    }
+    return b;
+}
+void test6284() {
+    assert(bug6284a() == 8);
+    assert(bug6284b() == 8);
+    assert(bug6284c() == 8);
+}
+
+/***************************************************/
+
+
 int main()
 {
     test1();
@@ -3428,6 +3469,7 @@ int main()
     test4031();
     test6230();
     test6264();
+    test6284();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Fixes [bug 6284](http://d.puremagic.com/issues/show_bug.cgi?id=6284).

Actually this solves a more generic regression, where

``` d
Structure* s = ...;
auto b = s.a;
```

cannot be used in 'pure' function. Not sure if this is allowed or not, but I think it is correct, because
1. There is no way to get a reference to some global variable from internal without refering it first, which the `pure` check can handle,
2. Accessing and modifying members are already possible via methods,
3. Even if this is restricted to `__withSym`, this can be worked-around using `with(*s) { ... }` anyway.
