### PR TITLE
Fix issue 10236 Ddoc: Warning on wrong parameter names/count

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -1570,7 +1570,7 @@ void ParamSection::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
     buf->writestring(")\n");
 
     TypeFunction *tf = isTypeFunction(s);
-    if (tf && tf->parameters)
+    if (tf)
     {
         if ((tf->parameters && tf->parameters->dim != paramcount) ||
             (!tf->parameters && paramcount))
@@ -1988,12 +1988,12 @@ Parameter *isFunctionParameter(Dsymbol *s, utf8_t *p, size_t len)
     if (tf && tf->parameters)
     {
         for (size_t k = 0; k < tf->parameters->dim; k++)
-        {   Parameter *arg = (*tf->parameters)[k];
-
-	    if (arg->ident && cmp(arg->ident->toChars(), p, len) == 0)
+        {
+            Parameter *arg = (*tf->parameters)[k];
+            if (arg->ident && cmp(arg->ident->toChars(), p, len) == 0)
             {
                 return arg;
-	    }
+            }
         }
     }
     return NULL;

--- a/test/compilable/ddoc10236.d
+++ b/test/compilable/ddoc10236.d
@@ -1,0 +1,59 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -w -o-
+
+/*
+TEST_OUTPUT:
+---
+compilable/ddoc10236.d(33): Warning: Ddoc: parameter count mismatch
+compilable/ddoc10236.d(45): Warning: Ddoc: function declaration has no parameter 'y'
+compilable/ddoc10236.d(57): Warning: Ddoc: function declaration has no parameter 'y'
+compilable/ddoc10236.d(57): Warning: Ddoc: parameter count mismatch
+---
+*/
+
+/***********************************
+ * foo_good does this.
+ * Params:
+ *	x =	is for this
+ *		and not for that
+ *	y =	is for that
+ */
+
+void foo_good(int x, int y)
+{
+}
+
+/***********************************
+ * foo_count_mismatch does this.
+ * Params:
+ *	x =	is for this
+ *		and not for that
+ */
+
+void foo_count_mismatch(int x, int y)	// Warning: Ddoc: parameter count mismatch
+{
+}
+
+/***********************************
+ * foo_no_param_y does this.
+ * Params:
+ *	x =	is for this
+ *		and not for that
+ *	y =	is for that
+ */
+
+void foo_no_param_y(int x, int z)		// Warning: Ddoc: function declaration has no parameter 'y'
+{
+}
+
+/***********************************
+ * foo_count_mismatch_no_param_y does this.
+ * Params:
+ *	x =	is for this
+ *		and not for that
+ *	y =	is for that
+ */
+
+void foo_count_mismatch_no_param_y(int x)
+{
+}

--- a/test/compilable/ddoc10236b.d
+++ b/test/compilable/ddoc10236b.d
@@ -1,0 +1,69 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -w -o-
+
+/*
+TEST_OUTPUT:
+---
+compilable/ddoc10236b.d(43): Warning: Ddoc: parameter count mismatch
+compilable/ddoc10236b.d(55): Warning: Ddoc: function declaration has no parameter 'y'
+compilable/ddoc10236b.d(67): Warning: Ddoc: function declaration has no parameter 'y'
+compilable/ddoc10236b.d(67): Warning: Ddoc: parameter count mismatch
+---
+*/
+
+/***********************************
+ * foo_good does this.
+ * Params:
+ *	x =	is for this
+ *		and not for that
+ *	y =	is for that
+ */
+
+void foo_good(int x)(int y)
+{
+}
+
+/***********************************
+ * foo_good2 does this.
+ * Params:
+ *	y =	is for that
+ */
+
+void foo_good2(int x)(int y)
+{
+}
+
+/***********************************
+ * foo_count_mismatch does this.
+ * Params:
+ *	x =	is for this
+ *		and not for that
+ */
+
+void foo_count_mismatch(int x)(int y)	// Warning: Ddoc: parameter count mismatch
+{
+}
+
+/***********************************
+ * foo_no_param_y does this.
+ * Params:
+ *	x =	is for this
+ *		and not for that
+ *	y =	is for that
+ */
+
+void foo_no_param_y(int x)(int z)		// Warning: Ddoc: function declaration has no parameter 'y'
+{
+}
+
+/***********************************
+ * foo_count_mismatch_no_param_y does this.
+ * Params:
+ *	x =	is for this
+ *		and not for that
+ *	y =	is for that
+ */
+
+void foo_count_mismatch_no_param_y(int x)()
+{
+}


### PR DESCRIPTION
Fix issue 10236 Ddoc: Warning on wrong parameter names/count
- issue a warning if the parameter cannot be found in the [template] function declaration.
- issue a warning if the parameter count in the Ddoc differs from the declaration
