### PR TITLE
test: Don't prepend more than once "bash" to post-scripts

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -418,8 +418,9 @@ int main(string[] args)
             if (testArgs.postScript)
             {
                 f.write("Executing post-test script: ");
-                version (Windows) testArgs.postScript = "bash " ~ testArgs.postScript;
-                execute(f, testArgs.postScript ~ " " ~ thisRunName, true);
+                string prefix = "";
+                version (Windows) prefix = "bash ";
+                execute(f, prefix ~ testArgs.postScript ~ " " ~ thisRunName, true);
             }
         }
         catch(Exception e)


### PR DESCRIPTION
When running the tests in Windows, if a post-script is specified, the
"bash" command is prepended to the script string. If arguments have to
be permuted, this is done more than once, resulting in an ill formatted
command to execute, with multiple "bash" prepended (like "bash bash
script"), making the post-script to invariably fail.

This patch makes the prepending temporal to avoid the accumulation
effect.
