### PR TITLE
Fix CTFE AA bug 6769, which is breaking the autotester.

### DIFF
--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2599,6 +2599,7 @@ static assert({
     assert(s.aa[7][56] == 57);
     bug6751c(s.aa);
     assert(s.aa.keys.length==1);
+    assert(s.aa.values.length==1);
     return true;
 }());
 
@@ -2623,3 +2624,13 @@ static assert({
     int[int] w;
     return w.length;
 }()==0);
+
+/**************************************************
+    6769   AA.keys, AA.values with -inline
+**************************************************/
+
+static assert({
+    double[char[3]] w = ["abc" : 2.3];
+    double[] z = w.values;
+    return w.keys.length;
+}() == 1);


### PR DESCRIPTION
This whole thing is pretty much a workaround for the hacks used in the druntime implementation of template AAs. The hacks get exposed when you compile with -inline.

6769 [CTFE] AA.keys doesn't compile when -inline is used
