### PR TITLE
Fix TypeNext::hasWild()

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2220,7 +2220,7 @@ Type *TypeNext::reliesOnTident()
 
 int TypeNext::hasWild()
 {
-    return mod == MODwild || (next && next->hasWild());
+    return mod & MODwild || (next && next->hasWild());
 }
 
 


### PR DESCRIPTION
Merging #433 causes an auto-tester breaking.
