### PR TITLE
Issue 9112 - Uniform construction for built-in types

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1609,6 +1609,21 @@ elem *toElem(Expression *e, IRState *irs)
 
                 int rtl = tp->next->isZeroInit() ? RTLSYM_NEWITEMT : RTLSYM_NEWITEMIT;
                 e = el_bin(OPcall,TYnptr,el_var(rtlsym[rtl]),e);
+
+                if (ne->arguments && ne->arguments->dim == 1)
+                {
+                    elem *e2 = (*ne->arguments)[0]->toElem(irs);
+
+                    symbol *ts = symbol_genauto(Type_toCtype(tp));
+                    elem *eeq1 = el_bin(OPeq, TYnptr, el_var(ts), e);
+
+                    elem *ederef = el_una(OPind, e2->Ety, el_var(ts));
+                    elem *eeq2 = el_bin(OPeq, e2->Ety, ederef, e2);
+
+                    e = el_combine(eeq1, eeq2);
+                    e = el_combine(e, el_var(ts));
+                    //elem_print(e);
+                }
             }
             else
             {

--- a/src/expression.c
+++ b/src/expression.c
@@ -5021,8 +5021,18 @@ Lagain:
     }
     else if (tb->isscalar())
     {
-        if (nargs)
-        {   error("no constructor for %s", type->toChars());
+        if (!nargs)
+        {
+        }
+        else if (nargs == 1)
+        {
+            Expression *e = (*arguments)[0];
+            e = e->implicitCastTo(sc, tb);
+            (*arguments)[0] = e;
+        }
+        else
+        {
+            error("more than one argument for construction of %s", type->toChars());
             goto Lerr;
         }
 
@@ -8136,6 +8146,30 @@ Lagain:
             // Rewrite as e1.call(arguments)
             Expression *e = new DotIdExp(loc, e1, Id::call);
             e = new CallExp(loc, e, arguments);
+            e = e->semantic(sc);
+            return e;
+        }
+        else if (e1->op == TOKtype && t1->isscalar())
+        {
+            if (arrayExpressionSemantic(arguments, sc))
+                return new ErrorExp();
+            preFunctionParameters(loc, sc, arguments);
+            Expression *e;
+            if (!arguments || arguments->dim == 0)
+            {
+                e = typeDotIdExp(loc, t1, Id::init);
+            }
+            else if (arguments->dim == 1)
+            {
+                e = (*arguments)[0];
+                e = e->implicitCastTo(sc, t1);
+                e = new CastExp(loc, e, t1);
+            }
+            else
+            {
+                error("more than one argument for construction of %s", t1->toChars());
+                e = new ErrorExp();
+            }
             e = e->semantic(sc);
             return e;
         }

--- a/src/expression.c
+++ b/src/expression.c
@@ -8157,7 +8157,7 @@ Lagain:
             Expression *e;
             if (!arguments || arguments->dim == 0)
             {
-                e = typeDotIdExp(loc, t1, Id::init);
+                e = t1->defaultInitLiteral(loc);
             }
             else if (arguments->dim == 1)
             {

--- a/src/parse.c
+++ b/src/parse.c
@@ -4072,6 +4072,8 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
             // bug 7773: int.max is always a part of expression
             if (peekNext() == TOKdot)
                 goto Lexp;
+            if (peekNext() == TOKlparen)
+                goto Lexp;
         case TOKtypedef:
         case TOKalias:
         case TOKconst:

--- a/src/parse.c
+++ b/src/parse.c
@@ -6002,6 +6002,12 @@ Expression *Parser::parsePrimaryExp()
         case TOKdchar:   t = Type::tdchar; goto LabelX;
         LabelX:
             nextToken();
+            if (token.value == TOKlparen)
+            {
+                e = new TypeExp(loc, t);
+                e = new CallExp(loc, e, parseArguments());
+                break;
+            }
             check(TOKdot, t->toChars());
             if (token.value != TOKidentifier)
             {   error("found '%s' when expecting identifier following '%s.'", token.toChars(), t->toChars());

--- a/test/runnable/uniformctor.d
+++ b/test/runnable/uniformctor.d
@@ -1,0 +1,153 @@
+extern(C) int printf(const char*, ...);
+template TypeTuple(TL...) { alias TypeTuple = TL; }
+
+import core.stdc.math : isnan;
+
+/********************************************/
+// 9112
+
+void test9112a()    //  T() and T(v)
+{
+    void test(T)(T v)
+    {
+        foreach (string qual; TypeTuple!("", "const ", "immutable "))
+        {
+            mixin("alias U = "~qual~T.stringof~";");
+            //pragma(msg, U);
+
+            mixin("auto x1 = "~qual~T.stringof~"();");      // U()      default construction syntax
+            mixin("auto x2 = "~qual~T.stringof~"(v);");     // U(v)
+            static assert(!__traits(compiles, mixin(qual~T.stringof~"(v, v)")));    // U(v, v)
+            static assert(is(typeof(x1) == U));
+            static assert(is(typeof(x2) == U));
+            static if ( is(typeof(U.nan) :  real)) assert( isnan(x1.re) && !isnan(x1.im), U.stringof);
+            static if ( is(typeof(U.nan) : ireal)) assert(!isnan(x1.re) &&  isnan(x1.im), U.stringof);
+            static if ( is(typeof(U.nan) : creal)) assert( isnan(x1.re) &&  isnan(x1.im), U.stringof);
+            static if (!is(typeof(U.nan)))         assert( x1 == U.init,                  U.stringof);
+            assert(x2 == v, U.stringof);
+        }
+    }
+    static assert(!__traits(compiles, { auto x1 = void(); }));
+    static assert(!__traits(compiles, { auto x2 = void(1); }));
+    test!( byte  )(10);
+    test!(ubyte  )(10);
+    test!( short )(10);
+    test!(ushort )(10);
+    test!( int   )(10);
+    test!(uint   )(10);
+    test!( long  )(10);
+    test!(ulong  )(10);
+    test!( float )(3.14);
+    test!( double)(3.14);
+    test!( real  )(3.14);
+    test!(ifloat )(1.4142i);
+    test!(idouble)(1.4142i);
+    test!(ireal  )(1.4142i);
+    test!(cfloat )(1.2+3.4i);
+    test!(cdouble)(1.2+3.4i);
+    test!(creal  )(1.2+3.4i);
+    test!( char  )('A');
+    test!(wchar  )('A');
+    test!(dchar  )('A');
+    test!(bool   )(true);
+
+    static assert(!__traits(compiles, int(1.42)));  // in curre,t this is disallowed
+    static assert(!__traits(compiles, double(3.14i)));
+
+    {
+        int x;
+        alias T = int*;
+      //auto p = int*(&x);      // Error: found '*' when expecting '.' following int
+      //auto p = (int*)(&x);    // Error: C style cast illegal, use cast(int*)&x
+        auto p = T(&x);
+        assert( p == &x);
+        assert(*p ==  x);
+    }
+}
+
+enum Enum : long { a = 10, b = 20 }
+
+void test9112b()    // new T(v)
+{
+    void test(T)(T v)
+    {
+        foreach (string qual; TypeTuple!("", "const ", "immutable "))
+        {
+            mixin("alias U = "~qual~T.stringof~";");
+            //pragma(msg, U);
+
+            mixin("auto p1 = new "~qual~T.stringof~"();");      // U()      default construction syntax
+            mixin("auto p2 = new "~qual~T.stringof~"(v);");     // U(v)
+            static assert(!__traits(compiles, mixin("new "~qual~T.stringof~"(v, v)")));    // U(v, v)
+            static assert(is(typeof(p1) == U*));
+            static assert(is(typeof(p2) == U*));
+            assert( p1 !is null);
+            assert( p2 !is null);
+            auto x1 = *p1;
+            auto x2 = *p2;
+            static if ( is(typeof(U.nan) :  real)) assert( isnan(x1.re) && !isnan(x1.im), U.stringof);
+            static if ( is(typeof(U.nan) : ireal)) assert(!isnan(x1.re) &&  isnan(x1.im), U.stringof);
+            static if ( is(typeof(U.nan) : creal)) assert( isnan(x1.re) &&  isnan(x1.im), U.stringof);
+            static if (!is(typeof(U.nan)))         assert( x1 == U.init,                  U.stringof);
+            assert(x2 == v, U.stringof);
+        }
+    }
+
+    static assert(!__traits(compiles, { auto x1 = new void(); }));
+    static assert(!__traits(compiles, { auto x2 = new void(1); }));
+    static assert(!__traits(compiles, { auto x2 = new void(1, 2); }));
+    test!( byte  )(10);
+    test!(ubyte  )(10);
+    test!( short )(10);
+    test!(ushort )(10);
+    test!( int   )(10);
+    test!(uint   )(10);
+    test!( long  )(10);
+    test!(ulong  )(10);
+    test!( float )(3.14);
+    test!( double)(3.14);
+    test!( real  )(3.14);
+    test!(ifloat )(1.4142i);
+    test!(idouble)(1.4142i);
+    test!(ireal  )(1.4142i);
+    test!(cfloat )(1.2+3.4i);
+    test!(cdouble)(1.2+3.4i);
+    test!(creal  )(1.2+3.4i);
+    test!( char  )('A');
+    test!(wchar  )('A');
+    test!(dchar  )('A');
+    test!(bool   )(true);
+    test!(Enum   )(Enum.a);
+
+    void testPtr(T)(T v)
+    {
+        T* pv = &v;
+        T** ppv = new T*(pv);
+        assert( *ppv == pv);
+        assert(**ppv ==  v);
+    }
+    foreach (T; TypeTuple!(int, const long, immutable double))
+    {
+        testPtr!T(10);
+    }
+    foreach (T; TypeTuple!(Enum, const Enum, immutable Enum))
+    {
+        testPtr!T(Enum.a);
+    }
+
+    static assert(!__traits(compiles, new const int(1, 2)));
+
+    static assert(!__traits(compiles, new int(1.42)));  // in curre,t this is disallowed
+    static assert(!__traits(compiles, new double(3.14i)));
+}
+
+/********************************************/
+
+int main()
+{
+    test9112a();
+    test9112b();
+
+    printf("Success\n");
+    return 0;
+}

--- a/test/runnable/uniformctor.d
+++ b/test/runnable/uniformctor.d
@@ -139,6 +139,10 @@ void test9112b()    // new T(v)
 
     static assert(!__traits(compiles, new int(1.42)));  // in curre,t this is disallowed
     static assert(!__traits(compiles, new double(3.14i)));
+
+    // int(1) in directly on statement scope should be parsed as an expression, but
+    // would fail to compile because of "has no effect" error.
+    static assert(!__traits(compiles, { int(1); }));
 }
 
 /********************************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9112

Support syntax `T()`, `T(v)`, and `new T(v)` for basic type `T`.
