### PR TITLE
Fix issue 6681 - struct constructor call is converted to struct literal ...

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1561,9 +1561,7 @@ void VarDeclaration::semantic2(Scope *sc)
         // Inside unions, default to void initializers
     if (!init && sc->inunion && !toParent()->isFuncDeclaration())
     {
-        AggregateDeclaration *aad = sc->anonAgg;
-        if (!aad)
-            aad = parent->isAggregateDeclaration();
+        AggregateDeclaration *aad = parent->isAggregateDeclaration();
         if (aad)
         {
             if (aad->fields[0] == this)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -246,6 +246,16 @@ struct ClassReferenceExp : Expression
     {
         return value->sd->isClassDeclaration();
     }
+    VarDeclaration *getFieldAt(int index)
+    {
+        ClassDeclaration *cd = originalClass();
+        size_t fieldsSoFar = 0;
+        while (index - fieldsSoFar >= cd->fields.dim)
+        {   fieldsSoFar += cd->fields.dim;
+            cd = cd->baseClass;
+        }
+        return cd->fields.tdata()[index - fieldsSoFar];
+    }
     // Return index of the field, or -1 if not found
     int getFieldIndex(Type *fieldtype, size_t fieldoffset)
     {
@@ -283,6 +293,28 @@ struct ClassReferenceExp : Expression
             }
         }
         return -1;
+    }
+};
+
+struct VoidInitExp : Expression
+{
+    VarDeclaration *var;
+
+    VoidInitExp(VarDeclaration *var, Type *type)
+        : Expression(var->loc, TOKvoid, sizeof(VoidInitExp))
+    {
+        this->var = var;
+        this->type = var->type;
+    }
+    char *toChars()
+    {
+        return (char *)"void";
+    }
+    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue)
+    {
+        error("CTFE internal error: trying to read uninitialized variable");
+        assert(0);
+        return EXP_CANT_INTERPRET;
     }
 };
 
@@ -986,7 +1018,7 @@ Expression *ctfeCat(Type *type, Expression *e1, Expression *e2)
     return Cat(type, e1, e2);
 }
 
-bool scrubArray(Loc loc, Expressions *elems);
+bool scrubArray(Loc loc, Expressions *elems, bool structlit = false);
 
 /* All results destined for use outside of CTFE need to have their CTFE-specific
  * features removed.
@@ -999,6 +1031,11 @@ Expression *scrubReturnValue(Loc loc, Expression *e)
         error(loc, "%s class literals cannot be returned from CTFE", ((ClassReferenceExp*)e)->originalClass()->toChars());
         return EXP_CANT_INTERPRET;
     }
+    if (e->op == TOKvoid)
+    {
+        error(loc, "uninitialized variable '%s' cannot be returned from CTFE", ((VoidInitExp *)e)->var->toChars());
+        e = new ErrorExp();
+    }
     if (e->op == TOKslice)
     {
         e = resolveSlice(e);
@@ -1007,7 +1044,7 @@ Expression *scrubReturnValue(Loc loc, Expression *e)
     {
         StructLiteralExp *se = (StructLiteralExp *)e;
         se->ownedByCtfe = false;
-        if (!scrubArray(loc, se->elements))
+        if (!scrubArray(loc, se->elements, true))
             return EXP_CANT_INTERPRET;
     }
     if (e->op == TOKstring)
@@ -1033,14 +1070,17 @@ Expression *scrubReturnValue(Loc loc, Expression *e)
 }
 
 // Scrub all members of an array. Return false if error
-bool scrubArray(Loc loc, Expressions *elems)
+bool scrubArray(Loc loc, Expressions *elems, bool structlit)
 {
     for (size_t i = 0; i < elems->dim; i++)
     {
         Expression *m = elems->tdata()[i];
         if (!m)
             continue;
-        m = scrubReturnValue(loc, m);
+        if (m && m->op == TOKvoid && structlit)
+            m = NULL;
+        if (m)
+            m = scrubReturnValue(loc, m);
         if (m == EXP_CANT_INTERPRET)
             return false;
         elems->tdata()[i] = m;
@@ -1932,11 +1972,16 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
             {
                 if (v->init->isVoidInitializer())
                 {
-                        error(loc, "variable %s is used before initialization", v->toChars());
-                        return EXP_CANT_INTERPRET;
+                    // var should have been initialized when it was created
+                    error("CTFE internal error - trying to access uninitialized var");
+                    assert(0);
+                    e = EXP_CANT_INTERPRET;
                 }
-                e = v->init->toExpression();
-                e = e->interpret(istate);
+                else
+                {
+                    e = v->init->toExpression();
+                    e = e->interpret(istate);
+                }
             }
             else
                 e = v->type->defaultInitLiteral(loc);
@@ -1952,7 +1997,11 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
                 e = EXP_CANT_INTERPRET;
             }
             else if (!e)
-                error(loc, "variable %s is used before initialization", v->toChars());
+            {
+                assert(0);
+                assert(v->init && v->init->isVoidInitializer());
+                e = v->type->voidInitLiteral(v);
+            }
             else if (exceptionOrCantInterpret(e))
                 return e;
             else if (goal == ctfeNeedLvalue && v->isRef() && e->op == TOKindex)
@@ -1971,6 +2020,13 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
                     || e->op == TOKassocarrayliteral || e->op == TOKslice
                     || e->type->toBasetype()->ty == Tpointer)
                 return e; // it's already an Lvalue
+            else if (e->op == TOKvoid)
+            {
+                VoidInitExp *ve = (VoidInitExp *)e;
+                error(loc, "cannot read uninitialized variable %s in ctfe", v->toPrettyChars());
+                errorSupplemental(ve->var->loc, "%s was uninitialized and used before set", ve->var->toChars());
+                e = EXP_CANT_INTERPRET;
+            }
             else
                 e = e->interpret(istate, goal);
         }
@@ -2052,7 +2108,12 @@ Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
             if (ie)
                 e = ie->exp->interpret(istate);
             else if (v->init->isVoidInitializer())
-                e = NULL;
+            {
+                e = v->type->voidInitLiteral(v);
+                // There is no AssignExp for void initializers,
+                // so set it here.
+                v->setValue(e);
+            }
             else
             {
                 error("Declaration %s is not yet implemented in CTFE", toChars());
@@ -3151,7 +3212,7 @@ Expression *copyLiteral(Expression *e)
             assert(v);
             // If it is a void assignment, use the default initializer
             if (!m)
-                m = v->type->defaultInitLiteral(e->loc);
+                m = v->type->voidInitLiteral(v);
             if (m->op == TOKslice)
                 m = resolveSlice(m);
             if ((v->type->ty != m->type->ty) && v->type->ty == Tsarray)
@@ -3178,7 +3239,8 @@ Expression *copyLiteral(Expression *e)
             || e->op == TOKsymoff || e->op == TOKnull
             || e->op == TOKvar
             || e->op == TOKint64 || e->op == TOKfloat64
-            || e->op == TOKchar || e->op == TOKcomplex80)
+            || e->op == TOKchar || e->op == TOKcomplex80
+            || e->op == TOKvoid)
     {   // Simple value types
         Expression *r = e->syntaxCopy();
         r->type = e->type;
@@ -3348,7 +3410,7 @@ void assignInPlace(Expression *dest, Expression *src)
             assert(o->op == e->op);
             assignInPlace(o, e);
         }
-        else if (e->type->ty == Tsarray && o->type->ty == Tsarray)
+        else if (e->type->ty == Tsarray && o->type->ty == Tsarray && e->op != TOKvoid)
         {
             assignInPlace(o, e);
         }
@@ -3975,14 +4037,29 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             ? (StructLiteralExp *)exx
             : ((ClassReferenceExp *)exx)->value;
         int fieldi =  exx->op == TOKstructliteral
-            ? se->getFieldIndex(member->type, member->offset)
-            : ((ClassReferenceExp *)exx)->getFieldIndex(member->type, member->offset);
+            ? findFieldIndexByName(se->sd, member)
+            : ((ClassReferenceExp *)exx)->findFieldIndexByName(member);
         if (fieldi == -1)
         {
             error("CTFE internal error: cannot find field %s in %s", member->toChars(), exx->toChars());
             return EXP_CANT_INTERPRET;
         }
-        assert(fieldi>=0 && fieldi < se->elements->dim);
+        assert(fieldi >= 0 && fieldi < se->elements->dim);
+        // If it's a union, set all other members of this union to void
+        if (exx->op == TOKstructliteral)
+        {
+            assert(se->sd);
+            int unionStart = se->sd->firstFieldInUnion(fieldi);
+            int unionSize = se->sd->numFieldsInUnion(fieldi);
+            for(int i = unionStart; i < unionStart + unionSize; ++i)
+            {   if (i == fieldi)
+                    continue;
+                Expression **el = &se->elements->tdata()[i];
+                if ((*el)->op != TOKvoid)
+                    *el = (*el)->type->voidInitLiteral(member);
+            }
+        }
+
         if (newval->op == TOKstructliteral)
             assignInPlace(se->elements->tdata()[fieldi], newval);
         else
@@ -5815,6 +5892,13 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
             if (e->op == TOKstructliteral || e->op == TOKarrayliteral ||
                 e->op == TOKassocarrayliteral || e->op == TOKstring)
                     return e;
+            if (e->op == TOKvoid)
+            {
+                VoidInitExp *ve = (VoidInitExp *)e;
+                error("cannot read uninitialized variable %s in ctfe", toChars());
+                ve->var->error("was uninitialized and used before set");
+                return EXP_CANT_INTERPRET;
+            }
             if ( isPointer(type) )
             {
                 return paintTypeOntoLiteral(type, e);
@@ -6493,6 +6577,10 @@ bool isCtfeValueValid(Expression *newval)
             assert(((ArrayLiteralExp *)se->e1)->ownedByCtfe);
         return true;
     }
+    if (newval->op == TOKvoid)
+    {
+        return true;
+    }
     newval->error("CTFE internal error: illegal value %s\n", newval->toChars());
     return false;
 }
@@ -6524,4 +6612,29 @@ void VarDeclaration::setValue(Expression *newval)
 {
     assert(isCtfeValueValid(newval));
     ctfeStack.setValue(this, newval);
+}
+
+
+Expression *Type::voidInitLiteral(VarDeclaration *var)
+{
+    return new VoidInitExp(var, this);
+}
+
+Expression *TypeSArray::voidInitLiteral(VarDeclaration *var)
+{
+    return createBlockDuplicatedArrayLiteral(var->loc, this, next->voidInitLiteral(var), dim->toInteger());
+}
+
+Expression *TypeStruct::voidInitLiteral(VarDeclaration *var)
+{
+    Expressions *exps = new Expressions();
+    exps->setDim(sym->fields.dim);
+    for (size_t i = 0; i < sym->fields.dim; i++)
+    {
+        (*exps)[i] = new VoidInitExp(var, sym->fields[i]->type);
+    }
+    StructLiteralExp *se = new StructLiteralExp(var->loc, sym, exps);
+    se->type = this;
+    se->ownedByCtfe = true;
+    return se;
 }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1973,7 +1973,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
                 if (v->init->isVoidInitializer())
                 {
                     // var should have been initialized when it was created
-                    error("CTFE internal error - trying to access uninitialized var");
+                    error(loc, "CTFE internal error - trying to access uninitialized var");
                     assert(0);
                     e = EXP_CANT_INTERPRET;
                 }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -302,6 +302,7 @@ struct Type : Object
     virtual unsigned memalign(unsigned salign);
     virtual Expression *defaultInit(Loc loc = 0);
     virtual Expression *defaultInitLiteral(Loc loc);
+    virtual Expression *voidInitLiteral(VarDeclaration *var);
     virtual int isZeroInit(Loc loc = 0);                // if initializer is 0
     virtual dt_t **toDt(dt_t **pdt);
     Identifier *getTypeInfoIdent(int internal);
@@ -460,6 +461,7 @@ struct TypeSArray : TypeArray
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
+    Expression *voidInitLiteral(VarDeclaration *var);
     dt_t **toDt(dt_t **pdt);
     dt_t **toDtElem(dt_t **pdt, Expression *e);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wildmatch = NULL);
@@ -758,6 +760,7 @@ struct TypeStruct : Type
     unsigned memalign(unsigned salign);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
+    Expression *voidInitLiteral(VarDeclaration *var);
     int isZeroInit(Loc loc);
     int isAssignable();
     int checkBoolean();

--- a/src/parse.c
+++ b/src/parse.c
@@ -6589,6 +6589,7 @@ void initPrecedence()
     precedence[TOKtraits] = PREC_primary;
     precedence[TOKdefault] = PREC_primary;
     precedence[TOKoverloadset] = PREC_primary;
+    precedence[TOKvoid] = PREC_primary;
 #endif
 
     // post

--- a/src/todt.c
+++ b/src/todt.c
@@ -108,7 +108,9 @@ dt_t *StructInitializer::toDt()
         {   // An instance specific initializer was not provided.
             // Look to see if there's a default initializer from the
             // struct definition
-            if (v->init)
+            if (v->init && v->init->isVoidInitializer())
+                ;
+            else if (v->init)
             {
                 d = v->init->toDt();
             }
@@ -646,6 +648,17 @@ dt_t **StructLiteralExp::toDt(dt_t **pdt)
              * If there is no overlap with any explicit initializer in dts[],
              * supply a default initializer.
              */
+#if 0
+           // An instance specific initializer was not provided.
+            // Look to see if there's a default initializer from the
+            // struct definition
+            if (v->init && v->init->isVoidInitializer())
+                ;
+            else if (v->init)
+            {
+                d = v->init->toDt();
+            } else
+#endif
             if (v->offset >= offset)
             {
                 unsigned offset2 = v->offset + v->type->size();
@@ -838,7 +851,9 @@ void ClassDeclaration::toDt2(dt_t **pdt, ClassDeclaration *cd)
         {   //printf("\t\t%s has initializer %s\n", v->toChars(), init->toChars());
             ExpInitializer *ei = init->isExpInitializer();
             Type *tb = v->type->toBasetype();
-            if (ei && tb->ty == Tsarray)
+            if (init->isVoidInitializer())
+                ;
+            else if (ei && tb->ty == Tsarray)
                 ((TypeSArray *)tb)->toDtElem(&dt, ei->exp);
             else
                 dt = init->toDt();
@@ -924,7 +939,9 @@ void StructDeclaration::toDt(dt_t **pdt)
             {   //printf("\t\thas initializer %s\n", init->toChars());
                 ExpInitializer *ei = init->isExpInitializer();
                 Type *tb = v->type->toBasetype();
-                if (ei && tb->ty == Tsarray)
+                if (init->isVoidInitializer())
+                    ;
+                else if (ei && tb->ty == Tsarray)
                     ((TypeSArray *)tb)->toDtElem(&dt, ei->exp);
                 else
                     dt = init->toDt();

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4118,3 +4118,46 @@ void vop() {
     const string x7536 = "x";
     static assert(bug7536(x7536));
 }
+
+/**************************************************
+    6681 unions
+**************************************************/
+
+struct S6681
+{
+    this(int a, int b) { this.a = b; this.b = a; }
+    union {
+        ulong g;
+        struct {int a, b; };
+    }
+}
+
+static immutable S6681 s6681 = S6681(0, 1);
+
+bool bug6681(int test)
+{
+    S6681 x = S6681(0, 1);
+    x.g = 5;
+    auto u = &x.g;
+    auto v = &x.a;
+    long w = *u;
+    int  z;
+    assert(w == 5);
+    if (test == 4)
+        z = *v; // error
+    x.a = 2; // invalidate g, and hence u.
+    if (test == 1)
+        w = *u; // error
+    z = *v;
+    assert(z == 2);
+    x.g = 6;
+    w = *u;
+    assert( w == 6);
+    if (test == 3)
+        z = *v;
+    return true;
+}
+static assert(bug6681(2));
+static assert(!is(typeof(compiles!(bug6681(1)))));
+static assert(!is(typeof(compiles!(bug6681(3)))));
+static assert(!is(typeof(compiles!(bug6681(4)))));


### PR DESCRIPTION
...that breaks union initialization

Add VoidExp to explicitly specify uninitialized variables. When a union member is written to,
set all other members of that union to VoidExp.

90% of this commit was written by yebblies.

There are some hard cases which this doesn't fix, but it fixes all of the regressions.
Please don't merge this until it has passed on the pull autotester.
