### PR TITLE
9774 Error message with __error using == on tuple members

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -2695,6 +2695,11 @@ Expression *BinExp::typeCombine(Scope *sc)
 
     if (!typeMerge(sc, this, &type, &e1, &e2))
         goto Lerror;
+    // If the types have no value, return an error
+    if (e1->op == TOKerror)
+        return e1;
+    if (e2->op == TOKerror)
+        return e2;
     return this;
 
 Lerror:


### PR DESCRIPTION
This is pretty simple. I deliberately haven't included a test case because the current error message "void has no value" is so terrible.

However, I have an forthcoming CTFE pull with a test case which will ICE if this isn't fixed.

Although this looks like a trivial bug, it's a blocker for my CTFE refactoring. Please give this a high priority.
