### PR TITLE
Add option to show deprecated errors as warnings

### DIFF
--- a/docs/man/man1/dmd.1
+++ b/docs/man/man1/dmd.1
@@ -43,6 +43,9 @@ Write documentation file to
 .IP -d
 Allow deprecated features.
 
+.IP -di
+Show use of deprecated features as warnings.
+
 .IP -debug
 Compile in debug code
 

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -123,11 +123,15 @@ struct Dsymbol : Object
     Dsymbol();
     Dsymbol(Identifier *);
     char *toChars();
+    Loc& getLoc();
     char *locToChars();
     int equals(Object *o);
     int isAnonymous();
+    char *genMsg(const char *format);
     void error(Loc loc, const char *format, ...);
     void error(const char *format, ...);
+    void deprecation(Loc loc, const char *format, ...);
+    void deprecation(const char *format, ...);
     void checkDeprecated(Loc loc, Scope *sc);
     Module *getModule();
     Dsymbol *pastMixin();

--- a/src/expression.c
+++ b/src/expression.c
@@ -1058,6 +1058,17 @@ void Expression::warning(const char *format, ...)
     }
 }
 
+void Expression::deprecation(const char *format, ...)
+{
+    if (type != Type::terror)
+    {
+        va_list ap;
+        va_start(ap, format);
+        ::vdeprecation(loc, format, ap);
+        va_end( ap );
+    }
+}
+
 void Expression::rvalue()
 {
     if (type && type->toBasetype()->ty == Tvoid)
@@ -4922,7 +4933,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                 error("declaration %s is already defined in another scope in %s",
                     s->toPrettyChars(), sc->func->toChars());
             }
-            else if (!global.params.useDeprecated)
+            else if (global.params.deprecation)
             {   // Disallow shadowing
 
                 for (Scope *scx = sc->enclosing; scx && scx->func == sc->func; scx = scx->enclosing)
@@ -4932,7 +4943,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                         (s2 = scx->scopesym->symtab->lookup(s->ident)) != NULL &&
                         s != s2)
                     {
-                        error("shadowing declaration %s is deprecated", s->toPrettyChars());
+                        deprecation("shadowing declaration %s is deprecated", s->toPrettyChars());
                     }
                 }
             }
@@ -5308,8 +5319,8 @@ Expression *IsExp::semantic(Scope *sc)
                 break;
 
             case TOKinvariant:
-                if (!global.params.useDeprecated)
-                    error("use of 'invariant' rather than 'immutable' is deprecated");
+                if (global.params.deprecation)
+                    deprecation("use of 'invariant' rather than 'immutable' is deprecated");
             case TOKimmutable:
                 if (!targ->isImmutable())
                     goto Lno;
@@ -8144,8 +8155,8 @@ Expression *DeleteExp::semantic(Scope *sc)
         IndexExp *ae = (IndexExp *)(e1);
         Type *tb1 = ae->e1->type->toBasetype();
         if (tb1->ty == Taarray)
-        {   if (!global.params.useDeprecated)
-                error("delete aa[key] deprecated, use aa.remove(key)");
+        {   if (global.params.deprecation)
+                deprecation("delete aa[key] deprecated, use aa.remove(key)");
         }
     }
 
@@ -9299,8 +9310,8 @@ Expression *AssignExp::semantic(Scope *sc)
                 if (search_function(ad, id))
                 {   Expression *e = new DotIdExp(loc, ae->e1, id);
 
-                    if (1 || !global.params.useDeprecated)
-                    {   error("operator [] assignment overload with opIndex(i, value) illegal, use opIndexAssign(value, i)");
+                    if (1 || !global.params.deprecation)
+                    {   deprecation("operator [] assignment overload with opIndex(i, value) illegal, use opIndexAssign(value, i)");
                         return new ErrorExp();
                     }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -105,6 +105,7 @@ struct Expression : Object
     virtual void dump(int indent);
     void error(const char *format, ...);
     void warning(const char *format, ...);
+    void deprecation(const char *format, ...);
     virtual void rvalue();
 
     static Expression *combine(Expression *e1, Expression *e2);

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3968,8 +3968,8 @@ STATIC OPND *asm_una_exp()
                     // Check for offset keyword
                     if (asmtok->ident == Id::offset)
                     {
-                        if (!global.params.useDeprecated)
-                            error(asmstate.loc, "offset deprecated, use offsetof");
+                        if (global.params.deprecation)
+                            deprecation(asmstate.loc, "offset deprecated, use offsetof");
                         goto Loffset;
                     }
                     if (asmtok->ident == Id::offsetof)

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -302,6 +302,8 @@ struct Lexer
     TOK inreal(Token *t);
     void error(const char *format, ...);
     void error(Loc loc, const char *format, ...);
+    void deprecation(const char *format, ...);
+    void deprecation(Loc loc, const char *format, ...);
     void pragma();
     unsigned decodeUTF();
     void getDocComment(Token *t, unsigned lineComment);

--- a/src/mars.c
+++ b/src/mars.c
@@ -155,6 +155,17 @@ void warning(Loc loc, const char *format, ...)
     va_end( ap );
 }
 
+void deprecation(Loc loc, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    if (global.params.deprecation > 1)
+        vwarning(loc, format, ap);
+    else
+        verror(loc, format, ap);
+    va_end( ap );
+}
+
 void verror(Loc loc, const char *format, va_list ap)
 {
     if (!global.gag)
@@ -206,6 +217,19 @@ void vwarning(Loc loc, const char *format, va_list ap)
         if (global.params.warnings == 1)
             global.warnings++;  // warnings don't count if gagged
     }
+}
+
+void vdeprecation(Loc loc, const char *format, va_list ap)
+{
+    if (global.params.deprecation > 1)
+    {
+        char oldw = global.params.warnings;
+        global.params.warnings = 2; // activate warnings temporarly
+        vwarning(loc, format, ap);
+        global.params.warnings = oldw;
+    }
+    else
+        verror(loc, format, ap);
 }
 
 /***************************************
@@ -260,6 +284,7 @@ Usage:\n\
   -Dddocdir      write documentation file to docdir directory\n\
   -Dffilename    write documentation file to filename\n\
   -d             allow deprecated features\n\
+  -di            show use of deprecated features as warnings\n\
   -debug         compile in debug code\n\
   -debug=level   compile in debug code <= level\n\
   -debug=ident   compile in debug code identified by ident\n\
@@ -359,6 +384,7 @@ int main(int argc, char *argv[])
     global.params.obj = 1;
     global.params.Dversion = 2;
     global.params.quiet = 1;
+    global.params.deprecation = 1; // deprecated features are errors
 
     global.params.linkswitches = new Array();
     global.params.libfiles = new Array();
@@ -443,7 +469,9 @@ int main(int argc, char *argv[])
         if (*p == '-')
         {
             if (strcmp(p + 1, "d") == 0)
-                global.params.useDeprecated = 1;
+                global.params.deprecation = 0;
+            else if (strcmp(p + 1, "di") == 0)
+                global.params.deprecation = 2;
             else if (strcmp(p + 1, "c") == 0)
                 global.params.link = 0;
             else if (strcmp(p + 1, "cov") == 0)

--- a/src/mars.h
+++ b/src/mars.h
@@ -146,7 +146,9 @@ struct Param
     char isOPenBSD;     // generate code for OpenBSD
     char isSolaris;     // generate code for Solaris
     char scheduler;     // which scheduler to use
-    char useDeprecated; // allow use of deprecated features
+    char deprecation;   // 0: sillently allow use of deprecated features
+                        // 1: use of deprecated features as errors
+                        // 2: informational warnings (no errors)
     char useAssert;     // generate runtime code for assert()'s
     char useInvariants; // generate class invariant checks
     char useIn;         // generate precondition checks
@@ -247,9 +249,10 @@ struct Global
     const char *version;
 
     Param params;
-    unsigned errors;    // number of errors reported so far
-    unsigned warnings;  // number of warnings reported so far
-    unsigned gag;       // !=0 means gag reporting of errors & warnings
+    unsigned errors;        // number of errors reported so far
+    unsigned warnings;      // number of warnings reported so far
+    unsigned deprecations;  // number of deprecations reported so far
+    unsigned gag;           // !=0 means gag reporting of errors & warnings
 
     Global();
 };
@@ -389,8 +392,10 @@ typedef uint64_t StorageClass;
 
 void warning(Loc loc, const char *format, ...);
 void error(Loc loc, const char *format, ...);
+void deprecation(Loc loc, const char *format, ...);
 void verror(Loc loc, const char *format, va_list);
 void vwarning(Loc loc, const char *format, va_list);
+void vdeprecation(Loc loc, const char *format, va_list);
 void fatal();
 void err_nomem();
 int runLINK();

--- a/src/module.c
+++ b/src/module.c
@@ -128,8 +128,8 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
         if (srcfilename->equalsExt("html") ||
             srcfilename->equalsExt("htm")  ||
             srcfilename->equalsExt("xhtml"))
-        {   if (!global.params.useDeprecated)
-                error("html source files is deprecated %s", srcfilename->toChars());
+        {   if (global.params.deprecation)
+                deprecation("html source files is deprecated %s", srcfilename->toChars());
             isHtml = 1;
         }
         else

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -56,7 +56,7 @@ FuncDeclaration *hasThis(Scope *sc);
 #define LOGDEFAULTINIT  0       // log ::defaultInit()
 
 // Allow implicit conversion of T[] to T*
-#define IMPLICIT_ARRAY_TO_PTR   global.params.useDeprecated
+#define IMPLICIT_ARRAY_TO_PTR   (!global.params.deprecation)
 
 /* These have default values for 32 bit code, they get
  * adjusted for 64 bit code.
@@ -1699,8 +1699,8 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
     }
     else if (ident == Id::typeinfo)
     {
-        if (!global.params.useDeprecated)
-            error(loc, ".typeinfo deprecated, use typeid(type)");
+        if (global.params.deprecation)
+            deprecation(loc, ".typeinfo deprecated, use typeid(type)");
         e = getTypeInfo(NULL);
     }
     else if (ident == Id::init)
@@ -1768,8 +1768,8 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
     {
         if (ident == Id::offset)
         {
-            if (!global.params.useDeprecated)
-                error(e->loc, ".offset deprecated, use .offsetof");
+            if (global.params.deprecation)
+                deprecation(e->loc, ".offset deprecated, use .offsetof");
             goto Loffset;
         }
         else if (ident == Id::offsetof)
@@ -1818,8 +1818,8 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
     }
     if (ident == Id::typeinfo)
     {
-        if (!global.params.useDeprecated)
-            error(e->loc, ".typeinfo deprecated, use typeid(type)");
+        if (global.params.deprecation)
+            deprecation(e->loc, ".typeinfo deprecated, use typeid(type)");
         e = getTypeInfo(sc);
     }
     else if (ident == Id::stringof)
@@ -7542,8 +7542,8 @@ L1:
 
         if (ident == Id::typeinfo)
         {
-            if (!global.params.useDeprecated)
-                error(e->loc, ".typeinfo deprecated, use typeid(type)");
+            if (global.params.deprecation)
+                deprecation(e->loc, ".typeinfo deprecated, use typeid(type)");
             return getTypeInfo(sc);
         }
         if (ident == Id::outer && sym->vthis)

--- a/src/parse.c
+++ b/src/parse.c
@@ -668,8 +668,8 @@ StorageClass Parser::parsePostfix()
         {
             case TOKconst:              stc |= STCconst;                break;
             case TOKinvariant:
-                if (!global.params.useDeprecated)
-                    error("use of 'invariant' rather than 'immutable' is deprecated");
+                if (global.params.deprecation)
+                    deprecation("use of 'invariant' rather than 'immutable' is deprecated");
             case TOKimmutable:          stc |= STCimmutable;            break;
             case TOKshared:             stc |= STCshared;               break;
             case TOKwild:               stc |= STCwild;                 break;
@@ -2337,8 +2337,8 @@ Type *Parser::parseBasicType()
             break;
 
         case TOKinvariant:
-            if (!global.params.useDeprecated)
-                error("use of 'invariant' rather than 'immutable' is deprecated");
+            if (global.params.deprecation)
+                deprecation("use of 'invariant' rather than 'immutable' is deprecated");
         case TOKimmutable:
             // invariant(type)
             nextToken();
@@ -2503,9 +2503,9 @@ Type *Parser::parseDeclarator(Type *t, Identifier **pident, TemplateParameters *
                  * although the D style would be:
                  *  int[]*[3] ident
                  */
-                if (!global.params.useDeprecated)
+                if (global.params.deprecation)
                 {
-                    error("C-style function pointer and pointer to array syntax is deprecated. Use 'function' to declare function pointers");
+                    deprecation("C-style function pointer and pointer to array syntax is deprecated. Use 'function' to declare function pointers");
                 }
                 nextToken();
                 ts = parseDeclarator(t, pident);
@@ -3792,8 +3792,8 @@ Statement *Parser::parseStatement(int flags)
                     arg = new Parameter(0, NULL, token.ident, NULL);
                     nextToken();
                     nextToken();
-                    if (1 || !global.params.useDeprecated)
-                        error("if (v; e) is deprecated, use if (auto v = e)");
+                    if (1 || global.params.deprecation)
+                        deprecation("if (v; e) is deprecated, use if (auto v = e)");
                 }
             }
 
@@ -4159,8 +4159,8 @@ Statement *Parser::parseStatement(int flags)
             nextToken();
             s = parseStatement(PSsemi | PScurlyscope);
 #if DMDV2
-            if (!global.params.useDeprecated)
-                error("volatile statements deprecated; used synchronized statements instead");
+            if (global.params.deprecation)
+                deprecation("volatile statements deprecated; used synchronized statements instead");
 #endif
             s = new VolatileStatement(loc, s);
             break;

--- a/src/statement.c
+++ b/src/statement.c
@@ -116,6 +116,14 @@ void Statement::warning(const char *format, ...)
     va_end( ap );
 }
 
+void Statement::deprecation(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    ::vdeprecation(loc, format, ap);
+    va_end( ap );
+}
+
 int Statement::hasBreak()
 {
     //printf("Statement::hasBreak()\n");
@@ -2858,8 +2866,8 @@ Statement *SwitchStatement::semantic(Scope *sc)
     if (!sc->sw->sdefault && !isFinal)
     {   hasNoDefault = 1;
 
-        if (!global.params.useDeprecated)
-           error("non-final switch statement without a default is deprecated");
+        if (global.params.deprecation)
+           deprecation("non-final switch statement without a default is deprecated");
 
         // Generate runtime error if the default is hit
         Statements *a = new Statements();

--- a/src/statement.h
+++ b/src/statement.h
@@ -92,6 +92,7 @@ struct Statement : Object
 
     void error(const char *format, ...);
     void warning(const char *format, ...);
+    void deprecation(const char *format, ...);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int incontract;
     virtual ScopeStatement *isScopeStatement() { return NULL; }

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -810,13 +810,13 @@ void ClassDeclaration::toObjFile(int multiobj)
                         continue;
                     if (fd->leastAsSpecialized(fd2) || fd2->leastAsSpecialized(fd))
                     {
-                        if (!global.params.useDeprecated)
+                        if (global.params.deprecation)
                         {
                             TypeFunction *tf = (TypeFunction *)fd->type;
                             if (tf->ty == Tfunction)
-                                error("use of %s%s hidden by %s is deprecated\n", fd->toPrettyChars(), Parameter::argsTypesToChars(tf->parameters, tf->varargs), toChars());
+                                deprecation("use of %s%s hidden by %s is deprecated\n", fd->toPrettyChars(), Parameter::argsTypesToChars(tf->parameters, tf->varargs), toChars());
                             else
-                                error("use of %s hidden by %s is deprecated\n", fd->toPrettyChars(), toChars());
+                                deprecation("use of %s hidden by %s is deprecated\n", fd->toPrettyChars(), toChars());
                         }
                         s = rtlsym[RTLSYM_DHIDDENFUNC];
                         break;


### PR DESCRIPTION
The new option -di treats deprecation errors as informational warnings,
just like -wi show warnings as informational messages without triggering
errors.

The deprecation option uses the same mechanism as warnings use, so the
same counter (globals.warnings) is shared for both regular and deprecation
warnings (when -di is in use). Some methods that print there own errors
now use the global function error() to print them. There is a particular
case in the Lexer where errors are not triggered but counted, in that case
the same is done with deprecation warnings, asuming it was intended
behaviour.
