### PR TITLE
Issue 8408 - Purity calculation should be improved

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -2932,6 +2932,8 @@ enum PURE FuncDeclaration::isPureBypassingInference()
 {
     if (flags & FUNCFLAGpurityInprocess)
         return PUREfwdref;
+    else if (type->nextOf() == NULL)
+        return PUREfwdref;
     else
         return isPure();
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8408

This pull improves purity calculation mechanism, and will change some functions PUREstrong, which had been determined as PUREconst.

This is based on #1109, for https://github.com/D-Programming-Language/druntime/pull/298.
