### PR TITLE
Issue 2246 - Regression(2.046, 1.061): Specialization of template to template containing int arguments fails

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3933,6 +3933,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     // will get called on the instance members
 #if 1
     int dosemantic3 = 0;
+    if (!sc->parameterSpecialization)
     {   Dsymbols *a;
 
         Scope *scx = sc;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -222,6 +222,42 @@ void test6404()
 }
 
 /**********************************/
+// 2246
+
+class A2246(T,d){
+    T p;
+}
+
+class B2246(int rk){
+    int[rk] p;
+}
+
+class C2246(T,int rk){
+    T[rk] p;
+}
+
+template f2246(T:A2246!(U,d),U,d){
+    void f2246(){ }
+}
+
+template f2246(T:B2246!(rank),int rank){
+    void f2246(){ }
+}
+
+template f2246(T:C2246!(U,rank),U,int rank){
+    void f2246(){ }
+}
+
+void test2246(){
+    A2246!(int,long) a;
+    B2246!(2) b;
+    C2246!(int,2) c;
+    f2246!(A2246!(int,long))();
+    f2246!(B2246!(2))();
+    f2246!(C2246!(int,2))();
+}
+
+/**********************************/
 
 int main()
 {
@@ -235,6 +271,7 @@ int main()
     test8();
     test9();
     test6404();
+    test2246();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=2246
Do not run `semantic3` of `TemplateInstance` that created for `TemplateDeclaration` parameter's `matchArg`.

While running template parameter's `matchArg`s on `TemplateDeclaration::semantic`, `TemplateDeclaration::matchWithInstance` cause an error at template.c L730 when `sparam` is not `TemplateValueParameter`, and if condition at L3833 becomes FALSE.
Therefore

<pre>
template f(T:A!(U,d),U,d){
             ^
</pre>

and

<pre>
template f(T:C!(U,rank),U,int rank){
             ^
</pre>

does not create TemplateInstance object, and does not cause compile error.

On the other hand,

<pre>
template f(T:B!(rank),int rank){
             ^
</pre>

has only `TemplateValueParameter`, so does not cause an error at L730, and pass conditoin at L3833.
After all, semantic3 of `B!(rank)` runs, and cause error in `class B(int rk)` because `rk` cannot evaluate at compile time.
