### PR TITLE
Fix treatment of string enums in CTFE

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1408,7 +1408,9 @@ int ctfeIdentity(Loc loc, enum TOK op, Expression *e1, Expression *e2)
 int ctfeCmp(Loc loc, enum TOK op, Expression *e1, Expression *e2)
 {
     int n;
-    if (e1->type->isString() && e2->type->isString())
+    Type *t1 = e1->type->toBasetype();
+    Type *t2 = e2->type->toBasetype();
+    if (t1->isString() && t2->isString())
     {
         int cmp = ctfeRawCmp(loc, e1, e2);
         switch (op)
@@ -1431,15 +1433,15 @@ int ctfeCmp(Loc loc, enum TOK op, Expression *e1, Expression *e2)
                 assert(0);
         }
     }
-    else if (e1->type->isreal())
+    else if (t1->isreal())
     {
         n = realCmp(op, e1->toReal(), e2->toReal());
     }
-    else if (e1->type->isimaginary())
+    else if (t1->isimaginary())
     {
         n = realCmp(op, e1->toImaginary(), e2->toImaginary());
     }
-    else if (e1->type->isunsigned() || e2->type->isunsigned())
+    else if (t1->isunsigned() || t2->isunsigned())
     {
         n = intUnsignedCmp(op, e1->toInteger(), e2->toInteger());
     }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1426,11 +1426,11 @@ Expression *StringExp::interpret(InterState *istate, CtfeGoal goal)
      * In D2, we also disallow casts of read-only literals to mutable,
      * though it isn't strictly necessary.
      */
-#if DMDV2
+#if 0 //DMDV2
     // Fixed-length char arrays always get duped later anyway.
     if (type->ty == Tsarray)
         return this;
-    if (!(((TypeNext *)type)->next->mod & (MODconst | MODimmutable)))
+    if (!(((TypeNext *)type)->next->toBasetype()->mod & (MODconst | MODimmutable)))
     {   // It seems this happens only when there has been an explicit cast
         error("cannot cast a read-only string literal to mutable in CTFE");
         return EXP_CANT_INTERPRET;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4720,6 +4720,21 @@ enum int bug7197 = 7;
 static assert(bar7197!(bug7197));
 
 /**************************************************
+    Enum string compare
+**************************************************/
+
+enum EScmp : string { a = "aaa" }
+
+bool testEScmp()
+{
+    EScmp x = EScmp.a;
+    assert( x < "abc" );
+    return true;
+}
+
+static assert(testEScmp());
+
+/**************************************************
     7667
 **************************************************/
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1267,7 +1267,7 @@ static assert(!is(typeof(compiles!(zfs(2)))));
 static assert(!is(typeof(compiles!(zfs(3)))));
 static assert(!is(typeof(compiles!(zfs(4)))));
 static assert(is(typeof(compiles!(zfs(1)))));
-static assert(!is(typeof(compiles!(zfs(5)))));
+static assert(is(typeof(compiles!(zfs(5)))));
 
 /**************************************************
    .dup must protect string literals


### PR DESCRIPTION
String enum compares were failing to compile because it wasn't checking the base type, so wasn't recognizing it as a string.
Likewise, it's OK to cast a string literal to an enum of string type.
After having done that, I've completely disabled the check for casting away string literals, since the assignment code safeguards you from modifying the string literal, and such casts are allowed in const-folding code. I'd like to keep the code around for a bit longer since it is useful for debugging some of the things I'm working on right now.
