### PR TITLE
Issue 1313 - out/body disables escape analysis

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3515,6 +3515,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
     FuncDeclaration *fd = sc->parent->isFuncDeclaration();
     Scope *scx = sc;
     int implicit0 = 0;
+    Expression *eorg = NULL;
 
     if (fd->fes)
         fd = fd->fes->func;             // fd is now function enclosing foreach
@@ -3591,10 +3592,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         else
             fd->nrvo_can = 0;
 
-        if (fd->returnLabel && tbret->ty != Tvoid)
-        {
-        }
-        else if (fd->inferRetType)
+        if (fd->inferRetType)
         {   TypeFunction *tf = (TypeFunction *)fd->type;
             assert(tf->ty == Tfunction);
             Type *tfret = tf->nextOf();
@@ -3655,6 +3653,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
                     tbret = tret->toBasetype();
                 }
             }
+            if (fd->returnLabel)
+                eorg = exp;
         }
         else if (tbret->ty != Tvoid)
         {
@@ -3664,10 +3664,14 @@ Statement *ReturnStatement::semantic(Scope *sc)
             {
                 exp = exp->castTo(sc, exp->type->invariantOf());
             }
-
             if (fd->tintro)
                 exp = exp->implicitCastTo(sc, fd->type->nextOf());
+
+            // eorg isn't casted to tret (== fd->tintro->nextOf())
+            if (fd->returnLabel)
+                eorg = exp->copy();
             exp = exp->implicitCastTo(sc, tret);
+
             if (!((TypeFunction *)fd->type)->isref)
                 exp = exp->optimize(WANTvalue);
         }
@@ -3771,7 +3775,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
             assert(fd->vresult);
             VarExp *v = new VarExp(0, fd->vresult);
 
-            exp = new ConstructExp(loc, v, exp);
+            assert(eorg);
+            exp = new ConstructExp(loc, v, eorg);
             exp = exp->semantic(sc);
         }
     }

--- a/test/fail_compilation/fail1313a.d
+++ b/test/fail_compilation/fail1313a.d
@@ -1,0 +1,7 @@
+int[] test()
+//out{}
+body
+{
+    int a[2];
+    return a;
+}

--- a/test/fail_compilation/fail1313b.d
+++ b/test/fail_compilation/fail1313b.d
@@ -1,0 +1,7 @@
+int[] test()
+out{}
+body
+{
+    int a[2];
+    return a;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=1313

We should cast exp to return type for escape analysis, even if returnLabel != NULL.
