### PR TITLE
Issue 2941 - Wrong code for inline asm because CPU type is set too late

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -43,7 +43,6 @@ struct Environment;
 
 Environment *benv;
 
-void out_config_init();
 void slist_add(Symbol *s);
 void slist_reset();
 void clearStringTab();
@@ -153,8 +152,6 @@ Outbuffer objbuf;
 void obj_start(char *srcfile)
 {
     //printf("obj_start()\n");
-
-    out_config_init();
 
     rtlsym_reset();
     slist_reset();

--- a/src/msc.c
+++ b/src/msc.c
@@ -399,6 +399,8 @@ void backend_init()
     }
 
     rtlsym_init(); // uses fregsaved, so must be after it's set inside cod3_set*
+
+    out_config_init();
 }
 
 void backend_term()

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -4766,6 +4766,32 @@ L1:     pop     RAX;
     }
 }
 
+void test2941()
+{
+    ubyte *p;
+    static ubyte data[] =
+    [
+        0x9B, 0xDF, 0xE0,	// fstsw AX;
+    ];
+    int i;
+
+    asm
+    {
+        call	L1			;
+
+        fstsw AX;
+
+L1:
+        pop	RBX			;
+        mov	p[RBP],RBX		;
+    }
+    for (i = 0; i < data.length; i++)
+    {
+        assert(p[i] == data[i]);
+    }
+}
+
+/****************************************************/
 /****************************************************/
 
 int main()
@@ -4830,6 +4856,7 @@ int main()
     test57();
     test58();
     test59();
+    test2941();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Move out_config_init to be run after arg parsing, into backend_init.
Side effect: configuration is only done once rather than once per module.
Side effect2: configuration is done before semantic analysis, specifically before iasm, which depends on config.target_cpu.
