### PR TITLE
'Fix' warnings from PVS Studio.

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -46,10 +46,10 @@ struct ClassReferenceExp : Expression
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     char *toChars();
     ClassDeclaration *originalClass();
-    VarDeclaration *getFieldAt(int index);
+    VarDeclaration *getFieldAt(unsigned index);
 
     /// Return index of the field, or -1 if not found
-    int getFieldIndex(Type *fieldtype, size_t fieldoffset);
+    int getFieldIndex(Type *fieldtype, unsigned fieldoffset);
     /// Return index of the field, or -1 if not found
     /// Same as getFieldIndex, but checks for a direct match with the VarDeclaration
     int findFieldIndexByName(VarDeclaration *v);

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -50,10 +50,10 @@ ClassDeclaration *ClassReferenceExp::originalClass()
     return value->sd->isClassDeclaration();
 }
 
-VarDeclaration *ClassReferenceExp::getFieldAt(int index)
+VarDeclaration *ClassReferenceExp::getFieldAt(unsigned index)
 {
     ClassDeclaration *cd = originalClass();
-    size_t fieldsSoFar = 0;
+    unsigned fieldsSoFar = 0;
     while (index - fieldsSoFar >= cd->fields.dim)
     {   fieldsSoFar += cd->fields.dim;
         cd = cd->baseClass;
@@ -62,10 +62,10 @@ VarDeclaration *ClassReferenceExp::getFieldAt(int index)
 }
 
 // Return index of the field, or -1 if not found
-int ClassReferenceExp::getFieldIndex(Type *fieldtype, size_t fieldoffset)
+int ClassReferenceExp::getFieldIndex(Type *fieldtype, unsigned fieldoffset)
 {
     ClassDeclaration *cd = originalClass();
-    size_t fieldsSoFar = 0;
+    unsigned fieldsSoFar = 0;
     for (size_t j = 0; j < value->elements->dim; j++)
     {   while (j - fieldsSoFar >= cd->fields.dim)
         {   fieldsSoFar += cd->fields.dim;
@@ -139,7 +139,7 @@ int findFieldIndexByName(StructDeclaration *sd, VarDeclaration *v)
 ThrownExceptionExp::ThrownExceptionExp(Loc loc, ClassReferenceExp *victim) : Expression(loc, TOKthrownexception, sizeof(ThrownExceptionExp))
 {
     this->thrown = victim;
-    this->type = type;
+    this->type = victim->type;
 }
 
 Expression *ThrownExceptionExp::interpret(InterState *istate, CtfeGoal)
@@ -475,7 +475,7 @@ StringExp *createBlockDuplicatedStringLiteral(Loc loc, Type *type,
 {
     unsigned char *s;
     s = (unsigned char *)mem.calloc(dim + 1, sz);
-    for (size_t elemi=0; elemi<dim; ++elemi)
+    for (size_t elemi = 0; elemi < dim; ++elemi)
     {
         switch (sz)
         {
@@ -581,12 +581,11 @@ Expression *getAggregateFromPointer(Expression *e, dinteger_t *ofs)
         assert(v);
         StructLiteralExp *se = ex->op == TOKclassreference ? ((ClassReferenceExp *)ex)->value : (StructLiteralExp *)ex;
         // We can't use getField, because it makes a copy
-        int i = -1;
+        unsigned i;
         if (ex->op == TOKclassreference)
             i = ((ClassReferenceExp *)ex)->getFieldIndex(e->type, v->offset);
         else
             i = se->getFieldIndex(e->type, v->offset);
-        assert(i != -1);
         e = se->elements->tdata()[i];
     }
     if (e->op == TOKindex)
@@ -670,7 +669,7 @@ Expression *pointerArithmetic(Loc loc, enum TOK op, Type *type,
 
     Expression *val = agg1;
     TypeArray *tar = (TypeArray *)val->type;
-    dinteger_t indx = ofs1;
+    sinteger_t indx = ofs1;
     if (op == TOKadd || op == TOKaddass || op == TOKplusplus)
         indx = indx + ofs2/sz;
     else if (op == TOKmin || op == TOKminass || op == TOKminusminus)
@@ -1162,7 +1161,7 @@ int ctfeCmpArrays(Loc loc, Expression *e1, Expression *e2, uinteger_t len)
     {   Expression *ee1 = (*ae1->elements)[lo1 + i];
         Expression *ee2 = (*ae2->elements)[lo2 + i];
         if (needCmp)
-        {   dinteger_t c = ee1->toInteger() - ee2->toInteger();
+        {   sinteger_t c = ee1->toInteger() - ee2->toInteger();
             if (c > 0)
                 return 1;
             if (c < 0)
@@ -1927,7 +1926,8 @@ void showCtfeExpr(Expression *e, int level)
         {   Expression *z = NULL;
             Dsymbol *s = NULL;
             if (i > 15) {
-                printf("...(total %d elements)\n", elements->dim);
+                int nelements = elements->dim;
+                printf("...(total %d elements)\n", nelements);
                 return;
             }
             if (sd)
@@ -1942,8 +1942,8 @@ void showCtfeExpr(Expression *e, int level)
                     printf(" BASE CLASS: %s\n", cd->toChars());
                 }
                 s = cd->fields[i - fieldsSoFar];
+                assert((elements->dim + i) >= (fieldsSoFar + cd->fields.dim));
                 size_t indx = (elements->dim - fieldsSoFar)- cd->fields.dim + i;
-                assert(indx >= 0);
                 assert(indx < elements->dim);
                 z = (*elements)[indx];
             }

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -737,7 +737,7 @@ VarDeclaration::VarDeclaration(Loc loc, Type *type, Identifier *id, Initializer 
     aliassym = NULL;
     onstack = 0;
     canassign = 0;
-    ctfeAdrOnStack = (size_t)(-1);
+    ctfeAdrOnStack = -1;
 #if DMDV2
     rundtor = NULL;
     edtor = NULL;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -267,7 +267,7 @@ struct VarDeclaration : Declaration
 
     // When interpreting, these point to the value (NULL if value not determinable)
     // The index of this variable on the CTFE stack, -1 if not allocated
-    size_t ctfeAdrOnStack;
+    int ctfeAdrOnStack;
     // The various functions are used only to detect compiler CTFE bugs
     Expression *getValue();
     bool hasValue();

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -168,7 +168,7 @@ void CtfeStack::push(VarDeclaration *v)
         values[v->ctfeAdrOnStack] = NULL;
         return;
     }
-    savedId.push((void *)(v->ctfeAdrOnStack));
+    savedId.push((void *)(size_t)(v->ctfeAdrOnStack));
     v->ctfeAdrOnStack = values.dim;
     vars.push(v);
     values.push(NULL);
@@ -179,7 +179,7 @@ void CtfeStack::pop(VarDeclaration *v)
     assert(!v->isDataseg() || v->isCTFE());
     assert(!(v->storage_class & (STCref | STCout)));
     int oldid = v->ctfeAdrOnStack;
-    v->ctfeAdrOnStack = (size_t)(savedId[oldid]);
+    v->ctfeAdrOnStack = (int)(size_t)(savedId[oldid]);
     if (v->ctfeAdrOnStack == values.dim - 1)
     {
         values.pop();
@@ -192,7 +192,7 @@ void CtfeStack::popAll(size_t stackpointer)
 {
     if (stackPointer() > maxStackPointer)
         maxStackPointer = stackPointer();
-    assert(values.dim >= stackpointer && stackpointer >= 0);
+    assert(values.dim >= stackpointer);
     for (size_t i = stackpointer; i < values.dim; ++i)
     {
         VarDeclaration *v = vars[i];
@@ -1565,18 +1565,19 @@ Expression * resolveReferences(Expression *e, Expression *thisval)
                 break;
             if (v->ctfeAdrOnStack == (size_t)-1) // If not on the stack, can't possibly be a ref.
                 break;
-            if (v->getValue() && (v->getValue()->op == TOKslice))
+            Expression *val = v->getValue();
+            if (val && (val->op == TOKslice))
             {
-                SliceExp *se = (SliceExp *)v->getValue();
+                SliceExp *se = (SliceExp *)val;
                 if (se->e1->op == TOKarrayliteral || se->e1->op == TOKassocarrayliteral || se->e1->op == TOKstring)
                     break;
-                e = v->getValue();
+                e = val;
                 continue;
             }
-            else if (v->getValue() && (v->getValue()->op==TOKindex || v->getValue()->op == TOKdotvar
-                  || v->getValue()->op == TOKthis  || v->getValue()->op == TOKvar))
+            else if (val && (val->op==TOKindex || val->op == TOKdotvar
+                  || val->op == TOKthis  || val->op == TOKvar))
             {
-                e = v->getValue();
+                e = val;
                 continue;
             }
         }
@@ -1762,7 +1763,7 @@ Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
             TupleDeclaration *td =v->toAlias()->isTupleDeclaration();
             if (!td->objects)
                 return NULL;
-            for(int i= 0; i < td->objects->dim; ++i)
+            for(size_t i= 0; i < td->objects->dim; ++i)
             {
                 Object * o = td->objects->tdata()[i];
                 Expression *ex = isExpression(o);
@@ -3343,7 +3344,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         if (aggregate->op == TOKslice)
         {   // Slice of a slice --> change the bounds
             SliceExp *sexpold = (SliceExp *)aggregate;
-            dinteger_t hi = upperbound + sexpold->lwr->toInteger();
+            sinteger_t hi = upperbound + sexpold->lwr->toInteger();
             firstIndex = lowerbound + sexpold->lwr->toInteger();
             if (hi > sexpold->upr->toInteger())
             {
@@ -3364,7 +3365,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
                 error("cannot slice null pointer %s", sexp->e1->toChars());
                 return EXP_CANT_INTERPRET;
             }
-            dinteger_t hi = upperbound + ofs;
+            sinteger_t hi = upperbound + ofs;
             firstIndex = lowerbound + ofs;
             if (firstIndex < 0 || hi > dim)
             {
@@ -4215,7 +4216,7 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
         e2 = this->e2->interpret(istate);
         if (exceptionOrCantInterpret(e2))
             return e2;
-        dinteger_t indx = e2->toInteger();
+        sinteger_t indx = e2->toInteger();
 
         dinteger_t ofs;
         Expression *agg = getAggregateFromPointer(e1, &ofs);
@@ -4400,7 +4401,7 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
         assert(agg->op == TOKarrayliteral || agg->op == TOKstring);
         dinteger_t len = ArrayLength(Type::tsize_t, agg)->toInteger();
         //Type *pointee = ((TypePointer *)agg->type)->next;
-        if (ilwr < 0 || iupr > (len + 1) || iupr < ilwr)
+        if (iupr > (len + 1) || iupr < ilwr)
         {
             error("pointer slice [%lld..%lld] exceeds allocated memory block [0..%lld]",
                 ilwr, iupr, len);
@@ -4497,7 +4498,7 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
     if (e1->op == TOKarrayliteral
         || e1->op == TOKstring)
     {
-        if (iupr < ilwr || ilwr < 0 || iupr > dollar)
+        if (iupr < ilwr || iupr > dollar)
         {
             error("slice [%lld..%lld] exceeds array bounds [0..%lld]",
                 ilwr, iupr, dollar);
@@ -5256,7 +5257,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
 
         if (ale)
         {   // If it is an array literal, copy the code points into the buffer
-            int buflen = 1; // #code points in the buffer
+            size_t buflen = 1; // #code points in the buffer
             size_t n = 1;   // #code points in this char
             size_t sz = ale->type->nextOf()->size();
 
@@ -5278,7 +5279,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
                 }
                 else
                     buflen = (indx + 4 > len) ? len - indx : 4;
-                for (int i=0; i < buflen; ++i)
+                for (int i = 0; i < buflen; ++i)
                 {
                     Expression * r = ale->elements->tdata()[indx + i];
                     assert(r->op == TOKint64);


### PR DESCRIPTION
PVS Studio didn't find anything of value, there was only one non-spurious warning (ctfeexpr:142).
Its best recommendation was to undo the change recommended by the previous static analysis tool...

Most of these changes are signed/unsigned warnings. Removed a few tests of the form   "unsigned_val >= 0" but they were all in asserts anyway. The only actual bug was in showCtfeExpr, which is only used in compiler debugging anyway.
