### PR TITLE
Issue 3068 - concatenation operator doesn't like typed named enums

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7588,6 +7588,8 @@ MATCH TypeEnum::constConv(Type *to)
     if (ty == to->ty && sym == ((TypeEnum *)to)->sym &&
         MODimplicitConv(mod, to->mod))
         return MATCHconst;
+    else if (sym->memtype->constConv(to))
+        return MATCHconst;
     return MATCHnomatch;
 }
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2954,6 +2954,22 @@ void test136() {
 }
 
 /***************************************************/
+
+void test3068()
+{
+    enum Enum : ubyte
+    {
+        Test
+    }
+
+    void main()
+    {
+        ubyte[] array;
+        array = array ~ [Enum.Test];
+    }
+}
+
+/***************************************************/
 // 4097
 
 void foo4097() { }
@@ -6912,6 +6928,7 @@ int main()
     test157();
     test6473();
     test6630();
+    test3068();
     test6690();
     test2953();
     test2997();


### PR DESCRIPTION
Allow const conversion when the enum's base type converts to the target type.

http://d.puremagic.com/issues/show_bug.cgi?id=3068
