### PR TITLE
Make DMD 1.x compile again

### DIFF
--- a/src/lib.h
+++ b/src/lib.h
@@ -49,7 +49,7 @@ struct Library
     int FillDict(unsigned char *bucketsP, unsigned short uNumPages);
     void WriteLibToBuffer(OutBuffer *libbuf);
 
-    void error(char *format, ...)
+    void error(const char *format, ...)
     {
         Loc loc;
         if (libfile)

--- a/src/util.c
+++ b/src/util.c
@@ -50,7 +50,7 @@ void file_progress()
  * Alternative assert failure.
  */
 
-void util_assert(char *file,int line)
+void util_assert(const char *file,int line)
 {
     fflush(stdout);
     printf("Internal error: %s %d\n",file,line);


### PR DESCRIPTION
Right now the compiler can't be linked because util_assert() is reported
to be missing, because the users of this function are using a different
signature. This pull request also fixes a warning about string literals.
