### PR TITLE
Issue 10302 - Package module conflicts with package name

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -849,6 +849,19 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
     //printf("%s->ScopeDsymbol::search(ident='%s', flags=x%x)\n", toChars(), ident->toChars(), flags);
     //if (strcmp(ident->toChars(),"c") == 0) *(char*)0=0;
 
+    if (Package *pkg = isPackage())
+    {
+        if (!pkg->isModule() && pkg->mod)
+        {
+            // Prefer full package name.
+            Dsymbol *s = pkg->symtab ? pkg->symtab->lookup(ident) : NULL;
+            if (s)
+                return s;
+            //printf("[%s] through pkdmod: %s\n", loc.toChars(), pkg->toChars());
+            return pkg->mod->search(loc, ident, flags);
+        }
+    }
+
     // Look in symbols declared in this module
     Dsymbol *s = symtab ? symtab->lookup(ident) : NULL;
     //printf("\ts = %p, imports = %p, %d\n", s, imports, imports ? imports->dim : 0);

--- a/src/expression.c
+++ b/src/expression.c
@@ -7460,7 +7460,7 @@ Expression *DotIdExp::semanticY(Scope *sc, int flag)
             ScopeDsymbol *sds = s->isScopeDsymbol();
             if (sds)
             {
-                //printf("it's a ScopeDsymbol\n");
+                //printf("it's a ScopeDsymbol %s\n", ident->toChars());
                 e = new ScopeExp(loc, sds);
                 e = e->semantic(sc);
                 if (eleft)

--- a/src/import.c
+++ b/src/import.c
@@ -125,6 +125,26 @@ void Import::load(Scope *sc)
             {
                 ::error(loc, "%s %s conflicts with %s", s->kind(), s->toPrettyChars(), id->toChars());
             }
+            else if (Package *p = s->isPackage())
+            {
+                if (p->isPkgMod == PKGunknown)
+                {
+                    mod = Module::load(loc, packages, id);
+                    if (!mod)
+                        p->isPkgMod = PKGpackage;
+                    else
+                        assert(p->isPkgMod == PKGmodule);
+                }
+                else if (p->isPkgMod == PKGmodule)
+                {
+                    mod = p->mod;
+                }
+                if (p->isPkgMod != PKGmodule)
+                {
+                    ::error(loc, "can only import from a module, not from package %s.%s",
+                        p->toPrettyChars(), id->toChars());
+                }
+            }
             else if (pkg)
             {
                 ::error(loc, "can only import from a module, not from package %s.%s",

--- a/src/module.h
+++ b/src/module.h
@@ -32,9 +32,19 @@ union tree_node; typedef union tree_node elem;
 struct elem;
 #endif
 
+enum PKG
+{
+    PKGunknown, // not yet determined whether it's a package.d or not
+    PKGmodule,  // already determined that's an actual package.d
+    PKGpackage, // already determined that's an actual package
+};
+
 class Package : public ScopeDsymbol
 {
 public:
+    PKG isPkgMod;
+    Module *mod;        // != NULL if isPkgMod == PKGmodule
+
     Package(Identifier *ident);
     const char *kind();
 

--- a/test/compilable/extra-files/pkg/datetime/common.d
+++ b/test/compilable/extra-files/pkg/datetime/common.d
@@ -1,3 +1,0 @@
-module pkg.datetime.common;
-
-void def();

--- a/test/compilable/extra-files/pkg/datetime/package.d
+++ b/test/compilable/extra-files/pkg/datetime/package.d
@@ -1,3 +1,0 @@
-module pkg.datetime;
-public import pkg.datetime.common;
-//alias std.datetime.common.def def;

--- a/test/compilable/extra-files/pkgDIP37/datetime/common.d
+++ b/test/compilable/extra-files/pkgDIP37/datetime/common.d
@@ -1,0 +1,3 @@
+module pkgDIP37.datetime.common;
+
+void def();

--- a/test/compilable/extra-files/pkgDIP37/datetime/package.d
+++ b/test/compilable/extra-files/pkgDIP37/datetime/package.d
@@ -1,0 +1,3 @@
+module pkgDIP37.datetime;
+public import pkgDIP37.datetime.common;
+//alias std.datetime.common.def def;

--- a/test/compilable/extra-files/pkgDIP37_10302/liba.d
+++ b/test/compilable/extra-files/pkgDIP37_10302/liba.d
@@ -1,0 +1,2 @@
+module pkgDIP37_10302.liba;
+void foo() {}

--- a/test/compilable/extra-files/pkgDIP37_10302/libb.d
+++ b/test/compilable/extra-files/pkgDIP37_10302/libb.d
@@ -1,0 +1,11 @@
+module pkgDIP37_10302.libb;
+import pkgDIP37_10302.liba;
+void bar()
+{
+    foo();
+
+    // should be error, but unfortunately this works by bug 314 now.
+    //lib.foo();
+
+    pkgDIP37_10302.liba.foo();
+}

--- a/test/compilable/extra-files/pkgDIP37_10302/package.d
+++ b/test/compilable/extra-files/pkgDIP37_10302/package.d
@@ -1,0 +1,2 @@
+module pkgDIP37_10302;
+public import pkgDIP37_10302.liba;

--- a/test/compilable/testDIP37.d
+++ b/test/compilable/testDIP37.d
@@ -3,35 +3,34 @@
 
 void test1()
 {
-    import pkg.datetime;
+    import pkgDIP37.datetime;
     def();
-}
-
-void test2()
-{
-    import pkg.datetime;
-    def();
-    pkg.datetime.common.def();
-    pkg.datetime.def();
+    pkgDIP37.datetime.def();
+    pkgDIP37.datetime.common.def();
 }
 
 void test3()
 {
-    import pkg.datetime.common;
+    import pkgDIP37.datetime.common;
     def();
+    pkgDIP37.datetime.def();
+    pkgDIP37.datetime.common.def();
 }
 
 void test4()
 {
-    import pkg.datetime : def;
+    import pkgDIP37.datetime : def;
     def();
+    static assert(!__traits(compiles, pkgDIP37.datetime.def()));
+    static assert(!__traits(compiles, pkgDIP37.datetime.common.def()));
 }
 
 
 void test7()
 {
-    static import pkg.datetime;
+    static import pkgDIP37.datetime;
     static assert(!__traits(compiles, def()));
-    pkg.datetime.def();
+    pkgDIP37.datetime.def();
+    pkgDIP37.datetime.common.def();
 }
 

--- a/test/compilable/testDIP37_10302.d
+++ b/test/compilable/testDIP37_10302.d
@@ -1,0 +1,8 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: compilable/extra-files/pkgDIP37_10302/liba.d
+// REQUIRED_ARGS: compilable/extra-files/pkgDIP37_10302/libb.d
+
+module test;
+import pkgDIP37_10302;
+void main() {}

--- a/test/compilable/testDIP37a.d
+++ b/test/compilable/testDIP37a.d
@@ -1,0 +1,6 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -c -Icompilable/extra-files compilable/extra-files/pkgDIP37/datetime/package.d compilable/extra-files/pkgDIP37/datetime/common.d
+
+void main()
+{
+}

--- a/test/fail_compilation/test64.d
+++ b/test/fail_compilation/test64.d
@@ -1,3 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+Error: module imports from file fail_compilation/imports/test64a.d conflicts with package name imports
+---
+*/
+
 // PERMUTE_ARGS:
 
 import std.stdio;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10302

...and small fix up for #2139.

If the source tree is as follows:

```
pkg/
+ package.d
+ common.d
```

A package module will be incorporated to the internal package tree in two ways: `import pkg;` and `import pkg.common;`.

Current code considers either only one of them will occur. If both case occurs at the same time, like as `import pkg; import pkg.common;`, pkg as a `Module` and pkg as a `Package` will conflict each other.

To solve the problem, I added two fields `isPkgMod` and `mod` in `Package` class.
