### PR TITLE
fix build with Visual Studio

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1550,7 +1550,7 @@ Expression *ctfeIndex(Loc loc, Type *type, Expression *e1, uinteger_t indx)
     {   StringExp *es1 = (StringExp *)e1;
         if (indx >= es1->len)
         {
-            error(loc, "string index %ju is out of bounds [0 .. %zu]", indx, es1->len);
+            error(loc, "string index %llu is out of bounds [0 .. %llu]", indx, (ulonglong)es1->len);
             return EXP_CANT_INTERPRET;
         }
         else
@@ -1560,7 +1560,7 @@ Expression *ctfeIndex(Loc loc, Type *type, Expression *e1, uinteger_t indx)
     ArrayLiteralExp *ale = (ArrayLiteralExp *)e1;
     if (indx >= ale->elements->dim)
     {
-        error(loc, "array index %ju is out of bounds %s[0 .. %u]", indx, e1->toChars(), ale->elements->dim);
+        error(loc, "array index %llu is out of bounds %s[0 .. %llu]", indx, e1->toChars(), (ulonglong)ale->elements->dim);
         return EXP_CANT_INTERPRET;
     }
     Expression *e = ale->elements->tdata()[indx];

--- a/src/dmd_msc.vcproj
+++ b/src/dmd_msc.vcproj
@@ -44,7 +44,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/TP"
 				AdditionalIncludeDirectories=".\root;.\tk;.\backend;.;vcbuild"
-				PreprocessorDefinitions="DEBUG,_DEBUG"
+				PreprocessorDefinitions="DEBUG,_DEBUG;TARGET_WINDOS=1"
 				RuntimeLibrary="1"
 				StructMemberAlignment="1"
 				WarningLevel="4"
@@ -646,10 +646,6 @@
 				>
 			</File>
 			<File
-				RelativePath=".\ph.c"
-				>
-			</File>
-			<File
 				RelativePath=".\s2ir.c"
 				>
 			</File>
@@ -790,10 +786,6 @@
 				>
 			</File>
 			<File
-				RelativePath=".\util.c"
-				>
-			</File>
-			<File
 				RelativePath=".\version.c"
 				>
 			</File>
@@ -810,6 +802,10 @@
 				</File>
 				<File
 					RelativePath=".\backend\aa.h"
+					>
+				</File>
+				<File
+					RelativePath=".\backend\backconfig.c"
 					>
 				</File>
 				<File
@@ -1085,6 +1081,10 @@
 					>
 				</File>
 				<File
+					RelativePath=".\backend\ph2.c"
+					>
+				</File>
+				<File
 					RelativePath=".\backend\ptrntab.c"
 					>
 				</File>
@@ -1134,6 +1134,10 @@
 				</File>
 				<File
 					RelativePath=".\backend\type.h"
+					>
+				</File>
+				<File
+					RelativePath=".\backend\util2.c"
 					>
 				</File>
 				<File
@@ -1367,14 +1371,6 @@
 							Name="VCCLCompilerTool"
 						/>
 					</FileConfiguration>
-				</File>
-				<File
-					RelativePath=".\root\gnuc.c"
-					>
-				</File>
-				<File
-					RelativePath=".\root\gnuc.h"
-					>
 				</File>
 				<File
 					RelativePath=".\root\longdouble.c"
@@ -1731,7 +1727,7 @@
 						<Tool
 							Name="VCCustomBuildTool"
 							Description="Building and running $(IntDir)\$(InputName).exe"
-							CommandLine="cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo&quot;$(IntDir)\$(InputName).obj&quot; /Fe&quot;$(IntDir)\$(InputName).exe&quot; &quot;$(InputPath)&quot;&#x0D;&#x0A;if errorlevel 1 goto VCReportError&#x0D;&#x0A;&quot;$(IntDir)\$(InputName).exe&quot;"
+							CommandLine="cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo&quot;$(IntDir)\$(InputName).obj&quot; /Fe&quot;$(IntDir)\$(InputName).exe&quot; &quot;$(InputPath)&quot;&#x0D;&#x0A;if errorlevel 1 goto VCReportError&#x0D;&#x0A;&quot;$(IntDir)\$(InputName).exe&quot;&#x0D;&#x0A;"
 							AdditionalDependencies="cc.h;oper.h"
 							Outputs="optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c"
 						/>
@@ -1980,6 +1976,10 @@
 						/>
 					</FileConfiguration>
 				</File>
+				<File
+					RelativePath=".\verstr.h"
+					>
+				</File>
 			</Filter>
 			<Filter
 				Name="no_win"
@@ -2146,6 +2146,56 @@
 				</File>
 			</Filter>
 		</Filter>
+		<File
+			RelativePath="..\VERSION"
+			>
+			<FileConfiguration
+				Name="Debug|Win32"
+				>
+				<Tool
+					Name="VCCustomBuildTool"
+					Description="Generatin verstr.h"
+					CommandLine="set /P X= &lt; $(InputPath) &amp;&amp; echo &quot;%X%&quot; &gt;verstr.h&#x0D;&#x0A;"
+					AdditionalDependencies=""
+					Outputs="verstr.h"
+				/>
+			</FileConfiguration>
+			<FileConfiguration
+				Name="Debug|x64"
+				>
+				<Tool
+					Name="VCCustomBuildTool"
+					Description="Generatin verstr.h"
+					CommandLine="set /P X= &lt; $(InputPath) &amp;&amp; echo &quot;%X%&quot; &gt;verstr.h&#x0D;&#x0A;"
+					Outputs="verstr.h"
+				/>
+			</FileConfiguration>
+			<FileConfiguration
+				Name="Release|Win32"
+				>
+				<Tool
+					Name="VCCustomBuildTool"
+					Description="Generatin verstr.h"
+					CommandLine="set /P X= &lt; $(InputPath) &amp;&amp; echo &quot;%X%&quot; &gt;verstr.h&#x0D;&#x0A;"
+					AdditionalDependencies="vergen.c"
+					Outputs="verstr.h"
+				/>
+			</FileConfiguration>
+			<FileConfiguration
+				Name="Release|x64"
+				>
+				<Tool
+					Name="VCCustomBuildTool"
+					Description="Generatin verstr.h"
+					CommandLine="set /P X= &lt; $(InputPath) &amp;&amp; echo &quot;%X%&quot; &gt;verstr.h&#x0D;&#x0A;"
+					Outputs="verstr.h"
+				/>
+			</FileConfiguration>
+		</File>
+		<File
+			RelativePath=".\win32.mak"
+			>
+		</File>
 	</Files>
 	<Globals>
 	</Globals>

--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -113,6 +113,11 @@
     <ClCompile Include="argtypes.c" />
     <ClCompile Include="arrayop.c" />
     <ClCompile Include="attrib.c" />
+    <ClCompile Include="backend\backconfig.c" />
+    <ClCompile Include="backend\cv8.c" />
+    <ClCompile Include="backend\pdata.c" />
+    <ClCompile Include="backend\ph2.c" />
+    <ClCompile Include="backend\util2.c" />
     <ClCompile Include="builtin.c" />
     <ClCompile Include="canthrow.c" />
     <ClCompile Include="cast.c" />
@@ -121,6 +126,7 @@
     <ClCompile Include="cond.c" />
     <ClCompile Include="constfold.c" />
     <ClCompile Include="cppmangle.c" />
+    <ClCompile Include="ctfeexpr.c" />
     <ClCompile Include="declaration.c" />
     <ClCompile Include="delegatize.c" />
     <ClCompile Include="doc.c" />
@@ -158,7 +164,6 @@
     <ClCompile Include="opover.c" />
     <ClCompile Include="optimize.c" />
     <ClCompile Include="parse.c" />
-    <ClCompile Include="ph.c" />
     <ClCompile Include="s2ir.c" />
     <ClCompile Include="scanmscoff.c" />
     <ClCompile Include="scope.c" />
@@ -190,7 +195,6 @@
     </ClCompile>
     <ClCompile Include="unittests.c" />
     <ClCompile Include="utf.c" />
-    <ClCompile Include="util.c" />
     <ClCompile Include="version.c" />
     <ClCompile Include="backend\aa.c" />
     <ClCompile Include="backend\bcomplex.c" />
@@ -275,7 +279,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="root\gnuc.c" />
     <ClCompile Include="root\longdouble.c" />
     <ClCompile Include="root\man.c" />
     <ClCompile Include="root\port.c" />
@@ -314,7 +317,6 @@
 if errorlevel 1 goto VCReportError
 $(IntDir)%(Filename).exe
 </Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">idgen.c;%(AdditionalInputs)</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">id.c;id.h;$(IntDir)%(Filename).exe;%(Outputs)</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cl /TP /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension)
@@ -330,7 +332,7 @@ $(IntDir)%(Filename).exe
 if errorlevel 1 goto VCReportError
 $(IntDir)%(Filename).exe
 </Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mtype.h;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mtype.h</AdditionalInputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">impcnvtab.c;%(Outputs)</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cl /TP /Itk /Iroot /Ivcbuild /FIvcbuild\warnings.h /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension)
@@ -346,14 +348,31 @@ $(IntDir)%(Filename).exe
 if errorlevel 1 goto VCReportError
 "$(IntDir)%(Filename).exe"
 </Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cc.h;oper.h;%(AdditionalInputs)</AdditionalInputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">backend\cc.h;backend\oper.h</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c</Outputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo"$(IntDir)%(Filename).obj" /Fe"$(IntDir)%(Filename).exe" "%(FullPath)"
 if errorlevel 1 goto VCReportError
-"$(IntDir)%(Filename).exe"</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cc.h;oper.h;%(AdditionalInputs)</AdditionalInputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c;%(Outputs)</Outputs>
+"$(IntDir)%(Filename).exe"
+</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">backend\cc.h;backend\oper.h</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo"$(IntDir)%(Filename).obj" /Fe"$(IntDir)%(Filename).exe" "%(FullPath)"
+if errorlevel 1 goto VCReportError
+"$(IntDir)%(Filename).exe"
+</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo"$(IntDir)%(Filename).obj" /Fe"$(IntDir)%(Filename).exe" "%(FullPath)"
+if errorlevel 1 goto VCReportError
+"$(IntDir)%(Filename).exe"
+</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Building and running $(IntDir)%(Filename).exe</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Building and running $(IntDir)%(Filename).exe</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">backend\cc.h;backend\oper.h</AdditionalInputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</LinkObjects>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">backend\cc.h;backend\oper.h</AdditionalInputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkObjects>
     </CustomBuild>
     <ClCompile Include="cdxxx.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -482,7 +501,6 @@ if errorlevel 1 goto VCReportError
     <ClInclude Include="tk\vec.h" />
     <ClInclude Include="root\aav.h" />
     <ClInclude Include="root\async.h" />
-    <ClInclude Include="root\gnuc.h" />
     <ClInclude Include="root\longdouble.h" />
     <ClInclude Include="root\port.h" />
     <ClInclude Include="root\rmem.h" />
@@ -505,6 +523,31 @@ if errorlevel 1 goto VCReportError
       <FileType>Document</FileType>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
     </CustomBuildStep>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\VERSION">
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating verstr.h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">verstr.h</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+      </AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Generating verstr.h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">verstr.h</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generating verstr.h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">verstr.h</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generating verstr.h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">verstr.h</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </AdditionalInputs>
+    </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/dmd_msc.vcxproj.filters
+++ b/src/dmd_msc.vcxproj.filters
@@ -183,9 +183,6 @@
     <ClCompile Include="parse.c">
       <Filter>src</Filter>
     </ClCompile>
-    <ClCompile Include="ph.c">
-      <Filter>src</Filter>
-    </ClCompile>
     <ClCompile Include="s2ir.c">
       <Filter>src</Filter>
     </ClCompile>
@@ -247,9 +244,6 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="utf.c">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="util.c">
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="version.c">
@@ -429,9 +423,6 @@
     <ClCompile Include="root\dmgcmem.c">
       <Filter>src\root</Filter>
     </ClCompile>
-    <ClCompile Include="root\gnuc.c">
-      <Filter>src\root</Filter>
-    </ClCompile>
     <ClCompile Include="root\longdouble.c">
       <Filter>src\root</Filter>
     </ClCompile>
@@ -500,6 +491,24 @@
     </ClCompile>
     <ClCompile Include="root\gc\linux.c">
       <Filter>src\no_win</Filter>
+    </ClCompile>
+    <ClCompile Include="backend\backconfig.c">
+      <Filter>src\backend</Filter>
+    </ClCompile>
+    <ClCompile Include="backend\ph2.c">
+      <Filter>src\backend</Filter>
+    </ClCompile>
+    <ClCompile Include="backend\util2.c">
+      <Filter>src\backend</Filter>
+    </ClCompile>
+    <ClCompile Include="ctfeexpr.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="backend\cv8.c">
+      <Filter>src\backend</Filter>
+    </ClCompile>
+    <ClCompile Include="backend\pdata.c">
+      <Filter>src\backend</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -710,9 +719,6 @@
     <ClInclude Include="root\async.h">
       <Filter>src\root</Filter>
     </ClInclude>
-    <ClInclude Include="root\gnuc.h">
-      <Filter>src\root</Filter>
-    </ClInclude>
     <ClInclude Include="root\longdouble.h">
       <Filter>src\root</Filter>
     </ClInclude>
@@ -777,5 +783,6 @@
     <CustomBuild Include="backend\optabgen.c">
       <Filter>src\gen</Filter>
     </CustomBuild>
+    <CustomBuild Include="..\VERSION" />
   </ItemGroup>
 </Project>

--- a/src/expression.c
+++ b/src/expression.c
@@ -907,7 +907,7 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
     size_t nparams = Parameter::dim(tf->parameters);
 
     if (nargs > nparams && tf->varargs == 0)
-    {   error(loc, "expected %zu arguments, not %llu for non-variadic function type %s", nparams, (ulonglong)nargs, tf->toChars());
+    {   error(loc, "expected %llu arguments, not %llu for non-variadic function type %s", (ulonglong)nparams, (ulonglong)nargs, tf->toChars());
         return Type::terror;
     }
 

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -345,7 +345,7 @@ int Port::memicmp(const char *s1, const char *s2, int n)
 
 int Port::stricmp(const char *s1, const char *s2)
 {
-    return ::stricmp(s1, s2, n);
+    return ::stricmp(s1, s2);
 }
 
 #endif

--- a/src/vcbuild/dmc_cl.bat
+++ b/src/vcbuild/dmc_cl.bat
@@ -14,6 +14,8 @@ if "%opt%" == "toir"     set opt=%opt%.c backend\strtold.c root\longdouble.c
 if "%opt%" == "toir.obj" set opt=%opt% strtold.obj longdouble.obj
 rem remove includes after ";"
 if "%opt%" == "tk" set opt=/Itk
+rem -DX=1 split into two arguments
+if "%opt%" == "1" goto shift
 
 if "%opt:~0,1%" == "-" goto opt
 if "%opt:~0,1%" == "/" goto opt


### PR DESCRIPTION
This patch
- fixes project files for VS2008 and VS2010 according to makefile changes
- fixes some format strings using %ju or %zu (using %llu instead)
- fix typo in stricmp in port.c
