### PR TITLE
Trivial error message correction for inout variables

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1120,7 +1120,7 @@ Lnomatch:
         }
         if (sc->func && !sc->func->type->hasWild())
         {
-            error("only inside inout function variables can be inout");
+            error("inout variables can only be declared inside inout functions");
         }
     }
 


### PR DESCRIPTION
Latest inout commit has an awkward error message when an inout variable is declared inside a non-inout function:

void main()
{
   inout int x;
}
