### PR TITLE
Fix Issue 9366 - Appending a value cast to void to a void[] crashes DMD

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -11469,7 +11469,8 @@ Expression *CatExp::semantic(Scope *sc)
              */
         }
         else if ((tb1->ty == Tsarray || tb1->ty == Tarray) &&
-            e2->implicitConvTo(tb1next) >= MATCHconvert)
+            e2->implicitConvTo(tb1next) >= MATCHconvert &&
+            tb2->ty != Tvoid)
         {
             checkPostblit(e2->loc, tb2);
             e2 = e2->implicitCastTo(sc, tb1next);
@@ -11482,7 +11483,8 @@ Expression *CatExp::semantic(Scope *sc)
             return this;
         }
         else if ((tb2->ty == Tsarray || tb2->ty == Tarray) &&
-            e1->implicitConvTo(tb2next) >= MATCHconvert)
+            e1->implicitConvTo(tb2next) >= MATCHconvert &&
+            tb1->ty != Tvoid)
         {
             checkPostblit(e1->loc, tb1);
             e1 = e1->implicitCastTo(sc, tb2next);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2864,6 +2864,12 @@ int test137(){
 
 /***************************************************/
 
+// 9366
+static assert(!is(typeof((void[]).init ~ cast(void)0)));
+static assert(!is(typeof(cast(void)0 ~ (void[]).init)));
+
+/***************************************************/
+
 struct Size138
 {
     union


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9366
