### PR TITLE
Supress spurious 'is used as a type' template error message

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6834,11 +6834,23 @@ Type *TypeInstance::semantic(Loc loc, Scope *sc)
         }
     }
     else
+    {
+        unsigned errors = global.errors;
         resolve(loc, sc, &e, &t, &s);
+        // if we had an error evaluating the symbol, suppress further errors
+        if (!t && errors != global.errors)
+            return terror;
+    }
 
     if (!t)
     {
-        error(loc, "%s is used as a type", toChars());
+        if (!e && s && s->errors)
+        {   // if there was an error evaluating the symbol, it might actually
+            // be a type. Avoid misleading error messages.
+            error(loc, "%s had previous errors", toChars());
+        }
+        else
+            error(loc, "%s is used as a type", toChars());
         t = terror;
     }
     return t;

--- a/src/template.c
+++ b/src/template.c
@@ -5705,7 +5705,9 @@ bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
 
     if (!td_best)
     {
-        if (tempdecl && !tempdecl->overnext)
+        if (errs != global.errors)
+            errorSupplemental(loc, "while looking for match for %s", toChars());
+        else if (tempdecl && !tempdecl->overnext)
             // Only one template, so we can give better error message
             error("%s does not match template declaration %s", toChars(), tempdecl->toChars());
         else

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -1,11 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test8556.d(45): Error: template test8556.grabExactly matches more than one template declaration, fail_compilation/test8556.d(31):grabExactly(R)(R range) if (!isSliceable!(R)) and fail_compilation/test8556.d(32):grabExactly(R)(R range) if (isSliceable!(R))
-fail_compilation/test8556.d(20): Error: template instance test8556.isSliceable!(Circle!(uint[])) error instantiating
-fail_compilation/test8556.d(25): Error: template instance Grab!(Circle!(uint[])) Grab!(Circle!(uint[])) does not match template declaration Grab(Range) if (!isSliceable!(Range))
-fail_compilation/test8556.d(25): Error: Grab!(Circle!(uint[])) is used as a type
-fail_compilation/test8556.d(56): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
+fail_compilation/test8556.d(44): Error: template test8556.grabExactly matches more than one template declaration, fail_compilation/test8556.d(30):grabExactly(R)(R range) if (!isSliceable!(R)) and fail_compilation/test8556.d(31):grabExactly(R)(R range) if (isSliceable!(R))
+fail_compilation/test8556.d(19): Error: template instance test8556.isSliceable!(Circle!(uint[])) error instantiating
+fail_compilation/test8556.d(24):        while looking for match for Grab!(Circle!(uint[]))
+fail_compilation/test8556.d(55): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
 ---
 */
 


### PR DESCRIPTION
If a template instantiation fails, a spurious 'XXX is used as a type' error is generated. Suppress it.
Also, when a constraint fails, change the instantiation error into a supplemental error message.

This pull request includes https://github.com/D-Programming-Language/dmd/pull/1789, which it depends on. That one needs to be pulled before this one.
