### PR TITLE
Issue 6674 - Regression(2.055) mixin and __traits(allMembers) generates incorrect result

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -986,11 +986,19 @@ size_t ScopeDsymbol::dim(Dsymbols *members)
         for (size_t i = 0; i < members->dim; i++)
         {   Dsymbol *s = (*members)[i];
             AttribDeclaration *a = s->isAttribDeclaration();
+            TemplateMixin *tm = s->isTemplateMixin();
+            TemplateInstance *ti = s->isTemplateInstance();
 
             if (a)
             {
                 n += dim(a->decl);
             }
+            else if (tm)
+            {
+                n += dim(tm->members);
+            }
+            else if (ti)
+                ;
             else
                 n++;
         }

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -606,6 +606,29 @@ static assert([__traits(allMembers, S2234c)] == ["foo"]);
 
 /********************************************************/
 
+mixin template Members6674()
+{
+    static int i1;
+    static int i2;
+    static int i3;  //comment out to make func2 visible
+    static int i4;  //comment out to make func1 visible
+}
+
+class Test6674
+{
+    mixin Members6674;
+
+    typedef void function() func1;
+    typedef bool function() func2;
+}
+
+static assert([__traits(allMembers,Test6674)] == [
+    "i1","i2","i3","i4",
+    "func1","func2",
+    "toString","toHash","opCmp","opEquals","Monitor","factory"]);
+
+/********************************************************/
+
 int main()
 {
     test1();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6674
