### PR TITLE
Fix issue 10198 CTFE struct Multidimensional block assignment

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -457,6 +457,13 @@ ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Loc loc, Type *type,
 {
     Expressions *elements = new Expressions();
     elements->setDim(dim);
+    if (type->ty == Tsarray && type->nextOf()->ty == Tsarray &&
+        elem->type->ty != Tsarray)
+    {
+        // If it is a multidimensional array literal, do it recursively
+        elem = createBlockDuplicatedArrayLiteral(loc, type->nextOf(), elem,
+            ((TypeSArray *)type->nextOf())->dim->toInteger());
+    }
     bool mustCopy = needToCopyLiteral(elem);
     for (size_t i = 0; i < dim; i++)
     {   if (mustCopy)

--- a/src/todt.c
+++ b/src/todt.c
@@ -591,9 +591,13 @@ dt_t **StructLiteralExp::toDt(dt_t **pdt)
                         pdt = dtnzeros(pdt, voffset - offset);
                     if (!d)
                     {
-                        if (v->init)
+                        // If this literal has an initializer, use it
+                        if ((*elements)[j])
+                            (*elements)[j]->toDt(&d);
+                        // else if the declaration has an initializer, use that
+                        else if (v->init)
                             d = v->init->toDt();
-                        else
+                        else    // else use the default initializer
                             vt->toDt(&d);
                     }
                     pdt = dtcat(pdt, d);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4002,6 +4002,24 @@ int bug6886()
 
 static assert(bug6886());
 
+/**************************************************
+    10198 Multidimensional struct block initializer
+**************************************************/
+
+struct Block10198 {
+    int val[3][4];
+}
+
+int bug10198()
+{
+   Block10198 pp = Block10198(67);
+   assert(pp.val[2][3] == 67);
+   assert(pp.val[1][3] == 67);
+  return 1;
+}
+static assert(bug10198());
+
+
 /****************************************************
  * Exception chaining tests from xtest46.d
  ****************************************************/

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -3213,18 +3213,16 @@ int bug2931()
 int bug2931_2()
 {
   Outer2931 v;
+  Bug2931 w = Bug2931(68);
   assert(v.move==3);
   for (int i = 0; i < 4; i++)
-  { for (int j = 0; j < 3; j++)
+  {
+    for (int j = 0; j < 3; j++)
     {
-	printf("[%d][%d] = %d\n", j, i, v.p.val[j][i]);
-	if (i == 0 && j == 0)
-	    assert(v.p.val[j][i] == 67);
-	else
-	    assert(v.p.val[j][i] == 0);
+        assert(w.val[j][i] == 68);
+	assert(v.p.val[j][i] == 67);
     }
   }
-  printf("v.zoom = %d\n", v.zoom);
   assert(v.scale == 4);
   return v.zoom;
 }


### PR DESCRIPTION
Block assignment of multi-dimensional fixed-length arrays was wrong in CTFE. It was only initializing the first dimension.

The wrong CTFE behaviour was actually coded into a test in test42.d.
It was clearly wrong because it behaved differently depending on where the
initialization was performed (it initialized all dimensions if declared in a CTFE function, but only initialized the first dimension if declared as a member of another struct). That test is fixed in this commit.
