### PR TITLE
Fix issue 1099 weird tupleof behavior in mixins

### DIFF
--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -148,3 +148,21 @@ void bug6720() { }
 //static assert(!is(typeof(
 //cast(bool)bug6720()
 //)));
+
+/**************************************************
+    1099
+**************************************************/
+
+template Mix1099(int a) {
+   alias typeof(this) ThisType;
+    static assert (ThisType.init.tupleof.length == 2);
+}
+
+
+struct Foo1099 {
+    mixin Mix1099!(0);
+    int foo;
+    mixin Mix1099!(1);
+    int bar;
+    mixin Mix1099!(2);
+}


### PR DESCRIPTION
Fixed some time ago, this is just the test case, so it can be closed
