### PR TITLE
[REG2.063a] Issue 10178 - Compiler segfault with zero-length tuple comparison

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -12733,17 +12733,21 @@ Expression *EqualExp::semantic(Scope *sc)
         TupleExp *tup1 = (TupleExp *)e1;
         TupleExp *tup2 = (TupleExp *)e2;
         size_t dim = tup1->exps->dim;
+        Expression *e = NULL;
         if (dim != tup2->exps->dim)
         {
             error("mismatched tuple lengths, %d and %d", (int)dim, (int)tup2->exps->dim);
-            return new ErrorExp();
+            e = new ErrorExp();
+        }
+        else if (dim == 0)
+        {
+            // zero-length tuple comparison should always return true or false.
+            e = new IntegerExp(loc, (op == TOKequal), Type::tboolean);
         }
         else
         {
             Expressions *exps = new Expressions;
             exps->setDim(dim);
-
-            Expression *e = NULL;
             for (size_t i = 0; i < dim; i++)
             {
                 Expression *ex1 = (*tup1->exps)[i];
@@ -12756,11 +12760,12 @@ Expression *EqualExp::semantic(Scope *sc)
                 else
                     e = new OrOrExp(loc, e, eeq);
             }
+            assert(e);
             e = combine(combine(tup1->e0, tup2->e0), e);
-            e = e->semantic(sc);
             //printf("e = %s\n", e->toChars());
-            return e;
         }
+        e = e->semantic(sc);
+        return e;
     }
 
     e = typeCombine(sc);

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1176,6 +1176,17 @@ void test9873()
 }
 
 /***************************************************/
+// 10178
+
+void test10178()
+{
+    struct S {}
+    S s;
+    assert((s.tupleof == s.tupleof) == true);
+    assert((s.tupleof != s.tupleof) == false);
+}
+
+/***************************************************/
 // 9890
 
 void test9890()


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10178

This is a regression caused by implementing [issue 9873](http://d.puremagic.com/issues/show_bug.cgi?id=9873).
