### PR TITLE
Add SRCFILENAME to Ddoc predefined macros

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -261,6 +261,9 @@ void Module::gendocfile()
         Macro::define(&macrotable, (unsigned char *)"YEAR", 4, (unsigned char *)p + 20, 4);
     }
 
+    char *srcfilename = srcfile->toChars();
+    Macro::define(&macrotable, (unsigned char *)"SRCFILENAME", 11, (unsigned char *)srcfilename, strlen(srcfilename));
+
     char *docfilename = docfile->toChars();
     Macro::define(&macrotable, (unsigned char *)"DOCFILENAME", 11, (unsigned char *)docfilename, strlen(docfilename));
 
@@ -907,7 +910,7 @@ void AggregateDeclaration::toDocBuffer(OutBuffer *buf)
 #if 0
         emitProtection(buf, protection);
 #endif
-        buf->printf("%s $(DDOC_PSYMBOL %s)", kind(), toChars());
+        buf->printf("%s $(DDOC_PSYMBOL %s %s)", kind(), toChars(), toPrettyChars());
         buf->writestring(";\n");
     }
 }
@@ -931,7 +934,7 @@ void StructDeclaration::toDocBuffer(OutBuffer *buf)
         }
         else
         {
-            buf->printf("%s $(DDOC_PSYMBOL %s)", kind(), toChars());
+            buf->printf("%s $(DDOC_PSYMBOL %s %s)", kind(), toChars(), toPrettyChars());
         }
         buf->writestring(";\n");
     }
@@ -958,7 +961,7 @@ void ClassDeclaration::toDocBuffer(OutBuffer *buf)
         {
             if (isAbstract())
                 buf->writestring("abstract ");
-            buf->printf("%s $(DDOC_PSYMBOL %s)", kind(), toChars());
+            buf->printf("%s $(DDOC_PSYMBOL %s %s)", kind(), toChars(), toPrettyChars());
         }
         int any = 0;
         for (size_t i = 0; i < baseclasses->dim; i++)
@@ -995,7 +998,7 @@ void EnumDeclaration::toDocBuffer(OutBuffer *buf)
 {
     if (ident)
     {
-        buf->printf("%s $(DDOC_PSYMBOL %s)", kind(), toChars());
+        buf->printf("%s $(DDOC_PSYMBOL %s %s)", kind(), toChars(), toPrettyChars());
         buf->writestring(";\n");
     }
 }
@@ -1771,6 +1774,7 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
 {
     //printf("highlightText()\n");
     const char *sid = s->ident->toChars();
+    const char *spretty = s->toPrettyChars();
     FuncDeclaration *f = s->isFuncDeclaration();
     unsigned char *p;
     const char *se;
@@ -1987,6 +1991,8 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
                             if (cmp(sid, buf->data + i, j - i) == 0)
                             {
                                 i = buf->bracket(i, "$(DDOC_PSYMBOL ", j, ")") - 1;
+                                //buf->insert(j, ", ", 2);
+                                //buf->insert(j+2, spretty, strlen(spretty));
                                 break;
                             }
                             else if (isKeyword(buf->data + i, j - i))
@@ -2022,6 +2028,7 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
 void highlightCode(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
 {
     char *sid = s->ident->toChars();
+    const char *spretty = s->toPrettyChars();
     FuncDeclaration *f = s->isFuncDeclaration();
 
     //printf("highlightCode(s = '%s', kind = %s)\n", sid, s->kind());
@@ -2046,6 +2053,8 @@ void highlightCode(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
                 if (cmp(sid, buf->data + i, j - i) == 0)
                 {
                     i = buf->bracket(i, "$(DDOC_PSYMBOL ", j, ")") - 1;
+                    //buf->insert(j, ", ", 2);
+                    //buf->insert(j+2, spretty, strlen(spretty));
                     continue;
                 }
                 else if (f)


### PR DESCRIPTION
I found this would be useful for something I'm experimenting with.  It is simply the filename of the source file.

Companion pull request to the website to add documentation of this is here: [d-programming-language.org #95](https://github.com/D-Programming-Language/d-programming-language.org/pull/95).
