### PR TITLE
Issue 4374 - Required do-while ending semicolon

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -1,4 +1,3 @@
-
 // Compiler implementation of the D programming language
 // Copyright (c) 1999-2011 by Digital Mars
 // All Rights Reserved
@@ -3678,6 +3677,7 @@ Statement *Parser::parseStatement(int flags)
             check(TOKlparen);
             condition = parseExpression();
             check(TOKrparen);
+            check(TOKsemicolon);
             s = new DoStatement(loc, body, condition);
             break;
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -1,3 +1,4 @@
+
 // Compiler implementation of the D programming language
 // Copyright (c) 1999-2011 by Digital Mars
 // All Rights Reserved


### PR DESCRIPTION
From TDPL, p. 73:

"If a loop with at least one execution is needed, the do-while statement comes in handy:

```
do <statement> while(<expression>);
```

Notice the **required semicolon** at the end of the construct. Again, _statement_ must be non-empty. The `do-while` statement is equivalent to a `while` statement that forces one initial execution of _statement_."

The parser without this change does actually not require the semicolon.

also see: http://d.puremagic.com/issues/show_bug.cgi?id=4374
