### PR TITLE
[DDMD] Replace condApply templates with macros

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -36,12 +36,7 @@ int Expression::apply(fp_t fp, void *param)
 /******************************
  * Perform apply() on an t if not null
  */
-template<typename T>
-int condApply(T* t, fp_t fp, void* param)
-{
-    return t ? t->apply(fp, param) : 0;
-}
-
+#define condApply(t, fp, param) (t ? t->apply(fp, param) : 0)
 
 int NewExp::apply(int (*fp)(Expression *, void *), void *param)
 {

--- a/src/sapply.c
+++ b/src/sapply.c
@@ -26,9 +26,9 @@
  * Creating an iterator for this would be much more complex.
  */
 
-typedef bool (*fp_t)(Statement *, void *);
+typedef bool (*sapply_fp_t)(Statement *, void *);
 
-bool Statement::apply(fp_t fp, void *param)
+bool Statement::apply(sapply_fp_t fp, void *param)
 {
     return (*fp)(this, param);
 }
@@ -36,179 +36,175 @@ bool Statement::apply(fp_t fp, void *param)
 /******************************
  * Perform apply() on an t if not null
  */
-template<typename T>
-bool condApply(T* t, fp_t fp, void* param)
-{
-    return t ? t->apply(fp, param) : 0;
-}
+#define scondApply(t, fp, param) (t ? t->apply(fp, param) : 0)
 
 
 
-bool PeelStatement::apply(fp_t fp, void *param)
+bool PeelStatement::apply(sapply_fp_t fp, void *param)
 {
     return s->apply(fp, param) ||
            (*fp)(this, param);
 }
 
-bool CompoundStatement::apply(fp_t fp, void *param)
+bool CompoundStatement::apply(sapply_fp_t fp, void *param)
 {
     for (size_t i = 0; i < statements->dim; i++)
     {   Statement *s = (*statements)[i];
 
-        bool r = condApply(s, fp, param);
+        bool r = scondApply(s, fp, param);
         if (r)
             return r;
     }
     return (*fp)(this, param);
 }
 
-bool UnrolledLoopStatement::apply(fp_t fp, void *param)
+bool UnrolledLoopStatement::apply(sapply_fp_t fp, void *param)
 {
     for (size_t i = 0; i < statements->dim; i++)
     {   Statement *s = (*statements)[i];
 
-        bool r = condApply(s, fp, param);
+        bool r = scondApply(s, fp, param);
         if (r)
             return r;
     }
     return (*fp)(this, param);
 }
 
-bool ScopeStatement::apply(fp_t fp, void *param)
+bool ScopeStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(statement, fp, param) ||
+    return scondApply(statement, fp, param) ||
            (*fp)(this, param);
 }
 
-bool WhileStatement::apply(fp_t fp, void *param)
+bool WhileStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(body, fp, param) ||
+    return scondApply(body, fp, param) ||
            (*fp)(this, param);
 }
 
-bool DoStatement::apply(fp_t fp, void *param)
+bool DoStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(body, fp, param) ||
+    return scondApply(body, fp, param) ||
            (*fp)(this, param);
 }
 
-bool ForStatement::apply(fp_t fp, void *param)
+bool ForStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(init, fp, param) ||
-           condApply(body, fp, param) ||
+    return scondApply(init, fp, param) ||
+           scondApply(body, fp, param) ||
            (*fp)(this, param);
 }
 
-bool ForeachStatement::apply(fp_t fp, void *param)
+bool ForeachStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(body, fp, param) ||
-           (*fp)(this, param);
-}
-
-#if DMDV2
-bool ForeachRangeStatement::apply(fp_t fp, void *param)
-{
-    return condApply(body, fp, param) ||
-           (*fp)(this, param);
-}
-#endif
-
-bool IfStatement::apply(fp_t fp, void *param)
-{
-    return condApply(ifbody, fp, param) ||
-           condApply(elsebody, fp, param) ||
-           (*fp)(this, param);
-}
-
-bool ConditionalStatement::apply(fp_t fp, void *param)
-{
-    return condApply(ifbody, fp, param) ||
-           condApply(elsebody, fp, param) ||
-           (*fp)(this, param);
-}
-
-bool PragmaStatement::apply(fp_t fp, void *param)
-{
-    return condApply(body, fp, param) ||
-           (*fp)(this, param);
-}
-
-bool SwitchStatement::apply(fp_t fp, void *param)
-{
-    return condApply(body, fp, param) ||
-           (*fp)(this, param);
-}
-
-bool CaseStatement::apply(fp_t fp, void *param)
-{
-    return condApply(statement, fp, param) ||
+    return scondApply(body, fp, param) ||
            (*fp)(this, param);
 }
 
 #if DMDV2
-bool CaseRangeStatement::apply(fp_t fp, void *param)
+bool ForeachRangeStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(statement, fp, param) ||
+    return scondApply(body, fp, param) ||
            (*fp)(this, param);
 }
 #endif
 
-bool DefaultStatement::apply(fp_t fp, void *param)
+bool IfStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(statement, fp, param) ||
+    return scondApply(ifbody, fp, param) ||
+           scondApply(elsebody, fp, param) ||
            (*fp)(this, param);
 }
 
-bool SynchronizedStatement::apply(fp_t fp, void *param)
+bool ConditionalStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(body, fp, param) ||
+    return scondApply(ifbody, fp, param) ||
+           scondApply(elsebody, fp, param) ||
            (*fp)(this, param);
 }
 
-bool WithStatement::apply(fp_t fp, void *param)
+bool PragmaStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(body, fp, param) ||
+    return scondApply(body, fp, param) ||
            (*fp)(this, param);
 }
 
-bool TryCatchStatement::apply(fp_t fp, void *param)
+bool SwitchStatement::apply(sapply_fp_t fp, void *param)
 {
-    bool r = condApply(body, fp, param);
+    return scondApply(body, fp, param) ||
+           (*fp)(this, param);
+}
+
+bool CaseStatement::apply(sapply_fp_t fp, void *param)
+{
+    return scondApply(statement, fp, param) ||
+           (*fp)(this, param);
+}
+
+#if DMDV2
+bool CaseRangeStatement::apply(sapply_fp_t fp, void *param)
+{
+    return scondApply(statement, fp, param) ||
+           (*fp)(this, param);
+}
+#endif
+
+bool DefaultStatement::apply(sapply_fp_t fp, void *param)
+{
+    return scondApply(statement, fp, param) ||
+           (*fp)(this, param);
+}
+
+bool SynchronizedStatement::apply(sapply_fp_t fp, void *param)
+{
+    return scondApply(body, fp, param) ||
+           (*fp)(this, param);
+}
+
+bool WithStatement::apply(sapply_fp_t fp, void *param)
+{
+    return scondApply(body, fp, param) ||
+           (*fp)(this, param);
+}
+
+bool TryCatchStatement::apply(sapply_fp_t fp, void *param)
+{
+    bool r = scondApply(body, fp, param);
     if (r)
         return r;
 
     for (size_t i = 0; i < catches->dim; i++)
     {   Catch *c = (*catches)[i];
 
-        bool r = condApply(c->handler, fp, param);
+        bool r = scondApply(c->handler, fp, param);
         if (r)
             return r;
     }
     return (*fp)(this, param);
 }
 
-bool TryFinallyStatement::apply(fp_t fp, void *param)
+bool TryFinallyStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(body, fp, param) ||
-           condApply(finalbody, fp, param) ||
+    return scondApply(body, fp, param) ||
+           scondApply(finalbody, fp, param) ||
            (*fp)(this, param);
 }
 
-bool OnScopeStatement::apply(fp_t fp, void *param)
+bool OnScopeStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(statement, fp, param) ||
+    return scondApply(statement, fp, param) ||
            (*fp)(this, param);
 }
 
-bool DebugStatement::apply(fp_t fp, void *param)
+bool DebugStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(statement, fp, param) ||
+    return scondApply(statement, fp, param) ||
            (*fp)(this, param);
 }
 
-bool LabelStatement::apply(fp_t fp, void *param)
+bool LabelStatement::apply(sapply_fp_t fp, void *param)
 {
-    return condApply(statement, fp, param) ||
+    return scondApply(statement, fp, param) ||
            (*fp)(this, param);
 }
 


### PR DESCRIPTION
Replace condApply templates with macros (to aid porting)
Give them different names to avoid limitation of automated porting tool
Rename fp_t to avoid conflicts with other, different function pointer types
