### PR TITLE
Issue 4090 - No foreach type inference with const, ref etc modifiers

### DIFF
--- a/src/opover.c
+++ b/src/opover.c
@@ -1344,7 +1344,10 @@ int ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *&sapply)
         for (size_t u = 0; u < arguments->dim; u++)
         {   Parameter *arg = (*arguments)[u];
             if (arg->type)
+            {
                 arg->type = arg->type->semantic(loc, sc);
+                arg->type = arg->type->addStorageClass(arg->storageClass);
+            }
         }
 
         Expression *ethis;
@@ -1395,11 +1398,17 @@ int ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *&sapply)
             if (arguments->dim == 2)
             {
                 if (!arg->type)
+                {
                     arg->type = Type::tsize_t;  // key type
+                    arg->type = arg->type->addStorageClass(arg->storageClass);
+                }
                 arg = (*arguments)[1];
             }
             if (!arg->type && tab->ty != Ttuple)
+            {
                 arg->type = tab->nextOf();      // value type
+                arg->type = arg->type->addStorageClass(arg->storageClass);
+            }
             break;
 
         case Taarray:
@@ -1408,11 +1417,17 @@ int ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *&sapply)
             if (arguments->dim == 2)
             {
                 if (!arg->type)
+                {
                     arg->type = taa->index;     // key type
+                    arg->type = arg->type->addStorageClass(arg->storageClass);
+                }
                 arg = (*arguments)[1];
             }
             if (!arg->type)
+            {
                 arg->type = taa->next;          // value type
+                arg->type = arg->type->addStorageClass(arg->storageClass);
+            }
             break;
         }
 
@@ -1439,7 +1454,10 @@ int ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *&sapply)
                         // Resolve inout qualifier of front type
                         arg->type = fd->type->nextOf();
                         if (arg->type)
+                        {
                             arg->type = arg->type->substWildTo(tab->mod);
+                            arg->type = arg->type->addStorageClass(arg->storageClass);
+                        }
                     }
                     else if (s && s->isTemplateDeclaration())
                         ;
@@ -1559,7 +1577,10 @@ static int inferApplyArgTypesY(TypeFunction *tf, Parameters *arguments, int flag
                 goto Lnomatch;
         }
         else if (!flags)
+        {
             arg->type = param->type;
+            arg->type = arg->type->addStorageClass(arg->storageClass);
+        }
     }
   Lmatch:
     return 1;

--- a/src/parse.c
+++ b/src/parse.c
@@ -3908,13 +3908,54 @@ Statement *Parser::parseStatement(int flags)
                 Type *at;
 
                 StorageClass storageClass = 0;
-                if (token.value == TOKref
+            Lagain:
+                switch (token.value)
+                {
+                    case TOKref:
 #if D1INOUT
-                        || token.value == TOKinout
+                    case TOKinout:
 #endif
-                   )
-                {   storageClass = STCref;
-                    nextToken();
+                        storageClass |= STCref;
+                        nextToken();
+                        goto Lagain;
+
+                    case TOKconst:
+                        if (peekNext() != TOKlparen)
+                        {
+                            storageClass |= STCconst;
+                            nextToken();
+                            goto Lagain;
+                        }
+                        break;
+                    case TOKinvariant:
+                    case TOKimmutable:
+                        if (peekNext() != TOKlparen)
+                        {
+                            storageClass |= STCimmutable;
+                            if (token.value == TOKinvariant)
+                                deprecation("use of 'invariant' rather than 'immutable' is deprecated");
+                            nextToken();
+                            goto Lagain;
+                        }
+                        break;
+                    case TOKshared:
+                        if (peekNext() != TOKlparen)
+                        {
+                            storageClass |= STCshared;
+                            nextToken();
+                            goto Lagain;
+                        }
+                        break;
+                    case TOKwild:
+                        if (peekNext() != TOKlparen)
+                        {
+                            storageClass |= STCwild;
+                            nextToken();
+                            goto Lagain;
+                        }
+                        break;
+                    default:
+                        break;
                 }
                 if (token.value == TOKidentifier)
                 {

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -187,6 +187,20 @@ void test3187()
 }
 
 /***************************************/
+// 4090
+
+void test4090()
+{
+    double[10] arr;
+    double tot = 0;
+    foreach (const ref x; arr)
+    {
+        static assert(is(typeof(x) == const double));
+        tot += x;
+    }
+}
+
+/***************************************/
 // 5605
 
 struct MyRange
@@ -416,6 +430,7 @@ int main()
     test2442();
     test2443();
     test3187();
+    test4090();
     test5605();
     test7004();
     test7406();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=4090

Support storage classes `const`, `immutable`, `shared`, `inout` on foreach arguments.
