### PR TITLE
Fix Issue 4269 for alias and typedef

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -508,6 +508,7 @@ void AliasDeclaration::semantic(Scope *sc)
     }
     else
     {
+        Dsymbol *savedovernext = overnext;
         FuncDeclaration *f = s->toAlias()->isFuncDeclaration();
         if (f)
         {
@@ -527,6 +528,14 @@ void AliasDeclaration::semantic(Scope *sc)
         {
             assert(global.errors);
             s = NULL;
+        }
+        if (errors != global.errors)
+        {
+            type = savedtype;
+            overnext = savedovernext;
+            aliassym = NULL;
+            inSemantic = 0;
+            return;
         }
     }
     //printf("setting aliassym %s to %s %s\n", toChars(), s->kind(), s->toChars());
@@ -585,7 +594,7 @@ Dsymbol *AliasDeclaration::toAlias()
     //static int count; if (++count == 10) *(char*)0=0;
     if (inSemantic)
     {   error("recursive alias declaration");
-        aliassym = new TypedefDeclaration(loc, ident, Type::terror, NULL);
+        aliassym = new AliasDeclaration(loc, ident, Type::terror);
         type = Type::terror;
     }
     else if (!aliassym && scope)

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -443,6 +443,9 @@ void AliasDeclaration::semantic(Scope *sc)
     // type. If it is a symbol, then aliassym is set and type is NULL -
     // toAlias() will return aliasssym.
 
+    int errors = global.errors;
+    Type *savedtype = type;
+
     Dsymbol *s;
     Type *t;
     Expression *e;
@@ -489,12 +492,15 @@ void AliasDeclaration::semantic(Scope *sc)
     }
     else if (t)
     {
-        type = t;
+        type = t->semantic(loc, sc);
         //printf("\talias resolved to type %s\n", type->toChars());
     }
     if (overnext)
         ScopeDsymbol::multiplyDefined(0, this, overnext);
     this->inSemantic = 0;
+
+    if (errors != global.errors)
+        type = savedtype;
     return;
 
   L2:

--- a/src/expression.c
+++ b/src/expression.c
@@ -2705,7 +2705,8 @@ Lagain:
     t = s->getType();
     if (t)
     {
-        return new TypeExp(loc, t);
+        TypeExp *te = new TypeExp(loc, t);
+        return te->semantic(sc);
     }
 
     TupleDeclaration *tup = s->isTupleDeclaration();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6558,7 +6558,10 @@ char *TypeTypedef::toChars()
 Type *TypeTypedef::semantic(Loc loc, Scope *sc)
 {
     //printf("TypeTypedef::semantic(%s), sem = %d\n", toChars(), sym->sem);
+    int errors = global.errors;
     sym->semantic(sc);
+    if (errors != global.errors)
+        return terror;
     return merge();
 }
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1486,6 +1486,7 @@ void Type::modToBuffer(OutBuffer *buf)
 Type *Type::merge()
 {   Type *t;
 
+    if (ty == Terror) return this;
     //printf("merge(%s)\n", toChars());
     t = this;
     assert(t);
@@ -3344,10 +3345,11 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
         return t;
     }
 
-    next = next->semantic(loc,sc);
-    transitive();
+    Type *tn = next->semantic(loc,sc);
+    if (tn->ty == Terror)
+        return terror;
 
-    Type *tbn = next->toBasetype();
+    Type *tbn = tn->toBasetype();
 
     if (dim)
     {   dinteger_t n, n2;
@@ -3436,7 +3438,9 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
     /* Ensure things like const(immutable(T)[3]) become immutable(T[3])
      * and const(T)[3] become const(T[3])
      */
-    t = addMod(next->mod);
+    next = tn;
+    transitive();
+    t = addMod(tn->mod);
 
     return t->merge();
 

--- a/test/fail_compilation/fail4269a.d
+++ b/test/fail_compilation/fail4269a.d
@@ -1,0 +1,4 @@
+static if(is(typeof(X5.init))) {}
+typedef Y X5;
+
+void main() {}

--- a/test/fail_compilation/fail4269b.d
+++ b/test/fail_compilation/fail4269b.d
@@ -1,0 +1,5 @@
+
+static if(is(typeof(X16))) {}
+alias X16 X16;
+
+void main() {}

--- a/test/fail_compilation/fail4269c.d
+++ b/test/fail_compilation/fail4269c.d
@@ -1,0 +1,6 @@
+
+int[2] d;
+static if(is(typeof(Xg.init))) {}
+alias d[1] Xg;
+
+void main() {}

--- a/test/fail_compilation/fail4269d.d
+++ b/test/fail_compilation/fail4269d.d
@@ -1,0 +1,5 @@
+
+static if(is(typeof(X6.init))) {}
+alias Y X6;
+
+void main() {}


### PR DESCRIPTION
Allow unwinding the semantic pass for alias and typedef declarations.  These are by far the simplest, but more to come.

http://d.puremagic.com/issues/show_bug.cgi?id=4269
