### PR TITLE
The 2nd fix of issue 6499 - [GSoC] Destructor not called on object returned by method. 

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7337,10 +7337,15 @@ Lagain:
         else
         {
             if (e1->op == TOKdotvar)
+            {
                 dve->var = f;
+                e1->type = f->type;
+            }
             else
+            {
                 e1 = new DotVarExp(loc, dte->e1, f);
-            e1->type = f->type;
+                e1 = e1->semantic(sc);
+            }
 #if 0
             printf("ue->e1 = %s\n", ue->e1->toChars());
             printf("f = %s\n", f->toChars());

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1714,10 +1714,10 @@ struct S6499
 
     this(string s)
     {
-	m = s;
+        m = s;
         printf("Constructor - %.*s\n", m.length, m.ptr);
-        if (m == "foo") ++sdtor, assert(sdtor == 1);
-        if (m == "bar") ++sdtor, assert(sdtor == 2);
+        if (m == "foo") { ++sdtor; assert(sdtor == 1); }
+        if (m == "bar") { ++sdtor; assert(sdtor == 2); }
     }
     this(this)
     {
@@ -1727,23 +1727,27 @@ struct S6499
     ~this()
     {
         printf("Destructor  - %.*s\n", m.length, m.ptr);
-        if (m == "bar") assert(sdtor == 2), --sdtor;
-        if (m == "foo") assert(sdtor == 1), --sdtor;
+        if (m == "bar") { assert(sdtor == 2); --sdtor; }
+        if (m == "foo") { assert(sdtor == 1); --sdtor; }
     }
-    S6499 bar()
-    {
-        return S6499("bar");
-    }
+    S6499 bar()     { return S6499("bar"); }
+    S6499 baz()()   { return S6499("baz"); }
 }
 
 void test6499()
 {
     S6499 foo() { return S6499("foo"); }
 
-    sdtor = 0;
-    scope(exit) assert(sdtor == 0);
-
-    foo().bar();
+    {
+        sdtor = 0;
+        scope(exit) assert(sdtor == 0);
+        foo().bar();
+    }
+    {
+        sdtor = 0;
+        scope(exit) assert(sdtor == 0);
+        foo().baz();
+    }
 }
 
 /**********************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6499#c3

If `CallExp::e1->op == TOKdottd`, it is resolved to `DotVarExp` in `CallExp::semantic`, but its `semantic` had not been called.
