### PR TITLE
fix test dhry for Win64

### DIFF
--- a/test/runnable/dhry.d
+++ b/test/runnable/dhry.d
@@ -865,7 +865,7 @@ Boolean Func_3 (Enumeration Enum_Par_Val)
     return (false);
 } /* Func_3 */
 
-version (Win32)
+version (Windows)
 {
     import std.c.windows.windows;
 


### PR DESCRIPTION
the function dtime() can have the same implementation for Win32 and Win64
