### PR TITLE
[D1] Include -devel-HASH(-dirty) in the version string

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -69,10 +69,8 @@ ifeq (OSX,$(TARGET))
     #if gcc sees -isysroot it should pass -syslibroot to the linker when needed
     #LDFLAGS=-lstdc++ -isysroot ${SDK} -Wl,-syslibroot,${SDK} -framework CoreServices
     LDFLAGS=-lstdc++ -isysroot ${SDK} -Wl -framework CoreServices
-    ECHO=/bin/echo
 else
     LDFLAGS=-lm -lstdc++ -lpthread
-    ECHO=echo
 endif
 
 HOST_CC=g++
@@ -217,7 +215,7 @@ impcnvgen : mtype.h impcnvgen.c
 #########
 
 verstr.h : ../VERSION1
-	$(ECHO) -n \"`cat ../VERSION1`\" > verstr.h
+	printf \"`cat ../VERSION1`\" > verstr.h
 
 #########
 


### PR DESCRIPTION
When not compiled with `make RELEASE=1`, the version string will include
a suffix with the exact version information based on the git hash. Also,
if the current working tree is dirty (it have uncommitted changed) an
extra suffix will be added (-dirty).

When using `make RELEASE=1` only the version information present in the
VERSION file will be used.

This is the D1 counterpart of #1737.
