### PR TITLE
 Use (u)longlong instead of (u)intmax_t

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -121,11 +121,11 @@ const char *Token::toChars()
             break;
 
         case TOKint64v:
-            sprintf(buffer,"%lldL",(intmax_t)int64value);
+            sprintf(buffer,"%lldL",(longlong)int64value);
             break;
 
         case TOKuns64v:
-            sprintf(buffer,"%lluUL",(uintmax_t)uns64value);
+            sprintf(buffer,"%lluUL",(ulonglong)uns64value);
             break;
 
 #ifdef IN_GCC


### PR DESCRIPTION
Since VC doesn't support C99 (inttypes.h), using format specifiers for
(u)intmax_t is very tricky. This patch canges the cast to (u)longlong
instead, so we can safely use "%llu"/"%lld".
