### PR TITLE
9744 and 9745: allow taking address of static variables in CTFE

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -609,6 +609,12 @@ Expression *getAggregateFromPointer(Expression *e, dinteger_t *ofs)
 */
 bool pointToSameMemoryBlock(Expression *agg1, Expression *agg2)
 {
+    // For integers cast to pointers, we regard them as non-comparable
+    // unless they are identical. (This may be overly strict).
+    if (agg1->op == TOKint64 && agg2->op == TOKint64
+        && agg1->toInteger() == agg2->toInteger())
+        return true;
+
     // Note that type painting can occur with VarExp, so we
     // must compare the variables being pointed to.
     return agg1 == agg2 ||

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -574,6 +574,8 @@ Expression *getAggregateFromPointer(Expression *e, dinteger_t *ofs)
     *ofs = 0;
     if (e->op == TOKaddress)
         e = ((AddrExp *)e)->e1;
+    if (e->op == TOKsymoff)
+        *ofs = ((SymOffExp *)e)->offset;
     if (e->op == TOKdotvar)
     {
         Expression *ex = ((DotVarExp *)e)->e1;
@@ -611,7 +613,9 @@ bool pointToSameMemoryBlock(Expression *agg1, Expression *agg2)
     // must compare the variables being pointed to.
     return agg1 == agg2 ||
             (agg1->op == TOKvar && agg2->op == TOKvar &&
-            ((VarExp *)agg1)->var == ((VarExp *)agg2)->var);
+            ((VarExp *)agg1)->var == ((VarExp *)agg2)->var) ||
+            (agg1->op == TOKsymoff && agg2->op == TOKsymoff &&
+            ((SymOffExp *)agg1)->var == ((SymOffExp *)agg2)->var);
 }
 
 // return e1 - e2 as an integer, or error if not possible
@@ -630,10 +634,15 @@ Expression *pointerDifference(Loc loc, Type *type, Expression *e1, Expression *e
     {
         if (((StringExp *)agg1)->string == ((StringExp *)agg2)->string)
         {
-        Type *pointee = ((TypePointer *)agg1->type)->next;
-        dinteger_t sz = pointee->size();
-        return new IntegerExp(loc, (ofs1-ofs2)*sz, type);
+            Type *pointee = ((TypePointer *)agg1->type)->next;
+            dinteger_t sz = pointee->size();
+            return new IntegerExp(loc, (ofs1-ofs2)*sz, type);
         }
+    }
+    else if (agg1->op == TOKsymoff && agg2->op == TOKsymoff &&
+            ((SymOffExp *)agg1)->var == ((SymOffExp *)agg2)->var)
+    {
+        return new IntegerExp(loc, ofs1-ofs2, type);
     }
     error(loc, "%s - %s cannot be interpreted at compile time: cannot subtract "
         "pointers to two different memory blocks",
@@ -655,21 +664,36 @@ Expression *pointerArithmetic(Loc loc, enum TOK op, Type *type,
     if (eptr->op == TOKaddress)
         eptr = ((AddrExp *)eptr)->e1;
     Expression *agg1 = getAggregateFromPointer(eptr, &ofs1);
-    if (agg1->op != TOKstring && agg1->op != TOKarrayliteral)
+    if (agg1->op == TOKsymoff)
+    {
+        if (((SymOffExp *)agg1)->var->type->ty != Tsarray)
+        {
+            error(loc, "cannot perform pointer arithmetic on arrays of unknown length at compile time");
+            return EXP_CANT_INTERPRET;
+        }
+    }
+    else if (agg1->op != TOKstring && agg1->op != TOKarrayliteral)
     {
         error(loc, "cannot perform pointer arithmetic on non-arrays at compile time");
         return EXP_CANT_INTERPRET;
     }
     ofs2 = e2->toInteger();
     Type *pointee = ((TypePointer *)agg1->type)->next;
+    sinteger_t indx = ofs1;
     dinteger_t sz = pointee->size();
-    Expression *dollar = ArrayLength(Type::tsize_t, agg1);
-    assert(dollar != EXP_CANT_INTERPRET);
+    Expression *dollar;
+    if (agg1->op == TOKsymoff)
+    {
+        dollar = ((TypeSArray *)(((SymOffExp *)agg1)->var->type))->dim;
+        indx = ofs1/sz;
+    }
+    else
+    {
+        dollar = ArrayLength(Type::tsize_t, agg1);
+        assert(dollar != EXP_CANT_INTERPRET);
+    }
     dinteger_t len = dollar->toInteger();
 
-    Expression *val = agg1;
-    TypeArray *tar = (TypeArray *)val->type;
-    sinteger_t indx = ofs1;
     if (op == TOKadd || op == TOKaddass || op == TOKplusplus)
         indx = indx + ofs2/sz;
     else if (op == TOKmin || op == TOKminass || op == TOKminusminus)
@@ -679,14 +703,24 @@ Expression *pointerArithmetic(Loc loc, enum TOK op, Type *type,
         error(loc, "CTFE Internal compiler error: bad pointer operation");
         return EXP_CANT_INTERPRET;
     }
-    if (val->op != TOKarrayliteral && val->op != TOKstring)
-    {
-        error(loc, "CTFE Internal compiler error: pointer arithmetic %s", val->toChars());
-        return EXP_CANT_INTERPRET;
-    }
+
     if (indx < 0 || indx > len)
     {
         error(loc, "cannot assign pointer to index %lld inside memory block [0..%lld]", indx, len);
+        return EXP_CANT_INTERPRET;
+    }
+
+    if (agg1->op == TOKsymoff)
+    {
+        SymOffExp *se = new SymOffExp(loc, ((SymOffExp *)agg1)->var, indx*sz);
+        se->type = type;
+        return se;
+    }
+
+    Expression *val = agg1;
+    if (val->op != TOKarrayliteral && val->op != TOKstring)
+    {
+        error(loc, "CTFE Internal compiler error: pointer arithmetic %s", val->toChars());
         return EXP_CANT_INTERPRET;
     }
 
@@ -1877,6 +1911,8 @@ bool isCtfeValueValid(Expression *newval)
     {
         if (((SymOffExp *)newval)->var->isFuncDeclaration())
             return true;
+        if (((SymOffExp *)newval)->var->isDataseg())
+            return true;    // pointer to static variable
     }
     if (newval->op == TOKint64 || newval->op == TOKfloat64 ||
         newval->op == TOKchar || newval->op == TOKcomplex80)

--- a/src/expression.h
+++ b/src/expression.h
@@ -616,6 +616,7 @@ struct SymOffExp : SymbolExp
 
     SymOffExp(Loc loc, Declaration *var, unsigned offset, int hasOverloads = 0);
     Expression *semantic(Scope *sc);
+    Expression *optimize(int result, bool keepLvalue = false);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void checkEscape();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4720,17 +4720,21 @@ Expression *CastExp::interpret(InterState *istate, CtfeGoal goal)
                 return e;
             }
         }
-        if (e1->op == TOKvar)
+        if (e1->op == TOKvar || e1->op == TOKsymoff)
         {   // type painting operation
-            Type *origType = ((VarExp *)e1)->var->type;
+            Type *origType = (e1->op == TOKvar) ? ((VarExp *)e1)->var->type :
+                    ((SymOffExp *)e1)->var->type;
             if (castBackFromVoid && !isSafePointerCast(origType, pointee))
             {
                 error("using void* to reinterpret cast from %s* to %s* is not supported in CTFE",
                     origType->toChars(), pointee->toChars());
                 return EXP_CANT_INTERPRET;
             }
-            e = new VarExp(loc, ((VarExp *)e1)->var);
-            e->type = type;
+            if (e1->op == TOKvar)
+                e = new VarExp(loc, ((VarExp *)e1)->var);
+            else
+                e = new SymOffExp(loc, ((SymOffExp *)e1)->var, 0);
+            e->type = to;
             return e;
         }
 

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -317,6 +317,14 @@ Expression *BoolExp::optimize(int result, bool keepLvalue)
     return e;
 }
 
+Expression *SymOffExp::optimize(int result, bool keepLvalue)
+{
+    assert(var);
+    if ((result & WANTinterpret) && var->isThreadlocal())
+            error("cannot take address of thread-local variable %s at compile time", var->toChars());
+    return this;
+}
+
 Expression *AddrExp::optimize(int result, bool keepLvalue)
 {   Expression *e;
 

--- a/src/template.c
+++ b/src/template.c
@@ -1661,7 +1661,7 @@ Lretry:
                         taa->index->resolve(loc, sc, &e, &t, &s);
                         if (!e)
                             goto Lnomatch;
-                        e = e->optimize(WANTvalue | WANTinterpret);
+                        e = e->ctfeInterpret();
                         e = e->implicitCastTo(sc, Type::tsize_t);
                         e = e->optimize(WANTvalue);
                         if (!dim->equals(e))

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2379,6 +2379,8 @@ shared (int) * bug9745(int m)
 int test9745(int m)
 {
     bug9745(m);
+    // type painting
+    shared int * w = bug9745(0);
     return 1;
 }
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2391,6 +2391,18 @@ static assert(!is(typeof(compiles!(test9745(7)))));
 static assert(!is(typeof(compiles!(test9745(8)))));
 static assert(!is(typeof(compiles!(test9745(9)))));
 
+// pointers cast from an absolute address
+// (mostly applies to fake pointers, eg Windows HANDLES)
+bool test9745b()
+{
+    void *b6 = cast(void *)0xFEFEFEFE;
+    void *b7 = cast(void *)0xFEFEFEFF;
+    assert(b6 is b6);
+    assert(b7 != b6);
+    return true;
+}
+static assert(test9745b());
+
 
 /**************************************************
     4065 [CTFE] AA "in" operator doesn't work

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2345,6 +2345,52 @@ bool bug7216() {
 static assert(bug7216());
 
 /**************************************************
+    9745 Allow pointers to static variables
+**************************************************/
+
+shared int x9745;
+shared int[5] y9745;
+
+shared (int) * bug9745(int m)
+{
+    auto k = &x9745;
+    auto j = &x9745;
+    auto p = &y9745[0];
+    auto q = &y9745[3];
+    assert (j - k == 0);
+    assert( j == k );
+    assert( q - p == 3);
+    --q;
+    int a = 0;
+    assert(p + 2 == q);
+    if (m==7)
+    {
+        auto z1 = y9745[0..2]; // slice global pointer
+    }
+    if (m==8)
+        p[1] = 7; // modify through a pointer
+    if (m==9)
+         a = p[1]; // read from a pointer
+    if (m == 0)
+        return & x9745;
+    return &y9745[1];
+}
+
+int test9745(int m)
+{
+    bug9745(m);
+    return 1;
+}
+
+shared int * w9745a = bug9745(0);
+shared int * w9745b = bug9745(1);
+static assert( is(typeof(compiles!(test9745(6)))));
+static assert(!is(typeof(compiles!(test9745(7)))));
+static assert(!is(typeof(compiles!(test9745(8)))));
+static assert(!is(typeof(compiles!(test9745(9)))));
+
+
+/**************************************************
     4065 [CTFE] AA "in" operator doesn't work
 **************************************************/
 


### PR DESCRIPTION
When constant-folding to produce a compile-time value, it's always been allowed to take the address of a static variable (this doesn't include thread locals). This patch allows it in CTFE as well.
Of course you cannot dereference such a pointer.

The motivation is to remove the difference between CTFE and constfolding, so that I can do a future pull request where the CTFE engine does _all_ interpreting, and optimize.c will only do optimizing.
