### PR TITLE
Issue 9385 - [Regression 2.057] null literal should be implicitly convertible to bool

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -9395,6 +9395,11 @@ MATCH TypeNull::implicitConvTo(Type *to)
     return MATCHnomatch;
 }
 
+int TypeNull::checkBoolean()
+{
+    return TRUE;
+}
+
 void TypeNull::toDecoBuffer(OutBuffer *buf, int flag)
 {
     //tvoidptr->toDecoBuffer(buf, flag);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -1008,6 +1008,7 @@ struct TypeNull : Type
     Type *syntaxCopy();
     void toDecoBuffer(OutBuffer *buf, int flag);
     MATCH implicitConvTo(Type *to);
+    int checkBoolean();
 
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
     void toJson(JsonOut *json);

--- a/test/runnable/nulltype.d
+++ b/test/runnable/nulltype.d
@@ -117,6 +117,16 @@ void test8221()
 }
 
 /**********************************************/
+// 9385
+
+void test9385()
+{
+    assert((null ? true : false) == false);
+    if (null) assert(0);
+    assert(!null);
+}
+
+/**********************************************/
 
 int main()
 {
@@ -124,6 +134,7 @@ int main()
     test2();
     test7278();
     test8221();
+    test9385();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9385
