### PR TITLE
Hide module members

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -410,3 +410,13 @@ void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
         cd->accessCheck(loc, sc, d);
     }
 }
+
+enum PROT moduleVisibility(Module *from, Module *to)
+{
+    if (from == to)
+        return PROTprivate;
+    else if (from && to && from->parent && from->parent == to->parent)
+        return PROTpackage;
+    else
+        return PROTpublic;
+}

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -661,7 +661,7 @@ struct FuncDeclaration : Declaration
     void appendExp(Expression *e);
     void appendState(Statement *s);
     char *mangle();
-    const char *toPrettyChars();
+    const char *toPrettyChars(bool verbose=false);
     int isMain();
     int isWinMain();
     int isDllMain();

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -691,6 +691,7 @@ struct FuncDeclaration : Declaration
     int canInline(int hasthis, int hdrscan, int statementsToo);
     Expression *expandInline(InlineScanState *iss, Expression *ethis, Expressions *arguments, Statement **ps);
     const char *kind();
+    enum PROT overprot();
     void toDocBuffer(OutBuffer *buf, Scope *sc);
     FuncDeclaration *isUnique();
     void checkNestedReference(Scope *sc, Loc loc);

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -364,7 +364,7 @@ void Dsymbol::inlineScan()
 /*********************************************
  * Search for ident as member of s.
  * Input:
- *      flags:  1       don't find private members
+ *      flags:  1       don't restrict visibility
  *              2       don't give error messages
  *              4       return NULL if ambiguous
  * Returns:
@@ -743,6 +743,11 @@ enum PROT Dsymbol::prot()
     return PROTpublic;
 }
 
+enum PROT Dsymbol::overprot()
+{
+    return prot();
+}
+
 /*************************************
  * Do syntax copy of an array of Dsymbol's.
  */
@@ -848,27 +853,49 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
     // Look in symbols declared in this module
     Dsymbol *s = symtab ? symtab->lookup(ident) : NULL;
     //printf("\ts = %p, imports = %p, %d\n", s, imports, imports ? imports->dim : 0);
-    if (s)
-    {
-        //printf("\ts = '%s.%s'\n",toChars(),s->toChars());
-    }
-    else if (imports)
+    if (!s)
+        s = searchImports(loc, ident, flags, PROTprivate);
+    return s;
+}
+
+/* Search the imports for symbol ident.
+ * Parameter:
+ *      loc, ident, flags - as Dsymbol::search
+ *      visibility        - restricts the visibility of symbols
+ * Returns:
+ *      NULL if not found
+ */
+Dsymbol *ScopeDsymbol::searchImports(Loc loc, Identifier *ident, int flags, enum PROT visibility)
+{
+    Dsymbol *s = NULL;
+    if (imports)
     {
         OverloadSet *a = NULL;
+        Module *thisModule = NULL;
 
         // Look in imported modules
         for (size_t i = 0; i < imports->dim; i++)
         {   Dsymbol *ss = (*imports)[i];
             Dsymbol *s2;
 
-            // If private import, don't search it
-            if (flags & 1 && prots[i] == PROTprivate)
+            // If restricted import, don't search it
+            if (!(flags & 1) && prots[i] < visibility)
                 continue;
 
             //printf("\tscanning import '%s', prots = %d, isModule = %p, isImport = %p\n", ss->toChars(), prots[i], ss->isModule(), ss->isImport());
-            /* Don't find private members if ss is a module
-             */
-            s2 = ss->search(loc, ident, ss->isModule() ? 1 : 0);
+            Module *m;
+            if (!(flags & 1) && (m = ss->isModule()) != NULL)
+            {
+                if (!thisModule)
+                    thisModule = getAccessModule();
+                enum PROT mvisibility = moduleVisibility(thisModule, m);
+                if (mvisibility < visibility) // restrict visibility
+                    mvisibility = visibility;
+                s2 = m->search(loc, ident, flags, mvisibility);
+            }
+            else
+                s2 = ss->search(loc, ident, flags);
+
             if (!s)
                 s = s2;
             else if (s2 && s != s2)

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -397,7 +397,7 @@ void *symbol_search_fp(void *arg, const char *seed)
 
     Dsymbol *s = (Dsymbol *)arg;
     Module::clearCache();
-    return s->search(0, id, 4|2);
+    return s->search(0, id, 1|2);
 }
 
 Dsymbol *Dsymbol::search_correct(Identifier *ident)
@@ -405,7 +405,10 @@ Dsymbol *Dsymbol::search_correct(Identifier *ident)
     if (global.gag)
         return NULL;            // don't do it for speculative compiles; too time consuming
 
-    return (Dsymbol *)speller(ident->toChars(), &symbol_search_fp, this, idchars);
+    Dsymbol *s = search(0, ident, 1|2); // repeat search including private symbols
+    if (!s)
+        s = (Dsymbol *)speller(ident->toChars(), &symbol_search_fp, this, idchars);
+    return s;
 }
 
 /***************************************

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -192,6 +192,7 @@ struct Dsymbol : Object
     virtual char *mangle();
     virtual int needThis();                     // need a 'this' pointer?
     virtual enum PROT prot();
+    virtual enum PROT overprot();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     virtual int oneMember(Dsymbol **ps, Identifier *ident);
     static int oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident = NULL);
@@ -272,6 +273,7 @@ struct ScopeDsymbol : Dsymbol
     ScopeDsymbol(Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
+    Dsymbol *searchImports(Loc loc, Identifier *ident, int flags, enum PROT visibility);
     void importScope(Dsymbol *s, enum PROT protection);
     int isforwardRef();
     void defineRef(Dsymbol *s);

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -150,7 +150,7 @@ struct Dsymbol : Object
 
     static Dsymbols *arraySyntaxCopy(Dsymbols *a);
 
-    virtual const char *toPrettyChars();
+    virtual const char *toPrettyChars(bool verbose=false);
     virtual const char *kind();
     virtual Dsymbol *toAlias();                 // resolve real symbol
     virtual int apply(Dsymbol_apply_ft_t fp, void *param);

--- a/src/expression.c
+++ b/src/expression.c
@@ -2908,7 +2908,7 @@ Expression *IdentifierExp::semantic(Scope *sc)
     {
         s = sc->search_correct(ident);
         if (s)
-            error("undefined identifier %s, did you mean %s %s?", ident->toChars(), s->kind(), s->toChars());
+            error("undefined identifier %s, did you mean '%s'?", ident->toChars(), s->toPrettyChars(true));
         else
             error("undefined identifier %s", ident->toChars());
     }
@@ -7037,8 +7037,7 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
         }
         s = ie->sds->search_correct(ident);
         if (s)
-            error("undefined identifier '%s', did you mean '%s %s'?",
-                  ident->toChars(), s->kind(), s->toChars());
+            error("undefined identifier '%s', did you mean '%s'?", ident->toChars(), s->toPrettyChars(true));
         else
             error("undefined identifier '%s'", ident->toChars());
         return new ErrorExp();

--- a/src/expression.c
+++ b/src/expression.c
@@ -6899,12 +6899,15 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
     {
         ScopeExp *ie = (ScopeExp *)eright;
 
-        /* Disable access to another module's private imports.
-         * The check for 'is sds our current module' is because
-         * the current module should have access to its own imports.
+        /* Restrict access to another module's symbols.
          */
-        Dsymbol *s = ie->sds->search(loc, ident,
-            (ie->sds->isModule() && ie->sds != sc->module) ? 1 : 0);
+        Dsymbol *s;
+        if (Module *m = ie->sds->isModule())
+        {   enum PROT visibility = moduleVisibility(sc->module, m);
+            s = m->search(loc, ident, 0, visibility);
+        }
+        else
+            s = ie->sds->search(loc, ident, 0);
         if (s)
         {
             /* Check for access before resolving aliases because public

--- a/src/func.c
+++ b/src/func.c
@@ -646,7 +646,7 @@ void FuncDeclaration::semantic(Scope *sc)
             }
 
             if (s)
-                error("does not override any function, did you mean to override '%s'?", s->toPrettyChars());
+                error("does not override any function, did you mean to override '%s'?", s->toPrettyChars(true));
             else
                 error("does not override any function");
         }
@@ -2896,12 +2896,12 @@ void FuncDeclaration::appendState(Statement *s)
     }
 }
 
-const char *FuncDeclaration::toPrettyChars()
+const char *FuncDeclaration::toPrettyChars(bool verbose)
 {
     if (isMain())
         return "D main";
     else
-        return Dsymbol::toPrettyChars();
+        return Dsymbol::toPrettyChars(verbose);
 }
 
 int FuncDeclaration::isMain()

--- a/src/func.c
+++ b/src/func.c
@@ -3210,6 +3210,21 @@ const char *FuncDeclaration::kind()
     return "function";
 }
 
+static int maxProt(void *arg, FuncDeclaration *f)
+{
+    enum PROT nprot = f->prot();
+    if (nprot > *(enum PROT*)arg) // take looser one
+        *(enum PROT*)arg = nprot;
+    return 0;
+}
+
+enum PROT FuncDeclaration::overprot()
+{
+    enum PROT result = prot();
+    overloadApply(this, &maxProt, &result);
+    return result;
+}
+
 void FuncDeclaration::checkNestedReference(Scope *sc, Loc loc)
 {
     //printf("FuncDeclaration::checkNestedReference() %s\n", toChars());

--- a/src/import.c
+++ b/src/import.c
@@ -233,11 +233,12 @@ void Import::semantic(Scope *sc)
 #else
         sc->protection = PROTpublic;
 #endif
+        enum PROT visibility = moduleVisibility(getAccessModule(), mod);
         for (size_t i = 0; i < aliasdecls.dim; i++)
         {   Dsymbol *s = aliasdecls[i];
 
             //printf("\tImport alias semantic('%s')\n", s->toChars());
-            if (mod->search(loc, names[i], 0))
+            if (mod->search(loc, names[i], 0, visibility))
                 s->semantic(sc);
             else
             {

--- a/src/import.c
+++ b/src/import.c
@@ -244,7 +244,7 @@ void Import::semantic(Scope *sc)
             {
                 s = mod->search_correct(names[i]);
                 if (s)
-                    mod->error(loc, "import '%s' not found, did you mean '%s %s'?", names[i]->toChars(), s->kind(), s->toChars());
+                    mod->error(loc, "import '%s' not found, did you mean '%s'?", names[i]->toChars(), s->toPrettyChars(true));
                 else
                     mod->error(loc, "import '%s' not found", names[i]->toChars());
             }

--- a/src/init.c
+++ b/src/init.c
@@ -202,8 +202,8 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t, NeedInterpret needI
                 {
                     s = ad->search_correct(id);
                     if (s)
-                        error(loc, "'%s' is not a member of '%s', did you mean '%s %s'?",
-                              id->toChars(), t->toChars(), s->kind(), s->toChars());
+                        error(loc, "'%s' is not a member of '%s', did you mean '%s'?",
+                              id->toChars(), t->toChars(), s->toPrettyChars(true));
                     else
                         error(loc, "'%s' is not a member of '%s'", id->toChars(), t->toChars());
                     errors = 1;

--- a/src/module.c
+++ b/src/module.c
@@ -77,6 +77,7 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
     searchCacheIdent = NULL;
     searchCacheSymbol = NULL;
     searchCacheFlags = 0;
+    searchCacheVisibility = PROTundefined;
     semanticstarted = 0;
     semanticRun = 0;
     decldefs = NULL;
@@ -869,6 +870,11 @@ int Module::needModuleInfo()
 
 Dsymbol *Module::search(Loc loc, Identifier *ident, int flags)
 {
+    return search(loc, ident, flags, PROTprivate);
+}
+
+Dsymbol *Module::search(Loc loc, Identifier *ident, int flags, enum PROT visibility)
+{
     /* Since modules can be circularly referenced,
      * need to stop infinite recursive searches.
      * This is done with the cache.
@@ -878,7 +884,8 @@ Dsymbol *Module::search(Loc loc, Identifier *ident, int flags)
     Dsymbol *s;
     if (insearch)
         s = NULL;
-    else if (searchCacheIdent == ident && searchCacheFlags == flags)
+    else if (searchCacheIdent == ident && searchCacheFlags == flags &&
+             searchCacheVisibility == visibility)
     {
         s = searchCacheSymbol;
         //printf("%s Module::search('%s', flags = %d) insearch = %d searchCacheSymbol = %s\n", toChars(), ident->toChars(), flags, insearch, searchCacheSymbol ? searchCacheSymbol->toChars() : "null");
@@ -886,12 +893,19 @@ Dsymbol *Module::search(Loc loc, Identifier *ident, int flags)
     else
     {
         insearch = 1;
-        s = ScopeDsymbol::search(loc, ident, flags);
+        s = symtab ? symtab->lookup(ident) : NULL;
+        // restrict visibility of top level symbols based on access
+        enum PROT prot;
+        if (s && !(flags & 1) && (prot = s->overprot()) != PROTundefined && prot < visibility)
+            s = NULL;
+        if (!s)
+            s = ScopeDsymbol::searchImports(loc, ident, flags, visibility);
         insearch = 0;
 
         searchCacheIdent = ident;
         searchCacheSymbol = s;
         searchCacheFlags = flags;
+        searchCacheVisibility = visibility;
     }
     return s;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -79,6 +79,7 @@ struct Module : Package
     Identifier *searchCacheIdent;
     Dsymbol *searchCacheSymbol; // cached value of search
     int searchCacheFlags;       // cached flags
+    enum PROT searchCacheVisibility;
 
     int semanticstarted;        // has semantic() been started?
     int semanticRun;            // has semantic() been done?
@@ -134,6 +135,7 @@ struct Module : Package
     void gendocfile();
     int needModuleInfo();
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
+    Dsymbol *search(Loc loc, Identifier *ident, int flags, enum PROT visibility);
     Dsymbol *symtabInsert(Dsymbol *s);
     void deleteObjFile();
     void addDeferredSemantic(Dsymbol *s);
@@ -175,6 +177,8 @@ struct Module : Package
     Module *isModule() { return this; }
 };
 
+// access.c
+enum PROT moduleVisibility(Module *from, Module *to);
 
 struct ModuleDeclaration
 {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2014,7 +2014,8 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
         if (this != Type::terror)
         {
             if (s)
-                error(loc, "no property '%s' for type '%s', did you mean '%s'?", ident->toChars(), toChars(), s->toChars());
+                error(loc, "no property '%s' for type '%s', did you mean '%s'?",
+                      ident->toChars(), toChars(), s->toPrettyChars(true));
             else
                 error(loc, "no property '%s' for type '%s'", ident->toChars(), toChars());
         }
@@ -6641,8 +6642,8 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                     {
                         sm = s->search_correct(id);
                         if (sm)
-                            error(loc, "identifier '%s' of '%s' is not defined, did you mean '%s %s'?",
-                                  id->toChars(), toChars(), sm->kind(), sm->toChars());
+                            error(loc, "identifier '%s' of '%s' is not defined, did you mean '%s'?",
+                                  id->toChars(), toChars(), sm->toPrettyChars(true));
                         else
                             error(loc, "identifier '%s' of '%s' is not defined", id->toChars(), toChars());
                     }
@@ -6742,9 +6743,9 @@ L1:
             Identifier *id = new Identifier(p, TOKidentifier);
             s = sc->search_correct(id);
             if (s)
-                error(loc, "undefined identifier %s, did you mean %s %s?", p, s->kind(), s->toChars());
+                error(loc, "undefined identifier '%s', did you mean '%s'?", p, s->toPrettyChars(true));
             else
-                error(loc, "undefined identifier %s", p);
+                error(loc, "undefined identifier '%s'", p);
         }
         *pt = Type::terror;
     }

--- a/src/scope.c
+++ b/src/scope.c
@@ -243,7 +243,7 @@ void Scope::mergeCallSuper(Loc loc, unsigned cs)
     }
 }
 
-Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym)
+Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym, int flags)
 {   Dsymbol *s;
     Scope *sc;
 
@@ -275,7 +275,7 @@ Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym)
         if (sc->scopesym)
         {
             //printf("\tlooking in scopesym '%s', kind = '%s'\n", sc->scopesym->toChars(), sc->scopesym->kind());
-            s = sc->scopesym->search(loc, ident, 0);
+            s = sc->scopesym->search(loc, ident, flags);
             if (s)
             {
                 if (global.params.Dversion > 1 &&
@@ -411,7 +411,7 @@ void *scope_search_fp(void *arg, const char *seed)
 
     Scope *sc = (Scope *)arg;
     Module::clearCache();
-    Dsymbol *s = sc->search(0, id, NULL);
+    Dsymbol *s = sc->search(0, id, NULL, 1|2);
     return s;
 }
 
@@ -420,5 +420,8 @@ Dsymbol *Scope::search_correct(Identifier *ident)
     if (global.gag)
         return NULL;            // don't do it for speculative compiles; too time consuming
 
-    return (Dsymbol *)speller(ident->toChars(), &scope_search_fp, this, idchars);
+    Dsymbol *s = search(0, ident, NULL, 1|2); // repeat search including private symbols
+    if (!s)
+        s = (Dsymbol *)speller(ident->toChars(), &scope_search_fp, this, idchars);
+    return s;
 }

--- a/src/scope.h
+++ b/src/scope.h
@@ -122,7 +122,7 @@ struct Scope
 
     void mergeCallSuper(Loc loc, unsigned cs);
 
-    Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym);
+    Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym, int flags=0);
     Dsymbol *search_correct(Identifier *ident);
     Dsymbol *insert(Dsymbol *s);
 

--- a/src/template.c
+++ b/src/template.c
@@ -5474,7 +5474,7 @@ TemplateDeclaration *TemplateInstance::findTemplateDeclaration(Scope *sc)
         {
             s = sc->search_correct(id);
             if (s)
-                error("template '%s' is not defined, did you mean %s?", id->toChars(), s->toChars());
+                error("template '%s' is not defined, did you mean '%s'?", id->toChars(), s->toPrettyChars(true));
             else
                 error("template '%s' is not defined", id->toChars());
             return NULL;

--- a/test/compilable/imports/test1238a.d
+++ b/test/compilable/imports/test1238a.d
@@ -1,0 +1,3 @@
+module imports.test1238a;
+
+private int zuiop;

--- a/test/compilable/imports/test1238b.d
+++ b/test/compilable/imports/test1238b.d
@@ -1,0 +1,3 @@
+module imports.test1238b;
+
+public int zuiop;

--- a/test/compilable/imports/test1754a.d
+++ b/test/compilable/imports/test1754a.d
@@ -1,0 +1,5 @@
+module imports.test1754a;
+
+private void bar()
+{
+}

--- a/test/compilable/imports/test1754b.d
+++ b/test/compilable/imports/test1754b.d
@@ -1,0 +1,5 @@
+module imports.test1754b;
+
+void bar()
+{
+}

--- a/test/compilable/imports/test2991.d
+++ b/test/compilable/imports/test2991.d
@@ -1,0 +1,5 @@
+module imports.test2991;
+
+private void foo()
+{
+}

--- a/test/compilable/test1238.d
+++ b/test/compilable/test1238.d
@@ -1,0 +1,10 @@
+module test1238;
+
+import imports.test1238a;
+import imports.test1238b;
+
+void foo()
+{
+    int qwert = zuiop;
+}
+

--- a/test/compilable/test1754.d
+++ b/test/compilable/test1754.d
@@ -1,0 +1,9 @@
+module test1754;
+
+import imports.test1754a;
+import imports.test1754b;
+
+void foo()
+{
+    bar();
+}

--- a/test/compilable/test2991.d
+++ b/test/compilable/test2991.d
@@ -1,0 +1,12 @@
+module test2991;
+
+void foo()
+{
+}
+
+class C
+{
+    import imports.test2991;
+
+    void bar() { foo(); }
+}

--- a/test/fail_compilation/diag9004.d
+++ b/test/fail_compilation/diag9004.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9004.d(4): Error: undefined identifier FooT.T
+fail_compilation/diag9004.d(4): Error: undefined identifier 'FooT.T'
 fail_compilation/diag9004.d(8): Error: template diag9004.bar does not match any function template declaration. Candidates are:
 fail_compilation/diag9004.d(4):        diag9004.bar(FooT)(FooT foo, FooT.T x)
 fail_compilation/diag9004.d(8): Error: template diag9004.bar(FooT)(FooT foo, FooT.T x) cannot deduce template function from argument types !()(Foo!(int),int)

--- a/test/fail_compilation/diag9191.d
+++ b/test/fail_compilation/diag9191.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9191.d(16): Error: function diag9191.C1.aaa does not override any function, did you mean to override 'diag9191.B1.aa'?
-fail_compilation/diag9191.d(21): Error: function diag9191.C2.aaa does not override any function, did you mean to override 'diag9191.I1.a'?
-fail_compilation/diag9191.d(31): Error: function diag9191.C3.foo does not override any function, did you mean to override 'diag9191.B2._foo'?
-fail_compilation/diag9191.d(36): Error: function diag9191.C4.toStringa does not override any function, did you mean to override 'object.Object.toString'?
+fail_compilation/diag9191.d(16): Error: function diag9191.C1.aaa does not override any function, did you mean to override 'public function diag9191.B1.aa'?
+fail_compilation/diag9191.d(21): Error: function diag9191.C2.aaa does not override any function, did you mean to override 'public function diag9191.I1.a'?
+fail_compilation/diag9191.d(31): Error: function diag9191.C3.foo does not override any function, did you mean to override 'public function diag9191.B2._foo'?
+fail_compilation/diag9191.d(36): Error: function diag9191.C4.toStringa does not override any function, did you mean to override 'public function object.Object.toString'?
 ---
 */
 

--- a/test/fail_compilation/fail61.d
+++ b/test/fail_compilation/fail61.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail61.d(22): Error: no property 'B' for type 'fail61.A.B', did you mean 'C'?
-fail_compilation/fail61.d(23): Error: no property 'B' for type 'fail61.A.B', did you mean 'C'?
+fail_compilation/fail61.d(22): Error: no property 'B' for type 'fail61.A.B', did you mean 'public variable fail61.A.B.C'?
+fail_compilation/fail61.d(23): Error: no property 'B' for type 'fail61.A.B', did you mean 'public variable fail61.A.B.C'?
 fail_compilation/fail61.d(32): Error: no property 'A2' for type 'fail61.B2'
 fail_compilation/fail61.d(41): Error: this for foo needs to be type B3 not type fail61.C3
 ---

--- a/test/fail_compilation/imports/test143.d
+++ b/test/fail_compilation/imports/test143.d
@@ -1,0 +1,3 @@
+module imports.test143;
+
+package int x = 5;

--- a/test/fail_compilation/test143.d
+++ b/test/fail_compilation/test143.d
@@ -1,0 +1,12 @@
+module test143; // Bugzilla 143
+
+import imports.test143;
+
+void bar(int)
+{
+}
+
+void foo()
+{
+    bar(x);
+}


### PR DESCRIPTION
- restrict visibility of module level symbols to given access rights
- restrict access rights when searching across imported modules
