### PR TITLE
Fix bug 8644 - CTFE doesn't support string <,> on array literals

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3015,7 +3015,7 @@ int ctfeCmpArrays(Loc loc, Expression *e1, Expression *e2, uinteger_t len)
             if (c > 0)
                 return 1;
             if (c < 0)
-                return 1;
+                return -1;
         }
         else
         {   if (ctfeRawCmp(loc, ee1, ee2))
@@ -3186,6 +3186,31 @@ Expression *ctfeIdentity(Loc loc, enum TOK op, Type *type, Expression *e1, Expre
 
 Expression *ctfeCmp(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2)
 {
+    if (e1->type->isString() && e2->type->isString())
+    {
+        int cmp = ctfeRawCmp(loc, e1, e2);
+        dinteger_t n;
+        switch (op)
+        {
+            case TOKlt: n = cmp <  0;   break;
+            case TOKle: n = cmp <= 0;   break;
+            case TOKgt: n = cmp >  0;   break;
+            case TOKge: n = cmp >= 0;   break;
+
+            case TOKleg:   n = 1;               break;
+            case TOKlg:    n = cmp != 0;        break;
+            case TOKunord: n = 0;               break;
+            case TOKue:    n = cmp == 0;        break;
+            case TOKug:    n = cmp >  0;        break;
+            case TOKuge:   n = cmp >= 0;        break;
+            case TOKul:    n = cmp <  0;        break;
+            case TOKule:   n = cmp <= 0;        break;
+
+            default:
+                assert(0);
+        }
+        return new IntegerExp(loc, n, type);
+    }
     return Cmp(op, type, e1, e2);
 }
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -885,6 +885,25 @@ int evil8624()
 }
 static assert(  evil8624() );
 
+/*******************************************
+        8644 array literal >,<
+*******************************************/
+int bug8644()
+{
+    auto m = "a";
+    auto z = ['b'];
+    auto c = "b7";
+    auto d = ['b', '6'];
+    assert(m < z);
+    assert(z > m);
+    assert(z <= c);
+    assert(c > z);
+    assert(c > d);
+    assert(d >= d);
+    return true;
+}
+
+static assert(bug8644());
 
 /*******************************************
         Bug 6159


### PR DESCRIPTION
A straightforward omission -- this case is not supported by Cmp(), but can happen in CTFE.
