### PR TITLE
Fix Issue 6319 - debug's relaxed purity does not apply to nested scopes

### DIFF
--- a/src/scope.c
+++ b/src/scope.c
@@ -127,7 +127,7 @@ Scope::Scope(Scope *enclosing)
     this->speculative = enclosing->speculative;
     this->parameterSpecialization = enclosing->parameterSpecialization;
     this->callSuper = enclosing->callSuper;
-    this->flags = (enclosing->flags & SCOPEcontract);
+    this->flags = (enclosing->flags & (SCOPEcontract | SCOPEdebug));
     this->lastdc = NULL;
     this->lastoffset = 0;
     this->docbuf = enclosing->docbuf;

--- a/test/compilable/test6319.d
+++ b/test/compilable/test6319.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -debug
+
+int x;
+
+void main() pure
+{
+    debug
+    {
+        {
+            x = 0;
+        }
+    }
+}


### PR DESCRIPTION
The `SCOPEdebug` flag should be passed to the nested scope.

http://d.puremagic.com/issues/show_bug.cgi?id=6319
