### PR TITLE
Remove top const from dynamic array types and pointer types in IFTI.

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1222,6 +1222,14 @@ Lretry:
                     argtype = argtype->invariantOf();
                 }
             }
+
+            /* Remove top const for dynamic array types and pointer types
+             */
+            if ((argtype->ty == Tarray || argtype->ty == Tpointer) &&
+                !argtype->isMutable())
+            {
+                argtype = argtype->mutableOf();
+            }
 #endif
 
             MATCH m;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -534,6 +534,30 @@ static assert(pow10_2550!(0) == 1);
 
 /**********************************/
 
+void foo10(T)(T prm)
+{
+    pragma(msg, T);
+    static assert(is(T == const(int)[]));
+}
+void bar10(T)(T prm)
+{
+    pragma(msg, T);
+    static assert(is(T == const(int)*));
+}
+void test10()
+{
+    const a = [1,2,3];
+    static assert(is(typeof(a) == const(int[])));
+    foo10(a);
+
+    int n;
+    const p = &n;
+    static assert(is(typeof(p) == const(int*)));
+    bar10(p);
+}
+
+/**********************************/
+
 int main()
 {
     test1();
@@ -558,6 +582,7 @@ int main()
     test2778get();
     test6994();
     test3467();
+    test10();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
The change Walter and Andrei decided.

All test suites pass, and following original sample also compiles.

``` d
import std.algorithm;
void main() {
    const arr = [1, 2, 3];
    assert(reduce!"a*b"(arr) == 6);
}
```
