### PR TITLE
Issue 8997 - template instances omit symbol that may be used in other modules

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4567,8 +4567,8 @@ StructDeclaration *TypeAArray::getImpl()
         dti->semantic(sc);
         TemplateInstance *ti = dti->ti;
 #endif
-        // instantiate on the first module given in command lines
-        sc = sc->push(Module::rootModule);
+        // Instantiate on the root module of import dependency graph.
+        sc = sc->push(sc->module->importedFrom);
         ti->semantic(sc);
         ti->semantic2(sc);
         ti->semantic3(sc);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -40,6 +40,7 @@
 #include "template.h"
 #include "id.h"
 #include "enum.h"
+#include "module.h"
 #include "import.h"
 #include "aggregate.h"
 #include "hdrgen.h"
@@ -4566,9 +4567,12 @@ StructDeclaration *TypeAArray::getImpl()
         dti->semantic(sc);
         TemplateInstance *ti = dti->ti;
 #endif
+        // instantiate on the first module given in command lines
+        sc = sc->push(Module::rootModule);
         ti->semantic(sc);
         ti->semantic2(sc);
         ti->semantic3(sc);
+        sc = sc->pop();
         impl = ti->toAlias()->isStructDeclaration();
 #ifdef DEBUG
         if (!impl)

--- a/test/runnable/imports/test8997a.d
+++ b/test/runnable/imports/test8997a.d
@@ -1,0 +1,6 @@
+module imports.test8997a;
+
+class A
+{
+    A[string] foobar;
+}

--- a/test/runnable/test8997.d
+++ b/test/runnable/test8997.d
@@ -1,0 +1,15 @@
+// COMPILE_SEPARATELY
+// EXTRA_SOURCES: imports/test8997a.d
+
+module test8997;
+
+import imports.test8997a;
+
+void main()
+{
+    auto a = new A();
+
+    foreach(key; a.foobar.byKey())
+    {
+    }
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8997

Add AA template instance implementation into the first  module in command line, instead of the first module the AA type found.
