### PR TITLE
[DDMD] Move SymbolDeclaration constructor into the frontend

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -2260,6 +2260,15 @@ void ObjectNotFound(Identifier *id)
     fatal();
 }
 
+/********************************* ClassInfoDeclaration ****************************/
+
+SymbolDeclaration::SymbolDeclaration(Loc loc, StructDeclaration *dsym)
+        : Declaration(dsym->ident)
+{
+    this->loc = loc;
+    this->dsym = dsym;
+    storage_class |= STCconst;
+}
 
 /********************************* ClassInfoDeclaration ****************************/
 

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -328,10 +328,9 @@ struct VarDeclaration : Declaration
 
 struct SymbolDeclaration : Declaration
 {
-    Symbol *sym;
     StructDeclaration *dsym;
 
-    SymbolDeclaration(Loc loc, Symbol *s, StructDeclaration *dsym);
+    SymbolDeclaration(Loc loc, StructDeclaration *dsym);
 
     Symbol *toSymbol();
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1754,16 +1754,12 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
     }
     else if (s)
     {   // Struct static initializers, for example
-        if (s->dsym->toInitializer() == s->sym)
-        {   e = s->dsym->type->defaultInitLiteral(loc);
-            e = e->semantic(NULL);
-            if (e->op == TOKerror)
-                e = EXP_CANT_INTERPRET;
-            else // Convert NULL to VoidExp
-                e = e->interpret(istate, goal);
-        }
-        else
-            error(loc, "cannot interpret symbol %s at compile time", s->toChars());
+        e = s->dsym->type->defaultInitLiteral(loc);
+        e = e->semantic(NULL);
+        if (e->op == TOKerror)
+            e = EXP_CANT_INTERPRET;
+        else // Convert NULL to VoidExp
+            e = e->interpret(istate, goal);
     }
     else
         error(loc, "cannot interpret declaration %s at compile time", d->toChars());

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7999,8 +7999,7 @@ Expression *TypeStruct::defaultInit(Loc loc)
 #if LOGDEFAULTINIT
     printf("TypeStruct::defaultInit() '%s'\n", toChars());
 #endif
-    Symbol *s = sym->toInitializer();
-    Declaration *d = new SymbolDeclaration(sym->loc, s, sym);
+    Declaration *d = new SymbolDeclaration(sym->loc, sym);
     assert(d);
     d->type = this;
     return new VarExp(sym->loc, d);

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -46,18 +46,9 @@ Classsym *fake_classsym(Identifier *id);
 
 /********************************* SymbolDeclaration ****************************/
 
-SymbolDeclaration::SymbolDeclaration(Loc loc, Symbol *s, StructDeclaration *dsym)
-    : Declaration(new Identifier(s->Sident, TOKidentifier))
-{
-    this->loc = loc;
-    sym = s;
-    this->dsym = dsym;
-    storage_class |= STCconst;
-}
-
 Symbol *SymbolDeclaration::toSymbol()
 {
-    return sym;
+    return dsym->toInitializer();
 }
 
 /*************************************


### PR DESCRIPTION
`SymbolDeclaration`'s constructor is the only constructor in the glue layer, and this is unnecessary as it only exists there to allow access to members of `Symbol`, which are always reachable through the `dsym` member.  This class is only used for wrapping a struct's default init symbol.
