### PR TITLE
Deprecations

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1266,7 +1266,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
         Expression *ce;
 
         if (ident == Id::length)
-            deprecation("using 'length' inside [ ] is deprecated, use '$' instead");
+            ::error(loc, "using 'length' inside [ ] is deprecated, use '$' instead");
 
     L1:
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3726,26 +3726,7 @@ elem *DeleteExp::toElem(IRState *irs)
     {
         IndexExp *ae = (IndexExp *)(e1);
         tb = ae->e1->type->toBasetype();
-        if (tb->ty == Taarray)
-        {
-            TypeAArray *taa = (TypeAArray *)tb;
-            elem *ea = ae->e1->toElem(irs);
-            elem *ekey = ae->e2->toElem(irs);
-            elem *ep;
-            elem *keyti;
-
-            if (tybasic(ekey->Ety) == TYstruct || tybasic(ekey->Ety) == TYarray)
-            {
-                ekey = el_una(OPstrpar, TYstruct, ekey);
-                ekey->ET = ekey->E1->ET;
-            }
-
-            Symbol *s = taa->aaGetSymbol("Del", 0);
-            keyti = taa->index->getInternalTypeInfo(NULL)->toElem(irs);
-            ep = el_params(ekey, keyti, ea, NULL);
-            e = el_bin(OPcall, TYnptr, el_var(s), ep);
-            goto Lret;
-        }
+        assert(tb->ty != Taarray);
     }
     //e1->type->print();
     e = e1->toElem(irs);

--- a/src/expression.c
+++ b/src/expression.c
@@ -8985,7 +8985,7 @@ Expression *DeleteExp::semantic(Scope *sc)
         IndexExp *ae = (IndexExp *)(e1);
         Type *tb1 = ae->e1->type->toBasetype();
         if (tb1->ty == Taarray)
-            deprecation("delete aa[key] deprecated, use aa.remove(key)");
+            error("delete aa[key] deprecated, use aa.remove(key)");
     }
 
     return this;

--- a/src/expression.c
+++ b/src/expression.c
@@ -5521,7 +5521,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                     s->toPrettyChars(), sc->func->toChars());
                 return new ErrorExp();
             }
-            else if (!global.params.useDeprecated)
+            else
             {   // Disallow shadowing
 
                 for (Scope *scx = sc->enclosing; scx && scx->func == sc->func; scx = scx->enclosing)
@@ -5531,7 +5531,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                         (s2 = scx->scopesym->symtab->lookup(s->ident)) != NULL &&
                         s != s2)
                     {
-                        deprecation("shadowing declaration %s is deprecated", s->toPrettyChars());
+                        error("is shadowing declaration %s", s->toPrettyChars());
                         return new ErrorExp();
                     }
                 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2406,7 +2406,7 @@ done:
     if (*p == 'i' || *p == 'I')
     {
         if (*p == 'I')
-            deprecation("'I' suffix is deprecated, use 'i' instead");
+            error("'I' suffix is deprecated, use 'i' instead");
         p++;
         switch (result)
         {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -578,7 +578,7 @@ void Lexer::scan(Token *t)
                 t->postfix = 0;
                 t->value = TOKstring;
 #if DMDV2
-                deprecation("Escape String literal %.*s is deprecated, use double quoted string literal \"%.*s\" instead", p - pstart, pstart, p - pstart, pstart);
+                error("Escape String literal %.*s is deprecated, use double quoted string literal \"%.*s\" instead", p - pstart, pstart, p - pstart, pstart);
 #endif
                 return;
             }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2397,7 +2397,7 @@ done:
             break;
 
         case 'l':
-            deprecation("'l' suffix is deprecated, use 'L' instead");
+            error("'l' suffix is deprecated, use 'L' instead");
         case 'L':
             result = TOKfloat80v;
             p++;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2147,8 +2147,6 @@ done:
                 f = FLAGS_unsigned;
                 goto L1;
 
-            case 'l':
-                error("'l' is not a valid suffix, did you mean 'L'?");
             case 'L':
                 f = FLAGS_long;
             L1:

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2020,7 +2020,7 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
     {
         if (ident == Id::offset)
         {
-            deprecation(e->loc, ".offset deprecated, use .offsetof");
+            error(e->loc, ".offset deprecated, use .offsetof");
             goto Loffset;
         }
         else if (ident == Id::offsetof)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1950,7 +1950,7 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
     }
     else if (ident == Id::typeinfo)
     {
-        deprecation(loc, ".typeinfo deprecated, use typeid(type)");
+        error(loc, ".typeinfo deprecated, use typeid(type)");
         e = getTypeInfo(NULL);
     }
     else if (ident == Id::init)
@@ -2046,7 +2046,7 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
     }
     if (ident == Id::typeinfo)
     {
-        deprecation(e->loc, ".typeinfo deprecated, use typeid(type)");
+        error(e->loc, ".typeinfo deprecated, use typeid(type)");
         e = getTypeInfo(sc);
     }
     else if (ident == Id::stringof)
@@ -8411,7 +8411,7 @@ L1:
 
         if (ident == Id::typeinfo)
         {
-            deprecation(e->loc, ".typeinfo deprecated, use typeid(type)");
+            error(e->loc, ".typeinfo deprecated, use typeid(type)");
             return getTypeInfo(sc);
         }
         if (ident == Id::outer && sym->vthis)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2851,8 +2851,8 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident)
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                                // For backwards compatibility - eventually, deprecate
-                                goto Lmin_normal;
+                warning(loc, "min property is deprecated, use min_normal instead");
+                goto Lmin_normal;
         }
     }
     else if (ident == Id::min_normal)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1939,11 +1939,6 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
     {
         e = new IntegerExp(loc, size(loc), Type::tsize_t);
     }
-    else if (ident == Id::size)
-    {
-        error(loc, ".size property should be replaced with .sizeof");
-        e = new ErrorExp();
-    }
     else if (ident == Id::__xalignof)
     {
         e = new IntegerExp(loc, alignsize(), Type::tsize_t);

--- a/src/parse.c
+++ b/src/parse.c
@@ -4010,7 +4010,7 @@ Statement *Parser::parseStatement(int flags)
                     arg = new Parameter(0, NULL, token.ident, NULL);
                     nextToken();
                     nextToken();
-                    deprecation("if (v%s e) is deprecated, use if (auto v = e)", t->toChars());
+                    error("if (v; e) is deprecated, use if (auto v = e)");
                 }
             }
 

--- a/test/runnable/deprecate1.d
+++ b/test/runnable/deprecate1.d
@@ -56,17 +56,6 @@ void test10()
 }
 
 /**************************************
-        backslash literals
-**************************************/
-
-// from lexer.d
-void lexerTest7()
-{
-    auto str = \xDB;
-    assert(str.length == 1);
-}
-
-/**************************************
             typedef
 **************************************/
 
@@ -1268,7 +1257,6 @@ int main()
 {
     test2();
     test5();
-    lexerTest7();
     test10();
     test19();
     test33();


### PR DESCRIPTION
The first wave of deprecations for language features.

The following were errors, and will now be removed compeltely:
- 'l' suffix (long)
- `.size`

The following were already deprecated, and are now errors
- Implicitly declared length variable for array indexing.
- Local variable shadowing
- `delete aa[key]`
- Escape string literals
- 'l' suffix (real)
- 'I' suffix (imaginary)
- `.typeinfo`
- `.offset`
- `if (v; e)`

And one was scheduled to be deprecated, and is now a warning:
- `.min` for floating point types

~~Depends on  [druntime pull 144](https://github.com/D-Programming-Language/druntime/pull/144) and [phobos pull 418](https://github.com/D-Programming-Language/phobos/pull/418)~~
