### PR TITLE
MinGW support in Port

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -18,10 +18,6 @@
 #include <complex.h>
 #endif
 
-#if _WIN32 && __DMC__
-extern "C" const char * __cdecl __locale_decpoint;
-#endif
-
 #include "rmem.h"
 #include "port.h"
 #include "root.h"
@@ -2976,14 +2972,8 @@ void floatToBuffer(OutBuffer *buf, Type *type, real_t value)
     char buffer[32];
     ld_sprint(buffer, 'g', value);
     assert(strlen(buffer) < sizeof(buffer) / sizeof(buffer[0]));
-#if _WIN32 && __DMC__
-    const char *save = __locale_decpoint;
-    __locale_decpoint = ".";
-    real_t r = strtold(buffer, NULL);
-    __locale_decpoint = save;
-#else
-    real_t r = strtold(buffer, NULL);
-#endif
+
+    real_t r = Port::strtold(buffer, NULL);
     if (r != value)                     // if exact duplication
         ld_sprint(buffer, 'a', value);
     buf->writestring(buffer);

--- a/src/root/longdouble.h
+++ b/src/root/longdouble.h
@@ -22,6 +22,12 @@ typedef volatile long double volatile_longdouble;
 // template<typename T> longdouble ldouble(T x) { return (longdouble) x; }
 #define ldouble(x) ((longdouble)(x))
 
+#if __MINGW32__
+// MinGW supports 80 bit reals, but the formatting functions map to versions
+// from the MSVC runtime by default which don't.
+#define sprintf __mingw_sprintf
+#endif
+
 inline size_t ld_sprint(char* str, int fmt, longdouble x)
 {
     if (((longdouble)(unsigned long long)x) == x)
@@ -39,6 +45,10 @@ inline size_t ld_sprint(char* str, int fmt, longdouble x)
         return sprintf(str, sfmt, x);
     }
 }
+
+#if __MINGW32__
+#undef sprintf
+#endif
 
 #else
 

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -165,6 +165,131 @@ int Port::stricmp(const char *s1, const char *s2)
 
 #endif
 
+#if __MINGW32__
+
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <wchar.h>
+#include <float.h>
+#include <assert.h>
+
+static double zero = 0;
+double Port::nan = copysign(NAN, 1.0);
+double Port::infinity = 1 / zero;
+double Port::dbl_max = 1.7976931348623157e308;
+double Port::dbl_min = 5e-324;
+longdouble Port::ldbl_max = LDBL_MAX;
+
+struct PortInitializer
+{
+    PortInitializer();
+};
+
+static PortInitializer portinitializer;
+
+PortInitializer::PortInitializer()
+{
+    assert(!signbit(Port::nan));
+}
+
+int Port::isNan(double r)
+{
+    return isnan(r);
+}
+
+int Port::isNan(longdouble r)
+{
+    return isnan(r);
+}
+
+int Port::isSignallingNan(double r)
+{
+    /* A signalling NaN is a NaN with 0 as the most significant bit of
+     * its significand, which is bit 51 of 0..63 for 64 bit doubles.
+     */
+    return isNan(r) && !((((unsigned char*)&r)[6]) & 8);
+}
+
+int Port::isSignallingNan(longdouble r)
+{
+    /* A signalling NaN is a NaN with 0 as the most significant bit of
+     * its significand, which is bit 62 of 0..79 for 80 bit reals.
+     */
+    return isNan(r) && !((((unsigned char*)&r)[7]) & 0x40);
+}
+
+int Port::isInfinity(double r)
+{
+    return isinf(r);
+}
+
+longdouble Port::fmodl(longdouble x, longdouble y)
+{
+    return ::fmodl(x, y);
+}
+
+char *Port::strupr(char *s)
+{
+    char *t = s;
+
+    while (*s)
+    {
+        *s = toupper(*s);
+        s++;
+    }
+
+    return t;
+}
+
+int Port::memicmp(const char *s1, const char *s2, int n)
+{
+    int result = 0;
+
+    for (int i = 0; i < n; i++)
+    {   char c1 = s1[i];
+        char c2 = s2[i];
+
+        result = c1 - c2;
+        if (result)
+        {
+            result = toupper(c1) - toupper(c2);
+            if (result)
+                break;
+        }
+    }
+    return result;
+}
+
+int Port::stricmp(const char *s1, const char *s2)
+{
+    int result = 0;
+
+    for (;;)
+    {   char c1 = *s1;
+        char c2 = *s2;
+
+        result = c1 - c2;
+        if (result)
+        {
+            result = toupper(c1) - toupper(c2);
+            if (result)
+                break;
+        }
+        if (!c1)
+            break;
+        s1++;
+        s2++;
+    }
+    return result;
+}
+
+#endif
+
 #if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__
 
 #include <math.h>

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -72,6 +72,36 @@ int Port::stricmp(const char *s1, const char *s2)
     return ::stricmp(s1, s2);
 }
 
+
+extern "C" const char * __cdecl __locale_decpoint;
+
+float Port::strtof(const char *buffer, char **endp)
+{
+    const char *save = __locale_decpoint;
+    __locale_decpoint = ".";
+    float result = ::strtof(buffer, endp);
+    __locale_decpoint = save;
+    return result;
+}
+
+double Port::strtod(const char *buffer, char **endp)
+{
+    const char *save = __locale_decpoint;
+    __locale_decpoint = ".";
+    double result = ::strtod(buffer, endp);
+    __locale_decpoint = save;
+    return result;
+}
+
+longdouble Port::strtold(const char *buffer, char **endp)
+{
+    const char *save = __locale_decpoint;
+    __locale_decpoint = ".";
+    longdouble result = ::strtold(buffer, endp);
+    __locale_decpoint = save;
+    return result;
+}
+
 #endif
 
 #if _MSC_VER
@@ -161,6 +191,22 @@ int Port::memicmp(const char *s1, const char *s2, int n)
 int Port::stricmp(const char *s1, const char *s2)
 {
     return ::stricmp(s1, s2);
+}
+
+float Port::strtof(const char *p, char **endp)
+{
+    return static_cast<float>(::strtod(p, endp));
+}
+
+double Port::strtod(const char *p, char **endp)
+{
+    return ::strtod(p, endp);
+}
+
+// See backend/strtold.c.
+longdouble Port::strtold(const char *p, char **endp)
+{
+    return ::strtold(p, endp);
 }
 
 #endif
@@ -286,6 +332,21 @@ int Port::stricmp(const char *s1, const char *s2)
         s2++;
     }
     return result;
+}
+
+float Port::strtof(const char *p, char **endp)
+{
+    return ::strtof(p, endp);
+}
+
+double Port::strtod(const char *p, char **endp)
+{
+    return ::strtod(p, endp);
+}
+
+longdouble Port::strtold(const char *p, char **endp)
+{
+    return ::__mingw_strtold(p, endp);
 }
 
 #endif
@@ -462,6 +523,21 @@ int Port::stricmp(const char *s1, const char *s2)
     return result;
 }
 
+float Port::strtof(const char *p, char **endp)
+{
+    return ::strtof(p, endp);
+}
+
+double Port::strtod(const char *p, char **endp)
+{
+    return ::strtod(p, endp);
+}
+
+longdouble Port::strtold(const char *p, char **endp)
+{
+    return ::strtold(p, endp);
+}
+
 #endif
 
 #if __sun
@@ -551,6 +627,21 @@ char *Port::strupr(char *s)
     }
 
     return t;
+}
+
+float Port::strtof(const char *p, char **endp)
+{
+    return ::strtof(p, endp);
+}
+
+double Port::strtod(const char *p, char **endp)
+{
+    return ::strtod(p, endp);
+}
+
+longdouble Port::strtold(const char *p, char **endp)
+{
+    return ::strtold(p, endp);
 }
 
 #endif

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -18,7 +18,6 @@
 #include <alloca.h>
 typedef __int64 longlong;
 typedef unsigned __int64 ulonglong;
-#define strtof strtod
 #else
 typedef long long longlong;
 typedef unsigned long long ulonglong;
@@ -46,6 +45,10 @@ struct Port
 
     static int memicmp(const char *s1, const char *s2, int n);
     static int stricmp(const char *s1, const char *s2);
+
+    static float strtof(const char *p, char **endp);
+    static double strtod(const char *p, char **endp);
+    static longdouble strtold(const char *p, char **endp);
 };
 
 #endif


### PR DESCRIPTION
See individual commits for details.

I chose to go for an extra MinGW block instead of further adding to the `#ifdef` forest as this seems to be the style preferred by Walter, but most of the code is actually identical to the `linux || __APPLE__ || __FreeBSD__ || __OpenBSD__` branch (with MinGW being on the macro-heavy side, like `__OpenBSD__`.
