### PR TITLE
Issue 3290,4510,5435 - Add strict type check for foreach argument

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1742,11 +1742,19 @@ Lagain:
                 else
                 {
                     value = var;
-                    /* Reference to immutable data should be marked as const
-                     */
-                    if (var->storage_class & STCref && !tn->isMutable())
+                    if (var->storage_class & STCref)
                     {
-                        var->storage_class |= STCconst;
+                        /* Reference to immutable data should be marked as const
+                         */
+                        if (!tn->isMutable())
+                            var->storage_class |= STCconst;
+
+                        Type *t = tab->nextOf();
+                        if (!t->invariantOf()->equals(argtype->invariantOf()))
+                        {
+                            error("argument type mismatch, %s to ref %s",
+                                  t->toChars(), argtype->toChars());
+                        }
                     }
                 }
 #if 0

--- a/src/statement.c
+++ b/src/statement.c
@@ -1750,7 +1750,8 @@ Lagain:
                             var->storage_class |= STCconst;
 
                         Type *t = tab->nextOf();
-                        if (!t->invariantOf()->equals(argtype->invariantOf()))
+                        if (!t->invariantOf()->equals(argtype->invariantOf()) ||
+                            !MODimplicitConv(t->mod, argtype->mod))
                         {
                             error("argument type mismatch, %s to ref %s",
                                   t->toChars(), argtype->toChars());

--- a/test/fail_compilation/fail3290.d
+++ b/test/fail_compilation/fail3290.d
@@ -1,0 +1,9 @@
+// 3290
+
+void main()
+{
+    const(int)[] array;
+    foreach (ref int i; array) {
+        //i = 42;
+    }
+}

--- a/test/fail_compilation/fail4510.d
+++ b/test/fail_compilation/fail4510.d
@@ -1,0 +1,9 @@
+// 4510
+
+void main()
+{
+    float[] arr = [1.0, 2.5, 4.0];
+    foreach (ref double elem; arr) {
+        //elem /= 2;
+    }
+}

--- a/test/fail_compilation/fail5435.d
+++ b/test/fail_compilation/fail5435.d
@@ -1,0 +1,13 @@
+// 5435
+
+template Tuple5435(E...) { alias E Tuple5435; }
+enum Enum5435 { A, B, C };
+
+void main()
+{
+    alias Tuple5435!(Enum5435.A, Enum5435.B, Enum5435.C, "foo", 3.0) tup;
+
+    foreach (Enum5435 foo; tup) pragma(msg, foo);
+    foreach (  string foo; tup) pragma(msg, foo);
+    foreach (     int foo; tup) pragma(msg, foo);
+}


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=3290">Issue 3290</a> - accepts-invalid: non-const by-ref foreach over a const array is accepted 
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=4510">Issue 4510</a> - [tdpl] ref with a wrong type specifier is accepted
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5435">Issue 5435</a> - Static foreach over tuple ignores type annotation
