### PR TITLE
[REG2.063a] Issue 9759 - compiler segfault in StructLiteral::implicitConvTo(Type*) on invalid code

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -452,7 +452,10 @@ MATCH StructLiteralExp::implicitConvTo(Type *t)
     {
         m = MATCHconst;
         for (size_t i = 0; i < elements->dim; i++)
-        {   Expression *e = (*elements)[i];
+        {
+            Expression *e = (*elements)[i];
+            if (!e)
+                continue;
             Type *te = e->type;
             te = te->castMod(t->mod);
             MATCH m2 = e->implicitConvTo(te);

--- a/test/fail_compilation/ice9759.d
+++ b/test/fail_compilation/ice9759.d
@@ -1,0 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice9759.d(24): Error: mutable method ice9759.Json.opAssign is not callable using a const object
+---
+*/
+
+struct Json
+{
+    union
+    {
+        Json[] m_array;
+        Json[string] m_object;
+    }
+
+    void opAssign(Json v)
+    {
+    }
+}
+
+void bug()
+{
+    const(Json) r;
+    r = r.init;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9759
