### PR TITLE
Add new Target hook to retrieve align sizes of basic types.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2759,41 +2759,8 @@ d_uns64 TypeBasic::size(Loc loc)
 }
 
 unsigned TypeBasic::alignsize()
-{   unsigned sz;
-
-    switch (ty)
-    {
-        case Tfloat80:
-        case Timaginary80:
-        case Tcomplex80:
-            sz = Target::realalignsize;
-            break;
-
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-        case Tint64:
-        case Tuns64:
-            sz = global.params.is64bit ? 8 : 4;
-            break;
-
-        case Tfloat64:
-        case Timaginary64:
-            sz = global.params.is64bit ? 8 : 4;
-            break;
-
-        case Tcomplex32:
-            sz = 4;
-            break;
-
-        case Tcomplex64:
-            sz = global.params.is64bit ? 8 : 4;
-            break;
-#endif
-
-        default:
-            sz = size(0);
-            break;
-    }
-    return sz;
+{
+    return Target::alignsize(this);
 }
 
 

--- a/src/target.c
+++ b/src/target.c
@@ -11,6 +11,7 @@
 
 #include "target.h"
 #include "mars.h"
+#include "mtype.h"
 
 int Target::ptrsize;
 int Target::realsize;
@@ -56,5 +57,38 @@ void Target::init()
             realalignsize = 16;
         }
     }
+}
+
+unsigned Target::alignsize (Type* type)
+{
+    assert (type->isTypeBasic());
+
+    switch (type->ty)
+    {
+        case Tfloat80:
+        case Timaginary80:
+        case Tcomplex80:
+            return Target::realalignsize;
+
+        case Tcomplex32:
+            if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD
+                || global.params.isOpenBSD || global.params.isSolaris)
+                return 4;
+            break;
+
+        case Tint64:
+        case Tuns64:
+        case Tfloat64:
+        case Timaginary64:
+        case Tcomplex64:
+            if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD
+                || global.params.isOpenBSD || global.params.isSolaris)
+                return global.params.is64bit ? 8 : 4;
+            break;
+
+        default:
+            break;
+    }
+    return type->size(0);
 }
 

--- a/src/target.h
+++ b/src/target.h
@@ -14,6 +14,8 @@
 // At present it is incomplete, but in future it should grow to contain
 // most or all target machine and target O/S specific information.
 
+struct Type;
+
 struct Target
 {
     static int ptrsize;
@@ -22,6 +24,7 @@ struct Target
     static int realalignsize;   // alignment for reals
     
     static void init();
+    static unsigned alignsize(Type* type);
 };
 
 #endif


### PR DESCRIPTION
Follow on from https://github.com/D-Programming-Language/dmd/pull/1626

This pull adds a new target hook to allow other compiler backends to return the type align size in a way that is independent from whichever host / target the compiler is built for.
