### PR TITLE
compiler segfaults if source file can't be read

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -1208,6 +1208,7 @@ int tryMain(int argc, char *argv[])
         if (aw->read(filei))
         {
             error(0, "cannot read file %s", m->srcfile->name->toChars());
+            fatal();
         }
 #endif
         m->parse();


### PR DESCRIPTION
- regression from #742 as error(Loc loc,) does no longer abort
