### PR TITLE
Issue 5590 - ICE(e2ir.c): when using .values on enum which is associative array

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -33,6 +33,7 @@ struct InterfaceDeclaration;
 struct TypeInfoClassDeclaration;
 struct VarDeclaration;
 struct dt_t;
+struct TypeAArray;
 
 
 struct AggregateDeclaration : ScopeDsymbol
@@ -134,6 +135,7 @@ struct StructDeclaration : AggregateDeclaration
 
     FuncDeclaration *xeq;       // TypeInfo_Struct.xopEquals
     static FuncDeclaration *xerreq;      // object.xopEquals
+    TypeAArray *isAA;
 #endif
 
     StructDeclaration(Loc loc, Identifier *id);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4370,6 +4370,7 @@ StructDeclaration *TypeAArray::getImpl()
         ti->semantic2(sc);
         ti->semantic3(sc);
         impl = ti->toAlias()->isStructDeclaration();
+        impl->isAA = this;
 #ifdef DEBUG
         if (!impl)
         {   Dsymbol *s = ti->toAlias();

--- a/src/struct.c
+++ b/src/struct.c
@@ -311,6 +311,7 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
     postblit = NULL;
 
     xeq = NULL;
+    isAA = NULL;
 #endif
 
     // For forward references

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -996,6 +996,20 @@ void test54()
 
 /***************************************************/
 
+void test5590()
+{
+    auto a = [5 : "hello"].values;
+    auto b = [5 : "hello"].keys;
+    auto c = [5 : "hello"].length;
+    auto d = [5 : "hello"].rehash;
+    assert(a == ["hello"]);
+    assert(b == [5]);
+    assert(c == 1);
+    assert(d == [5 : "hello"]);
+}
+
+/***************************************************/
+
 class Foo55
 {
 	synchronized void noop1() { }
@@ -4501,6 +4515,7 @@ int main()
     test37();
     test38();
     test39();
+    test5590();
     test40();
     test41();
     test42();


### PR DESCRIPTION
When the associative array type has been overwritten with the struct's type, change it back, store the function result in a tempoary, and return the address of that.

http://d.puremagic.com/issues/show_bug.cgi?id=5590
