### PR TITLE
Issue 5481 - Support deprecated("message")

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -52,6 +52,8 @@ struct AggregateDeclaration : ScopeDsymbol
                                 // 2: cannot determine size; fwd referenced
     Dsymbol *deferred;          // any deferred semantic2() or semantic3() symbol
     int isdeprecated;           // !=0 if deprecated
+    bool softDeprecated;
+    char *deprecatedMessage;
 
 #if DMDV2
     int isnested;               // !=0 if is nested

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -30,6 +30,8 @@ struct HdrGenState;
 struct AttribDeclaration : Dsymbol
 {
     Dsymbols *decl;     // array of Dsymbol's
+    bool softDeprecated;
+    char *deprecatedMessage;
 
     AttribDeclaration(Dsymbols *decl);
     virtual Dsymbols *include(Scope *sc, ScopeDsymbol *s);
@@ -180,6 +182,17 @@ struct CompileDeclaration : AttribDeclaration
     Dsymbol *syntaxCopy(Dsymbol *s);
     int addMember(Scope *sc, ScopeDsymbol *sd, int memnum);
     void compileIt(Scope *sc);
+    void semantic(Scope *sc);
+    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+};
+
+struct DeprecatedDeclaration : AttribDeclaration
+{
+    bool soft;
+    Expression *message;
+
+    DeprecatedDeclaration(Dsymbols *decl, Expression *message, bool soft);
+    Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 };

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -35,6 +35,8 @@ Declaration::Declaration(Identifier *id)
     linkage = LINKdefault;
     inuse = 0;
     sem = SemanticStart;
+    softDeprecated = false;
+    deprecatedMessage = NULL;
 }
 
 void Declaration::semantic(Scope *sc)

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -116,6 +116,8 @@ struct Declaration : Dsymbol
     enum PROT protection;
     enum LINK linkage;
     int inuse;                  // used to detect cycles
+    bool softDeprecated;
+    char *deprecatedMessage;
 
     enum Semantic sem;
 

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -31,6 +31,7 @@
 #include "import.h"
 #include "template.h"
 #include "attrib.h"
+#include "enum.h"
 
 /****************************** Dsymbol ******************************/
 
@@ -607,7 +608,29 @@ void Dsymbol::checkDeprecated(Loc loc, Scope *sc)
                 goto L1;
         }
 
-        error(loc, "is deprecated");
+        char *dmsg = NULL;
+        bool dsoft = false;
+        if (Declaration *d = isDeclaration())
+        {
+            dmsg = d->deprecatedMessage;
+            dsoft = d->softDeprecated;
+        }
+        else if (AggregateDeclaration *d = isAggregateDeclaration())
+        {
+            dmsg = d->deprecatedMessage;
+            dsoft = d->softDeprecated;
+        }
+        else if (EnumDeclaration *d = isEnumDeclaration())
+        {
+            dmsg = d->deprecatedMessage;
+            dsoft = d->softDeprecated;
+        }
+        const char *msg = dmsg ? "%s %s is deprecated - %s" : "%s %s is deprecated";
+
+        if (dsoft)
+            ::warning(loc, msg, kind(), toPrettyChars(),dmsg);
+        else
+            ::error(loc, msg, kind(), toPrettyChars(),dmsg);
     }
 
   L1:

--- a/src/enum.c
+++ b/src/enum.c
@@ -32,6 +32,8 @@ EnumDeclaration::EnumDeclaration(Loc loc, Identifier *id, Type *memtype)
     defaultval = NULL;
     sinit = NULL;
     isdeprecated = 0;
+    softDeprecated = false;
+    deprecatedMessage = NULL;
     isdone = 0;
 }
 

--- a/src/enum.h
+++ b/src/enum.h
@@ -40,6 +40,8 @@ struct EnumDeclaration : ScopeDsymbol
     Expression *defaultval;     // default initializer
 #endif
     int isdeprecated;
+    bool softDeprecated;
+    char *deprecatedMessage;
     int isdone;                 // 0: not done
                                 // 1: semantic() successfully completed
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -2568,9 +2568,10 @@ Lagain:
         return this;
     if (!s->isFuncDeclaration())        // functions are checked after overloading
         checkDeprecated(sc, s);
+    Dsymbol *olds = s;
     s = s->toAlias();
     //printf("s = '%s', s->kind = '%s', s->needThis() = %p\n", s->toChars(), s->kind(), s->needThis());
-    if (!s->isFuncDeclaration())
+    if (s != olds && !s->isFuncDeclaration())
         checkDeprecated(sc, s);
 
     if (sc->func)

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -266,6 +266,7 @@ Msgtable msgtable[] =
     { "lib" },
     { "msg" },
     { "startaddress" },
+    { "soft" },
 
     // For special functions
     { "tohash", "toHash" },

--- a/src/parse.c
+++ b/src/parse.c
@@ -369,7 +369,7 @@ Dsymbols *Parser::parseDeclDefs(int once)
             case TOKoverride:     stc = STCoverride;     goto Lstc;
             case TOKabstract:     stc = STCabstract;     goto Lstc;
             case TOKsynchronized: stc = STCsynchronized; goto Lstc;
-            case TOKdeprecated:   stc = STCdeprecated;   goto Lstc;
+            //case TOKdeprecated:   stc = STCdeprecated;   goto Lstc;
 #if DMDV2
             case TOKnothrow:      stc = STCnothrow;      goto Lstc;
             case TOKpure:         stc = STCpure;         goto Lstc;
@@ -412,7 +412,7 @@ Dsymbols *Parser::parseDeclDefs(int once)
                     case TOKoverride:     stc = STCoverride;     goto Lstc;
                     case TOKabstract:     stc = STCabstract;     goto Lstc;
                     case TOKsynchronized: stc = STCsynchronized; goto Lstc;
-                    case TOKdeprecated:   stc = STCdeprecated;   goto Lstc;
+                    //case TOKdeprecated:   stc = STCdeprecated;   goto Lstc;
                     case TOKnothrow:      stc = STCnothrow;      goto Lstc;
                     case TOKpure:         stc = STCpure;         goto Lstc;
                     case TOKref:          stc = STCref;          goto Lstc;
@@ -512,6 +512,34 @@ Dsymbols *Parser::parseDeclDefs(int once)
 
                 a = parseBlock();
                 s = new AlignDeclaration(n, a);
+                break;
+            }
+
+            case TOKdeprecated:
+            {
+                bool soft = false;
+                Expression *message = NULL;
+
+                nextToken();
+                if (token.value == TOKlparen)
+                {
+                    nextToken();
+                    if (token.value != TOKrparen)
+                        message = parseAssignExp();
+
+                    if (token.value == TOKcomma)
+                    {
+                        nextToken();
+                        if (token.value != TOKidentifier ||
+                            token.ident != Id::soft)
+                            error("'soft' exprected, not %s", token.toChars());
+                        soft = true;
+                        nextToken();
+                    }
+                    check(TOKrparen);
+                }
+                a = parseBlock();
+                s = new DeprecatedDeclaration(a, message, soft);
                 break;
             }
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -39,6 +39,8 @@ AggregateDeclaration::AggregateDeclaration(Loc loc, Identifier *id)
     sizeok = 0;                 // size not determined yet
     deferred = NULL;
     isdeprecated = 0;
+    softDeprecated = false;
+    deprecatedMessage = NULL;
     inv = NULL;
     aggNew = NULL;
     aggDelete = NULL;

--- a/test/compilable/test5481.d
+++ b/test/compilable/test5481.d
@@ -1,0 +1,21 @@
+// REQUIRED_ARGS: -d -w
+
+int n;
+deprecated int a;
+deprecated() int b;
+deprecated("hard") int c;
+deprecated("soft", soft) alias n d;
+deprecated int e;
+deprecated("through stc") immutable int f;
+deprecated("through attribute") extern(C) int g;
+
+class X
+{
+    deprecated("soft", soft) int y;
+}
+
+void main()
+{
+    auto x = new X();
+    auto z = a + b + c + d + e + f + g + x.y;
+}


### PR DESCRIPTION
This patch adds two new forms of deprecation:
`deprecated("message")` and
`deprecated("message", soft)`

The first behaves the same as the old deprecated, but also prints a message after the standard error.
The second instead issues a warning.

This patch is backwards compatible with the current deprecation system.

http://d.puremagic.com/issues/show_bug.cgi?id=5481

@jmdavis I know this isn't exactly what you wanted.  It can easily be changed if there's any sort of agreement. (@andralex ?)
