### PR TITLE
move file stuff out of json

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -72,9 +72,9 @@ struct JsonOut
 };
 
 
-void json_generate(Modules *modules)
-{   OutBuffer buf;
-    JsonOut json(&buf);
+void json_generate(OutBuffer *buf, Modules *modules)
+{
+    JsonOut json(buf);
 
     json.arrayStart();
     for (size_t i = 0; i < modules->dim; i++)
@@ -85,35 +85,6 @@ void json_generate(Modules *modules)
     }
     json.arrayEnd();
     json.removeComma();
-
-    // Write buf to file
-    char *arg = global.params.xfilename;
-    if (!arg || !*arg)
-    {   // Generate lib file name from first obj name
-        char *n = (*global.params.objfiles)[0];
-
-        n = FileName::name(n);
-        FileName *fn = FileName::forceExt(n, global.json_ext);
-        arg = fn->toChars();
-    }
-    else if (arg[0] == '-' && arg[1] == 0)
-    {   // Write to stdout; assume it succeeds
-        int n = fwrite(buf.data, 1, buf.offset, stdout);
-        assert(n == buf.offset);        // keep gcc happy about return values
-        return;
-    }
-//    if (!FileName::absolute(arg))
-//        arg = FileName::combine(dir, arg);
-    FileName *jsonfilename = FileName::defaultExt(arg, global.json_ext);
-    File *jsonfile = new File(jsonfilename);
-    assert(jsonfile);
-    jsonfile->setbuffer(buf.data, buf.offset);
-    jsonfile->ref = 1;
-    char *pt = FileName::path(jsonfile->toChars());
-    if (*pt)
-        FileName::ensurePathExists(pt);
-    mem.free(pt);
-    jsonfile->writev();
 }
 
 

--- a/src/json.h
+++ b/src/json.h
@@ -1,7 +1,7 @@
 
 
 // Compiler implementation of the D programming language
-// Copyright (c) 1999-2008 by Digital Mars
+// Copyright (c) 1999-2013 by Digital Mars
 // All Rights Reserved
 // written by Walter Bright
 // http://www.digitalmars.com
@@ -18,7 +18,9 @@
 
 #include "arraytypes.h"
 
-void json_generate(Modules *);
+struct OutBuffer;
+
+void json_generate(OutBuffer *, Modules *);
 
 #endif /* DMD_JSON_H */
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -1426,7 +1426,53 @@ int tryMain(size_t argc, char *argv[])
     // Generate output files
 
     if (global.params.doXGeneration)
-        json_generate(&modules);
+    {
+        OutBuffer buf;
+        json_generate(&buf, &modules);
+
+        // Write buf to file
+        const char *name = global.params.xfilename;
+
+        if (name && name[0] == '-' && name[1] == 0)
+        {   // Write to stdout; assume it succeeds
+            int n = fwrite(buf.data, 1, buf.offset, stdout);
+            assert(n == buf.offset);        // keep gcc happy about return values
+        }
+        else
+        {
+            /* The filename generation code here should be harmonized with Module::setOutfile()
+             */
+
+            FileName *jsonfilename;
+
+            if (name && *name)
+            {
+                jsonfilename = FileName::defaultExt(name, global.json_ext);
+            }
+            else
+            {
+                // Generate json file name from first obj name
+                char *n = (*global.params.objfiles)[0];
+                n = FileName::name(n);
+
+                //if (!FileName::absolute(name))
+                    //name = FileName::combine(dir, name);
+
+                jsonfilename = FileName::forceExt(n, global.json_ext);
+            }
+
+            char *pt = FileName::path(jsonfilename->toChars());
+            if (*pt)
+                FileName::ensurePathExists(pt);
+            mem.free(pt);
+
+            File *jsonfile = new File(jsonfilename);
+
+            jsonfile->setbuffer(buf.data, buf.offset);
+            jsonfile->ref = 1;
+            jsonfile->writev();
+        }
+    }
 
     if (global.params.oneobj)
     {


### PR DESCRIPTION
Json code should not be dealing with files.

This is refactoring only, no behavior changes. However, it exposes a problem where output files for json files are calculated differently than for ddoc, di, and obj files. They should all be harmonized, but that is a topic for another pull.
