### PR TITLE
Dmd 1.x

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -716,12 +716,6 @@ void FuncDeclaration::semantic3(Scope *sc)
         for (int i = 0; i < foverrides.dim; i++)
         {
             FuncDeclaration *fdv = (FuncDeclaration *)foverrides.data[i];
-
-            if (fdv->fbody && !fdv->frequire)
-            {
-                error("cannot have an in contract when overriden function %s does not have an in contract", fdv->toPrettyChars());
-                break;
-            }
         }
     }
 


### PR DESCRIPTION
Removed the erroneous error message 

"Error: function subclass.g cannot have an in contract when overriden function superclass.f does not have an in contract"
