### PR TITLE
Issue 6458 - Multibyte char literals shouldn't implicitly convert to char

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -215,6 +215,7 @@ MATCH IntegerExp::implicitConvTo(Type *t)
 
     TY ty = type->toBasetype()->ty;
     TY toty = t->toBasetype()->ty;
+    TY oldty = ty;
 
     if (m == MATCHnomatch && t->ty == Tenum)
         goto Lno;
@@ -282,6 +283,8 @@ MATCH IntegerExp::implicitConvTo(Type *t)
             goto Lyes;
 
         case Tchar:
+            if ((oldty == Twchar || oldty == Tdchar) && value > 0x7F)
+                goto Lno;
         case Tuns8:
             //printf("value = %llu %llu\n", (dinteger_t)(unsigned char)value, value);
             if ((unsigned char)value != value)
@@ -293,6 +296,9 @@ MATCH IntegerExp::implicitConvTo(Type *t)
                 goto Lno;
             goto Lyes;
 
+        case Twchar:
+            if (oldty == Tdchar && value > 0xD7FF && value < 0xE000)
+                goto Lno;
         case Tuns16:
             if ((unsigned short)value != value)
                 goto Lno;
@@ -316,11 +322,6 @@ MATCH IntegerExp::implicitConvTo(Type *t)
 
         case Tdchar:
             if (value > 0x10FFFFUL)
-                goto Lno;
-            goto Lyes;
-
-        case Twchar:
-            if ((unsigned short)value != value)
                 goto Lno;
             goto Lyes;
 

--- a/test/fail_compilation/fail6458.d
+++ b/test/fail_compilation/fail6458.d
@@ -1,0 +1,5 @@
+
+void main()
+{
+    char d = 'ä';
+}


### PR DESCRIPTION
Disallow implicit conversion from wider to narrower chars when the value same char is not representable in a single value of the narrower type.

Eg. `\u00e4` is a valid utf-16 code point, and fits in a char, but is not a valid utf-8 code point.

http://d.puremagic.com/issues/show_bug.cgi?id=6458
