### PR TITLE
Add isLP64 to differentiate between LP64 and x86_64 targets.

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -976,6 +976,9 @@ Language changes listed by -transition=id:\n\
         error(Loc(), "the architecture must not be changed in the %s section of %s",
               is64bit ? "Environment64" : "Environment32", inifilename);
 
+    // Target uses 64bit pointers.
+    global.params.isLP64 = global.params.is64bit;
+
     if (global.errors)
     {
         fatal();
@@ -1072,7 +1075,6 @@ Language changes listed by -transition=id:\n\
     {
         VersionCondition::addPredefinedGlobalIdent("D_InlineAsm_X86_64");
         VersionCondition::addPredefinedGlobalIdent("X86_64");
-        VersionCondition::addPredefinedGlobalIdent("D_LP64");
         VersionCondition::addPredefinedGlobalIdent("D_SIMD");
 #if TARGET_WINDOS
         VersionCondition::addPredefinedGlobalIdent("Win64");
@@ -1095,6 +1097,8 @@ Language changes listed by -transition=id:\n\
         VersionCondition::addPredefinedGlobalIdent("Win32");
 #endif
     }
+    if (global.params.isLP64)
+        VersionCondition::addPredefinedGlobalIdent("D_LP64");
     if (global.params.doDocComments)
         VersionCondition::addPredefinedGlobalIdent("D_Ddoc");
     if (global.params.cov)

--- a/src/mars.h
+++ b/src/mars.h
@@ -145,6 +145,7 @@ struct Param
     bool optimize;      // run optimizer
     char map;           // generate linker .map file
     char is64bit;       // generate 64 bit code
+    char isLP64;        // generate code for LP64
     char isLinux;       // generate code for linux
     char isOSX;         // generate code for Mac OSX
     char isWindows;     // generate code for Windows

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -324,7 +324,7 @@ void Type::init()
     tstring = tchar->invariantOf()->arrayOf();
     tvalist = tvoid->pointerTo();
 
-    if (global.params.is64bit)
+    if (global.params.isLP64)
     {
         Tsize_t = Tuns64;
         Tptrdiff_t = Tint64;

--- a/src/target.c
+++ b/src/target.c
@@ -49,7 +49,6 @@ void Target::init()
 
     if (global.params.is64bit)
     {
-        ptrsize = 8;
         if (global.params.isLinux || global.params.isFreeBSD || global.params.isSolaris)
         {
             realsize = 16;
@@ -57,6 +56,9 @@ void Target::init()
             realalignsize = 16;
         }
     }
+
+    if (global.params.isLP64)
+        ptrsize = 8;
 }
 
 /******************************

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -483,7 +483,7 @@ void ClassDeclaration::toObjFile(int multiobj)
        }
      */
     dt_t *dt = NULL;
-    unsigned classinfo_size = global.params.is64bit ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
+    unsigned classinfo_size = global.params.isLP64 ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
     offset = classinfo_size;
     if (classinfo)
     {
@@ -845,7 +845,7 @@ unsigned ClassDeclaration::baseVtblOffset(BaseClass *bc)
     unsigned csymoffset;
 
     //printf("ClassDeclaration::baseVtblOffset('%s', bc = %p)\n", toChars(), bc);
-    csymoffset = global.params.is64bit ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
+    csymoffset = global.params.isLP64 ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
     csymoffset += vtblInterfaces->dim * (4 * Target::ptrsize);
 
     for (size_t i = 0; i < vtblInterfaces->dim; i++)
@@ -999,7 +999,7 @@ void InterfaceDeclaration::toObjFile(int multiobj)
     dtsize_t(&dt, vtblInterfaces->dim);
     if (vtblInterfaces->dim)
     {
-        offset = global.params.is64bit ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
+        offset = global.params.isLP64 ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
         if (classinfo)
         {
             if (classinfo->structsize != offset)


### PR DESCRIPTION
is64bit has a meaning of `version(X86_64)` to the frontend, however gdc/ldc uses this to determine whether the target is 64bit capable.  Example:

object.d

```
struct TypeInfo_Struct
{
   /* ... */
   version (X86_64)
   {
      TypeInfo m_arg1;
      TypeInfo m_arg2;
   }
}
```

typinf.c

```
if (global.params.is64bit)
{
   /* emit m_arg1 and m_arg2 into toDt */
}
```

So on eg:  ARM64, is64bit is true, but X86_64 is false.  This causes a mismatch between the TypeInfo_Struct sizes at compile time, throwing an error.

The alternative could be to introduce isX86_64 instead, and change everything else that uses is64bit as necessary.
