### PR TITLE
Issue 9150 - Mismatching static array length should be detected in foreach

### DIFF
--- a/test/fail_compilation/fail3703.d
+++ b/test/fail_compilation/fail3703.d
@@ -1,5 +1,12 @@
 // Issue 3703 - static array assignment
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail3703.d(15): Error: mismatched array lengths, 2 and 1
+---
+*/
+
 void main()
 {
     int[1] a = [1];

--- a/test/fail_compilation/test9150.d
+++ b/test/fail_compilation/test9150.d
@@ -1,0 +1,21 @@
+// Issue 9150 - Mismatching static array length should be detected in foreach
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test9150.d(14): Error: mismatched array lengths, 5 and 3
+---
+*/
+
+void main()
+{
+    int[3][2] matrix = [ [1,11,111], [2,22,222] ];
+
+    foreach (int[5] row; matrix) //if int[3], there is no error.
+    {
+        foreach (x; row)
+        {}//write(x, "  ");
+
+        //writeln();
+    }
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9150

This is also a more general fix of [bug 3703](http://d.puremagic.com/issues/show_bug.cgi?id=3703).
