### PR TITLE
fix latent bug with Lexer::peek and recently introduced bug in Lexer::scan

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -370,7 +370,6 @@ Token *Lexer::peek(Token *ct)
     {
         t = new Token();
         scan(t);
-        t->next = NULL;
         ct->next = t;
     }
     return t;
@@ -1231,7 +1230,7 @@ void Lexer::scan(Token *t)
             case '#':
             {
                 p++;
-                Token *n = peek(&token);
+                Token *n = peek(t);
                 if (n->value == TOKidentifier && n->ident == Id::line)
                 {
                     nextToken();

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -252,6 +252,7 @@ struct Token
     static const char *tochars[TOKMAX];
     static void *operator new(size_t sz);
 
+    Token() : next(NULL) {}
     int isKeyword();
     void print();
     const char *toChars();


### PR DESCRIPTION
In Lexer::peek, the code truncated the next list in the case where peek was reentrant.  ie:

  ... peek ... ... peek ...

In TOKpound processing, it should peek relative to the passed in token rather than the global current token.
