### PR TITLE
Issue 4953 - Regression(2.031): templates don't do implicit conversion properly

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1193,6 +1193,12 @@ L2:
             m = argtype->deduceType(paramscope, fparam->type, parameters, &dedtypes);
             //printf("\tdeduceType m = %d\n", m);
 
+            /* If no match, see if the argument can be matched by using
+             * implicit conversions.
+             */
+            if (!m)
+                m = farg->implicitConvTo(fparam->type);
+
             /* If no match, see if there's a conversion to a delegate
              */
             if (!m && fparam->type->toBasetype()->ty == Tdelegate)

--- a/test/runnable/opover.d
+++ b/test/runnable/opover.d
@@ -910,6 +910,11 @@ void test15()
 
 /**************************************/
 
+void bug4953(T = void)(short x) {}
+static assert(is(typeof(bug4953(3))));
+
+/**************************************/
+
 int main()
 {
     test1();


### PR DESCRIPTION
Allow matching when the arg type is known and the argument expression implicitly converts to the arg type.

http://d.puremagic.com/issues/show_bug.cgi?id=4953
