### PR TITLE
Issue 7091 - ICE in Statement::blockExit

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -433,6 +433,12 @@ Statement *CompileStatement::semantic(Scope *sc)
     return s->semantic(sc);
 }
 
+int CompileStatement::blockExit(bool mustNotThrow)
+{
+    assert(global.errors);
+    return BEfallthru;
+}
+
 
 /******************************** CompoundStatement ***************************/
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -178,6 +178,7 @@ struct CompileStatement : Statement
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statements *flatten(Scope *sc);
     Statement *semantic(Scope *sc);
+    int blockExit(bool mustNotThrow);
 };
 
 struct CompoundStatement : Statement


### PR DESCRIPTION
In error path, `CompileStatement` might be staying in AST.
Add `CompileStatement::blockExit()` for the case.
