### PR TITLE
move ESCAPE related instructions to operand1

### DIFF
--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -470,7 +470,7 @@ code *genlinnum(code *c,Srcpos srcpos)
     cs.Irex = 0;
     cs.IFL1 = 0;
     cs.IFL2 = 0;
-    cs.IEV2.Vsrcpos = srcpos;
+    cs.IEV1.Vsrcpos = srcpos;
     return gen(c,&cs);
 }
 
@@ -505,7 +505,7 @@ code *genadjesp(code *c, int offset)
         cs.Iop = ESCAPE | ESCadjesp;
         cs.Iflags = 0;
         cs.Irex = 0;
-        cs.IEV2.Vint = offset;
+        cs.IEV1.Vint = offset;
         return gen(c,&cs);
     }
     else
@@ -525,7 +525,7 @@ code *genadjfpu(code *c, int offset)
         cs.Iop = ESCAPE | ESCadjfpu;
         cs.Iflags = 0;
         cs.Irex = 0;
-        cs.IEV2.Vint = offset;
+        cs.IEV1.Vint = offset;
         return gen(c,&cs);
     }
     else

--- a/src/backend/cgsched.c
+++ b/src/backend/cgsched.c
@@ -1350,7 +1350,7 @@ STATIC void getinfo(Cinfo *ci,code *c)
 
         case ESCAPE:
             if (c->Iop == (ESCAPE | ESCadjfpu))
-                ci->fpuadjust = c->IEV2.Vint;
+                ci->fpuadjust = c->IEV1.Vint;
             break;
 
         case 0xD0:

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -2766,7 +2766,7 @@ void assignaddrc(code *c)
             if (c->Iop == (ESCAPE | ESCadjesp))
             {
                 //printf("adjusting EBPtoESP (%d) by %ld\n",EBPtoESP,c->IEV2.Vint);
-                EBPtoESP += c->IEV2.Vint;
+                EBPtoESP += c->IEV1.Vint;
                 c->Iop = NOP;
             }
             if (c->Iop == (ESCAPE | ESCframeptr))
@@ -4089,7 +4089,7 @@ unsigned codout(code *c)
                 switch (op & 0xFFFF00)
                 {   case ESClinnum:
                         /* put out line number stuff    */
-                        objlinnum(c->IEV2.Vsrcpos,OFFSET());
+                        objlinnum(c->IEV1.Vsrcpos,OFFSET());
                         break;
 #if SCPP
 #if 1
@@ -4994,7 +4994,7 @@ void code_hydrate(code **pc)
                 break;
 
             case ESCAPE | ESClinnum:
-                srcpos_hydrate(&c->IEV2.Vsrcpos);
+                srcpos_hydrate(&c->IEV1.Vsrcpos);
                 goto done;
 
             case ESCAPE | ESCctor:
@@ -5162,7 +5162,7 @@ void code_dehydrate(code **pc)
                 break;
 
             case ESCAPE | ESClinnum:
-                srcpos_dehydrate(&c->IEV2.Vsrcpos);
+                srcpos_dehydrate(&c->IEV1.Vsrcpos);
                 goto done;
 
             case ESCAPE | ESCctor:
@@ -5348,7 +5348,7 @@ void code::print()
 
   if ((op & 0xFF) == ESCAPE)
   {     if ((op & 0xFF00) == ESClinnum)
-        {   printf(" linnum = %d\n",c->IEV2.Vsrcpos.Slinnum);
+        {   printf(" linnum = %d\n",c->IEV1.Vsrcpos.Slinnum);
             return;
         }
         printf(" ESCAPE %d",c->Iop >> 8);


### PR DESCRIPTION
Walter, I looked through the uses of the ESCAPE pseudo-op and it was indeed trivial to move them over to op1 rather than op2.  All other uses of op2 in platform generic files are really x86 specific (a block in eh.c and a block in s2ir.c)
