### PR TITLE
Issue 7550 – Missing AVX instruction VPMULDQ

### DIFF
--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -4039,6 +4039,11 @@ PTRNTAB2 aptb2PMULDQ[] = /* PMULDQ */ {
         { ASM_END }
 };
 
+PTRNTAB3 aptb3VPMULDQ[] = /* VPMULDQ */ {
+        { VEX_NDS_128_WIG(PMULDQ), _r, _xmm, _xmm, _xmm_m128 },
+        { ASM_END }
+};
+
 PTRNTAB2 aptb2PMULLD[] = /* PMULLD */ {
         { PMULLD, _r, _xmm, _xmm_m128 },
         { ASM_END }
@@ -5573,6 +5578,7 @@ PTRNTAB3 aptb3VFMSUB231SS[] = /* VFMSUB231SS */ {
         X("vpmovzxdq",      2,              (P) aptb2VPMOVZXDQ )            \
         X("vpmovzxwd",      2,              (P) aptb2VPMOVZXWD )            \
         X("vpmovzxwq",      2,              (P) aptb2VPMOVZXWQ )            \
+        X("vpmuldq",        3,              (P) aptb3VPMULDQ )              \
         X("vpmulhrsw",      3,              (P) aptb3VPMULHRSW )            \
         X("vpmulhuw",       3,              (P) aptb3VPMULHUW )             \
         X("vpmulhw",        3,              (P) aptb3VPMULHW )              \

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -4934,6 +4934,7 @@ void test61()
         0xC4, 0xE2, 0x79, 0x40, 0xC0,             // vpmulld XMM0, XMM0, XMM0;
         0xC5, 0xF9, 0xD5, 0xC0,                   // vpmullw XMM0, XMM0, XMM0;
         0xC5, 0xF9, 0xF4, 0xC0,                   // vpmuludq XMM0, XMM0, XMM0;
+        0xC4, 0xE2, 0x79, 0x28, 0xC0,             // vpmuldq XMM0, XMM0, XMM0;
 
         0xC5, 0xF9, 0xF6, 0xC0,                   // vpsadbw XMM0, XMM0, XMM0;
         0xC4, 0xE2, 0x79, 0x08, 0xC0,             // vpsignb XMM0, XMM0, XMM0;
@@ -5722,6 +5723,7 @@ void test61()
         vpmulld XMM0, XMM0, XMM0;
         vpmullw XMM0, XMM0, XMM0;
         vpmuludq XMM0, XMM0, XMM0;
+        vpmuldq XMM0, XMM0, XMM0;
 
         vpsadbw XMM0, XMM0, XMM0;
         vpsignb XMM0, XMM0, XMM0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7550
