### PR TITLE
10298 CTFE wrong code bug that Walter found

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3957,9 +3957,10 @@ Expression *BinExp::interpretAssignCommon(InterState *istate, CtfeGoal goal, fp_
         {
             Expressions *oldelems = existingAE->elements;
             Expressions *newelems = ((ArrayLiteralExp *)newval)->elements;
+            Type *elemtype = existingAE->type->nextOf();
             for (size_t j = 0; j < newelems->dim; j++)
             {
-                (*oldelems)[j + firstIndex] = (*newelems)[j];
+                (*oldelems)[j + firstIndex] = paintTypeOntoLiteral(elemtype, (*newelems)[j]);
             }
             return newval;
         }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4554,6 +4554,29 @@ int bug7940() {
 static assert(bug7940());
 
 /**************************************************
+    10298 wrong code for struct array literal init
+**************************************************/
+
+struct Bug10298 {
+    int m;
+}
+
+int bug10298()
+{
+    Bug10298[1] y = [Bug10298(78)];
+    y[0].m = 6;
+    assert(y[0].m == 6);
+
+    // Root cause
+    Bug10298[1] x;
+    x[] = [cast(const Bug10298)(Bug10298(78))];
+    assert(x[0].m == 78);
+    return 1;
+}
+
+static assert(bug10298());
+
+/**************************************************
     7266 dotvar ref parameters
 **************************************************/
 


### PR DESCRIPTION
This turned out to be a subtle bug in slice assignment from array literals. The types were wrong.

The elements in an array literal need to have constness implicitly cast away when they are being slice assigned.

http://d.puremagic.com/issues/show_bug.cgi?id=10298
