### PR TITLE
[DDMD] [C++] Add C++ mangling of struct and class names for member variables and functions

### DIFF
--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -281,9 +281,25 @@ Symbol *VarDeclaration::toSymbol()
                 break;
 
             case LINKcpp:
+            {
                 m = mTYman_cpp;
-                break;
 
+                s->Sflags = SFLpublic;
+                Dsymbol *parent = toParent();
+                ClassDeclaration *cd = parent->isClassDeclaration();
+                if (cd)
+                {
+                    ::type *tc = cd->type->toCtype();
+                    s->Sscope = tc->Tnext->Ttag;
+                }
+                StructDeclaration *sd = parent->isStructDeclaration();
+                if (sd)
+                {
+                    ::type *ts = sd->type->toCtype();
+                    s->Sscope = ts->Ttag;
+                }
+                break;
+            }
             default:
                 printf("linkage = %d\n", linkage);
                 assert(0);
@@ -421,6 +437,12 @@ Symbol *FuncDeclaration::toSymbol()
                     {
                         ::type *tc = cd->type->toCtype();
                         s->Sscope = tc->Tnext->Ttag;
+                    }
+                    StructDeclaration *sd = parent->isStructDeclaration();
+                    if (sd)
+                    {
+                        ::type *ts = sd->type->toCtype();
+                        s->Sscope = ts->Ttag;
                     }
                     break;
                 }


### PR DESCRIPTION
Extend the C++ mangling support already used by class member functions to struct functions, and class/struct variables.

I would love to add tests but unfortunately the mangling is done in the backend and cannot be accessed by static if.

This is required for porting the frontend to D.
