### PR TITLE
Issue 8913 - Wrong code in IfStatement condition Expression

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3979,7 +3979,13 @@ Expression *TypeSArray::dotExp(Scope *sc, Expression *e, Identifier *ident)
     }
     else if (ident == Id::ptr)
     {
-        e = e->castTo(sc, next->pointerTo());
+        if (size(e->loc) == 0)
+            e = new NullExp(e->loc, next->pointerTo());
+        else
+        {
+            e = new IndexExp(e->loc, e, new IntegerExp(0));
+            e = new AddrExp(e->loc, e);
+        }
     }
     else
     {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8913

Type cast from `e : T[n]` to `T*` should generate `&e[0]`, not `&e`.
