### PR TITLE
fix issue 8818:  CTFE fails to compare strings correctly

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3070,11 +3070,17 @@ int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2)
     {
         uinteger_t len1 = resolveArrayLength(e1);
         uinteger_t len2 = resolveArrayLength(e2);
-        uinteger_t len = (len1 < len2 ? len1 : len2);
-        int res = len == 0 ? 0 : ctfeCmpArrays(loc, e1, e2, len);
-        if (res == 0) // if equal, the longer is greater
-            return len1 - len2;
-        return res;
+        // workaround for dmc optimizer bug calculating wrong len for
+        // uinteger_t len = (len1 < len2 ? len1 : len2);
+        // if(len == 0) ...
+        if(len1 > 0 && len2 > 0)
+        {
+            uinteger_t len = (len1 < len2 ? len1 : len2);
+            int res = ctfeCmpArrays(loc, e1, e2, len);
+            if (res != 0)
+                return res;
+        }
+        return len1 - len2;
     }
     if (e1->type->isintegral())
     {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3070,11 +3070,11 @@ int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2)
     {
         uinteger_t len1 = resolveArrayLength(e1);
         uinteger_t len2 = resolveArrayLength(e2);
-        if (len1 != len2) // only for equality
+        uinteger_t len = (len1 < len2 ? len1 : len2);
+        int res = len == 0 ? 0 : ctfeCmpArrays(loc, e1, e2, len);
+        if (res == 0) // if equal, the longer is greater
             return len1 - len2;
-        if (len1 == 0 || len2 == 0)
-            return len1 - len2;  // Equal - both are empty
-        return ctfeCmpArrays(loc, e1, e2, len1);
+        return res;
     }
     if (e1->type->isintegral())
     {

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -2787,6 +2787,21 @@ void test6504()
     }
 }
 
+// 8818 regression
+void test8818()
+{
+    static bool test()
+    {
+        string op1 = "aa";
+        string op2 = "b";
+        assert("b" >= "aa");
+        assert(op2 >= op1);
+        return true;
+    }
+    static assert(test());
+    assert(test());
+}
+
 
 int main()
 {
@@ -2894,7 +2909,8 @@ int main()
     test102();
     test103();
     test6504();
-
+    test8818();
+    
     writefln("Success");
     return 0;
 }


### PR DESCRIPTION
The current code compares the lengths of arrays first to figure out which one is greater, but that is no good idea for strings. I'm not perfectly sure if the optimization was necessary for other arrays, though.

The patch compares the elements first, and only uses the length comparisons to resolve a tie.
