### PR TITLE
Implemented issue# 6277

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2312,7 +2312,15 @@ Lnext:
 
                 case 2:                 // no more digits to left of .
                     if (c == '.')
-                    {   dblstate++;
+                    {
+#if DMDV2
+                        unsigned char* next = p;
+                        while(*next == '_')
+                            ++next;
+                        if(hex ? !isxdigit(*next) : !isdigit(*next))
+                            error("Float literals must have digits to the right of their '.'");
+#endif
+                        dblstate++;
                         break;
                     }
                 case 4:                 // no more digits to right of .

--- a/test/runnable/test34.d
+++ b/test/runnable/test34.d
@@ -49,7 +49,7 @@ struct Struct
 {
     int langID;
     long _force_nrvo;
-}       
+}
 
 Struct[1] table;
 
@@ -57,7 +57,7 @@ Struct getfirst()
 {
     foreach(v; table) {
         writeln(v.langID);
-	assert(v.langID == 1);
+    assert(v.langID == 1);
         return v;
     }
     assert(0);
@@ -67,7 +67,7 @@ Struct getsecond()
 {
     foreach(ref v; table) {
         writeln(v.langID);
-	assert(v.langID == 1);
+    assert(v.langID == 1);
         return v;
     }
     assert(0);
@@ -92,11 +92,11 @@ class ExOuter
 {
     class ExInner
     {
-	this()
-	{
-	    typeof(this.outer) X;
-	    static assert(is(typeof(X) == ExOuter));
-	}
+    this()
+    {
+        typeof(this.outer) X;
+        static assert(is(typeof(X) == ExOuter));
+    }
     }
 }
 
@@ -107,20 +107,20 @@ void test4()
 /************************************************/
 
 int status5;
- 
+
 struct MyStruct5
 {
 }
- 
+
 void rec5(int i, MyStruct5 s)
 {
     if( i > 0 )
     {
-	status5++;
-	rec5(i-1, s);
+    status5++;
+    rec5(i-1, s);
     }
 }
- 
+
 void test5()
 {
     assert(status5==0);
@@ -155,37 +155,37 @@ void test6()
 template parseUinteger(string s)
 {
     static if (s.length == 0)
-    {	const char[] value = "";
-	const char[] rest = "";
+    {   const char[] value = "";
+    const char[] rest = "";
     }
     else static if (s[0] >= '0' && s[0] <= '9')
-    {	const char[] value = s[0] ~ parseUinteger!(s[1..$]).value;
-	const char[] rest = parseUinteger!(s[1..$]).rest;
+    {   const char[] value = s[0] ~ parseUinteger!(s[1..$]).value;
+    const char[] rest = parseUinteger!(s[1..$]).rest;
     }
     else
-    {	const char[] value = "";
-	const char[] rest = s;
+    {   const char[] value = "";
+    const char[] rest = s;
     }
 }
 
 template parseInteger(string s)
 {
     static if (s.length == 0)
-    {	const char[] value = "";
-	const char[] rest = "";
+    {   const char[] value = "";
+    const char[] rest = "";
     }
     else static if (s[0] >= '0' && s[0] <= '9')
-    {	const char[] value = s[0] ~ parseUinteger!(s[1..$]).value;
-	const char[] rest = parseUinteger!(s[1..$]).rest;
+    {   const char[] value = s[0] ~ parseUinteger!(s[1..$]).value;
+    const char[] rest = parseUinteger!(s[1..$]).rest;
     }
     else static if (s.length >= 2 &&
-		s[0] == '-' && s[1] >= '0' && s[1] <= '9')
-    {	const char[] value = s[0..2] ~ parseUinteger!(s[2..$]).value;
-	const char[] rest = parseUinteger!(s[2..$]).rest;
+        s[0] == '-' && s[1] >= '0' && s[1] <= '9')
+    {   const char[] value = s[0..2] ~ parseUinteger!(s[2..$]).value;
+    const char[] rest = parseUinteger!(s[2..$]).rest;
     }
     else
-    {	const char[] value = "";
-	const char[] rest = s;
+    {   const char[] value = "";
+    const char[] rest = s;
     }
 }
 
@@ -259,8 +259,8 @@ char[] toHtmlFilename(char[] fname)
 {
     foreach (ref c; fname)
     {
-	if (!isalnum(c) && c != '.' && c != '-')
-	    c = '_';
+    if (!isalnum(c) && c != '.' && c != '-')
+        c = '_';
     }
     return fname;
 }
@@ -304,9 +304,9 @@ class C13
     int a = 4;
     this()
     {
-	printf("C13.this()\n");
-	assert(a == 4);
-	a = 5;
+    printf("C13.this()\n");
+    assert(a == 4);
+    a = 5;
     }
 }
 
@@ -332,7 +332,7 @@ class Foo15 : Base15 {
 
 class Bar15 : Foo15 {
         alias Foo15.func func;
-	int func(string a) { return 2; }
+    int func(string a) { return 2; }
 }
 
 void test15()
@@ -350,9 +350,9 @@ struct Iterator16(T : Basic16!(T, U), U)
 {
     static void Foo()
     {
-	writeln(typeid(T), typeid(U));
-	assert(is(T == int));
-	assert(is(U == float));
+    writeln(typeid(T), typeid(U));
+    assert(is(T == int));
+    assert(is(U == float));
     }
 }
 
@@ -379,7 +379,7 @@ void test17()
     S17!(int).iterator i;
     auto x = insert17(a, i);
     assert(x == 3);
-} 
+}
 
 /************************************************/
 
@@ -388,10 +388,10 @@ void test18()
     real t = 0.0;
     for(int i=0; i<10; i++)
     {
-	t += 1.0;
-	real r =  (2*t);
-	printf("%Lg  %Lg  %Lg\n", t, r, 2*t);
-	assert(2*t == (i+1)*2);
+    t += 1.0;
+    real r =  (2*t);
+    printf("%Lg  %Lg  %Lg\n", t, r, 2*t);
+    assert(2*t == (i+1)*2);
     }
 }
 
@@ -417,16 +417,16 @@ class myclass20
 {
     template XX(uint a, uint c)
     {
-	static uint XX(){ return (a*256+c);}
+    static uint XX(){ return (a*256+c);}
     }
     void testcase()
     {
-	switch (cast(uint)type20.a)
-	{
-	    case XX!(cast(uint)type20.a,cast(uint)type20.b)():
-		break;
-	    default: assert(0);
-	}
+    switch (cast(uint)type20.a)
+    {
+        case XX!(cast(uint)type20.a,cast(uint)type20.b)():
+        break;
+        default: assert(0);
+    }
     }
 }
 
@@ -611,18 +611,18 @@ class RangeCoder
     ulong range;
 
     this() {
-	for (int i=0; i<cumCount.length; i++)
-	    cumCount[i] = i;
-	lower = 0;
-	upper = 0xffffffff;
-	range = 0x100000000;
+    for (int i=0; i<cumCount.length; i++)
+        cumCount[i] = i;
+    lower = 0;
+    upper = 0xffffffff;
+    range = 0x100000000;
     }
 
     void encode(uint symbol) {
-	uint total = cumCount[$ - 1];              
-	// "Error: Access Violation" in following line
-	upper = lower + cast(uint)((cumCount[symbol+1] * range) / total) - 1;
-	lower = lower + cast(uint)((cumCount[symbol]   * range) / total);
+    uint total = cumCount[$ - 1];
+    // "Error: Access Violation" in following line
+    upper = lower + cast(uint)((cumCount[symbol+1] * range) / total) - 1;
+    lower = lower + cast(uint)((cumCount[symbol]   * range) / total);
     }
 }
 
@@ -640,18 +640,18 @@ struct Vector34
 
     public static Vector34 opCall(float x = 0, float y = 0, float z = 0)
     {
-	Vector34 v;
+    Vector34 v;
 
-	v.x = x;
-	v.y = y;
-	v.z = z;
+    v.x = x;
+    v.y = y;
+    v.z = z;
 
-	return v;
+    return v;
     }
 
     public string toString()
     {
-	return std.string.format("<%f, %f, %f>", x, y, z);
+    return std.string.format("<%f, %f, %f>", x, y, z);
     }
 }
 
@@ -661,33 +661,33 @@ class Foo34
 
     public this()
     {
-	v = Vector34(1, 0, 0);
+    v = Vector34(1, 0, 0);
     }
 
     public void foo()
     {
-	bar();
+    bar();
     }
 
     private void bar()
     {
-	auto s = foobar();
-	writef("Returned: %s\n", s);
-	assert(std.string.format("%s", s) == "<1.000000, 0.000000, 0.000000>");
+    auto s = foobar();
+    writef("Returned: %s\n", s);
+    assert(std.string.format("%s", s) == "<1.000000, 0.000000, 0.000000>");
     }
 
     public Vector34 foobar()
     {
-	writef("Returning %s\n", v);
+    writef("Returning %s\n", v);
 
-	return v;
-	Vector34 b = Vector34();
-	return b;
+    return v;
+    Vector34 b = Vector34();
+    return b;
     }
 }
 
 void test34()
-{   
+{
     Foo34 f = new Foo34();
     f.foo();
 }
@@ -728,10 +728,10 @@ void test37()
 {
     synchronized
     {
-	synchronized
-	{
-	    writefln("Hello world!");
-	}
+    synchronized
+    {
+        writefln("Hello world!");
+    }
     }
 }
 
@@ -797,7 +797,7 @@ void test39()
 
 /************************************************/
 
-void test40() 
+void test40()
 {
     int[char] x;
     x['b'] = 123;
@@ -821,7 +821,7 @@ enum Enum42 {
 
 void test42() {
         Enum42[] enums = new Enum42[1];
-	assert(enums[0] == Enum42.A);
+    assert(enums[0] == Enum42.A);
 }
 
 
@@ -1026,12 +1026,12 @@ void test51()
 
 void test52()
 {
-    struct Foo {  
-	alias int Y;
-    }  
+    struct Foo {
+    alias int Y;
+    }
     with (Foo) {
-         Y y;  
-    }  
+         Y y;
+    }
 }
 
 /************************************************/
@@ -1116,29 +1116,29 @@ void test57()
 
     static if (is(AA T : T[U], U : const char[]))
     {
-	writeln(typeid(T));
-	writeln(typeid(U));
+    writeln(typeid(T));
+    writeln(typeid(U));
 
-	assert(is(T == long));
-	assert(is(U == const(char)[]));
+    assert(is(T == long));
+    assert(is(U == const(char)[]));
     }
 
     static if (is(AA A : A[B], B : int))
     {
-	assert(0);
+    assert(0);
     }
 
     static if (is(int[10] W : W[V], int V))
     {
-	writeln(typeid(W));
-	assert(is(W == int));
-	writeln(V);
-	assert(V == 10);
+    writeln(typeid(W));
+    assert(is(W == int));
+    writeln(V);
+    assert(V == 10);
     }
 
     static if (is(int[10] X : X[Y], int Y : 5))
     {
-	assert(0);
+    assert(0);
     }
 }
 
@@ -1164,11 +1164,11 @@ long foo58(B58 b)
 {   int i;
     try
     {
-	b.set(3);
+    b.set(3);
     }
     catch (HiddenFuncError o)
     {
-	i = 1;
+    i = 1;
     }
     assert(i == 1);
     return b.squareIt();
@@ -1213,20 +1213,20 @@ class C60
 {
     extern (C++) int bar60(int i, int j, int k)
     {
-	printf("this = %p\n", this);
-	printf("i = %d\n", i);
-	printf("j = %d\n", j);
-	printf("k = %d\n", k);
-	assert(i == 4);
-	assert(j == 5);
-	assert(k == 6);
-	return 1;
+    printf("this = %p\n", this);
+    printf("i = %d\n", i);
+    printf("j = %d\n", j);
+    printf("k = %d\n", k);
+    assert(i == 4);
+    assert(j == 5);
+    assert(k == 6);
+    return 1;
     }
 }
 
 
 extern (C++)
-	int foo60(int i, int j, int k)
+    int foo60(int i, int j, int k)
 {
     printf("i = %d\n", i);
     printf("j = %d\n", j);

--- a/test/runnable/test34.d
+++ b/test/runnable/test34.d
@@ -385,10 +385,10 @@ void test17()
 
 void test18()
 {
-    real t = 0.;
+    real t = 0.0;
     for(int i=0; i<10; i++)
     {
-	t += 1.;
+	t += 1.0;
 	real r =  (2*t);
 	printf("%Lg  %Lg  %Lg\n", t, r, 2*t);
 	assert(2*t == (i+1)*2);

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -27,21 +27,21 @@ void test1()
 
     int[6] foo = 1;
     for (i = 0; i < foo.length; i++)
-	assert(foo[i] == 1);
+    assert(foo[i] == 1);
 
     int[10] bar;
     for (i = 0; i < bar.length; i++)
-	assert(bar[i] == 0);
+    assert(bar[i] == 0);
 
     foo[3] = 4;
     int[6] abc = foo;
     for (i = 0; i < abc.length; i++)
-	assert(abc[i] == foo[i]);
+    assert(abc[i] == foo[i]);
 
     abc[2] = 27;
     foo[] = abc;
     for (i = 0; i < abc.length; i++)
-	assert(abc[i] == foo[i]);
+    assert(abc[i] == foo[i]);
 }
 
 /* ================================ */
@@ -64,32 +64,32 @@ void test2()
 
     printf("test2()\n");
     for (i = 0; i < foo1.length; i++)
-	assert(foo1[i] == 0);
+    assert(foo1[i] == 0);
     for (i = 0; i < foo2.length; i++)
-    {	printf("foo2[%d] = %d\n", i, foo2[i]);
-	assert(foo2[i] == 0);
+    {   printf("foo2[%d] = %d\n", i, foo2[i]);
+    assert(foo2[i] == 0);
     }
     for (i = 0; i < foo3.length; i++)
-	assert(foo3[i] == 0);
+    assert(foo3[i] == 0);
     for (i = 0; i < foo4.length; i++)
-	assert(foo4[i] == 0);
+    assert(foo4[i] == 0);
     for (i = 0; i < foo5.length; i++)
     {
-	printf("foo5[%d] = %d\n", i, foo5[i]);
-	assert(foo5[i] == 0);
+    printf("foo5[%d] = %d\n", i, foo5[i]);
+    assert(foo5[i] == 0);
     }
     for (i = 0; i < foo6.length; i++)
-	assert(foo6[i] == 0);
+    assert(foo6[i] == 0);
     for (i = 0; i < foo7.length; i++)
-	assert(foo7[i] == 0);
+    assert(foo7[i] == 0);
     for (i = 0; i < foo8.length; i++)
-	assert(foo8[i] == 0);
+    assert(foo8[i] == 0);
     for (i = 0; i < foo9.length; i++)
-	assert(isnan(foo9[i]));
+    assert(isnan(foo9[i]));
     for (i = 0; i < foo10.length; i++)
-	assert(isnan(foo10[i]));
+    assert(isnan(foo10[i]));
     for (i = 0; i < foo11.length; i++)
-	assert(isnan(foo11[i]));
+    assert(isnan(foo11[i]));
 }
 
 /* ================================ */
@@ -111,27 +111,27 @@ void test3()
     int i;
 
     for (i = 0; i < foo1.length; i++)
-	assert(foo1[i] == 20);
+    assert(foo1[i] == 20);
     for (i = 0; i < foo2.length; i++)
-	assert(foo2[i] == 21);
+    assert(foo2[i] == 21);
     for (i = 0; i < foo3.length; i++)
-	assert(foo3[i] == 22);
+    assert(foo3[i] == 22);
     for (i = 0; i < foo4.length; i++)
-	assert(foo4[i] == 23);
+    assert(foo4[i] == 23);
     for (i = 0; i < foo5.length; i++)
-	assert(foo5[i] == 24);
+    assert(foo5[i] == 24);
     for (i = 0; i < foo6.length; i++)
-	assert(foo6[i] == 25);
+    assert(foo6[i] == 25);
     for (i = 0; i < foo7.length; i++)
-	assert(foo7[i] == 26);
+    assert(foo7[i] == 26);
     for (i = 0; i < foo8.length; i++)
-	assert(foo8[i] == 27);
+    assert(foo8[i] == 27);
     for (i = 0; i < foo9.length; i++)
-	assert(foo9[i] == 28);
+    assert(foo9[i] == 28);
     for (i = 0; i < foo10.length; i++)
-	assert(foo10[i] == 29);
+    assert(foo10[i] == 29);
     for (i = 0; i < foo11.length; i++)
-	assert(foo11[i] == 30);
+    assert(foo11[i] == 30);
 }
 
 /* ================================ */
@@ -155,9 +155,9 @@ void test4()
     int j;
     for (j = 0; j < 3; j++)
     {
-	assert(c[j].b.length == 6);
-	i = cmp(c[j].b, "string");
-	assert(i == 0);
+    assert(c[j].b.length == 6);
+    i = cmp(c[j].b, "string");
+    assert(i == 0);
     }
 }
 
@@ -185,8 +185,8 @@ void test5()
     int i;
     for (i = 0; i < 5; i++)
     {
-	assert(foo5[i].c == 0);
-	assert(cmp(foo5[i].b, "string") == 0);
+    assert(foo5[i].c == 0);
+    assert(cmp(foo5[i].b, "string") == 0);
     }
 }
 
@@ -199,11 +199,11 @@ struct TRECT6
     union {
       struct
       {
-	int Left = 3, Top = 4, Right = 5, Bottom = 6;
+    int Left = 3, Top = 4, Right = 5, Bottom = 6;
       }
       struct
       {
-	long TopLeft, BottomRight;
+    long TopLeft, BottomRight;
       }
     }
 
@@ -269,20 +269,20 @@ struct TestVectors
 
 TestVectors tva[] =
 [
-  {  pattern:"(a)\\1",	input:"abaab",	result:"y",	format:"&",	replace:"aa" },
-  {  pattern:"abc",	input:"abc",	result:"y",	format:"&",	replace:"abc" },
+  {  pattern:"(a)\\1",  input:"abaab",  result:"y", format:"&", replace:"aa" },
+  {  pattern:"abc", input:"abc",    result:"y", format:"&", replace:"abc" },
 ];
 
 TestVectors tvs[2] =
 [
-  {  pattern:"(a)\\1",	input:"abaab",	result:"y",	format:"&",	replace:"aa" },
-  {  pattern:"abc",	input:"abc",	result:"y",	format:"&",	replace:"abc" },
+  {  pattern:"(a)\\1",  input:"abaab",  result:"y", format:"&", replace:"aa" },
+  {  pattern:"abc", input:"abc",    result:"y", format:"&", replace:"abc" },
 ];
 
 TestVectors* tvp =
 [
-  {  pattern:"(a)\\1",	input:"abaab",	result:"y",	format:"&",	replace:"aa" },
-  {  pattern:"abc",	input:"abc",	result:"y",	format:"&",	replace:"abc" },
+  {  pattern:"(a)\\1",  input:"abaab",  result:"y", format:"&", replace:"aa" },
+  {  pattern:"abc", input:"abc",    result:"y", format:"&", replace:"abc" },
 ];
 
 void test7()
@@ -418,14 +418,14 @@ class A13
 {
      X13 B(X13 x, out int i)
      {
-	i = 666;
-	return new X13;
+    i = 666;
+    return new X13;
      }
 
      X13 B(X13 x)
      {
-	int j;
-	return B(x, j);
+    int j;
+    return B(x, j);
      }
 }
 
@@ -448,11 +448,11 @@ int testx14(int x)
 {
     try
     {
-	return 3;
+    return 3;
     }
     finally
     {
-	foo14();
+    foo14();
     }
 }
 
@@ -461,8 +461,8 @@ class bar
     int y;
     synchronized int sync(int x)
     {
-	printf("in sync(%d) = %d\n", x, y + 3);
-	return y + 3;
+    printf("in sync(%d) = %d\n", x, y + 3);
+    return y + 3;
     }
 }
 
@@ -484,9 +484,9 @@ int foo15(int i)
 {
     switch (i)
     {
-	case 7:
-	case 8:
-	    return i;
+    case 7:
+    case 8:
+        return i;
     }
     return 0;
 }
@@ -496,12 +496,12 @@ void test15()
     int i = 0;
     try
     {
-	foo15(3);
+    foo15(3);
     }
     catch (SwitchError sw)
     {
-	//printf("caught switch error\n");
-	i = 1;
+    //printf("caught switch error\n");
+    i = 1;
     }
     assert(i == 1);
 }
@@ -512,10 +512,10 @@ void test15()
 
 struct GUID {          // size is 16
     align(1):
-	uint    Data1;
-	ushort  Data2;
-	ushort  Data3;
-	ubyte   Data4[8];
+    uint    Data1;
+    ushort  Data2;
+    ushort  Data3;
+    ubyte   Data4[8];
 }
 
 
@@ -599,7 +599,7 @@ void test19()
     int i;
 
     for (i = 0; i < 0xffff; i++)
-	assert(foo19[i] == 0);
+    assert(foo19[i] == 0);
 }
 
 /* ================================ */
@@ -692,21 +692,21 @@ struct Foo23
 
     int abc()
     {
-	def23(3, 4);
-	a *= b;
-	bar();
-	return a;
+    def23(3, 4);
+    a *= b;
+    bar();
+    return a;
     }
 
     int bar()
     {
-	a *= 2;
-	return a;
+    a *= 2;
+    return a;
     }
 
     invariant()
     {
-	assert(c == 9);
+    assert(c == 9);
     }
 }
 
@@ -724,8 +724,8 @@ void test23()
 
 struct Foo24
 {
-	int x, y;
-	int[] z;
+    int x, y;
+    int[] z;
 }
 
 void test24()
@@ -755,9 +755,9 @@ void test25()
 
     for (int i = 0; i < a.length - 1; i++)
     {
-	//printf("i = %d", i);
-	//printf(" %d %d\n", a[i], a[i + 1]);
-	assert(a[i] <= a[i + 1]);
+    //printf("i = %d", i);
+    //printf(" %d %d\n", a[i], a[i + 1]);
+    assert(a[i] <= a[i + 1]);
     }
 }
 
@@ -778,12 +778,12 @@ class Foo29
 {
     ~this()
     {
-	x29 = bar();
+    x29 = bar();
     }
 
     int bar()
     {
-	return 3;
+    return 3;
     }
 }
 
@@ -812,13 +812,13 @@ struct GC30
     void *malloc()
     {   void *p;
 
-	synchronized (gcLock)
-	{
-	    p = test();
-	    if (!p)
-		return null;
-	}
-	return p;
+    synchronized (gcLock)
+    {
+        p = test();
+        if (!p)
+        return null;
+    }
+    return p;
     }
 
     void *test() { return null; }
@@ -907,10 +907,10 @@ class X35
 {
     final synchronized void foo()
     {
-	for(;;)
-	{
-	    break;
-	}
+    for(;;)
+    {
+        break;
+    }
     }
 }
 
@@ -948,25 +948,25 @@ void test38()
 {
     version (D_Bits)
     {
-	bit a[];
-	a.length=3;
-	a[0]=false;
-	a[1]=true;
-	a[2]=false;
+    bit a[];
+    a.length=3;
+    a[0]=false;
+    a[1]=true;
+    a[2]=false;
 
-	bit[] b=a.sort;
+    bit[] b=a.sort;
 
-	assert(a.length==3);
-	assert(!a[0]);
-	assert(!a[1]);
-	assert(a[2]);
+    assert(a.length==3);
+    assert(!a[0]);
+    assert(!a[1]);
+    assert(a[2]);
 
-	assert(b.length==3);
-	assert(!b[0]);
-	assert(!b[1]);
-	assert(b[2]);
-	
-	assert(&a != &b);
+    assert(b.length==3);
+    assert(!b[0]);
+    assert(!b[1]);
+    assert(b[2]);
+
+    assert(&a != &b);
     }
 }
 
@@ -974,14 +974,14 @@ void test38()
 
 void test39()
 {
-	char[] array;
-	array.length=4;
-	char letter = 'a';
-	array[0..4]=letter;
-	assert(array[0]=='a');
-	assert(array[1]=='a');
-	assert(array[2]=='a');
-	assert(array[3]=='a');
+    char[] array;
+    array.length=4;
+    char letter = 'a';
+    array[0..4]=letter;
+    assert(array[0]=='a');
+    assert(array[1]=='a');
+    assert(array[2]=='a');
+    assert(array[3]=='a');
 }
 
 /* ================================ */
@@ -990,17 +990,17 @@ int dummyJob;
 
 int dummy()
 {
-	return ++dummyJob;
+    return ++dummyJob;
 }
 
 void bar40(){
-	return cast(void)dummy();
+    return cast(void)dummy();
 }
 
 int foo40()
 {
-	bar40();
-	return dummyJob-1;
+    bar40();
+    return dummyJob-1;
 }
 
 void test40()
@@ -1014,33 +1014,33 @@ int status;
 
 void check()
 {
-	assert(status==1);
-	void main(int dummy){
-		assert(status==3);
-		status+=5;
-	}
-	status+=2;
-	assert(status==3);
-	main(2);
-	assert(status==8);
-	status+=7;
+    assert(status==1);
+    void main(int dummy){
+        assert(status==3);
+        status+=5;
+    }
+    status+=2;
+    assert(status==3);
+    main(2);
+    assert(status==8);
+    status+=7;
 }
 
 void test41()
 {
-	status++;
-	assert(status==1);
-	check();
-	assert(status==15);
+    status++;
+    assert(status==1);
+    check();
+    assert(status==15);
 }
 
 /* ================================ */
 
 void test42()
 {
-	real[10] array;
-	real[] copy = array.dup;
-	copy.sort;
+    real[10] array;
+    real[] copy = array.dup;
+    copy.sort;
 }
 
 /* ================================ */
@@ -1074,10 +1074,10 @@ alias int MyInt;
 
 void test45()
 {
-	MyInt test(string c="x"){
-		return 2;
-	}
-	assert(test("abc")==2);
+    MyInt test(string c="x"){
+        return 2;
+    }
+    assert(test("abc")==2);
 }
 
 /* ================================ */
@@ -1086,31 +1086,31 @@ int status46;
 
 class Check46
 {
-	void sum(byte[] b){
-		status46++;
-	}
+    void sum(byte[] b){
+        status46++;
+    }
 
-	void add(byte b){
-		assert(0);
-	}	
+    void add(byte b){
+        assert(0);
+    }
 
-	alias sum write;
-	alias add write;
-	
-	void test(){
-		byte[] buffer;
-		write(buffer);
-	}
+    alias sum write;
+    alias add write;
+
+    void test(){
+        byte[] buffer;
+        write(buffer);
+    }
 }
 
 
 void test46()
 {
-	Check46 c = new Check46();
-	status46=0;
-	assert(status46==0);
-	c.test();
-	assert(status46==1);
+    Check46 c = new Check46();
+    status46=0;
+    assert(status46==0);
+    c.test();
+    assert(status46==1);
 }
 
 /* ================================ */
@@ -1122,46 +1122,46 @@ int foo47(int arg)
 loop:
     while(1)
     {
-	try
-	{
-	    try
-	    {
-		if (arg == 1)
-		{
-		    break loop;
-		}
-	    }
-	    finally
-	    {
-		assert(status47==0);
-		status47+=2;
-	    }
+    try
+    {
+        try
+        {
+        if (arg == 1)
+        {
+            break loop;
+        }
+        }
+        finally
+        {
+        assert(status47==0);
+        status47+=2;
+        }
 
-	    try
-	    {
-		assert(0);
-	    }
-	    finally
-	    {
-		assert(0);
-	    }
-	}
-	finally
-	{
-	    assert(status47==2);
-	    status47+=3;
-	}
-	assert(0);
-	return 0;
+        try
+        {
+        assert(0);
+        }
+        finally
+        {
+        assert(0);
+        }
+    }
+    finally
+    {
+        assert(status47==2);
+        status47+=3;
+    }
+    assert(0);
+    return 0;
     }
     return -1;
 }
 
 void test47()
 {
-	assert(status47 == 0);
-	assert(foo47(1) == -1);
-	assert(status47 == 5);
+    assert(status47 == 0);
+    assert(foo47(1) == -1);
+    assert(status47 == 5);
 }
 
 /* ================================ */
@@ -1173,21 +1173,21 @@ int foo48(int arg)
 
 loop:
     while(1){
-	try{
-	    try{
-		if(arg == 1)
-		{
-		    break loop;
-		}
-	    }finally{
-		assert(status48==0);
-		status48+=2;
-	    }
-	}finally{
-	    assert(status48==2);
-	    status48+=3;
-	}
-	return 0;
+    try{
+        try{
+        if(arg == 1)
+        {
+            break loop;
+        }
+        }finally{
+        assert(status48==0);
+        status48+=2;
+        }
+    }finally{
+        assert(status48==2);
+        status48+=3;
+    }
+    return 0;
     }
     return -1;
 }
@@ -1203,7 +1203,7 @@ void test48()
 
 int getch49()
 {
-	return 0;
+    return 0;
 }
 
 void writefln49(...)
@@ -1211,68 +1211,68 @@ void writefln49(...)
 }
 
 class Cout{
-	Cout set(int x){
-		return this;
-	}
-	alias set opShl;
+    Cout set(int x){
+        return this;
+    }
+    alias set opShl;
 }
 
 void test49()
 {
-	Cout cout = new Cout;
-	cout << 5 << 4;
-	writefln49,getch49;
+    Cout cout = new Cout;
+    cout << 5 << 4;
+    writefln49,getch49;
 }
 
 /* ================================ */
 
 struct S50{
-	int i;
+    int i;
 }
 
 class C50{
-	static S50 prop(){
-		S50 s;
-		return s;
-	}
+    static S50 prop(){
+        S50 s;
+        return s;
+    }
 
-	static void prop(S50 s){
-	}
+    static void prop(S50 s){
+    }
 }
 
 void test50()
 {
-	C50 c = new C50();
-	c.prop = true ? C50.prop : C50.prop;
-	assert(c.prop.i == 0);
-	c.prop.i = 7;
-	assert(c.prop.i != 7);
+    C50 c = new C50();
+    c.prop = true ? C50.prop : C50.prop;
+    assert(c.prop.i == 0);
+    c.prop.i = 7;
+    assert(c.prop.i != 7);
 }
 
 /* ================================ */
 
 void func1()
 {
-	static class foo {
-		public int a;
-	}
+    static class foo {
+        public int a;
+    }
 }
 
 void test51()
 {
-	static class foo {
-		public int b;
-	}
+    static class foo {
+        public int b;
+    }
 
-	foo bar = new foo();
-	bar.b = 255;
+    foo bar = new foo();
+    bar.b = 255;
 }
 
 /* ================================ */
 
 struct S52
 {
-	int i;
+    int i;
 }
 
 const int a52 = 3;
@@ -1292,40 +1292,40 @@ const int b53 = a53 + 1;
 
 void test53()
 {
-	assert(a53==1);
-	assert(b53==2);
-	assert(c53==3);
+    assert(a53==1);
+    assert(b53==2);
+    assert(c53==3);
 }
 
 /* ================================ */
 void test54()
 {
-	int status=0;
+    int status=0;
 
-	try
-	{
-		try
-		{
-			status++;
-			assert(status==1);
-			throw new Exception("first");
-		}
-		finally
-		{
-			printf("finally\n");
-			status++;
-			assert(status==2);
-			status++;
-			throw new Exception("second");
-		}
-	}
-	catch(Exception e)
-	{
-		printf("catch %.*s\n", e.msg.length, e.msg.ptr);
+    try
+    {
+        try
+        {
+            status++;
+            assert(status==1);
+            throw new Exception("first");
+        }
+        finally
+        {
+            printf("finally\n");
+            status++;
+            assert(status==2);
+            status++;
+            throw new Exception("second");
+        }
+    }
+    catch(Exception e)
+    {
+        printf("catch %.*s\n", e.msg.length, e.msg.ptr);
                 assert(e.msg == "first");
                 assert(e.next.msg == "second");
-	}
-	printf("success54\n");
+    }
+    printf("success54\n");
 }
 
 /* ================================ */
@@ -1334,44 +1334,44 @@ void foo55()
 {
     try
     {
-	Exception x = new Exception("second");
-	printf("inner throw %p\n", x);
-	throw x;
+    Exception x = new Exception("second");
+    printf("inner throw %p\n", x);
+    throw x;
     }
     catch (Exception e)
     {
-	printf("inner catch %p\n", e);
-	printf("e.msg == %.*s\n", e.msg.length, e.msg.ptr);
-	assert(e.msg == "second");
-	//assert(e.msg == "first");
-	//assert(e.next.msg == "second");
+    printf("inner catch %p\n", e);
+    printf("e.msg == %.*s\n", e.msg.length, e.msg.ptr);
+    assert(e.msg == "second");
+    //assert(e.msg == "first");
+    //assert(e.next.msg == "second");
     }
 }
 
 void test55()
 {
-	int status=0;
-	try{
-		try{
-			status++;
-			assert(status==1);
-			Exception x = new Exception("first");
-			printf("outer throw %p\n", x);
-			throw x;
-		}finally{
-			printf("finally\n");
-			status++;
-			assert(status==2);
-			status++;
-			foo55();
-			printf("finally2\n");
-		}
-	}catch(Exception e){
-		printf("outer catch %p\n", e);
-		assert(e.msg == "first");
-		assert(status==3);
-	}
-	printf("success55\n");
+    int status=0;
+    try{
+        try{
+            status++;
+            assert(status==1);
+            Exception x = new Exception("first");
+            printf("outer throw %p\n", x);
+            throw x;
+        }finally{
+            printf("finally\n");
+            status++;
+            assert(status==2);
+            status++;
+            foo55();
+            printf("finally2\n");
+        }
+    }catch(Exception e){
+        printf("outer catch %p\n", e);
+        assert(e.msg == "first");
+        assert(status==3);
+    }
+    printf("success55\n");
 }
 
 /* ================================ */
@@ -1395,15 +1395,15 @@ void test57()
   {
     void displayb(char[] name, bit[] x)
     {
-	writef("%-5s: ", name);
-	foreach(bit b; x)
-	    writef("%d",b);
-	writefln("");        
+    writef("%-5s: ", name);
+    foreach(bit b; x)
+        writef("%d",b);
+    writefln("");
     }
 
     bit[] a;
     bit[] b;
-    
+
     a.length = 7;
     a[0] = 0;
     a[1] = 1;
@@ -1412,25 +1412,25 @@ void test57()
     a[4] = 0;
     a[5] = 1;
     a[6] = 0;
-    
+
     displayb("a", a);
-    
+
     b ~= a;
     displayb("b1", b);
-    
+
     b ~= a;
     displayb("b2", b);
 
     for (int i = 0; i < a.length; i++)
     {
-	assert(b[i] == a[i]);
-	assert(b[i+7] == a[i]);
+    assert(b[i] == a[i]);
+    assert(b[i+7] == a[i]);
     }
 
-    b.length = 0;    
+    b.length = 0;
     b ~= a;
     displayb("b3", b);
-    
+
     b.length = b.length + 7;
     for(int i = 0; i < a.length; i++)
         b[i+7] = a[i];
@@ -1438,8 +1438,8 @@ void test57()
 
     for (int i = 0; i < a.length; i++)
     {
-	assert(b[i] == a[i]);
-	assert(b[i+7] == a[i]);
+    assert(b[i] == a[i]);
+    assert(b[i+7] == a[i]);
     }
   }
 }

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -555,7 +555,7 @@ void test16()
 
 void test17()
 {
-    creal z = 1. + 2.0i;
+    creal z = 1.0 + 2.0i;
 
     real r = z.re;
     assert(r == 1.0);
@@ -672,7 +672,7 @@ void test21()
 
 void test22()
 {
-    creal z1 = 1. - 2.0i;
+    creal z1 = 1.0 - 2.0i;
     ireal imag_part = z1.im/1i;
 }
 

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -2154,7 +2154,7 @@ public struct foo134
 
 class bar134
 {
-    final void fun(foo134 arg = foo134(0.)) { }
+    final void fun(foo134 arg = foo134(0.0)) { }
 }
 
 /***************************************************/

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -243,13 +243,13 @@ class C15
 
     private void callback(int i)
     {
-	x = i + 3;
+    x = i + 3;
     }
 
     void foo()
     {
-	bar15(&callback);
-	assert(x == 10);
+    bar15(&callback);
+    assert(x == 10);
     }
 }
 
@@ -343,20 +343,20 @@ void test21()
 
 void bar22(alias T)()
 {
-	assert(3 == T);
+    assert(3 == T);
 }
 
 class Test22
 {
-	int a;
-	mixin bar22!(a);
+    int a;
+    mixin bar22!(a);
 }
 
 void test22()
 {
-	Test22 t = new Test22();
-	t.a = 3;
-	t.bar22();
+    Test22 t = new Test22();
+    t.a = 3;
+    t.bar22();
 }
 
 /***************************************************/
@@ -731,10 +731,10 @@ class Ap50
 
     void update(ubyte input, int i)
     {
-	valuex =
-	    (((size + i) & 1) == 0) ?
-		    0 :
-		    input;
+    valuex =
+        (((size + i) & 1) == 0) ?
+            0 :
+            input;
     }
 }
 
@@ -799,10 +799,10 @@ void test54()
     string[] k=["adf","AsdfadSF","dfdsfassdf"];
     foreach(d;k)
     {
-	printf("%.*s\n", d.length, d.ptr);
-	string foo() {assert(d!="");return d;}
-	func54(&foo);
-	func54(delegate string() {assert(d!="");return d;});
+    printf("%.*s\n", d.length, d.ptr);
+    string foo() {assert(d!="");return d;}
+    func54(&foo);
+    func54(delegate string() {assert(d!="");return d;});
     }
 }
 
@@ -940,7 +940,7 @@ struct S63
     int a;
     static int foo()
     {
-	return a.sizeof;
+    return a.sizeof;
     }
 }
 
@@ -1120,7 +1120,7 @@ templates, which a lot of debuggers have serious problems with anyway, so..
 I would set it up as a method of last resort. It wouldn't be used unless the
 symbol can't be used any other way.
 "
-	).b.length;
+    ).b.length;
 }
 
 /***************************************************/
@@ -1149,7 +1149,7 @@ template Foo73()
 
     static if (x == 3)
     {
-	pragma(msg, "success");
+    pragma(msg, "success");
     }
 }
 
@@ -1301,8 +1301,8 @@ void test79()
     assert(c.__monitor == null);
     synchronized (c)
     {
-	writeln(c.__monitor);
-	assert(c.__monitor !is null);
+    writeln(c.__monitor);
+    assert(c.__monitor !is null);
     }
 }
 
@@ -1388,7 +1388,7 @@ class myid
     string buf;
     this(string str )
     {
-	    buf = str;
+        buf = str;
     }
 }
 struct Lex
@@ -1396,7 +1396,7 @@ struct Lex
     static myid myidinst;
     static void Init()
     {
-	    myidinst = new myid("abc");
+        myidinst = new myid("abc");
     }
 }
 
@@ -1465,9 +1465,9 @@ int function() wrap88(void function()) { return null; }
 
 void test88()
 {
-	printf("test88\n");
-	if (0)
-	    wrap88(&test88)();
+    printf("test88\n");
+    if (0)
+        wrap88(&test88)();
 }
 
 /***************************************************/
@@ -1486,7 +1486,7 @@ void bar89(float f) { assert(f == 3); }
 
 void test89()
 {
-	printf("test89\n");
+    printf("test89\n");
         bar89(S89.z[0]);
         bar89(S89.z[1]);
         bar89(C89.z[0]);
@@ -1577,7 +1577,7 @@ template foo96(alias bar)
 {
     pragma(msg, bar.stringof ~ " " ~ typeof(bar).stringof);
     static assert((bar.stringof ~ " " ~ typeof(bar).stringof) == "myInt int" ||
-	(bar.stringof ~ " " ~ typeof(bar).stringof) == "myBool bool");
+    (bar.stringof ~ " " ~ typeof(bar).stringof) == "myBool bool");
     void foo96() {}
 }
 
@@ -1612,10 +1612,10 @@ class Foo98
 
     void bar()
     {
-	printf("%c\n", foo[i]);
-	i++;
-	printf("%c\n", foo[i]);
-	assert(foo[i] == 'b');
+    printf("%c\n", foo[i]);
+    i++;
+    printf("%c\n", foo[i]);
+    assert(foo[i] == 'b');
     }
 }
 
@@ -1684,14 +1684,14 @@ class C103
 {
     void method ()
     {
-	void internal (...)
-	{
-	    printf("internal: %d\n", *cast (int *)_argptr);
-	    x103 = *cast (int *) _argptr;
-	}
+    void internal (...)
+    {
+        printf("internal: %d\n", *cast (int *)_argptr);
+        x103 = *cast (int *) _argptr;
+    }
 
-	internal (43);
-	assert(x103 == 43);
+    internal (43);
+    assert(x103 == 43);
     }
 }
 
@@ -1763,7 +1763,7 @@ struct Foo108
 {
     char[] byLine()()
     {
-	return null;
+    return null;
     }
 }
 
@@ -1788,7 +1788,7 @@ void test109()
 void test110()
 {
     struct C {
-	int[0] b;
+    int[0] b;
     }
     static C g_c2_ = {  };
 }
@@ -1841,7 +1841,7 @@ struct VariantN
     void foo()
     {
         VariantN v;
-	v.bar(42, 5);
+    v.bar(42, 5);
     }
 
     void bar(int value, int i)
@@ -1897,8 +1897,8 @@ void test118()
 {
     int foo(real x)
     {
-	real y = -x*-x;
-	return cast(int)y;
+    real y = -x*-x;
+    return cast(int)y;
     }
 
     auto i = foo(4.0);
@@ -1990,9 +1990,9 @@ int foo125(int x)
 {
     while (1)
     {
-	if (x)
-	    return 3;
-	x++;
+    if (x)
+        return 3;
+    x++;
     }
 }
 
@@ -2007,9 +2007,9 @@ int foo126(int x)
 {
     while (1)
     {
-	if (x)
-	    return 3;
-	x++;
+    if (x)
+        return 3;
+    x++;
     }
     assert(0);
 }
@@ -2353,7 +2353,7 @@ void test148()
     b ~= "\U00091234";
 
     if (a != b) {
-	    assert(0);
+        assert(0);
     }
 }
 
@@ -2707,8 +2707,8 @@ void test173()
 {
     switch(`Hi`.dup) {
         case ENUM_NAME[1]:
-	default:
-		break;
+    default:
+        break;
     }
 }
 
@@ -2783,7 +2783,7 @@ struct S178 {
     int x;
 
     template T(int val) {
-	enum S178 T = { val };
+    enum S178 T = { val };
     }
 }
 
@@ -2853,19 +2853,19 @@ struct Main {
 void fooa181(int x, int y, int[0] a, int z, int t)
 {
     if (!(x == 2 && y == 4 && z == 6 && t == 8))
-	assert(0);
+    assert(0);
 }
 
 void foob181(int x, int y, int[0] a)
 {
     if (!(x == 2 && y == 4))
-	assert(0);
+    assert(0);
 }
 
 void fooc181(int[0] a, int x, int y)
 {
     if (!(x == 2 && y == 4))
-	assert(0);
+    assert(0);
 }
 
 void food181(int[0] a)
@@ -2915,7 +2915,7 @@ interface IQGraphicsItem
 }
 
 abstract
-	class QGraphicsObject : IQGraphicsItem
+    class QGraphicsObject : IQGraphicsItem
 {
 }
 
@@ -2989,7 +2989,7 @@ void test188()
     int[3] t = [1,3,4];
     auto i = foo188(t);
     if (i != 8)
-	assert(0);
+    assert(0);
 }
 
 /***************************************************/
@@ -3006,13 +3006,13 @@ void a189()(T1189 x) {
 
 class T1189 {
     void foo() {
-	printf("T1.foo()\n");
+    printf("T1.foo()\n");
     }
 }
 
 class T2189 : T1189 {
     void bla() {
-	printf("T2.blah()\n");
+    printf("T2.blah()\n");
         assert(false); //line 19
     }
 }
@@ -3072,7 +3072,7 @@ void test193()
 {
     enum Shapes
     {
-	Circle, Square
+    Circle, Square
     }
 
     int i;
@@ -3140,7 +3140,7 @@ void test197()
 
 /***************************************************/
 
-void test198()	// Bugzilla 4506
+void test198()  // Bugzilla 4506
 {
     int c = 1;
     for (int k = 0; k < 2; k++) {
@@ -3216,11 +3216,11 @@ int bug2931_2()
   for (int i = 0; i < 4; i++)
   { for (int j = 0; j < 3; j++)
     {
-	printf("[%d][%d] = %d\n", j, i, v.p.val[j][i]);
-	if (i == 0 && j == 0)
-	    assert(v.p.val[j][i] == 67);
-	else
-	    assert(v.p.val[j][i] == 0);
+    printf("[%d][%d] = %d\n", j, i, v.p.val[j][i]);
+    if (i == 0 && j == 0)
+        assert(v.p.val[j][i] == 67);
+    else
+        assert(v.p.val[j][i] == 0);
     }
   }
   printf("v.zoom = %d\n", v.zoom);
@@ -3246,7 +3246,7 @@ void foo202(int x, ...) {
     for (int i = 0; i < _arguments.length; i++) {
         int j = va_arg!(int)(_argptr);
         printf("\t%d\n", j);
-	assert(j == i + 2);
+    assert(j == i + 2);
     }
 }
 
@@ -3255,7 +3255,7 @@ void fooRef202(ref int x, ...) {
     for (int i = 0; i < _arguments.length; i++) {
         int j = va_arg!(int)(_argptr);
         printf("\t%d\n", j);
-	assert(j == i + 2);
+    assert(j == i + 2);
     }
 }
 
@@ -3322,7 +3322,7 @@ TaskStatus test206(char[] s){
     char[] t="TaskStatus".dup;
     if (s.length>t.length && s[0..t.length]==t){
         long res=0;
-        if (s[t.length]=='-') res= -res;	// <= OPnegass
+        if (s[t.length]=='-') res= -res;    // <= OPnegass
         return cast(TaskStatus)cast(int)res;
     }
     assert(0);
@@ -3730,8 +3730,8 @@ void test224()
 
 public final class A3681 {
     private this() {
-	int i =0;
-	int j = i + 1;
+    int i =0;
+    int j = i + 1;
  i = j * 15; j = i * 59; i = j * 15; j = i * 59; i = j * 15; j = i * 59; i = j * 15; j = i * 59;
  i = j * 15; j = i * 59; i = j * 15; j = i * 59; i = j * 15; j = i * 59; i = j * 15; j = i * 59;
  i = j * 15; j = i * 59; i = j * 15; j = i * 59; i = j * 15; j = i * 59; i = j * 15; j = i * 59;
@@ -3945,10 +3945,10 @@ void test229() {
 
 static immutable real negtab[14] =
     [ 1e-4096L,1e-2048L,1e-1024L,1e-512L,1e-256L,1e-128L,1e-64L,1e-32L,
-	    1e-16L,1e-8L,1e-4L,1e-2L,1e-1L,1.0L ];
+        1e-16L,1e-8L,1e-4L,1e-2L,1e-1L,1.0L ];
 static immutable real postab[13] =
     [ 1e+4096L,1e+2048L,1e+1024L,1e+512L,1e+256L,1e+128L,1e+64L,1e+32L,
-	    1e+16L,1e+8L,1e+4L,1e+2L,1e+1L ];
+        1e+16L,1e+8L,1e+4L,1e+2L,1e+1L ];
 
 float parse(ref string p)
 {
@@ -4246,7 +4246,7 @@ void test237()
 
 void foo238(long a, long b)
 {
-  while (1)		// prevent inlining
+  while (1)     // prevent inlining
   {
     long x = a / b;
     long y = a % b;
@@ -4262,7 +4262,7 @@ void test238()
     a = 10;
     b = 3;
     long x = a / b;
-    long y = a % b;	// evaluate at compile time
+    long y = a % b; // evaluate at compile time
     assert(x == 3);
     assert(y == 1);
 
@@ -4376,8 +4376,8 @@ void test6665()
 double entropy(double[] probs) {
     double result = 0;
     foreach (p; probs) {
-	if (!p) continue;
-	result -= p;
+    if (!p) continue;
+    result -= p;
     }
     return result;
 }
@@ -4482,7 +4482,7 @@ ubyte foo7026(uint n) {
 
 void test7026() {
     if (foo7026(3) != 3)
-	assert(0);
+    assert(0);
 }
 
 
@@ -4657,10 +4657,10 @@ void test6504()
     for (int i=0; i<3; ++i)
     {
 /+
-	char[] x2 = "xxx" ~ ['c'];
-	if (i == 0)
-	    assert(x2[1] == 'x');
-	x2[1] = 'q';
+    char[] x2 = "xxx" ~ ['c'];
+    if (i == 0)
+        assert(x2[1] == 'x');
+    x2[1] = 'q';
 +/
     }
 }
@@ -4728,7 +4728,7 @@ void test7424()
 
 struct Logger {
     static bool info()() {
-	return false;
+    return false;
     }
 }
 
@@ -4840,7 +4840,7 @@ struct Array243(T) if (is(T == bool))
     {
         Array243!bool _outer;
         ulong _a, _b, _c;
-	ulong _d;
+    ulong _d;
     }
 
     Range opSlice()
@@ -4949,19 +4949,19 @@ struct Test244 {
 int noswap245(ubyte *data)
 {
     return
-	(data[0]<<  0) |
-	(data[1]<<  8) |
-	(data[2]<< 16) |
-	(data[3]<< 24);
+    (data[0]<<  0) |
+    (data[1]<<  8) |
+    (data[2]<< 16) |
+    (data[3]<< 24);
 }
 
 int bswap245(ubyte *data)
 {
     return
-	(data[0]<< 24) |
-	(data[1]<< 16) |
-	(data[2]<< 8 ) |
-	(data[3]<< 0 );
+    (data[0]<< 24) |
+    (data[1]<< 16) |
+    (data[2]<< 8 ) |
+    (data[3]<< 0 );
 }
 
 void test245()


### PR DESCRIPTION
6277 calls for making .1 and 1. illegal. .1 is very common when writing
floating point values by hand, and it seems to be used quite heavily in
dmd's tests, so I left it in. 1. on the other hand is downright bizarre
and makes even less sense now that 1.f is not a legal floating point
literal. I was very surprised to find out that 1. was still legal after
1.f was made illegal. I thought that it _wasn't_ legal anymore. So, this
makes it so that 1. isn't, but it leaves .1 legal.

The last commit contains whitespace changes only (the tests that I had to tweak had a bunch of tabs and trailing whitespace, and I cleaned that up), so you probably don't want to look at the full diff at once. The two commits with the actual functionality changes are quite small.
