### PR TITLE
Issue 5554 - [qtd] Covariance detection failure

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -609,9 +609,14 @@ void FuncDeclaration::semantic(Scope *sc)
                     }
                     if (ti)
                     {
-                        if (tintro && !tintro->equals(ti))
+                        if (tintro)
                         {
-                            error("incompatible covariant types %s and %s", tintro->toChars(), ti->toChars());
+                            if (!tintro->nextOf()->equals(ti->nextOf()) &&
+                                !tintro->nextOf()->isBaseOf(ti->nextOf(), NULL) &&
+                                !ti->nextOf()->isBaseOf(tintro->nextOf(), NULL))
+                            {
+                                error("incompatible covariant types %s and %s", tintro->toChars(), ti->toChars());
+                            }
                         }
                         tintro = ti;
                     }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3384,6 +3384,26 @@ ref func2521_7() {
 }
 
 /***************************************************/
+
+void test5554()
+{
+    class MA { }
+    class MB : MA { }
+    class MC : MB { }
+
+    class A { abstract MA foo(); }
+    interface I { MB foo(); }
+    class B : A
+    {
+        MC foo() { return null; }
+    }
+    class C : B, I
+    {
+        override MC foo() { return null; }
+    }
+}
+
+/***************************************************/
 // 5962
 
 struct S156
@@ -4730,6 +4750,7 @@ int main()
     test85();
     test86();
     test87();
+    test5554();
     test88();
     test7545();
     test89();


### PR DESCRIPTION
The functions match is A is a base class of B, _or_ if B is a base class of A.

http://d.puremagic.com/issues/show_bug.cgi?id=5554
