### PR TITLE
Issue 6939 & 6940 & 7136 - Fix type combination

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1829,7 +1829,7 @@ Lagain:
         t = t1;
         goto Lagain;
     }
-    else if (t1->ty == Tclass || t2->ty == Tclass)
+    else if (t1->ty == Tclass && t2->ty == Tclass)
     {
         if (t1->mod != t2->mod)
         {
@@ -1847,7 +1847,11 @@ Lagain:
             t = t1;
             goto Lagain;
         }
-
+        goto Lcc;
+    }
+    else if (t1->ty == Tclass || t2->ty == Tclass)
+    {
+Lcc:
         while (1)
         {
             int i1 = e2->implicitConvTo(t1);
@@ -1971,17 +1975,6 @@ Lagain:
     }
     else if (t1->ty == Tstruct || t2->ty == Tstruct)
     {
-        if (t1->mod != t2->mod)
-        {
-            unsigned char mod = MODmerge(t1->mod, t2->mod);
-            if (!t1->isImmutable() && !t2->isImmutable() && t1->isShared() != t2->isShared())
-                goto Lincompatible;
-            t1 = t1->castMod(mod);
-            t2 = t2->castMod(mod);
-            t = t1;
-            goto Lagain;
-        }
-
         if (t1->ty == Tstruct && ((TypeStruct *)t1)->sym->aliasthis)
         {
             e1 = new DotIdExp(e1->loc, e1, ((TypeStruct *)t1)->sym->aliasthis->ident);

--- a/src/cast.c
+++ b/src/cast.c
@@ -1671,13 +1671,16 @@ Lagain:
             t = t2;
         else if (t2n->ty == Tvoid)
             ;
+        else if (t1->implicitConvTo(t2))
+        {
+            goto Lt2;
+        }
+        else if (t2->implicitConvTo(t1))
+        {
+            goto Lt1;
+        }
         else if (t1n->ty == Tfunction && t2n->ty == Tfunction)
         {
-            if (t1->implicitConvTo(t2))
-                goto Lt2;
-            if (t2->implicitConvTo(t1))
-                goto Lt1;
-
             TypeFunction *tf1 = (TypeFunction *)t1n;
             TypeFunction *tf2 = (TypeFunction *)t2n;
             TypeFunction *d = (TypeFunction *)tf1->syntaxCopy();
@@ -1740,7 +1743,19 @@ Lagain:
                 goto Lincompatible;
         }
         else
+        {
+            t1 = t1n->constOf()->pointerTo();
+            t2 = t2n->constOf()->pointerTo();
+            if (t1->implicitConvTo(t2))
+            {
+                goto Lt2;
+            }
+            else if (t2->implicitConvTo(t1))
+            {
+                goto Lt1;
+            }
             goto Lincompatible;
+        }
     }
     else if ((t1->ty == Tsarray || t1->ty == Tarray) &&
              (e2->op == TOKnull && t2->ty == Tpointer && t2->nextOf()->ty == Tvoid ||

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -692,6 +692,32 @@ void test6929()
 }
 
 /***************************************************/
+// 7136
+
+void test7136()
+{
+    struct X
+    {
+        Object get() immutable { return null; }
+        alias get this;
+    }
+    immutable(X) x;
+    Object y;
+    static assert( is(typeof(1?x:y) == Object));        // fails
+    static assert(!is(typeof(1?x:y) == const(Object))); // fails
+
+    struct A
+    {
+        int[] get() immutable { return null; }
+        alias get this;
+    }
+    immutable(A) a;
+    int[] b;
+    static assert( is(typeof(1?a:b) == int[]));         // fails
+    static assert(!is(typeof(1?a:b) == const(int[])));  // fails
+}
+
+/***************************************************/
 
 int main()
 {
@@ -719,6 +745,7 @@ int main()
     test6832();
     test6928();
     test6929();
+    test7136();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2166,6 +2166,26 @@ static assert((shared(inout(const(int)[])[])).stringof == "shared(inout(const(in
 static assert((shared(inout(const(immutable(int)[])[])[])).stringof == "shared(inout(const(immutable(int)[])[])[])");
 
 /************************************/
+// 6939
+
+void test6939()
+{
+    shared    int* x;
+    immutable int* y;
+    const     int* z;
+    static assert( is(typeof(1?x:y) == shared(const(int))*));  // fail
+    static assert(!is(typeof(1?x:y) == const(int)*));          // fail
+    static assert(!is(typeof(1?x:z)));                         // fail
+
+    shared    int[] a;
+    immutable int[] b;
+    const     int[] c;
+    static assert( is(typeof(1?a:b) == shared(const(int))[])); // pass (ok)
+    static assert(!is(typeof(1?a:b) == const(int)[]));         // pass (ok)
+    static assert(!is(typeof(1?a:c)));                         // fail
+}
+
+/************************************/
 // 6940
 
 void test6940()
@@ -2286,6 +2306,7 @@ int main()
     test6866();
     test6870();
     test6912();
+    test6939();
     test6940();
 
     printf("Success\n");

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2166,6 +2166,28 @@ static assert((shared(inout(const(int)[])[])).stringof == "shared(inout(const(in
 static assert((shared(inout(const(immutable(int)[])[])[])).stringof == "shared(inout(const(immutable(int)[])[])[])");
 
 /************************************/
+// 6940
+
+void test6940()
+{
+    immutable(int*)*    x;
+    int**               y;
+    static assert(is(typeof(x) : const(int*)*)); // ok
+    static assert(is(typeof(y) : const(int*)*)); // ok
+    static assert(is(typeof(1?x:y) == const(int*)*));
+
+    immutable(int[])[]  a;
+    int[][]             b;
+    static assert(is(typeof(a) : const(int[])[])); // ok
+    static assert(is(typeof(b) : const(int[])[])); // ok
+    static assert(is(typeof(1?a:b) == const(int[])[]));
+
+    immutable(int)**    v;
+    int**               w;
+    static assert(is(typeof(1?v:w) == const(int*)*));
+}
+
+/************************************/
 
 int main()
 {
@@ -2264,6 +2286,7 @@ int main()
     test6866();
     test6870();
     test6912();
+    test6940();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6939">Issue 6939</a> - wrong type qualifier combination
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6940">Issue 6940</a> - immutable(int_)_/immutable(int)*\* and int*\* do not combine
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7136">Issue 7136</a> - alias this lookup should run before merging modifiers of both sides.
