### PR TITLE
Cast T[] to integral type: deprecation -> error.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9195,7 +9195,10 @@ Expression *CastExp::semantic(Scope *sc)
         }
 
         if (tob->isintegral() && t1b->ty == Tarray)
-            deprecation("casting %s to %s is deprecated", e1->type->toChars(), to->toChars());
+        {
+            error("cannot cast %s to integral type %s", e1->toChars(), to->toChars());
+            return new ErrorExp();
+        }
 
         if (tob->ty == Tpointer && t1b->ty == Tdelegate)
             deprecation("casting from %s to %s is deprecated", e1->type->toChars(), to->toChars());


### PR DESCRIPTION
Having a look at: http://dlang.org/deprecate.html

I see that casting from T[] to an integral type became an error in 2.061.  However it still produces the deprecation warning in the frontend before finally being rejected by the backend.

```
Deprecation: casting int[] to ulong is deprecated
Error: e2ir: cannot cast [1, 2] of type int[] to type ulong
```

This change makes it correctly error in the frontend, and probably puts the final nail in the coffin to make it error -> gone.
