### PR TITLE
Issue 9818 - Constant folding for static array does not work with initializing by element

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1208,6 +1208,14 @@ Expression *NullExp::castTo(Scope *sc, Type *t)
     return e;
 }
 
+Expression *StructLiteralExp::castTo(Scope *sc, Type *t)
+{
+    Expression *e = Expression::castTo(sc, t);
+    if (e->op == TOKstructliteral)
+        ((StructLiteralExp *)e)->stype = t; // commit type
+    return e;
+}
+
 Expression *StringExp::castTo(Scope *sc, Type *t)
 {
     /* This follows copy-on-write; any changes to 'this'

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -815,8 +815,10 @@ void VarDeclaration::semantic(Scope *sc)
 //      return;
 //    sem = SemanticIn;
 
+    Scope *scx = NULL;
     if (scope)
     {   sc = scope;
+        scx = sc;
         scope = NULL;
     }
 
@@ -1544,7 +1546,7 @@ Lnomatch:
         }
         else if (parent->isAggregateDeclaration())
         {
-            scope = new Scope(*sc);
+            scope = scx ? scx : new Scope(*sc);
             scope->setNoFree();
         }
         else if (storage_class & (STCconst | STCimmutable | STCmanifest) ||
@@ -1559,15 +1561,14 @@ Lnomatch:
             if (!global.errors && !inferred)
             {
                 unsigned errors = global.errors;
-                Expression *exp;
-                Initializer *i2 = init;
                 inuse++;
+#if DMDV2
                 if (ei)
                 {
+                    Expression *exp;
                     exp = ei->exp->syntaxCopy();
                     exp = exp->semantic(sc);
                     exp = resolveProperties(sc, exp);
-#if DMDV2
                     Type *tb = type->toBasetype();
                     Type *ti = exp->type->toBasetype();
 
@@ -1609,80 +1610,16 @@ Lnomatch:
                             ;
                         }
                     }
-
-                    // Look for implicit constructor call
-                    if (tb->ty == Tstruct &&
-                        !(ti->ty == Tstruct && tb->toDsymbol(sc) == ti->toDsymbol(sc)) &&
-                        !exp->implicitConvTo(type))
-                    {
-                        StructDeclaration *sd = ((TypeStruct *)tb)->sym;
-                        if (sd->ctor)
-                        {   // Look for constructor first
-                            // Rewrite as e1.ctor(arguments)
-                            Expression *e;
-                            e = new StructLiteralExp(loc, sd, NULL, NULL);
-                            e = new DotIdExp(loc, e, Id::ctor);
-                            e = new CallExp(loc, e, exp);
-                            e = e->semantic(sc);
-                            exp = e->ctfeInterpret();
-                        }
-                    }
+                    ei->exp = exp;
+                }
 #endif
-                    //printf("v->type = %s, exp = %s %s\n", type->toChars(), exp->type->toChars(), exp->toChars());
-                    if (tb->ty == Tsarray && exp->implicitConvTo(tb->nextOf()))
-                    {
-                        TypeSArray *tsa = (TypeSArray *)tb;
-                        size_t d = tsa->dim->toInteger();
-                        Expressions *elements = new Expressions();
-                        elements->setDim(d);
-                        for (size_t i = 0; i < d; i++)
-                            (*elements)[i] = exp;
-                        ArrayLiteralExp *ae = new ArrayLiteralExp(exp->loc, elements);
-                        ae->type = type;
-                        exp = ae;
-                    }
-                    exp = exp->implicitCastTo(sc, type);
-                }
-                else if (si || ai)
-                {   i2 = init->syntaxCopy();
-                    i2 = i2->semantic(sc, type, INITinterpret);
-                }
+                init = init->semantic(sc, type, INITinterpret);
                 inuse--;
                 if (global.errors > errors)
                 {
                     init = new ErrorInitializer();
                     type = Type::terror;
                 }
-                else if (ei)
-                {
-                    if (isDataseg() || (storage_class & STCmanifest))
-                        exp = exp->ctfeInterpret();
-                    else
-                        exp = exp->optimize(WANTvalue);
-                    switch (exp->op)
-                    {
-                        case TOKint64:
-                        case TOKfloat64:
-                        case TOKstring:
-                        case TOKarrayliteral:
-                        case TOKassocarrayliteral:
-                        case TOKstructliteral:
-                        case TOKnull:
-                            ei->exp = exp;          // no errors, keep result
-                            break;
-
-                        default:
-#if DMDV2
-                            /* Save scope for later use, to try again
-                             */
-                            scope = new Scope(*sc);
-                            scope->setNoFree();
-#endif
-                            break;
-                    }
-                }
-                else
-                    init = i2;          // no errors, keep result
             }
         }
         sc = sc->pop();

--- a/src/expression.c
+++ b/src/expression.c
@@ -3063,7 +3063,7 @@ Lagain:
 
         if ((v->storage_class & STCmanifest) && v->init)
         {
-            e = v->init->toExpression();
+            e = v->init->toExpression(v->type);
             if (!e)
             {   error("cannot make expression out of initializer for %s", v->toChars());
                 return new ErrorExp();

--- a/src/expression.h
+++ b/src/expression.h
@@ -511,6 +511,7 @@ struct StructLiteralExp : Expression
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     dt_t **toDt(dt_t **pdt);
     MATCH implicitConvTo(Type *t);
+    Expression *castTo(Scope *sc, Type *t);
 
     int inlineCost3(InlineCostState *ics);
     Expression *doInline(InlineDoState *ids);

--- a/src/init.c
+++ b/src/init.c
@@ -95,7 +95,7 @@ Initializer *ErrorInitializer::semantic(Scope *sc, Type *t, NeedInterpret needIn
 }
 
 
-Expression *ErrorInitializer::toExpression()
+Expression *ErrorInitializer::toExpression(Type *t)
 {
     return new ErrorExp();
 }
@@ -130,7 +130,7 @@ Initializer *VoidInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInt
 }
 
 
-Expression *VoidInitializer::toExpression()
+Expression *VoidInitializer::toExpression(Type *t)
 {
     error(loc, "void initializer has no value");
     return new ErrorExp();
@@ -303,7 +303,7 @@ Lerror:
  * a struct literal. In the future, the two should be the
  * same thing.
  */
-Expression *StructInitializer::toExpression()
+Expression *StructInitializer::toExpression(Type *t)
 {   Expression *e;
     size_t offset;
 
@@ -637,7 +637,7 @@ Lerr:
  * Otherwise return NULL.
  */
 
-Expression *ArrayInitializer::toExpression()
+Expression *ArrayInitializer::toExpression(Type *tx)
 {
     //printf("ArrayInitializer::toExpression(), dim = %d\n", dim);
     //static int i; if (++i == 2) halt();
@@ -1006,6 +1006,9 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
         exp->implicitConvTo(tb->nextOf())
        )
     {
+        /* If the variable is not actually used in compile time, array creation is
+         * redundant. So delay it until invocation of toExpression() or toDt().
+         */
         t = tb->nextOf();
     }
 
@@ -1064,8 +1067,24 @@ Type *ExpInitializer::inferType(Scope *sc)
     return t;
 }
 
-Expression *ExpInitializer::toExpression()
+Expression *ExpInitializer::toExpression(Type *t)
 {
+    if (t)
+    {
+        Type *tb = t->toBasetype();
+        if (tb->ty == Tsarray && exp->implicitConvTo(tb->nextOf()))
+        {
+            TypeSArray *tsa = (TypeSArray *)tb;
+            size_t d = tsa->dim->toInteger();
+            Expressions *elements = new Expressions();
+            elements->setDim(d);
+            for (size_t i = 0; i < d; i++)
+                (*elements)[i] = exp;
+            ArrayLiteralExp *ae = new ArrayLiteralExp(exp->loc, elements);
+            ae->type = t;
+            exp = ae;
+        }
+    }
     return exp;
 }
 

--- a/src/init.h
+++ b/src/init.h
@@ -40,7 +40,7 @@ struct Initializer : Object
     // needInterpret is INITinterpret if must be a manifest constant, 0 if not.
     virtual Initializer *semantic(Scope *sc, Type *t, NeedInterpret needInterpret);
     virtual Type *inferType(Scope *sc);
-    virtual Expression *toExpression() = 0;
+    virtual Expression *toExpression(Type *t = NULL) = 0;
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs) = 0;
     char *toChars();
 
@@ -62,7 +62,7 @@ struct VoidInitializer : Initializer
     VoidInitializer(Loc loc);
     Initializer *syntaxCopy();
     Initializer *semantic(Scope *sc, Type *t, NeedInterpret needInterpret);
-    Expression *toExpression();
+    Expression *toExpression(Type *t = NULL);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     dt_t *toDt();
@@ -75,7 +75,7 @@ struct ErrorInitializer : Initializer
     ErrorInitializer();
     Initializer *syntaxCopy();
     Initializer *semantic(Scope *sc, Type *t, NeedInterpret needInterpret);
-    Expression *toExpression();
+    Expression *toExpression(Type *t = NULL);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     virtual ErrorInitializer *isErrorInitializer() { return this; }
@@ -93,7 +93,7 @@ struct StructInitializer : Initializer
     Initializer *syntaxCopy();
     void addInit(Identifier *field, Initializer *value);
     Initializer *semantic(Scope *sc, Type *t, NeedInterpret needInterpret);
-    Expression *toExpression();
+    Expression *toExpression(Type *t = NULL);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     dt_t *toDt();
@@ -115,7 +115,7 @@ struct ArrayInitializer : Initializer
     Initializer *semantic(Scope *sc, Type *t, NeedInterpret needInterpret);
     int isAssociativeArray();
     Type *inferType(Scope *sc);
-    Expression *toExpression();
+    Expression *toExpression(Type *t = NULL);
     Expression *toAssocArrayLiteral();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
@@ -133,7 +133,7 @@ struct ExpInitializer : Initializer
     Initializer *syntaxCopy();
     Initializer *semantic(Scope *sc, Type *t, NeedInterpret needInterpret);
     Type *inferType(Scope *sc);
-    Expression *toExpression();
+    Expression *toExpression(Type *t = NULL);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     dt_t *toDt();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7948,11 +7948,12 @@ L1:
     {
         // Defer constant folding for the statically initialized
         // const/immutable field until optimize-phase.
-        Expression *ei = v->getConstInitializer();
+        Expression *ei = v->init->toExpression(v->type);
         if (ei)
-        {   e = ei->copy();     // need to copy it if it's a StringExp
-            e = e->semantic(sc);
-            return e;
+        {   ei = ei->copy();    // need to copy it if it's a StringExp
+            ei->loc = e->loc;   // for better error message
+            ei = ei->semantic(sc);
+            return ei;
         }
     }
 
@@ -8602,11 +8603,12 @@ L1:
     {
         // Defer constant folding for the statically initialized
         // const/immutable field until optimize-phase.
-        Expression *ei = v->getConstInitializer();
+        Expression *ei = v->init->toExpression(v->type);
         if (ei)
-        {   e = ei->copy();     // need to copy it if it's a StringExp
-            e = e->semantic(sc);
-            return e;
+        {   ei = ei->copy();    // need to copy it if it's a StringExp
+            ei->loc = e->loc;   // for better error message
+            ei = ei->semantic(sc);
+            return ei;
         }
     }
 

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -72,7 +72,7 @@ Expression *expandVar(int result, VarDeclaration *v)
                 {
                     v->init->semantic(v->scope, v->type, INITinterpret);
                 }
-                Expression *ei = v->init->toExpression();
+                Expression *ei = v->init->toExpression(v->type);
                 if (!ei)
                 {   if (v->storage_class & STCmanifest)
                         v->error("enum cannot be initialized with %s", v->init->toChars());
@@ -133,20 +133,6 @@ Expression *expandVar(int result, VarDeclaration *v)
             }
             if (e->type != v->type)
             {
-                //printf("v->type = %s, e = %s %s\n", v->type->toChars(), e->type->toChars(), e->toChars());
-                Type *tb = v->type->toBasetype();
-                if (tb->ty == Tsarray && e->implicitConvTo(tb->nextOf()))
-                {
-                    TypeSArray *tsa = (TypeSArray *)tb;
-                    size_t d = tsa->dim->toInteger();
-                    Expressions *elements = new Expressions();
-                    elements->setDim(d);
-                    for (size_t i = 0; i < d; i++)
-                        (*elements)[i] = e;
-                    ArrayLiteralExp *ae = new ArrayLiteralExp(e->loc, elements);
-                    ae->type = v->type;
-                    e = ae;
-                }
                 e = e->castTo(NULL, v->type);
             }
             v->inuse++;

--- a/test/compilable/test9818.d
+++ b/test/compilable/test9818.d
@@ -1,0 +1,76 @@
+/************************************/
+// 9818
+
+/*
+TEST_OUTPUT:
+---
+sa1: [1, 1, 1]
+ea1: [1, 1, 1]
+sa2: [1, 1, 1]
+ea2: [1, 1, 1]
+eas: [1, 1, 1]
+eac: [1, 1, 1]
+sa3: [1, 1, 1]
+ea3: [1, 1, 1]
+sa4: [1, 1, 1]
+ea4: [1, 1, 1]
+---
+*/
+
+static const int[3] sa1 = 1;
+pragma(msg, "sa1: ", sa1);          // doesn't work
+static assert(sa1 == [1, 1, 1]);    // doesn't work
+
+enum int[3] ea1 = 1;
+pragma(msg, "ea1: ", ea1);          // prints "1" - bad
+static assert(ea1 == [1, 1, 1]);    // doesn't work
+
+struct X
+{
+    static const int[3] sa2 = 1;
+    pragma(msg, "sa2: ", sa1);          // doesn't work
+    static assert(sa2 == [1, 1, 1]);    // doesn't work
+
+    enum int[3] ea2 = 1;
+    pragma(msg, "ea2: ", ea2);          // prints "1" - bad
+    static assert(ea2 == [1, 1, 1]);    // doesn't work
+}
+
+struct S
+{
+    enum int[3] eas = 1;
+}
+pragma(msg, "eas: ", S.eas);
+static assert(S.eas == [1, 1, 1]);
+class C
+{
+    enum int[3] eac = 1;
+}
+pragma(msg, "eac: ", C.eac);
+static assert(C.eac == [1, 1, 1]);
+
+void test()
+{
+    static const int[3] sa3 = 1;
+    pragma(msg, "sa3: ", sa3);          // doesn't work
+    static assert(sa3 == [1, 1, 1]);    // doesn't work
+
+    enum int[3] ea3 = 1;
+    pragma(msg, "ea3: ", ea3);          // prints "1" - bad
+    static assert(ea3 == [1, 1, 1]);    // doesn't work
+
+    struct Y
+    {
+        static const int[3] sa4 = 1;
+        pragma(msg, "sa4: ", sa4);          // doesn't work
+        static assert(sa4 == [1, 1, 1]);    // doesn't work
+
+        enum int[3] ea4 = 1;
+        pragma(msg, "ea4: ", ea4);          // prints "1" - bad
+        static assert(ea4 == [1, 1, 1]);    // doesn't work
+    }
+}
+
+/************************************/
+
+void main() {}

--- a/test/fail_compilation/fail9790.d
+++ b/test/fail_compilation/fail9790.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9790.d(13): Error: undefined identifier _Unused_
+fail_compilation/fail9790.d(20): Error: template instance fail9790.foo!() error instantiating
+fail_compilation/fail9790.d(18): Error: undefined identifier _Unused_
+fail_compilation/fail9790.d(21): Error: template instance fail9790.bar!() error instantiating
+---
+*/
+
+template foo()
+{
+    enum bool _foo = _Unused_._unused_;
+    enum bool foo = _foo;
+}
+template bar()
+{
+    enum bool bar = _Unused_._unused_;
+}
+alias Foo = foo!();
+alias Bar = bar!();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9818

(This pull request is based on #1800)

Refactoring code for initializer semantic.
- Handle implicit constructor call in `ExpInitializer::semantic`
- Add target type parameter in `Initializer::toExpression`.
  For `T[n] sa = e;`, its initializer translation to `[e1, e2, ..., en]` is delayed until it's really needed.
