### PR TITLE
Issue 7562 - DMD crashes by using TemplateThisParameter

### DIFF
--- a/src/template.h
+++ b/src/template.h
@@ -182,8 +182,6 @@ struct TemplateThisParameter : TemplateTypeParameter
     /* Syntax:
      *  this ident : specType = defaultType
      */
-    Type *specType;     // type parameter: if !=NULL, this is the type specialization
-    Type *defaultType;
 
     TemplateThisParameter(Loc loc, Identifier *ident, Type *specType, Type *defaultType);
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4657,6 +4657,31 @@ class B158 : A158
 
 
 /***************************************************/
+// 7562
+
+static struct MyInt
+{
+    private int value;
+    mixin ProxyOf!value;
+}
+mixin template ProxyOf(alias a)
+{
+    template X1(){}
+    template X2(){}
+    template X3(){}
+    template X4(){}
+    template X5(){}
+    template X6(){}
+    template X7(){}
+    template X8(){}
+    template X9(){}
+    template X10(){}
+
+    void test1(this X)(){}
+    void test2(this Y)(){}
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7562

Uninitialized pointer dereference crashes compiler.

This issue blocks <a href="https://github.com/D-Programming-Language/phobos/pull/300">ProxyOf</a>.
And maybe this is the cause of auto-tester breaking in some posix system.
