### PR TITLE
Implement `auto ref` that can receive both lvalue and rvalue, even if the function is template or not.

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -971,8 +971,8 @@ void VarDeclaration::semantic(Scope *sc)
             error("no definition of struct %s", ts->toChars());
         }
     }
-    if ((storage_class & STCauto) && !inferred)
-       error("storage class 'auto' has no effect if type is not inferred, did you mean 'scope'?");
+    if ((storage_class & (STCauto | STCparameter)) == STCauto && !inferred)
+        error("storage class 'auto' has no effect if type is not inferred, did you mean 'scope'?");
 
     if (tb->ty == Ttuple)
     {   /* Instead, declare variables for each of the tuple elements

--- a/src/expression.c
+++ b/src/expression.c
@@ -1214,6 +1214,16 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                     arg = arg->castTo(sc, p->type);
                     arg = arg->toLvalue(sc, arg);
                 }
+                else if (!arg->isLvalue() && p->storageClass & STCauto)
+                {
+                    Identifier *idtmp = Lexer::uniqueId("__tmprv");
+                    VarDeclaration *tmp = new VarDeclaration(loc, arg->type, idtmp, new ExpInitializer(0, arg));
+                    tmp->storage_class |= STCctfe;
+                    Expression *ae = new DeclarationExp(loc, tmp);
+                    Expression *e = new CommaExp(loc, ae, new VarExp(loc, tmp));
+                    arg = e->semantic(sc);
+                    arg = arg->toLvalue(sc, arg);
+                }
                 else
                     arg = arg->toLvalue(sc, arg);
             }

--- a/src/func.c
+++ b/src/func.c
@@ -2703,7 +2703,13 @@ MATCH FuncDeclaration::leastAsSpecialized(FuncDeclaration *g)
     {
         Parameter *p = Parameter::getNth(tf->parameters, u);
         Expression *e;
-        if (p->storageClass & (STCref | STCout))
+        if ((p->storageClass & (STCauto | STCref)) == (STCauto | STCref))
+        {
+            //     'ref' is more specialized than 'auto ref'
+            // non-'ref' is more specialized than 'auto ref'
+            e = p->type->defaultInitLiteral(0);
+        }
+        else if (p->storageClass & (STCref | STCout))
         {
             e = new IdentifierExp(0, p->ident);
             e->type = p->type;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5945,6 +5945,8 @@ MATCH TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
                             Type::tindex));
                     targb = targb->semantic(0, NULL);
                 }
+                else if (p->storageClass & STCauto)
+                    m = MATCHconvert;
                 else
                     goto Nomatch;
             }
@@ -9476,12 +9478,15 @@ void Parameter::toDecoBuffer(OutBuffer *buf)
 {
     if (storageClass & STCscope)
         buf->writeByte('M');
-    switch (storageClass & (STCin | STCout | STCref | STClazy))
+    switch (storageClass & (STCin | STCout | STCref | STClazy | STCauto))
     {   case 0:
         case STCin:
             break;
         case STCout:
             buf->writeByte('J');
+            break;
+        case STCauto | STCref:
+            buf->writestring("KK");
             break;
         case STCref:
             buf->writeByte('K');

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5033,7 +5033,6 @@ TypeFunction::TypeFunction(Parameters *parameters, Type *treturn, int varargs, e
     this->isproperty = false;
     this->isref = false;
     this->iswild = false;
-    this->fargs = NULL;
 
     if (stc & STCpure)
         this->purity = PUREfwdref;
@@ -5077,7 +5076,6 @@ Type *TypeFunction::syntaxCopy()
     t->isproperty = isproperty;
     t->isref = isref;
     t->trust = trust;
-    t->fargs = fargs;
     return t;
 }
 
@@ -5682,22 +5680,6 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 continue;
             }
 
-            /* Resolve "auto ref" storage class to be either ref or value,
-             * based on the argument matching the parameter
-             */
-            if (fparam->storageClass & STCauto)
-            {
-                if (fargs && i < fargs->dim)
-                {   Expression *farg = (*fargs)[i];
-                    if (farg->isLvalue())
-                        ;                               // ref parameter
-                    else
-                        fparam->storageClass &= ~STCref;        // value parameter
-                }
-                else
-                    error(loc, "auto can only be used for template function parameters");
-            }
-
             // Remove redundant storage classes for type, they are already applied
             fparam->storageClass &= ~(STC_TYPECTOR | STCin);
         }
@@ -6162,7 +6144,6 @@ Type *TypeFunction::addStorageClass(StorageClass stc)
         // Klunky to change these
         TypeFunction *tf = new TypeFunction(t->parameters, t->next, t->varargs, t->linkage, 0);
         tf->mod = t->mod;
-        tf->fargs = fargs;
         tf->purity = t->purity;
         tf->isnothrow = t->isnothrow;
         tf->isproperty = t->isproperty;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -648,7 +648,6 @@ struct TypeFunction : TypeNext
     enum TRUST trust;   // level of trust
     enum PURE purity;   // PURExxxx
     bool iswild;        // is inout function
-    Expressions *fargs; // function arguments
 
     int inuse;
 

--- a/src/template.c
+++ b/src/template.c
@@ -1354,8 +1354,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objec
                      */
                     if ((tt->ty == Tarray || tt->ty == Tpointer) &&
                         !tt->isMutable() &&
-                        (!(fparam->storageClass & STCref) ||
-                         (fparam->storageClass & STCauto) && !farg->isLvalue()))
+                        !(fparam->storageClass & STCref))
                     {
                         tt = tt->mutableOf();
                     }
@@ -1545,8 +1544,7 @@ Lretry:
              */
             if ((argtype->ty == Tarray || argtype->ty == Tpointer) &&
                 !argtype->isMutable() &&
-                (!(fparam->storageClass & STCref) ||
-                 (fparam->storageClass & STCauto) && !farg->isLvalue()))
+                !(fparam->storageClass & STCref))
             {
                 argtype = argtype->mutableOf();
             }
@@ -1609,7 +1607,7 @@ Lretry:
                 }
             }
 
-            if (m && (fparam->storageClass & (STCref | STCauto)) == STCref)
+            if (m && (fparam->storageClass & STCref))
             {
                 if (!farg->isLvalue())
                 {
@@ -1619,6 +1617,8 @@ Lretry:
                     else if (farg->op == TOKslice && argtype->ty == Tsarray)
                     {   // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
                     }
+                    else if (fparam->storageClass & STCauto)
+                        m = MATCHconvert;
                     else
                         goto Lnomatch;
                 }

--- a/src/template.c
+++ b/src/template.c
@@ -655,7 +655,7 @@ int TemplateDeclaration::overloadInsert(Dsymbol *s)
  * Declare all the function parameters as variables
  * and add them to the scope
  */
-void TemplateDeclaration::makeParamNamesVisibleInConstraint(Scope *paramscope, Expressions *fargs)
+void TemplateDeclaration::makeParamNamesVisibleInConstraint(Scope *paramscope)
 {
     /* We do this ONLY if there is only one function in the template.
      */
@@ -675,8 +675,7 @@ void TemplateDeclaration::makeParamNamesVisibleInConstraint(Scope *paramscope, E
             (*tf->parameters)[i]->defaultArg = NULL;
         tf->next = NULL;
 
-        // Resolve parameter types and 'auto ref's.
-        tf->fargs = fargs;
+        // Resolve parameter types
         tf = (TypeFunction *)tf->semantic(loc, paramscope);
 
         Parameters *fparameters = tf->parameters;
@@ -687,7 +686,7 @@ void TemplateDeclaration::makeParamNamesVisibleInConstraint(Scope *paramscope, E
         {
             Parameter *fparam = Parameter::getNth(fparameters, i);
             // Remove addMod same as func.d L1065 of FuncDeclaration::semantic3
-            fparam->storageClass &= (STCin | STCout | STCref | STClazy | STCfinal | STC_TYPECTOR | STCnodtor);
+            fparam->storageClass &= (STCin | STCout | STCauto | STCref | STClazy | STCfinal | STC_TYPECTOR | STCnodtor);
             fparam->storageClass |= STCparameter;
             if (fvarargs == 2 && i + 1 == nfparams)
                 fparam->storageClass |= STCvariadic;
@@ -721,7 +720,7 @@ void TemplateDeclaration::makeParamNamesVisibleInConstraint(Scope *paramscope, E
  */
 
 MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
-        Objects *dedtypes, Expressions *fargs, int flag)
+        Objects *dedtypes, int flag)
 {   MATCH m;
     size_t dedtypes_dim = dedtypes->dim;
 
@@ -817,7 +816,7 @@ MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
     if (m && constraint && !flag)
     {   /* Check to see if constraint is satisfied.
          */
-        makeParamNamesVisibleInConstraint(paramscope, fargs);
+        makeParamNamesVisibleInConstraint(paramscope);
         Expression *e = constraint->syntaxCopy();
         Scope *sc = paramscope->push();
 
@@ -913,7 +912,7 @@ Lret:
  *      0       td2 is more specialized than this
  */
 
-MATCH TemplateDeclaration::leastAsSpecialized(TemplateDeclaration *td2, Expressions *fargs)
+MATCH TemplateDeclaration::leastAsSpecialized(TemplateDeclaration *td2)
 {
     /* This works by taking the template parameters to this template
      * declaration and feeding them to td2 as if it were a template
@@ -951,7 +950,7 @@ MATCH TemplateDeclaration::leastAsSpecialized(TemplateDeclaration *td2, Expressi
     dedtypes.setDim(td2->parameters->dim);
 
     // Attempt a type deduction
-    MATCH m = td2->matchWithInstance(&ti, &dedtypes, fargs, 1);
+    MATCH m = td2->matchWithInstance(&ti, &dedtypes, 1);
     if (m)
     {
         /* A non-variadic template is more specialized than a
@@ -1819,7 +1818,7 @@ Lmatch:
     {   /* Check to see if constraint is satisfied.
          * Most of this code appears twice; this is a good candidate for refactoring.
          */
-        makeParamNamesVisibleInConstraint(paramscope, fargs);
+        makeParamNamesVisibleInConstraint(paramscope);
         Expression *e = constraint->syntaxCopy();
         paramscope->flags |= SCOPEstaticif;
 
@@ -2085,12 +2084,12 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Loc loc, Scope *sc,
             Objects dedtypes;
             dedtypes.setDim(td->parameters->dim);
             assert(td->semanticRun);
-            MATCH m2 = td->matchWithInstance(ti, &dedtypes, fargs, 0);
+            MATCH m2 = td->matchWithInstance(ti, &dedtypes, 0);
             //printf("matchWithInstance = %d\n", m2);
             if (!m2 || m2 < m_best2)        // no match or less match
                 continue;
 
-            ti->semantic(sc, fargs);
+            ti->semantic(sc);
             if (!ti->inst)                  // if template failed to expand
                 continue;
 
@@ -2145,8 +2144,8 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Loc loc, Scope *sc,
 
         {
         // Disambiguate by picking the most specialized TemplateDeclaration
-        MATCH c1 = td->leastAsSpecialized(td_best, fargs);
-        MATCH c2 = td_best->leastAsSpecialized(td, fargs);
+        MATCH c1 = td->leastAsSpecialized(td_best);
+        MATCH c2 = td_best->leastAsSpecialized(td);
         //printf("1: c1 = %d, c2 = %d\n", c1, c2);
 
         if (c1 > c2)
@@ -2157,12 +2156,12 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Loc loc, Scope *sc,
 
         if (!fd_best)
         {
-            fd_best = td_best->doHeaderInstantiation(sc, tdargs, fargs);
+            fd_best = td_best->doHeaderInstantiation(sc, tdargs);
             if (!fd_best)
                 goto Lerror;
         }
         {
-            fd = td->doHeaderInstantiation(sc, &dedargs, fargs);
+            fd = td->doHeaderInstantiation(sc, &dedargs);
             if (!fd)
                 goto Lerror;
         }
@@ -2256,7 +2255,7 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Loc loc, Scope *sc,
      */
     assert(td_best->scope);
     ti = new TemplateInstance(loc, td_best, tdargs);
-    ti->semantic(sc, fargs);
+    ti->semantic(sc);
     fd_best = ti->toAlias()->isFuncDeclaration();
     if (!fd_best)
         goto Lerror;
@@ -2327,7 +2326,7 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Loc loc, Scope *sc,
  * Limited function template instantiation for using fd->leastAsSpecialized()
  */
 FuncDeclaration *TemplateDeclaration::doHeaderInstantiation(Scope *sc,
-        Objects *tdargs, Expressions *fargs)
+        Objects *tdargs)
 {
     FuncDeclaration *fd = onemember->toAlias()->isFuncDeclaration();
     if (!fd)
@@ -2344,7 +2343,7 @@ FuncDeclaration *TemplateDeclaration::doHeaderInstantiation(Scope *sc,
     ti->tinst = sc->tinst;
     {
         ti->tdtypes.setDim(ti->tempdecl->parameters->dim);
-        if (!ti->tempdecl->matchWithInstance(ti, &ti->tdtypes, fargs, 2))
+        if (!ti->tempdecl->matchWithInstance(ti, &ti->tdtypes, 2))
             return NULL;
     }
 
@@ -2365,12 +2364,6 @@ FuncDeclaration *TemplateDeclaration::doHeaderInstantiation(Scope *sc,
     paramscope->stc = 0;
     ti->declareParameters(paramscope);
     paramscope->pop();
-
-    {
-        TypeFunction *tf = (TypeFunction *)fd->type;
-        if (tf && tf->ty == Tfunction)
-            tf->fargs = fargs;
-    }
 
     Scope *sc2;
     sc2 = scope->push(ti);
@@ -4743,11 +4736,6 @@ Dsymbol *TemplateInstance::syntaxCopy(Dsymbol *s)
 }
 
 
-void TemplateInstance::semantic(Scope *sc)
-{
-    semantic(sc, NULL);
-}
-
 void TemplateInstance::expandMembers(Scope *sc2)
 {
     for (size_t i = 0; i < members->dim; i++)
@@ -4835,7 +4823,7 @@ void TemplateInstance::trySemantic3(Scope *sc2)
     --nest;
 }
 
-void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
+void TemplateInstance::semantic(Scope *sc)
 {
     //printf("TemplateInstance::semantic('%s', this=%p, gag = %d, sc = %p)\n", toChars(), this, global.gag, sc);
 #if LOG
@@ -4871,7 +4859,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         assert(tempdecl->scope);
         // Deduce tdtypes
         tdtypes.setDim(tempdecl->parameters->dim);
-        if (!tempdecl->matchWithInstance(this, &tdtypes, fargs, 2))
+        if (!tempdecl->matchWithInstance(this, &tdtypes, 2))
         {
             error("incompatible arguments for template instantiation");
             inst = this;
@@ -4886,7 +4874,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
          */
         if (!findTemplateDeclaration(sc) ||
             !semanticTiargs(sc) ||
-            !findBestMatch(sc, fargs))
+            !findBestMatch(sc))
         {
             if (!sc->parameterSpecialization)
                 inst = this;
@@ -4925,34 +4913,6 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
 
         if (!arrayObjectMatch(&tdtypes, &ti->tdtypes, tempdecl, sc))
             goto L1;
-
-        /* Template functions may have different instantiations based on
-         * "auto ref" parameters.
-         */
-        if (fargs)
-        {
-            FuncDeclaration *fd = ti->toAlias()->isFuncDeclaration();
-            if (fd)
-            {
-                Parameters *fparameters = fd->getParameters(NULL);
-                size_t nfparams = Parameter::dim(fparameters); // Num function parameters
-                for (size_t j = 0; j < nfparams && j < fargs->dim; j++)
-                {   Parameter *fparam = Parameter::getNth(fparameters, j);
-                    Expression *farg = (*fargs)[j];
-                    if (fparam->storageClass & STCauto)         // if "auto ref"
-                    {
-                        if (farg->isLvalue())
-                        {   if (!(fparam->storageClass & STCref))
-                                goto L1;                        // auto ref's don't match
-                        }
-                        else
-                        {   if (fparam->storageClass & STCref)
-                                goto L1;                        // auto ref's don't match
-                        }
-                    }
-                }
-            }
-        }
 
         // It's a match
         inst = ti;
@@ -5163,22 +5123,6 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             //printf("'%s', '%s'\n", s->ident->toChars(), tempdecl->ident->toChars());
             //printf("setting aliasdecl\n");
             aliasdecl = new AliasDeclaration(loc, s->ident, s);
-        }
-    }
-
-    /* If function template declaration
-     */
-    if (fargs && aliasdecl)
-    {
-        FuncDeclaration *fd = aliasdecl->toAlias()->isFuncDeclaration();
-        if (fd)
-        {
-            /* Transmit fargs to type so that TypeFunction::semantic() can
-             * resolve any "auto ref" storage classes.
-             */
-            TypeFunction *tf = (TypeFunction *)fd->type;
-            if (tf && tf->ty == Tfunction)
-                tf->fargs = fargs;
         }
     }
 
@@ -5620,7 +5564,7 @@ bool TemplateInstance::findTemplateDeclaration(Scope *sc)
     return (tempdecl != NULL);
 }
 
-bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
+bool TemplateInstance::findBestMatch(Scope *sc)
 {
     /* Since there can be multiple TemplateDeclaration's with the same
      * name, look for the best match.
@@ -5674,7 +5618,7 @@ bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
         dedtypes.setDim(td->parameters->dim);
         dedtypes.zero();
         assert(td->semanticRun);
-        m = td->matchWithInstance(this, &dedtypes, fargs, 0);
+        m = td->matchWithInstance(this, &dedtypes, 0);
         //printf("matchWithInstance = %d\n", m);
         if (!m)                 // no match at all
             continue;
@@ -5686,8 +5630,8 @@ bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
 
         {
         // Disambiguate by picking the most specialized TemplateDeclaration
-        MATCH c1 = td->leastAsSpecialized(td_best, fargs);
-        MATCH c2 = td_best->leastAsSpecialized(td, fargs);
+        MATCH c1 = td->leastAsSpecialized(td_best);
+        MATCH c2 = td_best->leastAsSpecialized(td);
         //printf("c1 = %d, c2 = %d\n", c1, c2);
 
         if (c1 > c2)
@@ -6478,7 +6422,7 @@ void TemplateMixin::semantic(Scope *sc)
      * then find best match template with tiargs
      */
     if (!semanticTiargs(sc) ||
-        !findBestMatch(sc, NULL))
+        !findBestMatch(sc))
     {
         inst = this;
         inst->errors = true;

--- a/src/template.h
+++ b/src/template.h
@@ -91,20 +91,20 @@ struct TemplateDeclaration : ScopeDsymbol
     enum PROT prot();
 //    void toDocBuffer(OutBuffer *buf);
 
-    MATCH matchWithInstance(TemplateInstance *ti, Objects *atypes, Expressions *fargs, int flag);
-    MATCH leastAsSpecialized(TemplateDeclaration *td2, Expressions *fargs);
+    MATCH matchWithInstance(TemplateInstance *ti, Objects *atypes, int flag);
+    MATCH leastAsSpecialized(TemplateDeclaration *td2);
 
     MATCH deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objects *tiargs, Expression *ethis, Expressions *fargs, Objects *dedargs);
     FuncDeclaration *deduceFunctionTemplate(Loc loc, Scope *sc, Objects *tiargs, Expression *ethis, Expressions *fargs, int flags = 0);
     Object *declareParameter(Scope *sc, TemplateParameter *tp, Object *o);
-    FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs, Expressions *fargs);
+    FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs);
 
     TemplateDeclaration *isTemplateDeclaration() { return this; }
 
     TemplateTupleParameter *isVariadic();
     int isOverloadable();
 
-    void makeParamNamesVisibleInConstraint(Scope *paramscope, Expressions *fargs);
+    void makeParamNamesVisibleInConstraint(Scope *paramscope);
 };
 
 struct TemplateParameter
@@ -312,7 +312,6 @@ struct TemplateInstance : ScopeDsymbol
     TemplateInstance(Loc loc, TemplateDeclaration *tempdecl, Objects *tiargs);
     static Objects *arraySyntaxCopy(Objects *objs);
     Dsymbol *syntaxCopy(Dsymbol *);
-    void semantic(Scope *sc, Expressions *fargs);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
@@ -332,7 +331,7 @@ struct TemplateInstance : ScopeDsymbol
     static void semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int flags);
     bool semanticTiargs(Scope *sc);
     bool findTemplateDeclaration(Scope *sc);
-    bool findBestMatch(Scope *sc, Expressions *fargs);
+    bool findBestMatch(Scope *sc);
     void declareParameters(Scope *sc);
     int hasNestedArgs(Objects *tiargs);
     Identifier *genIdent(Objects *args);

--- a/test/runnable/autoref.d
+++ b/test/runnable/autoref.d
@@ -1,0 +1,79 @@
+struct S {}
+
+void foo   (auto ref S s) {}
+auto hoo(T)(auto ref T s) {}
+
+int bar   (auto ref S s) { return 1; }
+int bar   (         S s) { return 3; }
+int var(T)(auto ref T s) { return 1; }
+int var(T)(         T s) { return 3; }
+
+// 'auto ref' parameter is mangled as same as 'ref' parameter.
+// So linker will raise "Previous Definition Different" error.
+int baw   (auto ref S s) { return 1; }
+int baw   (     ref S s) { return 2; }
+int vaw(T)(auto ref T s) { return 1; }
+int vaw(T)(     ref T s) { return 2; }
+
+// 'auto ref' parameter is mangled as same as 'ref' parameter.
+// So linker will raise "Previous Definition Different" error.
+int bay(auto ref S s) { return 1; }
+int bay(     ref S s) { return 2; }
+int bay(         S s) { return 3; }
+
+struct S1 { int n; }
+struct S2 { this(int n){} }
+void baz(ref S1 s) {}
+void vaz(ref S2 s) {}
+
+bool testautoref()
+{
+    S s;
+
+    // 'auto ref' can bind both lvalue and rvalue
+    foo(s  );
+    foo(S());
+    // 'auto ref' and template function also can do.
+    hoo(s  );
+    hoo(S());
+    // 'auto ref' does not depends on IFTI
+    alias hoo!S Hoo;
+    Hoo(s  );
+    Hoo(S());
+
+    // overload resolution between 'auto ref' and non-ref
+    // 'auto ref' is always lesser matching.
+    assert(bar(s  ) == 1);
+    assert(bar(S()) == 3);
+    assert(var(s  ) == 1);
+    assert(var(S()) == 3);
+
+    //alias var!S Var;  // cannot make alias to overload set
+        // that instantiated by different function templates.
+    //assert(Var(s  ) == 1);
+    //assert(Var(S()) == 2);
+
+    // overload resolution between 'auto ref' and 'ref'
+    // 'auto ref' is always lesser matching.
+    assert(baw(s  ) == 2);
+    assert(baw(S()) == 1);
+    assert(vaw(s  ) == 2);
+    assert(vaw(S()) == 1);
+
+    // overload resolution between 'auto ref', 'ref', and non-ref
+    // 'auto ref' is always lesser matching, then *never matches anything*.
+    assert(bay(s  ) == 2);
+    assert(bay(S()) == 3);
+
+    // keep right behavior: rvalues never matches to 'ref'
+    static assert(!__traits(compiles, baz(S1(1)) ));
+    static assert(!__traits(compiles, vaz(S2(1)) ));
+
+    return true;
+}
+
+void main()
+{
+    testautoref();
+    static assert(testautoref());   // CTFE
+}

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -428,7 +428,8 @@ void test5885()
 struct S5889a { int n; }
 struct S5889b { this(int n){} }
 
-bool isLvalue(S)(auto ref S s){ return __traits(isRef, s); }
+bool isLvalue(S)(    S s){ return 0; }
+bool isLvalue(S)(ref S s){ return 1; }
 
 int foo(ref S5889a s) { return 1; }
 int foo(    S5889a s) { return 2; }

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -108,7 +108,7 @@ int foo6(T...)(auto ref T x)
         if (v == 10)
             assert(__traits(isRef, x[i]));
         else
-            assert(!__traits(isRef, x[i]));
+            assert(__traits(isRef, x[i]));
         result += v;
     }
     return result;
@@ -146,8 +146,8 @@ void test7()
     assert(i == 7);
     min(x, y) = 10;
     assert(x == 10);
-    static assert(!__traits(compiles, min(3, y) = 10));
-    static assert(!__traits(compiles, min(y, 3) = 10));
+    static assert(__traits(compiles, min(3, y) = 10));
+    static assert(__traits(compiles, min(y, 3) = 10));
 }
 
 /**********************************/
@@ -281,16 +281,16 @@ void test6404()
     int n;
 
     static assert(!__traits(compiles, rvalue(n)));
-    static assert( __traits(compiles, rvalue(0)));
+    static assert(!__traits(compiles, rvalue(0)));
 
     static assert( __traits(compiles, lvalue(n)));
-    static assert(!__traits(compiles, lvalue(0)));
+    static assert( __traits(compiles, lvalue(0)));
 
     static assert(!__traits(compiles, rvalueVargs(n)));
-    static assert( __traits(compiles, rvalueVargs(0)));
+    static assert(!__traits(compiles, rvalueVargs(0)));
 
     static assert( __traits(compiles, lvalueVargs(n)));
-    static assert(!__traits(compiles, lvalueVargs(0)));
+    static assert( __traits(compiles, lvalueVargs(0)));
 }
 
 /**********************************/
@@ -581,7 +581,7 @@ void test6208a()
     assert(getRefNonref(rvalue()) == 2);
 
     assert(getAutoRef(lvalue  ) == 1);
-    assert(getAutoRef(rvalue()) == 2);
+    assert(getAutoRef(rvalue()) == 1);
 
     static assert( __traits(compiles, getOut(lvalue  )));
     static assert(!__traits(compiles, getOut(rvalue())));
@@ -951,8 +951,8 @@ void goo10a(T   )(auto ref T)   { static assert(is(T    == const(int[]))); }
 void goo10b(T...)(auto ref T)   { static assert(is(T[0] == const(int[]))); }
 
 // auto ref with rvalue does
-void hoo10a(T   )(auto ref T)   { static assert(is(T    == const(int)[])); }
-void hoo10b(T...)(auto ref T)   { static assert(is(T[0] == const(int)[])); }
+void hoo10a(T   )(auto ref T)   { static assert(is(T    == const(int[]))); }
+void hoo10b(T...)(auto ref T)   { static assert(is(T[0] == const(int[]))); }
 
 void bar10a(T   )(T)            { static assert(is(T    == const(int)*)); }
 void bar10b(T...)(T)            { static assert(is(T[0] == const(int)*)); }


### PR DESCRIPTION
For rvalue argument, compiler will assign it to a temporary variable, and get its reference.
Change ref parameter semantics that can receive only pure lvalues, so users cannot pass struct-literals and constructions with `ref`.
Then opEquals in struct should have the signature:
`bool opEquals(const auto ref typeof(this) rhs) const;`
instead of:
`bool opEquals(const ref typeof(this) rhs) const;`

Note:
The current mangling character for `auto ref` is same as for `ref`, it is 'K'.
So overloading of `auto ref` and `ref` function is disallowed by the linker.
