### PR TITLE
[REG2.062] Issue 9865 - Crash on bogus import / circular reference

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -515,6 +515,12 @@ void AliasDeclaration::semantic(Scope *sc)
      * try to alias y to 3.
      */
     s = type->toDsymbol(sc);
+    if (s && s == this)
+    {
+        error("cannot resolve");
+        s = NULL;
+        type = Type::terror;
+    }
     if (s
 #if DMDV2
         && ((s->getType() && type->equals(s->getType())) || s->isEnumMember())
@@ -683,7 +689,9 @@ Dsymbol *AliasDeclaration::toAlias()
         /* If this is an internal alias for selective import,
          * resolve it under the correct scope.
          */
-        import->semantic(NULL);
+        if (import->scope)
+            import->semantic(NULL);
+        import = NULL;
     }
     else if (scope)
         semantic(scope);

--- a/test/fail_compilation/ice9865.d
+++ b/test/fail_compilation/ice9865.d
@@ -1,0 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice9865.d(9): Error: struct ice9865.Foo no size yet for forward reference
+fail_compilation/ice9865.d(8): Error: alias ice9865.Baz cannot resolve
+---
+*/
+import imports.ice9865b : Baz; 
+struct Foo { Baz f; }

--- a/test/fail_compilation/imports/ice9865b.d
+++ b/test/fail_compilation/imports/ice9865b.d
@@ -1,0 +1,2 @@
+import ice9865;
+class Bar { Foo foo; }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9865

This is a regression caused by fixing issue 9514 (03b0cad6bdfe9646f0907ca3abb8d1ac65073192).
