### PR TITLE
fix Issue 9623 - Illegal Win64 linker optimization?

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -232,6 +232,9 @@ int runLINK()
             cmdbuf.writestring("/DLL");
         }
 
+        // Bugzilla 9623
+        cmdbuf.writestring(" /OPT:REF /OPT:NOICF");
+
         for (size_t i = 0; i < global.params.linkswitches->dim; i++)
         {
             cmdbuf.writeByte(' ');


### PR DESCRIPTION
- ICF might break pointer comparison for COMDAT data/functions
- enabling REF also for debug builds removes the unreferenced
  NULL pointers in .minfo and ._deh

[Bugzilla 9623](http://d.puremagic.com/issues/show_bug.cgi?id=9623)
