### PR TITLE
Issue 8753 - Too aggressive expansion for variables which have void initializer

### DIFF
--- a/src/optimize.c
+++ b/src/optimize.c
@@ -71,6 +71,12 @@ Expression *expandVar(int result, VarDeclaration *v)
                         v->error("recursive initialization of constant");
                     goto L1;
                 }
+                if (!(result & WANTinterpret) &&
+                    !(v->storage_class & STCmanifest) &&
+                    v->init->isVoidInitializer())
+                {   // don't expand void initializer if it's not necessary
+                    goto L1;
+                }
                 Expression *ei = v->init->toExpression();
                 if (!ei)
                 {   if (v->storage_class & STCmanifest)

--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -564,6 +564,20 @@ void test8400()
 }
 
 /************************************/
+// 8753
+
+void test8753()
+{
+    static assert(is(typeof({
+        int mx = void;
+        const int cx = void;
+        immutable int ix = void;
+        mx = cx;
+        mx = ix;
+    })));
+}
+
+/************************************/
 
 int main()
 {
@@ -572,6 +586,7 @@ int main()
     test3();
     test6077();
     test8400();
+    test8753();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8753
