### PR TITLE
Issue 7108 - ICE: TraitsExp::semantic(Scope*) 2.056 -> 2.057 regression - segfault

### DIFF
--- a/src/traits.c
+++ b/src/traits.c
@@ -262,9 +262,12 @@ Expression *TraitsExp::semantic(Scope *sc)
             if (t)
             {
                 Dsymbol *sym = t->toDsymbol(sc);
-                Dsymbol *sm = sym->search(loc, id, 0);
-                if (sm)
-                    goto Ltrue;
+                if (sym)
+                {
+                    Dsymbol *sm = sym->search(loc, id, 0);
+                    if (sm)
+                        goto Ltrue;
+                }
             }
 
             /* Take any errors as meaning it wasn't found

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4227,6 +4227,12 @@ void test6056()
 }
 
 /***************************************************/
+// 7108
+
+static assert(!__traits(hasMember, int, "x"));
+static assert( __traits(hasMember, int, "init"));
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7108

It is null dereference problem.
