### PR TITLE
new runtime registration for executables and shared libraries

### DIFF
--- a/src/backend/melf.h
+++ b/src/backend/melf.h
@@ -104,6 +104,7 @@ typedef struct
         #define SHF_WRITE       (1 << 0)    /* Writable during execution */
         #define SHF_ALLOC       (1 << 1)    /* In memory during execution */
         #define SHF_EXECINSTR   (1 << 2)    /* Executable machine instructions*/
+        #define SHF_GROUP       (1 << 9)    /* Member of a section group */
         #define SHF_TLS         (1 << 10)   /* Thread local */
         #define SHF_MASKPROC    0xf0000000  /* Mask for processor-specific */
   elf_add_f32   sh_addr;                /* Starting virtual memory address */

--- a/test/runnable/testthread.d
+++ b/test/runnable/testthread.d
@@ -3,10 +3,16 @@
 import std.c.stdio;
 import core.thread;
 
-extern (C)
+version (Posix)
 {
-    extern __thread int _tlsstart;
-    extern __thread int _tlsend;
+}
+else
+{
+    extern (C)
+    {
+        extern __thread int _tlsstart;
+        extern __thread int _tlsend;
+    }
 }
 
 int tlsx;
@@ -22,7 +28,7 @@ class Foo
 	tlsx = 5;
         Thread t = Thread.getThis();
 
-	version (OSX)
+	version (Posix)
 	{
 	}
 	else


### PR DESCRIPTION
- Put ModuleInfos and EH tables in bracketed sections. This
  works because the linker will preserve the order of first
  occurence for non-standard sections. Use local zero sized
  symbols as brackets to refer to the start and end.
- Pass ModuleInfos along with EH tables to a new druntime
  function _d_dso_registry. We output a function, a ctor
  entry, a dtor entry and a local data record in a COMDAT
  section group. The linker will merge multiple occurences
  per executable/shared library, thus resulting in only one
  registration.
- We can't create brackets for .bss, .data, .tbss and .tdata
  as these sections are already known to the linker. Thus it
  would merge input sections in link order. Creating custom
  input sections for those is not desirable because COMDAT
  through section prefixes (.data.TypeInfo) won't get merged
  into a single output section. The needed segments can be
  obtained by reading the program headers.
- Until REQUIRE_DSO_REGISTRY is set in elfobj.c any
  generated object remains compatible with the old mechanism
  that uses global bracket symbols.
