### PR TITLE
Issue 6365 - Multiple var declaration (AutoTupleDeclaration)

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1010,46 +1010,6 @@ void VarDeclaration::semantic(Scope *sc)
                     iexps->insert(pos, te->exps);
                     goto Lexpand1;
                 }
-                else if (e->op == TOKarrayliteral)
-                {
-                    ArrayLiteralExp *ae = (ArrayLiteralExp *)e;
-                    if (iexps->dim - 1 + ae->elements->dim > nelems)
-                        goto Lnomatch;
-
-                    iexps->remove(pos);
-                    iexps->insert(pos, ae->elements);
-                    goto Lexpand1;
-                }
-                else if (e->type->ty == Tsarray)
-                {
-                    TypeSArray *tsa = (TypeSArray *)e->type;
-                    uinteger_t length = tsa->dim->toInteger();
-                    if (iexps->dim - 1 + length > nelems)
-                        goto Lnomatch;
-
-                    Identifier *id = Lexer::uniqueId("__sarr");
-                    ExpInitializer *ei = new ExpInitializer(e->loc, e);
-                    VarDeclaration *v = new VarDeclaration(loc, NULL, id, ei);
-                    v->storage_class = STCctfe | STCref | STCforeach;
-                    Expression *ve = new VarExp(loc, v);
-                    ve->type = e->type;
-
-                    exps = new Expressions();
-                    exps->setDim(length);
-                    for (size_t u = 0; u < length; u++)
-                    {
-                        Expression *e = new IndexExp(loc, ve, new IntegerExp(u));
-                        e->type = tsa->nextOf();
-                        exps->tdata()[u] = e;
-                    }
-                    Expression *e0 = exps->tdata()[0];
-                    exps->tdata()[0] = new CommaExp(loc, new DeclarationExp(loc, v), e0);
-                    exps->tdata()[0]->type = e0->type;
-
-                    iexps->remove(pos);
-                    iexps->insert(pos, exps);
-                    goto Lexpand1;
-                }
                 else if (isAliasThisTuple(e))
                 {
                     Identifier *id = Lexer::uniqueId("__tup");

--- a/src/doc.c
+++ b/src/doc.c
@@ -109,7 +109,7 @@ int isIdTail(unsigned char *p);
 int isIndentWS(unsigned char *p);
 int utfStride(unsigned char *p);
 
-static unsigned char ddoc_default[] = "\
+static const char ddoc_default[] = "\
 DDOC =  <html><head>\n\
         <META http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n\
         <title>$(TITLE)</title>\n\
@@ -200,11 +200,11 @@ ESCAPES = /</&lt;/\n\
           /&/&amp;/\n\
 ";
 
-static char ddoc_decl_s[] = "$(DDOC_DECL ";
-static char ddoc_decl_e[] = ")\n";
+static const char ddoc_decl_s[] = "$(DDOC_DECL ";
+static const char ddoc_decl_e[] = ")\n";
 
-static char ddoc_decl_dd_s[] = "$(DDOC_DECL_DD ";
-static char ddoc_decl_dd_e[] = ")\n";
+static const char ddoc_decl_dd_s[] = "$(DDOC_DECL_DD ";
+static const char ddoc_decl_dd_e[] = ")\n";
 
 
 /****************************************************

--- a/src/glue.c
+++ b/src/glue.c
@@ -36,10 +36,6 @@
 #include "outbuf.h"
 #include "irstate.h"
 
-struct Environment;
-
-Environment *benv;
-
 void slist_add(Symbol *s);
 void slist_reset();
 void clearStringTab();

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -307,6 +307,7 @@ Msgtable msgtable[] =
     { "isAssociativeArray" },
     { "isFinalClass" },
     { "isPOD" },
+    { "isNested" },
     { "isFloating" },
     { "isIntegral" },
     { "isScalar" },

--- a/src/json.c
+++ b/src/json.c
@@ -68,7 +68,6 @@ struct JsonOut
     void property(const char *name, Type* type);
     void property(const char *name, const char *deconame, Type* type);
     void property(const char *name, Parameters* parameters);
-    void property(const char *name, Expressions* expressions);
     void property(const char *name, enum TRUST trust);
     void property(const char *name, enum PURE purity);
     void property(const char *name, enum LINK linkage);

--- a/src/mars.c
+++ b/src/mars.c
@@ -96,7 +96,7 @@ Global::Global()
 #include "verstr.h"
     ;
 
-    global.structalign = STRUCTALIGN_DEFAULT;
+    structalign = STRUCTALIGN_DEFAULT;
 
     memset(&params, 0, sizeof(Param));
 }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8189,11 +8189,14 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
     //    return defaultInit(loc);
     Expressions *structelems = new Expressions();
     structelems->setDim(sym->fields.dim - sym->isnested);
+    unsigned offset = 0;
     for (size_t j = 0; j < structelems->dim; j++)
     {
         VarDeclaration *vd = sym->fields[j];
         Expression *e;
-        if (vd->init)
+        if (vd->offset < offset)
+            e = NULL;
+        else if (vd->init)
         {   if (vd->init->isVoidInitializer())
                 e = NULL;
             else
@@ -8218,6 +8221,7 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
 
             e = e->implicitCastTo(vd->scope, telem);
         }
+        offset = vd->offset + vd->type->size();
         (*structelems)[j] = e;
     }
     StructLiteralExp *structinit = new StructLiteralExp(loc, (StructDeclaration *)sym, structelems);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -187,7 +187,6 @@ void Type::init()
     mangleChar[Ttypedef] = 'T';
     mangleChar[Tdelegate] = 'D';
 
-    mangleChar[Tnone] = 'n';
     mangleChar[Tvoid] = 'v';
     mangleChar[Tint8] = 'g';
     mangleChar[Tuns8] = 'h';
@@ -223,8 +222,9 @@ void Type::init()
     mangleChar[Tvector] = '@';
     mangleChar[Tint128] = '@';
     mangleChar[Tuns128] = '@';
+    mangleChar[Tnone] = '@';
 
-    mangleChar[Tnull] = 'n';    // same as TypeNone
+    mangleChar[Tnull] = 'n';
 
     for (size_t i = 0; i < TMAX; i++)
     {   if (!mangleChar[i])
@@ -248,6 +248,9 @@ void Type::init()
         basic[basetab[i]] = t;
     }
     basic[Terror] = new TypeError();
+
+    tnone = new TypeNone();
+    tnone->deco = tnone->merge()->deco;
 
     tnull = new TypeNull();
     tnull->deco = tnull->merge()->deco;
@@ -2257,6 +2260,23 @@ uinteger_t Type::sizemask()
                 assert(0);
     }
     return m;
+}
+
+/* ============================= TypeNone =========================== */
+
+TypeNone::TypeNone()
+        : Type(Tnone)
+{
+}
+
+Type *TypeNone::syntaxCopy()
+{
+    return this;
+}
+
+void TypeNone::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
+{
+    buf->writestring("_none_");
 }
 
 /* ============================= TypeError =========================== */

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -182,6 +182,7 @@ struct Type : Object
     static Type *tvoidptr;              // void*
     static Type *tstring;               // immutable(char)[]
     static Type *tvalist;               // va_list alias
+    #define tnone       basic[Tnone]    // for type inference
     #define terror      basic[Terror]   // for error recovery
 
     #define tnull       basic[Tnull]    // for null type
@@ -343,6 +344,14 @@ struct Type : Object
 
     // For eliminating dynamic_cast
     virtual TypeBasic *isTypeBasic();
+};
+
+struct TypeNone : Type
+{
+    TypeNone();
+
+    Type *syntaxCopy();
+    void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
 };
 
 struct TypeError : Type

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -801,19 +801,19 @@ Expression *shift_optimize(int result, BinExp *e, Expression *(*shift)(Type *, E
 Expression *ShlExp::optimize(int result, bool keepLvalue)
 {
     //printf("ShlExp::optimize(result = %d) %s\n", result, toChars());
-    return shift_optimize(result, this, Shl);
+    return shift_optimize(result, this, &Shl);
 }
 
 Expression *ShrExp::optimize(int result, bool keepLvalue)
 {
     //printf("ShrExp::optimize(result = %d) %s\n", result, toChars());
-    return shift_optimize(result, this, Shr);
+    return shift_optimize(result, this, &Shr);
 }
 
 Expression *UshrExp::optimize(int result, bool keepLvalue)
 {
     //printf("UshrExp::optimize(result = %d) %s\n", result, toChars());
-    return shift_optimize(result, this, Ushr);
+    return shift_optimize(result, this, &Ushr);
 }
 
 Expression *AndExp::optimize(int result, bool keepLvalue)

--- a/src/parse.c
+++ b/src/parse.c
@@ -63,6 +63,7 @@ Parser::Parser(Module *module, unsigned char *base, size_t length, int doDocComm
     linkage = LINKd;
     endloc = 0;
     inBrackets = 0;
+    inStatements = 0;
     lookingForElse = 0;
     //nextToken();              // start up the scanner
 }
@@ -153,6 +154,8 @@ Dsymbols *Parser::parseDeclDefs(int once)
     StorageClass storageClass;
     Condition *condition;
     unsigned char *comment;
+
+    inStatements = 0;
 
     //printf("Parser::parseDeclDefs()\n");
     decldefs = new Dsymbols();
@@ -3687,6 +3690,8 @@ Statement *Parser::parseStatement(int flags)
     bool isfinal;
     Loc loc = this->loc;
 
+    inStatements = 1;
+
     //printf("parseStatement()\n");
 
     if (flags & PScurly && token.value != TOKlcurly)
@@ -4703,6 +4708,8 @@ Statement *Parser::parseStatement(int flags)
             s = NULL;
             break;
     }
+
+    inStatements = 0;
 
     return s;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -5088,7 +5088,13 @@ int Parser::isDeclarator(Token **pt, int *haveId, enum TOK endtok)
 }
 
 
-int Parser::isParameters(Token **pt)
+/************************************
+ * Input:
+ *      needId  0       no identifier
+ *              1       identifier optional
+ *              2       must have identifier
+ */
+int Parser::isParameters(Token **pt, int needId)
 {   // This code parallels parseParameters()
     Token *t = *pt;
 
@@ -5156,10 +5162,19 @@ int Parser::isParameters(Token **pt)
             {   if (!isBasicType(&t))
                     return FALSE;
             L2:
-                int tmp = FALSE;
+                int haveId = 0;
                 if (t->value != TOKdotdotdot &&
-                    !isDeclarator(&t, &tmp, TOKreserved))
+                    !isDeclarator(&t, &haveId, TOKreserved))
                     return FALSE;
+
+                if ( needId == 1 ||
+                    (needId == 0 && !haveId) ||
+                    (needId == 2 &&  haveId))
+                {
+                }
+                else
+                    return FALSE;
+
                 if (t->value == TOKassign)
                 {   t = peek(t);
                     if (!isExpression(&t))

--- a/src/parse.h
+++ b/src/parse.h
@@ -66,6 +66,7 @@ struct Parser : Lexer
     enum LINK linkage;
     Loc endloc;                 // set to location of last right curly
     int inBrackets;             // inside [] of array index or slice
+    int inStatements;           // inside runnable code
     Loc lookingForElse;         // location of lonely if looking for an else
 
     Parser(Module *module, unsigned char *base, size_t length, int doDocComment);

--- a/src/parse.h
+++ b/src/parse.h
@@ -124,7 +124,7 @@ struct Parser : Lexer
     int isDeclaration(Token *t, int needId, enum TOK endtok, Token **pt);
     int isBasicType(Token **pt);
     int isDeclarator(Token **pt, int *haveId, enum TOK endtok);
-    int isParameters(Token **pt);
+    int isParameters(Token **pt, int needId = 1);
     int isExpression(Token **pt);
     int skipParens(Token *t, Token **pt);
     int skipAttributes(Token *t, Token **pt);

--- a/src/parse.h
+++ b/src/parse.h
@@ -74,6 +74,7 @@ struct Parser : Lexer
     Dsymbols *parseModule();
     Dsymbols *parseDeclDefs(int once);
     Dsymbols *parseAutoDeclarations(StorageClass storageClass, unsigned char *comment);
+    Dsymbols *parseMultiVarDeclaration(StorageClass storageClass, unsigned char *comment);
     Dsymbols *parseBlock();
     void composeStorageClass(StorageClass stc);
     StorageClass parseAttribute(Expressions **pexps);

--- a/src/traits.c
+++ b/src/traits.c
@@ -379,7 +379,7 @@ Expression *TraitsExp::semantic(Scope *sc)
             p.exps = exps;
             p.e1 = e;
             p.ident = ident;
-            overloadApply(f, fptraits, &p);
+            overloadApply(f, &fptraits, &p);
 
             TupleExp *tup = new TupleExp(loc, exps);
             return tup->semantic(sc);

--- a/src/traits.c
+++ b/src/traits.c
@@ -168,6 +168,34 @@ Expression *TraitsExp::semantic(Scope *sc)
         }
         goto Ltrue;
     }
+    else if (ident == Id::isNested)
+    {
+        if (dim != 1)
+            goto Ldimerror;
+        Object *o = (*args)[0];
+        Dsymbol *s = getDsymbol(o);
+        AggregateDeclaration *a;
+        FuncDeclaration *f;
+
+        if (!s) { }
+        else if ((a = s->isAggregateDeclaration()) != NULL)
+        {
+            if (a->isnested)
+                goto Ltrue;
+            else
+                goto Lfalse;
+        }
+        else if ((f = s->isFuncDeclaration()) != NULL)
+        {
+            if (f->isNested())
+                goto Ltrue;
+            else
+                goto Lfalse;
+        }
+
+        error("aggregate or function expected instead of '%s'", o->toChars());
+        goto Lfalse;
+    }
     else if (ident == Id::isAbstractFunction)
     {
         FuncDeclaration *f;

--- a/test/runnable/multivar.d
+++ b/test/runnable/multivar.d
@@ -59,14 +59,14 @@ void test1()
 
 void test2()
 {
-    auto (n, m) = [1,2];
-    assert(n == 1);
-    assert(m == 2);
+    //auto (n, m) = [1,2];
+    //assert(n == 1);
+    //assert(m == 2);
 
-    int[2] sa = [1,2];
-    auto (x, y) = sa;
-    assert(x == 1);
-    assert(y == 2);
+    //int[2] sa = [1,2];
+    //auto (x, y) = sa;
+    //assert(x == 1);
+    //assert(y == 2);
 }
 
 /**********************************************/
@@ -130,8 +130,8 @@ void test5()
     (auto a2) = t[0..1];
     assert(a2 == 10);
 
-    auto (x1) = [10];
-    assert(x1 == 10);
+    //auto (x1) = [10];
+    //assert(x1 == 10);
 
     (auto x2) = tup(10);
     assert(x2 == 10);

--- a/test/runnable/multivar.d
+++ b/test/runnable/multivar.d
@@ -1,0 +1,218 @@
+
+extern (C) int printf(const(char*) fmt, ...);
+
+struct Tup(T...)
+{
+    T field;
+    alias field this;
+
+    bool opEquals()(auto ref Tup rhs) const
+    {
+        foreach (i, _; T)
+            if (field[i] != rhs.field[i])
+                return false;
+        return true;
+    }
+}
+
+Tup!T tup(T...)(T fields)
+{
+    return typeof(return)(fields);
+}
+
+template Seq(T...)
+{
+    alias T Seq;
+}
+
+/**********************************************/
+
+void test1()
+{
+    auto (num, str) = Seq!(10, "str");
+    assert(num == 10);
+    assert(str == "str");
+
+    int eval = 0;
+    auto (n, t) = (eval++, tup(10, tup("str", [1,2])));
+    assert(eval == 1);
+    assert(n == 10);
+    eval = 0;
+    auto (s, a) = (eval++, t);
+    assert(eval == 1);
+    assert(s == "str");
+    assert(a == [1,2]);
+
+    auto (i, j) = 10;
+    assert(i == 10);
+    assert(j == 10);
+
+    auto (t1, t2) = tup(1, "str", [1,2]);
+    assert(t1 == tup(1, "str", [1,2]));
+    assert(t2 == tup(1, "str", [1,2]));
+
+    auto (x) = 1;
+    assert(x == 1);
+}
+
+/**********************************************/
+
+void test2()
+{
+    auto (n, m) = [1,2];
+    assert(n == 1);
+    assert(m == 2);
+
+    int[2] sa = [1,2];
+    auto (x, y) = sa;
+    assert(x == 1);
+    assert(y == 2);
+}
+
+/**********************************************/
+
+void test3()
+{
+    alias tup tuple;
+    alias Seq TypeTuple;
+
+    // Example of 1
+    {
+        auto (i, j) = tuple(10, "a");
+        static assert(is(typeof(i) == int));
+        static assert(is(typeof(j) == string));
+
+        const (x, y) = TypeTuple!(1, 2);
+        static assert(is(typeof(x) == const(int)));
+        static assert(is(typeof(y) == const(int)));
+    }
+
+    {
+        // Example of 2-1
+        (int i, string j) = tuple(10, "a");
+        static assert(is(typeof(i) == int));
+        static assert(is(typeof(j) == string));
+
+        // Example of 2-2
+        (auto c, r) = TypeTuple!('c', "har");
+        static assert(is(typeof(c) == char));
+        static assert(is(typeof(r) == string));
+
+        (const x, auto y) = TypeTuple!(1, 2);
+        static assert(is(typeof(x) == const(int)));
+        static assert(is(typeof(y) == int));
+
+        (auto a1, const int[] a2) = TypeTuple!([1], [2,3]);
+        static assert(is(typeof(a1) == int[]));
+        static assert(is(typeof(a2) == const(int[])));
+    }
+}
+
+/**********************************************/
+
+void test4()
+{
+    auto (x, y, z) = Seq!(10, tup("a", [1,2]));
+    assert(x == 10);
+    assert(y == "a");
+    assert(z == [1,2]);
+}
+
+/**********************************************/
+
+void test5()
+{
+    auto t = tup(10, "a");
+
+    auto (a1) = t[0..1];
+    assert(a1 == 10);
+
+    (auto a2) = t[0..1];
+    assert(a2 == 10);
+
+    auto (x1) = [10];
+    assert(x1 == 10);
+
+    (auto x2) = tup(10);
+    assert(x2 == 10);
+
+    (auto x3) = tup(10)[0..1];
+    assert(x3 == 10);
+
+    (int x4) = Seq!(10);
+    assert(x4 == 10);
+
+    // isolated comma parsing
+    (int n,) = tup(10);
+    assert(n == 10);
+
+    auto (x, y,) = tup(10, 20);
+    assert(x == 10);
+    assert(y == 20);
+}
+
+/**********************************************/
+
+void test6()
+{
+    const(int x, string y) = tup(10, "a");
+    static assert(is(typeof(x) == const(int)));
+    static assert(is(typeof(y) == const(string)));
+    assert(x == 10);
+    assert(y == "a");
+
+    (int i, double j, string k) = tup(tup(10, 2.2), "a");
+    static assert(is(typeof(i) == int));
+    static assert(is(typeof(j) == double));
+    static assert(is(typeof(k) == string));
+    assert(i == 10);
+    assert(j == 2.2);
+    assert(k == "a");
+}
+
+/**********************************************/
+
+Tup!(int, string) func7(){ return tup(10, "str"); }
+
+auto (num71, str71) = func7();
+const (num72, str72) = Seq!(10, "str");
+
+enum (num73, str73) = func7();
+
+void test7()
+{
+    assert(num71 == 10);
+    assert(str71 == "str");
+    num71 = 20;
+    str71 = "hello";
+
+    assert(num72 == 10);
+    assert(str72 == "str");
+    static assert(!__traits(compiles, num72 = 20));
+    static assert(!__traits(compiles, str72 = "hello"));
+    auto pnum72 = &num72;
+    auto pstr72 = &str72;
+
+    static assert(num73 == 10);
+    static assert(str73 == "str");
+    static assert(!__traits(compiles, num73 = 20));
+//  static assert(!__traits(compiles, str73 = "hello"));
+    static assert(!__traits(compiles, &num73));
+//  static assert(!__traits(compiles, &str73));
+}
+
+/**********************************************/
+
+int main()
+{
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+    test6();
+    test7();
+
+    printf("Success\n");
+    return 0;
+}

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -589,6 +589,24 @@ void test8763()
 }
 
 /********************************************/
+// 8902
+
+union U8902 { int a, b; }
+
+enum U8902 u8902a = U8902.init; // No errors
+U8902 u8902b;                   // No errors
+U8902 u8902c = U8902.init;      // Error: duplicate union initialization for b
+
+void test8902()
+{
+    U8902 u8902d = U8902.init;                  // No errors
+    immutable U8902 u8902e = U8902.init;        // No errors
+    immutable static U8902 u8902f = U8902.init; // Error: duplicate union...
+    static U8902 u8902g = u8902e;               // Error: duplicate union...
+    static U8902 u8902h = U8902.init;           // Error: duplicate union...
+}
+
+/********************************************/
 // 9116
 
 void test9116()
@@ -672,6 +690,7 @@ int main()
     test7929();
     test7021();
     test8763();
+    test8902();
     test9116();
     test9293();
     test9566();

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1043,6 +1043,35 @@ void test9552()
 
 /*************************************************************/
 
+void test9136()
+{
+    int x;
+    struct S1 { void f() { x++; } }
+    struct U1 { void f() { x++; } }
+    static struct S2 { }
+    static struct S3 { S1 s; }
+    static struct U2 { }
+    void f1() { x++; }
+    static void f2() { }
+
+    static assert(__traits(isNested, S1));
+    static assert(__traits(isNested, U1));
+    static assert(!__traits(isNested, S2));
+    static assert(!__traits(isNested, S3));
+    static assert(!__traits(isNested, U2));
+    static assert(!__traits(compiles, __traits(isNested, int) ));
+    static assert(!__traits(compiles, __traits(isNested, f1, f2) ));
+    static assert(__traits(isNested, f1));
+    static assert(!__traits(isNested, f2));
+
+    static class A { static class SC { } class NC { } }
+    static assert(!__traits(isNested, A));
+    static assert(!__traits(isNested, A.SC));
+    static assert(__traits(isNested, A.NC));
+}
+
+/********************************************************/
+
 int main()
 {
     test1();
@@ -1075,6 +1104,7 @@ int main()
     test5978();
     test7408();
     test9552();
+    test9136();
 
     writeln("Success");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6365

Based on #321, declare multiple variables at once, and initialize them in the corresponding tuple fields.

Syntax:

<pre>
TupleDeclaration:
    <a href="http://d-programming-language.org/declaration.html#StorageClasses">StorageClasses</a> <b>(</b> TupleTypeList <b>)</b> <b>=</b> <a href="http://d-programming-language.org/declaration.html#Initializer">Initializer</a> <b>;</b>
    <b>(</b> TupleTypeList <b>)</b> <b>=</b> <a href="http://d-programming-language.org/declaration.html#Initializer">Initializer</a> <b>;</b>

TupleTypeList:
    TupleType
    TupleType <b>,</b> TupleTypeList

TupleType:
    <a href="http://d-programming-language.org/declaration.html#StorageClasses">StorageClasses</a> <a href="http://d-programming-language.org/declaration.html#BasicType">BasicType</a> <a href="http://d-programming-language.org/declaration.html#Declarator">Declarator</a>
    <a href="http://d-programming-language.org/declaration.html#BasicType">BasicType</a> <a href="http://d-programming-language.org/declaration.html#Declarator">Declarator</a>
    <a href="http://d-programming-language.org/declaration.html#StorageClasses">StorageClasses</a> Identifier
    Identifier
</pre>


TupleTypeList is similar to <a href="http://d-programming-language.org/statement.html#ForeachTypeList">ForeachTypeList</a>.

If you want to write left parenthesis at beginning, you cannot omit the type or storage class of first variable.

<pre>
(x, y) = getCoordinate();  // NG, this is not multiple var declaration
(auto x, y) = getCoordinate();  // OK
(double x, y) = getCoordinate();  // OK, types are specified explicitly
</pre>
