### PR TITLE
Issue 5679 - Type aliasing "this" from an access function defined in base class confuses the compiler about the type of objects

### DIFF
--- a/src/optimize.c
+++ b/src/optimize.c
@@ -597,9 +597,8 @@ Expression *CastExp::optimize(int result)
     if (e1->op == TOKstructliteral &&
         e1->type->implicitConvTo(type) >= MATCHconst)
     {
-        e1->type = type;
         if (X) printf(" returning2 %s\n", e1->toChars());
-        return e1;
+        goto L1;
     }
 
     /* The first test here is to prevent infinite loops
@@ -609,9 +608,8 @@ Expression *CastExp::optimize(int result)
     if (e1->op == TOKnull &&
         (type->ty == Tpointer || type->ty == Tclass || type->ty == Tarray))
     {
-        e1->type = type;
         if (X) printf(" returning3 %s\n", e1->toChars());
-        return e1;
+        goto L1;
     }
 
     if (result & WANTflags && type->ty == Tclass && e1->type->ty == Tclass)
@@ -625,18 +623,16 @@ Expression *CastExp::optimize(int result)
         cdto   = type->isClassHandle();
         if (cdto->isBaseOf(cdfrom, &offset) && offset == 0)
         {
-            e1->type = type;
             if (X) printf(" returning4 %s\n", e1->toChars());
-            return e1;
+            goto L1;
         }
     }
 
     // We can convert 'head const' to mutable
     if (to->mutableOf()->constOf()->equals(e1->type->mutableOf()->constOf()))
     {
-        e1->type = type;
         if (X) printf(" returning5 %s\n", e1->toChars());
-        return e1;
+        goto L1;
     }
 
     Expression *e;
@@ -648,8 +644,7 @@ Expression *CastExp::optimize(int result)
             if (type->size() == e1->type->size() &&
                 type->toBasetype()->ty != Tsarray)
             {
-                e1->type = type;
-                return e1;
+                goto L1;
             }
             return this;
         }
@@ -661,6 +656,10 @@ Expression *CastExp::optimize(int result)
     else
         e = this;
     if (X) printf(" returning6 %s\n", e->toChars());
+    return e;
+L1: // Returning e1 with changing its type
+    e = (e1old == e1 ? e1->copy() : e1);
+    e->type = type;
     return e;
 #undef X
 }

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -405,6 +405,27 @@ struct Derived2787
 }
 
 /***********************************/
+// 5679
+
+void test5679()
+{
+    class Foo {}
+
+    class Base
+    {
+        @property Foo getFoo() { return null; }
+    }
+    class Derived : Base
+    {
+        alias getFoo this;
+    }
+
+    Derived[] dl;
+    Derived d = new Derived();
+    dl ~= d; // Error: cannot append type alias_test.Base to type Derived[]
+}
+
+/***********************************/
 // 6508
 
 void test6508()
@@ -875,6 +896,7 @@ int main()
     test6736();
     test2777a();
     test2777b();
+    test5679();
     test6508();
     test6369a();
     test6369b();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=5679

It seems to me that is fragile which changing the type of an expression that semantic analysis is already done.
