### PR TITLE
Issue 3279 - Confusing error message when comparing types

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5930,9 +5930,18 @@ Expression *BinExp::incompatibleTypes()
     if (e1->type->toBasetype() != Type::terror &&
         e2->type->toBasetype() != Type::terror
        )
-    {   error("incompatible types for ((%s) %s (%s)): '%s' and '%s'",
-             e1->toChars(), Token::toChars(op), e2->toChars(),
-             e1->type->toChars(), e2->type->toChars());
+    {
+        if (e1->op == TOKtype || e2->op == TOKtype)
+        {
+            error("incompatible types for ((%s) %s (%s)): cannot use '%s' with types",
+                e1->toChars(), Token::toChars(op), e2->toChars(), Token::toChars(op));
+        }
+        else
+        {
+            error("incompatible types for ((%s) %s (%s)): '%s' and '%s'",
+                 e1->toChars(), Token::toChars(op), e2->toChars(),
+                 e1->type->toChars(), e2->type->toChars());
+        }
         return new ErrorExp();
     }
     return this;


### PR DESCRIPTION
If the binary operation fails because one or both of the operands are types, the error message is not as helpful as it could be.

http://d.puremagic.com/issues/show_bug.cgi?id=3279
