### PR TITLE
Fix issue 7770 __dollar cannot be read at compile time

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1398,6 +1398,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
                 VoidInitializer *e = new VoidInitializer(0);
                 e->type = Type::tsize_t;
                 v->init = e;
+                v->storage_class |= STCctfe; // it's never a true static variable
             }
             *pvar = v;
         }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1210,6 +1210,30 @@ int sdfgasf()
 static assert(sdfgasf() == 1);
 
 /**************************************************
+   Bug 7770
+**************************************************/
+
+immutable char[] foo7770 = "abcde";
+
+int bug7770a(string a)
+{
+    return 1;
+}
+
+bool bug7770b(char c)
+{
+    return true;
+}
+
+static assert( bug7770a(foo7770[0 .. $]));
+static assert( bug7770b(foo7770[ $ - 2 ]));
+void baz7770()
+{
+    static assert( bug7770a(foo7770[0 .. $]));
+    static assert( bug7770b(foo7770[ $ - 2 ]));
+}
+
+/**************************************************
    Bug 6015
 **************************************************/
 


### PR DESCRIPTION
It is always a CTFE variable, even if in global scope.
