### PR TITLE
[trivial] Remove default MODEL from posix.mak

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -43,7 +43,7 @@ C=backend
 TK=tk
 ROOT=root
 
-MODEL=32
+# Use make MODEL=32 or MODEL=64 to force the architecture
 ifneq (x,x$(MODEL))
     MODEL_FLAG=-m$(MODEL)
 endif


### PR DESCRIPTION
DMD compiles and work fine in 64 bit, so it makes no sense to set the
default MODEL to 32 instead of just let the compiler pick the native
model.
