### PR TITLE
Add front-end support for 64bit X32 target. 

### DIFF
--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -154,14 +154,6 @@ TypeTuple *TypeSArray::toArgTypes()
 #endif
 }
 
-TypeTuple *TypeDArray::toArgTypes()
-{
-    /* Should be done as if it were:
-     * struct S { size_t length; void* ptr; }
-     */
-    return new TypeTuple(Type::tsize_t, Type::tvoidptr);
-}
-
 TypeTuple *TypeAArray::toArgTypes()
 {
     return new TypeTuple(Type::tvoidptr);
@@ -170,14 +162,6 @@ TypeTuple *TypeAArray::toArgTypes()
 TypeTuple *TypePointer::toArgTypes()
 {
     return new TypeTuple(Type::tvoidptr);
-}
-
-TypeTuple *TypeDelegate::toArgTypes()
-{
-    /* Should be done as if it were:
-     * struct S { void* ptr; void* funcptr; }
-     */
-    return new TypeTuple(Type::tvoidptr, Type::tvoidptr);
 }
 
 /*************************************
@@ -271,6 +255,38 @@ Type *argtypemerge(Type *t1, Type *t2, unsigned offset2)
         }
     }
     return t;
+}
+
+TypeTuple *TypeDArray::toArgTypes()
+{
+    /* Should be done as if it were:
+     * struct S { size_t length; void* ptr; }
+     */
+    if (global.params.is64bit && !global.params.isLP64)
+    {
+        // For AMD64 ILP32 ABI, D arrays fit into a single integer register.
+        unsigned offset = Type::tsize_t->size(Loc());
+        Type *t = argtypemerge(Type::tsize_t, Type::tvoidptr, offset);
+        if (t)
+            return new TypeTuple(t);
+    }
+    return new TypeTuple(Type::tsize_t, Type::tvoidptr);
+}
+
+TypeTuple *TypeDelegate::toArgTypes()
+{
+    /* Should be done as if it were:
+     * struct S { size_t length; void* ptr; }
+     */
+    if (global.params.is64bit && !global.params.isLP64)
+    {
+        // For AMD64 ILP32 ABI, delegates fit into a single integer register.
+        unsigned offset = Type::tsize_t->size(Loc());
+        Type *t = argtypemerge(Type::tsize_t, Type::tvoidptr, offset);
+        if (t)
+            return new TypeTuple(t);
+    }
+    return new TypeTuple(Type::tvoidptr, Type::tvoidptr);
 }
 
 TypeTuple *TypeStruct::toArgTypes()

--- a/src/target.c
+++ b/src/target.c
@@ -123,7 +123,10 @@ unsigned Target::critsecsize()
     else if (global.params.isLinux)
     {
         // sizeof(pthread_mutex_t) for Linux.
-        return global.params.isLP64 ? 40 : 24;
+        if (global.params.is64bit)
+            return global.params.isLP64 ? 40 : 32;
+        else
+            return global.params.isLP64 ? 40 : 24;
     }
     else if (global.params.isFreeBSD)
     {

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -549,9 +549,13 @@ string toString26(cdouble z)
 void test26()
 {
   static cdouble[] A = [1+0i, 0+1i, 1+1i];
+  string s;
 
   foreach( cdouble z; A )
-    printf("%.*s  ",toString26(z));
+  {
+    s = toString26(z);
+    printf("%.*s  ", s.length, s.ptr);
+  }
   printf("\n");
 
   for(int ii=0; ii<A.length; ii++ )
@@ -562,7 +566,10 @@ void test26()
   assert(A[2] == 2);
 
   foreach( cdouble z; A )
-    printf("%.*s  ",toString26(z));
+  {
+    s = toString26(z);
+    printf("%.*s  ", s.length, s.ptr);
+  }
   printf("\n");
 }
 

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4138,36 +4138,27 @@ void bug3809b() {
 /***************************************************/
 //
 
-version (X86_64)
+void bug6184()
 {
-    void bug6184()
+    bool cmp(ref int[3] a, ref int[3] b)
     {
-        bool cmp(ref int[3] a, ref int[3] b)
-        {
-            return a is b;
-        }
-
-        static struct Ary
-        {
-            int[3] ary;
-        }
-
-        auto a = new Ary;
-        auto b = new Ary;
-        assert(!cmp(a.ary, b.ary));
-        b = a;
-        assert(cmp(a.ary, b.ary));
-
-        // change high bit of ary address
-        *(cast(size_t*)&b) ^= (1UL << 32);
-        assert(!cmp(a.ary, b.ary));
+        return a is b;
     }
-}
-else
-{
-    void bug6184()
+
+    static struct Ary
     {
+        int[3] ary;
     }
+
+    auto a = new Ary;
+    auto b = new Ary;
+    assert(!cmp(a.ary, b.ary));
+    b = a;
+    assert(cmp(a.ary, b.ary));
+
+    // change high bit of ary address
+    *(cast(size_t*)&b) ^= (1UL << (size_t.sizeof * 4));
+    assert(!cmp(a.ary, b.ary));
 }
 
 /***************************************************/


### PR DESCRIPTION
Alright, so this the work I've done to add X32 support into the D front-end.  Thankfully it has been very minimal work.

Summary:
- src/argtypes.c
  Pass D arrays and delegates correctly. Without this, an assertion is triggered in argtypemerge because it does not handle the case where array.sizeof or dg.sizeof is equal to 8 bytes on 64bit.  Required for gdc -mx32 (eg: Ubuntu raring supports this out of the box).
- src/target.c
  As per druntime fix (https://github.com/D-Programming-Language/druntime/pull/513) update the critsecsize hook to match.
- test/runnable/test22.d
  As from the fix in src/argtypes.c, we need to make sure that any `printf("%.*s")` are passed the length and ptr of D arrays as separate arguments.
-  test/runnable/test42.d
  Remove the X86_64 versioning, set the correct high bit depending on size_t.sizeof.

See also (https://github.com/D-Programming-Language/dmd/pull/2058) which allows the front-end to semantically handle the differences between X86_64 and X32,  and (https://github.com/D-Programming-Language/druntime/pull/514) for other runtime-related fixes.

@Walter - can you check this is fine?

Thanks
