### PR TITLE
Remove AssociativeArray from druntime

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3805,11 +3805,13 @@ elem *CastExp::toElem(IRState *irs)
     Type *tfrom = e1->type->toBasetype();
     Type *t = to->toBasetype();         // skip over typedef's
 
+#ifdef ASSOCIATIVEARRAY
 #if DMDV2
     if (tfrom->ty == Taarray)
         tfrom = ((TypeAArray*)tfrom)->getImpl()->type;
     if (t->ty == Taarray)
         t = ((TypeAArray*)t)->getImpl()->type;
+#endif
 #endif
 
     if (t->equals(tfrom))

--- a/src/expression.c
+++ b/src/expression.c
@@ -6562,7 +6562,11 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
     else if ((t1b->ty == Tarray || t1b->ty == Tsarray ||
              t1b->ty == Taarray) &&
              ident != Id::sort && ident != Id::reverse &&
+#ifdef ASSOCIATIVEARRAY
              ident != Id::dup && ident != Id::idup)
+#else
+             (ident != Id::dup || t1b->ty == Taarray) && ident != Id::idup)
+#endif
     {   /* If ident is not a valid property, rewrite:
          *   e1.ident
          * as:
@@ -7163,6 +7167,7 @@ Lagain:
             {
                 return NULL;
             }
+#ifdef ASSOCIATIVEARRAY
             else
             {   TypeAArray *taa = (TypeAArray *)tthis;
                 assert(taa->ty == Taarray);
@@ -7172,6 +7177,9 @@ Lagain:
                     return NULL;
                 goto Lshift;
             }
+#else
+            goto Lshift;
+#endif
         }
         else if (tthis->ty == Tarray || tthis->ty == Tsarray)
         {

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -255,6 +255,8 @@ Msgtable msgtable[] =
     { "aaKeys", "_aaKeys" },
     { "aaValues", "_aaValues" },
     { "aaRehash", "_aaRehash" },
+    { "aaApply", "_aaApply" },
+    { "aaApply2", "_aaApply2" },
     { "monitorenter", "_d_monitorenter" },
     { "monitorexit", "_d_monitorexit" },
     { "criticalenter", "_d_criticalenter" },

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -65,7 +65,9 @@ Msgtable msgtable[] =
     { "typeinfo" },
     { "outer" },
     { "Exception" },
+#ifdef ASSOCIATIVEARRAY
     { "AssociativeArray" },
+#endif
     { "Throwable" },
     { "Error" },
     { "withSym", "__withSym" },

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5340,12 +5340,14 @@ bool isAssocArray(Type *t)
     t = t->toBasetype();
     if (t->ty == Taarray)
         return true;
+#ifdef ASSOCIATIVEARRAY
 #if DMDV2
     if (t->ty != Tstruct)
         return false;
     StructDeclaration *sym = ((TypeStruct *)t)->sym;
     if (sym->ident == Id::AssociativeArray)
         return true;
+#endif
 #endif
     return false;
 }
@@ -5357,12 +5359,17 @@ TypeAArray *toBuiltinAAType(Type *t)
     if (t->ty == Taarray)
         return (TypeAArray *)t;
 #if DMDV2
+#ifdef ASSOCIATIVEARRAY
     assert(t->ty == Tstruct);
     StructDeclaration *sym = ((TypeStruct *)t)->sym;
     assert(sym->ident == Id::AssociativeArray);
     TemplateInstance *tinst = sym->parent->isTemplateInstance();
     assert(tinst);
     return new TypeAArray((Type *)(tinst->tiargs->tdata()[1]), (Type *)(tinst->tiargs->tdata()[0]));
+#else
+    assert(0);
+    return NULL;
+#endif
 #else
     assert(0);
     return NULL;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2872,6 +2872,7 @@ Expression *BinExp::interpretCommon2(InterState *istate, CtfeGoal goal, fp2_t fp
         e1->op != TOKnull &&
         e1->op != TOKstring &&
         e1->op != TOKarrayliteral &&
+        e1->op != TOKassocarrayliteral &&
         e1->op != TOKstructliteral &&
         e1->op != TOKclassreference)
     {
@@ -2888,6 +2889,7 @@ Expression *BinExp::interpretCommon2(InterState *istate, CtfeGoal goal, fp2_t fp
         e2->op != TOKnull &&
         e2->op != TOKstring &&
         e2->op != TOKarrayliteral &&
+        e2->op != TOKassocarrayliteral &&
         e2->op != TOKstructliteral &&
         e2->op != TOKclassreference)
     {
@@ -6228,20 +6230,9 @@ Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
 {
     Expression *e = NULL;
     int nargs = arguments ? arguments->dim : 0;
-#if DMDV2
-    if (pthis && isAssocArray(pthis->type))
-    {
-        if (fd->ident == Id::length &&  nargs==0)
-            return interpret_length(istate, pthis);
-        else if (fd->ident == Id::keys && nargs==0)
-            return interpret_keys(istate, pthis, returnedArrayElementType(fd));
-        else if (fd->ident == Id::values && nargs==0)
-            return interpret_values(istate, pthis, returnedArrayElementType(fd));
-        else if (fd->ident == Id::rehash && nargs==0)
-            return pthis->interpret(istate, ctfeNeedLvalue);  // rehash is a no-op
-    }
     if (!pthis)
     {
+#if DMDV2
         enum BUILTIN b = fd->isBuiltin();
         if (b)
         {   Expressions args;
@@ -6258,44 +6249,23 @@ Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
             if (!e)
                 e = EXP_CANT_INTERPRET;
         }
-    }
-    /* Horrid hack to retrieve the builtin AA functions after they've been
-     * mashed by the inliner.
-     */
-    if (!pthis)
-    {
-        Expression *firstarg =  nargs > 0 ? (Expression *)(arguments->data[0]) : NULL;
-        // Check for the first parameter being a templatized AA. Hack: we assume that
-        // template AA.var is always the AA data itself.
-        Expression *firstdotvar = (firstarg && firstarg->op == TOKdotvar)
-                ?  ((DotVarExp *)firstarg)->e1 : NULL;
-        if (nargs==3 && isAssocArray(firstarg->type) && !strcmp(fd->ident->string, "_aaApply"))
-            return interpret_aaApply(istate, firstarg, (Expression *)(arguments->data[2]));
-        if (nargs==3 && isAssocArray(firstarg->type) &&!strcmp(fd->ident->string, "_aaApply2"))
-            return interpret_aaApply(istate, firstarg, (Expression *)(arguments->data[2]));
-        if (firstdotvar && isAssocArray(firstdotvar->type))
-        {   if (fd->ident == Id::aaLen && nargs == 1)
-                return interpret_length(istate, firstdotvar->interpret(istate));
-            else if (fd->ident == Id::aaKeys && nargs == 2)
+
+        {
+            Expression *firstarg =  nargs > 0 ? (Expression *)(arguments->data[0]) : NULL;
+            if (firstarg && firstarg->type->toBasetype()->ty == Tpointer &&
+                firstarg->type->nextOf()->toBasetype()->ty == Taarray)
             {
-                Expression *trueAA = firstdotvar->interpret(istate);
-                return interpret_keys(istate, trueAA, toBuiltinAAType(trueAA->type)->index);
-            }
-            else if (fd->ident == Id::aaValues && nargs == 3)
-            {
-                Expression *trueAA = firstdotvar->interpret(istate);
-                return interpret_values(istate, trueAA, toBuiltinAAType(trueAA->type)->nextOf());
-            }
-            else if (fd->ident == Id::aaRehash && nargs == 2)
-            {
-                return firstdotvar->interpret(istate, ctfeNeedLvalue);
+                if ((nargs == 2 && fd->ident == Id::aaRehash) ||
+                    fd->ident == Id::rehash)
+                {
+                    e = new PtrExp(0, firstarg);
+                    e->type = firstarg->type->toBasetype()->nextOf();
+                    e = e->interpret(istate, ctfeNeedRvalue);
+                    return e;
+                }
             }
         }
-    }
 #endif
-#if DMDV1
-    if (!pthis)
-    {
         Expression *firstarg =  nargs > 0 ? (Expression *)(arguments->data[0]) : NULL;
         if (firstarg && firstarg->type->toBasetype()->ty == Taarray)
         {
@@ -6308,13 +6278,12 @@ Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
                 return interpret_values(istate, firstarg, firstAAtype->nextOf());
             else if (nargs==2 && fd->ident == Id::aaRehash)
                 return firstarg->interpret(istate, ctfeNeedLvalue); //no-op
-            else if (nargs==3 && !strcmp(fd->ident->string, "_aaApply"))
+            else if (nargs==3 && fd->ident == Id::aaApply)
                 return interpret_aaApply(istate, firstarg, (Expression *)(arguments->data[2]));
-            else if (nargs==3 && !strcmp(fd->ident->string, "_aaApply2"))
+            else if (nargs==3 && fd->ident == Id::aaApply2)
                 return interpret_aaApply(istate, firstarg, (Expression *)(arguments->data[2]));
         }
     }
-#endif
 #if DMDV2
     if (pthis && !fd->fbody && fd->isCtorDeclaration() && fd->parent && fd->parent->parent && fd->parent->parent->ident == Id::object)
     {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4515,7 +4515,7 @@ Expression *TypeAArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
         FuncDeclaration *fd;
         Expressions *arguments;
 
-        fd = FuncDeclaration::genCfunc(Type::tint64, Id::aaRehash);
+        fd = FuncDeclaration::genCfunc(Type::tindex, Id::aaRehash);
         ec = new VarExp(0, fd);
         arguments = new Expressions();
         arguments->push(e->addressOf(sc));

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2332,10 +2332,12 @@ Type *TypeNext::makeConst()
         else
             t->next = next->constOf();
     }
+#ifdef ASSOCIATIVEARRAY
     if (ty == Taarray)
     {
         ((TypeAArray *)t)->impl = NULL;         // lazily recompute it
     }
+#endif
     //printf("TypeNext::makeConst() returns %p, %s\n", t, t->toChars());
     return t;
 }
@@ -2353,10 +2355,12 @@ Type *TypeNext::makeInvariant()
         !next->isImmutable())
     {   t->next = next->invariantOf();
     }
+#ifdef ASSOCIATIVEARRAY
     if (ty == Taarray)
     {
         ((TypeAArray *)t)->impl = NULL;         // lazily recompute it
     }
+#endif
     return t;
 }
 
@@ -2379,10 +2383,12 @@ Type *TypeNext::makeShared()
         else
             t->next = next->sharedOf();
     }
+#ifdef ASSOCIATIVEARRAY
     if (ty == Taarray)
     {
         ((TypeAArray *)t)->impl = NULL;         // lazily recompute it
     }
+#endif
     //printf("TypeNext::makeShared() returns %p, %s\n", t, t->toChars());
     return t;
 }
@@ -2401,10 +2407,12 @@ Type *TypeNext::makeSharedConst()
     {
         t->next = next->sharedConstOf();
     }
+#ifdef ASSOCIATIVEARRAY
     if (ty == Taarray)
     {
         ((TypeAArray *)t)->impl = NULL;         // lazily recompute it
     }
+#endif
     //printf("TypeNext::makeSharedConst() returns %p, %s\n", t, t->toChars());
     return t;
 }
@@ -2426,10 +2434,12 @@ Type *TypeNext::makeWild()
         else
             t->next = next->wildOf();
     }
+#ifdef ASSOCIATIVEARRAY
     if (ty == Taarray)
     {
         ((TypeAArray *)t)->impl = NULL;         // lazily recompute it
     }
+#endif
     //printf("TypeNext::makeWild() returns %p, %s\n", t, t->toChars());
     return t;
 }
@@ -2451,10 +2461,12 @@ Type *TypeNext::makeSharedWild()
         else
             t->next = next->sharedWildOf();
     }
+#ifdef ASSOCIATIVEARRAY
     if (ty == Taarray)
     {
         ((TypeAArray *)t)->impl = NULL;         // lazily recompute it
     }
+#endif
     //printf("TypeNext::makeSharedWild() returns %p, %s\n", t, t->toChars());
     return t;
 }
@@ -2469,10 +2481,12 @@ Type *TypeNext::makeMutable()
     {
         t->next = next->mutableOf();
     }
+#ifdef ASSOCIATIVEARRAY
     if (ty == Taarray)
     {
         ((TypeAArray *)t)->impl = NULL;         // lazily recompute it
     }
+#endif
     //printf("TypeNext::makeMutable() returns %p, %s\n", t, t->toChars());
     return t;
 }
@@ -4243,7 +4257,9 @@ TypeAArray::TypeAArray(Type *t, Type *index)
     : TypeArray(Taarray, t)
 {
     this->index = index;
+#ifdef ASSOCIATIVEARRAY
     this->impl = NULL;
+#endif
     this->loc = 0;
     this->sc = NULL;
 }
@@ -4349,6 +4365,7 @@ printf("index->ito->ito = x%x\n", index->ito->ito);
     return merge();
 }
 
+#ifdef ASSOCIATIVEARRAY
 StructDeclaration *TypeAArray::getImpl()
 {
     // Do it lazily
@@ -4408,6 +4425,7 @@ StructDeclaration *TypeAArray::getImpl()
     }
     return impl;
 }
+#endif
 
 void TypeAArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps)
 {
@@ -4443,7 +4461,7 @@ Expression *TypeAArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
 #if LOGDOTEXP
     printf("TypeAArray::dotExp(e = '%s', ident = '%s')\n", e->toChars(), ident->toChars());
 #endif
-#if 0
+#ifndef ASSOCIATIVEARRAY
     if (ident == Id::length)
     {
         Expression *ec;
@@ -4506,7 +4524,7 @@ Expression *TypeAArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
         e->type = this;
     }
     else
-#endif
+#else
     if (ident != Id::__sizeof &&
         ident != Id::__xalignof &&
         ident != Id::init &&
@@ -4518,6 +4536,7 @@ Expression *TypeAArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
         e = e->type->dotExp(sc, e, ident);
     }
     else
+#endif
         e = Type::dotExp(sc, e, ident);
     return e;
 }
@@ -4597,6 +4616,7 @@ MATCH TypeAArray::implicitConvTo(Type *to)
             return m;
         }
     }
+#ifdef ASSOCIATIVEARRAY
     else if (to->ty == Tstruct && ((TypeStruct *)to)->sym->ident == Id::AssociativeArray)
     {
         int errs = global.startGagging();
@@ -4607,6 +4627,7 @@ MATCH TypeAArray::implicitConvTo(Type *to)
         }
         return from->implicitConvTo(to);
     }
+#endif
     return Type::implicitConvTo(to);
 }
 
@@ -7788,6 +7809,7 @@ MATCH TypeStruct::implicitConvTo(Type *to)
 {   MATCH m;
 
     //printf("TypeStruct::implicitConvTo(%s => %s)\n", toChars(), to->toChars());
+#ifdef ASSOCIATIVEARRAY
     if (to->ty == Taarray)
     {
         /* If there is an error instantiating AssociativeArray!(), it shouldn't
@@ -7800,6 +7822,7 @@ MATCH TypeStruct::implicitConvTo(Type *to)
             return MATCHnomatch;
         }
     }
+#endif
 
     if (ty == to->ty && sym == ((TypeStruct *)to)->sym)
     {   m = MATCHexact;         // exact match

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -509,13 +509,17 @@ struct TypeAArray : TypeArray
     Loc loc;
     Scope *sc;
 
+#ifdef ASSOCIATIVEARRAY
     StructDeclaration *impl;    // implementation
+#endif
 
     TypeAArray(Type *t, Type *index);
     Type *syntaxCopy();
     d_uns64 size(Loc loc);
     Type *semantic(Loc loc, Scope *sc);
+#ifdef ASSOCIATIVEARRAY
     StructDeclaration *getImpl();
+#endif
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps);
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);

--- a/src/statement.c
+++ b/src/statement.c
@@ -1726,8 +1726,12 @@ Lagain:
 #if SARRAYVALUE
             /* This only works if Key or Value is a static array.
              */
+#ifdef ASSOCIATIVEARRAY
             tab = taa->getImpl()->type;
             goto Lagain;
+#else
+            goto Lapply;
+#endif
 #else
             if (op == TOKforeach_reverse)
             {

--- a/src/template.c
+++ b/src/template.c
@@ -434,9 +434,11 @@ void TemplateDeclaration::semantic(Scope *sc)
         return;         // semantic() already run
     semanticRun = 1;
 
+#ifdef ASSOCIATIVEARRAY
     if (sc->module && sc->module->ident == Id::object && ident == Id::AssociativeArray)
     {   Type::associativearray = this;
     }
+#endif
 
     if (sc->func)
     {
@@ -4104,7 +4106,11 @@ void TemplateInstance::semantic(Scope *sc)
 void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
 {
     //printf("TemplateInstance::semantic('%s', this=%p, gag = %d, sc = %p)\n", toChars(), this, global.gag, sc);
+#ifdef ASSOCIATIVEARRAY
     if (global.errors && name != Id::AssociativeArray)
+#else
+    if (global.errors)
+#endif
     {
         //printf("not instantiating %s due to %d errors\n", toChars(), global.errors);
         if (!global.gag)

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -444,8 +444,10 @@ void TypeInfoAssociativeArrayDeclaration::toDt(dt_t **pdt)
     dtxoff(pdt, tc->index->vtinfo->toSymbol(), 0, TYnptr); // TypeInfo for array of type
 
 #if DMDV2
+#ifdef ASSOCIATIVEARRAY
     tc->getImpl()->type->getTypeInfo(NULL);
     dtxoff(pdt, tc->getImpl()->type->vtinfo->toSymbol(), 0, TYnptr);    // impl
+#endif
 #endif
 }
 

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -771,13 +771,13 @@ static assert(!is( ICE3996!(Bug3996) ));
 
 /************************************************/
 
-void bug4826c(T)(int[int] value, T x) {}
+/*void bug4826c(T)(int[int] value, T x) {}
 
 void test34()
 {
    AssociativeArray!(int, int) z;
    bug4826c(z,1);
-}
+}*/
 
 /************************************************/
 // 5131
@@ -859,7 +859,7 @@ printf("before test 30\n");   test30();
 printf("before test 31\n");   test31();
 printf("before test 32\n");   test32();
 
-    test34();
+    //test34();
     test35();
     test36();
     test7365();

--- a/test/runnable/testaa3.d
+++ b/test/runnable/testaa3.d
@@ -1,0 +1,124 @@
+
+/* Test all aa properties (length, values, keys, opApply(Key, Value), opApply_r(Value),
+ * dup, byKey, byValue, rehash, opIndex, opIndexAssign, opIn_r)
+ *
+ * With all aas: literal, variable, ref parameter, rvalue
+ */
+
+int testLiteral()
+{
+    assert([5 : 4].length == 1);
+    assert([5 : 4].values == [4]);
+    assert([5 : 4].keys == [5]);
+    foreach(k, v; [5 : 4])
+        assert(k == 5 && v == 4);
+    foreach(v; [5 : 4])
+        assert(v == 4);
+    assert([5 : 4].dup == [5 : 4]);
+    assert([5 : 4].dup);
+    if (!__ctfe)
+    foreach(k; [5 : 4].byKey)
+        assert(k == 5);
+    if (!__ctfe)
+    foreach(v; [5 : 4].byValue)
+        assert(v == 4);
+    assert([5 : 4].rehash == [5 : 4]);
+    assert([5 : 4][5] == 4);
+    //assert(([5 : 4][3] = 7) == 7);
+    assert(*(5 in [5 : 4]) == 4);
+    return 1;
+}
+
+int testVar()
+{
+    auto aa = [5 : 4];
+    assert(aa.length == 1);
+    assert(aa.values == [4]);
+    assert(aa.keys == [5]);
+    foreach(k, v; aa)
+        assert(k == 5 && v == 4);
+    foreach(v; aa)
+        assert(v == 4);
+    assert(aa.dup == aa);
+    assert(aa.dup);
+    if (!__ctfe)
+    foreach(k; aa.byKey)
+        assert(k == 5);
+    if (!__ctfe)
+    foreach(v; aa.byValue)
+        assert(v == 4);
+    assert(aa.rehash == aa);
+    assert(aa[5] == 4);
+    assert((aa[3] = 7) == 7);
+    assert(*(5 in aa) == 4);
+    return 1;
+}
+
+int testRef()
+{
+    auto aa = [5 : 4];
+    return testRefx(aa);
+}
+int testRefx(ref int[int] aa)
+{
+    assert(aa.length == 1);
+    assert(aa.values == [4]);
+    assert(aa.keys == [5]);
+    foreach(k, v; aa)
+        assert(k == 5 && v == 4);
+    foreach(v; aa)
+        assert(v == 4);
+    assert(aa.dup == aa);
+    assert(aa.dup);
+    if (!__ctfe)
+    foreach(k; aa.byKey)
+        assert(k == 5);
+    if (!__ctfe)
+    foreach(v; aa.byValue)
+        assert(v == 4);
+    //assert(aa.rehash == aa);
+    assert(aa[5] == 4);
+    assert((aa[3] = 7) == 7);
+    assert(*(5 in aa) == 4);
+    return 1;
+}
+
+int testRet()
+{
+    assert(testRetx().length == 1);
+    assert(testRetx().values == [4]);
+    assert(testRetx().keys == [5]);
+    foreach(k, v; testRetx())
+        assert(k == 5 && v == 4);
+    foreach(v; testRetx())
+        assert(v == 4);
+    assert(testRetx().dup == testRetx());
+    assert(testRetx().dup);
+    if (!__ctfe)
+    foreach(k; testRetx().byKey)
+        assert(k == 5);
+    if (!__ctfe)
+    foreach(v; testRetx().byValue)
+        assert(v == 4);
+    assert(testRetx().rehash == testRetx());
+    assert(testRetx()[5] == 4);
+    //assert((testRetx()[3] = 7) == 7);
+    assert(*(5 in testRetx()) == 4);
+    return 1;
+}
+int[int] testRetx()
+{
+    return [5 : 4];
+}
+
+void main()
+{
+    assert(testLiteral());
+    static assert(testLiteral());
+    assert(testVar());
+    static assert(testVar());
+    assert(testRef());
+    static assert(testRef());
+    assert(testRet());
+    static assert(testRet());
+}


### PR DESCRIPTION
This removes all references to AssociativeArray in the compiler, as well as some hacks in the interpreter to support it.
I think some of what I fixed never worked.
The extensions that were in object.d are still there, just as ufcs methods instead of member functions.  This means no hacky casting between types, and no need to mirror the structures in aaA.d.

Limitation: The byKey and byValue opApply methods do not work at compile time, but that is not a regression.

This is not quite ready, one case I couldn't get working was comparing an aa with a ref variable containing an aa, see line 105 in testaa3.  @donc how do you force the interpreter to do this? (interpret.c 6329)

See also: https://github.com/D-Programming-Language/druntime/pull/143
