### PR TITLE
Add a new DISABLED option for tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -35,6 +35,10 @@
 #
 #   REQUIRED_ARGS:       arguments to add to the $(DMD) command line
 #                        default: (none)
+#
+#  DISABLED:             text describing why the test is disabled (if empty, the test is
+#                        considered to be enabled).
+#                        default: (none, enabled)
 
 ifeq (,$(OS))
     OS:=$(shell uname)

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -51,6 +51,8 @@ struct TestArgs
     string   permuteArgs;
     string   postScript;
     string   requiredArgs;
+    // reason for disabling the test (if empty, the test is not disabled)
+    string   disabled;
 }
 
 struct EnvData
@@ -142,6 +144,8 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
 
     string compileSeparatelyStr;
     testArgs.compileSeparately = findTestParameter(file, "COMPILE_SEPARATELY", compileSeparatelyStr);
+
+    findTestParameter(file, "DISABLED", testArgs.disabled);
 
     if (findTestParameter(file, "POST_SCRIPT", testArgs.postScript))
         testArgs.postScript = replace(testArgs.postScript, "/", to!string(envData.sep));
@@ -273,6 +277,17 @@ int main(string[] args)
     }
 
     gatherTestParameters(testArgs, input_dir, input_file, envData);
+
+    if ("" != testArgs.disabled)
+    {
+        writefln(" !!! %-30s %s%s(%s) [DISABLED: %s]",
+            input_file,
+            testArgs.requiredArgs,
+            (testArgs.requiredArgs ? " " : ""),
+            testArgs.permuteArgs,
+            testArgs.disabled);
+        return 0;
+    }
 
     writefln(" ... %-30s %s%s(%s)",
             input_file,


### PR DESCRIPTION
Sometimes is useful to be able to add tests even when they don't pass.
Being able to do so, makes life easier for people wanting to fix the bug
(they have the test right there) and ensures people don't forget to add
test cases just because it would break the auto-tester.

Now tests can have a DISABLED option which should have a reason why the
test was disabled. For example:
// DISABLED: bug 123 is still not fixed

When a test is disabled, a special message is printed, for example:
 !!! runnable/bug123.d          () [DISABLED: bug 123 is still not fixed]
