### PR TITLE
Issue9652 -  __traits(getAttributes) doesn't work with manifest constants 

### DIFF
--- a/src/enum.c
+++ b/src/enum.c
@@ -18,6 +18,7 @@
 #include "expression.h"
 #include "module.h"
 #include "declaration.h"
+#include "init.h"
 
 /********************************* EnumDeclaration ****************************/
 
@@ -335,9 +336,13 @@ void EnumDeclaration::semantic(Scope *sc)
         if (isAnonymous() && !sc->func)
         {
             // already inserted to enclosing scope in addMember
+            assert(em->ed);
         }
         else
+        {
+            em->ed = this;
             em->addMember(sc, scopesym, 1);
+        }
 
         /* Compute .min, .max and .default values.
          * If enum doesn't have a name, we can never identify the enum type,
@@ -467,6 +472,7 @@ EnumMember::EnumMember(Loc loc, Identifier *id, Expression *value, Type *type)
     this->value = value;
     this->type = type;
     this->loc = loc;
+    this->vd = NULL;
 }
 
 Dsymbol *EnumMember::syntaxCopy(Dsymbol *s)
@@ -511,7 +517,24 @@ const char *EnumMember::kind()
 
 void EnumMember::semantic(Scope *sc)
 {
-    if (ed)
-        ed->semantic(NULL);
+    assert(ed);
+    if (this->vd) return;
+    ed->semantic(sc);
+    assert(value);
+    vd = new VarDeclaration(loc, type, ident, new ExpInitializer(loc, value->copy()));
+
+    vd->storage_class = STCmanifest;
+    vd->semantic(sc);
+
+    vd->protection = ed->isAnonymous() ? ed->protection : PROTpublic;
+    vd->parent = ed->isAnonymous() ? ed->parent : ed;
+    vd->userAttributes = ed->isAnonymous() ? ed->userAttributes : NULL;
 }
 
+Expression *EnumMember::getVarExp(Loc loc, Scope *sc)
+{
+    semantic(sc);
+    assert(vd);
+    Expression *e = new VarExp(loc, vd);
+    return e->semantic(sc);
+}

--- a/src/enum.h
+++ b/src/enum.h
@@ -22,7 +22,7 @@ struct Identifier;
 struct Type;
 struct Expression;
 struct HdrGenState;
-
+struct VarDeclaration;
 
 struct EnumDeclaration : ScopeDsymbol
 {   /* enum ident : memtype { ... }
@@ -80,12 +80,14 @@ struct EnumMember : Dsymbol
     EnumDeclaration *ed;
     Expression *value;
     Type *type;
+    VarDeclaration *vd;
 
     EnumMember(Loc loc, Identifier *id, Expression *value, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();
     void semantic(Scope *sc);
+    Expression *getVarExp(Loc loc, Scope *sc);
 
     void emitComment(Scope *sc);
     void toJson(JsonOut *json);

--- a/src/expression.c
+++ b/src/expression.c
@@ -3258,9 +3258,7 @@ Lagain:
             error("forward reference of %s %s", s->kind(), s->toChars());
             return new ErrorExp();
         }
-        e->loc = loc;
-        e = e->semantic(sc);
-        return e;
+        return em->getVarExp(loc, sc);
     }
     v = s->isVarDeclaration();
     if (v)
@@ -5385,13 +5383,17 @@ void VarExp::checkEscapeRef()
 
 int VarExp::isLvalue()
 {
-    if (var->storage_class & (STClazy | STCtemp))
+    if (var->storage_class & (STClazy | STCtemp | STCmanifest))
         return 0;
     return 1;
 }
 
 Expression *VarExp::toLvalue(Scope *sc, Expression *e)
 {
+    if (var->storage_class & STCmanifest)
+    {   error("manifest constant '%s' is not lvalue", var->toChars());
+        return new ErrorExp();
+    }
     if (var->storage_class & STClazy)
     {   error("lazy variables cannot be lvalues");
         return new ErrorExp();
@@ -5414,9 +5416,11 @@ int VarExp::checkModifiable(Scope *sc, int flag)
 Expression *VarExp::modifiableLvalue(Scope *sc, Expression *e)
 {
     //printf("VarExp::modifiableLvalue('%s')\n", var->toChars());
-    //if (type && type->toBasetype()->ty == Tsarray)
-        //error("cannot change reference to static array '%s'", var->toChars());
-
+    if (var->storage_class & STCmanifest)
+    {
+        error("Cannot modify '%s'", toChars());
+        return new ErrorExp();
+    }
     // See if this expression is a modifiable lvalue (i.e. not const)
     return Expression::modifiableLvalue(sc, e);
 }
@@ -7138,9 +7142,7 @@ Expression *DotIdExp::semanticY(Scope *sc, int flag)
             EnumMember *em = s->isEnumMember();
             if (em)
             {
-                e = em->value;
-                e = e->semantic(sc);
-                return e;
+                return em->getVarExp(loc, sc);
             }
 
             VarDeclaration *v = s->isVarDeclaration();
@@ -8877,7 +8879,7 @@ Expression *AddrExp::semantic(Scope *sc)
             ce->e2->type = NULL;
             ce->e2 = ce->e2->semantic(sc);
         }
-        
+
         return optimize(WANTvalue);
     }
     return this;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6385,7 +6385,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
         if (EnumMember *em = s->isEnumMember())
         {
             // It's not a type, it's an expression
-            *pe = em->value->copy();
+            *pe = em->getVarExp(loc, sc);
             return;
         }
 
@@ -7226,9 +7226,7 @@ Expression *TypeEnum::dotExp(Scope *sc, Expression *e, Identifier *ident, int fl
         return sym->memtype->dotExp(sc, e, ident, flag);
     }
     EnumMember *m = s->isEnumMember();
-    Expression *em = m->value->copy();
-    em->loc = e->loc;
-    return em;
+    return m->getVarExp(e->loc, sc);
 }
 
 Expression *TypeEnum::getProperty(Loc loc, Identifier *ident, int flag)
@@ -7843,15 +7841,9 @@ L1:
     }
     if (v && !v->isDataseg() && (v->storage_class & STCmanifest))
     {
-        // Defer constant folding for the statically initialized
-        // const/immutable field until optimize-phase.
-        Expression *ei = v->init->toExpression(v->type);
-        if (ei)
-        {   ei = ei->copy();    // need to copy it if it's a StringExp
-            ei->loc = e->loc;   // for better error message
-            ei = ei->semantic(sc);
-            return ei;
-        }
+        Expression *ve = new VarExp(e->loc, v);
+        ve = ve->semantic(sc);
+        return ve;
     }
 
     if (s->getType())
@@ -7862,8 +7854,7 @@ L1:
     EnumMember *em = s->isEnumMember();
     if (em)
     {
-        assert(em->value);
-        return em->value->copy();
+        return em->getVarExp(e->loc, sc);
     }
 
     TemplateMixin *tm = s->isTemplateMixin();
@@ -8477,15 +8468,9 @@ L1:
     }
     if (v && !v->isDataseg() && (v->storage_class & STCmanifest))
     {
-        // Defer constant folding for the statically initialized
-        // const/immutable field until optimize-phase.
-        Expression *ei = v->init->toExpression(v->type);
-        if (ei)
-        {   ei = ei->copy();    // need to copy it if it's a StringExp
-            ei->loc = e->loc;   // for better error message
-            ei = ei->semantic(sc);
-            return ei;
-        }
+        Expression *ve = new VarExp(e->loc, v);
+        ve = ve->semantic(sc);
+        return ve;
     }
 
     if (s->getType())
@@ -8496,8 +8481,7 @@ L1:
     EnumMember *em = s->isEnumMember();
     if (em)
     {
-        assert(em->value);
-        return em->value->copy();
+        return em->getVarExp(e->loc, sc);
     }
 
     TemplateMixin *tm = s->isTemplateMixin();

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -23,7 +23,7 @@
 #include "declaration.h"
 #include "aggregate.h"
 #include "init.h"
-
+#include "enum.h"
 
 #ifdef IN_GCC
 #include "d-gcc-real.h"
@@ -623,7 +623,7 @@ Expression *CastExp::optimize(int result, bool keepLvalue)
 
     if ((e1->op == TOKstring || e1->op == TOKarrayliteral) &&
         (type->ty == Tpointer || type->ty == Tarray) &&
-        e1->type->nextOf()->size() == type->nextOf()->size()
+        e1->type->toBasetype()->nextOf()->size() == type->nextOf()->size()
        )
     {
         Expression *e = e1->castTo(NULL, type);

--- a/test/fail_compilation/diag8178.d
+++ b/test/fail_compilation/diag8178.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8178.d(5): Error: Cannot modify '""'
+fail_compilation/diag8178.d(5): Error: Cannot modify 's'
 ---
 */
 

--- a/test/runnable/uda.d
+++ b/test/runnable/uda.d
@@ -139,7 +139,7 @@ void test7()
 
     if (!is(Test7 == typeof(tp[0])))
         assert(0);
-    
+
     assert(tp[0] == Test7(3, "foo"));
 }
 
@@ -260,6 +260,64 @@ void test9178()
     Foo foo = new Foo;
     static assert(__traits(getAttributes, foo.tupleof[0])[0] == 1);
 }
+
+/************************************************/
+// 9741
+
+struct Bug9741
+{
+    pragma(msg, __traits(getAttributes, enum_field));
+    alias Tuple!(__traits(getAttributes, enum_field)) Tenum_field;
+    private @(10) enum enum_field = 42;
+
+    static assert(Tenum_field[0] == 10);
+    static assert(__traits(getAttributes, enum_field)[0] == 10);
+    static assert(__traits(getProtection, enum_field) == "private");
+    static assert(__traits(isSame, __traits(parent, enum_field), Bug9741));
+    static assert(__traits(isSame, enum_field, enum_field));
+
+    pragma(msg, __traits(getAttributes, anon_enum_member));
+    alias Tuple!(__traits(getAttributes, anon_enum_member)) Tanon_enum_member;
+    private @(20) enum {anon_enum_member}
+
+    static assert(Tanon_enum_member[0] == 20);
+    static assert(__traits(getAttributes, anon_enum_member)[0] == 20);
+    static assert(__traits(getProtection, anon_enum_member) == "private");
+    static assert(__traits(isSame, __traits(parent, anon_enum_member), Bug9741));
+    static assert(__traits(isSame, anon_enum_member, anon_enum_member));
+
+    pragma(msg, __traits(getAttributes, Foo.enum_member));
+    alias Tuple!(__traits(getAttributes, Foo.enum_member)) Tfoo_enum_member;
+    private @(30) enum Foo {enum_member}
+    static assert(Tfoo_enum_member.length == 0); //Foo has attributes, not Foo.enum_member
+    static assert(__traits(getAttributes, Foo.enum_member).length == 0);
+    static assert(__traits(getProtection, Foo.enum_member) == "public");
+    static assert(__traits(isSame, __traits(parent, Foo.enum_member), Foo));
+    static assert(__traits(isSame, Foo.enum_member, Foo.enum_member));
+
+    pragma(msg, __traits(getAttributes, anon_enum_member_2));
+    alias Tuple!(__traits(getAttributes, anon_enum_member_2)) Tanon_enum_member_2;
+    private @(40) enum {long anon_enum_member_2 = 2L}
+
+    static assert(Tanon_enum_member_2[0] == 40);
+    static assert(__traits(getAttributes, anon_enum_member_2)[0] == 40);
+    static assert(__traits(getProtection, anon_enum_member_2) == "private");
+    static assert(__traits(isSame, __traits(parent, anon_enum_member_2), Bug9741));
+    static assert(__traits(isSame, anon_enum_member_2, anon_enum_member_2));
+
+    template Bug(alias X, bool is_exp)
+    {
+        static assert(is_exp == !__traits(compiles, __traits(parent, X)));
+        static assert(is_exp == !__traits(compiles, __traits(getAttributes, X)));
+        static assert(is_exp == !__traits(compiles, __traits(getProtection, X)));
+        enum Bug = 0;
+    }
+    enum en = 0;
+    enum dummy1 = Bug!(5, true);
+    enum dummy2 = Bug!(en, false);
+}
+
+
 
 /************************************************/
 


### PR DESCRIPTION
Fix Issue9652 and other.
Allows getAttributes, getProtection and parent traits for manifest constants.
Also fix isSame issue.
