### PR TITLE
Properly fix bug 6661

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -5035,21 +5035,26 @@ void TemplateInstance::semantic3(Scope *sc)
         sc = sc->push(this);
         sc->tinst = this;
         int oldgag = global.gag;
+        int olderrors = global.errors;
         /* If this is a speculative instantiation, gag errors.
          * Future optimisation: If the results are actually needed, errors
          * would already be gagged, so we don't really need to run semantic
          * on the members.
          */
-        if (speculative && !global.gag)
-            global.gag = 1;
+        if (speculative && !oldgag)
+            olderrors = global.startGagging();
         for (size_t i = 0; i < members->dim; i++)
         {
             Dsymbol *s = members->tdata()[i];
             s->semantic3(sc);
-            if (global.gag && errors)
+            if (speculative && global.errors != olderrors)
                 break;
         }
-        global.gag = oldgag;
+        if (speculative && !oldgag)
+        {   // If errors occurred, this instantiation failed
+            errors += global.errors - olderrors;
+            global.endGagging(olderrors);
+        }
         sc = sc->pop();
         sc->pop();
     }

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -64,7 +64,7 @@ template bug6661(Q)
     const Q blaz = 6;
 }
 
-//static assert(is(typeof(bug6661!(int).blaz)));
+static assert(is(typeof(bug6661!(int).blaz)));
 
 /**************************************************
     6599    ICE(constfold.c) or segfault


### PR DESCRIPTION
6661 Templates instantiated only through is(typeof()) shouldn't cause errors

My earlier fix wasn't correct, it didn't restore the state of global.errors properly. This effectively created a regression, because it went from rejects-valid with error message, to rejects-valid without error message.
