### PR TITLE
Issue 6690 - Using lazy parameter should be inferred as @safe

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7226,7 +7226,8 @@ Lagain:
 
             if (ve->var->storage_class & STClazy)
             {
-                TypeFunction *tf = new TypeFunction(NULL, ve->var->type, 0, LINKd);
+                // lazy paramaters can be called without violating purity and safety
+                TypeFunction *tf = new TypeFunction(NULL, ve->var->type, 0, LINKd, STCsafe | STCpure);
                 TypeDelegate *t = new TypeDelegate(tf);
                 ve->type = t->semantic(loc, sc);
             }
@@ -7635,10 +7636,7 @@ Lagain:
             tf = (TypeFunction *)(td->next);
             if (sc->func && !tf->purity && !(sc->flags & SCOPEdebug))
             {
-                if (e1->op == TOKvar && ((VarExp *)e1)->var->storage_class & STClazy)
-                {   // lazy paramaters can be called without violating purity
-                    // since they are checked explicitly
-                } else if (sc->func->setImpure())
+                if (sc->func->setImpure())
                     error("pure function '%s' cannot call impure delegate '%s'", sc->func->toChars(), e1->toChars());
             }
             if (sc->func && tf->trust <= TRUSTsystem)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4539,7 +4539,12 @@ int Type::covariant(Type *t)
         }
     }
     else if (t1->parameters != t2->parameters)
-        goto Ldistinct;
+    {
+        size_t dim1 = !t1->parameters ? 0 : t1->parameters->dim;
+        size_t dim2 = !t2->parameters ? 0 : t2->parameters->dim;
+        if (dim1 || dim2)
+            goto Ldistinct;
+    }
 
     // The argument lists match
     if (inoutmismatch)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3597,6 +3597,20 @@ void test6630()
 }
 
 /***************************************************/
+// 6690
+
+T useLazy6690(T)(lazy T val)
+{
+    return val;
+    // val is converted to delegate call, but it is typed as int delegate() - not @safe!
+}
+void test6690() @safe
+{
+    useLazy6690(0);
+    // Error: safe function 'test6690' cannot call system function 'useLazy6690'
+}
+
+/***************************************************/
 
 int main()
 {
@@ -3777,6 +3791,7 @@ int main()
     test5799();
     test157();
     test6630();
+    test6690();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6690
