### PR TITLE
Enhanced unittest support

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -130,6 +130,8 @@ struct AnonymousAggregateDeclaration : AggregateDeclaration
 
 struct StructDeclaration : AggregateDeclaration
 {
+    static StructDeclaration *UnitTest;
+
     int zeroInit;               // !=0 if initialize with 0 fill
 #if DMDV2
     int hasIdentityAssign;      // !=0 if has identity opAssign

--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -26,6 +26,8 @@ typedef ArrayBase<struct Statement> Statements;
 
 typedef ArrayBase<struct BaseClass> BaseClasses;
 
+typedef ArrayBase<struct UnitTestDeclaration> UnitTestDeclarations;
+
 typedef ArrayBase<struct ClassDeclaration> ClassDeclarations;
 
 typedef ArrayBase<struct Dsymbol> Dsymbols;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -880,6 +880,8 @@ struct UnitTestDeclaration : FuncDeclaration
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toJsonBuffer(OutBuffer *buf);
 
+    char* name; //Not used yet
+    ExpInitializer *toUnitTestStruct();
     UnitTestDeclaration *isUnitTestDeclaration() { return this; }
 };
 

--- a/src/func.c
+++ b/src/func.c
@@ -4019,16 +4019,22 @@ void UnitTestDeclaration::semantic(Scope *sc)
  *   string fileName;
  *   uint line;
  *   void function() testFunc;
+ *   bool disabled;
  *}
  */
 ExpInitializer *UnitTestDeclaration::toUnitTestStruct()
 {
     Expressions *inits = new Expressions();
+
+    bool disabled = storage_class & STCdisable;
+
     inits->push(new IntegerExp(loc, 1, TypeBasic::tuns16)); //version=1
     inits->push(new StringExp(loc, name)); //name
     inits->push(new StringExp(loc, (char*)loc.filename)); //fileName
     inits->push(new IntegerExp(loc, loc.linnum, TypeBasic::tuns32)); //line
-    inits->push(new AddrExp(loc, new VarExp(loc, this))); //testFunc
+    inits->push(disabled ? (Expression*)new NullExp(loc)
+        : (Expression*)new AddrExp(loc, new VarExp(loc, this))); //testFunc
+    inits->push(new IntegerExp(loc, disabled, TypeBasic::tbool)); //disabled
 
     StructLiteralExp *exp = new StructLiteralExp(loc, StructDeclaration::UnitTest,
         inits, StructDeclaration::UnitTest->type);

--- a/src/glue.c
+++ b/src/glue.c
@@ -56,7 +56,8 @@ symbol *ictorlocalgot;
 symbols sctors;
 StaticDtorDeclarations ectorgates;
 symbols sdtors;
-symbols stests;
+symbols oldstests;
+UnitTestDeclarations stests;
 
 symbols ssharedctors;
 SharedStaticDtorDeclarations esharedctorgates;
@@ -302,6 +303,7 @@ void Module::genobjfile(int multiobj)
     ssharedctors.setDim(0);
     esharedctorgates.setDim(0);
     sshareddtors.setDim(0);
+    oldstests.setDim(0);
     stests.setDim(0);
     dtorcount = 0;
     shareddtorcount = 0;
@@ -424,7 +426,37 @@ void Module::genobjfile(int multiobj)
         ssharedctor = callFuncsAndGates(this, &ssharedctors, (StaticDtorDeclarations *)&esharedctorgates, "__modsharedctor");
         sshareddtor = callFuncsAndGates(this, &sshareddtors, NULL, "__modshareddtor");
 #endif
-        stest = callFuncsAndGates(this, &stests, NULL, "__modtest");
+        stest = callFuncsAndGates(this, &oldstests, NULL, "__modtest");
+        /*
+         * New unittest: Generate static array of UnitTests (see druntime)
+         */
+        if(stests.dim)
+        {
+            if (!StructDeclaration::UnitTest)
+            {
+                warning(loc, "mismatch between compiler and object.d or object.di found. "
+                    "struct UnitTest was not found, advanced unittest information won't "
+                    "be available. "
+                    "Check installation and import paths with -v compiler switch.");
+            }
+            else
+            {
+                unitTests = new UnitTestDeclarations(stests);
+                Type *ttype = new TypeSArray(StructDeclaration::UnitTest->type,
+                    new IntegerExp(loc, stests.dim, Type::tsize_t));
+                ArrayInitializer *init = new ArrayInitializer(loc);
+                for(unsigned i = 0; i < stests.dim; i++)
+                {
+                    init->addInit(NULL,
+                        stests[i]->toUnitTestStruct());
+                }
+                init->semantic(this->scope, ttype, INITnointerpret);
+                unitTestArr = new VarDeclaration(loc, ttype,
+                    new Identifier("__modtestArray", 0), init);
+                unitTestArr->storage_class |= STCgshared | STCimmutable;
+                unitTestArr->semantic(this->scope);
+            }
+        }
 
         if (doppelganger)
             genmoduleinfo();
@@ -979,7 +1011,8 @@ void FuncDeclaration::toObjFile(int multiobj)
     // If unit test
     if (isUnitTestDeclaration())
     {
-        stests.push(s);
+        oldstests.push(s);
+        stests.push(this->isUnitTestDeclaration());
     }
 
     if (global.errors)

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -60,6 +60,7 @@ Msgtable msgtable[] =
     { "offset" },
     { "offsetof" },
     { "ModuleInfo" },
+    { "UnitTest" },
     { "ClassInfo" },
     { "classinfo" },
     { "typeinfo" },

--- a/src/module.c
+++ b/src/module.c
@@ -91,6 +91,8 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
     ssharedctor = NULL;
     sshareddtor = NULL;
     stest = NULL;
+    unitTestArr = NULL;
+    unitTests = NULL;
     sfilename = NULL;
     root = 0;
     importedFrom = NULL;

--- a/src/module.h
+++ b/src/module.h
@@ -140,6 +140,9 @@ struct Module : Package
     static void clearCache();
     int imports(Module *m);
 
+    Declaration *unitTestArr; //Static array of UnitTests (see druntime)
+    UnitTestDeclarations *unitTests; //All unitTests in this module
+
     // Back end
 
     int doppelganger;           // sub-module

--- a/src/struct.c
+++ b/src/struct.c
@@ -22,6 +22,7 @@
 #include "template.h"
 
 FuncDeclaration *StructDeclaration::xerreq;     // object.xopEquals
+StructDeclaration *StructDeclaration::UnitTest;
 
 /********************************* AggregateDeclaration ****************************/
 
@@ -343,6 +344,8 @@ int AggregateDeclaration::numFieldsInUnion(int firstIndex)
 StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
     : AggregateDeclaration(loc, id)
 {
+    static char msg[] = "only object.d can define this reserved class name";
+
     zeroInit = 0;       // assume false until we do semantic processing
 #if DMDV2
     hasIdentityAssign = 0;
@@ -358,6 +361,16 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
 
     // For forward references
     type = new TypeStruct(this);
+
+    if(id)
+    {
+        // Look for special struct names
+        if (id == Id::UnitTest)
+        {   if (UnitTest)
+                UnitTest->error("%s", msg);
+            UnitTest = this;
+        }
+    }
 }
 
 Dsymbol *StructDeclaration::syntaxCopy(Dsymbol *s)

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -92,9 +92,11 @@ void Module::genmoduleinfo()
     #define MIdtor            0x40
     #define MIxgetMembers     0x80
     #define MIictor           0x100
+    //deprecated
     #define MIunitTest        0x200
     #define MIimportedModules 0x400
     #define MIlocalClasses    0x800
+    #define MInewUnitTest     0x1000
     #define MInew             0x80000000   // it's the "new" layout
 
     unsigned flags = MInew;
@@ -112,6 +114,8 @@ void Module::genmoduleinfo()
         flags |= MIictor;
     if (stest)
         flags |= MIunitTest;
+    if (unitTestArr)
+        flags |= MInewUnitTest;
     if (aimports_dim)
         flags |= MIimportedModules;
     if (aclasses.dim)
@@ -137,6 +141,14 @@ void Module::genmoduleinfo()
         dtxoff(&dt, sictor, 0, TYnptr);
     if (flags & MIunitTest)
         dtxoff(&dt, stest, 0, TYnptr);
+    if (flags & MInewUnitTest)
+    {
+        //Put out unittests
+        unitTestArr->toObjFile(0);
+        //UnitTest[]
+        dtsize_t(&dt, unitTests->dim);
+        dtxoff(&dt, unitTestArr->toSymbol(), 0, TYnptr);
+    }
     if (flags & MIimportedModules)
     {
         dtsize_t(&dt, aimports_dim);


### PR DESCRIPTION
This allows to add additional data to unittests and it allows the runtime to run unittests seperately.

Currently supported information:

```
ushort version; //UnitTest info version, currently = 1
string filename;
uint line;
void function() testFunc;
```

Prepared:

```
string name; //Needs support in the lexer/parser.
```

The name is passed to the runtime, but currently it's always an empty string.

The old per module unittest function is still supported, but deprecated.

The second commit recognizes if a unittest is marked as `@disable` and passes this information to the runtime.

This druntime pull request should be pulled first:
https://github.com/D-Programming-Language/druntime/pull/308

Here's a small example of what can be done with these changes:
Custom test runner: http://dpaste.dzfl.pl/046ed6fb
Sample unittests: http://dpaste.dzfl.pl/517b1088
Output: http://dpaste.dzfl.pl/2780939b

**NOTE:**
The autotester does not pull in the druntime changes, so it only tests the old unit test method (The new method is disabled if druntime support is not found).
Therefore the druntime request should be pulled first. We should the wait for new autotester results with these druntime changes included. If those results look fine we can merge this pull request.
