### PR TITLE
[DDMD] Move #defines out of structs

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -99,6 +99,13 @@ enum CtfeGoal
     ctfeNeedNothing   // The return value is not required
 };
 
+#define WANTflags   1
+#define WANTvalue   2
+// A compile-time result is required. Give an error if not possible
+#define WANTinterpret 4
+// Same as WANTvalue, but also expand variables as far as possible
+#define WANTexpand  8
+
 struct Expression : Object
 {
     Loc loc;                    // file location
@@ -168,12 +175,6 @@ struct Expression : Object
     Expression *toDelegate(Scope *sc, Type *t);
 
     virtual Expression *optimize(int result, bool keepLvalue = false);
-    #define WANTflags   1
-    #define WANTvalue   2
-    // A compile-time result is required. Give an error if not possible
-    #define WANTinterpret 4
-    // Same as WANTvalue, but also expand variables as far as possible
-    #define WANTexpand  8
 
     // Entry point for CTFE.
     // A compile-time result is required. Give an error if not possible
@@ -493,6 +494,17 @@ struct AssocArrayLiteralExp : Expression
     Expression *inlineScan(InlineScanState *iss);
 };
 
+// scrubReturnValue is running
+#define stageScrub          0x1
+// hasNonConstPointers is running
+#define stageSearchPointers 0x2
+// optimize is running
+#define stageOptimize       0x4
+// apply is running
+#define stageApply          0x8
+//inlineScan is running
+#define stageInlineScan     0x10
+
 struct StructLiteralExp : Expression
 {
     StructDeclaration *sd;      // which aggregate this is for
@@ -518,17 +530,6 @@ struct StructLiteralExp : Expression
                                   // 'inlinecopy' uses similar 'stageflags' and from multiple evaluation 'doInline' 
                                   // (with infinite recursion) of this expression.
 
-    // scrubReturnValue is running
-    #define stageScrub          0x1 
-    // hasNonConstPointers is running
-    #define stageSearchPointers 0x2 
-    // optimize is running
-    #define stageOptimize       0x4
-    // apply is running
-    #define stageApply          0x8
-    //inlineScan is running
-    #define stageInlineScan     0x10
-                         
     StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *elements, Type *stype = NULL);
 
     Expression *syntaxCopy();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2492,11 +2492,6 @@ void TypeNext::transitive()
 
 /* ============================= TypeBasic =========================== */
 
-TypeBasic::TypeBasic(TY ty)
-        : Type(ty)
-{   const char *d;
-    unsigned flags;
-
 #define TFLAGSintegral  1
 #define TFLAGSfloating  2
 #define TFLAGSunsigned  4
@@ -2504,6 +2499,11 @@ TypeBasic::TypeBasic(TY ty)
 #define TFLAGSimaginary 0x10
 #define TFLAGScomplex   0x20
 #define TFLAGSvector    0x40    // valid for a SIMD vector type
+
+TypeBasic::TypeBasic(TY ty)
+        : Type(ty)
+{   const char *d;
+    unsigned flags;
 
     flags = 0;
     switch (ty)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -112,17 +112,18 @@ extern int Tsize_t;
 extern int Tptrdiff_t;
 
 
+/* pick this order of numbers so switch statements work better
+ */
+#define MODconst     1  // type is const
+#define MODimmutable 4  // type is immutable
+#define MODshared    2  // type is shared
+#define MODwild      8  // type is wild
+#define MODmutable   0x10       // type is mutable (only used in wildcard matching)
+
 struct Type : Object
 {
     TY ty;
     unsigned char mod;  // modifiers MODxxxx
-        /* pick this order of numbers so switch statements work better
-         */
-        #define MODconst     1  // type is const
-        #define MODimmutable 4  // type is immutable
-        #define MODshared    2  // type is shared
-        #define MODwild      8  // type is wild
-        #define MODmutable   0x10       // type is mutable (only used in wildcard matching)
     char *deco;
 
     /* These are cached values that are lazily evaluated by constOf(), invariantOf(), etc.

--- a/src/scope.h
+++ b/src/scope.h
@@ -38,6 +38,25 @@ enum LINK;
 enum PROT;
 #endif
 
+#define CSXthis_ctor    1       // called this()
+#define CSXsuper_ctor   2       // called super()
+#define CSXthis         4       // referenced this
+#define CSXsuper        8       // referenced super
+#define CSXlabel        0x10    // seen a label
+#define CSXreturn       0x20    // seen a return statement
+#define CSXany_ctor     0x40    // either this() or super() was called
+
+#define SCOPEctor       1       // constructor type
+#define SCOPEstaticif   2       // inside static if
+#define SCOPEfree       4       // is on free list
+#define SCOPEstaticassert 8     // inside static assert
+#define SCOPEdebug      0x10    // inside debug conditional
+
+#define SCOPEinvariant  0x20    // inside invariant code
+#define SCOPErequire    0x40    // inside in contract code
+#define SCOPEensure     0x60    // inside out contract code
+#define SCOPEcontract   0x60    // [mask] we're inside contract code
+
 struct Scope
 {
     Scope *enclosing;           // enclosing Scope
@@ -71,13 +90,6 @@ struct Scope
     int needctfe;               // inside a ctfe-only expression
 
     unsigned callSuper;         // primitive flow analysis for constructors
-#define CSXthis_ctor    1       // called this()
-#define CSXsuper_ctor   2       // called super()
-#define CSXthis         4       // referenced this
-#define CSXsuper        8       // referenced super
-#define CSXlabel        0x10    // seen a label
-#define CSXreturn       0x20    // seen a return statement
-#define CSXany_ctor     0x40    // either this() or super() was called
 
     structalign_t structalign;       // alignment for struct members
     enum LINK linkage;          // linkage for external functions
@@ -89,16 +101,6 @@ struct Scope
     char *depmsg;               // customized deprecation message
 
     unsigned flags;
-#define SCOPEctor       1       // constructor type
-#define SCOPEstaticif   2       // inside static if
-#define SCOPEfree       4       // is on free list
-#define SCOPEstaticassert 8     // inside static assert
-#define SCOPEdebug      0x10    // inside debug conditional
-
-#define SCOPEinvariant  0x20    // inside invariant code
-#define SCOPErequire    0x40    // inside in contract code
-#define SCOPEensure     0x60    // inside out contract code
-#define SCOPEcontract   0x60    // [mask] we're inside contract code
 
     Expressions *userAttributes;        // user defined attributes
 


### PR DESCRIPTION
Having these inside structs ignores scoping and does not make any sense for D
