### PR TITLE
Correct DMD C++11 Narrowing Violation

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -497,7 +497,7 @@ void FuncDeclaration::semantic(Scope *sc)
         doesoverride = FALSE;
         switch (vi)
         {
-            case -1:
+            case (size_t)-1:
         Lintro:
                 /* Didn't find one, so
                  * This is an 'introducing' function which gets a new
@@ -537,7 +537,7 @@ void FuncDeclaration::semantic(Scope *sc)
                 }
                 break;
 
-            case -2:    // can't determine because of fwd refs
+            case (size_t)-2:    // can't determine because of fwd refs
                 cd->sizeok = SIZEOKfwd; // can't finish due to forward reference
                 Module::dprogress = dprogress_save;
                 return;
@@ -626,10 +626,10 @@ void FuncDeclaration::semantic(Scope *sc)
             vi = findVtblIndex((Dsymbols *)&b->base->vtbl, b->base->vtbl.dim);
             switch (vi)
             {
-                case -1:
+                case (size_t)-1:
                     break;
 
-                case -2:
+                case (size_t)-2:
                     cd->sizeok = SIZEOKfwd;     // can't finish due to forward reference
                     Module::dprogress = dprogress_save;
                     return;

--- a/src/struct.c
+++ b/src/struct.c
@@ -232,11 +232,11 @@ void AggregateDeclaration::alignmember(
     //printf("alignment = %d, size = %d, offset = %d\n",alignment,size,offset);
     switch (alignment)
     {
-        case 1:
+        case (structalign_t) 1:
             // No alignment
             break;
 
-        case STRUCTALIGN_DEFAULT:
+        case (structalign_t) STRUCTALIGN_DEFAULT:
         {   /* Must match what the corresponding C compiler's default
              * alignment behavior is.
              */


### PR DESCRIPTION
Corrected in src/struct.c and src/func.c, Experienced when compiling ldc in clang after being build with C++11 support.
