### PR TITLE
8532 Pure segfault

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6081,6 +6081,11 @@ bool TypeFunction::parameterEscapes(Parameter *p)
     if (p->storageClass & (STCscope | STClazy))
         return FALSE;
 
+    /* If haven't inferred the return type yet, assume it escapes
+     */
+    if (!nextOf())
+        return TRUE;
+
     if (purity)
     {   /* With pure functions, we need only be concerned if p escapes
          * via any return statement.

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -14,6 +14,14 @@ template T5996(T)
 static assert(!is(typeof(T5996!(int).bug5996())));
 
 /**************************************************
+    8532    segfault(mtype.c) - type inference + pure
+**************************************************/
+auto segfault8532(Y, R ...)(R r, Y val) pure
+{ return segfault8532(r, val); }
+
+static assert(!is(typeof( segfault8532(1,2,3))));
+
+/**************************************************
     5932    ICE(s2ir.c)
     6675    ICE(glue.c)
 **************************************************/


### PR DESCRIPTION
Segfault when using the return type to check for parameters escaping, when the return type isn't known yet.
(The segfault occurs two lines down, when it does 
Type\* tret = nextOf()->toBasetype(),  but nextOf() is NULL).
