### PR TITLE
Issue 6434 - opDispatch must be considered before alias this.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1851,17 +1851,6 @@ Expression *Type::noMember(Scope *sc, Expression *e, Identifier *ident)
         ident != Id::stringof &&
         ident != Id::offsetof)
     {
-        /* See if we should forward to the alias this.
-         */
-        if (sym->aliasthis)
-        {   /* Rewrite e.ident as:
-             *  e.aliasthis.ident
-             */
-            e = new DotIdExp(e->loc, e, sym->aliasthis->ident);
-            e = new DotIdExp(e->loc, e, ident);
-            return e->semantic(sc);
-        }
-
         /* Look for overloaded opDot() to see if we should forward request
          * to it.
          */
@@ -1897,6 +1886,17 @@ Expression *Type::noMember(Scope *sc, Expression *e, Identifier *ident)
             ((DotTemplateInstanceExp *)e)->ti->tempdecl = td;
             return e;
             //return e->semantic(sc);
+        }
+
+        /* See if we should forward to the alias this.
+         */
+        if (sym->aliasthis)
+        {   /* Rewrite e.ident as:
+             *  e.aliasthis.ident
+             */
+            e = new DotIdExp(e->loc, e, sym->aliasthis->ident);
+            e = new DotIdExp(e->loc, e, ident);
+            return e->semantic(sc);
         }
     }
 

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -173,6 +173,27 @@ void test6() {
 }
 
 /**********************************************/
+// 6434
+
+struct Variant6434{}
+
+struct A6434
+{
+   Variant6434 i;
+   alias i this;
+
+   void opDispatch(string name)()
+   {
+   }
+}
+
+void test6434()
+{
+   A6434 a;
+   a.weird; // no property 'weird' for type 'VariantN!(maxSize)'
+}
+
+/**************************************/
 
 int main()
 {
@@ -184,6 +205,7 @@ int main()
     test4773();
     test5188();
     test6();
+    test6434();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6434

The process of `Type::noMember`

<table>
<tr><th>before</th><td><code>alias this</code> -&gt; <code>opDot</code> -&gt; <code>opDispatch</code></td></tr>
<tr><th>after</th><td><code>opDot</code> -&gt; <code>opDispatch</code> -&gt; <code>alias this</code></td></tr>
</table>
