### PR TITLE
Add -forcec option to force C calling convention for D functions.

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -1166,7 +1166,7 @@ unsigned TypeFunction::totym()
             break;
 
         case LINKd:
-            tyf = (varargs == 1) ? TYnfunc : TYjfunc;
+            tyf = (varargs == 1 || global.params.forceCconvention) ? TYnfunc : TYjfunc;
             break;
 
         case LINKcpp:

--- a/src/mars.c
+++ b/src/mars.c
@@ -325,7 +325,8 @@ Usage:\n\
   -debuglib=name    set symbolic debug library to name\n\
   -defaultlib=name  set default library to name\n\
   -deps=filename write module dependencies to filename\n%s"
-"  -g             add symbolic debug info\n\
+"  -forcec        force C calling convention for D functions\n\
+  -g             add symbolic debug info\n\
   -gc            add symbolic debug info, pretend to be C\n\
   -gs            always emit stack frame\n\
   -H             generate 'header' file\n\
@@ -537,6 +538,8 @@ int tryMain(int argc, char *argv[])
             else if (strcmp(p + 1, "fPIC") == 0)
                 global.params.pic = 1;
 #endif
+            else if (strcmp(p + 1, "forcec") == 0)
+                global.params.forceCconvention = 1;
             else if (strcmp(p + 1, "map") == 0)
                 global.params.map = 1;
             else if (strcmp(p + 1, "multiobj") == 0)

--- a/src/mars.h
+++ b/src/mars.h
@@ -174,6 +174,7 @@ struct Param
                         // 1: warnings as errors
                         // 2: informational warnings (no errors)
     char pic;           // generate position-independent-code for shared libs
+    char forceCconvention; // force C calling convention for LINKd functions
     char cov;           // generate code coverage data
     char nofloat;       // code should not pull in floating point support
     char Dversion;      // D version number


### PR DESCRIPTION
As discussed on the NG.

I'm not entirely sure whether this covers all cases, but through grepping the source, this seems to be the place to add it.
