### PR TITLE
[DDMD] Check that matched symbol is always a FuncDeclaration

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -485,9 +485,12 @@ void FuncDeclaration::semantic(Scope *sc)
                     if (s)
                     {
                         FuncDeclaration *f = s->isFuncDeclaration();
-                        f = f->overloadExactMatch(type);
-                        if (f && f->isFinal() && f->prot() != PROTprivate)
-                            error("cannot override final function %s", f->toPrettyChars());
+                        if (f)
+                        {
+                            f = f->overloadExactMatch(type);
+                            if (f && f->isFinal() && f->prot() != PROTprivate)
+                                error("cannot override final function %s", f->toPrettyChars());
+                        }
                     }
                 }
 


### PR DESCRIPTION
Not broken, but I ran into this while working on the code.  Can't hurt to check before dereferencing.
