### PR TITLE
initialize popndTmp rather than rely on carefulness

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -1305,7 +1305,7 @@ STATIC code *asm_emit(Loc loc,
         unsigned char *puc;
         unsigned usDefaultseg;
         code *pc = NULL;
-        OPND *popndTmp;
+        OPND *popndTmp = NULL;
         ASM_OPERAND_TYPE    aoptyTmp;
         unsigned  uSizemaskTmp;
         REG     *pregSegment;


### PR DESCRIPTION
when usNumops == 0 and emitting a vector instruction, popndTmp is left uninitialized and is later dereferenced.
