### PR TITLE
5703 support bsr, bsf, bswap in CTFE

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -43,6 +43,12 @@ enum BUILTIN FuncDeclaration::isBuiltin()
 {
     static const char FeZe [] = "FNaNbNfeZe";      // @safe pure nothrow real function(real)
     static const char FeZe2[] = "FNaNbNeeZe";      // @trusted pure nothrow real function(real)
+    static const char FuintZint[] = "FNaNbkZi";    // pure nothrow int function(uint)
+    static const char FuintZuint[] = "FNaNbkZk";   // pure nothrow uint function(uint)
+    static const char FulongZulong[] = "FNaNbkZk"; // pure nothrow int function(ulong)
+    static const char FulongZint[] = "FNaNbmZi";   // pure nothrow int function(uint)
+    static const char FrealrealZreal [] = "FNaNbNfeeZe";  // @safe pure nothrow real function(real, real)
+    static const char FrealZlong [] = "FNaNbNfeZl";  // @safe pure nothrow long function(real)
 
     //printf("FuncDeclaration::isBuiltin() %s, %d\n", toChars(), builtin);
     if (builtin == BUILTINunknown)
@@ -68,6 +74,10 @@ enum BUILTIN FuncDeclaration::isBuiltin()
                         builtin = BUILTINsqrt;
                     else if (ident == Id::fabs)
                         builtin = BUILTINfabs;
+                    else if (ident == Id::expm1)
+                        builtin = BUILTINexpm1;
+                    else if (ident == Id::exp2)
+                        builtin = BUILTINexp2;
                     //printf("builtin = %d\n", builtin);
                 }
                 // if float or double versions
@@ -77,19 +87,83 @@ enum BUILTIN FuncDeclaration::isBuiltin()
                     if (ident == Id::_sqrt)
                         builtin = BUILTINsqrt;
                 }
+                else if (strcmp(type->deco, FrealrealZreal) == 0)
+                {
+                    if (ident == Id::atan2)
+                        builtin = BUILTINatan2;
+                    else if (ident == Id::yl2x)
+                        builtin = BUILTINyl2x;
+                    else if (ident == Id::yl2xp1)
+                        builtin = BUILTINyl2xp1;
+                }
+                else if (strcmp(type->deco, FrealZlong) == 0 && ident == Id::rndtol)
+                    builtin = BUILTINrndtol;
+            }
+            if (parent->ident == Id::bitop &&
+                parent->parent && parent->parent->ident == Id::core &&
+                !parent->parent->parent)
+            {
+                //printf("deco = %s\n", type->deco);
+                if (strcmp(type->deco, FuintZint) == 0 || strcmp(type->deco, FulongZint) == 0)
+                {
+                    if (ident == Id::bsf)
+                        builtin = BUILTINbsf;
+                    else if (ident == Id::bsr)
+                        builtin = BUILTINbsr;
+                }
+                else if (strcmp(type->deco, FuintZuint) == 0)
+                {
+                    if (ident == Id::bswap)
+                        builtin = BUILTINbswap;
+                }
             }
         }
     }
     return builtin;
 }
 
+int eval_bsf(uinteger_t n)
+{
+    n = (n ^ (n - 1)) >> 1;  // convert trailing 0s to 1, and zero rest
+    int k = 0;
+    while( n )
+    {   ++k;
+        n >>=1;
+    }
+    return k;
+}
+
+int eval_bsr(uinteger_t n)
+{   int k= 0;
+    while(n>>=1)
+    {
+        ++k;
+    }
+    return k;
+}
+
+uinteger_t eval_bswap(Expression *arg0)
+{   uinteger_t n = arg0->toInteger();
+    #define BYTEMASK  0x00FF00FF00FF00FFLL
+    #define SHORTMASK 0x0000FFFF0000FFFFLL
+    #define INTMASK 0x0000FFFF0000FFFFLL
+    // swap adjacent ubytes
+    n = ((n >> 8 ) & BYTEMASK)  | ((n & BYTEMASK) << 8 );
+    // swap adjacent ushorts
+    n = ((n >> 16) & SHORTMASK) | ((n & SHORTMASK) << 16);
+    TY ty = arg0->type->toBasetype()->ty;
+    // If 64 bits, we need to swap high and low uints
+    if (ty == Tint64 || ty == Tuns64)
+        n = ((n >> 32) & INTMASK) | ((n & INTMASK) << 32);
+    return n;
+}
 
 /**************************************
  * Evaluate builtin function.
  * Return result; NULL if cannot evaluate it.
  */
 
-Expression *eval_builtin(enum BUILTIN builtin, Expressions *arguments)
+Expression *eval_builtin(Loc loc, enum BUILTIN builtin, Expressions *arguments)
 {
     assert(arguments && arguments->dim);
     Expression *arg0 = arguments->tdata()[0];
@@ -119,6 +193,39 @@ Expression *eval_builtin(enum BUILTIN builtin, Expressions *arguments)
         case BUILTINfabs:
             if (arg0->op == TOKfloat64)
                 e = new RealExp(0, fabsl(arg0->toReal()), arg0->type);
+            break;
+        // These math intrinsics are not yet implemented
+        case BUILTINatan2:
+            break;
+        case BUILTINrndtol:
+            break;
+        case BUILTINexpm1:
+            break;
+        case BUILTINexp2:
+            break;
+        case BUILTINyl2x:
+            break;
+        case BUILTINyl2xp1:
+            break;
+        case BUILTINbsf:
+            if (arg0->op == TOKint64)
+            {   if (arg0->toInteger()==0)
+                    error(loc, "bsf(0) is undefined");
+                else
+                    e = new IntegerExp(loc, eval_bsf(arg0->toInteger()), Type::tint32);
+            }
+            break;
+        case BUILTINbsr:
+            if (arg0->op == TOKint64)
+            {   if (arg0->toInteger()==0)
+                    error(loc, "bsr(0) is undefined");
+                else
+                    e = new IntegerExp(loc, eval_bsr(arg0->toInteger()), Type::tint32);
+            }
+            break;
+        case BUILTINbswap:
+            if (arg0->op == TOKint64)
+                e = new IntegerExp(loc, eval_bswap(arg0), arg0->type);
             break;
     }
     return e;

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -603,7 +603,7 @@ Expression *Pow(Type *type, Expression *e1, Expression *e2)
     }
     else if (e2->type->isfloating())
     {
-        // x ^ y for x < 0 and y not an integer is not defined
+        // x ^^ y for x < 0 and y not an integer is not defined
         if (e1->toReal() < 0.0)
         {
             e = new RealExp(loc, Port::nan, type);
@@ -614,7 +614,7 @@ Expression *Pow(Type *type, Expression *e1, Expression *e2)
             Expressions args;
             args.setDim(1);
             args.tdata()[0] = e1;
-            e = eval_builtin(BUILTINsqrt, &args);
+            e = eval_builtin(loc, BUILTINsqrt, &args);
             if (!e)
                 e = EXP_CANT_INTERPRET;
         }

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -508,9 +508,18 @@ enum BUILTIN
     BUILTINtan,                 // std.math.tan
     BUILTINsqrt,                // std.math.sqrt
     BUILTINfabs,                // std.math.fabs
+    BUILTINatan2,               // std.math.atan2
+    BUILTINrndtol,              // std.math.rndtol
+    BUILTINexpm1,               // std.math.expm1
+    BUILTINexp2,                // std.math.exp2
+    BUILTINyl2x,                // std.math.yl2x
+    BUILTINyl2xp1,              // std.math.yl2xp1
+    BUILTINbsr,                 // core.bitop.bsr
+    BUILTINbsf,                 // core.bitop.bsf
+    BUILTINbswap,               // core.bitop.bswap
 };
 
-Expression *eval_builtin(enum BUILTIN builtin, Expressions *arguments);
+Expression *eval_builtin(Loc loc, enum BUILTIN builtin, Expressions *arguments);
 
 #else
 enum BUILTIN { };

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -293,7 +293,17 @@ Msgtable msgtable[] =
     { "tan" },
     { "_sqrt", "sqrt" },
     { "_pow", "pow" },
+    { "atan2" },
+    { "rndtol" },
+    { "expm1" },
+    { "exp2" },
+    { "yl2x" },
+    { "yl2xp1" },
     { "fabs" },
+    { "bitop" },
+    { "bsf" },
+    { "bsr" },
+    { "bswap" },
 
     // Traits
     { "isAbstractClass" },

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -76,7 +76,7 @@ bool needToCopyLiteral(Expression *expr);
 Expression *copyLiteral(Expression *e);
 Expression *paintTypeOntoLiteral(Type *type, Expression *lit);
 Expression *findKeyInAA(AssocArrayLiteralExp *ae, Expression *e2);
-Expression *evaluateIfBuiltin(InterState *istate,
+Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
     FuncDeclaration *fd, Expressions *arguments, Expression *pthis);
 
 
@@ -4311,7 +4311,7 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
         }
     }
     // Check for built-in functions
-    Expression *eresult = evaluateIfBuiltin(istate, fd, arguments, pthis);
+    Expression *eresult = evaluateIfBuiltin(istate, loc, fd, arguments, pthis);
     if (eresult)
         return eresult;
 
@@ -5608,7 +5608,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
 /* If this is a built-in function, return the interpreted result,
  * Otherwise, return NULL.
  */
-Expression *evaluateIfBuiltin(InterState *istate,
+Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
     FuncDeclaration *fd, Expressions *arguments, Expression *pthis)
 {
     Expression *e = NULL;
@@ -5639,7 +5639,7 @@ Expression *evaluateIfBuiltin(InterState *istate,
                     return earg;
                 args.tdata()[i] = earg;
             }
-            e = eval_builtin(b, &args);
+            e = eval_builtin(loc, b, &args);
             if (!e)
                 e = EXP_CANT_INTERPRET;
         }

--- a/test/runnable/builtin.d
+++ b/test/runnable/builtin.d
@@ -1,6 +1,7 @@
 
 import std.stdio;
 import std.math;
+import core.bitop;
 
 /*******************************************/
 
@@ -41,6 +42,25 @@ void test2()
     i = i ^^ .5;
     assert(i == 2);
 }
+
+/**** Bug 5703 *****************************/
+
+static assert({
+    int a = 0x80;
+    int f = bsf(a);
+    int r = bsr(a);
+    a = 0x22;
+    assert(bsf(a)==1);
+    assert(bsr(a)==5);
+    a = 0x8000000;
+    assert(bsf(a)==27);
+    assert(bsr(a)==27);
+    a = 0x13f562c0;
+    assert(bsf(a) == 6);
+    assert(bsr(a) == 28);
+    assert(bswap(0xAABBCCDD) == 0xDDCCBBAA);
+    return true;
+}());
 
 /*******************************************/
 


### PR DESCRIPTION
Also lays the groundwork for supporting the std.math intrinsic and asm functions in CTFE (only the bit operations are implemented in this pull request).

5703 std.intrinsic. and core.bitop.bsf, bsr and bswap should be CTFE-able
