### PR TITLE
Issue 3091 & 6873 - Make "StorageClasses Type" syntax available in some where

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4498,18 +4498,23 @@ int Parser::isDeclaration(Token *t, int needId, enum TOK endtok, Token **pt)
     int haveId = 0;
 
 #if DMDV2
-    if ((t->value == TOKconst ||
-         t->value == TOKinvariant ||
-         t->value == TOKimmutable ||
-         t->value == TOKwild ||
-         t->value == TOKshared) &&
-        peek(t)->value != TOKlparen)
-    {   /* const type
-         * immutable type
-         * shared type
-         * wild type
-         */
-        t = peek(t);
+    while (1)
+    {
+        if ((t->value == TOKconst ||
+             t->value == TOKinvariant ||
+             t->value == TOKimmutable ||
+             t->value == TOKwild ||
+             t->value == TOKshared) &&
+            peek(t)->value != TOKlparen)
+        {   /* const type
+             * immutable type
+             * shared type
+             * wild type
+             */
+            t = peek(t);
+            continue;
+        }
+        break;
     }
 #endif
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -77,6 +77,7 @@ struct Parser : Lexer
     void composeStorageClass(StorageClass stc);
     StorageClass parseAttribute();
     StorageClass parsePostfix();
+    StorageClass parseTypeCtor();
     Expression *parseConstraint();
     TemplateDeclaration *parseTemplateDeclaration(int ismixin);
     TemplateParameters *parseTemplateParameterList(int flag = 0);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4639,6 +4639,30 @@ void test2856()
 }
 
 /***************************************************/
+// 3091
+
+void test3091(inout int = 0)
+{
+    struct Foo {}
+
+    auto  pm = new Foo;                 static assert(is( typeof( pm) ==              Foo  * ));
+    auto  pc = new const Foo;           static assert(is( typeof( pc) ==        const(Foo) * ));
+    auto  pw = new inout Foo;           static assert(is( typeof( pw) ==        inout(Foo) * ));
+    auto psm = new shared Foo;          static assert(is( typeof(psm) ==       shared(Foo) * ));
+    auto psc = new shared const Foo;    static assert(is( typeof(psc) == shared(const(Foo))* ));
+    auto psw = new shared inout Foo;    static assert(is( typeof(psw) == shared(inout(Foo))* ));
+    auto  pi = new immutable Foo;       static assert(is( typeof( pi) ==    immutable(Foo) * ));
+
+    auto  m = Foo();                    static assert(is( typeof( m) ==              Foo   ));
+    auto  c = const Foo();              static assert(is( typeof( c) ==        const(Foo)  ));
+    auto  w = inout Foo();              static assert(is( typeof( w) ==        inout(Foo)  ));
+    auto sm = shared Foo();             static assert(is( typeof(sm) ==       shared(Foo)  ));
+    auto sc = shared const Foo();       static assert(is( typeof(sc) == shared(const(Foo)) ));
+    auto sw = shared inout Foo();       static assert(is( typeof(sw) == shared(inout(Foo)) ));
+    auto  i = immutable Foo();          static assert(is( typeof( i) ==    immutable(Foo)  ));
+}
+
+/***************************************************/
 // 6056 fixup
 
 template ParameterTypeTuple6056(func)
@@ -5544,6 +5568,7 @@ int main()
     test6330();
     test6868();
     test2856();
+    test3091();
     test6056();
     test7073();
     test7150();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4663,6 +4663,16 @@ void test3091(inout int = 0)
 }
 
 /***************************************************/
+// 6837
+
+template Id6837(T)
+{
+	alias T Id6837;
+}
+static assert(is(Id6837!(shared const int) == shared const int));
+static assert(is(Id6837!(shared inout int) == shared inout int));
+
+/***************************************************/
 // 6056 fixup
 
 template ParameterTypeTuple6056(func)


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=3091">Issue 3091</a> - "auto x = new shared foo" does not compile
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6873">Issue 6873</a> - Multiple storage class is not allowed on template argument

Note: 3091 is marked as enhancement, and I think it is worth to fix.
