### PR TITLE
Issue 6763 - Using TypeTuple with (const/in/ref etc.) changes it forever

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5199,7 +5199,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
             if (t->ty == Ttuple)
             {
                 // Propagate storage class from tuple parameters to their element-parameters.
-                TypeTuple *tt = (TypeTuple *)t;
+                TypeTuple *tt = (TypeTuple *)(t->syntaxCopy());
                 if (tt->arguments)
                 {
                     size_t tdim = tt->arguments->dim;
@@ -5209,6 +5209,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                     }
                     fparam->storageClass = 0;
                 }
+                fparam->type = tt;
 
                 /* Reset number of parameters, and back up one to do this fparam again,
                  * now that it is the first element of a tuple

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5234,6 +5234,9 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 else
                     error(loc, "auto can only be used for template function parameters");
             }
+
+            // Remove redundant storage classes for type, they are already applied
+            fparam->storageClass &= ~(STC_TYPECTOR | STCin);
         }
         argsc->pop();
     }
@@ -8434,11 +8437,12 @@ void Parameter::argsToCBuffer(OutBuffer *buf, HdrGenState *hgs, Parameters *argu
     {
         OutBuffer argbuf;
 
-        for (size_t i = 0; i < arguments->dim; i++)
+        size_t dim = Parameter::dim(arguments);
+        for (size_t i = 0; i < dim; i++)
         {
             if (i)
                 buf->writestring(", ");
-            Parameter *arg = arguments->tdata()[i];
+            Parameter *arg = Parameter::getNth(arguments, i);
 
             if (arg->storageClass & STCauto)
                 buf->writestring("auto ");

--- a/src/template.c
+++ b/src/template.c
@@ -2278,6 +2278,7 @@ MATCH TypeFunction::deduceType(Scope *sc, Type *tparam, TemplateParameters *para
         {
             Parameter *fparam = Parameter::getNth(tp->parameters, i);
             fparam->type = fparam->type->addStorageClass(fparam->storageClass);
+            fparam->storageClass &= ~(STC_TYPECTOR | STCin);
         }
         //printf("\t-> this   = %d, ", ty); print();
         //printf("\t-> tparam = %d, ", tparam->ty); tparam->print();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3776,6 +3776,13 @@ void test6763()
     r6763(n);   static assert(!__traits(compiles, r6763(0)));
     i6763(0);
     o6763(n);   static assert(!__traits(compiles, o6763(0)));
+
+    // 6755
+    static assert(typeof(f6763).stringof == "void(int _param_0)");
+    static assert(typeof(c6763).stringof == "void(const(int) _param_0)");
+    static assert(typeof(r6763).stringof == "void(ref int _param_0)");
+    static assert(typeof(i6763).stringof == "void(const(int) _param_0)");
+    static assert(typeof(o6763).stringof == "void(out int _param_0)");
 }
 
 /***************************************************/

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3740,7 +3740,7 @@ void test6084()
 }
 
 /***************************************************/
-
+// 3133
 
 void test3133()
 {
@@ -3749,6 +3749,33 @@ void test3133()
 
     short[1] z = [1];
     static assert(!__traits(compiles, y = cast(int[1])z));
+}
+
+/***************************************************/
+// 6763
+
+template TypeTuple6763(TList...)
+{
+    alias TList TypeTuple6763;
+}
+
+alias TypeTuple6763!(int) T6763;
+
+void f6763(      T6763) { } ///
+void c6763(const T6763) { } ///T now is (const int)
+void r6763(ref   T6763) { } ///T now is(ref const int)
+void i6763(in    T6763) { } ///Uncomment to get an Assertion failure in 'mtype.c'
+void o6763(out   T6763) { } ///ditto
+
+void test6763()
+{
+    int n;
+
+    f6763(0);   //With D2: Error: function main.f ((ref const const(int) _param_0)) is not callable using argument types (int)
+    c6763(0);
+    r6763(n);   static assert(!__traits(compiles, r6763(0)));
+    i6763(0);
+    o6763(n);   static assert(!__traits(compiles, o6763(0)));
 }
 
 /***************************************************/
@@ -4298,6 +4325,7 @@ int main()
     test124();
     test125();
     test3133();
+    test6763();
 
     test127();
     test128();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6763

Additional fix:
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6755">Issue 6755</a> - Better wrong function pointer error message
