### PR TITLE
[REG2.063a] Issue 10096 - __traits(allMembers) triggers out of bounds error

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -317,10 +317,7 @@ Expression *resolvePropertiesX(Scope *sc, Expression *e)
         tthis  = NULL;
     L1:
         assert(td);
-        unsigned errors = global.startGagging();
         FuncDeclaration *fd = resolveFuncCall(e->loc, sc, td, tiargs, tthis, NULL, 1);
-        if (global.endGagging(errors))
-            fd = NULL;  // eat "is not a function template" error
         if (fd && fd->type)
         {   assert(fd->type->ty == Tfunction);
             TypeFunction *tf = (TypeFunction *)fd->type;

--- a/src/template.c
+++ b/src/template.c
@@ -2123,7 +2123,8 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Loc loc, Scope *sc,
             FuncDeclaration *fd = s->isFuncDeclaration();
             if (!fd)
             {
-                td->error("is not a function template");
+                if (!(flags & 1))
+                    td->error("is not a function template");
                 goto Lerror;
             }
             fd = resolveFuncCall(loc, sc, fd, NULL, tthis, fargs, flags);

--- a/src/traits.c
+++ b/src/traits.c
@@ -482,6 +482,14 @@ Expression *TraitsExp::semantic(Scope *sc)
                 //printf("\t[%i] %s %s\n", i, sm->kind(), sm->toChars());
                 if (sm->ident)
                 {
+                    if (sm->ident != Id::ctor &&        // backword compatibility
+                        sm->ident != Id::dtor &&        // backword compatibility
+                        sm->ident != Id::_postblit &&   // backword compatibility
+                        memcmp(sm->ident->string, "__", 2) == 0)
+                    {
+                        return 0;
+                    }
+
                     //printf("\t%s\n", sm->ident->toChars());
                     Identifiers *idents = (Identifiers *)ctx;
 

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1170,6 +1170,54 @@ void test10043()
 }
 
 /********************************************************/
+// 10096
+
+struct S10096X
+{
+    string str;
+
+    invariant() {}
+    invariant() {}
+    unittest {}
+
+    this(int) {}
+    this(this) {}
+    ~this() {}
+}
+static assert(
+    [__traits(allMembers, S10096X)] ==
+    ["str", "__ctor", "__postblit", "__dtor", "opAssign"]);
+
+// --------
+
+string foo10096(alias var, T = typeof(var))()
+{
+    foreach (idx, member; __traits(allMembers, T))
+    {
+        auto x = var.tupleof[idx];
+    }
+
+    return "";
+}
+
+string foo10096(T)(T var)
+{
+    return "";
+}
+
+struct S10096
+{
+    int i;
+    string s;
+}
+
+void test10096()
+{
+    S10096 s = S10096(1, "");
+    auto x = foo10096!s;
+}
+
+/********************************************************/
 
 int main()
 {
@@ -1205,6 +1253,7 @@ int main()
     test7408();
     test9552();
     test9136();
+    test10096();
 
     writeln("Success");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10096

Do not list internal members in `__traits(allMembers)`
- Names starting double underscore does not appear its result.
  Now, `__cpctor`, `__invariant`, `__xopEquals`, `__fieldPostBlit`, `__aggrPostBlit`, `__fieldDtor`, `__aggrDtor`, and others are not listed in there.
- Except `__ctor`, `__dtor`, and `__postblit`. They are already used in Phobos, so temporary keep them for backward compatibility.
