### PR TITLE
Test testbounds.d and testbounds2.d with permute switches

### DIFF
--- a/test/runnable/testbounds.d
+++ b/test/runnable/testbounds.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS:
+// REQUIRED_ARGS:
 
 // Test array bounds checking
 

--- a/test/runnable/testbounds2.d
+++ b/test/runnable/testbounds2.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS:
+// REQUIRED_ARGS:
 
 // Test compile time boundaries checking
 


### PR DESCRIPTION
Change from () to (-inline -release -g -O)

From 2.063, conversion slice to static array will be supported ([issue 3652](http://d.puremagic.com/issues/show_bug.cgi?id=3652) and others).
To make the code tough, I had tried to change test option as above, but [bug 9781](http://d.puremagic.com/issues/show_bug.cgi?id=9781) had blocked it. Now the bug was fixed by @dawgfoto in #1874, so I'd like to apply this.
