### PR TITLE
fix issue 8997: always force implementation of AssociativeArray!(K,V)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ src/optabgen.exe
 .DS_Store
 trace.def
 trace.log
+/src/vcbuild/x64
+/src/vcbuild/Win32

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -87,6 +87,14 @@ void Declaration::semantic(Scope *sc)
 {
 }
 
+void Declaration::semantic3(Scope *sc)
+{
+    if (type && type->ty == Taarray)
+    {
+        ((TypeAArray *)type)->getImpl(); // ensure AssociativeArray!(index,next) is instantiated
+    }
+}
+
 const char *Declaration::kind()
 {
     return "declaration";

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -133,6 +133,7 @@ struct Declaration : Dsymbol
 
     Declaration(Identifier *id);
     void semantic(Scope *sc);
+    void semantic3(Scope *sc);
     const char *kind();
     unsigned size(Loc loc);
     int checkModify(Loc loc, Scope *sc, Type *t);

--- a/test/runnable/imports/test8997a.d
+++ b/test/runnable/imports/test8997a.d
@@ -1,0 +1,6 @@
+module imports.test8997a;
+
+class A {
+	A[string] foobar;
+}
+

--- a/test/runnable/test8997.d
+++ b/test/runnable/test8997.d
@@ -1,0 +1,14 @@
+// COMPILE_SEPARATELY
+// EXTRA_SOURCES: imports/test8997a.d
+
+module test8997;
+
+import imports.test8997a;
+
+void main() {
+    auto a = new A();
+
+    foreach(key; a.foobar.byKey()) {
+
+    }
+}


### PR DESCRIPTION
This patch forces instantiation of AssociativeArray!(K,V) when a variable of type V[K] is declared. This is identical to declaring the variable as "AssociativeArray!(K,V) var;" in the first place. Otherwise a number of symbols are never produced.
I've put it into Declaration::semantic3() to void forward reference problems if it is run earlier.
