### PR TITLE
CTFE: reduce memory use for arr.length = n

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -144,6 +144,12 @@ Expression * modifyStructField(Type *type, StructLiteralExp *se, size_t offset, 
 Expression *assignAssocArrayElement(Loc loc, AssocArrayLiteralExp *aae,
     Expression *index, Expression *newval);
 
+/// Given array literal oldval of type ArrayLiteralExp or StringExp, of length
+/// oldlen, change its length to newlen. If the newlen is longer than oldlen,
+/// all new elements will be set to the default initializer for the element type.
+Expression *changeArrayLiteralLength(Loc loc, TypeArray *arrayType,
+    Expression *oldval,  size_t oldlen, size_t newlen);
+
 
 
 /// Return true if t is a pointer (not a function pointer)

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1314,6 +1314,70 @@ Expression *assignAssocArrayElement(Loc loc, AssocArrayLiteralExp *aae,
     return newval;
 }
 
+/// Given array literal oldval of type ArrayLiteralExp or StringExp, of length
+/// oldlen, change its length to newlen. If the newlen is longer than oldlen,
+/// all new elements will be set to the default initializer for the element type.
+Expression *changeArrayLiteralLength(Loc loc, TypeArray *arrayType,
+    Expression *oldval,  size_t oldlen, size_t newlen)
+{
+    Type *elemType = elemType = arrayType->next;
+    assert(elemType);
+    Expression *defaultElem = elemType->defaultInitLiteral(loc);
+    Expressions *elements = new Expressions();
+    elements->setDim(newlen);
+    if (oldval->op == TOKslice)
+        oldval = resolveSlice(oldval);
+    size_t copylen = oldlen < newlen ? oldlen : newlen;
+    if (oldval->op == TOKstring)
+    {
+        StringExp *oldse = (StringExp *)oldval;
+        unsigned char *s = (unsigned char *)mem.calloc(newlen + 1, oldse->sz);
+        memcpy(s, oldse->string, copylen * oldse->sz);
+        unsigned defaultValue = (unsigned)(defaultElem->toInteger());
+        for (size_t elemi = copylen; elemi < newlen; ++elemi)
+        {
+            switch (oldse->sz)
+            {
+                case 1:     s[elemi] = defaultValue; break;
+                case 2:     ((unsigned short *)s)[elemi] = defaultValue; break;
+                case 4:     ((unsigned *)s)[elemi] = defaultValue; break;
+                default:    assert(0);
+            }
+        }
+        StringExp *se = new StringExp(loc, s, newlen);
+        se->type = arrayType;
+        se->sz = oldse->sz;
+        se->committed = oldse->committed;
+        se->ownedByCtfe = true;
+        return se;
+    }
+    else
+    {
+        if (oldlen !=0)
+            assert(oldval->op == TOKarrayliteral);
+        ArrayLiteralExp *ae = (ArrayLiteralExp *)oldval;
+        for (size_t i = 0; i < copylen; i++)
+            (*elements)[i] = ae->elements->tdata()[i];
+        if (elemType->ty == Tstruct || elemType->ty == Tsarray)
+        {   /* If it is an aggregate literal representing a value type,
+             * we need to create a unique copy for each element
+             */
+            for (size_t i = copylen; i < newlen; i++)
+                (*elements)[i] = copyLiteral(defaultElem);
+        }
+        else
+        {
+            for (size_t i = copylen; i < newlen; i++)
+                (*elements)[i] = defaultElem;
+        }
+        ArrayLiteralExp *aae = new ArrayLiteralExp(0, elements);
+        aae->type = arrayType;
+        aae->ownedByCtfe = true;
+        return aae;
+    }
+}
+
+
 /*************************** CTFE Sanity Checks ***************************/
 
 


### PR DESCRIPTION
Fix one of the few remaining cases where there was a useless complete array creation in CTFE.
If 'arr' was a slice of another array, eg arr == x[lo..hi] then
arr.length = n
would first do new arr= x[lo..hi].dup   // this is what resolveSlice() does.
and then copy the elements into the new array literal for arr.
This pull request removes that first, useless array literal creation.
