### PR TITLE
CTFE debugging: Add loc to LOG trace

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -522,7 +522,7 @@ Expression *Expression::ctfeInterpret()
 Expression *FuncDeclaration::interpret(InterState *istate, Expressions *arguments, Expression *thisarg)
 {
 #if LOG
-    printf("\n********\nFuncDeclaration::interpret(istate = %p) %s\n", istate, toChars());
+    printf("\n********\n%s FuncDeclaration::interpret(istate = %p) %s\n", loc.toChars(), istate, toChars());
 #endif
     if (semanticRun == PASSsemantic3)
     {
@@ -789,7 +789,7 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
 Expression *Statement::interpret(InterState *istate)
 {
 #if LOG
-    printf("Statement::interpret()\n");
+    printf("%s Statement::interpret()\n", loc.toChars());
 #endif
     START()
     error("Statement %s cannot be interpreted at compile time", this->toChars());
@@ -799,7 +799,7 @@ Expression *Statement::interpret(InterState *istate)
 Expression *ExpStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("ExpStatement::interpret(%s)\n", exp ? exp->toChars() : "");
+    printf("%s ExpStatement::interpret(%s)\n", loc.toChars(), exp ? exp->toChars() : "");
 #endif
     START()
     if (exp)
@@ -820,7 +820,7 @@ Expression *CompoundStatement::interpret(InterState *istate)
 {   Expression *e = NULL;
 
 #if LOG
-    printf("CompoundStatement::interpret()\n");
+    printf("%s CompoundStatement::interpret()\n", loc.toChars());
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -838,7 +838,7 @@ Expression *CompoundStatement::interpret(InterState *istate)
         }
     }
 #if LOG
-    printf("-CompoundStatement::interpret() %p\n", e);
+    printf("%s -CompoundStatement::interpret() %p\n", loc.toChars(), e);
 #endif
     return e;
 }
@@ -847,7 +847,7 @@ Expression *UnrolledLoopStatement::interpret(InterState *istate)
 {   Expression *e = NULL;
 
 #if LOG
-    printf("UnrolledLoopStatement::interpret()\n");
+    printf("%s UnrolledLoopStatement::interpret()\n", loc.toChars());
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -893,7 +893,7 @@ int isTrueBool(Expression *e)
 Expression *IfStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("IfStatement::interpret(%s)\n", condition->toChars());
+    printf("%s IfStatement::interpret(%s)\n", loc.toChars(), condition->toChars());
 #endif
 
     if (istate->start == this)
@@ -930,7 +930,7 @@ Expression *IfStatement::interpret(InterState *istate)
 Expression *ScopeStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("ScopeStatement::interpret()\n");
+    printf("%s ScopeStatement::interpret()\n", loc.toChars());
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -1176,7 +1176,7 @@ bool scrubArray(Loc loc, Expressions *elems, bool structlit)
 Expression *ReturnStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("ReturnStatement::interpret(%s)\n", exp ? exp->toChars() : "");
+    printf("%s ReturnStatement::interpret(%s)\n", loc.toChars(), exp ? exp->toChars() : "");
 #endif
     START()
     if (!exp)
@@ -1239,7 +1239,7 @@ Expression *ReturnStatement::interpret(InterState *istate)
 Expression *BreakStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("BreakStatement::interpret()\n");
+    printf("%s BreakStatement::interpret()\n", loc.toChars());
 #endif
     START()
     if (ident)
@@ -1263,7 +1263,7 @@ Expression *BreakStatement::interpret(InterState *istate)
 Expression *ContinueStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("ContinueStatement::interpret()\n");
+    printf("%s ContinueStatement::interpret()\n", loc.toChars());
 #endif
     START()
     if (ident)
@@ -1293,7 +1293,7 @@ Expression *WhileStatement::interpret(InterState *istate)
 Expression *DoStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("DoStatement::interpret()\n");
+    printf("%s DoStatement::interpret()\n", loc.toChars());
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -1346,7 +1346,7 @@ Expression *DoStatement::interpret(InterState *istate)
 Expression *ForStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("ForStatement::interpret()\n");
+    printf("%s ForStatement::interpret()\n", loc.toChars());
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -1427,7 +1427,7 @@ Expression *ForeachRangeStatement::interpret(InterState *istate)
 Expression *SwitchStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("SwitchStatement::interpret()\n");
+    printf("%s SwitchStatement::interpret()\n", loc.toChars());
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -1500,7 +1500,7 @@ Expression *SwitchStatement::interpret(InterState *istate)
 Expression *CaseStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("CaseStatement::interpret(%s) this = %p\n", exp->toChars(), this);
+    printf("%s CaseStatement::interpret(%s) this = %p\n", loc.toChars(), exp->toChars(), this);
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -1513,7 +1513,7 @@ Expression *CaseStatement::interpret(InterState *istate)
 Expression *DefaultStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("DefaultStatement::interpret()\n");
+    printf("%s DefaultStatement::interpret()\n", loc.toChars());
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -1526,7 +1526,7 @@ Expression *DefaultStatement::interpret(InterState *istate)
 Expression *GotoStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("GotoStatement::interpret()\n");
+    printf("%s GotoStatement::interpret()\n", loc.toChars());
 #endif
     START()
     assert(label && label->statement);
@@ -1537,7 +1537,7 @@ Expression *GotoStatement::interpret(InterState *istate)
 Expression *GotoCaseStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("GotoCaseStatement::interpret()\n");
+    printf("%s GotoCaseStatement::interpret()\n", loc.toChars());
 #endif
     START()
     assert(cs);
@@ -1548,7 +1548,7 @@ Expression *GotoCaseStatement::interpret(InterState *istate)
 Expression *GotoDefaultStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("GotoDefaultStatement::interpret()\n");
+    printf("%s GotoDefaultStatement::interpret()\n", loc.toChars());
 #endif
     START()
     assert(sw && sw->sdefault);
@@ -1559,7 +1559,7 @@ Expression *GotoDefaultStatement::interpret(InterState *istate)
 Expression *LabelStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("LabelStatement::interpret()\n");
+    printf("%s LabelStatement::interpret()\n", loc.toChars());
 #endif
     if (istate->start == this)
         istate->start = NULL;
@@ -1570,7 +1570,7 @@ Expression *LabelStatement::interpret(InterState *istate)
 Expression *TryCatchStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("TryCatchStatement::interpret()\n");
+    printf("%s TryCatchStatement::interpret()\n", loc.toChars());
 #endif
     START()
     Expression *e = body ? body->interpret(istate) : NULL;
@@ -1642,7 +1642,7 @@ ThrownExceptionExp *chainExceptions(ThrownExceptionExp *oldest, ThrownExceptionE
 Expression *TryFinallyStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("TryFinallyStatement::interpret()\n");
+    printf("%s TryFinallyStatement::interpret()\n", loc.toChars());
 #endif
     START()
     Expression *e = body ? body->interpret(istate) : NULL;
@@ -1664,7 +1664,7 @@ Expression *TryFinallyStatement::interpret(InterState *istate)
 Expression *ThrowStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("ThrowStatement::interpret()\n");
+    printf("%s ThrowStatement::interpret()\n", loc.toChars());
 #endif
     START()
     Expression *e = exp->interpret(istate);
@@ -1683,7 +1683,7 @@ Expression *OnScopeStatement::interpret(InterState *istate)
 Expression *WithStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("WithStatement::interpret()\n");
+    printf("%s WithStatement::interpret()\n", loc.toChars());
 #endif
     START()
     Expression *e = exp->interpret(istate);
@@ -1704,7 +1704,7 @@ Expression *WithStatement::interpret(InterState *istate)
 Expression *AsmStatement::interpret(InterState *istate)
 {
 #if LOG
-    printf("AsmStatement::interpret()\n");
+    printf("%s AsmStatement::interpret()\n", loc.toChars());
 #endif
     START()
     error("asm statements cannot be interpreted at compile time");
@@ -1727,7 +1727,7 @@ Expression *ImportStatement::interpret(InterState *istate)
 Expression *Expression::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("Expression::interpret() %s\n", toChars());
+    printf("%s Expression::interpret() %s\n", loc.toChars(), toChars());
     printf("type = %s\n", type->toChars());
     dump(0);
 #endif
@@ -1755,7 +1755,7 @@ Expression *NullExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *IntegerExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("IntegerExp::interpret() %s\n", toChars());
+    printf("%s IntegerExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     return this;
 }
@@ -1763,7 +1763,7 @@ Expression *IntegerExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *RealExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("RealExp::interpret() %s\n", toChars());
+    printf("%s RealExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     return this;
 }
@@ -1776,7 +1776,7 @@ Expression *ComplexExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *StringExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("StringExp::interpret() %s\n", toChars());
+    printf("%s StringExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     /* In both D1 and D2, attempts to modify string literals are prevented
      * in BinExp::interpretAssignCommon.
@@ -1799,7 +1799,7 @@ Expression *StringExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *FuncExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("FuncExp::interpret() %s\n", toChars());
+    printf("%s FuncExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     return this;
 }
@@ -1828,7 +1828,7 @@ bool isSafePointerCast(Type *srcPointee, Type *destPointee)
 Expression *SymOffExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("SymOffExp::interpret() %s\n", toChars());
+    printf("%s SymOffExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     if (var->isFuncDeclaration() && offset == 0)
     {
@@ -1904,7 +1904,7 @@ Expression *SymOffExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *AddrExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("AddrExp::interpret() %s\n", toChars());
+    printf("%s AddrExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     // For reference types, we need to return an lvalue ref.
     TY tb = e1->type->toBasetype()->ty;
@@ -1921,7 +1921,7 @@ Expression *AddrExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *DelegateExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("DelegateExp::interpret() %s\n", toChars());
+    printf("%s DelegateExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     return this;
 }
@@ -2105,7 +2105,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
 Expression *VarExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("VarExp::interpret() %s\n", toChars());
+    printf("%s VarExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     if (goal == ctfeNeedLvalueRef)
     {
@@ -2134,7 +2134,7 @@ Expression *VarExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("DeclarationExp::interpret() %s\n", toChars());
+    printf("%s DeclarationExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     Expression *e;
     VarDeclaration *v = declaration->isVarDeclaration();
@@ -2228,7 +2228,7 @@ Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *TupleExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("TupleExp::interpret() %s\n", toChars());
+    printf("%s TupleExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     Expressions *expsx = NULL;
 
@@ -2280,7 +2280,7 @@ Expression *ArrayLiteralExp::interpret(InterState *istate, CtfeGoal goal)
 {   Expressions *expsx = NULL;
 
 #if LOG
-    printf("ArrayLiteralExp::interpret() %s\n", toChars());
+    printf("%s ArrayLiteralExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     if (ownedByCtfe) // We've already interpreted all the elements
         return copyLiteral(this);
@@ -2344,7 +2344,7 @@ Expression *AssocArrayLiteralExp::interpret(InterState *istate, CtfeGoal goal)
     Expressions *valuesx = values;
 
 #if LOG
-    printf("AssocArrayLiteralExp::interpret() %s\n", toChars());
+    printf("%s AssocArrayLiteralExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     if (ownedByCtfe) // We've already interpreted all the elements
         return copyLiteral(this);
@@ -2439,7 +2439,7 @@ Expression *StructLiteralExp::interpret(InterState *istate, CtfeGoal goal)
 {   Expressions *expsx = NULL;
 
 #if LOG
-    printf("StructLiteralExp::interpret() %s\n", toChars());
+    printf("%s StructLiteralExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     /* We don't know how to deal with overlapping fields
      */
@@ -2583,7 +2583,7 @@ Expression *recursivelyCreateArrayLiteral(Loc loc, Type *newtype, InterState *is
 Expression *NewExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("NewExp::interpret() %s\n", toChars());
+    printf("%s NewExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     if (newtype->ty == Tarray && arguments)
         return recursivelyCreateArrayLiteral(loc, newtype, istate, arguments, 0);
@@ -2665,7 +2665,7 @@ Expression *UnaExp::interpretCommon(InterState *istate,  CtfeGoal goal, Expressi
     Expression *e1;
 
 #if LOG
-    printf("UnaExp::interpretCommon() %s\n", toChars());
+    printf("%s UnaExp::interpretCommon() %s\n", loc.toChars(), toChars());
 #endif
     e1 = this->e1->interpret(istate);
     if (exceptionOrCantInterpret(e1))
@@ -2815,7 +2815,7 @@ Expression *BinExp::interpretCommon(InterState *istate, CtfeGoal goal, fp_t fp)
     Expression *e2;
 
 #if LOG
-    printf("BinExp::interpretCommon() %s\n", toChars());
+    printf("%s BinExp::interpretCommon() %s\n", loc.toChars(), toChars());
 #endif
     if (this->e1->type->ty == Tpointer && this->e2->type->ty == Tpointer && op == TOKmin)
     {
@@ -3233,7 +3233,7 @@ Expression *BinExp::interpretCommon2(InterState *istate, CtfeGoal goal, fp2_t fp
     Expression *e2;
 
 #if LOG
-    printf("BinExp::interpretCommon2() %s\n", toChars());
+    printf("%s BinExp::interpretCommon2() %s\n", loc.toChars(), toChars());
 #endif
     if (this->e1->type->ty == Tpointer && this->e2->type->ty == Tpointer)
     {
@@ -3773,7 +3773,7 @@ void recursiveBlockAssign(ArrayLiteralExp *ae, Expression *val, bool wantRef)
 Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_t fp, int post)
 {
 #if LOG
-    printf("BinExp::interpretAssignCommon() %s\n", toChars());
+    printf("%s BinExp::interpretAssignCommon() %s\n", loc.toChars(), toChars());
 #endif
     Expression *returnValue = EXP_CANT_INTERPRET;
     Expression *e1 = this->e1;
@@ -4897,7 +4897,7 @@ BIN_ASSIGN_INTERPRET(Pow)
 Expression *PostExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("PostExp::interpret() %s\n", toChars());
+    printf("%s PostExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     Expression *e;
     if (op == TOKplusplus)
@@ -5080,7 +5080,7 @@ Expression *BinExp::interpretFourPointerRelation(InterState *istate, CtfeGoal go
 Expression *AndAndExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("AndAndExp::interpret() %s\n", toChars());
+    printf("%s AndAndExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
 
     // Check for an insidePointer expression, evaluate it if so
@@ -5131,7 +5131,7 @@ Expression *AndAndExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *OrOrExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("OrOrExp::interpret() %s\n", toChars());
+    printf("%s OrOrExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
 
     // Check for an insidePointer expression, evaluate it if so
@@ -5235,7 +5235,7 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
 {   Expression *e = EXP_CANT_INTERPRET;
 
 #if LOG
-    printf("CallExp::interpret() %s\n", toChars());
+    printf("%s CallExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
 
     Expression * pthis = NULL;
@@ -5428,7 +5428,7 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *CommaExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("CommaExp::interpret() %s\n", toChars());
+    printf("%s CommaExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
 
     CommaExp * firstComma = this;
@@ -5497,7 +5497,7 @@ Expression *CommaExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *CondExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("CondExp::interpret() %s\n", toChars());
+    printf("%s CondExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     Expression *e;
     if ( isPointer(econd->type) )
@@ -5530,7 +5530,7 @@ Expression *ArrayLengthExp::interpret(InterState *istate, CtfeGoal goal)
     Expression *e1;
 
 #if LOG
-    printf("ArrayLengthExp::interpret() %s\n", toChars());
+    printf("%s ArrayLengthExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     e1 = this->e1->interpret(istate);
     assert(e1);
@@ -5606,7 +5606,7 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
     Expression *e2;
 
 #if LOG
-    printf("IndexExp::interpret() %s\n", toChars());
+    printf("%s IndexExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     if (this->e1->type->toBasetype()->ty == Tpointer)
     {
@@ -5749,7 +5749,7 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
     Expression *upr;
 
 #if LOG
-    printf("SliceExp::interpret() %s\n", toChars());
+    printf("%s SliceExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
 
     if (this->e1->type->toBasetype()->ty == Tpointer)
@@ -5915,7 +5915,7 @@ Expression *InExp::interpret(InterState *istate, CtfeGoal goal)
 {   Expression *e = EXP_CANT_INTERPRET;
 
 #if LOG
-    printf("InExp::interpret() %s\n", toChars());
+    printf("%s InExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     Expression *e1 = this->e1->interpret(istate);
     if (exceptionOrCantInterpret(e1))
@@ -5948,7 +5948,7 @@ Expression *CatExp::interpret(InterState *istate, CtfeGoal goal)
     Expression *e2;
 
 #if LOG
-    printf("CatExp::interpret() %s\n", toChars());
+    printf("%s CatExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     e1 = this->e1->interpret(istate);
     if (exceptionOrCantInterpret(e1))
@@ -6027,7 +6027,7 @@ Expression *CastExp::interpret(InterState *istate, CtfeGoal goal)
     Expression *e1;
 
 #if LOG
-    printf("CastExp::interpret() %s\n", toChars());
+    printf("%s CastExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     e1 = this->e1->interpret(istate, goal);
     if (exceptionOrCantInterpret(e1))
@@ -6200,7 +6200,7 @@ Expression *AssertExp::interpret(InterState *istate, CtfeGoal goal)
     Expression *e1;
 
 #if LOG
-    printf("AssertExp::interpret() %s\n", toChars());
+    printf("%s AssertExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
 #if DMDV2
     e1 = this->e1->interpret(istate);
@@ -6250,7 +6250,7 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
 {   Expression *e = EXP_CANT_INTERPRET;
 
 #if LOG
-    printf("PtrExp::interpret() %s\n", toChars());
+    printf("%s PtrExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     // Constant fold *(&structliteral + offset)
     if (e1->op == TOKadd)
@@ -6382,7 +6382,7 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
 {   Expression *e = EXP_CANT_INTERPRET;
 
 #if LOG
-    printf("DotVarExp::interpret() %s\n", toChars());
+    printf("%s DotVarExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
 
     Expression *ex = e1->interpret(istate);
@@ -6486,7 +6486,7 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
 Expression *RemoveExp::interpret(InterState *istate, CtfeGoal goal)
 {
 #if LOG
-    printf("RemoveExp::interpret() %s\n", toChars());
+    printf("%s RemoveExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
     Expression *agg = e1->interpret(istate);
     if (exceptionOrCantInterpret(agg))


### PR DESCRIPTION
This simple but long patch is to make fixing CTFE bugs quicker.

When interpret.c is compiled with LOG=1, print file and line number for each
statement and expression. No effect on a normal debug or release build.
