### PR TITLE
Fix type merging and deduction bugs

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1868,14 +1868,11 @@ Type *Type::substWildTo(unsigned mod)
             else if (ty == Tsarray)
                 t = new TypeSArray(t, ((TypeSArray *)this)->dim->syntaxCopy());
             else if (ty == Taarray)
-            {
                 t = new TypeAArray(t, ((TypeAArray *)this)->index->syntaxCopy());
-                t = t->merge();
-            }
             else
                 assert(0);
 
-            t = t->addMod(this->mod);
+            t = t->merge();
         }
     }
     else
@@ -2468,9 +2465,7 @@ Type *TypeNext::makeMutable()
 {
     //printf("TypeNext::makeMutable() %p, %s\n", this, toChars());
     TypeNext *t = (TypeNext *)Type::makeMutable();
-    if ((ty != Tfunction && next->ty != Tfunction &&
-        //(next->deco || next->ty == Tfunction) &&
-        next->isWild()) || ty == Tsarray)
+    if (ty == Tsarray)
     {
         t->next = next->mutableOf();
     }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -417,6 +417,8 @@ Type *Type::mutableOf()
         t = t->merge();
         t->fixTo(this);
     }
+    else
+        t = t->merge();
     assert(t->isMutable());
     return t;
 }
@@ -508,6 +510,8 @@ Type *Type::unSharedOf()
 
         t->fixTo(this);
     }
+    else
+        t = t->merge();
     assert(!t->isShared());
     return t;
 }

--- a/src/template.c
+++ b/src/template.c
@@ -1934,9 +1934,7 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
                 goto Lerror;
         }
         {
-            tdargs->setDim(dedargs.dim);
-            memcpy(tdargs->data, dedargs.data, tdargs->dim * sizeof(void *));
-            fd = td->doHeaderInstantiation(sc, tdargs, fargs);
+            fd = td->doHeaderInstantiation(sc, &dedargs, fargs);
             if (!fd)
                 goto Lerror;
         }

--- a/src/template.c
+++ b/src/template.c
@@ -2299,13 +2299,17 @@ MATCH Type::deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters,
         {
             switch (X(tparam->mod, mod))
             {
-                case X(MODwild,              MODwild):
-                case X(MODwild | MODshared,  MODwild | MODshared):
                 case X(MODwild,              0):
+                case X(MODwild,              MODshared):
                 case X(MODwild,              MODconst):
+                case X(MODwild,              MODconst | MODshared):
                 case X(MODwild,              MODimmutable):
+                case X(MODwild,              MODwild):
+                case X(MODwild,              MODwild | MODshared):
                 case X(MODwild | MODshared,  MODshared):
                 case X(MODwild | MODshared,  MODconst | MODshared):
+                case X(MODwild | MODshared,  MODimmutable):
+                case X(MODwild | MODshared,  MODwild | MODshared):
 
                     if (!at)
                     {

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1035,6 +1035,20 @@ void test7671()
 }
 
 /************************************/
+// 7672
+
+T foo7672(T)(T a){ return a; }
+
+void test7672(inout(int[]) a = null, inout(int*) p = null)
+{
+    static assert(is( typeof(        a ) == inout(int[]) ));
+    static assert(is( typeof(foo7672(a)) == inout(int)[] ));
+
+    static assert(is( typeof(        p ) == inout(int*) ));
+    static assert(is( typeof(foo7672(p)) == inout(int)* ));
+}
+
+/**********************************/
 // 7684
 
        U[]  id7684(U)(        U[]  );
@@ -1116,6 +1130,7 @@ int main()
     test7563();
     test7580();
     test7671();
+    test7672();
     test7684();
     test11a();
     test11b();

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1017,6 +1017,24 @@ alias T7643!(long, "x", string, "y") Specs7643;
 alias T7643!( Specs7643[] ) U7643;	// Error: tuple A is used as a type
 
 /**********************************/
+// 7671
+
+       inout(int)[3]  id7671n1             ( inout(int)[3] );
+       inout( U )[n]  id7671x1(U, size_t n)( inout( U )[n] );
+
+shared(inout int)[3]  id7671n2             ( shared(inout int)[3] );
+shared(inout  U )[n]  id7671x2(U, size_t n)( shared(inout  U )[n] );
+
+void test7671()
+{
+    static assert(is( typeof( id7671n1( (immutable(int)[3]).init ) ) == immutable(int[3]) ));
+    static assert(is( typeof( id7671x1( (immutable(int)[3]).init ) ) == immutable(int[3]) ));
+
+    static assert(is( typeof( id7671n2( (immutable(int)[3]).init ) ) == immutable(int[3]) ));
+    static assert(is( typeof( id7671x2( (immutable(int)[3]).init ) ) == immutable(int[3]) ));
+}
+
+/************************************/
 // 7684
 
        U[]  id7684(U)(        U[]  );
@@ -1069,6 +1087,7 @@ int main()
     test7416();
     test7563();
     test7580();
+    test7671();
     test7684();
 
     printf("Success\n");

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1048,6 +1048,34 @@ void test7684()
 
 /**********************************/
 
+       inout(U)[]  id11a(U)(        inout(U)[]  );
+       inout(U[])  id11a(U)(        inout(U[])  );
+inout(shared(U[])) id11a(U)( inout(shared(U[])) );
+
+void test11a(inout int _ = 0)
+{
+    shared(const(int))[] x;
+    static assert(is( typeof(id11a(x)) == shared(const(int))[] ));
+
+    shared(int)[] y;
+    static assert(is( typeof(id11a(y)) == shared(int)[] ));
+
+    inout(U)[n] idz(U, size_t n)( inout(U)[n] );
+
+    inout(shared(bool[1])) z;
+    static assert(is( typeof(idz(z)) == inout(shared(bool[1])) ));
+}
+
+inout(U[]) id11b(U)( inout(U[]) );
+
+void test11b()
+{
+    alias const(shared(int)[]) T;
+    static assert(is(typeof(id11b(T.init)) == const(shared(int)[])));
+}
+
+/**********************************/
+
 int main()
 {
     test1();
@@ -1089,6 +1117,8 @@ int main()
     test7580();
     test7671();
     test7684();
+    test11a();
+    test11b();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1017,6 +1017,18 @@ alias T7643!(long, "x", string, "y") Specs7643;
 alias T7643!( Specs7643[] ) U7643;	// Error: tuple A is used as a type
 
 /**********************************/
+// 7684
+
+       U[]  id7684(U)(        U[]  );
+shared(U[]) id7684(U)( shared(U[]) );
+
+void test7684()
+{
+    shared(int)[] x;
+    static assert(is( typeof(id7684(x)) == shared(int)[] ));
+}
+
+/**********************************/
 
 int main()
 {
@@ -1057,6 +1069,7 @@ int main()
     test7416();
     test7563();
     test7580();
+    test7684();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2550,6 +2550,15 @@ void test7518() {
 }
 
 /************************************/
+// 7669
+
+shared(inout U)[n] id7669(U, size_t n)( shared(inout U)[n] );
+void test7669()
+{
+    static assert(is(typeof( id7669((shared(int)[3]).init)) == shared(int)[3]));
+}
+
+/************************************/
 
 int main()
 {
@@ -2659,6 +2668,7 @@ int main()
     test7202();
     test7554();
     test7518();
+    test7669();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1426,7 +1426,7 @@ void test82(inout(int) _ = 0)
     pragma(msg, typeof(o));
     static assert(typeof(o).stringof == "inout(char*****)");
     pragma(msg, typeof(cast()o));
-    static assert(typeof(cast()o).stringof == "char*****");
+    static assert(typeof(cast()o).stringof == "inout(char****)*");
 
     const(char*****) p;
     pragma(msg, typeof(p));


### PR DESCRIPTION
(This is based on #798)

They have been attributed type merging bugs and template type deduction bugs.

<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7669">Issue 7669</a> - Broken inout deduction with static array type
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7671">Issue 7671</a> - Broken inout deduction of shared(inout(T[n])) from immutable(int[3]) 
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7672">Issue 7672</a> - Remove top const doesn't work for inout array type
