### PR TITLE
CTFE pointer and destructor bugs 6933 7185 7187 7194

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5401,28 +5401,7 @@ Expression *AssertExp::interpret(InterState *istate, CtfeGoal goal)
 #if LOG
     printf("AssertExp::interpret() %s\n", toChars());
 #endif
-    if (this->e1->op == TOKthis)
-    {
-        if (istate->localThis)
-        {
-            if (istate->localThis->op == TOKdotvar
-                && ((DotVarExp *)(istate->localThis))->e1->op == TOKthis)
-                return getVarExp(loc, istate, ((DotVarExp*)(istate->localThis))->var, ctfeNeedRvalue);
-            else
-                return istate->localThis->interpret(istate);
-        }
-    }
-    // Deal with pointers (including compiler-inserted assert(&this, "null this"))
-    if (this->e1->type->ty == Tpointer && this->e1->type->nextOf()->ty != Tfunction)
-    {
-        e1 = this->e1->interpret(istate, ctfeNeedLvalue);
-        if (exceptionOrCantInterpret(e1))
-            return e1;
-        if (e1->op != TOKnull)
-            return new IntegerExp(loc, 1, Type::tbool);
-    }
-    else
-        e1 = this->e1->interpret(istate);
+    e1 = this->e1->interpret(istate);
     if (exceptionOrCantInterpret(e1))
         return e1;
     if (isTrueBool(e1))

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1834,13 +1834,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
     else if (s)
     {   // Struct static initializers, for example
         if (s->dsym->toInitializer() == s->sym)
-        {   Expressions *exps = new Expressions();
-            e = new StructLiteralExp(loc, s->dsym, exps);
-            if (s->dsym->dtor)
-            {
-                error(loc, "CTFE fails for structs with destructors (Bugzilla 6933)");
-                return EXP_CANT_INTERPRET;
-            }
+        {   e = s->dsym->type->defaultInitLiteral();
             e = e->semantic(NULL);
             if (e->op == TOKerror)
                 e = EXP_CANT_INTERPRET;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -476,7 +476,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
         if (thisarg->interpret(istate) == EXP_CANT_INTERPRET)
             return EXP_CANT_INTERPRET;
     }
-    static bool evaluatingArgs;
+    static int evaluatingArgs = 0;
     if (arguments)
     {
         dim = arguments->dim;
@@ -500,9 +500,9 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
                     return EXP_CANT_INTERPRET;
                 }
                 // Convert all reference arguments into lvalue references
-                evaluatingArgs = true;
+                ++evaluatingArgs;
                 earg = earg->interpret(istate, ctfeNeedLvalueRef);
-                evaluatingArgs = false;
+                --evaluatingArgs;
                 if (earg == EXP_CANT_INTERPRET)
                     return earg;
             }
@@ -520,9 +520,9 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
                      */
                     earg = ((AddrExp *)earg)->e1;
                 }
-                evaluatingArgs = true;
+                ++evaluatingArgs;
                 earg = earg->interpret(istate);
-                evaluatingArgs = false;
+                --evaluatingArgs;
                 if (earg == EXP_CANT_INTERPRET)
                     return earg;
             }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -754,6 +754,22 @@ static assert(
     return true;
 }());
 
+// 7185 char[].length = n
+
+bool bug7185() {
+    auto arr = new char[2];
+    auto arr2 = new char[2];
+    arr2[] = "ab";
+    arr.length = 1;
+    arr2.length = 7;
+    assert(arr.length == 1);
+    assert(arr2.length == 7);
+    assert(arr2[0..2] == "ab");
+    return true;
+}
+
+static assert(bug7185());
+
 /*******************************************
     6934
 *******************************************/

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3801,6 +3801,7 @@ static assert(!S7165().f());
 **************************************************/
 
 int[] f7187() { return [0]; }
+int[] f7187b(int n) { return [0]; }
 
 int g7187(int[] r)
 {
@@ -3809,6 +3810,7 @@ int g7187(int[] r)
 }
 
 static assert(g7187(f7187()));
+static assert(g7187(f7187b(7)));
 
 /**************************************************
     6933 struct destructors

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3809,3 +3809,20 @@ int g7187(int[] r)
 }
 
 static assert(g7187(f7187()));
+
+/**************************************************
+    6933 struct destructors
+**************************************************/
+
+struct Bug6933 {
+    int x = 3;
+    ~this()     { }
+}
+
+int test6933() {
+    Bug6933 q;
+    assert(q.x == 3);
+    return 3;
+}
+
+static assert(test6933());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1961,6 +1961,37 @@ struct AList
 static assert(AList.checkList()==2);
 
 /**************************************************
+    7194 pointers as struct members
+**************************************************/
+
+struct S7194 { int* p, p2; }
+
+int f7194() {
+    assert(S7194().p == null);
+    assert(!S7194().p);
+    assert(S7194().p == S7194().p2);
+    S7194 s = S7194();
+    assert(!s.p);
+    assert(s.p == null);
+    assert(s.p == s.p2);
+    int x;
+    s.p = &x;
+    s.p2 = s.p;
+    assert(s.p == &x);
+    return 0;
+}
+
+int g7194() {
+    auto s = S7194();
+    assert(s.p);  // should fail
+    return 0;
+}
+
+static assert(f7194() == 0);
+static assert(!is(typeof(compiles!( g7194() ))));
+
+
+/**************************************************
     4065 [CTFE] AA "in" operator doesn't work
 **************************************************/
 


### PR DESCRIPTION
6933 Segfault(declaration.c) using struct with destructor in CTFE
7185 [CTFE] ICE on changing char array length
7194 [CTFE] Incorrect behaviour with pointers as local struct variable

also regression bug 7187 was reopened because I'd missed a case; this fixes it so it can be closed again.
