### PR TITLE
Issue 8434 - cannot implicitly convert expression (vs1.opCast()) of type const(Vector2D) to object.Object

### DIFF
--- a/src/opover.c
+++ b/src/opover.c
@@ -930,12 +930,20 @@ Expression *EqualExp::op_overload(Scope *sc)
         if (!(cd1->isCPPinterface() || cd2->isCPPinterface()))
         {
             /* Rewrite as:
-             *      .object.opEquals(cast(Object)e1, cast(Object)e2)
+             *      .object.opEquals(e1, e2)
+             */
+            Expression *e1x = e1;
+            Expression *e2x = e2;
+
+            /*
              * The explicit cast is necessary for interfaces,
              * see http://d.puremagic.com/issues/show_bug.cgi?id=4088
              */
-            Expression *e1x = new CastExp(loc, e1, ClassDeclaration::object->getType());
-            Expression *e2x = new CastExp(loc, e2, ClassDeclaration::object->getType());
+            Type *to = ClassDeclaration::object->getType();
+            if (cd1->isInterfaceDeclaration())
+                e1x = new CastExp(loc, e1, t1->isMutable() ? to : to->constOf());
+            if (cd2->isInterfaceDeclaration())
+                e2x = new CastExp(loc, e2, t2->isMutable() ? to : to->constOf());
 
             Expression *e = new IdentifierExp(loc, Id::empty);
             e = new DotIdExp(loc, e, Id::object);

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -694,6 +694,32 @@ void test7641()
 }
 
 /**************************************/
+// 8434
+
+void test8434()
+{
+    class Vector2D(T)
+    {
+        T x, y;
+
+        this(T x, T y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        U opCast(U)() const { assert(0); }
+    }
+
+    alias Vector2D!(short) Vector2s;
+    alias Vector2D!(float) Vector2f;
+
+    Vector2s vs1 = new Vector2s(42, 23);
+    Vector2s vs2 = new Vector2s(42, 23);
+
+    assert(vs1 != vs2);
+}
+
+/**************************************/
 
 int main()
 {
@@ -716,6 +742,7 @@ int main()
     test16();
     test17();
     test7641();
+    test8434();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8434

This is a regression of 2.058, by fixing issue 4088.
The equality comparison of class objects should not run opCast.
