### PR TITLE
Issue 6330 - Cannot disable assignment to a struct.

### DIFF
--- a/src/parse.h
+++ b/src/parse.h
@@ -108,7 +108,7 @@ struct Parser : Lexer
     Type *parseType(Identifier **pident = NULL, TemplateParameters **tpl = NULL);
     Type *parseBasicType();
     Type *parseBasicType2(Type *t);
-    Type *parseDeclarator(Type *t, Identifier **pident, TemplateParameters **tpl = NULL, StorageClass storage_class = 0);
+    Type *parseDeclarator(Type *t, Identifier **pident, TemplateParameters **tpl = NULL, StorageClass storage_class = 0, int* pdisable = NULL);
     Dsymbols *parseDeclarations(StorageClass storage_class, unsigned char *comment);
     void parseContracts(FuncDeclaration *f);
     void checkDanglingElse(Loc elseloc);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4041,6 +4041,24 @@ void test6902()
 }
 
 /***************************************************/
+// 6330
+
+struct S6330
+{
+    void opAssign(S6330 s) @disable
+    {
+        assert(0);  // This fails.
+    }
+}
+
+void test6330()
+{
+    S6330 s;
+    S6330 s2;
+    static assert(!is(typeof({ s2 = s; })));
+}
+
+/***************************************************/
 
 int main()
 {
@@ -4236,6 +4254,7 @@ int main()
     test6859();
     test6910();
     test6902();
+    test6330();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6330

`STCdisable` is not parsed a part of `TypeFunction`.
I think it is better treating `STCdisable` specially in `parseDeclarator()` than adding new member into `TypeFunction` to keep `STCdisable`.
