### PR TITLE
Fix build when targeting OS X Mountain Lion.

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -61,7 +61,7 @@ ifeq (OSX,$(TARGET))
     endif
     ## See: http://developer.apple.com/documentation/developertools/conceptual/cross_development/Using/chapter_3_section_2.html#//apple_ref/doc/uid/20002000-1114311-BABGCAAB
     ENVP= MACOSX_DEPLOYMENT_TARGET=10.3
-    SDKVERS:=1 2 3 4 5 6 7
+    SDKVERS:=1 2 3 4 5 6 7 8
     SDKFILES=$(foreach SDKVER, $(SDKVERS), $(wildcard $(SDKDIR)/MacOSX10.$(SDKVER).sdk))
     SDK=$(firstword $(SDKFILES))
     TARGET_CFLAGS=-isysroot ${SDK}

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -381,7 +381,11 @@ PortInitializer::PortInitializer()
 int Port::isNan(double r)
 {
 #if __APPLE__
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
+    return __inline_isnand(r);
+#else
     return __inline_isnan(r);
+#endif
 #elif __OpenBSD__
     return isnan(r);
 #else
@@ -393,7 +397,11 @@ int Port::isNan(double r)
 int Port::isNan(longdouble r)
 {
 #if __APPLE__
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
+    return __inline_isnanl(r);
+#else
     return __inline_isnan(r);
+#endif
 #elif __OpenBSD__
     return isnan(r);
 #else


### PR DESCRIPTION
The Mac OS X SDK appears to have changed __inline_isnan to
__inline_isnan[fdl] for SDK 10.8. This uses the proper functions
when targeting SDK 10.8+.
