### PR TITLE
Issue 7552 - Cannot get and combine a part of overloaded functions

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -686,6 +686,8 @@ struct FuncDeclaration : Declaration
     void buildClosure(IRState *irs);
 
     FuncDeclaration *isFuncDeclaration() { return this; }
+
+    virtual FuncDeclaration *toAliasFunc() { return this; }
 };
 
 #if DMDV2
@@ -699,12 +701,16 @@ FuncDeclaration *resolveFuncCall(Scope *sc, Loc loc, Dsymbol *s,
 struct FuncAliasDeclaration : FuncDeclaration
 {
     FuncDeclaration *funcalias;
+    int hasOverloads;
 
-    FuncAliasDeclaration(FuncDeclaration *funcalias);
+    FuncAliasDeclaration(FuncDeclaration *funcalias, int hasOverloads = 1);
 
     FuncAliasDeclaration *isFuncAliasDeclaration() { return this; }
     const char *kind();
     Symbol *toSymbol();
+    char *mangle() { return toAliasFunc()->mangle(); }
+
+    FuncDeclaration *toAliasFunc();
 };
 
 struct FuncLiteralDeclaration : FuncDeclaration

--- a/src/expression.c
+++ b/src/expression.c
@@ -8175,7 +8175,7 @@ Expression *AddrExp::semantic(Scope *sc)
                      * mark here that we took its address because castTo()
                      * may not be called with an exact match.
                      */
-                    f->toParent2()->isFuncDeclaration())
+                    f->isNested())
                     f->tookAddressOf++;
                 if (f->isNested())
                 {

--- a/src/traits.c
+++ b/src/traits.c
@@ -64,10 +64,10 @@ static int fptraits(void *param, FuncDeclaration *f)
 
     if (p->e1->op == TOKdotvar)
     {   DotVarExp *dve = (DotVarExp *)p->e1;
-        e = new DotVarExp(0, dve->e1, f);
+        e = new DotVarExp(0, dve->e1, new FuncAliasDeclaration(f, 0));
     }
     else
-        e = new DsymbolExp(0, f);
+        e = new DsymbolExp(0, new FuncAliasDeclaration(f, 0));
     p->exps->push(e);
     return 0;
 }

--- a/test/runnable/overload.d
+++ b/test/runnable/overload.d
@@ -1,0 +1,72 @@
+
+extern(C) int printf(const char* fmt, ...);
+
+template TypeTuple(T...){ alias T TypeTuple; }
+template Id(      T){ alias T Id; }
+template Id(alias A){ alias A Id; }
+
+/***************************************************/
+// 7552
+
+struct S7552
+{
+    static void foo(){}
+    static void foo(int){}
+}
+
+struct T7552
+{
+    alias TypeTuple!(__traits(getOverloads, S7552, "foo")) FooInS;
+    alias FooInS[0] foo;    // should be S7552.foo()
+    static void foo(string){}
+}
+
+struct U7552
+{
+    alias TypeTuple!(__traits(getOverloads, S7552, "foo")) FooInS;
+    alias FooInS[1] foo;    // should be S7552.foo(int)
+    static void foo(string){}
+}
+
+void test7552()
+{
+    alias TypeTuple!(__traits(getOverloads, S7552, "foo")) FooInS;
+    static assert(FooInS.length == 2);
+                                      FooInS[0]();
+    static assert(!__traits(compiles, FooInS[0](0)));
+    static assert(!__traits(compiles, FooInS[1]()));
+                                      FooInS[1](0);
+
+                                      Id!(FooInS[0])();
+    static assert(!__traits(compiles, Id!(FooInS[0])(0)));
+    static assert(!__traits(compiles, Id!(FooInS[1])()));
+                                      Id!(FooInS[1])(0);
+
+    alias TypeTuple!(__traits(getOverloads, T7552, "foo")) FooInT;
+    static assert(FooInT.length == 2);                  // fail
+                                      FooInT[0]();
+    static assert(!__traits(compiles, FooInT[0](0)));
+    static assert(!__traits(compiles, FooInT[0]("")));
+    static assert(!__traits(compiles, FooInT[1]()));
+    static assert(!__traits(compiles, FooInT[1](0)));   // fail
+                                      FooInT[1]("");    // fail
+
+    alias TypeTuple!(__traits(getOverloads, U7552, "foo")) FooInU;
+    static assert(FooInU.length == 2);
+    static assert(!__traits(compiles, FooInU[0]()));
+                                      FooInU[0](0);
+    static assert(!__traits(compiles, FooInU[0]("")));
+    static assert(!__traits(compiles, FooInU[1]()));
+    static assert(!__traits(compiles, FooInU[1](0)));
+                                      FooInU[1]("");
+}
+
+/***************************************************/
+
+int main()
+{
+    test7552();
+
+    printf("Success\n");
+    return 0;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7552

FuncAliasDeclaration now has flag that its member funcalias is overloaded.
And it is used as an element of __traits(getOverloads) due to represent the function symbol isn't overloaded.
