### PR TITLE
fix Issue 10030 - Support '-l:' switch when passing default library to l...

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -573,9 +573,19 @@ int runLINK()
     size_t slen = strlen(libname);
     if (slen)
     {
-        char *buf = (char *)malloc(2 + slen + 1);
+        char *buf = (char *)malloc(3 + slen + 1);
         strcpy(buf, "-l");
-        strcpy(buf + 2, libname);
+        /* Use "-l:libname.a" if the library name is complete
+         */
+        if (slen > 3 + 2 &&
+            memcmp(libname, "lib", 3) == 0 &&
+            (memcmp(libname + slen - 2, ".a", 2) == 0 ||
+             memcmp(libname + slen - 3, ".so", 3) == 0)
+           )
+        {
+            strcat(buf, ":");
+        }
+        strcat(buf, libname);
         argv.push(buf);             // turns into /usr/lib/libphobos2.a
     }
 


### PR DESCRIPTION
...d

http://d.puremagic.com/issues/show_bug.cgi?id=10030

This enables getting rid of the libphobos2so.so hack.
