### PR TITLE
more OP and FLndp cleanup

### DIFF
--- a/src/backend/cgcs.c
+++ b/src/backend/cgcs.c
@@ -325,9 +325,11 @@ STATIC void ecom(elem **pe)
     case OPand:
     case OPeqeq:
     case OPne:
+#if TX86
     case OPscale:
     case OPyl2x:
     case OPyl2xp1:
+#endif
         ecom(&e->E1);
         ecom(&e->E2);
         break;
@@ -343,7 +345,7 @@ STATIC void ecom(elem **pe)
 
     // Explicitly list all the unary ops for speed
     case OPnot: case OPcom: case OPneg: case OPuadd:
-    case OPabs: case OPsqrt: case OPrndtol: case OPsin: case OPcos: case OPrint:
+    case OPabs: case OPrndtol: case OPrint:
     case OPpreinc: case OPpredec:
     case OPbool: case OPstrlen: case OPs16_32: case OPu16_32:
     case OPd_s32: case OPd_u32:
@@ -360,6 +362,9 @@ STATIC void ecom(elem **pe)
     case OPvoid: case OPnullcheck:
     case OPbsf: case OPbsr: case OPbswap: case OPvector:
     case OPld_u64:
+#if TX86
+    case OPsqrt: case OPsin: case OPcos:
+#endif
 #if TARGET_SEGMENTED
     case OPoffset: case OPnp_fp: case OPnp_f16p: case OPf16p_np:
 #endif

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1615,10 +1615,12 @@ elem * evalu8(elem *e)
                 break;
         }
         break;
+#if TX86
     case OPsqrt:
-    case OPrndtol:
     case OPsin:
     case OPcos:
+#endif
+    case OPrndtol:
     case OPrint:
         return e;
     case OPngt:

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1050,15 +1050,17 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPu64_128:
 #endif
         case OPabs:
-        case OPsqrt:
         case OPrndtol:
-        case OPsin:
-        case OPcos:
         case OPrint:
         case OPsetjmp:
         case OPbsf:
         case OPbsr:
         case OPbswap:
+#if TX86
+        case OPsqrt:
+        case OPsin:
+        case OPcos:
+#endif
 #if TARGET_SEGMENTED
         case OPvp_fp: /* BUG for MacHandles */
         case OPnp_f16p: case OPf16p_np: case OPoffset: case OPnp_fp:
@@ -1118,10 +1120,12 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPcomma:
         case OPpair:
         case OPrpair:
-        case OPscale:
         case OPremquo:
+#if TX86
+        case OPscale:
         case OPyl2x:
         case OPyl2xp1:
+#endif
                 markinvar(n->E1,rd);
                 markinvar(n->E2,rd);
                 if (isLI(n->E2) && isLI(n->E1))

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -47,12 +47,12 @@ enum OPER
         OPuadd,                 /* unary +                      */
         OPvoid,                 // where casting to void is not a no-op
         OPabs,                  /* absolute value               */
+        OPrndtol,               // round to short, long, long long (inline 8087 only)
+        OPrint,                 // round to int
 #if TX86
         OPsqrt,                 /* square root                  */
-        OPrndtol,               // round to short, long, long long (inline 8087 only)
         OPsin,                  // sine
         OPcos,                  // cosine
-        OPrint,                 // round to int
         OPscale,                // ldexp
         OPyl2x,                 // y * log2(x)
         OPyl2xp1,               // y * log2(x + 1)
@@ -314,12 +314,8 @@ extern unsigned char rel_unord[];
  *      OTboolnop       operation is a nop if boolean result is desired
  */
 
-#if TX86
 extern const unsigned char optab1[OPMAX],optab2[OPMAX],optab3[OPMAX];
 extern const unsigned char opcost[OPMAX];
-#else
-extern unsigned char optab1[OPMAX],optab2[OPMAX];
-#endif
 /* optab1[]     */      /* Use byte arrays to avoid index scaling       */
 #define _OTbinary       1
 #define _OTunary        2
@@ -340,10 +336,9 @@ extern unsigned char optab1[OPMAX],optab2[OPMAX];
 #define _OTae           0x40
 #define _OTexp          0x80
 
-#if TX86
 // optab3[]
 #define _OTboolnop      1
-#endif
+
 #define OTbinary(op)    (optab1[op]&_OTbinary)
 #define OTunary(op)     (optab1[op]&_OTunary)
 #define OTleaf(op)      (!(optab1[op]&(_OTunary|_OTbinary)))
@@ -367,12 +362,8 @@ extern unsigned char optab1[OPMAX],optab2[OPMAX];
 #define OTdef(op)       (optab2[op]&_OTdef)
 #define OTae(op)        (optab2[op]&_OTae)
 #define OTexp(op)       (optab2[op]&_OTexp)
-#if TX86
 #define OTboolnop(op)   (optab3[op]&_OTboolnop)
 #define OTcalldef(op)   (OTcall(op) || (op) == OPstrcpy || (op) == OPstrcat || (op) == OPmemcpy)
-#else
-#define OTcalldef(op)   (OTcall(op))
-#endif
 
 /* Convert op= to op    */
 #define opeqtoop(opx)   ((opx) - OPaddass + OPadd)

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -36,17 +36,20 @@ int _binary[] =
          OPpostinc,OPpostdec,OPeq,OPaddass,OPminass,OPmulass,OPdivass,
          OPmodass,OPshrass,OPashrass,OPshlass,OPandass,OPxorass,OPorass,
          OPle,OPgt,OPlt,OPge,OPeqeq,OPne,OPparam,OPcall,OPcallns,OPcolon,OPcolon2,
-         OPbit,OPoutp,OPbrack,OParrowstar,OPmemcpy,OPmemcmp,OPmemset,
+         OPbit,OPbrack,OParrowstar,OPmemcpy,OPmemcmp,OPmemset,
          OPunord,OPlg,OPleg,OPule,OPul,OPuge,OPug,OPue,OPngt,OPnge,
          OPnlt,OPnle,OPord,OPnlg,OPnleg,OPnule,OPnul,OPnuge,OPnug,OPnue,
          OPinfo,OParray,OPfield,OPnewarray,OPmultinewarray,OPinstanceof,OPfinalinstanceof,
          OPcheckcast,OPpair,OPrpair,
          OPbt,OPbtc,OPbtr,OPbts,OPror,OProl,
-         OPscale,OPremquo,OPyl2x,OPyl2xp1,
+         OPremquo,
+#if TX86
+         OPoutp,OPscale,OPyl2x,OPyl2xp1,
+#endif
         };
 int _unary[] =
         {OPnot,OPcom,OPind,OPaddr,OPneg,OPuadd,
-         OPabs,OPsqrt,OPrndtol,OPsin,OPcos,OPrint,
+         OPabs,OPrndtol,OPrint,
          OPpreinc,OPpredec,
          OPbool,OPstrlen,OPnullcheck,
          OPb_8,OPs16_32,OPu16_32,OPd_s32,OPd_u32,
@@ -57,11 +60,14 @@ int _unary[] =
          OPd_s64,OPs64_d,OPd_u64,OPu64_d,OPld_u64,
          OP128_64,OPs64_128,OPu64_128,
          OPucall,OPucallns,OPstrpar,OPstrctor,OPu16_d,OPd_u16,
-         OPinp,OParrow,OPnegass,
+         OParrow,OPnegass,
          OPctor,OPdtor,OPsetjmp,OPvoid,OParraylength,
          OPbsf,OPbsr,OPbswap,
          OPddtor,
          OPvector,
+#if TX86
+         OPsqrt,OPsin,OPcos,OPinp,
+#endif
 #if TARGET_SEGMENTED
          OPvp_fp,OPcvp_fp,OPnp_fp,OPnp_f16p,OPf16p_np,OPoffset,
 #endif
@@ -108,10 +114,13 @@ int _sideff[] = {OPasm,OPucall,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,
                 OPcall,OPeq,OPstreq,OPpostinc,OPpostdec,
                 OPaddass,OPminass,OPmulass,OPdivass,OPmodass,OPandass,
                 OPorass,OPxorass,OPshlass,OPshrass,OPashrass,
-                OPinp,OPoutp,OPnegass,OPctor,OPdtor,OPmark,OPvoid,OPnewarray,
+                OPnegass,OPctor,OPdtor,OPmark,OPvoid,OPnewarray,
                 OPmultinewarray,OPcheckcast,OPnullcheck,
                 OPbtc,OPbtr,OPbts,
                 OPhalt,OPdctor,OPddtor,
+#if TX86
+                OPinp,OPoutp,
+#endif
                 };
 int _rtol[] = {OPeq,OPstreq,OPstrcpy,OPmemcpy,OPpostinc,OPpostdec,OPaddass,
                 OPminass,OPmulass,OPdivass,OPmodass,OPandass,
@@ -119,7 +128,7 @@ int _rtol[] = {OPeq,OPstreq,OPstrcpy,OPmemcpy,OPpostinc,OPpostdec,OPaddass,
                 OPcall,OPcallns,OPinfo,OPmemset,
                 };
 int _ae[] = {OPvar,OPconst,OPrelconst,OPneg,
-                OPabs,OPsqrt,OPrndtol,OPsin,OPcos,OPrint,OPscale,
+                OPabs,OPrndtol,OPrint,
                 OPstrlen,OPstrcmp,OPind,OPaddr,
                 OPnot,OPbool,OPcom,OPadd,OPmin,OPmul,OPand,OPor,OPmemcmp,
                 OPxor,OPdiv,OPmod,OPshl,OPshr,OPashr,OPeqeq,OPne,OPle,OPlt,OPge,OPgt,
@@ -138,12 +147,14 @@ int _ae[] = {OPvar,OPconst,OPrelconst,OPneg,
                 OPgot,OPremquo,
                 OPnullptr,
                 OProl,OPror,
+#if TX86
+                OPsqrt,OPsin,OPcos,OPscale,
+#endif
 #if TARGET_SEGMENTED
                 OPvp_fp,OPcvp_fp,OPnp_fp,OPnp_f16p,OPf16p_np,OPoffset,
 #endif
                 };
-int _exp[] = {OPvar,OPconst,OPrelconst,OPneg,OPabs,OPsqrt,OPrndtol,OPrint,
-                OPsin,OPcos,OPscale,OPyl2x,OPyl2xp1,
+int _exp[] = {OPvar,OPconst,OPrelconst,OPneg,OPabs,OPrndtol,OPrint,
                 OPstrlen,OPstrcmp,OPind,OPaddr,
                 OPnot,OPbool,OPcom,OPadd,OPmin,OPmul,OPand,OPor,OPstring,
                 OPxor,OPdiv,OPmod,OPshl,OPshr,OPashr,OPeqeq,OPne,OPle,OPlt,OPge,OPgt,
@@ -166,6 +177,9 @@ int _exp[] = {OPvar,OPconst,OPrelconst,OPneg,OPabs,OPsqrt,OPrndtol,OPrint,
                 OProl,OPror,OPvector,
                 OPpair,OPrpair,OPframeptr,OPgot,OPremquo,
                 OPcolon,OPcolon2,OPasm,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,OPnegass,
+#if TX86
+                OPsqrt,OPsin,OPcos,OPscale,OPyl2x,OPyl2xp1,
+#endif
 #if TARGET_SEGMENTED
                 OPvp_fp,OPcvp_fp,OPoffset,OPnp_fp,OPnp_f16p,OPf16p_np,
 #endif
@@ -444,8 +458,10 @@ void dotab()
         case OPxor:     X("^",          elxor,  cdorth);
         case OPstring:  X("string",     elstring,cderr);
         case OPrelconst: X("relconst",  elzot, cdrelconst);
+#if TX86
         case OPinp:     X("inp",        elzot, cdport);
         case OPoutp:    X("outp",       elzot, cdport);
+#endif
         case OPasm:     X("asm",        elzot, cdasm);
         case OPinfo:    X("info",       elinfo,cdinfo);
         case OPdctor:   X("dctor",      elzot, cddctor);
@@ -484,14 +500,16 @@ void dotab()
         case OPneg:     X("-",          elneg,  cdneg);
         case OPuadd:    X("+",          elzot,  cderr);
         case OPabs:     X("abs",        evalu8, cdabs);
+#if TX86
         case OPsqrt:    X("sqrt",       evalu8, cdneg);
         case OPsin:     X("sin",        evalu8, cdneg);
         case OPcos:     X("cos",        evalu8, cdneg);
-        case OPrint:    X("rint",       evalu8, cdneg);
-        case OPrndtol:  X("rndtol",     evalu8, cdrndtol);
         case OPscale:   X("scale",      elzot,  cdscale);
         case OPyl2x:    X("yl2x",       elzot,  cdscale);
         case OPyl2xp1:  X("yl2xp1",     elzot,  cdscale);
+#endif
+        case OPrint:    X("rint",       evalu8, cdneg);
+        case OPrndtol:  X("rndtol",     evalu8, cdrndtol);
         case OPstrlen:  X("strlen",     elzot,  cdstrlen);
         case OPstrcpy:  X("strcpy",     elstrcpy,cdstrcpy);
         case OPmemcpy:  X("memcpy",     elmemxxx,cdmemcpy);
@@ -661,14 +679,22 @@ void fltables()
 
         static char indatafl[] =        /* is FLxxxx a data type?       */
         { FLdata,FLudata,FLreg,FLpseudo,FLauto,FLpara,FLextern,FLtmp,
-          FLcs,FLfltreg,FLallocatmp,FLdatseg,FLndp,FLtlsdata,FLbprel,
-          FLstack,FLregsave };
+          FLcs,FLfltreg,FLallocatmp,FLdatseg,FLtlsdata,FLbprel,
+          FLstack,FLregsave,
+#if TX86
+          FLndp,
+#endif
+        };
 #if TARGET_SEGMENTED
         static char indatafl_s[] = { FLfardata, };
 #endif
 
         static char instackfl[] =       /* is FLxxxx a stack data type? */
-        { FLauto,FLpara,FLtmp,FLcs,FLfltreg,FLallocatmp,FLndp,FLbprel,FLstack,FLregsave };
+        { FLauto,FLpara,FLtmp,FLcs,FLfltreg,FLallocatmp,FLbprel,FLstack,FLregsave,
+#if TX86
+          FLndp,
+#endif
+        };
 
         static char inflinsymtab[] =    /* is FLxxxx in the symbol table? */
         { FLdata,FLudata,FLreg,FLpseudo,FLauto,FLpara,FLextern,FLtmp,FLfunc,
@@ -725,7 +751,9 @@ void fltables()
                 case FLblockoff: segfl[i] = CS; break;
                 case FLcs:      segfl[i] = SS;  break;
                 case FLregsave: segfl[i] = SS;  break;
+#if TX86
                 case FLndp:     segfl[i] = SS;  break;
+#endif
                 case FLswitch:  segfl[i] = -1;  break;
                 case FLfltreg:  segfl[i] = SS;  break;
                 case FLoffset:  segfl[i] = -1;  break;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -269,6 +269,7 @@ if (I32) assert(tysize[TYnptr] == 4);
             ep->Eoper = op;
             ep->Ety = tyret;
             e = ep;
+#if TX86
             if (op == OPscale)
             {
                 elem *et = e->E1;
@@ -282,6 +283,7 @@ if (I32) assert(tysize[TYnptr] == 4);
                 e->E1 = e->E2;
                 e->E2 = et;
             }
+#endif
         }
         else
             e = el_una(op,tyret,ep);


### PR DESCRIPTION
FLndp is only defined on TX86
OPsin, OPcos, OPsqrt, OPscale, OPyl2x, OPyl2xp1 are hidden behind TX86
OPOPrndtol, OPrint aren't

Also drop some TX86's around code that's not X86 specific in related code
