### PR TITLE
Deprecation (dmd-1.x)

### DIFF
--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -124,11 +124,13 @@ struct Dsymbol : Object
     Dsymbol();
     Dsymbol(Identifier *);
     char *toChars();
+    Loc& getLoc();
     char *locToChars();
     int equals(Object *o);
     int isAnonymous();
     void error(Loc loc, const char *format, ...);
     void error(const char *format, ...);
+    void deprecation(Loc loc, const char *format, ...);
     void checkDeprecated(Loc loc, Scope *sc);
     Module *getModule();
     Dsymbol *pastMixin();

--- a/src/expression.c
+++ b/src/expression.c
@@ -1002,6 +1002,17 @@ void Expression::warning(const char *format, ...)
     }
 }
 
+void Expression::deprecation(const char *format, ...)
+{
+    if (type != Type::terror)
+    {
+        va_list ap;
+        va_start(ap, format);
+        ::vdeprecation(loc, format, ap);
+        va_end( ap );
+    }
+}
+
 int Expression::rvalue()
 {
     if (type && type->toBasetype()->ty == Tvoid)
@@ -4711,7 +4722,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                         (s2 = scx->scopesym->symtab->lookup(s->ident)) != NULL &&
                         s != s2)
                     {
-                        error("shadowing declaration %s is deprecated", s->toPrettyChars());
+                        deprecation("shadowing declaration %s is deprecated", s->toPrettyChars());
                     }
                 }
             }
@@ -7434,8 +7445,7 @@ Expression *PtrExp::semantic(Scope *sc)
 
             case Tsarray:
             case Tarray:
-                if (!global.params.useDeprecated)
-                    error("using * on an array is deprecated; use *(%s).ptr instead", e1->toChars());
+                deprecation("using * on an array is deprecated; use *(%s).ptr instead", e1->toChars());
                 type = ((TypeArray *)tb)->next;
                 e1 = e1->castTo(sc, type->pointerTo());
                 break;
@@ -7691,9 +7701,7 @@ Expression *DeleteExp::semantic(Scope *sc)
         IndexExp *ae = (IndexExp *)(e1);
         Type *tb1 = ae->e1->type->toBasetype();
         if (tb1->ty == Taarray)
-        {   if (!global.params.useDeprecated)
-                error("delete aa[key] deprecated, use aa.remove(key)");
-        }
+            deprecation("delete aa[key] deprecated, use aa.remove(key)");
     }
 
     return this;
@@ -8629,7 +8637,7 @@ Expression *AssignExp::semantic(Scope *sc)
                 {   Expression *e = new DotIdExp(loc, ae->e1, id);
 
                     if (1 || !global.params.useDeprecated)
-                    {   error("operator [] assignment overload with opIndex(i, value) illegal, use opIndexAssign(value, i)");
+                    {   deprecation("operator [] assignment overload with opIndex(i, value) illegal, use opIndexAssign(value, i)");
                         return new ErrorExp();
                     }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -111,6 +111,7 @@ struct Expression : Object
     virtual void dump(int indent);
     void error(const char *format, ...);
     void warning(const char *format, ...);
+    void deprecation(const char *format, ...);
     virtual int rvalue();
 
     static Expression *combine(Expression *e1, Expression *e2);

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4238,8 +4238,7 @@ STATIC OPND *asm_una_exp()
                     // Check for offset keyword
                     if (asmtok->ident == Id::offset)
                     {
-                        if (!global.params.useDeprecated)
-                            error(asmstate.loc, "offset deprecated, use offsetof");
+                        deprecation(asmstate.loc, "offset deprecated, use offsetof");
                         goto Loffset;
                     }
                     if (asmtok->ident == Id::offsetof)

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -314,6 +314,14 @@ void Lexer::error(Loc loc, const char *format, ...)
     va_end(ap);
 }
 
+void Lexer::deprecation(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    ::vdeprecation(tokenLoc(), format, ap);
+    va_end(ap);
+}
+
 TOK Lexer::nextToken()
 {   Token *t;
 
@@ -594,8 +602,7 @@ void Lexer::scan(Token *t)
                 t->postfix = 0;
                 t->value = TOKstring;
 #if DMDV2
-                if (!global.params.useDeprecated)
-                    error("Escape String literal %.*s is deprecated, use double quoted string literal \"%.*s\" instead", p - pstart, pstart, p - pstart, pstart);
+                deprecation("Escape String literal %.*s is deprecated, use double quoted string literal \"%.*s\" instead", p - pstart, pstart, p - pstart, pstart);
 #endif
                 return;
             }
@@ -2254,8 +2261,7 @@ done:
                 goto L1;
 
             case 'l':
-                if (1 || !global.params.useDeprecated)
-                    error("'l' suffix is deprecated, use 'L' instead");
+                deprecation("'l' suffix is deprecated, use 'L' instead");
             case 'L':
                 f = FLAGS_long;
             L1:
@@ -2271,8 +2277,8 @@ done:
     }
 
 #if DMDV2
-    if (state == STATE_octal && n >= 8 && !global.params.useDeprecated)
-        error("octal literals 0%llo%.*s are deprecated, use std.conv.octal!%llo%.*s instead",
+    if (state == STATE_octal && n >= 8)
+        deprecation("octal literals 0%llo%.*s are deprecated, use std.conv.octal!%llo%.*s instead",
                 n, p - psuffix, psuffix, n, p - psuffix, psuffix);
 #endif
 
@@ -2504,8 +2510,7 @@ done:
             break;
 
         case 'l':
-            if (!global.params.useDeprecated)
-                error("'l' suffix is deprecated, use 'L' instead");
+            deprecation("'l' suffix is deprecated, use 'L' instead");
         case 'L':
             result = TOKfloat80v;
             p++;
@@ -2513,8 +2518,8 @@ done:
     }
     if (*p == 'i' || *p == 'I')
     {
-        if (!global.params.useDeprecated && *p == 'I')
-            error("'I' suffix is deprecated, use 'i' instead");
+        if (*p == 'I')
+            deprecation("'I' suffix is deprecated, use 'i' instead");
         p++;
         switch (result)
         {

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -305,6 +305,7 @@ struct Lexer
     TOK inreal(Token *t);
     void error(const char *format, ...);
     void error(Loc loc, const char *format, ...);
+    void deprecation(const char *format, ...);
     void pragma();
     unsigned decodeUTF();
     void getDocComment(Token *t, unsigned lineComment);

--- a/src/mars.h
+++ b/src/mars.h
@@ -416,11 +416,14 @@ typedef uint64_t StorageClass;
 
 
 void warning(Loc loc, const char *format, ...);
+void deprecation(Loc loc, const char *format, ...);
 void error(Loc loc, const char *format, ...);
 void errorSupplemental(Loc loc, const char *format, ...);
-void verror(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
+void verror(Loc loc, const char *format, va_list, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
 void vwarning(Loc loc, const char *format, va_list);
 void verrorSupplemental(Loc loc, const char *format, va_list);
+void verrorPrint(Loc loc, const char *header, const char *format, va_list, const char *p1 = NULL, const char *p2 = NULL);
+void vdeprecation(Loc loc, const char *format, va_list, const char *p1 = NULL, const char *p2 = NULL);
 void fatal();
 void err_nomem();
 int runLINK();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -626,8 +626,7 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
     }
     else if (ident == Id::typeinfo)
     {
-        if (!global.params.useDeprecated)
-            error(loc, ".typeinfo deprecated, use typeid(type)");
+        deprecation(loc, ".typeinfo deprecated, use typeid(type)");
         e = getTypeInfo(NULL);
     }
     else if (ident == Id::init)
@@ -695,8 +694,7 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
     {
         if (ident == Id::offset)
         {
-            if (!global.params.useDeprecated)
-                error(e->loc, ".offset deprecated, use .offsetof");
+            deprecation(e->loc, ".offset deprecated, use .offsetof");
             goto Loffset;
         }
         else if (ident == Id::offsetof)
@@ -745,8 +743,7 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
     }
     if (ident == Id::typeinfo)
     {
-        if (!global.params.useDeprecated)
-            error(e->loc, ".typeinfo deprecated, use typeid(type)");
+        deprecation(e->loc, ".typeinfo deprecated, use typeid(type)");
         e = getTypeInfo(sc);
         return e;
     }
@@ -5049,8 +5046,7 @@ L1:
 
         if (ident == Id::typeinfo)
         {
-            if (!global.params.useDeprecated)
-                error(e->loc, ".typeinfo deprecated, use typeid(type)");
+            deprecation(e->loc, ".typeinfo deprecated, use typeid(type)");
             return getTypeInfo(sc);
         }
         if (ident == Id::outer && sym->vthis)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1326,8 +1326,8 @@ BaseClasses *Parser::parseBaseClasses()
                 nextToken();
                 break;
         }
-        //if (prot && !global.params.useDeprecated)
-            //error("use of base class protection is deprecated");
+        //if (prot)
+            //deprecation("use of base class protection is deprecated");
         if (token.value == TOKidentifier)
         {
             BaseClass *b = new BaseClass(parseBasicType(), protection);
@@ -3221,8 +3221,7 @@ Statement *Parser::parseStatement(int flags)
                     arg = new Parameter(STCin, NULL, token.ident, NULL);
                     nextToken();
                     nextToken();
-                    if (1 || !global.params.useDeprecated)
-                        error("if (v; e) is deprecated, use if (auto v = e)");
+                    deprecation("if (v; e) is deprecated, use if (auto v = e)");
                 }
             }
 
@@ -3575,8 +3574,7 @@ Statement *Parser::parseStatement(int flags)
             nextToken();
             s = parseStatement(PSsemi | PScurlyscope);
 #if DMDV2
-            if (!global.params.useDeprecated)
-                error("volatile statements deprecated; used synchronized statements instead");
+            deprecation("volatile statements deprecated; used synchronized statements instead");
 #endif
             s = new VolatileStatement(loc, s);
             break;

--- a/src/statement.c
+++ b/src/statement.c
@@ -116,6 +116,14 @@ void Statement::warning(const char *format, ...)
     va_end( ap );
 }
 
+void Statement::deprecation(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    ::vdeprecation(loc, format, ap);
+    va_end( ap );
+}
+
 int Statement::hasBreak()
 {
     //printf("Statement::hasBreak()\n");

--- a/src/statement.h
+++ b/src/statement.h
@@ -92,6 +92,7 @@ struct Statement : Object
 
     void error(const char *format, ...);
     void warning(const char *format, ...);
+    void deprecation(const char *format, ...);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual TryCatchStatement *isTryCatchStatement() { return NULL; }
     virtual GotoStatement *isGotoStatement() { return NULL; }


### PR DESCRIPTION
The deprecation() function works similar to the error() or warning()
functions but only prints messages if global.params.useDeprecated is
false. If it is, it uses the error() function to actually print the
messages and halt the program.

This patch also tries to make the messages consistent with the
behaviour. Some messages said that some feature was deprecated when it
has been completely removed in reality and should be plain errors.
