### PR TITLE
Issue 1983 - Delegates violate const

### DIFF
--- a/src/dcast.d
+++ b/src/dcast.d
@@ -140,6 +140,34 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
                 semanticTypeInfo(sc, (cast(TypeDArray)tb).next);
         }
 
+        override void visit(SymOffExp e)
+        {
+            visit(cast(Expression)e);
+            if (!e.hasOverloads)
+                return;
+
+            if (result.op == TOKsymoff)
+            {
+                auto se = cast(SymOffExp)result;
+                if (!se.hasOverloads)
+                    se.checkDeprecated(sc, se.var);
+            }
+        }
+
+        override void visit(DelegateExp e)
+        {
+            visit(cast(Expression)e);
+            if (!e.hasOverloads)
+                return;
+
+            if (result.op == TOKdelegate)
+            {
+                auto de = cast(DelegateExp)result;
+                if (!de.hasOverloads)
+                    de.checkDeprecated(sc, de.func);
+            }
+        }
+
         override void visit(SliceExp e)
         {
             visit(cast(Expression)e);

--- a/src/dcast.d
+++ b/src/dcast.d
@@ -2116,12 +2116,12 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
 
             // Look for pointers to functions where the functions are overloaded.
-            if (e.hasOverloads &&
-                typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
+            if (typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
                 (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
             {
-                FuncDeclaration f = e.var.isFuncDeclaration();
-                f = f ? f.overloadExactMatch(tb.nextOf()) : null;
+                auto f = e.var.isFuncDeclaration();
+                if (f && e.hasOverloads)
+                    f = f.overloadExactMatch(tb.nextOf());
                 if (f)
                 {
                     if (tb.ty == Tdelegate)

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1076,6 +1076,13 @@ public:
             type = _init.toExpression().type;
             if (needctfe)
                 sc = sc.endCTFE();
+
+            if (type.isAmbiguous())
+            {
+                type = Type.terror;
+                return;
+            }
+
             inuse--;
             inferred = 1;
             /* This is a kludge to support the existing syntax for RAII

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -638,6 +638,13 @@ public:
                         error("cannot alias an expression %s", e.toChars());
                     t = Type.terror;
                 }
+                else if (e.op == TOKvar)
+                {
+                    auto ve = cast(VarExp)e;
+                    auto f = s.isFuncDeclaration();
+                    if (!ve.hasOverloads && f && !f.isFuncAliasDeclaration())
+                        s = new FuncAliasDeclaration(ident, f, false);
+                }
             }
             type = t;
         }

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -593,6 +593,7 @@ public:
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
     bool functionSemantic();
+    bool functionSemantic(Loc loc);
     bool functionSemantic3();
     // called from semantic3
     VarDeclaration *declareThis(Scope *sc, AggregateDeclaration *ad);

--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -835,14 +835,17 @@ extern (C++) const(char)* mangle(Dsymbol s)
  */
 extern (C++) const(char)* mangleExact(FuncDeclaration fd)
 {
-    if (!fd.mangleString)
+    const(char)* s = fd.mangleString;
+    if (!s)
     {
         OutBuffer buf;
         scope Mangler v = new Mangler(&buf);
         v.mangleExact(fd);
-        fd.mangleString = buf.extractString();
+        s = buf.extractString();
+        if (!fd.flags)
+            fd.mangleString = s;
     }
-    return fd.mangleString;
+    return s;
 }
 
 extern (C++) void mangleToBuffer(Type t, OutBuffer* buf)

--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -197,6 +197,12 @@ public:
 
     override void visit(TypeFunction t)
     {
+        if (t.isAmbiguous())
+        {
+            buf.writestring("_ambiguous_");
+            return;
+        }
+
         //printf("TypeFunction.toDecoBuffer() t = %p %s\n", t, t.toChars());
         //static int nest; if (++nest == 50) *(char*)0=0;
         mangleFuncType(t, t, t.mod, t.next);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3423,6 +3423,14 @@ elem *toElem(Expression *e, IRState *irs)
             int directcall = 0;
             //printf("DelegateExp::toElem() '%s'\n", de->toChars());
 
+            if (de->hasOverloads)
+            {
+                assert(de->type->ty == Tdelegate);
+                de->func = de->func->overloadExactMatch(de->type->nextOf());
+            }
+            else
+                de->func = de->func->toAliasFunc();
+
             if (de->func->semanticRun == PASSsemantic3done)
             {
                 // Bug 7745 - only include the function if it belongs to this module

--- a/src/expression.d
+++ b/src/expression.d
@@ -8995,7 +8995,10 @@ public:
                 if (f)                      // better or exact match
                     fd = f;
                 if (!hasOverloads)          // exact match
+                {
                     var = f;
+                    checkDeprecated(sc, f);
+                }
             }
             if (!fd.functionSemantic(loc))
                 return new ErrorExp();
@@ -9413,7 +9416,10 @@ public:
             if (f)                      // better or exact match
                 fd = f;
             if (!hasOverloads)          // exact match
+            {
                 func = f;
+                checkDeprecated(sc, f);
+            }
         }
         else
         {
@@ -10703,7 +10709,10 @@ public:
                     ve.hasOverloads = hasOverloads2;
                     e1 = ve;
                     if (!hasOverloads2)         // exact match
+                    {
                         ve.var = f;
+                        checkDeprecated(sc, f);
+                    }
                     type = e1.type.pointerTo();
                 }
             }

--- a/src/func.d
+++ b/src/func.d
@@ -2406,8 +2406,21 @@ public:
      */
     final bool functionSemantic()
     {
+        return functionSemantic(loc);
+    }
+    final bool functionSemantic(Loc loc)
+    {
         if (!_scope)
+        {
+            // Keep diagnostic for: fail_compilation/fail113.d,
+            // fail114.d, fail126.d, fail139.d, and fail333.d
+            if (!type.deco)
+            {
+                .error(loc, "forward reference to '%s'", toChars());
+                errors = true;
+            }
             return !errors;
+        }
 
         if (!originalType) // semantic not yet run
         {
@@ -2491,7 +2504,7 @@ public:
      */
     final bool checkForwardRef(Loc loc)
     {
-        if (!functionSemantic())
+        if (!functionSemantic(loc))
             return true;
 
         /* No deco means the functionSemantic() call could not resolve
@@ -2817,31 +2830,39 @@ public:
      * 1. If the 'tthis' matches only one candidate, it's an "exact match".
      *    Returns the function and 'hasOverloads' is set to false.
      *      eg. If 'tthis" is mutable and there's only one mutable method.
-     * 2. If there's two or more match candidates, but a candidate function will be
+     * 2. If there's two or more match candidates, but a candidate function can be
      *    a "better match".
      *    Returns the better match function but 'hasOverloads' is set to true.
      *      eg. If 'tthis' is mutable, and there's both mutable and const methods,
      *          the mutable method will be a better match.
-     * 3. If there's two or more match candidates, but there's no better match,
+     * 3. If there's two or more match candidates, but there's no better match.
      *    Returns null and 'hasOverloads' is set to true to represent "ambiguous match".
      *      eg. If 'tthis' is mutable, and there's two or more mutable methods.
-     * 4. If there's no candidates, it's "no match" and returns null with error report.
+     * 4. If there's no candidates, it's "no match".
+     *    Returns null and 'hasOverloads' is set to false, with error report.
      *      e.g. If 'tthis' is const but there's no const methods.
+     *
+     * If one or more TemplateDeclaration is in the list, it's always ambiguous match.
      */
     final FuncDeclaration overloadModMatch(Loc loc, Type tthis, ref bool hasOverloads)
     {
         //printf("FuncDeclaration::overloadModMatch('%s')\n", toChars());
+        //if (tthis) printf("\ttthis = %s\n", tthis.toChars());
+
         Match m;
         m.last = MATCHnomatch;
-        overloadApply(this, (Dsymbol s)
+        auto r = overloadApply(this, (Dsymbol s)
         {
+            if (s.isTemplateDeclaration())
+                return 1;
+
             auto f = s.isFuncDeclaration();
             if (!f || f == m.lastf) // skip duplicates
                 return 0;
             m.anyf = f;
 
             auto tf = cast(TypeFunction)f.type;
-            //printf("tf = %s\n", tf->toChars());
+            //printf("tf = %s\n", tf.toChars());
 
             MATCH match;
             if (tthis) // non-static functions are preferred than static ones
@@ -2876,7 +2897,6 @@ public:
 
         LlastIsBetter:
             //printf("\tlastbetter\n");
-            m.count++; // count up
             return 0;
 
         LcurrIsBetter:
@@ -2893,17 +2913,27 @@ public:
             return 0;
         });
 
+        if (r) // ambiguous match
+        {
+            hasOverloads = true;
+            return null;
+        }
+
         if (m.count == 1)       // exact match
         {
             hasOverloads = false;
+            //printf("\tcount == 1, lastf = %s\n", m.lastf.type.toChars());
         }
         else if (m.count > 1)   // better or ambiguous match
         {
             hasOverloads = true;
+            if (m.nextf)        // ambiguous match
+                m.lastf = null;
+            //printf("\tcount > 1, lastf = %s\n", m.lastf ? m.lastf.type.toChars() : null);
         }
         else                    // no match
         {
-            hasOverloads = true;
+            hasOverloads = false;
             auto tf = cast(TypeFunction)this.type;
             assert(tthis);
             assert(!MODimplicitConv(tthis.mod, tf.mod)); // modifier mismatch
@@ -4224,7 +4254,7 @@ extern (C++) int overloadApply(Dsymbol fstart, void* param, int function(void*, 
     return overloadApply(fstart, s => (*fp)(param, s));
 }
 
-extern (C++) static void MODMatchToBuffer(OutBuffer* buf, ubyte lhsMod, ubyte rhsMod)
+extern (C++) void MODMatchToBuffer(OutBuffer* buf, ubyte lhsMod, ubyte rhsMod)
 {
     bool bothMutable = ((lhsMod & rhsMod) == 0);
     bool sharedMismatch = ((lhsMod ^ rhsMod) & MODshared) != 0;
@@ -4296,7 +4326,7 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
         if (m.count == 1) // exactly one match
         {
             if (!(flags & 1))
-                m.lastf.functionSemantic();
+                m.lastf.functionSemantic(loc);
             return m.lastf;
         }
         if ((flags & 2) && !tthis && m.lastf.needThis())

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -787,6 +787,12 @@ public:
 
     override void visit(TypeFunction t)
     {
+        if (t.isAmbiguous())
+        {
+            buf.writestring("_ambiguous_");
+            return;
+        }
+
         //printf("TypeFunction::toCBuffer2() t = %p, ref = %d\n", t, t->isref);
         visitFuncIdentWithPostfix(t, null);
     }
@@ -908,6 +914,12 @@ public:
 
     override void visit(TypeDelegate t)
     {
+        if (t.isAmbiguous())
+        {
+            buf.writestring("_ambiguous_");
+            return;
+        }
+
         visitFuncIdentWithPostfix(cast(TypeFunction)t.next, "delegate");
     }
 
@@ -3171,6 +3183,12 @@ extern (C++) const(char)* protectionToChars(PROTKIND kind)
 // Print the full function signature with correct ident, attributes and template args
 extern (C++) void functionToBufferFull(TypeFunction tf, OutBuffer* buf, Identifier ident, HdrGenState* hgs, TemplateDeclaration td)
 {
+    if (tf.isAmbiguous())
+    {
+        buf.writestring("_ambiguous_");
+        return;
+    }
+
     //printf("TypeFunction::toCBuffer() this = %p\n", this);
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
     v.visitFuncIdentWithPrefix(tf, ident, td, true);

--- a/src/init.d
+++ b/src/init.d
@@ -776,8 +776,8 @@ public:
         exp = resolveProperties(sc, exp);
         if (exp.op == TOKscope)
         {
-            ScopeExp se = cast(ScopeExp)exp;
-            TemplateInstance ti = se.sds.isTemplateInstance();
+            auto se = cast(ScopeExp)exp;
+            auto ti = se.sds.isTemplateInstance();
             if (ti && ti.semanticRun == PASSsemantic && !ti.aliasdecl)
                 se.error("cannot infer type from %s %s, possible circular dependency", se.sds.kind(), se.toChars());
             else
@@ -791,7 +791,7 @@ public:
         {
             if (f.checkForwardRef(loc))
                 return new ErrorInitializer();
-            if (hasOverloads && !f.isUnique())
+            if (exp.type.isAmbiguous())
             {
                 exp.error("cannot infer type from overloaded function symbol %s", exp.toChars());
                 return new ErrorInitializer();
@@ -799,7 +799,7 @@ public:
         }
         if (exp.op == TOKaddress)
         {
-            AddrExp ae = cast(AddrExp)exp;
+            auto ae = cast(AddrExp)exp;
             if (ae.e1.op == TOKoverloadset)
             {
                 exp.error("cannot infer type from overloaded function symbol %s", exp.toChars());

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -530,6 +530,7 @@ public:
     extern (C++) static __gshared Type twstring;    // immutable(wchar)[]
     extern (C++) static __gshared Type tdstring;    // immutable(dchar)[]
     extern (C++) static __gshared Type tvalist;     // va_list alias
+    extern (C++) static __gshared Type tambig;
     extern (C++) static __gshared Type terror;      // for error recovery
     extern (C++) static __gshared Type tnull;       // for null type
 
@@ -897,6 +898,9 @@ public:
         twstring = twchar.immutableOf().arrayOf();
         tdstring = tdchar.immutableOf().arrayOf();
         tvalist = Target.va_listType();
+        tambig = new TypeFunction(null, null, 0, LINKd);
+        tambig.deco = cast(char*)"@".ptr;
+
         if (global.params.isLP64)
         {
             Tsize_t = Tuns64;
@@ -947,7 +951,8 @@ public:
         Type t = semantic(loc, sc);
         if (global.endGagging(errors) || t.ty == Terror) // if any errors happened
         {
-            t = null;
+            if (!t.isAmbiguous())
+                t = null;
         }
         //printf("-trySemantic(%s) %d\n", toChars(), global.errors);
         return t;
@@ -1119,6 +1124,11 @@ public:
     bool isAssignable()
     {
         return true;
+    }
+
+    bool isAmbiguous()
+    {
+        return false;
     }
 
     /**************************
@@ -2216,9 +2226,13 @@ public:
      */
     MATCH implicitConvTo(Type to)
     {
+        if (isAmbiguous())
+            return MATCHnomatch;
+
         //printf("Type::implicitConvTo(this=%p, to=%p)\n", this, to);
         //printf("from: %s\n", toChars());
         //printf("to  : %s\n", to->toChars());
+
         if (this.equals(to))
             return MATCHexact;
         return MATCHnomatch;
@@ -2992,6 +3006,11 @@ public:
     {
         super(ty);
         this.next = next;
+    }
+
+    override bool isAmbiguous()
+    {
+        return next && next.isAmbiguous();
     }
 
     override final void checkDeprecated(Loc loc, Scope* sc)
@@ -4745,7 +4764,11 @@ public:
 
     override MATCH implicitConvTo(Type to)
     {
+        if (isAmbiguous())
+            return MATCHnomatch;
+
         //printf("TypeSArray::implicitConvTo(to = %s) this = %s\n", to->toChars(), toChars());
+
         if (to.ty == Tarray)
         {
             TypeDArray ta = cast(TypeDArray)to;
@@ -5021,6 +5044,9 @@ public:
 
     override MATCH implicitConvTo(Type to)
     {
+        if (isAmbiguous())
+            return MATCHnomatch;
+
         //printf("TypeDArray::implicitConvTo(to = %s) this = %s\n", to->toChars(), toChars());
         if (equals(to))
             return MATCHexact;
@@ -5386,6 +5412,9 @@ public:
 
     override MATCH implicitConvTo(Type to)
     {
+        if (isAmbiguous())
+            return MATCHnomatch;
+
         //printf("TypeAArray::implicitConvTo(to = %s) this = %s\n", to->toChars(), toChars());
         if (equals(to))
             return MATCHexact;
@@ -5501,6 +5530,9 @@ public:
 
     override MATCH implicitConvTo(Type to)
     {
+        if (isAmbiguous())
+            return MATCHnomatch;
+
         //printf("TypePointer::implicitConvTo(to = %s) %s\n", to->toChars(), toChars());
         if (equals(to))
             return MATCHexact;
@@ -5803,6 +5835,11 @@ public:
         t.trust = trust;
         t.fargs = fargs;
         return t;
+    }
+
+    override bool isAmbiguous()
+    {
+        return this == tambig || TypeNext.isAmbiguous();
     }
 
     override Type semantic(Loc loc, Scope* sc)
@@ -6722,6 +6759,9 @@ public:
 
     override MATCH implicitConvTo(Type to)
     {
+        if (isAmbiguous())
+            return MATCHnomatch;
+
         //printf("TypeDelegate::implicitConvTo(this=%p, to=%p)\n", this, to);
         //printf("from: %s\n", toChars());
         //printf("to  : %s\n", to->toChars());
@@ -7569,6 +7609,14 @@ public:
         {
             error(loc, "expression (%s) has no type", exp.toChars());
             goto Lerr;
+        }
+        if (t.isAmbiguous())
+        {
+            //printf("typeof exp = %s -> t = %s\n", exp.toChars(), t.toChars());
+            error(loc, "expression (%s) has ambiguous type", exp.toChars());
+            *pt = Type.tambig;
+            inuse--;
+            return;
         }
         if (t.ty == Ttypeof)
         {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -197,6 +197,7 @@ public:
     static Type *twstring;              // immutable(wchar)[]
     static Type *tdstring;              // immutable(dchar)[]
     static Type *tvalist;               // va_list alias
+    static Type *tambig;
     static Type *terror;                // for error recovery
     static Type *tnull;                 // for null type
 
@@ -267,6 +268,7 @@ public:
     virtual bool isscope();
     virtual bool isString();
     virtual bool isAssignable();
+    virtual bool isAmbiguous();
     virtual bool isBoolean();
     virtual void checkDeprecated(Loc loc, Scope *sc);
     bool isConst() const       { return (mod & MODconst) != 0; }
@@ -369,6 +371,7 @@ public:
     Type *next;
 
     TypeNext(TY ty, Type *next);
+    bool isAmbiguous();
     void checkDeprecated(Loc loc, Scope *sc);
     int hasWild() const;
     Type *nextOf();
@@ -619,6 +622,7 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
+    bool isAmbiguous();
     void purityLevel();
     bool hasLazyParameters();
     bool parameterEscapes(Parameter *p);

--- a/src/statement.d
+++ b/src/statement.d
@@ -4426,7 +4426,13 @@ public:
             {
                 if (!tret)
                 {
-                    tf.next = exp.type;
+                    if (exp.type.isAmbiguous())
+                    {
+                        error("cannot infer return type from ambiguous expression %s", exp.toChars());
+                        tf.next = Type.terror;
+                    }
+                    else
+                        tf.next = exp.type;
                 }
                 else if (tret.ty != Terror && !exp.type.equals(tret))
                 {

--- a/test/compilable/test7322.d
+++ b/test/compilable/test7322.d
@@ -1,0 +1,79 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+compilable/test7322.d(29): Deprecation: function test7322.S7322.baz7322 is deprecated
+compilable/test7322.d(42): Deprecation: function test7322.foo7322 is deprecated
+compilable/test7322.d(49): Deprecation: function test7322.S7322.bar7322 is deprecated
+compilable/test7322.d(53): Deprecation: function test7322.S7322.baz7322 is deprecated
+---
+*/
+
+deprecated
+int foo7322(real a) { return 1; }
+int foo7322(long a) { return 0; }
+
+struct S7322
+{
+    deprecated
+    int bar7322(real a) { return 1; }
+    int bar7322(long a) { return 0; }
+
+    deprecated
+    int baz7322(real a)           { return 1; }
+    int baz7322(long a) immutable { return 0; }
+
+    // DelegateExp::semantic(!func->isNested() && hasOverloads)
+    void test1()
+    {
+        auto dg = &baz7322;                 // deprecated!
+        static assert(is(typeof(dg) == int delegate(real)));
+    }
+    void test2() immutable
+    {
+        auto dg = &baz7322;
+        static assert(is(typeof(dg) == int delegate(long) immutable));
+    }
+}
+
+void test7322a()
+{
+    // SymOffExp::implicitCastTo()
+    int function(real) fp1 = &foo7322;      // deprecated!
+    int function(long) fp2 = &foo7322;
+
+    S7322 sm;
+    immutable S7322 si;
+
+    // DelegateExp::implicitCastTo()
+    int delegate(real) dg1 = &sm.bar7322;   // deprecated!
+    int delegate(long) dg2 = &sm.bar7322;
+
+    // DotVarExp::semantic(var->isFuncDeclaration() && hasOverloads)
+    auto dg3 = &sm.baz7322;                 // deprecated!
+    static assert(is(typeof(dg3) == int delegate(real)));
+
+    auto dg4 = &si.baz7322;
+    static assert(is(typeof(dg4) == int delegate(long) immutable));
+}
+
+deprecated void test7322b()
+{
+    // SymOffExp::implicitCastTo()
+    int function(real) fp1 = &foo7322;      // deprecated!
+    int function(long) fp2 = &foo7322;
+
+    S7322 sm;
+    immutable S7322 si;
+
+    // DelegateExp::implicitCastTo()
+    int delegate(real) dg1 = &sm.bar7322;   // deprecated!
+    int delegate(long) dg2 = &sm.bar7322;
+
+    // DotVarExp::semantic(var->isFuncDeclaration() && hasOverloads)
+    auto dg3 = &sm.baz7322;                 // deprecated!
+    static assert(is(typeof(dg3) == int delegate(real)));
+
+    auto dg4 = &si.baz7322;
+    static assert(is(typeof(dg4) == int delegate(long) immutable));
+}

--- a/test/fail_compilation/depmsg.d
+++ b/test/fail_compilation/depmsg.d
@@ -52,13 +52,18 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/depmsg.d(94): Deprecation: function depmsg.test12954.Foo.bar1 is deprecated - [C] Use Foo.bar42 instead
-fail_compilation/depmsg.d(95): Deprecation: function depmsg.test12954.Foo.bar2 is deprecated - [E] Use Foo.bar42 instead
-fail_compilation/depmsg.d(96): Deprecation: function depmsg.test12954.Foo.bar3 is deprecated - [S] Use Foo.bar42 instead
-fail_compilation/depmsg.d(97): Deprecation: function depmsg.test12954.Foo.bar4 is deprecated - [F] Use Foo.bar42 instead
-fail_compilation/depmsg.d(98): Deprecation: variable depmsg.test12954.Foo.v2 is deprecated - Forward reference
-fail_compilation/depmsg.d(105): Deprecation: class depmsg.test12954.Obsolete is deprecated
-fail_compilation/depmsg.d(105): Deprecation: function depmsg.test12954.Obsolete.obs is deprecated - Function is obsolete
+fail_compilation/depmsg.d(99): Deprecation: function depmsg.test12954.Foo.bar1 is deprecated - [C] Use Foo.bar42 instead
+fail_compilation/depmsg.d(99): Deprecation: function depmsg.test12954.Foo.bar1 is deprecated - [C] Use Foo.bar42 instead
+fail_compilation/depmsg.d(100): Deprecation: function depmsg.test12954.Foo.bar2 is deprecated - [E] Use Foo.bar42 instead
+fail_compilation/depmsg.d(100): Deprecation: function depmsg.test12954.Foo.bar2 is deprecated - [E] Use Foo.bar42 instead
+fail_compilation/depmsg.d(101): Deprecation: function depmsg.test12954.Foo.bar3 is deprecated - [S] Use Foo.bar42 instead
+fail_compilation/depmsg.d(101): Deprecation: function depmsg.test12954.Foo.bar3 is deprecated - [S] Use Foo.bar42 instead
+fail_compilation/depmsg.d(102): Deprecation: function depmsg.test12954.Foo.bar4 is deprecated - [F] Use Foo.bar42 instead
+fail_compilation/depmsg.d(102): Deprecation: function depmsg.test12954.Foo.bar4 is deprecated - [F] Use Foo.bar42 instead
+fail_compilation/depmsg.d(103): Deprecation: variable depmsg.test12954.Foo.v2 is deprecated - Forward reference
+fail_compilation/depmsg.d(110): Deprecation: class depmsg.test12954.Obsolete is deprecated
+fail_compilation/depmsg.d(110): Deprecation: function depmsg.test12954.Obsolete.obs is deprecated - Function is obsolete
+fail_compilation/depmsg.d(110): Deprecation: function depmsg.test12954.Obsolete.obs is deprecated - Function is obsolete
 ---
 */
 void test12954()

--- a/test/fail_compilation/diag8101b.d
+++ b/test/fail_compilation/diag8101b.d
@@ -5,12 +5,12 @@ fail_compilation/diag8101b.d(26): Error: none of the overloads of 'foo' are call
 fail_compilation/diag8101b.d(17):        diag8101b.S.foo(int _param_0)
 fail_compilation/diag8101b.d(18):        diag8101b.S.foo(int _param_0, int _param_1)
 fail_compilation/diag8101b.d(28): Error: function diag8101b.S.bar (int _param_0) is not callable using argument types (double)
-fail_compilation/diag8101b.d(31): Error: none of the overloads of 'foo' are callable using a const object, candidates are:
-fail_compilation/diag8101b.d(17):        diag8101b.S.foo(int _param_0)
-fail_compilation/diag8101b.d(18):        diag8101b.S.foo(int _param_0, int _param_1)
+fail_compilation/diag8101b.d(31): Error: mutable method diag8101b.S.foo is not callable using a const object
 fail_compilation/diag8101b.d(33): Error: mutable method diag8101b.S.bar is not callable using a const object
 ---
 */
+
+
 
 struct S
 {

--- a/test/fail_compilation/fail7549.d
+++ b/test/fail_compilation/fail7549.d
@@ -1,0 +1,49 @@
+void foo() {}
+void foo(int) {}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail7549.d(13): Error: expression (foo) has ambiguous type
+---
+*/
+void test1()
+{
+    static assert(is(typeof(foo))); // OK
+    typeof(foo)* func_ptr;          // error
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail7549.d(30): Error: expression (&c.fun) has ambiguous type
+---
+*/
+void test2()
+{
+    class C
+    {
+        int fun(string) { return 1; }
+        int fun() { return 1; }
+    }
+    auto c = new C;
+    auto s = typeof(&c.fun).stringof;
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail7549.d(42): Error: cannot infer type from overloaded function symbol & foo
+fail_compilation/fail7549.d(46): Error: cannot infer return type from ambiguous expression & foo
+---
+*/
+void test3()
+{
+    auto val1 = &foo;                                    // should be ambiguous
+    auto val2 = cast(void function(int))&foo;            // works
+    void function(int) val3 = &foo;                      // works
+
+    auto bar1() { return &foo; }                         // should be ambiguous
+    auto bar2() { return cast(void function(int))&foo; } // works
+    void function(int) bar3() { return &foo; }           // works
+}

--- a/test/fail_compilation/fail9027.d
+++ b/test/fail_compilation/fail9027.d
@@ -1,0 +1,29 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9027.d(26): Error: cannot cast ambiguous expression & f2 to void function(int)
+fail_compilation/fail9027.d(27): Error: cannot cast ambiguous expression & f3 to void function(int)
+fail_compilation/fail9027.d(28): Error: cannot cast ambiguous expression & f4 to void function()
+---
+*/
+
+void f1() { }
+void f1(int) { }
+extern(C) void f1(int) { }
+
+void f2() { }
+extern(C) void f2(int) { }
+
+extern(C) void f3(int) { }
+void f3() { }
+
+extern(Windows) void f4(long) { }
+extern(C) void f4(long) { }
+
+void main()
+{
+    auto fp1 = cast(void function(int)) &f1;
+    auto fp2 = cast(void function(int)) &f2;
+    auto fp3 = cast(void function(int)) &f3;
+    auto fp4 = cast(void function()) &f4;
+}

--- a/test/runnable/overload.d
+++ b/test/runnable/overload.d
@@ -596,6 +596,44 @@ void test15()
 }
 
 /***************************************************/
+// 8868
+
+void test8868()
+{
+    struct S
+    {
+        static int g1()      { return 7; }
+               int g1(int n) { return 3; }
+
+               int g2(int n) { return 3; }
+        static int g2()      { return 7; }
+    }
+    S s;
+    S func() { return s; }
+
+    auto a1 = &(func()).g1;
+    auto a2 = &(func()).g2;
+    auto b1 = &s.g1;
+    auto b2 = &s.g2;
+    auto c1 = &S.g1;
+    auto c2 = &S.g2;
+
+    static assert(is(typeof(a1) == int delegate(int)));
+    static assert(is(typeof(a2) == int delegate(int)));
+    static assert(is(typeof(b1) == int delegate(int)));
+    static assert(is(typeof(b2) == int delegate(int)));
+    static assert(is(typeof(c1) == int function()));
+    static assert(is(typeof(c2) == int function()));
+
+    assert(a1(1) == 3);
+    assert(a2(1) == 3);
+    assert(b1(1) == 3);
+    assert(b2(1) == 3);
+    assert(c1() == 7);
+    assert(c2() == 7);
+}
+
+/***************************************************/
 // 1528
 
 int foo1528(long){ return 1; }
@@ -1811,6 +1849,7 @@ int main()
     test10();
     test11();
     test12();
+    test8868();
     test1528a();
     test1528b();
     test1528c();

--- a/test/runnable/overload.d
+++ b/test/runnable/overload.d
@@ -12,6 +12,590 @@ template Id(      T){ alias T Id; }
 template Id(alias A){ alias A Id; }
 
 /***************************************************/
+
+void test1()
+{
+    static class C1
+    {
+              void f1() {}
+        const void f1() {}
+
+              void f2() {}
+
+              auto f3() { return &f1; }
+        const auto f3() { return &f1; }
+    }
+    static class C2
+    {
+        const void f1() {}
+              void f1() {}
+
+              void f2() {}
+
+        const auto f3() { return &f1; }
+              auto f3() { return &f1; }
+    }
+
+    // FIX: the tolerance against C's member function declaration order
+    foreach (C; TypeTuple!(C1, C2))
+    {
+        auto mc = new C;
+
+        auto dg1 = &mc.f1;
+        static assert(is(typeof(dg1) == void delegate()));
+
+        auto dg2 = &mc.f2;
+        static assert(is(typeof(dg2) == void delegate()));
+
+        auto dg3 = &mc.f3;
+        static assert(is(typeof(dg3) : void delegate() delegate()));
+    }
+    foreach (C; TypeTuple!(C1, C2))
+    {
+        const cc = new C;
+
+        auto dg1 = &cc.f1;
+        static assert(is(typeof(dg1) == void delegate() const));
+
+        static assert(!is(typeof(&cc.f2)));
+
+        auto dg3 = &cc.f3;
+        static assert(is(typeof(dg3) : void delegate() const delegate() const));
+    }
+}
+
+/***************************************************/
+
+void test2()
+{
+    static class C1
+    {
+        bool f() const { return true; }
+        void f(bool v) {}
+
+               const void g1() {}
+        shared const void g1() {}
+
+               const int g2(int m)        { return 1; }
+        shared const int g2(int m, int n) { return 2; }
+    }
+    static class C2
+    {
+        void f(bool v) {}
+        bool f() const { return true; }
+
+        shared const void g1() {}
+               const void g1() {}
+
+        shared const int g2(int m, int n) { return 2; }
+               const int g2(int m)        { return 1; }
+    }
+    static bool g(bool v) { return v; }
+
+    foreach (C; TypeTuple!(C1, C2))
+    {
+        auto mc = new C();
+        assert(g(mc.f));
+
+        auto ic = new immutable(C)();
+        static assert(is(typeof(&ic.g1)));
+        static assert(!__traits(compiles, typeof(&ic.g1)));
+
+        assert(ic.g2(0) == 1);
+        assert(ic.g2(0,0) == 2);
+
+        alias C.f foo;
+        static assert(is(typeof(foo)));
+        static assert(!__traits(compiles, typeof(foo)));
+    }
+}
+
+/***************************************************/
+
+void test3()
+{
+    static class C
+    {
+        void f() {}
+        void f(int n) {}
+
+        // dummy functions to get type of f
+        void f1() {}
+        void f2(int n) {}
+    }
+
+    alias TypeTuple!(__traits(getOverloads, C, "f")) Fs;
+    alias Fs[0] F1;
+    alias Fs[1] F2;
+    static assert(is(typeof(F1) == typeof(C.f1)));
+    static assert(is(typeof(F2) == typeof(C.f2)));
+
+    static assert(is(typeof(Id!F1) == typeof(C.f1)));
+    static assert(is(typeof(Id!F2) == typeof(C.f2)));
+    // ovrload resolution keeps through template alias parameter.
+
+    foreach (i, F; __traits(getOverloads, C, "f"))
+    {
+        static if (i==0) static assert(is(typeof(F) == typeof(C.f1)));
+        static if (i==1) static assert(is(typeof(F) == typeof(C.f2)));
+
+        static if (i==0) static assert(is(typeof(Id!F) == typeof(C.f1)));
+        static if (i==1) static assert(is(typeof(Id!F) == typeof(C.f2)));
+    }
+}
+
+/***************************************************/
+
+static int g(int n)        { return 1; }
+static int g(int n, int m) { return 2; }
+
+void test4()
+{
+    static class C
+    {
+        int f(int n)        { return 1; }
+        int f(int n, int m) { return 2; }
+    }
+    auto c = new C();
+    static assert(!__traits(compiles, (&c.f)()));
+    assert((&c.f)(0) == 1);
+    assert((&c.f)(0,1) == 2);
+
+    static assert(!__traits(compiles, (&g)()));
+    assert((&g)(0) == 1);
+    assert((&g)(0,1) == 2);
+}
+
+/***************************************************/
+
+struct Test5S
+{
+    void f()      {}
+    void f(int n) {}
+    void g()
+    {
+        // mtype.c L7107 TODO -> resloved
+        //pragma(msg, typeof(Test5S.f));
+        static assert(is(typeof(Test5S.f)));
+        static assert(!__traits(compiles, typeof(Test5S.f)));
+    }
+
+    void h()      {}
+    void h(int n) {}
+}
+class Test5C
+{
+    void f()      {}
+    void f(int n) {}
+    void g()
+    {
+        // mtype.c L7646 TODO -> resolved
+        //pragma(msg, typeof(Test5C.f));
+        static assert(is(typeof(Test5C.f)));
+        static assert(!__traits(compiles, typeof(Test5C.f)));
+    }
+
+    class N
+    {
+        void x()
+        {
+            // mtype.c L7660 TODO -> resolved
+            //pragma(msg, typeof(Test5C.f));
+            static assert(is(typeof(Test5C.f)));
+            static assert(!__traits(compiles, typeof(Test5C.f)));
+        }
+    }
+
+}
+void test5()
+{
+    Test5S s;
+    s.g();
+    // mtype.c L7145 TODO -> resolved
+    //pragma(msg, typeof(s.h));
+    static assert(is(typeof(s.h)));
+    static assert(!__traits(compiles, typeof(s.h)));
+
+    Test5C c = new Test5C();
+    c.g();
+    // mtype.c L7694 TODO -> resolved
+    //pragma(msg, typeof(c.h));
+    static assert(is(typeof(c.f)));
+    static assert(!__traits(compiles, typeof(c.f)));
+}
+
+/***************************************************/
+
+void test6()
+{
+    static class C
+    {
+        void f()      {}
+        void f(int n) {}
+
+        void f1()      {}
+        void f2(int n) {}
+    }
+    alias C.f Fun;
+    alias TypeTuple!(__traits(getOverloads, C, "f")) FunSeq;
+
+    /*
+        When template instantiates, overloaded symbol passed by FuncDeclaratioin.
+        By the side, non overloaded symbol is passed by VarExp(var=fd, hasOverloads=0),
+        and its type is same as fd->type.
+    */
+
+    static assert(is(typeof(C.f)));
+    static assert(!__traits(compiles, typeof(C.f)));
+    // direct
+
+    static assert(is(typeof(Id!(C.f))));
+    static assert(!__traits(compiles, typeof(Id!(C.f))));
+    // direct -> through template alias parameter
+
+    static assert(is(typeof(Fun)));
+    static assert(!__traits(compiles, typeof(Fun)));
+    // indirect(through alias)
+
+    static assert(is(typeof(Id!(Fun))));
+    static assert(!__traits(compiles, typeof(Id!(Fun))));
+    // indirect -> through template alias parameter
+
+    static assert(is(typeof(FunSeq[0]) == typeof(C.f1)));
+    static assert(is(typeof(FunSeq[1]) == typeof(C.f2)));
+    // direct(tuple element)
+
+    static assert(is(typeof(Id!(FunSeq[0])) == typeof(C.f1)));
+    static assert(is(typeof(Id!(FunSeq[1])) == typeof(C.f2)));
+    // direct(tuple element) -> through template alias parameter
+}
+
+/***************************************************/
+
+void test7()
+{
+    static class C
+    {
+        static int f()      { return 1; }
+        static int f(int n) { return 2; }
+
+        int f1()      { return 1; }
+        int f2(int n) { return 2; }
+    }
+    alias C.f Fun;
+    alias TypeTuple!(__traits(getOverloads, C, "f")) FunSeq;
+
+    assert(C.f( ) == 1);
+    assert(C.f(0) == 2);
+
+    assert(Id!(C.f)( ) == 1);
+    assert(Id!(C.f)(0) == 2);
+
+    assert(FunSeq[0]( ) == 1);
+    assert(FunSeq[1](0) == 2);
+    static assert(!__traits(compiles, FunSeq[0](0) == 1));
+    static assert(!__traits(compiles, FunSeq[1]( ) == 2));
+
+    assert(Id!(FunSeq[0])( ) == 1);
+    assert(Id!(FunSeq[1])(0) == 2);
+    static assert(!__traits(compiles, Id!(FunSeq[0])(0) == 1));
+    static assert(!__traits(compiles, Id!(FunSeq[1])( ) == 2));
+}
+
+/***************************************************/
+
+class A8
+{
+    static int f() { return 1; }
+}
+int g8(int n) { return 2; }
+alias A8.f fun8;
+alias g8 fun8;
+void test8()
+{
+    assert(fun8( ) == 1);
+    assert(fun8(0) == 2);
+}
+
+/***************************************************/
+
+class A9
+{
+    static int f() { return 1; }
+}
+class B9
+{
+    static int g(int n) { return 2; }
+    alias A9.f fun;
+    alias g fun;
+}
+
+void test9()
+{
+    assert(B9.fun( ) == 1);
+    assert(B9.fun(0) == 2);
+}
+
+/***************************************************/
+
+class A10
+{
+    static int f()      { return 1; }
+    static int f(int n) { return 2; }
+    alias TypeTuple!(__traits(getOverloads, A10, "f")) F;
+    alias F[0] f0;
+    alias F[1] f1;
+}
+class B10
+{
+    static int g(string s) { return 3; }
+}
+
+// int(), int(int), int(string)
+alias A10.f fun10_1;
+alias B10.g fun10_1;
+
+// int(), int(string)
+alias A10.F[0] fun10_2;
+alias B10.g fun10_2;
+
+// int(), int(int), int(string)
+alias fun10_1 fun10_3;
+alias fun10_2 fun10_3;
+
+void test10()
+{
+    assert(fun10_1() == 1);
+    assert(fun10_1(0) == 2);
+    assert(fun10_1("s") == 3);
+
+    assert(fun10_2() == 1);
+    static assert(!__traits(compiles, fun10_2(0)));
+    assert(fun10_2("s") == 3);
+
+    assert(A10.f0() == 1);
+    static assert(!__traits(compiles, A10.f0(0)));
+
+    static assert(!__traits(compiles, A10.f1()));
+    assert(A10.f1(0) == 2);
+
+    assert(fun10_3() == 1);
+    assert(fun10_3(0) == 2);
+    assert(fun10_3("s") == 3);
+}
+
+/***************************************************/
+
+void test11()
+{
+    static class C
+    {
+        static int f()      { return 1; }
+        static int f(int n) { return 2; }
+
+        alias TypeTuple!(f) L;
+        alias L[0] F;
+        // Keep overloads through template tuple parameter
+    }
+
+    alias C.L L;
+    assert(L[0](0) == 2);
+    assert(L[0]( ) == 1);
+    static assert(!__traits(compiles,    typeof(L[0]) ));
+    static assert( __traits(compiles, is(typeof(L[0]))));
+    // L[0] keeps overloaded f
+
+    alias C.F F;
+    assert(F(0) == 2);
+    assert(F( ) == 1);
+    static assert(!__traits(compiles,    typeof(F) ));
+    static assert( __traits(compiles, is(typeof(F))));
+    // F keeps overloaded f
+
+    alias TypeTuple!(__traits(getOverloads, C, "F")) Fs;
+    assert(Fs[0]( ) == 1);
+    assert(Fs[1](0) == 2);
+    static assert(!__traits(compiles, Fs[0](0)));
+    static assert(!__traits(compiles, Fs[1]( )));
+    // separate overloads from C.F <- C.L[0] <- TypeTuple!(C.f)[0]
+}
+
+/***************************************************/
+
+void test12()
+{
+    // C.f prefers static functions, and c.f prefers virtual functions.
+
+    int f1()        { return 0; }   alias typeof(f1) F1;
+    int f2(int)     { return 0; }   alias typeof(f2) F2;
+    int f3(string)  { return 0; }   alias typeof(f3) F3;
+    int f4(int[])   { return 0; }   alias typeof(f4) F4;
+
+    static class C1
+    {
+        int f()     { return 1; }
+        int f(int)  { return 2; }
+    }
+    auto c1 = new C1();
+    static assert(!__traits(compiles,            C1.f    (   )));
+    static assert(!__traits(compiles,            C1.f    (100)));
+    static assert(!__traits(compiles,        Id!(C1.f)   (   )));
+    static assert(!__traits(compiles,        Id!(C1.f)   (100)));
+    static assert(!__traits(compiles, TypeTuple!(C1.f)[0](   )));
+    static assert(!__traits(compiles, TypeTuple!(C1.f)[0](100)));
+    static assert(is(typeof(c1.f)) && !__traits(compiles, typeof(c1.f)));   // virtual ambiguous
+    static assert(is(typeof(C1.f)) && !__traits(compiles, typeof(C1.f)));   // virtual ambiguous
+
+    static class C2
+    {
+        int f()     { return 1; }
+        int f(int)  { return 2; }
+        static int f(string) { return 3; }
+    }
+    auto c2 = new C2();
+    static assert(!__traits(compiles,            C2.f    (   )    ));
+    static assert(!__traits(compiles,            C2.f    (100)    ));
+           assert(                               C2.f    ("a") == 3);
+    static assert(!__traits(compiles,        Id!(C2.f)   (   )    ));
+    static assert(!__traits(compiles,        Id!(C2.f)   (100)    ));
+           assert(                           Id!(C2.f)   ("a") == 3);
+    static assert(!__traits(compiles, TypeTuple!(C2.f)[0](   )    ));
+    static assert(!__traits(compiles, TypeTuple!(C2.f)[0](100)    ));
+           assert(                    TypeTuple!(C2.f)[0]("a") == 3);
+    static assert(is(typeof(c2.f)) && !__traits(compiles, typeof(c2.f)));   // virtual ambiguous
+    static assert(is(typeof(C2.f) == F3));                                  // static  disambiguous
+
+    static class C31
+    {
+        int f() { return 1; }
+        static int f(string) { return 3; }
+    }
+    auto c31 = new C31();
+    static assert(!__traits(compiles,            C31.f    (100)    ));
+           assert(                               C31.f    ("a") == 3);
+    static assert(!__traits(compiles,        Id!(C31.f)   (100)    ));
+           assert(                           Id!(C31.f)   ("a") == 3);
+    static assert(!__traits(compiles, TypeTuple!(C31.f)[0](100)    ));
+           assert(                    TypeTuple!(C31.f)[0]("a") == 3);
+    static assert(is(typeof(c31.f) == F1));         // virtual disambiguous
+    static assert(is(typeof(C31.f) == F3));         // static  disambiguous
+
+    static class C32
+    {
+        int f()     { return 1; }
+        int f(int)  { return 2; }
+        static int f(string) { return 3; }
+        static int f(int[])  { return 4; }
+    }
+    auto c32 = new C32();
+    static assert(!__traits(compiles,            C32.f    (   )    ));
+    static assert(!__traits(compiles,            C32.f    (100)    ));
+           assert(                               C32.f    ("a") == 3);
+           assert(                               C32.f    ([0]) == 4);
+    static assert(!__traits(compiles,        Id!(C32.f)   (   )    ));
+    static assert(!__traits(compiles,        Id!(C32.f)   (100)    ));
+           assert(                           Id!(C32.f)   ("a") == 3);
+           assert(                           Id!(C32.f)   ([0]) == 4);
+    static assert(!__traits(compiles, TypeTuple!(C32.f)[0](   )    ));
+    static assert(!__traits(compiles, TypeTuple!(C32.f)[0](100)    ));
+           assert(                    TypeTuple!(C32.f)[0]("a") == 3);
+           assert(                    TypeTuple!(C32.f)[0]([0]) == 4);
+    static assert(is(typeof(c32.f)) && !__traits(compiles, typeof(c32.f))); // virtual ambiguous
+    static assert(is(typeof(C32.f)) && !__traits(compiles, typeof(C32.f))); // static  ambiguous
+
+    static class C4
+    {
+        int f()     { return 1; }
+        static int f(string) { return 3; }
+        static int f(int[])  { return 4; }
+    }
+    auto c4 = new C4();
+    static assert(!__traits(compiles,            C4.f    (   )    ));
+           assert(                               C4.f    ("a") == 3);
+           assert(                               C4.f    ([0]) == 4);
+    static assert(!__traits(compiles,        Id!(C4.f)   (   )    ));
+           assert(                           Id!(C4.f)   ("a") == 3);
+           assert(                           Id!(C4.f)   ([0]) == 4);
+    static assert(!__traits(compiles, TypeTuple!(C4.f)[0](   )    ));
+           assert(                    TypeTuple!(C4.f)[0]("a") == 3);
+           assert(                    TypeTuple!(C4.f)[0]([0]) == 4);
+    static assert(is(typeof(c4.f) == F1));                                  // virtual disambiguous
+    static assert(is(typeof(C4.f)) && !__traits(compiles, typeof(C4.f)));   // static  ambiguous
+
+    static class C5
+    {
+        static int f(string) { return 3; }
+        static int f(int[])  { return 4; }
+    }
+    auto c5 = new C5();
+    static assert(!__traits(compiles,            C5.f    (   )    ));
+    static assert(!__traits(compiles,            C5.f    (100)    ));
+    static assert(!__traits(compiles,        Id!(C5.f)   (   )    ));
+    static assert(!__traits(compiles,        Id!(C5.f)   (100)    ));
+    static assert(!__traits(compiles, TypeTuple!(C5.f)[0](   )    ));
+    static assert(!__traits(compiles, TypeTuple!(C5.f)[0](100)    ));
+    static assert(is(typeof(c5.f)) && !__traits(compiles, typeof(c5.f)));   // virtual ambiguous
+    static assert(is(typeof(C5.f)) && !__traits(compiles, typeof(C5.f)));   // virtual ambiguous
+}
+
+/***************************************************/
+
+class E13 : Exception
+{
+    this() { super(""); }
+}
+
+/***************************************************/
+
+template isFunction14(func...)
+{
+    enum isFunction14 = is(typeof(func[0]) == function);
+}
+template hasReturnType14(func...)
+{
+    enum isFunction14 = is(typeof(func[0]) == return);
+}
+template FunctionTypeOf14(func...)
+{
+    static if (is(typeof(&func[0]) Fsym : Fsym*))
+    {
+        alias Fsym FunctionTypeOf14;
+    }
+}
+
+void foo14() {}
+void foo14(int) {}
+static assert( isFunction14!foo14);
+static assert(!__traits(compiles, hasReturn14!foo14));
+static assert(!__traits(compiles, FunctionTypeOf14!foo14));
+
+/***************************************************/
+
+void test15()
+{
+    static struct S
+    {
+        void func(long) {}
+        void func(string) const {}
+    }
+
+    // VarExp.mangleof
+    static assert(S.func.mangleof[$-6..$] == "S4func");
+    static assert(__traits(getOverloads, S, "func")[0].mangleof[$-11..$] == "S4funcMFlZv");
+    static assert(__traits(getOverloads, S, "func")[1].mangleof[$-14..$] == "S4funcMxFAyaZv");
+
+    // DotVarExp.mangleof
+    S ms;
+    const S cs;
+    static assert(ms.func                              .mangleof[$-11..$] == "S4funcMFlZv");
+    static assert(cs.func                              .mangleof[$-14..$] == "S4funcMxFAyaZv");
+    static assert(__traits(getOverloads, ms, "func")[0].mangleof[$-11..$] == "S4funcMFlZv");
+    static assert(__traits(getOverloads, ms, "func")[1].mangleof[$-14..$] == "S4funcMxFAyaZv");
+    static assert(__traits(getOverloads, cs, "func").length == 1);
+    static assert(__traits(getOverloads, cs, "func")[0].mangleof[$-14..$] == "S4funcMxFAyaZv");
+}
+
+/***************************************************/
 // 1528
 
 int foo1528(long){ return 1; }
@@ -1215,6 +1799,18 @@ void test14965()
 
 int main()
 {
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+    test6();
+    test7();
+    test8();
+    test9();
+    test10();
+    test11();
+    test12();
     test1528a();
     test1528b();
     test1528c();

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2148,18 +2148,19 @@ void test5473()
     class C
     {
         int b;
-        void f(){}
+        void f() const {}
         static int x;
         static void g(){};
     }
     struct S
     {
         int b;
-        void f(){}
+        void f() const {}
         static int x;
         static void g(){};
     }
 
+    alias void VoidConstFunc() const;
     void dummy(){}
     alias typeof(dummy) VoidFunc;
 
@@ -2171,12 +2172,12 @@ void test5473()
         alias typeof(a) A;
 
         static assert(is(typeof(a.b) == const int));    // const(int)
-        static assert(is(typeof(a.f) == VoidFunc));
+        static assert(is(typeof(a.f) == VoidConstFunc));
         static assert(is(typeof(a.x) == int));
         static assert(is(typeof(a.g) == VoidFunc));
 
         static assert(is(typeof((const A).b) == const int));    // int, should be const(int)
-        static assert(is(typeof((const A).f) == VoidFunc));
+        static assert(is(typeof((const A).f) == VoidConstFunc));
         static assert(is(typeof((const A).x) == int));
         static assert(is(typeof((const A).g) == VoidFunc));
     }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4898,17 +4898,17 @@ void test5696()
 /***************************************************/
 // 5933
 
-int dummyfunc5933();
+int dummyfunc5933() pure nothrow @nogc @safe;
 alias typeof(dummyfunc5933) FuncType5933;
 
 struct S5933a { auto x() { return 0; } }
 static assert(is(typeof(&S5933a.init.x) == int delegate() pure nothrow @nogc @safe));
 
 struct S5933b { auto x() { return 0; } }
-//static assert(is(typeof(S5933b.init.x) == FuncType5933));
+static assert(is(typeof(S5933b.init.x) == FuncType5933));
 
 struct S5933c { auto x() { return 0; } }
-static assert(is(typeof(&S5933c.x) == int function()));
+static assert(is(typeof(&S5933c.x) == int function() pure nothrow @nogc @safe));
 
 struct S5933d { auto x() { return 0; } }
 static assert(is(typeof(S5933d.x) == FuncType5933));
@@ -4918,10 +4918,10 @@ class C5933a { auto x() { return 0; } }
 static assert(is(typeof(&(new C5933b()).x) == int delegate() pure nothrow @nogc @safe));
 
 class C5933b { auto x() { return 0; } }
-//static assert(is(typeof((new C5933b()).x) == FuncType5933));
+static assert(is(typeof((new C5933b()).x) == FuncType5933));
 
 class C5933c { auto x() { return 0; } }
-static assert(is(typeof(&C5933c.x) == int function()));
+static assert(is(typeof(&C5933c.x) == int function() pure nothrow @nogc @safe));
 
 class C5933d { auto x() { return 0; } }
 static assert(is(typeof(C5933d.x) == FuncType5933));


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=1983

<del>Depends on #2125, #2123, and https://github.com/D-Programming-Language/phobos/pull/1331</del>.
1. Add _ambiguous type_ to represent the type which comes from overloaded symbol.
2. Carry overload information properly, and use it.
