### PR TITLE
D1: never inline before CTFE

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4618,9 +4618,6 @@ Expression *FuncExp::semantic(Scope *sc)
                 (fd->type && fd->type->ty == Tfunction && !fd->type->nextOf()))
             {
                 fd->semantic3(sc);
-
-                if ( (olderrors == global.errors) && global.params.useInline)
-                    fd->inlineScan();
             }
         }
 
@@ -4749,9 +4746,6 @@ Expression *DeclarationExp::semantic(Scope *sc)
         if (global.errors == olderrors)
         {
             declaration->semantic3(sc);
-
-            if ((global.errors == olderrors) && global.params.useInline)
-                declaration->inlineScan();
         }
     }
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5478,38 +5478,14 @@ Expression *evaluateIfBuiltin(InterState *istate, Loc loc,
                 e = EXP_CANT_INTERPRET;
         }
     }
-    /* Horrid hack to retrieve the builtin AA functions after they've been
-     * mashed by the inliner.
-     */
+
     if (!pthis)
     {
         Expression *firstarg =  nargs > 0 ? (Expression *)(arguments->data[0]) : NULL;
-        // Check for the first parameter being a templatized AA. Hack: we assume that
-        // template AA.var is always the AA data itself.
-        Expression *firstdotvar = (firstarg && firstarg->op == TOKdotvar)
-                ?  ((DotVarExp *)firstarg)->e1 : NULL;
         if (nargs==3 && isAssocArray(firstarg->type) && !strcmp(fd->ident->string, "_aaApply"))
             return interpret_aaApply(istate, firstarg, (Expression *)(arguments->data[2]));
         if (nargs==3 && isAssocArray(firstarg->type) &&!strcmp(fd->ident->string, "_aaApply2"))
             return interpret_aaApply(istate, firstarg, (Expression *)(arguments->data[2]));
-        if (firstdotvar && isAssocArray(firstdotvar->type))
-        {   if (fd->ident == Id::aaLen && nargs == 1)
-                return interpret_length(istate, firstdotvar->interpret(istate));
-            else if (fd->ident == Id::aaKeys && nargs == 2)
-            {
-                Expression *trueAA = firstdotvar->interpret(istate);
-                return interpret_keys(istate, trueAA, toBuiltinAAType(trueAA->type)->index);
-            }
-            else if (fd->ident == Id::aaValues && nargs == 3)
-            {
-                Expression *trueAA = firstdotvar->interpret(istate);
-                return interpret_values(istate, trueAA, toBuiltinAAType(trueAA->type)->nextOf());
-            }
-            else if (fd->ident == Id::aaRehash && nargs == 2)
-            {
-                return firstdotvar->interpret(istate, ctfeNeedLvalue);
-            }
-        }
     }
 #endif
 #if DMDV1


### PR DESCRIPTION
This is the D1-only version of pulls #1333 and #1334.
Don't do inlining until semantic analysis is complete.
(The changes to interpret.c actually have no effect for D1, they just keep the code identical for D1 + D2).
