### PR TITLE
9113 ICE(interpret.c): CTFE assignment to member of struct in union

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10422,6 +10422,16 @@ Expression *AssignExp::semantic(Scope *sc)
                 return resolveUFCSProperties(sc, die, e2);
             }
         }
+
+        VarDeclaration * vd = NULL;
+        if (e1->op == TOKvar)
+            vd = ((VarExp *)e1)->var->isVarDeclaration();
+
+        if (vd && vd->needThis())
+        {
+            error("need 'this' to access member %s", e1->toChars());
+            return new ErrorExp();
+        }
     }
     e1 = e1->semantic(sc);
     if (e1->op == TOKerror)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4677,6 +4677,27 @@ static assert(!is(typeof(compiles!(bug6681(3)))));
 static assert(!is(typeof(compiles!(bug6681(4)))));
 
 /**************************************************
+    9113 ICE with struct in union
+**************************************************/
+
+union U9113 {
+   struct M {
+        int y;
+   }
+   int xx;
+}
+
+int bug9113(T)()
+{
+    U9113 x;
+    x.M.y = 10; // error, need 'this'
+    return 1;
+}
+
+static assert( !is( typeof( compiles!(bug9113!(int)())) ) );
+
+
+/**************************************************
     6438 void
 **************************************************/
 


### PR DESCRIPTION
The ICE was caused by the error being detected too late. Move the "needs 'this'
pointer" error message from e2ir.c into semantic, instead of creating an invalid
expression.
