### PR TITLE
Fix issue 7784 CTFE ICE with self-referencing AA literals

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5839,7 +5839,9 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
                 }
                 if (ie->e1->op == TOKassocarrayliteral)
                 {
-                    e = Index(type, ie->e1, ie->e2);
+                    e = findKeyInAA(loc, (AssocArrayLiteralExp *)ie->e1, ie->e2);
+                    assert(e != EXP_CANT_INTERPRET);
+                    e = paintTypeOntoLiteral(type, e);
                     if (isGenuineIndex)
                     {
                         if (e->op == TOKindex)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4279,6 +4279,36 @@ int test7732()
 static assert( test7732() );
 
 /**************************************************
+    7784
+**************************************************/
+struct Foo7784
+{
+    void bug()
+    {
+        tab["A"] = Bar7784(&this);
+        auto pbar = "A" in tab;
+        auto bar = *pbar;
+    }
+
+    Bar7784[string] tab;
+}
+
+struct Bar7784
+{
+    Foo7784* foo;
+    int val;
+}
+
+bool ctfe7784()
+{
+    auto foo = Foo7784();
+    foo.bug();
+    return true;
+}
+
+static assert(ctfe7784());
+
+/**************************************************
     7781
 **************************************************/
 


### PR DESCRIPTION
The fix is simple, but compiler stack overflows are always horrible (worse than segfaults).
