### PR TITLE
Issue 6847 & 6848 - Fix special cases of typeof(super)

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2935,7 +2935,7 @@ Expression *SuperExp::semantic(Scope *sc)
     if (!fd && sc->intypeof)
     {
         // Find enclosing class
-        for (Dsymbol *s = sc->parent; 1; s = s->parent)
+        for (Dsymbol *s = sc->getStructClassScope(); 1; s = s->parent)
         {
             if (!s)
             {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3806,7 +3806,26 @@ struct Bar6087
 }
 
 /***************************************************/
+// 6848
 
+class Foo6848 {}
+
+class Bar6848 : Foo6848
+{
+    void func() immutable
+    {
+        static assert(is(typeof(this) == immutable(Bar6848)));  // immutable(Bar6848)
+        auto t = this;
+        static assert(is(typeof(t) == immutable(Bar6848)));     // immutable(Bar6848)
+
+        static assert(is(typeof(super) == immutable(Foo6848))); // Foo6848 instead of immutable(Foo6848)
+        auto s = super;
+        static assert(is(typeof(s) == immutable(Foo6848)));     // Foo6848 instead of immutable(Foo6848)
+    }
+}
+
+/***************************************************/
+// 6289
 
 void test6289()
 {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3825,6 +3825,22 @@ class Bar6848 : Foo6848
 }
 
 /***************************************************/
+// 6847
+
+template True6847(T)
+{
+    immutable True6847 = true;
+}
+class Foo6847
+{}
+
+class Bar6847 : Foo6847
+{
+    static assert( True6847!(typeof(super)) );
+    static assert( is(typeof(super) == Foo6847) );
+}
+
+/***************************************************/
 // 6289
 
 void test6289()


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6847">Issue 6847</a> - typeof(super) doesn't work outside member function
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6848">Issue 6848</a> - typeof(super) does not take into account const/immutable attributes inside member functions

Supplemental changes of Phobos: https://github.com/D-Programming-Language/phobos/pull/301
