### PR TITLE
Fix SDoffset handling when writing at an offset not at the end of the buf

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -2233,7 +2233,8 @@ void obj_byte(int seg,targ_size_t offset,unsigned byte)
     buf->writeByte(byte);
     if (save > offset+1)
         buf->setsize(save);
-    SegData[seg]->SDoffset = offset+1;
+    else
+        SegData[seg]->SDoffset = offset+1;
     //dbg_printf("\tsize now %d\n",buf->size());
 }
 
@@ -2283,7 +2284,8 @@ unsigned obj_bytes(int seg, targ_size_t offset, unsigned nbytes, void *p)
     }
     if (save > offset+nbytes)
         buf->setsize(save);
-    SegData[seg]->SDoffset = offset+nbytes;
+    else
+        SegData[seg]->SDoffset = offset+nbytes;
     return nbytes;
 }
 

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -1903,7 +1903,8 @@ void obj_byte(int seg,targ_size_t offset,unsigned byte)
     buf->writeByte(byte);
     if (save > offset+1)
         buf->setsize(save);
-    SegData[seg]->SDoffset = offset+1;
+    else
+        SegData[seg]->SDoffset = offset+1;
     //dbg_printf("\tsize now %d\n",buf->size());
 }
 
@@ -1954,7 +1955,8 @@ if (!buf) halt();
     }
     if (save > offset+nbytes)
         buf->setsize(save);
-    SegData[seg]->SDoffset = offset+nbytes;
+    else
+        SegData[seg]->SDoffset = offset+nbytes;
     return nbytes;
 }
 


### PR DESCRIPTION
Fix SDoffset handling when writing at an offset not at the end of the buffer

note: found through code inspection.  not sure how to trigger it through the frontend with code.
