### PR TITLE
Issue 7453 - Can't return value from within opApply

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3627,6 +3627,7 @@ ReturnStatement::ReturnStatement(Loc loc, Expression *exp)
     : Statement(loc)
 {
     this->exp = exp;
+    this->implicit0 = 0;
 }
 
 Statement *ReturnStatement::syntaxCopy()
@@ -3644,7 +3645,6 @@ Statement *ReturnStatement::semantic(Scope *sc)
 
     FuncDeclaration *fd = sc->parent->isFuncDeclaration();
     Scope *scx = sc;
-    int implicit0 = 0;
     Expression *eorg = NULL;
 
     if (fd->fes)

--- a/src/statement.h
+++ b/src/statement.h
@@ -604,6 +604,7 @@ struct SwitchErrorStatement : Statement
 struct ReturnStatement : Statement
 {
     Expression *exp;
+    int implicit0;
 
     ReturnStatement(Loc loc, Expression *exp);
     Statement *syntaxCopy();

--- a/test/runnable/test7453.d
+++ b/test/runnable/test7453.d
@@ -1,0 +1,14 @@
+struct S
+{
+    int opApply(int delegate(string) dg)
+    {
+        return 0;
+    }
+}
+void main()
+{
+    foreach (_; S())
+    {
+        return;
+    }
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7453

Inside main function, and after first semantic, `ReturnStatement::exp` is
filled with `IntegerExp(0)`. Then in second semantic, implicit0 doesn't
become 1, and error occurs.

ReturnStatement object should keep implicit0 value for repeating
call of semantic().
