### PR TITLE
Issue 7110 - opSlice() & opIndex functions works unstable as template arguments

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3664,7 +3664,10 @@ void TypeSArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
     //printf("s = %p, e = %p, t = %p\n", *ps, *pe, *pt);
     if (*pe)
     {   // It's really an index expression
-        Expression *e = new IndexExp(loc, *pe, dim);
+        Expressions *exps = new Expressions();
+        exps->setDim(1);
+        (*exps)[0] = dim;
+        Expression *e = new ArrayExp(loc, *pe, exps);
         *pe = e;
     }
     else if (*ps)
@@ -4115,6 +4118,31 @@ Type *TypeDArray::semantic(Loc loc, Scope *sc)
     next = tn;
     transitive();
     return merge();
+}
+
+void TypeDArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps)
+{
+    //printf("TypeDArray::resolve() %s\n", toChars());
+    next->resolve(loc, sc, pe, pt, ps);
+    //printf("s = %p, e = %p, t = %p\n", *ps, *pe, *pt);
+    if (*pe)
+    {   // It's really a slice expression
+        Expression *e = new SliceExp(loc, *pe, NULL, NULL);
+        *pe = e;
+    }
+    else if (*ps)
+    {
+        TupleDeclaration *td = (*ps)->isTupleDeclaration();
+        if (td)
+            ;   // keep *ps
+        else
+            goto Ldefault;
+    }
+    else
+    {
+     Ldefault:
+        Type::resolve(loc, sc, pe, pt, ps);
+    }
 }
 
 void TypeDArray::toDecoBuffer(OutBuffer *buf, int flag)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -484,6 +484,7 @@ struct TypeDArray : TypeArray
     d_uns64 size(Loc loc);
     unsigned alignsize();
     Type *semantic(Loc loc, Scope *sc);
+    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps);
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -835,6 +835,40 @@ void test7037()
 }
 
 /**********************************/
+// 7110
+
+struct S7110
+{
+    int opSlice(int, int) const { return 0; }
+    int opSlice()         const { return 0; }
+    int opIndex(int, int) const { return 0; }
+    int opIndex(int)      const { return 0; }
+}
+
+enum e7110 = S7110();
+
+template T7110(alias a) { } // or T7110(a...)
+
+alias T7110!( S7110 ) T71100; // passes
+alias T7110!((S7110)) T71101; // passes
+
+alias T7110!( S7110()[0..0]  )  A0; // passes
+alias T7110!(  (e7110[0..0]) )  A1; // passes
+alias T7110!(   e7110[0..0]  )  A2; // passes
+
+alias T7110!( S7110()[0, 0]  ) B0; // passes
+alias T7110!(  (e7110[0, 0]) ) B1; // passes
+alias T7110!(   e7110[0, 0]  ) B2; // passes
+
+alias T7110!( S7110()[]  ) C0; // passes
+alias T7110!(  (e7110[]) ) C1; // passes
+alias T7110!(   e7110[]  ) C2; // fails: e7110 is used as a type
+
+alias T7110!( S7110()[0]  ) D0; // passes
+alias T7110!(  (e7110[0]) ) D1; // passes
+alias T7110!(   e7110[0]  ) D2; // fails: e7110 must be an array or pointer type, not S7110
+
+/**********************************/
 // 7124
 
 template StaticArrayOf(T : E[dim], E, size_t dim)

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1008,6 +1008,15 @@ void test7580()
 }
 
 /**********************************/
+// 7643
+
+template T7643(A...){ alias A T7643; }
+
+alias T7643!(long, "x", string, "y") Specs7643;
+
+alias T7643!( Specs7643[] ) U7643;	// Error: tuple A is used as a type
+
+/**********************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7110

While fixing it, I found a bug 7643. This change fixes it as a side effect.

Issue 7643 - Whole tuple slice isn't resolved as expected
http://d.puremagic.com/issues/show_bug.cgi?id=7643
