### PR TITLE
Issue 8902 - Unexpected "duplicate union initialization for X" error

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8189,11 +8189,14 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
     //    return defaultInit(loc);
     Expressions *structelems = new Expressions();
     structelems->setDim(sym->fields.dim - sym->isnested);
+    unsigned offset = 0;
     for (size_t j = 0; j < structelems->dim; j++)
     {
         VarDeclaration *vd = sym->fields[j];
         Expression *e;
-        if (vd->init)
+        if (vd->offset < offset)
+            e = NULL;
+        else if (vd->init)
         {   if (vd->init->isVoidInitializer())
                 e = NULL;
             else
@@ -8218,6 +8221,7 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
 
             e = e->implicitCastTo(vd->scope, telem);
         }
+        offset = vd->offset + vd->type->size();
         (*structelems)[j] = e;
     }
     StructLiteralExp *structinit = new StructLiteralExp(loc, (StructDeclaration *)sym, structelems);

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -589,6 +589,24 @@ void test8763()
 }
 
 /********************************************/
+// 8902
+
+union U8902 { int a, b; }
+
+enum U8902 u8902a = U8902.init; // No errors
+U8902 u8902b;                   // No errors
+U8902 u8902c = U8902.init;      // Error: duplicate union initialization for b
+
+void test8902()
+{
+    U8902 u8902d = U8902.init;                  // No errors
+    immutable U8902 u8902e = U8902.init;        // No errors
+    immutable static U8902 u8902f = U8902.init; // Error: duplicate union...
+    static U8902 u8902g = u8902e;               // Error: duplicate union...
+    static U8902 u8902h = U8902.init;           // Error: duplicate union...
+}
+
+/********************************************/
 // 9116
 
 void test9116()
@@ -672,6 +690,7 @@ int main()
     test7929();
     test7021();
     test8763();
+    test8902();
     test9116();
     test9293();
     test9566();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8902

Note that one CTFE limitation will be added by this:
- CTFE can only work for the first field of overlapped ones.

Example of breaking.

``` d
struct S {
    union {
        int x;
        int y;
    }
}
bool test() {
    S s = S.init;
    int x = s.x;    // OK -> OK
    int y = s.y;    // OK -> NG
    return true;
}
enum x = test();
```

This change will break `std.format.FormatSpec` struct, and it needs an additional Phobos fix.
@donc, may you have better idea for that?
