### PR TITLE
Implement proper UFCS name look up

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -685,14 +685,12 @@ Dsymbol *AliasDeclaration::toAlias()
     }
     else if (aliassym || type->deco)
         ;   // semantic is already done.
-    else if (import)
+    else if (import && import->scope)
     {
-        /* If this is an internal alias for selective import,
+        /* If this is an internal alias for selective/renamed import,
          * resolve it under the correct scope.
          */
-        if (import->scope)
-            import->semantic(NULL);
-        import = NULL;
+        import->semantic(NULL);
     }
     else if (scope)
         semantic(scope);

--- a/src/expression.h
+++ b/src/expression.h
@@ -1002,7 +1002,6 @@ struct CallExp : UnaExp
 
     Expression *syntaxCopy();
     int apply(apply_fp_t fp, void *param);
-    Expression *resolveUFCS(Scope *sc);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result, bool keepLvalue = false);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);

--- a/src/import.c
+++ b/src/import.c
@@ -245,7 +245,6 @@ void Import::semantic(Scope *sc)
             if (mod->search(loc, names[i], 0))
             {
                 ad->semantic(sc);
-                ad->import = NULL;  // forward reference resolved
             }
             else
             {

--- a/src/statement.c
+++ b/src/statement.c
@@ -5177,6 +5177,7 @@ Statement *ImportStatement::semantic(Scope *sc)
 
             TypeIdentifier *tname = new TypeIdentifier(s->loc, name);
             AliasDeclaration *ad = new AliasDeclaration(s->loc, alias, tname);
+            ad->import = s;
 
             s->aliasdecls.push(ad);
         }

--- a/test/runnable/imports/ufcs5a.d
+++ b/test/runnable/imports/ufcs5a.d
@@ -1,0 +1,13 @@
+module imports.ufcs5a;
+
+auto f5a1(int)    { return 1; }
+auto f5a2(string) { return 2; }
+auto f5a3(double) { return 3; }
+alias f5a4 = f5a1, f5a4 = f5a2;
+alias f5a5 = f5a3, f5a5 = f5a4;
+
+@property p5a1(int)    { return 1; }    @property p5a1(int,    int) { return 1; }
+@property p5a2(string) { return 2; }    @property p5a2(string, int) { return 2; }
+@property p5a3(double) { return 3; }    @property p5a3(double, int) { return 3; }
+alias p5a4 = p5a1, p5a4 = p5a2;         alias p5a4 = p5a1, p5a4 = p5a2;
+alias p5a5 = p5a3, p5a5 = p5a4;         alias p5a5 = p5a3, p5a5 = p5a4;

--- a/test/runnable/imports/ufcs5b.d
+++ b/test/runnable/imports/ufcs5b.d
@@ -1,0 +1,19 @@
+module imports.ufcs5b;
+
+auto f5b1(int)    { return 1; }
+auto f5b2(string) { return 2; }
+auto f5b3(double) { return 3; }
+alias f5b4 = f5b1, f5b4 = f5b2;
+alias f5b5 = f5b3, f5b5 = f5b4;
+
+@property p5b1(int)    { return 1; }    @property p5b1(int,    int) { return 1; }
+@property p5b2(string) { return 2; }    @property p5b2(string, int) { return 2; }
+@property p5b3(double) { return 3; }    @property p5b3(double, int) { return 3; }
+alias p5b4 = p5b1, p5b4 = p5b2;         alias p5b4 = p5b1, p5b4 = p5b2;
+alias p5b5 = p5b3, p5b5 = p5b4;         alias p5b5 = p5b3, p5b5 = p5b4;
+
+/***************************************/
+
+auto      f5ov(int)      { return 1; }
+@property p5ov(int)      { return 1; }
+@property p5ov(int, int) { return 1; }

--- a/test/runnable/imports/ufcs5c.d
+++ b/test/runnable/imports/ufcs5c.d
@@ -1,0 +1,19 @@
+module imports.ufcs5c;
+
+auto f5c1(int)    { return 1; }
+auto f5c2(string) { return 2; }
+auto f5c3(double) { return 3; }
+alias f5c4 = f5c1, f5c4 = f5c2;
+alias f5c5 = f5c3, f5c5 = f5c4;
+
+@property p5c1(int)    { return 1; }    @property p5c1(int,    int) { return 1; }
+@property p5c2(string) { return 2; }    @property p5c2(string, int) { return 2; }
+@property p5c3(double) { return 3; }    @property p5c3(double, int) { return 3; }
+alias p5c4 = p5c1, p5c4 = p5c2;         alias p5c4 = p5c1, p5c4 = p5c2;
+alias p5c5 = p5c3, p5c5 = p5c4;         alias p5c5 = p5c3, p5c5 = p5c4;
+
+/***************************************/
+
+auto      f5ov(string)      { return 2; }
+@property p5ov(string)      { return 2; }
+@property p5ov(string, int) { return 2; }

--- a/test/runnable/imports/ufcs5d.d
+++ b/test/runnable/imports/ufcs5d.d
@@ -1,0 +1,13 @@
+module imports.ufcs5d;
+
+auto f5d1(int)    { return 1; }
+auto f5d2(string) { return 2; }
+auto f5d3(double) { return 3; }
+alias f5d4 = f5d1, f5d4 = f5d2;
+alias f5d5 = f5d3, f5d5 = f5d4;
+
+@property p5d1(int)    { return 1; }    @property p5d1(int,    int) { return 1; }
+@property p5d2(string) { return 2; }    @property p5d2(string, int) { return 2; }
+@property p5d3(double) { return 3; }    @property p5d3(double, int) { return 3; }
+alias p5d4 = p5d1, p5d4 = p5d2;         alias p5d4 = p5d1, p5d4 = p5d2;
+alias p5d5 = p5d3, p5d5 = p5d4;         alias p5d5 = p5d3, p5d5 = p5d4;

--- a/test/runnable/imports/ufcs5e.d
+++ b/test/runnable/imports/ufcs5e.d
@@ -1,0 +1,13 @@
+module imports.ufcs5e;
+
+auto f5e1(int)    { return 1; }
+auto f5e2(string) { return 2; }
+auto f5e3(double) { return 3; }
+alias f5e4 = f5e1, f5e4 = f5e2;
+alias f5e5 = f5e3, f5e5 = f5e4;
+
+@property p5e1(int)    { return 1; }    @property p5e1(int,    int) { return 1; }
+@property p5e2(string) { return 2; }    @property p5e2(string, int) { return 2; }
+@property p5e3(double) { return 3; }    @property p5e3(double, int) { return 3; }
+alias p5e4 = p5e1, p5e4 = p5e2;         alias p5e4 = p5e1, p5e4 = p5e2;
+alias p5e5 = p5e3, p5e5 = p5e4;         alias p5e5 = p5e3, p5e5 = p5e4;

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -489,6 +489,20 @@ void test3382()
 }
 
 /*******************************************/
+// 6185
+
+void test6185()
+{
+    import std.algorithm;
+
+    auto r1 = [1,2,3].map!"a*2";
+    assert(equal(r1, [2,4,6]));
+
+    auto r2 = r1.map!"a+2"();
+    assert(equal(r2, [4,6,8]));
+}
+
+/*******************************************/
 // 6070
 
 enum test6070a = ["test"].foo6070();
@@ -663,6 +677,7 @@ int main()
     test5();
     test682();
     test3382();
+    test6185();
     test7670();
     test7703();
     test7773();


### PR DESCRIPTION
In basic, UFCS name search looks for only symbols in module scope.
If the enclosing scopes have local imports, the imported overload-set and selected/renamed symbols should also be considered in searching.

In my opinion, UFCS should not see the locally declared symbols (in statement scope and aggregate member scope). So, currently, this is a final step for the UFCS implementation.

---

Fixed bugzilla issue:
[Issue 6185](http://d.puremagic.com/issues/show_bug.cgi?id=6185) - Include non-global functions when resolving UFCS
