### PR TITLE
Bug 259: Error on unsafe signed/unsigned comparisons.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -11607,7 +11607,31 @@ Expression *CmpExp::semantic(Scope *sc)
         return new ErrorExp();
     }
 
+    Expression *eb1 = e1;
+    Expression *eb2 = e2;
+
     typeCombine(sc);
+
+    // For integer comparisons, ensure the combined type can hold both arguments.
+    if (type && type->isintegral() && (op == TOKlt || op == TOKle ||
+                                       op == TOKgt || op == TOKge))
+    {
+        IntRange trange = IntRange::fromType(type);
+
+        Expression *errorexp = 0;
+        if (!trange.contains(eb1->getIntRange()))
+            errorexp = eb1;
+        if (!trange.contains(eb2->getIntRange()))
+            errorexp = eb2;
+
+        if (errorexp)
+        {
+            error("implicit conversion of '%s' to '%s' is unsafe in '(%s) %s (%s)'",
+                  errorexp->toChars(), type->toChars(), eb1->toChars(), Token::toChars(op), eb2->toChars());
+            return new ErrorExp();
+        }
+    }
+
     type = Type::tboolean;
 
     // Special handling for array comparisons


### PR DESCRIPTION
Fixes http://d.puremagic.com/issues/show_bug.cgi?id=259 in a way that uses the range propagation of expressions. It is also still backwards compatible with C code, though some C code may now produce an error. It still breaks lots of existing code though.

Examples:

``` c
uint a = 3;
if (a > 4) {} // ok

uint b = 3;
if (b > -2) {} // now an error

byte c = -67;
uint u;
if (u < c + 0x100) {} // ok

int[] a;
for (int i = 0; i < a.length; ++i) {} // error, ugh
```
