### PR TITLE
CTFE: reduce memory usage for array comparisons

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -196,6 +196,10 @@ TypeAArray *toBuiltinAAType(Type *t);
 Expression *findKeyInAA(Loc loc, AssocArrayLiteralExp *ae, Expression *e2);
 
 
+/// Return true if non-pointer expression e can be compared
+/// with >,is, ==, etc, using ctfeCmp, ctfeEquals, ctfeIdentity
+bool isCtfeComparable(Expression *e);
+
 /// Evaluate ==, !=.  Resolves slices before comparing
 Expression *ctfeEqual(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2);
 

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -763,6 +763,25 @@ int comparePointers(Loc loc, enum TOK op, Type *type, Expression *agg1, dinteger
 
 /******** Constant folding, with support for CTFE ***************************/
 
+/// Return true if non-pointer expression e can be compared
+/// with >,is, ==, etc, using ctfeCmp, ctfeEquals, ctfeIdentity
+bool isCtfeComparable(Expression *e)
+{
+    Expression *x = e;
+    if (x->op == TOKslice)
+        x = ((SliceExp *)e)->e1;
+
+    if (x->isConst() != 1 &&
+        x->op != TOKnull &&
+        x->op != TOKstring &&
+        x->op != TOKarrayliteral &&
+        x->op != TOKstructliteral &&
+        x->op != TOKclassreference)
+    {
+        return false;
+    }
+    return true;
+}
 
 int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2);
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1094,8 +1094,6 @@ Expression *SwitchStatement::interpret(InterState *istate)
     Expression *econdition = condition->interpret(istate);
     if (exceptionOrCantInterpret(econdition))
         return econdition;
-    if (econdition->op == TOKslice)
-        econdition = resolveSlice(econdition);
 
     Statement *s = NULL;
     if (cases)
@@ -2013,8 +2011,6 @@ Expression *AssocArrayLiteralExp::interpret(InterState *istate, CtfeGoal goal)
      */
     for (size_t i = 1; i < keysx->dim; i++)
     {   Expression *ekey = keysx->tdata()[i - 1];
-        if (ekey->op == TOKslice)
-            ekey = resolveSlice(ekey);
         for (size_t j = i; j < keysx->dim; j++)
         {   Expression *ekey2 = keysx->tdata()[j];
             Expression *ex = ctfeEqual(loc, TOKequal, Type::tbool, ekey, ekey2);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2381,42 +2381,23 @@ Expression *BinExp::interpretCommon2(InterState *istate, CtfeGoal goal, fp2_t fp
     e1 = this->e1->interpret(istate);
     if (exceptionOrCantInterpret(e1))
         return e1;
-    if (e1->op == TOKslice)
-        e1 = resolveSlice(e1);
-
-    if (e1->isConst() != 1 &&
-        e1->op != TOKnull &&
-        e1->op != TOKstring &&
-        e1->op != TOKarrayliteral &&
-        e1->op != TOKstructliteral &&
-        e1->op != TOKclassreference)
+    if (!isCtfeComparable(e1))
     {
         error("cannot compare %s at compile time", e1->toChars());
-        goto Lcant;
+        return EXP_CANT_INTERPRET;
     }
-
     e2 = this->e2->interpret(istate);
     if (exceptionOrCantInterpret(e2))
         return e2;
-    if (e2->op == TOKslice)
-        e2 = resolveSlice(e2);
-    if (e2->isConst() != 1 &&
-        e2->op != TOKnull &&
-        e2->op != TOKstring &&
-        e2->op != TOKarrayliteral &&
-        e2->op != TOKstructliteral &&
-        e2->op != TOKclassreference)
+    if (!isCtfeComparable(e2))
     {
         error("cannot compare %s at compile time", e2->toChars());
-        goto Lcant;
+        return EXP_CANT_INTERPRET;
     }
     e = (*fp)(loc, op, type, e1, e2);
     if (e == EXP_CANT_INTERPRET)
         error("%s cannot be interpreted at compile time", toChars());
     return e;
-
-Lcant:
-    return EXP_CANT_INTERPRET;
 }
 
 #define BIN_INTERPRET2(op, opfunc) \


### PR DESCRIPTION
Things like "if (v == str)" always created a useless memory allocation, whenever v was a slice of another array. This is because it used to be implemented with constfold.Equals(), which couldn't handle CTFE-interal slice expressions. Ditto for Identity() and Cmp().
But the new functions ctfeEqual, ctfeIdentity, ctfeCmp support slices now, so the resolveSlice
call is no longer required. This could have a large performance impact for string comparisons.

The second commit does the same thing for strings in case statements and AA literals, but that's just for completeness --  I don't expect the performance impact to be large.
