### PR TITLE
LLVM-GCC/Clang fixes

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -19,6 +19,7 @@
         _MSC_VER        Microsoft compiler
         __GNUC__        Gnu compiler
         __clang__       Clang compiler
+        __llvm__        Compiler using LLVM as backend (LLVM-GCC/Clang)
 
     Host operating system:
         _WIN32          Microsoft NT, Windows 95, Windows 98, Win32s, Windows 2000

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -544,9 +544,8 @@ struct REGSAVE
     code *save(code *c, int reg, unsigned *pidx);
     code *restore(code *c, int reg, unsigned idx);
 };
-
-extern REGSAVE regsave;
 }
+extern REGSAVE regsave;
 
 /*******************************
  * As we generate code, collect information about

--- a/src/tk/mem.c
+++ b/src/tk/mem.c
@@ -755,10 +755,17 @@ void *mem_fmalloc(unsigned numbytes)
 {   void *p;
 
     //printf("fmalloc(%d)\n",numbytes);
+#ifdef __llvm__
+    // LLVM-GCC and Clang assume some types, notably elem (see DMD issue 6215),
+    // to be 16-byte aligned. Because we do not have any type information
+    // available here, we have to 16 byte-align everything.
+    numbytes = (numbytes + 0xF) & ~0xF;
+#else
     if (sizeof(size_t) == 2)
         numbytes = (numbytes + 1) & ~1;         /* word align   */
     else
         numbytes = (numbytes + 3) & ~3;         /* dword align  */
+#endif
 
     /* This ugly flow-of-control is so that the most common case
        drops straight through.

--- a/src/tk/mem.c
+++ b/src/tk/mem.c
@@ -755,7 +755,7 @@ void *mem_fmalloc(unsigned numbytes)
 {   void *p;
 
     //printf("fmalloc(%d)\n",numbytes);
-#ifdef __llvm__
+#if defined(__llvm__) && (defined(__GNUC__) || defined(__clang__))
     // LLVM-GCC and Clang assume some types, notably elem (see DMD issue 6215),
     // to be 16-byte aligned. Because we do not have any type information
     // available here, we have to 16 byte-align everything.


### PR DESCRIPTION
In both cases, I am not enough of a language lawyer to judge who is at fault, but with these commits, DMD builds and works fine with both LLVM-GCC and Clang on OS X 10.7 (see [issue 6215](http://d.puremagic.com/issues/show_bug.cgi?id=6215)).
