### PR TITLE
10280 CTFE: Circular variable initializers should be detected properly

### DIFF
--- a/test/fail_compilation/circ10280.d
+++ b/test/fail_compilation/circ10280.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/circ10280.d(11): Error: circular initialization of q10280
+fail_compilation/circ10280.d(10):        called from here: foo10280()
+---
+*/
+// 10280
+
+const int q10280 = foo10280();
+int foo10280() { return q10280; }
+


### PR DESCRIPTION
Use the existing 'inuse' mechanism to detect cycles.

http://d.puremagic.com/issues/show_bug.cgi?id=10280

This is part of my project to unify optimize(WANTinterpret) and CTFE. The existing CTFE behaviour (detect circular definitions only by stack overflow) doesn't work for const folding, since there are no function calls involved. And this method gives much better error messages.
