### PR TITLE
Issue 7019 - implicit constructors are inconsistently allowed

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4019,6 +4019,8 @@ StructLiteralExp::StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *
     : Expression(loc, TOKstructliteral, sizeof(StructLiteralExp))
 {
     this->sd = sd;
+    if (!elements)
+        elements = new Expressions();
     this->elements = elements;
     this->stype = stype;
     this->sinit = NULL;

--- a/src/init.c
+++ b/src/init.c
@@ -22,6 +22,7 @@
 #include "mtype.h"
 #include "hdrgen.h"
 #include "template.h"
+#include "id.h"
 
 /********************************** Initializer *******************************/
 
@@ -880,6 +881,7 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
     }
 
     Type *tb = t->toBasetype();
+    Type *ti = exp->type->toBasetype();
 
     if (exp->op == TOKtuple &&
         expandTuples &&
@@ -892,7 +894,7 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
      * Allow this by doing an explicit cast, which will lengthen the string
      * literal.
      */
-    if (exp->op == TOKstring && tb->ty == Tsarray && exp->type->ty == Tsarray)
+    if (exp->op == TOKstring && tb->ty == Tsarray && ti->ty == Tsarray)
     {   StringExp *se = (StringExp *)exp;
 
         if (!se->committed && se->type->ty == Tsarray &&
@@ -904,10 +906,30 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
         }
     }
 
+    // Look for implicit constructor call
+    if (tb->ty == Tstruct &&
+        !(ti->ty == Tstruct && tb->toDsymbol(sc) == ti->toDsymbol(sc)) &&
+        !exp->implicitConvTo(t))
+    {
+        StructDeclaration *sd = ((TypeStruct *)tb)->sym;
+        if (sd->ctor)
+        {   // Rewrite as S().ctor(exp)
+            Expression *e;
+            e = new StructLiteralExp(loc, sd, NULL);
+            e = new DotIdExp(loc, e, Id::ctor);
+            e = new CallExp(loc, e, exp);
+            e = e->semantic(sc);
+            if (needInterpret)
+                exp = e->ctfeInterpret();
+            else
+                exp = e->optimize(WANTvalue);
+        }
+    }
+
     // Look for the case of statically initializing an array
     // with a single member.
     if (tb->ty == Tsarray &&
-        !tb->nextOf()->equals(exp->type->toBasetype()->nextOf()) &&
+        !tb->nextOf()->equals(ti->toBasetype()->nextOf()) &&
         exp->implicitConvTo(tb->nextOf())
        )
     {

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -21,6 +21,44 @@ void test6475()
 }
 
 /***************************************************/
+// 7019
+
+struct S7019
+{
+    int store;
+    this(int n)
+    {
+        store = n << 3;
+    }
+}
+
+S7019 rt_gs = 2;
+enum S7019 ct_gs = 2;
+pragma(msg, ct_gs, ", ", ct_gs.store);
+
+void test7019()
+{
+    S7019 rt_ls = 3; // this compiles fine
+    enum S7019 ct_ls = 3;
+    pragma(msg, ct_ls, ", ", ct_ls.store);
+
+    static class C
+    {
+        S7019 rt_fs = 4;
+        enum S7019 ct_fs = 4;
+        pragma(msg, ct_fs, ", ", ct_fs.store);
+    }
+
+    auto c = new C;
+    assert(rt_gs == S7019(2) && rt_gs.store == 16);
+    assert(rt_ls == S7019(3) && rt_ls.store == 24);
+    assert(c.rt_fs == S7019(4) && c.rt_fs.store == 32);
+    static assert(ct_gs == S7019(2) && ct_gs.store == 16);
+    static assert(ct_ls == S7019(3) && ct_ls.store == 24);
+    static assert(C.ct_fs == S7019(4) && C.ct_fs.store == 32);
+}
+
+/***************************************************/
 // 7239
 
 struct vec7239
@@ -108,6 +146,7 @@ void test8410()
 int main()
 {
     test6475();
+    test7019();
     test7239();
     test8123();
     test8147();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7019

From the @andralex's [reply ](http://forum.dlang.org/thread/CAFDvkcvvL8GxHQB=Rw9pTm-uxOKzNGVQNDv9w5Os3SkQCc=DLQ@mail.gmail.com#post-50856AB4.8000909:40erdani.com), we can sure that it is an expected feature.
