### PR TITLE
CTFE: Enums and tuple wrappers are not variables

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1785,7 +1785,7 @@ Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
             }
             return NULL;
         }
-        if (!v->isDataseg() || v->isCTFE())
+        if (!(v->isDataseg() || v->storage_class & STCmanifest) || v->isCTFE())
             ctfeStack.push(v);
         Dsymbol *s = v->toAlias();
         if (s == v && !v->isStatic() && v->init)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1783,6 +1783,7 @@ Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
                 if (!v2->isDataseg() || v2->isCTFE())
                     ctfeStack.push(v2);
             }
+            return NULL;
         }
         if (!v->isDataseg() || v->isCTFE())
             ctfeStack.push(v);


### PR DESCRIPTION
CTFE is currently allocating stack space for local enums, and for tuple wrappers, even though they're not variables. The allocated variables never get used.
