### PR TITLE
some changes to ddoc

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -929,7 +929,7 @@ void AggregateDeclaration::toDocBuffer(OutBuffer *buf)
 #if 0
         emitProtection(buf, protection);
 #endif
-        buf->printf("%s $(DDOC_PSYMBOL %s, %s)", kind(), toChars(), toPrettyChars());
+        buf->printf("%s $(DDOC_PSYMBOL %s, %s)", kind(), toChars(), toPrettyChars() + strlen(this->getModule()->toChars()) + 1);
         buf->writestring(";\n");
     }
 }
@@ -953,7 +953,7 @@ void StructDeclaration::toDocBuffer(OutBuffer *buf)
         }
         else
         {
-            buf->printf("%s $(DDOC_PSYMBOL %s, %s)", kind(), toChars(), toPrettyChars());
+            buf->printf("%s $(DDOC_PSYMBOL %s, %s)", kind(), toChars(), toPrettyChars()  + strlen(this->getModule()->toChars()) + 1);
         }
         buf->writestring(";\n");
     }
@@ -980,7 +980,7 @@ void ClassDeclaration::toDocBuffer(OutBuffer *buf)
         {
             if (isAbstract())
                 buf->writestring("abstract ");
-            buf->printf("%s $(DDOC_PSYMBOL %s, %s)", kind(), toChars(), toPrettyChars());
+            buf->printf("%s $(DDOC_PSYMBOL %s, %s)", kind(), toChars(), toPrettyChars()  + strlen(this->getModule()->toChars()) + 1);
         }
         int any = 0;
         for (size_t i = 0; i < baseclasses->dim; i++)
@@ -1017,7 +1017,7 @@ void EnumDeclaration::toDocBuffer(OutBuffer *buf)
 {
     if (ident)
     {
-        buf->printf("%s $(DDOC_PSYMBOL %s, %s)", kind(), toChars(), toPrettyChars());
+        buf->printf("%s $(DDOC_PSYMBOL %s, %s)", kind(), toChars(), toPrettyChars()  + strlen(this->getModule()->toChars()) + 1  );
         buf->writestring(";\n");
     }
 }
@@ -1975,7 +1975,7 @@ void highlightCode(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
     char *sid = s->ident->toChars();
     FuncDeclaration *f = s->isFuncDeclaration();
 
-    const char *fullyQualifiedName = s->toPrettyChars();
+    const char *fullyQualifiedName = s->toPrettyChars() + strlen(s->getModule()->toChars()) + 1;
     int total = strlen(fullyQualifiedName);
     char *terminator = (char*) malloc(total + 3);
     terminator[0] = ','; // end the first argument

--- a/src/doc.c
+++ b/src/doc.c
@@ -288,12 +288,27 @@ void Module::gendocfile()
         emitMemberComments(sc);
     }
 
-    //printf("BODY= '%.*s'\n", buf.offset, buf.data);
-    Macro::define(&macrotable, (unsigned char *)"BODY", 4, buf.data, buf.offset);
+    // if I did the character encoding right here, I think we'd be in business
+    OutBuffer bufEncoded;
+    bufEncoded.reserve(buf.offset);
+    for(unsigned where = 0; where < buf.offset; where++)
+    {
+        unsigned char c = buf.data[where];
+        const char* replacement = escapetable->strings[c];
+	if (replacement == NULL)
+	    bufEncoded.writeByte(c);
+	else
+	    bufEncoded.writestring(replacement);
+    }
+
+    // printf("BODY= '%.*s'\n", bufEncoded.offset, bufEncoded.data);
+    // printf("BODY= '%.*s'\n", buf.offset, buf.data);
+    Macro::define(&macrotable, (unsigned char *)"BODY", 4, bufEncoded.data, bufEncoded.offset);
 
     OutBuffer buf2;
     buf2.writestring("$(DDOC)\n");
     unsigned end = buf2.offset;
+
     macrotable->expand(&buf2, 0, &end, NULL, 0);
 
 #if 1

--- a/src/doc.c
+++ b/src/doc.c
@@ -288,15 +288,24 @@ void Module::gendocfile()
 
     // if I did the character encoding right here, I think we'd be in business
     OutBuffer bufEncoded;
-    bufEncoded.reserve(buf.offset);
-    for(unsigned where = 0; where < buf.offset; where++)
+    if(escapetable != NULL)
     {
-        unsigned char c = buf.data[where];
-        const char* replacement = escapetable->strings[c];
-	if (replacement == NULL)
-	    bufEncoded.writeByte(c);
-	else
-	    bufEncoded.writestring(replacement);
+        bufEncoded.reserve(buf.offset);
+        for(unsigned where = 0; where < buf.offset; where++)
+        {
+            unsigned char c = buf.data[where];
+            const char* replacement = escapetable->strings[c];
+            if (replacement == NULL)
+                bufEncoded.writeByte(c);
+            else
+                bufEncoded.writestring(replacement);
+        }
+    }
+    else
+    {
+        bufEncoded.reserve(buf.offset);
+        for(unsigned where = 0; where < buf.offset; where++)
+        	bufEncoded.writeByte(buf.data[where]);
     }
 
     // printf("BODY= '%.*s'\n", bufEncoded.offset, bufEncoded.data);
@@ -1527,6 +1536,9 @@ void DocComment::parseEscapes(Escape **pescapetable, unsigned char *textstart, u
     }
     unsigned char *p = textstart;
     unsigned char *pend = p + textlen;
+
+    // By default, set null everywhere so no character is escaped.
+    memset(escapetable, 0, sizeof(*escapetable));
 
     while (1)
     {


### PR DESCRIPTION
Here's some details:
http://forum.dlang.org/thread/igiihgtmsaptfvfbtozz@forum.dlang.org

These are breaking changes, but everyone I've asked has thought
they are good ideas, and it is pretty easy to fix what it breaks.

There's two things in here:

1) change PSYMBOL to give both toChars() and toPrettyChars(), for better anchor generation

2) kill the embedded html feature, since it is more trouble than its worth. Instead, we'll use the ESCAPES system to encode input in a user defined fashion and macros to output html.

Aside from the expected breakage, it seems to work very well.
