### PR TITLE
workaround for OSX's ld64-77 linker bug

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -925,6 +925,11 @@ void dwarf_termfile()
     debugline.total_length = linebuf->size() - 4;
     memcpy(linebuf->buf, &debugline, sizeof(debugline));
 
+    // Bugzilla 3502, workaround OSX's ld64-77 bug.
+    // Don't emit the the debug_line section if nothing has been written to the line table.
+    if (debugline.prologue_length + 10 == debugline.total_length + 4)
+        linebuf->reset();
+
     /* ================================================= */
 
     abbrevbuf->writeByte(0);


### PR DESCRIPTION
[Bugzilla 3502](http://d.puremagic.com/issues/show_bug.cgi?id=3502) - Fix for dropped Mac OS X 10.5
