### PR TITLE
Issue 8437 - [2.060 beta] static struct no size yet for forward reference

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -640,9 +640,10 @@ void ClassDeclaration::semantic(Scope *sc)
         if (s->isEnumDeclaration() ||
             (s->isAggregateDeclaration() && s->ident) ||
             s->isTemplateMixin() ||
+            s->isAttribDeclaration() ||
             s->isAliasDeclaration())
         {
-            //printf("setScope %s %s\n", s->kind(), s->toChars());
+            //printf("[%d] setScope %s %s, sc = %p\n", i, s->kind(), s->toChars(), sc);
             s->setScope(sc);
         }
     }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5280,17 +5280,32 @@ struct DT160
 
 void foo160(DT160 dateTime)
 {
-        printf("test7 year %d, day %d\n", dateTime._date._year, dateTime._date._day);
-	assert(dateTime._date._year == 1999);
-	assert(dateTime._date._day == 6);
+    printf("test7 year %d, day %d\n", dateTime._date._year, dateTime._date._day);
+    assert(dateTime._date._year == 1999);
+    assert(dateTime._date._day == 6);
 }
 
-void test160() {
-        auto dateTime = DT160(1999, 7, 6, 12, 30, 33);
-        printf("test5 year %d, day %d\n", dateTime._date._year, dateTime._date._day);
-	assert(dateTime._date._year == 1999);
-	assert(dateTime._date._day == 6);
-        foo160(DT160(1999, 7, 6, 12, 30, 33));
+void test160()
+{
+    auto dateTime = DT160(1999, 7, 6, 12, 30, 33);
+    printf("test5 year %d, day %d\n", dateTime._date._year, dateTime._date._day);
+    assert(dateTime._date._year == 1999);
+    assert(dateTime._date._day == 6);
+    foo160(DT160(1999, 7, 6, 12, 30, 33));
+}
+
+/***************************************************/
+// 8437
+
+class Cgi8437
+{
+    struct PostParserState {
+        UploadedFile piece;
+    }
+
+    static struct UploadedFile {
+        string contentFilename;
+    }
 }
 
 /***************************************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8437

This is a regression introduced fixing aggregate alignment.
Introduced Commit: 154e44a006270d53745f99ec3e538a0ce526ae76

In VarDeclaration::semantic, if scope alignment is default, then its type's alignment is used, and it needs to resolve forward reference.
But, in ClassDeclaration::semantic, the calling setScope for AttribDeclaration members was lacked.
