### PR TITLE
Issue 5886 - Template this parameter cannot be made implicit, when other parameters are explicitly given 

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6859,7 +6859,13 @@ L1:
         TemplateDeclaration *td = dte->td;
         eleft = dte->e1;
         ti->tempdecl = td;
-        ti->semantic(sc);
+        if (ti->needsTypeInference(sc))
+        {
+            e = new CallExp(loc, this);
+            return e->semantic(sc);
+        }
+        else
+            ti->semantic(sc);
         if (!ti->inst)                  // if template failed to expand
             return new ErrorExp();
         Dsymbol *s = ti->inst->toAlias();

--- a/src/template.c
+++ b/src/template.c
@@ -4964,6 +4964,10 @@ int TemplateInstance::needsTypeInference(Scope *sc)
             return FALSE;
         }
 
+        for (size_t i = 0; i < td->parameters->dim; i++)
+            if (td->parameters->tdata()[i]->isTemplateThisParameter())
+                return TRUE;
+
         /* Determine if the instance arguments, tiargs, are all that is necessary
          * to instantiate the template.
          */

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -309,6 +309,52 @@ void test2579()
 }
 
 /**********************************/
+// 5886 & 5393
+
+struct K5886 {
+    void get1(this T)() const {
+        pragma(msg, T);
+    }
+    void get2(int N=4, this T)() const {
+        pragma(msg, N, " ; ", T);
+    }
+}
+
+void test5886() {
+    K5886 km;
+    const(K5886) kc;
+    immutable(K5886) ki;
+
+    km.get1;        // OK
+    kc.get1;        // OK
+    ki.get1;        // OK
+    km.get2;        // OK
+    kc.get2;        // OK
+    ki.get2;        // OK
+    km.get2!(1, K5886);             // Ugly
+    kc.get2!(2, const(K5886));      // Ugly
+    ki.get2!(3, immutable(K5886));  // Ugly
+    km.get2!8;      // Error
+    kc.get2!9;      // Error
+    ki.get2!10;     // Error
+}
+
+// --------
+
+void test5393()
+{
+    class A
+    {
+        void opDispatch (string name, this T) () { }
+    }
+
+    class B : A {}
+
+    auto b = new B;
+    b.foobar();
+}
+
+/**********************************/
 
 int main()
 {
@@ -325,6 +371,8 @@ int main()
     test2246();
     bug4984();
     test2579();
+    test5886();
+    test5393();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5886

This patch also fix <a href="http://d.puremagic.com/issues/show_bug.cgi?id=5393">Issue 5393</a> - opDispatch with template this parameter fails to compile
