### PR TITLE
Issue 6332 & 6356 & 6963 - Ignite pure/nothrow inference for template function

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1523,8 +1523,7 @@ Lnomatch:
             }
         }
         else if (storage_class & (STCconst | STCimmutable | STCmanifest) ||
-                 type->isConst() || type->isImmutable() ||
-                 parent->isAggregateDeclaration())
+                 type->isConst() || type->isImmutable())
         {
             /* Because we may need the results of a const declaration in a
              * subsequent type, such as an array dimension, before semantic2()
@@ -1633,6 +1632,11 @@ Lnomatch:
                 else
                     init = i2;          // no errors, keep result
             }
+        }
+        else if (parent->isAggregateDeclaration())
+        {
+            scope = new Scope(*sc);
+            scope->setNoFree();
         }
         sc = sc->pop();
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -974,7 +974,7 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                         t = t->semantic(loc, sc);
                         bool isSafe = fd ? fd->isSafe() : tf->trust == TRUSTsafe;
                         VarDeclaration *v = new VarDeclaration(loc, t, id,
-                            isSafe ? NULL : new VoidInitializer(loc));
+                            (isSafe && sc->func) ? NULL : new VoidInitializer(loc));
                         v->storage_class |= STCctfe;
                         v->semantic(sc);
                         v->parent = sc->parent;

--- a/src/init.c
+++ b/src/init.c
@@ -354,7 +354,20 @@ Expression *StructInitializer::toExpression()
             if (!(*elements)[i])
             {   // Default initialize
                 if (vd->init)
-                    (*elements)[i] = vd->init->toExpression();
+                {
+                    if (vd->scope)
+                    {   // Do deferred semantic analysis
+                        Initializer *i2 = vd->init->syntaxCopy();
+                        i2 = i2->semantic(vd->scope, vd->type, INITinterpret);
+                        (*elements)[i] = i2->toExpression();
+                        if (!global.gag)
+                        {   vd->scope = NULL;
+                            vd->init = i2;  // save result
+                        }
+                    }
+                    else
+                        (*elements)[i] = vd->init->toExpression();
+                }
                 else
                     (*elements)[i] = vd->type->defaultInit();
             }

--- a/src/template.c
+++ b/src/template.c
@@ -2162,6 +2162,16 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
         if (tf->next)
             fd_best->type = tf->semantic(loc, sc);
     }
+    if (fd_best->scope)
+    {
+        TemplateInstance *spec = fd_best->isSpeculative();
+        int olderrs = global.errors;
+        fd_best->semantic3(fd_best->scope);
+        // Update the template instantiation with the number
+        // of errors which occured.
+        if (spec && global.errors != olderrs)
+            spec->errors = global.errors - olderrs;
+    }
 
     return fd_best;
 

--- a/test/compilable/bug6963.d
+++ b/test/compilable/bug6963.d
@@ -1,0 +1,73 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+output foo: 1e: pure nothrow @safe void(int x)
+output foo: 3e: pure nothrow @safe void(int x)
+---
+*/
+
+alias void function(int) pure nothrow @safe FuncPtrType;
+
+void foo1a(X)(X x) {}
+void foo1b(X)(X x) {}
+void foo1c(X)(X x) {}
+void foo1d(X)(X x) {}
+void foo1e(X)(X x) {}
+
+// module level declaration with type inference
+auto fptr1 = &foo1a!int;
+static assert(is(typeof(fptr1) == FuncPtrType));
+
+// array initializer
+auto fptrlist1 = [&foo1b!int];
+static assert(is(typeof(fptrlist1) == FuncPtrType[]));
+
+// static assert
+static assert(is(typeof(&foo1c!int) == FuncPtrType));
+
+// static if
+static if(is(typeof(&foo1d!int) PF))
+    static assert(is(PF == FuncPtrType));
+else
+    static assert(0);
+
+// pragma test
+pragma(msg, "output foo: 1e: ", typeof(foo1e!int).stringof);
+
+void foo2a(X)(X x) {}
+void foo2b(X)(X x) {}
+void foo2c(X)(X x) {}
+
+FuncPtrType fptr3 = &foo2a!int;     // most similar to original issue
+
+FuncPtrType[] fptrlist3 = [&foo2b!int];
+
+struct S{ FuncPtrType fp; }
+S s = { &foo2c!int };
+
+void foo3a(X)(X x) {}
+void foo3b(X)(X x) {}
+void foo3c(X)(X x) {}
+void foo3d(X)(X x) {}
+void foo3e(X)(X x) {}
+
+void main()
+{
+    auto fptr2 = &foo3a!int;
+    static assert(is(typeof(fptr2) == FuncPtrType));
+
+    auto fptrlist2 = [&foo3b!int];
+    static assert(is(typeof(fptrlist2) == FuncPtrType[]));
+
+    static assert(is(typeof(&foo1c!int) == FuncPtrType));
+
+    static if(is(typeof(&foo1d!int) PF))
+        static assert(is(PF == FuncPtrType));
+    else
+        static assert(0);
+
+    pragma(msg, "output foo: 3e: ", typeof(foo3e!int));
+}

--- a/test/runnable/template4.d
+++ b/test/runnable/template4.d
@@ -1030,7 +1030,7 @@ struct T7589(T)
 static assert(!__traits(compiles, T7589!(int)));
 
 int bug7589b(T)() @safe { int *p; *(p + 8) = 6; }
-static assert(__traits(compiles, bug7589b!(int)()+7 ));
+static assert(!__traits(compiles, bug7589b!(int)()+7 ));
 
 
 /*********************************************************/

--- a/test/runnable/test7452.d
+++ b/test/runnable/test7452.d
@@ -49,6 +49,9 @@ void g7452c() pure nothrow @safe
 
 auto f6332a()() { return 1; }
 int f6332b()() { return 1; }
+
+alias f6332a!() F6332a;
+
 void g6332() pure nothrow @safe
 {
     auto x = f6332b();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4770,6 +4770,26 @@ void test6056()
 }
 
 /***************************************************/
+// 6356
+
+int f6356()(int a)
+{
+    return a*a;
+}
+
+alias f6356!() g6356;     // comment this out to eliminate the errors
+
+pure nothrow @safe int i6356()
+{
+    return f6356(1);
+}
+
+void test6356()
+{
+    assert(i6356() == 1);
+}
+
+/***************************************************/
 // 7108
 
 static assert(!__traits(hasMember, int, "x"));
@@ -5701,6 +5721,7 @@ int main()
     test2856();
     test3091();
     test6056();
+    test6356();
     test7073();
     test7150();
     test7160();


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6332">Issue 6332</a> - Auto-return function cannot be inferred as @safe
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6356">Issue 6356</a> - Pure/nothrow/@safe-inference failed for a template function if it is instantiated without evaluating at the global scope
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6963">Issue 6963</a> - pure/nothrow inference doesn't work for function pointers

Call semantic3() of a template function to ignite attribute inference.
And resolve forward reference in NewExp.
