### PR TITLE
Enhance ability to link with C++

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -2145,10 +2145,13 @@ size_t obj_mangle(Symbol *s,char *dest)
         size_t len2;
 
         // Attempt to compress the name
-        name2 = id_compress(name, len);
+        if (type_mangle(s->Stype) == mTYman_cpp)
+            name2 = strdup(name);
+        else
+            name2 = id_compress(name, len);
         len2  = strlen(name2);
 #if MARS
-        if (len2 > LIBIDMAX)            // still too long
+        if (len2 > LIBIDMAX && type_mangle(s->Stype) != mTYman_cpp)            // still too long
         {
             /* Form md5 digest of the name and store it in the
              * last 32 bytes of the name.

--- a/src/backend/newman.c
+++ b/src/backend/newman.c
@@ -1623,6 +1623,22 @@ STATIC void cpp_symbol_name(symbol *s)
         }
     }
 #endif
+#if MARS
+    // Write special functions specially
+    if (tyfunc(s->Stype->Tty) && s->Sfunc)
+    {
+        if (s->Sfunc->Fflags & Fctor)
+        {
+            cpp_zname(cpp_name_ct);
+            return;
+        }
+        else if (s->Sfunc->Fflags & Fdtor)
+        {
+            cpp_zname(cpp_name_dt);
+            return;
+        }
+    }
+#endif
     cpp_zname(p);
 }
 

--- a/src/backend/newman.c
+++ b/src/backend/newman.c
@@ -504,14 +504,16 @@ char *cpp_mangle(symbol *s)
     else
     {
         MangleInuse m;
-
+//__asm int 3;
         mangle.znamei = 0;
         mangle.argi = 0;
         mangle.np = mangle.buf;
         mangle.buf[BUFIDMAX + 1] = 0x55;
+        static int x = 0;
+        //if (!strcmp(s->Sident, "buildArrayIdent")) __asm int 3;
         cpp_decorated_name(s);
         *mangle.np = 0;                 // 0-terminate cpp_name[]
-        //dbg_printf("cpp_mangle() = '%s'\n", mangle.buf);
+        //printf("cpp_mangle() = '%s' %d\n", mangle.buf, x++);
         assert(strlen(mangle.buf) <= BUFIDMAX);
         assert(mangle.buf[BUFIDMAX + 1] == 0x55);
         return mangle.buf;
@@ -584,7 +586,7 @@ STATIC int cpp_protection(symbol *s)
  * Create mangled name for template instantiation.
  */
 
-#if SCPP
+#if SCPP || MARS
 
 char *template_mangle(symbol *s,param_t *arglist)
 {
@@ -693,12 +695,14 @@ char *template_mangle(symbol *s,param_t *arglist)
                     else
                         CHAR('S');
                     if (e->EV.ss.Voffset)
-                        synerr(EM_const_init);          // constant initializer expected
+                        assert(0);
+                        //synerr(EM_const_init);          // constant initializer expected
                     cpp_string(e->EV.ss.Vstring,e->EV.ss.Vstrlen);
                     break;
                 case OPrelconst:
                     if (e->EV.sp.Voffset)
-                        synerr(EM_const_init);          // constant initializer expected
+                        assert(0);
+                        //synerr(EM_const_init);          // constant initializer expected
                     s = e->EV.sp.Vsym;
                     if (NEWTEMPMANGLE)
                     {   STR("$1");
@@ -729,7 +733,7 @@ char *template_mangle(symbol *s,param_t *arglist)
                     if (!errcnt)
                         elem_print(e);
 #endif
-                    synerr(EM_const_init);              // constant initializer expected
+                    //synerr(EM_const_init);              // constant initializer expected
                     assert(errcnt);
 #endif
                     break;
@@ -1051,7 +1055,22 @@ STATIC void cpp_basic_data_type(type *t)
                 goto Ldefault;
             break;
 #endif
-
+#if MARS
+        case TYtemplate:
+            CHAR('V');
+            Mangle save = mangle;
+            Symbol *s = ((typetemp_t *)t)->Tsym;
+            char *p = template_mangle(s, s->Stemplate->TMptpl);
+            int len = mangle.np - mangle.buf;
+            char *q = (char *)malloc(len + 1);
+            memcpy(q, p, len);
+            q[len] = '\0';
+            //printf("%d\t%s\n", len, q);
+            mangle = save;
+            cpp_zname(q);
+            CHAR('@');
+            break;
+#endif
         default:
         Ldefault:
             if (tyfunc(t->Tty))
@@ -1544,6 +1563,23 @@ STATIC void cpp_scope(symbol *s)
 
             case SCstruct:
                 cpp_zname(symbol_ident(s));
+                break;
+
+            case SCtemplate:
+                Mangle save = mangle;
+                char *q;
+                int len;
+
+                p = template_mangle(s, s->Stemplate->TMptpl);
+                len = mangle.np - mangle.buf;
+                q = (char *)malloc(len + 1);
+                memcpy(q, p, len);
+                q[len] = '\0';
+                //printf("%d\t%s\n", len, q);
+                //printf("\t%*s\n", mangle.np - mangle.buf, mangle.buf);
+                mangle = save;
+                //printf("\t%*s\n", mangle.np - mangle.buf, mangle.buf);
+                cpp_zname(q);
                 break;
 
             default:

--- a/src/backend/ty.h
+++ b/src/backend/ty.h
@@ -104,7 +104,9 @@ enum TYM
 #if !MARS
     TYmemptr            = 0x2F, // pointer to member
     TYident             = 0x30, // type-argument
+#endif
     TYtemplate          = 0x31, // unexpanded class template
+#if !MARS
     TYvtshape           = 0x32, // virtual function table
 #endif
 

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -269,7 +269,7 @@ type *type_alloc(tym_t ty)
  * Allocate a TYtemplate.
  */
 
-#if !MARS
+#if 1 || !MARS
 type *type_alloc_template(symbol *s)
 {   type *t;
 
@@ -1439,6 +1439,8 @@ static int paramlstmatch(param_t *p1,param_t *p2)
  *      !=0 if types match.
  */
 
+int matchtemplate(type *t1, type *t2, tym_t t1ty, tym_t t2ty);
+
 int typematch(type *t1,type *t2,int relax)
 { tym_t t1ty, t2ty;
   tym_t tym;
@@ -1472,8 +1474,17 @@ int typematch(type *t1,type *t2,int relax)
             (!tyfunc(t1ty) ||
              ((t1->Tflags & TFfixed) == (t2->Tflags & TFfixed) &&
                  paramlstmatch(t1->Tparamtypes,t2->Tparamtypes) ))
+                 &&
+
+            matchtemplate(t1, t2, t1ty, t2ty)
          ;
 }
+
+int matchtemplate(type *t1, type *t2, tym_t t1ty, tym_t t2ty)
+{
+    return tybasic(t1ty) != TYtemplate || ((typetemp_t *)t1)->Tsym == ((typetemp_t *)t2)->Tsym;
+}
+
 
 #endif
 

--- a/src/class.c
+++ b/src/class.c
@@ -297,8 +297,8 @@ void ClassDeclaration::semantic(Scope *sc)
         isdeprecated = 1;
     }
 
-    if (sc->linkage == LINKcpp)
-        error("cannot create C++ classes");
+    //if (sc->linkage == LINKcpp)
+    //    error("cannot create C++ classes");
 
     // Expand any tuples in baseclasses[]
     for (size_t i = 0; i < baseclasses->dim; )

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -601,6 +601,8 @@ struct FuncDeclaration : Declaration
     #define FUNCFLAGpurityInprocess 1   // working on determining purity
     #define FUNCFLAGsafetyInprocess 2   // working on determining safety
     #define FUNCFLAGnothrowInprocess 4  // working on determining nothrow
+
+    int forceNonVirtual;
 #else
     int nestedFrameRef;                 // !=0 if nested variables referenced
 #endif

--- a/src/func.c
+++ b/src/func.c
@@ -493,6 +493,12 @@ void FuncDeclaration::semantic(Scope *sc)
             default:
             {   FuncDeclaration *fdv = (FuncDeclaration *)cd->baseClass->vtbl.tdata()[vi];
                 // This function is covariant with fdv
+
+                if (linkage == LINKcpp && isFinal() && fdv->isFinal())
+                {
+                    forceNonVirtual = 1;
+                    goto Ldone;
+                }
                 if (fdv->isFinal())
                     error("cannot override final function %s", fdv->toPrettyChars());
 

--- a/src/template.c
+++ b/src/template.c
@@ -4005,6 +4005,7 @@ TemplateInstance::TemplateInstance(Loc loc, Identifier *ident)
     this->isnested = NULL;
     this->errors = 0;
     this->speculative = 0;
+    this->csym = NULL;
 }
 
 /*****************

--- a/src/template.h
+++ b/src/template.h
@@ -38,6 +38,14 @@ struct FuncDeclaration;
 struct HdrGenState;
 enum MATCH;
 
+// Back end
+#if IN_GCC
+union tree_node; typedef union tree_node TYPE;
+typedef TYPE type;
+#else
+typedef struct TYPE type;
+#endif
+
 struct Tuple : Object
 {
     Objects objects;
@@ -336,6 +344,9 @@ struct TemplateInstance : ScopeDsymbol
 
     TemplateInstance *isTemplateInstance() { return this; }
     AliasDeclaration *isAliasDeclaration();
+    Symbol *csym;
+    Symbol *toSymbol();
+    type *toCtype();
 };
 
 struct TemplateMixin : TemplateInstance

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -356,6 +356,8 @@ Symbol *FuncDeclaration::toSymbol()
             func_t *f = s->Sfunc;
             if (isVirtual())
                 f->Fflags |= Fvirtual;
+            else if (forceNonVirtual || isCtorDeclaration())
+                ;
             else if (isMember2())
                 f->Fflags |= Fstatic;
             f->Fstartline.Slinnum = loc.linnum;
@@ -412,6 +414,17 @@ Symbol *FuncDeclaration::toSymbol()
                         ::type *tc = cd->type->toCtype();
                         s->Sscope = tc->Tnext->Ttag;
                     }
+                    StructDeclaration *sd = parent->isStructDeclaration();
+                    if (sd)
+                    {
+                        ::type *tc = sd->type->toCtype();
+                        s->Sscope = tc->Ttag;
+                    }
+
+                    if (isCtorDeclaration())
+                        s->Sfunc->Fflags |= Fctor;
+                    if (isDtorDeclaration())
+                        s->Sfunc->Fflags |= Fdtor;
                     break;
                 }
                 default:

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -270,25 +270,30 @@ Symbol *VarDeclaration::toSymbol()
                 break;
 
             case LINKcpp:
+            {
                 m = mTYman_cpp;
 
                 s->Sflags |= SFLpublic;
-
                 Dsymbol *parent = toParent();
                 ClassDeclaration *cd = parent->isClassDeclaration();
+                TemplateInstance *ti = NULL;
                 if (cd)
                 {
                     ::type *tc = cd->type->toCtype();
                     s->Sscope = tc->Tnext->Ttag;
+                    ti = cd->toParent()->isTemplateInstance();
                 }
                 StructDeclaration *sd = parent->isStructDeclaration();
                 if (sd)
                 {
                     ::type *tc = sd->type->toCtype();
                     s->Sscope = tc->Ttag;
+                    ti = sd->toParent()->isTemplateInstance();
                 }
+                if (ti)
+                    s->Sscope = ti->toSymbol();
                 break;
-
+            }
             default:
                 printf("linkage = %d\n", linkage);
                 assert(0);


### PR DESCRIPTION
This is a work in progress and is _NOT_ ready to be merged.  I've opened this at Walter's request.
Windows only.

@braddr: I'm not sure how to go about adding test cases for this.  Any suggestions?

Currently, the following are supported in dmd:
- c++ 'class' virtual functions
- c++ free functions
- c++ global variables

This patch adds/changes following:
- extern(C++) classes are un-disabled
- Correct mangling for static and non-virtual member functions for classes, structs and interfaces
- Correct mangling for static and non-static member variables of structs and classes
- Constructors and destructors of c++ classes and interfaces are mangled correctly
- final can be used on c++ member functions to force non-virtual
- c++ dtors are not automatically non-virtual (and are no longer disabled)
- Template structs and classes are mangled correctly when used as a return type, a parameter type, or parent of a function/variable
- C++ mangled names are not compressed (this was causing what looked like corruption, I have no idea why) or hashed

Basically, things link now.  And when I say link, I mean LINK.  Not much beyond that has been tested yet.

``` D
extern(C++)
struct Struct
{
  int member;
  static extern int staticmember;
  void memberfunc();
  static void staticfun();

  this();
  ~this();
}

extern(C++)
class Class
{
  int member;
  static extern int staticmember;
  void virtualfun();
  final void memberfunc();
  static void staticfun();

  this();
  ~this(); // virtual dtor, use final to force non-virtual
}

extern(C++)
interface I
{
  static extern int staticmember;
  void virtualfun();
  static void staticfun();
}

extern(C++)
class CT(T)
{
  int member;
  static extern int staticmember;
  void virtualfun();
  final void memberfunc();
  static void staticfun();
}

alias CT!int TT;

extern(C++)
extern int global;

extern(C++)
void globalfun();

extern(C++)
TT templatefun(TT, TT);
```

``` C++
struct Struct
{
  int member;
  static int staticmember;
  void memberfunc() {}
  static void staticfun() {}

  Struct() {}
  ~Struct() {}
};

class Class
{
  int member;
  static int staticmember;
  virtual void virtualfun() {}
  void memberfunc() {}
  static void staticfun() {}

  Class();
  virtual ~Class();
};

class I
{
  static int staticmember;
  virtual void virtualfun() {}
  static void staticfun() {}
};

template<typename T>
class CT
{
  int member;
  static int staticmember;
  virtual void virtualfun() {}
  void memberfunc() {}
  static void staticfun() {}
};

typedef CT<int> TT;

int global;

void globalfun() {}

TT templatefun(TT, TT) {}
```

Things missing:
- variables in template struct/classes
- variables that are template struct/classes
- template non-type parameters
- mangling of special functions other than ctor and dtor
- mangling global special functions
- a way to support c++ value type classes embedded in other classes / as globals
- mangling of struct vs class and int vs long and d keywords
- debug information - dmd just crashes at the moment
- non-windows support - I don't have a linux box set up to test on at the moment

Test cases, patches and advice welcome (_especially_ advice on the backend and mangling voodoo)

Edit: variables inside templates are now supported
