### PR TITLE
Issue 2355 - is() doesn't resolve aliases before template matching

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -326,7 +326,7 @@ int IftypeCondition::include(Scope *sc, ScopeDsymbol *sd)
             Objects dedtypes;
             dedtypes.setDim(1);
 
-            m = targ->deduceType(NULL, tspec, &parameters, &dedtypes);
+            m = targ->deduceType(sc, tspec, &parameters, &dedtypes);
             if (m == MATCHnomatch ||
                 (m != MATCHexact && tok == TOKequal))
                 inc = 2;

--- a/src/expression.c
+++ b/src/expression.c
@@ -5431,7 +5431,7 @@ Expression *IsExp::semantic(Scope *sc)
         dedtypes.setDim(parameters->dim);
         dedtypes.zero();
 
-        MATCH m = targ->deduceType(NULL, tspec, parameters, &dedtypes);
+        MATCH m = targ->deduceType(sc, tspec, parameters, &dedtypes);
 //printf("targ: %s\n", targ->toChars());
 //printf("tspec: %s\n", tspec->toChars());
         if (m == MATCHnomatch ||

--- a/test/runnable/template8.d
+++ b/test/runnable/template8.d
@@ -119,6 +119,9 @@ struct DoubleRep
         bool, "sign", 1);
 }
 
+struct Bug2355(string x) {}
+static assert(is(Bug2355!"a" U : Bug2355!V, string V));
+
 int main()
 {
     return 0;


### PR DESCRIPTION
The wrong scope was being used for the arg deduction.

http://d.puremagic.com/issues/show_bug.cgi?id=2355
