### PR TITLE
Issue 9035 & 9036 - Nested struct `init` is lvalue and can be modified

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -901,6 +901,11 @@ Expression *Equal(enum TOK op, Type *type, Expression *e1, Expression *e2)
                 if (cmp == 0)
                     break;
             }
+            if (cmp && es1->type->needsNested())
+            {
+                if ((es1->sinit != NULL) != (es2->sinit != NULL))
+                    cmp = 0;
+            }
         }
     }
 #if 0 // Should handle this

--- a/src/expression.c
+++ b/src/expression.c
@@ -4236,6 +4236,12 @@ Expression *StructLiteralExp::getField(Type *type, unsigned offset)
                 e = e->copy();
                 e->type = type;
             }
+            if (sinit && e->op == TOKstructliteral &&
+                e->type->needsNested())
+            {
+                StructLiteralExp *se = (StructLiteralExp *)e;
+                se->sinit = se->sd->toInitializer();
+            }
         }
     }
     return e;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7416,7 +7416,10 @@ Expression *TypeEnum::defaultInit(Loc loc)
         error(loc, "forward reference of %s.init", toChars());
         return new ErrorExp();
     }
-    return sym->defaultval;
+    Expression *e = sym->defaultval;
+    e = e->copy();
+    e->type = this;
+    return e;
 }
 
 int TypeEnum::isZeroInit(Loc loc)
@@ -8071,9 +8074,7 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
     if (size(loc) > PTRSIZE * 4 && !needsNested())
         structinit->sinit = sym->toInitializer();
 
-    // Why doesn't the StructLiteralExp constructor do this, when
-    // sym->type != NULL ?
-    structinit->type = sym->type;
+    structinit->type = this;
     return structinit;
 }
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1969,12 +1969,12 @@ Expression *Type::getProperty(Loc loc, Identifier *ident)
     else if (ident == Id::init)
     {
         Type *tb = toBasetype();
+        e = defaultInitLiteral(loc);
         if (tb->ty == Tstruct && tb->needsNested())
         {
-            e = defaultInit(loc);
+            StructLiteralExp *se = (StructLiteralExp *)e;
+            se->sinit = se->sd->toInitializer();
         }
-        else
-            e = defaultInitLiteral(loc);
     }
     else if (ident == Id::mangleof)
     {   const char *s;
@@ -2047,13 +2047,13 @@ Expression *Type::dotExp(Scope *sc, Expression *e, Identifier *ident)
         }
         else if (ident == Id::init)
         {
-            if (toBasetype()->ty == Tstruct &&
-                ((TypeStruct *)toBasetype())->sym->isNested())
+            Type *tb = toBasetype();
+            e = defaultInitLiteral(e->loc);
+            if (tb->ty == Tstruct && tb->needsNested())
             {
-                e = defaultInit(e->loc);
+                StructLiteralExp *se = (StructLiteralExp *)e;
+                se->sinit = se->sd->toInitializer();
             }
-            else
-                e = defaultInitLiteral(e->loc);
             goto Lreturn;
         }
     }

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2050,6 +2050,35 @@ void test9006()
 }
 
 /*******************************************/
+// 9035
+
+void test9035()
+{
+    static struct S {}
+
+    void f(T)(auto ref T t)
+    {
+        static assert(!__traits(isRef, t));
+    }
+
+    f(S.init); // ok, rvalue
+    f(S());    // ok, rvalue
+
+    int i;
+    struct Nested
+    {
+        int j = 0; void f() { ++i; }
+    }
+
+    f(Nested());    // ok, rvalue
+    f(Nested.init); // fails, lvalue
+
+    assert(Nested.init.j == 0);
+    (ref n) { n.j = 5; }(Nested.init);
+    assert(Nested.init.j == 0); // fails, j is 5
+}
+
+/*******************************************/
 
 int main()
 {
@@ -2126,6 +2155,7 @@ int main()
     test8923c();
     test9003();
     test9006();
+    test9035();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2079,6 +2079,40 @@ void test9035()
 }
 
 /*******************************************/
+// 9036
+
+void test9036()
+{
+    static int i;
+    static struct S
+    {
+        this(this) { ++i; }
+    }
+
+    S s = S.init;
+    assert(i == 0); // postblit not called
+    s = S.init;
+    assert(i == 0); // postblit not called
+
+    int k;
+    static int j = 0;
+    struct N
+    {
+        this(this)
+        {
+            ++j;
+            assert(this.tupleof[$-1] != null); // fails
+        }
+        void f() { ++k; }
+    }
+
+    N n = N.init;
+    assert(j == 0); // fails, j = 1, postblit called
+    n = N.init;
+    assert(j == 0); // fails, j = 2, postblit called
+}
+
+/*******************************************/
 
 int main()
 {
@@ -2156,6 +2190,7 @@ int main()
     test9003();
     test9006();
     test9035();
+    test9036();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2758,6 +2758,45 @@ void test8688()
 }
 
 /************************************/
+// 9046
+
+void test9046()
+{
+    foreach (T; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong, char, wchar, dchar,
+                           float, double, real, ifloat, idouble, ireal, cfloat, cdouble, creal))
+    foreach (U; TypeTuple!(T, const T, immutable T, shared T, shared const T, inout T, shared inout T))
+    {
+        static assert(is(typeof(U.init) == U));
+    }
+
+    foreach (T; TypeTuple!(int[], const(char)[], immutable(string[]), shared(const(int)[])[],
+                           int[1], const(char)[1], immutable(string[1]), shared(const(int)[1])[],
+                           int[int], const(char)[long], immutable(string[string]), shared(const(int)[double])[]))
+    foreach (U; TypeTuple!(T, const T, immutable T, shared T, shared const T, inout T, shared inout T))
+    {
+        static assert(is(typeof(U.init) == U));
+    }
+
+    int i;
+    enum E { x, y }
+    static struct S {}
+    static class  C {}
+    struct NS { void f(){ i++; } }
+    class  NC { void f(){ i++; } }
+    foreach (T; TypeTuple!(E, S, C, NS, NC))
+    foreach (U; TypeTuple!(T, const T, immutable T, shared T, shared const T, inout T, shared inout T))
+    {
+        static assert(is(typeof(U.init) == U));
+    }
+
+    alias TL = TypeTuple!(int, string, int[int]);
+    foreach (U; TypeTuple!(TL, const TL, immutable TL, shared TL, shared const TL, inout TL, shared inout TL))
+    {
+        static assert(is(typeof(U.init) == U));
+    }
+}
+
+/************************************/
 
 int main()
 {
@@ -2876,6 +2915,7 @@ int main()
     test8201();
     test8212();
     test8688();
+    test9046();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=9035">Issue 9035</a> - Nested struct `init` is lvalue and can be modified
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=9036">Issue 9036</a> - postblit is called for nested structs when assigning `init`

Requires: https://github.com/D-Programming-Language/dmd/pull/1300

After making S.init rvalue, it will be handled by constant folding. But, constant folding did not care the presence or absence of hidden frame pointer, so additional fix was necessary.
