### PR TITLE
Bug 7426 - Inner struct "no size yet for forward reference" when using .tupleof inside it.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7451,7 +7451,8 @@ Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident)
          */
         e = e->semantic(sc);    // do this before turning on noaccesscheck
         assert(e->type->ty == Tstruct);
-        ((TypeStruct *)e->type)->sym->semantic(sc); // do semantic of type
+        AggregateDeclaration *aggregate_decl = ((TypeStruct *)e->type)->sym;
+        aggregate_decl->semantic(aggregate_decl->scope); // do semantic of type
         Expressions *exps = new Expressions;
         exps->reserve(sym->fields.dim);
 
@@ -7925,7 +7926,8 @@ Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident)
          */
         e = e->semantic(sc);    // do this before turning on noaccesscheck
         assert(e->type->ty == Tclass);
-        ((TypeClass *)e->type)->sym->semantic(sc); // do semantic of type
+        AggregateDeclaration *aggregate_decl = ((TypeClass *)e->type)->sym;
+        aggregate_decl->semantic(aggregate_decl->scope); // do semantic of type
         Expressions *exps = new Expressions;
         exps->reserve(sym->fields.dim);
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7450,7 +7450,8 @@ Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident)
          * (e.field0, e.field1, e.field2, ...)
          */
         e = e->semantic(sc);    // do this before turning on noaccesscheck
-        e->type->size();        // do semantic of type
+        assert(e->type->ty == Tstruct);
+        ((TypeStruct *)e->type)->sym->semantic(sc); // do semantic of type
         Expressions *exps = new Expressions;
         exps->reserve(sym->fields.dim);
 
@@ -7923,7 +7924,8 @@ Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident)
         /* Create a TupleExp
          */
         e = e->semantic(sc);    // do this before turning on noaccesscheck
-        e->type->size();        // do semantic of type
+        assert(e->type->ty == Tclass);
+        ((TypeClass *)e->type)->sym->semantic(sc); // do semantic of type
         Expressions *exps = new Expressions;
         exps->reserve(sym->fields.dim);
 

--- a/test/compilable/test7426.d
+++ b/test/compilable/test7426.d
@@ -1,0 +1,32 @@
+struct S7426
+{
+    static struct InnerS
+    {
+        int x;
+        alias typeof(InnerS.tupleof) T;
+        static assert(is(T[0] == int));
+    }
+
+    static class InnerC
+    {
+        double y;
+        alias typeof(InnerC.tupleof) T;
+    }
+}
+
+class C7426
+{
+    static struct InnerT
+    {
+        int x;
+        alias typeof(InnerT.tupleof) T;
+    }
+
+    static class InnerD
+    {
+        double y;
+        alias typeof(InnerD.tupleof) T;
+        static assert(is(T[0] == double));
+    }
+}
+


### PR DESCRIPTION
Fix [bug 7426](http://d.puremagic.com/issues/show_bug.cgi?id=7426) - Inner struct "no size yet for forward reference" when using .tupleof inside it.

This commit weakens the semantic requirement for TypeStruct and TypeClass when a .tupleof is requested, so allowing .tupleof be used inside the aggregate while bug 7190 can still work.
