### PR TITLE
Issue 9561 - Many error messages from std.format

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -2769,6 +2769,11 @@ FuncDeclaration *resolveFuncCall(Loc loc, Scope *sc, Dsymbol *s,
 {
     if (!s)
         return NULL;                    // no match
+    if (tiargs    && arrayObjectIsError(tiargs) ||
+        arguments && arrayObjectIsError((Objects *)arguments))
+    {
+        return NULL;
+    }
     FuncDeclaration *f = s->isFuncDeclaration();
     if (f)
         f = f->overloadResolve(loc, ethis, arguments, flags);


### PR DESCRIPTION
If at least one of function arguments is already error, function matching will always fails. So we can skip matching.
By this change, the errors cause by the original test case:

``` d
import std.stdio: writeln;
import std.algorithm: map;
import std.math: log;
void main() {
    writeln( map!(p => log(1, 2))([1]) );
}
```

Will be reduced to:

``` d
test.d(5): Error: function std.math.log (real x) is not callable using argument types (int,int)
test.d(5): Error: expected 1 arguments, not 2 for non-variadic function type pure nothrow @safe real(real x)
std\algorithm.d(404): Error: template instance test.main.__lambda2!(int) error instantiating
std\algorithm.d(390):        instantiated from here: MapResult!(__lambda2, int[])
test.d(5):        instantiated from here: map!(int[])
std\algorithm.d(390): Error: template instance test.main.MapResult!(__lambda2, int[]) error instantiating
test.d(5):        instantiated from here: map!(int[])
test.d(5): Error: template instance test.main.map!(__lambda2).map!(int[]) error instantiating
```
