### PR TITLE
Fix error propagation for ! and BoolExp

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8917,6 +8917,8 @@ Expression *NotExp::semantic(Scope *sc)
         UnaExp::semantic(sc);
         e1 = resolveProperties(sc, e1);
         e1 = e1->checkToBoolean(sc);
+        if (e1->type == Type::terror)
+            return e1;
         type = Type::tboolean;
     }
     return this;
@@ -8944,6 +8946,8 @@ Expression *BoolExp::semantic(Scope *sc)
         UnaExp::semantic(sc);
         e1 = resolveProperties(sc, e1);
         e1 = e1->checkToBoolean(sc);
+        if (e1->type == Type::terror)
+            return e1;
         type = Type::tboolean;
     }
     return this;

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -1,10 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test8556.d(44): Error: template test8556.grabExactly matches more than one template declaration, fail_compilation/test8556.d(30):grabExactly(R)(R range) if (!isSliceable!(R)) and fail_compilation/test8556.d(31):grabExactly(R)(R range) if (isSliceable!(R))
-fail_compilation/test8556.d(19): Error: template instance test8556.isSliceable!(Circle!(uint[])) error instantiating
-fail_compilation/test8556.d(24): Error: Grab!(Circle!(uint[])) is used as a type
-fail_compilation/test8556.d(55): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
+fail_compilation/test8556.d(45): Error: template test8556.grabExactly matches more than one template declaration, fail_compilation/test8556.d(31):grabExactly(R)(R range) if (!isSliceable!(R)) and fail_compilation/test8556.d(32):grabExactly(R)(R range) if (isSliceable!(R))
+fail_compilation/test8556.d(20): Error: template instance test8556.isSliceable!(Circle!(uint[])) error instantiating
+fail_compilation/test8556.d(25): Error: template instance Grab!(Circle!(uint[])) Grab!(Circle!(uint[])) does not match template declaration Grab(Range) if (!isSliceable!(Range))
+fail_compilation/test8556.d(25): Error: Grab!(Circle!(uint[])) is used as a type
+fail_compilation/test8556.d(56): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
 ---
 */
 


### PR DESCRIPTION
If !x is an error, don't change it to a boolean.

I didn't find any cases where __error appears in an error message, but constfolding should not have to deal with invalid expressions.
