### PR TITLE
a little more backend tidying

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -192,8 +192,10 @@ typedef struct Symbol symbol;
 typedef Symbol Funcsym;
 //typedef Symbol Classsym;      // a Symbol that is an SCclass, SCstruct or SCunion
 struct elem;
+#if !MARS
 typedef struct MACRO macro_t;
 typedef struct BLKLST blklst;
+#endif
 typedef list_t symlist_t;       /* list of pointers to Symbols          */
 typedef struct SYMTAB_S symtab_t;
 struct code;

--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -19,6 +19,7 @@
 #include        "cc.h"
 #include        "code.h"
 #include        "iasm.h"
+#include        "global.h"
 
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"

--- a/src/backend/token.h
+++ b/src/backend/token.h
@@ -367,6 +367,7 @@ int binary(const char *p , const char __near * __near *tab, int high);
 #define ptoken()        rtoken(1)
 #define token()         rtoken(0)
 
+#if !MARS
 /* from pragma.c */
 //enum_TK ptoken(void);
 void pragma_process();
@@ -376,6 +377,7 @@ void __near listident(void);
 void pragma_term(void);
 macro_t *defmac(const char *name , const char *text);
 int pragma_defined(void);
+#endif
 
 #if SPP && TX86
 #define token_linnum()  getlinnum()

--- a/src/backend/token.h
+++ b/src/backend/token.h
@@ -360,9 +360,6 @@ void chktok(enum_TK toknum , unsigned errnum, const char *str);
 void opttok(enum_TK toknum);
 bool iswhite(int c);
 void token_term(void);
-#if TX86
-int binary(const char *p , const char __near * __near *tab, int high);
-#endif
 
 #define ptoken()        rtoken(1)
 #define token()         rtoken(0)


### PR DESCRIPTION
binary() was defined in token.h and global.h.  Eliminate the former.
macro_t is a c++ism
pragma_\* are c++isms
