### PR TITLE
4135 Regression(1.034): ICE(statement.c): mixin in bad foreach, D1 only

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1331,6 +1331,8 @@ Statement *ForeachStatement::semantic(Scope *sc)
         error("invalid foreach aggregate %s", aggr->toChars());
         return this;
     }
+    if (aggr->type->toBasetype()->ty == Terror)
+        return NULL;
 
     inferApplyArgTypes(op, arguments, aggr);
 


### PR DESCRIPTION
IMPORTANT: This is a pull request for D1 only.

A simple error propagation bug -- we should abandon hope if we don't know what the aggregate is.
