### PR TITLE
Issue 3822 - Invalid optimization of alloca called with constant size

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3541,6 +3541,9 @@ elem *CallExp::toElem(IRState *irs)
     {
         fd = ((VarExp *)e1)->var->isFuncDeclaration();
 
+#if 0 // This optimization is not valid if alloca can be called
+      // multiple times within the same function, eg in a loop
+      // see issue 3822
         if (fd && fd->ident == Id::alloca &&
             !fd->fbody && fd->linkage == LINKc &&
             arguments && arguments->dim == 1)
@@ -3567,6 +3570,7 @@ elem *CallExp::toElem(IRState *irs)
                 }
             }
         }
+#endif
 
         ec = e1->toElem(irs);
     }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2726,6 +2726,21 @@ void test138()
 
 /***************************************************/
 
+void test3822()
+{
+    import core.stdc.stdlib;
+    int i = 0;
+    void* ptr;
+    while(i++ != 2)
+    {
+        auto p = alloca(2);
+        assert(p != ptr);
+        ptr = p;
+    }
+}
+
+/***************************************************/
+
 // 5939, 5940
 
 template map(fun...)
@@ -4581,6 +4596,7 @@ int main()
     test115();
     test116();
     test117();
+    test3822();
     test118();
     test5081();
 


### PR DESCRIPTION
e2ir.c constains an optimization to turn alloca into a fixed sized array allocation on the stack when alloca is called with a compile-time constant.  This is invalid as alloca may be called inside a loop.

I think the correct place to perform this optimization is in the backend, where analysis can determine alloca is called at most once per function call and turn it into a local variable allocation.

http://d.puremagic.com/issues/show_bug.cgi?id=3822
