### PR TITLE
Issue 4517 - final switch over with base type allows missing values

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3069,6 +3069,10 @@ Statement *SwitchStatement::semantic(Scope *sc)
         return this;            // already run
     condition = condition->semantic(sc);
     condition = resolveProperties(sc, condition);
+    TypeEnum *te = NULL;
+    // preserve enum type for final switches
+    if (condition->type->ty == Tenum)
+        te = (TypeEnum *)condition->type;
     if (condition->type->isString())
     {
         // If it's not an array, cast it to one
@@ -3133,8 +3137,8 @@ Statement *SwitchStatement::semantic(Scope *sc)
         {   // Don't use toBasetype() because that will skip past enums
             t = ((TypeTypedef *)t)->sym->basetype;
         }
-        if (condition->type->ty == Tenum)
-        {   TypeEnum *te = (TypeEnum *)condition->type;
+        if (te)
+        {
             EnumDeclaration *ed = te->toDsymbol(sc)->isEnumDeclaration();
             assert(ed);
             size_t dim = ed->members->dim;
@@ -3145,7 +3149,7 @@ Statement *SwitchStatement::semantic(Scope *sc)
                 {
                     for (size_t j = 0; j < cases->dim; j++)
                     {   CaseStatement *cs = (*cases)[j];
-                        if (cs->exp->equals(em->value))
+                        if (cs->exp->equals(em->value) || cs->exp->toInteger() == em->value->toInteger())
                             goto L1;
                     }
                     error("enum member %s not represented in final switch", em->toChars());

--- a/test/fail_compilation/fail4517.d
+++ b/test/fail_compilation/fail4517.d
@@ -1,0 +1,15 @@
+
+enum E : ushort
+{
+    A, B
+}
+
+void main()
+{
+    E e;
+    final switch(e)
+    {
+        case E.A:
+            break;
+    }
+}


### PR DESCRIPTION
Integral promotions kills the type of the condition and the case expressions, so keep track of the original enum type and allow cases to match if they evaluate to the same integer expression.

http://d.puremagic.com/issues/show_bug.cgi?id=4517
