### PR TITLE
Issue 9946 - A UFCS disallowed in dynamic array allocation

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6687,7 +6687,16 @@ Expression *TypeIdentifier::toExpression()
     for (size_t i = 0; i < idents.dim; i++)
     {
         Identifier *id = idents[i];
-        e = new DotIdExp(loc, e, id);
+        if (id->dyncast() == DYNCAST_IDENTIFIER)
+        {
+            e = new DotIdExp(loc, e, id);
+        }
+        else
+        {   assert(id->dyncast() == DYNCAST_DSYMBOL);
+            TemplateInstance *ti = ((Dsymbol *)id)->isTemplateInstance();
+            assert(ti);
+            e = new DotTemplateInstanceExp(loc, e, ti->name, ti->tiargs);
+        }
     }
 
     return e;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -716,7 +716,8 @@ struct TypeDelegate : TypeNext
 struct TypeQualified : Type
 {
     Loc loc;
-    Identifiers idents;       // array of Identifier's representing ident.ident.ident etc.
+    Identifiers idents;     // array of Identifier and TypeInstance,
+                            // representing ident.ident!tiargs.ident. ... etc.
 
     TypeQualified(TY ty, Loc loc);
     void syntaxCopyHelper(TypeQualified *t);

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -407,6 +407,22 @@ void test9590()
 }
 
 /*******************************************/
+// 9946
+
+size_t count9946(alias x)(int[] haystack)
+{
+    return 0;
+}
+void test9946()
+{
+    int[] data;
+    auto n1 = count9946!5(data);          // OK
+    auto n2 = data.count9946!5;           // OK
+    auto a1 = new int[count9946!5(data)]; // OK
+    auto a2 = new int[data.count9946!5];  // Error
+}
+
+/*******************************************/
 
 int main()
 {
@@ -427,6 +443,7 @@ int main()
     test4();
     test9014();
     test9590();
+    test9946();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9946

`TypeQualified::idents` may have both `Identifier` and `TemplateInstance` objects. It should be treated correctly, as like as `Dsymbol::searchX` and `TypeQualified::resolveHelper`.
