### PR TITLE
Issue 3150 - cast from dynamic array to ulong is allowed

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8847,6 +8847,12 @@ Expression *CastExp::semantic(Scope *sc)
         {
             return new VectorExp(loc, e1, to);
         }
+
+        if (tob->isintegral() && t1b->ty == Tarray &&
+            !global.params.useDeprecated)
+        {
+            error("casting %s to %s is deprecated", e1->type->toChars(), to->toChars());
+        }
     }
     else if (!to)
     {   error("cannot cast tuple");

--- a/test/fail_compilation/fail3150.d
+++ b/test/fail_compilation/fail3150.d
@@ -1,0 +1,4 @@
+
+void main() {
+    ulong u = cast(ulong)[1,2];
+}


### PR DESCRIPTION
This patch makes this deprecated behavior.

http://d.puremagic.com/issues/show_bug.cgi?id=3150
