### PR TITLE
[REG2.059] Issue 9552 - DMD crashed when taking member delegate from __traits(getOverloads)

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8540,9 +8540,9 @@ Expression *AddrExp::semantic(Scope *sc)
         {
             DotVarExp *dve = (DotVarExp *)e1;
             FuncDeclaration *f = dve->var->isFuncDeclaration();
-
             if (f)
             {
+                f = f->toAliasFunc();   // FIXME, should see overlods - Bugzilla 1983
                 if (!dve->hasOverloads)
                     f->tookAddressOf++;
 
@@ -8580,7 +8580,6 @@ Expression *AddrExp::semantic(Scope *sc)
             }
 
             FuncDeclaration *f = ve->var->isFuncDeclaration();
-
             if (f)
             {
                 if (!ve->hasOverloads ||

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1023,6 +1023,26 @@ void test7408()
     static assert(!__traits(compiles, T7408!().offsetof));
 }
 
+/*************************************************************/
+// 9552
+
+class C9552
+{
+    int f() { return 10; }
+    int f(int n) { return n * 2; }
+}
+
+void test9552()
+{
+    auto c = new C9552;
+    auto dg1 = &(__traits(getOverloads, c, "f")[0]); // DMD crashes
+    assert(dg1() == 10);
+    auto dg2 = &(__traits(getOverloads, c, "f")[1]);
+    assert(dg2(10) == 20);
+}
+
+/*************************************************************/
+
 int main()
 {
     test1();
@@ -1054,6 +1074,7 @@ int main()
     test7858();
     test5978();
     test7408();
+    test9552();
 
     writeln("Success");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9552

This is workaround fix, because essentially we should treat overloaded functions.
