### PR TITLE
Add check that 'struct ModuleInfo' exists in object.d

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -218,11 +218,13 @@ ClassDeclaration::ClassDeclaration(Loc loc, Identifier *id, BaseClasses *basecla
             classinfo = this;
         }
 
+#if !MODULEINFO_IS_STRUCT
         if (id == Id::ModuleInfo)
         {   if (Module::moduleinfo)
                 Module::moduleinfo->error("%s", msg);
             Module::moduleinfo = this;
         }
+#endif
     }
 
     com = 0;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -108,6 +108,8 @@ int overloadApply(FuncDeclaration *fstart,
         int (*fp)(void *, FuncDeclaration *),
         void *param);
 
+void ObjectNotFound(Identifier *id);
+
 enum Semantic
 {
     SemanticStart,      // semantic has not been run

--- a/src/module.c
+++ b/src/module.c
@@ -27,7 +27,7 @@
 #include "d-dmd-gcc.h"
 #endif
 
-ClassDeclaration *Module::moduleinfo;
+AggregateDeclaration *Module::moduleinfo;
 
 Module *Module::rootModule;
 DsymbolTable *Module::modules;

--- a/src/module.h
+++ b/src/module.h
@@ -54,7 +54,7 @@ struct Module : Package
     static unsigned dprogress;  // progress resolving the deferred list
     static void init();
 
-    static ClassDeclaration *moduleinfo;
+    static AggregateDeclaration *moduleinfo;
 
 
     const char *arg;    // original argument name

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -47,8 +47,6 @@
 #include "hdrgen.h"
 
 FuncDeclaration *hasThis(Scope *sc);
-void ObjectNotFound(Identifier *id);
-
 
 #define LOGDOTEXP       0       // log ::dotExp()
 #define LOGDEFAULTINIT  0       // log ::defaultInit()

--- a/src/struct.c
+++ b/src/struct.c
@@ -427,6 +427,14 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
 
     // For forward references
     type = new TypeStruct(this);
+
+#if MODULEINFO_IS_STRUCT
+    if (id == Id::ModuleInfo)
+    {   if (Module::moduleinfo)
+            Module::moduleinfo->error("only object.d can define this reserved struct name");
+        Module::moduleinfo = this;
+    }
+#endif
 }
 
 Dsymbol *StructDeclaration::syntaxCopy(Dsymbol *s)

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -49,6 +49,11 @@ void Module::genmoduleinfo()
 {
     //printf("Module::genmoduleinfo() %s\n", toChars());
 
+    if (! Module::moduleinfo)
+    {
+        ObjectNotFound(Id::ModuleInfo);
+    }
+
     Symbol *msym = toSymbol();
 #if DMDV2
     unsigned sizeof_ModuleInfo = 16 * Target::ptrsize;


### PR DESCRIPTION
Makes Module::moduleinfo an AggregateDeclaration, sets it's value if found in object.d, and checks that it exists before generating the moduleinfo.

Knowing what type 'struct ModuleInfo' will be helpful for gdc in some related fixes in porting to ARM.
