### PR TITLE
Fix issue 7785 [CTFE] ICE when slicing pointer to variable

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4151,6 +4151,21 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             }
             aggregate = getAggregateFromPointer(aggregate, &ofs);
             indexToModify += ofs;
+            if (aggregate->op != TOKslice && aggregate->op != TOKstring &&
+                aggregate->op != TOKarrayliteral && aggregate->op != TOKassocarrayliteral)
+            {
+                if (indexToModify != 0)
+                {
+                    error("pointer index [%lld] lies outside memory block [0..1]", indexToModify);
+                    return EXP_CANT_INTERPRET;
+                }
+                // It is equivalent to *aggregate = newval.
+                // Aggregate could be varexp, a dotvar, ...
+                // TODO: we could support this
+                error("indexed assignment of non-array pointers is not yet supported at compile time; use *%s = %s instead",
+                    ie->e1->toChars(), e2->toChars());
+                return EXP_CANT_INTERPRET;
+            }
             destarraylen = resolveArrayLength(aggregate);
         }
         if (indexToModify >= destarraylen)
@@ -4289,7 +4304,13 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         if (oldval->op != TOKarrayliteral && oldval->op != TOKstring
             && oldval->op != TOKslice && oldval->op != TOKnull)
         {
-            error("CTFE ICE: cannot resolve array length");
+            if (assignmentToSlicedPointer)
+            {
+                error("pointer %s cannot be sliced at compile time (it does not point to an array)",
+                    sexp->e1->toChars());
+            }
+            else
+                error("CTFE ICE: cannot resolve array length");
             return EXP_CANT_INTERPRET;
         }
         uinteger_t dollar = resolveArrayLength(oldval);
@@ -5117,23 +5138,37 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
         if (exceptionOrCantInterpret(e2))
             return e2;
         dinteger_t indx = e2->toInteger();
+
         dinteger_t ofs;
         Expression *agg = getAggregateFromPointer(e1, &ofs);
+
         if (agg->op == TOKnull)
         {
             error("cannot index null pointer %s", this->e1->toChars());
             return EXP_CANT_INTERPRET;
         }
-        assert(agg->op == TOKarrayliteral || agg->op == TOKstring);
-        dinteger_t len = ArrayLength(Type::tsize_t, agg)->toInteger();
-        Type *pointee = ((TypePointer *)agg->type)->next;
-        if ((indx + ofs) < 0 || (indx+ofs) > len)
+        if ( agg->op == TOKarrayliteral || agg->op == TOKstring)
         {
-            error("pointer index [%lld] exceeds allocated memory block [0..%lld]",
-                indx+ofs, len);
-            return EXP_CANT_INTERPRET;
+            dinteger_t len = ArrayLength(Type::tsize_t, agg)->toInteger();
+            Type *pointee = ((TypePointer *)agg->type)->next;
+            if ((indx + ofs) < 0 || (indx+ofs) > len)
+            {
+                error("pointer index [%lld] exceeds allocated memory block [0..%lld]",
+                    indx+ofs, len);
+                return EXP_CANT_INTERPRET;
+            }
+            return ctfeIndex(loc, type, agg, indx+ofs);
         }
-        return ctfeIndex(loc, type, agg, indx+ofs);
+        else
+        {   // Pointer to a non-array variable
+            if ((indx + ofs) != 0)
+            {
+                error("pointer index [%lld] lies outside memory block [0..1]",
+                    indx+ofs);
+                return EXP_CANT_INTERPRET;
+            }
+            return agg->interpret(istate);
+        }
     }
     e1 = this->e1;
     if (!(e1->op == TOKarrayliteral && ((ArrayLiteralExp *)e1)->ownedByCtfe))
@@ -5274,6 +5309,12 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
                 return e;
             }
             error("cannot slice null pointer %s", this->e1->toChars());
+            return EXP_CANT_INTERPRET;
+        }
+        if (agg->op != TOKarrayliteral && agg->op != TOKstring)
+        {
+            error("pointer %s cannot be sliced at compile time (it does not point to an array)",
+                this->e1->toChars());
             return EXP_CANT_INTERPRET;
         }
         assert(agg->op == TOKarrayliteral || agg->op == TOKstring);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4271,3 +4271,26 @@ static assert( test7732() );
 **************************************************/
 
 static assert( ({return;}(), true) );
+
+/**************************************************
+    7785
+**************************************************/
+
+bool bug7785(int n)
+{
+    int val = 7;
+    auto p = &val;
+    if (n==2) {
+        auto ary = p[0 .. 1];
+    }
+    auto x = p[0];
+    val = 6;
+    assert(x == 7);
+    if (n==3)
+        p[0..1] = 1;
+    return true;
+}
+
+static assert(bug7785(1));
+static assert(!is(typeof(compiles!(bug7785(2)))));
+static assert(!is(typeof(compiles!(bug7785(3)))));


### PR DESCRIPTION
Disallow slicing of pointers to non-arrays.
Disallow non-zero indexing of pointers to non-arrays.
