### PR TITLE
[REG 2.062] Issue 9566 - Cannot use struct .init when it contains static array initialized from a single element.

### DIFF
--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -635,6 +635,19 @@ void test9293()
 }
 
 /********************************************/
+// 9566
+
+void test9566()
+{
+    static struct ExpandData
+    {
+        ubyte[4096] window = 0;
+    }
+    ExpandData a;
+    auto b = ExpandData.init;   // bug
+}
+
+/********************************************/
 
 int main()
 {
@@ -661,6 +674,7 @@ int main()
     test8763();
     test9116();
     test9293();
+    test9566();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9566
