### PR TITLE
Issue 9989 - destructor triggers creation of opAssign for structs

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -86,7 +86,7 @@ int StructDeclaration::needOpAssign()
     if (hasIdentityAssign)
         goto Lneed;         // because has identity==elaborate opAssign
 
-    if (dtor || postblit)
+    if (postblit)
         goto Lneed;
 
     /* If any of the fields need an opAssign, then we

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2630,6 +2630,21 @@ void test9907()
 }
 
 /**********************************/
+// 9989
+
+struct S9989
+{
+    ~this(){}
+}
+
+void test9989()
+{
+    S9989 s;
+    static assert(!__traits(compiles, s.opAssign(s)));
+    static assert(!__traits(compiles, s.__postblit()));
+}
+
+/**********************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9989
