### PR TITLE
9938 ICE using global interface variable in CTFE

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4042,8 +4042,10 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
         {   // Make a virtual function call.
             Expression *thisval = pthis;
             if (pthis->op == TOKvar)
-            {   assert(((VarExp*)thisval)->var->isVarDeclaration());
-                thisval = ((VarExp*)thisval)->var->isVarDeclaration()->getValue();
+            {
+                VarDeclaration *vthis = ((VarExp*)thisval)->var->isVarDeclaration();
+                assert(vthis);
+                thisval = getVarExp(loc, istate, vthis, ctfeNeedLvalue);
                 // If it is a reference, resolve it
                 if (thisval->op != TOKnull && thisval->op != TOKclassreference)
                     thisval = pthis->interpret(istate);

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -2831,6 +2831,7 @@ void test104()
 }
 
 /************************************************/
+
 interface ITest105a
 {
     string test105a() const;
@@ -2922,6 +2923,16 @@ void test105()
     assert(t105bi.test105b() == "test105b");   
     
 }
+
+int bug9938()
+{
+    assert(t105ia.test105a() == "test105a");
+    return 1;
+}
+
+static assert(t105ia.test105a() == "test105a");
+static assert(bug9938());
+
 
 /************************************************/
 


### PR DESCRIPTION
Can't just use getValue() to get the value of the 'this', it might be a global. It needs to be evaluated like any other variable.
