### PR TITLE
Allow setting environment from sc.ini/dmd.conf depending on architecture

### DIFF
--- a/src/inifile.c
+++ b/src/inifile.c
@@ -68,7 +68,7 @@ char *strupr(char *s)
  *      Note: this is a memory leak
  */
 
-const char *inifile(const char *argv0x, const char *inifilex)
+const char *inifile(const char *argv0x, const char *inifilex, const char* section)
 {
     char *argv0 = (char *)argv0x;
     char *inifile = (char *)inifilex;   // do const-correct later
@@ -76,6 +76,7 @@ const char *inifile(const char *argv0x, const char *inifilex)
     char *filename;
     OutBuffer buf;
     int envsection = 0;
+    int sectionlen = strlen(section);
 
 #if LOG
     printf("inifile(argv0 = '%s', inifile = '%s')\n", argv0, inifile);
@@ -284,8 +285,8 @@ const char *inifile(const char *argv0x, const char *inifilex)
                 p = skipspace(p + 1);
                 for (pn = p; isalnum((unsigned char)*pn); pn++)
                     ;
-                if (pn - p == 11 &&
-                    memicmp(p, "Environment", 11) == 0 &&
+                if (pn - p == sectionlen &&
+                    memicmp(p, section, sectionlen) == 0 &&
                     *skipspace(pn) == ']'
                    )
                     envsection = 1;

--- a/src/inifile.c
+++ b/src/inifile.c
@@ -59,16 +59,18 @@ char *strupr(char *s)
 #endif
 
 /*****************************
- * Read and analyze .ini file.
+ * Read and analyze .ini file, i.e. write the entries of the specified section 
+ *  into the process environment
  * Input:
- *      argv0   program name (argv[0])
- *      inifile .ini file name
+ *      argv0           program name (argv[0])
+ *      inifile         .ini file name
+ *      envsectionname  name of the section to process
  * Returns:
  *      file name of ini file
  *      Note: this is a memory leak
  */
 
-const char *inifile(const char *argv0x, const char *inifilex, const char* section)
+const char *inifile(const char *argv0x, const char *inifilex, const char *envsectionname)
 {
     char *argv0 = (char *)argv0x;
     char *inifile = (char *)inifilex;   // do const-correct later
@@ -76,7 +78,7 @@ const char *inifile(const char *argv0x, const char *inifilex, const char* sectio
     char *filename;
     OutBuffer buf;
     int envsection = 0;
-    int sectionlen = strlen(section);
+    int envsectionnamelen = strlen(envsectionname);
 
 #if LOG
     printf("inifile(argv0 = '%s', inifile = '%s')\n", argv0, inifile);
@@ -285,8 +287,8 @@ const char *inifile(const char *argv0x, const char *inifilex, const char* sectio
                 p = skipspace(p + 1);
                 for (pn = p; isalnum((unsigned char)*pn); pn++)
                     ;
-                if (pn - p == sectionlen &&
-                    memicmp(p, section, sectionlen) == 0 &&
+                if (pn - p == envsectionnamelen &&
+                    memicmp(p, envsectionname, envsectionnamelen) == 0 &&
                     *skipspace(pn) == ']'
                    )
                     envsection = 1;

--- a/src/mars.c
+++ b/src/mars.c
@@ -508,9 +508,9 @@ int tryMain(size_t argc, char *argv[])
     VersionCondition::addPredefinedGlobalIdent("all");
 
 #if _WIN32
-    inifilename = inifile(argv[0], "sc.ini");
+    inifilename = inifile(argv[0], "sc.ini", "Environment");
 #elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
-    inifilename = inifile(argv[0], "dmd.conf");
+    inifilename = inifile(argv[0], "dmd.conf", "Environment");
 #else
 #error "fix this"
 #endif
@@ -892,6 +892,8 @@ int tryMain(size_t argc, char *argv[])
     {   usage();
         return EXIT_FAILURE;
     }
+
+    inifile(argv[0], inifilename, global.params.is64bit ? "Environment32" : "Environment64");
 
     if (!setdebuglib)
         global.params.debuglibname = global.params.defaultlibname;

--- a/src/mars.c
+++ b/src/mars.c
@@ -49,6 +49,8 @@ void obj_end(Library *library, File *objfile);
 
 void printCtfePerformanceStats();
 
+static bool parse_arch(int argc, char** argv, bool is64bit);
+
 Global global;
 
 Global::Global()
@@ -514,6 +516,18 @@ int tryMain(size_t argc, char *argv[])
 #else
 #error "fix this"
 #endif
+
+    int dflags_argc = 0;
+    char** dflags_argv = NULL;
+    getenv_setargv("DFLAGS", &dflags_argc, &dflags_argv);
+
+    bool is64bit = global.params.is64bit; // use default
+    is64bit = parse_arch(argc, argv, is64bit);
+    is64bit = parse_arch(dflags_argc, dflags_argv, is64bit);
+    global.params.is64bit = is64bit;
+
+    inifile(argv[0], inifilename, is64bit ? "Environment64" : "Environment32");
+
     getenv_setargv("DFLAGS", &argc, &argv);
 
 #if 0
@@ -884,6 +898,11 @@ int tryMain(size_t argc, char *argv[])
             files.push(p);
         }
     }
+
+    if(global.params.is64bit != is64bit)
+        error(0, "the architecture must not be changed in the %s section of %s",
+              is64bit ? "Environment64" : "Environment32", inifilename);
+
     if (global.errors)
     {
         fatal();
@@ -892,8 +911,6 @@ int tryMain(size_t argc, char *argv[])
     {   usage();
         return EXIT_FAILURE;
     }
-
-    inifile(argv[0], inifilename, global.params.is64bit ? "Environment64" : "Environment32");
 
     if (!setdebuglib)
         global.params.debuglibname = global.params.defaultlibname;
@@ -1615,6 +1632,28 @@ void getenv_setargv(const char *envvar, size_t *pargc, char** *pargv)
 Ldone:
     *pargc = argc;
     *pargv = argv->tdata();
+}
+
+/***********************************
+ * Parse command line arguments for -m32 or -m64
+ * to detect the desired architecture.
+ */
+
+static bool parse_arch(int argc, char** argv, bool is64bit)
+{
+    for (size_t i = 0; i < argc; ++i)
+    {   char* p = argv[i];
+        if (p[0] == '-')
+        {
+            if (strcmp(p + 1, "m32") == 0)
+                is64bit = 0;
+            else if (strcmp(p + 1, "m64") == 0)
+                is64bit = 1;
+            else if (strcmp(p + 1, "run") == 0)
+                break;
+        }
+    }
+    return is64bit;
 }
 
 #if WINDOWS_SEH

--- a/src/mars.c
+++ b/src/mars.c
@@ -49,7 +49,7 @@ void obj_end(Library *library, File *objfile);
 
 void printCtfePerformanceStats();
 
-static bool parse_arch(int argc, char** argv, bool is64bit);
+static bool parse_arch(size_t argc, char** argv, bool is64bit);
 
 Global global;
 
@@ -517,7 +517,7 @@ int tryMain(size_t argc, char *argv[])
 #error "fix this"
 #endif
 
-    int dflags_argc = 0;
+    size_t dflags_argc = 0;
     char** dflags_argv = NULL;
     getenv_setargv("DFLAGS", &dflags_argc, &dflags_argv);
 
@@ -1639,7 +1639,7 @@ Ldone:
  * to detect the desired architecture.
  */
 
-static bool parse_arch(int argc, char** argv, bool is64bit)
+static bool parse_arch(size_t argc, char** argv, bool is64bit)
 {
     for (size_t i = 0; i < argc; ++i)
     {   char* p = argv[i];

--- a/src/mars.c
+++ b/src/mars.c
@@ -893,7 +893,7 @@ int tryMain(size_t argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    inifile(argv[0], inifilename, global.params.is64bit ? "Environment32" : "Environment64");
+    inifile(argv[0], inifilename, global.params.is64bit ? "Environment64" : "Environment32");
 
     if (!setdebuglib)
         global.params.debuglibname = global.params.defaultlibname;

--- a/src/mars.h
+++ b/src/mars.h
@@ -440,7 +440,7 @@ void err_nomem();
 int runLINK();
 void deleteExeFile();
 int runProgram();
-const char *inifile(const char *argv0, const char *inifile, const char* section);
+const char *inifile(const char *argv0, const char *inifile, const char* envsectionname);
 void halt();
 void util_progress();
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -440,7 +440,7 @@ void err_nomem();
 int runLINK();
 void deleteExeFile();
 int runProgram();
-const char *inifile(const char *argv0, const char *inifile);
+const char *inifile(const char *argv0, const char *inifile, const char* section);
 void halt();
 void util_progress();
 


### PR DESCRIPTION
This patch adds evaluation of sections [Environment32] or [Environment64] in sc.ini/dmd.conf after processing command line arguments,  so the target architecture is known and respective changes can be made to the environment
