### PR TITLE
[DDMD] Make verror extern(C)

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -244,6 +244,7 @@ void verrorPrint(Loc loc, const char *header, const char *format, va_list ap,
 }
 
 // header is "Error: " by default (see mars.h)
+extern "C" {
 void verror(Loc loc, const char *format, va_list ap,
                 const char *p1, const char *p2, const char *header)
 {
@@ -259,6 +260,7 @@ void verror(Loc loc, const char *format, va_list ap,
         global.gaggedErrors++;
     }
     global.errors++;
+}
 }
 
 // Doesn't increase error count, doesn't print "Error:".

--- a/src/mars.h
+++ b/src/mars.h
@@ -419,7 +419,9 @@ void warning(Loc loc, const char *format, ...);
 void deprecation(Loc loc, const char *format, ...);
 void error(Loc loc, const char *format, ...);
 void errorSupplemental(Loc loc, const char *format, ...);
+extern "C" {
 void verror(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
+}
 void vwarning(Loc loc, const char *format, va_list);
 void verrorSupplemental(Loc loc, const char *format, va_list ap);
 void verrorPrint(Loc loc, const char *header, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);


### PR DESCRIPTION
<del>This one is tricky.  In C++ or at least with dmc, va_list is a `char *`.  But in D/druntime, it's a `void *`.  This means the mangling is different for `verror` and it can't be used from whichever language it isn't implemented in.</del>


<del>Any better ideas?</del>


Ok, better idea - make it extern(C) so we don't have to care about mangling.
