### PR TITLE
Use isWindows to determine correct system linkage.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -993,11 +993,7 @@ LINK Parser::parseLinkage()
         }
         else if (id == Id::System)
         {
-#if _WIN32
-            link = LINKwindows;
-#else
-            link = LINKc;
-#endif
+            link = global.params.isWindows ? LINKwindows : LINKc;
         }
         else
         {


### PR DESCRIPTION
One more host macro down, and another fix for cross compilers.
