### PR TITLE
[DDMD] Make sure final functions do not get mangled as virtual

### DIFF
--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -373,9 +373,9 @@ Symbol *FuncDeclaration::toSymbol()
             s->Sclass = SCglobal;
             symbol_func(s);
             func_t *f = s->Sfunc;
-            if (isVirtual())
+            if (isVirtual() && vtblIndex != -1)
                 f->Fflags |= Fvirtual;
-            else if (isMember2())
+            else if (isMember2() && isStatic())
                 f->Fflags |= Fstatic;
             f->Fstartline.Slinnum = loc.linnum;
             f->Fstartline.Sfilename = (char *)loc.filename;


### PR DESCRIPTION
This allows non-virtual non-static extern(C++) member functions to be mangled correctly on win32.
