### PR TITLE
Issue 7682 - shared array type and "cast() is not an lvalue" error

### DIFF
--- a/src/optimize.c
+++ b/src/optimize.c
@@ -633,7 +633,7 @@ Expression *CastExp::optimize(int result)
     }
 
     // We can convert 'head const' to mutable
-    if (to->constOf()->equals(e1->type->constOf()))
+    if (to->mutableOf()->constOf()->equals(e1->type->mutableOf()->constOf()))
     {
         e1->type = type;
         if (X) printf(" returning5 %s\n", e1->toChars());

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4743,6 +4743,27 @@ void test7618(const int x = 1)
 }
 
 /***************************************************/
+// 7682
+
+template ConstOf7682(T)
+{
+    alias const(T) ConstOf7682;
+}
+bool pointsTo7682(S)(ref const S source) @trusted pure nothrow
+{
+    return true;
+}
+void test7682()
+{
+    shared(ConstOf7682!(int[])) x;  // line A
+
+    struct S3 { int[10] a; }
+    shared(S3) sh3;
+    shared(int[]) sh3sub = sh3.a[];
+    assert(pointsTo7682(sh3sub));   // line B
+}
+
+/***************************************************/
 
 int main()
 {
@@ -4963,6 +4984,7 @@ int main()
     test7285();
     test7321();
     test7618();
+    test7682();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7682

If you check 'head const convertible', you should keep shared qualifier.

(shared const T)->constOf() == `const T`, but
(shared const T)->mutableOf() == `shared T`, and (shared T)->constOf() == `shared const T`
