### PR TITLE
Issue 8589 - Incorrect conversion of function returning `typeof(null)` to function returning an array

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5222,7 +5222,8 @@ int Type::covariant(Type *t, StorageClass *pstc)
     }
     else if (t1n->ty == t2n->ty && t1n->implicitConvTo(t2n))
         goto Lcovariant;
-    else if (t1n->ty == Tnull && t1n->implicitConvTo(t2n))
+    else if (t1n->ty == Tnull && t1n->implicitConvTo(t2n) &&
+             t1n->size() == t2n->size())
         goto Lcovariant;
   }
     goto Lnotcovariant;

--- a/test/runnable/nulltype.d
+++ b/test/runnable/nulltype.d
@@ -116,6 +116,33 @@ void test8221()
     assert(a.foo() is null);
 }
 
+/***************************************************/
+// 8589
+
+void test8589()
+{
+    static typeof(null) retnull() { return null; }
+
+    void test(bool result, T)()
+    {
+        void f(T function() dg) { assert(!dg()); }
+
+        static assert((T.sizeof == typeof(null).sizeof) == result);
+        static assert(is(typeof( f(&retnull) )) == result);
+        static assert(is(typeof( f(()=>null) )) == result);
+        static if (result)
+        {
+            f(&retnull);
+            f(()=>null);
+        }
+    }
+    test!(true,  int*)();
+    test!(true,  Object)();
+    test!(true,  int[int])();
+    test!(false, int[])();
+    test!(false, void delegate())();
+}
+
 /**********************************************/
 // 9385
 
@@ -134,6 +161,7 @@ int main()
     test2();
     test7278();
     test8221();
+    test8589();
     test9385();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8589

Runtime representation of `typeof(null)` is same as `void*`, then delegate and dynamic array type should not be covariant with `typeof(null)`. It's limitation.
