### PR TITLE
fix failing runnable test with DEBUG dmd (at least in Windows)

### DIFF
--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1,7 +1,5 @@
 // PERMUTE_ARGS:
 
-// Note: compiling this overflows the stack if dmd is build with DEBUG
-
 module breaker;
 
 import std.c.stdio;
@@ -335,7 +333,9 @@ void bug4984b(U)(U u) {
 }
 
 void bug4984() {
-    bug4984a!400();
+  // Note: compiling this overflows the stack if dmd is build with DEBUG
+  //bug4984a!400();
+    bug4984a!200();
     bug4984b(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
 }
 


### PR DESCRIPTION
At least in Windows platform, test/runnable/template9.d overflows the stack with DEBUG dmd.
Reducing recursion of the template instantiation would resolve the problem.
