### PR TITLE
fix Issue 8675 - Nothrow can't throw Errors

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -4947,8 +4947,17 @@ Statement *ThrowStatement::semantic(Scope *sc)
 int ThrowStatement::blockExit(bool mustNotThrow)
 {
     if (mustNotThrow)
-        error("%s is thrown but not caught", exp->type->toChars());
-    return BEthrow;  // obviously
+    {
+        ClassDeclaration *cd = exp->type->toBasetype()->isClassHandle();
+        assert(cd);
+
+        // Bugzilla 8675
+        // Throwing Errors is allowed even if mustNotThrow
+        if (cd != ClassDeclaration::errorException &&
+            !ClassDeclaration::errorException->isBaseOf(cd, NULL))
+            error("%s is thrown but not caught", exp->type->toChars());
+    }
+    return BEthrow;
 }
 
 

--- a/test/compilable/test8675.d
+++ b/test/compilable/test8675.d
@@ -1,0 +1,17 @@
+class MyError : Error
+{
+    this(string msg)
+    {
+        super(msg);
+    }
+}
+
+void foo() nothrow
+{
+    throw new Error("Some error");
+}
+
+void bar() nothrow
+{
+    throw new MyError("Some error");
+}


### PR DESCRIPTION
- fixed by checking whether the thrown exception is derived
  from Error before complaining about uncaught throws
