### PR TITLE
[DDMD] Make global a struct without a default constructor

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -56,7 +56,7 @@ FILE *stdmsg;
 
 Global global;
 
-Global::Global()
+void Global::init()
 {
     mars_ext = "d";
     sym_ext  = "d";
@@ -413,6 +413,7 @@ int tryMain(size_t argc, char *argv[])
     char noboundscheck = 0;
         int setdefaultlib = 0;
     const char *inifilename = NULL;
+    global.init();
 
 #ifdef DEBUG
     printf("DMD %s DEBUG\n", global.version);

--- a/src/mars.h
+++ b/src/mars.h
@@ -290,7 +290,7 @@ struct Global
      */
     bool endGagging(unsigned oldGagged);
 
-    Global();
+    void init();
 };
 
 extern Global global;


### PR DESCRIPTION
`Global` is a struct with a destructor, and this is not valid in D.  Easily fixed by the constructor becoming an init method that is called from main.
