### PR TITLE
Issue 3990 - Deferencing a dynamic array as pointer

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8072,9 +8072,13 @@ Expression *PtrExp::semantic(Scope *sc)
 
             case Tsarray:
             case Tarray:
-                type = ((TypeArray *)tb)->next;
-                e1 = e1->castTo(sc, type->pointerTo());
-                break;
+                if (global.params.useDeprecated)
+                {
+                    type = ((TypeArray *)tb)->next;
+                    e1 = e1->castTo(sc, type->pointerTo());
+                    break;
+                }
+                // fall through
 
             default:
                 error("can only * a pointer, not a '%s'", e1->type->toChars());

--- a/test/runnable/deprecate1.d
+++ b/test/runnable/deprecate1.d
@@ -1197,6 +1197,22 @@ void test34_test52()
 }
 
 /******************************************/
+// 3990
+
+void test3990()
+{
+    int[] a1 = [5, 4, 3];
+    assert(*a1 == 5);
+    alias typeof(a1) T1;
+    assert(is(typeof(*T1)));
+
+    int[3] a2 = [5, 4, 3];
+    assert(*a2 == 5);
+    alias typeof(a2) T2;
+    assert(is(typeof(*T2)));
+}
+
+/******************************************/
 
 int main()
 {
@@ -1253,5 +1269,7 @@ int main()
     test23_test67();
     test34_test14();
     test34_test52();
+    test3990();
+
     return 0;
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3990

Deprecate dereferencing of dynamic or static array (It is still valid with `-d` option).
