### PR TITLE
Issue 5432 - Allow variable declaration inside while condition

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3635,14 +3635,45 @@ Statement *Parser::parseStatement(int flags)
 
         case TOKwhile:
         {   Expression *condition;
+            Type *type = NULL;
+            Identifier *ident = NULL;
             Statement *body;
 
             nextToken();
             check(TOKlparen);
+
+            if (token.value == TOKauto)
+            {
+                nextToken();
+                if (token.value == TOKidentifier)
+                {
+                    Token *t = peek(&token);
+                    if (t->value == TOKassign)
+                    {
+                        ident = token.ident;
+                        nextToken();
+                        nextToken();
+                    }
+                    else
+                    {   error("= expected following auto identifier");
+                        goto Lerror;
+                    }
+                }
+                else
+                {   error("identifier expected following auto");
+                    goto Lerror;
+                }
+            }
+            else if (isDeclaration(&token, 2, TOKassign, NULL))
+            {
+                type = parseType(&ident);
+                check(TOKassign);
+            }
+
             condition = parseExpression();
             check(TOKrparen);
             body = parseStatement(PSscope);
-            s = new WhileStatement(loc, condition, body);
+            s = new WhileStatement(loc, type, ident, condition, body);
             break;
         }
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -266,8 +266,10 @@ struct WhileStatement : Statement
 {
     Expression *condition;
     Statement *body;
+    Type *type;
+    Identifier *ident;
 
-    WhileStatement(Loc loc, Expression *c, Statement *b);
+    WhileStatement(Loc loc, Type *t, Identifier *i, Expression *c, Statement *b);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     int hasBreak();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3348,6 +3348,34 @@ void test6230() {
 
 /***************************************************/
 
+void test5432()
+{
+    int x;
+    int getnext() { return x--; }
+
+    x = 5;
+    while(auto i = getnext())
+        assert(i == x + 1);
+    assert(x == -1);
+
+    x = 5;
+    while(int i = getnext())
+        assert(i == x + 1);
+    assert(x == -1);
+
+    x = 5;
+    while(long i = getnext())
+        assert(i == x + 1);
+    assert(x == -1);
+
+    x = 0;
+    while(long i = getnext())
+        assert(0);
+    assert(x == -1);
+}
+
+/***************************************************/
+
 void test6264()
 {
     struct S { auto opSlice() { return this; } }
@@ -3664,6 +3692,7 @@ int main()
     test143();
     test144();
     test145();
+    test5432();
     test146();
     test147();
     test148();


### PR DESCRIPTION
Implement two re-writes:
`while(auto var = exp) body` => `for(typeof(exp) var; var = exp ;) body`
`while(type var = exp) body` => `for(type var; var = exp;) body`

http://d.puremagic.com/issues/show_bug.cgi?id=5432
