### PR TITLE
Fix parsing of catch statement with no type (bug #4024)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4246,7 +4246,7 @@ Statement *Parser::parseStatement(int flags)
                 Loc loc = this->loc;
 
                 nextToken();
-                if (token.value == TOKlcurly)
+                if (token.value == TOKlcurly || token.value != TOKlparen)
                 {
                     t = NULL;
                     id = NULL;


### PR DESCRIPTION
Allows catch statement with no Exception type ("last catch") to accept non-block statements.
See http://d.puremagic.com/issues/show_bug.cgi?id=4024.
