### PR TITLE
use CC variable to compile strtold.c

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -557,7 +557,7 @@ stringtable.o: $(ROOT)/stringtable.c
 	$(CC) -c $(GFLAGS) -I$(ROOT) $<
 
 strtold.o: $C/strtold.c
-	gcc $(MODEL_FLAG) -I$(ROOT) -c $<
+	$(CC) -c -I$(ROOT) $<
 
 struct.o: struct.c
 	$(CC) -c $(CFLAGS) $<


### PR DESCRIPTION
- strtold is compiled w/o optimizations
