### PR TITLE
Issue 9650 - __traits(compiles) + mixin

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6539,7 +6539,10 @@ Expression *CompileExp::semantic(Scope *sc)
     p.loc = loc;
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
+    unsigned errors = global.errors;
     Expression *e = p.parseExpression();
+    if (global.errors != errors)
+        return new ErrorExp();
     if (p.token.value != TOKeof)
     {   error("incomplete mixin expression (%s)", se->toChars());
         return new ErrorExp();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9650

I couldn't minimize test case, but the bug fix is obvious.

The bug had been hiding for a long time, but recent Phobos change (https://github.com/D-Programming-Language/phobos/commit/2a88fea7867f33fd1cf15c2dca7790a3c8aea474) had exposed the bug.

When a mixin expression gets invalid code string, the parsing error had not handled correctly. In such case, it had generated _invalid_ AST instead of returning ErrorExp. I guess that the invalid AST would report weird error in later semantic analysis.

I think that both CompileDeclaration and CompileStatement do not have same problem. So they are not changed.
