### PR TITLE
minor error message improvement

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10789,7 +10789,7 @@ Expression *MinExp::semantic(Scope *sc)
         else if (t2->isintegral())
             e = scaleFactor(sc);
         else
-        {   error("incompatible types for minus");
+        {   error("can't subtract %s from pointer", t2->toChars());
             return new ErrorExp();
         }
     }


### PR DESCRIPTION
before:
foo.d(40): Error: incompatible types for minus

after:
foo.d(40): Error: can't subtract char[] from pointer
