### PR TITLE
Issue 6205 - Strongly-pure nothrow functions with ignored return value are entirely stripped even if it contains a failing 'assert'.

### DIFF
--- a/test/runnable/imports/test41a.d
+++ b/test/runnable/imports/test41a.d
@@ -5,9 +5,8 @@ void foo()
         assert(false, "GO");
 }
 
-int i; // make func impure so it is not ctfed away
 public void func(T)()
 {
-        assert(i, "Blah");
+        assert(false, "Blah");
 }
 

--- a/test/runnable/test41.d
+++ b/test/runnable/test41.d
@@ -1,5 +1,5 @@
 // EXTRA_SOURCES: imports/test41a.d
-// PERMUTE_ARGS:
+// PERMUTE_ARGS: -inline -g -O
 
 import imports.test41a;
 import core.exception;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6205

Such optimization should run only when `-O -release` is specified.
