### PR TITLE
Issue 5498 - array of elements of subtypes of a common supertype

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1133,10 +1133,14 @@ Expressions *arrayExpressionToCommonType(Scope *sc, Expressions *exps, Type **pt
                 condexp.loc = e->loc;
                 condexp.semantic(sc);
                 (*exps)[j0] = condexp.e1;
+                if (condexp.e1->op == TOKfunction &&
+                    condexp.e2->op == TOKfunction)
+                    t0 = condexp.e2->type;
+                else
+                    t0 = condexp.type;
                 e = condexp.e2;
                 j0 = i;
                 e0 = e;
-                t0 = e0->type;
             }
         }
         else

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3179,6 +3179,14 @@ void test141()
 }
 
 /***************************************************/
+
+class test5498_A {}
+class test5498_B : test5498_A {}
+class test5498_C : test5498_A {}
+
+static assert(is(typeof([test5498_B.init, test5498_C.init]) == test5498_A[]));
+
+/***************************************************/
 // 3688
 
 struct S142


### PR DESCRIPTION
arrayExpressionsToCommonType incorrectly uses condexp.e2->type rather than condexp.type to determine the common type of the array.

http://d.puremagic.com/issues/show_bug.cgi?id=5498
