### PR TITLE
Fix Issue 3632 - modify float is float to do a bitwise compare

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -954,29 +954,56 @@ UnionExp Identity(TOK op, Type *type, Expression *e1, Expression *e2)
 
         cmp = (es1->var == es2->var && es1->offset == es2->offset);
     }
-    else
+    else if (e1->op == TOKstructliteral && e2->op == TOKstructliteral)
     {
-       if (e1->type->isreal())
-       {
-           cmp = RealEquals(e1->toReal(), e2->toReal());
-       }
-       else if (e1->type->isimaginary())
-       {
-           cmp = RealEquals(e1->toImaginary(), e2->toImaginary());
-       }
-       else if (e1->type->iscomplex())
-       {
-           complex_t v1 = e1->toComplex();
-           complex_t v2 = e2->toComplex();
-           cmp = RealEquals(creall(v1), creall(v2)) &&
-                 RealEquals(cimagl(v1), cimagl(v1));
-        }
+        StructLiteralExp *es1 = (StructLiteralExp *)e1;
+        StructLiteralExp *es2 = (StructLiteralExp *)e2;
+
+        if (es1->sd != es2->sd)
+            cmp = 0;
+        else if ((!es1->elements || !es1->elements->dim) &&
+            (!es2->elements || !es2->elements->dim))
+            cmp = 1;            // both arrays are empty
+        else if (!es1->elements || !es2->elements)
+            cmp = 0;
+        else if (es1->elements->dim != es2->elements->dim)
+            cmp = 0;
         else
         {
-           ue = Equal((op == TOKidentity) ? TOKequal : TOKnotequal,
-                   type, e1, e2);
-           return ue;
+            cmp = 1;
+            for (size_t i = 0; i < es1->elements->dim; i++)
+            {
+                Expression *ee1 = (*es1->elements)[i];
+                Expression *ee2 = (*es2->elements)[i];
+
+                if (ee1 == ee2)
+                    continue;
+                if (!ee1 || !ee2)
+                {
+                    cmp = 0;
+                    break;
+                }
+                ue = Identity(TOKequal, Type::tint32, ee1, ee2);
+                if (ue.exp()->op == TOKcantexp)
+                    return ue;
+                cmp = (int)ue.exp()->toInteger();
+                if (cmp == 0)
+                    break;
+            }
         }
+    }
+    else if (e1->type->isfloating() && e2->type->isfloating())
+    {
+        complex_t v1 = e1->toComplex();
+        complex_t v2 = e2->toComplex();
+        cmp = RealEquals(creall(v1), creall(v2)) &&
+              RealEquals(cimagl(v1), cimagl(v2));
+    }
+    else
+    {
+        ue = Equal((op == TOKidentity) ? TOKequal : TOKnotequal,
+                type, e1, e2);
+        return ue;
     }
     if (op == TOKnotidentity)
         cmp ^= 1;

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1632,6 +1632,43 @@ int ctfeIdentity(Loc loc, TOK op, Expression *e1, Expression *e2)
         cmp = RealEquals(creall(v1), creall(v2)) &&
                  RealEquals(cimagl(v1), cimagl(v1));
     }
+    else if (e1->op == TOKstructliteral)
+    {
+        StructLiteralExp *es1 = (StructLiteralExp *)e1;
+        StructLiteralExp *es2 = (StructLiteralExp *)e2;
+
+        if (es1->sd != es2->sd)
+            cmp = 0;
+        else if ((!es1->elements || !es1->elements->dim) &&
+            (!es2->elements || !es2->elements->dim))
+            cmp = 1;            // both arrays are empty
+        else if (!es1->elements || !es2->elements)
+            cmp = 0;
+        else if (es1->elements->dim != es2->elements->dim)
+            cmp = 0;
+        else
+        {
+            cmp = 1;
+            for (size_t i = 0; i < es1->elements->dim; i++)
+            {
+                Expression *ee1 = (*es1->elements)[i];
+                Expression *ee2 = (*es2->elements)[i];
+
+                if (ee1 == ee2)
+                    continue;
+                if (!ee1 || !ee2)
+                {
+                    cmp = 0;
+                    break;
+                }
+                if (!ctfeIdentity(loc, TOKidentity, ee1, ee2))
+                {
+                    cmp = 0;
+                    break;
+                }
+            }
+        }
+    }
     else
         cmp = !ctfeRawCmp(loc, e1, e2);
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2283,6 +2283,36 @@ elem *toElem(Expression *e, IRState *irs)
                 // we can skip the compare if the structs are empty
                 e = el_long(TYbool, ie->op == TOKidentity);
             }
+            else if (t1->ty == Tcomplex80 && Target::realpad != 0)
+            {
+                /* creal has padding in the middle on some platforms,
+                 * so do identity comparison on real and imaginary parts
+                 * separately.
+                 */
+                symbol *s1 = symbol_genauto(Type_toCtype(t1));
+                symbol *s2 = symbol_genauto(Type_toCtype(t2));
+                elem *el1 = toElem(ie->e1, irs);
+                elem *el2 = toElem(ie->e2, irs);
+                elem *ed1 = el_bin(OPeq, TYcldouble, el_var(s1), el1);
+                elem *ed2 = el_bin(OPeq, TYcldouble, el_var(s2), el2);
+
+                elem *e1a = addressElem(ed1, Type::tcomplex80);
+                elem *e2a = addressElem(ed2, Type::tcomplex80);
+                elem *ecount1 = el_long(TYsize_t, Target::realsize - Target::realpad);
+                elem *ec1 = el_bin(OPmemcmp, TYint, el_param(e1a, e2a), ecount1);
+                ec1 = el_bin(eop, TYint, ec1, el_long(TYint, 0));
+
+                e1a = el_bin(OPadd, e1a->Ety, addressElem(el_var(s1), Type::tcomplex80), el_long(TYsize_t, Target::realsize));
+                e2a = el_bin(OPadd, e2a->Ety, addressElem(el_var(s2), Type::tcomplex80), el_long(TYsize_t, Target::realsize));
+                elem *ecount2 = el_long(TYsize_t, Target::realsize - Target::realpad);
+                elem *ec2 = el_bin(OPmemcmp, TYint, el_param(e1a, e2a ), ecount2);
+                ec2 = el_bin(eop, TYint, ec2, el_long(TYint, 0));
+
+                enum OPER xop = (ie->op == TOKidentity) ? OPandand : OPoror;
+
+                e = el_bin(xop, TYint, ec1, ec2);
+                el_setLoc(e, ie->loc);
+            }
             else if (t1->ty == Tstruct || t1->isfloating())
             {
                 // Do bit compare of struct's
@@ -2291,7 +2321,11 @@ elem *toElem(Expression *e, IRState *irs)
                 elem *es2 = toElem(ie->e2, irs);
                 es2 = addressElem(es2, ie->e2->type);
                 e = el_param(es1, es2);
-                elem *ecount = el_long(TYsize_t, t1->size());
+                elem *ecount;
+                if (t1->ty == Tfloat80 || t1->ty == Timaginary80)
+                    ecount = el_long(TYsize_t, t1->size() - Target::realpad);
+                else
+                    ecount = el_long(TYsize_t, t1->size());
                 e = el_bin(OPmemcmp, TYint, e, ecount);
                 e = el_bin(eop, TYint, e, el_long(TYint, 0));
                 el_setLoc(e, ie->loc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -3043,8 +3043,10 @@ complex_t RealExp::toComplex()
 
 int RealEquals(real_t x1, real_t x2)
 {
-    return (Port::isNan(x1) && Port::isNan(x2)) ||
-        Port::fequal(x1, x2);
+    /* In some cases, the REALPAD bytes get garbage in them,
+     * so be sure and ignore them.
+     */
+    return memcmp(&x1, &x2, Target::realsize - Target::realpad) == 0;
 }
 
 bool RealExp::equals(RootObject *o)

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -128,8 +128,8 @@ void test3()
     assert(1    .init == 0);
     assert([1]  .init == null);
     assert([1:1].init == null);
-    assert(1.0  .init is double.nan);
-    assert(10i  .init is idouble.nan);
+    assert(1.0  .init is double.init);
+    assert(10i  .init is idouble.init);
     assert('c'  .init == 0xFF);
     assert("s"  .init == null);
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3925,6 +3925,81 @@ void test6708(const ref int y)
 }
 
 /***************************************************/
+
+
+template TT3632(T...) { alias T TT3632; }
+__gshared int global3632 = 1;
+
+void test3632()
+{
+    int test(T)()
+    {
+        static struct W
+        {
+            T f;
+            this(T g) { if (__ctfe || global3632) f = g; }
+        }
+        auto nan = W(T.nan);
+        auto nan2 = W(T.nan);
+        auto init = W(T.init);
+        auto init2 = W(T.init);
+        auto zero = W(cast(T)0);
+        auto zero2 = W(cast(T)0);
+        auto nzero2 = W(-cast(T)0);
+
+        // Struct equality
+        assert(!(nan == nan2));
+        assert(!(nan == init2));
+        assert(!(init == init2));
+        assert( (zero == zero2));
+        assert( (zero == nzero2));
+
+        // Float equality
+        assert(!(nan.f == nan2.f));
+        assert(!(nan.f == init2.f));
+        assert(!(init.f == init2.f));
+        assert( (zero.f == zero2.f));
+        assert( (zero.f == nzero2.f));
+
+        // Struct identity
+        assert( (nan is nan2));
+        assert(!(nan is init2));
+        assert( (init is init2));
+        assert( (zero is zero2));
+        assert(!(zero is nzero2));
+
+        // Float identity
+        assert( (nan.f is nan2.f));
+        assert(!(nan.f is init2.f));
+        assert( (init.f is init2.f));
+        assert( (zero.f is zero2.f));
+        assert(!(zero.f is nzero2.f));
+
+        // Struct !identity
+        assert(!(nan !is nan2));
+        assert( (nan !is init2));
+        assert(!(init !is init2));
+        assert(!(zero !is zero2));
+        assert( (zero !is nzero2));
+
+        // float !identity
+        assert(!(nan.f !is nan2.f));
+        assert( (nan.f !is init2.f));
+        assert(!(init.f !is init2.f));
+        assert(!(zero.f !is zero2.f));
+        assert( (zero.f !is nzero2.f));
+
+        return 1;
+    }
+
+    foreach(T; TT3632!(float, double, real, ifloat, idouble, ireal, cfloat, cdouble, creal))
+    {
+        auto x = test!T();
+        enum y = test!T();
+    }
+}
+
+/***************************************************/
 // 4258
 
 struct Vec4258 {
@@ -7635,6 +7710,7 @@ int main()
     test3733();
     test4392();
     test7942();
+    test3632();
     test6220();
     test5799();
     test157();


### PR DESCRIPTION
Currently floating point types are the only types where 'is' is not a bitwise comparison. This patch makes floating is floating perform a bitwise comparison, at runtime and compile-time.

http://d.puremagic.com/issues/show_bug.cgi?id=3632
