### PR TITLE
fix Issue 3404 - JSON output should retain original alias names

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -267,6 +267,9 @@ void Declaration::toJsonBuffer(OutBuffer *buf)
     if (type)
         JsonProperty(buf, Ptype, type->toChars());
 
+    if (originalType && type != originalType)
+        JsonProperty(buf, "originalType", originalType->toChars());
+
     if (comment)
         JsonProperty(buf, Pcomment, (const char *)comment);
 

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -13,6 +13,21 @@
 "kind" : "enum",
 "protection" : "public",
 "line" : 7}
+,
+{
+"name" : "myInt",
+"kind" : "alias",
+"protection" : "public",
+"type" : "int",
+"line" : 10}
+,
+{
+"name" : "x",
+"kind" : "variable",
+"protection" : "public",
+"type" : "int",
+"originalType" : "myInt",
+"line" : 11}
 ]
 }
 ]

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -5,3 +5,7 @@
 struct X;
 
 enum Y;
+
+// 3404
+alias int myInt;
+myInt x;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3404

Trying to break https://github.com/D-Programming-Language/dmd/pull/1179 into manageable chunks.
