### PR TITLE
7589 __traits(compiles) does not work with a template that fails to compile

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6726,6 +6726,7 @@ Type *TypeTypeof::semantic(Loc loc, Scope *sc)
     {
         Scope *sc2 = sc->push();
         sc2->intypeof++;
+        sc2->speculative = true;
         sc2->flags |= sc->flags & SCOPEstaticif;
         unsigned oldspecgag = global.speculativeGag;
         if (global.gag)

--- a/src/scope.c
+++ b/src/scope.c
@@ -74,6 +74,7 @@ Scope::Scope()
     this->noaccesscheck = 0;
     this->mustsemantic = 0;
     this->intypeof = 0;
+    this->speculative = 0;
     this->parameterSpecialization = 0;
     this->callSuper = 0;
     this->flags = 0;

--- a/src/scope.h
+++ b/src/scope.h
@@ -62,6 +62,7 @@ struct Scope
     int nofree;                 // set if shouldn't free it
     int noctor;                 // set if constructor calls aren't allowed
     int intypeof;               // in typeof(exp)
+    bool speculative;            // in __traits(compiles) or typeof(exp)
     int parameterSpecialization; // if in template parameter specialization
     int noaccesscheck;          // don't do access checks
     int mustsemantic;           // cannot defer semantic()

--- a/src/template.c
+++ b/src/template.c
@@ -4535,7 +4535,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     unsigned errorsave = global.errors;
     inst = this;
     // Mark as speculative if we are instantiated from inside is(typeof())
-    if (global.gag && sc->intypeof)
+    if (global.gag && sc->speculative)
         speculative = 1;
 
     int tempdecl_instance_idx = tempdecl->instances.dim;

--- a/src/traits.c
+++ b/src/traits.c
@@ -453,6 +453,8 @@ Expression *TraitsExp::semantic(Scope *sc)
             unsigned errors = global.startGagging();
             unsigned oldspec = global.speculativeGag;
             global.speculativeGag = global.gag;
+            bool scSpec = sc->speculative;
+            sc->speculative = true;
 
             Type *t = isType(o);
             if (t)
@@ -473,6 +475,7 @@ Expression *TraitsExp::semantic(Scope *sc)
                 }
             }
 
+            sc->speculative = scSpec;
             global.speculativeGag = oldspec;
             if (global.endGagging(errors))
             {

--- a/test/runnable/template4.d
+++ b/test/runnable/template4.d
@@ -709,7 +709,7 @@ class Bar26 {}
 string name26;
 
 template aliastest(alias A) {
-        pragma(msg,"Alias Test instanciated");  
+        pragma(msg,"Alias Test instantiated");
         void aliastest() {
 		name26 = (new A!().al).classinfo.name;
 		//writefln("Alias Test: ", name26);
@@ -1019,6 +1019,19 @@ void instantiate4652()
     bug4652default(true);
     bug4676(1, 2, 3);
 }
+
+/*********************************************************/
+// 7589
+
+struct T7589(T)
+{
+    void n;
+}
+static assert(!__traits(compiles, T7589!(int)));
+
+int bug7589b(T)() @safe { int *p; *(p + 8) = 6; }
+static assert(__traits(compiles, bug7589b!(int)()+7 ));
+
 
 /*********************************************************/
 


### PR DESCRIPTION
A very recent regression.
Root cause: up to now, templates instantiated in __traits(compiles) haven't been marked as speculative.
We need to get this from the scope.  This commit adds a new 'speculative' member to Scope, to stop conflating typeof() with speculation.

[Incompletely tested - do not push this until autotester has completed running]
