### PR TITLE
Issue 7702 & 5733 - opDispatch goes into infinite loop

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6875,8 +6875,8 @@ Expression *DotTemplateInstanceExp::semantic(Scope *sc)
 #endif
     Expression *eleft;
     Expression *e = new DotIdExp(loc, e1, ti->name);
-L1:
     e = e->semantic(sc);
+L1:
     if (e->op == TOKerror)
         return e;
     if (e->op == TOKdottd)
@@ -6962,6 +6962,9 @@ L1:
         else
             goto Lerr;
 
+        e = e->semantic(sc);
+        if (e == de)
+            goto Lerr;
         goto L1;
     }
 Lerr:

--- a/src/expression.c
+++ b/src/expression.c
@@ -6244,12 +6244,6 @@ DotIdExp::DotIdExp(Loc loc, Expression *e, Identifier *ident)
 }
 
 Expression *DotIdExp::semantic(Scope *sc)
-{
-    // Indicate we didn't come from CallExp::semantic()
-    return semantic(sc, 0);
-}
-
-Expression *DotIdExp::semantic(Scope *sc, int flag)
 {   Expression *e;
     Expression *eleft;
     Expression *eright;
@@ -6588,8 +6582,7 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
     else
     {
         e = e1->type->dotExp(sc, e1, ident);
-        if (!(flag && e->op == TOKdotti))       // let CallExp::semantic() handle this
-            e = e->semantic(sc);
+        e = e->semantic(sc);
         return e;
     }
 }
@@ -7395,7 +7388,7 @@ Lagain:
     {
         if (e1->op == TOKdot)
         {   DotIdExp *die = (DotIdExp *)e1;
-            e1 = die->semantic(sc, 1);
+            e1 = die->semantic(sc);
             /* Look for e1 having been rewritten to expr.opDispatch!(string)
              * We handle such earlier, so go back.
              * Note that in the rewrite, we carefully did not run semantic() on e1

--- a/src/expression.c
+++ b/src/expression.c
@@ -6959,8 +6959,12 @@ L1:
         {   TemplateExp *te = (TemplateExp *) de->e2;
             e = new DotTemplateExp(loc,de->e1,te->td);
         }
+        else
+            goto Lerr;
+
         goto L1;
     }
+Lerr:
     error("%s isn't a template", e->toChars());
     return new ErrorExp();
 }

--- a/src/expression.h
+++ b/src/expression.h
@@ -862,7 +862,6 @@ struct DotIdExp : UnaExp
 
     DotIdExp(Loc loc, Expression *e, Identifier *ident);
     Expression *semantic(Scope *sc);
-    Expression *semantic(Scope *sc, int flag);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void dump(int i);
 };

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2084,7 +2084,6 @@ Expression *Type::noMember(Scope *sc, Expression *e, Identifier *ident)
             tiargs->push(se);
             e = new DotTemplateInstanceExp(e->loc, e, Id::opDispatch, tiargs);
             ((DotTemplateInstanceExp *)e)->ti->tempdecl = td;
-            //return e;
             e = e->semantic(sc);
             return e;
         }

--- a/test/fail_compilation/fail5733.d
+++ b/test/fail_compilation/fail5733.d
@@ -1,0 +1,6 @@
+struct Test
+{
+    struct opDispatch(string dummy)
+    { enum opDispatch = 1; }
+}
+auto temp = Test().foo!(int);

--- a/test/fail_compilation/fail7702.d
+++ b/test/fail_compilation/fail7702.d
@@ -1,0 +1,9 @@
+struct S
+{
+   template opDispatch (string name) {}
+}
+void main()
+{
+    S s;
+    s.x!int;
+}


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5733">Issue 5733</a> - Calling opDispatch As Template Results in Compiler Infinite Loop
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7702">Issue 7702</a> - opDispatch goes into infinite loop
