### PR TITLE
Cross-references in generated ddoc

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -100,7 +100,7 @@ struct AggregateDeclaration : ScopeDsymbol
 
     void emitComment(Scope *sc);
     void toJsonBuffer(OutBuffer *buf);
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     // For access checking
     virtual PROT getAccess(Dsymbol *smember);   // determine access to smember
@@ -163,7 +163,7 @@ struct StructDeclaration : AggregateDeclaration
 
     FuncDeclaration *buildXopEquals(Scope *sc);
 #endif
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     PROT getAccess(Dsymbol *smember);   // determine access to smember
 
@@ -280,7 +280,7 @@ struct ClassDeclaration : AggregateDeclaration
     virtual int vtblOffset();
     const char *kind();
     char *mangle();
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     PROT getAccess(Dsymbol *smember);   // determine access to smember
 

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -133,7 +133,7 @@ struct Declaration : Dsymbol
 
     void emitComment(Scope *sc);
     void toJsonBuffer(OutBuffer *buf);
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     char *mangle();
     int isStatic() { return storage_class & STCstatic; }
@@ -200,7 +200,7 @@ struct TypedefDeclaration : Declaration
     Type *htype;
     Type *hbasetype;
 
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     void toObjFile(int multiobj);                       // compile to .obj file
     void toDebug();
@@ -232,7 +232,7 @@ struct AliasDeclaration : Declaration
     Type *htype;
     Dsymbol *haliassym;
 
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     AliasDeclaration *isAliasDeclaration() { return this; }
 };
@@ -670,7 +670,7 @@ struct FuncDeclaration : Declaration
     int canInline(int hasthis, int hdrscan, int statementsToo);
     Expression *expandInline(InlineScanState *iss, Expression *ethis, Expressions *arguments, Statement **ps);
     const char *kind();
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
     FuncDeclaration *isUnique();
     void checkNestedReference(Scope *sc, Loc loc);
     int needsClosure();

--- a/src/doc.c
+++ b/src/doc.c
@@ -599,9 +599,7 @@ void Dsymbol::emitIdentifier(OutBuffer *buf, HdrGenState *hgs)
     if (hgs->ddoc && comment && getModule()->docfile)
     {
         buf->writestring("$(LINK2 ");
-
         buf->writestring(getModule()->docfile->name->name());
-
         buf->writestring("#");
         emitAnchor(buf);
         buf->writestring(",");

--- a/src/doc.c
+++ b/src/doc.c
@@ -605,11 +605,11 @@ void Dsymbol::emitIdentifier(OutBuffer *buf, HdrGenState *hgs)
         buf->writestring("#");
         emitAnchor(buf);
         buf->writestring(",");
-        buf->writestring(this->ident->toChars());
+        buf->writestring(ident->toChars());
         buf->writestring(")");
     }
     else
-        buf->writestring(this->toChars());
+        buf->writestring(toChars());
 }
 
 void Dsymbol::emitComment(Scope *sc)               { }

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -196,6 +196,8 @@ struct Dsymbol : Object
 
     virtual void addComment(unsigned char *comment);
     virtual void emitComment(Scope *sc);
+    void emitAnchor(OutBuffer *buf);
+    void emitIdentifier(OutBuffer *buf, HdrGenState *hgs);
     void emitDitto(Scope *sc);
 
     // Backend

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -164,7 +164,7 @@ struct Dsymbol : Object
     char *toHChars();
     virtual void toHBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-    virtual void toDocBuffer(OutBuffer *buf);
+    virtual void toDocBuffer(OutBuffer *buf, Scope *sc);
     virtual void toJsonBuffer(OutBuffer *buf);
     virtual unsigned size(Loc loc);
     virtual int isforwardRef();

--- a/src/enum.h
+++ b/src/enum.h
@@ -61,7 +61,7 @@ struct EnumDeclaration : ScopeDsymbol
 
     void emitComment(Scope *sc);
     void toJsonBuffer(OutBuffer *buf);
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     EnumDeclaration *isEnumDeclaration() { return this; }
 
@@ -86,7 +86,7 @@ struct EnumMember : Dsymbol
 
     void emitComment(Scope *sc);
     void toJsonBuffer(OutBuffer *buf);
-    void toDocBuffer(OutBuffer *buf);
+    void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     EnumMember *isEnumMember() { return this; }
 };

--- a/src/hdrgen.h
+++ b/src/hdrgen.h
@@ -27,6 +27,7 @@ struct HdrGenState
         int init;
         int decl;
     } FLinit;
+    Scope* scope;       // Scope when generating ddoc
 
     HdrGenState() { memset(this, 0, sizeof(HdrGenState)); }
 };

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6465,6 +6465,7 @@ TypeIdentifier::TypeIdentifier(Loc loc, Identifier *ident)
     : TypeQualified(Tident, loc)
 {
     this->ident = ident;
+    this->originalSymbol = NULL;
 }
 
 
@@ -6494,7 +6495,12 @@ void TypeIdentifier::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
     {   toCBuffer3(buf, hgs, mod);
         return;
     }
-    buf->writestring(this->ident->toChars());
+
+    if (hgs->ddoc && this->originalSymbol)
+        this->originalSymbol->emitIdentifier(buf, hgs);
+    else
+        buf->writestring(this->ident->toChars());
+
     toCBuffer2Helper(buf, hgs);
 }
 
@@ -6535,6 +6541,9 @@ void TypeIdentifier::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsy
     }
 
     Dsymbol *s = sc->search(loc, ident, &scopesym);
+
+    this->originalSymbol = s;
+
     resolveHelper(loc, sc, s, scopesym, pe, pt, ps);
     if (*pt)
         (*pt) = (*pt)->addMod(mod);
@@ -7097,7 +7106,7 @@ void TypeEnum::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
     {   toCBuffer3(buf, hgs, mod);
         return;
     }
-    buf->writestring(sym->toChars());
+    sym->emitIdentifier(buf, hgs);
 }
 
 Expression *TypeEnum::dotExp(Scope *sc, Expression *e, Identifier *ident)
@@ -7610,7 +7619,7 @@ void TypeStruct::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
     if (ti && ti->toAlias() == sym)
         buf->writestring(ti->toChars());
     else
-        buf->writestring(sym->toChars());
+        sym->emitIdentifier(buf, hgs);
 }
 
 Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident)
@@ -8087,7 +8096,7 @@ void TypeClass::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
     {   toCBuffer3(buf, hgs, mod);
         return;
     }
-    buf->writestring(sym->toChars());
+    sym->emitIdentifier(buf, hgs);
 }
 
 Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6496,30 +6496,14 @@ void TypeIdentifier::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
         return;
     }
 
-    if (hgs->ddoc) {
+    if (hgs->ddoc)
+    {
         if (originalSymbol)
             originalSymbol->emitIdentifier(buf, hgs);
-        else {
-            Dsymbol *s = NULL;
-
-            // Try to search a symbol in the global scope.
-            // In most cases this is the correct guess.
-            // We don't search if the length is 1 because it's probably
-            // a template parameter (like E, which would incorrectly resolve to Math.E).
-            if (ident->len > 1) {
-                Dsymbol *scopesym;
-                Loc loc;
-                unsigned errors = global.startGagging();
-                s = hgs->scope->search(loc, ident, &scopesym);
-                global.endGagging(errors);
-            }
-
-            if (s) {
-                s->emitIdentifier(buf, hgs);
-            } else
-                buf->writestring(this->ident->toChars());
-        }
-    } else
+        else
+            identifierToDocBuffer(ident, buf, hgs);
+    }
+    else
         buf->writestring(this->ident->toChars());
 
     toCBuffer2Helper(buf, hgs);
@@ -9254,4 +9238,27 @@ int Parameter::foreach(Parameters *args, Parameter::ForeachDg dg, void *ctx, siz
     if (pn)
         *pn = n; // update index
     return result;
+}
+
+/* Try to search a symbol in the global scope.
+ * In most cases this is the correct guess.
+ * We don't search if the length is 1 because it's probably
+ * a template parameter (like E, which would incorrectly resolve to Math.E).
+ */
+void identifierToDocBuffer(Identifier* ident, OutBuffer *buf, HdrGenState *hgs) {
+    Dsymbol *s = NULL;
+
+    if (ident->len > 1)
+    {
+        Dsymbol *scopesym;
+        Loc loc;
+        unsigned errors = global.startGagging();
+        s = hgs->scope->search(loc, ident, &scopesym);
+        global.endGagging(errors);
+    }
+
+    if (s)
+        s->emitIdentifier(buf, hgs);
+    else
+        buf->writestring(ident->toChars());
 }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -692,6 +692,7 @@ struct TypeQualified : Type
 struct TypeIdentifier : TypeQualified
 {
     Identifier *ident;
+    Dsymbol *originalSymbol; // The symbol representing this identifier, before alias resolution
 
     TypeIdentifier(Loc loc, Identifier *ident);
     Type *syntaxCopy();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -999,5 +999,6 @@ void MODtoBuffer(OutBuffer *buf, unsigned char mod);
 int MODimplicitConv(unsigned char modfrom, unsigned char modto);
 int MODmethodConv(unsigned char modfrom, unsigned char modto);
 int MODmerge(unsigned char mod1, unsigned char mod2);
+void identifierToDocBuffer(Identifier* ident, OutBuffer *buf, HdrGenState *hgs);
 
 #endif /* DMD_MTYPE_H */

--- a/src/template.c
+++ b/src/template.c
@@ -5737,8 +5737,13 @@ void TemplateInstance::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     int i;
 
     Identifier *id = name;
-    if (hgs->ddoc && tempdecl && tempdecl->comment && tempdecl->getModule()->docfile)
-        tempdecl->emitIdentifier(buf, hgs);
+    if (hgs->ddoc)
+    {
+        if (tempdecl && tempdecl->comment && tempdecl->getModule()->docfile)
+            tempdecl->emitIdentifier(buf, hgs);
+        else
+            identifierToDocBuffer(id, buf, hgs);
+    }
     else
         buf->writestring(id->toChars());
     buf->writestring("!(");

--- a/src/template.c
+++ b/src/template.c
@@ -5737,7 +5737,7 @@ void TemplateInstance::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     int i;
 
     Identifier *id = name;
-    if (hgs->ddoc && tempdecl->comment && tempdecl->getModule()->docfile)
+    if (hgs->ddoc && tempdecl && tempdecl->comment && tempdecl->getModule()->docfile)
         tempdecl->emitIdentifier(buf, hgs);
     else
         buf->writestring(id->toChars());

--- a/src/template.c
+++ b/src/template.c
@@ -5737,7 +5737,10 @@ void TemplateInstance::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     int i;
 
     Identifier *id = name;
-    buf->writestring(id->toChars());
+    if (hgs->ddoc && tempdecl->comment && tempdecl->getModule()->docfile)
+        tempdecl->emitIdentifier(buf, hgs);
+    else
+        buf->writestring(id->toChars());
     buf->writestring("!(");
     if (nest)
         buf->writestring("...");


### PR DESCRIPTION
In this pull request there are two commits.

The first commit does three things:
- It changes the DDOC_DECL macro to also emit an html anchor (<a name="..."></a>) with the fully qualified name of the declaration, excluding the module name. So a class Foo::Bar inside some module would get an nchor equals to "Foo.Bar".
- Then when generating ddoc, instead of outputting a declaration's identifier, a link to that declaration is made with the LINK2 macro.
- Since aliases are resolved to their types and thus they wouldn't appear correctly in ddoc, I added an "originalSymboll" member to TypeIdentifier, that is the symbol the identifier resolved to. If it's available in ddoc, it is used. This works for plain aliases, but won't work for, for example, pointers to aliases or arrays of aliases (but I think that isn't a big deal).

Since D templates aren't semantically resolved until instantiation, the first commit can't generate cross-references for templates.

The second commit fixes that. What it basically does is search the idenfitier in the module's scope. This is almost always (if not always) the correct referenced type.

The only problem I found with my changes is this. In std.path there's a function like this:

``` d
enum CaseSensitive { ... }

void baseName(CaseSensitive cs)(SomeType path) {}
```

CaseSensitive docs is located in the path.html. So the generate ddoc will have `$(LINK2 path.html#CaseSensitive, CaseSensitive)`. But since highlightCode is invoked on that generated string, it becomes `$(LINK2 $DDOC_PARAM(path).html#CaseSensitive, CaseSensitive)` and after macros are replaced it will look like `<a href="<i>path</i>.html#CaseSensitive">CaseSensitive</a>``, which doesn't work.

So this only happens if a type is located in a module, and there's a parameter with that module name. If somebody knows a way to fix it (obviously not invoking highlightCode in this case could be a solution, but it won't be consistent with everything else), please let me know.

Actually, there's another problem. If you generate the ddoc with the -op then it won't work well. I still can't figure out how to deal with it if the directory structure is preserved. Again, if somebody has a solution for this, let me know.

I run this against phobos and it went just fine. You can see the output here:

http://pancake.io/1e79d0/algorithm.html
http://pancake.io/1e79d0/array.html
http://pancake.io/1e79d0/ascii.html
http://pancake.io/1e79d0/base64.html
http://pancake.io/1e79d0/bigint.html
http://pancake.io/1e79d0/biguintcore.html
http://pancake.io/1e79d0/biguintnoasm.html
http://pancake.io/1e79d0/biguintx86.html
http://pancake.io/1e79d0/bind.html
http://pancake.io/1e79d0/bitmanip.html
http://pancake.io/1e79d0/compiler.html
http://pancake.io/1e79d0/complex.html
http://pancake.io/1e79d0/concurrency.html
http://pancake.io/1e79d0/container.html
http://pancake.io/1e79d0/contracts.html
http://pancake.io/1e79d0/conv.html
http://pancake.io/1e79d0/cpuid.html
http://pancake.io/1e79d0/crc32.html
http://pancake.io/1e79d0/cstream.html
http://pancake.io/1e79d0/csv.html
http://pancake.io/1e79d0/ctype.html
http://pancake.io/1e79d0/curl.html
http://pancake.io/1e79d0/datetime.html
http://pancake.io/1e79d0/demangle.html
http://pancake.io/1e79d0/encoding.html
http://pancake.io/1e79d0/errorfunction.html
http://pancake.io/1e79d0/exception.html
http://pancake.io/1e79d0/fenv.html
http://pancake.io/1e79d0/file.html
http://pancake.io/1e79d0/functional.html
http://pancake.io/1e79d0/gammafunction.html
http://pancake.io/1e79d0/getopt.html
http://pancake.io/1e79d0/index.html
http://pancake.io/1e79d0/intrinsic.html
http://pancake.io/1e79d0/isemail.html
http://pancake.io/1e79d0/json.html
http://pancake.io/1e79d0/linux.html
http://pancake.io/1e79d0/linuxextern.html
http://pancake.io/1e79d0/loader.html
http://pancake.io/1e79d0/locale.html
http://pancake.io/1e79d0/math.html
http://pancake.io/1e79d0/mathspecial.html
http://pancake.io/1e79d0/md5.html
http://pancake.io/1e79d0/metastrings.html
http://pancake.io/1e79d0/mmfile.html
http://pancake.io/1e79d0/numeric.html
http://pancake.io/1e79d0/object.html
http://pancake.io/1e79d0/outbuffer.html
http://pancake.io/1e79d0/parallelism.html
http://pancake.io/1e79d0/path.html
http://pancake.io/1e79d0/perf.html
http://pancake.io/1e79d0/process.html
http://pancake.io/1e79d0/processinit.html
http://pancake.io/1e79d0/pthread.html
http://pancake.io/1e79d0/random.html
http://pancake.io/1e79d0/range.html
http://pancake.io/1e79d0/regex.html
http://pancake.io/1e79d0/regexp.html
http://pancake.io/1e79d0/signals.html
http://pancake.io/1e79d0/socket.html
http://pancake.io/1e79d0/socketstream.html
http://pancake.io/1e79d0/sqlite3.html
http://pancake.io/1e79d0/stdarg.html
http://pancake.io/1e79d0/stddef.html
http://pancake.io/1e79d0/stdint.html
http://pancake.io/1e79d0/stdio.html
http://pancake.io/1e79d0/stdiobase.html
http://pancake.io/1e79d0/stdlib.html
http://pancake.io/1e79d0/stream.html
http://pancake.io/1e79d0/string.html
http://pancake.io/1e79d0/syserror.html
http://pancake.io/1e79d0/system.html
http://pancake.io/1e79d0/termios.html
http://pancake.io/1e79d0/time.html
http://pancake.io/1e79d0/tipc.html
http://pancake.io/1e79d0/traits.html
http://pancake.io/1e79d0/typecons.html
http://pancake.io/1e79d0/typelist.html
http://pancake.io/1e79d0/typetuple.html
http://pancake.io/1e79d0/uni.html
http://pancake.io/1e79d0/uni_tab.html
http://pancake.io/1e79d0/unittest.html
http://pancake.io/1e79d0/uri.html
http://pancake.io/1e79d0/utf.html
http://pancake.io/1e79d0/variant.html
http://pancake.io/1e79d0/wcharh.html
http://pancake.io/1e79d0/xml.html
http://pancake.io/1e79d0/zip.html
http://pancake.io/1e79d0/zlib.html
