### PR TITLE
Bug7097

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1261,12 +1261,9 @@ ArrayScopeSymbol::ArrayScopeSymbol(Scope *sc, TupleDeclaration *s)
 Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
 {
     //printf("ArrayScopeSymbol::search('%s', flags = %d)\n", ident->toChars(), flags);
-    if (ident == Id::length || ident == Id::dollar)
+    if (ident == Id::dollar)
     {   VarDeclaration **pvar;
         Expression *ce;
-
-        if (ident == Id::length)
-            ::error(loc, "using 'length' inside [ ] is deprecated, use '$' instead");
 
     L1:
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -85,6 +85,8 @@ Expression *resolveAliasThis(Scope *sc, Expression *e);
 Expression *callCpCtor(Loc loc, Scope *sc, Expression *e, int noscope);
 int checkPostblit(Loc loc, Type *t);
 #endif
+struct ArrayExp *resolveOpDollar(Scope *sc, struct ArrayExp *ae);
+struct SliceExp *resolveOpDollar(Scope *sc, struct SliceExp *se);
 
 /* Interpreter: what form of return value expression is required?
  */

--- a/src/opover.c
+++ b/src/opover.c
@@ -236,6 +236,7 @@ Expression *UnaExp::op_overload(Scope *sc)
             Dsymbol *fd = search_function(ad, Id::opIndexUnary);
             if (fd)
             {
+                ae = resolveOpDollar(sc, ae);
                 Objects *targsi = opToArg(sc, op);
                 Expression *e = new DotTemplateInstanceExp(loc, ae->e1, fd->ident, targsi);
                 e = new CallExp(loc, e, ae->arguments);
@@ -273,12 +274,13 @@ Expression *UnaExp::op_overload(Scope *sc)
             Dsymbol *fd = search_function(ad, Id::opSliceUnary);
             if (fd)
             {
+                se = resolveOpDollar(sc, se);
                 Expressions *a = new Expressions();
+                assert(!se->lwr || se->upr);
                 if (se->lwr)
                 {   a->push(se->lwr);
                     a->push(se->upr);
                 }
-
                 Objects *targsi = opToArg(sc, op);
                 Expression *e = new DotTemplateInstanceExp(loc, se->e1, fd->ident, targsi);
                 e = new CallExp(loc, e, a);
@@ -375,35 +377,12 @@ Expression *ArrayExp::op_overload(Scope *sc)
         Dsymbol *fd = search_function(ad, opId());
         if (fd)
         {
-            for (size_t i = 0; i < arguments->dim; i++)
-            {   Expression *x = (*arguments)[i];
-                // Create scope for '$' variable for this dimension
-                ArrayScopeSymbol *sym = new ArrayScopeSymbol(sc, this);
-                sym->loc = loc;
-                sym->parent = sc->scopesym;
-                sc = sc->push(sym);
-                lengthVar = NULL;       // Create it only if required
-                currentDimension = i;   // Dimension for $, if required
-
-                x = x->semantic(sc);
-                x = resolveProperties(sc, x);
-                if (!x->type)
-                    error("%s has no value", x->toChars());
-                if (lengthVar)
-                {   // If $ was used, declare it now
-                    Expression *av = new DeclarationExp(loc, lengthVar);
-                    x = new CommaExp(0, av, x);
-                    x->semantic(sc);
-                }
-                (*arguments)[i] = x;
-                sc = sc->pop();
-            }
-
             /* Rewrite op e1[arguments] as:
              *    e1.opIndex(arguments)
              */
-            Expression *e = new DotIdExp(loc, e1, fd->ident);
-            e = new CallExp(loc, e, arguments);
+            ArrayExp *ae = resolveOpDollar(sc, this);
+            Expression *e = new DotIdExp(loc, ae->e1, fd->ident);
+            e = new CallExp(loc, e, ae->arguments);
             e = e->semantic(sc);
             return e;
         }
@@ -987,10 +966,9 @@ Expression *BinAssignExp::op_overload(Scope *sc)
             Dsymbol *fd = search_function(ad, Id::opIndexOpAssign);
             if (fd)
             {
-                Expressions *a = new Expressions();
-                a->push(e2);
-                for (size_t i = 0; i < ae->arguments->dim; i++)
-                    a->push((*ae->arguments)[i]);
+                ae = resolveOpDollar(sc, ae);
+                Expressions *a = (Expressions *)ae->arguments->copy();
+                a->insert(0, e2);
 
                 Objects *targsi = opToArg(sc, op);
                 Expression *e = new DotTemplateInstanceExp(loc, ae->e1, fd->ident, targsi);
@@ -1029,8 +1007,10 @@ Expression *BinAssignExp::op_overload(Scope *sc)
             Dsymbol *fd = search_function(ad, Id::opSliceOpAssign);
             if (fd)
             {
+                se = resolveOpDollar(sc, se);
                 Expressions *a = new Expressions();
                 a->push(e2);
+                assert(!se->lwr || se->upr);
                 if (se->lwr)
                 {   a->push(se->lwr);
                     a->push(se->upr);
@@ -1646,4 +1626,3 @@ static void templateResolve(Match *m, TemplateDeclaration *td, Scope *sc, Loc lo
         m->count = 1;
     }
 }
-

--- a/test/fail_compilation/fail151.d
+++ b/test/fail_compilation/fail151.d
@@ -1,7 +1,0 @@
-void main() {
-    int length;
-    int[4] data;
-
-    data[length - 1] = 42;
-}
-

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -721,6 +721,170 @@ void test8434()
 
 /**************************************/
 
+void test18()
+{
+    // one dimensional indexing
+    static struct IndexExp
+    {
+        int[] opIndex(int a)
+        {
+            return [a];
+        }
+
+        int[] opIndexUnary(string op)(int a)
+        {
+            return [a];
+        }
+
+        int[] opIndexAssign(int val, int a)
+        {
+            return [val, a];
+        }
+
+        int[] opIndexOpAssign(string op)(int val, int a)
+        {
+            return [val, a];
+        }
+
+        int opDollar()
+        {
+            return 8;
+        }
+    }
+
+    IndexExp index;
+    // opIndex
+    assert(index[8]     == [8]);
+    assert(index[$]     == [8]);
+    assert(index[$-1]   == [7]);
+    assert(index[$-$/2] == [4]);
+    // opIndexUnary
+    assert(-index[8]     == [8]);
+    assert(-index[$]     == [8]);
+    assert(-index[$-1]   == [7]);
+    assert(-index[$-$/2] == [4]);
+    // opIndexAssign
+    assert((index[8]     = 2) == [2, 8]);
+    assert((index[$]     = 2) == [2, 8]);
+    assert((index[$-1]   = 2) == [2, 7]);
+    assert((index[$-$/2] = 2) == [2, 4]);
+    // opIndexOpAssign
+    assert((index[8]     += 2) == [2, 8]);
+    assert((index[$]     += 2) == [2, 8]);
+    assert((index[$-1]   += 2) == [2, 7]);
+    assert((index[$-$/2] += 2) == [2, 4]);
+
+    // opDollar is only one-dimensional
+    static assert(!is(typeof(index[$, $])));
+    static assert(!is(typeof(-index[$, $])));
+    static assert(!is(typeof(index[$, $] = 2)));
+    static assert(!is(typeof(index[$, $] += 2)));
+
+    // multi dimensional indexing
+    static struct ArrayExp
+    {
+        int[] opIndex(int a, int b)
+        {
+            return [a, b];
+        }
+
+        int[] opIndexUnary(string op)(int a, int b)
+        {
+            return [a, b];
+        }
+
+        int[] opIndexAssign(int val, int a, int b)
+        {
+            return [val, a, b];
+        }
+
+        int[] opIndexOpAssign(string op)(int val, int a, int b)
+        {
+            return [val, a, b];
+        }
+
+        int opDollar(int dim)()
+        {
+            return dim;
+        }
+    }
+
+    ArrayExp array;
+    // opIndex
+    assert(array[8, 8]     == [8, 8]);
+    assert(array[$, $]     == [0, 1]);
+    assert(array[$, $-1]   == [0, 0]);
+    assert(array[2, $-$/2] == [2, 1]);
+    // opIndexUnary
+    assert(-array[8, 8]     == [8, 8]);
+    assert(-array[$, $]     == [0, 1]);
+    assert(-array[$, $-1]   == [0, 0]);
+    assert(-array[2, $-$/2] == [2, 1]);
+    // opIndexAssign
+    assert((array[8, 8]      = 2) == [2, 8, 8]);
+    assert((array[$, $]      = 2) == [2, 0, 1]);
+    assert((array[$, $-1]    = 2) == [2, 0, 0]);
+    assert((array[2, $-$/2]  = 2) == [2, 2, 1]);
+    // opIndexOpAssign
+    assert((array[8, 8]      += 2) == [2, 8, 8]);
+    assert((array[$, $]      += 2) == [2, 0, 1]);
+    assert((array[$, $-1]    += 2) == [2, 0, 0]);
+    assert((array[2, $-$/2]  += 2) == [2, 2, 1]);
+
+    // one dimensional slicing
+    static struct SliceExp
+    {
+        int[] opSlice(int a, int b)
+        {
+            return [a, b];
+        }
+
+        int[] opSliceUnary(string op)(int a, int b)
+        {
+            return [a, b];
+        }
+
+        int[] opSliceAssign(int val, int a, int b)
+        {
+            return [val, a, b];
+        }
+
+        int[] opSliceOpAssign(string op)(int val, int a, int b)
+        {
+            return [val, a, b];
+        }
+
+        int opDollar()
+        {
+            return 8;
+        }
+    }
+
+    SliceExp slice;
+    // opSlice
+    assert(slice[0 .. 8]     == [0, 8]);
+    assert(slice[0 .. $]     == [0, 8]);
+    assert(slice[0 .. $-1]   == [0, 7]);
+    assert(slice[$-3 .. $-1] == [5, 7]);
+    // opSliceUnary
+    assert(-slice[0 .. 8]     == [0, 8]);
+    assert(-slice[0 .. $]     == [0, 8]);
+    assert(-slice[0 .. $-1]   == [0, 7]);
+    assert(-slice[$-3 .. $-1] == [5, 7]);
+    // opSliceAssign
+    assert((slice[0 .. 8]     = 2) == [2, 0, 8]);
+    assert((slice[0 .. $]     = 2) == [2, 0, 8]);
+    assert((slice[0 .. $-1]   = 2) == [2, 0, 7]);
+    assert((slice[$-3 .. $-1] = 2) == [2, 5, 7]);
+    // opSliceOpAssign
+    assert((slice[0 .. 8]     += 2) == [2, 0, 8]);
+    assert((slice[0 .. $]     += 2) == [2, 0, 8]);
+    assert((slice[0 .. $-1]   += 2) == [2, 0, 7]);
+    assert((slice[$-3 .. $-1] += 2) == [2, 5, 7]);
+}
+
+/**************************************/
+
 int main()
 {
     test1();
@@ -743,6 +907,7 @@ int main()
     test17();
     test7641();
     test8434();
+    test18();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1,3 +1,4 @@
+// PERMUTE_ARGS: -inline -O -property
 
 // Test operator overloading
 
@@ -881,6 +882,23 @@ void test18()
     assert((slice[0 .. $]     += 2) == [2, 0, 8]);
     assert((slice[0 .. $-1]   += 2) == [2, 0, 7]);
     assert((slice[$-3 .. $-1] += 2) == [2, 5, 7]);
+
+    // test different kinds of opDollar
+    auto dollar(string opDollar)()
+    {
+        static struct Dollar
+        {
+            size_t opIndex(size_t a) { return a; }
+            mixin(opDollar);
+        }
+        Dollar d;
+        return d[$];
+    }
+    assert(dollar!q{@property size_t opDollar() { return 8; }}() == 8);
+    assert(dollar!q{template opDollar(size_t dim) { enum opDollar = dim; }}() == 0);
+    assert(dollar!q{const size_t opDollar = 8;}() == 8);
+    assert(dollar!q{enum opDollar = 8;}() == 8);
+    assert(dollar!q{size_t length() { return 8; } alias length opDollar;}() == 8);
 }
 
 /**************************************/


### PR DESCRIPTION
- resolve opDollar for all array operator overloads (op[Index,Slice][, Unary, Assign, OpAssign])
- throw out the deprecated resolving of 'length' to opDollary
  not doing so could break code that uses a length variable/property within
  one of the added expressions
