### PR TITLE
CTFE class bugs 7154 and 7158

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3130,7 +3130,7 @@ Expression *ctfeCast(Loc loc, Type *type, Type *to, Expression *e)
         if (originalClass->type->implicitConvTo(to))
             return paintTypeOntoLiteral(to, e);
         else
-            return new NullExp(loc);
+            return new NullExp(loc, to);
     }
     Expression *r = Cast(type, to, e);
     if (r == EXP_CANT_INTERPRET)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3130,10 +3130,7 @@ Expression *ctfeCast(Loc loc, Type *type, Type *to, Expression *e)
         if (originalClass->type->implicitConvTo(to))
             return paintTypeOntoLiteral(to, e);
         else
-        {
-            error(loc, "cannot reinterpret class from %s to %s at compile time", originalClass->toChars(), to->toChars());
-            return EXP_CANT_INTERPRET;
-        }
+            return new NullExp(loc);
     }
     Expression *r = Cast(type, to, e);
     if (r == EXP_CANT_INTERPRET)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5614,7 +5614,7 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
                 if ((type->ty == Tsarray || goal == ctfeNeedLvalue) && (
                     e->op == TOKarrayliteral ||
                     e->op == TOKassocarrayliteral || e->op == TOKstring ||
-                    e->op == TOKslice))
+                    e->op == TOKclassreference || e->op == TOKslice))
                     return e;
                 /* Element is an allocated pointer, which was created in
                  * CastExp.

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3056,6 +3056,7 @@ auto classtest1(int n)
     if (n==7)
     {   // bad cast -- should fail
         Unrelated u = cast(Unrelated)d;
+        assert(u is null);
     }
     SomeClass e = cast(SomeClass)d;
     d.q = 35;
@@ -3079,8 +3080,8 @@ auto classtest1(int n)
     return 6;
 }
 static assert(classtest1(1));
-static assert(is(typeof(compiles!(classtest1(2)))));
-static assert(!is(typeof(compiles!(classtest1(7)))));
+static assert(classtest1(2));
+static assert(classtest1(7)); // bug 7154
 
 // can't return classes literals outside CTFE
 SomeClass classtest2(int n)
@@ -3727,3 +3728,20 @@ int test7147()
 }
 
 static assert(test7147() == 1);
+
+/**************************************************
+    7158
+**************************************************/
+
+class C7158 {
+    bool b() {return true;}
+}
+struct S7158 {
+    C7158 c;
+}
+
+bool test7158() {
+    S7158 s = S7158(new C7158);
+    return s.c.b;
+}
+static assert(test7158());


### PR DESCRIPTION
These are both simple.

7154 [CTFE] failing downcast causes error
7158 [CTFE] ICE(interpret.c) calling a class member using a dotvar expression

http://d.puremagic.com/issues/show_bug.cgi?id=7154
http://d.puremagic.com/issues/show_bug.cgi?id=7158
