### PR TITLE
Partial fix issue 3789 - Structs members that require non-bitwise comparison not correctly compared

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -273,10 +273,8 @@ int StructDeclaration::needOpEquals()
     if (hasIdentityEquals)
         goto Lneed;
 
-#if 0
     if (isUnionDeclaration())
         goto Ldontneed;
-#endif
 
     /* If any of the fields has an opEquals, then we
      * need it too.
@@ -289,11 +287,11 @@ int StructDeclaration::needOpEquals()
         if (v->storage_class & STCref)
             continue;
         Type *tv = v->type->toBasetype();
-#if 0
         if (tv->isfloating())
             goto Lneed;
         if (tv->ty == Tarray)
             goto Lneed;
+#if 0
         if (tv->ty == Tclass)
             goto Lneed;
 #endif
@@ -380,10 +378,19 @@ FuncDeclaration *StructDeclaration::buildOpEquals(Scope *sc)
         assert(v && v->isField());
         if (v->storage_class & STCref)
             assert(0);                  // what should we do with this?
+        Type *tb = v->type->toBasetype();
         // this.v == s.v;
-        EqualExp *ec = new EqualExp(TOKequal, loc,
-            new DotVarExp(loc, new ThisExp(loc), v, 0),
-            new DotVarExp(loc, new IdentifierExp(loc, Id::p), v, 0));
+        Expression *e1x = new DotVarExp(loc, new ThisExp(loc), v, 0);
+        Expression *e2x = new DotVarExp(loc, new IdentifierExp(loc, Id::p), v, 0);
+        Expression *ec;
+        if (tb->ty == Tstruct && tb->toDsymbol(NULL)->isUnionDeclaration()
+#if 1   // workaround until bugzilla 9671 is fixed
+            || tb->ty == Tclass
+#endif
+           )
+            ec = new IdentityExp(TOKidentity, loc, e1x, e2x);
+        else
+            ec = new EqualExp(TOKequal, loc, e1x, e2x);
         if (e)
             e = new AndAndExp(loc, e, ec);
         else

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -665,6 +665,108 @@ void test17()
 }
 
 /**************************************/
+// 3789
+
+bool test3789()
+{
+    static struct Float
+    {
+        double x;
+    }
+    Float f;
+    assert(f.x != f.x); // NaN != NaN
+    assert(f != f);
+
+    static struct Array
+    {
+        int[] x;
+    }
+    Array a1 = Array([1,2,3].dup);
+    Array a2 = Array([1,2,3].dup);
+    if (!__ctfe)
+    {   // Doesn't work in CTFE, I'm not sure it is intended or not.
+        assert(a1.x !is a2.x);
+    }
+    assert(a1.x == a2.x);
+    assert(a1 == a2);
+
+    if (!__ctfe)
+    {   // union operation currently is not supported in CTFE.
+        union U1
+        {
+            double x;
+        }
+        static struct UnionA
+        {
+            int[] a;
+            U1 u;
+        }
+        auto ua1 = UnionA([1,2,3]);
+        auto ua2 = UnionA([1,2,3]);
+        assert(ua1.u.x is ua2.u.x);
+        assert(ua1.u.x != ua2.u.x);
+        assert(ua1 == ua2);
+        ua1.u.x = 1.0;
+        ua2.u.x = 1.0;
+        assert(ua1.u.x is ua2.u.x);
+        assert(ua1.u.x == ua2.u.x);
+        assert(ua1 == ua2);
+        ua1.u.x = double.nan;
+        assert(ua1.u.x !is ua2.u.x);
+        assert(ua1.u.x !=  ua2.u.x);
+        assert(ua1 != ua2);
+
+        union U2
+        {
+            int[] a;
+        }
+        static struct UnionB
+        {
+            double x;
+            U2 u;
+        }
+        auto ub1 = UnionB(1.0);
+        auto ub2 = UnionB(1.0);
+        assert(ub1.u.a is ub2.u.a);
+        assert(ub1.u.a == ub2.u.a);
+        assert(ub1 == ub2);
+        ub1.u.a = [1,2,3].dup;
+        ub2.u.a = [1,2,3].dup;
+        assert(ub1.u.a !is ub2.u.a);
+        assert(ub1.u.a  == ub2.u.a);
+        assert(ub1 != ub2);
+        ub2.u.a = ub1.u.a;
+        assert(ub1.u.a is ub2.u.a);
+        assert(ub1.u.a == ub2.u.a);
+        assert(ub1 == ub2);
+    }
+  /+
+    static struct Class
+    {
+        Object x;
+    }
+    static class X
+    {
+        override bool opEquals(Object o){ return true; }
+    }
+
+    Class c1a = Class(new Object());
+    Class c2a = Class(new Object());
+    assert(c1a.x !is c2a.x);
+    assert(c1a.x != c2a.x);
+    assert(c1a != c2a); // Pass, Object.opEquals works like bitwise compare
+
+    Class c1b = Class(new X());
+    Class c2b = Class(new X());
+    assert(c1b.x !is c2b.x);
+    assert(c1b.x == c2b.x);
+    assert(c1b == c2b); // Fails, should pass
+  +/
+    return true;
+}
+static assert(test3789());
+
+/**************************************/
 // 7641
 
 mixin template Proxy7641(alias a)
@@ -1044,6 +1146,7 @@ int main()
     test15();
     test16();
     test17();
+    test3789();
     test7641();
     test8434();
     test18();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=3789

Because of [bug 9671](http://d.puremagic.com/issues/show_bug.cgi?id=9671), class/interface field comparison is excepted.
