### PR TITLE
Fix issue 7794 Sea of errors when calling regex() after compile error

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2913,7 +2913,7 @@ Lagain:
     }
 
     TemplateInstance *ti = s->isTemplateInstance();
-    if (ti && !global.errors)
+    if (ti)
     {   if (!ti->semanticRun)
             ti->semantic(sc);
         s = ti->inst->toAlias();


### PR DESCRIPTION
This is just a one-liner.
