### PR TITLE
9113 ICE(interpret.c): CTFE assignment to member of struct in union

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8714,6 +8714,16 @@ Expression *AssignExp::semantic(Scope *sc)
         return e;
     }
 
+    if (e1->op == TOKvar)
+    {
+        VarDeclaration *vd = ((VarExp *)e1)->var->isVarDeclaration();
+        if (vd && vd->needThis())
+        {
+            error("need 'this' to access member %s", e1->toChars());
+            return new ErrorExp();
+        }
+    }
+
     e2 = resolveProperties(sc, e2);
     assert(e1->type);
 


### PR DESCRIPTION
D1 VERSION OF PREVIOUSLY MERGED PULL REQUEST

The ICE was caused by the error being detected too late. Move the "needs 'this'
pointer" error message from e2ir.c into semantic, instead of creating an invalid
expression.
