### PR TITLE
cleanup backend TYtypes related to flat vs segmented memory models

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -233,7 +233,7 @@ One and only one of these macros must be set by the makefile:
  * This is not quite the same as !SIXTEENBIT, as one could
  * have near/far with 32 bit code.
  */
-#define TARGET_FLAT     (MARS || !TARGET_WINDOS)
+#define TARGET_SEGMENTED     (!MARS && TARGET_WINDOS)
 
 
 #define STATEMENT_SCOPES CPP

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -2213,8 +2213,10 @@ code *codelem(elem *e,regm_t *pretregs,bool constflag)
                 case TYjhandle:
 #endif
                 case TYnptr:
+#if !TARGET_FLAT
                 case TYsptr:
                 case TYcptr:
+#endif
                     *pretregs |= IDXREGS;
                     break;
                 case TYshort:
@@ -2230,8 +2232,8 @@ code *codelem(elem *e,regm_t *pretregs,bool constflag)
 #if !TARGET_FLAT
                 case TYfptr:
                 case TYhptr:
-#endif
                 case TYvptr:
+#endif
                     *pretregs |= ALLREGS;
                     break;
             }

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -2213,7 +2213,7 @@ code *codelem(elem *e,regm_t *pretregs,bool constflag)
                 case TYjhandle:
 #endif
                 case TYnptr:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                 case TYsptr:
                 case TYcptr:
 #endif
@@ -2229,7 +2229,7 @@ code *codelem(elem *e,regm_t *pretregs,bool constflag)
                 case TYullong:
                 case TYcent:
                 case TYucent:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                 case TYfptr:
                 case TYhptr:
                 case TYvptr:

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -133,17 +133,17 @@ int elemisone(elem *e)
             case TYllong:
             case TYullong:
             case TYnullptr:
-#if TX86
 #if JHANDLE
             case TYjhandle:
 #endif
-            case TYnptr:
+#if !TARGET_FLAT
             case TYsptr:
             case TYcptr:
             case TYhptr:
-#endif
             case TYfptr:
             case TYvptr:
+#endif
+            case TYnptr:
             case TYbool:
             case TYwchar_t:
             case TYdchar:
@@ -198,17 +198,17 @@ int elemisnegone(elem *e)
             case TYllong:
             case TYullong:
             case TYnullptr:
-#if TX86
+            case TYnptr:
 #if JHANDLE
             case TYjhandle:
 #endif
-            case TYnptr:
+#if !TARGET_FLAT
             case TYsptr:
             case TYcptr:
             case TYhptr:
-#endif
             case TYfptr:
             case TYvptr:
+#endif
             case TYbool:
             case TYwchar_t:
             case TYdchar:
@@ -1084,7 +1084,11 @@ L1:
   /* for floating or far or huge pointers!                              */
   if (e1->Eoper == OPadd && e2->Eoper == OPadd &&
       cnst(e1->E2) && cnst(e2->E2) &&
-      (tyintegral(tym) || tybasic(tym) == TYjhandle || tybasic(tym) == TYnptr || tybasic(tym) == TYsptr ))
+      (tyintegral(tym) || tybasic(tym) == TYjhandle || tybasic(tym) == TYnptr
+#if !TARGET_FLAT
+       || tybasic(tym) == TYsptr
+#endif
+      ))
   {     elem *tmp;
 
         e->Eoper = OPadd;
@@ -2306,7 +2310,7 @@ STATIC elem * elind(elem *e)
           }
             break;
         case OPadd:
-#if TX86
+#if !TARGET_FLAT
             if (OPTIMIZER)
             {   /* Try to convert far pointer to stack pointer  */
                 elem *e12 = e1->E2;
@@ -2556,7 +2560,11 @@ CEXTERN elem * elstruct(elem *e)
                 /* We should do the analysis to see if we can use
                    something simpler than TYfptr.
                  */
+#if TARGET_FLAT
+                typ = TYnptr;
+#else
                 typ = (intsize == LONGSIZE) ? TYnptr : TYfptr;
+#endif
                 e2 = el_una(OPaddr,typ,e2);
                 e2 = optelem(e2,TRUE);          /* distribute & to x and y leaves */
                 *pe2 = el_una(OPind,ty2,e2);
@@ -3401,7 +3409,7 @@ STATIC elem * elptrlptr(elem *e)
 /*********************************
  * Conversions of handle pointers to far pointers.
  */
-
+// TODO: should this function go away entirely in TARGET_FLAT mode?
 STATIC elem * elvptrfptr(elem *e)
 {   elem *e1;
     elem *e12;
@@ -3411,7 +3419,9 @@ STATIC elem * elvptrfptr(elem *e)
     if (e1->Eoper == OPadd || e1->Eoper == OPmin)
     {
         e12 = e1->E2;
+#if !TARGET_FLAT
         if (tybasic(e12->Ety) != TYvptr)
+#endif
         {
             /* Rewrite (vtof(e11 + e12)) to (vtof(e11) + e12)   */
             op = e->Eoper;

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -136,7 +136,7 @@ int elemisone(elem *e)
 #if JHANDLE
             case TYjhandle:
 #endif
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYsptr:
             case TYcptr:
             case TYhptr:
@@ -202,7 +202,7 @@ int elemisnegone(elem *e)
 #if JHANDLE
             case TYjhandle:
 #endif
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYsptr:
             case TYcptr:
             case TYhptr:
@@ -1085,7 +1085,7 @@ L1:
   if (e1->Eoper == OPadd && e2->Eoper == OPadd &&
       cnst(e1->E2) && cnst(e2->E2) &&
       (tyintegral(tym) || tybasic(tym) == TYjhandle || tybasic(tym) == TYnptr
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
        || tybasic(tym) == TYsptr
 #endif
       ))
@@ -2310,7 +2310,7 @@ STATIC elem * elind(elem *e)
           }
             break;
         case OPadd:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             if (OPTIMIZER)
             {   /* Try to convert far pointer to stack pointer  */
                 elem *e12 = e1->E2;
@@ -2560,10 +2560,10 @@ CEXTERN elem * elstruct(elem *e)
                 /* We should do the analysis to see if we can use
                    something simpler than TYfptr.
                  */
-#if TARGET_FLAT
-                typ = TYnptr;
-#else
+#if TARGET_SEGMENTED
                 typ = (intsize == LONGSIZE) ? TYnptr : TYfptr;
+#else
+                typ = TYnptr;
 #endif
                 e2 = el_una(OPaddr,typ,e2);
                 e2 = optelem(e2,TRUE);          /* distribute & to x and y leaves */
@@ -3419,7 +3419,7 @@ STATIC elem * elvptrfptr(elem *e)
     if (e1->Eoper == OPadd || e1->Eoper == OPmin)
     {
         e12 = e1->E2;
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         if (tybasic(e12->Ety) != TYvptr)
 #endif
         {

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -343,8 +343,10 @@ regm_t regmask(tym_t tym, tym_t tyf)
 #endif
         case TYnullptr:
         case TYnptr:
+#if !TARGET_FLAT
         case TYsptr:
         case TYcptr:
+#endif
             return mAX;
 
         case TYfloat:
@@ -358,8 +360,10 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYdchar:
             if (!I16)
                 return mAX;
+#if !TARGET_FLAT
         case TYfptr:
         case TYhptr:
+#endif
             return mDX | mAX;
 
         case TYcent:
@@ -367,8 +371,10 @@ regm_t regmask(tym_t tym, tym_t tyf)
             assert(I64);
             return mDX | mAX;
 
+#if !TARGET_FLAT
         case TYvptr:
             return mDX | mBX;
+#endif
 
         case TYdouble:
         case TYdouble_alias:
@@ -3241,9 +3247,11 @@ void cod3_thunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
 
     /* Skip over return address */
     thunkty = tybasic(sthunk->ty());
+#if !TARGET_FLAT
     if (tyfarfunc(thunkty))
         p += I32 ? 8 : tysize[TYfptr];          /* far function */
     else
+#endif
         p += tysize[TYnptr];
 
     if (!I16)
@@ -3319,7 +3327,9 @@ void cod3_thunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
 #define FARTHIS (tysize(thisty) > REGSIZE)
 #define FARVPTR FARTHIS
 
+#if !TARGET_FLAT
         assert(thisty != TYvptr);               /* can't handle this case */
+#endif
 
         if (!I16)
         {
@@ -5848,12 +5858,14 @@ STATIC int outfixlist_dg(void *parameter, void *pkey, void *pvalue)
         symbol_debug(s);
         //printf("outfixlist '%s' offset %04x\n",s->Sident,ln->Loffset);
 
+#if !TARGET_FLAT
         if (tybasic(s->ty()) == TYf16func)
         {
             obj_far16thunk(s);          /* make it into a thunk         */
             searchfixlist(s);
         }
         else
+#endif
         {
             if (s->Sxtrnnum == 0)
             {   if (s->Sclass == SCstatic)

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -343,7 +343,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
 #endif
         case TYnullptr:
         case TYnptr:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         case TYsptr:
         case TYcptr:
 #endif
@@ -360,7 +360,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYdchar:
             if (!I16)
                 return mAX;
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         case TYfptr:
         case TYhptr:
 #endif
@@ -371,7 +371,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
             assert(I64);
             return mDX | mAX;
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         case TYvptr:
             return mDX | mBX;
 #endif
@@ -3247,7 +3247,7 @@ void cod3_thunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
 
     /* Skip over return address */
     thunkty = tybasic(sthunk->ty());
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     if (tyfarfunc(thunkty))
         p += I32 ? 8 : tysize[TYfptr];          /* far function */
     else
@@ -3327,7 +3327,7 @@ void cod3_thunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
 #define FARTHIS (tysize(thisty) > REGSIZE)
 #define FARVPTR FARTHIS
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         assert(thisty != TYvptr);               /* can't handle this case */
 #endif
 
@@ -5459,7 +5459,7 @@ STATIC void do64bit(enum FL fl,union evc *uev,int flags)
 #if DEBUG
             symbol_print(uev->sp.Vsym);
 #endif
-            assert(!TARGET_FLAT);
+            assert(TARGET_SEGMENTED);
             // NOTE: In ELFOBJ all symbol refs have been tagged FLextern
             // strings and statics are treated like offsets from a
             // un-named external with is the start of .rodata or .data
@@ -5483,7 +5483,7 @@ STATIC void do64bit(enum FL fl,union evc *uev,int flags)
 
         case FLfunc:                        /* function call                */
             s = uev->sp.Vsym;               /* symbol pointer               */
-            assert(!(TARGET_FLAT && tyfarfunc(s->ty())));
+            assert(TARGET_SEGMENTED || !tyfarfunc(s->ty()));
             FLUSH();
             reftoident(cseg,offset,s,0,CFoffset64 | flags);
             break;
@@ -5551,7 +5551,7 @@ STATIC void do32bit(enum FL fl,union evc *uev,int flags, targ_size_t val)
 #if DEBUG
         symbol_print(uev->sp.Vsym);
 #endif
-        assert(!TARGET_FLAT);
+        assert(TARGET_SEGMENTED);
         // NOTE: In ELFOBJ all symbol refs have been tagged FLextern
         // strings and statics are treated like offsets from a
         // un-named external with is the start of .rodata or .data
@@ -5575,7 +5575,7 @@ STATIC void do32bit(enum FL fl,union evc *uev,int flags, targ_size_t val)
 
     case FLfunc:                        /* function call                */
         s = uev->sp.Vsym;               /* symbol pointer               */
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         if (tyfarfunc(s->ty()))
         {       /* Large code references are always absolute    */
                 FLUSH();
@@ -5591,7 +5591,7 @@ STATIC void do32bit(enum FL fl,union evc *uev,int flags, targ_size_t val)
         else
 #endif
         {
-                assert(!(TARGET_FLAT && tyfarfunc(s->ty())));
+                assert(TARGET_SEGMENTED || !tyfarfunc(s->ty()));
                 FLUSH();
                 reftoident(cseg,offset,s,val,flags);
         }
@@ -5651,13 +5651,13 @@ STATIC void do16bit(enum FL fl,union evc *uev,int flags)
     case FLfardata:
     case FLextern:                      /* external data symbol         */
     case FLtlsdata:
-        assert(SIXTEENBIT || !TARGET_FLAT);
+        assert(SIXTEENBIT || TARGET_SEGMENTED);
         FLUSH();
         s = uev->sp.Vsym;               /* symbol pointer               */
         reftoident(cseg,offset,s,uev->sp.Voffset,flags);
         break;
     case FLfunc:                        /* function call                */
-        assert(SIXTEENBIT || !TARGET_FLAT);
+        assert(SIXTEENBIT || TARGET_SEGMENTED);
         s = uev->sp.Vsym;               /* symbol pointer               */
         if (tyfarfunc(s->ty()))
         {       /* Large code references are always absolute    */
@@ -5764,12 +5764,7 @@ void addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int flag
         ln->Lnext = *pv;
         *pv = ln;
 
-#if TARGET_FLAT
-        numbytes = tysize[TYnptr];
-        if (I64 && !(flags & CFoffset64))
-            numbytes = 4;
-        assert(!(flags & CFseg));
-#else
+#if TARGET_SEGMENTED
         switch (flags & (CFoff | CFseg))
         {
             case CFoff:         numbytes = tysize[TYnptr];      break;
@@ -5777,6 +5772,11 @@ void addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int flag
             case CFoff | CFseg: numbytes = tysize[TYfptr];      break;
             default:            assert(0);
         }
+#else
+        numbytes = tysize[TYnptr];
+        if (I64 && !(flags & CFoffset64))
+            numbytes = 4;
+        assert(!(flags & CFseg));
 #endif
 #ifdef DEBUG
         assert(numbytes <= sizeof(zeros));
@@ -5858,7 +5858,7 @@ STATIC int outfixlist_dg(void *parameter, void *pkey, void *pvalue)
         symbol_debug(s);
         //printf("outfixlist '%s' offset %04x\n",s->Sident,ln->Loffset);
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         if (tybasic(s->ty()) == TYf16func)
         {
             obj_far16thunk(s);          /* make it into a thunk         */

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -568,7 +568,7 @@ code *cdeq(elem *e,regm_t *pretregs)
   }
   else if (retregs & mES &&
             (
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
              (e1->Eoper == OPind &&
                 ((tymll = tybasic(e1->E1->Ety)) == TYfptr || tymll == TYhptr)
                 ) ||
@@ -635,7 +635,7 @@ code *cdeq(elem *e,regm_t *pretregs)
   c = getregs_imm(varregm);
 
   assert(!(retregs & mES && (cs.Iflags & CFSEG) == CFes));
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
   if ((tyml == TYfptr || tyml == TYhptr) && retregs & mES)
   {
         reg = findreglsw(retregs);
@@ -872,7 +872,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
         (el_allbits(e2, 1) || el_allbits(e2, -1))
        ) ||
        (!evalinregister(e2)
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         && tyml != TYhptr
 #endif
         )
@@ -1049,7 +1049,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
   else // evaluate e2 into register
   {
         retregs = (byte) ? BYTEREGS : ALLREGS;  // pick working reg
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         if (tyml == TYhptr)
             retregs &= ~mCX;                    // need CX for shift count
 #endif
@@ -1063,7 +1063,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
             if (sz == 1 && reg >= 4 && I64)
                 cs.Irex |= REX;
         }
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         else if (tyml == TYhptr)
         {   unsigned mreg,lreg;
 
@@ -1149,7 +1149,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
                 ce = gen(ce,&cs);               // MOV reg,EA
             }
         }
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         else if (tyfv(tyml) || tyml == TYhptr)
         {       regm_t idxregs;
 
@@ -2049,7 +2049,7 @@ code *cdcmp(elem *e,regm_t *pretregs)
                     cs.Irm |= modregrm(0,7,0);
                     if (sz > REGSIZE)
                     {
-#if TARGET_FLAT
+#if !TARGET_SEGMENTED
                         if (sz == 6)
                             assert(0);
 #endif
@@ -2633,7 +2633,7 @@ code *cdshtlng(elem *e,regm_t *pretregs)
             switch (tym1)
             {
                 case TYnptr:    segreg = SEG_DS;        break;
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                 case TYcptr:    segreg = SEG_CS;        break;
                 case TYsptr:    segreg = SEG_SS;        break;
 #endif

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -567,9 +567,12 @@ code *cdeq(elem *e,regm_t *pretregs)
                 retregs = BYTEREGS;
   }
   else if (retregs & mES &&
-            ((e1->Eoper == OPind &&
-                ((tymll = tybasic(e1->E1->Ety)) == TYfptr || tymll == TYhptr))
-                ||
+            (
+#if !TARGET_FLAT
+             (e1->Eoper == OPind &&
+                ((tymll = tybasic(e1->E1->Ety)) == TYfptr || tymll == TYhptr)
+                ) ||
+#endif
              (e1->Eoper == OPvar && e1->EV.sp.Vsym->Sfl == FLfardata)
             )
           )
@@ -632,6 +635,7 @@ code *cdeq(elem *e,regm_t *pretregs)
   c = getregs_imm(varregm);
 
   assert(!(retregs & mES && (cs.Iflags & CFSEG) == CFes));
+#if !TARGET_FLAT
   if ((tyml == TYfptr || tyml == TYhptr) && retregs & mES)
   {
         reg = findreglsw(retregs);
@@ -643,6 +647,7 @@ code *cdeq(elem *e,regm_t *pretregs)
         gen(c,&cs);                     /* MOV EA+2,ES                  */
   }
   else
+#endif
   {
         if (!I16)
         {
@@ -866,7 +871,11 @@ code *cdaddass(elem *e,regm_t *pretregs)
         (op == OPaddass || op == OPminass) &&
         (el_allbits(e2, 1) || el_allbits(e2, -1))
        ) ||
-       (!evalinregister(e2) && tyml != TYhptr)
+       (!evalinregister(e2)
+#if !TARGET_FLAT
+        && tyml != TYhptr
+#endif
+        )
       )
      )
   {
@@ -1040,8 +1049,10 @@ code *cdaddass(elem *e,regm_t *pretregs)
   else // evaluate e2 into register
   {
         retregs = (byte) ? BYTEREGS : ALLREGS;  // pick working reg
+#if !TARGET_FLAT
         if (tyml == TYhptr)
             retregs &= ~mCX;                    // need CX for shift count
+#endif
         cr = scodelem(e->E2,&retregs,0,TRUE);   // get rvalue
         cl = getlvalue(&cs,e1,retregs);         // get lvalue
         cl = cat(cl,modEA(&cs));
@@ -1052,6 +1063,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
             if (sz == 1 && reg >= 4 && I64)
                 cs.Irex |= REX;
         }
+#if !TARGET_FLAT
         else if (tyml == TYhptr)
         {   unsigned mreg,lreg;
 
@@ -1077,6 +1089,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
             NEWREG(cs.Irm,mreg);                        // ADD EA+2,mreg
             getlvalue_msw(&cs);
         }
+#endif
         else if (sz == 2 * REGSIZE)
         {
             cs.Irm |= modregrm(0,findreglsw(retregs),0);
@@ -1136,6 +1149,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
                 ce = gen(ce,&cs);               // MOV reg,EA
             }
         }
+#if !TARGET_FLAT
         else if (tyfv(tyml) || tyml == TYhptr)
         {       regm_t idxregs;
 
@@ -1163,6 +1177,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
                     gen(ce,&cs);                /* MOV mreg,EA+2        */
                 }
         }
+#endif
         else if (sz == 2 * REGSIZE)
         {       regm_t idx;
                 code *cm,*cl;
@@ -2618,8 +2633,10 @@ code *cdshtlng(elem *e,regm_t *pretregs)
             switch (tym1)
             {
                 case TYnptr:    segreg = SEG_DS;        break;
+#if !TARGET_FLAT
                 case TYcptr:    segreg = SEG_CS;        break;
                 case TYsptr:    segreg = SEG_SS;        break;
+#endif
                 default:        assert(0);
             }
             ce = gen2(ce,0x8C,modregrm(3,segreg,reg));  /* MOV reg,segreg */

--- a/src/backend/dt.c
+++ b/src/backend/dt.c
@@ -240,7 +240,11 @@ dt_t ** dtcoff(dt_t **pdtend,targ_size_t offset)
     while (*pdtend)
         pdtend = &((*pdtend)->DTnext);
     dt = dt_calloc(DT_coff);
+#if TARGET_FLAT
+    dt->Dty = TYnptr;
+#else
     dt->Dty = TYcptr;
+#endif
     dt->DToffset = offset;
     *pdtend = dt;
     pdtend = &dt->DTnext;

--- a/src/backend/dt.c
+++ b/src/backend/dt.c
@@ -240,10 +240,10 @@ dt_t ** dtcoff(dt_t **pdtend,targ_size_t offset)
     while (*pdtend)
         pdtend = &((*pdtend)->DTnext);
     dt = dt_calloc(DT_coff);
-#if TARGET_FLAT
-    dt->Dty = TYnptr;
-#else
+#if TARGET_SEGMENTED
     dt->Dty = TYcptr;
+#else
+    dt->Dty = TYnptr;
 #endif
     dt->DToffset = offset;
     *pdtend = dt;

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -1882,7 +1882,7 @@ elem *el_convstring(elem *e)
 #if TX86
     // Handle strings that go into the code segment
     if (
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         tybasic(e->Ety) == TYcptr ||
 #endif
         (tyfv(e->Ety) && config.flags3 & CFG3strcod))
@@ -2378,7 +2378,7 @@ L1:
 #endif
                     case TYnullptr:
                     case TYnptr:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                     case TYsptr:
                     case TYcptr:
 #endif
@@ -2399,7 +2399,7 @@ L1:
                         if (n1->EV.Vschar != n2->EV.Vschar)
                                 goto nomatch;
                         break;
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                     case TYfptr:
                     case TYhptr:
                     case TYvptr:
@@ -2658,7 +2658,7 @@ L1:
 #if JHANDLE
         case TYjhandle:
 #endif
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         case TYsptr:
         case TYcptr:
 #endif
@@ -2679,7 +2679,7 @@ L1:
 
         case TYulong:
         case TYdchar:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         case TYfptr:
         case TYhptr:
         case TYvptr:
@@ -3009,7 +3009,7 @@ void elem_print(elem *e)
 #if JHANDLE
                     case TYjhandle:
 #endif
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                     case TYsptr:
                     case TYcptr:
 #endif
@@ -3045,7 +3045,7 @@ void elem_print(elem *e)
                     case TYlong:
                     case TYulong:
                     case TYdchar:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                     case TYfptr:
                     case TYvptr:
                     case TYhptr:

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -1881,7 +1881,10 @@ elem *el_convstring(elem *e)
 
 #if TX86
     // Handle strings that go into the code segment
-    if (tybasic(e->Ety) == TYcptr ||
+    if (
+#if !TARGET_FLAT
+        tybasic(e->Ety) == TYcptr ||
+#endif
         (tyfv(e->Ety) && config.flags3 & CFG3strcod))
     {
         assert(OMFOBJ);         // option not done yet for others
@@ -2375,8 +2378,10 @@ L1:
 #endif
                     case TYnullptr:
                     case TYnptr:
+#if !TARGET_FLAT
                     case TYsptr:
                     case TYcptr:
+#endif
                         if (NPTRSIZE == SHORTSIZE)
                             goto case_short;
                         else if (NPTRSIZE == LONGSIZE)
@@ -2394,7 +2399,7 @@ L1:
                         if (n1->EV.Vschar != n2->EV.Vschar)
                                 goto nomatch;
                         break;
-#if TX86
+#if !TARGET_FLAT
                     case TYfptr:
                     case TYhptr:
                     case TYvptr:
@@ -2650,14 +2655,15 @@ L1:
             goto L1;
 #endif
 
-#if TX86
 #if JHANDLE
         case TYjhandle:
 #endif
-        case TYnullptr:
-        case TYnptr:
+#if !TARGET_FLAT
         case TYsptr:
         case TYcptr:
+#endif
+        case TYnptr:
+        case TYnullptr:
             if (NPTRSIZE == SHORTSIZE)
                 goto Ushort;
             if (NPTRSIZE == LONGSIZE)
@@ -2665,7 +2671,6 @@ L1:
             if (NPTRSIZE == LLONGSIZE)
                 goto Ullong;
             assert(0);
-#endif
 
         case TYuint:
             if (intsize == SHORTSIZE)
@@ -2674,17 +2679,16 @@ L1:
 
         case TYulong:
         case TYdchar:
+#if !TARGET_FLAT
         case TYfptr:
-#if TX86
         case TYhptr:
-#endif
         case TYvptr:
+#endif
         case TYvoid:                    /* some odd cases               */
         Ulong:
             result = e->EV.Vulong;
             break;
 
-#if TX86
         case TYint:
             if (intsize == SHORTSIZE)
                 goto Ishort;
@@ -2694,7 +2698,7 @@ L1:
         Ilong:
             result = e->EV.Vlong;
             break;
-#endif
+
         case TYllong:
         case TYullong:
         Ullong:
@@ -3002,15 +3006,15 @@ void elem_print(elem *e)
                     case TYuchar:
                         dbg_printf("%d ",e->EV.Vuchar);
                         break;
-#if TX86
-                    case TYsptr:
 #if JHANDLE
                     case TYjhandle:
 #endif
-                    case TYnullptr:
-                    case TYnptr:
+#if !TARGET_FLAT
+                    case TYsptr:
                     case TYcptr:
 #endif
+                    case TYnullptr:
+                    case TYnptr:
                         if (NPTRSIZE == LONGSIZE)
                             goto L1;
                         if (NPTRSIZE == SHORTSIZE)
@@ -3036,15 +3040,13 @@ void elem_print(elem *e)
                     case TYushort:
                     case TYchar16:
                     L3:
-#if TX86
                         dbg_printf("%d ",e->EV.Vint);
                         break;
-#endif
                     case TYlong:
                     case TYulong:
                     case TYdchar:
+#if !TARGET_FLAT
                     case TYfptr:
-#if TX86
                     case TYvptr:
                     case TYhptr:
 #endif
@@ -3101,9 +3103,11 @@ void elem_print(elem *e)
                         dbg_printf("%gL+%gLi ", (double)e->EV.Vcldouble.re, (double)e->EV.Vcldouble.im);
                         break;
 
+#if !MARS
                     case TYident:
                         dbg_printf("'%s' ", e->ET->Tident);
                         break;
+#endif
 
                     default:
                         dbg_printf("Invalid type ");

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -134,24 +134,25 @@ HINT boolres(elem *e)
                 case TYbool:
                 case TYwchar_t:
                 case TYenum:
+#if !MARS
                 case TYmemptr:
+#endif
                 case TYlong:
                 case TYulong:
                 case TYdchar:
                 case TYllong:
                 case TYullong:
-#if TX86
 #if JHANDLE
                 case TYjhandle:
 #endif
-                //case TYnullptr:
-                case TYnptr:
+#if !TARGET_FLAT
                 case TYsptr:
                 case TYcptr:
                 case TYhptr:
-#endif
                 case TYfptr:
                 case TYvptr:
+#endif
+                case TYnptr:
                     b = el_tolong(e) != 0;
                     break;
                 case TYfloat:

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -145,7 +145,7 @@ HINT boolres(elem *e)
 #if JHANDLE
                 case TYjhandle:
 #endif
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                 case TYsptr:
                 case TYcptr:
                 case TYhptr:

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -2036,14 +2036,16 @@ STATIC famlist * newfamlist(tym_t ty)
                 c.Vldouble = 1;
                 break;
 #if _MSDOS || __OS2__ || _WIN32         // if no byte ordering problems
-            case TYsptr:
-            case TYcptr:
 #if JHANDLE
             case TYjhandle:
 #endif
+#if !TARGET_FLAT
+            case TYsptr:
+            case TYcptr:
             case TYnptr:
             case TYfptr:
             case TYvptr:
+#endif
                 /* Convert pointers to integrals to avoid things like   */
                 /* multiplying pointers                                 */
                 ty = TYptrdiff;
@@ -2051,7 +2053,7 @@ STATIC famlist * newfamlist(tym_t ty)
             default:
                 c.Vlong = 1;
                 break;
-#if TX86
+#if !TARGET_FLAT
             case TYhptr:
                 ty = TYlong;
                 c.Vlong = 1;
@@ -2070,17 +2072,17 @@ STATIC famlist * newfamlist(tym_t ty)
             case TYwchar_t:             // BUG: what about 4 byte wchar_t's?
                 c.Vshort = 1;
                 break;
-#if TX86
-            case TYsptr:
-            case TYcptr:
 #if JHANDLE
             case TYjhandle:
 #endif
-            case TYnptr:
-#endif
-            case TYnullptr:
+#if !TARGET_FLAT
+            case TYsptr:
+            case TYcptr:
             case TYfptr:
             case TYvptr:
+#endif
+            case TYnptr:
+            case TYnullptr:
                 ty = TYint;
                 if (I64)
                     ty = TYllong;
@@ -2089,7 +2091,7 @@ STATIC famlist * newfamlist(tym_t ty)
             case TYuint:
                 c.Vint = 1;
                 break;
-#if TX86
+#if !TARGET_FLAT
             case TYhptr:
                 ty = TYlong;
 #endif
@@ -2110,13 +2112,13 @@ STATIC famlist * newfamlist(tym_t ty)
         c.Vldouble = 0;
         if (typtr(ty))
         {
-#if TX86
-            ty = (tybasic(ty) == TYhptr) ? TYlong : TYint;
+            ty = TYint;
+#if !TARGET_FLAT
+            if (tybasic(ty) == TYhptr)
+                ty = TYlong;
+#endif
             if (I64)
                 ty = TYllong;
-#else
-            ty = TYint;
-#endif
         }
         fl->c2 = el_const(ty,&c);               /* c2 = 0               */
         return fl;
@@ -2492,6 +2494,7 @@ STATIC void ivfamelems(register Iv *biv,register elem **pn)
                 n1 = n->E1;
         }
 
+#if !TARGET_FLAT
         // Get rid of case where we painted a far pointer to a long
         if (op == OPadd || op == OPmin)
         {   int sz;
@@ -2501,6 +2504,7 @@ STATIC void ivfamelems(register Iv *biv,register elem **pn)
                 (sz != tysize(n1->Ety) || sz != tysize(n2->Ety)))
                 return;
         }
+#endif
 
         /* Look for function of basic IV (-biv or biv op const)         */
         if (n1->Eoper == OPvar && n1->EV.sp.Vsym == biv->IVbasic)
@@ -2546,7 +2550,7 @@ STATIC void ivfamelems(register Iv *biv,register elem **pn)
                                 /* Check for subtracting two pointers */
                                 if (typtr(c2ty) && typtr(n2->Ety))
                                 {
-#if TX86
+#if !TARGET_FLAT
                                     if (tybasic(c2ty) == TYhptr)
                                         c2ty = TYlong;
                                     else
@@ -2885,7 +2889,7 @@ STATIC bool funcprev(Iv *biv,famlist *fl)
                     else                        /* can't subtract fptr  */
                         goto L1;
                 }
-#if TX86
+#if !TARGET_FLAT
                 if (tybasic(fls->c2->Ety) == TYhptr)
                     tymin = TYlong;
                 else
@@ -2893,7 +2897,7 @@ STATIC bool funcprev(Iv *biv,famlist *fl)
                     tymin = I64 ? TYllong : TYint;         /* type of (ptr - ptr) */
         }
 
-#if TX86
+#if !TARGET_FLAT
         /* If e1 and fls->c2 are fptrs, and are not from the same       */
         /* segment, we cannot subtract them.                            */
         if (tyfv(e1->Ety) && tyfv(fls->c2->Ety))
@@ -3214,7 +3218,7 @@ STATIC void elimbasivs(register loop *l)
                                 ne = el_bin(OPmin,ty,
                                         el_var(fl->FLtemp),
                                         C2);
-#if TX86
+#if !TARGET_FLAT
                                 if (tybasic(ne->E1->Ety) == TYfptr &&
                                     tybasic(ne->E2->Ety) == TYfptr)
                                 {   ne->Ety = I64 ? TYllong : TYint;
@@ -3439,15 +3443,15 @@ STATIC famlist * flcmp(famlist *f1,famlist *f2)
                         goto Lf2;
                 break;
 
-#if TX86
 #if JHANDLE
             case TYjhandle:
 #endif
-            case TYnullptr:
-            case TYnptr:        // BUG: 64 bit pointers?
+#if !TARGET_FLAT
             case TYsptr:
             case TYcptr:
 #endif
+            case TYnptr:        // BUG: 64 bit pointers?
+            case TYnullptr:
             case TYint:
             case TYuint:
                 if (intsize == SHORTSIZE)
@@ -3457,9 +3461,9 @@ STATIC famlist * flcmp(famlist *f1,famlist *f2)
             case TYlong:
             case TYulong:
             case TYdchar:
+#if !TARGET_FLAT
             case TYfptr:
             case TYvptr:
-#if TX86
             case TYhptr:
 #endif
             case_long:

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -2039,7 +2039,7 @@ STATIC famlist * newfamlist(tym_t ty)
 #if JHANDLE
             case TYjhandle:
 #endif
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYsptr:
             case TYcptr:
             case TYnptr:
@@ -2053,7 +2053,7 @@ STATIC famlist * newfamlist(tym_t ty)
             default:
                 c.Vlong = 1;
                 break;
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYhptr:
                 ty = TYlong;
                 c.Vlong = 1;
@@ -2075,7 +2075,7 @@ STATIC famlist * newfamlist(tym_t ty)
 #if JHANDLE
             case TYjhandle:
 #endif
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYsptr:
             case TYcptr:
             case TYfptr:
@@ -2091,7 +2091,7 @@ STATIC famlist * newfamlist(tym_t ty)
             case TYuint:
                 c.Vint = 1;
                 break;
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYhptr:
                 ty = TYlong;
 #endif
@@ -2113,7 +2113,7 @@ STATIC famlist * newfamlist(tym_t ty)
         if (typtr(ty))
         {
             ty = TYint;
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             if (tybasic(ty) == TYhptr)
                 ty = TYlong;
 #endif
@@ -2494,7 +2494,7 @@ STATIC void ivfamelems(register Iv *biv,register elem **pn)
                 n1 = n->E1;
         }
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         // Get rid of case where we painted a far pointer to a long
         if (op == OPadd || op == OPmin)
         {   int sz;
@@ -2550,7 +2550,7 @@ STATIC void ivfamelems(register Iv *biv,register elem **pn)
                                 /* Check for subtracting two pointers */
                                 if (typtr(c2ty) && typtr(n2->Ety))
                                 {
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                                     if (tybasic(c2ty) == TYhptr)
                                         c2ty = TYlong;
                                     else
@@ -2889,7 +2889,7 @@ STATIC bool funcprev(Iv *biv,famlist *fl)
                     else                        /* can't subtract fptr  */
                         goto L1;
                 }
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                 if (tybasic(fls->c2->Ety) == TYhptr)
                     tymin = TYlong;
                 else
@@ -2897,7 +2897,7 @@ STATIC bool funcprev(Iv *biv,famlist *fl)
                     tymin = I64 ? TYllong : TYint;         /* type of (ptr - ptr) */
         }
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         /* If e1 and fls->c2 are fptrs, and are not from the same       */
         /* segment, we cannot subtract them.                            */
         if (tyfv(e1->Ety) && tyfv(fls->c2->Ety))
@@ -3218,7 +3218,7 @@ STATIC void elimbasivs(register loop *l)
                                 ne = el_bin(OPmin,ty,
                                         el_var(fl->FLtemp),
                                         C2);
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                                 if (tybasic(ne->E1->Ety) == TYfptr &&
                                     tybasic(ne->E2->Ety) == TYfptr)
                                 {   ne->Ety = I64 ? TYllong : TYint;
@@ -3446,7 +3446,7 @@ STATIC famlist * flcmp(famlist *f1,famlist *f2)
 #if JHANDLE
             case TYjhandle:
 #endif
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYsptr:
             case TYcptr:
 #endif
@@ -3461,7 +3461,7 @@ STATIC famlist * flcmp(famlist *f1,famlist *f2)
             case TYlong:
             case TYulong:
             case TYdchar:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYfptr:
             case TYvptr:
             case TYhptr:

--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -1205,7 +1205,7 @@ void elimass(elem *n)
             /* Don't screw up assnod[]. */
             n->Eoper = OPcomma;
             n->Ety |= n->E2->Ety & (mTYconst | mTYvolatile | mTYimmutable | mTYshared
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                  | mTYfar
 #endif
                 );

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -748,7 +748,7 @@ void fltables()
 void dotytab()
 {
     static tym_t _ptr[]      = { TYjhandle,TYnptr };
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     static tym_t _ptr_nflat[]= { TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr };
 #endif
     static tym_t _real[]     = { TYfloat,TYdouble,TYdouble_alias,TYldouble,
@@ -765,7 +765,7 @@ void dotytab()
                                  TYchar16, TYcent, TYucent };
     static tym_t _ref[]      = { TYnref,TYref };
     static tym_t _func[]     = { TYnfunc,TYnpfunc,TYnsfunc,TYifunc,TYmfunc,TYjfunc,TYhfunc };
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     static tym_t _ref_nflat[] = { TYfref };
     static tym_t _func_nflat[]= { TYffunc,TYfpfunc,TYf16func,TYfsfunc,TYnsysfunc,TYfsysfunc, };
 #endif
@@ -785,11 +785,11 @@ void dotytab()
     static tym_t _farfunc[] = { TYffunc,TYfpfunc,TYfsfunc,TYfsysfunc };
 #endif
     static tym_t _pasfunc[] = { TYnpfunc,TYnsfunc,TYmfunc,TYjfunc };
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     static tym_t _pasfunc_nf[] = { TYfpfunc,TYf16func,TYfsfunc, };
 #endif
     static tym_t _revfunc[] = { TYnpfunc,TYjfunc };
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     static tym_t _revfunc_nf[] = { TYfpfunc,TYf16func, };
 #endif
     static tym_t _short[]     = { TYbool,TYchar,TYschar,TYuchar,TYshort,
@@ -858,7 +858,7 @@ void dotytab()
 "C func",       TYhfunc,        TYhfunc,   TYhfunc,     -1,     0,      0,
 "__near &",     TYnref,         TYnref,    TYnref,      2,      0,      0,
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
 "__ss *",       TYsptr,         TYsptr,    TYsptr,      2,  0x20,       0x100,
 "__cs *",       TYcptr,         TYcptr,    TYcptr,      2,  0x20,       0x100,
 "__far16 *",    TYf16ptr,       TYf16ptr,  TYf16ptr,    4,  0x40,       0x200,
@@ -907,7 +907,7 @@ void dotytab()
                      };
 
     T1(_ptr,      TYFLptr);
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     T1(_ptr_nflat,TYFLptr);
 #endif
     T1(_real,     TYFLreal);
@@ -930,7 +930,7 @@ void dotytab()
     T2(_ref,      TYFLref);
     T2(_func,     TYFLfunc);
     T2(_nullptr,  TYFLnullptr);
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     T2(_pasfunc_nf, TYFLpascal);
     T2(_revfunc_nf, TYFLrevparam);
     T2(_ref_nflat,  TYFLref);

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -747,8 +747,10 @@ void fltables()
 
 void dotytab()
 {
-    static tym_t _ptr[]      = { TYjhandle,TYnptr,TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,
-                                 TYvptr };
+    static tym_t _ptr[]      = { TYjhandle,TYnptr };
+#if !TARGET_FLAT
+    static tym_t _ptr_nflat[]= { TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr };
+#endif
     static tym_t _real[]     = { TYfloat,TYdouble,TYdouble_alias,TYldouble,
                                };
     static tym_t _imaginary[] = {
@@ -761,16 +763,20 @@ void dotytab()
                                  TYwchar_t,TYushort,TYenum,TYint,TYuint,
                                  TYlong,TYulong,TYllong,TYullong,TYdchar,
                                  TYchar16, TYcent, TYucent };
-    static tym_t _ref[]      = { TYnref,TYfref,TYref };
-    static tym_t _func[]     = { TYnfunc,TYffunc,TYnpfunc,TYfpfunc,TYf16func,
-                                 TYnsfunc,TYfsfunc,TYifunc,TYmfunc,TYjfunc,
-                                 TYnsysfunc,TYfsysfunc, TYhfunc };
+    static tym_t _ref[]      = { TYnref,TYref };
+    static tym_t _func[]     = { TYnfunc,TYnpfunc,TYnsfunc,TYifunc,TYmfunc,TYjfunc,TYhfunc };
+#if !TARGET_FLAT
+    static tym_t _ref_nflat[] = { TYfref };
+    static tym_t _func_nflat[]= { TYffunc,TYfpfunc,TYf16func,TYfsfunc,TYnsysfunc,TYfsysfunc, };
+#endif
     static tym_t _uns[]     = { TYuchar,TYushort,TYuint,TYulong,
 #if MARS
                                 TYwchar_t,
 #endif
                                 TYdchar,TYullong,TYucent,TYchar16 };
+#if !MARS
     static tym_t _mptr[]    = { TYmemptr };
+#endif
     static tym_t _nullptr[] = { TYnullptr };
 #if OMFOBJ
     static tym_t _fv[]      = { TYfptr, TYvptr };
@@ -778,8 +784,14 @@ void dotytab()
 #if TARGET_WINDOS
     static tym_t _farfunc[] = { TYffunc,TYfpfunc,TYfsfunc,TYfsysfunc };
 #endif
-    static tym_t _pasfunc[] = { TYnpfunc,TYfpfunc,TYf16func,TYnsfunc,TYfsfunc,TYmfunc,TYjfunc };
-    static tym_t _revfunc[] = { TYnpfunc,TYfpfunc,TYf16func,TYjfunc };
+    static tym_t _pasfunc[] = { TYnpfunc,TYnsfunc,TYmfunc,TYjfunc };
+#if !TARGET_FLAT
+    static tym_t _pasfunc_nf[] = { TYfpfunc,TYf16func,TYfsfunc, };
+#endif
+    static tym_t _revfunc[] = { TYnpfunc,TYjfunc };
+#if !TARGET_FLAT
+    static tym_t _revfunc_nf[] = { TYfpfunc,TYf16func, };
+#endif
     static tym_t _short[]     = { TYbool,TYchar,TYschar,TYuchar,TYshort,
                                   TYwchar_t,TYushort,TYchar16 };
     static tym_t _aggregate[] = { TYstruct,TYarray };
@@ -830,39 +842,43 @@ void dotytab()
 "complex double",       TYcdouble,      TYcdouble,  TYcdouble,  2*DOUBLESIZE,0x89,0x51,
 "complex long double",  TYcldouble,     TYcldouble, TYcldouble, 2*LNGDBLSIZE,0x89,0x52,
 
-"*",            TYptr,          TYptr,     TYptr,       2,  0x20,       0x100,
 "__near *",     TYjhandle,      TYjhandle, TYjhandle,   2,  0x20,       0x100,
 "nullptr_t",    TYnullptr,      TYnullptr, TYptr,       2,  0x20,       0x100,
 "*",            TYnptr,         TYnptr,    TYnptr,      2,  0x20,       0x100,
+"&",            TYref,          TYref,     TYref,       -1,     0,      0,
+"void",         TYvoid,         TYvoid,    TYvoid,      -1,     0x85,   3,
+"struct",       TYstruct,       TYstruct,  TYstruct,    -1,     0,      0,
+"array",        TYarray,        TYarray,   TYarray,     -1,     0x78,   0,
+"C func",       TYnfunc,        TYnfunc,   TYnfunc,     -1,     0x63,   0,
+"Pascal func",  TYnpfunc,       TYnpfunc,  TYnpfunc,    -1,     0x74,   0,
+"std func",     TYnsfunc,       TYnsfunc,  TYnsfunc,    -1,     0x63,   0,
+"*",            TYptr,          TYptr,     TYptr,       2,  0x20,       0x100,
+"member func",  TYmfunc,        TYmfunc,   TYmfunc,     -1,     0x64,   0,
+"D func",       TYjfunc,        TYjfunc,   TYjfunc,     -1,     0x74,   0,
+"C func",       TYhfunc,        TYhfunc,   TYhfunc,     -1,     0,      0,
+"__near &",     TYnref,         TYnref,    TYnref,      2,      0,      0,
+
+#if !TARGET_FLAT
 "__ss *",       TYsptr,         TYsptr,    TYsptr,      2,  0x20,       0x100,
 "__cs *",       TYcptr,         TYcptr,    TYcptr,      2,  0x20,       0x100,
 "__far16 *",    TYf16ptr,       TYf16ptr,  TYf16ptr,    4,  0x40,       0x200,
 "__far *",      TYfptr,         TYfptr,    TYfptr,      4,  0x40,       0x200,
 "__huge *",     TYhptr,         TYhptr,    TYhptr,      4,  0x40,       0x300,
 "__handle *",   TYvptr,         TYvptr,    TYvptr,      4,  0x40,       0x200,
-"struct",       TYstruct,       TYstruct,  TYstruct,    -1,     0,      0,
-"array",        TYarray,        TYarray,   TYarray,     -1,     0x78,   0,
-"&",            TYref,          TYref,     TYref,       -1,     0,      0,
-"__near &",     TYnref,         TYnref,    TYnref,      2,      0,      0,
-"__far &",      TYfref,         TYfref,    TYfref,      4,      0,      0,
-"C func",       TYnfunc,        TYnfunc,   TYnfunc,     -1,     0x63,   0,
-"C func",       TYhfunc,        TYhfunc,   TYhfunc,     -1,     0,      0,
 "far C func",   TYffunc,        TYffunc,   TYffunc,     -1,     0x64,   0,
-"std func",     TYnsfunc,       TYnsfunc,  TYnsfunc,    -1,     0x63,   0,
+"far Pascal func", TYfpfunc,    TYfpfunc,  TYfpfunc,    -1,     0x73,   0,
 "far std func", TYfsfunc,       TYfsfunc,  TYfsfunc,    -1,     0x64,   0,
+"_far16 Pascal func", TYf16func, TYf16func, TYf16func,  -1,     0x63,   0,
 "sys func",     TYnsysfunc,     TYnsysfunc,TYnsysfunc,  -1,     0x63,   0,
 "far sys func", TYfsysfunc,     TYfsysfunc,TYfsysfunc,  -1,     0x64,   0,
-"member func",  TYmfunc,        TYmfunc,   TYmfunc,     -1,     0x64,   0,
-"D func",        TYjfunc,       TYjfunc,   TYjfunc,     -1,     0x74,   0,
+"__far &",      TYfref,         TYfref,    TYfref,      4,      0,      0,
+#endif
+#if !MARS
 "interrupt func", TYifunc,      TYifunc,   TYifunc,     -1,     0x64,   0,
-"_far16 Pascal func", TYf16func, TYf16func, TYf16func,  -1,     0x63,   0,
-"Pascal func",  TYnpfunc,       TYnpfunc,  TYnpfunc,    -1,     0x74,   0,
-"far Pascal func",  TYfpfunc,   TYfpfunc,  TYfpfunc,    -1,     0x73,   0,
-"void",         TYvoid,         TYvoid,    TYvoid,      -1,     0x85,   3,
 "memptr",       TYmemptr,       TYmemptr,  TYmemptr,    -1,     0,      0,
 "ident",        TYident,        TYident,   TYident,     -1,     0,      0,
-"template",     TYtemplate,     TYtemplate, TYtemplate, -1,     0,      0,
 "vtshape",      TYvtshape,      TYvtshape,  TYvtshape,  -1,     0,      0,
+#endif
     };
 
     FILE *f;
@@ -891,12 +907,17 @@ void dotytab()
                      };
 
     T1(_ptr,      TYFLptr);
+#if !TARGET_FLAT
+    T1(_ptr_nflat,TYFLptr);
+#endif
     T1(_real,     TYFLreal);
     T1(_integral, TYFLintegral);
     T1(_imaginary,TYFLimaginary);
     T1(_complex,  TYFLcomplex);
     T1(_uns,      TYFLuns);
+#if !MARS
     T1(_mptr,     TYFLmptr);
+#endif
 
 #if OMFOBJ
     T1(_fv,       TYFLfv);
@@ -909,7 +930,12 @@ void dotytab()
     T2(_ref,      TYFLref);
     T2(_func,     TYFLfunc);
     T2(_nullptr,  TYFLnullptr);
-
+#if !TARGET_FLAT
+    T2(_pasfunc_nf, TYFLpascal);
+    T2(_revfunc_nf, TYFLrevparam);
+    T2(_ref_nflat,  TYFLref);
+    T2(_func_nflat, TYFLfunc);
+#endif
 #undef T1
 #undef T2
 

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -402,13 +402,15 @@ void outdata(symbol *s)
                     flags = CFoff | CFseg;
                 if (I64)
                     flags |= CFoffset64;
+#if !TARGET_FLAT
                 if (tybasic(dt->Dty) == TYcptr)
                     reftocodseg(seg,offset,dt->DTabytes);
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
                 else
+#endif
+#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
                     reftodatseg(seg,offset,dt->DTabytes,dt->DTseg,flags);
 #else
-                else if (dt->DTseg == DATA)
+                /*else*/ if (dt->DTseg == DATA)
                     reftodatseg(seg,offset,dt->DTabytes,DATA,flags);
                 else
                     reftofarseg(seg,offset,dt->DTabytes,dt->DTseg,flags);

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -402,7 +402,7 @@ void outdata(symbol *s)
                     flags = CFoff | CFseg;
                 if (I64)
                     flags |= CFoffset64;
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                 if (tybasic(dt->Dty) == TYcptr)
                     reftocodseg(seg,offset,dt->DTabytes);
                 else

--- a/src/backend/rtlsym.c
+++ b/src/backend/rtlsym.c
@@ -66,12 +66,12 @@ void rtlsym_init()
         }
 
 #if MARS
-        type *t = type_fake(LARGECODE ? TYffunc : TYnfunc);
+        type *t = type_fake(TYnfunc);
         t->Tmangle = mTYman_c;
         t->Tcount++;
 
         // Variadic function
-        type *tv = type_fake(LARGECODE ? TYffunc : TYnfunc);
+        type *tv = type_fake(TYnfunc);
         tv->Tmangle = mTYman_c;
         tv->Tcount++;
 #endif

--- a/src/backend/ty.h
+++ b/src/backend/ty.h
@@ -85,7 +85,7 @@ enum TYM
     TYcent              = 0x3C, // 128 bit signed integer
     TYucent             = 0x3D, // 128 bit unsigned integer
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     TYsptr              = 0x1E, // stack segment relative pointer
     TYcptr              = 0x1F, // code segment relative pointer
     TYf16ptr            = 0x20, // special OS/2 far16 pointer

--- a/src/backend/ty.h
+++ b/src/backend/ty.h
@@ -63,51 +63,55 @@ enum TYM
     TYcdouble           = 0x19,
     TYcldouble          = 0x1A,
 
-#if TX86
     TYjhandle           = 0x1B, // Jupiter handle type, equals TYnptr except
                                 // that the debug type is different so the
                                 // debugger can distinguish them
     TYnullptr           = 0x1C,
     TYnptr              = 0x1D, // data segment relative pointer
+    TYref               = 0x24, // reference to another type
+    TYvoid              = 0x25,
+    TYstruct            = 0x26, // watch tyaggregate()
+    TYarray             = 0x27, // watch tyaggregate()
+    TYnfunc             = 0x28, // near C func
+    TYnpfunc            = 0x2A, // near Cpp func
+    TYnsfunc            = 0x2C, // near stdcall func
+    TYifunc             = 0x2E, // interrupt func
+    TYptr               = 0x33, // generic pointer type
+    TYmfunc             = 0x37, // NT C++ member func
+    TYjfunc             = 0x38, // LINKd D function
+    TYhfunc             = 0x39, // C function with hidden parameter
+    TYnref              = 0x3A, // near reference
+
+    TYcent              = 0x3C, // 128 bit signed integer
+    TYucent             = 0x3D, // 128 bit unsigned integer
+
+#if !TARGET_FLAT
     TYsptr              = 0x1E, // stack segment relative pointer
     TYcptr              = 0x1F, // code segment relative pointer
     TYf16ptr            = 0x20, // special OS/2 far16 pointer
     TYfptr              = 0x21, // far pointer (has segment and offset)
     TYhptr              = 0x22, // huge pointer (has segment and offset)
     TYvptr              = 0x23, // __handle pointer (has segment and offset)
-    TYref               = 0x24, // reference to another type
-    TYvoid              = 0x25,
-    TYstruct            = 0x26, // watch tyaggregate()
-    TYarray             = 0x27, // watch tyaggregate()
-    TYnfunc             = 0x28, // near C func
     TYffunc             = 0x29, // far  C func
-    TYnpfunc            = 0x2A, // near Cpp func
     TYfpfunc            = 0x2B, // far  Cpp func
-    TYnsfunc            = 0x2C, // near stdcall func
     TYfsfunc            = 0x2D, // far stdcall func
-    TYifunc             = 0x2E, // interrupt func
+    TYf16func           = 0x34, // _far16 _pascal function
+    TYnsysfunc          = 0x35, // near __syscall func
+    TYfsysfunc          = 0x36, // far __syscall func
+    TYfref              = 0x3B, // far reference
+#endif
+
+#if !MARS
     TYmemptr            = 0x2F, // pointer to member
     TYident             = 0x30, // type-argument
     TYtemplate          = 0x31, // unexpanded class template
     TYvtshape           = 0x32, // virtual function table
-    TYptr               = 0x33, // generic pointer type
-    TYf16func           = 0x34, // _far16 _pascal function
-    TYnsysfunc          = 0x35, // near __syscall func
-    TYfsysfunc          = 0x36, // far __syscall func
-    TYmfunc             = 0x37, // NT C++ member func
-    TYjfunc             = 0x38, // LINKd D function
-    TYhfunc             = 0x39, // C function with hidden parameter
-    TYnref              = 0x3A, // near reference
-    TYfref              = 0x3B, // far reference
-
-    TYcent              = 0x3C, // 128 bit signed integer
-    TYucent             = 0x3D, // 128 bit unsigned integer
+#endif
 
 #if MARS
 #define TYaarray        TYnptr
 #define TYdelegate      (I64 ? TYcent : TYllong)
 #define TYdarray        (I64 ? TYucent : TYullong)
-#endif
 #endif
 
     TYMAX               = 0x3E,

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -69,7 +69,7 @@ targ_size_t type_size(type *t)
         switch (tyb)
         {
             // in case program plays games with function pointers
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
             case TYffunc:
             case TYfpfunc:
             case TYfsfunc:
@@ -239,7 +239,7 @@ type *type_alloc(tym_t ty)
 {   type *t;
     static type tzero;
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
     assert(tybasic(ty) != TYtemplate);
 #endif
     if (type_list)
@@ -470,10 +470,10 @@ void type_init()
     }
 
     // Type of trace function
-#if TARGET_FLAT
-    tstrace = type_fake(TYnfunc);
-#else
+#if TARGET_SEGMENTED
     tstrace = type_fake(I16 ? TYffunc : TYnfunc);
+#else
+    tstrace = type_fake(TYnfunc);
 #endif
     tstrace->Tmangle = mTYman_c;
     tstrace->Tcount++;
@@ -481,10 +481,10 @@ void type_init()
     chartype = (config.flags3 & CFG3ju) ? tsuchar : tschar;
 
     // Type of far library function
-#if TARGET_FLAT
-    tsclib = type_fake(TYnpfunc);
-#else
+#if TARGET_SEGMENTED
     tsclib = type_fake(LARGECODE ? TYfpfunc : TYnpfunc);
+#else
+    tsclib = type_fake(TYnpfunc);
 #endif
     tsclib->Tmangle = mTYman_c;
     tsclib->Tcount++;
@@ -801,7 +801,7 @@ int type_isdependent(type *t)
         if (t->Tflags & TFdependent)
             goto Lisdependent;
         if (tyfunc(t->Tty)
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                 || tybasic(t->Tty) == TYtemplate
 #endif
                 )

--- a/src/msc.c
+++ b/src/msc.c
@@ -193,12 +193,7 @@ void util_set32()
         tysize[TYuint + i] = LONGSIZE;
         tysize[TYjhandle + i] = LONGSIZE;
         tysize[TYnptr + i] = LONGSIZE;
-        tysize[TYsptr + i] = LONGSIZE;
-        tysize[TYcptr + i] = LONGSIZE;
         tysize[TYnref + i] = LONGSIZE;
-        tysize[TYfptr + i] = 6;
-        tysize[TYvptr + i] = 6;
-        tysize[TYfref + i] = 6;
     }
 
     for (int i = 0; i < 0x100; i += 0x40)
@@ -207,8 +202,6 @@ void util_set32()
         tyalignsize[TYuint + i] = LONGSIZE;
         tyalignsize[TYnullptr + i] = LONGSIZE;
         tyalignsize[TYnptr + i] = LONGSIZE;
-        tyalignsize[TYsptr + i] = LONGSIZE;
-        tyalignsize[TYcptr + i] = LONGSIZE;
         tyalignsize[TYnref + i] = LONGSIZE;
     }
 }
@@ -231,12 +224,7 @@ void util_set64()
         tysize[TYint  + i] = LONGSIZE;
         tysize[TYuint + i] = LONGSIZE;
         tysize[TYnptr + i] = 8;
-        tysize[TYsptr + i] = 8;
-        tysize[TYcptr + i] = 8;
         tysize[TYnref + i] = 8;
-        tysize[TYfptr + i] = 10;    // NOTE: There are codgen test that check
-        tysize[TYvptr + i] = 10;    // tysize[x] == tysize[TYfptr] so don't set
-        tysize[TYfref + i] = 10;    // tysize[TYfptr] to tysize[TYnptr]
         tysize[TYldouble + i] = REALSIZE;
         tysize[TYildouble + i] = REALSIZE;
         tysize[TYcldouble + i] = 2 * REALSIZE;
@@ -246,12 +234,7 @@ void util_set64()
         tyalignsize[TYuint + i] = LONGSIZE;
         tyalignsize[TYnullptr + i] = 8;
         tyalignsize[TYnptr + i] = 8;
-        tyalignsize[TYsptr + i] = 8;
-        tyalignsize[TYcptr + i] = 8;
         tyalignsize[TYnref + i] = 8;
-        tyalignsize[TYfptr + i] = 8;
-        tyalignsize[TYvptr + i] = 8;
-        tyalignsize[TYfref + i] = 8;
 #if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
         tyalignsize[TYldouble + i] = 16;
         tyalignsize[TYildouble + i] = 16;


### PR DESCRIPTION
The backend was fairly inconsistent in when some uses of segmented TY's were behind TX86 or TARGET_FLAT or nothing.  This cleans all that up and switches to positive boolean logic rather than negative with TARGET_SEGMENTED.

Walter, let me know if you want me to provide a pull request for dmc as well.  I wanted to make sure this set of changes passed your laugh test before doing that.
