### PR TITLE
10252 CTFE: Generate error for shr/ushr/shl out of range

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2421,6 +2421,15 @@ Expression *BinExp::interpretCommon(InterState *istate, CtfeGoal goal, fp_t fp)
     if (e2->isConst() != 1)
         goto Lcant;
 
+    if (op == TOKshr || op == TOKshl || op == TOKushr)
+    {
+        sinteger_t i2 = e2->toInteger();
+        d_uns64 sz = e1->type->size() * 8;
+        if (i2 < 0 || i2 >= sz)
+        {   error("shift by %lld is outside the range 0..%llu", i2, (ulonglong)sz - 1);
+            return EXP_CANT_INTERPRET;
+        }
+    }
     e = (*fp)(type, e1, e2);
     if (e == EXP_CANT_INTERPRET)
         error("%s cannot be interpreted at compile time", toChars());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -304,6 +304,35 @@ bool bug4837()
 static assert(bug4837());
 
 /**************************************************
+  10252 shift out of range
+**************************************************/
+int lshr10252(int shift)
+{
+     int a = 5;
+     return a << shift;
+}
+
+int rshr10252(int shift)
+{
+     int a = 5;
+     return a >> shift;
+}
+
+int ushr10252(int shift)
+{
+     int a = 5;
+     return a >>> shift;
+}
+
+static assert(is(typeof(compiles!(lshr10252(4)))));
+static assert(!is(typeof(compiles!(lshr10252(60)))));
+static assert(is(typeof(compiles!(rshr10252(4)))));
+static assert(!is(typeof(compiles!(rshr10252(80)))));
+static assert(is(typeof(compiles!(ushr10252(2)))));
+static assert(!is(typeof(compiles!(ushr10252(60)))));
+
+
+/**************************************************
   'this' parameter bug revealed during refactoring
 **************************************************/
 int thisbug1(int x) { return x; }


### PR DESCRIPTION
Part of the unification of optimize(WANTinterpret) and CTFE.

Use same behaviour as for const-folding.
