### PR TITLE
Issue 7105 - relax inout rules

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1127,7 +1127,7 @@ Lnomatch:
         {
             if (func->fes)
                 func = func->fes->func;
-            if (!func->type->hasWild())
+            if (!((TypeFunction *)func->type)->iswild)
             {
                 error("inout variables can only be declared inside inout functions");
             }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4865,6 +4865,7 @@ TypeFunction::TypeFunction(Parameters *parameters, Type *treturn, int varargs, e
     this->purity = PUREimpure;
     this->isproperty = false;
     this->isref = false;
+    this->iswild = false;
     this->fargs = NULL;
 
     if (stc & STCpure)
@@ -5421,8 +5422,8 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 !(t->ty == Tpointer && t->nextOf()->ty == Tfunction || t->ty == Tdelegate))
             {
                 wildparams = TRUE;
-                if (tf->next && !wildreturn)
-                    error(loc, "inout on parameter means inout must be on return type as well (if from D1 code, replace with 'ref')");
+                //if (tf->next && !wildreturn)
+                //    error(loc, "inout on parameter means inout must be on return type as well (if from D1 code, replace with 'ref')");
             }
 
             if (fparam->defaultArg)
@@ -5490,6 +5491,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
 
     if (wildreturn && !wildparams)
         error(loc, "inout on return means inout must be on a parameter as well for %s", toChars());
+    tf->iswild = wildparams;
 
     if (tf->next)
         tf->deco = tf->merge()->deco;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5380,7 +5380,6 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
     }
 
     bool wildparams = FALSE;
-    bool wildsubparams = FALSE;
     if (tf->parameters)
     {
         /* Create a scope for evaluating the default arguments for the parameters
@@ -5425,8 +5424,6 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 if (tf->next && !wildreturn)
                     error(loc, "inout on parameter means inout must be on return type as well (if from D1 code, replace with 'ref')");
             }
-            else if (!wildsubparams && t->hasWild())
-                wildsubparams = TRUE;
 
             if (fparam->defaultArg)
             {
@@ -5493,8 +5490,6 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
 
     if (wildreturn && !wildparams)
         error(loc, "inout on return means inout must be on a parameter as well for %s", toChars());
-    if (wildsubparams && wildparams)
-        error(loc, "inout must be all or none on top level for %s", toChars());
 
     if (tf->next)
         tf->deco = tf->merge()->deco;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -612,6 +612,7 @@ struct TypeFunction : TypeNext
     enum LINK linkage;  // calling convention
     enum TRUST trust;   // level of trust
     enum PURE purity;   // PURExxxx
+    bool iswild;        // is inout function
     Expressions *fargs; // function arguments
 
     int inuse;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1268,7 +1268,7 @@ void test79()
 
 /************************************/
 
-inout(int) test80(inout(int) _ = 0)
+void test80(inout(int) _ = 0)
 {
     char x;
     inout(char) y = x;
@@ -1321,13 +1321,11 @@ inout(int) test80(inout(int) _ = 0)
     static assert(!__traits(compiles, sw = sc));
     static assert(!__traits(compiles, sw = w));
     sw = sw;
-
-    return 0;
 }
 
 /************************************/
 
-inout(int) test81(inout(int) _ = 0)
+void test81(inout(int) _ = 0)
 {
     const(char)* c;
     immutable(char)* i;
@@ -1364,14 +1362,12 @@ inout(int) test81(inout(int) _ = 0)
     static assert(!__traits(compiles, w = s));
     static assert(!__traits(compiles, w = sc));
     w = w;
-
-    return 0;
 }
 
 /************************************/
 
 
-inout(int) test82(inout(int) _ = 0)
+void test82(inout(int) _ = 0)
 {
     const(immutable(char)*) c;
     pragma(msg, typeof(c));
@@ -1465,20 +1461,16 @@ inout(int) test82(inout(int) _ = 0)
     static assert(typeof(s).stringof == "inout(shared(char**)***)");
     pragma(msg, typeof(***s));
     static assert(typeof(***s).stringof == "shared(inout(char**))");
-
-    return 0;
 }
 
 /************************************/
 
-inout(int) test83(inout(int) _ = 0)
+void test83(inout(int) _ = 0)
 {
-    static assert(!__traits(compiles, typeid(int* function(inout int))));
+    static assert( __traits(compiles, typeid(int* function(inout int))));
     static assert(!__traits(compiles, typeid(inout(int*) function(int))));
     static assert(!__traits(compiles, typeid(inout(int*) function())));
     inout(int*) function(inout(int)) fp;
-
-    return 0;
 }
 
 /************************************/
@@ -2454,6 +2446,40 @@ void test6940()
 }
 
 /************************************/
+// 7105
+
+void copy(inout(int)** tgt, inout(int)* src){ *tgt = src; }
+
+void test7105()
+{
+    int* pm;
+    int m;
+    copy(&pm, &m);
+    assert(pm == &m);
+
+    const(int)* pc;
+    const(int) c;
+    copy(&pc, &c);
+    assert(pc == &c);
+
+    immutable(int)* pi;
+    immutable(int) i;
+    copy(&pi, &i);
+    assert(pi == &i);
+
+    static assert(!__traits(compiles, copy(&pm, &c)));
+    static assert(!__traits(compiles, copy(&pm, &i)));
+
+    copy(&pc, &m);
+    assert(pc == &m);
+    copy(&pc, &i);
+    assert(pc == &i);
+
+    static assert(!__traits(compiles, copy(&pi, &m)));
+    static assert(!__traits(compiles, copy(&pi, &c)));
+}
+
+/************************************/
 // 7202
 
 void test7202()
@@ -2573,6 +2599,7 @@ int main()
     test6912();
     test6939();
     test6940();
+    test7105();
     test7202();
 
     printf("Success\n");


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7105">Issue 7105</a> - relax inout rules

Now <a href="http://d.puremagic.com/issues/show_bug.cgi?id=5493">bug 5493</a> and <a href="http://d.puremagic.com/issues/show_bug.cgi?id=4251">bug 4251</a> was fixed, so inout function doesn't have inout return type works properly without breaking type system. So, there is no faults to do this.

<del>
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7542">Issue 7542</a> - inout parameter contravariant should be allowed
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7543">Issue 7543</a> - inout opApply should work properly
</del>


<del>
After relaxing inout rules, we can write useful inout opApply with delegate parameter that receives inout, and it should work properly. Supporting it will increase usefullness of inout type system.
</del>
