### PR TITLE
Bug 176. Error message "module and package have the same name"

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -93,7 +93,16 @@ void Import::load(Scope *sc)
 
     // See if existing module
     DsymbolTable *dst = Package::resolve(packages, NULL, &pkg);
-
+#if TARGET_NET  //dot net needs modules and packages with same name
+#else
+    if (pkg && pkg->isModule())
+    {
+        ::error(loc, "can only import from a module, not from a member of module %s. Did you mean `import %s : %s`?",
+             pkg->toChars(), pkg->toChars(), id->toChars());
+        mod = pkg->isModule(); // Error recovery - treat as import of that module
+        return;
+    }
+#endif
     Dsymbol *s = dst->lookup(id);
     if (s)
     {
@@ -103,7 +112,8 @@ void Import::load(Scope *sc)
         if (s->isModule())
             mod = (Module *)s;
         else
-            error("package and module have the same name");
+            ::error(loc, "can only import from a module, not from package %s.%s",
+                pkg->toChars(), id->toChars());
 #endif
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -1171,14 +1171,10 @@ DsymbolTable *Package::resolve(Identifiers *packages, Dsymbol **pparent, Package
             else
             {
                 assert(p->isPackage());
-#if TARGET_NET  //dot net needs modules and packages with same name
-#else
-                if (p->isModule())
-                {   p->error("module and package have the same name");
-                    fatal();
-                    break;
-                }
-#endif
+                // It might already be a module, not a package, but that needs
+                // to be checked at a higher level, where a nice error message
+                // can be generated.
+                // dot net needs modules and packages with same name
             }
             parent = p;
             dst = ((Package *)p)->symtab;


### PR DESCRIPTION
Generate a comprehensible error at a higher level (at the import statement).
One of the stupidest error messages in D, and the third oldest bug,
