### PR TITLE
Deprecate casting delegates to void*

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9196,6 +9196,9 @@ Expression *CastExp::semantic(Scope *sc)
 
         if (tob->isintegral() && t1b->ty == Tarray)
             deprecation("casting %s to %s is deprecated", e1->type->toChars(), to->toChars());
+
+        if (tob->ty == Tpointer && t1b->ty == Tdelegate)
+            deprecation("casting from %s to %s is deprecated", e1->type->toChars(), to->toChars());
     }
     else if (!to)
     {   error("cannot cast tuple");

--- a/test/fail_compilation/fail9735.d
+++ b/test/fail_compilation/fail9735.d
@@ -1,0 +1,12 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/fail9735.d(10): Deprecation: casting from void delegate() to void* is deprecated
+---
+*/
+
+void* dg2ptr(void delegate() dg) {
+    return cast(void*) dg;
+}
+


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9735

Deprecates casting delegate types to pointer types.  Similar to the deprecation of casting D array types to integral types in the line above this change.
