### PR TITLE
Additional fixes for inout (Issue 3748, 6770, and 6773)

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1109,7 +1109,8 @@ Lnomatch:
         error("only parameters or foreach declarations can be ref");
     }
 
-    if (type->hasWild())
+    if (type->hasWild() &&
+        !(type->ty == Tpointer && type->nextOf()->ty == Tfunction || type->ty == Tdelegate))
     {
         if (storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCfield) ||
             isDataseg()

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1109,11 +1109,11 @@ Lnomatch:
         error("only parameters or foreach declarations can be ref");
     }
 
-    if ((storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest) ||
+    if ((storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCfield) ||
         isDataseg()) &&
         type->hasWild())
     {
-        error("only fields, parameters or stack based variables can be inout");
+        error("only parameters or stack based variables can be inout");
     }
 
     if (!(storage_class & (STCctfe | STCref)) && tb->ty == Tstruct &&

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1109,11 +1109,18 @@ Lnomatch:
         error("only parameters or foreach declarations can be ref");
     }
 
-    if ((storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCfield) ||
-        isDataseg()) &&
-        type->hasWild())
+    if (type->hasWild())
     {
-        error("only parameters or stack based variables can be inout");
+        if (storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCfield) ||
+            isDataseg()
+            )
+        {
+            error("only parameters or stack based variables can be inout");
+        }
+        if (sc->func && !sc->func->type->hasWild())
+        {
+            error("only inside inout function variables can be inout");
+        }
     }
 
     if (!(storage_class & (STCctfe | STCref)) && tb->ty == Tstruct &&

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -107,6 +107,8 @@ void Declaration::checkModify(Loc loc, Scope *sc, Type *t)
                 p = "const";
             else if (isImmutable())
                 p = "immutable";
+            else if (isWild())
+                p = "inout";
             else if (storage_class & STCmanifest)
                 p = "enum";
             else if (!t->isAssignable())

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -142,6 +142,7 @@ struct Declaration : Dsymbol
     int isAbstract()     { return storage_class & STCabstract; }
     int isConst()        { return storage_class & STCconst; }
     int isImmutable()    { return storage_class & STCimmutable; }
+    int isWild()         { return storage_class & STCwild; }
     int isAuto()         { return storage_class & STCauto; }
     int isScope()        { return storage_class & STCscope; }
     int isSynchronized() { return storage_class & STCsynchronized; }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5043,7 +5043,8 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
             error(loc, "functions cannot return scope %s", tf->next->toChars());
         if (tf->next->toBasetype()->ty == Tvoid)
             tf->isref = FALSE;                  // rewrite "ref void" as just "void"
-        if (tf->next->hasWild())
+        if (tf->next->hasWild() &&
+            !(tf->next->ty == Tpointer && tf->next->nextOf()->ty == Tfunction || tf->next->ty == Tdelegate))
             wildreturn = TRUE;
     }
 
@@ -5085,7 +5086,8 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
             if (!(fparam->storageClass & STClazy) && t->ty == Tvoid)
                 error(loc, "cannot have parameter of type %s", fparam->type->toChars());
 
-            if (t->hasWild())
+            if (t->hasWild() &&
+                !(t->ty == Tpointer && t->nextOf()->ty == Tfunction || t->ty == Tdelegate))
             {
                 wildparams = TRUE;
                 if (tf->next && !wildreturn)

--- a/test/fail_compilation/failinout1.d
+++ b/test/fail_compilation/failinout1.d
@@ -1,0 +1,5 @@
+inout(int) foo(inout(int) x)
+{
+    x = 5;  // cannot modify inout
+    return 0;
+}

--- a/test/fail_compilation/failinout2.d
+++ b/test/fail_compilation/failinout2.d
@@ -1,0 +1,1 @@
+inout int x;

--- a/test/fail_compilation/failinout3748a.d
+++ b/test/fail_compilation/failinout3748a.d
@@ -1,0 +1,4 @@
+struct S3748
+{
+    inout(int) err8;
+}

--- a/test/fail_compilation/failinout3748b.d
+++ b/test/fail_compilation/failinout3748b.d
@@ -1,0 +1,4 @@
+void main()
+{
+    inout(int)* err11;
+}

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1878,6 +1878,23 @@ void test1961c()
 
 /************************************/
 
+inout(int) function(inout(int)) notinoutfun1() { return null; }
+inout(int) delegate(inout(int)) notinoutfun2() { return null; }
+void notinoutfun1(inout(int) function(inout(int)) fn) {}
+void notinoutfun2(inout(int) delegate(inout(int)) dg) {}
+
+void test88()
+{
+    inout(int) function(inout(int)) fp;
+    inout(int) delegate(inout(int)) dg;
+
+    static assert(!__traits(compiles, {
+        inout(int)* p;
+    }));
+}
+
+/************************************/
+
 int main()
 {
     test1();
@@ -1968,6 +1985,7 @@ int main()
     test1961a();
     test1961b();
     test1961c();
+    test88();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1268,7 +1268,7 @@ void test79()
 
 /************************************/
 
-void test80()
+inout(int) test80(inout(int) _ = 0)
 {
     char x;
     inout(char) y = x;
@@ -1321,11 +1321,13 @@ void test80()
     static assert(!__traits(compiles, sw = sc));
     static assert(!__traits(compiles, sw = w));
     sw = sw;
+
+    return 0;
 }
 
 /************************************/
 
-void test81()
+inout(int) test81(inout(int) _ = 0)
 {
     const(char)* c;
     immutable(char)* i;
@@ -1362,12 +1364,14 @@ void test81()
     static assert(!__traits(compiles, w = s));
     static assert(!__traits(compiles, w = sc));
     w = w;
+
+    return 0;
 }
 
 /************************************/
 
 
-void test82()
+inout(int) test82(inout(int) _ = 0)
 {
     const(immutable(char)*) c;
     pragma(msg, typeof(c));
@@ -1461,16 +1465,20 @@ void test82()
     static assert(typeof(s).stringof == "inout(shared(inout(char**))***)");
     pragma(msg, typeof(***s));
     static assert(typeof(***s).stringof == "shared(inout(char**))");
+
+    return 0;
 }
 
 /************************************/
 
-void test83()
+inout(int) test83(inout(int) _ = 0)
 {
     static assert(!__traits(compiles, typeid(int* function(inout int))));
     static assert(!__traits(compiles, typeid(inout(int*) function(int))));
     static assert(!__traits(compiles, typeid(inout(int*) function())));
     inout(int*) function(inout(int)) fp;
+
+    return 0;
 }
 
 /************************************/
@@ -1654,7 +1662,7 @@ void test3748()
         int *err10 = s3.getX;
     }));
     version(error11)
-        inout(int)* err11;
+        inout(int)* err11;  // see fail_compilation/failinout3748b.d
 
     auto v4 = getLowestXptr(s.c, s3.c);
     static assert(is(typeof(v4) == const(int)*));

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1613,7 +1613,7 @@ struct S3748
     }
 
     version(error8)
-        inout(int) err8;
+        inout(int) err8;    // see fail_compilation/failinout3748a.d
 }
 
 inout(int)* getLowestXptr(inout(C3748) c1, inout(C3748) c2)


### PR DESCRIPTION
- Remain of <a href="http://d.puremagic.com/issues/show_bug.cgi?id=3748">Issue 3748</a>, and <a href="http://d.puremagic.com/issues/show_bug.cgi?id=6770">Issue 6770</a>
  
  The definition of `inout` variable is only allowed in inout function, others are rejected (field, global, inside non-inout functions).
- <a href="http://d.puremagic.com/issues/show_bug.cgi?id=6773">Issue 6773</a> - inout variable should not be modifiable
  
  Fixing a bug of `Declaration::checkModify()`.
