### PR TITLE
Issue 7021 - Structs with disabled default constructors can be constructed without calling a constructor.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7888,7 +7888,7 @@ Lagain:
             ad = ((TypeStruct *)t1)->sym;
 #if DMDV2
             // First look for constructor
-            if (e1->op == TOKtype && ad->ctor && arguments && arguments->dim)
+            if (e1->op == TOKtype && ad->ctor && (ad->noDefaultCtor || arguments && arguments->dim))
             {
                 // Create variable that will get constructed
                 Identifier *idtmp = Lexer::uniqueId("__ctmp");

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -498,6 +498,21 @@ void test7929()
 }
 
 /********************************************/
+// 7021
+
+struct S7021
+{
+    @disable this();
+}
+
+void test7021()
+{
+  static assert(!is(typeof({
+    auto s = S7021();
+  })));
+}
+
+/********************************************/
 
 int main()
 {
@@ -519,6 +534,7 @@ int main()
     test5885();
     test5889();
     test7929();
+    test7021();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7021
