### PR TITLE
Issue 8496 - Assignment of function literal to function pointer variable with non-D linkage broken

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1745,7 +1745,7 @@ Expression *FuncExp::inferType(Type *to, int flag, TemplateParameters *tparams)
                 FuncLiteralDeclaration *fld = td->onemember->isFuncLiteralDeclaration();
                 assert(fld);
                 if (!fld->type->nextOf() && tfv->next)
-                    fld->treq = tfv;
+                    fld->treq = to;
 
                 TemplateInstance *ti = new TemplateInstance(loc, td, tiargs);
                 e = (new ScopeExp(loc, ti))->semantic(td->scope);

--- a/src/func.c
+++ b/src/func.c
@@ -174,6 +174,13 @@ void FuncDeclaration::semantic(Scope *sc)
 
     //printf("function storage_class = x%llx, sc->stc = x%llx, %x\n", storage_class, sc->stc, Declaration::isFinal());
 
+    FuncLiteralDeclaration *fld = isFuncLiteralDeclaration();
+    if (fld && fld->treq)
+        linkage = ((TypeFunction *)fld->treq->nextOf())->linkage;
+    else
+        linkage = sc->linkage;
+    protection = sc->protection;
+
     if (!originalType)
         originalType = type;
     if (!type->deco)
@@ -191,6 +198,8 @@ void FuncDeclaration::semantic(Scope *sc)
 
         if (isCtorDeclaration())
             sc->flags |= SCOPEctor;
+
+        sc->linkage = linkage;
 
         /* Apply const, immutable, wild and shared storage class
          * to the function type. Do this before type semantic.
@@ -259,9 +268,6 @@ void FuncDeclaration::semantic(Scope *sc)
     }
     f = (TypeFunction *)(type);
     size_t nparams = Parameter::dim(f->parameters);
-
-    linkage = sc->linkage;
-    protection = sc->protection;
 
     /* Purity and safety can be inferred for some functions by examining
      * the function body.

--- a/src/statement.c
+++ b/src/statement.c
@@ -3786,8 +3786,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
         FuncLiteralDeclaration *fld = fd->isFuncLiteralDeclaration();
         if (tret)
             exp = exp->inferType(tbret);
-        else if (fld && fld->treq && fld->treq->nextOf())
-            exp = exp->inferType(fld->treq->nextOf());
+        else if (fld && fld->treq)
+            exp = exp->inferType(fld->treq->nextOf()->nextOf());
         exp = exp->semantic(sc);
         exp = resolveProperties(sc, exp);
         if (!((TypeFunction *)fd->type)->isref)

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -668,6 +668,18 @@ void test8397()
 }
 
 /***************************************************/
+// 8496
+
+void test8496()
+{
+    alias extern (C) void function() Func;
+
+    Func fp = (){};
+
+    fp = (){};
+}
+
+/***************************************************/
 // 8575
 
 template tfunc8575(func...)
@@ -726,6 +738,7 @@ int main()
     test8242();
     test8315();
     test8397();
+    test8496();
     test8575();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8496

I think that lambda type inference should prefer required linkage.
