### PR TITLE
fix 7491

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8174,14 +8174,12 @@ L1:
         return de;
     }
 
-#if 0 // shouldn't this be here?
     if (s->isImport() || s->isModule() || s->isPackage())
     {
         e = new DsymbolExp(e->loc, s, 0);
         e = e->semantic(sc);
         return e;
     }
-#endif
 
     OverloadSet *o = s->isOverloadSet();
     if (o)

--- a/test/compilable/imports/test7491a.d
+++ b/test/compilable/imports/test7491a.d
@@ -1,0 +1,1 @@
+module imports.test7491a;

--- a/test/compilable/imports/test7491b.d
+++ b/test/compilable/imports/test7491b.d
@@ -1,0 +1,1 @@
+module imports.test7491b;

--- a/test/compilable/test7491.d
+++ b/test/compilable/test7491.d
@@ -1,0 +1,53 @@
+struct Struct
+{
+    import object;
+    import imports.test7491a;
+    import renamed=imports.test7491b;
+}
+
+struct AliasThis
+{
+    Struct _struct;
+    alias _struct this;
+}
+
+class Base
+{
+    import object;
+    import imports.test7491a;
+    import renamed=imports.test7491b;
+}
+
+class Derived : Base
+{
+}
+
+interface Interface
+{
+    import object;
+    import imports.test7491a;
+    import renamed=imports.test7491b;
+}
+
+class Impl : Interface
+{
+}
+
+static assert(__traits(compiles, Struct.object));
+static assert(__traits(compiles, Struct.imports));
+static assert(__traits(compiles, Struct.renamed));
+static assert(__traits(compiles, AliasThis.object));
+static assert(__traits(compiles, AliasThis.imports));
+static assert(__traits(compiles, AliasThis.renamed));
+static assert(__traits(compiles, Base.object));
+static assert(__traits(compiles, Base.imports));
+static assert(__traits(compiles, Base.renamed));
+static assert(__traits(compiles, Derived.object));
+static assert(__traits(compiles, Derived.imports));
+static assert(__traits(compiles, Derived.renamed));
+static assert(__traits(compiles, Interface.object));
+static assert(__traits(compiles, Interface.imports));
+static assert(__traits(compiles, Interface.renamed));
+static assert(__traits(compiles, Impl.object));
+static assert(__traits(compiles, Impl.imports));
+static assert(__traits(compiles, Impl.renamed));


### PR DESCRIPTION
- This is a rather odd feature but we support it for structs
  since 2.022 so classes should be treated the same.
- Adding the package name ('std') to the base class
  symbol table means that looking up package imports
  through the base class will take precedence over looking
  them up through module imports. In conjunction with
  access checks this could be potentially confusing
  (see Bugzilla [7491](http://d.puremagic.com/issues/show_bug.cgi?id=7491) for an example).
