### PR TITLE
Issue 7383 - Blank lines in code sections cause premature section termination

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -1116,7 +1116,7 @@ void DocComment::parseSections(unsigned char *comment)
                     goto L1;
                 if (*p == '\n')
                 {   p++;
-                    if (*p == '\n' && !summary && !namelen)
+                    if (*p == '\n' && !summary && !namelen && !inCode)
                     {
                         pend = p;
                         p++;


### PR DESCRIPTION
A blank line inside a code section does not mean the end of the code section.

http://d.puremagic.com/issues/show_bug.cgi?id=7383
