### PR TITLE
Error if requested alignment is not a power of 2.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -513,7 +513,11 @@ Dsymbols *Parser::parseDeclDefs(int once)
                 {
                     nextToken();
                     if (token.value == TOKint32v && token.uns64value > 0)
+                    {
+                        if (token.uns64value & (token.uns64value - 1))
+                            error("align(%s) must be a power of 2", token.toChars());
                         n = (unsigned)token.uns64value;
+                    }
                     else
                     {   error("positive integer expected, not %s", token.toChars());
                         n = 1;
@@ -536,7 +540,7 @@ Dsymbols *Parser::parseDeclDefs(int once)
                 nextToken();
                 check(TOKlparen);
                 if (token.value != TOKidentifier)
-                {   error("pragma(identifier expected");
+                {   error("pragma(identifier) expected");
                     goto Lerror;
                 }
                 ident = token.ident;


### PR DESCRIPTION
Disallows the use of align() where the value given isn't a power of 2.

Also noticed a missing closing bracket in an error message "pragma identifier expected" and thought to correct that too.
