### PR TITLE
Add 'Out of memory' error to backend

### DIFF
--- a/src/backend/outbuf.c
+++ b/src/backend/outbuf.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
+#include <stdio.h>
 
 #include "cc.h"
 
@@ -87,6 +88,12 @@ void Outbuffer::reserve(unsigned nbytes)
         else
             buf = (unsigned char *) malloc(len);
 #endif
+        if (!buf)
+        {
+            fprintf(stderr, "Fatal Error: Out of memory");
+            exit(EXIT_FAILURE);
+        }
+
         pend = buf + len;
         p = buf + used;
     }


### PR DESCRIPTION
The backend doesn't check the return value of 'realloc'. It should.

Context: I made a small change to CTFE, and it crashed running Phobos tests. I wasted a lot of time working out that it wasn't a segfault or a stack overflow, just an out of memory error.

BTW At present, Phobos unittests on Windows are very, very close to running out of memory. I think the cause is those std.datetime tests which were re-enabled.
