### PR TITLE
JA to JC, JBE to JNC

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1696,6 +1696,15 @@ int jmpopcode(elem *e)
   }
 
   jp = jops[i][zero][op - OPle];        /* table starts with OPle       */
+
+  /* Try to rewrite unsigned comparisons so they rely on just the Carry flag
+   */
+  if (i == 1 && (jp == JA || jp == JBE) &&
+      (e->E2->Eoper != OPconst && e->E2->Eoper != OPrelconst))
+  {
+        jp = (jp == JA) ? JC : JNC;
+  }
+
 L1:
 #if DEBUG
   if ((jp & 0xF0) != 0x70)


### PR DESCRIPTION
This tries to rewrite comparisons so that JA is replace by JC, and JBE to JNC. This is so that other optimizations that do clever things with the Carry bit can work.

See http://d.puremagic.com/issues/show_bug.cgi?id=9963
