### PR TITLE
Fixed imports for moved std.string functions.

### DIFF
--- a/test/runnable/extra-files/test2.d
+++ b/test/runnable/extra-files/test2.d
@@ -1,18 +1,18 @@
 
 import object;
 import std.c.stdio;
-import std.string;
+import std.algorithm;
 
 /* ================================ */
 
 class Foo
 {
-	int foo(int x) { return x + 3; }
+    int foo(int x) { return x + 3; }
 }
 
 class Bar : Foo
 {
-	override int foo(int y) { return y + 4; }
+    override int foo(int y) { return y + 4; }
 }
 
 void test1()
@@ -30,7 +30,7 @@ class Foo2
 {
     int foo(int x)
     {
-	return x + 3;
+    return x + 3;
     }
 }
 
@@ -38,8 +38,8 @@ class Bar2 : Foo2
 {
     override int foo(int y)
     {
-	assert(Foo2.foo(2) == 5);
-	return y + 4;
+    assert(Foo2.foo(2) == 5);
+    return y + 4;
     }
 }
 
@@ -65,13 +65,13 @@ void test3()
     debug(10) assert(0);
 
     debug(1)
-    {	int d1 = 3;
+    {   int d1 = 3;
 
-	printf("debug(1) { }\n");
+    printf("debug(1) { }\n");
     }
     debug(2)
     {
-	printf("debug(2): d1 = %d\n", d1);
+    printf("debug(2): d1 = %d\n", d1);
     }
 }
 
@@ -107,11 +107,11 @@ void test5()
 
     version (D_Bits)
     {
-	bit[] bits;
+    bit[] bits;
 
-	bits = (cast(bit *)&foo)[0..len];
-	bits[6] = true;
-	assert(foo == (1 << 6));
+    bits = (cast(bit *)&foo)[0..len];
+    bits[6] = true;
+    assert(foo == (1 << 6));
     }
 }
 
@@ -119,8 +119,8 @@ void test5()
 
 int[] test6_1(int[] a)
 {
-	a.length = 6;
-	return a;
+    a.length = 6;
+    return a;
 }
 
 void test6()
@@ -147,7 +147,7 @@ class OutBuffer7
 
     void write(const(char) *p, uint nbytes)
     {
-	data[offset .. offset + nbytes] = (cast(char *)p)[0 .. nbytes];
+    data[offset .. offset + nbytes] = (cast(char *)p)[0 .. nbytes];
     }
 }
 
@@ -162,22 +162,22 @@ void test7()
     printf("ob.data.length = %d\n", ob.data.length);
     assert(ob.data.length == 10);
     for (i = 0; i < 10; i++)
-	assert(ob.data[i] == char.init);
+    assert(ob.data[i] == char.init);
 
 printf("test7.1()\n");
     ob.data[] = '-';
 printf("test7.2()\n");
     printf("ob.data[] = '%.*s'\n", cast(int)ob.data.length, ob.data.ptr);
     for (i = 0; i < 10; i++)
-	assert(ob.data[i] == '-');
+    assert(ob.data[i] == '-');
 
     ob.offset = 3;
     ob.write("foo", 3);
     printf("ob.data.length = %d\n", ob.data.length);
     printf("ob.data[] = '%.*s'\n", cast(int)ob.data.length, ob.data.ptr);
     for (i = 0; i < 10; i++)
-    {	if (i < 3 || i >= 6)
-	    assert(ob.data[i] == '-');
+    {   if (i < 3 || i >= 6)
+        assert(ob.data[i] == '-');
     }
     assert(ob.data[3] == 'f');
     assert(ob.data[4] == 'o');
@@ -267,9 +267,9 @@ char[] tolower13(ref char[] s)
 
     for (i = 0; i < s.length; i++)
     {
-	char c = s[i];
-	if ('A' <= c && c <= 'Z')
-	    s[i] = cast(char)(c + (cast(char)'a' - 'A'));
+    char c = s[i];
+    if ('A' <= c && c <= 'Z')
+        s[i] = cast(char)(c + (cast(char)'a' - 'A'));
     }
     return s;
 }
@@ -280,7 +280,7 @@ void test13()
     char[] s2;
 
     s2 = tolower13(s1);
-    assert(std.string.cmp(s2, "fol") == 0);
+    assert(std.algorithm.cmp(s2, "fol") == 0);
     assert(s2 == s1);
 }
 
@@ -305,7 +305,7 @@ class bits15
     bool a = true, b = true, c = true;
     void dump()
     {
-	printf("%d %d %d\n", a, b, c);
+    printf("%d %d %d\n", a, b, c);
     }
 }
 

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -148,20 +148,20 @@ void test3()
 int[] fun(int i)
     in
     {
-	assert(i > 0);
+    assert(i > 0);
     }
     out (result)
     {
-	assert(result[0] == 2);
+    assert(result[0] == 2);
     }
     body
     {
-	char result;
-	int[] res = new int[10];
-	res[] = i;
-	int isZero = (result == 0xFF);
-	assert(isZero);
-	return res;
+    char result;
+    int[] res = new int[10];
+    res[] = i;
+    int isZero = (result == 0xFF);
+    assert(isZero);
+    return res;
     }
 
 void test4()
@@ -234,8 +234,8 @@ void test9()
     struct B { }
     B bar (ref int p)
     {
-	B b;
-	return b;
+    B b;
+    return b;
     }
 }
 
@@ -280,17 +280,17 @@ void test11()
 
 struct Array12
 {
-	char len;
-	void* p;
+    char len;
+    void* p;
 }
 Array12 f12(string a)
 {
-	return *cast(Array12*) &a[0..23]; //Internal error: ..\ztc\cgcs.c 350
+    return *cast(Array12*) &a[0..23]; //Internal error: ..\ztc\cgcs.c 350
 }
 
 Array12 g12(string a)
 {
-	return *cast(Array12*) &a; //works
+    return *cast(Array12*) &a; //works
 }
 
 void test12()
@@ -316,12 +316,12 @@ class A13
 
 void test13()
 {
-	A13 a = new A13();
-	int i;
-	i = a.opShl(cast(string)"");
-	assert(i == 2);
-	i = a << cast(string)"";
-	assert(i == 2);
+    A13 a = new A13();
+    int i;
+    i = a.opShl(cast(string)"");
+    assert(i == 2);
+    i = a << cast(string)"";
+    assert(i == 2);
 }
 
 /**************************************/
@@ -505,14 +505,14 @@ void test22()
 /**************************************/
 
 interface A23 { void x(); }
-class B23 : A23 { void x() { } }            
+class B23 : A23 { void x() { } }
 class C23 : B23 { uint y = 12345678; }
 
 void stest23(A23 a)
 {
     synchronized (a)
     {
-    }      
+    }
 }
 
 void test23()
@@ -557,7 +557,7 @@ char rot13(char ret)
 void test25()
 {
     foreach (char c; "hello World\n")
-	printf("%c %c\n", c, rot13(c));
+    printf("%c %c\n", c, rot13(c));
     assert(rot13('h') == 'u');
     assert(rot13('o') == 'b');
     assert(rot13('W') == 'J');
@@ -610,7 +610,7 @@ void test28()
 class Foo28 : Throwable
 {
   private:
-	this() { super(""); }
+    this() { super(""); }
 }
 
 /**************************************/
@@ -676,7 +676,7 @@ class Qwert32
 {
     struct
     {
-	int yuiop = 13;
+    int yuiop = 13;
     }
     int asdfg = 42;
 
@@ -736,13 +736,13 @@ void test34()
 
 private static extern (C)
 {
-	shared char* function () uloc_getDefault;
+    shared char* function () uloc_getDefault;
 }
 
 
 static shared void**[] targets =
     [
-	cast(shared(void*)*) &uloc_getDefault,
+    cast(shared(void*)*) &uloc_getDefault,
     ];
 
 void test35()
@@ -800,7 +800,7 @@ struct MyStruct
 {
     StructAlias* MyStruct()
     {
-	return null;
+    return null;
     }
 }
 
@@ -816,10 +816,10 @@ class Foo38
 {
     static void display_name()
     {
-	printf("%.*s\n", Object.classinfo.name.length, Object.classinfo.name.ptr);
-	assert(Object.classinfo.name == "object.Object");
-	assert(super.classinfo.name == "object.Object");
-	assert(this.classinfo.name == "test12.Foo38");
+    printf("%.*s\n", Object.classinfo.name.length, Object.classinfo.name.ptr);
+    assert(Object.classinfo.name == "object.Object");
+    assert(super.classinfo.name == "object.Object");
+    assert(this.classinfo.name == "test12.Foo38");
     }
 }
 
@@ -855,7 +855,7 @@ class C40
 
     static int foo()
     {
-	return this.x;
+    return this.x;
     }
 }
 
@@ -925,12 +925,12 @@ struct PropTable
 
     Value* get(Value* key)
     {
-	Property *p;
+    Property *p;
 
-	p = *key in table;
-	p = &table[*key];
-	table.remove(*key);
-	return null;
+    p = *key in table;
+    p = &table[*key];
+    table.remove(*key);
+    return null;
     }
 
 }
@@ -942,7 +942,7 @@ void test44()
 
 /**************************************/
 
-import std.string;
+import std.algorithm;
 
 struct Shell
 {
@@ -950,7 +950,7 @@ struct Shell
 
     const int opCmp(ref const Shell s)
     {
-	return std.string.cmp(this.str, s.str);
+    return std.algorithm.cmp(this.str, s.str);
     }
 }
 
@@ -966,7 +966,7 @@ void test45()
 
     foreach (Shell s; a)
     {
-	printf("%.*s\n", s.str.length, s.str.ptr);
+    printf("%.*s\n", s.str.length, s.str.ptr);
     }
 
     assert(a[0].str == "betty");
@@ -981,7 +981,7 @@ class A46
     char foo() { return 'a'; }
 }
 
-class B46 : A46 
+class B46 : A46
 {
 }
 
@@ -990,7 +990,7 @@ class C46 : B46
     override char foo() { return 'c'; }
     char bar()
     {
-	return B46.foo();
+    return B46.foo();
     }
 }
 
@@ -1034,7 +1034,7 @@ void test48()
     foo48[] arr;
     foreach(foo48 a; arr)
     {
-	bar48();
+    bar48();
     }
 }
 
@@ -1051,13 +1051,13 @@ void test49()
 
 void test50()
 {
-	S50!() s;
-	assert(s.i == int.sizeof);
+    S50!() s;
+    assert(s.i == int.sizeof);
 }
 
 struct S50()
 {
-	int i=f50(0).sizeof;
+    int i=f50(0).sizeof;
 }
 
 int f50(...);
@@ -1066,21 +1066,21 @@ int f50(...);
 
 enum Enum51
 {
-	A,
-	B,
-	C
+    A,
+    B,
+    C
 }
 
 struct Struct51
 {
-	Enum51 e;
+    Enum51 e;
 }
 
 void test51()
 {
-	Struct51 s;
-	assert(s.e == Enum51.A);
-	assert(s.e == 0);
+    Struct51 s;
+    assert(s.e == Enum51.A);
+    assert(s.e == 0);
 }
 
 /**************************************/
@@ -1198,32 +1198,32 @@ void test57()
 
 void test58()
 {
-	int label=1;
-	if (0)
-	{
+    int label=1;
+    if (0)
+    {
 label:
-	    int label2=2;
-	    assert(label2==2);		
-	}
-	else
-	{
-	    assert(label==1);
-	    goto label;
-	}
-	assert(label==1);
+        int label2=2;
+        assert(label2==2);
+    }
+    else
+    {
+        assert(label==1);
+        goto label;
+    }
+    assert(label==1);
 }
 
 /**************************************/
 
 void test59()
 {
-	if(0){
+    if(0){
 label:
-		return;
-	}else{
-		goto label;
-	}
-	assert(0);
+        return;
+    }else{
+        goto label;
+    }
+    assert(0);
 }
 
 /**************************************/

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -1,5 +1,6 @@
 // REQUIRED_ARGS:
 
+import std.array;
 import core.stdc.math : cos, fabs, sin, sqrt, rint;
 import core.vararg;
 import std.math: rndtol;
@@ -47,7 +48,7 @@ void test7()
     assert(s == "hello\"there'you");
     ubyte[] b = cast(ubyte[])x"8B 7D f4 0d";
     for (int i = 0; i < b.length; i++)
-	printf("b[%d] = x%02x\n", i, b[i]);
+    printf("b[%d] = x%02x\n", i, b[i]);
     assert(b.length == 4);
     assert(b[0] == 0x8B);
     assert(b[1] == 0x7D);
@@ -96,8 +97,8 @@ struct Pair
    {
        Pair result;
 
-	result.a = a + other.a;
-	result.b = b + other.b;
+    result.a = a + other.a;
+    result.b = b + other.b;
        return result;
    }
 }
@@ -199,8 +200,8 @@ class A15
 {
     void foo()
     {
-	List1.rehash;
-	List2.rehash;
+    List1.rehash;
+    List2.rehash;
     }
   private:
     int delegate(in int arg1) List1[char[]];
@@ -219,7 +220,7 @@ void test16()
     char[] a=new char[0];
     uint c = 200000;
     while (c--)
-	a ~= 'x';
+    a ~= 'x';
     //printf("a = '%.*s'\n", a.length, a.ptr);
 }
 
@@ -281,7 +282,7 @@ void test21()
     auto f = new File("runnable/extra-files/test15.txt");
 
     while(!f.eof())
-	esdom[cast(string)f.readLine()] = 0;
+    esdom[cast(string)f.readLine()] = 0;
     f.close();
     esdom.rehash;
 }
@@ -346,7 +347,7 @@ abstract class bar25 {
 class subbar25 : bar25 {
 
   this() {}
-  
+
 }
 
 void test25()
@@ -359,16 +360,16 @@ void test25()
 
 void test26()
 {
-    string[] instructions = std.string.split("a;b;c", ";");
+    string[] instructions = std.array.split("a;b;c", ";");
 
     foreach(ref string instr; instructions)
     {
-	std.string.strip(instr);
+    std.string.strip(instr);
     }
 
     foreach(string instr; instructions)
     {
-	printf("%.*s\n", instr.length, instr.ptr);
+    printf("%.*s\n", instr.length, instr.ptr);
     }
 }
 
@@ -385,8 +386,8 @@ class B27 : A27
 {
     static this()
     {
-	foo27(B27.classinfo);
-	foo27(A27.classinfo);
+    foo27(B27.classinfo);
+    foo27(A27.classinfo);
     }
 }
 
@@ -404,12 +405,12 @@ void foo28(ClassInfo ci)
     static int i;
     switch (i++)
     {
-	case 0:
-	case 2:	assert(ci.name == "test15.A28");
-		break;
-	case 1:	assert(ci.name == "test15.B28");
-		break;
-	default: assert(0);
+    case 0:
+    case 2: assert(ci.name == "test15.A28");
+        break;
+    case 1: assert(ci.name == "test15.B28");
+        break;
+    default: assert(0);
     }
 }
 
@@ -423,11 +424,11 @@ class A28
 class B28 : A28
 {
     static this() {
-	foo28(B28.classinfo );
-	(new B28()).bodge_it();
+    foo28(B28.classinfo );
+    (new B28()).bodge_it();
     }
     void bodge_it() {
-	foo28(A28.classinfo );
+    foo28(A28.classinfo );
     }
 }
 
@@ -518,13 +519,13 @@ class foo32
 {
     static void getMemberBar()
     {
-	//foo32 f = new foo32(); new A32( &(f.bar) );
-	new A32( &((new foo32()).bar) );
+    //foo32 f = new foo32(); new A32( &(f.bar) );
+    new A32( &((new foo32()).bar) );
     }
 
     int bar()
     {
-	return 0;
+    return 0;
     }
 }
 
@@ -557,14 +558,14 @@ void test34()
 {
     version (D_Bits)
     {
-	bool[8] a8;
-	assert(a8.sizeof == 4);
-	bool[16] a16;
-	assert(a16.sizeof == 4);
-	bool[32] a32;
-	assert(a32.sizeof == 4);
-	bool[256] a256;
-	assert(a256.sizeof == 32);
+    bool[8] a8;
+    assert(a8.sizeof == 4);
+    bool[16] a16;
+    assert(a16.sizeof == 4);
+    bool[32] a32;
+    assert(a32.sizeof == 4);
+    bool[256] a256;
+    assert(a256.sizeof == 32);
     }
 }
 
@@ -591,7 +592,7 @@ void test36x()
 {
     version (Win32)
     {
-//	stdin.getch();
+//  stdin.getch();
     }
 }
 
@@ -607,19 +608,19 @@ struct T37
     char x;
 
     T37 create()
-    {	T37 t;
-	t.x = 3;
-	return t;
+    {   T37 t;
+    t.x = 3;
+    return t;
     }
 
     bool test1()
     {
-	return create() == this;
+    return create() == this;
     }
 
     bool test2()
     {
-	return this == create();
+    return this == create();
     }
 }
 
@@ -707,11 +708,11 @@ class Bar41 : Foo41
 {
     void test()
     {
-	void printFoo41()
-	{
-	    super.print();      // DMD crashes here
-	}
-	printFoo41();
+    void printFoo41()
+    {
+        super.print();      // DMD crashes here
+    }
+    printFoo41();
     }
 }
 
@@ -841,7 +842,7 @@ class Bug47
 
     static void bar()
     {
-	foo(1);
+    foo(1);
     }
 }
 
@@ -935,12 +936,12 @@ deprecated class Qwert
 
     int twiceYuiop()
     {
-	return 2 * yuiop;
+    return 2 * yuiop;
     }
 
     invariant()
     {
-	assert (yuiop < 100);
+    assert (yuiop < 100);
     }
 }
 
@@ -1067,8 +1068,8 @@ void test58()
 {   int y, x;
 
     with ( new A58 )
-    {	y = foo58(0,1);
-	x = foo58();
+    {   y = foo58(0,1);
+    x = foo58();
     }
     assert(y == 2);
     assert(x == 3);
@@ -1081,8 +1082,8 @@ void test59()
 {
     struct data
     {
-	int b1=-1;
-	int b2=2;
+    int b1=-1;
+    int b2=2;
     }
 
     data d;
@@ -1230,7 +1231,7 @@ class FuBar
         void foo ()
         {
                 printf ("should never get here\n");
-		assert(0);
+        assert(0);
         }
 
         const(void)[] get ()
@@ -1290,11 +1291,11 @@ void test68()
 
 class ConduitStyle
 {
-        
-//	static ConduitStyle     Read;
-//	static ConduitStyle     ReadWrite;
 
-	static ConduitStyle     Read, ReadWrite;
+//  static ConduitStyle     Read;
+//  static ConduitStyle     ReadWrite;
+
+    static ConduitStyle     Read, ReadWrite;
 }
 
 void test69()


### PR DESCRIPTION
std.string.cmp was moved to std.algorithm some time ago, and
std.string.split was moved to std.array some time ago. Temporary public
imports for them were put in std.string to ease the transition, but it's
time to remove them now, and some places in dmd's unit tests still used
them as if they were in std.string. This fixes that.

The diff is as long as it is only because the files were detabbed as well. Too bad github's diffs can't be made to ignore whitespace like git-diff can.
