### PR TITLE
Issue 5933 & 7159 - Resolve forward reference to auto-return member function

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -632,6 +632,7 @@ struct FuncDeclaration : Declaration
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
+    bool functionSemantic(Scope *sc);
     // called from semantic3
     void varArgs(Scope *sc, TypeFunction*, VarDeclaration *&, VarDeclaration *&);
     VarDeclaration *declareThis(Scope *sc, AggregateDeclaration *ad);

--- a/src/func.c
+++ b/src/func.c
@@ -1681,6 +1681,49 @@ void FuncDeclaration::semantic3(Scope *sc)
     //fflush(stdout);
 }
 
+bool FuncDeclaration::functionSemantic(Scope *sc)
+{
+    if (!originalType && scope)     // semantic not yet run
+    {
+        unsigned oldgag = global.gag;
+        if (global.isSpeculativeGagging() && !isSpeculative())
+            global.gag = 0;
+        semantic(scope);
+        global.gag = oldgag;
+    }
+
+    // if inferring return type, sematic3 needs to be run
+    if (scope && (inferRetType && type && !type->nextOf() ||
+                  getFuncTemplateDecl(this)))
+    {
+        TemplateInstance *spec = isSpeculative();
+        int olderrs = global.errors;
+        // If it isn't speculative, we need to show errors
+        unsigned oldgag = global.gag;
+        if (global.gag && !spec)
+            global.gag = 0;
+        semantic3(scope);
+        global.gag = oldgag;
+        // Update the template instantiation with the number
+        // of errors which occured.
+        if (spec && global.errors != olderrs)
+            spec->errors = global.errors - olderrs;
+    }
+
+    if (isUnitTestDeclaration())
+    {
+        error("cannot call unittest function %s", toChars());
+        return false;
+    }
+    if (!type->deco)
+    {
+        error("forward reference to %s", toChars());
+        return false;
+    }
+
+    return true;
+}
+
 void FuncDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     //printf("FuncDeclaration::toCBuffer() '%s'\n", toChars());

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4862,6 +4862,18 @@ void test7150()
 }
 
 /***************************************************/
+// 7159
+
+class HomeController7159 {
+    void* foo() {
+        return cast(void*)&HomeController7159.displayDefault;
+    }
+    auto displayDefault() {
+        return 1;
+    }
+}
+
+/***************************************************/
 // 7160
 
 class HomeController {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4219,6 +4219,37 @@ void test5696()
 }
 
 /***************************************************/
+// 5933
+
+int dummyfunc();
+alias typeof(dummyfunc) FuncType;
+
+struct S5933a { auto x() { return 0; } }
+static assert(is(typeof(&S5933a.init.x) == int delegate()));
+
+struct S5933b { auto x() { return 0; } }
+static assert(is(typeof(S5933b.init.x) == FuncType));
+
+struct S5933c { auto x() { return 0; } }
+static assert(is(typeof(&S5933c.x) == int function()));
+
+struct S5933d { auto x() { return 0; } }
+static assert(is(typeof(S5933d.x) == FuncType));
+
+
+class C5933a { auto x() { return 0; } }
+static assert(is(typeof(&(new C5933b()).x) == int delegate()));
+
+class C5933b { auto x() { return 0; } }
+static assert(is(typeof((new C5933b()).x) == FuncType));
+
+class C5933c { auto x() { return 0; } }
+static assert(is(typeof(&C5933c.x) == int function()));
+
+class C5933d { auto x() { return 0; } }
+static assert(is(typeof(C5933d.x) == FuncType));
+
+/***************************************************/
 // 6084
 
 template TypeTuple6084(T...){ alias T TypeTuple6084; }


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5933">Issue 5933</a> - Cannot retrieve the return type of an auto-return member function

Bug 5933 is synonym of <a href="http://d.puremagic.com/issues/show_bug.cgi?id=2810">bug 2810</a>, and the fixing way is also almost same.

<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7159">Issue 7159</a> - Forward reference when casting auto return method
