### PR TITLE
CTFE 6282 and 6337

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3924,15 +3924,18 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
     {   // Member function call
         if (pthis->op == TOKthis)
             pthis = istate ? istate->localThis : NULL;
-        else if (pthis->op == TOKcomma)
-            pthis = pthis->interpret(istate);
-        if (pthis == EXP_CANT_INTERPRET)
-            return NULL;
-            // Evaluate 'this'
-        if (pthis->op != TOKvar)
-            pthis = pthis->interpret(istate, ctfeNeedLvalue);
-        if (pthis == EXP_CANT_INTERPRET)
-            return NULL;
+        else
+        {
+            if (pthis->op == TOKcomma)
+                pthis = pthis->interpret(istate);
+            if (pthis == EXP_CANT_INTERPRET)
+                return NULL;
+                // Evaluate 'this'
+            if (pthis->op != TOKvar)
+                pthis = pthis->interpret(istate, ctfeNeedLvalue);
+            if (pthis == EXP_CANT_INTERPRET)
+                return NULL;
+        }
 
         if (!fd->fbody)
         {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3383,11 +3383,18 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
          * slices of array literals, and AA literals.
          */
         if (aggregate->op == TOKindex || aggregate->op == TOKdotvar ||
-            aggregate->op == TOKslice || aggregate->op == TOKcall)
+            aggregate->op == TOKslice || aggregate->op == TOKcall ||
+            aggregate->op == TOKstar)
         {
             aggregate = aggregate->interpret(istate, ctfeNeedLvalue);
             if (aggregate == EXP_CANT_INTERPRET)
                 return EXP_CANT_INTERPRET;
+            // The array could be an index of an AA. Resolve it if so.
+            if (aggregate->op == TOKindex)
+            {
+                IndexExp *ie = (IndexExp *)aggregate;
+                aggregate = Index(ie->type, ie->e1, ie->e2);
+            }
         }
         if (aggregate->op == TOKvar)
         {
@@ -3547,11 +3554,18 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
          */
 
         if (aggregate->op == TOKindex || aggregate->op == TOKdotvar ||
-            aggregate->op == TOKslice || aggregate->op == TOKcall)
+            aggregate->op == TOKslice ||
+            aggregate->op == TOKstar  || aggregate->op == TOKcall)
         {
             aggregate = aggregate->interpret(istate, ctfeNeedLvalue);
             if (aggregate == EXP_CANT_INTERPRET)
                 return EXP_CANT_INTERPRET;
+            // The array could be an index of an AA. Resolve it if so.
+            if (aggregate->op == TOKindex)
+            {
+                IndexExp *ie = (IndexExp *)aggregate;
+                aggregate = Index(ie->type, ie->e1, ie->e2);
+            }
         }
         if (aggregate->op == TOKvar)
         {
@@ -4619,8 +4633,6 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
         e = e1->interpret(istate, ctfeNeedLvalue);
         if (e == EXP_CANT_INTERPRET)
             return e;
-        if (e->op == TOKaddress)
-            e = ((AddrExp*)e)->e1;
         if (goal != ctfeNeedLvalue)
         {
             if (e->op == TOKindex && e->type->ty == Tpointer)
@@ -4641,6 +4653,8 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
                     }
                     return Index(type, ie->e1, ie->e2);
                 }
+                if (ie->e1->op == TOKassocarrayliteral)
+                    return Index(type, ie->e1, ie->e2);
             }
             if (e->op == TOKstructliteral)
                 return e;
@@ -4653,13 +4667,13 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
             }
             if (e == EXP_CANT_INTERPRET)
                 return e;
-            e->type = type;
         }
         if (e->op == TOKnull)
         {
             error("dereference of null pointer '%s'", e1->toChars());
             return EXP_CANT_INTERPRET;
         }
+        e->type = type;
     }
 
 #if LOG

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1951,3 +1951,19 @@ static assert( {
     assert(z == 1);
     return true;
 }() );
+
+/**************************************************
+    6282 - dereference 'in' of an AA
+**************************************************/
+
+static assert({
+    int [] w = new int[4];
+    w[2] = 6;
+    auto c = [5: w];
+    auto kk  = (*(5 in c))[2];
+    (*(5 in c))[2] = 8;
+    (*(5 in c))[1..$-2] = 4;
+    auto a = [4:"1"];
+    auto n = *(4 in a);
+    return n;
+}() == "1");

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1967,3 +1967,21 @@ static assert({
     auto n = *(4 in a);
     return n;
 }() == "1");
+
+/**************************************************
+    6337 - member function call on struct literal
+**************************************************/
+
+struct Bug6337
+{
+    int k;
+    void six() {
+        k = 6;
+    }
+    int ctfe()
+    {
+        six();
+        return k;
+    }
+}
+static assert( Bug6337().ctfe() == 6);


### PR DESCRIPTION
6337 is a nasty wrong-code regression (member functions called on struct literals don't work properly).
6282 cleans up treatment of reference types stored in AAs.
The fix for 6282 also fixes the two extra cases in the reopened bug 6283, allowing it to be closed again.
