### PR TITLE
Issue 8400 - static array type cannot interpret dynamic array length

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6369,9 +6369,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                 v = s->isVarDeclaration();
                 if (v && id == Id::length)
                 {
-                    e = v->getConstInitializer();
-                    if (!e)
-                        e = new VarExp(loc, v);
+                    e = new VarExp(loc, v);
                     t = e->type;
                     if (!t)
                         goto Lerror;

--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -554,6 +554,16 @@ int test4()
 static assert(test4() == 24666);
 
 /************************************/
+// 8400
+
+void test8400()
+{
+    immutable a = [1,2];
+    int[a.length+0] b; // ok
+    int[a.length  ] c; // error
+}
+
+/************************************/
 
 int main()
 {
@@ -561,6 +571,7 @@ int main()
     test2();
     test3();
     test6077();
+    test8400();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8400

Local variables _always_ should be interpreted to detect whether it is really constant expression or not.
