### PR TITLE
fix issue #9805. 

### DIFF
--- a/docs/man/man1/dmd.1
+++ b/docs/man/man1/dmd.1
@@ -187,6 +187,11 @@ The value of
 .B DFLAGS
 is treated as if it were appended on the command line to
 \fBdmd\fR.
+.IP DFLAGS_PRE 10
+The value of
+.B DFLAGS_PRE
+is treated as if it were pre-pended on the command line to
+\fBdmd\fR.
 .SH BUGS
 .B -g
 is only implemented for line numbers, not local symbols,


### PR DESCRIPTION
Enable the optional DFLAGS_PRE env var to pre-pend arguments to the dmd command line. It is the complement to DFLAGS, which always appends.
