### PR TITLE
fix9866

### DIFF
--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -640,25 +640,23 @@ PTRNTAB2  aptb2MOVS[] = /* MOVS */ {
         { ASM_END }
 };
 PTRNTAB2  aptb2MOVSX[] = /* MOVSX */ {
-        { 0x0fbe,       _r|_16_bit,                     _r16,   _rm8 },
-        { 0x0fbe,       _r|_32_bit,                     _r32,   _rm8 },
-#if 1
-        { 0x0fbf,       _r|_16_bit,             _r16,   _rm16 },
-        { 0x0fbf,       _r|_32_bit,             _r32,   _rm16 },
-#else
+        { 0x0fbe,       _r|_16_bit,             _r16,   _rm8 },
+        { 0x0fbe,       _r|_32_bit,             _r32,   _rm8 },
+        { 0x0fbe,       _r|_64_bit,             _r64,   _rm8 },  // TODO: REX_W override is implicit
         { 0x0fbf,       _r,                     _r32,   _rm16 },
-#endif
+        { 0x0fbf,       _r|_64_bit,             _r64,   _rm16 }, // TODO: REX_W override is implicit
+        { ASM_END }
+};
+PTRNTAB2  aptb2MOVSXD[] = /* MOVSXD */ {
+        { 0x63,         _r|_64_bit,             _r64,   _rm32 }, // TODO: REX_W override is implicit
         { ASM_END }
 };
 PTRNTAB2  aptb2MOVZX[] = /* MOVZX */ {
-        { 0x0fb6,       _r|_16_bit,                     _r16,   _rm8 },
-        { 0x0fb6,       _r|_32_bit,                     _r32,   _rm8 },
-#if 1
-        { 0x0fb7,       _r|_16_bit,             _r16,   _rm16 },
-        { 0x0fb7,       _r|_32_bit,             _r32,   _rm16 },
-#else
+        { 0x0fb6,       _r|_16_bit,             _r16,   _rm8 },
+        { 0x0fb6,       _r|_32_bit,             _r32,   _rm8 },
+        { 0x0fb6,       _r|_64_bit,             _r64,   _rm8 },  // TODO: REX_W override is implicit
         { 0x0fb7,       _r,                     _r32,   _rm16 },
-#endif
+        { 0x0fb7,       _r|_64_bit,             _r64,   _rm16 }, // TODO: REX_W override is implicit
         { ASM_END }
 };
 PTRNTAB2  aptb2MUL[] = /* MUL */ {
@@ -5063,6 +5061,7 @@ PTRNTAB3 aptb3VFMSUB231SS[] = /* VFMSUB231SS */ {
         X("movss",          2,              (P) aptb2MOVSS )                \
         X("movsw",          0,              aptb0MOVSW )                    \
         X("movsx",          2,              (P) aptb2MOVSX )                \
+        X("movsxd",         2,              (P) aptb2MOVSXD )               \
         X("movupd",         2,              (P) aptb2MOVUPD )               \
         X("movups",         2,              (P) aptb2MOVUPS )               \
         X("movzx",          2,              (P) aptb2MOVZX )                \

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -4648,6 +4648,57 @@ L1:     pop     EAX;
     }
 }
 
+
+void test9866()
+{
+    ubyte* p;
+    static ubyte data[] =
+    [
+        0x66, 0x0f, 0xbe, 0xc0, // movsx AX, AL;
+        0x66, 0x0f, 0xbe, 0x00, // movsx AX, byte ptr [EAX];
+              0x0f, 0xbe, 0xc0, // movsx EAX, AL;
+              0x0f, 0xbe, 0x00, // movsx EAX, byte ptr [EAX];
+              0x0f, 0xbf, 0xc0, // movsx EAX, AX;
+              0x0f, 0xbf, 0x00, // movsx EAX, word ptr [EAX];
+
+        0x66, 0x0f, 0xb6, 0xc0, // movzx AX, AL;
+        0x66, 0x0f, 0xb6, 0x00, // movzx AX, byte ptr [EAX];
+              0x0f, 0xb6, 0xc0, // movzx EAX, AL;
+              0x0f, 0xb6, 0x00, // movzx EAX, byte ptr [EAX];
+              0x0f, 0xb7, 0xc0, // movzx EAX, AX;
+              0x0f, 0xb7, 0x00, // movzx EAX, word ptr [EAX];
+    ];
+
+    asm
+    {
+        call L1;
+
+        movsx AX, AL;
+        movsx AX, byte ptr [EAX];
+        movsx EAX, AL;
+        movsx EAX, byte ptr [EAX];
+        movsx EAX, AX;
+        movsx EAX, word ptr [EAX];
+
+        movzx AX, AL;
+        movzx AX, byte ptr [EAX];
+        movzx EAX, AL;
+        movzx EAX, byte ptr [EAX];
+        movzx EAX, AX;
+        movzx EAX, word ptr [EAX];
+
+L1:     pop     EAX;
+        mov     p[EBP],EAX;
+    }
+
+    foreach (ref i, b; data)
+    {
+        // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+        assert(p[i] == b);
+    }
+    assert(p[data.length] == 0x58); // pop EAX
+}
+
 /****************************************************/
 
 int main()
@@ -4717,6 +4768,7 @@ int main()
     test57();
     test58();
     test59();
+    test9866();
   }
     printf("Success\n");
     return 0;
@@ -4727,4 +4779,3 @@ else
 {
     int main() { return 0; }
 }
-

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -6419,6 +6419,43 @@ L1:
     }
 }
 
+
+void test9866()
+{
+    ubyte* p;
+    static ubyte data[] =
+    [
+        0x48, 0x0f, 0xbe, 0xc0, // movsx RAX, AL
+        0x48, 0x0f, 0xbe, 0x00, // movsx RAX, byte ptr [RAX]
+        0x48, 0x0f, 0xbf, 0xc0, // movsx RAX, AX
+        0x48, 0x0f, 0xbf, 0x00, // movsx RAX, word ptr [RAX]
+        0x48, 0x63, 0xc0,       // movsxd RAX, EAX
+        0x48, 0x63, 0x00,       // movsxd RAX, dword ptr [RAX]
+    ];
+
+    asm
+    {
+        call L1;
+
+        movsx RAX, AL;
+        movsx RAX, byte ptr [RAX];
+        movsx RAX, AX;
+        movsx RAX, word ptr [RAX];
+        movsxd RAX, EAX;
+        movsxd RAX, dword ptr [RAX];
+
+L1:     pop     RAX;
+        mov     p[RBP],RAX;
+    }
+
+    foreach (ref i, b; data)
+    {
+        // printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+        assert(p[i] == b);
+    }
+    assert(p[data.length] == 0x58); // pop RAX
+}
+
 /****************************************************/
 
 void testxadd()
@@ -6519,6 +6556,7 @@ int main()
     test60();
     test61();
     test2941();
+    test9866();
     testxadd();
 
     printf("Success\n");


### PR DESCRIPTION
- also removed non-existing MOVSX/MOVSZ r16, r/m16

[Bugzilla 9866](http://d.puremagic.com/issues/show_bug.cgi?id=9866)
