### PR TITLE
Issue 8556 - Using take results in a corrupted call to opSlice

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1469,6 +1469,11 @@ Expression *Expression::trySemantic(Scope *sc)
     {
         e = NULL;
     }
+    else if (!e->type || e->type->ty == Terror)
+    {   // Check ungagged errors had occured.
+        // -> Keep error result.
+        //e = NULL;
+    }
     //printf("-trySemantic(%s)\n", toChars());
     return e;
 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -928,6 +928,16 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
     // If inferring return type, and semantic3() needs to be run if not already run
     if (!tf->next && fd->inferRetType)
     {
+        if (fd && fd->semanticRun == PASSsemantic3)
+        {
+            unsigned oldgag = global.gag;
+            global.gag = 0;
+            error(loc, "forward reference of return type deduction %s", fd->toChars());
+            global.gag = oldgag;
+            fd->semanticRun = PASSsemanticdone;
+            ((TypeFunction *)fd->type)->next = Type::terror;    // stop repeating fwdref errors
+            return Type::terror;
+        }
         TemplateInstance *spec = fd->isSpeculative();
         int olderrs = global.errors;
         fd->semantic3(fd->scope);

--- a/src/mars.c
+++ b/src/mars.c
@@ -1294,7 +1294,7 @@ int tryMain(size_t argc, char *argv[])
        m->importAll(0);
     }
     if (global.errors)
-       fatal();
+        fatal();
 
     backend_init();
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -351,6 +351,10 @@ Type *Type::trySemantic(Loc loc, Scope *sc)
     {
         t = NULL;
     }
+    else if (!t || t->ty == Terror)
+    {   // Check ungagged errors had occured.
+        t = NULL;
+    }
     //printf("-trySemantic(%s) %d\n", toChars(), global.errors);
     return t;
 }

--- a/src/statement.c
+++ b/src/statement.c
@@ -4095,7 +4095,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         return gs;
     }
 
-    if (exp && tbret->ty == Tvoid && !implicit0)
+    if (exp && tbret && tbret->ty == Tvoid && !implicit0)
     {
         /* Replace:
          *      return exp;

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -14,14 +14,6 @@ template T5996(T)
 static assert(!is(typeof(T5996!(int).bug5996())));
 
 /**************************************************
-    8532    segfault(mtype.c) - type inference + pure
-**************************************************/
-auto segfault8532(Y, R ...)(R r, Y val) pure
-{ return segfault8532(r, val); }
-
-static assert(!is(typeof( segfault8532(1,2,3))));
-
-/**************************************************
     8801    ICE assigning to __ctfe
 **************************************************/
 static assert(!is(typeof( { bool __ctfe= true; })));

--- a/test/fail_compilation/test8532.d
+++ b/test/fail_compilation/test8532.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test8532.d(13): Error: forward reference of return type deduction segfault8532
+---
+*/
+
+
+/**************************************************
+    8532    segfault(mtype.c) - type inference + pure
+**************************************************/
+auto segfault8532(Y, R ...)(R r, Y val) pure
+{ return segfault8532(r, val); }
+
+static assert(!is(typeof( segfault8532(1,2,3))));

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -1,0 +1,59 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test8556.d(16): Error: forward reference of return type deduction opSlice
+fail_compilation/test8556.d(19): Error: template instance test8556.isSliceable!(Circle!(uint[])) error instantiating
+fail_compilation/test8556.d(24): Error: Grab!(Circle!(uint[])) is used as a type
+fail_compilation/test8556.d(55): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
+---
+*/
+
+extern(C) int printf(const char*, ...);
+
+//+
+template isSliceable(R)
+{
+    enum bool isSliceable = is(typeof( R.init[1 .. 2] ));
+}
+
+struct Grab(Range) if (!isSliceable!Range)
+{
+    public Range source;
+}
+
+Grab!R grab(R)(R input)
+{
+    return Grab!R(input);
+}
+
+// 3. evaluate isSliceable in template constraint
+auto grabExactly(R)(R range) if (!isSliceable!R) { return 0; }
+auto grabExactly(R)(R range) if ( isSliceable!R) { return 0; }
+
+struct Circle(Range)
+{
+    // 2. auto return opSlice
+    auto opSlice(size_t i, size_t j)
+    {
+        //pragma(msg, typeof(opSlice)); // prints "fwdref err" with B, but doesn't with A
+
+        printf("%d %d\n", i, j);
+        assert(j >= i);
+
+        // 1. grabExactly curcular refers this opSlice.
+        return grabExactly(typeof(this)());     // broken execution with A
+    }
+}
+
+Circle!R circle(R)()
+{
+    return Circle!R();
+}
+
+void main()
+{
+    auto t = grab(circle!(uint[])());
+
+    auto cx = circle!(uint[])();
+    auto slice = cx[23 .. 33];
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8556

This is a kind of incorrect gagging bug for forward reference error.
Original code in 8556 has forward reference error in return type deduction for opSlice, but compiler incorrectly gagging the error, then wrong code had generated.

**Note:** This change _correctly_ breaks current Phobos build, and [phobos/pull/854](https://github.com/D-Programming-Language/phobos/pull/854) is required to fix that.
