### PR TITLE
Issue 3581 - "private" attribute breaks "override"

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -274,6 +274,9 @@ void FuncDeclaration::semantic(Scope *sc)
     if (isAbstract() && !isVirtual())
         error("non-virtual functions cannot be abstract");
 
+    if (isOverride() && !isVirtual())
+        error("cannot override a non-virtual function");
+
     if ((f->isConst() || f->isImmutable()) && !isThis())
         error("without 'this' cannot be const/immutable");
 

--- a/test/fail_compilation/fail3581a.d
+++ b/test/fail_compilation/fail3581a.d
@@ -1,0 +1,5 @@
+
+class A { void f() {} }
+class B : A { static override void f() {}; }
+
+void main() {}

--- a/test/fail_compilation/fail3581b.d
+++ b/test/fail_compilation/fail3581b.d
@@ -1,0 +1,5 @@
+
+class A { void f() {} }
+class B : A { private override void f() {}; }
+
+void main() {}


### PR DESCRIPTION
Don's patch can be merged now that https://github.com/D-Programming-Language/phobos/pull/137 has been fixed.
Disable using `override` with non-virtual functions.

http://d.puremagic.com/issues/show_bug.cgi?id=3581
