### PR TITLE
Issue 4155 - return of NaN to temporary fails equality test

### DIFF
--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -3459,29 +3459,33 @@ code *fixresult_complex87(elem *e,regm_t retregs,regm_t *pretregs)
     else if ((tym == TYcfloat || tym == TYcdouble) &&
              *pretregs & (mXMM0|mXMM1) && retregs & mST01)
     {
+        unsigned xop = xmmload(tym == TYcfloat ? TYfloat : TYdouble);
+        unsigned mf = tym == TYcfloat ? MFfloat : MFdouble;
         if (*pretregs & mPSW && !(retregs & mPSW))
             c1 = genctst(c1,e,0);               // FTST
         pop87();
-        c1 = genfltreg(c1, ESC(MFdouble,1),3,0); // FSTP floatreg
+        c1 = genfltreg(c1, ESC(mf,1),3,0); // FSTP floatreg
         genfwait(c1);
         c2 = getregs(mXMM0|mXMM1);
-        c2 = genfltreg(c2, 0xF20F10, XMM1 - XMM0, 0);    // MOVD XMM1,floatreg
+        c2 = genfltreg(c2, xop, XMM1 - XMM0, 0);    // LODS(SD) XMM1,floatreg
 
         pop87();
-        c2 = genfltreg(c2, ESC(MFdouble,1),3,0); // FSTP floatreg
+        c2 = genfltreg(c2, ESC(mf,1),3,0); // FSTP floatreg
         genfwait(c2);
-        c2 = genfltreg(c2, 0xF20F10, XMM0 - XMM0, 0);    // MOVD XMM0,floatreg
+        c2 = genfltreg(c2, xop, XMM0 - XMM0, 0);    // LODS(SD) XMM0,floatreg
     }
     else if ((tym == TYcfloat || tym == TYcdouble) &&
              retregs & (mXMM0|mXMM1) && *pretregs & mST01)
     {
+        unsigned xop = xmmstore(tym == TYcfloat ? TYfloat : TYdouble);
+        unsigned fop = tym == TYcfloat ? 0xD9 : 0xDD;
         c1 = push87();
-        c1 = genfltreg(c1, 0xF20F11, XMM0-XMM0, 0);        // MOVD floatreg, XMM0
-        genfltreg(c1, 0xDD, 0, 0);              // FLD double ptr floatreg
+        c1 = genfltreg(c1, xop, XMM0-XMM0, 0); // STOS(SD) floatreg, XMM0
+        genfltreg(c1, fop, 0, 0);              // FLD float/double ptr floatreg
 
         c2 = push87();
-        c2 = genfltreg(c2, 0xF20F11, XMM1-XMM0, 0);        // MOV floatreg, XMM1
-        genfltreg(c2, 0xDD, 0, 0);              // FLD double ptr floatreg
+        c2 = genfltreg(c2, xop, XMM1-XMM0, 0); // STOS(SD) floatreg, XMM1
+        genfltreg(c2, fop, 0, 0);              // FLD float/double ptr floatreg
 
         if (*pretregs & mPSW)
             c2 = genctst(c2,e,0);               // FTST

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1353,20 +1353,21 @@ int jmpopcode(elem *e)
         e = e->E2;                      /* right operand determines it  */
 
   op = e->Eoper;
-  if (e->Ecount != e->Ecomsub)          // comsubs just get Z bit set
-        return JNE;
   if (!OTrel(op))                       // not relational operator
   {
         tym_t tymx = tybasic(e->Ety);
         if (tyfloating(tymx) && config.inline8087 &&
             (tymx == TYldouble || tymx == TYildouble || tymx == TYcldouble ||
              tymx == TYcdouble || tymx == TYcfloat ||
-             op == OPind))
+             op == OPind ||
+             (OTcall(op) && (regmask(tymx, tybasic(e->E1->Eoper)) & (mST0 | XMMREGS)))))
         {
             return XP|JNE;
         }
         return (op >= OPbt && op <= OPbts) ? JC : JNE;
   }
+  if (e->Ecount != e->Ecomsub)          // comsubs just get Z bit set
+        return JNE;
 
   if (e->E2->Eoper == OPconst)
         zero = !boolres(e->E2);

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1743,28 +1743,16 @@ elem * evalu8(elem *e)
             switch (tybasic(tym))
             {
                 case TYcfloat:
-                    if (isnan(e1->EV.Vcfloat.re) || isnan(e1->EV.Vcfloat.im) ||
-                        isnan(e2->EV.Vcfloat.re) || isnan(e2->EV.Vcfloat.im))
-                        i ^= 1;
-                    else
-                        i ^= (int)((e1->EV.Vcfloat.re == e2->EV.Vcfloat.re) &&
-                                   (e1->EV.Vcfloat.im == e2->EV.Vcfloat.im));
+                    i ^= (int)((e1->EV.Vcfloat.re == e2->EV.Vcfloat.re) &&
+                               (e1->EV.Vcfloat.im == e2->EV.Vcfloat.im));
                     break;
                 case TYcdouble:
-                    if (isnan(e1->EV.Vcdouble.re) || isnan(e1->EV.Vcdouble.im) ||
-                        isnan(e2->EV.Vcdouble.re) || isnan(e2->EV.Vcdouble.im))
-                        i ^= 1;
-                    else
-                        i ^= (int)((e1->EV.Vcdouble.re == e2->EV.Vcdouble.re) &&
-                                   (e1->EV.Vcdouble.im == e2->EV.Vcdouble.im));
+                    i ^= (int)((e1->EV.Vcdouble.re == e2->EV.Vcdouble.re) &&
+                               (e1->EV.Vcdouble.im == e2->EV.Vcdouble.im));
                     break;
                 case TYcldouble:
-                    if (isnan(e1->EV.Vcldouble.re) || isnan(e1->EV.Vcldouble.im) ||
-                        isnan(e2->EV.Vcldouble.re) || isnan(e2->EV.Vcldouble.im))
-                        i ^= 1;
-                    else
-                        i ^= (int)((e1->EV.Vcldouble.re == e2->EV.Vcldouble.re) &&
-                                   (e1->EV.Vcldouble.im == e2->EV.Vcldouble.im));
+                    i ^= (int)((e1->EV.Vcldouble.re == e2->EV.Vcldouble.re) &&
+                               (e1->EV.Vcldouble.im == e2->EV.Vcldouble.im));
                     break;
                 default:
                     i ^= (int)(d1 == d2);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3726,10 +3726,16 @@ void test4155()
             auto f = getnan!T();
             if (!__ctfe) // force f into memory
                 asm { nop; };
+
             assert(!(T.nan == 0), T.stringof);
             assert(!(f == 0), T.stringof);
             assert(!(getnan!T == 0), T.stringof);
             assert(!(getnanu!T == 0), T.stringof);
+
+            assert((T.nan != 0), T.stringof);
+            assert((f != 0), T.stringof);
+            assert((getnan!T != 0), T.stringof);
+            assert((getnanu!T != 0), T.stringof);
         }
         return 1;
     }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3712,6 +3712,33 @@ void test6295() {
 
 /***************************************************/
 
+template TT4155(T...) { alias T TT4155; }
+
+void test4155()
+{
+    static int test4155a()
+    {
+        T getnan(T)() { return T.nan; } // OPcall
+        static T getnanu(T)() { return T.nan; } // OPucall
+
+        foreach(T; TT4155!(float, double, real, ifloat, idouble, ireal, cfloat, cdouble, creal))
+        {
+            auto f = getnan!T();
+            if (!__ctfe) // force f into memory
+                asm { nop; };
+            assert(!(T.nan == 0), T.stringof);
+            assert(!(f == 0), T.stringof);
+            assert(!(getnan!T == 0), T.stringof);
+            assert(!(getnanu!T == 0), T.stringof);
+        }
+        return 1;
+    }
+    auto a = test4155a();
+    enum b = test4155a();
+}
+
+/***************************************************/
+
 template TT4536(T...) { alias T TT4536; }
 
 void test4536()
@@ -4723,6 +4750,7 @@ int main()
     test25();
     test26();
     test27();
+    test4155();
     test28();
     test29();
     test30();


### PR DESCRIPTION
When evaluating `cast(bool)v` where `v` is a `float` or `double`, and `v` is the result of a function call in `ST(0)` check for nan condition (ZF) to avoid returning the wrong value.

Also includes the fix for 7581, which is required for the unittests to pass with cfloat.

http://d.puremagic.com/issues/show_bug.cgi?id=4155
http://d.puremagic.com/issues/show_bug.cgi?id=7581
