### PR TITLE
Issue 7385 - Bad error message missing line number on invalid array op that isn't special cased

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -389,6 +389,7 @@ Expression *BinAssignExp::arrayOp(Scope *sc)
     if (tn && (!tn->isMutable() || !tn->isAssignable()))
     {
         error("slice %s is not mutable", e1->toChars());
+        return new ErrorExp();
     }
 
     return BinExp::arrayOp(sc);

--- a/test/runnable/arrayop.d
+++ b/test/runnable/arrayop.d
@@ -432,7 +432,7 @@ void test4662()
 
     static assert(!is(typeof({ nums[] += nums[]; })));
     static assert(!is(typeof({ nums[] -= nums[]; })));
-    //static assert(!is(typeof({ nums[] /= nums[]; }))); // bug 7385 prevents this from failing properly
+    static assert(!is(typeof({ nums[] /= nums[]; })));
     static assert(!is(typeof({ nums[] += 4; })));
     static assert(!is(typeof({ nums[] /= 7; })));
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7385

This also fixes the problem of commented out test for issue 4662.
Just calling error() function cannot stop the code generation while gagging errors. If errors exist, we should return ErrorExp.
