### PR TITLE
Remove trailing newline escape sequence from error messages.

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -479,7 +479,7 @@ void Dsymbol::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
 unsigned Dsymbol::size(Loc loc)
 {
-    error("Dsymbol '%s' has no size\n", toChars());
+    error("Dsymbol '%s' has no size", toChars());
     return 0;
 }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -6358,7 +6358,7 @@ Expression *CompileExp::semantic(Scope *sc)
         return e1;
     if (!e1->type->isString())
     {
-        error("argument to mixin must be a string type, not %s\n", e1->type->toChars());
+        error("argument to mixin must be a string type, not %s", e1->type->toChars());
         return new ErrorExp();
     }
     e1 = e1->ctfeInterpret();

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3493,7 +3493,7 @@ STATIC code *asm_da_parse(OP *pop)
 
             label = asmstate.sc->func->searchLabel(asmtok->ident);
             if (!label)
-                error(asmstate.loc, "label '%s' not found\n", asmtok->ident->toChars());
+                error(asmstate.loc, "label '%s' not found", asmtok->ident->toChars());
 
             c = code_calloc();
             c->Iop = ASM;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -7013,7 +7013,7 @@ bool isCtfeValueValid(Expression *newval)
     {
         return true;
     }
-    newval->error("CTFE internal error: illegal value %s\n", newval->toChars());
+    newval->error("CTFE internal error: illegal value %s", newval->toChars());
     return false;
 }
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1288,7 +1288,7 @@ unsigned Lexer::escapeSequence()
                     c = v;
                 }
                 else
-                    error("undefined escape hex sequence \\%c\n",c);
+                    error("undefined escape hex sequence \\%c",c);
                 break;
 
         case '&':                       // named character entity
@@ -1337,7 +1337,7 @@ unsigned Lexer::escapeSequence()
                         error("0%03o is larger than a byte", c);
                 }
                 else
-                    error("undefined escape sequence \\%c\n",c);
+                    error("undefined escape sequence \\%c",c);
                 break;
     }
     return c;

--- a/src/mars.c
+++ b/src/mars.c
@@ -555,7 +555,7 @@ int tryMain(int argc, char *argv[])
             else if (strcmp(p + 1, "gs") == 0)
                 global.params.alwaysframe = 1;
             else if (strcmp(p + 1, "gt") == 0)
-            {   error(0, "use -profile instead of -gt\n");
+            {   error(0, "use -profile instead of -gt");
                 global.params.trace = 1;
             }
             else if (strcmp(p + 1, "m32") == 0)
@@ -896,7 +896,7 @@ int tryMain(int argc, char *argv[])
 
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     if (global.params.lib && global.params.dll)
-        error(0, "cannot mix -lib and -shared\n");
+        error(0, "cannot mix -lib and -shared");
 #endif
 
     if (global.params.release)
@@ -1151,7 +1151,7 @@ int tryMain(int argc, char *argv[])
                 }
             }
             else
-            {   error(0, "unrecognized file extension %s\n", ext);
+            {   error(0, "unrecognized file extension %s", ext);
                 fatal();
             }
         }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3523,7 +3523,7 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
 
     if (!n->isMutable())
         if (ident == Id::sort || ident == Id::reverse)
-            error(e->loc, "can only %s a mutable array\n", ident->toChars());
+            error(e->loc, "can only %s a mutable array", ident->toChars());
 
     if (ident == Id::reverse && (n->ty == Tchar || n->ty == Twchar))
     {

--- a/src/root/root.c
+++ b/src/root/root.c
@@ -1275,7 +1275,7 @@ err:
 void File::readv()
 {
     if (read())
-        error("Error reading file '%s'\n",name->toChars());
+        error("Error reading file '%s'",name->toChars());
 }
 
 /**************************************
@@ -1290,13 +1290,13 @@ void File::mmreadv()
 void File::writev()
 {
     if (write())
-        error("Error writing file '%s'\n",name->toChars());
+        error("Error writing file '%s'",name->toChars());
 }
 
 void File::appendv()
 {
     if (write())
-        error("Error appending to file '%s'\n",name->toChars());
+        error("Error appending to file '%s'",name->toChars());
 }
 
 /*******************************************

--- a/src/template.c
+++ b/src/template.c
@@ -4818,7 +4818,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     Scope *scope = tempdecl->scope;
     if (!tempdecl->semanticRun)
     {
-        error("template instantiation %s forward references template declaration %s\n", toChars(), tempdecl->toChars());
+        error("template instantiation %s forward references template declaration %s", toChars(), tempdecl->toChars());
         return;
     }
 
@@ -5304,7 +5304,7 @@ TemplateDeclaration *TemplateInstance::findBestMatch(Scope *sc, Expressions *far
             }
             if (!td->semanticRun)
             {
-                error("%s forward references template declaration %s\n", toChars(), td->toChars());
+                error("%s forward references template declaration %s", toChars(), td->toChars());
                 return NULL;
             }
         }

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -813,9 +813,10 @@ void ClassDeclaration::toObjFile(int multiobj)
                         {
                             TypeFunction *tf = (TypeFunction *)fd->type;
                             if (tf->ty == Tfunction)
-                                error("use of %s%s hidden by %s is deprecated\n", fd->toPrettyChars(), Parameter::argsTypesToChars(tf->parameters, tf->varargs), toChars());
+                                error("use of %s%s hidden by %s is deprecated", fd->toPrettyChars(),
+                                      Parameter::argsTypesToChars(tf->parameters, tf->varargs), toChars());
                             else
-                                error("use of %s hidden by %s is deprecated\n", fd->toPrettyChars(), toChars());
+                                error("use of %s hidden by %s is deprecated", fd->toPrettyChars(), toChars());
                         }
                         s = rtlsym[RTLSYM_DHIDDENFUNC];
                         break;


### PR DESCRIPTION
No need to have them as verror() in mars.c already adds a newline at the end of the error message.
