### PR TITLE
Allow 1.userproperty syntax.

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2071,7 +2071,10 @@ TOK Lexer::number(Token *t)
                         continue;
                     }
                     if (c == '.' && p[1] != '.')
+                    {   if (isalpha(p[1]) || p[1] == '_')
+                            goto done;
                         goto real;
+                    }
                     else if (c == 'i' || c == 'f' || c == 'F' ||
                              c == 'e' || c == 'E')
                     {

--- a/test/runnable/test16.d
+++ b/test/runnable/test16.d
@@ -269,7 +269,7 @@ void test9()
     {
 	len9(a[0], a[1], a[2], a[3]);
 
-	float justOne() { return 1.f; }
+	float justOne() { return 1.0f; }
 
 	float dot = justOne();
 	if (dot < 0.f)

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -425,7 +425,7 @@ void test24()
 
 void test25()
 {
-    ireal x = 4.Li;
+    ireal x = 4.0Li;
     ireal y = 4.0Li;
     ireal z = 4Li;
     creal c = 4L + 0Li;

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -555,7 +555,7 @@ void test16()
 
 void test17()
 {
-    creal z = 1. + 2.i;
+    creal z = 1. + 2.0i;
 
     real r = z.re;
     assert(r == 1.0);
@@ -672,7 +672,7 @@ void test21()
 
 void test22()
 {
-    creal z1 = 1. - 2.i;
+    creal z1 = 1. - 2.0i;
     ireal imag_part = z1.im/1i;
 }
 


### PR DESCRIPTION
At the same time, it disallows short floating literals like 1.f, 1.Li, ... (Part of issue 6277)
