### PR TITLE
Issue 6062 - segv in dmd/64 with assoc array literals

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3864,6 +3864,9 @@ d_uns64 TypeAArray::size(Loc loc)
 Type *TypeAArray::semantic(Loc loc, Scope *sc)
 {
     //printf("TypeAArray::semantic() %s index->ty = %d\n", toChars(), index->ty);
+    if (deco)
+        return this;
+
     this->loc = loc;
     this->sc = sc;
     if (sc)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1108,21 +1108,18 @@ static assert(bug6001f());
 
 // Assignment to AAs
 
-version(X86)
+void blah(int[char] as)
 {
-    void blah(int[char] as)
-    {
-        auto k = [6: as];
-        as = k[6];
-    }
-    int blaz()
-    {
-        int[char] q;
-        blah(q);
-        return 67;
-    }
-    static assert(blaz()==67);
+    auto k = [6: as];
+    as = k[6];
 }
+int blaz()
+{
+    int[char] q;
+    blah(q);
+    return 67;
+}
+static assert(blaz()==67);
 
 void bug6001g(ref int[] w)
 {


### PR DESCRIPTION
The new druntime interface uses `ExpressionsToStaticArray` to generate the arguments for the arrays of keys and values passed to the runtime when creating an array literal.  When called, the key and value types have already completed semantic, but semantic is called again while resolving the static array type used, with a `NULL` scope.  As `TypeAArray::semantic` does not have an early exit, the `NULL` scope replaces the proper instantiation scope.  When it comes time to run semantic on the backing `TemplateInstance` for the aa, the `NULL` scope causes a segfault.

http://d.puremagic.com/issues/show_bug.cgi?id=6062
