### PR TITLE
partly fix issue 8525

### DIFF
--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -4446,6 +4446,7 @@ beg:
                infinite loops)
              */
             if (e2->Eoper == op &&
+                e2->E1->Eoper != OPconst &&
                 e2->E2->Eoper == OPconst &&
                 tysize(e2->E1->Ety) == tysize(e2->E2->Ety) &&
                 (!tyfloating(e1->Ety) || e1->Ety == e2->Ety)

--- a/test/compilable/test8525.d
+++ b/test/compilable/test8525.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -O
+
+class Bug8525
+{
+    int[] elements;
+
+    final int bar()
+    {
+        return elements[0];
+    }
+}


### PR DESCRIPTION
- Only perform associative 'a op1 (b op2 c) => (a op2 b) op1 c'
  transformation if 'b' is not a constant. This breaks a cycle
  with the '(a op c1) op c2 => a op (c1 op c2)' transformation
  if folding 'c1 op c2' fails.

http://d.puremagic.com/issues/show_bug.cgi?id=8525
