### PR TITLE
10275 CTFE: allow const casts of struct literals

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1645,7 +1645,12 @@ Expression *ctfeCast(Loc loc, Type *type, Type *to, Expression *e)
     // Allow TypeInfo type painting
     if (isTypeInfo_Class(e->type) && e->type->implicitConvTo(to))
         return paintTypeOntoLiteral(to, e);
-
+#if DMDV2
+    // Allow casting away const for struct literals
+    if (e->op == TOKstructliteral &&
+        e->type->toBasetype()->castMod(0) == to->toBasetype()->castMod(0))
+        return paintTypeOntoLiteral(to, e);
+#endif
     Expression *r = Cast(type, to, e);
     if (r == EXP_CANT_INTERPRET)
         error(loc, "cannot cast %s to %s at compile time", e->toChars(), to->toChars());

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3612,6 +3612,27 @@ static assert(!is(typeof(compiles!(bug7780(1)))));
 static assert(!is(typeof(compiles!(bug7780(2)))));
 
 /**************************************************
+    10275 cast struct literals to immutable
+**************************************************/
+
+struct Bug10275
+{
+    uint[] ivals;
+}
+
+Bug10275 bug10275() {
+    return Bug10275([1,2,3]);
+}
+
+int test10275()
+{
+    immutable(Bug10275) xxx = cast(immutable(Bug10275))bug10275();
+    return 1;
+}
+
+static assert(test10275());
+
+/**************************************************
     6851 passing pointer by argument
 **************************************************/
 


### PR DESCRIPTION
This was permitted in const-folding, but not in CTFE until now.
It's required to merge optimize(WANTinterpret) with CTFE.

http://d.puremagic.com/issues/show_bug.cgi?id=10275
