### PR TITLE
Target data structure - p1

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -15,6 +15,7 @@
 
 #include "root.h"
 #include "rmem.h"
+#include "target.h"
 
 #include "enum.h"
 #include "init.h"
@@ -620,11 +621,11 @@ void ClassDeclaration::semantic(Scope *sc)
     {   sc->offset = baseClass->structsize;
         alignsize = baseClass->alignsize;
 //      if (isnested)
-//          sc->offset += PTRSIZE;      // room for uplevel context pointer
+//          sc->offset += Target::ptrsize;      // room for uplevel context pointer
     }
     else
-    {   sc->offset = PTRSIZE * 2;       // allow room for __vptr and __monitor
-        alignsize = PTRSIZE;
+    {   sc->offset = Target::ptrsize * 2;       // allow room for __vptr and __monitor
+        alignsize = Target::ptrsize;
     }
     sc->userAttributes = NULL;
     structsize = sc->offset;
@@ -758,7 +759,7 @@ void ClassDeclaration::semantic(Scope *sc)
     for (size_t i = 0; i < vtblInterfaces->dim; i++)
     {
         BaseClass *b = (*vtblInterfaces)[i];
-        unsigned thissize = PTRSIZE;
+        unsigned thissize = Target::ptrsize;
 
         alignmember(STRUCTALIGN_DEFAULT, thissize, &sc->offset);
         assert(b->offset == 0);
@@ -1423,7 +1424,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
     sc->protection = PROTpublic;
     sc->explicitProtection = 0;
 //    structalign = sc->structalign;
-    sc->offset = PTRSIZE * 2;
+    sc->offset = Target::ptrsize * 2;
     sc->userAttributes = NULL;
     structsize = sc->offset;
     inuse++;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -14,6 +14,7 @@
 //#include        <complex.h>
 
 #include        "port.h"
+#include        "target.h"
 
 #include        "lexer.h"
 #include        "expression.h"
@@ -3551,7 +3552,7 @@ elem *DelegateExp::toElem(IRState *irs)
             assert((int)vindex >= 0);
 
             // Build *(ep + vindex * 4)
-            ep = el_bin(OPadd,TYnptr,ep,el_long(TYsize_t, vindex * PTRSIZE));
+            ep = el_bin(OPadd,TYnptr,ep,el_long(TYsize_t, vindex * Target::ptrsize));
             ep = el_una(OPind,TYnptr,ep);
         }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -25,6 +25,7 @@ extern "C" char * __cdecl __locale_decpoint;
 #include "rmem.h"
 #include "port.h"
 #include "root.h"
+#include "target.h"
 
 #include "mtype.h"
 #include "init.h"
@@ -2145,9 +2146,9 @@ dinteger_t IntegerExp::toInteger()
             case Tint64:        value = (d_int64) value;        break;
             case Tuns64:        value = (d_uns64) value;        break;
             case Tpointer:
-                if (PTRSIZE == 4)
+                if (Target::ptrsize == 4)
                     value = (d_uns32) value;
-                else if (PTRSIZE == 8)
+                else if (Target::ptrsize == 8)
                     value = (d_uns64) value;
                 else
                     assert(0);
@@ -2331,9 +2332,9 @@ void IntegerExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
                 buf->writestring("cast(");
                 buf->writestring(t->toChars());
                 buf->writeByte(')');
-                if (PTRSIZE == 4)
+                if (Target::ptrsize == 4)
                     goto L3;
-                else if (PTRSIZE == 8)
+                else if (Target::ptrsize == 8)
                     goto L4;
                 else
                     assert(0);
@@ -2474,7 +2475,7 @@ int RealEquals(real_t x1, real_t x2)
         /* In some cases, the REALPAD bytes get garbage in them,
          * so be sure and ignore them.
          */
-        memcmp(&x1, &x2, REALSIZE - REALPAD) == 0;
+        memcmp(&x1, &x2, Target::realsize - Target::realpad) == 0;
 }
 
 int RealExp::equals(Object *o)

--- a/src/func.c
+++ b/src/func.c
@@ -24,6 +24,7 @@
 #include "statement.h"
 #include "template.h"
 #include "hdrgen.h"
+#include "target.h"
 
 /********************************* FuncDeclaration ****************************/
 
@@ -1467,7 +1468,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                          */
                         while (p->storage_class & (STCout | STCref))
                         {
-                            offset += PTRSIZE;
+                            offset += Target::ptrsize;
                             if (lastNonref-- == 0)
                             {
                                 p = v_arguments;
@@ -1479,7 +1480,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     else
                         p = v_arguments;            // last parameter is _arguments[]
                     if (global.params.is64bit && global.params.isWindows)
-                    {   offset += PTRSIZE;
+                    {   offset += Target::ptrsize;
                     if (p->storage_class & STClazy)
                         {
                             /* Necessary to offset the extra level of indirection the Win64
@@ -1496,10 +1497,10 @@ void FuncDeclaration::semantic3(Scope *sc)
                     }
                     else if (p->storage_class & STClazy)
                         // If the last parameter is lazy, it's the size of a delegate
-                        offset += PTRSIZE * 2;
+                        offset += Target::ptrsize * 2;
                     else
                         offset += p->type->size();
-                    offset = (offset + PTRSIZE - 1) & ~(PTRSIZE - 1);  // assume stack aligns on pointer size
+                    offset = (offset + Target::ptrsize - 1) & ~(Target::ptrsize - 1);  // assume stack aligns on pointer size
                     e = new SymOffExp(0, p, offset);
                     e->type = Type::tvoidptr;
                     //e = e->semantic(sc);

--- a/src/glue.c
+++ b/src/glue.c
@@ -23,6 +23,7 @@
 #include "import.h"
 #include "template.h"
 #include "lib.h"
+#include "target.h"
 
 #include "rmem.h"
 #include "cc.h"
@@ -1282,7 +1283,7 @@ Symbol *Module::gencritsec()
     s->Sfl = FLdata;
     /* Must match D_CRITICAL_SECTION in phobos/internal/critical.c
      */
-    dtnzeros(&s->Sdt, PTRSIZE + (I64 ? os_critsecsize64() : os_critsecsize32()));
+    dtnzeros(&s->Sdt, Target::ptrsize + (I64 ? os_critsecsize64() : os_critsecsize32()));
     outdata(s);
     return s;
 }

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -36,6 +36,7 @@
 #include        "init.h"
 #include        "enum.h"
 #include        "module.h"
+#include        "target.h"
 
 // C/C++ compiler
 #define SCOPE_H 1               // avoid conflicts with D's Scope
@@ -2166,7 +2167,7 @@ STATIC opflag_t asm_float_type_size(Type *ptype, opflag_t *pusFloat)
     if (ptype && ptype->isscalar())
     {
         int sz = (int)ptype->size();
-        if (sz == REALSIZE)
+        if (sz == Target::realsize)
         {   *pusFloat = _f80;
             return 0;
         }

--- a/src/mars.c
+++ b/src/mars.c
@@ -23,6 +23,7 @@
 #include "rmem.h"
 #include "root.h"
 #include "async.h"
+#include "target.h"
 
 #include "mars.h"
 #include "module.h"
@@ -1049,6 +1050,7 @@ int tryMain(size_t argc, char *argv[])
     Type::init();
     Id::initialize();
     Module::init();
+    Target::init();
     initPrecedence();
 
     if (global.params.verbose)

--- a/src/msc.c
+++ b/src/msc.c
@@ -27,7 +27,6 @@ static char __file__[] = __FILE__;      /* for tassert.h                */
 
 
 extern Global global;
-extern int REALSIZE;
 
 Config config;
 Configv configv;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -1053,10 +1053,6 @@ struct Parameter : Object
     static int foreach(Parameters *args, ForeachDg dg, void *ctx, size_t *pn=NULL);
 };
 
-extern int PTRSIZE;
-extern int REALSIZE;
-extern int REALPAD;
-extern int REALALIGNSIZE;
 extern int Tsize_t;
 extern int Tptrdiff_t;
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -107,7 +107,7 @@ DMD_OBJS = \
 	builtin.o ctfeexpr.o clone.o aliasthis.o \
 	man.o arrayop.o port.o response.o async.o json.o speller.o aav.o unittests.o \
 	imphint.o argtypes.o ti_pvoid.o apply.o sideeffect.o \
-	intrange.o canthrow.o \
+	intrange.o canthrow.o target.o \
 	pdata.o cv8.o backconfig.o \
 	$(TARGET_OBJS)
 
@@ -136,7 +136,7 @@ SRC = win32.mak posix.mak \
 	libmscoff.c \
 	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c \
 	argtypes.c apply.c sideeffect.c \
-	intrange.h intrange.c canthrow.c \
+	intrange.h intrange.c canthrow.c target.c target.h \
 	scanmscoff.c ctfe.h ctfeexpr.c \
 	$C/cdef.h $C/cc.h $C/oper.h $C/ty.h $C/optabgen.c \
 	$C/global.h $C/code.h $C/type.h $C/dt.h $C/cgcv.h \
@@ -578,6 +578,9 @@ strtold.o: $C/strtold.c
 struct.o: struct.c
 	$(CC) -c $(CFLAGS) $<
 
+target.o: target.c target.h
+	$(CC) -c $(CFLAGS) $<
+
 template.o: template.c
 	$(CC) -c $(CFLAGS) $<
 
@@ -703,6 +706,7 @@ endif
 	gcov utf.c
 	gcov version.c
 	gcov intrange.c
+	gcov target.c
 
 #	gcov hdrgen.c
 #	gcov tocvdebug.c

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -33,6 +33,7 @@
 #include        "dt.h"
 
 #include        "rmem.h"
+#include        "target.h"
 
 static char __file__[] = __FILE__;      // for tassert.h
 #include        "tassert.h"
@@ -583,7 +584,7 @@ void SwitchStatement::toIR(IRState *irs)
         dt_t *dt = NULL;
         Symbol *si = symbol_generate(SCstatic,type_fake(TYdarray));
         dtsize_t(&dt, numcases);
-        dtxoff(&dt, si, PTRSIZE * 2, TYnptr);
+        dtxoff(&dt, si, Target::ptrsize * 2, TYnptr);
 
         for (size_t i = 0; i < numcases; i++)
         {   CaseStatement *cs = (*cases)[i];

--- a/src/statement.c
+++ b/src/statement.c
@@ -13,6 +13,7 @@
 #include <assert.h>
 
 #include "rmem.h"
+#include "target.h"
 
 #include "statement.h"
 #include "expression.h"
@@ -2200,7 +2201,7 @@ Lagain:
                 Expressions *exps = new Expressions();
                 exps->push(aggr);
                 size_t keysize = taa->index->size();
-                keysize = (keysize + ((size_t)PTRSIZE-1)) & ~((size_t)PTRSIZE-1);
+                keysize = (keysize + ((size_t)Target::ptrsize-1)) & ~((size_t)Target::ptrsize-1);
                 exps->push(new IntegerExp(0, keysize, Type::tsize_t));
                 exps->push(flde);
                 e = new CallExp(loc, ec, exps);
@@ -4400,7 +4401,7 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
          *  try { body } finally { _d_criticalexit(critsec.ptr); }
          */
         Identifier *id = Lexer::uniqueId("__critsec");
-        Type *t = new TypeSArray(Type::tint8, new IntegerExp(PTRSIZE + (global.params.is64bit ? os_critsecsize64() : os_critsecsize32())));
+        Type *t = new TypeSArray(Type::tint8, new IntegerExp(Target::ptrsize + (global.params.is64bit ? os_critsecsize64() : os_critsecsize32())));
         VarDeclaration *tmp = new VarDeclaration(loc, t, id, NULL);
         tmp->storage_class |= STCgshared | STCstatic;
 

--- a/src/target.c
+++ b/src/target.c
@@ -1,0 +1,60 @@
+
+// Copyright (c) 2013 by Digital Mars
+// All Rights Reserved
+// written by Iain Buclaw
+// http://www.digitalmars.com
+// License for redistribution is by either the Artistic License
+// in artistic.txt, or the GNU General Public License in gnu.txt.
+// See the included readme.txt for details.
+
+#include <assert.h>
+
+#include "target.h"
+#include "mars.h"
+
+int Target::ptrsize;
+int Target::realsize;
+int Target::realpad;
+int Target::realalignsize;
+
+
+void Target::init()
+{
+    // These have default values for 32 bit code, they get
+    // adjusted for 64 bit code.
+    ptrsize = 4;
+
+    if (global.params.isLinux || global.params.isFreeBSD
+        || global.params.isOpenBSD || global.params.isSolaris)
+    {
+        realsize = 12;
+        realpad = 2;
+        realalignsize = 4;
+    }
+    else if (global.params.isOSX)
+    {
+        realsize = 16;
+        realpad = 6;
+        realalignsize = 16;
+    }
+    else if (global.params.isWindows)
+    {
+        realsize = 10;
+        realpad = 0;
+        realalignsize = 2;
+    }
+    else
+        assert(0);
+
+    if (global.params.is64bit)
+    {
+        ptrsize = 8;
+        if (global.params.isLinux || global.params.isFreeBSD || global.params.isSolaris)
+        {
+            realsize = 16;
+            realpad = 6;
+            realalignsize = 16;
+        }
+    }
+}
+

--- a/src/target.h
+++ b/src/target.h
@@ -1,0 +1,27 @@
+
+// Copyright (c) 2013 by Digital Mars
+// All Rights Reserved
+// written by Iain Buclaw
+// http://www.digitalmars.com
+// License for redistribution is by either the Artistic License
+// in artistic.txt, or the GNU General Public License in gnu.txt.
+// See the included readme.txt for details.
+
+#ifndef TARGET_H
+#define TARGET_H
+
+// This file contains a data structure that describes a back-end target.
+// At present it is incomplete, but in future it should grow to contain
+// most or all target machine and target O/S specific information.
+
+struct Target
+{
+    static int ptrsize;
+    static int realsize;        // size a real consumes in memory
+    static int realpad;         // 'padding' added to the CPU real size to bring it up to realsize
+    static int realalignsize;   // alignment for reals
+    
+    static void init();
+};
+
+#endif

--- a/src/tocvdebug.c
+++ b/src/tocvdebug.c
@@ -23,6 +23,7 @@
 #include "template.h"
 
 #include "rmem.h"
+#include "target.h"
 #include "cc.h"
 #include "global.h"
 #include "oper.h"
@@ -907,7 +908,7 @@ int FuncDeclaration::cvMember(unsigned char *p)
             TOIDX(q, cv4_memfunctypidx(this));
             q += cgcv.sz_idx;
             if (introducing)
-            {   TOLONG(q, vtblIndex * PTRSIZE);
+            {   TOLONG(q, vtblIndex * Target::ptrsize);
                 q += 4;
             }
         }

--- a/src/todt.c
+++ b/src/todt.c
@@ -28,6 +28,7 @@
 #include        "enum.h"
 #include        "aggregate.h"
 #include        "declaration.h"
+#include        "target.h"
 
 
 // Back end
@@ -332,9 +333,9 @@ dt_t **RealExp::toDt(dt_t **pdt)
         case Tfloat80:
         case Timaginary80:
         {   d_float80 evalue = value;
-            pdt = dtnbytes(pdt,REALSIZE - REALPAD,(char *)&evalue);
-            pdt = dtnbytes(pdt,REALPAD,zeropad);
-            assert(REALPAD <= sizeof(zeropad));
+            pdt = dtnbytes(pdt,Target::realsize - Target::realpad,(char *)&evalue);
+            pdt = dtnbytes(pdt,Target::realpad,zeropad);
+            assert(Target::realpad <= sizeof(zeropad));
             break;
         }
 
@@ -371,11 +372,11 @@ dt_t **ComplexExp::toDt(dt_t **pdt)
 
         case Tcomplex80:
         {   d_float80 evalue = creall(value);
-            pdt = dtnbytes(pdt,REALSIZE - REALPAD,(char *)&evalue);
-            pdt = dtnbytes(pdt,REALPAD,zeropad);
+            pdt = dtnbytes(pdt,Target::realsize - Target::realpad,(char *)&evalue);
+            pdt = dtnbytes(pdt,Target::realpad,zeropad);
             evalue = cimagl(value);
-            pdt = dtnbytes(pdt,REALSIZE - REALPAD,(char *)&evalue);
-            pdt = dtnbytes(pdt,REALPAD,zeropad);
+            pdt = dtnbytes(pdt,Target::realsize - Target::realpad,(char *)&evalue);
+            pdt = dtnbytes(pdt,Target::realpad,zeropad);
             break;
         }
 
@@ -695,7 +696,7 @@ void ClassDeclaration::toDt2(dt_t **pdt, ClassDeclaration *cd)
     }
     else
     {
-        offset = PTRSIZE * 2;
+        offset = Target::ptrsize * 2;
     }
 
     // Note equivalence of this loop to struct's
@@ -760,7 +761,7 @@ void ClassDeclaration::toDt2(dt_t **pdt, ClassDeclaration *cd)
         assert(csymoffset != ~0);
         dtxoff(pdt, csym, csymoffset);
 #endif
-        offset = b->offset + PTRSIZE;
+        offset = b->offset + Target::ptrsize;
     }
 
     if (offset < structsize)
@@ -784,7 +785,7 @@ void StructDeclaration::toDt(dt_t **pdt)
 
         if (v->storage_class & STCref)
         {
-            sz = PTRSIZE;
+            sz = Target::ptrsize;
             if (v->offset >= offset)
                 dtnzeros(&dt, sz);
         }

--- a/src/toir.c
+++ b/src/toir.c
@@ -28,6 +28,7 @@
 #include        "module.h"
 #include        "init.h"
 #include        "template.h"
+#include        "target.h"
 
 #include        "mem.h" // for mem_malloc
 
@@ -693,7 +694,7 @@ void FuncDeclaration::buildClosure(IRState *irs)
         symbol_add(sclosure);
         irs->sclosure = sclosure;
 
-        unsigned offset = PTRSIZE;      // leave room for previous sthis
+        unsigned offset = Target::ptrsize;      // leave room for previous sthis
         for (size_t i = 0; i < closureVars.dim; i++)
         {   VarDeclaration *v = closureVars[i];
             //printf("closure var %s\n", v->toChars());
@@ -723,7 +724,7 @@ void FuncDeclaration::buildClosure(IRState *irs)
                 /* Lazy variables are really delegates,
                  * so give same answers that TypeDelegate would
                  */
-                memsize = PTRSIZE * 2;
+                memsize = Target::ptrsize * 2;
                 memalignsize = memsize;
                 xalign = global.structalign;
             }
@@ -735,7 +736,7 @@ void FuncDeclaration::buildClosure(IRState *irs)
             }
             else if (ISREF(v, NULL))
             {    // reference parameters are just pointers
-                memsize = PTRSIZE;
+                memsize = Target::ptrsize;
                 memalignsize = memsize;
                 xalign = global.structalign;
             }

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -26,6 +26,7 @@
 #include "template.h"
 
 #include "rmem.h"
+#include "target.h"
 #include "cc.h"
 #include "global.h"
 #include "oper.h"
@@ -48,12 +49,12 @@ void Module::genmoduleinfo()
 
     Symbol *msym = toSymbol();
 #if DMDV2
-    unsigned sizeof_ModuleInfo = 16 * PTRSIZE;
+    unsigned sizeof_ModuleInfo = 16 * Target::ptrsize;
 #else
-    unsigned sizeof_ModuleInfo = 14 * PTRSIZE;
+    unsigned sizeof_ModuleInfo = 14 * Target::ptrsize;
 #endif
 #if !MODULEINFO_IS_STRUCT
-    sizeof_ModuleInfo -= 2 * PTRSIZE;
+    sizeof_ModuleInfo -= 2 * Target::ptrsize;
 #endif
     //printf("moduleinfo size = x%x\n", sizeof_ModuleInfo);
 
@@ -235,7 +236,7 @@ void Module::genmoduleinfo()
     // localClasses[]
     dtdword(&dt, aclasses.dim);
     if (aclasses.dim)
-        dtxoff(&dt, csym, sizeof_ModuleInfo + aimports_dim * PTRSIZE, TYnptr);
+        dtxoff(&dt, csym, sizeof_ModuleInfo + aimports_dim * Target::ptrsize, TYnptr);
     else
         dtdword(&dt, 0);
 
@@ -608,7 +609,7 @@ void ClassDeclaration::toObjFile(int multiobj)
     // Put out (*vtblInterfaces)[]. Must immediately follow csym, because
     // of the fixup (*)
 
-    offset += vtblInterfaces->dim * (4 * PTRSIZE);
+    offset += vtblInterfaces->dim * (4 * Target::ptrsize);
     for (size_t i = 0; i < vtblInterfaces->dim; i++)
     {   BaseClass *b = (*vtblInterfaces)[i];
         ClassDeclaration *id = b->base;
@@ -633,7 +634,7 @@ void ClassDeclaration::toObjFile(int multiobj)
 
         dtsize_t(&dt, b->offset);                        // this offset
 
-        offset += id->vtbl.dim * PTRSIZE;
+        offset += id->vtbl.dim * Target::ptrsize;
     }
 
     // Put out the (*vtblInterfaces)[].vtbl[]
@@ -651,7 +652,7 @@ void ClassDeclaration::toObjFile(int multiobj)
             //dtxoff(&dt, id->toSymbol(), 0, TYnptr);
 
             // First entry is struct Interface reference
-            dtxoff(&dt, csym, classinfo_size + i * (4 * PTRSIZE), TYnptr);
+            dtxoff(&dt, csym, classinfo_size + i * (4 * Target::ptrsize), TYnptr);
             j = 1;
         }
         assert(id->vtbl.dim == b->vtbl.dim);
@@ -700,7 +701,7 @@ void ClassDeclaration::toObjFile(int multiobj)
                     //dtxoff(&dt, id->toSymbol(), 0, TYnptr);
 
                     // First entry is struct Interface reference
-                    dtxoff(&dt, cd->toSymbol(), classinfo_size + k * (4 * PTRSIZE), TYnptr);
+                    dtxoff(&dt, cd->toSymbol(), classinfo_size + k * (4 * Target::ptrsize), TYnptr);
                     j = 1;
                 }
 
@@ -744,7 +745,7 @@ void ClassDeclaration::toObjFile(int multiobj)
                         //dtxoff(&dt, id->toSymbol(), 0, TYnptr);
 
                         // First entry is struct Interface reference
-                        dtxoff(&dt, cd->toSymbol(), classinfo_size + k * (4 * PTRSIZE), TYnptr);
+                        dtxoff(&dt, cd->toSymbol(), classinfo_size + k * (4 * Target::ptrsize), TYnptr);
                         j = 1;
                     }
 
@@ -838,7 +839,7 @@ unsigned ClassDeclaration::baseVtblOffset(BaseClass *bc)
 
     //printf("ClassDeclaration::baseVtblOffset('%s', bc = %p)\n", toChars(), bc);
     csymoffset = global.params.is64bit ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
-    csymoffset += vtblInterfaces->dim * (4 * PTRSIZE);
+    csymoffset += vtblInterfaces->dim * (4 * Target::ptrsize);
 
     for (size_t i = 0; i < vtblInterfaces->dim; i++)
     {
@@ -846,7 +847,7 @@ unsigned ClassDeclaration::baseVtblOffset(BaseClass *bc)
 
         if (b == bc)
             return csymoffset;
-        csymoffset += b->base->vtbl.dim * PTRSIZE;
+        csymoffset += b->base->vtbl.dim * Target::ptrsize;
     }
 
 #if 1
@@ -867,7 +868,7 @@ unsigned ClassDeclaration::baseVtblOffset(BaseClass *bc)
                 {   //printf("\tcsymoffset = x%x\n", csymoffset);
                     return csymoffset;
                 }
-                csymoffset += bs->base->vtbl.dim * PTRSIZE;
+                csymoffset += bs->base->vtbl.dim * Target::ptrsize;
             }
         }
     }
@@ -888,7 +889,7 @@ unsigned ClassDeclaration::baseVtblOffset(BaseClass *bc)
                     return csymoffset;
                 }
                 if (b->base == bs->base)
-                    csymoffset += bs->base->vtbl.dim * PTRSIZE;
+                    csymoffset += bs->base->vtbl.dim * Target::ptrsize;
             }
         }
     }
@@ -1045,7 +1046,7 @@ void InterfaceDeclaration::toObjFile(int multiobj)
     // Put out (*vtblInterfaces)[]. Must immediately follow csym, because
     // of the fixup (*)
 
-    offset += vtblInterfaces->dim * (4 * PTRSIZE);
+    offset += vtblInterfaces->dim * (4 * Target::ptrsize);
     for (size_t i = 0; i < vtblInterfaces->dim; i++)
     {   BaseClass *b = (*vtblInterfaces)[i];
         ClassDeclaration *id = b->base;

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -25,6 +25,7 @@
 #include "enum.h"
 #include "import.h"
 #include "aggregate.h"
+#include "target.h"
 
 #include "dt.h"
 
@@ -233,7 +234,7 @@ TypeInfoDeclaration *TypeTuple::getTypeInfoDeclaration()
 void TypeInfoDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoDeclaration::toDt() %s\n", toChars());
-    verifyStructSize(Type::typeinfo, 2 * PTRSIZE);
+    verifyStructSize(Type::typeinfo, 2 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfo->toVtblSymbol(), 0); // vtbl for TypeInfo
     dtsize_t(pdt, 0);                        // monitor
@@ -243,7 +244,7 @@ void TypeInfoDeclaration::toDt(dt_t **pdt)
 void TypeInfoConstDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoConstDeclaration::toDt() %s\n", toChars());
-    verifyStructSize(Type::typeinfoconst, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfoconst, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfoconst->toVtblSymbol(), 0); // vtbl for TypeInfo_Const
     dtsize_t(pdt, 0);                        // monitor
@@ -256,7 +257,7 @@ void TypeInfoConstDeclaration::toDt(dt_t **pdt)
 void TypeInfoInvariantDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoInvariantDeclaration::toDt() %s\n", toChars());
-    verifyStructSize(Type::typeinfoinvariant, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfoinvariant, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfoinvariant->toVtblSymbol(), 0); // vtbl for TypeInfo_Invariant
     dtsize_t(pdt, 0);                        // monitor
@@ -269,7 +270,7 @@ void TypeInfoInvariantDeclaration::toDt(dt_t **pdt)
 void TypeInfoSharedDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoSharedDeclaration::toDt() %s\n", toChars());
-    verifyStructSize(Type::typeinfoshared, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfoshared, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfoshared->toVtblSymbol(), 0); // vtbl for TypeInfo_Shared
     dtsize_t(pdt, 0);                        // monitor
@@ -282,7 +283,7 @@ void TypeInfoSharedDeclaration::toDt(dt_t **pdt)
 void TypeInfoWildDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoWildDeclaration::toDt() %s\n", toChars());
-    verifyStructSize(Type::typeinfowild, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfowild, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfowild->toVtblSymbol(), 0); // vtbl for TypeInfo_Wild
     dtsize_t(pdt, 0);                        // monitor
@@ -297,7 +298,7 @@ void TypeInfoWildDeclaration::toDt(dt_t **pdt)
 void TypeInfoTypedefDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoTypedefDeclaration::toDt() %s\n", toChars());
-    verifyStructSize(Type::typeinfotypedef, 7 * PTRSIZE);
+    verifyStructSize(Type::typeinfotypedef, 7 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfotypedef->toVtblSymbol(), 0); // vtbl for TypeInfo_Typedef
     dtsize_t(pdt, 0);                        // monitor
@@ -340,7 +341,7 @@ void TypeInfoTypedefDeclaration::toDt(dt_t **pdt)
 void TypeInfoEnumDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoEnumDeclaration::toDt()\n");
-    verifyStructSize(Type::typeinfoenum, 7 * PTRSIZE);
+    verifyStructSize(Type::typeinfoenum, 7 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfoenum->toVtblSymbol(), 0); // vtbl for TypeInfo_Enum
     dtsize_t(pdt, 0);                        // monitor
@@ -384,7 +385,7 @@ void TypeInfoEnumDeclaration::toDt(dt_t **pdt)
 void TypeInfoPointerDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoPointerDeclaration::toDt()\n");
-    verifyStructSize(Type::typeinfopointer, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfopointer, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfopointer->toVtblSymbol(), 0); // vtbl for TypeInfo_Pointer
     dtsize_t(pdt, 0);                        // monitor
@@ -400,7 +401,7 @@ void TypeInfoPointerDeclaration::toDt(dt_t **pdt)
 void TypeInfoArrayDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoArrayDeclaration::toDt()\n");
-    verifyStructSize(Type::typeinfoarray, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfoarray, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfoarray->toVtblSymbol(), 0); // vtbl for TypeInfo_Array
     dtsize_t(pdt, 0);                        // monitor
@@ -416,7 +417,7 @@ void TypeInfoArrayDeclaration::toDt(dt_t **pdt)
 void TypeInfoStaticArrayDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoStaticArrayDeclaration::toDt()\n");
-    verifyStructSize(Type::typeinfostaticarray, 4 * PTRSIZE);
+    verifyStructSize(Type::typeinfostaticarray, 4 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfostaticarray->toVtblSymbol(), 0); // vtbl for TypeInfo_StaticArray
     dtsize_t(pdt, 0);                        // monitor
@@ -434,7 +435,7 @@ void TypeInfoStaticArrayDeclaration::toDt(dt_t **pdt)
 void TypeInfoVectorDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoVectorDeclaration::toDt()\n");
-    verifyStructSize(Type::typeinfovector, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfovector, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfovector->toVtblSymbol(), 0); // vtbl for TypeInfo_Vector
     dtsize_t(pdt, 0);                        // monitor
@@ -451,9 +452,9 @@ void TypeInfoAssociativeArrayDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoAssociativeArrayDeclaration::toDt()\n");
 #if DMDV2
-    verifyStructSize(Type::typeinfoassociativearray, 5 * PTRSIZE);
+    verifyStructSize(Type::typeinfoassociativearray, 5 * Target::ptrsize);
 #else
-    verifyStructSize(Type::typeinfoassociativearray, 4 * PTRSIZE);
+    verifyStructSize(Type::typeinfoassociativearray, 4 * Target::ptrsize);
 #endif
 
     dtxoff(pdt, Type::typeinfoassociativearray->toVtblSymbol(), 0); // vtbl for TypeInfo_AssociativeArray
@@ -478,7 +479,7 @@ void TypeInfoAssociativeArrayDeclaration::toDt(dt_t **pdt)
 void TypeInfoFunctionDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoFunctionDeclaration::toDt()\n");
-    verifyStructSize(Type::typeinfofunction, 5 * PTRSIZE);
+    verifyStructSize(Type::typeinfofunction, 5 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfofunction->toVtblSymbol(), 0); // vtbl for TypeInfo_Function
     dtsize_t(pdt, 0);                        // monitor
@@ -500,7 +501,7 @@ void TypeInfoFunctionDeclaration::toDt(dt_t **pdt)
 void TypeInfoDelegateDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoDelegateDeclaration::toDt()\n");
-    verifyStructSize(Type::typeinfodelegate, 5 * PTRSIZE);
+    verifyStructSize(Type::typeinfodelegate, 5 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfodelegate->toVtblSymbol(), 0); // vtbl for TypeInfo_Delegate
     dtsize_t(pdt, 0);                        // monitor
@@ -523,9 +524,9 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoStructDeclaration::toDt() '%s'\n", toChars());
     if (global.params.is64bit)
-        verifyStructSize(Type::typeinfostruct, 17 * PTRSIZE);
+        verifyStructSize(Type::typeinfostruct, 17 * Target::ptrsize);
     else
-        verifyStructSize(Type::typeinfostruct, 15 * PTRSIZE);
+        verifyStructSize(Type::typeinfostruct, 15 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfostruct->toVtblSymbol(), 0); // vtbl for TypeInfo_Struct
     dtsize_t(pdt, 0);                        // monitor
@@ -727,7 +728,7 @@ void TypeInfoClassDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoClassDeclaration::toDt() %s\n", tinfo->toChars());
 #if DMDV1
-    verifyStructSize(Type::typeinfoclass, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfoclass, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfoclass->toVtblSymbol(), 0); // vtbl for TypeInfoClass
     dtsize_t(pdt, 0);                        // monitor
@@ -749,7 +750,7 @@ void TypeInfoClassDeclaration::toDt(dt_t **pdt)
 void TypeInfoInterfaceDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoInterfaceDeclaration::toDt() %s\n", tinfo->toChars());
-    verifyStructSize(Type::typeinfointerface, 3 * PTRSIZE);
+    verifyStructSize(Type::typeinfointerface, 3 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfointerface->toVtblSymbol(), 0); // vtbl for TypeInfoInterface
     dtsize_t(pdt, 0);                        // monitor
@@ -772,7 +773,7 @@ void TypeInfoInterfaceDeclaration::toDt(dt_t **pdt)
 void TypeInfoTupleDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoTupleDeclaration::toDt() %s\n", tinfo->toChars());
-    verifyStructSize(Type::typeinfotypelist, 4 * PTRSIZE);
+    verifyStructSize(Type::typeinfotypelist, 4 * Target::ptrsize);
 
     dtxoff(pdt, Type::typeinfotypelist->toVtblSymbol(), 0); // vtbl for TypeInfoInterface
     dtsize_t(pdt, 0);                        // monitor

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -162,7 +162,7 @@ OBJ1= mars.obj enum.obj struct.obj dsymbol.obj import.obj id.obj \
 	eh.obj toobj.obj toctype.obj tocvdebug.obj toir.obj \
 	json.obj unittests.obj imphint.obj argtypes.obj apply.obj \
 	sideeffect.obj libmscoff.obj scanmscoff.obj \
-	intrange.obj canthrow.obj
+	intrange.obj canthrow.obj target.obj
 
 # D back end
 OBJ8= go.obj gdag.obj gother.obj gflow.obj gloop.obj var.obj el.obj \
@@ -205,7 +205,7 @@ SRCS= mars.c enum.c struct.c dsymbol.c import.c idgen.c impcnvgen.c utf.h \
 	clone.c lib.h libomf.c libelf.c libmach.c arrayop.c \
 	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c argtypes.c \
 	apply.c sideeffect.c libmscoff.c scanmscoff.c ctfe.h \
-	intrange.h intrange.c canthrow.c
+	intrange.h intrange.c canthrow.c target.c target.h
 
 
 # D back end
@@ -716,6 +716,7 @@ sideeffect.obj : $(TOTALH) sideeffect.c
 statement.obj : $(TOTALH) statement.h statement.c expression.h
 staticassert.obj : $(TOTALH) staticassert.h staticassert.c
 struct.obj : $(TOTALH) identifier.h enum.h struct.c
+target.obj : $(TOTALH) target.c target.h
 traits.obj : $(TOTALH) traits.c
 dsymbol.obj : $(TOTALH) identifier.h dsymbol.h dsymbol.c
 mtype.obj : $(TOTALH) mtype.h mtype.c


### PR DESCRIPTION
OK, first ice-breaker of a few.  I initially mentioned this here: http://bit.ly/XKFUa4

But to give a rundown of what Target is:

Target is intended to be a data structure that describes a backend target.  The `target.h` is a shared structure common to all, leaving each compiler backend left to implement their own `target.c` that provides the correct information for the targets they support.

This aims to reduce the need for GDC and LDC to use lots of `#if IN_GCC` or `#if LLVM` conditions in their own copies that deviate away from the hosted source of the D frontend here on github.

Haven't tested on windows, but I'll see what happens when the auto-tester kicks in.

Feedback welcome.
Thanks,
Iain.
