### PR TITLE
Some more cleanups/fixes to deprecation() (and warning() and error()) usage

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -432,8 +432,7 @@ void escapeStrayParenthesis(OutBuffer *buf, unsigned start, Loc loc)
                 if (par_open == 0)
                 {
                     //stray ')'
-                    if (global.params.warnings)
-                        warning(loc, "Ddoc: Stray ')'. This may cause incorrect Ddoc output."
+                    warning(loc, "Ddoc: Stray ')'. This may cause incorrect Ddoc output."
                         " Use $(RPAREN) instead for unpaired right parentheses.");
                     buf->remove(u, 1); //remove the )
                     buf->insert(u, "$(RPAREN)", 9); //insert this instead
@@ -468,8 +467,7 @@ void escapeStrayParenthesis(OutBuffer *buf, unsigned start, Loc loc)
                     if (par_open == 0)
                     {
                         //stray '('
-                        if (global.params.warnings)
-                            warning(loc, "Ddoc: Stray '('. This may cause incorrect Ddoc output."
+                        warning(loc, "Ddoc: Stray '('. This may cause incorrect Ddoc output."
                             " Use $(LPAREN) instead for unpaired left parentheses.");
                         buf->remove(u, 1); //remove the (
                         buf->insert(u, "$(LPAREN)", 9); //insert this instead

--- a/src/expression.c
+++ b/src/expression.c
@@ -5129,7 +5129,7 @@ Expression *VarExp::modifiableLvalue(Scope *sc, Expression *e)
 
 #if (BUG6652 == 1)
     VarDeclaration *v = var->isVarDeclaration();
-    if (v && (v->storage_class & STCbug6652) && global.params.warnings)
+    if (v && (v->storage_class & STCbug6652))
         warning("Variable modified in foreach body requires ref storage class");
 #elif (BUG6652 == 2)
     VarDeclaration *v = var->isVarDeclaration();

--- a/src/expression.c
+++ b/src/expression.c
@@ -5130,7 +5130,7 @@ Expression *VarExp::modifiableLvalue(Scope *sc, Expression *e)
 #if (BUG6652 == 1)
     VarDeclaration *v = var->isVarDeclaration();
     if (v && (v->storage_class & STCbug6652))
-        warning("Variable modified in foreach body requires ref storage class");
+        warning("variable modified in foreach body requires ref storage class");
 #elif (BUG6652 == 2)
     VarDeclaration *v = var->isVarDeclaration();
     if (v && (v->storage_class & STCbug6652) && !global.params.useDeprecated)

--- a/src/expression.c
+++ b/src/expression.c
@@ -10243,24 +10243,6 @@ Expression *AssignExp::semantic(Scope *sc)
                 e = e->semantic(sc);
                 return e;
             }
-#if 0 // Turned off to allow rewriting (a[i]=value) to (a.opIndex(i)=value)
-            else
-            {
-                // Rewrite (a[i] = value) to (a.opIndex(i, value))
-                if (search_function(ad, id))
-                {   Expression *e = new DotIdExp(loc, ae->e1, id);
-
-                    if (1 || !global.params.useDeprecated)
-                    {   error("operator [] assignment overload with opIndex(i, value) illegal, use opIndexAssign(value, i)");
-                        return new ErrorExp();
-                    }
-
-                    e = new CallExp(loc, e, (*ae->arguments)[0], e2);
-                    e = e->semantic(sc);
-                    return e;
-                }
-            }
-#endif
         }
 
         // No opIndexAssign found yet, but there might be an alias this to try.

--- a/src/expression.c
+++ b/src/expression.c
@@ -5133,8 +5133,8 @@ Expression *VarExp::modifiableLvalue(Scope *sc, Expression *e)
         warning("variable modified in foreach body requires ref storage class");
 #elif (BUG6652 == 2)
     VarDeclaration *v = var->isVarDeclaration();
-    if (v && (v->storage_class & STCbug6652) && !global.params.useDeprecated)
-        error("Variable modified in foreach body requires ref storage class");
+    if (v && (v->storage_class & STCbug6652))
+        deprecation("variable modified in foreach body requires ref storage class");
 #endif
 
     checkModifiable(sc);
@@ -5536,7 +5536,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                         (s2 = scx->scopesym->symtab->lookup(s->ident)) != NULL &&
                         s != s2)
                     {
-                        error("shadowing declaration %s is not allowed", s->toPrettyChars());
+                        deprecation("shadowing declaration %s is deprecated", s->toPrettyChars());
                         return new ErrorExp();
                     }
                 }
@@ -9126,11 +9126,8 @@ Expression *CastExp::semantic(Scope *sc)
             return new VectorExp(loc, e1, to);
         }
 
-        if (tob->isintegral() && t1b->ty == Tarray &&
-            !global.params.useDeprecated)
-        {
-            error("casting %s to %s is deprecated", e1->type->toChars(), to->toChars());
-        }
+        if (tob->isintegral() && t1b->ty == Tarray)
+            deprecation("casting %s to %s is deprecated", e1->type->toChars(), to->toChars());
     }
     else if (!to)
     {   error("cannot cast tuple");

--- a/src/func.c
+++ b/src/func.c
@@ -480,8 +480,8 @@ void FuncDeclaration::semantic(Scope *sc)
 
                 doesoverride = TRUE;
 #if DMDV2
-                if (!isOverride() && !global.params.useDeprecated)
-                    ::error(loc, "overriding base class function without using override attribute is deprecated (%s overrides %s)", toPrettyChars(), fdv->toPrettyChars());
+                if (!isOverride())
+                    ::deprecation(loc, "overriding base class function without using override attribute is deprecated (%s overrides %s)", toPrettyChars(), fdv->toPrettyChars());
 #endif
 
                 FuncDeclaration *fdc = ((Dsymbol *)cd->vtbl.data[vi])->isFuncDeclaration();

--- a/src/parse.c
+++ b/src/parse.c
@@ -753,8 +753,7 @@ StorageClass Parser::parseTypeCtor()
         {
             case TOKconst:              stc |= STCconst;                break;
             case TOKinvariant:
-                if (!global.params.useDeprecated)
-                    error("use of 'invariant' rather than 'immutable' is deprecated");
+                deprecation("use of 'invariant' rather than 'immutable' is deprecated");
             case TOKimmutable:          stc |= STCimmutable;            break;
             case TOKshared:             stc |= STCshared;               break;
             case TOKwild:               stc |= STCwild;                 break;

--- a/src/parse.c
+++ b/src/parse.c
@@ -3754,9 +3754,7 @@ Statement *Parser::parseStatement(int flags)
             if (!(flags & PSsemi_ok))
             {
                 if (flags & PSsemi)
-                {   if (global.params.warnings)
-                        warning(loc, "use '{ }' for an empty statement, not a ';'");
-                }
+                    warning(loc, "use '{ }' for an empty statement, not a ';'");
                 else
                     error("use '{ }' for an empty statement, not a ';'");
             }

--- a/src/scope.c
+++ b/src/scope.c
@@ -255,8 +255,7 @@ Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym)
             s = sc->scopesym->search(loc, ident, 0);
             if (s)
             {
-                if ((global.params.warnings ||
-                    global.params.Dversion > 1) &&
+                if (global.params.Dversion > 1 &&
                     ident == Id::length &&
                     sc->scopesym->isArrayScopeSymbol() &&
                     sc->enclosing &&

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -809,15 +809,12 @@ void ClassDeclaration::toObjFile(int multiobj)
                         continue;
                     if (fd->leastAsSpecialized(fd2) || fd2->leastAsSpecialized(fd))
                     {
-                        if (!global.params.useDeprecated)
-                        {
-                            TypeFunction *tf = (TypeFunction *)fd->type;
-                            if (tf->ty == Tfunction)
-                                error("use of %s%s hidden by %s is not allowed", fd->toPrettyChars(),
-                                      Parameter::argsTypesToChars(tf->parameters, tf->varargs), toChars());
-                            else
-                                error("use of %s hidden by %s is not allowed", fd->toPrettyChars(), toChars());
-                        }
+                        TypeFunction *tf = (TypeFunction *)fd->type;
+                        if (tf->ty == Tfunction)
+                            deprecation("use of %s%s hidden by %s is deprecated", fd->toPrettyChars(),
+                                    Parameter::argsTypesToChars(tf->parameters, tf->varargs), toChars());
+                        else
+                            deprecation("use of %s hidden by %s is deprecated", fd->toPrettyChars(), toChars());
                         s = rtlsym[RTLSYM_DHIDDENFUNC];
                         break;
                     }

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -633,19 +633,13 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
             dtxoff(pdt, fd->toSymbol(), 0, TYnptr);
             TypeFunction *tf = (TypeFunction *)fd->type;
             assert(tf->ty == Tfunction);
-            if (global.params.warnings)
-            {
-                /* I'm a little unsure this is the right way to do it. Perhaps a better
-                 * way would to automatically add these attributes to any struct member
-                 * function with the name "toHash".
-                 * So I'm leaving this here as an experiment for the moment.
-                 */
-                if (!tf->isnothrow || tf->trust == TRUSTsystem /*|| tf->purity == PUREimpure*/)
-                {   warning(fd->loc, "toHash() must be declared as extern (D) uint toHash() const nothrow @safe, not %s", tf->toChars());
-                    if (global.params.warnings == 1)
-                        global.errors++;
-                }
-            }
+            /* I'm a little unsure this is the right way to do it. Perhaps a better
+             * way would to automatically add these attributes to any struct member
+             * function with the name "toHash".
+             * So I'm leaving this here as an experiment for the moment.
+             */
+            if (!tf->isnothrow || tf->trust == TRUSTsystem /*|| tf->purity == PUREimpure*/)
+                warning(fd->loc, "toHash() must be declared as extern (D) uint toHash() const nothrow @safe, not %s", tf->toChars());
         }
         else
         {


### PR DESCRIPTION
Just more cleanups and fixes related to the new deprecation() function and error handling in general.

Also fixes a small regression introduced by #908 (see https://github.com/D-Programming-Language/dmd/pull/908#discussion_r1781383 for details).
