### PR TITLE
Stop running CTFE on symbols, + fix bug 8237

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -956,7 +956,7 @@ void PragmaDeclaration::semantic(Scope *sc)
                 Expression *e = (*args)[i];
 
                 e = e->semantic(sc);
-                if (e->op != TOKerror)
+                if (e->op != TOKerror && e->op != TOKtype)
                     e = e->ctfeInterpret();
                 if (e->op == TOKerror)
                 {   errorSupplemental(loc, "while evaluating pragma(msg, %s)", (*args)[i]->toChars());

--- a/src/expression.c
+++ b/src/expression.c
@@ -3011,6 +3011,8 @@ Lagain:
         s = ti->toAlias();
         if (!s->isTemplateInstance())
             goto Lagain;
+        if (ti->errors)
+            return new ErrorExp();
         e = new ScopeExp(loc, ti);
         e = e->semantic(sc);
         return e;

--- a/src/expression.c
+++ b/src/expression.c
@@ -4267,6 +4267,8 @@ Lagain:
             ti->semantic(sc);
         if (ti->inst)
         {
+            if (ti->inst->errors)
+                return new ErrorExp();
             Dsymbol *s = ti->inst->toAlias();
             sds2 = s->isScopeDsymbol();
             if (!sds2)

--- a/src/init.c
+++ b/src/init.c
@@ -819,6 +819,8 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
     //printf("ExpInitializer::semantic(%s), type = %s\n", exp->toChars(), t->toChars());
     exp = exp->semantic(sc);
     exp = resolveProperties(sc, exp);
+    if (exp->op == TOKerror)
+        return this;
 
     int olderrors = global.errors;
     if (needInterpret)
@@ -869,6 +871,8 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
     }
 
     exp = exp->implicitCastTo(sc, t);
+    if (exp->op == TOKerror)
+        return this;
 L1:
     if (needInterpret)
         exp = exp->ctfeInterpret();

--- a/src/statement.c
+++ b/src/statement.c
@@ -2890,7 +2890,7 @@ Statement *PragmaStatement::semantic(Scope *sc)
                 Expression *e = (*args)[i];
 
                 e = e->semantic(sc);
-                if (e->op != TOKerror)
+                if (e->op != TOKerror && e->op != TOKtype)
                     e = e->ctfeInterpret();
                 if (e->op == TOKerror)
                 {   errorSupplemental(loc, "while evaluating pragma(msg, %s)", (*args)[i]->toChars());

--- a/src/template.c
+++ b/src/template.c
@@ -1825,6 +1825,12 @@ void TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Obj
             }
         }
     }
+    if (ea && ea->op == TOKtype)
+        targ = ea->type;
+    else if (ea && ea->op == TOKimport)
+        sa = ((ScopeExp *)ea)->sds;
+    else if (ea && (ea->op == TOKthis || ea->op == TOKsuper))
+        sa = ((ThisExp *)ea)->var;
 
     if (targ)
     {
@@ -3785,6 +3791,11 @@ MATCH TemplateAliasParameter::matchArg(Scope *sc, Objects *tiargs,
     }
 
     sa = getDsymbol(oarg);
+    ea = isExpression(oarg);
+    if (ea && (ea->op == TOKthis || ea->op == TOKsuper))
+        sa = ((ThisExp *)ea)->var;
+    else if (ea && ea->op == TOKimport)
+        sa = ((ScopeExp *)ea)->sds;
     if (sa)
     {
         /* specType means the alias must be a declaration with a type
@@ -3801,7 +3812,6 @@ MATCH TemplateAliasParameter::matchArg(Scope *sc, Objects *tiargs,
     else
     {
         sa = oarg;
-        ea = isExpression(oarg);
         if (ea)
         {   if (specType)
             {
@@ -5052,7 +5062,8 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                 ea = ea->optimize(WANTvalue);
             else if (ea->op != TOKvar && ea->op != TOKtuple &&
                      ea->op != TOKimport && ea->op != TOKtype &&
-                     ea->op != TOKfunction)
+                     ea->op != TOKfunction &&
+                     ea->op != TOKthis && ea->op != TOKsuper)
                 ea = ea->ctfeInterpret();
             (*tiargs)[j] = ea;
             if (ea->op == TOKtype)

--- a/src/template.c
+++ b/src/template.c
@@ -795,6 +795,8 @@ MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
         }
 
         e = e->semantic(sc);
+        if (e->op == TOKerror)
+            goto Lnomatch;
 
         if (fd && fd->vthis)
             fd->vthis = vthissave;
@@ -1764,6 +1766,8 @@ Lmatch:
         previous = pr.prev;             // unlink from threaded list
 
         if (nerrors != global.errors)   // if any errors from evaluating the constraint, no match
+            goto Lnomatch;
+        if (e->op == TOKerror)
             goto Lnomatch;
 
         e = e->ctfeInterpret();
@@ -5062,7 +5066,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                 ea = ea->optimize(WANTvalue);
             else if (ea->op != TOKvar && ea->op != TOKtuple &&
                      ea->op != TOKimport && ea->op != TOKtype &&
-                     ea->op != TOKfunction &&
+                     ea->op != TOKfunction && ea->op != TOKerror &&
                      ea->op != TOKthis && ea->op != TOKsuper)
                 ea = ea->ctfeInterpret();
             (*tiargs)[j] = ea;

--- a/src/template.c
+++ b/src/template.c
@@ -4582,6 +4582,8 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         {   if (!sc->parameterSpecialization)
                 inst = this;
             //printf("error return %p, %d\n", tempdecl, global.errors);
+            if (inst)
+                ++inst->errors;
             return;             // error recovery
         }
 

--- a/src/template.c
+++ b/src/template.c
@@ -5048,7 +5048,9 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
             ea = ea->semantic(sc);
             if (flags & 1) // only used by __traits, must not interpret the args
                 ea = ea->optimize(WANTvalue);
-            else if (ea->op != TOKvar && ea->op != TOKtuple)
+            else if (ea->op != TOKvar && ea->op != TOKtuple &&
+                     ea->op != TOKimport && ea->op != TOKtype &&
+                     ea->op != TOKfunction)
                 ea = ea->ctfeInterpret();
             (*tiargs)[j] = ea;
             if (ea->op == TOKtype)


### PR DESCRIPTION
CTFE should only be run on expressions, not symbols. Up to now, CTFE has been requested for template alias parameters. This happened to work, because optimize(WANTinterpret) just ignored them. This tightens it all up.
Also fixes:

8237 Error message with _error_ when using failed type inference in template parameter

because it's another case where a symbol (an erroneous one!) gets passed to CTFE.
