### PR TITLE
Add option to show deprecated errors as warnings

### DIFF
--- a/docs/man/man1/dmd.1
+++ b/docs/man/man1/dmd.1
@@ -33,6 +33,8 @@ Write documentation file to
 .I filename
 .IP -d
 Allow deprecated features.
+.IP -di
+Show use of deprecated features as warnings.
 .IP -debug
 Compile in debug code
 .IP -debug=\fIlevel\fR

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -636,7 +636,7 @@ void Dsymbol::deprecation(const char *format, ...)
 
 void Dsymbol::checkDeprecated(Loc loc, Scope *sc)
 {
-    if (!global.params.useDeprecated && isDeprecated())
+    if (global.params.useDeprecated != 1 && isDeprecated())
     {
         // Don't complain if we're inside a deprecated symbol's scope
         for (Dsymbol *sp = sc->parent; sp; sp = sp->parent)

--- a/src/mars.c
+++ b/src/mars.c
@@ -267,8 +267,11 @@ void vwarning(Loc loc, const char *format, va_list ap)
 void vdeprecation(Loc loc, const char *format, va_list ap,
 		const char *p1, const char *p2)
 {
-    if (!global.params.useDeprecated)
-        verror(loc, format, ap, p1, p2, "Deprecation: ");
+    static const char *header = "Deprecation: ";
+    if (global.params.useDeprecated == 0)
+        verror(loc, format, ap, p1, p2, header);
+    else if (global.params.useDeprecated == 2 && !global.gag)
+        verrorPrint(loc, header, format, ap, p1, p2);
 }
 
 /***************************************
@@ -323,6 +326,7 @@ Usage:\n\
   -Dddocdir      write documentation file to docdir directory\n\
   -Dffilename    write documentation file to filename\n\
   -d             allow deprecated features\n\
+  -di            show use of deprecated features as warnings\n\
   -debug         compile in debug code\n\
   -debug=level   compile in debug code <= level\n\
   -debug=ident   compile in debug code identified by ident\n\
@@ -527,6 +531,8 @@ int tryMain(int argc, char *argv[])
         {
             if (strcmp(p + 1, "d") == 0)
                 global.params.useDeprecated = 1;
+            else if (strcmp(p + 1, "di") == 0)
+                global.params.useDeprecated = 2;
             else if (strcmp(p + 1, "c") == 0)
                 global.params.link = 0;
             else if (strcmp(p + 1, "cov") == 0)

--- a/src/mars.h
+++ b/src/mars.h
@@ -158,7 +158,9 @@ struct Param
     char isOPenBSD;     // generate code for OpenBSD
     char isSolaris;     // generate code for Solaris
     char scheduler;     // which scheduler to use
-    char useDeprecated; // allow use of deprecated features
+    char useDeprecated; // 0: don't allow use of deprecated features
+                        // 1: silently allow use of deprecated features
+                        // 2: warn about the use of deprecated features
     char useAssert;     // generate runtime code for assert()'s
     char useInvariants; // generate class invariant checks
     char useIn;         // generate precondition checks

--- a/test/compilable/depmsg.d
+++ b/test/compilable/depmsg.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -di
 
 void main()
 {

--- a/test/compilable/deprecate2.d
+++ b/test/compilable/deprecate2.d
@@ -1,4 +1,5 @@
 ﻿// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -di
 
 // Test cases using deprecated features
 

--- a/test/compilable/header.d
+++ b/test/compilable/header.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS:
+// PERMUTE_ARGS: -di
 // REQUIRED_ARGS: -H -Hdtest_results/compilable
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh
 // REQUIRED_ARGS: -d

--- a/test/compilable/test55.d
+++ b/test/compilable/test55.d
@@ -1,6 +1,6 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/test55a.d
-// PERMUTE_ARGS:
+// PERMUTE_ARGS: -di
 // REQUIRED_ARGS: -d
 
 public import imports.test55a;

--- a/test/compilable/test7754.d
+++ b/test/compilable/test7754.d
@@ -1,7 +1,6 @@
-// PERMUTE_ARGS:
 // REQUIRED_ARGS: -H -Hdtest_results/compilable
 // POST_SCRIPT: compilable/extra-files/test7754-postscript.sh
-// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -d -di
 
 struct Foo(T)
 {

--- a/test/fail_compilation/fail108.d
+++ b/test/fail_compilation/fail108.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -d -di
 // 249
 
 module test1;

--- a/test/fail_compilation/fail121.d
+++ b/test/fail_compilation/fail121.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -d -di
 // segfault on DMD0.150, never failed if use typeid() instead.
 
 struct myobject

--- a/test/fail_compilation/fail138.d
+++ b/test/fail_compilation/fail138.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -d -di
 
 typedef int T = void;
 

--- a/test/fail_compilation/fail156.d
+++ b/test/fail_compilation/fail156.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -d -di
 
 typedef int myint = 4;
 

--- a/test/fail_compilation/fail157.d
+++ b/test/fail_compilation/fail157.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -d -di
 
 typedef int myint = 4;
 

--- a/test/fail_compilation/fail187.d
+++ b/test/fail_compilation/fail187.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -d -di
 // On DMD 2.000 bug only with typedef, not alias
 
 typedef Exception A;

--- a/test/fail_compilation/fail4.d
+++ b/test/fail_compilation/fail4.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -d -di
 // On DMD0.165 fails only with typedef, not alias
 
 typedef foo bar;

--- a/test/fail_compilation/testhtml.html
+++ b/test/fail_compilation/testhtml.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!--
-PERMUTE_ARGS:
-REQUIRED_ARGS: -d
+PERMUTE_ARGS: -d -di
 -->
 <html><head><title>dstress: html_entity_01</title></head><body><pre><CODE>
 int main(){

--- a/test/fail_compilation/testhtml2.html
+++ b/test/fail_compilation/testhtml2.html
@@ -1,4 +1,3 @@
 <!--
-REQUIRED_ARGS: -d
-PERMUTE_ARGS:
+PERMUTE_ARGS: -d -di
 --><html>	<head><title>dstress: html_line_ending_mac</title></head>	<body><pre><CODE>// __DSTRESS_TORTURE_BLOCK__ -release int main(){	try{		assert(0);	}catch(Throwable e){		checkLineNumber(e);		return 0;	}	assert(-1, "b");	return 1;}/* * @WARNING@ this code depends on the phobos implementation. * char[]s returned by wrong assertions have to look like: *	 "blah blah (linenumber) blah blah" */void checkLineNumber(Object o){	string x=o.toString();	int start;	for(start=0; start&lt;x.length; start++){if(x[start]=='('){break;}}	int end;	for(end=start+1; end&lt;x.length; end++){if(x[end]==')'){break;}}	assert(end-start==3);	assert(x[start+1 .. end]=="10", x[start+1 .. end]);}	</CODE></pre></body></html>

--- a/test/fail_compilation/testhtml3.html
+++ b/test/fail_compilation/testhtml3.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-  PERMUTE_ARGS:
-  REQUIRED_ARGS: -d
+  PERMUTE_ARGS: -d -di
 -->
 <html>
 	<head><title>dstress: html_tag_space_01</title></head>

--- a/test/runnable/circular.d
+++ b/test/runnable/circular.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -di
 // EXTRA_SOURCES: imports/circularA.d
 // This bug is typedef-specific.
 

--- a/test/runnable/deprecate1.d
+++ b/test/runnable/deprecate1.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -di
 
 // Test cases using deprecated features
 module deprecate1;

--- a/test/runnable/literal.d
+++ b/test/runnable/literal.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -di
 
 import std.stdio;
 import std.c.stdlib;

--- a/test/runnable/test9.d
+++ b/test/runnable/test9.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -d
+// PERMUTE_ARGS: -di
 // The use of typedef in these tests is fundamental.
 
 public:


### PR DESCRIPTION
The new option -di treats deprecation errors as informational warnings,
just like -wi show warnings as informational messages without triggering
errors.

Tests that required -d are updated to use -di options too to ensure -d
and -di works exactly the same (except for the compiler messages). Test
that didn't really required -d to run (usually obscure bugs only
triggered with -d), are now using both -d and -di as PERMUTE_ARGS
instead of REQUIRED_ARGS, so the are more generally tested.
