### PR TITLE
Issue 7814 - ICE(tocsym.c) using scope(failure) within foreach-range

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -4579,7 +4579,9 @@ Catch *Catch::syntaxCopy()
 }
 
 void Catch::semantic(Scope *sc)
-{   ScopeDsymbol *sym;
+{
+    if (type && type->deco)
+        return;
 
     //printf("Catch::semantic(%s)\n", ident->toChars());
 
@@ -4596,7 +4598,7 @@ void Catch::semantic(Scope *sc)
     }
 #endif
 
-    sym = new ScopeDsymbol();
+    ScopeDsymbol *sym = new ScopeDsymbol();
     sym->parent = sc->scopesym;
     sc = sc->push(sym);
 

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -359,6 +359,35 @@ void test6659c()
 }
 
 /***************************************/
+// 7814
+
+struct File7814
+{
+    ~this(){}
+}
+
+struct ByLine7814
+{
+    File7814 file;
+
+    // foreach interface
+    @property bool empty() const    { return true; }
+    @property char[] front()        { return null; }
+    void popFront(){}
+}
+
+void test7814()
+{
+    int dummy;
+    ByLine7814 f;
+    foreach (l; f) {
+        scope(failure) // 'failure' or 'success' fails, but 'exit' works
+            dummy = -1;
+        dummy = 0;
+    }
+}
+
+/***************************************/
 
 int main()
 {
@@ -374,6 +403,7 @@ int main()
     test6659a();
     test6659b();
     test6659c();
+    test7814();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7814

`Catch::semantic()` should be reentrant.
