### PR TITLE
[DDMD] Rename StringTable::init -> _init

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2952,7 +2952,7 @@ void Lexer::initKeywords()
 {
     size_t nkeywords = sizeof(keywords) / sizeof(keywords[0]);
 
-    stringtable.init(6151);
+    stringtable._init(6151);
 
     if (global.params.Dversion == 1)
         nkeywords -= 2;

--- a/src/libelf.c
+++ b/src/libelf.c
@@ -77,7 +77,7 @@ Library *Library::factory()
 LibElf::LibElf()
 {
     libfile = NULL;
-    tab.init();
+    tab._init();
 }
 
 /***********************************

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -87,7 +87,7 @@ Library *Library::factory()
 LibMach::LibMach()
 {
     libfile = NULL;
-    tab.init();
+    tab._init();
 }
 
 /***********************************

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -103,7 +103,7 @@ Library *LibMSCoff_factory()
 LibMSCoff::LibMSCoff()
 {
     libfile = NULL;
-    tab.init();
+    tab._init();
 }
 
 /***********************************

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -87,7 +87,7 @@ Library *Library::factory()
 LibOMF::LibOMF()
 {
     libfile = NULL;
-    tab.init();
+    tab._init();
 }
 
 /***********************************

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -147,7 +147,7 @@ char Type::needThisPrefix()
 
 void Type::init()
 {
-    stringtable.init(1543);
+    stringtable._init(1543);
     Lexer::initKeywords();
 
     for (size_t i = 0; i < TMAX; i++)

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -62,7 +62,7 @@ void StringValue::ctor(const char *p, size_t length)
     memcpy(this->lstring, p, length * sizeof(char));
 }
 
-void StringTable::init(size_t size)
+void StringTable::_init(size_t size)
 {
     table = (void **)mem.calloc(size, sizeof(void *));
     tabledim = size;

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -53,7 +53,7 @@ private:
     size_t tabledim;
 
 public:
-    void init(size_t size = 37);
+    void _init(size_t size = 37);
     ~StringTable();
 
     StringValue *lookup(const char *s, size_t len);


### PR DESCRIPTION
Using a method called `init` in D code causes problems, because `init` is a built-in property in D.  In most cases it can be automatically converted, but `StringTable::init` is used in the glue layer, so the name mangling in D and C++ must match exactly.  The simplest answer is to rename it in the C++ code, 8 lines changed.
