### PR TITLE
add REQUIRED_ARGS to d_do_test

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -38,6 +38,8 @@
 #
 #   REQUIRED_ARGS:       arguments to add to the $(DMD) command line
 #                        default: (none)
+#                        note: the make variable REQUIRED_ARGS is also added to the $(DMD) 
+#                              command line (see below)
 #
 #   DISABLED:            text describing why the test is disabled (if empty, the test is
 #                        considered to be enabled).
@@ -77,6 +79,7 @@ endif
 QUIET=@
 export RESULTS_DIR=test_results
 export MODEL=32
+export REQUIRED_ARGS=
 
 ifeq ($(OS),win32)
 export ARGS=-inline -release -g -O -unittest

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -69,6 +69,7 @@ struct EnvData
     string exe;
     string os;
     string model;
+    string required_args;
 }
 
 bool findTestParameter(string file, string token, ref string result)
@@ -133,7 +134,9 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     string file = cast(string)std.file.read(input_file);
 
     findTestParameter(file, "REQUIRED_ARGS", testArgs.requiredArgs);
-
+    if(envData.required_args.length)
+        testArgs.requiredArgs ~= " " ~ envData.required_args;
+    
     if (! findTestParameter(file, "PERMUTE_ARGS", testArgs.permuteArgs))
     {
         if (testArgs.mode != TestMode.FAIL_COMPILE)
@@ -297,6 +300,7 @@ int main(string[] args)
     envData.os            = getenv("OS");
     envData.dmd           = replace(getenv("DMD"), "/", envData.sep);
     envData.model         = getenv("MODEL");
+    envData.required_args = getenv("REQUIRED_ARGS");
 
     string input_file     = input_dir ~ envData.sep ~ test_name ~ "." ~ test_extension;
     string output_dir     = envData.results_dir ~ envData.sep ~ input_dir;
@@ -385,7 +389,7 @@ int main(string[] args)
                 if (testArgs.mode == TestMode.RUN)
                 {
                     // link .o's into an executable
-                    string command = format("%s -m%s -od%s -of%s %s", envData.dmd, envData.model, output_dir, test_app_dmd, join(toCleanup, " "));
+                    string command = format("%s -m%s %s -od%s -of%s %s", envData.dmd, envData.model, envData.required_args, output_dir, test_app_dmd, join(toCleanup, " "));
                     version(Windows) command ~= " -map nul.map";
 
                     // add after building the command so that before now, it's purely the .o's involved

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -24,15 +24,16 @@ void usage()
           "   example: d_do_test runnable pi d\n"
           "\n"
           "   relevant environment variables:\n"
-          "      ARGS:        set to execute all combinations of\n"
-          "      DMD:         compiler to use, ex: ../src/dmd\n"
-          "      OS:          win32, linux, freebsd, osx\n"
-          "      RESULTS_DIR: base directory for test results\n"
+          "      ARGS:          set to execute all combinations of\n"
+          "      REQUIRED_ARGS: arguments always passed to the compiler\n"
+          "      DMD:           compiler to use, ex: ../src/dmd\n"
+          "      OS:            win32, linux, freebsd, osx\n"
+          "      RESULTS_DIR:   base directory for test results\n"
           "   windows vs non-windows portability env vars:\n"
-          "      DSEP:        \\\\ or /\n"
-          "      SEP:         \\ or /\n"
-          "      OBJ:        .obj or .o\n"
-          "      EXE:        .exe or <null>\n");
+          "      DSEP:          \\\\ or /\n"
+          "      SEP:           \\ or /\n"
+          "      OBJ:          .obj or .o\n"
+          "      EXE:          .exe or <null>\n");
 }
 
 enum TestMode


### PR DESCRIPTION
This is a little improvement to d_do_test that allows the caller to pass arguments to the test engine that are always placed on the compilation command line similar to the setting within the file itself. This has a number of use cases:
- pass "-g" to enable debug info generation for simpler investigation why a test is failing
- pass "-g -o -inline" for the "quick" run for a better code coverage without going through the full test machinery.
- pass "-unittest" to enable the asserts in release builds (otherwise only crashes will cause failures in a lot of tests)
