### PR TITLE
fixup Issue 7373

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -189,7 +189,13 @@ void Import::semantic(Scope *sc)
         if (aliasId)
         {
             AliasDeclaration *ad = new AliasDeclaration(loc, aliasId, mod);
-            sc->insert(ad);
+            for (Scope *sc2 = sc; sc2; sc2 = sc2->enclosing)
+            {   if (sc2->scopesym)
+                {   ad->addMember(sc, sc2->scopesym, 1);
+                    break;
+                }
+            }
+            ad->protection = prot;
             ad->semantic(sc);
         }
     }
@@ -289,8 +295,8 @@ Dsymbol *Import::search(Loc loc, Identifier *ident, int flags)
     {
         for (size_t i = 0; i < names.dim; i++)
         {
-            Identifier *name = (Identifier *)names[i];
-            Identifier *alias = (Identifier *)aliases[i];
+            Identifier *name = names[i];
+            Identifier *alias = aliases[i];
 
             if (!alias)
                 alias = name;

--- a/test/compilable/imports/test7373a.d
+++ b/test/compilable/imports/test7373a.d
@@ -1,0 +1,6 @@
+module imports.test7373a;
+import foo = imports.test7373b;
+
+struct S
+{
+}

--- a/test/compilable/imports/test7373b.d
+++ b/test/compilable/imports/test7373b.d
@@ -1,0 +1,9 @@
+module imports.test7373b;
+
+void foo()
+{
+}
+
+struct S
+{
+}

--- a/test/compilable/test7373.d
+++ b/test/compilable/test7373.d
@@ -1,0 +1,5 @@
+import imports.test7373a;
+import S = imports.test7373b;
+
+static assert(!__traits(compiles, foo.foo()));
+S.S s;

--- a/test/fail_compilation/test7373.d
+++ b/test/fail_compilation/test7373.d
@@ -1,0 +1,2 @@
+import foo = object;
+int foo;


### PR DESCRIPTION
- addMember alias to scope so that name collisions are detected
- apply protection to alias which fixes the bug
  from D-Programming-Language/dmd@df5d8fa
