### PR TITLE
Add no-op virtual destructor to Condition.

### DIFF
--- a/src/cond.h
+++ b/src/cond.h
@@ -33,6 +33,7 @@ public:
                         // 2: do not include
 
     Condition(Loc loc);
+    virtual ~Condition() {}
 
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc, ScopeDsymbol *s) = 0;


### PR DESCRIPTION
Silences GCC's "has virtual functions and accessible
non-virtual destructor" warning.
