### PR TITLE
Issue 6825 - Regression(2.055+): Address of templated method incorrectly taken

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -4975,7 +4975,7 @@ int TemplateInstance::needsTypeInference(Scope *sc)
         //printf("tp = %p, td->parameters->dim = %d, tiargs->dim = %d\n", tp, td->parameters->dim, tiargs->dim);
         TypeFunction *fdtype = (TypeFunction *)fd->type;
         if (Parameter::dim(fdtype->parameters) &&
-            (tp || tiargs->dim < td->parameters->dim))
+            ((tp && td->parameters->dim > 1) || tiargs->dim < td->parameters->dim))
             return TRUE;
         /* If there is more than one function template which matches, we may
          * need type inference (see Bugzilla 4430)

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -355,6 +355,22 @@ void test5393()
 }
 
 /**********************************/
+// 6825
+
+void test6825()
+{
+    struct File
+    {
+        void write(S...)(S args) {}
+    }
+
+    void dump(void delegate(string) d) {}
+
+    auto o = File();
+    dump(&o.write!string);
+}
+
+/**********************************/
 
 int main()
 {
@@ -373,6 +389,7 @@ int main()
     test2579();
     test5886();
     test5393();
+    test6825();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6825

If a template argument is explicitly given to the first variadic template parameter, `TemplateInstance::needsTypeInference` should return FALSE.
