### PR TITLE
[REG2.063a] Issue 9694 - A member struct that has mutable opEquals reports weird error message

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -330,9 +330,10 @@ FuncDeclaration *StructDeclaration::buildOpEquals(Scope *sc)
     {
         /* check identity opEquals exists
          */
-        Expression *er = new NullExp(loc, type);        // dummy rvalue
+        Type *tthis = type->constOf();
+        Expression *er = new NullExp(loc, tthis);       // dummy rvalue
         Expression *el = new IdentifierExp(loc, Id::p); // dummy lvalue
-        el->type = type;
+        el->type = tthis;
         Expressions ar;  ar.push(er);
         Expressions al;  al.push(el);
         FuncDeclaration *f = NULL;

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1003,6 +1003,26 @@ void test9689()
 }
 
 /**************************************/
+// 9694
+
+struct S9694
+{
+    bool opEquals(ref S9694 rhs)
+    {
+        assert(0);
+    }
+}
+struct T9694
+{
+    S9694 s;
+}
+void test9694()
+{
+    T9694 t;
+    assert(typeid(T9694).equals(&t, &t));
+}
+
+/**************************************/
 
 int main()
 {
@@ -1031,6 +1051,7 @@ int main()
     test9453();
     test9496();
     test9689();
+    test9694();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9694

It was introduced by a careless miss in #1738.
