### PR TITLE
Issue 6572 - Deprecate typedef

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -276,6 +276,8 @@ void TypedefDeclaration::semantic(Scope *sc)
         sem = SemanticDone;
 #if DMDV2
         type = type->addStorageClass(storage_class);
+        if (!global.params.useDeprecated)
+            error("use of typedef is deprecated");
 #endif
         type = type->semantic(loc, sc);
         if (sc->parent->isFuncDeclaration() && init)

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS:
+// REQUIRED_ARGS: -d
 
 alias float[2] vector2;
 typedef vector2 point2;  // if I change this typedef to alias it works fine

--- a/test/compilable/ddoc1.d
+++ b/test/compilable/ddoc1.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -d -D -Ddtest_results/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddoc1-postscript.sh
 
 /** This module is for ABC

--- a/test/compilable/forward1.d
+++ b/test/compilable/forward1.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 // 104
 
 Foofunc f;

--- a/test/compilable/header.d
+++ b/test/compilable/header.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -H -Hdtest_results/compilable
+// REQUIRED_ARGS: -d -H -Hdtest_results/compilable
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh
 
 module foo.bar;

--- a/test/compilable/imports/test55a.d
+++ b/test/compilable/imports/test55a.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 module imports.test55a;
 
 import test55;

--- a/test/compilable/test55.d
+++ b/test/compilable/test55.d
@@ -1,6 +1,7 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/test55a.d
 // PERMUTE_ARGS:
+// REQUIRED_ARGS: -d
 
 public import imports.test55a;
 

--- a/test/fail_compilation/fail108.d
+++ b/test/fail_compilation/fail108.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 // 249
 
 module test1;

--- a/test/fail_compilation/fail111.d
+++ b/test/fail_compilation/fail111.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 // 289
 
 typedef int ft(int);

--- a/test/fail_compilation/fail112.d
+++ b/test/fail_compilation/fail112.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 void func(int a) { }
 //typedef int ft(int);
 

--- a/test/fail_compilation/fail138.d
+++ b/test/fail_compilation/fail138.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 typedef int T = void;
 
 void main(){

--- a/test/fail_compilation/fail156.d
+++ b/test/fail_compilation/fail156.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 typedef int myint = 4;
 
 struct S

--- a/test/fail_compilation/fail157.d
+++ b/test/fail_compilation/fail157.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 typedef int myint = 4;
 
 struct S

--- a/test/fail_compilation/fail187.d
+++ b/test/fail_compilation/fail187.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 typedef Exception A;
 typedef Exception B;
 

--- a/test/fail_compilation/fail4.d
+++ b/test/fail_compilation/fail4.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 typedef foo bar;
 typedef bar foo;
 

--- a/test/fail_compilation/fail6572.d
+++ b/test/fail_compilation/fail6572.d
@@ -1,0 +1,3 @@
+// REQUIRED_ARGS:
+
+typedef int y;

--- a/test/runnable/circular.d
+++ b/test/runnable/circular.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 // EXTRA_SOURCES: imports/circularA.d
 
 // Bugzilla 4543

--- a/test/runnable/extra-files/test2.d
+++ b/test/runnable/extra-files/test2.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 import object;
 import std.c.stdio;
 import std.string;
@@ -357,7 +357,7 @@ void test17()
 /* ================================ */
 
 
-typedef void* HANDLE18;
+alias void* HANDLE18;
 
 HANDLE18 testx18()
 {

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 // Test operator overloading
 
 extern (C) int printf(const(char*) fmt, ...);

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 import std.stdio;
 
 struct S

--- a/test/runnable/template4.d
+++ b/test/runnable/template4.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 import std.stdio;
 import std.c.stdio;
 

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 extern(C) int printf(const char*, ...);
 extern(C) int sprintf(char*, const char*, ...);
 

--- a/test/runnable/test19.d
+++ b/test/runnable/test19.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -unittest
+// REQUIRED_ARGS: -d -unittest
 
 import std.string: cmp;
 

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 import core.vararg;
 
 extern(C) int printf(const char*, ...);

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 module test;
 
 import core.vararg;

--- a/test/runnable/test34.d
+++ b/test/runnable/test34.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 module test34;
 
 import std.stdio;

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 module testxxx8;
 
 import core.vararg;

--- a/test/runnable/test9.d
+++ b/test/runnable/test9.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 public:
 
 // VECTOR

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 // PERMUTE_ARGS: -fPIC
 
 /* Test associative arrays */

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 import std.c.stdio;
 
 class C { }

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 // PERMUTE_ARGS:
 
 module dstress.run.module_01;

--- a/test/runnable/testformat.d
+++ b/test/runnable/testformat.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 // PERMUTE_ARGS:
 
 import std.stdio;

--- a/test/runnable/testswitch.d
+++ b/test/runnable/testswitch.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -d
 // PERMUTE_ARGS:
 
 extern(C) int printf(const char*, ...);

--- a/test/runnable/testtypeid.d
+++ b/test/runnable/testtypeid.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 import core.vararg;
 import std.stdio;
 

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 import std.stdio;
 
 typedef int myint;

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1,4 +1,4 @@
-
+// REQUIRED_ARGS: -d
 import std.stdio;
 import std.string;
 import std.typetuple;


### PR DESCRIPTION
The only real change is in declaration.c and a new test.
The rest is adding -d to tests that use typedef.

The [druntime](https://github.com/D-Programming-Language/druntime/pull/63) and [phobos](https://github.com/D-Programming-Language/phobos/pull/224) pulls have already been merged.
http://d.puremagic.com/issues/show_bug.cgi?id=6572
