### PR TITLE
Issue 5437 - Problems with length of std.traits.EnumMembers

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4148,8 +4148,32 @@ Expression *TypeExp::syntaxCopy()
 Expression *TypeExp::semantic(Scope *sc)
 {
     //printf("TypeExp::semantic(%s)\n", type->toChars());
-    type = type->semantic(loc, sc);
-    return this;
+    Expression *e;
+    Type *t;
+    Dsymbol *s;
+
+    type->resolve(loc, sc, &e, &t, &s);
+    if (e)
+    {
+        //printf("e = %s %s\n", Token::toChars(e->op), e->toChars());
+        e = e->semantic(sc);
+    }
+    else if (t)
+    {
+        //printf("t = %d %s\n", t->ty, t->toChars());
+        type = t->semantic(loc, sc);
+        e = this;
+    }
+    else if (s)
+    {
+        //printf("s = %s %s\n", s->kind(), s->toChars());
+        e = new DsymbolExp(loc, s, s->hasOverloads());
+        e = e->semantic(sc);
+    }
+    else
+        assert(0);
+
+    return e;
 }
 
 int TypeExp::rvalue()

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3561,6 +3561,31 @@ pure int test4031()
 }
 
 /***************************************************/
+// 5437
+
+template EnumMembers5437(E)
+{
+    template TypeTuple(T...){ alias T TypeTuple; }
+
+    alias TypeTuple!("A", "B") EnumMembers5437;
+}
+template IntValue5437()
+{
+    int IntValue5437 = 10;
+}
+
+void test5437()
+{
+    enum Foo { A, B }
+    alias EnumMembers5437!Foo members;      // OK
+    enum n1 = members.length;               // OK
+    enum n2 = (EnumMembers5437!Foo).length; // NG, type -> symbol
+
+    enum s1 = IntValue5437!().sizeof;       // OK
+    enum s2 = (IntValue5437!()).sizeof;     // NG, type -> expression
+}
+
+/***************************************************/
 // 1962
 
 
@@ -5185,6 +5210,7 @@ int main()
     test4539();
     test4963();
     test4031();
+    test5437();
     test6230();
     test6264();
     test6284();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5437

Should allow resolving `TypeExp` to symbol or expression.
