### PR TITLE
D1 ONLY: Merge six CTFE bugfixes from D2

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -182,6 +182,12 @@ int comparePointers(Loc loc, enum TOK op, Type *type, Expression *agg1, dinteger
 Expression *pointerArithmetic(Loc loc, enum TOK op, Type *type,
     Expression *eptr, Expression *e2);
 
+// True if conversion from type 'from' to 'to' involves a reinterpret_cast
+// floating point -> integer or integer -> floating point
+bool isFloatIntPaint(Type *to, Type *from);
+
+// Reinterpret float/int value 'fromVal' as a float/integer of type 'to'.
+Expression *paintFloatInt(Expression *fromVal, Type *to);
 
 /// Return true if t is an AA, or AssociativeArray!(key, value)
 bool isAssocArray(Type *t);

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -574,6 +574,8 @@ Expression *getAggregateFromPointer(Expression *e, dinteger_t *ofs)
     *ofs = 0;
     if (e->op == TOKaddress)
         e = ((AddrExp *)e)->e1;
+    if (e->op == TOKsymoff)
+        *ofs = ((SymOffExp *)e)->offset;
     if (e->op == TOKdotvar)
     {
         Expression *ex = ((DotVarExp *)e)->e1;
@@ -611,7 +613,9 @@ bool pointToSameMemoryBlock(Expression *agg1, Expression *agg2)
     // must compare the variables being pointed to.
     return agg1 == agg2 ||
             (agg1->op == TOKvar && agg2->op == TOKvar &&
-            ((VarExp *)agg1)->var == ((VarExp *)agg2)->var);
+            ((VarExp *)agg1)->var == ((VarExp *)agg2)->var) ||
+            (agg1->op == TOKsymoff && agg2->op == TOKsymoff &&
+            ((SymOffExp *)agg1)->var == ((SymOffExp *)agg2)->var);
 }
 
 // return e1 - e2 as an integer, or error if not possible
@@ -630,10 +634,15 @@ Expression *pointerDifference(Loc loc, Type *type, Expression *e1, Expression *e
     {
         if (((StringExp *)agg1)->string == ((StringExp *)agg2)->string)
         {
-        Type *pointee = ((TypePointer *)agg1->type)->next;
-        dinteger_t sz = pointee->size();
-        return new IntegerExp(loc, (ofs1-ofs2)*sz, type);
+            Type *pointee = ((TypePointer *)agg1->type)->next;
+            dinteger_t sz = pointee->size();
+            return new IntegerExp(loc, (ofs1-ofs2)*sz, type);
         }
+    }
+    else if (agg1->op == TOKsymoff && agg2->op == TOKsymoff &&
+            ((SymOffExp *)agg1)->var == ((SymOffExp *)agg2)->var)
+    {
+        return new IntegerExp(loc, ofs1-ofs2, type);
     }
     error(loc, "%s - %s cannot be interpreted at compile time: cannot subtract "
         "pointers to two different memory blocks",
@@ -655,21 +664,36 @@ Expression *pointerArithmetic(Loc loc, enum TOK op, Type *type,
     if (eptr->op == TOKaddress)
         eptr = ((AddrExp *)eptr)->e1;
     Expression *agg1 = getAggregateFromPointer(eptr, &ofs1);
-    if (agg1->op != TOKstring && agg1->op != TOKarrayliteral)
+    if (agg1->op == TOKsymoff)
+    {
+        if (((SymOffExp *)agg1)->var->type->ty != Tsarray)
+        {
+            error(loc, "cannot perform pointer arithmetic on arrays of unknown length at compile time");
+            return EXP_CANT_INTERPRET;
+        }
+    }
+    else if (agg1->op != TOKstring && agg1->op != TOKarrayliteral)
     {
         error(loc, "cannot perform pointer arithmetic on non-arrays at compile time");
         return EXP_CANT_INTERPRET;
     }
     ofs2 = e2->toInteger();
     Type *pointee = ((TypePointer *)agg1->type)->next;
+    sinteger_t indx = ofs1;
     dinteger_t sz = pointee->size();
-    Expression *dollar = ArrayLength(Type::tsize_t, agg1);
-    assert(dollar != EXP_CANT_INTERPRET);
+    Expression *dollar;
+    if (agg1->op == TOKsymoff)
+    {
+        dollar = ((TypeSArray *)(((SymOffExp *)agg1)->var->type))->dim;
+        indx = ofs1/sz;
+    }
+    else
+    {
+        dollar = ArrayLength(Type::tsize_t, agg1);
+        assert(dollar != EXP_CANT_INTERPRET);
+    }
     dinteger_t len = dollar->toInteger();
 
-    Expression *val = agg1;
-    TypeArray *tar = (TypeArray *)val->type;
-    sinteger_t indx = ofs1;
     if (op == TOKadd || op == TOKaddass || op == TOKplusplus)
         indx = indx + ofs2/sz;
     else if (op == TOKmin || op == TOKminass || op == TOKminusminus)
@@ -679,14 +703,24 @@ Expression *pointerArithmetic(Loc loc, enum TOK op, Type *type,
         error(loc, "CTFE Internal compiler error: bad pointer operation");
         return EXP_CANT_INTERPRET;
     }
-    if (val->op != TOKarrayliteral && val->op != TOKstring)
-    {
-        error(loc, "CTFE Internal compiler error: pointer arithmetic %s", val->toChars());
-        return EXP_CANT_INTERPRET;
-    }
+
     if (indx < 0 || indx > len)
     {
         error(loc, "cannot assign pointer to index %lld inside memory block [0..%lld]", indx, len);
+        return EXP_CANT_INTERPRET;
+    }
+
+    if (agg1->op == TOKsymoff)
+    {
+        SymOffExp *se = new SymOffExp(loc, ((SymOffExp *)agg1)->var, indx*sz);
+        se->type = type;
+        return se;
+    }
+
+    Expression *val = agg1;
+    if (val->op != TOKarrayliteral && val->op != TOKstring)
+    {
+        error(loc, "CTFE Internal compiler error: pointer arithmetic %s", val->toChars());
         return EXP_CANT_INTERPRET;
     }
 
@@ -1879,6 +1913,8 @@ bool isCtfeValueValid(Expression *newval)
     {
         if (((SymOffExp *)newval)->var->isFuncDeclaration())
             return true;
+        if (((SymOffExp *)newval)->var->isDataseg())
+            return true;    // pointer to static variable
     }
     if (newval->op == TOKint64 || newval->op == TOKfloat64 ||
         newval->op == TOKchar || newval->op == TOKcomplex80)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3942,7 +3942,7 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
         Expression * pe = ((PtrExp*)ecall)->e1;
         if (pe->op == TOKvar) {
             VarDeclaration *vd = ((VarExp *)((PtrExp*)ecall)->e1)->var->isVarDeclaration();
-            if (vd && vd->getValue() && vd->getValue()->op == TOKsymoff)
+            if (vd && vd->hasValue() && vd->getValue()->op == TOKsymoff)
                 fd = ((SymOffExp *)vd->getValue())->var->isFuncDeclaration();
             else
             {
@@ -3983,7 +3983,7 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
     else if (ecall->op == TOKvar)
     {
         VarDeclaration *vd = ((VarExp *)ecall)->var->isVarDeclaration();
-        if (vd && vd->getValue())
+        if (vd && vd->hasValue())
             ecall = vd->getValue();
         else // Calling a function
             fd = ((VarExp *)e1)->var->isFuncDeclaration();

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3983,25 +3983,16 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
     }
     if (pthis)
     {   // Member function call
-        Expression *oldpthis;
-        if (pthis->op == TOKthis)
-        {
-            pthis = istate ? istate->localThis : NULL;
-            oldpthis = pthis;
-        }
-        else
-        {
-            if (pthis->op == TOKcomma)
-                pthis = pthis->interpret(istate);
-            if (exceptionOrCantInterpret(pthis))
-                return pthis;
-                // Evaluate 'this'
-            oldpthis = pthis;
-            if (pthis->op != TOKvar)
-                pthis = pthis->interpret(istate, ctfeNeedLvalue);
-            if (exceptionOrCantInterpret(pthis))
-                return pthis;
-        }
+        if (pthis->op == TOKcomma)
+            pthis = pthis->interpret(istate);
+        if (exceptionOrCantInterpret(pthis))
+            return pthis;
+        // Evaluate 'this'
+        Expression *oldpthis = pthis;
+        if (pthis->op != TOKvar)
+            pthis = pthis->interpret(istate, ctfeNeedLvalue);
+        if (exceptionOrCantInterpret(pthis))
+            return pthis;
         if (fd->isVirtual())
         {   // Make a virtual function call.
             Expression *thisval = pthis;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1458,6 +1458,32 @@ Expression *SymOffExp::interpret(InterState *istate, CtfeGoal goal)
         return EXP_CANT_INTERPRET;
     }
     Type *pointee = ((TypePointer *)type)->next;
+    if ( var->isThreadlocal())
+    {
+        error("cannot take address of thread-local variable %s at compile time", var->toChars());
+        return EXP_CANT_INTERPRET;
+    }
+    // Check for taking an address of a shared variable.
+    // If the shared variable is an array, the offset might not be zero.
+    VarDeclaration *vd = var->isVarDeclaration();
+    Type *fromType = NULL;
+    if (var->type->ty == Tarray || var->type->ty == Tsarray)
+    {
+        fromType = ((TypeArray *)(var->type))->next;
+    }
+    if ( var->isDataseg() && (
+         (offset == 0 && isSafePointerCast(var->type, pointee)) ||
+         (fromType && isSafePointerCast(fromType, pointee))
+        ) && !(vd && vd->init &&
+#if DMDV2
+        (var->isConst() || var->isImmutable())
+#else
+        var->isConst()
+#endif
+        ))
+    {
+        return this;
+    }
     Expression *val = getVarExp(loc, istate, var, goal);
     if (val == EXP_CANT_INTERPRET)
         return val;
@@ -3110,6 +3136,11 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             if (aggregate->op != TOKslice && aggregate->op != TOKstring &&
                 aggregate->op != TOKarrayliteral && aggregate->op != TOKassocarrayliteral)
             {
+                if (aggregate->op == TOKsymoff)
+                {
+                    error("mutable variable %s cannot be modified at compile time, even through a pointer", ((SymOffExp *)aggregate)->var->toChars());
+                    return EXP_CANT_INTERPRET;
+                }
                 if (indexToModify != 0)
                 {
                     error("pointer index [%lld] lies outside memory block [0..1]", indexToModify);
@@ -3260,6 +3291,11 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         if (oldval->op != TOKarrayliteral && oldval->op != TOKstring
             && oldval->op != TOKslice && oldval->op != TOKnull)
         {
+            if (oldval->op == TOKsymoff)
+            {
+                error("pointer %s cannot be sliced at compile time (it points to a static variable)", sexp->e1->toChars());
+                return EXP_CANT_INTERPRET;
+            }
             if (assignmentToSlicedPointer)
             {
                 error("pointer %s cannot be sliced at compile time (it does not point to an array)",
@@ -4236,6 +4272,11 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
         }
         else
         {   // Pointer to a non-array variable
+            if (agg->op == TOKsymoff)
+            {
+                    error("mutable variable %s cannot be read at compile time, even through a pointer", ((SymOffExp *)agg)->var->toChars());
+                    return EXP_CANT_INTERPRET;
+            }
             if ((indx + ofs) != 0)
             {
                 error("pointer index [%lld] lies outside memory block [0..1]",
@@ -4387,6 +4428,11 @@ Expression *SliceExp::interpret(InterState *istate, CtfeGoal goal)
                 return e;
             }
             error("cannot slice null pointer %s", this->e1->toChars());
+            return EXP_CANT_INTERPRET;
+        }
+        if (agg->op == TOKsymoff)
+        {
+            error("slicing pointers to static variables is not supported in CTFE");
             return EXP_CANT_INTERPRET;
         }
         if (agg->op != TOKarrayliteral && agg->op != TOKstring)
@@ -4855,7 +4901,10 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
         if (!(e->op == TOKvar || e->op == TOKdotvar || e->op == TOKindex
             || e->op == TOKslice || e->op == TOKaddress))
         {
-            error("dereference of invalid pointer '%s'", e->toChars());
+            if (e->op == TOKsymoff)
+                error("cannot dereference pointer to static variable %s at compile time", ((SymOffExp *)e)->var->toChars());
+            else
+                error("dereference of invalid pointer '%s'", e->toChars());
             return EXP_CANT_INTERPRET;
         }
         if (goal != ctfeNeedLvalue)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1319,6 +1319,11 @@ Expression *WithStatement::interpret(InterState *istate)
 #if LOG
     printf("%s WithStatement::interpret()\n", loc.toChars());
 #endif
+
+    // If it is with(Enum) {...}, just execute the body.
+    if (exp->op == TOKimport || exp->op == TOKtype)
+        return body ? body->interpret(istate) : EXP_VOID_INTERPRET;
+
     START()
     Expression *e = exp->interpret(istate);
     if (exceptionOrCantInterpret(e))


### PR DESCRIPTION
7790 [CTFE] assignment to AA apply ref argument
9170 CTFE: Allow reinterpret casts float <-> int
9236 CTFE ice on switch + with(EnumType)
9338 Compiler segfaults if try to CTFE member function without valid 'this'
9745 Allow &staticvar in CTFE
9445 ICE(interpret.c) calling parameter in CTFE

Walter - please run your D1 test suite over this, mine is incomplete.
