### PR TITLE
Fix issue 8354 - Some missing "import std.math to use ^^ operator" error...

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -11472,6 +11472,7 @@ Expression *PowExp::semantic(Scope *sc)
         }
 
         static int importMathChecked = 0;
+        static bool importMath = false;
         if (!importMathChecked)
         {
             importMathChecked = 1;
@@ -11481,12 +11482,23 @@ Expression *PowExp::semantic(Scope *sc)
                 if (mi->ident == Id::math &&
                     mi->parent->ident == Id::std &&
                     !mi->parent->parent)
+                {
+                    importMath = true;
                     goto L1;
+                }
             }
             error("must import std.math to use ^^ operator");
             return new ErrorExp();
 
          L1: ;
+        }
+        else
+        {
+            if (!importMath)
+            {
+                error("must import std.math to use ^^ operator");
+                return new ErrorExp();
+            }                
         }
 
         e = new IdentifierExp(loc, Id::empty);


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8354

... messages

This patch fixes a wrong error message of multiple power expressions without 'import std.math'.
This patch does not fix 'import std.math: pow;' issue, because
'^^' spec is a another problem.
