### PR TITLE
Issue 9068 - fix compiler error when breaking from some labelled loops.

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1254,7 +1254,7 @@ ForStatement::ForStatement(Loc loc, Statement *init, Expression *condition, Expr
     this->increment = increment;
     this->body = body;
     this->nest = 0;
-    this->relatedLabeled = 0;
+    this->relatedLabeled = NULL;
 }
 
 Statement *ForStatement::syntaxCopy()

--- a/src/statement.c
+++ b/src/statement.c
@@ -1254,6 +1254,7 @@ ForStatement::ForStatement(Loc loc, Statement *init, Expression *condition, Expr
     this->increment = increment;
     this->body = body;
     this->nest = 0;
+    this->relatedLabeled = 0;
 }
 
 Statement *ForStatement::syntaxCopy()
@@ -1343,6 +1344,7 @@ Statement *ForStatement::semanticInit(Scope *sc)
                 //printf("ex {{{\n");
                 s = s->semantic(sc);
                 //printf("}}}\n");
+                this->relatedLabeled = s;
                 statement = s;
 
                 if (init)
@@ -1369,6 +1371,7 @@ Statement *ForStatement::semanticInit(Scope *sc)
                 //printf("fi {{{\n");
                 s = s->semantic(sc);
                 //printf("}}} fi\n");
+                this->relatedLabeled = s;
                 statement = s;
 
                 if (init)

--- a/src/statement.h
+++ b/src/statement.h
@@ -98,6 +98,7 @@ struct Statement : Object
     virtual Statement *semantic(Scope *sc);
     Statement *semanticScope(Scope *sc, Statement *sbreak, Statement *scontinue);
     Statement *semanticNoScope(Scope *sc);
+    virtual Statement *getRelatedLabeled() { return this; }
     virtual bool hasBreak();
     virtual bool hasContinue();
     virtual bool usesEH();
@@ -320,11 +321,17 @@ struct ForStatement : Statement
     Statement *body;
     int nest;
 
+    // When wrapped in try/finally clauses, this points to the outermost one,
+    // which may have an associated label. Internal break/continue statements
+    // treat that label as referring to this loop.
+    Statement *relatedLabeled;
+
     ForStatement(Loc loc, Statement *init, Expression *condition, Expression *increment, Statement *body);
     Statement *syntaxCopy();
     Statement *semanticInit(Scope *sc);
     Statement *semantic(Scope *sc);
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
+    Statement *getRelatedLabeled() { return relatedLabeled ? relatedLabeled : this; }
     bool hasBreak();
     bool hasContinue();
     bool usesEH();

--- a/test/runnable/extra-files/test9068.txt
+++ b/test/runnable/extra-files/test9068.txt
@@ -1,0 +1,3 @@
+asdf
+zxcv
+qwer

--- a/test/runnable/extra-files/test9068.txt
+++ b/test/runnable/extra-files/test9068.txt
@@ -1,3 +1,0 @@
-asdf
-zxcv
-qwer

--- a/test/runnable/test9068.d
+++ b/test/runnable/test9068.d
@@ -1,13 +1,24 @@
 // PERMUTE_ARGS:
 
-import std.range;
-import std.stdio;
-
 struct Foo {
     static int[] destroyed;
     int x;
     ~this() { destroyed ~= x; }
-};
+}
+
+
+struct SimpleCounter {
+    static int destroyedCount;
+    const(int) limit = 5;
+    int counter;
+    ~this() { destroyedCount++; }
+
+    // Range primitives.
+    @property bool empty() const { return counter >= limit; }
+    @property int front() { return counter; }
+    void popFront() { counter++; }
+}
+
 
 // ICE when trying to break outer loop from inside switch statement
 void Bug9068() {
@@ -23,27 +34,27 @@ loop_simple:
     assert(sum == 10);
 
     //----------------------------------------
-    // The test case from the original bug report.
-    auto input = std.stdio.File("runnable/extra-files/test9068.txt", "r");
-    string result;
-X:  foreach (line; input.byLine()) {
-       switch(line.front) {
-           case 'q': break X;
-           default: result ~= line;
+    // There was a bug with loops over ranges.
+    int last = -1;
+X:  foreach (i; SimpleCounter()) {
+       switch(i) {
+           case 3: break X;
+           default: last = i;
        }
     }
-    assert(result == "asdfzxcv", std.conv.text("result is ", result));
+    assert(last == 2);
+    assert(SimpleCounter.destroyedCount == 1);
 
     //----------------------------------------
     // Simpler case: the compiler error had nothing to do with the switch.
-    input.rewind();
-    result = "";
+    last = -1;
 loop_with_range:
-    foreach (line; input.byLine()) {
-        result ~= line;
+    foreach (i; SimpleCounter()) {
+        last = i;
         break loop_with_range;
     }
-    assert(result == "asdf", std.conv.text("result is ", result));
+    assert(last == 0);
+    assert(SimpleCounter.destroyedCount == 2);
 
     //----------------------------------------
     // Test with destructors: the loop is implicitly wrapped into two
@@ -53,8 +64,7 @@ loop_with_dtors:
         if (x.x == 8)
             break loop_with_dtors;
     }
-    assert(Foo.destroyed == [5, 8],
-           std.conv.text("Foo.destroyed is ", Foo.destroyed));
+    assert(Foo.destroyed == [5, 8]);
     Foo.destroyed.clear();
 
     //----------------------------------------
@@ -63,8 +73,7 @@ loop_with_dtors:
         if (x.x == 7)
             break;
     }
-    assert(Foo.destroyed == [5, 7],
-           std.conv.text("Foo.destroyed is ", Foo.destroyed));
+    assert(Foo.destroyed == [5, 7]);
     Foo.destroyed.clear();
 }
 

--- a/test/runnable/test9068.d
+++ b/test/runnable/test9068.d
@@ -1,0 +1,73 @@
+// PERMUTE_ARGS:
+
+import std.range;
+import std.stdio;
+
+struct Foo {
+    static int[] destroyed;
+    int x;
+    ~this() { destroyed ~= x; }
+};
+
+// ICE when trying to break outer loop from inside switch statement
+void Bug9068() {
+
+    //----------------------------------------
+    // There was never a bug in this case (no range).
+    int sum;
+loop_simple:
+    foreach (i; [10, 20]) {
+        sum += i;
+        break loop_simple;
+    }
+    assert(sum == 10);
+
+    //----------------------------------------
+    // The test case from the original bug report.
+    auto input = std.stdio.File("runnable/extra-files/test9068.txt", "r");
+    string result;
+X:  foreach (line; input.byLine()) {
+       switch(line.front) {
+           case 'q': break X;
+           default: result ~= line;
+       }
+    }
+    assert(result == "asdfzxcv", std.conv.text("result is ", result));
+
+    //----------------------------------------
+    // Simpler case: the compiler error had nothing to do with the switch.
+    input.rewind();
+    result = "";
+loop_with_range:
+    foreach (line; input.byLine()) {
+        result ~= line;
+        break loop_with_range;
+    }
+    assert(result == "asdf", std.conv.text("result is ", result));
+
+    //----------------------------------------
+    // Test with destructors: the loop is implicitly wrapped into two
+    // try/finally clauses.
+loop_with_dtors:
+    for (auto x = Foo(4), y = Foo(5); x.x != 10; ++x.x) {
+        if (x.x == 8)
+            break loop_with_dtors;
+    }
+    assert(Foo.destroyed == [5, 8],
+           std.conv.text("Foo.destroyed is ", Foo.destroyed));
+    Foo.destroyed.clear();
+
+    //----------------------------------------
+    // Same with an unlabelled break.
+    for (auto x = Foo(4), y = Foo(5); x.x != 10; ++x.x) {
+        if (x.x == 7)
+            break;
+    }
+    assert(Foo.destroyed == [5, 7],
+           std.conv.text("Foo.destroyed is ", Foo.destroyed));
+    Foo.destroyed.clear();
+}
+
+void main() {
+    Bug9068();
+}


### PR DESCRIPTION
Specifically, the bug was affecting loops that get implicitly wrapped into additional
clauses, such as try/finally, causing the label to refer to another statement.

This also adds a test for this situation. See http://d.puremagic.com/issues/show_bug.cgi?id=9068.
