### PR TITLE
Issue 7544 - ICE(interpret.c) Catching an exception with a null catch block

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1475,25 +1475,25 @@ Expression *TryCatchStatement::interpret(InterState *istate)
     ThrownExceptionExp *ex = (ThrownExceptionExp *)e;
     Type *extype = ex->thrown->originalClass()->type;
     // Search for an appropriate catch clause.
-        for (size_t i = 0; i < catches->dim; i++)
-        {
+    for (size_t i = 0; i < catches->dim; i++)
+    {
 #if DMDV1
-            Catch *ca = (Catch *)catches->data[i];
+        Catch *ca = (Catch *)catches->data[i];
 #else
-            Catch *ca = catches->tdata()[i];
+        Catch *ca = catches->tdata()[i];
 #endif
-            Type *catype = ca->type;
+        Type *catype = ca->type;
 
-            if (catype->equals(extype) || catype->isBaseOf(extype, NULL))
-            {   // Execute the handler
+        if (catype->equals(extype) || catype->isBaseOf(extype, NULL))
+        {   // Execute the handler
             if (ca->var)
             {
                 ctfeStack.push(ca->var);
                 ca->var->setValue(ex->thrown);
             }
-            return ca->handler->interpret(istate);
-            }
+            return ca->handler ? ca->handler->interpret(istate) : NULL;
         }
+    }
     return e;
 }
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3439,6 +3439,17 @@ void test6228()
 
 /***************************************************/
 
+int test7544()
+{
+    try { throw new Exception(""); }
+    catch (Exception e) static assert(1);
+    return 1;
+}
+
+static assert(test7544());
+
+/***************************************************/
+
 struct S6230 {
     int p;
     int q() const pure {


### PR DESCRIPTION
One-liner in interpret.c to avoid interpreting a NULL pointer.

http://d.puremagic.com/issues/show_bug.cgi?id=7544
