### PR TITLE
Fix headinout conversion

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3937,16 +3937,12 @@ MATCH TypeDArray::implicitConvTo(Type *to)
         if (!MODimplicitConv(next->mod, ta->next->mod))
             return MATCHnomatch;        // not const-compatible
 
-        if (!MODimplicitConv(mod, ta->mod))
-        {
-            if ((mod & MODwild) != (to->mod & MODwild))
-            {
-                if (mod & MODwild)
-                    return MATCHnomatch;
-                if (!(next->mod & MODwild))
-                    return MATCHnomatch;
-            }
-        }
+        // Check head inout conversion:
+        //       T [] -> inout(const(T)[])
+        // const(T)[] -> inout(const(T)[])
+        if (isMutable() && ta->isWild())
+            if ((next->isMutable() || next->isConst()) && ta->next->isConst())
+                return MATCHnomatch;
 
         /* Allow conversion to void[]
          */
@@ -4347,15 +4343,12 @@ MATCH TypeAArray::implicitConvTo(Type *to)
         if (!MODimplicitConv(index->mod, ta->index->mod))
             return MATCHnomatch;        // not const-compatible
 
-        if (!MODimplicitConv(mod, ta->mod))
-        {   if ((mod & MODwild) != (to->mod & MODwild))
-            {
-                if (mod & MODwild)
-                    return MATCHnomatch;
-                if (!(next->mod & MODwild))
-                    return MATCHnomatch;
-            }
-        }
+        // Check head inout conversion:
+        //       V [K] -> inout(const(V)[K])
+        // const(V)[K] -> inout(const(V)[K])
+        if (isMutable() && ta->isWild())
+            if ((next->isMutable() || next->isConst()) && ta->next->isConst())
+                return MATCHnomatch;
 
         MATCH m = next->constConv(ta->next);
         MATCH mi = index->constConv(ta->index);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4481,6 +4481,13 @@ MATCH TypePointer::implicitConvTo(Type *to)
         if (!MODimplicitConv(next->mod, tp->next->mod))
             return MATCHnomatch;        // not const-compatible
 
+        // Check head inout conversion:
+        //       T * -> inout(const(T)*)
+        // const(T)* -> inout(const(T)*)
+        if (isMutable() && tp->isWild())
+            if ((next->isMutable() || next->isConst()) && tp->next->isConst())
+                return MATCHnomatch;
+
         /* Alloc conversion to void*
          */
         if (next->ty != Tvoid && tp->next->ty == Tvoid)

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2034,24 +2034,82 @@ static assert(is( inout(immutable(shared(T))) == immutable(T) ));
 /************************************/
 // 6912
 
-@property inout(int) testinout(string code)(inout(int) _dummy=0){ mixin(code); return _dummy; }
-static assert( is(typeof(testinout!q{ inout(int) wda = 2; }))); // unittest of testinout function
-
 void test6912()
 {
-    static assert(!is(typeof(testinout!q{           int [] mda; inout(          int []) wda = mda; })));
-    static assert(!is(typeof(testinout!q{           int [] mda; inout(    const(int)[]) wda = mda; })));
-    static assert(!is(typeof(testinout!q{     const(int)[] cda; inout(    const(int)[]) wda = cda; })));
-    static assert(!is(typeof(testinout!q{ immutable(int)[] ida; inout(    const(int)[]) wda = ida; })));
-    static assert(!is(typeof(testinout!q{ immutable(int)[] ida; inout(immutable(int)[]) wda = ida; })));
+    //                 From                      To
+    static assert( is(                 int []  :                 int []  ));
+    static assert(!is(           inout(int []) :                 int []  ));
+    static assert(!is(                 int []  :           inout(int []) ));
+    static assert( is(           inout(int []) :           inout(int []) ));
 
-    static assert(!is(typeof(testinout!q{           int [int] maa; inout(          int [int]) waa = maa; })));
-    static assert(!is(typeof(testinout!q{           int [int] maa; inout(    const(int)[int]) waa = maa; })));
-    static assert(!is(typeof(testinout!q{     const(int)[int] caa; inout(    const(int)[int]) waa = caa; })));
-    static assert(!is(typeof(testinout!q{ immutable(int)[int] iaa; inout(    const(int)[int]) waa = iaa; })));
-    static assert(!is(typeof(testinout!q{ immutable(int)[int] iaa; inout(immutable(int)[int]) waa = iaa; })));
+    static assert( is(                 int []  :           const(int)[]  ));
+    static assert( is(           inout(int []) :           const(int)[]  ));
+    static assert(!is(                 int []  :     inout(const(int)[]) ));
+    static assert( is(           inout(int []) :     inout(const(int)[]) ));
 
-    static assert( is(typeof(testinout!q{ inout(int[]) x; const(int[]) y = x; })));
+    static assert( is(           const(int)[]  :           const(int)[]  ));
+    static assert( is(     inout(const(int)[]) :           const(int)[]  ));
+    static assert(!is(           const(int)[]  :     inout(const(int)[]) ));
+    static assert( is(     inout(const(int)[]) :     inout(const(int)[]) ));
+
+    static assert( is(       immutable(int)[]  :           const(int)[]  ));
+    static assert( is( inout(immutable(int)[]) :           const(int)[]  ));
+    static assert( is(       immutable(int)[]  :     inout(const(int)[]) ));
+    static assert( is( inout(immutable(int)[]) :     inout(const(int)[]) ));
+
+    static assert( is(       immutable(int)[]  :       immutable(int)[]  ));
+    static assert( is( inout(immutable(int)[]) :       immutable(int)[]  ));
+    static assert( is(       immutable(int)[]  : inout(immutable(int)[]) ));
+    static assert( is( inout(immutable(int)[]) : inout(immutable(int)[]) ));
+
+    static assert( is(           inout(int)[]  :           inout(int)[]  ));
+    static assert( is(     inout(inout(int)[]) :           inout(int)[]  ));
+    static assert( is(           inout(int)[]  :     inout(inout(int)[]) ));
+    static assert( is(     inout(inout(int)[]) :     inout(inout(int)[]) ));
+
+    static assert( is(           inout(int)[]  :           const(int)[]  ));
+    static assert( is(     inout(inout(int)[]) :           const(int)[]  ));
+    static assert( is(           inout(int)[]  :     inout(const(int)[]) ));
+    static assert( is(     inout(inout(int)[]) :     inout(const(int)[]) ));
+
+    //                 From                         To
+    static assert( is(                 int [int]  :                 int [int]  ));
+    static assert(!is(           inout(int [int]) :                 int [int]  ));
+    static assert(!is(                 int [int]  :           inout(int [int]) ));
+    static assert( is(           inout(int [int]) :           inout(int [int]) ));
+
+    static assert( is(                 int [int]  :           const(int)[int]  ));
+    static assert( is(           inout(int [int]) :           const(int)[int]  ));
+    static assert(!is(                 int [int]  :     inout(const(int)[int]) ));
+    static assert( is(           inout(int [int]) :     inout(const(int)[int]) ));
+
+    static assert( is(           const(int)[int]  :           const(int)[int]  ));
+    static assert( is(     inout(const(int)[int]) :           const(int)[int]  ));
+    static assert(!is(           const(int)[int]  :     inout(const(int)[int]) ));
+    static assert( is(     inout(const(int)[int]) :     inout(const(int)[int]) ));
+
+    static assert( is(       immutable(int)[int]  :           const(int)[int]  ));
+    static assert( is( inout(immutable(int)[int]) :           const(int)[int]  ));
+    static assert( is(       immutable(int)[int]  :     inout(const(int)[int]) ));
+    static assert( is( inout(immutable(int)[int]) :     inout(const(int)[int]) ));
+
+    static assert( is(       immutable(int)[int]  :       immutable(int)[int]  ));
+    static assert( is( inout(immutable(int)[int]) :       immutable(int)[int]  ));
+    static assert( is(       immutable(int)[int]  : inout(immutable(int)[int]) ));
+    static assert( is( inout(immutable(int)[int]) : inout(immutable(int)[int]) ));
+
+    static assert( is(           inout(int)[int]  :           inout(int)[int]  ));
+    static assert( is(     inout(inout(int)[int]) :           inout(int)[int]  ));
+    static assert( is(           inout(int)[int]  :     inout(inout(int)[int]) ));
+    static assert( is(     inout(inout(int)[int]) :     inout(inout(int)[int]) ));
+
+    static assert( is(           inout(int)[int]  :           const(int)[int]  ));
+    static assert( is(     inout(inout(int)[int]) :           const(int)[int]  ));
+    static assert( is(           inout(int)[int]  :     inout(const(int)[int]) ));
+    static assert( is(     inout(inout(int)[int]) :     inout(const(int)[int]) ));
+
+    // Regression check
+    static assert( is( const(int)[] : const(int[]) ) );
 }
 
 /************************************/
@@ -2062,18 +2120,6 @@ static assert((const(shared(int[])[])).stringof != "const(shared(const(int[]))[]
 
 static assert((inout(shared(int[])[])).stringof == "inout(shared(int[])[])");	// fail
 static assert((inout(shared(int[])[])).stringof != "inout(shared(inout(int[]))[])");	// fail
-
-/************************************/
-
-const(int[]) bar89(const(int)[] x)
-{
-    return x;
-}
-
-inout(int[]) foo89(inout(int)[] x)
-{
-    return x;
-}
 
 /************************************/
 

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2110,6 +2110,42 @@ void test6912()
 
     // Regression check
     static assert( is( const(int)[] : const(int[]) ) );
+
+    //                 From                     To
+    static assert( is(                 int *  :                 int *  ));
+    static assert(!is(           inout(int *) :                 int *  ));
+    static assert(!is(                 int *  :           inout(int *) ));
+    static assert( is(           inout(int *) :           inout(int *) ));
+
+    static assert( is(                 int *  :           const(int)*  ));
+    static assert( is(           inout(int *) :           const(int)*  ));
+    static assert(!is(                 int *  :     inout(const(int)*) ));
+    static assert( is(           inout(int *) :     inout(const(int)*) ));
+
+    static assert( is(           const(int)*  :           const(int)*  ));
+    static assert( is(     inout(const(int)*) :           const(int)*  ));
+    static assert(!is(           const(int)*  :     inout(const(int)*) ));
+    static assert( is(     inout(const(int)*) :     inout(const(int)*) ));
+
+    static assert( is(       immutable(int)*  :           const(int)*  ));
+    static assert( is( inout(immutable(int)*) :           const(int)*  ));
+    static assert( is(       immutable(int)*  :     inout(const(int)*) ));
+    static assert( is( inout(immutable(int)*) :     inout(const(int)*) ));
+
+    static assert( is(       immutable(int)*  :       immutable(int)*  ));
+    static assert( is( inout(immutable(int)*) :       immutable(int)*  ));
+    static assert( is(       immutable(int)*  : inout(immutable(int)*) ));
+    static assert( is( inout(immutable(int)*) : inout(immutable(int)*) ));
+
+    static assert( is(           inout(int)*  :           inout(int)*  ));
+    static assert( is(     inout(inout(int)*) :           inout(int)*  ));
+    static assert( is(           inout(int)*  :     inout(inout(int)*) ));
+    static assert( is(     inout(inout(int)*) :     inout(inout(int)*) ));
+
+    static assert( is(           inout(int)*  :           const(int)*  ));
+    static assert( is(     inout(inout(int)*) :           const(int)*  ));
+    static assert( is(           inout(int)*  :     inout(const(int)*) ));
+    static assert( is(     inout(inout(int)*) :     inout(const(int)*) ));
 }
 
 /************************************/


### PR DESCRIPTION
This change fixes 6912 with the correct way.
I've also added exhaustive tests.

And, I've added pointer type fix that not mentioned by issue 6912 report.
Dynamic array type, associative array type, and pointer type are the three reference type that should consider transitive modifier in D.
We can check this "head inout conversion" issue with the same way.
