### PR TITLE
Implement more property syntax enforcement

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1426,7 +1426,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
                     exp->error("%s has no value", e->toChars());
                 t = e->type->toBasetype();
                 if (t && t->ty == Tfunction)
-                    e = new CallExp(e->loc, e);
+                    e = new CallExp(e->loc, e, PROPmemget);
                 v = new VarDeclaration(loc, NULL, Id::dollar, new ExpInitializer(0, e));
             }
             else

--- a/src/expression.c
+++ b/src/expression.c
@@ -8595,9 +8595,10 @@ void CallExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
 /************************************************************/
 
-AddrExp::AddrExp(Loc loc, Expression *e)
+AddrExp::AddrExp(Loc loc, Expression *e, bool resolveProp)
         : UnaExp(loc, TOKaddress, sizeof(AddrExp), e)
 {
+    this->resolveProp = resolveProp;
 }
 
 Expression *AddrExp::semantic(Scope *sc)
@@ -8608,6 +8609,8 @@ Expression *AddrExp::semantic(Scope *sc)
     if (!type)
     {
         UnaExp::semantic(sc);
+        if (resolveProp)
+            e1 = resolveProperties(sc, e1);
         Expression *olde1 = e1;
         if (e1->type == Type::terror)
             return new ErrorExp();

--- a/src/expression.c
+++ b/src/expression.c
@@ -8456,7 +8456,8 @@ Lagain:
 
                 case PROPufcset:    // e1.func = e2; -> .func(e1, e2);
                 case PROPmemset:    // e1.func = e2; -> e1.func(e2);
-                    e1->error("not a property %s", e1->toChars());
+                    if (f->ident != Id::opDispatch)
+                        e1->error("not a property %s", e1->toChars());
                     break;
             }
             //return new ErrorExp();

--- a/src/expression.c
+++ b/src/expression.c
@@ -8012,6 +8012,13 @@ Lagain:
 
             f = dve->var->isFuncDeclaration();
             assert(f);
+        #if 1
+            if (prop == PROPnone && global.params.enforcePropertySyntax)
+            if (((TypeFunction *)f->type)->isproperty)
+            {   e1 = resolveProperties(sc, e1);
+                goto Lagain;
+            }
+        #endif
             f = f->overloadResolve(loc, ue1, arguments);
 
             ad = f->toParent()->isAggregateDeclaration();
@@ -8020,6 +8027,15 @@ Lagain:
         {   dte = (DotTemplateExp *)(e1);
             TemplateDeclaration *td = dte->td;
             assert(td);
+        #if 1
+            if (prop == PROPnone && global.params.enforcePropertySyntax)
+            if (td->onemember)
+            if (FuncDeclaration *fd = td->onemember->toAlias()->isFuncDeclaration())
+            if (((TypeFunction *)fd->type)->isproperty)
+            {   e1 = resolveProperties(sc, e1);
+                goto Lagain;
+            }
+        #endif
             if (!arguments)
                 // Should fix deduceFunctionTemplate() so it works on NULL argument
                 arguments = new Expressions();
@@ -8380,6 +8396,14 @@ Lagain:
 
         f = ve->var->isFuncDeclaration();
         assert(f);
+    #if 1
+        if (prop == PROPnone && global.params.enforcePropertySyntax)
+        if (((TypeFunction *)f->type)->isproperty)
+        {   e1 = resolveProperties(sc, e1);
+//printf(" -> e1 = %s %s\n", e1->type->toChars(), e1->toChars());
+            goto Lagain;
+        }
+    #endif
 
         if (ve->hasOverloads)
             f = f->overloadResolve(loc, NULL, arguments, 2);

--- a/src/expression.h
+++ b/src/expression.h
@@ -982,7 +982,9 @@ struct CallExp : UnaExp
 
 struct AddrExp : UnaExp
 {
-    AddrExp(Loc loc, Expression *e);
+    bool resolveProp;
+
+    AddrExp(Loc loc, Expression *e, bool resolveProp = false);
     Expression *semantic(Scope *sc);
     void checkEscape();
     elem *toElem(IRState *irs);

--- a/src/expression.h
+++ b/src/expression.h
@@ -951,15 +951,25 @@ struct DotTypeExp : UnaExp
     elem *toElem(IRState *irs);
 };
 
+enum PROP
+{
+    PROPnone,       // func(...) or e1.func(...)
+    PROPmemget,     // e1.func       -> e1.func()
+    PROPmemset,     // e1.func = e2; -> e1.func(e2);
+    PROPufcget,     // e1.func;      -> .func(e1);
+    PROPufcset,     // e1.func = e2; -> .func(e1, e2);
+};
+
 struct CallExp : UnaExp
 {
     Expressions *arguments;     // function arguments
     FuncDeclaration *f;         // symbol to call
+    PROP prop;
 
-    CallExp(Loc loc, Expression *e, Expressions *exps);
-    CallExp(Loc loc, Expression *e);
-    CallExp(Loc loc, Expression *e, Expression *earg1);
-    CallExp(Loc loc, Expression *e, Expression *earg1, Expression *earg2);
+    CallExp(Loc loc, Expression *e, Expressions *exps, PROP prop = PROPnone);
+    CallExp(Loc loc, Expression *e, PROP prop = PROPnone);
+    CallExp(Loc loc, Expression *e, Expression *earg1, PROP prop = PROPnone);
+    CallExp(Loc loc, Expression *e, Expression *earg1, Expression *earg2, PROP prop = PROPnone);
 
     Expression *syntaxCopy();
     int apply(apply_fp_t fp, void *param);

--- a/src/parse.c
+++ b/src/parse.c
@@ -5965,18 +5965,20 @@ Expression *Parser::parsePostExp(Expression *e)
     }
 }
 
-Expression *Parser::parseUnaryExp()
+Expression *Parser::parseUnaryExp(bool* parenthesized)
 {   Expression *e;
     Loc loc = this->loc;
 
     switch (token.value)
     {
         case TOKand:
+        {
             nextToken();
-            e = parseUnaryExp();
-            e = new AddrExp(loc, e);
+            bool resolveProp = false;
+            e = parseUnaryExp(&resolveProp);
+            e = new AddrExp(loc, e, resolveProp);
             break;
-
+        }
         case TOKplusplus:
             nextToken();
             e = parseUnaryExp();
@@ -6203,7 +6205,10 @@ Expression *Parser::parseUnaryExp()
             }
 #endif
             e = parsePrimaryExp();
+            Expression *eold = e;
             e = parsePostExp(e);
+            if (e == eold && parenthesized)
+                *parenthesized = true;
             break;
         }
         default:

--- a/src/parse.h
+++ b/src/parse.h
@@ -132,7 +132,7 @@ struct Parser : Lexer
 
     Expression *parseExpression();
     Expression *parsePrimaryExp();
-    Expression *parseUnaryExp();
+    Expression *parseUnaryExp(bool* parenthesized = NULL);
     Expression *parsePostExp(Expression *e);
     Expression *parseMulExp();
     Expression *parseAddExp();

--- a/src/template.c
+++ b/src/template.c
@@ -554,6 +554,12 @@ void TemplateDeclaration::semantic(Scope *sc)
         {
             onemember = s;
             s->parent = this;
+            if (sc->stc & STCproperty)
+            if (FuncDeclaration *f = s->isFuncDeclaration())
+            {
+                ((TypeFunction *)f->type)->isproperty = 1;
+                //printf("sc->stc = %llx, f =%s\n\n", sc->stc, f->toChars());
+            }
         }
     }
 

--- a/test/fail_compilation/diag8629.d
+++ b/test/fail_compilation/diag8629.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8629.d(9): Error: not a property s.gunc
+fail_compilation/diag8629.d(9): Error: not a property gunc
 ---
 */
 

--- a/test/runnable/delegate.d
+++ b/test/runnable/delegate.d
@@ -259,13 +259,13 @@ public:
 //    fp(1,2);
     dg = &f;
     dg(1,2);
-//    fps[] = [&f, &f, &f, &(f)];  // bug 1: this line shouldn't compile
+//    fps[] = [&f, &f, &f, &f];  // bug 1: this line shouldn't compile
 //    this.fps[0](1, 2);  // seg-faults here!
 
-    dgs[] = [&(f), &(f), &(f), &(f)];  // bug 1: why this line can't compile?
+    dgs[] = [&f, &f, &f, &f];  // bug 1: why this line can't compile?
     this.dgs[0](1, 2);
 
-    dgs[] = [&(this.f), &(this.f), &(this.f), &(this.f)];
+    dgs[] = [&this.f, &this.f, &this.f, &this.f];
     this.dgs[0](1, 2);
   }
 

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -391,6 +391,58 @@ static assert(foo9063);
 
 /*****************************************/
 
+struct S2A
+{
+    template opDispatch(string name)
+    {
+        static if (name == "prop")
+        {
+            @property int prop() { return 1; }
+            @property void prop(int n) {}
+            alias prop opDispatch;
+        }
+
+        static if (name == "func")
+        {
+            int func() { return 1; }
+            void func(int n) {}
+            alias func opDispatch;
+        }
+    }
+}
+struct S2B
+{
+    auto opDispatch(string name)()
+    {
+        return 1;
+    }
+
+    auto opDispatch(string name, T)(T n)
+    {
+    }
+}
+
+void test2()
+{
+    S2A a;
+    a.func();
+    a.func(1);
+    a.func;     // still OK
+    static assert(__traits(compiles, a.func = 1) == !enforceProperty);
+    static assert(__traits(compiles, a.prop()  ) == !enforceProperty);
+    static assert(__traits(compiles, a.prop(1) ) == !enforceProperty);
+    a.prop;
+    a.prop = 1;
+
+    S2B b;
+    b.foo();
+    b.foo(1);
+    b.prop;
+    b.prop = 1;
+}
+
+/*****************************************/
+
 int main()
 {
     test1();
@@ -402,6 +454,7 @@ int main()
     test7275();
     test8251();
     test9062();
+    test2();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -443,6 +443,20 @@ void test2()
 
 /*****************************************/
 
+void test3()
+{
+  static if (enforceProperty)
+  {
+    @property foo(){ return (int n) => n * 2; }
+
+    static assert(typeof(&foo).stringof == "int function(int n) pure nothrow @safe delegate() @property");
+    auto n = foo(10);
+    assert(n == 20);
+  }
+}
+
+/*****************************************/
+
 int main()
 {
     test1();
@@ -455,6 +469,7 @@ int main()
     test8251();
     test9062();
     test2();
+    test3();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -4,8 +4,8 @@ extern (C) int printf(const char* fmt, ...);
 
 // Is -property option specified?
 enum enforceProperty = !__traits(compiles, {
-    int prop(){ return 1; }
-    int n = prop;
+    void prop(int n) {}
+    prop = 10;
 });
 
 /*******************************************/
@@ -192,21 +192,21 @@ void test7722a()
 
     check!(1, 1, x =>    foo(4)     );      check!(1, 1, x =>    baz(4)     );
     check!(1, 1, x =>  4.foo()      );      check!(1, 1, x =>  4.baz()      );
-    check!(0, 1, x =>  4.foo        );      check!(0, 1, x =>  4.baz        );
+    check!(1, 1, x =>  4.foo        );      check!(1, 1, x =>  4.baz        );
     check!(2, 2, x =>    foo(4, 2)  );      check!(2, 2, x =>    baz(4, 2)  );
     check!(2, 2, x =>  4.foo(2)     );      check!(2, 2, x =>  4.baz(2)     );
     check!(0, 2, x => (4.foo = 2)   );      check!(0, 2, x => (4.baz = 2)   );
 
     check!(1, 1, x =>    goo(a)     );      check!(1, 1, x =>    baz(a)     );
     check!(1, 1, x =>  a.goo()      );      check!(1, 1, x =>  a.baz()      );
-    check!(0, 1, x =>  a.goo        );      check!(0, 1, x =>  a.baz        );
+    check!(1, 1, x =>  a.goo        );      check!(1, 1, x =>  a.baz        );
     check!(2, 2, x =>    goo(a, 2)  );      check!(2, 2, x =>    baz(a, 2)  );
     check!(2, 2, x =>  a.goo(2)     );      check!(2, 2, x =>  a.baz(2)     );
     check!(0, 2, x => (a.goo = 2)   );      check!(0, 2, x => (a.baz = 2)   );
 
     check!(1, 1, x =>    bar(s)     );      check!(1, 1, x =>    baz(s)     );
     check!(1, 1, x =>  s.bar()      );      check!(1, 1, x =>  s.baz()      );
-    check!(0, 1, x =>  s.bar        );      check!(0, 1, x =>  s.baz        );
+    check!(1, 1, x =>  s.bar        );      check!(1, 1, x =>  s.baz        );
     check!(2, 2, x =>    bar(s, 2)  );      check!(2, 2, x =>    baz(s, 2)  );
     check!(2, 2, x =>  s.bar(2)     );      check!(2, 2, x =>  s.baz(2)     );
     check!(0, 2, x => (s.bar = 2)   );      check!(0, 2, x => (s.baz = 2)   );
@@ -244,21 +244,21 @@ void test7722b()
 
     check!(1, 1, x =>    hoo!int(4)     );  check!(1, 1, x =>    vaz!int(4)     );
     check!(1, 1, x =>  4.hoo!int()      );  check!(1, 1, x =>  4.vaz!int()      );
-    check!(0, 1, x =>  4.hoo!int        );  check!(0, 1, x =>  4.vaz!int        );
+    check!(1, 1, x =>  4.hoo!int        );  check!(1, 1, x =>  4.vaz!int        );
     check!(2, 2, x =>    hoo!int(4, 2)  );  check!(2, 2, x =>    vaz!int(4, 2)  );
     check!(2, 2, x =>  4.hoo!int(2)     );  check!(2, 2, x =>  4.vaz!int(2)     );
     check!(0, 2, x => (4.hoo!int = 2)   );  check!(0, 2, x => (4.vaz!int = 2)   );
 
     check!(1, 1, x =>    koo!int(a)     );  check!(1, 1, x =>    vaz!int(a)     );
     check!(1, 1, x =>  a.koo!int()      );  check!(1, 1, x =>  a.vaz!int()      );
-    check!(0, 1, x =>  a.koo!int        );  check!(0, 1, x =>  a.vaz!int        );
+    check!(1, 1, x =>  a.koo!int        );  check!(1, 1, x =>  a.vaz!int        );
     check!(2, 2, x =>    koo!int(a, 2)  );  check!(2, 2, x =>    vaz!int(a, 2)  );
     check!(2, 2, x =>  a.koo!int(2)     );  check!(2, 2, x =>  a.vaz!int(2)     );
     check!(0, 2, x => (a.koo!int = 2)   );  check!(0, 2, x => (a.vaz!int = 2)   );
 
     check!(1, 1, x =>    var!int(s)     );  check!(1, 1, x =>    vaz!int(s)     );
     check!(1, 1, x =>  s.var!int()      );  check!(1, 1, x =>  s.vaz!int()      );
-    check!(0, 1, x =>  s.var!int        );  check!(0, 1, x =>  s.vaz!int        );
+    check!(1, 1, x =>  s.var!int        );  check!(1, 1, x =>  s.vaz!int        );
     check!(2, 2, x =>    var!int(s, 2)  );  check!(2, 2, x =>    vaz!int(s, 2)  );
     check!(2, 2, x =>  s.var!int(2)     );  check!(2, 2, x =>  s.vaz!int(2)     );
     check!(0, 2, x => (s.var!int = 2)   );  check!(0, 2, x => (s.vaz!int = 2)   );
@@ -333,8 +333,16 @@ void test8251()
 {
     static assert(S8251.min == 123);    // OK
     static assert(T8251_Min == 456);    // OK
-    int a0 = T8251a!(S8251.min());      // OK
-    int b0 = T8251a!(T8251_Min());      // OK
+    static if (enforceProperty)
+    {
+        static assert(!__traits(compiles, { int a0 = T8251a!(S8251.min()); })); // NG
+        static assert(!__traits(compiles, { int b0 = T8251a!(T8251_Min()); })); // NG
+    }
+    else
+    {
+        int a0 = T8251a!(S8251.min());
+        int b0 = T8251a!(T8251_Min());
+    }
 
     // TemplateValueParameter
     int a1 = T8251a!(S8251.min);        // NG

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -350,6 +350,32 @@ void test8251()
 }
 
 /*****************************************/
+// 9062
+
+void test9062()
+{
+    struct S
+    {
+        static int g;
+
+        @property ref int foo() { return g; }
+        @property     int bar() { return 1; }
+        @property ref int baz() const { return g; }
+    }
+
+    S s;
+    static assert(    typeof(& s.foo ).stringof == "int delegate() @property ref");
+    static assert(    typeof(&(s.foo)).stringof == "int*");
+    static assert(    typeof(& s.bar ).stringof == "int delegate() @property");
+    static assert(!is(typeof(&(s.bar))));   // Error, s.bar() is not an lvalue
+
+    static assert(typeof(&        S .baz ).stringof == "int function() const @property ref");
+    static assert(typeof(& (const S).baz ).stringof == "int function() const @property ref");
+    static assert(typeof(&(       S .baz)).stringof == "int*");
+    static assert(typeof(&((const S).baz)).stringof == "int*");
+}
+
+/*****************************************/
 // 9063
 
 @property bool foo9063(){ return true; }
@@ -367,6 +393,7 @@ int main()
     test7274();
     test7275();
     test8251();
+    test9062();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -519,13 +519,13 @@ class foo32
 {
     static void getMemberBar()
     {
-	//foo32 f = new foo32(); new A32( &(f.bar) );
-	new A32( &((new foo32()).bar) );
+        //foo32 f = new foo32(); new A32( &f.bar );
+        new A32( &(new foo32()).bar );
     }
 
     int bar()
     {
-	return 0;
+        return 0;
     }
 }
 


### PR DESCRIPTION
Requires: <del>[dmd/pull/1309](https://github.com/D-Programming-Language/dmd/pull/1309)</del>(merged) and [dmd/pull/1310](https://github.com/D-Programming-Language/dmd/pull/1310)

The changes:

``` d
int func() { return 1; }
void func(int n) { }
@property int prop() { return 2; }
@property void prop(int n) { }
void main() {
  // Without -property switch, all lines can compile.
  // With -property switch:
  func();     // OK -> OK
  func(1);    // OK -> OK
  func;       // OK -> OK [*]
  func = 1;   // OK -> NG
  prop();     // OK -> NG
  prop;       // OK -> OK
  prop(1);    // OK -> NG
  prop = 1;   // OK -> OK
}
```

Keep the line at [_] is necessary to allow UFCS chain without redundant parentheses (e.g. `r.map!(a=>a_2).array`).
