### PR TITLE
Fix bug 10273: ICE(ctfeexpr.c): using CTFE after error in struct init

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2227,6 +2227,8 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
     else if (s)
     {   // Struct static initializers, for example
         e = s->dsym->type->defaultInitLiteral(loc);
+        if (e->op == TOKerror)
+            error(loc, "CTFE failed because of previous errors in %s.init", s->toChars());
         e = e->semantic(NULL);
         if (e->op == TOKerror)
             e = EXP_CANT_INTERPRET;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8073,6 +8073,8 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
         }
         else
             e = vd->type->defaultInitLiteral(loc);
+        if (e && e->op == TOKerror)
+            return e;
         offset = vd->offset + vd->type->size();
         (*structelems)[j] = e;
     }

--- a/test/fail_compilation/ice10273.d
+++ b/test/fail_compilation/ice10273.d
@@ -1,0 +1,12 @@
+// 10273 - ICE in CTFE
+
+struct Bug10273 {
+    int val = 3.45;
+}
+int bug10273()
+{
+    Bug10273 p;
+    return 1;
+}
+
+static assert(bug10273());


### PR DESCRIPTION
If the default initializer had an error, abort CTFE immediately.
