### PR TITLE
Allow out-of-source testsuite builds.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -156,24 +156,24 @@ $(addsuffix .sh.out,$(addprefix $(RESULTS_DIR)/runnable/,$(DISABLED_SH_TESTS))):
 	$(QUIET) echo " ... $@ - disabled"
 
 $(RESULTS_DIR)/runnable/%.d.out: runnable/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
-	$(QUIET) ./$(RESULTS_DIR)/d_do_test $(<D) $* d
+	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d
 
 $(RESULTS_DIR)/runnable/%.sh.out: runnable/%.sh $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
 	$(QUIET) echo " ... $(<D)/$*.sh"
 	$(QUIET) ./$(<D)/$*.sh
 
 $(RESULTS_DIR)/compilable/%.d.out: compilable/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
-	$(QUIET) ./$(RESULTS_DIR)/d_do_test $(<D) $* d
+	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d
 
 $(RESULTS_DIR)/compilable/%.sh.out: compilable/%.sh $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
 	$(QUIET) echo " ... $(<D)/$*.sh"
 	$(QUIET) ./$(<D)/$*.sh
 
 $(RESULTS_DIR)/fail_compilation/%.d.out: fail_compilation/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
-	$(QUIET) ./$(RESULTS_DIR)/d_do_test $(<D) $* d
+	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d
 
 $(RESULTS_DIR)/fail_compilation/%.html.out: fail_compilation/%.html $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test $(DMD)
-	$(QUIET) ./$(RESULTS_DIR)/d_do_test $(<D) $* html
+	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* html
 
 quick:
 	$(MAKE) ARGS="" run_tests

--- a/test/compilable/ddoc1.d
+++ b/test/compilable/ddoc1.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 1
 // REQUIRED_ARGS: -d
 

--- a/test/compilable/ddoc10.d
+++ b/test/compilable/ddoc10.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 10
 
 // 294

--- a/test/compilable/ddoc10325.d
+++ b/test/compilable/ddoc10325.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 10325
 
 module ddoc10325;

--- a/test/compilable/ddoc11.d
+++ b/test/compilable/ddoc11.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 11
 
 /// The various floating point exceptions

--- a/test/compilable/ddoc12.d
+++ b/test/compilable/ddoc12.d
@@ -1,5 +1,5 @@
 ﻿// PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 12
 
 int ruhred; /// This documents correctly.

--- a/test/compilable/ddoc13.d
+++ b/test/compilable/ddoc13.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 13
 
 /// struct doc

--- a/test/compilable/ddoc14.d
+++ b/test/compilable/ddoc14.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 14
 
 

--- a/test/compilable/ddoc2.d
+++ b/test/compilable/ddoc2.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 2
 
 /**

--- a/test/compilable/ddoc2273.d
+++ b/test/compilable/ddoc2273.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 2273
 // REQUIRED_ARGS: -m32
 

--- a/test/compilable/ddoc3.d
+++ b/test/compilable/ddoc3.d
@@ -1,6 +1,6 @@
 // EXTRA_SOURCES: extra-files/ddoc3.ddoc
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 3
 
 /**

--- a/test/compilable/ddoc4.d
+++ b/test/compilable/ddoc4.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 4
 
 /**

--- a/test/compilable/ddoc4162.d
+++ b/test/compilable/ddoc4162.d
@@ -1,5 +1,5 @@
 ﻿// PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 4162
 
 ///

--- a/test/compilable/ddoc5.d
+++ b/test/compilable/ddoc5.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 5
 
 /**

--- a/test/compilable/ddoc5446.d
+++ b/test/compilable/ddoc5446.d
@@ -1,5 +1,5 @@
 ﻿// PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 5446
 module ddoc5446;
 import ddoc5446a;

--- a/test/compilable/ddoc5446a.d
+++ b/test/compilable/ddoc5446a.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 module ddoc5446a;
 
 /** */

--- a/test/compilable/ddoc5446b.d
+++ b/test/compilable/ddoc5446b.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 module ddoc5446b;
 
 /** */

--- a/test/compilable/ddoc6.d
+++ b/test/compilable/ddoc6.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 6
 
 /**

--- a/test/compilable/ddoc6491.d
+++ b/test/compilable/ddoc6491.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 6491
 
 module ddoc6491;

--- a/test/compilable/ddoc7.d
+++ b/test/compilable/ddoc7.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 7
 
 //-----------------------------------------------

--- a/test/compilable/ddoc7795.d
+++ b/test/compilable/ddoc7795.d
@@ -1,5 +1,5 @@
 ﻿// PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 7795
 
 module ddoc7795;

--- a/test/compilable/ddoc8.d
+++ b/test/compilable/ddoc8.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 8
 
 /** foo */

--- a/test/compilable/ddoc8271.d
+++ b/test/compilable/ddoc8271.d
@@ -1,5 +1,5 @@
 ﻿// PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 8271
 
 module ddoc8271;

--- a/test/compilable/ddoc8739.d
+++ b/test/compilable/ddoc8739.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 8739
 
 module ddoc8739;

--- a/test/compilable/ddoc9.d
+++ b/test/compilable/ddoc9.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9
 
 // 273

--- a/test/compilable/ddoc9037.d
+++ b/test/compilable/ddoc9037.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9037
 
 module ddoc9037;

--- a/test/compilable/ddoc9155.d
+++ b/test/compilable/ddoc9155.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9155
 
 module ddoc9155;

--- a/test/compilable/ddoc9305.d
+++ b/test/compilable/ddoc9305.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9305
 
 module ddoc9305;

--- a/test/compilable/ddoc9369.d
+++ b/test/compilable/ddoc9369.d
@@ -1,6 +1,6 @@
 // PERMUTE_ARGS:
 // EXTRA_SOURCES: /extra-files/ddoc9369.ddoc
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9369
 
 /**

--- a/test/compilable/ddoc9475.d
+++ b/test/compilable/ddoc9475.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -w -o- -c -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -w -o- -c -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9475
 
 module ddoc9475;

--- a/test/compilable/ddoc9676a.d
+++ b/test/compilable/ddoc9676a.d
@@ -1,6 +1,6 @@
 // PERMUTE_ARGS:
 // EXTRA_SOURCES: /extra-files/ddoc9676a.ddoc
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9676a
 
 module ddoc9676a;

--- a/test/compilable/ddoc9676b.d
+++ b/test/compilable/ddoc9676b.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9676b
 
 module ddoc9676b;

--- a/test/compilable/ddoc9727.d
+++ b/test/compilable/ddoc9727.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9727
 module ddoc9727;
 

--- a/test/compilable/ddoc9789.d
+++ b/test/compilable/ddoc9789.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -w -o- -c -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -w -o- -c -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9789
 
 module ddoc9789;

--- a/test/compilable/ddoc9903.d
+++ b/test/compilable/ddoc9903.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9903
 
 /// sss

--- a/test/compilable/ddocYear.d
+++ b/test/compilable/ddocYear.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocYear-postscript.sh
 
 /// $(YEAR)

--- a/test/compilable/ddocunittest.d
+++ b/test/compilable/ddocunittest.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS: -unittest
-// REQUIRED_ARGS: -D -w -o- -c -Ddtest_results/compilable -o-
+// REQUIRED_ARGS: -D -w -o- -c -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh unittest
 
 module ddocunittest;

--- a/test/compilable/header.d
+++ b/test/compilable/header.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS: -dw
-// REQUIRED_ARGS: -H -Hdtest_results/compilable
+// REQUIRED_ARGS: -H -Hd${RESULTS_DIR}/compilable
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh
 // REQUIRED_ARGS: -d
 

--- a/test/compilable/inlineheader.d
+++ b/test/compilable/inlineheader.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -H -Hdtest_results/compilable -inline
+// REQUIRED_ARGS: -H -Hd${RESULTS_DIR}/compilable -inline
 // POST_SCRIPT: compilable/extra-files/inlineheader-postscript.sh
 // REQUIRED_ARGS: -d
 

--- a/test/compilable/inlinexheader.d
+++ b/test/compilable/inlinexheader.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -H -Hdtest_results/compilable -inline
+// REQUIRED_ARGS: -H -Hd${RESULTS_DIR}/compilable -inline
 // POST_SCRIPT: compilable/extra-files/inlinexheader-postscript.sh
 
 // for D 2.0 only

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -o- -X -Xftest_results/compilable/json.out
+// REQUIRED_ARGS: -o- -X -Xf${RESULTS_DIR}/compilable/json.out
 // POST_SCRIPT: compilable/extra-files/json-postscript.sh
 
 module json;

--- a/test/compilable/test7754.d
+++ b/test/compilable/test7754.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -H -Hdtest_results/compilable
+// REQUIRED_ARGS: -H -Hd${RESULTS_DIR}/compilable
 // POST_SCRIPT: compilable/extra-files/test7754-postscript.sh
 // PERMUTE_ARGS: -d -dw
 

--- a/test/compilable/xheader.d
+++ b/test/compilable/xheader.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -H -Hdtest_results/compilable
+// REQUIRED_ARGS: -H -Hd${RESULTS_DIR}/compilable
 // POST_SCRIPT: compilable/extra-files/xheader-postscript.sh
 
 // for D 2.0 only

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -143,6 +143,13 @@ bool findOutputParameter(string file, string token, out string result, string se
     return found;
 }
 
+void replaceResultsDir(ref string arguments, const ref EnvData envData)
+{
+    // Bash would expand this automatically on Posix, but we need to manually
+    // perform the replacement for Windows compatibility.
+    arguments = replace(arguments, "${RESULTS_DIR}", envData.results_dir);
+}
+
 void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_file, const ref EnvData envData)
 {
     string file = cast(string)std.file.read(input_file);
@@ -150,6 +157,7 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     findTestParameter(file, "REQUIRED_ARGS", testArgs.requiredArgs);
     if(envData.required_args.length)
         testArgs.requiredArgs ~= " " ~ envData.required_args;
+    replaceResultsDir(testArgs.requiredArgs, envData);
 
     if (! findTestParameter(file, "PERMUTE_ARGS", testArgs.permuteArgs))
     {
@@ -160,6 +168,7 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
         if(!findTestParameter(file, "unittest", unittestJunk))
             testArgs.permuteArgs = replace(testArgs.permuteArgs, "-unittest", "");
     }
+    replaceResultsDir(testArgs.permuteArgs, envData);
 
     // win(32|64) doesn't support pic, nor does freebsd/64 currently
     if (envData.os == "win32" || envData.os == "win64" || envData.os == "freebsd")
@@ -173,6 +182,7 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     testArgs.permuteArgs = strip(replace(testArgs.permuteArgs, "  ", " "));
 
     findTestParameter(file, "EXECUTE_ARGS", testArgs.executeArgs);
+    replaceResultsDir(testArgs.executeArgs, envData);
 
     string extraSourcesStr;
     findTestParameter(file, "EXTRA_SOURCES", extraSourcesStr);

--- a/test/runnable/a20.d
+++ b/test/runnable/a20.d
@@ -2,13 +2,14 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -cov
 // POST_SCRIPT: runnable/extra-files/a20-postscript.sh
+// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
 
 import a20a;
 
 extern(C) void dmd_coverDestPath(string path);
 
-void main()
+void main(string[] args)
 {
-    dmd_coverDestPath("test_results/runnable");
+    dmd_coverDestPath(args[1]);
 }
 

--- a/test/runnable/bug9010.d
+++ b/test/runnable/bug9010.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS: 
 // POST_SCRIPT: runnable/extra-files/bug9010-postscript.sh 
 // REQUIRED_ARGS: -cov 
+// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
  
 struct A
 {
@@ -13,9 +14,9 @@ struct A
 
 extern(C) void dmd_coverDestPath(string pathname); 
 
-void main()
+void main(string[] args)
 {
-    dmd_coverDestPath("test_results/runnable"); 
+    dmd_coverDestPath(args[1]);
 
     auto a = A();
     auto b = A();

--- a/test/runnable/cov2.d
+++ b/test/runnable/cov2.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // POST_SCRIPT: runnable/extra-files/cov2-postscript.sh
 // REQUIRED_ARGS: -cov
+// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
 
 extern(C) void dmd_coverDestPath(string pathname);
 
@@ -8,8 +9,6 @@ extern(C) void dmd_coverDestPath(string pathname);
 
 void test1()
 {
-    dmd_coverDestPath("test_results/runnable");
-
     int counter = 20;
     do {
         --counter;
@@ -43,8 +42,9 @@ void test2()
 
 /***************************************************/
 
-int main()
+int main(string[] args)
 {
+    dmd_coverDestPath(args[1]);
     test1();
     test2();
     return 0;

--- a/test/runnable/extra-files/hello-profile.d.trace.def
+++ b/test/runnable/extra-files/hello-profile.d.trace.def
@@ -1,3 +1,3 @@
 
 FUNCTIONS
-	_D5hello8showargsFAAaZv
+	_D5hello8showargsFAAyaZv

--- a/test/runnable/extra-files/runnable-a20.lst
+++ b/test/runnable/extra-files/runnable-a20.lst
@@ -2,13 +2,14 @@
        |// PERMUTE_ARGS:
        |// REQUIRED_ARGS: -cov
        |// POST_SCRIPT: runnable/extra-files/a20-postscript.sh
+       |// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
        |
        |import a20a;
        |
        |extern(C) void dmd_coverDestPath(string path);
        |
-       |void main()
+       |void main(string[] args)
        |{
-      1|    dmd_coverDestPath("test_results/runnable");
+      1|    dmd_coverDestPath(args[1]);
        |}
        |

--- a/test/runnable/extra-files/runnable-bug9010.lst
+++ b/test/runnable/extra-files/runnable-bug9010.lst
@@ -1,6 +1,7 @@
        |// PERMUTE_ARGS: 
        |// POST_SCRIPT: runnable/extra-files/bug9010-postscript.sh 
        |// REQUIRED_ARGS: -cov 
+       |// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
        | 
        |struct A
        |{
@@ -13,9 +14,9 @@
        |
        |extern(C) void dmd_coverDestPath(string pathname); 
        |
-       |void main()
+       |void main(string[] args)
        |{
-      1|    dmd_coverDestPath("test_results/runnable"); 
+      1|    dmd_coverDestPath(args[1]);
        |
       1|    auto a = A();
       1|    auto b = A();

--- a/test/runnable/extra-files/runnable-cov2.lst
+++ b/test/runnable/extra-files/runnable-cov2.lst
@@ -1,6 +1,7 @@
        |// PERMUTE_ARGS:
        |// POST_SCRIPT: runnable/extra-files/cov2-postscript.sh
        |// REQUIRED_ARGS: -cov
+       |// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
        |
        |extern(C) void dmd_coverDestPath(string pathname);
        |
@@ -8,8 +9,6 @@
        |
        |void test1()
        |{
-      1|    dmd_coverDestPath("test_results/runnable");
-       |
       1|    int counter = 20;
        |    do {
      20|        --counter;
@@ -43,8 +42,9 @@
        |
        |/***************************************************/
        |
-       |int main()
+       |int main(string[] args)
        |{
+      1|    dmd_coverDestPath(args[1]);
       1|    test1();
       1|    test2();
       1|    return 0;

--- a/test/runnable/extra-files/runnable-sieve.lst
+++ b/test/runnable/extra-files/runnable-sieve.lst
@@ -1,6 +1,7 @@
        |// PERMUTE_ARGS:
        |// REQUIRED_ARGS: -cov
        |// POST_SCRIPT: runnable/extra-files/sieve-postscript.sh
+       |// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
        |
        |/* Eratosthenes Sieve prime number calculation. */
        |
@@ -38,10 +39,10 @@
        |
        |extern(C) void dmd_coverDestPath(string path);
        |
-       |int main()
+       |int main(string[] args)
        |{
        |
-      1|    dmd_coverDestPath("test_results/runnable/");
+      1|    dmd_coverDestPath(args[1]);
        |
       1|    sieve();
        |

--- a/test/runnable/hello-profile.d
+++ b/test/runnable/hello-profile.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS: 
 // REQUIRED_ARGS: -profile
 // POST_SCRIPT: runnable/extra-files/hello-profile-postscript.sh
+// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
 
 module hello;
 
@@ -11,7 +12,7 @@ extern(C)
     int trace_setdeffilename(string name);
 }
 
-void showargs(char[][] args)
+void showargs(string[] args)
 {
     printf("hello world\n");
     printf("args.length = %d\n", args.length);
@@ -19,10 +20,10 @@ void showargs(char[][] args)
 	printf("args[%d] = '%.*s'\n", i, args[i].length, args[i].ptr);
 }
 
-int main(char[][] args)
+int main(string[] args)
 {
-    trace_setlogfilename("test_results/runnable/hello-profile.d.trace.log");
-    trace_setdeffilename("test_results/runnable/hello-profile.d.trace.def");
+    trace_setlogfilename(args[1] ~ "/hello-profile.d.trace.log");
+    trace_setdeffilename(args[1] ~ "/hello-profile.d.trace.def");
 
     showargs(args);
 

--- a/test/runnable/sieve.d
+++ b/test/runnable/sieve.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -cov
 // POST_SCRIPT: runnable/extra-files/sieve-postscript.sh
+// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
 
 /* Eratosthenes Sieve prime number calculation. */
 
@@ -38,10 +39,10 @@ int sieve()
 
 extern(C) void dmd_coverDestPath(string path);
 
-int main()
+int main(string[] args)
 {
 
-    dmd_coverDestPath("test_results/runnable/");
+    dmd_coverDestPath(args[1]);
 
     sieve();
 

--- a/test/runnable/test2.sh
+++ b/test/runnable/test2.sh
@@ -21,7 +21,7 @@ for x in "${a[@]}"; do
         exit 1
     fi
 
-    ./${dir}/test2 >> ${output_file}
+    ${dir}/test2 >> ${output_file}
     if [ $? -ne 0 ]; then
         cat ${output_file}
         rm -f ${output_file}

--- a/test/runnable/test35.sh
+++ b/test/runnable/test35.sh
@@ -27,7 +27,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-./${dir}/test35 >> ${output_file}
+${dir}/test35 >> ${output_file}
 if [ $? -ne 0 ]; then
     cat ${output_file}
     rm -f ${output_file}

--- a/test/runnable/test39.sh
+++ b/test/runnable/test39.sh
@@ -40,7 +40,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-./${dir}/test39 >> ${output_file}
+${dir}/test39 >> ${output_file}
 if [ $? -ne 0 ]; then
     cat ${output_file}
     rm -f ${output_file}

--- a/test/runnable/testzip.d
+++ b/test/runnable/testzip.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// EXECUTE_ARGS: runnable/extra-files/testzip.zip test_results/runnable/testzip-out.zip
+// EXECUTE_ARGS: runnable/extra-files/testzip.zip ${RESULTS_DIR}/runnable/testzip-out.zip
 // POST_SCRIPT: runnable/extra-files/testzip-postscript.sh
 
 import std.c.stdio;


### PR DESCRIPTION
Previously, "./" was prefixed to $RESULTS_DIR in several places, while $RESULTS_DIR == "test_result" was assumed in others.

This is useful for integrating the DMD test suite with the build system of other projects, e.g. LDC (via https://github.com/ldc-developers/dmd-testsuite).
