### PR TITLE
fix Dsymbol::search_correct

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -358,11 +358,21 @@ Dsymbol *Dsymbol::search(Loc loc, Identifier *ident, int flags)
 
 void *symbol_search_fp(void *arg, const char *seed)
 {
+    /* If not in the lexer's string table, it certainly isn't in the symbol table.
+     * Doing this first is a lot faster.
+     */
+    size_t len = strlen(seed);
+    if (!len)
+        return NULL;
+    StringValue *sv = Lexer::stringtable.lookup(seed, len);
+    if (!sv)
+        return NULL;
+    Identifier *id = (Identifier *)sv->ptrvalue;
+    assert(id);
+
     Dsymbol *s = (Dsymbol *)arg;
-    Identifier id(seed, 0);
     Module::clearCache();
-    s = s->search(0, &id, 4|2);
-    return s;
+    return s->search(0, id, 4|2);
 }
 
 Dsymbol *Dsymbol::search_correct(Identifier *ident)


### PR DESCRIPTION
- Since DsymbolTable no longer uses a StringTable we need to look up
  speller proposals in the lexer StringTable to get a unique identifier.
