### PR TITLE
Add toCtype for TypeVector

### DIFF
--- a/src/mtype.h
+++ b/src/mtype.h
@@ -434,6 +434,8 @@ struct TypeVector : Type
     int isZeroInit(Loc loc);
     TypeInfoDeclaration *getTypeInfoDeclaration();
     TypeTuple *toArgTypes();
+
+    type *toCtype();
 };
 
 struct TypeArray : TypeNext

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -75,6 +75,15 @@ type *TypeSArray::toCParamtype()
 #endif
 }
 
+type *TypeVector::toCtype()
+{
+    if (!ctype)
+    {   ctype = type_fake(totym());
+        ctype->Tcount++;
+    }
+    return ctype;
+}
+
 type *TypeSArray::toCtype()
 {
     if (!ctype)


### PR DESCRIPTION
Not much use for DMD (unless it plans to extend its debugging support for vectors) - but helps other compiler backends implement their own debug representation of vectors.
