### PR TITLE
Add Tvalist for keeping reference of target va_list type.

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -25,10 +25,6 @@
 #include "template.h"
 #include "hdrgen.h"
 
-#ifdef IN_GCC
-#include "d-dmd-gcc.h"
-#endif
-
 /********************************* FuncDeclaration ****************************/
 
 FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type)
@@ -968,11 +964,7 @@ void FuncDeclaration::semantic3(Scope *sc)
             }
             if (f->linkage == LINKd || (f->parameters && Parameter::dim(f->parameters)))
             {   // Declare _argptr
-#ifdef IN_GCC
-                t = d_gcc_builtin_va_list_d_type;
-#else
-                t = Type::tvoid->pointerTo();
-#endif
+                t = Type::tvalist;
                 argptr = new VarDeclaration(0, t, Id::_argptr, NULL);
                 argptr->semantic(sc2);
                 sc2->insert(argptr);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -113,6 +113,7 @@ TemplateDeclaration *Type::rtinfo;
 
 Type *Type::tvoidptr;
 Type *Type::tstring;
+Type *Type::tvalist;
 Type *Type::basic[TMAX];
 unsigned char Type::mangleChar[TMAX];
 unsigned char Type::sizeTy[TMAX];
@@ -281,6 +282,7 @@ void Type::init()
 
     tvoidptr = tvoid->pointerTo();
     tstring = tchar->invariantOf()->arrayOf();
+    tvalist = tvoid->pointerTo();
 
     if (global.params.is64bit)
     {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -102,6 +102,7 @@ enum ENUMTY
     Tvector,
     Tint128,
     Tuns128,
+    Tvalist,
     TMAX
 };
 typedef unsigned char TY;       // ENUMTY


### PR DESCRIPTION
For the benefit of backends that define va_list as a different type to DMD.  Removes some more ifdef IN_GCC code from dfrontend.
