### PR TITLE
Issue 6782 - inout-correct range is not iterable using foreach with type deduction inside non-inout function

### DIFF
--- a/src/opover.c
+++ b/src/opover.c
@@ -1274,7 +1274,10 @@ void inferApplyArgTypes(enum TOK op, Parameters *arguments, Expression *aggr)
                             break;
                         goto Lapply;
                     }
+                    // Resolve inout qualifier of front type
                     arg->type = fd->type->nextOf();
+                    if (arg->type)
+                        arg->type = arg->type->substWildTo(tab->mod);
                 }
                 break;
             }

--- a/src/statement.c
+++ b/src/statement.c
@@ -1838,6 +1838,9 @@ Lagain:
                 if (!ve->type || ve->type->ty == Terror)
                     goto Lrangeerr;
 
+                // Resolve inout qualifier of front type
+                ve->type = ve->type->substWildTo(tab->mod);
+
                 Expressions *exps = new Expressions();
                 exps->push(ve);
                 int pos = 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1894,6 +1894,44 @@ void test88()
 }
 
 /************************************/
+// 6782
+
+struct Tuple6782(T...)
+{
+    T field;
+    alias field this;
+}
+auto tuple6782(T...)(T field)
+{
+    return Tuple6782!T(field);
+}
+
+struct Range6782a
+{
+    int *ptr;
+    @property inout(int)* front() inout { return ptr; }
+    @property bool empty() const { return ptr is null; }
+    void popFront() { ptr = null; }
+}
+struct Range6782b
+{
+    Tuple6782!(int, int*) e;
+    @property front() inout { return e; }
+    @property empty() const { return e[1] is null; }
+    void popFront() { e[1] = null; }
+}
+
+void test6782()
+{
+    int x = 5;
+    auto r1 = Range6782a(&x);
+    foreach(p; r1) {}
+
+    auto r2 = Range6782b(tuple6782(1, &x));
+    foreach(i, p; r2) {}
+}
+
+/************************************/
 
 int main()
 {
@@ -1986,6 +2024,7 @@ int main()
     test1961b();
     test1961c();
     test88();
+    test6782();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6782

Resolve inout qualifier of range.front type before using it.
