### PR TITLE
Additional fix for pull #522

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -5138,7 +5138,7 @@ void TemplateInstance::printInstantiationTrace()
         return;
 
     const unsigned max_shown = 6;
-    const char format[] = "%s:        instantiated from here: %s\n";
+    const char format[] = "instantiated from here: %s";
 
     // determine instantiation depth and number of recursive instantiations
     int n_instantiations = 1;


### PR DESCRIPTION
Autotester fails in Windows.
http://d.puremagic.com/test-results/test_data.ghtml?dataid=126086

It is a mismatching issue between format specifier and arguments.
