### PR TITLE
Regression 8016 Methods defined in external object files when template alias parameter is involved 

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -590,7 +590,15 @@ void FuncDeclaration::toObjFile(int multiobj)
          * so we know things like where its local symbols are stored.
          */
         FuncDeclaration *fdp = toAliasFunc()->toParent2()->isFuncDeclaration();
-        if (fdp && fdp->semanticRun == PASSsemantic3done &&
+        // Bug 8016 - only include the function if it is a template instance
+        Dsymbol * owner = NULL;
+        if (fdp)
+        {   owner =  fdp->toParent();
+            while (owner && !owner->isTemplateInstance())
+                owner = owner->toParent();
+        }
+
+        if (owner && fdp && fdp->semanticRun == PASSsemantic3done &&
             !fdp->isUnitTestDeclaration())
         {
             /* Can't do unittest's out of order, they are order dependent in that their

--- a/test/runnable/imports/template2962a.d
+++ b/test/runnable/imports/template2962a.d
@@ -1,0 +1,10 @@
+module imports.template2962a;
+import template2962;
+
+alias bug2962comment36!() bug2962_comment36_alias;
+
+void main() {
+    funcC!(bool)(1.0);
+    foo!int(0);
+}
+

--- a/test/runnable/template2962.d
+++ b/test/runnable/template2962.d
@@ -1,0 +1,30 @@
+// EXTRA_SOURCES: imports/template2962a.d
+
+// comment 29
+void foo(T)(T p)
+{
+    void inner(U)() {
+        auto p2 = p;
+    }
+    inner!int();
+}
+
+// comment 20
+void funcD(alias x)() {
+   assert(x==1.0);
+}
+
+void funcC(T)(double a){
+    // Case 1: ICE(glue.c)
+    funcD!(a)();
+
+    // Case 2: wrong code
+    double b = 1.0; funcD!(b)();
+}
+
+void bug2962comment36()(int p)
+{
+    int inner()() { return p; }
+    alias inner!() finner;
+}
+


### PR DESCRIPTION
This regression was caused by the fix to bug 2962, but I found that bug 2962 is fixed if only template functions are written. The fix for 2962 didn't include anything for the test suite, so I have added it, including all test cases in the bug report.
