### PR TITLE
Issue 9309 - Regression (2.061): -O -release generates wrong code

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -2985,6 +2985,8 @@ enum PURE FuncDeclaration::isPure()
     if (tf->purity == PUREfwdref)
         tf->purityLevel();
     enum PURE purity = tf->purity;
+    if (purity > PUREweak && isNested())
+        purity = PUREweak;
     if (purity > PUREweak && needThis())
     {   // The attribute of the 'this' reference affects purity strength
         if (type->mod & (MODimmutable | MODwild))

--- a/test/runnable/test9309.d
+++ b/test/runnable/test9309.d
@@ -1,0 +1,37 @@
+immutable(T)[] assumeUnique(T)(ref T[] array) pure nothrow
+{
+    auto result = cast(immutable(T)[]) array;
+    array = null;
+    return result;
+}
+
+pure nothrow
+private string escapeShellArguments()
+{
+    char[] buf;
+
+    @safe nothrow
+    char[] allocator(size_t size)
+    {
+        return buf = new char[size];
+    }
+
+    escapeShellArgument!allocator("foo");
+    return assumeUnique(buf);
+}
+
+@safe nothrow
+auto escapeShellArgument(alias allocator)(in char[] arg)
+{
+    auto buf = allocator(4);
+    buf[0] = 'f';
+    buf[1] = 'o';
+    buf[2] = 'o';
+    buf[3] = '\0';
+}
+
+void main()
+{
+    string res = escapeShellArguments();
+    if (res != "foo\0") assert(0);
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9309

By merging pull #1110, escapeShellArgument!allocator is marked as PUREstrong.
But it is a nested function, and its call may have a side effect through
its hidden context pointer. So glue layer cannot remove its call.
