### PR TITLE
Ddwarf

### DIFF
--- a/src/backend/dwarf.h
+++ b/src/backend/dwarf.h
@@ -4,6 +4,8 @@
 
 /* ==================== Dwarf debug ======================= */
 
+#define USE_DWARF_D_EXTENSIONS
+
 void dwarf_initfile(const char *filename);
 void dwarf_termfile();
 void dwarf_initmodule(const char *filename, const char *modulename);

--- a/src/backend/dwarf.h
+++ b/src/backend/dwarf.h
@@ -4,7 +4,7 @@
 
 /* ==================== Dwarf debug ======================= */
 
-#define USE_DWARF_D_EXTENSIONS
+// #define USE_DWARF_D_EXTENSIONS
 
 void dwarf_initfile(const char *filename);
 void dwarf_termfile();

--- a/src/backend/dwarf2.h
+++ b/src/backend/dwarf2.h
@@ -65,9 +65,11 @@ enum
         DW_TAG_shared_type              = 0x40,
 
         // D programming language extensions
+#ifdef USE_DWARF_D_EXTENSIONS
         DW_TAG_darray_type              = 0x41,
         DW_TAG_aarray_type              = 0x42,
         DW_TAG_delegate_type            = 0x43,
+#endif
 
         DW_TAG_lo_user                  = 0x4080,
         DW_TAG_hi_user                  = 0xFFFF,


### PR DESCRIPTION
- emit debug infos for dynamic arrays as
  struct _Array_T { size_t length; T\* ptr; }
- emit debug infos for delegates as
  struct _Delegate{ void\* ctxptr; Function\* funcptr; }
- emit debug infos for aarrays as
  struct _AArray_KeyT_ValueT { void\* ptr; }
- remove D DWARF extensions
- remove dead code in toctype.c which changed the ctype to
  structs, the backend could not handle them
- emit same debug infos for -gc as the info is common C

Specifically the _Array_T type will hook to gdb's D support.
That is with gdb >= 2010-04-29 this will add full dynamic
array printing support.

The function pointer in _Delegate is correctly typed and
will be resolved to the actual symbol name during debugging.

For AAs we can't really add debug infos as their implementation
is hidden in druntime.
