### PR TITLE
Issue 8442 - [2.060 beta] Empty array enum not treated as immutable

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -543,23 +543,28 @@ MATCH ArrayLiteralExp::implicitConvTo(Type *t)
     if ((tb->ty == Tarray || tb->ty == Tsarray) &&
         (typeb->ty == Tarray || typeb->ty == Tsarray))
     {
+        Type *typen = typeb->nextOf()->toBasetype();
+
         if (tb->ty == Tsarray)
         {   TypeSArray *tsa = (TypeSArray *)tb;
             if (elements->dim != tsa->dim->toInteger())
                 result = MATCHnomatch;
         }
 
-        if (!elements->dim && typeb->nextOf()->toBasetype()->ty != Tvoid)
-            result = MATCHnomatch;
-
         Type *telement = tb->nextOf();
-        for (size_t i = 0; i < elements->dim; i++)
-        {   Expression *e = (*elements)[i];
-            if (result == MATCHnomatch)
-                break;                          // no need to check for worse
-            MATCH m = (MATCH)e->implicitConvTo(telement);
-            if (m < result)
-                result = m;                     // remember worst match
+        if (!elements->dim)
+        {   if (typen->ty != Tvoid)
+                result = typen->implicitConvTo(telement);
+        }
+        else
+        {   for (size_t i = 0; i < elements->dim; i++)
+            {   Expression *e = (*elements)[i];
+                if (result == MATCHnomatch)
+                    break;                          // no need to check for worse
+                MATCH m = (MATCH)e->implicitConvTo(telement);
+                if (m < result)
+                    result = m;                     // remember worst match
+            }
         }
 
         if (!result)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -830,6 +830,7 @@ void test44()
 }
 
 /***************************************************/
+// 2006
 
 void test2006()
 {
@@ -839,6 +840,15 @@ void test2006()
     assert(aas.length == 1);
     aas = aas ~ cast (string []) [];
     assert(aas.length == 2);
+}
+
+/***************************************************/
+// 8442
+
+void test8442()
+{
+    enum int[] fooEnum = [];
+    immutable fooImmutable = fooEnum;
 }
 
 /***************************************************/
@@ -5386,6 +5396,7 @@ int main()
     test84();
     test85();
     test2006();
+    test8442();
     test86();
     test87();
     test5554();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8442

This is a regression of fixing issue 2006.
If empty array literal has the type T[] and T isn't void, should check proper element type convertible (T[] to U --> T to U).
