### PR TITLE
Issue 9993 - const ctor should be preferred than mutable for const obj creation

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -2736,12 +2736,19 @@ MATCH FuncDeclaration::leastAsSpecialized(FuncDeclaration *g)
     /* If both functions have a 'this' pointer, and the mods are not
      * the same and g's is not const, then this is less specialized.
      */
-    if (needThis() && g->needThis())
+    if (needThis() && g->needThis() && tf->mod != tg->mod)
     {
-        if (tf->mod != tg->mod)
+        if (isCtorDeclaration())
+        {
+            if (MODimplicitConv(tg->mod, tf->mod))
+                match = MATCHconst;
+            else
+                return MATCHnomatch;
+        }
+        else
         {
             if (MODimplicitConv(tf->mod, tg->mod))
-                match = MATCHconst;
+                    match = MATCHconst;
             else
                 return MATCHnomatch;
         }

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -533,6 +533,71 @@ struct Foo9984
     auto foo() inout { return inout(Foo9984)(p); }
 }
 
+void test9993a()
+{
+    static class A
+    {
+        int x;
+        this()           { x = 13; }
+        this() immutable { x = 42; }
+    }
+              A ma = new           A;   assert(ma.x == 13);
+    immutable A ia = new immutable A;   assert(ia.x == 42);
+    static assert(!__traits(compiles, { immutable A ia = new A; }));
+
+    static class B
+    {
+        int x;
+        this()       { x = 13; }
+        this() const { x = 42; }
+    }
+    const B mb = new       B;           assert(mb.x == 13);
+    const B cb = new const B;           assert(cb.x == 42);
+    static assert(!__traits(compiles, { immutable B ib = new B; }));
+
+    static class C
+    {
+        int x;
+        this() const     { x = 13; }
+        this() immutable { x = 42; }
+    }
+        const C cc = new     const C;   assert(cc.x == 13);
+    immutable C ic = new immutable C;   assert(ic.x == 42);
+    static assert(!__traits(compiles, { C mc = new C; }));
+}
+void test9993b()
+{
+    static class A
+    {
+        int x;
+        this()()           { x = 13; }
+        this()() immutable { x = 42; }
+    }
+              A ma = new           A;   assert(ma.x == 13);
+    immutable A ia = new immutable A;   assert(ia.x == 42);
+    static assert(!__traits(compiles, { immutable A ia = new A; }));
+
+    static class B
+    {
+        int x;
+        this()()       { x = 13; }
+        this()() const { x = 42; }
+    }
+    const B mb = new       B;           assert(mb.x == 13);
+    const B cb = new const B;           assert(cb.x == 42);
+    static assert(!__traits(compiles, { immutable B ib = new B; }));
+
+    static class C
+    {
+        int x;
+        this()() const     { x = 13; }
+        this()() immutable { x = 42; }
+    }
+        const C cc = new     const C;   assert(cc.x == 13);
+    immutable C ic = new immutable C;   assert(ic.x == 42);
+    static assert(!__traits(compiles, { C mc = new C; }));
+}
+
 /********************************************/
 
 struct Bug1914a
@@ -916,6 +981,8 @@ int main()
     test15b();
     test15c();
     test15d();
+    test9993a();
+    test9993b();
     test3198and1914();
     test5885();
     test5889();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9993

This is necessary for proper qualified ctor support in 2.063.
