### PR TITLE
Issue 8794 - Add DDOC_ANCHOR macro for qualified anchor links

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -793,9 +793,16 @@ static bool emitAnchorName(OutBuffer *buf, Dsymbol *s)
         return dot;
     if (dot)
         buf->writeByte('.');
-    /* We just want the identifier, not overloads like TemplateDeclaration::toChars.
-     * We don't want the template parameter list and constraints. */
-    buf->writestring(s->Dsymbol::toChars());
+    // Use "this" not "__ctor"
+    if (s->isCtorDeclaration() || ((td = s->isTemplateDeclaration()) != NULL &&
+        td->onemember && td->onemember->isCtorDeclaration()))
+        buf->writestring("this");
+    else
+    {
+        /* We just want the identifier, not overloads like TemplateDeclaration::toChars.
+         * We don't want the template parameter list and constraints. */
+        buf->writestring(s->Dsymbol::toChars());
+    }
     return true;
 }
 

--- a/src/doc.c
+++ b/src/doc.c
@@ -102,7 +102,7 @@ unsigned skiptoident(OutBuffer *buf, size_t i);
 unsigned skippastident(OutBuffer *buf, size_t i);
 unsigned skippastURL(OutBuffer *buf, size_t i);
 void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset);
-void highlightCode(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset);
+void highlightCode(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset, bool anchor = true);
 void highlightCode2(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset);
 Parameter *isFunctionParameter(Dsymbol *s, unsigned char *p, unsigned len);
 
@@ -1351,7 +1351,7 @@ void ParamSection::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
                     else
                         buf->write(namestart, namelen);
                     escapeStrayParenthesis(buf, o, s->loc);
-                    highlightCode(sc, s, buf, o);
+                    highlightCode(sc, s, buf, o, false);
                 buf->writestring(")\n");
 
                 buf->writestring("$(DDOC_PARAM_DESC ");
@@ -2048,14 +2048,16 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
  * Highlight code for DDOC section.
  */
 
-void highlightCode(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset)
+void highlightCode(Scope *sc, Dsymbol *s, OutBuffer *buf, unsigned offset, bool anchor)
 {
-    OutBuffer ancbuf;
-    
-    emitAnchor(&ancbuf, s);
-    buf->insert(offset, (char*)ancbuf.data, ancbuf.offset);
-    offset += ancbuf.offset;
+    if (anchor)
+    {
+        OutBuffer ancbuf;
 
+        emitAnchor(&ancbuf, s);
+        buf->insert(offset, (char *)ancbuf.data, ancbuf.offset);
+        offset += ancbuf.offset;
+    }
     char *sid = s->ident->toChars();
     FuncDeclaration *f = s->isFuncDeclaration();
 

--- a/test/compilable/extra-files/ddoc1.html
+++ b/test/compilable/extra-files/ddoc1.html
@@ -6,11 +6,11 @@
 This module is for ABC
 <br><br>
 
-<dl><dt><big>alias <u>myint</u>;
+<dl><dt><big><a name="myint"></a>alias <u>myint</u>;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>myint <u>f</u>;
+<dt><big><a name="f"></a>myint <u>f</u>;
 </big></dt>
 <dd>windy
  city
@@ -27,29 +27,29 @@ paragraph 2 about of F
 1998<br><br>
 
 </dd>
-<dt><big>enum <u>E</u>;
+<dt><big><a name="E"></a>enum <u>E</u>;
 </big></dt>
 <dd>comment1<br><br>
 
 </dd>
-<dt><big>int <u>g</u>;
+<dt><big><a name="g"></a>int <u>g</u>;
 </big></dt>
 <dd>comment2<br><br>
 
 </dd>
-<dt><big>wchar <u>LS</u>;
+<dt><big><a name="LS"></a>wchar <u>LS</u>;
 </big></dt>
 <dd>UTF line separator<br><br>
 
 </dd>
-<dt><big>wchar <u>PS</u>;
-<br>wchar <u>_XX</u>;
-<br>wchar <u>YY</u>;
+<dt><big><a name="PS"></a>wchar <u>PS</u>;
+<br><a name="_XX"></a>wchar <u>_XX</u>;
+<br><a name="YY"></a>wchar <u>YY</u>;
 </big></dt>
 <dd>UTF paragraph separator<br><br>
 
 </dd>
-<dt><big>int <u>foo</u>(char <i>c</i>, int <i>argulid</i>, char <i>u</i>);
+<dt><big><a name="foo"></a>int <u>foo</u>(char <i>c</i>, int <i>argulid</i>, char <i>u</i>);
 </big></dt>
 <dd>Function <u>foo</u> takes argument <i>c</i> and adds it to <i>argulid</i>.
 <br><br>
@@ -65,45 +65,45 @@ Then it munges <i>argulid</i>, <i>u</i> <u>underline</u>. <!-- c, argulid, b -->
 </table><br>
 
 </dd>
-<dt><big>int <u>barr</u>();
+<dt><big><a name="barr"></a>int <u>barr</u>();
 </big></dt>
 <dd>doc for <u>barr</u>()<br><br>
 
 </dd>
-<dt><big>class <u>Bar</u>;
+<dt><big><a name="Bar"></a>class <u>Bar</u>;
 </big></dt>
 <dd>The Class <u>Bar</u> <br><br>
 
-<dl><dt><big>int <u>x</u>;
+<dl><dt><big><a name="Bar.x"></a>int <u>x</u>;
 </big></dt>
 <dd>member X<br><br>
 
 </dd>
-<dt><big>int <u>y</u>;
+<dt><big><a name="Bar.y"></a>int <u>y</u>;
 </big></dt>
 <dd>member Y<br><br>
 
 </dd>
-<dt><big>protected int <u>z</u>;
+<dt><big><a name="Bar.z"></a>protected int <u>z</u>;
 </big></dt>
 <dd>member Z<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>enum <u>Easy</u>;
+<dt><big><a name="Easy"></a>enum <u>Easy</u>;
 </big></dt>
 <dd>The Enum <u>Easy</u> <br><br>
 
-<dl><dt><big><u>red</u></big></dt>
+<dl><dt><big><a name="Easy.red"></a><u>red</u></big></dt>
 <dd>the Red<br><br>
 
 </dd>
-<dt><big><u>blue</u></big></dt>
+<dt><big><a name="Easy.blue"></a><u>blue</u></big></dt>
 <dd>the Blue<br><br>
 
 </dd>
-<dt><big><u>green</u></big></dt>
+<dt><big><a name="Easy.green"></a><u>green</u></big></dt>
 <dd>the Green<br><br>
 
 </dd>

--- a/test/compilable/extra-files/ddoc10.html
+++ b/test/compilable/extra-files/ddoc10.html
@@ -4,123 +4,123 @@
         </head><body>
         <h1>ddoc10</h1>
 <br><br>
-<dl><dt><big>struct <u>Foo</u>(T);
-<br>struct <u>Foo</u>(T,U);
+<dl><dt><big><a name="Foo"></a>struct <u>Foo</u>(T);
+<br><a name="Foo"></a>struct <u>Foo</u>(T,U);
 </big></dt>
 <dd>The foo<br><br>
 
 </dd>
-<dt><big>int <u>func1</u>(T)(T <i>x</i>);
+<dt><big><a name="func1"></a>int <u>func1</u>(T)(T <i>x</i>);
 </big></dt>
 <dd>This basic case doesn't work very well. The template signature is
  documented twice, but the function signature (argument names and return
  type) is not documented at all. This comment is also repeated twice. <br><br>
 
 </dd>
-<dt><big>int <u>func2</u>(T, U)(T <i>x</i>, U <i>y</i>);
-<br>int <u>func2</u>(T)(T <i>x</i>);
+<dt><big><a name="func2"></a>int <u>func2</u>(T, U)(T <i>x</i>, U <i>y</i>);
+<br><a name="func2"></a>int <u>func2</u>(T)(T <i>x</i>);
 </big></dt>
 <dd>This comment is also repeated twice, and the second function signature is
  not very well documented. <br><br>
 
 </dd>
-<dt><big>int <u>func3</u>(T, U)(T <i>x</i>, U <i>y</i>);
-<br>int <u>func3</u>(T, U = int, V : long)(T <i>x</i>);
+<dt><big><a name="func3"></a>int <u>func3</u>(T, U)(T <i>x</i>, U <i>y</i>);
+<br><a name="func3"></a>int <u>func3</u>(T, U = int, V : long)(T <i>x</i>);
 </big></dt>
 <dd>This used to work adequately and documented both <u>func3</u> templates
  simultaneously. Now, it documents the first template twice and
  no longer documents the function argument and return types.<br><br>
 
 </dd>
-<dt><big>void <u>map</u>(char <i>rs</i>);
-<br>void <u>map</u>(int <i>rs</i>);
+<dt><big><a name="map"></a>void <u>map</u>(char <i>rs</i>);
+<br><a name="map"></a>void <u>map</u>(int <i>rs</i>);
 </big></dt>
 <dd>blah<br><br>
 
 </dd>
-<dt><big>void <u>map2</u>()(char <i>rs</i>);
-<br>void <u>map2</u>()(int <i>rs</i>);
+<dt><big><a name="map2"></a>void <u>map2</u>()(char <i>rs</i>);
+<br><a name="map2"></a>void <u>map2</u>()(int <i>rs</i>);
 </big></dt>
 <dd>blah<br><br>
 
 </dd>
-<dt><big>void <u>map3</u>(char <i>rs</i>);
+<dt><big><a name="map3"></a>void <u>map3</u>(char <i>rs</i>);
 </big></dt>
 <dd>blah http://www.map3.com <u>map3</u><br><br>
 
 </dd>
-<dt><big>void <u>map4</u>(string s)(char <i>rs</i>);
+<dt><big><a name="map4"></a>void <u>map4</u>(string s)(char <i>rs</i>);
 </big></dt>
 <dd>blah http://www.map.com map<br><br>
 
 </dd>
-<dt><big>template <u>map5</u>(string s)</big></dt>
+<dt><big><a name="map5"></a>template <u>map5</u>(string s)</big></dt>
 <dd>blah http://www.map.com map<br><br>
 
 </dd>
-<dt><big>struct <u>bar6</u>;
+<dt><big><a name="bar6"></a>struct <u>bar6</u>;
 </big></dt>
 <dd>blah <br><br>
 
 </dd>
-<dt><big>struct <u>Foo7</u>(T);
+<dt><big><a name="Foo7"></a>struct <u>Foo7</u>(T);
 </big></dt>
 <dd>template bodies <br><br>
 
-<dl><dt><big>void <u>bar</u>();
+<dl><dt><big><a name="bar"></a>void <u>bar</u>();
 </big></dt>
 <dd>Attempt two:  Inside.
 Attempt one:  Doc outside static if.<br><br>
 
 </dd>
-<dt><big>void <u>abc</u>();
+<dt><big><a name="abc"></a>void <u>abc</u>();
 </big></dt>
 <dd>the <u>abc</u> function should be static <br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>abstract class <u>Foo8</u>;
+<dt><big><a name="Foo8"></a>abstract class <u>Foo8</u>;
 </big></dt>
 <dd>show abstract <br><br>
 
 </dd>
-<dt><big>void <u>bug4878</u>(string <i>a</i> = ")");
+<dt><big><a name="bug4878"></a>void <u>bug4878</u>(string <i>a</i> = ")");
 </big></dt>
 <dd><i>a</i> stray ) mustn't foul the macros<br><br>
 
 </dd>
-<dt><big>struct <u>S</u>;
+<dt><big><a name="S"></a>struct <u>S</u>;
 </big></dt>
 <dd><br><br>
-<dl><dt><big>const pure nothrow  this(long <i>ticks</i>);
+<dl><dt><big><a name="S.this"></a>const pure nothrow  this(long <i>ticks</i>);
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>const pure nothrow void <u>foo</u>(long <i>ticks</i>);
+<dt><big><a name="S.foo"></a>const pure nothrow void <u>foo</u>(long <i>ticks</i>);
 </big></dt>
 <dd><br><br>
 </dd>
 </dl>
 </dd>
-<dt><big>float <u>f10</u>(float <i>a</i>, float <i>b</i>);
+<dt><big><a name="f10"></a>float <u>f10</u>(float <i>a</i>, float <i>b</i>);
 </big></dt>
 <dd>Produces something in (<i>a</i>;<i>b</i>] <br><br>
 
 </dd>
-<dt><big>float <u>h10</u>(float <i>a</i>, float <i>b</i>);
+<dt><big><a name="h10"></a>float <u>h10</u>(float <i>a</i>, float <i>b</i>);
 </big></dt>
 <dd>Produces something in [<i>a</i>;<i>b</i>) <br><br>
 
 </dd>
-<dt><big>void <u>bug6090</u>(string f = "$(B b)", char g = ')')(string <i>h</i> = "$(", string <i>i</i> = "$)");
+<dt><big><a name="bug6090"></a>void <u>bug6090</u>(string f = "$(B b)", char g = ')')(string <i>h</i> = "$(", string <i>i</i> = "$)");
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>struct <u>T</u>;
+<dt><big><a name="T"></a>struct <u>T</u>;
 </big></dt>
 <dd><br><br>
-<dl><dt><big>this(A...)(A <i>args</i>);
+<dl><dt><big><a name="T.this"></a> this(A...)(A <i>args</i>);
 </big></dt>
 <dd><br><br>
 </dd>

--- a/test/compilable/extra-files/ddoc11.html
+++ b/test/compilable/extra-files/ddoc11.html
@@ -4,79 +4,79 @@
         </head><body>
         <h1>ddoc11</h1>
 <br><br>
-<dl><dt><big><u>FE_INVALID</u></big></dt>
+<dl><dt><big><a name="FE_INVALID"></a><u>FE_INVALID</u></big></dt>
 <dd><br><br>
 </dd>
-<dt><big><u>FE_DENORMAL</u></big></dt>
+<dt><big><a name="FE_DENORMAL"></a><u>FE_DENORMAL</u></big></dt>
 <dd><br><br>
 </dd>
-<dt><big><u>FE_DIVBYZERO</u></big></dt>
+<dt><big><a name="FE_DIVBYZERO"></a><u>FE_DIVBYZERO</u></big></dt>
 <dd><br><br>
 </dd>
-<dt><big><u>FE_OVERFLOW</u></big></dt>
+<dt><big><a name="FE_OVERFLOW"></a><u>FE_OVERFLOW</u></big></dt>
 <dd><br><br>
 </dd>
-<dt><big><u>FE_UNDERFLOW</u></big></dt>
+<dt><big><a name="FE_UNDERFLOW"></a><u>FE_UNDERFLOW</u></big></dt>
 <dd><br><br>
 </dd>
-<dt><big><u>FE_INEXACT</u></big></dt>
+<dt><big><a name="FE_INEXACT"></a><u>FE_INEXACT</u></big></dt>
 <dd><br><br>
 </dd>
-<dt><big><u>FE_ALL_EXCEPT</u></big></dt>
+<dt><big><a name="FE_ALL_EXCEPT"></a><u>FE_ALL_EXCEPT</u></big></dt>
 <dd>Mask of all the exceptions<br><br>
 
 </dd>
-<dt><big>myint <u>bar</u>;
+<dt><big><a name="bar"></a>myint <u>bar</u>;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>myint <u>foo</u>(myint <i>x</i> = (int).max);
+<dt><big><a name="foo"></a>myint <u>foo</u>(myint <i>x</i> = (int).max);
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>class <u>Foo</u>;
+<dt><big><a name="Foo"></a>class <u>Foo</u>;
 </big></dt>
 <dd><br><br>
-<dl><dt><big>this(string <i>s</i>);
+<dl><dt><big><a name="Foo.this"></a> this(string <i>s</i>);
 </big></dt>
 <dd><br><br>
 </dd>
 </dl>
 </dd>
-<dt><big>struct <u>div_t</u>;
+<dt><big><a name="div_t"></a>struct <u>div_t</u>;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>struct <u>ldiv_t</u>;
+<dt><big><a name="ldiv_t"></a>struct <u>ldiv_t</u>;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>struct <u>lldiv_t</u>;
+<dt><big><a name="lldiv_t"></a>struct <u>lldiv_t</u>;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>div_t <u>div</u>(int, int);
+<dt><big><a name="div"></a>div_t <u>div</u>(int, int);
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>ldiv_t <u>ldiv</u>(int, int);
+<dt><big><a name="ldiv"></a>ldiv_t <u>ldiv</u>(int, int);
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>lldiv_t <u>lldiv</u>(long, long);
+<dt><big><a name="lldiv"></a>lldiv_t <u>lldiv</u>(long, long);
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>void* <u>calloc</u>(size_t, size_t);
+<dt><big><a name="calloc"></a>void* <u>calloc</u>(size_t, size_t);
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big>void* <u>malloc</u>(size_t);
+<dt><big><a name="malloc"></a>void* <u>malloc</u>(size_t);
 </big></dt>
 <dd>dittx<br><br>
 
 </dd>
-<dt><big>void <u>test1</u>();
+<dt><big><a name="test1"></a>void <u>test1</u>();
 </big></dt>
 <dd><b>Example:</b><br>
 <pre class="d_code"><font color=blue>private</font>:

--- a/test/compilable/extra-files/ddoc12.html
+++ b/test/compilable/extra-files/ddoc12.html
@@ -4,17 +4,17 @@
         </head><body>
         <h1>ddoc12</h1>
 <br><br>
-<dl><dt><big>int <u>ruhred</u>;
+<dl><dt><big><a name="ruhred"></a>int <u>ruhred</u>;
 </big></dt>
 <dd>This documents correctly.<br><br>
 
 </dd>
-<dt><big>int <u>rühred</u>;
+<dt><big><a name="rühred"></a>int <u>rühred</u>;
 </big></dt>
 <dd>This should too<br><br>
 
 </dd>
-<dt><big>int <u>foo</u>(int <i>ü</i>, int <i>ş</i>, int <i>ğ</i>);
+<dt><big><a name="foo"></a>int <u>foo</u>(int <i>ü</i>, int <i>ş</i>, int <i>ğ</i>);
 </big></dt>
 <dd><b>BUG:</b><br>
 The parameters are not listed under Params in the generated output

--- a/test/compilable/extra-files/ddoc13.html
+++ b/test/compilable/extra-files/ddoc13.html
@@ -4,34 +4,34 @@
         </head><body>
         <h1>ddoc13</h1>
 <br><br>
-<dl><dt><big>struct <u>Bug4107</u>(T);
+<dl><dt><big><a name="Bug4107"></a>struct <u>Bug4107</u>(T);
 </big></dt>
 <dd>struct doc<br><br>
 
-<dl><dt><big>void <u>foo</u>(U)(U <i>u</i>);
+<dl><dt><big><a name="foo"></a>void <u>foo</u>(U)(U <i>u</i>);
 </big></dt>
 <dd>templated function doc<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>struct <u>Bug4107b</u>(T);
+<dt><big><a name="Bug4107b"></a>struct <u>Bug4107b</u>(T);
 </big></dt>
 <dd>alpha<br><br>
 
-<dl><dt><big>struct <u>B</u>(U);
+<dl><dt><big><a name="B"></a>struct <u>B</u>(U);
 </big></dt>
 <dd>beta<br><br>
 
-<dl><dt><big>struct <u>C</u>(V);
+<dl><dt><big><a name="C"></a>struct <u>C</u>(V);
 </big></dt>
 <dd>gamma<br><br>
 
-<dl><dt><big>struct <u>D</u>(W);
+<dl><dt><big><a name="D"></a>struct <u>D</u>(W);
 </big></dt>
 <dd>delta<br><br>
 
-<dl><dt><big>B!(W) <u>e</u>(X)(C!(V) <i>c</i>, X[] <i>x</i>...);
+<dl><dt><big><a name="e"></a>B!(W) <u>e</u>(X)(C!(V) <i>c</i>, X[] <i>x</i>...);
 </big></dt>
 <dd>epsilon<br><br>
 

--- a/test/compilable/extra-files/ddoc14.html
+++ b/test/compilable/extra-files/ddoc14.html
@@ -4,149 +4,149 @@
         </head><body>
         <h1>ddoc14</h1>
 <br><br>
-<dl><dt><big>struct <u>Structure</u>;
+<dl><dt><big><a name="Structure"></a>struct <u>Structure</u>;
 </big></dt>
 <dd>-1<br><br>
 
-<dl><dt><big>P <u>variable</u>;
+<dl><dt><big><a name="Structure.variable"></a>P <u>variable</u>;
 </big></dt>
 <dd>0<br><br>
 
 </dd>
-<dt><big>V <u>mNone</u>(lazy P <i>p</i>);
+<dt><big><a name="Structure.mNone"></a>V <u>mNone</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>1<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mPrefix</u>(lazy P <i>p</i>);
+<dt><big><a name="Structure.mPrefix"></a>pure nothrow V <u>mPrefix</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>2<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mSuffix</u>(lazy P <i>p</i>);
+<dt><big><a name="Structure.mSuffix"></a>pure nothrow V <u>mSuffix</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>3<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mSuffixTemplate</u>(T)(lazy P <i>p</i>, T[] <i>t</i>...);
+<dt><big><a name="Structure.mSuffixTemplate"></a>pure nothrow V <u>mSuffixTemplate</u>(T)(lazy P <i>p</i>, T[] <i>t</i>...);
 </big></dt>
 <dd>5<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mScoped</u>(lazy P <i>p</i>);
+<dt><big><a name="Structure.mScoped"></a>pure nothrow V <u>mScoped</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>6<br><br>
 
 </dd>
-<dt><big>pure nothrow auto <u>mAutoPrefix</u>(ref P <i>p</i>);
+<dt><big><a name="Structure.mAutoPrefix"></a>pure nothrow auto <u>mAutoPrefix</u>(ref P <i>p</i>);
 </big></dt>
 <dd>7<br><br>
 
 </dd>
-<dt><big>pure nothrow auto <u>mAutoTemplateSuffix</u>(alias T)(ref T <i>t</i>);
+<dt><big><a name="Structure.mAutoTemplateSuffix"></a>pure nothrow auto <u>mAutoTemplateSuffix</u>(alias T)(ref T <i>t</i>);
 </big></dt>
 <dd>9<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mColon</u>(lazy P <i>p</i>);
+<dt><big><a name="Structure.mColon"></a>pure nothrow V <u>mColon</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>10<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>class <u>Class</u>;
+<dt><big><a name="Class"></a>class <u>Class</u>;
 </big></dt>
 <dd>-1<br><br>
 
-<dl><dt><big>P <u>variable</u>;
+<dl><dt><big><a name="Class.variable"></a>P <u>variable</u>;
 </big></dt>
 <dd>0<br><br>
 
 </dd>
-<dt><big>V <u>mNone</u>(lazy P <i>p</i>);
+<dt><big><a name="Class.mNone"></a>V <u>mNone</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>1<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mPrefix</u>(lazy P <i>p</i>);
+<dt><big><a name="Class.mPrefix"></a>pure nothrow V <u>mPrefix</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>2<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mSuffix</u>(lazy P <i>p</i>);
+<dt><big><a name="Class.mSuffix"></a>pure nothrow V <u>mSuffix</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>3<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mSuffixTemplate</u>(T)(lazy P <i>p</i>, T[] <i>t</i>...);
+<dt><big><a name="Class.mSuffixTemplate"></a>pure nothrow V <u>mSuffixTemplate</u>(T)(lazy P <i>p</i>, T[] <i>t</i>...);
 </big></dt>
 <dd>5<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mScoped</u>(lazy P <i>p</i>);
+<dt><big><a name="Class.mScoped"></a>pure nothrow V <u>mScoped</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>6<br><br>
 
 </dd>
-<dt><big>pure nothrow auto <u>mAutoPrefix</u>(ref P <i>p</i>);
+<dt><big><a name="Class.mAutoPrefix"></a>pure nothrow auto <u>mAutoPrefix</u>(ref P <i>p</i>);
 </big></dt>
 <dd>7<br><br>
 
 </dd>
-<dt><big>pure nothrow auto <u>mAutoTemplateSuffix</u>(alias T)(ref T <i>t</i>);
+<dt><big><a name="Class.mAutoTemplateSuffix"></a>pure nothrow auto <u>mAutoTemplateSuffix</u>(alias T)(ref T <i>t</i>);
 </big></dt>
 <dd>9<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mColon</u>(lazy P <i>p</i>);
+<dt><big><a name="Class.mColon"></a>pure nothrow V <u>mColon</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>10<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>P <u>variable</u>;
+<dt><big><a name="variable"></a>P <u>variable</u>;
 </big></dt>
 <dd>0<br><br>
 
 </dd>
-<dt><big>V <u>mNone</u>(lazy P <i>p</i>);
+<dt><big><a name="mNone"></a>V <u>mNone</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>1<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mPrefix</u>(lazy P <i>p</i>);
+<dt><big><a name="mPrefix"></a>pure nothrow V <u>mPrefix</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>2<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mSuffix</u>(lazy P <i>p</i>);
+<dt><big><a name="mSuffix"></a>pure nothrow V <u>mSuffix</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>3<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mSuffixTemplate</u>(T)(lazy P <i>p</i>, T[] <i>t</i>...);
+<dt><big><a name="mSuffixTemplate"></a>pure nothrow V <u>mSuffixTemplate</u>(T)(lazy P <i>p</i>, T[] <i>t</i>...);
 </big></dt>
 <dd>5<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mScoped</u>(lazy P <i>p</i>);
+<dt><big><a name="mScoped"></a>pure nothrow V <u>mScoped</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>6<br><br>
 
 </dd>
-<dt><big>pure nothrow auto <u>mAutoPrefix</u>(ref P <i>p</i>);
+<dt><big><a name="mAutoPrefix"></a>pure nothrow auto <u>mAutoPrefix</u>(ref P <i>p</i>);
 </big></dt>
 <dd>7<br><br>
 
 </dd>
-<dt><big>pure nothrow auto <u>mAutoTemplateSuffix</u>(alias T)(ref T <i>t</i>);
+<dt><big><a name="mAutoTemplateSuffix"></a>pure nothrow auto <u>mAutoTemplateSuffix</u>(alias T)(ref T <i>t</i>);
 </big></dt>
 <dd>9<br><br>
 
 </dd>
-<dt><big>pure nothrow V <u>mColon</u>(lazy P <i>p</i>);
+<dt><big><a name="mColon"></a>pure nothrow V <u>mColon</u>(lazy P <i>p</i>);
 </big></dt>
 <dd>10<br><br>
 

--- a/test/compilable/extra-files/ddoc2.html
+++ b/test/compilable/extra-files/ddoc2.html
@@ -20,11 +20,11 @@ Things to see also.
 
 	And more things.<br><br>
 
-<dl><dt><big>class <u>StreamException</u>: object.Exception;
+<dl><dt><big><a name="StreamException"></a>class <u>StreamException</u>: object.Exception;
 </big></dt>
 <dd>A base class for stream exceptions.<br><br>
 
-<dl><dt><big>this(string <i>msg</i>, int <i>foo</i>);
+<dl><dt><big><a name="StreamException.this"></a> this(string <i>msg</i>, int <i>foo</i>);
 </big></dt>
 <dd>Construct a StreamException with given error message <i>msg</i>.
 <br><br>
@@ -38,7 +38,7 @@ Things to see also.
 </table><br>
 
 </dd>
-<dt><big>int <u>stars</u>;
+<dt><big><a name="StreamException.stars"></a>int <u>stars</u>;
 </big></dt>
 <dd><u>stars</u> <br><br>
 

--- a/test/compilable/extra-files/ddoc3.html
+++ b/test/compilable/extra-files/ddoc3.html
@@ -40,11 +40,11 @@ Things to see also.
       <u>(</u>
   </pre><br><br>
 
-<dl><dt><big>class <u>StreamException</u>: object.Exception;
+<dl><dt><big><a name="StreamException"></a>class <u>StreamException</u>: object.Exception;
 </big></dt>
 <dd>A base class for stream exceptions.<br><br>
 
-<dl><dt><big>this(string <i>msg</i>, int <i>foo</i>);
+<dl><dt><big><a name="StreamException.this"></a> this(string <i>msg</i>, int <i>foo</i>);
 </big></dt>
 <dd>Construct a StreamException with given error message <i>msg</i>.
 <br><br>
@@ -58,7 +58,7 @@ Things to see also.
 </table><br>
 
 </dd>
-<dt><big>int <u>stars</u>;
+<dt><big><a name="StreamException.stars"></a>int <u>stars</u>;
 </big></dt>
 <dd><u>stars</u> <br><br>
 

--- a/test/compilable/extra-files/ddoc5.html
+++ b/test/compilable/extra-files/ddoc5.html
@@ -6,11 +6,11 @@
 Test module
 <br><br>
 
-<dl><dt><big>class <u>TestMembers</u>(TemplateArg);
+<dl><dt><big><a name="TestMembers"></a>class <u>TestMembers</u>(TemplateArg);
 </big></dt>
 <dd>class to test DDOC on members<br><br>
 
-<dl><dt><big>void <u>PublicStaticMethod</u>(int <i>idx</i>);
+<dl><dt><big><a name="PublicStaticMethod"></a>void <u>PublicStaticMethod</u>(int <i>idx</i>);
 </big></dt>
 <dd>a static method
 <br><br>

--- a/test/compilable/extra-files/ddoc6.html
+++ b/test/compilable/extra-files/ddoc6.html
@@ -4,7 +4,7 @@
         </head><body>
         <h1>ddoc6</h1>
 <br><br>
-<dl><dt><big>struct <u>MyStruct</u>(T);
+<dl><dt><big><a name="MyStruct"></a>struct <u>MyStruct</u>(T);
 </big></dt>
 <dd><br><br>
 </dd>

--- a/test/compilable/extra-files/ddoc6491.html
+++ b/test/compilable/extra-files/ddoc6491.html
@@ -4,7 +4,7 @@
         </head><body>
         <h1>ddoc6491</h1>
 <br><br>
-<dl><dt><big>void <u>bug6491a</u>(int <i>a</i> = ddoc6491.c6491, string <i>b</i> = core.cpuid.vendor);
+<dl><dt><big><a name="bug6491a"></a>void <u>bug6491a</u>(int <i>a</i> = ddoc6491.c6491, string <i>b</i> = core.cpuid.vendor);
 </big></dt>
 <dd>test<br><br>
 

--- a/test/compilable/extra-files/ddoc7.html
+++ b/test/compilable/extra-files/ddoc7.html
@@ -4,91 +4,91 @@
         </head><body>
         <h1>ddoc7</h1>
 <br><br>
-<dl><dt><big>enum <u>E1</u>;
+<dl><dt><big><a name="E1"></a>enum <u>E1</u>;
 </big></dt>
 <dd>my enum<br><br>
 
-<dl><dt><big><u>A</u></big></dt>
+<dl><dt><big><a name="E1.A"></a><u>A</u></big></dt>
 <dd>element a<br><br>
 
 </dd>
-<dt><big><u>B</u></big></dt>
+<dt><big><a name="E1.B"></a><u>B</u></big></dt>
 <dd>element b<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>enum <u>E2</u>;
+<dt><big><a name="E2"></a>enum <u>E2</u>;
 </big></dt>
 <dd>my enum<br><br>
 
-<dl><dt><big><u>A</u></big></dt>
+<dl><dt><big><a name="E2.A"></a><u>A</u></big></dt>
 <dd>element a<br><br>
 
 </dd>
-<dt><big><u>B</u></big></dt>
+<dt><big><a name="E2.B"></a><u>B</u></big></dt>
 <dd>element b<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>enum <u>E3</u>;
+<dt><big><a name="E3"></a>enum <u>E3</u>;
 </big></dt>
 <dd>my enum<br><br>
 
-<dl><dt><big><u>A</u></big></dt>
+<dl><dt><big><a name="E3.A"></a><u>A</u></big></dt>
 <dd>element a<br><br>
 
 </dd>
-<dt><big><u>B</u></big></dt>
+<dt><big><a name="E3.B"></a><u>B</u></big></dt>
 <dd>element b<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>enum <u>E4</u>;
+<dt><big><a name="E4"></a>enum <u>E4</u>;
 </big></dt>
 <dd>my enum<br><br>
 
-<dl><dt><big><u>A</u></big></dt>
+<dl><dt><big><a name="E4.A"></a><u>A</u></big></dt>
 <dd>element a<br><br>
 
 </dd>
-<dt><big><u>B</u></big></dt>
+<dt><big><a name="E4.B"></a><u>B</u></big></dt>
 <dd>element b<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>enum <u>E5</u>;
+<dt><big><a name="E5"></a>enum <u>E5</u>;
 </big></dt>
 <dd>my enum<br><br>
 
-<dl><dt><big><u>A</u></big></dt>
+<dl><dt><big><a name="E5.A"></a><u>A</u></big></dt>
 <dd>element a<br><br>
 
 </dd>
-<dt><big><u>B</u></big></dt>
+<dt><big><a name="E5.B"></a><u>B</u></big></dt>
 <dd>element b<br><br>
 
 </dd>
 </dl>
 </dd>
-<dt><big>void <u>foo</u>();
+<dt><big><a name="foo"></a>void <u>foo</u>();
 </big></dt>
 <dd>Some doc<br><br>
 
 </dd>
-<dt><big>alias <u>bar</u>;
+<dt><big><a name="bar"></a>alias <u>bar</u>;
 </big></dt>
 <dd>More doc<br><br>
 
 </dd>
-<dt><big>abstract class <u>C</u>;
+<dt><big><a name="C"></a>abstract class <u>C</u>;
 </big></dt>
 <dd>asdf<br><br>
 
-<dl><dt><big>abstract void <u>foo</u>();
+<dl><dt><big><a name="C.foo"></a>abstract void <u>foo</u>();
 </big></dt>
 <dd>Some doc<br><br>
 

--- a/test/compilable/extra-files/ddoc8.html
+++ b/test/compilable/extra-files/ddoc8.html
@@ -4,7 +4,7 @@
         </head><body>
         <h1>ddoc8</h1>
 <br><br>
-<dl><dt><big>class <u>Foo</u>(T): Bar;
+<dl><dt><big><a name="Foo"></a>class <u>Foo</u>(T): Bar;
 </big></dt>
 <dd>foo <br><br>
 

--- a/test/compilable/extra-files/ddoc9.html
+++ b/test/compilable/extra-files/ddoc9.html
@@ -4,26 +4,26 @@
         </head><body>
         <h1>ddoc9</h1>
 <br><br>
-<dl><dt><big>template <u>Template</u>(T)</big></dt>
+<dl><dt><big><a name="Template"></a>template <u>Template</u>(T)</big></dt>
 <dd><u>Template</u> Documentation (OK)<br><br>
 
 </dd>
-<dt><big>void <u>Function</u>(T)(T <i>x</i>);
+<dt><big><a name="Function"></a>void <u>Function</u>(T)(T <i>x</i>);
 </big></dt>
 <dd><u>Function</u> Documentation (Not included at all by DDoc)<br><br>
 
 </dd>
-<dt><big>class <u>Class</u>(T);
+<dt><big><a name="Class"></a>class <u>Class</u>(T);
 </big></dt>
 <dd><u>Class</u> Documentation (OK)<br><br>
 
 </dd>
-<dt><big>struct <u>Struct</u>(T);
+<dt><big><a name="Struct"></a>struct <u>Struct</u>(T);
 </big></dt>
 <dd><u>Struct</u> Documentation<br><br>
 
 </dd>
-<dt><big>union <u>Union</u>(T);
+<dt><big><a name="Union"></a>union <u>Union</u>(T);
 </big></dt>
 <dd><u>Union</u> Documentation<br><br>
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8794

Currently there is no way to generate qualified anchor links in DDoc output - i.e. `<a name="MyClass.myMember"></a>` rather than just `myMember`.

This pull request adds a new DDoc macro, `DDOC_ANCHOR`, which is expanded wherever a symbol declaration appears in the documentation. The qualified symbol name is passed as argument `$1`. This is in contrast to `DDOC_PSYMBOL`, which only passes the current identifier without any context, and does so wherever the symbol name occurs in the document output, including text descriptions.
