### PR TITLE
Fixed conflicting attribute error message.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -696,10 +696,9 @@ StorageClass Parser::parsePostfix()
             case TOKpure:               stc |= STCpure;                 break;
             case TOKat:                 stc |= parseAttribute();        break;
 
-            default:
-                composeStorageClass(stc);
-                return stc;
+            default: return stc;
         }
+        composeStorageClass(stc);
         nextToken();
     }
 }

--- a/src/template.c
+++ b/src/template.c
@@ -4220,7 +4220,12 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             // (see bugzilla 4302 and 6602).
             tempdecl->instances.remove(tempdecl_instance_idx);
             if (target_symbol_list)
+            {
+                // Because we added 'this' in the last position above, we
+                // should be able to remove it without messing other indices up.
+                assert(target_symbol_list->tdata()[target_symbol_list_idx] == this);
                 target_symbol_list->remove(target_symbol_list_idx);
+            }
             semanticRun = 0;
             inst = NULL;
         }


### PR DESCRIPTION
Previously, composeStorageClass was only invoked when parsing the list of postfix specifications has been finished, so the error message referred to the opening brace instead of the attribute in question:

For example, `void foo() @safe @system {}` would previously give `conflicting attribute @{` instead of `conflicting attribute @system`.

No test case, because this commit improves an error message only.

---

The first commit just adds a comment and an assert documenting an assumption made in #364 as requested by Don.
