### PR TITLE
fix osx/64 bit build

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -156,7 +156,7 @@ One and only one of these macros must be set by the makefile:
  * Target machine types:
  */
 
-#if TARGET_CPU_X86
+#if DM_TARGET_CPU_X86
 #define TX86            1               // target is Intel 80X86 processor
 #endif
 

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -66,9 +66,9 @@ union evc
     } as;                       // asm node (FLasm)
 };
 
-#if TARGET_CPU_X86
+#if DM_TARGET_CPU_X86
 #include "code_x86.h"
-#elif TARGET_CPU_stub
+#elif DM_TARGET_CPU_stub
 #include "code_stub.h"
 #else
 #error unknown cpu

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -83,8 +83,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -DTARGET_CPU_$(TARGET_CPU)=1
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -DTARGET_CPU_$(TARGET_CPU)=1
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1
 
 CH= $C/cc.h $C/global.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/obj.h $(TARGET_CH)

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -130,9 +130,9 @@ BFLAGS=
 ##### Implementation variables (do not modify)
 
 # Compile flags
-CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DTARGET_CPU_X86=1
+CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DDM_TARGET_CPU_X86=1
 # Compile flags for modules with backend/toolkit dependencies
-MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_CPU_X86=1
+MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DDM_TARGET_CPU_X86=1
 # Compile flags for compiler unit tests
 TFLAGS=-I$(STLPORT);$(CPPUNIT)\include;$(INCLUDE) $(TFLAGS) -DDISABLE_MAIN=1 -cpp -Aa -Ab -Ae -Ar
 # Recursive make
@@ -343,15 +343,15 @@ zip: detab tolf $(MAKEFILES)
 
 elxxx.c cdxxx.c optab.c debtab.c fltables.c tytab.c : \
 	$C\cdef.h $C\cc.h $C\oper.h $C\ty.h $C\optabgen.c
-	$(CC) -cpp -ooptabgen.exe $C\optabgen -DMARS -DTARGET_CPU_X86=1 -I$(TK)
+	$(CC) -cpp -ooptabgen.exe $C\optabgen -DMARS -DDM_TARGET_CPU_X86=1 -I$(TK)
 	optabgen
 
 impcnvtab.c : impcnvgen.c
-	$(CC) -I$(ROOT) -cpp -DTARGET_CPU_X86=1 impcnvgen
+	$(CC) -I$(ROOT) -cpp -DDM_TARGET_CPU_X86=1 impcnvgen
 	impcnvgen
 
 id.h id.c : idgen.c
-	$(CC) -cpp -DTARGET_CPU_X86=1 idgen
+	$(CC) -cpp -DDM_TARGET_CPU_X86=1 idgen
 	idgen
 
 ############################# Intermediate Rules ############################


### PR DESCRIPTION
osx redefines TARGET_CPU_ defines on its own behalf, wrecking any existing definitions.. how horrible
