### PR TITLE
Issue 7462 - Error message with _error_ in overridden function

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -252,7 +252,8 @@ void FuncDeclaration::semantic(Scope *sc)
     storage_class &= ~STCref;
     if (type->ty != Tfunction)
     {
-        error("%s must be a function instead of %s", toChars(), type->toChars());
+        if (type->ty != Terror)
+            error("%s must be a function instead of %s", toChars(), type->toChars());
         return;
     }
     f = (TypeFunction *)(type);


### PR DESCRIPTION
When there is an error in the parameter types, default arguments or return type, propagate the error to the function's type.

http://d.puremagic.com/issues/show_bug.cgi?id=7462
