### PR TITLE
Remove dump_source from front end.

### DIFF
--- a/src/mars.h
+++ b/src/mars.h
@@ -206,8 +206,6 @@ struct Param
     unsigned versionlevel;      // version level
     Strings *versionids;   // version identifiers
 
-    bool dump_source;
-
     const char *defaultlibname; // default library for non-debug builds
     const char *debuglibname;   // default library for debug builds
 

--- a/src/module.c
+++ b/src/module.c
@@ -513,14 +513,6 @@ void Module::parse()
         }
     }
 
-#ifdef IN_GCC
-    // dump utf-8 encoded source
-    if (global.params.dump_source)
-    {   // %% srcname could contain a path ...
-        d_gcc_dump_source(srcname, "utf-8", buf, buflen);
-    }
-#endif
-
     /* If it starts with the string "Ddoc", then it's a documentation
      * source file.
      */


### PR DESCRIPTION
GDC specific, and I have no problem removing this switch from the compiler.
