### PR TITLE
Fix wrong code bug when tuple over member variable in multiple methods.

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -150,6 +150,8 @@ Dsymbol *getDsymbol(Object *oarg)
     {   // Try to convert Expression to symbol
         if (ea->op == TOKvar)
             sa = ((VarExp *)ea)->var;
+        else if (ea->op == TOKdotvar)
+            sa = ((DotVarExp *)ea)->var;
         else if (ea->op == TOKfunction)
         {
             if (((FuncExp *)ea)->td)

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -397,3 +397,27 @@ void test9348()
     assert(F!0 !is null);
     assert(F!0 !in [new Object():1]);
 }
+
+
+/***************************************************/
+// 9912
+
+template TypeTuple9912(Stuff...)
+{
+    alias Stuff TypeTuple9912;
+}
+
+struct S9912
+{
+    int i;
+    alias TypeTuple9912!i t;
+
+    void testA() {
+        auto x = t;
+    }
+
+    void testB() {
+        auto x = t;
+    }
+}
+


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9912

Not sure if there are other cases where this might happen with tuples, will need to test other variants of the original case.
