### PR TITLE
Issue5440

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1856,6 +1856,11 @@ void TypeInfoDeclaration::semantic(Scope *sc)
 TypeInfoConstDeclaration::TypeInfoConstDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfoconst)
+    {
+        Type::error(0, "TypeInfo_Const not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfoconst->type;
 }
 #endif
@@ -1866,6 +1871,11 @@ TypeInfoConstDeclaration::TypeInfoConstDeclaration(Type *tinfo)
 TypeInfoInvariantDeclaration::TypeInfoInvariantDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfoinvariant)
+    {
+        Type::error(0, "TypeInfo_Invariant not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfoinvariant->type;
 }
 #endif
@@ -1876,6 +1886,11 @@ TypeInfoInvariantDeclaration::TypeInfoInvariantDeclaration(Type *tinfo)
 TypeInfoSharedDeclaration::TypeInfoSharedDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfoshared)
+    {
+        Type::error(0, "TypeInfo_Shared not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfoshared->type;
 }
 #endif
@@ -1886,6 +1901,11 @@ TypeInfoSharedDeclaration::TypeInfoSharedDeclaration(Type *tinfo)
 TypeInfoWildDeclaration::TypeInfoWildDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfowild)
+    {
+        Type::error(0, "TypeInfo_Wild not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfowild->type;
 }
 #endif
@@ -1895,6 +1915,11 @@ TypeInfoWildDeclaration::TypeInfoWildDeclaration(Type *tinfo)
 TypeInfoStructDeclaration::TypeInfoStructDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfostruct)
+    {
+        Type::error(0, "TypeInfo_Struct not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfostruct->type;
 }
 
@@ -1903,6 +1928,11 @@ TypeInfoStructDeclaration::TypeInfoStructDeclaration(Type *tinfo)
 TypeInfoClassDeclaration::TypeInfoClassDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfoclass)
+    {
+        Type::error(0, "TypeInfo_Class not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfoclass->type;
 }
 
@@ -1911,6 +1941,11 @@ TypeInfoClassDeclaration::TypeInfoClassDeclaration(Type *tinfo)
 TypeInfoInterfaceDeclaration::TypeInfoInterfaceDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfointerface)
+    {
+        Type::error(0, "TypeInfo_Interface not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfointerface->type;
 }
 
@@ -1919,6 +1954,11 @@ TypeInfoInterfaceDeclaration::TypeInfoInterfaceDeclaration(Type *tinfo)
 TypeInfoTypedefDeclaration::TypeInfoTypedefDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfotypedef)
+    {
+        Type::error(0, "TypeInfo_Typedef not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfotypedef->type;
 }
 
@@ -1927,6 +1967,11 @@ TypeInfoTypedefDeclaration::TypeInfoTypedefDeclaration(Type *tinfo)
 TypeInfoPointerDeclaration::TypeInfoPointerDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfopointer)
+    {
+        Type::error(0, "TypeInfo_Pointer not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfopointer->type;
 }
 
@@ -1935,6 +1980,11 @@ TypeInfoPointerDeclaration::TypeInfoPointerDeclaration(Type *tinfo)
 TypeInfoArrayDeclaration::TypeInfoArrayDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfoarray)
+    {
+        Type::error(0, "TypeInfo_Array not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfoarray->type;
 }
 
@@ -1943,6 +1993,11 @@ TypeInfoArrayDeclaration::TypeInfoArrayDeclaration(Type *tinfo)
 TypeInfoStaticArrayDeclaration::TypeInfoStaticArrayDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfostaticarray)
+    {
+        Type::error(0, "TypeInfo_StaticArray not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfostaticarray->type;
 }
 
@@ -1951,6 +2006,11 @@ TypeInfoStaticArrayDeclaration::TypeInfoStaticArrayDeclaration(Type *tinfo)
 TypeInfoAssociativeArrayDeclaration::TypeInfoAssociativeArrayDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfoassociativearray)
+    {
+        Type::error(0, "TypeInfo_AssociativeArray not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfoassociativearray->type;
 }
 
@@ -1959,6 +2019,11 @@ TypeInfoAssociativeArrayDeclaration::TypeInfoAssociativeArrayDeclaration(Type *t
 TypeInfoEnumDeclaration::TypeInfoEnumDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfoenum)
+    {
+        Type::error(0, "TypeInfo_Enum not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfoenum->type;
 }
 
@@ -1967,6 +2032,11 @@ TypeInfoEnumDeclaration::TypeInfoEnumDeclaration(Type *tinfo)
 TypeInfoFunctionDeclaration::TypeInfoFunctionDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfofunction)
+    {
+        Type::error(0, "TypeInfo_Function not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfofunction->type;
 }
 
@@ -1975,6 +2045,11 @@ TypeInfoFunctionDeclaration::TypeInfoFunctionDeclaration(Type *tinfo)
 TypeInfoDelegateDeclaration::TypeInfoDelegateDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfodelegate)
+    {
+        Type::error(0, "TypeInfo_Delegate not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfodelegate->type;
 }
 
@@ -1983,6 +2058,11 @@ TypeInfoDelegateDeclaration::TypeInfoDelegateDeclaration(Type *tinfo)
 TypeInfoTupleDeclaration::TypeInfoTupleDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    if (!Type::typeinfotypelist)
+    {
+        Type::error(0, "TypeInfo_Tuple not found. object.d may be incorrectly installed or corrupt.");
+        fatal();
+    }
     type = Type::typeinfotypelist->type;
 }
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3972,6 +3972,11 @@ StructDeclaration *TypeAArray::getImpl()
 
         // Create AssociativeArray!(index, next)
 #if 1
+        if (! Type::associativearray)
+        {
+            error(0, "AssociativeArray not found. object.d may be incorrectly installed or corrupt.");
+            fatal();
+        }
         TemplateInstance *ti = new TemplateInstance(loc, Type::associativearray, tiargs);
 #else
         //Expression *e = new IdentifierExp(loc, Id::object);


### PR DESCRIPTION
Raised in bugzilla some time ago.  Only just gotten round to fixing it.

http://d.puremagic.com/issues/show_bug.cgi?id=5440

Commits fix corner cases where DMD will ICE if the AssociativeArray or any of the TypeInfo_\* declarations are missing from object.d, and just error graciously.
