### PR TITLE
Add new Global hook for compiler vendor name.

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -672,7 +672,7 @@ void Lexer::scan(Token *t)
                     }
                     else if (id == Id::VENDOR)
                     {
-                        t->ustring = (unsigned char *)"Digital Mars D";
+                        t->ustring = (unsigned char *)global.compiler.vendor;
                         goto Lstr;
                     }
                     else if (id == Id::TIMESTAMP)

--- a/src/mars.c
+++ b/src/mars.c
@@ -98,6 +98,8 @@ Global::Global()
 #include "verstr.h"
     ;
 
+    compiler.vendor = "Digital Mars D";
+
     main_d = "__main.d";
 
     structalign = STRUCTALIGN_DEFAULT;

--- a/src/mars.h
+++ b/src/mars.h
@@ -238,6 +238,11 @@ struct Param
     char *mapfile;
 };
 
+struct Compiler
+{
+    const char *vendor;     // Compiler backend name
+};
+
 typedef unsigned structalign_t;
 #define STRUCTALIGN_DEFAULT ~0  // magic value means "match whatever the underlying C compiler does"
 // other values are all powers of 2
@@ -264,6 +269,7 @@ struct Global
 
     const char *version;
 
+    Compiler compiler;
     Param params;
     unsigned errors;       // number of errors reported so far
     unsigned warnings;     // number of warnings reported so far


### PR DESCRIPTION
Self explanatory,  GDC has vendor `"GDC"`, LDC `"LDC"`, etc... 
