### PR TITLE
Issue 8937 - import declaration statement without scope after `if` imports to a parent scope

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3665,6 +3665,8 @@ Statement *Parser::parseStatement(int flags)
                 Dsymbols *imports = new Dsymbols();
                 parseImport(imports, 1);                // static import ...
                 s = new ImportStatement(loc, imports);
+                if (flags & PSscope)
+                    s = new ScopeStatement(loc, s);
                 break;
             }
             goto Ldeclaration;
@@ -3754,6 +3756,8 @@ Statement *Parser::parseStatement(int flags)
                     goto Ldeclaration;
             }
             s = new ExpStatement(loc, d);
+            if (flags & PSscope)
+                s = new ScopeStatement(loc, s);
             break;
         }
 
@@ -3776,6 +3780,8 @@ Statement *Parser::parseStatement(int flags)
             }
             Dsymbol *d = parseMixin();
             s = new ExpStatement(loc, d);
+            if (flags & PSscope)
+                s = new ScopeStatement(loc, s);
             break;
         }
 
@@ -4133,6 +4139,8 @@ Statement *Parser::parseStatement(int flags)
                 checkDanglingElse(elseloc);
             }
             s = new ConditionalStatement(loc, condition, ifbody, elsebody);
+            if (flags & PSscope)
+                s = new ScopeStatement(loc, s);
             break;
 
         case TOKpragma:
@@ -4548,6 +4556,8 @@ Statement *Parser::parseStatement(int flags)
         {   Dsymbols *imports = new Dsymbols();
             parseImport(imports, 0);
             s = new ImportStatement(loc, imports);
+            if (flags & PSscope)
+                s = new ScopeStatement(loc, s);
             break;
         }
 

--- a/test/compilable/test8937.d
+++ b/test/compilable/test8937.d
@@ -1,0 +1,60 @@
+
+mixin template X8937()
+{
+    int value;
+}
+
+debug = test;
+
+void main()
+{
+    // (static) import statement
+    {
+        static assert(!__traits(compiles, cos(0)));
+        if (true)
+        {
+            static assert(!__traits(compiles, cos(0)));
+            import core.stdc.math;
+            static assert( __traits(compiles, cos(0)));
+        }
+        static assert(!__traits(compiles, cos(0)));
+
+        if (true)
+            import core.stdc.math;
+        static assert(!__traits(compiles, cos(0))); // fails
+
+        if (true)
+            static import core.stdc.math;
+        static assert(!__traits(compiles, core.stdc.math.cos(0))); // fails
+    }
+    static assert(!__traits(compiles, cos(0)));
+
+    // mixin statement
+    {
+        if (true)
+            mixin X8937!();
+        static assert(!__traits(compiles, value)); // fails
+    }
+
+    // enum declaration
+    {
+        if (true)
+            enum E { x = 10 }
+        static assert(!__traits(compiles, E)); // fails
+    }
+
+    // conditional declarations
+    {
+        if (true)
+            static if (true) struct S1 {}
+        static assert(!__traits(compiles, S1)); // fails
+
+        if (true)
+            version (all) struct S2 {}
+        static assert(!__traits(compiles, S2)); // fails
+
+        if (true)
+            debug (test) struct S3 {}
+        static assert(!__traits(compiles, S3)); // fails
+    }
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8937

This is a parser problem, and not only for `import` statements, and also `mixin` statements, `enum` declarations, and conditional declarations (`static if`, `version` and `debug`)
