### PR TITLE
[enh] Issue 9062 - AddrExp should distinguish the existence of property resolution.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8595,9 +8595,10 @@ void CallExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
 /************************************************************/
 
-AddrExp::AddrExp(Loc loc, Expression *e)
+AddrExp::AddrExp(Loc loc, Expression *e, bool resolveProp)
         : UnaExp(loc, TOKaddress, sizeof(AddrExp), e)
 {
+    this->resolveProp = resolveProp;
 }
 
 Expression *AddrExp::semantic(Scope *sc)
@@ -8608,6 +8609,8 @@ Expression *AddrExp::semantic(Scope *sc)
     if (!type)
     {
         UnaExp::semantic(sc);
+        if (resolveProp)
+            e1 = resolveProperties(sc, e1);
         Expression *olde1 = e1;
         if (e1->type == Type::terror)
             return new ErrorExp();

--- a/src/expression.h
+++ b/src/expression.h
@@ -982,7 +982,9 @@ struct CallExp : UnaExp
 
 struct AddrExp : UnaExp
 {
-    AddrExp(Loc loc, Expression *e);
+    bool resolveProp;
+
+    AddrExp(Loc loc, Expression *e, bool resolveProp = false);
     Expression *semantic(Scope *sc);
     void checkEscape();
     elem *toElem(IRState *irs);

--- a/src/parse.c
+++ b/src/parse.c
@@ -5965,18 +5965,20 @@ Expression *Parser::parsePostExp(Expression *e)
     }
 }
 
-Expression *Parser::parseUnaryExp()
+Expression *Parser::parseUnaryExp(bool* parenthesized)
 {   Expression *e;
     Loc loc = this->loc;
 
     switch (token.value)
     {
         case TOKand:
+        {
             nextToken();
-            e = parseUnaryExp();
-            e = new AddrExp(loc, e);
+            bool resolveProp = false;
+            e = parseUnaryExp(&resolveProp);
+            e = new AddrExp(loc, e, resolveProp);
             break;
-
+        }
         case TOKplusplus:
             nextToken();
             e = parseUnaryExp();
@@ -6203,7 +6205,10 @@ Expression *Parser::parseUnaryExp()
             }
 #endif
             e = parsePrimaryExp();
+            Expression *eold = e;
             e = parsePostExp(e);
+            if (e == eold && parenthesized)
+                *parenthesized = true;
             break;
         }
         default:

--- a/src/parse.h
+++ b/src/parse.h
@@ -132,7 +132,7 @@ struct Parser : Lexer
 
     Expression *parseExpression();
     Expression *parsePrimaryExp();
-    Expression *parseUnaryExp();
+    Expression *parseUnaryExp(bool* parenthesized = NULL);
     Expression *parsePostExp(Expression *e);
     Expression *parseMulExp();
     Expression *parseAddExp();

--- a/test/runnable/delegate.d
+++ b/test/runnable/delegate.d
@@ -259,13 +259,13 @@ public:
 //    fp(1,2);
     dg = &f;
     dg(1,2);
-//    fps[] = [&f, &f, &f, &(f)];  // bug 1: this line shouldn't compile
+//    fps[] = [&f, &f, &f, &f];  // bug 1: this line shouldn't compile
 //    this.fps[0](1, 2);  // seg-faults here!
 
-    dgs[] = [&(f), &(f), &(f), &(f)];  // bug 1: why this line can't compile?
+    dgs[] = [&f, &f, &f, &f];  // bug 1: why this line can't compile?
     this.dgs[0](1, 2);
 
-    dgs[] = [&(this.f), &(this.f), &(this.f), &(this.f)];
+    dgs[] = [&this.f, &this.f, &this.f, &this.f];
     this.dgs[0](1, 2);
   }
 

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -350,6 +350,32 @@ void test8251()
 }
 
 /*****************************************/
+// 9062
+
+void test9062()
+{
+    struct S
+    {
+        static int g;
+
+        @property ref int foo() { return g; }
+        @property     int bar() { return 1; }
+        @property ref int baz() const { return g; }
+    }
+
+    S s;
+    static assert(    typeof(& s.foo ).stringof == "int delegate() @property ref");
+    static assert(    typeof(&(s.foo)).stringof == "int*");
+    static assert(    typeof(& s.bar ).stringof == "int delegate() @property");
+    static assert(!is(typeof(&(s.bar))));   // Error, s.bar() is not an lvalue
+
+    static assert(typeof(&        S .baz ).stringof == "int function() const @property ref");
+    static assert(typeof(& (const S).baz ).stringof == "int function() const @property ref");
+    static assert(typeof(&(       S .baz)).stringof == "int*");
+    static assert(typeof(&((const S).baz)).stringof == "int*");
+}
+
+/*****************************************/
 // 9063
 
 @property bool foo9063(){ return true; }
@@ -367,6 +393,7 @@ int main()
     test7274();
     test7275();
     test8251();
+    test9062();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -519,13 +519,13 @@ class foo32
 {
     static void getMemberBar()
     {
-	//foo32 f = new foo32(); new A32( &(f.bar) );
-	new A32( &((new foo32()).bar) );
+        //foo32 f = new foo32(); new A32( &f.bar );
+        new A32( &(new foo32()).bar );
     }
 
     int bar()
     {
-	return 0;
+        return 0;
     }
 }
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9062

To implement more strict property enforcement, I believe that the enhancement is really necessary .

Requires: https://github.com/D-Programming-Language/phobos/pull/966
