### PR TITLE
fix Issue 6659 - Destructor in range foreach called after initialization

### DIFF
--- a/src/statement.h
+++ b/src/statement.h
@@ -318,9 +318,11 @@ struct ForStatement : Statement
     Expression *condition;
     Expression *increment;
     Statement *body;
+    int nest;
 
     ForStatement(Loc loc, Statement *init, Expression *condition, Expression *increment, Statement *body);
     Statement *syntaxCopy();
+    Statement *semanticInit(Scope *sc);
     Statement *semantic(Scope *sc);
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
     int hasBreak();

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -270,6 +270,95 @@ void test7406()
 }
 
 /***************************************/
+// 6659
+
+void test6659()
+{
+    static struct Iter
+    {
+        ~this()
+        {
+            ++_dtor;
+        }
+
+        bool opCmp(ref const Iter rhs) { return _pos == rhs._pos; }
+        void opUnary(string op:"++")() { ++_pos; }
+        size_t _pos;
+
+        static size_t _dtor;
+    }
+
+    foreach (ref iter; Iter(0) .. Iter(10))
+    {
+        assert(Iter._dtor == 0);
+    }
+    assert(Iter._dtor == 2);
+
+    Iter._dtor = 0; // reset
+
+    for (auto iter = Iter(0), limit = Iter(10); iter != limit; ++iter)
+    {
+        assert(Iter._dtor == 0);
+    }
+    assert(Iter._dtor == 2);
+}
+
+void test6659a()
+{
+    auto value = 0;
+    try
+    {
+        for ({scope(success) { assert(value == 1); value = 2;} }  true; )
+        {
+            value = 1;
+            break;
+        }
+        assert(value == 2);
+    }
+    catch (Exception e)
+    {
+        assert(0);
+    }
+    assert(value == 2);
+}
+
+void test6659b()
+{
+    auto value = 0;
+    try
+    {
+        for ({scope(failure) value = 1;}  true; )
+        {
+            throw new Exception("");
+        }
+        assert(0);
+    }
+    catch (Exception e)
+    {
+        assert(e);
+    }
+    assert(value == 1);
+}
+
+void test6659c()
+{
+    auto value = 0;
+    try
+    {
+        for ({scope(exit) value = 1;}  true; )
+        {
+            throw new Exception("");
+        }
+        assert(0);
+    }
+    catch (Exception e)
+    {
+        assert(e);
+    }
+    assert(value == 1);
+}
+
+/***************************************/
 
 int main()
 {
@@ -281,6 +370,10 @@ int main()
     test5605();
     test7004();
     test7406();
+    test6659();
+    test6659a();
+    test6659b();
+    test6659c();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6659

If for statement has two or more declarations in its Intiliaze part, we should handle their destructors correctly.
This pull transform such for statement like follows.

``` d
for (auto x=X(a), y = Y(b); ...; ...) {}
```

to:

``` d
try {
  try {
    for (auto x=((x=X.init).this(a)), auto y=((y=Y.init)).this(b)); ...; ...) {}
  } finally {
    y.~this();
  }
} finally {
  x.~this();
}
```

The way is basically same as in `CompoundStatement::semantic`.
