### PR TITLE
Fix POSIX-only segfault in test/runnable/testsocket.d

### DIFF
--- a/test/runnable/testsocket.d
+++ b/test/runnable/testsocket.d
@@ -29,11 +29,6 @@ class Connection
 		sock = new TcpSocket;
 		sock.blocking = false;
 	}
-
-	~this ()
-	{
-		sock.close ();
-	}
 }
 
 int main ()


### PR DESCRIPTION
Since `std.socket` now correctly enforces `SocketSet` capacity, the `rset.add` call will now fail on POSIX. This causes the `Connection` class to be garbage-collected, instead of being explicitly deleted. `Connection`'s destructor then attempts to access a field allocated on the heap, which has already been collected, and thus segfaults.

It's not entirely clear whether this test expects `SocketSet.add` to not fail, though the comments suggest it doesn't.
