### PR TITLE
[DDMD] Remove (type) where type is a variable

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -291,7 +291,7 @@ void FuncDeclaration::semantic(Scope *sc)
         error("%s must be a function instead of %s", toChars(), type->toChars());
         return;
     }
-    f = (TypeFunction *)(type);
+    f = (TypeFunction *)type;
     size_t nparams = Parameter::dim(f->parameters);
 
     if (storage_class & STCscope)
@@ -902,7 +902,7 @@ void FuncDeclaration::semantic3(Scope *sc)
 
     if (!type || type->ty != Tfunction)
         return;
-    f = (TypeFunction *)(type);
+    f = (TypeFunction *)type;
     if (!inferRetType && f->next->ty == Terror)
         return;
 
@@ -1977,7 +1977,7 @@ void FuncDeclaration::buildResultVar()
 
     assert(type->nextOf());
     assert(type->nextOf()->toBasetype()->ty != Tvoid);
-    TypeFunction *tf = (TypeFunction *)(type);
+    TypeFunction *tf = (TypeFunction *)type;
 
     Loc loc = this->loc;
 

--- a/src/inline.c
+++ b/src/inline.c
@@ -1474,7 +1474,7 @@ int FuncDeclaration::canInline(int hasthis, int hdrscan, int statementsToo)
 
     if (type)
     {   assert(type->ty == Tfunction);
-        TypeFunction *tf = (TypeFunction *)(type);
+        TypeFunction *tf = (TypeFunction *)type;
         if (tf->varargs == 1)   // no variadic parameter lists
             goto Lno;
 


### PR DESCRIPTION
This is a trivial workaround for a limitation in the converter's parser.

It parses `(type)` as `cast(type)`, because 'type' is a valid backend struct.  It is so much easier to change these four lines than to add special cases.  I do not believe it changes the quality of the code in any way.
