### PR TITLE
CTFE 'ref' regression 8498 + bugs 7658 and 8539

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -243,7 +243,6 @@ void printCtfePerformanceStats()
 Expression * resolveReferences(Expression *e, Expression *thisval);
 Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal);
 VarDeclaration *findParentVar(Expression *e, Expression *thisval);
-Expression *findKeyInAA(Loc loc, AssocArrayLiteralExp *ae, Expression *e2);
 Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
     FuncDeclaration *fd, Expressions *arguments, Expression *pthis);
 Expression *scrubReturnValue(Loc loc, Expression *e);
@@ -1577,7 +1576,7 @@ Expression * resolveReferences(Expression *e, Expression *thisval)
                 continue;
             }
             else if (v->getValue() && (v->getValue()->op==TOKindex || v->getValue()->op == TOKdotvar
-                  || v->getValue()->op == TOKthis ))
+                  || v->getValue()->op == TOKthis  || v->getValue()->op == TOKvar))
             {
                 e = v->getValue();
                 continue;
@@ -1737,6 +1736,10 @@ Expression *VarExp::interpret(InterState *istate, CtfeGoal goal)
             else     // CTFE initiated from inside a function
                 error("variable %s cannot be read at compile time", v->toChars());
             return EXP_CANT_INTERPRET;
+        }
+        else if (v && v->hasValue() && v->getValue()->op == TOKvar)
+        {   // A ref of a reference,  is the original reference
+            return v->getValue();
         }
         return this;
     }
@@ -2501,7 +2504,18 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             }
         }
     }
+    // If it is a reference type (eg, an array), we need an lvalue.
+    // If it is a reference variable (such as happens in foreach), we
+    // need an lvalue reference. For example if x, y are int[], then
+    // y[0..4] = x[0..4] is an rvalue assignment (all copies in the
+    //   slice are duplicated)
+    // y = x[0..4] is an lvalue assignment (if x[0] changes later,
+    //    y[0] will also change)
+    // ref int [] z = x is an lvalueref assignment (if x itself changes,
+    //   z will also change)
     bool wantRef = false;
+    bool wantLvalueRef = false;
+
     if (!fp && this->e1->type->toBasetype() == this->e2->type->toBasetype() &&
         (e1->type->toBasetype()->ty == Tarray || isAssocArray(e1->type)
              || e1->type->toBasetype()->ty == Tclass)
@@ -2540,10 +2554,12 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         wantRef = true;
     }
     // If it is a construction of a ref variable, it is a ref assignment
+    // (in fact, it is an lvalue reference assignment).
     if (op == TOKconstruct && this->e1->op==TOKvar
         && ((VarExp*)this->e1)->var->storage_class & STCref)
     {
          wantRef = true;
+         wantLvalueRef = true;
     }
 
     if (fp)
@@ -2771,7 +2787,8 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
     // ---------------------------------------
     if (wantRef && !fp && this->e1->op != TOKarraylength)
     {
-        newval = this->e2->interpret(istate, ctfeNeedLvalue);
+        newval = this->e2->interpret(istate,
+            wantLvalueRef ? ctfeNeedLvalueRef : ctfeNeedLvalue);
         if (exceptionOrCantInterpret(newval))
             return newval;
         // If it is an assignment from a array function parameter passed by

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4098,6 +4098,47 @@ static assert(bug7245(0)==6);
 static assert(bug7245(1)==5);
 
 /**************************************************
+    8498 modifying foreach
+    7658 foreach ref
+    8539 nested funcs, ref param, -inline
+**************************************************/
+
+int bug8498()
+{
+    foreach(i; 0..5)
+    {
+        assert(i == 0);
+        i = 100;
+    }
+    return 1;
+}
+static assert(bug8498());
+
+string bug7658() {
+    string[] children = ["0"];
+    foreach(ref child; children)
+        child = "1";
+    return children[0];
+}
+
+static assert(bug7658() == "1");
+
+int bug8539() {
+    static void one(ref int x) {
+        x = 1;
+    }
+    static void go() {
+        int y;
+        one(y);
+        assert(y == 1); // fails with -inline
+    }
+    go();
+    return 1;
+}
+
+static assert(bug8539());
+
+/**************************************************
     6919
 **************************************************/
 


### PR DESCRIPTION
Regression [8498](http://d.puremagic.com/issues/show_bug.cgi?id=8498)  modifying foreach range iterator fails in CTFE
Also fixes [bug 7658](http://d.puremagic.com/issues/show_bug.cgi?id=7658): assignment to ref in foreach.
Also fixes [bug 8539](http://d.puremagic.com/issues/show_bug.cgi?id=8539): nested functions, ref parameter, -inline.

This was caused by ignoring assignment to ref variables.
(These guys can only be created by the inliner, or by lowering,
such as happens in foreach).

The three bugs aren't really duplicates, but the same patch fixes them all.
