### PR TITLE
Issue 3559 - DMD 1.048+ fails to take function pointer from overloaded member functions

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1450,7 +1450,7 @@ Expression *DelegateExp::castTo(Scope *sc, Type *t)
     Expression *e = this;
     Type *tb = t->toBasetype();
     Type *typeb = type->toBasetype();
-    if (tb != typeb)
+    if (tb != typeb || hasOverloads)
     {
         // Look for delegates to functions where the functions are overloaded.
         FuncDeclaration *f;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -640,6 +640,7 @@ struct FuncDeclaration : Declaration
     int isAbstract();
     int isCodeseg();
     int isOverloadable();
+    int hasOverloads();
     enum PURE isPure();
     enum PURE isPureBypassingInference();
     bool setImpure();

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -490,6 +490,11 @@ int Dsymbol::isOverloadable()
 {
     return 0;
 }
+
+int Dsymbol::hasOverloads()
+{
+    return 0;
+}
 #endif
 
 LabelDsymbol *Dsymbol::isLabel()                // is this a LabelDsymbol()?

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -172,6 +172,7 @@ struct Dsymbol : Object
     virtual int isDeprecated();                 // is Dsymbol deprecated?
 #if DMDV2
     virtual int isOverloadable();
+    virtual int hasOverloads();
 #endif
     virtual LabelDsymbol *isLabel();            // is this a LabelDsymbol?
     virtual AggregateDeclaration *isMember();   // is this symbol a member of an AggregateDeclaration?

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3460,8 +3460,7 @@ elem *DelegateExp::toElem(IRState *irs)
             ep = el_una(OPind, TYnptr, ep);
             vindex = func->vtblIndex;
 
-            if ((int)vindex < 0)
-                error("Internal compiler error: malformed delegate. See Bugzilla 4860");
+            assert((int)vindex >= 0);
 
             // Build *(ep + vindex * 4)
             ep = el_bin(OPadd,TYnptr,ep,el_long(TYsize_t, vindex * PTRSIZE));

--- a/src/func.c
+++ b/src/func.c
@@ -2771,6 +2771,11 @@ int FuncDeclaration::isOverloadable()
     return 1;                   // functions can be overloaded
 }
 
+int FuncDeclaration::hasOverloads()
+{
+    return overnext != NULL;
+}
+
 enum PURE FuncDeclaration::isPure()
 {
     //printf("FuncDeclaration::isPure() '%s'\n", toChars());

--- a/src/init.c
+++ b/src/init.c
@@ -870,7 +870,7 @@ Type *ExpInitializer::inferType(Scope *sc)
     // Give error for overloaded function addresses
     if (exp->op == TOKdelegate)
     {   DelegateExp *se = (DelegateExp *)exp;
-        if (
+        if (se->hasOverloads &&
             se->func->isFuncDeclaration() &&
             !se->func->isFuncDeclaration()->isUnique())
             exp->error("cannot infer type from overloaded function symbol %s", exp->toChars());

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8244,7 +8244,7 @@ L1:
         return e;
     }
 
-    DotVarExp *de = new DotVarExp(e->loc, e, d);
+    DotVarExp *de = new DotVarExp(e->loc, e, d, d->hasOverloads());
     return de->semantic(sc);
 }
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2950,6 +2950,82 @@ void test147()
 
 
 /***************************************************/
+
+void test3559()
+{
+    static class A
+    {
+        int foo(int a)   { return 0; }
+        int foo(float a) { return 1; }
+
+        int bar(float a) { return 1; }
+        int bar(int a) { return 0; }
+    }
+
+    static class B : A
+    {
+        int foo(float a) { return 2; }
+        alias A.foo foo;
+
+        alias A.bar bar;
+        int bar(float a) { return 2; }
+    }
+
+    {
+        auto x = new A;
+        auto f1 = cast(int delegate(int))&x.foo;
+        auto f2 = cast(int delegate(float))&x.foo;
+        int delegate(int) f3 = &x.foo;
+        int delegate(float) f4 = &x.foo;
+
+        assert(f1(0) == 0);
+        assert(f2(0) == 1);
+        assert(f3(0) == 0);
+        assert(f4(0) == 1);
+    }
+
+    {
+        auto x = new B;
+        auto f1 = cast(int delegate(int))&x.foo;
+        auto f2 = cast(int delegate(float))&x.foo;
+        int delegate(int) f3 = &x.foo;
+        int delegate(float) f4 = &x.foo;
+
+        assert(f1(0) == 0);
+        assert(f2(0) == 2);
+        assert(f3(0) == 0);
+        assert(f4(0) == 2);
+    }
+
+    {
+        auto x = new A;
+        auto f1 = cast(int delegate(int))&x.bar;
+        auto f2 = cast(int delegate(float))&x.bar;
+        int delegate(int) f3 = &x.bar;
+        int delegate(float) f4 = &x.bar;
+
+        assert(f1(0) == 0);
+        assert(f2(0) == 1);
+        assert(f3(0) == 0);
+        assert(f4(0) == 1);
+    }
+
+    {
+        auto x = new B;
+        auto f1 = cast(int delegate(int))&x.bar;
+        auto f2 = cast(int delegate(float))&x.bar;
+        int delegate(int) f3 = &x.bar;
+        int delegate(float) f4 = &x.bar;
+
+        assert(f1(0) == 0);
+        assert(f2(0) == 2);
+        assert(f3(0) == 0);
+        assert(f4(0) == 2);
+    }
+}
+
+
+/***************************************************/
 // 5897
 
 struct A148{ int n; }
@@ -4547,6 +4623,7 @@ int main()
     test81();
     test82();
     test83();
+    test3559();
     test84();
     test85();
     test86();


### PR DESCRIPTION
`TypeClass::dotExp` incorrectly marks the `DotIdExp` as having no overloads, and casting a `DelegateExp` incorrectly needs to mark it as not overloaded if any in the overload list match.

http://d.puremagic.com/issues/show_bug.cgi?id=3559
