### PR TITLE
Issue 9153 - Type inference for array of delegates should not break based on order

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1694,8 +1694,15 @@ Expression *FuncExp::castTo(Scope *sc, Type *t)
     //printf("FuncExp::castTo type = %s, t = %s\n", type->toChars(), t->toChars());
     Expression *e = inferType(t, 1);
     if (e)
-    {   if (e != this)
+    {
+        if (e != this)
             e = e->castTo(sc, t);
+        else if (!e->type->equals(t))
+        {
+            assert(e->type->nextOf()->covariant(t->nextOf()) == 1);
+            e = e->copy();
+            e->type = t;
+        }
         return e;
     }
     return Expression::castTo(sc, t);

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -700,6 +700,23 @@ void test8575()
 }
 
 /***************************************************/
+// 9153
+
+void writeln9153(string s){}
+
+void test9153()
+{
+    auto tbl1 = [
+        (string x) { writeln9153(x); },
+        (string x) { x ~= 'a'; },
+    ];
+    auto tbl2 = [
+        (string x) { x ~= 'a'; },
+        (string x) { writeln9153(x); },
+    ];
+}
+
+/***************************************************/
 
 int main()
 {
@@ -740,6 +757,7 @@ int main()
     test8397();
     test8496();
     test8575();
+    test9153();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9153

If `e->castTo(t)` succeeds, it should return an expression which has a exact type `t`.
