### PR TITLE
Issue 8939 - ICE(glue.c) on passing by ref statically initialized const/immutable variable

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1203,6 +1203,8 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                 }
             }
 #endif
+            if (!(p->storageClass & (STCref | STCout)))
+                arg = arg->optimize(WANTvalue);
         }
         else
         {
@@ -1263,8 +1265,8 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                 }
             }
             arg->rvalue();
+            arg = arg->optimize(WANTvalue);
         }
-        arg = arg->optimize(WANTvalue);
     L3:
         (*arguments)[i] =  arg;
     }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -142,7 +142,7 @@ bool CtfeStack::isInCurrentFrame(VarDeclaration *v)
 
 Expression *CtfeStack::getValue(VarDeclaration *v)
 {
-    if (v->isDataseg() && !v->isCTFE())
+    if ((v->isDataseg() || v->storage_class & STCmanifest) && !v->isCTFE())
     {
         assert(v->ctfeAdrOnStack >= 0 &&
         v->ctfeAdrOnStack < globalValues.dim);
@@ -206,7 +206,7 @@ void CtfeStack::popAll(size_t stackpointer)
 void CtfeStack::saveGlobalConstant(VarDeclaration *v, Expression *e)
 {
 #if DMDV2
-     assert( v->init && (v->isConst() || v->isImmutable()) && !v->isCTFE());
+     assert( v->init && (v->isConst() || v->isImmutable() || v->storage_class & STCmanifest) && !v->isCTFE());
 #else
      assert( v->init && v->isConst() && !v->isCTFE());
 #endif
@@ -1650,7 +1650,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
             else
                 e = v->type->defaultInitLiteral(loc);
         }
-        else if (!v->isDataseg() && !v->isCTFE() && !istate)
+        else if (!(v->isDataseg() || v->storage_class & STCmanifest) && !v->isCTFE() && !istate)
         {   error(loc, "variable %s cannot be read at compile time", v->toChars());
             return EXP_CANT_INTERPRET;
         }

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -497,8 +497,9 @@ Expression *CallExp::optimize(int result)
     //printf("CallExp::optimize(result = %d) %s\n", result, toChars());
     Expression *e = this;
 
-    // Optimize parameters
-    if (arguments)
+    // Don't optimize parameters here, because it is already done
+    // in functionParameters() by considering parameter ref-ness.
+    if (0 && arguments)
     {
         for (size_t i = 0; i < arguments->dim; i++)
         {   Expression *e = (*arguments)[i];

--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -473,8 +473,8 @@ static assert(is(typeof(C8.x) == int));
 int foo9() {
    int u = cast(int)(0x1_0000_0000L);
    while (u) {
-      if (u) { 
-         assert(u!=0); 
+      if (u) {
+         assert(u!=0);
         }
       assert(u!=0);
    }
@@ -564,6 +564,31 @@ void test8400()
 }
 
 /************************************/
+// 8939
+
+void foo8939(T)(ref T) { } // same for `auto ref`
+void bar8939(ref const int) { }
+void bar8939(ref const S8939) { }
+
+static struct S8939 { int n; }
+
+const gn8939 = 1; // or `immutable`
+const gs8939 = S8939(3);
+static assert(__traits(compiles, foo8939(gn8939), bar8939(gn8939)));
+static assert(__traits(compiles, foo8939(gs8939), bar8939(gs8939)));
+
+void test8939()
+{
+    foo8939(gn8939), bar8939(gn8939);
+    foo8939(gs8939), bar8939(gs8939);
+
+    const ln8939 = 1;
+    const ls8939 = S8939(3);
+    foo8939(ln8939), bar8939(ln8939);
+    foo8939(ls8939), bar8939(ls8939);
+}
+
+/************************************/
 
 int main()
 {
@@ -572,6 +597,7 @@ int main()
     test3();
     test6077();
     test8400();
+    test8939();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8939

Don't optimize an argument on ref parameter, even which can interpret at compile time.
