### PR TITLE
Bugzilla 8199: stack is not aligned in finally block

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -795,8 +795,7 @@ void outblkexitcode(block *bl, code*& c, int& anyspill, const char* sflsave, sym
             assert(!getregs(allregs));
             assert(!e);
             assert(!bl->Bcode);
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-            if (config.flags3 & CFG3pic)
+
             {
                 int nalign = 0;
                 if (STACKALIGN == 16)
@@ -811,17 +810,7 @@ void outblkexitcode(block *bl, code*& c, int& anyspill, const char* sflsave, sym
                 nextb = list_block(list_next(bl->Bsucc));
                 goto L2;
             }
-            else
-#endif
-            {
-                // Generate a PUSH of the address of the successor to the
-                // corresponding BC_ret
-                //assert(list_block(list_next(bl->Bsucc))->BC == BC_ret);
-                // PUSH &succ
-                c = genc(c,0x68,0,0,0,FLblock,(targ_size_t)list_block(list_next(bl->Bsucc)));
-                nextb = list_block(bl->Bsucc);
-                goto L2;
-            }
+            break;
 
         case BC_ret:
             c = gencodelem(c,e,&retregs,TRUE);

--- a/test/runnable/test8199.d
+++ b/test/runnable/test8199.d
@@ -1,0 +1,49 @@
+version (D_InlineAsm_X86_64)
+{
+    version = InlineAsmX86;
+    enum Align = 0x8;
+}
+else version (D_InlineAsm_X86)
+{
+    version = InlineAsmX86;
+    version (OSX)
+        enum Align = 0xC;
+}
+
+void onFailure()
+{
+    assert(0, "alignment failure");
+}
+
+void checkAlign()
+{
+    version (InlineAsmX86)
+    {
+        static if (is(typeof(Align)))
+        asm
+        {
+            naked;
+            mov EAX, ESP;
+            and EAX, 0xF;
+            cmp EAX, Align;
+            je Lpass;
+            call onFailure;
+        Lpass:
+            ret;
+        }
+    }
+    else
+        return;
+}
+
+void foo()
+{
+}
+
+void main()
+{
+    try
+        foo();
+    finally
+        checkAlign();
+}


### PR DESCRIPTION
- fixed by always performing a call to the finalizer code
- this is a net performance improvement because altering
  the return address always causes branch misprediction
