### PR TITLE
Issue 8201 - Conversion from dynamic array to static array fails when static array is immutable

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10687,7 +10687,10 @@ Ltupleassign:
         {
             checkPostblit(e2->loc, t2->nextOf());
         }
-        e2 = e2->implicitCastTo(sc, e1->type->constOf());
+        if (op == TOKconstruct)
+            e2 = e2->castTo(sc, e1->type->constOf());
+        else
+            e2 = e2->implicitCastTo(sc, e1->type->constOf());
     }
     else
     {

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2717,6 +2717,19 @@ void test8099()
 }
 
 /************************************/
+// 8201
+
+void test8201()
+{
+    uint[2] msa;
+    immutable uint[2] isa = msa;
+
+    ubyte[] buffer = [0, 1, 2, 3, 4, 5];
+    immutable ubyte[4] iArr = buffer[0 .. 4];
+}
+
+/************************************/
+// 8212
 
 struct S8212 { int x; }
 
@@ -2846,6 +2859,7 @@ int main()
     test7757();
     test8098();
     test8099();
+    test8201();
     test8212();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8201
