### PR TITLE
Issue 9423 - Missed conversion of lambda literal with ref argument

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -182,7 +182,22 @@ void FuncDeclaration::semantic(Scope *sc)
 
     FuncLiteralDeclaration *fld = isFuncLiteralDeclaration();
     if (fld && fld->treq)
-        linkage = ((TypeFunction *)fld->treq->nextOf())->linkage;
+    {
+        TypeFunction *tfreq = (TypeFunction *)fld->treq->nextOf();
+        TypeFunction *tf = (TypeFunction *)type;
+        assert(tf->deco == NULL);
+
+        size_t nparams = Parameter::dim(tf->parameters);
+        assert(nparams == Parameter::dim(tfreq->parameters));
+        for (size_t i = 0; i < nparams; i++)
+        {
+            Parameter *prmv = Parameter::getNth(tfreq->parameters, i);
+            Parameter *prml = Parameter::getNth(tf->parameters, i);
+            prml->storageClass |= prmv->storageClass & (STCout | STCref | STClazy);
+        }
+
+        linkage = tfreq->linkage;
+    }
     else
         linkage = sc->linkage;
     protection = sc->protection;

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -717,6 +717,21 @@ void test9153()
 }
 
 /***************************************************/
+// 9423
+
+void foo9423(int delegate( ref int[1]) dg) {}
+void bar9423(int delegate( out long  ) dg) {}
+void baz9423(int delegate(lazy Object) dg) {}
+
+void test9423()
+{
+    foo9423((ref int[1] x) => 0); // OK
+    foo9423(x => 0); // Error
+    bar9423(x => 0); // Error
+    baz9423(x => 0); // Error
+}
+
+/***************************************************/
 
 int main()
 {
@@ -758,6 +773,7 @@ int main()
     test8496();
     test8575();
     test9153();
+    test9423();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9423

This is similar to [bug 8496](http://d.puremagic.com/issues/show_bug.cgi?id=8496), a lambda linkage and parameter storage classes should be inferred from its context as well.
