### PR TITLE
Issue 9083 - mixin expression on template argument doesn't work

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6496,36 +6496,56 @@ CompileExp::CompileExp(Loc loc, Expression *e)
 {
 }
 
-Expression *CompileExp::semantic(Scope *sc)
+void CompileExp::resolve(Scope *sc, Expression **pe, Type **pt)
 {
-#if LOGSEMANTIC
-    printf("CompileExp::semantic('%s')\n", toChars());
-#endif
+    assert((pe != NULL) != (pt != NULL));
+    if (pe) *pe = NULL;
+    if (pt) *pt = NULL;
+
     UnaExp::semantic(sc);
     e1 = resolveProperties(sc, e1);
     if (e1->op == TOKerror)
-        return e1;
+        goto Lerr;
     if (!e1->type->isString())
     {
         error("argument to mixin must be a string type, not %s", e1->type->toChars());
-        return new ErrorExp();
+        goto Lerr;
     }
     e1 = e1->ctfeInterpret();
+  {
     StringExp *se = e1->toString();
     if (!se)
     {   error("argument to mixin must be a string, not (%s)", e1->toChars());
-        return new ErrorExp();
+        goto Lerr;
     }
     se = se->toUTF8(sc);
     Parser p(sc->module, (unsigned char *)se->string, se->len, 0);
     p.loc = loc;
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
-    Expression *e = p.parseExpression();
+    if (pe)
+        *pe = p.parseExpression();
+    else
+        *pt = p.parseType();
     if (p.token.value != TOKeof)
     {   error("incomplete mixin expression (%s)", se->toChars());
-        return new ErrorExp();
+        goto Lerr;
     }
+  }
+    return;
+
+Lerr:
+    if (pe) *pe = new ErrorExp();
+    if (pt) *pt = Type::terror;
+}
+
+Expression *CompileExp::semantic(Scope *sc)
+{
+#if LOGSEMANTIC
+    printf("CompileExp::semantic('%s')\n", toChars());
+#endif
+    Expression *e;
+    resolve(sc, &e, NULL);
     return e->semantic(sc);
 }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -847,6 +847,7 @@ struct CompileExp : UnaExp
 {
     CompileExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
+    void resolve(Scope *sc, Expression **pe, Type **pt);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 };
 

--- a/src/template.c
+++ b/src/template.c
@@ -5206,6 +5206,12 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
         Expression *ea = isExpression(o);
         Dsymbol *sa = isDsymbol(o);
 
+        if (ea && ea->op == TOKmixin)
+        {
+            ((CompileExp *)ea)->resolve(sc, NULL, &ta);
+            ta->resolve(loc, sc, &ea, &ta, &sa);
+        }
+
         //printf("1: (*tiargs)[%d] = %p, %p, %p, ea=%p, ta=%p\n", j, o, isDsymbol(o), isTuple(o), ea, ta);
         if (ta)
         {

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1689,6 +1689,44 @@ void test9038()
 }
 
 /**********************************/
+// 9083
+
+template isFunction9083(X...) if (X.length == 1)
+{
+    enum isFunction9083 = true;
+}
+
+struct S9083
+{
+    static string func(alias Class)()
+    {
+        foreach (m; __traits(allMembers, Class))
+        {
+            pragma(msg, m);  // prints "func"
+            enum x1 = isFunction9083!(mixin(m));  //NG
+            enum x2 = isFunction9083!(func);      //OK
+        }
+        return "";
+    }
+}
+enum nothing9083 = S9083.func!S9083();
+
+class C9083
+{
+    int x;  // some class members
+
+    void func()
+    {
+        void templateFunc(T)(ref const T obj)
+        {
+            enum x1 = isFunction9083!(mixin("x"));  // NG
+            enum x2 = isFunction9083!(x);           // NG
+        }
+        templateFunc(this);
+    }
+}
+
+/**********************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9083

In template arguments semantic, the string generated by `CompileExp` should be parsed as a type, then is resolved to actual template argument used by `Type::resolve`.
