### PR TITLE
7043 CTFE: ICE illegal reference value 0LU, only with -inline

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -260,10 +260,7 @@ struct VarDeclaration : Declaration
     bool hasValue();
     void setValueNull();
     void setValueWithoutChecking(Expression *newval);
-    void createRefValue(Expression *newval);
-    void setRefValue(Expression *newval);
-    void setStackValue(Expression *newval);
-    void createStackValue(Expression *newval);
+    void setValue(Expression *newval);
 
 #if DMDV2
     VarDeclaration *rundtor;    // if !NULL, rundtor is tested at runtime to see

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3631,3 +3631,16 @@ struct Foo6995
 }
 
 static assert(Foo6995.index!(27)() == 27);
+
+/**************************************************
+    7043 ref with -inline
+**************************************************/
+
+int bug7043(S)(ref int x) {
+    return x;
+}
+
+static assert( {
+    int i = 416;
+    return bug7043!(char)(i);
+}() == 416 );


### PR DESCRIPTION
Just an over-zealous assert.
I've consolidated the CTFE value checking. The distinction between ref-value and stack-value was required for earlier refactoring, but is now obsolete.
