### PR TITLE
Move code for handling lvalue SliceExp to glue-layer.

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1809,22 +1809,11 @@ Expression *SliceExp::castTo(Scope *sc, Type *t)
     Expression *e;
     if (typeb->ty == Tarray && tb->ty == Tsarray)
     {
-        e = copy();
-
-        /* Rewrite:
-         *      arr[lwr .. upr]
-         * as:
-         *      *(cast(T[dim]*)(arr[lwr .. upr].ptr))
-         *
-         * Note that:
-         *      static assert(dim == upr - lwr);
+        /* If a SliceExp has Tsarray, it will become lvalue.
+         * That's handled in SliceExp::isLvalue and toLvalue
          */
-        e = new DotIdExp(e->loc, e, Id::ptr);
-        e = e->semantic(sc);
-        e = e->castTo(sc, t->pointerTo());
-        e = new PtrExp(e->loc, e);
-        e = e->semantic(sc);
-        //printf("e = %s, %s => %s %s\n", toChars(), type->toChars(), e->toChars(), e->type->toChars());
+        e = copy();
+        e->type = t;
     }
     else
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -9617,6 +9617,21 @@ int SliceExp::checkModifiable(Scope *sc, int flag)
     return 1;
 }
 
+int SliceExp::isLvalue()
+{
+    /* slice expression is rvalue in default, but
+     * conversion to reference of static array is only allowed.
+     */
+    return (type && type->toBasetype()->ty == Tsarray);
+}
+
+Expression *SliceExp::toLvalue(Scope *sc, Expression *e)
+{
+    //printf("SliceExp::toLvalue(%s) type = %s\n", toChars(), type ? type->toChars() : NULL);
+    return (type && type->toBasetype()->ty == Tsarray)
+            ? this : Expression::toLvalue(sc, e);
+}
+
 Expression *SliceExp::modifiableLvalue(Scope *sc, Expression *e)
 {
     error("slice expression %s is not a modifiable lvalue", toChars());

--- a/src/expression.h
+++ b/src/expression.h
@@ -1146,6 +1146,8 @@ struct SliceExp : UnaExp
     void checkEscape();
     void checkEscapeRef();
     int checkModifiable(Scope *sc, int flag);
+    int isLvalue();
+    Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     int isBool(int result);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);


### PR DESCRIPTION
From 2.063, string and slice of dynamic array is convertible to static array type implicitly.

In #1829, I redefined the lvalue-ness of `StringExp` - if it has static array type, it would make lvalue.

This change will adopt same method for `SliceExp`, and makes front-end clean.
