### PR TITLE
Make deprecations as warnings the default

### DIFF
--- a/docs/man/man1/dmd.1
+++ b/docs/man/man1/dmd.1
@@ -32,9 +32,11 @@ directory
 Write documentation file to
 .I filename
 .IP -d
-Allow deprecated features.
-.IP -di
-Show use of deprecated features as warnings.
+Silently allow deprecated features.
+.IP -dw
+Show use of deprecated features as warnings (default).
+.IP -de
+Show use of deprecated features as errors (halt compilation).
 .IP -debug
 Compile in debug code
 .IP -debug=\fIlevel\fR

--- a/src/mars.c
+++ b/src/mars.c
@@ -325,8 +325,9 @@ Usage:\n\
   -D             generate documentation\n\
   -Dddocdir      write documentation file to docdir directory\n\
   -Dffilename    write documentation file to filename\n\
-  -d             allow deprecated features\n\
-  -di            show use of deprecated features as warnings\n\
+  -d             silently allow deprecated features\n\
+  -dw            show use of deprecated features as warnings (default)\n\
+  -de            show use of deprecated features as errors (halt compilation)\n\
   -debug         compile in debug code\n\
   -debug=level   compile in debug code <= level\n\
   -debug=ident   compile in debug code identified by ident\n\
@@ -445,6 +446,7 @@ int tryMain(int argc, char *argv[])
     global.params.obj = 1;
     global.params.Dversion = 2;
     global.params.quiet = 1;
+    global.params.useDeprecated = 2;
 
     global.params.linkswitches = new Strings();
     global.params.libfiles = new Strings();
@@ -529,9 +531,11 @@ int tryMain(int argc, char *argv[])
         p = argv[i];
         if (*p == '-')
         {
-            if (strcmp(p + 1, "d") == 0)
+            if (strcmp(p + 1, "de") == 0)
+                global.params.useDeprecated = 0;
+            else if (strcmp(p + 1, "d") == 0)
                 global.params.useDeprecated = 1;
-            else if (strcmp(p + 1, "di") == 0)
+            else if (strcmp(p + 1, "dw") == 0)
                 global.params.useDeprecated = 2;
             else if (strcmp(p + 1, "c") == 0)
                 global.params.link = 0;

--- a/test/compilable/depmsg.d
+++ b/test/compilable/depmsg.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -d
-// PERMUTE_ARGS: -di
+// PERMUTE_ARGS: -dw
 
 void main()
 {

--- a/test/compilable/deprecate2.d
+++ b/test/compilable/deprecate2.d
@@ -1,5 +1,5 @@
 ﻿// REQUIRED_ARGS: -d
-// PERMUTE_ARGS: -di
+// PERMUTE_ARGS: -dw
 
 // Test cases using deprecated features
 

--- a/test/compilable/header.d
+++ b/test/compilable/header.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -di
+// PERMUTE_ARGS: -dw
 // REQUIRED_ARGS: -H -Hdtest_results/compilable
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh
 // REQUIRED_ARGS: -d

--- a/test/compilable/test55.d
+++ b/test/compilable/test55.d
@@ -1,6 +1,6 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/test55a.d
-// PERMUTE_ARGS: -di
+// PERMUTE_ARGS: -dw
 // REQUIRED_ARGS: -d
 
 public import imports.test55a;

--- a/test/compilable/test7754.d
+++ b/test/compilable/test7754.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -H -Hdtest_results/compilable
 // POST_SCRIPT: compilable/extra-files/test7754-postscript.sh
-// PERMUTE_ARGS: -d -di
+// PERMUTE_ARGS: -d -dw
 
 struct Foo(T)
 {

--- a/test/fail_compilation/depmsg.d
+++ b/test/fail_compilation/depmsg.d
@@ -1,4 +1,5 @@
 /*
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
 fail_compilation/depmsg.d(20): Deprecation: struct depmsg.main.Inner.A is deprecated - With message!

--- a/test/fail_compilation/fail108.d
+++ b/test/fail_compilation/fail108.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -d -di
+// PERMUTE_ARGS: -d -dw
 // 249
 
 module test1;

--- a/test/fail_compilation/fail121.d
+++ b/test/fail_compilation/fail121.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -d -di
+// PERMUTE_ARGS: -d -dw
 // segfault on DMD0.150, never failed if use typeid() instead.
 
 struct myobject

--- a/test/fail_compilation/fail138.d
+++ b/test/fail_compilation/fail138.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -d -di
+// PERMUTE_ARGS: -d -dw
 
 typedef int T = void;
 

--- a/test/fail_compilation/fail156.d
+++ b/test/fail_compilation/fail156.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -d -di
+// PERMUTE_ARGS: -d -dw
 
 typedef int myint = 4;
 

--- a/test/fail_compilation/fail157.d
+++ b/test/fail_compilation/fail157.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -d -di
+// PERMUTE_ARGS: -d -dw
 
 typedef int myint = 4;
 

--- a/test/fail_compilation/fail187.d
+++ b/test/fail_compilation/fail187.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -d -di
+// PERMUTE_ARGS: -d -dw
 // On DMD 2.000 bug only with typedef, not alias
 
 typedef Exception A;

--- a/test/fail_compilation/fail199.d
+++ b/test/fail_compilation/fail199.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -de
+
 import std.stdio;
 
 deprecated class DepClass {

--- a/test/fail_compilation/fail200.d
+++ b/test/fail_compilation/fail200.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -de
+
 import std.stdio;
 
 deprecated interface DepClass {

--- a/test/fail_compilation/fail243.d
+++ b/test/fail_compilation/fail243.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -de
 
 deprecated {
     class DepClass {}

--- a/test/fail_compilation/fail4.d
+++ b/test/fail_compilation/fail4.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -d -di
+// PERMUTE_ARGS: -d -dw
 // On DMD0.165 fails only with typedef, not alias
 
 typedef foo bar;

--- a/test/fail_compilation/fail6572.d
+++ b/test/fail_compilation/fail6572.d
@@ -1,3 +1,3 @@
-// REQUIRED_ARGS:
+// REQUIRED_ARGS: -de
 
 typedef int y;

--- a/test/fail_compilation/testhtml.html
+++ b/test/fail_compilation/testhtml.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!--
-PERMUTE_ARGS: -d -di
+PERMUTE_ARGS: -d -dw
 -->
 <html><head><title>dstress: html_entity_01</title></head><body><pre><CODE>
 int main(){

--- a/test/fail_compilation/testhtml2.html
+++ b/test/fail_compilation/testhtml2.html
@@ -1,3 +1,3 @@
 <!--
-PERMUTE_ARGS: -d -di
+PERMUTE_ARGS: -d -dw
 --><html>	<head><title>dstress: html_line_ending_mac</title></head>	<body><pre><CODE>// __DSTRESS_TORTURE_BLOCK__ -release int main(){	try{		assert(0);	}catch(Throwable e){		checkLineNumber(e);		return 0;	}	assert(-1, "b");	return 1;}/* * @WARNING@ this code depends on the phobos implementation. * char[]s returned by wrong assertions have to look like: *	 "blah blah (linenumber) blah blah" */void checkLineNumber(Object o){	string x=o.toString();	int start;	for(start=0; start&lt;x.length; start++){if(x[start]=='('){break;}}	int end;	for(end=start+1; end&lt;x.length; end++){if(x[end]==')'){break;}}	assert(end-start==3);	assert(x[start+1 .. end]=="10", x[start+1 .. end]);}	</CODE></pre></body></html>

--- a/test/fail_compilation/testhtml3.html
+++ b/test/fail_compilation/testhtml3.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-  PERMUTE_ARGS: -d -di
+  PERMUTE_ARGS: -d -dw
 -->
 <html>
 	<head><title>dstress: html_tag_space_01</title></head>

--- a/test/runnable/circular.d
+++ b/test/runnable/circular.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -d
-// PERMUTE_ARGS: -di
+// PERMUTE_ARGS: -dw
 // EXTRA_SOURCES: imports/circularA.d
 // This bug is typedef-specific.
 

--- a/test/runnable/deprecate1.d
+++ b/test/runnable/deprecate1.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -d
-// PERMUTE_ARGS: -di
+// PERMUTE_ARGS: -dw
 
 // Test cases using deprecated features
 module deprecate1;

--- a/test/runnable/literal.d
+++ b/test/runnable/literal.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -d
-// PERMUTE_ARGS: -di
+// PERMUTE_ARGS: -dw
 
 import std.stdio;
 import std.c.stdlib;

--- a/test/runnable/test9.d
+++ b/test/runnable/test9.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -d
-// PERMUTE_ARGS: -di
+// PERMUTE_ARGS: -dw
 // The use of typedef in these tests is fundamental.
 
 public:


### PR DESCRIPTION
Since wanting to have deprecations as warnings is probably what most
people wants, make it the default. Also rename -di to -dw and introduce
-de to get the old default behaviour of having deprecations as errors.
-d stays untouched for backwards compatibility and those crazy people
that doesn't even want to know about deprecated features.
