### PR TITLE
Issue 6864, 6865, 6866, 6867 - Fix inout matching and other

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -21,6 +21,7 @@
 #include "module.h"
 #include "id.h"
 #include "expression.h"
+#include "statement.h"
 #include "hdrgen.h"
 
 /********************************* Declaration ****************************/
@@ -1119,9 +1120,15 @@ Lnomatch:
         {
             error("only parameters or stack based variables can be inout");
         }
-        if (sc->func && !sc->func->type->hasWild())
+        FuncDeclaration *func = sc->func;
+        if (func)
         {
-            error("inout variables can only be declared inside inout functions");
+            if (func->fes)
+                func = func->fes->func;
+            if (!func->type->hasWild())
+            {
+                error("inout variables can only be declared inside inout functions");
+            }
         }
     }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -804,14 +804,12 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
         L1:
             if (!(p->storageClass & STClazy && p->type->ty == Tvoid))
             {
-                if (p->type->hasWild())
-                {   unsigned mod = p->type->wildMatch(arg->type);
-                    if (mod)
-                    {
-                        wildmatch |= mod;
-                        arg = arg->implicitCastTo(sc, p->type->substWildTo(mod));
-                        arg = arg->optimize(WANTvalue);
-                    }
+                unsigned mod = arg->type->wildConvTo(p->type);
+                if (mod)
+                {
+                    wildmatch |= mod;
+                    arg = arg->implicitCastTo(sc, p->type->substWildTo(mod));
+                    arg = arg->optimize(WANTvalue);
                 }
                 else if (p->type != arg->type)
                 {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3098,7 +3098,14 @@ MATCH TypeBasic::implicitConvTo(Type *to)
 #if DMDV2
     if (ty == to->ty)
     {
-        return (mod == to->mod) ? MATCHexact : MATCHconst;
+        if (mod == to->mod)
+            return MATCHexact;
+        else if (MODimplicitConv(mod, to->mod))
+            return MATCHconst;
+        else if (!((mod ^ to->mod) & MODshared))    // for wild matching
+            return MATCHconst;
+        else
+            return MATCHconvert;
     }
 #endif
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -328,24 +328,6 @@ Type *Type::trySemantic(Loc loc, Scope *sc)
     return t;
 }
 
-/*******************************
- * Determine if converting 'this' to 'to' is an identity operation,
- * a conversion to const operation, or the types aren't the same.
- * Returns:
- *      MATCHexact      'this' == 'to'
- *      MATCHconst      'to' is const
- *      MATCHnomatch    conversion to mutable or invariant
- */
-
-MATCH Type::constConv(Type *to)
-{
-    if (equals(to))
-        return MATCHexact;
-    if (ty == to->ty && MODimplicitConv(mod, to->mod))
-        return MATCHconst;
-    return MATCHnomatch;
-}
-
 /********************************
  * Convert to 'const'.
  */
@@ -1211,16 +1193,6 @@ Type *Type::addStorageClass(StorageClass stc)
     return addMod(mod);
 }
 
-/**************************
- * Return type with the top level of it being mutable.
- */
-Type *Type::toHeadMutable()
-{
-    if (!mod)
-        return this;
-    return mutableOf();
-}
-
 Type *Type::pointerTo()
 {
     if (ty == Terror)
@@ -1258,6 +1230,43 @@ Type *Type::arrayOf()
         arrayof = t->merge();
     }
     return arrayof;
+}
+
+Type *Type::aliasthisOf()
+{
+    AggregateDeclaration *ad = NULL;
+    if (ty == Tclass)
+    {
+        ad = ((TypeClass *)this)->sym;
+        goto L1;
+    }
+    else if (ty == Tstruct)
+    {
+        ad = ((TypeStruct *)this)->sym;
+    L1:
+        if (!ad->aliasthis)
+            return NULL;
+
+        Declaration *d = ad->aliasthis->isDeclaration();
+        if (d)
+        {   assert(d->type);
+            Type *t = d->type;
+            if (d->isVarDeclaration() && d->needThis())
+            {
+                t = t->addMod(this->mod);
+            }
+            else if (d->isFuncDeclaration())
+            {
+                FuncDeclaration *fd = (FuncDeclaration *)d;
+                Expression *ethis = this->defaultInit(0);
+                fd = fd->overloadResolve(0, ethis, NULL);
+                if (fd)
+                    t = ((TypeFunction *)fd->type)->next;
+            }
+            return t;
+        }
+    }
+    return NULL;
 }
 
 Dsymbol *Type::toDsymbol(Scope *sc)
@@ -1705,6 +1714,106 @@ MATCH Type::implicitConvTo(Type *to)
     return MATCHnomatch;
 }
 
+/*******************************
+ * Determine if converting 'this' to 'to' is an identity operation,
+ * a conversion to const operation, or the types aren't the same.
+ * Returns:
+ *      MATCHexact      'this' == 'to'
+ *      MATCHconst      'to' is const
+ *      MATCHnomatch    conversion to mutable or invariant
+ */
+
+MATCH Type::constConv(Type *to)
+{
+    if (equals(to))
+        return MATCHexact;
+    if (ty == to->ty && MODimplicitConv(mod, to->mod))
+        return MATCHconst;
+    return MATCHnomatch;
+}
+
+/***************************************
+ * Return MOD bits matching this type to wild parameter type (tprm).
+ */
+
+unsigned Type::wildConvTo(Type *tprm)
+{
+    //printf("Type::wildConvTo this = '%s', tprm = '%s'\n", toChars(), tprm->toChars());
+
+    if (tprm->isWild() && implicitConvTo(tprm->substWildTo(MODconst)))
+    {
+        if (isWild())
+            return MODwild;
+        else if (isConst())
+            return MODconst;
+        else if (isImmutable())
+            return MODimmutable;
+        else if (isMutable())
+            return MODmutable;
+        else
+            assert(0);
+    }
+    return 0;
+}
+
+Type *Type::substWildTo(unsigned mod)
+{
+    //printf("+Type::substWildTo this = %s, mod = x%x\n", toChars(), mod);
+    Type *t;
+
+    if (nextOf())
+    {
+        t = nextOf()->substWildTo(mod);
+        if (t == nextOf())
+            t = this;
+        else
+        {
+            if (ty == Tpointer)
+                t = t->pointerTo();
+            else if (ty == Tarray)
+                t = t->arrayOf();
+            else if (ty == Tsarray)
+                t = new TypeSArray(t, ((TypeSArray *)this)->dim->syntaxCopy());
+            else if (ty == Taarray)
+            {
+                t = new TypeAArray(t, ((TypeAArray *)this)->index->syntaxCopy());
+                t = t->merge();
+            }
+            else
+                assert(0);
+
+            t = t->addMod(this->mod);
+        }
+    }
+    else
+        t = this;
+
+    if (isWild())
+    {
+        if (mod & MODconst)
+            t = isShared() ? t->sharedConstOf() : t->constOf();
+        else if (mod & MODimmutable)
+            t = t->invariantOf();
+        else if (mod & MODwild)
+            t = isShared() ? t->sharedWildOf() : t->wildOf();
+        else
+            t = isShared() ? t->sharedOf() : t->mutableOf();
+    }
+
+    //printf("-Type::substWildTo t = %s\n", t->toChars());
+    return t;
+}
+
+/**************************
+ * Return type with the top level of it being mutable.
+ */
+Type *Type::toHeadMutable()
+{
+    if (!mod)
+        return this;
+    return mutableOf();
+}
+
 Expression *Type::getProperty(Loc loc, Identifier *ident)
 {   Expression *e;
 
@@ -2019,100 +2128,6 @@ int Type::hasWild()
     return mod & MODwild;
 }
 
-/***************************************
- * Return MOD bits matching argument type (targ) to wild parameter type (this).
- */
-
-unsigned getWildModConv(Type *twild, Type *targ)
-{
-    assert(twild);
-    assert(targ);
-
-    unsigned mod = 0;
-    
-    if (twild->nextOf())
-        mod = getWildModConv(twild->nextOf(), targ->nextOf());
-
-    if (!mod)
-    {
-        if (twild->isWild())
-        {
-            if (targ->isWild())
-                mod = MODwild;
-            else if (targ->isConst())
-                mod = MODconst;
-            else if (targ->isImmutable())
-                mod = MODimmutable;
-            else if (targ->isMutable())
-                mod = MODmutable;
-            else
-                assert(0);
-        }
-    }
-
-    return mod;
-}
-
-unsigned Type::wildMatch(Type *targ)
-{
-    //printf("Type::wildMatch this = '%s', targ = '%s'\n", toChars(), targ->toChars());
-    assert(hasWild());
-
-    Type *tc = substWildTo(MODconst);
-    if (targ->implicitConvTo(tc))
-        return getWildModConv(this, targ);
-
-    return 0;
-}
-
-Type *Type::substWildTo(unsigned mod)
-{
-    //printf("+Type::substWildTo this = %s, mod = x%x\n", toChars(), mod);
-    Type *t;
-
-    if (nextOf())
-    {
-        t = nextOf()->substWildTo(mod);
-        if (t == nextOf())
-            t = this;
-        else
-        {
-            if (ty == Tpointer)
-                t = t->pointerTo();
-            else if (ty == Tarray)
-                t = t->arrayOf();
-            else if (ty == Tsarray)
-                t = new TypeSArray(t, ((TypeSArray *)this)->dim->syntaxCopy());
-            else if (ty == Taarray)
-            {
-                t = new TypeAArray(t, ((TypeAArray *)this)->index->syntaxCopy());
-                t = t->merge();
-            }
-            else
-                assert(0);
-
-            t = t->addMod(this->mod);
-        }
-    }
-    else
-        t = this;
-
-    if (isWild())
-    {
-        if (mod & MODconst)
-            t = isShared() ? t->sharedConstOf() : t->constOf();
-        else if (mod & MODimmutable)
-            t = t->invariantOf();
-        else if (mod & MODwild)
-            t = isShared() ? t->sharedWildOf() : t->wildOf();
-        else
-            t = isShared() ? t->sharedOf() : t->mutableOf();
-    }
-
-    //printf("-Type::substWildTo t = %s\n", t->toChars());
-    return t;
-}
-
 /********************************
  * We've mistakenly parsed this as a type.
  * Redo it as an Expression.
@@ -2398,6 +2413,22 @@ MATCH TypeNext::constConv(Type *to)
         next->constConv(((TypeNext *)to)->next) == MATCHnomatch)
         m = MATCHnomatch;
     return m;
+}
+
+unsigned TypeNext::wildConvTo(Type *tprm)
+{
+    if (ty == Tfunction)
+        return 0;
+
+    unsigned mod = 0;
+    Type *tn = tprm->nextOf();
+    if (!tn)
+        return 0;
+    mod = next->wildConvTo(tn);
+    if (!mod)
+        mod = Type::wildConvTo(tprm);
+
+    return mod;
 }
 
 
@@ -5275,7 +5306,6 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
 {
     //printf("TypeFunction::callMatch() %s\n", toChars());
     MATCH match = MATCHexact;           // assume exact match
-    bool exactwildmatch = FALSE;
     bool wildmatch = FALSE;
 
     if (ethis)
@@ -5359,24 +5389,10 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             else
                 m = arg->implicitConvTo(p->type);
             //printf("match %d\n", m);
-            if (p->type->hasWild())
+            if (m == MATCHnomatch && arg->type->wildConvTo(p->type))
             {
-                if (m == MATCHnomatch)
-                {
-                    if (p->type->wildMatch(arg->type))
-                    {
-                        wildmatch = TRUE;       // mod matched to wild
-                        m = MATCHconst;
-                    }
-                }
-                else
-                    exactwildmatch = TRUE;      // wild matched to wild
-
-                /* If both are allowed, then there could be more than one
-                 * binding of mod to wild, leaving a gaping type hole.
-                 */
-                //if (wildmatch && exactwildmatch)
-                //    m = MATCHnomatch;
+                wildmatch = TRUE;       // mod matched to wild
+                m = MATCHconst;
             }
         }
 
@@ -6775,19 +6791,6 @@ Dsymbol *TypeTypedef::toDsymbol(Scope *sc)
     return sym;
 }
 
-Type *TypeTypedef::toHeadMutable()
-{
-    if (!mod)
-        return this;
-
-    Type *tb = toBasetype();
-    Type *t = tb->toHeadMutable();
-    if (t->equals(tb))
-        return this;
-    else
-        return mutableOf();
-}
-
 void TypeTypedef::toDecoBuffer(OutBuffer *buf, int flag)
 {
     Type::toDecoBuffer(buf, flag);
@@ -6923,6 +6926,18 @@ MATCH TypeTypedef::constConv(Type *to)
     return MATCHnomatch;
 }
 
+Type *TypeTypedef::toHeadMutable()
+{
+    if (!mod)
+        return this;
+
+    Type *tb = toBasetype();
+    Type *t = tb->toHeadMutable();
+    if (t->equals(tb))
+        return this;
+    else
+        return mutableOf();
+}
 
 Expression *TypeTypedef::defaultInit(Loc loc)
 {
@@ -7388,33 +7403,6 @@ int TypeStruct::hasPointers()
     return FALSE;
 }
 
-static MATCH aliasthisConvTo(AggregateDeclaration *ad, Type *from, Type *to)
-{
-    assert(ad->aliasthis);
-    Declaration *d = ad->aliasthis->isDeclaration();
-    if (d)
-    {   assert(d->type);
-        Type *t = d->type;
-        if (d->isVarDeclaration() && d->needThis())
-        {
-            t = t->addMod(from->mod);
-        }
-        else if (d->isFuncDeclaration())
-        {
-            FuncDeclaration *fd = (FuncDeclaration *)d;
-            Expression *ethis = from->defaultInit(0);
-            fd = fd->overloadResolve(0, ethis, NULL);
-            if (fd)
-            {
-                t = ((TypeFunction *)fd->type)->next;
-            }
-        }
-        MATCH m = t->implicitConvTo(to);
-        return m;
-    }
-    return MATCHnomatch;
-}
-
 MATCH TypeStruct::implicitConvTo(Type *to)
 {   MATCH m;
 
@@ -7462,15 +7450,10 @@ MATCH TypeStruct::implicitConvTo(Type *to)
         }
     }
     else if (sym->aliasthis)
-        m = aliasthisConvTo(sym, this, to);
+        m = aliasthisOf()->implicitConvTo(to);
     else
         m = MATCHnomatch;       // no match
     return m;
-}
-
-Type *TypeStruct::toHeadMutable()
-{
-    return this;
 }
 
 MATCH TypeStruct::constConv(Type *to)
@@ -7481,6 +7464,22 @@ MATCH TypeStruct::constConv(Type *to)
         MODimplicitConv(mod, to->mod))
         return MATCHconst;
     return MATCHnomatch;
+}
+
+unsigned TypeStruct::wildConvTo(Type *tprm)
+{
+    if (ty == tprm->ty && sym == ((TypeStruct *)tprm)->sym)
+        return Type::wildConvTo(tprm);
+
+    if (sym->aliasthis)
+        return aliasthisOf()->wildConvTo(tprm);
+
+    return 0;
+}
+
+Type *TypeStruct::toHeadMutable()
+{
+    return this;
 }
 
 
@@ -7877,7 +7876,7 @@ MATCH TypeClass::implicitConvTo(Type *to)
 
     m = MATCHnomatch;
     if (sym->aliasthis)
-        m = aliasthisConvTo(sym, this, to);
+        m = aliasthisOf()->implicitConvTo(to);
 
     return m;
 }
@@ -7890,6 +7889,23 @@ MATCH TypeClass::constConv(Type *to)
         MODimplicitConv(mod, to->mod))
         return MATCHconst;
     return MATCHnomatch;
+}
+
+unsigned TypeClass::wildConvTo(Type *tprm)
+{
+    Type *tcprm = tprm->substWildTo(MODconst);
+
+    if (constConv(tcprm))
+        return Type::wildConvTo(tprm);
+
+    ClassDeclaration *cdprm = tcprm->isClassHandle();
+    if (cdprm && cdprm->isBaseOf(sym, NULL))
+        return Type::wildConvTo(tprm);
+
+    if (sym->aliasthis)
+        return aliasthisOf()->wildConvTo(tprm);
+
+    return 0;
 }
 
 Type *TypeClass::toHeadMutable()

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2100,13 +2100,13 @@ Type *Type::substWildTo(unsigned mod)
     if (isWild())
     {
         if (mod & MODconst)
-            t = t->constOf();
+            t = isShared() ? t->sharedConstOf() : t->constOf();
         else if (mod & MODimmutable)
             t = t->invariantOf();
         else if (mod & MODwild)
-            t = t->wildOf();
+            t = isShared() ? t->sharedWildOf() : t->wildOf();
         else
-            t = t->mutableOf();
+            t = isShared() ? t->sharedOf() : t->mutableOf();
     }
 
     //printf("-Type::substWildTo t = %s\n", t->toChars());

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -274,6 +274,7 @@ struct Type : Object
     Type *pointerTo();
     Type *referenceTo();
     Type *arrayOf();
+    Type *aliasthisOf();
     virtual Type *makeConst();
     virtual Type *makeInvariant();
     virtual Type *makeShared();
@@ -283,10 +284,12 @@ struct Type : Object
     virtual Type *makeMutable();
     virtual Dsymbol *toDsymbol(Scope *sc);
     virtual Type *toBasetype();
-    virtual Type *toHeadMutable();
     virtual int isBaseOf(Type *t, int *poffset);
-    virtual MATCH constConv(Type *to);
     virtual MATCH implicitConvTo(Type *to);
+    virtual MATCH constConv(Type *to);
+    virtual unsigned wildConvTo(Type *tprm);
+    Type *substWildTo(unsigned mod);
+    virtual Type *toHeadMutable();
     virtual ClassDeclaration *isClassHandle();
     virtual Expression *getProperty(Loc loc, Identifier *ident);
     virtual Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
@@ -305,8 +308,6 @@ struct Type : Object
     virtual int builtinTypeInfo();
     virtual Type *reliesOnTident();
     virtual int hasWild();
-    unsigned wildMatch(Type *targ);
-    Type *substWildTo(unsigned mod);
     virtual Expression *toExpression();
     virtual int hasPointers();
     virtual TypeTuple *toArgTypes();
@@ -358,6 +359,7 @@ struct TypeNext : Type
     Type *makeSharedWild();
     Type *makeMutable();
     MATCH constConv(Type *to);
+    unsigned wildConvTo(Type *tprm);
     void transitive();
 };
 
@@ -728,6 +730,7 @@ struct TypeStruct : Type
     TypeTuple *toArgTypes();
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
+    unsigned wildConvTo(Type *tprm);
     Type *toHeadMutable();
 #if CPP_MANGLE
     void toCppMangle(OutBuffer *buf, CppMangleState *cms);
@@ -805,6 +808,7 @@ struct TypeTypedef : Type
     Type *toBasetype();
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
+    Type *toHeadMutable();
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
     int isZeroInit(Loc loc);
@@ -814,7 +818,6 @@ struct TypeTypedef : Type
     int hasPointers();
     TypeTuple *toArgTypes();
     int hasWild();
-    Type *toHeadMutable();
 #if CPP_MANGLE
     void toCppMangle(OutBuffer *buf, CppMangleState *cms);
 #endif
@@ -839,6 +842,9 @@ struct TypeClass : Type
     ClassDeclaration *isClassHandle();
     int isBaseOf(Type *t, int *poffset);
     MATCH implicitConvTo(Type *to);
+    MATCH constConv(Type *to);
+    unsigned wildConvTo(Type *tprm);
+    Type *toHeadMutable();
     Expression *defaultInit(Loc loc);
     int isZeroInit(Loc loc);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wildmatch = NULL);
@@ -848,12 +854,8 @@ struct TypeClass : Type
     int hasPointers();
     TypeTuple *toArgTypes();
     int builtinTypeInfo();
-#if DMDV2
-    Type *toHeadMutable();
-    MATCH constConv(Type *to);
 #if CPP_MANGLE
     void toCppMangle(OutBuffer *buf, CppMangleState *cms);
-#endif
 #endif
 
     type *toCtype();

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1961,6 +1961,23 @@ void test6865()
 }
 
 /************************************/
+// 6866
+
+struct S6866
+{
+    const(char)[] val;
+    alias val this;
+}
+inout(char)[] foo6866(inout(char)[] s) { return s; }
+
+void test6866()
+{
+    S6866 s;
+    static assert(is(typeof(foo6866(s)) == const(char)[]));
+    // Assertion failure: 'targ' on line 2029 in file 'mtype.c'
+}
+
+/************************************/
 
 int main()
 {
@@ -2056,6 +2073,7 @@ int main()
     test6782();
     test6864();
     test6865();
+    test6866();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1932,6 +1932,25 @@ void test6782()
 }
 
 /************************************/
+// 6864
+
+int fn6864( const int n) { return 1; }
+int fn6864(shared int n) { return 2; }
+inout(int) fw6864(inout int s) { return 1; }
+inout(int) fw6864(shared inout int s) { return 2; }
+
+void test6864()
+{
+    int n;
+    assert(fn6864(n) == 1);
+    assert(fw6864(n) == 1);
+
+    shared int sn;
+    assert(fn6864(sn) == 2);
+    assert(fw6864(sn) == 2);
+}
+
+/************************************/
 
 int main()
 {
@@ -2025,6 +2044,7 @@ int main()
     test1961c();
     test88();
     test6782();
+    test6864();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1978,6 +1978,20 @@ void test6866()
 }
 
 /************************************/
+// 6867
+
+inout(char)[] test6867(inout(char)[] a)
+{
+   foreach(dchar d; a) // No error if 'dchar' is removed
+   {
+       foreach(c; a) // line 5
+       {
+       }
+   }
+   return [];
+}
+
+/************************************/
 
 int main()
 {

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1951,6 +1951,16 @@ void test6864()
 }
 
 /************************************/
+// 6865
+
+shared(inout(int)) foo6865(shared(inout(int)) n){ return n; }
+void test6865()
+{
+    shared(const(int)) n;
+    static assert(is(typeof(foo6865(n)) == shared(const(int))));
+}
+
+/************************************/
 
 int main()
 {
@@ -2045,6 +2055,7 @@ int main()
     test88();
     test6782();
     test6864();
+    test6865();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6864">Issue 6864</a> - Const conversion should precedence over the shared one
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6865">Issue 6865</a> - inout matching removes shared qualifier
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6866">Issue 6866</a> - ICE(mtype.c): alias this and inout matching
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6867">Issue 6867</a> - inout and nested foreach loops
