### PR TITLE
Added new trait to return the code of a given symbol

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -324,6 +324,7 @@ Msgtable msgtable[] =
     { "hasMember" },
     { "identifier" },
     { "parent" },
+    { "codeof" },
     { "getMember" },
     { "getOverloads" },
     { "getVirtualFunctions" },

--- a/src/traits.c
+++ b/src/traits.c
@@ -221,6 +221,19 @@ Expression *TraitsExp::semantic(Scope *sc)
         }
         return (new DsymbolExp(loc, s))->semantic(sc);
     }
+    else if (ident == Id::codeof)
+    {
+        Object *o = (*args)[0];
+        Dsymbol *s = getDsymbol(o);
+        if (!s)
+        {
+           goto Lfalse;
+        }
+        OutBuffer *outBuffer = new OutBuffer();
+        HdrGenState *hgs = new HdrGenState();
+        s->toCBuffer(outBuffer, hgs);
+        return (new StringExp(loc, (char*)outBuffer->data))->semantic(sc);
+    }
 
 #endif
     else if (ident == Id::hasMember ||

--- a/src/traits.c
+++ b/src/traits.c
@@ -229,6 +229,24 @@ Expression *TraitsExp::semantic(Scope *sc)
         {
            goto Lfalse;
         }
+
+        //Resolve function aliases
+        FuncAliasDeclaration *alias = s->isFuncAliasDeclaration();
+        while (alias)
+        {
+            s = alias->toAliasFunc();
+            alias = s->isFuncAliasDeclaration();
+        }
+
+        //Handle lambdas
+        if(strncmp(s->ident->toChars(), "__lambda", 8) == 0)
+        {
+            TemplateDeclaration *td = s->isTemplateDeclaration();
+            if (td)
+            {
+                s = td->onemember;
+            }
+        }
         OutBuffer outBuffer;
         HdrGenState hgs;
         s->toCBuffer(&outBuffer, &hgs);

--- a/src/traits.c
+++ b/src/traits.c
@@ -229,10 +229,12 @@ Expression *TraitsExp::semantic(Scope *sc)
         {
            goto Lfalse;
         }
-        OutBuffer *outBuffer = new OutBuffer();
-        HdrGenState *hgs = new HdrGenState();
-        s->toCBuffer(outBuffer, hgs);
-        return (new StringExp(loc, (char*)outBuffer->data))->semantic(sc);
+        OutBuffer outBuffer;
+        HdrGenState hgs;
+        s->toCBuffer(&outBuffer, &hgs);
+        char* code = (char*)malloc(outBuffer.size);
+        strcpy(code, (char*)outBuffer.data);
+        return (new StringExp(loc, code))->semantic(sc);
     }
 
 #endif


### PR DESCRIPTION
This is an implementation of a new trait that returns the source code for a given symbol.  It was originally discussed [here](http://forum.dlang.org/thread/huyqfcoosgzfneswnrur@forum.dlang.org).

This implementation uses __traits(codeof, symbol)
