### PR TITLE
Issue 3659 & others - Relax opEquals signature

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -132,6 +132,7 @@ struct StructDeclaration : AggregateDeclaration
     FuncDeclaration *postblit;  // aggregate postblit
 
     FuncDeclaration *xeq;       // TypeInfo_Struct.xopEquals
+    static FuncDeclaration *xerreq;      // object.xopEquals
 #endif
 
     StructDeclaration(Loc loc, Identifier *id);
@@ -151,6 +152,8 @@ struct StructDeclaration : AggregateDeclaration
     FuncDeclaration *buildOpEquals(Scope *sc);
     FuncDeclaration *buildPostBlit(Scope *sc);
     FuncDeclaration *buildCpCtor(Scope *sc);
+
+    FuncDeclaration *buildXopEquals(Scope *sc);
 #endif
     void toDocBuffer(OutBuffer *buf);
 

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -126,11 +126,12 @@ struct StructDeclaration : AggregateDeclaration
     int zeroInit;               // !=0 if initialize with 0 fill
 #if DMDV2
     int hasIdentityAssign;      // !=0 if has identity opAssign
+    int hasIdentityEquals;      // !=0 if has identity opEquals
     FuncDeclaration *cpctor;    // generated copy-constructor, if any
-    FuncDeclaration *eq;        // bool opEquals(ref const T), if any
-
     FuncDeclarations postblits; // Array of postblit functions
     FuncDeclaration *postblit;  // aggregate postblit
+
+    FuncDeclaration *xeq;       // TypeInfo_Struct.xopEquals
 #endif
 
     StructDeclaration(Loc loc, Identifier *id);

--- a/src/clone.c
+++ b/src/clone.c
@@ -71,48 +71,6 @@ Lneed:
 #undef X
 }
 
-/*******************************************
- * We need an opEquals for the struct if
- * any fields has an opEquals.
- * Generate one if a user-specified one does not exist.
- */
-
-int StructDeclaration::needOpEquals()
-{
-#define X 0
-    if (X) printf("StructDeclaration::needOpEquals() %s\n", toChars());
-
-    /* If any of the fields has an opEquals, then we
-     * need it too.
-     */
-    for (size_t i = 0; i < fields.dim; i++)
-    {
-        Dsymbol *s = fields.tdata()[i];
-        VarDeclaration *v = s->isVarDeclaration();
-        assert(v && v->storage_class & STCfield);
-        if (v->storage_class & STCref)
-            continue;
-        Type *tv = v->type->toBasetype();
-        while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
-            tv = tv->nextOf()->toBasetype();
-        }
-        if (tv->ty == Tstruct)
-        {   TypeStruct *ts = (TypeStruct *)tv;
-            StructDeclaration *sd = ts->sym;
-            if (sd->eq)
-                goto Lneed;
-        }
-    }
-    if (X) printf("\tdontneed\n");
-    return 0;
-
-Lneed:
-    if (X) printf("\tneed\n");
-    return 1;
-#undef X
-}
-
 /******************************************
  * Build opAssign for struct.
  *      S* opAssign(S s) { ... }
@@ -230,6 +188,48 @@ FuncDeclaration *StructDeclaration::buildOpAssign(Scope *sc)
     //printf("-StructDeclaration::buildOpAssign() %s\n", toChars());
 
     return fop;
+}
+
+/*******************************************
+ * We need an opEquals for the struct if
+ * any fields has an opEquals.
+ * Generate one if a user-specified one does not exist.
+ */
+
+int StructDeclaration::needOpEquals()
+{
+#define X 0
+    if (X) printf("StructDeclaration::needOpEquals() %s\n", toChars());
+
+    /* If any of the fields has an opEquals, then we
+     * need it too.
+     */
+    for (size_t i = 0; i < fields.dim; i++)
+    {
+        Dsymbol *s = fields.tdata()[i];
+        VarDeclaration *v = s->isVarDeclaration();
+        assert(v && v->storage_class & STCfield);
+        if (v->storage_class & STCref)
+            continue;
+        Type *tv = v->type->toBasetype();
+        while (tv->ty == Tsarray)
+        {   TypeSArray *ta = (TypeSArray *)tv;
+            tv = tv->nextOf()->toBasetype();
+        }
+        if (tv->ty == Tstruct)
+        {   TypeStruct *ts = (TypeStruct *)tv;
+            StructDeclaration *sd = ts->sym;
+            if (sd->eq)
+                goto Lneed;
+        }
+    }
+    if (X) printf("\tdontneed\n");
+    return 0;
+
+Lneed:
+    if (X) printf("\tneed\n");
+    return 1;
+#undef X
 }
 
 /******************************************

--- a/src/clone.c
+++ b/src/clone.c
@@ -201,6 +201,9 @@ int StructDeclaration::needOpEquals()
 #define X 0
     if (X) printf("StructDeclaration::needOpEquals() %s\n", toChars());
 
+    if (hasIdentityEquals)
+        goto Lneed;
+
     /* If any of the fields has an opEquals, then we
      * need it too.
      */
@@ -219,7 +222,7 @@ int StructDeclaration::needOpEquals()
         if (tv->ty == Tstruct)
         {   TypeStruct *ts = (TypeStruct *)tv;
             StructDeclaration *sd = ts->sym;
-            if (sd->eq)
+            if (sd->needOpEquals())
                 goto Lneed;
         }
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -9798,6 +9798,9 @@ Ltupleassign:
                 {   /* Write as:
                      *  e1.cpctor(e2);
                      */
+                    if (!e2->type->implicitConvTo(e1->type))
+                        error("conversion error from %s to %s", e2->type->toChars(), e1->type->toChars());
+
                     Expression *e = new DotVarExp(loc, e1, sd->cpctor, 0);
                     e = new CallExp(loc, e, e2);
                     if (ec)

--- a/src/expression.c
+++ b/src/expression.c
@@ -11783,7 +11783,11 @@ Expression *EqualExp::semantic(Scope *sc)
             e = new CallExp(loc, eq, args);
             if (op == TOKnotequal)
                 e = new NotExp(loc, e);
-            e = e->semantic(sc);
+            e = e->trySemantic(sc); // for better error message
+            if (!e)
+            {   error("cannot compare %s and %s", t1->toChars(), t2->toChars());
+                return new ErrorExp();
+            }
             return e;
         }
     }

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -73,6 +73,7 @@ Msgtable msgtable[] =
     { "line" },
     { "empty", "" },
     { "p" },
+    { "q" },
     { "coverage", "__coverage" },
     { "__vptr" },
     { "__monitor" },

--- a/src/struct.c
+++ b/src/struct.c
@@ -595,39 +595,7 @@ void StructDeclaration::semantic(Scope *sc)
     }
 #endif
 #if DMDV2
-    /* Try to find the opEquals function. Build it if necessary.
-     */
-    TypeFunction *tfeqptr;
-    {   // bool opEquals(const T*) const;
-        Parameters *parameters = new Parameters;
-#if STRUCTTHISREF
-        // bool opEquals(ref const T) const;
-        Parameter *param = new Parameter(STCref, type->constOf(), NULL, NULL);
-#else
-        // bool opEquals(const T*) const;
-        Parameter *param = new Parameter(STCin, type->pointerTo(), NULL, NULL);
-#endif
-
-        parameters->push(param);
-        tfeqptr = new TypeFunction(parameters, Type::tbool, 0, LINKd);
-        tfeqptr->mod = MODconst;
-        tfeqptr = (TypeFunction *)tfeqptr->semantic(0, sc2);
-
-        Dsymbol *s = search_function(this, Id::eq);
-        FuncDeclaration *fdx = s ? s->isFuncDeclaration() : NULL;
-        if (fdx)
-        {
-            eq = fdx->overloadExactMatch(tfeqptr);
-            if (!eq)
-                fdx->error("type signature should be %s not %s", tfeqptr->toChars(), fdx->type->toChars());
-        }
-
-        TemplateDeclaration *td = s ? s->isTemplateDeclaration() : NULL;
-        // BUG: should also check that td is a function template, not just a template
-
-        if (!eq && !td)
-            eq = buildOpEquals(sc2);
-    }
+    buildOpEquals(sc2);
 
     dtor = buildDtor(sc2);
     postblit = buildPostBlit(sc2);

--- a/src/struct.c
+++ b/src/struct.c
@@ -21,6 +21,8 @@
 #include "statement.h"
 #include "template.h"
 
+FuncDeclaration *StructDeclaration::xerreq;     // object.xopEquals
+
 /********************************* AggregateDeclaration ****************************/
 
 AggregateDeclaration::AggregateDeclaration(Loc loc, Identifier *id)
@@ -597,12 +599,14 @@ void StructDeclaration::semantic(Scope *sc)
     }
 #endif
 #if DMDV2
-    buildOpEquals(sc2);
-
     dtor = buildDtor(sc2);
     postblit = buildPostBlit(sc2);
     cpctor = buildCpCtor(sc2);
+
     buildOpAssign(sc2);
+    hasIdentityEquals = (buildOpEquals(sc2) != NULL);
+
+    xeq = buildXopEquals(sc2);
 #endif
 
     sc2->pop();

--- a/src/struct.c
+++ b/src/struct.c
@@ -299,9 +299,11 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
     zeroInit = 0;       // assume false until we do semantic processing
 #if DMDV2
     hasIdentityAssign = 0;
+    hasIdentityEquals = 0;
     cpctor = NULL;
     postblit = NULL;
-    eq = NULL;
+
+    xeq = NULL;
 #endif
 
     // For forward references

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -567,8 +567,8 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
     else
         dtsize_t(pdt, 0);
 
-    if (sd->eq)
-        dtxoff(pdt, sd->eq->toSymbol(), 0, TYnptr);
+    if (sd->xeq)
+        dtxoff(pdt, sd->xeq->toSymbol(), 0, TYnptr);
     else
         dtsize_t(pdt, 0);
 

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -6,7 +6,7 @@ struct Tup(T...)
     T field;
     alias field this;
 
-    bool opEquals()(auto ref Tup rhs) const
+    bool opEquals(const Tup rhs) const
     {
         foreach (i, _; T)
             if (field[i] != rhs.field[i])

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -3,6 +3,14 @@
 
 extern (C) int printf(const(char*) fmt, ...);
 
+template Seq(T...){ alias T Seq; }
+
+bool thrown(E, T)(lazy T val)
+{
+    try { val(); return false; }
+    catch (E e) { return true; }
+}
+
 /**************************************/
 
 class A
@@ -498,6 +506,145 @@ void test4099()
 
 /**************************************/
 
+void test12()
+{
+    static int opeq;
+
+    // xopEquals OK
+    struct S1a { const bool opEquals(    const typeof(this) rhs) { ++opeq; return false; } }
+    struct S1b { const bool opEquals(ref const typeof(this) rhs) { ++opeq; return false; } }
+    struct S1c { const bool opEquals(          typeof(this) rhs) { ++opeq; return false; } }
+
+    // xopEquals NG
+    struct S2a {       bool opEquals(          typeof(this) rhs) { ++opeq; return false; } }
+
+    foreach (S; Seq!(S1a, S1b, S1c))
+    {
+        S s;
+        opeq = 0;
+        assert(s != s);                     // call opEquals directly
+        assert(!typeid(S).equals(&s, &s));  // -> xopEquals (-> __xopEquals) -> opEquals
+        assert(opeq == 2);
+    }
+
+    foreach (S; Seq!(S2a))
+    {
+        S s;
+        opeq = 0;
+        assert(s != s);
+        assert(thrown!Error(!typeid(S).equals(&s, &s)));
+            // Error("notImplemented") thrown
+        assert(opeq == 1);
+    }
+}
+
+/**************************************/
+
+void test13()
+{
+    static int opeq;
+
+    struct X
+    {
+        const bool opEquals(const X){ ++opeq; return false; }
+    }
+    struct S
+    {
+        X x;
+    }
+
+    S makeS(){ return S(); }
+
+    S s;
+    opeq = 0;
+    assert(s != s);
+    assert(makeS() != s);
+    assert(s != makeS());
+    assert(makeS() != makeS());
+    assert(opeq == 4);
+
+    // built-in opEquals == const bool opEquals(const S rhs);
+    assert(!s.opEquals(s));
+    assert(opeq == 5);
+
+    // xopEquals
+    assert(!typeid(S).equals(&s, &s));
+    assert(opeq == 6);
+}
+
+/**************************************/
+
+void test14()
+{
+    static int opeq;
+
+    struct S
+    {
+        const bool opEquals(T)(const T rhs) { ++opeq; return false; }
+    }
+
+    S makeS(){ return S(); }
+
+    S s;
+    opeq = 0;
+    assert(s != s);
+    assert(makeS() != s);
+    assert(s != makeS());
+    assert(makeS() != makeS());
+    assert(opeq == 4);
+
+    // xopEquals (-> __xxopEquals) -> template opEquals
+    assert(!typeid(S).equals(&s, &s));
+    assert(opeq == 5);
+}
+
+/**************************************/
+
+void test15()
+{
+    struct S
+    {
+        const bool opEquals(T)(const(T) rhs)
+        if (!is(T == typeof(this)))
+        { return false; }
+    }
+
+    S makeS(){ return S(); }
+
+    S s;
+    static assert(!__traits(compiles, s != s));
+    static assert(!__traits(compiles, makeS() != s));
+    static assert(!__traits(compiles, s != makeS()));
+    static assert(!__traits(compiles, makeS() != makeS()));
+
+    // xopEquals (-> __xxopEquals) -> Error thrown
+    assert(thrown!Error(!typeid(S).equals(&s, &s)));
+}
+
+/**************************************/
+
+void test16()
+{
+    struct X
+    {
+        int n;
+        const bool opEquals(T)(T t)
+        {
+            return false;
+        }
+    }
+    struct S
+    {
+        X x;
+    }
+
+    S s1, s2;
+    assert(s1 != s2);
+        // field template opEquals should call
+}
+
+/**************************************/
+
 int main()
 {
     test1();
@@ -512,6 +659,11 @@ int main()
     test10();
     test11();
     test4099();
+    test12();
+    test13();
+    test14();
+    test15();
+    test16();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -645,6 +645,27 @@ void test16()
 
 /**************************************/
 
+void test17()
+{
+    static int opeq = 0;
+
+    struct S
+    {
+        bool opEquals(ref S rhs) { ++opeq; return false; }
+    }
+    S[] sa1 = new S[3];
+    S[] sa2 = new S[3];
+    assert(sa1 != sa2);     // isn't used TypeInfo.equals
+    assert(opeq == 1);
+
+    const(S)[] csa = new const(S)[3];
+    static assert(!__traits(compiles, csa == sa1));
+    static assert(!__traits(compiles, sa1 == csa));
+    static assert(!__traits(compiles, csa == csa));
+}
+
+/**************************************/
+
 int main()
 {
     test1();
@@ -664,6 +685,7 @@ int main()
     test14();
     test15();
     test16();
+    test17();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1,7 +1,5 @@
 
-import core.vararg;
-import std.c.stdio;
-import core.exception;
+extern (C) int printf(const(char*) fmt, ...);
 
 int sdtor;
 
@@ -66,14 +64,14 @@ int sdtor4;
 struct S4
 {   int a = 3;
     ~this()
-    {	printf("~S4()\n");
-	if (a == 4)
-	    assert(sdtor4 == 2);
-	else
-	{   assert(a == 3);
-	    assert(sdtor4 == 1);
-	}
-	sdtor4++;
+    {   printf("~S4()\n");
+        if (a == 4)
+            assert(sdtor4 == 2);
+        else
+        {   assert(a == 3);
+            assert(sdtor4 == 1);
+        }
+        sdtor4++;
     }
 }
 
@@ -100,7 +98,7 @@ int sdtor5;
 template M5()
 {  ~this()
    {
-	printf("~M5()\n"); assert(sdtor5 == 1); sdtor5++;
+        printf("~M5()\n"); assert(sdtor5 == 1); sdtor5++;
    }
 }
 
@@ -122,11 +120,11 @@ void test5()
 int sdtor6;
 
 struct S6
-{  int b = 7;
-   ~this()
-   {
-	printf("~S6()\n"); assert(b == 7); assert(sdtor6 == 1); sdtor6++;
-   }
+{   int b = 7;
+    ~this()
+    {
+        printf("~S6()\n"); assert(b == 7); assert(sdtor6 == 1); sdtor6++;
+    }
 }
 
 class T6
@@ -148,14 +146,14 @@ void test6()
 int sdtor7;
 
 struct S7
-{  int b = 7;
-   ~this()
-   {
-	printf("~S7()\n");
-	assert(b == 7);
-	assert(sdtor7 >= 1 && sdtor7 <= 3);
-	sdtor7++;
-   }
+{   int b = 7;
+    ~this()
+    {
+        printf("~S7()\n");
+        assert(b == 7);
+        assert(sdtor7 >= 1 && sdtor7 <= 3);
+        sdtor7++;
+    }
 }
 
 struct T7
@@ -163,10 +161,10 @@ struct T7
     int a = 3;
     S7[3] s;
     ~this()
-    {	printf("~T7() %d\n", sdtor7);
-	assert(a == 3);
-	assert(sdtor7 == 0);
-	sdtor7++;
+    {   printf("~T7() %d\n", sdtor7);
+        assert(a == 3);
+        assert(sdtor7 == 0);
+        sdtor7++;
     }
 }
 
@@ -182,15 +180,15 @@ void test7()
 int sdtor8;
 
 struct S8
-{  int b = 7;
-   int c;
-   ~this()
-   {
-	printf("~S8() %d\n", sdtor8);
-	assert(b == 7);
-	assert(sdtor8 == c);
-	sdtor8++;
-   }
+{   int b = 7;
+    int c;
+    ~this()
+    {
+        printf("~S8() %d\n", sdtor8);
+        assert(b == 7);
+        assert(sdtor8 == c);
+        sdtor8++;
+    }
 }
 
 void test8()
@@ -208,13 +206,13 @@ void test8()
 int sdtor9;
 
 struct S9
-{  int b = 7;
-   ~this()
-   {
-	printf("~S9() %d\n", sdtor9);
-	assert(b == 7);
-	sdtor9++;
-   }
+{   int b = 7;
+    ~this()
+    {
+        printf("~S9() %d\n", sdtor9);
+        assert(b == 7);
+        sdtor9++;
+    }
 }
 
 void test9()
@@ -230,15 +228,15 @@ void test9()
 int sdtor10;
 
 struct S10
-{  int b = 7;
-   int c;
-   ~this()
-   {
-	printf("~S10() %d\n", sdtor10);
-	assert(b == 7);
-	assert(sdtor10 == c);
-	sdtor10++;
-   }
+{   int b = 7;
+    int c;
+    ~this()
+    {
+        printf("~S10() %d\n", sdtor10);
+        assert(b == 7);
+        assert(sdtor10 == c);
+        sdtor10++;
+    }
 }
 
 void test10()
@@ -257,10 +255,10 @@ void test10()
 int sdtor11;
 
 template M11()
-{  ~this()
-   {
-	printf("~M11()\n"); assert(sdtor11 == 1); sdtor11++;
-   }
+{   ~this()
+    {
+        printf("~M11()\n"); assert(sdtor11 == 1); sdtor11++;
+    }
 }
 
 class T11
@@ -305,9 +303,9 @@ struct S13
 {   int a = 3;
     int opAssign(S13 s)
     {
-	printf("S13.opAssign(%p)\n", &this);
-	a = 4;
-	return s.a + 2;
+        printf("S13.opAssign(%p)\n", &this);
+        a = 4;
+        return s.a + 2;
     }
 }
 
@@ -325,9 +323,9 @@ struct S14
 {   int a = 3;
     int opAssign(ref S14 s)
     {
-	printf("S14.opAssign(%p)\n", &this);
-	a = 4;
-	return s.a + 2;
+        printf("S14.opAssign(%p)\n", &this);
+        a = 4;
+        return s.a + 2;
     }
 }
 
@@ -345,9 +343,9 @@ struct S15
 {   int a = 3;
     int opAssign(ref const S15 s)
     {
-	printf("S15.opAssign(%p)\n", &this);
-	a = 4;
-	return s.a + 2;
+        printf("S15.opAssign(%p)\n", &this);
+        a = 4;
+        return s.a + 2;
     }
 }
 
@@ -365,9 +363,9 @@ struct S16
 {   int a = 3;
     int opAssign(S16 s, ...)
     {
-	printf("S16.opAssign(%p)\n", &this);
-	a = 4;
-	return s.a + 2;
+        printf("S16.opAssign(%p)\n", &this);
+        a = 4;
+        return s.a + 2;
     }
 }
 
@@ -385,9 +383,9 @@ struct S17
 {   int a = 3;
     int opAssign(...)
     {
-	printf("S17.opAssign(%p)\n", &this);
-	a = 4;
-	return 5;
+        printf("S17.opAssign(%p)\n", &this);
+        a = 4;
+        return 5;
     }
 }
 
@@ -405,10 +403,10 @@ struct S18
 {   int a = 3;
     int opAssign(S18 s, int x = 7)
     {
-	printf("S18.opAssign(%p)\n", &this);
-	a = 4;
-	assert(x == 7);
-	return s.a + 2;
+        printf("S18.opAssign(%p)\n", &this);
+        a = 4;
+        assert(x == 7);
+        return s.a + 2;
     }
 }
 
@@ -533,10 +531,10 @@ struct S23
 
     this(int x)
     {
-	printf("S23(%d)\n", x);
-	assert(x == 3);
-	assert(m == 4 && n == 0 && o == 0 && p == 0 && q == 0);
-	q = 7;
+        printf("S23(%d)\n", x);
+        assert(x == 3);
+        assert(m == 4 && n == 0 && o == 0 && p == 0 && q == 0);
+        q = 7;
     }
 }
 
@@ -568,10 +566,10 @@ struct S24
 
     this(int x)
     {
-	printf("S24(%d)\n", x);
-	assert(x == 3);
-	assert(m == 0 && n == 0 && o == 0 && p == 0 && q == 0);
-	q = 7;
+        printf("S24(%d)\n", x);
+        assert(x == 3);
+        assert(m == 0 && n == 0 && o == 0 && p == 0 && q == 0);
+        q = 7;
     }
 }
 
@@ -681,7 +679,7 @@ struct A28
     this(this)
     {
         printf("A's copy\n");
-	s28 ~= "A";
+        s28 ~= "A";
     }
 }
 
@@ -691,7 +689,7 @@ struct B28
     this(this)
     {
         printf("B's copy\n");
-	s28 ~= "B";
+        s28 ~= "B";
     }
 }
 
@@ -767,20 +765,20 @@ struct S32
 
     this(int i)
     {
-	printf("ctor %p(%d)\n", &this, i);
-	x += 1;
+        printf("ctor %p(%d)\n", &this, i);
+        x += 1;
     }
 
     this(this)
     {
-	printf("postblit %p\n", &this);
-	x += 0x10;
+        printf("postblit %p\n", &this);
+        x += 0x10;
     }
 
     ~this()
     {
-	printf("dtor %p\n", &this);
-	x += 0x100;
+        printf("dtor %p\n", &this);
+        x += 0x100;
     }
 }
 
@@ -820,20 +818,20 @@ struct S33
 
     this(int i)
     {
-	printf("ctor %p(%d)\n", &this, i);
-	x += 1;
+        printf("ctor %p(%d)\n", &this, i);
+        x += 1;
     }
 
     this(this)
     {
-	printf("postblit %p\n", &this);
-	x += 0x10;
+        printf("postblit %p\n", &this);
+        x += 0x10;
     }
 
     ~this()
     {
-	printf("dtor %p\n", &this);
-	x += 0x100;
+        printf("dtor %p\n", &this);
+        x += 0x100;
     }
 }
 
@@ -841,7 +839,7 @@ struct T33
 {
     S33 foo()
     {
-	return t;
+        return t;
     }
 
     S33 t;
@@ -849,12 +847,12 @@ struct T33
 
 void test33()
 {
-  {
-	T33 t;
-	S33 s = t.foo();
-  }
-  printf("S.x = %x\n", S33.x);
-  assert(S33.x == 0x210);
+    {
+        T33 t;
+        S33 s = t.foo();
+    }
+    printf("S.x = %x\n", S33.x);
+    assert(S33.x == 0x210);
 }
 
 /**********************************/
@@ -862,28 +860,28 @@ void test33()
 struct X34 {
     int i;
     this(this) {
-	printf("postblit %p\n", &this);
+        printf("postblit %p\n", &this);
         ++i;
     }
 
     ~this() {
-	printf("dtor %p\n", &this);
+        printf("dtor %p\n", &this);
     }
 }
 
 void test34()
 {
-     X34[2] xs;
-//     xs[0][0] = X34();
-     printf("foreach\n");
-     for (int j = 0; j < xs.length; j++) { auto x = (j++,j--,xs[j]);
-	//foreach(x; xs) {
-	//printf("foreach x.i = %d\n", x[0].i);
+    X34[2] xs;
+//  xs[0][0] = X34();
+    printf("foreach\n");
+    for (int j = 0; j < xs.length; j++) { auto x = (j++,j--,xs[j]);
+        //foreach(x; xs) {
+        //printf("foreach x.i = %d\n", x[0].i);
         //assert(x[0].i == 1);
-	printf("foreach x.i = %d\n", x.i);
+        printf("foreach x.i = %d\n", x.i);
         assert(x.i == 1);
-     }
-     printf("loop done\n");
+    }
+    printf("loop done\n");
 }
 
 /**********************************/
@@ -892,28 +890,28 @@ struct X35 {
     __gshared int k;
     int i;
     this(this) {
-	printf("postblit %p\n", &this);
+        printf("postblit %p\n", &this);
         ++i;
     }
 
     ~this() {
-	printf("dtor %p\n", &this);
-	k++;
+        printf("dtor %p\n", &this);
+        k++;
     }
 }
 
 void test35()
 {
-  {
-     X35[2] xs;
-     printf("foreach\n");
-     foreach(ref x; xs) {
-	printf("foreach x.i = %d\n", x.i);
-        assert(x.i == 0);
-     }
-     printf("loop done\n");
-  }
-  assert(X35.k == 2);
+    {
+        X35[2] xs;
+        printf("foreach\n");
+        foreach(ref x; xs) {
+            printf("foreach x.i = %d\n", x.i);
+            assert(x.i == 0);
+        }
+        printf("loop done\n");
+    }
+    assert(X35.k == 2);
 }
 
 /**********************************/
@@ -922,28 +920,28 @@ struct X36 {
     __gshared int k;
     int i;
     this(this) {
-	printf("postblit %p\n", &this);
+        printf("postblit %p\n", &this);
         ++i;
     }
 
     ~this() {
-	printf("dtor %p\n", &this);
-	k++;
+        printf("dtor %p\n", &this);
+        k++;
     }
 }
 
 void test36()
 {
-  {
-     X36[2] xs;
-     printf("foreach\n");
-     foreach(x; xs) {
-	printf("foreach x.i = %d\n", x.i);
-        assert(x.i == 1);
-     }
-     printf("loop done\n");
-  }
-  assert(X36.k == 4);
+    {
+        X36[2] xs;
+        printf("foreach\n");
+        foreach(x; xs) {
+            printf("foreach x.i = %d\n", x.i);
+            assert(x.i == 1);
+        }
+        printf("loop done\n");
+    }
+    assert(X36.k == 4);
 }
 
 /**********************************/
@@ -952,26 +950,26 @@ struct X37 {
     __gshared int k;
     int i;
     this(this) {
-	printf("postblit %p\n", &this);
+        printf("postblit %p\n", &this);
         ++i;
     }
 
     ~this() {
-	printf("dtor %p\n", &this);
-	k++;
+        printf("dtor %p\n", &this);
+        k++;
     }
 }
 
 void test37() {
-  {
-     X37[2][3] xs;
-     printf("foreach\n");
-     foreach(ref x; xs) {
-	printf("foreach x.i = %d\n", x[0].i);
-        assert(x[0].i == 0);
-     }
-     printf("loop done\n");
-  }
+    {
+        X37[2][3] xs;
+        printf("foreach\n");
+        foreach(ref x; xs) {
+            printf("foreach x.i = %d\n", x[0].i);
+            assert(x[0].i == 0);
+        }
+        printf("loop done\n");
+    }
   assert(X37.k == 6);
 }
 
@@ -983,21 +981,21 @@ struct S38 {
 
     this(int x) {
         printf("this(%d)\n", x);
-	assert(this.x == 0);
+        assert(this.x == 0);
         this.x = x;
-	count++;
+        count++;
     }
     this(this) {
         printf("this(this) with %d\n", x);
-	assert(x == 1 || x == 2);
-	count++;
-	postblit++;
+        assert(x == 1 || x == 2);
+        count++;
+        postblit++;
     }
     ~this() {
         printf("~this(%d)\n", x);
-	assert(x == 1 || x == 2);
-	x = 0;
-	count--;
+        assert(x == 1 || x == 2);
+        x = 0;
+        count--;
     }
     int x;
 }
@@ -1048,7 +1046,7 @@ void test39()
     assert(f.x == 6);
     f = y;
     assert(f.x == 8);
-//    f = Foo39(y);
+//  f = Foo39(y);
 
 }
 
@@ -1059,12 +1057,12 @@ bool approxEqual(float a, float b)
     return a < b ? b-a < .001 : a-b < .001;
 }
 
-struct Point { 
-   float x = 0, y = 0;
-   const bool opEquals(const ref Point rhs)
-   {
-	return approxEqual(x, rhs.x) && approxEqual(y, rhs.y);
-   }
+struct Point {
+    float x = 0, y = 0;
+    const bool opEquals(const ref Point rhs)
+    {
+        return approxEqual(x, rhs.x) && approxEqual(y, rhs.y);
+    }
 }
 
 struct Rectangle {
@@ -1121,7 +1119,7 @@ void test42()
 struct S43 {
     int i;
     int* p;
-//    this(int i, int* t) immutable { this.i = i; p = t;  }
+//  this(int i, int* t) immutable { this.i = i; p = t;  }
 }
 
 void test43()
@@ -1155,10 +1153,10 @@ void test44()
 /**********************************/
 
 class C45 {
-   C45 next;
-   this(int[] data) immutable {
-      next = new immutable(C45)(data[1 .. $]);
-   }
+    C45 next;
+    this(int[] data) immutable {
+        next = new immutable(C45)(data[1 .. $]);
+    }
 }
 
 void test45()
@@ -1185,24 +1183,24 @@ struct Segfault3984
 {
     int a;
     this(int x){
-      a = x;
+        a = x;
     }
 }
 
 void test47()
 {
     //static
-	assert(Segfault3984(3).a == 3);
+    assert(Segfault3984(3).a == 3);
 }
 
 /**********************************/
 
 void test48()
 {
-   struct B {
-       void foo()  {   }
-   }
-   B x = B.init;
+    struct B {
+        void foo()  {   }
+    }
+    B x = B.init;
 }
 
 /**********************************/
@@ -1236,7 +1234,7 @@ struct aStruct{
 class aClass{
     void aFunc(aStruct a = aStruct(44))
     {
-	assert(a.m_Int == 44);
+        assert(a.m_Int == 44);
     }
 }
 
@@ -1289,18 +1287,18 @@ struct A52
     this(this)
     {
         printf("this(this) %p\n", &this);
-	s52 ~= 'a';
+        s52 ~= 'a';
     }
     ~this()
     {
         printf("~this() %p\n", &this);
-	s52 ~= 'b';
+        s52 ~= 'b';
     }
     A52 copy()
     {
-	s52 ~= 'c';
-	A52 another = this;
-	return another;
+        s52 ~= 'c';
+        A52 another = this;
+        return another;
     }
 }
 
@@ -1335,20 +1333,20 @@ struct S54
 
     this(int i)
     {
-	printf("ctor %p(%d)\n", &this, i);
-	t ~= "a";
+        printf("ctor %p(%d)\n", &this, i);
+        t ~= "a";
     }
 
     this(this)
     {
-	printf("postblit %p\n", &this);
-	t ~= "b";
+        printf("postblit %p\n", &this);
+        t ~= "b";
     }
 
     ~this()
     {
-	printf("dtor %p\n", &this);
-	t ~= "c";
+        printf("dtor %p\n", &this);
+        t ~= "c";
     }
 
     static string t;
@@ -1360,50 +1358,50 @@ S54 abc54() { return S54(1); }
 
 void test54()
 {
-    {	S54.t = null;
-	S54 s = S54(1);
+    {   S54.t = null;
+        S54 s = S54(1);
     }
     assert(S54.t == "ac");
 
-    {	S54.t = null;
-	S54 s = S54();
+    {   S54.t = null;
+        S54 s = S54();
     }
     assert(S54.t == "c");
 
-    {	S54.t = null;
-	int b = 1 && (bar54(S54(1)), 1);
+    {   S54.t = null;
+        int b = 1 && (bar54(S54(1)), 1);
     }
     assert(S54.t == "ac");
 
-    {	S54.t = null;
-	int b = 0 && (bar54(S54(1)), 1);
+    {   S54.t = null;
+        int b = 0 && (bar54(S54(1)), 1);
     }
     assert(S54.t == "");
 
-    {	S54.t = null;
-	int b = 0 || (bar54(S54(1)), 1);
+    {   S54.t = null;
+        int b = 0 || (bar54(S54(1)), 1);
     }
     assert(S54.t == "ac");
 
-    {	S54.t = null;
-	int b = 1 || (bar54(S54(1)), 1);
+    {   S54.t = null;
+        int b = 1 || (bar54(S54(1)), 1);
     }
     assert(S54.t == "");
 
     {
-	S54.t = null;
-	{ const S54 s = S54(1); }
-	assert(S54.t == "ac");
+    S54.t = null;
+    { const S54 s = S54(1); }
+        assert(S54.t == "ac");
     }
     {
-	S54.t = null;
-	abc54();
-	assert(S54.t == "ac");
+        S54.t = null;
+        abc54();
+        assert(S54.t == "ac");
     }
     {
-	S54.t = null;
-	abc54().x += 1;
-	assert(S54.t == "ac");
+        S54.t = null;
+        abc54().x += 1;
+        assert(S54.t == "ac");
     }
 }
 
@@ -1433,20 +1431,20 @@ struct S56
 
     this(int i)
     {
-	printf("ctor %p(%d)\n", &this, i);
-	t ~= "a";
+        printf("ctor %p(%d)\n", &this, i);
+        t ~= "a";
     }
 
     this(this)
     {
-	printf("postblit %p\n", &this);
-	t ~= "b";
+        printf("postblit %p\n", &this);
+        t ~= "b";
     }
 
     ~this()
     {
-	printf("dtor %p\n", &this);
-	t ~= "c";
+        printf("dtor %p\n", &this);
+        t ~= "c";
     }
 
     static string t;
@@ -1482,147 +1480,146 @@ void test56()
 /**********************************/
 // 5859
 
-import std.stdio : writeln;
 int dtor_cnt = 0;
 struct S57
 {
-	int v;
-	this(int n){ writeln("S.ctor v=", v=n); }
-	~this(){ ++dtor_cnt; writeln("S.dtor v=", v); }
-	bool opCast(T:bool)(){ writeln("S.cast v=", v); return true; }
+    int v;
+    this(int n){ v = n; printf("S.ctor v=%d\n", v); }
+    ~this(){ ++dtor_cnt; printf("S.dtor v=%d\n", v); }
+    bool opCast(T:bool)(){ printf("S.cast v=%d\n", v); return true; }
 }
 S57 f(int n){ return S57(n); }
 
 void test57()
 {
-	writeln("----");
-	dtor_cnt = 0;
-	if (auto s = S57(10))
-	{
-		writeln("ifbody");
-	}
-	else assert(0);
-	assert(dtor_cnt == 1);
+    printf("----\n");
+    dtor_cnt = 0;
+    if (auto s = S57(10))
+    {
+        printf("ifbody\n");
+    }
+    else assert(0);
+    assert(dtor_cnt == 1);
 
-	writeln("----");	//+
-	dtor_cnt = 0;
-	if (auto s = (S57(1), S57(2), S57(10)))
-	{
-		assert(dtor_cnt == 2);
-		writeln("ifbody");
-	}
-	else assert(0);
-	assert(dtor_cnt == 3);	// +/
+    printf("----\n");    //+
+    dtor_cnt = 0;
+    if (auto s = (S57(1), S57(2), S57(10)))
+    {
+        assert(dtor_cnt == 2);
+        printf("ifbody\n");
+    }
+    else assert(0);
+    assert(dtor_cnt == 3);  // +/
 
-	writeln("----");
-	dtor_cnt = 0;
-	try{
-		if (auto s = S57(10))
-		{
-			writeln("ifbody");
-			throw new Exception("test");
-		}
-		else assert(0);
-	}catch (Exception e){}
-	assert(dtor_cnt == 1);
-
-
-
-	writeln("----");
-	dtor_cnt = 0;
-	if (auto s = f(10))
-	{
-		writeln("ifbody");
-	}
-	else assert(0);
-	assert(dtor_cnt == 1);
-
-	writeln("----");	//+
-	dtor_cnt = 0;
-	if (auto s = (f(1), f(2), f(10)))
-	{
-		assert(dtor_cnt == 2);
-		writeln("ifbody");
-	}
-	else assert(0);
-	assert(dtor_cnt == 3);	// +/
-
-	writeln("----");
-	dtor_cnt = 0;
-	try{
-		if (auto s = f(10))
-		{
-			writeln("ifbody");
-			throw new Exception("test");
-		}
-		else assert(0);
-	}catch (Exception e){}
-	assert(dtor_cnt == 1);
+    printf("----\n");
+    dtor_cnt = 0;
+    try{
+        if (auto s = S57(10))
+        {
+            printf("ifbody\n");
+            throw new Exception("test");
+        }
+        else assert(0);
+    }catch (Exception e){}
+    assert(dtor_cnt == 1);
 
 
 
+    printf("----\n");
+    dtor_cnt = 0;
+    if (auto s = f(10))
+    {
+        printf("ifbody\n");
+    }
+    else assert(0);
+    assert(dtor_cnt == 1);
 
-	writeln("----");
-	dtor_cnt = 0;
-	if (S57(10))
-	{
-		assert(dtor_cnt == 1);
-		writeln("ifbody");
-	}
-	else assert(0);
+    printf("----\n");    //+
+    dtor_cnt = 0;
+    if (auto s = (f(1), f(2), f(10)))
+    {
+        assert(dtor_cnt == 2);
+        printf("ifbody\n");
+    }
+    else assert(0);
+    assert(dtor_cnt == 3);  // +/
 
-	writeln("----");
-	dtor_cnt = 0;
-	if ((S57(1), S57(2), S57(10)))
-	{
-		assert(dtor_cnt == 3);
-		writeln("ifbody");
-	}
-	else assert(0);
-
-	writeln("----");
-	dtor_cnt = 0;
-	try{
-		if (auto s = S57(10))
-		{
-			writeln("ifbody");
-			throw new Exception("test");
-		}
-		else assert(0);
-	}catch (Exception e){}
-	assert(dtor_cnt == 1);
+    printf("----\n");
+    dtor_cnt = 0;
+    try{
+        if (auto s = f(10))
+        {
+            printf("ifbody\n");
+            throw new Exception("test");
+        }
+        else assert(0);
+    }catch (Exception e){}
+    assert(dtor_cnt == 1);
 
 
 
-	writeln("----");
-	dtor_cnt = 0;
-	if (f(10))
-	{
-		assert(dtor_cnt == 1);
-		writeln("ifbody");
-	}
-	else assert(0);
 
-	writeln("----");
-	dtor_cnt = 0;
-	if ((f(1), f(2), f(10)))
-	{
-		assert(dtor_cnt == 3);
-		writeln("ifbody");
-	}
-	else assert(0);
+    printf("----\n");
+    dtor_cnt = 0;
+    if (S57(10))
+    {
+        assert(dtor_cnt == 1);
+        printf("ifbody\n");
+    }
+    else assert(0);
 
-	writeln("----");
-	dtor_cnt = 0;
-	try{
-		if (auto s = f(10))
-		{
-			writeln("ifbody");
-			throw new Exception("test");
-		}
-		else assert(0);
-	}catch (Exception e){}
-	assert(dtor_cnt == 1);
+    printf("----\n");
+    dtor_cnt = 0;
+    if ((S57(1), S57(2), S57(10)))
+    {
+        assert(dtor_cnt == 3);
+        printf("ifbody\n");
+    }
+    else assert(0);
+
+    printf("----\n");
+    dtor_cnt = 0;
+    try{
+        if (auto s = S57(10))
+        {
+            printf("ifbody\n");
+            throw new Exception("test");
+        }
+        else assert(0);
+    }catch (Exception e){}
+    assert(dtor_cnt == 1);
+
+
+
+    printf("----\n");
+    dtor_cnt = 0;
+    if (f(10))
+    {
+        assert(dtor_cnt == 1);
+        printf("ifbody\n");
+    }
+    else assert(0);
+
+    printf("----\n");
+    dtor_cnt = 0;
+    if ((f(1), f(2), f(10)))
+    {
+        assert(dtor_cnt == 3);
+        printf("ifbody\n");
+    }
+    else assert(0);
+
+    printf("----\n");
+    dtor_cnt = 0;
+    try{
+        if (auto s = f(10))
+        {
+            printf("ifbody\n");
+            throw new Exception("test");
+        }
+        else assert(0);
+    }catch (Exception e){}
+    assert(dtor_cnt == 1);
 }
 
 /**********************************/
@@ -1654,22 +1651,22 @@ S58* ps58;
 
 struct S58
 {
-	@disable this(this);
-	~this(){ ++sdtor58; }
+    @disable this(this);
+    ~this(){ ++sdtor58; }
 }
 
 S58 makeS58()
 {
-	S58 s;
-	ps58 = &s;
-	return s;
+    S58 s;
+    ps58 = &s;
+    return s;
 }
 
 void test58()
 {
-	auto s1 = makeS58();
-	assert(ps58 == &s1);
-	assert(sdtor58 == 0);
+    auto s1 = makeS58();
+    assert(ps58 == &s1);
+    assert(sdtor58 == 0);
 }
 
 /**********************************/
@@ -1690,7 +1687,7 @@ struct C59
 void foo59()
 {
     C59().oops();
-//    auto c = C(); c.oops();
+//  auto c = C(); c.oops();
 }
 
 
@@ -1698,7 +1695,7 @@ void test59()
 {
     int i = 0;
     try
-	foo59();
+        foo59();
     catch (Throwable)
     {   i = 1;
     }

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1752,6 +1752,75 @@ void test6499()
 
 /**********************************/
 
+template isImplicitlyConvertible(From, To)
+{
+    enum bool isImplicitlyConvertible = is(typeof({
+                        void fun(ref From v) {
+                            void gun(To) {}
+                            gun(v);
+                        }
+                    }()));
+}
+
+void test60()
+{
+    static struct X1
+    {
+        void* ptr;
+        this(this){}
+    }
+    static struct S1
+    {
+        X1 x;
+    }
+
+    static struct X2
+    {
+        int ptr;
+        this(this){}
+    }
+    static struct S2
+    {
+        X2 x;
+    }
+
+    {
+              S1  ms;
+              S1  ms2 = ms; // mutable to mutable
+        const(S1) cs2 = ms; // mutable to const                         // NG -> OK
+    }
+    {
+        const(S1) cs;
+        static assert(!__traits(compiles,{                              // NG -> OK
+              S1 ms2 = cs;  // field has reference, then const to mutable is invalid
+        }));
+        const(S1) cs2 = cs; // const to const                           // NG -> OK
+    }
+    static assert( isImplicitlyConvertible!(      S1 ,       S1 ) );
+    static assert( isImplicitlyConvertible!(      S1 , const(S1)) );    // NG -> OK
+    static assert(!isImplicitlyConvertible!(const(S1),       S1 ) );
+    static assert( isImplicitlyConvertible!(const(S1), const(S1)) );    // NG -> OK
+
+
+    {
+              S2  ms;
+              S2  ms2 = ms; // mutable to mutable
+        const(S2) cs2 = ms; // mutable to const                         // NG -> OK
+    }
+    {
+        const(S2) cs;
+              S2  ms2 = cs; // all fields are value, then const to mutable is OK
+        const(S2) cs2 = cs; // const to const                           // NG -> OK
+    }
+
+    static assert( isImplicitlyConvertible!(      S2 ,       S2 ) );
+    static assert( isImplicitlyConvertible!(      S2 , const(S2)) );    // NG -> OK
+    static assert( isImplicitlyConvertible!(const(S2),       S2 ) );
+    static assert( isImplicitlyConvertible!(const(S2), const(S2)) );    // NG -> OK
+}
+
+/**********************************/
+
 int main()
 {
     test1();
@@ -1814,6 +1883,7 @@ int main()
     test58();
     test59();
     test6499();
+    test60();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3659

requires: druntime git://github.com/9rnsr/druntime.git relax_opEquals_sig

Points:
- Remove opEquals signature restriction.
  
  We can define any signatures of `opEquals`, even if it is template funciton.
- Make stub for TypeInfo_Struct.xopEquals
  
  (Needs druntime fix, see https://github.com/D-Programming-Language/druntime/pull/70)
  
  `TypeInfo.equals` gets two lvalue through `in void*`.
  So we should make stub for calling user `opEquals`.
  
  ```
  xopEquals = bool function(in void* p, in void* q) {
      return ( *cast(const S*)p ).opEquals( *cast(const S*)q );
  };
  ```
  
  // If user opEquals is qualified const, and gets ref const S, and returns bool,
  // we can set its function pointer to xopEquals directly.
  // But it is not yet implemented.
  
  If this stub couldn't compile, stub code is replaced with follows:
  
  ```
  xopEquals = bool function(in void* p, in void* q) {
      throw Error("TypeInfo.equals is not implemented")
  };
  ```
  
  `TypeInfo.equals` should not break both objects constness, so we cannot call
  the `opEquals` that breaks objects constness. Instead throws `Error` at runtime.
- If no user opEquals (and need opEquals definition), compiler builds following opEquals automatically.
  
  const bool opEquals(const S rhs) { ... }
  
  This signature can receive rvalue of S, and const copy of lvalue.
