### PR TITLE
Issue 8891 - non-static opCall runs in initialization incorrectly

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1496,7 +1496,7 @@ Lnomatch:
                             ei->exp = new CommaExp(loc, e, ei->exp);
                         }
                         else
-                        /* Look for opCall
+                        /* Look for static opCall
                          * See bugzilla 2702 for more discussion
                          */
                         // Don't cast away invariant or mutability in initializer
@@ -1505,8 +1505,8 @@ Lnomatch:
                              */
                             !(ti->ty == Tstruct && t->toDsymbol(sc) == ti->toDsymbol(sc)))
                         {   // Rewrite as e1.call(arguments)
-                            Expression * eCall = new DotIdExp(loc, e1, Id::call);
-                            ei->exp = new CallExp(loc, eCall, ei->exp);
+                            Expression *e = typeDotIdExp(ei->exp->loc, t, Id::call);
+                            ei->exp = new CallExp(loc, e, ei->exp);
                         }
                     }
                 }

--- a/test/fail_compilation/bug8891.d
+++ b/test/fail_compilation/bug8891.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/bug8891.d(21): Error: need 'this' for opCall type S(int n)
+---
+*/
+
+struct S
+{
+    int value = 10;
+    S opCall(int n) // non-static
+    {
+        //printf("this.value = %d\n", this.value);    // prints garbage!
+        S s;
+        s.value = n;
+        return s;
+    }
+}
+void main()
+{
+    S s = 10;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8891

For the old `static opCall` idiom for the initialization, compiler should not use instance opCall.
