### PR TITLE
Issue 8630 - Assertion failure: 'fd && fd->inferRetType' on line 81 in file 'mangle.c'

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -847,6 +847,8 @@ void FuncDeclaration::semantic3(Scope *sc)
     if (!type || type->ty != Tfunction)
         return;
     f = (TypeFunction *)(type);
+    if (!inferRetType && f->next->ty == Terror)
+        return;
 
 #if 0
     // Check the 'throws' clause


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8630

If function type invalidation is detected in `FuncDeclaration::semantic`, `FuncDeclaration::semantic3` should not run.

When return type is an error, running function body semantic would print some relevant errors, but they are fake errors. So we should stop meaningless semantic3 IMO.
