### PR TITLE
fix issue 4507

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -627,7 +627,11 @@ void FuncDeclaration::semantic(Scope *sc)
 
         if (!doesoverride && isOverride())
         {
-            error("does not override any function");
+            Dsymbol *s = cd->search_correct(ident);
+            if (s)
+                error("does not override any function, did you mean '%s'", s->toPrettyChars());
+            else
+                error("does not override any function");
         }
 
     L2: ;


### PR DESCRIPTION
[Issue 4507](http://d.puremagic.com/issues/show_bug.cgi?id=4507) - use spellchecker when override function doesn't override anything
