### PR TITLE
7987 [CTFE] cannot compare arrays of slices, + improve speed

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -793,7 +793,7 @@ struct BinExp : Expression
     Expression *interpretCommon(InterState *istate, CtfeGoal goal,
         Expression *(*fp)(Type *, Expression *, Expression *));
     Expression *interpretCommon2(InterState *istate, CtfeGoal goal,
-        Expression *(*fp)(TOK, Type *, Expression *, Expression *));
+        Expression *(*fp)(Loc, TOK, Type *, Expression *, Expression *));
     Expression *interpretAssignCommon(InterState *istate, CtfeGoal goal,
         Expression *(*fp)(Type *, Expression *, Expression *), int post = 0);
     Expression *arrayOp(Scope *sc);
@@ -1709,6 +1709,9 @@ Expression *Slice(Type *type, Expression *e1, Expression *lwr, Expression *upr);
 void sliceAssignArrayLiteralFromString(ArrayLiteralExp *existingAE, StringExp *newval, int firstIndex);
 void sliceAssignStringFromArrayLiteral(StringExp *existingSE, ArrayLiteralExp *newae, int firstIndex);
 void sliceAssignStringFromString(StringExp *existingSE, StringExp *newstr, int firstIndex);
+
+int sliceCmpStringWithString(StringExp *se1, StringExp *se2, size_t lo1, size_t lo2, size_t len);
+int sliceCmpStringWithArray(StringExp *se1, ArrayLiteralExp *ae2, size_t lo1, size_t lo2, size_t len);
 
 
 #endif /* DMD_EXPRESSION_H */

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -27,6 +27,8 @@
 #include "attrib.h" // for AttribDeclaration
 
 #include "template.h"
+#include "port.h"
+int RealEquals(real_t x1, real_t x2);
 
 
 #define LOG     0
@@ -221,6 +223,7 @@ Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
 Expression *scrubReturnValue(Loc loc, Expression *e);
 bool isAssocArray(Type *t);
 bool isPointer(Type *t);
+Expression *ctfeEqual(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2);
 
 // CTFE only expressions
 #define TOKclassreference ((TOK)(TOKMAX+1))
@@ -950,19 +953,6 @@ uinteger_t resolveArrayLength(Expression *e)
     }
     assert(0);
     return 0;
-}
-
-// As Equal, but resolves slices before comparing
-Expression *ctfeEqual(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2)
-{
-    if (e1->op == TOKslice)
-        e1 = resolveSlice(e1);
-    if (e2->op == TOKslice)
-        e2 = resolveSlice(e2);
-    Expression *e = Equal(op, type, e1, e2);
-    if (e == EXP_CANT_INTERPRET)
-        error(loc, "cannot evaluate %s==%s at compile time", e1->toChars(), e2->toChars());
-    return e;
 }
 
 Expression *ctfeCat(Type *type, Expression *e1, Expression *e2)
@@ -2857,7 +2847,7 @@ BIN_INTERPRET(Pow)
 #endif
 
 
-typedef Expression *(*fp2_t)(enum TOK, Type *, Expression *, Expression *);
+typedef Expression *(*fp2_t)(Loc loc, enum TOK, Type *, Expression *, Expression *);
 
 // Return EXP_CANT_INTERPRET if they point to independent memory blocks
 Expression *comparePointers(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2)
@@ -2918,21 +2908,227 @@ Expression *comparePointers(Loc loc, enum TOK op, Type *type, Expression *e1, Ex
     return new IntegerExp(loc, cmp, type);
 }
 
-Expression *ctfeIdentity(enum TOK op, Type *type, Expression *e1, Expression *e2)
+
+int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2);
+
+/* Conceptually the same as memcmp(e1, e2).
+ * e1 and e2 may be strings, arrayliterals, or slices.
+ * For string types, return <0 if e1 < e2, 0 if e1==e2, >0 if e1 > e2.
+ * For all other types, return 0 if e1 == e2, !=0 if e1 != e2.
+ */
+int ctfeCmpArrays(Loc loc, Expression *e1, Expression *e2, uinteger_t len)
 {
-    if (e1->op == TOKclassreference || e2->op == TOKclassreference)
-    {
-        int cmp = 0;
-        if (e1->op == TOKclassreference && e2->op == TOKclassreference &&
-            ((ClassReferenceExp *)e1)->value == ((ClassReferenceExp *)e2)->value)
-            cmp = 1;
-        if (op == TOKnotidentity || op == TOKnotequal)
-            cmp ^= 1;
-        return new IntegerExp(e1->loc, cmp, type);
+    // Resolve slices, if necessary
+    uinteger_t lo1 = 0;
+    uinteger_t lo2 = 0;
+
+    Expression *x = e1;
+    if (x->op == TOKslice)
+    {   lo1 = ((SliceExp *)x)->lwr->toInteger();
+        x = ((SliceExp*)x)->e1;
     }
-    return Identity(op, type, e1, e2);
+    StringExp *se1 = (x->op == TOKstring) ? (StringExp *)x : 0;
+    ArrayLiteralExp *ae1 = (x->op == TOKarrayliteral) ? (ArrayLiteralExp *)x : 0;
+
+    x = e2;
+    if (x->op == TOKslice)
+    {   lo2 = ((SliceExp *)x)->lwr->toInteger();
+        x = ((SliceExp*)x)->e1;
+    }
+    StringExp *se2 = (x->op == TOKstring) ? (StringExp *)x : 0;
+    ArrayLiteralExp *ae2 = (x->op == TOKarrayliteral) ? (ArrayLiteralExp *)x : 0;
+
+    // Now both must be either TOKarrayliteral or TOKstring
+    if (se1 && se2)
+        return sliceCmpStringWithString(se1, se2, lo1, lo2, len);
+    if (se1 && ae2)
+        return sliceCmpStringWithArray(se1, ae2, lo1, lo2, len);
+    if (se2 && ae1)
+        return -sliceCmpStringWithArray(se2, ae1, lo2, lo1, len);
+
+    assert (ae1 && ae2);
+    // Comparing two array literals. This case is potentially recursive.
+    // If they aren't strings, we just need an equality check rather than
+    // a full cmp.
+    bool needCmp = ae1->type->nextOf()->isintegral();
+    for (size_t i = 0; i < len; i++)
+    {   Expression *ee1 = (*ae1->elements)[lo1 + i];
+        Expression *ee2 = (*ae2->elements)[lo2 + i];
+        if (needCmp)
+        {   int c = ee1->toInteger() - ee2->toInteger();
+            if (c)
+                return c;
+        }
+        else
+        {   if (ctfeRawCmp(loc, ee1, ee2))
+                return 1;
+        }
+    }
+    return 0;
 }
 
+bool isArray(Expression *e)
+{
+    return e->op == TOKarrayliteral || e->op == TOKstring ||
+           e->op == TOKslice || e->op == TOKnull;
+}
+
+/* For strings, return <0 if e1 < e2, 0 if e1==e2, >0 if e1 > e2.
+ * For all other types, return 0 if e1 == e2, !=0 if e1 != e2.
+ */
+int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2)
+{
+    if (e1->op == TOKclassreference || e2->op == TOKclassreference)
+    {   if (e1->op == TOKclassreference && e2->op == TOKclassreference &&
+            ((ClassReferenceExp *)e1)->value == ((ClassReferenceExp *)e2)->value)
+            return 0;
+        return 1;
+    }
+    if (e1->op == TOKnull && e2->op == TOKnull)
+        return 0;
+
+    if (e1->type->ty == Tpointer && e2->type->ty == Tpointer)
+    {    // Can only be an equality test.
+        if (e1->op == TOKnull && e2->op == TOKnull)
+            return 0;
+        dinteger_t ofs1, ofs2;
+        Expression *agg1 = getAggregateFromPointer(e1, &ofs1);
+        Expression *agg2 = getAggregateFromPointer(e2, &ofs2);
+        if ((agg1 == agg2) || (agg1->op == TOKvar && agg2->op == TOKvar &&
+            ((VarExp *)agg1)->var == ((VarExp *)agg2)->var))
+        {   if (ofs1 == ofs2)
+                return 0;
+        }
+        return 1;
+    }
+    if (isArray(e1) && isArray(e2))
+    {
+        uinteger_t len1 = resolveArrayLength(e1);
+        uinteger_t len2 = resolveArrayLength(e2);
+        if (len1 != len2) // only for equality
+            return len1 - len2;
+        if (len1 == 0 || len2 == 0)
+            return len1 - len2;  // Equal - both are empty
+        return ctfeCmpArrays(loc, e1, e2, len1);
+    }
+    if (e1->type->isintegral())
+    {
+        return e1->toInteger() - e2->toInteger();
+    }
+    real_t r1;
+    real_t r2;
+    if (e1->type->isreal())
+    {
+        r1 = e1->toReal();
+        r2 = e2->toReal();
+        goto L1;
+    }
+    else if (e1->type->isimaginary())
+    {
+        r1 = e1->toImaginary();
+        r2 = e2->toImaginary();
+     L1:
+#if __DMC__
+        return (r1 == r2);
+#else
+        if (Port::isNan(r1) || Port::isNan(r2)) // if unordered
+        {
+            return 1;
+        }
+        else
+        {
+            return (r1 != r2);
+        }
+#endif
+    }
+    else if (e1->type->iscomplex())
+    {
+        return e1->toComplex() != e2->toComplex();
+    }
+
+    if (e1->op == TOKstructliteral && e2->op == TOKstructliteral)
+    {   StructLiteralExp *es1 = (StructLiteralExp *)e1;
+        StructLiteralExp *es2 = (StructLiteralExp *)e2;
+        // For structs, we only need to return 0 or 1 (< and > aren't legal).
+
+        if (es1->sd != es2->sd)
+            return 1;
+        else if ((!es1->elements || !es1->elements->dim) &&
+            (!es2->elements || !es2->elements->dim))
+            return 0;            // both arrays are empty
+        else if (!es1->elements || !es2->elements)
+            return 1;
+        else if (es1->elements->dim != es2->elements->dim)
+            return 1;
+        else
+        {
+            for (size_t i = 0; i < es1->elements->dim; i++)
+            {   Expression *ee1 = (*es1->elements)[i];
+                Expression *ee2 = (*es2->elements)[i];
+
+                if (ee1 == ee2)
+                    continue;
+                if (!ee1 || !ee2)
+                   return 1;
+                int cmp = ctfeRawCmp(loc, ee1, ee2);
+                if (cmp)
+                    return 1;
+            }
+            return 0;   // All elements are equal
+        }
+    }
+    error(loc, "CTFE internal error: bad compare");
+    assert(0);
+}
+
+// As Equal, but resolves slices before comparing
+Expression *ctfeEqual(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2)
+{
+    int cmp = !ctfeRawCmp(loc, e1, e2);
+    if (op == TOKnotequal)
+        cmp ^= 1;
+    return new IntegerExp(loc, cmp, type);
+}
+
+Expression *ctfeIdentity(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2)
+{
+    int cmp;
+    if (e1->op == TOKnull)
+    {
+        cmp = (e2->op == TOKnull);
+    }
+    else if (e2->op == TOKnull)
+    {
+        cmp = 0;
+    }
+    else if (e1->op == TOKsymoff && e2->op == TOKsymoff)
+    {
+        SymOffExp *es1 = (SymOffExp *)e1;
+        SymOffExp *es2 = (SymOffExp *)e2;
+        cmp = (es1->var == es2->var && es1->offset == es2->offset);
+    }
+    else if (e1->type->isreal())
+        cmp = RealEquals(e1->toReal(), e2->toReal());
+    else if (e1->type->isimaginary())
+        cmp = RealEquals(e1->toImaginary(), e2->toImaginary());
+    else if (e1->type->iscomplex())
+    {   complex_t v1 = e1->toComplex();
+        complex_t v2 = e2->toComplex();
+        cmp = RealEquals(creall(v1), creall(v2)) &&
+                 RealEquals(cimagl(v1), cimagl(v1));
+    }
+    else
+        cmp = !ctfeRawCmp(loc, e1, e2);
+
+    if (op == TOKnotidentity || op == TOKnotequal)
+        cmp ^= 1;
+    return new IntegerExp(loc, cmp, type);
+}
+
+Expression *ctfeCmp(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2)
+{
+    return Cmp(op, type, e1, e2);
+}
 
 Expression *BinExp::interpretCommon2(InterState *istate, CtfeGoal goal, fp2_t fp)
 {   Expression *e;
@@ -2991,7 +3187,7 @@ Expression *BinExp::interpretCommon2(InterState *istate, CtfeGoal goal, fp2_t fp
         error("cannot compare %s at compile time", e2->toChars());
         goto Lcant;
     }
-    e = (*fp)(op, type, e1, e2);
+    e = (*fp)(loc, op, type, e1, e2);
     if (e == EXP_CANT_INTERPRET)
         error("%s cannot be interpreted at compile time", toChars());
     return e;
@@ -3006,9 +3202,9 @@ Expression *op##Exp::interpret(InterState *istate, CtfeGoal goal)  \
     return interpretCommon2(istate, goal, &opfunc);                \
 }
 
-BIN_INTERPRET2(Equal, Equal)
+BIN_INTERPRET2(Equal, ctfeEqual)
 BIN_INTERPRET2(Identity, ctfeIdentity)
-BIN_INTERPRET2(Cmp, Cmp)
+BIN_INTERPRET2(Cmp, ctfeCmp)
 
 /* Helper functions for BinExp::interpretAssignCommon
  */
@@ -3518,7 +3714,8 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
     }
     bool wantRef = false;
     if (!fp && this->e1->type->toBasetype() == this->e2->type->toBasetype() &&
-        (e1->type->toBasetype()->ty == Tarray || isAssocArray(e1->type))
+        (e1->type->toBasetype()->ty == Tarray || isAssocArray(e1->type)
+             || e1->type->toBasetype()->ty == Tclass)
          //  e = *x is never a reference, because *x is always a value
          && this->e2->op != TOKstar
         )
@@ -3973,7 +4170,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         // (in which case, we already have the lvalue).
         if (this->e1->op != TOKcall && !(this->e1->op==TOKvar
             && ((VarExp*)this->e1)->var->storage_class & (STCref | STCout)))
-            e1 = e1->interpret(istate, ctfeNeedLvalue);
+            e1 = e1->interpret(istate, isPointer(type)? ctfeNeedLvalueRef : ctfeNeedLvalue);
         if (exceptionOrCantInterpret(e1))
             return e1;
         if (e1->op == TOKstructliteral && newval->op == TOKstructliteral)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3029,7 +3029,7 @@ int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2)
         r2 = e2->toImaginary();
      L1:
 #if __DMC__
-        return (r1 == r2);
+        return (r1 != r2);
 #else
         if (Port::isNan(r1) || Port::isNan(r2)) // if unordered
         {

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4384,6 +4384,46 @@ static assert(bug7785(1));
 static assert(!is(typeof(compiles!(bug7785(2)))));
 static assert(!is(typeof(compiles!(bug7785(3)))));
 
+/**************************************************
+    7987
+**************************************************/
+
+class C7987 {
+    int m;
+}
+
+struct S7987 {
+    int *p;
+    C7987 c;
+}
+
+bool bug7987()
+{
+    int [7] q;
+    int[][2] b = q[0..5];
+    assert(b == b);
+    assert(b is b);
+    C7987 c1 = new C7987;
+    C7987 c2 = new C7987;
+    S7987 s, t;
+    s.p = &q[0];
+    t.p = &q[1];
+    assert(s!=t);
+    s.p = &q[1];
+    assert(s == t);
+    s.c = c1;
+    t.c = c2;
+    assert(s != t);
+    assert(s !is t);
+    s.c = c2;
+    assert(s == t);
+    assert(s is t);
+    return true;
+}
+
+static assert(bug7987());
+
+
 /******************************************************/
 
 struct B73 {}


### PR DESCRIPTION
Creates a CTFE-aware implementaton of the Identity() and Equals() functions from constfold.c
This removes heap allocation when comparing slices of strings, so it also improves
performance in a few important cases.

This temporarily creates code duplication with constfold.c, but I have plans to clean that up in the future.
