### PR TITLE
Fix bug in d_do_test

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -362,7 +362,7 @@ int main(string[] args)
             writeln("Test failed.  The logged output:");
             if (std.file.exists(output_file))
             {
-                writeln(std.file.read(output_file));
+                writeln(cast(string)std.file.read(output_file));
                 std.file.remove(output_file);
             }
             return 1;


### PR DESCRIPTION
The autotester sometimes outputs cryptic error messages in the form of large ubyte[] array literals.  This turned out to be the cause.
