### PR TITLE
Issue 3235 & 6714 - [tdpl] Improve function literal deduction

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1669,6 +1669,11 @@ void VarDeclaration::checkNestedReference(Scope *sc, Loc loc)
                 if (f == fdthis)
                     goto L1;
             }
+
+            // function literal has reference to enclosing scope is delegate
+            if (FuncLiteralDeclaration *fld = fdthis->isFuncLiteralDeclaration())
+                fld->tok = TOKdelegate;
+
             nestedrefs.push(fdthis);
           L1: ;
 

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1231,6 +1231,9 @@ Lnomatch:
         StructInitializer *si = init->isStructInitializer();
         ExpInitializer *ei = init->isExpInitializer();
 
+        if (ei && ei->exp->op == TOKfunction && !inferred)
+            ((FuncExp *)ei->exp)->setType(type);
+
         // See if initializer is a NewExp that can be allocated on the stack
         if (ei && isScope() && ei->exp->op == TOKnew)
         {   NewExp *ne = (NewExp *)ei->exp;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1099,6 +1099,10 @@ elem *FuncExp::toElem(IRState *irs)
     Symbol *s;
 
     //printf("FuncExp::toElem() %s\n", toChars());
+    if (fd->tok == TOKreserved && type->ty == Tpointer && fd->vthis)
+    {   fd->tok = TOKfunction;
+        fd->vthis = NULL;
+    }
     s = fd->toSymbol();
     e = el_ptr(s);
     if (fd->isNested())

--- a/src/expression.c
+++ b/src/expression.c
@@ -5090,7 +5090,8 @@ Expression *FuncExp::semantic(Scope *sc)
             ((TypeFunction *)fd->type)->next = Type::terror;
 
         // Type is a "delegate to" or "pointer to" the function literal
-        if (fd->isNested())
+        if ((fd->isNested() && fd->tok == TOKdelegate) ||
+            (tok == TOKreserved && tded && tded->ty == Tdelegate))
         {
             type = new TypeDelegate(fd->type);
             type = type->semantic(loc, sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -5056,7 +5056,9 @@ Expression *FuncExp::semantic(Scope *sc)
             {
                 Expression *e = inferType(sc, tded);
                 if (e)
+                {   e = e->castTo(sc, tded);
                     e = e->semantic(sc);
+                }
                 if (!e)
                 {   error("cannot infer function literal type");
                     e = new ErrorExp();
@@ -5209,6 +5211,13 @@ Expression *FuncExp::inferType(Scope *sc, Type *to)
         e = this;
     }
 
+    if (e)
+    {   // Check implicit function to delegate conversion
+        if (e->implicitConvTo(to))
+            e = e->castTo(sc, to);
+        else
+            e = NULL;
+    }
     return e;
 }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -5009,10 +5009,12 @@ void TupleExp::checkEscape()
 
 /******************************** FuncExp *********************************/
 
-FuncExp::FuncExp(Loc loc, FuncLiteralDeclaration *fd)
+FuncExp::FuncExp(Loc loc, FuncLiteralDeclaration *fd, TemplateDeclaration *td)
         : Expression(loc, TOKfunction, sizeof(FuncExp))
 {
     this->fd = fd;
+    this->td = td;
+    tok = fd->tok;  // save original kind of function/delegate/(infer)
 }
 
 Expression *FuncExp::syntaxCopy()

--- a/src/expression.h
+++ b/src/expression.h
@@ -675,6 +675,8 @@ struct FuncExp : Expression
     Expression *semantic(Scope *sc);
     Expression *semantic(Scope *sc, Expressions *arguments);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
+    MATCH implicitConvTo(Type *t);
+    Expression *castTo(Scope *sc, Type *t);
     Expression *inferType(Scope *sc, Type *t);
     void setType(Type *t);
     void scanForNestedRef(Scope *sc);

--- a/src/expression.h
+++ b/src/expression.h
@@ -673,6 +673,7 @@ struct FuncExp : Expression
     FuncExp(Loc loc, FuncLiteralDeclaration *fd, TemplateDeclaration *td = NULL);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
+    Expression *semantic(Scope *sc, Expressions *arguments);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     Expression *inferType(Scope *sc, Type *t);
     void setType(Type *t);

--- a/src/expression.h
+++ b/src/expression.h
@@ -665,8 +665,10 @@ struct OverExp : Expression
 struct FuncExp : Expression
 {
     FuncLiteralDeclaration *fd;
+    TemplateDeclaration *td;
+    enum TOK tok;
 
-    FuncExp(Loc loc, FuncLiteralDeclaration *fd);
+    FuncExp(Loc loc, FuncLiteralDeclaration *fd, TemplateDeclaration *td = NULL);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);

--- a/src/expression.h
+++ b/src/expression.h
@@ -667,11 +667,14 @@ struct FuncExp : Expression
     FuncLiteralDeclaration *fd;
     TemplateDeclaration *td;
     enum TOK tok;
+    Type *tded;
 
     FuncExp(Loc loc, FuncLiteralDeclaration *fd, TemplateDeclaration *td = NULL);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
+    Expression *inferType(Scope *sc, Type *t);
+    void setType(Type *t);
     void scanForNestedRef(Scope *sc);
     char *toChars();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/expression.h
+++ b/src/expression.h
@@ -668,6 +668,7 @@ struct FuncExp : Expression
     TemplateDeclaration *td;
     enum TOK tok;
     Type *tded;
+    Scope *scope;
 
     FuncExp(Loc loc, FuncLiteralDeclaration *fd, TemplateDeclaration *td = NULL);
     Expression *syntaxCopy();

--- a/src/func.c
+++ b/src/func.c
@@ -3018,6 +3018,8 @@ FuncLiteralDeclaration::FuncLiteralDeclaration(Loc loc, Loc endloc, Type *type,
 
     if (fes)
         id = "__foreachbody";
+    else if (tok == TOKreserved)
+        id = "__lambda";
     else if (tok == TOKdelegate)
         id = "__dgliteral";
     else
@@ -3046,7 +3048,7 @@ Dsymbol *FuncLiteralDeclaration::syntaxCopy(Dsymbol *s)
 int FuncLiteralDeclaration::isNested()
 {
     //printf("FuncLiteralDeclaration::isNested() '%s'\n", toChars());
-    return (tok == TOKdelegate);
+    return (tok != TOKfunction);
 }
 
 int FuncLiteralDeclaration::isVirtual()
@@ -3057,7 +3059,7 @@ int FuncLiteralDeclaration::isVirtual()
 const char *FuncLiteralDeclaration::kind()
 {
     // GCC requires the (char*) casts
-    return (tok == TOKdelegate) ? (char*)"delegate" : (char*)"function";
+    return (tok != TOKfunction) ? (char*)"delegate" : (char*)"function";
 }
 
 void FuncLiteralDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)

--- a/src/func.c
+++ b/src/func.c
@@ -2316,6 +2316,11 @@ if (arguments)
         {
             HdrGenState hgs;
 
+            for (size_t i = 0; i < arguments->dim; i++)
+            {   Expression *arg = (*arguments)[i];
+                if (!arg->type) // inference failed
+                    arg->type = Type::terror;
+            }
             argExpTypesToCBuffer(&buf, arguments, &hgs);
             buf.writeByte(')');
             if (ethis)

--- a/src/init.c
+++ b/src/init.c
@@ -849,6 +849,12 @@ L1:
 Type *ExpInitializer::inferType(Scope *sc)
 {
     //printf("ExpInitializer::inferType() %s\n", toChars());
+    if (exp->op == TOKfunction && ((FuncExp *)exp)->td)
+    {
+        exp->error("cannot infer type from ambiguous function literal %s", exp->toChars());
+        return Type::terror;
+    }
+
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5444,6 +5444,13 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
         }
         arg = args->tdata()[u];
         assert(arg);
+
+        if (arg->op == TOKfunction)
+        {   arg = ((FuncExp *)arg)->inferType(NULL, p->type);
+            if (!arg)
+                goto Nomatch;
+        }
+
         //printf("arg: %s, type: %s\n", arg->toChars(), arg->type->toChars());
 
         // Non-lvalues do not match ref or out parameters

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4785,7 +4785,7 @@ int Type::covariant(Type *t)
         goto Lnotcovariant;
 
   {
-            // Return types
+    // Return types
     Type *t1n = t1->next;
     Type *t2n = t2->next;
 
@@ -4815,7 +4815,13 @@ int Type::covariant(Type *t)
             return 3;   // forward references
         }
     }
-    if (t1n->implicitConvTo(t2n))
+    if (t1n->ty == Tstruct && t2n->ty == Tstruct)
+    {
+        if (((TypeStruct *)t1n)->sym == ((TypeStruct *)t2n)->sym &&
+            MODimplicitConv(t1n->mod, t2n->mod))
+            goto Lcovariant;
+    }
+    else if (t1n->ty == t2n->ty && t1n->implicitConvTo(t2n))
         goto Lcovariant;
   }
     goto Lnotcovariant;

--- a/src/parse.c
+++ b/src/parse.c
@@ -5470,7 +5470,7 @@ Expression *Parser::parsePrimaryExp()
             int varargs = 0;
             Type *tret = NULL;
             StorageClass stc = 0;
-            enum TOK save = TOKdelegate;
+            enum TOK save = TOKreserved;
             Loc loc = this->loc;
 
             switch (token.value)

--- a/src/parse.h
+++ b/src/parse.h
@@ -100,7 +100,7 @@ struct Parser : Lexer
     UnitTestDeclaration *parseUnitTest();
     NewDeclaration *parseNew();
     DeleteDeclaration *parseDelete();
-    Parameters *parseParameters(int *pvarargs);
+    Parameters *parseParameters(int *pvarargs, TemplateParameters **tpl = NULL);
     EnumDeclaration *parseEnum();
     Dsymbol *parseAggregate();
     BaseClasses *parseBaseClasses();

--- a/src/statement.c
+++ b/src/statement.c
@@ -3543,6 +3543,9 @@ Statement *ReturnStatement::semantic(Scope *sc)
     {
         fd->hasReturnExp |= 1;
 
+        if (exp->op == TOKfunction && tbret)
+            ((FuncExp *)exp)->setType(tbret);
+
         exp = exp->semantic(sc);
         exp = resolveProperties(sc, exp);
         if (!((TypeFunction *)fd->type)->isref)

--- a/src/template.c
+++ b/src/template.c
@@ -1228,6 +1228,18 @@ Lretry:
             {
                 argtype = argtype->mutableOf();
             }
+
+            if (farg->op == TOKfunction)
+            {   FuncExp *fe = (FuncExp *)farg;
+                if (fparam->type->ty == Tdelegate &&
+                    argtype && argtype->ty == Tpointer && argtype->nextOf()->ty == Tfunction &&
+                    fe->tok == TOKreserved)
+                {   Type *tdg = new TypeDelegate(argtype->nextOf());
+                    tdg = tdg->semantic(loc, sc);
+                    farg = fe->inferType(sc, tdg);
+                    argtype = farg->type;
+                }
+            }
 #endif
 
             MATCH m;

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -481,7 +481,7 @@ class.obj : $(TOTALH) enum.h class.c
 clone.obj : $(TOTALH) clone.c
 constfold.obj : $(TOTALH) expression.h constfold.c
 cond.obj : $(TOTALH) identifier.h declaration.h cond.h cond.c
-declaration.obj : $(TOTALH) identifier.h attrib.h declaration.h declaration.c
+declaration.obj : $(TOTALH) identifier.h attrib.h declaration.h declaration.c expression.h
 delegatize.obj : $(TOTALH) delegatize.c
 doc.obj : $(TOTALH) doc.h doc.c
 enum.obj : $(TOTALH) identifier.h enum.h enum.c

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -54,10 +54,76 @@ void test1()
 }
 
 /***************************************************/
+// on initializer
+
+void test2()
+{
+    // explicit typed binding ignite parameter types inference
+    //int function(int) fn1 = a => a*2;                               assert(fn1(2) == 4);
+    //int function(int) fn2 =             (    a){ return a*2; };     assert(fn2(2) == 4);
+    int function(int) fn3 = function    (    a){ return a*2; };     assert(fn3(2) == 4);
+    int function(int) fn4 = function int(    a){ return a*2; };     assert(fn4(2) == 4);
+    int function(int) fn5 = function    (int a){ return a*2; };     assert(fn5(2) == 4);
+    int function(int) fn6 = function int(int a){ return a*2; };     assert(fn6(2) == 4);
+    int delegate(int) dg1 = a => a*2;                               assert(dg1(2) == 4);
+    int delegate(int) dg2 =             (    a){ return a*2; };     assert(dg2(2) == 4);
+    int delegate(int) dg3 = delegate    (    a){ return a*2; };     assert(dg3(2) == 4);
+    int delegate(int) dg4 = delegate int(    a){ return a*2; };     assert(dg4(2) == 4);
+    int delegate(int) dg5 = delegate    (int a){ return a*2; };     assert(dg5(2) == 4);
+    int delegate(int) dg6 = delegate int(int a){ return a*2; };     assert(dg6(2) == 4);
+
+    // funciton/delegate mismatching always raises an error
+    static assert(!__traits(compiles, { int function(int) xfg3 = delegate    (    a){ return a*2; }; }));
+    static assert(!__traits(compiles, { int function(int) xfg4 = delegate int(    a){ return a*2; }; }));
+    static assert(!__traits(compiles, { int function(int) xfg5 = delegate    (int a){ return a*2; }; }));
+    static assert(!__traits(compiles, { int function(int) xfg6 = delegate int(int a){ return a*2; }; }));
+    static assert(!__traits(compiles, { int delegate(int) xdn3 = function    (    a){ return a*2; }; }));
+    static assert(!__traits(compiles, { int delegate(int) xdn4 = function int(    a){ return a*2; }; }));
+    static assert(!__traits(compiles, { int delegate(int) xdn5 = function    (int a){ return a*2; }; }));
+    static assert(!__traits(compiles, { int delegate(int) xdn6 = function int(int a){ return a*2; }; }));
+/+
+    // auto binding requires explicit parameter types at least
+    static assert(!__traits(compiles, { auto afn1 = a => a*2;                           }));
+    static assert(!__traits(compiles, { auto afn2 =             (    a){ return a*2; }; }));
+    static assert(!__traits(compiles, { auto afn3 = function    (    a){ return a*2; }; }));
+    static assert(!__traits(compiles, { auto afn4 = function int(    a){ return a*2; }; }));
+    static assert(!__traits(compiles, { auto adg3 = delegate    (    a){ return a*2; }; }));
+    static assert(!__traits(compiles, { auto adg4 = delegate int(    a){ return a*2; }; }));
+    auto afn5 = function    (int a){ return a*2; };     assert(afn5(2) == 4);
+    auto afn6 = function int(int a){ return a*2; };     assert(afn6(2) == 4);
+    auto adg5 = delegate    (int a){ return a*2; };     assert(adg5(2) == 4);
+    auto adg6 = delegate int(int a){ return a*2; };     assert(adg6(2) == 4);
++/
+    // partial specialized lambda
+    string delegate(int, string) dg =
+        (n, string s){
+            string r = "";
+            foreach (_; 0..n) r~=s;
+            return r;
+        };
+    assert(dg(2, "str") == "strstr");
+}
+
+/***************************************************/
+// on return statement
+
+void test3()
+{
+    // inference matching system is same as on initializer
+    int delegate(int) mul(int x)
+    {
+        return a => a * x;
+    }
+    assert(mul(5)(2) == 10);
+}
+
+/***************************************************/
 
 int main()
 {
     test1();
+    test2();
+    test3();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -184,6 +184,27 @@ void test3235()
 }
 
 /***************************************************/
+// 6714
+
+void foo6714x(int function (int, int) a){}
+void bar6714x(int delegate (int, int) a){}
+
+int bar6714y(double delegate(int, int) a){ return 1; }
+int bar6714y(   int delegate(int, int) a){ return 2; }
+
+void test6714()
+{
+    foo6714x((a, b) { return a + b; });
+    bar6714x((a, b) { return a + b; });
+
+    assert(bar6714y((a, b){ return 1.0;  }) == 1);
+    static assert(!__traits(compiles, {
+           bar6714y((a, b){ return 1.0f; });
+    }));
+    assert(bar6714y((a, b){ return a;    }) == 2);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -193,6 +214,7 @@ int main()
     test4();
     test5();
     test3235();
+    test6714();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -173,6 +173,17 @@ void test5()
 }
 
 /***************************************************/
+// 3235
+
+void test3235()
+{
+    // from TDPL
+    auto f = (int i) {};
+    static if (is(typeof(f) _ == F*, F) && is(F == function))
+    {} else static assert(0);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -181,6 +192,7 @@ int main()
     test3();
     test4();
     test5();
+    test3235();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -161,6 +161,18 @@ void test4()
 }
 
 /***************************************************/
+// on CallExp::e1
+
+void test5()
+{
+    assert((a => a*2)(10) == 20);
+    assert((    a,        s){ return s~s; }(10, "str") == "strstr");
+    assert((int a,        s){ return s~s; }(10, "str") == "strstr");
+    assert((    a, string s){ return s~s; }(10, "str") == "strstr");
+    assert((int a, string s){ return s~s; }(10, "str") == "strstr");
+}
+
+/***************************************************/
 
 int main()
 {
@@ -168,6 +180,7 @@ int main()
     test2();
     test3();
     test4();
+    test5();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -1,0 +1,64 @@
+extern (C) int printf(const char*, ...);
+
+/***************************************************/
+// lambda syntax check
+
+auto una(alias dg)(int n)
+{
+    return dg(n);
+}
+auto bin(alias dg)(int n, int m)
+{
+    return dg(n, m);
+}
+void test1()
+{
+    assert(una!(      a  => a*2 )(2) == 4);
+    assert(una!( (    a) => a*2 )(2) == 4);
+    assert(una!( (int a) => a*2 )(2) == 4);
+    assert(una!(             (    a){ return a*2; } )(2) == 4);
+    assert(una!( function    (    a){ return a*2; } )(2) == 4);
+    assert(una!( function int(    a){ return a*2; } )(2) == 4);
+    assert(una!( function    (int a){ return a*2; } )(2) == 4);
+    assert(una!( function int(int a){ return a*2; } )(2) == 4);
+    assert(una!( delegate    (    a){ return a*2; } )(2) == 4);
+    assert(una!( delegate int(    a){ return a*2; } )(2) == 4);
+    assert(una!( delegate    (int a){ return a*2; } )(2) == 4);
+    assert(una!( delegate int(int a){ return a*2; } )(2) == 4);
+
+    // partial parameter specialization syntax
+    assert(bin!( (    a,     b) => a*2+b )(2,1) == 5);
+    assert(bin!( (int a,     b) => a*2+b )(2,1) == 5);
+    assert(bin!( (    a, int b) => a*2+b )(2,1) == 5);
+    assert(bin!( (int a, int b) => a*2+b )(2,1) == 5);
+    assert(bin!(             (    a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!(             (int a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!(             (    a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!(             (int a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( function    (    a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( function    (int a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( function    (    a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( function    (int a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( function int(    a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( function int(int a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( function int(    a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( function int(int a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( delegate    (    a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( delegate    (int a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( delegate    (    a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( delegate    (int a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( delegate int(    a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( delegate int(int a,     b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( delegate int(    a, int b){ return a*2+b; } )(2,1) == 5);
+    assert(bin!( delegate int(int a, int b){ return a*2+b; } )(2,1) == 5);
+}
+
+/***************************************************/
+
+int main()
+{
+    test1();
+
+    printf("Success\n");
+    return 0;
+}

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -59,14 +59,14 @@ void test1()
 void test2()
 {
     // explicit typed binding ignite parameter types inference
-    //int function(int) fn1 = a => a*2;                               assert(fn1(2) == 4);
-    //int function(int) fn2 =             (    a){ return a*2; };     assert(fn2(2) == 4);
+    int function(int) fn1 = a => a*2;                               assert(fn1(2) == 4);
+    int function(int) fn2 =             (    a){ return a*2; };     assert(fn2(2) == 4);
     int function(int) fn3 = function    (    a){ return a*2; };     assert(fn3(2) == 4);
     int function(int) fn4 = function int(    a){ return a*2; };     assert(fn4(2) == 4);
     int function(int) fn5 = function    (int a){ return a*2; };     assert(fn5(2) == 4);
     int function(int) fn6 = function int(int a){ return a*2; };     assert(fn6(2) == 4);
-    int delegate(int) dg1 = a => a*2;                               assert(dg1(2) == 4);
-    int delegate(int) dg2 =             (    a){ return a*2; };     assert(dg2(2) == 4);
+    //int delegate(int) dg1 = a => a*2;                               assert(dg1(2) == 4);
+    //int delegate(int) dg2 =             (    a){ return a*2; };     assert(dg2(2) == 4);
     int delegate(int) dg3 = delegate    (    a){ return a*2; };     assert(dg3(2) == 4);
     int delegate(int) dg4 = delegate int(    a){ return a*2; };     assert(dg4(2) == 4);
     int delegate(int) dg5 = delegate    (int a){ return a*2; };     assert(dg5(2) == 4);
@@ -95,13 +95,13 @@ void test2()
     auto adg6 = delegate int(int a){ return a*2; };     assert(adg6(2) == 4);
 
     // partial specialized lambda
-    string delegate(int, string) dg =
-        (n, string s){
-            string r = "";
-            foreach (_; 0..n) r~=s;
-            return r;
-        };
-    assert(dg(2, "str") == "strstr");
+    //string delegate(int, string) dg =
+    //    (n, string s){
+    //        string r = "";
+    //        foreach (_; 0..n) r~=s;
+    //        return r;
+    //    };
+    //assert(dg(2, "str") == "strstr");
 }
 
 /***************************************************/
@@ -140,23 +140,23 @@ void test4()
     int v;
 
     // parameter type inference + overload resolution
-    assert(foo4((a)   => a * 2) == 20);
-    assert(foo4((a,b) => a * 2 + b) == 40);
+    //assert(foo4((a)   => a * 2) == 20);
+    //assert(foo4((a,b) => a * 2 + b) == 40);
 
     // function/delegate inference
-    //nbar4fp((int x){ });
-    nbar4dg((int x){ });
-    //tbar4fp((int x){ });
-    tbar4dg((int x){ });
+    nbar4fp((int x){ });
+    //nbar4dg((int x){ });
+    tbar4fp((int x){ });
+    //tbar4dg((int x){ });
 
     // function/delegate inference + overload resolution
-    //assert(nbaz4({ }) == 1);
+    assert(nbaz4({ }) == 1);
     assert(nbaz4({ v = 1; }) == 2);
     //assert(tbaz4({ }) == 1);
     assert(tbaz4({ v = 1; }) == 2);
 
     // template function deduction
-    //static assert(is(typeof(thoo4({ })) : void function()));
+    static assert(is(typeof(thoo4({ })) : void function()));
     static assert(is(typeof(thoo4({ v = 1;  })) : void delegate()));
 }
 

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -81,7 +81,7 @@ void test2()
     static assert(!__traits(compiles, { int delegate(int) xdn4 = function int(    a){ return a*2; }; }));
     static assert(!__traits(compiles, { int delegate(int) xdn5 = function    (int a){ return a*2; }; }));
     static assert(!__traits(compiles, { int delegate(int) xdn6 = function int(int a){ return a*2; }; }));
-/+
+
     // auto binding requires explicit parameter types at least
     static assert(!__traits(compiles, { auto afn1 = a => a*2;                           }));
     static assert(!__traits(compiles, { auto afn2 =             (    a){ return a*2; }; }));
@@ -93,7 +93,7 @@ void test2()
     auto afn6 = function int(int a){ return a*2; };     assert(afn6(2) == 4);
     auto adg5 = delegate    (int a){ return a*2; };     assert(adg5(2) == 4);
     auto adg6 = delegate int(int a){ return a*2; };     assert(adg6(2) == 4);
-+/
+
     // partial specialized lambda
     string delegate(int, string) dg =
         (n, string s){
@@ -118,12 +118,56 @@ void test3()
 }
 
 /***************************************************/
+// on function arguments
+
+auto foo4(int delegate(int) dg) { return dg(10); }
+auto foo4(int delegate(int, int) dg) { return dg(10, 20); }
+
+void nbar4fp(void function(int) fp) { }
+void nbar4dg(void delegate(int) dg) { }
+void tbar4fp(T,R)(R function(T) dg) { static assert(is(typeof(dg) == void function(int))); }
+void tbar4dg(T,R)(R delegate(T) dg) { static assert(is(typeof(dg) == void delegate(int))); }
+
+auto nbaz4(void function() fp) { return 1; }
+auto nbaz4(void delegate() dg) { return 2; }
+auto tbaz4(R)(R function() dg) { static assert(is(R == void)); return 1; }
+auto tbaz4(R)(R delegate() dg) { static assert(is(R == void)); return 2; }
+
+auto thoo4(T)(T lambda){ return lambda; }
+
+void test4()
+{
+    int v;
+
+    // parameter type inference + overload resolution
+    assert(foo4((a)   => a * 2) == 20);
+    assert(foo4((a,b) => a * 2 + b) == 40);
+
+    // function/delegate inference
+    //nbar4fp((int x){ });
+    nbar4dg((int x){ });
+    //tbar4fp((int x){ });
+    tbar4dg((int x){ });
+
+    // function/delegate inference + overload resolution
+    //assert(nbaz4({ }) == 1);
+    assert(nbaz4({ v = 1; }) == 2);
+    //assert(tbaz4({ }) == 1);
+    assert(tbaz4({ v = 1; }) == 2);
+
+    // template function deduction
+    //static assert(is(typeof(thoo4({ })) : void function()));
+    static assert(is(typeof(thoo4({ v = 1;  })) : void delegate()));
+}
+
+/***************************************************/
 
 int main()
 {
     test1();
     test2();
     test3();
+    test4();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -65,8 +65,8 @@ void test2()
     int function(int) fn4 = function int(    a){ return a*2; };     assert(fn4(2) == 4);
     int function(int) fn5 = function    (int a){ return a*2; };     assert(fn5(2) == 4);
     int function(int) fn6 = function int(int a){ return a*2; };     assert(fn6(2) == 4);
-    //int delegate(int) dg1 = a => a*2;                               assert(dg1(2) == 4);
-    //int delegate(int) dg2 =             (    a){ return a*2; };     assert(dg2(2) == 4);
+    int delegate(int) dg1 = a => a*2;                               assert(dg1(2) == 4);
+    int delegate(int) dg2 =             (    a){ return a*2; };     assert(dg2(2) == 4);
     int delegate(int) dg3 = delegate    (    a){ return a*2; };     assert(dg3(2) == 4);
     int delegate(int) dg4 = delegate int(    a){ return a*2; };     assert(dg4(2) == 4);
     int delegate(int) dg5 = delegate    (int a){ return a*2; };     assert(dg5(2) == 4);
@@ -95,13 +95,13 @@ void test2()
     auto adg6 = delegate int(int a){ return a*2; };     assert(adg6(2) == 4);
 
     // partial specialized lambda
-    //string delegate(int, string) dg =
-    //    (n, string s){
-    //        string r = "";
-    //        foreach (_; 0..n) r~=s;
-    //        return r;
-    //    };
-    //assert(dg(2, "str") == "strstr");
+    string delegate(int, string) dg =
+        (n, string s){
+            string r = "";
+            foreach (_; 0..n) r~=s;
+            return r;
+        };
+    assert(dg(2, "str") == "strstr");
 }
 
 /***************************************************/
@@ -140,19 +140,19 @@ void test4()
     int v;
 
     // parameter type inference + overload resolution
-    //assert(foo4((a)   => a * 2) == 20);
-    //assert(foo4((a,b) => a * 2 + b) == 40);
+    assert(foo4((a)   => a * 2) == 20);
+    assert(foo4((a,b) => a * 2 + b) == 40);
 
     // function/delegate inference
     nbar4fp((int x){ });
-    //nbar4dg((int x){ });
+    nbar4dg((int x){ });
     tbar4fp((int x){ });
-    //tbar4dg((int x){ });
+    tbar4dg((int x){ });
 
     // function/delegate inference + overload resolution
     assert(nbaz4({ }) == 1);
     assert(nbaz4({ v = 1; }) == 2);
-    //assert(tbaz4({ }) == 1);
+    assert(tbaz4({ }) == 1);
     assert(tbaz4({ v = 1; }) == 2);
 
     // template function deduction

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1906,7 +1906,7 @@ void test100()
    /* Testing order of evaluation */
    void delegate(string, string) fun(string) {
       s ~= "b";
-      return delegate void(string, string) { s ~= "e"; };
+      return delegate void(string x, string y) { s ~= "e"; };
    }
    fun(s ~= "a")(s ~= "c", s ~= "d");
    assert(s == "abcde", s);


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=3235">Issue 3235</a> - [tdpl] Function literals must be deduced as "function" or "delegate"
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6714">Issue 6714</a> - [tdpl] Type inference for parameters of function and delegate literals
### Features:
- All of function literals that require parameter type inference are rewritten to template literal.
- Parameter types and function/delegate inference works in following places:
  Var declaration, return statement, caller (`CallExp::e1`), and argument of function call.
### A small breaking of existing code:

Past normal function literals, not in template arguments, are can omit parameter names.

e.g. `(string, size_t){ return 1024; }`

But this change regards them as parameter type omission, then raises an error.

Supplemental changes of Phobos:
https://github.com/D-Programming-Language/phobos/pull/381
