### PR TITLE
testgc2: Make sure GC allocations are not optimized out.

### DIFF
--- a/test/runnable/testgc2.d
+++ b/test/runnable/testgc2.d
@@ -9,16 +9,11 @@ import core.exception : OutOfMemoryError;
 
 void test1()
 {
-  version (none)
-  {
-  }
-  else
-  {
     printf("This should not take a while\n");
     try
     {
-	long[] l = new long[ptrdiff_t.max];
-	assert(0);
+        long[] l = new long[ptrdiff_t.max];
+        assert(0);
     }
     catch (OutOfMemoryError o)
     {
@@ -27,14 +22,13 @@ void test1()
     printf("This may take a while\n");
     try
     {
-	byte[] b = new byte[size_t.max / 3];
-	version (Windows)
-	    assert(0);
+        byte[] b = new byte[size_t.max / 3];
+        version (Windows)
+            assert(0);
     }
     catch (OutOfMemoryError o)
     {
     }
-  }
 }
 
 /*******************************************/

--- a/test/runnable/testgc2.d
+++ b/test/runnable/testgc2.d
@@ -13,6 +13,7 @@ void test1()
     try
     {
         long[] l = new long[ptrdiff_t.max];
+        printf("%lu\n", cast(ulong)l.capacity); // Make sure l is not optimized out.
         assert(0);
     }
     catch (OutOfMemoryError o)
@@ -23,6 +24,7 @@ void test1()
     try
     {
         byte[] b = new byte[size_t.max / 3];
+        printf("%lu\n", cast(ulong)b.capacity); // Make sure b is not optimized out.
         version (Windows)
             assert(0);
     }


### PR DESCRIPTION
This makes sure the GC allocations are not optimized out, causing the assert to be hit, in addition to some cosmetic changes in a separate commit.
