### PR TITLE
Additional fix for Issue 4090 - No foreach type inference with const, ref etc modifiers

### DIFF
--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -189,15 +189,45 @@ void test3187()
 /***************************************/
 // 4090
 
-void test4090()
+void test4090a()
 {
-    double[10] arr;
+    double[10] arr = 1;
     double tot = 0;
+
+  static assert(!__traits(compiles, {
+    foreach (immutable ref x; arr) {}
+  }));
     foreach (const ref x; arr)
     {
         static assert(is(typeof(x) == const double));
         tot += x;
     }
+    foreach (immutable x; arr)
+    {
+        static assert(is(typeof(x) == immutable double));
+        tot += x;
+    }
+    assert(tot == 1*10 + 1*10);
+}
+
+void test4090b()
+{
+    int tot = 0;
+
+  static assert(!__traits(compiles, {
+    foreach (immutable ref x; 1..11) {}
+  }));
+    foreach (const ref x; 1..11)
+    {
+        static assert(is(typeof(x) == const int));
+        tot += x;
+    }
+    foreach (immutable x; 1..11)
+    {
+        static assert(is(typeof(x) == immutable int));
+        tot += x;
+    }
+    assert(tot == 55 + 55);
 }
 
 /***************************************/
@@ -430,7 +460,8 @@ int main()
     test2442();
     test2443();
     test3187();
-    test4090();
+    test4090a();
+    test4090b();
     test5605();
     test7004();
     test7406();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=4090

This fixes foreach-range statements, which the pull #1033 hadn't fix.
