### PR TITLE
Issue 2547 - Array Ops should check length, at least when bounds checking is on

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -354,14 +354,14 @@ Expression *BinExp::arrayOp(Scope *sc)
 
             sc->module->importedFrom->members->push(fd);
 
-            sc = sc->push();
-            sc->parent = sc->module->importedFrom;
-            sc->stc = 0;
-            sc->linkage = LINKc;
-            fd->semantic(sc);
-            fd->semantic2(sc);
-            fd->semantic3(sc);
-            sc->pop();
+            Scope *scx = sc->push();
+            scx->parent = sc->module->importedFrom;
+            scx->stc = 0;
+            scx->linkage = LINKc;
+            fd->semantic(scx);
+            fd->semantic2(scx);
+            fd->semantic3(scx);
+            scx->pop();
         }
         else
         {   /* In library, refer to it.
@@ -374,9 +374,68 @@ Expression *BinExp::arrayOp(Scope *sc)
     /* Call the function fd(arguments)
      */
     Expression *ec = new VarExp(0, fd);
-    Expression *e = new CallExp(loc, ec, arguments);
-    e->type = type;
-    return e;
+    Expression *e;
+
+    if (global.params.useArrayBounds == 2 ||
+        (global.params.useArrayBounds == 1 &&
+         sc->func && ((TypeFunction *)sc->func->type)->trust == TRUSTsafe))
+    {
+        /* arrayOp(a, b, ...) ->
+         *      (auto tmp0 = e0, tmp1 = e1, ...),
+         *      assert(tmp0.length == tmp1.length && ...),
+         *      arrayOp(tmp0, tmp1, ...)
+         *
+         *  This is only possible because all parameters must be array slices,
+         *  so we don't have to worry about destructors/postblits etc
+         */
+
+        assert(arguments->dim);
+        Expression *decls = NULL;
+        Expression *econd = new IntegerExp(0, 1, Type::tbool);
+        VarDeclaration *tmp0 = NULL;
+
+        for(size_t i = 0; i < arguments->dim; ++i)
+        {
+            VarDeclaration *tmpn = new VarDeclaration(0, (*arguments)[i]->type, Lexer::uniqueId("__tmp"),
+                                                      new ExpInitializer(0, (*arguments)[i]));
+            if (!tmp0)
+                tmp0 = tmpn;
+
+            Expression *de = new DeclarationExp(0, tmpn);
+            if (decls)
+                decls = new CommaExp(0, de, decls);
+            else
+                decls = de;
+
+            if ((*arguments)[i]->type->ty == Tarray && tmp0 != tmpn)
+            {
+                Expression *equal = new EqualExp(TOKequal, 0, new ArrayLengthExp(0, new VarExp(0, tmp0)),
+                                                              new ArrayLengthExp(0, new VarExp(0, tmpn)));
+                econd = new AndAndExp(0, econd, equal);
+            }
+            (*arguments)[i] = new VarExp(0, tmpn);
+        }
+
+        OutBuffer msgbuf;
+        msgbuf.printf("length mismatch match for array operation '%s'", toChars());
+        msgbuf.writebyte(0);
+        Expression *emsg = new StringExp(0, msgbuf.extractData());
+        Expression *ea = new AssertExp(loc, econd, emsg);
+
+        e = new CallExp(loc, ec, arguments);
+        e->type = type;
+        e = new CommaExp(0, ea, e);
+        e = new CommaExp(0, decls, e);
+        //printf("%s\n", e->toChars());
+        //printf("%s\n", fd->type->toChars());
+    }
+    else
+    {
+        e = new CallExp(loc, ec, arguments);
+        e->type = type;
+    }
+
+    return e->semantic(sc);
 }
 
 /******************************************

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2027,6 +2027,44 @@ pure int genFactorials(int n) {
 
 /***************************************************/
 
+void test2547a()
+{
+    bool failed;
+    try
+    {
+        real[] a,b,c;
+        a.length = 2;
+        b.length = 2;
+        c.length = 5;
+        a[] = b[] + c[]; // not in druntime
+    }
+    catch
+    {
+        failed = true;
+    }
+    assert(failed);
+}
+
+void test2547b()
+{
+    bool failed;
+    try
+    {
+        int[] a,b,c;
+        a.length = 2;
+        b.length = 2;
+        c.length = 5;
+        a[] = b[] + c[]; // in druntime
+    }
+    catch
+    {
+        failed = true;
+    }
+    assert(failed);
+}
+
+/***************************************************/
+
 void test107()
 {
     int[6] a;
@@ -5054,6 +5092,8 @@ int main()
     test80();
     test81();
     test82();
+    test2547a();
+    test2547b();
     test83();
     test3559();
     test84();


### PR DESCRIPTION
When array bounds checking is enabled, turn

`arrayOp(a, b, ...)`

into

```
auto tmpa = a, tmpb = b, tmpc = c;,
assert(tmpa.length == tmpb.length && tmpa.length == tmpc.length && ..., "length mismatch for <array op name>");,
arrayOp(tmpa, tmpb, tmpc, ...)
```

http://d.puremagic.com/issues/show_bug.cgi?id=2547
