### PR TITLE
Implement pragma(mangle, "...") to override the mangled symbol of a variable/function declaration.

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1,4 +1,3 @@
-
 // Compiler implementation of the D programming language
 // Copyright (c) 1999-2012 by Digital Mars
 // All Rights Reserved
@@ -1154,8 +1153,8 @@ void PragmaDeclaration::semantic(Scope *sc)
             {
                 char c = ((char *)se->string)[i];
 
-                if (c < 0x20 || c > 0x7E)
-                    error("mangled names may only contain printable ASCII characters, not '0x%x'", c);
+                if (c <= 0x20)
+                    error("mangled names may not contain ASCII characters below 0x20");
             }
         }
     }

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -81,6 +81,7 @@ Declaration::Declaration(Identifier *id)
     linkage = LINKdefault;
     inuse = 0;
     sem = SemanticStart;
+    symbol_override = NULL;
 }
 
 void Declaration::semantic(Scope *sc)

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -124,6 +124,7 @@ struct Declaration : Dsymbol
     enum PROT protection;
     enum LINK linkage;
     int inuse;                  // used to detect cycles
+    char *symbol_override;      // overridden symbol with pragma(mangle, "...")
 
 #ifdef IN_GCC
     Expressions *attributes;    // GCC decl/type attributes
@@ -312,6 +313,7 @@ struct VarDeclaration : Declaration
     Symbol *toSymbol();
     void toObjFile(int multiobj);                       // compile to .obj file
     int cvMember(unsigned char *p);
+    char *mangle();
 
     // Eliminate need for dynamic_cast
     VarDeclaration *isVarDeclaration() { return (VarDeclaration *)this; }

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -265,6 +265,7 @@ Msgtable msgtable[] =
     { "lib" },
     { "msg" },
     { "startaddress" },
+    { "mangle" },
 
     // For special functions
     { "tohash", "toHash" },

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -154,6 +154,9 @@ char *FuncDeclaration::mangle()
     __body
 #endif
     {
+        if (symbol_override)
+            return symbol_override;
+
         if (isMain())
             return (char *)"_Dmain";
 
@@ -161,6 +164,21 @@ char *FuncDeclaration::mangle()
             return ident->toChars();
 
         assert(this);
+        return Declaration::mangle();
+    }
+
+char *VarDeclaration::mangle()
+#if __DMC__
+    __out(result)
+    {
+        assert(strlen(result) > 0);
+    }
+    __body
+#endif
+    {
+        if (symbol_override)
+            return symbol_override;
+
         return Declaration::mangle();
     }
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -1102,46 +1102,20 @@ bool WhileStatement::hasContinue()
 
 bool WhileStatement::usesEH()
 {
-    assert(0);
-    return body ? body->usesEH() : 0;
+    assert(global.errors);
+    return 0;
 }
 
 int WhileStatement::blockExit(bool mustNotThrow)
 {
-    assert(0);
-    //printf("WhileStatement::blockExit(%p)\n", this);
-
-    int result = BEnone;
-    if (condition->canThrow(mustNotThrow))
-        result |= BEthrow;
-    if (condition->isBool(TRUE))
-    {
-        if (body)
-        {   result |= body->blockExit(mustNotThrow);
-            if (result & BEbreak)
-                result |= BEfallthru;
-        }
-    }
-    else if (condition->isBool(FALSE))
-    {
-        result |= BEfallthru;
-    }
-    else
-    {
-        if (body)
-            result |= body->blockExit(mustNotThrow);
-        result |= BEfallthru;
-    }
-    result &= ~(BEbreak | BEcontinue);
-    return result;
+    assert(global.errors);
+    return BEfallthru;
 }
 
 
 int WhileStatement::comeFrom()
 {
-    assert(0);
-    if (body)
-        return body->comeFrom();
+    assert(global.errors);
     return FALSE;
 }
 
@@ -2651,33 +2625,20 @@ bool ForeachRangeStatement::hasContinue()
 
 bool ForeachRangeStatement::usesEH()
 {
-    assert(0);
+    assert(global.errors);
     return body->usesEH();
 }
 
 int ForeachRangeStatement::blockExit(bool mustNotThrow)
 {
-    assert(0);
-    int result = BEfallthru;
-
-    if (lwr && lwr->canThrow(mustNotThrow))
-        result |= BEthrow;
-    else if (upr && upr->canThrow(mustNotThrow))
-        result |= BEthrow;
-
-    if (body)
-    {
-        result |= body->blockExit(mustNotThrow) & ~(BEbreak | BEcontinue);
-    }
-    return result;
+    assert(global.errors);
+    return BEfallthru;
 }
 
 
 int ForeachRangeStatement::comeFrom()
 {
-    assert(0);
-    if (body)
-        return body->comeFrom();
+    assert(global.errors);
     return FALSE;
 }
 

--- a/test/compilable/mangle.d
+++ b/test/compilable/mangle.d
@@ -1,0 +1,28 @@
+// PERMUTE_ARGS:
+
+pragma(mangle, "_test1_") int test1;
+
+static assert(test1.mangleof == "_test1_");
+
+__gshared pragma(mangle, "_test2_") ubyte test2;
+
+static assert(test2.mangleof == "_test2_");
+
+pragma(mangle, "_test3_") void test3()
+{
+}
+
+static assert(test3.mangleof == "_test3_");
+
+pragma(mangle, "_test6_") __gshared char test6;
+
+static assert(test6.mangleof == "_test6_");
+
+pragma(mangle, "_test7_") @system
+{
+    void test7()
+    {
+    }
+}
+
+static assert(test7.mangleof == "_test7_");

--- a/test/fail_compilation/ice9254a.d
+++ b/test/fail_compilation/ice9254a.d
@@ -1,0 +1,12 @@
+
+void main()
+{
+    foreach (divisor; !(2, 3, 4, 8, 7, 9))
+    {
+        // ice in ForeachRangeStatement::blockExit()
+        foreach (v; 0..uint.max) {}
+
+        // ice in WhileStatement::blockExit()
+        while (1) {}
+    }
+}

--- a/test/fail_compilation/ice9254b.d
+++ b/test/fail_compilation/ice9254b.d
@@ -1,0 +1,15 @@
+
+class C
+{
+    synchronized void foo()
+    {
+        foreach(divisor; !(2, 3, 4, 8, 7, 9))
+        {
+            // ice in ForeachRangeStatement::usesEH()
+            foreach (v; 0..uint.max) {}
+
+            // ice in WhileStatement::usesEH()
+            while (1) {}
+        }
+    }
+}

--- a/test/fail_compilation/ice9254c.d
+++ b/test/fail_compilation/ice9254c.d
@@ -1,0 +1,14 @@
+
+void main()
+{
+    foreach(divisor; !(2, 3, 4, 8, 7, 9))
+    {
+        assert(0);
+
+        // ice in ForeachRangeStatement::comeFrom()
+        foreach (v; 0..uint.max) {}
+
+        // ice in WhileStatement::comeFrom()
+        while (1) {}
+    }
+}

--- a/test/fail_compilation/mangle1.d
+++ b/test/fail_compilation/mangle1.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/mangle1.d(9): Error: pragma mangle can only apply to a single declaration
+---
+*/
+
+pragma(mangle, "_stuff_") __gshared { int x, y; }


### PR DESCRIPTION
See the test for what this allows the programmer to do.

I deliberately decided not to care about cases like this one:

```
pragma(symbol, "foo") __gshared int bar, baz;
```

In all likelihood, it will not do what the user expects in the general case, but I wasn't sure if there might be some obscure use case with weak symbols or something like that, so I left the possibility there.
