### PR TITLE
Never run CTFE on template alias parameters

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -4446,6 +4446,11 @@ MATCH TemplateValueParameter::matchArg(Scope *sc, Object *oarg,
             ei = ei->semantic(sc);
             if (!f->needThis())
                 ei = resolveProperties(sc, ei);
+            /* If it was really a property, it will become a CallExp.
+             * If it stayed as a var, it cannot be interpreted.
+             */
+            if (ei->op == TOKvar)
+                goto Lnomatch;
             ei = ei->ctfeInterpret();
         }
         else

--- a/src/template.c
+++ b/src/template.c
@@ -3344,19 +3344,29 @@ MATCH TypeInstance::deduceType(Scope *sc,
             {
             Le:
                 e1 = e1->ctfeInterpret();
+
+                /* If it is one of the template parameters for this template,
+                 * we should not attempt to interpret it. It already has a value.
+                 */
+                if (e2->op == TOKvar &&
+                    (((VarExp *)e2)->var->storage_class & STCtemplateparameter))
+                {
+                    /*
+                     * (T:Number!(e2), int e2)
+                     */
+                    j = templateIdentifierLookup(((VarExp *)e2)->var->ident, parameters);
+                    if (j != IDX_NOTFOUND)
+                        goto L1;
+                    // The template parameter was not from this template
+                    // (it may be from a parent template, for example)
+                }
+
                 e2 = e2->ctfeInterpret();
 
                 //printf("e1 = %s, type = %s %d\n", e1->toChars(), e1->type->toChars(), e1->type->ty);
                 //printf("e2 = %s, type = %s %d\n", e2->toChars(), e2->type->toChars(), e2->type->ty);
                 if (!e1->equals(e2))
-                {   if (e2->op == TOKvar)
-                    {
-                        /*
-                         * (T:Number!(e2), int e2)
-                         */
-                        j = templateIdentifierLookup(((VarExp *)e2)->var->ident, parameters);
-                        goto L1;
-                    }
+                {
                     if (!e2->implicitConvTo(e1->type))
                         goto Lnomatch;
 

--- a/src/template.c
+++ b/src/template.c
@@ -5474,6 +5474,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
             }
             else if (ea->op != TOKtuple &&
                      ea->op != TOKimport && ea->op != TOKtype &&
+                     ea->op != TOKtemplate &&
                      ea->op != TOKfunction && ea->op != TOKerror &&
                      ea->op != TOKthis && ea->op != TOKsuper)
             {


### PR DESCRIPTION
This is the most important pull request of my major project to unify optimize(WANTinterpret) and CTFE.
A crucial issue is to make sure that optimize(WANTinterpret) is called only when a value is required.

Up to now, optimize(WANTinterpret) has always been called, even for types, tuples, and aliases. If it can't interpret it, it just returns it unchanged.
This pull request identifies all the situations where a template parameter might be a alias or a type, and doesn't try to interpret it in that case. Only when it KNOWS that it needs a value, should it invoke CTFE.

Apart from the benefit for CTFE, this change also makes template,c much easier to understand. It means that optimize(WANTinterpret) no longer plays a role in determining if a template parameter is an alias, or not. I don't think anybody understood exactly what it was doing, before. It certainly took me a long time to figure it out.
