### PR TITLE
Remove evil CTFE casts from the test suite

### DIFF
--- a/test/runnable/deprecate1.d
+++ b/test/runnable/deprecate1.d
@@ -479,14 +479,17 @@ void opover2_test2()
 // http://www.digitalmars.com/d/archives/10750.html
 // test12.d, test7(). ICE(constfold.c)
 
+version(none) // This contains an incredibly nasty cast
+{
 template base7( T )
 {
  void errfunc() { throw new Exception("no init"); }
- typedef T safeptr = cast(T)&errfunc;
+ typedef T safeptr = cast(T)&errfunc; // Nasty cast
 }
 
 alias int function(int) mfp;
 alias base7!(mfp) I_V_fp;
+}
 
 typedef bool antibool = 1;
 antibool[8] z21 = [ cast(antibool) 0, ];

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5168,9 +5168,11 @@ void test7150()
 /***************************************************/
 // 7159
 
+alias void delegate()  Void7159;
+
 class HomeController7159 {
-    void* foo() {
-        return cast(void*)&HomeController7159.displayDefault;
+    Void7159 foo() {
+        return cast(Void7159)&HomeController7159.displayDefault;
     }
     auto displayDefault() {
         return 1;


### PR DESCRIPTION
There are two tests in the test suite which are currently accepted by const folding (basically because const folding is rather cavalier in what it accepts) but which cause huge problems for CTFE:

(1) a cast from delegate to void*.
I fixed the test case to use a valid cast instead of this deprecated one.

(2) setting a default value of a typedef to be a cast from a void function() to int function(int).

This would inevitably cause a segfault at runtime if called. This seems like an unnecessary feature. Historically the compiler has not done much checking of compile-time values, presumably it's an accident that it was ever accepted.

To support this properly would require specific CTFE support, which isn't worth doing since typedef is deprecated anyway.  So just disable this test.
