### PR TITLE
Issue 8004 - Direct call of function literal should consider default arguments

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8061,7 +8061,15 @@ Lagain:
     {
         TypeFunction *tf;
         const char *p;
-        if (t1->ty == Tdelegate)
+        if (e1->op == TOKfunction)
+        {
+            // function literal that direct called is always inferred.
+            assert(((FuncExp *)e1)->fd);
+            f = ((FuncExp *)e1)->fd;
+            tf = (TypeFunction *)f->type;
+            p = "function literal";
+        }
+        else if (t1->ty == Tdelegate)
         {   TypeDelegate *td = (TypeDelegate *)t1;
             assert(td->next->ty == Tfunction);
             tf = (TypeFunction *)(td->next);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5047,16 +5047,25 @@ class A7983 {
         }
         unittest {
         }
-}     
+}
 
 void g7983(T)(T a)
-{      
+{
         foreach (name; __traits(allMembers, T)) {
                 pragma(msg, name);
                 static if (__traits(compiles, &__traits(getMember, a, name)))
                 {
                 }
         }
+}
+
+/***************************************************/
+// 8004
+
+void test8004()
+{
+    auto n = (int n = 10){ return n; }();
+    assert(n == 10);
 }
 
 /***************************************************/
@@ -5291,6 +5300,7 @@ int main()
     test7871();
     test7906();
     test7907();
+    test8004();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8004
