### PR TITLE
Use va_arg instead of platform specific cast

### DIFF
--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -594,7 +594,7 @@ void test30()
 
 void foo31(...)
 {
-    byte b = *cast(byte*)_argptr;
+    byte b = va_arg!byte(_argptr);
     assert(b == 8);
 }
 

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -208,7 +208,7 @@ struct TestStruct
 {
 	void add(...)
 	{
-		TestStruct other = *cast(TestStruct*)(_argptr);
+		TestStruct other = va_arg!TestStruct(_argptr);
 		foreach(int value; other)
 		{
 			foo();


### PR DESCRIPTION
On ARM (EABI), va_list and therefore _argptr is not a pointer and the pointer casts will fail.

(If those test were meant to actually check for x86 specific behaviour, let me know and I'll add version blocks instead of using va_arg)
