### PR TITLE
Issue 3733 - Overloading on 'this' modifiers fails with implicit 'this'

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8317,13 +8317,7 @@ Lagain:
         assert(f);
 
         if (ve->hasOverloads)
-            f = f->overloadResolve(loc, NULL, arguments);
-        checkDeprecated(sc, f);
-#if DMDV2
-        checkPurity(sc, f);
-        checkSafety(sc, f);
-#endif
-        f->checkNestedReference(sc, loc);
+            f = f->overloadResolve(loc, NULL, arguments, 2);
 
         if (f->needThis())
         {
@@ -8342,6 +8336,12 @@ Lagain:
             }
         }
 
+        checkDeprecated(sc, f);
+#if DMDV2
+        checkPurity(sc, f);
+        checkSafety(sc, f);
+#endif
+        f->checkNestedReference(sc, loc);
         accessCheck(loc, sc, NULL, f);
 
         ethis = NULL;

--- a/src/expression.c
+++ b/src/expression.c
@@ -8332,7 +8332,7 @@ Lagain:
                 // Supply an implicit 'this', as in
                 //    this.ident
 
-                e1 = new DotVarExp(loc, (new ThisExp(loc))->semantic(sc), f);
+                e1 = new DotVarExp(loc, (new ThisExp(loc))->semantic(sc), ve->var);
                 goto Lagain;
             }
             else if (!sc->intypeof && !sc->getStructClassScope())

--- a/src/func.c
+++ b/src/func.c
@@ -2316,6 +2316,8 @@ FuncDeclaration *FuncDeclaration::overloadExactMatch(Type *t)
 
 /********************************************
  * Decide which function matches the arguments best.
+ *      flags           1: do not issue error message on no match, just return NULL
+ *                      2: do not issue error on ambiguous matches and need explicit this
  */
 
 struct Param2
@@ -2481,6 +2483,8 @@ if (arguments)
         }
         else
         {
+            if ((flags & 2) && m.lastf->needThis() && !ethis)
+                return m.lastf;
 #if 1
             TypeFunction *t1 = (TypeFunction *)m.lastf->type;
             TypeFunction *t2 = (TypeFunction *)m.nextf->type;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3902,6 +3902,22 @@ void test2774()
 }
 
 /***************************************************/
+// 3733
+
+class C3733
+{
+    int foo()        { return 1; }
+    int foo() shared { return 2; }
+
+    int bar()        { return foo(); }
+}
+void test3733()
+{
+    auto c = new C3733();
+    assert(c.bar() == 1);
+}
+
+/***************************************************/
 // 4392
 
 class C4392
@@ -5571,6 +5587,7 @@ int main()
     test6335();
     test6228();
     test2774();
+    test3733();
     test4392();
     test6220();
     test5799();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3902,6 +3902,22 @@ void test2774()
 }
 
 /***************************************************/
+// 4392
+
+class C4392
+{
+    int foo() const { return 1; }
+    int foo()       { return 2; }
+
+    int bar() const { return foo(); }
+}
+void test4392()
+{
+    auto c = new C4392();
+    assert(c.bar() == 1);
+}
+
+/***************************************************/
 // 6220
 
 void test6220() {
@@ -5555,6 +5571,7 @@ int main()
     test6335();
     test6228();
     test2774();
+    test4392();
     test6220();
     test5799();
     test157();


### PR DESCRIPTION
4392 and 3733 are similar, but are bit different.
- <a href="http://d.puremagic.com/issues/show_bug.cgi?id=4392">Issue 4392</a> - Problems with const/non-const overloads of member functions
  
  In `CallExp::semantic` with `e1->op == TOKvar`, the head of overloads is unintentionally changed.
- <a href="http://d.puremagic.com/issues/show_bug.cgi?id=3733">Issue 3733</a> - Overloading on 'this' modifiers fails with implicit 'this'
  
  Between shared and non-shared overloading, `FuncDeclaration::overloadResolve` cannot determine the actual callee if `ethis` is `NULL`. In this case we should defer the resolution until after adding 'this'
