### PR TITLE
Issue 7322 - Taking address of deprecated functions isn't refused

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8302,6 +8302,7 @@ Expression *AddrExp::semantic(Scope *sc)
         if (e1->op == TOKdotvar)
         {
             DotVarExp *dve = (DotVarExp *)e1;
+            checkDeprecated(sc, dve->var);
             FuncDeclaration *f = dve->var->isFuncDeclaration();
 
             if (f)
@@ -8317,6 +8318,7 @@ Expression *AddrExp::semantic(Scope *sc)
         {
             VarExp *ve = (VarExp *)e1;
 
+            checkDeprecated(sc, ve->var);
             VarDeclaration *v = ve->var->isVarDeclaration();
             if (v)
             {

--- a/test/fail_compilation/fail7322.d
+++ b/test/fail_compilation/fail7322.d
@@ -1,0 +1,7 @@
+
+deprecated void fun() {}
+
+void main()
+{
+    auto x = &fun;
+}


### PR DESCRIPTION
`AddrExp::semantic` is missing a check when `e1` is a `VarExp`.

http://d.puremagic.com/issues/show_bug.cgi?id=7322
