### PR TITLE
fixes for win32 and osx32 segmented architecture changes

### DIFF
--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -2270,10 +2270,12 @@ STATIC void cv4_outsym(symbol *s)
                         idx1 = idx2 = s->Sxtrnnum;
                     }
                 }
+#if TARGET_SEGMENTED
                 else if (s->ty() & (mTYfar | mTYcs))
                 {   fd = 0x04;
                     idx1 = idx2 = s->Sseg;
                 }
+#endif
                 else
                 {   fd = 0x14;
                     idx1 = DGROUPIDX;

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -1857,11 +1857,12 @@ int obj_comdat(Symbol *s)
 #endif
                                 break;
 
+#if TARGET_SEGMENTED
             case mTYcs:         obj.ledata->flags |= 0x08;      // data in code seg
                                 atyp = 0x11;    break;
 
             case mTYfar:        atyp = 0x12;    break;
-
+#endif
             case mTYthread:     obj.ledata->pubbase = obj_tlsseg()->SDseg;
                                 atyp = 0x10;    // pick any (also means it is
                                                 // not searched for in a library)
@@ -2647,11 +2648,17 @@ STATIC void obj_modend()
             switch (s->Sfl)
             {
                 case FLextern:
-                    if (!(ty & (mTYcs | mTYthread)))
+                    if (!(ty & (
+#if TARGET_SEGMENTED
+                                    mTYcs |
+#endif
+                                    mTYthread)))
                         goto L1;
                 case FLfunc:
+#if TARGET_SEGMENTED
                 case FLfardata:
                 case FLcsdata:
+#endif
                 case FLtlsdata:
                     if (config.exe & EX_flat)
                     {   fd |= FD_F1;
@@ -2676,11 +2683,17 @@ STATIC void obj_modend()
             switch (s->Sfl)
             {
                 case FLextern:
-                    if (!(ty & (mTYcs | mTYthread)))
+                    if (!(ty & (
+#if TARGET_SEGMENTED
+                                    mTYcs |
+#endif
+                                    mTYthread)))
                         goto L1;
                 case FLfunc:
+#if TARGET_SEGMENTED
                 case FLfardata:
                 case FLcsdata:
+#endif
                 case FLtlsdata:
                     if (config.exe & EX_flat)
                     {   fd |= FD_F1;
@@ -3310,11 +3323,17 @@ int reftoident(int seg,targ_size_t offset,Symbol *s,targ_size_t val,
         switch (s->Sfl)
         {
             case FLextern:
-                if (!(ty & (mTYcs | mTYthread)))
+                if (!(ty & (
+#if TARGET_SEGMENTED
+                                mTYcs |
+#endif
+                                mTYthread)))
                     goto L1;
             case FLfunc:
+#if TARGET_SEGMENTED
             case FLfardata:
             case FLcsdata:
+#endif
             case FLtlsdata:
                 if (config.exe & EX_flat)
                 {   lc |= FD_F1;
@@ -3339,11 +3358,17 @@ int reftoident(int seg,targ_size_t offset,Symbol *s,targ_size_t val,
         switch (s->Sfl)
         {
             case FLextern:
-                if (!(ty & (mTYcs | mTYthread)))
+                if (!(ty & (
+#if TARGET_SEGMENTED
+                                mTYcs |
+#endif
+                                mTYthread)))
                     goto L1;
             case FLfunc:
+#if TARGET_SEGMENTED
             case FLfardata:
             case FLcsdata:
+#endif
             case FLtlsdata:
                 if (config.exe & EX_flat)
                 {   lc |= FD_F1;

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -1836,7 +1836,11 @@ int obj_comdef(Symbol *s,targ_size_t size,targ_size_t count)
     symbol_debug(s);
 
     // can't have code or thread local comdef's
-    assert(!(s->ty() & (mTYcs | mTYthread)));
+    assert(!(s->ty() & (
+#if TARGET_SEGMENTED
+                    mTYcs |
+#endif
+                    mTYthread)));
 
     struct Comdef comdef;
     comdef.sym = s;

--- a/src/backend/newman.c
+++ b/src/backend/newman.c
@@ -1122,19 +1122,21 @@ STATIC void cpp_ecsu_data_indirect_type(type *t)
             case TYhptr:
                 i += 8;
                 break;
-#endif
             case TYref:
             case TYarray:
                 if (LARGEDATA && !(ty & mTYLINK))
                     ty |= mTYfar;
                 break;
+#endif
         }
     }
     else
         ty = t->Tty & (mTYLINK | mTYconst | mTYvolatile);
     i |= cpp_cvidx(ty);
+#if TARGET_SEGMENTED
     if (ty & (mTYcs | mTYfar))
         i += 4;
+#endif
     CHAR('A' + i);
 }
 
@@ -1322,8 +1324,10 @@ STATIC void cpp_storage_convention(symbol *s)
     type *t = s->Stype;
 
     ty = t->Tty;
+#if TARGET_SEGMENTED
     if (LARGEDATA && !(ty & mTYLINK))
         t->Tty |= mTYfar;
+#endif
     cpp_data_indirect_type(t);
     t->Tty = ty;
 }
@@ -1383,9 +1387,11 @@ STATIC void cpp_function_type(type *t)
     //cpp_return_type(s);
     tn = t->Tnext;
     ty = tn->Tty;
+#if TARGET_SEGMENTED
     if (LARGEDATA && (tybasic(ty) == TYstruct || tybasic(ty) == TYenum) &&
         !(ty & mTYLINK))
         tn->Tty |= mTYfar;
+#endif
     cpp_data_type(tn);
     tn->Tty = ty;
     cpp_argument_types(t);

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -536,11 +536,17 @@ void outcommon(symbol *s,targ_size_t n)
             obj_comdef(s, 0, n, 1);
 #else
             s->Sclass = SCcomdef;
+#if TARGET_SEGMENTED
             s->Sxtrnnum = obj_comdef(s,(s->ty() & mTYfar) == 0,n,1);
+#else
+            s->Sxtrnnum = obj_comdef(s,true,n,1);
+#endif
             s->Sseg = UNKNOWN;
+#if TARGET_SEGMENTED
             if (s->ty() & mTYfar)
                 s->Sfl = FLfardata;
             else
+#endif
                 s->Sfl = FLextern;
             pstate.STflags |= PFLcomdef;
 #if SCPP


### PR DESCRIPTION
Really not sure how the win32 problems weren't caught in my previous builds.  The only thing I can see is that the commits on my system were in a different order than what showed up in the pull request.

The machobj.c changes were because I didn't test the osx build before submitting.  Oops.

The full druntime, phobos, and dmd test suites pass for both platforms.
