### PR TITLE
7117 Regression(2.057, 1.072): out contract for class member functions are broken

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1671,12 +1671,9 @@ void VarDeclaration::checkNestedReference(Scope *sc, Loc loc)
         // The current function
         FuncDeclaration *fdthis = sc->parent->isFuncDeclaration();
 
-        if (fdv && fdthis && fdv != fdthis && fdthis->ident != Id::ensure)
+        // BUG: The __ensure condition is not correct. See bugs 7117 and 6859.
+        if (fdv && fdthis && fdv != fdthis && !(fdthis->ident == Id::ensure && ident == Id::This))
         {
-            /* __ensure is always called directly,
-             * so it never becomes closure.
-             */
-
             if (loc.filename)
                 fdthis->getLevel(loc, fdv);
 

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -242,6 +242,27 @@ void test6()
 +/
 
 /*******************************************/
+// 7117
+class Sad7117
+{
+    void func ( int n )
+    out
+    {
+        assert ( n == 23);
+    }
+    body
+    {
+        assert ( n == 23);
+    }
+}
+
+void test7117()
+{
+    auto c = new Sad7117;
+    c.func(23);
+}
+
+/*******************************************/
 // 7218
 
 void test7218()
@@ -262,6 +283,7 @@ int main()
     test4();
     test5();
 //    test6();
+    test7117();
     test7218();
 
     printf("Success\n");


### PR DESCRIPTION
This is a quick fix for a bug which is a blocker for us.
This reverts the bad commit (attempt to fix bug 6859) which caused the regression, but does it in a way that the test case for 6859 still passes.
There's still something badly wrong with out contracts, and this doesn't fix that.
