### PR TITLE
9921: Enum variables of type void should be illegal

### DIFF
--- a/src/enum.c
+++ b/src/enum.c
@@ -126,7 +126,7 @@ void EnumDeclaration::semantic(Scope *sc)
 
     //printf("EnumDeclaration::semantic(sd = %p, '%s') %s\n", sc->scopesym, sc->scopesym->toChars(), toChars());
     //printf("EnumDeclaration::semantic() %s\n", toChars());
-    if (!members)               // enum ident;
+    if (!members && !memtype)               // enum ident;
         return;
 
     if (!memtype && !isAnonymous())
@@ -191,6 +191,10 @@ void EnumDeclaration::semantic(Scope *sc)
     }
 
     isdone = 1;
+
+    if (!members)               // enum ident : memtype;
+        return;
+
     Module::dprogress++;
 
     type = type->semantic(loc, sc);

--- a/src/enum.c
+++ b/src/enum.c
@@ -182,6 +182,11 @@ void EnumDeclaration::semantic(Scope *sc)
                 return;
             }
         }
+        if (memtype->ty == Tvoid)
+        {
+            error("base type must not be void");
+            memtype = Type::terror;
+        }
 #if 0   // Decided to abandon this restriction for D 2.0
         if (!memtype->isintegral())
         {   error("base type must be of integral type, not %s", memtype->toChars());
@@ -281,6 +286,13 @@ void EnumDeclaration::semantic(Scope *sc)
             if (!isAnonymous())
                 e = e->castTo(sce, type);
         }
+        else if (memtype && memtype == Type::terror)
+        {
+            e = new ErrorExp();
+            minval = e;
+            maxval = e;
+            defaultval = e;
+        }
         else
         {
             // Lazily evaluate enum.max
@@ -331,7 +343,7 @@ void EnumDeclaration::semantic(Scope *sc)
          * If enum doesn't have a name, we can never identify the enum type,
          * so there is no purpose for a .min, .max or .default
          */
-        if (!isAnonymous())
+        if (!isAnonymous() && memtype != Type::terror)
         {
             if (first)
             {   defaultval = e;

--- a/test/fail_compilation/enum9921.d
+++ b/test/fail_compilation/enum9921.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/enum9921.d(1): Error: enum enum9921.X base type must not be void
+fail_compilation/enum9921.d(3): Error: enum enum9921.Z base type must not be void
+---
+*/
+
+#line 1
+enum X : void;
+
+enum Z : void { Y };


### PR DESCRIPTION
Sounds like a trivial accepts-invalid bug, but the fix is necessary for my CTFE refactoring.

The important part of this pull request is to avoid calculating min and max for an enum with an erroneous base type, because in that case it was sending garbage to the CTFE engine.
