### PR TITLE
Add HOST_POSIX define

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -11,7 +11,7 @@
  */
 
 
-/* Macros defined by the compiler, not the code:
+/* Macros defined by the compiler, not the code (see comments for exceptions):
 
     Compiler:
         __SC__          Symantec compiler
@@ -22,13 +22,14 @@
         __llvm__        Compiler using LLVM as backend (LLVM-GCC/Clang)
 
     Host operating system:
-        _WIN32          Microsoft NT, Windows 95, Windows 98, Win32s, Windows 2000
-        _WIN64          Windows for AMD64
         linux           Linux
         __APPLE__       Mac OSX
         __FreeBSD__     FreeBSD
         __OpenBSD__     OpenBSD
         __sun           Solaris, OpenSolaris, SunOS, OpenIndiana, etc
+	HOST_POSIX      Any of the above operating systems (DEFINED IN THIS FILE)
+        _WIN32          Microsoft NT, Windows 95, Windows 98, Win32s, Windows 2000
+        _WIN64          Windows for AMD64
         __OS2__         IBM OS/2
         DOS386          32 bit DOS extended executable
         DOS16RM         Rational Systems 286 DOS extender
@@ -153,6 +154,12 @@ One and only one of these macros must be set by the makefile:
 
 
 /***********************************
+ * Host grouping
+ */
+#define HOST_POSIX (linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+
+
+/***********************************
  * Target machine types:
  */
 
@@ -267,7 +274,7 @@ typedef long double longdouble;
 
 // Precompiled header variations
 #define MEMORYHX        (_WINDLL && _WIN32)     // HX and SYM files are cached in memory
-#define MMFIO           (_WIN32 || linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)  // if memory mapped files
+#define MMFIO           (_WIN32 || HOST_POSIX)  // if memory mapped files
 #define LINEARALLOC     _WIN32  // if we can reserve address ranges
 
 // H_STYLE takes on one of these precompiled header methods

--- a/src/backend/debug.c
+++ b/src/backend/debug.c
@@ -92,7 +92,7 @@ void WRTYxx(tym_t t)
         dbg_printf("mTYconst|");
     if (t & mTYvolatile)
         dbg_printf("mTYvolatile|");
-#if !MARS && (linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+#if !MARS && HOST_POSIX
     if (t & mTYtransu)
         dbg_printf("mTYtransu|");
 #endif

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -9,6 +9,8 @@
 
 // Emit Dwarf symbolic debug info
 
+#include        "cc.h"
+
 #if !SPP
 #include        <stdio.h>
 #include        <string.h>
@@ -22,13 +24,12 @@
 #include        <malloc.h>
 #endif
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include        <signal.h>
 #include        <unistd.h>
 #include        <errno.h>
 #endif
 
-#include        "cc.h"
 #include        "global.h"
 #include        "code.h"
 #include        "type.h"
@@ -570,7 +571,7 @@ void dwarf_initfile(const char *filename)
         linebuf->writeString((char *)list_ptr(pl));
         linebuf->writeByte(0);
     }
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
     for (pl = pathsyslist; pl; pl = list_next(pl))
     {
         linebuf->writeString((char *)list_ptr(pl));

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -21,7 +21,7 @@
 #include        <malloc.h>
 #endif
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include        <signal.h>
 #include        <unistd.h>
 #endif

--- a/src/backend/os.c
+++ b/src/backend/os.c
@@ -16,6 +16,8 @@
  * up code with OS .h files.
  */
 
+#include "cc.h"
+
 #include <stdio.h>
 #include <time.h>
 #include <stdlib.h>
@@ -26,7 +28,7 @@
 #include <sys\stat.h>
 #endif
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -667,7 +669,7 @@ int os_file_exists(const char *name)
     if (!find)
         return 0;
     return (find->attribute & FA_DIREC) ? 2 : 1;
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#elif HOST_POSIX
     struct stat buf;
 
     return stat(name,&buf) == 0;        /* file exists if stat succeeded */
@@ -744,7 +746,7 @@ char *file_8dot3name(const char *filename)
 
 int file_write(char *name, void *buffer, unsigned len)
 {
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
     int fd;
     ssize_t numwritten;
 
@@ -820,7 +822,7 @@ err:
 
 int file_createdirs(char *name)
 {
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
     return 1;
 #endif
 #if _WIN32

--- a/src/backend/strtold.c
+++ b/src/backend/strtold.c
@@ -16,12 +16,10 @@
 #include        <float.h>
 #include        <string.h>
 #include        <math.h>
+#include        <errno.h>
 #if _WIN32 && __DMC__
 #include        <fenv.h>
 #include        <fltpnt.h>
-#endif
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
-#include        <errno.h>
 #endif
 
 #include        "longdouble.h"
@@ -32,7 +30,7 @@ extern char * __cdecl __locale_decpoint;
 void __pascal __set_errno (int an_errno);
 #endif
 
-#if _WIN32 || linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if _WIN32 || HOST_POSIX
 
 #if 0
 /* This is for compilers that don't support hex float literals,

--- a/src/doc.c
+++ b/src/doc.c
@@ -18,12 +18,12 @@
 
 #include "rmem.h"
 #include "root.h"
+#include "mars.h"
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include "gnuc.h"
 #endif
 
-#include "mars.h"
 #include "dsymbol.h"
 #include "macro.h"
 #include "template.h"

--- a/src/inifile.c
+++ b/src/inifile.c
@@ -10,6 +10,8 @@
  * For any other uses, please contact Digital Mars.
  */
 
+#include "mars.h"
+
 #include        <stdio.h>
 #include        <string.h>
 #include        <stdlib.h>
@@ -32,7 +34,7 @@
 #include        <alloca.h>
 #endif
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include "gnuc.h"
 #endif
 
@@ -116,7 +118,7 @@ const char *inifile(const char *argv0x, const char *inifilex, const char *envsec
                 filename = (char *)FileName::replaceName(argv0, inifile);
                 if (!FileName::exists(filename))
                 {
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #if __GLIBC__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun   // This fix by Thomas Kuehne
                     /* argv0 might be a symbolic link,
                      * so try again looking past it to the real path

--- a/src/link.c
+++ b/src/link.c
@@ -7,6 +7,7 @@
 // in artistic.txt, or the GNU General Public License in gnu.txt.
 // See the included readme.txt for details.
 
+#include        "mars.h"
 
 #include        <stdio.h>
 #include        <ctype.h>
@@ -19,7 +20,7 @@
 #include        <process.h>
 #endif
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include        <sys/types.h>
 #include        <sys/wait.h>
 #include        <unistd.h>
@@ -37,8 +38,6 @@
 #endif
 
 #include        "root.h"
-
-#include        "mars.h"
 
 #include        "rmem.h"
 
@@ -79,7 +78,7 @@ void writeFilename(OutBuffer *buf, const char *filename)
     writeFilename(buf, filename, strlen(filename));
 }
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #define NME_MAX_OFFSET 100
 
 #if __APPLE__
@@ -463,7 +462,7 @@ int runLINK()
         }
         return status;
     }
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#elif HOST_POSIX
     pid_t childpid;
     int status;
 
@@ -808,7 +807,7 @@ int executearg0(char *cmd, char *args)
 #if _WIN32
     // spawnlp returns intptr_t in some systems, not int
     return spawnl(0,file,file,args,NULL);
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#elif HOST_POSIX
     char *full;
     int cmdl = strlen(cmd);
 
@@ -872,7 +871,7 @@ int runProgram()
         ex = global.params.exefile;
     // spawnlp returns intptr_t in some systems, not int
     return spawnv(0,ex,argv.tdata());
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#elif HOST_POSIX
     pid_t childpid;
     int status;
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -9,6 +9,8 @@
 // in artistic.txt, or the GNU General Public License in gnu.txt.
 // See the included readme.txt for details.
 
+#include "mars.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -16,7 +18,7 @@
 #include <limits.h>
 #include <string.h>
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include <errno.h>
 #endif
 
@@ -24,7 +26,6 @@
 #include "root.h"
 #include "async.h"
 
-#include "mars.h"
 #include "module.h"
 #include "mtype.h"
 #include "id.h"
@@ -312,7 +313,7 @@ void usage()
 #else
     const char fpic[] = "";
 #endif
-    printf("DMD%d D Compiler %s\n%s %s\n",
+    printf("DMD%lu D Compiler %s\n%s %s\n",
         sizeof(size_t) * 8,
         global.version, global.copyright, global.written);
     printf("\
@@ -512,7 +513,7 @@ int tryMain(size_t argc, char *argv[])
 
 #if _WIN32
     inifilename = inifile(argv[0], "sc.ini", "Environment");
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#elif HOST_POSIX
     inifilename = inifile(argv[0], "dmd.conf", "Environment");
 #else
 #error "fix this"

--- a/src/mars.h
+++ b/src/mars.h
@@ -23,7 +23,7 @@ The host compiler and host operating system are also different,
 and are predefined by the host compiler. The ones used in
 dmd are:
 
-Macros defined by the compiler, not the code:
+Macros defined by the compiler, not the code (see comments for exceptions):
 
     Compiler:
         __DMC__         Digital Mars compiler
@@ -32,14 +32,15 @@ Macros defined by the compiler, not the code:
         __clang__       Clang compiler
 
     Host operating system:
-        _WIN32          Microsoft NT, Windows 95, Windows 98, Win32s,
-                        Windows 2000, Win XP, Vista
-        _WIN64          Windows for AMD64
         linux           Linux
         __APPLE__       Mac OSX
         __FreeBSD__     FreeBSD
         __OpenBSD__     OpenBSD
         __sun           Solaris, OpenSolaris, SunOS, OpenIndiana, etc
+	HOST_POSIX      Any of the above operating systems (DEFINED IN THIS FILE)
+        _WIN32          Microsoft NT, Windows 95, Windows 98, Win32s,
+                        Windows 2000, Win XP, Vista
+        _WIN64          Windows for AMD64
 
 For the target systems, there are the target operating system and
 the target object file format:
@@ -94,6 +95,9 @@ void unittests();
 #define BUG6652 1       // Making foreach range statement parameter non-ref in default
                         // 1: Modifying iteratee in body is warned with -w switch
                         // 2: Modifying iteratee in body is error without -d switch
+
+// Host grouping
+#define HOST_POSIX (linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
 
 // Set if C++ mangling is done by the front end
 #define CPP_MANGLE (DMDV2 && (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS))

--- a/src/root/dmgcmem.c
+++ b/src/root/dmgcmem.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <assert.h>
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include <unistd.h>
 #include <pthread.h>
 #endif
@@ -135,7 +135,7 @@ void Mem::check(void *p)
 
 void Mem::error()
 {
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
     assert(0);
 #endif
     printf("Error: out of memory\n");
@@ -286,9 +286,9 @@ void Mem::operator delete(void *p)
  * of the collector per thread.
  */
 
-/* ===================== linux ================================ */
+/* ===================== POSIX ================================ */
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 
 #include <pthread.h>
 

--- a/src/root/response.c
+++ b/src/root/response.c
@@ -9,6 +9,8 @@
  * For any other uses, please contact Digital Mars.
  */
 
+#include "root.h"
+
 #include <stdio.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -20,7 +22,7 @@
 #include <io.h>
 #endif
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if HOST_POSIX
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>

--- a/src/root/rmem.c
+++ b/src/root/rmem.c
@@ -11,11 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
-#include "../root/rmem.h"
-#else
 #include "rmem.h"
-#endif
 
 /* This implementation of the storage allocator uses the standard C allocation package.
  */

--- a/src/root/root.c
+++ b/src/root/root.c
@@ -7,7 +7,7 @@
 // in artistic.txt, or the GNU General Public License in gnu.txt.
 // See the included readme.txt for details.
 
-#define POSIX (linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+#include "root.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -33,7 +33,7 @@
 #include <errno.h>
 #endif
 
-#if POSIX
+#if HOST_POSIX
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -43,7 +43,6 @@
 #endif
 
 #include "port.h"
-#include "root.h"
 #include "rmem.h"
 
 #if 0 //__SC__ //def DEBUG
@@ -239,7 +238,7 @@ char *FileName::combine(const char *path, const char *name)
     namelen = strlen(name);
     f = (char *)mem.malloc(pathlen + 1 + namelen + 1);
     memcpy(f, path, pathlen);
-#if POSIX
+#if HOST_POSIX
     if (path[pathlen - 1] != '/')
     {   f[pathlen] = '/';
         pathlen++;
@@ -291,7 +290,7 @@ Strings *FileName::splitPath(const char *path)
 #if _WIN32
                     case ';':
 #endif
-#if POSIX
+#if HOST_POSIX
                     case ':':
 #endif
                         p++;
@@ -305,7 +304,7 @@ Strings *FileName::splitPath(const char *path)
                     case '\r':
                         continue;       // ignore carriage returns
 
-#if POSIX
+#if HOST_POSIX
                     case '~':
                         buf.writestring(getenv("HOME"));
                         continue;
@@ -412,7 +411,7 @@ int FileName::absolute(const char *name)
     return (*name == '\\') ||
            (*name == '/')  ||
            (*name && name[1] == ':');
-#elif POSIX
+#elif HOST_POSIX
     return (*name == '/');
 #else
     assert(0);
@@ -436,7 +435,7 @@ char *FileName::ext(const char *str)
         switch (*e)
         {   case '.':
                 return e + 1;
-#if POSIX
+#if HOST_POSIX
             case '/':
                 break;
 #endif
@@ -492,7 +491,7 @@ char *FileName::name(const char *str)
     {
         switch (*e)
         {
-#if POSIX
+#if HOST_POSIX
             case '/':
                return e + 1;
 #endif
@@ -537,7 +536,7 @@ char *FileName::path(const char *str)
 
     if (n > str)
     {
-#if POSIX
+#if HOST_POSIX
         if (n[-1] == '/')
             n--;
 #elif _WIN32
@@ -574,7 +573,7 @@ const char *FileName::replaceName(const char *path, const char *name)
     namelen = strlen(name);
     f = (char *)mem.malloc(pathlen + 1 + namelen + 1);
     memcpy(f, path, pathlen);
-#if POSIX
+#if HOST_POSIX
     if (path[pathlen - 1] != '/')
     {   f[pathlen] = '/';
         pathlen++;
@@ -653,7 +652,7 @@ int FileName::equalsExt(const char *ext)
         return 1;
     if (!e || !ext)
         return 0;
-#if POSIX
+#if HOST_POSIX
     return strcmp(e,ext) == 0;
 #elif _WIN32
     return stricmp(e,ext) == 0;
@@ -672,7 +671,7 @@ void FileName::CopyTo(FileName *to)
 
 #if _WIN32
     file.touchtime = mem.malloc(sizeof(WIN32_FIND_DATAA));      // keep same file time
-#elif POSIX
+#elif HOST_POSIX
     file.touchtime = mem.malloc(sizeof(struct stat)); // keep same file time
 #else
     assert(0);
@@ -744,7 +743,7 @@ char *FileName::safeSearchPath(Strings *path, const char *name)
     }
 
     return FileName::searchPath(path, name, 0);
-#elif POSIX
+#elif HOST_POSIX
     /* Even with realpath(), we must check for // and disallow it
      */
     for (const char *p = name; *p; p++)
@@ -801,7 +800,7 @@ cont:
 
 int FileName::exists(const char *name)
 {
-#if POSIX
+#if HOST_POSIX
     struct stat st;
 
     if (stat(name, &st) < 0)
@@ -849,7 +848,7 @@ void FileName::ensurePathExists(const char *path)
 #if _WIN32
             if (path[strlen(path) - 1] != '\\')
 #endif
-#if POSIX
+#if HOST_POSIX
             if (path[strlen(path) - 1] != '\\')
 #endif
             {
@@ -857,7 +856,7 @@ void FileName::ensurePathExists(const char *path)
 #if _WIN32
                 if (_mkdir(path))
 #endif
-#if POSIX
+#if HOST_POSIX
                 if (mkdir(path, 0777))
 #endif
                 {
@@ -882,7 +881,7 @@ char *FileName::canonicalName(const char *name)
 #if linux
     // Lovely glibc extension to do it for us
     return canonicalize_file_name(name);
-#elif POSIX
+#elif HOST_POSIX
   #if _POSIX_VERSION >= 200809L || defined (linux)
     // NULL destination buffer is allowed and preferred
     return realpath(name, NULL);
@@ -976,7 +975,7 @@ void File::mark()
 
 int File::read()
 {
-#if POSIX
+#if HOST_POSIX
     off_t size;
     ssize_t numread;
     int fd;
@@ -1109,7 +1108,7 @@ err1:
 
 int File::mmread()
 {
-#if POSIX
+#if HOST_POSIX
     return read();
 #elif _WIN32
     HANDLE hFile;
@@ -1164,7 +1163,7 @@ Lerr:
 
 int File::write()
 {
-#if POSIX
+#if HOST_POSIX
     int fd;
     ssize_t numwritten;
     char *name;
@@ -1238,7 +1237,7 @@ err:
 
 int File::append()
 {
-#if POSIX
+#if HOST_POSIX
     return 1;
 #elif _WIN32
     HANDLE h;
@@ -1319,7 +1318,7 @@ void File::appendv()
 
 int File::exists()
 {
-#if POSIX
+#if HOST_POSIX
     return 0;
 #elif _WIN32
     DWORD dw;
@@ -1345,7 +1344,7 @@ int File::exists()
 
 void File::remove()
 {
-#if POSIX
+#if HOST_POSIX
     ::remove(this->name->toChars());
 #elif _WIN32
     DeleteFileA(this->name->toChars());
@@ -1361,7 +1360,7 @@ Files *File::match(char *n)
 
 Files *File::match(FileName *n)
 {
-#if POSIX
+#if HOST_POSIX
     return NULL;
 #elif _WIN32
     HANDLE h;
@@ -1400,7 +1399,7 @@ Files *File::match(FileName *n)
 
 int File::compareTime(File *f)
 {
-#if POSIX
+#if HOST_POSIX
     return 0;
 #elif _WIN32
     if (!touchtime)
@@ -1415,7 +1414,7 @@ int File::compareTime(File *f)
 
 void File::stat()
 {
-#if POSIX
+#if HOST_POSIX
     if (!touchtime)
     {
         touchtime = mem.calloc(1, sizeof(struct stat));
@@ -1780,7 +1779,7 @@ void OutBuffer::vprintf(const char *format, va_list args)
         if (count != -1)
             break;
         psize *= 2;
-#elif POSIX
+#elif HOST_POSIX
         va_list va;
         va_copy(va, args);
 /*

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -21,6 +21,12 @@
 #pragma once
 #endif
 
+/*
+ * Define HOST_POSIX for convenience.
+ */
+
+#define HOST_POSIX (linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+
 typedef size_t hash_t;
 
 /*

--- a/src/util.c
+++ b/src/util.c
@@ -136,7 +136,7 @@ void util_progress(int linnum)
 
 #endif
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun || _MSC_VER
+#if HOST_POSIX || _MSC_VER
 void util_progress()
 {
 }


### PR DESCRIPTION
Checks about the host operating system are made everywhere to use some
POSIX specific stuff. To do this check the verbose and error prone idiom
is used: `#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun`

This patch adds a new define, HOST_POSIX, as a shortcut to the old
idiom.
