### PR TITLE
Issue 3927 - array.length++; is an error, but ++array.length compiles

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9447,10 +9447,11 @@ Expression *PostExp::semantic(Scope *sc)
         if (e)
             return e;
 
-        e1 = e1->modifiableLvalue(sc, e1);
+        if (e1->op != TOKarraylength)
+            e1 = e1->modifiableLvalue(sc, e1);
 
         Type *t1 = e1->type->toBasetype();
-        if (t1->ty == Tclass || t1->ty == Tstruct)
+        if (t1->ty == Tclass || t1->ty == Tstruct || e1->op == TOKarraylength)
         {   /* Check for operator overloading,
              * but rewrite in terms of ++e instead of e++
              */
@@ -9458,7 +9459,7 @@ Expression *PostExp::semantic(Scope *sc)
             /* If e1 is not trivial, take a reference to it
              */
             Expression *de = NULL;
-            if (e1->op != TOKvar)
+            if (e1->op != TOKvar && e1->op != TOKarraylength)
             {
                 // ref v = e1;
                 Identifier *id = Lexer::uniqueId("__postref");

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1109,6 +1109,17 @@ void test62()
 
 /***************************************************/
 
+void test3927()
+{
+    int[] array;
+    assert(array.length++ == 0);
+    assert(array.length == 1);
+    assert(array.length-- == 1);
+    assert(array.length == 0);
+}
+
+/***************************************************/
+
 void test63()
 {
     int[3] b;
@@ -4569,7 +4580,7 @@ int main()
     test103();
     test104();
     test105();
-
+    test3927();
     test107();
 
     test109();


### PR DESCRIPTION
Rewrite array.length to `(auto tmp = array.length, ++array.length, tmp)`

http://d.puremagic.com/issues/show_bug.cgi?id=3927
