### PR TITLE
64 bit wrong code for byte sized shift assign

### DIFF
--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -1636,11 +1636,15 @@ code *cdshass(elem *e,regm_t *pretregs)
             cg = allocreg(&retregs,&reg,tym);
             cs.Iop = 0x8B ^ byte;
             code_newreg(&cs, reg);
+            if (byte && I64 && (reg >= 4))
+                cs.Irex |= REX;
             c = ce = gen(CNIL,&cs);                     /* MOV reg,EA   */
             if (!I16)
             {
                 assert(!byte || (mask[reg] & BYTEREGS));
                 ce = genc2(CNIL,v ^ byte,modregrmx(3,op1,reg),shiftcnt);
+                if (byte && I64 && (reg >= 4))
+                    ce->Irex |= REX;
                 code_orrex(ce, rex);
                 /* We can do a 32 bit shift on a 16 bit operand if      */
                 /* it's a left shift and we're not concerned about      */
@@ -1666,6 +1670,8 @@ code *cdshass(elem *e,regm_t *pretregs)
             }
 
             cs.Iop = 0x89 ^ byte;
+            if (byte && I64 && (reg >= 4))
+                cs.Irex |= REX;
             gen(ce,&cs);                                /* MOV EA,reg   */
 
             // If result is not in correct register

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4325,6 +4325,36 @@ void test6563()
 
 /***************************************************/
 
+ubyte foo241(ubyte[] data)
+{
+    ubyte a, b, c, d;
+
+    a = data[0];
+    b = data[1];
+    c = data[2];
+    d = data[3];
+
+    c <<= 1;
+    if (c & 0x80)
+        c >>= 1;
+    d <<= 1;
+    if (d & 0x80)
+        d >>= 1;
+
+    return d;
+}
+
+void test241()
+{
+    ubyte[4] data;
+    data[3] = 0x40;
+    assert(foo241(data[]) == 0x40);
+    data[3] = 0x20;
+    assert(foo241(data[]) == 0x40);
+}
+
+/***************************************************/
+
 int main()
 {
     test1();
@@ -4554,6 +4584,7 @@ int main()
     test6506();
     test240();
     test6563();
+    test241();
 
     writefln("Success");
     return 0;


### PR DESCRIPTION
- byte sized shift assign might use legacy high bytes
