### PR TITLE
Issue 7848 - pure and nothrow ignored on unittest blocks

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -267,9 +267,12 @@ ArrayOp *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc)
     //printf("s2: %s\n", s2->toChars());
     Statement *fbody = new CompoundStatement(Loc(), s1, s2);
 
+    // Built-in array ops should be @trusted, pure and nothrow
+    StorageClass stc = STCtrusted | STCpure | STCnothrow;
+
     /* Construct the function
      */
-    TypeFunction *ftype = new TypeFunction(fparams, exp->type, 0, LINKc);
+    TypeFunction *ftype = new TypeFunction(fparams, exp->type, 0, LINKc, stc);
     //printf("ftype: %s\n", ftype->toChars());
     FuncDeclaration *fd = new FuncDeclaration(Loc(), Loc(), ident, STCundefined, ftype);
     fd->fbody = fbody;

--- a/src/func.c
+++ b/src/func.c
@@ -4537,8 +4537,6 @@ void UnitTestDeclaration::semantic(Scope *sc)
         if (!type)
             type = new TypeFunction(NULL, Type::tvoid, FALSE, LINKd);
         Scope *sc2 = sc->push();
-        // It makes no sense for unit tests to be pure or nothrow.
-        sc2->stc &= ~(STCnothrow | STCpure);
         sc2->linkage = LINKd;
         FuncDeclaration::semantic(sc2);
         sc2->pop();

--- a/test/fail_compilation/fail7848.d
+++ b/test/fail_compilation/fail7848.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -unittest
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail7848.d(17): Error: pure function 'fail7848.__unittestL15_1' cannot call impure function 'fail7848.func'
+fail_compilation/fail7848.d(17): Error: safe function 'fail7848.__unittestL15_1' cannot call system function 'fail7848.func'
+fail_compilation/fail7848.d(17): Error: func is not nothrow
+fail_compilation/fail7848.d(15): Error: function fail7848.__unittestL15_1 '__unittestL15_1' is nothrow yet may throw
+---
+*/
+
+void func() {}
+
+@safe pure nothrow unittest
+{
+    func();
+}

--- a/test/runnable/arrayop.d
+++ b/test/runnable/arrayop.d
@@ -549,6 +549,61 @@ void test8390() {
 }
 
 /************************************************************************/
+// 8651
+
+void test8651()
+{
+    void test(T)() @safe pure nothrow
+    {
+        T[3] a = [11, 22, 33];
+        T[3] b = [1, 2, 3];
+        T[3] c = [4, 5, 6];
+        T    d = 4;
+
+        // Arithmetic array ops
+        {
+            a[] = b[] + c[];
+            a[] = b[] + 4;
+            a[] = 4 + b[];
+            a[] = d + b[];
+            a[] += b[];
+            a[] += 4;
+            a[] -= 4;
+            a[] *= 4;
+            a[] /= 4;
+            a[] %= 4;
+            a[] += 4 + b[];
+            a[] = b[] - c[];
+            a[] = -b[] - c[];
+            a[] = b[] + c[] * 4;
+            a[] = b[] + c[] * b[];
+            a[] = b[] + c[] / 2;
+            a[] = b[] + c[] % 2;
+        }
+        // Bitwise array ops
+        static if (is(typeof(T.init & T.init)))
+        {
+            a[] &= 4;
+            a[] |= 4;
+            a[] ^= 4;
+            a[] = ~b[];
+            a[] = b[] & 2;
+            a[] = b[] | 2;
+            a[] = b[] ^ 2;
+        }
+    }
+
+    test!float();
+    test!double();
+    test!real();
+
+    test!byte();
+    test!short();
+    test!int();
+    test!long();
+}
+
+/************************************************************************/
 // 9656
 
 void test9656()
@@ -604,6 +659,7 @@ int main()
     test5();
     test6();
     test8390();
+    test8651();
     test9656();
 
     printf("Success\n");

--- a/test/runnable/test19.d
+++ b/test/runnable/test19.d
@@ -8,12 +8,12 @@ extern(C) int printf(const char*, ...);
 
 class Foo
 {
-	int foo(int x) { return x + 3; }
+    int foo(int x) { return x + 3; }
 }
 
 class Bar : Foo
 {
-	override int foo(int y) { return y + 4; }
+    override int foo(int y) { return y + 4; }
 }
 
 void test1()
@@ -31,7 +31,7 @@ class Foo2
 {
     int foo(int x)
     {
-	return x + 3;
+        return x + 3;
     }
 }
 
@@ -39,8 +39,8 @@ class Bar2 : Foo2
 {
     override int foo(int y)
     {
-	assert(Foo2.foo(2) == 5);
-	return y + 4;
+        assert(Foo2.foo(2) == 5);
+        return y + 4;
     }
 }
 
@@ -66,13 +66,14 @@ void test3()
     debug(10) assert(0);
 
     debug(1)
-    {	int d1 = 3;
+    {
+        int d1 = 3;
 
-	printf("debug(1) { }\n");
+        printf("debug(1) { }\n");
     }
     debug(2)
     {
-	printf("debug(2): d1 = %d\n", d1);
+        printf("debug(2): d1 = %d\n", d1);
     }
 }
 
@@ -120,8 +121,8 @@ void test5()
 
 int[] test6_1(int[] a)
 {
-	a.length = 6;
-	return a;
+    a.length = 6;
+    return a;
 }
 
 void test6()
@@ -148,7 +149,7 @@ class OutBuffer7
 
     void write(const(char) *p, uint nbytes)
     {
-	data[offset .. offset + nbytes] = (cast(char *)p)[0 .. nbytes];
+        data[offset .. offset + nbytes] = (cast(char *)p)[0 .. nbytes];
     }
 }
 
@@ -163,22 +164,23 @@ void test7()
     printf("ob.data.length = %d\n", ob.data.length);
     assert(ob.data.length == 10);
     for (i = 0; i < 10; i++)
-	assert(ob.data[i] == char.init);
+        assert(ob.data[i] == char.init);
 
 printf("test7.1()\n");
     ob.data[] = '-';
 printf("test7.2()\n");
     printf("ob.data[] = '%.*s'\n", ob.data.length, ob.data.ptr);
     for (i = 0; i < 10; i++)
-	assert(ob.data[i] == '-');
+        assert(ob.data[i] == '-');
 
     ob.offset = 3;
     ob.write("foo", 3);
     printf("ob.data.length = %d\n", ob.data.length);
     printf("ob.data[] = '%.*s'\n", ob.data.length, ob.data.ptr);
     for (i = 0; i < 10; i++)
-    {	if (i < 3 || i >= 6)
-	    assert(ob.data[i] == '-');
+    {
+        if (i < 3 || i >= 6)
+            assert(ob.data[i] == '-');
     }
     assert(ob.data[3] == 'f');
     assert(ob.data[4] == 'o');
@@ -268,9 +270,9 @@ char[] tolower13(ref char[] s)
 
     for (i = 0; i < s.length; i++)
     {
-	char c = s[i];
-	if ('A' <= c && c <= 'Z')
-	    s[i] = cast(char)(c + (cast(char)'a' - 'A'));
+        char c = s[i];
+        if ('A' <= c && c <= 'Z')
+            s[i] = cast(char)(c + (cast(char)'a' - 'A'));
     }
     return s;
 }
@@ -307,7 +309,7 @@ class bools15
     bool a = true, b = true, c = true;
     void dump()
     {
-	printf("%d %d %d\n", a, b, c);
+        printf("%d %d %d\n", a, b, c);
     }
 }
 
@@ -389,15 +391,26 @@ bool tested20;
 
 struct S20
 {
-	unittest{
-		assert(!tested20);
-		tested20 = true;
-	}
+    unittest
+    {
+        assert(!tested20);
+        tested20 = true;
+    }
 }
 
 void test20()
 {
-	assert(tested20);
+    assert(tested20);
+}
+
+/* ================================ */
+// 7848
+
+@safe pure nothrow void func7848() {}
+
+@safe pure nothrow unittest
+{
+    func7848();
 }
 
 /* ================================ */


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7848

Depends on #2141 (Essentially bug 7848 and [bug 8651](http://d.puremagic.com/issues/show_bug.cgi?id=8651) are unrelated, but it is necessary to avoid druntime unittest breaking).
