### PR TITLE
Issue 4843 - Inconsistency in overloading ref vs. non-ref 

### DIFF
--- a/src/mars.h
+++ b/src/mars.h
@@ -398,7 +398,9 @@ enum MATCH
     MATCHnomatch,       // no match
     MATCHconvert,       // match with conversions
 #if DMDV2
+    MATCHconstref,      // match with conversion to const with lvalue as non-ref
     MATCHconst,         // match with conversion to const
+    MATCHref,           // match with lvalue as non-ref 
 #endif
     MATCHexact          // exact match
 };

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5414,6 +5414,16 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
                 m = MATCHconst;
             }
         }
+        // lvalues match non-ref or out parameters with lower match level
+        if (!(p->storageClass & (STCref | STCout)))
+        {
+            if (arg->isLvalue()) {
+                if (m == MATCHconst)
+                    m = MATCHconstref;
+                else
+                    m = (MATCHref < m) ? MATCHref : m;
+            }
+        }
 
         /* prefer matching the element type rather than the array
          * type when more arguments are present with T[]...

--- a/test/compilable/test70.d
+++ b/test/compilable/test70.d
@@ -1,0 +1,20 @@
+import std.stdio;
+struct S {};
+alias S T;
+//alias int T;
+
+T fun() { T t; return t; }
+const(T) constfun() { T t; return t; }
+void gun(const ref T t) { writeln("gun(const ref T)"); }
+void gun(ref T t) { writeln("gun(ref T)"); }
+void gun(const T t) { writeln("gun(const T)"); }
+void gun(T t) { writeln("gun(T)"); }
+void main()
+{
+	T t;
+	const T constt;
+	gun(constt);
+	gun(t);
+    gun(constfun);
+    gun(fun);
+}


### PR DESCRIPTION
[Issue 4843](http://d.puremagic.com/issues/show_bug.cgi?id=4843) - Inconsistency in overloading ref vs. non-ref 

Fix issue 4843 by using an additional match level for lvalues passed as non-ref parameters.
