### PR TITLE
Fix issue 8714 Missing error message with circular use of CTFE

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -525,8 +525,10 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
     printf("\n********\nFuncDeclaration::interpret(istate = %p) %s\n", istate, toChars());
 #endif
     if (semanticRun == PASSsemantic3)
+    {
+        error("circular dependency. Functions cannot be interpreted while being compiled");
         return EXP_CANT_INTERPRET;
-
+    }
     if (semanticRun < PASSsemantic3 && scope)
     {
         /* Forward reference - we need to run semantic3 on this function.

--- a/src/template.c
+++ b/src/template.c
@@ -5150,7 +5150,12 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                      ea->op != TOKimport && ea->op != TOKtype &&
                      ea->op != TOKfunction && ea->op != TOKerror &&
                      ea->op != TOKthis && ea->op != TOKsuper)
+            {
+                int olderrs = global.errors;
                 ea = ea->ctfeInterpret();
+                if (global.errors != olderrs)
+                    ea = new ErrorExp();
+            }
             (*tiargs)[j] = ea;
             if (ea->op == TOKtype)
             {   ta = ea->type;

--- a/test/fail_compilation/diag8714.d
+++ b/test/fail_compilation/diag8714.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8714.d(1): Error: function diag8714.foo circular dependency in CTFE. Functions cannot be interpreted while being compiled
+fail_compilation/diag8714.d(1): Error: function diag8714.foo circular dependency. Functions cannot be interpreted while being compiled
 fail_compilation/diag8714.d(7):        called from here: foo("somestring")
 ---
 */

--- a/test/fail_compilation/diag8714.d
+++ b/test/fail_compilation/diag8714.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag8714.d(1): Error: function diag8714.foo circular dependency in CTFE. Functions cannot be interpreted while being compiled
+fail_compilation/diag8714.d(7):        called from here: foo("somestring")
+---
+*/
+
+#line 1
+string foo(string f)
+{
+    if (f == "somestring")
+    {
+        return "got somestring";
+    }
+    return bar!(foo("somestring"));
+}
+
+template bar(string s)
+{
+    enum bar = s;
+}


### PR DESCRIPTION
The error message was missing (in interpret.c), and the supplementary error was also spuriously repeated (in template.c).

http://d.puremagic.com/issues/show_bug.cgi?id=8714
