### PR TITLE
8608 ICE(interpret.c): CTFE using runtime variable as ref param

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2111,9 +2111,13 @@ Expression *VarExp::interpret(InterState *istate, CtfeGoal goal)
         {   error("variable %s cannot be referenced at compile time", v->toChars());
             return EXP_CANT_INTERPRET;
         }
-        else if (v && !v->hasValue() && !v->isCTFE() && v->isDataseg())
-        {   error("static variable %s cannot be referenced at compile time", v->toChars());
-                return EXP_CANT_INTERPRET;
+        else if (v && !v->hasValue())
+        {
+            if (!v->isCTFE() && v->isDataseg())
+                error("static variable %s cannot be referenced at compile time", v->toChars());
+            else     // CTFE initiated from inside a function
+                error("variable %s cannot be read at compile time", v->toChars());
+            return EXP_CANT_INTERPRET;
         }
         return this;
     }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1246,6 +1246,23 @@ int sdfgasf()
 static assert(sdfgasf() == 1);
 
 /**************************************************
+   8608 ICE
+**************************************************/
+
+void bug8608(ref int m) {}
+void test8608()
+{
+    int z;
+    int foo(bool b)
+    {
+        if (b)  bug8608(z);
+        return 1;
+    }
+    static assert( is(typeof(compiles!( foo(false) ))));
+    static assert(!is(typeof(compiles!( foo(true) ))));
+}
+
+/**************************************************
    Bug 7770
 **************************************************/
 


### PR DESCRIPTION
The case where the variable is not global, and yet not a CTFE local variable, can happen in nested functions and similar things like copy constructor calls. There's an existing check for variables accessed by value but the byref case was missed.
