### PR TITLE
Use the GC to determine whether delegate was stack or heap allocated in test7290.

### DIFF
--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5,6 +5,7 @@ module test42;
 import std.stdio;
 import std.c.stdio;
 import std.string;
+import core.memory;
 
 /***************************************************/
 
@@ -50,7 +51,7 @@ void test3()
 {
     auto i = mixin("__LINE__");
     writefln("%d", i);
-    assert(i == 51);
+    assert(i == 52);
 }
 
 /***************************************************/
@@ -4557,51 +4558,19 @@ void test242()
 /***************************************************/
 // 7290
 
-version (D_InlineAsm_X86)
-{
-    enum GP_BP = "EBP";
-    version = ASM_X86;
-}
-else version (D_InlineAsm_X86_64)
-{
-    enum GP_BP = "RBP";
-    version = ASM_X86;
-}
-
-int foo7290a(alias dg)()
+void foo7290a(alias dg)()
 {
     assert(dg(5) == 7);
-
-    version (ASM_X86)
-    {
-        void* p;
-        mixin(`asm { mov p, ` ~ GP_BP ~ `; }`);
-        assert(p < dg.ptr);
-    }
 }
 
-int foo7290b(scope int delegate(int a) dg)
+void foo7290b(scope int delegate(int a) dg)
 {
     assert(dg(5) == 7);
-
-    version (ASM_X86)
-    {
-        void* p;
-        mixin(`asm { mov p, ` ~ GP_BP ~ `; }`);
-        assert(p < dg.ptr);
-    }
 }
 
-int foo7290c(int delegate(int a) dg)
+void foo7290c(int delegate(int a) dg)
 {
     assert(dg(5) == 7);
-
-    version (ASM_X86)
-    {
-        void* p;
-        mixin(`asm { mov p, ` ~ GP_BP ~ `; }`);
-        assert(p < dg.ptr);
-    }
 }
 
 void test7290()
@@ -4609,12 +4578,7 @@ void test7290()
     int add = 2;
     scope dg = (int a) => a + add;
 
-    version (ASM_X86)
-    {
-        void* p;
-        mixin(`asm { mov p, ` ~ GP_BP ~ `; }`);
-        assert(dg.ptr <= p);
-    }
+    assert(GC.addrOf(dg.ptr) == null);
 
     foo7290a!dg();
     foo7290b(dg);


### PR DESCRIPTION
This test looks at the address of the delegate, and infers locality based the value of that address.  Unfortunately this method is extremely fragile, and is implementation specific.

What it does not even consider is the following may happen under optimisations that causes any of the tests to fail:
- The compiler may inline the functions.
- The compiler may omit the frame pointer.
- The compiler may lazily push the local vars onto the stack only at the point where it's address/value is read, and not in a top down fashion in order of when defined.

The most portable and reliable way to determine that `scope dg` does not create a closure is to check that it's address is not referenced in memory allocated by the GC.
