### PR TITLE
Issue 9712 - IFTI does not support deducing static array types from array literal arguments

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1008,12 +1008,9 @@ MATCH SliceExp::implicitConvTo(Type *t)
         tb->ty == Tsarray && typeb->ty == Tarray &&
         lwr && upr)
     {
-        if (typeb->nextOf()->constConv(tb->nextOf()))
-        {
-            typeb = toStaticArrayType();
-            if (typeb)
-                result = typeb->implicitConvTo(t);
-        }
+        typeb = toStaticArrayType();
+        if (typeb)
+            result = typeb->implicitConvTo(t);
     }
     return result;
 }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5948,13 +5948,19 @@ MATCH TypeFunction::callMatch(Expression *ethis, Expressions *args, int flag)
             {
                 if (arg->op == TOKstring && tprmb->ty == Tsarray)
                 {   if (targb->ty != Tsarray)
+                	{
                         targb = new TypeSArray(targb->nextOf(),
                                 new IntegerExp(0, ((StringExp *)arg)->len,
                                 Type::tindex));
+                        targb = targb->semantic(0, NULL);
+                    }
                 }
                 else if (arg->op == TOKslice && tprmb->ty == Tsarray)
                 {   // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
-                    targb = tprmb;
+                    targb = new TypeSArray(targb->nextOf(),
+                            new IntegerExp(0, ((TypeSArray *)tprmb)->dim->toUInteger(),
+                            Type::tindex));
+                    targb = targb->semantic(0, NULL);
                 }
                 else
                     goto Nomatch;

--- a/src/template.c
+++ b/src/template.c
@@ -1490,11 +1490,11 @@ Lretry:
 #if DMDV2
             /* Allow expressions that have CT-known boundaries and type [] to match with [dim]
              */
-            Type *tpn;
+            Type *taai;
             if ( argtype->ty == Tarray &&
                 (prmtype->ty == Tsarray ||
-                 prmtype->ty == Taarray && (tpn = prmtype->nextOf())->ty == Tident &&
-                                           ((TypeIdentifier *)tpn)->idents.dim == 0))
+                 prmtype->ty == Taarray && (taai = ((TypeAArray *)prmtype)->index)->ty == Tident &&
+                                           ((TypeIdentifier *)taai)->idents.dim == 0))
             {
                 if (farg->op == TOKstring && !((StringExp *)farg)->committed)
                 {   StringExp *se = (StringExp *)farg;

--- a/src/template.c
+++ b/src/template.c
@@ -1490,38 +1490,25 @@ Lretry:
 #if DMDV2
             /* Allow expressions that have CT-known boundaries and type [] to match with [dim]
              */
-            if (farg->op == TOKstring)
-            {   StringExp *se = (StringExp *)farg;
-                if (!se->committed &&
-                    argtype->ty == Tarray &&
-                    prmtype->toBasetype()->ty == Tsarray)
-                {
+            Type *tpn;
+            if ( argtype->ty == Tarray &&
+                (prmtype->ty == Tsarray ||
+                 prmtype->ty == Taarray && (tpn = prmtype->nextOf())->ty == Tident &&
+                                           ((TypeIdentifier *)tpn)->idents.dim == 0))
+            {
+                if (farg->op == TOKstring && !((StringExp *)farg)->committed)
+                {   StringExp *se = (StringExp *)farg;
                     argtype = new TypeSArray(argtype->nextOf(), new IntegerExp(se->loc, se->len, Type::tindex));
                     argtype = argtype->semantic(se->loc, NULL);
-                    argtype = argtype->invariantOf();
                 }
-            }
-            else if (farg->op == TOKslice)
-            {   SliceExp *se = (SliceExp *)farg;
-                Type *tb = prmtype->toBasetype();
-                Type *tbn;
-                if (tb->ty == Tsarray ||
-                    tb->ty == Taarray && (tbn = tb->nextOf())->ty == Tident &&
-                                         ((TypeIdentifier *)tbn)->idents.dim == 0)
-                {
+                else if (farg->op == TOKslice)
+                {   SliceExp *se = (SliceExp *)farg;
                     Type *tsa = se->toStaticArrayType();
                     if (tsa)
                         argtype = tsa;
                 }
-            }
-            else if (farg->op == TOKarrayliteral)
-            {   ArrayLiteralExp *ae = (ArrayLiteralExp *)farg;
-                Type *tb = prmtype->toBasetype();
-                Type *tbn;
-                if (tb->ty == Tsarray ||
-                    tb->ty == Taarray && (tbn = tb->nextOf())->ty == Tident &&
-                                         ((TypeIdentifier *)tbn)->idents.dim == 0)
-                {
+                else if (farg->op == TOKarrayliteral)
+                {   ArrayLiteralExp *ae = (ArrayLiteralExp *)farg;
                     argtype = new TypeSArray(argtype->nextOf(), new IntegerExp(ae->loc, ae->elements->dim, Type::tindex));
                     argtype = argtype->semantic(ae->loc, NULL);
                 }

--- a/src/template.c
+++ b/src/template.c
@@ -1488,16 +1488,42 @@ Lretry:
             }
 
 #if DMDV2
-            /* Allow string literals which are type [] to match with [dim]
+            /* Allow expressions that have CT-known boundaries and type [] to match with [dim]
              */
             if (farg->op == TOKstring)
             {   StringExp *se = (StringExp *)farg;
-                if (!se->committed && argtype->ty == Tarray &&
+                if (!se->committed &&
+                    argtype->ty == Tarray &&
                     prmtype->toBasetype()->ty == Tsarray)
                 {
                     argtype = new TypeSArray(argtype->nextOf(), new IntegerExp(se->loc, se->len, Type::tindex));
                     argtype = argtype->semantic(se->loc, NULL);
                     argtype = argtype->invariantOf();
+                }
+            }
+            else if (farg->op == TOKslice)
+            {   SliceExp *se = (SliceExp *)farg;
+                Type *tb = prmtype->toBasetype();
+                Type *tbn;
+                if (tb->ty == Tsarray ||
+                    tb->ty == Taarray && (tbn = tb->nextOf())->ty == Tident &&
+                                         ((TypeIdentifier *)tbn)->idents.dim == 0)
+                {
+                    Type *tsa = se->toStaticArrayType();
+                    if (tsa)
+                        argtype = tsa;
+                }
+            }
+            else if (farg->op == TOKarrayliteral)
+            {   ArrayLiteralExp *ae = (ArrayLiteralExp *)farg;
+                Type *tb = prmtype->toBasetype();
+                Type *tbn;
+                if (tb->ty == Tsarray ||
+                    tb->ty == Taarray && (tbn = tb->nextOf())->ty == Tident &&
+                                         ((TypeIdentifier *)tbn)->idents.dim == 0)
+                {
+                    argtype = new TypeSArray(argtype->nextOf(), new IntegerExp(ae->loc, ae->elements->dim, Type::tindex));
+                    argtype = argtype->semantic(ae->loc, NULL);
                 }
             }
 
@@ -1511,20 +1537,6 @@ Lretry:
                     goto Lvarargs;
                 farg = e;
                 argtype = farg->type;
-            }
-
-            if (farg->op == TOKslice)
-            {   SliceExp *se = (SliceExp *)farg;
-                Type *tb = prmtype->toBasetype();
-                Type *tbn;
-                if (tb->ty == Tsarray ||
-                    tb->ty == Taarray && (tbn = tb->nextOf())->ty == Tident &&
-                                         ((TypeIdentifier *)tbn)->idents.dim == 0)
-                {
-                    Type *tsa = se->toStaticArrayType();
-                    if (tsa)
-                        argtype = tsa;
-                }
             }
 
             if (!(fparam->storageClass & STClazy) && argtype->ty == Tvoid)

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2044,13 +2044,26 @@ void test9536()
 /**********************************/
 // 9654
 
-auto foo9654(ref const char[8] str) { return str; }
-auto bar9654(T)(ref const T[8] str) { return str; }
-auto baz9654(T, size_t dim)(ref const T[dim] str) { return str; }
+auto foo9654a(ref           char[8] str) { return str; }
+auto foo9654b(ref     const char[8] str) { return str; }
+auto foo9654c(ref immutable char[8] str) { return str; }
+static assert(!is(typeof(foo9654a("testinfo"))));
+static assert( is(typeof(foo9654b("testinfo")) ==     const char[8]));
+static assert( is(typeof(foo9654c("testinfo")) == immutable char[8]));
 
-static assert(is(typeof(foo9654("testinfo")) == const char[8]));
-static assert(is(typeof(bar9654("testinfo")) == const char[8]));
-static assert(is(typeof(baz9654("testinfo")) == const char[8]));
+auto bar9654a(T)(ref           T[8] str) { return str; static assert(is(T == immutable char)); }
+auto bar9654b(T)(ref     const T[8] str) { return str; static assert(is(T ==           char)); }
+auto bar9654c(T)(ref immutable T[8] str) { return str; static assert(is(T ==           char)); }
+static assert( is(typeof(bar9654a("testinfo")) == immutable char[8]));
+static assert( is(typeof(bar9654b("testinfo")) ==     const char[8]));
+static assert( is(typeof(bar9654c("testinfo")) == immutable char[8]));
+
+auto baz9654a(T, size_t dim)(ref           T[dim] str) { return str; static assert(is(T == immutable char)); }
+auto baz9654b(T, size_t dim)(ref     const T[dim] str) { return str; static assert(is(T ==           char)); }
+auto baz9654c(T, size_t dim)(ref immutable T[dim] str) { return str; static assert(is(T ==           char)); }
+static assert( is(typeof(baz9654a("testinfo")) == immutable char[8]));
+static assert( is(typeof(baz9654b("testinfo")) ==     const char[8]));
+static assert( is(typeof(baz9654c("testinfo")) == immutable char[8]));
 
 /******************************************/
 // 9712

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2044,14 +2044,13 @@ void test9536()
 /**********************************/
 // 9654
 
-void foo9654(ref const char[8] str) {}
-void bar9654(T)(ref const T[8] str) {}
+auto foo9654(ref const char[8] str) { return str; }
+auto bar9654(T)(ref const T[8] str) { return str; }
+auto baz9654(T, size_t dim)(ref const T[dim] str) { return str; }
 
-void test9654()
-{
-    foo9654("testinfo");
-    bar9654("testinfo");
-}
+static assert(is(typeof(foo9654("testinfo")) == const char[8]));
+static assert(is(typeof(bar9654("testinfo")) == const char[8]));
+static assert(is(typeof(baz9654("testinfo")) == const char[8]));
 
 /******************************************/
 // 9712
@@ -2138,7 +2137,6 @@ int main()
     test9143();
     test9266();
     test9536();
-    test9654();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2054,6 +2054,15 @@ void test9654()
 }
 
 /******************************************/
+// 9712
+
+auto func9712(T)(T[2] arg) { return arg; }
+static assert(is(typeof(func9712([1,2])) == int[2]));
+
+auto deduceLength9712(T,size_t n)(T[n] a) { return a; }
+static assert(is(typeof(deduceLength9712([1,2,3])) == int[3]));
+
+/******************************************/
 
 int main()
 {

--- a/test/runnable/testbounds.d
+++ b/test/runnable/testbounds.d
@@ -244,6 +244,9 @@ void test3652a() @safe
     size_t calc2(){ return n; }
     static assert(!__traits(compiles, foo(str[n .. 16])));
     static assert(!__traits(compiles, foo(str[calc2() .. 16])));
+
+    //void hoo(size_t dim)(char[dim]) { static assert(dim == 2); }
+    //hoo(str[0 .. 2]);
 }
 void test3652b() @safe
 {
@@ -280,6 +283,9 @@ void test3652b() @safe
     static assert(!__traits(compiles, baz1(da[0..4], da[0..4])));
     baz2(da[0..3], da[0..3], 3);
     baz2(da[0..4], da[0..4], 4);
+
+    void hoo(size_t dim)(int[dim]) { static assert(dim == 2); }
+    hoo(da[0 .. 2]);
 }
 
 /******************************************/

--- a/test/runnable/testbounds.d
+++ b/test/runnable/testbounds.d
@@ -245,8 +245,14 @@ void test3652a() @safe
     static assert(!__traits(compiles, foo(str[n .. 16])));
     static assert(!__traits(compiles, foo(str[calc2() .. 16])));
 
-    //void hoo(size_t dim)(char[dim]) { static assert(dim == 2); }
-    //hoo(str[0 .. 2]);
+    void hoo1(size_t dim)(char[dim]) { static assert(dim == 2); }
+    void hoo2(char[2]) {}
+    void hoo3(size_t dim)(ref char[dim]) {}
+    void hoo4(ref char[2]) {}
+    hoo1(str[0 .. 2]);
+    hoo2(str[0 .. 2]);
+    static assert(!__traits(compiles, hoo3(str[0 .. 2])));
+    static assert(!__traits(compiles, hoo4(str[0 .. 2])));
 }
 void test3652b() @safe
 {
@@ -284,8 +290,14 @@ void test3652b() @safe
     baz2(da[0..3], da[0..3], 3);
     baz2(da[0..4], da[0..4], 4);
 
-    void hoo(size_t dim)(int[dim]) { static assert(dim == 2); }
-    hoo(da[0 .. 2]);
+    void hoo1(size_t dim)(int[dim]) { static assert(dim == 2); }
+    void hoo2(int[2]) {}
+    void hoo3(size_t dim)(ref int[dim]) {}
+    void hoo4(ref int[2]) {}
+    hoo1(da.idup[0 .. 2]);
+    hoo2(da.idup[0 .. 2]);
+    static assert(!__traits(compiles, hoo3(da.idup[0 .. 2])));
+    static assert(!__traits(compiles, hoo4(da.idup[0 .. 2])));
 }
 
 /******************************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9712

IFTI should consider the argument's compile-time known boundaries.

By this change, the lengths of string literal, slice expression, and array literal can be handled in compile time if possible.
