### PR TITLE
Another fix for Issue 3144 - Invalid break accepted

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4091,7 +4091,6 @@ Statement *Parser::parseStatement(int flags)
 
         case TOKcase:
         {   Expression *exp;
-            Statements *statements;
             Expressions cases;        // array of Expression's
             Expression *last = NULL;
 
@@ -4119,15 +4118,20 @@ Statement *Parser::parseStatement(int flags)
             }
 #endif
 
-            statements = new Statements();
-            while (token.value != TOKcase &&
-                   token.value != TOKdefault &&
-                   token.value != TOKeof &&
-                   token.value != TOKrcurly)
+            if (flags & PScurlyscope)
             {
-                statements->push(parseStatement(PSsemi | PScurlyscope));
+                Statements *statements = new Statements();
+                while (token.value != TOKcase &&
+                       token.value != TOKdefault &&
+                       token.value != TOKeof &&
+                       token.value != TOKrcurly)
+                {
+                    statements->push(parseStatement(PSsemi | PScurlyscope));
+                }
+                s = new CompoundStatement(loc, statements);
             }
-            s = new CompoundStatement(loc, statements);
+            else
+                s = parseStatement(PSsemi | PScurlyscope);
             s = new ScopeStatement(loc, s);
 
 #if DMDV2
@@ -4150,20 +4154,23 @@ Statement *Parser::parseStatement(int flags)
 
         case TOKdefault:
         {
-            Statements *statements;
-
             nextToken();
             check(TOKcolon);
 
-            statements = new Statements();
-            while (token.value != TOKcase &&
-                   token.value != TOKdefault &&
-                   token.value != TOKeof &&
-                   token.value != TOKrcurly)
+            if (flags & PScurlyscope)
             {
-                statements->push(parseStatement(PSsemi | PScurlyscope));
+                Statements *statements = new Statements();
+                while (token.value != TOKcase &&
+                       token.value != TOKdefault &&
+                       token.value != TOKeof &&
+                       token.value != TOKrcurly)
+                {
+                    statements->push(parseStatement(PSsemi | PScurlyscope));
+                }
+                s = new CompoundStatement(loc, statements);
             }
-            s = new CompoundStatement(loc, statements);
+            else
+                s = parseStatement(PSsemi | PScurlyscope);
             s = new ScopeStatement(loc, s);
             s = new DefaultStatement(loc, s);
             break;

--- a/test/fail_compilation/fail3144.d
+++ b/test/fail_compilation/fail3144.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail3144.d(12): Error: break is not inside a loop or switch
+fail_compilation/fail3144.d(15): Error: break is not inside a loop or switch
+---
+*/
+
+void main()
+{
+    switch (1)
+        default: {} break;
+
+    final switch (1)
+        case 1: {} break;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3144

This is another pull request for issue 3114, which against #660.
This doesn't reject `switch(cond) with(exp) { ... }` idiom.
