### PR TITLE
Static array and array literal improvements

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2753,7 +2753,7 @@ elem *AssignExp::toElem(IRState *irs)
             /* Determine if we need to do postblit
              */
             int postblit = 0;
-            if (needsPostblit(t1))
+            if (needsPostblit(t1->nextOf()))
                 postblit = 1;
 
             assert(e2->type->ty != Tpointer);

--- a/src/expression.c
+++ b/src/expression.c
@@ -10361,16 +10361,6 @@ Ltupleassign:
                 sd->cpctor)
             {   /* We have a copy constructor for this
                  */
-                // Scan past commma's
-                Expression *ec = NULL;
-                while (e2->op == TOKcomma)
-                {   CommaExp *ecomma = (CommaExp *)e2;
-                    e2 = ecomma->e2;
-                    if (ec)
-                        ec = new CommaExp(ecomma->loc, ec, ecomma->e1);
-                    else
-                        ec = ecomma->e1;
-                }
                 if (e2->op == TOKquestion)
                 {   /* Write as:
                      *  a ? e1 = b : e1 = c;
@@ -10381,8 +10371,6 @@ Ltupleassign:
                     AssignExp *ea2 = new AssignExp(econd->e1->loc, e1, econd->e2);
                     ea2->op = op;
                     Expression *e = new CondExp(loc, econd->econd, ea1, ea2);
-                    if (ec)
-                        e = new CommaExp(loc, ec, e);
                     return e->semantic(sc);
                 }
                 else if (e2->op == TOKvar ||
@@ -10398,8 +10386,6 @@ Ltupleassign:
 
                     Expression *e = new DotVarExp(loc, e1, sd->cpctor, 0);
                     e = new CallExp(loc, e, e2);
-                    if (ec)
-                        e = new CommaExp(loc, ec, e);
                     return e->semantic(sc);
                 }
                 else if (e2->op == TOKcall)

--- a/src/expression.c
+++ b/src/expression.c
@@ -10410,6 +10410,21 @@ Ltupleassign:
 
     if (t1->ty == Tsarray && !refinit)
     {
+        Type *t2 = e2->type->toBasetype();
+
+        if (t2->ty == Tsarray && !t2->implicitConvTo(t1->nextOf()))
+        {   // static array assignment should check their lengths
+            TypeSArray *tsa1 = (TypeSArray *)t1;
+            TypeSArray *tsa2 = (TypeSArray *)t2;
+            uinteger_t dim1 = tsa1->dim->toInteger();
+            uinteger_t dim2 = tsa2->dim->toInteger();
+            if (dim1 != dim2)
+            {
+                error("mismatched array lengths, %d and %d", (int)dim1, (int)dim2);
+                return new ErrorExp();
+            }
+        }
+
         if (e1->op == TOKindex &&
             ((IndexExp *)e1)->e1->type->toBasetype()->ty == Taarray)
         {
@@ -10421,7 +10436,6 @@ Ltupleassign:
         }
         else
         {
-            Type *t2 = e2->type->toBasetype();
             // Convert e2 to e2[], unless e2-> e1[0]
             if (t2->ty == Tsarray && !t2->implicitConvTo(t1->nextOf()))
             {

--- a/src/func.c
+++ b/src/func.c
@@ -1577,12 +1577,14 @@ void FuncDeclaration::semantic3(Scope *sc)
                     if (v->storage_class & (STCref | STCout))
                         continue;
 
+#if !SARRAYVALUE
                     /* Don't do this for static arrays, since static
                      * arrays are called by reference. Remove this
                      * when we change them to call by value.
                      */
                     if (v->type->toBasetype()->ty == Tsarray)
                         continue;
+#endif
 
                     if (v->noscope)
                         continue;

--- a/test/fail_compilation/fail3703.d
+++ b/test/fail_compilation/fail3703.d
@@ -1,0 +1,9 @@
+// Issue 3703 - static array assignment
+
+void main()
+{
+    int[1] a = [1];
+    int[2] b;
+
+    b = a;  // should make compile error
+}

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1878,6 +1878,37 @@ void test6177()
 
 
 /**********************************/
+// 6470
+
+struct S6470
+{
+    static int spblit;
+
+    this(this){ ++spblit; }
+}
+
+void test6470()
+{
+    S6470[] a1;
+    S6470[] a2;
+    a1.length = 3;
+    a2.length = 3;
+    a1[] = a2[];
+    assert(S6470.spblit == 3);
+
+    S6470 s;
+
+    S6470[] a3;
+    a3.length = 3;
+    a3 = [s, s, s];
+    assert(S6470.spblit == 6);
+
+    void func(S6470[] a){}
+    func([s, s, s]);
+    assert(S6470.spblit == 9);
+}
+
+/**********************************/
 // 6636
 
 struct S6636
@@ -2025,6 +2056,7 @@ int main()
     test60();
     test4316();
     test6177();
+    test6470();
     test6636();
     test6637();
     test7353();

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1878,6 +1878,28 @@ void test6177()
 
 
 /**********************************/
+// 6636
+
+struct S6636
+{
+    ~this()
+    {
+        ++sdtor;
+    }
+}
+
+void func6636(S6636[3] sa) {}
+
+void test6636()
+{
+    sdtor = 0;
+
+    S6636[3] sa;
+    func6636(sa);
+    assert(sdtor == 3);
+}
+
+/**********************************/
 // 7353
 
 struct S7353
@@ -1984,6 +2006,7 @@ int main()
     test60();
     test4316();
     test6177();
+    test6636();
     test7353();
 
     printf("Success\n");

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1900,6 +1900,25 @@ void test6636()
 }
 
 /**********************************/
+// 6637
+
+struct S6637
+{
+    static int spblit;
+
+    this(this){ ++spblit; }
+}
+
+void test6637()
+{
+    void func(S6637[3] sa){}
+
+    S6637[3] sa;
+    func(sa);
+    assert(S6637.spblit == 3);
+}
+
+/**********************************/
 // 7353
 
 struct S7353
@@ -2007,6 +2026,7 @@ int main()
     test4316();
     test6177();
     test6636();
+    test6637();
     test7353();
 
     printf("Success\n");


### PR DESCRIPTION
- <a href="http://d.puremagic.com/issues/show_bug.cgi?id=3703">Issue 3703</a> - static array assignment
  Check static-array length matching on assign expression.
- <del><a href="http://d.puremagic.com/issues/show_bug.cgi?id=5290">Issue 5290</a> - Static array literals with too few elements
  Check static-array length matching on initialiging.</del>
- <a href="http://d.puremagic.com/issues/show_bug.cgi?id=6470">Issue 6470</a> - postblits not called on arrays of structs
  Call postblits of array literal elements correctly.
- <del><a href="http://d.puremagic.com/issues/show_bug.cgi?id=2356">Issue 2356</a> - array literal as non static initializer generates horribly inefficient code
  If array literal is used as static-array initializer, the initializing is converted as initializings of elements.
  An initializing of static-array
    `S[n] sa = [e0, e1, ..., en-1];`
  is converted to
    `sa[0] = e0, sa[1] = e1, ..., sa[n-1] = en-1;`</del>
- <a href="http://d.puremagic.com/issues/show_bug.cgi?id=6636">Issue 6636</a> - Destructors of static array elements are not called on function parameter
- <a href="http://d.puremagic.com/issues/show_bug.cgi?id=6637">Issue 6637</a> - Postblits of static array elements are not called on function argument
