### PR TITLE
More deprecation of using 'invariant' rather than 'immutable'

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -266,6 +266,8 @@ Dsymbols *Parser::parseDeclDefs(int once)
                 }
                 else
                 {
+                    if (!global.params.useDeprecated)
+                        error("use of 'invariant' rather than 'immutable' is deprecated");
                     stc = STCimmutable;
                     goto Lstc;
                 }
@@ -407,7 +409,11 @@ Dsymbols *Parser::parseDeclDefs(int once)
                         else if (token.value == TOKwild)
                             stc = STCwild;
                         else
+                        {
+                            if (token.value == TOKinvariant && !global.params.useDeprecated)
+                                error("use of 'invariant' rather than 'immutable' is deprecated");
                             stc = STCimmutable;
+                        }
                         goto Lstc;
                     case TOKfinal:        stc = STCfinal;        goto Lstc;
                     case TOKauto:         stc = STCauto;         goto Lstc;
@@ -1275,6 +1281,8 @@ Parameters *Parser::parseParameters(int *pvarargs)
                 case TOKimmutable:
                     if (peek(&token)->value == TOKlparen)
                         goto Ldefault;
+                    if (token.value == TOKinvariant && !global.params.useDeprecated)
+                        error("use of 'invariant' rather than 'immutable' is deprecated");
                     stc = STCimmutable;
                     goto L2;
 
@@ -2728,6 +2736,8 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, unsigned char *c
             case TOKimmutable:
                 if (peek(&token)->value == TOKlparen)
                     break;
+                if (token.value == TOKinvariant && !global.params.useDeprecated)
+                    error("use of 'invariant' rather than 'immutable' is deprecated");
                 stc = STCimmutable;
                 goto L1;
 
@@ -5332,6 +5342,8 @@ Expression *Parser::parsePrimaryExp()
                          token.value == TOKdelegate ||
                          token.value == TOKreturn))
                     {
+                        if (token.value == TOKinvariant && !global.params.useDeprecated)
+                            error("use of 'invariant' rather than 'immutable' is deprecated");
                         tok2 = token.value;
                         nextToken();
                     }
@@ -5705,6 +5717,8 @@ Expression *Parser::parseUnaryExp()
             }
             else if ((token.value == TOKimmutable || token.value == TOKinvariant) && peekNext() == TOKrparen)
             {
+                if (token.value == TOKinvariant && !global.params.useDeprecated)
+                    error("use of 'invariant' rather than 'immutable' is deprecated");
                 m = MODimmutable;
                 goto Lmod2;
             }

--- a/test/fail_compilation/fail176.d
+++ b/test/fail_compilation/fail176.d
@@ -2,7 +2,7 @@
 void foo()
 {
     auto a = "abc";
-    invariant char[3] b = "abc";
+    immutable char[3] b = "abc";
     //const char[3] b = "abc";
     b[1] = 'd';
 }

--- a/test/fail_compilation/fail177.d
+++ b/test/fail_compilation/fail177.d
@@ -9,7 +9,7 @@ struct S
 
 void test(const(S) s, const(int) i)
 {
-    invariant int j = 3;
+    immutable int j = 3;
     j = 4;
     i = 4;
     s.x = 3;

--- a/test/fail_compilation/fail178.d
+++ b/test/fail_compilation/fail178.d
@@ -9,7 +9,7 @@ struct S
 
 void test(const S s, const(int) i)
 {
-    invariant int j = 3;
+    immutable int j = 3;
     j = 4;
     i = 4;
     s.x = 3;

--- a/test/fail_compilation/fail225.d
+++ b/test/fail_compilation/fail225.d
@@ -5,6 +5,6 @@ struct Struct {
 void main()
 {
         char ch = 'd';
-        invariant Struct iStruct = {1, &ch};
+        immutable Struct iStruct = {1, &ch};
 }
 

--- a/test/fail_compilation/fail226.d
+++ b/test/fail_compilation/fail226.d
@@ -4,7 +4,7 @@ struct Struct {
 
 void main()
 {
-        invariant Struct iStruct;
+        immutable Struct iStruct;
         Struct y = iStruct;
 }
 

--- a/test/fail_compilation/fail227.d
+++ b/test/fail_compilation/fail227.d
@@ -5,7 +5,7 @@ struct Struct {
 void main()
 {
         char ch = 'd';
-        invariant Struct iStruct = {&ch};
+        immutable Struct iStruct = {&ch};
 }
 
 

--- a/test/fail_compilation/fail260.d
+++ b/test/fail_compilation/fail260.d
@@ -1,7 +1,7 @@
 struct Static( uint width2, uint height2 )
 {
-    invariant width = width2;
-    invariant height = height2;
+    immutable width = width2;
+    immutable height = height2;
 
     static Static opCall()
     {

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -646,7 +646,7 @@ void test30()
 
 template dog31(string sheep)
 {
-  invariant string dog31 = "daschund";
+  immutable string dog31 = "daschund";
 }
 
 void test31()

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -54,11 +54,11 @@ void test2()
 /*******************************************/
 
 template Qwert3(string yuiop) {
-    invariant string Qwert3 = cast(string)yuiop;
+    immutable string Qwert3 = cast(string)yuiop;
 }
 
 template Asdfg3(string yuiop) {
-    invariant string Asdfg3 = cast(string)Qwert3!(cast(string)(cast(string)yuiop ~ cast(string)"hjkl"));
+    immutable string Asdfg3 = cast(string)Qwert3!(cast(string)(cast(string)yuiop ~ cast(string)"hjkl"));
 }
 
 void test3()
@@ -72,7 +72,7 @@ void test3()
 
 template Qwert4(string yuiop)
 {
-    invariant string Qwert4 = cast(string)(yuiop ~ "asdfg" ~ yuiop);
+    immutable string Qwert4 = cast(string)(yuiop ~ "asdfg" ~ yuiop);
 }
 
 void test4()

--- a/test/runnable/testaa2.d
+++ b/test/runnable/testaa2.d
@@ -21,7 +21,7 @@ void testaa()
 
 int a[string];
 
-size_t foo(invariant char [3] s)
+size_t foo(immutable char [3] s)
 {
     printf("foo()\n");
     int b[string];

--- a/test/runnable/testswitch.d
+++ b/test/runnable/testswitch.d
@@ -323,7 +323,7 @@ void test14()
 /*****************************************/
 
 const int X15;
-invariant int Y15;
+immutable int Y15;
 const int Z15;
 
 int foo15(int i)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -60,7 +60,7 @@ void test3()
 
 void test4()
 {
-  invariant int maxi = 8;
+  immutable int maxi = 8;
   int[][maxi] neighbors = [ cast(int[])[ ], [ 0 ], [ 0, 1], [ 0, 2], [1, 2], [1, 2, 3, 4],
 [ 2, 3, 5], [ 4, 5, 6 ] ];
   int[maxi] grid;
@@ -437,7 +437,7 @@ void test21()
 
 void test22()
 {
-    invariant uint x, y;
+    immutable uint x, y;
     foreach (i; x .. y) {}
 }
 


### PR DESCRIPTION
In the future, we should remove using invariant keyword as type modifier and storage class.
This pull request makes deprecated the using 'invariant' as storage class.
