### PR TITLE
Issue 9790 - Internal error when compiling a invalid variable in template

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1208,6 +1208,14 @@ Expression *NullExp::castTo(Scope *sc, Type *t)
     return e;
 }
 
+Expression *StructLiteralExp::castTo(Scope *sc, Type *t)
+{
+    Expression *e = Expression::castTo(sc, t);
+    if (e->op == TOKstructliteral)
+        ((StructLiteralExp *)e)->stype = t; // commit type
+    return e;
+}
+
 Expression *StringExp::castTo(Scope *sc, Type *t)
 {
     /* This follows copy-on-write; any changes to 'this'

--- a/src/expression.h
+++ b/src/expression.h
@@ -511,6 +511,7 @@ struct StructLiteralExp : Expression
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     dt_t **toDt(dt_t **pdt);
     MATCH implicitConvTo(Type *t);
+    Expression *castTo(Scope *sc, Type *t);
 
     int inlineCost3(InlineCostState *ics);
     Expression *doInline(InlineDoState *ids);

--- a/test/fail_compilation/fail9790.d
+++ b/test/fail_compilation/fail9790.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9790.d(13): Error: undefined identifier _Unused_
+fail_compilation/fail9790.d(20): Error: template instance fail9790.foo!() error instantiating
+fail_compilation/fail9790.d(18): Error: undefined identifier _Unused_
+fail_compilation/fail9790.d(21): Error: template instance fail9790.bar!() error instantiating
+---
+*/
+
+template foo()
+{
+    enum bool _foo = _Unused_._unused_;
+    enum bool foo = _foo;
+}
+template bar()
+{
+    enum bool bar = _Unused_._unused_;
+}
+alias Foo = foo!();
+alias Bar = bar!();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9790
1. Remove gagging in `VarDeclaration::semantic`
2. Commit type in `StructLiteralExp::castTo` like as `StringExp` and `NullExp`
   It's necessary to avoid std.traits unittest breaking.
