### PR TITLE
[Refactoring] TemplateMixin symbol resolution

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2075,11 +2075,6 @@ Dsymbol *Parser::parseMixin()
             tqual = parseTypeof();
             check(TOKdot);
         }
-        else if (token.value == TOKvector)
-        {
-            tqual = parseVector();
-            check(TOKdot);
-        }
         if (token.value != TOKidentifier)
         {
             error("identifier expected, not %s", token.toChars());

--- a/src/template.h
+++ b/src/template.h
@@ -30,6 +30,7 @@ struct TemplateValueParameter;
 struct TemplateAliasParameter;
 struct TemplateTupleParameter;
 struct Type;
+struct TypeQualified;
 struct TypeTypeof;
 struct Scope;
 struct Expression;
@@ -343,10 +344,9 @@ struct TemplateInstance : ScopeDsymbol
 
 struct TemplateMixin : TemplateInstance
 {
-    Identifiers *idents;
-    Type *tqual;
+    TypeQualified *tqual;
 
-    TemplateMixin(Loc loc, Identifier *ident, Type *tqual, Identifiers *idents, Objects *tiargs);
+    TemplateMixin(Loc loc, Identifier *ident, TypeQualified *tqual, Objects *tiargs);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);


### PR DESCRIPTION
When I see `TemplateMixin::semanitic`, I found that we can improve a little the mechanism for template declaration lookup.

Related to that, I found a grammar bug around template mixin, so I posted [a website fix](https://github.com/D-Programming-Language/d-programming-language.org/pull/278) and it was already merged.

One more, I found a compiler bug that `TypeTypeof::resolve` and `TypeReturn::resolve` did not work as expected. I filed [bug 9504](http://d.puremagic.com/issues/show_bug.cgi?id=9504) and it also was [already fixed](https://github.com/D-Programming-Language/dmd/pull/1659).

In the new grammar, the `QualifiedIdentifierList` can be constructed as a `TypeQualified` object - actually it is one of `TypeIdentifier`, `TypeInstance`, `TypeTypeof`, or `TypeReturn`.

Finally we can simplify `TemplateMixin::semantic` - it's just a call of `tqual->resolve`.
