### PR TITLE
[DDMD] TypeQualified::idents are not always Identifiers, so stop pretending they are

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -420,7 +420,7 @@ Dsymbol *Dsymbol::search_correct(Identifier *ident)
  *      symbol found, NULL if not
  */
 
-Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, Identifier *id)
+Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, Object *id)
 {
     //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident->toChars());
     Dsymbol *s = toAlias();
@@ -429,7 +429,7 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, Identifier *id)
     switch (id->dyncast())
     {
         case DYNCAST_IDENTIFIER:
-            sm = s->search(loc, id, 0);
+            sm = s->search(loc, (Identifier *)id, 0);
             break;
 
         case DYNCAST_DSYMBOL:
@@ -437,7 +437,7 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, Identifier *id)
             //printf("\ttemplate instance id\n");
             Dsymbol *st = (Dsymbol *)id;
             TemplateInstance *ti = st->isTemplateInstance();
-            id = ti->name;
+            Identifier *id = ti->name;
             sm = s->search(loc, id, 0);
             if (!sm)
             {

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -164,7 +164,7 @@ struct Dsymbol : Object
     virtual void inlineScan();
     virtual Dsymbol *search(Loc loc, Identifier *ident, int flags);
     Dsymbol *search_correct(Identifier *id);
-    Dsymbol *searchX(Loc loc, Scope *sc, Identifier *id);
+    Dsymbol *searchX(Loc loc, Scope *sc, Object *id);
     virtual int overloadInsert(Dsymbol *s);
     virtual void toHBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/json.c
+++ b/src/json.c
@@ -544,7 +544,7 @@ void TypeQualified::toJson(JsonOut *json) // ident.ident.ident.etc
     json->arrayStart();
 
     for (size_t i = 0; i < idents.dim; i++)
-    {   Identifier *ident = idents[i];
+    {   Object *ident = idents[i];
         json->item(ident->toChars());
     }
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -716,12 +716,13 @@ struct TypeDelegate : TypeNext
 struct TypeQualified : Type
 {
     Loc loc;
-    Identifiers idents;     // array of Identifier and TypeInstance,
+    Objects idents;         // array of Identifier and TypeInstance,
                             // representing ident.ident!tiargs.ident. ... etc.
 
     TypeQualified(TY ty, Loc loc);
     void syntaxCopyHelper(TypeQualified *t);
     void addIdent(Identifier *ident);
+    void addInst(TemplateInstance *inst);
     void toCBuffer2Helper(OutBuffer *buf, HdrGenState *hgs);
     void toJson(JsonOut *json);
     d_uns64 size(Loc loc);

--- a/src/parse.c
+++ b/src/parse.c
@@ -2135,7 +2135,7 @@ Dsymbol *Parser::parseMixin()
             if (!tqual)
                 tqual = new TypeInstance(loc, tempinst);
             else
-                tqual->addIdent((Identifier *)tempinst);
+                tqual->addInst(tempinst);
             tiargs = NULL;
         }
         else
@@ -2507,7 +2507,7 @@ Type *Parser::parseBasicType()
                     else
                         // ident!template_argument
                         tempinst->tiargs = parseTemplateArgument();
-                    tid->addIdent((Identifier *)tempinst);
+                    tid->addInst(tempinst);
                 }
                 else
                     tid->addIdent(id);

--- a/src/template.c
+++ b/src/template.c
@@ -3202,8 +3202,8 @@ MATCH TypeIdentifier::deduceType(Scope *sc, Type *tparam, TemplateParameters *pa
 
         for (size_t i = 0; i < idents.dim; i++)
         {
-            Identifier *id1 = idents[i];
-            Identifier *id2 = tp->idents[i];
+            Object *id1 = idents[i];
+            Object *id2 = tp->idents[i];
 
             if (!id1->equals(id2))
                 return MATCHnomatch;
@@ -3510,8 +3510,8 @@ MATCH TypeStruct::deduceType(Scope *sc, Type *tparam, TemplateParameters *parame
          */
         TypeInstance *tpi = (TypeInstance *)tparam;
         if (tpi->idents.dim)
-        {   Identifier *id = tpi->idents[tpi->idents.dim - 1];
-            if (id->dyncast() == DYNCAST_IDENTIFIER && sym->ident->equals(id))
+        {   Object *id = tpi->idents[tpi->idents.dim - 1];
+            if (id->dyncast() == DYNCAST_IDENTIFIER && sym->ident->equals((Identifier *)id))
             {
                 Type *tparent = sym->parent->getType();
                 if (tparent)
@@ -3654,8 +3654,8 @@ MATCH TypeClass::deduceType(Scope *sc, Type *tparam, TemplateParameters *paramet
          */
         TypeInstance *tpi = (TypeInstance *)tparam;
         if (tpi->idents.dim)
-        {   Identifier *id = tpi->idents[tpi->idents.dim - 1];
-            if (id->dyncast() == DYNCAST_IDENTIFIER && sym->ident->equals(id))
+        {   Object *id = tpi->idents[tpi->idents.dim - 1];
+            if (id->dyncast() == DYNCAST_IDENTIFIER && sym->ident->equals((Identifier *)id))
             {
                 Type *tparent = sym->parent->getType();
                 if (tparent)
@@ -6480,7 +6480,7 @@ char *TemplateInstance::toChars()
 /* ======================== TemplateMixin ================================ */
 
 TemplateMixin::TemplateMixin(Loc loc, Identifier *ident, TypeQualified *tqual, Objects *tiargs)
-        : TemplateInstance(loc, tqual->idents.dim ? tqual->idents[tqual->idents.dim - 1]
+        : TemplateInstance(loc, tqual->idents.dim ? (Identifier *)tqual->idents[tqual->idents.dim - 1]
                                                   : ((TypeIdentifier *)tqual)->ident)
 {
     //printf("TemplateMixin(ident = '%s')\n", ident ? ident->toChars() : "");


### PR DESCRIPTION
Use the base class (Object) instead of storing `Identifier`s that are actually TemplateInstances.

I ran into this is the D port of dmd because cast became dynamic cast and casting `TemplateInstance` to `Identifier` gave `null`.  As usual D is the sane one here and this code should die.
