### PR TITLE
Mixin gen

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1544,9 +1544,15 @@ void CompileDeclaration::compileIt(Scope *sc)
     {
         se = se->toUTF8(sc);
         Parser p(sc->module, (unsigned char *)se->string, se->len, 0);
-        p.loc = loc;
+        if (global.params.doMxnGeneration)
+            p.loc = sc->module->importedFrom->writeMixin((unsigned char *)se->string, se->len, loc);
+        else
+            p.loc = loc;
+        const size_t linstart = p.loc.linnum;
         p.nextToken();
         decl = p.parseDeclDefs(0);
+        if (global.params.doMxnGeneration)
+            sc->module->importedFrom->mxnloc.linnum += p.loc.linnum - linstart;
         if (p.token.value != TOKeof)
             exp->error("incomplete mixin declaration (%s)", se->toChars());
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -6568,10 +6568,16 @@ Expression *CompileExp::semantic(Scope *sc)
     }
     se = se->toUTF8(sc);
     Parser p(sc->module, (unsigned char *)se->string, se->len, 0);
-    p.loc = loc;
+    if (global.params.doMxnGeneration)
+        p.loc = sc->module->importedFrom->writeMixin((unsigned char *)se->string, se->len, loc);
+    else
+        p.loc = loc;
+    const size_t linstart = p.loc.linnum;
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
     Expression *e = p.parseExpression();
+    if (global.params.doMxnGeneration)
+        sc->module->importedFrom->mxnloc.linnum += p.loc.linnum - linstart;
     if (p.token.value != TOKeof)
     {   error("incomplete mixin expression (%s)", se->toChars());
         return new ErrorExp();

--- a/src/mars.c
+++ b/src/mars.c
@@ -62,6 +62,7 @@ Global::Global()
     ddoc_ext = "ddoc";
     json_ext = "json";
     map_ext  = "map";
+    mxn_ext  = "mixin";
 
 #if TARGET_WINDOS
     obj_ext  = "obj";
@@ -347,7 +348,10 @@ Usage:\n\
   -inline        do function inlining\n\
   -Jpath         where to look for string imports\n\
   -Llinkerflag   pass linkerflag to link\n\
-  -lib           generate library rather than object files\n"
+  -lib           generate library rather than object files\n\
+  -M             generate 'mixin' file\n\
+  -Mddirectory   write 'mixin' file to directory\n\
+  -Mffilename    write 'mixin' file to filename\n"
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
 "  -m32           generate 32 bit code\n\
   -m64           generate 64 bit code\n"
@@ -671,6 +675,29 @@ int tryMain(size_t argc, char *argv[])
                         if (!p[3])
                             goto Lnoarg;
                         global.params.hdrname = p + 3;
+                        break;
+
+                    case 0:
+                        break;
+
+                    default:
+                        goto Lerror;
+                }
+            }
+            else if (p[1] == 'M')
+            {   global.params.doMxnGeneration = 1;
+                switch (p[2])
+                {
+                    case 'd':
+                        if (!p[3])
+                            goto Lnoarg;
+                        global.params.mxndir = p + 3;
+                        break;
+
+                    case 'f':
+                        if (!p[3])
+                            goto Lnoarg;
+                        global.params.mxnname = p + 3;
                         break;
 
                     case 0:

--- a/src/mars.h
+++ b/src/mars.h
@@ -197,9 +197,13 @@ struct Param
     char *docname;      // write documentation file to docname
     Strings *ddocfiles;   // macro include files for Ddoc
 
-    char doHdrGeneration;       // process embedded documentation comments
-    char *hdrdir;               // write 'header' file to docdir directory
-    char *hdrname;              // write 'header' file to docname
+    char doHdrGeneration;       // generate header files
+    char *hdrdir;               // write 'header' file to hdrdir directory
+    char *hdrname;              // write 'header' file to hdrname
+
+    char doMxnGeneration;       // write mixins to file
+    char *mxndir;               // write 'mixin' file to mxndir directory
+    char *mxnname;              // write 'mixin' file to mxnname
 
     char doXGeneration;         // write JSON file
     char *xfilename;            // write JSON file to xfilename
@@ -258,6 +262,7 @@ struct Global
     const char *hdr_ext;        // for D 'header' import files
     const char *json_ext;       // for JSON files
     const char *map_ext;        // for .map files
+    const char *mxn_ext;        // for D 'mixin' files
     const char *copyright;
     const char *written;
     Strings *path;        // Array of char*'s which form the import lookup path

--- a/src/module.c
+++ b/src/module.c
@@ -907,6 +907,64 @@ void Module::gensymfile()
     symfile->writev();
 }
 
+/****************************************************
+ */
+
+Loc Module::writeMixin(unsigned char *str, size_t len, Loc loc)
+{
+    assert(global.params.doMxnGeneration);
+
+    if (!mxnfile)
+    {
+        FileName *mxnfilename;
+        char *argmxn;
+
+        if (global.params.mxnname)
+            argmxn = global.params.mxnname;
+        else if (global.params.preservePaths)
+            argmxn = (char *)arg;
+        else
+            argmxn = FileName::name((char *)arg);
+        if (!FileName::absolute(argmxn))
+        {   //FileName::ensurePathExists(global.params.hdrdir);
+            argmxn = FileName::combine(global.params.mxndir, argmxn);
+        }
+        if (global.params.mxnname)
+            mxnfilename = new FileName(argmxn);
+        else
+            mxnfilename = FileName::forceExt(argmxn, global.mxn_ext);
+
+        if (mxnfilename->equals(srcfile->name))
+        {   error("Source file and 'mixin' file have same name '%s'", srcfile->name->str);
+            fatal();
+        }
+
+        char *pt = FileName::path(mxnfilename->str);
+        if (*pt)
+            FileName::ensurePathExists(pt);
+        mem.free(pt);
+
+        mxnfile = new File(mxnfilename);
+        mxnfile->remove();
+        mxnloc = Loc(1);
+        mxnloc.filename = mxnfilename->str;
+    }
+    OutBuffer buf;
+
+    buf.printf("// mixin at %s", loc.toChars());
+    buf.writenl();
+    ++mxnloc.linnum;
+    Loc start = mxnloc;
+    buf.write(str, len);
+    buf.writenl();
+    ++mxnloc.linnum;
+
+    mxnfile->setbuffer(buf.data, buf.offset);
+    mxnfile->appendv();
+
+    return start;
+}
+
 /**********************************
  * Determine if we need to generate an instance of ModuleInfo
  * for this Module.

--- a/src/module.h
+++ b/src/module.h
@@ -64,6 +64,8 @@ struct Module : Package
     File *hdrfile;      // 'header' file
     File *symfile;      // output symbol file
     File *docfile;      // output documentation file
+    File *mxnfile;      // 'mixin' file
+    Loc mxnloc;         // location in mixin file
     unsigned errors;    // if any errors in file
     unsigned numlines;  // number of lines in source file
     int isDocFile;      // if it is a documentation input file, not D source
@@ -131,6 +133,7 @@ struct Module : Package
     void genobjfile(int multiobj);
     void gensymfile();
     void gendocfile();
+    Loc writeMixin(unsigned char* str, size_t len, Loc loc);
     int needModuleInfo();
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
     Dsymbol *symtabInsert(Dsymbol *s);

--- a/src/root/root.c
+++ b/src/root/root.c
@@ -1165,37 +1165,7 @@ Lerr:
 int File::write()
 {
 #if POSIX
-    int fd;
-    ssize_t numwritten;
-    char *name;
-
-    name = this->name->toChars();
-    fd = open(name, O_CREAT | O_WRONLY | O_TRUNC, 0644);
-    if (fd == -1)
-        goto err;
-
-    numwritten = ::write(fd, buffer, len);
-    if (len != numwritten)
-        goto err2;
-
-    if (close(fd) == -1)
-        goto err;
-
-    if (touchtime)
-    {   struct utimbuf ubuf;
-
-        ubuf.actime = ((struct stat *)touchtime)->st_atime;
-        ubuf.modtime = ((struct stat *)touchtime)->st_mtime;
-        if (utime(name, &ubuf))
-            goto err;
-    }
-    return 0;
-
-err2:
-    close(fd);
-    ::remove(name);
-err:
-    return 1;
+    return writePosix(false);
 #elif _WIN32
     HANDLE h;
     DWORD numwritten;
@@ -1239,7 +1209,7 @@ err:
 int File::append()
 {
 #if POSIX
-    return 1;
+    return writePosix(true);
 #elif _WIN32
     HANDLE h;
     DWORD numwritten;
@@ -1280,6 +1250,54 @@ err:
 #endif
 }
 
+/*********************************************
+ * Writes or Append to a file.
+ * Returns:
+ *      0       success
+ */
+
+#if POSIX
+int File::writePosix(bool append)
+{
+    int fd;
+    ssize_t numwritten;
+    char *name;
+    int flags = O_CREAT | O_WRONLY;
+
+    if (append)
+        flags |= O_APPEND;
+    else
+        flags |= O_TRUNC;
+    name = this->name->toChars();
+    fd = open(name, flags, 0644);
+    if (fd == -1)
+        goto err;
+
+    numwritten = ::write(fd, buffer, len);
+    if (len != numwritten)
+        goto err2;
+
+    if (close(fd) == -1)
+        goto err;
+
+    if (touchtime)
+    {   struct utimbuf ubuf;
+
+        ubuf.actime = ((struct stat *)touchtime)->st_atime;
+        ubuf.modtime = ((struct stat *)touchtime)->st_mtime;
+        if (utime(name, &ubuf))
+            goto err;
+    }
+    return 0;
+
+err2:
+    close(fd);
+    ::remove(name);
+err:
+    return 1;
+}
+#endif
+
 /**************************************
  */
 
@@ -1306,7 +1324,7 @@ void File::writev()
 
 void File::appendv()
 {
-    if (write())
+    if (append())
         error("Error appending to file '%s'",name->toChars());
 }
 

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -162,6 +162,7 @@ struct File : Object
 
     void mmreadv();
 
+
     /* Write file, return !=0 if error
      */
 
@@ -195,6 +196,12 @@ struct File : Object
      *  1:      normal file
      *  2:      directory
      */
+
+#if POSIX
+    /* POSIX implementation of write and append
+     */
+    int writePosix(bool append);
+#endif
 
     int exists();
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -29,6 +29,7 @@
 #include "template.h"
 #include "attrib.h"
 #include "import.h"
+#include "module.h"
 
 extern int os_critsecsize32();
 extern int os_critsecsize64();
@@ -439,7 +440,11 @@ Statements *CompileStatement::flatten(Scope *sc)
     }
     se = se->toUTF8(sc);
     Parser p(sc->module, (unsigned char *)se->string, se->len, 0);
-    p.loc = loc;
+    if (global.params.doMxnGeneration)
+        p.loc = sc->module->importedFrom->writeMixin((unsigned char *)se->string, se->len, loc);
+    else
+        p.loc = loc;
+    const size_t linstart = p.loc.linnum;
     p.nextToken();
 
     Statements *a = new Statements();
@@ -449,6 +454,8 @@ Statements *CompileStatement::flatten(Scope *sc)
         if (s)                  // if no parsing errors
             a->push(s);
     }
+    if (global.params.doMxnGeneration)
+        sc->module->importedFrom->mxnloc.linnum += p.loc.linnum - linstart;
     return a;
 }
 

--- a/test/compilable/extra-files/mixin-postscript.sh
+++ b/test/compilable/extra-files/mixin-postscript.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+diff --strip-trailing-cr compilable/extra-files/mixin.mixin ${RESULTS_DIR}/compilable/mixin.mixin
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
+rm ${RESULTS_DIR}/compilable/mixin.mixin
+

--- a/test/compilable/extra-files/mixin.mixin
+++ b/test/compilable/extra-files/mixin.mixin
@@ -1,0 +1,37 @@
+// mixin at compilable/mixin.d(64)
+
+int bar2()
+{
+    mixin Foo2;
+    return result();
+}
+
+// mixin at compilable/mixin.d(9)
+5 + 3
+// mixin at compilable/mixin.d(10)
+int a1 = 5;
+int b1 = 10;
+auto res1 = a1 * b1;
+
+// mixin at compilable/mixin.d(16)
+
+          int a2 = 5;
+          int b2 = 10;
+          auto res2 = a2 * b2;
+
+// mixin at compilable/mixin.d(41)
+5 + 3
+// mixin at compilable/mixin.d(42)
+int s1a = 5;
+int s1b = 10;
+auto s1res = s1a * s1b;
+
+// mixin at compilable/mixin.d(61)
+
+    int result()
+    {
+        auto tmp = a + mixin(bar2nested2());
+        return tmp;
+    };
+// mixin at test_results/compilable/mixin.mixin(33)
+getb

--- a/test/compilable/mixin.d
+++ b/test/compilable/mixin.d
@@ -1,0 +1,96 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -M -Mdtest_results/compilable
+// POST_SCRIPT: compilable/extra-files/mixin-postscript.sh
+
+module foo.bar;
+
+void foo()
+{
+    auto a = mixin("5 + 3");
+    mixin(
+        "int a1 = 5;\n"
+        "int b1 = 10;\n"
+        "auto res1 = a1 * b1;\n"
+    );
+
+    mixin("
+          int a2 = 5;
+          int b2 = 10;
+          auto res2 = a2 * b2;
+");
+}
+
+string exp1()
+{
+    return "5 + 3";
+}
+
+string stmt1()
+{
+    string s = "int s1a = 5;\n";
+    s ~= "int s1b = 10;\n";
+    s ~= "auto s1res = s1a * s1b;\n";
+    return s;
+}
+
+enum e1 = exp1();
+enum s1 = stmt1();
+
+void bar()
+{
+    auto e1res = mixin(e1);
+    mixin(s1);
+}
+
+// Only generate output for string mixins
+mixin template Foo()
+{
+    int x = 5;
+}
+
+mixin Foo;
+
+struct Bar {
+    mixin Foo;
+}
+
+mixin template Foo2()
+{
+    int a = 5;
+    int b = 3;
+    mixin(bar2nested());
+}
+
+mixin("
+int bar2()
+{
+    mixin Foo2;
+    return result();
+}
+");
+
+string bar2nested()
+{
+    return "
+    int result()
+    {
+        auto tmp = a + mixin(bar2nested2());
+        return tmp;
+    };";
+}
+
+string bar2nested2()
+{
+    return "getb";
+}
+
+@property int getb()
+{
+    return 6;
+}
+
+void main()
+{
+    bar();
+    bar2();
+}


### PR DESCRIPTION
This pull adds a new command line option -M (-Mf, -Md).
When set string mixins are written to a separate file, which by default
carry a .mixin extension.
The logic for the files paths matches that of header generation.

The main benefits of adding this option are the simpler visibility of the
code vs. using pragma(msg) and fixing debug line information
which made it previously almost impossible to debug mixins.

I had to fix File::appendv and add File::append for POSIX.
