### PR TITLE
[REG2.063a] Issue 10002 - calling std.algorithm.remove is impure

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1834,8 +1834,9 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
         }
 
         // Find the closest pure parent of the called function
-        if (getFuncTemplateDecl(f))
-        {   // The closest pure parent of instantiated template function is
+        if (getFuncTemplateDecl(f) &&
+            f->parent->isTemplateInstance()->enclosing == NULL)
+        {   // The closest pure parent of instantiated non-nested template function is
             // always itself.
             if (!f->isPure() && outerfunc->setImpure())
                 error("pure function '%s' cannot call impure function '%s'",

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -107,7 +107,7 @@ void test7017a() pure
     static assert(!__traits(compiles, map7017!((){})()));   // should pass, but fails
     static assert(!__traits(compiles, map7017!q{ 1 }()));   // pass, OK
     static assert(!__traits(compiles, map7017!foo7017()));  // pass, OK
-    static assert(!__traits(compiles, map7017!bar7017()));  // should pass, but fails
+    static assert( __traits(compiles, map7017!bar7017()));
 }
 
 /***************************************************/
@@ -250,6 +250,35 @@ void test5933()
     // inside function
     static assert(typeof(foo5933!()).stringof == "pure nothrow @safe int(int a)");
     static assert(typeof(S5933.init.foo!()).stringof == "pure nothrow @safe double(double a)");
+}
+
+/***************************************************/
+// 10002
+
+void impure10002() {}
+void remove10002(alias pred, bool impure = false, Range)(Range range)
+{
+    pred(range[0]);
+    static if (impure) impure10002();
+}
+class Node10002
+{
+    Node10002 parent;
+    Node10002[] children;
+
+    void foo() pure
+    {
+        parent.children.remove10002!(n => n is parent)();
+        remove10002!(n => n is parent)(parent.children);
+        static assert(!__traits(compiles, parent.children.remove10002x!(n => n is parent, true)()));
+        static assert(!__traits(compiles, remove10002x!(n => n is parent, true)(parent.children)));
+
+        Node10002 p;
+        p.children.remove10002!(n => n is p)();
+        remove10002!(n => n is p)(p.children);
+        static assert(!__traits(compiles, p.children.remove10002x!(n => n is p, true)()));
+        static assert(!__traits(compiles, remove10002x!(n => n is p, true)(p.children)));
+    }
 }
 
 /***************************************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10002

This regression is caused by fixing [issue 9415](http://d.puremagic.com/issues/show_bug.cgi?id=9415) with #1527.
