### PR TITLE
Fix nested struct comparison in constant-folding.

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -901,11 +901,11 @@ Expression *Equal(enum TOK op, Type *type, Expression *e1, Expression *e2)
                 if (cmp == 0)
                     break;
             }
-            if (cmp && es1->type->needsNested())
-            {
-                if ((es1->sinit != NULL) != (es2->sinit != NULL))
-                    cmp = 0;
-            }
+        }
+        if (cmp && es1->type->needsNested())
+        {
+            if ((es1->sinit != NULL) != (es2->sinit != NULL))
+                cmp = 0;
         }
     }
 #if 0 // Should handle this

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2078,6 +2078,20 @@ void test9035()
     assert(Nested.init.j == 0); // fails, j is 5
 }
 
+void test9035a()
+{
+    int x;
+    struct S {
+        // no field
+        void foo() { x = 1; }
+    }
+    S s1;
+    S s2 = S();
+    assert(s1  != S.init);  // OK
+    assert(s2  != S.init);  // OK
+    assert(S() != S.init);  // NG -> OK
+}
+
 /*******************************************/
 // 9036
 
@@ -2190,6 +2204,7 @@ int main()
     test9003();
     test9006();
     test9035();
+    test9035a();
     test9036();
 
     printf("Success\n");


### PR DESCRIPTION
In #1301, I didn't considered a nested struct which has no field.
