### PR TITLE
7481 Compiler should 'soldier on' after template errors

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7279,7 +7279,10 @@ Expression *CallExp::semantic(Scope *sc)
             /* Attempt to instantiate ti. If that works, go with it.
              * If not, go with partial explicit specialization.
              */
+            unsigned olderrors = global.errors;
             ti->semanticTiargs(sc);
+            if (olderrors != global.errors)
+                return new ErrorExp();
             if (ti->needsTypeInference(sc))
             {
                 /* Go with partial explicit specialization

--- a/src/template.c
+++ b/src/template.c
@@ -4104,18 +4104,6 @@ void TemplateInstance::semantic(Scope *sc)
 void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
 {
     //printf("TemplateInstance::semantic('%s', this=%p, gag = %d, sc = %p)\n", toChars(), this, global.gag, sc);
-    if (global.errors && name != Id::AssociativeArray)
-    {
-        //printf("not instantiating %s due to %d errors\n", toChars(), global.errors);
-        if (!global.gag)
-        {
-            /* Trying to soldier on rarely generates useful messages
-             * at this point.
-             */
-            fatal();
-        }
-//        return;
-    }
 #if LOG
     printf("\n+TemplateInstance::semantic('%s', this=%p)\n", toChars(), this);
 #endif
@@ -4167,11 +4155,11 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             //printf("error return %p, %d\n", tempdecl, global.errors);
             return;             // error recovery
         }
-
+        unsigned errs = global.errors;
         tempdecl = findTemplateDeclaration(sc);
         if (tempdecl)
             tempdecl = findBestMatch(sc, fargs);
-        if (!tempdecl || global.errors)
+        if (!tempdecl || (errs != global.errors))
         {   inst = this;
             //printf("error return %p, %d\n", tempdecl, global.errors);
             return;             // error recovery
@@ -5147,8 +5135,9 @@ Identifier *TemplateInstance::genIdent(Objects *args)
                 continue;
             }
             // Now that we know it is not an alias, we MUST obtain a value
+            unsigned olderr = global.errors;
             ea = ea->optimize(WANTvalue | WANTinterpret);
-            if (ea->op == TOKerror)
+            if (ea->op == TOKerror || olderr != global.errors)
                 continue;
 #if 1
             /* Use deco that matches what it would be for a function parameter


### PR DESCRIPTION
Apart from improved diagnostics, this is a patch for improved robustness. See the bug report for discussion.
It removes a couple of hacks from the compiler.

http://d.puremagic.com/issues/show_bug.cgi?id=7481

There is a moderately high chance that this patch will lead to a compiler ICE or strange error messages, so it shouldn't be pulled at the end of a release cycle. But bad behaviour can only happen after an error message has already been printed, so the potential harm is not high.
