### PR TITLE
DMD 1 build fix – harmonize createTypeInfoArray() signatures.

### DIFF
--- a/src/typinf.c
+++ b/src/typinf.c
@@ -821,7 +821,7 @@ int TypeClass::builtinTypeInfo()
  * Used to supply hidden _arguments[] value for variadic D functions.
  */
 
-Expression *createTypeInfoArray(Scope *sc, Expression *exps[], int dim)
+Expression *createTypeInfoArray(Scope *sc, Expression *exps[], unsigned dim)
 {
 #if 1
     /* Get the corresponding TypeInfo_Tuple and


### PR DESCRIPTION
unsigned is the argument type of Array::setDim(), so it appears to be the most appropriate choice.
