### PR TITLE
Issue 6518 - break inside a static foreach inside a switch

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -663,7 +663,8 @@ int CompoundStatement::blockExit(bool mustNotThrow)
             if (global.params.warnings && result & BEfallthru && slast)
             {
                 slast = slast->last();
-                if (slast && (s->isCaseStatement() || s->isDefaultStatement()))
+                if (slast && (slast->isCaseStatement() || slast->isDefaultStatement()) &&
+                             (s->isCaseStatement() || s->isDefaultStatement()))
                 {
                     // Allow if last case/default was empty
                     CaseStatement *sc = slast->isCaseStatement();

--- a/test/runnable/warning1.d
+++ b/test/runnable/warning1.d
@@ -104,3 +104,13 @@ nothrow int foo6()
 
 /*****************************************/
 
+template TypeTuple(T...) { alias T TypeTuple; }
+void test6518()
+{
+    switch(2)
+    {
+        foreach(v; TypeTuple!(1, 2, 3))
+            case v: break;
+        default: assert(0);
+    }
+}


### PR DESCRIPTION
Fallthrough only exists when a case statement is followed by another case statement, while switch statements bodies can contain other kinds of statements.

http://d.puremagic.com/issues/show_bug.cgi?id=6518
