### PR TITLE
Cleanup matchArg

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3012,6 +3012,8 @@ TemplateThisParameter  *TemplateParameter::isTemplateThisParameter()
 
 // type-parameter
 
+Type *TemplateTypeParameter::tdummy = NULL;
+
 TemplateTypeParameter::TemplateTypeParameter(Loc loc, Identifier *ident, Type *specType,
         Type *defaultType)
     : TemplateParameter(loc, ident)
@@ -3137,6 +3139,9 @@ MATCH TemplateTypeParameter::matchArg(Scope *sc, Objects *tiargs,
 
     if (specType)
     {
+        if (!ta || ta == tdummy)
+            goto Lnomatch;
+
         //printf("\tcalling deduceType(): ta is %s, specType is %s\n", ta->toChars(), specType->toChars());
         MATCH m2 = ta->deduceType(sc, specType, parameters, dedtypes);
         if (m2 == MATCHnomatch)
@@ -3228,7 +3233,9 @@ void *TemplateTypeParameter::dummyArg()
         t = specType;
     else
     {   // Use this for alias-parameter's too (?)
-        t = new TypeIdentifier(loc, ident);
+        if (!tdummy)
+            tdummy = new TypeIdentifier(loc, ident);
+        t = tdummy;
     }
     return (void *)t;
 }

--- a/src/template.c
+++ b/src/template.c
@@ -3099,7 +3099,6 @@ MATCH TemplateTypeParameter::matchArg(Scope *sc, Objects *tiargs,
         Declaration **psparam)
 {
     //printf("TemplateTypeParameter::matchArg()\n");
-    Type *t;
     Object *oarg;
     MATCH m = MATCHexact;
     Type *ta;
@@ -3128,8 +3127,6 @@ MATCH TemplateTypeParameter::matchArg(Scope *sc, Objects *tiargs,
     }
     //printf("ta is %s\n", ta->toChars());
 
-    t = (Type *)dedtypes->tdata()[i];
-
     if (specType)
     {
         if (!ta || ta == tdummy)
@@ -3144,30 +3141,29 @@ MATCH TemplateTypeParameter::matchArg(Scope *sc, Objects *tiargs,
 
         if (m2 < m)
             m = m2;
-        t = (Type *)dedtypes->tdata()[i];
+        if (dedtypes->tdata()[i])
+            ta = (Type *)dedtypes->tdata()[i];
     }
     else
     {
-        // So that matches with specializations are better
-        m = MATCHconvert;
-
-        if (t)
+        if (dedtypes->tdata()[i])
         {   // Must match already deduced type
+            Type *t = (Type *)dedtypes->tdata()[i];
 
-            m = MATCHexact;
             if (!t->equals(ta))
             {   //printf("t = %s ta = %s\n", t->toChars(), ta->toChars());
                 goto Lnomatch;
             }
         }
+        else
+        {
+            // So that matches with specializations are better
+            m = MATCHconvert;
+        }
     }
+    dedtypes->tdata()[i] = ta;
 
-    if (!t)
-    {
-        dedtypes->tdata()[i] = ta;
-        t = ta;
-    }
-    *psparam = new AliasDeclaration(loc, ident, t);
+    *psparam = new AliasDeclaration(loc, ident, ta);
     //printf("\tm = %d\n", m);
     return m;
 

--- a/src/template.h
+++ b/src/template.h
@@ -159,6 +159,8 @@ struct TemplateTypeParameter : TemplateParameter
     Type *specType;     // type parameter: if !=NULL, this is the type specialization
     Type *defaultType;
 
+    static Type *tdummy;
+
     TemplateTypeParameter(Loc loc, Identifier *ident, Type *specType, Type *defaultType);
 
     TemplateTypeParameter *isTemplateTypeParameter();

--- a/src/template.h
+++ b/src/template.h
@@ -144,7 +144,7 @@ struct TemplateParameter
 
     /* Match actual argument against parameter.
      */
-    virtual MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam, int flags = 0) = 0;
+    virtual MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam) = 0;
 
     /* Create dummy argument based on parameter.
      */
@@ -172,7 +172,7 @@ struct TemplateTypeParameter : TemplateParameter
     Object *specialization();
     Object *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
-    MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam, int flags);
+    MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -216,7 +216,7 @@ struct TemplateValueParameter : TemplateParameter
     Object *specialization();
     Object *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
-    MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam, int flags);
+    MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -243,7 +243,7 @@ struct TemplateAliasParameter : TemplateParameter
     Object *specialization();
     Object *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
-    MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam, int flags);
+    MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -264,7 +264,7 @@ struct TemplateTupleParameter : TemplateParameter
     Object *specialization();
     Object *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
-    MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam, int flags);
+    MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 


### PR DESCRIPTION
This is small refactoring for `TemplateParameter::matchArg()`.
