### PR TITLE
Fix the gagging system: bugs 4197 5453 6296 6661

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1358,9 +1358,7 @@ Lnomatch:
 
             if (!global.errors && !inferred)
             {
-                unsigned errors = global.errors;
-                global.gag++;
-                //printf("+gag\n");
+                unsigned errors = global.startGagging();
                 Expression *e;
                 Initializer *i2 = init;
                 inuse++;
@@ -1419,12 +1417,8 @@ Lnomatch:
                     i2 = i2->semantic(sc, type, WANTinterpret);
                 }
                 inuse--;
-                global.gag--;
-                //printf("-gag\n");
-                if (errors != global.errors)    // if errors happened
+                if (global.endGagging(errors))    // if errors happened
                 {
-                    if (global.gag == 0)
-                        global.errors = errors; // act as if nothing happened
 #if DMDV2
                     /* Save scope for later use, to try again
                      */

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -558,6 +558,10 @@ void Dsymbol::error(const char *format, ...)
         fflush(stdmsg);
 //halt();
     }
+    else
+    {
+        global.gaggedErrors++;
+    }
     global.errors++;
 
     //fatal();
@@ -586,6 +590,10 @@ void Dsymbol::error(Loc loc, const char *format, ...)
         fprintf(stdmsg, "\n");
         fflush(stdmsg);
 //halt();
+    }
+    else
+    {
+        global.gaggedErrors++;
     }
 
     global.errors++;

--- a/src/expression.c
+++ b/src/expression.c
@@ -1106,13 +1106,10 @@ Expression *Expression::semantic(Scope *sc)
 Expression *Expression::trySemantic(Scope *sc)
 {
     //printf("+trySemantic(%s)\n", toChars());
-    unsigned errors = global.errors;
-    global.gag++;
+    unsigned errors = global.startGagging();
     Expression *e = semantic(sc);
-    global.gag--;
-    if (errors != global.errors)
+    if (global.endGagging(errors))
     {
-        global.errors = errors;
         e = NULL;
     }
     //printf("-trySemantic(%s)\n", toChars());
@@ -6503,14 +6500,11 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
          * as:
          *   .ident(e1)
          */
-        unsigned errors = global.errors;
-        global.gag++;
+        unsigned errors = global.startGagging();
         Type *t1 = e1->type;
         e = e1->type->dotExp(sc, e1, ident);
-        global.gag--;
-        if (errors != global.errors)    // if failed to find the property
+        if (global.endGagging(errors))    // if failed to find the property
         {
-            global.errors = errors;
             e1->type = t1;              // kludge to restore type
             e = new DotIdExp(loc, new IdentifierExp(loc, Id::empty), ident);
             e = new CallExp(loc, e, e1);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -318,6 +318,10 @@ void Lexer::error(const char *format, ...)
         if (global.errors >= 20)        // moderate blizzard of cascading messages
             fatal();
     }
+    else
+    {
+        global.gaggedErrors++;
+    }
     global.errors++;
 }
 
@@ -340,6 +344,10 @@ void Lexer::error(Loc loc, const char *format, ...)
 
         if (global.errors >= 20)        // moderate blizzard of cascading messages
             fatal();
+    }
+    else
+    {
+        global.gaggedErrors++;
     }
     global.errors++;
 }

--- a/src/mars.c
+++ b/src/mars.c
@@ -98,6 +98,24 @@ Global::Global()
     memset(&params, 0, sizeof(Param));
 }
 
+unsigned Global::startGagging()
+{
+    ++gag;
+    return gaggedErrors;
+}
+
+bool Global::endGagging(unsigned oldGagged)
+{
+    bool anyErrs = (gaggedErrors != oldGagged);
+    --gag;
+    // Restore the original state of gagged errors; set total errors
+    // to be original errors + new ungagged errors.
+    errors -= (gaggedErrors - oldGagged);
+    gaggedErrors = oldGagged;
+    return anyErrs;
+}
+
+
 char *Loc::toChars()
 {
     OutBuffer buf;
@@ -176,6 +194,10 @@ void verror(Loc loc, const char *format, va_list ap)
         fprintf(stdmsg, "\n");
         fflush(stdmsg);
 //halt();
+    }
+    else
+    {
+        global.gaggedErrors++;
     }
     global.errors++;
 }

--- a/src/mars.h
+++ b/src/mars.h
@@ -256,9 +256,18 @@ struct Global
     const char *version;
 
     Param params;
-    unsigned errors;    // number of errors reported so far
-    unsigned warnings;  // number of warnings reported so far
-    unsigned gag;       // !=0 means gag reporting of errors & warnings
+    unsigned errors;       // number of errors reported so far
+    unsigned warnings;     // number of warnings reported so far
+    unsigned gag;          // !=0 means gag reporting of errors & warnings
+    unsigned gaggedErrors; // number of errors reported while gagged
+
+    // Start gagging. Return the current number of gagged errors
+    unsigned startGagging();
+
+    /* End gagging, restoring the old gagged state.
+     * Return true if errors occured while gagged.
+     */
+    bool endGagging(unsigned oldGagged);
 
     Global();
 };

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -317,13 +317,10 @@ Type *Type::semantic(Loc loc, Scope *sc)
 Type *Type::trySemantic(Loc loc, Scope *sc)
 {
     //printf("+trySemantic(%s) %d\n", toChars(), global.errors);
-    unsigned errors = global.errors;
-    global.gag++;                       // suppress printing of error messages
+    unsigned errors = global.startGagging();
     Type *t = semantic(loc, sc);
-    global.gag--;
-    if (errors != global.errors)        // if any errors happened
+    if (global.endGagging(errors))        // if any errors happened
     {
-        global.errors = errors;
         t = NULL;
     }
     //printf("-trySemantic(%s) %d\n", toChars(), global.errors);
@@ -5993,15 +5990,12 @@ Type *TypeInstance::semantic(Loc loc, Scope *sc)
 
     if (sc->parameterSpecialization)
     {
-        unsigned errors = global.errors;
-        global.gag++;
+        unsigned errors = global.startGagging();
 
         resolve(loc, sc, &e, &t, &s);
 
-        global.gag--;
-        if (errors != global.errors)
-        {   if (global.gag == 0)
-                global.errors = errors;
+        if (global.endGagging(errors))
+        {
             return this;
         }
     }
@@ -6026,17 +6020,12 @@ Dsymbol *TypeInstance::toDsymbol(Scope *sc)
 
     if (sc->parameterSpecialization)
     {
-        unsigned errors = global.errors;
-        global.gag++;
+        unsigned errors = global.startGagging();
 
         resolve(loc, sc, &e, &t, &s);
 
-        global.gag--;
-        if (errors != global.errors)
-        {   if (global.gag == 0)
-                global.errors = errors;
+        if (global.endGagging(errors))
             return NULL;
-        }
     }
     else
         resolve(loc, sc, &e, &t, &s);
@@ -7258,13 +7247,10 @@ MATCH TypeStruct::implicitConvTo(Type *to)
         /* If there is an error instantiating AssociativeArray!(), it shouldn't
          * be reported -- it just means implicit conversion is impossible.
          */
-        ++global.gag;
-        int errs = global.errors;
+        int errs = global.startGagging();
         to = ((TypeAArray*)to)->getImpl()->type;
-        --global.gag;
-        if (errs != global.errors)
+        if (global.endGagging(errs))
         {
-            global.errors = errs;
             return MATCHnomatch;
         }
     }

--- a/src/statement.c
+++ b/src/statement.c
@@ -3597,13 +3597,10 @@ Statement *ReturnStatement::semantic(Scope *sc)
                          * (but first ensure it doesn't fail the "check for
                          * escaping reference" test)
                          */
-                        unsigned errors = global.errors;
-                        global.gag++;
+                        unsigned errors = global.startGagging();
                         exp->checkEscapeRef();
-                        global.gag--;
-                        if (errors != global.errors)
+                        if (global.endGagging(errors))
                         {   tf->isref = FALSE;  // return by value
-                            global.errors = errors;
                         }
                     }
                     else

--- a/src/template.c
+++ b/src/template.c
@@ -3906,9 +3906,26 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         // It's a match
         inst = ti;
         parent = ti->parent;
-        // Check if it is the first non-speculative instantiation
+
+        // If both this and the previous instantiation were speculative,
+        // use the number of errors that happened last time.
+        if (inst->speculative && global.gag)
+        {
+            global.errors += inst->errors;
+            global.gaggedErrors += inst->errors;
+        }
+
+        // If the first instantiation was speculative, but this is not:
         if (inst->speculative && !global.gag)
+        {
+            // If the first instantiation had failed, re-run semantic,
+            // so that error messages are shown.
+            if (inst->errors)
+                goto L1;
+            // It had succeeded, mark it is a non-speculative instantiation,
+            // and reuse it.
             inst->speculative = 0;
+        }
 
 #if LOG
         printf("\tit's a match with instance %p\n", inst);

--- a/src/template.c
+++ b/src/template.c
@@ -4954,11 +4954,22 @@ void TemplateInstance::semantic3(Scope *sc)
         sc = sc->push(argsym);
         sc = sc->push(this);
         sc->tinst = this;
+        int oldgag = global.gag;
+        /* If this is a speculative instantiation, gag errors.
+         * Future optimisation: If the results are actually needed, errors
+         * would already be gagged, so we don't really need to run semantic
+         * on the members.
+         */
+        if (speculative && !global.gag)
+            global.gag = 1;
         for (size_t i = 0; i < members->dim; i++)
         {
             Dsymbol *s = members->tdata()[i];
             s->semantic3(sc);
+            if (global.gag && errors)
+                break;
         }
+        global.gag = oldgag;
         sc = sc->pop();
         sc->pop();
     }

--- a/src/template.h
+++ b/src/template.h
@@ -293,6 +293,7 @@ struct TemplateInstance : ScopeDsymbol
     int havetempdecl;   // 1 if used second constructor
     Dsymbol *isnested;  // if referencing local symbols, this is the context
     int errors;         // 1 if compiled with errors
+    int speculative;    // 1 if only instantiated with errors gagged
 #ifdef IN_GCC
     /* On some targets, it is necessary to know whether a symbol
        will be emitted in the output or not before the symbol

--- a/src/traits.c
+++ b/src/traits.c
@@ -403,8 +403,7 @@ Expression *TraitsExp::semantic(Scope *sc)
         {   Object *o = args->tdata()[i];
             Expression *e;
 
-            unsigned errors = global.errors;
-            global.gag++;
+            unsigned errors = global.startGagging();
 
             Type *t = isType(o);
             if (t)
@@ -425,10 +424,8 @@ Expression *TraitsExp::semantic(Scope *sc)
                 }
             }
 
-            global.gag--;
-            if (errors != global.errors)
+            if (global.endGagging(errors))
             {
-                global.errors = errors;
                 goto Lfalse;
             }
         }

--- a/src/traits.c
+++ b/src/traits.c
@@ -263,7 +263,10 @@ Expression *TraitsExp::semantic(Scope *sc)
             e = e->trySemantic(sc);
             if (!e)
             {   if (global.gag)
+                {
                     global.errors++;
+                    global.gaggedErrors++;
+                }
                 goto Lfalse;
             }
             else


### PR DESCRIPTION
This pull request fixes a major structural problem: errors can be gagged, but not ungagged.
It's a big problem because when forward references cause us to run semantic early, if the forward reference happened while errors were gagged, the error messages will never be seen. This typically results in wrong code or an ICE in the back end.

The first two commits change the global.errors struct to include both gagged and ungagged errors. It's done in a way to minimize changes elsewhere (global.errors behaves exactly as before).
Secondly, a 'speculative' member is added to TemplateInstance, which is true if the template has only ever been instantiated with errors gagged.
Finally, we use this 'speculative' member to ungag errors when running semantic3 on a forward referenced function. I've dealt with two cases here: (a) where we're inferring the return type; (b) where it is in CTFE.

There are still some other forward reference gagging bugs which I haven't dealt with yet, but these commits deal with all of the function-related ones, and they prevent failed template instantiations from surviving to the back-end. Fixes these bugs:

4197 ICE(glue.c): error in forward-referenced in/out contract
5453 ICE(statement.c): invalid switch statement forward referenced by CTFE
6296 ICE(glue.c): invalid template instantiated in is(typeof())
6661 Templates instantiated only through is(typeof()) shouldn't cause errors
