### PR TITLE
Small split(string, string) fix in d_do_test.d

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -161,7 +161,7 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     findTestParameter(file, "EXTRA_SOURCES", extraSourcesStr);
     testArgs.sources = [input_file];
     // prepend input_dir to each extra source file
-    foreach(s; split(extraSourcesStr, " "))
+    foreach(s; split(extraSourcesStr))
         testArgs.sources ~= input_dir ~ "/" ~ s;
 
     // swap / with $SEP
@@ -184,7 +184,7 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
 string[] combinations(string argstr)
 {
     string[] results;
-    string[] args = split(argstr, " ");
+    string[] args = split(argstr);
     long combinations = 1 << args.length;
     for (size_t i = 0; i < combinations; i++)
     {


### PR DESCRIPTION
As mentioned in https://github.com/D-Programming-Language/phobos/pull/934#issuecomment-10282813

The _correct_ behavior for `splitter(string, string)` is to create empty tokens when input is empty (or when there are trailing separators or whatnot).

My fix was creating a problem here, where a new empty token was being (correctly) generated:
http://d.puremagic.com/test-results/pull.ghtml?runid=368596&logid=7

`../src/dmd -m32 -Icompilable   -odtest_results/compilable -oftest_results/compilable/99bottles_0.o -c compilable/99bottles.d compilable/`
(notice the trailing `compilable/`)

Anyways, the simple fix is to just use the simple string-dedicated `split(string)`, which merges runs of white, and does not produce empty tokens.
