### PR TITLE
CTFE: support with + synchronized +6416+6901

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -884,7 +884,8 @@ void FuncDeclaration::semantic3(Scope *sc)
         sc2->sw = NULL;
         sc2->fes = fes;
         sc2->linkage = LINKd;
-        sc2->stc &= ~(STCauto | STCscope | STCstatic | STCabstract | STCdeprecated |
+        sc2->stc &= ~(STCauto | STCscope | STCstatic | STCabstract |
+                        STCdeprecated | STCoverride |
                         STC_TYPECTOR | STCfinal | STCtls | STCgshared | STCref |
                         STCproperty | STCsafe | STCtrusted | STCsystem);
         sc2->protection = PROTpublic;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -24,6 +24,7 @@
 #include "aggregate.h"
 #include "id.h"
 #include "utf.h"
+#include "attrib.h" // for AttribDeclaration
 
 #include "template.h"
 TemplateInstance *isSpeculativeFunction(FuncDeclaration *fd);
@@ -2055,7 +2056,13 @@ Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
     else if (declaration->isAttribDeclaration() ||
              declaration->isTemplateMixin() ||
              declaration->isTupleDeclaration())
-    {   // These can be made to work, too lazy now
+    {   // Check for static struct declarations, which aren't executable
+        AttribDeclaration *ad = declaration->isAttribDeclaration();
+        if (ad && ad->decl && ad->decl->dim == 1
+            && ad->decl->tdata()[0]->isAggregateDeclaration())
+            return NULL;    // static struct declaration. Nothing to do.
+
+        // These can be made to work, too lazy now
         error("Declaration %s is not yet implemented in CTFE", toChars());
         e = EXP_CANT_INTERPRET;
     }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4659,6 +4659,11 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
                 {   assert(((VarExp*)thisval)->var->isVarDeclaration());
                     thisval = ((VarExp*)thisval)->var->isVarDeclaration()->getValue();
                 }
+                if (thisval && thisval->op == TOKnull)
+                {
+                    error("function call through null class reference %s", pthis->toChars());
+                    return EXP_CANT_INTERPRET;
+                }
                 // Get the function from the vtable of the original class
                 assert(thisval && thisval->op == TOKclassreference);
                 ClassDeclaration *cd = ((ClassReferenceExp *)thisval)->originalClass();

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -6192,6 +6192,11 @@ Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
         }
     }
 #endif
+    if (nargs == 1 && !pthis &&
+        (fd->ident == Id::criticalenter || fd->ident == Id::criticalexit))
+    {   // Support synchronized{} as a no-op
+        return EXP_VOID_INTERPRET;
+    }
     if (!pthis)
     {
         size_t idlen = strlen(fd->ident->string);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2044,9 +2044,11 @@ Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
         }
         else if (s->isTupleDeclaration() && !v->init)
             e = NULL;
+        else if (v->isStatic() && !v->init)
+            e = NULL;   // Just ignore static variables which aren't read or written yet
         else
         {
-            error("Declaration %s is not yet implemented in CTFE", toChars());
+            error("Static variable %s cannot be modified at compile time", v->toChars());
             e = EXP_CANT_INTERPRET;
         }
     }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3388,4 +3388,99 @@ int testsFromEH()
 }
 static assert(testsFromEH());
 
-/****************************************************/
+/**************************************************
+    With + synchronized statements + bug 6901
+**************************************************/
+
+struct With1
+{
+    int a;
+    int b;
+}
+
+class Foo6
+{
+}
+
+class Foo32
+{
+   struct Bar
+   {
+	int x;
+   }
+}
+
+class Base56
+{
+    private string myfoo;
+    private string mybar;
+
+    // Get/set properties that will be overridden.
+    void foo(string s) { myfoo = s; }
+    string foo() { return myfoo; }
+
+    // Get/set properties that will not be overridden.
+    void bar(string s) { mybar = s; }
+    string bar() { return mybar; }
+}
+
+class Derived56: Base56
+{
+    alias Base56.foo foo; // Bring in Base56's foo getter.
+    override void foo(string s) { super.foo = s; } // Override foo setter.
+}
+
+
+int testwith()
+{
+    With1 x = With1(7);
+    with(x)
+    {
+        a = 2;
+    }
+    assert(x.a == 2);
+
+    // from test11.d
+    Foo6 foo6 = new Foo6();
+
+    with (foo6)
+    {
+        int xx;
+        xx = 4;
+    }
+    with (new Foo32)
+    {
+        Bar z;
+        z.x = 5;
+    }
+    Derived56 d = new Derived56;
+    with (d)
+    {
+        foo = "hi";
+        d.foo = "hi";
+        bar = "hi";
+        assert(foo == "hi");
+        assert(d.foo == "hi");
+        assert(bar == "hi");
+    }
+    int w = 7;
+    synchronized {
+        ++w;
+    }
+    assert(w == 8);
+    return 1;
+}
+
+static assert(testwith());
+
+/**************************************************
+    6416 static struct declaration
+**************************************************/
+
+static assert({
+    static struct S { int y = 7; }
+    S a;
+    a.y += 6;
+    assert(a.y == 13);
+    return true;
+}());


### PR DESCRIPTION
Adds support for with statements in CTFE,  and fixes two bugs:

6416 [CTFE] Declaration static struct is not yet implemented in CTFE
6901 wrong error "override cannot be applied to variable" in CTFE forward reference

Also allows synchronized statements in CTFE. It's a bit of a useless feature (since it's a no-op), but allowing it makes the spec shorter, and it's easier to implement it than to give a nice error message about it...

Although there are still some open CTFE feature-related bugs (unions, local structs with constructors, closures), these commits allow us to remove all the arbitrary rules from the spec. Ie, the rules become:
- must have source code 
- no static variables 
- no asm or non-portable casts
