### PR TITLE
Add feature for testing diagnostic bugs

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -220,7 +220,7 @@ void execute(ref File f, string command, bool expectpass)
     f.writeln(command);
     auto rc = system(command ~ " > " ~ filename ~ " 2>&1");
 
-    f.write(readText(filename));
+    f.rawWrite(readText(filename));
 
     if (WIFSIGNALED(rc))
     {

--- a/test/fail_compilation/diag8354.d
+++ b/test/fail_compilation/diag8354.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag8354.d(3): Error: must import std.math to use ^^ operator
+fail_compilation/diag8354.d(5): Error: must import std.math to use ^^ operator
+---
+*/
+
+#line 1
+void main() {
+    int x1 = 10;
+    auto y1 = x1 ^^ 5;
+    double x2 = 10.5;
+    auto y2 = x2 ^^ 5;
+}


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=8354">Issue 8354</a> - Some missing "import std.math to use ^^ operator" error messages
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=8559">Issue 8559</a> - void and function type prints redundant error message with init property

In fail_compilation tests, now can use ERROR_MSG parameter for testing error messages.
