### PR TITLE
CTFE: Allow to reinterpret cast from numeric array or string to ubyte[] or byte[]

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -276,7 +276,7 @@ Expression *Expression::ctfeInterpret()
 
 /*************************************/
 
-bool isFloating(Type* t)
+bool isfloating(Type* t)
 {
     switch(t->ty)
     {
@@ -295,7 +295,7 @@ bool isFloating(Type* t)
 }
 
 //We can not ot cast real* to int* because real can contains not a integer count of int (if real.sizeof == 10)
-bool isByteOrShort(Type* t)
+bool isbyteorshort(Type* t)
 {
     switch(t->ty)
     {
@@ -2533,7 +2533,7 @@ bool isIndexFloatPtrCast(Expression *e, InterState *istate, Expression **floatex
     if (e->op != TOKindex) return false;
     IndexExp* ie = (IndexExp*)e;
     //printf("%s: %d\n", ie->toChars(), ie->e1->op == TOKcast && ie->e1->type->ty == Tpointer);
-    if (ie->e1->op == TOKcast && ie->e1->type->ty == Tpointer && isByteOrShort(ie->e1->type->nextOf()) && (((CastExp*)ie->e1)->e1->op == TOKsymoff))
+    if (ie->e1->op == TOKcast && ie->e1->type->ty == Tpointer && isbyteorshort(ie->e1->type->nextOf()) && (((CastExp*)ie->e1)->e1->op == TOKsymoff))
     {
         Expression *eidx = ie->e2->interpret(istate);
         if (exceptionOrCantInterpret(eidx))
@@ -2560,7 +2560,7 @@ union Caster
 //Try to evaluate (cast(to)cast(void*)from)[idx]
 Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx, Expression* assignval)
 {
-    if (!isFloating(from->type)) return NULL;
+    if (!isfloating(from->type)) return NULL;
     d_uns64 sz = to->size();
     if (sz*idx >= from->type->size())
     {
@@ -2575,18 +2575,18 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
         {
             Caster<d_float32> cc;
             cc.val = ((RealExp*)from)->value;
-            Target::toTargetByteOrder(&cc.val, sizeof(cc.val));
+            Target::toTargetFloatBO(&cc.val, sizeof(cc.val));
             d_uns64 ival = -1;
             if (sz == 2)
             {
                 if (assignval)
                 {
                     d_uns16 aval = assignval->toInteger();
-                    Target::toTargetByteOrder(&aval, sizeof(aval));
+                    Target::toTargetWordBO(&aval, sizeof(aval));
                     ((d_uns16*)&cc.bytes)[idx] = aval;
                 }
                 ival = ((d_uns16*)&cc.bytes)[idx];
-                Target::toTargetByteOrder(&ival, sizeof(sz));
+                Target::toTargetWordBO(&ival, sizeof(sz));
             }
             else if (sz == 1)
             {
@@ -2603,7 +2603,7 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             
             if (assignval)
             {
-                Target::toTargetByteOrder(&cc.val, sizeof(cc.val));
+                Target::toTargetFloatBO(&cc.val, sizeof(cc.val));
                 ((RealExp*)from)->value = cc.val;
             }
             return new IntegerExp(from->loc, ival, to);
@@ -2613,18 +2613,18 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
         {
             Caster<d_float64> cc;
             cc.val = ((RealExp*)from)->value;
-            Target::toTargetByteOrder(&cc.val, sizeof(cc.val));
+            Target::toTargetFloatBO(&cc.val, sizeof(cc.val));
             d_uns64 ival = -1;
             if (sz == 2)
             {
                 if (assignval)
                 {
                     d_uns16 aval = assignval->toInteger();
-                    Target::toTargetByteOrder(&aval, sizeof(aval));
+                    Target::toTargetWordBO(&aval, sizeof(aval));
                     ((d_uns16*)&cc.bytes)[idx] = aval;
                 }
                 ival = ((d_uns16*)&cc.bytes)[idx];
-                Target::toTargetByteOrder(&ival, sizeof(sz));
+                Target::toTargetWordBO(&ival, sizeof(sz));
             }
             else if (sz == 1)
             {
@@ -2641,7 +2641,7 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             
             if (assignval)
             {
-                Target::toTargetByteOrder(&cc.val, sizeof(cc.val));
+                Target::toTargetFloatBO(&cc.val, sizeof(cc.val));
                 ((RealExp*)from)->value = cc.val;
             }
             return new IntegerExp(from->loc, ival, to);
@@ -2651,7 +2651,7 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
         {
             Caster<d_float80> cc;
             cc.val = ((RealExp*)from)->value;
-            Target::toTargetByteOrder(&cc.val, Target::realsize-Target::realpad);
+            Target::toTargetFloatBO(&cc.val, Target::realsize-Target::realpad);
             assert(!((Target::realsize-Target::realpad)%2)); //realsize is an even number
             d_uns64 ival = -1;
             if (sz*idx >= (Target::realsize-Target::realpad))
@@ -2668,11 +2668,11 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
                 if (assignval)
                 {
                     d_uns16 aval = assignval->toInteger();
-                    Target::toTargetByteOrder(&aval, sizeof(aval));
+                    Target::toTargetWordBO(&aval, sizeof(aval));
                     ((d_uns16*)&cc.bytes)[idx] = aval;
                 }
                 ival = ((d_uns16*)&cc.bytes)[idx];
-                Target::toTargetByteOrder(&ival, sizeof(sz));
+                Target::toTargetWordBO(&ival, sizeof(sz));
             }
             else if (sz == 1)
             {
@@ -2689,7 +2689,7 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             
             if (assignval)
             {
-                Target::toTargetByteOrder(&cc.val, Target::realsize-Target::realpad);
+                Target::toTargetFloatBO(&cc.val, Target::realsize-Target::realpad);
                 ((RealExp*)from)->value = cc.val;
             }
             return new IntegerExp(from->loc, ival, to);
@@ -2708,18 +2708,18 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             {
                 cc.val = creall(((ComplexExp*)from)->value);
             }
-            Target::toTargetByteOrder(&cc.val, sizeof(cc.val));
+            Target::toTargetFloatBO(&cc.val, sizeof(cc.val));
             d_uns64 ival = -1;
             if (sz == 2)
             {
                 if (assignval)
                 {
                     d_uns16 aval = assignval->toInteger();
-                    Target::toTargetByteOrder(&aval, sizeof(aval));
+                    Target::toTargetWordBO(&aval, sizeof(aval));
                     ((d_uns16*)&cc.bytes)[idx] = aval;
                 }
                 ival = ((d_uns16*)&cc.bytes)[idx];
-                Target::toTargetByteOrder(&ival, sizeof(sz));
+                Target::toTargetWordBO(&ival, sizeof(sz));
             }
             else if (sz == 1)
             {
@@ -2736,7 +2736,7 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             
             if (assignval)
             {
-                Target::toTargetByteOrder(&cc.val, sizeof(cc.val));
+                Target::toTargetFloatBO(&cc.val, sizeof(cc.val));
                 if (accessim)
                 {
                     ((real_t *)&((ComplexExp*)from)->value)[1] = cc.val; 
@@ -2763,18 +2763,18 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             {
                 cc.val = creall(((ComplexExp*)from)->value);
             }
-            Target::toTargetByteOrder(&cc.val, sizeof(cc.val));
+            Target::toTargetFloatBO(&cc.val, sizeof(cc.val));
             d_uns64 ival = -1;
             if (sz == 2)
             {
                 if (assignval)
                 {
                     d_uns16 aval = assignval->toInteger();
-                    Target::toTargetByteOrder(&aval, sizeof(aval));
+                    Target::toTargetWordBO(&aval, sizeof(aval));
                     ((d_uns16*)&cc.bytes)[idx] = aval;
                 }
                 ival = ((d_uns16*)&cc.bytes)[idx];
-                Target::toTargetByteOrder(&ival, sizeof(sz));
+                Target::toTargetWordBO(&ival, sizeof(sz));
             }
             else if (sz == 1)
             {
@@ -2791,7 +2791,7 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             
             if (assignval)
             {
-                Target::toTargetByteOrder(&cc.val, sizeof(cc.val));
+                Target::toTargetFloatBO(&cc.val, sizeof(cc.val));
                 if (accessim)
                 {
                     ((real_t *)&((ComplexExp*)from)->value)[1] = cc.val; 
@@ -2818,7 +2818,7 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             {
                 cc.val = creall(((ComplexExp*)from)->value);
             }
-            Target::toTargetByteOrder(&cc.val, Target::realsize-Target::realpad);
+            Target::toTargetFloatBO(&cc.val, Target::realsize-Target::realpad);
             assert(!((Target::realsize-Target::realpad)%2)); //realsize is an even number
             d_uns64 ival = -1;
             if (sz*idx >= (Target::realsize-Target::realpad))
@@ -2835,11 +2835,11 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
                 if (assignval)
                 {
                     d_uns16 aval = assignval->toInteger();
-                    Target::toTargetByteOrder(&aval, sizeof(aval));
+                    Target::toTargetWordBO(&aval, sizeof(aval));
                     ((d_uns16*)&cc.bytes)[idx] = aval;
                 }
                 ival = ((d_uns16*)&cc.bytes)[idx];
-                Target::toTargetByteOrder(&ival, sizeof(sz));
+                Target::toTargetWordBO(&ival, sizeof(sz));
             }
             else if (sz == 1)
             {
@@ -2856,7 +2856,7 @@ Expression *tryReinterpretPointerCast(Expression *from, Type* to, sinteger_t idx
             
             if (assignval)
             {
-                Target::toTargetByteOrder(&cc.val, Target::realsize-Target::realpad);
+                Target::toTargetFloatBO(&cc.val, Target::realsize-Target::realpad);
                 if (accessim)
                 {
                     ((real_t *)&((ComplexExp*)from)->value)[1] = cc.val; 

--- a/src/target.c
+++ b/src/target.c
@@ -38,7 +38,7 @@ bool hostWordsBigEndian()
 bool hostFloatBigEndian()
 {
     const float probe = 1;
-    return !!(*cast(ubyte*)&probe);
+    return !!(*(unsigned char*)&probe);
 }
 
 

--- a/src/target.c
+++ b/src/target.c
@@ -17,6 +17,16 @@ int Target::ptrsize;
 int Target::realsize;
 int Target::realpad;
 int Target::realalignsize;
+Target::ByteOrder Target::byteorder;
+
+Target::ByteOrder currentByteOrder()
+{
+    const int probe = 0xff;
+    return (Target::ByteOrder)(*(unsigned char*)&probe);
+}
+
+
+
 
 
 void Target::init()
@@ -57,6 +67,8 @@ void Target::init()
             realalignsize = 16;
         }
     }
+    
+    byteorder = currentByteOrder();
 }
 
 unsigned Target::alignsize (Type* type)
@@ -90,5 +102,19 @@ unsigned Target::alignsize (Type* type)
             break;
     }
     return type->size(0);
+}
+
+void Target::toTargetByteOrder (void *p, unsigned size)
+{
+    if(byteorder != currentByteOrder())
+    {
+        char* c = (char*)p;
+        for(unsigned i=0; i<size/2; ++i)
+        {
+            char tmp = c[i];
+            c[i] = c[size - 1 - i];
+            c[size - 1 - i] = c[i];
+        }
+    }
 }
 

--- a/src/target.c
+++ b/src/target.c
@@ -82,9 +82,9 @@ void Target::init()
         }
     }
     
-    bytesbigendian = hostBytesBigEndian();
-    wordsbigendian = hostWordsBigEndian();
-    floatbigendian = hostFloatBigEndian();
+    bytesbigendian = false;
+    wordsbigendian = false;
+    floatbigendian = false;
 }
 
 unsigned Target::alignsize (Type* type)

--- a/src/target.h
+++ b/src/target.h
@@ -23,8 +23,16 @@ struct Target
     static int realpad;         // 'padding' added to the CPU real size to bring it up to realsize
     static int realalignsize;   // alignment for reals
     
+    enum ByteOrder
+    {
+        BigEndian    = 0x00,
+        LittleEndian = 0xff
+    };
+    static ByteOrder byteorder;   // byte order
+    
     static void init();
     static unsigned alignsize(Type* type);
+    static void toTargetByteOrder (void *p, unsigned size);
 };
 
 #endif

--- a/src/target.h
+++ b/src/target.h
@@ -23,16 +23,14 @@ struct Target
     static int realpad;         // 'padding' added to the CPU real size to bring it up to realsize
     static int realalignsize;   // alignment for reals
     
-    enum ByteOrder
-    {
-        BigEndian    = 0x00,
-        LittleEndian = 0xff
-    };
-    static ByteOrder byteorder;   // byte order
+    static bool bytesbigendian;   // bytes order in word
+    static bool wordsbigendian;   // words order in multi-word object
+    static bool floatbigendian;   // bytes order in floating point types
     
     static void init();
     static unsigned alignsize(Type* type);
-    static void toTargetByteOrder (void *p, unsigned size);
+    static void toTargetFloatBO (void *p, unsigned size);
+    static void toTargetWordBO (void *p, unsigned size);
 };
 
 #endif

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3083,6 +3083,108 @@ void test9954()
 
 /************************************************/
 
+enum t111exp1 = 32.0f;
+enum t111exp2 = 32.0;
+enum t111exp3 = 15.0L;
+enum t111exp4 = 1f+999fi;
+enum t111exp5 = 1+999i;
+enum t111exp6 = 1L+999Li;
+
+T pCast(T, T2)(T2 val, size_t idx)
+{
+    return (cast(T*)&val)[idx];
+}
+
+T2 pCastAssign(T, T2)(T2 val, size_t idx, T aval)
+{
+    auto ret = ((cast(T*)&val)[idx] = aval);
+    assert(cast(short)ret == cast(short)aval);
+    return val;
+}
+
+auto t111e1 = pCast!short(t111exp1, 1);
+auto t111e2 = pCast!short(t111exp2, 2);
+auto t111e3 = pCast!short(t111exp3, 2);
+auto t111e4 = pCast!short(t111exp4, 1);
+auto t111e5 = pCast!short(t111exp5, 2);
+auto t111e6 = pCast!short(t111exp6, 2);
+auto t111e7 = pCast!short(t111exp4, 3);
+auto t111e8 = pCast!short(t111exp5, 7);
+auto t111e9 = pCast!short(t111exp6, 9);
+
+auto t111e11 = pCast!byte(t111exp1, 1);
+auto t111e12 = pCast!byte(t111exp2, 2);
+auto t111e13 = pCast!byte(t111exp3, 2);
+auto t111e14 = pCast!byte(t111exp4, 1);
+auto t111e15 = pCast!byte(t111exp5, 2);
+auto t111e16 = pCast!byte(t111exp6, 2);
+auto t111e17 = pCast!byte(t111exp4, 3);
+auto t111e18 = pCast!byte(t111exp5, 14);
+auto t111e19 = pCast!byte(t111exp6, 16);
+static if(t111exp3.sizeof > 10) static assert(!pCast!byte(t111exp3, 11));
+
+auto t111ae1  = pCastAssign!short(t111exp1, 0, -1);
+auto t111ae2  = pCastAssign!short(t111exp2, 2, -1);
+auto t111ae3  = pCastAssign!short(t111exp3, 2, -1);
+auto t111ae4  = pCastAssign!short(t111exp4, 0, -1);
+auto t111ae5  = pCastAssign!short(t111exp5, 2, -1);
+auto t111ae6  = pCastAssign!short(t111exp6, 2, -1);
+auto t111ae7  = pCastAssign!short(t111exp4, 2, -1);
+auto t111ae8  = pCastAssign!short(t111exp5, 6, -1);
+auto t111ae9  = pCastAssign!short(t111exp6, 9, -1);
+auto t111ae11 = pCastAssign!byte(t111exp1,  1, -1);
+auto t111ae12 = pCastAssign!byte(t111exp2,  2, -1);
+auto t111ae13 = pCastAssign!byte(t111exp3,  2, -1);
+auto t111ae14 = pCastAssign!byte(t111exp4,  1, -1);
+auto t111ae15 = pCastAssign!byte(t111exp5,  2, -1);
+auto t111ae16 = pCastAssign!byte(t111exp6,  2, -1);
+auto t111ae17 = pCastAssign!byte(t111exp4,  3, -1);
+auto t111ae18 = pCastAssign!byte(t111exp5, 14, -1);
+auto t111ae19 = pCastAssign!byte(t111exp6, 16, -1);
+
+void test111()
+{
+    assert(t111e1 is pCast!short(t111exp1, 1));
+    assert(t111e2 is pCast!short(t111exp2, 2));
+    assert(t111e3 is pCast!short(t111exp3, 2));
+    assert(t111e4 is pCast!short(t111exp4, 1));
+    assert(t111e5 is pCast!short(t111exp5, 2));
+    assert(t111e6 is pCast!short(t111exp6, 2));
+    assert(t111e7 is pCast!short(t111exp4, 3));
+    assert(t111e8 is pCast!short(t111exp5, 7));
+    assert(t111e9 is pCast!short(t111exp6, 9));
+    assert(t111e11 is pCast!byte(t111exp1, 1));
+    assert(t111e12 is pCast!byte(t111exp2, 2));
+    assert(t111e13 is pCast!byte(t111exp3, 2));
+    assert(t111e14 is pCast!byte(t111exp4, 1));
+    assert(t111e15 is pCast!byte(t111exp5, 2));
+    assert(t111e16 is pCast!byte(t111exp6, 2));
+    assert(t111e17 is pCast!byte(t111exp4, 3));
+    assert(t111e18 is pCast!byte(t111exp5, 14));
+    assert(t111e19 is pCast!byte(t111exp6, 16));   
+    
+    assert(t111ae1  is pCastAssign!short(t111exp1, 0, -1));
+    assert(t111ae2  is pCastAssign!short(t111exp2, 2, -1));
+    assert(t111ae3  is pCastAssign!short(t111exp3, 2, -1));
+    assert(t111ae4  is pCastAssign!short(t111exp4, 0, -1));
+    assert(t111ae5  is pCastAssign!short(t111exp5, 2, -1));
+    assert(t111ae6  is pCastAssign!short(t111exp6, 2, -1));
+    assert(t111ae7  is pCastAssign!short(t111exp4, 2, -1));
+    assert(t111ae8  is pCastAssign!short(t111exp5, 6, -1));
+    assert(t111ae9  is pCastAssign!short(t111exp6, 9, -1));
+    assert(t111ae11 is pCastAssign!byte(t111exp1,  1, -1));
+    assert(t111ae12 is pCastAssign!byte(t111exp2,  2, -1));
+    assert(t111ae13 is pCastAssign!byte(t111exp3,  2, -1));
+    assert(t111ae14 is pCastAssign!byte(t111exp4,  1, -1));
+    assert(t111ae15 is pCastAssign!byte(t111exp5,  2, -1));
+    assert(t111ae16 is pCastAssign!byte(t111exp6,  2, -1));
+    assert(t111ae17 is pCastAssign!byte(t111exp4,  3, -1));
+    assert(t111ae18 is pCastAssign!byte(t111exp5, 14, -1));
+    assert(t111ae19 is pCastAssign!byte(t111exp6, 16, -1)); 
+}
+
+/************************************************/
+
 TypeInfo getTi()
 {
     return typeid(int);
@@ -3207,6 +3309,7 @@ int main()
     test107();
     //test108(); 
     test109();
+    test111();
     test112();
     test6504();
     test8818();


### PR DESCRIPTION
Purpose: compile-time hash calculating and other useful things.
