### PR TITLE
ComplexExp::toChars fills wrong buffers on non-GDC

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2528,8 +2528,8 @@ char *ComplexExp::toChars()
     creall(value).format(buf1, sizeof(buf1));
     cimagl(value).format(buf2, sizeof(buf2));
 #else
-    ld_sprint(buffer, 'g', creall(value));
-    ld_sprint(buffer, 'g', cimagl(value));
+    ld_sprint(buf1, 'g', creall(value));
+    ld_sprint(buf2, 'g', cimagl(value));
 #endif
     sprintf(buffer, "(%s+%si)", buf1, buf2);
     assert(strlen(buffer) < sizeof(buffer));


### PR DESCRIPTION
Resulted in uninitialized buffers being used in the subsequent sprintf (potential buffer overflow).

I didn't hit this problem, I just stumbled upon the mistake browsing the code. Looks like it was introduced by 6faeb273.
