### PR TITLE
fix issue 5168: do not try to generate codeview debug info for non-integer enum

### DIFF
--- a/src/tocvdebug.c
+++ b/src/tocvdebug.c
@@ -136,8 +136,8 @@ unsigned cv4_Denum(EnumDeclaration *e)
 {
     //dbg_printf("cv4_Denum(%s)\n", e->toChars());
     unsigned property = 0;
-    if (!e->members || !e->memtype)
-        property |= 0x80;               // enum is forward referenced
+	if (!e->members || !e->memtype || !e->memtype->isintegral())
+        property |= 0x80;               // enum is forward referenced or non-integer
 
     // Compute the number of fields, and the length of the fieldlist record
     unsigned nfields = 0;


### PR DESCRIPTION
CodeView debug info can only encode enums of integer base type, not strings or more complex data. So these should be skipped to avoid compilation to abort.

http://d.puremagic.com/issues/show_bug.cgi?id=5168
