### PR TITLE
Issue 7168 - & 7160 Fix regressions (2.057) of __traits

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -998,8 +998,7 @@ static int dimDg(void *ctx, size_t n, Dsymbol *)
 size_t ScopeDsymbol::dim(Dsymbols *members)
 {
     size_t n = 0;
-    if (members)
-        foreach(members, &dimDg, &n);
+    foreach(members, &dimDg, &n);
     return n;
 }
 #endif
@@ -1049,7 +1048,9 @@ Dsymbol *ScopeDsymbol::getNth(Dsymbols *members, size_t nth, size_t *pn)
 #if DMDV2
 int ScopeDsymbol::foreach(Dsymbols *members, ScopeDsymbol::ForeachDg dg, void *ctx, size_t *pn)
 {
-    assert(members);
+    assert(dg);
+    if (!members)
+        return 0;
 
     size_t n = pn ? *pn : 0; // take over index
     int result = 0;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8532,8 +8532,7 @@ void Parameter::argsToDecoBuffer(OutBuffer *buf, Parameters *arguments)
 {
     //printf("Parameter::argsToDecoBuffer()\n");
     // Write argument types
-    if (arguments)
-        foreach(arguments, &argsToDecoBufferDg, buf);
+    foreach(arguments, &argsToDecoBufferDg, buf);
 }
 
 /****************************************
@@ -8551,9 +8550,7 @@ static int isTPLDg(void *ctx, size_t n, Parameter *arg)
 int Parameter::isTPL(Parameters *arguments)
 {
     //printf("Parameter::isTPL()\n");
-    if (arguments)
-        return foreach(arguments, &isTPLDg, NULL);
-    return 0;
+    return foreach(arguments, &isTPLDg, NULL);
 }
 
 /****************************************************
@@ -8633,8 +8630,7 @@ static int dimDg(void *ctx, size_t n, Parameter *)
 size_t Parameter::dim(Parameters *args)
 {
     size_t n = 0;
-    if (args)
-        foreach(args, &dimDg, &n);
+    foreach(args, &dimDg, &n);
     return n;
 }
 
@@ -8679,7 +8675,9 @@ Parameter *Parameter::getNth(Parameters *args, size_t nth, size_t *pn)
 
 int Parameter::foreach(Parameters *args, Parameter::ForeachDg dg, void *ctx, size_t *pn)
 {
-    assert(args && dg);
+    assert(dg);
+    if (!args)
+        return 0;
 
     size_t n = pn ? *pn : 0; // take over index
     int result = 0;

--- a/src/traits.c
+++ b/src/traits.c
@@ -389,9 +389,20 @@ Expression *TraitsExp::semantic(Scope *sc)
         ScopeDsymbol::foreach(sd->members, &PushIdentsDg::dg, idents);
 
         ClassDeclaration *cd = sd->isClassDeclaration();
-        if (cd && cd->baseClass && ident == Id::allMembers)
-        {   sd = cd->baseClass; // do again with base class
-            ScopeDsymbol::foreach(sd->members, &PushIdentsDg::dg, idents);
+        if (cd && ident == Id::allMembers)
+        {
+            struct PushBaseMembers
+            {
+                static void dg(ClassDeclaration *cd, Identifiers *idents)
+                {
+                    if (cd->baseClass)
+                    {   ClassDeclaration *cb = cd->baseClass;
+                        ScopeDsymbol::foreach(cb->members, &PushIdentsDg::dg, idents);
+                        dg(cb, idents);
+                    }
+                }
+            };
+            PushBaseMembers::dg(cd, idents);
         }
 
         // Turn Identifiers into StringExps reusing the allocated array

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4283,6 +4283,27 @@ static assert(!__traits(hasMember, int, "x"));
 static assert( __traits(hasMember, int, "init"));
 
 /***************************************************/
+// 7168
+
+void test7168()
+{
+    static class X
+    {
+        void foo(){}
+    }
+    static class Y : X
+    {
+        void bar(){}
+    }
+
+    enum ObjectMembers = ["toString","toHash","opCmp","opEquals","Monitor","factory"];
+
+    static assert([__traits(allMembers, X)] == ["foo"]~ObjectMembers);          // pass
+    static assert([__traits(allMembers, Y)] == ["bar", "foo"]~ObjectMembers);   // fail
+    static assert([__traits(allMembers, Y)] != ["bar", "foo"]);                 // fail
+}
+
+/***************************************************/
 // 7170
 
 T to7170(T)(string x) { return 1; }
@@ -4496,6 +4517,7 @@ int main()
     test6868();
     test2856();
     test6056();
+    test7168();
     test7170();
 
     printf("Success\n");

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4283,6 +4283,22 @@ static assert(!__traits(hasMember, int, "x"));
 static assert( __traits(hasMember, int, "init"));
 
 /***************************************************/
+// 7160
+
+class HomeController {
+    static if (false) {
+        mixin(q{ int a; });
+    }
+    void foo() {
+        foreach (m; __traits(derivedMembers, HomeController)) {
+        }
+    }
+}
+
+void test7160()
+{}
+
+/***************************************************/
 // 7168
 
 void test7168()
@@ -4517,6 +4533,7 @@ int main()
     test6868();
     test2856();
     test6056();
+    test7160();
     test7168();
     test7170();
 


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7160">Issue 7160</a> - Regression(2.057): ICE(dsymbol.c:1052) ICE using __traits(derivedMembers)
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7168">Issue 7168</a> - Regression(2.057) __traits(allMembers) returns wrong tuple
