### PR TITLE
Issue 8526 & 6141 - DMD 2.060 regression: anonymous delegate call in foreach loop

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2925,7 +2925,11 @@ elem *AssignExp::toElem(IRState *irs)
             e = e2->toElem(irs);
             e = addressElem(e, e2->type);
 #endif
-            elem *es = el_var(s->toSymbol());
+            elem *es = e1->toElem(irs);
+            if (es->Eoper == OPind)
+                es = es->E1;
+            else
+                es = el_una(OPaddr, TYnptr, es);
             es->Ety = TYnptr;
             e = el_bin(OPeq, TYnptr, es, e);
 // BUG: type is struct, and e2 is TOKint64

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5500,7 +5500,39 @@ void test8108()
 }
 
 /***************************************************/
-// 8526
+// 6141 + 8526
+
+void test6141()
+{
+    static void takeADelegate(void delegate()) {}
+    auto items = new int[1];
+    items[0] = 17;
+    foreach (ref item; items)
+    {
+        // both asserts fail
+        assert(item == 17);
+        assert(&item == items.ptr);
+
+        takeADelegate({ auto x = &item; });
+    }
+
+    foreach(ref val; [3])
+    {
+        auto dg = { int j = val; };
+        assert(&val != null); // Assertion failure
+        assert(val == 3);
+    }
+
+    static void f(lazy int) {}
+    int i = 0;
+    auto dg = { int j = i; };
+    foreach(ref val; [3])
+    {
+        f(val);
+        assert(&val != null); // Assertion failure
+        assert(val == 3);
+    }
+}
 
 void test8526()
 {
@@ -5841,6 +5873,7 @@ int main()
     test160();
     test8665();
     test8108();
+    test6141();
     test8526();
     test161();
     test8917();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5500,6 +5500,28 @@ void test8108()
 }
 
 /***************************************************/
+// 8526
+
+void test8526()
+{
+    static void call(void delegate() dg) { dg(); }
+
+    foreach (i, j; [0])
+    {
+        call({
+            assert(i == 0); // fails, i is corrupted
+        });
+    }
+
+    foreach (n; 0..1)
+    {
+        call({
+            assert(n == 0); // fails, n is corrupted
+        });
+    }
+}
+
+/***************************************************/
 
 template ParameterTuple(alias func)
 {
@@ -5819,6 +5841,7 @@ int main()
     test160();
     test8665();
     test8108();
+    test8526();
     test161();
     test8917();
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8526

This regression has occured from the commit:
https://github.com/D-Programming-Language/dmd/commit/38a0a5141a3455395e8b9571a57bf85ed698c6b3

But the root cause is a bug 6141.
http://d.puremagic.com/issues/show_bug.cgi?id=6141

When an internal ref variable is marked as closure var, the glue layer had generated incorrect code for that.
