### PR TITLE
Issue 8099 - Inner class's outer pointer matches constancy of inner, but can be set to object of arbitrary constancy

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4386,6 +4386,13 @@ Lagain:
             sc = sc->push(cdthis);
             type = newtype->semantic(loc, sc);
             sc = sc->pop();
+
+            if (!MODimplicitConv(thisexp->type->mod, newtype->mod))
+            {
+                error("nested type %s should have the same or weak constancy as enclosing type %s",
+                    newtype->toChars(), thisexp->type->toChars());
+                goto Lerr;
+            }
         }
         else
         {

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2682,6 +2682,41 @@ void test8098()
 }
 
 /************************************/
+// 8099
+
+void test8099()
+{
+    static class Outer
+    {
+        class Inner {}
+    }
+
+    auto m = new Outer;
+    auto c = new const(Outer);
+    auto i = new immutable(Outer);
+
+    auto mm = m.new Inner;            // m -> m  OK
+    auto mc = m.new const(Inner);     // m -> c  OK
+  static assert(!__traits(compiles, {
+    auto mi = m.new immutable(Inner); // m -> i  bad
+  }));
+
+  static assert(!__traits(compiles, {
+    auto cm = c.new Inner;            // c -> m  bad
+  }));
+    auto cc = c.new const(Inner);     // c -> c  OK
+  static assert(!__traits(compiles, {
+    auto ci = c.new immutable(Inner); // c -> i  bad
+  }));
+
+  static assert(!__traits(compiles, {
+    auto im = i.new Inner;            // i -> m  bad
+  }));
+    auto ic = i.new const(Inner);     // i -> c  OK
+    auto ii = i.new immutable(Inner); // i -> i  OK
+}
+
+/************************************/
 
 int main()
 {
@@ -2796,6 +2831,7 @@ int main()
     test7669();
     test7757();
     test8098();
+    test8099();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8099
