### PR TITLE
7147 typeid() should be supported in CTFE

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -208,6 +208,9 @@ TypeAArray *toBuiltinAAType(Type *t);
  */
 Expression *findKeyInAA(Loc loc, AssocArrayLiteralExp *ae, Expression *e2);
 
+/// True if type is TypeInfo_Class
+bool isTypeInfo_Class(Type *type);
+
 /***********************************************
       In-place integer operations
 ***********************************************/

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -533,6 +533,16 @@ TypeAArray *toBuiltinAAType(Type *t)
 #endif
 }
 
+/************** TypeInfo operations ************************************/
+
+// Return true if type is TypeInfo_Class
+bool isTypeInfo_Class(Type *type)
+{
+    return type->ty == Tclass &&
+        (( Type::typeinfo == ((TypeClass*)type)->sym)
+        || Type::typeinfo->isBaseOf(((TypeClass*)type)->sym, NULL));
+}
+
 /************** Pointer operations ************************************/
 
 // Return true if t is a pointer (not a function pointer)
@@ -1623,6 +1633,10 @@ Expression *ctfeCast(Loc loc, Type *type, Type *to, Expression *e)
         else
             return new NullExp(loc, to);
     }
+    // Allow TypeInfo type painting
+    if (isTypeInfo_Class(e->type) && e->type->implicitConvTo(to))
+        return paintTypeOntoLiteral(to, e);
+
     Expression *r = Cast(type, to, e);
     if (r == EXP_CANT_INTERPRET)
         error(loc, "cannot cast %s to %s at compile time", e->toChars(), to->toChars());

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1470,7 +1470,7 @@ Expression *SymOffExp::interpret(InterState *istate, CtfeGoal goal)
     {
         return this;
     }
-    if((type->ty == Tclass)&&((Type::typeinfo == ((TypeClass*)type)->sym)||Type::typeinfo->isBaseOf(((TypeClass*)type)->sym, NULL)))
+    if (isTypeInfo_Class(type) && offset == 0)
     {
         return this;
     }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4906,7 +4906,34 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
     }
 #endif
     else
-    {   // It's possible we have an array bounds error. We need to make sure it
+    {
+        // Check for .classinfo, which is lowered in the semantic pass into **(class).
+        if (e1->op == TOKstar && e1->type->ty == Tpointer && isTypeInfo_Class(e1->type->nextOf()))
+        {
+            e = (((PtrExp *)e1)->e1)->interpret(istate, ctfeNeedLvalue);
+            if (exceptionOrCantInterpret(e))
+                return e;
+            if (e->op == TOKnull)
+            {
+                error("Null pointer dereference evaluating typeid. '%s' is null", ((PtrExp *)e1)->e1->toChars());
+                return EXP_CANT_INTERPRET;
+            }
+            if (e->op != TOKclassreference)
+            {   error("CTFE internal error determining classinfo");
+                return EXP_CANT_INTERPRET;
+            }
+            ClassDeclaration *cd = ((ClassReferenceExp *)e)->originalClass();
+            assert(cd);
+
+            // Create the classinfo, if it doesn't yet exist.
+            // TODO: This belongs in semantic, CTFE should not have to do this.
+            if (!cd->vclassinfo)
+                cd->vclassinfo = new TypeInfoClassDeclaration(cd->type);
+            e = new SymOffExp(loc, cd->vclassinfo, 0);
+            e->type = type;
+            return e;
+        }
+       // It's possible we have an array bounds error. We need to make sure it
         // errors with this line number, not the one where the pointer was set.
         e = e1->interpret(istate, ctfeNeedLvalue);
         if (exceptionOrCantInterpret(e))

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3794,6 +3794,27 @@ int classtest3()
 static assert(classtest3());
 
 /**************************************************
+    7147 typeid()
+**************************************************/
+
+static assert({
+    TypeInfo xxx = typeid(Object);
+    TypeInfo yyy = typeid(new Error("xxx"));
+    return true;
+    }());
+
+int bug7147(int n)
+{
+    Error err = n ? new Error("xxx") : null;
+    TypeInfo qqq = typeid(err);
+    return 1;
+}
+
+// Must not segfault if class is null
+static assert(!is(typeof(compiles!(bug7147(0)))));
+static assert( is(typeof(compiles!(bug7147(1)))));
+
+/**************************************************
     6885 wrong code with new array
 **************************************************/
 


### PR DESCRIPTION
 Recognize the lowering which happens in the front-end ( typeid(C) becomes `cast(TypeInfo)**C` ), and create a reference to the static 'typeinfo' variable, just as happens in mtype.c when the type is statically known.
