### PR TITLE
9170 CTFE: Allow reinterpret casts float <-> int

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -182,6 +182,12 @@ int comparePointers(Loc loc, enum TOK op, Type *type, Expression *agg1, dinteger
 Expression *pointerArithmetic(Loc loc, enum TOK op, Type *type,
     Expression *eptr, Expression *e2);
 
+// True if conversion from type 'from' to 'to' involves a reinterpret_cast
+// floating point -> integer or integer -> floating point
+bool isFloatIntPaint(Type *to, Type *from);
+
+// Reinterpret float/int value 'fromVal' as a float/integer of type 'to'.
+Expression *paintFloatInt(Expression *fromVal, Type *to);
 
 /// Return true if t is an AA, or AssociativeArray!(key, value)
 bool isAssocArray(Type *t);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3330,6 +3330,56 @@ static assert(!is(typeof(compiles!(badpointer(7)))));
 static assert(!is(typeof(compiles!(badpointer(8)))));
 
 /**************************************************
+    9170 Allow reinterpret casts float<->int
+**************************************************/
+int f9170(float x) {
+    return *(cast(int*)&x);
+}
+
+float i9170(int x) {
+    return *(cast(float*)&x);
+}
+
+float u9170(uint x) {
+    return *(cast(float*)&x);
+}
+
+int f9170arr(float[] x) {
+    return *(cast(int*)&(x[1]));
+}
+
+long d9170(double x) {
+    return *(cast(long*)&x);
+}
+
+int fref9170(ref float x) {
+    return *(cast(int*)&x);
+}
+
+long dref9170(ref double x) {
+    return *(cast(long*)&x);
+}
+
+bool bug9170()
+{
+    float f = 1.25;
+    double d = 1.25;
+    assert(f9170(f) == 0x3FA0_0000);
+    assert(fref9170(f) == 0x3FA0_0000);
+    assert(d9170(d)==0x3FF4_0000_0000_0000L);
+    assert(dref9170(d)==0x3FF4_0000_0000_0000L);
+    float [3] farr = [0, 1.25, 0];
+    assert(f9170arr(farr) == 0x3FA0_0000);
+    int i = 0x3FA0_0000;
+    assert(i9170(i) == 1.25);
+    uint u = 0x3FA0_0000;
+    assert(u9170(u) == 1.25);
+    return true;
+}
+
+static assert(bug9170());
+
+/**************************************************
     6792 ICE with pointer cast of indexed array
 **************************************************/
 


### PR DESCRIPTION
This a special-case extension to CTFE at Walter's request, to allow the implementation of HalfFloat to be completed. Up to now there has been no way in CTFE to peek into the raw bits of a floating-point type to extract the exponent, etc.

This adds the special case _(cast(U_))&e, where e is an expression
of type T, T.sizeof == U.sizeof, one type is integral (int, uint, long, ulong) and the other is floating point (float,double, ifloat, idouble).

More general situations will be added later. (Note that there is still no way to extract the components of an 80-bit real).
