### PR TITLE
d_do_test: keep test build files until the test succeeds

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -346,7 +346,6 @@ int main(string[] args)
         try
         {
             string[] toCleanup;
-            scope(success) foreach (file; toCleanup) collectException(std.file.remove(file));
 
             auto thisRunName = genTempFilename(result_path);
             auto fThisRun = File(thisRunName, "w");
@@ -430,6 +429,8 @@ int main(string[] args)
                 version (Windows) prefix = "bash ";
                 execute(f, prefix ~ testArgs.postScript ~ " " ~ thisRunName, true, result_path);
             }
+
+            foreach (file; toCleanup) collectException(std.file.remove(file));
         }
         catch(Exception e)
         {


### PR DESCRIPTION
So far, the test executable is deleted after running the test, so you have a hard time to rebuild it with the same options from the command line. 

This patch only deletes intermediate results and the executable if the test succeeds. This allows investigating the failure and firing up the executable in the debugger.

In addition two more files that are generated during a win64 build are deleted.
