### PR TITLE
Fix issue 7786 dmd crashes with invalid module name

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -666,7 +666,7 @@ void Module::parse()
         assert(prev);
         Module *mprev = prev->isModule();
         if (mprev)
-            error(loc, "from file %s conflicts with another module %s fro file %s",
+            error(loc, "from file %s conflicts with another module %s from file %s",
                 srcname, mprev->toChars(), mprev->srcfile->toChars());
         else
         {


### PR DESCRIPTION
Generate a nice error message in this case, too.
Typical error message is:

src/a.d: Error: module src.a package name 'src' in file src/a.d conflicts with usage as a module name in file src/b.d

This pull request is an alternative to
https://github.com/D-Programming-Language/dmd/pull/861
They are incompatible with each other - only one should be merged
