### PR TITLE
Issue 6497 - [safeD] Can take address of local variable through ?:

### DIFF
--- a/test/fail_compilation/fail6497.d
+++ b/test/fail_compilation/fail6497.d
@@ -1,0 +1,6 @@
+
+void main() @safe
+{
+    int n;
+    auto b = &(0 ? n : n);
+}

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -321,6 +321,12 @@ void structcast()
     static assert(!__traits(compiles, c = cast(C)b)); 
 } 
 
+@safe void test6497()
+{
+    int n;
+    (0 ? n : n) = 3;
+}
+
 @safe
 void varargs()
 {


### PR DESCRIPTION
If the compiler rewrote `&(a ? b : c)` to `&*(a ? &b : &c)`, re-run semantic on the `AddrExp`s to ensure they don't take addresses of local variables.

http://d.puremagic.com/issues/show_bug.cgi?id=6497
