### PR TITLE
Issue 7278 - Templated struct (instantiated with null) can't access its own members

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2989,6 +2989,17 @@ NullExp::NullExp(Loc loc, Type *type)
     this->type = type;
 }
 
+int NullExp::equals(Object *o)
+{
+    if (o && o->dyncast() == DYNCAST_EXPRESSION)
+    {   Expression *e = (Expression *)o;
+
+        if (e->op == TOKnull)
+            return TRUE;
+    }
+    return FALSE;
+}
+
 Expression *NullExp::semantic(Scope *sc)
 {
 #if LOGSEMANTIC

--- a/src/expression.h
+++ b/src/expression.h
@@ -344,6 +344,7 @@ struct NullExp : Expression
     unsigned char committed;    // !=0 if type is committed
 
     NullExp(Loc loc, Type *t = NULL);
+    int equals(Object *o);
     Expression *semantic(Scope *sc);
     int isBool(int result);
     int isConst();

--- a/test/runnable/nulltype.d
+++ b/test/runnable/nulltype.d
@@ -78,9 +78,31 @@ static assert(is(typeof(h5899) R == return) && is(R == int[]));
 pragma(msg, typeof(h5899));
 
 /**********************************************/
+// 7278
 
-void main()
+struct Foo7278(string s)
+{
+    string var;
+    void func()
+    {
+        string local = var;
+    }
+}
+
+void test7278()
+{
+    Foo7278!null a;
+    Foo7278!null b;
+}
+
+/**********************************************/
+
+int main()
 {
     test1();
     test2();
+    test7278();
+
+    printf("Success\n");
+    return 0;
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7278

Null literals should behave like 'singleton' object, even if they have different types.
