### PR TITLE
fix dmc warning about missing return

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4883,7 +4883,7 @@ TOK reverseRelation(TOK op)
         case TOKle: return TOKgt;
         case TOKlt: return TOKge;
         default:
-            assert(0);
+            return assert(0), TOKreserved;
     }
 }
 


### PR DESCRIPTION
It would be great if we'd enable the dmc switch.
`-wx treat warnings as errors`
