### PR TITLE
[DDMD] Do not use #defined aliases to expressions in Type

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -81,6 +81,44 @@ ClassDeclaration *Type::typeinfowild;
 TemplateDeclaration *Type::associativearray;
 TemplateDeclaration *Type::rtinfo;
 
+Type *Type::tvoid;
+Type *Type::tint8;
+Type *Type::tuns8;
+Type *Type::tint16;
+Type *Type::tuns16;
+Type *Type::tint32;
+Type *Type::tuns32;
+Type *Type::tint64;
+Type *Type::tuns64;
+Type *Type::tint128;
+Type *Type::tuns128;
+Type *Type::tfloat32;
+Type *Type::tfloat64;
+Type *Type::tfloat80;
+
+Type *Type::timaginary32;
+Type *Type::timaginary64;
+Type *Type::timaginary80;
+
+Type *Type::tcomplex32;
+Type *Type::tcomplex64;
+Type *Type::tcomplex80;
+
+Type *Type::tbool;
+Type *Type::tchar;
+Type *Type::twchar;
+Type *Type::tdchar;
+
+Type *Type::tshiftcnt;
+Type *Type::tboolean;
+Type *Type::terror;
+Type *Type::tnull;
+
+Type *Type::tsize_t;
+Type *Type::tptrdiff_t;
+Type *Type::thash_t;
+Type *Type::tindex;
+
 Type *Type::tvoidptr;
 Type *Type::tstring;
 Type *Type::tvalist;
@@ -247,6 +285,38 @@ void Type::init()
     }
     basic[Terror] = new TypeError();
 
+    tvoid = basic[Tvoid];
+    tint8 = basic[Tint8];
+    tuns8 = basic[Tuns8];
+    tint16 = basic[Tint16];
+    tuns16 = basic[Tuns16];
+    tint32 = basic[Tint32];
+    tuns32 = basic[Tuns32];
+    tint64 = basic[Tint64];
+    tuns64 = basic[Tuns64];
+    tint128 = basic[Tint128];
+    tuns128 = basic[Tuns128];
+    tfloat32 = basic[Tfloat32];
+    tfloat64 = basic[Tfloat64];
+    tfloat80 = basic[Tfloat80];
+
+    timaginary32 = basic[Timaginary32];
+    timaginary64 = basic[Timaginary64];
+    timaginary80 = basic[Timaginary80];
+
+    tcomplex32 = basic[Tcomplex32];
+    tcomplex64 = basic[Tcomplex64];
+    tcomplex80 = basic[Tcomplex80];
+
+    tbool = basic[Tbool];
+    tchar = basic[Tchar];
+    twchar = basic[Twchar];
+    tdchar = basic[Tdchar];
+
+    tshiftcnt = tint32;
+    tboolean = tbool;
+    terror = basic[Terror];
+    tnull = basic[Tnull];
     tnull = new TypeNull();
     tnull->deco = tnull->merge()->deco;
 
@@ -264,6 +334,11 @@ void Type::init()
         Tsize_t = Tuns32;
         Tptrdiff_t = Tint32;
     }
+
+    tsize_t = basic[Tsize_t];
+    tptrdiff_t = basic[Tptrdiff_t];
+    thash_t = tsize_t;
+    tindex = tsize_t;
 }
 
 d_uns64 Type::size()

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -147,49 +147,47 @@ struct Type : Object
 
     type *ctype;        // for back end
 
-    #define tvoid       basic[Tvoid]
-    #define tint8       basic[Tint8]
-    #define tuns8       basic[Tuns8]
-    #define tint16      basic[Tint16]
-    #define tuns16      basic[Tuns16]
-    #define tint32      basic[Tint32]
-    #define tuns32      basic[Tuns32]
-    #define tint64      basic[Tint64]
-    #define tuns64      basic[Tuns64]
-    #define tint128     basic[Tint128]
-    #define tuns128     basic[Tuns128]
-    #define tfloat32    basic[Tfloat32]
-    #define tfloat64    basic[Tfloat64]
-    #define tfloat80    basic[Tfloat80]
+    static Type *tvoid;
+    static Type *tint8;
+    static Type *tuns8;
+    static Type *tint16;
+    static Type *tuns16;
+    static Type *tint32;
+    static Type *tuns32;
+    static Type *tint64;
+    static Type *tuns64;
+    static Type *tint128;
+    static Type *tuns128;
+    static Type *tfloat32;
+    static Type *tfloat64;
+    static Type *tfloat80;
 
-    #define timaginary32 basic[Timaginary32]
-    #define timaginary64 basic[Timaginary64]
-    #define timaginary80 basic[Timaginary80]
+    static Type *timaginary32;
+    static Type *timaginary64;
+    static Type *timaginary80;
 
-    #define tcomplex32  basic[Tcomplex32]
-    #define tcomplex64  basic[Tcomplex64]
-    #define tcomplex80  basic[Tcomplex80]
+    static Type *tcomplex32;
+    static Type *tcomplex64;
+    static Type *tcomplex80;
 
-    #define tbool       basic[Tbool]
-    #define tchar       basic[Tchar]
-    #define twchar      basic[Twchar]
-    #define tdchar      basic[Tdchar]
+    static Type *tbool;
+    static Type *tchar;
+    static Type *twchar;
+    static Type *tdchar;
 
     // Some special types
-    #define tshiftcnt   tint32          // right side of shift expression
-//    #define tboolean  tint32          // result of boolean expression
-    #define tboolean    tbool           // result of boolean expression
-    #define tindex      tsize_t         // array/ptr index
+    static Type *tshiftcnt;
+    static Type *tboolean;
     static Type *tvoidptr;              // void*
     static Type *tstring;               // immutable(char)[]
     static Type *tvalist;               // va_list alias
-    #define terror      basic[Terror]   // for error recovery
+    static Type *terror;                // for error recovery
+    static Type *tnull;                 // for null type
 
-    #define tnull       basic[Tnull]    // for null type
-
-    #define tsize_t     basic[Tsize_t]          // matches size_t alias
-    #define tptrdiff_t  basic[Tptrdiff_t]       // matches ptrdiff_t alias
-    #define thash_t     tsize_t                 // matches hash_t alias
+    static Type *tsize_t;               // matches size_t alias
+    static Type *tptrdiff_t;            // matches ptrdiff_t alias
+    static Type *thash_t;               // matches hash_t alias
+    static Type *tindex;                // array/ptr index
 
     static ClassDeclaration *typeinfo;
     static ClassDeclaration *typeinfoclass;


### PR DESCRIPTION
This patch gets rid of #defines which effectively alias expressions.  This is (thankfully) not allowed in D.

Some of the other type shortcuts were already static variables, so this is a straightforward extension.
