### PR TITLE
Allow small deviation in builtin tests

### DIFF
--- a/test/runnable/builtin.d
+++ b/test/runnable/builtin.d
@@ -11,19 +11,22 @@ void test1()
     auto f = 6.8L;
     writefln("%a", sin(f));
     assert(sin(f) == sin(6.8));
-    static assert(sin(6.8) == 0x1.f9f8d9aea10fdf1cp-2);
+    static assert(sin(6.8) - 0x1.f9f8d9aea10fdf1cp-2 <= real.epsilon
+        && sin(6.8) - 0x1.f9f8d9aea10fdf1cp-2 >= -real.epsilon);
 
     writefln("%a", cos(6.8));
     f = 6.8L;
     writefln("%a", cos(f));
     assert(cos(f) == cos(6.8));
-    static assert(cos(6.8) == 0x1.bd21aaf88dcfa13ap-1);
+    static assert(cos(6.8) - 0x1.bd21aaf88dcfa13ap-1 <= real.epsilon
+        && cos(6.8) - 0x1.bd21aaf88dcfa13ap-1 >= -real.epsilon);
 
     writefln("%a", tan(6.8));
     f = 6.8L;
     writefln("%a", tan(f));
     assert(tan(f) == tan(6.8));
-    static assert(tan(6.8) == 0x1.22fd752af75cd08cp-1);
+    static assert(tan(6.8) - 0x1.22fd752af75cd08cp-1 <= real.epsilon
+        && tan(6.8) - 0x1.22fd752af75cd08cp-1 >= -real.epsilon);
 }
 
 /*******************************************/


### PR DESCRIPTION
On systems where real is just an alias for double (e.g. ARM) the exact literal values might not be representable, so allow a deviation of real.epsilon.
