### PR TITLE
[DDMD] Make __locale_decpoint const char *

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -19,7 +19,7 @@
 #endif
 
 #if _WIN32 && __DMC__
-extern "C" char * __cdecl __locale_decpoint;
+extern "C" const char * __cdecl __locale_decpoint;
 #endif
 
 #include "rmem.h"
@@ -2625,7 +2625,7 @@ void floatToBuffer(OutBuffer *buf, Type *type, real_t value)
     ld_sprint(buffer, 'g', value);
     assert(strlen(buffer) < sizeof(buffer));
 #if _WIN32 && __DMC__
-    char *save = __locale_decpoint;
+    const char *save = __locale_decpoint;
     __locale_decpoint = ".";
     real_t r = strtold(buffer, NULL);
     __locale_decpoint = save;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -32,7 +32,7 @@
 
 #if _WIN32 && __DMC__
 // from \dm\src\include\setlocal.h
-extern "C" char * __cdecl __locale_decpoint;
+extern "C" const char * __cdecl __locale_decpoint;
 #endif
 
 extern int HtmlNamedEntity(unsigned char *p, size_t length);
@@ -2353,7 +2353,7 @@ done:
     stringbuffer.writeByte(0);
 
 #if _WIN32 && __DMC__
-    char *save = __locale_decpoint;
+    const char *save = __locale_decpoint;
     __locale_decpoint = ".";
 #endif
 #ifdef IN_GCC


### PR DESCRIPTION
We assign a string literal to `__locale_decpoint` - in D this would need to be const.  As far as I can tell nobody should ever be modifying the chars `__locale_decpoint` points to.

Part of the dmd -> d project.
