### PR TITLE
6601 Regression(2.053): CTFE segfault taking address of function template

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1679,7 +1679,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
             error(loc, "cannot interpret symbol %s at compile time", v->toChars());
     }
     else
-        error(loc, "cannot interpret variable %s at compile time", v->toChars());
+        error(loc, "cannot interpret declaration %s at compile time", d->toChars());
     return e;
 }
 


### PR DESCRIPTION
Found this embarressing segfault regression via code in std.functional.
Uses the wrong variable to print the error message.

6601 Regression(2.053): CTFE segfault taking address of function template
