### PR TITLE
CTFE: two wrong-code bugs 6672 and 6749

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3104,6 +3104,13 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         if ((e1->op==TOKslice) && ((SliceExp *)e1)->e1->type->ty == Tsarray)
             wantRef = false;
 #endif
+        // If it is assignment from a ref parameter, it's not a ref assignment
+        if (this->e2->op == TOKvar)
+        {
+            VarDeclaration *v = ((VarExp *)this->e2)->var->isVarDeclaration();
+            if (v && (v->storage_class & (STCref | STCout)))
+                wantRef = false;
+        }
     }
     if (isBlockAssignment && (e2->type->toBasetype()->ty == Tarray || e2->type->toBasetype()->ty == Tsarray))
     {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3212,7 +3212,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             // ~= can create new values (see bug 6052)
             if (op == TOKcatass)
             {
-                if (needToCopyLiteral(this->e2))
+                if (needToCopyLiteral(newval))
                     newval = copyLiteral(newval);
                 if (newval->op == TOKslice)
                     newval = resolveSlice(newval);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2303,6 +2303,23 @@ static assert( {
     return true;
 }());
 
+void bug6672b(ref string lhs, ref string rhs)
+{
+    auto tmp = lhs;
+    assert(tmp == "a");
+    lhs = rhs;
+    assert(tmp == "a");
+    rhs = tmp;
+}
+
+static assert( {
+    auto kw=["a", "b"];
+    bug6672b(kw[0], kw[1]);
+    assert(kw[0]=="b");
+    assert(kw[1]=="a");
+    return true;
+}());
+
 /**************************************************
     6399 (*p).length = n
 **************************************************/

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1341,6 +1341,24 @@ static assert({
 }());
 
 /**************************************************
+    Bug 6749
+**************************************************/
+
+struct CtState {
+    string code;
+}
+
+CtState bug6749()
+{
+    CtState[] pieces;
+    CtState r = CtState("correct");
+    pieces ~= r;
+    r = CtState("clobbered");
+    return pieces[0];
+}
+static assert(bug6749().code == "correct");
+
+/**************************************************
     Index + slice assign to function returns
 **************************************************/
 


### PR DESCRIPTION
Nasty wrong code struzct appending bug. Simple fix though.
6749 [CTFE] problem with array of structs

My previous fix for this was incomplete, and turned it into a wrong-code bug.
6672 [CTFE] ICE on compile time std.algorithm.sort
