### PR TITLE
Heisenbug: D1-only uninitialized variable

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3281,6 +3281,7 @@ StructLiteralExp::StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *
     this->sym = NULL;
     this->soffset = 0;
     this->fillHoles = 1;
+    this->ownedByCtfe = false;
 }
 
 Expression *StructLiteralExp::syntaxCopy()


### PR DESCRIPTION
It's initialized in D2, but not in D1.
Caused really bizarre heisenbugs. 
In the case I encountered, compiling with -deps would cause template instantiations to fail.
