### PR TITLE
Issue 5585 - bad debug line number info for return statements with enumerator expressions

### DIFF
--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -1295,6 +1295,7 @@ void ReturnStatement::toIR(IRState *irs)
             assert(e);
         }
 
+        elem_setLoc(e, loc);
         block_appendexp(blx->curblock, e);
         block_next(blx, BCretexp, NULL);
     }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5585
