### PR TITLE
Add -sL swith to pass linker flags at the end of the linker command

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -196,6 +196,11 @@ int runLINK()
         cmdbuf.writestring((*global.params.linkswitches)[i]);
     }
     cmdbuf.writeByte(';');
+    for (size_t i = 0; i < global.params.linkpostswitches->dim; i++)
+    {
+        cmdbuf.writestring(global.params.linkpostswitches->tdata()[i]);
+    }
+    cmdbuf.writeByte(';');
 
     p = cmdbuf.toChars();
 
@@ -345,6 +350,13 @@ int runLINK()
         argv.push(p);
     }
 
+    for (size_t i = 0; i < global.params.linkpostswitches->dim; i++)
+    {   char *p = global.params.linkpostswitches->tdata()[i];
+        if (!p || !p[0] || !(p[0] == '-' && p[1] == 'l'))
+            // Don't need -Xlinker if switch starts with -l
+            argv.push((char *)"-Xlinker");
+    }
+
     /* Add each library, prefixing it with "-l".
      * The order of libraries passed is:
      *  1. any libraries passed with -L command line switch
@@ -352,6 +364,7 @@ int runLINK()
      *  3. libraries specified by pragma(lib), which were appended
      *     to global.params.libfiles.
      *  4. standard libraries.
+     *  5. any libraries passed with -sL command line switch
      */
     for (size_t i = 0; i < global.params.libfiles->dim; i++)
     {   char *p = (*global.params.libfiles)[i];
@@ -390,6 +403,10 @@ int runLINK()
     // Changes in ld for Ubuntu 11.10 require this to appear after phobos2
     argv.push((char *)"-lrt");
 #endif
+
+    /* Some switched (libraries) needs to be passed after the standard libs */
+    for (size_t i = 0; i < global.params.linkpostswitches->dim; i++)
+        argv.push(global.params.linkpostswitches->tdata()[i]);
 
     if (!global.params.quiet || global.params.verbose)
     {

--- a/src/mars.c
+++ b/src/mars.c
@@ -331,6 +331,7 @@ Usage:\n\
   -debug=ident   compile in debug code identified by ident\n\
   -debuglib=name    set symbolic debug library to name\n\
   -defaultlib=name  set default library to name\n\
+  -sLlinkerflag  pass linkerflag at the end of the linker command line\n\
   -deps=filename write module dependencies to filename\n%s"
 "  -g             add symbolic debug info\n\
   -gc            add symbolic debug info, pretend to be C\n\
@@ -438,6 +439,7 @@ int main(int argc, char *argv[])
     global.params.quiet = 1;
 
     global.params.linkswitches = new Strings();
+    global.params.linkpostswitches = new Strings();
     global.params.libfiles = new Strings();
     global.params.objfiles = new Strings();
     global.params.ddocfiles = new Strings();
@@ -771,6 +773,10 @@ int main(int argc, char *argv[])
                 global.params.debugx = 1;
             else if (strcmp(p + 1, "-y") == 0)
                 global.params.debugy = 1;
+            else if (p[1] == 's' && p[2] == 'L')
+            {
+                global.params.linkpostswitches->push(p + 3);
+            }
             else if (p[1] == 'L')
             {
                 global.params.linkswitches->push(p + 2);

--- a/src/mars.h
+++ b/src/mars.h
@@ -231,6 +231,7 @@ struct Param
     // Linker stuff
     Strings *objfiles;
     Strings *linkswitches;
+    Strings *linkpostswitches;
     Strings *libfiles;
     char *deffile;
     char *resfile;


### PR DESCRIPTION
There are some cases where linker flags order do matter (for example for
linking libraries). In those cases DMD provide no mechanism for altering
the order. This patches tries to minimize this problem by adding an
option (-sL) to add flags at the _end_ of the linker command line. This
is specially useful to include libraries _after_ the standard library
passed with -debuglib or -defaultlib.

Posted in the devel ML: http://permalink.gmane.org/gmane.comp.lang.d.dmd.devel/2530
