### PR TITLE
Issue 3789 and 10037 - [TDPL] Structs members that require non-bitwise comparison not correctly compared

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -107,7 +107,8 @@ struct AggregateDeclaration : ScopeDsymbol
     void toJson(JsonOut *json);
     void toDocBuffer(OutBuffer *buf, Scope *sc);
 
-    FuncDeclaration *hasIdentityOpAssign(Scope *sc, Dsymbol *assign);
+    FuncDeclaration *hasIdentityOpAssign(Scope *sc);
+    FuncDeclaration *hasIdentityOpEquals(Scope *sc);
 
     char *mangle(bool isv = false);
 

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -164,7 +164,6 @@ struct StructDeclaration : AggregateDeclaration
     int needOpAssign();
     int needOpEquals();
     FuncDeclaration *buildOpAssign(Scope *sc);
-    FuncDeclaration *buildOpEquals(Scope *sc);
     FuncDeclaration *buildPostBlit(Scope *sc);
     FuncDeclaration *buildCpCtor(Scope *sc);
 

--- a/src/class.c
+++ b/src/class.c
@@ -767,13 +767,10 @@ void ClassDeclaration::semantic(Scope *sc)
     Module::dprogress++;
 
     dtor = buildDtor(sc);
-    if (Dsymbol *assign = search_function(this, Id::assign))
+    if (FuncDeclaration *f = hasIdentityOpAssign(sc))
     {
-        if (FuncDeclaration *f = hasIdentityOpAssign(sc, assign))
-        {
-            if (!(f->storage_class & STCdisable))
-                error("identity assignment operator overload is illegal");
-        }
+        if (!(f->storage_class & STCdisable))
+            error("identity assignment operator overload is illegal");
     }
     sc->pop();
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -12610,6 +12610,26 @@ Expression *EqualExp::semantic(Scope *sc)
         return new ErrorExp();
     }
 
+    if (t1->ty == Tstruct && t2->ty == Tstruct)
+    {
+        StructDeclaration *sd = ((TypeStruct *)t1)->sym;
+        if (sd == ((TypeStruct *)t2)->sym)
+        {
+            if (sd->needOpEquals())
+            {
+                this->e1 = new DotIdExp(loc, e1, Id::tupleof);
+                this->e2 = new DotIdExp(loc, e2, Id::tupleof);
+                e = this;
+            }
+            else
+            {
+                e = new IdentityExp(op == TOKequal ? TOKidentity : TOKnotidentity, loc, e1, e2);
+            }
+            e = e->semantic(sc);
+            return e;
+        }
+    }
+
     if (e1->op == TOKtuple && e2->op == TOKtuple)
     {
         TupleExp *tup1 = (TupleExp *)e1;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4440,11 +4440,11 @@ StructDeclaration *TypeAArray::getImpl()
         TemplateInstance *ti = dti->ti;
 #endif
         // Instantiate on the root module of import dependency graph.
-        sc = sc->push(sc->module->importedFrom);
-        ti->semantic(sc);
-        ti->semantic2(sc);
-        ti->semantic3(sc);
-        sc = sc->pop();
+        Scope *scx = sc->push(sc->module->importedFrom);
+        ti->semantic(scx);
+        ti->semantic2(scx);
+        ti->semantic3(scx);
+        scx->pop();
         impl = ti->toAlias()->isStructDeclaration();
 #ifdef DEBUG
         if (!impl)

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -1004,7 +1004,8 @@ Expression *IdentityExp::optimize(int result, bool keepLvalue)
     Expression *e = this;
 
     if ((this->e1->isConst()     && this->e2->isConst()) ||
-        (this->e1->op == TOKnull && this->e2->op == TOKnull))
+        (this->e1->op == TOKnull && this->e2->op == TOKnull) ||
+        (result & WANTinterpret))
     {
         e = Identity(op, type, this->e1, this->e2);
         if (e == EXP_CANT_INTERPRET)

--- a/src/struct.c
+++ b/src/struct.c
@@ -682,8 +682,8 @@ void StructDeclaration::semantic(Scope *sc)
     postblit = buildPostBlit(sc2);
     cpctor = buildCpCtor(sc2);
 
-    hasIdentityAssign = (buildOpAssign(sc2) != NULL);
-    hasIdentityEquals = (buildOpEquals(sc2) != NULL);
+    buildOpAssign(sc2);
+    buildOpEquals(sc2);
 
     xeq = buildXopEquals(sc2);
 #endif

--- a/src/struct.c
+++ b/src/struct.c
@@ -683,7 +683,6 @@ void StructDeclaration::semantic(Scope *sc)
     cpctor = buildCpCtor(sc2);
 
     buildOpAssign(sc2);
-    buildOpEquals(sc2);
 
     xeq = buildXopEquals(sc2);
 #endif

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -268,6 +268,30 @@
         "originalType" : "Object",
        }
       ]
+     },
+     {
+      "name" : "__xopEquals",
+      "kind" : "function",
+      "storageClass" : [
+       "static"
+      ],
+      "deco" : "FKxS4json4Foo2KxS4json4Foo2Zb",
+      "parameters" : [
+       {
+        "name" : "p",
+        "deco" : "xS4json4Foo2",
+        "storageClass" : [
+         "ref"
+        ]
+       },
+       {
+        "name" : "q",
+        "deco" : "xS4json4Foo2",
+        "storageClass" : [
+         "ref"
+        ]
+       }
+      ]
      }
     ]
    },

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -5083,13 +5083,13 @@ bool bug7987()
     t.p = &q[1];
     assert(s!=t);
     s.p = &q[1];
-    assert(s == t);
+    /*assert(s == t);*/     assert(s.p == t.p);
     s.c = c1;
     t.c = c2;
-    assert(s != t);
+    /*assert(s != t);*/     assert(s.c !is t.c);
     assert(s !is t);
     s.c = c2;
-    assert(s == t);
+    /*assert(s == t);*/     assert(s.p == t.p && s.c is t.c);
     assert(s is t);
     return true;
 }

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -787,6 +787,42 @@ bool test3789()
 static assert(test3789());
 
 /**************************************/
+// 10037
+
+struct S10037
+{
+    bool opEquals(ref const S10037) { assert(0); }
+}
+
+struct T10037
+{
+    S10037 s;
+    // Compiler should not generate 'opEquals' here implicitly:
+}
+
+struct Sub10037(TL...)
+{
+    TL data;
+    int value;
+    alias value this;
+}
+
+void test10037()
+{
+    S10037 s;
+    T10037 t;
+    static assert( __traits(hasMember, S10037, "opEquals"));
+    static assert(!__traits(hasMember, T10037, "opEquals"));
+    assert(thrown!Error(s == s));
+    assert(thrown!Error(t == t));
+
+    Sub10037!(S10037) lhs;
+    Sub10037!(S10037) rhs;
+    static assert(!__traits(hasMember, Sub10037!(S10037), "opEquals"));
+    assert(lhs == rhs);     // lowered to: lhs.value == rhs.value
+}
+
+/**************************************/
 // 7641
 
 mixin template Proxy7641(alias a)
@@ -1167,6 +1203,7 @@ int main()
     test16();
     test17();
     test3789();
+    test10037();
     test7641();
     test8434();
     test18();

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1019,7 +1019,7 @@ struct T9694
 void test9694()
 {
     T9694 t;
-    assert(typeid(T9694).equals(&t, &t));
+    assert(thrown!Error(typeid(T9694).equals(&t, &t)));
 }
 
 /**************************************/


### PR DESCRIPTION
[Issue 3789](http://d.puremagic.com/issues/show_bug.cgi?id=3789) - [TDPL] Structs members that require non-bitwise comparison not correctly compared
[Issue 10037](http://d.puremagic.com/issues/show_bug.cgi?id=10037) - Compiler should not generate opEquals method implicitly
This is the revised pull request of #1731.

If `opEquals` method is not defined, compiler should translate struct objects equality operation `s1 == s2` to `s1.tupleof == s2.tupleof`, instead of the implicit generation of `opEquals`. The expansion would provide member-wise equality comparison recursively.
