### PR TITLE
Regression 7557 - sea of errors after template failure

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4055,8 +4055,9 @@ Expression *ScopeExp::semantic(Scope *sc)
 #endif
 Lagain:
     ti = sds->isTemplateInstance();
-    if (ti && !global.errors)
+    if (ti && !ti->errors)
     {
+        unsigned olderrs = global.errors;
         if (!ti->semanticRun)
             ti->semantic(sc);
         if (ti->inst)
@@ -4086,7 +4087,7 @@ Lagain:
             }
             //printf("sds = %s, '%s'\n", sds->kind(), sds->toChars());
         }
-        if (global.errors)
+        if (olderrs != global.errors)
             return new ErrorExp();
     }
     else

--- a/src/expression.c
+++ b/src/expression.c
@@ -6898,8 +6898,8 @@ L1:
         return e;
     if (e->op == TOKdottd)
     {
-        if (global.errors)
-            return new ErrorExp();      // TemplateInstance::semantic() will fail anyway
+        if (ti->errors)
+            return new ErrorExp();
         DotTemplateExp *dte = (DotTemplateExp *)e;
         TemplateDeclaration *td = dte->td;
         eleft = dte->e1;


### PR DESCRIPTION
Fix issue 7557  - Sea of errors after template failure

Remove reliance on global.errors. ScopeExp wasn't running semantic if errors had ever occurred, so the template engine was being fed raw food. It responding by vomiting it all up.
