### PR TITLE
6832 & 6928 & 6929 - Fix common type calculation with alias this

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1923,6 +1923,28 @@ Lagain:
             goto Lagain;
         }
     }
+    else if (t1->ty == Tstruct || t2->ty == Tstruct)
+    {
+        if (t1->ty == Tstruct && ((TypeStruct *)t1)->sym->aliasthis)
+        {
+            e1 = new DotIdExp(e1->loc, e1, ((TypeStruct *)t1)->sym->aliasthis->ident);
+            e1 = e1->semantic(sc);
+            e1 = resolveProperties(sc, e1);
+            t1 = e1->type;
+            t = t1;
+            goto Lagain;
+        }
+        if (t2->ty == Tstruct && ((TypeStruct *)t2)->sym->aliasthis)
+        {
+            e2 = new DotIdExp(e2->loc, e2, ((TypeStruct *)t2)->sym->aliasthis->ident);
+            e2 = e2->semantic(sc);
+            e2 = resolveProperties(sc, e2);
+            t2 = e2->type;
+            t = t2;
+            goto Lagain;
+        }
+        goto Lincompatible;
+    }
     else if ((e1->op == TOKstring || e1->op == TOKnull) && e1->implicitConvTo(t2))
     {
         goto Lt2;

--- a/src/cast.c
+++ b/src/cast.c
@@ -1879,6 +1879,15 @@ Lagain:
     }
     else if (t1->ty == Tstruct && t2->ty == Tstruct)
     {
+        if (t1->mod != t2->mod)
+        {
+            unsigned char mod = MODmerge(t1->mod, t2->mod);
+            t1 = t1->castMod(mod);
+            t2 = t2->castMod(mod);
+            t = t1;
+            goto Lagain;
+        }
+
         TypeStruct *ts1 = (TypeStruct *)t1;
         TypeStruct *ts2 = (TypeStruct *)t2;
         if (ts1->sym != ts2->sym)
@@ -1920,11 +1929,21 @@ Lagain:
             {   e2 = e2b;
                 t2 = e2b->type->toBasetype();
             }
+            t = t1;
             goto Lagain;
         }
     }
     else if (t1->ty == Tstruct || t2->ty == Tstruct)
     {
+        if (t1->mod != t2->mod)
+        {
+            unsigned char mod = MODmerge(t1->mod, t2->mod);
+            t1 = t1->castMod(mod);
+            t2 = t2->castMod(mod);
+            t = t1;
+            goto Lagain;
+        }
+
         if (t1->ty == Tstruct && ((TypeStruct *)t1)->sym->aliasthis)
         {
             e1 = new DotIdExp(e1->loc, e1, ((TypeStruct *)t1)->sym->aliasthis->ident);

--- a/src/cast.c
+++ b/src/cast.c
@@ -1914,7 +1914,8 @@ Lagain:
                 e1b = resolveProperties(sc, e1b);
                 i2 = e1b->implicitConvTo(t2);
             }
-            assert(!(i1 && i2));
+            if (i1 && i2)
+                goto Lincompatible;
 
             if (i1)
                 goto Lt1;

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -631,6 +631,24 @@ mixin template Wrapper6479()
 }
 
 /**********************************************/
+// 6832
+
+void test6832()
+{
+	static class Foo { }
+	static struct Bar { Foo foo; alias foo this; }
+    Bar bar;
+    bar = new Foo;          // ok
+    assert(bar !is null);   // ng
+
+    struct Int { int n; alias n this; }
+    Int a;
+    int b;
+    auto c = (true ? a : b);    // TODO
+    assert(c == a);
+}
+
+/**********************************************/
 
 int main()
 {
@@ -655,6 +673,7 @@ int main()
     test6434();
     test6366();
     test6759();
+    test6832();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -649,6 +649,29 @@ void test6832()
 }
 
 /**********************************************/
+// 6928
+
+void test6928()
+{
+    struct T { int* p; } // p is necessary.
+    T tx;
+
+    struct S {
+        T get() const { return tx; }
+        alias get this;
+    }
+
+    immutable(S) s;
+    immutable(T) t;
+    static assert(is(typeof(1? s:t))); // ok.
+    static assert(is(typeof(1? t:s))); // ok.
+    static assert(is(typeof(1? s:t)==typeof(1? t:s))); // fail.
+
+    auto x = 1? t:s; // ok.
+    auto y = 1? s:t; // compile error.
+}
+
+/**********************************************/
 
 int main()
 {
@@ -674,6 +697,7 @@ int main()
     test6366();
     test6759();
     test6832();
+    test6928();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -672,6 +672,26 @@ void test6928()
 }
 
 /**********************************************/
+// 6929
+
+struct S6929
+{
+    T6929 get() const { return T6929.init; }
+    alias get this;
+}
+struct T6929
+{
+    S6929 get() const { return S6929.init; }
+    alias get this;
+}
+void test6929()
+{
+    T6929 t;
+    S6929 s;
+    static assert(!is(typeof(1? t:s)));
+}
+
+/***************************************************/
 
 int main()
 {
@@ -698,6 +718,7 @@ int main()
     test6759();
     test6832();
     test6928();
+    test6929();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6832">Issue 6832</a> - Can't test objects wrapped with alias this
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6928">Issue 6928</a> - alias this, immutable and common type fail in presence of fields with indirections
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6929">Issue 6929</a> - [ICE] typeMerge crashes in presence of ambiguous alias this conversions
