### PR TITLE
Fix Issue 9097 - Value range propagation to disable some array bound tests

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1321,6 +1321,8 @@ Expression *ArrayLength(Type *type, Expression *e1)
 
         e = new IntegerExp(loc, dim, type);
     }
+    else if (e1->type->toBasetype()->ty == Tsarray)
+        e = ((TypeSArray *)e1->type->toBasetype())->dim;
     else
         e = EXP_CANT_INTERPRET;
     return e;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4955,7 +4955,7 @@ elem *IndexExp::toElem(IRState *irs)
         elem *einit = resolveLengthVar(lengthVar, &n1, t1);
         elem *n2 = e2->toElem(irs);
 
-        if (irs->arrayBoundsCheck())
+        if (irs->arrayBoundsCheck() && !skipboundscheck)
         {
             elem *elength;
             elem *n2x;

--- a/src/expression.c
+++ b/src/expression.c
@@ -10437,6 +10437,7 @@ IndexExp::IndexExp(Loc loc, Expression *e1, Expression *e2)
     //printf("IndexExp::IndexExp('%s')\n", toChars());
     lengthVar = NULL;
     modifiable = 0;     // assume it is an rvalue
+    skipboundscheck = 0;
 }
 
 Expression *IndexExp::syntaxCopy()
@@ -10599,6 +10600,21 @@ Expression *IndexExp::semantic(Scope *sc)
         case Terror:
             goto Lerr;
     }
+
+    if (t1->ty == Tsarray || t1->ty == Tarray)
+    {
+        Expression *el = new ArrayLengthExp(loc, e1);
+        el = el->semantic(sc);
+        el = el->optimize(WANTvalue);
+        if (el->op == TOKint64)
+        {
+            e2 = e2->optimize(WANTvalue);
+            dinteger_t length = el->toInteger();
+            if (length)
+                skipboundscheck = IntRange(0, length).contains(e2->getIntRange());
+        }
+    }
+
     return e;
 
 Lerr:

--- a/src/expression.h
+++ b/src/expression.h
@@ -1340,6 +1340,7 @@ class IndexExp : public BinExp
 public:
     VarDeclaration *lengthVar;
     int modifiable;
+    bool skipboundscheck;
 
     IndexExp(Loc loc, Expression *e1, Expression *e2);
     Expression *syntaxCopy();

--- a/src/init.c
+++ b/src/init.c
@@ -132,8 +132,7 @@ Initializer *VoidInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInt
 
 Expression *VoidInitializer::toExpression(Type *t)
 {
-    error(loc, "void initializer has no value");
-    return new ErrorExp();
+    return NULL;
 }
 
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7747,7 +7747,13 @@ Expression *TypeTypedef::defaultInitLiteral(Loc loc)
     if (sym->init)
     {
         //sym->init->toExpression()->print();
-        return sym->init->toExpression();
+        Expression *e = sym->init->toExpression();
+        if (!e)
+        {
+            error(loc, "void initializer has no value");
+            e = new ErrorExp();
+        }
+        return e;
     }
     Type *bt = sym->basetype;
     Expression *e = bt->defaultInitLiteral(loc);

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -979,7 +979,8 @@ Expression *ArrayLengthExp::optimize(int result, bool keepLvalue)
     //printf("ArrayLengthExp::optimize(result = %d) %s\n", result, toChars());
     e1 = e1->optimize(WANTvalue | WANTexpand | (result & WANTinterpret));
     e = this;
-    if (e1->op == TOKstring || e1->op == TOKarrayliteral || e1->op == TOKassocarrayliteral)
+    if (e1->op == TOKstring || e1->op == TOKarrayliteral || e1->op == TOKassocarrayliteral ||
+        e1->type->toBasetype()->ty == Tsarray)
     {
         e = ArrayLength(type, e1);
     }


### PR DESCRIPTION
Do not emit bounds check code if the index is statically known to be within bounds

http://d.puremagic.com/issues/show_bug.cgi?id=9097
