### PR TITLE
CTFE regressions and ref bugs 7187 7245 7248 7266

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1820,6 +1820,17 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
                 error(loc, "variable %s is used before initialization", v->toChars());
             else if (exceptionOrCantInterpret(e))
                 return e;
+            else if (goal == ctfeNeedLvalue && v->isRef() && e->op == TOKindex)
+            {   // If it is a foreach ref, resolve the index into a constant
+                IndexExp *ie = (IndexExp *)e;
+                Expression *w = ie->e2->interpret(istate);
+                if (w != ie->e2)
+                {
+                    e = new IndexExp(ie->loc, ie->e1, w);
+                    e->type = ie->type;
+                }
+                return e;
+            }
             else if ((goal == ctfeNeedLvalue)
                     || e->op == TOKstring || e->op == TOKstructliteral || e->op == TOKarrayliteral
                     || e->op == TOKassocarrayliteral || e->op == TOKslice

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -952,7 +952,7 @@ Expression *ReturnStatement::interpret(InterState *istate)
         e = exp->interpret(istate);
     if (exceptionOrCantInterpret(e))
         return e;
-    if (needToCopyLiteral(exp))
+    if (needToCopyLiteral(e))
         e = copyLiteral(e);
 #if LOGASSIGN
     printf("RETURN %s\n", loc.toChars());

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3816,8 +3816,10 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
     if (!wantRef && e1->op == TOKdotvar)
     {
         // Strip of all of the leading dotvars, unless we started with a call
+        // or a ref parameter
         // (in which case, we already have the lvalue).
-        if (this->e1->op != TOKcall)
+        if (this->e1->op != TOKcall && !(this->e1->op==TOKvar
+            && ((VarExp*)this->e1)->var->storage_class & (STCref | STCout)))
             e1 = e1->interpret(istate, ctfeNeedLvalue);
         if (exceptionOrCantInterpret(e1))
             return e1;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3630,7 +3630,7 @@ static assert({
 }());
 
 /**************************************************
-    6522 opAssign + foreach
+    6522 opAssign + foreach ref
 **************************************************/
 
 struct Foo6522 {
@@ -3648,6 +3648,30 @@ bool foo6522() {
 }
 
 static assert(foo6522());
+
+/**************************************************
+    7245 pointers + foreach ref
+**************************************************/
+
+int bug7245(int testnum) {
+    int[3] arr;
+    arr[0] = 4;
+    arr[1] = 6;
+    arr[2] = 8;
+    int* ptr;
+
+    foreach(i, ref p; arr) {
+        if(i == 1)
+            ptr = &p;
+        if (testnum == 1)
+            p = 5;
+    }
+
+    return *ptr;
+}
+
+static assert(bug7245(0)==6);
+static assert(bug7245(1)==5);
 
 /**************************************************
     6919

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2002,6 +2002,19 @@ int g7194() {
 static assert(f7194() == 0);
 static assert(!is(typeof(compiles!( g7194() ))));
 
+/**************************************************
+    7248 recursive struct pointers in array
+**************************************************/
+struct S7248 { S7248* ptr; }
+
+bool bug7248() {
+    S7248[2] sarr;
+    sarr[0].ptr = &sarr[1];
+    sarr[0].ptr = null;
+    S7248* t = sarr[0].ptr;
+    return true;
+}
+static assert(bug7248());
 
 /**************************************************
     4065 [CTFE] AA "in" operator doesn't work

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3752,6 +3752,37 @@ int bug6037outer(){
 static assert(bug6037outer() == 401);
 
 /**************************************************
+    7266 dotvar ref parameters
+**************************************************/
+
+struct S7266 { int a; }
+
+bool bug7266()
+{
+    S7266 s;
+    s.a = 4;
+    bar7266(s.a);
+    assert(s.a == 5);
+    out7266(s.a);
+    assert(s.a == 7);
+    return true;
+}
+
+void bar7266(ref int b)
+{
+    b = 5;
+    assert(b == 5);
+}
+
+void out7266(out int b)
+{
+    b = 7;
+    assert(b == 7);
+}
+
+static assert( bug7266());
+
+/**************************************************
     7143 'is' for classes
 **************************************************/
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3871,6 +3871,22 @@ int g7187(int[] r)
 static assert(g7187(f7187()));
 static assert(g7187(f7187b(7)));
 
+struct S7187 { const(int)[] field; }
+
+const(int)[] f7187c() {
+    auto s = S7187([0]);
+    return s.field;
+}
+
+bool g7187c(const(int)[] r)
+{
+    auto t = r[0..0];
+    return true;
+}
+
+static assert(g7187c(f7187c()));
+
+
 /**************************************************
     6933 struct destructors
 **************************************************/


### PR DESCRIPTION
7187 was reopened; this fixes the extra test case so it can be closed again. 7248 is another regression. The other two are wrong code.

7187 Regression(head 12d62ca5): [CTFE] ICE on slicing
7245 [CTFE] Address of ref foreach parameter changes to point after array
7248 [CTFE] Stack overflow on using struct filed pointer with address of array element
7266 [CTFE] Assign to ref param (that's taken from struct member) is noop
