### PR TITLE
Issue 2789 - Functions overloads are not checked for conflicts

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -694,6 +694,15 @@ void ClassDeclaration::semantic(Scope *sc)
 
     //printf("\tsemantic('%s') successful\n", toChars());
 
+    for (size_t i = 0; i < members_dim; i++)
+    {
+        Dsymbol *s = members->tdata()[i];
+        FuncDeclaration *f = s->isFuncDeclaration();
+        if (f && f->overnext)
+            if (!f->overnext->overloadInsert(f, OVERcheck))
+                multiplyDefined(0, f, f->overnext);
+    }
+
     //members->print();
 
     /* Look for special member functions.

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -525,7 +525,7 @@ void AliasDeclaration::semantic(Scope *sc)
             if (overnext)
             {
                 FuncAliasDeclaration *fa = new FuncAliasDeclaration(f);
-                if (!fa->overloadInsert(overnext))
+                if (!fa->overloadInsert(overnext, OVERcheck | OVERupdate))
                     ScopeDsymbol::multiplyDefined(0, f, overnext);
                 overnext = NULL;
                 s = fa;
@@ -553,7 +553,7 @@ void AliasDeclaration::semantic(Scope *sc)
     this->inSemantic = 0;
 }
 
-int AliasDeclaration::overloadInsert(Dsymbol *s)
+int AliasDeclaration::overloadInsert(Dsymbol *s, int flags)
 {
     /* Don't know yet what the aliased symbol is, so assume it can
      * be overloaded and check later for correctness.
@@ -568,7 +568,7 @@ int AliasDeclaration::overloadInsert(Dsymbol *s)
         {
             FuncAliasDeclaration *fa = new FuncAliasDeclaration(f);
             aliassym = fa;
-            return fa->overloadInsert(s);
+            return fa->overloadInsert(s, flags);
         }
     }
 
@@ -583,7 +583,7 @@ int AliasDeclaration::overloadInsert(Dsymbol *s)
     }
     else
     {
-        return overnext->overloadInsert(s);
+        return overnext->overloadInsert(s, flags);
     }
 }
 

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -224,7 +224,7 @@ struct AliasDeclaration : Declaration
     AliasDeclaration(Loc loc, Identifier *ident, Dsymbol *s);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
-    int overloadInsert(Dsymbol *s);
+    int overloadInsert(Dsymbol *s, int flags);
     const char *kind();
     Type *getType();
     Dsymbol *toAlias();
@@ -629,7 +629,7 @@ struct FuncDeclaration : Declaration
     void bodyToCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int overrides(FuncDeclaration *fd);
     int findVtblIndex(Dsymbols *vtbl, int dim);
-    int overloadInsert(Dsymbol *s);
+    int overloadInsert(Dsymbol *s, int flags);
     FuncDeclaration *overloadExactMatch(Type *t);
     FuncDeclaration *overloadResolve(Loc loc, Expression *ethis, Expressions *arguments, int flags = 0);
     MATCH leastAsSpecialized(FuncDeclaration *g);
@@ -756,7 +756,7 @@ struct PostBlitDeclaration : FuncDeclaration
     int isVirtual();
     int addPreInvariant();
     int addPostInvariant();
-    int overloadInsert(Dsymbol *s);
+    int overloadInsert(Dsymbol *s, int flags);
     void emitComment(Scope *sc);
     void toJsonBuffer(OutBuffer *buf);
 
@@ -776,7 +776,7 @@ struct DtorDeclaration : FuncDeclaration
     int isVirtual();
     int addPreInvariant();
     int addPostInvariant();
-    int overloadInsert(Dsymbol *s);
+    int overloadInsert(Dsymbol *s, int flags);
     void emitComment(Scope *sc);
     void toJsonBuffer(OutBuffer *buf);
 

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -466,7 +466,7 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, Identifier *id)
     return sm;
 }
 
-int Dsymbol::overloadInsert(Dsymbol *s)
+int Dsymbol::overloadInsert(Dsymbol *s, int)
 {
     //printf("Dsymbol::overloadInsert('%s')\n", s->toChars());
     return FALSE;
@@ -580,7 +580,10 @@ int Dsymbol::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
             Dsymbol *s2;
 
             s2 = sd->symtab->lookup(ident);
-            if (!s2->overloadInsert(this))
+            int flags = OVERupdate;
+            if (!sd->isAggregateDeclaration())
+                flags |= OVERcheck;
+            if (!s2->overloadInsert(this, flags))
             {
                 sd->multiplyDefined(0, this, s2);
             }

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -160,7 +160,9 @@ struct Dsymbol : Object
     virtual Dsymbol *search(Loc loc, Identifier *ident, int flags);
     Dsymbol *search_correct(Identifier *id);
     Dsymbol *searchX(Loc loc, Scope *sc, Identifier *id);
-    virtual int overloadInsert(Dsymbol *s);
+    virtual int overloadInsert(Dsymbol *s, int flags);
+    #define OVERcheck  0x1
+    #define OVERupdate 0x2
     char *toHChars();
     virtual void toHBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/mars.c
+++ b/src/mars.c
@@ -94,7 +94,7 @@ Global::Global()
     "\nMSIL back-end (alpha release) by Cristian L. Vlasceanu and associates.";
 #endif
     ;
-    version = "v2.059";
+    version = "v2.060";
     global.structalign = 8;
 
     memset(&params, 0, sizeof(Param));

--- a/src/msc.c
+++ b/src/msc.c
@@ -251,7 +251,7 @@ void util_set64()
         tyalignsize[TYnullptr + i] = 8;
         tyalignsize[TYnptr + i] = 8;
         tyalignsize[TYnref + i] = 8;
-#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS || TARGET_OSX
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS || TARGET_OSX || TARGET_WINDOS
         tyalignsize[TYldouble + i] = 16;
         tyalignsize[TYildouble + i] = 16;
         tyalignsize[TYcldouble + i] = 16;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5158,6 +5158,41 @@ Lnotcovariant:
     return 2;
 }
 
+int TypeFunction::overloadConflict(TypeFunction *t1, TypeFunction *t2)
+{
+    assert(t1 && t2);
+
+    if (t1->equals(t2))
+        return TRUE;
+
+    if (t1->varargs != t2->varargs)
+        return FALSE;
+
+    if (t1->mod != t2->mod)
+        return FALSE;
+
+    int pn1 = Parameter::dim(t1->parameters);
+    int pn2 = Parameter::dim(t2->parameters);
+    if (pn1 != pn2)
+        return FALSE;
+
+    for(size_t i = 0; i < pn1; ++i)
+    {
+        Parameter *arg1 = Parameter::getNth(t1->parameters, i);
+        Parameter *arg2 = Parameter::getNth(t2->parameters, i);
+        StorageClass sc = STCref | STCin | STCout | STClazy;
+
+        if (!arg1->type->equals(arg2->type))
+            return FALSE;
+        if (arg1->storageClass != arg2->storageClass)
+            return FALSE;
+        if (arg1->type->mod != arg2->type->mod)
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
 void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
 {   unsigned char mc;
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -631,6 +631,7 @@ struct TypeFunction : TypeNext
     void toCBufferWithAttributes(OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void attributesToCBuffer(OutBuffer *buf, int mod);
+    static int overloadConflict(TypeFunction *t1, TypeFunction *t2);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wildmatch = NULL);
     TypeInfoDeclaration *getTypeInfoDeclaration();
     Type *reliesOnTident(TemplateParameters *tparams = NULL);

--- a/src/struct.c
+++ b/src/struct.c
@@ -497,6 +497,15 @@ void StructDeclaration::semantic(Scope *sc)
         return;
     }
 
+    for (size_t i = 0; i < members_dim; i++)
+    {
+        Dsymbol *s = members->tdata()[i];
+        FuncDeclaration *f = s->isFuncDeclaration();
+        if (f && f->overnext)
+            if (!f->overnext->overloadInsert(f, OVERcheck))
+                multiplyDefined(0, f, f->overnext);
+    }
+
     Module::dprogress++;
 
     //printf("-StructDeclaration::semantic(this=%p, '%s')\n", this, toChars());

--- a/src/template.c
+++ b/src/template.c
@@ -546,7 +546,7 @@ const char *TemplateDeclaration::kind()
  * Return !=0 if successful; i.e. no conflict.
  */
 
-int TemplateDeclaration::overloadInsert(Dsymbol *s)
+int TemplateDeclaration::overloadInsert(Dsymbol *s, int flags)
 {
     TemplateDeclaration **pf;
     TemplateDeclaration *f;

--- a/src/template.h
+++ b/src/template.h
@@ -76,7 +76,7 @@ struct TemplateDeclaration : ScopeDsymbol
         Expression *constraint, Dsymbols *decldefs, int ismixin);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
-    int overloadInsert(Dsymbol *s);
+    int overloadInsert(Dsymbol *s, int flags);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     bool hasStaticCtorOrDtor();
     const char *kind();

--- a/test/fail_compilation/fail2789a.d
+++ b/test/fail_compilation/fail2789a.d
@@ -1,0 +1,8 @@
+
+struct S
+{
+    void myfunc() {}
+    int myfunc() { return 0; }
+}
+
+void main() {}

--- a/test/fail_compilation/fail2789b.d
+++ b/test/fail_compilation/fail2789b.d
@@ -1,0 +1,8 @@
+
+class S
+{
+    void myfunc() {}
+    int myfunc() { return 0; }
+}
+
+void main() {}

--- a/test/fail_compilation/fail2789c.d
+++ b/test/fail_compilation/fail2789c.d
@@ -1,0 +1,5 @@
+
+void myfunc() {}
+int myfunc() { return 0; }
+
+void main() {}


### PR DESCRIPTION
Two issues here:
- The check in `overloadInsert` is disabled as it can't work until semantic has been run on all overloads.  This has been changed so that the check and the actual insertion can be run seperately.
- The check is out of date. `Type::covariant` is no longer suitable, as it allows a much wider set of conversions and requires return type covariance, which is not needed for two overloads to conflict.  The new function to perform this check is `TypeFunction::overloadConflict`.

http://d.puremagic.com/issues/show_bug.cgi?id=2789
