### PR TITLE
add -shared-druntime flag, add new meaning for -defaultlib=

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -573,19 +573,25 @@ int runLINK()
                                 ? global.params.debuglibname
                                 : global.params.defaultlibname;
     size_t slen = strlen(libname);
-    if (slen)
+    if (slen)    // 0-length library name means do not include default libraries
     {
         char *buf = (char *)malloc(2 + slen + 1);
         strcpy(buf, "-l");
         strcpy(buf + 2, libname);
         argv.push(buf);             // turns into /usr/lib/libphobos2.a
+
+#if linux
+        if (global.params.shared_druntime)
+            argv.push(const_cast<char*>("-ldruntimeso"));
+        else
+            argv.push(const_cast<char*>("-ldruntime"));
+#endif
     }
 
 #ifdef __sun
     argv.push((char *)"-mt");
 #endif
 
-//    argv.push((void *)"-ldruntime");
     argv.push((char *)"-lpthread");
     argv.push((char *)"-lm");
 #if linux && DMDV2

--- a/src/mars.c
+++ b/src/mars.c
@@ -370,7 +370,8 @@ Usage:\n\
   -release       compile release version\n\
   -run srcfile args...   run resulting program, passing args\n"
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-"  -shared        generate shared library\n"
+"  -shared        generate shared library\n\
+  -shared-druntime link with shared version of druntime\n"
 #endif
 "  -unittest      compile in unit tests\n\
   -v             verbose\n\
@@ -409,7 +410,7 @@ int tryMain(size_t argc, char *argv[])
     size_t argcstart = argc;
     int setdebuglib = 0;
     char noboundscheck = 0;
-        int setdefaultlib = 0;
+    int setdefaultlib = 0;
     const char *inifilename = NULL;
 
 #ifdef DEBUG
@@ -583,6 +584,8 @@ int tryMain(size_t argc, char *argv[])
             else if (strcmp(p + 1, "fPIC") == 0)
                 global.params.pic = 1;
 #endif
+            else if (strcmp(p + 1, "shared-druntime") == 0)
+                global.params.shared_druntime = true;
             else if (strcmp(p + 1, "map") == 0)
                 global.params.map = 1;
             else if (strcmp(p + 1, "multiobj") == 0)

--- a/src/mars.h
+++ b/src/mars.h
@@ -132,6 +132,7 @@ struct Param
     char obj;           // write object file
     char link;          // perform link
     char dll;           // generate shared dynamic library
+    bool shared_druntime; // link with shared druntime
     char lib;           // write library file instead of object file(s)
     char multiobj;      // break one object file into multiple ones
     char oneobj;        // write one object file instead of multiple ones


### PR DESCRIPTION
This implements phobos2 being split into libphobos2.a and libdruntime.a. With -shared-druntime flag, libdruntimeso.so is linked to instead. -defaultlib= with no library specified causes neither phobos2 nor druntime to be linked it (necessary to build libdruntime.so).

Relies on https://github.com/D-Programming-Language/phobos/pull/1223

and https://github.com/D-Programming-Language/druntime/pull/462
