### PR TITLE
gcc -> g++

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -141,7 +141,7 @@ SRC = win32.mak posix.mak \
 all: dmd
 
 dmd: $(DMD_OBJS)
-	$(ENVP) gcc -o dmd -m$(MODEL) $(COV) $(DMD_OBJS) $(LDFLAGS)
+	$(ENVP) g++ -o dmd -m$(MODEL) $(COV) $(DMD_OBJS) $(LDFLAGS)
 
 clean:
 	rm -f $(DMD_OBJS) dmd optab.o id.o impcnvgen idgen id.c id.h \


### PR DESCRIPTION
This should be g++, not gcc, in case gcc and g++ point to completely different gcc installations as happened to me when I built and installed GDC on my Linux VM.  An installation compiled without C++ support is unlikely to know where to find the relevant C++ libraries like libstdc++.
