### PR TITLE
Issue 9230 - Incorrect implicit immutable conversion occurs in pure function

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5832,7 +5832,7 @@ void TypeFunction::purityLevel()
  * FIXME: This function is a workaround for fixing Bugzilla 9210.
  * In 2.061, TypeFunction::purityLevel() improved to make more functions
  * strong purity, but immutable conversion on return statemet had broken by that.
- * Because, it is essentially unrelated to PUREstring. This function is
+ * Because, it is essentially unrelated to PUREstrong. This function is
  * necessary to check the convertibility.
  */
 bool TypeFunction::hasMutableIndirectionParams()

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -637,6 +637,7 @@ struct TypeFunction : TypeNext
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     void purityLevel();
+    bool hasMutableIndirectionParams();
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
     void toCBufferWithAttributes(OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td);

--- a/src/statement.c
+++ b/src/statement.c
@@ -3956,7 +3956,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
         {
             assert(fd->type->ty == Tfunction);
             TypeFunction *tf = (TypeFunction *)fd->type;
-            if (!tf->hasMutableIndirectionParams() &&
+            if (fd->isPureBypassingInference() != PUREimpure &&
+                !tf->hasMutableIndirectionParams() &&
                 !exp->type->implicitConvTo(tret) &&
                 exp->type->invariantOf()->implicitConvTo(tret))
             {

--- a/src/statement.c
+++ b/src/statement.c
@@ -3954,7 +3954,9 @@ Statement *ReturnStatement::semantic(Scope *sc)
         }
         else if (tbret->ty != Tvoid)
         {
-            if (fd->isPureBypassingInference() == PUREstrong &&
+            assert(fd->type->ty == Tfunction);
+            TypeFunction *tf = (TypeFunction *)fd->type;
+            if (!tf->hasMutableIndirectionParams() &&
                 !exp->type->implicitConvTo(tret) &&
                 exp->type->invariantOf()->implicitConvTo(tret))
             {

--- a/test/fail_compilation/test9230.d
+++ b/test/fail_compilation/test9230.d
@@ -1,10 +1,29 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test9230.d(9): Error: cannot implicitly convert expression (s) of type const(char[]) to string
+fail_compilation/test9230.d(12): Error: cannot implicitly convert expression (s) of type const(char[]) to string
+fail_compilation/test9230.d(18): Error: cannot implicitly convert expression (a) of type int[] to immutable(int[])
+fail_compilation/test9230.d(23): Error: cannot implicitly convert expression (a) of type int[] to immutable(int[])
+fail_compilation/test9230.d(28): Error: cannot implicitly convert expression (a) of type int[] to immutable(int[])
 ---
 */
 
 string foo(in char[] s) pure {
     return s; //
+}
+
+/*pure*/ immutable(int[]) x1()
+{
+    int[] a = new int[](10);
+    return a;
+}
+/*pure */immutable(int[]) x2(int len)
+{
+    int[] a = new int[](len);
+    return a;
+}
+/*pure */immutable(int[]) x3(immutable(int[]) org)
+{
+    int[] a = new int[](org.length);
+    return a;
 }

--- a/test/fail_compilation/test9230.d
+++ b/test/fail_compilation/test9230.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test9230.d(9): Error: cannot implicitly convert expression (s) of type const(char[]) to string
+---
+*/
+
+string foo(in char[] s) pure {
+    return s; //
+}

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1966,18 +1966,29 @@ void test99()
 
 void test5081()
 {
-    static pure immutable(int[]) x()
+    static pure immutable(int[]) x1()
+    {
+        return new int[](10);
+    }
+    static pure immutable(int[]) x2(int len)
+    {
+        return new int[](len);
+    }
+    static pure immutable(int[]) x3(immutable(int[]) org)
+    {
+        return new int[](org.length);
+    }
+
+    immutable a1 = x1();
+    immutable a2 = x2(10);
+    immutable a3 = x3([1,2]);
+
+    static pure int[] y1()
     {
         return new int[](10);
     }
 
-    static pure int[] y()
-    {
-        return new int[](10);
-    }
-
-    immutable a = x();
-    immutable b = y();
+    immutable b1 = y1();
 }
 
 /***************************************************/

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1963,20 +1963,24 @@ void test99()
 }
 
 /***************************************************/
+// 5081
 
 void test5081()
 {
     static pure immutable(int[]) x1()
     {
-        return new int[](10);
+        int[] a = new int[](10);
+        return a;
     }
     static pure immutable(int[]) x2(int len)
     {
-        return new int[](len);
+        int[] a = new int[](len);
+        return a;
     }
     static pure immutable(int[]) x3(immutable(int[]) org)
     {
-        return new int[](org.length);
+        int[] a = new int[](org.length);
+        return a;
     }
 
     immutable a1 = x1();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9230

`hasMutableIndirectionParams()` is based on the old `TypeFunction::purityLevel()` (before fixing issue 8408). So its result is consistent with `TypeFunction::purityLevel() != PUREstrong` in 2.060. Then it _fixes_ the regression.
