### PR TITLE
Include symbol protection in JSON output

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -43,6 +43,8 @@ const char Pline[] = "line";
 const char Ptype[] = "type";
 const char Pcomment[] = "comment";
 const char Pmembers[] = "members";
+const char Pprotection[] = "protection";
+const char* Pprotectionnames[] = {NULL, "none", "private", "package", "protected", "public", "export"};
 
 void JsonRemoveComma(OutBuffer *buf);
 
@@ -259,6 +261,10 @@ void Declaration::toJsonBuffer(OutBuffer *buf)
 
     JsonProperty(buf, Pname, toChars());
     JsonProperty(buf, Pkind, kind());
+
+    if (prot())
+        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+
     if (type)
         JsonProperty(buf, Ptype, type->toChars());
 
@@ -285,8 +291,13 @@ void AggregateDeclaration::toJsonBuffer(OutBuffer *buf)
 
     JsonProperty(buf, Pname, toChars());
     JsonProperty(buf, Pkind, kind());
+
+    if (prot())
+        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);
+
     if (loc.linnum)
         JsonProperty(buf, Pline, loc.linnum);
 
@@ -344,6 +355,10 @@ void TemplateDeclaration::toJsonBuffer(OutBuffer *buf)
 
     JsonProperty(buf, Pname, toChars());
     JsonProperty(buf, Pkind, kind());
+
+    if (prot())
+        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);
 
@@ -389,6 +404,10 @@ void EnumDeclaration::toJsonBuffer(OutBuffer *buf)
 
     JsonProperty(buf, Pname, toChars());
     JsonProperty(buf, Pkind, kind());
+
+    if (prot())
+        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);
 
@@ -426,6 +445,9 @@ void EnumMember::toJsonBuffer(OutBuffer *buf)
 
     JsonProperty(buf, Pname, toChars());
     JsonProperty(buf, Pkind, kind());
+
+    if (prot())
+        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
 
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);


### PR DESCRIPTION
There, my first DMD pull request. Hoping I got everything right.

This should apply cleanly to D1 as well.
