### PR TITLE
add -gx to add stack smash code

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -47,7 +47,8 @@ void out_config_init(
         int symdebug,   // add symbolic debug information
                         // 1: D
                         // 2: fake it with C symbolic debug info
-        bool alwaysframe        // always create standard function frame
+        bool alwaysframe,       // always create standard function frame
+        bool stacksmash // add stack smashing code
         )
 {
 #if MARS
@@ -193,6 +194,8 @@ void out_config_init(
 
     if (alwaysframe)
         config.flags |= CFGalwaysframe;
+    if (stacksmash)
+        config.flags2 |= CFG2smash;
 
     ph_init();
     block_init();

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -766,9 +766,10 @@ struct Config
 #define CFG2noerrmax    0x4000  // no error count maximum
 #define CFG2expand      0x8000  // expanded output to list file
 #define CFG2seh         0x10000 // use Win32 SEH to support any exception handling
+#define CFG2smash       0x20000 // enable stack smashing code
 #define CFGX2   (CFG2warniserr | CFG2phuse | CFG2phgen | CFG2phauto | \
                  CFG2once | CFG2hdrdebug | CFG2noobj | CFG2noerrmax | \
-                 CFG2expand | CFG2nodeflib)
+                 CFG2expand | CFG2nodeflib | CFG2smash)
     unsigned flags3;
 #define CFG3ju          1       // char == unsigned char
 #define CFG3eh          4       // generate exception handling stuff

--- a/src/mars.c
+++ b/src/mars.c
@@ -336,6 +336,7 @@ Usage:\n\
 "  -g             add symbolic debug info\n\
   -gc            add symbolic debug info, pretend to be C\n\
   -gs            always emit stack frame\n\
+  -gx            add stack stomp code\n\
   -H             generate 'header' file\n\
   -Hddirectory   write 'header' file to directory\n\
   -Hffilename    write 'header' file to filename\n\
@@ -566,6 +567,8 @@ int tryMain(size_t argc, char *argv[])
                 global.params.symdebug = 2;
             else if (strcmp(p + 1, "gs") == 0)
                 global.params.alwaysframe = 1;
+            else if (strcmp(p + 1, "gx") == 0)
+                global.params.stackstomp = true;
             else if (strcmp(p + 1, "gt") == 0)
             {   error(0, "use -profile instead of -gt");
                 global.params.trace = 1;

--- a/src/mars.h
+++ b/src/mars.h
@@ -168,6 +168,7 @@ struct Param
                          // 1: array bounds checks for safe functions only
                          // 2: array bounds checks for all functions
     char noboundscheck; // no array bounds checking at all
+    bool stackstomp;    // add stack stomping code
     char useSwitchError; // check for switches without a default
     char useUnitTests;  // generate unittest code
     char useInline;     // inline expand functions

--- a/src/msc.c
+++ b/src/msc.c
@@ -46,7 +46,8 @@ void out_config_init(
         int symdebug,   // add symbolic debug information
                         // 1: D
                         // 2: fake it with C symbolic debug info
-        bool alwaysframe        // always create standard function frame
+        bool alwaysframe,       // always create standard function frame
+        bool stackstomp         // add stack stomping code
         );
 
 void out_config_debug(
@@ -93,7 +94,8 @@ void backend_init()
         params->verbose,
         params->optimize,
         params->symdebug,
-        params->alwaysframe
+        params->alwaysframe,
+        params->stackstomp
     );
 
 #ifdef DEBUG


### PR DESCRIPTION
With -gx switch, adds code to smash the local variables upon function exit. Useful for flushing out heisenbugs.

A partial implementation of bug http://d.puremagic.com/issues/show_bug.cgi?id=9242
