### PR TITLE
Issue 5879 - Not all frontend errors use stderr

### DIFF
--- a/src/backend/html.c
+++ b/src/backend/html.c
@@ -101,15 +101,15 @@ Html::Html(const char *sourcename, unsigned char *base, unsigned length)
 
 void Html::error(const char *format, ...)
 {
-    printf("%s(%d) : HTML Error: ", sourcename, linnum);
+    fprintf(stderr, "%s(%d) : HTML Error: ", sourcename, linnum);
 
     va_list ap;
     va_start(ap, format);
-    vprintf(format, ap);
+    vfprintf(stderr, format, ap);
     va_end(ap);
 
-    printf("\n");
-    fflush(stdout);
+    fprintf(stderr, "\n");
+    fflush(stderr);
 
 //#if MARS
 //    global.errors++;

--- a/src/expression.c
+++ b/src/expression.c
@@ -506,7 +506,7 @@ Expressions *arrayExpressionToCommonType(Scope *sc, Expressions *exps, Type **pt
 
         e = resolveProperties(sc, e);
         if (!e->type)
-        {   error("%s has no value", e->toChars());
+        {   e->error("%s has no value", e->toChars());
             e = new ErrorExp();
         }
 

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2123,18 +2123,12 @@ code *asm_genloc(Loc loc, code *c)
 STATIC void asmerr(int errnum, ...)
 {   const char *format;
 
-    const char *p = asmstate.loc.toChars();
-    if (*p)
-        printf("%s: ", p);
-
     format = asmerrmsgs[errnum];
     va_list ap;
     va_start(ap, errnum);
-    vprintf(format, ap);
+    verror(asmstate.loc, format, ap);
     va_end(ap);
 
-    printf("\n");
-    fflush(stdout);
     longjmp(asmstate.env,1);
 }
 
@@ -2143,17 +2137,10 @@ STATIC void asmerr(int errnum, ...)
 
 STATIC void asmerr(const char *format, ...)
 {
-    const char *p = asmstate.loc.toChars();
-    if (*p)
-        printf("%s: ", p);
-
     va_list ap;
     va_start(ap, format);
-    vprintf(format, ap);
+    verror(asmstate.loc, format, ap);
     va_end(ap);
-
-    printf("\n");
-    fflush(stdout);
 
     longjmp(asmstate.env,1);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -802,7 +802,7 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, int needInterpret)
         return this; // Failed, suppress duplicate error messages
 
     if (exp->op == TOKtype)
-        error("initializer must be an expression, not '%s'", exp->toChars());
+        exp->error("initializer must be an expression, not '%s'", exp->toChars());
 
     // Make sure all pointers are constants
     if (needInterpret && hasNonConstPointers(exp))

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4949,7 +4949,7 @@ Expression *findKeyInAA(AssocArrayLiteralExp *ae, Expression *e2)
         Expression *ex = ctfeEqual(TOKequal, Type::tbool, ekey, e2);
         if (ex == EXP_CANT_INTERPRET)
         {
-            error("cannot evaluate %s==%s at compile time",
+            e2->error("cannot evaluate %s==%s at compile time",
                 ekey->toChars(), e2->toChars());
             return ex;
         }
@@ -6017,7 +6017,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
     else if (str->op == TOKarrayliteral)
         ale = (ArrayLiteralExp *)str;
     else
-    {   error("CTFE internal error: cannot foreach %s", str->toChars());
+    {   str->error("CTFE internal error: cannot foreach %s", str->toChars());
         return EXP_CANT_INTERPRET;
     }
     Expressions args;

--- a/src/lib.h
+++ b/src/lib.h
@@ -48,6 +48,20 @@ struct Library
     unsigned short numDictPages(unsigned padding);
     int FillDict(unsigned char *bucketsP, unsigned short uNumPages);
     void WriteLibToBuffer(OutBuffer *libbuf);
+
+    void error(char *format, ...)
+    {
+        Loc loc;
+        if (libfile)
+        {
+            loc.filename = libfile->name->toChars();
+            loc.linnum = 0;
+        }
+        va_list ap;
+        va_start(ap, format);
+        ::verror(loc, format, ap);
+        va_end(ap);
+    }
 };
 
 #endif /* DMD_LIB_H */

--- a/src/link.c
+++ b/src/link.c
@@ -208,7 +208,7 @@ int runLINK()
         flnk.setbuffer(p, plen);
         flnk.ref = 1;
         if (flnk.write())
-            error("error writing file %s", lnkfilename);
+            error(0, "error writing file %s", lnkfilename);
         if (lnkfilename->len() < plen)
             sprintf(p, "@%s", lnkfilename->toChars());
     }
@@ -490,7 +490,7 @@ int executecmd(char *cmd, char *args, int useenv)
         else
         {
         L1:
-            error("command line length of %d is too long",len);
+            error(0, "command line length of %d is too long",len);
         }
     }
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -404,7 +404,7 @@ int main(int argc, char *argv[])
     if (argc < 1 || !argv)
     {
       Largs:
-        error("missing or null command line arguments");
+        error(0, "missing or null command line arguments");
         fatal();
     }
     for (size_t i = 0; i < argc; i++)
@@ -414,7 +414,7 @@ int main(int argc, char *argv[])
     }
 
     if (response_expand(&argc,&argv))   // expand response files
-        error("can't open response file");
+        error(0, "can't open response file");
 
     files.reserve(argc - 1);
 
@@ -542,7 +542,7 @@ int main(int argc, char *argv[])
             else if (strcmp(p + 1, "gs") == 0)
                 global.params.alwaysframe = 1;
             else if (strcmp(p + 1, "gt") == 0)
-            {   error("use -profile instead of -gt\n");
+            {   error(0, "use -profile instead of -gt\n");
                 global.params.trace = 1;
             }
             else if (strcmp(p + 1, "m32") == 0)
@@ -562,7 +562,7 @@ int main(int argc, char *argv[])
 #if DMDV1
                 global.params.Dversion = 1;
 #else
-                error("use DMD 1.0 series compilers for -v1 switch");
+                error(0, "use DMD 1.0 series compilers for -v1 switch");
                 break;
 #endif
             }
@@ -599,7 +599,7 @@ int main(int argc, char *argv[])
                         break;
 
                     case 0:
-                        error("-o no longer supported, use -of or -od");
+                        error(0, "-o no longer supported, use -of or -od");
                         break;
 
                     default:
@@ -844,11 +844,11 @@ int main(int argc, char *argv[])
             else
             {
              Lerror:
-                error("unrecognized switch '%s'", argv[i]);
+                error(0, "unrecognized switch '%s'", argv[i]);
                 continue;
 
              Lnoarg:
-                error("argument expected for switch '%s'", argv[i]);
+                error(0, "argument expected for switch '%s'", argv[i]);
                 continue;
             }
         }
@@ -883,7 +883,7 @@ int main(int argc, char *argv[])
 
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     if (global.params.lib && global.params.dll)
-        error("cannot mix -lib and -shared\n");
+        error(0, "cannot mix -lib and -shared\n");
 #endif
 
     if (global.params.release)
@@ -945,7 +945,7 @@ int main(int argc, char *argv[])
     }
     else if (global.params.run)
     {
-        error("flags conflict with -run");
+        error(0, "flags conflict with -run");
         fatal();
     }
     else
@@ -1136,12 +1136,12 @@ int main(int argc, char *argv[])
                     strcmp(name, ".") == 0)
                 {
                 Linvalid:
-                    error("invalid file name '%s'", files.tdata()[i]);
+                    error(0, "invalid file name '%s'", files.tdata()[i]);
                     fatal();
                 }
             }
             else
-            {   error("unrecognized file extension %s\n", ext);
+            {   error(0, "unrecognized file extension %s\n", ext);
                 fatal();
             }
         }
@@ -1205,7 +1205,7 @@ int main(int argc, char *argv[])
 #if ASYNCREAD
         if (aw->read(filei))
         {
-            error("cannot read file %s", m->srcfile->name->toChars());
+            error(0, "cannot read file %s", m->srcfile->name->toChars());
         }
 #endif
         m->parse();
@@ -1239,7 +1239,7 @@ int main(int argc, char *argv[])
     if (anydocfiles && modules.dim &&
         (global.params.oneobj || global.params.objname))
     {
-        error("conflicting Ddoc and obj generation options");
+        error(0, "conflicting Ddoc and obj generation options");
         fatal();
     }
     if (global.errors)
@@ -1441,7 +1441,7 @@ int main(int argc, char *argv[])
     if (!global.params.objfiles->dim)
     {
         if (global.params.link)
-            error("no object files to link");
+            error(0, "no object files to link");
     }
     else
     {

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -32,9 +32,6 @@ int wcharIsAscii(wchar_t *, unsigned len);
 
 int bstrcmp(unsigned char *s1, unsigned char *s2);
 char *bstr2str(unsigned char *b);
-void error(const char *format, ...);
-void error(const wchar_t *format, ...);
-void warning(const char *format, ...);
 
 #ifndef TYPEDEFS
 #define TYPEDEFS

--- a/src/template.c
+++ b/src/template.c
@@ -203,7 +203,7 @@ int match(Object *o1, Object *o2, TemplateDeclaration *tempdecl, Scope *sc)
                 {
                     if (sc1->scopesym == ti1)
                     {
-                        error("recursive template expansion for template argument %s", t1->toChars());
+                        tempdecl->error("recursive template expansion for template argument %s", t1->toChars());
                         return 1;       // fake a match
                     }
                 }


### PR DESCRIPTION
Use `fprintf(stderr)` in `iasm.c`, and stop using `root::error` in the frontend.  Most cases are obvious mistakes where code has been refactored into free functions and ended up calling error without a `loc`.
This makes all frontend errors correctly print to `stdmsg` (`stderr`) and fixes five unreported 'no line number' bugs.
Removing `error`/`warning` from the root headers prevents these cases from creeping back in.

http://d.puremagic.com/issues/show_bug.cgi?id=5879
