### PR TITLE
Issue 9985 - Postblit isn't called on local struct return

### DIFF
--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2630,6 +2630,49 @@ void test9907()
 }
 
 /**********************************/
+// 9985
+
+struct S9985
+{
+    ubyte* b;
+    ubyte buf[128];
+    this(this) { assert(0); }
+
+    static void* ptr;
+}
+auto ref makeS9985()
+{
+    S9985 s;
+    s.b = s.buf.ptr;
+    S9985.ptr = &s;
+    return s;
+}
+void test9985()
+{
+    S9985 s = makeS9985();
+    assert(S9985.ptr == &s);    // NRVO
+
+    static const int n = 1;
+    static auto ref retN()
+    {
+        return n;
+    }
+    auto p = &(retN());        // OK
+    assert(p == &n);
+    alias ref const(int) F1();
+    static assert(is(typeof(retN) == F1));
+
+    enum const(int) x = 1;
+    static auto ref retX()
+    {
+        return x;
+    }
+    static assert(!__traits(compiles, { auto q = &(retX()); }));
+    alias const(int) F2();
+    static assert(is(typeof(retX) == F2));
+}
+
+/**********************************/
 // 9994
 
 void test9994()
@@ -2737,6 +2780,7 @@ int main()
     test9720();
     test9899();
     test9907();
+    test9985();
     test9994();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9985

Until 'ref' deduction finished, auto ref function is not an actual ref function. So compiler should keep NRVO ability.
