### PR TITLE
[DDMD] Print all braces in impcnv tables

### DIFF
--- a/src/impcnvgen.c
+++ b/src/impcnvgen.c
@@ -381,44 +381,64 @@ int main()
     fprintf(fp,"unsigned char Type::impcnvResult[TMAX][TMAX] =\n{\n");
     for (i = 0; i < TMAX; i++)
     {
+        if (i)
+            fprintf(fp, ",");
+        fprintf(fp, "{");
         for (j = 0; j < TMAX; j++)
         {
-            fprintf(fp, "%d,",impcnvResult[i][j]);
+            if (j)
+                fprintf(fp, ",");
+            fprintf(fp, "%d",impcnvResult[i][j]);
         }
-        fprintf(fp, "\n");
+        fprintf(fp, "}\n");
     }
     fprintf(fp,"};\n");
 
     fprintf(fp,"unsigned char Type::impcnvType1[TMAX][TMAX] =\n{\n");
     for (i = 0; i < TMAX; i++)
     {
+        if (i)
+            fprintf(fp, ",");
+        fprintf(fp, "{");
         for (j = 0; j < TMAX; j++)
         {
-            fprintf(fp, "%d,",impcnvType1[i][j]);
+            if (j)
+                fprintf(fp, ",");
+            fprintf(fp, "%d",impcnvType1[i][j]);
         }
-        fprintf(fp, "\n");
+        fprintf(fp, "}\n");
     }
     fprintf(fp,"};\n");
 
     fprintf(fp,"unsigned char Type::impcnvType2[TMAX][TMAX] =\n{\n");
     for (i = 0; i < TMAX; i++)
     {
+        if (i)
+            fprintf(fp, ",");
+        fprintf(fp, "{");
         for (j = 0; j < TMAX; j++)
         {
-            fprintf(fp, "%d,",impcnvType2[i][j]);
+            if (j)
+                fprintf(fp, ",");
+            fprintf(fp, "%d",impcnvType2[i][j]);
         }
-        fprintf(fp, "\n");
+        fprintf(fp, "}\n");
     }
     fprintf(fp,"};\n");
 
     fprintf(fp,"unsigned char Type::impcnvWarn[TMAX][TMAX] =\n{\n");
     for (i = 0; i < TMAX; i++)
     {
+        if (i)
+            fprintf(fp, ",");
+        fprintf(fp, "{");
         for (j = 0; j < TMAX; j++)
         {
-            fprintf(fp, "%d,",impcnvWarn[i][j]);
+            if (j)
+                fprintf(fp, ",");
+            fprintf(fp, "%d",impcnvWarn[i][j]);
         }
-        fprintf(fp, "\n");
+        fprintf(fp, "}\n");
     }
     fprintf(fp,"};\n");
 


### PR DESCRIPTION
Print braces in the generated tables.

The C array literal style:

```
struct S { int a, b, c; }
S s[2] =
{
   1, 2, 3,
   4, 5, 6
};
```

Is annoying to convert to the D version:

```
S[2] s =
[
   S(1, 2, 3),
   S(4, 5, 6)
];
```

Because then the tool need to know the number of members in the struct.  It's trivial to just add the brackets.
