### PR TITLE
Comments in response file

### DIFF
--- a/docs/man/man1/dmd.1
+++ b/docs/man/man1/dmd.1
@@ -22,6 +22,10 @@ Object files to link in
 .IP file.a
 Library files to link in
 
+.IP @cmdfile
+A file to read more command-line arguments from,
+which may contain sh-style single-line comments
+
 .IP -c
 Compile only, do not link
 

--- a/src/root/response.c
+++ b/src/root/response.c
@@ -102,6 +102,7 @@ int response_expand(int *pargc, char ***pargv)
             char *buffer;
             char *bufend;
             char *p;
+            int comment = 0;
 
             cp++;
             p = getenv(cp);
@@ -164,15 +165,31 @@ int response_expand(int *pargc, char ***pargv)
                         goto L2;
 
                     case 0xD:
+                    case '\n':
+                        if (comment)
+                        {
+                            comment = 0;
+                        }
                     case 0:
                     case ' ':
                     case '\t':
-                    case '\n':
                         continue;   // scan to start of argument
+                        
+                    case '#':
+                        comment = 1;
+                        continue;
 
                     case '@':
+                        if (comment)
+                        {
+                            continue;
+                        }
                         recurse = 1;
                     default:      /* start of new argument   */
+                        if (comment)
+                        {
+                            continue;
+                        }
                         if (addargp(&n,p))
                             goto noexpand;
                         instring = 0;


### PR DESCRIPTION
I've added this feature where you can have comments delimited by `#` and newlines in the response file (`dmd @cmdfile`). It works on separate lines, and when whitespace separates it from an argument.
