### PR TITLE
Don't do inlining during the semantic3 pass

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5407,9 +5407,6 @@ Expression *FuncExp::semantic(Scope *sc)
                 (fd->type && fd->type->ty == Tfunction && !fd->type->nextOf()))
             {
                 fd->semantic3(sc);
-
-                if ( (olderrors == global.errors) && global.params.useInline)
-                    fd->inlineScan();
             }
         }
 
@@ -5614,9 +5611,6 @@ Expression *DeclarationExp::semantic(Scope *sc)
         if (global.errors == olderrors)
         {
             declaration->semantic3(sc);
-
-            if ((global.errors == olderrors) && global.params.useInline)
-                declaration->inlineScan();
         }
     }
 


### PR DESCRIPTION
Inlining happens after semantic, except in these special cases. They cause problems for CTFE.
The reason why they were done so early is unknown.

(Barely tested, I'm relying on the autotester).
