### PR TITLE
Fix inout matching with template function

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5462,10 +5462,14 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             else
                 m = arg->implicitConvTo(p->type);
             //printf("match %d\n", m);
-            if (m == MATCHnomatch && arg->type->wildConvTo(p->type))
+            if (m == MATCHnomatch)
             {
-                wildmatch = TRUE;       // mod matched to wild
-                m = MATCHconst;
+                unsigned mod = arg->type->wildConvTo(p->type);
+                if (mod)
+                {
+                    wildmatch = TRUE;       // mod matched to wild
+                    m = arg->type->implicitConvTo(p->type->substWildTo(mod));
+                }
             }
         }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -4407,18 +4407,23 @@ int Parser::isDeclaration(Token *t, int needId, enum TOK endtok, Token **pt)
     int haveId = 0;
 
 #if DMDV2
-    if ((t->value == TOKconst ||
-         t->value == TOKinvariant ||
-         t->value == TOKimmutable ||
-         t->value == TOKwild ||
-         t->value == TOKshared) &&
-        peek(t)->value != TOKlparen)
-    {   /* const type
-         * immutable type
-         * shared type
-         * wild type
-         */
-        t = peek(t);
+    while (1)
+    {
+        if ((t->value == TOKconst ||
+             t->value == TOKinvariant ||
+             t->value == TOKimmutable ||
+             t->value == TOKwild ||
+             t->value == TOKshared) &&
+            peek(t)->value != TOKlparen)
+        {   /* const type
+             * immutable type
+             * shared type
+             * wild type
+             */
+            t = peek(t);
+            continue;
+        }
+        break;
     }
 #endif
 

--- a/src/template.c
+++ b/src/template.c
@@ -1209,6 +1209,9 @@ Lretry:
 #endif
             Type *argtype = farg->type;
 
+            // Apply function parameter storage classes to parameter types
+            fparam->type = fparam->type->addStorageClass(fparam->storageClass);
+
 #if DMDV2
             /* Allow string literals which are type [] to match with [dim]
              */
@@ -1277,6 +1280,18 @@ Lretry:
                     }
                 }
             }
+
+            if (m && (fparam->storageClass & (STCref | STCauto)) == STCref)
+            {   if (!farg->isLvalue())
+                    goto Lnomatch;
+            }
+            if (m && (fparam->storageClass & STCout))
+            {   if (!farg->isLvalue())
+                    goto Lnomatch;
+            }
+            if (!m && (fparam->storageClass & STClazy) && fparam->type->ty == Tvoid &&
+                    farg->type->ty != Tvoid)
+                m = MATCHconvert;
 
             if (m)
             {   if (m < match)

--- a/src/template.h
+++ b/src/template.h
@@ -91,6 +91,7 @@ struct TemplateDeclaration : ScopeDsymbol
     MATCH deduceFunctionTemplateMatch(Scope *sc, Loc loc, Objects *targsi, Expression *ethis, Expressions *fargs, Objects *dedargs);
     FuncDeclaration *deduceFunctionTemplate(Scope *sc, Loc loc, Objects *targsi, Expression *ethis, Expressions *fargs, int flags = 0);
     void declareParameter(Scope *sc, TemplateParameter *tp, Object *o);
+    FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs, Expressions *fargs);
 
     TemplateDeclaration *isTemplateDeclaration() { return this; }
 

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -807,7 +807,7 @@ void abc50(T)(const T t)
 {
     showf(typeid(T).toString());
     showf(typeid(typeof(t)).toString());
-    assert(is(T == const(C)));
+    assert(is(T == C));
     assert(is(typeof(t) == const(C)));
 }
 

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2059,6 +2059,16 @@ void test6872b()
 }
 
 /************************************/
+// 6837
+
+template Id6837(T)
+{
+	alias T Id6837;
+}
+static assert(is(Id6837!(shared const int) == shared const int));
+static assert(is(Id6837!(shared inout int) == shared inout int));
+
+/************************************/
 // 6870
 
 void test6870()

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1992,6 +1992,73 @@ inout(char)[] test6867(inout(char)[] a)
 }
 
 /************************************/
+// 6872
+
+      int  fn6872a     (             int  []  v){ return 1; }
+      int  fn6872a     (shared(      int )[]  v){ return 2; }
+      int  fn6872a     (shared(      int  []) v){ return 3; }
+
+inout(int) fw6872a     (       inout(int) []  v){ return 1; }
+inout(int) fw6872a     (shared(inout(int))[]  v){ return 2; }
+inout(int) fw6872a     (shared(inout(int) []) v){ return 3; }
+
+inout(int) ft6872a(Typ)(       inout(Typ) []  v){ return 1; }
+inout(int) ft6872a(Typ)(shared(inout(Typ))[]  v){ return 2; }
+inout(int) ft6872a(Typ)(shared(inout(Typ) []) v){ return 3; }
+
+void test6872a()
+{
+           int []  lla;
+    shared(int)[]  lga;
+    shared(int []) gga;
+
+    assert(fn6872a(lla) == 1);
+    assert(fn6872a(lga) == 2);
+    assert(fn6872a(gga) == 3);
+
+    assert(fw6872a(lla) == 1);
+    assert(fw6872a(lga) == 2);
+    assert(fw6872a(gga) == 3);
+
+//  assert(ft6872a(lla) == 1);
+//  assert(ft6872a(lga) == 2);
+//  assert(ft6872a(gga) == 3);
+}
+
+// ----
+
+      int  fn6872b            (             int  [float]  v){ return 1; }
+      int  fn6872b            (shared(      int )[float]  v){ return 2; }
+      int  fn6872b            (shared(      int  [float]) v){ return 3; }
+
+inout(int) fw6872b            (       inout(int) [float]  v){ return 1; }
+inout(int) fw6872b            (shared(inout(int))[float]  v){ return 2; }
+inout(int) fw6872b            (shared(inout(int) [float]) v){ return 3; }
+
+inout(int) ft6872b(Key, Value)(       inout(Key) [Value]  v){ return 1; }
+inout(int) ft6872b(Key, Value)(shared(inout(Key))[Value]  v){ return 2; }
+inout(int) ft6872b(Key, Value)(shared(inout(Key) [Value]) v){ return 3; }
+
+void test6872b()
+{
+           int [float]  llaa;
+    shared(int)[float]  lgaa;
+    shared(int [float]) ggaa;
+
+    assert(fn6872b(llaa) == 1);
+    assert(fn6872b(lgaa) == 2);
+    assert(fn6872b(ggaa) == 3);
+
+    assert(fw6872b(llaa) == 1);
+    assert(fw6872b(lgaa) == 2);
+    assert(fw6872b(ggaa) == 3);
+
+//  assert(ft6872b(llaa) == 1);
+//  assert(ft6872b(lgaa) == 2);
+//  assert(ft6872b(ggaa) == 3);
+}
+
+/************************************/
 // 6870
 
 void test6870()
@@ -2262,6 +2329,8 @@ int main()
     test6864();
     test6865();
     test6866();
+    test6872a();
+    test6872b();
     test6870();
     test6912();
 

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2020,9 +2020,9 @@ void test6872a()
     assert(fw6872a(lga) == 2);
     assert(fw6872a(gga) == 3);
 
-//  assert(ft6872a(lla) == 1);
-//  assert(ft6872a(lga) == 2);
-//  assert(ft6872a(gga) == 3);
+    assert(ft6872a(lla) == 1);
+    assert(ft6872a(lga) == 2);
+    assert(ft6872a(gga) == 3);
 }
 
 // ----
@@ -2053,9 +2053,9 @@ void test6872b()
     assert(fw6872b(lgaa) == 2);
     assert(fw6872b(ggaa) == 3);
 
-//  assert(ft6872b(llaa) == 1);
-//  assert(ft6872b(lgaa) == 2);
-//  assert(ft6872b(ggaa) == 3);
+    assert(ft6872b(llaa) == 1);
+    assert(ft6872b(lgaa) == 2);
+    assert(ft6872b(ggaa) == 3);
 }
 
 /************************************/


### PR DESCRIPTION
This pull request includes #425 for inout matching test of template function.
Therefore this patch requires the patches of druntime and phobos.

Additional fixes.
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6872">Issue 6872</a> - Breaking type parsing of shared(inout(int)[])
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6873">Issue 6873</a> - Multiple storage class is not allowed on template argument

requires: druntime git://github.com/9rnsr/druntime.git fix6208_on_inout
requires: phobos git://github.com/9rnsr/phobos.git fix6208_on_inout
