### PR TITLE
fix warnings

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9490,7 +9490,7 @@ Expression *AssignExp::semantic(Scope *sc)
                 Type * aaValueType = ((TypeAArray *)((IndexExp*)e1)->e1->type->toBasetype())->next;
                 Identifier *id = Lexer::uniqueId("__aatmp");
                 VarDeclaration *v = new VarDeclaration(loc, aaValueType,
-                    id, new VoidInitializer(NULL));
+                    id, new VoidInitializer(0));
                 v->storage_class |= STCctfe;
                 v->semantic(sc);
                 v->parent = sc->parent;

--- a/src/intrange.c
+++ b/src/intrange.c
@@ -458,8 +458,8 @@ void IntRange::splitBySign(IntRange& negRange, bool& hasNegRange,
 const IntRange& IntRange::dump(const char* funcName, Expression *e) const 
 {
     printf("[(%c)%#018llx, (%c)%#018llx] @ %s ::: %s\n",
-           imin.negative?'-':'+', imin.value,
-           imax.negative?'-':'+', imax.value,
+           imin.negative?'-':'+', (unsigned long long)imin.value,
+           imax.negative?'-':'+', (unsigned long long)imax.value,
            funcName, e->toChars());
     return *this;
 }


### PR DESCRIPTION
warning 1:
expression.c: In member function ‘virtual Expression\* AssignExp::semantic(Scope*)’:
expression.c:9493:49: warning: passing NULL to non-pointer argument 1 of ‘Loc::Loc(int)’

warning 2:
intrange.c: In member function ‘const IntRange& IntRange::dump(const char_, Expression_) const’:
intrange.c:463:34: warning: format ‘%#018llx’ expects type ‘long long unsigned int’, but argument 3 has type ‘uinteger_t’
intrange.c:463:34: warning: format ‘%#018llx’ expects type ‘long long unsigned int’, but argument 5 has type ‘uinteger_t’
