### PR TITLE
Made auto ref work for non template functions.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1154,6 +1154,19 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             }
             if (p->storageClass & STCref)
             {
+                if(p->storageClass & STCauto && !arg->isLvalue())
+                {
+                    VarDeclaration* vd = new VarDeclaration(
+                        loc, p->type, Identifier::generateId("__rvalueRefParam"), 
+                        new ExpInitializer(loc, arg));
+   
+                    DeclarationExp* de = new DeclarationExp(loc, vd);
+                    VarExp* ve = new VarExp(loc, vd);
+
+                    arg = new CommaExp(loc, de, ve);
+                    arg = arg->semantic(sc);
+                }
+
                 arg = arg->toLvalue(sc, arg);
             }
             else if (p->storageClass & STCout)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5674,7 +5674,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 continue;
             }
 
-            /* Resolve "auto ref" storage class to be either ref or value,
+            /* Resolve "auto ref" storage class for templates to be either ref or value,
              * based on the argument matching the parameter
              */
             if (fparam->storageClass & STCauto)
@@ -5686,8 +5686,6 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                     else
                         fparam->storageClass &= ~STCref;        // value parameter
                 }
-                else
-                    error(loc, "auto can only be used for template function parameters");
             }
 
             // Remove redundant storage classes for type, they are already applied
@@ -6019,8 +6017,13 @@ MATCH TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             //printf("match %d\n", m);
         }
 
-        // Non-lvalues do not match ref or out parameters
-        if (p->storageClass & STCref)
+        // Non-lvalues do not match (non auto) ref or out parameters
+        if (p->storageClass & STCauto && p->storageClass & STCref)
+        {
+            if(!arg->isLvalue())
+                match = MATCHconvert;
+        }
+        else if (p->storageClass & STCref)
         {   if (m && !arg->isLvalue())
             {
                 Type *ta = targ->aliasthisOf();

--- a/test/compilable/auto_ref.d
+++ b/test/compilable/auto_ref.d
@@ -1,0 +1,30 @@
+void foo(auto ref int a)
+{
+}
+
+void bar(auto ref const int a)
+{
+}
+
+void baz(auto ref int a)
+{
+}
+
+void baz(int a)
+{
+}
+
+void callAll()
+{
+    int lval = 1;
+    enum int rval = 1;
+    
+    foo(lval);
+    foo(rval);
+    
+    bar(lval);
+    bar(rval);
+
+    baz(lval);
+    baz(rval);
+}

--- a/test/runnable/auto_ref.d
+++ b/test/runnable/auto_ref.d
@@ -1,0 +1,23 @@
+int* getAddress(auto ref int a)
+{
+    return &a; 
+}
+
+int foo(auto ref int a)
+{
+    return 1;
+}
+
+int foo(int a)
+{
+    return 2;
+}
+
+void main()
+{
+    int lval = 1;
+    enum int rval = 1;
+
+    assert(getAddress(lval) == &lval);
+    assert(foo(rval) == 2);
+}


### PR DESCRIPTION
This implements auto ref parameters for non template functions so that local variables are created when the function is called with rvalue arguments, as discussed in [this newsgroup thread](http://forum.dlang.org/thread/mailman.2989.1356370854.5162.digitalmars-d@puremagic.com?page=2#post-rsjzbadnwzoetyeonhcz:40forum.dlang.org).
