### PR TITLE
Fix CTFE ICE bugs 6672 and 2315; fix nested AAs 6739

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3647,6 +3647,11 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
                 assert(0);
             }
         }
+        if (wantRef && newval->op == TOKindex
+            && ((IndexExp *)newval)->e1 == aggregate)
+        {   // It's a circular reference, resolve it now
+                newval = newval->interpret(istate);
+        }
 
         if (existingAE)
         {
@@ -3806,6 +3811,11 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
                 assert(0);
             }
         }
+        if (wantRef && newval->op == TOKindex
+            && ((IndexExp *)newval)->e1 == aggregate)
+        {   // It's a circular reference, resolve it now
+                newval = newval->interpret(istate);
+        }
 
         // For slice assignment, we check that the lengths match.
         size_t srclen = 0;
@@ -3834,7 +3844,8 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             sliceAssignStringFromString((StringExp *)existingSE, (StringExp *)newval, firstIndex);
             return newval;
         }
-        else if (newval->op == TOKstring && existingAE)
+        else if (newval->op == TOKstring && existingAE
+                && existingAE->type->isString())
         {   /* Mixed slice: it was initialized as an array literal of chars.
              * Now a slice of it is being set with a string.
              */

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3292,6 +3292,11 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         if (type->toBasetype()->ty == Tstruct && newval->op == TOKint64)
         {
             newval = type->defaultInitLiteral(loc);
+            if (newval->op != TOKstructliteral)
+            {
+                error("nested structs with constructors are not yet supported in CTFE (Bug 6419)");
+                return EXP_CANT_INTERPRET;
+            }
         }
         newval = Cast(type, type, newval);
         if (newval == EXP_CANT_INTERPRET)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -32,6 +32,9 @@ TemplateInstance *isSpeculativeFunction(FuncDeclaration *fd);
 #define LOG     0
 #define LOGASSIGN 0
 
+// Maximum allowable recursive function calls in CTFE
+#define CTFE_RECURSION_LIMIT 1000
+
 struct InterState
 {
     InterState *caller;         // calling function's InterState
@@ -347,7 +350,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
     Expression *e = NULL;
     while (1)
     {
-        if (CtfeStatus::callDepth > 1000)
+        if (CtfeStatus::callDepth > CTFE_RECURSION_LIMIT)
         {   // This is a compiler error. It must not be suppressed.
             global.gag = 0;
             error("CTFE recursion limit exceeded");

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -347,7 +347,8 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
     while (1)
     {
         if (CtfeStatus::callDepth > 1000)
-        {
+        {   // This is a compiler error. It must not be suppressed.
+            global.gag = 0;
             error("CTFE recursion limit exceeded");
             e = NULL;
             break;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2504,3 +2504,22 @@ static assert({
     s.m[2] = 4;
     return 6693;
  }() == 6693);
+
+/**************************************************
+    6739   Nested AA assignment
+**************************************************/
+
+static assert({
+    int[int][int][int] aaa;
+    aaa[3][1][6] = 14;
+    return aaa[3][1][6];
+}() == 14);
+
+static assert({
+    int[int][int] aaa;
+    aaa[3][1] = 4;
+    aaa[3][3] = 3;
+    aaa[1][5] = 9;
+    auto kk = aaa[1][5];
+    return kk;
+}() == 9);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2252,6 +2252,40 @@ int ctfeSort6250()
 static assert(ctfeSort6250()==57);
 
 /**************************************************
+    6672 circular references in array
+**************************************************/
+
+void bug6672(ref string lhs, ref string rhs)
+{
+    auto tmp = lhs;
+    lhs = rhs;
+    rhs = tmp;
+}
+
+static assert( {
+    auto kw = ["a"];
+    bug6672(kw[0], kw[0]);
+    return true;
+}());
+
+void slice6672(ref string[2] agg, ref string lhs) { agg[0..$] = lhs; }
+
+static assert( {
+    string[2] kw = ["a", "b"];
+    slice6672(kw, kw[0]);
+    assert(kw[0] == "a");
+    assert(kw[1] == "a");
+    return true;
+}());
+
+// an unrelated rejects-valid bug
+static assert( {
+    string[2] kw = ["a", "b"];
+    kw[0..2] = "x";
+    return true;
+}());
+
+/**************************************************
     6399 (*p).length = n
 **************************************************/
 


### PR DESCRIPTION
Also improves the CTFE stack trace (similar to the template backtrace), so that it detects recursion instead of printing hundreds of error messages.

Bugs fixed (the first one is the oldest open ICE bug of any kind):
2315 DMD Stack Overflow on unwanted ctfe recursion
6672 [CTFE] ICE on compile time std.algorithm.sort
6739 [CTFE] Cannot set a value to an outer AA of a nested AA
