### PR TITLE
disble part of test6293 in runnable/xtest46.d due to bug 5239.

### DIFF
--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3383,8 +3383,10 @@ void f6293(in C6293[] a) pure {
     auto x0 = a[0].token;
     assert(x0 is a[0].token.token.token);
     assert(x0 is (&x0).token);
-    auto p1 = &x0 + 1;
-    assert(x0 is (p1 - 1).token);
+    version(none) {
+        auto p1 = &x0 + 1;
+        assert(x0 is (p1 - 1).token);
+    }
     int c = 0;
     assert(x0 is a[c].token);
 }


### PR DESCRIPTION
I really really hate disabling tests due to bugs, but it's a new test so disabling part of the test doesn't hide a regression.

See also:
   https://github.com/D-Programming-Language/dmd/pull/243
   http://d.puremagic.com/issues/show_bug.cgi?id=6293
   http://d.puremagic.com/issues/show_bug.cgi?id=5239
