### PR TITLE
Fix qualified constructor call semantics.

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -47,8 +47,8 @@ FuncDeclaration *AggregateDeclaration::hasIdentityOpAssign(Scope *sc, Dsymbol *a
         sc = sc->push();
         sc->speculative = true;
 
-                 f = resolveFuncCall(loc, sc, assign, NULL, er, &ar, 1);
-        if (!f)  f = resolveFuncCall(loc, sc, assign, NULL, er, &al, 1);
+                 f = resolveFuncCall(loc, sc, assign, NULL, type, &ar, 1);
+        if (!f)  f = resolveFuncCall(loc, sc, assign, NULL, type, &al, 1);
 
         sc = sc->pop();
         global.speculativeGag = oldspec;
@@ -344,8 +344,8 @@ FuncDeclaration *StructDeclaration::buildOpEquals(Scope *sc)
         sc = sc->push();
         sc->speculative = true;
 
-                 f = resolveFuncCall(loc, sc, eq, NULL, er, &ar, 1);
-        if (!f)  f = resolveFuncCall(loc, sc, eq, NULL, er, &al, 1);
+                 f = resolveFuncCall(loc, sc, eq, NULL, tthis, &ar, 1);
+        if (!f)  f = resolveFuncCall(loc, sc, eq, NULL, tthis, &al, 1);
 
         sc = sc->pop();
         global.speculativeGag = oldspec;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -103,7 +103,7 @@ struct Match
 };
 
 void overloadResolveX(Match *m, FuncDeclaration *f,
-        Expression *ethis, Expressions *arguments);
+        Type *tthis, Expressions *arguments);
 int overloadApply(FuncDeclaration *fstart,
         int (*fp)(void *, FuncDeclaration *),
         void *param);
@@ -651,7 +651,7 @@ struct FuncDeclaration : Declaration
     int findVtblIndex(Dsymbols *vtbl, int dim);
     int overloadInsert(Dsymbol *s);
     FuncDeclaration *overloadExactMatch(Type *t);
-    FuncDeclaration *overloadResolve(Loc loc, Expression *ethis, Expressions *arguments, int flags = 0);
+    FuncDeclaration *overloadResolve(Loc loc, Type *tthis, Expressions *arguments, int flags = 0);
     MATCH leastAsSpecialized(FuncDeclaration *g);
     LabelDsymbol *searchLabel(Identifier *ident);
     AggregateDeclaration *isThis();
@@ -720,7 +720,7 @@ struct FuncDeclaration : Declaration
 #if DMDV2
 FuncDeclaration *resolveFuncCall(Loc loc, Scope *sc, Dsymbol *s,
         Objects *tiargs,
-        Expression *ethis,
+        Type *tthis,
         Expressions *arguments,
         int flags = 0);
 #endif

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1163,8 +1163,7 @@ Type *Type::aliasthisOf()
             }
             else if (d->isFuncDeclaration())
             {
-                Expression *ethis = this->defaultInit(0);
-                FuncDeclaration *fd = resolveFuncCall(0, NULL, d, NULL, ethis, NULL, 1);
+                FuncDeclaration *fd = resolveFuncCall(0, NULL, d, NULL, this, NULL, 1);
                 if (fd && fd->functionSemantic())
                 {
                     t = fd->type->nextOf();
@@ -1184,8 +1183,7 @@ Type *Type::aliasthisOf()
         TemplateDeclaration *td = ad->aliasthis->isTemplateDeclaration();
         if (td)
         {   assert(td->scope);
-            Expression *ethis = defaultInit(0);
-            FuncDeclaration *fd = resolveFuncCall(0, NULL, td, NULL, ethis, NULL, 1);
+            FuncDeclaration *fd = resolveFuncCall(0, NULL, td, NULL, this, NULL, 1);
             if (fd && fd->functionSemantic())
             {
                 Type *t = fd->type->nextOf();
@@ -5724,14 +5722,14 @@ void TypeFunction::purityLevel()
  *      MATCHxxxx
  */
 
-MATCH TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
+MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
 {
     //printf("TypeFunction::callMatch() %s\n", toChars());
     MATCH match = MATCHexact;           // assume exact match
     unsigned wildmatch = 0;
 
-    if (ethis)
-    {   Type *t = ethis->type;
+    if (tthis)
+    {   Type *t = tthis;
         if (t->toBasetype()->ty == Tpointer)
             t = t->toBasetype()->nextOf();      // change struct* to struct
         if (t->mod != mod)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -677,7 +677,7 @@ struct TypeFunction : TypeNext
     bool parameterEscapes(Parameter *p);
     Type *addStorageClass(StorageClass stc);
 
-    MATCH callMatch(Expression *ethis, Expressions *toargs, int flag = 0);
+    MATCH callMatch(Type *tthis, Expressions *toargs, int flag = 0);
     type *toCtype();
     enum RET retStyle();
 

--- a/src/opover.c
+++ b/src/opover.c
@@ -1668,7 +1668,7 @@ static void templateResolve(Match *m, TemplateDeclaration *td, Loc loc, Scope *s
     FuncDeclaration *fd;
 
     assert(td);
-    fd = td->deduceFunctionTemplate(loc, sc, tiargs, ethis, arguments, 1);
+    fd = td->deduceFunctionTemplate(loc, sc, tiargs, ethis->type, arguments, 1);
     if (!fd)
         return;
     m->anyf = fd;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1126,7 +1126,7 @@ Dsymbol *Parser::parseCtor()
     Loc loc = this->loc;
 
     nextToken();
-    if (token.value == TOKlparen && peek(&token)->value == TOKthis)
+    if (token.value == TOKlparen && peekNext() == TOKthis && peekNext2() == TOKrparen)
     {   // this(this) { ... }
         nextToken();
         nextToken();

--- a/src/template.h
+++ b/src/template.h
@@ -97,7 +97,7 @@ struct TemplateDeclaration : ScopeDsymbol
     MATCH deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, Objects *dedargs);
     FuncDeclaration *deduceFunctionTemplate(Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, int flags = 0);
     Object *declareParameter(Scope *sc, TemplateParameter *tp, Object *o);
-    FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs, Expressions *fargs);
+    FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs, Type *tthis, Expressions *fargs);
 
     TemplateDeclaration *isTemplateDeclaration() { return this; }
 

--- a/src/template.h
+++ b/src/template.h
@@ -94,8 +94,8 @@ struct TemplateDeclaration : ScopeDsymbol
     MATCH matchWithInstance(TemplateInstance *ti, Objects *atypes, Expressions *fargs, int flag);
     MATCH leastAsSpecialized(TemplateDeclaration *td2, Expressions *fargs);
 
-    MATCH deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objects *tiargs, Expression *ethis, Expressions *fargs, Objects *dedargs);
-    FuncDeclaration *deduceFunctionTemplate(Loc loc, Scope *sc, Objects *tiargs, Expression *ethis, Expressions *fargs, int flags = 0);
+    MATCH deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, Objects *dedargs);
+    FuncDeclaration *deduceFunctionTemplate(Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, int flags = 0);
     Object *declareParameter(Scope *sc, TemplateParameter *tp, Object *o);
     FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs, Expressions *fargs);
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -5142,7 +5142,7 @@ static assert(bug8865());
 
 struct Test75
 {
-    this(int){}
+    this(int) pure {}
 }
 
 static assert(__traits(compiles, {static shared Test75* t75 = new shared(Test75)(0); return t75;}));
@@ -5166,7 +5166,7 @@ static assert(!__traits(compiles, {static Test75* t75 = new Test75(0); return t7
 
 class Test76
 {
-    this(int){}
+    this(int) pure {}
 }
 
 //static assert(!__traits(compiles, {enum t76 = new shared(Test76)(0); return t76;}));

--- a/test/runnable/eh2.d
+++ b/test/runnable/eh2.d
@@ -4,7 +4,7 @@ extern(C) int printf(const char*, ...);
 
 class Abc : Throwable
 {
-    this()
+    this() pure
     {
         super("");
     }
@@ -13,20 +13,20 @@ class Abc : Throwable
 
     synchronized void test()
     {
-	printf("test 1\n");
-	x |= 1;
-	foo();
-	printf("test 2\n");
-	x |= 2;
+        printf("test 1\n");
+        x |= 1;
+        foo();
+        printf("test 2\n");
+        x |= 2;
     }
 
     shared void foo()
     {
-	printf("foo 1\n");
-	x |= 4;
-	throw this;
-	printf("foo 2\n");
-	x |= 8;
+        printf("foo 1\n");
+        x |= 4;
+        throw this;
+        printf("foo 2\n");
+        x |= 8;
     }
 }
 
@@ -41,21 +41,22 @@ struct RefCounted
 
 struct S
 {
-  RefCounted _data;
+    RefCounted _data;
 
-  int get() @property
-  {
-      throw new Exception("");
-  }
+    int get() @property
+    {
+        throw new Exception("");
+    }
 }
 
 void b9438()
 {
-     try {
+    try
+    {
         S s;
         S().get;
-     }
-     catch (Exception e){ }
+    }
+    catch (Exception e){ }
 }
 
 int main()
@@ -67,16 +68,16 @@ int main()
 
     try
     {
-	Abc.x |= 0x20;
-	a.test();
-	Abc.x |= 0x40;
+        Abc.x |= 0x20;
+        a.test();
+        Abc.x |= 0x40;
     }
     catch (shared(Abc) b)
     {
-	Abc.x |= 0x80;
-	printf("Caught %p, x = x%x\n", b, Abc.x);
-	assert(a is b);
-	assert(Abc.x == 0xB5);
+        Abc.x |= 0x80;
+        printf("Caught %p, x = x%x\n", b, Abc.x);
+        assert(a is b);
+        assert(Abc.x == 0xB5);
     }
     printf("Success!\n");
     b9438();

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -2854,7 +2854,7 @@ class Test105b: Test105a, ITest105b
 {
     char e;
     int f;
-    this(char _e, int _f, char _a, int _b)
+    this(char _e, int _f, char _a, int _b) pure
     {
         e = _e;
         f = _f;

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1089,11 +1089,11 @@ struct S41 {
 
 void test41()
 {
-    auto s = new S41(3);
+    auto s = new immutable S41(3);
     //writeln(typeid(typeof(s)));
     static assert(is(typeof(s) == immutable(S41)*));
 
-    auto t = S41(3);
+    auto t = immutable S41(3);
     //writeln(typeid(typeof(t)));
     static assert(is(typeof(t) == immutable(S41)));
 }
@@ -1107,9 +1107,9 @@ class C42 {
 
 void test42()
 {
-    auto c = new C42(3);
+    static assert(!__traits(compiles, new C42(3)));
     //writeln(typeid(typeof(c)));
-    static assert(is(typeof(c) == immutable(C42)));
+    //static assert(is(typeof(c) == immutable(C42)));
 
     auto d = new immutable(C42)(3);
     //writeln(typeid(typeof(d)));

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2116,7 +2116,7 @@ void test5493()
     class C
     {
         int x;
-        this(int i) { x = i; }
+        this(int i) immutable { x = i; }
     }
     C[] cs;
     immutable C ci = new immutable(C)(6);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3029,7 +3029,7 @@ void test141()
 struct S142
 {
     int v;
-    this(int n) { v = n; }
+    this(int n) pure { v = n; }
     const bool opCast(T:bool)() { return true; }
 }
 
@@ -4191,7 +4191,7 @@ void test6578()
 {
     static struct Foo
     {
-        this(int x) {}
+        this(int x) pure {}
     }
     auto f1 = new const(Foo)(1);
     auto f2 = new immutable(Foo)(1);
@@ -4208,7 +4208,7 @@ void test6578()
 
     static struct Bar
     {
-        this(int x) const {}
+        this(int x) const pure {}
     }
     auto g1 = new const(Bar)(1);
     auto g2 = new immutable(Bar)(1);
@@ -4218,21 +4218,21 @@ void test6578()
     auto g6 = shared(Bar)(1);
     static assert(is(typeof(g1) == const(Bar)*));
     static assert(is(typeof(g2) == immutable(Bar)*));
-    static assert(is(typeof(g3) == shared(const(Bar))*));
+    static assert(is(typeof(g3) == shared(Bar)*));
     static assert(is(typeof(g4) == const(Bar)));
     static assert(is(typeof(g5) == immutable(Bar)));
-    static assert(is(typeof(g6) == shared(const(Bar))));
+    static assert(is(typeof(g6) == shared(Bar)));
 
     static struct Baz
     {
-        this()(int x) const {}
+        this()(int x) const pure {}
     }
     auto h1 = new const(Baz)(1);
     auto h2 = new immutable(Baz)(1);
-    auto h3 = new shared(Baz)(1);
+    auto h3 = new shared(const(Baz))(1);
     auto h4 = const(Baz)(1);
     auto h5 = immutable(Baz)(1);
-    auto h6 = shared(Baz)(1);
+    auto h6 = shared(const(Baz))(1);
     static assert(is(typeof(h1) == const(Baz)*));
     static assert(is(typeof(h2) == immutable(Baz)*));
     static assert(is(typeof(h3) == shared(const(Baz))*));


### PR DESCRIPTION
By this change, one of following is required for immutable object construction:
1. immutable constructor
   That is described in TDPL.
   
   ``` d
   struct S {
     int[] value;
     this(int v, int n) immutable { foreach (_; 0 .. n) value ~= v; }
   }
   void main() {
     auto i = immutable S(1, 3); // OK
     assert(i.value == [1,1,1]);
   
     auto c = const S(1, 3); // also OK
     // because immutable object is implicitly convertible to const
   
     static assert(!__traits(compiles, S(1, 3))); // not allowed
   }
   ```
2. inout constructor
   The qualifier of generated object by inout constructor is calculated as if that is returned value from inout function.
   
   ``` d
   struct S {
     int[] value;
     this(inout int[] arr) inout { value = arr; }
   }
   void main() {
     auto m = S([1,2,3]); // OK
     auto c = const S([1,2,3]); // OK
     auto i = immutable S([1,2,3].idup); // OK
   
     static assert(!__traits(compiles, immutable S([1,2,3]))); // not allowed
     static assert(!__traits(compiles, S([1,2,3].idup))); // not allowed
   }
   ```
3. unique constructor
   If a pure constructor can create _unique_ object, the generated object can be implicitly convertible to any qualifier.
   
   ``` d
   struct S {
     int[] value;
     this(inout int[] arr) pure {
       value = arr.dup;
     }
   }
   void main() {
     auto m = S([1,2,3]); // OK
     auto c = const S([1,2,3]); // OK
     auto i = immutable S([1,2,3].idup); // OK
   
     auto m2 = S([1,2,3].idup);   // also OK
     auto i2 = immutable S([1,2,3]);  // also OK
   
     auto s = shared S([1,2,3]); // OK!
     auto sc = shared S([1,2,3]); // OK!
   }
   ```
