### PR TITLE
Issue 5933 & 7159 - Resolve forward reference to auto-return member function

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -632,6 +632,8 @@ struct FuncDeclaration : Declaration
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
+    bool functionSemantic(Scope *sc);
+    bool functionSemantic3();
     // called from semantic3
     void varArgs(Scope *sc, TypeFunction*, VarDeclaration *&, VarDeclaration *&);
     VarDeclaration *declareThis(Scope *sc, AggregateDeclaration *ad);

--- a/src/expression.c
+++ b/src/expression.c
@@ -928,18 +928,7 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
     // If inferring return type, and semantic3() needs to be run if not already run
     if (!tf->next && fd->inferRetType)
     {
-        TemplateInstance *spec = fd->isSpeculative();
-        int olderrs = global.errors;
-        // If it isn't speculative, we need to show errors
-        unsigned oldgag = global.gag;
-        if (global.gag && !spec)
-            global.gag = 0;
-        fd->semantic3(fd->scope);
-        global.gag = oldgag;
-        // Update the template instantiation with the number
-        // of errors which occured.
-        if (spec && global.errors != olderrs)
-            spec->errors = global.errors - olderrs;
+        fd->functionSemantic(sc);
     }
 
     size_t n = (nargs > nparams) ? nargs : nparams;   // n = max(nargs, nparams)
@@ -3061,34 +3050,10 @@ Lagain:
     }
     f = s->isFuncDeclaration();
     if (f)
-    {   f = f->toAliasFunc();
-
-        if (!f->originalType && f->scope)       // semantic not yet run
-        {
-            unsigned oldgag = global.gag;
-            if (global.isSpeculativeGagging() && !f->isSpeculative())
-                global.gag = 0;
-            f->semantic(f->scope);
-            global.gag = oldgag;
-        }
-
-        // if inferring return type, sematic3 needs to be run
-        if (f->scope && (f->inferRetType && f->type && !f->type->nextOf() ||
-                         getFuncTemplateDecl(f)))
-        {
-            TemplateInstance *spec = f->isSpeculative();
-            int olderrs = global.errors;
-            // If it isn't speculative, we need to show errors
-            unsigned oldgag = global.gag;
-            if (global.gag && !spec)
-                global.gag = 0;
-            f->semantic3(f->scope);
-            global.gag = oldgag;
-            // Update the template instantiation with the number
-            // of errors which occured.
-            if (spec && global.errors != olderrs)
-                spec->errors = global.errors - olderrs;
-        }
+    {
+        f = f->toAliasFunc();
+        if (!f->functionSemantic(sc))
+            return new ErrorExp();
 
         if (f->isUnitTestDeclaration())
         {

--- a/src/func.c
+++ b/src/func.c
@@ -1694,6 +1694,64 @@ void FuncDeclaration::semantic3(Scope *sc)
     //fflush(stdout);
 }
 
+bool FuncDeclaration::functionSemantic(Scope *sc)
+{
+    if (scope && !originalType)     // semantic not yet run
+    {
+        TemplateInstance *spec = isSpeculative();
+        unsigned olderrs = global.errors;
+        unsigned oldgag = global.gag;
+        if (global.gag && !spec)
+            global.gag = 0;
+        semantic(scope);
+        global.gag = oldgag;
+        if (spec && global.errors != olderrs)
+            spec->errors = global.errors - olderrs;
+        if (olderrs != global.errors)   // if errors compiling this function
+            return false;
+    }
+
+    // if inferring return type, sematic3 needs to be run
+    if (scope &&
+        (inferRetType && type && !type->nextOf() ||
+         sc && (sc->func || sc->intypeof) && getFuncTemplateDecl(this)))
+    {
+        // Attribute inference for template function is necessary
+        // 1. inside function body
+        // 2. inside typeof
+        return functionSemantic3();
+    }
+
+    return true;
+}
+
+bool FuncDeclaration::functionSemantic3()
+{
+    if (scope)
+    {
+        /* Forward reference - we need to run semantic3 on this function.
+         * If errors are gagged, and it's not part of a speculative
+         * template instance, we need to temporarily ungag errors.
+         */
+        TemplateInstance *spec = isSpeculative();
+        unsigned olderrs = global.errors;
+        unsigned oldgag = global.gag;
+        if (global.gag && !spec)
+            global.gag = 0;
+        semantic3(scope);
+        global.gag = oldgag;
+
+        // If it is a speculatively-instantiated template, and errors occur,
+        // we need to mark the template as having errors.
+        if (spec && global.errors != olderrs)
+            spec->errors = global.errors - olderrs;
+        if (olderrs != global.errors)   // if errors compiling this function
+            return false;
+    }
+
+    return true;
+}
+
 void FuncDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     //printf("FuncDeclaration::toCBuffer() '%s'\n", toChars());

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -278,27 +278,8 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
         error("circular dependency. Functions cannot be interpreted while being compiled");
         return EXP_CANT_INTERPRET;
     }
-    if (semanticRun < PASSsemantic3 && scope)
-    {
-        /* Forward reference - we need to run semantic3 on this function.
-         * If errors are gagged, and it's not part of a speculative
-         * template instance, we need to temporarily ungag errors.
-         */
-        int olderrors = global.errors;
-        int oldgag = global.gag;
-        TemplateInstance *spec = isSpeculative();
-        if (global.gag && !spec)
-            global.gag = 0;
-        semantic3(scope);
-        global.gag = oldgag;    // regag errors
-
-        // If it is a speculatively-instantiated template, and errors occur,
-        // we need to mark the template as having errors.
-        if (spec && global.errors != olderrors)
-            spec->errors = global.errors - olderrors;
-        if (olderrors != global.errors) // if errors compiling this function
-            return EXP_CANT_INTERPRET;
-    }
+    if (!functionSemantic3())
+        return EXP_CANT_INTERPRET;
     if (semanticRun < PASSsemantic3done)
         return EXP_CANT_INTERPRET;
 

--- a/src/template.c
+++ b/src/template.c
@@ -2251,16 +2251,8 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
         if (tf->next)
             fd_best->type = tf->semantic(loc, sc);
     }
-    if (fd_best->scope)
-    {
-        TemplateInstance *spec = fd_best->isSpeculative();
-        int olderrs = global.errors;
-        fd_best->semantic3(fd_best->scope);
-        // Update the template instantiation with the number
-        // of errors which occured.
-        if (spec && global.errors != olderrs)
-            spec->errors = global.errors - olderrs;
-    }
+
+    fd_best->functionSemantic(sc);
 
     return fd_best;
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -787,11 +787,7 @@ void ClassDeclaration::toObjFile(int multiobj)
         if (fd && (fd->fbody || !isAbstract()))
         {
             // Ensure function has a return value (Bugzilla 4869)
-            if (fd->type->ty == Tfunction && !((TypeFunction *)fd->type)->next)
-            {
-                assert(fd->scope);
-                fd->semantic3(fd->scope);
-            }
+            fd->functionSemantic(NULL);
 
             Symbol *s = fd->toSymbol();
 

--- a/test/fail_compilation/ice5996.d
+++ b/test/fail_compilation/ice5996.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice5996.d(9): Error: undefined identifier anyOldGarbage
-fail_compilation/ice5996.d(12): Error: CTFE failed because of previous errors in bug5996
+fail_compilation/ice5996.d(8): Error: undefined identifier anyOldGarbage
 ---
 */
 auto bug5996() {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4862,6 +4862,18 @@ void test7150()
 }
 
 /***************************************************/
+// 7159
+
+class HomeController7159 {
+    void* foo() {
+        return cast(void*)&HomeController7159.displayDefault;
+    }
+    auto displayDefault() {
+        return 1;
+    }
+}
+
+/***************************************************/
 // 7160
 
 class HomeController {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4219,6 +4219,37 @@ void test5696()
 }
 
 /***************************************************/
+// 5933
+
+int dummyfunc();
+alias typeof(dummyfunc) FuncType;
+
+struct S5933a { auto x() { return 0; } }
+static assert(is(typeof(&S5933a.init.x) == int delegate()));
+
+struct S5933b { auto x() { return 0; } }
+static assert(is(typeof(S5933b.init.x) == FuncType));
+
+struct S5933c { auto x() { return 0; } }
+static assert(is(typeof(&S5933c.x) == int function()));
+
+struct S5933d { auto x() { return 0; } }
+static assert(is(typeof(S5933d.x) == FuncType));
+
+
+class C5933a { auto x() { return 0; } }
+static assert(is(typeof(&(new C5933b()).x) == int delegate()));
+
+class C5933b { auto x() { return 0; } }
+static assert(is(typeof((new C5933b()).x) == FuncType));
+
+class C5933c { auto x() { return 0; } }
+static assert(is(typeof(&C5933c.x) == int function()));
+
+class C5933d { auto x() { return 0; } }
+static assert(is(typeof(C5933d.x) == FuncType));
+
+/***************************************************/
 // 6084
 
 template TypeTuple6084(T...){ alias T TypeTuple6084; }


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5933">Issue 5933</a> - Cannot retrieve the return type of an auto-return member function
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=7159">Issue 7159</a> - Forward reference when casting auto return method

This is a revised pull of #535.
