### PR TITLE
Issue 5737 & 6199 - fix postblit call with ref return

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1087,7 +1087,7 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
 #if DMDV2
             if (tb->ty == Tstruct && !(p->storageClass & (STCref | STCout)))
             {
-                if (arg->op == TOKcall)
+                if (arg->op == TOKcall && !arg->isLvalue())
                 {
                     /* The struct value returned from the function is transferred
                      * to the function, so the callee should not call the destructor

--- a/src/expression.c
+++ b/src/expression.c
@@ -10385,11 +10385,7 @@ Ltupleassign:
                         e = new CommaExp(loc, ec, e);
                     return e->semantic(sc);
                 }
-                else if (e2->op == TOKvar ||
-                         e2->op == TOKdotvar ||
-                         e2->op == TOKstar ||
-                         e2->op == TOKthis ||
-                         e2->op == TOKindex)
+                else if (e2->isLvalue())
                 {   /* Write as:
                      *  e1.cpctor(e2);
                      */

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1705,6 +1705,42 @@ void test59()
 }
 
 /**********************************/
+// 5737
+
+void test5737()
+{
+    static struct S
+    {
+        static int destroyed;
+        static int copied;
+
+        this(this)
+        {
+            copied++;
+        }
+
+        ~this()
+        {
+            destroyed++;
+        }
+    }
+
+    static S s;
+
+    ref S foo()
+    {
+        return s;
+    }
+
+    {
+        auto s2 = foo();
+    }
+
+    assert(S.copied == 1); // fail, s2 was not copied;
+    assert(S.destroyed == 1); // ok, s2 was destroyed
+}
+
+/**********************************/
 // 6364
 
 struct Foo6364
@@ -1979,6 +2015,7 @@ int main()
     test57();
     test58();
     test59();
+    test5737();
     test6364();
     test6499();
     test60();

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1741,6 +1741,38 @@ void test5737()
 }
 
 /**********************************/
+// 6119
+
+void test6119()
+{
+    int postblit = 0;
+    int dtor = 0;
+
+    struct Test
+    {
+        this(this) { ++postblit; }
+        ~this()    { ++dtor; }
+    }
+
+    void takesVal(Test x) {}
+    ref Test returnsRef(ref Test x) { return x; }
+
+    void f(ref Test x) { takesVal( x ); }
+
+    Test x;
+
+    postblit = dtor = 0;
+    takesVal(returnsRef(x));
+    assert(postblit == 1);
+    assert(dtor == 1);
+
+    postblit = dtor = 0;
+    f(x);
+    assert(postblit == 1);
+    assert(dtor == 1);
+}
+
+/**********************************/
 // 6364
 
 struct Foo6364
@@ -2016,6 +2048,7 @@ int main()
     test58();
     test59();
     test5737();
+    test6119();
     test6364();
     test6499();
     test60();


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5737">Issue 5737</a> - postblit not called for locals initialized from ref functions
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=6199">Issue 6199</a> - [GSoC] Postblit not called when returning a reference to a by-value function.
