### PR TITLE
Use D_LP64 for tests that aren't X86/X86_64 specific.

### DIFF
--- a/test/runnable/bitops.d
+++ b/test/runnable/bitops.d
@@ -9,12 +9,10 @@ void test1()
 {   
     size_t array[2];
     uint x;
-version (X86)
-    size_t bitToUse = 35;
-else version (X86_64)
+version (D_LP64)
     size_t bitToUse = 67;
 else
-    static assert(0);
+    size_t bitToUse = 35;
 
     array[0] = 2;
     array[1] = 0x100;

--- a/test/runnable/test11.d
+++ b/test/runnable/test11.d
@@ -93,12 +93,10 @@ void test4()
 {
     byte* p;
 
-    version(X86)
-        assert(p.sizeof == 4);
-    else version(X86_64)
+    version(D_LP64)
         assert(p.sizeof == 8);
     else
-        assert(false, "unknown platform");
+        assert(p.sizeof == 4);
 }
 
 

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -683,18 +683,16 @@ class Qwert32
     void foo()
     {
         printf("yuiop = %d, asdfg = %d\n", Qwert32.yuiop.offsetof, Qwert32.asdfg.offsetof);
-        version(X86)
-        {
-            assert(Qwert32.yuiop.offsetof == 8);
-            assert(Qwert32.asdfg.offsetof == 12);
-        }
-        else version (X86_64)
+        version(D_LP64)
         {
             assert(Qwert32.yuiop.offsetof == 16);
             assert(Qwert32.asdfg.offsetof == 20);
         }
         else
-            assert(0);
+        {
+            assert(Qwert32.yuiop.offsetof == 8);
+            assert(Qwert32.asdfg.offsetof == 12);
+        }
     }
 }
 
@@ -780,12 +778,10 @@ void test36()
     printf("%d\n", a.c);
     printf("%d\n", a.d);
 
-    version(X86)
-        assert(a.classinfo.init.length == 28);
-    else version(X86_64)
+    version(D_LP64)
         assert(a.classinfo.init.length == 36);
     else
-        assert(0);
+        assert(a.classinfo.init.length == 28);
     assert(a.s == 1);
     assert(a.a == 2);
     assert(a.b == 3);


### PR DESCRIPTION
Spoke to alexrp, and he admitted he didn't sweep the testsuite for these cases when he did phobos/druntime fix-up.
