### PR TITLE
Issue 9961 - Using UFCS properties suppress actual errors

### DIFF
--- a/src/enum.c
+++ b/src/enum.c
@@ -298,7 +298,7 @@ void EnumDeclaration::semantic(Scope *sc)
             // Lazily evaluate enum.max
             if (!emax)
             {
-                emax = t->getProperty(0, Id::max);
+                emax = t->getProperty(0, Id::max, 0);
                 emax = emax->semantic(sce);
                 emax = emax->ctfeInterpret();
             }

--- a/src/expression.c
+++ b/src/expression.c
@@ -7053,7 +7053,7 @@ Expression *DotIdExp::semanticY(Scope *sc, int flag)
          */
         e = new PtrExp(loc, e1);
         e = e->semantic(sc);
-        return e->type->dotExp(sc, e, ident, 0);
+        return e->type->dotExp(sc, e, ident, flag);
     }
     else
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -459,9 +459,11 @@ Expression *resolveUFCSProperties(Scope *sc, Expression *e1, Expression *e2 = NU
          */
         e = new IdentifierExp(loc, Id::empty);
         if (tiargs)
-            e = new DotTemplateInstanceExp(loc, e, ident, tiargs);
+            e = (new DotTemplateInstanceExp(loc, e, ident, tiargs))->semanticY(sc, 1);
         else
-            e = new DotIdExp(loc, e, ident);
+            e = (new DotIdExp(loc, e, ident))->semanticY(sc, 1);
+        if (!e)
+            return eleft->type->Type::getProperty(eleft->loc, ident, 0);
 
         if (e2)
         {
@@ -470,7 +472,7 @@ Expression *resolveUFCSProperties(Scope *sc, Expression *e1, Expression *e2 = NU
 
             /* .f(e1) = e2
              */
-            Expression *ex = e->syntaxCopy();
+            Expression *ex = e->copy();
             Expressions *a1 = new Expressions();
             a1->setDim(1);
             (*a1)[0] = eleft;
@@ -514,48 +516,6 @@ Expression *resolveUFCSProperties(Scope *sc, Expression *e1, Expression *e2 = NU
         }
     }
     return e;
-}
-
-/*********************************
- * Attempt to find a type property. If failed, attempt to find
- * UFCS property. If UFCS found, return expression. Otherwise
- * show type property error message.
- * Returns non-NULL only if UFCS property found.
- */
-Expression * resolveProperty(Scope *sc, Expression **e1, Expression *e2)
-{
-    enum TOK op = (*e1)->op;
-    UnaExp *una = (UnaExp *)(*e1);
-    Type *t = una->e1->type;
-    int olderrors = global.errors;
-    una->e1 = una->e1->semantic(sc);
-    if (global.errors == olderrors && una->e1->type)
-    {
-        unsigned errors = global.startGagging();
-        // try property gagged
-        if (op == TOKdotti)
-            *e1 = ((DotTemplateInstanceExp *)una)->semantic(sc, 1);
-        else if (op == TOKdot)
-            *e1 = ((DotIdExp *)una)->semantic(sc, 1);
-
-        if (global.endGagging(errors) || (*e1)->op == TOKerror)
-        {
-            (*e1)->op = op;
-            errors = global.startGagging();  // try UFCS gagged
-            Expression *e = resolveUFCSProperties(sc, una, e2);
-            if (!global.endGagging(errors) && (*e1)->op != TOKerror)
-                return e;  // found UFCS
-
-            // try property non-gagged
-            una->type = t;  // restore type
-            if (op == TOKdotti)
-                *e1 = ((DotTemplateInstanceExp *)una)->semantic(sc, 1);
-            else if (op == TOKdot)
-                *e1 = ((DotIdExp *)una)->semantic(sc, 1);
-        }
-    }
-
-    return NULL;
 }
 
 /******************************
@@ -4387,7 +4347,7 @@ void StructLiteralExp::toMangleBuffer(OutBuffer *buf)
  *      cast(foo).size
  */
 
-Expression *typeDotIdExp(Loc loc, Type *type, Identifier *ident)
+DotIdExp *typeDotIdExp(Loc loc, Type *type, Identifier *ident)
 {
     return new DotIdExp(loc, new TypeExp(loc, type), ident);
 }
@@ -6781,66 +6741,32 @@ DotIdExp::DotIdExp(Loc loc, Expression *e, Identifier *ident)
 
 Expression *DotIdExp::semantic(Scope *sc)
 {
-    // Indicate we need to resolve by UFCS.
-    return semantic(sc, 0);
-}
-
-Expression *DotIdExp::semantic(Scope *sc, int flag)
-{   Expression *e;
-    Expression *eleft;
-    Expression *eright;
-
 #if LOGSEMANTIC
     printf("DotIdExp::semantic(this = %p, '%s')\n", this, toChars());
     //printf("e1->op = %d, '%s'\n", e1->op, Token::toChars(e1->op));
 #endif
-
-//{ static int z; fflush(stdout); if (++z == 10) *(char*)0=0; }
-
-    /* Special case: rewrite this.id and super.id
-     * to be classtype.id and baseclasstype.id
-     * if we have no this pointer.
-     */
-    if ((e1->op == TOKthis || e1->op == TOKsuper) && !hasThis(sc))
-    {   ClassDeclaration *cd;
-        StructDeclaration *sd;
-        AggregateDeclaration *ad;
-
-        ad = sc->getStructClassScope();
-        if (ad)
-        {
-            cd = ad->isClassDeclaration();
-            if (cd)
-            {
-                if (e1->op == TOKthis)
-                {
-                    e = typeDotIdExp(loc, cd->type, ident);
-                    return e->semantic(sc);
-                }
-                else if (cd->baseClass && e1->op == TOKsuper)
-                {
-                    e = typeDotIdExp(loc, cd->baseClass->type, ident);
-                    return e->semantic(sc);
-                }
-            }
-            else
-            {
-                sd = ad->isStructDeclaration();
-                if (sd)
-                {
-                    if (e1->op == TOKthis)
-                    {
-                        e = typeDotIdExp(loc, sd->type, ident);
-                        return e->semantic(sc);
-                    }
-                }
-            }
-        }
+    Expression *e = semanticY(sc, 1);
+    if (!e)     // if failed to find the property
+    {
+        /* If ident is not a valid property, rewrite:
+         *   e1.ident
+         * as:
+         *   .ident(e1)
+         */
+        e = resolveUFCSProperties(sc, this);
     }
+    return e;
+}
 
-//    Type *t1save = e1->type;
+// Run sematnic in e1
+Expression *DotIdExp::semanticX(Scope *sc)
+{
+    //printf("DotIdExp::semanticX(this = %p, '%s')\n", this, toChars());
+    Expression *e;
 
     UnaExp::semantic(sc);
+    if (e1->op == TOKerror)
+        return e1;
 
     if (ident == Id::mangleof)
     {   // symbol.mangleof
@@ -6861,15 +6787,10 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
 
     if (e1->op == TOKdotexp)
     {
-        DotExp *de = (DotExp *)e1;
-        eleft = de->e1;
-        eright = de->e2;
     }
     else
     {
         e1 = resolvePropertiesX(sc, e1);
-        eleft = NULL;
-        eright = e1;
     }
 #if DMDV2
     if (e1->op == TOKtuple && ident == Id::offsetof)
@@ -6909,6 +6830,67 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
     {
         error("expression %s does not have property %s", e1->toChars(), ident->toChars());
         return new ErrorExp();
+    }
+
+    return this;
+}
+
+// Resolve e1.ident without seeing UFCS.
+// If flag == 1, stop "not a property" error and return NULL.
+Expression *DotIdExp::semanticY(Scope *sc, int flag)
+{
+    //printf("DotIdExp::semanticY(this = %p, '%s')\n", this, toChars());
+
+//{ static int z; fflush(stdout); if (++z == 10) *(char*)0=0; }
+
+    /* Special case: rewrite this.id and super.id
+     * to be classtype.id and baseclasstype.id
+     * if we have no this pointer.
+     */
+    if ((e1->op == TOKthis || e1->op == TOKsuper) && !hasThis(sc))
+    {
+        if (AggregateDeclaration *ad = sc->getStructClassScope())
+        {
+            if (ClassDeclaration *cd = ad->isClassDeclaration())
+            {
+                if (e1->op == TOKthis)
+                {
+                    DotIdExp *die = typeDotIdExp(loc, cd->type, ident);
+                    return die->semanticY(sc, flag);
+                }
+                else if (cd->baseClass && e1->op == TOKsuper)
+                {
+                    DotIdExp *die = typeDotIdExp(loc, cd->baseClass->type, ident);
+                    return die->semanticY(sc, flag);
+                }
+            }
+            else if (StructDeclaration *sd = ad->isStructDeclaration())
+            {
+                if (e1->op == TOKthis)
+                {
+                    DotIdExp *die = typeDotIdExp(loc, sd->type, ident);
+                    return die->semanticY(sc, flag);
+                }
+            }
+        }
+    }
+
+    Expression *e = semanticX(sc);
+    if (e != this)
+        return e;
+
+    Expression *eleft;
+    Expression *eright;
+    if (e1->op == TOKdotexp)
+    {
+        DotExp *de = (DotExp *)e1;
+        eleft = de->e1;
+        eright = de->e2;
+    }
+    else
+    {
+        eleft = NULL;
+        eright = e1;
     }
 
     Type *t1b = e1->type->toBasetype();
@@ -7050,6 +7032,8 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
             e = e->semantic(sc);
             return e;
         }
+        if (flag)
+            return NULL;
         s = ie->sds->search_correct(ident);
         if (s)
             error("undefined identifier '%s', did you mean '%s %s'?",
@@ -7069,66 +7053,13 @@ Expression *DotIdExp::semantic(Scope *sc, int flag)
          */
         e = new PtrExp(loc, e1);
         e = e->semantic(sc);
-        return e->type->dotExp(sc, e, ident);
+        return e->type->dotExp(sc, e, ident, 0);
     }
-#if DMDV2
-    else if (!flag)
-    {   /* If ident is not a valid property, rewrite:
-         *   e1.ident
-         * as:
-         *   .ident(e1)
-         */
-        if (e1->op == TOKtype ||
-            t1b->ty == Tvoid ||
-            (t1b->ty == Tarray || t1b->ty == Tsarray || t1b->ty == Taarray) &&
-            (ident == Id::sort || ident == Id::reverse || ident == Id::dup || ident == Id::idup))
-        {   goto L2;
-        }
-
-        /* This would be much better if we added a "hasProperty" method to types,
-         * i.e. the gagging is a bad way.
-         */
-
-        if (t1b->ty == Taarray)
-        {
-            TypeAArray *taa = (TypeAArray *)t1b;
-            if (!taa->impl &&
-                ident != Id::__sizeof &&
-                ident != Id::__xalignof &&
-                ident != Id::init &&
-                ident != Id::mangleof &&
-                ident != Id::stringof &&
-                ident != Id::offsetof)
-            {
-                // Find out about these errors when not gagged
-                taa->getImpl();
-            }
-        }
-
-        Type *t1 = e1->type;
-        unsigned errors = global.startGagging();
-        e = t1->dotExp(sc, e1, ident);
-        if (global.endGagging(errors))  // if failed to find the property
-        {
-            e1->type = t1;              // kludge to restore type
-            errors = global.startGagging();
-            e = resolveUFCSProperties(sc, this);
-            if (global.endGagging(errors))
-            {
-                // both lookups failed, lookup property again for better error message
-                e1->type = t1;  // restore type
-                e = t1->dotExp(sc, e1, ident);
-            }
-        }
-        e = e->semantic(sc);
-        return e;
-    }
-#endif
     else
     {
-    L2:
-        e = e1->type->dotExp(sc, e1, ident);
-        e = e->semantic(sc);
+        e = e1->type->dotExp(sc, e1, ident, flag);
+        if (!flag || e)
+            e = e->semantic(sc);
         return e;
     }
 }
@@ -7431,53 +7362,47 @@ TemplateDeclaration *DotTemplateInstanceExp::getTempdecl(Scope *sc)
 
 Expression *DotTemplateInstanceExp::semantic(Scope *sc)
 {
-    // Indicate we need to resolve by UFCS.
-    return semantic(sc, 0);
-}
-Expression *DotTemplateInstanceExp::semantic(Scope *sc, int flag)
-{
 #if LOGSEMANTIC
     printf("DotTemplateInstanceExp::semantic('%s')\n", toChars());
 #endif
 
-    UnaExp::semantic(sc);
-    if (e1->op == TOKerror)
-        return e1;
+    // Indicate we need to resolve by UFCS.
+    Expression *e = semanticY(sc, 1);
+    if (!e)
+        e = resolveUFCSProperties(sc, this);
+    return e;
+}
 
-    Expression *e;
+// Resolve e1.ident!tiargs without seeing UFCS.
+// If flag == 1, stop "not a property" error and return NULL.
+Expression *DotTemplateInstanceExp::semanticY(Scope *sc, int flag)
+{
+#if LOGSEMANTIC
+    printf("DotTemplateInstanceExpY::semantic('%s')\n", toChars());
+#endif
+
     DotIdExp *die = new DotIdExp(loc, e1, ti->name);
 
-    if (flag || !e1->type || e1->op == TOKtype ||
-        (e1->op == TOKimport && ((ScopeExp *)e1)->sds->isModule()))
+    Expression *e = die->semanticX(sc);
+    if (e == die)
     {
-        e = die->semantic(sc, 1);
-    }
-    else
-    {
+        e1 = die->e1;   // take back
+
         Type *t1b = e1->type->toBasetype();
         if (t1b->ty == Tarray || t1b->ty == Tsarray || t1b->ty == Taarray ||
             t1b->ty == Tnull  || (t1b->isTypeBasic() && t1b->ty != Tvoid))
         {
-            /* No built-in type has templatized property, so can short cut.
+            /* No built-in type has templatized property, so do shortcut.
+             * It is necessary in: 1024.max!"a < b"
              */
-            return resolveUFCSProperties(sc, this);
+            if (flag)
+                return NULL;
         }
-
-        unsigned errors = global.startGagging();
-        e = die->semantic(sc, 1);
-        Type *t = e1->type;
-        if (global.endGagging(errors))
-        {
-            errors = global.startGagging();
-            e = resolveUFCSProperties(sc, this);
-            if (!global.endGagging(errors))
-                return e;
-
-            // both lookups failed, lookup property again for better error message
-            e->type = t;  // restore type
-            e = die->semantic(sc, 1);
-        }
+        e = die->semanticY(sc, flag);
+        if (flag && !e)
+            return NULL;
     }
+    assert(e);
 
 L1:
     if (e->op == TOKerror)
@@ -7810,9 +7735,8 @@ Lshift:
     {
         DotIdExp *die = new DotIdExp(e->loc, e, ident);
 
-        unsigned errors = global.startGagging();
-        Expression *ex = die->semantic(sc, 1);
-        if (global.endGagging(errors))
+        Expression *ex = die->semanticY(sc, 1);
+        if (!ex)
         {
             goto Lshift;
         }
@@ -10549,13 +10473,19 @@ Expression *AssignExp::semantic(Scope *sc)
      */
     if (e1->op == TOKdotti)
     {
-        Expression *e = resolveProperty(sc, &e1, e2);
-        if (e) return e;
+        DotTemplateInstanceExp *dti = (DotTemplateInstanceExp *)e1;
+        Expression *e = dti->semanticY(sc, 1);
+        if (!e)
+            return resolveUFCSProperties(sc, e1, e2);
+        e1 = e;
     }
     else if (e1->op == TOKdot)
     {
-        Expression *e = resolveProperty(sc, &e1, e2);
-        if (e) return e;
+        DotIdExp *die = (DotIdExp *)e1;
+        Expression *e = die->semanticY(sc, 1);
+        if (!e)
+            return resolveUFCSProperties(sc, e1, e2);
+        e1 = e;
     }
     e1 = e1->semantic(sc);
     if (e1->op == TOKerror)

--- a/src/expression.h
+++ b/src/expression.h
@@ -550,7 +550,8 @@ struct StructLiteralExp : Expression
     Expression *inlineScan(InlineScanState *iss);
 };
 
-Expression *typeDotIdExp(Loc loc, Type *type, Identifier *ident);
+struct DotIdExp;
+DotIdExp *typeDotIdExp(Loc loc, Type *type, Identifier *ident);
 
 struct TypeExp : Expression
 {
@@ -917,7 +918,8 @@ struct DotIdExp : UnaExp
 
     DotIdExp(Loc loc, Expression *e, Identifier *ident);
     Expression *semantic(Scope *sc);
-    Expression *semantic(Scope *sc, int flag);
+    Expression *semanticX(Scope *sc);
+    Expression *semanticY(Scope *sc, int flag);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void dump(int i);
 };
@@ -956,7 +958,7 @@ struct DotTemplateInstanceExp : UnaExp
     Expression *syntaxCopy();
     TemplateDeclaration *getTempdecl(Scope *sc);
     Expression *semantic(Scope *sc);
-    Expression *semantic(Scope *sc, int flag);
+    Expression *semanticY(Scope *sc, int flag);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void dump(int indent);
 };

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -310,10 +310,10 @@ struct Type : Object
     Type *substWildTo(unsigned mod);
     virtual Type *toHeadMutable();
     virtual ClassDeclaration *isClassHandle();
-    virtual Expression *getProperty(Loc loc, Identifier *ident);
-    virtual Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    virtual Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    virtual Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     virtual structalign_t alignment();
-    Expression *noMember(Scope *sc, Expression *e, Identifier *ident);
+    Expression *noMember(Scope *sc, Expression *e, Identifier *ident, int flag);
     virtual Expression *defaultInit(Loc loc = 0);
     virtual Expression *defaultInitLiteral(Loc loc);
     virtual Expression *voidInitLiteral(VarDeclaration *var);
@@ -357,8 +357,8 @@ struct TypeError : Type
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
 
     d_uns64 size(Loc loc);
-    Expression *getProperty(Loc loc, Identifier *ident);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
     TypeTuple *toArgTypes();
@@ -396,8 +396,8 @@ struct TypeBasic : Type
     Type *syntaxCopy();
     d_uns64 size(Loc loc);
     unsigned alignsize();
-    Expression *getProperty(Loc loc, Identifier *ident);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     char *toChars();
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
 #if CPP_MANGLE
@@ -430,8 +430,8 @@ struct TypeVector : Type
     Type *semantic(Loc loc, Scope *sc);
     d_uns64 size(Loc loc);
     unsigned alignsize();
-    Expression *getProperty(Loc loc, Identifier *ident);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     char *toChars();
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toDecoBuffer(OutBuffer *buf, int flag);
@@ -458,7 +458,7 @@ struct TypeVector : Type
 struct TypeArray : TypeNext
 {
     TypeArray(TY ty, Type *next);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
 };
 
 // Static array, one with a fixed dimension
@@ -476,7 +476,7 @@ struct TypeSArray : TypeArray
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     int isString();
     int isZeroInit(Loc loc);
     structalign_t alignment();
@@ -515,7 +515,7 @@ struct TypeDArray : TypeArray
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     int isString();
     int isZeroInit(Loc loc);
     int checkBoolean();
@@ -551,7 +551,7 @@ struct TypeAArray : TypeArray
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wildmatch = NULL);
     int isZeroInit(Loc loc);
@@ -606,7 +606,7 @@ struct TypeReference : TypeNext
     d_uns64 size(Loc loc);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     int isZeroInit(Loc loc);
 #if CPP_MANGLE
@@ -703,7 +703,7 @@ struct TypeDelegate : TypeNext
     int isZeroInit(Loc loc);
     int checkBoolean();
     TypeInfoDeclaration *getTypeInfoDeclaration();
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     int hasPointers();
     TypeTuple *toArgTypes();
 #if CPP_MANGLE
@@ -822,7 +822,7 @@ struct TypeStruct : Type
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     structalign_t alignment();
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
@@ -863,8 +863,8 @@ struct TypeEnum : Type
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
-    Expression *getProperty(Loc loc, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
+    Expression *getProperty(Loc loc, Identifier *ident, int flag);
     int isintegral();
     int isfloating();
     int isreal();
@@ -907,9 +907,9 @@ struct TypeTypedef : Type
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     structalign_t alignment();
-    Expression *getProperty(Loc loc, Identifier *ident);
+    Expression *getProperty(Loc loc, Identifier *ident, int flag);
     int isintegral();
     int isfloating();
     int isreal();
@@ -957,7 +957,7 @@ struct TypeClass : Type
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toJson(JsonOut *json);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
+    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     ClassDeclaration *isClassHandle();
     int isBaseOf(Type *t, int *poffset);
     MATCH implicitConvTo(Type *to);
@@ -999,7 +999,7 @@ struct TypeTuple : Type
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toJson(JsonOut *json);
-    Expression *getProperty(Loc loc, Identifier *ident);
+    Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     TypeInfoDeclaration *getTypeInfoDeclaration();
 };
@@ -1032,10 +1032,7 @@ struct TypeNull : Type
     void toJson(JsonOut *json);
 
     d_uns64 size(Loc loc);
-    //Expression *getProperty(Loc loc, Identifier *ident);
-    //Expression *dotExp(Scope *sc, Expression *e, Identifier *ident);
     Expression *defaultInit(Loc loc);
-    //Expression *defaultInitLiteral(Loc loc);
 };
 
 /**************************************************************/

--- a/test/fail_compilation/diag8629.d
+++ b/test/fail_compilation/diag8629.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8629.d(9): Error: no property 'gunc' for type 'S'
+fail_compilation/diag8629.d(9): Error: not a property s.gunc
 ---
 */
 

--- a/test/fail_compilation/diag9241.d
+++ b/test/fail_compilation/diag9241.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -property
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag9241.d(18): Error: not a property s.splitLines
+fail_compilation/diag9241.d(18): Error: cannot implicitly convert expression (splitLines(s)) of type string[] to string
+---
+*/
+
+S[] splitLines(S)(S s)
+{
+    return null;
+}
+
+void main()
+{
+    string s;
+    s = s.splitLines;
+}

--- a/test/fail_compilation/diag9961.d
+++ b/test/fail_compilation/diag9961.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag9961.d(11): Error: cannot implicitly convert expression ("") of type string to int
+fail_compilation/diag9961.d(14): Error: template instance diag9961.foo!(int) error instantiating
+fail_compilation/diag9961.d(11): Error: cannot implicitly convert expression ("") of type string to int
+fail_compilation/diag9961.d(15): Error: template instance diag9961.foo!(char) error instantiating
+---
+*/
+
+void foo(T)(T) { int x = ""; }
+void main()
+{
+    100.foo();
+    'a'.foo;
+}

--- a/test/fail_compilation/ice9540.d
+++ b/test/fail_compilation/ice9540.d
@@ -1,0 +1,37 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice9540.d(34): Error: function ice9540.A.test.AddFront!(this, f).AddFront.dg (int _param_0) is not callable using argument types ()
+fail_compilation/ice9540.d(25): Error: template instance ice9540.A.test.AddFront!(this, f) error instantiating
+---
+*/
+
+template Tuple(E...) { alias E Tuple; }
+alias Tuple!(int) Args;
+
+void main() {
+    (new A).test ();
+}
+
+void test1 (int delegate (int) f) { f (-2); }
+
+class A
+{
+    int f (int a) {
+        return a;
+    }
+
+    void test () {
+        test1 (&AddFront!(this, f));
+    }
+}
+
+template AddFront (alias ctx, alias fun)  {
+    auto AddFront(Args args) {
+        auto dg (Args dgArgs) {
+            return fun (dgArgs);
+        }
+        dg.ptr = ctx;
+        return dg(args);
+    }
+}

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -392,16 +392,26 @@ static assert(is(typeof(bug4953(3))));
 /**********************************/
 // 5886 & 5393
 
-struct K5886 {
-    void get1(this T)() const {
+struct K5886
+{
+    void get1(this T)() const
+    {
         pragma(msg, T);
     }
-    void get2(int N=4, this T)() const {
+    void get2(int N=4, this T)() const
+    {
         pragma(msg, N, " ; ", T);
+    }
+    void test() const
+    {
+        get1;       // OK
+        get2;       // OK
+        get2!8;     // NG
     }
 }
 
-void test5886() {
+void test5886()
+{
     K5886 km;
     const(K5886) kc;
     immutable(K5886) ki;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1177,6 +1177,25 @@ void test7563()
 }
 
 /**********************************/
+// 7572
+
+class F7572
+{
+    Tr fn7572(Tr, T...)(T t) { return 1; }
+}
+Tr Fn7572(Tr, T...)(T t) { return 2; }
+
+void test7572()
+{
+    F7572 f = new F7572();
+    int delegate() dg = &f.fn7572!int;
+    assert(dg() == 1);
+
+    int function() fn = &Fn7572!int;
+    assert(fn() == 2);
+}
+
+/**********************************/
 // 7580
 
 struct S7580(T)
@@ -2336,6 +2355,7 @@ int main()
     test7359();
     test7416();
     test7563();
+    test7572();
     test7580();
     test7585();
     test7671();

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -304,6 +304,19 @@ void test8180()
 }
 
 /*******************************************/
+// 8245
+
+          string toStr8245(immutable(char)* p) { return null; }
+@property string asStr8245(immutable(char)* p) { return null; }
+
+void test8245()
+{
+    immutable(char)* p = "foobar".ptr;
+    p.toStr8245();
+    p.asStr8245;    // Error: no property 'asStr' for type 'immutable(char)'
+}
+
+/*******************************************/
 // 8252
 
 bool f(int x) { return !x; }
@@ -382,6 +395,7 @@ int main()
     test7773();
     test7943();
     test8180();
+    test8245();
     test8252();
     test8453();
     test8503();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9961

Remove gagging errors from the UFCS name look-up mechanism.

This change is based on the #1868.
