### PR TITLE
Regression 7493 Initialization of void[][N]

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10365,8 +10365,16 @@ Ltupleassign:
     }
     else
 #endif
+    // If it is a array, get the element type. Note that it may be
+    // multi-dimensional.
+    Type *telem = t1;
+    while (telem->ty == Tarray)
+        telem = telem->nextOf();
+
+    // Check for block assignment. If it is of type void[], void[][], etc,
+    // '= null' is the only allowable block assignment (Bug 7493)
     if (e1->op == TOKslice &&
-        t1->nextOf() &&
+        t1->nextOf() && (telem->ty != Tvoid || e2->op == TOKnull) &&
         e2->implicitConvTo(t1->nextOf())
        )
     {   // memset

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -1254,6 +1254,18 @@ void test61()
 
 /*****************************************/
 
+void bug7493()
+{
+    string str = "abcde";
+    const(void) [][1] arr = [str];
+    assert(arr[0].length == str.length);
+    const(void) [][1] arr2;
+    arr2 = [str];
+    assert(arr[0].length == str.length);
+}
+
+/*****************************************/
+
 int main()
 {
     test1();
@@ -1314,6 +1326,7 @@ int main()
     test59();
     test60();
     test61();
+    bug7493();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -860,15 +860,17 @@ template pow(F)
         if (i < 1)
         {
             static if (is(F : real))
-		return 1;
+                return 1;
             else
-		return F(1);
+                return F(1);
         }
         if (i & 1)
-	    if(i == 1)
-		return x;
-	    else
-		return x * pow(x,i-1);
+        {
+            if (i == 1)
+                return x;
+            else
+                return x * pow(x,i-1);
+        }
         return sqr!(F)(pow(x,i/2));
     }
 }


### PR DESCRIPTION
Make it so that:

void []...[N] arr = foo

is never a block assignment, except for the necessary:

void []...[N] arr = null

Ie, foo must always be an array of length N with members that implicitly convert to void[]...
I think this is the most defensible and predictable semantics for this bizarre corner case.
However, note that the spec doesn't mention block assignment _at all_.
