### PR TITLE
For integer comparisons, ensure the signed-unsigned comparison is safe.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -12218,11 +12218,6 @@ CmpExp::CmpExp(enum TOK op, Loc loc, Expression *e1, Expression *e2)
 {
 }
 
-bool isdisjoint(const IntRange& r1, const IntRange& r2)
-{
-    return r1.imax < r2.imin || r1.imin > r2.imax;
-}
-
 Expression *CmpExp::semantic(Scope *sc)
 {   Expression *e;
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -12270,7 +12270,7 @@ Expression *CmpExp::semantic(Scope *sc)
     if (e->op == TOKerror)
         return e;
 
-    // For integer comparisons, ensure the signed-unsigned comparison is safe.
+    // For integer comparisons, ensure the signed-unsigned comparison is safe. (bug 259)
     if ((op == TOKlt || op == TOKle || op == TOKgt || op == TOKge) &&
         type && type->isintegral() && t1->isunsigned() != t2->isunsigned())
     {
@@ -12300,9 +12300,9 @@ Expression *CmpExp::semantic(Scope *sc)
         else
         {
             // Otherwise, the comparison is in error.
-            error("implicit conversion of '%s' to '%s' is unsafe in '(%s) %s (%s)'",
+            // Issue a deprecation warning, since an error causes template instantiations to fail silently.
+            deprecation("implicit conversion of '%s' to '%s' is unsafe in '(%s) %s (%s)'",
                 a->toChars(), type->toChars(), eb1->toChars(), Token::toChars(op), eb2->toChars());
-            return new ErrorExp();
         }
     }
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -270,8 +270,17 @@ void vdeprecation(Loc loc, const char *format, va_list ap,
                 const char *p1, const char *p2)
 {
     static const char *header = "Deprecation: ";
+    // 0: don't allow use of deprecated features
+    // 1: silently allow use of deprecated features
+    // 2: warn about the use of deprecated features
     if (global.params.useDeprecated == 0)
+    {
         verror(loc, format, ap, p1, p2, header);
+        // The error will cause a template instantiation to fail,
+        // but it wouldn't get printed by verror() when gagged (bug 9960)
+        if (global.gag)
+            verrorPrint(loc, header, format, ap, p1, p2);
+    }
     else if (global.params.useDeprecated == 2 && !global.gag)
         verrorPrint(loc, header, format, ap, p1, p2);
 }


### PR DESCRIPTION
1. If the sizeof(signed type) > sizeof(unsigned type), cast to unsigned to signed
2. If min(signed value) >= 0, cast signed to unsigned
   else the comparison is in error.
