### PR TITLE
Issue 6056 & 7093 - Should not merge type that is not yet confirmed

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -349,7 +349,7 @@ Type *Type::constOf()
     Type *t = makeConst();
     t = t->merge();
     t->fixTo(this);
-    //printf("-Type::constOf() %p %s\n", t, toChars());
+    //printf("-Type::constOf() %p %s\n", t, t->toChars());
     return t;
 }
 
@@ -1528,11 +1528,16 @@ void Type::modToBuffer(OutBuffer *buf)
  */
 
 Type *Type::merge()
-{   Type *t;
-
+{
     if (ty == Terror) return this;
+    if (ty == Ttypeof) return this;
+    if (ty == Tident) return this;
+    if (ty == Tinstance) return this;
+    if (nextOf() && !nextOf()->merge()->deco)
+        return this;
+
     //printf("merge(%s)\n", toChars());
-    t = this;
+    Type *t = this;
     assert(t);
     if (!deco)
     {

--- a/test/compilable/test6056a.d
+++ b/test/compilable/test6056a.d
@@ -1,0 +1,3 @@
+alias const(typeof('c')*) A;
+alias const(typeof(0)*) B;
+static assert(is(B == const(int*)));

--- a/test/compilable/test6056b.d
+++ b/test/compilable/test6056b.d
@@ -1,0 +1,5 @@
+template X(T) { alias T X; }
+
+alias const(X!char*) A;
+alias const(X!int*) B;
+static assert(is(B == const(int*)));

--- a/test/compilable/test6056c.d
+++ b/test/compilable/test6056c.d
@@ -1,0 +1,3 @@
+alias int T;
+static assert( is( T** : const(T**) ));
+static assert( is( T*  : const(T* ) ));


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6056">Issue 6056</a> - Type lookup problem in string mixins
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7093">Issue 7093</a> - aliased type sometimes isn't resolved

Should not run `Type::merge()` against `Ttypeof`, `Tinstance`, `Tident`, and the types contains them as a part.
