### PR TITLE
Fix another broken test

### DIFF
--- a/test/fail_compilation/fail111.d
+++ b/test/fail_compilation/fail111.d
@@ -1,6 +1,6 @@
 // 289
 
-alias int function (int) ft;
+alias int ft(int);
 
 ft[] x;  // is allowed 
 


### PR DESCRIPTION
I mistakenly converted _function_ type to function pointer. This allowed the code to compile -- but it's supposed to be a fail test!
