### PR TITLE
Issue 7678: Added -cflag=ccflags switch.  

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -223,7 +223,7 @@ int runLINK()
         delete lnkfilename;
     }
     return status;
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun&&__SVR4
+#elif CC_DRIVES_LINKING
     pid_t childpid;
     int i;
     int status;
@@ -340,6 +340,11 @@ int runLINK()
         if (!p || !p[0] || !(p[0] == '-' && p[1] == 'l'))
             // Don't need -Xlinker if switch starts with -l
             argv.push((char *)"-Xlinker");
+        argv.push(p);
+    }
+    
+    for (size_t i = 0; i < global.params.ccswitches->dim; i++)
+    {   char *p = global.params.ccswitches->tdata()[i];
         argv.push(p);
     }
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -314,8 +314,11 @@ Usage:\n\
   files.d        D source files\n\
   @cmdfile       read arguments from cmdfile\n\
   -c             do not link\n\
-  -cov           do code coverage analysis\n\
-  -D             generate documentation\n\
+  -cov           do code coverage analysis\n"
+#if CC_DRIVES_LINKING
+"  -cflag=ccflag  pass ccflag to the C compiler being used to drive linking\n"
+#endif
+"  -D             generate documentation\n\
   -Dddocdir      write documentation file to docdir directory\n\
   -Dffilename    write documentation file to filename\n\
   -d             allow deprecated features\n\
@@ -438,6 +441,7 @@ int tryMain(int argc, char *argv[])
     global.params.quiet = 1;
 
     global.params.linkswitches = new Strings();
+    global.params.ccswitches = new Strings();
     global.params.libfiles = new Strings();
     global.params.objfiles = new Strings();
     global.params.ddocfiles = new Strings();
@@ -777,6 +781,12 @@ int tryMain(int argc, char *argv[])
             {
                 global.params.linkswitches->push(p + 2);
             }
+#if CC_DRIVES_LINKING
+            else if (memcmp(p + 1, "cflag=", 6) == 0)
+            {
+                global.params.ccswitches->push(p + 1 + 6);
+            }
+#endif
             else if (memcmp(p + 1, "defaultlib=", 11) == 0)
             {
                 global.params.defaultlibname = p + 1 + 11;

--- a/src/mars.h
+++ b/src/mars.h
@@ -122,6 +122,15 @@ void unittests();
 #endif
 #endif
 
+// On these systems the C Compiler is used to drive linking.
+// The compiler is chosen using the ${CC} environment variable, but if that is
+//   not provided it will default to gcc.
+#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun&&__SVR4
+#ifndef CC_DRIVES_LINKING
+#define CC_DRIVES_LINKING 1
+#endif
+#endif
+
 
 struct OutBuffer;
 
@@ -230,6 +239,7 @@ struct Param
     // Linker stuff
     Strings *objfiles;
     Strings *linkswitches;
+    Strings *ccswitches;
     Strings *libfiles;
     char *deffile;
     char *resfile;


### PR DESCRIPTION
This allows arguments to be passed to the C compiler being used to drive linking.

I've also opened issue 7678 for this.  (http://d.puremagic.com/issues/show_bug.cgi?id=7678)

I was prompted to make this patch because of issue 5278 remaining unresolved. (http://d.puremagic.com/issues/show_bug.cgi?id=5278)
