### PR TITLE
some mem_ vs MEM_ cleanups

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -727,13 +727,8 @@ typedef struct FUNC_S
 #endif
 } func_t;
 
-#if TX86
 #define func_calloc()   ((func_t *) mem_fcalloc(sizeof(func_t)))
 #define func_free(f)    mem_ffree(f)
-#else
-#define func_calloc()   ((func_t *) MEM_PH_CALLOC(sizeof(func_t)))
-#define func_free(f)    MEM_PH_FREE(f)
-#endif
 
 /**************************
  * Item in list for member initializer.
@@ -1064,13 +1059,8 @@ typedef struct STRUCT
                                 // identical to Sarglist).
 } struct_t;
 
-#if TX86
 #define struct_calloc() ((struct_t *) mem_fcalloc(sizeof(struct_t)))
 #define struct_free(st) ((void)(st))
-#else
-#define struct_calloc() ((struct_t *) MEM_PH_CALLOC(sizeof(struct_t)))
-#define struct_free(st) MEM_PH_FREE(st)
-#endif
 
 /**********************************
  * Symbol Table

--- a/src/backend/dt.c
+++ b/src/backend/dt.c
@@ -45,11 +45,7 @@ dt_t *dt_calloc(char dtx)
         *dt = dtzero;
     }
     else
-#if TX86
         dt = (dt_t *) mem_fcalloc(sizeof(dt_t));
-#else
-        dt = (dt_t *) MEM_PH_MALLOC(sizeof(dt_t));
-#endif
     dt->dt = dtx;
     return dt;
 }
@@ -87,11 +83,7 @@ void dt_term()
 
     while (dt_freelist)
     {   dtn = dt_freelist->DTnext;
-#if TX86
         mem_ffree(dt_freelist);
-#else
-        MEM_PH_FREE(dt_freelist);
-#endif
         dt_freelist = dtn;
     }
 #endif

--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -222,11 +222,7 @@ symbol * symbol_calloc(const char *id)
 
     len = strlen(id);
     //printf("sizeof(symbol)=%d, sizeof(s->Sident)=%d, len=%d\n",sizeof(symbol),sizeof(s->Sident),len);
-#if TX86
     s = (symbol *) mem_fmalloc(sizeof(symbol) - sizeof(s->Sident) + len + 1 + 5);
-#else
-    s = (symbol *) MEM_PH_MALLOC(sizeof(symbol) - sizeof(s->Sident) + len + 1);
-#endif
     memset(s,0,sizeof(symbol) - sizeof(s->Sident));
 #if SCPP
     s->Ssequence = pstate.STsequence;
@@ -965,11 +961,7 @@ void symbol_free(symbol *s)
 #ifdef DEBUG
             s->id = 0;
 #endif
-#if TX86
             mem_ffree(s);
-#else
-            MEM_PH_FREE(s);
-#endif
         }
         s = sr;
     }

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -242,11 +242,7 @@ type *type_alloc(tym_t ty)
         type_list = t->Tnext;
     }
     else
-#if TX86
         t = (type *) mem_fmalloc(sizeof(type));
-#else
-        t = (type *) MEM_PH_MALLOC(sizeof(type));
-#endif
     tzero.Tty = ty;
     *t = tzero;
 #if SRCPOS_4TYPES
@@ -271,12 +267,7 @@ type *type_alloc(tym_t ty)
 type *type_alloc_template(symbol *s)
 {   type *t;
 
-#if TX86
     t = (type *) mem_fcalloc(sizeof(typetemp_t));
-#else
-    t = (type *) MEM_PH_MALLOC(sizeof(typetemp_t));
-    memset(t, 0, sizeof(typetemp_t));
-#endif
     t->Tty = TYtemplate;
     if (s->Stemplate->TMprimary)
         s = s->Stemplate->TMprimary;
@@ -553,21 +544,13 @@ void type_term()
 
     while (type_list)
     {   tn = type_list->Tnext;
-#if TX86
         mem_ffree(type_list);
-#else
-        MEM_PH_FREE(type_list);
-#endif
         type_list = tn;
     }
 
     while (param_list)
     {   pn = param_list->Pnext;
-#if TX86
         mem_ffree(param_list);
-#else
-        MEM_PH_FREE(param_list);
-#endif
         param_list = pn;
     }
 
@@ -1151,11 +1134,7 @@ param_t *param_calloc()
     }
     else
     {
-#if TX86
         p = (param_t *) mem_fmalloc(sizeof(param_t));
-#else
-        p = (param_t *) MEM_PH_MALLOC(sizeof(param_t));
-#endif
     }
     *p = pzero;
 #ifdef DEBUG
@@ -1208,11 +1187,7 @@ void param_free(param_t **pparamlst)
     {   param_debug(p);
         pn = p->Pnext;
         type_free(p->Ptype);
-#if TX86
         mem_free(p->Pident);
-#else
-        MEM_PH_FREE(p->Pident);
-#endif
         el_free(p->Pelem);
         type_free(p->Pdeftype);
         if (p->Pptpl)

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -454,7 +454,7 @@ elem *array_toDarray(Type *t, elem *e)
                     elem *es = el_calloc();
                     es->Eoper = OPstring;
 
-                    // Match MEM_PH_FREE for OPstring in ztc\el.c
+                    // freed in el_free
                     es->EV.ss.Vstring = (char *)mem_malloc(len);
                     memcpy(es->EV.ss.Vstring, &e->EV, len);
 
@@ -1536,13 +1536,9 @@ elem *StringExp::toElem(IRState *irs)
     {
         e = el_calloc();
         e->Eoper = OPstring;
-#if 1
-        // Match MEM_PH_FREE for OPstring in ztc\el.c
+        // freed in el_free
         e->EV.ss.Vstring = (char *)mem_malloc((len + 1) * sz);
         memcpy(e->EV.ss.Vstring, string, (len + 1) * sz);
-#else
-        e->EV.ss.Vstring = (char *)string;
-#endif
         e->EV.ss.Vstrlen = (len + 1) * sz;
         e->Ety = TYnptr;
     }


### PR DESCRIPTION
Remove else block of TX86 related to mem_ vs MEM_.
Fix consistency of mem_ vs MEM_ for Vstring (note, dmc still has some mismatches in exp.c after this diff).

NOTE: not all of them.. focused on the ones wrapped in TX86 blocks.
