### PR TITLE
Bug 4375: Dangling else

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1445,7 +1445,7 @@ void CompileDeclaration::compileIt(Scope *sc)
         Parser p(sc->module, (unsigned char *)se->string, se->len, 0);
         p.loc = loc;
         p.nextToken();
-        decl = p.parseDeclDefs(0);
+        decl = p.parseDeclDefs(0, 0);
         if (p.token.value != TOKeof)
             exp->error("incomplete mixin declaration (%s)", se->toChars());
     }

--- a/src/parse.h
+++ b/src/parse.h
@@ -58,7 +58,6 @@ enum ParseStatementFlags
     PScurlyscope = 8,   // { } starts a new scope
 };
 
-
 struct Parser : Lexer
 {
     ModuleDeclaration *md;
@@ -69,9 +68,9 @@ struct Parser : Lexer
     Parser(Module *module, unsigned char *base, unsigned length, int doDocComment);
 
     Dsymbols *parseModule();
-    Dsymbols *parseDeclDefs(int once);
+    Dsymbols *parseDeclDefs(int once, Loc *containsElse = NULL);
     Dsymbols *parseAutoDeclarations(StorageClass storageClass, unsigned char *comment);
-    Dsymbols *parseBlock();
+    Dsymbols *parseBlock(Loc *containsElse);
     void composeStorageClass(StorageClass stc);
     StorageClass parseAttribute();
     StorageClass parsePostfix();
@@ -110,7 +109,7 @@ struct Parser : Lexer
     Type *parseDeclarator(Type *t, Identifier **pident, TemplateParameters **tpl = NULL, StorageClass storage_class = 0);
     Dsymbols *parseDeclarations(StorageClass storage_class, unsigned char *comment);
     void parseContracts(FuncDeclaration *f);
-    Statement *parseStatement(int flags);
+    Statement *parseStatement(int flags, Loc *containsElse = NULL);
     Initializer *parseInitializer();
     Expression *parseDefaultInitExp();
     void check(Loc loc, enum TOK value);
@@ -125,6 +124,8 @@ struct Parser : Lexer
     int isTemplateInstance(Token *t, Token **pt);
     int skipParens(Token *t, Token **pt);
     int skipAttributes(Token *t, Token **pt);
+
+    void checkDanglingElse(Loc containsElse);
 
     Expression *parseExpression();
     Expression *parsePrimaryExp();

--- a/test/compilable/test4375.d
+++ b/test/compilable/test4375.d
@@ -1,0 +1,472 @@
+// 4375: disallow dangling else
+
+void main() {
+
+	if (true) {
+		if (false) {
+			assert(1);
+		} else {
+			assert(2);
+		}
+	}
+
+
+    if (true) {
+        if (false)
+            assert(7);
+    } else
+        assert(8);
+
+
+    if (true) {
+        if (false)
+            assert(9);
+        else
+            assert(10);
+    }
+
+
+    {
+        if (true)
+            assert(11);
+        else
+            assert(12);
+    }
+
+
+    {
+label1:
+        if (true)
+            assert(13);
+        else
+            assert(14);
+    }
+
+
+	if (true)
+		foreach (i; 0 .. 5) {
+			if (true)
+				assert(17);
+            else
+                assert(18);
+        }
+
+
+	if (true) {
+		foreach (i; 0 .. 5)
+			if (true)
+				assert(18.1);
+    } else
+        assert(18.2);
+
+
+    if (true)
+        assert(19);
+    else
+        assert(20);
+
+
+    if (true)
+        assert(21);
+    else if (false)
+        assert(22);
+    else
+        assert(23);
+
+
+    version (A) {
+        if (true)
+            assert(26);
+    } else
+        assert(27);
+
+
+    version (A) {
+        if (true)
+            assert(28);
+        else
+            assert(29);
+    }
+
+
+    version (A)
+        assert(30);
+    else version (B)
+        assert(31);
+    else
+        assert(32);
+
+
+    static if (true) {
+        static if (true)
+            assert(35);
+    } else
+        assert(36);
+
+
+    static if (true) {
+        static if (true)
+            assert(37);
+        else
+            assert(38);
+    }
+
+
+    static if (true)
+        assert(39);
+    else static if (true)
+        assert(40);
+    else
+        assert(41);
+
+    switch (4) {
+        case 0:
+            if (true)
+                assert(42);
+            else
+                assert(43);
+            break;
+        case 1: .. case 5:
+            if (true)
+                assert(44);
+            else
+                assert(45);
+            break;
+        default:
+            if (true)
+                assert(46);
+            else
+                assert(47);
+            break;
+    }
+
+    // (o_O)
+    switch (1)
+        default:
+            if (true)
+                assert(113);
+            else
+                assert(114);
+
+    // (o_O)
+    final switch (1)
+        case 1:
+            if (true)
+                assert(117);
+            else
+                assert(118);
+
+    mixin(q{
+        if (true)
+            assert(56);
+        else
+            assert(57);
+    });
+
+
+
+    while (false)
+        if (true)
+            assert(66);
+        else
+            assert(67);
+
+
+    if (true)
+        while (false)
+            assert(68);
+    else
+        assert(69);
+
+
+    do
+        if (true)
+            assert(72);
+        else
+            assert(73);
+    while (false);
+
+
+    if (true)
+        do
+            if (true)
+                assert(74);
+            else
+                assert(75);
+        while (false);
+
+    for (
+        if (true)        // (o_O)
+            assert(78);
+        else
+            assert(79);
+        false; false
+    )
+        if (true)
+            assert(80);
+        else
+            assert(81);
+
+    if (true)
+        for (if (true) assert(84); else assert(85); false;)
+            assert(86);
+
+
+    if (true)
+        if (true)
+            if (true)
+                if (true)
+                    if (true)
+                        assert(87);
+
+    auto x = new C;
+
+
+    if (true)
+        while (false)
+            for (;;)
+                scope (exit)
+                    synchronized (x)
+                        assert(88);
+    else
+        assert(89);
+
+
+    if (true)
+        while (false)
+            for (;;) {
+                scope (exit)
+                    synchronized (x)
+                        if (true)
+                            assert(90);
+                        else
+                            assert(89);
+            }
+
+
+    if (true)
+        while (false)
+            for (;;)
+                scope (exit)
+                    synchronized (x)
+                        if (true)
+                            assert(90);
+                        else
+                            assert(89);
+    else
+        assert(12); 
+
+
+    with (x)
+        if (false)
+            assert(92);
+        else
+            assert(93);
+
+
+    try
+        if (true)
+            assert(94);
+        else
+            assert(95);
+    catch (Exception e)
+        if (true)
+            assert(96);
+        else
+            assert(97);
+    finally
+        if (true)
+            assert(98);
+        else
+            assert(99);
+
+
+    if (true)
+        try
+            if (true)
+                assert(100);
+            else
+                assert(101);
+        finally
+            assert(102);
+
+    if (true)
+        try
+            assert(109);
+        catch(Exception e)
+            if (true)
+                assert(110);
+            else
+                assert(112);                
+        finally
+            assert(111);
+
+    static struct F {
+        static if (true)
+            int x;
+        else
+            int y;
+
+        static if (true) {
+            static if (false)
+                int z;
+        } else
+            int w;
+
+        static if (true)
+            int t; 
+        else static if (false)
+            int u;
+        else
+            int v;
+    }
+
+    if (true)
+        if (true)
+            assert(113);
+        else
+            assert(114);
+    else
+        assert(115);
+
+    static if (true)
+        static if (true)
+            assert(116);
+        else
+            assert(117);
+    else
+        assert(118);
+
+}
+
+unittest {
+    if (true)
+        assert(50);
+    else
+        assert(51);
+}
+
+class C {
+    invariant() {
+        if (true)
+            assert(58);
+        else
+            assert(59);
+    }
+
+    int f()
+    in {
+        if (true)
+            assert(60);
+        else
+            assert(61);
+    }
+    out(res) {
+        if (true)
+            assert(62);
+        else
+            assert(63);
+    }
+    body {
+        if (true)
+            assert(64);
+        else
+            assert(65);
+        return 0;
+    }
+}
+
+enum q = q{
+    if(true)
+        if(true)
+            assert(54.1);
+    else
+        assert(55.2);
+};
+
+static if (true)
+    struct F0 {}
+else static if (true)
+    struct F1 {}
+else
+    struct F2 {}
+
+static if (true) {
+    static if (false)
+        struct F3 {}
+} else
+    struct F4 {}
+
+version(A) {
+    version(B)
+        struct F5 {}
+} else
+    struct F6 {}
+
+version(A) {
+    version(B)
+        struct F5a {}
+    else
+        struct F5b {}
+}
+
+version (C)
+    struct F5c {}
+else
+    struct F5d {}
+
+struct F7 {
+    static if (true)
+        int x;
+    else
+        float x;
+
+private:
+    static if (true)
+        int y;
+    else
+        float y;
+}
+
+template F8() {
+    static if (true)
+        int x;
+    else
+        float x;
+}
+
+static if (true)
+    align(1)
+        static if (false)
+            struct F9 {}
+
+static if (true)
+    align(1) {
+        extern(C)
+            pure
+                static if (false)
+                    void F10(){}
+                else
+                    void F11(){}
+    }
+
+
+void f() {
+    int[] x;
+    static if (5 > 0)
+        version (Y)
+            scope (failure)
+                foreach (i, e; x)
+                    while (i > 20)
+                        with (e)
+                            if (e < 0)
+                                synchronized(e)
+                                    assert(1);
+                            else
+                                assert(2);
+        else
+            x = null;
+    else
+        x = null;
+}
+

--- a/test/fail_compilation/fail4375a.d
+++ b/test/fail_compilation/fail4375a.d
@@ -1,0 +1,10 @@
+// 4375: Dangling else
+
+void main() {
+	if (true)
+		if (false)
+			assert(3);
+    else
+        assert(4);
+}
+

--- a/test/fail_compilation/fail4375b.d
+++ b/test/fail_compilation/fail4375b.d
@@ -1,0 +1,12 @@
+// 4375: Dangling else
+
+void main() {
+    // disallowed
+	if (true)
+		foreach (i; 0 .. 5)
+			if (true)
+				assert(5);
+    else
+        assert(6);
+}
+

--- a/test/fail_compilation/fail4375c.d
+++ b/test/fail_compilation/fail4375c.d
@@ -1,0 +1,12 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+        if (false) {
+            assert(6.1);
+        }
+    else {
+        assert(6.2);
+    }
+}
+

--- a/test/fail_compilation/fail4375d.d
+++ b/test/fail_compilation/fail4375d.d
@@ -1,0 +1,11 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+label2:
+        if (true)
+            assert(15);
+    else 
+        assert(16);
+}
+

--- a/test/fail_compilation/fail4375e.d
+++ b/test/fail_compilation/fail4375e.d
@@ -1,0 +1,10 @@
+// 4375: Dangling else
+
+void main() {
+    version (A)
+        if (true)
+            assert(24);
+    else
+        assert(25);
+}
+

--- a/test/fail_compilation/fail4375f.d
+++ b/test/fail_compilation/fail4375f.d
@@ -1,0 +1,10 @@
+// 4375: Dangling else
+
+void main() {
+    version (A)
+        version (B)
+            assert(25.1);
+    else
+        assert(25.2);
+}
+

--- a/test/fail_compilation/fail4375g.d
+++ b/test/fail_compilation/fail4375g.d
@@ -1,0 +1,10 @@
+// 4375: Dangling else
+
+void main() {
+    static if (true)
+        static if (true)
+            assert(33);
+    else
+        assert(34);
+}
+

--- a/test/fail_compilation/fail4375h.d
+++ b/test/fail_compilation/fail4375h.d
@@ -1,0 +1,14 @@
+// 4375: Dangling else
+
+void main() {
+    switch (4) {
+        default:
+            if (true)   // disallowed
+                if (false)
+                    assert(48);
+            else
+                assert(49);
+            break;
+    }
+}
+

--- a/test/fail_compilation/fail4375i.d
+++ b/test/fail_compilation/fail4375i.d
@@ -1,0 +1,12 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+        switch (1)  // o_O
+            default:
+                if (false)
+                    assert(115);
+    else
+        assert(116);
+}
+

--- a/test/fail_compilation/fail4375j.d
+++ b/test/fail_compilation/fail4375j.d
@@ -1,0 +1,12 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+        final switch (1)    // o_O
+            case 1:
+                if (false)
+                    assert(119);
+    else
+        assert(120);
+}
+

--- a/test/fail_compilation/fail4375k.d
+++ b/test/fail_compilation/fail4375k.d
@@ -1,0 +1,12 @@
+// 4375: Dangling else
+
+void main() {
+    mixin(q{
+        if(true)
+            if(true)
+                assert(54);
+        else
+            assert(55);
+    });
+}
+

--- a/test/fail_compilation/fail4375l.d
+++ b/test/fail_compilation/fail4375l.d
@@ -1,0 +1,11 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+        while (false)
+            if (true)
+                assert(70);
+    else
+        assert(71);
+}
+

--- a/test/fail_compilation/fail4375m.d
+++ b/test/fail_compilation/fail4375m.d
@@ -1,0 +1,12 @@
+// 4375: Dangling else
+
+void main() {
+    do
+        if (true)
+            if (true)
+                assert(76);
+        else
+            assert(77);
+    while (false);
+}
+

--- a/test/fail_compilation/fail4375o.d
+++ b/test/fail_compilation/fail4375o.d
@@ -1,0 +1,11 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+        for (; false;)
+            if (true)
+                assert(82);
+    else
+        assert(83);
+}
+

--- a/test/fail_compilation/fail4375p.d
+++ b/test/fail_compilation/fail4375p.d
@@ -1,0 +1,14 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+        while (false)
+            for (;;)
+                scope (exit)
+                    synchronized (x)
+                        if (true)
+                            assert(90);
+    else
+        assert(89);
+}
+

--- a/test/fail_compilation/fail4375q.d
+++ b/test/fail_compilation/fail4375q.d
@@ -1,0 +1,12 @@
+// 4375: Dangling else
+
+void main() {
+    auto x = 1;
+    if (true)
+        with (x)
+            if (false)
+                assert(90);
+    else
+        assert(91);
+}
+

--- a/test/fail_compilation/fail4375r.d
+++ b/test/fail_compilation/fail4375r.d
@@ -1,0 +1,13 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+        try
+            assert(103);
+        finally
+            if (true)
+                assert(104);
+    else
+        assert(105);
+}
+

--- a/test/fail_compilation/fail4375s.d
+++ b/test/fail_compilation/fail4375s.d
@@ -1,0 +1,13 @@
+// 4375: Dangling else
+
+void main() {
+    if (true)
+        try
+            assert(106);
+        catch(Exception e)
+            if (true)
+                assert(107);
+    else
+        assert(108);
+}
+

--- a/test/fail_compilation/fail4375t.d
+++ b/test/fail_compilation/fail4375t.d
@@ -1,0 +1,10 @@
+// 4375: Dangling else
+
+unittest {  // disallowed
+    if (true)
+        if (false)
+            assert(52);
+    else
+        assert(53);
+}
+

--- a/test/fail_compilation/fail4375u.d
+++ b/test/fail_compilation/fail4375u.d
@@ -1,0 +1,8 @@
+// 4375: Dangling else
+
+static if (true)
+    static if (false)
+        struct G1 {}
+else
+    struct G2 {}
+

--- a/test/fail_compilation/fail4375v.d
+++ b/test/fail_compilation/fail4375v.d
@@ -1,0 +1,8 @@
+// 4375: Dangling else
+
+version (A)
+    version (B)
+        struct G3 {}
+else
+    struct G4 {}
+

--- a/test/fail_compilation/fail4375w.d
+++ b/test/fail_compilation/fail4375w.d
@@ -1,0 +1,8 @@
+// 4375: Dangling else
+
+static if (true)
+    version (B)
+        struct G1 {}
+else
+    struct G2 {}
+

--- a/test/fail_compilation/fail4375x.d
+++ b/test/fail_compilation/fail4375x.d
@@ -1,0 +1,9 @@
+// 4375: Dangling else
+
+static if (true)
+abstract:
+    static if (false)
+        class G5 {}
+else
+    class G6 {}
+

--- a/test/fail_compilation/fail4375y.d
+++ b/test/fail_compilation/fail4375y.d
@@ -1,0 +1,11 @@
+// 4375: Dangling else
+
+static if (true)
+    align(1)
+        extern(C)
+            pure
+                static if (false)
+                    void G10(){}
+else
+    void G11(){}
+


### PR DESCRIPTION
Implements [bug 4375: Require explicit braces when 'else' is ambiguous](http://d.puremagic.com/issues/show_bug.cgi?id=4375). See the enormous test cases for what are allowed and what are not, but basically:

``` d
if (x)
   if (y)
      foo();    // allowed


if (x)
   if (y)       // NOT allowed
      foo();
   else
      bar();


if (x)         // allowed (because some important Phobos module uses this)
   if (y)
      foo();
   else
      bar();
else
   baz();


if (useThisFeature)    // allowed 
foreach (x; 0 .. 100)
foreach (y; 0 .. 100)
if (blah_blah_long_thing)
if (simple_unrelated_condition)
if (hell_maybe_even_another)
  statement();


if (x)         // NOT allowed
  for (;;)
    if (y)
      break;
else
  foo();
```

This changes `parse.c`, but the grammar isn't really changed. It is just that, when this parser recognizes some particular form that resemble a dangling else, an error would be emitted. I don't think a pure grammar-based solution could catch "if / if / else" but ignore "if / if / else / else".

I have implemented it as an error, this maybe this should be a warning.
