### PR TITLE
Issue 7941 - Regression(2.059): Type check is ignored when manifest constant initializer is function literal

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -138,7 +138,12 @@ Expression *ErrorExp::implicitCastTo(Scope *sc, Type *t)
 Expression *FuncExp::implicitCastTo(Scope *sc, Type *t)
 {
     //printf("FuncExp::implicitCastTo type = %p %s, t = %s\n", type, type ? type->toChars() : NULL, t->toChars());
-    return inferType(t);
+    if ((t->ty == Tpointer && t->nextOf()->ty == Tfunction) ||
+        t->ty == Tdelegate)
+    {
+        return inferType(t);
+    }
+    return Expression::implicitCastTo(sc, t);
 }
 
 /*******************************************

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -548,6 +548,14 @@ void test7761()
 }
 
 /***************************************************/
+// 7941
+
+void test7941()
+{
+    static assert(!__traits(compiles, { enum int c = function(){}; }));
+}
+
+/***************************************************/
 // 8005
 
 void test8005()
@@ -587,6 +595,7 @@ int main()
     test7713();
     test7743();
     test7761();
+    test7941();
     test8005();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7941
