### PR TITLE
Remove import of std.random from the test suite

### DIFF
--- a/test/runnable/stress.d
+++ b/test/runnable/stress.d
@@ -1,8 +1,8 @@
 // PERMUTE_ARGS:
 
-import std.c.stdio;
-import std.string;
-import std.utf;
+import std.c.stdio : printf;
+import std.string : splitLines;
+import std.utf : toUTF16, toUTF32;
 
 /***********************************************/
 
@@ -106,7 +106,7 @@ void MDCHAR()
         tmp = tmp ~ s;
     }
 
-    foreach(s; splitlines(cast(string)tmp)) {
+    foreach(s; splitLines(cast(string)tmp)) {
         int lstart;
         foreach(int idx, char c; s) {
             if(c == '\n') {

--- a/test/runnable/template2.d
+++ b/test/runnable/template2.d
@@ -3,10 +3,8 @@
 // Test to manipulate 3D vectors, in D!
 // by Sean L Palmer (seanpalmer@directvinternet.com)
 // This code is released without any warranty.  Use at your own risk.
-import std.stream;
-import std.string;
 import std.c.stdio;
-import std.math;
+import std.math : sqrt;
 
 template VecTemplate(tfloat, int dim:3)
 {

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -1,6 +1,3 @@
-// REQUIRED_ARGS: -d
-
-import std.utf: toUTF8;
 
 extern(C) int printf(const char*, ...);
 extern(C) int sprintf(char*, const char*, ...);
@@ -99,7 +96,7 @@ void test2()
 
 /**************************************/
 
-bool all(string array, bool (*predicate)(char)) {
+bool all(string array, bool function(char) predicate) {
     for (int i = 0; i < array.length; i++) {
         if (!predicate(array[i])) {
             return false;
@@ -216,7 +213,7 @@ template base7( T )
  typedef T safeptr = cast(T)&errfunc;
 }
 
-alias int (*mfp)(int);
+alias int function(int) mfp;
 alias base7!(mfp) I_V_fp;
 
 void test7()
@@ -488,7 +485,7 @@ void test20()
 
 /**************************************/
 
-import std.math;
+bool isnan(float x) { return !( (x >= 0)  || (x < 0)); }
 
 struct X21 { float f, g, h; }
 X21 x21_1;
@@ -1202,34 +1199,22 @@ void test56()
 
 /**************************************/
 
-void writefln(wstring ws)
-{
-    string s = toUTF8(ws);
-    printf("%.*s\n", s.length, s.ptr);
-}
-
+// DMD 0.114: Fixed .reverse bug of char[] and wchar[] with multibyte encodings.
 void test57()
 {
     wstring a = "abcd";
-    wstring r;
+    wchar[] r;
 
-    r = a.idup.reverse;
-    writefln(r);
+    r = a.dup.reverse;
     assert(r == "dcba");
 
     a = "a\U00012356\U00012346c";
-    writefln(a);
-    r = a.idup.reverse;
-    writefln(r);
+    r = a.dup.reverse;
     assert(r == "c\U00012346\U00012356a");
 
     a = "ab\U00012345c";
-    writefln(a);
-    r = a.idup.reverse;
-    writefln(r);
+    r = a.dup.reverse;
     assert(r == "c\U00012345ba");
-
-    printf("Success\n");
 }
 
 /**************************************/

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -1,9 +1,7 @@
-// REQUIRED_ARGS: -d
 
 module testxxx8;
 
 import core.vararg;
-import std.utf: validate;
 
 extern(C)
 {
@@ -283,7 +281,7 @@ void test15()
 
 void test16()
 {
-    static int (*fp)() = &func16;
+    static int function() fp = &func16;
     int i = fp();
     assert(i == 648);
 }
@@ -1035,18 +1033,14 @@ void test51()
 
 /***********************************/
 
+// Bug 391
 void test52()
 {
-    string a;
-    a = "\u3026\u2021\u3061\n".idup;
-    printf("plain\n");
-    validate(a);
-
-    printf("sorted\n");
-    validate(a.sort);
-
-    printf("reversed\n");
-    validate(a.reverse);
+    char[] a;
+    a = "\u3026\u2021\u3061\n".dup;
+    assert(a =="\u3026\u2021\u3061\n");
+    assert(a.sort == "\n\u2021\u3026\u3061");
+    assert(a.reverse =="\u3061\u3026\u2021\n");
 }
 
 /***********************************/

--- a/test/runnable/testgc2.d
+++ b/test/runnable/testgc2.d
@@ -2,10 +2,8 @@
 
 module testgc2;
 
-import std.stdio;
-import std.string;
-import std.format;
-import core.exception;
+import core.stdc.stdio;
+import core.exception : OutOfMemoryError;
 
 /*******************************************/
 
@@ -45,7 +43,7 @@ void main()
 {
     test1();
 
-    writefln("Success");
+    printf("Success\n");
 }
 
 

--- a/test/runnable/testgc3.d
+++ b/test/runnable/testgc3.d
@@ -1,20 +1,22 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -d
+// REQUIRED_ARGS:
 
 import std.c.stdio;
-import std.random;
 
+/* This isn't a very good test. If it 'fails' it just takes a very
+ * long time. The performance improved by a factor of five between
+ * 2.042 and 2.043.
+ */
 void main()
 {
-    rand_seed(1, 2);
     uint[uint][] aa;
     aa.length = 10000;
     for(int i = 0; i < 10_000_000; i++)
     {
-	size_t j = rand() % aa.length;
-	uint k = rand();
-	uint l = rand();
-	aa[j][k] = l;
+        size_t j = i % aa.length;
+        uint k = i;
+        uint l = i;
+        aa[j][k] = l;
     }
     printf("finished\n");
     aa[] = null;


### PR DESCRIPTION
This removes std.random from testgc3.d

I first received this test in the beta of 2.044. The performance was 5X faster
in 2.043 than 2.042. In 2.020, it doesn't finish within two minutes (vs ~5secs
for the recent versions).
