### PR TITLE
Turn casting of T[] to integral types an error 

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9192,7 +9192,7 @@ Expression *CastExp::semantic(Scope *sc)
         }
 
         if (tob->isintegral() && t1b->ty == Tarray)
-            deprecation("casting %s to %s is deprecated", e1->type->toChars(), to->toChars());
+            error("cannot cast from %s to %s", e1->type->toChars(), to->toChars());
     }
     else if (!to)
     {   error("cannot cast tuple");

--- a/test/fail_compilation/fail3150.d
+++ b/test/fail_compilation/fail3150.d
@@ -1,3 +1,4 @@
+// PERMUTE_ARGS: -d -di
 
 void main() {
     ulong u = cast(ulong)[1,2];


### PR DESCRIPTION
Casting t[] to integral types emit a deprecation error but is always
rejected by the backend (except on very few targets), so it will fail
even if -d is specified (at least for portable code). It is better to
make it just a plain error.
