### PR TITLE
Issue 7618 - delegate/function pointer call bypass parameter storage class

### DIFF
--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4715,6 +4715,24 @@ int bug7583() {
 static assert (bug7583());
 
 /***************************************************/
+// 7618
+
+void test7618(const int x = 1)
+{
+    int func(ref int x) { return 1; }
+    static assert(!__traits(compiles, func(x)));
+    // Error: function test.foo.func (ref int _param_0) is not callable using argument types (const(int))
+
+    int delegate(ref int) dg = (ref int x) => 1;
+    static assert(!__traits(compiles, dg(x)));
+    // --> no error, bad!
+
+    int function(ref int) fp = (ref int x) => 1;
+    static assert(!__traits(compiles, fp(x)));
+    // --> no error, bad!
+}
+
+/***************************************************/
 
 int main()
 {
@@ -4934,6 +4952,7 @@ int main()
     test7196();
     test7285();
     test7321();
+    test7618();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7618

We should call `TypeFunction::callMatch` against delegate and function pointer call, as same as normal function call.
