### PR TITLE
Issue 2006 - Empty array literals with explicit type implicitly convert to any array type

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -554,6 +554,9 @@ MATCH ArrayLiteralExp::implicitConvTo(Type *t)
                 result = MATCHnomatch;
         }
 
+        if (!elements->dim && typeb->nextOf()->toBasetype()->ty != Tvoid)
+            result = MATCHnomatch;
+
         Type *telement = tb->nextOf();
         for (size_t i = 0; i < elements->dim; i++)
         {   Expression *e = (*elements)[i];

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -831,6 +831,18 @@ void test44()
 
 /***************************************************/
 
+void test2006()
+{
+    string [][] aas = [];
+    assert(aas.length == 0);
+    aas ~= cast (string []) [];
+    assert(aas.length == 1);
+    aas = aas ~ cast (string []) [];
+    assert(aas.length == 2);
+}
+
+/***************************************************/
+
 class A45
 {
   int x;
@@ -5240,6 +5252,7 @@ int main()
     test3559();
     test84();
     test85();
+    test2006();
     test86();
     test87();
     test5554();


### PR DESCRIPTION
`ArrayLiteralExp::implicitConvTo` defaults to `MATCHexact`, and when there are no parameters it is never corrected.

http://d.puremagic.com/issues/show_bug.cgi?id=2006
