### PR TITLE
Issue 3630 - bad error location in "has no effect in expression" error

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2690,6 +2690,7 @@ Lagain:
     if (em)
     {
         e = em->value;
+        e->loc = loc;
         e = e->semantic(sc);
         return e;
     }


### PR DESCRIPTION
When resolving a symbol to an enum member, use the SymbolExp's loc instead of the enum value's loc.

http://d.puremagic.com/issues/show_bug.cgi?id=3630
