### PR TITLE
Minor: Fix uninitialized globals

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -96,9 +96,19 @@ Global::Global()
 #endif
     ;
     version = "v2.060";
-    global.structalign = 8;
+
+    path = NULL;
+    filePath = NULL;
+
+    structalign = 8;
 
     memset(&params, 0, sizeof(Param));
+
+    errors = 0;
+    warnings = 0;
+    gag = 0;
+    gaggedErrors = 0;
+    speculativeGag = 0;
 }
 
 unsigned Global::startGagging()


### PR DESCRIPTION
If these were causing problems it would have come up long ago most likely but better safe than sorry. Feel free to close this if you don't think it is necessary (I don't have a strong grasp of the finer details of uninitialized variable behavior).
- Global::path = NULL
- Global::filePath = NULL
- Global::structAlign = 8 (was initialized but in a weird--probably unintentional--way through the global "global")
- Global::errors = 0
- Global::warnings = 0
- Global::gag = 0
- Global::gaggedErrors = 0
- Global::speculativeGag = 0
