### PR TITLE
fully recreate old selective import behavior...

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -211,7 +211,11 @@ void Import::semantic(Scope *sc)
         /* BUG: Protection checks can't be enabled yet. The issue is
          * that Dsymbol::search errors before overload resolution.
          */
-        // sc->protection = protection;
+#if 0
+        sc->protection = protection;
+#else
+        sc->protection = PROTpublic;
+#endif
         for (size_t i = 0; i < aliasdecls.dim; i++)
         {   Dsymbol *s = aliasdecls.tdata()[i];
 

--- a/test/compilable/imports/test72a.d
+++ b/test/compilable/imports/test72a.d
@@ -1,0 +1,2 @@
+module imports.test72a;
+public import imports.test72b;

--- a/test/compilable/imports/test72b.d
+++ b/test/compilable/imports/test72b.d
@@ -1,0 +1,2 @@
+module imports.test72b;
+private import imports.test72c : foo;

--- a/test/compilable/imports/test72c.d
+++ b/test/compilable/imports/test72c.d
@@ -1,0 +1,5 @@
+module imports.test72c;
+
+void foo()
+{
+}

--- a/test/compilable/test72.d
+++ b/test/compilable/test72.d
@@ -1,0 +1,8 @@
+module test72;
+
+import imports.test72a, imports.test72c;
+
+void bar()
+{
+    foo();
+}


### PR DESCRIPTION
...which is known to be awfully broken but sets us back to 2.057.
- Explicitly set the protection of the selective aliases to public.
  This is needed because we formerly didn't had alias protection.
  But now selective imports with explicit private protection fail
  access checks in ScopeDsymbol::search before merging them into
  overload sets.
