### PR TITLE
Issue 3836 - [TDPL] obligatory override attribute

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -484,8 +484,8 @@ void FuncDeclaration::semantic(Scope *sc)
 
                 doesoverride = TRUE;
 #if DMDV2
-                if (!isOverride())
-                    warning(loc, "overrides base class function %s, but is not marked with 'override'", fdv->toPrettyChars());
+                if (!isOverride() && !global.params.useDeprecated)
+                    ::error(loc, "overriding base class function without using override attribute is deprecated (%s overrides %s)", toPrettyChars(), fdv->toPrettyChars());
 #endif
 
                 FuncDeclaration *fdc = ((Dsymbol *)cd->vtbl.data[vi])->isFuncDeclaration();

--- a/test/compilable/deprecate2.d
+++ b/test/compilable/deprecate2.d
@@ -16,3 +16,12 @@ float distance(point2 a, point2 b)
   d[0] = b[0] - a[0]; // if I comment out this line it won't crash
   return 0.0f;
 }
+
+class A3836
+{
+    void fun() {}
+}
+class B3836 : A3836
+{
+    void fun() {}
+}

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3327,11 +3327,11 @@ class SomeClass : TheBase, SomeInterface
     int fab;
     int a = 17;
     int b = 23;
-    int foo() { return gab + a; }
-    float bar(char c) { return 2.6; }
+    override int foo() { return gab + a; }
+    override float bar(char c) { return 2.6; }
     int something() { return 0; }
-    int daz() { return 0; }
-    int baz() { return 0; }
+    override int daz() { return 0; }
+    override int baz() { return 0; }
 }
 
 class Unrelated : TheBase {

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -365,7 +365,7 @@ class P7699
 }
 class D7699 : P7699
 {
-    void f(int n) in { } body { }
+    override void f(int n) in { } body { }
 }
 
 /*******************************************/

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -696,7 +696,7 @@ class EE
 
 class FF : EE
 {
-    final int YYY() { return 4; }
+    final override int YYY() { return 4; }
 }
 
 static assert(__traits(isVirtualMethod, FF.YYY));

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3056,11 +3056,11 @@ void test3559()
 
     static class B : A
     {
-        int foo(float a) { return 2; }
+        override int foo(float a) { return 2; }
         alias A.foo foo;
 
         alias A.bar bar;
-        int bar(float a) { return 2; }
+        override int bar(float a) { return 2; }
     }
 
     {
@@ -3427,7 +3427,7 @@ void test5554()
     interface I { MB foo(); }
     class B : A
     {
-        MC foo() { return null; }
+        override MC foo() { return null; }
     }
     class C : B, I
     {
@@ -4734,11 +4734,11 @@ class Base3282
 }
 class Derived3282 : Base3282
 {
-    string f()
+    override string f()
     {
         return "Derived.f()";
     }
-    string f() const
+    override string f() const
     {
         return "Derived.f() const";
     }
@@ -4764,7 +4764,7 @@ class C7534
 class D7534 : C7534
 {
     override int foo(){ return 2; }
-    int foo() const { return 3; }
+    override int foo() const { return 3; }
     // Error: D.foo multiple overrides of same function
 }
 void test7534()
@@ -4798,8 +4798,8 @@ class V7534
 }
 class W7534 : V7534
 {
-    Y7534 foo(){ return new Y7534(1); }
-    Y7534 foo() const { return new Y7534(2); }
+    override Y7534 foo(){ return new Y7534(1); }
+    override Y7534 foo() const { return new Y7534(2); }
 }
 
 void test7534cov()


### PR DESCRIPTION
Move requiring the override attribute to the next stage, from warning to deprecated.

http://d.puremagic.com/issues/show_bug.cgi?id=3836
