### PR TITLE
Write documentation file to docdir/module/path

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -181,6 +181,18 @@ void Module::setDocfile()
         argdoc = global.params.docname;
     else if (global.params.preservePaths)
         argdoc = (char *)arg;
+    else if (md)
+    {
+        const char* path = "";
+        if (md->packages)
+        {
+            for (size_t i = 0; i < md->packages->dim; i++)
+            {   Identifier *pid = (*(md->packages))[i];
+                path = FileName::combine(path, pid->toChars());
+            }
+        }
+        argdoc = FileName::combine(path, md->id->toChars());
+    }
     else
         argdoc = FileName::name((char *)arg);
     if (!FileName::absolute(argdoc))
@@ -599,6 +611,7 @@ void Module::parse()
     srcfile->len = 0;
 
     md = p.md;
+    setDocfile();
     numlines = p.loc.linnum;
 
     DsymbolTable *dst;

--- a/test/compilable/ddoc1.d
+++ b/test/compilable/ddoc1.d
@@ -7,7 +7,7 @@
  * Copyright: Copyright &copy; $(YEAR)
  */
 
-module abc;
+module ddoc1;
 
 string foos = "foo";
 

--- a/test/compilable/ddoc2.d
+++ b/test/compilable/ddoc2.d
@@ -23,7 +23,7 @@
 /*
  */
 
-module std.test;
+module ddoc2;
 
 /// A base class for stream exceptions.
 class StreamException: Exception {

--- a/test/compilable/ddoc3.d
+++ b/test/compilable/ddoc3.d
@@ -52,7 +52,7 @@
 /*
  */
 
-module std.test;
+module ddoc3;
 
 /// A base class for stream exceptions.
 class StreamException: Exception {

--- a/test/compilable/ddoc5.d
+++ b/test/compilable/ddoc5.d
@@ -7,7 +7,7 @@
   Test module
 
 */
-module test;
+module ddoc5;
 
 /// class to test DDOC on members
 class TestMembers(TemplateArg)

--- a/test/compilable/extra-files/ddoc1.html
+++ b/test/compilable/extra-files/ddoc1.html
@@ -1,8 +1,8 @@
 <html><head>
         <META http-equiv="content-type" content="text/html; charset=utf-8">
-        <title>abc</title>
+        <title>ddoc1</title>
         </head><body>
-        <h1>abc</h1>
+        <h1>ddoc1</h1>
 This module is for ABC
 <br><br>
 

--- a/test/compilable/extra-files/ddoc2.html
+++ b/test/compilable/extra-files/ddoc2.html
@@ -1,8 +1,8 @@
 <html><head>
         <META http-equiv="content-type" content="text/html; charset=utf-8">
-        <title>std.test</title>
+        <title>ddoc2</title>
         </head><body>
-        <h1>std.test</h1>
+        <h1>ddoc2</h1>
 Summary
 <br><br>
 Description1

--- a/test/compilable/extra-files/ddoc3.html
+++ b/test/compilable/extra-files/ddoc3.html
@@ -1,8 +1,8 @@
 <html><head>
         <META http-equiv="content-type" content="text/html; charset=utf-8">
-        <title>std.test</title>
+        <title>ddoc3</title>
         </head><body>
-        <h1>std.test</h1>
+        <h1>ddoc3</h1>
 Summary
 <br><br>
 Description1

--- a/test/compilable/extra-files/ddoc5.html
+++ b/test/compilable/extra-files/ddoc5.html
@@ -1,8 +1,8 @@
 <html><head>
         <META http-equiv="content-type" content="text/html; charset=utf-8">
-        <title>test</title>
+        <title>ddoc5</title>
         </head><body>
-        <h1>test</h1>
+        <h1>ddoc5</h1>
 Test module
 <br><br>
 


### PR DESCRIPTION
Considering the case of two modules with the same name but in different
packages. If dmd is requested to generate documentation it will
overwrite the first generated documentation file with the second.
This commit changes the documentation filename to include the module
path. Hence, the module documentation will end up in a directory
hierarchy analogously to the package hierarchy.
