### PR TITLE
fix ICE Bug7212

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -714,7 +714,8 @@ MATCH DelegateExp::implicitConvTo(Type *t)
 MATCH FuncExp::implicitConvTo(Type *t)
 {
     //printf("FuncExp::implicitCastTo type = %p %s, t = %s\n", type, type ? type->toChars() : NULL, t->toChars());
-    if (type && type != Type::tvoid && tok == TOKreserved && type->ty == Tpointer)
+    if (type && type != Type::tvoid && tok == TOKreserved && type->ty == Tpointer
+        && (t->ty == Tpointer || t->ty == Tdelegate))
     {   // Allow implicit function to delegate conversion
         if (type->nextOf()->covariant(t->nextOf()) == 1)
             return t->ty == Tpointer ? MATCHconst : MATCHconvert;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4526,6 +4526,21 @@ struct Point6881
 }
 
 /***************************************************/
+// 7212
+void foo7212(scope int delegate(int a) dg)
+{
+}
+
+void foo7212(bool a)
+{
+}
+
+void test7212()
+{
+    foo7212((int a) => a);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -4764,6 +4779,7 @@ int main()
     test7026();
     test6354();
     test7072();
+    test7212();
 
     writefln("Success");
     return 0;


### PR DESCRIPTION
- Only check covariant conversion to Type::nextOf
  for delegates and pointers.
  - With t->ty == Tfunction this would have
    checked conversion to the return type.
