### PR TITLE
Refactor: pragma(msg) shouldn't always run CTFE.

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1003,8 +1003,8 @@ void PragmaDeclaration::semantic(Scope *sc)
 
                 e = e->ctfeSemantic(sc);
                 e = resolveProperties(sc, e);
-                if (e->op != TOKerror && e->op != TOKtype)
-                    e = e->ctfeInterpret();
+                // pragma(msg) is allowed to contain types as well as expressions
+                e = ctfeInterpretForPragmaMsg(e);
                 if (e->op == TOKerror)
                 {   errorSupplemental(loc, "while evaluating pragma(msg, %s)", (*args)[i]->toChars());
                     return;

--- a/src/expression.h
+++ b/src/expression.h
@@ -91,6 +91,11 @@ ArrayExp *resolveOpDollar(Scope *sc, ArrayExp *ae);
 SliceExp *resolveOpDollar(Scope *sc, SliceExp *se);
 Expressions *arrayExpressionSemantic(Expressions *exps, Scope *sc);
 
+/* Run CTFE on the expression, but allow the expression to be a TypeExp
+ * or a tuple containing a TypeExp. (This is required by pragma(msg)).
+ */
+Expression *ctfeInterpretForPragmaMsg(Expression *e);
+
 /* Interpreter: what form of return value expression is required?
  */
 enum CtfeGoal

--- a/src/statement.c
+++ b/src/statement.c
@@ -2816,8 +2816,8 @@ Statement *PragmaStatement::semantic(Scope *sc)
 
                 e = e->ctfeSemantic(sc);
                 e = resolveProperties(sc, e);
-                if (e->op != TOKerror && e->op != TOKtype)
-                    e = e->ctfeInterpret();
+                // pragma(msg) is allowed to contain types as well as expressions
+                e = ctfeInterpretForPragmaMsg(e);
                 if (e->op == TOKerror)
                 {   errorSupplemental(loc, "while evaluating pragma(msg, %s)", (*args)[i]->toChars());
                     goto Lerror;


### PR DESCRIPTION
This is part of my major project to unify optimize(WANTinterpret) and CTFE.
A crucial issue is to make sure that optimize(WANTinterpret) is called _only_ when a value is required.

pragma(msg) needs to be treated as a special case since it allows types and aliases, as well as expressions, but everything else should be CTFE'd. This commit gives it a special entry point, to prevent types and aliases from being sent to ctfeInterpret().
