### PR TITLE
Issue 3541 - Add -oq to dmd (use fully qualified module name as object filename)

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -207,7 +207,7 @@ void verror(Loc loc, const char *format, va_list ap)
 #endif
         fprintf(stdmsg, "\n");
         fflush(stdmsg);
-halt();
+//halt();
     }
     else
     {

--- a/src/mars.c
+++ b/src/mars.c
@@ -207,7 +207,7 @@ void verror(Loc loc, const char *format, va_list ap)
 #endif
         fprintf(stdmsg, "\n");
         fflush(stdmsg);
-//halt();
+halt();
     }
     else
     {
@@ -345,6 +345,7 @@ Usage:\n\
   -odobjdir      write object & library files to directory objdir\n\
   -offilename    name output file to filename\n\
   -op            do not strip paths from source file\n\
+  -oq            use fully qualified module name for object filenames\n\
   -profile       profile runtime performance of generated code\n\
   -property      enforce property syntax\n\
   -quiet         suppress unnecessary messages\n\
@@ -589,6 +590,12 @@ int main(int argc, char *argv[])
                         if (p[3])
                             goto Lerror;
                         global.params.preservePaths = 1;
+                        break;
+
+                    case 'q':
+                        if (p[3])
+                            goto Lerror;
+                        global.params.packagePaths = 1;
                         break;
 
                     case 0:
@@ -1025,6 +1032,7 @@ int main(int argc, char *argv[])
     // Create Modules
     Modules modules;
     modules.reserve(files.dim);
+
     int firstmodule = 1;
     for (size_t i = 0; i < files.dim; i++)
     {
@@ -1142,11 +1150,6 @@ int main(int argc, char *argv[])
         Identifier *id = Lexer::idPool(name);
         m = new Module(files[i], id, global.params.doDocComments, global.params.doHdrGeneration);
         modules.push(m);
-
-        if (firstmodule)
-        {   global.params.objfiles->push(m->objfile->name->str);
-            firstmodule = 0;
-        }
     }
 
 #if WINDOWS_SEH
@@ -1184,8 +1187,7 @@ int main(int argc, char *argv[])
         if (!Module::rootModule)
             Module::rootModule = m;
         m->importedFrom = m;
-        if (!global.params.oneobj || modi == 0 || m->isDocFile)
-            m->deleteObjFile();
+
 #if ASYNCREAD
         if (aw->read(filei))
         {
@@ -1193,6 +1195,9 @@ int main(int argc, char *argv[])
         }
 #endif
         m->parse();
+        m->prepareObjfile();
+        if (!global.params.oneobj || modi == 0 || m->isDocFile)
+            m->deleteObjFile();
         if (m->isDocFile)
         {
             anydocfiles = true;
@@ -1214,6 +1219,11 @@ int main(int argc, char *argv[])
 
             if (global.params.objfiles->dim == 0)
                 global.params.link = 0;
+        }
+
+        if (firstmodule)
+        {   global.params.objfiles->push(m->objfile->name->str);
+            firstmodule = 0;
         }
     }
 #if ASYNCREAD

--- a/src/mars.h
+++ b/src/mars.h
@@ -170,6 +170,7 @@ struct Param
     char useInline;     // inline expand functions
     char release;       // build release version
     char preservePaths; // !=0 means don't strip path from source file
+    char packagePaths;  // !=0 means use the fully qualified module name as object file output filename
     char warnings;      // 0: enable warnings
                         // 1: warnings as errors
                         // 2: informational warnings (no errors)

--- a/src/module.c
+++ b/src/module.c
@@ -67,6 +67,7 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
 
 //    printf("Module::Module(filename = '%s', ident = '%s')\n", filename, ident->toChars());
     this->arg = filename;
+	orig_filename = filename;
     md = NULL;
     errors = 0;
     numlines = 0;
@@ -136,6 +137,21 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
         }
     }
 
+    srcfile = new File(srcfilename);
+
+    if (doDocComment)
+        setDocfile();
+
+    if (doHdrGen)
+        setHdrfile();
+}
+
+void Module::prepareObjfile()
+{
+	char *filename = orig_filename;
+    FileName *objfilename;
+    FileName *symfilename;
+
     char *argobj;
     if (global.params.objname)
         argobj = global.params.objname;
@@ -153,6 +169,18 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
     {
         if (global.params.preservePaths)
             argobj = filename;
+
+	    else if (global.params.packagePaths) {
+	        argobj = (char*)toPrettyChars();
+	        //FileName::forceExt will think the last part of the package path is an extension
+	        //argobj = argobj ~ '.' ~ global.obj_ext;
+	        char* tmp = (char*)calloc(1, strlen(argobj) + strlen(global.obj_ext) + 2);
+	        memcpy(tmp, argobj, strlen(argobj));
+	        tmp[strlen(argobj)] = '.';
+	        memcpy(tmp + strlen(argobj) + 1, global.obj_ext, strlen(global.obj_ext));
+	        argobj = tmp;
+	    }
+
         else
             argobj = FileName::name(filename);
         if (!FileName::absolute(argobj))
@@ -168,18 +196,6 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
         objfilename = FileName::forceExt(argobj, global.obj_ext);
 
     symfilename = FileName::forceExt(filename, global.sym_ext);
-
-    srcfile = new File(srcfilename);
-
-    if (doDocComment)
-    {
-        setDocfile();
-    }
-
-    if (doHdrGen)
-    {
-        setHdrfile();
-    }
 
     objfile = new File(objfilename);
     symfile = new File(symfilename);
@@ -243,7 +259,7 @@ void Module::setHdrfile()
 
 void Module::deleteObjFile()
 {
-    if (global.params.obj)
+    if (global.params.obj && objfile)
         objfile->remove();
     if (docfile)
         docfile->remove();
@@ -646,6 +662,9 @@ void Module::parse()
          */
         if (!Lexer::isValidIdentifier(this->ident->toChars()))
             error("has non-identifier characters in filename, use module declaration instead");
+
+		if (global.params.packagePaths)
+			error("has no module declaration; this is not allowed when using option -oq");
     }
 
     // Update global list of modules

--- a/src/module.h
+++ b/src/module.h
@@ -58,6 +58,7 @@ struct Module : Package
 
 
     const char *arg;    // original argument name
+    char *orig_filename; //original filename (passed to Module ctor)
     ModuleDeclaration *md; // if !NULL, the contents of the ModuleDeclaration declaration
     File *srcfile;      // input source file
     File *objfile;      // output .obj file
@@ -113,6 +114,8 @@ struct Module : Package
 
     Module(char *arg, Identifier *ident, int doDocComment, int doHdrGen);
     ~Module();
+
+    void prepareObjfile();
 
     static Module *load(Loc loc, Identifiers *packages, Identifier *ident);
 


### PR DESCRIPTION
Issue 3541 - Add -oq to dmd (use fully qualified module name as object filename).

Trying this again, I've just updated my fork. I have tested this on Mac OS X by running the Phobos unit tests and they all DO PASS. The command line I used to run the unit tests was "make unittest".

http://d.puremagic.com/issues/show_bug.cgi?id=3541
