### PR TITLE
Appendix for Issue 6652

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5142,11 +5142,11 @@ Expression *VarExp::modifiableLvalue(Scope *sc, Expression *e)
 
 #if (BUG6652 == 1)
     VarDeclaration *v = var->isVarDeclaration();
-    if (v && (v->storage_class & STCbug6652))
+    if (v && (v->storage_class & STCbug6652) && v->type->isMutable())
         warning("variable modified in foreach body requires ref storage class");
 #elif (BUG6652 == 2)
     VarDeclaration *v = var->isVarDeclaration();
-    if (v && (v->storage_class & STCbug6652))
+    if (v && (v->storage_class & STCbug6652) && v->type->isMutable())
         deprecation("variable modified in foreach body requires ref storage class");
 #endif
 

--- a/test/fail_compilation/fail6652a.d
+++ b/test/fail_compilation/fail6652a.d
@@ -3,11 +3,24 @@
 /******************************************/
 // 6652
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail6652a.d(19): Warning: variable modified in foreach body requires ref storage class
+fail_compilation/fail6652a.d(24): Error: cannot modify const expression i
+---
+*/
+
 void main()
 {
     size_t[] res;
     foreach (i; 0..2)
     {
         res ~= ++i;
+    }
+
+    foreach (const i; 0..2)
+    {
+        ++i;
     }
 }

--- a/test/fail_compilation/fail6652b.d
+++ b/test/fail_compilation/fail6652b.d
@@ -3,11 +3,24 @@
 /******************************************/
 // 6652
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail6652b.d(19): Warning: variable modified in foreach body requires ref storage class
+fail_compilation/fail6652b.d(24): Error: cannot modify const expression i
+---
+*/
+
 void main()
 {
     size_t[] res;
     foreach (i, e; [1,2,3,4,5])
     {
         res ~= ++i;
+    }
+
+    foreach (const i, e; [1,2,3,4,5])
+    {
+        ++i;
     }
 }


### PR DESCRIPTION
From the coment: http://d.puremagic.com/issues/show_bug.cgi?id=4090#c15

By the interaction of fix 4090 and 6652, useless warning has been reported.
If _implicit ref_ foreach key doesn't have a mutable type, warning is not necessary.
