### PR TITLE
Divide autotester logging

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -109,36 +109,36 @@ DISABLED_SH_TESTS += test39
 endif
 
 runnable_tests=$(wildcard runnable/*.d) $(wildcard runnable/*.sh)
-runnable_test_results=$(addsuffix .out,$(addprefix $(RESULTS_DIR)/,$(runnable_tests)))
+runnable_test_results=$(addsuffix .log,$(addprefix $(RESULTS_DIR)/,$(runnable_tests)))
 
 compilable_tests=$(wildcard compilable/*.d)
-compilable_test_results=$(addsuffix .out,$(addprefix $(RESULTS_DIR)/,$(compilable_tests)))
+compilable_test_results=$(addsuffix .log,$(addprefix $(RESULTS_DIR)/,$(compilable_tests)))
 
 fail_compilation_tests=$(wildcard fail_compilation/*.d) $(wildcard fail_compilation/*.html)
-fail_compilation_test_results=$(addsuffix .out,$(addprefix $(RESULTS_DIR)/,$(fail_compilation_tests)))
+fail_compilation_test_results=$(addsuffix .log,$(addprefix $(RESULTS_DIR)/,$(fail_compilation_tests)))
 
 all: run_tests
 
-$(addsuffix .d.out,$(addprefix $(RESULTS_DIR)/runnable/,$(DISABLED_TESTS))): $(RESULTS_DIR)/.created
+$(addsuffix .d.log,$(addprefix $(RESULTS_DIR)/runnable/,$(DISABLED_TESTS))): $(RESULTS_DIR)/.created
 	$(QUIET) echo " ... $@ - disabled"
 
-$(addsuffix .sh.out,$(addprefix $(RESULTS_DIR)/runnable/,$(DISABLED_SH_TESTS))): $(RESULTS_DIR)/.created
+$(addsuffix .sh.log,$(addprefix $(RESULTS_DIR)/runnable/,$(DISABLED_SH_TESTS))): $(RESULTS_DIR)/.created
 	$(QUIET) echo " ... $@ - disabled"
 
-$(RESULTS_DIR)/runnable/%.d.out: runnable/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
+$(RESULTS_DIR)/runnable/%.d.log: runnable/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
 	$(QUIET) ./$(RESULTS_DIR)/d_do_test $(<D) $* d
 
-$(RESULTS_DIR)/runnable/%.sh.out: runnable/%.sh $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
+$(RESULTS_DIR)/runnable/%.sh.log: runnable/%.sh $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
 	$(QUIET) echo " ... $(<D)/$*.sh"
 	$(QUIET) ./$(<D)/$*.sh
 
-$(RESULTS_DIR)/compilable/%.d.out: compilable/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
+$(RESULTS_DIR)/compilable/%.d.log: compilable/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
 	$(QUIET) ./$(RESULTS_DIR)/d_do_test $(<D) $* d
 
-$(RESULTS_DIR)/fail_compilation/%.d.out: fail_compilation/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
+$(RESULTS_DIR)/fail_compilation/%.d.log: fail_compilation/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
 	$(QUIET) ./$(RESULTS_DIR)/d_do_test $(<D) $* d
 
-$(RESULTS_DIR)/fail_compilation/%.html.out: fail_compilation/%.html $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
+$(RESULTS_DIR)/fail_compilation/%.html.log: fail_compilation/%.html $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
 	$(QUIET) ./$(RESULTS_DIR)/d_do_test $(<D) $* html
 
 quick:

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -432,11 +432,8 @@ int main(string[] args)
             f.close();
 
             writeln("Test failed.  The logged output:");
-            if (std.file.exists(log_file))
-            {
-                writeln(cast(string)std.file.read(log_file));
-                std.file.remove(log_file);
-            }
+            writeln(cast(string)std.file.read(log_file));
+            std.file.remove(log_file);
             return 1;
         }
     }

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -245,10 +245,16 @@ version(Windows)
     }
 }
 
+void removeIfExists(in char[] filename)
+{
+    if (std.file.exists(filename))
+        std.file.remove(filename);
+}
+
 string execute(ref File f, string command, bool expectpass)
 {
     auto filename = genTempFilename();
-    scope(exit) if (std.file.exists(filename)) std.file.remove(filename);
+    scope(exit) removeIfExists(filename);
 
     f.writeln(command);
     auto rc = system(command ~ " > " ~ filename ~ " 2>&1");
@@ -326,8 +332,7 @@ int main(string[] args)
     else
         write("\n");
 
-    if (std.file.exists(log_file))
-        std.file.remove(log_file);
+    removeIfExists(log_file);
 
     auto f = File(log_file, "a");
 

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -298,7 +298,7 @@ int main(string[] args)
 
     string input_file     = input_dir ~ envData.sep ~ test_name ~ "." ~ test_extension;
     string output_dir     = envData.results_dir ~ envData.sep ~ input_dir;
-    string output_file    = envData.results_dir ~ envData.sep ~ input_dir ~ envData.sep ~ test_name ~ "." ~ test_extension ~ ".out";
+    string log_file    = envData.results_dir ~ envData.sep ~ input_dir ~ envData.sep ~ test_name ~ "." ~ test_extension ~ ".log";
     string test_app_dmd_base = output_dir ~ envData.sep ~ test_name ~ "_";
 
     TestArgs testArgs;
@@ -326,10 +326,10 @@ int main(string[] args)
     else
         write("\n");
 
-    if (std.file.exists(output_file))
-        std.file.remove(output_file);
+    if (std.file.exists(log_file))
+        std.file.remove(log_file);
 
-    auto f = File(output_file, "a");
+    auto f = File(log_file, "a");
 
     foreach(i, c; combinations(testArgs.permuteArgs))
     {
@@ -427,10 +427,10 @@ int main(string[] args)
             f.close();
 
             writeln("Test failed.  The logged output:");
-            if (std.file.exists(output_file))
+            if (std.file.exists(log_file))
             {
-                writeln(cast(string)std.file.read(output_file));
-                std.file.remove(output_file);
+                writeln(cast(string)std.file.read(log_file));
+                std.file.remove(log_file);
             }
             return 1;
         }

--- a/test/do_test.sh
+++ b/test/do_test.sh
@@ -32,11 +32,11 @@ shopt -s extglob
 
 input_file=${input_dir}/${test_name}.${test_extension}
 output_dir=${RESULTS_DIR}${SEP}${input_dir}
-output_file=${RESULTS_DIR}/${input_dir}/${test_name}.${test_extension}.out
+log_file=${RESULTS_DIR}/${input_dir}/${test_name}.${test_extension}.log
 test_app_dmd=${output_dir}${SEP}${test_name}
 test_app_exe=${RESULTS_DIR}/${input_dir}/${test_name}
 
-rm -f ${output_file}
+rm -f ${log_file}
 
 r_args=`grep REQUIRED_ARGS ${input_file} | tr -d \\\\r\\\\n`
 if [ ! -z "${r_args}" ]; then
@@ -107,20 +107,20 @@ printf " ... %-25s %s%s(%s)\n" "${input_file}" "${r_args}" "${extra_space}" "${p
 ${RESULTS_DIR}/combinations ${p_args} | while read x; do
 
     if [ ${separate} -ne 0 ]; then
-        echo ${DMD} -m${MODEL} -I${input_dir} ${r_args} $x -od${output_dir} -of${test_app_dmd} ${extra_compile_args} ${all_sources[*]} >> ${output_file}
-             ${DMD} -m${MODEL} -I${input_dir} ${r_args} $x -od${output_dir} -of${test_app_dmd} ${extra_compile_args} ${all_sources[*]} >> ${output_file} 2>&1
+        echo ${DMD} -m${MODEL} -I${input_dir} ${r_args} $x -od${output_dir} -of${test_app_dmd} ${extra_compile_args} ${all_sources[*]} >> ${log_file}
+             ${DMD} -m${MODEL} -I${input_dir} ${r_args} $x -od${output_dir} -of${test_app_dmd} ${extra_compile_args} ${all_sources[*]} >> ${log_file} 2>&1
         if [ $? -eq ${expect_compile_rc} -o $? -gt 125 ]; then
-            cat ${output_file}
-            rm -f ${output_file}
+            cat ${log_file}
+            rm -f ${log_file}
             exit 1
         fi
     else
         for file in ${all_sources[*]}; do
-            echo ${DMD} -m${MODEL} -I${input_dir} ${r_args} $x -od${output_dir} -c $file >> ${output_file}
-                 ${DMD} -m${MODEL} -I${input_dir} ${r_args} $x -od${output_dir} -c $file >> ${output_file} 2>&1
+            echo ${DMD} -m${MODEL} -I${input_dir} ${r_args} $x -od${output_dir} -c $file >> ${log_file}
+                 ${DMD} -m${MODEL} -I${input_dir} ${r_args} $x -od${output_dir} -c $file >> ${log_file} 2>&1
             if [ $? -eq ${expect_compile_rc} -o $? -gt 125 ]; then
-                cat ${output_file}
-                rm -f ${output_file}
+                cat ${log_file}
+                rm -f ${log_file}
                 exit 1
             fi
         done
@@ -130,39 +130,39 @@ ${RESULTS_DIR}/combinations ${p_args} | while read x; do
         all_os=(${all_os[*]/#/${RESULTS_DIR}${SEP}})
 
         if [ "${input_dir}" = "runnable" ]; then
-            echo ${DMD} -m${MODEL} -od${output_dir} -of${test_app_dmd} ${all_os[*]} >> ${output_file}
-                 ${DMD} -m${MODEL} -od${output_dir} -of${test_app_dmd} ${all_os[*]} >> ${output_file} 2>&1
+            echo ${DMD} -m${MODEL} -od${output_dir} -of${test_app_dmd} ${all_os[*]} >> ${log_file}
+                 ${DMD} -m${MODEL} -od${output_dir} -of${test_app_dmd} ${all_os[*]} >> ${log_file} 2>&1
             if [ $? -eq ${expect_compile_rc} -o $? -gt 125 ]; then
-                cat ${output_file}
-                rm -f ${output_file}
+                cat ${log_file}
+                rm -f ${log_file}
                 exit 1
             fi
         fi
     fi
 
     if [ "${input_dir}" = "runnable" ]; then
-        echo ${test_app_exe} ${e_args} >> ${output_file}
-             ${test_app_exe} ${e_args} >> ${output_file} 2>&1
+        echo ${test_app_exe} ${e_args} >> ${log_file}
+             ${test_app_exe} ${e_args} >> ${log_file} 2>&1
         if [ $? -ne 0 ]; then
-            cat ${output_file}
-            rm -f ${output_file}
+            cat ${log_file}
+            rm -f ${log_file}
             exit 1
         fi
     fi
 
     if [ ! -z ${post_script} ]; then
-        echo "Executing post-test script: ${post_script}" >> ${output_file}
-        ${post_script} >> ${output_file} 2>&1
+        echo "Executing post-test script: ${post_script}" >> ${log_file}
+        ${post_script} >> ${log_file} 2>&1
         if [ $? -ne 0 ]; then
-            cat ${output_file}
-            rm -f ${output_file}
+            cat ${log_file}
+            rm -f ${log_file}
             exit 1
         fi
     fi
 
     rm -f ${test_app_exe} ${test_app_exe}${OBJ} ${all_os[*]}
 
-    echo >> ${output_file}
+    echo >> ${log_file}
 done
 
 

--- a/test/runnable/extra-files/statictor-postscript.sh
+++ b/test/runnable/extra-files/statictor-postscript.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 
-# trim off the first line which contains the path of the file which differs between windows and non-windows
-# also trim off compiler debug message
-grep -v "runnable\|DEBUG" ${RESULTS_DIR}/runnable/statictor.d.log > ${RESULTS_DIR}/runnable/statictor.d.log.2
-
-diff --strip-trailing-cr runnable/extra-files/statictor.d.out ${RESULTS_DIR}/runnable/statictor.d.log.2
+diff --strip-trailing-cr runnable/extra-files/statictor.d.out ${RESULTS_DIR}/runnable/statictor.d.out
 if [ $? -ne 0 ]; then
     exit 1;
 fi
-
-rm ${RESULTS_DIR}/runnable/statictor.d.log.2
-

--- a/test/runnable/extra-files/statictor-postscript.sh
+++ b/test/runnable/extra-files/statictor-postscript.sh
@@ -2,12 +2,12 @@
 
 # trim off the first line which contains the path of the file which differs between windows and non-windows
 # also trim off compiler debug message
-grep -v "runnable\|DEBUG" ${RESULTS_DIR}/runnable/statictor.d.out > ${RESULTS_DIR}/runnable/statictor.d.out.2
+grep -v "runnable\|DEBUG" ${RESULTS_DIR}/runnable/statictor.d.log > ${RESULTS_DIR}/runnable/statictor.d.log.2
 
-diff --strip-trailing-cr runnable/extra-files/statictor.d.out ${RESULTS_DIR}/runnable/statictor.d.out.2
+diff --strip-trailing-cr runnable/extra-files/statictor.d.out ${RESULTS_DIR}/runnable/statictor.d.log.2
 if [ $? -ne 0 ]; then
     exit 1;
 fi
 
-rm ${RESULTS_DIR}/runnable/statictor.d.out.2
+rm ${RESULTS_DIR}/runnable/statictor.d.log.2
 

--- a/test/runnable/test2.sh
+++ b/test/runnable/test2.sh
@@ -2,9 +2,9 @@
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test2.sh.out
+log_file=${dir}/test2.sh.log
 
-rm -f ${output_file}
+rm -f ${log_file}
 
 a[0]=''
 a[1]='-debug'
@@ -12,23 +12,23 @@ a[2]='-debug=1'
 a[3]='-debug=2 -debug=bar'
 
 for x in "${a[@]}"; do
-    echo "executing with args: $x" >> ${output_file}
+    echo "executing with args: $x" >> ${log_file}
 
-    $DMD -m${MODEL} $x -unittest -od${dmddir} -of${dmddir}${SEP}test2 runnable/extra-files/test2.d >> ${output_file}
+    $DMD -m${MODEL} $x -unittest -od${dmddir} -of${dmddir}${SEP}test2 runnable/extra-files/test2.d >> ${log_file}
     if [ $? -ne 0 ]; then
-        cat ${output_file}
-        rm -f ${output_file}
+        cat ${log_file}
+        rm -f ${log_file}
         exit 1
     fi
 
-    ./${dir}/test2 >> ${output_file}
+    ./${dir}/test2 >> ${log_file}
     if [ $? -ne 0 ]; then
-        cat ${output_file}
-        rm -f ${output_file}
+        cat ${log_file}
+        rm -f ${log_file}
         exit 1
     fi
 
     rm ${dir}/{test2${OBJ},test2${EXE}}
 
-    echo >> ${output_file}
+    echo >> ${log_file}
 done

--- a/test/runnable/test35.sh
+++ b/test/runnable/test35.sh
@@ -2,35 +2,35 @@
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test35.sh.out
+log_file=${dir}/test35.sh.log
 
-rm -f ${output_file}
+rm -f ${log_file}
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test35.d >> ${output_file}
+$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test35.d >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-$DMD -m${MODEL} -od${dmddir} -c -release runnable/imports/test35a.d >> ${output_file}
+$DMD -m${MODEL} -od${dmddir} -c -release runnable/imports/test35a.d >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-$DMD -m${MODEL} -of${dmddir}${SEP}test35 ${dir}/test35${OBJ} ${dir}/test35a${OBJ} >> ${output_file}
+$DMD -m${MODEL} -of${dmddir}${SEP}test35 ${dir}/test35${OBJ} ${dir}/test35a${OBJ} >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-./${dir}/test35 >> ${output_file}
+./${dir}/test35 >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 

--- a/test/runnable/test39.sh
+++ b/test/runnable/test39.sh
@@ -2,48 +2,48 @@
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test39.sh.out
+log_file=${dir}/test39.sh.log
 
-rm -f ${output_file}
+rm -f ${log_file}
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test39.d >> ${output_file}
+$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test39.d >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/imports/test39a.d >> ${output_file}
+$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/imports/test39a.d >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
 if [ ${OS} == "win32" ]; then
-    lib -c ${dmddir}${SEP}test39a.lib ${dmddir}${SEP}test39a.obj >> ${output_file} 2>&1
+    lib -c ${dmddir}${SEP}test39a.lib ${dmddir}${SEP}test39a.obj >> ${log_file} 2>&1
     LIBEXT=.lib
 else
-    ar -r ${dir}/test39a.a ${dir}/test39a.o >> ${output_file} 2>&1
+    ar -r ${dir}/test39a.a ${dir}/test39a.o >> ${log_file} 2>&1
     LIBEXT=.a
 fi
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-$DMD -m${MODEL} -of${dmddir}${SEP}test39 ${dir}/test39${OBJ} ${dir}/test39a${LIBEXT} >> ${output_file}
+$DMD -m${MODEL} -of${dmddir}${SEP}test39 ${dir}/test39${OBJ} ${dir}/test39a${LIBEXT} >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-./${dir}/test39 >> ${output_file}
+./${dir}/test39 >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 

--- a/test/runnable/test44.sh
+++ b/test/runnable/test44.sh
@@ -2,35 +2,35 @@
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test44.sh.out
+log_file=${dir}/test44.sh.log
 
-rm -f ${output_file}
+rm -f ${log_file}
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_1 runnable/extra-files/test44.d runnable/imports/test44a.d >> ${output_file}
+$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_1 runnable/extra-files/test44.d runnable/imports/test44a.d >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-./${dir}/test44_1 >> ${output_file}
+./${dir}/test44_1 >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_2 runnable/imports/test44a.d runnable/extra-files/test44.d >> ${output_file}
+$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_2 runnable/imports/test44a.d runnable/extra-files/test44.d >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 
-./${dir}/test44_2 >> ${output_file}
+./${dir}/test44_2 >> ${log_file}
 if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
+    cat ${log_file}
+    rm -f ${log_file}
     exit 1
 fi
 


### PR DESCRIPTION
Do not write both program output and log into one file. This also fixes issues of current error-prone solution discovered in [phobos pull 778 discussion](https://github.com/D-Programming-Language/phobos/pull/778#issuecomment-8612657)

[EDITED] A short story:

When I read sources and I see some error-prone place (e.g. pointer arithmetic) I read it very very carefully. That's how I find bugs from time to time.

From the other side, when there is an issue and I have found it's source and do understand what's wrong (I mean I know the smallest change that will fix this issue) I will never ever start from doing this fix. The first thing I will think about: why it is here? Why somebody did a mistake? And if I see an error-prone design, I will try to change it instead of dirty-fixing (e.g. I'll never fix pointer arithmetic unless I'm sure it is really required here).

Problems `d_do_test.d` and my solutions:
1. It writes log (program output + comments) to `*.out` file that isn't obvious at all because it looks like a program output and some tests do use `*.out` files for pure output. So I changed extension to `*.log`.
2. The `*.log` (previously `*.out`) file is used by postscripts when it is still opened for writing. This requires careful flushes and changes in all postscripts for every log format change that unnecessary complicates things. So I created temporary `*.out` file for a postscripts to process with program output only.
