### PR TITLE
Refactor CTFE stack frames

### DIFF
--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -304,6 +304,27 @@ bool bug4837()
 static assert(bug4837());
 
 /**************************************************
+  'this' parameter bug revealed during refactoring
+**************************************************/
+int thisbug1(int x) { return x; }
+
+struct ThisBug1
+{
+    int m = 1;
+    int wut() {
+        return thisbug1(m);
+    }
+}
+
+int thisbug2()
+{
+    ThisBug1 spec;
+    return spec.wut();
+}
+
+static assert(thisbug2());
+
+/**************************************************
    6972 ICE with cast()cast()assign
 **************************************************/
 


### PR DESCRIPTION
The CTFE frame pointers and 'this' pointers were stored in Interstate, because they originally were an ugly hack. This pull request moves them into CtfeStack where all other stack variables are stored; it removes a nasty coupling between Interstate and CtfeStack.

(This is part of a massive CTFE rewrite, I've split it into pieces to make it easier to review).
