### PR TITLE
DO NOT PULL. test reverting back to previously successful win32 build

### DIFF
--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -520,13 +520,14 @@ size_t flarray_max;
  * Add to the fix list.
  */
 
-size_t addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int flags)
-{
+void addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int flags)
+{       fixlist *ln;
         static char zeros[8];
+        int numbytes;
 
         //printf("addtofixlist(%p '%s')\n",s,s->Sident);
         assert(flags);
-        fixlist *ln = (fixlist *) mem_calloc(sizeof(fixlist));
+        ln = (fixlist *) mem_calloc(sizeof(fixlist));
         //ln->Lsymbol = s;
         ln->Loffset = soffset;
         ln->Lseg = seg;
@@ -567,7 +568,6 @@ size_t addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int fl
         ln->Lnext = *pv;
         *pv = ln;
 
-        size_t numbytes;
 #if TARGET_SEGMENTED
         switch (flags & (CFoff | CFseg))
         {
@@ -586,7 +586,6 @@ size_t addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int fl
         assert(numbytes <= sizeof(zeros));
 #endif
         objmod->bytes(seg,soffset,numbytes,zeros);
-        return numbytes;
 }
 
 /****************************

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -3395,8 +3395,7 @@ int Obj::reftoident(int seg,targ_size_t offset,Symbol *s,targ_size_t val,
             else
             {   // Don't know yet, worry about it later
              Ladd:
-                size_t byteswritten = addtofixlist(s,offset,seg,val,flags);
-                assert(byteswritten == numbytes);
+                addtofixlist(s,offset,seg,val,flags);
                 return numbytes;
             }
             break;

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -364,7 +364,7 @@ int code_match(code *c1,code *c2);
 unsigned calcblksize (code *c);
 unsigned calccodsize(code *c);
 unsigned codout (code *c );
-size_t addtofixlist (symbol *s , targ_size_t soffset , int seg , targ_size_t val , int flags );
+void addtofixlist (symbol *s , targ_size_t soffset , int seg , targ_size_t val , int flags );
 void searchfixlist (symbol *s );
 void outfixlist (void );
 void code_hydrate(code **pc);

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -19,20 +19,8 @@
 #include        <float.h>
 #include        <time.h>
 
-#if defined __OpenBSD__
-    #include <sys/param.h>
-    #if OpenBSD < 201111 // 5.0
-        #define HAVE_FENV_H 0
-    #else
-        #define HAVE_FENV_H 1
-    #endif
-#elif _MSC_VER
-    #define HAVE_FENV_H 0
-#else
-    #define HAVE_FENV_H 1
-#endif
-
-#if HAVE_FENV_H
+#if !defined(__OpenBSD__)
+// Mysteriously missing from OpenBSD
 #include        <fenv.h>
 #endif
 
@@ -60,34 +48,17 @@ static char __file__[] = __FILE__;      /* for tassert.h                */
 
 extern void error(const char *filename, unsigned linnum, const char *format, ...);
 
-#if HAVE_FENV_H
-    #define HAVE_FLOAT_EXCEPT 1
+#if linux || __APPLE__ || __FreeBSD__ || __sun
+int _status87()
+{
+    return fetestexcept(FE_ALL_EXCEPT);
+}
 
-    static int testFE()
-    {
-        return fetestexcept(FE_ALL_EXCEPT);
-    }
-
-    static void clearFE()
-    {
-        feclearexcept(FE_ALL_EXCEPT);
-    }
-#elif defined _MSC_VER && TX86
-    #define HAVE_FLOAT_EXCEPT 1
-
-    static int testFE()
-    {
-        return _status87() & 0x3F;
-    }
-
-    static void clearFE()
-    {
-        _clear87();
-    }
-#else
-    #define HAVE_FLOAT_EXCEPT 0
+void _clear87()
+{
+    feclearexcept(FE_ALL_EXCEPT);
+}
 #endif
-
 
 CEXTERN elem * evalu8(elem *);
 
@@ -634,8 +605,8 @@ elem * evalu8(elem *e)
             return e;
 #endif
         esave = *e;
-#if HAVE_FLOAT_EXCEPT
-        clearFE();
+#if TX86 && !__OpenBSD__
+        _clear87();
 #endif
     }
     else
@@ -2021,10 +1992,10 @@ elem * evalu8(elem *e)
 
     if (!ignore_exceptions &&
         (config.flags4 & CFG4fastfloat) == 0 &&
-#if HAVE_FLOAT_EXCEPT
-        testFE()
+#if __OpenBSD__
+        1                    // until OpenBSD supports C standard fenv.h
 #else
-        1
+        _status87() & 0x3F
 #endif
        )
     {

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -2520,8 +2520,7 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
     assert(seg > 0);
     if (s->Sclass != SClocstat && !s->Sxtrnnum)
     {   // It may get defined later as public or local, so defer
-        size_t numbyteswritten = addtofixlist(s, offset, seg, val, flags);
-        assert(numbyteswritten == retsize);
+        addtofixlist(s, offset, seg, val, flags);
     }
     else
     {

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -2360,8 +2360,7 @@ int MsCoffObj::reftoident(segidx_t seg, targ_size_t offset, Symbol *s, targ_size
     assert(seg > 0);
     if (s->Sclass != SClocstat && !s->Sxtrnnum)
     {   // It may get defined later as public or local, so defer
-        size_t numbyteswritten = addtofixlist(s, offset, seg, val, flags);
-        assert(numbyteswritten == retsize);
+        addtofixlist(s, offset, seg, val, flags);
     }
     else
     {

--- a/src/backend/nteh.c
+++ b/src/backend/nteh.c
@@ -316,7 +316,7 @@ code *nteh_prolog()
         /* An sindex value of -2 is a magic value that tells the
          * stack unwinder to skip this frame.
          */
-        assert(config.exe & (EX_LINUX | EX_LINUX64 | EX_OSX | EX_OSX64 | EX_FREEBSD | EX_FREEBSD64 | EX_SOLARIS | EX_SOLARIS64 | EX_OPENBSD | EX_OPENBSD64));
+        assert(config.exe & (EX_LINUX | EX_LINUX64 | EX_OSX | EX_OSX64 | EX_FREEBSD | EX_FREEBSD64 | EX_SOLARIS | EX_SOLARIS64));
         cs.Iop = 0x68;
         cs.Iflags = 0;
         cs.Irex = 0;


### PR DESCRIPTION
DO NOT PULL

This reverts back to the last known good win32 point to test to see if it's the windows and cygwin update that broke the build or one of the recent commits.
