### PR TITLE
Issue 7871 - RangeViolation with findSplitBefore

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8962,7 +8962,9 @@ Expression *SliceExp::syntaxCopy()
     if (this->upr)
         upr = this->upr->syntaxCopy();
 
-    return new SliceExp(loc, e1->syntaxCopy(), lwr, upr);
+    SliceExp *se = new SliceExp(loc, e1->syntaxCopy(), lwr, upr);
+    se->lengthVar = this->lengthVar;    // bug7871
+    return se;
 }
 
 Expression *SliceExp::semantic(Scope *sc)
@@ -9307,7 +9309,9 @@ ArrayExp::ArrayExp(Loc loc, Expression *e1, Expressions *args)
 
 Expression *ArrayExp::syntaxCopy()
 {
-    return new ArrayExp(loc, e1->syntaxCopy(), arraySyntaxCopy(arguments));
+    ArrayExp *ae = new ArrayExp(loc, e1->syntaxCopy(), arraySyntaxCopy(arguments));
+    ae->lengthVar = this->lengthVar;    // bug7871
+    return ae;
 }
 
 Expression *ArrayExp::semantic(Scope *sc)
@@ -9472,6 +9476,13 @@ IndexExp::IndexExp(Loc loc, Expression *e1, Expression *e2)
     //printf("IndexExp::IndexExp('%s')\n", toChars());
     lengthVar = NULL;
     modifiable = 0;     // assume it is an rvalue
+}
+
+Expression *IndexExp::syntaxCopy()
+{
+    IndexExp *ie = new IndexExp(loc, e1->syntaxCopy(), e2->syntaxCopy());
+    ie->lengthVar = this->lengthVar;    // bug7871
+    return ie;
 }
 
 Expression *IndexExp::semantic(Scope *sc)

--- a/src/expression.h
+++ b/src/expression.h
@@ -1196,6 +1196,7 @@ struct IndexExp : BinExp
     int modifiable;
 
     IndexExp(Loc loc, Expression *e1, Expression *e2);
+    Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4946,6 +4946,27 @@ struct A7823 {
 void test7823(A7823 a = A7823.b) { }
 
 /***************************************************/
+// 7871
+
+struct Tuple7871
+{
+    string field;
+    alias field this;
+}
+
+//auto findSplitBefore(R1)(R1 haystack)
+auto findSplitBefore7871(string haystack)
+{
+    return Tuple7871(haystack);
+}
+
+void test7871()
+{
+    string line = `<bookmark href="https://stuff">`;
+    auto a = findSplitBefore7871(line[0 .. $])[0];
+}
+
+/***************************************************/
 
 int main()
 {
@@ -5173,6 +5194,7 @@ int main()
     test7682();
     test7735();
     test7823();
+    test7871();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7871

This is a regression caused by fixing issue 7583.
When you syntaxCopy() a ast sub-tree, contained lengthVar is discarded.
But it is already inserted to scope symbol table. So we should share lengthVar between all copy of syntax trees instead of creating new one.
