### PR TITLE
fix issue 9782: do not generate RTInfo for deprecated types and _error_ types

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -106,7 +106,9 @@ void AggregateDeclaration::semantic3(Scope *sc)
         }
         sc->pop();
 
-        if (!getRTInfo)
+        if (!getRTInfo && Type::rtinfo && 
+            (!isDeprecated() || global.params.useDeprecated) && // don't do it for unused deprecated types
+            (type && type->ty != Terror)) // or error types
         {   // Evaluate: gcinfo!type
             Objects *tiargs = new Objects();
             tiargs->push(type);


### PR DESCRIPTION
The behaveour is a bit strange for deprecated types:
- if deprecated stuff is disallowed, no error or warning
- if deprecated stuff is allowed, no error or warning
- if warnings only are enabled (the default), the deprecation warning is shown even if the type seems never to be used (but actually is in the TypeInfo generation).
