### PR TITLE
Issue 8366 - Overriding const member function in conjunction with mutable overload causes a strange error

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5209,11 +5209,15 @@ Lcovariant:
      */
     if (!MODimplicitConv(t2->mod, t1->mod))
     {
+#if 0//stop attribute inference with const
         // If adding 'const' will make it covariant
         if (MODimplicitConv(t2->mod, MODmerge(t1->mod, MODconst)))
             stc |= STCconst;
         else
             goto Lnotcovariant;
+#else
+        goto Ldistinct;
+#endif
     }
 
     /* Can convert pure to impure, and nothrow to throw

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2744,6 +2744,57 @@ void test8212()
 }
 
 /************************************/
+// 8366
+
+class B8366
+{
+    bool foo(in Object o) const { return true; }
+}
+
+class C8366a : B8366
+{
+    bool foo(in Object o)              { return true; }
+  override
+    bool foo(in Object o) const        { return false; }
+    bool foo(in Object o) immutable    { return true; }
+    bool foo(in Object o) shared       { return true; }
+    bool foo(in Object o) shared const { return true; }
+}
+
+class C8366b : B8366
+{
+    bool foo(in Object o)              { return false; }
+    alias super.foo foo;
+    bool foo(in Object o) immutable    { return false; }
+    bool foo(in Object o) shared       { return false; }
+    bool foo(in Object o) shared const { return false; }
+}
+
+void test8366()
+{
+    {
+              C8366a mca = new C8366a();
+        const C8366a cca = new C8366a();
+              B8366  mb  = mca;
+        const B8366  cb  = cca;
+        assert(mca.foo(null) == true);
+        assert(cca.foo(null) == false);
+        assert(mb .foo(null) == false);
+        assert(cb .foo(null) == false);
+    }
+    {
+              C8366b mcb = new C8366b();
+        const C8366b ccb = new C8366b();
+              B8366  mb  = mcb;
+        const B8366  cb  = ccb;
+        assert(mcb.foo(null) == false);
+        assert(ccb.foo(null) == true);
+        assert(mb .foo(null) == true);
+        assert(cb .foo(null) == true);
+    }
+}
+
+/************************************/
 // 8408
 
 template hasMutableIndirection8408(T)
@@ -3001,6 +3052,7 @@ int main()
     test8099();
     test8201();
     test8212();
+    test8366();
     test8408();
     test8688();
     test9046();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4943,7 +4943,7 @@ class A158
 class B158 : A158
 {
     override void foo1() { }
-    override void foo2() { }
+    override void foo2() const { }
     override void foo3() { }
     override void foo4() { }
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8366

We MUST kill attribute inference with const. To implement it correctly without breaking overriding and overloading features, re-scanning and arrangement of vtbl entries is needed in the end of `ClassDeclaration::semantic`, it will decrease compile speed.

I think that is a big drawbacks than the benefit.
