### PR TITLE
Issue 8475 - postblits fails attributes qualifying when in a template.

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -567,8 +567,7 @@ FuncDeclaration *StructDeclaration::buildPostBlit(Scope *sc)
      */
     if (e || (stc & STCdisable))
     {   //printf("Building __fieldPostBlit()\n");
-        PostBlitDeclaration *dd = new PostBlitDeclaration(loc, 0, Lexer::idPool("__fieldPostBlit"));
-        dd->storage_class |= stc;
+        PostBlitDeclaration *dd = new PostBlitDeclaration(loc, 0, stc, Lexer::idPool("__fieldPostBlit"));
         dd->fbody = new ExpStatement(0, e);
         postblits.shift(dd);
         members->push(dd);
@@ -598,8 +597,7 @@ FuncDeclaration *StructDeclaration::buildPostBlit(Scope *sc)
                 ex = new CallExp(0, ex);
                 e = Expression::combine(e, ex);
             }
-            PostBlitDeclaration *dd = new PostBlitDeclaration(loc, 0, Lexer::idPool("__aggrPostBlit"));
-            dd->storage_class |= stc;
+            PostBlitDeclaration *dd = new PostBlitDeclaration(loc, 0, stc, Lexer::idPool("__aggrPostBlit"));
             dd->fbody = new ExpStatement(0, e);
             members->push(dd);
             dd->semantic(sc);

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -760,8 +760,7 @@ struct CtorDeclaration : FuncDeclaration
 #if DMDV2
 struct PostBlitDeclaration : FuncDeclaration
 {
-    PostBlitDeclaration(Loc loc, Loc endloc, StorageClass stc = STCundefined);
-    PostBlitDeclaration(Loc loc, Loc endloc, Identifier *id);
+    PostBlitDeclaration(Loc loc, Loc endloc, StorageClass stc = STCundefined, Identifier *id = NULL);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -760,7 +760,7 @@ struct CtorDeclaration : FuncDeclaration
 #if DMDV2
 struct PostBlitDeclaration : FuncDeclaration
 {
-    PostBlitDeclaration(Loc loc, Loc endloc, StorageClass stc = STCundefined, Identifier *id = NULL);
+    PostBlitDeclaration(Loc loc, Loc endloc, StorageClass stc, Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/func.c
+++ b/src/func.c
@@ -3436,20 +3436,15 @@ int CtorDeclaration::addPostInvariant()
 /********************************* PostBlitDeclaration ****************************/
 
 #if DMDV2
-PostBlitDeclaration::PostBlitDeclaration(Loc loc, Loc endloc, StorageClass stc)
-    : FuncDeclaration(loc, endloc, Id::_postblit, stc, NULL)
-{
-}
-
-PostBlitDeclaration::PostBlitDeclaration(Loc loc, Loc endloc, Identifier *id)
-    : FuncDeclaration(loc, endloc, id, STCundefined, NULL)
+PostBlitDeclaration::PostBlitDeclaration(Loc loc, Loc endloc, StorageClass stc, Identifier *id)
+    : FuncDeclaration(loc, endloc, id ? id : Id::_postblit, stc, NULL)
 {
 }
 
 Dsymbol *PostBlitDeclaration::syntaxCopy(Dsymbol *s)
 {
     assert(!s);
-    PostBlitDeclaration *dd = new PostBlitDeclaration(loc, endloc, ident);
+    PostBlitDeclaration *dd = new PostBlitDeclaration(loc, endloc, storage_class, ident);
     return FuncDeclaration::syntaxCopy(dd);
 }
 

--- a/src/func.c
+++ b/src/func.c
@@ -3437,7 +3437,7 @@ int CtorDeclaration::addPostInvariant()
 
 #if DMDV2
 PostBlitDeclaration::PostBlitDeclaration(Loc loc, Loc endloc, StorageClass stc, Identifier *id)
-    : FuncDeclaration(loc, endloc, id ? id : Id::_postblit, stc, NULL)
+    : FuncDeclaration(loc, endloc, id, stc, NULL)
 {
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -245,11 +245,6 @@ Dsymbols *Parser::parseDeclDefs(int once)
                     s = parseCtor();
                 break;
 
-#if 0 // dead end, use this(this){} instead
-            case TOKassign:
-                s = parsePostBlit();
-                break;
-#endif
             case TOKtilde:
                 s = parseDtor();
                 break;
@@ -1061,26 +1056,6 @@ Dsymbol *Parser::parseCtor()
     tf = tf->addSTC(stc);
 
     CtorDeclaration *f = new CtorDeclaration(loc, 0, stc, tf);
-    parseContracts(f);
-    return f;
-}
-
-/*****************************************
- * Parse a postblit definition:
- *      =this() { body }
- * Current token is '='.
- */
-
-PostBlitDeclaration *Parser::parsePostBlit()
-{
-    Loc loc = this->loc;
-
-    nextToken();
-    check(TOKthis);
-    check(TOKlparen);
-    check(TOKrparen);
-
-    PostBlitDeclaration *f = new PostBlitDeclaration(loc, 0);
     parseContracts(f);
     return f;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -1014,7 +1014,7 @@ Dsymbol *Parser::parseCtor()
         nextToken();
         check(TOKrparen);
         StorageClass stc = parsePostfix();
-        PostBlitDeclaration *f = new PostBlitDeclaration(loc, 0, stc);
+        PostBlitDeclaration *f = new PostBlitDeclaration(loc, 0, stc, Id::_postblit);
         parseContracts(f);
         return f;
     }

--- a/src/parse.h
+++ b/src/parse.h
@@ -92,7 +92,6 @@ struct Parser : Lexer
     Condition *parseVersionCondition();
     Condition *parseStaticIfCondition();
     Dsymbol *parseCtor();
-    PostBlitDeclaration *parsePostBlit();
     DtorDeclaration *parseDtor();
     StaticCtorDeclaration *parseStaticCtor();
     StaticDtorDeclaration *parseStaticDtor();

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2325,6 +2325,30 @@ void test8356()
 }
 
 /**********************************/
+// 8475
+
+T func8475(T)(T x) @safe pure
+{
+    return T();
+}
+
+template X8475(bool something)
+{
+    struct XY
+    {
+        this(this) @safe pure {}
+        void func(XY x) @safe pure
+        {
+            XY y = x; //Error: see below
+            func8475(x);
+            func8475(y);
+        }
+    }
+}
+
+alias X8475!(true).XY Xtrue;
+
+/**********************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8475

In PostBlitDeclaration::syntaxCopy, storage_class should also be copied to new AST object.
It's a design failure of the signature in PostBlitDeclaration constructor, so merge two constructors into one.
