### PR TITLE
Issue 2442 & 2443 - More foreach + opApply fix

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -2398,7 +2398,7 @@ MATCH FuncDeclaration::leastAsSpecialized(FuncDeclaration *g)
     {
         if (tf->mod != tg->mod)
         {
-            if (tg->mod == MODconst)
+            if (MODimplicitConv(tf->mod, tg->mod))
                 match = MATCHconst;
             else
                 return MATCHnomatch;

--- a/src/opover.c
+++ b/src/opover.c
@@ -35,7 +35,7 @@
 #include "aggregate.h"
 #include "template.h"
 
-static void inferApplyArgTypesX(FuncDeclaration *fstart, Parameters *arguments);
+static Dsymbol *inferApplyArgTypesX(FuncDeclaration *fstart, Parameters *arguments);
 static void inferApplyArgTypesZ(TemplateDeclaration *tstart, Parameters *arguments);
 static int inferApplyArgTypesY(TypeFunction *tf, Parameters *arguments);
 static void templateResolve(Match *m, TemplateDeclaration *td, Scope *sc, Loc loc, Objects *targsi, Expression *ethis, Expressions *arguments);
@@ -1212,10 +1212,8 @@ Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid)
 }
 
 
-int ForeachStatement::inferAggregate(Scope *sc, Dsymbol** sapply)
+int ForeachStatement::inferAggregate(Scope *sc, Dsymbol *&sapply)
 {
-    assert(sapply);
-
     Identifier *idapply = (op == TOKforeach) ? Id::apply : Id::applyReverse;
 #if DMDV2
     Identifier *idhead = (op == TOKforeach) ? Id::Fhead : Id::Ftoe;
@@ -1253,8 +1251,8 @@ int ForeachStatement::inferAggregate(Scope *sc, Dsymbol** sapply)
 #if DMDV2
                 if (!sliced)
                 {
-                    *sapply = search_function(ad, idapply);
-                    if (*sapply)
+                    sapply = search_function(ad, idapply);
+                    if (sapply)
                     {   // opApply aggregate
                         break;
                     }
@@ -1282,8 +1280,8 @@ int ForeachStatement::inferAggregate(Scope *sc, Dsymbol** sapply)
                     continue;
                 }
 #else
-                *sapply = search_function(ad, idapply);
-                if (*sapply)
+                sapply = search_function(ad, idapply);
+                if (sapply)
                 {   // opApply aggregate
                     break;
                 }
@@ -1291,6 +1289,10 @@ int ForeachStatement::inferAggregate(Scope *sc, Dsymbol** sapply)
                 goto Lerr;
 
             case Tdelegate:
+                if (aggr->op == TOKdelegate)
+                {   DelegateExp *de = (DelegateExp *)aggr;
+                    sapply = de->func->isFuncDeclaration();
+                }
                 break;
 
             case Terror:
@@ -1313,17 +1315,40 @@ Lerr:
  * them from the aggregate type.
  */
 
-void ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *sapply)
+int ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *&sapply)
 {
     if (!arguments || !arguments->dim)
-        return;
+        return 0;
+
+    if (sapply)     // prefer opApply
+    {
+        for (size_t u = 0; u < arguments->dim; u++)
+        {   Parameter *arg = arguments->tdata()[u];
+            if (arg->type)
+                arg->type = arg->type->semantic(loc, sc);
+        }
+
+        /* Look for like an
+         *  int opApply(int delegate(ref Type [, ...]) dg);
+         * overload
+         */
+        FuncDeclaration *fd = sapply->isFuncDeclaration();
+        if (fd)
+        {   sapply = inferApplyArgTypesX(fd, arguments);
+        }
+#if 0
+        TemplateDeclaration *td = sapply->isTemplateDeclaration();
+        if (td)
+        {   inferApplyArgTypesZ(td, arguments);
+        }
+#endif
+        return sapply ? 1 : 0;
+    }
 
     /* Return if no arguments need types.
      */
-    for (size_t u = 0; 1; u++)
-    {   if (u == arguments->dim)
-            return;
-        Parameter *arg = arguments->tdata()[u];
+    for (size_t u = 0; u < arguments->dim; u++)
+    {   Parameter *arg = arguments->tdata()[u];
         if (!arg->type)
             break;
     }
@@ -1332,8 +1357,7 @@ void ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *sapply)
 
     Parameter *arg = arguments->tdata()[0];
     Type *taggr = aggr->type;
-    if (!taggr)
-        return;
+    assert(taggr);
     Type *tab = taggr->toBasetype();
     switch (tab->ty)
     {
@@ -1373,9 +1397,6 @@ void ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *sapply)
             goto Laggr;
 
         Laggr:
-            if (sapply)
-                goto Lapply;                    // prefer opApply
-
             if (arguments->dim == 1)
             {
                 if (!arg->type)
@@ -1388,7 +1409,7 @@ void ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *sapply)
                     if (!fd)
                     {   if (s && s->isTemplateDeclaration())
                             break;
-                        goto Lapply;
+                        break;
                     }
                     // Resolve inout qualifier of front type
                     arg->type = fd->type->nextOf();
@@ -1397,77 +1418,53 @@ void ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *sapply)
                 }
                 break;
             }
-
-        Lapply:
-        {   /* Look for an
-             *  int opApply(int delegate(ref Type [, ...]) dg);
-             * overload
-             */
-            if (sapply)
-            {
-                FuncDeclaration *fd = sapply->isFuncDeclaration();
-                if (fd)
-                {   inferApplyArgTypesX(fd, arguments);
-                    break;
-                }
-#if 0
-                TemplateDeclaration *td = sapply->isTemplateDeclaration();
-                if (td)
-                {   inferApplyArgTypesZ(td, arguments);
-                    break;
-                }
-#endif
-            }
             break;
-        }
 
         case Tdelegate:
         {
-            if (0 && aggr->op == TOKdelegate)
-            {   DelegateExp *de = (DelegateExp *)aggr;
-
-                FuncDeclaration *fd = de->func->isFuncDeclaration();
-                if (fd)
-                    inferApplyArgTypesX(fd, arguments);
-            }
-            else
-            {
-                inferApplyArgTypesY((TypeFunction *)tab->nextOf(), arguments);
-            }
+            if (!inferApplyArgTypesY((TypeFunction *)tab->nextOf(), arguments))
+                return 0;
             break;
         }
 
         default:
             break;              // ignore error, caught later
     }
+    return 1;
 }
 
-/********************************
- * Recursive helper function,
- * analogous to func.overloadResolveX().
- */
-
-int fp3(void *param, FuncDeclaration *f)
+static Dsymbol *inferApplyArgTypesX(FuncDeclaration *fstart, Parameters *arguments)
 {
-    Parameters *arguments = (Parameters *)param;
-    TypeFunction *tf = (TypeFunction *)f->type;
-    if (inferApplyArgTypesY(tf, arguments) == 1)
-        return 0;
-    if (arguments->dim == 0)
-        return 1;
-    return 0;
-}
+    struct Param3
+    {
+        Parameters *arguments;
+        FuncDeclaration *fd;
 
-static void inferApplyArgTypesX(FuncDeclaration *fstart, Parameters *arguments)
-{
-    overloadApply(fstart, &fp3, arguments);
+        static int fp(void *param, FuncDeclaration *f)
+        {
+            Param3 *p = (Param3 *)param;
+            TypeFunction *tf = (TypeFunction *)f->type;
+
+            if (!inferApplyArgTypesY(tf, p->arguments))
+                return 0;
+
+            p->fd = f;
+            return 1;
+        }
+    };
+
+    Param3 p;
+    p.arguments = arguments;
+    p.fd = NULL;
+    overloadApply(fstart, &Param3::fp, &p);
+    return p.fd;
 }
 
 /******************************
  * Infer arguments from type of function.
  * Returns:
- *      0 match for this function
- *      1 no match for this function
+ *      1 match for this function
+ *      0 no match for this function
  */
 
 static int inferApplyArgTypesY(TypeFunction *tf, Parameters *arguments)
@@ -1497,22 +1494,22 @@ static int inferApplyArgTypesY(TypeFunction *tf, Parameters *arguments)
         Parameter *param = Parameter::getNth(tf->parameters, u);
         if (arg->type)
         {   if (!arg->type->equals(param->type))
-            {
-                /* Cannot resolve argument types. Indicate an
-                 * error by setting the number of arguments to 0.
-                 */
-                arguments->dim = 0;
-                goto Lmatch;
-            }
+                goto Lnomatch;
             continue;
         }
-        arg->type = param->type;
     }
   Lmatch:
-    return 0;
+    for (size_t u = 0; u < nparams; u++)
+    {
+        Parameter *arg = arguments->tdata()[u];
+        Parameter *param = Parameter::getNth(tf->parameters, u);
+        if (!arg->type)
+            arg->type = param->type;
+    }
+    return 1;
 
   Lnomatch:
-    return 1;
+    return 0;
 }
 
 /*******************************************

--- a/src/statement.c
+++ b/src/statement.c
@@ -1873,7 +1873,6 @@ Lagain:
         {
             Expression *ec;
             Expression *e;
-            Parameter *a;
 
             if (!checkForArgTypes())
             {   body = body->semanticNoScope(sc);
@@ -1894,34 +1893,74 @@ Lagain:
                 sc->func->vresult = v;
             }
 
+            TypeFunction *tfld = NULL;
+            if (sapply)
+            {   FuncDeclaration *fdapply = sapply->isFuncDeclaration();
+                if (fdapply)
+                {   assert(fdapply->type && fdapply->type->ty == Tfunction);
+                    tfld = (TypeFunction *)fdapply->type->semantic(loc, sc);
+                    goto Lget;
+                }
+                else if (tab->ty == Tdelegate)
+                {
+                    tfld = (TypeFunction *)tab->nextOf();
+                Lget:
+                    //printf("tfld = %s\n", tfld->toChars());
+                    if (tfld->parameters->dim == 1)
+                    {
+                        Parameter *p = Parameter::getNth(tfld->parameters, 0);
+                        if (p->type && p->type->ty == Tdelegate)
+                        {   Type *t = p->type->semantic(loc, sc);
+                            assert(t->ty == Tdelegate);
+                            tfld = (TypeFunction *)t->nextOf();
+                        }
+                    }
+                }
+            }
+
             /* Turn body into the function literal:
              *  int delegate(ref T arg) { body }
              */
             Parameters *args = new Parameters();
             for (size_t i = 0; i < dim; i++)
             {   Parameter *arg = arguments->tdata()[i];
+                StorageClass stc = STCref;
                 Identifier *id;
 
                 arg->type = arg->type->semantic(loc, sc);
-                if (arg->storageClass & STCref)
+                if (tfld)
+                {   Parameter *prm = Parameter::getNth(tfld->parameters, i);
+                    //printf("\tprm = %s%s\n", (prm->storageClass&STCref?"ref ":""), prm->ident->toChars());
+                    stc = prm->storageClass & STCref;
+                    id = arg->ident;    // argument copy is not need.
+                    if ((arg->storageClass & STCref) != stc)
+                    {   if (!stc)
+                            error("foreach: cannot make %s ref", arg->ident->toChars());
+                        goto LcopyArg;
+                    }
+                }
+                else if (arg->storageClass & STCref)
+                {   // default delegate parameters are marked as ref, then
+                    // argument copy is not need.
                     id = arg->ident;
+                }
                 else
                 {   // Make a copy of the ref argument so it isn't
                     // a reference.
-
+                LcopyArg:
                     id = Lexer::uniqueId("__applyArg", i);
+
                     Initializer *ie = new ExpInitializer(0, new IdentifierExp(0, id));
                     VarDeclaration *v = new VarDeclaration(0, arg->type, arg->ident, ie);
                     s = new ExpStatement(0, v);
                     body = new CompoundStatement(loc, s, body);
                 }
-                a = new Parameter(STCref, arg->type, id, NULL);
-                args->push(a);
+                args->push(new Parameter(stc, arg->type, id, NULL));
             }
-            Type *t = new TypeFunction(args, Type::tint32, 0, LINKd);
+            tfld = new TypeFunction(args, Type::tint32, 0, LINKd);
             cases = new Statements();
             gotos = new CompoundStatements();
-            FuncLiteralDeclaration *fld = new FuncLiteralDeclaration(loc, 0, t, TOKdelegate, this);
+            FuncLiteralDeclaration *fld = new FuncLiteralDeclaration(loc, 0, tfld, TOKdelegate, this);
             fld->fbody = body;
             Expression *flde = new FuncExp(loc, fld);
             flde = flde->semantic(sc);

--- a/src/statement.c
+++ b/src/statement.c
@@ -1403,17 +1403,15 @@ Statement *ForeachStatement::semantic(Scope *sc)
     if (func->fes)
         func = func->fes->func;
 
-    if (!inferAggregate(sc, &sapply))
+    if (!inferAggregate(sc, sapply))
     {
         error("invalid foreach aggregate %s", aggr->toChars());
         return this;
     }
 
-    inferApplyArgTypes(sc, sapply);
-
     /* Check for inference errors
      */
-    if (dim != arguments->dim)
+    if (!inferApplyArgTypes(sc, sapply))
     {
         //printf("dim = %d, arguments->dim = %d\n", dim, arguments->dim);
         error("cannot uniquely infer foreach argument types");

--- a/src/statement.h
+++ b/src/statement.h
@@ -348,8 +348,8 @@ struct ForeachStatement : Statement
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     bool checkForArgTypes();
-    int inferAggregate(Scope *sc, Dsymbol **sapply);
-    void inferApplyArgTypes(Scope *sc, Dsymbol *sapply);
+    int inferAggregate(Scope *sc, Dsymbol *&sapply);
+    int inferApplyArgTypes(Scope *sc, Dsymbol *&sapply);
     int hasBreak();
     int hasContinue();
     int usesEH();

--- a/test/runnable/foreach.d
+++ b/test/runnable/foreach.d
@@ -9,37 +9,37 @@ void test1()
 
     foreach (char c; "abcd")
     {
-	switch (i++)
-	{   case 0:	assert(c == 'a');	break;
-	    case 1:	assert(c == 'b');	break;
-	    case 2:	assert(c == 'c');	break;
-	    case 3:	assert(c == 'd');	break;
-	    default:	assert(0);
-	}
+        switch (i++)
+        {   case 0:     assert(c == 'a');   break;
+            case 1:     assert(c == 'b');   break;
+            case 2:     assert(c == 'c');   break;
+            case 3:     assert(c == 'd');   break;
+            default:    assert(0);
+        }
     }
 
     i = 0;
     foreach (wchar c; "asdf")
     {
-	switch (i++)
-	{   case 0:	assert(c == 'a');	break;
-	    case 1:	assert(c == 's');	break;
-	    case 2:	assert(c == 'd');	break;
-	    case 3:	assert(c == 'f');	break;
-	    default:	assert(0);
-	}
+        switch (i++)
+        {   case 0:     assert(c == 'a');   break;
+            case 1:     assert(c == 's');   break;
+            case 2:     assert(c == 'd');   break;
+            case 3:     assert(c == 'f');   break;
+            default:    assert(0);
+        }
     }
 
     i = 0;
     foreach (dchar c; "bncd")
     {
-	switch (i++)
-	{   case 0:	assert(c == 'b');	break;
-	    case 1:	assert(c == 'n');	break;
-	    case 2:	assert(c == 'c');	break;
-	    case 3:	assert(c == 'd');	break;
-	    default:	assert(0);
-	}
+        switch (i++)
+        {   case 0:     assert(c == 'b');   break;
+            case 1:     assert(c == 'n');   break;
+            case 2:     assert(c == 'c');   break;
+            case 3:     assert(c == 'd');   break;
+            default:    assert(0);
+        }
     }
 }
 
@@ -58,14 +58,14 @@ void test2()
 
     foreach (uint u; a)
     {
-	switch (i++)
-	{   case 0:	assert(u == 16);	break;
-	    case 1:	assert(u == 1);		break;
-	    case 2:	assert(u == 5);		break;
-	    case 3:	assert(u == 8);		break;
-	    case 4:	assert(u == 3);		break;
-	    default:	assert(0);
-	}
+        switch (i++)
+        {   case 0:     assert(u == 16);    break;
+            case 1:     assert(u == 1);     break;
+            case 2:     assert(u == 5);     break;
+            case 3:     assert(u == 8);     break;
+            case 4:     assert(u == 3);     break;
+            default:    assert(0);
+        }
     }
 
     uint[] b = a;
@@ -73,14 +73,14 @@ void test2()
     i = 0;
     foreach (uint u; b)
     {
-	switch (i++)
-	{   case 0:	assert(u == 16);	break;
-	    case 1:	assert(u == 1);		break;
-	    case 2:	assert(u == 5);		break;
-	    case 3:	assert(u == 8);		break;
-	    case 4:	assert(u == 3);		break;
-	    default:	assert(0);
-	}
+        switch (i++)
+        {   case 0:     assert(u == 16);    break;
+            case 1:     assert(u == 1);     break;
+            case 2:     assert(u == 5);     break;
+            case 3:     assert(u == 8);     break;
+            case 4:     assert(u == 3);     break;
+            default:    assert(0);
+        }
     }
 
     test2_x(a);
@@ -92,14 +92,14 @@ void test2_x(uint[5] a)
 
     foreach (uint u; a)
     {
-	switch (i++)
-	{   case 0:	assert(u == 16);	break;
-	    case 1:	assert(u == 1);		break;
-	    case 2:	assert(u == 5);		break;
-	    case 3:	assert(u == 8);		break;
-	    case 4:	assert(u == 3);		break;
-	    default:	assert(0);
-	}
+        switch (i++)
+        {   case 0:     assert(u == 16);    break;
+            case 1:     assert(u == 1);     break;
+            case 2:     assert(u == 5);     break;
+            case 3:     assert(u == 8);     break;
+            case 4:     assert(u == 3);     break;
+            default:    assert(0);
+        }
     }
 }
 
@@ -114,8 +114,8 @@ void test3()
 
     foreach (ref uint u; a)
     {
-	i += u;
-	u++;
+        i += u;
+        u++;
     }
     assert(i == 16);
     assert(a[0] == 17);
@@ -123,8 +123,8 @@ void test3()
 
     foreach (uint u; a)
     {
-	printf("u = %d\n", u);
-	//u++;
+        printf("u = %d\n", u);
+        //u++;
     }
     assert(a[0] == 17);
     assert(a[4] == 1);
@@ -184,19 +184,19 @@ void test6()
 
     foreach (int i, ref long v; a)
     {
-	printf("a[%d] = %lld\n", i, v);
-	b[i] = v;
+        printf("a[%d] = %lld\n", i, v);
+        b[i] = v;
     }
 
     for (uint i = 0; i < 3; i++)
     {
-	assert(b[i] == 21 + i);
+        assert(b[i] == 21 + i);
     }
 
     foreach (ref long v; a)
     {
-	printf("a[] = %lld\n", v);
-	sum += v;
+        printf("a[] = %lld\n", v);
+        sum += v;
     }
     assert(sum == 21 + 22 + 23);
 }
@@ -211,13 +211,13 @@ void test7()
     a["bar"] = 4;
     foreach (string s, uint v; a)
     {
-	printf("a[%.*s] = %d\n", s, v);
-	if (s == "bar")
-	    assert(v == 4);
-	else if (s == "foo")
-	    assert(v == 3);
-	else
-	    assert(0);
+        printf("a[%.*s] = %d\n", s, v);
+        if (s == "bar")
+            assert(v == 4);
+        else if (s == "foo")
+            assert(v == 3);
+        else
+            assert(0);
     }
 }
 
@@ -230,8 +230,8 @@ class Foo8
 
     int opApply(int delegate(ref int a, ref int b, ref int c) dg)
     {
-	int result = dg(x, y, z);
-	return 0;
+        int result = dg(x, y, z);
+        return 0;
     }
 }
 
@@ -243,23 +243,23 @@ void test8()
     f.z = 83;
     foreach (int a, ref int b, int c; f)
     {
-	printf("a = %d, b = %d, c = %d\n", a, b, c);
-	assert(a == 63);
-	assert(b == 47);
-	assert(c == 83);
-	a++;
-	b++;
-	c++;
+        printf("a = %d, b = %d, c = %d\n", a, b, c);
+        assert(a == 63);
+        assert(b == 47);
+        assert(c == 83);
+        a++;
+        b++;
+        c++;
     }
     foreach (int a, ref int b, int c; f)
     {
-	printf("a = %d, b = %d, c = %d\n", a, b, c);
-	assert(a == 63);
-	assert(b == 48);
-	assert(c == 83);
-	a++;
-	b++;
-	c++;
+        printf("a = %d, b = %d, c = %d\n", a, b, c);
+        assert(a == 63);
+        assert(b == 48);
+        assert(c == 83);
+        a++;
+        b++;
+        c++;
     }
 }
 

--- a/test/runnable/foreach2.d
+++ b/test/runnable/foreach2.d
@@ -13,8 +13,8 @@ void test1()
 
     foreach (uint u; a)
     {
-	i++;
-	u++;
+        i++;
+        u++;
     }
     assert(i == 2);
     assert(a["hello"] == 73);
@@ -33,8 +33,8 @@ void test2()
 
     foreach (ref uint u; a)
     {
-	i++;
-	u++;
+        i++;
+        u++;
     }
     assert(i == 2);
     assert(a["hello"] == 74);
@@ -53,10 +53,10 @@ void test3()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    break;
-	u++;
+        i++;
+        if (i)
+            break;
+        u++;
     }
     assert(i == 1);
     assert(a["hello"] == 73);
@@ -75,14 +75,14 @@ void test4()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i == 1)
-	    continue;
-	u++;
+        i++;
+        if (i == 1)
+            continue;
+        u++;
     }
     assert(i == 2);
     assert((a["hello"] == 73 && a["world"] == 83) ||
-	   (a["hello"] == 74 && a["world"] == 82));
+           (a["hello"] == 74 && a["world"] == 82));
 }
 
 /**************************************************/
@@ -98,13 +98,13 @@ void test5()
 Loop:
     while (1)
     {
-	foreach (ref uint u; a)
-	{
-	    i++;
-	    if (i)
-		break Loop;
-	    u++;
-	}
+        foreach (ref uint u; a)
+        {
+            i++;
+            if (i)
+                break Loop;
+            u++;
+        }
     }
     assert(i == 1);
     assert(a["hello"] == 73);
@@ -124,14 +124,14 @@ void test6()
 Loop:
     while (1)
     {
-	foreach (ref uint u; a)
-	{
-	    i++;
-	    if (i == 1)
-		continue Loop;
-	    u++;
-	}
-	break;
+        foreach (ref uint u; a)
+        {
+            i++;
+            if (i == 1)
+                continue Loop;
+            u++;
+        }
+        break;
     }
     assert(i == 3);
     assert(a["hello"] == 74);
@@ -150,10 +150,10 @@ void test7()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    goto Label;
-	u++;
+        i++;
+        if (i)
+            goto Label;
+        u++;
     }
     assert(0);
 Label:
@@ -165,14 +165,14 @@ Label:
 /**************************************************/
 
 void test8_x(uint[char[]] a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return;
-	u++;
+        i++;
+        if (i)
+            return;
+        u++;
     }
 }
 
@@ -193,14 +193,14 @@ void test8()
 /**************************************************/
 
 int test9_x(uint[char[]] a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return 67;
-	u++;
+        i++;
+        if (i)
+            return 67;
+        u++;
     }
     return 23;
 }
@@ -222,14 +222,14 @@ void test9()
 /**************************************************/
 
 int test10_x(uint[char[]] a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return i;
-	u++;
+        i++;
+        if (i)
+            return i;
+        u++;
     }
     return 23;
 }

--- a/test/runnable/foreach3.d
+++ b/test/runnable/foreach3.d
@@ -6,15 +6,15 @@ struct Foo
     uint array[2];
 
     int opApply(int delegate(ref uint) dg)
-    {	int result;
-
-	for (int i = 0; i < array.length; i++)
-	{
-	    result = dg(array[i]);
-	    if (result)
-		break;
-	}
-	return result;
+    {
+        int result;
+        for (int i = 0; i < array.length; i++)
+        {
+            result = dg(array[i]);
+            if (result)
+                break;
+        }
+        return result;
     }
 }
 
@@ -31,8 +31,8 @@ void test1()
 
     foreach (uint u; a)
     {
-	i++;
-	u++;
+        i++;
+        u++;
     }
     assert(i == 2);
     assert(a.array[0] == 73);
@@ -51,8 +51,8 @@ void test2()
 
     foreach (ref uint u; a)
     {
-	i++;
-	u++;
+        i++;
+        u++;
     }
     assert(i == 2);
     assert(a.array[0] == 74);
@@ -71,10 +71,10 @@ void test3()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    break;
-	u++;
+        i++;
+        if (i)
+            break;
+        u++;
     }
     assert(i == 1);
     assert(a.array[0] == 73);
@@ -93,10 +93,10 @@ void test4()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i == 1)
-	    continue;
-	u++;
+        i++;
+        if (i == 1)
+            continue;
+        u++;
     }
     assert(i == 2);
     assert(a.array[0] == 73 && a.array[1] == 83);
@@ -115,13 +115,13 @@ void test5()
 Loop:
     while (1)
     {
-	foreach (ref uint u; a)
-	{
-	    i++;
-	    if (i)
-		break Loop;
-	    u++;
-	}
+        foreach (ref uint u; a)
+        {
+            i++;
+            if (i)
+                break Loop;
+            u++;
+        }
     }
     assert(i == 1);
     assert(a.array[0] == 73);
@@ -141,14 +141,14 @@ void test6()
 Loop:
     while (1)
     {
-	foreach (ref uint u; a)
-	{
-	    i++;
-	    if (i == 1)
-		continue Loop;
-	    u++;
-	}
-	break;
+        foreach (ref uint u; a)
+        {
+            i++;
+            if (i == 1)
+                continue Loop;
+            u++;
+        }
+        break;
     }
     assert(i == 3);
     assert(a.array[0] == 74);
@@ -167,10 +167,10 @@ void test7()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    goto Label;
-	u++;
+        i++;
+        if (i)
+            goto Label;
+        u++;
     }
     assert(0);
 Label:
@@ -182,14 +182,14 @@ Label:
 /**************************************************/
 
 void test8_x(Foo a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return;
-	u++;
+        i++;
+        if (i)
+            return;
+        u++;
     }
 }
 
@@ -210,14 +210,14 @@ void test8()
 /**************************************************/
 
 int test9_x(Foo a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return 67;
-	u++;
+        i++;
+        if (i)
+            return 67;
+        u++;
     }
     return 23;
 }
@@ -239,14 +239,14 @@ void test9()
 /**************************************************/
 
 int test10_x(Foo a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return i;
-	u++;
+        i++;
+        if (i)
+            return i;
+        u++;
     }
     return 23;
 }

--- a/test/runnable/foreach4.d
+++ b/test/runnable/foreach4.d
@@ -11,15 +11,15 @@ class Foo
     uint array[2];
 
     int opApply(int delegate(ref uint) dg)
-    {	int result;
-
-	for (int i = 0; i < array.length; i++)
-	{
-	    result = dg(array[i]);
-	    if (result)
-		break;
-	}
-	return result;
+    {
+        int result;
+        for (int i = 0; i < array.length; i++)
+        {
+            result = dg(array[i]);
+            if (result)
+                break;
+        }
+        return result;
     }
 }
 
@@ -36,8 +36,8 @@ void test1()
 
     foreach (uint u; a)
     {
-	i++;
-	u++;
+        i++;
+        u++;
     }
     assert(i == 2);
     assert(a.array[0] == 73);
@@ -56,8 +56,8 @@ void test2()
 
     foreach (ref uint u; a)
     {
-	i++;
-	u++;
+        i++;
+        u++;
     }
     assert(i == 2);
     assert(a.array[0] == 74);
@@ -76,10 +76,10 @@ void test3()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    break;
-	u++;
+        i++;
+        if (i)
+            break;
+        u++;
     }
     assert(i == 1);
     assert(a.array[0] == 73);
@@ -98,10 +98,10 @@ void test4()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i == 1)
-	    continue;
-	u++;
+        i++;
+        if (i == 1)
+            continue;
+        u++;
     }
     assert(i == 2);
     assert(a.array[0] == 73 && a.array[1] == 83);
@@ -120,13 +120,13 @@ void test5()
 Loop:
     while (1)
     {
-	foreach (ref uint u; a)
-	{
-	    i++;
-	    if (i)
-		break Loop;
-	    u++;
-	}
+        foreach (ref uint u; a)
+        {
+            i++;
+            if (i)
+                break Loop;
+            u++;
+        }
     }
     assert(i == 1);
     assert(a.array[0] == 73);
@@ -146,14 +146,14 @@ void test6()
 Loop:
     while (1)
     {
-	foreach (ref uint u; a)
-	{
-	    i++;
-	    if (i == 1)
-		continue Loop;
-	    u++;
-	}
-	break;
+        foreach (ref uint u; a)
+        {
+            i++;
+            if (i == 1)
+                continue Loop;
+            u++;
+        }
+        break;
     }
     assert(i == 3);
     assert(a.array[0] == 74);
@@ -172,10 +172,10 @@ void test7()
 
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    goto Label;
-	u++;
+        i++;
+        if (i)
+            goto Label;
+        u++;
     }
     assert(0);
 Label:
@@ -187,14 +187,14 @@ Label:
 /**************************************************/
 
 void test8_x(Foo a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return;
-	u++;
+        i++;
+        if (i)
+            return;
+        u++;
     }
 }
 
@@ -215,14 +215,14 @@ void test8()
 /**************************************************/
 
 int test9_x(Foo a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return 67;
-	u++;
+        i++;
+        if (i)
+            return 67;
+        u++;
     }
     return 23;
 }
@@ -244,14 +244,14 @@ void test9()
 /**************************************************/
 
 int test10_x(Foo a)
-{   int i;
-
+{
+    int i;
     foreach (ref uint u; a)
     {
-	i++;
-	if (i)
-	    return i;
-	u++;
+        i++;
+        if (i)
+            return i;
+        u++;
     }
     return 23;
 }
@@ -287,15 +287,15 @@ void test11()
     int j;
 
     for (int i = 0; i < 25; i += 5) {
-	data[i+0] = data[i+1] = true;
+        data[i+0] = data[i+1] = true;
     }
 
     for (int i = 0; i < 25; i++) {
-	printf("%d ", data[i]);
-	if ((i % 5) < 2)
-	    assert(data[i] == true);
-	else
-	    assert(data[i] == false);
+        printf("%d ", data[i]);
+        if ((i % 5) < 2)
+            assert(data[i] == true);
+        else
+            assert(data[i] == false);
     }
 
     printf("\n%d\n", data[22] = true);
@@ -303,39 +303,39 @@ void test11()
     assert(j == true);
 
     for (int i = 0; i < 25; i += 5) {
-	data[i+1] = data[i+3] = true;
-	j = i % 5;
-	if (j == 0 || j == 1 || j == 3)
-	    assert(data[i] == true);
-	else
-	    assert(data[i] == false);
+        data[i+1] = data[i+3] = true;
+        j = i % 5;
+        if (j == 0 || j == 1 || j == 3)
+            assert(data[i] == true);
+        else
+            assert(data[i] == false);
     }
 
     for (int i = 0; i < 25; i++) {
-	printf("%d ", data[i]);
+        printf("%d ", data[i]);
     }
 
     printf("\n");
 
     int k;
     foreach (bit b; data) {
-	printf("%d ", b);
-	j = k % 5;
-	if (j == 0 || j == 1 || j == 3 || k == 22)
-	    assert(data[k] == true);
-	else
-	    assert(data[k] == false);
-	k++;
+        printf("%d ", b);
+        j = k % 5;
+        if (j == 0 || j == 1 || j == 3 || k == 22)
+            assert(data[k] == true);
+        else
+            assert(data[k] == false);
+        k++;
     }
     printf("\n");
 
     foreach (int l, bit b; data) {
-	printf("%d ", b);
-	j = l % 5;
-	if (j == 0 || j == 1 || j == 3 || l == 22)
-	    assert(data[l] == true);
-	else
-	    assert(data[l] == false);
+        printf("%d ", b);
+        j = l % 5;
+        if (j == 0 || j == 1 || j == 3 || l == 22)
+            assert(data[l] == true);
+        else
+            assert(data[l] == false);
     }
     printf("\n");
 }
@@ -350,27 +350,27 @@ void test12()
     j = 0;
     foreach (dchar d; "hello")
     {
-	printf("d = x%x\n", d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	j++;
+        printf("d = x%x\n", d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        j++;
     }
     assert(j == 5);
 
     j = 0;
     foreach (size_t i, dchar d; "hello")
     {
-	printf("i = %d, d = x%x\n", i, d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	assert(i == j);
-	j++;
+        printf("i = %d, d = x%x\n", i, d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        assert(i == j);
+        j++;
     }
     assert(j == 5);
 }
@@ -384,27 +384,27 @@ void test13()
     j = 0;
     foreach (wchar d; "hello")
     {
-	printf("d = x%x\n", d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	j++;
+        printf("d = x%x\n", d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        j++;
     }
     assert(j == 5);
 
     j = 0;
     foreach (size_t i, wchar d; "hello")
     {
-	printf("i = %d, d = x%x\n", i, d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	assert(i == j);
-	j++;
+        printf("i = %d, d = x%x\n", i, d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        assert(i == j);
+        j++;
     }
     assert(j == 5);
 }
@@ -418,27 +418,27 @@ void test14()
     j = 0;
     foreach (char d; cast(wstring)"hello")
     {
-	printf("d = x%x\n", d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	j++;
+        printf("d = x%x\n", d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        j++;
     }
     assert(j == 5);
 
     j = 0;
     foreach (size_t i, char d; cast(wstring)"hello")
     {
-	printf("i = %d, d = x%x\n", i, d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	assert(i == j);
-	j++;
+        printf("i = %d, d = x%x\n", i, d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        assert(i == j);
+        j++;
     }
     assert(j == 5);
 }
@@ -452,27 +452,27 @@ void test15()
     j = 0;
     foreach (dchar d; cast(wstring)"hello")
     {
-	printf("d = x%x\n", d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	j++;
+        printf("d = x%x\n", d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        j++;
     }
     assert(j == 5);
 
     j = 0;
     foreach (size_t i, dchar d; cast(wstring)"hello")
     {
-	printf("i = %d, d = x%x\n", i, d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	assert(i == j);
-	j++;
+        printf("i = %d, d = x%x\n", i, d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        assert(i == j);
+        j++;
     }
     assert(j == 5);
 }
@@ -486,27 +486,27 @@ void test16()
     j = 0;
     foreach (char d; cast(dstring)"hello")
     {
-	printf("d = x%x\n", d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	j++;
+        printf("d = x%x\n", d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        j++;
     }
     assert(j == 5);
 
     j = 0;
     foreach (size_t i, char d; cast(dstring)"hello")
     {
-	printf("i = %d, d = x%x\n", i, d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	assert(i == j);
-	j++;
+        printf("i = %d, d = x%x\n", i, d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        assert(i == j);
+        j++;
     }
     assert(j == 5);
 }
@@ -520,27 +520,27 @@ void test17()
     j = 0;
     foreach (wchar d; cast(dstring)"hello")
     {
-	printf("d = x%x\n", d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	j++;
+        printf("d = x%x\n", d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        j++;
     }
     assert(j == 5);
 
     j = 0;
     foreach (size_t i, wchar d; cast(dstring)"hello")
     {
-	printf("i = %d, d = x%x\n", i, d);
-	if (j == 0) assert(d == 'h');
-	if (j == 1) assert(d == 'e');
-	if (j == 2) assert(d == 'l');
-	if (j == 3) assert(d == 'l');
-	if (j == 4) assert(d == 'o');
-	assert(i == j);
-	j++;
+        printf("i = %d, d = x%x\n", i, d);
+        if (j == 0) assert(d == 'h');
+        if (j == 1) assert(d == 'e');
+        if (j == 2) assert(d == 'l');
+        if (j == 3) assert(d == 'l');
+        if (j == 4) assert(d == 'o');
+        assert(i == j);
+        j++;
     }
     assert(j == 5);
 }
@@ -549,12 +549,12 @@ void test17()
 
 void test18()
 {
-    string a = "\xE2\x89\xA0";	// \u2260 encoded as 3 UTF-8 bytes
+    string a = "\xE2\x89\xA0";      // \u2260 encoded as 3 UTF-8 bytes
 
     foreach (dchar c; a)
     {
-	printf("a[] = %x\n", c);	// prints 'a[] = 2260'
-	assert(c == 0x2260);
+        printf("a[] = %x\n", c);    // prints 'a[] = 2260'
+        assert(c == 0x2260);
     }
 
     dstring b = "\u2260";
@@ -562,13 +562,13 @@ void test18()
     int i;
     foreach (char c; b)
     {
-	printf("%x, ", c);	// prints e2, 89, a0
-	if (i == 0) assert(c == 0xE2);
-	else if (i == 1) assert(c == 0x89);
-	else if (i == 2) assert(c == 0xA0);
-	else
-	    assert(0);
-	i++;
+        printf("%x, ", c);      // prints e2, 89, a0
+        if (i == 0) assert(c == 0xE2);
+        else if (i == 1) assert(c == 0x89);
+        else if (i == 2) assert(c == 0xA0);
+        else
+            assert(0);
+        i++;
     }
     printf("\n");
 }
@@ -577,16 +577,16 @@ void test18()
 
 void test19()
 {
-	string string = x"F0 9D 83 93";
+    string string = x"F0 9D 83 93";
 
-	int count=0;
-	dchar tmp;
-	foreach(dchar value ; string){
-		tmp=value;
-		count++;
-	}
-	assert(count==1);
-	assert(tmp==0x01D0D3);
+    int count=0;
+    dchar tmp;
+    foreach(dchar value ; string){
+        tmp=value;
+        count++;
+    }
+    assert(count==1);
+    assert(tmp==0x01D0D3);
 }
 
 /**************************************************/
@@ -619,14 +619,14 @@ void foo21(string[] args)
     assert(args.length == 3);
     foreach (i, arg; args)
     {
-	assert(typeid(typeof(i)) == typeid(size_t));
-	assert(typeid(typeof(arg)) == typeid(string));
-	writefln("args[%d] = '%s'", i, arg);
+        assert(typeid(typeof(i)) == typeid(size_t));
+        assert(typeid(typeof(arg)) == typeid(string));
+        writefln("args[%d] = '%s'", i, arg);
     }
     foreach (arg; args)
     {
-	assert(typeid(typeof(arg)) == typeid(string));
-	writefln("args[] = '%s'", arg);
+        assert(typeid(typeof(arg)) == typeid(string));
+        writefln("args[] = '%s'", arg);
     }
 }
 
@@ -652,26 +652,26 @@ void test22()
 
     foreach (key, value; map)
     {
-	assert(typeid(typeof(key)) == typeid(string));
-	assert(typeid(typeof(value)) == typeid(int));
-	writefln("map[%s] = %s", key, value);
+        assert(typeid(typeof(key)) == typeid(string));
+        assert(typeid(typeof(value)) == typeid(int));
+        writefln("map[%s] = %s", key, value);
     }
     foreach (key, int value; map)
     {
-	assert(typeid(typeof(key)) == typeid(string));
-	assert(typeid(typeof(value)) == typeid(int));
-	writefln("map[%s] = %s", key, value);
+        assert(typeid(typeof(key)) == typeid(string));
+        assert(typeid(typeof(value)) == typeid(int));
+        writefln("map[%s] = %s", key, value);
     }
     foreach (string key, value; map)
     {
-	assert(typeid(typeof(key)) == typeid(string));
-	assert(typeid(typeof(value)) == typeid(int));
-	writefln("map[%s] = %s", key, value);
+        assert(typeid(typeof(key)) == typeid(string));
+        assert(typeid(typeof(value)) == typeid(int));
+        writefln("map[%s] = %s", key, value);
     }
     foreach (value; map)
     {
-	assert(typeid(typeof(value)) == typeid(int));
-	writefln("map[] = %s", value);
+        assert(typeid(typeof(value)) == typeid(int));
+        writefln("map[] = %s", value);
     }
 }
 
@@ -682,27 +682,27 @@ class Foo23
     int array[2];
 
     int opApply(int delegate(ref int) dg)
-    {	int result;
-
-	for (int i = 0; i < array.length; i++)
-	{
-	    result = dg(array[i]);
-	    if (result)
-		break;
-	}
-	return result;
+    {
+        int result;
+        for (int i = 0; i < array.length; i++)
+        {
+            result = dg(array[i]);
+            if (result)
+                break;
+        }
+        return result;
     }
 
     int opApply(int delegate(ref size_t, ref int) dg)
-    {	int result;
-
-	for (size_t i = 0; i < array.length; i++)
-	{
-	    result = dg(i, array[i]);
-	    if (result)
-		break;
-	}
-	return result;
+    {
+        int result;
+        for (size_t i = 0; i < array.length; i++)
+        {
+            result = dg(i, array[i]);
+            if (result)
+                break;
+        }
+        return result;
     }
 }
 
@@ -716,11 +716,11 @@ void test23()
 
     foreach (u; a)
     {
-	assert(typeid(typeof(u)) == typeid(int));
-	i++;
-	u++;
-	//writefln("u = %d", u);
-	assert((i == 1) ? u == 74 : u == 83);
+        assert(typeid(typeof(u)) == typeid(int));
+        i++;
+        u++;
+        //writefln("u = %d", u);
+        assert((i == 1) ? u == 74 : u == 83);
     }
     assert(i == 2);
     assert(a.array[0] == 73);
@@ -728,13 +728,13 @@ void test23()
 
     foreach (j, u; a)
     {
-	assert(typeid(typeof(j)) == typeid(size_t));
-	assert(typeid(typeof(u)) == typeid(int));
-	i++;
-	u++;
-	writefln("u = %d", u);
-	assert((i == 3) ? u == 74 : u == 83);
-	assert(j == i - 3);
+        assert(typeid(typeof(j)) == typeid(size_t));
+        assert(typeid(typeof(u)) == typeid(int));
+        i++;
+        u++;
+        writefln("u = %d", u);
+        assert((i == 3) ? u == 74 : u == 83);
+        assert(j == i - 3);
     }
     assert(i == 4);
     assert(a.array[0] == 73);
@@ -743,22 +743,24 @@ void test23()
 
 /**************************************************/
 
-struct Collection24{
-	int opApply(int delegate(ref int) dg){
-		return 0;
-	}
+struct Collection24
+{
+    int opApply(int delegate(ref int) dg){
+        return 0;
+    }
 }
 
-bool foo24(){
-	Collection24 a,b;
-	
-	foreach(int x; a){
-		foreach(int y; b){
-			return false;
-		}
-	}
-	
-	return true;
+bool foo24()
+{
+    Collection24 a,b;
+
+    foreach(int x; a){
+        foreach(int y; b){
+            return false;
+        }
+    }
+
+    return true;
 }
 
 void test24()
@@ -773,11 +775,11 @@ void test25()
     alias void function(string[string]) FN;
     FN fn = function (string[string] aarray)
     {
-	foreach (string s; aarray)
-	{
-	    writeln(s);
-	    assert(s == "b");
-	}
+        foreach (string s; aarray)
+        {
+            writeln(s);
+            assert(s == "b");
+        }
     };
     string[string] aarray;
     aarray["a"] = "b";
@@ -791,15 +793,15 @@ struct Foo26
     uint array[2];
 
     int forward(int delegate(ref uint) dg)
-    {	int result;
-
-	for (int i = 0; i < array.length; i++)
-	{
-	    result = dg(array[i]);
-	    if (result)
-		break;
-	}
-	return result;
+    {
+        int result;
+        for (int i = 0; i < array.length; i++)
+        {
+            result = dg(array[i]);
+            if (result)
+                break;
+        }
+        return result;
     }
 
     int forward(int delegate(ref uint) dg, int x) { return 1; }
@@ -807,16 +809,16 @@ struct Foo26
     int reverse(int delegate(ref uint) dg, int x) { return 1; }
 
     int reverse(int delegate(ref uint) dg)
-    {	int result;
-
-	foreach_reverse (v; array)
-	{
-	    auto u = v;
-	    result = dg(u);
-	    if (result)
-		break;
-	}
-	return result;
+    {
+        int result;
+        foreach_reverse (v; array)
+        {
+            auto u = v;
+            result = dg(u);
+            if (result)
+                break;
+        }
+        return result;
     }
 }
 
@@ -831,9 +833,9 @@ void test26()
 
     foreach (u; &a.forward)
     {
-	writeln(u);
-	i++;
-	u++;
+        writeln(u);
+        i++;
+        u++;
     }
     assert(i == 2);
     assert(a.array[0] == 73);
@@ -841,7 +843,7 @@ void test26()
 
     foreach (uint u; &a.reverse)
     {
-	writeln(u);
+        writeln(u);
     }
 }
 
@@ -868,25 +870,25 @@ void test27()
 
     foreach (e; s)
     {
-	printf("%d\n", e);
-	r ~= cast(char)(e + '0');
+        printf("%d\n", e);
+        r ~= cast(char)(e + '0');
     }
     assert(r == "567");
 
     r = null;
     foreach_reverse (ref e; s)
     {
-	e++;
-	printf("%d\n", e);
-	r ~= cast(char)(e + '0');
+        e++;
+        printf("%d\n", e);
+        r ~= cast(char)(e + '0');
     }
     assert(r == "876");
 
     r = null;
     foreach (e; s)
     {
-	printf("%d\n", e);
-	r ~= cast(char)(e + '0');
+        printf("%d\n", e);
+        r ~= cast(char)(e + '0');
     }
     assert(r == "678");
 }

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -30,6 +30,33 @@ void test1()
 }
 
 /***************************************/
+// 2443
+
+struct S2443
+{
+    int[] arr;
+    int opApply(int delegate(size_t i, ref int v) dg)
+    {
+        int result = 0;
+        foreach (i, ref x; arr)
+        {
+            if ((result = dg(i, x)) != 0)
+                break;
+        }
+        return result;
+    }
+}
+
+void test2443()
+{
+    S2443 s;
+    foreach (i, ref v; s) {}
+    foreach (i,     v; s) {}
+    static assert(!__traits(compiles, { foreach (ref i, ref v; s) {} }));
+    static assert(!__traits(compiles, { foreach (ref i,     v; s) {} }));
+}
+
+/***************************************/
 // 3187
 
 class Collection
@@ -111,6 +138,7 @@ void test7004()
 int main()
 {
     test1();
+    test2443();
     test3187();
     test5605();
     test7004();

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -30,6 +30,86 @@ void test1()
 }
 
 /***************************************/
+// 2442
+
+template canForeach(T, E)
+{
+    enum canForeach = __traits(compiles,
+    {
+        foreach(a; new T)
+        {
+            static assert(is(typeof(a) == E));
+        }
+    });
+}
+
+void test2442()
+{
+    struct S1
+    {
+        int opApply(int delegate(ref const(int) v) dg) const { return 0; }
+        int opApply(int delegate(ref int v) dg)              { return 0; }
+    }
+          S1 ms1;
+    const S1 cs1;
+    foreach (x; ms1) { static assert(is(typeof(x) ==       int)); }
+    foreach (x; cs1) { static assert(is(typeof(x) == const int)); }
+
+    struct S2
+    {
+        int opApply(int delegate(ref  int v) dg) { return 0; }
+        int opApply(int delegate(ref long v) dg) { return 0; }
+    }
+    S2 ms2;
+    static assert(!__traits(compiles, { foreach (    x; ms2) {} }));    // ambiguous
+    static assert( __traits(compiles, { foreach (int x; ms2) {} }));
+
+    struct S3
+    {
+        int opApply(int delegate(ref int v) dg) const        { return 0; }
+        int opApply(int delegate(ref int v) dg) shared const { return 0; }
+    }
+    immutable S3 ms3;
+    static assert(!__traits(compiles, { foreach (int x; ms3) {} }));    // ambiguous
+
+    // from https://github.com/D-Programming-Language/dmd/pull/120
+    static class C
+    {
+        int opApply(int delegate(ref              int v) dg)              { return 0; }
+        int opApply(int delegate(ref        const int v) dg) const        { return 0; }
+        int opApply(int delegate(ref    immutable int v) dg) immutable    { return 0; }
+        int opApply(int delegate(ref       shared int v) dg) shared       { return 0; }
+        int opApply(int delegate(ref shared const int v) dg) shared const { return 0; }
+    }
+    static class D
+    {
+        int opApply(int delegate(ref int v) dg) const        { return 0; }
+    }
+    static class E
+    {
+        int opApply(int delegate(ref int v) dg) shared const { return 0; }
+    }
+
+    static assert( canForeach!(             C  ,              int  ));
+    static assert( canForeach!(       const(C) ,        const(int) ));
+    static assert( canForeach!(   immutable(C) ,    immutable(int) ));
+    static assert( canForeach!(      shared(C) ,       shared(int) ));
+    static assert( canForeach!(shared(const(C)), shared(const(int))));
+
+    static assert( canForeach!(             D  , int));
+    static assert( canForeach!(       const(D) , int));
+    static assert( canForeach!(   immutable(D) , int));
+    static assert(!canForeach!(      shared(D) , int));
+    static assert(!canForeach!(shared(const(D)), int));
+
+    static assert(!canForeach!(             E  , int));
+    static assert(!canForeach!(       const(E) , int));
+    static assert( canForeach!(   immutable(E) , int));
+    static assert( canForeach!(      shared(E) , int));
+    static assert( canForeach!(shared(const(E)), int));
+}
+
+/***************************************/
 // 2443
 
 struct S2443
@@ -138,6 +218,7 @@ void test7004()
 int main()
 {
     test1();
+    test2442();
     test2443();
     test3187();
     test5605();


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=2442">Issue 2442</a> - opApply does not allow inferring parameter types when overloaded on const
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=2443">Issue 2443</a> - opApply should allow delegates that are not ref if it makes no sense

@yebblies has already posted a pull request #120 against issue 2442, but it was not updated while half year.
