### PR TITLE
Implement nogc framework (warn about GC allocations)

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -612,6 +612,7 @@ public:
     #define FUNCFLAGpurityInprocess 1   // working on determining purity
     #define FUNCFLAGsafetyInprocess 2   // working on determining safety
     #define FUNCFLAGnothrowInprocess 4  // working on determining nothrow
+    #define FUNCFLAGgcuseInprocess  8   // working on determining gc usage
 
     FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);
@@ -631,6 +632,7 @@ public:
     bool overloadInsert(Dsymbol *s);
     FuncDeclaration *overloadExactMatch(Type *t);
     TemplateDeclaration *findTemplateDeclRoot();
+    bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration *g);
     LabelDsymbol *searchLabel(Identifier *ident);
     AggregateDeclaration *isThis();
@@ -655,6 +657,9 @@ public:
     bool isSafeBypassingInference();
     bool isTrusted();
     bool setUnsafe();
+    bool isNOGC();
+    bool setGCUse(Loc loc, const char *warn);
+    bool setGCUse();
     bool isolateReturn();
     bool parametersIntersect(Type *t);
     virtual bool isNested();

--- a/src/func.c
+++ b/src/func.c
@@ -33,6 +33,8 @@ void functionToBufferWithIdent(TypeFunction *t, OutBuffer *buf, const char *iden
 void genCmain(Scope *sc);
 void toBufferShort(Type *t, OutBuffer *buf, HdrGenState *hgs);
 
+void checkGC(FuncDeclaration *func, Statement *stmt);
+
 /* A visitor to walk entire statements and provides ability to replace any sub-statements.
  */
 class StatementRewriteWalker : public Visitor
@@ -2077,6 +2079,19 @@ void FuncDeclaration::semantic3(Scope *sc)
         f->trust = TRUSTsafe;
     }
 
+    if (fbody)
+        checkGC(this, fbody);
+
+    if (needsClosure() && setGCUse(loc, "Using closure causes gc allocation"))
+        error("Can not use closures in @nogc code");
+
+    if (flags & FUNCFLAGgcuseInprocess)
+    {
+        flags &= ~FUNCFLAGgcuseInprocess;
+        if (type == f) f = (TypeFunction *)f->copy();
+        f->gcuse = GCUSEnogc;
+    }
+
     // reset deco to apply inference result to mangled name
     if (f != type)
         f->deco = NULL;
@@ -2863,6 +2878,23 @@ static void MODMatchToBuffer(OutBuffer *buf, unsigned char lhsMod, unsigned char
 }
 
 /********************************************
+ * Returns true if function was declared
+ * directly or indirectly in a unittest block
+ */
+bool FuncDeclaration::inUnittest()
+{
+    Dsymbol *f = this;
+    do
+    {
+        if (f->isUnitTestDeclaration())
+            return true;
+        f = f->toParent();
+    } while (f);
+
+    return false;
+}
+
+/********************************************
  * find function template root in overload list
  */
 
@@ -3504,6 +3536,52 @@ bool FuncDeclaration::setUnsafe()
         ((TypeFunction *)type)->trust = TRUSTsystem;
     }
     else if (isSafe())
+        return true;
+    return false;
+}
+
+/**************************************
+ * Return true if the function is marked
+ * as @nogc and therefore must not allocate.
+ */
+bool FuncDeclaration::isNOGC()
+{
+    assert(type->ty == Tfunction);
+    if (flags & FUNCFLAGgcuseInprocess)
+        setGCUse();
+    return ((TypeFunction *)type)->gcuse == GCUSEnogc;
+}
+
+/**************************************
+ * Mark function as using GC, warn on -vgc, return
+ * true if GC access is an error (@nogc)
+ */
+bool FuncDeclaration::setGCUse(Loc loc, const char* warn)
+{
+    if (setGCUse())
+    {
+        return true;
+    }
+    //Only warn about errors in 'root' modules
+    else if (global.params.vgc && getModule() && getModule()->isRoot()
+        && !inUnittest())
+    {
+        fprintf(global.stdmsg, "%s: vgc: %s\n", loc.toChars(), warn);
+    }
+    return false;
+}
+
+/**************************************
+ * Same as above, but do not warn on -vgc
+ */
+bool FuncDeclaration::setGCUse()
+{
+    if (flags & FUNCFLAGgcuseInprocess)
+    {
+        flags &= ~FUNCFLAGgcuseInprocess;
+        ((TypeFunction *)type)->gcuse = GCUSEgc;
+    }
+    else if (isNOGC())
         return true;
     return false;
 }

--- a/src/mars.c
+++ b/src/mars.c
@@ -464,6 +464,7 @@ Usage:\n\
   -version=level compile in version code >= level\n\
   -version=ident compile in version code identified by ident\n\
   -vtls          list all variables going into thread local storage\n\
+  -vgc           list all hidden gc allocations\n\
   -w             warnings as errors (compilation will halt)\n\
   -wi            warnings as messages (compilation will continue)\n\
   -X             generate JSON file\n\
@@ -739,6 +740,8 @@ int tryMain(size_t argc, const char *argv[])
                 global.params.vtls = true;
             else if (strcmp(p + 1, "vcolumns") == 0)
                 global.params.showColumns = true;
+            else if (strcmp(p + 1, "vgc") == 0)
+                global.params.vgc = true;
             else if (memcmp(p + 1, "transition", 10) == 0)
             {
                 // Parse:

--- a/src/mars.h
+++ b/src/mars.h
@@ -95,6 +95,7 @@ struct Param
     bool verbose;       // verbose compile
     bool showColumns;   // print character (column) numbers in diagnostics
     bool vtls;          // identify thread local variables
+    char vgc;           // identify gc usage
     bool vfield;        // identify non-mutable field variables
     char symdebug;      // insert debug symbolic information
     bool alwaysframe;   // always emit standard stack frame

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2098,6 +2098,7 @@ Type *TypeFunction::substWildTo(unsigned)
     t->isref = isref;
     t->iswild = 0;
     t->trust = trust;
+    t->gcuse = gcuse;
     t->fargs = fargs;
     return t->merge();
 }
@@ -5150,6 +5151,7 @@ TypeFunction::TypeFunction(Parameters *parameters, Type *treturn, int varargs, L
         this->isref = true;
 
     this->trust = TRUSTdefault;
+    this->gcuse = GCUSEdefault;
     if (stc & STCsafe)
         this->trust = TRUSTsafe;
     if (stc & STCsystem)
@@ -5180,6 +5182,7 @@ Type *TypeFunction::syntaxCopy()
     t->isref = isref;
     t->iswild = iswild;
     t->trust = trust;
+    t->gcuse = gcuse;
     t->fargs = fargs;
     return t;
 }
@@ -6161,6 +6164,7 @@ Type *TypeFunction::addStorageClass(StorageClass stc)
         tf->isproperty = t->isproperty;
         tf->isref = t->isref;
         tf->trust = t->trust;
+        tf->gcuse = t->gcuse;
         tf->iswild = t->iswild;
 
         if (stc & STCpure)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -594,6 +594,13 @@ enum TRUST
     TRUSTsafe = 3,      // @safe
 };
 
+enum GCUSE
+{
+    GCUSEdefault = 0,
+    GCUSEgc     = 1,    // @gc (same as GCUSEdefault)
+    GCUSEnogc   = 2,    // @nogc
+};
+
 enum PURE
 {
     PUREimpure = 0,     // not pure at all
@@ -618,6 +625,7 @@ public:
     bool isref;         // true: returns a reference
     LINK linkage;  // calling convention
     TRUST trust;   // level of trust
+    GCUSE gcuse;   // is gc used?
     PURE purity;   // PURExxxx
     unsigned char iswild;   // bit0: inout on params, bit1: inout on qualifier
     Expressions *fargs; // function arguments

--- a/src/nogc.c
+++ b/src/nogc.c
@@ -1,0 +1,244 @@
+// Compiler implementation of the D programming language
+// Copyright (c) 1999-2013 by Digital Mars
+// All Rights Reserved
+// written by Walter Bright
+// http://www.digitalmars.com
+// License for redistribution is by either the Artistic License
+// in artistic.txt, or the GNU General Public License in gnu.txt.
+// See the included readme.txt for details.
+
+#include "mars.h"
+#include "init.h"
+#include "visitor.h"
+#include "expression.h"
+#include "statement.h"
+#include "declaration.h"
+#include "id.h"
+
+bool walkPostorder(Statement *s, StoppableVisitor *v);
+bool walkPostorder(Expression *e, StoppableVisitor *v);
+
+/**************************************
+ * Look for GC-allocations
+ */
+class NOGCVisitor : public StoppableVisitor
+{
+public:
+    FuncDeclaration *func;
+
+    NOGCVisitor(FuncDeclaration *fdecl)
+    {
+        func = fdecl;
+    }
+
+    void doCond(Initializer *init)
+    {
+        if (init)
+            init->accept(this);
+    }
+
+    void doCond(Expression *exp)
+    {
+        if (exp)
+            walkPostorder(exp, this);
+    }
+
+    void visit(Initializer *init)
+    {
+    }
+    void visit(StructInitializer *init)
+    {
+        for (size_t i = 0; i < init->value.dim; i++)
+            doCond(init->value[i]);
+    }
+    void visit(ArrayInitializer *init)
+    {
+        for (size_t i = 0; i < init->value.dim; i++)
+            doCond(init->value[i]);
+    }
+    void visit(ExpInitializer *init)
+    {
+        doCond(init->exp);
+    }
+
+    void visit(Statement *s)
+    {
+    }
+    void visit(ExpStatement *s)
+    {
+        doCond(s->exp);
+    }
+    void visit(CompileStatement *s)
+    {
+    }
+    void visit(WhileStatement *s)
+    {
+        doCond(s->condition);
+    }
+    void visit(DoStatement *s)
+    {
+        doCond(s->condition);
+    }
+    void visit(ForStatement *s)
+    {
+        doCond(s->condition);
+        doCond(s->increment);
+    }
+    void visit(ForeachStatement *s)
+    {
+        doCond(s->aggr);
+    }
+    void visit(ForeachRangeStatement *s)
+    {
+        doCond(s->lwr);
+        doCond(s->upr);
+    }
+    void visit(IfStatement *s)
+    {
+        doCond(s->condition);
+    }
+    void visit(PragmaStatement *s)
+    {
+        for (size_t i = 0; i < s->args->dim; i++)
+            doCond((*s->args)[i]);
+    }
+    void visit(SwitchStatement *s)
+    {
+        doCond(s->condition);
+    }
+    void visit(CaseStatement *s)
+    {
+        doCond(s->exp);
+    }
+    void visit(CaseRangeStatement *s)
+    {
+        doCond(s->first);
+        doCond(s->last);
+    }
+    void visit(ReturnStatement *s)
+    {
+        doCond(s->exp);
+    }
+    void visit(SynchronizedStatement *s)
+    {
+        doCond(s->exp);
+    }
+    void visit(WithStatement *s)
+    {
+        doCond(s->exp);
+    }
+    void visit(ThrowStatement *s)
+    {
+        doCond(s->exp);
+    }
+
+    void visit(Expression *e)
+    {
+    }
+    void visit(DeclarationExp *e)
+    {
+        VarDeclaration *var = e->declaration->isVarDeclaration();
+        if (var)
+        {
+            doCond(var->init);
+        }
+    }
+    void visit(CallExp *e)
+    {
+        if (e->e1 && e->e1->op == TOKvar)
+        {
+            VarExp *ve = (VarExp*)e->e1;
+            if (ve->var && ve->var->isFuncDeclaration() && ve->var->isFuncDeclaration()->ident)
+            {
+                Identifier *ident = ve->var->isFuncDeclaration()->ident;
+
+                if (ident == Id::adDup)
+                {
+                    if (func->setGCUse(e->loc, "'dup' causes gc allocation"))
+                    {
+                        e->error("Can not use 'dup' in @nogc code");
+                    }
+                }
+            }
+        }
+    }
+    void visit(CatExp *e)
+    {
+        if (func->setGCUse(e->loc, "Concatenation may cause gc allocation"))
+            e->error("Can not use concatenation in @nogc code");
+    }
+    void visit(CatAssignExp *e)
+    {
+        if (func->setGCUse(e->loc, "Concatenation may cause gc allocation"))
+            e->error("Can not use concatenation in @nogc code");
+    }
+    void visit(AssignExp *e)
+    {
+        if (e->e1->op == TOKarraylength
+           && func->setGCUse(e->loc, "Setting 'length' may cause gc allocation"))
+        {
+            e->error("Can not set 'length' in @nogc code");
+        }
+    }
+    void visit(DeleteExp *e)
+    {
+        if (func->setGCUse(e->loc, "'delete' requires gc"))
+            e->error("Can not use 'delete' in @nogc code");
+    }
+    void visit(NewExp *e)
+    {
+        if (!e->allocator && !e->onstack && func->setGCUse(e->loc, "'new' causes gc allocation"))
+            e->error("Can not use 'new' in @nogc code");
+    }
+    void visit(NewAnonClassExp *e)
+    {
+        if (func->setGCUse(e->loc, "'new' causes gc allocation"))
+            e->error("Can not use 'new' in @nogc code");
+    }
+    void visit(AssocArrayLiteralExp *e)
+    {
+        if (e->keys->dim
+            && func->setGCUse(e->loc, "Associative array literals cause gc allocation"))
+        {
+            e->error("Can not use associative array literals in @nogc code");
+        }
+    }
+    void visit(ArrayLiteralExp *e)
+    {
+        bool init_const = false;
+        if (e->type->ty == Tarray)
+        {
+            init_const = true;
+            for (size_t i = 0; i < e->elements->dim; i++)
+            {
+                if (!((*e->elements)[i])->isConst())
+                {
+                    init_const = false;
+                    break;
+                }
+            }
+        }
+        if (e->elements && e->elements->dim != 0 && e->type->ty != Tsarray && !init_const &&
+            func->setGCUse(e->loc, "Array literals cause gc allocation"))
+        {
+                e->error("Can not use array literals in @nogc code");
+        }
+    }
+    void visit(IndexExp* e)
+    {
+        if (e->e1->type->ty == Taarray && func->setGCUse(e->loc, "Indexing an associative"
+            " array may cause gc allocation"))
+        {
+            e->error("Can not index an associative array in @nogc code");
+        }
+    }
+};
+
+void checkGC(FuncDeclaration *func, Statement *stmt)
+{
+    if (global.params.vgc)
+    {
+        NOGCVisitor gcv(func);
+        walkPostorder(stmt, &gcv);
+    }
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -61,7 +61,7 @@ DMD_OBJS = \
 	class.o \
 	constfold.o cond.o \
 	declaration.o dsymbol.o \
-	enum.o expression.o func.o \
+	enum.o expression.o func.o nogc.o \
 	id.o \
 	identifier.o impcnvtab.o import.o inifile.o init.o inline.o \
 	lexer.o link.o mangle.o mars.o module.o mtype.o \
@@ -118,7 +118,7 @@ SRC = win32.mak posix.mak osmodel.mak \
 	template.c lexer.c declaration.c cast.c cond.h cond.c link.c \
 	aggregate.h parse.c statement.c constfold.c version.h version.c \
 	inifile.c module.c scope.c init.h init.c attrib.h \
-	attrib.c opover.c class.c mangle.c func.c inline.c \
+	attrib.c opover.c class.c mangle.c func.c nogc.c inline.c \
 	access.c complex_t.h \
 	identifier.h parse.h \
 	scope.h enum.h import.h mars.h module.h mtype.h dsymbol.h \
@@ -440,6 +440,9 @@ filename.o : $(ROOT)/filename.c
 func.o: func.c
 	$(CC) -c $(CFLAGS) $<
 
+nogc.o: nogc.c
+	$(CC) -c $(CFLAGS) $<
+
 gdag.o: $C/gdag.c
 	$(CC) -c $(MFLAGS) $<
 
@@ -726,6 +729,7 @@ gcov:
 	gcov enum.c
 	gcov expression.c
 	gcov func.c
+	gcov nogc.c
 	gcov glue.c
 	gcov iasm.c
 	gcov identifier.c

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -132,7 +132,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT)
 FRONTOBJ= enum.obj struct.obj dsymbol.obj import.obj id.obj \
 	staticassert.obj identifier.obj mtype.obj expression.obj \
 	optimize.obj template.obj lexer.obj declaration.obj cast.obj \
-	init.obj func.obj utf.obj parse.obj statement.obj \
+	init.obj func.obj nogc.obj utf.obj parse.obj statement.obj \
 	constfold.obj version.obj inifile.obj cppmangle.obj \
 	module.obj scope.obj cond.obj inline.obj opover.obj \
 	entity.obj class.obj mangle.obj attrib.obj impcnvtab.obj \
@@ -179,7 +179,7 @@ SRCS= mars.c enum.c struct.c dsymbol.c import.c idgen.c impcnvgen.c utf.h \
 	cond.h cond.c link.c aggregate.h staticassert.h parse.c statement.c \
 	constfold.c version.h version.c inifile.c staticassert.c \
 	module.c scope.c init.h init.c attrib.h attrib.c opover.c \
-	class.c mangle.c func.c inline.c access.c complex_t.h cppmangle.c \
+	class.c mangle.c func.c nogc.c inline.c access.c complex_t.h cppmangle.c \
 	identifier.h parse.h scope.h enum.h import.h \
 	mars.h module.h mtype.h dsymbol.h \
 	declaration.h lexer.h expression.h statement.h doc.h doc.c \

--- a/test/compilable/nogc.d
+++ b/test/compilable/nogc.d
@@ -1,0 +1,97 @@
+// REQUIRED_ARGS: -vgc
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+// Tests special cases which do not allocate and shouldn't error
+// Statically typed dynamic array literals
+int[4] arr = [1,2,3,4];
+
+int testSArray()
+{
+    int[4] arr = [1,2,3,4];
+    auto x = cast(int[4])[1,2,3,4];
+    return [1, 2, 3][1];
+}
+
+enum int[] enumliteral = [1,2,3,4];
+
+void testArrayLiteral()
+{
+    void helper(int[] a){}
+    int[] allocate2 = [1,2,4];
+    int[] e = enumliteral;
+    helper([1,2,3]);
+}
+
+// String literal concatenation
+immutable s1 = "test" ~ "string";
+enum s2 = "test" ~ "string";
+
+void testLiteral()
+{
+    string s3 = "test" ~ "string";
+}
+
+//Appending to user defined type is OK
+void testAppend()
+{
+    struct App
+    {
+        ref App opOpAssign(string op)(in string s)
+        {
+            return this;
+        }
+        App opBinary(string op)(in string s) const
+        {
+            return this;
+        }
+    }
+
+    App a;
+    a ~= "test";
+    auto b = a ~ "test";
+}
+
+// mixins
+mixin(int.stringof ~ " mixInt;");
+
+// CTFE
+enum ctfe1 = "test".dup ~ "abcd";
+
+/*
+ * Can't test this with -nogc, as -nogc marks the delegate as @nogc (as it should):
+ * ------
+ * enum n = () { auto a = [1,2,3]; return a[0] + a[1] + a[2]; }();
+ * ------
+ * Correct test:
+ * ------
+ * @nogc void func()
+ * {
+ *     enum n = () { auto a = [1,2,3]; return a[0] + a[1] + a[2]; }();
+ * }
+ * ------
+ */
+
+// Reading .length is OK
+void testLength()
+{
+    int[] arr;
+    auto x = arr.length;
+}
+
+// scope prevents closure allocation
+void closureHelper1(scope void delegate() d) {}
+void testClosure()
+{
+    int a;
+
+    void del1()
+    {
+        a++;
+    }
+
+    closureHelper1(&del1);
+}

--- a/test/compilable/nogc_warn.d
+++ b/test/compilable/nogc_warn.d
@@ -1,0 +1,121 @@
+/*
+REQUIRED_ARGS: -vgc
+TEST_OUTPUT:
+---
+compilable/nogc_warn.d(34): vgc: 'new' causes gc allocation
+compilable/nogc_warn.d(35): vgc: 'new' causes gc allocation
+compilable/nogc_warn.d(36): vgc: 'new' causes gc allocation
+compilable/nogc_warn.d(37): vgc: 'new' causes gc allocation
+compilable/nogc_warn.d(42): vgc: 'delete' requires gc
+compilable/nogc_warn.d(47): vgc: 'delete' requires gc
+compilable/nogc_warn.d(52): vgc: 'delete' requires gc
+compilable/nogc_warn.d(59): vgc: Associative array literals cause gc allocation
+compilable/nogc_warn.d(60): vgc: Associative array literals cause gc allocation
+compilable/nogc_warn.d(66): vgc: Setting 'length' may cause gc allocation
+compilable/nogc_warn.d(69): vgc: Setting 'length' may cause gc allocation
+compilable/nogc_warn.d(70): vgc: Setting 'length' may cause gc allocation
+compilable/nogc_warn.d(75): vgc: Concatenation may cause gc allocation
+compilable/nogc_warn.d(76): vgc: Concatenation may cause gc allocation
+compilable/nogc_warn.d(79): vgc: Concatenation may cause gc allocation
+compilable/nogc_warn.d(80): vgc: Concatenation may cause gc allocation
+compilable/nogc_warn.d(85): vgc: Using closure causes gc allocation
+compilable/nogc_warn.d(100): vgc: 'dup' causes gc allocation
+compilable/nogc_warn.d(101): vgc: 'dup' causes gc allocation
+compilable/nogc_warn.d(107): vgc: 'dup' causes gc allocation
+compilable/nogc_warn.d(108): vgc: 'dup' causes gc allocation
+compilable/nogc_warn.d-mixin-114(114): vgc: 'new' causes gc allocation
+compilable/nogc_warn.d(120): vgc: Indexing an associative array may cause gc allocation
+---
+*/
+
+struct Struct {}
+void testNew()
+{
+    auto obj = new Object();
+    auto s = new Struct();
+    auto s2 = new Struct[5];
+    auto i = new int[3];
+}
+
+void testDelete(Struct* instance)
+{
+    delete instance;
+}
+
+void testDelete(void* instance)
+{
+    delete instance;
+}
+
+void testDelete(Object instance)
+{
+    delete instance;
+}
+
+enum aaLiteral = ["test" : 0];
+void testAA()
+{
+    int[string] aa;
+    aa = ["test" : 0];
+    aa = aaLiteral;
+}
+
+void testLength()
+{
+    string s;
+    s.length = 100;
+
+    int[] arr;
+    arr.length += 1;
+    arr.length -= 1;
+}
+
+void testConcat(string sin)
+{
+    sin ~= "test";
+    string s2 = sin ~ "test";
+
+    int[] arr;
+    arr ~= 1;
+    arr ~= arr;
+}
+
+void closureHelper2(void delegate() d) {}
+
+void testClosure2()
+{
+    int a;
+
+    void del1()
+    {
+        a++;
+    }
+
+    closureHelper2(&del1);
+}
+
+void testIdup()
+{
+    int[] x;
+    auto x2 = x.idup;
+    auto s2 = "test".idup;
+}
+
+void testDup()
+{
+    int[] x;
+    auto x2 = x.dup;
+    auto s2 = "test".dup;
+}
+
+// mixins
+void testMixin()
+{
+    mixin("auto a = new " ~ int.stringof ~ " ();");
+}
+
+void testAAIndex()
+{
+    int[string] aa;
+    aa["test"] = 0;
+}


### PR DESCRIPTION
This pull request adds the foundation for `nogc` related functionality.
It implements the basics to track if a function uses the GC in exactly the same way as `@safe/@trusted/@system`.
On top of that it adds
- a `-vgc` switch which will print all implicit gc allocations, similar to `-vtls`
- a `-nogc` switch which will make all implicit GC accesses in the current module an error

It currently does not help if functions like `GC.malloc` or other functions which allocate are called. In order to detect this a `@nogc` attribute is needed. This pull requests implements the basics for `@nogc` including inference in templated methods, but it does not implement the `@nogc` attribute in the parser. I'll leave that for another pull request.

The following known allocations are intentionally not handled:
- AssertExp
- CmpExp
- AssignExp: Calls _d_arrayassign
- Hidden function errors: Are already deprecated
- SwitchErrorStatement

All these cases only allocate by throwing exceptions
and disallowing them would impact user code a lot. In
order to really solve such issues we need some way to
throw exceptions without GC-allocation.

Also not handled are indirect calls to user-defined
functions which may allocate (calling postblits in
array assignment for example). As this commit does
not provide a way to mark a function as @nogc there's
no way to know if such functions actually allocate.

These indirect calls to user defined functions must
be revisited when a @nogc attribute is introduced.
