### PR TITLE
Type-checked array: followup

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9003,7 +9003,7 @@ Expression *IndexExp::semantic(Scope *sc)
         goto Lerr;
     }
     if (e2->type->ty == Ttuple && ((TupleExp *)e2)->exps->dim == 1) // bug 4444 fix
-        e2 = (Expression *)((TupleExp *)e2)->exps->data[0];
+        e2 = ((TupleExp *)e2)->exps->tdata()[0];
     e2 = resolveProperties(sc, e2);
     if (e2->type == Type::terror)
         goto Lerr;

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -349,8 +349,10 @@ struct Array : Object
 };
 
 template <typename TYPE>
-struct ArrayBase : Array
+struct ArrayBase : protected Array
 {
+    using Array::dim;
+
     TYPE **tdata()
     {
         return (TYPE **)data;
@@ -362,6 +364,28 @@ struct ArrayBase : Array
         assert(index < dim);
 #endif
         return ((TYPE **)data)[index];
+    }
+
+    using Array::mark;
+    using Array::toChars;
+
+    using Array::reserve;
+    using Array::setDim;
+    using Array::fixDim;
+
+    void push(TYPE *a)
+    {
+        Array::push((void *)a);
+    }
+
+    TYPE *pop()
+    {
+        return (TYPE *)Array::pop();
+    }
+
+    void shift(TYPE *a)
+    {
+        Array::shift((void *)a);
     }
 
     void insert(size_t index, TYPE *v)
@@ -379,10 +403,10 @@ struct ArrayBase : Array
         Array::append((Array *)a);
     }
 
-    void push(TYPE *a)
-    {
-        Array::push((void *)a);
-    }
+    using Array::remove;
+    using Array::zero;
+    using Array::tos;
+    using Array::sort;
 
     ArrayBase *copy()
     {


### PR DESCRIPTION
Because `Array::data` has been made public again, the compiler no longer catch accesses to untyped elements when using `ArrayBase< Type >`. This patch restores the type-safety for the `ArrayBase` template while avoiding changes to `Array`.
