### PR TITLE
Issue 8822 - Usiing qualified delegate type in template argument causes parser error.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4754,6 +4754,7 @@ int Parser::isDeclarator(Token **pt, int *haveId, enum TOK endtok)
                 t = peek(t);
                 if (!isParameters(&t))
                     return FALSE;
+                skipAttributes(t, &t);
                 continue;
         }
         break;

--- a/test/compilable/testfptr.d
+++ b/test/compilable/testfptr.d
@@ -399,6 +399,18 @@ void bug4838()
     static assert(typeof(dgsw).stringof == "void delegate() shared inout");
 }
 
+void test8822()
+{
+    struct S { void foo() const {} }
+    S s;
+    void delegate() const dg = &s.foo;      // OK
+
+    void foo(void delegate() const dg){}    // OK
+
+    struct Foo(T) {}
+    alias Foo!(void delegate() const) X;    // NG -> OK
+}
+
 void main()
 {
     static assert(is(typeof(&main) P : U*, U));


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8822
