### PR TITLE
Bug 259 Comparing signed to unsigned does not generate an error

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -3622,8 +3622,8 @@ IntRange getIntRange(Expression *e)
         {
             Expression *ie;
             VarDeclaration* vd = e->var->isVarDeclaration();
-            if (vd && vd->range)
-                range = vd->range->cast(e->type);
+            if (vd && vd->rangeStack)
+                range = vd->rangeStack->range.cast(e->type);
             else if (vd && vd->init && !vd->type->isMutable() &&
                 (ie = vd->getConstInitializer()) != NULL)
                 ie->accept(this);

--- a/src/conditionvisitor.c
+++ b/src/conditionvisitor.c
@@ -1,0 +1,102 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2014 by Digital Mars
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/expression.c
+ */
+
+#include "conditionvisitor.h"
+
+static TOK invertOp(TOK op)
+{
+    switch (op)
+    {
+    case TOKlt:
+        return TOKge;
+    case TOKle:
+        return TOKgt;
+    case TOKgt:
+        return TOKle;
+    case TOKge:
+        return TOKlt;
+    case TOKequal:
+        return TOKnotequal;
+    case TOKnotequal:
+        return TOKequal;
+    default:
+        assert(0);
+    }
+}
+
+static void fixupRanges(IntRange& v1, TOK op, IntRange& v2)
+{
+    switch (op)
+    {
+    case TOKle:
+        v1 = IntRange(v1.imin, v2.imax <= v1.imax ? v2.imax : v1.imax);
+        v2 = IntRange(v1.imin >= v2.imin ? v1.imin : v2.imin, v2.imax);
+        break;
+    case TOKlt:
+        v1 = IntRange(v1.imin, v2.imax <= v1.imax ? v2.imax - 1 : v1.imax);
+        v2 = IntRange(v1.imin >= v2.imin ? v1.imin + 1 : v2.imin, v2.imax);
+        break;
+    case TOKge:
+        v1 = IntRange(v2.imin >= v1.imin ? v2.imin : v1.imin, v1.imax);
+        v2 = IntRange(v2.imin, v1.imax <= v2.imax ? v1.imax : v2.imax);
+        break;
+    case TOKgt:
+        v1 = IntRange(v2.imin >= v1.imin ? v2.imin + 1 : v1.imin, v1.imax);
+        v2 = IntRange(v2.imin, v1.imax <= v2.imax ? v1.imax - 1: v2.imax);
+        break;
+    case TOKequal:
+        v2 = v1 = v1.intersectWith(v2);
+        break;
+    case TOKnotequal:
+        if (v1.imin == v1.imax)
+            v2 = IntRange(v2.imin + (v1.imin == v2.imin), v2.imax - (v1.imax == v2.imax));
+        else if (v2.imin == v2.imax)
+            v1 = IntRange(v1.imin + (v1.imin == v2.imin), v1.imax - (v1.imax == v2.imax));
+        break;
+    default:
+        assert(0);
+    }
+}
+
+VarDeclaration *ConditionVisitor::getVarDecl(Expression *e)
+{
+    if (e->op == TOKcast)
+        e = ((CastExp *)e)->e1;//FIXME unsafe
+    VarDeclaration *vd = e->op == TOKvar && e->type->isscalar() ? ((VarExp *)e)->var->isVarDeclaration() : NULL;
+    return vd && !vd->type->isMutable() ? vd : NULL;
+}
+
+void ConditionVisitor::push(Expression *e1, TOK op, Expression *e2)
+{
+    VarDeclaration *vd1 = getVarDecl(e1);
+    VarDeclaration *vd2 = e2 ? getVarDecl(e2) : NULL;
+    if (vd1 || vd2)
+    {
+        IntRange r1 = getIntRange(e1);
+        IntRange r2 = e2 ? getIntRange(e2) : IntRange(0, 0);
+        fixupRanges(r1, invert ? invertOp(op) : op, r2);
+        pushRange(vd1, r1);
+        pushRange(vd2, r2);
+    }
+}
+
+void ConditionVisitor::pushRange(VarDeclaration *vd, IntRange ir)
+{
+    if (ir.imin > ir.imax)
+    {
+        deadcode = true;
+    }
+    else if (vd)
+    {
+        vd->rangeStack = new IntRangeList(ir.imin, ir.imax, vd->rangeStack);
+        toPop.push(vd);
+    }
+}

--- a/src/conditionvisitor.h
+++ b/src/conditionvisitor.h
@@ -1,0 +1,93 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2014 by Digital Mars
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/lexer.h
+ */
+
+#ifndef DMD_CONDITIONVISITOR_H
+#define DMD_CONDITIONVISITOR_H
+
+#ifdef __DMC__
+#pragma once
+#endif /* __DMC__ */
+
+#include "expression.h"
+#include "declaration.h"
+
+class ConditionVisitor : public Visitor
+{
+public:
+    bool invert;
+    bool deadcode;
+
+    ConditionVisitor() : invert(false), deadcode(false) { }
+
+    void visit(Expression *e) { }
+
+    void visit(CastExp *e)
+    {
+        push(e, TOKnotequal, NULL);
+    }
+
+    void visit(EqualExp *e)
+    {
+        push(e->e1, e->op, e->e2);
+    }
+
+    void visit(CmpExp *e)
+    {
+        push(e->e1, e->op, e->e2);
+    }
+
+    void visit(VarExp *e)
+    {
+        push(e, TOKnotequal, NULL);
+    }
+
+    void visit(NotExp *e)
+    {
+        invert = !invert;
+        e->e1->accept(this);
+        invert = !invert;
+    }
+
+    void visit(OrOrExp *e)
+    {
+        if (invert)
+        {
+            e->e1->accept(this);
+            e->e2->accept(this);
+        }
+    }
+
+    void visit(AndAndExp *e)
+    {
+        if (!invert)
+        {
+            e->e1->accept(this);
+            e->e2->accept(this);
+        }
+    }
+
+    void popRanges()
+    {
+        for (int i=0; i<toPop.dim; ++i)
+        {
+            toPop[i]->rangeStack = toPop[i]->rangeStack->next;
+        }
+    }
+
+private:
+    Array<VarDeclaration *> toPop;
+    VarDeclaration *getVarDecl(Expression *e);
+
+    void push(Expression *e1, TOK op, Expression *e2);
+    void pushRange(VarDeclaration *vd, IntRange ir);
+};
+
+#endif

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -985,6 +985,62 @@ UnionExp Identity(TOK op, Type *type, Expression *e1, Expression *e2)
 }
 
 
+static bool unsignedCmp(d_uns64 n1, TOK op, d_uns64 n2)
+{
+    switch (op)
+    {
+        case TOKlt:     return n1 <  n2;
+        case TOKle:     return n1 <= n2;
+        case TOKgt:     return n1 >  n2;
+        case TOKge:     return n1 >= n2;
+
+        case TOKleg:    return 1;
+        case TOKlg:     return n1 != n2;
+        case TOKunord:  return 0;
+        case TOKue:     return n1 == n2;
+        case TOKug:     return n1 >  n2;
+        case TOKuge:    return n1 >= n2;
+        case TOKul:     return n1 <  n2;
+        case TOKule:    return n1 <= n2;
+
+        default:
+            assert(0);
+    }
+}
+
+static bool signedCmp(sinteger_t n1, TOK op, sinteger_t n2)
+{
+    switch (op)
+    {
+        case TOKlt:     return n1 <  n2;
+        case TOKle:     return n1 <= n2;
+        case TOKgt:     return n1 >  n2;
+        case TOKge:     return n1 >= n2;
+
+        case TOKleg:    return 1;
+        case TOKlg:     return n1 != n2;
+        case TOKunord:  return 0;
+        case TOKue:     return n1 == n2;
+        case TOKug:     return n1 >  n2;
+        case TOKuge:    return n1 >= n2;
+        case TOKul:     return n1 <  n2;
+        case TOKule:    return n1 <= n2;
+
+        default:
+            assert(0);
+    }
+}
+
+static bool integerCmp(bool anyunsigned, sinteger_t n1, TOK op, sinteger_t n2)
+{
+    /* Do an unsigned comparison if any of the integers is unsigned. */
+    if (anyunsigned)
+        return unsignedCmp(n1, op, n2);
+    else
+        return signedCmp(n1, op, n2);
+}
+
+
 UnionExp Cmp(TOK op, Type *type, Expression *e1, Expression *e2)
 {
     UnionExp ue;
@@ -1030,19 +1086,26 @@ UnionExp Cmp(TOK op, Type *type, Expression *e1, Expression *e2)
                 assert(0);
         }
     }
-    else if (e1->isConst() != 1 || e2->isConst() != 1)
-    {
-        new(&ue) CTFEExp(TOKcantexp);
-        return ue;
-    }
     else if (e1->type->isreal())
     {
+        if (e1->isConst() != 1 || e2->isConst() != 1)
+        {
+            new(&ue) CTFEExp(TOKcantexp);
+            return ue;
+        }
+
         r1 = e1->toReal();
         r2 = e2->toReal();
         goto L1;
     }
     else if (e1->type->isimaginary())
     {
+        if (e1->isConst() != 1 || e2->isConst() != 1)
+        {
+            new(&ue) CTFEExp(TOKcantexp);
+            return ue;
+        }
+
         r1 = e1->toImaginary();
         r2 = e2->toImaginary();
      L1:
@@ -1097,57 +1160,68 @@ UnionExp Cmp(TOK op, Type *type, Expression *e1, Expression *e2)
     {
         assert(0);
     }
+    else if (e1->isConst() != 1 || e2->isConst() != 1)
+    {
+        /* Use VRP to determine whether the comparison is always true or false. */
+        bool anyunsigned = (e1->type->isunsigned() || e2->type->isunsigned());
+        IntRange r1 = getIntRange(e1);
+        IntRange r2 = getIntRange(e2);
+        switch (op)
+        {
+            case TOKul:
+            case TOKule:
+            case TOKlt:
+            case TOKle:
+                if (integerCmp(anyunsigned, r1.imax.value, op, r2.imin.value))
+                    n = 1;
+                else if (integerCmp(anyunsigned, r1.imin.value, op, r2.imax.value))
+                {
+                    new(&ue) CTFEExp(TOKcantexp);
+                    return ue;
+                }
+                else
+                    n = 0;
+                break;
+
+            case TOKug:
+            case TOKuge:
+            case TOKgt:
+            case TOKge:
+                if (integerCmp(anyunsigned, r1.imin.value, op, r2.imax.value))
+                    n = 1;
+                else if (integerCmp(anyunsigned, r1.imax.value, op, r2.imin.value))
+                {
+                    new(&ue) CTFEExp(TOKcantexp);
+                    return ue;
+                }
+                else
+                    n = 0;
+                break;
+
+            case TOKleg:
+                n = 1;
+                break;
+
+            case TOKunord:
+                n = 0;
+                break;
+
+            case TOKue:
+            case TOKlg:
+                new(&ue) CTFEExp(TOKcantexp);
+                return ue;
+
+            default:
+                assert(0);
+        }
+    }
     else
     {
-        sinteger_t n1;
-        sinteger_t n2;
+        sinteger_t n1 = e1->toInteger();
+        sinteger_t n2 = e2->toInteger();
 
-        n1 = e1->toInteger();
-        n2 = e2->toInteger();
-        if (e1->type->isunsigned() || e2->type->isunsigned())
-        {
-            switch (op)
-            {
-                case TOKlt:     n = ((d_uns64) n1) <  ((d_uns64) n2);   break;
-                case TOKle:     n = ((d_uns64) n1) <= ((d_uns64) n2);   break;
-                case TOKgt:     n = ((d_uns64) n1) >  ((d_uns64) n2);   break;
-                case TOKge:     n = ((d_uns64) n1) >= ((d_uns64) n2);   break;
-
-                case TOKleg:    n = 1;                                  break;
-                case TOKlg:     n = ((d_uns64) n1) != ((d_uns64) n2);   break;
-                case TOKunord:  n = 0;                                  break;
-                case TOKue:     n = ((d_uns64) n1) == ((d_uns64) n2);   break;
-                case TOKug:     n = ((d_uns64) n1) >  ((d_uns64) n2);   break;
-                case TOKuge:    n = ((d_uns64) n1) >= ((d_uns64) n2);   break;
-                case TOKul:     n = ((d_uns64) n1) <  ((d_uns64) n2);   break;
-                case TOKule:    n = ((d_uns64) n1) <= ((d_uns64) n2);   break;
-
-                default:
-                    assert(0);
-            }
-        }
-        else
-        {
-            switch (op)
-            {
-                case TOKlt:     n = n1 <  n2;   break;
-                case TOKle:     n = n1 <= n2;   break;
-                case TOKgt:     n = n1 >  n2;   break;
-                case TOKge:     n = n1 >= n2;   break;
-
-                case TOKleg:    n = 1;          break;
-                case TOKlg:     n = n1 != n2;   break;
-                case TOKunord:  n = 0;          break;
-                case TOKue:     n = n1 == n2;   break;
-                case TOKug:     n = n1 >  n2;   break;
-                case TOKuge:    n = n1 >= n2;   break;
-                case TOKul:     n = n1 <  n2;   break;
-                case TOKule:    n = n1 <= n2;   break;
-
-                default:
-                    assert(0);
-            }
-        }
+        bool anyunsigned = (e1->type->isunsigned() || e2->type->isunsigned());
+        n = integerCmp(anyunsigned, n1, op, n2);
     }
     new(&ue) IntegerExp(loc, n, type);
     return ue;

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -759,7 +759,7 @@ VarDeclaration::VarDeclaration(Loc loc, Type *type, Identifier *id, Initializer 
     ctfeAdrOnStack = -1;
     rundtor = NULL;
     edtor = NULL;
-    range = NULL;
+    rangeStack = NULL;
 }
 
 Dsymbol *VarDeclaration::syntaxCopy(Dsymbol *s)

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -232,6 +232,12 @@ public:
 };
 
 /**************************************************************/
+struct IntRangeList
+{
+    IntRangeList(SignExtendedNumber lower, SignExtendedNumber upper, IntRangeList *n = NULL) : range(lower, upper), next(n) {}
+    IntRange range;
+    IntRangeList *next;
+};
 
 class VarDeclaration : public Declaration
 {
@@ -258,7 +264,7 @@ public:
                                 // if the destructor should be run. Used to prevent
                                 // dtor calls on postblitted vars
     Expression *edtor;          // if !=NULL, does the destruction of the variable
-    IntRange *range;            // if !NULL, the variable is known to be within the range
+    IntRangeList *rangeStack;   // if !NULL, the variable is known to be within the range
 
     VarDeclaration(Loc loc, Type *t, Identifier *id, Initializer *init);
     Dsymbol *syntaxCopy(Dsymbol *);

--- a/src/expression.c
+++ b/src/expression.c
@@ -41,6 +41,7 @@
 #include "aav.h"
 #include "nspace.h"
 #include "ctfe.h"
+#include "conditionvisitor.h"
 
 bool typeMerge(Scope *sc, TOK op, Type **pt, Expression **pe1, Expression **pe2);
 bool isArrayOpValid(Expression *e);
@@ -12901,6 +12902,7 @@ Expression *UshrExp::semantic(Scope *sc)
     if (type)
         return this;
 
+    // TODO: if e1 is a comparison with a variable, push range before and pop after e2->semantic
     if (Expression *ex = binSemanticProp(sc))
         return ex;
     Expression *e = op_overload(sc);
@@ -13139,9 +13141,12 @@ Expression *AndAndExp::semantic(Scope *sc)
         }
     }
 
+    ConditionVisitor v;
+    e1->accept(&v);
     e2 = e2->semantic(sc);
     sc->mergeCallSuper(loc, cs1);
     e2 = resolveProperties(sc, e2);
+    v.popRanges();//should not be here; move to scope?
 
     if (e2->type->ty == Tvoid)
         type = Type::tvoid;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2238,6 +2238,13 @@ public:
                     return CTFEExp::cantexp;
             }
 
+            if (v->rangeStack && v->rangeStack->range.imin == v->rangeStack->range.imax)
+            {
+                /* Variable only has a single possible value in this scope
+                 */
+                return new IntegerExp(loc, v->rangeStack->range.imax.value, v->type);
+            }
+
             if ((v->isConst() || v->isImmutable() || v->storage_class & STCmanifest) &&
                 !hasValue(v) &&
                 v->init && !v->isCTFE())

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2245,6 +2245,13 @@ public:
                 return new IntegerExp(loc, v->rangeStack->range.imax.value, v->type);
             }
 
+            if (v->rangeStack && v->rangeStack->range.imin == v->rangeStack->range.imax)
+            {
+                /* Variable only has a single possible value in this scope
+                 */
+                return new IntegerExp(loc, v->rangeStack->range.imax.value, v->type);
+            }
+
             if ((v->isConst() || v->isImmutable() || v->storage_class & STCmanifest) &&
                 !hasValue(v) &&
                 v->init && !v->isCTFE())

--- a/src/intrange.c
+++ b/src/intrange.c
@@ -429,6 +429,12 @@ IntRange IntRange::unionWith(const IntRange& other) const
                     imax > other.imax ? imax : other.imax);
 }
 
+IntRange IntRange::intersectWith(const IntRange& other) const
+{
+    return IntRange(imin > other.imin ? imin : other.imin,
+                    imax < other.imax ? imax : other.imax);
+}
+
 void IntRange::unionOrAssign(const IntRange& other, bool& union_)
 {
     if (!union_ || imin > other.imin)

--- a/src/intrange.h
+++ b/src/intrange.h
@@ -148,6 +148,9 @@ struct IntRange
     /// Split the range into two nonnegative- and negative-only subintervals.
     void splitBySign(IntRange& negRange, bool& hasNegRange,
                      IntRange& nonNegRange, bool& hasNonNegRange) const;
+
+    /// Compute the intersection of two ranges.
+    IntRange intersectWith(const IntRange& other) const;
 };
 
 #endif

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -143,7 +143,7 @@ DMD_OBJS = \
 	arrayop.o json.o unittests.o \
 	imphint.o argtypes.o apply.o sapply.o sideeffect.o \
 	intrange.o canthrow.o target.o nspace.o errors.o \
-	escape.o tokens.o globals.o
+	escape.o tokens.o globals.o conditionvisitor.o
 
 ROOT_OBJS = \
 	rmem.o port.o man.o stringtable.o response.o \

--- a/src/statement.c
+++ b/src/statement.c
@@ -31,6 +31,7 @@
 #include "template.h"
 #include "attrib.h"
 #include "import.h"
+#include "conditionvisitor.h"
 
 bool walkPostorder(Statement *s, StoppableVisitor *v);
 StorageClass mergeFuncAttrs(StorageClass s1, FuncDeclaration *f);
@@ -1917,7 +1918,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
                             error("index type '%s' cannot cover index range 0..%llu", p->type->toChars(), ta->dim->toInteger());
                             goto Lerror2;
                         }
-                        key->range = new IntRange(SignExtendedNumber(0), dimrange.imax);
+                        key->rangeStack = new IntRangeList(0, dimrange.imax);
                     }
                 }
                 else
@@ -2017,7 +2018,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
                 Parameter *p = (*parameters)[0];
                 if ((p->storageClass & STCref) && p->type->equals(key->type))
                 {
-                    key->range = NULL;
+                    key->rangeStack = NULL;
                     AliasDeclaration *v = new AliasDeclaration(loc, p->ident, key);
                     body = new CompoundStatement(loc, new ExpStatement(loc, v), body);
                 }
@@ -2027,11 +2028,11 @@ Statement *ForeachStatement::semantic(Scope *sc)
                     VarDeclaration *v = new VarDeclaration(loc, p->type, p->ident, ei);
                     v->storage_class |= STCforeach | (p->storageClass & STCref);
                     body = new CompoundStatement(loc, new ExpStatement(loc, v), body);
-                    if (key->range && !p->type->isMutable())
+                    if (key->rangeStack && !p->type->isMutable())
                     {
                         /* Limit the range of the key to the specified range
                          */
-                        v->range = new IntRange(key->range->imin, key->range->imax - SignExtendedNumber(1));
+                        v->rangeStack = new IntRangeList(key->rangeStack->range.imin, key->rangeStack->range.imax - SignExtendedNumber(1));
                     }
                 }
             }
@@ -2687,7 +2688,7 @@ Statement *ForeachRangeStatement::semantic(Scope *sc)
     SignExtendedNumber upper = getIntRange(upr).imax;
     if (lower <= upper)
     {
-        key->range = new IntRange(lower, upper);
+        key->rangeStack = new IntRangeList(lower, upper);
     }
 
     Identifier *id = Identifier::generateId("__limit");
@@ -2746,7 +2747,7 @@ Statement *ForeachRangeStatement::semantic(Scope *sc)
 
     if ((prm->storageClass & STCref) && prm->type->equals(key->type))
     {
-        key->range = NULL;
+        key->rangeStack = NULL;
         AliasDeclaration *v = new AliasDeclaration(loc, prm->ident, key);
         body = new CompoundStatement(loc, new ExpStatement(loc, v), body);
     }
@@ -2756,11 +2757,11 @@ Statement *ForeachRangeStatement::semantic(Scope *sc)
         VarDeclaration *v = new VarDeclaration(loc, prm->type, prm->ident, ie);
         v->storage_class |= STCtemp | STCforeach | (prm->storageClass & STCref);
         body = new CompoundStatement(loc, new ExpStatement(loc, v), body);
-        if (key->range && !prm->type->isMutable())
+        if (key->rangeStack && !prm->type->isMutable())
         {
             /* Limit the range of the key to the specified range
              */
-            v->range = new IntRange(key->range->imin, key->range->imax - SignExtendedNumber(1));
+            v->rangeStack = new IntRangeList(key->rangeStack->range.imin, key->rangeStack->range.imax - SignExtendedNumber(1));
         }
     }
     if (prm->storageClass & STCref)
@@ -2836,13 +2837,13 @@ Statement *IfStatement::semantic(Scope *sc)
         condition = new CommaExp(loc, de, ve);
         condition = condition->semantic(scd);
 
-       if (match->edtor)
-       {
+        if (match->edtor)
+        {
             Statement *sdtor = new ExpStatement(loc, match->edtor);
             sdtor = new OnScopeStatement(loc, TOKon_scope_exit, sdtor);
             ifbody = new CompoundStatement(loc, sdtor, ifbody);
             match->noscope = 1;
-       }
+        }
     }
     else
     {
@@ -2857,21 +2858,32 @@ Statement *IfStatement::semantic(Scope *sc)
     // where S is a struct that defines opCast!bool.
     condition = condition->toBoolean(sc);
 
-    // If we can short-circuit evaluate the if statement, don't do the
-    // semantic analysis of the skipped code.
-    // This feature allows a limited form of conditional compilation.
-    condition = condition->optimize(WANTvalue);
+    ConditionVisitor v;
+    condition->accept(&v);
+
     ifbody = ifbody->semanticNoScope(scd);
     scd->pop();
+    v.popRanges();
 
     cs1 = sc->callSuper;
     fi1 = sc->fieldinit;
     sc->callSuper = cs0;
     sc->fieldinit = fi0;
     if (elsebody)
+    {
+        ConditionVisitor vi;
+        vi.invert = true;
+        condition->accept(&vi);
         elsebody = elsebody->semanticScope(sc, NULL, NULL);
+        vi.popRanges();
+    }
     sc->mergeCallSuper(loc, cs1);
     sc->mergeFieldInit(loc, fi1);
+
+    // If we can short-circuit evaluate the if statement, don't do the
+    // semantic analysis of the skipped code.
+    // This feature allows a limited form of conditional compilation.
+    condition = condition->optimize(WANTvalue);
 
     if (condition->op == TOKerror ||
         (ifbody && ifbody->isErrorStatement()) ||

--- a/src/traits.c
+++ b/src/traits.c
@@ -39,7 +39,6 @@
 
 #define LOGSEMANTIC     0
 
-
 /************************************************
  * Delegate to be passed to overloadApply() that looks
  * for functions matching a trait.

--- a/test/compilable/bug259.d
+++ b/test/compilable/bug259.d
@@ -1,0 +1,48 @@
+// REQUIRED_ARGS: -de
+short s;
+ushort us;
+int i;
+uint ui;
+long l;
+ulong ul;
+// 0. same-signed-ness
+static assert(__traits(compiles, ui>ul));
+static assert(__traits(compiles, ul>ui));
+static assert(__traits(compiles, i>l));
+static assert(__traits(compiles, l>i));
+static assert(!(1>2));
+static assert(2>1);
+static assert(!(-1>2));
+static assert(2>-1);
+// 1. sizeof(signed) > sizeof(unsigned)
+static assert(__traits(compiles, l>ui));
+static assert(__traits(compiles, ui>l));
+static assert(!(-1L>2));
+static assert(2>-1L);
+// 1b. sizeof(common) > sizeof(either)
+static assert(__traits(compiles, s>us));
+static assert(__traits(compiles, us>s));
+static assert(!(cast(short)-1>cast(ushort)2));
+static assert(cast(ushort)2>cast(short)-1);
+// 2. signed.min >= 0
+static assert(__traits(compiles, ui>cast(int)2));
+static assert(__traits(compiles, cast(int)2>ui));
+static assert(__traits(compiles, ul>cast(int)2));
+static assert(__traits(compiles, cast(int)2>ul));
+// 3. unsigned.max < typeof(unsigned.max/2) => ERROR
+static assert(!__traits(compiles, i>cast(uint)2));
+static assert(!__traits(compiles, cast(uint)2>i));
+static assert(!__traits(compiles, cast(int)-1>cast(uint)3));
+static assert(!__traits(compiles, cast(uint)3>cast(int)-1));
+static assert(!__traits(compiles, -1>2UL));
+static assert(!__traits(compiles, 2UL>-1));
+// error
+static assert(!__traits(compiles, ul>-2));
+static assert(!__traits(compiles, -2>ul));
+static assert(!__traits(compiles, i>ul));
+static assert(!__traits(compiles, ul>i));
+static assert(!__traits(compiles, l>ul));
+static assert(!__traits(compiles, ul>l));
+static assert(!__traits(compiles, i>ui));
+static assert(!__traits(compiles, ui>i));
+

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -329,3 +329,9 @@ void test13001(bool unknown)
         static assert(!__traits(compiles, b = i + 254));
     }
 }
+
+void test13010(ubyte value)
+{
+    immutable int i = value;
+    static assert(i + 1 > 0);
+}

--- a/test/compilable/testifelserange.d
+++ b/test/compilable/testifelserange.d
@@ -1,0 +1,90 @@
+import std.traits : Unqual;
+alias Tuple(T...) = T;
+
+void test(T,int Q)(bool unknown)
+{
+    static if (Q)
+    {
+      Unqual!T ii = unknown ? 33 : -1;
+      T i = ii;
+    }
+    else
+    {
+      T i = unknown ? -1 : 33;
+    }
+
+    if (i)
+    {
+      static assert(Q || i >= -1);
+      static assert(Q || i <= 33);
+    }
+    else
+    {
+      static assert(i == 0);
+    }
+
+    if (i == 33)
+    {
+      static assert(i == 33);
+    }
+    else
+    {
+      static assert(Q || i >= -1);
+      static assert(Q || i <= 32);
+    }
+
+    if (i != 33)
+    {
+      static assert(Q || i >= -1);
+      static assert(Q || i <= 32);
+    }
+    else
+    {
+      static assert(i == 33);
+    }
+
+    if (10 <= i)
+    {
+      static assert(i >= 10);
+      static assert(i <= (Q?T.max:33));
+    }
+    else
+    {
+      static assert(i >= (Q?T.min:-1));
+      static assert(i <= 9);
+    }
+
+    if (i > 10)
+    {
+      static assert(i >= 11);
+      static assert(i <= (Q?T.max:33));
+    }
+    else
+    {
+      static assert(i >= (Q?T.min:-1));
+      static assert(i <= 10);
+    }
+
+    if (!i)
+    {
+      static assert(i == 0);
+    }
+    else
+    {
+      static assert(Q || i >= -1);
+      static assert(Q || i <= 33);
+    }
+}
+
+void main(string[] args)
+{
+    test!(immutable int, 0)(args.length < 1);
+    test!(const int, 0)(args.length < 1);
+    test!(immutable(int), 0)(args.length < 1);
+    test!(const(int), 0)(args.length < 1);
+
+    test!(immutable int, 1)(args.length < 1);
+    test!(const int, 1)(args.length < 1);
+    test!(immutable(int), 1)(args.length < 1);
+    test!(const(int), 1)(args.length < 1);
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=259

Consider a comparison a < b, a <= b, a > b, or a >= b, in which a and b are
integral types of different signedness. Without loss of generality, let's
consider a is signed and b is unsigned and the comparison is a < b. Then we
have the following cases:
1. If a.sizeof > b.sizeof, then a < b is lowered into a < cast(typeof(a)) b.
   Then signed comparison proceeds normally. This is a classic value-based
   conversion dating from the C days, and we do it in D as well.
2. If the sizeof common type of a and b is bigger than both sizeof(a) and sizeof(b), both a and b can be safely cast to the bigger [signed] type and the comparison proceeds normally.
3. Otherwise, if a is determined through Value Range Propagation to be greater
   than or equal to zero, then a < b is lowered into cast(U) a < b, where U is the
   unsigned variant of typeof(a). Then unsigned comparison proceeds normally.
4. Otherwise, the comparison is in error. 

Using deprecation() since warnings and errors during template instantiations are suppressed and the final "errors instantiating template" doesn't say why ( http://d.puremagic.com/issues/show_bug.cgi?id=9960 ) 
