### PR TITLE
10283: ICE in CTFE

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1065,7 +1065,7 @@ Expression *Expression::castTo(Scope *sc, Type *t)
         VarDeclaration *v = ((VarExp *)this)->var->isVarDeclaration();
         if (v && v->storage_class & STCmanifest)
         {
-            Expression *e = optimize(WANTvalue | WANTinterpret);
+            Expression *e = ctfeInterpret();
             return e->castTo(sc, t);
         }
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -4588,6 +4588,8 @@ Expression *StructLiteralExp::semantic(Scope *sc)
             }
             offset = v->offset + v->type->size();
         }
+        if (e && e->op == TOKerror)
+            return e;
         elements->push(e);
     }
 

--- a/test/fail_compilation/ice10283.d
+++ b/test/fail_compilation/ice10283.d
@@ -1,0 +1,10 @@
+// 10283
+
+S10283 blah(S10283 xxx) { return xxx; }
+S10283 repy = blah(S10283());
+
+struct S10283
+{
+    string source = 7;
+}
+


### PR DESCRIPTION
Another fix required by my optimize(WANTinterpret) -> CTFE project.

Fixes a simple error-propagation bug relating to initializer errors in struct literals:

http://d.puremagic.com/issues/show_bug.cgi?id=10283

I also found a place where ctfeInterpret() wasn't being called. It's not really related to bug 10283, but both fixes are so trivial I've combined them here.
