### PR TITLE
Issue 7358 - final switch over enum should add throwing default in debug mode

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3272,7 +3272,7 @@ Statement *SwitchStatement::semantic(Scope *sc)
     }
 #endif
 
-    if (!sc->sw->sdefault && (!isFinal || needswitcherror))
+    if (!sc->sw->sdefault && (!isFinal || needswitcherror || global.params.useAssert))
     {   hasNoDefault = 1;
 
         if (!isFinal)

--- a/test/runnable/testswitch.d
+++ b/test/runnable/testswitch.d
@@ -472,6 +472,32 @@ static assert(!is(typeof(
 
 /*****************************************/
 
+void test7358()
+{
+    static void test7358a()
+    {
+        enum X { A = 1, B = 2 }
+
+        auto x = X.A | X.B;
+
+        final switch(x)
+        {
+        case X.A:
+        case X.B:
+            break;
+        }
+    }
+
+    bool exception;
+    try
+        test7358a();
+    catch (Error)
+        exception = true;
+    assert(exception);
+}
+
+/*****************************************/
+
 int main()
 {
     test1();
@@ -493,6 +519,7 @@ int main()
     test17();
     test19();
     test20();
+    test7358();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Add a throwing default case when compiled with asserts on.

http://d.puremagic.com/issues/show_bug.cgi?id=7358
