### PR TITLE
8801 assigning to __ctfe crashes the compiler

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5120,6 +5120,11 @@ Expression *VarExp::toLvalue(Scope *sc, Expression *e)
     {   error("lazy variables cannot be lvalues");
         return new ErrorExp();
     }
+    if (var->ident == Id::ctfe)
+    {
+        error("compiler-generated variable __ctfe is not an lvalue");
+        return new ErrorExp();
+    }
     return this;
 }
 
@@ -10816,6 +10821,10 @@ Ltupleassign:
         op == TOKassign)
     {
         error("cannot rebind scope variables");
+    }
+    if (e1->op == TOKvar && ((VarExp*)e1)->var->ident == Id::ctfe)
+    {
+        error("cannot modify compiler-generated variable __ctfe");
     }
 
     type = e1->type;

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -22,6 +22,12 @@ auto segfault8532(Y, R ...)(R r, Y val) pure
 static assert(!is(typeof( segfault8532(1,2,3))));
 
 /**************************************************
+    8801    ICE assigning to __ctfe
+**************************************************/
+static assert(!is(typeof( { bool __ctfe= true; })));
+static assert(!is(typeof( { __ctfe |= true; })));
+
+/**************************************************
     5932    ICE(s2ir.c)
     6675    ICE(glue.c)
 **************************************************/


### PR DESCRIPTION
Any use of a symbol beginning with __ is undefined behaviour but this particular example is worth detecting because it is something people may actually try to do.

The example in the bug report was a declaration causing an ICE, but the same ICE can also be created by anything using __ctfe as an an lvalue.

We need checks in two places, because constructing a variable doesn't call toLvalue().
