### PR TITLE
Fix bug 7399: Broken import statement in trySemantic() causes silent compiler error

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -113,10 +113,13 @@ void Import::load(Scope *sc)
     {
         // Load module
         mod = Module::load(loc, packages, id);
-        dst->insert(id, mod);           // id may be different from mod->ident,
-                                        // if so then insert alias
-        if (!mod->importedFrom)
-            mod->importedFrom = sc ? sc->module->importedFrom : Module::rootModule;
+        if (mod)
+        {
+            dst->insert(id, mod);           // id may be different from mod->ident,
+                                            // if so then insert alias
+            if (!mod->importedFrom)
+                mod->importedFrom = sc ? sc->module->importedFrom : Module::rootModule;
+        }
     }
     if (!pkg)
         pkg = mod;
@@ -167,7 +170,8 @@ void Import::semantic(Scope *sc)
     // Load if not already done so
     if (!mod)
     {   load(sc);
-        mod->importAll(0);
+        if (mod)
+            mod->importAll(0);
     }
 
     if (mod)

--- a/src/module.c
+++ b/src/module.c
@@ -342,7 +342,9 @@ Module *Module::load(Loc loc, Identifiers *packages, Identifier *ident)
         printf("%s\t(%s)\n", ident->toChars(), m->srcfile->toChars());
     }
 
-    m->read(loc);
+    if (!m->read(loc))
+        return NULL;
+
     m->parse();
 
 #ifdef IN_GCC
@@ -352,7 +354,7 @@ Module *Module::load(Loc loc, Identifiers *packages, Identifier *ident)
     return m;
 }
 
-void Module::read(Loc loc)
+bool Module::read(Loc loc)
 {
     //printf("Module::read('%s') file '%s'\n", toChars(), srcfile->toChars());
     if (srcfile->read())
@@ -370,9 +372,11 @@ void Module::read(Loc loc)
             }
             else
                 fprintf(stdmsg, "Specify path to file '%s' with -I switch\n", srcfile->toChars());
+            fatal();
         }
-        fatal();
+        return false;
     }
+    return true;
 }
 
 inline unsigned readwordLE(unsigned short *p)

--- a/src/module.h
+++ b/src/module.h
@@ -120,7 +120,7 @@ struct Module : Package
     void toJsonBuffer(OutBuffer *buf);
     const char *kind();
     void setDocfile();  // set docfile member
-    void read(Loc loc); // read file
+    bool read(Loc loc); // read file, returns 'true' if succeed, 'false' otherwise.
 #if IN_GCC
     void parse(bool dump_source = false);       // syntactic parse
 #else

--- a/test/compilable/test7399.d
+++ b/test/compilable/test7399.d
@@ -1,0 +1,6 @@
+// 7399
+static assert(!__traits(compiles, { import non.existing.file; }));
+
+// 7400
+static assert(!is(typeof({import non_existing_file;})));
+


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7399

This patch is a hack. It make `Module::read()` not to call `fatal()` when the system is gagging, and make `Module::load()` return NULL when read failed. Some null-checks are introduced in several other places as a result.

Proper fix would require exceptions be enabled (by using a `throw` statement instead of `exit(EXIT_FAILURE)` in `fatal()`) and incorporate RAII, which would be too difficult to change at this stage.
