### PR TITLE
Floating point and xmm codegen

### DIFF
--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -3459,29 +3459,33 @@ code *fixresult_complex87(elem *e,regm_t retregs,regm_t *pretregs)
     else if ((tym == TYcfloat || tym == TYcdouble) &&
              *pretregs & (mXMM0|mXMM1) && retregs & mST01)
     {
+        unsigned xop = xmmload(tym == TYcfloat ? TYfloat : TYdouble);
+        unsigned mf = tym == TYcfloat ? MFfloat : MFdouble;
         if (*pretregs & mPSW && !(retregs & mPSW))
             c1 = genctst(c1,e,0);               // FTST
         pop87();
-        c1 = genfltreg(c1, ESC(MFdouble,1),3,0); // FSTP floatreg
+        c1 = genfltreg(c1, ESC(mf,1),3,0); // FSTP floatreg
         genfwait(c1);
         c2 = getregs(mXMM0|mXMM1);
-        c2 = genfltreg(c2, 0xF20F10, XMM1 - XMM0, 0);    // MOVD XMM1,floatreg
+        c2 = genfltreg(c2, xop, XMM1 - XMM0, 0);    // LODS(SD) XMM1,floatreg
 
         pop87();
-        c2 = genfltreg(c2, ESC(MFdouble,1),3,0); // FSTP floatreg
+        c2 = genfltreg(c2, ESC(mf,1),3,0); // FSTP floatreg
         genfwait(c2);
-        c2 = genfltreg(c2, 0xF20F10, XMM0 - XMM0, 0);    // MOVD XMM0,floatreg
+        c2 = genfltreg(c2, xop, XMM0 - XMM0, 0);    // LODS(SD) XMM0,floatreg
     }
     else if ((tym == TYcfloat || tym == TYcdouble) &&
              retregs & (mXMM0|mXMM1) && *pretregs & mST01)
     {
+        unsigned xop = xmmstore(tym == TYcfloat ? TYfloat : TYdouble);
+        unsigned fop = tym == TYcfloat ? 0xD9 : 0xDD;
         c1 = push87();
-        c1 = genfltreg(c1, 0xF20F11, XMM0-XMM0, 0);        // MOVD floatreg, XMM0
-        genfltreg(c1, 0xDD, 0, 0);              // FLD double ptr floatreg
+        c1 = genfltreg(c1, xop, XMM0-XMM0, 0); // STOS(SD) floatreg, XMM0
+        genfltreg(c1, fop, 0, 0);              // FLD float/double ptr floatreg
 
         c2 = push87();
-        c2 = genfltreg(c2, 0xF20F11, XMM1-XMM0, 0);        // MOV floatreg, XMM1
-        genfltreg(c2, 0xDD, 0, 0);              // FLD double ptr floatreg
+        c2 = genfltreg(c2, xop, XMM1-XMM0, 0); // STOS(SD) floatreg, XMM1
+        genfltreg(c2, fop, 0, 0);              // FLD float/double ptr floatreg
 
         if (*pretregs & mPSW)
             c2 = genctst(c2,e,0);               // FTST

--- a/src/backend/cgxmm.c
+++ b/src/backend/cgxmm.c
@@ -89,6 +89,19 @@ code *orthxmm(elem *e, regm_t *pretregs)
     regm_t rretregs = XMMREGS & ~retregs;
     code *cr = scodelem(e2, &rretregs, retregs, TRUE);  // eval right leaf
 
+    // float + ifloat is not actually addition
+    if ((e->Eoper == OPadd || e->Eoper == OPmin) &&
+        ((tyreal(e1->Ety) && tyimaginary(e2->Ety)) ||
+         (tyreal(e2->Ety) && tyimaginary(e1->Ety))))
+    {
+        assert(e->Eoper == OPadd);
+        retregs |= rretregs;
+        c = cat(c, cr);
+        if (retregs != *pretregs)
+            c = cat(c, fixresult(e,retregs,pretregs));
+        return c;
+    }
+
     unsigned op = xmmoperator(e1->Ety, e->Eoper);
     unsigned rreg = findreg(rretregs);
 

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1353,20 +1353,21 @@ int jmpopcode(elem *e)
         e = e->E2;                      /* right operand determines it  */
 
   op = e->Eoper;
-  if (e->Ecount != e->Ecomsub)          // comsubs just get Z bit set
-        return JNE;
   if (!OTrel(op))                       // not relational operator
   {
         tym_t tymx = tybasic(e->Ety);
         if (tyfloating(tymx) && config.inline8087 &&
             (tymx == TYldouble || tymx == TYildouble || tymx == TYcldouble ||
              tymx == TYcdouble || tymx == TYcfloat ||
-             op == OPind))
+             op == OPind ||
+             (OTcall(op) && (regmask(tymx, tybasic(e->E1->Eoper)) & (mST0 | XMMREGS)))))
         {
             return XP|JNE;
         }
         return (op >= OPbt && op <= OPbts) ? JC : JNE;
   }
+  if (e->Ecount != e->Ecomsub)          // comsubs just get Z bit set
+        return JNE;
 
   if (e->E2->Eoper == OPconst)
         zero = !boolres(e->E2);

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -2523,6 +2523,8 @@ code *cdcnvt(elem *e, regm_t *pretregs)
 
             case OPf_d:
             case OPd_f:
+                if (tycomplex(e->E1->Ety))
+                    goto Lcomplex;
                 if (config.fpxmmregs && *pretregs & XMMREGS)
                     return xmmcnvt(e, pretregs);
 
@@ -2541,8 +2543,6 @@ code *cdcnvt(elem *e, regm_t *pretregs)
                     else
                         break;
                 }
-                if (tycomplex(e->E1->Ety))
-                    goto Lcomplex;
                 goto Lload87;
 
             case OPs64_d:

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1743,28 +1743,16 @@ elem * evalu8(elem *e)
             switch (tybasic(tym))
             {
                 case TYcfloat:
-                    if (isnan(e1->EV.Vcfloat.re) || isnan(e1->EV.Vcfloat.im) ||
-                        isnan(e2->EV.Vcfloat.re) || isnan(e2->EV.Vcfloat.im))
-                        i ^= 1;
-                    else
-                        i ^= (int)((e1->EV.Vcfloat.re == e2->EV.Vcfloat.re) &&
-                                   (e1->EV.Vcfloat.im == e2->EV.Vcfloat.im));
+                    i ^= (int)((e1->EV.Vcfloat.re == e2->EV.Vcfloat.re) &&
+                               (e1->EV.Vcfloat.im == e2->EV.Vcfloat.im));
                     break;
                 case TYcdouble:
-                    if (isnan(e1->EV.Vcdouble.re) || isnan(e1->EV.Vcdouble.im) ||
-                        isnan(e2->EV.Vcdouble.re) || isnan(e2->EV.Vcdouble.im))
-                        i ^= 1;
-                    else
-                        i ^= (int)((e1->EV.Vcdouble.re == e2->EV.Vcdouble.re) &&
-                                   (e1->EV.Vcdouble.im == e2->EV.Vcdouble.im));
+                    i ^= (int)((e1->EV.Vcdouble.re == e2->EV.Vcdouble.re) &&
+                               (e1->EV.Vcdouble.im == e2->EV.Vcdouble.im));
                     break;
                 case TYcldouble:
-                    if (isnan(e1->EV.Vcldouble.re) || isnan(e1->EV.Vcldouble.im) ||
-                        isnan(e2->EV.Vcldouble.re) || isnan(e2->EV.Vcldouble.im))
-                        i ^= 1;
-                    else
-                        i ^= (int)((e1->EV.Vcldouble.re == e2->EV.Vcldouble.re) &&
-                                   (e1->EV.Vcldouble.im == e2->EV.Vcldouble.im));
+                    i ^= (int)((e1->EV.Vcldouble.re == e2->EV.Vcldouble.re) &&
+                               (e1->EV.Vcldouble.im == e2->EV.Vcldouble.im));
                     break;
                 default:
                     i ^= (int)(d1 == d2);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4339,7 +4339,7 @@ Lagain:
         case X(Timaginary80,Tfloat32):
         case X(Timaginary80,Tfloat64):
         case X(Timaginary80,Tfloat80):  goto Lzero;
-        case X(Timaginary80,Timaginary32): e = el_una(OPf_d, TYidouble, e);
+        case X(Timaginary80,Timaginary32): e = el_una(OPld_d, TYidouble, e);
                                    fty = Timaginary64;
                                    goto Lagain;
         case X(Timaginary80,Timaginary64): eop = OPld_d; goto Leop;

--- a/test/runnable/testcomplex.d
+++ b/test/runnable/testcomplex.d
@@ -1,0 +1,100 @@
+template TT4155(T...) { alias T TT4155; }
+
+void test4155()
+{
+    static int test4155a()
+    {
+        T getnan(T)() { return T.nan; } // OPcall
+        static T getnanu(T)() { return T.nan; } // OPucall
+        static T passback(T)(T v) { return v; }
+
+        foreach(T; TT4155!(float, double, real, ifloat, idouble, ireal, cfloat, cdouble, creal))
+        {
+            auto f = getnan!T();
+            if (!__ctfe) // force f into memory
+                asm { nop; };
+
+            assert(!(T.nan == 0), T.stringof);
+            assert(!(f == 0), T.stringof);
+            assert(!(getnan!T == 0), T.stringof);
+            assert(!(getnanu!T == 0), T.stringof);
+
+            assert((T.nan != 0), T.stringof);
+            assert((f != 0), T.stringof);
+            assert((getnan!T != 0), T.stringof);
+            assert((getnanu!T != 0), T.stringof);
+
+            assert(passback(0) == 0);
+            static if (is(T == cfloat))
+               assert(passback(1.0f+1.0fi) == 1.0f+1.0fi);
+        }
+        return 1;
+    }
+    auto a = test4155a();
+    enum b = test4155a();
+}
+
+template TT(T...) { alias T TT; }
+
+void testa()
+{
+   static T one(T)()
+   {
+       static if (is(T == float)) return 1.0f;
+       else static if (is(T == double)) return 1.0;
+       else static if (is(T == real)) return 1.0L;
+       else static if (is(T == ifloat)) return 1.0fi;
+       else static if (is(T == idouble)) return 1.0i;
+       else static if (is(T == ireal)) return 1.0Li;
+       else static if (is(T == cfloat)) return one!float() + one!ifloat();
+       else static if (is(T == cdouble)) return one!double() + one!idouble();
+       else static if (is(T == creal)) return one!real() + one!ireal();
+   }
+
+   static void test(T, U)()
+   {
+       U conv(T v) { return v; }
+       assert(conv(one!T()) == one!U(), T.stringof ~ U.stringof);
+       static assert(conv(one!T()) == one!U());
+   }
+
+   foreach(T; TT!(float, double, real, ifloat, idouble, ireal, cfloat, cdouble, creal))
+   {
+       foreach(U; TT!(float, double, real, ifloat, idouble, ireal, cfloat, cdouble, creal))
+       {
+           static if (is(T : U))
+           {
+               test!(T, U);
+           }
+       }
+   }
+}
+
+extern(C) int printf(const char *, ...);
+
+cfloat conv(cdouble val)
+{
+    return val;
+}
+
+cfloat conv2(cdouble val)
+{
+    printf("%f %f\n", val.re, val.im);
+    return val;
+}
+
+void testb()
+{
+    auto a = conv(1.0 + 1.0i);
+    printf("%f %f\n", a.re, a.im);
+    auto b = conv2(1.0 + 1.0i);
+    printf("%f %f\n", b.re, b.im);
+    assert(a == b);
+}
+
+void main()
+{
+    test4155();
+    testa();
+    testb();
+}

--- a/test/runnable/testcomplex.d
+++ b/test/runnable/testcomplex.d
@@ -50,12 +50,26 @@ void testa()
        else static if (is(T == cdouble)) return one!double() + one!idouble();
        else static if (is(T == creal)) return one!real() + one!ireal();
    }
+   static T neg(T)()
+   {
+       static if (is(T == float)) return -1.0f;
+       else static if (is(T == double)) return -1.0;
+       else static if (is(T == real)) return -1.0L;
+       else static if (is(T == ifloat)) return -1.0fi;
+       else static if (is(T == idouble)) return -1.0i;
+       else static if (is(T == ireal)) return -1.0Li;
+       else static if (is(T == cfloat)) return one!float() - one!ifloat();
+       else static if (is(T == cdouble)) return one!double() - one!idouble();
+       else static if (is(T == creal)) return one!real() - one!ireal();
+   }
 
    static void test(T, U)()
    {
        U conv(T v) { return v; }
        assert(conv(one!T()) == one!U(), T.stringof ~ U.stringof);
        static assert(conv(one!T()) == one!U());
+       assert(conv(neg!T()) == neg!U(), T.stringof ~ U.stringof);
+       static assert(conv(neg!T()) == neg!U());
    }
 
    foreach(T; TT!(float, double, real, ifloat, idouble, ireal, cfloat, cdouble, creal))


### PR DESCRIPTION
Starting with 4155, every time I fixed one bug I ran into another while testing it.

4155 - `jmpopcode` assumes that <80bit floating point types are converted to bool by moving them into integer registers and doubling, but this is not the case when they're returned from a function on the floating point stack or in xmm registers.

7581 - `fixresult_complex87` treats cfloat and cdouble _exactly_ the same.  This means a trying to return a cfloat in an xmm reg which is on the floating point stack results the value getting written to memory as a double, read into xmm as a double, then returned to code expecting the xmm regs to hold a float.

7591 - The backend constfolding code for complex ==/!= incorrectly inverts the result if either operand contains nans.  Using the built-in comparison generates the correct result.

7592 - e2ir contains a typo which makes it use the wrong op for casting from ireal -> ifloat via idouble

7593 - `cdcnvt` takes the wrong path when converting cfloat to cdouble, because the check to see if dealing with complex types is after the check for using xmm regs

7594 - Code generation for real+imaginary,imaginary+real,real-imaginary and
imaginary-real is done by xmmorth, which implements it the same as real+real,
resulting in very wrong code.

http://d.puremagic.com/issues/show_bug.cgi?id=4155
http://d.puremagic.com/issues/show_bug.cgi?id=7581
http://d.puremagic.com/issues/show_bug.cgi?id=7591
http://d.puremagic.com/issues/show_bug.cgi?id=7592
http://d.puremagic.com/issues/show_bug.cgi?id=7593
http://d.puremagic.com/issues/show_bug.cgi?id=7594
