### PR TITLE
Issue 9436 - enum cannot be forward referenced with cyclic imports and mixin

### DIFF
--- a/src/enum.c
+++ b/src/enum.c
@@ -53,6 +53,13 @@ Dsymbol *EnumDeclaration::syntaxCopy(Dsymbol *s)
     return ed;
 }
 
+void EnumDeclaration::setScope(Scope *sc)
+{
+    if (isdone)
+        return;
+    ScopeDsymbol::setScope(sc);
+}
+
 void EnumDeclaration::semantic0(Scope *sc)
 {
     /* This function is a hack to get around a significant problem.

--- a/src/enum.h
+++ b/src/enum.h
@@ -49,6 +49,7 @@ struct EnumDeclaration : ScopeDsymbol
 
     EnumDeclaration(Loc loc, Identifier *id, Type *memtype);
     Dsymbol *syntaxCopy(Dsymbol *s);
+    void setScope(Scope *sc);
     void semantic0(Scope *sc);
     void semantic(Scope *sc);
     int oneMember(Dsymbol **ps, Identifier *ident = NULL);

--- a/test/compilable/imports/test9436aggr.d
+++ b/test/compilable/imports/test9436aggr.d
@@ -1,0 +1,11 @@
+module imports.test9436aggr;
+
+import imports.test9436type;
+
+class Aggregate : Type
+{
+}
+
+class Class
+{
+}

--- a/test/compilable/imports/test9436interp.d
+++ b/test/compilable/imports/test9436interp.d
@@ -1,0 +1,16 @@
+module imports.test9436interp;
+
+import imports.test9436type;
+import imports.test9436aggr;
+
+class ReferenceValueT(T)
+{
+    void doCast()
+    {
+        auto x = Type.ConversionFlags.kAllowBaseClass;
+    }
+}
+
+class ClassValue : ReferenceValueT!Class
+{
+}

--- a/test/compilable/imports/test9436node.d
+++ b/test/compilable/imports/test9436node.d
@@ -1,0 +1,7 @@
+module imports.test9436node;
+
+import imports.test9436aggr;
+
+template ForwardCtor()
+{
+}

--- a/test/compilable/imports/test9436type.d
+++ b/test/compilable/imports/test9436type.d
@@ -1,0 +1,13 @@
+module imports.test9436type;
+
+import imports.test9436node;
+
+class Type
+{
+    mixin ForwardCtor!();
+
+    enum ConversionFlags
+    {
+        kAllowBaseClass = 0
+    }
+}

--- a/test/compilable/test9436.d
+++ b/test/compilable/test9436.d
@@ -1,0 +1,4 @@
+// REQUIRED_ARGS: -c compilable/imports/test9436interp.d
+
+// this is a dummy module for test 9436.
+


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9436

If `EnumDeclaration::isdone != 0`, `setScope` should do nothing.
