### PR TITLE
Fix small regression of line number in IFTI error message.

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -2052,7 +2052,7 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
         OutBuffer buf;
         argExpTypesToCBuffer(&buf, fargs, &hgs);
         if (this->overnext)
-            ::error(loc, "%s %s.%s cannot deduce template function from argument types !(%s)(%s)",
+            ::error(this->loc, "%s %s.%s cannot deduce template function from argument types !(%s)(%s)",
                     kind(), parent->toPrettyChars(), ident->toChars(),
                     bufa.toChars(), buf.toChars());
         else


### PR DESCRIPTION
With following example:

``` d
void hoo()(ref string v){}
void hoo()(ref double v){}
void main()
{
    hoo(10);
}
```

compiler prints these error messages:

```
test.d(5): Error: template test.hoo does not match any function template declaration
test.d(5): Error: template test.hoo cannot deduce template function from argument types !()(int)
```

But the second error should be:

```
test.d(1): Error: template test.hoo cannot deduce template function from argument types !()(int)
```
