### PR TITLE
check that block displacement fits into immediate

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -212,7 +212,7 @@ typedef struct Srcpos
 #endif
 #if MARS
     const char *Sfilename;
-    #define srcpos_name(p)      ((p).SFname)
+    #define srcpos_name(p)      ((p)->Sfilename)
 #endif
 #if M_UNIX
     short Sfilnum;              // file number

--- a/test/fail_compilation/fail353.d
+++ b/test/fail_compilation/fail353.d
@@ -9,6 +9,7 @@ void foo()
         dq NOP,NOP,NOP,NOP;    //  64
         dq NOP,NOP,NOP,NOP;    //  96
         dq NOP,NOP,NOP,NOP;    // 128
-        loop L1; // signed underflow of rel8
+        // unnoticed signed underflow of rel8 with DMD2.056
+        loop L1;
     }
 }

--- a/test/fail_compilation/fail353.d
+++ b/test/fail_compilation/fail353.d
@@ -1,0 +1,14 @@
+void foo()
+{
+    enum NOP = 0x9090_9090_9090_9090;
+
+    asm
+    {
+    L1:
+        dq NOP,NOP,NOP,NOP;    //  32
+        dq NOP,NOP,NOP,NOP;    //  64
+        dq NOP,NOP,NOP,NOP;    //  96
+        dq NOP,NOP,NOP,NOP;    // 128
+        loop L1; // signed underflow of rel8
+    }
+}


### PR DESCRIPTION
- instructions like loop only allow 1-byte
  displacements and silently wrap currently
