### PR TITLE
[trivial] size_t/int format specifier mismatch

### DIFF
--- a/src/traits.c
+++ b/src/traits.c
@@ -670,7 +670,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     return NULL;
 
 Ldimerror:
-    error("wrong number of arguments %d", dim);
+    error("wrong number of arguments %d", (int)dim);
     goto Lfalse;
 
 


### PR DESCRIPTION
Stumbled on this while looking at the DMD/LDC diff.

Just inserting a cast seems to be the cleanest option due to the messy affair that C99 format specifiers are w.r.t. platform portability, and is what is done elsewhere too.
