### PR TITLE
Issue 2953 - tuple.length rejected as a tuple parameter in a static foreach

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4913,10 +4913,6 @@ Expression *TupleExp::semantic(Scope *sc)
     }
 
     expandTuples(exps);
-    if (0 && exps->dim == 1)
-    {
-        return (*exps)[0];
-    }
     type = new TypeTuple(exps);
     type = type->semantic(loc, sc);
     //printf("-TupleExp::semantic(%s)\n", toChars());

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5635,7 +5635,14 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
 
                 t = s->getType();
                 if (!t && s->isDeclaration())
-                    t = s->isDeclaration()->type;
+                {   t = s->isDeclaration()->type;
+                    if (!t && s->isTupleDeclaration())
+                    {
+                        e = new TupleExp(loc, s->isTupleDeclaration());
+                        e = e->semantic(sc);
+                        t = e->type;
+                    }
+                }
                 if (t)
                 {
                     sm = t->toDsymbol(sc);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3626,6 +3626,27 @@ template Hoge6691()
 alias Hoge6691!() H6691;
 
 /***************************************************/
+// 2953
+
+template Tuple2953(T...)
+{
+    alias T Tuple2953;
+}
+template Range2953(int b)
+{
+    alias Tuple2953!(1) Range2953;
+}
+void foo2953()()
+{
+    Tuple2953!(int, int) args;
+    foreach( x ; Range2953!(args.length) ){ }
+}
+void test2953()
+{
+    foo2953!()();
+}
+
+/***************************************************/
 
 int main()
 {
@@ -3807,6 +3828,7 @@ int main()
     test157();
     test6630();
     test6690();
+    test2953();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=2953

A `TupleDeclaration` that isn't wrapped by `TupleExp`and `isexp==1` doesn't have type, therefore `TypeQualified::resolveHelper` cannot resolve `.length` property from its type.
