### PR TITLE
8741 wrong code for struct member inititalited using struct ctor

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7922,6 +7922,17 @@ Lagain:
         {
             ad = ((TypeStruct *)t1)->sym;
 #if DMDV2
+
+            if (ad->sizeok == SIZEOKnone && !ad->ctor &&
+                ad->search(0, Id::ctor, 0))
+            {
+                // The constructor hasn't been found yet, see bug 8741
+                // This can happen if we are inferring type from
+                // from VarDeclaration::semantic() in declaration.c
+                error("cannot create a struct until its size is determined");
+                return new ErrorExp();
+            }
+
             // First look for constructor
             if (e1->op == TOKtype && ad->ctor && (ad->noDefaultCtor || arguments && arguments->dim))
             {

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1166,6 +1166,7 @@ void test45()
 }
 
 /**********************************/
+// 3986
 
 struct SiberianHamster
 {
@@ -1177,6 +1178,26 @@ void test46()
 {
    SiberianHamster basil = "cybil";
    assert(basil.rat == 813);
+}
+
+/**********************************/
+// 8741
+
+struct Vec8741
+{
+    this(float x)
+    {
+        m[0] = x;
+        m[1] = 58;
+    }
+    float[2] m;
+    static Vec8741 zzz = Vec8741(7);
+}
+
+void test8741()
+{
+    assert(Vec8741.zzz.m[0] == 7);
+    assert(Vec8741.zzz.m[1] == 58);
 }
 
 /**********************************/
@@ -2413,6 +2434,7 @@ int main()
     test59();
     test5737();
     test6119();
+    test8741();
     test6364();
     test6499();
     test60();


### PR DESCRIPTION
Generate an error if we need to decide if it is a ctor or a struct literal, when we haven't determined the size yet (so that we don't know if if it has a constructor). Since this whole thing is happening in a trySemantic block, it will try again later when it has found the ctor, and at that point, it will compile without error.

The wording for the error message is not very good, but I think this only happens while errors are gagged, so the message will never be visible.
