### PR TITLE
Issue 9003 & 9006 - fill nested struct context pointers

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8071,7 +8071,7 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
     /* Copy from the initializer symbol for larger symbols,
      * otherwise the literals expressed as code get excessively large.
      */
-    if (size(loc) > PTRSIZE * 4 && !sym->isnested)
+    if (size(loc) > PTRSIZE * 4 && !needsNested())
         structinit->sinit = sym->toInitializer();
 
     // Why doesn't the StructLiteralExp constructor do this, when

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1968,8 +1968,8 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
     }
     else if (ident == Id::init)
     {
-        if (toBasetype()->ty == Tstruct &&
-            ((TypeStruct *)toBasetype())->sym->isNested())
+        Type *tb = toBasetype();
+        if (tb->ty == Tstruct && tb->needsNested())
         {
             e = defaultInit(loc);
         }

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2021,6 +2021,35 @@ void test9003()
 }
 
 /*******************************************/
+// 9006
+
+void test9006()
+{
+    int i;
+    struct NS
+    {
+        int n;
+        int[3] a; // Uncomment to fail assert on line 20 and pass on line 23
+        int f() { return i; }
+    }
+    NS ns;
+    assert(ns != NS.init);
+    ns = NS.init;
+    assert(ns == NS.init);
+
+    static struct SS { NS ns; }
+    assert(SS.init.ns == NS.init); // fails
+    assert(SS.init.ns != NS());    // fails
+
+    SS s;
+    assert(s.ns != NS.init); // line 20
+    assert(s != SS.init);    // fails
+    s = SS.init;
+    assert(s.ns == NS.init); // line 23, fails
+    assert(s == SS.init);
+}
+
+/*******************************************/
 
 int main()
 {
@@ -2096,6 +2125,7 @@ int main()
     test8923b();
     test8923c();
     test9003();
+    test9006();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -1978,6 +1978,49 @@ void test8923c()
 }
 
 /*******************************************/
+// 9003
+
+void test9003()
+{
+    int i;
+    struct NS {
+        int n1;    // Comment to pass all asserts
+        int n2;    // Uncomment to fail assert on line 19
+        int f() { return i; }
+    }
+
+    static struct SS1 {
+        NS ns;
+    }
+    SS1 ss1;
+    assert(ss1.ns != NS.init);
+
+    static struct SS2 {
+        NS ns1, ns2;
+    }
+    SS2 ss2;
+    assert(ss2.ns1 != NS.init); // line 19
+    assert(ss2.ns2 != NS.init);
+
+    static struct SS3 {
+        int i;
+        NS ns;
+    }
+
+    SS3 ss3;
+    assert(ss3.ns != NS.init);
+
+    static struct SS4 {
+        int i;
+        NS ns1, ns2;
+    }
+
+    SS4 ss4;
+    assert(ss4.ns1 != NS.init); // fails
+    assert(ss4.ns2 != NS.init); // fails
+}
+
+/*******************************************/
 
 int main()
 {
@@ -2052,6 +2095,7 @@ int main()
     test8923a();
     test8923b();
     test8923c();
+    test9003();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
[Issue 9003](http://d.puremagic.com/issues/show_bug.cgi?id=9003) - Nested structs sometimes have null context pointers in static struct
[Issue 9006](http://d.puremagic.com/issues/show_bug.cgi?id=9006) - Static struct with nested struct fields sometimes has current context pointers in `init`
