### PR TITLE
Fix issue 9289: Show deprecations even when gag is on

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -269,7 +269,7 @@ void vdeprecation(Loc loc, const char *format, va_list ap,
     static const char *header = "Deprecation: ";
     if (global.params.useDeprecated == 0)
         verror(loc, format, ap, p1, p2, header);
-    else if (global.params.useDeprecated == 2 && !global.gag)
+    else if (global.params.useDeprecated == 2)
         verrorPrint(loc, header, format, ap, p1, p2);
 }
 

--- a/test/runnable/depregag.d
+++ b/test/runnable/depregag.d
@@ -1,0 +1,14 @@
+// PERMUTE_ARGS: -dw
+/* COMPILE_OUTPUT:
+---
+runnable/depregag.d(10): Deprecation: using * on an array is deprecated; use *(arr).ptr instead
+---
+*/
+extern (C) int printf(char* msg, ...);
+void main() {
+    int[] arr;
+    static if (is(typeof({ auto ptr = *arr; })))
+        printf("*arr is still valid even if deprecated\n".dup.ptr);
+    else
+        assert(0, "*arr is not longer supported");
+}


### PR DESCRIPTION
Deprecations warnings should be shown everywhere, because if you are
using _any_ deprecated features (even in traits or static ifs) you
should be noticed.

This pull request will pass the test suite only when pull #1579 is merged.

I can update this if pull #1579 doesn't get accepted but this one does.
