### PR TITLE
Issue 9296: LITTLE_ENDIAN and BIG_ENDIAN are always defined on Linux

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -604,9 +604,9 @@ typedef int bool;
 #endif
 
 // gcc defines this for us, dmc doesn't, so look for it's __I86__
-#if ! (defined(LITTLE_ENDIAN) || defined(BIG_ENDIAN) )
+#if ! (defined(__LITTLE_ENDIAN__) || defined(__BIG_ENDIAN__) )
 #if defined(__I86__) || defined(i386) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64) || defined(_M_I86) || defined(_M_AMD64)
-#define LITTLE_ENDIAN 1
+#define __LITTLE_ENDIAN__ 1
 #else
 #error unknown platform, so unknown endianness
 #endif

--- a/src/backend/mach.h
+++ b/src/backend/mach.h
@@ -303,14 +303,14 @@ struct relocation_info
 
 struct scattered_relocation_info
 {
-    #if LITTLE_ENDIAN
+    #if __LITTLE_ENDIAN__
         uint32_t r_address:24,
         r_type:4,
         r_length:2,
         r_pcrel:1,
         r_scattered:1;
         int32_t r_value;
-    #elif BIG_ENDIAN
+    #elif __BIG_ENDIAN__
         uint32_t r_scattered:1,
         r_pcrel:1,
         r_length:2,

--- a/src/module.c
+++ b/src/module.c
@@ -378,7 +378,7 @@ bool Module::read(Loc loc)
 
 inline unsigned readwordLE(unsigned short *p)
 {
-#if LITTLE_ENDIAN
+#if __LITTLE_ENDIAN__
     return *p;
 #else
     return (((unsigned char *)p)[1] << 8) | ((unsigned char *)p)[0];
@@ -392,7 +392,7 @@ inline unsigned readwordBE(unsigned short *p)
 
 inline unsigned readlongLE(unsigned *p)
 {
-#if LITTLE_ENDIAN
+#if __LITTLE_ENDIAN__
     return *p;
 #else
     return ((unsigned char *)p)[0] |

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -54,6 +54,8 @@ ifneq (x,x$(MODEL))
     MODEL_FLAG=-m$(MODEL)
 endif
 
+ENDIAN=LITTLE
+
 ifeq (OSX,$(TARGET))
     SDKDIR=/Developer/SDKs
     ifeq "$(wildcard $(SDKDIR))" ""
@@ -86,8 +88,8 @@ WARNINGS=-Wno-deprecated -Wstrict-aliasing
 #GFLAGS = $(WARNINGS) -D__pascal= -fno-exceptions -g -DDEBUG=1 -DUNITTEST $(COV)
 GFLAGS = $(WARNINGS) -D__pascal= -fno-exceptions -O2
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 -D__${ENDIAN}_ENDIAN__=1
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -I$(ROOT) -DMARS=1 -DTARGET_$(TARGET)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 -D__${ENDIAN}_ENDIAN__=1
 
 CH= $C/cc.h $C/global.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/obj.h $(TARGET_CH)

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -36,7 +36,7 @@ hash_t calcHash(const char *str, size_t len)
 
             case 2:
                 hash *= 37;
-#if LITTLE_ENDIAN
+#if __LITTLE_ENDIAN__
                 hash += *(const uint16_t *)str;
 #else
                 hash += str[0] * 256 + str[1];
@@ -45,7 +45,7 @@ hash_t calcHash(const char *str, size_t len)
 
             case 3:
                 hash *= 37;
-#if LITTLE_ENDIAN
+#if __LITTLE_ENDIAN__
                 hash += (*(const uint16_t *)str << 8) +
                         ((const uint8_t *)str)[2];
 #else
@@ -55,7 +55,7 @@ hash_t calcHash(const char *str, size_t len)
 
             default:
                 hash *= 37;
-#if LITTLE_ENDIAN
+#if __LITTLE_ENDIAN__
                 hash += *(const uint32_t *)str;
 #else
                 hash += ((str[0] * 256 + str[1]) * 256 + str[2]) * 256 + str[3];

--- a/src/vcbuild/dmc_cl.bat
+++ b/src/vcbuild/dmc_cl.bat
@@ -1,6 +1,6 @@
 @echo off
 rem echo called with: %*
-set def=/DLITTLE_ENDIAN=1 /D__pascal= /D_M_I86=1
+set def=/D__LITTLE_ENDIAN__=1 /D__pascal= /D_M_I86=1
 rem copt defaults to linker options
 set copt=/nologo /link /LARGEADDRESSAWARE
 set cmd=

--- a/src/vcbuild/warnings.h
+++ b/src/vcbuild/warnings.h
@@ -32,7 +32,7 @@
 #pragma warning(disable:4310) // cast truncates constant value
 #endif
 
-#define LITTLE_ENDIAN 1
+#define __LITTLE_ENDIAN__ 1
 #define __pascal
 #define MARS     1
 #define UNITTEST 1

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -137,9 +137,9 @@ BFLAGS=
 ##### Implementation variables (do not modify)
 
 # Compile flags
-CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DDM_TARGET_CPU_X86=1
+CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DDM_TARGET_CPU_X86=1 -D__LITTLE_ENDIAN__=1
 # Compile flags for modules with backend/toolkit dependencies
-MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DDM_TARGET_CPU_X86=1
+MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DDM_TARGET_CPU_X86=1 -D__LITTLE_ENDIAN__=1
 # Compile flags for compiler unit tests
 TFLAGS=-I$(STLPORT);$(CPPUNIT)\include;$(INCLUDE) $(TFLAGS) -DDISABLE_MAIN=1 -cpp -Aa -Ab -Ae -Ar
 # Recursive make


### PR DESCRIPTION
My solution is to replace `LITTLE_ENDIAN` and `BIG_ENDIAN` with `__LITTLE_ENDIAN__`
and `__BIG_ENDIAN__`. These are flags which are defined for clang and old gcc
versions but not in a glibc include file. The makefiles are changed to contain the right definition.
