### PR TITLE
Fix OPmsw codegen

### DIFF
--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -2302,7 +2302,7 @@ code *opass87(elem *e,regm_t *pretregs)
         retregs = mST0;
         cr = codelem(e->E2,&retregs,FALSE);     // evaluate rvalue
         note87(e->E2,0,0);
-        cl = getlvalue(&cs,e->E1,0);
+        cl = getlvalue(&cs,e->E1,e->Eoper==OPmodass?mAX:0);
         cl = cat(cl,makesure87(e->E2,0,0,0));
         cs.Iflags |= ADDFWAIT() ? CFwait : 0;
         if (I32)

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -3864,8 +3864,6 @@ elem *elmsw(elem *e)
     elem *e1 = e->E1;
 
     if (OPTIMIZER &&
-        tyintegral(e1->Ety) &&
-        tyintegral(ty) &&
         tysize(e1->Ety) == LLONGSIZE &&
         tysize(ty) == LONGSIZE)
     {
@@ -3894,8 +3892,6 @@ elem *elmsw(elem *e)
         }
     }
     else if (OPTIMIZER && I64 &&
-        tyintegral(e1->Ety) &&
-        tyintegral(ty) &&
         tysize(e1->Ety) == CENTSIZE &&
         tysize(ty) == LLONGSIZE)
     {


### PR DESCRIPTION
Restricting the optimization to integral types only was wrong - the problems I thought this was fixing were actually caused by the code emitted by `float %= float` destroying eax while using it as a pointer.  The test case for this is already included in `runnable/arrayop.d`
