### PR TITLE
add include of stdlib.h since aa.h seems to require it

### DIFF
--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -13,6 +13,7 @@
 #if !SPP
 
 #include        <stdio.h>
+#include        <stdlib.h>
 #include        <string.h>
 #include        <time.h>
 #include        "cc.h"


### PR DESCRIPTION
add include of stdlib.h since aa.h seems to require the includer to include it.  To be cleaned up in some potential future.
