### PR TITLE
8893 ICE(interpret.c) with invalid struct literal

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4074,6 +4074,8 @@ Expression *StructLiteralExp::semantic(Scope *sc)
         }
 
         e = e->implicitCastTo(sc, telem);
+        if (e->op == TOKerror)
+            return e;
 
         (*elements)[i] = e;
     }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1084,6 +1084,17 @@ void oddity4001(int q)
 
 static const bug3779 = ["123"][0][$-1];
 
+/*******************************************
+    Bug 8893 ICE with bad struct literal
+*******************************************/
+
+struct Foo8893 {
+    char[3] data;
+}
+int bar8893(Foo8893 f) {
+    return f.data[0];
+}
+static assert( !is(typeof(compiles!( bar8893(Foo8893(['a','b'])) ))));
 
 /*******************************************
     non-Cow struct literals


### PR DESCRIPTION
The implicit conversion can fail.  In this case the struct literal is invalid and should be treated as an ErrorExp (which means it will never reach CTFE).

http://d.puremagic.com/issues/show_bug.cgi?id=8893
