### PR TITLE
Issue 6084 - Impossible to instantiate local template with TypeTuple-foreach iterator variable. 

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1510,9 +1510,7 @@ Lretry:
                     arg->type = e->type;
                     Initializer *ie = new ExpInitializer(0, e);
                     VarDeclaration *v = new VarDeclaration(loc, arg->type, arg->ident, ie);
-                    if (e->isConst())
-                        v->storage_class |= STCconst;
-                    if (e->op == TOKstring)
+                    if (e->isConst() || e->op == TOKstring)
                         v->storage_class |= STCmanifest;
                     var = v;
                 }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3655,6 +3655,17 @@ static assert(typeof(pfunc6596).stringof == "extern (C) int function()");
 static assert(typeof(cfunc6596).stringof == "extern (C) int()");
 
 /***************************************************/
+// 6084
+
+template TypeTuple6084(T...){ alias T TypeTuple6084; }
+void test6084()
+{
+    int foo(int x)() { return x; }
+    foreach(i; TypeTuple6084!(0))
+        foo!(i);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -3837,6 +3848,7 @@ int main()
     test6630();
     test6690();
     test2953();
+    test6084();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6084

If it is static foreach, making an element manifest constant is better than adding const modifier.
