### PR TITLE
fix initialization of OverExp::loc

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3025,7 +3025,7 @@ Lagain:
     o = s->isOverloadSet();
     if (o)
     {   //printf("'%s' is an overload set\n", o->toChars());
-        return new OverExp(o);
+        return new OverExp(loc, o);
     }
     imp = s->isImport();
     if (imp)
@@ -5119,8 +5119,8 @@ Expression *VarExp::modifiableLvalue(Scope *sc, Expression *e)
 /******************************** OverExp **************************/
 
 #if DMDV2
-OverExp::OverExp(OverloadSet *s)
-        : Expression(s->loc, TOKoverloadset, sizeof(OverExp))
+OverExp::OverExp(Loc loc, OverloadSet *s)
+        : Expression(loc, TOKoverloadset, sizeof(OverExp))
 {
     //printf("OverExp(this = %p, '%s')\n", this, var->toChars());
     vars = s;
@@ -6819,7 +6819,7 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
             OverloadSet *o = s->isOverloadSet();
             if (o)
             {   //printf("'%s' is an overload set\n", o->toChars());
-                return new OverExp(o);
+                return new OverExp(loc, o);
             }
 #endif
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -5120,7 +5120,7 @@ Expression *VarExp::modifiableLvalue(Scope *sc, Expression *e)
 
 #if DMDV2
 OverExp::OverExp(OverloadSet *s)
-        : Expression(loc, TOKoverloadset, sizeof(OverExp))
+        : Expression(s->loc, TOKoverloadset, sizeof(OverExp))
 {
     //printf("OverExp(this = %p, '%s')\n", this, var->toChars());
     vars = s;

--- a/src/expression.h
+++ b/src/expression.h
@@ -661,7 +661,7 @@ struct OverExp : Expression
 {
     OverloadSet *vars;
 
-    OverExp(OverloadSet *s);
+    OverExp(Loc loc, OverloadSet *s);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
 };

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8151,7 +8151,7 @@ L1:
     OverloadSet *o = s->isOverloadSet();
     if (o)
     {
-        OverExp *oe = new OverExp(o);
+        OverExp *oe = new OverExp(e->loc, o);
         if (e->op == TOKtype)
             return oe;
         return new DotExp(e->loc, e, oe);
@@ -8752,7 +8752,7 @@ L1:
     OverloadSet *o = s->isOverloadSet();
     if (o)
     {
-        OverExp *oe = new OverExp(o);
+        OverExp *oe = new OverExp(e->loc, o);
         if (e->op == TOKtype)
             return oe;
         return new DotExp(e->loc, e, oe);


### PR DESCRIPTION
So far, OverExp initializes it's loc member from itself, resulting in unitialized data to be used. This can cause crashes in the compiler when generating debug info, and also arbitrary problems in the linker aswell.

The patch uses the location of the passed OverloadSet which is usually set to 0, but that's a lot better than bad data.
