### PR TITLE
Move toObjFile to toobj.c

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -6192,27 +6192,6 @@ void TemplateInstance::printInstantiationTrace()
     }
 }
 
-void TemplateInstance::toObjFile(int multiobj)
-{
-#if LOG
-    printf("TemplateInstance::toObjFile('%s', this = %p)\n", toChars(), this);
-#endif
-    if (!errors && members)
-    {
-        if (multiobj)
-            // Append to list of object files to be written later
-            obj_append(this);
-        else
-        {
-            for (size_t i = 0; i < members->dim; i++)
-            {
-                Dsymbol *s = (*members)[i];
-                s->toObjFile(multiobj);
-            }
-        }
-    }
-}
-
 void TemplateInstance::inlineScan()
 {
 #if LOG
@@ -6851,10 +6830,4 @@ void TemplateMixin::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     buf->writenl();
 }
 
-
-void TemplateMixin::toObjFile(int multiobj)
-{
-    //printf("TemplateMixin::toObjFile('%s')\n", toChars());
-    TemplateInstance::toObjFile(0);
-}
 


### PR DESCRIPTION
Doing some reworking here and there.  Dropping all obj_ related code from gdc glue and rewriting the bulk of typinf.c, toobj,c, and todt.c.  It helps if these toObjFile functions are put into toobj.c.

Thanks
Iain
