### PR TITLE
Define Pprotectionnames as extern.

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -33,6 +33,9 @@
 #include "attrib.h"
 #include "enum.h"
 
+const char* Pprotectionnames[] = {NULL, "none", "private", "package", "protected", "public", "export"};
+
+
 /****************************** Dsymbol ******************************/
 
 Dsymbol::Dsymbol()

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -95,7 +95,7 @@ enum PROT
 };
 
 // this is used for printing the protection in json, traits, docs, etc.
-static const char* Pprotectionnames[] = {NULL, "none", "private", "package", "protected", "public", "export"};
+extern const char* Pprotectionnames[];
 
 /* State of symbol in winding its way through the passes of the compiler
  */


### PR DESCRIPTION
Trivial change.  More of a cosmetic thing if anything, but at least its enough to stop spurious warnings occurring for those of us who build their compilers with -Wunused.
