### PR TITLE
Issue 9413 & 9414 - Detect incorrect modification inside contracts

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -94,7 +94,7 @@ struct AggregateDeclaration : ScopeDsymbol
     Type *getType();
     int firstFieldInUnion(int indx); // first field in union that includes indx
     int numFieldsInUnion(int firstIndex); // #fields in union starting at index
-    int isDeprecated();         // is aggregate deprecated?
+    bool isDeprecated();         // is aggregate deprecated?
     FuncDeclaration *buildDtor(Scope *sc);
     int isNested();
     int isExport();

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -143,7 +143,7 @@ int Declaration::checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int fl
         {
             if (scx->func == parent && (scx->flags & SCOPEcontract))
             {
-                const char *s = isParameter() ? "parameter" : "result";
+                const char *s = isParameter() && parent->ident != Id::ensure ? "parameter" : "result";
                 if (!flag) error(loc, "cannot modify %s '%s' in contract", s, toChars());
                 return 0;
             }

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -137,15 +137,17 @@ int Declaration::checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int fl
     if (v && v->canassign)
         return 2;
 
-    if ((sc->flags & SCOPEcontract) && isParameter())
+    if (isParameter() || isResult())
     {
-        if (!flag) error(loc, "cannot modify parameter '%s' in contract", toChars());
-        return 0;
-    }
-    if ((sc->flags & SCOPEcontract) && isResult())
-    {
-        if (!flag) error(loc, "cannot modify result '%s' in contract", toChars());
-        return 0;
+        for (Scope *scx = sc; scx; scx = scx->enclosing)
+        {
+            if (scx->func == parent && (scx->flags & SCOPEcontract))
+            {
+                const char *s = isParameter() ? "parameter" : "result";
+                if (!flag) error(loc, "cannot modify %s '%s' in contract", s, toChars());
+                return 0;
+            }
+        }
     }
 
     if (v && isCtorinit())

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -151,29 +151,29 @@ struct Declaration : Dsymbol
     void toDocBuffer(OutBuffer *buf, Scope *sc);
 
     char *mangle(bool isv = false);
-    int isStatic() { return storage_class & STCstatic; }
+    bool isStatic() { return (storage_class & STCstatic) != 0; }
     virtual int isDelete();
     virtual int isDataseg();
     virtual int isThreadlocal();
     virtual int isCodeseg();
-    int isCtorinit()     { return storage_class & STCctorinit; }
-    int isFinal()        { return storage_class & STCfinal; }
-    int isAbstract()     { return storage_class & STCabstract; }
-    int isConst()        { return storage_class & STCconst; }
-    int isImmutable()    { return storage_class & STCimmutable; }
-    int isWild()         { return storage_class & STCwild; }
-    int isAuto()         { return storage_class & STCauto; }
-    int isScope()        { return storage_class & STCscope; }
-    int isSynchronized() { return storage_class & STCsynchronized; }
-    int isParameter()    { return storage_class & STCparameter; }
-    int isDeprecated()   { return storage_class & STCdeprecated; }
-    int isOverride()     { return storage_class & STCoverride; }
-    int isResult()       { return storage_class & STCresult; }
-    int isField()        { return storage_class & STCfield; }
+    bool isCtorinit()     { return (storage_class & STCctorinit) != 0; }
+    bool isFinal()        { return (storage_class & STCfinal) != 0; }
+    bool isAbstract()     { return (storage_class & STCabstract) != 0; }
+    bool isConst()        { return (storage_class & STCconst) != 0; }
+    bool isImmutable()    { return (storage_class & STCimmutable) != 0; }
+    bool isWild()         { return (storage_class & STCwild) != 0; }
+    bool isAuto()         { return (storage_class & STCauto) != 0; }
+    bool isScope()        { return (storage_class & STCscope) != 0; }
+    bool isSynchronized() { return (storage_class & STCsynchronized) != 0; }
+    bool isParameter()    { return (storage_class & STCparameter) != 0; }
+    bool isDeprecated()   { return (storage_class & STCdeprecated) != 0; }
+    bool isOverride()     { return (storage_class & STCoverride) != 0; }
+    bool isResult()       { return (storage_class & STCresult) != 0; }
+    bool isField()        { return (storage_class & STCfield) != 0; }
 
-    int isIn()    { return storage_class & STCin; }
-    int isOut()   { return storage_class & STCout; }
-    int isRef()   { return storage_class & STCref; }
+    bool isIn()    { return (storage_class & STCin) != 0; }
+    bool isOut()   { return (storage_class & STCout) != 0; }
+    bool isRef()   { return (storage_class & STCref) != 0; }
 
     enum PROT prot();
 

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -531,9 +531,9 @@ int Dsymbol::isImportedSymbol()
     return FALSE;
 }
 
-int Dsymbol::isDeprecated()
+bool Dsymbol::isDeprecated()
 {
-    return FALSE;
+    return false;
 }
 
 #if DMDV2

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -180,7 +180,7 @@ struct Dsymbol : Object
     ClassDeclaration *isClassMember();          // are we a member of a class?
     virtual int isExport();                     // is Dsymbol exported?
     virtual int isImportedSymbol();             // is Dsymbol imported?
-    virtual int isDeprecated();                 // is Dsymbol deprecated?
+    virtual bool isDeprecated();                // is Dsymbol deprecated?
 #if DMDV2
     virtual int isOverloadable();
     virtual int hasOverloads();

--- a/src/enum.c
+++ b/src/enum.c
@@ -31,7 +31,7 @@ EnumDeclaration::EnumDeclaration(Loc loc, Identifier *id, Type *memtype)
     minval = NULL;
     defaultval = NULL;
     sinit = NULL;
-    isdeprecated = 0;
+    isdeprecated = false;
     isdone = 0;
     objFileDone = 0;
 }
@@ -120,7 +120,7 @@ void EnumDeclaration::semantic(Scope *sc)
     unsigned dprogress_save = Module::dprogress;
 
     if (sc->stc & STCdeprecated)
-        isdeprecated = 1;
+        isdeprecated = true;
     userAttributes = sc->userAttributes;
 
     parent = sc->parent;
@@ -380,7 +380,7 @@ const char *EnumDeclaration::kind()
     return "enum";
 }
 
-int EnumDeclaration::isDeprecated()
+bool EnumDeclaration::isDeprecated()
 {
     return isdeprecated;
 }

--- a/src/enum.h
+++ b/src/enum.h
@@ -40,7 +40,7 @@ struct EnumDeclaration : ScopeDsymbol
     Expression *minval;
     Expression *defaultval;     // default initializer
 #endif
-    int isdeprecated;
+    bool isdeprecated;
     int isdone;                 // 0: not done
                                 // 1: semantic() successfully completed
 #ifdef IN_GCC
@@ -59,7 +59,7 @@ struct EnumDeclaration : ScopeDsymbol
 #if DMDV2
     Dsymbol *search(Loc, Identifier *ident, int flags);
 #endif
-    int isDeprecated();                 // is Dsymbol deprecated?
+    bool isDeprecated();                // is Dsymbol deprecated?
 
     void emitComment(Scope *sc);
     void toJson(JsonOut *json);

--- a/src/expression.c
+++ b/src/expression.c
@@ -9546,16 +9546,6 @@ void SliceExp::checkEscapeRef()
     e1->checkEscapeRef();
 }
 
-int SliceExp::isLvalue()
-{
-    return 1;
-}
-
-Expression *SliceExp::toLvalue(Scope *sc, Expression *e)
-{
-    return this;
-}
-
 int SliceExp::checkModifiable(Scope *sc, int flag)
 {
     //printf("SliceExp::checkModifiable %s\n", toChars());

--- a/src/expression.h
+++ b/src/expression.h
@@ -1131,8 +1131,6 @@ struct SliceExp : UnaExp
     void checkEscape();
     void checkEscapeRef();
     int checkModifiable(Scope *sc, int flag);
-    int isLvalue();
-    Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     int isBool(int result);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/func.c
+++ b/src/func.c
@@ -923,7 +923,8 @@ void FuncDeclaration::semantic3(Scope *sc)
         sc2->protection = PROTpublic;
         sc2->explicitProtection = 0;
         sc2->structalign = STRUCTALIGN_DEFAULT;
-        sc2->flags = sc->flags & ~SCOPEcontract;
+        if (this->ident != Id::require && this->ident != Id::ensure)
+            sc2->flags = sc->flags & ~SCOPEcontract;
         sc2->tf = NULL;
         sc2->noctor = 0;
         sc2->speculative = sc->speculative || isSpeculative() != NULL;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5941,27 +5941,26 @@ MATCH TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
 
         // Non-lvalues do not match ref or out parameters
         if (p->storageClass & STCref)
-        {   if (m && !arg->isLvalue())
-            {
-                Type *ta = targ->aliasthisOf();
-                if (arg->op == TOKstring && tprm->ty == Tsarray)
-                {   if (targ->ty != Tsarray)
-                        targ = new TypeSArray(targ->nextOf(),
-                                new IntegerExp(0, ((StringExp *)arg)->len,
-                                Type::tindex));
-                }
-                else
-                    goto Nomatch;
-            }
-
+        {
             Type *targb = targ->toBasetype();
             Type *tprmb = tprm->toBasetype();
             //printf("%s\n", targb->toChars());
             //printf("%s\n", tprmb->toChars());
 
-            if (arg->op == TOKslice && tprmb->ty == Tsarray)
-            {   // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
-                targb = tprmb;
+            if (m && !arg->isLvalue())
+            {
+                if (arg->op == TOKstring && tprmb->ty == Tsarray)
+                {   if (targb->ty != Tsarray)
+                        targb = new TypeSArray(targb->nextOf(),
+                                new IntegerExp(0, ((StringExp *)arg)->len,
+                                Type::tindex));
+                }
+                else if (arg->op == TOKslice && tprmb->ty == Tsarray)
+                {   // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
+                    targb = tprmb;
+                }
+                else
+                    goto Nomatch;
             }
 
             /* find most derived alias this type being matched.

--- a/src/struct.c
+++ b/src/struct.c
@@ -197,7 +197,7 @@ Type *AggregateDeclaration::getType()
     return type;
 }
 
-int AggregateDeclaration::isDeprecated()
+bool AggregateDeclaration::isDeprecated()
 {
     return isdeprecated;
 }

--- a/src/template.c
+++ b/src/template.c
@@ -1592,9 +1592,14 @@ Lretry:
             }
 
             if (m && (fparam->storageClass & (STCref | STCauto)) == STCref)
-            {   if (!farg->isLvalue())
+            {
+                if (!farg->isLvalue())
                 {
-                    goto Lnomatch;
+                    if (farg->op == TOKslice && argtype->ty == Tsarray)
+                    {   // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
+                    }
+                    else
+                        goto Lnomatch;
                 }
             }
             if (m && (fparam->storageClass & STCout))

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1108,7 +1108,8 @@ struct Zadok
     int bfg()
     {
         z[0] = 56;
-        fog(z[]) = [56, 6, 8];
+        auto zs = z[];
+        fog(zs) = [56, 6, 8];
         assert(z[1] == 6);
         assert(z[0] == 56);
         return z[2];

--- a/test/fail_compilation/fail9413.d
+++ b/test/fail_compilation/fail9413.d
@@ -1,0 +1,85 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9413.d(45): Error: variable fail9413.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9413.d(32): Error: variable fail9413.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9413.d(33): Error: variable fail9413.foo.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9413.d(38): Error: variable fail9413.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9413.d(39): Error: variable fail9413.foo.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9413.d(40): Error: variable fail9413.foo.bar.s cannot modify result 's' in contract
+fail_compilation/fail9413.d(50): Error: variable fail9413.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9413.d(73): Error: variable fail9413.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9413.d(74): Error: variable fail9413.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9413.d(58): Error: variable fail9413.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9413.d(59): Error: variable fail9413.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9413.d(60): Error: variable fail9413.foo.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9413.d(65): Error: variable fail9413.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9413.d(66): Error: variable fail9413.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9413.d(67): Error: variable fail9413.foo.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9413.d(68): Error: variable fail9413.foo.baz.s cannot modify result 's' in contract
+fail_compilation/fail9413.d(79): Error: variable fail9413.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9413.d(80): Error: variable fail9413.foo.r cannot modify result 'r' in contract
+---
+*/
+
+int foo(int x)
+in
+{
+    int a;
+    int bar(int y)
+    in
+    {
+        x = 10; // err
+        y = 10; // err
+        a = 1;  // OK
+    }
+    out(s)
+    {
+        x = 10; // err
+        y = 10; // err
+        s = 10; // err
+        a = 1;  // OK
+    }
+    body
+    {
+        x = 10; // err
+        y = 1;  // OK
+        a = 1;  // OK
+        return 2;
+    }
+    x = 10; // err
+}
+out(r)
+{
+    int a;
+    int baz(int y)
+    in
+    {
+        x = 10; // err
+        r = 10; // err
+        y = 10; // err
+        a = 1;  // OK
+    }
+    out(s)
+    {
+        x = 10; // err
+        r = 10; // err
+        y = 10; // err
+        s = 10; // err
+        a = 1;  // OK
+    }
+    body
+    {
+        x = 10; // err
+        r = 10; // err
+        y = 1;  // OK
+        a = 1;  // OK
+        return 2;
+    }
+    x = 10; // err
+    r = 10; // err
+}
+body
+{
+    return 1;
+}

--- a/test/fail_compilation/fail9414a.d
+++ b/test/fail_compilation/fail9414a.d
@@ -1,0 +1,88 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9414a.d(47): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414a.d(34): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414a.d(35): Error: variable fail9414a.C.foo.__require.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414a.d(40): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414a.d(41): Error: variable fail9414a.C.foo.__require.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414a.d(42): Error: variable fail9414a.C.foo.__require.bar.s cannot modify result 's' in contract
+fail_compilation/fail9414a.d(52): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414a.d(75): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414a.d(76): Error: cannot modify const expression r
+fail_compilation/fail9414a.d(60): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414a.d(61): Error: cannot modify const expression r
+fail_compilation/fail9414a.d(62): Error: variable fail9414a.C.foo.__ensure.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414a.d(67): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414a.d(68): Error: cannot modify const expression r
+fail_compilation/fail9414a.d(69): Error: variable fail9414a.C.foo.__ensure.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414a.d(70): Error: variable fail9414a.C.foo.__ensure.baz.s cannot modify result 's' in contract
+fail_compilation/fail9414a.d(81): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414a.d(82): Error: cannot modify const expression r
+---
+*/
+
+class C
+{
+    int foo(int x)
+    in
+    {
+        int a;
+        int bar(int y)
+        in
+        {
+            x = 10; // err
+            y = 10; // err
+            a = 1;  // OK
+        }
+        out(s)
+        {
+            x = 10; // err
+            y = 10; // err
+            s = 10; // err
+            a = 1;  // OK
+        }
+        body
+        {
+            x = 10; // err
+            y = 1;  // OK
+            a = 1;  // OK
+            return 2;
+        }
+        x = 10; // err
+    }
+    out(r)
+    {
+        int a;
+        int baz(int y)
+        in
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 10; // err
+            a = 1;  // OK
+        }
+        out(s)
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 10; // err
+            s = 10; // err
+            a = 1;  // OK
+        }
+        body
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 1;  // OK
+            a = 1;  // OK
+            return 2;
+        }
+        x = 10; // err
+        r = 10; // err
+    }
+    body
+    {
+        return 1;
+    }
+}

--- a/test/fail_compilation/fail9414a.d
+++ b/test/fail_compilation/fail9414a.d
@@ -9,16 +9,16 @@ fail_compilation/fail9414a.d(41): Error: variable fail9414a.C.foo.__require.bar.
 fail_compilation/fail9414a.d(42): Error: variable fail9414a.C.foo.__require.bar.s cannot modify result 's' in contract
 fail_compilation/fail9414a.d(52): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
 fail_compilation/fail9414a.d(75): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
-fail_compilation/fail9414a.d(76): Error: cannot modify const expression r
+fail_compilation/fail9414a.d(76): Error: variable fail9414a.C.foo.__ensure.r cannot modify result 'r' in contract
 fail_compilation/fail9414a.d(60): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
-fail_compilation/fail9414a.d(61): Error: cannot modify const expression r
+fail_compilation/fail9414a.d(61): Error: variable fail9414a.C.foo.__ensure.r cannot modify result 'r' in contract
 fail_compilation/fail9414a.d(62): Error: variable fail9414a.C.foo.__ensure.baz.y cannot modify parameter 'y' in contract
 fail_compilation/fail9414a.d(67): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
-fail_compilation/fail9414a.d(68): Error: cannot modify const expression r
+fail_compilation/fail9414a.d(68): Error: variable fail9414a.C.foo.__ensure.r cannot modify result 'r' in contract
 fail_compilation/fail9414a.d(69): Error: variable fail9414a.C.foo.__ensure.baz.y cannot modify parameter 'y' in contract
 fail_compilation/fail9414a.d(70): Error: variable fail9414a.C.foo.__ensure.baz.s cannot modify result 's' in contract
 fail_compilation/fail9414a.d(81): Error: variable fail9414a.C.foo.x cannot modify parameter 'x' in contract
-fail_compilation/fail9414a.d(82): Error: cannot modify const expression r
+fail_compilation/fail9414a.d(82): Error: variable fail9414a.C.foo.__ensure.r cannot modify result 'r' in contract
 ---
 */
 

--- a/test/fail_compilation/fail9414b.d
+++ b/test/fail_compilation/fail9414b.d
@@ -1,0 +1,88 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9414b.d(47): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414b.d(34): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414b.d(35): Error: variable fail9414b.C.foo.__require.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414b.d(40): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414b.d(41): Error: variable fail9414b.C.foo.__require.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414b.d(42): Error: variable fail9414b.C.foo.__require.bar.s cannot modify result 's' in contract
+fail_compilation/fail9414b.d(52): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414b.d(75): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414b.d(76): Error: cannot modify const expression r
+fail_compilation/fail9414b.d(60): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414b.d(61): Error: cannot modify const expression r
+fail_compilation/fail9414b.d(62): Error: variable fail9414b.C.foo.__ensure.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414b.d(67): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414b.d(68): Error: cannot modify const expression r
+fail_compilation/fail9414b.d(69): Error: variable fail9414b.C.foo.__ensure.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414b.d(70): Error: variable fail9414b.C.foo.__ensure.baz.s cannot modify result 's' in contract
+fail_compilation/fail9414b.d(81): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414b.d(82): Error: cannot modify const expression r
+---
+*/
+
+class C
+{
+    final int foo(int x)
+    in
+    {
+        int a;
+        int bar(int y)
+        in
+        {
+            x = 10; // err
+            y = 10; // err
+            a = 1;  // OK
+        }
+        out(s)
+        {
+            x = 10; // err
+            y = 10; // err
+            s = 10; // err
+            a = 1;  // OK
+        }
+        body
+        {
+            x = 10; // err
+            y = 1;  // OK
+            a = 1;  // OK
+            return 2;
+        }
+        x = 10; // err
+    }
+    out(r)
+    {
+        int a;
+        int baz(int y)
+        in
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 10; // err
+            a = 1;  // OK
+        }
+        out(s)
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 10; // err
+            s = 10; // err
+            a = 1;  // OK
+        }
+        body
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 1;  // OK
+            a = 1;  // OK
+            return 2;
+        }
+        x = 10; // err
+        r = 10; // err
+    }
+    body
+    {
+        return 1;
+    }
+}

--- a/test/fail_compilation/fail9414b.d
+++ b/test/fail_compilation/fail9414b.d
@@ -9,16 +9,16 @@ fail_compilation/fail9414b.d(41): Error: variable fail9414b.C.foo.__require.bar.
 fail_compilation/fail9414b.d(42): Error: variable fail9414b.C.foo.__require.bar.s cannot modify result 's' in contract
 fail_compilation/fail9414b.d(52): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
 fail_compilation/fail9414b.d(75): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
-fail_compilation/fail9414b.d(76): Error: cannot modify const expression r
+fail_compilation/fail9414b.d(76): Error: variable fail9414b.C.foo.__ensure.r cannot modify result 'r' in contract
 fail_compilation/fail9414b.d(60): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
-fail_compilation/fail9414b.d(61): Error: cannot modify const expression r
+fail_compilation/fail9414b.d(61): Error: variable fail9414b.C.foo.__ensure.r cannot modify result 'r' in contract
 fail_compilation/fail9414b.d(62): Error: variable fail9414b.C.foo.__ensure.baz.y cannot modify parameter 'y' in contract
 fail_compilation/fail9414b.d(67): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
-fail_compilation/fail9414b.d(68): Error: cannot modify const expression r
+fail_compilation/fail9414b.d(68): Error: variable fail9414b.C.foo.__ensure.r cannot modify result 'r' in contract
 fail_compilation/fail9414b.d(69): Error: variable fail9414b.C.foo.__ensure.baz.y cannot modify parameter 'y' in contract
 fail_compilation/fail9414b.d(70): Error: variable fail9414b.C.foo.__ensure.baz.s cannot modify result 's' in contract
 fail_compilation/fail9414b.d(81): Error: variable fail9414b.C.foo.x cannot modify parameter 'x' in contract
-fail_compilation/fail9414b.d(82): Error: cannot modify const expression r
+fail_compilation/fail9414b.d(82): Error: variable fail9414b.C.foo.__ensure.r cannot modify result 'r' in contract
 ---
 */
 

--- a/test/fail_compilation/fail9414c.d
+++ b/test/fail_compilation/fail9414c.d
@@ -1,0 +1,88 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9414c.d(47): Error: variable fail9414c.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414c.d(34): Error: variable fail9414c.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414c.d(35): Error: variable fail9414c.C.foo.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414c.d(40): Error: variable fail9414c.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414c.d(41): Error: variable fail9414c.C.foo.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414c.d(42): Error: variable fail9414c.C.foo.bar.s cannot modify result 's' in contract
+fail_compilation/fail9414c.d(52): Error: variable fail9414c.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414c.d(75): Error: variable fail9414c.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414c.d(76): Error: variable fail9414c.C.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9414c.d(60): Error: variable fail9414c.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414c.d(61): Error: variable fail9414c.C.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9414c.d(62): Error: variable fail9414c.C.foo.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414c.d(67): Error: variable fail9414c.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414c.d(68): Error: variable fail9414c.C.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9414c.d(69): Error: variable fail9414c.C.foo.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414c.d(70): Error: variable fail9414c.C.foo.baz.s cannot modify result 's' in contract
+fail_compilation/fail9414c.d(81): Error: variable fail9414c.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414c.d(82): Error: variable fail9414c.C.foo.r cannot modify result 'r' in contract
+---
+*/
+
+class C
+{
+    private int foo(int x)
+    in
+    {
+        int a;
+        int bar(int y)
+        in
+        {
+            x = 10; // err
+            y = 10; // err
+            a = 1;  // OK
+        }
+        out(s)
+        {
+            x = 10; // err
+            y = 10; // err
+            s = 10; // err
+            a = 1;  // OK
+        }
+        body
+        {
+            x = 10; // err
+            y = 1;  // OK
+            a = 1;  // OK
+            return 2;
+        }
+        x = 10; // err
+    }
+    out(r)
+    {
+        int a;
+        int baz(int y)
+        in
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 10; // err
+            a = 1;  // OK
+        }
+        out(s)
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 10; // err
+            s = 10; // err
+            a = 1;  // OK
+        }
+        body
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 1;  // OK
+            a = 1;  // OK
+            return 2;
+        }
+        x = 10; // err
+        r = 10; // err
+    }
+    body
+    {
+        return 1;
+    }
+}

--- a/test/fail_compilation/fail9414d.d
+++ b/test/fail_compilation/fail9414d.d
@@ -1,0 +1,88 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9414d.d(47): Error: variable fail9414d.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414d.d(34): Error: variable fail9414d.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414d.d(35): Error: variable fail9414d.C.foo.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414d.d(40): Error: variable fail9414d.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414d.d(41): Error: variable fail9414d.C.foo.bar.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414d.d(42): Error: variable fail9414d.C.foo.bar.s cannot modify result 's' in contract
+fail_compilation/fail9414d.d(52): Error: variable fail9414d.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414d.d(75): Error: variable fail9414d.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414d.d(76): Error: variable fail9414d.C.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9414d.d(60): Error: variable fail9414d.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414d.d(61): Error: variable fail9414d.C.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9414d.d(62): Error: variable fail9414d.C.foo.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414d.d(67): Error: variable fail9414d.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414d.d(68): Error: variable fail9414d.C.foo.r cannot modify result 'r' in contract
+fail_compilation/fail9414d.d(69): Error: variable fail9414d.C.foo.baz.y cannot modify parameter 'y' in contract
+fail_compilation/fail9414d.d(70): Error: variable fail9414d.C.foo.baz.s cannot modify result 's' in contract
+fail_compilation/fail9414d.d(81): Error: variable fail9414d.C.foo.x cannot modify parameter 'x' in contract
+fail_compilation/fail9414d.d(82): Error: variable fail9414d.C.foo.r cannot modify result 'r' in contract
+---
+*/
+
+class C
+{
+    static int foo(int x)
+    in
+    {
+        int a;
+        int bar(int y)
+        in
+        {
+            x = 10; // err
+            y = 10; // err
+            a = 1;  // OK
+        }
+        out(s)
+        {
+            x = 10; // err
+            y = 10; // err
+            s = 10; // err
+            a = 1;  // OK
+        }
+        body
+        {
+            x = 10; // err
+            y = 1;  // OK
+            a = 1;  // OK
+            return 2;
+        }
+        x = 10; // err
+    }
+    out(r)
+    {
+        int a;
+        int baz(int y)
+        in
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 10; // err
+            a = 1;  // OK
+        }
+        out(s)
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 10; // err
+            s = 10; // err
+            a = 1;  // OK
+        }
+        body
+        {
+            x = 10; // err
+            r = 10; // err
+            y = 1;  // OK
+            a = 1;  // OK
+            return 2;
+        }
+        x = 10; // err
+        r = 10; // err
+    }
+    body
+    {
+        return 1;
+    }
+}

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -280,17 +280,17 @@ void test11()
 
 struct Array12
 {
-	char len;
-	void* p;
+    char len;
+    void* p;
 }
-Array12 f12(string a)
-{
-	return *cast(Array12*) &a[0..23]; //Internal error: ..\ztc\cgcs.c 350
-}
+//Array12 f12(string a)
+//{
+//    return *cast(Array12*) &a[0..23]; //Internal error: ..\ztc\cgcs.c 350
+//}
 
 Array12 g12(string a)
 {
-	return *cast(Array12*) &a; //works
+    return *cast(Array12*) &a; //works
 }
 
 void test12()
@@ -298,8 +298,8 @@ void test12()
     string a = "12345678901234567890123";
     Array12 b;
 
-    b = f12(a);
-    printf("b.len = %x\n", b.len);
+    //b = f12(a);
+    //printf("b.len = %x\n", b.len);
     b = g12(a);
     printf("b.len = %x\n", b.len);
 }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3494,6 +3494,29 @@ void test155()
 }
 
 /***************************************************/
+// 2486
+
+void test2486()
+{
+    void foo(ref int[] arr) {}
+
+    int[] arr = [1,2,3];
+    foo(arr);   //OK
+    static assert(!__traits(compiles, foo(arr[1..2]))); // should be NG
+
+    struct S
+    {
+        int[] a;
+        auto ref opSlice(){ return a[]; }  // line 4
+    }
+    S s;
+    s[];
+    // opSlice should return rvalue
+    static assert(is(typeof(&S.opSlice) == int[] function()));
+    static assert(!__traits(compiles, foo(s[])));       // should be NG
+}
+
+/***************************************************/
 // 2521
 
 immutable int val = 23;
@@ -5996,6 +6019,7 @@ int main()
     test8442();
     test86();
     test87();
+    test2486();
     test5554();
     test88();
     test7545();


### PR DESCRIPTION
[Issue 9413](http://d.puremagic.com/issues/show_bug.cgi?id=9413) - Incorrect modification inside contracts is not detected correctly
[Issue 9414](http://d.puremagic.com/issues/show_bug.cgi?id=9414) - Incorrect modification inside contracts is not detected on virtual function

To resolve duplicated error message issue (which described in bugzilla 9413), this pull request contains a refactoring commit.
