### PR TITLE
Refactor XxxAssignExp semantic

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -777,8 +777,7 @@ struct BinExp : Expression
     int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     Expression *semanticp(Scope *sc);
-    void checkComplexMulAssign();
-    void checkComplexAddAssign();
+    Expression *checkComplexOpAssign(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *scaleFactor(Scope *sc);
     Expression *typeCombine(Scope *sc);
@@ -810,8 +809,7 @@ struct BinAssignExp : BinExp
     {
     }
 
-    Expression *commonSemanticAssign(Scope *sc);
-    Expression *commonSemanticAssignIntegral(Scope *sc);
+    Expression *semantic(Scope *sc);
 
     Expression *op_overload(Scope *sc);
 
@@ -1247,7 +1245,7 @@ struct ConstructExp : AssignExp
 struct op##AssignExp : BinAssignExp                             \
 {                                                               \
     op##AssignExp(Loc loc, Expression *e1, Expression *e2);     \
-    Expression *semantic(Scope *sc);                            \
+    S(Expression *semantic(Scope *sc);)                          \
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);                  \
     X(void buildArrayIdent(OutBuffer *buf, Expressions *arguments);) \
     X(Expression *buildArrayLoop(Parameters *fparams);)         \
@@ -1258,6 +1256,7 @@ struct op##AssignExp : BinAssignExp                             \
 };
 
 #define X(a) a
+#define S(a)
 ASSIGNEXP(Add)
 ASSIGNEXP(Min)
 ASSIGNEXP(Mul)
@@ -1266,17 +1265,28 @@ ASSIGNEXP(Mod)
 ASSIGNEXP(And)
 ASSIGNEXP(Or)
 ASSIGNEXP(Xor)
+#undef S
+
 #if DMDV2
+#define S(a) a
 ASSIGNEXP(Pow)
+#undef S
 #endif
+
+#undef S
 #undef X
 
 #define X(a)
 
+#define S(a)
 ASSIGNEXP(Shl)
 ASSIGNEXP(Shr)
 ASSIGNEXP(Ushr)
+#undef S
+
+#define S(a) a
 ASSIGNEXP(Cat)
+#undef S
 
 #undef X
 #undef ASSIGNEXP

--- a/test/compilable/testexpression.d
+++ b/test/compilable/testexpression.d
@@ -1,0 +1,121 @@
+
+template TT(T...) { alias T TT; }
+
+void TestOpAssign(Tx, Ux, ops)()
+{
+    foreach(T; Tx.x)
+    foreach(U; Ux.x)
+    foreach(op; ops.x)
+    {
+        T a = cast(T)1;
+        mixin("a " ~ op ~ " cast(U)1;");
+    }
+}
+
+void TestOpAssignAssign(Tx, Ux, ops)()
+{
+    foreach(T; Tx.x)
+    foreach(U; Ux.x)
+    foreach(op; ops.x)
+    {
+        T a = cast(T)1;
+        U b = cast(U)1;
+        T r;
+        mixin("r = a " ~ op ~ " cast(U)1;");
+    }
+}
+
+void TestOpAssignAuto(Tx, Ux, ops)()
+{
+    foreach(T; Tx.x)
+    foreach(U; Ux.x)
+    static if (U.sizeof <= T.sizeof)
+    foreach(op; ops.x)
+    {
+        T a = cast(T)1;
+        U b = cast(U)1;
+        mixin("auto r = a " ~ op ~ " cast(U)1;");
+    }
+}
+
+void TestOpAndAssign(Tx, Ux, ops)()
+{
+    foreach(T; Tx.x)
+    foreach(U; Ux.x)
+    static if (U.sizeof <= T.sizeof && T.sizeof >= 4)
+    foreach(op; ops.x)
+    {
+        T a = cast(T)1;
+        U b = cast(U)1;
+        mixin("a = a " ~ op[0..$-1] ~ " cast(U)1;");
+    }
+}
+
+struct boolean   { alias TT!(bool) x; }
+struct integral  { alias TT!(byte, ubyte, short, ushort, int, uint, long, ulong) x; }
+struct floating  { alias TT!(float, double, real) x; }
+struct imaginary { alias TT!(ifloat, idouble, ireal) x; }
+struct complex   { alias TT!(cfloat, cdouble, creal) x; }
+
+struct all       { alias TT!("+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=", ">>>=") x; }
+struct arith     { alias TT!("+=", "-=", "*=", "/=", "%=") x; }
+struct bitwise   { alias TT!("&=", "|=", "^=") x; }
+struct shift     { alias TT!("<<=", ">>=", ">>>=") x; }
+struct addsub    { alias TT!("+=", "-=") x; }
+struct muldivmod { alias TT!("*=", "/=", "%=") x; }
+struct nomod     { alias TT!("+=", "-=", "*=", "/=") x; }
+
+void OpAssignCases(alias X)()
+{
+    X!(boolean, boolean, bitwise)();
+
+    X!(integral, boolean, all)();
+    X!(integral, integral, all)();
+    X!(integral, floating, arith)();
+
+    X!(floating, boolean, arith)();
+    X!(floating, integral, arith)();
+    X!(floating, floating, arith)();
+
+    X!(imaginary, boolean, muldivmod)();
+    X!(imaginary, integral, muldivmod)();
+    X!(imaginary, floating, muldivmod)();
+    X!(imaginary, imaginary, addsub)();
+
+    X!(complex, boolean, arith)();
+    X!(complex, integral, arith)();
+    X!(complex, floating, arith)();
+    X!(complex, imaginary, arith)();
+    X!(complex, complex, nomod)();
+}
+
+void OpReAssignCases(alias X)()
+{
+    X!(boolean, boolean, bitwise)();
+
+    X!(integral, boolean, all)();
+    X!(integral, integral, all)();
+
+    X!(floating, boolean, arith)();
+    X!(floating, integral, arith)();
+    X!(floating, floating, arith)();
+
+    X!(imaginary, boolean, muldivmod)();
+    X!(imaginary, integral, muldivmod)();
+    X!(imaginary, floating, muldivmod)();
+    X!(imaginary, imaginary, addsub)();
+
+    X!(complex, boolean, arith)();
+    X!(complex, integral, arith)();
+    X!(complex, floating, arith)();
+    X!(complex, imaginary, arith)();
+    X!(complex, complex, nomod)();
+}
+
+void main()
+{
+    OpAssignCases!TestOpAssign();
+    //OpAssignCases!TestOpAssignAssign(); // disabled due to bug 7436
+    //OpAssignCases!TestOpAssignAuto(); // 5181
+    OpReAssignCases!TestOpAndAssign();
+}

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1718,6 +1718,27 @@ void test90( )
 
 /***************************************************/
 
+struct A7439(int r, int c)
+{
+    alias r R;
+    alias c C;
+    alias float[R * C] Data;
+    Data _data;
+    alias _data this;
+
+    this(Data ar){ _data = ar; }
+
+    pure ref float opIndex(size_t rr, size_t cc){ return _data[cc + rr * C]; }
+}
+
+void test7439()
+{
+    A7439!(2, 2) a = A7439!(2, 2)([8, 3, 2, 9]);
+    a[0,0] -= a[0,0] * 2.0;
+}
+
+/***************************************************/
+
 void foo91(uint line = __LINE__) { printf("%d\n", line); }
 
 void test91()


### PR DESCRIPTION
Reduce code duplication for the semantic routines of `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, `>>>=`

The semantic routines for these operators are nearly identical, and a lot of the differences are probably bugs.

Most of the remaining special casing is due to imaginary and complex types, which can be delete when those types are removed from the language.

In the process fix issues 7439 and 5181. (and possibly others)

http://d.puremagic.com/issues/show_bug.cgi?id=5181
http://d.puremagic.com/issues/show_bug.cgi?id=7439
