### PR TITLE
Issue 6207 - Mixin template evaluated to string can convert to string mixin expression implicitly 

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4281,7 +4281,20 @@ Lagain:
                     e = new DotVarExp(loc, e, s->isDeclaration());
                 }
                 else
+                {
+                    VarDeclaration *v = s->isVarDeclaration();
+                    if (v && v->storage_class & STCmanifest)
+                    {   ExpInitializer *ei = v->init->isExpInitializer();
+                        if (ei && ei->exp->op == TOKstring)
+                        {   if (ti->tempdecl->ismixin)
+                            {   e = new CompileExp(loc, ei->exp);
+                                e = e->semantic(sc);
+                                return e;
+                            }
+                        }
+                    }
                     e = new DsymbolExp(loc, s, s->hasOverloads());
+                }
                 e = e->semantic(sc);
                 //printf("-1ScopeExp::semantic()\n");
                 return e;

--- a/src/template.c
+++ b/src/template.c
@@ -4595,10 +4595,6 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         }
     }
 
-    // If tempdecl is a mixin, disallow it
-    if (tempdecl->ismixin)
-        error("mixin templates are not regular templates");
-
     hasNestedArgs(tiargs);
 
     /* See if there is an existing TemplateInstantiation that already
@@ -4912,6 +4908,20 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     if (sc->func || dosemantic3)
     {
         trySemantic3(sc2);
+    }
+
+    // If tempdecl is a mixin, disallow it
+    if (tempdecl->ismixin)
+    {
+        if (aliasdecl)
+        {   VarDeclaration *v = aliasdecl->toAlias()->isVarDeclaration();
+            if (v && v->storage_class & STCmanifest)
+            {   ExpInitializer *ei = v->init->isExpInitializer();
+                if (ei && ei->exp->op == TOKstring)
+                    goto Laftersemantic;
+            }
+        }
+        error("mixin templates are not regular templates");
     }
 
   Laftersemantic:

--- a/test/runnable/mixin2.d
+++ b/test/runnable/mixin2.d
@@ -18,10 +18,10 @@ void test2()
 {
     int j;
     mixin("
-	int x = 3;
-	for (int i = 0; i < 10; i++)
-	    writeln(x + i, ++j);
-	");
+        int x = 3;
+        for (int i = 0; i < 10; i++)
+            writeln(x + i, ++j);
+    ");
     assert(j == 10);
 }
 
@@ -49,27 +49,27 @@ int x5;
 
 scope class Foo5
 {
-	this ()
-	{
-		writeln ("Constructor");
-		assert(x5 == 0);
-		x5++;
-	}
-	~this ()
-	{
-		writeln ("Destructor");
-		assert(x5 == 2);
-		x5++;
-	}
+    this ()
+    {
+        writeln ("Constructor");
+        assert(x5 == 0);
+        x5++;
+    }
+    ~this ()
+    {
+        writeln ("Destructor");
+        assert(x5 == 2);
+        x5++;
+    }
 }
 
 void test5()
 {
     {
-	mixin ("scope Foo5 f = new Foo5;\n");
-	writeln ("  Inside Scope");
-	assert(x5 == 1);
-	x5++;
+        mixin ("scope Foo5 f = new Foo5;\n");
+        writeln ("  Inside Scope");
+        assert(x5 == 1);
+        x5++;
     }
     assert(x5 == 3);
 }
@@ -81,7 +81,7 @@ void test6()
     static const b = "printf(`hey\n`);";
 
     if (true)
-	mixin(b);
+        mixin(b);
 }
 
 /*********************************************/
@@ -180,6 +180,66 @@ class Derived7560 : Base7560
 }
 
 /*********************************************/
+// 6207
+
+mixin template Inj6207(string x)
+{
+    enum Inj6207 = x;
+}
+void test6207a()
+{
+    auto a = Inj6207!("10");
+    assert(a == 10);
+}
+
+// ----
+
+mixin template expand6207(string code)
+{
+    static if (code.length >= 2 && code[0..2] == "$x")
+    {
+        enum expand6207 = `x` ~ code[2..$];
+        pragma(msg, expand6207);
+    }
+    else
+        enum expand6207 = code;
+}
+
+void test6207b()
+{
+    int x = 1;
+    int y = expand6207!q{$x+2};
+        // Rhs is implicitly converted to mixin(expand6207!(q{$x+2}))
+    assert(y == 3);
+}
+
+// ----
+
+mixin template map6207(string pred)
+{
+    enum map6207 = `map6207!((a){ return `~pred~`; })`;
+}
+template map6207(alias pred)
+{
+    auto map6207(E)(E[] r)
+    {
+        E[] result;
+        foreach (e; r)
+            result ~= pred(e);
+        return result;
+    }
+}
+
+void test6207c()
+{
+    int b = 10;
+    auto r = map6207!q{ a * b }([1,2,3]);
+    //   --> mixin(`map6207!((a){ return ` ~ q{ a * b } ~ `; })`)([1,2,3])
+    //   --> map6207!((a){ return  a * b ; })([1,2,3]);
+    assert(r == [10,20,30]);
+}
+
+/*********************************************/
 
 void main()
 {
@@ -193,6 +253,9 @@ void main()
     test8();
     test9();
     test10();
+    test6207a();
+    test6207b();
+    test6207c();
 
     writeln("Success");
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6207

If mixin template instantiation makes manifest constant string and it appears in expression context, the compiler converts it implicitly to string mixin expression.
