### PR TITLE
Fix most cases of regression 4269 (invalid types while gagging)

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -898,7 +898,12 @@ Dsymbol *ClassDeclaration::search(Loc loc, Identifier *ident, int flags)
     if (scope && !symtab)
     {   Scope *sc = scope;
         sc->mustsemantic++;
+        // If speculatively gagged, ungag now.
+        unsigned oldgag = global.gag;
+        if (global.isSpeculativeGagging())
+            global.gag = 0;
         semantic(sc);
+        global.gag = oldgag;
         sc->mustsemantic--;
     }
 

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -502,7 +502,7 @@ void AliasDeclaration::semantic(Scope *sc)
         ScopeDsymbol::multiplyDefined(0, this, overnext);
     this->inSemantic = 0;
 
-    if (errors != global.errors)
+    if (global.gag && errors != global.errors)
         type = savedtype;
     return;
 
@@ -538,7 +538,7 @@ void AliasDeclaration::semantic(Scope *sc)
             assert(global.errors);
             s = NULL;
         }
-        if (errors != global.errors)
+        if (global.gag && errors != global.errors)
         {
             type = savedtype;
             overnext = savedovernext;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -274,6 +274,23 @@ TemplateInstance *Dsymbol::inTemplateInstance()
     return NULL;
 }
 
+// Check if this function is a member of a template which has only been
+// instantiated speculatively, eg from inside is(typeof()).
+// Return the speculative template instance it is part of,
+// or NULL if not speculative.
+TemplateInstance *Dsymbol::isSpeculative()
+{
+    Dsymbol * par = parent;
+    while (par)
+    {
+        TemplateInstance *ti = par->isTemplateInstance();
+        if (ti && ti->speculative)
+            return ti;
+        par = par->toParent();
+    }
+    return NULL;
+}
+
 int Dsymbol::isAnonymous()
 {
     return ident ? 0 : 1;

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -136,6 +136,7 @@ struct Dsymbol : Object
     Dsymbol *toParent();
     Dsymbol *toParent2();
     TemplateInstance *inTemplateInstance();
+    TemplateInstance *isSpeculative();
 
     int dyncast() { return DYNCAST_DSYMBOL; }   // kludge for template.isSymbol()
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -670,23 +670,6 @@ Expression *callCpCtor(Loc loc, Scope *sc, Expression *e, int noscope)
 }
 #endif
 
-// Check if this function is a member of a template which has only been
-// instantiated speculatively, eg from inside is(typeof()).
-// Return the speculative template instance it is part of,
-// or NULL if not speculative.
-TemplateInstance *isSpeculativeFunction(FuncDeclaration *fd)
-{
-    Dsymbol * par = fd->parent;
-    while (par)
-    {
-        TemplateInstance *ti = par->isTemplateInstance();
-        if (ti && ti->speculative)
-            return ti;
-        par = par->toParent();
-    }
-    return NULL;
-}
-
 /****************************************
  * Now that we know the exact type of the function we're calling,
  * the arguments[] need to be adjusted:
@@ -716,7 +699,7 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
     // If inferring return type, and semantic3() needs to be run if not already run
     if (!tf->next && fd->inferRetType)
     {
-        TemplateInstance *spec = isSpeculativeFunction(fd);
+        TemplateInstance *spec = fd->isSpeculative();
         int olderrs = global.errors;
         fd->semantic3(fd->scope);
         // Update the template instantiation with the number
@@ -2741,7 +2724,7 @@ Lagain:
         // if inferring return type, sematic3 needs to be run
         if (f->inferRetType && f->scope && f->type && !f->type->nextOf())
         {
-            TemplateInstance *spec = isSpeculativeFunction(f);
+            TemplateInstance *spec = f->isSpeculative();
             int olderrs = global.errors;
             f->semantic3(f->scope);
             // Update the template instantiation with the number

--- a/src/expression.c
+++ b/src/expression.c
@@ -2719,7 +2719,13 @@ Lagain:
     {   //printf("'%s' is a function\n", f->toChars());
 
         if (!f->originalType && f->scope)       // semantic not yet run
+        {
+            unsigned oldgag = global.gag;
+            if (global.isSpeculativeGagging() && !f->isSpeculative())
+                global.gag = 0;
             f->semantic(f->scope);
+            global.gag = oldgag;
+        }
 
         // if inferring return type, sematic3 needs to be run
         if (f->inferRetType && f->scope && f->type && !f->type->nextOf())

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -27,7 +27,6 @@
 #include "attrib.h" // for AttribDeclaration
 
 #include "template.h"
-TemplateInstance *isSpeculativeFunction(FuncDeclaration *fd);
 
 
 #define LOG     0
@@ -475,7 +474,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
          */
         int olderrors = global.errors;
         int oldgag = global.gag;
-        TemplateInstance *spec = isSpeculativeFunction(this);
+        TemplateInstance *spec = isSpeculative();
         if (global.gag && !spec)
             global.gag = 0;
         semantic3(scope);

--- a/src/mars.c
+++ b/src/mars.c
@@ -117,6 +117,11 @@ bool Global::endGagging(unsigned oldGagged)
     return anyErrs;
 }
 
+bool Global::isSpeculativeGagging()
+{
+    return gag && gag == speculativeGag;
+}
+
 
 char *Loc::toChars()
 {

--- a/src/mars.h
+++ b/src/mars.h
@@ -262,6 +262,12 @@ struct Global
     unsigned gag;          // !=0 means gag reporting of errors & warnings
     unsigned gaggedErrors; // number of errors reported while gagged
 
+    /* Gagging can either be speculative (is(typeof()), etc)
+     * or because of forward references
+     */
+    unsigned speculativeGag; // == gag means gagging is for is(typeof);
+    bool isSpeculativeGagging();
+
     // Start gagging. Return the current number of gagged errors
     unsigned startGagging();
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6692,7 +6692,12 @@ Type *TypeTypeof::semantic(Loc loc, Scope *sc)
         Scope *sc2 = sc->push();
         sc2->intypeof++;
         sc2->flags |= sc->flags & SCOPEstaticif;
+        unsigned oldspecgag = global.speculativeGag;
+        if (global.gag)
+            global.speculativeGag = global.gag;
         exp = exp->semantic(sc2);
+        global.speculativeGag = oldspecgag;
+
 #if DMDV2
         if (exp->type && exp->type->ty == Tfunction &&
             ((TypeFunction *)exp->type)->isproperty)

--- a/src/struct.c
+++ b/src/struct.c
@@ -472,7 +472,12 @@ void StructDeclaration::semantic(Scope *sc)
             if (sizeok == 0 && s->isAliasDeclaration())
                 finalizeSize();
         }
+        // Ungag errors when not speculative
+        unsigned oldgag = global.gag;
+        if (global.isSpeculativeGagging() && !isSpeculative())
+            global.gag = 0;
         s->semantic(sc2);
+        global.gag = oldgag;
     }
 
     if (sizeok == 2)

--- a/src/traits.c
+++ b/src/traits.c
@@ -451,6 +451,8 @@ Expression *TraitsExp::semantic(Scope *sc)
             Expression *e;
 
             unsigned errors = global.startGagging();
+            unsigned oldspec = global.speculativeGag;
+            global.speculativeGag = global.gag;
 
             Type *t = isType(o);
             if (t)
@@ -471,6 +473,7 @@ Expression *TraitsExp::semantic(Scope *sc)
                 }
             }
 
+            global.speculativeGag = oldspec;
             if (global.endGagging(errors))
             {
                 goto Lfalse;

--- a/test/fail_compilation/gag4269a.d
+++ b/test/fail_compilation/gag4269a.d
@@ -1,0 +1,11 @@
+﻿// REQUIRED_ARGS: -c -o-
+
+static if(is(typeof(A4269.sizeof))) {}
+
+class A4269
+{
+    void foo(B b);
+}
+
+
+ 

--- a/test/fail_compilation/gag4269b.d
+++ b/test/fail_compilation/gag4269b.d
@@ -1,0 +1,6 @@
+﻿// REQUIRED_ARGS: -c -o-
+
+static if(is(typeof(X2.init))) {}
+struct X2 { Y y; }
+
+ 

--- a/test/fail_compilation/gag4269c.d
+++ b/test/fail_compilation/gag4269c.d
@@ -1,0 +1,5 @@
+﻿// REQUIRED_ARGS: -c -o-
+
+static if(is(typeof(X3.init))) {}
+void X3(T3) { }
+ 

--- a/test/fail_compilation/gag4269d.d
+++ b/test/fail_compilation/gag4269d.d
@@ -1,0 +1,5 @@
+﻿// REQUIRED_ARGS: -c -o-
+
+static if(is(typeof(X4.init))) {}
+Y4 X4() { return typeof(return).init; }
+ 

--- a/test/fail_compilation/gag4269e.d
+++ b/test/fail_compilation/gag4269e.d
@@ -1,0 +1,4 @@
+﻿// REQUIRED_ARGS: -c -o-
+
+static if(is(typeof(X8.init))) {}
+class X8 : Y8 {} 

--- a/test/fail_compilation/gag4269f.d
+++ b/test/fail_compilation/gag4269f.d
@@ -1,0 +1,4 @@
+﻿// REQUIRED_ARGS: -c -o-
+
+static if(is(typeof(X9.init))) {}
+interface X9 { Y9 y; }


### PR DESCRIPTION
Fixes the function, struct, class and alias test cases. Unlike the existing catch-all in the glue layer, this patch gives proper front-end error messages.
Test cases 7, 11, 12, 13, and 15 are still not fixed. They involve var and enum declarations.

How it works:
Errors can be gagged for two reasons: (a) attempts to deal with forward references; (b) speculation about types, (is(typeof()), __traits(compiles)). Whenever we enter case (b), set a 'global::speculativeGag' integer to record which gagging level it began at.
If we're in case (b), and we need to run semantic on a declaration, then ungag errors, unless it is part of a speculatively instantiated template. The code relating to speculative templates is already in the compiler, from a previous pull request I made last year.
