### PR TITLE
8257 x.staticfunc() is a function pointer, not a delegate

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8565,7 +8565,12 @@ Expression *AddrExp::semantic(Scope *sc)
             {
                 if (!dve->hasOverloads)
                     f->tookAddressOf++;
-                Expression *e = new DelegateExp(loc, dve->e1, f, dve->hasOverloads);
+
+                Expression *e;
+                if ( f->needThis())
+                    e = new DelegateExp(loc, dve->e1, f, dve->hasOverloads);
+                else // It is a function pointer. Convert &v.f() --> (v, &V.f())
+                    e = new CommaExp(loc, dve->e1, new AddrExp(loc, new VarExp(loc, f)));
                 e = e->semantic(sc);
                 return e;
             }

--- a/test/runnable/delegate.d
+++ b/test/runnable/delegate.d
@@ -187,6 +187,29 @@ void test9()
 }
 
 /********************************************************/
+// 8257
+
+struct S8257 {
+    static int g() {
+        return 6;
+    }
+}
+
+void test8257()
+{
+     S8257 s;
+     int w = 2;
+     S8257 func() { ++w; return s; }
+     auto k = &(func()).g;
+     // check that the call to func() still happened
+     assert(w == 3);
+     assert( k() == 6);
+}
+
+auto f8257(string m)() { return &__traits(getMember, S8257.init, m); }
+static assert (__traits(compiles, f8257!"g"()));
+
+/********************************************************/
 
 void foo10(int delegate() dg)
 {
@@ -318,6 +341,7 @@ int main()
     test12();
     test13();
     test2472();
+    test8257();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
The bug title is "__traits(compiles) gives compile error" but this has nothing to do with __traits.

Instead of saying that & v.staticfunc is a delegate, and generating an error in the glue layer, 
change it into (v, &typeof(v).staticfunc) and mark it as a function pointer.
