### PR TITLE
Bug7253: Improve failed selective import error

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -200,7 +200,7 @@ void Import::semantic(Scope *sc)
 
             //printf("\tImport alias semantic('%s')\n", s->toChars());
             if (!mod->search(loc, (Identifier *)names.data[i], 0))
-                error("%s not found", ((Identifier *)names.data[i])->toChars());
+                error("can't find selected symbol '%s'", ((Identifier *)names.data[i])->toChars());
 
             s->semantic(sc);
         }


### PR DESCRIPTION
See http://d.puremagic.com/issues/show_bug.cgi?id=7253

Improve failed selective import error. It just changes the specific error to:
can't find selected symbol 'non_exitent_symbol'

It doesn't fix the __anonymous or the second bogus error message.
