### PR TITLE
test: Rename TEST_OUTPUT to COMPILE_OUTPUT

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -30,6 +30,16 @@
 #   PERMUTE_ARGS:        the set of arguments to permute in multiple $(DMD) invocations
 #                        default: the make variable ARGS (see below)
 #
+#   COMPILE_OUTPUT:      the output is expected from the compilation (if the
+#                        output of the compilation doesn't match, the test
+#                        fails). You can use the this format for multi-line
+#                        output:
+#                        COMPILE_OUTPUT:
+#                        ---
+#                        Some
+#                        Output
+#                        ---
+#
 #   POST_SCRIPT:         name of script to execute after test run
 #                        note: arguments to the script may be included after the name.
 #                              additionally, the name of the file that contains the output

--- a/test/compilable/bug6963.d
+++ b/test/compilable/bug6963.d
@@ -2,7 +2,7 @@
 // REQUIRED_ARGS:
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 output foo: 1e: pure nothrow @safe void(int x)
 output foo: 3e: pure nothrow @safe void(int x)

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -192,7 +192,7 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
 
     findTestParameter(file, "DISABLED", testArgs.disabled_reason);
 
-    findOutputParameter(file, "TEST_OUTPUT", testArgs.compileOutput, envData.sep);
+    findOutputParameter(file, "COMPILE_OUTPUT", testArgs.compileOutput, envData.sep);
 
     if (findTestParameter(file, "POST_SCRIPT", testArgs.postScript))
         testArgs.postScript = replace(testArgs.postScript, "/", to!string(envData.sep));

--- a/test/fail_compilation/bug4283.d
+++ b/test/fail_compilation/bug4283.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/bug4283.d(12): Error: Declaration expected, not '}'
 ---

--- a/test/fail_compilation/bug8891.d
+++ b/test/fail_compilation/bug8891.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/bug8891.d(21): Error: need 'this' for opCall type S(int n)
 ---

--- a/test/fail_compilation/depmsg.d
+++ b/test/fail_compilation/depmsg.d
@@ -1,6 +1,6 @@
 /*
 REQUIRED_ARGS: -de
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/depmsg.d(20): Deprecation: struct depmsg.main.Inner.A is deprecated - With message!
 fail_compilation/depmsg.d(20): Deprecation: struct depmsg.main.Inner.A is deprecated - With message!

--- a/test/fail_compilation/diag1730.d
+++ b/test/fail_compilation/diag1730.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag1730.d(38): Error: mutable method diag1730.S.func is not callable using a inout object
 fail_compilation/diag1730.d(40): Error: immutable method diag1730.S.iFunc is not callable using a inout object

--- a/test/fail_compilation/diag2452.d
+++ b/test/fail_compilation/diag2452.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag2452.d(14): Error: class diag2452.C interface function I.f(float p) isn't implemented
 ---

--- a/test/fail_compilation/diag4285.d
+++ b/test/fail_compilation/diag4285.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag4285.d(2): Error: template definitions aren't allowed inside functions
 fail_compilation/diag4285.d(3): Error: unrecognized declaration

--- a/test/fail_compilation/diag4540.d
+++ b/test/fail_compilation/diag4540.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag4540.d(4): Error: 'x' must be of integral or string type, it is a float
 ---

--- a/test/fail_compilation/diag5385.d
+++ b/test/fail_compilation/diag5385.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag5385.d(3): Error: class imports.fail5385.C member privX is not accessible
 fail_compilation/diag5385.d(4): Error: class imports.fail5385.C member packX is not accessible

--- a/test/fail_compilation/diag6373.d
+++ b/test/fail_compilation/diag6373.d
@@ -1,6 +1,6 @@
 /*
 REQUIRED_ARGS: -de
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag6373.d(7): Deprecation: class diag6373.Bar use of diag6373.Foo.method(double x) hidden by Bar is deprecated. Use 'alias Foo.method method;' to introduce base class overload set.
 ---

--- a/test/fail_compilation/diag6707.d
+++ b/test/fail_compilation/diag6707.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag6707.d(9): Error: mutable method diag6707.Foo.value is not callable using a const object
 ---

--- a/test/fail_compilation/diag6743.d
+++ b/test/fail_compilation/diag6743.d
@@ -1,6 +1,6 @@
 /*
 REQUIRED_ARGS: -run test.exe
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 Error: -run must be followed by a source file, not 'test.exe'
 ---

--- a/test/fail_compilation/diag7050a.d
+++ b/test/fail_compilation/diag7050a.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag7050a.d(5): Error: safe function 'diag7050a.foo' cannot call system function 'diag7050a.Foo.this'
 ---

--- a/test/fail_compilation/diag7050b.d
+++ b/test/fail_compilation/diag7050b.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag7050b.d(5): Error: pure function 'diag7050b.f.g' cannot call impure function 'diag7050b.f'
 ---

--- a/test/fail_compilation/diag7050c.d
+++ b/test/fail_compilation/diag7050c.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag7050c.d(7): Error: safe function 'diag7050c.B.~this' cannot call system function 'diag7050c.A.~this'
 ---

--- a/test/fail_compilation/diag7420.d
+++ b/test/fail_compilation/diag7420.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -m32
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag7420.d(3): Error: variable x cannot be read at compile time
 fail_compilation/diag7420.d(3):        while evaluating: static assert(x < 4)

--- a/test/fail_compilation/diag7998.d
+++ b/test/fail_compilation/diag7998.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag7998.d(3): Error: static assert  "abcxe"
 ---

--- a/test/fail_compilation/diag8178.d
+++ b/test/fail_compilation/diag8178.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8178.d(5): Error: Cannot modify '""'
 ---

--- a/test/fail_compilation/diag8354.d
+++ b/test/fail_compilation/diag8354.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8354.d(3): Error: must import std.math to use ^^ operator
 fail_compilation/diag8354.d(5): Error: must import std.math to use ^^ operator

--- a/test/fail_compilation/diag8510.d
+++ b/test/fail_compilation/diag8510.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8510.d(10): Error: alias diag8510.a conflicts with alias diag8510.a at fail_compilation/diag8510.d(9)
 fail_compilation/diag8510.d(15): Error: alias diag8510.S.a conflicts with alias diag8510.S.a at fail_compilation/diag8510.d(14)

--- a/test/fail_compilation/diag8559.d
+++ b/test/fail_compilation/diag8559.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8559.d(4): Error: void does not have a default initializer
 fail_compilation/diag8559.d(5): Error: function does not have a default initializer

--- a/test/fail_compilation/diag8629.d
+++ b/test/fail_compilation/diag8629.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -property
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8629.d(9): Error: no property 'gunc' for type 'S'
 ---

--- a/test/fail_compilation/diag8714.d
+++ b/test/fail_compilation/diag8714.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8714.d(1): Error: function diag8714.foo circular dependency. Functions cannot be interpreted while being compiled
 fail_compilation/diag8714.d(7):        called from here: foo("somestring")

--- a/test/fail_compilation/diag8770.d
+++ b/test/fail_compilation/diag8770.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8770.d(6): Error: this.f is not mutable
 ---

--- a/test/fail_compilation/diag8777a.d
+++ b/test/fail_compilation/diag8777a.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8777a.d(3): Error: constructor diag8777a.Foo.this missing initializer for immutable field bar
 ---

--- a/test/fail_compilation/diag8777b.d
+++ b/test/fail_compilation/diag8777b.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8777b.d(3): Error: constructor diag8777b.Foo.this missing initializer for const field bar
 ---

--- a/test/fail_compilation/diag8777c.d
+++ b/test/fail_compilation/diag8777c.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8777c.d(4): Error: cannot modify const expression x
 ---

--- a/test/fail_compilation/diag8777d.d
+++ b/test/fail_compilation/diag8777d.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8777d.d(4): Error: cannot modify immutable expression x
 ---

--- a/test/fail_compilation/diag8777e.d
+++ b/test/fail_compilation/diag8777e.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8777e.d(5): Error: cannot remove key from immutable associative array hash
 ---

--- a/test/fail_compilation/diag8777f.d
+++ b/test/fail_compilation/diag8777f.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8777f.d(5): Error: cannot remove key from const associative array hash
 ---

--- a/test/fail_compilation/diag8787.d
+++ b/test/fail_compilation/diag8787.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8787.d(3): Error: function diag8787.I.f function body only allowed in final functions in interface I
 ---

--- a/test/fail_compilation/diag8892.d
+++ b/test/fail_compilation/diag8892.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -m32
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8892.d(15): Error: cannot implicitly convert expression (['A']) of type char[] to char[2u]
 ---

--- a/test/fail_compilation/diag8894.d
+++ b/test/fail_compilation/diag8894.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8894.d(6): Error: no property 'x' for type 'Foo'
 fail_compilation/diag8894.d(7): Error: no property 'y' for type 'Foo'

--- a/test/fail_compilation/diag8928.d
+++ b/test/fail_compilation/diag8928.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag8928.d(7): Error: constructor diag8928.Y.this no match for implicit super() call in constructor
 fail_compilation/diag8928.d(10): Error: constructor diag8928.Z.this no match for implicit super() call in implicitly generated constructor

--- a/test/fail_compilation/diag9004.d
+++ b/test/fail_compilation/diag9004.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag9004.d(4): Error: undefined identifier FooT.T
 fail_compilation/diag9004.d(8): Error: template diag9004.bar does not match any function template declaration. Candidates are:

--- a/test/fail_compilation/diag9191.d
+++ b/test/fail_compilation/diag9191.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag9191.d(16): Error: function diag9191.C1.aaa does not override any function, did you mean to override 'diag9191.B1.aa'?
 fail_compilation/diag9191.d(21): Error: function diag9191.C2.aaa does not override any function, did you mean to override 'diag9191.I1.a'?

--- a/test/fail_compilation/diag9210a.d
+++ b/test/fail_compilation/diag9210a.d
@@ -2,7 +2,7 @@
 // PERMUTE_ARGS:
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/imports/diag9210b.d(6): Error: undefined identifier A, did you mean interface B?
 ---

--- a/test/fail_compilation/diag9250.d
+++ b/test/fail_compilation/diag9250.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -m32
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag9250.d(19): Error: cannot implicitly convert expression (10u) of type uint to Foo
 fail_compilation/diag9250.d(22): Error: cannot implicitly convert expression (10u) of type uint to void*

--- a/test/fail_compilation/diag9312.d
+++ b/test/fail_compilation/diag9312.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag9312.d(10): Error: with expressions must be aggregate types, not 'int'
 ---

--- a/test/fail_compilation/diag9358.d
+++ b/test/fail_compilation/diag9358.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag9358.d(12): Error: 'x' must be of integral or string type, it is a double
 fail_compilation/diag9358.d(14): Error: case must be a string or an integral constant, not 1.1

--- a/test/fail_compilation/diag9398.d
+++ b/test/fail_compilation/diag9398.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/diag9398.d(11): Error: incompatible types for ((f) : (s)): 'float' and 'string'
 ---

--- a/test/fail_compilation/fail3144.d
+++ b/test/fail_compilation/fail3144.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail3144.d(12): Error: break is not inside a loop or switch
 fail_compilation/fail3144.d(15): Error: break is not inside a loop or switch

--- a/test/fail_compilation/fail3703.d
+++ b/test/fail_compilation/fail3703.d
@@ -1,7 +1,7 @@
 // Issue 3703 - static array assignment
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail3703.d(15): Error: mismatched array lengths, 2 and 1
 ---

--- a/test/fail_compilation/fail44.d
+++ b/test/fail_compilation/fail44.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail44.d(18): Error: expression bar[i] is void and has no value
 ---

--- a/test/fail_compilation/fail61.d
+++ b/test/fail_compilation/fail61.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail61.d(22): Error: no property 'B' for type 'fail61.A.B', did you mean 'C'?
 fail_compilation/fail61.d(23): Error: no property 'B' for type 'fail61.A.B', did you mean 'C'?

--- a/test/fail_compilation/fail6652a.d
+++ b/test/fail_compilation/fail6652a.d
@@ -4,7 +4,7 @@
 // 6652
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail6652a.d(19): Deprecation: variable modified in foreach body requires ref storage class
 fail_compilation/fail6652a.d(24): Error: cannot modify const expression i

--- a/test/fail_compilation/fail6652b.d
+++ b/test/fail_compilation/fail6652b.d
@@ -4,7 +4,7 @@
 // 6652
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail6652b.d(19): Deprecation: variable modified in foreach body requires ref storage class
 fail_compilation/fail6652b.d(24): Error: cannot modify const expression i

--- a/test/fail_compilation/fail8631.d
+++ b/test/fail_compilation/fail8631.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail8631.d(14): Error: function fail8631.D.foo does not override any function, did you mean to override 'fail8631.B.foo'?
 ---

--- a/test/fail_compilation/fail9063.d
+++ b/test/fail_compilation/fail9063.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail9063.d(9): Error: static assert  "msg"
 ---

--- a/test/fail_compilation/fail9368.d
+++ b/test/fail_compilation/fail9368.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -d
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/fail9368.d(20): Error: enum member b not represented in final switch
 ---

--- a/test/fail_compilation/ice5996.d
+++ b/test/fail_compilation/ice5996.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice5996.d(8): Error: undefined identifier anyOldGarbage
 ---

--- a/test/fail_compilation/ice6538.d
+++ b/test/fail_compilation/ice6538.d
@@ -7,7 +7,7 @@ template allSatisfy(alias F, T...) { enum bool allSatisfy = true; }
 template isIntegral(T) { enum bool isIntegral = true; }
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice6538.d(18): Error: cannot take a not yet instantiated symbol 'sizes' inside template constraint
 fail_compilation/ice6538.d(23): Error: template ice6538.foo does not match any function template declaration. Candidates are:
@@ -24,7 +24,7 @@ void test6538a()
 }
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice6538.d(36): Error: cannot take a not yet instantiated symbol 't1' inside template constraint
 fail_compilation/ice6538.d(36): Error: cannot take a not yet instantiated symbol 't2' inside template constraint
@@ -50,7 +50,7 @@ template Sym(alias A)
 }
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice6538.d(63): Error: cannot take a not yet instantiated symbol 'this' inside template constraint
 fail_compilation/ice6538.d(69): Error: template ice6538.S.foo does not match any function template declaration. Candidates are:
@@ -71,7 +71,7 @@ void test9361a()
 }
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice6538.d(85): Error: cannot take a not yet instantiated symbol 'super' inside template constraint
 fail_compilation/ice6538.d(90): Error: template ice6538.D.foo does not match any function template declaration. Candidates are:

--- a/test/fail_compilation/ice9273a.d
+++ b/test/fail_compilation/ice9273a.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice9273a.d(19): Error: constructor ice9273a.C.__ctor!().this no match for implicit super() call in constructor
 fail_compilation/ice9273a.d(23): Error: template instance ice9273a.C.__ctor!() error instantiating

--- a/test/fail_compilation/ice9273b.d
+++ b/test/fail_compilation/ice9273b.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice9273b.d(14): Error: constructor ice9273b.B.this no match for implicit super() call in constructor
 ---

--- a/test/fail_compilation/ice9284.d
+++ b/test/fail_compilation/ice9284.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice9284.d(15): Error: template ice9284.C.__ctor does not match any function template declaration. Candidates are:
 fail_compilation/ice9284.d(13):        ice9284.C.__ctor()(string)

--- a/test/fail_compilation/ice9291.d
+++ b/test/fail_compilation/ice9291.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice9291.d(10): Error: undefined identifier F
 ---

--- a/test/fail_compilation/ice9338.d
+++ b/test/fail_compilation/ice9338.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/ice9338.d(13): Error: value of 'this' is not known at compile time
 fail_compilation/ice9338.d(14): Error: value of 'this' is not known at compile time

--- a/test/fail_compilation/test4838.d
+++ b/test/fail_compilation/test4838.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/test4838.d(13): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
 fail_compilation/test4838.d(14): Error: const/immutable/shared/inout attributes are only valid for non-static member functions

--- a/test/fail_compilation/test6883.d
+++ b/test/fail_compilation/test6883.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/test6883.d(15): Error: array index 5 is out of bounds x[0 .. 5]
 fail_compilation/test6883.d(17): Error: array index 7 is out of bounds x[0 .. 5]

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/test8556.d(44): Error: template test8556.grabExactly matches more than one template declaration, fail_compilation/test8556.d(30):grabExactly(R)(R range) if (!isSliceable!(R)) and fail_compilation/test8556.d(31):grabExactly(R)(R range) if (isSliceable!(R))
 fail_compilation/test8556.d(19): Error: template instance test8556.isSliceable!(Circle!(uint[])) error instantiating

--- a/test/fail_compilation/test8793.d
+++ b/test/fail_compilation/test8793.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/test8793.d(13): Error: cannot implicitly convert expression (__lambda2) of type bool delegate(const(int) x) @system to bool delegate(const(int)) pure
 fail_compilation/test8793.d(14): Error: cannot implicitly convert expression (__lambda4) of type bool delegate(const(int) x) @system to bool delegate(const(int)) pure

--- a/test/fail_compilation/test9150.d
+++ b/test/fail_compilation/test9150.d
@@ -1,7 +1,7 @@
 // Issue 9150 - Mismatching static array length should be detected in foreach
 
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/test9150.d(14): Error: mismatched array lengths, 5 and 3
 ---

--- a/test/fail_compilation/test9176.d
+++ b/test/fail_compilation/test9176.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/test9176.d(12): Error: forward reference to get
 ---

--- a/test/fail_compilation/test9230.d
+++ b/test/fail_compilation/test9230.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUTPUT:
+COMPILE_OUTPUT:
 ---
 fail_compilation/test9230.d(12): Error: cannot implicitly convert expression (s) of type const(char[]) to string
 fail_compilation/test9230.d(18): Error: cannot implicitly convert expression (a) of type int[] to immutable(int[])


### PR DESCRIPTION
The real meaning for TEST_OUTPUT is to provide the correct output from the
compiler, not the whole test. This is specially confusing for runnable
tests where someone could think this test parameter is used to check
against the program output. For this reason the test parameter is renamed
to COMPILE_OUTPUT (which is the same internal name d_do_test.d use).

Also the documentation in test/Makefile is updated to describe the
previously missing test parameter.
