### PR TITLE
Issue 4536 - Typetuples (T...) should have an .init member

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8538,12 +8538,32 @@ Expression *TypeTuple::getProperty(Loc loc, Identifier *ident)
     {
         e = new IntegerExp(loc, arguments->dim, Type::tsize_t);
     }
+    else if (ident == Id::init)
+    {
+        e = defaultInitLiteral(loc);
+    }
     else
     {
         error(loc, "no property '%s' for tuple '%s'", ident->toChars(), toChars());
         e = new ErrorExp();
     }
     return e;
+}
+
+Expression *TypeTuple::defaultInit(Loc loc)
+{
+    Expressions *exps = new Expressions();
+    exps->setDim(arguments->dim);
+    for (size_t i = 0; i < arguments->dim; i++)
+    {
+        Parameter *p = (*arguments)[i];
+        assert(p->type);
+        Expression *e = p->type->defaultInitLiteral(loc);
+        if (e->op == TOKerror)
+            return e;
+        (*exps)[i] = e;
+    }
+    return new TupleExp(loc, exps);
 }
 
 /***************************** TypeSlice *****************************/

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -915,6 +915,7 @@ struct TypeTuple : Type
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toDecoBuffer(OutBuffer *buf, int flag);
     Expression *getProperty(Loc loc, Identifier *ident);
+    Expression *defaultInit(Loc loc);
     TypeInfoDeclaration *getTypeInfoDeclaration();
 };
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3534,6 +3534,18 @@ void test6295() {
 
 /***************************************************/
 
+template TT4536(T...) { alias T TT4536; }
+
+void test4536()
+{
+    auto x = TT4536!(int, long, [1, 2]).init;
+    assert(x[0] is int.init);
+    assert(x[1] is long.init);
+    assert(x[2] is [1, 2].init);
+}
+
+/***************************************************/
+
 struct S6284 {
     int a;
 }
@@ -4556,6 +4568,7 @@ int main()
     test90();
     test91();
     test92();
+    test4536();
     test93();
     test94();
     test95();


### PR DESCRIPTION
Transform `TT!(T, U, V, ...).init` to `TT!(T.init, U.init, V.init, ...)`

http://d.puremagic.com/issues/show_bug.cgi?id=4536
