### PR TITLE
Refactor semanticTiargs() and fix Issue 9178 - UDA: getAttributes does not play well with tupleof

### DIFF
--- a/test/runnable/uda.d
+++ b/test/runnable/uda.d
@@ -251,6 +251,17 @@ void test12()
 }
 
 /************************************************/
+// 9178
+
+void test9178()
+{
+    static class Foo { @(1) int a; }
+
+    Foo foo = new Foo;
+    static assert(__traits(getAttributes, foo.tupleof[0])[0] == 1);
+}
+
+/************************************************/
 
 int main()
 {
@@ -266,6 +277,7 @@ int main()
     test10();
     test11();
     test12();
+    test9178();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9178

In `TemplateInstance::semanticTiargs`, all template arguments should be processed by a consistent way. But its implementation is a little dirty.
9178 is a bug which was leaked from the fix for [9100](http://d.puremagic.com/issues/show_bug.cgi?id=9100) (== #1340), which implicitly had caused by it.
This refactoring cleans the code, and get a bug fix as a side-effect.
