### PR TITLE
Fix regression introduced by issue 7793 fix.

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -265,7 +265,7 @@ int StaticIfCondition::include(Scope *sc, ScopeDsymbol *s)
         {
             if (e->type->toBasetype() != Type::terror)
                 exp->error("expression %s of type %s does not have a boolean value", exp->toChars(), e->type->toChars());
-            inc = 2;
+            inc = 0;
             return 0;
         }
         e = e->ctfeInterpret();


### PR DESCRIPTION
In 3bfac13, inc is set to 2 instead of 0, which causes errors to go by unnoticed in some circumstances.

An alternative fix for 7793 would be to only skip invoking e->ctfeInterpret() if the type is not bool – I'm not sure why/if returning early is preferrable here.
