### PR TITLE
fixed posix.mak to work on OSX 10.8

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -38,10 +38,15 @@ ifeq (OSX,$(TARGET))
     endif
     ## See: http://developer.apple.com/documentation/developertools/conceptual/cross_development/Using/chapter_3_section_2.html#//apple_ref/doc/uid/20002000-1114311-BABGCAAB
     ENVP= MACOSX_DEPLOYMENT_TARGET=10.3
-    #SDK=$(SDKDIR)/MacOSX10.4u.sdk #doesn't work because can't find <stdarg.h>
-    #SDK=$(SDKDIR)/MacOSX10.5.sdk
-    #SDK=$(SDKDIR)/MacOSX10.6.sdk
-    SDK:=$(if $(filter 11.%, $(OSVER)), $(SDKDIR)/MacOSX10.6.sdk, $(SDKDIR)/MacOSX10.5.sdk)
+    ifneq ($(filter 11.%, $(OSVER)), "")
+        SDK:=$(SDKDIR)/MacOSX10.7.sdk
+    else
+        ifneq ($(filter 11.%, $(OSVER)), "")
+            SDK:=$(SDKDIR)/MacOSX10.6.sdk
+        else
+            SDK:=$(SDKDIR)/MacOSX10.5.sdk
+        endif
+    endif
     TARGET_CFLAGS=-isysroot ${SDK}
     #-syslibroot is only passed to libtool, not ld.
     #if gcc sees -isysroot it should pass -syslibroot to the linker when needed


### PR DESCRIPTION
I've expanded the conditional so DMD will build on OSX 10.8.  This should also work for 10.7 through 10.5.
