### PR TITLE
6681 - Regression with unions in CTFE

### DIFF
--- a/src/mtype.h
+++ b/src/mtype.h
@@ -302,6 +302,7 @@ struct Type : Object
     virtual unsigned memalign(unsigned salign);
     virtual Expression *defaultInit(Loc loc = 0);
     virtual Expression *defaultInitLiteral(Loc loc = 0);
+    virtual Expression *voidInitLiteral(VarDeclaration *var);
     virtual int isZeroInit(Loc loc = 0);                // if initializer is 0
     virtual dt_t **toDt(dt_t **pdt);
     Identifier *getTypeInfoIdent(int internal);
@@ -459,6 +460,7 @@ struct TypeSArray : TypeArray
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
+    Expression *voidInitLiteral(VarDeclaration *var);
     dt_t **toDt(dt_t **pdt);
     dt_t **toDtElem(dt_t **pdt, Expression *e);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wildmatch = NULL);
@@ -755,6 +757,7 @@ struct TypeStruct : Type
     unsigned memalign(unsigned salign);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
+    Expression *voidInitLiteral(VarDeclaration *var);
     int isZeroInit(Loc loc);
     int isAssignable();
     int checkBoolean();

--- a/src/parse.c
+++ b/src/parse.c
@@ -6589,6 +6589,7 @@ void initPrecedence()
     precedence[TOKtraits] = PREC_primary;
     precedence[TOKdefault] = PREC_primary;
     precedence[TOKoverloadset] = PREC_primary;
+    precedence[TOKvoid] = PREC_primary;
 #endif
 
     // post

--- a/src/todt.c
+++ b/src/todt.c
@@ -109,7 +109,9 @@ dt_t *StructInitializer::toDt()
         {   // An instance specific initializer was not provided.
             // Look to see if there's a default initializer from the
             // struct definition
-            if (v->init)
+            if (v->init && v->init->isVoidInitializer())
+                ;
+            else if (v->init)
             {
                 d = v->init->toDt();
             }
@@ -649,7 +651,9 @@ dt_t **StructLiteralExp::toDt(dt_t **pdt)
         {   // An instance specific initializer was not provided.
             // Look to see if there's a default initializer from the
             // struct definition
-            if (v->init)
+            if (v->init && v->init->isVoidInitializer())
+                ;
+            else if (v->init)
             {
                 d = v->init->toDt();
             }
@@ -843,7 +847,9 @@ void ClassDeclaration::toDt2(dt_t **pdt, ClassDeclaration *cd)
         {   //printf("\t\t%s has initializer %s\n", v->toChars(), init->toChars());
             ExpInitializer *ei = init->isExpInitializer();
             Type *tb = v->type->toBasetype();
-            if (ei && tb->ty == Tsarray)
+            if (init->isVoidInitializer())
+                ;
+            else if (ei && tb->ty == Tsarray)
                 ((TypeSArray *)tb)->toDtElem(&dt, ei->exp);
             else
                 dt = init->toDt();
@@ -929,7 +935,9 @@ void StructDeclaration::toDt(dt_t **pdt)
             {   //printf("\t\thas initializer %s\n", init->toChars());
                 ExpInitializer *ei = init->isExpInitializer();
                 Type *tb = v->type->toBasetype();
-                if (ei && tb->ty == Tsarray)
+                if (init->isVoidInitializer())
+                    ;
+                else if (ei && tb->ty == Tsarray)
                     ((TypeSArray *)tb)->toDtElem(&dt, ei->exp);
                 else
                     dt = init->toDt();


### PR DESCRIPTION
Add VoidExp to explicitly specify uninitialized variables.
When a union member is written to, set all other members of that union to VoidExp.

90% of this commit was written by yebblies. I've only added the union part.

Note: Please wait until this clears the autotester, it was not developed on my normal machine.
