### PR TITLE
Enhancement 1353 - Can't use typeof() in base class list.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -1727,18 +1727,10 @@ BaseClasses *Parser::parseBaseClasses()
         }
         if (prot)
             deprecation("use of base class protection is deprecated");
-        if (token.value == TOKidentifier || token.value == TOKdot)
-        {
-            BaseClass *b = new BaseClass(parseBasicType(), protection);
-            baseclasses->push(b);
-            if (token.value != TOKcomma)
-                break;
-        }
-        else
-        {
-            error("base classes expected instead of %s", token.toChars());
-            return NULL;
-        }
+        BaseClass *b = new BaseClass(parseBasicType(), protection);
+        baseclasses->push(b);
+        if (token.value != TOKcomma)
+            break;
     }
     return baseclasses;
 }

--- a/test/compilable/test1353.d
+++ b/test/compilable/test1353.d
@@ -1,0 +1,14 @@
+
+class A {}
+interface B {}
+interface C {}
+interface D(X) {}
+
+void fun()
+{
+    class T : typeof(new A), .B, const(C), D!int {}
+    version(none)
+    {
+        class U : int, float, __vector(int[3]) {}
+    }
+}


### PR DESCRIPTION
Remove the restriction that a base class must being with an identifier (or a dot) and accept any type during passing.  The semantic checks give better error messages anyway.

(From Pull #1175)

While it will let really stupid base class choices pass to semantic, the error messages in those cases will improve signifigantly:
`class A : int {}`
results in:

```
test.d(2): Error: base classes expected instead of int
test.d(2): Error: members expected
test.d(2): Error: { } expected following aggregate declaration
test.d(2): Error: no identifier for declarator int
test.d(2): Error: semicolon expected, not '{'
test.d(2): Error: Declaration expected, not '{'
```

while

```
alias int Int;
class A : Int {}
```

results in:
`test.d(3): Error: class test.A base type must be class or interface, not int`

The downside is that some really silly types will not be rejected if the code doesn't go through semantic, such as code in templates that are not instantiated or code that is versioned out.  This is nothing new and applies to the vast majority of bugs.  The type used has to be _really_ silly, `int` currently fails at parse time while an alias to `int` makes it through to semantic.

http://d.puremagic.com/issues/show_bug.cgi?id=1353
