### PR TITLE
OPind and vector

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -2627,7 +2627,7 @@ code *cdind(elem *e,regm_t *pretregs)
         }
         if (retregs & XMMREGS)
         {
-            assert(sz == 4 || sz == 8);         // float or double
+            assert(sz == 4 || sz == 8 || sz == 16); // float, double or vector
             cs.Iop = xmmload(tym);
             reg -= XMM0;
             goto L2;


### PR DESCRIPTION
- also fixes OSX build

Not sure why OSX uses a separate LEA to load constants.
