### PR TITLE
fix Issue 8575 - Lambda expression causes compilation error with template function

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2089,11 +2089,7 @@ Objects *Parser::parseTemplateArgumentList2()
             else
             {   // Template argument is an expression
                 Expression *ea = parseAssignExp();
-
-                if (ea->op == TOKfunction && ((FuncExp *)ea)->td)
-                    tiargs->push(((FuncExp *)ea)->td);
-                else
-                    tiargs->push(ea);
+                tiargs->push(ea);
             }
             if (token.value != TOKcomma)
                 break;

--- a/src/template.c
+++ b/src/template.c
@@ -427,6 +427,7 @@ Dsymbol *TemplateDeclaration::syntaxCopy(Dsymbol *)
         e = constraint->syntaxCopy();
     Dsymbols *d = Dsymbol::arraySyntaxCopy(members);
     td = new TemplateDeclaration(loc, ident, p, e, d, ismixin);
+    td->literal = literal;
     return td;
 }
 
@@ -5177,6 +5178,13 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                     fe->fd->tok = TOKfunction;
                     fe->fd->vthis = NULL;
                 }
+                else if (fe->td)
+                {   /* If template argument is a template lambda,
+                     * get template declaration itself. */
+                    ea = NULL;
+                    (*tiargs)[j] = sa = fe->td;
+                    goto Lsa;
+                }
             }
             if (ea->op == TOKtuple)
             {   // Expand tuple
@@ -5193,6 +5201,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
         }
         else if (sa)
         {
+		Lsa:
             TemplateDeclaration *td = sa->isTemplateDeclaration();
             if (td && !td->semanticRun && td->literal)
                 td->semantic(sc);

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -661,6 +661,26 @@ void test8397()
 }
 
 /***************************************************/
+// 8575
+
+template tfunc8575(func...)
+{
+    auto tfunc8575(U)(U u) { return func[0](u); }
+}
+auto bar8575(T)(T t)
+{
+    return tfunc8575!(a => a)(t);
+}
+void foo8575a() { assert(bar8575(uint.init + 1) == +1); }
+void foo8575b() { assert(bar8575( int.init - 1) == -1); }
+
+void test8575()
+{
+    foo8575a();
+    foo8575b();
+}
+
+/***************************************************/
 
 int main()
 {
@@ -699,6 +719,7 @@ int main()
     test8242();
     test8315();
     test8397();
+    test8575();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8575

Template lambda (e.g. `a => a`) is an expression, so we should keep `FuncExp` until actually starting instantiation of passed template instance.
