### PR TITLE
CTFE primitives that don't allocate memory

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -214,14 +214,14 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
 /// with >,is, ==, etc, using ctfeCmp, ctfeEquals, ctfeIdentity
 bool isCtfeComparable(Expression *e);
 
-/// Evaluate ==, !=.  Resolves slices before comparing
-Expression *ctfeEqual(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2);
+/// Evaluate ==, !=.  Resolves slices before comparing. Returns 0 or 1
+int ctfeEqual(Loc loc, enum TOK op, Expression *e1, Expression *e2);
 
-/// Evaluate is, !is.  Resolves slices before comparing
-Expression *ctfeIdentity(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2);
+/// Evaluate is, !is.  Resolves slices before comparing. Returns 0 or 1
+int ctfeIdentity(Loc loc, enum TOK op, Expression *e1, Expression *e2);
 
-/// Evaluate >,<=, etc. Resolves slices before comparing
-Expression *ctfeCmp(Loc loc, enum TOK op, Type *type, Expression *e1, Expression *e2);
+/// Evaluate >,<=, etc. Resolves slices before comparing. Returns 0 or 1
+int ctfeCmp(Loc loc, enum TOK op, Expression *e1, Expression *e2);
 
 /// Returns e1 ~ e2. Resolves slices before concatenation.
 Expression *ctfeCat(Type *type, Expression *e1, Expression *e2);

--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -195,6 +195,20 @@ TypeAArray *toBuiltinAAType(Type *t);
  */
 Expression *findKeyInAA(Loc loc, AssocArrayLiteralExp *ae, Expression *e2);
 
+/***********************************************
+      In-place integer operations
+***********************************************/
+
+/// e = OP e
+void intUnary(TOK op, IntegerExp *e);
+
+/// dest = e1 OP e2;
+void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp *e2);
+
+
+/***********************************************
+      COW const-folding operations
+***********************************************/
 
 /// Return true if non-pointer expression e can be compared
 /// with >,is, ==, etc, using ctfeCmp, ctfeEquals, ctfeIdentity

--- a/src/expression.h
+++ b/src/expression.h
@@ -805,8 +805,8 @@ struct BinExp : Expression
 
     Expression *interpretCommon(InterState *istate, CtfeGoal goal,
         Expression *(*fp)(Type *, Expression *, Expression *));
-    Expression *interpretCommon2(InterState *istate, CtfeGoal goal,
-        Expression *(*fp)(Loc, TOK, Type *, Expression *, Expression *));
+    Expression *interpretCompareCommon(InterState *istate, CtfeGoal goal,
+        int (*fp)(Loc, TOK, Expression *, Expression *));
     Expression *interpretAssignCommon(InterState *istate, CtfeGoal goal,
         Expression *(*fp)(Type *, Expression *, Expression *), int post = 0);
     Expression *interpretFourPointerRelation(InterState *istate, CtfeGoal goal);


### PR DESCRIPTION
First step to fast CTFE. Implements primitives that don't allocate memory.
This eliminates memory allocation for internal compares, which improves things such as searches through AA literals. The integer binary and unary operators aren't used for anything yet.
