### PR TITLE
7295 pure + alias this + 7296 regression

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1287,12 +1287,17 @@ Lretry:
                     ad = ((TypeStruct *)tba)->sym;
             Lad:
                     if (ad->aliasthis)
-                    {
+                    {   /* If a semantic error occurs while doing alias this,
+                         * eg purity(bug 7295), just regard it as not a match.
+                         */
+                        unsigned olderrors = global.startGagging();
                         Expression *e = new DotIdExp(farg->loc, farg, ad->aliasthis->ident);
                         e = e->semantic(sc);
                         e = resolveProperties(sc, e);
-                        farg = e;
-                        goto Lretry;
+                        if (!global.endGagging(olderrors))
+                        {   farg = e;
+                            goto Lretry;
+                        }
                     }
                 }
             }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3042,6 +3042,25 @@ void test2540()
 }
 
 /***************************************************/
+// 7295
+
+struct S7295
+{
+    int member;
+    @property ref int refCountedPayload() { return member; }
+    alias refCountedPayload this;
+}
+
+void foo7295(S)(immutable S t, int qq) pure { }
+void foo7295(S)(S s) pure { }
+
+void bar7295() pure
+{
+    S7295 b;
+    foo7295(b);
+}
+
+/***************************************************/
 // 5659
 
 void test149()


### PR DESCRIPTION
7295 Alias This + Pure + pointsTo = rejects-valid
7296 [2.058] Regression:  Cannot swap RefCounted

Suppress errors while determining 'alias this' while looking for a template match. If an error occurs, treat it as a failed match. Bug 7296 is a Phobos regression, where a minor change has triggered this bug.

Ideally the matching step would completely ignore purity and safety, only checking them after a match is found -- that would give better error messages. But to do that cleanly would involve some very intrusive changes. Even then I think errors should still be gagged while doing the alias this transformation.
