### PR TITLE
Issue 3144 - Invalid break accepted

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4027,7 +4027,7 @@ Statement *Parser::parseStatement(int flags)
             check(TOKlparen);
             Expression *condition = parseExpression();
             check(TOKrparen);
-            Statement *body = parseStatement(PSscope);
+            Statement *body = parseStatement(PSscope | PScurly);
             s = new SwitchStatement(loc, condition, body, isfinal);
             break;
         }

--- a/test/compilable/test4375.d
+++ b/test/compilable/test4375.d
@@ -142,19 +142,23 @@ label1:
 
     // (o_O)
     switch (1)
+    {
         default:
             if (true)
                 assert(113);
             else
                 assert(114);
+    }
 
     // (o_O)
     final switch (1)
+    {
         case 1:
             if (true)
                 assert(117);
             else
                 assert(118);
+    }
 
     mixin(q{
         if (true)

--- a/test/fail_compilation/fail3144.d
+++ b/test/fail_compilation/fail3144.d
@@ -1,0 +1,8 @@
+
+void main()
+{
+    int i = 1;
+    switch (i)
+       default: {} break;
+
+}

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1270,7 +1270,6 @@ void test51()
   A51_a = 0; { do A51 a; while(0);                  } assert(A51_a == 1);
   A51_a = 0; { if (0) while(1) A51 a;               } assert(A51_a == 0);
   A51_a = 0; { try A51 a; catch(Error e) {}         } assert(A51_a == 1);
-  A51_a = 0; { if (0) final switch(1) A51 a;        } assert(A51_a == 0); // should fail to build
   A51_a = 0; { if (0) switch(1) { A51 a; default: } } assert(A51_a == 0);
   A51_a = 0; { if (0) switch(1) { default: A51 a; } } assert(A51_a == 0);
   A51_a = 0; { if (1) switch(1) { A51 a; default: } } assert(A51_a == 1); // should be 0, right?


### PR DESCRIPTION
Force curly braces on switch statement's body.

It also disables the technically allowed but absolutely useless version:

``` D
switch(exp)
    default:
       statement;
```

I don't see any reason to allow this.

http://d.puremagic.com/issues/show_bug.cgi?id=3144
