### PR TITLE
preserve path to object file in COFF library to avoid ambiguities

### DIFF
--- a/src/scanmscoff.c
+++ b/src/scanmscoff.c
@@ -39,7 +39,7 @@
  *      loc             location to use for error printing
  */
 
-void scanMSCoffObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, int pickAny), void *base, size_t buflen, char *module_name, Loc loc)
+void scanMSCoffObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, int pickAny), void *base, size_t buflen, const char *module_name, Loc loc)
 {
 #if LOG
     printf("scanMSCoffObjModule(%s)\n", module_name);


### PR DESCRIPTION
Object files in a COFF library with the same name cause ambiguities and errors when linking against them, especially when building with debug info. Linking with phobos built with debug info results in

```
..\..\windows\bin\dmd.exe -m64 -Irunnable  -g -debuglib=phobos64_d  -odtest_results\runnable -oftest_results\runnable\A16_0.exe runnable\A16.d runnable\imports\A16a.d -map nul.map
Microsoft (R) Incremental Linker Version 10.00.30319.01
Copyright (C) Microsoft Corporation.  All rights reserved.

phobos64_d.lib(utf.obj) : warning LNK4255: library contain multiple objects of the same name; linking object as if no debug info
phobos64_d.lib(string.obj) : warning LNK4255: library contain multiple objects of the same name; linking object as if no debug info
phobos64_d.lib(stdio.obj) : warning LNK4255: library contain multiple objects of the same name; linking object as if no debug info
phobos64_d.lib(exception.obj) : warning LNK4255: library contain multiple objects of the same name; linking object as if no debug info
phobos64_d.lib(exception.obj) : fatal error LNK1103: debugging information corrupt; recompile module
--- errorlevel 1103
```

This patch keeps the object module path if "-op" is specified. Maybe it might be better to figure out a better path to distinguish object files, e.g. the module package name, but that info is currently unavailable when adding the module to the library.
