### PR TITLE
[REG2.060] fix Issue 10076 - expression.c:4310: virtual Expression* TypeExp::semantic(Scope*): Assertion `0' failed.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6486,6 +6486,7 @@ L1:
         }
         if (t->ty == Tinstance && t != this && !t->deco)
         {   error(loc, "forward reference to '%s'", t->toChars());
+            *pt = Type::terror;
             return;
         }
 
@@ -6505,6 +6506,7 @@ L1:
                     {
                         if (!scx)
                         {   error(loc, "forward reference to '%s'", t->toChars());
+                            *pt = Type::terror;
                             return;
                         }
                         if (scx->scopesym == scopesym)

--- a/test/fail_compilation/ice10076.d
+++ b/test/fail_compilation/ice10076.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice10076.d(21): Error: template instance getMembersAndAttributesWhere!() template 'getMembersAndAttributesWhere' is not defined
+fail_compilation/ice10076.d(26): Error: template instance ice10076.getValidaterAttrs!(string) error instantiating
+fail_compilation/ice10076.d(16):        instantiated from here: validate!(string)
+fail_compilation/ice10076.d(26): Error: forward reference to 'getMembersAndAttributesWhere!().Elements'
+fail_compilation/ice10076.d(26): Error: forward reference to 'getMembersAndAttributesWhere!().Elements'
+fail_compilation/ice10076.d(16): Error: template instance ice10076.validate!(string) error instantiating
+---
+*/
+
+void main()
+{
+    string s;
+    validate(s);
+}
+
+template getValidaterAttrs(T)
+{
+    alias getMembersAndAttributesWhere!().Elements getValidaterAttrs;
+}
+
+void validate(T)(T)
+{
+    alias getValidaterAttrs!T memberAttrs;
+    auto x = memberAttrs.length;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10076
