### PR TITLE
Issue 4940 - ICE(symbol.c): Accessing tuple-typed field of struct literal with user-defined constructor

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1328,6 +1328,13 @@ Lnomatch:
                                      * variable with a bit copy of the default
                                      * initializer
                                      */
+
+                                    /* Remove ref if this declaration is ref binding.
+                                     * ref Type __self = (__ctmp = 0, __ctmp).this(...);
+                                     * ->  Type __self = (__self = 0, __self.this(...));
+                                     */
+                                    storage_class &= ~(STCref | STCforeach | STCparameter);
+
                                     Expression *e;
                                     if (sd->zeroInit == 1)
                                     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -6569,8 +6569,8 @@ Expression *DotVarExp::semantic(Scope *sc)
                     v->storage_class |= STCctfe | STCref | STCforeach;
 
                     ev = new VarExp(e->loc, v);
-                    e = new DotVarExp(loc, ev, s->isDeclaration());
-                    e = new CommaExp(e1->loc, new DeclarationExp(e1->loc, v), e);
+                    e = new CommaExp(e1->loc, new DeclarationExp(e1->loc, v), ev);
+                    e = new DotVarExp(loc, e, s->isDeclaration());
                 }
                 else
                     e = new DotVarExp(loc, ev, s->isDeclaration());

--- a/src/expression.c
+++ b/src/expression.c
@@ -8735,6 +8735,12 @@ Lagain:
                 {   Expression *e = (*te->exps)[j1 + i];
                     (*exps)[i] = e;
                 }
+                if (j1 > 0 && j2 - j1 > 0 && sc->func && (*te->exps)[0]->op == TOKdotvar)
+                {
+                    Expression *einit = ((DotVarExp *)(*te->exps)[0])->e1->isTemp();
+                    if (einit)
+                        ((DotVarExp *)(*exps)[0])->e1 = einit;
+                }
                 e = new TupleExp(loc, exps);
             }
             else
@@ -9208,7 +9214,15 @@ Expression *IndexExp::semantic(Scope *sc)
             {
 
                 if (e1->op == TOKtuple)
+                {
                     e = (*te->exps)[(size_t)index];
+                    if (sc->func && (*te->exps)[0]->op == TOKdotvar)
+                    {
+                        Expression *einit = ((DotVarExp *)(*te->exps)[0])->e1->isTemp();
+                        if (einit)
+                            ((DotVarExp *)e)->e1 = einit;
+                    }
+                }
                 else
                     e = new TypeExp(e1->loc, Parameter::getNth(tup->arguments, (size_t)index)->type);
             }

--- a/src/statement.c
+++ b/src/statement.c
@@ -1441,24 +1441,13 @@ Statement *ForeachStatement::semantic(Scope *sc)
         {   te = (TupleExp *)aggr;
             n = te->exps->dim;
 
-            if (te->exps->dim > 0 && (*te->exps)[0]->op == TOKcomma)
+            if (te->exps->dim > 0 && (*te->exps)[0]->op == TOKdotvar &&
+            	((DotVarExp *)(*te->exps)[0])->e1->isTemp())
             {
-                Expression *&e0 = (*te->exps)[0];
+                CommaExp *ce = (CommaExp *)((DotVarExp *)(*te->exps)[0])->e1;
 
-                Expression **pe = &e0;
-                while (((CommaExp *)(*pe))->e2->op == TOKcomma)
-                    pe = &((CommaExp *)(*pe))->e2;
-                if (pe == &e0)
-                {
-                    prelude = ((CommaExp *)(*pe))->e1;
-                    e0 = ((CommaExp *)(*pe))->e2;
-                }
-                else
-                {
-                    prelude = e0;
-                    e0 = ((CommaExp *)(*pe))->e2;
-                    *pe = ((CommaExp *)(*pe))->e1;
-                }
+				prelude = ce->e1;
+				((DotVarExp *)(*te->exps)[0])->e1 = ce->e2;
             }
         }
         else if (aggr->op == TOKtype)   // type tuple

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1364,6 +1364,26 @@ TypeTuple!(int, long) TT6700;
 static assert(bug6700!( (TT6700[1..$]) )==2);
  
 /***************************************/
+// 7263
+
+template TypeTuple7263(T...){ alias T TypeTuple7263; }
+
+struct tuple7263
+{
+    TypeTuple7263!(int, int) field;
+    alias field this;
+}
+
+auto front7263(T)(ref T arr){ return arr[0]; }
+
+void test7263()
+{
+    auto bars = [tuple7263(0, 0), tuple7263(1, 1)];
+    auto spam1 = bars.front7263[1];
+    auto spam2 = bars.front7263[1..2];
+}
+
+/***************************************/
 
 int main()
 {
@@ -1432,6 +1452,7 @@ int main()
     test63();
     test1411();
     test64();
+    test7263();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1143,7 +1143,7 @@ template Filter52()
 static assert(Filter52!().FilteredFoos.length == 1);
 
 void test52()
-{    
+{
 }
 
 /***************************************/
@@ -1344,14 +1344,81 @@ void test1411()
 }
 
 /***************************************/
-// Bugzilla 4444 
- 
-void test64() 
-{ 
-    alias TypeTuple!(1) index; 
-    auto arr = new int[4]; 
-    auto x = arr[index];    // error 
-} 
+// Bugzilla 4444
+
+void test4444()
+{
+    alias TypeTuple!(1) index;
+    auto arr = new int[4];
+    auto x = arr[index];    // error
+}
+
+/***************************************/
+// 4940
+
+template Tuple4940(T...)
+{
+    alias T Tuple4940;
+}
+
+struct S4940
+{
+    Tuple4940!(int, int) x;
+    this(int) { }
+}
+
+void test4940()
+{
+    auto w = S4940(0).x;
+}
+
+//----
+
+struct S4940add
+{
+    string s;
+    long x;
+}
+
+ref S4940add get4940add(ref S4940add s){ return s; }
+
+void test4940add()
+{
+    S4940add s;
+    get4940add(s).tupleof[1] = 20;
+    assert(s.x == 20);
+}
+
+/***************************************/
+// 6530
+
+struct S6530
+{
+    int a, b, c;
+}
+
+struct HasPostblit6530
+{
+    this(this) {}  // Bug goes away without this.
+}
+
+auto toRandomAccessTuple6530(T...)(T input, HasPostblit6530 hasPostblit)
+{
+    return S6530(1, 2, 3);
+}
+
+void doStuff6530(T...)(T args)
+{
+    HasPostblit6530 hasPostblit;
+
+    // Bug goes away without the .tupleof.
+    auto foo = toRandomAccessTuple6530(args, hasPostblit).tupleof;
+}
+
+void test6530()
+{
+    doStuff6530(1, 2, 3);
+}
 
 /***************************************/
 // 6700
@@ -1362,7 +1429,31 @@ template bug6700(TList ...) {
 TypeTuple!(int, long) TT6700;
 
 static assert(bug6700!( (TT6700[1..$]) )==2);
- 
+
+/***************************************/
+// 7233
+
+struct Foo7233 { int x, y; }
+Foo7233[] front7233(Foo7233[][] a)
+{
+    return a[0];
+}
+
+class Bar7233 { int x, y; }
+Bar7233[] front7233(Bar7233[][] a)
+{
+    return a[0];
+}
+
+void test7233()
+{
+    Foo7233[][] b1 = [[Foo7233()]];
+    auto xy1 = b1.front7233[0].tupleof;
+
+    Bar7233[][] b2 = [[new Bar7233()]];
+    auto xy2 = b2.front7233[0].tupleof;
+}
+
 /***************************************/
 // 7263
 
@@ -1451,7 +1542,11 @@ int main()
     test62();
     test63();
     test1411();
-    test64();
+    test4444();
+    test4940();
+    test4940add();
+    test6530();
+    test7233();
     test7263();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=4940

Explanation of bug mechanism:
http://d.puremagic.com/issues/show_bug.cgi?id=4940#c3

`e1.tupleof` should be translated by the same way in `DotVarExp::semantic()` to save side effect of `e1`.

2012/01/10
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7263">Issue 7263</a> - Tuple slicing + -O switch causes "used before set" error
Tuple slicing has same problem.
