### PR TITLE
remove more TX86 around OP codes

### DIFF
--- a/src/backend/cgcs.c
+++ b/src/backend/cgcs.c
@@ -302,7 +302,6 @@ STATIC void ecom(elem **pe)
         if (tyfloating(tym))
             return;
         break;
-#if TX86
     case OPstrcpy:
     case OPstrcat:
     case OPmemcpy:
@@ -312,9 +311,7 @@ STATIC void ecom(elem **pe)
         ecom(&e->E1);
         touchfunc(0);
         return;
-#endif
     default:                            /* other operators */
-#if TX86
 #ifdef DEBUG
         if (!EBIN(e)) WROP(e->Eoper);
 #endif
@@ -334,16 +331,6 @@ STATIC void ecom(elem **pe)
         ecom(&e->E1);
         ecom(&e->E2);
         break;
-#else
-#ifdef DEBUG
-        if (!EOP(e)) WROP(e->Eoper);
-#endif
-        assert(EOP(e));
-        ecom(&e->E1);
-        if (EBIN(e))
-                ecom(&e->E2);           /* eval left first              */
-        break;
-#endif
     case OPstring:
     case OPaddr:
     case OPbit:
@@ -620,12 +607,10 @@ STATIC void touchfunc(int flag)
                 }
                 break;
             case OPind:
-#if TX86
             case OPstrlen:
             case OPstrcmp:
             case OPmemcmp:
             case OPbt:
-#endif
                 goto L1;
 #if TARGET_SEGMENTED
             case OPvp_fp:
@@ -653,7 +638,7 @@ STATIC void touchstar()
 
   for (i = touchstari; i < hcstop; i++)
   {     e = hcstab[i].Helem;
-        if (e && (e->Eoper == OPind || e->Eoper == OPbt) /*&& !(e->Ety & mTYconst)*/)
+        if (e && (e->Eoper == OPind || e->Eoper == OPbt) )
                 hcstab[i].Helem = NULL;
   }
   touchstari = hcstop;

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -581,12 +581,6 @@ STATIC elem * elstrcpy(elem *e)
 #endif
         case OPstring:
             /* Replace strcpy(e1,"string") with memcpy(e1,"string",sizeof("string")) */
-#if 0
-            // As memcpy
-            e->Eoper = OPmemcpy;
-            elem *en = el_long(TYsize_t, strlen(e->E2->EV.ss.Vstring) + 1);
-            e->E2 = el_bin(OPparam,TYvoid,e->E2,en);
-#else
             // As streq
             e->Eoper = OPstreq;
             type *t = type_allocn(TYarray, tschar);
@@ -599,7 +593,6 @@ STATIC elem * elstrcpy(elem *e)
             e = el_bin(OPcomma,e->Ety,e,el_copytree(e->E1->E1));
             if (el_sideeffect(e->E2))
                 fixside(&e->E1->E1->E1,&e->E2);
-#endif
             e = optelem(e,TRUE);
             break;
     }
@@ -741,7 +734,6 @@ STATIC elem * elmemxxx(elem *e)
                         el_free(ex);
                         return optelem(e, TRUE);
                     }
-#if 1
                     // Convert OPmemcpy to OPstreq
                     e->Eoper = OPstreq;
                     type *t = type_allocn(TYarray, tschar);
@@ -761,7 +753,6 @@ STATIC elem * elmemxxx(elem *e)
                     if (el_sideeffect(e->E2))
                         fixside(&e->E1->E1->E1,&e->E2);
                     return optelem(e,TRUE);
-#endif
                 }
                 break;
 
@@ -2520,7 +2511,6 @@ CEXTERN elem * elstruct(elem *e)
     if (e->ET)
     switch ((int) type_size(e->ET))
     {
-#if TX86
         case CHARSIZE:  tym = TYchar;   goto L1;
         case SHORTSIZE: tym = TYshort;  goto L1;
         case LONGSIZE:  tym = TYlong;   goto L1;
@@ -2547,7 +2537,6 @@ CEXTERN elem * elstruct(elem *e)
                     break;
             }
             break;
-#endif
         case 0:
             if (e->Eoper == OPstreq)
             {   e->Eoper = OPcomma;
@@ -4219,7 +4208,6 @@ beg:
                     goto retnull;
                 leftgoal = rightgoal;
                 break;
-#if TX86
             case OPmemcmp:
                 if (!goal)
                 {   // So OPmemcmp is removed cleanly
@@ -4228,7 +4216,6 @@ beg:
                 }
                 leftgoal = rightgoal;
                 break;
-#endif
         }
 
         e1 = e->E1;

--- a/src/backend/gflow.c
+++ b/src/backend/gflow.c
@@ -805,12 +805,10 @@ void main()
                            )
                             break;
 #endif
-#if TX86
                     case OPstrlen:
                     case OPstrcmp:
                     case OPmemcmp:
                     case OPbt:          // OPbt is like OPind
-#endif
                         vec_setbit(i,defkill);
                         vec_setbit(i,starkill);
                         break;
@@ -1339,11 +1337,9 @@ STATIC void accumlv(vec_t GEN,vec_t KILL,elem *n)
 
             case OPcall:
             case OPcallns:
-#if TX86
             case OPstrcpy:
             case OPmemcpy:
             case OPmemset:
-#endif
 #ifdef DEBUG
                 assert(OTrtol(op));
 #endif
@@ -1351,14 +1347,12 @@ STATIC void accumlv(vec_t GEN,vec_t KILL,elem *n)
                 accumlv(GEN,KILL,n->E1);
                 goto L1;
 
-#if TX86
             case OPstrcat:
 #ifdef DEBUG
                 assert(!OTrtol(op));
 #endif
                 accumlv(GEN,KILL,n->E1);
                 accumlv(GEN,KILL,n->E2);
-#endif
             L1:
                 vec_orass(GEN,ambigsym);
                 vec_subass(GEN,KILL);

--- a/src/backend/glocal.c
+++ b/src/backend/glocal.c
@@ -269,9 +269,7 @@ Loop:
                 local_remove(LFambigdef | LFambigref);
             }
             break;
-#if TX86
         case OPstrlen:
-#endif
         case OPind:
             local_exp(e->E1,1);
             local_ambigref();
@@ -316,7 +314,6 @@ Loop:
             local_remove(LFfloat | LFambigref | LFambigdef);
             break;
 
-#if TX86
         case OPmemset:
             local_exp(e->E2,1);
             if (e->E1->Eoper == OPvar)
@@ -334,7 +331,6 @@ Loop:
                 local_exp(e->E1,1);
             local_ambigdef();
             break;
-#endif
 
         case OPvar:
             s = e->EV.sp.Vsym;
@@ -590,23 +586,19 @@ STATIC int local_getflags(elem *e,symbol *s)
             case OPcallns:
             case OPnewarray:
             case OPmultinewarray:
-#if TX86
             case OPstrcat:
             case OPstrcpy:
             case OPmemcpy:
             case OPbtc:
             case OPbtr:
             case OPbts:
-#endif
             case OPstrctor:
                 flags |= LFambigref | LFambigdef;
                 break;
 
-#if TX86
             case OPmemset:
                 flags |= LFambigdef;
                 break;
-#endif
 
             case OPvar:
                 if (e->EV.sp.Vsym == s)
@@ -618,12 +610,10 @@ STATIC int local_getflags(elem *e,symbol *s)
             case OPind:
             case OParray:
             case OPfield:
-#if TX86
             case OPstrlen:
             case OPstrcmp:
             case OPmemcmp:
             case OPbt:
-#endif
                 flags |= LFambigref;
                 break;
 

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -958,7 +958,6 @@ STATIC void markinvar(elem *n,vec_t rd)
                 markinvar(n->E1,rd);
                 break;
 
-#if TX86
         case OPstrcpy:
         case OPstrcat:
         case OPmemcpy:
@@ -974,7 +973,6 @@ STATIC void markinvar(elem *n,vec_t rd)
                 markinvar(n->E2,rd);
                 updaterd(n,rd,NULL);
                 break;
-#endif
         case OPucall:
                 markinvar(n->E1,rd);
                 /* FALL-THROUGH */
@@ -987,20 +985,20 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPstrpar:
         case OPstrctor:
         case OPvector:
-#if TX86
         case OPvoid:
         case OPstrlen:
+#if TX86
         case OPinp:
 #endif
                 markinvar(n->E1,rd);
                 break;
         case OPcond:
         case OPparam:
-#if TX86
-        case OPoutp:
         case OPstrcmp:
         case OPmemcmp:
         case OPbt:                      // OPbt is like OPind, assume not LI
+#if TX86
+        case OPoutp:
 #endif
                 markinvar(n->E1,rd);
                 markinvar(n->E2,rd);
@@ -1057,12 +1055,10 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPsin:
         case OPcos:
         case OPrint:
-#if TX86
         case OPsetjmp:
         case OPbsf:
         case OPbsr:
         case OPbswap:
-#endif
 #if TARGET_SEGMENTED
         case OPvp_fp: /* BUG for MacHandles */
         case OPnp_f16p: case OPf16p_np: case OPoffset: case OPnp_fp:

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -45,9 +45,9 @@ enum OPER
         OPaddr,                 /* &E                           */
         OPneg,                  /* unary -                      */
         OPuadd,                 /* unary +                      */
-#if TX86
         OPvoid,                 // where casting to void is not a no-op
         OPabs,                  /* absolute value               */
+#if TX86
         OPsqrt,                 /* square root                  */
         OPrndtol,               // round to short, long, long long (inline 8087 only)
         OPsin,                  // sine
@@ -56,6 +56,7 @@ enum OPER
         OPscale,                // ldexp
         OPyl2x,                 // y * log2(x)
         OPyl2xp1,               // y * log2(x + 1)
+#endif
         OPstrlen,               /* strlen()                     */
         OPstrcpy,               /* strcpy()                     */
         OPstrcat,               /* strcat()                     */
@@ -64,11 +65,9 @@ enum OPER
         OPmemcmp,
         OPmemset,
         OPsetjmp,               // setjmp()
-#endif
 
         OPremquo,               // / and % in one operation
 
-#if TX86
         OPbsf,                  // bit scan forward
         OPbsr,                  // bit scan reverse
         OPbt,                   // bit test
@@ -78,7 +77,6 @@ enum OPER
         OPbswap,                // swap bytes
         OProl,                  // rotate left
         OPror,                  // rotate right
-#endif
 
         OPstreq,                /* structure assignment         */
 

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -75,7 +75,6 @@ int _assign[] =
         {OPstreq,OPeq,OPaddass,OPminass,OPmulass,OPdivass,OPmodass,
          OPshrass,OPashrass,OPshlass,OPandass,OPxorass,OPorass,OPpostinc,OPpostdec,
          OPnegass,
-        /* OPbtc,OPbtr,OPbts,*/
         };
 int _wid[] =
         {OPadd,OPmin,OPand,OPor,OPxor,OPcom,OPneg,OPmul,OPaddass,OPnegass,
@@ -142,7 +141,7 @@ int _ae[] = {OPvar,OPconst,OPrelconst,OPneg,
 #if TARGET_SEGMENTED
                 OPvp_fp,OPcvp_fp,OPnp_fp,OPnp_f16p,OPf16p_np,OPoffset,
 #endif
-                /*OPcomma,OPbit,OPoror,OPandand,OPcond,OPcolon,OPcolon2*/};
+                };
 int _exp[] = {OPvar,OPconst,OPrelconst,OPneg,OPabs,OPsqrt,OPrndtol,OPrint,
                 OPsin,OPcos,OPscale,OPyl2x,OPyl2xp1,
                 OPstrlen,OPstrcmp,OPind,OPaddr,

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2784,13 +2784,8 @@ elem *AssignExp::toElem(IRState *irs)
                 esize = el_bin(OPmul, TYsize_t, elen, esize);
                 elem *epto = array_toPtr(e1->type, ex);
                 elem *epfr = array_toPtr(e2->type, efrom);
-#if 1
-                // memcpy() is faster, so if we can't beat 'em, join 'em
                 e = el_params(esize, epfr, epto, NULL);
                 e = el_bin(OPcall,TYnptr,el_var(rtlsym[RTLSYM_MEMCPY]),e);
-#else
-                e = el_bin(OPmemcpy, TYnptr, epto, el_param(epfr, esize));
-#endif
                 e = el_pair(eto->Ety, el_copytree(elen), e);
                 e = el_combine(eto, e);
             }


### PR DESCRIPTION
OPmem*
OPstr*
OPbt*
OPvoid
OPsetjmp

They're all not specific to X86.

Also, remove #if 1's and #if 0's from a few rather old parts of the code that aren't for debugging or going to change back.
