### PR TITLE
[DDMD] Mangle C++ contructors and destructors correctly

### DIFF
--- a/src/backend/newman.c
+++ b/src/backend/newman.c
@@ -1629,6 +1629,21 @@ STATIC void cpp_symbol_name(symbol *s)
         }
     }
 #endif
+#if MARS
+    if (tyfunc(s->Stype->Tty) && s->Sfunc)
+    {
+        if (s->Sfunc->Fflags & Fctor)
+        {
+            cpp_zname(cpp_name_ct);
+            return;
+        }
+        if (s->Sfunc->Fflags & Fdtor)
+        {
+            cpp_zname(cpp_name_dt);
+            return;
+        }
+    }
+#endif
     cpp_zname(p);
 }
 

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -427,6 +427,10 @@ Symbol *FuncDeclaration::toSymbol()
                         ::type *ts = sd->type->toCtype();
                         s->Sscope = ts->Ttag;
                     }
+                    if (isCtorDeclaration())
+                        s->Sfunc->Fflags |= Fctor;
+                    if (isDtorDeclaration())
+                        s->Sfunc->Fflags |= Fdtor;
                     break;
                 }
                 default:


### PR DESCRIPTION
Mangle contructors and destructors correctly when marked with `extern(C++)`
