### PR TITLE
Fix std_ioptab for DMDV2.

### DIFF
--- a/src/toir.c
+++ b/src/toir.c
@@ -414,20 +414,6 @@ int intrinsic_op(char *name)
         OPscale,
         OPrndtol,
         OPyl2xp1,
-
-        OPbt,
-        OPbsf,
-        OPbsr,
-        OPbtc,
-        OPbtr,
-        OPbts,
-        OPinp,
-        OPinp,
-        OPinp,
-        OPoutp,
-        OPbswap,
-        OPoutp,
-        OPoutp,
     };
 
 #ifdef DMDV2


### PR DESCRIPTION
Forgot to delete these.
