### PR TITLE
Fix error message with missing line number

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -281,7 +281,7 @@ if (I32) assert(tysize[TYnptr] == 4);
     else if (fd && fd->isNested())
     {
         assert(!ethis);
-        ethis = getEthis(0, irs, fd);
+        ethis = getEthis(loc, irs, fd);
     }
 
     ep = el_param(ep, ethis);


### PR DESCRIPTION
Test case is in bug 6426.
Doesn't fix the actual bug, but makes the error message a bit less horrible.

Error before:
Error: function std.algorithm.MapResult!(reduce, int[][]).MapResult.back cannot get frame pointer to reduce

With this patch:
std/algorithm.d(394): Error: function std.algorithm.MapResult!(reduce, int[][]).MapResult.back cannot get frame pointer to reduce

It's still basically an internal compiler error, so I'm not adding a test case.
