### PR TITLE
Remove struct ModuleInfoDeclaration.

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -2314,25 +2314,6 @@ void ClassInfoDeclaration::semantic(Scope *sc)
 {
 }
 
-/********************************* ModuleInfoDeclaration ****************************/
-
-ModuleInfoDeclaration::ModuleInfoDeclaration(Module *mod)
-    : VarDeclaration(Loc(), Module::moduleinfo->type, mod->ident, NULL)
-{
-    this->mod = mod;
-    storage_class = STCstatic | STCgshared;
-}
-
-Dsymbol *ModuleInfoDeclaration::syntaxCopy(Dsymbol *s)
-{
-    assert(0);          // should never be produced by syntax
-    return NULL;
-}
-
-void ModuleInfoDeclaration::semantic(Scope *sc)
-{
-}
-
 /********************************* TypeInfoDeclaration ****************************/
 
 TypeInfoDeclaration::TypeInfoDeclaration(Type *tinfo, int internal)

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -358,21 +358,6 @@ public:
     Symbol *toSymbol();
 };
 
-class ModuleInfoDeclaration : public VarDeclaration
-{
-public:
-    Module *mod;
-
-    ModuleInfoDeclaration(Module *mod);
-    Dsymbol *syntaxCopy(Dsymbol *);
-    void semantic(Scope *sc);
-
-    void emitComment(Scope *sc);
-    void toJson(JsonOut *json);
-
-    Symbol *toSymbol();
-};
-
 class TypeInfoDeclaration : public VarDeclaration
 {
 public:

--- a/src/doc.c
+++ b/src/doc.c
@@ -661,7 +661,6 @@ void DtorDeclaration::emitComment(Scope *sc)       { }
 void StaticCtorDeclaration::emitComment(Scope *sc) { }
 void StaticDtorDeclaration::emitComment(Scope *sc) { }
 void ClassInfoDeclaration::emitComment(Scope *sc)  { }
-void ModuleInfoDeclaration::emitComment(Scope *sc) { }
 void TypeInfoDeclaration::emitComment(Scope *sc)   { }
 
 

--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -54,12 +54,6 @@ Symbol *ClassInfoDeclaration::toSymbol()
     return NULL;
 }
 
-Symbol *ModuleInfoDeclaration::toSymbol()
-{
-    assert(0);
-    return NULL;
-}
-
 Symbol *TypeInfoDeclaration::toSymbol()
 {
     assert(0);

--- a/src/json.c
+++ b/src/json.c
@@ -806,7 +806,6 @@ void ConditionalDeclaration::toJson(JsonOut *json)
 
 
 void ClassInfoDeclaration::toJson(JsonOut *json)  { }
-void ModuleInfoDeclaration::toJson(JsonOut *json) { }
 void TypeInfoDeclaration::toJson(JsonOut *json)   { }
 #if DMDV2
 void PostBlitDeclaration::toJson(JsonOut *json)   { }

--- a/src/module.c
+++ b/src/module.c
@@ -63,7 +63,6 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
     semanticstarted = 0;
     semanticRun = 0;
     decldefs = NULL;
-    vmoduleinfo = NULL;
     massert = NULL;
     munittest = NULL;
     marray = NULL;

--- a/src/module.h
+++ b/src/module.h
@@ -18,7 +18,6 @@
 #include "root.h"
 #include "dsymbol.h"
 
-class ModuleInfoDeclaration;
 class ClassDeclaration;
 struct ModuleDeclaration;
 struct Macro;
@@ -91,8 +90,6 @@ public:
     Dsymbols *decldefs;         // top level declarations for this Module
 
     Modules aimports;             // all imported modules
-
-    ModuleInfoDeclaration *vmoduleinfo;
 
     unsigned debuglevel;        // debug level
     Strings *debugids;      // debug identifiers

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -314,14 +314,6 @@ Symbol *ClassInfoDeclaration::toSymbol()
 /*************************************
  */
 
-Symbol *ModuleInfoDeclaration::toSymbol()
-{
-    return mod->toSymbol();
-}
-
-/*************************************
- */
-
 Symbol *TypeInfoDeclaration::toSymbol()
 {
     //printf("TypeInfoDeclaration::toSymbol(%s), linkage = %d\n", toChars(), linkage);


### PR DESCRIPTION
Self explanatory, is not used and has no planned future use in the D compiler front-end implementation.
