### PR TITLE
Issue 8942 - `alias <qualifier> <type>` ignores <qualifier> in foreach over tuple

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -439,6 +439,7 @@ Dsymbol *AliasDeclaration::syntaxCopy(Dsymbol *s)
         sa = new AliasDeclaration(loc, ident, type->syntaxCopy());
     else
         sa = new AliasDeclaration(loc, ident, aliassym->syntaxCopy(NULL));
+    sa->storage_class = storage_class;
 
     // Syntax copy for header file
     if (!htype)     // Don't overwrite original

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -104,6 +104,29 @@ void test8410()
 }
 
 /***************************************************/
+// 8942
+
+alias const int A8942_0;
+static assert(is(A8942_0 == const int)); // passes
+
+void test8942()
+{
+    alias const int A8942_1;
+    static assert(is(A8942_1 == const int)); // passes
+
+    static struct S { int i; }
+    foreach (Unused; typeof(S.tupleof))
+    {
+        alias const(int) A8942_2;
+        static assert(is(A8942_2 == const int)); // also passes
+
+        alias const int A8942_3;
+        static assert(is(A8942_3 == const int)); // fails
+        // Error: static assert  (is(int == const(int))) is false
+    }
+}
+
+/***************************************************/
 
 int main()
 {
@@ -112,6 +135,7 @@ int main()
     test8123();
     test8147();
     test8410();
+    test8942();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8942

`AliasDeclaration::syntaxCopy` should copy its `storage_class` field for the later semantic.
