### PR TITLE
8982 ICE(ctfeexpr.c) __parameters of an erroneous default parameter

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -5989,6 +5989,12 @@ Expression *IsExp::semantic(Scope *sc)
                 for (size_t i = 0; i < dim; i++)
                 {   Parameter *arg = Parameter::getNth(params, i);
                     assert(arg && arg->type);
+                    /* If one of the default arguments was an error,
+                       don't return an invalid tuple
+                    */
+                    if (tok2 == TOKparameters && arg->defaultArg &&
+                        arg->defaultArg->op == TOKerror)
+                        return new ErrorExp();
                     args->push(new Parameter(arg->storageClass, arg->type,
                         (tok2 == TOKparameters) ? arg->ident : NULL,
                         (tok2 == TOKparameters) ? arg->defaultArg : NULL));

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -22,6 +22,21 @@ auto segfault8532(Y, R ...)(R r, Y val) pure
 static assert(!is(typeof( segfault8532(1,2,3))));
 
 /**************************************************
+    8982    ICE(ctfeexpr.c) __parameters with error in default value
+**************************************************/
+template ice8982(T)
+{
+    void bug8982(ref const int v = 7){}
+
+    static if (is(typeof(bug8982) P == __parameters)) {
+        pragma(msg, ((P[0..1] g) => g[0])());
+    }
+}
+
+static assert(!is(ice8982!(int)));
+
+
+/**************************************************
     8801    ICE assigning to __ctfe
 **************************************************/
 static assert(!is(typeof( { bool __ctfe= true; })));


### PR DESCRIPTION
Don't create a tuple with an error in it; instead, return an ErrorExp.
This is the same behaviour you get when creating a erroneous tuple by normal means.

(The test case is wrapped in a speculative template so that the module compiles even though
it contains an error).
