### PR TITLE
Issue 6453 - Allow multiple invariants per struct/class

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -58,7 +58,8 @@ struct AggregateDeclaration : ScopeDsymbol
     VarDeclaration *vthis;      // 'this' parameter if this aggregate is nested
 #endif
     // Special member functions
-    InvariantDeclaration *inv;          // invariant
+    InvariantDeclaration *inv;          // linked list of invariants
+    FuncDeclaration *superInv;          // function to call all invariants
     NewDeclaration *aggNew;             // allocator
     DeleteDeclaration *aggDelete;       // deallocator
 
@@ -91,6 +92,8 @@ struct AggregateDeclaration : ScopeDsymbol
     FuncDeclaration *buildDtor(Scope *sc);
     int isNested();
     int isExport();
+    void addInvariant(InvariantDeclaration *inv);
+    void combineInvariants(Scope *sc);
 
     void emitComment(Scope *sc);
     void toJsonBuffer(OutBuffer *buf);

--- a/src/class.c
+++ b/src/class.c
@@ -689,13 +689,10 @@ void ClassDeclaration::semantic(Scope *sc)
 //    if (dtor && dtor->toParent() != this)
 //      dtor = NULL;
 
-//    inv = (InvariantDeclaration *)search(Id::classInvariant, 0);
-//    if (inv && inv->toParent() != this)
-//      inv = NULL;
-
     // Can be in base class
     aggNew    = (NewDeclaration *)search(0, Id::classNew, 0);
     aggDelete = (DeleteDeclaration *)search(0, Id::classDelete, 0);
+    combineInvariants(sc);
 
     // If this class has no constructor, but base class does, create
     // a constructor:

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -826,6 +826,8 @@ struct SharedStaticDtorDeclaration : StaticDtorDeclaration
 
 struct InvariantDeclaration : FuncDeclaration
 {
+    InvariantDeclaration *next;
+
     InvariantDeclaration(Loc loc, Loc endloc);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1972,7 +1972,7 @@ elem *AssertExp::toElem(IRState *irs)
         symbol *ts = NULL;
         elem *einv = NULL;
 
-        InvariantDeclaration *inv = (InvariantDeclaration *)(void *)1;
+        FuncDeclaration *inv = (InvariantDeclaration *)(void *)1;
 
         // If e1 is a class object, call the class invariant on it
         if (global.params.useInvariants && t1->ty == Tclass &&
@@ -1989,7 +1989,7 @@ elem *AssertExp::toElem(IRState *irs)
         else if (global.params.useInvariants &&
             t1->ty == Tpointer &&
             t1->nextOf()->ty == Tstruct &&
-            (inv = ((TypeStruct *)t1->nextOf())->sym->inv) != NULL)
+            (inv = ((TypeStruct *)t1->nextOf())->sym->superInv) != NULL)
         {
             ts = symbol_genauto(t1->toCtype());
             einv = callfunc(loc, irs, 1, inv->type->nextOf(), el_var(ts), e1->type, inv, inv->type, NULL, NULL);

--- a/src/identifier.c
+++ b/src/identifier.c
@@ -51,7 +51,6 @@ const char *Identifier::toHChars2()
 
     if (this == Id::ctor) p = "this";
     else if (this == Id::dtor) p = "~this";
-    else if (this == Id::classInvariant) p = "invariant";
     else if (this == Id::unitTest) p = "unittest";
     else if (this == Id::dollar) p = "$";
     else if (this == Id::withSym) p = "with";
@@ -65,6 +64,8 @@ const char *Identifier::toHChars2()
                 p = "static this";
             else if (memcmp(p, "_staticDtor", 11) == 0)
                 p = "static ~this";
+            else if (memcmp(p, Id::classInvariant->toChars(), strlen(Id::classInvariant->toChars())) == 0)
+                p = "invariant";
         }
     }
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -42,6 +42,7 @@ AggregateDeclaration::AggregateDeclaration(Loc loc, Identifier *id)
     deferred = NULL;
     isdeprecated = 0;
     inv = NULL;
+    superInv = NULL;
     aggNew = NULL;
     aggDelete = NULL;
 
@@ -139,6 +140,48 @@ int AggregateDeclaration::isDeprecated()
 int AggregateDeclaration::isExport()
 {
     return protection == PROTexport;
+}
+
+void AggregateDeclaration::addInvariant(InvariantDeclaration *inv)
+{
+    inv->next = this->inv;
+    this->inv = inv;
+}
+
+void AggregateDeclaration::combineInvariants(Scope *sc)
+{
+    if (!inv)
+        return;
+
+    assert(!superInv);
+    InvariantDeclaration *xinv = inv;
+
+    // Define a new function to call all the invariants
+    superInv = new FuncDeclaration(loc, 0, Id::classInvariant, STCundefined, inv->type);
+
+    Expression *call = new CallExp(loc, new DsymbolExp(loc, xinv));
+    Statement *body = new ExpStatement(loc, call);
+    xinv = xinv->next;
+
+    while (xinv)
+    {
+        call = new CallExp(loc, new DsymbolExp(loc, xinv));
+        body = new CompoundStatement(loc, new ExpStatement(loc, call), body);
+        xinv = xinv->next;
+    }
+    superInv->fbody = body;
+
+    members->push(superInv);
+    superInv->addMember(sc, this, 0);
+
+    sc = sc->push();
+    sc->stc &= ~STCstatic;              // not a static invariant
+    sc->incontract++;
+    sc->linkage = LINKd;
+
+    superInv->semantic(sc);
+
+    sc->pop();
 }
 
 /****************************
@@ -614,6 +657,8 @@ void StructDeclaration::semantic(Scope *sc)
     xeq = buildXopEquals(sc2);
 #endif
 
+    combineInvariants(sc2);
+
     sc2->pop();
 
     /* Look for special member functions.
@@ -621,7 +666,6 @@ void StructDeclaration::semantic(Scope *sc)
 #if DMDV2
     ctor = search(0, Id::ctor, 0);
 #endif
-    inv =    (InvariantDeclaration *)search(0, Id::classInvariant, 0);
     aggNew =       (NewDeclaration *)search(0, Id::classNew,       0);
     aggDelete = (DeleteDeclaration *)search(0, Id::classDelete,    0);
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -542,8 +542,8 @@ void ClassDeclaration::toObjFile(int multiobj)
         dtsize_t(&dt, 0);
 
     // invariant
-    if (inv)
-        dtxoff(&dt, inv->toSymbol(), 0, TYnptr);
+    if (superInv)
+        dtxoff(&dt, superInv->toSymbol(), 0, TYnptr);
     else
         dtsize_t(&dt, 0);
 

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -12,7 +12,7 @@ class Foo : Object
     }
 }
 
-int main()
+int testinvariant()
 {
     printf("hello\n");
     Foo f = new Foo();
@@ -23,4 +23,55 @@ int main()
     f.test();
     printf("world\n");
     return 0;
+}
+
+/***************************************************/
+
+void test6453()
+{
+    static class C
+    {
+        static uint called;
+        invariant() { called += 1; }
+        invariant() { called += 4; }
+        invariant() { called += 16; }
+
+        void publicmember() {}
+    }
+
+    static struct S
+    {
+        static uint called;
+        invariant() { called += 1; }
+        invariant() { called += 4; }
+        invariant() { called += 16; }
+
+        void publicmember() {}
+    }
+
+    auto c = new C();
+    C.called = 0;
+    c.publicmember();
+    assert(C.called == 42);
+
+    C.called = 0;
+    c.__invariant();
+    assert(C.called == 21);
+
+    auto s = new S();
+    S.called = 0;
+    s.publicmember();
+    assert(S.called == 42);
+
+    S.called = 0;
+    s.__invariant();
+    assert(S.called == 21);
+}
+
+/***************************************************/
+
+void main()
+{
+    testinvariant();
+    test6453();
 }


### PR DESCRIPTION
Build a linked list of invariants and insert a call to the next one at the end of the function.
Invariants are executed in lexical order.

http://d.puremagic.com/issues/show_bug.cgi?id=6453
