### PR TITLE
Issue 8651 - Slice op Slice throws exceptions (not errors), and nothrow

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -267,9 +267,12 @@ ArrayOp *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc)
     //printf("s2: %s\n", s2->toChars());
     Statement *fbody = new CompoundStatement(Loc(), s1, s2);
 
+    // Built-in array ops should be @trusted, pure and nothrow
+    StorageClass stc = STCtrusted | STCpure | STCnothrow;
+
     /* Construct the function
      */
-    TypeFunction *ftype = new TypeFunction(fparams, exp->type, 0, LINKc);
+    TypeFunction *ftype = new TypeFunction(fparams, exp->type, 0, LINKc, stc);
     //printf("ftype: %s\n", ftype->toChars());
     FuncDeclaration *fd = new FuncDeclaration(Loc(), Loc(), ident, STCundefined, ftype);
     fd->fbody = fbody;

--- a/test/runnable/arrayop.d
+++ b/test/runnable/arrayop.d
@@ -549,6 +549,61 @@ void test8390() {
 }
 
 /************************************************************************/
+// 8651
+
+void test8651()
+{
+    void test(T)() @safe pure nothrow
+    {
+        T[3] a = [11, 22, 33];
+        T[3] b = [1, 2, 3];
+        T[3] c = [4, 5, 6];
+        T    d = 4;
+
+        // Arithmetic array ops
+        {
+            a[] = b[] + c[];
+            a[] = b[] + 4;
+            a[] = 4 + b[];
+            a[] = d + b[];
+            a[] += b[];
+            a[] += 4;
+            a[] -= 4;
+            a[] *= 4;
+            a[] /= 4;
+            a[] %= 4;
+            a[] += 4 + b[];
+            a[] = b[] - c[];
+            a[] = -b[] - c[];
+            a[] = b[] + c[] * 4;
+            a[] = b[] + c[] * b[];
+            a[] = b[] + c[] / 2;
+            a[] = b[] + c[] % 2;
+        }
+        // Bitwise array ops
+        static if (is(typeof(T.init & T.init)))
+        {
+            a[] &= 4;
+            a[] |= 4;
+            a[] ^= 4;
+            a[] = ~b[];
+            a[] = b[] & 2;
+            a[] = b[] | 2;
+            a[] = b[] ^ 2;
+        }
+    }
+
+    test!float();
+    test!double();
+    test!real();
+
+    test!byte();
+    test!short();
+    test!int();
+    test!long();
+}
+
+/************************************************************************/
 // 9656
 
 void test9656()
@@ -604,6 +659,7 @@ int main()
     test5();
     test6();
     test8390();
+    test8651();
     test9656();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8651

Array ops should work in @safe pure nothrow code.
