### PR TITLE
merge VarDeclaration flags into bitfield

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -114,7 +114,7 @@ FuncDeclaration *StructDeclaration::buildOpAssign(Scope *sc)
         if (dtor)
         {
             tmp = new VarDeclaration(0, type, idtmp, new VoidInitializer(0));
-            tmp->noscope = 1;
+            tmp->flags |= VARDECLnoscope;
             tmp->storage_class |= STCctfe;
             e = new DeclarationExp(0, tmp);
             ec = new AssignExp(0,

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -239,17 +239,22 @@ struct VarDeclaration : Declaration
 {
     Initializer *init;
     unsigned offset;
-    int noscope;                 // no auto semantics
+
+    unsigned flags;
+#define VARDECLnoscope     1    // no auto semantics
+#define VARDECLctorinit    2    // it has been initialized in a ctor
+#define VARDECLcanassign   4    // it can be assigned to
+#if DMDV2
+#define VARDECLisargptr    8    // if parameter that _argptr points to
+#endif
+
 #if DMDV2
     FuncDeclarations nestedrefs; // referenced by these lexically nested functions
-    bool isargptr;              // if parameter that _argptr points to
 #else
     int nestedref;              // referenced by a lexically nested function
 #endif
-    int ctorinit;               // it has been initialized in a ctor
     int onstack;                // 1: it has been allocated on the stack
                                 // 2: on stack, run destructor anyway
-    int canassign;              // it can be assigned to
     Dsymbol *aliassym;          // if redone as alias to another symbol
 
     // When interpreting, these point to the value (NULL if value not determinable)

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1168,7 +1168,7 @@ elem *Dsymbol_toElem(Dsymbol *s, IRState *irs)
 
             /* Mark the point of construction of a variable that needs to be destructed.
              */
-            if (vd->edtor && !vd->noscope)
+            if (vd->edtor && !(vd->flags & VARDECLnoscope))
             {
                 e = el_dctor(e, vd);
 

--- a/src/func.c
+++ b/src/func.c
@@ -1118,7 +1118,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     loc = fensure->loc;
 
                 VarDeclaration *v = new VarDeclaration(loc, type->nextOf(), outId, NULL);
-                v->noscope = 1;
+                v->flags |= VARDECLnoscope;
                 v->storage_class |= STCresult;
 #if DMDV2
                 if (!isVirtual())
@@ -1216,7 +1216,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 for (size_t i = 0; i < ad->fields.dim; i++)
                 {   VarDeclaration *v = ad->fields[i];
 
-                    v->ctorinit = 0;
+                    v->flags &= ~VARDECLctorinit;
                 }
             }
 
@@ -1270,7 +1270,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     for (size_t i = 0; i < ad->fields.dim; i++)
                     {   VarDeclaration *v = ad->fields[i];
 
-                        if (v->ctorinit == 0)
+                        if (!(v->flags & VARDECLctorinit))
                         {
                             /* Current bugs in the flow analysis:
                              * 1. union members should not produce error messages even if
@@ -1453,7 +1453,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     e = new AssignExp(0, e1, e);
                     e->type = t;
                     a->push(new ExpStatement(0, e));
-                    p->isargptr = TRUE;
+                    p->flags |= VARDECLisargptr;
                 }
 #endif
             }
@@ -1562,7 +1562,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     if (v->type->toBasetype()->ty == Tsarray)
                         continue;
 
-                    if (v->noscope)
+                    if (v->flags & VARDECLnoscope)
                         continue;
 
                     Expression *e = v->edtor;

--- a/src/statement.c
+++ b/src/statement.c
@@ -321,7 +321,7 @@ Statement *ExpStatement::scopeCode(Scope *sc, Statement **sentry, Statement **se
         {
             DeclarationExp *de = (DeclarationExp *)(exp);
             VarDeclaration *v = de->declaration->isVarDeclaration();
-            if (v && !v->noscope)
+            if (v && !(v->flags & VARDECLnoscope))
             {
                 Expression *e = v->edtor;
                 if (e)
@@ -348,7 +348,7 @@ Statement *ExpStatement::scopeCode(Scope *sc, Statement **sentry, Statement **se
 #endif
                     *sfinally = new DtorExpStatement(loc, e, v);
                 }
-                v->noscope = 1;         // don't add in dtor again
+                v->flags |= VARDECLnoscope;         // don't add in dtor again
             }
         }
     }
@@ -1888,7 +1888,7 @@ Lagain:
             if (!sc->func->vresult && tret && tret != Type::tvoid)
             {
                 VarDeclaration *v = new VarDeclaration(loc, tret, Id::result, NULL);
-                v->noscope = 1;
+                v->flags |= VARDECLnoscope;
                 v->semantic(sc);
                 if (!sc->insert(v))
                     assert(0);
@@ -2471,7 +2471,7 @@ Statement *IfStatement::semantic(Scope *sc)
             Statement *sdtor = new ExpStatement(loc, match->edtor);
             sdtor = new OnScopeStatement(loc, TOKon_scope_exit, sdtor);
             ifbody = new CompoundStatement(loc, sdtor, ifbody);
-            match->noscope = 1;
+            match->flags |= VARDECLnoscope;
        }
     }
     else
@@ -3672,7 +3672,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
             if (!fd->vresult)
             {   // Declare vresult
                 VarDeclaration *v = new VarDeclaration(loc, tret, Id::result, NULL);
-                v->noscope = 1;
+                v->flags |= VARDECLnoscope;
                 v->storage_class |= STCresult;
                 v->semantic(scx);
                 if (!scx->insert(v))

--- a/src/toir.c
+++ b/src/toir.c
@@ -740,7 +740,7 @@ void FuncDeclaration::buildClosure(IRState *irs)
                 /* Because the value needs to survive the end of the scope!
                  */
                 v->error("has scoped destruction, cannot build closure");
-            if (v->isargptr)
+            if (v->flags & VARDECLisargptr)
                 /* See Bugzilla 2479
                  * This is actually a bug, but better to produce a nice
                  * message at compile time rather than memory corruption at runtime


### PR DESCRIPTION
- canassign was set recursively before running
  semantic on the initializer, this was not needed
  as the initializer can't reference the declaration
