### PR TITLE
fix Issue 8104 - UFCS on opaque struct won't compile

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -662,11 +662,9 @@ Dsymbol *StructDeclaration::search(Loc loc, Identifier *ident, int flags)
     if (scope && !symtab)
         semantic(scope);
 
+    // fail silently if struct is opaque (lookup may get resolved by UFCS)
     if (!members || !symtab)
-    {
-        error("is forward referenced when looking for '%s'", ident->toChars());
         return NULL;
-    }
 
     return ScopeDsymbol::search(loc, ident, flags);
 }

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -237,6 +237,20 @@ void test7943()
 }
 
 /*******************************************/
+// 8104 - UFCS on opaque struct won't compile
+
+struct Opaque8104;
+
+int foo8104(Opaque8104*) { return 1; }
+int bar8104(T)(Opaque8104*) { return 2; }
+
+void test8104() {
+    Opaque8104* s;
+    assert(s.foo8104() == 1);
+    assert(s.bar8104!(int)() == 2);
+}
+
+/*******************************************/
 
 int main()
 {


### PR DESCRIPTION
Change member lookup on opaque struct to fail silently rather than produce an error-- giving UFCS a chance to resolve.

http://d.puremagic.com/issues/show_bug.cgi?id=8104
