### PR TITLE
Implement DIP36 - 'scope ref' and 'in ref' for proper rvalue reference

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -991,7 +991,7 @@ void VarDeclaration::semantic(Scope *sc)
         }
     }
     if ((storage_class & STCauto) && !inferred)
-       error("storage class 'auto' has no effect if type is not inferred, did you mean 'scope'?");
+        error("storage class 'auto' has no effect if type is not inferred, did you mean 'scope'?");
 
     if (tb->ty == Ttuple)
     {

--- a/src/func.c
+++ b/src/func.c
@@ -3063,7 +3063,13 @@ MATCH FuncDeclaration::leastAsSpecialized(FuncDeclaration *g)
     {
         Parameter *p = Parameter::getNth(tf->parameters, u);
         Expression *e;
-        if (p->storageClass & (STCref | STCout))
+        if ((p->storageClass & STCref) && (p->storageClass & (STCscope | STCin)))
+        {
+            //     'ref' is more specialized than 'scope ref'
+            // non-'ref' is more specialized than 'scope ref'
+            e = p->type->defaultInitLiteral(Loc());
+        }
+        else if (p->storageClass & (STCref | STCout))
         {
             e = new IdentifierExp(Loc(), p->ident);
             e->type = p->type;

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -2861,13 +2861,15 @@ public:
     {
         if (p->storageClass & STCauto)
             buf->writestring("auto ");
+        else if (p->storageClass & STCin)
+            buf->writestring("in ");
+        else if (p->storageClass & STCscope)
+            buf->writestring("scope ");
 
         if (p->storageClass & STCout)
             buf->writestring("out ");
         else if (p->storageClass & STCref)
             buf->writestring("ref ");
-        else if (p->storageClass & STCin)
-            buf->writestring("in ");
         else if (p->storageClass & STClazy)
             buf->writestring("lazy ");
         else if (p->storageClass & STCalias)
@@ -2878,7 +2880,7 @@ public:
             stc &= ~STCshared;
 
         StorageClassDeclaration::stcToCBuffer(buf,
-            stc & (STCconst | STCimmutable | STCwild | STCshared | STCscope));
+            stc & (STCconst | STCimmutable | STCwild | STCshared));
 
         if (p->storageClass & STCalias)
         {
@@ -2891,6 +2893,11 @@ public:
         {
             // print parameter name, instead of undetermined type parameter
             buf->writestring(p->ident->toChars());
+        }
+        else if ((p->storageClass & STCref) &&
+                 (p->storageClass & (STCin | STCscope)))
+        {
+            typeToBuffer(p->type->mutableOf(), p->ident);
         }
         else
             typeToBuffer(p->type, p->ident);

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -854,6 +854,10 @@ public:
             case STClazy:
                 buf->writeByte('L');
                 break;
+            case STCin | STCref:
+                buf->writeByte('M');    // scope
+                buf->writeByte('K');    // ref
+                break;
             default:
     #ifdef DEBUG
                 printf("storageClass = x%llx\n", p->storageClass & (STCin | STCout | STCref | STClazy));

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5571,7 +5571,10 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
             }
 
             // Remove redundant storage classes for type, they are already applied
-            fparam->storageClass &= ~(STC_TYPECTOR | STCin);
+            if ((fparam->storageClass & (STCin | STCref)) == (STCin | STCref))
+                fparam->storageClass &= ~(STC_TYPECTOR);        // keep STCin
+            else
+                fparam->storageClass &= ~(STC_TYPECTOR | STCin);
         }
         argsc->pop();
     }
@@ -5849,6 +5852,8 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
                         targb = tn->sarrayOf(dim);
                     }
                 }
+                else if (p->storageClass & (STCin | STCscope))
+                    m = MATCHconvert;
                 else
                     goto Nomatch;
             }

--- a/src/parse.c
+++ b/src/parse.c
@@ -1829,13 +1829,14 @@ Parameters *Parser::parseParameters(int *pvarargs, TemplateParameters **tpl)
 
                 default:
                 Ldefault:
-                {   stc = storageClass & (STCin | STCout | STCref | STClazy);
+                {
+                    stc = storageClass & (STCin | STCout | STCref | STClazy);
                     // if stc is not a power of 2
                     if (stc & (stc - 1) &&
                         !(stc == (STCin | STCref)))
                         error("incompatible parameter storage classes");
-                    if ((storageClass & STCscope) && (storageClass & (STCref | STCout)))
-                        error("scope cannot be ref or out");
+                    if ((storageClass & STCscope) && (storageClass & STCout))
+                        error("scope cannot be out");
 
                     Token *t;
                     if (tpl && token.value == TOKidentifier &&

--- a/src/template.c
+++ b/src/template.c
@@ -1595,6 +1595,8 @@ Lretry:
                     {
                         // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
                     }
+                    else if (fparam->storageClass & (STCin | STCscope))
+                        m = MATCHconvert;
                     else
                         goto Lnomatch;
                 }

--- a/test/fail_compilation/fail191.d
+++ b/test/fail_compilation/fail191.d
@@ -1,8 +1,0 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail191.d(8): Error: scope cannot be ref or out
----
-*/
-
-void foo(scope ref int x) { }

--- a/test/runnable/scoperef.d
+++ b/test/runnable/scoperef.d
@@ -1,0 +1,108 @@
+extern(C) int printf(const char*, ...);
+
+/******************************************/
+
+bool test1()
+{
+    struct S
+    {
+    static:
+        // Wrap functions in inner struct to make function overloads
+
+        auto foo   (scope ref S s) { return 1; }
+        auto hoo(T)(scope ref T s) { return 1; }
+
+        auto bar   (scope ref S s) { return 1; }
+        auto bar   (          S s) { return 3; }
+        auto var(T)(scope ref T s) { return 1; }
+        auto var(T)(          T s) { return 3; }
+
+        auto baw   (scope ref S s) { return 1; }
+        auto baw   (      ref S s) { return 2; }
+        auto vaw(T)(scope ref T s) { return 1; }
+        auto vaw(T)(      ref T s) { return 2; }
+
+        auto bay   (scope ref S s) { return 1; }
+        auto bay   (      ref S s) { return 2; }
+        auto bay   (          S s) { return 3; }
+        auto vay(T)(scope ref T s) { return 1; }
+        auto vay(T)(      ref T s) { return 2; }
+        auto vay(T)(          T s) { return 3; }
+    }
+
+    S s;
+
+    // 'scope ref' can bind both lvalue and rvalue
+    S.foo(s  );
+    S.foo(S());
+    // 'scope ref' and template function also can do.
+    S.hoo(s  );
+    S.hoo(S());
+    // 'scope ref' does not depends on IFTI
+    alias S.hoo!S Hoo;
+    Hoo(s  );
+    Hoo(S());
+
+    // overload resolution between 'scope ref' and non-ref
+    // 'scope ref' is always lesser matching.
+    assert(S.bar(s  ) == 1);
+    assert(S.bar(S()) == 3);
+    assert(S.var(s  ) == 1);
+    assert(S.var(S()) == 3);
+
+    // overload resolution between 'scope ref' and 'ref'
+    // 'scope ref' is always lesser matching.
+    assert(S.baw(s  ) == 2);
+    assert(S.baw(S()) == 1);
+    assert(S.vaw(s  ) == 2);
+    assert(S.vaw(S()) == 1);
+
+    // overload resolution between 'scope ref', 'ref', and non-ref
+    // 'scope ref' is always lesser matching, then *never matches anything*.
+    assert(S.bay(s  ) == 2);
+    assert(S.bay(S()) == 3);
+    assert(S.vay(s  ) == 2);
+    assert(S.vay(S()) == 3);
+
+    // keep right behavior: rvalues never matches to 'ref'
+    struct S1 { int n; }
+    struct S2 { this(int n){} }
+    void baz(ref S1 s) {}
+    void vaz(ref S2 s) {}
+    static assert(!__traits(compiles, baz(S1(1)) ));
+    static assert(!__traits(compiles, vaz(S2(1)) ));
+
+    return true;
+}
+static assert(test1());     // CTFE
+
+/******************************************/
+
+void test2()
+{
+    static void foo(scope ref int x) { static assert(is(typeof(x) == int)); }
+    static void bar(   in ref int x) { static assert(is(typeof(x) == const int)); }
+
+    static assert(typeof(foo).stringof == "void(scope ref int x)");
+    static assert(typeof(bar).stringof == "void(in ref int x)");
+    static assert(typeof(foo).mangleof == "FMKiZv");    // 'M'==scope, 'K'==ref, 'i'==int
+    static assert(typeof(bar).mangleof == "FMKxiZv");   // 'M'==scope, 'K'==ref, 'x'==const, 'i'==int,
+
+    void voo(scope ref int x) {}
+    void var(   in ref int x) {}
+    static assert(foo.mangleof == "_D8scoperef5test2FZ3fooFMKiZv");
+    static assert(bar.mangleof == "_D8scoperef5test2FZ3barFMKxiZv");
+    static assert(voo.mangleof == "_D8scoperef5test2FZ3vooMFMKiZv");
+    static assert(var.mangleof == "_D8scoperef5test2FZ3varMFMKxiZv");
+}
+
+/******************************************/
+
+int main()
+{
+    test1();
+    test2();
+
+    printf("Success\n");
+    return 0;
+}


### PR DESCRIPTION
http://wiki.dlang.org/DIP36

`scope ref` and `in ref` parameters can bind both lvalues and rvalues.
