### PR TITLE
Fix bug 7424 and bug 7425.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -253,7 +253,7 @@ Expression *resolveProperties(Scope *sc, Expression *e)
             e = new CallExp(e->loc, e);
             e = e->semantic(sc);
         }
-        return e;
+        goto return_expr;
     }
 
     if (e->type)
@@ -290,6 +290,13 @@ Expression *resolveProperties(Scope *sc, Expression *e)
             return new ErrorExp();
         }
 
+    }
+
+return_expr:
+    if (!e->type)
+    {
+        error(e->loc, "cannot resolve type for %s", e->toChars());
+        e->type = new TypeError();
     }
     return e;
 }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1337,6 +1337,31 @@ int MODimplicitConv(unsigned char modfrom, unsigned char modto)
 }
 
 /***************************
+ * Return !=0 if a method of type '() modfrom' can call a method of type '() modto'.
+ */
+int MODmethodConv(unsigned char modfrom, unsigned char modto)
+{
+    if (MODimplicitConv(modfrom, modto))
+        return 1;
+
+    #define X(m, n) (((m) << 4) | (n))
+    switch (X(modfrom, modto))
+    {
+        case X(0, MODwild):
+        case X(MODimmutable, MODwild):
+        case X(MODconst, MODwild):
+        case X(MODshared, MODshared|MODwild):
+        case X(MODshared|MODimmutable, MODshared|MODwild):
+        case X(MODshared|MODconst, MODshared|MODwild):
+            return 1;
+
+        default:
+            return 0;
+    }
+    #undef X
+}
+
+/***************************
  * Merge mod bits to form common mod.
  */
 int MODmerge(unsigned char mod1, unsigned char mod2)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -986,6 +986,7 @@ int arrayTypeCompatible(Loc loc, Type *t1, Type *t2);
 int arrayTypeCompatibleWithoutCasting(Loc loc, Type *t1, Type *t2);
 void MODtoBuffer(OutBuffer *buf, unsigned char mod);
 int MODimplicitConv(unsigned char modfrom, unsigned char modto);
+int MODmethodConv(unsigned char modfrom, unsigned char modto);
 int MODmerge(unsigned char mod1, unsigned char mod2);
 
 #endif /* DMD_MTYPE_H */

--- a/src/template.c
+++ b/src/template.c
@@ -1167,7 +1167,7 @@ L2:
                 mod &= ~STCwild;
             if (tthis->mod != mod)
             {
-                if (!MODimplicitConv(tthis->mod, mod))
+                if (!MODmethodConv(tthis->mod, mod))
                     goto Lnomatch;
                 if (MATCHconst < match)
                     match = MATCHconst;

--- a/test/fail_compilation/fail7424b.d
+++ b/test/fail_compilation/fail7424b.d
@@ -1,0 +1,5 @@
+struct S7424b
+{
+    @property int g()() { return 0; }
+    void test() const { int f = g; }
+}

--- a/test/fail_compilation/fail7424c.d
+++ b/test/fail_compilation/fail7424c.d
@@ -1,0 +1,6 @@
+struct S7424c
+{
+    @property int g()() { return 0; }
+    void test() immutable { int f = g; }
+}
+

--- a/test/fail_compilation/fail7424d.d
+++ b/test/fail_compilation/fail7424d.d
@@ -1,0 +1,6 @@
+struct S7424d
+{
+    @property int g()() immutable { return 0; }
+    void test() const { int f = g; }
+}
+

--- a/test/fail_compilation/fail7424e.d
+++ b/test/fail_compilation/fail7424e.d
@@ -1,0 +1,6 @@
+struct S7424e
+{
+    @property int g()() immutable { return 0; }
+    void test() { int f = g; }
+}
+

--- a/test/fail_compilation/fail7424f.d
+++ b/test/fail_compilation/fail7424f.d
@@ -1,0 +1,6 @@
+struct S7424f
+{
+    @property int g()() shared { return 0; }
+    void test() { int f = g; }
+}
+

--- a/test/fail_compilation/fail7424g.d
+++ b/test/fail_compilation/fail7424g.d
@@ -1,0 +1,6 @@
+struct S7424g
+{
+    @property int g()() { return 0; }
+    void test() shared { int f = g; }
+}
+

--- a/test/fail_compilation/fail7424h.d
+++ b/test/fail_compilation/fail7424h.d
@@ -1,0 +1,6 @@
+struct S7424g
+{
+    @property int g()() { return 0; }
+    void test() inout { int f = g; }
+}
+

--- a/test/fail_compilation/fail7424i.d
+++ b/test/fail_compilation/fail7424i.d
@@ -1,0 +1,6 @@
+struct S7424g
+{
+    @property int g()() immutable { return 0; }
+    void test() inout { int f = g; }
+}
+

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4665,6 +4665,63 @@ void test6504()
     }
 }
 
+struct S7424a
+{
+    @property inout(int) g()() inout { return 7424; }
+    void test1()
+    {
+        int f = g;
+        assert(f == 7424);
+        assert(g == 7424);
+    }
+    void test2() const
+    {
+        int f = g;
+        assert(f == 7424);
+        assert(g == 7424);
+    }
+    void test3() immutable
+    {
+        int f = g;
+        assert(f == 7424);
+        assert(g == 7424);
+    }
+}
+struct S7425
+{
+    inout(T) g(T)(T x) inout
+    {
+        return x;
+    }
+    void test1()
+    {
+        int f = g(2);
+        assert(f == 2);
+    }
+    void test2() const
+    {
+        double y = g(4.5);
+        assert(y == 4.5);
+    }
+}
+void test7424()
+{
+    S7424a s1;
+    s1.test1();
+    s1.test2();
+
+    immutable(S7424a) s2;
+    s2.test2();
+    s2.test3();
+
+    const(S7424a) s3;
+    s3.test2();
+
+    S7425 s4;
+    s4.test1();
+    s4.test2();
+}
+
 /***************************************************/
 
 int main()
@@ -4910,6 +4967,7 @@ int main()
     test7367();
     test7375();
     test6504();
+    test7424();
 
     writefln("Success");
     return 0;


### PR DESCRIPTION
The commit contains two changes:
1. It is now _allowed_ to call an `inout` method from a method with any
   const qualifiers, which also allows an `inout` method template be
   matched from other non-`inout` methods, thus fixing [bug 7425](http://d.puremagic.com/issues/show_bug.cgi?id=7425);
2. When resolveProperty failed to compute the type of an expression, the
   type is now set as TypeError instead of leaving as NULL, thus fixing
   [bug 7424](http://d.puremagic.com/issues/show_bug.cgi?id=7424).
