### PR TITLE
Revert "Merge pull request #1932 from 9rnsr/fix9987".

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -219,16 +219,11 @@ ClassDeclaration::ClassDeclaration(Loc loc, Identifier *id, BaseClasses *basecla
         }
 
 #if !MODULEINFO_IS_STRUCT
-  #ifdef DMDV2
-        if (id == Id::ModuleInfo && !Module::moduleinfo)
-            Module::moduleinfo = this;
-  #else
         if (id == Id::ModuleInfo)
         {   if (Module::moduleinfo)
                 Module::moduleinfo->error("%s", msg);
             Module::moduleinfo = this;
         }
-  #endif
 #endif
     }
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -437,16 +437,11 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
     type = new TypeStruct(this);
 
 #if MODULEINFO_IS_STRUCT
-  #ifdef DMDV2
-    if (id == Id::ModuleInfo && !Module::moduleinfo)
-        Module::moduleinfo = this;
-  #else
     if (id == Id::ModuleInfo)
     {   if (Module::moduleinfo)
             Module::moduleinfo->error("only object.d can define this reserved struct name");
         Module::moduleinfo = this;
     }
-  #endif
 #endif
 }
 

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -397,23 +397,3 @@ void test9348()
     assert(F!0 !is null);
     assert(F!0 !in [new Object():1]);
 }
-
-
-/***************************************************/
-// 9987
-
-static if (is(object.ModuleInfo == struct))
-{
-    struct ModuleInfo {}
-
-    static assert(!is(object.ModuleInfo == ModuleInfo));
-    static assert(object.ModuleInfo.sizeof != ModuleInfo.sizeof);
-}
-static if (is(object.ModuleInfo == class))
-{
-    class ModuleInfo {}
-
-    static assert(!is(object.ModuleInfo == ModuleInfo));
-    static assert(__traits(classInstanceSize, object.ModuleInfo) !=
-                  __traits(classInstanceSize, ModuleInfo));
-}


### PR DESCRIPTION
After the "fix", Module::moduleinfo might actually point to an
user-defined struct instead of object.ModuleInfo if the user
module is parsed first (e.g. because it is the root module).

An example for this is the added test case in compile1.d.
