### PR TITLE
[REG2.063a] Issue 10101 - static if conditional cannot be at global scope using mixin template

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1413,7 +1413,13 @@ Dsymbols *StaticIfDeclaration::include(Scope *sc, ScopeDsymbol *sd)
 
     if (condition->inc == 0)
     {
+        /* Bugzilla 10101: Condition evaluation may cause self-recursive
+         * condition evaluation. To resolve it, temporarily save sc into scope.
+         */
+        bool x = !scope && sc;
+        if (x) scope = sc;
         Dsymbols *d = ConditionalDeclaration::include(sc, sd);
+        if (x) scope = NULL;
 
         // Set the scopes lazily.
         if (scope && d)

--- a/test/compilable/fwdref10101.d
+++ b/test/compilable/fwdref10101.d
@@ -1,0 +1,25 @@
+// PERMUTE_ARGS:
+
+int front(int);
+
+mixin template reflectRange()
+{
+    static if ( is( typeof(this.front) ) )
+    {
+        int x;
+    }
+}
+
+struct S(R)
+{
+    R r_;
+
+    typeof(r_.front) front() @property { return r_.front; }
+
+    mixin reflectRange;
+}
+
+void main()
+{
+    S!(int) s;
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10101

This regression is caused by merging #1227.
