### PR TITLE
Kill deprecated implicit conversion from T[] to T*

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -53,8 +53,8 @@ void ObjectNotFound(Identifier *id);
 #define LOGDOTEXP       0       // log ::dotExp()
 #define LOGDEFAULTINIT  0       // log ::defaultInit()
 
-// Allow implicit conversion of T[] to T*
-#define IMPLICIT_ARRAY_TO_PTR   global.params.useDeprecated
+// Allow implicit conversion of T[] to T*  --> Removed in 2.063
+#define IMPLICIT_ARRAY_TO_PTR   0
 
 int Tsize_t = Tuns32;
 int Tptrdiff_t = Tint32;
@@ -4296,7 +4296,7 @@ MATCH TypeDArray::implicitConvTo(Type *to)
             return MATCHconvert;
         }
 
-        return next->constConv(to) ? MATCHconvert : MATCHnomatch;
+        return next->constConv(tp->next) ? MATCHconvert : MATCHnomatch;
     }
 
     if (to->ty == Tarray)

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5617,22 +5617,22 @@ void test250()
 {
     static uint[2]  a1 = [0x1001_1100, 0x0220_0012];
 
-    if ( bt32(a1,30)) assert(0);
-    if (!bt32(a1,8))  assert(0);
-    if ( bt32(a1,30+32)) assert(0);
-    if (!bt32(a1,1+32))  assert(0);
+    if ( bt32(a1.ptr,30)) assert(0);
+    if (!bt32(a1.ptr,8))  assert(0);
+    if ( bt32(a1.ptr,30+32)) assert(0);
+    if (!bt32(a1.ptr,1+32))  assert(0);
 
     static ulong[2] a2 = [0x1001_1100_12345678, 0x0220_0012_12345678];
 
-    if ( bt64a(a2,30+32)) assert(0);
-    if (!bt64a(a2,8+32))  assert(0);
-    if ( bt64a(a2,30+32+64)) assert(0);
-    if (!bt64a(a2,1+32+64))  assert(0);
+    if ( bt64a(a2.ptr,30+32)) assert(0);
+    if (!bt64a(a2.ptr,8+32))  assert(0);
+    if ( bt64a(a2.ptr,30+32+64)) assert(0);
+    if (!bt64a(a2.ptr,1+32+64))  assert(0);
 
-    if ( bt64b(a2,30+32)) assert(0);
-    if (!bt64b(a2,8+32))  assert(0);
-    if ( bt64b(a2,30+32+64)) assert(0);
-    if (!bt64b(a2,1+32+64))  assert(0);
+    if ( bt64b(a2.ptr,30+32)) assert(0);
+    if (!bt64b(a2.ptr,8+32))  assert(0);
+    if ( bt64b(a2.ptr,30+32+64)) assert(0);
+    if (!bt64b(a2.ptr,1+32+64))  assert(0);
 }
 
 /***************************************************/

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5878,6 +5878,24 @@ void test9538()
 }
 
 /***************************************************/
+// 9539
+
+void test9539()
+{
+    void f(int** ptr)
+    {
+        assert(**ptr == 10);
+    }
+    int* p = new int;
+    *p = 10;
+    int*[1] x = [p];
+    f(&x[0]);
+
+    int*[] arr = [null];
+    static assert(!__traits(compiles, p = arr));    // bad!
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
This is necessary to fix a regression.
[Issue 9539](http://d.puremagic.com/issues/show_bug.cgi?id=9539) - Regression (2.061): Wrong-code on static array pointer

See my detailed explanation in [here](http://d.puremagic.com/issues/show_bug.cgi?id=9539#c1)

Just I should say here is: the deprecated implicit conversion feature already being a cancer in D2 type system.
