### PR TITLE
Issue 3713 - Tail call optimization not enabled with the ?: operator

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3836,6 +3836,16 @@ Statement *ReturnStatement::semantic(Scope *sc)
         }
     }
 
+    if (exp && exp->op == TOKquestion)
+    {
+        // Re-write as if (cond) return a; else return b;
+        CondExp *ce = (CondExp *)exp;
+        ReturnStatement *ra = new ReturnStatement(loc, ce->e1);
+        ReturnStatement *rb = new ReturnStatement(loc, ce->e2);
+        IfStatement *is = new IfStatement(loc, NULL, ce->econd, ra, rb);
+        return is->semantic(sc);
+    }
+
     return this;
 }
 

--- a/test/runnable/test3713.d
+++ b/test/runnable/test3713.d
@@ -1,0 +1,22 @@
+// REQUIRED_ARGS: -O
+
+extern(C) int printf(const char *, ...);
+
+long funca(long v)
+{
+    return v ? funca(v - 1) : 0;
+}
+
+long funcb(long v)
+{
+    if (v)
+        return funcb(v - 1);
+    else
+        return 0;
+}
+
+void main()
+{
+    printf("%d\n", funca(100_000));
+    printf("%d\n", funcb(100_000));
+}


### PR DESCRIPTION
Turn `return c ? a : b` into `if (c) return a; else return b;` to allow tco with condexp.

http://d.puremagic.com/issues/show_bug.cgi?id=3713
