### PR TITLE
Fix issue 10270

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -270,7 +270,7 @@ cg.o: $C/cg.c fltables.c
 cg87.o: $C/cg87.c
 	$(CC) -c $(MFLAGS) $<
 
-cgcod.o: $C/cgcod.c
+cgcod.o: $C/cgcod.c cdxxx.c
 	$(CC) -c $(MFLAGS) -I. $<
 
 cgcs.o: $C/cgcs.c
@@ -279,7 +279,7 @@ cgcs.o: $C/cgcs.c
 cgcv.o: $C/cgcv.c
 	$(CC) -c $(MFLAGS) $<
 
-cgelem.o: $C/cgelem.c $C/rtlsym.h
+cgelem.o: $C/cgelem.c $C/rtlsym.h elxxx.c
 	$(CC) -c $(MFLAGS) -I. $<
 
 cgen.o: $C/cgen.c $C/rtlsym.h
@@ -342,7 +342,7 @@ cppmangle.o: cppmangle.c
 cv8.o: $C/cv8.c
 	$(CC) -c $(MFLAGS) $<
 
-debug.o: $C/debug.c
+debug.o: $C/debug.c debtab.c
 	$(CC) -c $(MFLAGS) -I. $<
 
 declaration.o: declaration.c
@@ -639,7 +639,7 @@ utf.o: utf.c utf.h
 unittests.o: unittests.c
 	$(CC) -c $(CFLAGS) $<
 
-var.o: $C/var.c optab.c
+var.o: $C/var.c optab.c tytab.c
 	$(CC) -c $(MFLAGS) -I. $<
 
 version.o: version.c


### PR DESCRIPTION
Now make -j works nicely. On my machine, simple make runs in 34.8 seconds, and make -j4 finishes in 11.6 seconds, and make -j8 runs in 8.7 seconds!
