### PR TITLE
7998 static assert message string printing problem

### DIFF
--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -79,6 +79,11 @@ void StaticAssert::semantic2(Scope *sc)
             msg = msg->semantic(sc);
             msg = msg->ctfeInterpret();
             hgs.console = 1;
+            StringExp * s = msg->toString();
+            if (s)
+            {   s->postfix = 0; // Don't display a trailing 'c'
+                msg = s;
+            }
             msg->toCBuffer(&buf, &hgs);
             error("%s", buf.toChars());
         }

--- a/test/fail_compilation/diag7998.d
+++ b/test/fail_compilation/diag7998.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag7998.d(3): Error: static assert  "abcxe"
+---
+*/
+
+#line 1
+module diag7998;
+
+static assert(false, "abc" ~['x'] ~ "e");


### PR DESCRIPTION
If the result of msg is a char[] array literal, convert it to a StringExp before printing. Also make sure it doesn't have a silly 'c', 'w' or 'd' after it.
