### PR TITLE
Make CTFE error messages same as for const-folding

### DIFF
--- a/src/optimize.c
+++ b/src/optimize.c
@@ -172,7 +172,10 @@ Expression *fromConstInitializer(int result, Expression *e1)
             if (v && (result & WANTinterpret) &&
                 !(v->storage_class & STCtemplateparameter))
             {
-                e1->error("variable %s cannot be read at compile time", v->toChars());
+                if (!v->isCTFE() && v->isDataseg())
+                    e1->error("static variable %s cannot be read at compile time", v->toChars());
+                else
+                    e1->error("variable %s cannot be read at compile time", v->toChars());
                 e = e->copy();
                 e->type = Type::terror;
             }

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -57,6 +57,8 @@ void StaticAssert::semantic2(Scope *sc)
     sc->flags |= SCOPEstaticassert;
     Expression *e = exp->ctfeSemantic(sc);
     e = resolveProperties(sc, e);
+    // Simplify expression, to make error messages nicer if CTFE fails
+    e = e->optimize(0);
     sc = sc->pop();
     if (!e->type->checkBoolean())
     {

--- a/test/fail_compilation/diag7420.d
+++ b/test/fail_compilation/diag7420.d
@@ -2,15 +2,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7420.d(3): Error: variable x cannot be read at compile time
+fail_compilation/diag7420.d(3): Error: static variable x cannot be read at compile time
 fail_compilation/diag7420.d(3):        while evaluating: static assert(x < 4)
-fail_compilation/diag7420.d(4): Error: variable y cannot be read at compile time
+fail_compilation/diag7420.d(4): Error: static variable y cannot be read at compile time
 fail_compilation/diag7420.d(4):        while evaluating: static assert(y == "abc")
-fail_compilation/diag7420.d(5): Error: variable y cannot be read at compile time
+fail_compilation/diag7420.d(5): Error: static variable y cannot be read at compile time
 fail_compilation/diag7420.d(5):        while evaluating: static assert(cast(ubyte[])y != null)
-fail_compilation/diag7420.d(6): Error: variable y cannot be read at compile time
+fail_compilation/diag7420.d(6): Error: static variable y cannot be read at compile time
 fail_compilation/diag7420.d(6):        while evaluating: static assert(cast(int)y[0u] == 1)
-fail_compilation/diag7420.d(7): Error: variable y cannot be read at compile time
+fail_compilation/diag7420.d(7): Error: static variable y cannot be read at compile time
 fail_compilation/diag7420.d(7):        while evaluating: static assert(y[0u..1u].length == 1u)
 ---
 */


### PR DESCRIPTION
Two more commits from my project to unify optimize(WANTinterpret) and CTFE.
(1) Currently static assert uses optimize(WANTinterpret) for const folding. This has the side-effect of simplifying the expression before evaluating it, which makes error messages nicer. If we simply change to using CTFE instead, the error messages won't get simplified. So insert a call to optimize(0) before running CTFE.

(2) The error message for an attempt to read a runtime variable from optimize(WANTinterpret) is less informative than the CTFE one.
Improve the optimize() version, so that the test suite is ready for the change to using CTFE throughout.
