### PR TITLE
Get test suite to compile without std.random.rand and rand_seed.

### DIFF
--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -1,7 +1,7 @@
 // REQUIRED_ARGS: -d
 
 import core.stdc.math: isnan;
-import std.random: rand;
+import std.random: rndGen;
 import std.math: poly;
 import std.c.stdarg;
 
@@ -15,6 +15,13 @@ extern(C)
     }
     else
         int snprintf(char*, size_t, const char*, ...);
+}
+
+auto rand()
+{
+    auto value = rndGen().front;
+    rndGen.popFront();
+    return value;
 }
 
 /*************************************/

--- a/test/runnable/testgc3.d
+++ b/test/runnable/testgc3.d
@@ -4,9 +4,15 @@
 import std.c.stdio;
 import std.random;
 
+auto rand()
+{
+    auto value = rndGen().front;
+    rndGen.popFront();
+    return value;
+}
+
 void main()
 {
-    rand_seed(1, 2);
     uint[uint][] aa;
     aa.length = 10000;
     for(int i = 0; i < 10_000_000; i++)


### PR DESCRIPTION
`std.random.rnd` and `std.random.rand_seed` have been deprecated for some time and now have been removed, which broke the dmd test suite. Thes changes attempt to fix the test suite (they at least make it compile and pass).

However, I don't know if they're is the best way to fix these tests or not, since I really don't know what they're testing. It's not entirely clear to me whether they're supposed to be testing `rand` or just using`rand` in tests. So, I took the simplest route to get them to compile by creating a `rand` function which used `std.random.rndGen` to generate random numbers.
