### PR TITLE
Issue 9874 - Function call syntax disuniformity in template constraints

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -846,6 +846,8 @@ MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
         }
 
         e = e->semantic(sc);
+        e = resolveProperties(sc, e);
+
         if (e->op == TOKerror)
             goto Lnomatch;
 
@@ -1906,6 +1908,7 @@ Lmatch:
         }
 
         e = e->semantic(paramscope);
+        e = resolveProperties(sc, e);
 
         if (fd && fd->vthis)
             fd->vthis = vthissave;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2160,6 +2160,20 @@ void test9837()
 }
 
 /******************************************/
+// 9874
+
+bool foo9874() { return true; }
+void bar9874(T)(T) if (foo9874()) {} // OK
+void baz9874(T)(T) if (foo9874)   {} // error
+
+void test9874()
+{
+    foo9874;                      // OK
+    bar9874(0);
+    baz9874(0);
+}
+
+/******************************************/
 
 void test9885()
 {
@@ -2314,6 +2328,7 @@ int main()
     test9266();
     test9536();
     test9837();
+    test9874();
     test9885();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9874
