### PR TITLE
move fregsaved global initialization into an init function

### DIFF
--- a/src/backend/cg.c
+++ b/src/backend/cg.c
@@ -44,9 +44,8 @@ targ_size_t localsize,          /* amt subtracted from SP for local vars */
  * will change them as appropriate.
  */
 int     BPRM = 6;               /* R/M value for [BP] or [EBP]          */
-regm_t  fregsaved = mBP | mSI | mDI;    // mask of registers saved across
-                                        // function calls
-                                        // (add in mBX for I32)
+regm_t  fregsaved;              // mask of registers saved across function calls
+
 regm_t  FLOATREGS = FLOATREGS_16;
 regm_t  FLOATREGS2 = FLOATREGS2_16;
 regm_t  DOUBLEREGS = DOUBLEREGS_16;

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -292,6 +292,15 @@ int cod3_EA(code *c)
 }
 
 /********************************
+ * set initial global variable values
+ */
+
+void cod3_setdefault()
+{
+    fregsaved = mBP | mSI | mDI;
+}
+
+/********************************
  * Fix global variables for 386.
  */
 

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -777,6 +777,7 @@ extern int BPoff;
 
 int cod3_EA(code *c);
 regm_t cod3_useBP();
+void cod3_setdefault();
 void cod3_set32 (void );
 void cod3_set64 (void );
 void cod3_align (void );

--- a/src/msc.c
+++ b/src/msc.c
@@ -385,6 +385,7 @@ void backend_init()
     ph_init();
     block_init();
 
+    cod3_setdefault();
     if (global.params.is64bit)
     {
         util_set64();


### PR DESCRIPTION
When merging with dmc, the call to cod3_setdefault will need to go before the rtl symbol init code
