### PR TITLE
Restore tests that were accidentally removed.

### DIFF
--- a/test/fail_compilation/fail4269e.d
+++ b/test/fail_compilation/fail4269e.d
@@ -1,0 +1,5 @@
+
+static if(is(typeof(X5.init))) {}
+typedef Y X5;
+
+void main() {}

--- a/test/fail_compilation/fail4269f.d
+++ b/test/fail_compilation/fail4269f.d
@@ -1,0 +1,5 @@
+
+static if(is(typeof(X16))) {}
+alias X16 X16;
+
+void main() {}

--- a/test/fail_compilation/fail4269g.d
+++ b/test/fail_compilation/fail4269g.d
@@ -1,0 +1,6 @@
+
+int[2] d;
+static if(is(typeof(Xg.init))) {}
+alias d[1] Xg;
+
+void main() {}


### PR DESCRIPTION
Three test cases for bug 4269 were accidentally replaced by [this commit](https://github.com/D-Programming-Language/dmd/commit/75ccf8c3ae057aad7128d710fe735f7772be0471) - add them back.
