### PR TITLE
Fix Issue 6408 - string[].init gives a wrong type

### DIFF
--- a/test/runnable/imports/bug846.d
+++ b/test/runnable/imports/bug846.d
@@ -2,7 +2,7 @@ module imports.bug846;
 
 template ElemTypeOf( T )
 {
-    alias typeof(T[0]) ElemTypeOf;
+    alias typeof(T.init[0]) ElemTypeOf;
 }
 
 template removeIf_( Elem, Pred )

--- a/test/runnable/imports/test35a.d
+++ b/test/runnable/imports/test35a.d
@@ -2,7 +2,7 @@ module imports.test35a;
 
 template ElemTypeOf( T )
 {
-    alias typeof(T[0]) ElemTypeOf;
+    alias typeof(T.init[0]) ElemTypeOf;
 }
 
 template removeIf_( Elem, Pred )

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -946,6 +946,26 @@ void test48()
 
 /***************************************************/
 
+// 6408
+
+static assert(!is(typeof(string[0..1].init)));
+static assert(is(typeof(string[].init) == string[]));
+static assert(is(typeof(string[][].init) == string[][]));
+static assert(is(typeof(string[][][].init) == string[][][]));
+
+static assert(is(typeof(string[1].init) == string[1]));
+static assert(is(typeof(string[1][1].init) == string[1][1]));
+static assert(is(typeof(string[1][1][1].init) == string[1][1][1]));
+
+static assert(is(typeof(string[string].init) == string[string]));
+static assert(is(typeof(string[string][string].init) == string[string][string]));
+static assert(is(typeof(string[string][string][string].init) == string[string][string][string]));
+
+template TT6408(T...) { alias T TT6408; }
+static assert(is(typeof(TT6408!(int, int)[].init) == TT6408!(int, int)));
+
+/***************************************************/
+
 struct S49
 {
     static void* p;


### PR DESCRIPTION
Allow reinterpreting a slice or index expression as a dynamic array, static array, or associative array

http://d.puremagic.com/issues/show_bug.cgi?id=6408
