### PR TITLE
Improve codegen for OPmsw

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -459,6 +459,7 @@ typedef unsigned        targ_uns;
 #define WCHARSIZE       2       // 2 for WIN32, 4 for linux/OSX/FreeBSD/OpenBSD/Solaris
 #define LONGSIZE        4
 #define LLONGSIZE       8
+#define CENTSIZE        16
 #define FLOATSIZE       4
 #define DOUBLESIZE      8
 #if TARGET_OSX

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -583,7 +583,7 @@ void dotab()
         case OPu64_128: X("u64_128",    evalu8, cdshtlng);
         case OPs64_128: X("s64_128",    evalu8, cdshtlng);
         case OP128_64:  X("128_64",     el64_32, cdlngsht);
-        case OPmsw:     X("msw",        evalu8, cdmsw);
+        case OPmsw:     X("msw",        elmsw, cdmsw);
 
         case OPd_s64:   X("d_s64",      evalu8, cdcnvt);
         case OPs64_d:   X("s64_d",      evalu8, cdcnvt);


### PR DESCRIPTION
`(int)(msw (long))` -> `(int)*(&x+4)`
`(long)(msw (cent))` -> `(long)*(&x+8)`

These ops are quite common when using arrays.

I'm not sure how to make test cases for this... I've examined the assembly and it now generates the same code as it does for pointers.  How do you write test cases for the optimizer, apart from the thousands of existing array element assignments that are testing this doesn't generate wrong code?
