### PR TITLE
Evaluate try and finally block in compile time

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1319,8 +1319,7 @@ Expression *TryCatchStatement::interpret(InterState *istate)
     printf("TryCatchStatement::interpret()\n");
 #endif
     START()
-    error("try-catch statements are not yet supported in CTFE");
-    return EXP_CANT_INTERPRET;
+    return body ? body->interpret(istate) : NULL;
 }
 
 
@@ -1330,8 +1329,10 @@ Expression *TryFinallyStatement::interpret(InterState *istate)
     printf("TryFinallyStatement::interpret()\n");
 #endif
     START()
-    error("try-finally statements are not yet supported in CTFE");
-    return EXP_CANT_INTERPRET;
+    Expression *e = body ? body->interpret(istate) : NULL;
+    if (e && e != EXP_CANT_INTERPRET)
+        e = finalbody ? finalbody->interpret(istate) : NULL;
+    return e;
 }
 
 Expression *ThrowStatement::interpret(InterState *istate)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2700,3 +2700,28 @@ static assert({
     assert(aa.length == 0);
     return true;
 }());
+
+/**************************************************
+    try, finally
+**************************************************/
+
+static assert({
+    int n = 0;
+    try {
+        n = 1;
+    }
+    catch (Exception e)
+    {}
+    assert(n == 1);
+    try {
+        n = 2;
+    }
+    catch (Exception e)
+    {}
+    finally {
+        assert(n == 2);
+        n = 3;
+    }
+    assert(n == 3);
+    return true;
+}());


### PR DESCRIPTION
There is no reason to forbid to evaluate `try` and `finally` blocks in CTFE, because throw statement always stops interpreter.
