### PR TITLE
Issue 8504 - Template attribute inferrence doesn't work

### DIFF
--- a/src/delegatize.c
+++ b/src/delegatize.c
@@ -37,6 +37,7 @@ Expression *Expression::toDelegate(Scope *sc, Type *t)
     Type *tw = t->semantic(loc, sc);
     Type *tc = t->substWildTo(MODconst)->semantic(loc, sc);
     TypeFunction *tf = new TypeFunction(NULL, tc, 0, LINKd);
+    if (tw != tc) tf->mod = MODwild;                            // hack for bug7757
     (tf = (TypeFunction *)tf->semantic(loc, sc))->next = tw;    // hack for bug7757
     FuncLiteralDeclaration *fld =
         new FuncLiteralDeclaration(loc, loc, tf, TOKdelegate, NULL);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5103,6 +5103,13 @@ const char *TypeFunction::kind()
     return "function";
 }
 
+TypeFunction *TypeFunction::copy()
+{
+    TypeFunction *tf = (TypeFunction *)mem.malloc(sizeof(TypeFunction));
+    memcpy(tf, this, sizeof(TypeFunction));
+    return tf;
+}
+
 Type *TypeFunction::syntaxCopy()
 {
     Type *treturn = next ? next->syntaxCopy() : NULL;
@@ -5538,8 +5545,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
      * This can produce redundant copies if inferring return type,
      * as semantic() will get called again on this.
      */
-    TypeFunction *tf = (TypeFunction *)mem.malloc(sizeof(TypeFunction));
-    memcpy(tf, this, sizeof(TypeFunction));
+    TypeFunction *tf = copy();
     if (parameters)
     {   tf->parameters = (Parameters *)parameters->copy();
         for (size_t i = 0; i < parameters->dim; i++)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -652,6 +652,7 @@ struct TypeFunction : TypeNext
 
     TypeFunction(Parameters *parameters, Type *treturn, int varargs, enum LINK linkage, StorageClass stc = 0);
     const char *kind();
+    TypeFunction *copy();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     void purityLevel();

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -160,6 +160,36 @@ pure string escapeShellArguments()
 }
 
 /***************************************************/
+// 8504
+
+void foo8504()()
+{
+    static assert(typeof(foo8504!()).stringof == "void()");
+    static assert(typeof(foo8504!()).mangleof == "FZv");
+    static assert(foo8504!().mangleof == "_D13testInference12__T7foo8504Z7foo8504FZv");
+}
+
+auto toDelegate8504a(F)(auto ref F fp) { return fp; }
+   F toDelegate8504b(F)(auto ref F fp) { return fp; }
+
+extern(C) void testC8504() {}
+
+void test8504()
+{
+    static assert(typeof(foo8504!()).stringof == "pure nothrow @safe void()");
+    static assert(typeof(foo8504!()).mangleof == "FNaNbNfZv");
+    static assert(foo8504!().mangleof == "_D13testInference12__T7foo8504Z7foo8504FNaNbNfZv");
+
+    auto fp1 = toDelegate8504a(&testC8504);
+    auto fp2 = toDelegate8504b(&testC8504);
+    static assert(is(typeof(fp1) == typeof(fp2)));
+    static assert(typeof(fp1).stringof == "extern (C) void function()");
+    static assert(typeof(fp2).stringof == "extern (C) void function()");
+    static assert(typeof(fp1).mangleof == "PUZv");
+    static assert(typeof(fp2).mangleof == "PUZv");
+}
+
+/***************************************************/
 // 8751
 
 alias bool delegate(in int) pure Bar8751;

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -586,7 +586,7 @@ void test8198()
         return f => x => f(n(f)(x));
     }
 
-    auto n = &zero!uint;
+    uint delegate(uint) delegate(uint delegate(uint)) n = &zero!uint;
     foreach (i; 0..10)
     {
         assert(n(x => x + 1)(0) == i);


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8504

While template function body semantic, function type and its mangled name are not yet reflected the attribute inference. After semantic3 done, its type and mangled name will be fixed to actual ones.

This change is based on <del>#544</del> (merged).
