### PR TITLE
Issue 7922 - alias this causes weird formatting issues for strings

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1373,11 +1373,17 @@ Lnomatch:
                                         e->op = TOKblit;
                                     }
                                     e->type = t;
-                                    (*pinit) = new CommaExp(loc, e, (*pinit));
 
-                                    /* Replace __ctmp being constructed with e1
+                                    /* Replace __ctmp being constructed with e1.
+                                     * We need to copy constructor call expression,
+                                     * because it may be used in other place.
                                      */
-                                    dve->e1 = e1;
+                                    DotVarExp *dvx = (DotVarExp *)dve->copy();
+                                    dvx->e1 = e1;
+                                    CallExp *cx = (CallExp *)ce->copy();
+                                    cx->e1 = dvx;
+
+                                    (*pinit) = new CommaExp(loc, e, cx);
                                     (*pinit) = (*pinit)->semantic(sc);
                                     goto Ldtor;
                                 }

--- a/src/opover.c
+++ b/src/opover.c
@@ -354,9 +354,11 @@ Expression *UnaExp::op_overload(Scope *sc)
             /* Rewrite op(e1) as:
              *  op(e1.aliasthis)
              */
-            UnaExp *e = (UnaExp *)syntaxCopy();
-            e->e1 = new DotIdExp(loc, e->e1, ad->aliasthis->ident);
-            return e->trySemantic(sc);
+            Expression *e1 = new DotIdExp(loc, this->e1, ad->aliasthis->ident);
+            Expression *e = copy();
+            ((UnaExp *)e)->e1 = e1;
+            e = e->trySemantic(sc);
+            return e;
         }
 #endif
     }
@@ -411,9 +413,11 @@ Expression *ArrayExp::op_overload(Scope *sc)
             /* Rewrite op(e1) as:
              *  op(e1.aliasthis)
              */
-            UnaExp *e = (UnaExp *)syntaxCopy();
-            e->e1 = new DotIdExp(loc, e->e1, ad->aliasthis->ident);
-            return e->trySemantic(sc);
+            Expression *e1 = new DotIdExp(loc, this->e1, ad->aliasthis->ident);
+            Expression *e = copy();
+            ((UnaExp *)e)->e1 = e1;
+            e = e->trySemantic(sc);
+            return e;
         }
     }
     return NULL;
@@ -456,9 +460,11 @@ Expression *CastExp::op_overload(Scope *sc)
             /* Rewrite op(e1) as:
              *  op(e1.aliasthis)
              */
-            UnaExp *e = (UnaExp *)syntaxCopy();
-            e->e1 = new DotIdExp(loc, e->e1, ad->aliasthis->ident);
-            return e->trySemantic(sc);
+            Expression *e1 = new DotIdExp(loc, this->e1, ad->aliasthis->ident);
+            Expression *e = copy();
+            ((UnaExp *)e)->e1 = e1;
+            e = e->trySemantic(sc);
+            return e;
         }
     }
     return NULL;
@@ -714,9 +720,11 @@ L1:
         /* Rewrite (e1 op e2) as:
          *      (e1.aliasthis op e2)
          */
-        BinExp *e = (BinExp *)syntaxCopy();
-        e->e1 = new DotIdExp(loc, e->e1, ad1->aliasthis->ident);
-        return e->trySemantic(sc);
+        Expression *e1 = new DotIdExp(loc, this->e1, ad1->aliasthis->ident);
+        Expression *e = copy();
+        ((BinExp *)e)->e1 = e1;
+        e = e->trySemantic(sc);
+        return e;
     }
 
     // Try alias this on second operand
@@ -729,9 +737,11 @@ L1:
         /* Rewrite (e1 op e2) as:
          *      (e1 op e2.aliasthis)
          */
-        BinExp *e = (BinExp *)syntaxCopy();
-        e->e2 = new DotIdExp(loc, e->e2, ad2->aliasthis->ident);
-        return e->trySemantic(sc);
+        Expression *e2 = new DotIdExp(loc, this->e2, ad2->aliasthis->ident);
+        Expression *e = copy();
+        ((BinExp *)e)->e2 = e2;
+        e = e->trySemantic(sc);
+        return e;
     }
 #endif
     return NULL;
@@ -883,9 +893,11 @@ Expression *BinExp::compare_overload(Scope *sc, Identifier *id)
         /* Rewrite (e1 op e2) as:
          *      (e1.aliasthis op e2)
          */
-        BinExp *e = (BinExp *)syntaxCopy();
-        e->e1 = new DotIdExp(loc, e->e1, ad1->aliasthis->ident);
-        return e->trySemantic(sc);
+        Expression *e1 = new DotIdExp(loc, this->e1, ad1->aliasthis->ident);
+        Expression *e = copy();
+        ((BinExp *)e)->e1 = e1;
+        e = e->trySemantic(sc);
+        return e;
     }
 
     // Try alias this on second operand
@@ -894,9 +906,11 @@ Expression *BinExp::compare_overload(Scope *sc, Identifier *id)
         /* Rewrite (e1 op e2) as:
          *      (e1 op e2.aliasthis)
          */
-        BinExp *e = (BinExp *)syntaxCopy();
-        e->e2 = new DotIdExp(loc, e->e2, ad2->aliasthis->ident);
-        return e->trySemantic(sc);
+        Expression *e2 = new DotIdExp(loc, this->e2, ad2->aliasthis->ident);
+        Expression *e = copy();
+        ((BinExp *)e)->e2 = e2;
+        e = e->trySemantic(sc);
+        return e;
     }
 
     return NULL;
@@ -1131,9 +1145,11 @@ L1:
         /* Rewrite (e1 op e2) as:
          *      (e1.aliasthis op e2)
          */
-        BinExp *e = (BinExp *)syntaxCopy();
-        e->e1 = new DotIdExp(loc, e->e1, ad1->aliasthis->ident);
-        return e->trySemantic(sc);
+        Expression *e1 = new DotIdExp(loc, this->e1, ad1->aliasthis->ident);
+        Expression *e = copy();
+        ((BinExp *)e)->e1 = e1;
+        e = e->trySemantic(sc);
+        return e;
     }
 
     // Try alias this on second operand
@@ -1143,9 +1159,11 @@ L1:
         /* Rewrite (e1 op e2) as:
          *      (e1 op e2.aliasthis)
          */
-        BinExp *e = (BinExp *)syntaxCopy();
-        e->e2 = new DotIdExp(loc, e->e2, ad2->aliasthis->ident);
-        return e->trySemantic(sc);
+        Expression *e2 = new DotIdExp(loc, this->e2, ad2->aliasthis->ident);
+        Expression *e = copy();
+        ((BinExp *)e)->e2 = e2;
+        e = e->trySemantic(sc);
+        return e;
     }
 #endif
     return NULL;

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1,5 +1,6 @@
 
 extern (C) int printf(const(char*) fmt, ...);
+import core.vararg;
 
 struct Tup(T...)
 {
@@ -810,6 +811,29 @@ void test7945()
 }
 
 /***************************************************/
+// 7992
+
+struct S7992
+{
+    int[] arr;
+    alias arr this;
+}
+S7992 func7992(...)
+{
+    S7992 ret;
+    ret.arr.length = _arguments.length;
+    return ret;
+}
+void test7992()
+{
+    int[] arr;
+    assert(arr.length == 0);
+    arr ~= func7992(1, 2);  //NG
+    //arr = func7992(1, 2); //OK
+    assert(arr.length == 2);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -841,6 +865,7 @@ int main()
     test7731();
     test7808();
     test7945();
+    test7992();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
This was a regression of fixing 7583, and redundant copy of syntax tree have been made this problem.
So I revert efd4711 + cd7dfca, and add necessary and sufficient copy.
