### PR TITLE
Issue 5933 & 7159 & 9377 - Invoke function semantic3 correctly where it is required.

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -641,6 +641,8 @@ struct FuncDeclaration : Declaration
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
+    bool functionSemantic();
+    bool functionSemantic3();
     // called from semantic3
     VarDeclaration *declareThis(Scope *sc, AggregateDeclaration *ad);
     int equals(Object *o);

--- a/src/expression.c
+++ b/src/expression.c
@@ -930,6 +930,14 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
     {
         fd->functionSemantic();
     }
+    else if (fd && fd->parent)
+    {
+        TemplateInstance *ti = fd->parent->isTemplateInstance();
+        if (ti && ti->tempdecl)
+        {
+            fd->functionSemantic3();
+        }
+    }
 
     size_t n = (nargs > nparams) ? nargs : nparams;   // n = max(nargs, nparams)
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -278,27 +278,8 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
         error("circular dependency. Functions cannot be interpreted while being compiled");
         return EXP_CANT_INTERPRET;
     }
-    if (semanticRun < PASSsemantic3 && scope)
-    {
-        /* Forward reference - we need to run semantic3 on this function.
-         * If errors are gagged, and it's not part of a speculative
-         * template instance, we need to temporarily ungag errors.
-         */
-        int olderrors = global.errors;
-        int oldgag = global.gag;
-        TemplateInstance *spec = isSpeculative();
-        if (global.gag && !spec)
-            global.gag = 0;
-        semantic3(scope);
-        global.gag = oldgag;    // regag errors
-
-        // If it is a speculatively-instantiated template, and errors occur,
-        // we need to mark the template as having errors.
-        if (spec && global.errors != olderrors)
-            spec->errors = global.errors - olderrors;
-        if (olderrors != global.errors) // if errors compiling this function
-            return EXP_CANT_INTERPRET;
-    }
+    if (!functionSemantic3())
+        return EXP_CANT_INTERPRET;
     if (semanticRun < PASSsemantic3done)
         return EXP_CANT_INTERPRET;
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1306,28 +1306,13 @@ Type *Type::aliasthisOf()
                 FuncDeclaration *fd = (FuncDeclaration *)d;
                 Expression *ethis = this->defaultInit(0);
                 fd = fd->overloadResolve(0, ethis, NULL, 1);
-                if (fd)
-                {   TypeFunction *tf = (TypeFunction *)fd->type;
-                    if (!tf->next && fd->inferRetType)
-                    {
-                        TemplateInstance *spec = fd->isSpeculative();
-                        int olderrs = global.errors;
-                        // If it isn't speculative, we need to show errors
-                        unsigned oldgag = global.gag;
-                        if (global.gag && !spec)
-                            global.gag = 0;
-                        fd->semantic3(fd->scope);
-                        global.gag = oldgag;
-                        // Update the template instantiation with the number
-                        // of errors which occured.
-                        if (spec && global.errors != olderrs)
-                            spec->errors = global.errors - olderrs;
-                        tf = (TypeFunction *)fd->type;
-                    }
-                    t = tf->next;
-                    if (tf->isWild())
-                        t = t->substWildTo(mod == 0 ? MODmutable : mod);
+                if (fd && fd->functionSemantic())
+                {
+                    t = fd->type->nextOf();
+                    t = t->substWildTo(mod == 0 ? MODmutable : mod);
                 }
+                else
+                    return Type::terror;
             }
             return t;
         }
@@ -1342,26 +1327,14 @@ Type *Type::aliasthisOf()
         {   assert(td->scope);
             Expression *ethis = defaultInit(0);
             FuncDeclaration *fd = td->deduceFunctionTemplate(td->scope, 0, NULL, ethis, NULL, 1);
-            if (fd)
+            if (fd && fd->functionSemantic())
             {
-                //if (!fd->type->nextOf() && fd->inferRetType)
-                {
-                    TemplateInstance *spec = fd->isSpeculative();
-                    int olderrs = global.errors;
-                    fd->semantic3(fd->scope);
-                    // Update the template instantiation with the number
-                    // of errors which occured.
-                    if (spec && global.errors != olderrs)
-                        spec->errors = global.errors - olderrs;
-                }
-                if (!fd->errors)
-                {
-                    Type *t = fd->type->nextOf();
-                    t = t->substWildTo(mod == 0 ? MODmutable : mod);
-                    return t;
-                }
+                Type *t = fd->type->nextOf();
+                t = t->substWildTo(mod == 0 ? MODmutable : mod);
+                return t;
             }
-            return Type::terror;
+            else
+                return Type::terror;
         }
         //printf("%s\n", ad->aliasthis->kind());
     }

--- a/src/template.c
+++ b/src/template.c
@@ -2265,16 +2265,8 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Scope *sc, Loc loc,
             fd_best->type = tf->semantic(loc, sc);
         }
     }
-    if (fd_best->scope)
-    {
-        TemplateInstance *spec = fd_best->isSpeculative();
-        int olderrs = global.errors;
-        fd_best->semantic3(fd_best->scope);
-        // Update the template instantiation with the number
-        // of errors which occured.
-        if (spec && global.errors != olderrs)
-            spec->errors = global.errors - olderrs;
-    }
+
+    fd_best->functionSemantic();
 
     return fd_best;
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -787,11 +787,7 @@ void ClassDeclaration::toObjFile(int multiobj)
         if (fd && (fd->fbody || !isAbstract()))
         {
             // Ensure function has a return value (Bugzilla 4869)
-            if (fd->type->ty == Tfunction && !((TypeFunction *)fd->type)->next)
-            {
-                assert(fd->scope);
-                fd->semantic3(fd->scope);
-            }
+            fd->functionSemantic();
 
             Symbol *s = fd->toSymbol();
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -125,6 +125,7 @@ DISABLED_TESTS += testargtypes
 DISABLED_TESTS += testxmm
 
 DISABLED_SH_TESTS += test39
+DISABLED_SH_TESTS += test9377
 endif
 
 runnable_tests=$(wildcard runnable/*.d) $(wildcard runnable/*.sh)

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -93,7 +93,18 @@ template bug6661(Q)
     const Q blaz = 6;
 }
 
-static assert(is(typeof(bug6661!(int).blaz)));
+static assert(!is(typeof(bug6661!(int).blaz)));
+
+template bug6661x(Q)
+{
+    int qutz(Q y)
+    {
+        Q q = "abc";
+        return 67;
+    }
+}
+// should pass, but doesn't in current
+//static assert(!is(typeof(bug6661x!(int))));
 
 /**************************************************
     6599    ICE(constfold.c) or segfault

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -234,6 +234,25 @@ void test9072()
 }
 
 /***************************************************/
+// 5933 + Issue 8504 - Template attribute inferrence doesn't work
+
+int foo5933()(int a) { return a*a; }
+struct S5933
+{
+    double foo()(double a) { return a * a; }
+}
+// outside function
+static assert(typeof(foo5933!()).stringof == "pure nothrow @safe int(int a)");
+static assert(typeof(S5933.init.foo!()).stringof == "pure nothrow @safe double(double a)");
+
+void test5933()
+{
+    // inside function
+    static assert(typeof(foo5933!()).stringof == "pure nothrow @safe int(int a)");
+    static assert(typeof(S5933.init.foo!()).stringof == "pure nothrow @safe double(double a)");
+}
+
+/***************************************************/
 
 // Add more tests regarding inferences later.
 

--- a/test/fail_compilation/ice5996.d
+++ b/test/fail_compilation/ice5996.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice5996.d(9): Error: undefined identifier anyOldGarbage
-fail_compilation/ice5996.d(12): Error: CTFE failed because of previous errors in bug5996
+fail_compilation/ice5996.d(8): Error: undefined identifier anyOldGarbage
 ---
 */
 auto bug5996() {

--- a/test/runnable/extra-files/mul9377a.d
+++ b/test/runnable/extra-files/mul9377a.d
@@ -1,0 +1,11 @@
+import std.c.stdio;
+
+import mul9377b;
+
+void abc()
+{
+    printf("mul9377b.abc()\n");
+    foo();
+    bar();
+}
+

--- a/test/runnable/extra-files/mul9377b.d
+++ b/test/runnable/extra-files/mul9377b.d
@@ -1,0 +1,40 @@
+module mul9377b;
+
+import std.c.stdio;
+
+int j;
+
+int foo()()
+{
+    printf("foo()\n");
+    static int z = 7;
+    assert(z != 10);
+    return ++z;
+}
+
+void bar()
+{
+    assert(j == 7);
+    foo();
+    printf("bar\n");
+}
+
+template def()
+{
+    alias int defint;
+
+    static this()
+    {
+        printf("def.static this()\n");
+        j = 7;
+    }
+
+    //void mem(int){}
+    void mem()
+    {
+        printf("def().mem()\n");
+    }
+}
+
+def!().defint x;
+

--- a/test/runnable/extra-files/multi9377.d
+++ b/test/runnable/extra-files/multi9377.d
@@ -1,0 +1,13 @@
+import std.c.stdio;
+
+import mul9377a, mul9377b;
+
+int main()
+{
+    printf("main\n");
+    abc();
+    def!().mem();
+    pragma(msg, def!().mem.mangleof);
+    return 0;
+}
+

--- a/test/runnable/test9377.sh
+++ b/test/runnable/test9377.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+
+if [ $OS == "win32" -o  $OS == "win64" ]; then
+	LIBEXT=.lib
+else
+	LIBEXT=.a
+fi
+libname=${dir}${SEP}lib9377${LIBEXT}
+
+$DMD -m${MODEL} -I${src} -of${libname} -c ${src}${SEP}mul9377a.d ${src}${SEP}mul9377b.d -lib
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}mul9377 ${src}${SEP}multi9377.d ${libname}
+
+rm ${dir}/{lib9377${LIBEXT},mul9377${OBJ},mul9377${EXE}}
+

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4911,6 +4911,18 @@ void test7150()
 }
 
 /***************************************************/
+// 7159
+
+class HomeController7159 {
+    void* foo() {
+        return cast(void*)&HomeController7159.displayDefault;
+    }
+    auto displayDefault() {
+        return 1;
+    }
+}
+
+/***************************************************/
 // 7160
 
 class HomeController {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4268,6 +4268,37 @@ void test5696()
 }
 
 /***************************************************/
+// 5933
+
+int dummyfunc5933();
+alias typeof(dummyfunc5933) FuncType5933;
+
+struct S5933a { auto x() { return 0; } }
+static assert(is(typeof(&S5933a.init.x) == int delegate()));
+
+struct S5933b { auto x() { return 0; } }
+static assert(is(typeof(S5933b.init.x) == FuncType5933));
+
+struct S5933c { auto x() { return 0; } }
+static assert(is(typeof(&S5933c.x) == int function()));
+
+struct S5933d { auto x() { return 0; } }
+static assert(is(typeof(S5933d.x) == FuncType5933));
+
+
+class C5933a { auto x() { return 0; } }
+static assert(is(typeof(&(new C5933b()).x) == int delegate()));
+
+class C5933b { auto x() { return 0; } }
+static assert(is(typeof((new C5933b()).x) == FuncType5933));
+
+class C5933c { auto x() { return 0; } }
+static assert(is(typeof(&C5933c.x) == int function()));
+
+class C5933d { auto x() { return 0; } }
+static assert(is(typeof(C5933d.x) == FuncType5933));
+
+/***************************************************/
 // 6084
 
 template TypeTuple6084(T...){ alias T TypeTuple6084; }


### PR DESCRIPTION
- [Issue 5933](http://d.puremagic.com/issues/show_bug.cgi?id=5933) - Cannot retrieve the return type of an auto-return member function
- [Issue 7159](http://d.puremagic.com/issues/show_bug.cgi?id=7159) - Forward reference when casting auto return method
- [Issue 9377](http://d.puremagic.com/issues/show_bug.cgi?id=9377) - Link-failure regression cause by fixing issue 8504

This is a superseded pull of #535.

By this, the test result of [bug 6661](http://d.puremagic.com/issues/show_bug.cgi?id=6661) in `test/compilable/compile1.d` is changed. I think that the old one was a incorrect behavior.

---

Requires a phobos pull: https://github.com/D-Programming-Language/phobos/pull/1096
