### PR TITLE
Issue 8865 - Assertion failure: on line 1166 in interpret.c

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -132,10 +132,10 @@ enum PROT Declaration::prot()
 
 int Declaration::checkModify(Loc loc, Scope *sc, Type *t)
 {
-    if (sc->incontract && isParameter())
+    if ((sc->flags & SCOPEcontract) && isParameter())
         error(loc, "cannot modify parameter '%s' in contract", toChars());
 
-    if (sc->incontract && isResult())
+    if ((sc->flags & SCOPEcontract) && isResult())
         error(loc, "cannot modify result '%s' in contract", toChars());
 
     if (isCtorinit() && !t->isMutable() ||

--- a/src/func.c
+++ b/src/func.c
@@ -1509,7 +1509,6 @@ void FuncDeclaration::semantic3(Scope *sc)
                 else if (fpreinv)
                     freq = new CompoundStatement(0, freq, fpreinv);
 
-                freq->incontract = 1;
                 a->push(freq);
             }
 

--- a/src/scope.c
+++ b/src/scope.c
@@ -70,7 +70,6 @@ Scope::Scope()
     this->depmsg = NULL;
     this->offset = 0;
     this->inunion = 0;
-    this->incontract = 0;
     this->nofree = 0;
     this->noctor = 0;
     this->noaccesscheck = 0;
@@ -119,7 +118,6 @@ Scope::Scope(Scope *enclosing)
     this->stc = enclosing->stc;
     this->offset = 0;
     this->inunion = enclosing->inunion;
-    this->incontract = enclosing->incontract;
     this->nofree = 0;
     this->noctor = enclosing->noctor;
     this->noaccesscheck = enclosing->noaccesscheck;
@@ -128,7 +126,7 @@ Scope::Scope(Scope *enclosing)
     this->speculative = enclosing->speculative;
     this->parameterSpecialization = enclosing->parameterSpecialization;
     this->callSuper = enclosing->callSuper;
-    this->flags = 0;
+    this->flags = (enclosing->flags & SCOPEcontract);
     this->lastdc = NULL;
     this->lastoffset = 0;
     this->docbuf = enclosing->docbuf;

--- a/src/scope.h
+++ b/src/scope.h
@@ -62,7 +62,6 @@ struct Scope
                                 // set in a pass after semantic() on all fields so they can be
                                 // semantic'd in any order.
     int inunion;                // we're processing members of a union
-    int incontract;             // we're inside contract code
     int nofree;                 // set if shouldn't free it
     int noctor;                 // set if constructor calls aren't allowed
     int intypeof;               // in typeof(exp)
@@ -95,6 +94,11 @@ struct Scope
 #define SCOPEfree       4       // is on free list
 #define SCOPEstaticassert 8     // inside static assert
 #define SCOPEdebug      0x10    // inside debug conditional
+
+#define SCOPEinvariant  0x20    // inside invariant code
+#define SCOPErequire    0x40    // inside in contract code
+#define SCOPEensure     0x60    // inside out contract code
+#define SCOPEcontract   0x60    // [mask] we're inside contract code
 
 #ifdef IN_GCC
     Expressions *attributes;    // GCC decl/type attributes

--- a/src/statement.c
+++ b/src/statement.c
@@ -33,6 +33,27 @@
 extern int os_critsecsize32();
 extern int os_critsecsize64();
 
+Identifier *fixupLabelName(Scope *sc, Identifier *ident)
+{
+    unsigned flags = (sc->flags & SCOPEcontract);
+    if (flags && flags != SCOPEinvariant &&
+        !(ident->string[0] == '_' && ident->string[1] == '_'))
+    {
+        /* CTFE requires FuncDeclaration::labtab for the interpretation.
+         * So fixing the label name inside in/out contracts is necessary
+         * for the uniqueness in labtab.
+         */
+        const char *prefix = flags == SCOPErequire ? "__in_" : "__out_";
+        OutBuffer buf;
+        buf.printf("%s%s", prefix, ident->toChars());
+        buf.writeByte(0);
+
+        const char *name = (const char *)buf.extractData();
+        ident = Lexer::idPool(name);
+    }
+    return ident;
+}
+
 /******************************** Statement ***************************/
 
 Statement::Statement(Loc loc)
@@ -3760,7 +3781,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         exp = new IntegerExp(0);
     }
 
-    if (sc->incontract || scx->incontract)
+    if ((sc->flags & SCOPEcontract) || (scx->flags & SCOPEcontract))
         error("return statements cannot be in contracts");
     if (sc->tf || scx->tf)
         error("return statements cannot be in finally, scope(exit) or scope(success) bodies");
@@ -4102,6 +4123,8 @@ Statement *BreakStatement::semantic(Scope *sc)
     //  break Identifier;
     if (ident)
     {
+        ident = fixupLabelName(sc, ident);
+
         Scope *scx;
         FuncDeclaration *thisfunc = sc->func;
 
@@ -4193,6 +4216,8 @@ Statement *ContinueStatement::semantic(Scope *sc)
     //printf("ContinueStatement::semantic() %p\n", this);
     if (ident)
     {
+        ident = fixupLabelName(sc, ident);
+
         Scope *scx;
         FuncDeclaration *thisfunc = sc->func;
 
@@ -5110,6 +5135,8 @@ Statement *GotoStatement::semantic(Scope *sc)
 {   FuncDeclaration *fd = sc->parent->isFuncDeclaration();
 
     //printf("GotoStatement::semantic()\n");
+    ident = fixupLabelName(sc, ident);
+
     tf = sc->tf;
     label = fd->searchLabel(ident);
     if (!label->statement && sc->fes)
@@ -5171,6 +5198,8 @@ Statement *LabelStatement::semantic(Scope *sc)
     FuncDeclaration *fd = sc->parent->isFuncDeclaration();
 
     //printf("LabelStatement::semantic()\n");
+    ident = fixupLabelName(sc, ident);
+
     ls = fd->searchLabel(ident);
     if (ls->statement)
         error("Label '%s' already defined", ls->toChars());

--- a/src/statement.c
+++ b/src/statement.c
@@ -40,7 +40,6 @@ Statement::Statement(Loc loc)
 {
     // If this is an in{} contract scope statement (skip for determining
     //  inlineStatus of a function body for header content)
-    incontract = 0;
 }
 
 Statement *Statement::syntaxCopy()

--- a/src/statement.h
+++ b/src/statement.h
@@ -94,7 +94,6 @@ struct Statement : Object
     void warning(const char *format, ...);
     void deprecation(const char *format, ...);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-    int incontract;
     virtual ScopeStatement *isScopeStatement() { return NULL; }
     virtual Statement *semantic(Scope *sc);
     Statement *semanticScope(Scope *sc, Statement *sbreak, Statement *scontinue);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4728,4 +4728,47 @@ struct S74 {
 
 enum Test74 = S74.test();
 
+/******************************************************/
+
+static bool bug8865()
+in
+{
+    int x = 0;
+label:
+    foreach (i; (++x)..3)
+    {
+        if (i == 1)
+            continue label;     // doesn't work.
+        else
+            break label;        // doesn't work.
+    }
+}
+out
+{
+    int x = 0;
+label:
+    foreach (i; (++x)..3)
+    {
+        if (i == 1)
+            continue label;     // doesn't work.
+        else
+            break label;        // doesn't work.
+    }
+}
+body
+{
+    int x = 0;
+label:
+    foreach (i; (++x)..3)
+    {
+        if (i == 1)
+            continue label;     // works.
+        else
+            break label;        // works.
+    }
+
+    return true;
+}
+static assert(bug8865());
+
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8865

FuncDeclaration::labtab is used by CTFE interpreter, but the labels used in `in`/`out` contracts are not merged in `labtab`.
But, syntactically labels can have same name between `in`/`out` and body. Then for the labels in contract, the internal prefixes `__in_` and `__out_` should be added to them for the look-up name uniqueness.

Additional change: `Statement::incontract` is not used completely, so remove it.
