### PR TITLE
Issue 9658 - Setting pre-initialized field should be allowed in qualified constructor.

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -148,7 +148,7 @@ int Declaration::checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int fl
         return 0;
     }
 
-    if (v && isCtorinit())
+    if (v && (isCtorinit() || isField()))
     {   // It's only modifiable if inside the right constructor
         if ((storage_class & (STCforeach | STCref)) == (STCforeach | STCref))
             return 2;

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -798,6 +798,18 @@ void test9416()
 }
 
 /***************************************************/
+// 9658
+
+struct S9658
+{
+    private bool _isNull = true;
+    this(int v) const
+    {
+        _isNull = false;    // cannot modify const expression this._isNull
+    }
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9658

This is a blocker for qualified constructor support.
