### PR TITLE
Issue 9100 - Weird behavior on template instance argument

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3758,8 +3758,17 @@ void TypeSArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
             }
             if (o->dyncast() == DYNCAST_EXPRESSION)
             {
-                *ps = NULL;
-                *pe = (Expression *)o;
+                Expression *e = (Expression *)o;
+                if (e->op == TOKdsymbol)
+                {
+                    *ps = ((DsymbolExp *)e)->s;
+                    *pe = NULL;
+                }
+                else
+                {
+                    *ps = NULL;
+                    *pe = e;
+                }
                 return;
             }
             if (o->dyncast() == DYNCAST_TYPE)

--- a/src/template.c
+++ b/src/template.c
@@ -5270,6 +5270,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
         }
         else if (ea)
         {
+            //printf("+[%d] ea = %s %s\n", j, Token::toChars(ea->op), ea->toChars());
             ea = ea->semantic(sc);
             if (flags & 1) // only used by __traits, must not interpret the args
                 ea = ea->optimize(WANTvalue);
@@ -5283,6 +5284,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                 if (global.errors != olderrs)
                     ea = new ErrorExp();
             }
+            //printf("-[%d] ea = %s %s\n", j, Token::toChars(ea->op), ea->toChars());
             (*tiargs)[j] = ea;
             if (ea->op == TOKtype)
             {   ta = ea->type;
@@ -5310,6 +5312,20 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                     (*tiargs)[j] = sa = fe->td;
                     goto Lsa;
                 }
+            }
+            if (ea->op == TOKdotvar)
+            {   // translate expression to dsymbol.
+                sa = ((DotVarExp *)ea)->var;
+                goto Ldsym;
+            }
+            if (ea->op == TOKtemplate)
+            {   sa = ((TemplateExp *)ea)->td;
+                goto Ldsym;
+            }
+            if (ea->op == TOKdottd)
+            {   // translate expression to dsymbol.
+                sa = ((DotTemplateExp *)ea)->td;
+                goto Ldsym;
             }
             if (ea->op == TOKtuple)
             {   // Expand tuple

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1704,6 +1704,44 @@ void test9076()
 }
 
 /**********************************/
+// 9083
+
+template isFunction9083(X...) if (X.length == 1)
+{
+    enum isFunction9083 = true;
+}
+
+struct S9083
+{
+    static string func(alias Class)()
+    {
+        foreach (m; __traits(allMembers, Class))
+        {
+            pragma(msg, m);  // prints "func"
+            enum x1 = isFunction9083!(mixin(m));  //NG
+            enum x2 = isFunction9083!(func);      //OK
+        }
+        return "";
+    }
+}
+enum nothing9083 = S9083.func!S9083();
+
+class C9083
+{
+    int x;  // some class members
+
+    void func()
+    {
+        void templateFunc(T)(ref const T obj)
+        {
+            enum x1 = isFunction9083!(mixin("x"));  // NG
+            enum x2 = isFunction9083!(x);           // NG
+        }
+        templateFunc(this);
+    }
+}
+
+/**********************************/
 // 9100
 
 template Id(alias A) { alias Id = A; }

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1704,6 +1704,62 @@ void test9076()
 }
 
 /**********************************/
+// 9100
+
+template Id(alias A) { alias Id = A; }
+template ErrId(alias A) { static assert(0); }
+template TypeTuple9100(TL...) { alias TypeTuple9100 = TL; }
+
+class C9100
+{
+    int value;
+
+    int fun() { return value; }
+    int tfun(T)() { return value; }
+    TypeTuple9100!(int, long) field;
+
+    void test()
+    {
+        this.value = 1;
+        auto c = new C9100();
+        c.value = 2;
+
+        alias t1a = Id!(c.fun);             // OK
+        alias t1b = Id!(this.fun);          // Prints weird error, bad
+        // -> internally given TOKdotvar
+        assert(t1a() == this.value);
+        assert(t1b() == this.value);
+
+        alias t2a = Id!(c.tfun);            // OK
+        static assert(!__traits(compiles, ErrId!(this.tfun)));
+        alias t2b = Id!(this.tfun);         // No error occurs, why?
+        // -> internally given TOKdottd
+        assert(t2a!int() == this.value);
+        assert(t2b!int() == this.value);
+
+        alias t3a = Id!(foo9100);           // OK
+        alias t3b = Id!(mixin("foo9100"));  // Prints weird error, bad
+        // -> internally given TOKtemplate
+        assert(t3a() == 10);
+        assert(t3b() == 10);
+
+        assert(field[0] == 0);
+        alias t4a = TypeTuple9100!(field);              // NG
+        alias t4b = TypeTuple9100!(GetField9100!());    // NG
+        t4a[0] = 1; assert(field[0] == 1);
+        t4b[0] = 2; assert(field[0] == 2);
+    }
+}
+
+int foo9100()() { return 10; }
+template GetField9100() { alias GetField9100 = C9100.field[0]; }
+
+void test9100()
+{
+    (new C9100()).test();
+}
+
+/**********************************/
 
 int main()
 {
@@ -1771,6 +1827,7 @@ int main()
     test9026();
     test9038();
     test9076();
+    test9100();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -443,11 +443,11 @@ void test15()
     D15 d = new D15();
 
     foreach (t; __traits(getVirtualFunctions, D15, "foo"))
-	writeln(typeid(typeof(t)));
+        writeln(typeid(typeof(t)));
 
     alias typeof(__traits(getVirtualFunctions, D15, "foo")) b;
     foreach (t; b)
-	writeln(typeid(t));
+        writeln(typeid(t));
 
     auto i = __traits(getVirtualFunctions, d, "foo")[1](1);
     assert(i == 2);
@@ -515,12 +515,12 @@ void test18()
 
 class C19
 {
-        void mutating_method(){}
+    void mutating_method(){}
 
-        const void const_method(){}
+    const void const_method(){}
 
-        void bastard_method(){}
-        const void bastard_method(int){}
+    void bastard_method(){}
+    const void bastard_method(int){}
 }
 
 
@@ -531,7 +531,7 @@ void test19()
     assert(a.length == 9);
 
     foreach( m; __traits(allMembers, C19) )
-	writeln(m);
+        writeln(m);
 }
 
 
@@ -541,23 +541,23 @@ void test20()
 {
     void fooref(ref int x)
     {
-	static assert(__traits(isRef, x));
-	static assert(!__traits(isOut, x));
-	static assert(!__traits(isLazy, x));
+        static assert(__traits(isRef, x));
+        static assert(!__traits(isOut, x));
+        static assert(!__traits(isLazy, x));
     }
 
     void fooout(out int x)
     {
-	static assert(!__traits(isRef, x));
-	static assert(__traits(isOut, x));
-	static assert(!__traits(isLazy, x));
+        static assert(!__traits(isRef, x));
+        static assert(__traits(isOut, x));
+        static assert(!__traits(isLazy, x));
     }
 
     void foolazy(lazy int x)
     {
-	static assert(!__traits(isRef, x));
-	static assert(!__traits(isOut, x));
-	static assert(__traits(isLazy, x));
+        static assert(!__traits(isRef, x));
+        static assert(!__traits(isOut, x));
+        static assert(__traits(isLazy, x));
     }
 }
 
@@ -585,11 +585,11 @@ void test22()
     D22 d = new D22();
 
     foreach (t; __traits(getOverloads, D22, "foo"))
-	writeln(typeid(typeof(t)));
+        writeln(typeid(typeof(t)));
 
     alias typeof(__traits(getOverloads, D22, "foo")) b;
     foreach (t; b)
-	writeln(typeid(t));
+        writeln(typeid(t));
 
     auto i = __traits(getOverloads, d, "foo")[1](1);
     assert(i == 2);
@@ -861,6 +861,30 @@ void getProtection()
     static assert(__traits(getProtection, __traits(getMember, t, "fc")) == "protected");
     static assert(__traits(getProtection, __traits(getMember, t, "fd")) == "public");
     static assert(__traits(getProtection, __traits(getMember, t, "fe")) == "export");
+}
+
+/********************************************************/
+// 9091
+
+template isVariable9091(X...) if (X.length == 1)
+{
+    enum isVariable9091 = true;
+}
+class C9091
+{
+    void func()
+    {
+        enum is_x = isVariable9091!(__traits(getMember, C9091, "x"));
+    }
+    int x;  // some class members
+}
+struct S9091
+{
+    void func()
+    {
+        enum is_x = isVariable9091!(__traits(getMember, S9091, "x"));
+    }
+    int x;  // some struct members
 }
 
 /********************************************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9100

Fixing bug 9100 will increase consistency of semantic analysis behavior on template argument.

The bugs that are fixed in relation:
[Issue 9083](http://d.puremagic.com/issues/show_bug.cgi?id=9083) - mixin expression on template argument doesn't work
[Issue 9091](http://d.puremagic.com/issues/show_bug.cgi?id=9091) - Using __traits(getMember) on template argument fails inside member function
