### PR TITLE
Isolate CFseg usage in common code

### DIFF
--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -580,10 +580,12 @@ size_t addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int fl
         if (I64 && !(flags & CFoffset64))
             numbytes = 4;
 
+#if TARGET_WINDOS
         /* This can happen when generating CV8 data
          */
         if (flags & CFseg)
             numbytes += 2;
+#endif
 #endif
 #ifdef DEBUG
         assert(numbytes <= sizeof(zeros));


### PR DESCRIPTION
Hide CFseg related code that's quixotically in !TARGET_SEGMENTED code inside TARGET_WINDOS for the time being.
