### PR TITLE
Issue 620 - Can't use property syntax with a template function

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2817,7 +2817,11 @@ Lagain:
     TemplateDeclaration *td = s->isTemplateDeclaration();
     if (td)
     {
-        e = new TemplateExp(loc, td);
+        Dsymbol *p = td->toParent2();
+        if (hasThis(sc) && p && p->isAggregateDeclaration())
+            e = new DotTemplateExp(loc, new ThisExp(loc), td);
+        else
+            e = new TemplateExp(loc, td);
         e = e->semantic(sc);
         return e;
     }

--- a/src/opover.c
+++ b/src/opover.c
@@ -385,6 +385,7 @@ Expression *ArrayExp::op_overload(Scope *sc)
                 currentDimension = i;   // Dimension for $, if required
 
                 x = x->semantic(sc);
+                x = resolveProperties(sc, x);
                 if (!x->type)
                     error("%s has no value", x->toChars());
                 if (lengthVar)

--- a/test/runnable/opdisp.d
+++ b/test/runnable/opdisp.d
@@ -1,0 +1,277 @@
+extern (C) int printf(const char* fmt, ...);
+
+int pass(int n){ return n; }
+
+struct X
+{
+    int m;
+
+    int opIndex(int m, int n)
+    {
+        return n;
+    }
+}
+
+/**********************************************/
+
+struct S1f
+{
+    int opDispatch(string name, A...)(A args)
+    {
+      static if (args.length)
+        return args[0];
+      else
+        return 0;
+    }
+}
+struct S1p
+{
+    @property int opDispatch(string name, A...)(A args)
+    {
+      static if (args.length)
+        return args[0];
+      else
+        return 0;
+    }
+}
+void test1()
+{
+    S1f s1f;
+    assert(s1f.func() == 0);            // ok -> ok
+    assert(s1f.func(1) == 1);           // ok -> ok
+    assert(pass(s1f.func()) == 0);      // ok -> ok
+    assert(pass(s1f.func(1)) == 1);     // ok -> ok
+    assert(X(s1f.func()).m == 0);
+    assert(X()[0, s1f.func()] == 0);
+
+    S1p s1p;
+    assert(s1p.prop == 0);              // ok   -> ok
+    assert((s1p.prop = 1) == 1);        // CTng -> CTng
+    assert(pass(s1p.prop) == 0);        // ok   -> ok
+    assert(pass(s1p.prop = 2) == 2);    // CTng -> CTng
+    assert(X(s1p.prop).m == 0);
+    assert(X()[0, s1p.prop] == 0);
+}
+
+/**********************************************/
+
+struct S2f
+{
+    template opDispatch(string name)
+    {
+        int opDispatch(A...)(A args)
+        {
+          static if (args.length)
+            return args[0];
+          else
+            return 0;
+        }
+    }
+}
+struct S2p
+{
+    template opDispatch(string name)
+    {
+        @property int opDispatch(A...)(A args)
+        {
+          static if (args.length)
+            return args[0];
+          else
+            return 0;
+        }
+    }
+}
+void test2()
+{
+    S2f s2f;
+    assert(s2f.func() == 0);            // ok -> ok
+    assert(s2f.func(1) == 1);           // ok -> ok
+    assert(pass(s2f.func()) == 0);      // ok -> ok
+    assert(pass(s2f.func(1)) == 1);     // ok -> ok
+    assert(X(s2f.func()).m == 0);
+    assert(X()[0, s2f.func()] == 0);
+
+    S2p s2p;
+    assert(s2p.prop == 0);              // CTng -> ok
+    assert((s2p.prop = 1) == 1);        // ok   -> ok
+    assert(pass(s2p.prop) == 0);        // CTng -> ok
+    assert(pass(s2p.prop = 2) == 2);    // ok   -> ok
+    assert(X(s2p.prop).m == 0);
+    assert(X()[0, s2p.prop] == 0);
+}
+
+/**********************************************/
+
+struct S3f
+{
+    template opDispatch(string name)
+    {
+        template opDispatch(T)
+        {
+            int opDispatch(A...)(A args)
+            {
+              static if (args.length)
+                return args[0];
+              else
+                return 0;
+            }
+        }
+    }
+}
+struct S3p
+{
+    template opDispatch(string name)
+    {
+        template opDispatch(T)
+        {
+            @property int opDispatch(A...)(A args)
+            {
+              static if (args.length)
+                return args[0];
+              else
+                return 0;
+            }
+        }
+    }
+}
+void test3()
+{
+    S3f s3f;
+    assert(s3f.func!int() == 0);            // ok -> ok
+    assert(s3f.func!int(1) == 1);           // ok -> ok
+    assert(pass(s3f.func!int()) == 0);      // ok -> ok
+    assert(pass(s3f.func!int(1)) == 1);     // ok -> ok
+    assert(X(s3f.func!int()).m == 0);
+    assert(X()[0, s3f.func!int()] == 0);
+
+    S3p s3p;
+    assert(s3p.prop!int == 0);              // CTng -> ok
+    assert((s3p.prop!int = 1) == 1);        // ok   -> ok
+    assert(pass(s3p.prop!int) == 0);        // CTng -> ok
+    assert(pass(s3p.prop!int = 2) == 2);    // ok   -> ok
+    assert(X(s3p.prop!int).m == 0);
+    assert(X()[0, s3p.prop!int] == 0);
+}
+
+/**********************************************/
+
+struct S4f
+{
+    ref int opDispatch(string name, A...)(A args)
+    {
+        static int n;
+        n = args.length;
+        return n;
+    }
+}
+struct S4p
+{
+    @property ref int opDispatch(string name, A...)(A args)
+    {
+        static int n;
+        n = args.length;
+        return n;
+    }
+}
+void test4()
+{
+    S4f s4f;
+    assert(s4f.func == 0);          // getter
+    assert((s4f.func = 1) == 1);    // setter
+
+    S4p s4p;
+    assert(s4p.prop == 0);          // getter
+    assert((s4p.prop = 1) == 1);    // setter
+}
+
+/**********************************************/
+
+struct S5f
+{
+    template opDispatch(string name)
+    {
+        ref int opDispatch(A...)(A args)
+        {
+            static int n;
+            n = args.length;
+            return n;
+        }
+    }
+}
+struct S5p
+{
+    template opDispatch(string name)
+    {
+        @property ref int opDispatch(A...)(A args)
+        {
+            static int n;
+            n = args.length;
+            return n;
+        }
+    }
+}
+void test5()
+{
+    S5f s5f;
+    assert(s5f.prop == 0);          // getter   ng -> ok
+    assert((s5f.prop = 1) == 1);    // setter
+
+    S5p s5p;
+    assert(s5p.prop == 0);          // getter   ng -> ok
+    assert((s5p.prop = 1) == 1);    // setter
+}
+
+/**********************************************/
+
+struct S6f
+{
+    template opDispatch(string name)
+    {
+        template opDispatch(T)
+        {
+            ref int opDispatch(A...)(A args)
+            {
+                static int n;
+                n = args.length;
+                return n;
+            }
+        }
+    }
+}
+struct S6p
+{
+    template opDispatch(string name)
+    {
+        template opDispatch(T)
+        {
+            @property ref int opDispatch(A...)(A args)
+            {
+                static int n;
+                n = args.length;
+                return n;
+            }
+        }
+    }
+}
+void test6()
+{
+    S6f s6f;
+    assert(s6f.prop!int == 0);          // getter   ng -> ok
+    assert((s6f.prop!int = 1) == 1);    // setter
+
+    S6p s6p;
+    assert(s6p.prop!int == 0);          // getter   ng -> ok
+    assert((s6p.prop!int = 1) == 1);    // setter
+}
+
+/**********************************************/
+
+void main()
+{
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+    test6();
+}

--- a/test/runnable/property.d
+++ b/test/runnable/property.d
@@ -1,4 +1,7 @@
 
+
+/******************************************/
+
 struct Foo
 {
     int v;
@@ -7,7 +10,7 @@ struct Foo
     int bar() { return 73; }
 }
 
-int main()
+int test1()
 {
     Foo f;
     int i;
@@ -22,3 +25,26 @@ int main()
     return 0;
 }
 
+/******************************************/
+// 6259
+
+struct S6259
+{
+    private int m_prop;
+    ref const(int) prop() { return m_prop; }
+    void prop(int v) { m_prop = v; }
+}
+
+void test6259()
+{
+    S6259 s;
+    s.prop = 1;
+}
+
+/******************************************/
+
+void main()
+{
+    test1();
+    test6259();
+}

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -1,0 +1,131 @@
+// PERMUTE_ARGS: -property
+
+extern (C) int printf(const char* fmt, ...);
+
+// Is -property option specified?
+enum enforceProperty = !__traits(compiles, {
+    int prop(){ return 1; }
+    int n = prop;
+});
+
+template select(alias v1, alias v2)
+{
+    static if (enforceProperty)
+        enum select = v1;
+    else
+        enum select = v2;
+}
+
+struct Test(int N)
+{
+    int value;
+    int getset;
+
+    static if (N == 0)
+    {
+        ref foo(){ getset = 1; return value; }
+
+        enum result = select!(0, 1);
+        // -property    test.d(xx): Error: not a property foo
+        // (no option)  prints "getter"
+    }
+    static if (N == 1)
+    {
+        ref foo(int x){ getset = 2; value = x; return value; }
+
+        enum result = select!(0, 2);
+        // -property    test.d(xx): Error: not a property foo
+        // (no option)  prints "setter"
+    }
+    static if (N == 2)
+    {
+        @property ref foo(){ getset = 1; return value; }
+
+        enum result = select!(1, 1);
+        // -property    prints "getter"
+        // (no option)  prints "getter"
+    }
+    static if (N == 3)
+    {
+        @property ref foo(int x){ getset = 2; value = x; return value; }
+
+        enum result = select!(2, 2);
+        // -property    prints "setter"
+        // (no option)  prints "setter"
+    }
+
+
+    static if (N == 4)
+    {
+        ref foo()     { getset = 1; return value; }
+        ref foo(int x){ getset = 2; value = x; return value; }
+
+        enum result = select!(0, 2);
+        // -property    test.d(xx): Error: not a property foo
+        // (no option)  prints "setter"
+    }
+    static if (N == 5)
+    {
+        @property ref foo()     { getset = 1; return value; }
+                  ref foo(int x){ getset = 2; value = x; return value; }
+
+        enum result = select!(0, 0);
+        // -property    test.d(xx): Error: cannot overload both property and non-property functions
+        // (no option)  test.d(xx): Error: cannot overload both property and non-property functions
+    }
+    static if (N == 6)
+    {
+                  ref foo()     { getset = 1; return value; }
+        @property ref foo(int x){ getset = 2; value = x; return value; }
+
+        enum result = select!(0, 0);
+        // -property    test.d(xx): Error: cannot overload both property and non-property functions
+        // (no option)  test.d(xx): Error: cannot overload both property and non-property functions
+    }
+    static if (N == 7)
+    {
+        @property ref foo()     { getset = 1; return value; }
+        @property ref foo(int x){ getset = 2; value = x; return value; }
+
+        enum result = select!(2, 2);
+        // -property    prints "setter"
+        // (no option)  prints "setter"
+    }
+}
+
+template seq(T...)
+{
+    alias T seq;
+}
+template iota(int begin, int end)
+    if (begin <= end)
+{
+    static if (begin == end)
+        alias seq!() iota;
+    else
+        alias seq!(begin, iota!(begin+1, end)) iota;
+}
+
+void main()
+{
+    foreach (N; iota!(0, 8))
+    {
+        printf("%d: ", N);
+
+        Test!N s;
+        static if (Test!N.result == 0)
+        {
+            static assert(!is(typeof({ s.foo = 1; })));
+            printf("compile error\n");
+        }
+        else
+        {
+            s.foo = 1;
+            if (s.getset == 1)
+                printf("getter\n");
+            else
+                printf("setter\n");
+            assert(s.getset == Test!N.result);
+        }
+    }
+}

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -520,6 +520,25 @@ struct T6805
 static assert(is(T6805.xxx.Type == int));
 
 /**********************************/
+// 6738
+
+struct Foo6738
+{
+    int _val = 10;
+
+    @property int val()() { return _val; }
+    int get() { return val; }  // fail
+}
+
+void test6738()
+{
+    Foo6738 foo;
+    auto x = foo.val;  // ok
+    assert(x == 10);
+    assert(foo.get() == 10);
+}
+
+/**********************************/
 // 6994
 
 struct Foo6994
@@ -775,6 +794,7 @@ int main()
     test2778get();
     test6208a();
     test6208b();
+    test6738();
     test6994();
     test3467();
     test4413();

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -539,6 +539,23 @@ void test6738()
 }
 
 /**********************************/
+// 6780
+
+@property int foo6780()(){ return 10; }
+
+int g6780;
+@property void bar6780()(int n){ g6780 = n; }
+
+void test6780()
+{
+    auto n = foo6780;
+    assert(n == 10);
+
+    bar6780 = 10;
+    assert(g6780 == 10);
+}
+
+/**********************************/
 // 6994
 
 struct Foo6994
@@ -795,6 +812,7 @@ int main()
     test6208a();
     test6208b();
     test6738();
+    test6780();
     test6994();
     test3467();
     test4413();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=620

opDispatch should allow property syntax.

This patch allows making `foo.bar!(args)` (DotTemplateInstanceExp) as getter/setter property.
And it also allows DotTemplateExp, too.

The way resolving getter/setter property function is same as #279.

2011/10/08
Add fixes for issue 6738 and 6780.
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6738">Issue 6738</a> - Can't call templatized property function from within a struct/class method
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6780">Issue 6780</a> - Templated global property functions do not work

requires: phobos git://github.com/9rnsr/phobos.git fix_property
