### PR TITLE
Ignore trace.def and trace.log.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ src/dmd.exe
 src/impcnvgen.exe
 *.map
 .DS_Store
+trace.def
+trace.log


### PR DESCRIPTION
It's annoying when these show up in `git status` due to tests.
