### PR TITLE
Issue 9266 - Cannot define two Tuple objects. (Regression in 2.061)

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -4662,7 +4662,10 @@ Dsymbol *TemplateInstance::syntaxCopy(Dsymbol *s)
 
     ti->tiargs = arraySyntaxCopy(tiargs);
 
-    ScopeDsymbol::syntaxCopy(ti);
+    if (inst)
+        tempdecl->ScopeDsymbol::syntaxCopy(ti);
+    else
+        ScopeDsymbol::syntaxCopy(ti);
     return ti;
 }
 

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1903,6 +1903,22 @@ void test9143()
 }
 
 /**********************************/
+// 9266
+
+template Foo9266(T...)
+{
+    T Foo9266;
+}
+struct Bar9266()
+{
+    alias Foo9266!int f;
+}
+void test9266()
+{
+    Bar9266!() a, b;
+}
+
+/**********************************/
 
 int main()
 {
@@ -1974,6 +1990,7 @@ int main()
     test9124a();
     test9124b();
     test9143();
+    test9266();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9266

If the semantics in template instance is already done (`inst != NULL`), `syntaxCopy` should copy members from original template declaration (== `tempdecl`).
