### PR TITLE
Issue 9293 - enum struct with StructInitializer reports weird error

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -2013,6 +2013,10 @@ Expression *VarDeclaration::getConstInitializer()
         ExpInitializer *ei = getExpInitializer();
         if (ei)
             return ei->exp;
+        else if (init)
+        {
+            return init->toExpression();
+        }
     }
 
     return NULL;

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -590,6 +590,31 @@ void test9116()
 }
 
 /********************************************/
+// 9293
+
+void test9293()
+{
+    static struct A
+    {
+    //  enum A zero = A(); // This works as expected
+        enum A zero = {};  // Note the difference here
+
+        int opCmp(const ref A a) const
+        {
+            assert(0);
+        }
+
+        int opCmp(const A a) const
+        {
+            return 0;
+        }
+    }
+
+    A a;
+    auto b = a >= A.zero;  // Error: A() is not an lvalue
+}
+
+/********************************************/
 
 int main()
 {
@@ -614,6 +639,7 @@ int main()
     test7929();
     test7021();
     test9116();
+    test9293();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9293

`VarDeclaration::getConstInitializer` should return an actual expression, even if init is not an `ExpInitializer`.
