### PR TITLE
Issue 2774 - Functions-as-properties makes it impossible to get the .mangleof a function

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6143,6 +6143,22 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
 
     UnaExp::semantic(sc);
 
+    if (ident == Id::mangleof)
+    {   // symbol.mangleof
+        Dsymbol *ds;
+        switch (e1->op)
+        {
+            case TOKimport: ds = ((ScopeExp *)e1)->sds;     goto L1;
+            case TOKvar:    ds = ((VarExp *)e1)->var;       goto L1;
+            case TOKdotvar: ds = ((DotVarExp *)e1)->var;    goto L1;
+        L1:
+                char* s = ds->mangle();
+                e = new StringExp(loc, s, strlen(s), 'c');
+                e = e->semantic(sc);
+                return e;
+        }
+    }
+
     if (e1->op == TOKdotexp)
     {
         DotExp *de = (DotExp *)e1;

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -596,7 +596,8 @@ void test27()
     string s = (int*function(int ...)[]).mangleof;
     printf("%.*s\n", s.length, s.ptr);
     assert((int*function(int ...)[]).mangleof == "APFiXPi");
-    assert(x.mangleof == "i");
+    assert(typeof(x).mangleof == "i");
+    assert(x.mangleof == "_D6test226test27FZv1xi");
 }
 
 /*************************************/

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -92,7 +92,8 @@ void test8()
 {
     auto p = &foo8;
     showf(p.mangleof);
-    assert(p.mangleof == "PFxAaxC9testconst2C8xiZv");
+    assert(typeof(p).mangleof == "PFxAaxC9testconst2C8xiZv");
+    assert(p.mangleof == "_D9testconst5test8FZv1pPFxAaxC9testconst2C8xiZv");
 }
 
 /************************************/

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3395,6 +3395,27 @@ void test6293() {
 }
 
 /***************************************************/
+// 2774
+
+int foo2774(int n){ return 0; }
+static assert(foo2774.mangleof == "_D7xtest467foo2774FiZi");
+
+class C2774
+{
+    int foo2774(){ return 0; }
+}
+static assert(C2774.foo2774.mangleof == "_D7xtest465C27747foo2774MFZi");
+
+template TFoo2774(T){}
+static assert(TFoo2774!int.mangleof == "7xtest4615__T8TFoo2774TiZ");
+
+void test2774()
+{
+    int foo2774(int n){ return 0; }
+    static assert(foo2774.mangleof == "_D7xtest468test2774FZv7foo2774MFiZi");
+}
+
+/***************************************************/
 
 int main()
 {
@@ -3566,6 +3587,7 @@ int main()
     test5046();
     test1471();
     test6335();
+    test2774();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=2774">Issue 2774</a>
Original code is Shin Fujishiro's patch.
Changes:
- Separating DMDV1 & DMDV2 is not necessary.
