### PR TITLE
8788 super() can be bypassed using return

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8090,6 +8090,8 @@ Lagain:
                         error("constructor calls not allowed in loops or after labels");
                     if (sc->callSuper & (CSXsuper_ctor | CSXthis_ctor))
                         error("multiple constructor calls");
+                    if ((sc->callSuper & CSXreturn) && !(sc->callSuper & CSXany_ctor))
+                        error("an earlier return statement skips constructor");
                     sc->callSuper |= CSXany_ctor | CSXsuper_ctor;
                 }
 
@@ -8130,6 +8132,8 @@ Lagain:
                     error("constructor calls not allowed in loops or after labels");
                 if (sc->callSuper & (CSXsuper_ctor | CSXthis_ctor))
                     error("multiple constructor calls");
+                if ((sc->callSuper & CSXreturn) && !(sc->callSuper & CSXany_ctor))
+                    error("an earlier return statement skips constructor");
                 sc->callSuper |= CSXany_ctor | CSXthis_ctor;
             }
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -4009,13 +4009,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         }
     }
 
-    /* BUG: need to issue an error on:
-     *  this
-     *  {   if (x) return;
-     *      super();
-     *  }
-     */
-
+    // If any branches have called a ctor, but this branch hasn't, it's an error
     if (sc->callSuper & CSXany_ctor &&
         !(sc->callSuper & (CSXthis_ctor | CSXsuper_ctor)))
         error("return without calling constructor");

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -192,6 +192,110 @@ struct Foo1099 {
 }
 
 /**************************************************
+    8788 - super() and return
+**************************************************/
+
+class B8788 {
+        this ( ) { }
+}
+
+class C8788(int test) : B8788
+{
+    this ( int y )
+    {   // TESTS WHICH SHOULD PASS
+        static if (test == 1) {
+            if (y == 3) {
+                super();
+                return;
+            }
+            super();
+            return;
+        } else static if (test == 2) {
+            if (y == 3) {
+                super();
+                return;
+            }
+            super();
+        } else static if (test == 3) {
+            if (y > 3) {
+                if (y == 7) {
+                   super();
+                   return;
+                }
+                super();
+                return;
+            }
+            super();
+        } else static if (test == 4) {
+            if (y > 3) {
+                if (y == 7) {
+                   super();
+                   return;
+                }
+                else if (y> 5)
+                    super();
+                else super();
+                return;
+            }
+            super();
+        }
+        // TESTS WHICH SHOULD FAIL
+        else static if (test == 5) {
+            if (y == 3) {
+                super();
+                return;
+            }
+            return; // no super
+        } else static if (test == 6) {
+            if (y > 3) {
+                if (y == 7) {
+                   super();
+                   return;
+                }
+                super();
+            }
+            super(); // two calls
+        } else static if (test == 7) {
+            if (y == 3) {
+                return; // no super
+            }
+            super();
+        } else static if (test == 8) {
+            if (y > 3) {
+                if (y == 7) {
+                   return; // no super
+                }
+                super();
+                return;
+            }
+            super();
+        } else static if (test == 9) {
+            if (y > 3) {
+                if (y == 7) {
+                   super();
+                   return;
+                }
+                else if (y> 5)
+                    super();
+                else return; // no super
+                return;
+            }
+            super();
+        }
+    }
+}
+
+static assert( is(typeof( { new C8788!(1)(0); } )));
+static assert( is(typeof( { new C8788!(2)(0); } )));
+static assert( is(typeof( { new C8788!(3)(0); } )));
+static assert( is(typeof( { new C8788!(4)(0); } )));
+static assert(!is(typeof( { new C8788!(5)(0); } )));
+static assert(!is(typeof( { new C8788!(6)(0); } )));
+static assert(!is(typeof( { new C8788!(7)(0); } )));
+static assert(!is(typeof( { new C8788!(8)(0); } )));
+static assert(!is(typeof( { new C8788!(9)(0); } )));
+
+/**************************************************
     4967, 7058
 **************************************************/
 


### PR DESCRIPTION
Fixes the flow analysis by clearly distinguishing "ALL branches have called a
constructor" from "ANY branches have called a ctor".
There are a large number of special cases.
