### PR TITLE
Ctfe internal fixes

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5064,7 +5064,10 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
             ex = ((AddrExp *)ex)->e1;
         VarDeclaration *v = var->isVarDeclaration();
         if (!v)
+        {
             error("CTFE internal error: %s", toChars());
+            return EXP_CANT_INTERPRET;
+        }
         if (ex->op == TOKnull && ex->type->toBasetype()->ty == Tclass)
         {   error("class '%s' is null and cannot be dereferenced", e1->toChars());
             return EXP_CANT_INTERPRET;
@@ -5109,7 +5112,7 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
             if (!e)
             {
                 error("couldn't find field %s in %s", v->toChars(), type->toChars());
-                e = EXP_CANT_INTERPRET;
+                return EXP_CANT_INTERPRET;
             }
             // If it is an rvalue literal, return it...
             if (e->op == TOKstructliteral || e->op == TOKarrayliteral ||

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1682,7 +1682,8 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
             if (e && e != EXP_CANT_INTERPRET && e->op != TOKthrownexception)
             {
                 e = copyLiteral(e);
-                ctfeStack.saveGlobalConstant(v, e);
+                if (v->isDataseg() || (v->storage_class & STCmanifest ))
+                    ctfeStack.saveGlobalConstant(v, e);
             }
         }
         else if (v->isCTFE() && !v->hasValue())

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2293,6 +2293,11 @@ Expression *UnaExp::interpret(InterState *istate,  CtfeGoal goal)
 #if LOG
     printf("%s UnaExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
+    if (op == TOKdottype)
+    {
+        error("Internal Compiler Error: CTFE DotType: %s", toChars());
+        return EXP_CANT_INTERPRET;
+    }
     e1 = this->e1->interpret(istate);
     if (exceptionOrCantInterpret(e1))
         return e1;


### PR DESCRIPTION
This is part of my major project to unify optimize(WANTinterpret) and CTFE.

Fixes some bugs inside the code, which have no user-visible impact.
Two of the commits are to prevent segfaults when an ICE occurs. They make debugging easier.
The more important commit:
"CTFE: Don't save local variables in the global constants list"
fixes a simple logic bug.
