### PR TITLE
fix issue 6738 revisited

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2633,6 +2633,8 @@ DsymbolExp::DsymbolExp(Loc loc, Dsymbol *s, int hasOverloads)
     this->hasOverloads = hasOverloads;
 }
 
+AggregateDeclaration *isAggregate(Type *t);
+
 Expression *DsymbolExp::semantic(Scope *sc)
 {
 #if LOGSEMANTIC
@@ -2833,12 +2835,14 @@ Lagain:
     TemplateDeclaration *td = s->isTemplateDeclaration();
     if (td)
     {
-#if 0 // This was the fix for Bugzilla 6738, but it breaks 7498
         Dsymbol *p = td->toParent2();
-        if (hasThis(sc) && p && p->isAggregateDeclaration())
+        FuncDeclaration *fdthis = hasThis(sc);
+        AggregateDeclaration *ad = p ? p->isAggregateDeclaration() : NULL;
+        if (fdthis && ad && isAggregate(fdthis->vthis->type) == ad)
+        {
             e = new DotTemplateExp(loc, new ThisExp(loc), td);
+        }
         else
-#endif
             e = new TemplateExp(loc, td);
         e = e->semantic(sc);
         return e;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -585,8 +585,6 @@ static assert(is(T6805.xxx.Type == int));
 /**********************************/
 // 6738
 
-version (none)
-{
 struct Foo6738
 {
     int _val = 10;
@@ -602,9 +600,6 @@ void test6738()
     assert(x == 10);
     assert(foo.get() == 10);
 }
-}
-else
-    void test6738() { }
 
 /**********************************/
 // 7498


### PR DESCRIPTION
Translate TemplateDeclaration(td) to this.td only when 'this' belongs to td->toParent2(). Other cases (e.g. this.outer.td) are captured by TypeClass::dotExp before.
