### PR TITLE
Issue 4838 - Cannot declare a delegate variable for const member functions

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2540,10 +2540,14 @@ Type *Parser::parseBasicType2(Type *t)
                 arguments = parseParameters(&varargs);
 
                 StorageClass stc = parsePostfix();
-                if (stc & (STCconst | STCimmutable | STCshared | STCwild))
-                    error("const/immutable/shared/inout attributes are only valid for non-static member functions");
-
                 TypeFunction *tf = new TypeFunction(arguments, t, varargs, linkage, stc);
+                if (stc & (STCconst | STCimmutable | STCshared | STCwild))
+                {
+                    if (save == TOKfunction)
+                        error("const/immutable/shared/inout attributes are only valid for non-static member functions");
+                    else
+                        tf = (TypeFunction *)tf->addSTC(stc);
+                }
 
                 if (save == TOKdelegate)
                     t = new TypeDelegate(tf);

--- a/test/compilable/testfptr.d
+++ b/test/compilable/testfptr.d
@@ -378,6 +378,27 @@ void bug3833dg()
     static assert( is(typeof( arr ) == typeof(func)[]) );
 }
 
+void bug4838()
+{
+    void delegate() const dgc;
+    static assert(typeof(dgc).stringof == "void delegate() const");
+
+    void delegate() immutable dgi;
+    static assert(typeof(dgi).stringof == "void delegate() immutable");
+
+    void delegate() shared dgs;
+    static assert(typeof(dgs).stringof == "void delegate() shared");
+
+    void delegate() shared const dgsc;
+    static assert(typeof(dgsc).stringof == "void delegate() shared const");
+
+    void delegate() inout dgw;
+    static assert(typeof(dgw).stringof == "void delegate() inout");
+
+    void delegate() shared inout dgsw;
+    static assert(typeof(dgsw).stringof == "void delegate() shared inout");
+}
+
 void main()
 {
     static assert(is(typeof(&main) P : U*, U));

--- a/test/fail_compilation/test4838.d
+++ b/test/fail_compilation/test4838.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test4838.d(13): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
+fail_compilation/test4838.d(14): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
+fail_compilation/test4838.d(15): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
+fail_compilation/test4838.d(16): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
+fail_compilation/test4838.d(17): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
+fail_compilation/test4838.d(18): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
+---
+*/
+
+void function() const fpc;
+void function() immutable fpi;
+void function() shared fps;
+void function() shared const fpsc;
+void function() inout fpw;
+void function() shared inout fpsw;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=4838

Allow postfix const/immutable/shared/inout qualifiers for delegate types.
