### PR TITLE
Clean up CTFE treatment of forward referenced variables

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1670,6 +1670,11 @@ Lnomatch:
                 else
                     init = i2;          // no errors, keep result
             }
+            else
+            {   // Save scope so that semantic2 can run later
+                scope = new Scope(*sc);
+                scope->setNoFree();
+            }
         }
         else if (parent->isAggregateDeclaration())
         {

--- a/src/expression.c
+++ b/src/expression.c
@@ -3063,6 +3063,11 @@ Lagain:
 
         if ((v->storage_class & STCmanifest) && v->init)
         {
+            // Ensure v->init has had semantic run on it
+            // (TODO: should we ungag errors?)
+            if (v->sem < Semantic2Done && v->scope)
+                v->semantic2(v->scope);
+
             e = v->init->toExpression();
             if (!e)
             {   error("cannot make expression out of initializer for %s", v->toChars());

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -68,6 +68,12 @@ Expression *expandVar(int result, VarDeclaration *v)
                         v->error("recursive initialization of constant");
                     goto L1;
                 }
+                // Ensure v->init has had semantic run on it
+                // (TODO: should we ungag errors?)
+                if (v->sem < Semantic2Done && v->scope)
+                {
+                    v->semantic2(v->scope);
+                }
                 Expression *ei = v->init->toExpression();
                 if (!ei)
                 {   if (v->storage_class & STCmanifest)
@@ -97,18 +103,8 @@ Expression *expandVar(int result, VarDeclaration *v)
                     else
                         goto L1;
                 }
-                if (v->scope)
-                {
-                    v->inuse++;
-                    e = ei->syntaxCopy();
-                    e = e->semantic(v->scope);
-                    e = e->implicitCastTo(v->scope, v->type);
-                    // enabling this line causes test22 in test suite to fail
-                    //ei->type = e->type;
-                    v->scope = NULL;
-                    v->inuse--;
-                }
-                else if (!ei->type)
+
+                if (!ei->type)
                 {
                     goto L1;
                 }

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -600,6 +600,7 @@ void test29()
 static assert((10_000_000_000_000_000 / 1_000_000_000_000_000) == 10);
 
 /*************************************/
+// http://www.digitalmars.com/d/archives/digitalmars/D/bugs/5773.html
 
 template chook(int n)
 {
@@ -616,11 +617,29 @@ const int goose = dog!(pig);
 
 void test30()
 {
-    printf("%d\n", goose);
     assert(goose == 3);
 }
 
 /*************************************/
+
+template Tym(alias T)
+{
+    alias Tym = T;
+}
+
+template Zym(alias waq){
+    alias waq Zym;
+}
+
+struct Qym {
+    int value;
+}
+
+enum Bym : Qym { aq = Qym(1) }
+alias Tym!( Zym!(Bym.aq) ) Xym;
+
+/*************************************/
+// http://forum.dlang.org/thread/dn45s8$vd9$1@digitaldaemon.com
 
 template dog31(string sheep)
 {


### PR DESCRIPTION
If a variable is forward referenced, it may be used in CTFE before it has had a semantic2 pass run on it. This means it hasn't had const-folding run on its initializer yet.
When CTFE executed v->init->toExpression(), the semantic gets run, but the result was discarded (not saved back into v).
If the same variable is used elsewhere in CTFE, the semantic would get run on it again...

As well as being inefficient, this causes problems for any attempt to JIT the CTFE code.
