### PR TITLE
Fix up for issue 6453 change, allow shared/synchronized invariants

### DIFF
--- a/test/fail_compilation/fail6453.d
+++ b/test/fail_compilation/fail6453.d
@@ -1,0 +1,24 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail6453.d(13): Error: struct fail6453.S6453x mixing invariants with shared/synchronized differene is not supported
+fail_compilation/fail6453.d(18): Error: class fail6453.C6453y mixing invariants with shared/synchronized differene is not supported
+fail_compilation/fail6453.d(23): Error: class fail6453.C6453z mixing invariants with shared/synchronized differene is not supported
+---
+*/
+
+struct S6453x
+{
+           invariant() {}
+    shared invariant() {}
+}
+class C6453y
+{
+           invariant() {}
+    synchronized invariant() {}
+}
+class C6453z
+{
+          shared invariant() {}
+    synchronized invariant() {}
+}

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -85,6 +85,25 @@ void test6453()
             static assert(!__traits(compiles, y));
         }
     }
+
+    static struct S6453a
+    {
+        pure    invariant() {}
+        nothrow invariant() {}
+        @safe   invariant() {}
+    }
+    static struct S6453b
+    {
+        pure    shared invariant() {}
+        nothrow shared invariant() {}
+        @safe   shared invariant() {}
+    }
+    static class C6453c
+    {
+        pure    synchronized invariant() {}
+        nothrow synchronized invariant() {}
+        @safe   synchronized invariant() {}
+    }
 }
 
 /***************************************************/


### PR DESCRIPTION
But mixing non-shared/shared/synchronized is currently rejected.
