### PR TITLE
Fix Issue 10058 - Inconsistent mangling between C++ and extern(C++).

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -72,11 +72,11 @@ int CppMangleState::substitute(OutBuffer *buf, void *p)
     {
         if (p == components[i])
         {
-            /* Sequence is S_, S0_, .., S9_, SA_, ..., SZ_, S10_, ...
+            /* Sequence is S_, S1_, .., S9_, SA_, ..., SZ_, S10_, ...
              */
             buf->writeByte('S');
             if (i)
-                writeBase36(buf, i - 1);
+                writeBase36(buf, i);
             buf->writeByte('_');
             return 1;
         }
@@ -337,7 +337,7 @@ void TypeFunction::toCppMangle(OutBuffer *buf, CppMangleState *cms)
         TypeFunctions for non-static member functions, and non-static
         member functions of different classes.
      */
-    if (!cms->substitute(buf, this))
+    if (!cms->exist(this))
     {
         buf->writeByte('F');
         if (linkage == LINKc)
@@ -346,6 +346,8 @@ void TypeFunction::toCppMangle(OutBuffer *buf, CppMangleState *cms)
         Parameter::argsCppMangle(buf, cms, parameters, varargs);
         buf->writeByte('E');
     }
+    else
+        cms->substitute(buf, this);
 }
 
 

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1,0 +1,103 @@
+
+// Test C++ name mangling.
+// See Bug 7024, Bug 10058
+
+version(linux):
+extern(C++):
+
+/**********************************/
+
+void test1(void*)
+{
+}
+
+static assert(test1.mangleof  == "_Z5test1Pv");
+
+/**********************************/
+
+void test2(void function(void*))
+{
+}
+
+static assert(test2.mangleof  == "_Z5test2PFvPvE");
+
+/**********************************/
+
+void test3(void* function(void*))
+{
+}
+
+static assert(test3.mangleof  == "_Z5test3PFPvS_E");
+
+/**********************************/
+
+void test4(void function(void*), void*)
+{
+}
+
+static assert(test4.mangleof  == "_Z5test4PFvPvES_");
+
+/**********************************/
+
+void test5(void* function(void*), void*)
+{
+}
+
+static assert(test5.mangleof  == "_Z5test5PFPvS_ES_");
+
+/**********************************/
+
+void test6(void* function(void*), void* function(void*))
+{
+}
+
+static assert(test6.mangleof  == "_Z5test6PFPvS_ES1_");
+
+/**********************************/
+
+void test7(void function(void*), void*, void*)
+{
+}
+
+static assert(test7.mangleof  == "_Z5test7PFvPvES_S_");
+
+/**********************************/
+
+void test8(void* function(void*), void*, void*)
+{
+}
+
+static assert(test8.mangleof  == "_Z5test8PFPvS_ES_S_");
+
+/**********************************/
+
+void test9(void* function(void*), void* function(void*), void*)
+{
+}
+
+static assert(test9.mangleof  == "_Z5test9PFPvS_ES1_S_");
+
+/**********************************/
+
+void test10(void* function(void*), void* function(void*), void* function(void*))
+{
+}
+
+static assert(test10.mangleof == "_Z6test10PFPvS_ES1_S1_");
+
+/**********************************/
+
+void test11(void* function(void*), void* function(const (void)*))
+{
+}
+
+static assert(test11.mangleof == "_Z6test11PFPvS_EPFS_PKvE");
+
+/**********************************/
+
+void test12(void* function(void*), void* function(const (void)*), const(void)* function(void*))
+{
+}
+
+static assert(test12.mangleof == "_Z6test12PFPvS_EPFS_PKvEPFS3_S_E");
+


### PR DESCRIPTION
Fixes http://d.puremagic.com/issues/show_bug.cgi?id=10058

Though maybe the other implementations of ::toCppMangle should be altered to have the same logic as the change here?

Currently it's a half/half situation.
