### PR TITLE
Issue 3467 & 2550 - Stored template value arguments should be optimized as their parameter type.

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3571,6 +3571,11 @@ MATCH TemplateValueParameter::matchArg(Scope *sc,
         //printf("m: %d\n", m);
         if (!m)
             goto Lnomatch;
+        else if (m != MATCHexact)
+        {
+            ei = ei->implicitCastTo(sc, vt);
+            ei = ei->optimize(WANTvalue);
+        }
     }
     dedtypes->tdata()[i] = ei;
 

--- a/test/runnable/template4.d
+++ b/test/runnable/template4.d
@@ -738,7 +738,7 @@ alias TFoo27!(2+1) b;
 alias TFoo27!(3u) c;
 
 static assert(is(TFoo27!(3) == TFoo27!(2 + 1)));
-static assert(!is(TFoo27!(3) == TFoo27!(3u)));
+static assert(is(TFoo27!(3) == TFoo27!(3u)));
 
 void test27()
 {

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -489,6 +489,33 @@ void test6994()
 }
 
 /**********************************/
+// 3467 & 6806
+
+struct Foo3467( uint n )
+{
+    Foo3467!( n ) bar( ) {
+        typeof( return ) result;
+        return result;
+    }
+}
+struct Vec3467(size_t N)
+{
+    void opBinary(string op:"~", size_t M)(Vec3467!M) {}
+}
+void test3467()
+{
+    Foo3467!( 4 ) baz;
+    baz = baz.bar;// FAIL
+
+    Vec3467!2 a1;
+    Vec3467!3 a2;
+    a1 ~ a2; // line 7, Error
+}
+
+struct TS6806(size_t n) { pragma(msg, typeof(n)); }
+static assert(is(TS6806!(1u) == TS6806!(1)));
+
+/**********************************/
 
 int main()
 {
@@ -513,6 +540,7 @@ int main()
     test2778aa();
     test2778get();
     test6994();
+    test3467();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -516,6 +516,23 @@ struct TS6806(size_t n) { pragma(msg, typeof(n)); }
 static assert(is(TS6806!(1u) == TS6806!(1)));
 
 /**********************************/
+// 2550
+
+template pow10_2550(long n)
+{
+    const long pow10_2550 = 0;
+    static if (n < 0)
+        const long pow10_2550 = 0;
+    else
+        const long pow10_2550 = 10 * pow10_2550!(n - 1);
+}
+template pow10_2550(long n:0)
+{
+    const long pow10_2550 = 1;
+}
+static assert(pow10_2550!(0) == 1);
+
+/**********************************/
 
 int main()
 {


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=3467">Issue 3467</a> - Non-int integral template parameters not correctly propagated
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=2550">Issue 2550</a> - implicit conversions don't apply to template value parameter specialization
