### PR TITLE
#define alias - stdmsg

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -52,6 +52,8 @@ void printCtfePerformanceStats();
 
 static bool parse_arch(size_t argc, char** argv, bool is64bit);
 
+FILE *stdmsg;
+
 Global global;
 
 Global::Global()
@@ -414,6 +416,7 @@ int tryMain(size_t argc, char *argv[])
     printf("DMD %s DEBUG\n", global.version);
 #endif
 
+    stdmsg = stdout;
     unittests();
 
     // Check for malformed input

--- a/src/mars.h
+++ b/src/mars.h
@@ -447,11 +447,7 @@ void halt();
 void util_progress();
 
 /*** Where to send error messages ***/
-#ifdef IN_GCC
-#define stdmsg stderr
-#else
-#define stdmsg stderr
-#endif
+extern FILE *stdmsg;
 
 struct Dsymbol;
 class Library;


### PR DESCRIPTION
Using `#define` only for type aliases and compile-time constants is in my opinion much cleaner and makes auto-porting to d easier.  This is one of many.
