### PR TITLE
CTFE: 6984 7143 7144

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -557,6 +557,7 @@ struct FuncDeclaration : Declaration
     int inlineNest;                     // !=0 if nested inline
     int isArrayOp;                      // !=0 if array operation
     enum PASS semanticRun;
+    int semantic3Errors;                // !=0 if errors in semantic3
                                         // this function's frame ptr
     ForeachStatement *fes;              // if foreach body, this is the foreach
     int introducing;                    // !=0 if 'introducing' function

--- a/src/func.c
+++ b/src/func.c
@@ -68,6 +68,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     inlineNest = 0;
     isArrayOp = 0;
     semanticRun = PASSinit;
+    semantic3Errors = 0;
 #if DMDV1
     nestedFrameRef = 0;
 #endif
@@ -827,6 +828,7 @@ void FuncDeclaration::semantic3(Scope *sc)
     if (semanticRun >= PASSsemantic3)
         return;
     semanticRun = PASSsemantic3;
+    semantic3Errors = 0;
 
     if (!type || type->ty != Tfunction)
         return;
@@ -1645,7 +1647,10 @@ void FuncDeclaration::semantic3(Scope *sc)
     if (global.gag && global.errors != nerrors)
         semanticRun = PASSsemanticdone; // Ensure errors get reported again
     else
+    {
         semanticRun = PASSsemantic3done;
+        semantic3Errors = global.errors - nerrors;
+    }
     //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", parent->toChars(), toChars(), sc, loc.toChars());
     //fflush(stdout);
 }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4491,12 +4491,6 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
     printf("CallExp::interpret() %s\n", toChars());
 #endif
 
-    if (global.errors)
-    {
-        error("CTFE failed because of previous errors");
-        return EXP_CANT_INTERPRET;
-    }
-
     Expression * pthis = NULL;
     FuncDeclaration *fd = NULL;
     Expression *ecall = e1;
@@ -4632,6 +4626,11 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
                 assert(fd);
             }
         }
+    }
+    if (fd && fd->semanticRun >= PASSsemantic3done && fd->semantic3Errors)
+    {
+        error("CTFE failed because of previous errors in %s", fd->toChars());
+        return EXP_CANT_INTERPRET;
     }
     // Check for built-in functions
     Expression *eresult = evaluateIfBuiltin(istate, loc, fd, arguments, pthis);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3644,3 +3644,59 @@ static assert( {
     int i = 416;
     return bug7043!(char)(i);
 }() == 416 );
+
+/**************************************************
+    7143 'is' for classes
+**************************************************/
+
+class C7143
+{
+    int x;
+}
+
+int bug7143(int test)
+{
+    C7143 c = new C7143;
+    C7143 d = new C7143;
+    if (test == 1)
+    {
+        if (c)
+            return c.x + 8;
+        return -1;
+    }
+    if (test == 2)
+    {
+        if(c is null)
+            return -1;
+        return c.x + 45;
+    }
+    if (test == 3)
+    {
+        if (c is c)
+            return 58;
+    }
+    if (test == 4)
+    {
+        if (c !is c)
+            return -1;
+        else
+            return 48;
+    }
+    if (test == 6)
+        d = c;
+    if (test == 5 || test == 6)
+    {
+        if (c is d)
+            return 188;
+        else
+            return 48;
+    }
+    return -1;
+}
+
+static assert(bug7143(1) == 8);
+static assert(bug7143(2) == 45);
+static assert(bug7143(3) == 58);
+static assert(bug7143(4) == 48);
+static assert(bug7143(5) == 48);
+static assert(bug7143(6) == 188);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3700,3 +3700,30 @@ static assert(bug7143(3) == 58);
 static assert(bug7143(4) == 48);
 static assert(bug7143(5) == 48);
 static assert(bug7143(6) == 188);
+
+/**************************************************
+    7147 virtual function calls from base class
+**************************************************/
+
+class A7147
+{
+    int foo() { return 0; }
+
+    int callfoo()
+    {
+        return foo();
+    }
+}
+
+class B7147 : A7147
+{
+    override int foo() { return 1; }
+}
+
+int test7147()
+{
+    A7147 a = new B7147;
+    return a.callfoo();
+}
+
+static assert(test7147() == 1);


### PR DESCRIPTION
6984 is a big diagnostic improvement, it allows CTFE to continue in most cases. The hard work was done in my earlier CTFE pull request.
7144 is a simple wrong-code bug. 7143 is a straightforward missing case.

6984 CTFE generates a torrent of spurious errors, if there was a previous error
7143 [CTFE] cannot compare class references with "is"
7144 [CTFE] base class does not call overridden members

http://d.puremagic.com/issues/show_bug.cgi?id=6984
http://d.puremagic.com/issues/show_bug.cgi?id=7143
http://d.puremagic.com/issues/show_bug.cgi?id=7144
