### PR TITLE
[REG2.063a] Issue 10144 - Using enum inside final class occurs weird errors

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1157,7 +1157,7 @@ Lnomatch:
     else if (type->isWild())
         storage_class |= STCwild;
 
-    if (storage_class & (STCmanifest | STCstatic))
+    if (storage_class & (STCmanifest | STCstatic | STCgshared))
     {
     }
     else if (isSynchronized())

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1157,7 +1157,10 @@ Lnomatch:
     else if (type->isWild())
         storage_class |= STCwild;
 
-    if (isSynchronized())
+    if (storage_class & (STCmanifest | STCstatic))
+    {
+    }
+    else if (isSynchronized())
     {
         error("variable %s cannot be synchronized", toChars());
     }

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -199,6 +199,29 @@ void test8942()
 }
 
 /***************************************************/
+// 10144
+
+final class TNFA10144(char_t)
+{
+    enum Act { don }
+    const Act[] action_lookup1 = [ Act.don, ];
+}
+alias X10144 = TNFA10144!char;
+
+class C10144
+{
+    enum Act { don }
+    synchronized { enum x1 = [Act.don]; }
+    override     { enum x2 = [Act.don]; }
+    abstract     { enum x3 = [Act.don]; }
+    final        { enum x4 = [Act.don]; }
+    synchronized { static s1 = [Act.don]; }
+    override     { static s2 = [Act.don]; }
+    abstract     { static s3 = [Act.don]; }
+    final        { static s4 = [Act.don]; }
+}
+
+/***************************************************/
 
 int main()
 {

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -219,6 +219,10 @@ class C10144
     override     { static s2 = [Act.don]; }
     abstract     { static s3 = [Act.don]; }
     final        { static s4 = [Act.don]; }
+    synchronized { __gshared gs1 = [Act.don]; }
+    override     { __gshared gs2 = [Act.don]; }
+    abstract     { __gshared gs3 = [Act.don]; }
+    final        { __gshared gs4 = [Act.don]; }
 }
 
 /***************************************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10144

An enum and static variable declaration should not be affected by `synchronized`, `override`, `abstract`, and `final` attributes.
