### PR TITLE
Issue 7560 - Base class overloaded methods created by mixins can't be overriden

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -544,6 +544,17 @@ void AliasDeclaration::semantic(Scope *sc)
                 s->parent = sc->parent;
             }
         }
+        OverloadSet *o = s->toAlias()->isOverloadSet();
+        if (o)
+        {
+            if (overnext)
+            {
+                o->push(overnext);
+                overnext = NULL;
+                s = o;
+                s->parent = sc->parent;
+            }
+        }
         if (overnext)
             ScopeDsymbol::multiplyDefined(0, this, overnext);
         if (s == this)

--- a/test/runnable/mixin2.d
+++ b/test/runnable/mixin2.d
@@ -161,6 +161,25 @@ void test10()
 }
 
 /*********************************************/
+// 7560
+
+class Base7560
+{
+    template getter(T)
+    {
+        void get(ref T[] i, uint n) {}
+    }
+    mixin getter!uint;
+    mixin getter!char;
+}
+
+class Derived7560 : Base7560
+{
+    alias Base7560.get get;
+    void get(ref char[] x) {}
+}
+
+/*********************************************/
 
 void main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7560
