### PR TITLE
CTFE array and pointer bugs 6851 6885 6886

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1631,16 +1631,9 @@ Expression *SymOffExp::interpret(InterState *istate, CtfeGoal goal)
     }
     else if ( offset == 0 && isSafePointerCast(var->type, pointee) )
     {
-        if (goal == ctfeNeedLvalue || goal == ctfeNeedLvalueRef)
-        {
-            VarExp *ve = new VarExp(loc, var);
-            ve->type = type;
-            return ve;
-        }
-        Expression *e = getVarExp(loc, istate, var, goal);
-        e = new AddrExp(loc, e);
-        e->type = type;
-        return e;
+        VarExp *ve = new VarExp(loc, var);
+        ve->type = type;
+        return ve;
     }
 
     error("Cannot convert &%s to %s at compile time", var->type->toChars(), type->toChars());

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2188,8 +2188,12 @@ ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Type *type,
 {
     Expressions *elements = new Expressions();
     elements->setDim(dim);
+    bool mustCopy = needToCopyLiteral(elem);
     for (size_t i = 0; i < dim; i++)
-         elements->tdata()[i] = elem;
+    {   if (mustCopy)
+            elem  = copyLiteral(elem);
+        elements->tdata()[i] = elem;
+    }
     ArrayLiteralExp *ae = new ArrayLiteralExp(0, elements);
     ae->type = type;
     return ae;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2235,9 +2235,8 @@ Expression *recursivelyCreateArrayLiteral(Type *newtype, InterState *istate,
         return EXP_CANT_INTERPRET;
     size_t len = (size_t)(lenExpr->toInteger());
     Type *elemType = ((TypeArray *)newtype)->next;
-    if (elemType->ty == Tarray)
+    if (elemType->ty == Tarray && argnum < arguments->dim - 1)
     {
-        assert(argnum < arguments->dim - 1);
         Expression *elem = recursivelyCreateArrayLiteral(elemType, istate,
             arguments, argnum + 1);
         if (elem == EXP_CANT_INTERPRET)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2987,3 +2987,27 @@ SomeClass classtest2(int n)
 }
 static assert(is(typeof( (){ enum xx = classtest2(2);}() )));
 static assert(!is(typeof( (){ enum xx = classtest2(5);}() )));
+
+/**************************************************
+    6885 wrong code with new array
+**************************************************/
+
+struct S6885 {
+    int p;
+}
+
+int bug6885()
+{
+    auto array = new double[1][2];
+    array[1][0] = 6;
+    array[0][0] = 1;
+    assert(array[1][0]==6);
+
+    auto barray = new S6885[2];
+    barray[1].p = 5;
+    barray[0].p = 2;
+    assert(barray[1].p == 5);
+    return 1;
+}
+
+static assert(bug6885());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2863,6 +2863,24 @@ static assert({
 }());
 
 /**************************************************
+    6851 passing pointer by argument
+**************************************************/
+
+void set6851(int* pn)
+{
+    *pn = 20;
+}
+void bug6851()
+{
+    int n = 0;
+    auto pn = &n;
+    *pn = 10;
+    assert(n == 10);
+    set6851(&n);
+}
+static assert({ bug6851(); return true; }());
+
+/**************************************************
     6817 if converted to &&, only with -inline
 **************************************************/
 static assert({

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3011,3 +3011,18 @@ int bug6885()
 }
 
 static assert(bug6885());
+
+/**************************************************
+    6886 ICE with new array of dynamic arrays
+**************************************************/
+
+int bug6886()
+{
+    auto carray = new int[][2];
+    carray[1] = [6];
+    carray[0] = [4];
+    assert(carray[1][0]==6);
+    return 1;
+}
+
+static assert(bug6886());


### PR DESCRIPTION
6885 is a nasty wrong-code bug. The other two are rejects-valid and ice-on-valid.

They're all pretty simple fixes.

6851 [CTFE] Cannot deref pointer passed by argument
6885 [CTFE] wrong code with dynamically allocated 2D array
6886 [CTFE] ICE(interpret.c) new array with initializer
