### PR TITLE
Issue 8847 - voldemort + inout confuses "is"

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -105,6 +105,8 @@ struct AggregateDeclaration : ScopeDsymbol
 
     FuncDeclaration *hasIdentityOpAssign(Scope *sc, Dsymbol *assign);
 
+    char *mangle(bool isv = false);
+
     // For access checking
     virtual PROT getAccess(Dsymbol *smember);   // determine access to smember
     int isFriendOf(AggregateDeclaration *cd);
@@ -146,7 +148,7 @@ struct StructDeclaration : AggregateDeclaration
     void semantic(Scope *sc);
     Dsymbol *search(Loc, Identifier *ident, int flags);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-    char *mangle();
+    char *mangle(bool isv = false);
     const char *kind();
     void finalizeSize(Scope *sc);
     bool isPOD();
@@ -280,7 +282,7 @@ struct ClassDeclaration : AggregateDeclaration
     int isAbstract();
     virtual int vtblOffset();
     const char *kind();
-    char *mangle();
+    char *mangle(bool isv = false);
     void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     PROT getAccess(Dsymbol *smember);   // determine access to smember

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -150,7 +150,7 @@ struct Declaration : Dsymbol
     void jsonProperties(JsonOut *json);
     void toDocBuffer(OutBuffer *buf, Scope *sc);
 
-    char *mangle();
+    char *mangle(bool isv = false);
     int isStatic() { return storage_class & STCstatic; }
     virtual int isDelete();
     virtual int isDataseg();
@@ -208,7 +208,7 @@ struct TypedefDeclaration : Declaration
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
-    char *mangle();
+    char *mangle(bool isv = false);
     const char *kind();
     Type *getType();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -664,7 +664,7 @@ struct FuncDeclaration : Declaration
     int getLevel(Loc loc, Scope *sc, FuncDeclaration *fd); // lexical nesting level difference
     void appendExp(Expression *e);
     void appendState(Statement *s);
-    char *mangle();
+    char *mangle(bool isv = false);
     const char *toPrettyChars();
     int isMain();
     int isWinMain();
@@ -737,7 +737,7 @@ struct FuncAliasDeclaration : FuncDeclaration
     FuncAliasDeclaration *isFuncAliasDeclaration() { return this; }
     const char *kind();
     Symbol *toSymbol();
-    char *mangle() { return toAliasFunc()->mangle(); }
+    char *mangle(bool isv = false) { return toAliasFunc()->mangle(isv); }
 
     FuncDeclaration *toAliasFunc();
 };

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -189,7 +189,7 @@ struct Dsymbol : Object
     virtual LabelDsymbol *isLabel();            // is this a LabelDsymbol?
     virtual AggregateDeclaration *isMember();   // is this symbol a member of an AggregateDeclaration?
     virtual Type *getType();                    // is this a type?
-    virtual char *mangle();
+    virtual char *mangle(bool isv = false);
     virtual int needThis();                     // need a 'this' pointer?
     virtual enum PROT prot();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -77,7 +77,9 @@ L1:
     FuncDeclaration *fd = sthis->isFuncDeclaration();
     if (fd && (fd->needThis() || fd->isNested()))
         buf.writeByte(Type::needThisPrefix());
-    if (sthis->type->deco)
+    if (isv && fd && fd->inferRetType)
+        sthis->type->toDecoBuffer(&buf, 0x200);
+    else if (sthis->type->deco)
         buf.writestring(sthis->type->deco);
     else
     {
@@ -181,6 +183,17 @@ char *TypedefDeclaration::mangle(bool isv)
 
 char *AggregateDeclaration::mangle(bool isv)
 {
+#if 1
+    //printf("AggregateDeclaration::mangle() '%s'\n", toChars());
+    if (Dsymbol *p = toParent2())
+    {   if (FuncDeclaration *fd = p->isFuncDeclaration())
+        {   // This might be the Voldemort Type
+            char *id = Dsymbol::mangle(fd->inferRetType);
+            //printf("isv ad %s, %s\n", toChars(), id);
+            return id;
+        }
+    }
+#endif
     return Dsymbol::mangle(isv);
 }
 

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -78,7 +78,17 @@ L1:
     if (fd && (fd->needThis() || fd->isNested()))
         buf.writeByte(Type::needThisPrefix());
     if (isv && fd && fd->inferRetType)
-        sthis->type->toDecoBuffer(&buf, 0x200);
+    {
+        TypeFunction tfn = *(TypeFunction *)sthis->type;
+        TypeFunction *tfo = (TypeFunction *)sthis->originalType;
+        tfn.purity      = tfo->purity;
+        tfn.isnothrow   = tfo->isnothrow;
+        tfn.isproperty  = tfo->isproperty;
+        tfn.isref       = fd->storage_class & STCauto ? false : tfo->isref;
+        tfn.trust       = tfo->trust;
+        tfn.next        = NULL;     // do not mangle return type
+        tfn.toDecoBuffer(&buf, 0);
+    }
     else if (sthis->type->deco)
         buf.writestring(sthis->type->deco);
     else

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1551,7 +1551,6 @@ char *MODtoChars(unsigned char mod)
  * Name mangling.
  * Input:
  *      flag    0x100   do not do const/invariant
- *              0x200   do not mangle attributes and return type in TypeFunction
  */
 
 void Type::toDecoBuffer(OutBuffer *buf, int flag)
@@ -5330,7 +5329,7 @@ void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
             assert(0);
     }
     buf->writeByte(mc);
-    if (!(flag & 0x200) && (purity || isnothrow || isproperty || isref || trust))
+    if (purity || isnothrow || isproperty || isref || trust)
     {
         if (purity)
             buf->writestring("Na");
@@ -5355,7 +5354,7 @@ void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
     Parameter::argsToDecoBuffer(buf, parameters);
     //if (buf->data[buf->offset - 1] == '@') halt();
     buf->writeByte('Z' - varargs);      // mark end of arg list
-    if (!(flag & 0x200) && next != NULL)
+    if (next != NULL)
         next->toDecoBuffer(buf);
     inuse--;
 }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1551,6 +1551,7 @@ char *MODtoChars(unsigned char mod)
  * Name mangling.
  * Input:
  *      flag    0x100   do not do const/invariant
+ *              0x200   do not mangle attributes and return type in TypeFunction
  */
 
 void Type::toDecoBuffer(OutBuffer *buf, int flag)
@@ -5329,7 +5330,7 @@ void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
             assert(0);
     }
     buf->writeByte(mc);
-    if (purity || isnothrow || isproperty || isref || trust)
+    if (!(flag & 0x200) && (purity || isnothrow || isproperty || isref || trust))
     {
         if (purity)
             buf->writestring("Na");
@@ -5354,7 +5355,7 @@ void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
     Parameter::argsToDecoBuffer(buf, parameters);
     //if (buf->data[buf->offset - 1] == '@') halt();
     buf->writeByte('Z' - varargs);      // mark end of arg list
-    if(next != NULL)
+    if (!(flag & 0x200) && next != NULL)
         next->toDecoBuffer(buf);
     inuse--;
 }

--- a/src/template.h
+++ b/src/template.h
@@ -320,7 +320,7 @@ struct TemplateInstance : ScopeDsymbol
     int oneMember(Dsymbol **ps, Identifier *ident);
     int needsTypeInference(Scope *sc);
     char *toChars();
-    char *mangle();
+    char *mangle(bool isv = false);
     void printInstantiationTrace();
 
     void toObjFile(int multiobj);                       // compile to .obj file

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2127,6 +2127,151 @@ void test9036()
 }
 
 /*******************************************/
+// 8847
+
+auto S8847()
+{
+    static struct Result
+    {
+        inout(Result) get() inout { return this; }
+    }
+    return Result();
+}
+
+void test8847a()
+{
+    auto a = S8847();
+    auto b = a.get();
+    alias typeof(a) A;
+    alias typeof(b) B;
+    assert(is(A == B), A.stringof~ " is different from "~B.stringof);
+}
+
+// --------
+
+enum result8847a = "S6nested9iota8847aFZ6Result";
+enum result8847b = "S6nested9iota8847bFZ4iotaMFZ6Result";
+enum result8847c = "C6nested9iota8847cFZ6Result";
+enum result8847d = "C6nested9iota8847dFZ4iotaMFZ6Result";
+
+auto iota8847a()
+{
+    static struct Result
+    {
+        this(int) {}
+        inout(Result) test() inout { return cast(inout)Result(0); }
+    }
+    static assert(Result.mangleof == result8847a);
+    return Result.init;
+}
+auto iota8847b()
+{
+    auto iota()
+    {
+        static struct Result
+        {
+            this(int) {}
+            inout(Result) test() inout { return cast(inout)Result(0); }
+        }
+        static assert(Result.mangleof == result8847b);
+        return Result.init;
+    }
+    return iota();
+}
+auto iota8847c()
+{
+    static class Result
+    {
+        this(int) {}
+        inout(Result) test() inout { return cast(inout)new Result(0); }
+    }
+    static assert(Result.mangleof == result8847c);
+    return Result.init;
+}
+auto iota8847d()
+{
+    auto iota()
+    {
+        static class Result
+        {
+            this(int) {}
+            inout(Result) test() inout { return cast(inout)new Result(0); }
+        }
+        static assert(Result.mangleof == result8847d);
+        return Result.init;
+    }
+    return iota();
+}
+void test8847b()
+{
+    static assert(typeof(iota8847a().test()).mangleof == result8847a);
+    static assert(typeof(iota8847b().test()).mangleof == result8847b);
+    static assert(typeof(iota8847c().test()).mangleof == result8847c);
+    static assert(typeof(iota8847d().test()).mangleof == result8847d);
+}
+
+// --------
+
+struct Test8847
+{
+    enum result1 = "S6nested8Test88478__T3fooZ3fooMFZ6Result";
+    enum result2 = "S6nested8Test88478__T3fooZ3fooMxFiZ6Result";
+
+    auto foo()()
+    {
+        static struct Result
+        {
+            inout(Result) get() inout { return this; }
+        }
+        static assert(Result.mangleof == Test8847.result1);
+        return Result();
+    }
+    auto foo()(int n) const
+    {
+        static struct Result
+        {
+            inout(Result) get() inout { return this; }
+        }
+        static assert(Result.mangleof == Test8847.result2);
+        return Result();
+    }
+}
+void test8847c()
+{
+    static assert(typeof(Test8847().foo( ).get()).mangleof == Test8847.result1);
+    static assert(typeof(Test8847().foo(1).get()).mangleof == Test8847.result2);
+}
+
+// --------
+
+void test8847d()
+{
+    enum resultS = "S6nested9test8847dFZv3fooMFZ3barMFZAya3bazMFZ1S";
+    enum resultX = "S6nested9test8847dFZv3fooMFZ1X";
+    // Return types for test8847d and bar are mangled correctly,
+    // and return types for foo and baz are not mangled correctly.
+
+    auto foo()
+    {
+        struct X { inout(X) get() inout { return inout(X)(); } }
+        string bar()
+        {
+            auto baz()
+            {
+                struct S { inout(S) get() inout { return inout(S)(); } }
+                return S();
+            }
+            static assert(typeof(baz()      ).mangleof == resultS);
+            static assert(typeof(baz().get()).mangleof == resultS);
+            return "";
+        }
+        return X();
+    }
+    static assert(typeof(foo()      ).mangleof == resultX);
+    static assert(typeof(foo().get()).mangleof == resultX);
+}
+
+/*******************************************/
 
 /+
 auto fun8863(T)(T* ret) { *ret = T(); }

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2271,6 +2271,28 @@ void test8847d()
     static assert(typeof(foo().get()).mangleof == resultX);
 }
 
+// --------
+
+void test8847e()
+{
+    enum resultHere = "6nested"~"9test8847eFZv"~"8__T3fooZ"~"3foo";
+    enum resultBar =  "S"~resultHere~"MFNaNfNgiZ3Bar";
+    enum resultFoo = "_D"~resultHere~"MFNaNbNfNgiZNg"~resultBar;   // added 'Nb'
+
+    // Make template functoin to infer 'nothrow' attributes
+    auto foo()(inout int) pure @safe
+    {
+        struct Bar {}
+        static assert(Bar.mangleof == resultBar);
+        return inout(Bar)();
+    }
+
+    auto bar = foo(0);
+    static assert(typeof(bar).stringof == "Bar");
+    static assert(typeof(bar).mangleof == resultBar);
+    static assert(foo!().mangleof == resultFoo);
+}
+
 /*******************************************/
 
 /+


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8847

By this pull, all mangled result of inner aggregate types in auto functions are changed.

As I wrote [in bugzilla](http://d.puremagic.com/issues/show_bug.cgi?id=8847#c5), Voldemort types cannot be mangled correctly with current mangling rule. I think that a special exception is necessary there.
