### PR TITLE
Fix bug 10211: CTFE: Allow cast S**->D**, if S*->D* is OK

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -564,7 +564,14 @@ int isTrueBool(Expression *e)
  * destPointee may be void.
  */
 bool isSafePointerCast(Type *srcPointee, Type *destPointee)
-{   // It's OK if both are the same (modulo const)
+{
+    // It's safe to cast S** to D** if it's OK to cast S* to D*
+    while (srcPointee->ty == Tpointer && destPointee->ty == Tpointer)
+    {
+        srcPointee = srcPointee->nextOf();
+        destPointee = destPointee->nextOf();
+    }
+   // It's OK if both are the same (modulo const)
 #if DMDV2
     if (srcPointee->castMod(0) == destPointee->castMod(0))
         return true;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3419,6 +3419,23 @@ static assert(!is(typeof(compiles!(badpointer(7)))));
 static assert(!is(typeof(compiles!(badpointer(8)))));
 
 /**************************************************
+    10211 Allow casts S**->D**, when S*->D* is OK
+**************************************************/
+
+int bug10211()
+{
+    int m = 7;
+    int *x = &m;
+    int **y = &x;
+    assert(**y == 7);
+    uint *p = cast(uint *)x;
+    uint **q = cast(uint **)y;
+    return 1;
+}
+
+static assert(bug10211());
+
+/**************************************************
     9170 Allow reinterpret casts float<->int
 **************************************************/
 int f9170(float x) {


### PR DESCRIPTION
Another fix required by my project to unify CTFE and optimize(WANTinterpret).

Up to now this has been accepted in const-folding but not in CTFE.
