### PR TITLE
Fix issue 9960 Show deprecation errors during template instantiation in verbose mode

### DIFF
--- a/src/errors.d
+++ b/src/errors.d
@@ -216,13 +216,13 @@ extern (C++) void verrorPrint(const ref Loc loc, COLOR headerColor, const(char)*
     fflush(stderr);
 }
 
-// header is "Error: " by default (see errors.h)
-extern (C++) void verror(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null, const(char)* header = "Error: ")
+private void _verror(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1, const(char)* p2, const(char)* header, bool print)
 {
     global.errors++;
+    if (print)
+        verrorPrint(loc, COLOR_RED, header, format, ap, p1, p2);
     if (!global.gag)
     {
-        verrorPrint(loc, COLOR_RED, header, format, ap, p1, p2);
         if (global.errorLimit && global.errors >= global.errorLimit)
             fatal(); // moderate blizzard of cascading messages
     }
@@ -232,6 +232,12 @@ extern (C++) void verror(const ref Loc loc, const(char)* format, va_list ap, con
         //verrorPrint(loc, COLOR_RED, header, format, ap, p1, p2);
         global.gaggedErrors++;
     }
+}
+
+// header is "Error: " by default (see errors.h)
+extern (C++) void verror(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null, const(char)* header = "Error: ")
+{
+    _verror(loc, format, ap, p1, p2, header, !global.gag);
 }
 
 // Doesn't increase error count, doesn't print "Error:".
@@ -261,8 +267,16 @@ extern (C++) void vwarningSupplemental(const ref Loc loc, const(char)* format, v
 extern (C++) void vdeprecation(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null)
 {
     static __gshared const(char)* header = "Deprecation: ";
+    // 0: don't allow use of deprecated features
+    // 1: silently allow use of deprecated features
+    // 2: warn about the use of deprecated features
     if (global.params.useDeprecated == 0)
-        verror(loc, format, ap, p1, p2, header);
+    {
+        // The error will cause a template instantiation to fail,
+        // but it wouldn't get printed by verror() when gagged (bug 9960.)
+        // Enabling verbose mode will show these hidden deprecation errors.
+        _verror(loc, format, ap, p1, p2, header, !global.gag || global.params.verbose);
+    }
     else if (global.params.useDeprecated == 2 && !global.gag)
         verrorPrint(loc, COLOR_BLUE, header, format, ap, p1, p2);
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -34,6 +34,9 @@
 #   PERMUTE_ARGS:        the set of arguments to permute in multiple $(DMD) invocations
 #                        default: the make variable ARGS (see below)
 #
+#   CAPTURE_OUTPUT:      either "stdout" or "stderr", determining the output to be captured
+#                        default: (none, both stdout and stderr are captured)
+#
 #   TEST_OUTPUT:         the output is expected from the compilation (if the
 #                        output of the compilation doesn't match, the test
 #                        fails). You can use the this format for multi-line

--- a/test/compilable/test9960.d
+++ b/test/compilable/test9960.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -de -v
+// PERMUTE_ARGS:
+// CAPTURE_OUTPUT: stderr
+/*
+TEST_OUTPUT:
+---
+compilable/test9960.d(13): Deprecation: constructor test9960.D.this is deprecated
+compilable/test9960.d(13): Deprecation: constructor test9960.D.this is deprecated
+---
+*/
+
+class D { deprecated this(){} }
+T func(T)() if (is(typeof(new T()))) { return null; }
+int main() {
+    enum res1 = is(typeof(func!D()));
+    return res1;
+}

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -44,6 +44,13 @@ enum TestMode
     RUN
 }
 
+enum CaptureOutput
+{
+    STDOUT = 1,
+    STDERR = 2,
+    BOTH = STDOUT|STDERR
+}
+
 struct TestArgs
 {
     TestMode mode;
@@ -63,6 +70,7 @@ struct TestArgs
     // reason for disabling the test (if empty, the test is not disabled)
     string[] disabledPlatforms;
     bool     disabled;
+    CaptureOutput capture;
 }
 
 struct EnvData
@@ -239,6 +247,18 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     if (findTestParameter(file, "POST_SCRIPT", testArgs.postScript))
         testArgs.postScript = replace(testArgs.postScript, "/", to!string(envData.sep));
 
+    string captureOutputStr;
+    findTestParameter(file, "CAPTURE_OUTPUT", captureOutputStr);
+    if (captureOutputStr == "stderr")
+        testArgs.capture = CaptureOutput.STDERR;
+    else if (captureOutputStr == "stdout")
+        testArgs.capture = CaptureOutput.STDOUT;
+    else
+    {
+        enforce(captureOutputStr == "", "invalid CAPTURE_OUTPUT value; should be stdout, stderr, or empty");
+        testArgs.capture = CaptureOutput.BOTH;
+    }
+
     return true;
 }
 
@@ -310,12 +330,24 @@ void removeIfExists(in char[] filename)
         std.file.remove(filename);
 }
 
-string execute(ref File f, string command, bool expectpass, string result_path)
+string execute(ref File f, string command, bool expectpass, string result_path, CaptureOutput capture)
 {
     auto filename = genTempFilename(result_path);
     scope(exit) removeIfExists(filename);
 
-    auto rc = system(command ~ " > " ~ filename ~ " 2>&1");
+    version(Windows)
+        enum DevNull = "NUL:";
+    else
+        enum DevNull = "/dev/null";
+
+    string commandstr;
+    if (capture == CaptureOutput.STDOUT)
+        commandstr = command ~ " > " ~ filename ~ " 2> " ~ DevNull;
+    else if (capture == CaptureOutput.STDERR)
+        commandstr = command ~ " 2> " ~ filename ~ " > " ~ DevNull;
+    else
+        commandstr = command ~ " > " ~ filename ~ " 2>&1";
+    auto rc = system(commandstr);
 
     string output = readText(filename);
     f.writeln(command);
@@ -559,7 +591,7 @@ int main(string[] args)
                         join(testArgs.sources, " "));
                 version(Windows) command ~= " -map nul.map";
 
-                compile_output = execute(fThisRun, command, testArgs.mode != TestMode.FAIL_COMPILE, result_path);
+                compile_output = execute(fThisRun, command, testArgs.mode != TestMode.FAIL_COMPILE, result_path, testArgs.capture);
             }
             else
             {
@@ -570,7 +602,7 @@ int main(string[] args)
 
                     string command = format("%s -conf= -m%s -I%s %s %s -od%s -c %s", envData.dmd, envData.model, input_dir,
                         reqArgs, c, output_dir, filename);
-                    compile_output ~= execute(fThisRun, command, testArgs.mode != TestMode.FAIL_COMPILE, result_path);
+                    compile_output ~= execute(fThisRun, command, testArgs.mode != TestMode.FAIL_COMPILE, result_path, testArgs.capture);
                 }
 
                 if (testArgs.mode == TestMode.RUN)
@@ -580,7 +612,7 @@ int main(string[] args)
                             testArgs.requiredArgsForLink, output_dir, test_app_dmd, join(toCleanup, " "));
                     version(Windows) command ~= " -map nul.map";
 
-                    execute(fThisRun, command, true, result_path);
+                    execute(fThisRun, command, true, result_path, testArgs.capture);
                 }
             }
 
@@ -612,7 +644,7 @@ int main(string[] args)
                     string command = test_app_dmd;
                     if (testArgs.executeArgs) command ~= " " ~ testArgs.executeArgs;
 
-                    execute(fThisRun, command, true, result_path);
+                    execute(fThisRun, command, true, result_path, testArgs.capture);
                 }
                 else version (linux)
                 {
@@ -621,7 +653,7 @@ int main(string[] args)
                     with (File(script, "w"))
                         write(testArgs.gdbScript);
                     string command = "gdb "~test_app_dmd~" --batch -x "~script;
-                    auto gdb_output = execute(fThisRun, command, true, result_path);
+                    auto gdb_output = execute(fThisRun, command, true, result_path, testArgs.capture);
                     if (testArgs.gdbMatch !is null)
                     {
                         enforce(match(gdb_output, regex(testArgs.gdbMatch)),
@@ -637,7 +669,7 @@ int main(string[] args)
                 f.write("Executing post-test script: ");
                 string prefix = "";
                 version (Windows) prefix = "bash ";
-                execute(f, prefix ~ testArgs.postScript ~ " " ~ thisRunName, true, result_path);
+                execute(f, prefix ~ testArgs.postScript ~ " " ~ thisRunName, true, result_path, testArgs.capture);
             }
 
             foreach (file; toCleanup) collectException(std.file.remove(file));


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9960

This fix allows you to fix issues in templates. Without the fix, specifying "-de" on the command line will silently drop templates from being instantiated, resulting in either the application of a different template, or a fatal template instantiation error.
