### PR TITLE
Bug7030

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -133,8 +133,7 @@ void cpp_mangle_name(OutBuffer *buf, CppMangleState *cms, Dsymbol *s)
         {
             s->error("C++ static variables not supported");
         }
-        else
-        if (fd->isConst())
+        else if (fd->type->isConst())
             buf->writeByte('K');
 
         prefix_name(buf, cms, p);

--- a/test/compilable/test7030.d
+++ b/test/compilable/test7030.d
@@ -1,0 +1,19 @@
+extern(C++)
+{
+    struct S
+    {
+        void foo(int) const;
+        void bar(int);
+    }
+}
+
+version (OSX)
+{
+    static assert(S.foo.mangleof == "__ZNK1S3fooEi");
+    static assert(S.bar.mangleof == "__ZN1S3barEi");
+}
+else version (Posix)
+{
+    static assert(S.foo.mangleof == "_ZNK1S3fooEi");
+    static assert(S.bar.mangleof == "_ZN1S3barEi");
+}


### PR DESCRIPTION
- look for const method type when mangling C++
  previously it only took the storage class of the function declaration

http://d.puremagic.com/issues/show_bug.cgi?id=7030
