### PR TITLE
don't pretend we found a match

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4735,6 +4735,8 @@ Lagain:
             newargs->shift(e);
 
             f = resolveFuncCall(loc, sc, cd->aggNew, NULL, NULL, newargs);
+            if (!f)
+                goto Lerr;
             allocator = f->isNewDeclaration();
             assert(allocator);
 
@@ -4773,6 +4775,8 @@ Lagain:
             newargs->shift(e);
 
             FuncDeclaration *f = resolveFuncCall(loc, sc, sd->aggNew, NULL, NULL, newargs);
+            if (!f)
+                goto Lerr;
             allocator = f->isNewDeclaration();
             assert(allocator);
 

--- a/src/func.c
+++ b/src/func.c
@@ -2594,13 +2594,17 @@ FuncDeclaration *FuncDeclaration::overloadResolve(Loc loc, Expression *ethis, Ex
             m.lastf->functionSemantic();
         return m.lastf;
     }
-    else if (m.last != MATCHnomatch && (flags & 2) && !ethis && m.lastf->needThis())
+
+    if (m.last != MATCHnomatch && (flags & 2) && !ethis && m.lastf->needThis())
     {
         return m.lastf;
     }
-    else if (m.last == MATCHnomatch && (flags & 1))
+
+    /* Failed to find a best match.
+     * Do nothing or print error.
+     */
+    if (m.last == MATCHnomatch && (flags & 1))
     {                   // if do not print error messages
-        return NULL;    // no match
     }
     else
     {
@@ -2635,8 +2639,6 @@ FuncDeclaration *FuncDeclaration::overloadResolve(Loc loc, Expression *ethis, Ex
                     tf->modToChars(),
                     buf.toChars());
             }
-
-            return m.anyf;              // as long as it's not a FuncAliasDeclaration
         }
         else
         {
@@ -2647,9 +2649,9 @@ FuncDeclaration *FuncDeclaration::overloadResolve(Loc loc, Expression *ethis, Ex
                     buf.toChars(),
                     m.lastf->loc.filename, m.lastf->loc.linnum, m.lastf->toPrettyChars(), Parameter::argsTypesToChars(t1->parameters, t1->varargs),
                     m.nextf->loc.filename, m.nextf->loc.linnum, m.nextf->toPrettyChars(), Parameter::argsTypesToChars(t2->parameters, t2->varargs));
-            return m.lastf;
         }
     }
+    return NULL;
 }
 
 /*************************************

--- a/test/fail_compilation/diag9420.d
+++ b/test/fail_compilation/diag9420.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT
 ---
-fail_compilation/diag9420.d(21): Error: function diag9420.S.t3!().tx () is not callable using argument types (int)
-fail_compilation/diag9420.d(21): Error: expected 0 arguments, not 1 for non-variadic function type pure nothrow @safe void()
+fail_compilation/diag9420.d(20): Error: function diag9420.S.t3!().tx () is not callable using argument types (int)
 ---
 */
 


### PR DESCRIPTION
Changed it so it does not attempt to recover from function overload errors by picking one essentially at random. Now it marks the call as invalid.
