### PR TITLE
Issue 6872 - Breaking type parsing of shared(inout(int)[])

### DIFF
--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2158,6 +2158,14 @@ static assert((inout(shared(int[])[])).stringof == "inout(shared(int[])[])");	//
 static assert((inout(shared(int[])[])).stringof != "inout(shared(inout(int[]))[])");	// fail
 
 /************************************/
+// 6872
+
+static assert((shared(inout(int)[])).stringof == "shared(inout(int)[])");
+static assert((shared(inout(const(int)[]))).stringof == "shared(inout(const(int)[]))");
+static assert((shared(inout(const(int)[])[])).stringof == "shared(inout(const(int)[])[])");
+static assert((shared(inout(const(immutable(int)[])[])[])).stringof == "shared(inout(const(immutable(int)[])[])[])");
+
+/************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6872

I've separated this patch from #486 as a single pull request.
Because it is more urgent problem and there is no workaround.
