### PR TITLE
Issue 9162 - [tdpl] Non-static structs should have access to outer lexical scope

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -170,6 +170,7 @@ struct StructDeclaration : AggregateDeclaration
     FuncDeclaration *buildCpCtor(Scope *sc);
 
     FuncDeclaration *buildXopEquals(Scope *sc);
+    void makeNested();
 #endif
     void toDocBuffer(OutBuffer *buf, Scope *sc);
 

--- a/src/func.c
+++ b/src/func.c
@@ -170,7 +170,12 @@ void FuncDeclaration::semantic(Scope *sc)
     storage_class |= sc->stc & ~STCref;
     ad = isThis();
     if (ad)
+    {
         storage_class |= ad->storage_class & (STC_TYPECTOR | STCsynchronized);
+
+        if (StructDeclaration *sd = ad->isStructDeclaration())
+            sd->makeNested();
+    }
 
     //printf("function storage_class = x%llx, sc->stc = x%llx, %x\n", storage_class, sc->stc, Declaration::isFinal());
 

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -511,12 +511,12 @@ void test12()
     static int opeq;
 
     // xopEquals OK
-    struct S1a { const bool opEquals(    const typeof(this) rhs) { ++opeq; return false; } }
-    struct S1b { const bool opEquals(ref const typeof(this) rhs) { ++opeq; return false; } }
-    struct S1c { const bool opEquals(          typeof(this) rhs) { ++opeq; return false; } }
+    static struct S1a { const bool opEquals(    const typeof(this) rhs) { ++opeq; return false; } }
+    static struct S1b { const bool opEquals(ref const typeof(this) rhs) { ++opeq; return false; } }
+    static struct S1c { const bool opEquals(          typeof(this) rhs) { ++opeq; return false; } }
 
     // xopEquals NG
-    struct S2a {       bool opEquals(          typeof(this) rhs) { ++opeq; return false; } }
+    static struct S2a {       bool opEquals(          typeof(this) rhs) { ++opeq; return false; } }
 
     foreach (S; Seq!(S1a, S1b, S1c))
     {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9162

Calculate `StructDeclaration::isnested` lazily.
