### PR TITLE
remove recursive alias in test case

### DIFF
--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -554,7 +554,6 @@ void test23()
 template T24()
 {
    void foo24() { return cast(void)0; }
-   alias foo24 foo24;
 }
 
 mixin T24;


### PR DESCRIPTION
This is an accepts-invalid bug, isn't it?
