### PR TITLE
Issue 9504 - typeof does not look up properties correctly on template argument

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7214,7 +7214,7 @@ Type *TypeTypeof::semantic(Loc loc, Scope *sc)
         t = t->addMod(mod);
     if (!t)
     {
-        error(loc, "is not a type");
+        error(loc, "%s is used as a type", toChars());
         t = Type::terror;
     }
     return t;
@@ -7330,6 +7330,7 @@ Lerr:
 
 Type *TypeReturn::semantic(Loc loc, Scope *sc)
 {
+    //printf("TypeReturn::semantic() %s\n", toChars());
 
     Expression *e;
     Type *t;
@@ -7339,7 +7340,7 @@ Type *TypeReturn::semantic(Loc loc, Scope *sc)
         t = t->addMod(mod);
     if (!t)
     {
-        error(loc, "is not a type");
+        error(loc, "%s is used as a type", toChars());
         t = Type::terror;
     }
     return t;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -777,6 +777,7 @@ struct TypeTypeof : TypeQualified
     Dsymbol *toDsymbol(Scope *sc);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
+    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps);
     Type *semantic(Loc loc, Scope *sc);
     d_uns64 size(Loc loc);
 };
@@ -787,6 +788,7 @@ struct TypeReturn : TypeQualified
     const char *kind();
     Type *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
+    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps);
     Type *semantic(Loc loc, Scope *sc);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5801,6 +5801,37 @@ struct X164()
 
 
 /***************************************************/
+// 9504
+
+struct Bar9504
+{
+    template Abc(T)
+    {
+        T y;
+    }
+
+    enum size_t num = 123;
+
+    class Def {}
+}
+
+template GetSym9504(alias sym) { static assert(__traits(isSame, sym, Bar9504.Abc)); }
+template GetExp9504(size_t n) { static assert(n == Bar9504.num); }
+template GetTyp9504(T) { static assert(is(T == Bar9504.Def)); }
+
+alias GetSym9504!(typeof(Bar9504.init).Abc) X9504; // NG
+alias GetExp9504!(typeof(Bar9504.init).num) Y9504; // NG
+alias GetTyp9504!(typeof(Bar9504.init).Def) Z9504;
+
+Bar9504 test9504()
+{
+    alias GetSym9504!(typeof(return).Abc) V9504; // NG
+    alias GetExp9504!(typeof(return).num) W9504; // NG
+    alias GetTyp9504!(typeof(return).Def) X9504;
+    return Bar9504();
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9504

The identifiers followed by `typeof(exp)` or `typeod(return)` may be resolved to symbol or expression. `Type[Typeof|Return]::resolve` should consider it.
