### PR TITLE
Issue 10005 - struct variable declaration and const-correctness

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -457,7 +457,7 @@ MATCH StructLiteralExp::implicitConvTo(Type *t)
             if (!e)
                 continue;
             Type *te = e->type;
-            te = te->castMod(t->mod);
+            te = sd->fields[i]->type->addMod(t->mod);
             MATCH m2 = e->implicitConvTo(te);
             //printf("\t%s => %s, match = %d\n", e->toChars(), te->toChars(), m2);
             if (m2 < m)

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1460,7 +1460,7 @@ Lnomatch:
                         /* Look for form of constructor call which is:
                          *    *__ctmp.ctor(arguments...)
                          */
-                        if (1)
+                        if ((*pinit)->type->implicitConvTo(t))
                         {   CallExp *ce = (CallExp *)(*pinit);
                             if (ce->e1->op == TOKdotvar)
                             {   DotVarExp *dve = (DotVarExp *)ce->e1;

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -525,6 +525,49 @@ void test15d()  // Bugzilla 9974
     shared const ssc = new shared const SSC(1);
 }
 
+void test15e()  // Bugzilla 10005
+{
+    // struct literal
+    static struct S
+    {
+        int[] a;
+    }
+    int[] marr = [1,2,3];
+    static assert( __traits(compiles, {           S m =           S(marr); }));
+    static assert( __traits(compiles, {     const S c =           S(marr); }));
+    static assert(!__traits(compiles, { immutable S i =           S(marr); }));
+    immutable int[] iarr = [1,2,3];
+    static assert(!__traits(compiles, {           S m = immutable S(iarr); }));
+    static assert( __traits(compiles, {     const S c = immutable S(iarr); }));
+    static assert( __traits(compiles, { immutable S i = immutable S(iarr); }));
+
+    // mutable constructor
+    static struct MS
+    {
+        int[] a;
+        this(int n) { a = new int[](n); }
+    }
+    static assert( __traits(compiles, {           MS m =           MS(3); }));
+    static assert( __traits(compiles, {     const MS c =           MS(3); }));
+    static assert(!__traits(compiles, { immutable MS i =           MS(3); }));
+    static assert(!__traits(compiles, {           MS m = immutable MS(3); }));
+    static assert(!__traits(compiles, {     const MS c = immutable MS(3); }));
+    static assert(!__traits(compiles, { immutable MS i = immutable MS(3); }));
+
+    // immutable constructor
+    static struct IS
+    {
+        int[] a;
+        this(int n) immutable { a = new int[](n); }
+    }
+    static assert(!__traits(compiles, {           IS m =           IS(3); }));
+    static assert(!__traits(compiles, {     const IS c =           IS(3); }));
+    static assert(!__traits(compiles, { immutable IS i =           IS(3); }));
+    static assert(!__traits(compiles, {           IS m = immutable IS(3); }));
+    static assert( __traits(compiles, {     const IS c = immutable IS(3); }));
+    static assert( __traits(compiles, { immutable IS i = immutable IS(3); }));
+}
+
 struct Foo9984
 {
     int[] p;
@@ -981,6 +1024,7 @@ int main()
     test15b();
     test15c();
     test15d();
+    test15e();
     test9993a();
     test9993b();
     test3198and1914();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10005

This change fixes const-correctness issues around qualified object construction.
I think this is necessary for 2.063 release.
