### PR TITLE
Issue 1780 & 3608 & 8125 - Fix TypeInstance deduction problems

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3059,11 +3059,22 @@ MATCH TypeInstance::deduceType(Scope *sc,
                     (*dedtypes)[j] = e1;
                 }
             }
+            else if (s1 && s2)
+            {
+            Ls:
+                if (!s1->equals(s2))
+                    goto Lnomatch;
+            }
             else if (s1 && t2 && t2->ty == Tident)
             {
                 j = templateParameterLookup(t2, parameters);
                 if (j == -1)
+                {
+                    t2->resolve(loc, sc, &e2, &t2, &s2);
+                    if (s2)
+                        goto Ls;
                     goto Lnomatch;
+                }
                 TemplateParameter *tp = (*parameters)[j];
                 // BUG: use tp->matchArg() instead of the following
                 TemplateAliasParameter *ta = tp->isTemplateAliasParameter();
@@ -3079,11 +3090,6 @@ MATCH TypeInstance::deduceType(Scope *sc,
                 {
                     (*dedtypes)[j] = s1;
                 }
-            }
-            else if (s1 && s2)
-            {
-                if (!s1->equals(s2))
-                    goto Lnomatch;
             }
             // BUG: Need to handle tuple parameters
             else

--- a/src/template.c
+++ b/src/template.c
@@ -2884,15 +2884,11 @@ MATCH TypeInstance::deduceType(Scope *sc,
                         s = t->toDsymbol(sc);
                         if (s)
                         {   TemplateInstance *ti = s->parent->isTemplateInstance();
-                            if (ti)
-                            {   s = ti->tempdecl;
-                                goto L3;
-                            }
+                            s = ti ? ti->tempdecl : NULL;
                         }
                     }
-                    else if (s)
+                    if (s)
                     {
-                    L3:
                         s = s->toAlias();
                         TemplateDeclaration *td = s->isTemplateDeclaration();
                         if (td && td == tempinst->tempdecl)

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -206,6 +206,30 @@ void test1780()
 }
 
 /**********************************/
+// 3608
+
+template foo3608(T, U){}
+
+template BaseTemplate3608(alias TTT : U!V, alias U, V...)
+{
+    alias U BaseTemplate3608;
+}
+template TemplateParams3608(alias T : U!V, alias U, V...)
+{
+    alias V TemplateParams3608;
+}
+
+template TyueTuple3608(T...) { alias T TyueTuple3608; }
+
+void test3608()
+{
+    alias foo3608!(int, long) Foo3608;
+
+    static assert(__traits(isSame, BaseTemplate3608!Foo3608, foo3608));
+    static assert(is(TemplateParams3608!Foo3608 == TyueTuple3608!(int, long)));
+}
+
+/**********************************/
 // 5015
 
 import breaker;
@@ -1384,6 +1408,7 @@ int main()
     test8();
     test9();
     test1780();
+    test3608();
     test6404();
     test2246();
     bug4984();

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1281,6 +1281,22 @@ void test12()
 }
 
 /**********************************/
+// 8125
+
+void foo8125(){}
+
+struct X8125(alias a) {}
+
+template Y8125a(T : A!f, alias A, alias f) {}  //OK
+template Y8125b(T : A!foo8125, alias A) {}     //NG
+
+void test8125()
+{
+    alias Y8125a!(X8125!foo8125) y1;
+    alias Y8125b!(X8125!foo8125) y2;
+}
+
+/**********************************/
 
 int main()
 {
@@ -1333,6 +1349,7 @@ int main()
     test7933();
     test8094();
     test12();
+    test8125();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -189,6 +189,23 @@ void test9()
 }
 
 /**********************************/
+// 1780
+
+template Tuple1780(Ts ...) { alias Ts Tuple1780; }
+
+template Decode1780( T )                            { alias Tuple1780!() Types; }
+template Decode1780( T : TT!(Us), alias TT, Us... ) { alias Us Types; }
+
+void test1780()
+{
+    struct S1780(T1, T2) {}
+
+    // should extract tuple (bool,short) but matches the first specialisation
+    alias Decode1780!( S1780!(bool,short) ).Types SQ1780;  // --> SQ2 is empty tuple!
+    static assert(is(SQ1780 == Tuple1780!(bool, short)));
+}
+
+/**********************************/
 // 5015
 
 import breaker;
@@ -1298,6 +1315,63 @@ void test8125()
 
 /**********************************/
 
+struct A13() {}
+struct B13(TT...) {}
+struct C13(T1) {}
+struct D13(T1, TT...) {}
+struct E13(T1, T2) {}
+struct F13(T1, T2, TT...) {}
+
+template Test13(alias X)
+{
+    static if (is(X x : P!U, alias P, U...))
+        enum Test13 = true;
+    else
+        enum Test13 = false;
+}
+
+void test13()
+{
+    static assert(Test13!( A13!() ));
+    static assert(Test13!( B13!(int) ));
+    static assert(Test13!( B13!(int, double) ));
+    static assert(Test13!( B13!(int, double, string) ));
+    static assert(Test13!( C13!(int) ));
+    static assert(Test13!( D13!(int) ));
+    static assert(Test13!( D13!(int, double) ));
+    static assert(Test13!( D13!(int, double, string) ));
+    static assert(Test13!( E13!(int, double) ));
+    static assert(Test13!( F13!(int, double) ));
+    static assert(Test13!( F13!(int, double, string) ));
+    static assert(Test13!( F13!(int, double, string, bool) ));
+}
+
+/**********************************/
+
+struct A14(T, U, int n = 1)
+{
+}
+
+template Test14(alias X)
+{
+    static if (is(X x : P!U, alias P, U...))
+        alias U Test14;
+    else
+        static assert(0);
+}
+
+void test14()
+{
+    alias A14!(int, double) Type;
+    alias Test14!Type Params;
+    static assert(Params.length == 3);
+    static assert(is(Params[0] == int));
+    static assert(is(Params[1] == double));
+    static assert(   Params[2] == 1);
+}
+
+/**********************************/
+
 int main()
 {
     test1();
@@ -1309,6 +1383,7 @@ int main()
     test7();
     test8();
     test9();
+    test1780();
     test6404();
     test2246();
     bug4984();
@@ -1350,6 +1425,8 @@ int main()
     test8094();
     test12();
     test8125();
+    test13();
+    test14();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=1780">Issue 1780</a> - Type tuple deduction failure for class templates
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=3608">Issue 3608</a> - Allow isExpression and templates to capture template parameters and FQN of template
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=8125">Issue 8125</a> - TypeInstance dedunction problem
