### PR TITLE
fix Issue 9568 - [64bit] wrong code for scope(exit)

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -1288,7 +1288,11 @@ STATIC void blcodgen(block *bl)
         regcon.indexregs &= regcon.indexregs - 1;
     }
 
-    regsave.idx = 0;
+    /* This doesn't work when calling the BC_finally function,
+     * as it is one block calling another.
+     */
+    //regsave.idx = 0;
+
     reflocal = 0;
     refparamsave = refparam;
     refparam = 0;

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -563,6 +563,23 @@ void multicollide()
 
 /****************************************************/
 
+void use9568(char [] x, char [] y) {}
+
+int bug9568()
+{
+    try
+        return 7;
+     finally
+        use9568(null,null);
+}
+
+void test9568()
+{
+    assert( bug9568() == 7 );
+}
+
+/****************************************************/
+
 int main()
 {
     printf("start\n");
@@ -578,6 +595,7 @@ int main()
     doublecollide();
     collideMixed();
     multicollide();
+    test9568();
 
     printf("finish\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9568
