### PR TITLE
Issue 7321 - returning void considered unsafe by safety inference

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3678,7 +3678,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         else
         {
             ((TypeFunction *)fd->type)->next = Type::tvoid;
-            fd->type = fd->type->semantic(loc, sc);
+            //fd->type = fd->type->semantic(loc, sc);   // Remove with7321, same as 6902
             if (!fd->tintro)
             {   tret = Type::tvoid;
                 tbret = tret;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4416,6 +4416,15 @@ void test7285()
 }
 
 /***************************************************/
+// 7321
+
+void test7321()
+{
+    static assert(is(typeof((){})==void function()pure nothrow @safe));         // ok
+    static assert(is(typeof((){return;})==void function()pure nothrow @safe));  // fail
+}
+
+/***************************************************/
 
 int main()
 {
@@ -4627,6 +4636,7 @@ int main()
     test7170();
     test7196();
     test7285();
+    test7321();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7321

This is a shortfall of fixing bug 6902.
