### PR TITLE
Fix issue 8180 and increase consistency of UFCS lookup

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2103,10 +2103,9 @@ Expression *Type::noMember(Scope *sc, Expression *e, Identifier *ident)
             StringExp *se = new StringExp(e->loc, ident->toChars());
             Objects *tiargs = new Objects();
             tiargs->push(se);
-            e = new DotTemplateInstanceExp(e->loc, e, Id::opDispatch, tiargs);
-            ((DotTemplateInstanceExp *)e)->ti->tempdecl = td;
-            e = e->semantic(sc);
-            return e;
+            DotTemplateInstanceExp *dti = new DotTemplateInstanceExp(e->loc, e, Id::opDispatch, tiargs);
+            dti->ti->tempdecl = td;
+            return dti->semantic(sc, 1);
         }
 
         /* See if we should forward to the alias this.
@@ -2116,8 +2115,8 @@ Expression *Type::noMember(Scope *sc, Expression *e, Identifier *ident)
              *  e.aliasthis.ident
              */
             e = resolveAliasThis(sc, e);
-            e = new DotIdExp(e->loc, e, ident);
-            return e->semantic(sc);
+            DotIdExp *die = new DotIdExp(e->loc, e, ident);
+            return die->semantic(sc, 1);
         }
     }
 

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -111,6 +111,56 @@ void test2()
 }
 
 /*******************************************/
+
+auto init(T)(T val) { return 1; }
+
+auto sort(alias fun, T)(T val) { return 1; }
+
+@property auto max(alias fun, T)(T val) { return 1; }
+
+@property auto infinity(alias opt, T)(T val) { return 1; }
+
+void test3()
+{
+    // See built-in 'init' property
+    assert(1    .init == 0);
+    assert([1]  .init == null);
+    assert([1:1].init == null);
+    assert(1.0  .init is double.nan);
+    assert(10i  .init is idouble.nan);
+    assert('c'  .init == 0xFF);
+    assert("s"  .init == null);
+
+    // x.init() has parens, so it runs UFCS call
+    assert( 1   .init() == 1);
+    assert([1]  .init() == 1);
+    assert([1:1].init() == 1);
+    assert(1.0  .init() == 1);
+    assert(10i  .init() == 1);
+    assert('c'  .init() == 1);
+    assert("s"  .init() == 1);
+
+    // x.init!YYY matches templatized UFCS call.
+    assert( 1   .init!int()        == 1);
+    assert([1]  .init!(int[])()    == 1);
+    assert([1:1].init!(int[int])() == 1);
+    assert(1.0  .init!double()     == 1);
+    assert(10i  .init!idouble()    == 1);
+    assert('c'  .init!char()       == 1);
+    assert("s"  .init!string()     == 1);
+
+    assert([1].sort!"a<b"() == 1);
+    assert([1].sort == [1]);
+
+    // templatized properties runs UFCS call.
+    assert(1024.max!"a<b" == 1);
+    assert(1024.max  == int.max);
+
+    assert(3.14.infinity!"+" == 1);
+    assert(3.14.infinity == (double).infinity);
+}
+
+/*******************************************/
 // 662
 
 import std.stdio,std.string, std.conv;
@@ -259,6 +309,7 @@ int main()
 {
     test1();
     test2();
+    test3();
     test682();
     test3382();
     test7670();

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -237,6 +237,23 @@ void test7943()
 }
 
 /*******************************************/
+// 8180
+
+int writeln8180(T...)(T args) { return 1; }
+
+struct Tuple8180(T...)
+{
+    T field;
+    alias field this;
+}
+
+void test8180()
+{
+    auto t = Tuple8180!(int)(10);
+    assert(t.writeln8180() == 1);
+}
+
+/*******************************************/
 
 int main()
 {
@@ -248,6 +265,7 @@ int main()
     test7703();
     test7773();
     test7943();
+    test8180();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
- <a href="http://d.puremagic.com/issues/show_bug.cgi?id=8180">Issue 8180</a> - UFCS writeln doesn't work with Tuples
- Allow ignoring built-in property names on call-exp and templatized property with UFCS.
  
  For array types, followings are already allowed:
  `darr.init(...), sarr.ptr(...), aarr.stringof(...)`
  
  I'm not sure that it is a feature or bug, but if it's expected, following should work, too:
  `arr.sort!"a>b"`
