### PR TITLE
TYdarray is dwarf-typed as ucent

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1621,9 +1621,12 @@ unsigned dwarf_typidx(type *t)
 
     tym_t ty;
     ty = tybasic(t->Tty);
-    idx = typidx_tab[ty];
-    if (idx)
-        return idx;
+    if (!(t->Tnext && (ty == TYucent || ty == TYcent)))
+    {   // use cached basic type if it's not TYdarray or TYdelegate
+        idx = typidx_tab[ty];
+        if (idx)
+            return idx;
+    }
 
     unsigned char ate;
     ate = tyuns(t->Tty) ? DW_ATE_unsigned : DW_ATE_signed;


### PR DESCRIPTION
- detect false usage of cached ucent type
  for TYdarray
- the ucent entry is added by fake_type(TYdarray)
  for auto variables
