### PR TITLE
[DDMD] Make Condition an Object

### DIFF
--- a/src/cond.h
+++ b/src/cond.h
@@ -33,7 +33,6 @@ public:
                         // 2: do not include
 
     Condition(Loc loc);
-    virtual ~Condition() {}
 
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc, ScopeDsymbol *s) = 0;


### PR DESCRIPTION
An alternative to adding a meanlingless virtual destructor is to make it inherit from Object, so it inherits Object's meanless virtual destructor.  It will end up a class in D, so this is cleaner.
