### PR TITLE
fix cv8 array debug info

### DIFF
--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -374,6 +374,11 @@ L1:
     return debtyptop++ + cgcv.deb_offset;
 }
 
+idx_t cv_numdebtypes()
+{
+    return debtyptop;
+}
+
 /****************************
  * Store a null record at DEB_NULL.
  */

--- a/src/backend/cgcv.h
+++ b/src/backend/cgcv.h
@@ -64,6 +64,7 @@ int cv_namestring ( unsigned char *p , const char *name );
 unsigned cv4_typidx(type *t);
 idx_t cv4_arglist(type *t,unsigned *pnparam);
 unsigned char cv4_callconv(type *t);
+idx_t cv_numdebtypes();
 
 #define TOIDX(a,b)      ((cgcv.sz_idx == 4) ? TOLONG(a,b) : TOWORD(a,b))
 

--- a/src/backend/cv8.c
+++ b/src/backend/cv8.c
@@ -801,7 +801,7 @@ idx_t cv8_darray(type *t, idx_t etypidx)
             break;
 
         default:
-            id = "dArray";
+            id = t->Tident ? t->Tident : "dArray";
             break;
     }
 
@@ -815,7 +815,12 @@ idx_t cv8_darray(type *t, idx_t etypidx)
     TOWORD(d->data + 18, 16);   // size
     cv_namestring(d->data + 20, id);
 
-    return cv_debtyp(d);
+    idx_t top = cv_numdebtypes();
+    idx_t debidx = cv_debtyp(d);
+    if(top != cv_numdebtypes())
+        cv8_udt(id, debidx);
+
+    return debidx;
 }
 
 /****************************************

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -67,7 +67,10 @@ type *TypeSArray::toCtype()
 type *TypeDArray::toCtype()
 {
     if (!ctype)
+    {
         ctype = type_dyn_array(next->toCtype());
+        ctype->Tident = toChars(); // needed to generate sensible debug info for cv8
+    }
     return ctype;
 }
 


### PR DESCRIPTION
So far, D-Array are always named "dArray" in the CV8 debug info. This causes the debugger to use a single debug entry for all kind of arrays, so the elements are displayed with wrong types.

What's needed is a unique name (the patch tunnels the D name through the unused union of the type) and a UDT entry.
