### PR TITLE
[Issue 9571] Proof-of-concept fix for emitting only required template symbols

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -4874,6 +4874,25 @@ void TemplateInstance::trySemantic3(Scope *sc2)
     --nest;
 }
 
+Module* TemplateInstance::getRootModule()
+{
+	TemplateInstance *ti = this;
+
+	while (true)
+	{
+		while (ti->tinst)
+			ti = ti->tinst;
+
+		TemplateInstance *enclosing_tmpl = NULL;
+		if ((ti->enclosing) && (enclosing_tmpl = dynamic_cast<TemplateInstance*>(ti->enclosing)))
+			ti = enclosing_tmpl;
+		else
+			break;
+	}
+
+	return ti->getModule();
+}
+
 void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
 {
     //printf("TemplateInstance::semantic('%s', this=%p, gag = %d, sc = %p)\n", toChars(), this, global.gag, sc);
@@ -5089,8 +5108,8 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         }
         else
         {
-            Module *m = (enclosing ? sc : tempdecl->scope)->module->importedFrom;
-            //printf("\t2: adding to module %s instead of module %s\n", m->toChars(), sc->module->toChars());
+            Module *m = getRootModule();
+           // printf("\t2: adding %s to module %s instead of module %s\n", this->name->string, m->toChars(), sc->module->toChars());
             a = m->members;
             if (m->semanticRun >= 3)
             {

--- a/src/template.h
+++ b/src/template.h
@@ -325,6 +325,7 @@ struct TemplateInstance : ScopeDsymbol
     char *toChars();
     char *mangle(bool isv = false);
     void printInstantiationTrace();
+    Module* getRootModule(); // tracks down the root module of template instantiation chain
 
     void toObjFile(int multiobj);                       // compile to .obj file
 


### PR DESCRIPTION
Don't have easy access to different OS and linking is quite platform-dependent, so I'll abuse pull tester a bit ;)

This pull attempts to clean up template symbol emitting to object files. Currently all of them are generated to object file associated with module supplied to the command line. For separate compilation scenario that means that ALL template symbols from ALL imported modules are emitted into compiled single module.

Most time it is just extra job for linker, but sometimes this results in nasty bugs when resulting symbols are not weak ones (issue 9581 is exactly one such case).

After this pull request is merged dmd will try to find root module where template instantiation chain has started via call from non-templated scope. Implementation improvementn suggestions are welcome, of course, this is quick and dirty attempt.
