### PR TITLE
Issue 9195 - Should not be able to index a pointer in safed

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10070,6 +10070,19 @@ Expression *IndexExp::semantic(Scope *sc)
     switch (t1->ty)
     {
         case Tpointer:
+            e2 = e2->implicitCastTo(sc, Type::tsize_t);
+            e2 = e2->optimize(WANTvalue);
+            if (e2->op == TOKint64 && e2->toInteger() == 0)
+                ;
+            else if (sc->func->setUnsafe())
+            {
+                error("safe function '%s' cannot index pointer '%s'",
+                    sc->func->toPrettyChars(), e1->toChars());
+                return new ErrorExp();
+            }
+            e->type = ((TypeNext *)t1)->next;
+            break;
+
         case Tarray:
             e2 = e2->implicitCastTo(sc, Type::tsize_t);
             e->type = ((TypeNext *)t1)->next;

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -279,7 +279,14 @@ void voidinitializers()
     static assert(!__traits(compiles, { int** a = void; } )); 
     static assert(!__traits(compiles, { int[int] a = void; } )); 
 } 
- 
+
+@safe
+void pointerindex()
+{//http://d.puremagic.com/issues/show_bug.cgi?id=9195
+    static assert(!__traits(compiles, { int* p; auto a = p[30]; }));
+    static assert( __traits(compiles, { int* p; auto a = p[0]; }));
+}
+
 @safe 
 void basiccast() 
 {//http://d.puremagic.com/issues/show_bug.cgi?id=5088 


### PR DESCRIPTION
This prevents indexing a pointer in @safe code unless the index is known at compile time to be zero.

http://d.puremagic.com/issues/show_bug.cgi?id=9195
