### PR TITLE
CTFE refactoring -- move ALL interpreting into CTFE

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -921,7 +921,7 @@ void PragmaDeclaration::setScope(Scope *sc)
         {
             Expression *e = (*args)[0];
             e = e->semantic(sc);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             (*args)[0] = e;
             StringExp* se = e->toString();
             if (!se)
@@ -956,7 +956,7 @@ void PragmaDeclaration::semantic(Scope *sc)
 
                 e = e->semantic(sc);
                 if (e->op != TOKerror)
-                    e = e->optimize(WANTvalue | WANTinterpret);
+                    e = e->ctfeInterpret();
                 if (e->op == TOKerror)
                 {   errorSupplemental(loc, "while evaluating pragma(msg, %s)", (*args)[i]->toChars());
                     return;
@@ -982,7 +982,7 @@ void PragmaDeclaration::semantic(Scope *sc)
             Expression *e = (*args)[0];
 
             e = e->semantic(sc);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             (*args)[0] = e;
             if (e->op == TOKerror)
                 goto Lnodecl;
@@ -1024,7 +1024,7 @@ void PragmaDeclaration::semantic(Scope *sc)
 
             e = (*args)[1];
             e = e->semantic(sc);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             e = e->toString();
             if (e && ((StringExp *)e)->sz == 1)
                 s = ((StringExp *)e);
@@ -1046,7 +1046,7 @@ void PragmaDeclaration::semantic(Scope *sc)
         {
             Expression *e = (*args)[0];
             e = e->semantic(sc);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             (*args)[0] = e;
             Dsymbol *sa = getDsymbol(e);
             if (!sa || !sa->isFuncDeclaration())
@@ -1073,7 +1073,7 @@ void PragmaDeclaration::semantic(Scope *sc)
                 {
                     Expression *e = (*args)[i];
                     e = e->semantic(sc);
-                    e = e->optimize(WANTvalue | WANTinterpret);
+                    e = e->ctfeInterpret();
                     if (i == 0)
                         printf(" (");
                     else
@@ -1488,7 +1488,7 @@ void CompileDeclaration::compileIt(Scope *sc)
     //printf("CompileDeclaration::compileIt(loc = %d) %s\n", loc.linnum, exp->toChars());
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
-    exp = exp->optimize(WANTvalue | WANTinterpret);
+    exp = exp->ctfeInterpret();
     StringExp *se = exp->toString();
     if (!se)
     {   exp->error("argument to mixin must be a string, not (%s)", exp->toChars());

--- a/src/cond.c
+++ b/src/cond.c
@@ -260,7 +260,7 @@ int StaticIfCondition::include(Scope *sc, ScopeDsymbol *s)
         sc->flags |= SCOPEstaticif;
         Expression *e = exp->semantic(sc);
         sc->pop();
-        e = e->optimize(WANTvalue | WANTinterpret);
+        e = e->ctfeInterpret();
         --nest;
         if (e->op == TOKerror)
         {   exp = e;

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1513,7 +1513,7 @@ Lnomatch:
                 else if (ei)
                 {
                     if (isDataseg() || (storage_class & STCmanifest))
-                        e = e->optimize(WANTvalue | WANTinterpret);
+                        e = e->ctfeInterpret();
                     else
                         e = e->optimize(WANTvalue);
                     switch (e->op)

--- a/src/enum.c
+++ b/src/enum.c
@@ -183,11 +183,11 @@ void EnumDeclaration::semantic(Scope *sc)
         {
             assert(e->dyncast() == DYNCAST_EXPRESSION);
             e = e->semantic(sce);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             if (memtype)
             {
                 e = e->implicitCastTo(sce, memtype);
-                e = e->optimize(WANTvalue | WANTinterpret);
+                e = e->ctfeInterpret();
                 if (!isAnonymous())
                     e = e->castTo(sce, type);
                 t = memtype;
@@ -195,7 +195,7 @@ void EnumDeclaration::semantic(Scope *sc)
             else if (em->type)
             {
                 e = e->implicitCastTo(sce, em->type);
-                e = e->optimize(WANTvalue | WANTinterpret);
+                e = e->ctfeInterpret();
                 assert(isAnonymous());
                 t = e->type;
             }
@@ -212,7 +212,7 @@ void EnumDeclaration::semantic(Scope *sc)
                 t = Type::tint32;
             e = new IntegerExp(em->loc, 0, Type::tint32);
             e = e->implicitCastTo(sce, t);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             if (!isAnonymous())
                 e = e->castTo(sce, type);
         }
@@ -223,7 +223,7 @@ void EnumDeclaration::semantic(Scope *sc)
             {
                 emax = t->getProperty(0, Id::max);
                 emax = emax->semantic(sce);
-                emax = emax->optimize(WANTvalue | WANTinterpret);
+                emax = emax->ctfeInterpret();
             }
 
             // Set value to (elast + 1).
@@ -231,7 +231,7 @@ void EnumDeclaration::semantic(Scope *sc)
             assert(elast);
             e = new EqualExp(TOKequal, em->loc, elast, emax);
             e = e->semantic(sce);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             if (e->toInteger())
                 error("overflow of enum value %s", elast->toChars());
 
@@ -239,14 +239,14 @@ void EnumDeclaration::semantic(Scope *sc)
             e = new AddExp(em->loc, elast, new IntegerExp(em->loc, 1, Type::tint32));
             e = e->semantic(sce);
             e = e->castTo(sce, elast->type);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
 
             if (t->isfloating())
             {
                 // Check that e != elast (not always true for floats)
                 Expression *etest = new EqualExp(TOKequal, em->loc, e, elast);
                 etest = etest->semantic(sce);
-                etest = etest->optimize(WANTvalue | WANTinterpret);
+                etest = etest->ctfeInterpret();
                 if (etest->toInteger())
                     error("enum member %s has inexact value, due to loss of precision", em->toChars());
             }
@@ -296,13 +296,13 @@ void EnumDeclaration::semantic(Scope *sc)
                 // Compute if(e < minval)
                 ec = new CmpExp(TOKlt, em->loc, e, minval);
                 ec = ec->semantic(sce);
-                ec = ec->optimize(WANTvalue | WANTinterpret);
+                ec = ec->ctfeInterpret();
                 if (ec->toInteger())
                     minval = e;
 
                 ec = new CmpExp(TOKgt, em->loc, e, maxval);
                 ec = ec->semantic(sce);
-                ec = ec->optimize(WANTvalue | WANTinterpret);
+                ec = ec->ctfeInterpret();
                 if (ec->toInteger())
                     maxval = e;
             }

--- a/src/expression.c
+++ b/src/expression.c
@@ -6245,7 +6245,7 @@ Expression *CompileExp::semantic(Scope *sc)
         error("argument to mixin must be a string type, not %s\n", e1->type->toChars());
         return new ErrorExp();
     }
-    e1 = e1->optimize(WANTvalue | WANTinterpret);
+    e1 = e1->ctfeInterpret();
     StringExp *se = e1->toString();
     if (!se)
     {   error("argument to mixin must be a string, not (%s)", e1->toChars());
@@ -6287,7 +6287,7 @@ Expression *FileExp::semantic(Scope *sc)
 #endif
     UnaExp::semantic(sc);
     e1 = resolveProperties(sc, e1);
-    e1 = e1->optimize(WANTvalue | WANTinterpret);
+    e1 = e1->ctfeInterpret();
     if (e1->op != TOKstring)
     {   error("file name argument must be a string, not (%s)", e1->toChars());
         goto Lerror;
@@ -9137,8 +9137,8 @@ Lagain:
 
     if (t->ty == Ttuple)
     {
-        lwr = lwr->optimize(WANTvalue | WANTinterpret);
-        upr = upr->optimize(WANTvalue | WANTinterpret);
+        lwr = lwr->ctfeInterpret();
+        upr = upr->ctfeInterpret();
         uinteger_t i1 = lwr->toUInteger();
         uinteger_t i2 = upr->toUInteger();
 
@@ -9631,7 +9631,7 @@ Expression *IndexExp::semantic(Scope *sc)
         case Ttuple:
         {
             e2 = e2->implicitCastTo(sc, Type::tsize_t);
-            e2 = e2->optimize(WANTvalue | WANTinterpret);
+            e2 = e2->ctfeInterpret();
             uinteger_t index = e2->toUInteger();
             size_t length;
             TupleExp *te;

--- a/src/expression.h
+++ b/src/expression.h
@@ -165,6 +165,11 @@ struct Expression : Object
     // Same as WANTvalue, but also expand variables as far as possible
     #define WANTexpand  8
 
+    // Entry point for CTFE.
+    // A compile-time result is required. Give an error if not possible
+    Expression *ctfeInterpret();
+
+    // Implementation of CTFE for this expression
     virtual Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
 
     virtual int isConst();

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3654,7 +3654,7 @@ STATIC code *asm_db_parse(OP *pop)
             case TOKidentifier:
             {   Expression *e = new IdentifierExp(asmstate.loc, asmtok->ident);
                 e = e->semantic(asmstate.sc);
-                e = e->optimize(WANTvalue | WANTinterpret);
+                e = e->ctfeInterpret();
                 if (e->op == TOKint64)
                 {   dt.ul = e->toInteger();
                     goto L2;
@@ -3730,7 +3730,7 @@ int asm_getnum()
 
             e = new IdentifierExp(asmstate.loc, asmtok->ident);
             e = e->semantic(asmstate.sc);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             i = e->toInteger();
             v = (int) i;
             if (v != i)
@@ -4442,7 +4442,7 @@ STATIC OPND *asm_primary_exp()
                             }
                         }
                         e = e->semantic(asmstate.sc);
-                        e = e->optimize(WANTvalue | WANTinterpret);
+                        e = e->ctfeInterpret();
                         if (e->isConst())
                         {
                             if (e->type->isintegral())

--- a/src/init.c
+++ b/src/init.c
@@ -490,7 +490,7 @@ Initializer *ArrayInitializer::semantic(Scope *sc, Type *t, int needInterpret)
         Expression *idx = index[i];
         if (idx)
         {   idx = idx->semantic(sc);
-            idx = idx->optimize(WANTvalue | WANTinterpret);
+            idx = idx->ctfeInterpret();
             index[i] = idx;
             length = idx->toInteger();
         }
@@ -811,10 +811,12 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, int needInterpret)
     //printf("ExpInitializer::semantic(%s), type = %s\n", exp->toChars(), t->toChars());
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
-    int wantOptimize = needInterpret ? WANTinterpret|WANTvalue : WANTvalue;
 
     int olderrors = global.errors;
-    exp = exp->optimize(wantOptimize);
+    if (needInterpret)
+        exp = exp->ctfeInterpret();
+    else
+        exp = exp->optimize(WANTvalue);
     if (!global.gag && olderrors != global.errors)
         return this; // Failed, suppress duplicate error messages
 
@@ -860,7 +862,10 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, int needInterpret)
 
     exp = exp->implicitCastTo(sc, t);
 L1:
-    exp = exp->optimize(wantOptimize);
+    if (needInterpret)
+        exp = exp->ctfeInterpret();
+    else
+        exp = exp->optimize(WANTvalue);
     //printf("-ExpInitializer::semantic(): "); exp->print();
     return this;
 }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -489,6 +489,16 @@ void showCtfeExpr(Expression *e, int level = 0)
 }
 
 /*************************************
+ *
+ * Entry point for CTFE.
+ * A compile-time result is required. Give an error if not possible
+ */
+Expression *Expression::ctfeInterpret()
+{
+    return optimize(WANTvalue | WANTinterpret);
+}
+
+/*************************************
  * Attempt to interpret a function given the arguments.
  * Input:
  *      istate     state for calling function (NULL if none)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3706,7 +3706,7 @@ void TypeSArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
             sc = sc->push(sym);
 
             dim = dim->semantic(sc);
-            dim = dim->optimize(WANTvalue | WANTinterpret);
+            dim = dim->ctfeInterpret();
             uinteger_t d = dim->toUInteger();
 
             sc = sc->pop();
@@ -3768,7 +3768,7 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
     {   TupleDeclaration *sd = s->isTupleDeclaration();
 
         dim = semanticLength(sc, sd, dim);
-        dim = dim->optimize(WANTvalue | WANTinterpret);
+        dim = dim->ctfeInterpret();
         uinteger_t d = dim->toUInteger();
 
         if (d >= sd->objects->dim)
@@ -3807,7 +3807,7 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
              */
             return this;
         }
-        dim = dim->optimize(WANTvalue | WANTinterpret);
+        dim = dim->ctfeInterpret();
         dinteger_t d1 = dim->toInteger();
         dim = dim->implicitCastTo(sc, tsize_t);
         dim = dim->optimize(WANTvalue);
@@ -8814,11 +8814,11 @@ Type *TypeSlice::semantic(Loc loc, Scope *sc)
     TypeTuple *tt = (TypeTuple *)tbn;
 
     lwr = semanticLength(sc, tbn, lwr);
-    lwr = lwr->optimize(WANTvalue | WANTinterpret);
+    lwr = lwr->ctfeInterpret();
     uinteger_t i1 = lwr->toUInteger();
 
     upr = semanticLength(sc, tbn, upr);
-    upr = upr->optimize(WANTvalue | WANTinterpret);
+    upr = upr->ctfeInterpret();
     uinteger_t i2 = upr->toUInteger();
 
     if (!(i1 <= i2 && i2 <= tt->arguments->dim))
@@ -8858,11 +8858,11 @@ void TypeSlice::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol 
             sc = sc->push(sym);
 
             lwr = lwr->semantic(sc);
-            lwr = lwr->optimize(WANTvalue | WANTinterpret);
+            lwr = lwr->ctfeInterpret();
             uinteger_t i1 = lwr->toUInteger();
 
             upr = upr->semantic(sc);
-            upr = upr->optimize(WANTvalue | WANTinterpret);
+            upr = upr->ctfeInterpret();
             uinteger_t i2 = upr->toUInteger();
 
             sc = sc->pop();

--- a/src/statement.c
+++ b/src/statement.c
@@ -400,7 +400,7 @@ Statements *CompileStatement::flatten(Scope *sc)
     //printf("CompileStatement::flatten() %s\n", exp->toChars());
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
-    exp = exp->optimize(WANTvalue | WANTinterpret);
+    exp = exp->ctfeInterpret();
     if (exp->op == TOKerror)
         return NULL;
     StringExp *se = exp->toString();
@@ -2882,7 +2882,7 @@ Statement *PragmaStatement::semantic(Scope *sc)
 
                 e = e->semantic(sc);
                 if (e->op != TOKerror)
-                    e = e->optimize(WANTvalue | WANTinterpret);
+                    e = e->ctfeInterpret();
                 if (e->op == TOKerror)
                 {   errorSupplemental(loc, "while evaluating pragma(msg, %s)", (*args)[i]->toChars());
                     goto Lerror;
@@ -2912,7 +2912,7 @@ Statement *PragmaStatement::semantic(Scope *sc)
             Expression *e = (*args)[0];
 
             e = e->semantic(sc);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             (*args)[0] = e;
             StringExp *se = e->toString();
             if (!se)
@@ -2937,7 +2937,7 @@ Statement *PragmaStatement::semantic(Scope *sc)
         {
             Expression *e = (*args)[0];
             e = e->semantic(sc);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             (*args)[0] = e;
             Dsymbol *sa = getDsymbol(e);
             if (!sa || !sa->isFuncDeclaration())
@@ -3284,7 +3284,7 @@ Statement *CaseStatement::semantic(Scope *sc)
             }
         }
         else
-            exp = exp->optimize(WANTvalue | WANTinterpret);
+            exp = exp->ctfeInterpret();
 
         if (exp->op != TOKstring && exp->op != TOKint64 && exp->op != TOKerror)
         {
@@ -3389,12 +3389,11 @@ Statement *CaseRangeStatement::semantic(Scope *sc)
 
     first = first->semantic(sc);
     first = first->implicitCastTo(sc, sw->condition->type);
-    first = first->optimize(WANTvalue | WANTinterpret);
-
+    first = first->ctfeInterpret();
 
     last = last->semantic(sc);
     last = last->implicitCastTo(sc, sw->condition->type);
-    last = last->optimize(WANTvalue | WANTinterpret);
+    last = last->ctfeInterpret();
 
     if (first->op == TOKerror || last->op == TOKerror)
         return statement ? statement->semantic(sc) : NULL;

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -61,7 +61,7 @@ void StaticAssert::semantic2(Scope *sc)
     if (e->type == Type::terror)
         return;
     unsigned olderrs = global.errors;
-    e = e->optimize(WANTvalue | WANTinterpret);
+    e = e->ctfeInterpret();
     if (global.errors != olderrs)
     {
         errorSupplemental(loc, "while evaluating: static assert(%s)", exp->toChars());
@@ -73,7 +73,7 @@ void StaticAssert::semantic2(Scope *sc)
             OutBuffer buf;
 
             msg = msg->semantic(sc);
-            msg = msg->optimize(WANTvalue | WANTinterpret);
+            msg = msg->ctfeInterpret();
             hgs.console = 1;
             msg->toCBuffer(&buf, &hgs);
             error("%s", buf.toChars());

--- a/src/struct.c
+++ b/src/struct.c
@@ -108,7 +108,7 @@ void AggregateDeclaration::semantic3(Scope *sc)
             Dsymbol *s = ti->toAlias();
             Expression *e = new DsymbolExp(0, s, 0);
             e = e->semantic(ti->tempdecl->scope);
-            e = e->optimize(WANTvalue | WANTinterpret);
+            e = e->ctfeInterpret();
             getRTInfo = e;
         }
     }

--- a/src/template.c
+++ b/src/template.c
@@ -800,7 +800,7 @@ MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
             fd->vthis = vthissave;
 
         sc->pop();
-        e = e->optimize(WANTvalue | WANTinterpret);
+        e = e->ctfeInterpret();
         if (e->isBool(TRUE))
             ;
         else if (e->isBool(FALSE))
@@ -1737,7 +1737,7 @@ Lmatch:
         if (nerrors != global.errors)   // if any errors from evaluating the constraint, no match
             goto Lnomatch;
 
-        e = e->optimize(WANTvalue | WANTinterpret);
+        e = e->ctfeInterpret();
         if (e->isBool(TRUE))
             ;
         else if (e->isBool(FALSE))
@@ -2974,7 +2974,7 @@ MATCH TypeInstance::deduceType(Scope *sc,
             }
             else if (e1 && e2)
             {
-                e1 = e1->optimize(WANTvalue | WANTinterpret);
+                e1 = e1->ctfeInterpret();
 
                 //printf("e1 = %s, type = %s %d\n", e1->toChars(), e1->type->toChars(), e1->type->ty);
                 //printf("e2 = %s, type = %s %d\n", e2->toChars(), e2->type->toChars(), e2->type->ty);
@@ -2991,7 +2991,7 @@ MATCH TypeInstance::deduceType(Scope *sc,
                         goto Lnomatch;
 
                     e2 = e2->implicitCastTo(sc, e1->type);
-                    e2 = e2->optimize(WANTvalue | WANTinterpret);
+                    e2 = e2->ctfeInterpret();
                     if (!e1->equals(e2))
                         goto Lnomatch;
                 }
@@ -3655,7 +3655,7 @@ Object *aliasParameterSemantic(Loc loc, Scope *sc, Object *o)
         else if (ea)
         {
             ea = ea->semantic(sc);
-            o = ea->optimize(WANTvalue | WANTinterpret);
+            o = ea->ctfeInterpret();
         }
     }
     return o;
@@ -3920,7 +3920,7 @@ void TemplateValueParameter::semantic(Scope *sc)
 
         e = e->semantic(sc);
         e = e->implicitCastTo(sc, valType);
-        e = e->optimize(WANTvalue | WANTinterpret);
+        e = e->ctfeInterpret();
         if (e->op == TOKint64 || e->op == TOKfloat64 ||
             e->op == TOKcomplex80 || e->op == TOKnull || e->op == TOKstring)
             specValue = e;
@@ -3932,7 +3932,7 @@ void TemplateValueParameter::semantic(Scope *sc)
 
         e = e->semantic(sc);
         e = e->implicitCastTo(sc, valType);
-        e = e->optimize(WANTvalue | WANTinterpret);
+        e = e->ctfeInterpret();
         if (e->op == TOKint64)
             defaultValue = e;
         //e->toInteger();
@@ -3997,7 +3997,7 @@ MATCH TemplateValueParameter::matchArg(Scope *sc,
 
     if (ei && ei->op == TOKvar)
     {   // Resolve const variables that we had skipped earlier
-        ei = ei->optimize(WANTvalue | WANTinterpret);
+        ei = ei->ctfeInterpret();
     }
 
     //printf("\tvalType: %s, ty = %d\n", valType->toChars(), valType->ty);
@@ -4022,12 +4022,12 @@ MATCH TemplateValueParameter::matchArg(Scope *sc,
 
         e = e->semantic(sc);
         e = e->implicitCastTo(sc, vt);
-        e = e->optimize(WANTvalue | WANTinterpret);
+        e = e->ctfeInterpret();
 
         ei = ei->syntaxCopy();
         ei = ei->semantic(sc);
         ei = ei->implicitCastTo(sc, vt);
-        ei = ei->optimize(WANTvalue | WANTinterpret);
+        ei = ei->ctfeInterpret();
         //printf("\tei: %s, %s\n", ei->toChars(), ei->type->toChars());
         //printf("\te : %s, %s\n", e->toChars(), e->type->toChars());
         if (!ei->equals(e))
@@ -4045,7 +4045,7 @@ MATCH TemplateValueParameter::matchArg(Scope *sc,
         else if (m != MATCHexact)
         {
             ei = ei->implicitCastTo(sc, vt);
-            ei = ei->optimize(WANTvalue | WANTinterpret);
+            ei = ei->ctfeInterpret();
         }
     }
     (*dedtypes)[i] = ei;
@@ -4907,7 +4907,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                 if (flags & 1) // only used by __traits, must not interpret the args
                     ea = ea->optimize(WANTvalue);
                 else if (ea->op != TOKvar)
-                    ea = ea->optimize(WANTvalue | WANTinterpret);
+                    ea = ea->ctfeInterpret();
                 (*tiargs)[j] = ea;
             }
             else if (sa)
@@ -4960,7 +4960,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
             if (flags & 1) // only used by __traits, must not interpret the args
                 ea = ea->optimize(WANTvalue);
             else if (ea->op != TOKvar && ea->op != TOKtuple)
-                ea = ea->optimize(WANTvalue | WANTinterpret);
+                ea = ea->ctfeInterpret();
             (*tiargs)[j] = ea;
             if (ea->op == TOKtype)
             {   ta = ea->type;
@@ -5258,7 +5258,7 @@ TemplateDeclaration *TemplateInstance::findBestMatch(Scope *sc, Expressions *far
         {
             assert(ea);
             ea = ea->castTo(tvp->valType);
-            ea = ea->optimize(WANTvalue | WANTinterpret);
+            ea = ea->ctfeInterpret();
             (*tiargs)[i] = (Object *)ea;
         }
     }
@@ -5423,7 +5423,7 @@ Identifier *TemplateInstance::genIdent(Objects *args)
             }
             // Now that we know it is not an alias, we MUST obtain a value
             unsigned olderr = global.errors;
-            ea = ea->optimize(WANTvalue | WANTinterpret);
+            ea = ea->ctfeInterpret();
             if (ea->op == TOKerror || olderr != global.errors)
                 continue;
 #if 1

--- a/src/traits.c
+++ b/src/traits.c
@@ -237,7 +237,7 @@ Expression *TraitsExp::semantic(Scope *sc)
         {   error("expression expected as second argument of __traits %s", ident->toChars());
             goto Lfalse;
         }
-        e = e->optimize(WANTvalue | WANTinterpret);
+        e = e->ctfeInterpret();
         StringExp *se = e->toString();
         if (!se || se->length() == 0)
         {   error("string expected as second argument of __traits %s instead of %s", ident->toChars(), e->toChars());

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -2766,6 +2766,13 @@ struct S5117b
 }
 
 /************************************************/
+// This is required by druntime for Windows
+
+struct DruntimeCtfe { int dummy; }
+shared DruntimeCtfe required_by_Windows[4];
+static assert(&required_by_Windows[1]);
+
+/************************************************/
 // from tests/fail_compilation/fail147
 
 static assert(!is(typeof(Compileable!(


### PR DESCRIPTION
This fixes a structural problem. Up to now, CTFE was initiated with a call to
optimize(WANTvalue | WANTinterpret). The CTFE engine only starts when there is a function call.
There are lots of (buggy!) special cases in optimize.c for the case where WANTinterpret is set outside of a function call. This duplicates code from interpret.c. This commit removes the distinction between the interpreter and CTFE.

It incidentally fixes a few bugs, such as:

7640 CTFE: Confusing error message when looking up missing hash key

and it allows code like this to work

class X { int y; this() { y = 2; }}
static assert( (new X).y == 2);

since the class never actually leaves the interpreter.
