### PR TITLE
Error messages with __error: 6699, 7462, 7463

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -333,7 +333,8 @@ void ClassDeclaration::semantic(Scope *sc)
         //b->type = b->type->semantic(loc, sc);
         tb = b->type->toBasetype();
         if (tb->ty != Tclass)
-        {   error("base type must be class or interface, not %s", b->type->toChars());
+        {   if (b->type != Type::terror)
+                error("base type must be class or interface, not %s", b->type->toChars());
             baseclasses->remove(0);
         }
         else
@@ -406,8 +407,8 @@ void ClassDeclaration::semantic(Scope *sc)
         else
             tc = NULL;
         if (!tc || !tc->sym->isInterfaceDeclaration())
-        {
-            error("base type must be interface, not %s", b->type->toChars());
+        {   if (b->type != Type::terror)
+                error("base type must be interface, not %s", b->type->toChars());
             baseclasses->remove(i);
             continue;
         }
@@ -1272,8 +1273,8 @@ void InterfaceDeclaration::semantic(Scope *sc)
         else
             tc = NULL;
         if (!tc || !tc->sym->isInterfaceDeclaration())
-        {
-            error("base type must be interface, not %s", b->type->toChars());
+        {   if (b->type != Type::terror)
+                error("base type must be interface, not %s", b->type->toChars());
             baseclasses->remove(i);
             continue;
         }

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -490,7 +490,8 @@ void AliasDeclaration::semantic(Scope *sc)
         if (s)
             goto L2;
 
-        error("cannot alias an expression %s", e->toChars());
+        if (e->op != TOKerror)
+            error("cannot alias an expression %s", e->toChars());
         t = e->type;
     }
     else if (t)

--- a/src/expression.c
+++ b/src/expression.c
@@ -7512,6 +7512,21 @@ Lagain:
     if (e1->op == TOKerror)
         return e1;
 
+    // If there was an error processing any template argument,
+    // return an error without trying to resolve the template.
+    if (targsi && targsi->dim)
+    {
+        for (size_t k = 0; k < targsi->dim; k++)
+        {   Object *o = targsi->tdata()[k];
+            Expression *checkarg = isExpression(o);
+            Type *txx = isType(o);
+            if (checkarg && checkarg->op == TOKerror)
+                return checkarg;
+            if (txx && txx == Type::terror)
+                return new ErrorExp();
+        }
+    }
+
     if (e1->op == TOKdotvar && t1->ty == Tfunction ||
         e1->op == TOKdottd)
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -7518,11 +7518,7 @@ Lagain:
     {
         for (size_t k = 0; k < targsi->dim; k++)
         {   Object *o = targsi->tdata()[k];
-            Expression *checkarg = isExpression(o);
-            Type *txx = isType(o);
-            if (checkarg && checkarg->op == TOKerror)
-                return checkarg;
-            if (txx && txx == Type::terror)
+            if (isError(o))
                 return new ErrorExp();
         }
     }

--- a/src/func.c
+++ b/src/func.c
@@ -434,6 +434,9 @@ void FuncDeclaration::semantic(Scope *sc)
             //printf("\tnot virtual\n");
             goto Ldone;
         }
+        // Suppress further errors if the return type is an error
+        if (type->nextOf() == Type::terror)
+            goto Ldone;
 
         /* Find index of existing function in base class's vtbl[] to override
          * (the index will be the same as in cd's current vtbl[])

--- a/src/statement.c
+++ b/src/statement.c
@@ -4077,6 +4077,8 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
     {
         exp = exp->semantic(sc);
         exp = resolveProperties(sc, exp);
+        if (exp->op == TOKerror)
+            goto Lbody;
         ClassDeclaration *cd = exp->type->isClassHandle();
         if (!cd)
             error("can only synchronize on class objects, not '%s'", exp->type->toChars());
@@ -4155,6 +4157,7 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
         return s->semantic(sc);
     }
 #endif
+Lbody:
     if (body)
         body = body->semantic(sc);
     return this;

--- a/src/template.c
+++ b/src/template.c
@@ -3650,7 +3650,13 @@ void TemplateValueParameter::declareParameter(Scope *sc)
 
 void TemplateValueParameter::semantic(Scope *sc)
 {
+    bool wasSame = (sparam->type == valType);
     sparam->semantic(sc);
+    if (sparam->type == Type::terror && wasSame)
+    {   // If sparam has a type error, avoid duplicate errors
+        valType = Type::terror;
+        return;
+    }
     valType = valType->semantic(loc, sc);
     if (!(valType->isintegral() || valType->isfloating() || valType->isString()) &&
         valType->ty != Tident)


### PR DESCRIPTION
The motivation for fixing these is not much that the error messages improve, but rather that it protects other parts of the compiler (eg, CTFE) from having to deal with garbage. OTOH, the fix for 6699a noticeably improves error message quality. (Don't try to deduce a function template, if one of the template arguments is an error).

6699 More cases of __error in error messages
7462 Error message with _error_ in overridden function
7463 Duplicated error message with bad template value parameter
