### PR TITLE
Remove redundant memalignsize check.

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -260,8 +260,6 @@ unsigned AggregateDeclaration::placeField(
             ;
         else if (8 < memalignsize)
             memalignsize = 8;
-        else if (alignment < memalignsize)
-            memalignsize = alignment;
     }
     else
     {


### PR DESCRIPTION
The full diff in view is:

```
     if (alignment == STRUCTALIGN_DEFAULT)
     {
         if (global.params.is64bit && memalignsize == 16)
             ;
         else if (8 < memalignsize)
             memalignsize = 8;
-        else if (alignment < memalignsize)
-            memalignsize = alignment;
     }
     else
     {
         if (memalignsize < alignment)
             memalignsize = alignment;
     }
```

The bottom part is redundant code (if alignment == ~(0),  then it can never be < memalignsize).
