### PR TITLE
Add new Target hook to retrieve member field alignment.

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -25,6 +25,7 @@
 #include "statement.h"
 #include "hdrgen.h"
 #include "ctfe.h"
+#include "target.h"
 
 AggregateDeclaration *isAggregate(Type *t); // from opover.c
 
@@ -1833,7 +1834,7 @@ void VarDeclaration::setFieldOffset(AggregateDeclaration *ad, unsigned *poffset,
 
 
     unsigned memsize      = t->size(loc);            // size of member
-    unsigned memalignsize = t->alignsize();          // size of member for alignment purposes
+    unsigned memalignsize = Target::fieldalign(t);   // size of member for alignment purposes
 
     offset = AggregateDeclaration::placeField(poffset, memsize, memalignsize, alignment,
                 &ad->structsize, &ad->alignsize, isunion);

--- a/src/target.c
+++ b/src/target.c
@@ -59,6 +59,10 @@ void Target::init()
     }
 }
 
+/******************************
+ * Return memory alignment size of type.
+ */
+
 unsigned Target::alignsize (Type* type)
 {
     assert (type->isTypeBasic());
@@ -92,3 +96,11 @@ unsigned Target::alignsize (Type* type)
     return type->size(0);
 }
 
+/******************************
+ * Return field alignment size of type.
+ */
+
+unsigned Target::fieldalign (Type* type)
+{
+    return type->alignsize();
+}

--- a/src/target.h
+++ b/src/target.h
@@ -25,6 +25,7 @@ struct Target
     
     static void init();
     static unsigned alignsize(Type* type);
+    static unsigned fieldalign(Type* type);
 };
 
 #endif


### PR DESCRIPTION
Required to be alternative to Target::alignsize because some targets limit struct field alignment to a lower boundary than alignment of variables.
