### PR TITLE
Issue 3354 - asm fld x, ST(6); accepted

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -638,6 +638,11 @@ RETRY:
                 if (I64 && (pop->ptb.pptb0->usFlags & _i64_bit))
                     asmerr( EM_invalid_64bit_opcode, asm_opstr(pop));  // illegal opcode in 64bit mode
 
+                if ((asmstate.ucItype == ITopt ||
+                     asmstate.ucItype == ITfloat) &&
+                    usNumops != 0)
+                    goto PARAM_ERROR;
+
                 ptbRet = pop->ptb;
 
                 goto RETURN_IT;
@@ -674,16 +679,23 @@ RETRY:
                                                  0)) &&
                                 popnd1->disp == table1->usFlags)
                             break;
-                        if ((asmstate.ucItype == ITopt ||
-                             asmstate.ucItype == ITfloat) &&
-                            !usNumops &&
-                            !table1->usOp1)
+                        if (asmstate.ucItype == ITopt ||
+                            asmstate.ucItype == ITfloat)
                         {
-                            if (usNumops > 1)
-                                goto PARAM_ERROR;
-                            break;
+                                switch (usNumops)
+                                {
+                                    case 0:
+                                        if (!table1->usOp1)
+                                            goto Lfound1;
+                                        break;
+                                    case 1:
+                                        break;
+                                    default:
+                                        goto PARAM_ERROR;
+                                }
                         }
                 }
+            Lfound1:
                 if (table1->usOpcode == ASM_END)
                 {
 #ifdef DEBUG

--- a/test/fail_compilation/fail3354.d
+++ b/test/fail_compilation/fail3354.d
@@ -1,0 +1,12 @@
+
+void main()
+{
+    version(D_InlineAsm_X86) {}
+    else version(D_InlineAsm_X64) {}
+    else static assert(0);
+
+    asm {
+        fldz ST(0), ST(1), ST(2), ST(3);
+        fld ST(0), ST(1), ST(2), ST(3);
+    }
+}


### PR DESCRIPTION
Zero and one argument floating point instructions are not checked to ensure they have the correct number of arugments.  Treat them the same as 2/3/4 argument instructions.

http://d.puremagic.com/issues/show_bug.cgi?id=3354
