### PR TITLE
don't let -wi override -w

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -531,7 +531,10 @@ int main(int argc, char *argv[])
             else if (strcmp(p + 1, "w") == 0)
                 global.params.warnings = 1;
             else if (strcmp(p + 1, "wi") == 0)
-                global.params.warnings = 2;
+            {
+                if (!global.params.warnings)
+                    global.params.warnings = 2;
+            }
             else if (strcmp(p + 1, "O") == 0)
                 global.params.optimize = 1;
             else if (p[1] == 'o')


### PR DESCRIPTION
Passing -w -wi will only turn on informational warnings.
Mixing -w and -wi happens e.g. through DFLAGS in dmd.conf.
