### PR TITLE
Update samples/winsamp.d

### DIFF
--- a/samples/winsamp.d
+++ b/samples/winsamp.d
@@ -102,7 +102,7 @@ int myWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int
 
 int* p;
 extern(Windows)
-LRESULT WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) nothrow
 {
     switch (message)
     {


### PR DESCRIPTION
Fixing Issue 8519 - winsamp.d doesn't compile with 2.060
