### PR TITLE
Issue 5596 - Regression(2.052): Different template alias parameters to the same literal result in different template instances

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -4195,6 +4195,7 @@ void TemplateInstance::semanticTiargs(Scope *sc)
 /**********************************
  * Input:
  *      flags   1: replace const variables with their initializers
+ *              2: do not optimise
  */
 
 void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int flags)
@@ -4226,7 +4227,9 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                  */
                 if (flags & 1) // only used by __traits, must not interpret the args
                     ea = ea->optimize(WANTvalue);
-                else if (ea->op != TOKvar)
+                else if (flags & 2) // don't touch ea, the symbol is what's needed
+                    ;
+                else if (ea->op != TOKvar || (((VarExp *)ea)->var->storage_class & STCmanifest))
                     ea = ea->optimize(WANTvalue | WANTinterpret);
                 tiargs->tdata()[j] = ea;
             }

--- a/src/traits.c
+++ b/src/traits.c
@@ -180,9 +180,9 @@ Expression *TraitsExp::semantic(Scope *sc)
     else if (ident == Id::identifier)
     {   // Get identifier for symbol as a string literal
 
-        // Specify 0 for the flags argument to semanticTiargs() so that
-        // a symbol should not be folded to a constant.
-        TemplateInstance::semanticTiargs(loc, sc, args, 0);
+        // Specify 2 for the flags argument to semanticTiargs() so that
+        // a symbol should not be optimised at all.
+        TemplateInstance::semanticTiargs(loc, sc, args, 2);
 
         if (dim != 1)
             goto Ldimerror;

--- a/test/runnable/template1.d
+++ b/test/runnable/template1.d
@@ -2058,6 +2058,19 @@ void test83()
 
 /******************************************/
 
+struct Bug5596(alias a) { void fx() { a = 4; } int a; }
+
+alias Bug5596!"a" x;
+
+void bug5596(alias b)() { Bug5596!b g; }
+
+void test5596()
+{
+    bug5596!("a")();
+}
+
+/******************************************/
+
 int main()
 {
     test1();
@@ -2143,6 +2156,7 @@ int main()
     test81();
     test82();
     test83();
+    test5596();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
It is ok to interpret alias parameters when they are manifest constants (unless we are only looking for the identifier)

http://d.puremagic.com/issues/show_bug.cgi?id=5596
