### PR TITLE
Add predefined Ddoc macro SRCFILENAME

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -261,6 +261,9 @@ void Module::gendocfile()
         Macro::define(&macrotable, (unsigned char *)"YEAR", 4, (unsigned char *)p + 20, 4);
     }
 
+    char *srcfilename = srcfile->toChars();
+    Macro::define(&macrotable, (unsigned char *)"SRCFILENAME", 11, (unsigned char *)srcfilename, strlen(srcfilename));
+
     char *docfilename = docfile->toChars();
     Macro::define(&macrotable, (unsigned char *)"DOCFILENAME", 11, (unsigned char *)docfilename, strlen(docfilename));
 


### PR DESCRIPTION
I found this would be useful for something I'm experimenting with. It is simply the filename of the source file.

Companion pull request to the website to add documentation of this is here: [d-programming-language.org #95](https://github.com/D-Programming-Language/d-programming-language.org/pull/95).

This replaces the closed pull request #786 that had unrelated changes accidentally added.
