### PR TITLE
[REG2.063a] Issue 10040 - struct-related ICE

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2778,6 +2778,7 @@ elem *AssignExp::toElem(IRState *irs)
             }
 
             Type *tn = tsa->nextOf()->toBasetype();
+            bool postblit = needsPostblit(tn) != NULL;
             tym_t ty = tn->totym();
 
             symbol *stmp = symbol_genauto(TYnptr);
@@ -2790,7 +2791,12 @@ elem *AssignExp::toElem(IRState *irs)
             {
                 Expression *en = (*ae->elements)[i];
                 size_t j = i + 1;
-                while (j < dim && en->equals((*ae->elements)[j])) { j++; }
+                if (!postblit)
+                {
+                    // If the elements are same literal and elaborate copy
+                    // is not necessary, do memcpy.
+                    while (j < dim && en->equals((*ae->elements)[j])) { j++; }
+                }
 
                 elem *e1 = el_var(stmp);
                 if (i > 0)

--- a/src/expression.c
+++ b/src/expression.c
@@ -4297,6 +4297,28 @@ StructLiteralExp::StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *
     //printf("StructLiteralExp::StructLiteralExp(%s)\n", toChars());
 }
 
+int StructLiteralExp::equals(Object *o)
+{
+    if (this == o)
+        return 1;
+    if (o && o->dyncast() == DYNCAST_EXPRESSION &&
+        ((Expression *)o)->op == TOKstructliteral)
+    {
+        StructLiteralExp *se = (StructLiteralExp *)o;
+        if (sd != se->sd)
+            return 0;
+        if (elements->dim != se->elements->dim)
+            return 0;
+        for (size_t i = 0; i < elements->dim; i++)
+        {
+            if (!(*elements)[i]->equals((*se->elements)[i]))
+                return 0;
+        }
+        return 1;
+    }
+    return 0;
+}
+
 Expression *StructLiteralExp::syntaxCopy()
 {
     StructLiteralExp *exp = new StructLiteralExp(loc, sd, arraySyntaxCopy(elements), stype);

--- a/src/expression.h
+++ b/src/expression.h
@@ -519,19 +519,19 @@ struct StructLiteralExp : Expression
     bool ownedByCtfe;           // true = created in CTFE
     int ctorinit;
 
-    StructLiteralExp *origin;   // pointer to the origin instance of the expression. 
-                                // once a new expression is created, origin is set to 'this'. 
-                                // anytime when an expression copy is created, 'origin' pointer is set to 
+    StructLiteralExp *origin;   // pointer to the origin instance of the expression.
+                                // once a new expression is created, origin is set to 'this'.
+                                // anytime when an expression copy is created, 'origin' pointer is set to
                                 // 'origin' pointer value of the original expression.
-                                
-    StructLiteralExp *inlinecopy; // those fields need to prevent a infinite recursion when one field of struct initialized with 'this' pointer. 
+
+    StructLiteralExp *inlinecopy; // those fields need to prevent a infinite recursion when one field of struct initialized with 'this' pointer.
     int stageflags;               // anytime when recursive function is calling, 'stageflags' marks with bit flag of
-                                  // current stage and unmarks before return from this function. 
-                                  // 'inlinecopy' uses similar 'stageflags' and from multiple evaluation 'doInline' 
+                                  // current stage and unmarks before return from this function.
+                                  // 'inlinecopy' uses similar 'stageflags' and from multiple evaluation 'doInline'
                                   // (with infinite recursion) of this expression.
 
     StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *elements, Type *stype = NULL);
-
+    int equals(Object *o);
     Expression *syntaxCopy();
     int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);

--- a/test/compilable/ice10040.d
+++ b/test/compilable/ice10040.d
@@ -1,0 +1,15 @@
+struct MsgProc1 { mixin MsgMixin; }
+struct MsgProc2 { mixin MsgMixin; }
+
+struct MsgHeader {}
+
+template MsgMixin()
+{
+    mixin(mixinMembers!(MsgHeader.init));
+}
+
+string mixinMembers(T ...)()
+{
+    struct Op {}
+    return null;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10040

This is one of the AST-identity issue. Maybe GDC/LDC requires this fix for the particular code compilation.

The second instantiation of `mixinMembers!(MsgHeader.init)` is incorrectly
judged as not identical with the first one, by the lack of `StructLiteralExp::equals`.
