### PR TITLE
Implement rvalue reference for struct literal and construction

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1037,7 +1037,37 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             }
             if (p->storageClass & STCref)
             {
-                arg = arg->toLvalue(sc, arg);
+                if (arg->op == TOKstructliteral)
+                {
+                    Identifier *idtmp = Lexer::uniqueId("__tmpsl");
+                    VarDeclaration *tmp = new VarDeclaration(loc, arg->type, idtmp, new ExpInitializer(0, arg));
+                    tmp->storage_class |= STCctfe;
+                    Expression *ae = new DeclarationExp(loc, tmp);
+                    Expression *e = new CommaExp(loc, ae, new VarExp(loc, tmp));
+                    e = e->semantic(sc);
+
+                    arg = e;
+                }
+                else if (arg->op == TOKcall)
+                {
+                    CallExp *ce = (CallExp *)arg;
+                    if (ce->e1->op == TOKdotvar &&
+                        ((DotVarExp *)ce->e1)->var->isCtorDeclaration())
+                    {
+                        DotVarExp *dve = (DotVarExp *)ce->e1;
+                        assert(dve->e1->op == TOKcomma);
+                        assert(((CommaExp *)dve->e1)->e2->op == TOKvar);
+                        VarExp *ve = (VarExp *)((CommaExp *)dve->e1)->e2;
+                        VarDeclaration *tmp = ve->var->isVarDeclaration();
+
+                        arg = new CommaExp(arg->loc, arg, new VarExp(loc, tmp));
+                        arg = arg->semantic(sc);
+                    }
+                    else
+                        arg = arg->toLvalue(sc, arg);
+                }
+                else
+                    arg = arg->toLvalue(sc, arg);
             }
             else if (p->storageClass & STCout)
             {

--- a/src/expression.c
+++ b/src/expression.c
@@ -4060,19 +4060,6 @@ int StructLiteralExp::getFieldIndex(Type *type, unsigned offset)
     return -1;
 }
 
-#if DMDV2
-int StructLiteralExp::isLvalue()
-{
-    return 1;
-}
-#endif
-
-Expression *StructLiteralExp::toLvalue(Scope *sc, Expression *e)
-{
-    return this;
-}
-
-
 void StructLiteralExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring(sd->toChars());

--- a/src/expression.h
+++ b/src/expression.h
@@ -497,8 +497,6 @@ struct StructLiteralExp : Expression
     Expression *optimize(int result);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     dt_t **toDt(dt_t **pdt);
-    int isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
     MATCH implicitConvTo(Type *t);
 
     int inlineCost3(InlineCostState *ics);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5827,6 +5827,19 @@ int TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
                                 new IntegerExp(0, ((StringExp *)arg)->len,
                                 Type::tindex));
                 }
+                else if (arg->op == TOKstructliteral)
+                    match = MATCHconvert;
+                else if (arg->op == TOKcall)
+                {
+                    CallExp *ce = (CallExp *)arg;
+                    if (ce->e1->op == TOKdotvar &&
+                        ((DotVarExp *)ce->e1)->var->isCtorDeclaration())
+                    {
+                        match = MATCHconvert;
+                    }
+                    else
+                        goto Nomatch;
+                }
                 else
                     goto Nomatch;
             }

--- a/src/template.c
+++ b/src/template.c
@@ -1504,7 +1504,23 @@ Lretry:
 
             if (m && (fparam->storageClass & (STCref | STCauto)) == STCref)
             {   if (!farg->isLvalue())
-                    goto Lnomatch;
+                {
+                    if (farg->op == TOKstructliteral)
+                        m = MATCHconvert;
+                    else if (farg->op == TOKcall)
+                    {
+                        CallExp *ce = (CallExp *)farg;
+                        if (ce->e1->op == TOKdotvar &&
+                            ((DotVarExp *)ce->e1)->var->isCtorDeclaration())
+                        {
+                            m = MATCHconvert;
+                        }
+                        else
+                            goto Lnomatch;
+                    }
+                    else
+                        goto Lnomatch;
+                }
             }
             if (m && (fparam->storageClass & STCout))
             {   if (!farg->isLvalue())

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -295,28 +295,52 @@ struct S14b { this(int n){} }
 
 void foo14(ref S14a s) {}
 void foo14(ref S14b s) {}
+void hoo14()(ref S14a s) {}
+void hoo14()(ref S14b s) {}
+void poo14(S)(ref S s) {}
 
 void bar14(S14a s) {}
 void bar14(S14b s) {}
+void var14()(S14a s) {}
+void var14()(S14b s) {}
+void war14(S)(S s) {}
 
 int baz14(    S14a s) { return 1; }
 int baz14(ref S14a s) { return 2; }
 int baz14(    S14b s) { return 1; }
 int baz14(ref S14b s) { return 2; }
+int vaz14()(    S14a s) { return 1; }
+int vaz14()(ref S14a s) { return 2; }
+int vaz14()(    S14b s) { return 1; }
+int vaz14()(ref S14b s) { return 2; }
+int waz14(S)(    S s) { return 1; }
+int waz14(S)(ref S s) { return 2; }
 
 void test14()
 {
     // can bind rvalue-sl with ref
     foo14(S14a(0));
     foo14(S14b(0));
+    hoo14(S14a(0));
+    hoo14(S14b(0));
+    poo14(S14a(0));
+    poo14(S14b(0));
 
     // still can bind rvalue-sl with non-ref
     bar14(S14a(0));
     bar14(S14b(0));
+    var14(S14a(0));
+    var14(S14b(0));
+    war14(S14a(0));
+    war14(S14b(0));
 
     // preferred binding of rvalue-sl in overload resolution
     assert(baz14(S14a(0)) == 1);
     assert(baz14(S14b(0)) == 1);
+    assert(vaz14(S14a(0)) == 1);
+    assert(vaz14(S14b(0)) == 1);
+    assert(waz14(S14a(0)) == 1);
+    assert(waz14(S14b(0)) == 1);
 }
 
 /********************************************/

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -396,28 +396,28 @@ void test5889()
 
     assert( isLvalue(sa));
     assert( isLvalue(sb));
-//    assert(!isLvalue(S5889a(0)));
+    assert(!isLvalue(S5889a(0)));
     assert(!isLvalue(S5889b(0)));
     assert(!isLvalue(makeRvalue!S5889a()));
     assert(!isLvalue(makeRvalue!S5889b()));
 
-//    assert(foo(sa) == 1);
-//    assert(foo(sb) == 1);
-//    assert(foo(S5889a(0)) == 2);
+    assert(foo(sa) == 1);
+    assert(foo(sb) == 1);
+    assert(foo(S5889a(0)) == 2);
     assert(foo(S5889b(0)) == 2);
     assert(foo(makeRvalue!S5889a()) == 2);
     assert(foo(makeRvalue!S5889b()) == 2);
 
     assert(goo(sa) == 1);
     assert(goo(sb) == 1);
-//    assert(goo(S5889a(0)) == 2);
+    assert(goo(S5889a(0)) == 2);
     assert(goo(S5889b(0)) == 2);
     assert(goo(makeRvalue!S5889a()) == 2);
     assert(goo(makeRvalue!S5889b()) == 2);
 
-//    assert(too(sa) == 1);
-//    assert(too(sb) == 1);
-//    assert(too(S5889a(0)) == 2);
+    assert(too(sa) == 1);
+    assert(too(sb) == 1);
+    assert(too(S5889a(0)) == 2);
     assert(too(S5889b(0)) == 2);
     assert(too(makeRvalue!S5889a()) == 2);
     assert(too(makeRvalue!S5889b()) == 2);

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -190,8 +190,9 @@ struct S10
 {
     int i;
     union
-    {	int x = 2;
-	int y;
+    {
+        int x = 2;
+        int y;
     }
     int j = 3;
     myint10 k = 4;
@@ -249,42 +250,73 @@ void test11()
 
 struct S12
 {
-        int[5] x;
-        int[5] y = 3;
+    int[5] x;
+    int[5] y = 3;
 }
 
 void test12()
 {
-        S12 s = S12();
-	foreach (v; s.x)
-	    assert(v == 0);
-	foreach (v; s.y)
-	    assert(v == 3);
+    S12 s = S12();
+    foreach (v; s.x)
+        assert(v == 0);
+    foreach (v; s.y)
+        assert(v == 3);
 }
 
 /********************************************/
 
 struct S13
 {
-        int[5] x;
-        int[5] y;
-	int[6][3] z;
+    int[5] x;
+    int[5] y;
+    int[6][3] z;
 }
 
 void test13()
 {
-        S13 s = S13(0,3,4);
-	foreach (v; s.x)
-	    assert(v == 0);
-	foreach (v; s.y)
-	    assert(v == 3);
-	for (int i = 0; i < 6; i++)
-	{
-	    for (int j = 0; j < 3; j++)
-	    {
-		assert(s.z[j][i] == 4);
-	    }
-	}
+    S13 s = S13(0,3,4);
+    foreach (v; s.x)
+        assert(v == 0);
+    foreach (v; s.y)
+        assert(v == 3);
+    for (int i = 0; i < 6; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            assert(s.z[j][i] == 4);
+        }
+    }
+}
+
+/********************************************/
+
+struct S14a { int n; }
+struct S14b { this(int n){} }
+
+void foo14(ref S14a s) {}
+void foo14(ref S14b s) {}
+
+void bar14(S14a s) {}
+void bar14(S14b s) {}
+
+int baz14(    S14a s) { return 1; }
+int baz14(ref S14a s) { return 2; }
+int baz14(    S14b s) { return 1; }
+int baz14(ref S14b s) { return 2; }
+
+void test14()
+{
+    // can bind rvalue-sl with ref
+    foo14(S14a(0));
+    foo14(S14b(0));
+
+    // still can bind rvalue-sl with non-ref
+    bar14(S14a(0));
+    bar14(S14b(0));
+
+    // preferred binding of rvalue-sl in overload resolution
+    assert(baz14(S14a(0)) == 1);
+    assert(baz14(S14b(0)) == 1);
 }
 
 /********************************************/
@@ -440,6 +472,7 @@ int main()
     test11();
     test12();
     test13();
+    test14();
     test3198and1914();
     test5885();
     test5889();


### PR DESCRIPTION
This implements "rvalue reference" for D (proposal and discussions are <a href="http://forum.dlang.org/thread/4F84D6DD.5090405@digitalmars.com">here</a>).

This pull supports only struct literal, so we still cannot bind other literals (integer, floating point, array, ...) with `ref`. But it is enough for 2.059 release.
