### PR TITLE
Issue 4284 - empty string[] alias lacks .length in a template

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3725,6 +3725,8 @@ Expression *TypeDArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
 
             return new IntegerExp(se->loc, se->len, Type::tindex);
         }
+        if (e->op == TOKnull)
+            return new IntegerExp(e->loc, 0, Type::tindex);
         e = new ArrayLengthExp(e->loc, e);
         e->type = Type::tsize_t;
         return e;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1644,6 +1644,12 @@ void test87()
 
 /***************************************************/
 
+template test4284(alias v) { enum test4284 = v.length == 0; }
+static assert(test4284!(cast(string)null));
+static assert(test4284!(cast(string[])null));
+
+/***************************************************/
+
 struct S88
 {
     void opDispatch(string s, T)(T i)


### PR DESCRIPTION
NullExp should provide .length when typed as a dynamic array.

http://d.puremagic.com/issues/show_bug.cgi?id=4284
