### PR TITLE
printf %j needs explicit cast

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -121,11 +121,11 @@ const char *Token::toChars()
             break;
 
         case TOKint64v:
-            sprintf(buffer,"%jdL",int64value);
+            sprintf(buffer,"%jdL",(intmax_t)int64value);
             break;
 
         case TOKuns64v:
-            sprintf(buffer,"%juUL",uns64value);
+            sprintf(buffer,"%juUL",(uintmax_t)uns64value);
             break;
 
 #if IN_GCC


### PR DESCRIPTION
- emitted warning on llvm-g++
