### PR TITLE
Issue 8744 - Fixed printing of uint expression when value >= 2^31

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2225,7 +2225,7 @@ void IntegerExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
             case Tuns32:
             L3:
-                buf->printf("%du", (unsigned)v);
+                buf->printf("%uu", (unsigned)v);
                 break;
 
             case Tint64:

--- a/test/compilable/extra-files/header.di
+++ b/test/compilable/extra-files/header.di
@@ -20,7 +20,7 @@ int i = cast(int)f;
 writeln((i , 1),2);
 writeln(cast(int)(float).max);
 assert(i == cast(int)(float).max);
-assert(i == -2147483648u);
+assert(i == 2147483648u);
 return 0;
 }
 template Foo(T,int V)


### PR DESCRIPTION
It fixes the IntegerExp::toCBuffer() handling of uints. Previously it treated uints as ints. For example pragma(msg, uint.max) printed "-1u". Now it correctly prints "4294967295u".

http://d.puremagic.com/issues/show_bug.cgi?id=8744
