### PR TITLE
Issue 9912 - Wrong codegen when using tuple over member variable in more than one method

### DIFF
--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -6244,6 +6244,28 @@ void test9834()
 }
 
 /***************************************************/
+// 9912
+
+template TypeTuple9912(Stuff...)
+{
+    alias Stuff TypeTuple9912;
+}
+
+struct S9912
+{
+    int i;
+    alias TypeTuple9912!i t;
+
+    void testA() {
+        auto x = t;
+    }
+
+    void testB() {
+        auto x = t;
+    }
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9912

This pull request intends to replace #1880 with better way.
