### PR TITLE
fix Issue 10274 - DMD 2.063 produces broken binaries

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -502,8 +502,8 @@ void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset)
         buf->writeByte(REX | REX_W);
         buf->writeByte(LEA);
         buf->writeByte(modregrm(0,AX,5));
-        buf->write32(refOffset);
-        ElfObj::addrel(seg, codeOffset + 3, R_X86_64_PC32, 3 /*STI_DATA*/, -4);
+        buf->write32(0);
+        ElfObj::addrel(seg, codeOffset + 3, R_X86_64_PC32, 3 /*STI_DATA*/, refOffset - 4);
 
         // MOV RCX,_DmoduleRef@GOTPCREL[RIP]
         buf->writeByte(REX | REX_W);
@@ -518,8 +518,16 @@ void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset)
 
         /* movl ModuleReference*, %eax */
         buf->writeByte(0xB8);
-        buf->write32(refOffset);
-        ElfObj::addrel(seg, codeOffset + 1, reltype, 3 /*STI_DATA*/, 0);
+        if (I64)
+        {
+            buf->write32(0);
+            ElfObj::addrel(seg, codeOffset + 1, reltype, 3 /*STI_DATA*/, refOffset);
+        }
+        else
+        {
+            buf->write32(refOffset);
+            ElfObj::addrel(seg, codeOffset + 1, reltype, 3 /*STI_DATA*/, 0);
+        }
 
         /* movl _Dmodule_ref, %ecx */
         buf->writeByte(0xB9);


### PR DESCRIPTION
- Elf64 uses only the explicit addends of a relocation.
  It seems like ld.bfd still adds the value at the to be
  relocated address, but ld.gold does not.

It would make sense to always use explicit addends for Elf32 (Rela) too to avoid this bug.
Previous occurrence of this 5666e440bbee6b819c0de76a9583dc91313c8a56.

http://d.puremagic.com/issues/show_bug.cgi?id=10274
