### PR TITLE
global state setup cleanups

### DIFF
--- a/src/backend/cg.c
+++ b/src/backend/cg.c
@@ -40,16 +40,12 @@ targ_size_t localsize,          /* amt subtracted from SP for local vars */
         Toff,                   /* base for temporaries                 */
         Poff,Aoff;              // comsubexps, params, regs, autos
 
-/* The following are initialized for the 8088. cod3_set32() or cod3_set64()
- * will change them as appropriate.
- */
-int     BPRM = 6;               /* R/M value for [BP] or [EBP]          */
-regm_t  fregsaved = mBP | mSI | mDI;    // mask of registers saved across
-                                        // function calls
-                                        // (add in mBX for I32)
-regm_t  FLOATREGS = FLOATREGS_16;
-regm_t  FLOATREGS2 = FLOATREGS2_16;
-regm_t  DOUBLEREGS = DOUBLEREGS_16;
+// Global register settings, initialized in cod3_set[16|32|64]
+int     BPRM       = 0;         // R/M value for [BP] or [EBP]
+regm_t  fregsaved  = 0;         // mask of registers saved across function calls
+regm_t  FLOATREGS  = 0;
+regm_t  FLOATREGS2 = 0;
+regm_t  DOUBLEREGS = 0;
 
 symbol *localgot;               // reference to GOT for this function
 symbol *tls_get_addr_sym;       // function __tls_get_addr

--- a/src/backend/cg.c
+++ b/src/backend/cg.c
@@ -43,6 +43,8 @@ targ_size_t localsize,          /* amt subtracted from SP for local vars */
 // Global register settings, initialized in cod3_set[16|32|64]
 int     BPRM       = 0;         // R/M value for [BP] or [EBP]
 regm_t  fregsaved  = 0;         // mask of registers saved across function calls
+regm_t  ALLREGS    = 0;
+regm_t  BYTEREGS   = 0;
 regm_t  FLOATREGS  = 0;
 regm_t  FLOATREGS2 = 0;
 regm_t  DOUBLEREGS = 0;

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -129,26 +129,7 @@ void codgen()
     csmax = 64;
     csextab = (struct CSE *) util_calloc(sizeof(struct CSE),csmax);
     functy = tybasic(funcsym_p->ty());
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-    if (0 && config.flags3 & CFG3pic)
-    {
-        ALLREGS = ALLREGS_INIT_PIC;
-        BYTEREGS = BYTEREGS_INIT_PIC;
-    }
-    else
-    {
-        regm_t value = BYTEREGS_INIT;
-        ALLREGS = ALLREGS_INIT;
-        BYTEREGS = value;
-    }
-    if (I64)
-    {   ALLREGS = mAX|mBX|mCX|mDX|mSI|mDI| mR8|mR9|mR10|mR11|mR12|mR13|mR14|mR15;
-        BYTEREGS = ALLREGS;
-    }
-#endif
     allregs = ALLREGS;
-    if (0 && config.flags3 & CFG3pic)
-        allregs &= ~mBX;
     pass = PASSinit;
 
 tryagain:

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -235,6 +235,23 @@ int cod3_EA(code *c)
 }
 
 /********************************
+ * Setup global variables for 16 bit x86
+ */
+
+void cod3_set16()
+{
+    // R/M value for [BP] or [EBP]
+    BPRM = 6;
+
+    // mask of registers saved across function calls
+    fregsaved = mBP | mSI | mDI;
+
+    FLOATREGS = FLOATREGS_16;
+    FLOATREGS2 = FLOATREGS2_16;
+    DOUBLEREGS = DOUBLEREGS_16;
+}
+
+/********************************
  * Fix global variables for 386.
  */
 

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -246,6 +246,9 @@ void cod3_set16()
     // mask of registers saved across function calls
     fregsaved = mBP | mSI | mDI;
 
+    ALLREGS = (mAX|mBX|mCX|mDX|mSI|mDI);
+    BYTEREGS = (mAX|mBX|mCX|mDX);
+
     FLOATREGS = FLOATREGS_16;
     FLOATREGS2 = FLOATREGS2_16;
     DOUBLEREGS = DOUBLEREGS_16;
@@ -271,7 +274,18 @@ void cod3_set32()
 
     for (unsigned i = 0x80; i < 0x90; i++)
         inssize2[i] = W|T|6;
+
+    ALLREGS = (mAX|mBX|mCX|mDX|mSI|mDI);
+    BYTEREGS = (mAX|mBX|mCX|mDX);
 }
+
+// Saved for the moment, but the code that used it was dead
+//#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
+//// To support positional independent code,
+//// must be able to remove BX from available registers
+//#define ALLREGS_INIT_PIC        (mAX|mCX|mDX|mSI|mDI)
+//#define BYTEREGS_INIT_PIC       (mAX|mCX|mDX)
+//#endif
 
 /********************************
  * Fix global variables for I64.
@@ -291,10 +305,8 @@ void cod3_set64()
     DOUBLEREGS = DOUBLEREGS_64;
     STACKALIGN = 16;
 
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     ALLREGS = mAX|mBX|mCX|mDX|mSI|mDI|  mR8|mR9|mR10|mR11|mR12|mR13|mR14|mR15;
     BYTEREGS = ALLREGS;
-#endif
 
     for (unsigned i = 0x80; i < 0x90; i++)
         inssize2[i] = W|T|6;

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -110,21 +110,8 @@ struct Declaration;
 #define RMload  (1 << 30)
 #define RMstore (1 << 31)
 
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-    // To support positional independent code,
-    // must be able to remove BX from available registers
 extern regm_t ALLREGS;
-#define ALLREGS_INIT            (mAX|mBX|mCX|mDX|mSI|mDI)
-#define ALLREGS_INIT_PIC        (mAX|mCX|mDX|mSI|mDI)
 extern regm_t BYTEREGS;
-#define BYTEREGS_INIT           (mAX|mBX|mCX|mDX)
-#define BYTEREGS_INIT_PIC       (mAX|mCX|mDX)
-#else
-#define ALLREGS                 (mAX|mBX|mCX|mDX|mSI|mDI)
-#define ALLREGS_INIT            ALLREGS
-#undef BYTEREGS
-#define BYTEREGS                (mAX|mBX|mCX|mDX)
-#endif
 
 /* We use the same IDXREGS for the 386 as the 8088, because if
    we used ALLREGS, it would interfere with mMSW

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -728,6 +728,7 @@ extern int BPoff;
 
 int cod3_EA(code *c);
 regm_t cod3_useBP();
+void cod3_set16 (void );
 void cod3_set32 (void );
 void cod3_set64 (void );
 void cod3_align (void );

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -45,9 +45,6 @@
 
 static Outbuffer *fobjbuf;
 
-regm_t BYTEREGS = BYTEREGS_INIT;
-regm_t ALLREGS = ALLREGS_INIT;
-
 static char __file__[] = __FILE__;      // for tassert.h
 #include        "tassert.h"
 

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -58,9 +58,6 @@ const SInt32 MacOSX_10_6 = 0x1060;
 
 static Outbuffer *fobjbuf;
 
-regm_t BYTEREGS = BYTEREGS_INIT;
-regm_t ALLREGS = ALLREGS_INIT;
-
 static char __file__[] = __FILE__;      // for tassert.h
 #include        "tassert.h"
 

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4444,9 +4444,7 @@ Statement *AsmStatement::semantic(Scope *sc)
         asmstate.bInit = TRUE;
         init_optab();
         asmstate.psDollar = new LabelDsymbol(Id::__dollar);
-        //asmstate.psLocalsize = new VarDeclaration(0, Type::tint32, Id::__LOCAL_SIZE, NULL);
         asmstate.psLocalsize = new Dsymbol(Id::__LOCAL_SIZE);
-        cod3_set32();
     }
 
     asmstate.loc = loc;

--- a/src/msc.c
+++ b/src/msc.c
@@ -163,23 +163,6 @@ void out_config_init()
         //config.flags &= ~CFGalwaysframe;
     }
 
-    // overwritten in set_32 or 64, mostly here as a note to fix up
-    // dmc since the global variables are no longer initialized.
-    cod3_set16();
-
-    if (params->is64bit)
-    {
-        util_set64();
-        cod3_set64();
-    }
-    else
-    {
-        util_set32();
-        cod3_set32();
-    }
-
-    rtlsym_init();
-
 #ifdef DEBUG
     debugb = params->debugb;
     debugc = params->debugc;
@@ -404,7 +387,19 @@ void backend_init()
     block_init();
     type_init();
 
-    fregsaved = I64 ? mBP | mBX | mR12 | mR13 | mR14 | mR15 | mES : mES | mBP | mBX | mSI | mDI;
+    if (global.params.is64bit)
+    {
+        util_set64();
+        cod3_set64();
+    }
+    else
+    {
+        util_set32();
+        cod3_set32();
+    }
+
+    // must be after util_set* due to depending on having correct type size data.
+    rtlsym_init();
 }
 
 void backend_term()

--- a/src/msc.c
+++ b/src/msc.c
@@ -163,6 +163,10 @@ void out_config_init()
         //config.flags &= ~CFGalwaysframe;
     }
 
+    // overwritten in set_32 or 64, mostly here as a note to fix up
+    // dmc since the global variables are no longer initialized.
+    cod3_set16();
+
     if (params->is64bit)
     {
         util_set64();


### PR DESCRIPTION
Tested in win32 and linux64.

getcmd.c in dmc will need to have a call to cod3_set16 added.  No building/testing done with dmc, just code examination.

NOTE: this fixes a critical bug in that any use of asm blocks currently resets the backend state to 32 bit mode.  That initialization doesn't need to be done at all since the backend should have been (and definitely is with this pull request) already setup appropriately.

NOTE2: this set of changes has a minor perf improvement side effect.. not re-initializing the backend one per .obj and once per asm statement.
