### PR TITLE
[post-2.063] Move typedefs into port.h

### DIFF
--- a/src/intrange.h
+++ b/src/intrange.h
@@ -12,7 +12,7 @@
 #ifndef DMD_SXNUM_H
 #define DMD_SXNUM_H
 
-#include "mars.h"   // for uinteger_t
+#include "port.h"   // for uinteger_t
 class Type;
 class Expression;
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -303,49 +303,10 @@ extern Global global;
  #include  <complex.h>
  typedef _Complex long double complex_t;
 #else
- #ifndef IN_GCC
-  #include "complex_t.h"
- #endif
- #ifdef __APPLE__
-  //#include "complex.h"//This causes problems with include the c++ <complex> and not the C "complex.h"
- #endif
+ #include "complex_t.h"
 #endif
 
-// Be careful not to care about sign when using dinteger_t
-//typedef uint64_t integer_t;
-typedef uint64_t dinteger_t;    // use this instead of integer_t to
-                                // avoid conflicts with system #include's
-
-// Signed and unsigned variants
-typedef int64_t sinteger_t;
-typedef uint64_t uinteger_t;
-
-typedef int8_t                  d_int8;
-typedef uint8_t                 d_uns8;
-typedef int16_t                 d_int16;
-typedef uint16_t                d_uns16;
-typedef int32_t                 d_int32;
-typedef uint32_t                d_uns32;
-typedef int64_t                 d_int64;
-typedef uint64_t                d_uns64;
-
-typedef float                   d_float32;
-typedef double                  d_float64;
-typedef longdouble              d_float80;
-
-typedef d_uns8                  d_char;
-typedef d_uns16                 d_wchar;
-typedef d_uns32                 d_dchar;
-
-#ifdef IN_GCC
-#include "d-gcc-real.h"
-#else
-typedef longdouble real_t;
-#endif
-
-#ifdef IN_GCC
-#include "d-gcc-complex_t.h"
-#endif
+typedef longdouble  real_t;
 
 class Module;
 

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -10,7 +10,34 @@
 // Portable wrapper around compiler/system specific things.
 // The idea is to minimize #ifdef's in the app code.
 
+#include <stdint.h>
+
 #include "longdouble.h"
+
+// Be careful not to care about sign when using dinteger_t
+typedef uint64_t dinteger_t;    // use this instead of integer_t to
+                                // avoid conflicts with system #include's
+
+// Signed and unsigned variants
+typedef int64_t sinteger_t;
+typedef uint64_t uinteger_t;
+
+typedef int8_t      d_int8;
+typedef uint8_t     d_uns8;
+typedef int16_t     d_int16;
+typedef uint16_t    d_uns16;
+typedef int32_t     d_int32;
+typedef uint32_t    d_uns32;
+typedef int64_t     d_int64;
+typedef uint64_t    d_uns64;
+
+typedef float       d_float32;
+typedef double      d_float64;
+typedef longdouble  d_float80;
+
+typedef d_uns8      d_char;
+typedef d_uns16     d_wchar;
+typedef d_uns32     d_dchar;
 
 #if _MSC_VER
 #include <float.h>  // for _isnan


### PR DESCRIPTION
Ditto #2064 and #2065.  Moves typedefs into port.h so that gdc's real_t implementation does not depend on mars.h (and so can be used at lower levels of the front end).

Please leave this until after the 2.063 release.
