### PR TITLE
Tester cleanup

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -31,12 +31,15 @@
 #                        default: the make variable ARGS (see below)
 #
 #   POST_SCRIPT:         name of script to execute after test run
+#                        note: arguments to the script may be included after the name.
+#                              additionally, the name of the file that contains the output
+#                              of the compile/link/run steps is added as the last parameter.
 #                        default: (none)
 #
 #   REQUIRED_ARGS:       arguments to add to the $(DMD) command line
 #                        default: (none)
 #
-#  DISABLED:             text describing why the test is disabled (if empty, the test is
+#   DISABLED:            text describing why the test is disabled (if empty, the test is
 #                        considered to be enabled).
 #                        default: (none, enabled)
 

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -252,10 +252,10 @@ string execute(ref File f, string command, bool expectpass)
     auto filename = genTempFilename();
     scope(exit) removeIfExists(filename);
 
-    f.writeln(command);
     auto rc = system(command ~ " > " ~ filename ~ " 2>&1");
 
     string output = readText(filename);
+    f.writeln(command);
     f.write(output);
 
     if (WIFSIGNALED(rc))

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -334,12 +334,13 @@ int main(string[] args)
 
     foreach(i, c; combinations(testArgs.permuteArgs))
     {
-        string[] toCleanup;
-
         string test_app_dmd = test_app_dmd_base ~ to!string(i) ~ envData.exe;
 
         try
         {
+            string[] toCleanup;
+            scope(exit) foreach (file; toCleanup) collectException(std.file.remove(file));
+
             string compile_output;
             if (!testArgs.compileSeparately)
             {
@@ -408,10 +409,6 @@ int main(string[] args)
                 version (Windows) testArgs.postScript = "bash " ~ testArgs.postScript;
                 execute(f, testArgs.postScript, true);
             }
-
-            // cleanup
-            foreach (file; toCleanup)
-                collectException(std.file.remove(file));
 
             f.writeln();
 

--- a/test/runnable/extra-files/statictor-postscript.sh
+++ b/test/runnable/extra-files/statictor-postscript.sh
@@ -2,7 +2,7 @@
 
 # trim off the first line which contains the path of the file which differs between windows and non-windows
 # also trim off compiler debug message
-grep -v "runnable\|DEBUG" ${RESULTS_DIR}/runnable/statictor.d.out > ${RESULTS_DIR}/runnable/statictor.d.out.2
+grep -v "runnable\|DEBUG" $1 > ${RESULTS_DIR}/runnable/statictor.d.out.2
 
 diff --strip-trailing-cr runnable/extra-files/statictor.d.out ${RESULTS_DIR}/runnable/statictor.d.out.2
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Refactoring and fixes for output sloppiness exposed by @denis-sh's changes to std.stdio.File.

This set of changes has been tested with those changes applied to phobos.

As another side effect of this set of changes, tests don't need to disable arg permuting to also use a post scripts.  Each post script execution is on just one combinations output now.  That restriction wasn't documented anywhere, but I did update the minimal docs in the Makefile.

None of the other post scripts currently look at the run's output, just at side effect files (like profile results, json, html, etc).
