### PR TITLE
Remove util_progress from frontend.

### DIFF
--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -1516,12 +1516,6 @@ Library *Library::factory()
     return NULL;
 }
 
-// ???
-
-void util_progress()
-{
-}
-
 Statement *AsmStatement::semantic(Scope *)
 {
     assert(0);

--- a/src/mars.h
+++ b/src/mars.h
@@ -433,7 +433,6 @@ void deleteExeFile();
 int runProgram();
 const char *inifile(const char *argv0, const char *inifile, const char* envsectionname);
 void halt();
-void util_progress();
 
 /*** Where to send error messages ***/
 class Dsymbol;

--- a/src/template.c
+++ b/src/template.c
@@ -6529,9 +6529,6 @@ void TemplateMixin::semantic(Scope *sc)
 #if LOG
     printf("\tdo semantic\n");
 #endif
-#ifndef IN_GCC
-    util_progress();
-#endif
 
     Scope *scx = NULL;
     if (scope)


### PR DESCRIPTION
This also irks me. This routine apparently only serves the benefit for dmc/win32 built dmd, but there shouldn't be a need for this in TemplateMixin::semantic  (it should already gracefully exit if it discovers a recursive mixin).
