### PR TITLE
Issue 7983 - ICE with getMember on a unittest member

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -3948,17 +3948,14 @@ void UnitTestDeclaration::semantic(Scope *sc)
         scope = NULL;
     }
 
-    if (global.params.useUnitTests)
-    {
-        if (!type)
-            type = new TypeFunction(NULL, Type::tvoid, FALSE, LINKd);
-        Scope *sc2 = sc->push();
-        // It makes no sense for unit tests to be pure or nothrow.
-        sc2->stc &= ~(STCnothrow | STCpure);
-        sc2->linkage = LINKd;
-        FuncDeclaration::semantic(sc2);
-        sc2->pop();
-    }
+    if (!type)
+        type = new TypeFunction(NULL, Type::tvoid, FALSE, LINKd);
+    Scope *sc2 = sc->push();
+    // It makes no sense for unit tests to be pure or nothrow.
+    sc2->stc &= ~(STCnothrow | STCpure);
+    sc2->linkage = LINKd;
+    FuncDeclaration::semantic(sc2);
+    sc2->pop();
 
 #if 0
     // We're going to need ModuleInfo even if the unit tests are not

--- a/src/template.c
+++ b/src/template.c
@@ -465,7 +465,7 @@ void TemplateDeclaration::semantic(Scope *sc)
     }
 
 #if DMDV2
-    if (/*global.params.useUnitTests &&*/ sc->module)
+    if (sc->module)
     {
         // Generate this function as it may be used
         // when template is instantiated in other modules

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5032,6 +5032,23 @@ class B1175 : A1175
 }
 
 /***************************************************/
+// 7983
+
+void test7983()
+{
+    class A
+    {
+        unittest {}
+    }
+    A a;
+
+    foreach (name; __traits(allMembers, A))
+    {
+        static if (__traits(compiles, &__traits(getMember, a, name))) {}
+    }
+}
+
+/***************************************************/
 
 int main()
 {
@@ -5263,6 +5280,7 @@ int main()
     test7871();
     test7906();
     test7907();
+    test7983();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7983

Front-end should not switch its semantic process by global.params.useUnitTests.
