### PR TITLE
Issue 8169 - Method loses its compile-time evaluability when used through alias this

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7843,13 +7843,23 @@ Lagain:
         AggregateDeclaration *ad;
         UnaExp *ue = (UnaExp *)(e1);
 
+        Expression *ue1 = ue->e1;
+        VarDeclaration *v;
+        if (ue1->op == TOKvar &&
+            (v = ((VarExp *)ue1)->var->isVarDeclaration()) != NULL &&
+            v->needThis())
+        {
+            ue->e1 = new TypeExp(ue1->loc, ue1->type);
+            ue1 = NULL;
+        }
+
         if (e1->op == TOKdotvar)
         {   // Do overload resolution
             dve = (DotVarExp *)(e1);
 
             f = dve->var->isFuncDeclaration();
             assert(f);
-            f = f->overloadResolve(loc, ue->e1, arguments);
+            f = f->overloadResolve(loc, ue1, arguments);
 
             ad = f->toParent()->isAggregateDeclaration();
         }
@@ -7860,7 +7870,7 @@ Lagain:
             if (!arguments)
                 // Should fix deduceFunctionTemplate() so it works on NULL argument
                 arguments = new Expressions();
-            f = td->deduceFunctionTemplate(sc, loc, targsi, ue->e1, arguments);
+            f = td->deduceFunctionTemplate(sc, loc, targsi, ue1, arguments);
             if (!f)
                 return new ErrorExp();
             ad = td->toParent()->isAggregateDeclaration();

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -834,6 +834,31 @@ void test7992()
 }
 
 /***************************************************/
+// 8169
+
+void test8169()
+{
+    static struct ValueImpl
+    {
+       static immutable(int) getValue()
+       {
+           return 42;
+       }
+    }
+
+    static struct ValueUser
+    {
+       ValueImpl m_valueImpl;
+       alias m_valueImpl this;
+    }
+
+    static assert(ValueImpl.getValue() == 42); // #0, OK
+    static assert(ValueUser.getValue() == 42); // #1, NG
+    static assert(       ValueUser.m_valueImpl .getValue() == 42); // #2, NG
+    static assert(typeof(ValueUser.m_valueImpl).getValue() == 42); // #3, OK
+}
+
+/***************************************************/
 
 int main()
 {
@@ -866,6 +891,7 @@ int main()
     test7808();
     test7945();
     test7992();
+    test8169();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8169
