### PR TITLE
Add deprecation() to print deprecation messages

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -216,10 +216,8 @@ const char *Dsymbol::toPrettyChars()
     return s;
 }
 
-char *Dsymbol::locToChars()
+Loc& Dsymbol::getLoc()
 {
-    OutBuffer buf;
-
     if (!loc.filename)  // avoid bug 5861.
     {
         Module *m = getModule();
@@ -227,7 +225,12 @@ char *Dsymbol::locToChars()
         if (m && m->srcfile)
             loc.filename = m->srcfile->toChars();
     }
-    return loc.toChars();
+    return loc;
+}
+
+char *Dsymbol::locToChars()
+{
+    return getLoc().toChars();
 }
 
 const char *Dsymbol::kind()
@@ -598,17 +601,9 @@ int Dsymbol::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
 
 void Dsymbol::error(const char *format, ...)
 {
-    //printf("Dsymbol::error()\n");
-    if (!loc.filename)  // avoid bug 5861.
-    {
-        Module *m = getModule();
-
-        if (m && m->srcfile)
-            loc.filename = m->srcfile->toChars();
-    }
     va_list ap;
     va_start(ap, format);
-    verror(loc, format, ap, kind(), toPrettyChars());
+    ::verror(getLoc(), format, ap, kind(), toPrettyChars());
     va_end(ap);
 }
 
@@ -616,7 +611,23 @@ void Dsymbol::error(Loc loc, const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);
-    verror(loc, format, ap, kind(), toPrettyChars());
+    ::verror(loc, format, ap, kind(), toPrettyChars());
+    va_end(ap);
+}
+
+void Dsymbol::deprecation(Loc loc, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    ::vdeprecation(loc, format, ap, kind(), toPrettyChars());
+    va_end(ap);
+}
+
+void Dsymbol::deprecation(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    ::vdeprecation(getLoc(), format, ap, kind(), toPrettyChars());
     va_end(ap);
 }
 
@@ -640,7 +651,7 @@ void Dsymbol::checkDeprecated(Loc loc, Scope *sc)
                 goto L1;
         }
 
-        error(loc, "is deprecated");
+        deprecation(loc, "is deprecated");
     }
 
   L1:
@@ -1240,8 +1251,8 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
     {   VarDeclaration **pvar;
         Expression *ce;
 
-        if (ident == Id::length && !global.params.useDeprecated)
-            error("using 'length' inside [ ] is deprecated, use '$' instead");
+        if (ident == Id::length)
+            deprecation("using 'length' inside [ ] is deprecated, use '$' instead");
 
     L1:
 

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -126,11 +126,14 @@ struct Dsymbol : Object
     Dsymbol();
     Dsymbol(Identifier *);
     char *toChars();
+    Loc& getLoc();
     char *locToChars();
     int equals(Object *o);
     int isAnonymous();
     void error(Loc loc, const char *format, ...);
     void error(const char *format, ...);
+    void deprecation(Loc loc, const char *format, ...);
+    void deprecation(const char *format, ...);
     void checkDeprecated(Loc loc, Scope *sc);
     Module *getModule();
     Module *getAccessModule();

--- a/src/expression.c
+++ b/src/expression.c
@@ -1467,6 +1467,17 @@ void Expression::warning(const char *format, ...)
     }
 }
 
+void Expression::deprecation(const char *format, ...)
+{
+    if (type != Type::terror)
+    {
+        va_list ap;
+        va_start(ap, format);
+        ::vdeprecation(loc, format, ap);
+        va_end( ap );
+    }
+}
+
 int Expression::rvalue()
 {
     if (type && type->toBasetype()->ty == Tvoid)
@@ -5459,7 +5470,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                         (s2 = scx->scopesym->symtab->lookup(s->ident)) != NULL &&
                         s != s2)
                     {
-                        error("shadowing declaration %s is deprecated", s->toPrettyChars());
+                        error("shadowing declaration %s is not allowed", s->toPrettyChars());
                         return new ErrorExp();
                     }
                 }
@@ -5743,8 +5754,7 @@ Expression *IsExp::semantic(Scope *sc)
                 break;
 
             case TOKinvariant:
-                if (!global.params.useDeprecated)
-                    error("use of 'invariant' rather than 'immutable' is deprecated");
+                deprecation("use of 'invariant' rather than 'immutable' is deprecated");
             case TOKimmutable:
                 if (!targ->isImmutable())
                     goto Lno;
@@ -8619,8 +8629,7 @@ Expression *PtrExp::semantic(Scope *sc)
 
             case Tsarray:
             case Tarray:
-                if (!global.params.useDeprecated)
-                    error("using * on an array is deprecated; use *(%s).ptr instead", e1->toChars());
+                deprecation("using * on an array is deprecated; use *(%s).ptr instead", e1->toChars());
                 type = ((TypeArray *)tb)->next;
                 e1 = e1->castTo(sc, type->pointerTo());
                 break;
@@ -8910,9 +8919,7 @@ Expression *DeleteExp::semantic(Scope *sc)
         IndexExp *ae = (IndexExp *)(e1);
         Type *tb1 = ae->e1->type->toBasetype();
         if (tb1->ty == Taarray)
-        {   if (!global.params.useDeprecated)
-                error("delete aa[key] deprecated, use aa.remove(key)");
-        }
+            deprecation("delete aa[key] deprecated, use aa.remove(key)");
     }
 
     return this;

--- a/src/expression.h
+++ b/src/expression.h
@@ -118,6 +118,7 @@ struct Expression : Object
     virtual void dump(int indent);
     void error(const char *format, ...);
     void warning(const char *format, ...);
+    void deprecation(const char *format, ...);
     virtual int rvalue();
 
     static Expression *combine(Expression *e1, Expression *e2);

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4236,8 +4236,7 @@ STATIC OPND *asm_una_exp()
                     // Check for offset keyword
                     if (asmtok->ident == Id::offset)
                     {
-                        if (!global.params.useDeprecated)
-                            error(asmstate.loc, "offset deprecated, use offsetof");
+                        deprecation(asmstate.loc, "offset deprecated, use offsetof");
                         goto Loffset;
                     }
                     if (asmtok->ident == Id::offsetof)

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -315,6 +315,14 @@ void Lexer::error(Loc loc, const char *format, ...)
     va_end(ap);
 }
 
+void Lexer::deprecation(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    ::vdeprecation(tokenLoc(), format, ap);
+    va_end(ap);
+}
+
 TOK Lexer::nextToken()
 {   Token *t;
 
@@ -570,8 +578,7 @@ void Lexer::scan(Token *t)
                 t->postfix = 0;
                 t->value = TOKstring;
 #if DMDV2
-                if (!global.params.useDeprecated)
-                    error("Escape String literal %.*s is deprecated, use double quoted string literal \"%.*s\" instead", p - pstart, pstart, p - pstart, pstart);
+                deprecation("Escape String literal %.*s is deprecated, use double quoted string literal \"%.*s\" instead", p - pstart, pstart, p - pstart, pstart);
 #endif
                 return;
             }
@@ -2141,8 +2148,7 @@ done:
                 goto L1;
 
             case 'l':
-                if (1 || !global.params.useDeprecated)
-                    error("'l' suffix is deprecated, use 'L' instead");
+                error("'l' is not a valid suffix, did you mean 'L'?");
             case 'L':
                 f = FLAGS_long;
             L1:
@@ -2158,8 +2164,8 @@ done:
     }
 
 #if DMDV2
-    if (state == STATE_octal && n >= 8 && !global.params.useDeprecated)
-        error("octal literals 0%llo%.*s are deprecated, use std.conv.octal!%llo%.*s instead",
+    if (state == STATE_octal && n >= 8)
+        deprecation("octal literals 0%llo%.*s are deprecated, use std.conv.octal!%llo%.*s instead",
                 n, p - psuffix, psuffix, n, p - psuffix, psuffix);
 #endif
 
@@ -2393,8 +2399,7 @@ done:
             break;
 
         case 'l':
-            if (!global.params.useDeprecated)
-                error("'l' suffix is deprecated, use 'L' instead");
+            deprecation("'l' suffix is deprecated, use 'L' instead");
         case 'L':
             result = TOKfloat80v;
             p++;
@@ -2402,8 +2407,8 @@ done:
     }
     if (*p == 'i' || *p == 'I')
     {
-        if (!global.params.useDeprecated && *p == 'I')
-            error("'I' suffix is deprecated, use 'i' instead");
+        if (*p == 'I')
+            deprecation("'I' suffix is deprecated, use 'i' instead");
         p++;
         switch (result)
         {

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -307,6 +307,7 @@ struct Lexer
     TOK inreal(Token *t);
     void error(const char *format, ...);
     void error(Loc loc, const char *format, ...);
+    void deprecation(const char *format, ...);
     void poundLine();
     unsigned decodeUTF();
     void getDocComment(Token *t, unsigned lineComment);

--- a/src/mars.c
+++ b/src/mars.c
@@ -192,33 +192,51 @@ void errorSupplemental(Loc loc, const char *format, ...)
     va_end( ap );
 }
 
-void verror(Loc loc, const char *format, va_list ap, const char *p1, const char *p2)
+void deprecation(Loc loc, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vdeprecation(loc, format, ap);
+
+    va_end( ap );
+}
+
+// Just print, doesn't care about gagging
+void verrorPrint(Loc loc, const char *header, const char *format, va_list ap,
+		const char *p1, const char *p2)
+{
+    char *p = loc.toChars();
+
+    if (*p)
+        fprintf(stdmsg, "%s: ", p);
+    mem.free(p);
+
+    fputs(header, stdmsg);
+    if (p1)
+        fprintf(stdmsg, "%s ", p1);
+    if (p2)
+        fprintf(stdmsg, "%s ", p2);
+#if _MSC_VER
+    // MS doesn't recognize %zu format
+    OutBuffer tmp;
+    tmp.vprintf(format, ap);
+    fprintf(stdmsg, "%s", tmp.toChars());
+#else
+    vfprintf(stdmsg, format, ap);
+#endif
+    fprintf(stdmsg, "\n");
+    fflush(stdmsg);
+}
+
+// header is "Error: " by default (see mars.h)
+void verror(Loc loc, const char *format, va_list ap,
+		const char *p1, const char *p2, const char *header)
 {
     if (!global.gag)
     {
-        char *p = loc.toChars();
-
-        if (*p)
-            fprintf(stdmsg, "%s: ", p);
-        mem.free(p);
-
-        fprintf(stdmsg, "Error: ");
-        if (p1)
-            fprintf(stdmsg, "%s ", p1);
-        if (p2)
-            fprintf(stdmsg, "%s ", p2);
-#if _MSC_VER
-        // MS doesn't recognize %zu format
-        OutBuffer tmp;
-        tmp.vprintf(format, ap);
-        fprintf(stdmsg, "%s", tmp.toChars());
-#else
-        vfprintf(stdmsg, format, ap);
-#endif
-        fprintf(stdmsg, "\n");
-        fflush(stdmsg);
-        if (global.errors >= 20)        // moderate blizzard of cascading messages
-            fatal();
+        verrorPrint(loc, header, format, ap, p1, p2);
+	if (global.errors >= 20)        // moderate blizzard of cascading messages
+		fatal();
 //halt();
     }
     else
@@ -232,46 +250,25 @@ void verror(Loc loc, const char *format, va_list ap, const char *p1, const char 
 void verrorSupplemental(Loc loc, const char *format, va_list ap)
 {
     if (!global.gag)
-    {
-        fprintf(stdmsg, "%s:        ", loc.toChars());
-#if _MSC_VER
-        // MS doesn't recognize %zu format
-        OutBuffer tmp;
-        tmp.vprintf(format, ap);
-        fprintf(stdmsg, "%s", tmp.toChars());
-#else
-        vfprintf(stdmsg, format, ap);
-#endif
-        fprintf(stdmsg, "\n");
-        fflush(stdmsg);
-    }
+        verrorPrint(loc, "       ", format, ap);
 }
 
 void vwarning(Loc loc, const char *format, va_list ap)
 {
     if (global.params.warnings && !global.gag)
     {
-        char *p = loc.toChars();
-
-        if (*p)
-            fprintf(stdmsg, "%s: ", p);
-        mem.free(p);
-
-        fprintf(stdmsg, "Warning: ");
-#if _MSC_VER
-        // MS doesn't recognize %zu format
-        OutBuffer tmp;
-        tmp.vprintf(format, ap);
-        fprintf(stdmsg, "%s", tmp.toChars());
-#else
-        vfprintf(stdmsg, format, ap);
-#endif
-        fprintf(stdmsg, "\n");
-        fflush(stdmsg);
+        verrorPrint(loc, "Warning: ", format, ap);
 //halt();
         if (global.params.warnings == 1)
             global.warnings++;  // warnings don't count if gagged
     }
+}
+
+void vdeprecation(Loc loc, const char *format, va_list ap,
+		const char *p1, const char *p2)
+{
+    if (!global.params.useDeprecated)
+        verror(loc, format, ap, p1, p2, "Deprecation: ");
 }
 
 /***************************************

--- a/src/mars.h
+++ b/src/mars.h
@@ -424,11 +424,14 @@ typedef uint64_t StorageClass;
 
 
 void warning(Loc loc, const char *format, ...);
+void deprecation(Loc loc, const char *format, ...);
 void error(Loc loc, const char *format, ...);
 void errorSupplemental(Loc loc, const char *format, ...);
-void verror(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
+void verror(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
 void vwarning(Loc loc, const char *format, va_list);
-void verrorSupplemental(Loc loc, const char *format, va_list);
+void verrorSupplemental(Loc loc, const char *format, va_list ap);
+void verrorPrint(Loc loc, const char *header, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
+void vdeprecation(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
 void fatal();
 void err_nomem();
 int runLINK();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1950,8 +1950,7 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
     }
     else if (ident == Id::typeinfo)
     {
-        if (!global.params.useDeprecated)
-            error(loc, ".typeinfo deprecated, use typeid(type)");
+        deprecation(loc, ".typeinfo deprecated, use typeid(type)");
         e = getTypeInfo(NULL);
     }
     else if (ident == Id::init)
@@ -2021,8 +2020,7 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
     {
         if (ident == Id::offset)
         {
-            if (!global.params.useDeprecated)
-                error(e->loc, ".offset deprecated, use .offsetof");
+            deprecation(e->loc, ".offset deprecated, use .offsetof");
             goto Loffset;
         }
         else if (ident == Id::offsetof)
@@ -2048,8 +2046,7 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
     }
     if (ident == Id::typeinfo)
     {
-        if (!global.params.useDeprecated)
-            error(e->loc, ".typeinfo deprecated, use typeid(type)");
+        deprecation(e->loc, ".typeinfo deprecated, use typeid(type)");
         e = getTypeInfo(sc);
     }
     else if (ident == Id::stringof)
@@ -8390,8 +8387,7 @@ L1:
 
         if (ident == Id::typeinfo)
         {
-            if (!global.params.useDeprecated)
-                error(e->loc, ".typeinfo deprecated, use typeid(type)");
+            deprecation(e->loc, ".typeinfo deprecated, use typeid(type)");
             return getTypeInfo(sc);
         }
         if (ident == Id::outer && sym->vthis)

--- a/src/parse.c
+++ b/src/parse.c
@@ -263,8 +263,7 @@ Dsymbols *Parser::parseDeclDefs(int once)
                 }
                 else
                 {
-                    if (!global.params.useDeprecated)
-                        error("use of 'invariant' rather than 'immutable' is deprecated");
+                    deprecation("use of 'invariant' rather than 'immutable' is deprecated");
                     stc = STCimmutable;
                     goto Lstc;
                 }
@@ -407,8 +406,8 @@ Dsymbols *Parser::parseDeclDefs(int once)
                             stc = STCwild;
                         else
                         {
-                            if (token.value == TOKinvariant && !global.params.useDeprecated)
-                                error("use of 'invariant' rather than 'immutable' is deprecated");
+                            if (token.value == TOKinvariant)
+                                deprecation("use of 'invariant' rather than 'immutable' is deprecated");
                             stc = STCimmutable;
                         }
                         goto Lstc;
@@ -708,8 +707,7 @@ StorageClass Parser::parsePostfix()
         {
             case TOKconst:              stc |= STCconst;                break;
             case TOKinvariant:
-                if (!global.params.useDeprecated)
-                    error("use of 'invariant' rather than 'immutable' is deprecated");
+                deprecation("use of 'invariant' rather than 'immutable' is deprecated");
             case TOKimmutable:          stc |= STCimmutable;            break;
             case TOKshared:             stc |= STCshared;               break;
             case TOKwild:               stc |= STCwild;                 break;
@@ -1316,8 +1314,8 @@ Parameters *Parser::parseParameters(int *pvarargs, TemplateParameters **tpl)
                 case TOKimmutable:
                     if (peek(&token)->value == TOKlparen)
                         goto Ldefault;
-                    if (token.value == TOKinvariant && !global.params.useDeprecated)
-                        error("use of 'invariant' rather than 'immutable' is deprecated");
+                    if (token.value == TOKinvariant)
+                        deprecation("use of 'invariant' rather than 'immutable' is deprecated");
                     stc = STCimmutable;
                     goto L2;
 
@@ -1712,8 +1710,8 @@ BaseClasses *Parser::parseBaseClasses()
                 nextToken();
                 break;
         }
-        if (prot && !global.params.useDeprecated)
-            error("use of base class protection is deprecated");
+        if (prot)
+            deprecation("use of base class protection is deprecated");
         if (token.value == TOKidentifier)
         {
             BaseClass *b = new BaseClass(parseBasicType(), protection);
@@ -2419,8 +2417,7 @@ Type *Parser::parseBasicType()
             break;
 
         case TOKinvariant:
-            if (!global.params.useDeprecated)
-                error("use of 'invariant' rather than 'immutable' is deprecated");
+            deprecation("use of 'invariant' rather than 'immutable' is deprecated");
         case TOKimmutable:
             // invariant(type)
             nextToken();
@@ -2589,10 +2586,7 @@ Type *Parser::parseDeclarator(Type *t, Identifier **pident, TemplateParameters *
                  * although the D style would be:
                  *  int[]*[3] ident
                  */
-                if (!global.params.useDeprecated)
-                {
-                    error("C-style function pointer and pointer to array syntax is deprecated. Use 'function' to declare function pointers");
-                }
+                deprecation("C-style function pointer and pointer to array syntax is deprecated. Use 'function' to declare function pointers");
                 nextToken();
                 ts = parseDeclarator(t, pident);
                 check(TOKrparen);
@@ -2764,8 +2758,7 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, unsigned char *c
             }
             break;
         case TOKtypedef:
-            if (!global.params.useDeprecated)
-                error("use of typedef is deprecated; use alias instead");
+            deprecation("use of typedef is deprecated; use alias instead");
             tok = token.value;
             nextToken();
             break;
@@ -2786,8 +2779,8 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, unsigned char *c
             case TOKimmutable:
                 if (peek(&token)->value == TOKlparen)
                     break;
-                if (token.value == TOKinvariant && !global.params.useDeprecated)
-                    error("use of 'invariant' rather than 'immutable' is deprecated");
+                if (token.value == TOKinvariant)
+                    deprecation("use of 'invariant' rather than 'immutable' is deprecated");
                 stc = STCimmutable;
                 goto L1;
 
@@ -2927,8 +2920,7 @@ L2:
             }
             if (tok == TOKtypedef)
             {   v = new TypedefDeclaration(loc, ident, t, init);
-                if (!global.params.useDeprecated)
-                    error("use of typedef is deprecated; use alias instead");
+                deprecation("use of typedef is deprecated; use alias instead");
             }
             else
             {   if (init)
@@ -3764,8 +3756,8 @@ Statement *Parser::parseStatement(int flags)
             check(TOKrparen);
             if (token.value == TOKsemicolon)
                 nextToken();
-            else if (!global.params.useDeprecated)
-                error("do-while statement requires terminating ;");
+            else
+                deprecation("do-while statement without terminating ; is deprecated");
             s = new DoStatement(loc, body, condition);
             break;
         }
@@ -3933,8 +3925,7 @@ Statement *Parser::parseStatement(int flags)
                     arg = new Parameter(0, NULL, token.ident, NULL);
                     nextToken();
                     nextToken();
-                    if (!global.params.useDeprecated)
-                        error("if (v%s e) is deprecated, use if (auto v = e)", t->toChars());
+                    deprecation("if (v%s e) is deprecated, use if (auto v = e)", t->toChars());
                 }
             }
 
@@ -4317,8 +4308,7 @@ Statement *Parser::parseStatement(int flags)
             nextToken();
             s = parseStatement(PSsemi | PScurlyscope);
 #if DMDV2
-            if (!global.params.useDeprecated)
-                error("volatile statements deprecated; use synchronized statements instead");
+            deprecation("volatile statements deprecated; used synchronized statements instead");
 #endif
             s = new VolatileStatement(loc, s);
             break;
@@ -5448,8 +5438,8 @@ Expression *Parser::parsePrimaryExp()
                          token.value == TOKdelegate ||
                          token.value == TOKreturn))
                     {
-                        if (token.value == TOKinvariant && !global.params.useDeprecated)
-                            error("use of 'invariant' rather than 'immutable' is deprecated");
+                        if (token.value == TOKinvariant)
+                            deprecation("use of 'invariant' rather than 'immutable' is deprecated");
                         tok2 = token.value;
                         nextToken();
                     }
@@ -5881,8 +5871,8 @@ Expression *Parser::parseUnaryExp()
             }
             else if ((token.value == TOKimmutable || token.value == TOKinvariant) && peekNext() == TOKrparen)
             {
-                if (token.value == TOKinvariant && !global.params.useDeprecated)
-                    error("use of 'invariant' rather than 'immutable' is deprecated");
+                if (token.value == TOKinvariant)
+                    deprecation("use of 'invariant' rather than 'immutable' is deprecated");
                 m = MODimmutable;
                 goto Lmod2;
             }

--- a/src/statement.c
+++ b/src/statement.c
@@ -117,6 +117,14 @@ void Statement::warning(const char *format, ...)
     va_end( ap );
 }
 
+void Statement::deprecation(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    ::vdeprecation(loc, format, ap);
+    va_end( ap );
+}
+
 int Statement::hasBreak()
 {
     //printf("Statement::hasBreak()\n");
@@ -3244,8 +3252,8 @@ Statement *SwitchStatement::semantic(Scope *sc)
     if (!sc->sw->sdefault && (!isFinal || needswitcherror))
     {   hasNoDefault = 1;
 
-        if (!global.params.useDeprecated && !isFinal)
-           error("non-final switch statement without a default is deprecated");
+        if (!isFinal)
+           deprecation("non-final switch statement without a default is deprecated");
 
         // Generate runtime error if the default is hit
         Statements *a = new Statements();

--- a/src/statement.h
+++ b/src/statement.h
@@ -92,6 +92,7 @@ struct Statement : Object
 
     void error(const char *format, ...);
     void warning(const char *format, ...);
+    void deprecation(const char *format, ...);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int incontract;
     virtual ScopeStatement *isScopeStatement() { return NULL; }

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -813,10 +813,10 @@ void ClassDeclaration::toObjFile(int multiobj)
                         {
                             TypeFunction *tf = (TypeFunction *)fd->type;
                             if (tf->ty == Tfunction)
-                                error("use of %s%s hidden by %s is deprecated", fd->toPrettyChars(),
+                                error("use of %s%s hidden by %s is not allowed", fd->toPrettyChars(),
                                       Parameter::argsTypesToChars(tf->parameters, tf->varargs), toChars());
                             else
-                                error("use of %s hidden by %s is deprecated", fd->toPrettyChars(), toChars());
+                                error("use of %s hidden by %s is not allowed", fd->toPrettyChars(), toChars());
                         }
                         s = rtlsym[RTLSYM_DHIDDENFUNC];
                         break;


### PR DESCRIPTION
The deprecation() function works similar to the error() or warning()
functions but only prints messages if global.params.useDeprecated is
false. If it is, it uses the error() function to actually print the
messages and halt the program.

This patch also tries to make the messages consistent with the
behaviour. Some messages said that some feature was deprecated when it
has been completely removed in reality and should be plain errors.
