### PR TITLE
Issue 7173 - dmd: glue.c:1065: virtual unsigned int Type::totym(): Assertion `0' failed.

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -110,7 +110,7 @@ struct Expression : Object
     virtual void dump(int indent);
     void error(const char *format, ...);
     void warning(const char *format, ...);
-    virtual void rvalue();
+    virtual int rvalue();
 
     static Expression *combine(Expression *e1, Expression *e2);
     static Expressions *arraySyntaxCopy(Expressions *exps);
@@ -515,7 +515,7 @@ struct TypeExp : Expression
     TypeExp(Loc loc, Type *type);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    void rvalue();
+    int rvalue();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *optimize(int result);
     elem *toElem(IRState *irs);
@@ -537,7 +537,7 @@ struct TemplateExp : Expression
     TemplateDeclaration *td;
 
     TemplateExp(Loc loc, TemplateDeclaration *td);
-    void rvalue();
+    int rvalue();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 };
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -507,7 +507,7 @@ opover.obj : $(TOTALH) expression.h opover.c
 optimize.obj : $(TOTALH) expression.h optimize.c
 parse.obj : $(TOTALH) attrib.h lexer.h parse.h parse.c
 scope.obj : $(TOTALH) scope.h scope.c
-statement.obj : $(TOTALH) statement.h statement.c
+statement.obj : $(TOTALH) statement.h statement.c expression.h
 staticassert.obj : $(TOTALH) staticassert.h staticassert.c
 struct.obj : $(TOTALH) identifier.h enum.h struct.c
 traits.obj : $(TOTALH) traits.c

--- a/test/fail_compilation/fail7173.d
+++ b/test/fail_compilation/fail7173.d
@@ -1,0 +1,18 @@
+struct A{
+
+  A opBinary(string op)(A a){ A rt; return rt; }
+
+  void fun(){ }
+}
+
+struct B{
+
+  A _a;
+  alias _a this;
+}
+
+
+void main(){
+
+  B b1, b2, b3; b3 = (b1 - b2).fun();
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7173

This is `trySemantic` + `Expression::rvalue()` problem.

First, an AssignExp `b3 = (b1 - b2).fun();` tries call `AssignExp::op_overload`, but B does not have `opAssign`.
Next, AssignExp::op_overload tries to semantic of `b3._a = (b1 - b2).fun();` to resolve alias this.
But in this second `AssignExp`, the error caused by `e2->rvaue()` is gagged.
After go back to 1st `AssignExp`, `op_overload` returns `NULL`, but `e2->type` is rewritten to `Terror`.
So second call of `e2->rvalue()` does not cause an actual error, and then semantic incorrectly succeeds.
