### PR TITLE
Issue 2356 - array literal as non static initializer generates horribly inefficient code.

### DIFF
--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -399,6 +399,15 @@ STATIC void chkrd(elem *n,list_t rdlist)
         if (sv->Stype->Ttag->Sstruct->Sflags & (STRbitfields | STR0size))
             return;
     }
+#if 0
+    // If variable is zero length static array, don't print message.
+    // BUG: Suppress error even if variable is initialized with void.
+    if (sv->Stype->Tty == TYarray && sv->Stype->Tdim == 0)
+    {
+        printf("sv->Sident = %s\n", sv->Sident);
+        return;
+    }
+#endif
 #if SCPP
     {   Outbuffer buf;
         char *p2;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2722,6 +2722,97 @@ elem *AssignExp::toElem(IRState *irs)
         SliceExp *are = (SliceExp *)(e1);
         Type *t1 = t1b;
         Type *t2 = e2->type->toBasetype();
+        Type *ta = are->e1->type->toBasetype();
+
+        /* Optimize static array assignment with array literal.
+         * Rewrite:
+         *      sa[] = [a, b, ...];
+         * as:
+         *      sa[0] = a, sa[1] = b, ...;
+         *
+         * If the same values are contiguous, that will be rewritten
+         * to block assignment.
+         * Rewrite:
+         *      sa[] = [x, a, a, b, ...];
+         * as:
+         *      sa[0] = x, sa[1..2] = a, sa[3] = b, ...;
+         */
+        if (are->lwr == NULL && ta->ty == Tsarray &&
+            e2->op == TOKarrayliteral &&
+            t2->nextOf()->mutableOf()->implicitConvTo(ta->nextOf()))
+        {
+            ArrayLiteralExp *ae = (ArrayLiteralExp *)e2;
+            TypeSArray *tsa = (TypeSArray *)ta;
+
+            size_t dim = ae->elements->dim;
+            if (dim == 0)
+            {
+                goto Lx;
+            #if 0
+                /* This code doesn't work with -O switch. Because backend optimizer
+                 * will eliminate this useless initializing code for zero-length
+                 * static array completely, then the variable kept in "unset".
+                 * Instead to fallback to the __d_arrayliteral call.
+                 */
+                symbol *stmp = symbol_genauto(TYnptr);
+                e = are->e1->toElem(irs);
+                e = addressElem(e, tsa);
+                e = el_bin(OPeq, TYnptr, el_var(stmp), e);
+
+                elem *e1 = el_var(stmp);
+                e1 = el_una(OPind, tsa->totym(), e1);
+                e1->ET = tsa->toCtype();
+                elem *e2 = el_long(tsa->totym(), 0);
+
+                elem *ex = el_bin(OPstreq, TYstruct, e1, e2);
+                ex->ET = tsa->toCtype();
+                e = el_combine(e, ex);
+                goto Lret;
+            #endif
+            }
+
+            Type *tn = tsa->nextOf()->toBasetype();
+            tym_t ty = tn->totym();
+
+            symbol *stmp = symbol_genauto(TYnptr);
+            e = are->e1->toElem(irs);
+            e = addressElem(e, tsa);
+            e = el_bin(OPeq, TYnptr, el_var(stmp), e);
+
+            size_t esz = tn->size();
+            for (size_t i = 0; i < dim; )
+            {
+                Expression *en = (*ae->elements)[i];
+                size_t j = i + 1;
+                while (j < dim && en->equals((*ae->elements)[j])) { j++; }
+
+                elem *e1 = el_var(stmp);
+                if (i > 0)
+                    e1 = el_bin(OPadd, TYnptr, e1, el_long(TYsize_t, i * esz));
+                elem *ex;
+                if (j == i + 1)
+                {
+                    e1 = el_una(OPind, ty, e1);
+                    if (tybasic(ty) == TYstruct)
+                        e1->ET = tn->toCtype();
+                    ex = el_bin(OPeq, e1->Ety, e1, en->toElem(irs));
+                    if (tybasic(ty) == TYstruct)
+                    {   ex->Eoper = OPstreq;
+                        ex->ET = tn->toCtype();
+                    }
+                }
+                else
+                {
+                    assert(j - i >= 2);
+                    elem *edim = el_long(TYsize_t, j - i);
+                    ex = setArray(e1, edim, tn, en->toElem(irs), irs, op);
+                }
+                e = el_combine(e, ex);
+                i = j;
+            }
+            goto Lret;
+        }
+    Lx:
 
         // which we do if the 'next' types match
         if (ismemset)
@@ -2731,7 +2822,6 @@ elem *AssignExp::toElem(IRState *irs)
             elem *enbytes;
             elem *elength;
             elem *einit;
-            Type *ta = are->e1->type->toBasetype();
             Type *tb = ta->nextOf()->toBasetype();
             unsigned sz = tb->size();
             tym_t tym = type->totym();

--- a/src/expression.c
+++ b/src/expression.c
@@ -10816,7 +10816,7 @@ Ltupleassign:
         else
         {
             // Convert e2 to e2[], unless e2-> e1[0]
-            if (t2->ty == Tsarray && !t2->implicitConvTo(t1->nextOf()))
+            if (e2->op != TOKarrayliteral && t2->ty == Tsarray && !t2->implicitConvTo(t1->nextOf()))
             {
                 e2 = new SliceExp(e2->loc, e2, NULL, NULL);
                 e2 = e2->semantic(sc);

--- a/test/fail_compilation/fail3703.d
+++ b/test/fail_compilation/fail3703.d
@@ -3,14 +3,25 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3703.d(15): Error: mismatched array lengths, 2 and 1
+fail_compilation/fail3703.d(18): Error: mismatched array lengths, 2 and 1
+fail_compilation/fail3703.d(20): Error: mismatched array lengths, 2 and 1
+fail_compilation/fail3703.d(22): Error: mismatched array lengths, 3 and 2
+fail_compilation/fail3703.d(23): Error: mismatched array lengths, 2 and 3
+fail_compilation/fail3703.d(25): Error: mismatched array lengths, 3 and 2
+fail_compilation/fail3703.d(26): Error: mismatched array lengths, 2 and 3
 ---
 */
 
 void main()
 {
     int[1] a = [1];
-    int[2] b;
+    int[2] b = a;   // should make compile error
 
     b = a;  // should make compile error
+
+    int[3] sa3 = [1,2][];
+    int[2] sa2 = sa3[][];
+
+    sa3 = [1,2][];
+    sa2 = sa3[][];
 }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3279,6 +3279,52 @@ void cantthrow() nothrow
 }
 
 /***************************************************/
+// 2356
+
+void test2356()
+{
+    int[3] x = [1,2,3];
+    printf("x[] = [%d %d %d]\n", x[0], x[1], x[2]);
+    assert(x[0] == 1 && x[1] == 2 && x[2] == 3);
+
+    struct S
+    {
+        static int pblit;
+        int n;
+        this(this) { ++pblit; printf("postblit: %d\n", n); }
+    }
+    S s2 = S(2);
+    S[3] s = [S(1), s2, S(3)];
+    assert(s[0].n == 1 && s[1].n == 2 && s[2].n == 3);
+    printf("s[].n = [%d %d %d]\n", s[0].n, s[1].n, s[2].n);
+    assert(S.pblit == 1);
+
+    ubyte[1024] v;
+    v = typeof(v).init;
+    printf("v[] = [%d %d %d, ..., %d]\n", v[0], v[1], v[2], v[$-1]);
+    foreach (ref a; v) assert(a == 0);
+
+    int n = 5;
+    int[3] y = [n, n, n];
+    printf("y[] = [%d %d %d]\n", y[0], y[1], y[2]);
+    assert(y[0] == 5 && y[1] == 5 && y[2] == 5);
+
+    S[3] z = [s2, s2, s2];
+    assert(z[0].n == 2 && z[1].n == 2 && z[2].n == 2);
+    printf("z[].n = [%d %d %d]\n", z[0].n, z[1].n, z[2].n);
+    assert(S.pblit == 1 + 3);
+
+    int[0] nsa0 = [];
+    void[0] vsa0 = [];
+
+    void foo(T)(T){}
+    foo(vsa0);
+
+    ref int[0] bar() { static int[1] sa; return *cast(int[0]*)&sa; }
+    bar() = [];
+}
+
+/***************************************************/
 
 class A2540
 {
@@ -6369,6 +6415,7 @@ int main()
     test6685();
     test148();
     test149();
+    test2356();
     test2540();
     test150();
     test151();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=2356

In static array initializing and assignment, removes redundant heap allocation of the array literal. If element values are contiguous, translates it to block assignment.
