### PR TITLE
Bug 5587: Give unit test name by __LINE__.

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -3812,12 +3812,18 @@ void InvariantDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
  * instances per module.
  */
 
+#if __DMC__ || _MSC_VER
+#define snprintf _snprintf
+#endif
 static Identifier *unitTestId(Loc loc)
 {
-    char name[24]; 
+    char name[24];
     snprintf(name, 24, "__unittestL%u_", loc.linnum);
     return Lexer::uniqueId(name);
 }
+#if __DMC__ || _MSC_VER
+#undef snprintf
+#endif
 
 UnitTestDeclaration::UnitTestDeclaration(Loc loc, Loc endloc)
     : FuncDeclaration(loc, endloc, unitTestId(loc), STCundefined, NULL)

--- a/src/func.c
+++ b/src/func.c
@@ -3812,13 +3812,15 @@ void InvariantDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
  * instances per module.
  */
 
-static Identifier *unitTestId()
+static Identifier *unitTestId(Loc loc)
 {
-    return Lexer::uniqueId("__unittest");
+    char name[24]; 
+    snprintf(name, 24, "__unittestL%u_", loc.linnum);
+    return Lexer::uniqueId(name);
 }
 
 UnitTestDeclaration::UnitTestDeclaration(Loc loc, Loc endloc)
-    : FuncDeclaration(loc, endloc, unitTestId(), STCundefined, NULL)
+    : FuncDeclaration(loc, endloc, unitTestId(loc), STCundefined, NULL)
 {
 }
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5587

This commit appends 'Lxx' to the unittest's mangled name. The user can get the line number from the traceback:

```
5   x       0x000091c5 onAssertErrorMsg + 73
6   x       0x00009206 onUnittestErrorMsg + 26
7   x       0x00013199 _d_unittestm + 45
8   x       0x000019d7 void x.__unittest_fail(int) + 27
9   x       0x00001a0a void x.__unittestL13_1() + 46
                                        ^^^ line 13
```
