### PR TITLE
Don't eagerly remove all catches if try body is empty.

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -710,6 +710,13 @@ Statement *CompoundStatement::semantic(Scope *sc)
                     }
                 }
             }
+            else
+            {
+                /* Remove NULL statements from the list.
+                 */
+                statements->remove(i);
+                continue;
+            }
         }
         i++;
     }
@@ -4520,8 +4527,9 @@ Statement *TryCatchStatement::syntaxCopy()
 Statement *TryCatchStatement::semantic(Scope *sc)
 {
     body = body->semanticScope(sc, NULL /*this*/, NULL);
+    assert(body);
 
-    /* Even if body is NULL, still do semantic analysis on catches
+    /* Even if body is empty, still do semantic analysis on catches
      */
     bool catchErrors = false;
     for (size_t i = 0; i < catches->dim; i++)
@@ -4548,16 +4556,8 @@ Statement *TryCatchStatement::semantic(Scope *sc)
     if (catchErrors)
         return new ErrorStatement();
 
-    if (!body)
-        return NULL;
-
     if (body->isErrorStatement())
         return body;
-
-    if (!body->hasCode())
-    {
-        return NULL;
-    }
 
     /* If the try body never throws, we can eliminate any catches
      * of recoverable exceptions.
@@ -4580,7 +4580,7 @@ Statement *TryCatchStatement::semantic(Scope *sc)
     }
 
     if (catches->dim == 0)
-        return body;
+        return body->hasCode() ? body : NULL;
 
     return this;
 }

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -580,7 +580,7 @@ void test9568()
 
 /****************************************************/
 
-void test8()
+void test8a()
 {
   int a;
   goto L2;    // L2 is not addressable.
@@ -588,12 +588,49 @@ void test8()
   try {
       a += 2;
   }
-  catch (Exception e) {
+  catch (Exception) {
       a += 3;
 L2: ;
       a += 100;
   }
   assert(a == 100);
+}
+
+void test8b()
+{
+  int a;
+  goto L2;    // L2 is not addressable.
+
+  try {
+  }
+  catch (Exception) {
+      a += 3;
+L2: ;
+      a += 100;
+  }
+  assert(a == 100);
+}
+
+void test8c()
+{
+  int a;
+  goto L2;    // L2 is not addressable.
+
+  try
+    static assert(true);
+  catch (Exception) {
+      a += 3;
+L2: ;
+      a += 100;
+  }
+  assert(a == 100);
+}
+
+void test8()
+{
+  test8a();
+  test8b();
+  test8c();
 }
 
 /****************************************************/


### PR DESCRIPTION
Stemmed from discussion here: http://forum.dlang.org/post/mailman.1094.1371164023.13711.digitalmars-d@puremagic.com

For now, allow the following code in the test suite to be compiled.  Required for gdc to scan for jumps into catch blocks that skip initialisation of exception pointers - also, code generated by dmd currently SEGV's during runtime in test8b and test8c.

All three tests currently fail in gdc with error "cannot goto into catch block", but may fix that at a later date depending on whether or not the code should be considered valid.
