### PR TITLE
Fix Issue 9195 - Should not be able to index a pointer in safed

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1934,18 +1934,10 @@ Expression *CondExp::inferType(Type *t, int flag, TemplateParameters *tparams)
 
 Expression *BinExp::scaleFactor(Scope *sc)
 {
-    if (sc->func && !sc->intypeof)
-    {
-        if (sc->func->setUnsafe())
-        {
-            error("pointer arithmetic not allowed in @safe functions");
-            return new ErrorExp();
-        }
-    }
-
     d_uns64 stride;
     Type *t1b = e1->type->toBasetype();
     Type *t2b = e2->type->toBasetype();
+    Expression *eoff;
 
     if (t1b->ty == Tpointer && t2b->isintegral())
     {   // Need to adjust operator by the stride
@@ -1955,6 +1947,7 @@ Expression *BinExp::scaleFactor(Scope *sc)
         stride = t1b->nextOf()->size(loc);
         if (!t->equals(t2b))
             e2 = e2->castTo(sc, t);
+        eoff = e2;
         e2 = new MulExp(loc, e2, new IntegerExp(0, stride, t));
         e2->type = t;
         type = e1->type;
@@ -1970,12 +1963,28 @@ Expression *BinExp::scaleFactor(Scope *sc)
             e = e1->castTo(sc, t);
         else
             e = e1;
+        eoff = e;
         e = new MulExp(loc, e, new IntegerExp(0, stride, t));
         e->type = t;
         type = e2->type;
         e1 = e2;
         e2 = e;
     }
+    else
+        assert(0);
+
+    if (sc->func && !sc->intypeof)
+    {
+        eoff = eoff->optimize(WANTvalue);
+        if (eoff->op == TOKint64 && eoff->toInteger() == 0)
+            ;
+        else if (sc->func->setUnsafe())
+        {
+            error("pointer arithmetic not allowed in @safe functions");
+            return new ErrorExp();
+        }
+    }
+
     return this;
 }
 

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -43,6 +43,16 @@ void pointerarithmetic()
     static assert(!__traits(compiles, a--)); 
     static assert(!__traits(compiles, ++a)); 
     static assert(!__traits(compiles, --a)); 
+    static assert( __traits(compiles, a + 0));
+    static assert( __traits(compiles, a - 0));
+    static assert( __traits(compiles, 0 + a));
+    static assert(!__traits(compiles, a + 1));
+    static assert(!__traits(compiles, a - 1));
+    static assert(!__traits(compiles, 1 + a));
+    static assert( __traits(compiles, a += 0));
+    static assert( __traits(compiles, a -= 0));
+    static assert(!__traits(compiles, a += 1));
+    static assert(!__traits(compiles, a -= 1));
 } 
  
  


### PR DESCRIPTION
Allow pointer arithmetic when using an offset that is known to be zero

This is an extension of pull #1482

http://d.puremagic.com/issues/show_bug.cgi?id=9195
