### PR TITLE
fix for #4082

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1302,11 +1302,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (f->isnothrow && (global.errors != nothrowErrors) )
                     error("'%s' is nothrow yet may throw", toChars());
                 if (flags & FUNCFLAGnothrowInprocess)
-                {
-                    flags &= ~FUNCFLAGnothrowInprocess;
-                    if (!(blockexit & BEthrow))
-                        f->isnothrow = TRUE;
-                }
+                    f->isnothrow = !(blockexit & BEthrow);
 
                 int offend = blockexit & BEfallthru;
 #endif
@@ -1574,6 +1570,13 @@ void FuncDeclaration::semantic3(Scope *sc)
                     if (e)
                     {   Statement *s = new ExpStatement(0, e);
                         s = s->semantic(sc2);
+                        int nothrowErrors = global.errors;
+                        bool isnothrow = f->isnothrow & !(flags & FUNCFLAGnothrowInprocess);
+                        int blockexit = s->blockExit(isnothrow);
+                        if (f->isnothrow && (global.errors != nothrowErrors) )
+                            error("'%s' is nothrow yet may throw", toChars());
+                        if (flags & FUNCFLAGnothrowInprocess && blockexit & BEthrow)
+                            f->isnothrow = FALSE;
                         if (fbody->blockExit(f->isnothrow) == BEfallthru)
                             fbody = new CompoundStatement(0, fbody, s);
                         else
@@ -1581,6 +1584,8 @@ void FuncDeclaration::semantic3(Scope *sc)
                     }
                 }
             }
+            // from this point on all possible 'throwers' are checked
+            flags &= ~FUNCFLAGnothrowInprocess;
 #endif
 
 #if 1

--- a/src/statement.c
+++ b/src/statement.c
@@ -4813,9 +4813,18 @@ int TryFinallyStatement::usesEH()
 
 int TryFinallyStatement::blockExit(bool mustNotThrow)
 {
+    int result = BEfallthru;
     if (body)
-        return body->blockExit(mustNotThrow);
-    return BEfallthru;
+        result = body->blockExit(mustNotThrow);
+    // check finally body as well, it may throw (bug #4082)
+    if (finalbody)
+    {
+        int finalresult = finalbody->blockExit(mustNotThrow);
+        if (!(finalresult & BEfallthru))
+            result &= ~BEfallthru;
+        result |= finalresult & ~BEfallthru;
+    }
+    return result;
 }
 
 

--- a/test/fail_compilation/fail4082a.d
+++ b/test/fail_compilation/fail4082a.d
@@ -1,0 +1,8 @@
+struct Foo {
+    ~this() { throw new Exception(""); }
+}
+nothrow void main() {
+    Foo f;
+    goto NEXT;
+    NEXT:;
+}

--- a/test/fail_compilation/fail4082b.d
+++ b/test/fail_compilation/fail4082b.d
@@ -1,0 +1,4 @@
+struct Foo {
+    ~this() { throw new Exception(""); }
+}
+nothrow void b(Foo t) {}


### PR DESCRIPTION
Bug: http://d.puremagic.com/issues/show_bug.cgi?id=4082

The finally block of a try-finally wasn't checked in blockExit(). This may have had other symptoms as well, but it is difficult to search bugzilla in that fashion. In this case it didn't bubble up that the destructor of a struct throws, when the surrounding function was labeled nothrow.
The other fix concerns the automatically inserted try-finally for by-value parameters that have a destructor that has to be called before function exit. A quick check on the destructor call now determines if any destructor invalidates nothrow. It is a copy and paste from the original nothrow-check a few pages further up.
