### PR TITLE
Restory legacy definition of isValidDchar()

### DIFF
--- a/src/test/UTFTest.cpp
+++ b/src/test/UTFTest.cpp
@@ -84,17 +84,17 @@ public:             // Tests
 
     void            testIsValidPrivateUse1()
     {
-        CPPUNIT_ASSERT(!utf_isValidDchar(0x00E123));
+        CPPUNIT_ASSERT(utf_isValidDchar(0x00E123));
     }
 
     void            testIsValidPrivateUse2()
     {
-        CPPUNIT_ASSERT(!utf_isValidDchar(0x0F1234));
+        CPPUNIT_ASSERT(utf_isValidDchar(0x0F1234));
     }
 
     void            testIsValidPrivateUse3()
     {
-        CPPUNIT_ASSERT(!utf_isValidDchar(0x101234));
+        CPPUNIT_ASSERT(utf_isValidDchar(0x101234));
     }
 
     void            testIsValidASCII()

--- a/src/test/UTFTest.cpp
+++ b/src/test/UTFTest.cpp
@@ -74,12 +74,14 @@ public:             // Tests
 
     void            testIsValidNonCharacter1()
     {
-        CPPUNIT_ASSERT(!utf_isValidDchar(0x03FFFE));
+        // TODO: Review this!
+        CPPUNIT_ASSERT(utf_isValidDchar(0x03FFFE));
     }
 
     void            testIsValidNonCharacter2()
     {
-        CPPUNIT_ASSERT(!utf_isValidDchar(0x00FDD9));
+        // TODO: Review this!
+        CPPUNIT_ASSERT(utf_isValidDchar(0x00FDD9));
     }
 
     void            testIsValidPrivateUse1()

--- a/src/utf.c
+++ b/src/utf.c
@@ -76,17 +76,13 @@ using namespace Unicode;
 
 /// The Unicode code space is the range of code points [0x000000,0x10FFFF]
 /// except the UTF-16 surrogate pairs in the range [0xD800,0xDFFF]
-/// and non-characters (which end in 0xFFFE or 0xFFFF).  The D language
-/// reference also rejects Private-Use code points.
+/// and non-characters (which end in 0xFFFE or 0xFFFF).
 bool utf_isValidDchar(dchar_t c)
 {
-    return c <= 0x0EFFFD                        // largest non-private code point
+    return c <= 0x10FFFD                        // largest character code point
         && !(0xD800 <= c && c <= 0xDFFF)        // surrogate pairs
         && (c & 0xFFFE) != 0xFFFE               // non-characters
         && !(0x00FDD0 <= c && c <= 0x00FDEF)    // non-characters
-        && !(0x00E000 <= c && c <= 0x00F8FF)    // private-use
-//      && !(0x0F0000 <= c && c <= 0x0FFFFD)    // private-use supp. A
-//      && !(0x100000 <= c && c <= 0x10FFFD)    // private-use supp. B
         ;
 }
 

--- a/src/utf.c
+++ b/src/utf.c
@@ -79,10 +79,12 @@ using namespace Unicode;
 /// and non-characters (which end in 0xFFFE or 0xFFFF).
 bool utf_isValidDchar(dchar_t c)
 {
-    return c <= 0x10FFFD                        // largest character code point
+    // TODO: Whether non-char code points should be rejected is pending review
+    return c <= 0x10FFFF                        // largest character code point
         && !(0xD800 <= c && c <= 0xDFFF)        // surrogate pairs
-        && (c & 0xFFFE) != 0xFFFE               // non-characters
-        && !(0x00FDD0 <= c && c <= 0x00FDEF)    // non-characters
+        && (c & 0xFFFFFE) != 0x00FFFE           // non-characters
+//        && (c & 0xFFFE) != 0xFFFE               // non-characters
+//        && !(0x00FDD0 <= c && c <= 0x00FDEF)    // non-characters
         ;
 }
 


### PR DESCRIPTION
Although I agree that private-use code points should be treated as D characters, the issue of non-character code points must be addressed.
