### PR TITLE
Fixed wrong AA test introduced by pull request #291.

### DIFF
--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -813,7 +813,7 @@ void test36() {
     static assert(aa.sizeof != 0);
     static assert(aa.alignof != 0);
     static assert(is(typeof(aa.init) == int[int]));
-    static assert(aa.mangleof == "Hii");
+    static assert(typeof(aa).mangleof == "Hii");
     static assert(typeof(aa).stringof == "int[int]");
     static struct AA { int[int] aa; }
     static assert(AA.aa.offsetof == 0);


### PR DESCRIPTION
Previously, the test for AA type mangling would compare the mangled name of the nested variable to the expected mangling for only the type part of it.
