### PR TITLE
use literal instead of symbol for init

### DIFF
--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -1637,6 +1637,13 @@ extern (C++) class VarDeclaration : Declaration
             }
             else if (auto e = type.defaultInit(loc))
             {
+                /* For smaller types, prefer the literal as that has better code gen,
+                 * using immediate instructions.
+                 * Still call the previous defaultInit, as that does checking for void[n]
+                 * initializations.
+                 */
+                if (type.size() <= 16)
+                    e = type.defaultInitLiteral(loc);
                 _init = new ExpInitializer(loc, e);
             }
 


### PR DESCRIPTION
which enables better code to be generated for small wrapper structs, i.e.:

```
mov EAX,3
```

instead of:

```
mov EAX,S.init
```

for:

```
struct S { int a = 3; this(int I) { } }
S s = S(1);
```
