### PR TITLE
Fix issue 6438 - [CTFE] wrong error "value used before set" with = void

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2047,6 +2047,8 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
             e = e->semantic(NULL);
             if (e->op == TOKerror)
                 e = EXP_CANT_INTERPRET;
+            else // Convert NULL to VoidExp
+                e = e->interpret(istate, goal);
         }
         else
             error(loc, "cannot interpret symbol %s at compile time", v->toChars());
@@ -5206,6 +5208,12 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
         return e;
     if (goal == ctfeNeedRvalue && (e->op == TOKslice || e->op == TOKdotvar))
         e = e->interpret(istate);
+    if (goal == ctfeNeedRvalue && e->op == TOKvoid)
+    {
+        error("%s is used before initialized", toChars());
+        errorSupplemental(e->loc, "originally uninitialized here");
+        return EXP_CANT_INTERPRET;
+    }
     e = paintTypeOntoLiteral(type, e);
     return e;
 }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4186,3 +4186,42 @@ static assert(bug6681(2));
 static assert(!is(typeof(compiles!(bug6681(1)))));
 static assert(!is(typeof(compiles!(bug6681(3)))));
 static assert(!is(typeof(compiles!(bug6681(4)))));
+
+/**************************************************
+    6438 void
+**************************************************/
+
+struct S6438
+{
+    int a;
+    int b = void;
+}
+
+void fill6438(int[] arr, int testnum)
+{
+    if (testnum == 2)
+    {
+        auto u = arr[0];
+    }
+    foreach(ref x; arr)
+        x = 7;
+    auto r = arr[0];
+    S6438[2] s;
+    auto p = &s[0].b;
+    if (testnum == 3)
+    {
+        auto v = *p;
+    }
+}
+
+bool bug6438(int testnum)
+{
+    int[4] stackSpace = void;
+    fill6438(stackSpace[], testnum);
+    assert(stackSpace == [7,7,7,7]);
+    return true;
+}
+
+static assert( is(typeof(compiles!(bug6438(1)))));
+static assert(!is(typeof(compiles!(bug6438(2)))));
+static assert(!is(typeof(compiles!(bug6438(3)))));


### PR DESCRIPTION
Take advantage of the newly introduced VoidExp.
This also fixes a potential segfault.
