### PR TITLE
Hide module members

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -410,3 +410,13 @@ void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
         cd->accessCheck(loc, sc, d);
     }
 }
+
+enum PROT moduleVisibility(Module *from, Module *to)
+{
+    if (from == to)
+        return PROTprivate;
+    else if (from && to && from->parent && from->parent == to->parent)
+        return PROTpackage;
+    else
+        return PROTpublic;
+}

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -658,6 +658,7 @@ struct FuncDeclaration : Declaration
     int canInline(int hasthis, int hdrscan, int statementsToo);
     Expression *expandInline(InlineScanState *iss, Expression *ethis, Expressions *arguments, Statement **ps);
     const char *kind();
+    enum PROT overprot();
     void toDocBuffer(OutBuffer *buf);
     FuncDeclaration *isUnique();
     void checkNestedReference(Scope *sc, Loc loc);

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -339,7 +339,7 @@ void Dsymbol::inlineScan()
 /*********************************************
  * Search for ident as member of s.
  * Input:
- *      flags:  1       don't find private members
+ *      flags:  1       don't restrict visibility
  *              2       don't give error messages
  *              4       return NULL if ambiguous
  * Returns:
@@ -696,6 +696,11 @@ enum PROT Dsymbol::prot()
     return PROTpublic;
 }
 
+enum PROT Dsymbol::overprot()
+{
+    return prot();
+}
+
 /*************************************
  * Do syntax copy of an array of Dsymbol's.
  */
@@ -801,27 +806,49 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
     // Look in symbols declared in this module
     Dsymbol *s = symtab ? symtab->lookup(ident) : NULL;
     //printf("\ts = %p, imports = %p, %d\n", s, imports, imports ? imports->dim : 0);
-    if (s)
-    {
-        //printf("\ts = '%s.%s'\n",toChars(),s->toChars());
-    }
-    else if (imports)
+    if (!s)
+        s = searchImports(loc, ident, flags, PROTprivate);
+    return s;
+}
+
+/* Search the imports for symbol ident.
+ * Parameter:
+ *      loc, ident, flags - as Dsymbol::search
+ *      visibility        - restricts the visibility of symbols
+ * Returns:
+ *      NULL if not found
+ */
+Dsymbol *ScopeDsymbol::searchImports(Loc loc, Identifier *ident, int flags, enum PROT visibility)
+{
+    Dsymbol *s = NULL;
+    if (imports)
     {
         OverloadSet *a = NULL;
+        Module *thisModule = NULL;
 
         // Look in imported modules
         for (size_t i = 0; i < imports->dim; i++)
         {   Dsymbol *ss = (*imports)[i];
             Dsymbol *s2;
 
-            // If private import, don't search it
-            if (flags & 1 && prots[i] == PROTprivate)
+            // If restricted import, don't search it
+            if (!(flags & 1) && prots[i] < visibility)
                 continue;
 
             //printf("\tscanning import '%s', prots = %d, isModule = %p, isImport = %p\n", ss->toChars(), prots[i], ss->isModule(), ss->isImport());
-            /* Don't find private members if ss is a module
-             */
-            s2 = ss->search(loc, ident, ss->isModule() ? 1 : 0);
+            Module *m;
+            if (!(flags & 1) && (m = ss->isModule()))
+            {
+                if (!thisModule)
+                    thisModule = getAccessModule();
+                enum PROT mvisibility = moduleVisibility(thisModule, m);
+                if (mvisibility < visibility) // restrict visibility
+                    mvisibility = visibility;
+                s2 = m->search(loc, ident, flags, mvisibility);
+            }
+            else
+                s2 = ss->search(loc, ident, flags);
+
             if (!s)
                 s = s2;
             else if (s2 && s != s2)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -179,6 +179,7 @@ struct Dsymbol : Object
     virtual char *mangle();
     virtual int needThis();                     // need a 'this' pointer?
     virtual enum PROT prot();
+    virtual enum PROT overprot();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     virtual int oneMember(Dsymbol **ps, Identifier *ident);
     static int oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident = NULL);
@@ -261,6 +262,7 @@ struct ScopeDsymbol : Dsymbol
     ScopeDsymbol(Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
+    Dsymbol *searchImports(Loc loc, Identifier *ident, int flags, enum PROT visibility);
     void importScope(Dsymbol *s, enum PROT protection);
     int isforwardRef();
     void defineRef(Dsymbol *s);

--- a/src/expression.c
+++ b/src/expression.c
@@ -6422,12 +6422,15 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
     {
         ScopeExp *ie = (ScopeExp *)eright;
 
-        /* Disable access to another module's private imports.
-         * The check for 'is sds our current module' is because
-         * the current module should have access to its own imports.
+        /* Restrict access to another module's symbols.
          */
-        Dsymbol *s = ie->sds->search(loc, ident,
-            (ie->sds->isModule() && ie->sds != sc->module) ? 1 : 0);
+        Dsymbol *s;
+        if (Module *m = ie->sds->isModule())
+        {   enum PROT visibility = moduleVisibility(sc->module, m);
+            s = m->search(loc, ident, 0, visibility);
+        }
+        else
+            s = ie->sds->search(loc, ident, 0);
         if (s)
         {
             /* Check for access before resolving aliases because public

--- a/src/func.c
+++ b/src/func.c
@@ -2959,6 +2959,21 @@ const char *FuncDeclaration::kind()
     return "function";
 }
 
+static int maxProt(void *arg, FuncDeclaration *f)
+{
+    enum PROT nprot = f->prot();
+    if (nprot > *(enum PROT*)arg) // take looser one
+        *(enum PROT*)arg = nprot;
+    return 0;
+}
+
+enum PROT FuncDeclaration::overprot()
+{
+    enum PROT result = prot();
+    overloadApply(this, &maxProt, &result);
+    return result;
+}
+
 void FuncDeclaration::checkNestedReference(Scope *sc, Loc loc)
 {
     //printf("FuncDeclaration::checkNestedReference() %s\n", toChars());

--- a/src/import.c
+++ b/src/import.c
@@ -216,11 +216,12 @@ void Import::semantic(Scope *sc)
 #else
         sc->protection = PROTpublic;
 #endif
+        enum PROT visibility = moduleVisibility(getAccessModule(), mod);
         for (size_t i = 0; i < aliasdecls.dim; i++)
         {   Dsymbol *s = aliasdecls.tdata()[i];
 
             //printf("\tImport alias semantic('%s')\n", s->toChars());
-            if (!mod->search(loc, names.tdata()[i], 0))
+            if (!mod->search(loc, names.tdata()[i], 0, visibility))
                 error("%s not found", (names.tdata()[i])->toChars());
 
             s->semantic(sc);

--- a/src/module.h
+++ b/src/module.h
@@ -80,6 +80,7 @@ struct Module : Package
     Identifier *searchCacheIdent;
     Dsymbol *searchCacheSymbol; // cached value of search
     int searchCacheFlags;       // cached flags
+    enum PROT searchCacheVisibility;
 
     int semanticstarted;        // has semantic() been started?
     int semanticRun;            // has semantic() been done?
@@ -138,6 +139,7 @@ struct Module : Package
     void gendocfile();
     int needModuleInfo();
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
+    Dsymbol *search(Loc loc, Identifier *ident, int flags, enum PROT visibility);
     Dsymbol *symtabInsert(Dsymbol *s);
     void deleteObjFile();
     void addDeferredSemantic(Dsymbol *s);
@@ -179,6 +181,8 @@ struct Module : Package
     Module *isModule() { return this; }
 };
 
+// access.c
+enum PROT moduleVisibility(Module *from, Module *to);
 
 struct ModuleDeclaration
 {

--- a/test/compilable/imports/test1238a.d
+++ b/test/compilable/imports/test1238a.d
@@ -1,0 +1,3 @@
+module imports.test1238a;
+
+private int zuiop;

--- a/test/compilable/imports/test1238b.d
+++ b/test/compilable/imports/test1238b.d
@@ -1,0 +1,3 @@
+module imports.test1238b;
+
+public int zuiop;

--- a/test/compilable/imports/test1754a.d
+++ b/test/compilable/imports/test1754a.d
@@ -1,0 +1,5 @@
+module imports.test1754a;
+
+private void bar()
+{
+}

--- a/test/compilable/imports/test1754b.d
+++ b/test/compilable/imports/test1754b.d
@@ -1,0 +1,5 @@
+module imports.test1754b;
+
+void bar()
+{
+}

--- a/test/compilable/test1238.d
+++ b/test/compilable/test1238.d
@@ -1,0 +1,10 @@
+module test1238;
+
+import imports.test1238a;
+import imports.test1238b;
+
+void foo()
+{
+    int qwert = zuiop;
+}
+

--- a/test/compilable/test1754.d
+++ b/test/compilable/test1754.d
@@ -1,0 +1,9 @@
+module test1754;
+
+import imports.test1754a;
+import imports.test1754b;
+
+void foo()
+{
+    bar();
+}


### PR DESCRIPTION
- restrict visibility of module level symbols to given access rights
- restrict access rights when searching across imported modules
