### PR TITLE
Bunch of changes, enough to introduce a stub platform.

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -156,7 +156,9 @@ One and only one of these macros must be set by the makefile:
  * Target machine types:
  */
 
+#if TARGET_CPU_X86
 #define TX86            1               // target is Intel 80X86 processor
+#endif
 
 // Set to 1 using the makefile
 #ifndef TARGET_LINUX

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -250,8 +250,8 @@ tryagain:
         allregs |= cod3_useBP();                // see if we can use EBP
 
         // If pic code, but EBX was never needed
-        if (!(allregs & mBX) && !gotref)
-        {   allregs |= mBX;                     // EBX can now be used
+        if (!(allregs & mask[PICREG]) && !gotref)
+        {   allregs |= mask[PICREG];            // EBX can now be used
             cgreg_assign(retsym);
             pass = PASSreg;
         }
@@ -813,7 +813,7 @@ Lagain:
     if (usednteh & NTEHjmonitor)
     {   Symbol *sthis;
 
-        for (si = 0; 1; si++)
+        for (SYMIDX si = 0; 1; si++)
         {   assert(si < globsym.top);
             sthis = globsym.tab[si];
             if (strcmp(sthis->Sident,"this") == 0)
@@ -1597,7 +1597,9 @@ code *allocreg(regm_t *pretregs,unsigned *preg,tym_t tym
 #ifdef DEBUG
 #define allocreg(a,b,c) allocreg((a),(b),(c),__LINE__,__FILE__)
 #endif
-{       regm_t r;
+{
+#if TX86
+        regm_t r;
         regm_t retregs;
         unsigned reg;
         unsigned msreg,lsreg;
@@ -1762,6 +1764,9 @@ L3:
         last2retregs = lastretregs;
         lastretregs = retregs;
         return getregs(retregs);
+#else
+#warning cpu specific code
+#endif
 }
 
 /*************************
@@ -1808,7 +1813,7 @@ STATIC code * cse_save(regm_t ms)
     regcon.cse.mops &= ~ms;
 
     /* Skip CSEs that are already saved */
-    for (regm = 1; regm <= mES; regm <<= 1)
+    for (regm = 1; regm < mask[NUMREGS]; regm <<= 1)
     {
         if (regm & ms)
         {   elem *e;
@@ -2225,7 +2230,7 @@ if (regcon.cse.mval & 1) elem_print(regcon.cse.value[i]);
         assert(I16);
         if (((csemask | emask) & DOUBLEREGS_16) == DOUBLEREGS_16)
         {
-            for (reg = AX; reg != -1; reg = dblreg[reg])
+            for (reg = 0; reg != -1; reg = dblreg[reg])
             {   assert((int) reg >= 0 && reg <= 7);
                 if (mask[reg] & csemask)
                     c = cat(c,loadcse(e,reg,mask[reg]));

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -2248,6 +2248,7 @@ code *callclib(elem *e,unsigned clib,regm_t *pretregs,regm_t keepmask)
             c = cod3_stackadj(c, -nalign);
         calledafunc = 1;
 
+#if SCPP & TX86
         if (I16 &&                                   // bug in Optlink for weak references
             config.flags3 & CFG3wkfloat &&
             (info[clib].flags & (INFfloat | INFwkdone)) == INFfloat)
@@ -2255,6 +2256,7 @@ code *callclib(elem *e,unsigned clib,regm_t *pretregs,regm_t keepmask)
             makeitextern(rtlsym[RTLSYM_INTONLY]);
             objmod->wkext(s,rtlsym[RTLSYM_INTONLY]);
         }
+#endif
     }
     if (I16)
         stackpush -= info[clib].pop;

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -21,339 +21,6 @@ struct Declaration;
 
 #define CNIL ((code *) NULL)
 
-/* Register definitions */
-
-#define AX      0
-#define CX      1
-#define DX      2
-#define BX      3
-#define SP      4
-#define BP      5
-#define SI      6
-#define DI      7
-
-enum // #defining R12-R15 interfere with setjmps' _JUMP_BUFFER members
-{
-    R8       = 8,
-    R9       = 9,
-    R10      = 10,
-    R11      = 11,
-    R12      = 12,
-    R13      = 13,
-    R14      = 14,
-    R15      = 15,
-};
-
-#define XMM0    16
-#define XMM1    17
-#define XMM2    18
-#define XMM3    19
-#define XMM4    20
-#define XMM5    21
-#define XMM6    22
-#define XMM7    23
-/* There are also XMM8..XMM14 */
-#define XMM15   31
-
-
-#define ES      24
-#define PSW     25
-#define STACK   26      // top of stack
-#define ST0     27      // 8087 top of stack register
-#define ST01    28      // top two 8087 registers; for complex types
-
-#define NOREG   29     // no register
-
-#define AL      0
-#define CL      1
-#define DL      2
-#define BL      3
-#define AH      4
-#define CH      5
-#define DH      6
-#define BH      7
-
-#define mAX     1
-#define mCX     2
-#define mDX     4
-#define mBX     8
-#define mSP     0x10
-#define mBP     0x20
-#define mSI     0x40
-#define mDI     0x80
-
-#define mR8     (1 << R8)
-#define mR9     (1 << R9)
-#define mR10    (1 << R10)
-#define mR11    (1 << R11)
-#define mR12    (1 << R12)
-#define mR13    (1 << R13)
-#define mR14    (1 << R14)
-#define mR15    (1 << R15)
-
-#define mXMM0   (1 << XMM0)
-#define mXMM1   (1 << XMM1)
-#define mXMM2   (1 << XMM2)
-#define mXMM3   (1 << XMM3)
-#define mXMM4   (1 << XMM4)
-#define mXMM5   (1 << XMM5)
-#define mXMM6   (1 << XMM6)
-#define mXMM7   (1 << XMM7)
-#define XMMREGS  (mXMM0 |mXMM1 |mXMM2 |mXMM3 |mXMM4 |mXMM5 |mXMM6 |mXMM7)
-
-#define mES     (1 << ES)       // 0x1000000
-#define mPSW    (1 << PSW)      // 0x2000000
-
-#define mSTACK  (1 << STACK)    // 0x4000000
-
-#define mST0    (1 << ST0)      // 0x20000000
-#define mST01   (1 << ST01)     // 0x40000000
-
-// Flags for getlvalue (must fit in regm_t)
-#define RMload  (1 << 30)
-#define RMstore (1 << 31)
-
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-    // To support positional independent code,
-    // must be able to remove BX from available registers
-extern regm_t ALLREGS;
-#define ALLREGS_INIT            (mAX|mBX|mCX|mDX|mSI|mDI)
-#define ALLREGS_INIT_PIC        (mAX|mCX|mDX|mSI|mDI)
-extern regm_t BYTEREGS;
-#define BYTEREGS_INIT           (mAX|mBX|mCX|mDX)
-#define BYTEREGS_INIT_PIC       (mAX|mCX|mDX)
-#else
-#define ALLREGS                 (mAX|mBX|mCX|mDX|mSI|mDI)
-#define ALLREGS_INIT            ALLREGS
-#undef BYTEREGS
-#define BYTEREGS                (mAX|mBX|mCX|mDX)
-#endif
-
-/* We use the same IDXREGS for the 386 as the 8088, because if
-   we used ALLREGS, it would interfere with mMSW
- */
-#define IDXREGS         (mBX|mSI|mDI)
-
-#define FLOATREGS_64    mAX
-#define FLOATREGS2_64   mDX
-#define DOUBLEREGS_64   mAX
-#define DOUBLEREGS2_64  mDX
-
-#define FLOATREGS_32    mAX
-#define FLOATREGS2_32   mDX
-#define DOUBLEREGS_32   (mAX|mDX)
-#define DOUBLEREGS2_32  (mCX|mBX)
-
-#define FLOATREGS_16    (mDX|mAX)
-#define FLOATREGS2_16   (mCX|mBX)
-#define DOUBLEREGS_16   (mAX|mBX|mCX|mDX)
-
-/*#define _8087REGS (mST0|mST1|mST2|mST3|mST4|mST5|mST6|mST7)*/
-
-/* Segment registers    */
-#define SEG_ES  0
-#define SEG_CS  1
-#define SEG_SS  2
-#define SEG_DS  3
-
-/*********************
- * Masks for register pairs.
- * Note that index registers are always LSWs. This is for the convenience
- * of implementing far pointers.
- */
-
-#if 0
-// Give us an extra one so we can enregister a long
-#define mMSW    (mCX|mDX|mDI|mES)       // most significant regs
-#define mLSW    (mAX|mBX|mSI)           // least significant regs
-#else
-#define mMSW    (mCX|mDX|mES)           /* most significant regs        */
-#define mLSW    (mAX|mBX|mSI|mDI)       /* least significant regs       */
-#endif
-
-/* Return !=0 if there is a SIB byte   */
-#define issib(rm)       (((rm) & 7) == 4 && ((rm) & 0xC0) != 0xC0)
-
-#if 0
-// relocation field size is always 32bits
-#define is32bitaddr(x,Iflags) (1)
-#else
-//
-// is32bitaddr works correctly only when x is 0 or 1.  This is
-// true today for the current definition of I32, but if the definition
-// of I32 changes, this macro will need to change as well
-//
-// Note: even for linux targets, CFaddrsize can be set by the inline
-// assembler.
-#define is32bitaddr(x,Iflags) (I64 || ((x) ^(((Iflags) & CFaddrsize) !=0)))
-#endif
-
-/*******************
- * Some instructions.
- */
-
-#define SEGES   0x26
-#define SEGCS   0x2E
-#define SEGSS   0x36
-#define SEGDS   0x3E
-#define SEGFS   0x64
-#define SEGGS   0x65
-
-#define CALL    0xE8
-#define JMP     0xE9    /* Intra-Segment Direct */
-#define JMPS    0xEB    /* JMP SHORT            */
-#define JCXZ    0xE3
-#define LOOP    0xE2
-#define LES     0xC4
-#define LEA     0x8D
-
-#define JO      0x70
-#define JNO     0x71
-#define JC      0x72
-#define JB      0x72
-#define JNC     0x73
-#define JAE     0x73
-#define JE      0x74
-#define JNE     0x75
-#define JBE     0x76
-#define JA      0x77
-#define JS      0x78
-#define JNS     0x79
-#define JP      0x7A
-#define JNP     0x7B
-#define JL      0x7C
-#define JGE     0x7D
-#define JLE     0x7E
-#define JG      0x7F
-
-/* NOP is used as a placeholder in the linked list of instructions, no  */
-/* actual code will be generated for it.                                */
-#define NOP     0x2E    /* actually CS: (we don't use 0x90 because the  */
-                        /* silly Windows stuff wants to output 0x90's)  */
-
-#define ESCAPE  0x3E    // marker that special information is here
-                        // (Iop2 is the type of special information)
-                        // (Same as DS:, but we will never generate
-                        // a separate DS: opcode anyway)
-    #define ESClinnum   (1 << 8)       // line number information
-    #define ESCctor     (2 << 8)       // object is constructed
-    #define ESCdtor     (3 << 8)       // object is destructed
-    #define ESCmark     (4 << 8)       // mark eh stack
-    #define ESCrelease  (5 << 8)       // release eh stack
-    #define ESCoffset   (6 << 8)       // set code offset for eh
-    #define ESCadjesp   (7 << 8)       // adjust ESP by IEV2.Vint
-    #define ESCmark2    (8 << 8)       // mark eh stack
-    #define ESCrelease2 (9 << 8)       // release eh stack
-    #define ESCframeptr (10 << 8)      // replace with load of frame pointer
-    #define ESCdctor    (11 << 8)      // D object is constructed
-    #define ESCddtor    (12 << 8)      // D object is destructed
-    #define ESCadjfpu   (13 << 8)      // adjust fpustackused by IEV2.Vint
-
-#define ASM     0x36    // string of asm bytes, actually an SS: opcode
-
-/*********************************
- * Macros to ease generating code
- * modregrm:    generate mod reg r/m field
- * modregxrm:   reg could be R8..R15
- * modregrmx:   rm could be R8..R15
- * modregxrmx:  reg or rm could be R8..R15
- * NEWREG:      change reg field of x to r
- * genorreg:    OR  t,f
- */
-
-#define modregrm(m,r,rm)        (((m)<<6)|((r)<<3)|(rm))
-#define modregxrm(m,r,rm)       ((((r)&8)<<15)|modregrm((m),(r)&7,rm))
-#define modregrmx(m,r,rm)       ((((rm)&8)<<13)|modregrm((m),r,(rm)&7))
-#define modregxrmx(m,r,rm)      ((((r)&8)<<15)|(((rm)&8)<<13)|modregrm((m),(r)&7,(rm)&7))
-
-#define NEWREXR(x,r)            ((x)=((x)&~REX_R)|(((r)&8)>>1))
-#define NEWREG(x,r)             ((x)=((x)&~(7<<3))|((r)<<3))
-#define code_newreg(c,r)        (NEWREG((c)->Irm,(r)&7),NEWREXR((c)->Irex,(r)))
-
-#define genorreg(c,t,f)         genregs((c),0x09,(f),(t))
-
-#define REX     0x40            // REX prefix byte, OR'd with the following bits:
-#define REX_W   8               // 0 = default operand size, 1 = 64 bit operand size
-#define REX_R   4               // high bit of reg field of modregrm
-#define REX_X   2               // high bit of sib index reg
-#define REX_B   1               // high bit of rm field, sib base reg, or opcode reg
-
-#define VEX2_B1(ivex)                           \
-    (                                           \
-        ivex.r    << 7 |                        \
-        ivex.vvvv << 3 |                        \
-        ivex.l    << 2 |                        \
-        ivex.pp                                 \
-    )
-
-#define VEX3_B1(ivex)                           \
-    (                                           \
-        ivex.r    << 7 |                        \
-        ivex.x    << 6 |                        \
-        ivex.b    << 5 |                        \
-        ivex.mmmm                               \
-    )
-
-#define VEX3_B2(ivex)                           \
-    (                                           \
-        ivex.w    << 7 |                        \
-        ivex.vvvv << 3 |                        \
-        ivex.l    << 2 |                        \
-        ivex.pp                                 \
-    )
-
-/**********************
- * C library routines.
- * See callclib().
- */
-
-enum CLIB
-{
-        CLIBlcmp,
-        CLIBlmul,
-        CLIBldiv,
-        CLIBlmod,
-        CLIBuldiv,
-        CLIBulmod,
-
-#if TARGET_WINDOS
-        CLIBdmul,CLIBddiv,CLIBdtst0,CLIBdtst0exc,CLIBdcmp,CLIBdcmpexc,CLIBdneg,CLIBdadd,CLIBdsub,
-        CLIBfmul,CLIBfdiv,CLIBftst0,CLIBftst0exc,CLIBfcmp,CLIBfcmpexc,CLIBfneg,CLIBfadd,CLIBfsub,
-#endif
-
-        CLIBdbllng,CLIBlngdbl,CLIBdblint,CLIBintdbl,
-        CLIBdbluns,CLIBunsdbl,
-        CLIBdblulng,
-#if TARGET_WINDOS
-        // used the GNU way of converting unsigned long long to signed
-        CLIBulngdbl,
-#endif
-        CLIBdblflt,CLIBfltdbl,
-        CLIBdblllng,
-        CLIBllngdbl,
-        CLIBdblullng,
-        CLIBullngdbl,
-        CLIBdtst,
-        CLIBvptrfptr,CLIBcvptrfptr,
-
-        CLIB87topsw,CLIBfltto87,CLIBdblto87,CLIBdblint87,CLIBdbllng87,
-        CLIBftst,
-        CLIBfcompp,
-        CLIBftest,
-        CLIBftest0,
-        CLIBfdiv87,
-
-        // Complex numbers
-        CLIBcmul,
-        CLIBcdiv,
-        CLIBccmp,
-
-        CLIBu64_ldbl,
-        CLIBld_u64,
-
-        CLIBMAX
-};
-
 /**********************************
  * Code data type
  */
@@ -397,127 +64,13 @@ union evc
     } as;                       // asm node (FLasm)
 };
 
-struct code
-{
-    code *next;
-    unsigned Iflags;
-#define CFes              1     // generate an ES: segment override for this instr
-#define CFjmp16           2     // need 16 bit jump offset (long branch)
-#define CFtarg            4     // this code is the target of a jump
-#define CFseg             8     // get segment of immediate value
-#define CFoff          0x10     // get offset of immediate value
-#define CFss           0x20     // generate an SS: segment override (not with
-                                // CFes at the same time, though!)
-#define CFpsw          0x40     // we need the flags result after this instruction
-#define CFopsize       0x80     // prefix with operand size
-#define CFaddrsize    0x100     // prefix with address size
-#define CFds          0x200     // need DS override (not with es, ss, or cs )
-#define CFcs          0x400     // need CS override
-#define CFfs          0x800     // need FS override
-#define CFgs    (CFcs | CFfs)   // need GS override
-#define CFwait       0x1000     // If I32 it indicates when to output a WAIT
-#define CFselfrel    0x2000     // if self-relative
-#define CFunambig    0x4000     // indicates cannot be accessed by other addressing
-                                // modes
-#define CFtarg2      0x8000     // like CFtarg, but we can't optimize this away
-#define CFvolatile  0x10000     // volatile reference, do not schedule
-#define CFclassinit 0x20000     // class init code
-#define CFoffset64  0x40000     // offset is 64 bits
-#define CFpc32      0x80000     // I64: PC relative 32 bit fixup
-
-#define CFvex       0x100000    // vex prefix
-#define CFvex3      0x200000    // 3 byte vex prefix
-
-#define CFjmp5      0x400000    // always a 5 byte jmp
-
-#define CFPREFIX (CFSEG | CFopsize | CFaddrsize)
-#define CFSEG   (CFes | CFss | CFds | CFcs | CFfs | CFgs)
-
-    union {
-        unsigned _Iop;
-        struct {
-#pragma pack(1)
-            unsigned char  op;
-            unsigned short   pp : 2;
-            unsigned short    l : 1;
-            unsigned short vvvv : 4;
-            unsigned short    w : 1;
-            unsigned short mmmm : 5;
-            unsigned short    b : 1;
-            unsigned short    x : 1;
-            unsigned short    r : 1;
-            unsigned char pfx; // always 0xC4
-#pragma pack()
-        } _Ivex;
-    } _OP;
-
-    /* The _EA is the "effective address" for the instruction, and consists of the modregrm byte,
-     * the sib byte, and the REX prefix byte. The 16 bit code generator just used the modregrm,
-     * the 32 bit x86 added the sib, and the 64 bit one added the rex.
-     */
-    union
-    {   unsigned _Iea;
-        struct
-        {
-            unsigned char _Irm;          // reg/mode
-            unsigned char _Isib;         // SIB byte
-            unsigned char _Irex;         // REX prefix
-        } _ea;
-    } _EA;
-
-#define Iop  _OP._Iop
-#define Ivex _OP._Ivex
-#define Iea  _EA._Iea
-#define Irm  _EA._ea._Irm
-#define Isib _EA._ea._Isib
-#define Irex _EA._ea._Irex
-
-
-    /* IFL1 and IEV1 are the first operand, which usually winds up being the offset to the Effective
-     * Address. IFL1 is the tag saying which variant type is in IEV1. IFL2 and IEV2 is the second
-     * operand, usually for immediate instructions.
-     */
-
-    unsigned char IFL1,IFL2;    // FLavors of 1st, 2nd operands
-    union evc IEV1;             // 1st operand, if any
-      #define IEVpointer1 IEV1._EP.Vpointer
-      #define IEVseg1     IEV1._EP.Vseg
-      #define IEVsym1     IEV1.sp.Vsym
-      #define IEVdsym1    IEV1.dsp.Vsym
-      #define IEVoffset1  IEV1.sp.Voffset
-      #define IEVlsym1    IEV1.lab.Vsym
-      #define IEVint1     IEV1.Vint
-    union evc IEV2;             // 2nd operand, if any
-      #define IEVpointer2 IEV2._EP.Vpointer
-      #define IEVseg2     IEV2._EP.Vseg
-      #define IEVsym2     IEV2.sp.Vsym
-      #define IEVdsym2    IEV2.dsp.Vsym
-      #define IEVoffset2  IEV2.sp.Voffset
-      #define IEVlsym2    IEV2.lab.Vsym
-      #define IEVint2     IEV2.Vint
-      #define IEVllong2   IEV2.Vllong
-    void print();               // pretty-printer
-
-    code() { next = NULL; Iflags = 0; Iop = 0; Iea = 0; IFL1 = 0; IFL2 = 0; }      // constructor
-
-    void orReg(unsigned reg)
-    {   if (reg & 8)
-            Irex |= REX_R;
-        Irm |= modregrm(0, reg & 7, 0);
-    }
-
-    void setReg(unsigned reg)
-    {
-        Irex &= ~REX_R;
-        Irm &= ~modregrm(0, 7, 0);
-        orReg(reg);
-    }
-
-    bool isJumpOP() { return Iop == JMP || Iop == JMPS; }
-};
-
-// !=0 if we have to add FWAIT to floating point ops
-#define ADDFWAIT()      (config.target_cpu <= TARGET_80286)
+#if TARGET_CPU_X86
+#include "code_x86.h"
+#elif TARGET_CPU_stub
+#include "code_stub.h"
+#else
+#error unknown cpu
+#endif
 
 /********************** PUBLIC FUNCTIONS *******************/
 
@@ -526,10 +79,6 @@ void code_free (code *);
 void code_term(void);
 
 #define code_next(c)    ((c)->next)
-
-//#define code_calloc() ((code *) mem_calloc(sizeof(code)))
-
-typedef code *code_p;
 
 /**********************************
  * Set value in regimmed for reg.
@@ -562,23 +111,6 @@ struct CSE
 // != 0 if CSE was ever loaded
 #define CSE_loaded(i)   (csextab[i].flags & CSEload)
 };
-
-/************************************
- */
-
-#if TX86
-struct NDP
-{
-    elem *e;                    // which elem is stored here (NULL if none)
-    unsigned offset;            // offset from e (used for complex numbers)
-
-    static NDP *save;
-    static int savemax;         // # of entries in save[]
-    static int savetop;         // # of entries used in save[]
-};
-
-extern NDP _8087elems[8];
-#endif
 
 /************************************
  * Register save state.
@@ -630,8 +162,6 @@ extern CGstate cgstate;
 /***********************************************************/
 
 extern regm_t msavereg,mfuncreg,allregs;
-
-/*long cxmalloc,cxcalloc,cx1;*/
 
 typedef code *cd_t (elem *e , regm_t *pretregs );
 
@@ -720,12 +250,8 @@ void gensaverestore(regm_t, code **, code **);
 void gensaverestore2(regm_t regm,code **csave,code **crestore);
 code *genstackclean(code *c,unsigned numpara,regm_t keepmsk);
 code *logexp (elem *e , int jcond , unsigned fltarg , code *targ );
-code *loadea (elem *e , code *cs , unsigned op , unsigned reg , targ_size_t offset , regm_t keepmsk , regm_t desmsk );
 unsigned getaddrmode (regm_t idxregs );
 void setaddrmode(code *c, regm_t idxregs);
-void getlvalue_msw(code *);
-void getlvalue_lsw(code *);
-code *getlvalue (code *pcs , elem *e , regm_t keepmsk );
 code *fltregs (code *pcs , tym_t tym );
 code *tstresult (regm_t regm , tym_t tym , unsigned saveflag );
 code *fixresult (elem *e , regm_t retregs , regm_t *pretregs );
@@ -790,6 +316,7 @@ void cod3_set32 (void );
 void cod3_set64 (void );
 void cod3_align_bytes (size_t nbytes);
 void cod3_align (void );
+void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset);
 code* cod3_stackadj(code* c, int nbytes);
 regm_t regmask(tym_t tym, tym_t tyf);
 void cgreg_dst_regs(unsigned *dst_integer_reg, unsigned *dst_float_reg);

--- a/src/backend/code_stub.h
+++ b/src/backend/code_stub.h
@@ -1,0 +1,88 @@
+// opcodes
+#define ASM 0
+#define NOP 1
+#define ESCAPE 2
+    // 8 is to leave room for opcodes to be in the range 0 .. 255
+    // probably better off moving them to the high byte rather than second byte
+    #define ESClinnum   (0 << 8)
+    #define ESCadjesp   (1 << 8)
+    #define ESCadjfpu   (2 << 8)
+    #define ESCdctor    (3 << 8)      // D object is constructed
+    #define ESCddtor    (4 << 8)      // D object is destructed
+
+// registers
+
+// base pointer
+#define BP    0
+// stack pointer
+#define SP    1
+// status word
+#define PSW   2
+// stack
+#define STACK 3
+
+#define NUMGENREGS 2
+#define NUMREGS 1
+
+#define NOREG 3
+
+// which register is used for PIC code?
+#define PICREG BP
+
+// masks
+#define mBP    (1 << BP)
+#define mPSW   (1 << PSW)
+#define mSTACK (1 << STACK)
+
+// used in several generic parts of the code still
+#define mES  0
+
+#define mLSW 0
+#define mMSW 0
+
+#define IDXREGS 0
+#define XMMREGS 0
+
+#define FLOATREGS_16 0
+#define FLOATREGS2_16 0
+#define DOUBLEREGS_16 0
+#define BYTEREGS_INIT 0
+
+#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
+extern regm_t ALLREGS;
+extern regm_t BYTEREGS;
+#define ALLREGS_INIT            0
+#define ALLREGS_INIT_PIC        0
+#define BYTEREGS_INIT           0
+#define BYTEREGS_INIT_PIC       0
+#else
+#define ALLREGS                 0
+#define ALLREGS_INIT            ALLREGS
+#undef BYTEREGS
+#define BYTEREGS                0
+#endif
+
+struct code
+{
+    code* next;
+    unsigned Iop;                           // opcode
+    unsigned Iflags;
+      // eliminate these?
+      #define CFpc32      (1 << 0)          // PC relative 32 bit fixup
+      #define CFselfrel   (1 << 1)          // if self-relative
+      #define CFoff       (1 << 2)          // get offset of immediate value
+      #define CFoffset64  (1 << 3)          // offset is 64 bits
+      #define CFseg       (1 << 4)          // get segment of immediate value
+
+    unsigned char IFL1;                     // FLavors of 1st operands
+    union evc IEV1;                         // 1st operand, if any
+      #define IEVsym1     IEV1.sp.Vsym
+      #define IEVdsym1    IEV1.dsp.Vsym
+      #define IEVlsym1    IEV1.lab.Vsym
+
+    void setReg(unsigned) {}
+
+    bool isJumpOP() { return false; }
+
+};
+

--- a/src/backend/code_x86.h
+++ b/src/backend/code_x86.h
@@ -1,0 +1,495 @@
+// Copyright (C) 1985-1996 by Symantec
+// Copyright (C) 2000-2011 by Digital Mars
+// All Rights Reserved
+// http://www.digitalmars.com
+// Written by Walter Bright
+/*
+ * This source file is made available for personal use
+ * only. The license is in /dmd/src/dmd/backendlicense.txt
+ * or /dm/src/dmd/backendlicense.txt
+ * For any other uses, please contact Digital Mars.
+ */
+
+/* Register definitions */
+
+#define AX      0
+#define CX      1
+#define DX      2
+#define BX      3
+#define SP      4
+#define BP      5
+#define SI      6
+#define DI      7
+
+#define PICREG  BX
+
+enum // #defining R12-R15 interfere with setjmps' _JUMP_BUFFER members
+{
+    R8       = 8,
+    R9       = 9,
+    R10      = 10,
+    R11      = 11,
+    R12      = 12,
+    R13      = 13,
+    R14      = 14,
+    R15      = 15,
+};
+
+#define XMM0    16
+#define XMM1    17
+#define XMM2    18
+#define XMM3    19
+#define XMM4    20
+#define XMM5    21
+#define XMM6    22
+#define XMM7    23
+/* There are also XMM8..XMM14 */
+#define XMM15   31
+
+#define ES      24
+
+#define NUMGENREGS 16
+
+// fishy naming as it covers XMM7 but not XMM15
+// currently only used as a replacement for mES in cgcod.c
+#define NUMREGS 25
+
+#define PSW     25
+#define STACK   26      // top of stack
+#define ST0     27      // 8087 top of stack register
+#define ST01    28      // top two 8087 registers; for complex types
+
+#define NOREG   29     // no register
+
+#define AL      0
+#define CL      1
+#define DL      2
+#define BL      3
+#define AH      4
+#define CH      5
+#define DH      6
+#define BH      7
+
+#define mAX     1
+#define mCX     2
+#define mDX     4
+#define mBX     8
+#define mSP     0x10
+#define mBP     0x20
+#define mSI     0x40
+#define mDI     0x80
+
+#define mR8     (1 << R8)
+#define mR9     (1 << R9)
+#define mR10    (1 << R10)
+#define mR11    (1 << R11)
+#define mR12    (1 << R12)
+#define mR13    (1 << R13)
+#define mR14    (1 << R14)
+#define mR15    (1 << R15)
+
+#define mXMM0   (1 << XMM0)
+#define mXMM1   (1 << XMM1)
+#define mXMM2   (1 << XMM2)
+#define mXMM3   (1 << XMM3)
+#define mXMM4   (1 << XMM4)
+#define mXMM5   (1 << XMM5)
+#define mXMM6   (1 << XMM6)
+#define mXMM7   (1 << XMM7)
+#define XMMREGS  (mXMM0 |mXMM1 |mXMM2 |mXMM3 |mXMM4 |mXMM5 |mXMM6 |mXMM7)
+
+#define mES     (1 << ES)       // 0x1000000
+#define mPSW    (1 << PSW)      // 0x2000000
+
+#define mSTACK  (1 << STACK)    // 0x4000000
+
+#define mST0    (1 << ST0)      // 0x20000000
+#define mST01   (1 << ST01)     // 0x40000000
+
+// Flags for getlvalue (must fit in regm_t)
+#define RMload  (1 << 30)
+#define RMstore (1 << 31)
+
+#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
+    // To support positional independent code,
+    // must be able to remove BX from available registers
+extern regm_t ALLREGS;
+#define ALLREGS_INIT            (mAX|mBX|mCX|mDX|mSI|mDI)
+#define ALLREGS_INIT_PIC        (mAX|mCX|mDX|mSI|mDI)
+extern regm_t BYTEREGS;
+#define BYTEREGS_INIT           (mAX|mBX|mCX|mDX)
+#define BYTEREGS_INIT_PIC       (mAX|mCX|mDX)
+#else
+#define ALLREGS                 (mAX|mBX|mCX|mDX|mSI|mDI)
+#define ALLREGS_INIT            ALLREGS
+#undef BYTEREGS
+#define BYTEREGS                (mAX|mBX|mCX|mDX)
+#endif
+
+/* We use the same IDXREGS for the 386 as the 8088, because if
+   we used ALLREGS, it would interfere with mMSW
+ */
+#define IDXREGS         (mBX|mSI|mDI)
+
+#define FLOATREGS_64    mAX
+#define FLOATREGS2_64   mDX
+#define DOUBLEREGS_64   mAX
+#define DOUBLEREGS2_64  mDX
+
+#define FLOATREGS_32    mAX
+#define FLOATREGS2_32   mDX
+#define DOUBLEREGS_32   (mAX|mDX)
+#define DOUBLEREGS2_32  (mCX|mBX)
+
+#define FLOATREGS_16    (mDX|mAX)
+#define FLOATREGS2_16   (mCX|mBX)
+#define DOUBLEREGS_16   (mAX|mBX|mCX|mDX)
+
+/*#define _8087REGS (mST0|mST1|mST2|mST3|mST4|mST5|mST6|mST7)*/
+
+/* Segment registers    */
+#define SEG_ES  0
+#define SEG_CS  1
+#define SEG_SS  2
+#define SEG_DS  3
+
+/*********************
+ * Masks for register pairs.
+ * Note that index registers are always LSWs. This is for the convenience
+ * of implementing far pointers.
+ */
+
+#if 0
+// Give us an extra one so we can enregister a long
+#define mMSW    (mCX|mDX|mDI|mES)       // most significant regs
+#define mLSW    (mAX|mBX|mSI)           // least significant regs
+#else
+#define mMSW    (mCX|mDX|mES)           /* most significant regs        */
+#define mLSW    (mAX|mBX|mSI|mDI)       /* least significant regs       */
+#endif
+
+/* Return !=0 if there is a SIB byte   */
+#define issib(rm)       (((rm) & 7) == 4 && ((rm) & 0xC0) != 0xC0)
+
+#if 0
+// relocation field size is always 32bits
+#define is32bitaddr(x,Iflags) (1)
+#else
+//
+// is32bitaddr works correctly only when x is 0 or 1.  This is
+// true today for the current definition of I32, but if the definition
+// of I32 changes, this macro will need to change as well
+//
+// Note: even for linux targets, CFaddrsize can be set by the inline
+// assembler.
+#define is32bitaddr(x,Iflags) (I64 || ((x) ^(((Iflags) & CFaddrsize) !=0)))
+#endif
+
+/*******************
+ * Some instructions.
+ */
+
+#define SEGES   0x26
+#define SEGCS   0x2E
+#define SEGSS   0x36
+#define SEGDS   0x3E
+#define SEGFS   0x64
+#define SEGGS   0x65
+
+#define CALL    0xE8
+#define JMP     0xE9    /* Intra-Segment Direct */
+#define JMPS    0xEB    /* JMP SHORT            */
+#define JCXZ    0xE3
+#define LOOP    0xE2
+#define LES     0xC4
+#define LEA     0x8D
+
+#define JO      0x70
+#define JNO     0x71
+#define JC      0x72
+#define JB      0x72
+#define JNC     0x73
+#define JAE     0x73
+#define JE      0x74
+#define JNE     0x75
+#define JBE     0x76
+#define JA      0x77
+#define JS      0x78
+#define JNS     0x79
+#define JP      0x7A
+#define JNP     0x7B
+#define JL      0x7C
+#define JGE     0x7D
+#define JLE     0x7E
+#define JG      0x7F
+
+
+/* NOP is used as a placeholder in the linked list of instructions, no  */
+/* actual code will be generated for it.                                */
+#define NOP     0x2E    /* actually CS: (we don't use 0x90 because the  */
+                        /* silly Windows stuff wants to output 0x90's)  */
+
+#define ESCAPE  0x3E    // marker that special information is here
+                        // (Iop2 is the type of special information)
+                        // (Same as DS:, but we will never generate
+                        // a separate DS: opcode anyway)
+    #define ESClinnum   (1 << 8)       // line number information
+    #define ESCctor     (2 << 8)       // object is constructed
+    #define ESCdtor     (3 << 8)       // object is destructed
+    #define ESCmark     (4 << 8)       // mark eh stack
+    #define ESCrelease  (5 << 8)       // release eh stack
+    #define ESCoffset   (6 << 8)       // set code offset for eh
+    #define ESCadjesp   (7 << 8)       // adjust ESP by IEV2.Vint
+    #define ESCmark2    (8 << 8)       // mark eh stack
+    #define ESCrelease2 (9 << 8)       // release eh stack
+    #define ESCframeptr (10 << 8)      // replace with load of frame pointer
+    #define ESCdctor    (11 << 8)      // D object is constructed
+    #define ESCddtor    (12 << 8)      // D object is destructed
+    #define ESCadjfpu   (13 << 8)      // adjust fpustackused by IEV2.Vint
+
+#define ASM     0x36    // string of asm bytes, actually an SS: opcode
+
+/*********************************
+ * Macros to ease generating code
+ * modregrm:    generate mod reg r/m field
+ * modregxrm:   reg could be R8..R15
+ * modregrmx:   rm could be R8..R15
+ * modregxrmx:  reg or rm could be R8..R15
+ * NEWREG:      change reg field of x to r
+ * genorreg:    OR  t,f
+ */
+
+#define modregrm(m,r,rm)        (((m)<<6)|((r)<<3)|(rm))
+#define modregxrm(m,r,rm)       ((((r)&8)<<15)|modregrm((m),(r)&7,rm))
+#define modregrmx(m,r,rm)       ((((rm)&8)<<13)|modregrm((m),r,(rm)&7))
+#define modregxrmx(m,r,rm)      ((((r)&8)<<15)|(((rm)&8)<<13)|modregrm((m),(r)&7,(rm)&7))
+
+#define NEWREXR(x,r)            ((x)=((x)&~REX_R)|(((r)&8)>>1))
+#define NEWREG(x,r)             ((x)=((x)&~(7<<3))|((r)<<3))
+#define code_newreg(c,r)        (NEWREG((c)->Irm,(r)&7),NEWREXR((c)->Irex,(r)))
+
+#define genorreg(c,t,f)         genregs((c),0x09,(f),(t))
+
+#define REX     0x40            // REX prefix byte, OR'd with the following bits:
+#define REX_W   8               // 0 = default operand size, 1 = 64 bit operand size
+#define REX_R   4               // high bit of reg field of modregrm
+#define REX_X   2               // high bit of sib index reg
+#define REX_B   1               // high bit of rm field, sib base reg, or opcode reg
+
+#define VEX2_B1(ivex)                           \
+    (                                           \
+        ivex.r    << 7 |                        \
+        ivex.vvvv << 3 |                        \
+        ivex.l    << 2 |                        \
+        ivex.pp                                 \
+    )
+
+#define VEX3_B1(ivex)                           \
+    (                                           \
+        ivex.r    << 7 |                        \
+        ivex.x    << 6 |                        \
+        ivex.b    << 5 |                        \
+        ivex.mmmm                               \
+    )
+
+#define VEX3_B2(ivex)                           \
+    (                                           \
+        ivex.w    << 7 |                        \
+        ivex.vvvv << 3 |                        \
+        ivex.l    << 2 |                        \
+        ivex.pp                                 \
+    )
+
+/**********************
+ * C library routines.
+ * See callclib().
+ */
+
+enum CLIB
+{
+        CLIBlcmp,
+        CLIBlmul,
+        CLIBldiv,
+        CLIBlmod,
+        CLIBuldiv,
+        CLIBulmod,
+
+#if TARGET_WINDOS
+        CLIBdmul,CLIBddiv,CLIBdtst0,CLIBdtst0exc,CLIBdcmp,CLIBdcmpexc,CLIBdneg,CLIBdadd,CLIBdsub,
+        CLIBfmul,CLIBfdiv,CLIBftst0,CLIBftst0exc,CLIBfcmp,CLIBfcmpexc,CLIBfneg,CLIBfadd,CLIBfsub,
+#endif
+
+        CLIBdbllng,CLIBlngdbl,CLIBdblint,CLIBintdbl,
+        CLIBdbluns,CLIBunsdbl,
+        CLIBdblulng,
+#if TARGET_WINDOS
+        // used the GNU way of converting unsigned long long to signed
+        CLIBulngdbl,
+#endif
+        CLIBdblflt,CLIBfltdbl,
+        CLIBdblllng,
+        CLIBllngdbl,
+        CLIBdblullng,
+        CLIBullngdbl,
+        CLIBdtst,
+        CLIBvptrfptr,CLIBcvptrfptr,
+
+        CLIB87topsw,CLIBfltto87,CLIBdblto87,CLIBdblint87,CLIBdbllng87,
+        CLIBftst,
+        CLIBfcompp,
+        CLIBftest,
+        CLIBftest0,
+        CLIBfdiv87,
+
+        // Complex numbers
+        CLIBcmul,
+        CLIBcdiv,
+        CLIBccmp,
+
+        CLIBu64_ldbl,
+        CLIBld_u64,
+
+        CLIBMAX
+};
+
+struct code
+{
+    code *next;
+    unsigned Iflags;
+#define CFes              1     // generate an ES: segment override for this instr
+#define CFjmp16           2     // need 16 bit jump offset (long branch)
+#define CFtarg            4     // this code is the target of a jump
+#define CFseg             8     // get segment of immediate value
+#define CFoff          0x10     // get offset of immediate value
+#define CFss           0x20     // generate an SS: segment override (not with
+                                // CFes at the same time, though!)
+#define CFpsw          0x40     // we need the flags result after this instruction
+#define CFopsize       0x80     // prefix with operand size
+#define CFaddrsize    0x100     // prefix with address size
+#define CFds          0x200     // need DS override (not with es, ss, or cs )
+#define CFcs          0x400     // need CS override
+#define CFfs          0x800     // need FS override
+#define CFgs    (CFcs | CFfs)   // need GS override
+#define CFwait       0x1000     // If I32 it indicates when to output a WAIT
+#define CFselfrel    0x2000     // if self-relative
+#define CFunambig    0x4000     // indicates cannot be accessed by other addressing
+                                // modes
+#define CFtarg2      0x8000     // like CFtarg, but we can't optimize this away
+#define CFvolatile  0x10000     // volatile reference, do not schedule
+#define CFclassinit 0x20000     // class init code
+#define CFoffset64  0x40000     // offset is 64 bits
+#define CFpc32      0x80000     // I64: PC relative 32 bit fixup
+
+#define CFvex       0x100000    // vex prefix
+#define CFvex3      0x200000    // 3 byte vex prefix
+
+#define CFjmp5      0x400000    // always a 5 byte jmp
+
+#define CFPREFIX (CFSEG | CFopsize | CFaddrsize)
+#define CFSEG   (CFes | CFss | CFds | CFcs | CFfs | CFgs)
+
+    union {
+        unsigned _Iop;
+        struct {
+#pragma pack(1)
+            unsigned char  op;
+            unsigned short   pp : 2;
+            unsigned short    l : 1;
+            unsigned short vvvv : 4;
+            unsigned short    w : 1;
+            unsigned short mmmm : 5;
+            unsigned short    b : 1;
+            unsigned short    x : 1;
+            unsigned short    r : 1;
+            unsigned char pfx; // always 0xC4
+#pragma pack()
+        } _Ivex;
+    } _OP;
+
+    /* The _EA is the "effective address" for the instruction, and consists of the modregrm byte,
+     * the sib byte, and the REX prefix byte. The 16 bit code generator just used the modregrm,
+     * the 32 bit x86 added the sib, and the 64 bit one added the rex.
+     */
+    union
+    {   unsigned _Iea;
+        struct
+        {
+            unsigned char _Irm;          // reg/mode
+            unsigned char _Isib;         // SIB byte
+            unsigned char _Irex;         // REX prefix
+        } _ea;
+    } _EA;
+
+#define Iop  _OP._Iop
+#define Ivex _OP._Ivex
+#define Iea  _EA._Iea
+#define Irm  _EA._ea._Irm
+#define Isib _EA._ea._Isib
+#define Irex _EA._ea._Irex
+
+
+    /* IFL1 and IEV1 are the first operand, which usually winds up being the offset to the Effective
+     * Address. IFL1 is the tag saying which variant type is in IEV1. IFL2 and IEV2 is the second
+     * operand, usually for immediate instructions.
+     */
+
+    unsigned char IFL1,IFL2;    // FLavors of 1st, 2nd operands
+    union evc IEV1;             // 1st operand, if any
+      #define IEVpointer1 IEV1._EP.Vpointer
+      #define IEVseg1     IEV1._EP.Vseg
+      #define IEVsym1     IEV1.sp.Vsym
+      #define IEVdsym1    IEV1.dsp.Vsym
+      #define IEVoffset1  IEV1.sp.Voffset
+      #define IEVlsym1    IEV1.lab.Vsym
+      #define IEVint1     IEV1.Vint
+    union evc IEV2;             // 2nd operand, if any
+      #define IEVpointer2 IEV2._EP.Vpointer
+      #define IEVseg2     IEV2._EP.Vseg
+      #define IEVsym2     IEV2.sp.Vsym
+      #define IEVdsym2    IEV2.dsp.Vsym
+      #define IEVoffset2  IEV2.sp.Voffset
+      #define IEVlsym2    IEV2.lab.Vsym
+      #define IEVint2     IEV2.Vint
+      #define IEVllong2   IEV2.Vllong
+    void print();               // pretty-printer
+
+    code() { Iflags = 0; Irex = 0; Isib = 0; IFL1 = 0; IFL2 = 0; }      // constructor
+
+    void orReg(unsigned reg)
+    {   if (reg & 8)
+            Irex |= REX_R;
+        Irm |= modregrm(0, reg & 7, 0);
+    }
+
+    void setReg(unsigned reg)
+    {
+        Irex &= ~REX_R;
+        Irm &= ~modregrm(0, 7, 0);
+        orReg(reg);
+    }
+
+    bool isJumpOP() { return Iop == JMP || Iop == JMPS; }
+};
+
+// !=0 if we have to add FWAIT to floating point ops
+#define ADDFWAIT()      (config.target_cpu <= TARGET_80286)
+
+/************************************
+ */
+
+struct NDP
+{
+    elem *e;                    // which elem is stored here (NULL if none)
+    unsigned offset;            // offset from e (used for complex numbers)
+
+    static NDP *save;
+    static int savemax;         // # of entries in save[]
+    static int savetop;         // # of entries used in save[]
+};
+
+extern NDP _8087elems[8];
+
+void getlvalue_msw(code *);
+void getlvalue_lsw(code *);
+code *getlvalue (code *pcs , elem *e , regm_t keepmsk );
+code *loadea (elem *e , code *cs , unsigned op , unsigned reg , targ_size_t offset , regm_t keepmsk , regm_t desmsk );

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -151,7 +151,7 @@ struct CFA_state
 
 int dwarf_regno(int reg)
 {
-    assert(reg <= R15);
+    assert(reg < NUMGENREGS);
     if (I16 || I32)
         return reg;
     else

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -2998,68 +2998,14 @@ void Obj::moduleinfo(Symbol *scc)
         SegData[seg]->SDoffset += Obj::reftoident(seg, SegData[seg]->SDoffset, scc, 0, CFoffset64 | CFoff);
     }
 
-    /* Constructor that links the ModuleReference to the head of
-     * the list pointed to by _Dmoduleref
-     */
     {
-        /*      ret
-         * codeOffset:
-         *      pushad
-         *      mov     EAX,&ModuleReference
-         *      mov     ECX,_DmoduleRef
-         *      mov     EDX,[ECX]
-         *      mov     [EAX],EDX
-         *      mov     [ECX],EAX
-         *      popad
-         *      ret
-         */
-
         const int seg = CODE;
         Outbuffer *buf = SegData[seg]->SDbuf;
         SegData[seg]->SDoffset = buf->size();
         codeOffset = SegData[seg]->SDoffset;
 
-        if (I64 && config.flags3 & CFG3pic)
-        {   // LEA RAX,ModuleReference[RIP]
-            buf->writeByte(REX | REX_W);
-            buf->writeByte(0x8D);
-            buf->writeByte(modregrm(0,AX,5));
-            buf->write32(refOffset);
-            ElfObj::addrel(seg, codeOffset + 3, R_X86_64_PC32, STI_DATA, -4);
+        cod3_buildmodulector(buf, codeOffset, refOffset);
 
-            // MOV RCX,_DmoduleRef@GOTPCREL[RIP]
-            buf->writeByte(REX | REX_W);
-            buf->writeByte(0x8B);
-            buf->writeByte(modregrm(0,CX,5));
-            buf->write32(0);
-            ElfObj::addrel(seg, codeOffset + 10, R_X86_64_GOTPCREL, Obj::external_def("_Dmodule_ref"), -4);
-        }
-        else
-        {
-            const int reltype = I64 ? R_X86_64_32 : RI_TYPE_SYM32;
-
-            /* movl ModuleReference*, %eax */
-            buf->writeByte(0xB8);
-            buf->write32(refOffset);
-            ElfObj::addrel(seg, codeOffset + 1, reltype, STI_DATA, 0);
-
-            /* movl _Dmodule_ref, %ecx */
-            buf->writeByte(0xB9);
-            buf->write32(0);
-            ElfObj::addrel(seg, codeOffset + 6, reltype, Obj::external_def("_Dmodule_ref"), 0);
-        }
-
-        if (I64)
-            buf->writeByte(REX | REX_W);
-        buf->writeByte(0x8B); buf->writeByte(0x11); /* movl (%ecx), %edx */
-        if (I64)
-            buf->writeByte(REX | REX_W);
-        buf->writeByte(0x89); buf->writeByte(0x10); /* movl %edx, (%eax) */
-        if (I64)
-            buf->writeByte(REX | REX_W);
-        buf->writeByte(0x89); buf->writeByte(0x01); /* movl %eax, (%ecx) */
-
-        buf->writeByte(0xC3); /* ret */
         SegData[seg]->SDoffset = buf->size();
     }
 

--- a/src/backend/platform_stub.c
+++ b/src/backend/platform_stub.c
@@ -1,0 +1,166 @@
+// Copyright (C) 2011 by Digital Mars
+// All Rights Reserved
+// http://www.digitalmars.com
+// Written by Brad Roberts
+/*
+ * This file is licensed under the Boost 1.0 license.
+ */
+
+// this file stubs out all the apis that are platform specific
+
+#include <stdio.h>
+
+#include "cc.h"
+#include "code.h"
+
+static char __file__[] = __FILE__;
+#include "tassert.h"
+
+#if SCPP
+#error SCPP not supported
+#endif
+
+int clib_inited = 0;
+const unsigned dblreg[] = { -1 };
+
+code* nteh_epilog()                               { assert(0); return NULL; }
+code* nteh_filter(block* b)                       { assert(0); return NULL; }
+void  nteh_framehandler(symbol* scopetable)       { assert(0); }
+code *nteh_patchindex(code* c, int sindex)        { assert(0); return NULL; }
+code* nteh_gensindex(int sindex)                  { assert(0); return NULL; }
+code* nteh_monitor_epilog(regm_t retregs)         { assert(0); return NULL; }
+code* nteh_monitor_prolog(Symbol* shandle)        { assert(0); return NULL; }
+code* nteh_prolog()                               { assert(0); return NULL; }
+code* nteh_setsp(int op)                          { assert(0); return NULL; }
+code* nteh_unwind(regm_t retregs, unsigned index) { assert(0); return NULL; }
+
+code* REGSAVE::restore(code* c, int reg, unsigned idx) { assert(0); return NULL; }
+code* REGSAVE::save(code* c, int reg, unsigned* pidx) { assert(0); return NULL; }
+
+FuncParamRegs::FuncParamRegs(tym_t tyf) { assert(0); }
+int FuncParamRegs::alloc(type *t, tym_t ty, unsigned char *preg1, unsigned char *preg2) { assert(0); return 0; }
+
+code* prolog_ifunc(tym_t* tyf) { assert(0); return NULL; }
+code* prolog_ifunc2(tym_t tyf, tym_t tym, bool pushds) { assert(0); return NULL; }
+code* prolog_16bit_windows_farfunc(tym_t* tyf, bool* pushds) { assert(0); return NULL; }
+code* prolog_frame(unsigned farfunc, unsigned* xlocalsize, bool* enter) { assert(0); return NULL; }
+code* prolog_frameadj(tym_t tyf, unsigned xlocalsize, bool enter, bool* pushalloc) { assert(0); return NULL; }
+code* prolog_frameadj2(tym_t tyf, unsigned xlocalsize, bool* pushalloc) { assert(0); return NULL; }
+code* prolog_setupalloca() { assert(0); return NULL; }
+code* prolog_trace(bool farfunc, unsigned* regsaved) { assert(0); return NULL; }
+code* prolog_genvarargs(symbol* sv, regm_t* namedargs) { assert(0); return NULL; }
+code* prolog_loadparams(tym_t tyf, bool pushalloc, regm_t* namedargs) { assert(0); return NULL; }
+targ_size_t cod3_spoff() { assert(0); }
+
+void  epilog(block* b) { assert(0); }
+unsigned calcblksize(code* c) { assert(0); return 0; }
+unsigned calccodsize(code* c) { assert(0); return 0; }
+unsigned codout(code* c) { assert(0); return 0; }
+
+void assignaddr(block* bl) { assert(0); }
+int  branch(block* bl, int flag) { assert(0); return 0; }
+void cgsched_block(block* b) { assert(0); }
+void doswitch(block* b) { assert(0); }
+void jmpaddr(code* c) { assert(0); }
+void outblkexitcode(block* bl, code*& c, int& anyspill, const char* sflsave, symbol** retsym, const regm_t mfuncregsave) { assert(0); }
+void outjmptab(block* b) { assert(0); }
+void outswitab(block* b) { assert(0); }
+void pinholeopt(code* c, block* bn) { assert(0); }
+
+bool cse_simple(code* c, elem* e) { assert(0); return false; }
+code* comsub87(elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* fixresult(elem* e, regm_t retregs, regm_t* pretregs) { assert(0); return NULL; }
+code* genmovreg(code* c, unsigned to, unsigned from) { assert(0); return NULL; }
+code* genpush(code *c , unsigned reg) { assert(0); return NULL; }
+code* gensavereg(unsigned& reg, targ_uns slot) { assert(0); return NULL; }
+code* gen_spill_reg(Symbol* s, bool toreg) { assert(0); return NULL; }
+code* genstackclean(code* c, unsigned numpara, regm_t keepmsk) { assert(0); return NULL; }
+code* loaddata(elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* longcmp(elem* e, bool jcond, unsigned fltarg, code* targ) { assert(0); return NULL; }
+code* movregconst(code* c, unsigned reg, targ_size_t value, regm_t flags) { assert(0); return NULL; }
+code* params(elem* e, unsigned stackalign) { assert(0); return NULL; }
+code* save87() { assert(0); return NULL; }
+code* tstresult(regm_t regm, tym_t tym, unsigned saveflag) { assert(0); return NULL; }
+int cod3_EA(code* c) { assert(0); return 0; }
+regm_t cod3_useBP() { assert(0); return 0; }
+regm_t regmask(tym_t tym, tym_t tyf) { assert(0); return 0; }
+targ_size_t cod3_bpoffset(symbol* s) { assert(0); return 0; }
+unsigned char loadconst(elem* e, int im) { assert(0); return 0; }
+void cod3_adjSymOffsets() { assert(0); }
+void cod3_align() { assert(0); }
+void cod3_align_bytes(size_t nbytes) { assert(0); }
+void cod3_initregs() { assert(0); }
+void cod3_setdefault() { assert(0); }
+void cod3_set32() { assert(0); }
+void cod3_set64() { assert(0); }
+void cod3_thunk(symbol* sthunk, symbol* sfunc, unsigned p, tym_t thisty, targ_size_t d, int i, targ_size_t d2) { assert(0); }
+void genEEcode() { assert(0); }
+void gensaverestore(regm_t regm, code** csave, code** crestore) { assert(0); }
+void gensaverestore2(regm_t regm, code** csave, code** crestore) { assert(0); }
+
+const unsigned char* getintegerparamsreglist(tym_t tyf, size_t* num) { assert(0); *num = 0; return NULL; }
+const unsigned char* getfloatparamsreglist(tym_t tyf, size_t* num) { assert(0); *num = 0; return NULL; }
+void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset) { assert(0); }
+code* gen_testcse(code *c, unsigned sz, targ_uns i) { assert(0); return NULL; }
+code* gen_loadcse(code *c, unsigned reg, targ_uns i) { assert(0); return NULL; }
+code* cod3_stackadj(code* c, int nbytes) { assert(0); return NULL; }
+void simplify_code(code *c) { assert(0); }
+void cgreg_dst_regs(unsigned *dst_integer_reg, unsigned *dst_float_reg) { assert(0); }
+void cgreg_set_priorities(tym_t ty, char **pseq, char **pseqmsw) { assert(0); }
+
+code* cdabs      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdaddass   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdasm      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdbscan    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdbswap    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdbt       (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdbyteint  (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdcmp      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdcnvt     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdcom      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdcomma    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdcond     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdconvt87  (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdctor     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cddctor    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdddtor    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cddtor     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdeq       (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cderr      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdframeptr (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdfunc     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdgot      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdhalt     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdind      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdinfo     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdlngsht   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdloglog   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdmark     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdmemcmp   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdmemcpy   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdmemset   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdmsw      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdmul      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdmulass   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdneg      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdnot      (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdnullcheck(elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdorth     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdpair     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdport     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdpost     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdrelconst (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdrndtol   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdscale    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdsetjmp   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdshass    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdshift    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdshtlng   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdstrcmp   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdstrcpy   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdstreq    (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdstrlen   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdstrthis  (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdvector   (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+code* cdvoid     (elem* e, regm_t* pretregs) { assert(0); return NULL; }
+

--- a/src/backend/rtlsym.h
+++ b/src/backend/rtlsym.h
@@ -140,11 +140,11 @@ SYMBOL_SCPP(AHSHIFT,   FLfunc,0,"_AHSHIFT",0,tstrace) \
 \
 SYMBOL_SCPP_TX86(HDIFFN, FLfunc,mBX|mCX|mSI|mDI|mBP|mES,"_aNahdiff", 0, 0) \
 SYMBOL_SCPP_TX86(HDIFFF, FLfunc,mBX|mCX|mSI|mDI|mBP|mES,"_aFahdiff", 0, 0) \
+SYMBOL_SCPP_TX86(INTONLY,FLfunc,mSI|mDI,"_intonly", 0, 0) \
 \
 SYMBOL_Z(EXCEPT_LIST, FLextern,0,"_except_list",0,tsint) \
 SYMBOL_Z(SETJMP3, FLfunc,FREGSAVED,"_setjmp3", 0, 0) \
 SYMBOL_Z(LONGJMP, FLfunc,FREGSAVED,"_seh_longjmp_unwind@4", 0, 0) \
-SYMBOL_Z(INTONLY, FLfunc,mSI|mDI,"_intonly", 0, 0) \
 SYMBOL_Z(ALLOCA,  FLfunc,fregsaved,"__alloca", 0, 0) \
 SYMBOL_Z(CPP_LONGJMP, FLfunc,FREGSAVED,"_cpp_longjmp_unwind@4", 0, 0) \
 SYMBOL_Z(PTRCHK, FLfunc,fregsaved,"_ptrchk", 0, 0) \

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -1668,6 +1668,7 @@ void AsmStatement::toIR(IRState *irs)
                 break;
         }
 
+#if TX86
         // Repeat for second operand
         switch (c->IFL2)
         {
@@ -1691,6 +1692,7 @@ void AsmStatement::toIR(IRState *irs)
                     s->Sflags |= SFLlivexit;
                 break;
         }
+#endif
         //c->print();
     }
 

--- a/src/toir.c
+++ b/src/toir.c
@@ -310,6 +310,7 @@ elem *setEthis(Loc loc, IRState *irs, elem *ey, AggregateDeclaration *ad)
 
 int intrinsic_op(char *name)
 {
+#if TX86
     //printf("intrinsic_op(%s)\n", name);
     static const char *std_namearray[] =
     {
@@ -569,6 +570,8 @@ int intrinsic_op(char *name)
         return (i == -1) ? i : core_ioptab[i];
     }
 #endif
+#endif
+
     return -1;
 }
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -130,9 +130,9 @@ BFLAGS=
 ##### Implementation variables (do not modify)
 
 # Compile flags
-CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp
+CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DTARGET_CPU_X86=1
 # Compile flags for modules with backend/toolkit dependencies
-MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx
+MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_CPU_X86=1
 # Compile flags for compiler unit tests
 TFLAGS=-I$(STLPORT);$(CPPUNIT)\include;$(INCLUDE) $(TFLAGS) -DDISABLE_MAIN=1 -cpp -Aa -Ab -Ae -Ar
 # Recursive make
@@ -198,7 +198,8 @@ SRCS= mars.c enum.c struct.c dsymbol.c import.c idgen.c impcnvgen.c utf.h \
 
 # D back end
 BACKSRC= $C\cdef.h $C\cc.h $C\oper.h $C\ty.h $C\optabgen.c \
-	$C\global.h $C\code.h $C\type.h $C\dt.h $C\cgcv.h \
+	$C\global.h $C\code.h $C\code_x86.h $C/code_stub.h $C/platform_stub.c \
+	$C\type.h $C\dt.h $C\cgcv.h \
 	$C\el.h $C\iasm.h $C\rtlsym.h \
 	$C\bcomplex.c $C\blockopt.c $C\cg.c $C\cg87.c $C\cgxmm.c \
 	$C\cgcod.c $C\cgcs.c $C\cgcv.c $C\cgelem.c $C\cgen.c $C\cgobj.c \
@@ -239,7 +240,7 @@ ROOTSRC= $(ROOT)\root.h $(ROOT)\root.c $(ROOT)\array.c \
 # Header files
 #TOTALH=total.sym # Use with pre-compiled headers
 TOTALH=id.h
-CH= $C\cc.h $C\global.h $C\oper.h $C\code.h $C\type.h $C\dt.h $C\cgcv.h \
+CH= $C\cc.h $C\global.h $C\oper.h $C\code.h $C\code_x86.h $C\type.h $C\dt.h $C\cgcv.h \
 	$C\el.h $C\iasm.h $C\obj.h
 
 # Makefiles
@@ -342,15 +343,15 @@ zip: detab tolf $(MAKEFILES)
 
 elxxx.c cdxxx.c optab.c debtab.c fltables.c tytab.c : \
 	$C\cdef.h $C\cc.h $C\oper.h $C\ty.h $C\optabgen.c
-	$(CC) -cpp -ooptabgen.exe $C\optabgen -DMARS -I$(TK)
+	$(CC) -cpp -ooptabgen.exe $C\optabgen -DMARS -DTARGET_CPU_X86=1 -I$(TK)
 	optabgen
 
 impcnvtab.c : impcnvgen.c
-	$(CC) -I$(ROOT) -cpp impcnvgen
+	$(CC) -I$(ROOT) -cpp -DTARGET_CPU_X86=1 impcnvgen
 	impcnvgen
 
 id.h id.c : idgen.c
-	$(CC) -cpp idgen
+	$(CC) -cpp -DTARGET_CPU_X86=1 idgen
 	idgen
 
 ############################# Intermediate Rules ############################


### PR DESCRIPTION
Finish (well, not really, but achieved a big milestone) cleaving the backend into separate layers: generic code and platform specific code.  This introduces a new make variable, TARGET_CPU which defaults to X86.  The only other supported value is 'stub' which builds backend/platform-stub.c and does NOT link in the x86 specific files (cg87.o cgxmm.o cgsched.o cod1.o cod2.o cod3.o cod4.o ptrntab.o).
