### PR TITLE
Fixed crash with Ddoc-only files included at the command line.

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -1104,7 +1104,7 @@ int main(int argc, char *argv[])
 #endif
 
     // Parse files
-    int anydocfiles = 0;
+    bool anydocfiles = false;
     for (size_t i = 0; i < modules.dim; i++)
     {
         m = modules.tdata()[i];
@@ -1124,7 +1124,7 @@ int main(int argc, char *argv[])
         m->parse();
         if (m->isDocFile)
         {
-            anydocfiles = 1;
+            anydocfiles = true;
             m->gendocfile();
 
             // Remove m from list of modules

--- a/src/mars.c
+++ b/src/mars.c
@@ -1105,18 +1105,19 @@ int main(int argc, char *argv[])
 
     // Parse files
     bool anydocfiles = false;
-    for (size_t i = 0; i < modules.dim; i++)
+    size_t filecount = modules.dim;
+    for (size_t filei = 0, modi = 0; filei < filecount; filei++, modi++)
     {
-        m = modules.tdata()[i];
+        m = modules.tdata()[modi];
         if (global.params.verbose)
             printf("parse     %s\n", m->toChars());
         if (!Module::rootModule)
             Module::rootModule = m;
         m->importedFrom = m;
-        if (!global.params.oneobj || i == 0 || m->isDocFile)
+        if (!global.params.oneobj || modi == 0 || m->isDocFile)
             m->deleteObjFile();
 #if ASYNCREAD
-        if (aw->read(i))
+        if (aw->read(filei))
         {
             error("cannot read file %s", m->srcfile->name->toChars());
         }
@@ -1128,8 +1129,8 @@ int main(int argc, char *argv[])
             m->gendocfile();
 
             // Remove m from list of modules
-            modules.remove(i);
-            i--;
+            modules.remove(modi);
+            modi--;
 
             // Remove m's object file from list of object files
             for (size_t j = 0; j < global.params.objfiles->dim; j++)


### PR DESCRIPTION
Previously, the index into the AsyncRead file list was off by one after removing a Ddoc file from the module list, causing a crash because `m->parse()` would be called for a source file not yet loaded.
