### PR TITLE
6995 [CTFE] can't interpret static template method

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7551,7 +7551,10 @@ Lagain:
         if (!f->needThis())
         {
             VarExp *ve = new VarExp(loc, f);
-            e1 = new CommaExp(loc, ue->e1, ve);
+            if ((ue->e1)->op == TOKtype) // just a FQN
+                e1 = ve;
+            else // things like (new Foo).bar()
+                e1 = new CommaExp(loc, ue->e1, ve);
             e1->type = f->type;
         }
         else

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3617,3 +3617,17 @@ void test6919b()
     assert(val == "1");
 }
 static assert({ test6919b(); return true; }());
+
+/**************************************************
+    6995
+**************************************************/
+
+struct Foo6995
+{
+    static size_t index(size_t v)()
+    {
+        return v;
+    }
+}
+
+static assert(Foo6995.index!(27)() == 27);


### PR DESCRIPTION
Really a bug in the front-end, not in CTFE. 
Foo.bar(), where Foo is a type, is a fully qualified name, not something which should be lowered into a comma expression with a TypeExp. The bug doesn't show up outside of CTFE, because CommaExp::optimize simply discards the TypeExp.
