### PR TITLE
Kill the syntax `alias this = sym`;

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2836,6 +2836,7 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, unsigned char *c
                 addComment(s, comment);
                 return a;
             }
+#if 0
             /* Look for:
              *  alias this = identifier;
              */
@@ -2851,6 +2852,7 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, unsigned char *c
                 addComment(s, comment);
                 return a;
             }
+#endif
             /* Look for:
              *  alias identifier = type;
              */

--- a/test/compilable/aliasdecl.d
+++ b/test/compilable/aliasdecl.d
@@ -24,12 +24,12 @@ void main()
     static assert(is(Y4 == void delegate() const));
     static assert(is(Y5.Type == int));
 
-    struct S
+ /+ struct S
     {
         int value;
         alias this = value;
     }
     auto s = S(10);
     int n = s;
-    assert(n == 10);
+    assert(n == 10); +/
 }


### PR DESCRIPTION
In the pull https://github.com/D-Programming-Language/d-programming-language.org/pull/200, we discussed to replace the syntax `alias this = sym;`, which introduced by the pull #1187.

To keep the discussion continuable, we should not contain the syntax in 2.061 release.
(As far as I know, it is not deeply discussed in @1187.)

@WalterBright , please merge this in 2.061 release.
