### PR TITLE
4269 case 13: invalid template accepted errors are gagged

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -5525,8 +5525,14 @@ TemplateDeclaration *TemplateInstance::findBestMatch(Scope *sc, Expressions *far
         if (!td->semanticRun)
         {
             if (td->scope)
-            {   // Try to fix forward reference
+            {   // Try to fix forward reference. Ungag errors while doing so.
+                int oldgag = global.gag;
+                if (global.isSpeculativeGagging() && !td->isSpeculative())
+                    global.gag = 0;
+
                 td->semantic(td->scope);
+
+                global.gag = oldgag;
             }
             if (!td->semanticRun)
             {

--- a/test/fail_compilation/gag4269g.d
+++ b/test/fail_compilation/gag4269g.d
@@ -1,0 +1,4 @@
+﻿// REQUIRED_ARGS: -c -o-
+
+static if(is(typeof(X13!(0).init))) {}
+template X13(Y13 y) {}


### PR DESCRIPTION
Need to ungag template declarations if they are forward referenced and not speculative.

This is the only remaining accepts-invalid test case from bug 4269, which should allow that bug to be closed.
