### PR TITLE
Issue 8147 - Blah!R.init now requires parens - (Blah!R).init

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -632,7 +632,9 @@ Dsymbol *AliasDeclaration::toAlias()
         aliassym = new AliasDeclaration(loc, ident, Type::terror);
         type = Type::terror;
     }
-    else if (!aliassym && scope)
+    else if (aliassym || type->deco)
+        ;   // semantic is already done.
+    else if (scope)
         semantic(scope);
     Dsymbol *s = aliassym ? aliassym->toAlias() : this;
     return s;

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -66,12 +66,39 @@ void test8123()
 }
 
 /***************************************************/
+// 8147
+
+enum A8147 { a, b, c }
+
+@property ref T front8147(T)(T[] a)
+if (!is(T[] == void[]))
+{
+    return a[0];
+}
+
+template ElementType8147(R)
+{
+    static if (is(typeof({ R r = void; return r.front8147; }()) T))
+        alias T ElementType8147;
+    else
+        alias void ElementType8147;
+}
+
+void test8147()
+{
+    auto arr = [A8147.a];
+    alias typeof(arr) R;
+    auto e = ElementType8147!R.init;
+}
+
+/***************************************************/
 
 int main()
 {
     test6475();
     test7239();
     test8123();
+    test8147();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5008,6 +5008,26 @@ void test4155()
 }
 
 /***************************************************/
+// 7911
+
+struct Klass7911
+{
+    double value;
+
+    //static const Klass zero; // Does not trigger bug!
+    static const Klass7911 zero = {0}; // Bug trigger #1
+
+    static if (true) // Bug trigger #2
+        static if (true)
+            Klass7911 foo() { return Klass7911(); }
+}
+
+void test7911()
+{
+    auto a = Klass7911().foo();
+}
+
+/***************************************************/
 // 8069
 
 interface I8069
@@ -5349,6 +5369,7 @@ int main()
     test245();
     test7807();
     test4155();
+    test7911();
     test8095();
     test8091();
     test6189_2();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8147
This is a regression of fixing bug 7911, but real problem had been in AliasDeclaration::toAlias().

We should not call AliasDeclaratation::semantic() twice, even if Dsymbol::scope != NULL.
