### PR TITLE
Issue 9254 - ICE on invalid foreach aggregate

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1102,46 +1102,20 @@ bool WhileStatement::hasContinue()
 
 bool WhileStatement::usesEH()
 {
-    assert(0);
-    return body ? body->usesEH() : 0;
+    assert(global.errors);
+    return 0;
 }
 
 int WhileStatement::blockExit(bool mustNotThrow)
 {
-    assert(0);
-    //printf("WhileStatement::blockExit(%p)\n", this);
-
-    int result = BEnone;
-    if (condition->canThrow(mustNotThrow))
-        result |= BEthrow;
-    if (condition->isBool(TRUE))
-    {
-        if (body)
-        {   result |= body->blockExit(mustNotThrow);
-            if (result & BEbreak)
-                result |= BEfallthru;
-        }
-    }
-    else if (condition->isBool(FALSE))
-    {
-        result |= BEfallthru;
-    }
-    else
-    {
-        if (body)
-            result |= body->blockExit(mustNotThrow);
-        result |= BEfallthru;
-    }
-    result &= ~(BEbreak | BEcontinue);
-    return result;
+    assert(global.errors);
+    return BEfallthru;
 }
 
 
 int WhileStatement::comeFrom()
 {
-    assert(0);
-    if (body)
-        return body->comeFrom();
+    assert(global.errors);
     return FALSE;
 }
 
@@ -2651,33 +2625,20 @@ bool ForeachRangeStatement::hasContinue()
 
 bool ForeachRangeStatement::usesEH()
 {
-    assert(0);
+    assert(global.errors);
     return body->usesEH();
 }
 
 int ForeachRangeStatement::blockExit(bool mustNotThrow)
 {
-    assert(0);
-    int result = BEfallthru;
-
-    if (lwr && lwr->canThrow(mustNotThrow))
-        result |= BEthrow;
-    else if (upr && upr->canThrow(mustNotThrow))
-        result |= BEthrow;
-
-    if (body)
-    {
-        result |= body->blockExit(mustNotThrow) & ~(BEbreak | BEcontinue);
-    }
-    return result;
+    assert(global.errors);
+    return BEfallthru;
 }
 
 
 int ForeachRangeStatement::comeFrom()
 {
-    assert(0);
-    if (body)
-        return body->comeFrom();
+    assert(global.errors);
     return FALSE;
 }
 

--- a/test/fail_compilation/ice9254a.d
+++ b/test/fail_compilation/ice9254a.d
@@ -1,0 +1,12 @@
+
+void main()
+{
+    foreach (divisor; !(2, 3, 4, 8, 7, 9))
+    {
+        // ice in ForeachRangeStatement::blockExit()
+        foreach (v; 0..uint.max) {}
+
+        // ice in WhileStatement::blockExit()
+        while (1) {}
+    }
+}

--- a/test/fail_compilation/ice9254b.d
+++ b/test/fail_compilation/ice9254b.d
@@ -1,0 +1,15 @@
+
+class C
+{
+    synchronized void foo()
+    {
+        foreach(divisor; !(2, 3, 4, 8, 7, 9))
+        {
+            // ice in ForeachRangeStatement::usesEH()
+            foreach (v; 0..uint.max) {}
+
+            // ice in WhileStatement::usesEH()
+            while (1) {}
+        }
+    }
+}

--- a/test/fail_compilation/ice9254c.d
+++ b/test/fail_compilation/ice9254c.d
@@ -1,0 +1,14 @@
+
+void main()
+{
+    foreach(divisor; !(2, 3, 4, 8, 7, 9))
+    {
+        assert(0);
+
+        // ice in ForeachRangeStatement::comeFrom()
+        foreach (v; 0..uint.max) {}
+
+        // ice in WhileStatement::comeFrom()
+        while (1) {}
+    }
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9254

ForeachRangeStatement and WhileStatement are basically replaced into ForStatement in semantic phase.
If any error occurs, they will be left as is, however.

Therefor, `assert(0)` in blockExit, usesEH, comeFrom have the potential to be invoked.
