### PR TITLE
Issue 783 - Cannot use an array w/ const or variable index as new[] size argument.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4531,6 +4531,22 @@ int TypeAArray::checkBoolean()
     return TRUE;
 }
 
+Expression *TypeAArray::toExpression()
+{
+    Expression *e = next->toExpression();
+    if (e)
+    {
+        Expression *ei = index->toExpression();
+        if (ei)
+        {
+            Expressions *arguments = new Expressions();
+            arguments->push(ei);
+            return new ArrayExp(loc, e, arguments);
+        }
+    }
+    return NULL;
+}
+
 int TypeAArray::hasPointers()
 {
     return TRUE;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -525,6 +525,7 @@ struct TypeAArray : TypeArray
     int isZeroInit(Loc loc);
     int checkBoolean();
     TypeInfoDeclaration *getTypeInfoDeclaration();
+    Expression *toExpression();
     int hasPointers();
     TypeTuple *toArgTypes();
     MATCH implicitConvTo(Type *to);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3644,6 +3644,15 @@ ref const(Foo6529) func6529(const(Foo6529)[] arr){ return arr[0]; }
 
 /***************************************************/
 
+void test783()
+{
+    const arr = [ 1,2,3 ];
+    const i = 2;
+    auto jhk = new int[arr[i]]; // "need size of rightmost array, not type arr[i]"
+}
+
+/***************************************************/
+
 template X157(alias x)
 {
     alias x X157;


### PR DESCRIPTION
The length is first parsed as an associate array type, so it needs to be reinterpreted as an expression.

http://d.puremagic.com/issues/show_bug.cgi?id=783
