### PR TITLE
CTFE regression 7197 enum string doesn't work with CTFE

### DIFF
--- a/src/optimize.c
+++ b/src/optimize.c
@@ -918,9 +918,6 @@ Expression *CommaExp::optimize(int result)
         e = interpret(NULL);
         return (e == EXP_CANT_INTERPRET) ?  this : e;
     }
-    // Don't constant fold if it is a compiler-generated temporary.
-    if (e1->op == TOKdeclaration)
-       return this;
 
     e1 = e1->optimize(result & WANTinterpret);
     e2 = e2->optimize(result);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4017,3 +4017,16 @@ int test6933() {
 }
 
 static assert(test6933());
+
+/**************************************************
+    7197
+**************************************************/
+
+int foo7197(int[] x...) {
+    return 1;
+}
+template bar7197(y...) {
+    enum int bar7197 = foo7197(y);
+}
+enum int bug7197 = 7;
+static assert(bar7197!(bug7197));

--- a/test/runnable/ctorpowtests.d
+++ b/test/runnable/ctorpowtests.d
@@ -99,6 +99,7 @@ static assert( 9 ^^ -1.0 == 1.0 / 9);
 static assert( !is(typeof(2 ^^ -5)));
 static assert( !is(typeof((-2) ^^ -4)));
 
+// Bug 3535
 struct StructWithCtor
 {
     this(int _n) {


### PR DESCRIPTION
7197 enum string doesn't work with CTFE

This wasn't actually a bug in CTFE at all, it was caused by some erroneous code in the const folding for comma expressions. The new asserts and error checking in CTFE have detected it, but it's been incorrect for a long time.
I originally introduced that CommaExp code while fixing bug 3535, it was a workaround for another problem which has since been fixed.
