### PR TITLE
Define 'Darwin' version ident instead of 'darwin'.

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -432,7 +432,7 @@ int main(int argc, char *argv[])
     global.params.isOSX = 1;
 
     // For legacy compatibility
-    VersionCondition::addPredefinedGlobalIdent("darwin");
+    VersionCondition::addPredefinedGlobalIdent("Darwin");
 #elif TARGET_FREEBSD
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("FreeBSD");


### PR DESCRIPTION
GDC is switching to 'Darwin', so this is a patch to keep the two compilers in sync.
