### PR TITLE
Fix segfault regressions 5936 and 6351

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -642,11 +642,16 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
 {
     //printf("functionParameters()\n");
     assert(arguments);
+    assert(fd || tf->next);
     size_t nargs = arguments ? arguments->dim : 0;
     size_t nparams = Parameter::dim(tf->parameters);
 
     if (nargs > nparams && tf->varargs == 0)
         error(loc, "expected %zu arguments, not %zu for non-variadic function type %s", nparams, nargs, tf->toChars());
+
+    // If inferring return type, and semantic3() needs to be run if not already run
+    if (!tf->next && fd->inferRetType)
+        fd->semantic3(fd->scope);
 
     unsigned n = (nargs > nparams) ? nargs : nparams;   // n = max(nargs, nparams)
 
@@ -944,10 +949,6 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                 arguments->dim - nparams);
         arguments->insert(0, e);
     }
-
-    // If inferring return type, and semantic3() needs to be run if not already run
-    if (!tf->next && fd->inferRetType)
-        fd->semantic3(fd->scope);
 
     Type *tret = tf->next;
     if (wildmatch)

--- a/src/expression.c
+++ b/src/expression.c
@@ -721,7 +721,9 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                         Identifier *id = Lexer::uniqueId("__arrayArg");
                         Type *t = new TypeSArray(((TypeArray *)tb)->next, new IntegerExp(nargs - i));
                         t = t->semantic(loc, sc);
-                        VarDeclaration *v = new VarDeclaration(loc, t, id, fd->isSafe() ? NULL : new VoidInitializer(loc));
+                        bool isSafe = fd ? fd->isSafe() : tf->trust == TRUSTsafe;
+                        VarDeclaration *v = new VarDeclaration(loc, t, id,
+                            isSafe ? NULL : new VoidInitializer(loc));
                         v->storage_class |= STCctfe;
                         v->semantic(sc);
                         v->parent = sc->parent;

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -59,5 +59,25 @@ void fECPb() {
     static assert( is(typeof(&g!()) == void delegate()));
 }
 
+// 5936
+
+auto bug5936c(R)(R i) @safe pure nothrow {
+    return true;
+}
+static assert( bug5936c(0) );
+
+// 6351
+
+void bug6351(alias dg)()
+{
+    dg();
+}
+
+void test6351()
+{
+    void delegate(int[] a...) deleg6351 = (int[] a...){};
+    alias bug6351!(deleg6351) baz6531;
+}
+
 // Add more tests regarding inferences later.
 


### PR DESCRIPTION
These bugs are very closely related. Both are segfaults related to pure/@safe inference; they're both caused by code in functionParameters() that incorrectly assumes parameters are non-null.

http://d.puremagic.com/issues/show_bug.cgi?id=5936
Regression(2.050): Segfault when forward-referencing pure auto-return member function with parameter. 

http://d.puremagic.com/issues/show_bug.cgi?id=6351
Regression(2.054) Segfault: Vararg delegate as template param

which is a dup of 6341: Regression(2.054): Segfault with variadic delegate parameter
