### PR TITLE
fix VC build failures due to added/removed files and a few more issues

### DIFF
--- a/src/backend/mscoff.h
+++ b/src/backend/mscoff.h
@@ -17,7 +17,7 @@ struct filehdr
 #define IMAGE_FILE_MACHINE_I386    0x14C        // x86
 #define IMAGE_FILE_MACHINE_AMD64   0x8664       // x86_64
         unsigned short f_nscns; // number of sections (96 is max)
-        time_t f_timdat;        // creation date, number of seconds since 1970
+        long f_timdat;        // creation date, number of seconds since 1970
         long f_symptr;          // file offset of symbol table
         long f_nsyms;           // number of entried in the symbol table
         unsigned short f_opthdr; // optional header size (0)

--- a/src/backend/mscoff.h
+++ b/src/backend/mscoff.h
@@ -1,6 +1,12 @@
 /* Microsoft COFF object file format */
 
+#include <time.h>
+
+#ifdef _MSC_VER
+#pragma pack(push,1)
+#else
 #pragma ZTC align 1
+#endif
 
 /***********************************************/
 
@@ -11,7 +17,7 @@ struct filehdr
 #define IMAGE_FILE_MACHINE_I386    0x14C        // x86
 #define IMAGE_FILE_MACHINE_AMD64   0x8664       // x86_64
         unsigned short f_nscns; // number of sections (96 is max)
-        long f_timdat;          // creation date, number of seconds since 1970
+        time_t f_timdat;        // creation date, number of seconds since 1970
         long f_symptr;          // file offset of symbol table
         long f_nsyms;           // number of entried in the symbol table
         unsigned short f_opthdr; // optional header size (0)
@@ -249,4 +255,8 @@ union auxent
 
 /***********************************************/
 
+#ifdef _MSC_VER
+#pragma pack(pop)
+#else
 #pragma ZTC align
+#endif

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -119,7 +119,8 @@ int seg_data::isCode()
 }
 
 
-seg_data **SegData;
+// already in cgobj.c (should be part of objmod?):
+// seg_data **SegData;
 int seg_count;
 int seg_max;
 segidx_t seg_tlsseg = UNKNOWN;

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -710,7 +710,7 @@ void MsCoffObj::term()
 
     header.f_magic = I64 ? IMAGE_FILE_MACHINE_AMD64 : IMAGE_FILE_MACHINE_I386;
     header.f_nscns = scnhdr_cnt;
-    time(&header.f_timdat);
+    header.f_timdat = time(NULL);
     header.f_symptr = 0;        // offset to symbol table
     header.f_nsyms = 0;
     header.f_opthdr = 0;

--- a/src/dmd_msc.vcproj
+++ b/src/dmd_msc.vcproj
@@ -570,6 +570,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\libmscoff.c"
+				>
+			</File>
+			<File
 				RelativePath=".\libomf.c"
 				>
 			</File>
@@ -643,6 +647,10 @@
 			</File>
 			<File
 				RelativePath=".\s2ir.c"
+				>
+			</File>
+			<File
+				RelativePath=".\scanmscoff.c"
 				>
 			</File>
 			<File
@@ -1029,14 +1037,6 @@
 					>
 				</File>
 				<File
-					RelativePath=".\backend\html.c"
-					>
-				</File>
-				<File
-					RelativePath=".\backend\html.h"
-					>
-				</File>
-				<File
 					RelativePath=".\backend\iasm.h"
 					>
 				</File>
@@ -1058,6 +1058,14 @@
 				</File>
 				<File
 					RelativePath=".\backend\melf.h"
+					>
+				</File>
+				<File
+					RelativePath=".\backend\mscoff.h"
+					>
+				</File>
+				<File
+					RelativePath=".\backend\mscoffobj.c"
 					>
 				</File>
 				<File
@@ -1333,7 +1341,8 @@
 					>
 				</File>
 				<File
-					RelativePath=".\root\dmgcmem.c"					>
+					RelativePath=".\root\dmgcmem.c"
+					>
 					<FileConfiguration
 						Name="Debug|Win32"
 						ExcludedFromBuild="true"
@@ -1384,7 +1393,8 @@
 					>
 				</File>
 				<File
-					RelativePath=".\root\man.c"					>
+					RelativePath=".\root\man.c"
+					>
 				</File>
 				<File
 					RelativePath=".\root\port.c"

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -211,7 +211,7 @@ struct ObjModule
     unsigned short index;       // index in Second Linker Member
     char *name;                 // module name (file name)
     int name_offset;            // if not -1, offset into string table of name
-    long file_time;             // file time
+    time_t file_time;           // file time
     unsigned user_id;
     unsigned group_id;
     unsigned file_mode;

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -211,7 +211,7 @@ struct ObjModule
     unsigned short index;       // index in Second Linker Member
     char *name;                 // module name (file name)
     int name_offset;            // if not -1, offset into string table of name
-    time_t file_time;           // file time
+    long file_time;             // file time
     unsigned user_id;
     unsigned group_id;
     unsigned file_mode;
@@ -609,7 +609,7 @@ void LibMSCoff::addObject(const char *module_name, void *buf, size_t buflen)
     {   /* Mock things up for the object module file that never was
          * actually written out.
          */
-        time(&om->file_time);
+        om->file_time = time(NULL);
         om->user_id = 0;                // meaningless on Windows
         om->group_id = 0;               // meaningless on Windows
         om->file_mode = 0100644;
@@ -726,7 +726,7 @@ void LibMSCoff::WriteLibToBuffer(OutBuffer *libbuf)
     om.length = 4 + objsymbols.dim * 4 + slength;
     om.offset = 8;
     om.name = (char*)"";
-    ::time(&om.file_time);
+    om.file_time = ::time(NULL);
     om.user_id = 0;
     om.group_id = 0;
     om.file_mode = 0;

--- a/src/root/longdouble.c
+++ b/src/root/longdouble.c
@@ -377,7 +377,7 @@ bool operator!=(longdouble x, longdouble y)
 
 int _isnan(longdouble ld)
 {
-    return (ld.exponent == 0x7fff && ld.mantissa != 0);
+    return (ld.exponent == 0x7fff && ld.mantissa != 0 && ld.mantissa != (1LL << 63)); // exclude pseudo-infinity and infinity, but not FP Indefinite
 }
 
 longdouble fabsl(longdouble ld)

--- a/src/vcbuild/warnings.h
+++ b/src/vcbuild/warnings.h
@@ -28,3 +28,4 @@
 #define MARS     1
 #define UNITTEST 1
 #define _M_I86   1
+#define DM_TARGET_CPU_X86 1


### PR DESCRIPTION
This pull request mainly fixes the added/removed files in the VC-Project.

At the same time, a few compilation issues are fixed. There was also a test failing due to an incomplete infinity-check. (I wasn't aware that there two possible representation of infinity in a float).

One strange thing: there are to definitions of SegData, one in cgobj.c and one in the new mscoffobj.c. I wonder why optlink doesn't complain.
