### PR TITLE
fix Issue 143,1161,1441,2225,2775,2830,6180

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -888,15 +888,6 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
             a->push(s);
             s = a;
         }
-
-        if (s)
-        {
-            Declaration *d = s->isDeclaration();
-            if (d && d->protection == PROTprivate &&
-                !d->parent->isTemplateMixin() &&
-                !(flags & 2))
-                error(loc, "%s is private", d->toPrettyChars());
-        }
     }
     return s;
 }

--- a/src/enum.c
+++ b/src/enum.c
@@ -33,6 +33,7 @@ EnumDeclaration::EnumDeclaration(Loc loc, Identifier *id, Type *memtype)
     sinit = NULL;
     isdeprecated = 0;
     isdone = 0;
+    protection = PROTpublic;
 }
 
 Dsymbol *EnumDeclaration::syntaxCopy(Dsymbol *s)
@@ -113,7 +114,7 @@ void EnumDeclaration::semantic(Scope *sc)
 
     if (sc->stc & STCdeprecated)
         isdeprecated = 1;
-
+    protection = sc->protection;
     parent = sc->parent;
 
     /* The separate, and distinct, cases are:
@@ -348,6 +349,11 @@ Type *EnumDeclaration::getType()
 const char *EnumDeclaration::kind()
 {
     return "enum";
+}
+
+enum PROT EnumDeclaration::prot()
+{
+    return protection;
 }
 
 int EnumDeclaration::isDeprecated()

--- a/src/enum.h
+++ b/src/enum.h
@@ -42,6 +42,7 @@ struct EnumDeclaration : ScopeDsymbol
     int isdeprecated;
     int isdone;                 // 0: not done
                                 // 1: semantic() successfully completed
+    enum PROT protection;
 
     EnumDeclaration(Loc loc, Identifier *id, Type *memtype);
     Dsymbol *syntaxCopy(Dsymbol *s);
@@ -51,6 +52,7 @@ struct EnumDeclaration : ScopeDsymbol
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Type *getType();
     const char *kind();
+    enum PROT prot();
 #if DMDV2
     Dsymbol *search(Loc, Identifier *ident, int flags);
 #endif

--- a/src/expression.c
+++ b/src/expression.c
@@ -2483,6 +2483,8 @@ Expression *IdentifierExp::semantic(Scope *sc)
     {   Expression *e;
         WithScopeSymbol *withsym;
 
+        accessCheck(loc, sc, NULL, s);
+
         /* See if the symbol was a member of an enclosing 'with'
          */
         withsym = scopesym->isWithScopeSymbol();
@@ -4719,12 +4721,6 @@ Expression *VarExp::semantic(Scope *sc)
     if (type && !type->deco)
         type = type->semantic(loc, sc);
 
-    /* Fix for 1161 doesn't work because it causes protection
-     * problems when instantiating imported templates passing private
-     * variables as alias template parameters.
-     */
-    //accessCheck(loc, sc, NULL, var);
-
     VarDeclaration *v = var->isVarDeclaration();
     if (v)
     {
@@ -6420,8 +6416,7 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
             /* Check for access before resolving aliases because public
              * aliases to private symbols are public.
              */
-            if (Declaration *d = s->isDeclaration())
-                accessCheck(loc, sc, 0, d);
+            accessCheck(loc, sc, NULL, s);
 
             s = s->toAlias();
             checkDeprecated(sc, s);
@@ -7866,6 +7861,7 @@ Lagain:
             goto Lagain;
         }
 
+        // BUG: this doesn't work with public aliases, see Bugzilla 4533
         accessCheck(loc, sc, NULL, f);
 
         ethis = NULL;

--- a/src/expression.h
+++ b/src/expression.h
@@ -65,7 +65,7 @@ void initPrecedence();
 typedef int (*apply_fp_t)(Expression *, void *);
 
 Expression *resolveProperties(Scope *sc, Expression *e);
-void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d);
+void accessCheck(Loc loc, Scope *sc, Expression *e, Dsymbol *s);
 Expression *build_overload(Loc loc, Scope *sc, Expression *ethis, Expression *earg, Dsymbol *d);
 Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid);
 void argExpTypesToCBuffer(OutBuffer *buf, Expressions *arguments, HdrGenState *hgs);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6127,10 +6127,10 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
     {
         //printf("\t1: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
         s->checkDeprecated(loc, sc);            // check for deprecated aliases
-        s = s->toAlias();
         //printf("\t2: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
         for (size_t i = 0; i < idents.dim; i++)
         {
+            s = s->toAlias();
             Identifier *id = idents.tdata()[i];
             Dsymbol *sm = s->searchX(loc, sc, id);
             //printf("\t3: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
@@ -6185,6 +6185,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                     e = t->dotExp(sc, e, id);
                     i++;
                 L3:
+                    accessCheck(loc, sc, NULL, s);
                     for (; i < idents.dim; i++)
                     {
                         id = idents.tdata()[i];
@@ -6206,8 +6207,10 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                 return;
             }
         L2:
-            s = sm->toAlias();
+            s = sm;
         }
+        accessCheck(loc, sc, NULL, s);
+        s = s->toAlias();
 
         v = s->isVarDeclaration();
         if (v)
@@ -7531,7 +7534,9 @@ L1:
         return noMember(sc, e, ident);
     }
     if (!s->isFuncDeclaration())        // because of overloading
-        s->checkDeprecated(e->loc, sc);
+    {   s->checkDeprecated(e->loc, sc);
+        accessCheck(e->loc, sc, NULL, s);
+    }
     s = s->toAlias();
 
     v = s->isVarDeclaration();
@@ -8089,7 +8094,9 @@ L1:
         }
     }
     if (!s->isFuncDeclaration())        // because of overloading
-        s->checkDeprecated(e->loc, sc);
+    {   s->checkDeprecated(e->loc, sc);
+        accessCheck(e->loc, sc, NULL, s);
+    }
     s = s->toAlias();
     v = s->isVarDeclaration();
     if (v && !v->isDataseg())

--- a/src/template.c
+++ b/src/template.c
@@ -382,6 +382,7 @@ TemplateDeclaration::TemplateDeclaration(Loc loc, Identifier *id,
     this->overnext = NULL;
     this->overroot = NULL;
     this->semanticRun = 0;
+    this->protection = PROTpublic;
     this->onemember = NULL;
     this->literal = 0;
     this->ismixin = ismixin;
@@ -480,7 +481,9 @@ void TemplateDeclaration::semantic(Scope *sc)
     Scope *paramscope = sc->push(paramsym);
     paramscope->parameterSpecialization = 1;
     paramscope->stc = 0;
+    paramscope->protection = PROTpublic;
 
+    protection = sc->protection;
     if (!parent)
         parent = sc->parent;
 
@@ -535,6 +538,11 @@ const char *TemplateDeclaration::kind()
     return (onemember && onemember->isAggregateDeclaration())
                 ? onemember->kind()
                 : (char *)"template";
+}
+
+enum PROT TemplateDeclaration::prot()
+{
+    return protection;
 }
 
 /**********************************
@@ -703,6 +711,7 @@ MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
     paramsym->parent = scope->parent;
     Scope *paramscope = scope->push(paramsym);
     paramscope->stc = 0;
+    paramscope->protection = PROTpublic;
 
     // Attempt type deduction
     m = MATCHexact;
@@ -967,6 +976,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(Scope *sc, Loc loc, Objec
     paramsym->parent = scope->parent;
     Scope *paramscope = scope->push(paramsym);
     paramscope->stc = 0;
+    paramscope->protection = PROTpublic;
 
     TemplateTupleParameter *tp = isVariadic();
     int tp_is_declared = 0;
@@ -1584,11 +1594,11 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
     Dsymbol *sa = isDsymbol(o);
     Tuple *va = isTuple(o);
 
-    Dsymbol *s;
+    Declaration *d;
 
     // See if tp->ident already exists with a matching definition
     Dsymbol *scopesym;
-    s = sc->search(loc, tp->ident, &scopesym);
+    Dsymbol *s = sc->search(loc, tp->ident, &scopesym);
     if (s && scopesym == sc->scopesym)
     {
         TupleDeclaration *td = s->isTupleDeclaration();
@@ -1605,12 +1615,12 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
     if (targ)
     {
         //printf("type %s\n", targ->toChars());
-        s = new AliasDeclaration(0, tp->ident, targ);
+        d = new AliasDeclaration(0, tp->ident, targ);
     }
     else if (sa)
     {
         //printf("Alias %s %s;\n", sa->ident->toChars(), tp->ident->toChars());
-        s = new AliasDeclaration(0, tp->ident, sa);
+        d = new AliasDeclaration(0, tp->ident, sa);
     }
     else if (ea)
     {
@@ -1620,14 +1630,13 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
 
         Type *t = tvp ? tvp->valType : NULL;
 
-        VarDeclaration *v = new VarDeclaration(loc, t, tp->ident, init);
-        v->storage_class = STCmanifest;
-        s = v;
+        d = new VarDeclaration(loc, t, tp->ident, init);
+        d->storage_class = STCmanifest;
     }
     else if (va)
     {
         //printf("\ttuple\n");
-        s = new TupleDeclaration(loc, tp->ident, &va->objects);
+        d = new TupleDeclaration(loc, tp->ident, &va->objects);
     }
     else
     {
@@ -1636,9 +1645,14 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
 #endif
         assert(0);
     }
-    if (!sc->insert(s))
+    /* Loose protection so that private symbols can be arguments to a
+     * template in a different module. This works because public
+     * aliases to private symbols are public.
+     */
+    d->protection = sc->protection;
+    if (!sc->insert(d))
         error("declaration %s is already defined", tp->ident->toChars());
-    s->semantic(sc);
+    d->semantic(sc);
 }
 
 /**************************************
@@ -4168,7 +4182,8 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             return;             // error recovery
         }
 
-        tempdecl = findTemplateDeclaration(sc);
+        int aliasaccess;
+        tempdecl = findTemplateDeclaration(sc, &aliasaccess);
         if (tempdecl)
             tempdecl = findBestMatch(sc, fargs);
         if (!tempdecl || global.errors)
@@ -4176,6 +4191,8 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             //printf("error return %p, %d\n", tempdecl, global.errors);
             return;             // error recovery
         }
+        if (!aliasaccess)
+            accessCheck(loc, sc, NULL, tempdecl);
     }
 
     // If tempdecl is a mixin, disallow it
@@ -4377,6 +4394,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     // Declare each template parameter as an alias for the argument type
     Scope *paramscope = scope->push();
     paramscope->stc = 0;
+    paramscope->protection = PROTpublic;
     declareParameters(paramscope);
     paramscope->pop();
 
@@ -4438,6 +4456,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     sc2 = scope->push(this);
     //printf("isnested = %d, sc->parent = %s\n", isnested, sc->parent->toChars());
     sc2->parent = /*isnested ? sc->parent :*/ this;
+    sc2->protection = PROTpublic;
     sc2->tinst = this;
 
 #if WINDOWS_SEH
@@ -4746,7 +4765,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
  * Find template declaration corresponding to template instance.
  */
 
-TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc)
+TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc, int *paliasaccess)
 {
     //printf("TemplateInstance::findTemplateDeclaration() %s\n", toChars());
     if (!tempdecl)
@@ -4771,13 +4790,24 @@ TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc)
             return NULL;
         }
 
+        AliasDeclaration *ad = s->isAliasDeclaration();
+        if (ad && !ad->inSemantic) // resolve aliases, but not eponymous recursions
+        {
+            accessCheck(loc, sc, NULL, s);
+            if (paliasaccess)
+                *paliasaccess = true;
+            s = s->toAlias();
+        }
+        else if (paliasaccess)
+            *paliasaccess = false;
+
         /* If an OverloadSet, look for a unique member that is a template declaration
          */
         OverloadSet *os = s->isOverloadSet();
         if (os)
         {   s = NULL;
             for (size_t i = 0; i < os->a.dim; i++)
-            {   Dsymbol *s2 = os->a.tdata()[i];
+            {   Dsymbol *s2 = os->a.tdata()[i]->toAlias();
                 if (s2->isTemplateDeclaration())
                 {
                     if (s)
@@ -4817,8 +4847,6 @@ TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc)
                 s = tempdecl;
             }
         }
-
-        s = s->toAlias();
 
         /* It should be a TemplateDeclaration, not some other symbol
          */
@@ -5241,7 +5269,7 @@ int TemplateInstance::needsTypeInference(Scope *sc)
 {
     //printf("TemplateInstance::needsTypeInference() %s\n", toChars());
     if (!tempdecl)
-        tempdecl = findTemplateDeclaration(sc);
+        tempdecl = findTemplateDeclaration(sc, NULL);
     int multipleMatches = FALSE;
     for (TemplateDeclaration *td = tempdecl; td; td = td->overnext)
     {
@@ -5661,6 +5689,7 @@ void TemplateMixin::semantic(Scope *sc)
             inst = this;
             return;
         }
+        accessCheck(loc, sc, NULL, s);
         tempdecl = s->toAlias()->isTemplateDeclaration();
         if (!tempdecl)
         {

--- a/src/template.h
+++ b/src/template.h
@@ -58,6 +58,7 @@ struct TemplateDeclaration : ScopeDsymbol
     TemplateDeclaration *overroot;      // first in overnext list
 
     int semanticRun;                    // 1 semantic() run
+    enum PROT protection;
 
     Dsymbol *onemember;         // if !=NULL then one member of this template
 
@@ -79,6 +80,7 @@ struct TemplateDeclaration : ScopeDsymbol
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     bool hasStaticCtorOrDtor();
     const char *kind();
+    enum PROT prot();
     char *toChars();
 
     void emitComment(Scope *sc);
@@ -298,6 +300,7 @@ struct TemplateInstance : ScopeDsymbol
     Dsymbol *isnested;  // if referencing local symbols, this is the context
     int errors;         // 1 if compiled with errors
     int speculative;    // 1 if only instantiated with errors gagged
+
 #ifdef IN_GCC
     /* On some targets, it is necessary to know whether a symbol
        will be emitted in the output or not before the symbol
@@ -328,7 +331,7 @@ struct TemplateInstance : ScopeDsymbol
     // Internal
     static void semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int flags);
     void semanticTiargs(Scope *sc);
-    TemplateDeclaration *findTemplateDeclaration(Scope *sc);
+    TemplateDeclaration *findTemplateDeclaration(Scope *sc, int *paliasaccess);
     TemplateDeclaration *findBestMatch(Scope *sc, Expressions *fargs);
     void declareParameters(Scope *sc);
     int hasNestedArgs(Objects *tiargs);

--- a/test/compilable/imports/testprotection1.d
+++ b/test/compilable/imports/testprotection1.d
@@ -1,0 +1,267 @@
+module same_package.imp;
+
+string decls(string prot)
+{
+    return
+(prot == "none" ? "" : prot ~ ":")~`
+    int            `~prot~`_variable;
+    class          `~prot~`_class {}
+    struct         `~prot~`_struct {}
+    union          `~prot~`_union {}
+    enum           `~prot~`_enum_1 { A }
+    enum           `~prot~`_enum_2 = 2;
+    alias int      `~prot~`_type_alias;
+    template       `~prot~`_template() {}
+    template       `~prot~`_eponymous_template() { enum `~prot~`_eponymous_template = 0; }
+    mixin template `~prot~`_mixin_template() {}
+    void           `~prot~`_func() {}
+    static void    `~prot~`_static_func() {}
+`;
+}
+
+mixin template protection_body()
+{
+    mixin(decls("none"));
+    mixin(decls("public"));
+    mixin(decls("package"));
+    mixin(decls("private"));
+}
+
+public:
+
+mixin protection_body!();
+
+struct   public_struct     { mixin protection_body!(); }
+class    public_class      { mixin protection_body!(); }
+template public_template() { mixin protection_body!(); }
+
+package:
+
+struct   package_struct     { mixin protection_body!(); }
+class    package_class      { mixin protection_body!(); }
+template package_template() { mixin protection_body!(); }
+
+private:
+
+struct   private_struct     { mixin protection_body!(); }
+class    private_class      { mixin protection_body!(); }
+template private_template() { mixin protection_body!(); }
+
+public:
+
+enum HasPackageAccess : bool
+{
+    yes = true,
+    no  = false,
+};
+
+
+mixin template basic_test_cases(HasPackageAccess pkg)
+{
+    static assert(__traits(compiles, () {public_struct s;}));
+    static assert(__traits(compiles, () {auto c = new public_class;}));
+    static assert(__traits(compiles, public_template!()));
+    static assert(__traits(compiles, public_eponymous_template!()));
+
+    static assert(pkg == __traits(compiles, () {package_struct s;}));
+    static assert(pkg == __traits(compiles, () {auto c = new package_class;}));
+    static assert(pkg == __traits(compiles, package_template!()));
+    static assert(pkg == __traits(compiles, package_eponymous_template!()));
+
+    static assert(!__traits(compiles, () {private_struct s;}));
+    static assert(!__traits(compiles, () {auto c = new private_class;}));
+    static assert(!__traits(compiles, private_template!()));
+    static assert(!__traits(compiles, private_eponymous_template!()));
+}
+
+
+mixin template builtin_property_test_cases(HasPackageAccess pkg)
+{
+    static assert(__traits(compiles, public_struct.stringof));
+    static assert(__traits(compiles, public_class.stringof));
+    static assert(__traits(compiles, public_func.mangleof));
+
+    static assert(pkg == __traits(compiles, package_struct.stringof));
+    static assert(pkg == __traits(compiles, package_class.stringof));
+    static assert(pkg == __traits(compiles, package_func.mangleof));
+
+    static assert(!__traits(compiles, private_struct.stringof));
+    static assert(!__traits(compiles, private_class.stringof));
+    static assert(!__traits(compiles, private_func.mangleof));
+}
+
+
+template TypeTuple(T...)
+{
+    alias T TypeTuple;
+}
+
+// Need to split those (Bug #7406)
+public alias TypeTuple!(
+    public_struct,
+    public_class,
+    package_struct,
+    package_class,
+    private_struct,
+    private_class,
+) ScopeSymbolsTypes;
+
+public alias TypeTuple!(
+    same_package.imp,
+    public_template!(),
+    package_template!(),
+    private_template!(),
+) ScopeSymbolsExpressions;
+
+/* Nested scopes are public by default even for private symbols,
+ * i.e. one can't instantiate a private struct, but access all it's members.
+ */
+mixin template scope_test_cases(HasPackageAccess pkg)
+{
+    static assert(__traits(compiles, none_variable), none_variable);
+    static assert(__traits(compiles, none_class));
+    static assert(__traits(compiles, none_struct));
+    static assert(__traits(compiles, none_union));
+    static assert(__traits(compiles, none_enum_1));
+    static assert(__traits(compiles, none_enum_2));
+    static assert(__traits(compiles, none_type_alias));
+    static assert(__traits(compiles, none_template!()));
+    static assert(__traits(compiles, none_eponymous_template!()));
+    static assert(__traits(compiles, () { mixin none_mixin_template!(); }));
+    static assert(__traits(compiles, none_func));
+    static assert(__traits(compiles, none_static_func));
+
+    static assert(__traits(compiles, public_variable));
+    static assert(__traits(compiles, public_class));
+    static assert(__traits(compiles, public_struct));
+    static assert(__traits(compiles, public_union));
+    static assert(__traits(compiles, public_enum_1));
+    static assert(__traits(compiles, public_enum_2));
+    static assert(__traits(compiles, public_type_alias));
+    static assert(__traits(compiles, public_template!()));
+    static assert(__traits(compiles, public_eponymous_template!()));
+    static assert(__traits(compiles, () { mixin public_mixin_template!(); }));
+    static assert(__traits(compiles, public_func));
+    static assert(__traits(compiles, public_static_func));
+
+    static assert(pkg == __traits(compiles, package_variable));
+    static assert(pkg == __traits(compiles, package_class));
+    static assert(pkg == __traits(compiles, package_struct));
+    static assert(pkg == __traits(compiles, package_union));
+    static assert(pkg == __traits(compiles, package_enum_1));
+    static assert(pkg == __traits(compiles, package_enum_2));
+    static assert(pkg == __traits(compiles, package_type_alias));
+    static assert(pkg == __traits(compiles, package_template!()));
+    static assert(pkg == __traits(compiles, package_eponymous_template!()));
+    static assert(pkg == __traits(compiles, () { mixin package_mixin_template!(); }));
+    static assert(pkg == __traits(compiles, package_func));
+    static assert(pkg == __traits(compiles, package_static_func));
+
+    static assert(!__traits(compiles, private_variable));
+    static assert(!__traits(compiles, private_class));
+    static assert(!__traits(compiles, private_struct));
+    static assert(!__traits(compiles, private_union));
+    static assert(!__traits(compiles, private_enum_1));
+    static assert(!__traits(compiles, private_enum_2));
+    static assert(!__traits(compiles, private_type_alias));
+    static assert(!__traits(compiles, private_template!()));
+    static assert(!__traits(compiles, private_eponymous_template!()));
+    static assert(!__traits(compiles, () { mixin private_mixin_template!(); }));
+    static assert(!__traits(compiles, private_func));
+    static assert(!__traits(compiles, private_static_func));
+}
+
+
+template template_test_typ(T)
+{
+    enum template_test_typ = T.stringof;
+}
+
+template template_test_sym(alias S)
+{
+    enum template_test_sym = S.stringof;
+}
+
+template template_test_tup(T...)
+{
+    static if (T.length > 0)
+        enum template_test_tup = T[0].stringof ~ template_test_tup!(T[1 .. $]);
+    else
+        enum template_test_tup = "";
+}
+
+/* Templates have full access to their arguments. Protection checks
+ * are only done at instantiation scope. This doesn't work yet for
+ * aliases to private functions (Bugzilla 4533).
+ */
+version = Bug4533;
+mixin template template_test_cases()
+{
+    mixin protection_body!();
+
+    static assert(__traits(compiles, template_test_sym!(none_variable)));
+    static assert(__traits(compiles, template_test_typ!(none_class)));
+    static assert(__traits(compiles, template_test_typ!(none_struct)));
+    static assert(__traits(compiles, template_test_typ!(none_union)));
+    static assert(__traits(compiles, template_test_typ!(none_enum_1)));
+    static assert(__traits(compiles, template_test_sym!(none_enum_2)));
+    static assert(__traits(compiles, template_test_typ!(none_type_alias)));
+    static assert(__traits(compiles, template_test_sym!(none_template!())));
+    static assert(__traits(compiles, template_test_sym!(none_eponymous_template!())));
+    static assert(__traits(compiles, template_test_sym!(none_mixin_template)));
+    static assert(__traits(compiles, template_test_sym!(none_func)));
+    static assert(__traits(compiles, template_test_sym!(none_static_func)));
+    static assert(__traits(compiles, template_test_tup!(
+                               none_variable, none_class, none_enum_1, none_mixin_template)));
+
+    static assert(__traits(compiles, template_test_sym!(public_variable)));
+    static assert(__traits(compiles, template_test_typ!(public_class)));
+    static assert(__traits(compiles, template_test_typ!(public_struct)));
+    static assert(__traits(compiles, template_test_typ!(public_union)));
+    static assert(__traits(compiles, template_test_typ!(public_enum_1)));
+    static assert(__traits(compiles, template_test_sym!(public_enum_2)));
+    static assert(__traits(compiles, template_test_typ!(public_type_alias)));
+    static assert(__traits(compiles, template_test_sym!(public_template!())));
+    static assert(__traits(compiles, template_test_sym!(public_eponymous_template!())));
+    static assert(__traits(compiles, template_test_sym!(public_mixin_template)));
+    static assert(__traits(compiles, template_test_sym!(public_func)));
+    static assert(__traits(compiles, template_test_sym!(public_static_func)));
+    static assert(__traits(compiles, template_test_tup!(
+                               public_variable, public_class, public_enum_1, public_mixin_template)));
+
+    static assert(__traits(compiles, template_test_sym!(package_variable)));
+    static assert(__traits(compiles, template_test_typ!(package_class)));
+    static assert(__traits(compiles, template_test_typ!(package_struct)));
+    static assert(__traits(compiles, template_test_typ!(package_union)));
+    static assert(__traits(compiles, template_test_typ!(package_enum_1)));
+    static assert(__traits(compiles, template_test_sym!(package_enum_2)));
+    static assert(__traits(compiles, template_test_typ!(package_type_alias)));
+    static assert(__traits(compiles, template_test_sym!(package_template!())));
+    static assert(__traits(compiles, template_test_sym!(package_eponymous_template!())));
+    static assert(__traits(compiles, template_test_sym!(package_mixin_template)));
+    version (Bug4533) {} else
+    {
+        static assert(__traits(compiles, template_test_sym!(package_func)));
+        static assert(__traits(compiles, template_test_sym!(package_static_func)));
+    }
+    static assert(__traits(compiles, template_test_tup!(
+                               package_variable, package_class, package_enum_1, package_mixin_template)));
+
+    static assert(__traits(compiles, template_test_sym!(private_variable)));
+    static assert(__traits(compiles, template_test_typ!(private_class)));
+    static assert(__traits(compiles, template_test_typ!(private_struct)));
+    static assert(__traits(compiles, template_test_typ!(private_union)));
+    static assert(__traits(compiles, template_test_typ!(private_enum_1)));
+    static assert(__traits(compiles, template_test_sym!(private_enum_2)));
+    static assert(__traits(compiles, template_test_typ!(private_type_alias)));
+    static assert(__traits(compiles, template_test_sym!(private_template!())));
+    static assert(__traits(compiles, template_test_sym!(private_eponymous_template!())));
+    static assert(__traits(compiles, template_test_sym!(private_mixin_template)));
+    version (Bug4533) {} else
+    {
+        static assert(__traits(compiles, template_test_sym!(private_func)));
+        static assert(__traits(compiles, template_test_sym!(private_static_func)));
+    }
+    static assert(__traits(compiles, template_test_tup!(
+                               private_variable, private_class, private_enum_1, private_mixin_template)));
+}

--- a/test/compilable/testprotection1a.d
+++ b/test/compilable/testprotection1a.d
@@ -1,0 +1,22 @@
+module same_package.a;
+
+import imports.testprotection1;
+
+mixin basic_test_cases!(HasPackageAccess.yes);
+mixin builtin_property_test_cases!(HasPackageAccess.yes);
+
+void test_scope()
+{
+    mixin scope_test_cases!(HasPackageAccess.yes);
+
+    foreach(Scope; ScopeSymbolsTypes)
+        with (Scope) mixin scope_test_cases!(HasPackageAccess.yes);
+
+    foreach(Scope; ScopeSymbolsExpressions)
+        with (Scope) mixin scope_test_cases!(HasPackageAccess.yes);
+}
+
+void test_templates()
+{
+    mixin template_test_cases!();
+}

--- a/test/compilable/testprotection1b.d
+++ b/test/compilable/testprotection1b.d
@@ -1,0 +1,22 @@
+module different_package.a;
+
+import imports.testprotection1;
+
+mixin basic_test_cases!(HasPackageAccess.no);
+mixin builtin_property_test_cases!(HasPackageAccess.no);
+
+void test_scope()
+{
+    mixin scope_test_cases!(HasPackageAccess.no);
+
+    foreach(Scope; ScopeSymbolsTypes)
+        with (Scope) mixin scope_test_cases!(HasPackageAccess.no);
+
+    foreach(Scope; ScopeSymbolsExpressions)
+        with (Scope) mixin scope_test_cases!(HasPackageAccess.no);
+}
+
+void test_templates()
+{
+    mixin template_test_cases!();
+}


### PR DESCRIPTION
##### Protection Checks
- Check protection whenever resolving Identifiers.
- Check all symbols not only declarations, this includes UDT.
- Protection peephole for template arguments so that
  they can be instatiated with private symbols.

requires: D-Programming-Language/phobos#413 (dawgfoto/phobos@a55c4bf)
