### PR TITLE
Fix build error due to missing argument to a parseBlock() in #336.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3486,7 +3486,7 @@ Statement *Parser::parseStatement(int flags, Loc *containsElse)
             if (t->value == TOKstruct || t->value == TOKunion || t->value == TOKclass)
             {
                 nextToken();
-                Dsymbols *a = parseBlock();
+                Dsymbols *a = parseBlock(NULL);
                 Dsymbol *d = new StorageClassDeclaration(STCstatic, a);
                 s = new ExpStatement(loc, d);
                 if (flags & PSscope)


### PR DESCRIPTION
Fix build error due to missing argument to a parseBlock() in #336.
