### PR TITLE
10251 CTFE returning pointers to global statics of known value

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1547,12 +1547,6 @@ Expression *SymOffExp::interpret(InterState *istate, CtfeGoal goal)
     if ( var->isDataseg() && (
          (offset == 0 && isSafePointerCast(var->type, pointee)) ||
          (fromType && isSafePointerCast(fromType, pointee))
-        ) && !(vd && vd->init &&
-#if DMDV2
-        (var->isConst() || var->isImmutable())
-#else
-        var>isConst()
-#endif
         ))
     {
         return this;

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2410,6 +2410,19 @@ bool test9745b()
 }
 static assert(test9745b());
 
+/**************************************************
+    10251 Pointers to const globals
+**************************************************/
+
+static const int glob10251 = 7;
+
+const (int) * bug10251()
+{
+   return &glob10251;
+}
+
+static a10251 = &glob10251; //  OK
+static b10251 = bug10251();
 
 /**************************************************
     4065 [CTFE] AA "in" operator doesn't work


### PR DESCRIPTION
This is part of my project to unify optimize(WANTinterpret) and CTFE.
It's something which worked in constfolding but not CTFE.

Don't expand pointers to global variables.
They should stay as a SymOffExp, even if their value is known.
