### PR TITLE
[fwdref bug] Issue 9441 - struct constructor missed on auto/type-inferred variable definition

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7994,14 +7994,18 @@ Lagain:
             ad = ((TypeStruct *)t1)->sym;
 #if DMDV2
 
-            if (ad->sizeok == SIZEOKnone && !ad->ctor &&
-                ad->search(0, Id::ctor, 0))
+            if (ad->sizeok == SIZEOKnone)
             {
-                // The constructor hasn't been found yet, see bug 8741
-                // This can happen if we are inferring type from
-                // from VarDeclaration::semantic() in declaration.c
-                error("cannot create a struct until its size is determined");
-                return new ErrorExp();
+                if (ad->scope)
+                    ad->semantic(ad->scope);
+                else if (!ad->ctor && ad->search(0, Id::ctor, 0))
+                {
+                    // The constructor hasn't been found yet, see bug 8741
+                    // This can happen if we are inferring type from
+                    // from VarDeclaration::semantic() in declaration.c
+                    error("cannot create a struct until its size is determined");
+                    return new ErrorExp();
+                }
             }
 
             // First look for constructor

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1128,7 +1128,7 @@ void test43()
 {
     int i;
     assert(!__traits(compiles, immutable(S43)(3, &i)));
-    immutable int j = 4; 
+    immutable int j = 4;
     auto s = immutable(S43)(3, &j);
     //writeln(typeid(typeof(s)));
     static assert(is(typeof(s) == immutable(S43)));
@@ -1146,7 +1146,7 @@ void test44()
 {
     int i;
     assert(!__traits(compiles, immutable(S44)(3, &i)));
-    immutable int j = 4; 
+    immutable int j = 4;
     auto s = immutable(S44)(3, &j);
     //writeln(typeid(typeof(s)));
     static assert(is(typeof(s) == immutable(S44)));
@@ -2375,7 +2375,7 @@ struct Foo9320 {
     real x;
 
     this(real x) {
-	this.x = x;
+        this.x = x;
     }
 
     Foo9320 opBinary(string op)(Foo9320 other) {
@@ -2385,6 +2385,22 @@ struct Foo9320 {
 
 Foo9320 test9320(Foo9320 a, Foo9320 b, Foo9320 c) {
     return (a + b) / (a * b) - c;
+}
+
+/**********************************/
+// 9441
+
+auto x9441 = X9441(0.123);
+
+struct X9441
+{
+    int a;
+    this(double x) { a = cast(int)(x * 100); }
+}
+
+void test9441()
+{
+    assert(x9441.a == 12);
 }
 
 /**********************************/
@@ -2470,6 +2486,7 @@ int main()
     test7579b();
     test8335();
     test8356();
+    test9441();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9441
