### PR TITLE
fix Issue 6208 with tuple parameter deduction in IFTI.

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1089,6 +1089,9 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(Scope *sc, Loc loc, Objec
                 if (tp_is_declared)
                     goto L2;
 
+                // Apply function parameter storage classes to parameter type
+                tid = (TypeIdentifier *)tid->addStorageClass(fparam->storageClass);
+
                 /* The types of the function arguments
                  * now form the tuple argument.
                  */
@@ -1099,7 +1102,143 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(Scope *sc, Loc loc, Objec
                 t->objects.setDim(tuple_dim);
                 for (size_t i = 0; i < tuple_dim; i++)
                 {   Expression *farg = fargs->tdata()[fptupindex + i];
-                    t->objects.tdata()[i] = farg->type;
+                    Type *tt;
+                    MATCH m;
+
+                    #define X(U,T)  ((U) << 4) | (T)
+                    switch (X(tid->mod, farg->type->mod))
+                    {
+                        case X(0, 0):
+                        case X(0, MODconst):
+                        case X(0, MODimmutable):
+                        case X(0, MODshared):
+                        case X(0, MODconst | MODshared):
+                        case X(0, MODwild):
+                        case X(0, MODwild | MODshared):
+                            // foo(U:U) T                              => T
+                            // foo(U:U) const(T)                       => const(T)
+                            // foo(U:U) immutable(T)                   => immutable(T)
+                            // foo(U:U) shared(T)                      => shared(T)
+                            // foo(U:U) const(shared(T))               => const(shared(T))
+                            // foo(U:U) wild(T)                        => wild(T)
+                            // foo(U:U) wild(shared(T))                => wild(shared(T))
+
+                            tt = farg->type;
+                            m = MATCHexact;
+                            break;
+
+                        case X(MODconst, MODconst):
+                        case X(MODimmutable, MODimmutable):
+                        case X(MODshared, MODshared):
+                        case X(MODconst | MODshared, MODconst | MODshared):
+                        case X(MODwild, MODwild):
+                        case X(MODwild | MODshared, MODwild | MODshared):
+                            // foo(U:const(U))        const(T)         => T
+                            // foo(U:immutable(U))    immutable(T)     => T
+                            // foo(U:shared(U))       shared(T)        => T
+                            // foo(U:const(shared(U)) const(shared(T)) => T
+                            // foo(U:wild(U))         wild(T)          => T
+                            // foo(U:wild(shared(U))  wild(shared(T)) => T
+
+                            tt = farg->type->mutableOf()->unSharedOf();
+                            m = MATCHexact;
+                            break;
+
+                        case X(MODconst, 0):
+                        case X(MODconst, MODimmutable):
+                        case X(MODconst, MODconst | MODshared):
+                        case X(MODconst | MODshared, MODimmutable):
+                        case X(MODconst, MODwild):
+                        case X(MODconst, MODwild | MODshared):
+                            // foo(U:const(U)) T                       => T
+                            // foo(U:const(U)) immutable(T)            => T
+                            // foo(U:const(U)) const(shared(T))        => shared(T)
+                            // foo(U:const(shared(U)) immutable(T)     => T
+                            // foo(U:const(U)) wild(shared(T))         => shared(T)
+
+                            tt = farg->type->mutableOf();
+                            m = MATCHconst;
+                            break;
+
+                        case X(MODshared, MODconst | MODshared):
+                        case X(MODconst | MODshared, MODshared):
+                        case X(MODshared, MODwild | MODshared):
+                            // foo(U:shared(U)) const(shared(T))       => const(T)
+                            // foo(U:const(shared(U)) shared(T)        => T
+                            // foo(U:shared(U)) wild(shared(T))        => wild(T)
+                            tt = farg->type->unSharedOf();
+                            m = MATCHconst;
+                            break;
+
+                        case X(MODimmutable,         0):
+                        case X(MODimmutable,         MODconst):
+                        case X(MODimmutable,         MODshared):
+                        case X(MODimmutable,         MODconst | MODshared):
+                        case X(MODconst,             MODshared):
+                        case X(MODshared,            0):
+                        case X(MODshared,            MODconst):
+                        case X(MODshared,            MODimmutable):
+                        case X(MODconst | MODshared, 0):
+                        case X(MODconst | MODshared, MODconst):
+                        case X(MODimmutable,         MODwild):
+                        case X(MODshared,            MODwild):
+                        case X(MODconst | MODshared, MODwild):
+                        case X(MODwild,              0):
+                        case X(MODwild,              MODconst):
+                        case X(MODwild,              MODimmutable):
+                        case X(MODwild,              MODshared):
+                        case X(MODwild,              MODconst | MODshared):
+                        case X(MODwild | MODshared,  0):
+                        case X(MODwild | MODshared,  MODconst):
+                        case X(MODwild | MODshared,  MODimmutable):
+                        case X(MODwild | MODshared,  MODshared):
+                        case X(MODwild | MODshared,  MODconst | MODshared):
+                        case X(MODwild | MODshared,  MODwild):
+                        case X(MODimmutable,         MODwild | MODshared):
+                        case X(MODconst | MODshared, MODwild | MODshared):
+                        case X(MODwild,              MODwild | MODshared):
+
+                            // foo(U:immutable(U)) T                   => nomatch
+                            // foo(U:immutable(U)) const(T)            => nomatch
+                            // foo(U:immutable(U)) shared(T)           => nomatch
+                            // foo(U:immutable(U)) const(shared(T))    => nomatch
+                            // foo(U:const(U)) shared(T)               => nomatch
+                            // foo(U:shared(U)) T                      => nomatch
+                            // foo(U:shared(U)) const(T)               => nomatch
+                            // foo(U:shared(U)) immutable(T)           => nomatch
+                            // foo(U:const(shared(U)) T                => nomatch
+                            // foo(U:const(shared(U)) const(T)         => nomatch
+                            // foo(U:immutable(U)) wild(T)             => nomatch
+                            // foo(U:shared(U)) wild(T)                => nomatch
+                            // foo(U:const(shared(U)) wild(T)          => nomatch
+                            // foo(U:wild(U)) T                        => nomatch
+                            // foo(U:wild(U)) const(T)                 => nomatch
+                            // foo(U:wild(U)) immutable(T)             => nomatch
+                            // foo(U:wild(U)) shared(T)                => nomatch
+                            // foo(U:wild(U)) const(shared(T))         => nomatch
+                            // foo(U:wild(shared(U)) T                 => nomatch
+                            // foo(U:wild(shared(U)) const(T)          => nomatch
+                            // foo(U:wild(shared(U)) immutable(T)      => nomatch
+                            // foo(U:wild(shared(U)) shared(T)         => nomatch
+                            // foo(U:wild(shared(U)) const(shared(T))  => nomatch
+                            // foo(U:wild(shared(U)) wild(T)           => nomatch
+                            // foo(U:immutable(U)) wild(shared(T))     => nomatch
+                            // foo(U:const(shared(U))) wild(shared(T)) => nomatch
+                            // foo(U:wild(U)) wild(shared(T))          => nomatch
+                            m = MATCHnomatch;
+                            break;
+
+                        default:
+                            assert(0);
+                    }
+                    #undef X
+
+                    if (m == MATCHnomatch)
+                        goto Lnomatch;
+                    if (m < match)
+                        match = m;
+
+                    t->objects.tdata()[i] = tt;
                 }
                 declareParameter(paramscope, tp, t);
                 goto L2;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -497,8 +497,6 @@ void test6208a()
     assert(xm.f!int(0) == 1);   // ditto
 }
 
-/**********************************/
-
 void test6208b()
 {
     void foo(T)(const T value) if (!is(T == int)) {}
@@ -507,6 +505,54 @@ void test6208b()
     const int cn;
     static assert(!__traits(compiles, foo(mn)));    // OK -> OK
     static assert(!__traits(compiles, foo(cn)));    // NG -> OK
+}
+
+void test6208c()
+{
+    struct S
+    {
+        // Original test case.
+        int foo(V)(in V v)                         { return 1; }
+        int foo(Args...)(auto ref const Args args) { return 2; }
+
+        // Reduced test cases
+
+        int hoo(V)(const V v)             { return 1; }  // typeof(10) : const V       -> MATCHconst
+        int hoo(Args...)(const Args args) { return 2; }  // typeof(10) : const Args[0] -> MATCHconst
+        // If deduction matching level is same, tuple parameter is less specialized than others.
+
+        int bar(V)(V v)                   { return 1; }  // typeof(10) : V             -> MATCHexact
+        int bar(Args...)(const Args args) { return 2; }  // typeof(10) : const Args[0] -> MATCHconst
+
+        int baz(V)(const V v)             { return 1; }  // typeof(10) : const V -> MATCHconst
+        int baz(Args...)(Args args)       { return 2; }  // typeof(10) : Args[0] -> MATCHexact
+
+        inout(int) war(V)(inout V v)            { return 1; }
+        inout(int) war(Args...)(inout Args args){ return 2; }
+    }
+
+    S s;
+
+    int nm = 10;
+    assert(s.foo(nm) == 1);
+    assert(s.hoo(nm) == 1);
+    assert(s.bar(nm) == 1);
+    assert(s.baz(nm) == 2);
+    assert(s.war(nm) == 1);
+
+    const int nc = 10;
+    assert(s.foo(nc) == 1);
+    assert(s.hoo(nc) == 1);
+    assert(s.bar(nc) == 1);
+    assert(s.baz(nc) == 1);
+    assert(s.war(nc) == 1);
+
+    immutable int ni = 10;
+    assert(s.foo(ni) == 1);
+    assert(s.hoo(ni) == 1);
+    assert(s.bar(ni) == 1);
+    assert(s.baz(ni) == 2);
+    assert(s.war(ni) == 1);
 }
 
 /**********************************/
@@ -856,6 +902,7 @@ int main()
     test2778get();
     test6208a();
     test6208b();
+    test6208c();
     test6738();
     test6780();
     test6994();

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -529,6 +529,8 @@ void test6208c()
 
         inout(int) war(V)(inout V v)            { return 1; }
         inout(int) war(Args...)(inout Args args){ return 2; }
+
+        inout(int) waz(Args...)(inout Args args){ return 0; }   // wild deduction test
     }
 
     S s;
@@ -539,6 +541,7 @@ void test6208c()
     assert(s.bar(nm) == 1);
     assert(s.baz(nm) == 2);
     assert(s.war(nm) == 1);
+    static assert(is(typeof(s.waz(nm)) == int));
 
     const int nc = 10;
     assert(s.foo(nc) == 1);
@@ -546,6 +549,7 @@ void test6208c()
     assert(s.bar(nc) == 1);
     assert(s.baz(nc) == 1);
     assert(s.war(nc) == 1);
+    static assert(is(typeof(s.waz(nc)) == const(int)));
 
     immutable int ni = 10;
     assert(s.foo(ni) == 1);
@@ -553,6 +557,17 @@ void test6208c()
     assert(s.bar(ni) == 1);
     assert(s.baz(ni) == 2);
     assert(s.war(ni) == 1);
+    static assert(is(typeof(s.waz(ni)) == immutable(int)));
+
+    static assert(is(typeof(s.waz(nm, nm)) == int));
+    static assert(is(typeof(s.waz(nm, nc)) == const(int)));
+    static assert(is(typeof(s.waz(nm, ni)) == const(int)));
+    static assert(is(typeof(s.waz(nc, nm)) == const(int)));
+    static assert(is(typeof(s.waz(nc, nc)) == const(int)));
+    static assert(is(typeof(s.waz(nc, ni)) == const(int)));
+    static assert(is(typeof(s.waz(ni, nm)) == const(int)));
+    static assert(is(typeof(s.waz(ni, nc)) == const(int)));
+    static assert(is(typeof(s.waz(ni, ni)) == immutable(int)));
 }
 
 /**********************************/


### PR DESCRIPTION
If a function parameter using tuple template parameter has some storage classes, the its whole matching level should be the worst of each tuple elements.
