### PR TITLE
[REG2.063a] Issue 9858 - const alias this fails when opAssign is present

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -473,6 +473,8 @@ Type *Type::unSharedOf()
         t->wto = NULL;
         t->swto = NULL;
         t->vtinfo = NULL;
+        if (t->ty == Tstruct) ((TypeStruct *)t)->att = RECfwdref;
+        if (t->ty == Tclass) ((TypeClass *)t)->att = RECfwdref;
         t = t->merge();
 
         t->fixTo(this);
@@ -884,6 +886,8 @@ Type *Type::makeConst()
     t->swto = NULL;
     t->vtinfo = NULL;
     t->ctype = NULL;
+    if (t->ty == Tstruct) ((TypeStruct *)t)->att = RECfwdref;
+    if (t->ty == Tclass) ((TypeClass *)t)->att = RECfwdref;
     //printf("-Type::makeConst() %p, %s\n", t, toChars());
     return t;
 }
@@ -908,6 +912,8 @@ Type *Type::makeInvariant()
     t->swto = NULL;
     t->vtinfo = NULL;
     t->ctype = NULL;
+    if (t->ty == Tstruct) ((TypeStruct *)t)->att = RECfwdref;
+    if (t->ty == Tclass) ((TypeClass *)t)->att = RECfwdref;
     return t;
 }
 
@@ -931,6 +937,8 @@ Type *Type::makeShared()
     t->swto = NULL;
     t->vtinfo = NULL;
     t->ctype = NULL;
+    if (t->ty == Tstruct) ((TypeStruct *)t)->att = RECfwdref;
+    if (t->ty == Tclass) ((TypeClass *)t)->att = RECfwdref;
     return t;
 }
 
@@ -954,6 +962,8 @@ Type *Type::makeSharedConst()
     t->swto = NULL;
     t->vtinfo = NULL;
     t->ctype = NULL;
+    if (t->ty == Tstruct) ((TypeStruct *)t)->att = RECfwdref;
+    if (t->ty == Tclass) ((TypeClass *)t)->att = RECfwdref;
     return t;
 }
 
@@ -977,6 +987,8 @@ Type *Type::makeWild()
     t->swto = NULL;
     t->vtinfo = NULL;
     t->ctype = NULL;
+    if (t->ty == Tstruct) ((TypeStruct *)t)->att = RECfwdref;
+    if (t->ty == Tclass) ((TypeClass *)t)->att = RECfwdref;
     return t;
 }
 
@@ -1000,6 +1012,8 @@ Type *Type::makeSharedWild()
     t->swto = NULL;
     t->vtinfo = NULL;
     t->ctype = NULL;
+    if (t->ty == Tstruct) ((TypeStruct *)t)->att = RECfwdref;
+    if (t->ty == Tclass) ((TypeClass *)t)->att = RECfwdref;
     return t;
 }
 
@@ -1021,6 +1035,8 @@ Type *Type::makeMutable()
     t->swto = NULL;
     t->vtinfo = NULL;
     t->ctype = NULL;
+    if (t->ty == Tstruct) ((TypeStruct *)t)->att = RECfwdref;
+    if (t->ty == Tclass) ((TypeClass *)t)->att = RECfwdref;
     return t;
 }
 

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1123,6 +1123,24 @@ struct S9177
 pragma(msg, is(S9177 : int));
 
 /***************************************************/
+// 9858
+
+struct S9858()
+{
+    @property int get() const
+    {
+        return 42;
+    }
+    alias get this;
+    void opAssign(int) {}
+}
+void test9858()
+{
+    const S9858!() s;
+    int i = s;
+}
+
+/***************************************************/
 
 int main()
 {
@@ -1161,6 +1179,7 @@ int main()
     test7992();
     test8169();
     test9174();
+    test9858();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9858

This regression is introduced by merging #1028.
