### PR TITLE
Issue 7127 - Const-related infinite recursion in DWARF generation

### DIFF
--- a/test/compilable/debuginfo.d
+++ b/test/compilable/debuginfo.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -g
+
+struct Bug7127a {
+    const(Bug7127a)* self;
+}
+
+struct Bug7127b {
+    void function(const(Bug7127b) self) foo;
+}
+
+void main() {
+    Bug7127a a;
+    Bug7127b b;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7127

The `volatile` code a few lines after that could potentially suffer from the same issue, but I'm not sure if it can ever be hit from D, so I left it alone.

I'm not really sure that this is the best way to fix the issue, but it seems to do the job.
