### PR TITLE
Issue 9348 - "tmpl!arg" syntax followed by "!is" or "!in"

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2231,7 +2231,11 @@ Objects *Parser::parseTemplateArgument()
             break;
     }
     if (token.value == TOKnot)
-        error("multiple ! arguments are not allowed");
+    {
+        enum TOK tok = peekNext();
+        if (tok != TOKis && tok != TOKin)
+            error("multiple ! arguments are not allowed");
+    }
     return tiargs;
 }
 

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -376,3 +376,13 @@ alias test8163!(ubyte, ubyte, ubyte, ubyte, ubyte, ubyte, ubyte, ubyte) _BBBBBBB
 alias test8163!(ubyte, ubyte, ushort, float) _BBSf;
 
 
+/***************************************************/
+// 9348
+
+void test9348()
+{
+    @property Object F(int E)() { return null; }
+
+    assert(F!0 !is null);
+    assert(F!0 !in [new Object():1]);
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9348
