### PR TITLE
Fix a buffer overrun on Linux/PPC64.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2669,7 +2669,7 @@ void realToMangleBuffer(OutBuffer *buf, real_t value)
         buf->writestring("NAN");        // no -NAN bugs
     else
     {
-        char buffer[32];
+        char buffer[36];
         int n = ld_sprint(buffer, 'A', value);
         assert(n > 0 && n < sizeof(buffer));
         for (int i = 0; i < n; i++)


### PR DESCRIPTION
The buffer in `realToMangleBuffer()` is too small for longdouble values. It produces strings like `0X1.599999999999999999999999998P+1` or `0X1.999999999999999999999999998P-4` which have a length of 34. This results in an ICE e.g. in the unit test of std.range.
