### PR TITLE
Issue 7170 - [UFCS] array + specialized template member syntax causes ICE

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7212,9 +7212,9 @@ Lshift:
                  *  array.foo!(tiargs)(args) into .foo!(tiargs)(array,args)
                  */
 #if DMDV2
-                e1 = new DotExp(dotti->loc,
+                e1 = new DotTemplateInstanceExp(dotti->loc,
                                 new IdentifierExp(dotti->loc, Id::empty),
-                                new ScopeExp(dotti->loc, dotti->ti));
+                                dotti->ti->name, dotti->ti->tiargs);
 #else
                 e1 = new ScopeExp(dotti->loc, dotti->ti);
 #endif

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4283,6 +4283,16 @@ static assert(!__traits(hasMember, int, "x"));
 static assert( __traits(hasMember, int, "init"));
 
 /***************************************************/
+// 7170
+
+T to7170(T)(string x) { return 1; }
+void test7170()
+{
+//  auto i = to7170!int("1");   // OK
+    auto j = "1".to7170!int();  // NG, Internal error: e2ir.c 683
+}
+
+/***************************************************/
 
 int main()
 {
@@ -4486,6 +4496,7 @@ int main()
     test6868();
     test2856();
     test6056();
+    test7170();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7170
