### PR TITLE
[trivial] Make guessing the target an info instead of a warning

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -23,7 +23,7 @@ ifeq (,$(OS))
 endif
 
 ifeq (,$(TARGET_CPU))
-    $(warning no cpu specified, assuming X86)
+    $(info no cpu specified, assuming X86)
     TARGET_CPU=X86
 endif
 


### PR DESCRIPTION
Having this as a warning makes IDEs to go to the Makefile where the
warning was issued as if an error occurred, which is rather annoying for
something is really normal. An info is enough to let the user now how
the target was guessed.
