### PR TITLE
[DDMD] Workaround bug in dmd: common type of string literal and null does not convert to const char *

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -855,7 +855,7 @@ Ldone:
     static bool printedMain = false;  // semantic might run more than once
     if (global.params.verbose && !printedMain)
     {
-        const char *type = isMain() ? "main" : isWinMain() ? "winmain" : isDllMain() ? "dllmain" : NULL;
+        const char *type = isMain() ? "main" : isWinMain() ? "winmain" : isDllMain() ? "dllmain" : (const char *)NULL;
         Module *mod = sc->module;
 
         if (type && mod)


### PR DESCRIPTION
This code is not valid in D because of http://d.puremagic.com/issues/show_bug.cgi?id=9968

The common type of `? "" : null` is `string`, but as the implicit conversion from either to `const char *` is part of the expression, not the type, the resulting `CondExp` can no longer convert.  Much simpler to just add a cast!
