### PR TITLE
2156 and regression 5373: allow array literals as compile-time strings

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -900,7 +900,7 @@ void PragmaDeclaration::setScope(Scope *sc)
             e = e->semantic(sc);
             e = e->optimize(WANTvalue | WANTinterpret);
             args->tdata()[0] = e;
-            StringExp* se = e->toString(sc);
+            StringExp* se = e->toString();
             if (!se)
             {
                 error("string expected, not '%s'", e->toChars());
@@ -933,7 +933,7 @@ void PragmaDeclaration::semantic(Scope *sc)
 
                 e = e->semantic(sc);
                 e = e->optimize(WANTvalue | WANTinterpret);
-                StringExp *se = e->toString(sc);
+                StringExp *se = e->toString();
                 if (se)
                 {
                     fprintf(stdmsg, "%.*s", (int)se->len, (char *)se->string);
@@ -958,7 +958,7 @@ void PragmaDeclaration::semantic(Scope *sc)
             args->tdata()[0] = e;
             if (e->op == TOKerror)
                 goto Lnodecl;
-            StringExp *se = e->toString(sc);
+            StringExp *se = e->toString();
             if (!se)
                 error("string expected for library name, not '%s'", e->toChars());
             else if (global.params.verbose)
@@ -996,8 +996,8 @@ void PragmaDeclaration::semantic(Scope *sc)
 
             e = args->tdata()[1];
             e = e->semantic(sc);
-            e = e->optimize(WANTvalue);
-            e = e->toString(sc);
+            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->toString();
             if (e && ((StringExp *)e)->sz == 1)
                 s = ((StringExp *)e);
             else
@@ -1437,7 +1437,7 @@ void CompileDeclaration::compileIt(Scope *sc)
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
     exp = exp->optimize(WANTvalue | WANTinterpret);
-    StringExp *se = exp->toString(sc);
+    StringExp *se = exp->toString();
     if (!se)
     {   exp->error("argument to mixin must be a string, not (%s)", exp->toChars());
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -3491,7 +3491,8 @@ StringExp *ArrayLiteralExp::toString()
 {
     TY telem = type->nextOf()->toBasetype()->ty;
 
-    if (telem == Tchar || telem == Twchar || telem == Tdchar)
+    if (telem == Tchar || telem == Twchar || telem == Tdchar ||
+        (telem == Tvoid && (!elements || elements->dim == 0)))
     {
         OutBuffer buf;
         if (elements)

--- a/src/expression.h
+++ b/src/expression.h
@@ -46,6 +46,7 @@ struct InterState;
 struct Symbol;          // back end symbol
 struct OverloadSet;
 struct Initializer;
+struct StringExp;
 
 enum TOK;
 
@@ -115,6 +116,7 @@ struct Expression : Object
     virtual real_t toReal();
     virtual real_t toImaginary();
     virtual complex_t toComplex();
+    virtual StringExp *toString(Scope *sc);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toMangleBuffer(OutBuffer *buf);
     virtual int isLvalue();
@@ -340,6 +342,7 @@ struct NullExp : Expression
     Expression *semantic(Scope *sc);
     int isBool(int result);
     int isConst();
+    StringExp *toString(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     MATCH implicitConvTo(Type *t);
@@ -366,6 +369,7 @@ struct StringExp : Expression
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     size_t length();
+    StringExp *toString(Scope *sc);
     StringExp *toUTF8(Scope *sc);
     Expression *implicitCastTo(Scope *sc, Type *t);
     MATCH implicitConvTo(Type *t);
@@ -419,6 +423,7 @@ struct ArrayLiteralExp : Expression
     int isBool(int result);
     elem *toElem(IRState *irs);
     int checkSideEffect(int flag);
+    StringExp *toString(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);

--- a/src/expression.h
+++ b/src/expression.h
@@ -121,7 +121,7 @@ struct Expression : Object
     virtual real_t toReal();
     virtual real_t toImaginary();
     virtual complex_t toComplex();
-    virtual StringExp *toString(Scope *sc);
+    virtual StringExp *toString();
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toMangleBuffer(OutBuffer *buf);
     virtual int isLvalue();
@@ -347,7 +347,7 @@ struct NullExp : Expression
     Expression *semantic(Scope *sc);
     int isBool(int result);
     int isConst();
-    StringExp *toString(Scope *sc);
+    StringExp *toString();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     MATCH implicitConvTo(Type *t);
@@ -374,7 +374,7 @@ struct StringExp : Expression
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     size_t length();
-    StringExp *toString(Scope *sc);
+    StringExp *toString();
     StringExp *toUTF8(Scope *sc);
     Expression *implicitCastTo(Scope *sc, Type *t);
     MATCH implicitConvTo(Type *t);
@@ -428,7 +428,7 @@ struct ArrayLiteralExp : Expression
     int isBool(int result);
     elem *toElem(IRState *irs);
     int checkSideEffect(int flag);
-    StringExp *toString(Scope *sc);
+    StringExp *toString();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     void scanForNestedRef(Scope *sc);

--- a/src/statement.c
+++ b/src/statement.c
@@ -403,11 +403,11 @@ Statements *CompileStatement::flatten(Scope *sc)
     exp = exp->optimize(WANTvalue | WANTinterpret);
     if (exp->op == TOKerror)
         return NULL;
-    if (exp->op != TOKstring)
+    StringExp *se = exp->toString(sc);
+    if (!se)
     {   error("argument to mixin must be a string, not (%s)", exp->toChars());
         return NULL;
     }
-    StringExp *se = (StringExp *)exp;
     se = se->toUTF8(sc);
     Parser p(sc->module, (unsigned char *)se->string, se->len, 0);
     p.loc = loc;

--- a/src/statement.c
+++ b/src/statement.c
@@ -403,7 +403,7 @@ Statements *CompileStatement::flatten(Scope *sc)
     exp = exp->optimize(WANTvalue | WANTinterpret);
     if (exp->op == TOKerror)
         return NULL;
-    StringExp *se = exp->toString(sc);
+    StringExp *se = exp->toString();
     if (!se)
     {   error("argument to mixin must be a string, not (%s)", exp->toChars());
         return NULL;

--- a/src/statement.c
+++ b/src/statement.c
@@ -2729,9 +2729,9 @@ Statement *PragmaStatement::semantic(Scope *sc)
 
                 e = e->semantic(sc);
                 e = e->optimize(WANTvalue | WANTinterpret);
-                if (e->op == TOKstring)
+                StringExp *se = e->toString();
+                if (se)
                 {
-                    StringExp *se = (StringExp *)e;
                     fprintf(stdmsg, "%.*s", (int)se->len, (char *)se->string);
                 }
                 else
@@ -2756,11 +2756,11 @@ Statement *PragmaStatement::semantic(Scope *sc)
             e = e->semantic(sc);
             e = e->optimize(WANTvalue | WANTinterpret);
             args->tdata()[0] = e;
-            if (e->op != TOKstring)
+            StringExp *se = e->toString();
+            if (!se)
                 error("string expected for library name, not '%s'", e->toChars());
             else if (global.params.verbose)
             {
-                StringExp *se = (StringExp *)e;
                 char *name = (char *)mem.malloc(se->len + 1);
                 memcpy(name, se->string, se->len);
                 name[se->len] = 0;

--- a/src/traits.c
+++ b/src/traits.c
@@ -227,11 +227,11 @@ Expression *TraitsExp::semantic(Scope *sc)
             goto Lfalse;
         }
         e = e->optimize(WANTvalue | WANTinterpret);
-        if (e->op != TOKstring)
+        StringExp *se = e->toString(sc);
+        if (!se || se->length == 0)
         {   error("string expected as second argument of __traits %s instead of %s", ident->toChars(), e->toChars());
             goto Lfalse;
         }
-        StringExp *se = (StringExp *)e;
         se = se->toUTF8(sc);
         if (se->sz != 1)
         {   error("string must be chars");

--- a/src/traits.c
+++ b/src/traits.c
@@ -229,7 +229,7 @@ Expression *TraitsExp::semantic(Scope *sc)
             goto Lfalse;
         }
         e = e->optimize(WANTvalue | WANTinterpret);
-        StringExp *se = e->toString(sc);
+        StringExp *se = e->toString();
         if (!se || se->length == 0)
         {   error("string expected as second argument of __traits %s instead of %s", ident->toChars(), e->toChars());
             goto Lfalse;

--- a/test/fail_compilation/fail234.d
+++ b/test/fail_compilation/fail234.d
@@ -1,6 +1,0 @@
-//bug1941 = 1158   attrib.c
-/*
-attribute argument to mixin must be a string, not (null)
-*/
-
-mixin(null);

--- a/test/runnable/mixin2.d
+++ b/test/runnable/mixin2.d
@@ -136,6 +136,22 @@ void test9()
 
 /*********************************************/
 
+void test10()
+{
+    pragma(msg, "hello");
+    pragma(msg, ['h', 'e', 'l', 'l', 'o']);
+    pragma(msg, "");
+    pragma(msg, []);
+    pragma(msg, null);
+    mixin("string hello;");
+    mixin(['i', 'n', 't', ' ', 'a', ';']);
+    mixin("");
+    mixin([]);
+    mixin(null);
+}
+
+/*********************************************/
+
 void main()
 {
     test1();
@@ -147,6 +163,7 @@ void main()
     test7();
     test8();
     test9();
+    test10();
 
     writeln("Success");
 }

--- a/test/runnable/mixin2.d
+++ b/test/runnable/mixin2.d
@@ -136,6 +136,16 @@ void test9()
 
 /*********************************************/
 
+pragma(msg, "hello");
+pragma(msg, ['h', 'e', 'l', 'l', 'o']);
+pragma(msg, "");
+pragma(msg, []);
+pragma(msg, null);
+mixin("string hello;");
+mixin(['i', 'n', 't', ' ', 't', 'e', 's', 't', '1', '0', 'x', ';']);
+mixin("");
+mixin([]);
+mixin(null);
 void test10()
 {
     pragma(msg, "hello");


### PR DESCRIPTION
This is a slightly improved version of yebblies' pull request 180.
It's not a CTFE issue but is frequently mistaken as one. Fixing this will increase the number of Phobos functions usable at compile time.

http://d.puremagic.com/issues/show_bug.cgi?id=2156
[] and null should be accepted where a compile-time string is required

This regression is already in the changelog for the next release, but was reopened because it hit 2156.
http://d.puremagic.com/issues/show_bug.cgi?id=5373
Regression (2.051) CTFE and std.string.replace() causes "Bad binary function q{a == b}..
