### PR TITLE
fix Issue 8898 - false positive dangling else warning

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -309,10 +309,15 @@ Dsymbols *Parser::parseDeclDefs(int once)
                     s = parseStaticAssert();
                 else if (token.value == TOKif)
                 {   condition = parseStaticIfCondition();
-                    Loc lookingForElseSave = lookingForElse;
-                    lookingForElse = loc;
-                    a = parseBlock();
-                    lookingForElse = lookingForElseSave;
+                    if (token.value == TOKcolon)
+                        a = parseBlock();
+                    else
+                    {
+                        Loc lookingForElseSave = lookingForElse;
+                        lookingForElse = loc;
+                        a = parseBlock();
+                        lookingForElse = lookingForElseSave;
+                    }
                     aelse = NULL;
                     if (token.value == TOKelse)
                     {

--- a/test/compilable/test8898.d
+++ b/test/compilable/test8898.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -w
+// PERMUTE_ARGS:
+
+static if (true):
+
+version (Foo)
+{
+}
+else
+{
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8898

Apply the same way as #1129 to `static if`.
