### PR TITLE
Fixed test to use overload of sleep which takes a Duration.

### DIFF
--- a/test/runnable/testthread.d
+++ b/test/runnable/testthread.d
@@ -56,7 +56,7 @@ int main()
         tx[i].start();
     for (i = 0; i < tx.length; i++)
         tx[i].join();
-    Thread.sleep(10000);
+    Thread.sleep(dur!"msecs"(1));
 
     printf("**Success**\n");
     return 0;


### PR DESCRIPTION
The overload which takes a ulong is soon to be deprecated, which will
break the tests.
