### PR TITLE
Issue 8397 - parameter types are not checked when assigning a function literal

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -140,12 +140,7 @@ Expression *ErrorExp::implicitCastTo(Scope *sc, Type *t)
 Expression *FuncExp::implicitCastTo(Scope *sc, Type *t)
 {
     //printf("FuncExp::implicitCastTo type = %p %s, t = %s\n", type, type ? type->toChars() : NULL, t->toChars());
-    if ((t->ty == Tpointer && t->nextOf()->ty == Tfunction) ||
-        t->ty == Tdelegate)
-    {
-        return inferType(t);
-    }
-    return Expression::implicitCastTo(sc, t);
+    return inferType(t)->Expression::implicitCastTo(sc, t);
 }
 
 /*******************************************

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -650,6 +650,17 @@ if (is(typeof(pred(1)) == bool))
 {}
 
 /***************************************************/
+// 8397
+
+void test8397()
+{
+    void function(int) f;
+  static assert(!is(typeof({
+    f = function(string x) {};
+  })));
+}
+
+/***************************************************/
 
 int main()
 {
@@ -687,6 +698,7 @@ int main()
     test8241();
     test8242();
     test8315();
+    test8397();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8397
