### PR TITLE
Apply pull request #380 (gagging) to D1

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4811,15 +4811,9 @@ Expression *IsExp::semantic(Scope *sc)
     if (id && !(sc->flags & SCOPEstaticif))
         error("can only declare type aliases within static if conditionals");
 
-    unsigned errors_save = global.errors;
-    global.errors = 0;
-    global.gag++;                       // suppress printing of error messages
+    unsigned errors_save = global.startGagging();
     targ = targ->semantic(loc, sc);
-    global.gag--;
-    unsigned gerrors = global.errors;
-    global.errors = errors_save;
-
-    if (gerrors)                        // if any errors happened
+    if (global.endGagging(errors_save)) // if any errors happened
     {                                   // then condition is false
         goto Lno;
     }
@@ -6520,11 +6514,9 @@ Expression *CallExp::semantic(Scope *sc)
              * If not, go with partial explicit specialization.
              */
             ti->semanticTiargs(sc);
-            unsigned errors = global.errors;
-            global.gag++;
+            unsigned errors = global.startGagging();
             ti->semantic(sc);
-            global.gag--;
-            if (errors != global.errors)
+            if (global.endGagging(errors))
             {
                 /* Didn't work, go with partial explicit specialization
                  */

--- a/src/expression.c
+++ b/src/expression.c
@@ -6520,7 +6520,6 @@ Expression *CallExp::semantic(Scope *sc)
             {
                 /* Didn't work, go with partial explicit specialization
                  */
-                global.errors = errors;
                 targsi = ti->tiargs;
                 e1 = new IdentifierExp(loc, ti->name);
             }
@@ -6540,13 +6539,10 @@ Expression *CallExp::semantic(Scope *sc)
              */
             ti->semanticTiargs(sc);
             Expression *etmp;
-            unsigned errors = global.errors;
-            global.gag++;
+            unsigned errors = global.startGagging();
             etmp = e1->semantic(sc);
-            global.gag--;
-            if (errors != global.errors)
+            if (global.endGagging(errors))
             {
-                global.errors = errors;
                 targsi = ti->tiargs;
                 e1 = new DotIdExp(loc, se->e1, ti->name);
             }

--- a/src/func.c
+++ b/src/func.c
@@ -467,15 +467,12 @@ void FuncDeclaration::semantic(Scope *sc)
                         /* Only need to have a tintro if the vptr
                          * offsets differ
                          */
-                        unsigned errors = global.errors;
-                        global.gag++;            // suppress printing of error messages
+                        unsigned errors = global.startGagging();             // suppress printing of error messages
                         int offset;
                         int baseOf = fdv->type->nextOf()->isBaseOf(type->nextOf(), &offset);
-                        global.gag--;            // suppress printing of error messages
-                        if (errors != global.errors)
+                        if (global.endGagging(errors))
                         {
                             // any error in isBaseOf() is a forward reference error, so we bail out
-                            global.errors = errors;
                             cd->sizeok = 2;    // can't finish due to forward reference
                             Module::dprogress = dprogress_save;
                             return;

--- a/src/mars.c
+++ b/src/mars.c
@@ -101,21 +101,11 @@ Global::Global()
 unsigned Global::startGagging()
 {
     ++gag;
-#if DMDV1
-    return global.errors;
-#else
     return gaggedErrors;
-#endif
 }
 
 bool Global::endGagging(unsigned oldGagged)
 {
-#if DMDV1
-    bool anyErrs = (errors != oldGagged);
-    --gag;
-    errors = oldGagged;
-    return anyErrs;
-#else
     bool anyErrs = (gaggedErrors != oldGagged);
     --gag;
     // Restore the original state of gagged errors; set total errors
@@ -123,7 +113,6 @@ bool Global::endGagging(unsigned oldGagged)
     errors -= (gaggedErrors - oldGagged);
     gaggedErrors = oldGagged;
     return anyErrs;
-#endif
 }
 
 

--- a/src/template.c
+++ b/src/template.c
@@ -4467,7 +4467,6 @@ void TemplateInstance::semantic3(Scope *sc)
         sc = sc->push(argsym);
         sc = sc->push(this);
         sc->tinst = this;
-#if DMDV2
         int oldgag = global.gag;
         /* If this is a speculative instantiation, gag errors.
          * Future optimisation: If the results are actually needed, errors
@@ -4476,19 +4475,14 @@ void TemplateInstance::semantic3(Scope *sc)
          */
         if (speculative && !global.gag)
             global.gag = 1;
-#endif
         for (size_t i = 0; i < members->dim; i++)
         {
             Dsymbol *s = (*members)[i];
             s->semantic3(sc);
-#if DMDV2
             if (global.gag && errors)
                 break;
-#endif
         }
-#if DMDV2
         global.gag = oldgag;
-#endif
         sc = sc->pop();
         sc->pop();
     }


### PR DESCRIPTION
This implements pull request #380 to D1, undoing some of the workarounds in the original merge from D2.
I noticed that trySemantic() got added to D1 during the merge; it can be removed if desired, none of this code uses it.

Fixes these bugs:
4197 ICE(glue.c): error in forward-referenced in/out contract
5453 ICE(statement.c): invalid switch statement forward referenced by CTFE
6661 Templates instantiated only through is(typeof()) shouldn't cause errors

This one in pull 380 was D2-specific, so is already fixed.
6296 ICE(glue.c): invalid template instantiated in is(typeof())
