### PR TITLE
Issue 7722 - Refuse normal functions to be used as properties

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -302,6 +302,34 @@ return_expr:
 }
 
 /******************************
+ * Check the tail CallExp is really property function call.
+ */
+
+void checkPropertyCall(Expression *e, Expression *emsg)
+{
+    while (e->op == TOKcomma)
+        e = ((CommaExp *)e)->e2;
+
+    if (e->op == TOKcall)
+    {   CallExp *ce = (CallExp *)e;
+        TypeFunction *tf;
+        if (ce->f)
+            tf = (TypeFunction *)ce->f->type;
+        else if (ce->e1->type->ty == Tfunction)
+            tf = (TypeFunction *)ce->e1->type;
+        else if (ce->e1->type->ty == Tdelegate)
+            tf = (TypeFunction *)ce->e1->type->nextOf();
+        else if (ce->e1->type->ty == Tpointer && ce->e1->type->nextOf()->ty == Tfunction)
+            tf = (TypeFunction *)ce->e1->type->nextOf();
+        else
+            assert(0);
+
+        if (!tf->isproperty && global.params.enforcePropertySyntax)
+            ce->e1->error("not a property %s", (emsg ? emsg : ce)->toChars());
+    }
+}
+
+/******************************
  * Perform semantic() on an array of Expressions.
  */
 
@@ -6567,6 +6595,8 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
             e1->type = t1;              // kludge to restore type
             e = new DotIdExp(loc, new IdentifierExp(loc, Id::empty), ident);
             e = new CallExp(loc, e, e1);
+            e = e->semantic(sc);
+            checkPropertyCall(e, this);
         }
         e = e->semantic(sc);
         return e;
@@ -6889,6 +6919,7 @@ Expression *DotTemplateInstanceExp::semantic(Scope *sc, int flag)
                             ti->name, ti->tiargs);
             e = new CallExp(loc, e, e1);
             e = e->semantic(sc);
+            checkPropertyCall(e, this);
             e = resolveProperties(sc, e);
             return e;
         }
@@ -9874,7 +9905,9 @@ Expression *AssignExp::semantic(Scope *sc)
                 e = new CallExp(loc, e, arguments);
                 e = e->trySemantic(sc);
                 if (e)
+                {   checkPropertyCall(e, dti);
                     return e;
+                }
 
                 e = new CallExp(loc, ex, dti->e1);
                 e = e->trySemantic(sc);
@@ -9882,6 +9915,7 @@ Expression *AssignExp::semantic(Scope *sc)
                 {   error("not a property");
                     return new ErrorExp();
                 }
+                checkPropertyCall(e, dti);
                 e1 = e;
             }
         }
@@ -9909,7 +9943,9 @@ Expression *AssignExp::semantic(Scope *sc)
                 e = new CallExp(loc, e, arguments);
                 e = e->trySemantic(sc);
                 if (e)
+                {   checkPropertyCall(e, die);
                     return e;
+                }
 
                 e = new CallExp(loc, ex, die->e1);
                 e = e->trySemantic(sc);
@@ -9917,6 +9953,7 @@ Expression *AssignExp::semantic(Scope *sc)
                 {   error("not a property");
                     return new ErrorExp();
                 }
+                checkPropertyCall(e, die);
                 e1 = e;
             }
         }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5589,8 +5589,8 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
         return terror;
     }
 
-    if (tf->isproperty && (tf->varargs || Parameter::dim(tf->parameters) > 1))
-        error(loc, "properties can only have zero or one parameter");
+    if (tf->isproperty && (tf->varargs || Parameter::dim(tf->parameters) > 2))
+        error(loc, "properties can only have zero, one, or two parameter");
 
     if (tf->varargs == 1 && tf->linkage != LINKd && Parameter::dim(tf->parameters) == 0)
         error(loc, "variadic functions with non-D linkage must have at least one parameter");

--- a/test/fail_compilation/fail334.d
+++ b/test/fail_compilation/fail334.d
@@ -1,7 +1,7 @@
 
 struct S
 {
-    @property int foo(int a, int b) { return 1; }
+    @property int foo(int a, int b, int c) { return 1; }
 }
 
 void main()

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -8,6 +8,8 @@ enum enforceProperty = !__traits(compiles, {
     int n = prop;
 });
 
+/*******************************************/
+
 template select(alias v1, alias v2)
 {
     static if (enforceProperty)
@@ -106,7 +108,7 @@ template iota(int begin, int end)
         alias seq!(begin, iota!(begin+1, end)) iota;
 }
 
-void main()
+void test1()
 {
     foreach (N; iota!(0, 8))
     {
@@ -128,4 +130,156 @@ void main()
             assert(s.getset == Test!N.result);
         }
     }
+}
+
+/*******************************************/
+// 7722
+
+class Foo7722 {}
+void spam7722(Foo7722 f) {}
+
+void test7722()
+{
+    auto f = new Foo7722;
+    static if (enforceProperty)
+        static assert(!__traits(compiles, f.spam7722));
+    else
+        f.spam7722;
+}
+
+/*******************************************/
+
+@property void check(alias v1, alias v2, alias dg)()
+{
+    void checkImpl(alias v)()
+    {
+        static if (v == 0)
+            static assert(!__traits(compiles, dg(0)));
+        else
+            assert(dg(0) == v);
+    }
+
+    static if (enforceProperty)
+        checkImpl!(v1)();
+    else
+        checkImpl!(v2)();
+}
+
+struct S {}
+
+int foo(int n)          { return 1; }
+int foo(int n, int m)   { return 2; }
+int goo(int[] a)        { return 1; }
+int goo(int[] a, int m) { return 2; }
+int bar(S s)            { return 1; }
+int bar(S s, int n)     { return 2; }
+
+int baz(X)(X x)         { return 1; }
+int baz(X)(X x, int n)  { return 2; }
+
+int temp;
+ref int boo(int n)      { return temp; }
+ref int coo(int[] a)    { return temp; }
+ref int mar(S s)        { return temp; }
+
+ref int maz(X)(X x)     { return temp; }
+
+void test7722a()
+{
+    int n;
+    int[] a;
+    S s;
+
+    check!(1, 1, x =>    foo(4)     );      check!(1, 1, x =>    baz(4)     );
+    check!(1, 1, x =>  4.foo()      );      check!(1, 1, x =>  4.baz()      );
+    check!(0, 1, x =>  4.foo        );      check!(0, 1, x =>  4.baz        );
+    check!(2, 2, x =>    foo(4, 2)  );      check!(2, 2, x =>    baz(4, 2)  );
+    check!(2, 2, x =>  4.foo(2)     );      check!(2, 2, x =>  4.baz(2)     );
+    check!(0, 2, x => (4.foo = 2)   );      check!(0, 2, x => (4.baz = 2)   );
+
+    check!(1, 1, x =>    goo(a)     );      check!(1, 1, x =>    baz(a)     );
+    check!(1, 1, x =>  a.goo()      );      check!(1, 1, x =>  a.baz()      );
+    check!(0, 1, x =>  a.goo        );      check!(0, 1, x =>  a.baz        );
+    check!(2, 2, x =>    goo(a, 2)  );      check!(2, 2, x =>    baz(a, 2)  );
+    check!(2, 2, x =>  a.goo(2)     );      check!(2, 2, x =>  a.baz(2)     );
+    check!(0, 2, x => (a.goo = 2)   );      check!(0, 2, x => (a.baz = 2)   );
+
+    check!(1, 1, x =>    bar(s)     );      check!(1, 1, x =>    baz(s)     );
+    check!(1, 1, x =>  s.bar()      );      check!(1, 1, x =>  s.baz()      );
+    check!(0, 1, x =>  s.bar        );      check!(0, 1, x =>  s.baz        );
+    check!(2, 2, x =>    bar(s, 2)  );      check!(2, 2, x =>    baz(s, 2)  );
+    check!(2, 2, x =>  s.bar(2)     );      check!(2, 2, x =>  s.baz(2)     );
+    check!(0, 2, x => (s.bar = 2)   );      check!(0, 2, x => (s.baz = 2)   );
+
+    check!(2, 2, x => (  boo(4) = 2));      check!(2, 2, x => (  maz(4) = 2));
+    check!(0, 2, x => (4.boo    = 2));      check!(0, 2, x => (4.maz    = 2));
+    check!(2, 2, x => (  coo(a) = 2));      check!(2, 2, x => (  maz(a) = 2));
+    check!(0, 2, x => (a.coo    = 2));      check!(0, 2, x => (a.maz    = 2));
+    check!(2, 2, x => (  mar(s) = 2));      check!(2, 2, x => (  maz(s) = 2));
+    check!(0, 2, x => (s.mar    = 2));      check!(0, 2, x => (s.maz    = 2));
+}
+
+int hoo(T)(int n)          { return 1; }
+int hoo(T)(int n, int m)   { return 2; }
+int koo(T)(int[] a)        { return 1; }
+int koo(T)(int[] a, int m) { return 2; }
+int var(T)(S s)            { return 1; }
+int var(T)(S s, int n)     { return 2; }
+
+int vaz(T, X)(X x)         { return 1; }
+int vaz(T, X)(X x, int n)  { return 2; }
+
+//int temp;
+ref int voo(T)(int n)      { return temp; }
+ref int woo(T)(int[] a)    { return temp; }
+ref int nar(T)(S s)        { return temp; }
+
+ref int naz(T, X)(X x)     { return temp; }
+
+void test7722b()
+{
+    int n;
+    int[] a;
+    S s;
+
+    check!(1, 1, x =>    hoo!int(4)     );  check!(1, 1, x =>    vaz!int(4)     );
+    check!(1, 1, x =>  4.hoo!int()      );  check!(1, 1, x =>  4.vaz!int()      );
+    check!(0, 1, x =>  4.hoo!int        );  check!(0, 1, x =>  4.vaz!int        );
+    check!(2, 2, x =>    hoo!int(4, 2)  );  check!(2, 2, x =>    vaz!int(4, 2)  );
+    check!(2, 2, x =>  4.hoo!int(2)     );  check!(2, 2, x =>  4.vaz!int(2)     );
+    check!(0, 2, x => (4.hoo!int = 2)   );  check!(0, 2, x => (4.vaz!int = 2)   );
+
+    check!(1, 1, x =>    koo!int(a)     );  check!(1, 1, x =>    vaz!int(a)     );
+    check!(1, 1, x =>  a.koo!int()      );  check!(1, 1, x =>  a.vaz!int()      );
+    check!(0, 1, x =>  a.koo!int        );  check!(0, 1, x =>  a.vaz!int        );
+    check!(2, 2, x =>    koo!int(a, 2)  );  check!(2, 2, x =>    vaz!int(a, 2)  );
+    check!(2, 2, x =>  a.koo!int(2)     );  check!(2, 2, x =>  a.vaz!int(2)     );
+    check!(0, 2, x => (a.koo!int = 2)   );  check!(0, 2, x => (a.vaz!int = 2)   );
+
+    check!(1, 1, x =>    var!int(s)     );  check!(1, 1, x =>    vaz!int(s)     );
+    check!(1, 1, x =>  s.var!int()      );  check!(1, 1, x =>  s.vaz!int()      );
+    check!(0, 1, x =>  s.var!int        );  check!(0, 1, x =>  s.vaz!int        );
+    check!(2, 2, x =>    var!int(s, 2)  );  check!(2, 2, x =>    vaz!int(s, 2)  );
+    check!(2, 2, x =>  s.var!int(2)     );  check!(2, 2, x =>  s.vaz!int(2)     );
+    check!(0, 2, x => (s.var!int = 2)   );  check!(0, 2, x => (s.vaz!int = 2)   );
+
+    check!(2, 2, x => (  voo!int(4) = 2));  check!(2, 2, x => (  naz!int(4) = 2));
+    check!(0, 2, x => (4.voo!int    = 2));  check!(0, 2, x => (4.naz!int    = 2));
+    check!(2, 2, x => (  woo!int(a) = 2));  check!(2, 2, x => (  naz!int(a) = 2));
+    check!(0, 2, x => (a.woo!int    = 2));  check!(0, 2, x => (a.naz!int    = 2));
+    check!(2, 2, x => (  nar!int(s) = 2));  check!(2, 2, x => (  naz!int(s) = 2));
+    check!(0, 2, x => (s.nar!int    = 2));  check!(0, 2, x => (s.naz!int    = 2));
+}
+
+/*******************************************/
+
+int main()
+{
+    test1();
+    test7722();
+    test7722a();
+    test7722b();
+
+    printf("Success\n");
+    return 0;
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7722

Enforce @property syntax for UFCS by -property switch.
