### PR TITLE
Clean symbol fixlist after outputting

### DIFF
--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -687,6 +687,7 @@ STATIC int outfixlist_dg(void *parameter, void *pkey, void *pvalue)
 #endif
         }
     }
+    s->Sxtrnnum = 0;
     return 0;
 }
 
@@ -700,8 +701,8 @@ void outfixlist()
         fixlist::nodel--;
 #if TERMCODE
         delete fixlist::start;
-        fixlist::start = NULL;
 #endif
+        fixlist::start = NULL;
     }
 }
 

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -921,6 +921,7 @@ void *elf_renumbersyms()
                 {
                     unsigned t = ELF64_R_TYPE(rel->r_info);
                     unsigned si = ELF64_R_SYM(rel->r_info);
+                    assert(si < symbol_idx);
                     rel->r_info = ELF64_R_INFO(sym_map[si],t);
                     rel++;
                 }
@@ -933,6 +934,7 @@ void *elf_renumbersyms()
                 {
                     unsigned t = ELF32_R_TYPE(rel->r_info);
                     unsigned si = ELF32_R_IDX(rel->r_info);
+                    assert(si < symbol_idx);
                     rel->r_info = ELF32_R_INFO(sym_map[si],t);
                     rel++;
                 }


### PR DESCRIPTION
- Symbol Sxtrnnum indices and the fixlist need to be reset while outputting
  or they will contain garbage with multilib builds.
