### PR TITLE
Issue 9418 + 9458 - Invalid array operation should be rejected in glue layer

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1969,6 +1969,12 @@ elem *ComExp::toElem(IRState *irs)
             e = el_bin(OPxor, ty, e1, el_long(ty, 1));
             break;
 
+        case Tarray:
+        case Tsarray:
+            error("Array operation %s not implemented", toChars());
+            e = el_long(type->totym(), 0);  // error recovery
+            break;
+
         case Tvector:
         {   // rewrite (~e) as (e^~0)
             elem *ec = el_calloc();

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2290,15 +2290,20 @@ elem *DivExp::toElem(IRState *irs)
 
 elem *ModExp::toElem(IRState *irs)
 {
+    Type *tb1 = e1->type->toBasetype();
+    Type *tb2 = e2->type->toBasetype();
+
+    if (tb1->ty == Tarray || tb1->ty == Tsarray)
+    {
+        error("Array operation %s not implemented", toChars());
+        return el_long(type->totym(), 0);  // error recovery
+    }
+
     elem *e;
-    elem *e1;
-    elem *e2;
-    tym_t tym;
 
-    tym = type->totym();
-
-    e1 = this->e1->toElem(irs);
-    e2 = this->e2->toElem(irs);
+    tym_t tym = type->totym();
+    elem *e1 = this->e1->toElem(irs);
+    elem *e2 = this->e2->toElem(irs);
 
 #if 0 // Now inlined
     if (this->e1->type->isfloating())

--- a/test/fail_compilation/fail9418.d
+++ b/test/fail_compilation/fail9418.d
@@ -1,0 +1,32 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9418.d(20): Error: Array operation -a[] not implemented
+fail_compilation/fail9418.d(21): Error: Array operation ~a[] not implemented
+fail_compilation/fail9418.d(23): Error: Array operation a[] + a[] not implemented
+fail_compilation/fail9418.d(24): Error: Array operation a[] - a[] not implemented
+fail_compilation/fail9418.d(25): Error: Array operation a[] * a[] not implemented
+fail_compilation/fail9418.d(26): Error: Array operation a[] / a[] not implemented
+fail_compilation/fail9418.d(28): Error: Array operation a[] ^ a[] not implemented
+fail_compilation/fail9418.d(29): Error: Array operation a[] & a[] not implemented
+fail_compilation/fail9418.d(30): Error: Array operation a[] | a[] not implemented
+fail_compilation/fail9418.d(31): Error: Array operation a[] ^^ a[] not implemented
+---
+*/
+
+void main()
+{
+    int[] a = [1, 2, 3];
+    a = -a[];
+    a = ~a[];   // 9418
+
+    a = a[] + a[];
+    a = a[] - a[];
+    a = a[] * a[];
+    a = a[] / a[];
+  //a = a[] % a[];
+    a = a[] ^ a[];
+    a = a[] & a[];
+    a = a[] | a[];
+    a = a[] ^^ a[];
+}

--- a/test/fail_compilation/fail9418.d
+++ b/test/fail_compilation/fail9418.d
@@ -7,13 +7,13 @@ fail_compilation/fail9418.d(23): Error: Array operation a[] + a[] not implemente
 fail_compilation/fail9418.d(24): Error: Array operation a[] - a[] not implemented
 fail_compilation/fail9418.d(25): Error: Array operation a[] * a[] not implemented
 fail_compilation/fail9418.d(26): Error: Array operation a[] / a[] not implemented
+fail_compilation/fail9418.d(27): Error: Array operation a[] % a[] not implemented
 fail_compilation/fail9418.d(28): Error: Array operation a[] ^ a[] not implemented
 fail_compilation/fail9418.d(29): Error: Array operation a[] & a[] not implemented
 fail_compilation/fail9418.d(30): Error: Array operation a[] | a[] not implemented
 fail_compilation/fail9418.d(31): Error: Array operation a[] ^^ a[] not implemented
 ---
 */
-
 void main()
 {
     int[] a = [1, 2, 3];
@@ -24,7 +24,7 @@ void main()
     a = a[] - a[];
     a = a[] * a[];
     a = a[] / a[];
-  //a = a[] % a[];
+    a = a[] % a[];  // 9458
     a = a[] ^ a[];
     a = a[] & a[];
     a = a[] | a[];


### PR DESCRIPTION
[Issue 9418](http://d.puremagic.com/issues/show_bug.cgi?id=9418) - Segmentation fault using only datetime and stdio
[Issue 9458](http://d.puremagic.com/issues/show_bug.cgi?id=9458) - ModExp generates invalid code against array operands

Essentially such invalid expressions should be detected in front end layer. (filed as [bug 9459](http://d.puremagic.com/issues/show_bug.cgi?id=9459))
