### PR TITLE
fix 7494 - selective imports in function scope

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -559,7 +559,7 @@ int AliasDeclaration::overloadInsert(Dsymbol *s)
      */
 
     //printf("AliasDeclaration::overloadInsert('%s')\n", s->toChars());
-    if (aliassym) // see test/test56.d
+    if (aliassym) // see test/runnable/test61.d
     {
         Dsymbol *a = aliassym->toAlias();
         FuncDeclaration *f = a->isFuncDeclaration();

--- a/src/statement.c
+++ b/src/statement.c
@@ -5073,10 +5073,29 @@ Statement *ImportStatement::syntaxCopy()
 
 Statement *ImportStatement::semantic(Scope *sc)
 {
+    ScopeDsymbol *sds;
+    bool hasMembers;
+    for (Scope *sc2 = sc; sc2; sc2 = sc2->enclosing)
+    {   if (sc2->scopesym)
+        {
+            sds = sc2->scopesym;
+            hasMembers = !!sds->symtab;
+            if (!sds->symtab)
+                sds->symtab = new DsymbolTable();
+            break;
+        }
+    }
+
+    /* BUG: Fails to detect symbol collisions of multiple selective
+     * imports (test/fail_compilation/fail357d.d). This is because at
+     * the time we add the second alias as overnext to the first one
+     * semantic on the first one was already run.
+     *
+     */
     for (size_t i = 0; i < imports->dim; i++)
     {   Dsymbol *s = (*imports)[i];
+        hasMembers |= s->addMember(sc, sds, hasMembers);
         s->semantic(sc);
-        sc->insert(s);
     }
     return this;
 }

--- a/test/fail_compilation/fail357a.d
+++ b/test/fail_compilation/fail357a.d
@@ -1,0 +1,7 @@
+void fail357()
+{
+    enum foo { A, }
+
+    // symbol collision of enum and function
+    import imports.fail357a : foo;
+}

--- a/test/fail_compilation/fail357b.d
+++ b/test/fail_compilation/fail357b.d
@@ -1,0 +1,7 @@
+void fail357()
+{
+    // symbol collision of enum and function
+    import imports.fail357a : foo;
+
+    enum foo { A, }
+}

--- a/test/fail_compilation/fail357c.d
+++ b/test/fail_compilation/fail357c.d
@@ -1,0 +1,7 @@
+void fail357()
+{
+    // symbol collision
+    import Foo = imports.fail357a;
+    import imports.fail357b : Foo;
+    alias Foo.foo fun;
+}

--- a/test/fail_compilation/fail357d.d
+++ b/test/fail_compilation/fail357d.d
@@ -1,0 +1,10 @@
+void fail357()
+{
+    // symbol collision
+    import imports.fail357b : Foo;
+    import imports.fail357c : Foo;
+
+    static if (__traits(compiles, () { Foo foo; }))
+        pragma(msg, "FAILING TEST");
+    static assert(0);
+}

--- a/test/fail_compilation/fail4245a.d
+++ b/test/fail_compilation/fail4245a.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        void foo() {}
+    }
+    {
+        void foo() {}
+    }
+}

--- a/test/fail_compilation/fail4245b.d
+++ b/test/fail_compilation/fail4245b.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -d
+// 4245
+void fail4245()
+{
+    {
+        typedef int Foo;
+    }
+    {
+        typedef int Foo;
+    }
+}

--- a/test/fail_compilation/fail4245c.d
+++ b/test/fail_compilation/fail4245c.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        struct Foo {}
+    }
+    {
+        struct Foo {}
+    }
+}

--- a/test/fail_compilation/fail4245d.d
+++ b/test/fail_compilation/fail4245d.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        class Foo {}
+    }
+    {
+        class Foo {}
+    }
+}

--- a/test/fail_compilation/fail4245e.d
+++ b/test/fail_compilation/fail4245e.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        enum Foo { A, }
+    }
+    {
+        enum Foo { A, }
+    }
+}

--- a/test/fail_compilation/fail4245f.d
+++ b/test/fail_compilation/fail4245f.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        interface Foo { }
+    }
+    {
+        interface Foo { }
+    }
+}

--- a/test/fail_compilation/imports/fail357a.d
+++ b/test/fail_compilation/imports/fail357a.d
@@ -1,0 +1,5 @@
+module imports.fail357a;
+
+void foo()
+{
+}

--- a/test/fail_compilation/imports/fail357b.d
+++ b/test/fail_compilation/imports/fail357b.d
@@ -1,0 +1,6 @@
+module imports.fail357b;
+
+struct Foo
+{
+    static void foo() {}
+}

--- a/test/fail_compilation/imports/fail357c.d
+++ b/test/fail_compilation/imports/fail357c.d
@@ -1,0 +1,5 @@
+module inports.fail357c;
+
+struct Foo
+{
+}

--- a/test/runnable/imports/test7494a.d
+++ b/test/runnable/imports/test7494a.d
@@ -1,0 +1,6 @@
+module imports.test7494a;
+
+string foo7494()
+{
+    return "imports.test7494a.foo7494";
+}

--- a/test/runnable/imports/test7494b.d
+++ b/test/runnable/imports/test7494b.d
@@ -1,0 +1,6 @@
+module imports.test7494b;
+
+string foo7494()
+{
+    return "imports.test7494b.foo7494";
+}

--- a/test/runnable/test43.d
+++ b/test/runnable/test43.d
@@ -1,0 +1,68 @@
+// EXTRA_SOURCES: imports/test7494a.d imports/test7494b.d
+module test43;
+
+/***************************************************/
+// Bugzilla 7494
+
+string foo7494()
+{
+    return "test43.foo7494";
+}
+
+void test1()
+{
+    assert(foo7494() == "test43.foo7494");
+
+    string foo7494()
+    {
+        return "test43.test1.foo7494";
+    }
+    assert(foo7494() == "test43.test1.foo7494");
+    assert(.foo7494() == "test43.foo7494");
+    assert(test43.foo7494() == "test43.foo7494");
+
+    void nested()
+    {
+        assert(foo7494() == "test43.test1.foo7494");
+        assert(.foo7494() == "test43.foo7494");
+        assert(test43.foo7494() == "test43.foo7494");
+
+        import imports.test7494a;
+        assert(foo7494() == "imports.test7494a.foo7494");
+        assert(.foo7494() == "test43.foo7494");
+        assert(test43.foo7494() == "test43.foo7494");
+
+        import imports.test7494b : foo7494;
+        assert(foo7494() == "imports.test7494b.foo7494");
+        assert(imports.test7494b.foo7494() == "imports.test7494b.foo7494");
+        // Bugzilla 7496
+        version (none)
+            static assert(!__traits(compiles, imports.test7494b.foo7494()));
+        assert(.foo7494() == "test43.foo7494");
+        assert(test43.foo7494() == "test43.foo7494");
+    }
+    nested();
+
+    static assert(!__traits(compiles, imports.test7494a.foo7494()));
+    static assert(!__traits(compiles, imports.test7494b.foo7494()));
+
+    import imports.test7494a;
+    assert(foo7494() == "test43.test1.foo7494");
+    assert(imports.test7494a.foo7494() == "imports.test7494a.foo7494");
+    assert(.foo7494() == "test43.foo7494");
+    assert(test43.foo7494() == "test43.foo7494");
+
+    import imports.test7494b : foo7494;
+    // ambiguous test43.test1.foo7494 and imports.test7494b.foo7494 overload
+    static assert(!__traits(compiles, foo7494()));
+    assert(imports.test7494a.foo7494() == "imports.test7494a.foo7494");
+    assert(.foo7494() == "test43.foo7494");
+    assert(test43.foo7494() == "test43.foo7494");
+}
+
+/***************************************************/
+
+void main()
+{
+    test1();
+}


### PR DESCRIPTION
- Add all import symbols to the function scope
  using Import::addMember.
- There are additional tests for an older bugfix of 4245
  because I had to understand the localsymtab purpose.

There is one corner case of colliding selective imports with non-overloadable
symbols. Because it involves touching the alias overload mechanism I'd
rather treat it as a separate bug later.
