### PR TITLE
Issue 9140 - ref foreach of immutables in postcondition

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -138,13 +138,8 @@ int Declaration::checkModify(Loc loc, Scope *sc, Type *t)
     if ((sc->flags & SCOPEcontract) && isResult())
         error(loc, "cannot modify result '%s' in contract", toChars());
 
-    if (isCtorinit() && !t->isMutable())
-    {
-        if ((storage_class & (STCforeach | STCref)) == (STCforeach | STCref))
-            return TRUE;
-        return modifyFieldVar(loc, sc, isVarDeclaration(), NULL);
-    }
-    else if (storage_class & STCnodefaultctor)
+    if (isCtorinit() && !t->isMutable() ||
+        (storage_class & STCnodefaultctor))
     {   // It's only modifiable if inside the right constructor
         return modifyFieldVar(loc, sc, isVarDeclaration(), NULL);
     }

--- a/src/statement.c
+++ b/src/statement.c
@@ -1812,9 +1812,7 @@ Lagain:
                     {
                         /* Reference to immutable data should be marked as const
                          */
-                        if (aggr->checkCtorInit(sc))
-                            var->storage_class |= STCctorinit;
-                        else if (!tn->isMutable())
+                        if (!tn->isMutable())
                             var->storage_class |= STCconst;
 
                         Type *t = tab->nextOf();

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -1123,6 +1123,8 @@ void test6336()
 /***************************************************/
 // 8783
 
+version(none)
+{
 struct Foo8783
 {
     int[1] bar;
@@ -1136,6 +1138,7 @@ static this()
         foos8783[i].bar[i] = 1; // OK
     foreach (i, ref f; foos8783)
         f.bar[i] = 1; // line 9, Error
+}
 }
 
 /***************************************************/
@@ -1152,6 +1155,16 @@ struct S9077b
     void opAssign()(int n) {}
     void test() { typeof(this) s; s = this; }
     this(this) {}
+}
+
+/***************************************************/
+// 9140
+
+immutable(int)[] bar9140()
+out(result) {
+    foreach (ref r; result) {}
+} body {
+    return null;
 }
 
 /***************************************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9140

This change reopens bug 8783 (wrongly fixed by #1355), and it had not work in 2.060 and earlier. So, this change itself is not a big problem for 2.061 release.

I'll plan for fixing bug 8783 later again. Sorry for my wrong pull #1355.
