### PR TITLE
fix clang build error

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -1491,7 +1491,7 @@ int tryMain(size_t argc, char *argv[])
     return status;
 }
 
-int main(size_t argc, char *argv[])
+int main(int argc, char *argv[])
 {
     int status = -1;
 #if WINDOWS_SEH


### PR DESCRIPTION
error: first parameter of 'main' (argument count) must be of type 'int'
