### PR TITLE
CTFE: 3512 4021 6418 (foreach with UTF conversion)

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4984,9 +4984,9 @@ bool evaluateIfBuiltin(Expression **result, InterState *istate,
     FuncDeclaration *fd, Expressions *arguments, Expression *pthis)
 {
     Expression *e = NULL;
+    int nargs = arguments ? arguments->dim : 0;
 #if DMDV2
-    if (pthis && isAssocArray(pthis->type) &&
-        (!arguments || arguments->dim == 0))
+    if (pthis && isAssocArray(pthis->type) && nargs==0)
     {
         if (fd->ident == Id::length)
             e = interpret_length(istate, pthis);
@@ -4994,6 +4994,8 @@ bool evaluateIfBuiltin(Expression **result, InterState *istate,
             e = interpret_keys(istate, pthis, fd);
         else if (fd->ident == Id::values)
             e = interpret_values(istate, pthis, fd);
+        else if (fd->ident == Id::rehash)
+            e = pthis;  // rehash is a no-op
     }
     if (!pthis)
     {
@@ -5024,6 +5026,11 @@ bool evaluateIfBuiltin(Expression **result, InterState *istate,
             e = interpret_aaKeys(istate, arguments);
         else if (fd->ident == Id::aaValues)
             e = interpret_aaValues(istate, arguments);
+        else if (fd->ident == Id::aaRehash && nargs == 2)
+        {   // rehash is a no-op
+            Expression *earg = (Expression *)(arguments->data[0]);
+            return earg->interpret(istate, ctfeNeedLvalue);
+        }
     }
 #endif
     if (!e)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2226,10 +2226,12 @@ bool test3512()
     foreach (int i, char c; d) {} // _aApplydc2
     foreach (int i, wchar c; d) {} // _aApplydw2
 
-    dchar[] qq = "squop"d.dup;
-    dchar[] dr = qq;
-    dr[2] = 'w';
-    foreach(int n, char c; dr) {}
+    dchar[] dr = "squop"d.dup;
+    foreach(int n, char c; dr) { if (n==2) break; assert(c!='o'); }
+    foreach_reverse (char c; dr) {} // _aApplyRdc1
+    foreach_reverse (wchar c; dr) {} // _aApplyRdw1
+    foreach_reverse (int n, char c; dr) { if (n==4) break; assert(c!='o');} // _aApplyRdc2
+    foreach_reverse (int i, wchar c; dr) {} // _aApplyRdw2
     return true;
 }
 static assert(test3512());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2175,3 +2175,23 @@ static assert({
     A6399 a;
     return a.subLen();
 }() == 4);
+
+/**************************************************
+    6418 member named 'length'
+**************************************************/
+
+struct Bug6418 {
+    size_t length() { return 189; }
+}
+static assert(Bug6418.init.length == 189);
+
+/**************************************************
+    4021 rehash
+**************************************************/
+
+bool bug4021() {
+    int[int] aa = [1: 1];
+    aa.rehash;
+    return true;
+}
+static assert(bug4021());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2195,3 +2195,41 @@ bool bug4021() {
     return true;
 }
 static assert(bug4021());
+
+/**************************************************
+    3512 foreach(dchar; string)
+**************************************************/
+
+bool test3512()
+{
+    string s = "ohai";
+    int q = 0;
+    foreach (wchar c; s) {
+        if (q==2) assert(c=='a');
+        ++q;
+    }
+    assert(q==4);
+    foreach (dchar c; s) { ++q; if (c=='h') break; } // _aApplycd1
+    assert(q == 6);
+    foreach (int i, wchar c; s) {}   // _aApplycw2
+    foreach (int i, dchar c; s) {} // _aApplycd2
+
+    wstring w = "xxx";
+    foreach (char c; w) {} // _aApplywc1
+    foreach (dchar c; w) {} // _aApplywd1
+    foreach (int i, char c; w) {} // _aApplywc2
+    foreach (int i, dchar c; w) {} // _aApplywd2
+
+    dstring d = "yyy";
+    foreach (char c; d) {} // _aApplydc1
+    foreach (wchar c; d) {} // _aApplydw1
+    foreach (int i, char c; d) {} // _aApplydc2
+    foreach (int i, wchar c; d) {} // _aApplydw2
+
+    dchar[] qq = "squop"d.dup;
+    dchar[] dr = qq;
+    dr[2] = 'w';
+    foreach(int n, char c; dr) {}
+    return true;
+}
+static assert(test3512());


### PR DESCRIPTION
All these fixes are related to built-in functions. Implements all 24 of the UTF foreach conversion helper functions,
also fixes 6418 which was blocking the the use of many Phobos functions.

Only partly tested on D1 because of the broken Windows build, but it seems that the typesafety Array improvements were D2-only?
