### PR TITLE
CTFE: Allow creation (but not reading) of unions and __vectors

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2353,6 +2353,7 @@ Expression *UnaExp::interpret(InterState *istate,  CtfeGoal goal)
     case TOKtilde:  e = Com(type, e1); break;
     case TOKnot:    e = Not(type, e1); break;
     case TOKtobool: e = Bool(type, e1); break;
+    case TOKvector: e = this; break; // do nothing
     default: assert(0);
     }
     return e;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2167,12 +2167,6 @@ Expression *StructLiteralExp::interpret(InterState *istate, CtfeGoal goal)
 #if LOG
     printf("%s StructLiteralExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
-    /* We don't know how to deal with overlapping fields
-     */
-    if (sd->hasUnions)
-    {   error("Unions with overlapping fields are not yet supported in CTFE");
-        return EXP_CANT_INTERPRET;
-    }
     if (ownedByCtfe)
         return copyLiteral(this);
 
@@ -5132,6 +5126,12 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
         if (ex->op == TOKstructliteral || ex->op == TOKclassreference)
         {
             StructLiteralExp *se = ex->op == TOKclassreference ? ((ClassReferenceExp *)ex)->value : (StructLiteralExp *)ex;
+            /* We don't know how to deal with overlapping fields
+             */
+            if (se->sd->hasUnions)
+            {   error("Unions with overlapping fields are not yet supported in CTFE");
+                return EXP_CANT_INTERPRET;
+            }
             // We can't use getField, because it makes a copy
             int i = -1;
             if (ex->op == TOKclassreference)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4952,6 +4952,23 @@ int bug9113(T)()
 
 static assert( !is( typeof( compiles!(bug9113!(int)())) ) );
 
+/**************************************************
+    Creation of unions
+**************************************************/
+
+union UnionTest1
+{
+    int x;
+    float y;
+}
+
+int uniontest1()
+{
+    UnionTest1 u = UnionTest1(1);
+    return 1;
+}
+
+static assert(uniontest1());
 
 /**************************************************
     6438 void


### PR DESCRIPTION
Part of my project to unify const folding and CTFE.

Allow the no-op cases for unions and __vector which are supported by optimize(WANTinterpret) but not be CTFE,
They just pass the literal through, unaltered.
