### PR TITLE
Issue 4953 - Regression(2.031): templates don't do implicit conversion properly

### DIFF
--- a/src/mars.h
+++ b/src/mars.h
@@ -386,6 +386,7 @@ enum DYNCAST
 enum MATCH
 {
     MATCHnomatch,       // no match
+    MATCHdeduced,
     MATCHconvert,       // match with conversions
 #if DMDV2
     MATCHconst,         // match with conversion to const

--- a/src/template.c
+++ b/src/template.c
@@ -1199,6 +1199,12 @@ L2:
             m = argtype->deduceType(paramscope, fparam->type, parameters, &dedtypes);
             //printf("\tdeduceType m = %d\n", m);
 
+            /* If no match, see if the argument can be matched by using
+             * implicit conversions.
+             */
+            if (!m)
+                m = farg->implicitConvTo(fparam->type);
+
             /* If no match, see if there's a conversion to a delegate
              */
             if (!m && fparam->type->toBasetype()->ty == Tdelegate)
@@ -2892,7 +2898,7 @@ MATCH TemplateTypeParameter::matchArg(Scope *sc, Objects *tiargs,
     {
         // So that matches with specializations are better
         if (!(flags & 1))
-            m = MATCHconvert;
+            m = MATCHdeduced;
 
         /* This is so that:
          *   template Foo(T), Foo!(const int), => ta == int

--- a/test/runnable/opover.d
+++ b/test/runnable/opover.d
@@ -910,8 +910,8 @@ void test15()
 
 /**************************************/
 
-//void bug4953(T = void)(short x) {}
-//static assert(is(typeof(bug4953(3))));
+void bug4953(T = void)(short x) {}
+static assert(is(typeof(bug4953(3))));
 
 /**************************************/
 

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -6,24 +6,6 @@ import std.c.stdio;
 
 /**********************************/
 
-U foo(T, U)(U i)
-{
-    return i + 1;
-}
-
-int foo(T)(int i)
-{
-    return i + 2;
-}
-
-void test1()
-{
-    auto i = foo!(int)(2L);
-//    assert(i == 4);    // now returns 3
-}
-
-/**********************************/
-
 U foo2(T, U)(U i)
 {
     return i + 1;
@@ -304,7 +286,6 @@ void test2579()
 
 int main()
 {
-    test1();
     test2();
     test3();
     test4();


### PR DESCRIPTION
Issue 4953 - Regression(2.031): templates don't do implicit conversion properly

Allow matching when the arg type is known and the argument expression implicitly converts to the arg type.

http://d.puremagic.com/issues/show_bug.cgi?id=4953
