### PR TITLE
Issue 6389 - Segfault(dsymbol.c): deprecated @disable

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -597,13 +597,13 @@ void Dsymbol::checkDeprecated(Loc loc, Scope *sc)
                 goto L1;
         }
 
-        for (; sc; sc = sc->enclosing)
+        for (Scope *sc2 = sc; sc2; sc2 = sc2->enclosing)
         {
-            if (sc->scopesym && sc->scopesym->isDeprecated())
+            if (sc2->scopesym && sc2->scopesym->isDeprecated())
                 goto L1;
 
             // If inside a StorageClassDeclaration that is deprecated
-            if (sc->stc & STCdeprecated)
+            if (sc2->stc & STCdeprecated)
                 goto L1;
         }
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3254,6 +3254,11 @@ void test1471()
 
 /***************************************************/
 
+deprecated @disable int bug6389a;
+static assert(!is(typeof({ int bug6389b = bug6389a; })));
+
+/***************************************************/
+
 void test4963()
 {
     struct Value {


### PR DESCRIPTION
Use a new variable to iterate through scopes, avoids passing a null scope to the `@disable` check later in the function.

http://d.puremagic.com/issues/show_bug.cgi?id=6389
