### PR TITLE
issue 4014: output debug info for all referenced classes/structs and enumerators

### DIFF
--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -1835,7 +1835,7 @@ L1:
             {
                 // This is a hack to duplicate bugs in VC, so that the VC
                 // debugger will work.
-                tymnext = t->Tnext->Tty;
+                tymnext = t->Tnext ? t->Tnext->Tty : 0;
                 if (tymnext & (mTYconst | mTYimmutable | mTYvolatile) &&
                     !tycv &&
                     tyarithmetic(tymnext) &&

--- a/src/mars.c
+++ b/src/mars.c
@@ -748,8 +748,12 @@ int tryMain(size_t argc, const char *argv[])
                 global.params.map = true;
             else if (strcmp(p + 1, "multiobj") == 0)
                 global.params.multiobj = true;
-            else if (strcmp(p + 1, "g") == 0)
+            else if (strcmp(p + 1, "g") == 0 || strcmp(p + 1, "g1") == 0)
                 global.params.symdebug = 1;
+            else if (strcmp(p + 1, "g2") == 0)
+            {   global.params.symdebug = 1;
+                global.params.symdebugref = 1;
+            }
             else if (strcmp(p + 1, "gc") == 0)
                 global.params.symdebug = 2;
             else if (strcmp(p + 1, "gs") == 0)

--- a/src/mars.h
+++ b/src/mars.h
@@ -99,6 +99,7 @@ struct Param
     char vgc;           // identify gc usage
     bool vfield;        // identify non-mutable field variables
     char symdebug;      // insert debug symbolic information
+    bool symdebugref;   // insert debug symbolic information for referenced classes/structs/enums
     bool alwaysframe;   // always emit standard stack frame
     bool optimize;      // run optimizer
     bool map;           // generate linker .map file

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -30,6 +30,11 @@ void slist_add(Symbol *s);
 void slist_reset();
 unsigned totym(Type *tx);
 
+void toDebug(TypedefDeclaration *tdd);
+void toDebug(EnumDeclaration *ed);
+void toDebug(StructDeclaration *sd);
+void toDebug(ClassDeclaration *cd);
+
 /***************************************
  * Convert from D type to C type.
  * This is done so C debug info can be generated.
@@ -160,6 +165,9 @@ public:
             }
         }
 
+        if (global.params.symdebugref)
+            toDebug(t->sym);
+
         //printf("t = %p, Tflags = x%x\n", ctype, ctype->Tflags);
     }
 
@@ -211,6 +219,9 @@ public:
         {
             t->ctype = Type_toCtype(t->sym->memtype);
         }
+        
+        if (global.params.symdebugref)
+            toDebug(t->sym);
 
         //printf("t = %p, Tflags = x%x\n", t, t->Tflags);
     }
@@ -218,6 +229,9 @@ public:
     void visit(TypeTypedef *t)
     {
         t->ctype = Type_toCtype(t->sym->basetype);
+
+        if (global.params.symdebugref)
+            toDebug(t->sym);
     }
 
     void visit(TypeClass *t)
@@ -243,6 +257,8 @@ public:
                 symbol_struct_addField(tc->Ttag, v->ident->toChars(), Type_toCtype(v->type), v->offset);
             }
         }
+        if (global.params.symdebugref)
+            toDebug(t->sym);
     }
 };
 

--- a/src/tocvdebug.c
+++ b/src/tocvdebug.c
@@ -147,7 +147,7 @@ unsigned cv4_Denum(EnumDeclaration *e)
 {
     //dbg_printf("cv4_Denum(%s)\n", e->toChars());
     unsigned property = 0;
-        if (!e->members || !e->memtype || !e->memtype->isintegral())
+    if (!e->members || !e->memtype || !e->memtype->isintegral())
         property |= 0x80;               // enum is forward referenced or non-integer
 
     // Compute the number of fields, and the length of the fieldlist record

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -51,6 +51,7 @@ void ClassDeclaration_toDt(ClassDeclaration *cd, dt_t **pdt);
 void StructDeclaration_toDt(StructDeclaration *sd, dt_t **pdt);
 Symbol *toSymbol(Dsymbol *s);
 
+type *Type_toCtype(Type *t);
 void toDebug(TypedefDeclaration *tdd);
 void toDebug(EnumDeclaration *ed);
 void toDebug(StructDeclaration *sd);
@@ -230,7 +231,9 @@ void ClassDeclaration::toObjFile(bool multiobj)
         return;
     }
 
-    if (global.params.symdebug)
+    if (global.params.symdebugref)
+        Type_toCtype(type); // calls toDebug() only once
+    else if (global.params.symdebug)
         toDebug(this);
 
     assert(!scope);     // semantic() should have been run to completion
@@ -670,7 +673,9 @@ void InterfaceDeclaration::toObjFile(bool multiobj)
     if (!members)
         return;
 
-    if (global.params.symdebug)
+    if (global.params.symdebugref)
+        Type_toCtype(type); // calls toDebug() only once
+    else if (global.params.symdebug)
         toDebug(this);
 
     scclass = SCglobal;
@@ -849,7 +854,9 @@ void StructDeclaration::toObjFile(bool multiobj)
     // do not output forward referenced structs's
     if (!isAnonymous() && members)
     {
-        if (global.params.symdebug)
+        if (global.params.symdebugref)
+            Type_toCtype(type); // calls toDebug() only once
+        else if (global.params.symdebug)
             toDebug(this);
 
         type->genTypeInfo(NULL);
@@ -1020,7 +1027,9 @@ void TypedefDeclaration::toObjFile(bool multiobj)
         return;
     }
 
-    if (global.params.symdebug)
+    if (global.params.symdebugref)
+        Type_toCtype(type); // calls toDebug() only once
+    else if (global.params.symdebug)
         toDebug(this);
 
     type->genTypeInfo(NULL);
@@ -1060,7 +1069,9 @@ void EnumDeclaration::toObjFile(bool multiobj)
     if (isAnonymous())
         return;
 
-    if (global.params.symdebug)
+    if (global.params.symdebugref)
+        Type_toCtype(type); // calls toDebug() only once
+    else if (global.params.symdebug)
         toDebug(this);
 
     type->genTypeInfo(NULL);


### PR DESCRIPTION
This patch outputs full debug info for anything that is referenced, not only for declaration in modules on the command line. Leave it to the linker to filter out duplicates.

In toobj.c, it might also be possible to just leave out the call to toDebug()/toCtype(), because the debug info will always end up where the declaration is used.

The patch in cgcv.c was necessary, because it crashed on some debug info for me. Is the hack still necessary?

bugzilla: http://d.puremagic.com/issues/show_bug.cgi?id=4014
