### PR TITLE
Issue 5525 - Eponymous templates should allow for overloaded eponymous members

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -132,12 +132,15 @@ int Dsymbol::oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident)
                     if (!(*ps)->ident || !(*ps)->ident->equals(ident))
                         continue;
                 }
-                if (s)                  // more than one symbol
+                if (!s)
+                    s = *ps;
+                else if (s->isOverloadable() && (*ps)->isOverloadable())
+                    ;   // keep head of overload set
+                else                    // more than one symbol
                 {   *ps = NULL;
                     //printf("\tfalse 2\n");
                     return FALSE;
                 }
-                s = *ps;
             }
         }
     }

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -724,6 +724,22 @@ void test4675()
 }
 
 /**********************************/
+// 5525
+
+template foo5525(T)
+{
+    T foo5525(T t)      { return t; }
+    T foo5525(T t, T u) { return t + u; }
+}
+
+void test5525()
+{
+    alias foo5525!int f;
+    assert(f(1) == 1);
+    assert(f(1, 2) == 3);
+}
+
+/**********************************/
 // 5801
 
 int a5801;
@@ -939,6 +955,7 @@ int main()
     test6994();
     test3467();
     test4413();
+    test5525();
     test5801();
     test10();
     test7037();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5525

Allow eponymous overload set.
