### PR TITLE
Added .DS_Store to .gitignore for OSX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src/idgen.exe
 src/dmd.exe
 src/impcnvgen.exe
 *.map
+.DS_Store


### PR DESCRIPTION
Added .DS_Store to the ignore list.

http://en.wikipedia.org/wiki/.DS_Store

> .DS_Store (Desktop Services Store) is a hidden file created by Apple Inc.'s Mac OS X operating system to store custom attributes of a folder such as the position of icons or the choice of a background image."
