### PR TITLE
Issue 7694 - Internal error: e2ir.c 1251 when calling member function inside struct via alias param

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -5255,6 +5255,11 @@ int TemplateInstance::hasNestedArgs(Objects *args)
                 sa = ((VarExp *)ea)->var;
                 goto Lsa;
             }
+            if (ea->op == TOKthis)
+            {
+                sa = ((ThisExp *)ea)->var;
+                goto Lsa;
+            }
             if (ea->op == TOKfunction)
             {
                 sa = ((FuncExp *)ea)->fd;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1061,6 +1061,27 @@ void test7684()
 }
 
 /**********************************/
+// 7694
+
+void match7694(alias m)()
+{
+    m.foo();    //removing this line supresses ice in both cases
+}
+
+struct T7694
+{
+    void foo(){}
+    void bootstrap()
+    {
+    //next line causes ice
+        match7694!(this)();
+    //while this works:
+        alias this p;
+        match7694!(p)();
+    }
+}
+
+/**********************************/
 // 7755
 
 template to7755(T)


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7694
