### PR TITLE
distinguish ALLREGS from allregs

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -98,7 +98,15 @@ static symbol *retsym;          // set to symbol that should be placed in
 regm_t msavereg;        // Mask of registers that we would like to save.
                         // they are temporaries (set by scodelem())
 regm_t mfuncreg;        // Mask of registers preserved by a function
-regm_t allregs;         // ALLREGS optionally including mBP
+
+#if __DMC__
+extern "C" {
+// make sure it isn't merged with ALLREGS
+regm_t __cdecl allregs;         // ALLREGS optionally including mBP
+}
+#else
+regm_t allregs;                // ALLREGS optionally including mBP
+#endif
 
 int dfoidx;                     /* which block we are in                */
 struct CSE *csextab = NULL;     /* CSE table (allocated for each function) */


### PR DESCRIPTION
Linking on Win32 can confuse ALLREGS with allregs.
