### PR TITLE
Supplemental changes of druntime/pull/72 - Issue 1824 - Object not const correct 

### DIFF
--- a/test/runnable/imports/test13a.d
+++ b/test/runnable/imports/test13a.d
@@ -29,13 +29,13 @@ template TPair(T, U) {
             this._left = left;
             this._right = right;
         }
-        public T left() {
+        public const T left() {
             return this._left;
         }
-        public U right() {
+        public const U right() {
             return this._right;
         }
-        override public boolean opEquals(Object obj) {
+        override public const boolean opEquals(const Object obj) {
             Pair other = cast(Pair) obj;
             if (other !is null) {
                 return (left() == other.left()) && (right() == other.right());

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -133,7 +133,7 @@ void test4()
 
 class A5
 {
-    override bool opEquals(Object o)
+    override const bool opEquals(const Object o)
     {
         printf("A.opEquals!(%p)\n", o);
         return 1;
@@ -155,7 +155,7 @@ class A5
 
 class B5 : A5
 {
-    override bool opEquals(Object o)
+    override const bool opEquals(const Object o)
     {
         printf("B.opEquals!(%p)\n", o);
         return 1;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -3576,7 +3576,7 @@ static assert(is(typeof(S5110.value) == int));
 class C5110
 {
  override:
-    string toString() { return ""; }
+    const string toString() { return ""; }
 
     class Nested
     {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=1824
https://github.com/D-Programming-Language/dmd/pull/387
https://github.com/D-Programming-Language/druntime/pull/72
https://github.com/D-Programming-Language/phobos/pull/262

This pull request does not change compiler, but fixes only dmd test suites.

2011/10/15
This change also fix <a href="http://d.puremagic.com/issues/show_bug.cgi?id=3789">issue 3780</a>, because it requires const equality comparison for member classes.

requires: druntime git://github.com/9rnsr/druntime.git constApply
requires: phobos git://github.com/9rnsr/phobos.git constApply
