### PR TITLE
OpenBSD

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -2549,7 +2549,7 @@ code* prolog_frame(unsigned farfunc, unsigned* xlocalsize, bool* enter)
     if (config.wflags & WFincbp && farfunc)
         c = gen1(c,0x40 + BP);      /* INC  BP                      */
     if (config.target_cpu < TARGET_80286 ||
-        config.exe & (EX_LINUX | EX_LINUX64 | EX_OSX | EX_OSX64 | EX_FREEBSD | EX_FREEBSD64 | EX_SOLARIS | EX_SOLARIS64) ||
+        config.exe & (EX_LINUX | EX_LINUX64 | EX_OSX | EX_OSX64 | EX_FREEBSD | EX_FREEBSD64 | EX_SOLARIS | EX_SOLARIS64 | EX_OPENBSD | EX_OPENBSD64) ||
         !localsize ||
         config.flags & CFGstack ||
         (*xlocalsize >= 0x1000 && config.exe & EX_flat) ||

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -19,8 +19,20 @@
 #include        <float.h>
 #include        <time.h>
 
-#if !defined(__OpenBSD__)
-// Mysteriously missing from OpenBSD
+#if defined __OpenBSD__
+    #include <sys/param.h>
+    #if OpenBSD < 201111 // 5.0
+        #define HAVE_FENV_H 0
+    #else
+        #define HAVE_FENV_H 1
+    #endif
+#elif _MSC_VER
+    #define HAVE_FENV_H 0
+#else
+    #define HAVE_FENV_H 1
+#endif
+
+#if HAVE_FENV_H
 #include        <fenv.h>
 #endif
 
@@ -48,17 +60,34 @@ static char __file__[] = __FILE__;      /* for tassert.h                */
 
 extern void error(const char *filename, unsigned linnum, const char *format, ...);
 
-#if linux || __APPLE__ || __FreeBSD__ || __sun&&__SVR4
-int _status87()
-{
-    return fetestexcept(FE_ALL_EXCEPT);
-}
+#if HAVE_FENV_H
+    #define HAVE_FLOAT_EXCEPT 1
 
-void _clear87()
-{
-    feclearexcept(FE_ALL_EXCEPT);
-}
+    static int testFE()
+    {
+        return fetestexcept(FE_ALL_EXCEPT);
+    }
+
+    static void clearFE()
+    {
+        feclearexcept(FE_ALL_EXCEPT);
+    }
+#elif defined _MSC_VER && TX86
+    #define HAVE_FLOAT_EXCEPT 1
+
+    static int testFE()
+    {
+        return _status87() & 0x3F;
+    }
+
+    static void clearFE()
+    {
+        _clear87();
+    }
+#else
+    #define HAVE_FLOAT_EXCEPT 0
 #endif
+
 
 CEXTERN elem * evalu8(elem *);
 
@@ -605,8 +634,8 @@ elem * evalu8(elem *e)
             return e;
 #endif
         esave = *e;
-#if TX86 && !__OpenBSD__
-        _clear87();
+#if HAVE_FLOAT_EXCEPT
+        clearFE();
 #endif
     }
     else
@@ -1992,10 +2021,10 @@ elem * evalu8(elem *e)
 
     if (!ignore_exceptions &&
         (config.flags4 & CFG4fastfloat) == 0 &&
-#if __OpenBSD__
-        1                    // until OpenBSD supports C standard fenv.h
+#if HAVE_FLOAT_EXCEPT
+        testFE()
 #else
-        _status87() & 0x3F
+        1
 #endif
        )
     {

--- a/src/backend/nteh.c
+++ b/src/backend/nteh.c
@@ -316,7 +316,7 @@ code *nteh_prolog()
         /* An sindex value of -2 is a magic value that tells the
          * stack unwinder to skip this frame.
          */
-        assert(config.exe & (EX_LINUX | EX_LINUX64 | EX_OSX | EX_OSX64 | EX_FREEBSD | EX_FREEBSD64 | EX_SOLARIS | EX_SOLARIS64));
+        assert(config.exe & (EX_LINUX | EX_LINUX64 | EX_OSX | EX_OSX64 | EX_FREEBSD | EX_FREEBSD64 | EX_SOLARIS | EX_SOLARIS64 | EX_OPENBSD | EX_OPENBSD64));
         cs.Iop = 0x68;
         cs.Iflags = 0;
         cs.Irex = 0;


### PR DESCRIPTION
- use fenv.h on OpenBSD >= 5.0 and for DMC
- fallback to _clear87/_status87 for MSC
- add missing EX_OPENBSD

we have no TLS emulation yet
