### PR TITLE
Fix issue 7876 [CTFE] assertion failure on invalid stack reference

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -89,6 +89,12 @@ public:
         popAll(framepointer);
         framepointer = oldframe;
     }
+    bool isInCurrentFrame(VarDeclaration *v)
+    {
+        if (v->isDataseg() && !v->isCTFE())
+            return false;   // It's a global
+        return v->ctfeAdrOnStack >= framepointer;
+    }
     Expression *getValue(VarDeclaration *v)
     {
         if (v->isDataseg() && !v->isCTFE())
@@ -1034,6 +1040,66 @@ Expression *ctfeCat(Type *type, Expression *e1, Expression *e2)
     return Cat(type, e1, e2);
 }
 
+/**
+  Given an expression e which is about to be returned from the current
+  function, generate an error if it contains pointers to local variables.
+  Return true if it is safe to return, false if an error was generated.
+
+  Only checks expressions passed by value (pointers to local variables
+  may already be stored in members of classes, arrays, or AAs which
+  were passed as mutable function parameters).
+*/
+bool stopPointersEscapingFromArray(Loc loc, Expressions *elems);
+
+bool stopPointersEscaping(Loc loc, Expression *e)
+{
+    if (!e->type->hasPointers())
+        return true;
+    if ( isPointer(e->type) )
+    {
+        if (e->op == TOKvar && ((VarExp *)e)->var->isVarDeclaration() &&
+            ctfeStack.isInCurrentFrame( ((VarExp *)e)->var->isVarDeclaration() ) )
+        {   error(loc, "returning a pointer to a local stack variable");
+            return false;
+        }
+        // TODO: If it is a TOKdotvar or TOKindex, we should check that it is not
+        // pointing to a local struct or static array.
+    }
+    if (e->op == TOKstructliteral)
+    {
+        StructLiteralExp *se = (StructLiteralExp *)e;
+        return stopPointersEscapingFromArray(loc, se->elements);
+    }
+    if (e->op == TOKarrayliteral)
+    {
+        return stopPointersEscapingFromArray(loc, ((ArrayLiteralExp *)e)->elements);
+    }
+    if (e->op == TOKassocarrayliteral)
+    {
+        AssocArrayLiteralExp *aae = (AssocArrayLiteralExp *)e;
+        if (!stopPointersEscapingFromArray(loc, aae->keys))
+            return false;
+        return stopPointersEscapingFromArray(loc, aae->values);
+    }
+    return true;
+}
+
+// Check all members of an array for escaping local variables. Return false if error
+bool stopPointersEscapingFromArray(Loc loc, Expressions *elems)
+{
+    for (size_t i = 0; i < elems->dim; i++)
+    {
+        Expression *m = elems->tdata()[i];
+        if (!m)
+            continue;
+        if (m)
+            if ( !stopPointersEscaping(loc, m) )
+                return false;
+    }
+    return true;
+}
+
+
 bool scrubArray(Loc loc, Expressions *elems, bool structlit = false);
 
 /* All results destined for use outside of CTFE need to have their CTFE-specific
@@ -1141,11 +1207,24 @@ Expression *ReturnStatement::interpret(InterState *istate)
     // return a value OR a pointer
     Expression *e;
     if ( isPointer(exp->type) )
-        e = exp->interpret(istate, ctfeNeedLvalue);
+    {   e = exp->interpret(istate, ctfeNeedLvalue);
+        if (exceptionOrCantInterpret(e))
+            return e;
+        // Disallow returning pointers to stack-allocated variables (bug 7876)
+        if (e->op == TOKvar && ((VarExp *)e)->var->isVarDeclaration() &&
+            ctfeStack.isInCurrentFrame( ((VarExp *)e)->var->isVarDeclaration() ) )
+        {   error("returning a pointer to a local stack variable");
+            return EXP_CANT_INTERPRET;
+        }
+    }
     else
+    {
         e = exp->interpret(istate);
-    if (exceptionOrCantInterpret(e))
-        return e;
+        if (exceptionOrCantInterpret(e))
+            return e;
+        if (!stopPointersEscaping(loc, e))
+            return EXP_CANT_INTERPRET;
+    }
     if (needToCopyLiteral(e))
         e = copyLiteral(e);
 #if LOGASSIGN

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3256,6 +3256,43 @@ void bug6851()
 static assert({ bug6851(); return true; }());
 
 /**************************************************
+    7876
+**************************************************/
+int* bug7876(int n){
+    int x;auto ptr = &x;
+    if (n==2) ptr = null;
+    return ptr;
+}
+
+struct S7876
+{
+    int *p;
+}
+
+S7876 bug7876b(int n) {
+    int x;
+    S7876 s;
+    s.p = &x;
+    if (n==11) s.p = null;
+    return s;
+}
+
+int test7876(int n)
+{
+    if (n >= 10) {
+        S7876 m = bug7876b(n);
+        return 1;
+    }
+    int *p = bug7876(n);
+    return 1;
+}
+
+static assert( is(typeof(compiles!(test7876(2)))));
+static assert(!is(typeof(compiles!(test7876(0)))));
+static assert( is(typeof(compiles!(test7876(11)))));
+static assert(!is(typeof(compiles!(test7876(10)))));
+
+/**************************************************
     6817 if converted to &&, only with -inline
 **************************************************/
 static assert({


### PR DESCRIPTION
Generate an error when returning a pointer to a local variable.
Includes the case where the pointer is a member of an array or struct.
(Does not yet check for escaping pointers to local structs or static arrays, but those don't cause an ICE).
