### PR TITLE
Lazy ident

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -520,6 +520,9 @@ void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset)
         buf->writeByte(0xB8);
         if (I64)
         {
+            // Elf64 uses only the explicit addends of a relocation.
+            // It seems like ld.bfd still adds the value at the to be relocated address,
+            // but ld.gold does not.
             buf->write32(0);
             ElfObj::addrel(seg, codeOffset + 1, reltype, 3 /*STI_DATA*/, refOffset);
         }

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -520,9 +520,6 @@ void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset)
         buf->writeByte(0xB8);
         if (I64)
         {
-            // Elf64 uses only the explicit addends of a relocation.
-            // It seems like ld.bfd still adds the value at the to be relocated address,
-            // but ld.gold does not.
             buf->write32(0);
             ElfObj::addrel(seg, codeOffset + 1, reltype, 3 /*STI_DATA*/, refOffset);
         }

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -176,6 +176,11 @@ void Dsymbol::setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool i
 {
 }
 
+Identifier *Dsymbol::getIdent()
+{
+    return ident;
+}
+
 char *Dsymbol::toChars()
 {
     return ident ? ident->toChars() : (char *)"__anonymous";

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -150,6 +150,7 @@ public:
 
     static Dsymbols *arraySyntaxCopy(Dsymbols *a);
 
+    virtual Identifier *getIdent();
     virtual const char *toPrettyChars();
     virtual const char *kind();
     virtual Dsymbol *toAlias();                 // resolve real symbol

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -46,7 +46,7 @@ char *mangle(Declaration *sthis, bool isv)
     do
     {
         //printf("mangle: s = %p, '%s', parent = %p\n", s, s->toChars(), s->parent);
-        if (s->ident)
+        if (s->getIdent())
         {
             FuncDeclaration *fd = s->isFuncDeclaration();
             if (s != sthis && fd)
@@ -174,8 +174,8 @@ const char *FuncDeclaration::mangle(bool isv)
 #endif
     {
         if (mangleOverride)
-            return mangleOverride; 
-    
+            return mangleOverride;
+
         if (isMain())
             return (char *)"_Dmain";
 
@@ -272,6 +272,7 @@ const char *TemplateInstance::mangle(bool isv)
         printf("  parent = %s %s", parent->kind(), parent->toChars());
     printf("\n");
 #endif
+    getIdent();
     const char *id = ident ? ident->toChars() : toChars();
     if (!tempdecl)
         error("is not defined");

--- a/src/template.c
+++ b/src/template.c
@@ -5109,7 +5109,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     parent = tempdecl->parent;
     //printf("parent = '%s'\n", parent->kind());
 
-    ident = genIdent(tiargs);         // need an identifier for name mangling purposes.
+    //getIdent();
 
 #if 1
     if (enclosing)
@@ -6202,6 +6202,17 @@ Identifier *TemplateInstance::genIdent(Objects *args)
     return Lexer::idPool(id);
 }
 
+/*************************************
+ * Lazily generate identifier for template instance.
+ * This is because 75% of the ident's are never needed.
+ */
+
+Identifier *TemplateInstance::getIdent()
+{
+    if (!ident && inst)
+        ident = genIdent(tiargs);         // need an identifier for name mangling purposes.
+    return ident;
+}
 
 /****************************************************
  * Declare parameters of template instance, initialize them with the

--- a/src/template.h
+++ b/src/template.h
@@ -339,6 +339,7 @@ public:
     char *toChars();
     const char *mangle(bool isv = false);
     void printInstantiationTrace();
+    Identifier *getIdent();
 
     void toObjFile(int multiobj);                       // compile to .obj file
 


### PR DESCRIPTION
This cuts generation of TemplateInstance::ident's down about 75% by doing it lazily.

Not a big improvement, but perceptible.
