### PR TITLE
Use structalign_t in VarDeclaration

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -258,7 +258,7 @@ struct VarDeclaration : Declaration
 #else
     int nestedref;              // referenced by a lexically nested function
 #endif
-    unsigned short alignment;
+    structalign_t alignment;
     int ctorinit;               // it has been initialized in a ctor
     int onstack;                // 1: it has been allocated on the stack
                                 // 2: on stack, run destructor anyway


### PR DESCRIPTION
Because 65535 != 4294967295  in the comparison (alignment == STRUCTALIGN_DEFAULT)
