### PR TITLE
D1 ONLY: Make missing return an error instead of a warning

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1181,11 +1181,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 {
                     if (offend)
                     {   Expression *e;
-#if DMDV1
-                        warning(loc, "no return exp; or assert(0); at end of function");
-#else
                         error("no return exp; or assert(0); at end of function");
-#endif
                         if (global.params.useAssert &&
                             !global.params.useInline)
                         {   /* Add an assert(0, msg); where the missing return


### PR DESCRIPTION
The implementation in D2 has been a resounding success. There is no reason for this to remain a warning, it is an error in 100% of cases -- and it's a particularly common and dangerous bug.
