### PR TITLE
[DDMD] Work around multiple-static-variable bug in dmd by removing the array

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3528,17 +3528,11 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
     }
     else if (ident == Id::sort && (n->ty == Tchar || n->ty == Twchar))
     {
-        Expression *ec;
-        FuncDeclaration *fd;
-        Expressions *arguments;
-        const char *nm;
-        static const char *name[2] = { "_adSortChar", "_adSortWchar" };
-
-        nm = name[n->ty == Twchar];
-        fd = FuncDeclaration::genCfunc(Type::tindex, nm);
-        ec = new VarExp(Loc(), fd);
+        const char *nm = n->ty == Twchar ? "_adSortWchar" : "_adSortChar";
+        FuncDeclaration *fd = FuncDeclaration::genCfunc(Type::tindex, nm);
+        Expression *ec = new VarExp(Loc(), fd);
         e = e->castTo(sc, n->arrayOf());        // convert to dynamic array
-        arguments = new Expressions();
+        Expressions *arguments = new Expressions();
         arguments->push(e);
         e = new CallExp(e->loc, ec, arguments);
         e->type = next->arrayOf();


### PR DESCRIPTION
Replace the variable 'name' with a ternary operator, and take the opportunity to move the variable declarations to the point of initialization.
