### PR TITLE
Two more CTFE internal fixes relating to pointers

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5226,7 +5226,7 @@ Expression *CastExp::interpret(InterState *istate, CtfeGoal goal)
         }
         if (e1->op == TOKaddress)
         {
-            Type *origType = ((AddrExp *)e1)->type;
+            Type *origType = ((AddrExp *)e1)->e1->type;
             if (isSafePointerCast(origType, pointee))
             {
                 e = new AddrExp(loc, ((AddrExp *)e1)->e1);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2043,6 +2043,13 @@ Expression *AddrExp::interpret(InterState *istate, CtfeGoal goal)
 #if LOG
     printf("%s AddrExp::interpret() %s\n", loc.toChars(), toChars());
 #endif
+    if (e1->op == TOKvar && ((VarExp *)e1)->var->isDataseg())
+    {   // Normally this is already done by optimize()
+        // Do it here in case optimize(0) wasn't run before CTFE
+        SymOffExp *se = new SymOffExp(loc, ((VarExp *)e1)->var, 0);
+        se->type = type;
+        return se;
+    }
     // For reference types, we need to return an lvalue ref.
     TY tb = e1->type->toBasetype()->ty;
     bool needRef = (tb == Tarray || tb == Taarray || tb == Tclass);


### PR DESCRIPTION
Both cases were exposed by trying to use CTFE to do the work of optimize(WANTinterpret).

(1) When checking pointer casts involving AddrExp, was checking the pointer type instead of the pointee type. Simple typo.

(2) optimize() changes AddrExp(globalvar) into a SymOffExp.
But optimize() isn't always called before CTFE, so we need to do it in CTFE too.
