### PR TITLE
Fix Issue 10022 - Importing packages

### DIFF
--- a/src/module.h
+++ b/src/module.h
@@ -110,7 +110,8 @@ struct Module : Package
     Module(char *arg, Identifier *ident, int doDocComment, int doHdrGen);
     ~Module();
 
-    static Module *load(Loc loc, Identifiers *packages, Identifier *ident);
+    static const char *searchDir(Loc loc, const char *dir, const char *filename, bool *packagemodule);
+    static Module *load(Loc loc, Identifiers *packages, Identifier *ident, bool *packagemodule);
 
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toJson(JsonOut *json);

--- a/src/parse.c
+++ b/src/parse.c
@@ -113,11 +113,16 @@ Dsymbols *Parser::parseModule()
                     a = new Identifiers();
                 a->push(id);
                 nextToken();
-                if (token.value != TOKidentifier)
+                if (token.value == TOKpackage)
+                {
+                    id = idPool("package");
+                }
+                else if (token.value != TOKidentifier)
                 {   error("Identifier expected following package");
                     goto Lerr;
                 }
-                id = token.ident;
+                else
+                    id = token.ident;
             }
 
             md = new ModuleDeclaration(a, id, safe);

--- a/test/compilable/imports/package10022/a.d
+++ b/test/compilable/imports/package10022/a.d
@@ -1,0 +1,4 @@
+
+module imports.package10022.a;
+
+void funa() {}

--- a/test/compilable/imports/package10022/b.d
+++ b/test/compilable/imports/package10022/b.d
@@ -1,0 +1,4 @@
+
+module imports.package10022.b;
+
+void funb() {}

--- a/test/compilable/imports/package10022/c.d
+++ b/test/compilable/imports/package10022/c.d
@@ -1,0 +1,4 @@
+
+module imports.package10022.c;
+
+void func() {}

--- a/test/compilable/imports/package10022/package.d
+++ b/test/compilable/imports/package10022/package.d
@@ -1,0 +1,6 @@
+
+module imports.package10022.package;
+
+public import imports.package10022.a;
+public import imports.package10022.b : funb;
+private import imports.package10022.c;

--- a/test/compilable/test10022.d
+++ b/test/compilable/test10022.d
@@ -1,0 +1,11 @@
+
+// EXTRA_SOURCES: imports/package10022/package imports/package10022/a imports/package10022/b imports/package10022/c
+
+import imports.package10022;
+
+void main()
+{
+    funa();
+    funb();
+    static assert(!is(typeof(func())));
+}


### PR DESCRIPTION
When attempting to import a package, rewrite to importing a module called 'package' instead.
When a file search detects a package, rewrite the import to directly use the 'package' module.
Allow declaring a module named 'package'.

http://d.puremagic.com/issues/show_bug.cgi?id=10022
