### PR TITLE
Issue 4958 - Floating point enums should check for total loss of precision

### DIFF
--- a/test/fail_compilation/fail4958.d
+++ b/test/fail_compilation/fail4958.d
@@ -1,0 +1,2 @@
+
+enum FloatEnum : float { A = float.max/2, B, C }


### PR DESCRIPTION
This is Don's fix from the bug report.  Issue an error if last+1 == last when assigning values to enum members.

http://d.puremagic.com/issues/show_bug.cgi?id=4958
