### PR TITLE
Remove dead code in root.*, refactor redundant code

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -233,7 +233,7 @@ void Module::gendocfile()
         // Override with the ddoc macro files from the command line
         for (size_t i = 0; i < global.params.ddocfiles->dim; i++)
         {
-            FileName f((*global.params.ddocfiles)[i], 0);
+            FileName f((*global.params.ddocfiles)[i]);
             File file(&f);
             file.readv();
             // BUG: convert file contents to UTF-8 before use

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -311,7 +311,7 @@ void LibMSCoff::addObject(const char *module_name, void *buf, size_t buflen)
     int fromfile = 0;
     if (!buf)
     {   assert(module_name[0]);
-        FileName f((char *)module_name, 0);
+        FileName f((char *)module_name);
         File file(&f);
         file.readv();
         buf = file.buffer;

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -422,7 +422,7 @@ void LibOMF::addObject(const char *module_name, void *buf, size_t buflen)
 #endif
     if (!buf)
     {   assert(module_name);
-        FileName f((char *)module_name, 0);
+        FileName f((char *)module_name);
         File file(&f);
         file.readv();
         buf = file.buffer;

--- a/src/module.c
+++ b/src/module.c
@@ -150,7 +150,7 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
 #endif
 
     if (global.params.objname)
-        objfilename = new FileName(argobj, 0);
+        objfilename = new FileName(argobj);
     else
         objfilename = FileName::forceExt(argobj, global.obj_ext);
 
@@ -188,7 +188,7 @@ void Module::setDocfile()
         argdoc = FileName::combine(global.params.docdir, argdoc);
     }
     if (global.params.docname)
-        docfilename = new FileName(argdoc, 0);
+        docfilename = new FileName(argdoc);
     else
         docfilename = FileName::forceExt(argdoc, global.doc_ext);
 
@@ -216,7 +216,7 @@ void Module::setHdrfile()
         arghdr = FileName::combine(global.params.hdrdir, arghdr);
     }
     if (global.params.hdrname)
-        hdrfilename = new FileName(arghdr, 0);
+        hdrfilename = new FileName(arghdr);
     else
         hdrfilename = FileName::forceExt(arghdr, global.hdr_ext);
 

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -1,10 +1,11 @@
 
-// Copyright (c) 1999-2011 by Digital Mars
+// Copyright (c) 1999-2012 by Digital Mars
 // All Rights Reserved
 // written by Walter Bright
 // http://www.digitalmars.com
 
 #include "port.h"
+
 #if __DMC__
 #include <math.h>
 #include <float.h>
@@ -12,6 +13,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wchar.h>
 
 double Port::nan = NAN;
 double Port::infinity = INFINITY;
@@ -127,6 +129,7 @@ char *Port::strupr(char *s)
 #include <errno.h>
 #include <string.h>
 #include <ctype.h>
+#include <wchar.h>
 #include <stdlib.h>
 #include <limits> // for std::numeric_limits
 
@@ -343,6 +346,7 @@ char *Port::strupr(char *s)
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <wchar.h>
 #include <float.h>
 #include <assert.h>
 
@@ -510,7 +514,7 @@ char *Port::strupr(char *s)
 
 #endif
 
-#if __sun&&__SVR4
+#if __sun && __SVR4
 
 #define __C99FEATURES__ 1       // Needed on Solaris for NaN and more
 #include <math.h>
@@ -520,6 +524,7 @@ char *Port::strupr(char *s)
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <wchar.h>
 #include <float.h>
 #include <ieeefp.h>
 
@@ -648,4 +653,3 @@ char *Port::strupr(char *s)
 }
 
 #endif
-

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -1,5 +1,5 @@
 
-// Copyright (c) 1999-2009 by Digital Mars
+// Copyright (c) 1999-2012 by Digital Mars
 // All Rights Reserved
 // written by Walter Bright
 // http://www.digitalmars.com
@@ -11,9 +11,6 @@
 // The idea is to minimize #ifdef's in the app code.
 
 #include "longdouble.h"
-
-#ifndef TYPEDEFS
-#define TYPEDEFS
 
 #if _MSC_VER
 #include <float.h>  // for _isnan
@@ -28,8 +25,6 @@ typedef unsigned __int64 ulonglong;
 #else
 typedef long long longlong;
 typedef unsigned long long ulonglong;
-#endif
-
 #endif
 
 typedef double d_time;

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -15,16 +15,16 @@
 #ifndef TYPEDEFS
 #define TYPEDEFS
 
-#include <wchar.h>
-
 #if _MSC_VER
-typedef __int64 longlong;
-typedef unsigned __int64 ulonglong;
-
+#include <float.h>  // for _isnan
+#include <malloc.h> // for alloca
 // According to VC 8.0 docs, long double is the same as double
 longdouble strtold(const char *p,char **endp);
 #define strtof  strtod
+#define isnan   _isnan
 
+typedef __int64 longlong;
+typedef unsigned __int64 ulonglong;
 #else
 typedef long long longlong;
 typedef unsigned long long ulonglong;

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -15,44 +15,13 @@
 #ifdef DEBUG
 #include <assert.h>
 #endif
+#include "port.h"
 
 #if __DMC__
 #pragma once
 #endif
 
 typedef size_t hash_t;
-
-#include "longdouble.h"
-
-char *wchar2ascii(wchar_t *);
-int wcharIsAscii(wchar_t *);
-char *wchar2ascii(wchar_t *, unsigned len);
-int wcharIsAscii(wchar_t *, unsigned len);
-
-int bstrcmp(unsigned char *s1, unsigned char *s2);
-char *bstr2str(unsigned char *b);
-
-#ifndef TYPEDEFS
-#define TYPEDEFS
-
-#if _MSC_VER
-#include <float.h>  // for _isnan
-#include <malloc.h> // for alloca
-// According to VC 8.0 docs, long double is the same as double
-longdouble strtold(const char *p,char **endp);
-#define strtof  strtod
-#define isnan   _isnan
-
-typedef __int64 longlong;
-typedef unsigned __int64 ulonglong;
-#else
-typedef long long longlong;
-typedef unsigned long long ulonglong;
-#endif
-
-#endif
-
-longlong randomx();
 
 /*
  * Root of our class library.
@@ -107,11 +76,9 @@ struct Object
 
 struct String : Object
 {
-    int ref;                    // != 0 if this is a reference to someone else's string
     char *str;                  // the string itself
 
-    String(char *str, int ref = 1);
-
+    String(char *str);
     ~String();
 
     static hash_t calcHash(const char *str, size_t len);
@@ -127,8 +94,7 @@ struct String : Object
 
 struct FileName : String
 {
-    FileName(char *str, int ref);
-    FileName(char *path, char *name);
+    FileName(char *str);
     hash_t hashCode();
     int equals(Object *obj);
     static int equals(const char *name1, const char *name2);
@@ -378,6 +344,7 @@ struct ArrayBase : Array
     }
 };
 
+// TODO: Remove (only used by disabled GC)
 struct Bits : Object
 {
     unsigned bitdim;

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -17,6 +17,7 @@
 #include "rmem.h"                       // mem
 #include "stringtable.h"
 
+// TODO: Merge with root.String
 hash_t calcHash(const char *str, size_t len)
 {
     hash_t hash = 0;


### PR DESCRIPTION
- wchar*() not used
- bstr*() not used
- Merged TYPEDEFS into port.h
- randomx() not used
- String.ref not used
  - String itself only used in FileName
  - All uses of FileName set ref=0
- FileName(path, name) not used
- error_mem() not used
