### PR TITLE
Issue 6902 - Different "pure nothrow int()" types

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1291,7 +1291,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (!type->nextOf())
                 {
                     ((TypeFunction *)type)->next = Type::tvoid;
-                    //type = type->semantic(loc, sc);
+                    //type = type->semantic(loc, sc);   // Removed with 6902
                 }
                 f = (TypeFunction *)type;
             }

--- a/src/func.c
+++ b/src/func.c
@@ -1291,7 +1291,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (!type->nextOf())
                 {
                     ((TypeFunction *)type)->next = Type::tvoid;
-                    type = type->semantic(loc, sc);
+                    //type = type->semantic(loc, sc);
                 }
                 f = (TypeFunction *)type;
             }
@@ -1695,6 +1695,12 @@ void FuncDeclaration::semantic3(Scope *sc)
     {
         flags &= ~FUNCFLAGsafetyInprocess;
         f->trust = TRUSTsafe;
+    }
+
+    // Do semantic type AFTER pure/nothrow inference.
+    if (inferRetType)
+    {
+        type = type->semantic(loc, sc);
     }
 
     if (global.gag && global.errors != nerrors)

--- a/src/statement.c
+++ b/src/statement.c
@@ -3618,7 +3618,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
                         tf->isref = FALSE;      // return by value
                 }
                 tf->next = exp->type;
-                //fd->type = tf->semantic(loc, sc);
+                //fd->type = tf->semantic(loc, sc);     // Removed with 6902
                 if (!fd->tintro)
                 {   tret = fd->type->nextOf();
                     tbret = tret->toBasetype();

--- a/src/statement.c
+++ b/src/statement.c
@@ -3618,7 +3618,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
                         tf->isref = FALSE;      // return by value
                 }
                 tf->next = exp->type;
-                fd->type = tf->semantic(loc, sc);
+                //fd->type = tf->semantic(loc, sc);
                 if (!fd->tintro)
                 {   tret = fd->type->nextOf();
                     tbret = tret->toBasetype();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4021,6 +4021,26 @@ void test6910()
 }
 
 /***************************************************/
+// 6902
+
+void test6902()
+{
+    static assert(is(typeof({
+        return int.init; // int, long, real, etc.
+    })));
+
+    int f() pure nothrow { assert(0); }
+    alias int T() pure nothrow;
+    static if(is(typeof(&f) DT == delegate))
+    {
+        static assert(is(DT* == T*));  // ok
+
+        // Error: static assert  (is(pure nothrow int() == pure nothrow int())) is false
+        static assert(is(DT == T));
+    }
+}
+
+/***************************************************/
 
 int main()
 {
@@ -4215,6 +4235,7 @@ int main()
     test6813();
     test6859();
     test6910();
+    test6902();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
While the semantic analysis of function body, we should not do `fd->type->semantic()`, even if the type inference is necessary.
Because the result of safe/pure/nothrow inference should apply BEFORE `fd->type->semantic()`.

To fix <a href="http://d.puremagic.com/test-results/test_data.ghtml?dataid=113170">phobos unit test breaking in Windows</a>, we should apply <del><a href="https://github.com/D-Programming-Language/phobos/pull/322">phobos/pull/322</a></del> <a href="https://github.com/D-Programming-Language/phobos/pull/326">phobos/pull/326</a> at the same time.

requires: phobos git://github.com/9rnsr/phobos.git fix6902
