### PR TITLE
Issue 8453 - Associative array keys refused as property by sort

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7463,11 +7463,14 @@ Expression *CallExp::resolveUFCS(Scope *sc)
     if (e->op == TOKerror || !e->type)
         return NULL;
 
-    if (e->op == TOKtype || e->op == TOKimport)
+    if (e->op == TOKtype || e->op == TOKimport || e->op == TOKdotexp)
         return NULL;
 
-    //printf("resolveUCSS %s, e->op = %s\n", toChars(), Token::toChars(e->op));
+    e = resolveProperties(sc, e);
+
     Type *t = e->type->toBasetype();
+    //printf("resolveUCSS %s, e = %s, %s, %s\n",
+    //    toChars(), Token::toChars(e->op), t->toChars(), e->toChars());
     if (t->ty == Taarray)
     {
         if (tiargs)

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -315,6 +315,34 @@ void test8252()
 }
 
 /*******************************************/
+// 8453
+
+T[] sort8453(T)(T[] a) { return a; }
+
+void test8453()
+{
+    int[int] foo;
+    auto bar1 = foo.keys().sort8453(); // OK
+    auto bar2 = foo.keys.sort8453();   // Error
+}
+
+/*******************************************/
+
+template Signal4()
+{
+    void connect(){}
+}
+struct S4
+{
+    mixin Signal4!() s;
+}
+void test4()
+{
+    S4 s;
+    s.s.connect();  // s.s is TOKdotexp, so never match UFCS
+}
+
+/*******************************************/
 
 int main()
 {
@@ -329,6 +357,8 @@ int main()
     test7943();
     test8180();
     test8252();
+    test8453();
+    test4();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8453

This is a regression of refactoring around UFCS mechanism.
Introduced commit: e9538dc00db8789ab1f686f0a0a2bed7316ee794
