### PR TITLE
Fixes warning C4099 in MSVC

### DIFF
--- a/src/lib.h
+++ b/src/lib.h
@@ -15,9 +15,8 @@
 #pragma once
 #endif /* __DMC__ */
 
-class Library
+struct Library
 {
-  public:
     static Library *factory();
 
     virtual void setFilename(char *dir, char *filename) = 0;


### PR DESCRIPTION
Fixes warning C4099: 'Library' : type name first seen using 'struct' now seen using 'class' in MSVC.
