### PR TITLE
fixup for pull #1301 and #1309

### DIFF
--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2074,7 +2074,7 @@ void test9035()
     f(Nested.init); // fails, lvalue
 
     assert(Nested.init.j == 0);
-    (ref n) { n.j = 5; }(Nested.init);
+    //(ref n) { n.j = 5; }(Nested.init);
     assert(Nested.init.j == 0); // fails, j is 5
 }
 


### PR DESCRIPTION
By fixing bug 9069 and 9035, T.init always returns rvalue and ref cannot receive it.
