### PR TITLE
More fix for issue 7965

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7980,7 +7980,7 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
     //if (sym->isNested())
     //    return defaultInit(loc);
     Expressions *structelems = new Expressions();
-    structelems->setDim(sym->fields.dim);
+    structelems->setDim(sym->fields.dim - sym->isnested);
     for (size_t j = 0; j < structelems->dim; j++)
     {
         VarDeclaration *vd = sym->fields[j];
@@ -8000,7 +8000,7 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
     /* Copy from the initializer symbol for larger symbols,
      * otherwise the literals expressed as code get excessively large.
      */
-    if (size(loc) > PTRSIZE * 4)
+    if (size(loc) > PTRSIZE * 4 && !sym->isnested)
         structinit->sinit = sym->toInitializer();
 
     // Why doesn't the StructLiteralExp constructor do this, when

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -1612,6 +1612,31 @@ void test7965()
     S2 s2 = S2(10);
 }
 
+struct S7965
+{
+    string str;
+    uint unused1, unused2 = 0;
+}
+
+auto f7965(alias fun)()
+{
+    struct Result
+    {
+        S7965 s;
+        this(S7965 _s) { s = _s; }  // required for the problem
+        void g() { assert(fun(s.str) == "xa"); }
+    }
+
+    return Result(S7965("a"));
+}
+
+void test7965a()
+{
+    string s = "x";
+    f7965!(a => s ~= a)().g();
+    assert(s == "xa");
+}
+
 /*******************************************/
 // 8188
 
@@ -1741,6 +1766,7 @@ int main()
     test4841();
     test7199();
     test7965();
+    test7965a();
     test8188();
 
     test5082();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7965

All nested structs should be initialized by `StructLiteralExp`, not `__init`.
