### PR TITLE
Add a test to validate druntime's trace code

### DIFF
--- a/test/runnable/testprofile.d
+++ b/test/runnable/testprofile.d
@@ -1,0 +1,31 @@
+// REQUIRED_ARGS: -profile
+
+module testprofile;
+
+// ------------------
+
+struct FourUShort {
+    this(ushort a, ushort b, ushort c, ushort d) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+        this.d = d;
+    }
+    ushort a, b, c, d;
+}
+
+void test1()
+{
+    auto f = FourUShort(0, 1, 2, 3);
+    assert(f.a == 0);
+    assert(f.b == 1);
+    assert(f.c == 2);
+    assert(f.d == 3);
+}
+
+// ------------------
+
+void main()
+{
+    test1();
+}


### PR DESCRIPTION
Add a test to validate druntime's trace code, see also https://github.com/D-Programming-Language/druntime/pull/58

I validated that the test does indeed catch the bug and passes correctly after the fix.  I only tested on 64 bit, but no reason it won't correctly pass on 32 bit platforms also.
