### PR TITLE
serious bug fix for iasm on 64 bit setting up the backend to be 32 bit.

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4424,9 +4424,7 @@ Statement *AsmStatement::semantic(Scope *sc)
         asmstate.bInit = TRUE;
         init_optab();
         asmstate.psDollar = new LabelDsymbol(Id::__dollar);
-        //asmstate.psLocalsize = new VarDeclaration(0, Type::tint32, Id::__LOCAL_SIZE, NULL);
         asmstate.psLocalsize = new Dsymbol(Id::__LOCAL_SIZE);
-        cod3_set32();
     }
 
     asmstate.loc = loc;

--- a/src/msc.c
+++ b/src/msc.c
@@ -163,19 +163,6 @@ void out_config_init()
         //config.flags &= ~CFGalwaysframe;
     }
 
-    if (params->is64bit)
-    {
-        util_set64();
-        cod3_set64();
-    }
-    else
-    {
-        util_set32();
-        cod3_set32();
-    }
-
-    rtlsym_init();
-
 #ifdef DEBUG
     debugb = params->debugb;
     debugc = params->debugc;
@@ -400,7 +387,18 @@ void backend_init()
     block_init();
     type_init();
 
-    fregsaved = I64 ? mBP | mBX | mR12 | mR13 | mR14 | mR15 | mES : mES | mBP | mBX | mSI | mDI;
+    if (global.params.is64bit)
+    {
+        util_set64();
+        cod3_set64();
+    }
+    else
+    {
+        util_set32();
+        cod3_set32();
+    }
+
+    rtlsym_init(); // uses fregsaved, so must be after it's set inside cod3_set*
 }
 
 void backend_term()


### PR DESCRIPTION
Move initialization of the backend to be run earlier: 
 enables the below change to iasm
  fixes fregsaved to be correctly setup, I64 is always false at the point it was used
    result, parts of the code ran with fregsaved improperly setup
  and less importantly, no longer re-initialize the backend for each obj file

Fix a serious bug in iasm on 64 bit:
  it unconditionally called cod3_set32
  and less importantly, no longer runs it for every asm block

NOTE: nothing to change in dmc for this fix.  It's initialization is different and early enough to not have this bug (not that it supports 64 bit anyway).
