### PR TITLE
Avoid infinite recursion on StructLiteralExp::toChars().

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4705,7 +4705,21 @@ void StructLiteralExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring(sd->toChars());
     buf->writeByte('(');
-    argsToCBuffer(buf, elements, hgs);
+
+    // CTFE can generate struct literals that contain an AddrExp pointing
+    // to themselves, need to avoid infinite recursion:
+    // struct S { this(int){ this.s = &this; } S* s; }
+    // const foo = new S(0);
+    if (stageflags & stageToCBuffer)
+        buf->writestring("<recursion>");
+    else
+    {
+        int old = stageflags;
+        stageflags |= stageToCBuffer;
+        argsToCBuffer(buf, elements, hgs);
+        stageflags = old;
+    }
+
     buf->writeByte(')');
 }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -526,6 +526,8 @@ public:
 #define stageApply          0x8
 //inlineScan is running
 #define stageInlineScan     0x10
+// toCBuffer is running
+#define stageToCBuffer      0x20
 
 class StructLiteralExp : public Expression
 {

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3044,6 +3044,7 @@ const t109c = new Test109C();
 
 struct Test109S { this(int){ this.s = &this; } Test109S* s; }
 const t109s = new Test109S(0);
+pragma(msg, t109s); // Make sure there is no infinite recursion.
 
 void test109()
 {


### PR DESCRIPTION
This makes debugging of self-referential structs at least somewhat feasible.

http://d.puremagic.com/issues/show_bug.cgi?id=10389
