### PR TITLE
Fixed time_t definition.

### DIFF
--- a/test/runnable/pi.d
+++ b/test/runnable/pi.d
@@ -1,12 +1,8 @@
 // PERMUTE_ARGS:
 // EXECUTE_ARGS: 1000
 
-extern(C)
-{
-    int printf(const char*, ...);
-    int sscanf(const char*, const char*, ...);
-    int time(int*);
-}
+import core.stdc.stdio;
+import core.stdc.time;
 
 const int LONG_TIME=4000;
 
@@ -16,7 +12,7 @@ int q;
 
 int main(char[][] args)
 {
-	int startime, endtime;
+	time_t startime, endtime;
 	int i;
 
 	if (args.length == 2) {
@@ -60,7 +56,7 @@ int main(char[][] args)
 	for (i = 1; i <= q; i++)
 	printf("%d",cast(int)(p[i]));
 	printf("\n");
-	printf("%ld seconds to compute pi with a precision of %d digits.\n",endtime-startime,q);
+	printf("%lld seconds to compute pi with a precision of %d digits.\n", cast(long)(endtime-startime),q);
 
 	return 0;
 }


### PR DESCRIPTION
This was causing test suite failures with ldc2 -O3 -release.

As noted in the comment, `time_t` is actually just 32 bit on older Windows runtimes and 32 bit Linux systems, but it shouldn't cause any troubles, and a correct fix is way too much work (without pulling in any of druntime, ...) for an unimportant detail in a test case.
