### PR TITLE
Issue 3812 - Missing line number for implicit cast of variadic function to array

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -456,7 +456,8 @@ void showCtfeExpr(Expression *e, int level = 0)
  *      arguments  function arguments
  *      thisarg    'this', if a needThis() function, NULL if not.
  *
- * Return result expression if successful, EXP_CANT_INTERPRET if not.
+ * Return result expression if successful, EXP_CANT_INTERPRET if not,
+ * or EXP_VOID_INTERPRET if function returned void.
  */
 
 Expression *FuncDeclaration::interpret(InterState *istate, Expressions *arguments, Expression *thisarg)
@@ -4801,6 +4802,10 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
         if (!global.gag)
             showCtfeBackTrace(istate, this, fd);
     }
+    else if (eresult == EXP_VOID_INTERPRET)
+        ;
+    else
+        eresult->loc = loc;
     return eresult;
 }
 


### PR DESCRIPTION
The interpreter drops the loc when interpreting a function call, so restore it.

http://d.puremagic.com/issues/show_bug.cgi?id=3812
