### PR TITLE
CTFE fixes for 4682 6250 6306 6386 6399

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -526,6 +526,21 @@ Expression *Mod(Type *type, Expression *e1, Expression *e2)
             e2 = new IntegerExp(loc, 1, e2->type);
             n2 = 1;
         }
+        if (n2 == -1 && !type->isunsigned())
+        {    // Check for int.min % -1
+            if (n1 == 0xFFFFFFFF80000000UL && type->toBasetype()->ty != Tint64)
+            {
+                e2->error("integer overflow: int.min % -1");
+                e2 = new IntegerExp(loc, 1, e2->type);
+                n2 = 1;
+            }
+            else if (n1 == 0x8000000000000000LL) // long.min % -1
+            {
+                e2->error("integer overflow: long.min % -1");
+                e2 = new IntegerExp(loc, 1, e2->type);
+                n2 = 1;
+            }
+        }
         if (e1->type->isunsigned() || e2->type->isunsigned())
             n = ((d_uns64) n1) % ((d_uns64) n2);
         else

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2703,7 +2703,7 @@ Expression *copyLiteral(Expression *e)
     {   // For pointers, we only do a shallow copy.
         Expression *r;
         if (e->op == TOKaddress)
-            r = new AddrExp(e->loc, copyLiteral(((AddrExp *)e)->e1));
+            r = new AddrExp(e->loc, ((AddrExp *)e)->e1);
         else if (e->op == TOKindex)
             r = new IndexExp(e->loc, ((IndexExp *)e)->e1, ((IndexExp *)e)->e2);
         else if (e->op == TOKdotvar)
@@ -4597,6 +4597,16 @@ Expression *CastExp::interpret(InterState *istate, CtfeGoal goal)
         {
             return e1;
         }
+        if (e1->op == TOKindex && ((IndexExp *)e1)->e1->type != e1->type)
+        {   // type painting operation
+            IndexExp *ie = (IndexExp *)e1;
+            e = new IndexExp(e1->loc, ie->e1, ie->e2);
+            e->type = type;
+            return e;
+        }
+        error("pointer cast from %s to %s is not supported at compile time",
+                e1->type->toChars(), to->toChars());
+        return EXP_CANT_INTERPRET;
     }
     if (to->ty == Tarray && e1->op == TOKslice)
     {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -312,7 +312,11 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
         valueSaves.setDim(istate->vars.dim);
         for (size_t i = 0; i < istate->vars.dim; i++)
         {   VarDeclaration *v = istate->vars.tdata()[i];
-            if (v && v->parent == this)
+            bool isParentVar = false;
+            /* Nested functions only restore their own local variables
+             * (not variables in the parent function)
+             */
+            if (v && (!isNested() || v->parent == this))
             {
                 //printf("\tsaving [%d] %s = %s\n", i, v->toChars(), v->getValue() ? v->getValue()->toChars() : "");
                 valueSaves.tdata()[i] = v->getValue();
@@ -368,7 +372,10 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
         //printf("restoring local variables...\n");
         for (size_t i = 0; i < istate->vars.dim; i++)
         {   VarDeclaration *v = istate->vars.tdata()[i];
-            if (v && v->parent == this)
+            /* Nested functions only restore their own local variables
+             * (not variables in the parent function)
+             */
+            if (v && (!isNested() || v->parent == this))
             {   v->setValueWithoutChecking(valueSaves.tdata()[i]);
                 //printf("\trestoring [%d] %s = %s\n", i, v->toChars(), v->getValue() ? v->getValue()->toChars() : "");
             }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2143,3 +2143,22 @@ int ctfeSort6250()
 }
 
 static assert(ctfeSort6250()==57);
+
+/**************************************************
+    6399 (*p).length = n
+**************************************************/
+
+struct A6399{
+    int[] arr;
+    int subLen()
+    {
+        arr = [1,2,3,4,5];
+        arr.length -= 1;
+        return arr.length;
+    }
+}
+
+static assert({
+    A6399 a;
+    return a.subLen();
+}() == 4);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2063,3 +2063,22 @@ static assert({
     assert(k==2);
     return arr[0];
 }() == 2);
+
+/**************************************************
+    6306  recursion and local variables
+**************************************************/
+
+void recurse6306() {
+    bug6306(false);
+}
+
+bool bug6306(bool b) {
+    int x = 0;
+    if (b)
+        recurse6306();
+    assert(x == 0);
+    x = 1;
+    return true;
+}
+
+static assert( bug6306(true) );

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2082,3 +2082,24 @@ bool bug6306(bool b) {
 }
 
 static assert( bug6306(true) );
+
+/**************************************************
+    6386  ICE on unsafe pointer cast
+**************************************************/
+
+static assert(!is(typeof(compiles!({
+    int x = 123;
+    int* p = &x;
+    float z;
+    float* q = cast(float*)p;
+    return true;
+}()
+))));
+
+static assert({
+    int [] x = [123, 456];
+    int* p = &x[0];
+    auto m = cast(const(int) *)p;
+    auto q = p;
+    return *q;
+}());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2103,3 +2103,43 @@ static assert({
     auto q = p;
     return *q;
 }());
+
+/**************************************************
+    6250  deref pointers to array
+**************************************************/
+
+int []* simple6250(int []* x) { return x; }
+
+void swap6250(int[]* lhs, int[]* rhs)
+{
+    int[] kk = *lhs;
+    assert(simple6250(lhs) == lhs);
+    lhs = simple6250(lhs);
+    assert(kk[0] == 18);
+    assert((*lhs)[0] == 18);
+    assert((*rhs)[0] == 19);
+    *lhs = *rhs;
+    assert((*lhs)[0] == 19);
+    *rhs = kk;
+    assert(*rhs == kk);
+    assert(kk[0] == 18);
+    assert((*rhs)[0] == 18);
+}
+
+int ctfeSort6250()
+{
+     int[][2] x;
+     int[3] a = [17, 18, 19];
+     x[0] = a[1..2];
+     x[1] = a[2..$];
+     assert(x[0][0] == 18);
+     assert(x[0][1] == 19);
+     swap6250(&x[0], &x[1]);
+     assert(x[0][0] == 19);
+     assert(x[1][0] == 18);
+     a[1] = 57;
+     assert(x[0][0] == 19);
+     return x[1][0];
+}
+
+static assert(ctfeSort6250()==57);


### PR DESCRIPTION
Bug 6306 (incorrectly labelled 6304 in the commit message) is the most important one, it's a nasty regression in the last release.
6250 (stack overflow when swapping two pointers to arrays) is also quite severe.
