### PR TITLE
1841 Closure detection fails in nested functions

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -572,7 +572,7 @@ typedef targ_uns        targ_size_t;    /* size_t for the target machine */
 #define DATA    2       /* initialized data             */
 #define CDATA   3       /* constant data                */
 #define UDATA   4       /* uninitialized data           */
-#define UNKNOWN 0x7FFF  // unknown segment
+#define UNKNOWN -1      /* unknown segment              */
 #define DGROUPIDX 1     /* group index of DGROUP        */
 
 #define KEEPBITFIELDS 0 /* 0 means code generator cannot handle bit fields, */

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -2775,7 +2775,7 @@ elem * elstruct(elem *e, goal_t goal)
                         // In-memory only
                         goto Ldefault;
                     }
-                    if (type_size(e->ET) == 16)
+//                    if (type_size(e->ET) == 16)
                         goto Ldefault;
                 }
                 else if (I64 && targ1 && targ2)

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -458,7 +458,7 @@ static IDXSYM elf_addsym(IDXSTR nam, targ_size_t val, unsigned sz,
      */
     if(sz == 0 && (bind == STB_GLOBAL || bind == STB_WEAK) &&
        (typ == STT_OBJECT || typ == STT_TLS) &&
-       sec != SHT_UNDEF)
+       sec != SHN_UNDEF)
        sz = 1; // so fake it if it doesn't
 
     if (I64)
@@ -781,7 +781,7 @@ Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
     local_cnt = 0;
     // The symbols that every object file has
     elf_addsym(0, 0, 0, STT_NOTYPE,  STB_LOCAL, 0);
-    elf_addsym(0, 0, 0, STT_FILE,    STB_LOCAL, SHT_ABS);       // STI_FILE
+    elf_addsym(0, 0, 0, STT_FILE,    STB_LOCAL, SHN_ABS);       // STI_FILE
     elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_TEXT);      // STI_TEXT
     elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_DATA);      // STI_DATA
     elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_BSS);       // STI_BSS
@@ -1435,7 +1435,7 @@ void obj_filename(const char *modname)
 {
     //dbg_printf("obj_filename(char *%s)\n",modname);
     unsigned strtab_idx = Obj::addstr(symtab_strings,modname);
-    elf_addsym(strtab_idx,0,0,STT_FILE,STB_LOCAL,SHT_ABS);
+    elf_addsym(strtab_idx,0,0,STT_FILE,STB_LOCAL,SHN_ABS);
 }
 
 /*******************************
@@ -2177,7 +2177,7 @@ int Obj::external_def(const char *name)
     //dbg_printf("Obj::external_def('%s')\n",name);
     assert(name);
     IDXSTR namidx = Obj::addstr(symtab_strings,name);
-    IDXSYM symidx = elf_addsym(namidx, 0, 0, STT_NOTYPE, STB_GLOBAL, SHT_UNDEF);
+    IDXSYM symidx = elf_addsym(namidx, 0, 0, STT_NOTYPE, STB_GLOBAL, SHN_UNDEF);
     return symidx;
 }
 
@@ -2205,14 +2205,14 @@ int Obj::external(Symbol *s)
     if (s->Sscope && !tyfunc(s->ty()))
     {
         symtype = STT_OBJECT;
-        sectype = SHT_COMMON;
+        sectype = SHN_COMMON;
         size = type_size(s->Stype);
     }
     else
 #endif
     {
         symtype = STT_NOTYPE;
-        sectype = SHT_UNDEF;
+        sectype = SHN_UNDEF;
         size = 0;
     }
     if (s->ty() & mTYthread)
@@ -2681,12 +2681,12 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
     {                           // identifier is defined somewhere else
         if (I64)
         {
-            if (SymbolTable64[s->Sxtrnnum].st_shndx != SHT_UNDEF)
+            if (SymbolTable64[s->Sxtrnnum].st_shndx != SHN_UNDEF)
                 external = FALSE;
         }
         else
         {
-            if (SymbolTable[s->Sxtrnnum].st_shndx != SHT_UNDEF)
+            if (SymbolTable[s->Sxtrnnum].st_shndx != SHN_UNDEF)
                 external = FALSE;
         }
     }
@@ -3220,7 +3220,7 @@ static void obj_rtinit()
 
         // use a weak reference for _d_dso_registry
         namidx = ElfObj::addstr(symtab_strings, "_d_dso_registry");
-        const IDXSYM symidx = elf_addsym(namidx, 0, 0, STT_NOTYPE, STB_WEAK, SHT_UNDEF);
+        const IDXSYM symidx = elf_addsym(namidx, 0, 0, STT_NOTYPE, STB_WEAK, SHN_UNDEF);
 
         if (config.flags3 & CFG3pic)
         {

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -216,17 +216,17 @@ Outbuffer  *SECbuf;             // Buffer to build section table in
 // not used.
 static int section_cnt; // Number of sections in table
 
-#define SHI_TEXT        1
-#define SHI_RELTEXT     2
-#define SHI_DATA        3
-#define SHI_RELDATA     4
-#define SHI_BSS         5
-#define SHI_RODAT       6
-#define SHI_STRINGS     7
-#define SHI_SYMTAB      8
-#define SHI_SECNAMES    9
-#define SHI_COM         10
-#define SHI_NOTE        11
+#define SHN_TEXT        1
+#define SHN_RELTEXT     2
+#define SHN_DATA        3
+#define SHN_RELDATA     4
+#define SHN_BSS         5
+#define SHN_RODAT       6
+#define SHN_STRINGS     7
+#define SHN_SYMTAB      8
+#define SHN_SECNAMES    9
+#define SHN_COM         10
+#define SHN_NOTE        11
 
 IDXSYM *mapsec2sym;
 #define S2S_INC 20
@@ -702,9 +702,9 @@ Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
         // name,type,flags,addr,offset,size,link,info,addralign,entsize
         elf_newsection2(0,               SHT_NULL,   0,                 0,0,0,0,0, 0,0);
         elf_newsection2(NAMIDX_TEXT,SHT_PROGDEF,SHF_ALLOC|SHF_EXECINSTR,0,0,0,0,0, 4,0);
-        elf_newsection2(NAMIDX_RELTEXT,SHT_RELA, 0,0,0,0,SHI_SYMTAB,     SHI_TEXT, 8,0x18);
+        elf_newsection2(NAMIDX_RELTEXT,SHT_RELA, 0,0,0,0,SHN_SYMTAB,     SHN_TEXT, 8,0x18);
         elf_newsection2(NAMIDX_DATA,SHT_PROGDEF,SHF_ALLOC|SHF_WRITE,    0,0,0,0,0, 8,0);
-        elf_newsection2(NAMIDX_RELDATA64,SHT_RELA, 0,0,0,0,SHI_SYMTAB,   SHI_DATA, 8,0x18);
+        elf_newsection2(NAMIDX_RELDATA64,SHT_RELA, 0,0,0,0,SHN_SYMTAB,   SHN_DATA, 8,0x18);
         elf_newsection2(NAMIDX_BSS, SHT_NOBITS,SHF_ALLOC|SHF_WRITE,     0,0,0,0,0, 16,0);
         elf_newsection2(NAMIDX_RODATA,SHT_PROGDEF,SHF_ALLOC,            0,0,0,0,0, 16,0);
         elf_newsection2(NAMIDX_STRTAB,SHT_STRTAB, 0,                    0,0,0,0,0, 1,0);
@@ -748,9 +748,9 @@ Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
         // name,type,flags,addr,offset,size,link,info,addralign,entsize
         elf_newsection2(0,               SHT_NULL,   0,                 0,0,0,0,0, 0,0);
         elf_newsection2(NAMIDX_TEXT,SHT_PROGDEF,SHF_ALLOC|SHF_EXECINSTR,0,0,0,0,0, 16,0);
-        elf_newsection2(NAMIDX_RELTEXT,SHT_REL, 0,0,0,0,SHI_SYMTAB,      SHI_TEXT, 4,8);
+        elf_newsection2(NAMIDX_RELTEXT,SHT_REL, 0,0,0,0,SHN_SYMTAB,      SHN_TEXT, 4,8);
         elf_newsection2(NAMIDX_DATA,SHT_PROGDEF,SHF_ALLOC|SHF_WRITE,    0,0,0,0,0, 4,0);
-        elf_newsection2(NAMIDX_RELDATA,SHT_REL, 0,0,0,0,SHI_SYMTAB,      SHI_DATA, 4,8);
+        elf_newsection2(NAMIDX_RELDATA,SHT_REL, 0,0,0,0,SHN_SYMTAB,      SHN_DATA, 4,8);
         elf_newsection2(NAMIDX_BSS, SHT_NOBITS,SHF_ALLOC|SHF_WRITE,     0,0,0,0,0, 32,0);
         elf_newsection2(NAMIDX_RODATA,SHT_PROGDEF,SHF_ALLOC,            0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX_STRTAB,SHT_STRTAB, 0,                    0,0,0,0,0, 1,0);
@@ -782,32 +782,32 @@ Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
     // The symbols that every object file has
     elf_addsym(0, 0, 0, STT_NOTYPE,  STB_LOCAL, 0);
     elf_addsym(0, 0, 0, STT_FILE,    STB_LOCAL, SHN_ABS);       // STI_FILE
-    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_TEXT);      // STI_TEXT
-    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_DATA);      // STI_DATA
-    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_BSS);       // STI_BSS
-    elf_addsym(0, 0, 0, STT_NOTYPE,  STB_LOCAL, SHI_TEXT);      // STI_GCC
-    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_RODAT);     // STI_RODAT
-    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_NOTE);      // STI_NOTE
-    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHI_COM);       // STI_COM
+    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHN_TEXT);      // STI_TEXT
+    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHN_DATA);      // STI_DATA
+    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHN_BSS);       // STI_BSS
+    elf_addsym(0, 0, 0, STT_NOTYPE,  STB_LOCAL, SHN_TEXT);      // STI_GCC
+    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHN_RODAT);     // STI_RODAT
+    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHN_NOTE);      // STI_NOTE
+    elf_addsym(0, 0, 0, STT_SECTION, STB_LOCAL, SHN_COM);       // STI_COM
 
     // Initialize output buffers for CODE, DATA and COMMENTS
     //      (NOTE not supported, BSS not required)
 
     seg_count = 0;
 
-    elf_getsegment2(SHI_TEXT, STI_TEXT, SHI_RELTEXT);
+    elf_getsegment2(SHN_TEXT, STI_TEXT, SHN_RELTEXT);
     assert(SegData[CODE]->SDseg == CODE);
 
-    elf_getsegment2(SHI_DATA, STI_DATA, SHI_RELDATA);
+    elf_getsegment2(SHN_DATA, STI_DATA, SHN_RELDATA);
     assert(SegData[DATA]->SDseg == DATA);
 
-    elf_getsegment2(SHI_RODAT, STI_RODAT, 0);
+    elf_getsegment2(SHN_RODAT, STI_RODAT, 0);
     assert(SegData[CDATA]->SDseg == CDATA);
 
-    elf_getsegment2(SHI_BSS, STI_BSS, 0);
+    elf_getsegment2(SHN_BSS, STI_BSS, 0);
     assert(SegData[UDATA]->SDseg == UDATA);
 
-    elf_getsegment2(SHI_COM, STI_COM, 0);
+    elf_getsegment2(SHN_COM, STI_COM, 0);
     assert(SegData[COMD]->SDseg == COMD);
 
     if (config.fulltypes)
@@ -938,7 +938,7 @@ void *elf_renumbersyms()
             unsigned oidx = SecHdrTab[pseg->SDshtidx].sh_info;
             assert(oidx < symbol_idx);
             // we only have one symbol table
-            assert(SecHdrTab[pseg->SDshtidx].sh_link == SHI_SYMTAB);
+            assert(SecHdrTab[pseg->SDshtidx].sh_link == SHN_SYMTAB);
             SecHdrTab[pseg->SDshtidx].sh_info = sym_map[oidx];
         }
 
@@ -1065,7 +1065,7 @@ void Obj::term(const char *objfilename)
     int hdrsize = I64 ? sizeof(Elf64_Ehdr) : sizeof(Elf32_Hdr);
 
     elf_header.e_shnum = section_cnt;
-    elf_header.e_shstrndx = SHI_SECNAMES;
+    elf_header.e_shstrndx = SHN_SECNAMES;
     fobjbuf->writezeros(hdrsize);
 
             // Walk through sections determining size and file offsets
@@ -1139,7 +1139,7 @@ void Obj::term(const char *objfilename)
 
     if (comment_data)
     {
-        sechdr = &SecHdrTab[SHI_COM];           // Comments
+        sechdr = &SecHdrTab[SHN_COM];           // Comments
         sechdr->sh_size = comment_data->size();
         sechdr->sh_offset = foffset;
         fobjbuf->write(comment_data->buf, sechdr->sh_size);
@@ -1149,7 +1149,7 @@ void Obj::term(const char *objfilename)
     //
     // Then output string table for section names
     //
-    sechdr = &SecHdrTab[SHI_SECNAMES];  // Section Names
+    sechdr = &SecHdrTab[SHN_SECNAMES];  // Section Names
     sechdr->sh_size = section_names->size();
     sechdr->sh_offset = foffset;
     //dbg_printf("section names offset %d\n",foffset);
@@ -1160,10 +1160,10 @@ void Obj::term(const char *objfilename)
     // Symbol table and string table for symbols next
     //
     //dbg_printf("output symbol table size %d\n",SYMbuf->size());
-    sechdr = &SecHdrTab[SHI_SYMTAB];    // Symbol Table
+    sechdr = &SecHdrTab[SHN_SYMTAB];    // Symbol Table
     sechdr->sh_size = SYMbuf->size();
     sechdr->sh_entsize = I64 ? sizeof(Elf64_Sym) : sizeof(Elf32_Sym);
-    sechdr->sh_link = SHI_STRINGS;
+    sechdr->sh_link = SHN_STRINGS;
     sechdr->sh_info = local_cnt;
     foffset = elf_align(4,foffset);
     sechdr->sh_offset = foffset;
@@ -1172,7 +1172,7 @@ void Obj::term(const char *objfilename)
     util_free(symtab);
 
     //dbg_printf("output section strings size 0x%x,offset 0x%x\n",symtab_strings->size(),foffset);
-    sechdr = &SecHdrTab[SHI_STRINGS];   // Symbol Strings
+    sechdr = &SecHdrTab[SHN_STRINGS];   // Symbol Strings
     sechdr->sh_size = symtab_strings->size();
     sechdr->sh_offset = foffset;
     fobjbuf->write(symtab_strings->buf, sechdr->sh_size);
@@ -2270,7 +2270,7 @@ int Obj::common_block(Symbol *s,targ_size_t size,targ_size_t count)
     alignOffset(UDATA,size);
     IDXSYM symidx = elf_addsym(namidx, SegData[UDATA]->SDoffset, size*count,
                     (s->ty() & mTYthread) ? STT_TLS : STT_OBJECT,
-                    STB_WEAK, SHI_BSS);
+                    STB_WEAK, SHN_BSS);
     //dbg_printf("\tObj::common_block returning symidx %d\n",symidx);
     s->Sseg = UDATA;
     s->Sfl = FLudata;
@@ -2429,10 +2429,10 @@ void ElfObj::addrel(int seg, targ_size_t offset, unsigned type,
     if (segdata->SDrel->size() == 0)
     {   IDXSEC relidx;
 
-        if (secidx == SHI_TEXT)
-            relidx = SHI_RELTEXT;
-        else if (secidx == SHI_DATA)
-            relidx = SHI_RELDATA;
+        if (secidx == SHN_TEXT)
+            relidx = SHN_RELTEXT;
+        else if (secidx == SHN_DATA)
+            relidx = SHN_RELDATA;
         else
         {
             // Get the section name, and make a copy because
@@ -2453,7 +2453,7 @@ void ElfObj::addrel(int seg, targ_size_t offset, unsigned type,
              * Elf64_Shdr.
              */
             Elf32_Shdr *relsec = &SecHdrTab[relidx];
-            relsec->sh_link = SHI_SYMTAB;
+            relsec->sh_link = SHN_SYMTAB;
             relsec->sh_info = secidx;
             relsec->sh_entsize = sizeof(Elf64_Rela);
             relsec->sh_addralign = 8;
@@ -2461,7 +2461,7 @@ void ElfObj::addrel(int seg, targ_size_t offset, unsigned type,
         else
         {
             Elf32_Shdr *relsec = &SecHdrTab[relidx];
-            relsec->sh_link = SHI_SYMTAB;
+            relsec->sh_link = SHN_SYMTAB;
             relsec->sh_info = secidx;
             relsec->sh_entsize = sizeof(Elf32_Rel);
             relsec->sh_addralign = 4;
@@ -3345,7 +3345,7 @@ static void obj_rtinit()
     // set group section infos
     Offset(groupseg) = SegData[groupseg]->SDbuf->size();
     Elf32_Shdr *p = MAP_SEG2SEC(groupseg);
-    p->sh_link    = SHI_SYMTAB;
+    p->sh_link    = SHN_SYMTAB;
     p->sh_info    = dso_rec; // set the dso_rec as group symbol
     p->sh_entsize = sizeof(IDXSYM);
     p->sh_size    = Offset(groupseg);

--- a/src/backend/melf.h
+++ b/src/backend/melf.h
@@ -117,13 +117,16 @@ typedef struct
 } Elf32_Shdr;
 
 // Special Section Header Table Indices
-#define SHT_UNDEF       0               /* Undefined section */
-#define SHT_ABS         0xfff1          /* Absolute value for symbol references */
-#define SHT_COMMON      0xfff2          /* Symbol defined in common section */
-#define SHT_RESVSTART   0xff00          /* Start of reserved indices */
-#define SHT_PROCSTART   0xff00          /* Start of processor-specific */
-#define SHT_PROCEND     0xff1f          /* End of processor-specific */
-#define SHT_RESVEND     0xffff          /* End of reserved indices */
+#define SHN_UNDEF       0               /* Undefined section */
+#define SHN_LORESERVE   0xff00          /* Start of reserved indices */
+#define SHN_LOPROC      0xff00          /* Start of processor-specific */
+#define SHN_HIPROC      0xff1f          /* End of processor-specific */
+#define SHN_LOOS        0xff20          /* Start of OS-specific */
+#define SHN_HIOS        0xff3f          /* End of OS-specific */
+#define SHN_ABS         0xfff1          /* Absolute value for symbol references */
+#define SHN_COMMON      0xfff2          /* Symbol defined in common section */
+#define SHN_XINDEX      0xffff          /* Index is in extra table.  */
+#define SHN_HIRESERVE   0xffff          /* End of reserved indices */
 
 /* Symbol Table */
 

--- a/src/backend/melf.h
+++ b/src/backend/melf.h
@@ -100,6 +100,7 @@ typedef struct
         #define SHT_RESTYPE      10         /* Reserved section type*/
         #define SHT_DYNTAB       11         /* Dynamic linker symbol table */
         #define SHT_GROUP        17         /* Section group (COMDAT) */
+        #define SHT_SYMTAB_SHNDX 18         /* Extended section indeces */
   elf_u32_f32   sh_flags;               /* Section attribute flags */
         #define SHF_WRITE       (1 << 0)    /* Writable during execution */
         #define SHF_ALLOC       (1 << 1)    /* In memory during execution */

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -626,6 +626,8 @@ struct FuncDeclaration : Declaration
     VarDeclarations closureVars;        // local variables in this function
                                         // which are referenced by nested
                                         // functions
+    FuncDeclarations siblingCallers;    // Sibling nested functions which
+                                        // called this one
     FuncDeclarations deferred;          // toObjFile() these functions after this one
 
     unsigned flags;

--- a/src/func.c
+++ b/src/func.c
@@ -3281,6 +3281,18 @@ void FuncDeclaration::checkNestedReference(Scope *sc, Loc loc)
 
         if (fdv && fdthis && fdv != fdthis)
         {
+            // Add this function to the list of those which called us
+            if (fdthis != this)
+            {
+                bool found = false;
+                for (int i = 0; i < siblingCallers.dim; ++i)
+                {   if (siblingCallers[i] == fdthis)
+                        found = true;
+                }
+                if (!found)
+                    siblingCallers.push(fdthis);
+            }
+
             int lv = fdthis->getLevel(loc, sc, fdv);
             if (lv == -1)
                 return; // OK
@@ -3296,6 +3308,50 @@ void FuncDeclaration::checkNestedReference(Scope *sc, Loc loc)
     }
 }
 
+/* For all functions between outerFunc and f, mark them as needing
+ * a closure.
+ */
+void markAsNeedingClosure(Dsymbol *f, FuncDeclaration *outerFunc)
+{
+    for (Dsymbol *sx = f; sx != outerFunc; sx = sx->parent)
+    {
+        FuncDeclaration *fy = sx->isFuncDeclaration();
+        if (fy && fy->closureVars.dim)
+        {
+            /* fy needs a closure if it has closureVars[],
+             * because the frame pointer in the closure will be accessed.
+             */
+            fy->requiresClosure = true;
+        }
+    }
+}
+
+
+/* Given a nested function f inside a function outerFunc, check
+ * if any sibling callers of f have escaped. If so, mark
+ * all the enclosing functions as needing closures.
+ * Return true if any closures were detected.
+ * This is recursive: we need to check the callers of our siblings.
+ * Note that nested functions can only call lexically earlier nested
+ * functions, so loops are impossible.
+ */
+bool checkEscapingSiblings(FuncDeclaration *f, FuncDeclaration *outerFunc)
+{
+    bool bAnyClosures = false;
+    for (int i = 0; i < f->siblingCallers.dim; ++i)
+    {
+        FuncDeclaration *g = f->siblingCallers[i];
+        if (g->isThis() || g->tookAddressOf)
+        {
+            markAsNeedingClosure(g, outerFunc);
+            bAnyClosures = true;
+        }
+        bAnyClosures |= checkEscapingSiblings(g, outerFunc);
+    }
+    return bAnyClosures;
+}
+
+
 /*******************************
  * Look at all the variables in this function that are referenced
  * by nested functions, and determine if a closure needs to be
@@ -3308,12 +3364,14 @@ int FuncDeclaration::needsClosure()
     /* Need a closure for all the closureVars[] if any of the
      * closureVars[] are accessed by a
      * function that escapes the scope of this function.
-     * We take the conservative approach and decide that any function that:
+     * We take the conservative approach and decide that a function needs
+     * a closure if it:
      * 1) is a virtual function
      * 2) has its address taken
      * 3) has a parent that escapes
+     * 4) calls another nested function that needs a closure
      * -or-
-     * 4) this function returns a local struct/class
+     * 5) this function returns a local struct/class
      *
      * Note that since a non-virtual function can be called by
      * a virtual one, if that non-virtual function accesses a closure
@@ -3337,7 +3395,11 @@ int FuncDeclaration::needsClosure()
 
             //printf("\t\tf = %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", f->toChars(), f->isVirtual(), f->isThis(), f->tookAddressOf);
 
-            // Look to see if f or any parents of f that are below this escape
+            /* Look to see if f escapes. We consider all parents of f within
+             * this, and also all siblings which call f; if any of them escape,
+             * so does f.
+             * Mark all affected functions as requiring closures.
+             */
             for (Dsymbol *s = f; s && s != this; s = s->parent)
             {
                 FuncDeclaration *fx = s->isFuncDeclaration();
@@ -3347,26 +3409,22 @@ int FuncDeclaration::needsClosure()
 
                     /* Mark as needing closure any functions between this and f
                      */
-                    for (Dsymbol *sx = fx; sx != this; sx = sx->parent)
-                    {
-                        if (sx != f)
-                        {   FuncDeclaration *fy = sx->isFuncDeclaration();
-                            if (fy && fy->closureVars.dim)
-                            {
-                                /* fy needs a closure if it has closureVars[],
-                                 * because the frame pointer in the closure will be accessed.
-                                 */
-                                fy->requiresClosure = true;
-                            }
-                        }
-                    }
+                    markAsNeedingClosure( (fx == f) ? fx->parent : fx, this);
+
                     goto Lyes;
                 }
+
+                /* We also need to check if any sibling functions that
+                 * called us, have escaped. This is recursive: we need
+                 * to check the callers of our siblings.
+                 */
+                if (fx && checkEscapingSiblings(fx, this))
+                    goto Lyes;
             }
         }
     }
 
-    /* Look for case (4)
+    /* Look for case (5)
      */
     if (closureVars.dim)
     {

--- a/src/libelf.c
+++ b/src/libelf.c
@@ -334,7 +334,7 @@ void LibElf::scanObjModule(ObjModule *om)
 
                     if (((sym->st_info >> 4) == STB_GLOBAL ||
                          (sym->st_info >> 4) == STB_WEAK) &&
-                        sym->st_shndx != SHT_UNDEF)     // not extern
+                        sym->st_shndx != SHN_UNDEF)     // not extern
                     {
                         char *name = string_tab + sym->st_name;
                         //printf("sym st_name = x%x\n", sym->st_name);
@@ -380,7 +380,7 @@ void LibElf::scanObjModule(ObjModule *om)
 
                     if (((sym->st_info >> 4) == STB_GLOBAL ||
                          (sym->st_info >> 4) == STB_WEAK) &&
-                        sym->st_shndx != SHT_UNDEF)     // not extern
+                        sym->st_shndx != SHN_UNDEF)     // not extern
                     {
                         char *name = string_tab + sym->st_name;
                         //printf("sym st_name = x%x\n", sym->st_name);

--- a/src/parse.c
+++ b/src/parse.c
@@ -2231,7 +2231,11 @@ Objects *Parser::parseTemplateArgument()
             break;
     }
     if (token.value == TOKnot)
-        error("multiple ! arguments are not allowed");
+    {
+        enum TOK tok = peekNext();
+        if (tok != TOKis && tok != TOKin)
+            error("multiple ! arguments are not allowed");
+    }
     return tiargs;
 }
 

--- a/src/toir.c
+++ b/src/toir.c
@@ -924,6 +924,8 @@ L2:
 #endif
             goto Lagain;
         }
+        else if (global.params.is64bit && !sd->arg1type && !sd->arg2type)
+            return RETstack;
         else if (sd->isPOD())
         {
             switch (sz)

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -376,3 +376,13 @@ alias test8163!(ubyte, ubyte, ubyte, ubyte, ubyte, ubyte, ubyte, ubyte) _BBBBBBB
 alias test8163!(ubyte, ubyte, ushort, float) _BBSf;
 
 
+/***************************************************/
+// 9348
+
+void test9348()
+{
+    @property Object F(int E)() { return null; }
+
+    assert(F!0 !is null);
+    assert(F!0 !in [new Object():1]);
+}

--- a/test/runnable/closure.d
+++ b/test/runnable/closure.d
@@ -667,6 +667,50 @@ void test22()
     assert(gi22 == 42);
 }
 
+// 1841
+
+int delegate() foo1841()
+{
+  int stack;
+  int heap = 3;
+
+  int nested_func()
+  {
+    ++heap;
+    return heap;
+  }
+  return delegate int() { return nested_func(); };
+}
+
+int delegate() foo1841b()
+{
+  int stack;
+  int heap = 7;
+
+  int nested_func()
+  {
+    ++heap;
+    return heap;
+  }
+  int more_nested() { return nested_func(); }
+  return delegate int() { return more_nested(); };
+}
+
+void bug1841()
+{
+  auto z = foo1841();
+  auto p = foo1841();
+  assert(z() == 4);
+  p();
+  assert(z() == 5);
+  z = foo1841b();
+  p = foo1841b();
+  assert(z() == 8);
+  p();
+  assert(z() == 9);
+}
+
+
 /************************************/
 
 int main()
@@ -693,6 +737,7 @@ int main()
     test20();
     test21();
     test22();
+    bug1841();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
If an escaping function doesn't use any closure variables itself, but is ultimately calls another nested function which does, it must be marked as needing a closure.

This 'calling a sibling nested function' case was missing. I've fixed this by constructing a simple call graph for nested functions. Note that nested functions cannot be forward referenced by other nested functions, so the call graph is a simple tree, with no cycles, and that makes it trivial to traverse.
