### PR TITLE
Issue 9014 - ICE(glue.c) line 1225: with array.front and missing array

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -378,6 +378,9 @@ Expression *resolveUFCSProperties(Scope *sc, Expression *e1, Expression *e2 = NU
 
         if (e2)
         {
+            // run semantic without gagging
+            e2 = e2->semantic(sc);
+
             /* .f(e1) = e2
              */
             Expression *ex = e->syntaxCopy();

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -354,6 +354,21 @@ void test4()
 }
 
 /*******************************************/
+// 9014
+
+@property ref int foo9014(int[] a)
+{
+    return a[0];
+}
+void test9014()
+{
+    int[] bar;
+  static assert(!__traits(compiles, {
+    bar.foo9014 = missing.foo9014;
+  }));
+}
+
+/*******************************************/
 
 int main()
 {
@@ -371,6 +386,7 @@ int main()
     test8453();
     test8503();
     test4();
+    test9014();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9014

UFCS property setter semantic should not gagging errors in e2.
