### PR TITLE
Issue 8959 - IsExpression should support syntax which has no Identifier in all cases

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5942,16 +5942,9 @@ Expression *IsExp::semantic(Scope *sc)
          * is(targ id : tspec, tpl)
          */
 
-        if (id)
-        {
-            TemplateParameter *tp = new TemplateTypeParameter(loc, id, NULL, NULL);
-            parameters->insert(0, tp);
-        }
-        else
-        {
-            TemplateParameter *tp = new TemplateTypeParameter(loc, Lexer::uniqueId("is_id"), NULL, NULL);
-            parameters->insert(0, tp);
-        }
+        Identifier *tid = id ? id : Lexer::uniqueId("__isexp_id");
+        TemplateParameter *tp = new TemplateTypeParameter(loc, tid, NULL, NULL);
+        parameters->insert(0, tp);
 
         Objects dedtypes;
         dedtypes.setDim(parameters->dim);
@@ -5967,7 +5960,7 @@ Expression *IsExp::semantic(Scope *sc)
         }
         else
         {
-            tded = id ? (Type *)dedtypes[0] : targ;
+            tded = (Type *)dedtypes[0];
             if (!tded)
                 tded = targ;
 #if DMDV2

--- a/src/parse.c
+++ b/src/parse.c
@@ -5717,7 +5717,7 @@ Expression *Parser::parsePrimaryExp()
                         tspec = parseType();
                     }
                 }
-                if (ident && tspec)
+                if (tspec)
                 {
                     if (token.value == TOKcomma)
                         tpl = parseTemplateParameterList(1);
@@ -5725,8 +5725,6 @@ Expression *Parser::parsePrimaryExp()
                     {   tpl = new TemplateParameters();
                         check(TOKrparen);
                     }
-                    TemplateParameter *tp = new TemplateTypeParameter(loc, ident, NULL, NULL);
-                    tpl->insert(0, tp);
                 }
                 else
                     check(TOKrparen);

--- a/test/compilable/test8959.d
+++ b/test/compilable/test8959.d
@@ -1,0 +1,55 @@
+/*
+TEST_OUTPUT:
+---
+U1 = int
+U2 = int
+V1 = long, K1 = string
+V2 = long, K2 = string
+TL1 = (int, string)
+TL2 = (int, string)
+U3 = int
+U4 = int
+V3 = long, K3 = string
+V4 = long, K4 = string
+TL3 = (int, string)
+TL4 = (int, string)
+---
+*/
+
+static if (is(int* == U1*, U1)) { pragma(msg, "U1 = ", U1); }
+static if (is(int* :  U2*, U2)) { pragma(msg, "U2 = ", U2); }
+static assert(is(int* == U*, U));
+static assert(is(int* :  U*, U));
+
+alias AA = long[string];
+static if (is(AA == V1[K1], V1, K1)) { pragma(msg, "V1 = ", V1, ", K1 = ", K1); }
+static if (is(AA :  V2[K2], V2, K2)) { pragma(msg, "V2 = ", V2, ", K2 = ", K2); }
+static assert(is(AA == V[K], V, K));
+static assert(is(AA :  V[K], V, K));
+
+class B(TL...) {}
+class C(TL...) : B!TL {}
+alias X = C!(int, string);
+
+static if (is(X == C!TL1, TL1...)) { pragma(msg, "TL1 = ", TL1); }
+static if (is(X :  B!TL2, TL2...)) { pragma(msg, "TL2 = ", TL2); }
+static assert(is(X == C!TL, TL...));
+static assert(is(X :  B!TL, TL...));
+
+void test8959()
+{
+    static if (is(int* == U3*, U3)) { pragma(msg, "U3 = ", U3); }
+    static if (is(int* :  U4*, U4)) { pragma(msg, "U4 = ", U4); }
+    static assert(is(int* == U*, U));
+    static assert(is(int* :  U*, U));
+
+    static if (is(AA == V3[K3], V3, K3)) { pragma(msg, "V3 = ", V3, ", K3 = ", K3); }
+    static if (is(AA :  V4[K4], V4, K4)) { pragma(msg, "V4 = ", V4, ", K4 = ", K4); }
+    static assert(is(AA == V[K], V, K));
+    static assert(is(AA :  V[K], V, K));
+
+    static if (is(X == C!TL3, TL3...)) { pragma(msg, "TL3 = ", TL3); }
+    static if (is(X :  B!TL4, TL4...)) { pragma(msg, "TL4 = ", TL4); }
+    static assert(is(X == C!TL, TL...));
+    static assert(is(X :  B!TL, TL...));
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8959

This supports additional syntax of _IsExpression_.

```
is ( Type :  TypeSpecialization , TemplateParameterList )
is ( Type == TypeSpecialization , TemplateParameterList )
```
