### PR TITLE
[DDMD] Replace global.structalign with STRUCTALIGN_DEFAULT

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -100,8 +100,6 @@ void Global::init()
 
     main_d = "__main.d";
 
-    structalign = STRUCTALIGN_DEFAULT;
-
     memset(&params, 0, sizeof(Param));
 }
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -265,8 +265,6 @@ struct Global
     Strings *path;        // Array of char*'s which form the import lookup path
     Strings *filePath;    // Array of char*'s which form the file import lookup path
 
-    structalign_t structalign;       // default alignment for struct fields
-
     const char *version;
 
     Compiler compiler;

--- a/src/parse.c
+++ b/src/parse.c
@@ -574,7 +574,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl)
                     check(TOKrparen);
                 }
                 else
-                    n = global.structalign;             // default
+                    n = STRUCTALIGN_DEFAULT;             // default
 
                 a = parseBlock(pLastDecl);
                 s = new AlignDeclaration(n, a);
@@ -3046,7 +3046,7 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, unsigned char *c
                     check(TOKrparen);
                 }
                 else
-                    structalign = global.structalign;   // default
+                    structalign = STRUCTALIGN_DEFAULT;   // default
                 continue;
             }
             default:

--- a/src/scope.c
+++ b/src/scope.c
@@ -61,7 +61,7 @@ Scope::Scope()
     this->scontinue = NULL;
     this->fes = NULL;
     this->callsc = NULL;
-    this->structalign = global.structalign;
+    this->structalign = STRUCTALIGN_DEFAULT;
     this->func = NULL;
     this->slabel = NULL;
     this->linkage = LINKd;

--- a/src/toir.c
+++ b/src/toir.c
@@ -726,7 +726,7 @@ void FuncDeclaration::buildClosure(IRState *irs)
                  */
                 memsize = Target::ptrsize * 2;
                 memalignsize = memsize;
-                xalign = global.structalign;
+                xalign = STRUCTALIGN_DEFAULT;
             }
             else if (ISWIN64REF(v))
             {
@@ -738,7 +738,7 @@ void FuncDeclaration::buildClosure(IRState *irs)
             {    // reference parameters are just pointers
                 memsize = Target::ptrsize;
                 memalignsize = memsize;
-                xalign = global.structalign;
+                xalign = STRUCTALIGN_DEFAULT;
             }
             else
 #endif


### PR DESCRIPTION
Since STRUCTALIGN_DEFAULT was introduced, global.structalign is no longer set to any other value.

Getting rid of this also allows Scope to be implemented as a struct in D, as it no longer needs a default constructor.
