### PR TITLE
Refactoring template parameter deduction code

### DIFF
--- a/src/mtype.h
+++ b/src/mtype.h
@@ -441,6 +441,7 @@ public:
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toJson(JsonOut *json);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wildmatch = NULL);
+    Type *reliesOnTident(TemplateParameters *tparams);
 #if CPP_MANGLE
     void toCppMangle(OutBuffer *buf, CppMangleState *cms);
 #endif

--- a/src/scope.c
+++ b/src/scope.c
@@ -77,7 +77,6 @@ Scope::Scope()
     this->needctfe = 0;
     this->intypeof = 0;
     this->speculative = 0;
-    this->parameterSpecialization = 0;
     this->callSuper = 0;
     this->flags = 0;
     this->lastdc = NULL;
@@ -127,7 +126,6 @@ Scope::Scope(Scope *enclosing)
     this->needctfe = enclosing->needctfe;
     this->intypeof = enclosing->intypeof;
     this->speculative = enclosing->speculative;
-    this->parameterSpecialization = enclosing->parameterSpecialization;
     this->callSuper = enclosing->callSuper;
     this->flags = (enclosing->flags & (SCOPEcontract | SCOPEdebug));
     this->lastdc = NULL;

--- a/src/scope.h
+++ b/src/scope.h
@@ -86,7 +86,6 @@ public:
     int noctor;                 // set if constructor calls aren't allowed
     int intypeof;               // in typeof(exp)
     bool speculative;            // in __traits(compiles) or typeof(exp)
-    int parameterSpecialization; // if in template parameter specialization
     int noaccesscheck;          // don't do access checks
     int needctfe;               // inside a ctfe-only expression
 

--- a/src/template.h
+++ b/src/template.h
@@ -154,6 +154,7 @@ public:
     /* Match actual argument against parameter.
      */
     virtual MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam) = 0;
+    virtual MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam) = 0;
 
     /* Create dummy argument based on parameter.
      */
@@ -183,6 +184,7 @@ public:
     Object *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
     MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
+    MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -227,6 +229,7 @@ public:
     Object *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
     MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
+    MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -255,6 +258,7 @@ public:
     Object *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
     MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
+    MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -277,6 +281,7 @@ public:
     Object *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
     MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
+    MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 

--- a/src/template.h
+++ b/src/template.h
@@ -141,7 +141,7 @@ public:
 
     virtual TemplateParameter *syntaxCopy() = 0;
     virtual void declareParameter(Scope *sc) = 0;
-    virtual void semantic(Scope *) = 0;
+    virtual void semantic(Scope *sc, TemplateParameters *parameters) = 0;
     virtual void print(Object *oarg, Object *oded) = 0;
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs) = 0;
     virtual Object *specialization() = 0;
@@ -176,7 +176,7 @@ public:
     TemplateTypeParameter *isTemplateTypeParameter();
     TemplateParameter *syntaxCopy();
     void declareParameter(Scope *sc);
-    void semantic(Scope *);
+    void semantic(Scope *sc, TemplateParameters *parameters);
     void print(Object *oarg, Object *oded);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Object *specialization();
@@ -220,7 +220,7 @@ public:
     TemplateValueParameter *isTemplateValueParameter();
     TemplateParameter *syntaxCopy();
     void declareParameter(Scope *sc);
-    void semantic(Scope *);
+    void semantic(Scope *sc, TemplateParameters *parameters);
     void print(Object *oarg, Object *oded);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Object *specialization();
@@ -248,7 +248,7 @@ public:
     TemplateAliasParameter *isTemplateAliasParameter();
     TemplateParameter *syntaxCopy();
     void declareParameter(Scope *sc);
-    void semantic(Scope *);
+    void semantic(Scope *sc, TemplateParameters *parameters);
     void print(Object *oarg, Object *oded);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Object *specialization();
@@ -270,7 +270,7 @@ public:
     TemplateTupleParameter *isTemplateTupleParameter();
     TemplateParameter *syntaxCopy();
     void declareParameter(Scope *sc);
-    void semantic(Scope *);
+    void semantic(Scope *sc, TemplateParameters *parameters);
     void print(Object *oarg, Object *oded);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Object *specialization();


### PR DESCRIPTION
1. Remove unnecessary `Scope::parameterSpecialization`
   
   Can determine the necessity of `semantic` by using `Type::reliesOnTident`
2. Use TemplateParameter::matchArg in `Type::deduceType`
   
   Fix commented "BUG"s.
