### PR TITLE
[enh][REG2.063a] Issue 10150 - Prefix method 'this' qualifiers should be just ignored anytime

### DIFF
--- a/test/compilable/test10150.d
+++ b/test/compilable/test10150.d
@@ -1,0 +1,36 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+void foo() {}
+alias F = typeof(foo);
+
+class C
+{
+    const        static void fc() {}
+    immutable    static void fi() {}
+    inout        static void fw() {}
+    shared       static void fs() {}
+    shared const static void fsc() {}
+    shared inout static void fsw() {}
+
+    static assert(is(typeof(fc) == F));
+    static assert(is(typeof(fi) == F));
+    static assert(is(typeof(fw) == F));
+    static assert(is(typeof(fs) == F));
+    static assert(is(typeof(fsc) == F));
+    static assert(is(typeof(fsw) == F));
+}
+
+const        { void fc() {} }
+immutable    { void fi() {} }
+inout        { void fw() {} }
+shared       { void fs() {} }
+shared const { void fsc() {} }
+shared inout { void fsw() {} }
+
+static assert(is(typeof(fc) == F));
+static assert(is(typeof(fi) == F));
+static assert(is(typeof(fw) == F));
+static assert(is(typeof(fs) == F));
+static assert(is(typeof(fsc) == F));
+static assert(is(typeof(fsw) == F));

--- a/test/fail_compilation/fail9199.d
+++ b/test/fail_compilation/fail9199.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -o-
 /*
 TEST_OUTPUT:
 ---
@@ -9,10 +10,31 @@ fail_compilation/fail9199.d(17): Error: function fail9199.fsc without 'this' can
 fail_compilation/fail9199.d(18): Error: function fail9199.fsw without 'this' cannot be shared inout
 ---
 */
-
 void fc() const {}
 void fi() immutable {}
 void fw() inout {}
 void fs() shared {}
 void fsc() shared const {}
 void fsw() shared inout {}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9199.d(33): Error: function fail9199.C.fc without 'this' cannot be const
+fail_compilation/fail9199.d(34): Error: function fail9199.C.fi without 'this' cannot be immutable
+fail_compilation/fail9199.d(35): Error: function fail9199.C.fw without 'this' cannot be inout
+fail_compilation/fail9199.d(36): Error: function fail9199.C.fs without 'this' cannot be shared
+fail_compilation/fail9199.d(37): Error: function fail9199.C.fsc without 'this' cannot be shared const
+fail_compilation/fail9199.d(38): Error: function fail9199.C.fsw without 'this' cannot be shared inout
+---
+*/
+class C
+{
+    static void fc() const {}
+    static void fi() immutable {}
+    static void fw() inout {}
+    static void fs() shared {}
+    static void fsc() shared const {}
+    static void fsw() shared inout {}
+}
+


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10150

Fixing [bug 9199](http://d.puremagic.com/issues/show_bug.cgi?id=9199) was not so bad, but it had broke existing code by the too restrictive behavior.
For fixing the regression and proposing more consistent/convenient compiler behavior, I filed issue 10150.
