### PR TITLE
optimize out dead catches

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -4590,9 +4590,8 @@ Statement *TryCatchStatement::syntaxCopy()
     Catches *a = new Catches();
     a->setDim(catches->dim);
     for (size_t i = 0; i < a->dim; i++)
-    {   Catch *c;
-
-        c = (*catches)[i];
+    {
+        Catch *c = (*catches)[i];
         c = c->syntaxCopy();
         (*a)[i] = c;
     }
@@ -4625,12 +4624,36 @@ Statement *TryCatchStatement::semantic(Scope *sc)
     {
         return NULL;
     }
+
+    /* If the try body never throws, we can eliminate any catches
+     * of recoverable exceptions.
+     */
+
+    if (!(body->blockExit(false) & BEthrow) && ClassDeclaration::exception)
+    {
+        for (size_t i = 0; i < catches->dim; i++)
+        {   Catch *c = (*catches)[i];
+
+            /* If catch exception type is derived from Exception
+             */
+            if (c->type->toBasetype()->implicitConvTo(ClassDeclaration::exception->type) &&
+                (!c->handler || !c->handler->comeFrom()))
+            {   // Remove c from the array of catches
+                catches->remove(i);
+                --i;
+            }
+        }
+    }
+
+    if (catches->dim == 0)
+        return body;
+
     return this;
 }
 
 bool TryCatchStatement::hasBreak()
 {
-    return FALSE; //TRUE;
+    return FALSE;
 }
 
 bool TryCatchStatement::usesEH()

--- a/test/fail_compilation/testpull1810.d
+++ b/test/fail_compilation/testpull1810.d
@@ -1,0 +1,21 @@
+// REQUIRED_ARGS: -c -w
+/*
+TEST_OUTPUT:
+---
+fail_compilation/testpull1810.d(19): Warning: statement is not reachable
+---
+*/
+
+uint foo(uint i)
+{
+    try
+    {
+        ++i;
+        return 3;
+    }
+    catch (Exception e)
+    {
+    }
+    return 4;
+}
+

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -580,6 +580,45 @@ void test9568()
 
 /****************************************************/
 
+void test8()
+{
+  int a;
+  goto L2;    // L2 is not addressable.
+
+  try {
+      a += 2;
+  }
+  catch (Exception e) {
+      a += 3;
+L2: ;
+      a += 100;
+  }
+  assert(a == 100);
+}
+
+/****************************************************/
+
+uint foo9(uint i)
+{
+    try
+    {
+        ++i;
+        return 3;
+    }
+    catch (Exception e)
+    {
+        debug printf("Exception happened\n");
+    }
+    return 4;
+}
+
+void test9()
+{
+    assert(foo9(7) == 3);
+}
+
+/****************************************************/
+
 int main()
 {
     printf("start\n");
@@ -596,6 +635,9 @@ int main()
     collideMixed();
     multicollide();
     test9568();
+
+    test8();
+    test9();
 
     printf("finish\n");
     return 0;


### PR DESCRIPTION
With increasing inference of and use of nothrow, being able to eliminate dead catch blocks can significantly improve code speed.

Also needs Phobos pull https://github.com/D-Programming-Language/phobos/pull/1230
