### PR TITLE
Fix ripple effects specific to win32 from the cpp.h and parser.h purge

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -27,7 +27,6 @@
 #include        "code.h"
 #include        "type.h"
 #include        "outbuf.h"
-#include        "scope.h"
 
 #include        "md5.h"
 

--- a/src/backend/global.h
+++ b/src/backend/global.h
@@ -331,6 +331,7 @@ void symbol_keep(Symbol *s);
 #endif
 void symbol_print(Symbol *s);
 void symbol_term(void);
+char *symbol_ident(symbol *s);
 Symbol *symbol_calloc(const char *id);
 Symbol *symbol_name(const char *name, int sclass, type *t);
 Symbol *symbol_generate(int sclass, type *t);

--- a/src/backend/newman.c
+++ b/src/backend/newman.c
@@ -19,13 +19,11 @@
 #include        <time.h>
 
 #include        "cc.h"
-#include        "parser.h"
 #include        "token.h"
 #include        "global.h"
 #include        "oper.h"
 #include        "el.h"
 #include        "type.h"
-#include        "cpp.h"
 #include        "filespec.h"
 
 #if NEWMANGLE
@@ -129,8 +127,13 @@ STATIC void cpp_string ( char *s, size_t len );
 /****************************
  */
 
-struct OPTABLE oparray[] =
+struct OPTABLE
 {
+    unsigned char tokn;
+    unsigned char oper;
+    char __near *string;
+    char *pretty;
+} oparray[] = {
     {   TKnew, OPnew,           cpp_name_new,   "new" },
     {   TKdelete, OPdelete,     cpp_name_delete,"del" },
     {   TKadd, OPadd,           "?H",           "+" },

--- a/src/backend/type.h
+++ b/src/backend/type.h
@@ -226,5 +226,6 @@ void param_free(param_t **);
 symbol *param_search(const char *name, param_t **pp);
 void param_hydrate(param_t **);
 void param_dehydrate(param_t **);
+int typematch(type *t1, type *t2, int relax);
 
 #endif


### PR DESCRIPTION
Two windows specific files needed a little care and feeding to cope with cpp.h and purge.h being removed.  Test built on win32 and linux64.
