### PR TITLE
Fix broken -O test

### DIFF
--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -2768,14 +2768,13 @@ struct S5117b
 /************************************************/
 // from tests/fail_compilation/fail147
 
-int fail147(int i)
-{
-    int x = void;
-    ++x; // used before initialization
-    return i + x;
-}
-static assert(!is(typeof(Compileable!(fail147(3)))));
-
+static assert(!is(typeof(Compileable!(
+    (int i){
+        int x = void;
+        ++x; // used before initialization
+        return i + x;
+    }(3)
+))));
 
 int main()
 {


### PR DESCRIPTION
Autotester is failing, due to a test failing only with -O. This will fix it.
