### PR TITLE
Issue 6208 - Parameter storage classes are ignored in template function deducing.

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1209,6 +1209,9 @@ Lretry:
 #endif
             Type *argtype = farg->type;
 
+            // Apply function parameter storage classes to parameter types
+            fparam->type = fparam->type->addStorageClass(fparam->storageClass);
+
 #if DMDV2
             /* Allow string literals which are type [] to match with [dim]
              */
@@ -1277,6 +1280,18 @@ Lretry:
                     }
                 }
             }
+
+            if (m && (fparam->storageClass & (STCref | STCauto)) == STCref)
+            {   if (!farg->isLvalue())
+                    goto Lnomatch;
+            }
+            if (m && (fparam->storageClass & STCout))
+            {   if (!farg->isLvalue())
+                    goto Lnomatch;
+            }
+            if (!m && (fparam->storageClass & STClazy) && fparam->type->ty == Tvoid &&
+                    farg->type->ty != Tvoid)
+                m = MATCHconvert;
 
             if (m)
             {   if (m < match)

--- a/src/template.h
+++ b/src/template.h
@@ -91,6 +91,7 @@ struct TemplateDeclaration : ScopeDsymbol
     MATCH deduceFunctionTemplateMatch(Scope *sc, Loc loc, Objects *targsi, Expression *ethis, Expressions *fargs, Objects *dedargs);
     FuncDeclaration *deduceFunctionTemplate(Scope *sc, Loc loc, Objects *targsi, Expression *ethis, Expressions *fargs, int flags = 0);
     void declareParameter(Scope *sc, TemplateParameter *tp, Object *o);
+    FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs, Expressions *fargs);
 
     TemplateDeclaration *isTemplateDeclaration() { return this; }
 

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -807,7 +807,7 @@ void abc50(T)(const T t)
 {
     showf(typeid(T).toString());
     showf(typeid(typeof(t)).toString());
-    assert(is(T == const(C)));
+    assert(is(T == C));
     assert(is(typeof(t) == const(C)));
 }
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6208

Related pull requests:
https://github.com/D-Programming-Language/dmd/pull/425
https://github.com/D-Programming-Language/druntime/pull/78
https://github.com/D-Programming-Language/phobos/pull/284

For auto-tester (http://yebblies.com/results/)
requires: druntime git://github.com/9rnsr/druntime.git fix6208_on_inout
requires: phobos git://github.com/9rnsr/phobos.git fix6208_on_inout
