### PR TITLE
6602 – Don't add failed template instantiations to enclosing scope.

### DIFF
--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -3436,6 +3436,19 @@ alias tough4302!() tougher;
 
 /***************************************************/
 
+template Bug6602A(T) {
+  Bug6602B!(T).Result result;
+}
+
+template Bug6602B(U) {
+  static assert(is(U == int));
+  alias bool Result;
+}
+
+enum bug6602Compiles = __traits(compiles, Bug6602A!short);
+
+/***************************************************/
+
 // Bugzilla 190
 
 //typedef int avocado;


### PR DESCRIPTION
Previously, we didn't remove a template instance from the symbol list of the enclosing scope even if error gagging was enabled, for example by `Type::trySemantic`. This caused the static assert in the following snipped to trigger ([bug 6602](http://d.puremagic.com/issues/show_bug.cgi?id=6602)), because `B!short` was added to the module `members` array while evaluating the `__traits(compiles, …)` and thus semantic analysis was run on it later:

``` d
template A(T) {
  B!(T).Result result;
}

template B(U) {
  static assert(is(U == int));
  alias bool Result;
}

pragma(msg, __traits(compiles, A!short));
```

This should be the proper fix for [bug 4302](http://d.puremagic.com/issues/show_bug.cgi?id=4302), the test cases for it still works.
