### PR TITLE
[REG2.063a] Issue 10047 - opDispatch instantiation failure should be gagged for UFCS

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2044,7 +2044,12 @@ Expression *Type::noMember(Scope *sc, Expression *e, Identifier *ident, int flag
             tiargs->push(se);
             DotTemplateInstanceExp *dti = new DotTemplateInstanceExp(e->loc, e, Id::opDispatch, tiargs);
             dti->ti->tempdecl = td;
-            return dti->semanticY(sc, flag);
+
+            unsigned errors = flag ? global.startGagging() : 0;
+            Expression *e = dti->semanticY(sc, 0);
+            if (flag && global.endGagging(errors))
+                e = NULL;
+            return e;
         }
 
         /* See if we should forward to the alias this.

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -705,6 +705,26 @@ void test10041()
 }
 
 /*******************************************/
+// 10047
+
+struct Typedef10047(T)
+{
+    template opDispatch(string name)
+    {
+        static assert(0);
+    }
+}
+
+struct A10047 {}
+int foo10047(Typedef10047!A10047 a) { return 10; }
+
+void test10047()
+{
+    Typedef10047!A10047 a;
+    assert(a.foo10047() == 10);
+}
+
+/*******************************************/
 
 int main()
 {
@@ -730,6 +750,7 @@ int main()
     test9946();
     test10003();
     test10041();
+    test10047();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10047
