### PR TITLE
Remove import of std.random:rand from test22

### DIFF
--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -1,7 +1,5 @@
 // REQUIRED_ARGS: -d
 
-import core.stdc.math: isnan;
-import std.random: rand;
 import std.math: poly;
 import std.c.stdarg;
 
@@ -19,68 +17,70 @@ extern(C)
 
 /*************************************/
 
+// http://www.digitalmars.com/d/archives/digitalmars/D/bugs/4766.html
+// Only with -O
+
+real randx()
+{
+    return 1.2;
+}
+
 void test1()
 {
-    float x10=rand();
-    float x11=rand();
-    float x20=rand();
-    float x21=rand();
-    float y10=rand();
-    float y11=rand();
-    float y20=rand();
-    float y21=rand();
+    float x10=randx();
+    float x11=randx();
+    float x20=randx();
+    float x21=randx();
+    float y10=randx();
+    float y11=randx();
+    float y20=randx();
+    float y21=randx();
 
     float tmp=(
     x20*x21 + y10*y10 + y10*y11 + y11*y11 + 
     y11*y20 + y20*y20 + y10*y21 + y11*y21 +
     y21*y21);
-
-    printf("%f\n", tmp);
-    assert(!isnan(tmp));
+    assert(tmp > 0);
 }
 
 /*************************************/
 
 void test2()
 {
-    double x10=rand();
-    double x11=rand();
-    double x20=rand();
-    double x21=rand();
-    double y10=rand();
-    double y11=rand();
-    double y20=rand();
-    double y21=rand();
+	double x10=randx();
+	double x11=randx();
+	double x20=randx();
+	double x21=randx();
+	double y10=randx();
+	double y11=randx();
+	double y20=randx();
+	double y21=randx();
 
     double tmp=(
     x20*x21 + y10*y10 + y10*y11 + y11*y11 + 
     y11*y20 + y20*y20 + y10*y21 + y11*y21 +
     y21*y21);
-
-    printf("%f\n", tmp);
-    assert(!isnan(tmp));
+    assert(tmp > 0);
 }
 
 /*************************************/
 
 void test3()
 {
-    real x10=rand();
-    real x11=rand();
-    real x20=rand();
-    real x21=rand();
-    real y10=rand();
-    real y11=rand();
-    real y20=rand();
-    real y21=rand();
+    real x10=randx();
+    real x11=randx();
+    real x20=randx();
+    real x21=randx();
+    real y10=randx();
+    real y11=randx();
+    real y20=randx();
+    real y21=randx();
 
     real tmp=(
     x20*x21 + y10*y10 + y10*y11 + y11*y11 + 
     y11*y20 + y20*y20 + y10*y21 + y11*y21 +
     y21*y21);
-
-    printf("%Lf\n", tmp);
-    assert(!isnan(tmp));
+    assert(tmp > 0);
 }
 
 /*************************************/


### PR DESCRIPTION
I checked this reduced test case on DMD 0.120, to make sure it accurately
reproduced the bug.
This completely removes the Phobos import.
