### PR TITLE
Fix issue 7745 Regression(2.059beta) Methods defined in external object ...

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3422,9 +3422,17 @@ elem *DelegateExp::toElem(IRState *irs)
 
     //printf("DelegateExp::toElem() '%s'\n", toChars());
 
-    if (func->semanticRun == PASSsemantic3done)
-    {
-        irs->deferToObj->push(func);
+     if (func->semanticRun == PASSsemantic3done)
+     {  // Bug 7745 - only include the function if it belongs to this module
+        // ie, it is a member of this module, or is a template instance
+        // (the template declaration could come from any module).
+        Dsymbol * owner = func->toParent();
+        while (!owner->isTemplateInstance() && owner->toParent())
+            owner = owner->toParent();
+        if (owner->isTemplateInstance() || owner ==  irs->m )
+        {
+            irs->deferToObj->push(func);
+        }
     }
 
     sfunc = func->toSymbol();

--- a/test/runnable/imports/link7745b.d
+++ b/test/runnable/imports/link7745b.d
@@ -1,0 +1,6 @@
+struct C { auto asdfg() {} }
+
+// extreme test of bug 4820
+void nextis(W)(void delegate() dg = {}) {}
+
+

--- a/test/runnable/link7745.d
+++ b/test/runnable/link7745.d
@@ -1,0 +1,20 @@
+// COMPILE_SEPARATELY
+// EXTRA_SOURCES: imports/link7745b.d
+// PERMUTE_ARGS:
+
+import imports.link7745b;
+
+bool forceSemantic7745()
+{
+   C c;
+   c.asdfg();
+  return true;
+}
+static assert(forceSemantic7745());
+
+void f(C c) { auto x = &c.asdfg; }
+
+void main() {
+    // extra test for bug 4820
+    nextis!(int)();
+}


### PR DESCRIPTION
...files when a pointer to it is taken

This regression was caused by the fix to regression 4820. As well as the test for this bug, I added a nasty test case of bug 4820 to the test suite, since they are closely related.
I'm not sure if the question of which object file should own the function belongs here. Perhaps it should be in func::toObjFile.

[Not completely tested, wait until this passes the pull tester],
