### PR TITLE
Fix issue 9777 Wrong code when calling final interface methods

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -261,7 +261,7 @@ struct ClassDeclaration : AggregateDeclaration
 
     virtual int isBaseInfoComplete();
     Dsymbol *search(Loc, Identifier *ident, int flags);
-    Dsymbol *searchBase(Loc, Identifier *ident);
+    ClassDeclaration *searchBase(Loc, Identifier *ident);
 #if DMDV2
     int isFuncHidden(FuncDeclaration *fd);
 #endif

--- a/src/class.c
+++ b/src/class.c
@@ -979,17 +979,17 @@ Dsymbol *ClassDeclaration::search(Loc loc, Identifier *ident, int flags)
     return s;
 }
 
-Dsymbol *ClassDeclaration::searchBase(Loc loc, Identifier *ident)
+ClassDeclaration *ClassDeclaration::searchBase(Loc loc, Identifier *ident)
 {
     // Search bases classes in depth-first, left to right order
 
     for (size_t i = 0; i < baseclasses->dim; i++)
     {
         BaseClass *b = (*baseclasses)[i];
-        Dsymbol *cdb = b->type->isClassHandle();
+        ClassDeclaration *cdb = b->type->isClassHandle();
         if (cdb->ident->equals(ident))
             return cdb;
-        cdb = ((ClassDeclaration *)cdb)->searchBase(loc, ident);
+        cdb = cdb->searchBase(loc, ident);
         if (cdb)
             return cdb;
     }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8487,12 +8487,25 @@ L1:
         // See if it's 'this' class or a base class
         if (e->op != TOKtype)
         {
-            Dsymbol *cbase = sym->ident == ident ?
-                             sym : sym->searchBase(e->loc, ident);
+            if (sym->ident == ident)
+            {
+                e = new DotTypeExp(0, e, sym);
+                return e;
+            }
+            
+            ClassDeclaration *cbase = sym->searchBase(e->loc, ident);
             if (cbase)
             {
-                e = new DotTypeExp(0, e, cbase);
-                return e;
+                if (InterfaceDeclaration *ifbase = cbase->isInterfaceDeclaration())
+                {
+                    e = new CastExp(0, e, ifbase->type);
+                    return e;
+                }
+                else
+                {
+                    e = new DotTypeExp(0, e, cbase);
+                    return e;
+                }
             }
         }
 


### PR DESCRIPTION
Can't use DotTypeExp when converting to the interface as the pointer needs to be adjusted. Use CastExp instead.

It would be nice if we can get this merged soon as it causes worse consequences in gdc. (In gdc not even the simple case in the original test case is working)
