### PR TITLE
Issue 9124 & 9143 - manifest constant should be de-symbolize in template argument comparison

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3210,13 +3210,10 @@ MATCH TypeInstance::deduceType(Scope *sc,
                 break;
 
             Type *t1 = isType(o1);
-
-            Expression *e1 = isExpression(o1);
-            Expression *e2 = isExpression(o2);
-
             Dsymbol *s1 = isDsymbol(o1);
             Dsymbol *s2 = isDsymbol(o2);
-
+            Expression *e1 = s1 ? getValue(s1) : getValue(isExpression(o1));
+            Expression *e2 = isExpression(o2);
             Tuple *v1 = isTuple(o1);
             Tuple *v2 = isTuple(o2);
 #if 0

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1864,6 +1864,45 @@ void test9124b()
 }
 
 /**********************************/
+// 9143
+
+struct Foo9143a(bool S, bool L)
+{
+    auto noCall() {
+        Foo9143a!(S, false) x1;         // compiles if this line commented
+        static if(S) Foo9143a!(true,  false) x2;
+        else         Foo9143a!(false, false) x2;
+    }
+    this(T)(T other)        // constructor
+    if (is(T unused == Foo9143a!(P, Q), bool P, bool Q)) { }
+}
+
+struct Foo9143b(bool L, size_t N)
+{
+    void baaz0() {
+        bar!(Foo9143b!(false, N))();    // line 7
+        // -> move to before the baaz semantic
+    }
+    void baaz() {
+        bar!(Foo9143b!(false, 2LU))();  // line 3
+        bar!(Foo9143b!(true, 2LU))();   // line 4
+        bar!(Foo9143b!(L, N))();        // line 5
+        bar!(Foo9143b!(true, N))();     // line 6
+        bar!(Foo9143b!(false, N))();    // line 7
+    }
+    void bar(T)()
+    if (is(T unused == Foo9143b!(_L, _N), bool _L, size_t _N))
+    {}
+}
+
+void test9143()
+{
+    Foo9143a!(false, true) k = Foo9143a!(false, false)();
+
+    auto p = Foo9143b!(true, 2LU)();
+}
+
+/**********************************/
 
 int main()
 {
@@ -1934,6 +1973,7 @@ int main()
     test9100();
     test9124a();
     test9124b();
+    test9143();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1798,33 +1798,6 @@ void test9100()
 }
 
 /**********************************/
-// 9124
-
-struct Foo9124(N...)
-{
-    enum SIZE = N[0];
-    private int _val;
-
-    public void opAssign (T) (T other)
-    if (is(T unused == Foo9124!(_N), _N...))
-    {
-        _val = other._val;          // compile error
-        // this._val = other._val;  // explicit this make it work
-    }
-
-    public auto opUnary (string op) () if (op == "~") {
-        Foo9124!(SIZE) result = this;
-        return result;
-    }
-}
-
-void test9124()
-{
-    Foo9124!(28) a;
-    Foo9124!(28) b = ~a;
-}
-
-/**********************************/
 // 9101
 
 class Node9101
@@ -1836,6 +1809,59 @@ class Node9101
     }
 }
 enum x9101 = __traits(compiles, Node9101.ForwardCtorNoId!());
+
+/**********************************/
+// 9124
+
+struct Foo9124a(N...)
+{
+    enum SIZE = N[0];
+    private int _val;
+
+    public void opAssign (T) (T other)
+    if (is(T unused == Foo9124a!(_N), _N...))
+    {
+        _val = other._val;          // compile error
+        this._val = other._val;     // explicit this make it work
+    }
+
+    public auto opUnary (string op) () if (op == "~") {
+        Foo9124a!(SIZE) result = this;
+        return result;
+    }
+}
+void test9124a()
+{
+    Foo9124a!(28) a;
+    Foo9124a!(28) b = ~a;
+}
+
+// --------
+
+template Foo9124b(T, U, string OP)
+{
+    enum N = T.SIZE;
+    alias Foo9124b = Foo9124b!(false, true, N);
+}
+struct Foo9124b(bool S, bool L, N...)
+{
+    enum SIZE = 5;
+    long[1] _a = 0;
+    void someFunction() const {
+        auto data1 = _a;        // Does not compile
+        auto data2 = this._a;   // <--- Compiles
+    }
+    auto opBinary(string op, T)(T) {
+        Foo9124b!(typeof(this), T, op) test;
+    }
+}
+void test9124b()
+{
+    auto p = Foo9124b!(false, false, 5)();
+    auto q = Foo9124b!(false, false, 5)();
+    p|q;
+    p&q;
+}
 
 /**********************************/
 
@@ -1906,7 +1932,8 @@ int main()
     test9038();
     test9076();
     test9100();
-    test9124();
+    test9124a();
+    test9124b();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
[Issue 9124](http://d.puremagic.com/issues/show_bug.cgi?id=9124) - Object variable of variadic template struct needs explicit "this" in certain situations

This is more general fix for issue 9124, because #1366 was not sufficient.

[Issue 9143](http://d.puremagic.com/issues/show_bug.cgi?id=9143) - template structs with two parameters confuse DMD on multiple instantiations

The root cause is similar to issue 9124.
