### PR TITLE
More improvement for lambda inference

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -714,7 +714,7 @@ MATCH DelegateExp::implicitConvTo(Type *t)
 MATCH FuncExp::implicitConvTo(Type *t)
 {
     //printf("FuncExp::implicitCastTo type = %p %s, t = %s\n", type, type ? type->toChars() : NULL, t->toChars());
-    if (type && tok == TOKreserved && type->ty == Tpointer)
+    if (type && type != Type::tvoid && tok == TOKreserved && type->ty == Tpointer)
     {   // Allow implicit function to delegate conversion
         if (type->nextOf()->covariant(t->nextOf()) == 1)
             return t->ty == Tpointer ? MATCHconst : MATCHconvert;
@@ -1479,7 +1479,7 @@ Expression *FuncExp::castTo(Scope *sc, Type *t)
 {
     //printf("FuncExp::castTo type = %s, t = %s\n", type->toChars(), t->toChars());
     if (tok == TOKreserved)
-    {
+    {   assert(type && type != Type::tvoid);
         if (type->ty == Tpointer && t->ty == Tdelegate)
         {
             Expression *e = copy();

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -652,6 +652,7 @@ struct FuncDeclaration : Declaration
     const char *kind();
     void toDocBuffer(OutBuffer *buf);
     FuncDeclaration *isUnique();
+    void checkNestedReference(Scope *sc, Loc loc);
     int needsClosure();
     Statement *mergeFrequire(Statement *);
     Statement *mergeFensure(Statement *);

--- a/src/expression.c
+++ b/src/expression.c
@@ -544,8 +544,6 @@ void preFunctionParameters(Loc loc, Scope *sc, Expressions *exps)
         for (size_t i = 0; i < exps->dim; i++)
         {   Expression *arg = (*exps)[i];
 
-            if (arg->op == TOKfunction)
-                continue;
             if (!arg->type)
             {
 #ifdef DEBUG
@@ -5037,7 +5035,7 @@ Expression *FuncExp::semantic(Scope *sc)
 #if LOGSEMANTIC
     printf("FuncExp::semantic(%s)\n", toChars());
 #endif
-    if (!type)
+    if (!type || type == Type::tvoid)
     {
         // save for later use
         scope = sc;
@@ -5050,6 +5048,7 @@ Expression *FuncExp::semantic(Scope *sc)
 
             if (!tded)
             {   // defer type determination
+                type = Type::tvoid; // temporary type
                 return this;
             }
             else
@@ -5113,7 +5112,7 @@ Expression *FuncExp::semantic(Scope *sc, Expressions *arguments)
     assert(!tded);
     assert(!scope);
 
-    if (!type && td && arguments && arguments->dim)
+    if ((!type || type == Type::tvoid) && td && arguments && arguments->dim)
     {
         for (size_t k = 0; k < arguments->dim; k++)
         {   Expression *checkarg = arguments->tdata()[k];
@@ -5207,7 +5206,7 @@ Expression *FuncExp::inferType(Scope *sc, Type *to)
     }
     else
     {
-        assert(type);   // semantic is already done
+        assert(type && type != Type::tvoid);   // semantic is already done
         e = this;
     }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -3782,6 +3782,14 @@ Expression *StructLiteralExp::semantic(Scope *sc)
             telem = telem->toBasetype()->nextOf();
         }
 
+        if (e->op == TOKfunction)
+        {   e = ((FuncExp *)e)->inferType(sc, telem);
+            if (!e)
+            {   error("cannot infer function literal type from %s", telem->toChars());
+                e = new ErrorExp();
+            }
+        }
+
         e = e->implicitCastTo(sc, telem);
 
         elements->tdata()[i] = e;

--- a/src/expression.c
+++ b/src/expression.c
@@ -10088,6 +10088,27 @@ Ltupleassign:
         }
     }
 
+    if (t1->ty == Tdelegate || (t1->ty == Tpointer && t1->nextOf()->ty == Tfunction)
+        && e2->op == TOKfunction)
+    {
+        FuncExp *fe = (FuncExp *)e2;
+        if (e2->type == Type::tvoid)
+        {
+            e2 = fe->inferType(sc, t1);
+        }
+        else if (e2->type->ty == Tpointer && e2->type->nextOf()->ty == Tfunction &&
+                 fe->tok == TOKreserved &&
+                 t1->ty == Tdelegate)
+        {
+            if (fe->implicitConvTo(t1))
+                e2 = fe->castTo(sc, t1);
+        }
+        if (!e2)
+        {   error("cannot infer function literal type from %s", t1->toChars());
+            e2 = new ErrorExp();
+        }
+    }
+
     /* If it is an assignment from a 'foreign' type,
      * check for operator overloading.
      */

--- a/src/expression.c
+++ b/src/expression.c
@@ -4683,6 +4683,9 @@ Expression *SymOffExp::semantic(Scope *sc)
     VarDeclaration *v = var->isVarDeclaration();
     if (v)
         v->checkNestedReference(sc, loc);
+    FuncDeclaration *f = var->isFuncDeclaration();
+    if (f)
+        f->checkNestedReference(sc, loc);
     return this;
 }
 
@@ -4773,6 +4776,9 @@ Expression *VarExp::semantic(Scope *sc)
         checkPurity(sc, v, NULL);
 #endif
     }
+    FuncDeclaration *f = var->isFuncDeclaration();
+    if (f)
+        f->checkNestedReference(sc, loc);
 #if 0
     else if ((fd = var->isFuncLiteralDeclaration()) != NULL)
     {   Expression *e;
@@ -8039,6 +8045,7 @@ Lagain:
         checkPurity(sc, f);
         checkSafety(sc, f);
 #endif
+        f->checkNestedReference(sc, loc);
 
         if (f->needThis() && hasThis(sc))
         {

--- a/src/func.c
+++ b/src/func.c
@@ -2317,11 +2317,6 @@ if (arguments)
         {
             HdrGenState hgs;
 
-            for (size_t i = 0; i < arguments->dim; i++)
-            {   Expression *arg = (*arguments)[i];
-                if (!arg->type) // inference failed
-                    arg->type = Type::terror;
-            }
             argExpTypesToCBuffer(&buf, arguments, &hgs);
             buf.writeByte(')');
             if (ethis)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5444,17 +5444,17 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
         {
             if (p->defaultArg)
                 continue;
-            if (varargs == 2 && u + 1 == nparams)
-                goto L1;
-            goto Nomatch;               // not enough arguments
+            goto L1;        // try typesafe variadics
         }
         arg = args->tdata()[u];
         assert(arg);
 
         if (arg->op == TOKfunction)
-        {   arg = ((FuncExp *)arg)->inferType(NULL, p->type);
+        {   FuncExp *fe = (FuncExp *)arg;
+            Type *pt = p->type;
+            arg = ((FuncExp *)arg)->inferType(NULL, pt);
             if (!arg)
-                goto Nomatch;
+                goto L1;    // try typesafe variadics
         }
 
         //printf("arg: %s, type: %s\n", arg->toChars(), arg->type->toChars());
@@ -5527,6 +5527,14 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
                             arg = args->tdata()[u];
                             assert(arg);
 #if 1
+                            if (arg->op == TOKfunction)
+                            {   FuncExp *fe = (FuncExp *)arg;
+                                Type *pt = tb->nextOf();
+                                arg = ((FuncExp *)arg)->inferType(NULL, pt);
+                                if (!arg)
+                                    goto Nomatch;
+                            }
+
                             /* If lazy array of delegates,
                              * convert arg(s) to delegate(s)
                              */

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -135,6 +135,10 @@ auto tbaz4(R)(R delegate() dg) { static assert(is(R == void)); return 2; }
 
 auto thoo4(T)(T lambda){ return lambda; }
 
+void tfun4a()(int function(int) a){}
+void tfun4b(T)(T function(T) a){}
+void tfun4c(T)(T f){}
+
 void test4()
 {
     int v;
@@ -158,6 +162,37 @@ void test4()
     // template function deduction
     static assert(is(typeof(thoo4({ })) : void function()));
     static assert(is(typeof(thoo4({ v = 1;  })) : void delegate()));
+
+    tfun4a(a => a);
+    static assert(!__traits(compiles, { tfun4b(a => a); }));
+    static assert(!__traits(compiles, { tfun4c(a => a); }));
+}
+
+void fsvarg4(int function(int)[] a...){}
+void fcvarg4(int dummy, ...){}
+
+void tsvarg4a()(int function(int)[] a...){}
+void tsvarg4b(T)(T function(T)[] a...){}
+void tsvarg4c(T)(T [] a...){}
+void tcvarg4()(int dummy, ...){}
+
+void test4v()
+{
+    fsvarg4(function(int a){ return a; });      // OK
+    fsvarg4(a => a);                            // OK
+
+    fcvarg4(0, function(int a){ return a; });   // OK
+    static assert(!__traits(compiles, { fcvarg4(0, a => a); }));
+
+    tsvarg4a(function(int a){ return a; });     // OK
+    tsvarg4b(function(int a){ return a; });     // OK
+    tsvarg4c(function(int a){ return a; });     // OK
+    tsvarg4a(a => a);
+    static assert(!__traits(compiles, { tsvarg4b(a => a); }));
+    static assert(!__traits(compiles, { tsvarg4c(a => a); }));
+
+    tcvarg4(0, function(int a){ return a; });   // OK
+    static assert(!__traits(compiles, { tcvarg4(0, a => a); }));
 }
 
 /***************************************************/
@@ -222,6 +257,7 @@ int main()
     test2();
     test3();
     test4();
+    test4v();
     test5();
     test3235();
     test6714();

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -208,6 +208,42 @@ void test5()
 }
 
 /***************************************************/
+// escape check to nested function symbols
+
+void checkNestedRef(alias dg)(bool isnested)
+{
+    static if (is(typeof(dg) == delegate))
+        enum isNested = true;
+    else static if ((is(typeof(dg) PF == F*, F) && is(F == function)))
+        enum isNested = false;
+    else
+        static assert(0);
+
+    assert(isnested == isNested);
+    dg();
+}
+
+void freeFunc(){}
+
+void test6()
+{
+    static void localFunc(){}
+    void nestedLocalFunc(){}
+
+    checkNestedRef!({  })(false);
+
+    checkNestedRef!({ freeFunc(); })(false);
+    checkNestedRef!({ localFunc(); })(false);
+    checkNestedRef!({ nestedLocalFunc(); })(true);
+    checkNestedRef!({ void inner(){} inner(); })(false);
+
+    checkNestedRef!({ auto f = &freeFunc; })(false);
+    checkNestedRef!({ auto f = &localFunc; })(false);
+    checkNestedRef!({ auto f = &nestedLocalFunc; })(true);
+    checkNestedRef!({ void inner(){} auto f = &inner; })(false);
+}
+
+/***************************************************/
 // 3235
 
 void test3235()
@@ -259,6 +295,7 @@ int main()
     test4();
     test4v();
     test5();
+    test6();
     test3235();
     test6714();
     test7193();

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -1,3 +1,5 @@
+import core.vararg;
+
 extern (C) int printf(const char*, ...);
 
 /***************************************************/

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -323,6 +323,15 @@ void test7193()
 }
 
 /***************************************************/
+// 7207 : on CastExp
+
+void test7202()
+{
+    auto dg = cast(int function(int))(a => a);
+    assert(dg(10) == 10);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -338,6 +347,7 @@ int main()
     test3235();
     test6714();
     test7193();
+    test7202();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -266,6 +266,19 @@ void test7()
 }
 
 /***************************************************/
+// on StructLiteralExp::elements
+
+void test8()
+{
+    struct S
+    {
+        int function(int) fp;
+    }
+    auto s1 = S(a => a);
+    static assert(!__traits(compiles, { auto s2 = S((a, b) => a); }));
+}
+
+/***************************************************/
 // 3235
 
 void test3235()
@@ -319,6 +332,7 @@ int main()
     test5();
     test6();
     test7();
+    test8();
     test3235();
     test6714();
     test7193();

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -244,6 +244,28 @@ void test6()
 }
 
 /***************************************************/
+// on AssignExp::e2
+
+void test7()
+{
+    int function(int) fp;
+    fp = a => a;
+    fp = (int a) => a;
+    fp = function(int a) => a;
+    fp = function int(int a) => a;
+    static assert(!__traits(compiles, { fp = delegate(int a) => a; }));
+    static assert(!__traits(compiles, { fp = delegate int(int a) => a; }));
+
+    int delegate(int) dg;
+    dg = a => a;
+    dg = (int a) => a;
+    dg = delegate(int a) => a;
+    dg = delegate int(int a) => a;
+    static assert(!__traits(compiles, { dg = function(int a) => a; }));
+    static assert(!__traits(compiles, { dg = function int(int a) => a; }));
+}
+
+/***************************************************/
 // 3235
 
 void test3235()
@@ -296,6 +318,7 @@ int main()
     test4v();
     test5();
     test6();
+    test7();
     test3235();
     test6714();
     test7193();

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -205,6 +205,16 @@ void test6714()
 }
 
 /***************************************************/
+// 7193
+
+void test7193()
+{
+    static assert(!__traits(compiles, {
+        delete a => a;
+    }));
+}
+
+/***************************************************/
 
 int main()
 {
@@ -215,6 +225,7 @@ int main()
     test5();
     test3235();
     test6714();
+    test7193();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2782,7 +2782,7 @@ void test140()
    int foo(int i) { return i; }
 
    int[] arr;
-   auto x = mapx!( function(int a){return foo(a);} )(arr);
+   auto x = mapx!( (int a){return foo(a);} )(arr);
 }
 
 /***************************************************/


### PR DESCRIPTION
Fix bug:
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7193">Issue 7193</a> - Regression(2.058head): ICE: delete lambda expression crashes dmd
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7201">Issue 7201</a> - Lambda template assignment to variable
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7207">Issue 7207</a> - Explicit cast should resolve lambda type

Improvements:
- Improve inference behavior on arguments of normal/template function.
- Run lambda inference on AssignExp::e2 and StructLiteralExp::elements
- Add escape check to nested function symbol.
