### PR TITLE
Issue 4884 - Using template struct parameters in method definition fails with "parameter _param_0 is already defined"

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5572,8 +5572,13 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
              */
             if (t->ty == Ttuple)
             {
+                /* TypeFunction::parameter also is used as the storage of
+                 * Parameter objects for FuncDeclaration. So we should copy
+                 * the elements of TypeTuple::arguments to avoid unintended
+                 * sharing of Parameter object among other functions.
+                 */
                 TypeTuple *tt = (TypeTuple *)t;
-                if (fparam->storageClass && tt->arguments && tt->arguments->dim)
+                if (tt->arguments && tt->arguments->dim)
                 {
                     /* Propagate additional storage class from tuple parameters to their
                      * element-parameters.

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1354,6 +1354,21 @@ void test4444()
 }
 
 /***************************************/
+// 4884
+
+struct A4884(T...)
+{
+    void foo(T) {}
+    void bar(bool, T) {}
+}
+
+void test4884()
+{
+    auto a1 = A4884!(int)();
+    auto a2 = A4884!(int, long)();
+}
+
+/***************************************/
 // 4940
 
 template Tuple4940(T...)
@@ -1543,6 +1558,7 @@ int main()
     test63();
     test1411();
     test4444();
+    test4884();
     test4940();
     test4940add();
     test6530();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=4884
