### PR TITLE
[DDMD] Remove zero-length array from StringValue

### DIFF
--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -58,8 +58,8 @@ hash_t calcHash(const char *str, size_t len)
 void StringValue::ctor(const char *p, size_t length)
 {
     this->length = length;
-    this->lstring[length] = 0;
-    memcpy(this->lstring, p, length * sizeof(char));
+    (&this->lstring)[this->length] = 0;
+    memcpy(&this->lstring, p, length * sizeof(char));
 }
 
 void StringTable::init(size_t size)

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -28,15 +28,11 @@ struct StringValue
 private:
     size_t length;
 
-#ifndef IN_GCC
-    // Disable warning about nonstandard extension
-    #pragma warning (disable : 4200)
-#endif
-    char lstring[];
+    char lstring;
 
 public:
     size_t len() const { return length; }
-    const char *toDchars() const { return lstring; }
+    const char *toDchars() const { return &lstring; }
 
 private:
     friend struct StringEntry;


### PR DESCRIPTION
There is no reason we need a zero-length array here, it is completely internal.  Having a char there and taking the address gives the same effect.

Using a length-one array here would result in bounds checking when converting to D.  This solution is portable.
