### PR TITLE
Issue 3632 - modify float is float to do a bitwise compare

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -204,6 +204,9 @@ int StructDeclaration::needOpEquals()
     if (hasIdentityEquals)
         goto Lneed;
 
+    if (isUnionDeclaration())
+        goto Ldontneed;
+
     /* If any of the fields has an opEquals, then we
      * need it too.
      */
@@ -215,6 +218,12 @@ int StructDeclaration::needOpEquals()
         if (v->storage_class & STCref)
             continue;
         Type *tv = v->type->toBasetype();
+        if (tv->isfloating())
+            goto Lneed;
+        if (tv->ty == Tarray)
+            goto Lneed;
+        if (tv->ty == Tclass)
+            goto Lneed;
         while (tv->ty == Tsarray)
         {   TypeSArray *ta = (TypeSArray *)tv;
             tv = tv->nextOf()->toBasetype();
@@ -226,6 +235,7 @@ int StructDeclaration::needOpEquals()
                 goto Lneed;
         }
     }
+Ldontneed:
     if (X) printf("\tdontneed\n");
     return 0;
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2454,7 +2454,37 @@ elem *IdentityExp::toElem(IRState *irs)
 
     //printf("IdentityExp::toElem() %s\n", toChars());
 
-    if (t1->ty == Tstruct || t1->isfloating())
+    if (t1->ty == Tcomplex80 && REALPAD != 0)
+    {
+        /* creal has padding in the middle on some platforms,
+         * so do identity comparison on real and imaginary parts
+         * separately.
+         */
+        symbol *s1 = symbol_genauto(t1->toCtype());
+        symbol *s2 = symbol_genauto(t2->toCtype());
+        elem *el1 = e1->toElem(irs);
+        elem *el2 = e2->toElem(irs);
+        elem *ed1 = el_bin(OPeq, TYcldouble, el_var(s1), el1);
+        elem *ed2 = el_bin(OPeq, TYcldouble, el_var(s2), el2);
+
+        elem *e1a = addressElem(ed1, Type::tcomplex80);
+        elem *e2a = addressElem(ed2, Type::tcomplex80);
+        elem *ecount1 = el_long(TYsize_t, REALSIZE - REALPAD);
+        elem *ec1 = el_bin(OPmemcmp, TYint, el_param(e1a, e2a), ecount1);
+        ec1 = el_bin(eop, TYint, ec1, el_long(TYint, 0));
+
+        e1a = el_bin(OPadd, e1a->Ety, addressElem(el_var(s1), Type::tcomplex80), el_long(TYsize_t, REALSIZE));
+        e2a = el_bin(OPadd, e2a->Ety, addressElem(el_var(s2), Type::tcomplex80), el_long(TYsize_t, REALSIZE));
+        elem *ecount2 = el_long(TYsize_t, REALSIZE - REALPAD);
+        elem *ec2 = el_bin(OPmemcmp, TYint, el_param(e1a, e2a ), ecount2);
+        ec2 = el_bin(eop, TYint, ec2, el_long(TYint, 0));
+
+        enum OPER xop = (op == TOKidentity) ? OPandand : OPoror;
+
+        e = el_bin(xop, TYint, ec1, ec2);
+        el_setLoc(e,loc);
+    }
+    else if (t1->ty == Tstruct || t1->isfloating())
     {   // Do bit compare of struct's
         elem *es1;
         elem *es2;
@@ -2467,7 +2497,10 @@ elem *IdentityExp::toElem(IRState *irs)
         es2 = addressElem(es2, e2->type);
         //es2 = el_una(OPaddr, TYnptr, es2);
         e = el_param(es1, es2);
-        ecount = el_long(TYsize_t, t1->size());
+        if (t1->ty == Tfloat80 || t1->ty == Timaginary80)
+            ecount = el_long(TYsize_t, t1->size() - REALPAD);
+        else
+            ecount = el_long(TYsize_t, t1->size());
         e = el_bin(OPmemcmp, TYint, e, ecount);
         e = el_bin(eop, TYint, e, el_long(TYint, 0));
         el_setLoc(e,loc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -2197,11 +2197,10 @@ complex_t RealExp::toComplex()
 
 int RealEquals(real_t x1, real_t x2)
 {
-    return (Port::isNan(x1) && Port::isNan(x2)) ||
-        /* In some cases, the REALPAD bytes get garbage in them,
-         * so be sure and ignore them.
-         */
-        memcmp(&x1, &x2, REALSIZE - REALPAD) == 0;
+    /* In some cases, the REALPAD bytes get garbage in them,
+     * so be sure and ignore them.
+     */
+    return memcmp(&x1, &x2, REALSIZE - REALPAD) == 0;
 }
 
 int RealExp::equals(Object *o)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -435,6 +435,79 @@ void test21()
 
 /***************************************************/
 
+template TT3632(T...) { alias T TT3632; }
+
+void test3632()
+{
+    __gshared static int global;
+    if (!__ctfe)
+    { // defeat optimizer/constfolding
+        asm { mov global, 1; }
+    }
+
+    int test(T)()
+    {
+        static struct W
+        {
+            T f;
+            this(T g) { if (__ctfe || global) f = g; }
+        }
+        auto nan = W(T.nan);
+        auto nan2 = W(T.nan);
+        auto init = W(T.init);
+        auto init2 = W(T.init);
+        auto zero = W(cast(T)0);
+        auto zero2 = W(cast(T)0);
+        auto nzero2 = W(-cast(T)0);
+
+        assert(!(nan == nan2));
+        assert(!(nan == init2));
+        assert(!(init == init2));
+        assert( (zero == zero2));
+        assert( (zero == nzero2));
+
+        assert(!(nan.f == nan2.f));
+        assert(!(nan.f == init2.f));
+        assert(!(init.f == init2.f));
+        assert( (zero.f == zero2.f));
+        assert( (zero.f == nzero2.f));
+
+        assert( (nan is nan2));
+        assert(!(nan is init2));
+        assert( (init is init2));
+        assert( (zero is zero2));
+        assert(!(zero is nzero2));
+
+        assert( (nan.f is nan2.f));
+        assert(!(nan.f is init2.f));
+        assert( (init.f is init2.f));
+        assert( (zero.f is zero2.f));
+        assert(!(zero.f is nzero2.f));
+
+        assert(!(nan !is nan2));
+        assert( (nan !is init2));
+        assert(!(init !is init2));
+        assert(!(zero !is zero2));
+        assert( (zero !is nzero2));
+
+        assert(!(nan.f !is nan2.f));
+        assert( (nan.f !is init2.f));
+        assert(!(init.f !is init2.f));
+        assert(!(zero.f !is zero2.f));
+        assert( (zero.f !is nzero2.f));
+
+        return 1;
+    }
+
+    foreach(T; TT3632!(float, double, real, ifloat, idouble, ireal, cfloat, cdouble, creal))
+    {
+        auto x = test!T();
+        enum y = test!T();
+    }
+}
+
+/***************************************************/
+
 void test22()
 {
     immutable uint x, y;
@@ -4599,6 +4672,7 @@ int main()
     test129();
     test130();
     test131();
+    test3632();
     test132();
     test133();
     test134();


### PR DESCRIPTION
Make 'is' between floats and structs containing floats consistent at run-time and compile-time.

This fixes the padding issue of the previous fix.

http://d.puremagic.com/issues/show_bug.cgi?id=3632

@9rnsr This includes your fix for 3789 from pull #387 - if you can put those changes into a single commit I'll rebase on top of that instead of copying your fix.
