### PR TITLE
Unresolved differences between gdc/dmd front ends

### DIFF
--- a/src/ddmd/clone.d
+++ b/src/ddmd/clone.d
@@ -636,7 +636,10 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     fop.generated = true;
     Expression e1 = new IdentifierExp(loc, Id.p);
     Expression e2 = new IdentifierExp(loc, Id.q);
-    Expression e = new CallExp(loc, new DotIdExp(loc, e2, Id.cmp), e1);
+    static if (IN_GCC)
+        Expression e = new CallExp(loc, new DotIdExp(loc, e1, Id.cmp), e2);
+    else
+        Expression e = new CallExp(loc, new DotIdExp(loc, e2, Id.cmp), e1);
     fop.fbody = new ReturnStatement(loc, e);
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();

--- a/src/ddmd/cppmangle.d
+++ b/src/ddmd/cppmangle.d
@@ -503,6 +503,19 @@ extern (C++) final class CppMangleVisitor : Visitor
                 td = new TypeDelegate(td);
                 t = t.merge();
             }
+            static if (IN_GCC)
+            {
+                // Could be a va_list, which we mangle as a pointer.
+                if (t.ty == Tsarray && Type.tvalist.ty == Tsarray)
+                {
+                    Type tb = t.toBasetype().mutableOf();
+                    if (tb == Type.tvalist)
+                    {
+                        tb = t.nextOf().pointerTo();
+                        t = tb.castMod(t.mod);
+                    }
+                }
+            }
             if (t.ty == Tsarray)
             {
                 // Mangle static arrays as pointers

--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -1475,8 +1475,8 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
              */
 
             // Fat Value types
-            const(bool) tob_isFV = (tob.ty == Tstruct || tob.ty == Tsarray);
-            const(bool) t1b_isFV = (t1b.ty == Tstruct || t1b.ty == Tsarray);
+            const(bool) tob_isFV = (tob.ty == Tstruct || tob.ty == Tsarray || tob.ty == Tvector);
+            const(bool) t1b_isFV = (t1b.ty == Tstruct || t1b.ty == Tsarray || t1b.ty == Tvector);
 
             // Fat Reference types
             const(bool) tob_isFR = (tob.ty == Tarray || tob.ty == Tdelegate);
@@ -1487,8 +1487,8 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             const(bool) t1b_isR = (t1b_isFR || t1b.ty == Tpointer || t1b.ty == Taarray || t1b.ty == Tclass);
 
             // Arithmetic types (== valueable basic types)
-            const(bool) tob_isA = (tob.isintegral() || tob.isfloating());
-            const(bool) t1b_isA = (t1b.isintegral() || t1b.isfloating());
+            const(bool) tob_isA = ((tob.isintegral() || tob.isfloating()) && tob.ty != Tvector);
+            const(bool) t1b_isA = ((t1b.isintegral() || t1b.isfloating()) && t1b.ty != Tvector);
 
             if (AggregateDeclaration t1ad = isAggregate(t1b))
             {

--- a/src/ddmd/dinterpret.d
+++ b/src/ddmd/dinterpret.d
@@ -666,6 +666,18 @@ public:
         // we can't compile asm statements
     }
 
+    static if (IN_GCC)
+    {
+        override void visit(ExtAsmStatement s)
+        {
+            debug (LOGCOMPILE)
+            {
+                printf("%s ExtAsmStatement::ctfeCompile\n", s.loc.toChars());
+            }
+            // we can't compile extended asm statements
+        }
+    }
+
     void ctfeCompile(Statement s)
     {
         s.accept(this);
@@ -1996,6 +2008,25 @@ public:
         }
         s.error("asm statements cannot be interpreted at compile time");
         result = CTFEExp.cantexp;
+    }
+
+    static if (IN_GCC)
+    {
+        override void visit(ExtAsmStatement s)
+        {
+            debug (LOG)
+            {
+                printf("%s ExtAsmStatement::interpret()\n", s.loc.toChars());
+            }
+            if (istate.start)
+            {
+                if (istate.start != s)
+                    return;
+                istate.start = null;
+            }
+            s.error("extended asm statements cannot be interpreted at compile time");
+            result = CTFEExp.cantexp;
+        }
     }
 
     override void visit(ImportStatement s)

--- a/src/ddmd/dsymbol.h
+++ b/src/ddmd/dsymbol.h
@@ -75,11 +75,11 @@ class Expression;
 class DeleteDeclaration;
 class OverloadSet;
 struct AA;
-#ifdef IN_GCC
+#ifdef IN_GCC	// %%
 typedef union tree_node Symbol;
-#else
+#else	// %%
 struct Symbol;
-#endif
+#endif	// %%
 
 struct Ungag
 {

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -49,11 +49,11 @@ class StringExp;
 class ArrayExp;
 class SliceExp;
 struct UnionExp;
-#ifdef IN_GCC
+#ifdef IN_GCC	// %%
 typedef union tree_node Symbol;
-#else
+#else	// %%
 struct Symbol;          // back end symbol
-#endif
+#endif	// %%
 
 Expression *resolveProperties(Scope *sc, Expression *e);
 Expression *resolvePropertiesOnly(Scope *sc, Expression *e1);

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -35,7 +35,6 @@ import ddmd.hdrgen;
 import ddmd.id;
 import ddmd.identifier;
 import ddmd.init;
-import ddmd.mars;
 import ddmd.mtype;
 import ddmd.nogc;
 import ddmd.objc;
@@ -49,6 +48,8 @@ import ddmd.statement;
 import ddmd.target;
 import ddmd.tokens;
 import ddmd.visitor;
+
+extern (C++) void genCmain(Scope* sc);
 
 /// Inline Status
 enum ILS : int

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -23,7 +23,7 @@ template xversion(string s)
     enum xversion = mixin(`{ version (` ~ s ~ `) return true; else return false; }`)();
 }
 
-enum IN_GCC     = xversion!`IN_GCC`;
+enum IN_GCC     = xversion!`IN_GCC`;  // %%
 
 enum TARGET_LINUX   = xversion!`linux`;
 enum TARGET_OSX     = xversion!`OSX`;

--- a/src/ddmd/gluelayer.d
+++ b/src/ddmd/gluelayer.d
@@ -53,6 +53,24 @@ version (NoBackend)
         void objc_initSymbols() {}
     }
 }
+else version (IN_GCC)
+{
+    union tree_node;
+
+    alias Symbol = tree_node;
+    alias code = tree_node;
+    alias type = tree_node;
+
+    // d-frontend.cc
+    extern (C++)
+    {
+        RET retStyle(TypeFunction tf);
+        Statement asmSemantic(AsmStatement s, Scope* sc);
+    }
+
+    // stubs
+    void objc_initSymbols() { }
+}
 else
 {
     import ddmd.lib : Library;

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -685,6 +685,67 @@ public:
         buf.writenl();
     }
 
+    static if (IN_GCC)
+    {
+        override void visit(ExtAsmStatement s)
+        {
+            buf.writestring ("gcc asm { ");
+
+            if (s.insn)
+                buf.writestring (s.insn.toChars());
+
+            buf.writestring (" : ");
+
+            if (s.args)
+            {
+                for (size_t i = 0; i < s.args.dim; i++)
+                {
+                    Identifier name = (*s.names)[i];
+                    Expression constr = (*s.constraints)[i];
+                    Expression arg = (*s.args)[i];
+
+                    if (name)
+                    {
+                        buf.writestring ("[");
+                        buf.writestring (name.toChars());
+                        buf.writestring ("] ");
+                    }
+
+                    if (constr)
+                    {
+                        buf.writestring (constr.toChars());
+                        buf.writestring (" ");
+                    }
+
+                    if (arg)
+                        buf.writestring (arg.toChars());
+
+                    if (i < s.outputargs - 1)
+                        buf.writestring (", ");
+                    else if (i == s.outputargs - 1)
+                        buf.writestring (" : ");
+                    else if (i < s.args.dim - 1)
+                        buf.writestring (", ");
+                }
+            }
+
+            if (s.clobbers)
+            {
+                buf.writestring (" : ");
+                for (size_t i = 0; i < s.clobbers.dim; i++)
+                {
+                    Expression clobber = (*s.clobbers)[i];
+                    buf.writestring (clobber.toChars());
+                    if (i < s.clobbers.dim - 1)
+                        buf.writestring (", ");
+                }
+            }
+
+            buf.writestring ("; }");
+            buf.writenl();
+        }
+    }
+
     override void visit(ImportStatement s)
     {
         foreach (imp; *s.imports)

--- a/src/ddmd/id.d
+++ b/src/ddmd/id.d
@@ -34,7 +34,7 @@ struct Id
      * An identifier that corresponds to each static field in this struct will
      * be placed in the identifier pool.
      */
-    void initialize()
+    extern (C++) void initialize()
     {
         mixin(msgtable.generate(&initializer));
     }

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -2863,11 +2863,11 @@ extern (C++) abstract class Type : RootObject
         assert(0 < length && length < namelen); // don't overflow the buffer
 
         int off = 0;
-        static if (!IN_GCC)
+        static if (!IN_GCC) // %%
         {
             if (global.params.isOSX || global.params.isWindows && !global.params.is64bit)
                 ++off; // C mangling will add '_' back in
-        }
+        }   // %%
         auto id = Identifier.idPool(name + off, length - off);
 
         if (name != namebuf.ptr)

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -4531,8 +4531,22 @@ extern (C++) final class TypeVector : Type
         //printf("TypeVector::implicitConvTo(%s) from %s\n", to.toChars(), toChars());
         if (this == to)
             return MATCHexact;
-        if (ty == to.ty)
-            return MATCHconvert;
+        if (to.ty == Tvector)
+        {
+            TypeVector tv = cast(TypeVector)to;
+            assert(basetype.ty == Tsarray && tv.basetype.ty == Tsarray);
+
+            // Can't convert to a vector which has different size.
+            if (basetype.size() != tv.basetype.size())
+                return MATCHnomatch;
+
+            // Allow conversion to void[]
+            if (tv.basetype.nextOf().ty == Tvoid)
+                return MATCHconvert;
+
+            // Otherwise implicitly convertible only if basetypes are.
+            return basetype.implicitConvTo(tv.basetype);
+        }
         return MATCHnomatch;
     }
 

--- a/src/ddmd/mtype.h
+++ b/src/ddmd/mtype.h
@@ -40,11 +40,11 @@ class TypeBasic;
 class Parameter;
 
 // Back end
-#ifdef IN_GCC
+#ifdef IN_GCC   // %%
 typedef union tree_node type;
-#else
+#else   // %%
 typedef struct TYPE type;
-#endif
+#endif  // %%
 
 void semanticTypeInfo(Scope *sc, Type *t);
 MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL, size_t inferStart = 0);

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -5973,6 +5973,20 @@ final class Parser(AST) : Lexer
                         error("matching `}` expected, not end of file");
                         goto Lerror;
 
+                static if (IN_GCC)
+                {
+                    case TOKlparen:
+                    case TOKstring:
+                        // If the first token is a string or '(', parse as extended asm.
+                        if (!toklist)
+                        {
+                            s = parseExtAsm(stc);
+                            statements.push(s);
+                            continue;
+                        }
+                        goto Ldefault;
+                }
+
                     default:
                     Ldefault:
                         *ptoklist = Token.alloc();
@@ -6017,6 +6031,228 @@ final class Parser(AST) : Lexer
         if (pEndloc)
             *pEndloc = token.loc;
         return s;
+    }
+
+    static if (IN_GCC)
+    {
+        /***********************************
+         * Parse list of extended asm input or output operands.
+         * ExtAsmOperand:
+         *     [Identifier] StringLiteral (Identifier), ...
+         */
+        int parseExtAsmOperands(AST.Expressions* args, AST.Identifiers* names, AST.Expressions* constraints)
+        {
+            int numargs = 0;
+
+            while (1)
+            {
+                AST.Expression arg;
+                Identifier name;
+                AST.Expression constraint;
+
+                switch (token.value)
+                {
+                    case TOKsemicolon:
+                    case TOKcolon:
+                    case TOKeof:
+                        return numargs;
+
+                    case TOKlbracket:
+                        nextToken();
+                        if (token.value == TOKidentifier)
+                        {
+                            name = token.ident;
+                            nextToken();
+                        }
+                        else
+                        {
+                            error("expected identifier after '['");
+                            return numargs;
+                        }
+                        check(TOKrbracket);
+                        // fall through
+
+                    default:
+                        constraint = parsePrimaryExp();
+                        if (constraint.op != TOKstring)
+                        {
+                            error(constraint.loc, "expected constant string constraint for operand, not '%s'", constraint.toChars());
+                            goto Lerror;
+                        }
+                        arg = parseAssignExp();
+
+                        args.push(arg);
+                        names.push(name);
+                        constraints.push(constraint);
+                        numargs++;
+
+                        if (token.value == TOKcomma)
+                            nextToken();
+                        break;
+
+                }
+            }
+        Lerror:
+            while (token.value != TOKrcurly &&
+                   token.value != TOKsemicolon &&
+                   token.value != TOKeof)
+                nextToken();
+
+            return numargs;
+        }
+
+        /***********************************
+         * Parse list of extended asm clobbers.
+         * ExtAsmClobbers:
+         *     StringLiteral, ...
+         */
+        AST.Expressions *parseExtAsmClobbers()
+        {
+            AST.Expressions *clobbers;
+
+            while (1)
+            {
+                AST.Expression clobber;
+
+                switch (token.value)
+                {
+                    case TOKsemicolon:
+                    case TOKcolon:
+                    case TOKeof:
+                        return clobbers;
+
+                    case TOKstring:
+                        clobber = parseAssignExp();
+                        if (!clobbers)
+                            clobbers = new AST.Expressions();
+                        clobbers.push(clobber);
+
+                        if (token.value == TOKcomma)
+                            nextToken();
+                        break;
+
+                    default:
+                        error("expected constant string constraint for clobber name, not '%s'", token.toChars());
+                        goto Lerror;
+                }
+            }
+        Lerror:
+            while (token.value != TOKrcurly &&
+                   token.value != TOKsemicolon &&
+                   token.value != TOKeof)
+                nextToken();
+
+            return clobbers;
+        }
+
+        /***********************************
+         * Parse list of extended asm goto labels.
+         * ExtAsmGotoLabels:
+         *     Identifier, ...
+         */
+        AST.Identifiers *parseExtAsmGotoLabels()
+        {
+            AST.Identifiers *labels;
+
+            while (1)
+            {
+                switch (token.value)
+                {
+                    case TOKsemicolon:
+                    case TOKeof:
+                        return labels;
+
+                    case TOKidentifier:
+                        if (!labels)
+                            labels = new AST.Identifiers();
+                        labels.push(token.ident);
+
+                        if (nextToken() == TOKcomma)
+                            nextToken();
+                        break;
+
+                    default:
+                        error("expected identifier for goto label name, not '%s'", token.toChars());
+                        goto Lerror;
+                }
+            }
+        Lerror:
+            while (token.value != TOKrcurly &&
+                   token.value != TOKsemicolon &&
+                   token.value != TOKeof)
+                nextToken();
+
+            return labels;
+        }
+
+        /***********************************
+         * Parse an extended asm statement.
+         * ExtAsmStatement:
+         *     asm { StringLiterals [ : InputOperands [ : OutputOperands [ : Clobbers [ : GotoLabels ] ] ] ] }
+         */
+
+        AST.Statement parseExtAsm(StorageClass stc)
+        {
+            AST.Expressions *args;
+            AST.Identifiers *names;
+            AST.Expressions *constraints;
+            int outputargs = 0;
+            AST.Expressions *clobbers;
+            AST.Identifiers *labels;
+            Loc loc = token.loc;
+
+            AST.Expression insn = parseExpression();
+            if (token.value == TOKsemicolon)
+                goto Ldone;
+
+            for (int section = 0; section < 4; ++section)
+            {
+                check(TOKcolon);
+
+                final switch (section)
+                {
+                    case 0:
+                        if (!args)
+                        {
+                            args = new AST.Expressions();
+                            constraints = new AST.Expressions();
+                            names = new AST.Identifiers();
+                        }
+                        outputargs = parseExtAsmOperands(args, names, constraints);
+                        break;
+
+                    case 1:
+                        parseExtAsmOperands(args, names, constraints);
+                        break;
+
+                    case 2:
+                        clobbers = parseExtAsmClobbers();
+                        break;
+
+                    case 3:
+                        labels = parseExtAsmGotoLabels();
+                        break;
+                }
+
+                switch (token.value)
+                {
+                    case TOKsemicolon:
+                        goto Ldone;
+
+                    case TOKeof:
+                        error("matching '}' expected, not end of file");
+                        goto Ldone;
+
+                    default:
+                        continue;
+                }
+            }
+        Ldone:
+            check(TOKsemicolon);
+
+            return new AST.ExtAsmStatement(loc, stc, insn, args, names,
+                                           constraints, outputargs, clobbers, labels);
+        }
     }
 
     /*****************************************

--- a/src/ddmd/statement.h
+++ b/src/ddmd/statement.h
@@ -707,4 +707,27 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+#ifdef IN_GCC
+
+// Assembler instructions with D expression operands
+class ExtAsmStatement : public Statement
+{
+public:
+    StorageClass stc;
+    Expression *insn;
+    Expressions *args;
+    Identifiers *names;
+    Expressions *constraints;   // Array of StringExp's
+    unsigned outputargs;
+    Expressions *clobbers;      // Array of StringExp's
+    Identifiers *labels;
+    GotoStatements *gotos;
+
+    Statement *syntaxCopy();
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+#endif
+
 #endif /* DMD_STATEMENT_H */

--- a/src/ddmd/statement_rewrite_walker.d
+++ b/src/ddmd/statement_rewrite_walker.d
@@ -14,6 +14,7 @@ module ddmd.statement_rewrite_walker;
 
 import core.stdc.stdio;
 
+import ddmd.globals;
 import ddmd.statement;
 import ddmd.visitor;
 
@@ -259,6 +260,13 @@ public:
 
     override void visit(AsmStatement s)
     {
+    }
+
+    static if (IN_GCC)
+    {
+        override void visit(ExtAsmStatement s)
+        {
+        }
     }
 
     override void visit(ImportStatement s)

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -3572,7 +3572,7 @@ else
 
     override void visit(OnScopeStatement oss)
     {
-        static if (!IN_GCC)
+        static if (!IN_GCC) // %%
         {
             if (oss.tok != TOKon_scope_exit)
             {
@@ -3591,7 +3591,7 @@ else
                     return setError();
                 }
             }
-        }
+        }   // %%
 
         sc = sc.push();
         sc.tf = null;
@@ -3855,7 +3855,7 @@ void semantic(Catch c, Scope* sc)
 {
     //printf("Catch::semantic(%s)\n", ident.toChars());
 
-    static if (!IN_GCC)
+    static if (!IN_GCC) // %%
     {
         if (sc.os && sc.os.tok != TOKon_scope_failure)
         {
@@ -3874,7 +3874,7 @@ void semantic(Catch c, Scope* sc)
             error(c.loc, "cannot put catch statement inside finally block");
             c.errors = true;
         }
-    }
+    }   // %%
 
     auto sym = new ScopeDsymbol();
     sym.parent = sc.scopesym;

--- a/src/ddmd/visitor.d
+++ b/src/ddmd/visitor.d
@@ -28,6 +28,7 @@ import ddmd.dtemplate;
 import ddmd.dversion;
 import ddmd.expression;
 import ddmd.func;
+import ddmd.globals;
 import ddmd.init;
 import ddmd.mtype;
 import ddmd.nspace;
@@ -242,6 +243,14 @@ extern (C++) class Visitor
     void visit(AsmStatement s)
     {
         visit(cast(Statement)s);
+    }
+
+    static if (IN_GCC)
+    {
+        void visit(ExtAsmStatement s)
+        {
+            visit(cast(Statement)s);
+        }
     }
 
     void visit(CompoundAsmStatement s)

--- a/src/ddmd/visitor.h
+++ b/src/ddmd/visitor.h
@@ -54,6 +54,9 @@ class DebugStatement;
 class GotoStatement;
 class LabelStatement;
 class AsmStatement;
+#ifdef IN_GCC
+class ExtAsmStatement;
+#endif
 class CompoundAsmStatement;
 class ImportStatement;
 
@@ -343,6 +346,9 @@ public:
     virtual void visit(GotoStatement *s) { visit((Statement *)s); }
     virtual void visit(LabelStatement *s) { visit((Statement *)s); }
     virtual void visit(AsmStatement *s) { visit((Statement *)s); }
+#ifdef IN_GCC
+    virtual void visit(ExtAsmStatement *s) { visit((Statement *)s); }
+#endif
     virtual void visit(CompoundAsmStatement *s) { visit((CompoundStatement *)s); }
     virtual void visit(ImportStatement *s) { visit((Statement *)s); }
 


### PR DESCRIPTION
I recall mentioning this in one of the DDMD pulls.  FYI @yebblies

This covers all current unresolved differences between gdc and dmd front ends  (and acts as a TODO list).  An internal goal is to have them 100% shared code bases by release 2.065.  This makes a transition from the D front-end implement from C++ to D more of a 'drop in' (and is arguably a blocker and hindrance for adoption of the new implementation),  and also relieves a _HUGE_ maintenance burden when it comes round to merge-time.  However such a goal requires a bit of tug and pull from both sides of the fence so I'm raising this here to allow discussion with any core devs to iron these out in a way that we can say good riddance to the IN_GCC macro.

The diff can be summarised into the following points:
- Internal backend types differ
- Differing `_argptr` and `_arguments` front end implementation.
- Always use Itanium ABI for C++ mangling
- Support for GDC Extended Assembly in parser.
- Rejected/not yet pulled fixes for things done in the front end that send invalid/garbage code to the glue part of the front-end.

@yebblies - or anyone else - if you have any questions or suggestions, anything is welcome.  Also let me know if you'd rather this broken down... :o)

Will be sending separate pulls for things that can be folded in immediately...

Thanks
Iain.
