### PR TITLE
Fix issue 8249 Spurious error message with templates and alias this

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1331,7 +1331,7 @@ Type *Type::aliasthisOf()
                     if (spec && global.errors != olderrs)
                         spec->errors = global.errors - olderrs;
                 }
-                if (!global.errors)
+                if (!fd->errors)
                 {
                     Type *t = fd->type->nextOf();
                     t = t->substWildTo(mod == 0 ? MODmutable : mod);


### PR DESCRIPTION
Lookup should be blocked only by errors in this particular template instance, not by any global error.
