### PR TITLE
Bug 977

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -307,7 +307,7 @@ void Lexer::error(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);
-    verror(loc, format, ap);
+    verror(tokenLoc(), format, ap);
     va_end(ap);
 }
 
@@ -2870,6 +2870,38 @@ unsigned char *Lexer::combineComments(unsigned char *c1, unsigned char *c2)
         }
     }
     return c;
+}
+
+/*******************************************
+ * Search actual location of current token
+ * even when infinite look-ahead was done.
+ */
+Loc Lexer::tokenLoc()
+{
+    Loc result = this->loc;
+    Token* last = &token;
+    while (last->next)
+        last = last->next;
+
+    unsigned char* start = token.ptr;
+    unsigned char* stop = last->ptr;
+
+    for (unsigned char* p = start; p < stop; ++p)
+    {
+        switch (*p)
+        {
+            case '\n':
+                result.linnum--;
+                break;
+            case '\r':
+                if (p[1] != '\n')
+                    result.linnum--;
+                break;
+            default:
+                break;
+        }
+    }
+    return result;
 }
 
 /********************************************

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -313,6 +313,8 @@ struct Lexer
 
     static int isValidIdentifier(char *p);
     static unsigned char *combineComments(unsigned char *c1, unsigned char *c2);
+
+    Loc tokenLoc();
 };
 
 #endif /* DMD_LEXER_H */

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3038,7 +3038,7 @@ Expression *TypeBasic::dotExp(Scope *sc, Expression *e, Identifier *ident)
             case Timaginary64:  t = tfloat64;           goto L2;
             case Timaginary80:  t = tfloat80;           goto L2;
             L2:
-                e = new RealExp(0, ldouble(0.0), t);
+                e = new RealExp(e->loc, ldouble(0.0), t);
                 break;
 
             default:
@@ -3070,7 +3070,7 @@ Expression *TypeBasic::dotExp(Scope *sc, Expression *e, Identifier *ident)
             case Tfloat32:
             case Tfloat64:
             case Tfloat80:
-                e = new RealExp(0, ldouble(0.0), this);
+                e = new RealExp(e->loc, ldouble(0.0), this);
                 break;
 
             default:


### PR DESCRIPTION
Hi,

My first commit in the dmd codebase, fix bug #977.

The line given in errors in array initializers, seems to be correct. But I'm afraid of what could have been broken. Worst case scenario with a large number of errors in a big lookahead is O^2. As no line numbers goes with token I'm not sure anything else can be done.

Please review!
