### PR TITLE
fix Issue 8832 - Segfault when accessing range returned by function that...

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -259,6 +259,7 @@ Dsymbol *Dsymbol::pastMixin()
 /**********************************
  * Use this instead of toParent() when looking for the
  * 'this' pointer of the enclosing function/class.
+ * This skips over both TemplateInstance's and TemplateMixin's.
  */
 
 Dsymbol *Dsymbol::toParent2()

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2192,6 +2192,35 @@ void test8774() {
 
 /*******************************************/
 
+int Bug8832(alias X)()
+{
+    return X();
+}
+
+int delegate() foo8832()
+{
+  int stack;
+  int heap = 3;
+
+  int nested_func()
+  {
+    ++heap;
+    return heap;
+  }
+  return delegate int() { return Bug8832!(nested_func); };
+}
+
+void test8832()
+{
+  auto z = foo8832();
+  auto p = foo8832();
+  assert(z() == 4);
+  p();
+  assert(z() == 5);
+}
+
+/*******************************************/
+
 int main()
 {
     test1();
@@ -2272,6 +2301,7 @@ int main()
     test9036();
 //    test8863();
     test8774();
+    test8832();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
... has delegate referencing local variables

This extends Don's earlier fix https://github.com/D-Programming-Language/dmd/pull/1554
 to cover this case as well.

Fix http://d.puremagic.com/issues/show_bug.cgi?id=8832
