### PR TITLE
5996 ICE(expression.c) CTFE of erroneous auto return function

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3003,7 +3003,12 @@ Lagain:
         {
             TemplateInstance *spec = f->isSpeculative();
             int olderrs = global.errors;
+            // If it isn't speculative, we need to show errors
+            unsigned oldgag = global.gag;
+            if (global.gag && !spec)
+                global.gag = 0;
             f->semantic3(f->scope);
+            global.gag = oldgag;
             // Update the template instantiation with the number
             // of errors which occured.
             if (spec && global.errors != olderrs)

--- a/test/fail_compilation/ice5996.d
+++ b/test/fail_compilation/ice5996.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice5996.d(9): Error: undefined identifier anyOldGarbage
+fail_compilation/ice5996.d(12): Error: CTFE failed because of previous errors in bug5996
+---
+*/
+auto bug5996() {
+    if (anyOldGarbage) {}
+    return 2;
+}
+enum uint h5996 = bug5996();


### PR DESCRIPTION
When running semantic3 on a function to determine its return value, errors
must not be gagged. There is no chance to re-run semantic3 on it.
