### PR TITLE
Issue 9461 - Ability to break typesystem with `inout`

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8955,7 +8955,7 @@ MATCH TypeClass::constConv(Type *to)
     /* Conversion derived to const(base)
      */
     int offset = 0;
-    if (to->isBaseOf(this, &offset) && offset == 0 && !to->isMutable())
+    if (to->isBaseOf(this, &offset) && offset == 0 && !to->isMutable() && !to->isWild())
         return MATCHconvert;
 
     return MATCHnomatch;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2884,6 +2884,27 @@ void test9090()
 }
 
 /************************************/
+// 9461
+
+void test9461()
+{
+    class A {}
+    class B : A {}
+
+    void conv(S, T)(ref S x) { T y = x; }
+
+    // should be NG
+    static assert(!__traits(compiles, conv!(inout(B)[],     inout(A)[])));
+    static assert(!__traits(compiles, conv!(int[inout(B)],  int[inout(A)])));
+    static assert(!__traits(compiles, conv!(inout(B)[int],  inout(A)[int])));
+    static assert(!__traits(compiles, conv!(inout(B)*,      inout(A)*)));
+    static assert(!__traits(compiles, conv!(inout(B)[1],    inout(A)[])));
+
+    // should be OK
+    static assert( __traits(compiles, conv!(inout(B),       inout(A))));
+}
+
+/************************************/
 
 int main()
 {
@@ -3005,6 +3026,7 @@ int main()
     test8688();
     test9046();
     test9090();
+    test9461();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9461
