### PR TITLE
D1: fix Issue 9568 - [64bit] wrong code for scope(exit)

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -1288,7 +1288,11 @@ STATIC void blcodgen(block *bl)
         regcon.indexregs &= regcon.indexregs - 1;
     }
 
-    regsave.idx = 0;
+    /* This doesn't work when calling the BC_finally function,
+     * as it is one block calling another.
+     */
+    //regsave.idx = 0;
+
     reflocal = 0;
     refparamsave = refparam;
     refparam = 0;


### PR DESCRIPTION
D1 merge of D-Programming-Language/dmd#1689
