### PR TITLE
9236 CTFE ice on switch + with(EnumType)

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1319,6 +1319,11 @@ Expression *WithStatement::interpret(InterState *istate)
 #if LOG
     printf("%s WithStatement::interpret()\n", loc.toChars());
 #endif
+
+    // If it is with(Enum) {...}, just execute the body.
+    if (exp->op == TOKimport || exp->op == TOKtype)
+        return body ? body->interpret(istate) : EXP_VOID_INTERPRET;
+
     START()
     Expression *e = exp->interpret(istate);
     if (exceptionOrCantInterpret(e))

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4152,6 +4152,40 @@ int testwith()
 static assert(testwith());
 
 /**************************************************
+    9236 ICE  switch with(EnumType)
+**************************************************/
+
+enum Command9236 {
+    Char,
+    Any,
+};
+
+bool bug9236(Command9236 cmd)
+{
+    int n = 0;
+    with(Command9236) switch(cmd)
+    {
+     case Any:
+        n = 1;
+        break;
+    default:
+        n = 2;
+    }
+    assert(n == 1);
+
+    switch(cmd) with(Command9236)
+    {
+    case Any:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static assert(bug9236(Command9236.Any));
+
+
+/**************************************************
     6416 static struct declaration
 **************************************************/
 


### PR DESCRIPTION
When it's with(Type), don't try to interpret it, it's a no-op.
