### PR TITLE
Issue 7437,7980,8053 - Partial fix for stack overflow with recursive alias this

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -2047,6 +2047,9 @@ int typeMerge(Scope *sc, Expression *e, Type **pt, Expression **pe1, Expression 
     assert(t1);
     Type *t = t1;
 
+    Type *att1 = NULL;
+    Type *att2 = NULL;
+
     //if (t1) printf("\tt1 = %s\n", t1->toChars());
     //if (t2) printf("\tt2 = %s\n", t2->toChars());
 #ifdef DEBUG
@@ -2350,12 +2353,22 @@ Lcc:
             }
             else if (t1->ty == Tstruct && ((TypeStruct *)t1)->sym->aliasthis)
             {
+                if (att1 && e1->type == att1)
+                    goto Lincompatible;
+                if (!att1 && e1->type->checkAliasThisRec())
+                    att1 = e1->type;
+                //printf("att tmerge(c || c) e1 = %s\n", e1->type->toChars());
                 e1 = resolveAliasThis(sc, e1);
                 t1 = e1->type;
                 continue;
             }
             else if (t2->ty == Tstruct && ((TypeStruct *)t2)->sym->aliasthis)
             {
+                if (att2 && e2->type == att2)
+                    goto Lincompatible;
+                if (!att2 && e2->type->checkAliasThisRec())
+                    att2 = e2->type;
+                //printf("att tmerge(c || c) e2 = %s\n", e2->type->toChars());
                 e2 = resolveAliasThis(sc, e2);
                 t2 = e2->type;
                 continue;
@@ -2391,11 +2404,21 @@ Lcc:
             Expression *e2b = NULL;
             if (ts2->sym->aliasthis)
             {
+                if (att2 && e2->type == att2)
+                    goto Lincompatible;
+                if (!att2 && e2->type->checkAliasThisRec())
+                    att2 = e2->type;
+                //printf("att tmerge(s && s) e2 = %s\n", e2->type->toChars());
                 e2b = resolveAliasThis(sc, e2);
                 i1 = e2b->implicitConvTo(t1);
             }
             if (ts1->sym->aliasthis)
             {
+                if (att1 && e1->type == att1)
+                    goto Lincompatible;
+                if (!att1 && e1->type->checkAliasThisRec())
+                    att1 = e1->type;
+                //printf("att tmerge(s && s) e1 = %s\n", e1->type->toChars());
                 e1b = resolveAliasThis(sc, e1);
                 i2 = e1b->implicitConvTo(t2);
             }
@@ -2423,6 +2446,11 @@ Lcc:
     {
         if (t1->ty == Tstruct && ((TypeStruct *)t1)->sym->aliasthis)
         {
+            if (att1 && e1->type == att1)
+                goto Lincompatible;
+            if (!att1 && e1->type->checkAliasThisRec())
+                att1 = e1->type;
+            //printf("att tmerge(s || s) e1 = %s\n", e1->type->toChars());
             e1 = resolveAliasThis(sc, e1);
             t1 = e1->type;
             t = t1;
@@ -2430,6 +2458,11 @@ Lcc:
         }
         if (t2->ty == Tstruct && ((TypeStruct *)t2)->sym->aliasthis)
         {
+            if (att2 && e2->type == att2)
+                goto Lincompatible;
+            if (!att2 && e2->type->checkAliasThisRec())
+                att2 = e2->type;
+            //printf("att tmerge(s || s) e2 = %s\n", e2->type->toChars());
             e2 = resolveAliasThis(sc, e2);
             t2 = e2->type;
             t = t2;

--- a/src/cast.c
+++ b/src/cast.c
@@ -2047,6 +2047,11 @@ int typeMerge(Scope *sc, Expression *e, Type **pt, Expression **pe1, Expression 
     assert(t1);
     Type *t = t1;
 
+    /* The start type of alias this type recursion.
+     * In following case, we should save A, and stop recursion
+     * if it appears again.
+     *      X -> Y -> [A] -> B -> A -> B -> ...
+     */
     Type *att1 = NULL;
     Type *att2 = NULL;
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -6179,6 +6179,7 @@ UnaExp::UnaExp(Loc loc, enum TOK op, int size, Expression *e1)
         : Expression(loc, op, size)
 {
     this->e1 = e1;
+    this->att1 = NULL;
 }
 
 Expression *UnaExp::syntaxCopy()
@@ -6219,6 +6220,9 @@ BinExp::BinExp(Loc loc, enum TOK op, int size, Expression *e1, Expression *e2)
 {
     this->e1 = e1;
     this->e2 = e2;
+
+    this->att1 = NULL;
+    this->att2 = NULL;
 }
 
 Expression *BinExp::syntaxCopy()
@@ -9524,8 +9528,10 @@ Lagain:
             e = e->semantic(sc);
             return e;
         }
-        if (ad->aliasthis)
+        if (ad->aliasthis && e1->type != att1)
         {
+            if (!att1 && e1->type->checkAliasThisRec())
+                att1 = e1->type;
             e1 = resolveAliasThis(sc, e1);
             goto Lagain;
         }

--- a/src/expression.h
+++ b/src/expression.h
@@ -769,6 +769,7 @@ struct IsExp : Expression
 struct UnaExp : Expression
 {
     Expression *e1;
+    Type *att1; // Save alias this type to detect recursion
 
     UnaExp(Loc loc, enum TOK op, int size, Expression *e1);
     Expression *syntaxCopy();
@@ -791,6 +792,9 @@ struct BinExp : Expression
 {
     Expression *e1;
     Expression *e2;
+
+    Type *att1; // Save alias this type to detect recursion
+    Type *att2; // Save alias this type to detect recursion
 
     BinExp(Loc loc, enum TOK op, int size, Expression *e1, Expression *e2);
     Expression *syntaxCopy();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -790,10 +790,20 @@ struct TypeReturn : TypeQualified
     void toJson(JsonOut *json);
 };
 
+// Whether alias this dependency is recursive or not.
+enum AliasThisRec
+{
+    RECno = 0,      // no alias this recursion
+    RECyes = 1,     // alias this has recursive dependency
+    RECfwdref = 2,  // not yet known
+
+    RECtracing = 0x4, // mark in progress of implicitConvTo/wildConvTo
+};
+
 struct TypeStruct : Type
 {
     StructDeclaration *sym;
-    int att, isrec;
+    enum AliasThisRec att;
 
     TypeStruct(StructDeclaration *sym);
     const char *kind();
@@ -929,7 +939,7 @@ struct TypeTypedef : Type
 struct TypeClass : Type
 {
     ClassDeclaration *sym;
-    int att, isrec;
+    enum AliasThisRec att;
 
     TypeClass(ClassDeclaration *sym);
     const char *kind();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -289,6 +289,7 @@ struct Type : Object
     Type *referenceTo();
     Type *arrayOf();
     Type *aliasthisOf();
+    int checkAliasThisRec();
     virtual Type *makeConst();
     virtual Type *makeInvariant();
     virtual Type *makeShared();
@@ -792,6 +793,7 @@ struct TypeReturn : TypeQualified
 struct TypeStruct : Type
 {
     StructDeclaration *sym;
+    int att, isrec;
 
     TypeStruct(StructDeclaration *sym);
     const char *kind();
@@ -927,6 +929,7 @@ struct TypeTypedef : Type
 struct TypeClass : Type
 {
     ClassDeclaration *sym;
+    int att, isrec;
 
     TypeClass(ClassDeclaration *sym);
     const char *kind();

--- a/src/opover.c
+++ b/src/opover.c
@@ -1259,6 +1259,8 @@ int ForeachStatement::inferAggregate(Scope *sc, Dsymbol *&sapply)
     int sliced = 0;
 #endif
     Type *tab;
+    Type *att = NULL;
+    Expression *org_aggr = aggr;
     AggregateDeclaration *ad;
 
     while (1)
@@ -1270,6 +1272,10 @@ int ForeachStatement::inferAggregate(Scope *sc, Dsymbol *&sapply)
             goto Lerr;
 
         tab = aggr->type->toBasetype();
+        if (att == tab)
+        {   aggr = org_aggr;
+            goto Lerr;
+        }
         switch (tab->ty)
         {
             case Tarray:
@@ -1315,6 +1321,8 @@ int ForeachStatement::inferAggregate(Scope *sc, Dsymbol *&sapply)
 
                 if (ad->aliasthis)
                 {
+                    if (!att && tab->checkAliasThisRec())
+                        att = tab;
                     aggr = new DotIdExp(aggr->loc, aggr, ad->aliasthis->ident);
                     continue;
                 }

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -248,6 +248,72 @@ void test7()
     static assert(!__traits(compiles, s3 is 10));   // typeMerge(s || s) e1
     static assert(!__traits(compiles, 10 is s1));   // typeMerge(s || s) e2
     static assert(!__traits(compiles, 10 is s3));   // typeMerge(s || s) e2
+
+    // SliceExp::semantic
+    static assert(!__traits(compiles, c1[]));
+    static assert(!__traits(compiles, c3[]));
+    static assert(!__traits(compiles, s1[]));
+    static assert(!__traits(compiles, s3[]));
+
+    // UnaExp::op_overload
+    static assert(!__traits(compiles, +c1[1]));
+    static assert(!__traits(compiles, +c3[1]));
+    static assert(!__traits(compiles, +s1[1]));
+    static assert(!__traits(compiles, +s3[1]));
+    static assert(!__traits(compiles, +c1[ ]));
+    static assert(!__traits(compiles, +c3[ ]));
+    static assert(!__traits(compiles, +s1[ ]));
+    static assert(!__traits(compiles, +s3[ ]));
+    static assert(!__traits(compiles, +c1));
+    static assert(!__traits(compiles, +c3));
+    static assert(!__traits(compiles, +s1));
+    static assert(!__traits(compiles, +s3));
+
+    // ArrayExp::op_overload
+    static assert(!__traits(compiles, c1[1]));
+    static assert(!__traits(compiles, c3[1]));
+    static assert(!__traits(compiles, s1[1]));
+    static assert(!__traits(compiles, s3[1]));
+
+    // BinExp::op_overload
+    static assert(!__traits(compiles, c1 + 10));    // e1
+    static assert(!__traits(compiles, c3 + 10));    // e1
+    static assert(!__traits(compiles, 10 + c1));    // e2
+    static assert(!__traits(compiles, 10 + c3));    // e2
+    static assert(!__traits(compiles, s1 + 10));    // e1
+    static assert(!__traits(compiles, s3 + 10));    // e1
+    static assert(!__traits(compiles, 10 + s1));    // e2
+    static assert(!__traits(compiles, 10 + s3));    // e2
+
+    // BinExp::compare_overload
+    static assert(!__traits(compiles, c1 < 10));    // (Object.opCmp(int) is invalid)
+    static assert(!__traits(compiles, c3 < 10));    // (Object.opCmp(int) is invalid)
+    static assert(!__traits(compiles, 10 < c1));    // (Object.opCmp(int) is invalid)
+    static assert(!__traits(compiles, 10 < c3));    // (Object.opCmp(int) is invalid)
+    static assert(!__traits(compiles, s1 < 10));    // e1
+    static assert(!__traits(compiles, s3 < 10));    // e1
+    static assert(!__traits(compiles, 10 < s1));    // e2
+    static assert(!__traits(compiles, 10 < s3));    // e2
+
+    // BinAssignExp::op_overload
+    static assert(!__traits(compiles, c1[1] += 1));
+    static assert(!__traits(compiles, c3[1] += 1));
+    static assert(!__traits(compiles, s1[1] += 1));
+    static assert(!__traits(compiles, s3[1] += 1));
+    static assert(!__traits(compiles, c1[ ] += 1));
+    static assert(!__traits(compiles, c3[ ] += 1));
+    static assert(!__traits(compiles, s1[ ] += 1));
+    static assert(!__traits(compiles, s3[ ] += 1));
+    static assert(!__traits(compiles, c1 += c0));   // e1
+    static assert(!__traits(compiles, c3 += c0));   // e1
+    static assert(!__traits(compiles, s1 += s0));   // e1
+    static assert(!__traits(compiles, s3 += s0));   // e1
+    static assert(!__traits(compiles, c0 += c1));   // e2
+    static assert(!__traits(compiles, c0 += c3));   // e2
+    static assert(!__traits(compiles, s0 += s1));   // e2
+    static assert(!__traits(compiles, s0 += s3));   // e2
+    static assert(!__traits(compiles, c1 += s1));   // e1 + e2
+    static assert(!__traits(compiles, c3 += s3));   // e1 + e2
 }
 
 /***************************************************/

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -330,6 +330,12 @@ void test7()
     static assert(!__traits(compiles, s0 += s3));   // e2
     static assert(!__traits(compiles, c1 += s1));   // e1 + e2
     static assert(!__traits(compiles, c3 += s3));   // e1 + e2
+
+    // ForeachStatement::inferAggregate
+    static assert(!__traits(compiles, { foreach (e; s1){} }));
+    static assert(!__traits(compiles, { foreach (e; s3){} }));
+    static assert(!__traits(compiles, { foreach (e; c1){} }));
+    static assert(!__traits(compiles, { foreach (e; c3){} }));
 }
 
 /***************************************************/

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -336,6 +336,10 @@ void test7()
     static assert(!__traits(compiles, { foreach (e; s3){} }));
     static assert(!__traits(compiles, { foreach (e; c1){} }));
     static assert(!__traits(compiles, { foreach (e; c3){} }));
+
+    // Expression::checkToBoolean
+    static assert(!__traits(compiles, { if (s1){} }));
+    static assert(!__traits(compiles, { if (s3){} }));
 }
 
 /***************************************************/

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -255,6 +255,22 @@ void test7()
     static assert(!__traits(compiles, s1[]));
     static assert(!__traits(compiles, s3[]));
 
+    // CallExp::semantic
+//  static assert(!__traits(compiles, c1()));
+//  static assert(!__traits(compiles, c3()));
+    static assert(!__traits(compiles, s1()));
+    static assert(!__traits(compiles, s3()));
+
+    // AssignExp::semantic
+    static assert(!__traits(compiles, { c1[1] = 0; }));
+    static assert(!__traits(compiles, { c3[1] = 0; }));
+    static assert(!__traits(compiles, { s1[1] = 0; }));
+    static assert(!__traits(compiles, { s3[1] = 0; }));
+    static assert(!__traits(compiles, { c1[ ] = 0; }));
+    static assert(!__traits(compiles, { c3[ ] = 0; }));
+    static assert(!__traits(compiles, { s1[ ] = 0; }));
+    static assert(!__traits(compiles, { s3[ ] = 0; }));
+
     // UnaExp::op_overload
     static assert(!__traits(compiles, +c1[1]));
     static assert(!__traits(compiles, +c3[1]));

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -186,6 +186,41 @@ void test6() {
 }
 
 /**********************************************/
+// recursive alias this detection
+
+class C0 {}
+
+class C1 { C2 c; alias c this; }
+class C2 { C1 c; alias c this; }
+
+class C3 { C2 c; alias c this; }
+
+struct S0 {}
+
+struct S1 { S2* ps; @property ref get(){return *ps;} alias get this; }
+struct S2 { S1* ps; @property ref get(){return *ps;} alias get this; }
+
+struct S3 { S2* ps; @property ref get(){return *ps;} alias get this; }
+
+void test7()
+{
+    // Able to check a type is implicitly convertible within a finite time.
+    static assert(!is(C1 : C0));
+    static assert( is(C2 : C1));
+    static assert( is(C1 : C2));
+    static assert(!is(C3 : C0));
+    static assert( is(C3 : C1));
+    static assert( is(C3 : C2));
+
+    static assert(!is(S1 : S0));
+    static assert( is(S2 : S1));
+    static assert( is(S1 : S2));
+    static assert(!is(S3 : S0));
+    static assert( is(S3 : S1));
+    static assert( is(S3 : S2));
+}
+
+/***************************************************/
 // 2781
 
 struct Tuple2781a(T...) {
@@ -901,6 +936,7 @@ int main()
     test4773();
     test5188();
     test6();
+    test7();
     test2781();
     test6546();
     test6736();

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -202,6 +202,11 @@ struct S2 { S1* ps; @property ref get(){return *ps;} alias get this; }
 
 struct S3 { S2* ps; @property ref get(){return *ps;} alias get this; }
 
+struct S4 { S5* ps; @property ref get(){return *ps;} alias get this; }
+struct S5 { S4* ps; @property ref get(){return *ps;} alias get this; }
+
+struct S6 { S5* ps; @property ref get(){return *ps;} alias get this; }
+
 void test7()
 {
     // Able to check a type is implicitly convertible within a finite time.
@@ -218,6 +223,31 @@ void test7()
     static assert(!is(S3 : S0));
     static assert( is(S3 : S1));
     static assert( is(S3 : S2));
+
+    C0 c0;  C1 c1;  C3 c3;
+    S0 s0;  S1 s1;  S3 s3;  S4 s4;  S6 s6;
+
+    // Allow merging types that contains alias this recursion.
+    static assert( __traits(compiles, c0 is c1));   // typeMerge(c || c) e2->implicitConvTo(t1);
+    static assert( __traits(compiles, c0 is c3));   // typeMerge(c || c) e2->implicitConvTo(t1);
+    static assert( __traits(compiles, c1 is c0));   // typeMerge(c || c) e1->implicitConvTo(t2);
+    static assert( __traits(compiles, c3 is c0));   // typeMerge(c || c) e1->implicitConvTo(t2);
+    static assert(!__traits(compiles, s1 is c0));   // typeMerge(c || c) e1
+    static assert(!__traits(compiles, s3 is c0));   // typeMerge(c || c) e1
+    static assert(!__traits(compiles, c0 is s1));   // typeMerge(c || c) e2
+    static assert(!__traits(compiles, c0 is s3));   // typeMerge(c || c) e2
+
+    static assert(!__traits(compiles, s1 is s0));   // typeMerge(s && s) e1
+    static assert(!__traits(compiles, s3 is s0));   // typeMerge(s && s) e1
+    static assert(!__traits(compiles, s0 is s1));   // typeMerge(s && s) e2
+    static assert(!__traits(compiles, s0 is s3));   // typeMerge(s && s) e2
+    static assert(!__traits(compiles, s1 is s4));   // typeMerge(s && s) e1 + e2
+    static assert(!__traits(compiles, s3 is s6));   // typeMerge(s && s) e1 + e2
+
+    static assert(!__traits(compiles, s1 is 10));   // typeMerge(s || s) e1
+    static assert(!__traits(compiles, s3 is 10));   // typeMerge(s || s) e1
+    static assert(!__traits(compiles, 10 is s1));   // typeMerge(s || s) e2
+    static assert(!__traits(compiles, 10 is s3));   // typeMerge(s || s) e2
 }
 
 /***************************************************/


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7437">Issue 7437</a> - DMD enters infinite loop during overload resolution
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7980">Issue 7980</a> - Stack overflow / recursive expansion with alias this
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=8053">Issue 8053</a> - Recursive alias this causes infinite loop

Compiler should detect recursive alias this dependencies and avoid stack overflow / infinite loop.

This pull request is not complete (there is still problems around CastExp and castTo), but able to detect many cases.
