### PR TITLE
fix Issue 7773 - UCFS syntax on built-in attributes too?

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3568,6 +3568,9 @@ Statement *Parser::parseStatement(int flags)
             goto Ldeclaration;
 
         case BASIC_TYPES:
+            // bug 7773: int.max is always a part of expression
+            if (peekNext() == TOKdot)
+                goto Lexp;
         case TOKtypedef:
         case TOKalias:
         case TOKconst:

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -208,6 +208,17 @@ void test7703()
 }
 
 /*******************************************/
+// 7773
+
+//import std.stdio;
+void writeln7773(int n){}
+void test7773()
+{
+    (int.max).writeln7773(); // OK
+    int.max.writeln7773();   // error
+}
+
+/*******************************************/
 
 void main()
 {
@@ -217,4 +228,5 @@ void main()
     test3382();
     test7670();
     test7703();
+    test7773();
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7773

A small parser problem.
