### PR TITLE
Fix issue 8422 TypeTuple of tuples can't be read at compile time

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1660,7 +1660,8 @@ Statement *ForeachStatement::semantic(Scope *sc)
                     VarDeclaration *v = new VarDeclaration(loc, arg->type, arg->ident, ie);
                     if (arg->storageClass & STCref)
                         v->storage_class |= STCref | STCforeach;
-                    if (e->isConst() || e->op == TOKstring)
+                    if (e->isConst() || e->op == TOKstring ||
+                        e->op == TOKstructliteral || e->op == TOKarrayliteral)
                     {   if (v->storage_class & STCref)
                             error("constant value %s cannot be ref", ie->toChars());
                         else

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -90,6 +90,26 @@ template Bug6599(X)
 static assert(!is(typeof(Bug6599!int)));
 
 /**************************************************
+    8422    TypeTuple of tuples can't be read at compile time
+**************************************************/
+
+template TypeTuple8422(TList...)
+{
+    alias TList TypeTuple8422;
+}
+
+struct S8422 { int x; }
+
+void test8422()
+{
+    enum a = S8422(1);
+    enum b = S8422(2);
+    foreach(t; TypeTuple8422!(b, a)) {
+        enum u = t;
+    }
+}
+
+/**************************************************
     6096    ICE(el.c) with -O
 **************************************************/
 

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -104,8 +104,12 @@ void test8422()
 {
     enum a = S8422(1);
     enum b = S8422(2);
+    enum c = [1,2,3];
     foreach(t; TypeTuple8422!(b, a)) {
         enum u = t;
+    }
+    foreach(t; TypeTuple8422!(c)) {
+        enum v = t;
     }
 }
 


### PR DESCRIPTION
A tuple foreach over a struct literal, or an array literal, should be considered to be a const assignment, just as foreach over a numeric or string literal is.
The struct literal should not be considered to be an lvalue, just because it is in a tuple foreach.

Not sure if this is a language change or not. The current behaviour is not in the spec.
