### PR TITLE
Remove Module::gencritsec

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -1296,25 +1296,6 @@ Symbol *TypeClass::toSymbol()
     return sym->toSymbol();
 }
 
-/*************************************
- * Generate symbol in data segment for critical section.
- */
-
-Symbol *Module::gencritsec()
-{
-    Symbol *s;
-    type *t;
-
-    t = Type::tint32->toCtype();
-    s = symbol_name("critsec", SCstatic, t);
-    s->Sfl = FLdata;
-    /* Must match D_CRITICAL_SECTION in phobos/internal/critical.c
-     */
-    dtnzeros(&s->Sdt, Target::ptrsize + (I64 ? os_critsecsize64() : os_critsecsize32()));
-    outdata(s);
-    return s;
-}
-
 /**************************************
  * Generate elem that is a pointer to the module file name.
  */

--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -1104,12 +1104,6 @@ Symbol *TypeClass::toSymbol()
     return NULL;
 }
 
-Symbol *Module::gencritsec()
-{
-    assert(0);
-    return NULL;
-}
-
 elem *Module::toEfilename()
 {
     assert(0);

--- a/src/module.h
+++ b/src/module.h
@@ -165,7 +165,6 @@ public:
     Symbol *toModuleArray();    // get module array bounds function
 
 
-    static Symbol *gencritsec();
     elem *toEfilename();
 
     Symbol *toSymbol();


### PR DESCRIPTION
This is not used anywhere in the D frontend/glue implementation.
