### PR TITLE
fix issue 7698

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3883,6 +3883,7 @@ void TemplateValueParameter::semantic(Scope *sc)
             error(loc, "arithmetic/string type expected for value-parameter, not %s", valType->toChars());
     }
 
+#if 0   // defer semantic analysis to arg match
     if (specValue)
     {   Expression *e = specValue;
 
@@ -3895,7 +3896,6 @@ void TemplateValueParameter::semantic(Scope *sc)
         //e->toInteger();
     }
 
-#if 0   // defer semantic analysis to arg match
     if (defaultValue)
     {   Expression *e = defaultValue;
 
@@ -3990,7 +3990,7 @@ MATCH TemplateValueParameter::matchArg(Scope *sc,
         Expression *e = specValue;
 
         e = e->semantic(sc);
-        e = e->implicitCastTo(sc, valType);
+        e = e->implicitCastTo(sc, vt);
         e = e->optimize(WANTvalue | WANTinterpret);
 
         ei = ei->syntaxCopy();

--- a/test/runnable/template4.d
+++ b/test/runnable/template4.d
@@ -1061,6 +1061,30 @@ void test6701()
     assert(foo2_6701!(0u, "+")() == 1);
 }
 
+/******************************************/
+
+template foo7698a(T, T val : 0)
+{
+    enum foo7698a = val;
+}
+
+T foo7698b(T, T val : 0)()
+{
+    return val;
+}
+
+T foo7698c(T, T val : T.init)()
+{
+    return val;
+}
+
+void test7698()
+{
+    static assert(foo7698a!(int, 0) == 0);
+    assert(foo7698b!(int, 0)() == 0);
+    assert(foo7698c!(int, 0)() == 0);
+}
+
 /*********************************************************/
 
 int main()
@@ -1105,6 +1129,7 @@ int main()
     test38();
     test39();
     test6701();
+    test7698();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
- defer semantic of the spec value until matchArg
  so that parameterized types can be resolved
- specValue needs to be implictly converted to vt
  which is the resolved valType
