### PR TITLE
more backend cleanups

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1479,6 +1479,7 @@ enum FL
         FLctor,         // constructed object
         FLdtor,         // destructed object
         FLregsave,      // ref to saved register on stack, int contains offset
+        FLasm,          // (code) an ASM code
 #if TX86
         FLndp,          // saved 8087 register
         FLfardata,      // ref to far data segment
@@ -1487,7 +1488,6 @@ enum FL
         FLtlsdata,      // thread local storage
         FLbprel,        // ref to variable at fixed offset from frame pointer
         FLframehandler, // ref to C++ frame handler for NT EH
-        FLasm,          // (code) an ASM code
         FLblockoff,     // address of block
         FLallocatmp,    // temp for built-in alloca()
         FLstack,        // offset from ESP rather than EBP

--- a/src/backend/cgcs.c
+++ b/src/backend/cgcs.c
@@ -284,12 +284,11 @@ STATIC void ecom(elem **pe)
     case OPinfo:
         ecom(&e->E2);
         return;
-#if !TX86
     case OPcomma:
+    case OPremquo:
         ecom(&e->E1);
         ecom(&e->E2);
         break;
-#endif
     case OPvptrfptr:
     case OPcvptrfptr:
         ecom(&e->E1);
@@ -318,7 +317,6 @@ STATIC void ecom(elem **pe)
         if (!EBIN(e)) WROP(e->Eoper);
 #endif
         assert(EBIN(e));
-    case OPcomma:
     case OPadd:
     case OPmin:
     case OPmul:
@@ -329,7 +327,6 @@ STATIC void ecom(elem **pe)
     case OPeqeq:
     case OPne:
     case OPscale:
-    case OPremquo:
     case OPyl2x:
     case OPyl2xp1:
         ecom(&e->E1);

--- a/src/backend/debug.c
+++ b/src/backend/debug.c
@@ -272,7 +272,7 @@ void WRFL(enum FL fl)
          "auto  ","para  ","extrn ","tmp   ",
          "code  ","block ","udata ","cs    ","swit  ",
          "fltrg ","offst ","datsg ",
-         "ctor  ","dtor  ",
+         "ctor  ","dtor  ","regsav",
 #if TX86
          "ndp   ","farda ","local ","csdat ","tlsdat",
          "bprel ","frameh","asm   ","blocko","alloca",

--- a/src/backend/debug.c
+++ b/src/backend/debug.c
@@ -272,10 +272,10 @@ void WRFL(enum FL fl)
          "auto  ","para  ","extrn ","tmp   ",
          "code  ","block ","udata ","cs    ","swit  ",
          "fltrg ","offst ","datsg ",
-         "ctor  ","dtor  ","regsav",
+         "ctor  ","dtor  ","regsav","asm   ",
 #if TX86
          "ndp   ","farda ","local ","csdat ","tlsdat",
-         "bprel ","frameh","asm   ","blocko","alloca",
+         "bprel ","frameh","blocko","alloca",
          "stack ","dsym  ",
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
          "got   ","gotoff",

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -64,8 +64,11 @@ enum OPER
         OPmemcmp,
         OPmemset,
         OPsetjmp,               // setjmp()
+#endif
+
         OPremquo,               // / and % in one operation
 
+#if TX86
         OPbsf,                  // bit scan forward
         OPbsr,                  // bit scan reverse
         OPbt,                   // bit test


### PR DESCRIPTION
Is the list of OP\* code in oper.h order sensitive?  I didn't want to risk it in this commit, but it'd be useful to know.
