### PR TITLE
Issue 7873 - IFTI with inout does not properly match template parameter if called from inout function for pointers

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -2319,7 +2319,7 @@ MATCH Type::deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters,
                             *wildmatch |= MODmutable;
                         else
                             *wildmatch |= (mod & ~MODshared);
-                        tt = mutableOf();
+                        tt = mutableOf()->substWildTo(MODmutable);
                         dedtypes->tdata()[i] = tt;
                         goto Lconst;
                     }

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1159,6 +1159,26 @@ template D7812()
 static assert(!__traits(compiles, D7812!()));
 
 /**********************************/
+// 7873
+
+inout(T)* foo(T)(inout(T)* t)
+{
+    static assert(is(T == int*));
+    return t;
+}
+
+inout(T)* bar(T)(inout(T)* t)
+{
+    return foo(t);
+}
+
+void test7873()
+{
+    int *i;
+    bar(&i);
+}
+
+/**********************************/
 
 int main()
 {
@@ -1205,6 +1225,7 @@ int main()
     test11a();
     test11b();
     test7769();
+    test7873();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7873

Now `Type::mutableOf` always removes only top qualifier, it was introduced by the commit:
3a4dd88de8f68cfc7613fca5d5cbb74f1d1289f8

So, if you want to remove inout qualifiers from whole type structure, you should use `substWildTo(MODMutable)` instead of `mutableOf()`.
