### PR TITLE
[DDMD] Do not use implicit conversion from 0 to Loc

### DIFF
--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -220,8 +220,8 @@ Type *argtypemerge(Type *t1, Type *t2, unsigned offset2)
     if (!t2)
         return t1;
 
-    unsigned sz1 = t1->size(0);
-    unsigned sz2 = t2->size(0);
+    unsigned sz1 = t1->size(Loc());
+    unsigned sz2 = t2->size(Loc());
 
     if (t1->ty != t2->ty &&
         (t1->ty == Tfloat80 || t2->ty == Tfloat80))
@@ -284,7 +284,7 @@ TypeTuple *TypeStruct::toArgTypes()
     }
     Type *t1 = NULL;
     Type *t2 = NULL;
-    d_uns64 sz = size(0);
+    d_uns64 sz = size(Loc());
     assert(sz < 0xFFFFFFFF);
     switch ((unsigned)sz)
     {
@@ -346,7 +346,7 @@ TypeTuple *TypeStruct::toArgTypes()
                     goto Lmemory;
 
                 // Fields that overlap the 8byte boundary goto Lmemory
-                unsigned fieldsz = f->type->size(0);
+                unsigned fieldsz = f->type->size(Loc());
                 if (f->offset < 8 && (f->offset + fieldsz) > 8)
                     goto Lmemory;
             }

--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -322,30 +322,30 @@ Expression *BinExp::arrayOp(Scope *sc)
             Parameter *p = (*fparams)[0 /*fparams->dim - 1*/];
 #if DMDV1
             // for (size_t i = 0; i < p.length; i++)
-            Initializer *init = new ExpInitializer(0, new IntegerExp(0, 0, Type::tsize_t));
+            Initializer *init = new ExpInitializer(Loc(), new IntegerExp(Loc(), 0, Type::tsize_t));
             Dsymbol *d = new VarDeclaration(0, Type::tsize_t, Id::p, init);
             Statement *s1 = new ForStatement(0,
-                new ExpStatement(0, d),
-                new CmpExp(TOKlt, 0, new IdentifierExp(0, Id::p), new ArrayLengthExp(0, new IdentifierExp(0, p->ident))),
-                new PostExp(TOKplusplus, 0, new IdentifierExp(0, Id::p)),
-                new ExpStatement(0, loopbody));
+                new ExpStatement(Loc(), d),
+                new CmpExp(TOKlt, 0, new IdentifierExp(Loc(), Id::p), new ArrayLengthExp(0, new IdentifierExp(Loc(), p->ident))),
+                new PostExp(TOKplusplus, 0, new IdentifierExp(Loc(), Id::p)),
+                new ExpStatement(Loc(), loopbody));
 #else
             // foreach (i; 0 .. p.length)
-            Statement *s1 = new ForeachRangeStatement(0, TOKforeach,
+            Statement *s1 = new ForeachRangeStatement(Loc(), TOKforeach,
                 new Parameter(0, NULL, Id::p, NULL),
-                new IntegerExp(0, 0, Type::tsize_t),
-                new ArrayLengthExp(0, new IdentifierExp(0, p->ident)),
-                new ExpStatement(0, loopbody));
+                new IntegerExp(Loc(), 0, Type::tsize_t),
+                new ArrayLengthExp(Loc(), new IdentifierExp(Loc(), p->ident)),
+                new ExpStatement(Loc(), loopbody));
 #endif
-            Statement *s2 = new ReturnStatement(0, new IdentifierExp(0, p->ident));
+            Statement *s2 = new ReturnStatement(Loc(), new IdentifierExp(Loc(), p->ident));
             //printf("s2: %s\n", s2->toChars());
-            Statement *fbody = new CompoundStatement(0, s1, s2);
+            Statement *fbody = new CompoundStatement(Loc(), s1, s2);
 
             /* Construct the function
              */
             TypeFunction *ftype = new TypeFunction(fparams, type, 0, LINKc);
             //printf("ftype: %s\n", ftype->toChars());
-            fd = new FuncDeclaration(loc, 0, ident, STCundefined, ftype);
+            fd = new FuncDeclaration(loc, Loc(), ident, STCundefined, ftype);
             fd->fbody = fbody;
             fd->protection = PROTpublic;
             fd->linkage = LINKc;
@@ -372,7 +372,7 @@ Expression *BinExp::arrayOp(Scope *sc)
 
     /* Call the function fd(arguments)
      */
-    Expression *ec = new VarExp(0, fd);
+    Expression *ec = new VarExp(Loc(), fd);
     Expression *e = new CallExp(loc, ec, arguments);
     e->type = type;
     return e;
@@ -503,7 +503,7 @@ Expression *Expression::buildArrayLoop(Parameters *fparams)
     Identifier *id = Identifier::generateId("c", fparams->dim);
     Parameter *param = new Parameter(0, type, id, NULL);
     fparams->shift(param);
-    Expression *e = new IdentifierExp(0, id);
+    Expression *e = new IdentifierExp(Loc(), id);
     return e;
 }
 
@@ -523,11 +523,11 @@ Expression *SliceExp::buildArrayLoop(Parameters *fparams)
     Identifier *id = Identifier::generateId("p", fparams->dim);
     Parameter *param = new Parameter(STCconst, type, id, NULL);
     fparams->shift(param);
-    Expression *e = new IdentifierExp(0, id);
+    Expression *e = new IdentifierExp(Loc(), id);
     Expressions *arguments = new Expressions();
-    Expression *index = new IdentifierExp(0, Id::p);
+    Expression *index = new IdentifierExp(Loc(), Id::p);
     arguments->push(index);
-    e = new ArrayExp(0, e, arguments);
+    e = new ArrayExp(Loc(), e, arguments);
     return e;
 }
 
@@ -542,12 +542,12 @@ Expression *AssignExp::buildArrayLoop(Parameters *fparams)
      * where b is a byte fails because (c + p[i]) is an int
      * which cannot be implicitly cast to byte.
      */
-    ex2 = new CastExp(0, ex2, e1->type->nextOf());
+    ex2 = new CastExp(Loc(), ex2, e1->type->nextOf());
 #endif
     Expression *ex1 = e1->buildArrayLoop(fparams);
     Parameter *param = (*fparams)[0];
     param->storageClass = 0;
-    Expression *e = new AssignExp(0, ex1, ex2);
+    Expression *e = new AssignExp(Loc(), ex1, ex2);
     return e;
 }
 
@@ -581,14 +581,14 @@ X(Pow)
 Expression *NegExp::buildArrayLoop(Parameters *fparams)
 {
     Expression *ex1 = e1->buildArrayLoop(fparams);
-    Expression *e = new NegExp(0, ex1);
+    Expression *e = new NegExp(Loc(), ex1);
     return e;
 }
 
 Expression *ComExp::buildArrayLoop(Parameters *fparams)
 {
     Expression *ex1 = e1->buildArrayLoop(fparams);
-    Expression *e = new ComExp(0, ex1);
+    Expression *e = new ComExp(Loc(), ex1);
     return e;
 }
 
@@ -599,7 +599,7 @@ Expression *Str##Exp::buildArrayLoop(Parameters *fparams)       \
      */                                                         \
     Expression *ex1 = e1->buildArrayLoop(fparams);              \
     Expression *ex2 = e2->buildArrayLoop(fparams);              \
-    Expression *e = new Str##Exp(0, ex1, ex2);                  \
+    Expression *e = new Str##Exp(Loc(), ex1, ex2);                  \
     return e;                                                   \
 }
 

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1536,8 +1536,8 @@ Expressions *UserAttributeDeclaration::concat(Expressions *udas1, Expressions *u
          * (do not append to left operand, as this is a copy-on-write operation)
          */
         udas = new Expressions();
-        udas->push(new TupleExp(0, udas1));
-        udas->push(new TupleExp(0, udas2));
+        udas->push(new TupleExp(Loc(), udas1));
+        udas->push(new TupleExp(Loc(), udas2));
     }
     return udas;
 }
@@ -1562,8 +1562,8 @@ void UserAttributeDeclaration::setScope(Scope *sc)
             {
                 // Create a tuple that combines them
                 Expressions *exps = new Expressions();
-                exps->push(new TupleExp(0, newsc->userAttributes));
-                exps->push(new TupleExp(0, atts));
+                exps->push(new TupleExp(Loc(), newsc->userAttributes));
+                exps->push(new TupleExp(Loc(), atts));
                 newsc->userAttributes = exps;
             }
         }

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -2248,7 +2248,7 @@ size_t Obj::mangle(Symbol *s,char *dest)
 #if SCPP
             synerr(EM_identifier_too_long, name, len - IDMAX, IDMAX);
 #elif MARS
-//          error(0, "identifier %s is too long by %d characters", name, len - IDMAX);
+//          error(Loc(), "identifier %s is too long by %d characters", name, len - IDMAX);
 #else
             assert(0);
 #endif

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -163,27 +163,27 @@ Expression *eval_builtin(Loc loc, enum BUILTIN builtin, Expressions *arguments)
     {
         case BUILTINsin:
             if (arg0->op == TOKfloat64)
-                e = new RealExp(0, sinl(arg0->toReal()), arg0->type);
+                e = new RealExp(Loc(), sinl(arg0->toReal()), arg0->type);
             break;
 
         case BUILTINcos:
             if (arg0->op == TOKfloat64)
-                e = new RealExp(0, cosl(arg0->toReal()), arg0->type);
+                e = new RealExp(Loc(), cosl(arg0->toReal()), arg0->type);
             break;
 
         case BUILTINtan:
             if (arg0->op == TOKfloat64)
-                e = new RealExp(0, tanl(arg0->toReal()), arg0->type);
+                e = new RealExp(Loc(), tanl(arg0->toReal()), arg0->type);
             break;
 
         case BUILTINsqrt:
             if (arg0->op == TOKfloat64)
-                e = new RealExp(0, sqrtl(arg0->toReal()), arg0->type);
+                e = new RealExp(Loc(), sqrtl(arg0->toReal()), arg0->type);
             break;
 
         case BUILTINfabs:
             if (arg0->op == TOKfloat64)
-                e = new RealExp(0, fabsl(arg0->toReal()), arg0->type);
+                e = new RealExp(Loc(), fabsl(arg0->toReal()), arg0->type);
             break;
         // These math intrinsics are not yet implemented
         case BUILTINatan2:

--- a/src/cast.c
+++ b/src/cast.c
@@ -1022,7 +1022,7 @@ Type *SliceExp::toStaticArrayType()
         {
             size_t len = upr->toUInteger() - lwr->toUInteger();
             return new TypeSArray(type->toBasetype()->nextOf(),
-                        new IntegerExp(0, len, Type::tindex));
+                        new IntegerExp(Loc(), len, Type::tindex));
         }
     }
     return NULL;
@@ -2063,7 +2063,7 @@ Expression *BinExp::scaleFactor(Scope *sc)
         if (!t->equals(t2b))
             e2 = e2->castTo(sc, t);
         eoff = e2;
-        e2 = new MulExp(loc, e2, new IntegerExp(0, stride, t));
+        e2 = new MulExp(loc, e2, new IntegerExp(Loc(), stride, t));
         e2->type = t;
         type = e1->type;
     }
@@ -2079,7 +2079,7 @@ Expression *BinExp::scaleFactor(Scope *sc)
         else
             e = e1;
         eoff = e;
-        e = new MulExp(loc, e, new IntegerExp(0, stride, t));
+        e = new MulExp(loc, e, new IntegerExp(Loc(), stride, t));
         e->type = t;
         type = e2->type;
         e1 = e2;

--- a/src/class.c
+++ b/src/class.c
@@ -686,7 +686,7 @@ void ClassDeclaration::semantic(Scope *sc)
     /* Look for special member functions.
      * They must be in this class, not in a base class.
      */
-    ctor = search(0, Id::ctor, 0);
+    ctor = search(Loc(), Id::ctor, 0);
 #if DMDV1
     if (ctor && (ctor->toParent() != this || !ctor->isCtorDeclaration()))
         ctor = NULL;
@@ -704,8 +704,8 @@ void ClassDeclaration::semantic(Scope *sc)
 //      inv = NULL;
 
     // Can be in base class
-    aggNew    = (NewDeclaration *)search(0, Id::classNew, 0);
-    aggDelete = (DeleteDeclaration *)search(0, Id::classDelete, 0);
+    aggNew    = (NewDeclaration *)search(Loc(), Id::classNew, 0);
+    aggDelete = (DeleteDeclaration *)search(Loc(), Id::classDelete, 0);
 
     // If this class has no constructor, but base class has a default
     // ctor, create a constructor:
@@ -716,8 +716,8 @@ void ClassDeclaration::semantic(Scope *sc)
         {
             //printf("Creating default this(){} for class %s\n", toChars());
             Type *tf = new TypeFunction(NULL, NULL, 0, LINKd, 0);
-            CtorDeclaration *ctor = new CtorDeclaration(loc, 0, 0, tf);
-            ctor->fbody = new CompoundStatement(0, new Statements());
+            CtorDeclaration *ctor = new CtorDeclaration(loc, Loc(), 0, tf);
+            ctor->fbody = new CompoundStatement(Loc(), new Statements());
             members->push(ctor);
             ctor->addMember(sc, this, 1);
             *sc = scsave;   // why? What about sc->nofree?
@@ -1002,7 +1002,7 @@ int isf(void *param, FuncDeclaration *fd)
 int ClassDeclaration::isFuncHidden(FuncDeclaration *fd)
 {
     //printf("ClassDeclaration::isFuncHidden(class = %s, fd = %s)\n", toChars(), fd->toChars());
-    Dsymbol *s = search(0, fd->ident, 4|2);
+    Dsymbol *s = search(Loc(), fd->ident, 4|2);
     if (!s)
     {   //printf("not found\n");
         /* Because, due to a hack, if there are multiple definitions

--- a/src/clone.c
+++ b/src/clone.c
@@ -184,7 +184,7 @@ FuncDeclaration *StructDeclaration::buildOpAssign(Scope *sc)
     Type *ftype = new TypeFunction(fparams, handle, FALSE, LINKd);
     ((TypeFunction *)ftype)->isref = 1;
 
-    FuncDeclaration *fop = new FuncDeclaration(loc, 0, Id::assign, STCundefined, ftype);
+    FuncDeclaration *fop = new FuncDeclaration(loc, Loc(), Id::assign, STCundefined, ftype);
 
     Expression *e = NULL;
     if (dtor || postblit)
@@ -411,7 +411,7 @@ FuncDeclaration *StructDeclaration::buildXopEquals(Scope *sc)
      *     return p == q;
      * }
      */
-    Loc loc = 0;    // errors are gagged, so loc is not need
+    Loc loc = Loc();    // errors are gagged, so loc is not need
 
     Parameters *parameters = new Parameters;
     parameters->push(new Parameter(STCref | STCconst, type, Id::p, NULL));
@@ -420,11 +420,11 @@ FuncDeclaration *StructDeclaration::buildXopEquals(Scope *sc)
     tf = (TypeFunction *)tf->semantic(loc, sc);
 
     Identifier *id = Lexer::idPool("__xopEquals");
-    FuncDeclaration *fop = new FuncDeclaration(loc, 0, id, STCstatic, tf);
+    FuncDeclaration *fop = new FuncDeclaration(loc, Loc(), id, STCstatic, tf);
 
     Expression *e1 = new IdentifierExp(loc, Id::p);
     Expression *e2 = new IdentifierExp(loc, Id::q);
-    Expression *e = new EqualExp(TOKequal, 0, e1, e2);
+    Expression *e = new EqualExp(TOKequal, Loc(), e1, e2);
 
     fop->fbody = new ReturnStatement(loc, e);
 
@@ -505,7 +505,7 @@ FuncDeclaration *StructDeclaration::buildCpCtor(Scope *sc)
     Type *ftype = new TypeFunction(fparams, Type::tvoid, 0, LINKd, stc);
     ftype->mod = MODconst;
 
-    FuncDeclaration *fcp = new FuncDeclaration(loc, 0, Id::cpctor, stc, ftype);
+    FuncDeclaration *fcp = new FuncDeclaration(loc, Loc(), Id::cpctor, stc, ftype);
 
     if (!(stc & STCdisable))
     {
@@ -611,7 +611,7 @@ FuncDeclaration *StructDeclaration::buildPostBlit(Scope *sc)
      */
     if (e || (stc & STCdisable))
     {   //printf("Building __fieldPostBlit()\n");
-        PostBlitDeclaration *dd = new PostBlitDeclaration(loc, 0, stc, Lexer::idPool("__fieldPostBlit"));
+        PostBlitDeclaration *dd = new PostBlitDeclaration(loc, Loc(), stc, Lexer::idPool("__fieldPostBlit"));
         dd->fbody = new ExpStatement(loc, e);
         postblits.shift(dd);
         members->push(dd);
@@ -643,7 +643,7 @@ FuncDeclaration *StructDeclaration::buildPostBlit(Scope *sc)
                 ex = new CallExp(loc, ex);
                 e = Expression::combine(e, ex);
             }
-            PostBlitDeclaration *dd = new PostBlitDeclaration(loc, 0, stc, Lexer::idPool("__aggrPostBlit"));
+            PostBlitDeclaration *dd = new PostBlitDeclaration(loc, Loc(), stc, Lexer::idPool("__aggrPostBlit"));
             dd->fbody = new ExpStatement(loc, e);
             members->push(dd);
             dd->semantic(sc);
@@ -723,7 +723,7 @@ FuncDeclaration *AggregateDeclaration::buildDtor(Scope *sc)
      */
     if (e || (stc & STCdisable))
     {   //printf("Building __fieldDtor()\n");
-        DtorDeclaration *dd = new DtorDeclaration(loc, 0, stc, Lexer::idPool("__fieldDtor"));
+        DtorDeclaration *dd = new DtorDeclaration(loc, Loc(), stc, Lexer::idPool("__fieldDtor"));
         dd->fbody = new ExpStatement(loc, e);
         dtors.shift(dd);
         members->push(dd);
@@ -756,7 +756,7 @@ FuncDeclaration *AggregateDeclaration::buildDtor(Scope *sc)
                 ex = new CallExp(loc, ex);
                 e = Expression::combine(ex, e);
             }
-            DtorDeclaration *dd = new DtorDeclaration(loc, 0, stc, Lexer::idPool("__aggrDtor"));
+            DtorDeclaration *dd = new DtorDeclaration(loc, Loc(), stc, Lexer::idPool("__aggrDtor"));
             dd->fbody = new ExpStatement(loc, e);
             members->push(dd);
             dd->semantic(sc);

--- a/src/cond.c
+++ b/src/cond.c
@@ -52,7 +52,7 @@ Condition::Condition(Loc loc)
 /* ============================================================ */
 
 DVCondition::DVCondition(Module *mod, unsigned level, Identifier *ident)
-        : Condition(0)
+        : Condition(Loc())
 {
     this->mod = mod;
     this->level = level;
@@ -162,7 +162,7 @@ void VersionCondition::checkPredefined(Loc loc, const char *ident)
 
 void VersionCondition::addGlobalIdent(const char *ident)
 {
-    checkPredefined(0, ident);
+    checkPredefined(Loc(), ident);
     addPredefinedGlobalIdent(ident);
 }
 

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -380,13 +380,13 @@ Expression *paintTypeOntoLiteral(Type *type, Expression *lit)
     else if (lit->op == TOKarrayliteral)
     {
         e = new SliceExp(lit->loc, lit,
-            new IntegerExp(0, 0, Type::tsize_t), ArrayLength(Type::tsize_t, lit));
+            new IntegerExp(Loc(), 0, Type::tsize_t), ArrayLength(Type::tsize_t, lit));
     }
     else if (lit->op == TOKstring)
     {
         // For strings, we need to introduce another level of indirection
         e = new SliceExp(lit->loc, lit,
-            new IntegerExp(0, 0, Type::tsize_t), ArrayLength(Type::tsize_t, lit));
+            new IntegerExp(Loc(), 0, Type::tsize_t), ArrayLength(Type::tsize_t, lit));
     }
     else if (lit->op == TOKassocarrayliteral)
     {

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -246,7 +246,7 @@ Type *TupleDeclaration::getType()
 
         tupletype = new TypeTuple(args);
         if (hasdeco)
-            return tupletype->semantic(0, NULL);
+            return tupletype->semantic(Loc(), NULL);
     }
 
     return tupletype;
@@ -564,7 +564,7 @@ void AliasDeclaration::semantic(Scope *sc)
         //printf("\talias resolved to type %s\n", type->toChars());
     }
     if (overnext)
-        ScopeDsymbol::multiplyDefined(0, overnext, this);
+        ScopeDsymbol::multiplyDefined(Loc(), overnext, this);
     this->inSemantic = 0;
 
     if (global.gag && errors != global.errors)
@@ -590,7 +590,7 @@ void AliasDeclaration::semantic(Scope *sc)
             {
                 FuncAliasDeclaration *fa = new FuncAliasDeclaration(f);
                 if (!fa->overloadInsert(overnext))
-                    ScopeDsymbol::multiplyDefined(0, overnext, f);
+                    ScopeDsymbol::multiplyDefined(Loc(), overnext, f);
                 overnext = NULL;
                 s = fa;
                 s->parent = sc->parent;
@@ -608,7 +608,7 @@ void AliasDeclaration::semantic(Scope *sc)
             }
         }
         if (overnext)
-            ScopeDsymbol::multiplyDefined(0, overnext, this);
+            ScopeDsymbol::multiplyDefined(Loc(), overnext, this);
         if (s == this)
         {
             assert(global.errors);
@@ -1433,7 +1433,7 @@ Lnomatch:
                             if (t->ty != Tsarray)
                                 break;
                             dim *= ((TypeSArray *)t)->dim->toInteger();
-                            e1->type = new TypeSArray(t->nextOf(), new IntegerExp(0, dim, Type::tindex));
+                            e1->type = new TypeSArray(t->nextOf(), new IntegerExp(Loc(), dim, Type::tindex));
                         }
                     }
                     e1 = new SliceExp(loc, e1, NULL, NULL);
@@ -2270,7 +2270,7 @@ Expression *VarDeclaration::callScopeDtor(Scope *sc)
 
 void ObjectNotFound(Identifier *id)
 {
-    Type::error(0, "%s not found. object.d may be incorrectly installed or corrupt.", id->toChars());
+    Type::error(Loc(), "%s not found. object.d may be incorrectly installed or corrupt.", id->toChars());
     fatal();
 }
 
@@ -2287,7 +2287,7 @@ SymbolDeclaration::SymbolDeclaration(Loc loc, StructDeclaration *dsym)
 /********************************* ClassInfoDeclaration ****************************/
 
 ClassInfoDeclaration::ClassInfoDeclaration(ClassDeclaration *cd)
-    : VarDeclaration(0, ClassDeclaration::classinfo->type, cd->ident, NULL)
+    : VarDeclaration(Loc(), ClassDeclaration::classinfo->type, cd->ident, NULL)
 {
     this->cd = cd;
     storage_class = STCstatic | STCgshared;
@@ -2306,7 +2306,7 @@ void ClassInfoDeclaration::semantic(Scope *sc)
 /********************************* ModuleInfoDeclaration ****************************/
 
 ModuleInfoDeclaration::ModuleInfoDeclaration(Module *mod)
-    : VarDeclaration(0, Module::moduleinfo->type, mod->ident, NULL)
+    : VarDeclaration(Loc(), Module::moduleinfo->type, mod->ident, NULL)
 {
     this->mod = mod;
     storage_class = STCstatic | STCgshared;
@@ -2325,7 +2325,7 @@ void ModuleInfoDeclaration::semantic(Scope *sc)
 /********************************* TypeInfoDeclaration ****************************/
 
 TypeInfoDeclaration::TypeInfoDeclaration(Type *tinfo, int internal)
-    : VarDeclaration(0, Type::typeinfo->type, tinfo->getTypeInfoIdent(internal), NULL)
+    : VarDeclaration(Loc(), Type::typeinfo->type, tinfo->getTypeInfoIdent(internal), NULL)
 {
     this->tinfo = tinfo;
     storage_class = STCstatic | STCgshared;

--- a/src/delegatize.c
+++ b/src/delegatize.c
@@ -116,7 +116,7 @@ int lambdaCheckForNestedRef(Expression *e, void *param)
         {   SymOffExp *se = (SymOffExp *)e;
             VarDeclaration *v = se->var->isVarDeclaration();
             if (v)
-                v->checkNestedReference(sc, 0);
+                v->checkNestedReference(sc, Loc());
             break;
         }
 
@@ -124,7 +124,7 @@ int lambdaCheckForNestedRef(Expression *e, void *param)
         {   VarExp *ve = (VarExp *)e;
             VarDeclaration *v = ve->var->isVarDeclaration();
             if (v)
-                v->checkNestedReference(sc, 0);
+                v->checkNestedReference(sc, Loc());
             break;
         }
 
@@ -133,7 +133,7 @@ int lambdaCheckForNestedRef(Expression *e, void *param)
         {   ThisExp *te = (ThisExp *)e;
             VarDeclaration *v = te->var->isVarDeclaration();
             if (v)
-                v->checkNestedReference(sc, 0);
+                v->checkNestedReference(sc, Loc());
             break;
         }
 
@@ -142,7 +142,7 @@ int lambdaCheckForNestedRef(Expression *e, void *param)
             VarDeclaration *v = de->declaration->isVarDeclaration();
             if (v)
             {
-                v->checkNestedReference(sc, 0);
+                v->checkNestedReference(sc, Loc());
 
                 /* Some expressions cause the frontend to create a temporary.
                  * For example, structs with cpctors replace the original

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -45,7 +45,7 @@ Dsymbol::Dsymbol()
     this->parent = NULL;
     this->csym = NULL;
     this->isym = NULL;
-    this->loc = 0;
+    this->loc = Loc();
     this->comment = NULL;
     this->scope = NULL;
     this->errors = false;
@@ -61,7 +61,7 @@ Dsymbol::Dsymbol(Identifier *ident)
     this->parent = NULL;
     this->csym = NULL;
     this->isym = NULL;
-    this->loc = 0;
+    this->loc = Loc();
     this->comment = NULL;
     this->scope = NULL;
     this->errors = false;
@@ -402,7 +402,7 @@ void *symbol_search_fp(void *arg, const char *seed)
 
     Dsymbol *s = (Dsymbol *)arg;
     Module::clearCache();
-    return s->search(0, id, 4|2);
+    return s->search(Loc(), id, 4|2);
 }
 
 Dsymbol *Dsymbol::search_correct(Identifier *ident)
@@ -594,7 +594,7 @@ int Dsymbol::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
             s2 = sd->symtab->lookup(ident);
             if (!s2->overloadInsert(this))
             {
-                sd->multiplyDefined(0, this, s2);
+                sd->multiplyDefined(Loc(), this, s2);
             }
         }
         if (sd->isAggregateDeclaration() || sd->isEnumDeclaration())
@@ -1063,7 +1063,7 @@ Dsymbol *ScopeDsymbol::nameCollision(Dsymbol *s)
             return sprev;
         }
     }
-    multiplyDefined(0, s, sprev);
+    multiplyDefined(Loc(), s, sprev);
     return sprev;
 }
 
@@ -1214,7 +1214,7 @@ FuncDeclaration *ScopeDsymbol::findGetMembers()
 
         Type *tret = NULL;
         tfgetmembers = new TypeFunction(arguments, tret, 0, LINKd);
-        tfgetmembers = (TypeFunction *)tfgetmembers->semantic(0, &sc);
+        tfgetmembers = (TypeFunction *)tfgetmembers->semantic(Loc(), &sc);
     }
     if (fdx)
         fdx = fdx->overloadExactMatch(tfgetmembers);
@@ -1284,8 +1284,8 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
         {   /* $ gives the number of elements in the tuple
              */
             VarDeclaration *v = new VarDeclaration(loc, Type::tsize_t, Id::dollar, NULL);
-            Expression *e = new IntegerExp(0, td->objects->dim, Type::tsize_t);
-            v->init = new ExpInitializer(0, e);
+            Expression *e = new IntegerExp(Loc(), td->objects->dim, Type::tsize_t);
+            v->init = new ExpInitializer(Loc(), e);
             v->storage_class |= STCstatic | STCconst;
             v->semantic(sc);
             return v;
@@ -1295,8 +1295,8 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
         {   /* $ gives the number of type entries in the type tuple
              */
             VarDeclaration *v = new VarDeclaration(loc, Type::tsize_t, Id::dollar, NULL);
-            Expression *e = new IntegerExp(0, type->arguments->dim, Type::tsize_t);
-            v->init = new ExpInitializer(0, e);
+            Expression *e = new IntegerExp(Loc(), type->arguments->dim, Type::tsize_t);
+            v->init = new ExpInitializer(Loc(), e);
             v->storage_class |= STCstatic | STCconst;
             v->semantic(sc);
             return v;
@@ -1360,8 +1360,8 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
             {   /* It is for an expression tuple, so the
                  * length will be a const.
                  */
-                Expression *e = new IntegerExp(0, ((TupleExp *)ce)->exps->dim, Type::tsize_t);
-                v = new VarDeclaration(loc, Type::tsize_t, Id::dollar, new ExpInitializer(0, e));
+                Expression *e = new IntegerExp(Loc(), ((TupleExp *)ce)->exps->dim, Type::tsize_t);
+                v = new VarDeclaration(loc, Type::tsize_t, Id::dollar, new ExpInitializer(Loc(), e));
                 v->storage_class |= STCstatic | STCconst;
             }
             else if (ce->type && (t = ce->type->toBasetype()) != NULL &&
@@ -1423,7 +1423,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
                     }
 
                     Objects *tdargs = new Objects();
-                    Expression *edim = new IntegerExp(0, dim, Type::tsize_t);
+                    Expression *edim = new IntegerExp(Loc(), dim, Type::tsize_t);
                     edim = edim->semantic(sc);
                     tdargs->push(edim);
 
@@ -1453,7 +1453,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
                 t = e->type->toBasetype();
                 if (t && t->ty == Tfunction)
                     e = new CallExp(e->loc, e);
-                v = new VarDeclaration(loc, NULL, Id::dollar, new ExpInitializer(0, e));
+                v = new VarDeclaration(loc, NULL, Id::dollar, new ExpInitializer(Loc(), e));
             }
             else
             {   /* For arrays, $ will either be a compile-time constant
@@ -1461,7 +1461,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
                  * or a variable (in which case an expression is created in
                  * toir.c).
                  */
-                VoidInitializer *e = new VoidInitializer(0);
+                VoidInitializer *e = new VoidInitializer(Loc());
                 e->type = Type::tsize_t;
                 v = new VarDeclaration(loc, Type::tsize_t, Id::dollar, e);
                 v->storage_class |= STCctfe; // it's never a true static variable

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -59,7 +59,7 @@ elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi);
  */
 bool ISREF(Declaration *var, Type *tb)
 {
-    return (var->isParameter() && config.exe == EX_WIN64 && (var->type->size(0) > REGSIZE || var->storage_class & STClazy))
+    return (var->isParameter() && config.exe == EX_WIN64 && (var->type->size(Loc()) > REGSIZE || var->storage_class & STClazy))
             || var->isOut() || var->isRef();
 }
 
@@ -68,7 +68,7 @@ bool ISREF(Declaration *var, Type *tb)
 bool ISWIN64REF(Declaration *var)
 {
     return (config.exe == EX_WIN64 && var->isParameter() &&
-            (var->type->size(0) > REGSIZE || var->storage_class & STClazy)) &&
+            (var->type->size(Loc()) > REGSIZE || var->storage_class & STClazy)) &&
             !(var->isOut() || var->isRef());
 }
 

--- a/src/enum.c
+++ b/src/enum.c
@@ -298,7 +298,7 @@ void EnumDeclaration::semantic(Scope *sc)
             // Lazily evaluate enum.max
             if (!emax)
             {
-                emax = t->getProperty(0, Id::max, 0);
+                emax = t->getProperty(Loc(), Id::max, 0);
                 emax = emax->ctfeSemantic(sce);
                 emax = emax->ctfeInterpret();
             }

--- a/src/expression.c
+++ b/src/expression.c
@@ -557,7 +557,7 @@ Expression *resolveUFCS(Scope *sc, CallExp *ce)
             {   TypeAArray *taa = (TypeAArray *)t;
                 assert(taa->ty == Taarray);
                 StructDeclaration *sd = taa->getImpl();
-                Dsymbol *s = sd->search(0, ident, 2);
+                Dsymbol *s = sd->search(Loc(), ident, 2);
                 if (s)
                     return NULL;
             }
@@ -868,7 +868,7 @@ Expressions *arrayExpressionToCommonType(Scope *sc, Expressions *exps, Type **pt
      */
     //printf("arrayExpressionToCommonType()\n");
     IntegerExp integerexp(0);
-    CondExp condexp(0, &integerexp, NULL, NULL);
+    CondExp condexp(Loc(), &integerexp, NULL, NULL);
 
     Type *t0 = NULL;
     Expression *e0;
@@ -1090,7 +1090,7 @@ Expression *callCpCtor(Loc loc, Scope *sc, Expression *e, int noscope)
              * directly onto the stack.
              */
             Identifier *idtmp = Lexer::uniqueId("__cpcttmp");
-            VarDeclaration *tmp = new VarDeclaration(loc, tb, idtmp, new ExpInitializer(0, e));
+            VarDeclaration *tmp = new VarDeclaration(loc, tb, idtmp, new ExpInitializer(Loc(), e));
             tmp->storage_class |= STCctfe;
             tmp->noscope = noscope;
             Expression *ae = new DeclarationExp(loc, tmp);
@@ -1245,7 +1245,7 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                         v->parent = sc->parent;
                         //sc->insert(v);
 
-                        Expression *c = new DeclarationExp(0, v);
+                        Expression *c = new DeclarationExp(Loc(), v);
                         c->type = v->type;
 
                         for (size_t u = i; u < nargs; u++)
@@ -2395,7 +2395,7 @@ IntegerExp::IntegerExp(Loc loc, dinteger_t value, Type *type)
 }
 
 IntegerExp::IntegerExp(dinteger_t value)
-        : Expression(0, TOKint64, sizeof(IntegerExp))
+        : Expression(Loc(), TOKint64, sizeof(IntegerExp))
 {
     this->type = Type::tint32;
     this->value = value;
@@ -2677,7 +2677,7 @@ void IntegerExp::toMangleBuffer(OutBuffer *buf)
  */
 
 ErrorExp::ErrorExp()
-    : IntegerExp(0, 0, Type::terror)
+    : IntegerExp(Loc(), 0, Type::terror)
 {
     op = TOKerror;
 }
@@ -4427,7 +4427,7 @@ Expression *StructLiteralExp::semantic(Scope *sc)
     if (sd->dtor && sc->func)
     {
         Identifier *idtmp = Lexer::uniqueId("__sl");
-        VarDeclaration *tmp = new VarDeclaration(loc, type, idtmp, new ExpInitializer(0, this));
+        VarDeclaration *tmp = new VarDeclaration(loc, type, idtmp, new ExpInitializer(Loc(), this));
         tmp->storage_class |= STCctfe;
         Expression *ae = new DeclarationExp(loc, tmp);
         Expression *e = new CommaExp(loc, ae, new VarExp(loc, tmp));
@@ -8087,7 +8087,7 @@ Lagain:
             {
                 if (ad->scope)
                     ad->semantic(ad->scope);
-                else if (!ad->ctor && ad->search(0, Id::ctor, 0))
+                else if (!ad->ctor && ad->search(Loc(), Id::ctor, 0))
                 {
                     // The constructor hasn't been found yet, see bug 8741
                     // This can happen if we are inferring type from
@@ -9187,7 +9187,7 @@ Expression *DeleteExp::semantic(Scope *sc)
 
                 if (fd)
                 {   Expression *e = ea ? new VarExp(loc, v) : e1;
-                    e = new DotVarExp(0, e, fd, 0);
+                    e = new DotVarExp(Loc(), e, fd, 0);
                     eb = new CallExp(loc, e);
                     eb = eb->semantic(sc);
                 }
@@ -10847,7 +10847,7 @@ Ltupleassign:
                 Type * aaValueType = ((TypeAArray *)((IndexExp*)e1)->e1->type->toBasetype())->next;
                 Identifier *id = Lexer::uniqueId("__aatmp");
                 VarDeclaration *v = new VarDeclaration(loc, aaValueType,
-                    id, new VoidInitializer(0));
+                    id, new VoidInitializer(Loc()));
                 v->storage_class |= STCctfe;
                 v->semantic(sc);
                 v->parent = sc->parent;
@@ -11215,7 +11215,7 @@ Expression *CatAssignExp::semantic(Scope *sc)
         (e2->implicitConvTo(e1->type)
 #if DMDV2
          || (tb2->nextOf()->implicitConvTo(tb1next) &&
-             (tb2->nextOf()->size(0) == tb1next->size(0) ||
+             (tb2->nextOf()->size(Loc()) == tb1next->size(Loc()) ||
              tb1next->ty == Tchar || tb1next->ty == Twchar || tb1next->ty == Tdchar))
 #endif
         )
@@ -11512,7 +11512,7 @@ Expression *MinExp::semantic(Scope *sc)
             }
             else
             {
-                e = new DivExp(loc, this, new IntegerExp(0, stride, Type::tptrdiff_t));
+                e = new DivExp(loc, this, new IntegerExp(Loc(), stride, Type::tptrdiff_t));
                 e->type = Type::tptrdiff_t;
             }
             return e;
@@ -11955,7 +11955,7 @@ Expression *PowExp::semantic(Scope *sc)
             // Replace x^^2 with (tmp = x, tmp*tmp)
             // Replace x^^3 with (tmp = x, tmp*tmp*tmp)
             Identifier *idtmp = Lexer::uniqueId("__powtmp");
-            VarDeclaration *tmp = new VarDeclaration(loc, e1->type->toBasetype(), idtmp, new ExpInitializer(0, e1));
+            VarDeclaration *tmp = new VarDeclaration(loc, e1->type->toBasetype(), idtmp, new ExpInitializer(Loc(), e1));
             tmp->storage_class = STCctfe;
             Expression *ve = new VarExp(loc, tmp);
             Expression *ae = new DeclarationExp(loc, tmp);
@@ -12992,7 +12992,7 @@ Expression *FuncInitExp::semantic(Scope *sc)
 {
     //printf("FuncInitExp::semantic()\n");
     type = Type::tstring;
-    if (sc->func) return this->resolveLoc(0, sc);
+    if (sc->func) return this->resolveLoc(Loc(), sc);
     return this;
 }
 
@@ -13022,7 +13022,7 @@ Expression *PrettyFuncInitExp::semantic(Scope *sc)
 {
     //printf("PrettyFuncInitExp::semantic()\n");
     type = Type::tstring;
-    if (sc->func) return this->resolveLoc(0, sc);
+    if (sc->func) return this->resolveLoc(Loc(), sc);
     return this;
 }
 
@@ -13082,7 +13082,7 @@ ArrayExp *resolveOpDollar(Scope *sc, ArrayExp *ae)
         if (ae->lengthVar)
         {   // If $ was used, declare it now
             Expression *de = new DeclarationExp(ae->loc, ae->lengthVar);
-            e = new CommaExp(0, de, e);
+            e = new CommaExp(Loc(), de, e);
             e = e->semantic(sc);
         }
         (*ae->arguments)[i] = e;
@@ -13122,7 +13122,7 @@ SliceExp *resolveOpDollar(Scope *sc, SliceExp *se)
     if (se->lengthVar)
     {   // If $ was used, declare it now
         Expression *de = new DeclarationExp(se->loc, se->lengthVar);
-        se->lwr = new CommaExp(0, de, se->lwr);
+        se->lwr = new CommaExp(Loc(), de, se->lwr);
         se->lwr = se->lwr->semantic(sc);
     }
     sc = sc->pop();

--- a/src/func.c
+++ b/src/func.c
@@ -1019,7 +1019,7 @@ void FuncDeclaration::semantic3(Scope *sc)
 
             if (f->linkage == LINKd)
             {   // Declare _arguments[]
-                v_arguments = new VarDeclaration(0, Type::typeinfotypelist->type, Id::_arguments_typeinfo, NULL);
+                v_arguments = new VarDeclaration(Loc(), Type::typeinfotypelist->type, Id::_arguments_typeinfo, NULL);
                 v_arguments->storage_class = STCparameter;
                 v_arguments->semantic(sc2);
                 sc2->insert(v_arguments);
@@ -1027,7 +1027,7 @@ void FuncDeclaration::semantic3(Scope *sc)
 
                 //t = Type::typeinfo->type->constOf()->arrayOf();
                 t = Type::typeinfo->type->arrayOf();
-                _arguments = new VarDeclaration(0, t, Id::_arguments, NULL);
+                _arguments = new VarDeclaration(Loc(), t, Id::_arguments, NULL);
                 _arguments->semantic(sc2);
                 sc2->insert(_arguments);
                 _arguments->parent = this;
@@ -1035,7 +1035,7 @@ void FuncDeclaration::semantic3(Scope *sc)
             if (f->linkage == LINKd || (f->parameters && Parameter::dim(f->parameters)))
             {   // Declare _argptr
                 t = Type::tvalist;
-                argptr = new VarDeclaration(0, t, Id::_argptr, NULL);
+                argptr = new VarDeclaration(Loc(), t, Id::_argptr, NULL);
                 argptr->semantic(sc2);
                 sc2->insert(argptr);
                 argptr->parent = this;
@@ -1117,7 +1117,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     for (size_t j = 0; j < dim; j++)
                     {   Parameter *narg = Parameter::getNth(t->arguments, j);
                         assert(narg->ident);
-                        VarDeclaration *v = sc2->search(0, narg->ident, NULL)->isVarDeclaration();
+                        VarDeclaration *v = sc2->search(Loc(), narg->ident, NULL)->isVarDeclaration();
                         assert(v);
                         Expression *e = new VarExp(v->loc, v);
                         (*exps)[j] = e;
@@ -1154,24 +1154,24 @@ void FuncDeclaration::semantic3(Scope *sc)
                 }
                 if (inv)
                 {
-                    e = new DsymbolExp(0, inv);
-                    e = new CallExp(0, e);
+                    e = new DsymbolExp(Loc(), inv);
+                    e = new CallExp(Loc(), e);
                     e = e->semantic(sc2);
                 }
             }
             else
             {   // Call invariant virtually
-                Expression *v = new ThisExp(0);
+                Expression *v = new ThisExp(Loc());
                 v->type = vthis->type;
                 if (ad->isStructDeclaration())
                     v = v->addressOf(sc);
-                Expression *se = new StringExp(0, (char *)"null this");
+                Expression *se = new StringExp(Loc(), (char *)"null this");
                 se = se->semantic(sc);
                 se->type = Type::tchar->arrayOf();
                 e = new AssertExp(loc, v, se);
             }
             if (e)
-                fpreinv = new ExpStatement(0, e);
+                fpreinv = new ExpStatement(Loc(), e);
         }
 
         // Postcondition invariant
@@ -1194,21 +1194,21 @@ void FuncDeclaration::semantic3(Scope *sc)
                 }
                 if (inv)
                 {
-                    e = new DsymbolExp(0, inv);
-                    e = new CallExp(0, e);
+                    e = new DsymbolExp(Loc(), inv);
+                    e = new CallExp(Loc(), e);
                     e = e->semantic(sc2);
                 }
             }
             else
             {   // Call invariant virtually
-                Expression *v = new ThisExp(0);
+                Expression *v = new ThisExp(Loc());
                 v->type = vthis->type;
                 if (ad->isStructDeclaration())
                     v = v->addressOf(sc);
-                e = new AssertExp(0, v);
+                e = new AssertExp(Loc(), v);
             }
             if (e)
-                fpostinv = new ExpStatement(0, e);
+                fpostinv = new ExpStatement(Loc(), e);
         }
 
         if (fensure || addPostInvariant())
@@ -1247,7 +1247,7 @@ void FuncDeclaration::semantic3(Scope *sc)
 
             fbody = fbody->semantic(sc2);
             if (!fbody)
-                fbody = new CompoundStatement(0, new Statements());
+                fbody = new CompoundStatement(Loc(), new Statements());
 
             if (inferRetType)
             {   // If no return type inferred yet, then infer a void
@@ -1338,18 +1338,18 @@ void FuncDeclaration::semantic3(Scope *sc)
                     sc2->callSuper = 0;
 
                     // Insert implicit super() at start of fbody
-                    if (!resolveFuncCall(0, sc2, cd->baseClass->ctor, NULL, NULL, NULL, 1))
+                    if (!resolveFuncCall(Loc(), sc2, cd->baseClass->ctor, NULL, NULL, NULL, 1))
                     {
                         error("no match for implicit super() call in constructor");
                     }
                     else
                     {
-                        Expression *e1 = new SuperExp(0);
-                        Expression *e = new CallExp(0, e1);
+                        Expression *e1 = new SuperExp(Loc());
+                        Expression *e = new CallExp(Loc(), e1);
                         e = e->semantic(sc2);
 
-                        Statement *s = new ExpStatement(0, e);
-                        fbody = new CompoundStatement(0, s, fbody);
+                        Statement *s = new ExpStatement(Loc(), e);
+                        fbody = new CompoundStatement(Loc(), s, fbody);
                     }
                 }
 
@@ -1370,8 +1370,8 @@ void FuncDeclaration::semantic3(Scope *sc)
             else if (fes)
             {   // For foreach(){} body, append a return 0;
                 Expression *e = new IntegerExp(0);
-                Statement *s = new ReturnStatement(0, e);
-                fbody = new CompoundStatement(0, fbody, s);
+                Statement *s = new ReturnStatement(Loc(), e);
+                fbody = new CompoundStatement(Loc(), fbody, s);
                 assert(!returnLabel);
             }
             else if (!hasReturnExp && type->nextOf()->ty != Tvoid)
@@ -1418,10 +1418,10 @@ void FuncDeclaration::semantic3(Scope *sc)
                         }
                         else
                             e = new HaltExp(endloc);
-                        e = new CommaExp(0, e, type->nextOf()->defaultInit());
+                        e = new CommaExp(Loc(), e, type->nextOf()->defaultInit());
                         e = e->semantic(sc2);
-                        Statement *s = new ExpStatement(0, e);
-                        fbody = new CompoundStatement(0, fbody, s);
+                        Statement *s = new ExpStatement(Loc(), e);
+                        fbody = new CompoundStatement(Loc(), fbody, s);
                     }
                 }
             }
@@ -1494,7 +1494,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                         assert(ie);
                         if (ie->exp->op == TOKconstruct)
                             ie->exp->op = TOKassign; // construction occured in parameter processing
-                        a->push(new ExpStatement(0, ie->exp));
+                        a->push(new ExpStatement(Loc(), ie->exp));
                     }
                 }
             }
@@ -1509,12 +1509,12 @@ void FuncDeclaration::semantic3(Scope *sc)
                 Type *t = argptr->type;
                 if (global.params.is64bit && !global.params.isWindows)
                 {   // Initialize _argptr to point to v_argsave
-                    Expression *e1 = new VarExp(0, argptr);
-                    Expression *e = new SymOffExp(0, v_argsave, 6*8 + 8*16);
+                    Expression *e1 = new VarExp(Loc(), argptr);
+                    Expression *e = new SymOffExp(Loc(), v_argsave, 6*8 + 8*16);
                     e->type = argptr->type;
-                    e = new AssignExp(0, e1, e);
+                    e = new AssignExp(Loc(), e1, e);
                     e = e->semantic(sc);
-                    a->push(new ExpStatement(0, e));
+                    a->push(new ExpStatement(Loc(), e));
                 }
                 else
                 {   // Initialize _argptr to point past non-variadic arg
@@ -1522,7 +1522,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     unsigned offset = 0;
                     Expression *e;
 
-                    Expression *e1 = new VarExp(0, argptr);
+                    Expression *e1 = new VarExp(Loc(), argptr);
                     // Find the last non-ref parameter
                     if (parameters && parameters->dim)
                     {
@@ -1552,11 +1552,11 @@ void FuncDeclaration::semantic3(Scope *sc)
                             /* Necessary to offset the extra level of indirection the Win64
                              * ABI demands
                              */
-                            e = new SymOffExp(0,p,0);
+                            e = new SymOffExp(Loc(),p,0);
                             e->type = Type::tvoidptr;
-                            e = new AddrExp(0, e);
+                            e = new AddrExp(Loc(), e);
                             e->type = Type::tvoidptr;
-                            e = new AddExp(0, e, new IntegerExp(offset));
+                            e = new AddExp(Loc(), e, new IntegerExp(offset));
                             e->type = Type::tvoidptr;
                             goto L1;
                         }
@@ -1567,13 +1567,13 @@ void FuncDeclaration::semantic3(Scope *sc)
                     else
                         offset += p->type->size();
                     offset = (offset + Target::ptrsize - 1) & ~(Target::ptrsize - 1);  // assume stack aligns on pointer size
-                    e = new SymOffExp(0, p, offset);
+                    e = new SymOffExp(Loc(), p, offset);
                     e->type = Type::tvoidptr;
                     //e = e->semantic(sc);
                 L1:
-                    e = new AssignExp(0, e1, e);
+                    e = new AssignExp(Loc(), e1, e);
                     e->type = t;
-                    a->push(new ExpStatement(0, e));
+                    a->push(new ExpStatement(Loc(), e));
                     p->isargptr = TRUE;
                 }
 #endif
@@ -1588,12 +1588,12 @@ void FuncDeclaration::semantic3(Scope *sc)
                 /* Advance to elements[] member of TypeInfo_Tuple with:
                  *  _arguments = v_arguments.elements;
                  */
-                Expression *e = new VarExp(0, v_arguments);
-                e = new DotIdExp(0, e, Id::elements);
-                Expression *e1 = new VarExp(0, _arguments);
-                e = new ConstructExp(0, e1, e);
+                Expression *e = new VarExp(Loc(), v_arguments);
+                e = new DotIdExp(Loc(), e, Id::elements);
+                Expression *e1 = new VarExp(Loc(), _arguments);
+                e = new ConstructExp(Loc(), e1, e);
                 e = e->semantic(sc2);
-                a->push(new ExpStatement(0, e));
+                a->push(new ExpStatement(Loc(), e));
             }
 
             // Merge contracts together with body into one compound statement
@@ -1603,7 +1603,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (!freq)
                     freq = fpreinv;
                 else if (fpreinv)
-                    freq = new CompoundStatement(0, freq, fpreinv);
+                    freq = new CompoundStatement(Loc(), freq, fpreinv);
 
                 a->push(freq);
             }
@@ -1616,31 +1616,31 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (!fens)
                     fens = fpostinv;
                 else if (fpostinv)
-                    fens = new CompoundStatement(0, fpostinv, fens);
+                    fens = new CompoundStatement(Loc(), fpostinv, fens);
 
-                LabelStatement *ls = new LabelStatement(0, Id::returnLabel, fens);
+                LabelStatement *ls = new LabelStatement(Loc(), Id::returnLabel, fens);
                 returnLabel->statement = ls;
                 a->push(returnLabel->statement);
 
                 if (type->nextOf()->ty != Tvoid && vresult)
                 {
                     // Create: return vresult;
-                    Expression *e = new VarExp(0, vresult);
+                    Expression *e = new VarExp(Loc(), vresult);
                     if (tintro)
                     {   e = e->implicitCastTo(sc, tintro->nextOf());
                         e = e->semantic(sc);
                     }
-                    ReturnStatement *s = new ReturnStatement(0, e);
+                    ReturnStatement *s = new ReturnStatement(Loc(), e);
                     a->push(s);
                 }
             }
             if (isMain() && type->nextOf()->ty == Tvoid)
             {   // Add a return 0; statement
-                Statement *s = new ReturnStatement(0, new IntegerExp(0));
+                Statement *s = new ReturnStatement(Loc(), new IntegerExp(0));
                 a->push(s);
             }
 
-            fbody = new CompoundStatement(0, a);
+            fbody = new CompoundStatement(Loc(), a);
 #if DMDV2
             /* Append destructor calls for parameters as finally blocks.
              */
@@ -1657,7 +1657,7 @@ void FuncDeclaration::semantic3(Scope *sc)
 
                     Expression *e = v->edtor;
                     if (e)
-                    {   Statement *s = new ExpStatement(0, e);
+                    {   Statement *s = new ExpStatement(Loc(), e);
                         s = s->semantic(sc2);
                         int nothrowErrors = global.errors;
                         bool isnothrow = f->isnothrow & !(flags & FUNCFLAGnothrowInprocess);
@@ -1667,9 +1667,9 @@ void FuncDeclaration::semantic3(Scope *sc)
                         if (flags & FUNCFLAGnothrowInprocess && blockexit & BEthrow)
                             f->isnothrow = FALSE;
                         if (fbody->blockExit(f->isnothrow) == BEfallthru)
-                            fbody = new CompoundStatement(0, fbody, s);
+                            fbody = new CompoundStatement(Loc(), fbody, s);
                         else
-                            fbody = new TryFinallyStatement(0, fbody, s);
+                            fbody = new TryFinallyStatement(Loc(), fbody, s);
                     }
                 }
             }
@@ -2138,11 +2138,11 @@ Statement *FuncDeclaration::mergeFensure(Statement *sf)
                      * to match offset difference in covariant return.
                      * See bugzilla 5204.
                      */
-                    ExpInitializer *ei = new ExpInitializer(0, eresult);
-                    VarDeclaration *v = new VarDeclaration(0, t1, Lexer::uniqueId("__covres"), ei);
-                    DeclarationExp *de = new DeclarationExp(0, v);
-                    VarExp *ve = new VarExp(0, v);
-                    eresult = new CommaExp(0, de, ve);
+                    ExpInitializer *ei = new ExpInitializer(Loc(), eresult);
+                    VarDeclaration *v = new VarDeclaration(Loc(), t1, Lexer::uniqueId("__covres"), ei);
+                    DeclarationExp *de = new DeclarationExp(Loc(), v);
+                    VarExp *ve = new VarExp(Loc(), v);
+                    eresult = new CommaExp(Loc(), de, ve);
                 }
             }
             Expression *e = new CallExp(loc, new VarExp(loc, fdv->fdensure, 0), eresult);
@@ -2764,11 +2764,11 @@ MATCH FuncDeclaration::leastAsSpecialized(FuncDeclaration *g)
         Expression *e;
         if (p->storageClass & (STCref | STCout))
         {
-            e = new IdentifierExp(0, p->ident);
+            e = new IdentifierExp(Loc(), p->ident);
             e->type = p->type;
         }
         else
-            e = p->type->defaultInitLiteral(0);
+            e = p->type->defaultInitLiteral(Loc());
         args[u] = e;
     }
 
@@ -2958,7 +2958,7 @@ Lerr:
 void FuncDeclaration::appendExp(Expression *e)
 {   Statement *s;
 
-    s = new ExpStatement(0, e);
+    s = new ExpStatement(Loc(), e);
     appendState(s);
 }
 
@@ -2977,7 +2977,7 @@ void FuncDeclaration::appendState(Statement *s)
                 cs->statements->push(s);
         }
         else
-            fbody = new CompoundStatement(0, fbody, s);
+            fbody = new CompoundStatement(Loc(), fbody, s);
     }
 }
 
@@ -3451,7 +3451,7 @@ FuncDeclaration *FuncDeclaration::genCfunc(Type *treturn, Identifier *id)
     else
     {
         tf = new TypeFunction(NULL, treturn, 0, LINKc);
-        fd = new FuncDeclaration(0, 0, id, STCstatic, tf);
+        fd = new FuncDeclaration(Loc(), Loc(), id, STCstatic, tf);
         fd->protection = PROTpublic;
         fd->linkage = LINKc;
 
@@ -4160,19 +4160,19 @@ void StaticCtorDeclaration::semantic(Scope *sc)
          * during static construction.
          */
         Identifier *id = Lexer::idPool("__gate");
-        VarDeclaration *v = new VarDeclaration(0, Type::tint32, id, NULL);
+        VarDeclaration *v = new VarDeclaration(Loc(), Type::tint32, id, NULL);
         v->storage_class = isSharedStaticCtorDeclaration() ? STCstatic : STCtls;
         Statements *sa = new Statements();
-        Statement *s = new ExpStatement(0, v);
+        Statement *s = new ExpStatement(Loc(), v);
         sa->push(s);
-        Expression *e = new IdentifierExp(0, id);
-        e = new AddAssignExp(0, e, new IntegerExp(1));
-        e = new EqualExp(TOKnotequal, 0, e, new IntegerExp(1));
-        s = new IfStatement(0, NULL, e, new ReturnStatement(0, NULL), NULL);
+        Expression *e = new IdentifierExp(Loc(), id);
+        e = new AddAssignExp(Loc(), e, new IntegerExp(1));
+        e = new EqualExp(TOKnotequal, Loc(), e, new IntegerExp(1));
+        s = new IfStatement(Loc(), NULL, e, new ReturnStatement(Loc(), NULL), NULL);
         sa->push(s);
         if (fbody)
             sa->push(fbody);
-        fbody = new CompoundStatement(0, sa);
+        fbody = new CompoundStatement(Loc(), sa);
     }
 
     FuncDeclaration::semantic(sc);
@@ -4294,19 +4294,19 @@ void StaticDtorDeclaration::semantic(Scope *sc)
          * during static destruction.
          */
         Identifier *id = Lexer::idPool("__gate");
-        VarDeclaration *v = new VarDeclaration(0, Type::tint32, id, NULL);
+        VarDeclaration *v = new VarDeclaration(Loc(), Type::tint32, id, NULL);
         v->storage_class = isSharedStaticDtorDeclaration() ? STCstatic : STCtls;
         Statements *sa = new Statements();
-        Statement *s = new ExpStatement(0, v);
+        Statement *s = new ExpStatement(Loc(), v);
         sa->push(s);
-        Expression *e = new IdentifierExp(0, id);
-        e = new AddAssignExp(0, e, new IntegerExp(-1));
-        e = new EqualExp(TOKnotequal, 0, e, new IntegerExp(0));
-        s = new IfStatement(0, NULL, e, new ReturnStatement(0, NULL), NULL);
+        Expression *e = new IdentifierExp(Loc(), id);
+        e = new AddAssignExp(Loc(), e, new IntegerExp(-1));
+        e = new EqualExp(TOKnotequal, Loc(), e, new IntegerExp(0));
+        s = new IfStatement(Loc(), NULL, e, new ReturnStatement(Loc(), NULL), NULL);
         sa->push(s);
         if (fbody)
             sa->push(fbody);
-        fbody = new CompoundStatement(0, sa);
+        fbody = new CompoundStatement(Loc(), sa);
         vgate = v;
     }
 

--- a/src/glue.c
+++ b/src/glue.c
@@ -926,29 +926,29 @@ void FuncDeclaration::toObjFile(int multiobj)
              *   finally
              *     _c_trace_epi();
              */
-            StringExp *se = new StringExp(0, s->Sident);
+            StringExp *se = new StringExp(Loc(), s->Sident);
             se->type = new TypeDArray(Type::tchar->invariantOf());
-            se->type = se->type->semantic(0, NULL);
+            se->type = se->type->semantic(Loc(), NULL);
             Expressions *exps = new Expressions();
             exps->push(se);
             FuncDeclaration *fdpro = FuncDeclaration::genCfunc(Type::tvoid, "trace_pro");
-            Expression *ec = new VarExp(0, fdpro);
-            Expression *e = new CallExp(0, ec, exps);
+            Expression *ec = new VarExp(Loc(), fdpro);
+            Expression *e = new CallExp(Loc(), ec, exps);
             e->type = Type::tvoid;
             Statement *sp = new ExpStatement(loc, e);
 
             FuncDeclaration *fdepi = FuncDeclaration::genCfunc(Type::tvoid, "_c_trace_epi");
-            ec = new VarExp(0, fdepi);
-            e = new CallExp(0, ec);
+            ec = new VarExp(Loc(), fdepi);
+            e = new CallExp(Loc(), ec);
             e->type = Type::tvoid;
             Statement *sf = new ExpStatement(loc, e);
 
             Statement *stf;
             if (sbody->blockExit(tf->isnothrow) == BEfallthru)
-                stf = new CompoundStatement(0, sbody, sf);
+                stf = new CompoundStatement(Loc(), sbody, sf);
             else
-                stf = new TryFinallyStatement(0, sbody, sf);
-            sbody = new CompoundStatement(0, sp, stf);
+                stf = new TryFinallyStatement(Loc(), sbody, sf);
+            sbody = new CompoundStatement(Loc(), sp, stf);
         }
 
 #if DMDV2
@@ -1163,7 +1163,7 @@ unsigned Type::totym()
 #ifdef DEBUG
             printf("ty = %d, '%s'\n", ty, toChars());
 #endif
-            error(0, "forward reference of %s", toChars());
+            error(Loc(), "forward reference of %s", toChars());
             t = TYint;
             break;
 
@@ -1196,11 +1196,11 @@ unsigned Type::totym()
                 if (global.params.is64bit || global.params.isOSX)
                     ;
                 else
-                {   error(0, "SIMD vector types not supported on this platform");
+                {   error(Loc(), "SIMD vector types not supported on this platform");
                     once = true;
                 }
-                if (tv->size(0) == 32)
-                {   error(0, "AVX vector types not supported");
+                if (tv->size(Loc()) == 32)
+                {   error(Loc(), "AVX vector types not supported");
                     once = true;
                 }
             }

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4424,14 +4424,14 @@ STATIC OPND *asm_primary_exp()
                         if (asmstate.sc->func->labtab)
                             s = asmstate.sc->func->labtab->lookup(asmtok->ident);
                         if (!s)
-                            s = asmstate.sc->search(0, asmtok->ident, &scopesym);
+                            s = asmstate.sc->search(Loc(), asmtok->ident, &scopesym);
                         if (!s)
                         {   // Assume it is a label, and define that label
                             s = asmstate.sc->func->searchLabel(asmtok->ident);
                         }
                     }
                     else
-                        s = asmstate.sc->search(0, asmtok->ident, &scopesym);
+                        s = asmstate.sc->search(Loc(), asmtok->ident, &scopesym);
                     if (!s)
                         asmerr(EM_undefined, asmtok->toChars());
 

--- a/src/init.c
+++ b/src/init.c
@@ -77,7 +77,7 @@ char *Initializer::toChars()
 /********************************** ErrorInitializer ***************************/
 
 ErrorInitializer::ErrorInitializer()
-    : Initializer(0)
+    : Initializer(Loc())
 {
 }
 
@@ -276,7 +276,7 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t, NeedInterpret needI
          */
         Parameters *arguments = new Parameters;
         Type *tf = new TypeFunction(arguments, NULL, 0, LINKd);
-        FuncLiteralDeclaration *fd = new FuncLiteralDeclaration(loc, 0, tf, TOKdelegate, NULL);
+        FuncLiteralDeclaration *fd = new FuncLiteralDeclaration(loc, Loc(), tf, TOKdelegate, NULL);
         fd->fbody = new CompoundStatement(loc, new Statements());
         fd->endloc = loc;
         Expression *e = new FuncExp(loc, fd);

--- a/src/inline.c
+++ b/src/inline.c
@@ -1646,7 +1646,7 @@ Expression *FuncDeclaration::expandInline(InlineScanState *iss, Expression *ethi
     // Set up parameters
     if (ethis)
     {
-        e = new DeclarationExp(0, ids.vthis);
+        e = new DeclarationExp(Loc(), ids.vthis);
         e->type = Type::tvoid;
         if (as)
             as->push(new ExpStatement(e->loc, e));
@@ -1686,11 +1686,11 @@ Expression *FuncDeclaration::expandInline(InlineScanState *iss, Expression *ethi
             ids.from.push(vfrom);
             ids.to.push(vto);
 
-            de = new DeclarationExp(0, vto);
+            de = new DeclarationExp(Loc(), vto);
             de->type = Type::tvoid;
 
             if (as)
-                as->push(new ExpStatement(0, de));
+                as->push(new ExpStatement(Loc(), de));
             else
                 e = Expression::combine(e, de);
         }
@@ -1701,7 +1701,7 @@ Expression *FuncDeclaration::expandInline(InlineScanState *iss, Expression *ethi
         inlineNest++;
         Statement *s = fbody->doInlineStatement(&ids);
         as->push(s);
-        *ps = new ScopeStatement(0, new CompoundStatement(0, as));
+        *ps = new ScopeStatement(Loc(), new CompoundStatement(Loc(), as));
         inlineNest--;
     }
     else
@@ -1745,7 +1745,7 @@ Expression *FuncDeclaration::expandInline(InlineScanState *iss, Expression *ethi
         ei->exp = new ConstructExp(loc, ve, e);
         ei->exp->type = ve->type;
 
-        DeclarationExp* de = new DeclarationExp(0, vd);
+        DeclarationExp* de = new DeclarationExp(Loc(), vd);
         de->type = Type::tvoid;
 
         // Chain the two together:

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2625,7 +2625,7 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
             // f() = e2, when f returns an array, is always a slice assignment.
             // Convert into arr[0..arr.length] = e2
             e1 = new SliceExp(loc, e1,
-                new IntegerExp(0, 0, Type::tsize_t),
+                new IntegerExp(Loc(), 0, Type::tsize_t),
                 ArrayLength(Type::tsize_t, e1));
             e1->type = type;
         }

--- a/src/link.c
+++ b/src/link.c
@@ -265,7 +265,7 @@ int runLINK()
             flnk.setbuffer(p, plen);
             flnk.ref = 1;
             if (flnk.write())
-                error(0, "error writing file %s", lnkfilename);
+                error(Loc(), "error writing file %s", lnkfilename);
             if (strlen(lnkfilename) < plen)
                 sprintf(p, "@%s", lnkfilename);
         }
@@ -410,7 +410,7 @@ int runLINK()
             flnk.setbuffer(p, plen);
             flnk.ref = 1;
             if (flnk.write())
-                error(0, "error writing file %s", lnkfilename);
+                error(Loc(), "error writing file %s", lnkfilename);
             if (strlen(lnkfilename) < plen)
                 sprintf(p, "@%s", lnkfilename);
         }
@@ -654,7 +654,7 @@ int runLINK()
             else
             {
                 printf("--- errorlevel %d\n", status);
-                if (nme == 1) error(0, "no main function specified");
+                if (nme == 1) error(Loc(), "no main function specified");
             }
         }
     }
@@ -724,7 +724,7 @@ int executecmd(char *cmd, char *args, int useenv)
         else
         {
         L1:
-            error(0, "command line length of %d is too long",len);
+            error(Loc(), "command line length of %d is too long",len);
             }
         }
     }

--- a/src/mars.c
+++ b/src/mars.c
@@ -423,7 +423,7 @@ int tryMain(size_t argc, char *argv[])
     if (argc < 1 || !argv)
     {
       Largs:
-        error(0, "missing or null command line arguments");
+        error(Loc(), "missing or null command line arguments");
         fatal();
     }
     for (size_t i = 0; i < argc; i++)
@@ -433,7 +433,7 @@ int tryMain(size_t argc, char *argv[])
     }
 
     if (response_expand(&argc,&argv))   // expand response files
-        error(0, "can't open response file");
+        error(Loc(), "can't open response file");
 
     files.reserve(argc - 1);
 
@@ -597,7 +597,7 @@ int tryMain(size_t argc, char *argv[])
             else if (strcmp(p + 1, "gx") == 0)
                 global.params.stackstomp = true;
             else if (strcmp(p + 1, "gt") == 0)
-            {   error(0, "use -profile instead of -gt");
+            {   error(Loc(), "use -profile instead of -gt");
                 global.params.trace = 1;
             }
             else if (strcmp(p + 1, "m32") == 0)
@@ -617,7 +617,7 @@ int tryMain(size_t argc, char *argv[])
 #if DMDV1
                 global.params.Dversion = 1;
 #else
-                error(0, "use DMD 1.0 series compilers for -v1 switch");
+                error(Loc(), "use DMD 1.0 series compilers for -v1 switch");
                 break;
 #endif
             }
@@ -654,7 +654,7 @@ int tryMain(size_t argc, char *argv[])
                         break;
 
                     case 0:
-                        error(0, "-o no longer supported, use -of or -od");
+                        error(Loc(), "-o no longer supported, use -of or -od");
                         break;
 
                     default:
@@ -897,7 +897,7 @@ int tryMain(size_t argc, char *argv[])
                     if (ext && FileName::equals(ext, "d") == 0
                             && FileName::equals(ext, "di") == 0)
                     {
-                        error(0, "-run must be followed by a source file, not '%s'", argv[i + 1]);
+                        error(Loc(), "-run must be followed by a source file, not '%s'", argv[i + 1]);
                         break;
                     }
 
@@ -914,11 +914,11 @@ int tryMain(size_t argc, char *argv[])
             else
             {
              Lerror:
-                error(0, "unrecognized switch '%s'", argv[i]);
+                error(Loc(), "unrecognized switch '%s'", argv[i]);
                 continue;
 
              Lnoarg:
-                error(0, "argument expected for switch '%s'", argv[i]);
+                error(Loc(), "argument expected for switch '%s'", argv[i]);
                 continue;
             }
         }
@@ -937,7 +937,7 @@ int tryMain(size_t argc, char *argv[])
     }
 
     if(global.params.is64bit != is64bit)
-        error(0, "the architecture must not be changed in the %s section of %s",
+        error(Loc(), "the architecture must not be changed in the %s section of %s",
               is64bit ? "Environment64" : "Environment32", inifilename);
 
     if (global.errors)
@@ -958,7 +958,7 @@ int tryMain(size_t argc, char *argv[])
 
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     if (global.params.lib && global.params.dll)
-        error(0, "cannot mix -lib and -shared");
+        error(Loc(), "cannot mix -lib and -shared");
 #endif
 
     if (global.params.release)
@@ -1020,7 +1020,7 @@ int tryMain(size_t argc, char *argv[])
     }
     else if (global.params.run)
     {
-        error(0, "flags conflict with -run");
+        error(Loc(), "flags conflict with -run");
         fatal();
     }
     else
@@ -1226,12 +1226,12 @@ int tryMain(size_t argc, char *argv[])
                     strcmp(name, ".") == 0)
                 {
                 Linvalid:
-                    error(0, "invalid file name '%s'", files[i]);
+                    error(Loc(), "invalid file name '%s'", files[i]);
                     fatal();
                 }
             }
             else
-            {   error(0, "unrecognized file extension %s", ext);
+            {   error(Loc(), "unrecognized file extension %s", ext);
                 fatal();
             }
         }
@@ -1310,7 +1310,7 @@ int tryMain(size_t argc, char *argv[])
 #if ASYNCREAD
         if (aw->read(filei))
         {
-            error(0, "cannot read file %s", m->srcfile->name->toChars());
+            error(Loc(), "cannot read file %s", m->srcfile->name->toChars());
             fatal();
         }
 #endif
@@ -1345,7 +1345,7 @@ int tryMain(size_t argc, char *argv[])
     if (anydocfiles && modules.dim &&
         (global.params.oneobj || global.params.objname))
     {
-        error(0, "conflicting Ddoc and obj generation options");
+        error(Loc(), "conflicting Ddoc and obj generation options");
         fatal();
     }
     if (global.errors)
@@ -1586,7 +1586,7 @@ int tryMain(size_t argc, char *argv[])
     if (!global.params.objfiles->dim)
     {
         if (global.params.link)
-            error(0, "no object files to link");
+            error(Loc(), "no object files to link");
     }
     else
     {

--- a/src/mars.h
+++ b/src/mars.h
@@ -372,12 +372,6 @@ struct Loc
         filename = NULL;
     }
 
-    Loc(int x)
-    {
-        linnum = x;
-        filename = NULL;
-    }
-
     Loc(Module *mod, unsigned linnum);
 
     char *toChars();

--- a/src/module.c
+++ b/src/module.c
@@ -623,7 +623,7 @@ void Module::importAll(Scope *prevsc)
     // would fail inside object.d.
     if (members->dim == 0 || ((*members)[0])->ident != Id::object)
     {
-        Import *im = new Import(0, NULL, Id::object, NULL, 0);
+        Import *im = new Import(Loc(), NULL, Id::object, NULL, 0);
         members->shift(im);
     }
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -313,10 +313,10 @@ struct Type : Object
     virtual Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     virtual structalign_t alignment();
     Expression *noMember(Scope *sc, Expression *e, Identifier *ident, int flag);
-    virtual Expression *defaultInit(Loc loc = 0);
+    virtual Expression *defaultInit(Loc loc = Loc());
     virtual Expression *defaultInitLiteral(Loc loc);
     virtual Expression *voidInitLiteral(VarDeclaration *var);
-    virtual int isZeroInit(Loc loc = 0);                // if initializer is 0
+    virtual int isZeroInit(Loc loc = Loc());                // if initializer is 0
     virtual dt_t **toDt(dt_t **pdt);
     Identifier *getTypeInfoIdent(int internal);
     virtual MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wildmatch = NULL);

--- a/src/opover.c
+++ b/src/opover.c
@@ -202,7 +202,7 @@ Objects *opToArg(Scope *sc, enum TOK op)
         case TOKcatass: op = TOKcat; break;
         case TOKpowass: op = TOKpow; break;
     }
-    Expression *e = new StringExp(0, (char *)Token::toChars(op));
+    Expression *e = new StringExp(Loc(), (char *)Token::toChars(op));
     e = e->semantic(sc);
     Objects *tiargs = new Objects();
     tiargs->push(e);
@@ -1259,7 +1259,7 @@ Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid)
     FuncDeclaration *fd;
     TemplateDeclaration *td;
 
-    s = ad->search(0, funcid, 0);
+    s = ad->search(Loc(), funcid, 0);
     if (s)
     {   Dsymbol *s2;
 
@@ -1341,7 +1341,7 @@ int ForeachStatement::inferAggregate(Scope *sc, Dsymbol *&sapply)
                     }
                 }
 
-                if (Dsymbol *shead = ad->search(0, idfront, 0))
+                if (Dsymbol *shead = ad->search(Loc(), idfront, 0))
                 {   // range aggregate
                     break;
                 }
@@ -1502,7 +1502,7 @@ int ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *&sapply)
                     /* Look for a front() or back() overload
                      */
                     Identifier *id = (op == TOKforeach) ? Id::Ffront : Id::Fback;
-                    Dsymbol *s = ad->search(0, id, 0);
+                    Dsymbol *s = ad->search(Loc(), id, 0);
                     FuncDeclaration *fd = s ? s->isFuncDeclaration() : NULL;
                     if (fd)
                     {

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -1031,8 +1031,8 @@ void setLengthVarIfKnown(VarDeclaration *lengthVar, Expression *arr)
             return; // we don't know the length yet
     }
 
-    Expression *dollar = new IntegerExp(0, len, Type::tsize_t);
-    lengthVar->init = new ExpInitializer(0, dollar);
+    Expression *dollar = new IntegerExp(Loc(), len, Type::tsize_t);
+    lengthVar->init = new ExpInitializer(Loc(), dollar);
     lengthVar->storage_class |= STCstatic | STCconst;
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -61,9 +61,9 @@ Parser::Parser(Module *module, unsigned char *base, size_t length, int doDocComm
     //printf("Parser::Parser()\n");
     md = NULL;
     linkage = LINKd;
-    endloc = 0;
+    endloc = Loc();
     inBrackets = 0;
-    lookingForElse = 0;
+    lookingForElse = Loc();
     //nextToken();              // start up the scanner
 }
 
@@ -865,7 +865,7 @@ Dsymbols *Parser::parseBlock(Dsymbol **pLastDecl)
         case TOKlcurly:
         {
             Loc lookingForElseSave = lookingForElse;
-            lookingForElse = 0;
+            lookingForElse = Loc();
 
             nextToken();
             a = parseDeclDefs(0, pLastDecl);
@@ -1132,7 +1132,7 @@ Dsymbol *Parser::parseCtor()
         nextToken();
         check(TOKrparen);
         StorageClass stc = parsePostfix();
-        PostBlitDeclaration *f = new PostBlitDeclaration(loc, 0, stc, Id::_postblit);
+        PostBlitDeclaration *f = new PostBlitDeclaration(loc, Loc(), stc, Id::_postblit);
         parseContracts(f);
         return f;
     }
@@ -1154,7 +1154,7 @@ Dsymbol *Parser::parseCtor()
         Type *tf = new TypeFunction(parameters, NULL, varargs, linkage, stc);   // RetrunType -> auto
         tf = tf->addSTC(stc);
 
-        CtorDeclaration *f = new CtorDeclaration(loc, 0, stc, tf);
+        CtorDeclaration *f = new CtorDeclaration(loc, Loc(), stc, tf);
         parseContracts(f);
 
         // Wrap a template around it
@@ -1173,7 +1173,7 @@ Dsymbol *Parser::parseCtor()
     Type *tf = new TypeFunction(parameters, NULL, varargs, linkage, stc);   // RetrunType -> auto
     tf = tf->addSTC(stc);
 
-    CtorDeclaration *f = new CtorDeclaration(loc, 0, stc, tf);
+    CtorDeclaration *f = new CtorDeclaration(loc, Loc(), stc, tf);
     parseContracts(f);
     return f;
 }
@@ -1195,7 +1195,7 @@ DtorDeclaration *Parser::parseDtor()
     check(TOKrparen);
 
     StorageClass stc = parsePostfix();
-    f = new DtorDeclaration(loc, 0, stc, Id::dtor);
+    f = new DtorDeclaration(loc, Loc(), stc, Id::dtor);
     parseContracts(f);
     return f;
 }
@@ -1214,7 +1214,7 @@ StaticCtorDeclaration *Parser::parseStaticCtor()
     check(TOKlparen);
     check(TOKrparen);
 
-    StaticCtorDeclaration *f = new StaticCtorDeclaration(loc, 0);
+    StaticCtorDeclaration *f = new StaticCtorDeclaration(loc, Loc());
     parseContracts(f);
     return f;
 }
@@ -1235,7 +1235,7 @@ SharedStaticCtorDeclaration *Parser::parseSharedStaticCtor()
     check(TOKlparen);
     check(TOKrparen);
 
-    SharedStaticCtorDeclaration *f = new SharedStaticCtorDeclaration(loc, 0);
+    SharedStaticCtorDeclaration *f = new SharedStaticCtorDeclaration(loc, Loc());
     parseContracts(f);
     return f;
 }
@@ -1255,7 +1255,7 @@ StaticDtorDeclaration *Parser::parseStaticDtor()
     check(TOKlparen);
     check(TOKrparen);
 
-    StaticDtorDeclaration *f = new StaticDtorDeclaration(loc, 0);
+    StaticDtorDeclaration *f = new StaticDtorDeclaration(loc, Loc());
     parseContracts(f);
     return f;
 }
@@ -1277,7 +1277,7 @@ SharedStaticDtorDeclaration *Parser::parseSharedStaticDtor()
     check(TOKlparen);
     check(TOKrparen);
 
-    SharedStaticDtorDeclaration *f = new SharedStaticDtorDeclaration(loc, 0);
+    SharedStaticDtorDeclaration *f = new SharedStaticDtorDeclaration(loc, Loc());
     parseContracts(f);
     return f;
 }
@@ -1300,7 +1300,7 @@ InvariantDeclaration *Parser::parseInvariant()
         check(TOKrparen);
     }
 
-    f = new InvariantDeclaration(loc, 0);
+    f = new InvariantDeclaration(loc, Loc());
     f->fbody = parseStatement(PScurly);
     return f;
 }
@@ -1364,7 +1364,7 @@ NewDeclaration *Parser::parseNew()
 
     nextToken();
     arguments = parseParameters(&varargs);
-    f = new NewDeclaration(loc, 0, arguments, varargs);
+    f = new NewDeclaration(loc, Loc(), arguments, varargs);
     parseContracts(f);
     return f;
 }
@@ -1386,7 +1386,7 @@ DeleteDeclaration *Parser::parseDelete()
     arguments = parseParameters(&varargs);
     if (varargs)
         error("... not allowed in delete function parameter list");
-    f = new DeleteDeclaration(loc, 0, arguments);
+    f = new DeleteDeclaration(loc, Loc(), arguments);
     parseContracts(f);
     return f;
 }
@@ -3231,7 +3231,7 @@ L2:
             //printf("%s funcdecl t = %s, storage_class = x%lx\n", loc.toChars(), t->toChars(), storage_class);
 
             FuncDeclaration *f =
-                new FuncDeclaration(loc, 0, ident, storage_class | (disable ? STCdisable : 0), t);
+                new FuncDeclaration(loc, Loc(), ident, storage_class | (disable ? STCdisable : 0), t);
             addComment(f, comment);
             if (tpl)
                 constraint = parseConstraint();
@@ -3967,7 +3967,7 @@ Statement *Parser::parseStatement(int flags, unsigned char** endPtr)
         case TOKlcurly:
         {
             Loc lookingForElseSave = lookingForElse;
-            lookingForElse = 0;
+            lookingForElse = Loc();
 
             nextToken();
             //if (token.value == TOKsemicolon)
@@ -4018,7 +4018,7 @@ Statement *Parser::parseStatement(int flags, unsigned char** endPtr)
 
             nextToken();
             Loc lookingForElseSave = lookingForElse;
-            lookingForElse = 0;
+            lookingForElse = Loc();
             body = parseStatement(PSscope);
             lookingForElse = lookingForElseSave;
             check(TOKwhile);
@@ -4049,7 +4049,7 @@ Statement *Parser::parseStatement(int flags, unsigned char** endPtr)
             else
             {
                 Loc lookingForElseSave = lookingForElse;
-                lookingForElse = 0;
+                lookingForElse = Loc();
                 init = parseStatement(0);
                 lookingForElse = lookingForElseSave;
             }
@@ -4612,7 +4612,7 @@ Statement *Parser::parseStatement(int flags, unsigned char** endPtr)
 
             nextToken();
             Loc lookingForElseSave = lookingForElse;
-            lookingForElse = 0;
+            lookingForElse = Loc();
             body = parseStatement(PSscope);
             lookingForElse = lookingForElseSave;
             while (token.value == TOKcatch)
@@ -6029,7 +6029,7 @@ Expression *Parser::parsePrimaryExp()
             if (!parameters)
                 parameters = new Parameters();
             TypeFunction *tf = new TypeFunction(parameters, tret, varargs, linkage, stc);
-            FuncLiteralDeclaration *fd = new FuncLiteralDeclaration(loc, 0, tf, save, NULL);
+            FuncLiteralDeclaration *fd = new FuncLiteralDeclaration(loc, Loc(), tf, save, NULL);
 
             if (token.value == TOKgoesto)
             {

--- a/src/scope.c
+++ b/src/scope.c
@@ -413,7 +413,7 @@ void *scope_search_fp(void *arg, const char *seed)
 
     Scope *sc = (Scope *)arg;
     Module::clearCache();
-    Dsymbol *s = sc->search(0, id, NULL);
+    Dsymbol *s = sc->search(Loc(), id, NULL);
     return s;
 }
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -617,26 +617,26 @@ Statement *CompoundStatement::semantic(Scope *sc)
                         {
                             a->push((*statements)[j]);
                         }
-                        Statement *body = new CompoundStatement(0, a);
-                        body = new ScopeStatement(0, body);
+                        Statement *body = new CompoundStatement(Loc(), a);
+                        body = new ScopeStatement(Loc(), body);
 
                         Identifier *id = Lexer::uniqueId("__o");
 
                         Statement *handler = sexception;
                         if (sexception->blockExit(FALSE) & BEfallthru)
-                        {   handler = new ThrowStatement(0, new IdentifierExp(0, id));
+                        {   handler = new ThrowStatement(Loc(), new IdentifierExp(Loc(), id));
                             ((ThrowStatement *)handler)->internalThrow = true;
-                            handler = new CompoundStatement(0, sexception, handler);
+                            handler = new CompoundStatement(Loc(), sexception, handler);
                         }
 
                         Catches *catches = new Catches();
-                        Catch *ctch = new Catch(0, NULL, id, handler);
+                        Catch *ctch = new Catch(Loc(), NULL, id, handler);
                         ctch->internalCatch = true;
                         catches->push(ctch);
-                        s = new TryCatchStatement(0, body, catches);
+                        s = new TryCatchStatement(Loc(), body, catches);
 
                         if (sfinally)
-                            s = new TryFinallyStatement(0, s, sfinally);
+                            s = new TryFinallyStatement(Loc(), s, sfinally);
                         s = s->semantic(sc);
                         statements->setDim(i + 1);
                         statements->push(s);
@@ -661,8 +661,8 @@ Statement *CompoundStatement::semantic(Scope *sc)
                         {
                             a->push((*statements)[j]);
                         }
-                        Statement *body = new CompoundStatement(0, a);
-                        s = new TryFinallyStatement(0, body, sfinally);
+                        Statement *body = new CompoundStatement(Loc(), a);
+                        s = new TryFinallyStatement(Loc(), body, sfinally);
                         s = s->semantic(sc);
                         statements->setDim(i + 1);
                         statements->push(s);
@@ -1247,19 +1247,19 @@ Statement *ForStatement::semanticInit(Scope *sc, Statements *ainit, size_t i)
             Identifier *id = Lexer::uniqueId("__o");
             Statement *handler;
             if (sexception->blockExit(FALSE) & BEfallthru)
-            {   handler = new ThrowStatement(0, new IdentifierExp(0, id));
+            {   handler = new ThrowStatement(Loc(), new IdentifierExp(Loc(), id));
                 ((ThrowStatement *)handler)->internalThrow = true;
-                handler = new CompoundStatement(0, sexception, handler);
+                handler = new CompoundStatement(Loc(), sexception, handler);
             }
             else
                 handler = sexception;
             Catches *catches = new Catches();
-            Catch *ctch = new Catch(0, NULL, id, handler);
+            Catch *ctch = new Catch(Loc(), NULL, id, handler);
             catches->push(ctch);
-            statement = new TryCatchStatement(0, statement, catches);
+            statement = new TryCatchStatement(Loc(), statement, catches);
         }
         if (sfinally)
-            statement = new TryFinallyStatement(0, statement, sfinally);
+            statement = new TryFinallyStatement(Loc(), statement, sfinally);
     }
 
     //printf("-ForStatement::semanticInit %s\n", statement->toChars());
@@ -1517,7 +1517,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
                     else
                         error("foreach: key type must be int or uint, not %s", arg->type->toChars());
                 }
-                Initializer *ie = new ExpInitializer(0, new IntegerExp(k));
+                Initializer *ie = new ExpInitializer(Loc(), new IntegerExp(k));
                 VarDeclaration *var = new VarDeclaration(loc, arg->type, arg->ident, ie);
                 var->storage_class |= STCmanifest;
                 DeclarationExp *de = new DeclarationExp(loc, var);
@@ -1558,7 +1558,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
                     arg->type = e->type;
                     if (argtype && argtype->ty != Terror)
                         arg->type = argtype;
-                    Initializer *ie = new ExpInitializer(0, e);
+                    Initializer *ie = new ExpInitializer(Loc(), e);
                     VarDeclaration *v = new VarDeclaration(loc, arg->type, arg->ident, ie);
                     if (arg->storageClass & STCref)
                         v->storage_class |= STCref | STCforeach;
@@ -1848,7 +1848,7 @@ Lagain:
             {   idfront = Id::Fback;
                 idpopFront = Id::FpopBack;
             }
-            Dsymbol *sfront = ad->search(0, idfront, 0);
+            Dsymbol *sfront = ad->search(Loc(), idfront, 0);
             if (!sfront)
                 goto Lapply;
 
@@ -2026,9 +2026,9 @@ Lagain:
                 LcopyArg:
                     id = Lexer::uniqueId("__applyArg", (int)i);
 
-                    Initializer *ie = new ExpInitializer(0, new IdentifierExp(0, id));
-                    VarDeclaration *v = new VarDeclaration(0, arg->type, arg->ident, ie);
-                    s = new ExpStatement(0, v);
+                    Initializer *ie = new ExpInitializer(Loc(), new IdentifierExp(Loc(), id));
+                    VarDeclaration *v = new VarDeclaration(Loc(), arg->type, arg->ident, ie);
+                    s = new ExpStatement(Loc(), v);
                     body = new CompoundStatement(loc, s, body);
                 }
                 args->push(new Parameter(stc, arg->type, id, NULL));
@@ -2036,7 +2036,7 @@ Lagain:
             tfld = new TypeFunction(args, Type::tint32, 0, LINKd);
             cases = new Statements();
             gotos = new CompoundStatements();
-            FuncLiteralDeclaration *fld = new FuncLiteralDeclaration(loc, 0, tfld, TOKdelegate, this);
+            FuncLiteralDeclaration *fld = new FuncLiteralDeclaration(loc, Loc(), tfld, TOKdelegate, this);
             fld->fbody = body;
             Expression *flde = new FuncExp(loc, fld);
             flde = flde->semantic(sc);
@@ -2050,7 +2050,7 @@ Lagain:
                 if (!gs->label->statement)
                 {   // 'Promote' it to this scope, and replace with a return
                     cases->push(gs);
-                    s = new ReturnStatement(0, new IntegerExp(cases->dim + 1));
+                    s = new ReturnStatement(Loc(), new IntegerExp(cases->dim + 1));
                     (*cs->statements)[0] = s;
                 }
             }
@@ -2078,12 +2078,12 @@ Lagain:
                     fdapply = FuncDeclaration::genCfunc(Type::tindex, "_aaApply2");
                 else
                     fdapply = FuncDeclaration::genCfunc(Type::tindex, "_aaApply");
-                ec = new VarExp(0, fdapply);
+                ec = new VarExp(Loc(), fdapply);
                 Expressions *exps = new Expressions();
                 exps->push(aggr);
                 size_t keysize = taa->index->size();
                 keysize = (keysize + ((size_t)Target::ptrsize-1)) & ~((size_t)Target::ptrsize-1);
-                exps->push(new IntegerExp(0, keysize, Type::tsize_t));
+                exps->push(new IntegerExp(Loc(), keysize, Type::tsize_t));
                 exps->push(flde);
                 e = new CallExp(loc, ec, exps);
                 e->type = Type::tindex; // don't run semantic() on e
@@ -2120,7 +2120,7 @@ Lagain:
                 assert(j < sizeof(fdname) / sizeof(fdname[0]));
                 FuncDeclaration *fdapply = FuncDeclaration::genCfunc(Type::tindex, fdname);
 
-                ec = new VarExp(0, fdapply);
+                ec = new VarExp(Loc(), fdapply);
                 Expressions *exps = new Expressions();
                 if (tab->ty == Tsarray)
                    aggr = aggr->castTo(sc, tn->arrayOf());
@@ -2186,15 +2186,15 @@ Lagain:
                 Statements *a = new Statements();
 
                 // default: break; takes care of cases 0 and 1
-                s = new BreakStatement(0, NULL);
-                s = new DefaultStatement(0, s);
+                s = new BreakStatement(Loc(), NULL);
+                s = new DefaultStatement(Loc(), s);
                 a->push(s);
 
                 // cases 2...
                 for (size_t i = 0; i < cases->dim; i++)
                 {
                     s = (*cases)[i];
-                    s = new CaseStatement(0, new IntegerExp(i + 2), s);
+                    s = new CaseStatement(Loc(), new IntegerExp(i + 2), s);
                     a->push(s);
                 }
 
@@ -2568,7 +2568,7 @@ Statement *IfStatement::semantic(Scope *sc)
         match->storage_class |= arg->storageClass;
 
         DeclarationExp *de = new DeclarationExp(loc, match);
-        VarExp *ve = new VarExp(0, match);
+        VarExp *ve = new VarExp(Loc(), match);
         condition = new CommaExp(loc, de, ve);
         condition = condition->semantic(scd);
 
@@ -3128,7 +3128,7 @@ Statement *SwitchStatement::semantic(Scope *sc)
         sc->sw->sdefault = new DefaultStatement(loc, s);
         a->push(body);
         if (body->blockExit(FALSE) & BEfallthru)
-            a->push(new BreakStatement(0, NULL));
+            a->push(new BreakStatement(Loc(), NULL));
         a->push(sc->sw->sdefault);
         cs = new CompoundStatement(loc, a);
         body = cs;
@@ -3613,7 +3613,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         //      return this;
         if (exp && exp->op != TOKthis)
             error("cannot return expression from constructor");
-        exp = new ThisExp(0);
+        exp = new ThisExp(Loc());
         exp->type = tret;
     }
 
@@ -3805,16 +3805,16 @@ Statement *ReturnStatement::semantic(Scope *sc)
         {
             sc->fes->cases->push(this);
             // Construct: return cases->dim+1;
-            s = new ReturnStatement(0, new IntegerExp(sc->fes->cases->dim + 1));
+            s = new ReturnStatement(Loc(), new IntegerExp(sc->fes->cases->dim + 1));
         }
         else if (tf->next->toBasetype() == Type::tvoid)
         {
-            s = new ReturnStatement(0, NULL);
+            s = new ReturnStatement(Loc(), NULL);
             sc->fes->cases->push(s);
 
             // Construct: { exp; return cases->dim + 1; }
             Statement *s1 = new ExpStatement(loc, exp);
-            Statement *s2 = new ReturnStatement(0, new IntegerExp(sc->fes->cases->dim + 1));
+            Statement *s2 = new ReturnStatement(Loc(), new IntegerExp(sc->fes->cases->dim + 1));
             s = new CompoundStatement(loc, s1, s2);
         }
         else
@@ -3837,14 +3837,14 @@ Statement *ReturnStatement::semantic(Scope *sc)
                 fd->vresult = v;
             }
 
-            s = new ReturnStatement(0, new VarExp(0, fd->vresult));
+            s = new ReturnStatement(Loc(), new VarExp(Loc(), fd->vresult));
             sc->fes->cases->push(s);
 
             // Construct: { vresult = exp; return cases->dim + 1; }
-            exp = new ConstructExp(loc, new VarExp(0, fd->vresult), exp);
+            exp = new ConstructExp(loc, new VarExp(Loc(), fd->vresult), exp);
             exp = exp->semantic(sc);
             Statement *s1 = new ExpStatement(loc, exp);
-            Statement *s2 = new ReturnStatement(0, new IntegerExp(sc->fes->cases->dim + 1));
+            Statement *s2 = new ReturnStatement(Loc(), new IntegerExp(sc->fes->cases->dim + 1));
             s = new CompoundStatement(loc, s1, s2);
         }
         return s;
@@ -3867,7 +3867,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         if (fd->returnLabel && tbret->ty != Tvoid)
         {
             fd->buildResultVar();
-            VarExp *v = new VarExp(0, fd->vresult);
+            VarExp *v = new VarExp(Loc(), fd->vresult);
 
             assert(eorg);
             exp = new ConstructExp(loc, v, eorg);
@@ -3892,7 +3892,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         {   /* Replace: return exp;
              * with:    exp; goto returnLabel;
              */
-            Statement *s = new ExpStatement(0, exp);
+            Statement *s = new ExpStatement(Loc(), exp);
             return new CompoundStatement(loc, s, gs);
         }
         return gs;
@@ -3981,7 +3981,7 @@ Statement *BreakStatement::semantic(Scope *sc)
                      */
                     Statement *s;
                     sc->fes->cases->push(this);
-                    s = new ReturnStatement(0, new IntegerExp(sc->fes->cases->dim + 1));
+                    s = new ReturnStatement(Loc(), new IntegerExp(sc->fes->cases->dim + 1));
                     return s;
                 }
                 break;                  // can't break to it
@@ -4007,7 +4007,7 @@ Statement *BreakStatement::semantic(Scope *sc)
         {   Statement *s;
 
             // Replace break; with return 1;
-            s = new ReturnStatement(0, new IntegerExp(1));
+            s = new ReturnStatement(Loc(), new IntegerExp(1));
             return s;
         }
         error("break is not inside a loop or switch");
@@ -4071,7 +4071,7 @@ Statement *ContinueStatement::semantic(Scope *sc)
                         if (ls && ls->ident == ident && ls->statement == sc->fes)
                         {
                             // Replace continue ident; with return 0;
-                            return new ReturnStatement(0, new IntegerExp(0));
+                            return new ReturnStatement(Loc(), new IntegerExp(0));
                         }
                     }
 
@@ -4084,7 +4084,7 @@ Statement *ContinueStatement::semantic(Scope *sc)
                      */
                     Statement *s;
                     sc->fes->cases->push(this);
-                    s = new ReturnStatement(0, new IntegerExp(sc->fes->cases->dim + 1));
+                    s = new ReturnStatement(Loc(), new IntegerExp(sc->fes->cases->dim + 1));
                     return s;
                 }
                 break;                  // can't continue to it
@@ -4110,7 +4110,7 @@ Statement *ContinueStatement::semantic(Scope *sc)
         {   Statement *s;
 
             // Replace continue; with return 0;
-            s = new ReturnStatement(0, new IntegerExp(0));
+            s = new ReturnStatement(Loc(), new IntegerExp(0));
             return s;
         }
         error("continue is not inside a loop");
@@ -4182,7 +4182,7 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
             }
 
             Type *t = ClassDeclaration::object->type;
-            t = t->semantic(0, sc)->toBasetype();
+            t = t->semantic(Loc(), sc)->toBasetype();
             assert(t->ty == Tclass);
 
             exp = new CastExp(loc, exp, t);
@@ -4571,7 +4571,7 @@ void Catch::semantic(Scope *sc)
     sc = sc->push(sym);
 
     if (!type)
-        type = new TypeIdentifier(0, Id::Throwable);
+        type = new TypeIdentifier(Loc(), Id::Throwable);
     type = type->semantic(loc, sc);
     ClassDeclaration *cd = type->toBasetype()->isClassHandle();
     if (!cd || ((cd != ClassDeclaration::throwable) && !ClassDeclaration::throwable->isBaseOf(cd, NULL)))
@@ -4772,17 +4772,17 @@ Statement *OnScopeStatement::scopeCode(Scope *sc, Statement **sentry, Statement 
              */
             Identifier *id = Lexer::uniqueId("__os");
 
-            ExpInitializer *ie = new ExpInitializer(loc, new IntegerExp(0, 0, Type::tbool));
+            ExpInitializer *ie = new ExpInitializer(loc, new IntegerExp(Loc(), 0, Type::tbool));
             VarDeclaration *v = new VarDeclaration(loc, Type::tbool, id, ie);
             *sentry = new ExpStatement(loc, v);
 
-            Expression *e = new IntegerExp(0, 1, Type::tbool);
-            e = new AssignExp(0, new VarExp(0, v), e);
-            *sexception = new ExpStatement(0, e);
+            Expression *e = new IntegerExp(Loc(), 1, Type::tbool);
+            e = new AssignExp(Loc(), new VarExp(Loc(), v), e);
+            *sexception = new ExpStatement(Loc(), e);
 
-            e = new VarExp(0, v);
-            e = new NotExp(0, e);
-            *sfinally = new IfStatement(0, NULL, e, statement, NULL);
+            e = new VarExp(Loc(), v);
+            e = new NotExp(Loc(), e);
+            *sfinally = new IfStatement(Loc(), NULL, e, statement, NULL);
 
             break;
         }

--- a/src/struct.c
+++ b/src/struct.c
@@ -117,7 +117,7 @@ void AggregateDeclaration::semantic3(Scope *sc)
             ti->semantic2(sc);
             ti->semantic3(sc);
             Dsymbol *s = ti->toAlias();
-            Expression *e = new DsymbolExp(0, s, 0);
+            Expression *e = new DsymbolExp(Loc(), s, 0);
             e = e->ctfeSemantic(ti->tempdecl->scope);
             e = e->ctfeInterpret();
             getRTInfo = e;
@@ -633,7 +633,7 @@ void StructDeclaration::semantic(Scope *sc)
 
         arguments->push(arg);
         tfeqptr = new TypeFunction(arguments, Type::tint32, 0, LINKd);
-        tfeqptr = (TypeFunction *)tfeqptr->semantic(0, sc);
+        tfeqptr = (TypeFunction *)tfeqptr->semantic(Loc(), sc);
     }
 
     TypeFunction *tfeq;
@@ -643,7 +643,7 @@ void StructDeclaration::semantic(Scope *sc)
 
         arguments->push(arg);
         tfeq = new TypeFunction(arguments, Type::tint32, 0, LINKd);
-        tfeq = (TypeFunction *)tfeq->semantic(0, sc);
+        tfeq = (TypeFunction *)tfeq->semantic(Loc(), sc);
     }
 
     Identifier *id = Id::eq;
@@ -692,11 +692,11 @@ void StructDeclaration::semantic(Scope *sc)
     /* Look for special member functions.
      */
 #if DMDV2
-    ctor = search(0, Id::ctor, 0);
+    ctor = search(Loc(), Id::ctor, 0);
 #endif
-    inv =    (InvariantDeclaration *)search(0, Id::classInvariant, 0);
-    aggNew =       (NewDeclaration *)search(0, Id::classNew,       0);
-    aggDelete = (DeleteDeclaration *)search(0, Id::classDelete,    0);
+    inv =    (InvariantDeclaration *)search(Loc(), Id::classInvariant, 0);
+    aggNew =       (NewDeclaration *)search(Loc(), Id::classNew,       0);
+    aggDelete = (DeleteDeclaration *)search(Loc(), Id::classDelete,    0);
 
     TypeTuple *tup = type->toArgTypes();
     size_t dim = tup->arguments->dim;

--- a/src/target.c
+++ b/src/target.c
@@ -93,7 +93,7 @@ unsigned Target::alignsize (Type* type)
         default:
             break;
     }
-    return type->size(0);
+    return type->size(Loc());
 }
 
 /******************************

--- a/src/template.c
+++ b/src/template.c
@@ -912,7 +912,7 @@ MATCH TemplateDeclaration::leastAsSpecialized(TemplateDeclaration *td2, Expressi
      * as td2.
      */
 
-    TemplateInstance ti(0, ident);      // create dummy template instance
+    TemplateInstance ti(Loc(), ident);      // create dummy template instance
     Objects dedtypes;
 
 #define LOG_LEASTAS     0
@@ -1176,7 +1176,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objec
             if (ttp)
             {   hasttp = true;
 
-                Type *t = new TypeIdentifier(0, ttp->ident);
+                Type *t = new TypeIdentifier(Loc(), ttp->ident);
                 MATCH m = tthis->deduceType(paramscope, t, parameters, &dedtypes);
                 if (!m)
                     goto Lnomatch;
@@ -1711,7 +1711,7 @@ Lretry:
                         }
                         else
                         {
-                            Type *vt = tvp->valType->semantic(0, sc);
+                            Type *vt = tvp->valType->semantic(Loc(), sc);
                             MATCH m = (MATCH)dim->implicitConvTo(vt);
                             if (!m)
                                 goto Lnomatch;
@@ -1975,12 +1975,12 @@ Object *TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, 
     if (targ)
     {
         //printf("type %s\n", targ->toChars());
-        s = new AliasDeclaration(0, tp->ident, targ);
+        s = new AliasDeclaration(Loc(), tp->ident, targ);
     }
     else if (sa)
     {
         //printf("Alias %s %s;\n", sa->ident->toChars(), tp->ident->toChars());
-        s = new AliasDeclaration(0, tp->ident, sa);
+        s = new AliasDeclaration(Loc(), tp->ident, sa);
     }
     else if (ea && ea->op == TOKfunction)
     {
@@ -1988,7 +1988,7 @@ Object *TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, 
             sa = ((FuncExp *)ea)->td;
         else
             sa = ((FuncExp *)ea)->fd;
-        s = new AliasDeclaration(0, tp->ident, sa);
+        s = new AliasDeclaration(Loc(), tp->ident, sa);
     }
     else if (ea)
     {
@@ -3039,7 +3039,7 @@ MATCH TypeSArray::deduceType(Scope *sc, Type *tparam, TemplateParameters *parame
             }
             else
             {
-                Type *vt = tvp->valType->semantic(0, sc);
+                Type *vt = tvp->valType->semantic(Loc(), sc);
                 MATCH m = (MATCH)dim->implicitConvTo(vt);
                 if (!m)
                     goto Lnomatch;
@@ -3226,11 +3226,11 @@ MATCH TypeInstance::deduceType(Scope *sc,
                 {   /* Didn't find it as a parameter identifier. Try looking
                      * it up and seeing if is an alias. See Bugzilla 1454
                      */
-                    TypeIdentifier *tid = new TypeIdentifier(0, tp->tempinst->name);
+                    TypeIdentifier *tid = new TypeIdentifier(Loc(), tp->tempinst->name);
                     Type *t;
                     Expression *e;
                     Dsymbol *s;
-                    tid->resolve(0, sc, &e, &t, &s);
+                    tid->resolve(Loc(), sc, &e, &t, &s);
                     if (t)
                     {
                         s = t->toDsymbol(sc);
@@ -3408,7 +3408,7 @@ MATCH TypeInstance::deduceType(Scope *sc,
                             goto Lnomatch;
                     }
                     else
-                    {   Type *vt = tv->valType->semantic(0, sc);
+                    {   Type *vt = tv->valType->semantic(Loc(), sc);
                         MATCH m = (MATCH)e1->implicitConvTo(vt);
                         if (!m)
                             goto Lnomatch;
@@ -3486,7 +3486,7 @@ MATCH TypeStruct::deduceType(Scope *sc, Type *tparam, TemplateParameters *parame
     {
         if (ti && ti->toAlias() == sym)
         {
-            TypeInstance *t = new TypeInstance(0, ti);
+            TypeInstance *t = new TypeInstance(Loc(), ti);
             return t->deduceType(sc, tparam, parameters, dedtypes, wildmatch);
         }
 
@@ -3585,7 +3585,7 @@ void deduceBaseClassParameters(BaseClass *b,
         tmpdedtypes->setDim(dedtypes->dim);
         memcpy(tmpdedtypes->tdata(), dedtypes->tdata(), dedtypes->dim * sizeof(void *));
 
-        TypeInstance *t = new TypeInstance(0, parti);
+        TypeInstance *t = new TypeInstance(Loc(), parti);
         MATCH m = t->deduceType(sc, tparam, parameters, tmpdedtypes);
         if (m != MATCHnomatch)
         {
@@ -3626,7 +3626,7 @@ MATCH TypeClass::deduceType(Scope *sc, Type *tparam, TemplateParameters *paramet
     {
         if (ti && ti->toAlias() == sym)
         {
-            TypeInstance *t = new TypeInstance(0, ti);
+            TypeInstance *t = new TypeInstance(Loc(), ti);
             MATCH m = t->deduceType(sc, tparam, parameters, dedtypes, wildmatch);
             // Even if the match fails, there is still a chance it could match
             // a base class.
@@ -4214,7 +4214,7 @@ MATCH TemplateAliasParameter::matchArg(Scope *sc, Objects *tiargs,
             Type *ta = isType(specAlias);
             if (!ti || !ta)
                 goto Lnomatch;
-            Type *t = new TypeInstance(0, ti);
+            Type *t = new TypeInstance(Loc(), ti);
             MATCH m = t->deduceType(sc, ta, parameters, dedtypes);
             if (m == MATCHnomatch)
                 goto Lnomatch;
@@ -4483,7 +4483,7 @@ MATCH TemplateValueParameter::matchArg(Scope *sc,
     }
 
     //printf("\tvalType: %s, ty = %d\n", valType->toChars(), valType->ty);
-    vt = valType->semantic(0, sc);
+    vt = valType->semantic(Loc(), sc);
     //printf("ei: %s, ei->type: %s\n", ei->toChars(), ei->type->toChars());
     //printf("vt = %s\n", vt->toChars());
 

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -184,7 +184,7 @@ Symbol *VarDeclaration::toSymbol()
         }
         else if (isParameter())
         {
-            if (config.exe == EX_WIN64 && type->size(0) > REGSIZE)
+            if (config.exe == EX_WIN64 && type->size(Loc()) > REGSIZE)
             {
                 // should be TYref, but problems in back end
                 t = type_pointer(type->toCtype());

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1346,7 +1346,7 @@ void EnumDeclaration::toObjFile(int multiobj)
         sinit->Sclass = scclass;
         sinit->Sfl = FLdata;
 #if DMDV1
-        dtnbytes(&sinit->Sdt, tc->size(0), (char *)&tc->sym->defaultval);
+        dtnbytes(&sinit->Sdt, tc->size(Loc()), (char *)&tc->sym->defaultval);
         //sinit->Sdt = tc->sym->init->toDt();
 #endif
 #if DMDV2

--- a/src/traits.c
+++ b/src/traits.c
@@ -64,9 +64,9 @@ static int fptraits(void *param, FuncDeclaration *f)
     FuncAliasDeclaration* alias = new FuncAliasDeclaration(f, 0);
     alias->protection = f->protection;
     if (p->e1)
-        e = new DotVarExp(0, p->e1, alias);
+        e = new DotVarExp(Loc(), p->e1, alias);
     else
-        e = new DsymbolExp(0, alias);
+        e = new DsymbolExp(Loc(), alias);
     p->exps->push(e);
     return 0;
 }

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -91,7 +91,7 @@ Expression *Type::getInternalTypeInfo(Scope *sc)
             {   tid = new TypeInfoDeclaration(t, 1);
                 internalTI[t->ty] = tid;
             }
-            e = new VarExp(0, tid);
+            e = new VarExp(Loc(), tid);
             e = e->addressOf(sc);
             e->type = tid->type;        // do this so we don't get redundant dereference
             return e;
@@ -113,7 +113,7 @@ Expression *Type::getTypeInfo(Scope *sc)
     //printf("Type::getTypeInfo() %p, %s\n", this, toChars());
     if (!Type::typeinfo)
     {
-        error(0, "TypeInfo not found. object.d may be incorrectly installed or corrupt, compile with -v switch");
+        error(Loc(), "TypeInfo not found. object.d may be incorrectly installed or corrupt, compile with -v switch");
         fatal();
     }
 
@@ -153,7 +153,7 @@ Expression *Type::getTypeInfo(Scope *sc)
     }
     if (!vtinfo)
         vtinfo = t->vtinfo;     // Types aren't merged, but we can share the vtinfo's
-    Expression *e = new VarExp(0, t->vtinfo);
+    Expression *e = new VarExp(Loc(), t->vtinfo);
     e = e->addressOf(sc);
     e->type = t->vtinfo->type;          // do this so we don't get redundant dereference
     return e;
@@ -581,10 +581,10 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
          */
         tftohash = new TypeFunction(NULL, Type::thash_t, 0, LINKd);
         tftohash->mod = MODconst;
-        tftohash = (TypeFunction *)tftohash->semantic(0, &sc);
+        tftohash = (TypeFunction *)tftohash->semantic(Loc(), &sc);
 
         tftostring = new TypeFunction(NULL, Type::tchar->invariantOf()->arrayOf(), 0, LINKd);
-        tftostring = (TypeFunction *)tftostring->semantic(0, &sc);
+        tftostring = (TypeFunction *)tftostring->semantic(Loc(), &sc);
     }
 
     TypeFunction *tfcmpptr;
@@ -601,7 +601,7 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
         arguments->push(arg);
         tfcmpptr = new TypeFunction(arguments, Type::tint32, 0, LINKd);
         tfcmpptr->mod = MODconst;
-        tfcmpptr = (TypeFunction *)tfcmpptr->semantic(0, &sc);
+        tfcmpptr = (TypeFunction *)tfcmpptr->semantic(Loc(), &sc);
     }
 
     s = search_function(sd, Id::tohash);
@@ -906,7 +906,7 @@ Expression *createTypeInfoArray(Scope *sc, Expression *exps[], size_t dim)
         for (int i = 0; i < dim; i++)
         {   t = exps[i]->type;
             e = t->getTypeInfo(sc);
-            ai->addInit(new IntegerExp(i), new ExpInitializer(0, e));
+            ai->addInit(new IntegerExp(i), new ExpInitializer(Loc(), e));
         }
 
         t = Type::typeinfo->type->arrayOf();
@@ -922,7 +922,7 @@ Expression *createTypeInfoArray(Scope *sc, Expression *exps[], size_t dim)
         v->parent = m;
         sc = sc->pop();
     }
-    e = new VarExp(0, v);
+    e = new VarExp(Loc(), v);
     e = e->semantic(sc);
     return e;
 #endif


### PR DESCRIPTION
In D, you cannot implicitly call a struct constructor when passing a value to a constructor.  Most of these cases are generated code that will never be seen by the user.

In each case an existing loc was used if there was an obvious one available, otherwise existing behavior was preserved by explicitly calling `Loc()`.
