### PR TITLE
Issue 4251 - Hole in the const system: immutable(T)[] implicitly casts to ref const(T)[]

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5478,6 +5478,10 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             if (targb->nextOf() && tparb->ty == Tsarray &&
                 !MODimplicitConv(targb->nextOf()->mod, tparb->nextOf()->mod))
                 goto Nomatch;
+
+            // ref variable behaves like head-const reference
+            if (arg->op != TOKstring && !arg->type->toBasetype()->constConv(p->type->toBasetype()))
+                goto Nomatch;
         }
 
         if (p->storageClass & STClazy && p->type->ty == Tvoid &&

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -633,7 +633,6 @@ Expression *CastExp::optimize(int result)
 
     // We can convert 'head const' to mutable
     if (to->constOf()->equals(e1->type->constOf()))
-//    if (to->constConv(e1->type) >= MATCHconst)
     {
         e1->type = type;
         if (X) printf(" returning5 %s\n", e1->toChars());

--- a/src/template.c
+++ b/src/template.c
@@ -1804,7 +1804,7 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
     ti = new TemplateInstance(loc, td_best, tdargs);
     ti->semantic(sc, fargs);
     fd_best = ti->toAlias()->isFuncDeclaration();
-    if (!fd_best)
+    if (!fd_best || !((TypeFunction*)fd_best->type)->callMatch(ethis, fargs, flags))
         goto Lerror;
     return fd_best;
 

--- a/src/template.c
+++ b/src/template.c
@@ -1245,7 +1245,9 @@ Lretry:
             /* Remove top const for dynamic array types and pointer types
              */
             if ((argtype->ty == Tarray || argtype->ty == Tpointer) &&
-                !argtype->isMutable())
+                !argtype->isMutable() &&
+                (!(fparam->storageClass & STCref) ||
+                 (fparam->storageClass & STCauto) && !farg->isLvalue()))
             {
                 argtype = argtype->mutableOf();
             }

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -626,6 +626,21 @@ void foo10(T)(T prm)
     pragma(msg, T);
     static assert(is(T == const(int)[]));
 }
+void boo10(T)(ref T val)        // ref paramter doesn't remove top const
+{
+    pragma(msg, T);
+    static assert(is(T == const(int[])));
+}
+void goo10(T)(auto ref T val)   // auto ref with lvalue doesn't
+{
+    pragma(msg, T);
+    static assert(is(T == const(int[])));
+}
+void hoo10(T)(auto ref T val)   // auto ref with rvalue does
+{
+    pragma(msg, T);
+    static assert(is(T == const(int)[]));
+}
 void bar10(T)(T prm)
 {
     pragma(msg, T);
@@ -636,6 +651,9 @@ void test10()
     const a = [1,2,3];
     static assert(is(typeof(a) == const(int[])));
     foo10(a);
+    boo10(a);
+    goo10(a);
+    hoo10(cast(const(int[]))[1,2,3]);
 
     int n;
     const p = &n;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1894,6 +1894,149 @@ void test88()
 }
 
 /************************************/
+// 4251
+
+void test4251a()
+{
+    alias int T;
+
+    static assert(!is( immutable(T)** : const(T)** ));  // NG, tail difference
+    static assert( is( immutable(T)** : const(T**) ));  // OK, tail to const
+
+    static assert( is(           T *** :           T *** ));    // OK, tail is same
+    static assert(!is(           T *** :     const(T)*** ));
+    static assert(!is(           T *** :     const(T*)** ));
+    static assert( is(           T *** :     const(T**)* ));    // OK, tail to const
+    static assert( is(           T *** :     const(T***) ));    // OK, tail to const
+    static assert(!is(           T *** : immutable(T)*** ));
+    static assert(!is(           T *** : immutable(T*)** ));
+    static assert(!is(           T *** : immutable(T**)* ));
+    static assert(!is(           T *** : immutable(T***) ));
+
+    static assert(!is(     const(T)*** :           T *** ));
+    static assert( is(     const(T)*** :     const(T)*** ));    // OK, tail is same
+    static assert(!is(     const(T)*** :     const(T*)** ));
+    static assert( is(     const(T)*** :     const(T**)* ));    // OK, tail to const
+    static assert( is(     const(T)*** :     const(T***) ));    // OK, tail to const
+    static assert(!is(     const(T)*** : immutable(T)*** ));
+    static assert(!is(     const(T)*** : immutable(T*)** ));
+    static assert(!is(     const(T)*** : immutable(T**)* ));
+    static assert(!is(     const(T)*** : immutable(T***) ));
+
+    static assert(!is(     const(T*)** :           T *** ));
+    static assert(!is(     const(T*)** :     const(T)*** ));
+    static assert( is(     const(T*)** :     const(T*)** ));    // OK, tail is same
+    static assert( is(     const(T*)** :     const(T**)* ));    // OK, tail to const
+    static assert( is(     const(T*)** :     const(T***) ));    // OK, tail to const
+    static assert(!is(     const(T*)** : immutable(T)*** ));
+    static assert(!is(     const(T*)** : immutable(T*)** ));
+    static assert(!is(     const(T*)** : immutable(T**)* ));
+    static assert(!is(     const(T*)** : immutable(T***) ));
+
+    static assert(!is(     const(T**)* :           T *** ));
+    static assert(!is(     const(T**)* :     const(T)*** ));
+    static assert(!is(     const(T**)* :     const(T*)** ));
+    static assert( is(     const(T**)* :     const(T**)* ));    // OK, tail is same
+    static assert( is(     const(T**)* :     const(T***) ));    // OK, tail is same
+    static assert(!is(     const(T**)* : immutable(T)*** ));
+    static assert(!is(     const(T**)* : immutable(T*)** ));
+    static assert(!is(     const(T**)* : immutable(T**)* ));
+    static assert(!is(     const(T**)* : immutable(T***) ));
+
+    static assert(!is(     const(T***) :           T *** ));
+    static assert(!is(     const(T***) :     const(T)*** ));
+    static assert(!is(     const(T***) :     const(T*)** ));
+    static assert( is(     const(T***) :     const(T**)* ));    // OK, tail is same
+    static assert( is(     const(T***) :     const(T***) ));    // OK, tail is same
+    static assert(!is(     const(T***) :           T *** ));
+    static assert(!is(     const(T***) : immutable(T)*** ));
+    static assert(!is(     const(T***) : immutable(T*)** ));
+    static assert(!is(     const(T***) : immutable(T**)* ));
+    static assert(!is(     const(T***) : immutable(T***) ));
+
+    static assert(!is( immutable(T)*** :           T *** ));
+    static assert(!is( immutable(T)*** :     const(T)*** ));
+    static assert(!is( immutable(T)*** :     const(T*)** ));
+    static assert( is( immutable(T)*** :     const(T**)* ));    // OK, tail to const
+    static assert( is( immutable(T)*** :     const(T***) ));    // OK, tail to const
+    static assert( is( immutable(T)*** : immutable(T)*** ));    // OK, tail is same
+    static assert(!is( immutable(T)*** : immutable(T*)** ));
+    static assert(!is( immutable(T)*** : immutable(T**)* ));
+    static assert(!is( immutable(T)*** : immutable(T***) ));
+
+    static assert(!is( immutable(T*)** :           T *** ));
+    static assert(!is( immutable(T*)** :     const(T)*** ));
+    static assert(!is( immutable(T*)** :     const(T*)** ));
+    static assert( is( immutable(T*)** :     const(T**)* ));    // OK, tail to const
+    static assert( is( immutable(T*)** :     const(T***) ));    // OK, tail to const
+    static assert(!is( immutable(T*)** : immutable(T)*** ));
+    static assert( is( immutable(T*)** : immutable(T*)** ));    // OK, tail is same
+    static assert(!is( immutable(T*)** : immutable(T**)* ));
+    static assert(!is( immutable(T*)** : immutable(T***) ));
+
+    static assert(!is( immutable(T**)* :           T *** ));
+    static assert(!is( immutable(T**)* :     const(T)*** ));
+    static assert(!is( immutable(T**)* :     const(T*)** ));
+    static assert( is( immutable(T**)* :     const(T**)* ));    // OK, tail to const
+    static assert( is( immutable(T**)* :     const(T***) ));    // OK, tail to const
+    static assert(!is( immutable(T**)* : immutable(T)*** ));
+    static assert(!is( immutable(T**)* : immutable(T*)** ));
+    static assert( is( immutable(T**)* : immutable(T**)* ));    // OK, tail is same
+    static assert( is( immutable(T**)* : immutable(T***) ));    // OK, tail is same
+
+    static assert(!is( immutable(T***) :           T *** ));
+    static assert(!is( immutable(T***) :     const(T)*** ));
+    static assert(!is( immutable(T***) :     const(T*)** ));
+    static assert( is( immutable(T***) :     const(T**)* ));    // OK, tail to const
+    static assert( is( immutable(T***) :     const(T***) ));    // OK, tail to const
+    static assert(!is( immutable(T***) : immutable(T)*** ));
+    static assert(!is( immutable(T***) : immutable(T*)** ));
+    static assert( is( immutable(T***) : immutable(T**)* ));    // OK, tail is same
+    static assert( is( immutable(T***) : immutable(T***) ));    // OK, tail is same
+
+    static assert( is( immutable(int)** : const(immutable(int)*)* ));   // OK, tail to const
+
+    // shared level should be same
+    static assert(!is( shared(T)*** :        const(T***)  ));   // NG, tail to const but shared level is different
+    static assert( is( shared(T***) : shared(const(T***)) ));   // OK, tail to const and shared level is same
+
+    // head qualifier difference is ignored
+    static assert(is( shared(int)* : shared(int*) ));
+    static assert(is( inout (int)* : inout (int*) ));
+
+    //
+    static assert(!is( T** : T*** ));
+    static assert(!is( T[]** : T*** ));
+}
+
+void test4251b()
+{
+    class C {}
+    class D : C {}
+
+    static assert(!is( C[]* : const(C)[]* ));
+    static assert( is( C[]* : const(C[])* ));
+
+    // derived class to const(base class) in tail
+    static assert( is( D[]  : const(C)[] ));
+    static assert( is( D[]* : const(C[])* ));
+
+    static assert( is( D*  : const(C)* ));
+    static assert( is( D** : const(C*)* ));
+
+    // derived class to const(base interface) in tail
+    interface I {}
+    class X : I {}
+    static assert(!is( X[] : const(I)[] ));
+
+    // interface to const(base interface) in tail
+    interface J {}
+    interface K : I, J {}
+    static assert( is( K[] : const(I)[] )); // OK, runtime offset is same
+    static assert(!is( K[] : const(J)[] )); // NG, runtime offset is different
+}
+
+/************************************/
 // 6782
 
 struct Tuple6782(T...)
@@ -2300,6 +2443,8 @@ int main()
     test1961b();
     test1961c();
     test88();
+    test4251a();
+    test4251b();
     test6782();
     test6864();
     test6865();

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2037,6 +2037,61 @@ void test4251b()
 }
 
 /************************************/
+// 5493
+
+void test5493()
+{
+    // non template function
+    void pifun(immutable(char)[]* a) {}
+    void rifun(ref immutable(char)[] a) {}
+
+    void pcfun(const(char)[]* a) {}
+    void rcfun(ref const(char)[] a) {}
+
+    immutable char[] buf1 = "hello";
+    static assert(!__traits(compiles, pifun(buf1)));
+    static assert(!__traits(compiles, pcfun(buf1)));
+    static assert(!__traits(compiles, rifun(buf1)));
+    static assert(!__traits(compiles, rcfun(buf1)));
+
+    immutable char[5] buf2 = "hello";
+    static assert(!__traits(compiles, pifun(buf2)));
+    static assert(!__traits(compiles, pcfun(buf2)));
+    static assert(!__traits(compiles, rifun(buf2)));
+    static assert(!__traits(compiles, rcfun(buf2)));
+
+    const char[] buf3 = "hello";
+    static assert(!__traits(compiles, pcfun(buf3)));
+    static assert(!__traits(compiles, rcfun(buf3)));
+
+    const char[5] buf4 = "hello";
+    static assert(!__traits(compiles, pcfun(buf4)));
+    static assert(!__traits(compiles, rcfun(buf4)));
+
+    // template function
+    void pmesswith(T)(const(T)[]* ts, const(T) t)
+    {
+        *ts ~= t;
+    }
+    void rmesswith(T)(ref const(T)[] ts, const(T) t)
+    {
+        ts ~= t;
+    }
+    class C
+    {
+        int x;
+        this(int i) { x = i; }
+    }
+    C[] cs;
+    immutable C ci = new immutable(C)(6);
+    assert (ci.x == 6);
+    static assert(!__traits(compiles, pmesswith(&cs,ci)));
+    static assert(!__traits(compiles, rmesswith(cs,ci)));
+    //cs[$-1].x = 14;
+    //assert (ci.x == 14); //whoops.
+}
+
+/************************************/
 // 6782
 
 struct Tuple6782(T...)
@@ -2445,6 +2500,7 @@ int main()
     test88();
     test4251a();
     test4251b();
+    test5493();
     test6782();
     test6864();
     test6865();

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2454,6 +2454,21 @@ void test6940()
 }
 
 /************************************/
+// 7202
+
+void test7202()
+{
+    void writeln(string s) @system { printf("%.*s\n", s.length, s.ptr); }
+    void delegate() @system x = { writeln("I am @system"); };
+    void delegate() @safe y = {  };
+    auto px = &x;
+    auto py = &y;
+    static assert(!__traits(compiles, px = py)); // accepts-invalid
+    *px = x;
+    y(); // "I am @system" -> no output, OK
+}
+
+/************************************/
 
 int main()
 {
@@ -2558,6 +2573,7 @@ int main()
     test6912();
     test6939();
     test6940();
+    test7202();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2092,6 +2092,54 @@ void test5493()
 }
 
 /************************************/
+// 5493 + inout
+
+void test5493inout()
+{
+    int m;
+    const(int) c;
+    immutable(int) i;
+
+    inout(int) ptrfoo(inout(int)** a, inout(int)* b)
+    {
+        *a = b;
+        return 0;   // dummy
+    }
+    inout(int) reffoo(ref inout(int)* a, inout(int)* b)
+    {
+        a = b;
+        return 0;   // dummy
+    }
+
+    // wild matching: inout == mutable
+    int* pm;
+                                      ptrfoo(&pm, &m);    assert(pm == &m);
+    static assert(!__traits(compiles, ptrfoo(&pm, &c)));
+    static assert(!__traits(compiles, ptrfoo(&pm, &i)));
+                                      reffoo( pm, &m);    assert(pm == &m);
+    static assert(!__traits(compiles, reffoo( pm, &c)));
+    static assert(!__traits(compiles, reffoo( pm, &i)));
+
+    // wild matching: inout == const
+    const(int)* pc;
+    ptrfoo(&pc, &m);    assert(pc == &m);
+    ptrfoo(&pc, &c);    assert(pc == &c);
+    ptrfoo(&pc, &i);    assert(pc == &i);
+    reffoo( pc, &m);    assert(pc == &m);
+    reffoo( pc, &c);    assert(pc == &c);
+    reffoo( pc, &i);    assert(pc == &i);
+
+    // wild matching: inout == immutable
+    immutable(int)* pi;
+    static assert(!__traits(compiles, ptrfoo(&pi, &m)));
+    static assert(!__traits(compiles, ptrfoo(&pi, &c)));
+                                      ptrfoo(&pi, &i);    assert(pi == &i);
+    static assert(!__traits(compiles, reffoo( pi, &m)));
+    static assert(!__traits(compiles, reffoo( pi, &c)));
+                                      reffoo( pi, &i);    assert(pi == &i);
+}
+
+/************************************/
 // 6782
 
 struct Tuple6782(T...)
@@ -2501,6 +2549,7 @@ int main()
     test4251a();
     test4251b();
     test5493();
+    test5493inout();
     test6782();
     test6864();
     test6865();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=4251
This pull request requires #425 doe to prevent druntime breaking.

(@yebblies had posted #115, but it was a bit complicated than I had thought.)

When implicitly converting types with indirections, we consider only _tail part_ of the types.
e.g. The tail part of `T***` is `T**`.
There are two rules:
- If the tail of destination type is full const of the tail of source type, it is const convertible.
- Otherwise the tails of source and destination should be same.

e.g.

<table>
<tr><td> T*** => const(T***)            </td><td> OK, dst tail is full const of src tail </td></tr>
<tr><td> T*** => const(T**)*            </td><td> OK, dst tail is full const of src tail </td></tr>
<tr><td> T*** => const(T*)**            </td><td> NG, dst tail is differnt from src tail </td></tr>
<tr><td> T*** => const(T)***            </td><td> NG, dst tail is differnt from src tail </td></tr>
<tr><td> T*** => T***                   </td><td> OK, dst tail is same as src tail </td></tr>
<tr><td> immutable(T*)** => const(T*)** </td><td> <strong>NG</strong>, dst tail is differnt from src tail </td></tr>
</table>


Additional fix:
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5493">Issue 5493</a> - Able to overwrite immutable data by passing through ref function parameter
