### PR TITLE
Issue 4923 - immutable module variables are modifiable in non-shared module constructors

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -157,6 +157,23 @@ int Declaration::checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int fl
     {   // It's only modifiable if inside the right constructor
         if ((storage_class & (STCforeach | STCref)) == (STCforeach | STCref))
             return 2;
+        if (isCtorinit() && !isField())
+        {
+            if (sc->func->isStaticCtorDeclaration() &&
+                !sc->func->isSharedStaticCtorDeclaration() &&
+                !isThreadlocal())
+            {
+                const char *p = isImmutable() ? "immutable" : "shared";
+                error(loc, "can only initialize %s global variable inside shared static constructor",
+                    p);
+                return 0;
+            }
+            else if (sc->func->isSharedStaticCtorDeclaration() && isThreadlocal())
+            {
+                error(loc, "can only initialize thread local global variable inside static constructor");
+                return 0;
+            }
+        }
         return modifyFieldVar(loc, sc, v, e1) ? 2 : 1;
     }
     return 1;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -165,6 +165,7 @@ public:
     bool isOverride()     { return (storage_class & STCoverride) != 0; }
     bool isResult()       { return (storage_class & STCresult) != 0; }
     bool isField()        { return (storage_class & STCfield) != 0; }
+    bool isShared()       { return (storage_class & STCshared) != 0; }
 
     bool isIn()    { return (storage_class & STCin) != 0; }
     bool isOut()   { return (storage_class & STCout) != 0; }

--- a/test/fail_compilation/fail4923.d
+++ b/test/fail_compilation/fail4923.d
@@ -1,0 +1,35 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail4923.d(9): Error: variable fail4923.x can only initialize immutable global variable inside shared static constructor
+fail_compilation/fail4923.d(10): Error: variable fail4923.y can only initialize shared global variable inside shared static constructor
+fail_compilation/fail4923.d(11): Error: variable fail4923.z can only initialize immutable global variable inside shared static constructor
+fail_compilation/fail4923.d(16): Error: variable fail4923.w can only initialize unshared global variable inside static constructor
+---
+*/
+
+#line 1
+int w;
+immutable int x;
+shared int y;
+shared immutable int z;
+
+static this()
+{
+    w = 6;
+    x = 7;
+    y = 8;
+    z = 9;
+}
+
+shared static this()
+{
+    w = 6;
+    x = 7;
+    y = 8;
+    z = 9;
+}
+
+void main()
+{
+}

--- a/test/runnable/testswitch.d
+++ b/test/runnable/testswitch.d
@@ -353,7 +353,7 @@ int foo15(int i)
     return y;
 }
 
-static this()
+shared static this()
 {
     X15 = 4;
     Y15 = 4;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4352,7 +4352,7 @@ template Hoge6691()
     immutable static int[int] dict;
     immutable static int value;
 
-    static this()
+    shared static this()
     {
         dict = [1:1, 2:2];
         value = 10;


### PR DESCRIPTION
Check that the right kind of module constructor is used to initialize globals.  Improve error message.

Fixes Issue 4923

http://d.puremagic.com/issues/show_bug.cgi?id=4923
