### PR TITLE
Copy-paste error

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -96,7 +96,7 @@ Global::Global()
 #include "verstr.h"
     ;
 
-    global.structalign = STRUCTALIGN_DEFAULT;
+    structalign = STRUCTALIGN_DEFAULT;
 
     memset(&params, 0, sizeof(Param));
 }


### PR DESCRIPTION
This refers to global variable 'global' from inside Global's constructor.
