### PR TITLE
Issue 9259 - Passing an array of pointers to a typesafe vararg is broken

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4311,7 +4311,7 @@ MATCH TypeDArray::implicitConvTo(Type *to)
             return MATCHconvert;
         }
 
-        return next->constConv(to);
+        return next->constConv(to) ? MATCHconvert : MATCHnomatch;
     }
 
     if (to->ty == Tarray)

--- a/test/runnable/test9259.d
+++ b/test/runnable/test9259.d
@@ -1,0 +1,13 @@
+// PERMUTE_ARGS: -inline -release -g -O -d -dw -de
+
+void test(int*[] arr...)
+{
+    assert(arr.length == 1);
+    assert(*arr[0] == 5); // This assertion fails
+}
+
+void main()
+{
+    int a = 5;
+    test([&a]);
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9259

Root issue: Implicit conversion from `T[]` to `T*` is incorrectly deduced to `MATCHexact`. It should always be `MATCHconvert`, as same as `TypeSArray::implicitConvTo`.

Related issue: Implicit conversion from `T[]` to `T*` had been a deprecated language feature. But from 2.061, it is accidentally enabled in default. See [here](https://github.com/D-Programming-Language/dmd/pull/1287#issuecomment-12080557).
