### PR TITLE
Issue 5416 & 5889 - typeof(null) should have a type of its own

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3013,7 +3013,7 @@ Expression *NullExp::semantic(Scope *sc)
 #endif
     // NULL is the same as (void *)0
     if (!type)
-        type = Type::tvoid->pointerTo();
+        type = Type::tnull;
     return this;
 }
 

--- a/src/glue.c
+++ b/src/glue.c
@@ -1109,6 +1109,10 @@ unsigned Type::totym()
             t = TYint;
             break;
 
+        case Tnull:
+            t = TYnptr;
+            break;
+
         default:
 #ifdef DEBUG
             printf("ty = %d, '%s'\n", ty, toChars());

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -6237,7 +6237,8 @@ Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
 
 bool isStackValueValid(Expression *newval)
 {
-    if (newval->type->ty == Tpointer && newval->type->nextOf()->ty != Tfunction)
+    if (newval->type->ty == Tnull ||
+        newval->type->ty == Tpointer && newval->type->nextOf()->ty != Tfunction)
     {
         if (newval->op == TOKaddress || newval->op == TOKnull ||
             newval->op == TOKstring)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -61,8 +61,8 @@ enum ENUMTY
     Tident,
     Tclass,
     Tstruct,
-
     Tenum,
+
     Ttypedef,
     Tdelegate,
     Tnone,
@@ -72,8 +72,8 @@ enum ENUMTY
     Tint16,
     Tuns16,
     Tint32,
-
     Tuns32,
+
     Tint64,
     Tuns64,
     Tfloat32,
@@ -83,8 +83,8 @@ enum ENUMTY
     Timaginary64,
     Timaginary80,
     Tcomplex32,
-
     Tcomplex64,
+
     Tcomplex80,
     Tbool,
     Tchar,
@@ -93,10 +93,11 @@ enum ENUMTY
     Terror,
     Tinstance,
     Ttypeof,
-
     Ttuple,
     Tslice,
+
     Treturn,
+    Tnull,
     TMAX
 };
 typedef unsigned char TY;       // ENUMTY
@@ -175,6 +176,8 @@ struct Type : Object
     static Type *tvoidptr;              // void*
     static Type *tstring;               // immutable(char)[]
     #define terror      basic[Terror]   // for error recovery
+
+    #define tnull       basic[Tnull]    // for null type
 
     #define tsize_t     basic[Tsize_t]          // matches size_t alias
     #define tptrdiff_t  basic[Tptrdiff_t]       // matches ptrdiff_t alias
@@ -892,6 +895,22 @@ struct TypeSlice : TypeNext
     Type *semantic(Loc loc, Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
+};
+
+struct TypeNull : Type
+{
+    TypeNull();
+
+    void toDecoBuffer(OutBuffer *buf, int flag);
+    MATCH implicitConvTo(Type *to);
+
+    void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
+
+    d_uns64 size(Loc loc);
+    //Expression *getProperty(Loc loc, Identifier *ident);
+    //Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *defaultInit(Loc loc);
+    //Expression *defaultInitLiteral(Loc loc);
 };
 
 /**************************************************************/

--- a/src/statement.c
+++ b/src/statement.c
@@ -3586,9 +3586,26 @@ Statement *ReturnStatement::semantic(Scope *sc)
             Type *tfret = tf->nextOf();
             if (tfret)
             {
-                if (tfret != Type::terror && !exp->type->equals(tfret))
-                    error("mismatched function return type inference of %s and %s",
-                        exp->type->toChars(), tfret->toChars());
+                if (tfret != Type::terror)
+                {
+                    if (!exp->type->equals(tfret))
+                    {
+                        int m1 = exp->type->implicitConvTo(tfret);
+                        int m2 = tfret->implicitConvTo(exp->type);
+                        //printf("exp->type = %s m2<-->m1 tret %s\n", exp->type->toChars(), tfret->toChars());
+                        //printf("m1 = %d, m2 = %d\n", m1, m2);
+
+                        if (m1 && m2)
+                            ;
+                        else if (!m1 && m2)
+                            tf->next = exp->type;
+                        else if (m1 && !m2)
+                            ;
+                        else
+                            error("mismatched function return type inference of %s and %s",
+                                exp->type->toChars(), tfret->toChars());
+                    }
+                }
 
                 /* The "refness" is determined by the first return statement,
                  * not all of them. This means:

--- a/test/runnable/nulltype.d
+++ b/test/runnable/nulltype.d
@@ -1,0 +1,53 @@
+extern (C) int printf(const(char*) fmt, ...);
+
+alias typeof(null) null_t;
+
+/**********************************************/
+
+void test1()
+{
+    null_t null1;
+    typeof(null) null2;
+
+    static assert(is(typeof(null1) == typeof(null)));
+    static assert(is(typeof(null2) == typeof(null)));
+
+    static assert(is(typeof(null1) == null_t));
+    static assert(is(typeof(null2) == null_t));
+}
+
+/**********************************************/
+
+interface I{}
+class C{}
+
+int f(null_t)   { return 1; }
+int f(int[])    { return 2; }
+int f(C)        { return 3; }
+
+void test2()
+{
+    static assert(is(null_t : C));
+    static assert(is(null_t : I));
+    static assert(is(null_t : int[]));
+    static assert(is(null_t : void*));
+    static assert(is(null_t : int**));
+
+    static assert(!is(null_t == C));
+    static assert(!is(null_t == I));
+    static assert(!is(null_t == int[]));
+    static assert(!is(null_t == void*));
+    static assert(!is(null_t == int**));
+
+    static assert(is(null_t == null_t));
+
+    assert(f(null) == 1);
+}
+
+/**********************************************/
+
+void main()
+{
+    test1();
+    test2();
+}

--- a/test/runnable/nulltype.d
+++ b/test/runnable/nulltype.d
@@ -45,6 +45,39 @@ void test2()
 }
 
 /**********************************************/
+// 5899
+
+auto f5899(bool b)
+{
+    if (b)
+        return new Object;
+    else
+        return null;
+}
+static assert(is(typeof(f5899) R == return) && is(R == Object));
+pragma(msg, typeof(f5899));
+
+auto g5899(bool b)
+{
+    if (b)
+        return new int;
+    else
+        return null;
+}
+static assert(is(typeof(g5899) R == return) && is(R == int*));
+pragma(msg, typeof(g5899));
+
+auto h5899(bool b)
+{
+    if (b)
+        return [1];
+    else
+        return null;
+}
+static assert(is(typeof(h5899) R == return) && is(R == int[]));
+pragma(msg, typeof(h5899));
+
+/**********************************************/
 
 void main()
 {


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5416">Issue 5416</a> - null should have a type of its own
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5899">Issue 5899</a> - auto-return function cannot match 'null' with reference type.

`typeof(null)` should have the own type, that is implicitly convertible to _any reference types_.
In binary level, `typeof(null)` is treated as `void*`

I think this is also useful for `NonNull!T`, because we can reject `NonNull!T p = null;` statically.
