### PR TITLE
Visual Studio fixes

### DIFF
--- a/src/backend/mscoff.h
+++ b/src/backend/mscoff.h
@@ -103,7 +103,7 @@ struct syment
         {   long _n_zeroes;
             long _n_offset;
         } _n_n;
-        char *_n_nptr[2];
+        //char *_n_nptr[2]; // Breaks struct on x64
     } _n;
 #define n_name          _n._n_name
 #define n_zeroes        _n._n_n._n_zeroes

--- a/src/dmd_msc.vcproj
+++ b/src/dmd_msc.vcproj
@@ -648,6 +648,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\sapply.c"
+				>
+			</File>
+			<File
 				RelativePath=".\scanmscoff.c"
 				>
 			</File>

--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -163,6 +163,7 @@
     <ClCompile Include="optimize.c" />
     <ClCompile Include="parse.c" />
     <ClCompile Include="s2ir.c" />
+    <ClCompile Include="sapply.c" />
     <ClCompile Include="scanmscoff.c" />
     <ClCompile Include="scanomf.c" />
     <ClCompile Include="scope.c" />

--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -47,8 +47,8 @@
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebug</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreaded</RuntimeLibrary>
-      <Optimization Condition="'$(Configuration)'=='Release'">Full</Optimization>
-      <InlineFunctionExpansion Condition="'$(Configuration)'=='Release'">OnlyExplicitInline</InlineFunctionExpansion>
+      <Optimization Condition="'$(Configuration)'=='Release'">MaxSpeed</Optimization>
+      <InlineFunctionExpansion Condition="'$(Configuration)'=='Release'">AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions Condition="'$(Configuration)'=='Release'">true</IntrinsicFunctions>
       <FavorSizeOrSpeed Condition="'$(Configuration)'=='Release'">Speed</FavorSizeOrSpeed>
       <OmitFramePointers Condition="'$(Configuration)'=='Release'">true</OmitFramePointers>

--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -24,47 +24,35 @@
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+  <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">vcbuild\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)</IntDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">vcbuild\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)</IntDir>
+    <OutDir>vcbuild\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)</IntDir>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>.\root;.\tk;.\backend;.;vcbuild;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DEBUG;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">DEBUG;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreaded</RuntimeLibrary>
+      <Optimization Condition="'$(Configuration)'=='Release'">Full</Optimization>
+      <InlineFunctionExpansion Condition="'$(Configuration)'=='Release'">OnlyExplicitInline</InlineFunctionExpansion>
+      <IntrinsicFunctions Condition="'$(Configuration)'=='Release'">true</IntrinsicFunctions>
+      <FavorSizeOrSpeed Condition="'$(Configuration)'=='Release'">Speed</FavorSizeOrSpeed>
+      <OmitFramePointers Condition="'$(Configuration)'=='Release'">true</OmitFramePointers>
+      <BufferSecurityCheck Condition="'$(Configuration)'=='Release'">false</BufferSecurityCheck>
       <StructMemberAlignment>1Byte</StructMemberAlignment>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -75,33 +63,10 @@
       <AdditionalOptions>/LARGEADDRESSAWARE %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OptimizeReferences>false</OptimizeReferences>
-      <EnableCOMDATFolding>false</EnableCOMDATFolding>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <Optimization>Full</Optimization>
-      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\root;.\tk;.\backend;.;vcbuild;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <StructMemberAlignment>1Byte</StructMemberAlignment>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
-      <WarningLevel>Level4</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <CompileAs>CompileAsCpp</CompileAs>
-      <ForcedIncludeFiles>vcbuild\warnings.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-    </ClCompile>
-    <Link>
-      <AdditionalOptions>/LARGEADDRESSAWARE %(AdditionalOptions)</AdditionalOptions>
-      <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OptimizeReferences>true</OptimizeReferences>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences Condition="'$(Configuration)'=='Debug'">false</OptimizeReferences>
+      <OptimizeReferences Condition="'$(Configuration)'=='Release'">true</OptimizeReferences>
+      <EnableCOMDATFolding Condition="'$(Configuration)'=='Debug'">false</EnableCOMDATFolding>
+      <EnableCOMDATFolding Condition="'$(Configuration)'=='Release'">true</EnableCOMDATFolding>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -179,10 +144,7 @@
     <ClCompile Include="tocvdebug.c" />
     <ClCompile Include="todt.c" />
     <ClCompile Include="toelfdebug.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="toir.c" />
     <ClCompile Include="toobj.c" />
@@ -242,37 +204,22 @@
     <ClCompile Include="backend\type.c" />
     <ClCompile Include="backend\var.c" />
     <ClCompile Include="tk\filespec.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="tk\list.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="tk\mem.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="tk\vec.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="root\aav.c" />
     <ClCompile Include="root\array.c" />
     <ClCompile Include="root\async.c" />
     <ClCompile Include="root\dmgcmem.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="root\longdouble.c" />
     <ClCompile Include="root\man.c" />
@@ -283,99 +230,48 @@
     <ClCompile Include="root\speller.c" />
     <ClCompile Include="root\stringtable.c" />
     <CustomBuild Include="idgen.c">
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cl /TP /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension) &amp;&amp; $(IntDir)%(Filename).exe</Command>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">id.c;id.h;$(IntDir)%(Filename).exe;%(Outputs)</Outputs>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cl /TP /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension) &amp;&amp; $(IntDir)%(Filename).exe</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">idgen.c;%(AdditionalInputs)</AdditionalInputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">id.c;id.h;$(IntDir)%(Filename).exe;%(Outputs)</Outputs>
+      <Message>Building and running $(IntDir)%(Filename).exe</Message>
+      <Command>cl /TP /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension) &amp;&amp; $(IntDir)%(Filename).exe</Command>
+      <AdditionalInputs>idgen.c;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs>id.c;id.h;$(IntDir)%(Filename).exe;%(Outputs)</Outputs>
     </CustomBuild>
     <CustomBuild Include="impcnvgen.c">
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cl /TP /Itk /Iroot /Ivcbuild /FIvcbuild\warnings.h /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension) &amp;&amp; $(IntDir)%(Filename).exe</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mtype.h</AdditionalInputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">impcnvtab.c;%(Outputs)</Outputs>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cl /TP /Itk /Iroot /Ivcbuild /FIvcbuild\warnings.h /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension) &amp;&amp; $(IntDir)%(Filename).exe</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">mtype.h;%(AdditionalInputs)</AdditionalInputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">impcnvtab.c;%(Outputs)</Outputs>
+      <Message>Building and running $(IntDir)%(Filename).exe</Message>
+      <Command>cl /TP /Itk /Iroot /Ivcbuild /FIvcbuild\warnings.h /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension) &amp;&amp; $(IntDir)%(Filename).exe</Command>
+      <AdditionalInputs>mtype.h;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs>impcnvtab.c;%(Outputs)</Outputs>
     </CustomBuild>
     <CustomBuild Include="backend\optabgen.c">
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo"$(IntDir)%(Filename).obj" /Fe"$(IntDir)%(Filename).exe" "%(FullPath)" &amp;&amp; "$(IntDir)%(Filename).exe"</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">backend\cc.h;backend\oper.h</AdditionalInputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c</Outputs>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Building and running $(IntDir)%(Filename).exe</Message>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo"$(IntDir)%(Filename).obj" /Fe"$(IntDir)%(Filename).exe" "%(FullPath)" &amp;&amp; "$(IntDir)%(Filename).exe"</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">backend\cc.h;backend\oper.h</AdditionalInputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo"$(IntDir)%(Filename).obj" /Fe"$(IntDir)%(Filename).exe" "%(FullPath)"
-if errorlevel 1 goto VCReportError
-"$(IntDir)%(Filename).exe"
-</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo"$(IntDir)%(Filename).obj" /Fe"$(IntDir)%(Filename).exe" "%(FullPath)"
-if errorlevel 1 goto VCReportError
-"$(IntDir)%(Filename).exe"
-</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Building and running $(IntDir)%(Filename).exe</Message>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Building and running $(IntDir)%(Filename).exe</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">backend\cc.h;backend\oper.h</AdditionalInputs>
-      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</LinkObjects>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">backend\cc.h;backend\oper.h</AdditionalInputs>
-      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkObjects>
+      <Message>Building and running $(IntDir)%(Filename).exe</Message>
+      <Command>cl /TP /Itk /Iroot /Ivcbuild /I. /FIwarnings.h /Fo"$(IntDir)%(Filename).obj" /Fe"$(IntDir)%(Filename).exe" "%(FullPath)" &amp;&amp; "$(IntDir)%(Filename).exe"</Command>
+      <AdditionalInputs>backend\cc.h;backend\oper.h;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs>optab.c;debtab.c;cdxxx.c;elxxx.c;tytab.c;fltables.c;%(Outputs)</Outputs>
     </CustomBuild>
     <ClCompile Include="cdxxx.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="debtab.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="elxxx.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="fltables.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="id.c" />
     <ClCompile Include="impcnvtab.c" />
     <ClCompile Include="optab.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="tytab.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="libelf.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="libmach.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -461,33 +357,24 @@ if errorlevel 1 goto VCReportError
     <ClInclude Include="vcbuild\warnings.h" />
   </ItemGroup>
   <ItemGroup>
-    <CustomBuildStep Include="vcbuild\ldfpu.asm">
-      <FileType>Document</FileType>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-    </CustomBuildStep>
+    <CustomBuild Include="vcbuild\ldfpu.asm">
+      <ExcludedFromBuild Condition="'$(Platform)'=='Win32'">true</ExcludedFromBuild>
+      <Message>Assembling $(IntDir)%(Filename)%(Extension)</Message>
+      <Command>ml64 -c -Zi "-Fl$(IntDir)%(Filename).lst" "-Fo$(IntDir)%(Filename).obj" "%(FullPath)"</Command>
+      <Outputs>$(IntDir)%(Filename).obj;%(Outputs)</Outputs>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\VERSION">
+      <Message>Building and running $(IntDir)%(Filename).exe</Message>
+      <Command>cl /TP /Itk /Iroot /Ivcbuild /FIvcbuild\warnings.h /Fo$(IntDir)%(Filename).obj /Fe$(IntDir)%(Filename).exe %(Filename)%(Extension) &amp;&amp; $(IntDir)%(Filename).exe</Command>
+      <AdditionalInputs>mtype.h;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs>impcnvtab.c;%(Outputs)</Outputs>
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating verstr.h</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">verstr.h</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-      </AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Generating verstr.h</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">verstr.h</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-      </AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generating verstr.h</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">verstr.h</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      </AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generating verstr.h</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">verstr.h</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      <Command>cmd /E:ON /Q /C "for /f %%f in ( ..\VERSION ) do ( echo "%%f" )" &gt;verstr.h</Command>
+      <Message>Generating verstr.h</Message>
+      <Outputs>verstr.h</Outputs>
+      <AdditionalInputs>
       </AdditionalInputs>
     </CustomBuild>
   </ItemGroup>

--- a/src/dmd_msc.vcxproj.filters
+++ b/src/dmd_msc.vcxproj.filters
@@ -183,6 +183,9 @@
     <ClCompile Include="s2ir.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="sapply.c">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="scanmscoff.c">
       <Filter>src</Filter>
     </ClCompile>

--- a/src/dmd_msc.vcxproj.filters
+++ b/src/dmd_msc.vcxproj.filters
@@ -742,11 +742,6 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <CustomBuildStep Include="vcbuild\ldfpu.asm">
-      <Filter>src\vcbuild</Filter>
-    </CustomBuildStep>
-  </ItemGroup>
-  <ItemGroup>
     <CustomBuild Include="idgen.c">
       <Filter>src\gen</Filter>
     </CustomBuild>
@@ -757,5 +752,8 @@
       <Filter>src\gen</Filter>
     </CustomBuild>
     <CustomBuild Include="..\VERSION" />
+    <CustomBuild Include="vcbuild\ldfpu.asm">
+      <Filter>src\vcbuild</Filter>
+    </CustomBuild>
   </ItemGroup>
 </Project>

--- a/src/root/longdouble.c
+++ b/src/root/longdouble.c
@@ -51,6 +51,7 @@ bool initFPU()
     int old_cw = _control87(_MCW_EM | _PC_64  | _RC_NEAR,
                             _MCW_EM | _MCW_PC | _MCW_RC);
 #endif
+    _set_output_format(_TWO_DIGIT_EXPONENT);
     return true;
 }
 static bool doInitFPU = initFPU();
@@ -592,6 +593,9 @@ static bool unittest()
 
     ld_sprint(buffer, 'g', ldouble(2.0));
     assert(strcmp(buffer, "2.00000") == 0);
+
+    ld_sprint(buffer, 'g', ldouble(1234567.89));
+    assert(strcmp(buffer, "1.23457e+06") == 0);
 
     longdouble ldb = ldouble(0.4);
     long long b = ldb;

--- a/src/root/longdouble.c
+++ b/src/root/longdouble.c
@@ -55,10 +55,10 @@ bool initFPU()
 }
 static bool doInitFPU = initFPU();
 
-#ifndef _WIN64
 extern "C"
 {
 
+#ifndef _WIN64
 double ld_read(const longdouble* pthis)
 {
     double res;
@@ -70,6 +70,8 @@ double ld_read(const longdouble* pthis)
     }
     return res;
 }
+#endif // !_WIN64
+
 long long ld_readll(const longdouble* pthis)
 {
 #if 1
@@ -126,6 +128,7 @@ unsigned long long ld_readull(const longdouble* pthis)
 #endif
 }
 
+#ifndef _WIN64
 void ld_set(longdouble* pthis, double d)
 {
     __asm
@@ -157,9 +160,9 @@ void ld_setull(longdouble* pthis, unsigned long long d)
         fstp tbyte ptr [eax]
     }
 }
+#endif // !_WIN64
 
 } // extern "C"
-#endif // !_WIN64
 
 longdouble ldexpl(longdouble ld, int exp)
 {

--- a/src/root/longdouble.c
+++ b/src/root/longdouble.c
@@ -522,6 +522,13 @@ size_t ld_sprint(char* str, int fmt, longdouble x)
     // fmt is 'a','A','f' or 'g'
     if(fmt != 'a' && fmt != 'A')
     {
+        if (ldouble((unsigned long long)x) == x)
+        {   // ((1.5 -> 1 -> 1.0) == 1.5) is false
+            // ((1.0 -> 1 -> 1.0) == 1.0) is true
+            // see http://en.cppreference.com/w/cpp/io/c/fprintf
+            char format[] = {'%', '#', 'L', fmt, 0};
+            return sprintf(str, format, ld_read(&x));
+        }
         char format[] = { '%', fmt, 0 };
         return sprintf(str, format, ld_read(&x));
     }
@@ -582,6 +589,9 @@ static bool unittest()
     char buffer[32];
     ld_sprint(buffer, 'a', ld_pi);
     assert(strcmp(buffer, "0x1.921fb54442d1846ap+1") == 0);
+
+    ld_sprint(buffer, 'g', ldouble(2.0));
+    assert(strcmp(buffer, "2.00000") == 0);
 
     longdouble ldb = ldouble(0.4);
     long long b = ldb;

--- a/src/vcbuild/ldfpu.asm
+++ b/src/vcbuild/ldfpu.asm
@@ -39,27 +39,27 @@ ld_read ENDP
 
 ; long long ld_readll(longdouble* ld);
 ; rcx: ld
-ld_readll PROC
-	fld tbyte ptr [rcx]
-	push rax
-	fistp qword ptr [rsp]
-	pop rax
-	ret
-ld_readll ENDP
+;ld_readll PROC
+;	fld tbyte ptr [rcx]
+;	push rax
+;	fistp qword ptr [rsp]
+;	pop rax
+;	ret
+;ld_readll ENDP
 
 ; unsigned long long ld_readull(longdouble* ld);
 ; rcx: ld
-ld_readull PROC
-	fld tbyte ptr [rcx]
-	push rax
-	lea rax,twoPow63
-	fld tbyte ptr [rax]
-	fsubp ST(1),ST(0)  ; move it into signed range
-	fistp qword ptr [rsp]
-	pop rax
-	btc rax,63
-	ret
-ld_readull ENDP
+;ld_readull PROC
+;	fld tbyte ptr [rcx]
+;	push rax
+;	lea rax,twoPow63
+;	fld tbyte ptr [rax]
+;	fsubp ST(1),ST(0)  ; move it into signed range
+;	fistp qword ptr [rsp]
+;	pop rax
+;	btc rax,63
+;	ret
+;ld_readull ENDP
 
 ; void ld_set(longdouble* ld, double d);
 ; rcx: ld


### PR DESCRIPTION
x64 builds again, and test suite runs again with `-m32`. One `real`-related test is still failing with `-m64` (when built with VS).
