### PR TITLE
Issue 5188 - alias this and compare expression generates wrong code

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -11313,7 +11313,7 @@ Expression *CmpExp::semantic(Scope *sc)
             error("recursive opCmp expansion");
             e = new ErrorExp();
         }
-        else
+        else if (e->op == TOKcall)
         {   e = new CmpExp(op, loc, e, new IntegerExp(loc, 0, Type::tint32));
             e = e->semantic(sc);
         }
@@ -11453,7 +11453,7 @@ Expression *EqualExp::semantic(Scope *sc)
         e = op_overload(sc);
         if (e)
         {
-            if (op == TOKnotequal)
+            if (e->op == TOKcall && op == TOKnotequal)
             {
                 e = new NotExp(e->loc, e);
                 e = e->semantic(sc);

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -132,6 +132,22 @@ void test4773()
 }
 
 /**********************************************/
+// 5188
+
+void test5188()
+{
+    struct S
+    {
+        int v = 10;
+        alias v this;
+    }
+
+    S s;
+    assert(s <= 20);
+    assert(s != 14);
+}
+
+/**********************************************/
 
 int main()
 {
@@ -141,6 +157,7 @@ int main()
     test4();
     test5();
     test4773();
+    test5188();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5188

Check the result of op_overload that is by normal operator overloading (e->op == TOKcall) or not.
