### PR TITLE
partial fix Issue 3652 - Allow explicit and implicit casting of dynamic array slices of known size to static array 

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -994,12 +994,11 @@ MATCH SliceExp::implicitConvTo(Type *t)
     {
         if (typeb->nextOf()->constConv(tb->nextOf()))
         {
-            unsigned errors = global.startGagging();
-            Expression *lwr = this->lwr->optimize(WANTvalue);//ctfeInterpret();
-            Expression *upr = this->upr->optimize(WANTvalue);//ctfeInterpret();
-            size_t len = upr->toUInteger() - lwr->toUInteger();
-            if (!global.endGagging(errors))
+            Expression *lwr = this->lwr->optimize(WANTvalue);
+            Expression *upr = this->upr->optimize(WANTvalue);
+            if (lwr->isConst() && upr->isConst())
             {
+                size_t len = upr->toUInteger() - lwr->toUInteger();
                 typeb = new TypeSArray(typeb->nextOf(),
                             new IntegerExp(0, len, Type::tindex));
                 result = typeb->implicitConvTo(t);

--- a/src/cast.c
+++ b/src/cast.c
@@ -20,6 +20,7 @@
 #include "aggregate.h"
 #include "template.h"
 #include "scope.h"
+#include "id.h"
 
 //#define DUMP .dump(__PRETTY_FUNCTION__, this)
 #define DUMP
@@ -981,6 +982,34 @@ MATCH NewExp::implicitConvTo(Type *t)
     return MATCHnomatch;
 }
 
+MATCH SliceExp::implicitConvTo(Type *t)
+{
+    MATCH result = Expression::implicitConvTo(t);
+
+    Type *tb = t->toBasetype();
+    Type *typeb = type->toBasetype();
+    if (result == MATCHnomatch &&
+        tb->ty == Tsarray && typeb->ty == Tarray &&
+        lwr && upr) // test
+    {
+        if (typeb->nextOf()->constConv(tb->nextOf()))
+        {
+            unsigned errors = global.startGagging();
+            Expression *lwr = this->lwr->optimize(WANTvalue);//ctfeInterpret();
+            Expression *upr = this->upr->optimize(WANTvalue);//ctfeInterpret();
+            size_t len = upr->toUInteger() - lwr->toUInteger();
+            if (!global.endGagging(errors))
+            {
+                typeb = new TypeSArray(typeb->nextOf(),
+                            new IntegerExp(0, len, Type::tindex));
+                result = typeb->implicitConvTo(t);
+            }
+            //printf("targ = %s => %s, m = %d\n", toChars(), typeb->toChars(), result);
+        }
+    }
+    return result;
+}
+
 /* ==================== castTo ====================== */
 
 /**************************************
@@ -1749,6 +1778,37 @@ Expression *CommaExp::castTo(Scope *sc, Type *t)
     else
     {   e = this;
         e->type = e2->type;
+    }
+    return e;
+}
+
+Expression *SliceExp::castTo(Scope *sc, Type *t)
+{
+    Type *typeb = type->toBasetype();
+    Type *tb = t->toBasetype();
+    Expression *e;
+    if (typeb->ty == Tarray && tb->ty == Tsarray)
+    {
+        e = copy();
+
+        /* Rewrite:
+         *      arr[lwr .. upr]
+         * as:
+         *      *(cast(T[dim]*)(arr[lwr .. upr].ptr))
+         *
+         * Note that:
+         *      static assert(dim == upr - lwr);
+         */
+        e = new DotIdExp(e->loc, e, Id::ptr);
+        e = e->semantic(sc);
+        e = e->castTo(sc, t->pointerTo());
+        e = new PtrExp(e->loc, e);
+        e = e->semantic(sc);
+        //printf("e = %s, %s => %s %s\n", toChars(), type->toChars(), e->toChars(), e->type->toChars());
+    }
+    else
+    {
+        e = Expression::castTo(sc, t);
     }
     return e;
 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -1196,7 +1196,14 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             }
             if (p->storageClass & STCref)
             {
-                arg = arg->toLvalue(sc, arg);
+                if (arg->op == TOKslice
+                    && p->type->toBasetype()->ty == Tsarray)    // Workaround for bug 2486
+                {
+                    arg = arg->castTo(sc, p->type);
+                    arg = arg->toLvalue(sc, arg);
+                }
+                else
+                    arg = arg->toLvalue(sc, arg);
             }
             else if (p->storageClass & STCout)
             {

--- a/src/expression.h
+++ b/src/expression.h
@@ -1136,6 +1136,7 @@ struct SliceExp : UnaExp
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     int isBool(int result);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    Type *toStaticArrayType();
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     Expression *optimize(int result, bool keepLvalue = false);

--- a/src/expression.h
+++ b/src/expression.h
@@ -1136,6 +1136,8 @@ struct SliceExp : UnaExp
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     int isBool(int result);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    MATCH implicitConvTo(Type *t);
+    Expression *castTo(Scope *sc, Type *t);
     Expression *optimize(int result, bool keepLvalue = false);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void dump(int indent);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6049,6 +6049,11 @@ MATCH TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             //printf("%s\n", targb->toChars());
             //printf("%s\n", tprmb->toChars());
 
+            if (arg->op == TOKslice && tprmb->ty == Tsarray)
+            {   // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
+                targb = tprmb;
+            }
+
             /* find most derived alias this type being matched.
              */
             while (1)

--- a/src/template.c
+++ b/src/template.c
@@ -1517,12 +1517,11 @@ Lretry:
                     tb->ty == Taarray && (tbn = tb->nextOf())->ty == Tident &&
                                          ((TypeIdentifier *)tbn)->idents.dim == 0)
                 {
-                    unsigned errors = global.startGagging();
-                    Expression *lwr = se->lwr->optimize(WANTvalue);//ctfeInterpret();
-                    Expression *upr = se->upr->optimize(WANTvalue);//ctfeInterpret();
-                    size_t len = upr->toUInteger() - lwr->toUInteger();
-                    if (!global.endGagging(errors))
+                    Expression *lwr = se->lwr->optimize(WANTvalue);
+                    Expression *upr = se->upr->optimize(WANTvalue);
+                    if (lwr->isConst() && upr->isConst())
                     {
+                        size_t len = upr->toUInteger() - lwr->toUInteger();
                         argtype = new TypeSArray(argtype->nextOf(),
                                     new IntegerExp(0, len, Type::tindex));
                     }

--- a/src/template.c
+++ b/src/template.c
@@ -1517,14 +1517,9 @@ Lretry:
                     tb->ty == Taarray && (tbn = tb->nextOf())->ty == Tident &&
                                          ((TypeIdentifier *)tbn)->idents.dim == 0)
                 {
-                    Expression *lwr = se->lwr->optimize(WANTvalue);
-                    Expression *upr = se->upr->optimize(WANTvalue);
-                    if (lwr->isConst() && upr->isConst())
-                    {
-                        size_t len = upr->toUInteger() - lwr->toUInteger();
-                        argtype = new TypeSArray(argtype->nextOf(),
-                                    new IntegerExp(0, len, Type::tindex));
-                    }
+                    Type *tsa = se->toStaticArrayType();
+                    if (tsa)
+                        argtype = tsa;
                 }
             }
 

--- a/test/runnable/testbounds.d
+++ b/test/runnable/testbounds.d
@@ -177,10 +177,119 @@ void test1()
 }
 
 /******************************************/
+// 3652
+
+void test3652()
+{
+    int foo(int[4] x)
+    {
+        return x[0] + x[1] * x[2] - x[3];
+    }
+
+    int[] xs = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15];
+
+    // simple case
+    foo(xs[0 .. 4]);
+
+  version(none)
+  {
+    // Need deformation of formula and detection of base point
+    int x = 0;
+    int y = 0;
+    foreach (i; 0 .. 4)
+    {
+        x += foo(xs[i .. i + 4]);
+        y += foo(xs[(i*4+10)/2 .. (i*8>>1)/2+9]);
+        // lwr = (i*4 + 10)/2 = i*4/2 + 10/2            = (i*2+5)
+        // upr = (i*8>>1)/2 + 5 = (i*4/2) + 5 = i*2 + 9 = (i*2+5) + 4
+    }
+    assert(x == (0,1,2,3) + (1,2,3, 4) + (2, 3, 4, 5) + ( 3, 4, 5, 6));
+    assert(y == (5,6,7,8) + (7,8,9,10) + (9,10,11,12) + (11,12,13,14));
+  }
+}
+
+void test3652a() @safe
+{
+    string str = "aaaabbbbccccdddd";
+    //printf("str.ptr = %p\n", str.ptr);
+
+    void foo(ref const(char)[16] buf)
+    {
+        //printf("buf.ptr = %p\n", buf.ptr);
+        assert(buf.ptr is str.ptr);
+    }
+
+    // can check length at runtime
+    assert(str.length == 16);
+
+    // compiler can check the length of string literal, so
+    // conversion from immutable(char)[] to ref const(char)[16] is allowed;
+    static assert(__traits(compiles, foo("aaaabbbbccccdddd")));
+
+    // OK, correctly rejected by the compiler.
+    static assert(!__traits(compiles, foo(str[])));
+
+    // Ugly, furthermore does not work in safe code!
+    //foo(*cast(const(char)[16]*)(str[0..16].ptr));
+
+    // New: compiler can check the length of slice, but currently it is not allowed.
+    enum size_t m = 0;
+    size_t calc(){ return 0; }
+    foo(str[0 .. 16]);
+    foo(str[m .. 16]);
+  //foo(str[calc() .. 16]); // with CTFE
+
+    // If boundaries cannot be calculated in compile time, it's rejected.
+    size_t n;
+    size_t calc2(){ return n; }
+    static assert(!__traits(compiles, foo(str[n .. 16])));
+    static assert(!__traits(compiles, foo(str[calc2() .. 16])));
+}
+void test3652b() @safe
+{
+    int[] da = [1,2,3,4,5];
+
+    void bar(int[3] sa1, ref int[3] sa2)
+    {
+        assert(sa1 == [1,2,3] && sa1.ptr !is da.ptr);
+        assert(sa2 == [1,2,3] && sa2.ptr  is da.ptr);
+    }
+    bar(da[0..3], da[0..3]);
+    static assert(!__traits(compiles, bar(da[0..4], da[0..4])));
+
+    void baz1(T)(T[3] sa1, ref T[3] sa2)
+    {
+        assert(sa1 == [1,2,3] && sa1.ptr !is da.ptr);
+        assert(sa2 == [1,2,3] && sa2.ptr  is da.ptr);
+    }
+    void baz2(T, size_t dim)(T[dim] sa1, ref T[dim] sa2, size_t result)
+    {
+        assert(dim == result);
+        static if (dim == 3)
+        {
+            assert(sa1 == [1,2,3] && sa1.ptr !is da.ptr);
+            assert(sa2 == [1,2,3] && sa2.ptr  is da.ptr);
+        }
+        else
+        {
+            assert(sa1 == [1,2,3,4] && sa1.ptr !is da.ptr);
+            assert(sa2 == [1,2,3,4] && sa2.ptr  is da.ptr);
+        }
+    }
+    baz1(da[0..3], da[0..3]);
+    static assert(!__traits(compiles, baz1(da[0..4], da[0..4])));
+    baz2(da[0..3], da[0..3], 3);
+    baz2(da[0..4], da[0..4], 4);
+}
+
+/******************************************/
 
 int main()
 {
     test1();
+    test3652();
+    test3652a();
+    test3652b();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testbounds.d
+++ b/test/runnable/testbounds.d
@@ -3,6 +3,9 @@
 // Test array bounds checking
 
 import core.exception;
+extern(C) int printf(const char*, ...);
+
+/******************************************/
 
 const int foos[10] = [1,2,3,4,5,6,7,8,9,10];
 const int food[]   = [21,22,23,24,25,26,27,28,29,30];
@@ -45,7 +48,7 @@ const(int)[] slicep(int lwr, int upr)
     return foop[lwr .. upr];
 }
 
-int main()
+void test1()
 {
     int i;
 
@@ -61,22 +64,22 @@ int main()
     x = 10;
     try
     {
-	i = tests(0);
+        i = tests(0);
     }
     catch (RangeError a)
     {
-	i = 73;
+        i = 73;
     }
     assert(i == 73);
 
     x = -1;
     try
     {
-	i = testd(0);
+        i = testd(0);
     }
     catch (RangeError a)
     {
-	i = 37;
+        i = 37;
     }
     assert(i == 37);
 
@@ -96,45 +99,45 @@ int main()
 
     try
     {
-	i = 7;
-	r = slices(5,3);
+        i = 7;
+        r = slices(5,3);
     }
     catch (RangeError a)
     {
-	i = 53;
+        i = 53;
     }
     assert(i == 53);
 
     try
     {
-	i = 7;
-	r = slices(5,11);
+        i = 7;
+        r = slices(5,11);
     }
     catch (RangeError a)
     {
-	i = 53;
+        i = 53;
     }
     assert(i == 53);
 
     try
     {
-	i = 7;
-	r = sliced(5,11);
+        i = 7;
+        r = sliced(5,11);
     }
     catch (RangeError a)
     {
-	i = 53;
+        i = 53;
     }
     assert(i == 53);
 
     try
     {
-	i = 7;
-	r = slicep(5,3);
+        i = 7;
+        r = slicep(5,3);
     }
     catch (RangeError a)
     {
-	i = 53;
+        i = 53;
     }
     assert(i == 53);
 
@@ -171,7 +174,14 @@ int main()
     assert(r.length == 1);
     assert(x == 3);
     assert(r[0] == foop[1]);
+}
 
+/******************************************/
 
+int main()
+{
+    test1();
+
+    printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3652

If and only if both side of slice boundaries can be constant-folded, the conversion will succeed.

Limitation:
- Does not run CTFE.
- There is no deformation of formula.
