### PR TITLE
fix issue 9093: C++ symbol mangling for Win64

### DIFF
--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -52,12 +52,6 @@ static char __file__[] = __FILE__;      // for tassert.h
 #define DEST_LEN (IDMAX + IDOHD + 1)
 char *obj_mangle2(Symbol *s,char *dest);
 
-#if MARS
-// C++ name mangling is handled by front end
-#define cpp_mangle(s) ((s)->Sident)
-#endif
-
-
 /******************************************
  */
 
@@ -637,7 +631,9 @@ void build_syment_table()
 
         struct syment sym;
 
-        syment_set_name(&sym, s->Sident);
+        char dest[DEST_LEN+1];
+        char *destr = obj_mangle2(s, dest);
+        syment_set_name(&sym, destr);
 
         sym.n_value = 0;
         switch (s->Sclass)
@@ -686,7 +682,9 @@ void build_syment_table()
 
         struct syment sym;
 
-        syment_set_name(&sym, s->Sident);
+        char dest[DEST_LEN+1];
+        char *destr = obj_mangle2(s, dest);
+        syment_set_name(&sym, destr);
 
         sym.n_scnum = IMAGE_SYM_UNDEFINED;
         sym.n_type = 0;

--- a/src/backend/newman.c
+++ b/src/backend/newman.c
@@ -1016,6 +1016,8 @@ STATIC void cpp_basic_data_type(type *t)
         case TYnptr:
             c = 'P' + cpp_cvidx(t->Tty);
             CHAR(c);
+            if(I64)
+                CHAR('E'); // __ptr64 modifier
             cpp_pointer_type(t);
             break;
         case TYstruct:


### PR DESCRIPTION
So far, there is no name mangling for Win64, but the mangling is the same as for win32 but for a modifier for 64-bit pointers. So this patch enables it for the COFF output.
