### PR TITLE
Issue 7073 - Parsing of class-returning varargs function inside module ctor fails

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4696,6 +4696,7 @@ int Parser::isDeclarator(Token **pt, int *haveId, enum TOK endtok)
             case TOKrbracket:
             case TOKassign:
             case TOKcomma:
+            case TOKdotdotdot:
             case TOKsemicolon:
             case TOKlcurly:
             case TOKin:

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4283,6 +4283,17 @@ static assert(!__traits(hasMember, int, "x"));
 static assert( __traits(hasMember, int, "init"));
 
 /***************************************************/
+// 7073
+
+void test7073()
+{
+    string f(int[] arr...)
+    {
+        return "";
+    }
+}
+
+/***************************************************/
 // 7160
 
 class HomeController {
@@ -4533,6 +4544,7 @@ int main()
     test6868();
     test2856();
     test6056();
+    test7073();
     test7160();
     test7168();
     test7170();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7073

This is simple parser issue.
