### PR TITLE
Fix protection/imports

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -412,3 +412,13 @@ void accessCheck(Loc loc, Scope *sc, Dsymbol *s, bool overloads)
         error(loc, "%s %s is not accessible from module %s",
               s->kind(), s->toPrettyChars(), sc->module->toChars());
 }
+
+enum PROT moduleVisibility(Module *from, Module *to)
+{
+    if (from == to)
+        return PROTprivate;
+    else if (from && to && from->parent && from->parent == to->parent)
+        return PROTpackage;
+    else
+        return PROTpublic;
+}

--- a/src/access.c
+++ b/src/access.c
@@ -413,6 +413,12 @@ void accessCheck(Loc loc, Scope *sc, Dsymbol *s, bool overloads)
               s->kind(), s->toPrettyChars(), sc->module->toChars());
 }
 
+const char *protectionToChars(enum PROT prot)
+{
+    static const char *names[] = {"", "none", "private", "package", "protected", "public", "export"};
+    return names[prot];
+}
+
 enum PROT moduleVisibility(Module *from, Module *to)
 {
     if (from == to)

--- a/src/access.c
+++ b/src/access.c
@@ -289,24 +289,27 @@ int hasPackageAccess(Scope *sc, Dsymbol *s)
     printf("hasPackageAccess(s = '%s', sc = '%p')\n", s->toChars(), sc);
 #endif
 
-    for (; s; s = s->parent)
-    {
-        if (s->isPackage() && !s->isModule())
-            break;
-    }
+    s = s->getAccessModule();
+
 #if LOG
     if (s)
         printf("\tthis is in package '%s'\n", s->toChars());
 #endif
 
-    if (s && s == sc->module->parent)
+    if (s && s->parent == sc->module->parent)
     {
 #if LOG
         printf("\ts is in same package as sc\n");
 #endif
         return 1;
     }
-
+    else if (s == sc->module)
+    {
+#if LOG
+        printf("\ts is same module as sc\n");
+#endif
+        return 1;
+    }
 
 #if LOG
     printf("\tno package access\n");
@@ -372,28 +375,14 @@ int AggregateDeclaration::hasPrivateAccess(Dsymbol *smember)
  * Check access to d for expression e.d
  */
 
-void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
+void accessCheck(Loc loc, Scope *sc, Expression *e, Dsymbol *s)
 {
+    assert(e);
 #if LOG
-    if (e)
-    {   printf("accessCheck(%s . %s)\n", e->toChars(), d->toChars());
-        printf("\te->type = %s\n", e->type->toChars());
-    }
-    else
-    {
-        printf("accessCheck(%s)\n", d->toPrettyChars());
-    }
+    printf("accessCheck(%s . %s)\n", e->toChars(), s->toChars());
+    printf("\te->type = %s\n", e->type->toChars());
 #endif
-    if (!e)
-    {
-        if (d->prot() == PROTprivate && d->getAccessModule() != sc->module ||
-            d->prot() == PROTpackage && !hasPackageAccess(sc, d))
-        {
-            error(loc, "%s %s is not accessible from module %s",
-                d->kind(), d->toPrettyChars(), sc->module->toChars());
-        }
-    }
-    else if (e->type->ty == Tclass)
+    if (e->type->ty == Tclass)
     {   // Do access check
         ClassDeclaration *cd = (ClassDeclaration *)(((TypeClass *)e->type)->sym);
         if (e->op == TOKsuper)
@@ -402,11 +391,24 @@ void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
             if (cd2)
                 cd = cd2;
         }
-        cd->accessCheck(loc, sc, d);
+        cd->accessCheck(loc, sc, s);
     }
     else if (e->type->ty == Tstruct)
     {   // Do access check
         StructDeclaration *cd = (StructDeclaration *)(((TypeStruct *)e->type)->sym);
-        cd->accessCheck(loc, sc, d);
+        cd->accessCheck(loc, sc, s);
     }
+}
+
+void accessCheck(Loc loc, Scope *sc, Dsymbol *s, bool overloads)
+{
+#if LOG
+    printf("accessCheck(%s)\n", s->toPrettyChars());
+#endif
+    enum PROT prot = overloads ? s->overprot() : s->prot();
+    if ((prot == PROTprivate || prot == PROTpackage && !hasPackageAccess(sc, s)) &&
+        s->getAccessModule() != sc->module)
+
+        error(loc, "%s %s is not accessible from module %s",
+              s->kind(), s->toPrettyChars(), sc->module->toChars());
 }

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -667,22 +667,12 @@ void ProtDeclaration::semantic(Scope *sc)
     }
 }
 
-void ProtDeclaration::protectionToCBuffer(OutBuffer *buf, enum PROT protection)
+void ProtDeclaration::protectionToCBuffer(OutBuffer *buf, enum PROT prot)
 {
     const char *p;
 
-    switch (protection)
-    {
-        case PROTprivate:       p = "private";          break;
-        case PROTpackage:       p = "package";          break;
-        case PROTprotected:     p = "protected";        break;
-        case PROTpublic:        p = "public";           break;
-        case PROTexport:        p = "export";           break;
-        default:
-            assert(0);
-            break;
-    }
-    buf->writestring(p);
+    assert(prot != PROTundefined);
+    buf->writestring(protectionToChars(prot));
     buf->writeByte(' ');
 }
 

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -560,7 +560,7 @@ int AliasDeclaration::overloadInsert(Dsymbol *s)
      */
 
     //printf("AliasDeclaration::overloadInsert('%s')\n", s->toChars());
-    if (aliassym) // see test/test56.d
+    if (aliassym) // see test/runnable/test61.d
     {
         Dsymbol *a = aliassym->toAlias();
         FuncDeclaration *f = a->isFuncDeclaration();

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -274,6 +274,7 @@ void TypedefDeclaration::semantic(Scope *sc)
     if (sem == SemanticStart)
     {   sem = SemanticIn;
         parent = sc->parent;
+        protection = sc->protection;
         int errors = global.errors;
         Type *savedbasetype = basetype;
         basetype = basetype->semantic(loc, sc);

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -658,6 +658,7 @@ struct FuncDeclaration : Declaration
     int canInline(int hasthis, int hdrscan, int statementsToo);
     Expression *expandInline(InlineScanState *iss, Expression *ethis, Expressions *arguments, Statement **ps);
     const char *kind();
+    enum PROT overprot();
     void toDocBuffer(OutBuffer *buf);
     FuncDeclaration *isUnique();
     void checkNestedReference(Scope *sc, Loc loc);

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -696,6 +696,11 @@ enum PROT Dsymbol::prot()
     return PROTpublic;
 }
 
+enum PROT Dsymbol::overprot()
+{
+    return prot();
+}
+
 /*************************************
  * Do syntax copy of an array of Dsymbol's.
  */
@@ -890,15 +895,6 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
         {   assert(s);
             a->push(s);
             s = a;
-        }
-
-        if (s)
-        {
-            Declaration *d = s->isDeclaration();
-            if (d && d->protection == PROTprivate &&
-                !d->parent->isTemplateMixin() &&
-                !(flags & 2))
-                error(loc, "%s is private", d->toPrettyChars());
         }
     }
     return s;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -339,7 +339,7 @@ void Dsymbol::inlineScan()
 /*********************************************
  * Search for ident as member of s.
  * Input:
- *      flags:  1       don't find private members
+ *      flags:  1       don't restrict visibility
  *              2       don't give error messages
  *              4       return NULL if ambiguous
  * Returns:
@@ -806,27 +806,49 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
     // Look in symbols declared in this module
     Dsymbol *s = symtab ? symtab->lookup(ident) : NULL;
     //printf("\ts = %p, imports = %p, %d\n", s, imports, imports ? imports->dim : 0);
-    if (s)
-    {
-        //printf("\ts = '%s.%s'\n",toChars(),s->toChars());
-    }
-    else if (imports)
+    if (!s)
+        s = searchImports(loc, ident, flags, PROTprivate);
+    return s;
+}
+
+/* Search the imports for symbol ident.
+ * Parameter:
+ *      loc, ident, flags - as Dsymbol::search
+ *      access            - restricts the visibility if != PROTundefined
+ * Returns:
+ *      NULL if not found
+ */
+Dsymbol *ScopeDsymbol::searchImports(Loc loc, Identifier *ident, int flags, enum PROT visibility)
+{
+    Dsymbol *s = NULL;
+    if (imports)
     {
         OverloadSet *a = NULL;
+        Module *thisModule = NULL;
 
         // Look in imported modules
         for (size_t i = 0; i < imports->dim; i++)
         {   Dsymbol *ss = (*imports)[i];
             Dsymbol *s2;
 
-            // If private import, don't search it
-            if (flags & 1 && prots[i] == PROTprivate)
+            // If restricted import, don't search it
+            if (!(flags & 1) && prots[i] < visibility)
                 continue;
 
             //printf("\tscanning import '%s', prots = %d, isModule = %p, isImport = %p\n", ss->toChars(), prots[i], ss->isModule(), ss->isImport());
-            /* Don't find private members if ss is a module
-             */
-            s2 = ss->search(loc, ident, ss->isModule() ? 1 : 0);
+            Module *m;
+            if (!(flags & 1) && (m = ss->isModule()))
+            {
+                if (!thisModule)
+                    thisModule = getAccessModule();
+                enum PROT mvisibility = moduleVisibility(thisModule, m);
+                if (mvisibility < visibility) // restrict visibility
+                    mvisibility = visibility;
+                s2 = m->search(loc, ident, flags, mvisibility);
+            }
+            else
+                s2 = ss->search(loc, ident, flags);
+
             if (!s)
                 s = s2;
             else if (s2 && s != s2)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -262,6 +262,7 @@ struct ScopeDsymbol : Dsymbol
     ScopeDsymbol(Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
+    Dsymbol *searchImports(Loc loc, Identifier *ident, int flags, enum PROT visibility);
     void importScope(Dsymbol *s, enum PROT protection);
     int isforwardRef();
     void defineRef(Dsymbol *s);

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -96,6 +96,9 @@ enum PROT
     PROTexport,
 };
 
+// access.c
+const char *protectionToChars(enum PROT prot);
+
 /* State of symbol in winding its way through the passes of the compiler
  */
 enum PASS
@@ -180,6 +183,7 @@ struct Dsymbol : Object
     virtual int needThis();                     // need a 'this' pointer?
     virtual enum PROT prot();
     virtual enum PROT overprot();
+    const char *protChars() { return protectionToChars(prot()); }
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     virtual int oneMember(Dsymbol **ps, Identifier *ident);
     static int oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident = NULL);

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -179,6 +179,7 @@ struct Dsymbol : Object
     virtual char *mangle();
     virtual int needThis();                     // need a 'this' pointer?
     virtual enum PROT prot();
+    virtual enum PROT overprot();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     virtual int oneMember(Dsymbol **ps, Identifier *ident);
     static int oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident = NULL);

--- a/src/enum.c
+++ b/src/enum.c
@@ -33,6 +33,7 @@ EnumDeclaration::EnumDeclaration(Loc loc, Identifier *id, Type *memtype)
     sinit = NULL;
     isdeprecated = 0;
     isdone = 0;
+    protection = PROTpublic;
 }
 
 Dsymbol *EnumDeclaration::syntaxCopy(Dsymbol *s)
@@ -113,7 +114,7 @@ void EnumDeclaration::semantic(Scope *sc)
 
     if (sc->stc & STCdeprecated)
         isdeprecated = 1;
-
+    protection = sc->protection;
     parent = sc->parent;
 
     /* The separate, and distinct, cases are:
@@ -348,6 +349,11 @@ Type *EnumDeclaration::getType()
 const char *EnumDeclaration::kind()
 {
     return "enum";
+}
+
+enum PROT EnumDeclaration::prot()
+{
+    return protection;
 }
 
 int EnumDeclaration::isDeprecated()

--- a/src/enum.h
+++ b/src/enum.h
@@ -42,6 +42,7 @@ struct EnumDeclaration : ScopeDsymbol
     int isdeprecated;
     int isdone;                 // 0: not done
                                 // 1: semantic() successfully completed
+    enum PROT protection;
 
     EnumDeclaration(Loc loc, Identifier *id, Type *memtype);
     Dsymbol *syntaxCopy(Dsymbol *s);
@@ -51,6 +52,7 @@ struct EnumDeclaration : ScopeDsymbol
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Type *getType();
     const char *kind();
+    enum PROT prot();
 #if DMDV2
     Dsymbol *search(Loc, Identifier *ident, int flags);
 #endif

--- a/src/expression.c
+++ b/src/expression.c
@@ -6418,12 +6418,15 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
     {
         ScopeExp *ie = (ScopeExp *)eright;
 
-        /* Disable access to another module's private imports.
-         * The check for 'is sds our current module' is because
-         * the current module should have access to its own imports.
+        /* Restrict access to another module's symbols.
          */
-        Dsymbol *s = ie->sds->search(loc, ident,
-            (ie->sds->isModule() && ie->sds != sc->module) ? 1 : 0);
+        Dsymbol *s;
+        if (Module *m = ie->sds->isModule())
+        {   enum PROT visibility = moduleVisibility(sc->module, m);
+            s = m->search(loc, ident, 0, visibility);
+        }
+        else
+            s = ie->sds->search(loc, ident, 0);
         if (s)
         {
             /* Check for access before resolving aliases because public

--- a/src/expression.c
+++ b/src/expression.c
@@ -2578,7 +2578,8 @@ Expression *IdentifierExp::semantic(Scope *sc)
     {
         s = sc->search_correct(ident);
         if (s)
-            error("undefined identifier %s, did you mean %s %s?", ident->toChars(), s->kind(), s->toChars());
+            error("undefined identifier %s, did you mean %s %s %s?",
+                  ident->toChars(), s->protChars(), s->kind(), s->toPrettyChars());
         else
             error("undefined identifier %s", ident->toChars());
     }

--- a/src/expression.h
+++ b/src/expression.h
@@ -65,7 +65,8 @@ void initPrecedence();
 typedef int (*apply_fp_t)(Expression *, void *);
 
 Expression *resolveProperties(Scope *sc, Expression *e);
-void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d);
+void accessCheck(Loc loc, Scope *sc, Expression *e, Dsymbol *s);
+void accessCheck(Loc loc, Scope *sc, Dsymbol *s, bool overloads);
 Expression *build_overload(Loc loc, Scope *sc, Expression *ethis, Expression *earg, Dsymbol *d);
 Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid);
 void argExpTypesToCBuffer(OutBuffer *buf, Expressions *arguments, HdrGenState *hgs);

--- a/src/func.c
+++ b/src/func.c
@@ -2959,6 +2959,21 @@ const char *FuncDeclaration::kind()
     return "function";
 }
 
+static int maxProt(void *arg, FuncDeclaration *f)
+{
+    enum PROT nprot = f->prot();
+    if (nprot > *(enum PROT*)arg) // take looser one
+        *(enum PROT*)arg = nprot;
+    return 0;
+}
+
+enum PROT FuncDeclaration::overprot()
+{
+    enum PROT result = prot();
+    overloadApply(this, &maxProt, &result);
+    return result;
+}
+
 void FuncDeclaration::checkNestedReference(Scope *sc, Loc loc)
 {
     //printf("FuncDeclaration::checkNestedReference() %s\n", toChars());

--- a/src/import.c
+++ b/src/import.c
@@ -361,8 +361,15 @@ Dsymbol *Import::search(Loc loc, Identifier *ident, int flags)
 
 int Import::overloadInsert(Dsymbol *s)
 {
-    // Allow multiple imports of the same name
-    return s->isImport() != NULL;
+    /* Allow multiple imports with the same package base, but disallow
+     * alias collisions (Bugzilla 5412).
+     */
+    assert(ident && ident == s->ident);
+    Import *imp;
+    if (!aliasId && (imp = s->isImport()) && !imp->aliasId)
+        return TRUE;
+    else
+        return FALSE;
 }
 
 void Import::toCBuffer(OutBuffer *buf, HdrGenState *hgs)

--- a/src/import.c
+++ b/src/import.c
@@ -151,12 +151,10 @@ void Import::importAll(Scope *sc)
        load(sc);
        mod->importAll(0);
 
+       if (sc->explicitProtection)
+           protection = sc->protection;
        if (!isstatic && !aliasId && !names.dim)
-       {
-           if (sc->explicitProtection)
-               protection = sc->protection;
            sc->scopesym->importScope(mod, protection);
-       }
     }
 }
 
@@ -186,10 +184,10 @@ void Import::semantic(Scope *sc)
         //printf("%s imports %s\n", sc->module->toChars(), mod->toChars());
         sc->module->aimports.push(mod);
 
+        if (sc->explicitProtection)
+            protection = sc->protection;
         if (!isstatic && !aliasId && !names.dim)
         {
-            if (sc->explicitProtection)
-                protection = sc->protection;
             for (Scope *scd = sc; scd; scd = scd->enclosing)
             {
                 if (scd->scopesym)
@@ -208,19 +206,15 @@ void Import::semantic(Scope *sc)
         }
 
         sc = sc->push(mod);
-        /* BUG: Protection checks can't be enabled yet. The issue is
-         * that Dsymbol::search errors before overload resolution.
-         */
-#if 0
+
         sc->protection = protection;
-#else
-        sc->protection = PROTpublic;
-#endif
+        enum PROT visibility = moduleVisibility(getAccessModule(), mod);
         for (size_t i = 0; i < aliasdecls.dim; i++)
         {   Dsymbol *s = aliasdecls.tdata()[i];
 
             //printf("\tImport alias semantic('%s')\n", s->toChars());
-            if (!mod->search(loc, names.tdata()[i], 0))
+            if (!mod->search(loc, names.tdata()[i], 0, visibility))
+                // Bug: NEEDS_SEARCH_CORRECT
                 error("%s not found", (names.tdata()[i])->toChars());
 
             s->semantic(sc);

--- a/src/import.c
+++ b/src/import.c
@@ -210,14 +210,20 @@ void Import::semantic(Scope *sc)
         sc->protection = protection;
         enum PROT visibility = moduleVisibility(getAccessModule(), mod);
         for (size_t i = 0; i < aliasdecls.dim; i++)
-        {   Dsymbol *s = aliasdecls.tdata()[i];
+        {   Dsymbol *s = aliasdecls[i];
 
             //printf("\tImport alias semantic('%s')\n", s->toChars());
-            if (!mod->search(loc, names.tdata()[i], 0, visibility))
-                // Bug: NEEDS_SEARCH_CORRECT
-                error("%s not found", (names.tdata()[i])->toChars());
-
-            s->semantic(sc);
+            if (mod->search(loc, names[i], 0, visibility))
+                s->semantic(sc);
+            else
+            {
+                s = mod->search_correct(names[i]);
+                if (s)
+                    mod->error(loc, "import %s not found, did you mean %s %s %s?",
+                          names[i]->toChars(), s->protChars(), s->kind(), s->toPrettyChars());
+                else
+                    mod->error(loc, "import %s not found", names[i]->toChars());
+            }
         }
         sc = sc->pop();
     }

--- a/src/json.c
+++ b/src/json.c
@@ -44,7 +44,6 @@ const char Ptype[] = "type";
 const char Pcomment[] = "comment";
 const char Pmembers[] = "members";
 const char Pprotection[] = "protection";
-const char* Pprotectionnames[] = {NULL, "none", "private", "package", "protected", "public", "export"};
 
 void JsonRemoveComma(OutBuffer *buf);
 
@@ -263,7 +262,7 @@ void Declaration::toJsonBuffer(OutBuffer *buf)
     JsonProperty(buf, Pkind, kind());
 
     if (prot())
-        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+        JsonProperty(buf, Pprotection, protectionToChars(prot()));
 
     if (type)
         JsonProperty(buf, Ptype, type->toChars());
@@ -293,7 +292,7 @@ void AggregateDeclaration::toJsonBuffer(OutBuffer *buf)
     JsonProperty(buf, Pkind, kind());
 
     if (prot())
-        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+        JsonProperty(buf, Pprotection, protectionToChars(prot()));
 
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);
@@ -357,7 +356,7 @@ void TemplateDeclaration::toJsonBuffer(OutBuffer *buf)
     JsonProperty(buf, Pkind, kind());
 
     if (prot())
-        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+        JsonProperty(buf, Pprotection, protectionToChars(prot()));
 
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);
@@ -406,7 +405,7 @@ void EnumDeclaration::toJsonBuffer(OutBuffer *buf)
     JsonProperty(buf, Pkind, kind());
 
     if (prot())
-        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+        JsonProperty(buf, Pprotection, protectionToChars(prot()));
 
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);
@@ -447,7 +446,7 @@ void EnumMember::toJsonBuffer(OutBuffer *buf)
     JsonProperty(buf, Pkind, kind());
 
     if (prot())
-        JsonProperty(buf, Pprotection, Pprotectionnames[prot()]);
+        JsonProperty(buf, Pprotection, protectionToChars(prot()));
 
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);

--- a/src/module.h
+++ b/src/module.h
@@ -80,6 +80,7 @@ struct Module : Package
     Identifier *searchCacheIdent;
     Dsymbol *searchCacheSymbol; // cached value of search
     int searchCacheFlags;       // cached flags
+    enum PROT searchCacheVisibility;
 
     int semanticstarted;        // has semantic() been started?
     int semanticRun;            // has semantic() been done?
@@ -138,6 +139,7 @@ struct Module : Package
     void gendocfile();
     int needModuleInfo();
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
+    Dsymbol *search(Loc loc, Identifier *ident, int flags, enum PROT visibility);
     Dsymbol *symtabInsert(Dsymbol *s);
     void deleteObjFile();
     void addDeferredSemantic(Dsymbol *s);
@@ -179,6 +181,8 @@ struct Module : Package
     Module *isModule() { return this; }
 };
 
+// access.c
+enum PROT moduleVisibility(Module *from, Module *to);
 
 struct ModuleDeclaration
 {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6166,10 +6166,10 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
     {
         //printf("\t1: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
         s->checkDeprecated(loc, sc);            // check for deprecated aliases
-        s = s->toAlias();
         //printf("\t2: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
         for (size_t i = 0; i < idents.dim; i++)
         {
+            s = s->toAlias();
             Identifier *id = idents.tdata()[i];
             Dsymbol *sm = s->searchX(loc, sc, id);
             //printf("\t3: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
@@ -6224,6 +6224,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                     e = t->dotExp(sc, e, id);
                     i++;
                 L3:
+                    accessCheck(loc, sc, s, true);
                     for (; i < idents.dim; i++)
                     {
                         id = idents.tdata()[i];
@@ -6245,8 +6246,10 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                 return;
             }
         L2:
-            s = sm->toAlias();
+            s = sm;
         }
+        accessCheck(loc, sc, s, true);
+        s = s->toAlias();
 
         v = s->isVarDeclaration();
         if (v)
@@ -7558,6 +7561,7 @@ L1:
     }
     if (!s->isFuncDeclaration())        // because of overloading
         s->checkDeprecated(e->loc, sc);
+    accessCheck(e->loc, sc, s, true);
     s = s->toAlias();
 
     v = s->isVarDeclaration();
@@ -8116,6 +8120,7 @@ L1:
     }
     if (!s->isFuncDeclaration())        // because of overloading
         s->checkDeprecated(e->loc, sc);
+    accessCheck(e->loc, sc, s, true);
     s = s->toAlias();
     v = s->isVarDeclaration();
     if (v && !v->isDataseg())

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6339,7 +6339,7 @@ L1:
             Identifier *id = new Identifier(p, TOKidentifier);
             s = sc->search_correct(id);
             if (s)
-                error(loc, "undefined identifier %s, did you mean %s %s?", p, s->kind(), s->toChars());
+                error(loc, "undefined identifier %s, did you mean %s %s %s?", p, s->protChars(), s->kind(), s->toPrettyChars());
             else
                 error(loc, "undefined identifier %s", p);
         }

--- a/src/scope.c
+++ b/src/scope.c
@@ -217,7 +217,7 @@ void Scope::mergeCallSuper(Loc loc, unsigned cs)
     }
 }
 
-Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym)
+Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym, int flags)
 {   Dsymbol *s;
     Scope *sc;
 
@@ -249,7 +249,7 @@ Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym)
         if (sc->scopesym)
         {
             //printf("\tlooking in scopesym '%s', kind = '%s'\n", sc->scopesym->toChars(), sc->scopesym->kind());
-            s = sc->scopesym->search(loc, ident, 0);
+            s = sc->scopesym->search(loc, ident, flags);
             if (s)
             {
                 if ((global.params.warnings ||
@@ -386,7 +386,7 @@ void *scope_search_fp(void *arg, const char *seed)
 
     Scope *sc = (Scope *)arg;
     Module::clearCache();
-    Dsymbol *s = sc->search(0, id, NULL);
+    Dsymbol *s = sc->search(0, id, NULL, 1|2);
     return s;
 }
 
@@ -395,5 +395,8 @@ Dsymbol *Scope::search_correct(Identifier *ident)
     if (global.gag)
         return NULL;            // don't do it for speculative compiles; too time consuming
 
-    return (Dsymbol *)speller(ident->toChars(), &scope_search_fp, this, idchars);
+    Dsymbol *s = search(0, ident, NULL, 1|2);
+    if (!s)
+        s = (Dsymbol *)speller(ident->toChars(), &scope_search_fp, this, idchars);
+    return s;
 }

--- a/src/scope.h
+++ b/src/scope.h
@@ -110,7 +110,7 @@ struct Scope
 
     void mergeCallSuper(Loc loc, unsigned cs);
 
-    Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym);
+    Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym, int flags=0);
     Dsymbol *search_correct(Identifier *ident);
     Dsymbol *insert(Dsymbol *s);
 

--- a/src/template.c
+++ b/src/template.c
@@ -4969,8 +4969,8 @@ TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc, bool *
         if (!s)
         {
             s = sc->search_correct(id);
-            if (s)
-                error("template '%s' is not defined, did you mean %s?", id->toChars(), s->toChars());
+            if (s) // Bug: should only suggest templates
+                error("template '%s' is not defined, did you mean %s %s?", id->toChars(), s->protChars(), s->toPrettyChars());
             else
                 error("template '%s' is not defined", id->toChars());
             return NULL;

--- a/src/template.c
+++ b/src/template.c
@@ -382,6 +382,7 @@ TemplateDeclaration::TemplateDeclaration(Loc loc, Identifier *id,
     this->overnext = NULL;
     this->overroot = NULL;
     this->semanticRun = 0;
+    this->protection = PROTpublic;
     this->onemember = NULL;
     this->literal = 0;
     this->ismixin = ismixin;
@@ -481,7 +482,9 @@ void TemplateDeclaration::semantic(Scope *sc)
     Scope *paramscope = sc->push(paramsym);
     paramscope->parameterSpecialization = 1;
     paramscope->stc = 0;
+    paramscope->protection = PROTpublic;
 
+    protection = sc->protection;
     if (!parent)
         parent = sc->parent;
 
@@ -538,6 +541,23 @@ const char *TemplateDeclaration::kind()
     return (onemember && onemember->isAggregateDeclaration())
                 ? onemember->kind()
                 : (char *)"template";
+}
+
+enum PROT TemplateDeclaration::overprot()
+{
+    enum PROT result = prot();
+    for (TemplateDeclaration *td = overnext; td; td = td->overnext)
+    {
+        enum PROT nprot = td->prot();
+        if (nprot > result) // take looser one
+            result = nprot;
+    }
+    return result;
+}
+
+enum PROT TemplateDeclaration::prot()
+{
+    return protection;
 }
 
 /**********************************
@@ -709,6 +729,7 @@ MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
     paramsym->parent = scope->parent;
     Scope *paramscope = scope->push(paramsym);
     paramscope->stc = 0;
+    paramscope->protection = PROTpublic;
 
     // Attempt type deduction
     m = MATCHexact;
@@ -976,6 +997,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(Scope *sc, Loc loc, Objec
     paramsym->parent = scope->parent;
     Scope *paramscope = scope->push(paramsym);
     paramscope->stc = 0;
+    paramscope->protection = PROTpublic;
 
     TemplateTupleParameter *tp = isVariadic();
     int tp_is_declared = 0;
@@ -1761,11 +1783,11 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
     Dsymbol *sa = isDsymbol(o);
     Tuple *va = isTuple(o);
 
-    Dsymbol *s;
+    Declaration *d;
 
     // See if tp->ident already exists with a matching definition
     Dsymbol *scopesym;
-    s = sc->search(loc, tp->ident, &scopesym);
+    Dsymbol *s = sc->search(loc, tp->ident, &scopesym);
     if (s && scopesym == sc->scopesym)
     {
         TupleDeclaration *td = s->isTupleDeclaration();
@@ -1782,12 +1804,12 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
     if (targ)
     {
         //printf("type %s\n", targ->toChars());
-        s = new AliasDeclaration(0, tp->ident, targ);
+        d = new AliasDeclaration(0, tp->ident, targ);
     }
     else if (sa)
     {
         //printf("Alias %s %s;\n", sa->ident->toChars(), tp->ident->toChars());
-        s = new AliasDeclaration(0, tp->ident, sa);
+        d = new AliasDeclaration(0, tp->ident, sa);
     }
     else if (ea)
     {
@@ -1797,14 +1819,13 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
 
         Type *t = tvp ? tvp->valType : NULL;
 
-        VarDeclaration *v = new VarDeclaration(loc, t, tp->ident, init);
-        v->storage_class = STCmanifest;
-        s = v;
+        d = new VarDeclaration(loc, t, tp->ident, init);
+        d->storage_class = STCmanifest;
     }
     else if (va)
     {
         //printf("\ttuple\n");
-        s = new TupleDeclaration(loc, tp->ident, &va->objects);
+        d = new TupleDeclaration(loc, tp->ident, &va->objects);
     }
     else
     {
@@ -1813,9 +1834,14 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
 #endif
         assert(0);
     }
-    if (!sc->insert(s))
+    /* Loose protection so that private symbols can be arguments to a
+     * template in a different module. This works because public
+     * aliases to private symbols are public.
+     */
+    d->protection = sc->protection;
+    if (!sc->insert(d))
         error("declaration %s is already defined", tp->ident->toChars());
-    s->semantic(sc);
+    d->semantic(sc);
 }
 
 /**************************************
@@ -4318,6 +4344,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
 #if LOG
     printf("\tdo semantic\n");
 #endif
+    bool hasAccess = false;
     if (havetempdecl)
     {
         assert((size_t)tempdecl->scope > 0x10000);
@@ -4342,7 +4369,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             return;             // error recovery
         }
         unsigned errs = global.errors;
-        tempdecl = findTemplateDeclaration(sc);
+        tempdecl = findTemplateDeclaration(sc, &hasAccess);
         if (tempdecl)
             tempdecl = findBestMatch(sc, fargs);
         if (!tempdecl || (errs != global.errors))
@@ -4351,6 +4378,8 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             return;             // error recovery
         }
     }
+    if (!hasAccess)
+        accessCheck(loc, sc, tempdecl, false);
 
     // If tempdecl is a mixin, disallow it
     if (tempdecl->ismixin)
@@ -4551,6 +4580,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     // Declare each template parameter as an alias for the argument type
     Scope *paramscope = scope->push();
     paramscope->stc = 0;
+    paramscope->protection = PROTpublic;
     declareParameters(paramscope);
     paramscope->pop();
 
@@ -4612,6 +4642,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     sc2 = scope->push(this);
     //printf("isnested = %d, sc->parent = %s\n", isnested, sc->parent->toChars());
     sc2->parent = /*isnested ? sc->parent :*/ this;
+    sc2->protection = PROTpublic;
     sc2->tinst = this;
 
 #if WINDOWS_SEH
@@ -4920,7 +4951,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
  * Find template declaration corresponding to template instance.
  */
 
-TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc)
+TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc, bool *pHasAccess)
 {
     //printf("TemplateInstance::findTemplateDeclaration() %s\n", toChars());
     if (!tempdecl)
@@ -4945,13 +4976,24 @@ TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc)
             return NULL;
         }
 
+        AliasDeclaration *ad = s->isAliasDeclaration();
+        if (ad && !ad->inSemantic) // resolve aliases, but not eponymous recursions
+        {
+            accessCheck(loc, sc, s, true);
+            s = s->toAlias();
+            if (pHasAccess)
+                *pHasAccess = true;
+        }
+        else if (pHasAccess)
+            *pHasAccess = false;
+
         /* If an OverloadSet, look for a unique member that is a template declaration
          */
         OverloadSet *os = s->isOverloadSet();
         if (os)
         {   s = NULL;
             for (size_t i = 0; i < os->a.dim; i++)
-            {   Dsymbol *s2 = os->a.tdata()[i];
+            {   Dsymbol *s2 = os->a.tdata()[i]->toAlias();
                 if (s2->isTemplateDeclaration())
                 {
                     if (s)
@@ -4991,8 +5033,6 @@ TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc)
                 s = tempdecl;
             }
         }
-
-        s = s->toAlias();
 
         /* It should be a TemplateDeclaration, not some other symbol
          */
@@ -5417,7 +5457,7 @@ int TemplateInstance::needsTypeInference(Scope *sc)
 {
     //printf("TemplateInstance::needsTypeInference() %s\n", toChars());
     if (!tempdecl)
-        tempdecl = findTemplateDeclaration(sc);
+        tempdecl = findTemplateDeclaration(sc, NULL);
     int multipleMatches = FALSE;
     for (TemplateDeclaration *td = tempdecl; td; td = td->overnext)
     {
@@ -5793,7 +5833,10 @@ void TemplateMixin::semantic(Scope *sc)
     }
 
     // Follow qualifications to find the TemplateDeclaration
-    if (!tempdecl)
+    bool hasAccess;
+    if (tempdecl)
+        hasAccess = true;
+    else
     {   Dsymbol *s;
         size_t i;
         Identifier *id;
@@ -5837,7 +5880,16 @@ void TemplateMixin::semantic(Scope *sc)
             inst = this;
             return;
         }
-        tempdecl = s->toAlias()->isTemplateDeclaration();
+        AliasDeclaration *ad = s->isAliasDeclaration();
+        if (ad && !ad->inSemantic) // resolve aliases, but not eponymous recursions
+        {
+            accessCheck(loc, sc, s, true);
+            s = s->toAlias();
+            hasAccess = true;
+        }
+        else
+            hasAccess = false;
+        tempdecl = s->isTemplateDeclaration();
         if (!tempdecl)
         {
             error("%s isn't a template", s->toChars());
@@ -5884,6 +5936,8 @@ void TemplateMixin::semantic(Scope *sc)
     {   inst = this;
         return;         // error recovery
     }
+    if (!hasAccess)
+        accessCheck(loc, sc, tempdecl, false);
 
     if (!ident)
         ident = genIdent(tiargs);

--- a/src/template.h
+++ b/src/template.h
@@ -59,6 +59,7 @@ struct TemplateDeclaration : ScopeDsymbol
 
     int semanticRun;                    // 1 semantic() run
     bool errors;                        // this template is not correct
+    enum PROT protection;
 
     Dsymbol *onemember;         // if !=NULL then one member of this template
 
@@ -80,6 +81,8 @@ struct TemplateDeclaration : ScopeDsymbol
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     bool hasStaticCtorOrDtor();
     const char *kind();
+    enum PROT prot();
+    enum PROT overprot();
     char *toChars();
 
     void emitComment(Scope *sc);
@@ -299,6 +302,7 @@ struct TemplateInstance : ScopeDsymbol
     Dsymbol *isnested;  // if referencing local symbols, this is the context
     int errors;         // 1 if compiled with errors
     int speculative;    // 1 if only instantiated with errors gagged
+
 #ifdef IN_GCC
     /* On some targets, it is necessary to know whether a symbol
        will be emitted in the output or not before the symbol
@@ -329,7 +333,7 @@ struct TemplateInstance : ScopeDsymbol
     // Internal
     static void semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int flags);
     void semanticTiargs(Scope *sc);
-    TemplateDeclaration *findTemplateDeclaration(Scope *sc);
+    TemplateDeclaration *findTemplateDeclaration(Scope *sc, bool *pHasAccess);
     TemplateDeclaration *findBestMatch(Scope *sc, Expressions *fargs);
     void declareParameters(Scope *sc);
     int hasNestedArgs(Objects *tiargs);

--- a/test/compilable/imports/test1238a.d
+++ b/test/compilable/imports/test1238a.d
@@ -1,0 +1,3 @@
+module imports.test1238a;
+
+private int zuiop;

--- a/test/compilable/imports/test1238b.d
+++ b/test/compilable/imports/test1238b.d
@@ -1,0 +1,3 @@
+module imports.test1238b;
+
+public int zuiop;

--- a/test/compilable/imports/test1754a.d
+++ b/test/compilable/imports/test1754a.d
@@ -1,0 +1,5 @@
+module imports.test1754a;
+
+private void bar()
+{
+}

--- a/test/compilable/imports/test1754b.d
+++ b/test/compilable/imports/test1754b.d
@@ -1,0 +1,5 @@
+module imports.test1754b;
+
+void bar()
+{
+}

--- a/test/compilable/imports/test2401a.d
+++ b/test/compilable/imports/test2401a.d
@@ -1,0 +1,3 @@
+module imports.test2401a;
+
+alias int Foo;

--- a/test/compilable/imports/test2401b.d
+++ b/test/compilable/imports/test2401b.d
@@ -1,0 +1,3 @@
+module imports.test2401b;
+
+import imports.test2401a : Foo;

--- a/test/compilable/imports/test2991.d
+++ b/test/compilable/imports/test2991.d
@@ -1,0 +1,5 @@
+module imports.test2991;
+
+private void foo()
+{
+}

--- a/test/compilable/imports/test3254a.d
+++ b/test/compilable/imports/test3254a.d
@@ -1,0 +1,9 @@
+module imports.test3254a;
+
+void bar(int)
+{
+}
+
+private void bar(float)
+{
+}

--- a/test/compilable/imports/test3254b.d
+++ b/test/compilable/imports/test3254b.d
@@ -1,0 +1,9 @@
+module imports.test3254b;
+
+private void bar(float)
+{
+}
+
+void bar(int)
+{
+}

--- a/test/compilable/imports/test73.d
+++ b/test/compilable/imports/test73.d
@@ -1,0 +1,33 @@
+module imports.test73;
+
+void foo()
+{
+}
+
+private void bar()
+{
+}
+
+private void foo(int)
+{
+}
+
+void bar(int)
+{
+}
+
+void foot()()
+{
+}
+
+private void bart()()
+{
+}
+
+private void foot()(int)
+{
+}
+
+void bart()(int)
+{
+}

--- a/test/compilable/imports/test74.d
+++ b/test/compilable/imports/test74.d
@@ -1,0 +1,8 @@
+module imports.test74;
+
+private template bar()
+{
+    alias int bar;
+}
+
+alias bar foo;

--- a/test/compilable/imports/test75.d
+++ b/test/compilable/imports/test75.d
@@ -1,0 +1,16 @@
+module imports.test75;
+
+void foo(alias pred)()
+{
+    pred();
+}
+
+void tfoo(alias tmpl)()
+{
+    enum res = tmpl!();
+}
+
+void Tfoo(alias Type)()
+{
+    Type t;
+}

--- a/test/compilable/imports/testprotection1.d
+++ b/test/compilable/imports/testprotection1.d
@@ -1,0 +1,267 @@
+module same_package.imp;
+
+string decls(string prot)
+{
+    return
+(prot == "none" ? "" : prot ~ ":")~`
+    int            `~prot~`_variable;
+    class          `~prot~`_class {}
+    struct         `~prot~`_struct {}
+    union          `~prot~`_union {}
+    enum           `~prot~`_enum_1 { A }
+    enum           `~prot~`_enum_2 = 2;
+    alias int      `~prot~`_type_alias;
+    template       `~prot~`_template() {}
+    template       `~prot~`_eponymous_template() { enum `~prot~`_eponymous_template = 0; }
+    mixin template `~prot~`_mixin_template() {}
+    void           `~prot~`_func() {}
+    static void    `~prot~`_static_func() {}
+`;
+}
+
+mixin template protection_body()
+{
+    mixin(decls("none"));
+    mixin(decls("public"));
+    mixin(decls("package"));
+    mixin(decls("private"));
+}
+
+public:
+
+mixin protection_body!();
+
+struct   public_struct     { mixin protection_body!(); }
+class    public_class      { mixin protection_body!(); }
+template public_template() { mixin protection_body!(); }
+
+package:
+
+struct   package_struct     { mixin protection_body!(); }
+class    package_class      { mixin protection_body!(); }
+template package_template() { mixin protection_body!(); }
+
+private:
+
+struct   private_struct     { mixin protection_body!(); }
+class    private_class      { mixin protection_body!(); }
+template private_template() { mixin protection_body!(); }
+
+public:
+
+enum HasPackageAccess : bool
+{
+    yes = true,
+    no  = false,
+};
+
+
+mixin template basic_test_cases(HasPackageAccess pkg)
+{
+    static assert(__traits(compiles, () {public_struct s;}));
+    static assert(__traits(compiles, () {auto c = new public_class;}));
+    static assert(__traits(compiles, public_template!()));
+    static assert(__traits(compiles, public_eponymous_template!()));
+
+    static assert(pkg == __traits(compiles, () {package_struct s;}));
+    static assert(pkg == __traits(compiles, () {auto c = new package_class;}));
+    static assert(pkg == __traits(compiles, package_template!()));
+    static assert(pkg == __traits(compiles, package_eponymous_template!()));
+
+    static assert(!__traits(compiles, () {private_struct s;}));
+    static assert(!__traits(compiles, () {auto c = new private_class;}));
+    static assert(!__traits(compiles, private_template!()));
+    static assert(!__traits(compiles, private_eponymous_template!()));
+}
+
+
+mixin template builtin_property_test_cases(HasPackageAccess pkg)
+{
+    static assert(__traits(compiles, public_struct.stringof));
+    static assert(__traits(compiles, public_class.stringof));
+    static assert(__traits(compiles, public_func.mangleof));
+
+    static assert(pkg == __traits(compiles, package_struct.stringof));
+    static assert(pkg == __traits(compiles, package_class.stringof));
+    static assert(pkg == __traits(compiles, package_func.mangleof));
+
+    static assert(!__traits(compiles, private_struct.stringof));
+    static assert(!__traits(compiles, private_class.stringof));
+    static assert(!__traits(compiles, private_func.mangleof));
+}
+
+
+template TypeTuple(T...)
+{
+    alias T TypeTuple;
+}
+
+// Need to split those (Bug #7406)
+public alias TypeTuple!(
+    public_struct,
+    public_class,
+    package_struct,
+    package_class,
+    private_struct,
+    private_class,
+) ScopeSymbolsTypes;
+
+public alias TypeTuple!(
+    same_package.imp,
+    public_template!(),
+    package_template!(),
+    private_template!(),
+) ScopeSymbolsExpressions;
+
+/* Nested scopes are public by default even for private symbols,
+ * i.e. one can't instantiate a private struct, but access all it's members.
+ */
+mixin template scope_test_cases(HasPackageAccess pkg)
+{
+    static assert(__traits(compiles, none_variable), none_variable);
+    static assert(__traits(compiles, none_class));
+    static assert(__traits(compiles, none_struct));
+    static assert(__traits(compiles, none_union));
+    static assert(__traits(compiles, none_enum_1));
+    static assert(__traits(compiles, none_enum_2));
+    static assert(__traits(compiles, none_type_alias));
+    static assert(__traits(compiles, none_template!()));
+    static assert(__traits(compiles, none_eponymous_template!()));
+    static assert(__traits(compiles, () { mixin none_mixin_template!(); }));
+    static assert(__traits(compiles, none_func));
+    static assert(__traits(compiles, none_static_func));
+
+    static assert(__traits(compiles, public_variable));
+    static assert(__traits(compiles, public_class));
+    static assert(__traits(compiles, public_struct));
+    static assert(__traits(compiles, public_union));
+    static assert(__traits(compiles, public_enum_1));
+    static assert(__traits(compiles, public_enum_2));
+    static assert(__traits(compiles, public_type_alias));
+    static assert(__traits(compiles, public_template!()));
+    static assert(__traits(compiles, public_eponymous_template!()));
+    static assert(__traits(compiles, () { mixin public_mixin_template!(); }));
+    static assert(__traits(compiles, public_func));
+    static assert(__traits(compiles, public_static_func));
+
+    static assert(pkg == __traits(compiles, package_variable));
+    static assert(pkg == __traits(compiles, package_class));
+    static assert(pkg == __traits(compiles, package_struct));
+    static assert(pkg == __traits(compiles, package_union));
+    static assert(pkg == __traits(compiles, package_enum_1));
+    static assert(pkg == __traits(compiles, package_enum_2));
+    static assert(pkg == __traits(compiles, package_type_alias));
+    static assert(pkg == __traits(compiles, package_template!()));
+    static assert(pkg == __traits(compiles, package_eponymous_template!()));
+    static assert(pkg == __traits(compiles, () { mixin package_mixin_template!(); }));
+    static assert(pkg == __traits(compiles, package_func));
+    static assert(pkg == __traits(compiles, package_static_func));
+
+    static assert(!__traits(compiles, private_variable));
+    static assert(!__traits(compiles, private_class));
+    static assert(!__traits(compiles, private_struct));
+    static assert(!__traits(compiles, private_union));
+    static assert(!__traits(compiles, private_enum_1));
+    static assert(!__traits(compiles, private_enum_2));
+    static assert(!__traits(compiles, private_type_alias));
+    static assert(!__traits(compiles, private_template!()));
+    static assert(!__traits(compiles, private_eponymous_template!()));
+    static assert(!__traits(compiles, () { mixin private_mixin_template!(); }));
+    static assert(!__traits(compiles, private_func));
+    static assert(!__traits(compiles, private_static_func));
+}
+
+
+template template_test_typ(T)
+{
+    enum template_test_typ = T.stringof;
+}
+
+template template_test_sym(alias S)
+{
+    enum template_test_sym = S.stringof;
+}
+
+template template_test_tup(T...)
+{
+    static if (T.length > 0)
+        enum template_test_tup = T[0].stringof ~ template_test_tup!(T[1 .. $]);
+    else
+        enum template_test_tup = "";
+}
+
+/* Templates have full access to their arguments. Protection checks
+ * are only done at instantiation scope. This doesn't work yet for
+ * aliases to private functions (Bugzilla 4533).
+ */
+version = Bug4533;
+mixin template template_test_cases()
+{
+    mixin protection_body!();
+
+    static assert(__traits(compiles, template_test_sym!(none_variable)));
+    static assert(__traits(compiles, template_test_typ!(none_class)));
+    static assert(__traits(compiles, template_test_typ!(none_struct)));
+    static assert(__traits(compiles, template_test_typ!(none_union)));
+    static assert(__traits(compiles, template_test_typ!(none_enum_1)));
+    static assert(__traits(compiles, template_test_sym!(none_enum_2)));
+    static assert(__traits(compiles, template_test_typ!(none_type_alias)));
+    static assert(__traits(compiles, template_test_sym!(none_template!())));
+    static assert(__traits(compiles, template_test_sym!(none_eponymous_template!())));
+    static assert(__traits(compiles, template_test_sym!(none_mixin_template)));
+    static assert(__traits(compiles, template_test_sym!(none_func)));
+    static assert(__traits(compiles, template_test_sym!(none_static_func)));
+    static assert(__traits(compiles, template_test_tup!(
+                               none_variable, none_class, none_enum_1, none_mixin_template)));
+
+    static assert(__traits(compiles, template_test_sym!(public_variable)));
+    static assert(__traits(compiles, template_test_typ!(public_class)));
+    static assert(__traits(compiles, template_test_typ!(public_struct)));
+    static assert(__traits(compiles, template_test_typ!(public_union)));
+    static assert(__traits(compiles, template_test_typ!(public_enum_1)));
+    static assert(__traits(compiles, template_test_sym!(public_enum_2)));
+    static assert(__traits(compiles, template_test_typ!(public_type_alias)));
+    static assert(__traits(compiles, template_test_sym!(public_template!())));
+    static assert(__traits(compiles, template_test_sym!(public_eponymous_template!())));
+    static assert(__traits(compiles, template_test_sym!(public_mixin_template)));
+    static assert(__traits(compiles, template_test_sym!(public_func)));
+    static assert(__traits(compiles, template_test_sym!(public_static_func)));
+    static assert(__traits(compiles, template_test_tup!(
+                               public_variable, public_class, public_enum_1, public_mixin_template)));
+
+    static assert(__traits(compiles, template_test_sym!(package_variable)));
+    static assert(__traits(compiles, template_test_typ!(package_class)));
+    static assert(__traits(compiles, template_test_typ!(package_struct)));
+    static assert(__traits(compiles, template_test_typ!(package_union)));
+    static assert(__traits(compiles, template_test_typ!(package_enum_1)));
+    static assert(__traits(compiles, template_test_sym!(package_enum_2)));
+    static assert(__traits(compiles, template_test_typ!(package_type_alias)));
+    static assert(__traits(compiles, template_test_sym!(package_template!())));
+    static assert(__traits(compiles, template_test_sym!(package_eponymous_template!())));
+    static assert(__traits(compiles, template_test_sym!(package_mixin_template)));
+    version (Bug4533) {} else
+    {
+        static assert(__traits(compiles, template_test_sym!(package_func)));
+        static assert(__traits(compiles, template_test_sym!(package_static_func)));
+    }
+    static assert(__traits(compiles, template_test_tup!(
+                               package_variable, package_class, package_enum_1, package_mixin_template)));
+
+    static assert(__traits(compiles, template_test_sym!(private_variable)));
+    static assert(__traits(compiles, template_test_typ!(private_class)));
+    static assert(__traits(compiles, template_test_typ!(private_struct)));
+    static assert(__traits(compiles, template_test_typ!(private_union)));
+    static assert(__traits(compiles, template_test_typ!(private_enum_1)));
+    static assert(__traits(compiles, template_test_sym!(private_enum_2)));
+    static assert(__traits(compiles, template_test_typ!(private_type_alias)));
+    static assert(__traits(compiles, template_test_sym!(private_template!())));
+    static assert(__traits(compiles, template_test_sym!(private_eponymous_template!())));
+    static assert(__traits(compiles, template_test_sym!(private_mixin_template)));
+    version (Bug4533) {} else
+    {
+        static assert(__traits(compiles, template_test_sym!(private_func)));
+        static assert(__traits(compiles, template_test_sym!(private_static_func)));
+    }
+    static assert(__traits(compiles, template_test_tup!(
+                               private_variable, private_class, private_enum_1, private_mixin_template)));
+}

--- a/test/compilable/test1238.d
+++ b/test/compilable/test1238.d
@@ -1,0 +1,10 @@
+module test1238;
+
+import imports.test1238a;
+import imports.test1238b;
+
+void foo()
+{
+    int qwert = zuiop;
+}
+

--- a/test/compilable/test1754.d
+++ b/test/compilable/test1754.d
@@ -1,0 +1,9 @@
+module test1754;
+
+import imports.test1754a;
+import imports.test1754b;
+
+void foo()
+{
+    bar();
+}

--- a/test/compilable/test2401.d
+++ b/test/compilable/test2401.d
@@ -1,0 +1,9 @@
+module test2401;
+
+import imports.test2401a;
+import imports.test2401b;
+
+void foo()
+{
+    Foo bar = 42;
+}

--- a/test/compilable/test2991.d
+++ b/test/compilable/test2991.d
@@ -1,0 +1,12 @@
+module test2991;
+
+void foo()
+{
+}
+
+class C
+{
+    import imports.test2991;
+
+    void bar() { foo(); }
+}

--- a/test/compilable/test3254a.d
+++ b/test/compilable/test3254a.d
@@ -1,0 +1,8 @@
+module test3254a;
+
+import imports.test3254a;
+
+void foo()
+{
+    bar(0);
+}

--- a/test/compilable/test3254b.d
+++ b/test/compilable/test3254b.d
@@ -1,0 +1,8 @@
+module test3254b;
+
+import imports.test3254b;
+
+void foo()
+{
+    bar(0);
+}

--- a/test/compilable/test73.d
+++ b/test/compilable/test73.d
@@ -1,0 +1,17 @@
+module test73;
+
+import imports.test73;
+
+// test overloads with mixed protection
+void baz()
+{
+    foo();
+    bar(0);
+    foot();
+    bart(0);
+
+    static assert(!__traits(compiles, foo(0)));
+    static assert(!__traits(compiles, bar()));
+    static assert(!__traits(compiles, foot(0)));
+    static assert(!__traits(compiles, bart()));
+}

--- a/test/compilable/test74.d
+++ b/test/compilable/test74.d
@@ -1,0 +1,8 @@
+module test74;
+
+import imports.test74;
+
+void baz()
+{
+    foo!() f;
+}

--- a/test/compilable/test75.d
+++ b/test/compilable/test75.d
@@ -1,0 +1,33 @@
+module test75;
+
+import imports.test75;
+
+// templates should have full access to their arguments
+void bar()
+{
+    version (none) // doesn't work yet for functions
+        foo!baz();
+}
+
+private void baz()
+{
+}
+
+void tbar()
+{
+    tfoo!tbaz();
+}
+
+private template tbaz()
+{
+    enum tbaz = 5;
+}
+
+void Tbar()
+{
+    Tfoo!Tbaz();
+}
+
+private struct Tbaz
+{
+}

--- a/test/compilable/testprotection1a.d
+++ b/test/compilable/testprotection1a.d
@@ -1,0 +1,22 @@
+module same_package.a;
+
+import imports.testprotection1;
+
+mixin basic_test_cases!(HasPackageAccess.yes);
+mixin builtin_property_test_cases!(HasPackageAccess.yes);
+
+void test_scope()
+{
+    mixin scope_test_cases!(HasPackageAccess.yes);
+
+    foreach(Scope; ScopeSymbolsTypes)
+        with (Scope) mixin scope_test_cases!(HasPackageAccess.yes);
+
+    foreach(Scope; ScopeSymbolsExpressions)
+        with (Scope) mixin scope_test_cases!(HasPackageAccess.yes);
+}
+
+void test_templates()
+{
+    mixin template_test_cases!();
+}

--- a/test/compilable/testprotection1b.d
+++ b/test/compilable/testprotection1b.d
@@ -1,0 +1,22 @@
+module different_package.a;
+
+import imports.testprotection1;
+
+mixin basic_test_cases!(HasPackageAccess.no);
+mixin builtin_property_test_cases!(HasPackageAccess.no);
+
+void test_scope()
+{
+    mixin scope_test_cases!(HasPackageAccess.no);
+
+    foreach(Scope; ScopeSymbolsTypes)
+        with (Scope) mixin scope_test_cases!(HasPackageAccess.no);
+
+    foreach(Scope; ScopeSymbolsExpressions)
+        with (Scope) mixin scope_test_cases!(HasPackageAccess.no);
+}
+
+void test_templates()
+{
+    mixin template_test_cases!();
+}

--- a/test/fail_compilation/fail357a.d
+++ b/test/fail_compilation/fail357a.d
@@ -1,0 +1,7 @@
+void fail357()
+{
+    enum foo { A, }
+
+    // symbol collision of enum and function
+    import imports.fail357a : foo;
+}

--- a/test/fail_compilation/fail357b.d
+++ b/test/fail_compilation/fail357b.d
@@ -1,0 +1,7 @@
+void fail357()
+{
+    // symbol collision of enum and function
+    import imports.fail357a : foo;
+
+    enum foo { A, }
+}

--- a/test/fail_compilation/fail357c.d
+++ b/test/fail_compilation/fail357c.d
@@ -1,0 +1,7 @@
+void fail357()
+{
+    // symbol collision
+    import Foo = imports.fail357a;
+    import imports.fail357b : Foo;
+    alias Foo.foo fun;
+}

--- a/test/fail_compilation/fail357d.d
+++ b/test/fail_compilation/fail357d.d
@@ -1,0 +1,10 @@
+void fail357()
+{
+    // symbol collision
+    import imports.fail357b : Foo;
+    import imports.fail357c : Foo;
+
+    static if (__traits(compiles, () { Foo foo; }))
+        pragma(msg, "FAILING TEST");
+    static assert(0);
+}

--- a/test/fail_compilation/fail4245a.d
+++ b/test/fail_compilation/fail4245a.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        void foo() {}
+    }
+    {
+        void foo() {}
+    }
+}

--- a/test/fail_compilation/fail4245b.d
+++ b/test/fail_compilation/fail4245b.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -d
+// 4245
+void fail4245()
+{
+    {
+        typedef int Foo;
+    }
+    {
+        typedef int Foo;
+    }
+}

--- a/test/fail_compilation/fail4245c.d
+++ b/test/fail_compilation/fail4245c.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        struct Foo {}
+    }
+    {
+        struct Foo {}
+    }
+}

--- a/test/fail_compilation/fail4245d.d
+++ b/test/fail_compilation/fail4245d.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        class Foo {}
+    }
+    {
+        class Foo {}
+    }
+}

--- a/test/fail_compilation/fail4245e.d
+++ b/test/fail_compilation/fail4245e.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        enum Foo { A, }
+    }
+    {
+        enum Foo { A, }
+    }
+}

--- a/test/fail_compilation/fail4245f.d
+++ b/test/fail_compilation/fail4245f.d
@@ -1,0 +1,10 @@
+// 4245
+void fail4245()
+{
+    {
+        interface Foo { }
+    }
+    {
+        interface Foo { }
+    }
+}

--- a/test/fail_compilation/imports/fail357a.d
+++ b/test/fail_compilation/imports/fail357a.d
@@ -1,0 +1,5 @@
+module imports.fail357a;
+
+void foo()
+{
+}

--- a/test/fail_compilation/imports/fail357b.d
+++ b/test/fail_compilation/imports/fail357b.d
@@ -1,0 +1,6 @@
+module imports.fail357b;
+
+struct Foo
+{
+    static void foo() {}
+}

--- a/test/fail_compilation/imports/fail357c.d
+++ b/test/fail_compilation/imports/fail357c.d
@@ -1,0 +1,5 @@
+module inports.fail357c;
+
+struct Foo
+{
+}

--- a/test/fail_compilation/imports/test1161.d
+++ b/test/fail_compilation/imports/test1161.d
@@ -1,0 +1,7 @@
+module imports.test1161;
+
+class Test
+{
+private:
+    static int counter = 0;
+}

--- a/test/fail_compilation/imports/test143.d
+++ b/test/fail_compilation/imports/test143.d
@@ -1,0 +1,3 @@
+module imports.test143;
+
+package int x = 5;

--- a/test/fail_compilation/imports/test1441a.d
+++ b/test/fail_compilation/imports/test1441a.d
@@ -1,0 +1,5 @@
+module imports.test1441a;
+
+private class Foo
+{
+}

--- a/test/fail_compilation/imports/test1441b.d
+++ b/test/fail_compilation/imports/test1441b.d
@@ -1,0 +1,8 @@
+module imports.test1441b;
+
+class Foo
+{
+    private static class Bar
+    {
+    }
+}

--- a/test/fail_compilation/imports/test2225.d
+++ b/test/fail_compilation/imports/test2225.d
@@ -1,0 +1,14 @@
+module imports.test2225;
+
+class Outer
+{
+    int a;
+private:
+    class Inner
+    {
+        void foo()
+        {
+            return a;
+        }
+    }
+}

--- a/test/fail_compilation/imports/test2775.d
+++ b/test/fail_compilation/imports/test2775.d
@@ -1,0 +1,6 @@
+module imports.test2775;
+
+private template bar()
+{
+    string bar = "bar";
+}

--- a/test/fail_compilation/imports/test2830a.d
+++ b/test/fail_compilation/imports/test2830a.d
@@ -1,0 +1,5 @@
+module imports.test2830a;
+
+private struct TestStruct
+{
+}

--- a/test/fail_compilation/imports/test2830b.d
+++ b/test/fail_compilation/imports/test2830b.d
@@ -1,0 +1,5 @@
+module imports.test2830b;
+
+private union TestUnion
+{
+}

--- a/test/fail_compilation/imports/test2830c.d
+++ b/test/fail_compilation/imports/test2830c.d
@@ -1,0 +1,5 @@
+module imports.test2830c;
+
+private class TestClass
+{
+}

--- a/test/fail_compilation/imports/test2830d.d
+++ b/test/fail_compilation/imports/test2830d.d
@@ -1,0 +1,3 @@
+module imports.test2830d;
+
+private typedef int TestTypedef;

--- a/test/fail_compilation/imports/test2830e.d
+++ b/test/fail_compilation/imports/test2830e.d
@@ -1,0 +1,3 @@
+module imports.test2830e;
+
+private enum TestEnum { A, }

--- a/test/fail_compilation/imports/test2830f.d
+++ b/test/fail_compilation/imports/test2830f.d
@@ -1,0 +1,3 @@
+module imports.test2830f;
+
+private alias int TestAlias;

--- a/test/fail_compilation/imports/test313a.d
+++ b/test/fail_compilation/imports/test313a.d
@@ -1,0 +1,3 @@
+module imports.test313a;
+
+import imports.test313priv;

--- a/test/fail_compilation/imports/test313b.d
+++ b/test/fail_compilation/imports/test313b.d
@@ -1,0 +1,4 @@
+module imports.test313b;
+
+public import imports.test313a;
+import imports.test313priv;

--- a/test/fail_compilation/imports/test313priv.d
+++ b/test/fail_compilation/imports/test313priv.d
@@ -1,0 +1,5 @@
+module imports.test313priv;
+
+void foo()
+{
+}

--- a/test/fail_compilation/imports/test314a.d
+++ b/test/fail_compilation/imports/test314a.d
@@ -1,0 +1,3 @@
+module imports.test314a;
+
+static import imports.test314imp;

--- a/test/fail_compilation/imports/test314b.d
+++ b/test/fail_compilation/imports/test314b.d
@@ -1,0 +1,3 @@
+module imports.test314b;
+
+import imp = imports.test314imp;

--- a/test/fail_compilation/imports/test314c.d
+++ b/test/fail_compilation/imports/test314c.d
@@ -1,0 +1,3 @@
+module imports.test314c;
+
+import imports.test314imp : foo;

--- a/test/fail_compilation/imports/test314d.d
+++ b/test/fail_compilation/imports/test314d.d
@@ -1,0 +1,3 @@
+module imports.test314d;
+
+import imports.test314imp : bar=foo;

--- a/test/fail_compilation/imports/test314e.d
+++ b/test/fail_compilation/imports/test314e.d
@@ -1,0 +1,3 @@
+module imports.test314e;
+
+import imports.test314imp : bar=foo;

--- a/test/fail_compilation/imports/test314imp.d
+++ b/test/fail_compilation/imports/test314imp.d
@@ -1,0 +1,5 @@
+module imports.test314a;
+
+void foo()
+{
+}

--- a/test/fail_compilation/imports/test5412a.d
+++ b/test/fail_compilation/imports/test5412a.d
@@ -1,0 +1,7 @@
+module imports.test5412a;
+
+void bar()
+{
+}
+
+

--- a/test/fail_compilation/imports/test5412b.d
+++ b/test/fail_compilation/imports/test5412b.d
@@ -1,0 +1,1 @@
+module imports.test5412b;

--- a/test/fail_compilation/test1161.d
+++ b/test/fail_compilation/test1161.d
@@ -1,0 +1,8 @@
+module test1161;
+
+import imports.test1161;
+
+void foo()
+{
+    Test.counter = 5;
+}

--- a/test/fail_compilation/test143.d
+++ b/test/fail_compilation/test143.d
@@ -1,0 +1,12 @@
+module test143; // Bugzilla 143
+
+import imports.test143;
+
+void bar(int)
+{
+}
+
+void foo()
+{
+    bar(x);
+}

--- a/test/fail_compilation/test1441a.d
+++ b/test/fail_compilation/test1441a.d
@@ -1,0 +1,8 @@
+module test1441a;
+
+import imports.test1441a;
+
+void foo()
+{
+    auto obj = new Foo();
+}

--- a/test/fail_compilation/test1441b.d
+++ b/test/fail_compilation/test1441b.d
@@ -1,0 +1,8 @@
+module test1441b;
+
+import imports.test1441b;
+
+void foo()
+{
+    auto obj = new Foo.Bar;
+}

--- a/test/fail_compilation/test2225.d
+++ b/test/fail_compilation/test2225.d
@@ -1,0 +1,10 @@
+module test2225;
+
+import imports.test2225;
+
+void foo()
+{
+    auto o = new Outer;
+    o.a = 3;
+    auto oi = o.new Inner;
+}

--- a/test/fail_compilation/test2775.d
+++ b/test/fail_compilation/test2775.d
@@ -1,0 +1,8 @@
+module test2775;
+
+import imports.test2775;
+
+void foo()
+{
+    string str = bar!();
+}

--- a/test/fail_compilation/test2830a.d
+++ b/test/fail_compilation/test2830a.d
@@ -1,0 +1,8 @@
+module test2830a;
+
+import imports.test2830a;
+
+void foo()
+{
+    TestStruct s;
+}

--- a/test/fail_compilation/test2830b.d
+++ b/test/fail_compilation/test2830b.d
@@ -1,0 +1,8 @@
+module test2830b;
+
+import imports.test2830b;
+
+void foo()
+{
+    TestUnion u;
+}

--- a/test/fail_compilation/test2830c.d
+++ b/test/fail_compilation/test2830c.d
@@ -1,0 +1,8 @@
+module test2830c;
+
+import imports.test2830c;
+
+void foo()
+{
+    TestClass c;
+}

--- a/test/fail_compilation/test2830d.d
+++ b/test/fail_compilation/test2830d.d
@@ -1,0 +1,9 @@
+// REQUIRED_ARGS: -d
+module test2830d;
+
+import imports.test2830d;
+
+void foo()
+{
+    TestTypedef s;
+}

--- a/test/fail_compilation/test2830e.d
+++ b/test/fail_compilation/test2830e.d
@@ -1,0 +1,8 @@
+module test2830e;
+
+import imports.test2830e;
+
+void foo()
+{
+    TestEnum e;
+}

--- a/test/fail_compilation/test2830f.d
+++ b/test/fail_compilation/test2830f.d
@@ -1,0 +1,6 @@
+module imports.2830f;
+
+void foo()
+{
+    TestAlias a;
+}

--- a/test/fail_compilation/test313a.d
+++ b/test/fail_compilation/test313a.d
@@ -1,0 +1,9 @@
+module test313a;
+
+import imports.test313a;
+
+void foo()
+{
+    imports.test313priv.foo();
+    static assert(0, "FAILING TEST");
+}

--- a/test/fail_compilation/test313b.d
+++ b/test/fail_compilation/test313b.d
@@ -1,0 +1,9 @@
+module test313b;
+
+import imports.test313b;
+
+void foo()
+{
+    imports.test313priv.foo();
+    static assert(0, "FAILING TEST");
+}

--- a/test/fail_compilation/test314a.d
+++ b/test/fail_compilation/test314a.d
@@ -1,0 +1,8 @@
+module test314a;
+
+import imports.test314a;
+
+void foo()
+{
+    imports.test314imp.foo();
+}

--- a/test/fail_compilation/test314b.d
+++ b/test/fail_compilation/test314b.d
@@ -1,0 +1,8 @@
+module test314b;
+
+import imports.test314b;
+
+void foo()
+{
+    imp.foo();
+}

--- a/test/fail_compilation/test314c.d
+++ b/test/fail_compilation/test314c.d
@@ -1,0 +1,8 @@
+module test314c;
+
+import imports.test314c;
+
+void bar()
+{
+    foo();
+}

--- a/test/fail_compilation/test314d.d
+++ b/test/fail_compilation/test314d.d
@@ -1,0 +1,8 @@
+module test314d;
+
+import imports.test314d;
+
+void foo()
+{
+    bar();
+}

--- a/test/fail_compilation/test314e.d
+++ b/test/fail_compilation/test314e.d
@@ -1,0 +1,8 @@
+module test314e;
+
+import imports.test314e;
+
+void baz()
+{
+    foo();
+}

--- a/test/fail_compilation/test5412a.d
+++ b/test/fail_compilation/test5412a.d
@@ -1,0 +1,4 @@
+module test5412a;
+
+import A = imports.test5412a;
+import A = imports.test5412b;

--- a/test/fail_compilation/test5412b.d
+++ b/test/fail_compilation/test5412b.d
@@ -1,0 +1,4 @@
+module test5412b;
+
+import A = imports.test5412a;
+static import A = imports.test5412b;

--- a/test/fail_compilation/test5412c.d
+++ b/test/fail_compilation/test5412c.d
@@ -1,0 +1,4 @@
+module test5412c;
+
+import test5412c2 = imports.test5412a;
+import test5412c2;

--- a/test/fail_compilation/test5412c2.di
+++ b/test/fail_compilation/test5412c2.di
@@ -1,0 +1,1 @@
+module test5412c2;

--- a/test/runnable/imports/test2225.d
+++ b/test/runnable/imports/test2225.d
@@ -1,0 +1,20 @@
+module imports.test2225;
+
+class Outer
+{
+    int a;
+
+    Inner makeInner()
+    {
+        return this.new Inner;
+    }
+
+private:
+    class Inner
+    {
+        int foo()
+        {
+            return a;
+        }
+    }
+}

--- a/test/runnable/imports/test7494a.d
+++ b/test/runnable/imports/test7494a.d
@@ -1,0 +1,6 @@
+module imports.test7494a;
+
+string foo7494()
+{
+    return "imports.test7494a.foo7494";
+}

--- a/test/runnable/imports/test7494b.d
+++ b/test/runnable/imports/test7494b.d
@@ -1,0 +1,6 @@
+module imports.test7494b;
+
+string foo7494()
+{
+    return "imports.test7494b.foo7494";
+}

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -554,7 +554,6 @@ void test23()
 template T24()
 {
    void foo24() { return cast(void)0; }
-   alias foo24 foo24;
 }
 
 mixin T24;

--- a/test/runnable/test2225.d
+++ b/test/runnable/test2225.d
@@ -1,0 +1,18 @@
+// EXTRA_SOURCES: imports/test2225.d
+module test2225;
+
+import imports.test2225;
+
+void main()
+{
+    auto o = new Outer;
+    o.a = 3;
+    static assert(!is(typeof(Outer.Inner)));
+    static assert(!is(typeof(() { Outer.Inner oi; })));
+    auto oi = o.makeInner();
+    assert(oi.foo() == 3);
+    typeof(o.makeInner()) oi2;
+    oi2 = cast(typeof(oi))oi.classinfo.create();
+    oi2.outer = o;
+    assert(oi2.foo() == 3);
+}

--- a/test/runnable/test43.d
+++ b/test/runnable/test43.d
@@ -1,0 +1,68 @@
+// EXTRA_SOURCES: imports/test7494a.d imports/test7494b.d
+module test43;
+
+/***************************************************/
+// Bugzilla 7494
+
+string foo7494()
+{
+    return "test43.foo7494";
+}
+
+void test1()
+{
+    assert(foo7494() == "test43.foo7494");
+
+    string foo7494()
+    {
+        return "test43.test1.foo7494";
+    }
+    assert(foo7494() == "test43.test1.foo7494");
+    assert(.foo7494() == "test43.foo7494");
+    assert(test43.foo7494() == "test43.foo7494");
+
+    void nested()
+    {
+        assert(foo7494() == "test43.test1.foo7494");
+        assert(.foo7494() == "test43.foo7494");
+        assert(test43.foo7494() == "test43.foo7494");
+
+        import imports.test7494a;
+        assert(foo7494() == "imports.test7494a.foo7494");
+        assert(.foo7494() == "test43.foo7494");
+        assert(test43.foo7494() == "test43.foo7494");
+
+        import imports.test7494b : foo7494;
+        assert(foo7494() == "imports.test7494b.foo7494");
+        assert(imports.test7494b.foo7494() == "imports.test7494b.foo7494");
+        // Bugzilla 7496
+        version (none)
+            static assert(!__traits(compiles, imports.test7494b.foo7494()));
+        assert(.foo7494() == "test43.foo7494");
+        assert(test43.foo7494() == "test43.foo7494");
+    }
+    nested();
+
+    static assert(!__traits(compiles, imports.test7494a.foo7494()));
+    static assert(!__traits(compiles, imports.test7494b.foo7494()));
+
+    import imports.test7494a;
+    assert(foo7494() == "test43.test1.foo7494");
+    assert(imports.test7494a.foo7494() == "imports.test7494a.foo7494");
+    assert(.foo7494() == "test43.foo7494");
+    assert(test43.foo7494() == "test43.foo7494");
+
+    import imports.test7494b : foo7494;
+    // ambiguous test43.test1.foo7494 and imports.test7494b.foo7494 overload
+    static assert(!__traits(compiles, foo7494()));
+    assert(imports.test7494a.foo7494() == "imports.test7494a.foo7494");
+    assert(.foo7494() == "test43.foo7494");
+    assert(test43.foo7494() == "test43.foo7494");
+}
+
+/***************************************************/
+
+void main()
+{
+    test1();
+}


### PR DESCRIPTION
- extend protection checks to all kinds of symbols
- restrict visibility of module-level symbols with protection
- w.r.t. visibility use loosest protection for overload sets
- apply protection to import symbols (module, pkg, renames, aliases)

supersedes #726 / #714
