### PR TITLE
split libelf.c and libmach.c

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -97,9 +97,9 @@ DMD_OBJS = \
 	$(TARGET_OBJS)
 
 ifeq (OSX,$(OS))
-    DMD_OBJS += libmach.o machobj.o
+    DMD_OBJS += libmach.o scanmach.o machobj.o
 else
-    DMD_OBJS += libelf.o elfobj.o
+    DMD_OBJS += libelf.o scanelf.o elfobj.o
 endif
 
 SRC = win32.mak posix.mak \
@@ -118,7 +118,7 @@ SRC = win32.mak posix.mak \
 	doc.h doc.c macro.h macro.c hdrgen.h hdrgen.c arraytypes.h \
 	delegatize.c toir.h toir.c interpret.c traits.c cppmangle.c \
 	builtin.c clone.c lib.h libomf.c libelf.c libmach.c arrayop.c \
-	libmscoff.c \
+	libmscoff.c scanelf.c scanmach.c \
 	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c \
 	argtypes.c apply.c sideeffect.c \
 	intrange.h intrange.c canthrow.c target.c target.h \
@@ -552,6 +552,12 @@ rtlsym.o: $C/rtlsym.c $C/rtlsym.h
 
 s2ir.o: s2ir.c $C/rtlsym.h statement.h
 	$(CC) -c $(MFLAGS) -I$(ROOT) $<
+
+scanelf.o: scanelf.c $C/melf.h
+	$(CC) -c $(CFLAGS) -I$C $<
+
+scanmach.o: scanmach.c $C/mach.h
+	$(CC) -c $(CFLAGS) -I$C $<
 
 scope.o: scope.c
 	$(CC) -c $(CFLAGS) $<

--- a/src/scanelf.c
+++ b/src/scanelf.c
@@ -1,0 +1,183 @@
+
+// Compiler implementation of the D programming language
+// Copyright (c) 1999-2013 by Digital Mars
+// All Rights Reserved
+// written by Walter Bright
+// http://www.digitalmars.com
+// License for redistribution is by either the Artistic License
+// in artistic.txt, or the GNU General Public License in gnu.txt.
+// See the included readme.txt for details.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "melf.h"
+
+#include "mars.h"
+
+#define LOG 0
+
+/*****************************************************************************/
+
+static char elf[4] = { 0x7F, 'E', 'L', 'F' };   // ELF file signature
+
+/*****************************************
+ * Reads an object module from base[0..buflen] and passes the names
+ * of any exported symbols to (*pAddSymbol)().
+ * Input:
+ *      pctx            context pointer, pass to *pAddSymbol
+ *      pAddSymbol      function to pass the names to
+ *      base[0..buflen] contains contents of object module
+ *      module_name     name of the object module (used for error messages)
+ *      loc             location to use for error printing
+ */
+
+void scanElfObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, int pickAny), void *base, size_t buflen, const char *module_name, Loc loc)
+{
+#if LOG
+    printf("scanElfObjModule(%s)\n", module_name);
+#endif
+
+    unsigned char *buf = (unsigned char *)base;
+    int reason = 0;
+
+    if (buflen < EI_NIDENT + sizeof(Elf32_Hdr))
+    {
+        reason = __LINE__;
+      Lcorrupt:
+        error(loc, "corrupt ELF object module %s %d", module_name, reason);
+        return;
+    }
+
+    if (memcmp(buf, elf, 4))
+    {   reason = __LINE__;
+        goto Lcorrupt;
+    }
+    if (buf[EI_VERSION] != EV_CURRENT)
+    {
+        error(loc, "ELF object module %s has EI_VERSION = %d, should be %d", module_name, buf[EI_VERSION], EV_CURRENT);
+        return;
+    }
+    if (buf[EI_DATA] != ELFDATA2LSB)
+    {
+        error(loc, "ELF object module %s is byte swapped and unsupported", module_name);
+        return;
+    }
+    if (buf[EI_CLASS] == ELFCLASS32)
+    {
+        Elf32_Hdr *eh = (Elf32_Hdr *)(buf + EI_NIDENT);
+        if (eh->e_type != ET_REL)
+        {
+            error(loc, "ELF object module %s is not relocatable", module_name);
+            return;                             // not relocatable object module
+        }
+        if (eh->e_version != EV_CURRENT)
+            goto Lcorrupt;
+
+        /* For each Section
+         */
+        for (unsigned u = 0; u < eh->e_shnum; u++)
+        {   Elf32_Shdr *section = (Elf32_Shdr *)(buf + eh->e_shoff + eh->e_shentsize * u);
+
+            if (section->sh_type == SHT_SYMTAB)
+            {   /* sh_link gives the particular string table section
+                 * used for the symbol names.
+                 */
+                Elf32_Shdr *string_section = (Elf32_Shdr *)(buf + eh->e_shoff +
+                    eh->e_shentsize * section->sh_link);
+                if (string_section->sh_type != SHT_STRTAB)
+                {
+                    reason = __LINE__;
+                    goto Lcorrupt;
+                }
+                char *string_tab = (char *)(buf + string_section->sh_offset);
+
+                for (unsigned offset = 0; offset < section->sh_size; offset += sizeof(Elf32_Sym))
+                {   Elf32_Sym *sym = (Elf32_Sym *)(buf + section->sh_offset + offset);
+
+                    if (((sym->st_info >> 4) == STB_GLOBAL ||
+                         (sym->st_info >> 4) == STB_WEAK) &&
+                        sym->st_shndx != SHN_UNDEF)     // not extern
+                    {
+                        char *name = string_tab + sym->st_name;
+                        //printf("sym st_name = x%x\n", sym->st_name);
+                        (*pAddSymbol)(pctx, name, 1);
+                    }
+                }
+            }
+        }
+    }
+    else if (buf[EI_CLASS] == ELFCLASS64)
+    {
+        Elf64_Ehdr *eh = (Elf64_Ehdr *)(buf + EI_NIDENT);
+        if (buflen < EI_NIDENT + sizeof(Elf64_Ehdr))
+            goto Lcorrupt;
+        if (eh->e_type != ET_REL)
+        {
+            error(loc, "ELF object module %s is not relocatable", module_name);
+            return;                             // not relocatable object module
+        }
+        if (eh->e_version != EV_CURRENT)
+        {   reason = __LINE__;
+            goto Lcorrupt;
+        }
+
+        /* For each Section
+         */
+        for (unsigned u = 0; u < eh->e_shnum; u++)
+        {   Elf64_Shdr *section = (Elf64_Shdr *)(buf + eh->e_shoff + eh->e_shentsize * u);
+
+            if (section->sh_type == SHT_SYMTAB)
+            {   /* sh_link gives the particular string table section
+                 * used for the symbol names.
+                 */
+                Elf64_Shdr *string_section = (Elf64_Shdr *)(buf + eh->e_shoff +
+                    eh->e_shentsize * section->sh_link);
+                if (string_section->sh_type != SHT_STRTAB)
+                {
+                    reason = 3;
+                    goto Lcorrupt;
+                }
+                char *string_tab = (char *)(buf + string_section->sh_offset);
+
+                for (unsigned offset = 0; offset < section->sh_size; offset += sizeof(Elf64_Sym))
+                {   Elf64_Sym *sym = (Elf64_Sym *)(buf + section->sh_offset + offset);
+
+                    if (((sym->st_info >> 4) == STB_GLOBAL ||
+                         (sym->st_info >> 4) == STB_WEAK) &&
+                        sym->st_shndx != SHN_UNDEF)     // not extern
+                    {
+                        char *name = string_tab + sym->st_name;
+                        //printf("sym st_name = x%x\n", sym->st_name);
+                        (*pAddSymbol)(pctx, name, 1);
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        error(loc, "ELF object module %s is unrecognized class %d", module_name, buf[EI_CLASS]);
+        return;
+    }
+
+#if 0
+    /* String table section
+     */
+    Elf32_Shdr *string_section = (Elf32_Shdr *)(buf + eh->e_shoff +
+        eh->e_shentsize * eh->e_shstrndx);
+    if (string_section->sh_type != SHT_STRTAB)
+    {
+        //printf("buf = %p, e_shentsize = %d, e_shstrndx = %d\n", buf, eh->e_shentsize, eh->e_shstrndx);
+        //printf("sh_type = %d, SHT_STRTAB = %d\n", string_section->sh_type, SHT_STRTAB);
+        reason = 2;
+        goto Lcorrupt;
+    }
+    printf("strtab sh_offset = x%x\n", string_section->sh_offset);
+    char *string_tab = (char *)(buf + string_section->sh_offset);
+#endif
+
+}
+

--- a/src/scanmach.c
+++ b/src/scanmach.c
@@ -1,0 +1,234 @@
+
+// Compiler implementation of the D programming language
+// Copyright (c) 1999-2013 by Digital Mars
+// All Rights Reserved
+// written by Walter Bright
+// http://www.digitalmars.com
+// License for redistribution is by either the Artistic License
+// in artistic.txt, or the GNU General Public License in gnu.txt.
+// See the included readme.txt for details.
+
+/* Implements object reading and writing in the Mach-O object
+ * module format. While the format is
+ * equivalent to the Linux arch format, it differs in many details.
+ * This format is described in the Apple document
+ * "Mac OS X ABI Mach-O File Format Reference" dated 2007-04-26
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "mach.h"
+
+#include "mars.h"
+
+#define LOG 0
+
+
+/*****************************************
+ * Reads an object module from base[0..buflen] and passes the names
+ * of any exported symbols to (*pAddSymbol)().
+ * Input:
+ *      pctx            context pointer, pass to *pAddSymbol
+ *      pAddSymbol      function to pass the names to
+ *      base[0..buflen] contains contents of object module
+ *      module_name     name of the object module (used for error messages)
+ *      loc             location to use for error printing
+ */
+
+void scanMachObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, int pickAny), void *base, size_t buflen, const char *module_name, Loc loc)
+{
+#if LOG
+    printf("scanMachObjModule(%s)\n", module_name);
+#endif
+
+    unsigned char *buf = (unsigned char *)base;
+    int reason = 0;
+    uint32_t ncmds;
+
+    struct mach_header *header = (struct mach_header *)buf;
+    struct mach_header_64 *header64 = NULL;
+
+    /* First do sanity checks on object file
+     */
+    if (buflen < sizeof(struct mach_header))
+    {
+        reason = __LINE__;
+      Lcorrupt:
+        error(loc, "Mach-O object module %s corrupt, %d", module_name, reason);
+        return;
+    }
+    if (header->magic == MH_MAGIC)
+    {
+        if (header->cputype != CPU_TYPE_I386)
+        {
+            error(loc, "Mach-O object module %s has cputype = %d, should be %d",
+                    module_name, header->cputype, CPU_TYPE_I386);
+            return;
+        }
+        if (header->filetype != MH_OBJECT)
+        {
+            error(loc, "Mach-O object module %s has file type = %d, should be %d",
+                    module_name, header->filetype, MH_OBJECT);
+            return;
+        }
+        if (buflen < sizeof(struct mach_header) + header->sizeofcmds)
+        {   reason = __LINE__;
+            goto Lcorrupt;
+        }
+        ncmds = header->ncmds;
+    }
+    else if (header->magic == MH_MAGIC_64)
+    {
+        header64 = (struct mach_header_64 *)buf;
+        if (buflen < sizeof(struct mach_header_64))
+            goto Lcorrupt;
+        if (header64->cputype != CPU_TYPE_X86_64)
+        {
+            error(loc, "Mach-O object module %s has cputype = %d, should be %d",
+                    module_name, header64->cputype, CPU_TYPE_X86_64);
+            return;
+        }
+        if (header64->filetype != MH_OBJECT)
+        {
+            error(loc, "Mach-O object module %s has file type = %d, should be %d",
+                    module_name, header64->filetype, MH_OBJECT);
+            return;
+        }
+        if (buflen < sizeof(struct mach_header_64) + header64->sizeofcmds)
+        {   reason = __LINE__;
+            goto Lcorrupt;
+        }
+        ncmds = header64->ncmds;
+    }
+    else
+    {   reason = __LINE__;
+        goto Lcorrupt;
+    }
+
+    struct segment_command *segment_commands = NULL;
+    struct segment_command_64 *segment_commands64 = NULL;
+    struct symtab_command *symtab_commands = NULL;
+    struct dysymtab_command *dysymtab_commands = NULL;
+
+    // Commands immediately follow mach_header
+    char *commands = (char *)buf +
+        (header->magic == MH_MAGIC_64
+                ? sizeof(struct mach_header_64)
+                : sizeof(struct mach_header));
+    for (uint32_t i = 0; i < ncmds; i++)
+    {   struct load_command *command = (struct load_command *)commands;
+        //printf("cmd = 0x%02x, cmdsize = %u\n", command->cmd, command->cmdsize);
+        switch (command->cmd)
+        {
+            case LC_SEGMENT:
+                segment_commands = (struct segment_command *)command;
+                break;
+            case LC_SEGMENT_64:
+                segment_commands64 = (struct segment_command_64 *)command;
+                break;
+            case LC_SYMTAB:
+                symtab_commands = (struct symtab_command *)command;
+                break;
+            case LC_DYSYMTAB:
+                dysymtab_commands = (struct dysymtab_command *)command;
+                break;
+        }
+        commands += command->cmdsize;
+    }
+
+    if (symtab_commands)
+    {
+        // Get pointer to string table
+        char *strtab = (char *)buf + symtab_commands->stroff;
+        if (buflen < symtab_commands->stroff + symtab_commands->strsize)
+        {   reason = __LINE__;
+            goto Lcorrupt;
+        }
+
+        if (header->magic == MH_MAGIC_64)
+        {
+            // Get pointer to symbol table
+            struct nlist_64 *symtab = (struct nlist_64 *)((char *)buf + symtab_commands->symoff);
+            if (buflen < symtab_commands->symoff + symtab_commands->nsyms * sizeof(struct nlist_64))
+            {   reason = __LINE__;
+                goto Lcorrupt;
+            }
+
+            // For each symbol
+            for (int i = 0; i < symtab_commands->nsyms; i++)
+            {   struct nlist_64 *s = symtab + i;
+                char *name = strtab + s->n_un.n_strx;
+
+                if (s->n_type & N_STAB)
+                    // values in /usr/include/mach-o/stab.h
+                    ; //printf(" N_STAB");
+                else
+                {
+                    if (s->n_type & N_PEXT)
+                        ;
+                    if (s->n_type & N_EXT)
+                        ;
+                    switch (s->n_type & N_TYPE)
+                    {
+                        case N_UNDF:
+                            break;
+                        case N_ABS:
+                            break;
+                        case N_SECT:
+                            if (s->n_type & N_EXT /*&& !(s->n_desc & N_REF_TO_WEAK)*/)
+                                (*pAddSymbol)(pctx, name, 1);
+                            break;
+                        case N_PBUD:
+                            break;
+                        case N_INDR:
+                            break;
+                    }
+                }
+            }
+        }
+        else
+        {
+            // Get pointer to symbol table
+            struct nlist *symtab = (struct nlist *)((char *)buf + symtab_commands->symoff);
+            if (buflen < symtab_commands->symoff + symtab_commands->nsyms * sizeof(struct nlist))
+            {   reason = __LINE__;
+                goto Lcorrupt;
+            }
+
+            // For each symbol
+            for (int i = 0; i < symtab_commands->nsyms; i++)
+            {   struct nlist *s = symtab + i;
+                char *name = strtab + s->n_un.n_strx;
+
+                if (s->n_type & N_STAB)
+                    // values in /usr/include/mach-o/stab.h
+                    ; //printf(" N_STAB");
+                else
+                {
+                    if (s->n_type & N_PEXT)
+                        ;
+                    if (s->n_type & N_EXT)
+                        ;
+                    switch (s->n_type & N_TYPE)
+                    {
+                        case N_UNDF:
+                            break;
+                        case N_ABS:
+                            break;
+                        case N_SECT:
+                            if (s->n_type & N_EXT /*&& !(s->n_desc & N_REF_TO_WEAK)*/)
+                                (*pAddSymbol)(pctx, name, 1);
+                            break;
+                        case N_PBUD:
+                            break;
+                        case N_INDR:
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -202,7 +202,7 @@ SRCS= mars.c enum.c struct.c dsymbol.c import.c idgen.c impcnvgen.c utf.h \
 	declaration.h lexer.h expression.h statement.h doc.h doc.c \
 	macro.h macro.c hdrgen.h hdrgen.c arraytypes.h \
 	delegatize.c toir.h toir.c interpret.c ctfeexpr.c traits.c builtin.c \
-	clone.c lib.h libomf.c scanomf.c libelf.c libmach.c arrayop.c \
+	clone.c lib.h libomf.c scanomf.c libelf.c scanelf.c libmach.c scanmach.c arrayop.c \
 	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c argtypes.c \
 	apply.c sideeffect.c libmscoff.c scanmscoff.c ctfe.h \
 	intrange.h intrange.c canthrow.c target.c target.h


### PR DESCRIPTION
Splits libelf.c into libelf.c and scanelf.c.
Splits libmach.c into libmach.c and scanmach.c.

The purpose is to encapsulate the lib and object file formats into different files.
