### PR TITLE
remove redundant declarations

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -24,16 +24,6 @@
 #include "id.h"
 #include "module.h"
 
-#if __FreeBSD__
-extern "C"
-{
-    longdouble sinl(longdouble);
-    longdouble cosl(longdouble);
-    longdouble tanl(longdouble);
-    longdouble sqrtl(longdouble);
-}
-#endif
-
 #if DMDV2
 
 /**********************************


### PR DESCRIPTION
- FreeBSD has long double versions of these functions since 8.0.
  If we wanted to have this work on pre-8.0 there should be definitions.
