### PR TITLE
Fix parser for proper "redundant storage class" check

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -393,7 +393,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl)
 
             Lstc:
                 if (storageClass & stc)
-                    error("redundant storage class %s", Token::toChars(token.value));
+                    error("redundant storage class '%s'", Token::toChars(token.value));
                 composeStorageClass(storageClass | stc);
                 nextToken();
             Lstc2:
@@ -1464,7 +1464,7 @@ Parameters *Parser::parseParameters(int *pvarargs, TemplateParameters **tpl)
                         (storageClass & STCin && stc & (STCconst | STCscope)) ||
                         (stc & STCin && storageClass & (STCconst | STCscope))
                        )
-                        error("redundant storage class %s", Token::toChars(token.value));
+                        error("redundant storage class '%s'", Token::toChars(token.value));
                     storageClass |= stc;
                     composeStorageClass(storageClass);
                     continue;

--- a/src/parse.c
+++ b/src/parse.c
@@ -4093,22 +4093,29 @@ Statement *Parser::parseStatement(int flags, unsigned char** endPtr)
                 Type *at;
 
                 StorageClass storageClass = 0;
+                StorageClass stc = 0;
             Lagain:
+                if (stc)
+                {
+                    if (storageClass & stc)
+                        error("redundant storage class '%s'", Token::toChars(token.value));
+                    storageClass |= stc;
+                    composeStorageClass(storageClass);
+                    nextToken();
+                }
                 switch (token.value)
                 {
                     case TOKref:
 #if D1INOUT
                     case TOKinout:
 #endif
-                        storageClass |= STCref;
-                        nextToken();
+                        stc = STCref;
                         goto Lagain;
 
                     case TOKconst:
                         if (peekNext() != TOKlparen)
                         {
-                            storageClass |= STCconst;
-                            nextToken();
+                            stc = STCconst;
                             goto Lagain;
                         }
                         break;
@@ -4116,26 +4123,23 @@ Statement *Parser::parseStatement(int flags, unsigned char** endPtr)
                     case TOKimmutable:
                         if (peekNext() != TOKlparen)
                         {
-                            storageClass |= STCimmutable;
+                            stc = STCimmutable;
                             if (token.value == TOKinvariant)
                                 deprecation("use of 'invariant' rather than 'immutable' is deprecated");
-                            nextToken();
                             goto Lagain;
                         }
                         break;
                     case TOKshared:
                         if (peekNext() != TOKlparen)
                         {
-                            storageClass |= STCshared;
-                            nextToken();
+                            stc = STCshared;
                             goto Lagain;
                         }
                         break;
                     case TOKwild:
                         if (peekNext() != TOKlparen)
                         {
-                            storageClass |= STCwild;
-                            nextToken();
+                            stc = STCwild;
                             goto Lagain;
                         }
                         break;

--- a/src/parse.c
+++ b/src/parse.c
@@ -4196,25 +4196,28 @@ Statement *Parser::parseStatement(int flags, unsigned char** endPtr)
             check(TOKlparen);
 
             StorageClass storageClass = 0;
+            StorageClass stc = 0;
         LagainStc:
+            if (stc)
+            {
+                if (storageClass & stc)
+                    error("redundant storage class '%s'", Token::toChars(token.value));
+                storageClass |= stc;
+                composeStorageClass(storageClass);
+                nextToken();
+            }
             switch (token.value)
             {
                 case TOKref:
-                    storageClass |= STCref;
-                    composeStorageClass(storageClass);
-                    nextToken();
+                    stc = STCref;
                     goto LagainStc;
                 case TOKauto:
-                    storageClass |= STCauto;
-                    composeStorageClass(storageClass);
-                    nextToken();
+                    stc = STCauto;
                     goto LagainStc;
                 case TOKconst:
                     if (peekNext() != TOKlparen)
                     {
-                        storageClass |= STCconst;
-                        composeStorageClass(storageClass);
-                        nextToken();
+                        stc = STCconst;
                         goto LagainStc;
                     }
                     break;
@@ -4222,29 +4225,23 @@ Statement *Parser::parseStatement(int flags, unsigned char** endPtr)
                 case TOKimmutable:
                     if (peekNext() != TOKlparen)
                     {
-                        storageClass |= STCimmutable;
+                        stc = STCimmutable;
                         if (token.value == TOKinvariant)
                             deprecation("use of 'invariant' rather than 'immutable' is deprecated");
-                        composeStorageClass(storageClass);
-                        nextToken();
                         goto LagainStc;
                     }
                     break;
                 case TOKshared:
                     if (peekNext() != TOKlparen)
                     {
-                        storageClass |= STCshared;
-                        composeStorageClass(storageClass);
-                        nextToken();
+                        stc = STCshared;
                         goto LagainStc;
                     }
                     break;
                 case TOKwild:
                     if (peekNext() != TOKlparen)
                     {
-                        storageClass |= STCwild;
-                        composeStorageClass(storageClass);
-                        nextToken();
+                        stc = STCwild;
                         goto LagainStc;
                     }
                     break;

--- a/test/fail_compilation/parseStc.d
+++ b/test/fail_compilation/parseStc.d
@@ -10,3 +10,18 @@ void test1()
     if (x; 1) {}
     if (const const auto x = 1) {}
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc.d(24): Error: redundant storage class 'const'
+fail_compilation/parseStc.d(25): Error: redundant storage class 'const'
+fail_compilation/parseStc.d(26): Error: conflicting storage class immutable
+---
+*/
+void test2()
+{
+    const const x = 1;
+    foreach (const const x; [1,2,3]) {}
+    foreach (const immutable x; [1,2,3]) {}
+}

--- a/test/fail_compilation/parseStc.d
+++ b/test/fail_compilation/parseStc.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc.d(10): Error: if (v; e) is deprecated, use if (auto v = e)
+fail_compilation/parseStc.d(11): Error: redundant storage class 'const'
+---
+*/
+void test1()
+{
+    if (x; 1) {}
+    if (const const auto x = 1) {}
+}

--- a/test/fail_compilation/parseStc.d
+++ b/test/fail_compilation/parseStc.d
@@ -25,3 +25,13 @@ void test2()
     foreach (const const x; [1,2,3]) {}
     foreach (const immutable x; [1,2,3]) {}
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc.d(36): Error: redundant storage class 'const'
+fail_compilation/parseStc.d(37): Error: redundant storage class 'const'
+---
+*/
+struct S3 { const const test3() {} }
+void test4(const const int x) {}


### PR DESCRIPTION
Current dmd parser reports "redundant storage class" error for such code:

``` d
const const x = 1;
```

Recently I fixed [issue 9679](http://d.puremagic.com/issues/show_bug.cgi?id=9679) in #1937, but it did not support the "redundant storage class" check, and I found same issue in `foreach` statement.

This pull request fixes the two issues.
