### PR TITLE
Issue 8696 - Compiler reports incorrect dangling else with version():

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -605,10 +605,15 @@ Dsymbols *Parser::parseDeclDefs(int once)
 
             Lcondition:
                 {
-                    Loc lookingForElseSave = lookingForElse;
-                    lookingForElse = loc;
-                    a = parseBlock();
-                    lookingForElse = lookingForElseSave;
+                    if (token.value == TOKcolon)
+                        a = parseBlock();
+                    else
+                    {
+                        Loc lookingForElseSave = lookingForElse;
+                        lookingForElse = loc;
+                        a = parseBlock();
+                        lookingForElse = lookingForElseSave;
+                    }
                 }
                 aelse = NULL;
                 if (token.value == TOKelse)

--- a/test/compilable/test8696.d
+++ b/test/compilable/test8696.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -w
+
+// 8696: incorrect dangling else with version():
+version (all):
+
+version (linux)
+{
+}
+else version (OSX)
+{
+}
+else
+{
+}


### PR DESCRIPTION
 Issue 8696 - Compiler reports incorrect dangling else with version attributes.

May need a comment to explain that with `version (foo):`  we do not need to look for an else condition.

Bug report: http://d.puremagic.com/issues/show_bug.cgi?id=8696
