### PR TITLE
[DDMD] Rename Object to _Object

### DIFF
--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -30,7 +30,7 @@ typedef Array<class ClassDeclaration> ClassDeclarations;
 
 typedef Array<class Dsymbol> Dsymbols;
 
-typedef Array<class Object> Objects;
+typedef Array<class RootObject> Objects;
 
 typedef Array<class FuncDeclaration> FuncDeclarations;
 

--- a/src/canthrow.c
+++ b/src/canthrow.c
@@ -175,7 +175,7 @@ int Dsymbol_canThrow(Dsymbol *s, bool mustNotThrow)
     else if ((td = s->isTupleDeclaration()) != NULL)
     {
         for (size_t i = 0; i < td->objects->dim; i++)
-        {   Object *o = (*td->objects)[i];
+        {   RootObject *o = (*td->objects)[i];
             if (o->dyncast() == DYNCAST_EXPRESSION)
             {   Expression *eo = (Expression *)o;
                 if (eo->op == TOKdsymbol)

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -212,7 +212,7 @@ Type *TupleDeclaration::getType()
         /* It's only a type tuple if all the Object's are types
          */
         for (size_t i = 0; i < objects->dim; i++)
-        {   Object *o = (*objects)[i];
+        {   RootObject *o = (*objects)[i];
 
             if (o->dyncast() != DYNCAST_TYPE)
             {
@@ -257,7 +257,7 @@ bool TupleDeclaration::needThis()
 {
     //printf("TupleDeclaration::needThis(%s)\n", toChars());
     for (size_t i = 0; i < objects->dim; i++)
-    {   Object *o = (*objects)[i];
+    {   RootObject *o = (*objects)[i];
         if (o->dyncast() == DYNCAST_EXPRESSION)
         {   Expression *e = (Expression *)o;
             if (e->op == TOKdsymbol)
@@ -1803,7 +1803,7 @@ void VarDeclaration::setFieldOffset(AggregateDeclaration *ad, unsigned *poffset,
         TupleDeclaration *v2 = aliassym->isTupleDeclaration();
         assert(v2);
         for (size_t i = 0; i < v2->objects->dim; i++)
-        {   Object *o = (*v2->objects)[i];
+        {   RootObject *o = (*v2->objects)[i];
             assert(o->dyncast() == DYNCAST_EXPRESSION);
             Expression *e = (Expression *)o;
             assert(e->op == TOKdsymbol);

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -659,7 +659,7 @@ public:
     bool functionSemantic3();
     // called from semantic3
     VarDeclaration *declareThis(Scope *sc, AggregateDeclaration *ad);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
 
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void bodyToCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -70,7 +70,7 @@ Dsymbol::Dsymbol(Identifier *ident)
     this->unittest = NULL;
 }
 
-bool Dsymbol::equals(Object *o)
+bool Dsymbol::equals(RootObject *o)
 {
     if (this == o)
         return true;
@@ -424,7 +424,7 @@ Dsymbol *Dsymbol::search_correct(Identifier *ident)
  *      symbol found, NULL if not
  */
 
-Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, Object *id)
+Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
 {
     //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident->toChars());
     Dsymbol *s = toAlias();

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -110,7 +110,7 @@ enum PASS
 
 typedef int (*Dsymbol_apply_ft_t)(Dsymbol *, void *);
 
-class Dsymbol : public Object
+class Dsymbol : public RootObject
 {
 public:
     Identifier *ident;
@@ -130,7 +130,7 @@ public:
     char *toChars();
     Loc& getLoc();
     char *locToChars();
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     bool isAnonymous();
     void error(Loc loc, const char *format, ...);
     void error(const char *format, ...);
@@ -164,7 +164,7 @@ public:
     virtual void inlineScan();
     virtual Dsymbol *search(Loc loc, Identifier *ident, int flags);
     Dsymbol *search_correct(Identifier *id);
-    Dsymbol *searchX(Loc loc, Scope *sc, Object *id);
+    Dsymbol *searchX(Loc loc, Scope *sc, RootObject *id);
     virtual bool overloadInsert(Dsymbol *s);
     virtual void toHBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -341,7 +341,7 @@ public:
 
 // Table of Dsymbol's
 
-class DsymbolTable : public Object
+class DsymbolTable : public RootObject
 {
 public:
     AA *tab;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1311,7 +1311,7 @@ elem *Dsymbol_toElem(Dsymbol *s, IRState *irs)
     else if ((td = s->isTupleDeclaration()) != NULL)
     {
         for (size_t i = 0; i < td->objects->dim; i++)
-        {   Object *o = (*td->objects)[i];
+        {   RootObject *o = (*td->objects)[i];
             if (o->dyncast() == DYNCAST_EXPRESSION)
             {   Expression *eo = (Expression *)o;
                 if (eo->op == TOKdsymbol)

--- a/src/expression.c
+++ b/src/expression.c
@@ -2546,7 +2546,7 @@ IntegerExp::IntegerExp(dinteger_t value)
     this->value = value;
 }
 
-bool IntegerExp::equals(Object *o)
+bool IntegerExp::equals(RootObject *o)
 {
     if (this == o)
         return true;
@@ -2921,7 +2921,7 @@ int RealEquals(real_t x1, real_t x2)
         memcmp(&x1, &x2, Target::realsize - Target::realpad) == 0;
 }
 
-bool RealExp::equals(Object *o)
+bool RealExp::equals(RootObject *o)
 {
     if (this == o)
         return true;
@@ -3114,7 +3114,7 @@ complex_t ComplexExp::toComplex()
     return value;
 }
 
-bool ComplexExp::equals(Object *o)
+bool ComplexExp::equals(RootObject *o)
 {
     if (this == o)
         return true;
@@ -3770,7 +3770,7 @@ NullExp::NullExp(Loc loc, Type *type)
     this->type = type;
 }
 
-bool NullExp::equals(Object *o)
+bool NullExp::equals(RootObject *o)
 {
     if (o && o->dyncast() == DYNCAST_EXPRESSION)
     {
@@ -3861,7 +3861,7 @@ Expression *StringExp::syntaxCopy()
 }
 #endif
 
-bool StringExp::equals(Object *o)
+bool StringExp::equals(RootObject *o)
 {
     //printf("StringExp::equals('%s') %s\n", o->toChars(), toChars());
     if (o && o->dyncast() == DYNCAST_EXPRESSION)
@@ -4021,7 +4021,7 @@ StringExp *StringExp::toUTF8(Scope *sc)
     return this;
 }
 
-int StringExp::compare(Object *obj)
+int StringExp::compare(RootObject *obj)
 {
     //printf("StringExp::compare()\n");
     // Used to sort case statement expressions so we can do an efficient lookup
@@ -4445,7 +4445,7 @@ StructLiteralExp::StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *
     //printf("StructLiteralExp::StructLiteralExp(%s)\n", toChars());
 }
 
-bool StructLiteralExp::equals(Object *o)
+bool StructLiteralExp::equals(RootObject *o)
 {
     if (this == o)
         return true;
@@ -5495,7 +5495,7 @@ VarExp::VarExp(Loc loc, Declaration *var, bool hasOverloads)
     this->type = var->type;
 }
 
-bool VarExp::equals(Object *o)
+bool VarExp::equals(RootObject *o)
 {
     if (this == o)
         return true;
@@ -5681,7 +5681,7 @@ TupleExp::TupleExp(Loc loc, TupleDeclaration *tup)
 
     this->exps->reserve(tup->objects->dim);
     for (size_t i = 0; i < tup->objects->dim; i++)
-    {   Object *o = (*tup->objects)[i];
+    {   RootObject *o = (*tup->objects)[i];
         if (Dsymbol *s = getDsymbol(o))
         {
             /* If tuple element represents a symbol, translate to DsymbolExp
@@ -5708,7 +5708,7 @@ TupleExp::TupleExp(Loc loc, TupleDeclaration *tup)
     }
 }
 
-bool TupleExp::equals(Object *o)
+bool TupleExp::equals(RootObject *o)
 {
     if (this == o)
         return true;
@@ -6114,7 +6114,7 @@ void DeclarationExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
  *      typeid(int)
  */
 
-TypeidExp::TypeidExp(Loc loc, Object *o)
+TypeidExp::TypeidExp(Loc loc, RootObject *o)
     : Expression(loc, TOKtypeid, sizeof(TypeidExp))
 {
     this->obj = o;
@@ -6220,7 +6220,7 @@ void TraitsExp::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
         for (size_t i = 0; i < args->dim; i++)
         {
             buf->writestring(", ");;
-            Object *oarg = (*args)[i];
+            RootObject *oarg = (*args)[i];
             ObjectToCBuffer(buf, hgs, oarg);
         }
     }
@@ -7600,7 +7600,7 @@ Expression *DotVarExp::semantic(Scope *sc)
 
             exps->reserve(tup->objects->dim);
             for (size_t i = 0; i < tup->objects->dim; i++)
-            {   Object *o = (*tup->objects)[i];
+            {   RootObject *o = (*tup->objects)[i];
                 Expression *e;
                 if (o->dyncast() == DYNCAST_EXPRESSION)
                 {
@@ -8415,7 +8415,7 @@ Lagain:
     if (tiargs && tiargs->dim)
     {
         for (size_t k = 0; k < tiargs->dim; k++)
-        {   Object *o = (*tiargs)[k];
+        {   RootObject *o = (*tiargs)[k];
             if (isError(o))
                 return new ErrorExp();
         }

--- a/src/expression.h
+++ b/src/expression.h
@@ -113,7 +113,7 @@ enum CtfeGoal
 // Same as WANTvalue, but also expand variables as far as possible
 #define WANTexpand  8
 
-class Expression : public Object
+class Expression : public RootObject
 {
 public:
     Loc loc;                    // file location
@@ -227,7 +227,7 @@ public:
 
     IntegerExp(Loc loc, dinteger_t value, Type *type);
     IntegerExp(dinteger_t value);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     char *toChars();
@@ -264,7 +264,7 @@ public:
     real_t value;
 
     RealExp(Loc loc, real_t value, Type *type);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     char *toChars();
@@ -288,7 +288,7 @@ public:
     complex_t value;
 
     ComplexExp(Loc loc, complex_t value, Type *type);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     char *toChars();
@@ -380,7 +380,7 @@ public:
     unsigned char committed;    // !=0 if type is committed
 
     NullExp(Loc loc, Type *t = NULL);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     int isBool(int result);
     int isConst();
@@ -408,7 +408,7 @@ public:
     StringExp(Loc loc, void *s, size_t len);
     StringExp(Loc loc, void *s, size_t len, unsigned char postfix);
     //Expression *syntaxCopy();
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     size_t length();
@@ -417,7 +417,7 @@ public:
     Expression *implicitCastTo(Scope *sc, Type *t);
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
-    int compare(Object *obj);
+    int compare(RootObject *obj);
     int isBool(int result);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -449,7 +449,7 @@ public:
     TupleExp(Loc loc, TupleDeclaration *tup);
     Expression *syntaxCopy();
     int apply(apply_fp_t fp, void *param);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void checkEscape();
@@ -556,7 +556,7 @@ public:
                                   // (with infinite recursion) of this expression.
 
     StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *elements, Type *stype = NULL);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Expression *syntaxCopy();
     int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
@@ -706,7 +706,7 @@ class VarExp : public SymbolExp
 {
 public:
     VarExp(Loc loc, Declaration *var, bool hasOverloads = false);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result, bool keepLvalue = false);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
@@ -790,9 +790,9 @@ public:
 class TypeidExp : public Expression
 {
 public:
-    Object *obj;
+    RootObject *obj;
 
-    TypeidExp(Loc loc, Object *obj);
+    TypeidExp(Loc loc, RootObject *obj);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/func.c
+++ b/src/func.c
@@ -1921,7 +1921,7 @@ VarDeclaration *FuncDeclaration::declareThis(Scope *sc, AggregateDeclaration *ad
     return NULL;
 }
 
-bool FuncDeclaration::equals(Object *o)
+bool FuncDeclaration::equals(RootObject *o)
 {
     if (this == o)
         return true;

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2306,7 +2306,7 @@ ILLEGAL_ADDRESS_ERROR:
                 error(asmstate.loc, "tuple index %u exceeds length %u", index, tup->objects->dim);
             else
             {
-                Object *o = (*tup->objects)[index];
+                RootObject *o = (*tup->objects)[index];
                 if (o->dyncast() == DYNCAST_DSYMBOL)
                 {   o1->s = (Dsymbol *)o;
                     return o1;

--- a/src/identifier.c
+++ b/src/identifier.c
@@ -30,12 +30,12 @@ hash_t Identifier::hashCode()
     return String::calcHash(string);
 }
 
-bool Identifier::equals(Object *o)
+bool Identifier::equals(RootObject *o)
 {
     return this == o || memcmp(string,o->toChars(),len+1) == 0;
 }
 
-int Identifier::compare(Object *o)
+int Identifier::compare(RootObject *o)
 {
     return memcmp(string, o->toChars(), len + 1);
 }

--- a/src/identifier.h
+++ b/src/identifier.h
@@ -17,7 +17,7 @@
 
 #include "root.h"
 
-class Identifier : public Object
+class Identifier : public RootObject
 {
 public:
     int value;
@@ -25,9 +25,9 @@ public:
     size_t len;
 
     Identifier(const char *string, int value);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     hash_t hashCode();
-    int compare(Object *o);
+    int compare(RootObject *o);
     void print();
     char *toChars();
     const char *toHChars2();

--- a/src/init.h
+++ b/src/init.h
@@ -31,7 +31,7 @@ struct HdrGenState;
 
 enum NeedInterpret { INITnointerpret, INITinterpret };
 
-class Initializer : public Object
+class Initializer : public RootObject
 {
 public:
     Loc loc;

--- a/src/inline.c
+++ b/src/inline.c
@@ -280,7 +280,7 @@ int DeclarationExp::inlineCost3(InlineCostState *ics)
             return COST_MAX;    // finish DeclarationExp::doInline
 #else
             for (size_t i = 0; i < td->objects->dim; i++)
-            {   Object *o = (*td->objects)[i];
+            {   RootObject *o = (*td->objects)[i];
                 if (o->dyncast() != DYNCAST_EXPRESSION)
                     return COST_MAX;
                 Expression *eo = (Expression *)o;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -322,7 +322,7 @@ int CompiledCtfeFunction::walkAllVars(Expression *e, void *_this)
                 return 0;
             for(size_t i= 0; i < td->objects->dim; ++i)
             {
-                Object * o = td->objects->tdata()[i];
+                RootObject *o = td->objects->tdata()[i];
                 Expression *ex = isExpression(o);
                 DsymbolExp *s = (ex && ex->op == TOKdsymbol) ? (DsymbolExp *)ex : NULL;
                 assert(s);
@@ -2306,7 +2306,7 @@ Expression *DeclarationExp::interpret(InterState *istate, CtfeGoal goal)
                 return NULL;
             for(size_t i= 0; i < td->objects->dim; ++i)
             {
-                Object * o = (*td->objects)[i];
+                RootObject * o = (*td->objects)[i];
                 Expression *ex = isExpression(o);
                 DsymbolExp *s = (ex && ex->op == TOKdsymbol) ? (DsymbolExp *)ex : NULL;
                 VarDeclaration *v2 = s ? s->s->isVarDeclaration() : NULL;

--- a/src/json.c
+++ b/src/json.c
@@ -544,7 +544,7 @@ void TypeQualified::toJson(JsonOut *json) // ident.ident.ident.etc
     json->arrayStart();
 
     for (size_t i = 0; i < idents.dim; i++)
-    {   Object *ident = idents[i];
+    {   RootObject *ident = idents[i];
         json->item(ident->toChars());
     }
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -162,7 +162,7 @@ Type *Type::syntaxCopy()
     return this;
 }
 
-bool Type::equals(Object *o)
+bool Type::equals(RootObject *o)
 {
     Type *t = (Type *)o;
     //printf("Type::equals(%s, %s)\n", toChars(), t->toChars());
@@ -3725,7 +3725,7 @@ void TypeSArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
             {   error(loc, "tuple index %llu exceeds length %u", d, td->objects->dim);
                 goto Ldefault;
             }
-            Object *o = (*td->objects)[(size_t)d];
+            RootObject *o = (*td->objects)[(size_t)d];
             if (o->dyncast() == DYNCAST_DSYMBOL)
             {
                 *ps = (Dsymbol *)o;
@@ -3794,7 +3794,7 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
         {   error(loc, "tuple index %llu exceeds %u", d, sd->objects->dim);
             return Type::terror;
         }
-        Object *o = (*sd->objects)[(size_t)d];
+        RootObject *o = (*sd->objects)[(size_t)d];
         if (o->dyncast() != DYNCAST_TYPE)
         {   error(loc, "%s is not a type", toChars());
             return Type::terror;
@@ -6276,7 +6276,7 @@ void TypeQualified::syntaxCopyHelper(TypeQualified *t)
     idents.setDim(t->idents.dim);
     for (size_t i = 0; i < idents.dim; i++)
     {
-        Object *id = t->idents[i];
+        RootObject *id = t->idents[i];
         if (id->dyncast() == DYNCAST_DSYMBOL)
         {
             TemplateInstance *ti = (TemplateInstance *)id;
@@ -6302,7 +6302,7 @@ void TypeQualified::addInst(TemplateInstance *inst)
 void TypeQualified::toCBuffer2Helper(OutBuffer *buf, HdrGenState *hgs)
 {
     for (size_t i = 0; i < idents.dim; i++)
-    {   Object *id = idents[i];
+    {   RootObject *id = idents[i];
 
         buf->writeByte('.');
 
@@ -6350,7 +6350,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
         //printf("\t2: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
         for (size_t i = 0; i < idents.dim; i++)
         {
-            Object *id = idents[i];
+            RootObject *id = idents[i];
             Dsymbol *sm = s->searchX(loc, sc, id);
             //printf("\t3: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
             //printf("\tgetType = '%s'\n", s->getType()->toChars());
@@ -6383,7 +6383,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                     e = e->semantic(sc);
                     for (; i < idents.dim; i++)
                     {
-                        Object *id = idents[i];
+                        RootObject *id = idents[i];
                         //printf("e: '%s', id: '%s', type = %s\n", e->toChars(), id->toChars(), e->type->toChars());
                         if (id->dyncast() == DYNCAST_IDENTIFIER)
                         {
@@ -6627,7 +6627,7 @@ Dsymbol *TypeIdentifier::toDsymbol(Scope *sc)
     {
         for (size_t i = 0; i < idents.dim; i++)
         {
-            Object *id = idents[i];
+            RootObject *id = idents[i];
             s = s->searchX(loc, sc, id);
             if (!s)                 // failed to find a symbol
             {   //printf("\tdidn't find a symbol\n");
@@ -6699,7 +6699,7 @@ Expression *TypeIdentifier::toExpression()
     Expression *e = new IdentifierExp(loc, ident);
     for (size_t i = 0; i < idents.dim; i++)
     {
-        Object *id = idents[i];
+        RootObject *id = idents[i];
         if (id->dyncast() == DYNCAST_IDENTIFIER)
         {
             e = new DotIdExp(loc, e, (Identifier *)id);
@@ -6962,7 +6962,7 @@ void TypeTypeof::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
             Expression *e = new TypeExp(loc, t);
             for (size_t i = 0; i < idents.dim; i++)
             {
-                Object *id = idents[i];
+                RootObject *id = idents[i];
                 switch (id->dyncast())
                 {
                     case DYNCAST_IDENTIFIER:
@@ -7090,7 +7090,7 @@ void TypeReturn::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
             Expression *e = new TypeExp(loc, t);
             for (size_t i = 0; i < idents.dim; i++)
             {
-                Object *id = idents[i];
+                RootObject *id = idents[i];
                 switch (id->dyncast())
                 {
                     case DYNCAST_IDENTIFIER:
@@ -8910,7 +8910,7 @@ Type *TypeTuple::semantic(Loc loc, Scope *sc)
     return this;
 }
 
-bool TypeTuple::equals(Object *o)
+bool TypeTuple::equals(RootObject *o)
 {
     Type *t = (Type *)o;
     //printf("TypeTuple::equals(%s, %s)\n", toChars(), t->toChars());

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -120,7 +120,7 @@ extern int Tptrdiff_t;
 #define MODwild      8  // type is wild
 #define MODmutable   0x10       // type is mutable (only used in wildcard matching)
 
-class Type : public Object
+class Type : public RootObject
 {
 public:
     TY ty;
@@ -229,7 +229,7 @@ public:
     Type(TY ty);
     virtual const char *kind();
     virtual Type *syntaxCopy();
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     int dyncast() { return DYNCAST_TYPE; } // kludge for template.isType()
     int covariant(Type *t, StorageClass *pstc = NULL);
     char *toChars();
@@ -1022,7 +1022,7 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
-    bool equals(Object *o);
+    bool equals(RootObject *o);
     Type *reliesOnTident(TemplateParameters *tparams = NULL);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toDecoBuffer(OutBuffer *buf, int flag);
@@ -1069,7 +1069,7 @@ public:
 
 //enum InOut { None, In, Out, InOut, Lazy };
 
-class Parameter : public Object
+class Parameter : public RootObject
 {
 public:
     //enum InOut inout;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1973,7 +1973,7 @@ TemplateParameters *Parser::parseTemplateParameterList(int flag)
                     tp_ident = token.ident;
                     nextToken();
                 }
-                Object *spec = NULL;
+                RootObject *spec = NULL;
                 if (token.value == TOKcolon)    // : Type
                 {
                     nextToken();
@@ -1982,7 +1982,7 @@ TemplateParameters *Parser::parseTemplateParameterList(int flag)
                     else
                         spec = parseCondExp();
                 }
-                Object *def = NULL;
+                RootObject *def = NULL;
                 if (token.value == TOKassign)   // = Type
                 {
                     nextToken();
@@ -5754,7 +5754,7 @@ Expression *Parser::parsePrimaryExp()
         {
             nextToken();
             check(TOKlparen, "typeid");
-            Object *o;
+            RootObject *o;
             if (isDeclaration(&token, 0, TOKreserved, NULL))
             {   // argument is a type
                 o = parseType();

--- a/src/root/root.c
+++ b/src/root/root.c
@@ -92,42 +92,42 @@ void warning(const char *format, ...)
 
 /****************************** Object ********************************/
 
-bool Object::equals(Object *o)
+bool RootObject::equals(RootObject *o)
 {
     return o == this;
 }
 
-hash_t Object::hashCode()
+hash_t RootObject::hashCode()
 {
     return (hash_t) this;
 }
 
-int Object::compare(Object *obj)
+int RootObject::compare(RootObject *obj)
 {
     return this - obj;
 }
 
-void Object::print()
+void RootObject::print()
 {
     printf("%s %p\n", toChars(), this);
 }
 
-char *Object::toChars()
+char *RootObject::toChars()
 {
     return (char *)"Object";
 }
 
-int Object::dyncast()
+int RootObject::dyncast()
 {
     return 0;
 }
 
-void Object::toBuffer(OutBuffer *b)
+void RootObject::toBuffer(OutBuffer *b)
 {
     b->writestring("Object");
 }
 
-void Object::mark()
+void RootObject::mark()
 {
 }
 
@@ -200,12 +200,12 @@ size_t String::len()
     return strlen(str);
 }
 
-bool String::equals(Object *obj)
+bool String::equals(RootObject *obj)
 {
     return strcmp(str,((String *)obj)->str) == 0;
 }
 
-int String::compare(Object *obj)
+int String::compare(RootObject *obj)
 {
     return strcmp(str,((String *)obj)->str);
 }
@@ -378,7 +378,7 @@ hash_t FileName::hashCode()
 #endif
 }
 
-int FileName::compare(Object *obj)
+int FileName::compare(RootObject *obj)
 {
     return compare(str, ((FileName *)obj)->str);
 }
@@ -392,7 +392,7 @@ int FileName::compare(const char *name1, const char *name2)
 #endif
 }
 
-bool FileName::equals(Object *obj)
+bool FileName::equals(RootObject *obj)
 {
     return compare(obj) == 0;
 }
@@ -1724,7 +1724,7 @@ void OutBuffer::write(OutBuffer *buf)
     }
 }
 
-void OutBuffer::write(Object *obj)
+void OutBuffer::write(RootObject *obj)
 {
     if (obj)
     {

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -35,13 +35,13 @@ typedef Array<class File> Files;
 typedef Array<char> Strings;
 
 
-class Object
+class RootObject
 {
 public:
-    Object() { }
-    virtual ~Object() { }
+    RootObject() { }
+    virtual ~RootObject() { }
 
-    virtual bool equals(Object *o);
+    virtual bool equals(RootObject *o);
 
     /**
      * Returns a hash code, useful for things like building hash tables of Objects.
@@ -52,7 +52,7 @@ public:
      * Return <0, ==0, or >0 if this is less than, equal to, or greater than obj.
      * Useful for sorting Objects.
      */
-    virtual int compare(Object *obj);
+    virtual int compare(RootObject *obj);
 
     /**
      * Pretty-print an Object. Useful for debugging the old-fashioned way.
@@ -75,7 +75,7 @@ public:
         void mark();
 };
 
-class String : public Object
+class String : public RootObject
 {
 public:
     const char *str;                  // the string itself
@@ -87,8 +87,8 @@ public:
     static hash_t calcHash(const char *str);
     hash_t hashCode();
     size_t len();
-    bool equals(Object *obj);
-    int compare(Object *obj);
+    bool equals(RootObject *obj);
+    int compare(RootObject *obj);
     char *toChars();
     void print();
     void mark();
@@ -99,9 +99,9 @@ class FileName : public String
 public:
     FileName(const char *str);
     hash_t hashCode();
-    bool equals(Object *obj);
+    bool equals(RootObject *obj);
     static int equals(const char *name1, const char *name2);
-    int compare(Object *obj);
+    int compare(RootObject *obj);
     static int compare(const char *name1, const char *name2);
     static int absolute(const char *name);
     static const char *ext(const char *);
@@ -131,7 +131,7 @@ public:
     static void free(const char *str);
 };
 
-class File : public Object
+class File : public RootObject
 {
 public:
     int ref;                    // != 0 if this is a reference to someone else's buffer
@@ -237,7 +237,7 @@ public:
     void remove();              // delete file
 };
 
-class OutBuffer : public Object
+class OutBuffer : public RootObject
 {
 public:
     unsigned char *data;
@@ -268,7 +268,7 @@ public:
     void writeUTF16(unsigned w);
     void write4(unsigned w);
     void write(OutBuffer *buf);
-    void write(Object *obj);
+    void write(RootObject *obj);
     void fill0(size_t nbytes);
     void align(size_t size);
     void vprintf(const char *format, va_list args);
@@ -321,7 +321,7 @@ struct Array
         size_t len = 2;
         for (size_t u = 0; u < dim; u++)
         {
-            buf[u] = ((Object *)data[u])->toChars();
+            buf[u] = ((RootObject *)data[u])->toChars();
             len += strlen(buf[u]) + 1;
         }
         char *str = (char *)mem.malloc(len);
@@ -438,8 +438,8 @@ struct Array
     #endif
             Array_sort_compare(const void *x, const void *y)
             {
-                Object *ox = *(Object **)x;
-                Object *oy = *(Object **)y;
+                RootObject *ox = *(RootObject **)x;
+                RootObject *oy = *(RootObject **)y;
 
                 return ox->compare(oy);
             }
@@ -447,7 +447,7 @@ struct Array
 
         if (dim)
         {
-            qsort(data, dim, sizeof(Object *), &ArraySort::Array_sort_compare);
+            qsort(data, dim, sizeof(RootObject *), &ArraySort::Array_sort_compare);
         }
     }
 
@@ -522,7 +522,7 @@ struct Array
 };
 
 // TODO: Remove (only used by disabled GC)
-class Bits : public Object
+class Bits : public RootObject
 {
 public:
     unsigned bitdim;

--- a/src/statement.c
+++ b/src/statement.c
@@ -3275,7 +3275,7 @@ Statement *CaseStatement::semantic(Scope *sc)
     return this;
 }
 
-int CaseStatement::compare(Object *obj)
+int CaseStatement::compare(RootObject *obj)
 {
     // Sort cases so we can do an efficient lookup
     CaseStatement *cs2 = (CaseStatement *)(obj);

--- a/src/statement.h
+++ b/src/statement.h
@@ -84,7 +84,7 @@ enum BE
     BEany = (BEfallthru | BEthrow | BEreturn | BEgoto | BEhalt),
 };
 
-class Statement : public Object
+class Statement : public RootObject
 {
 public:
     Loc loc;
@@ -552,7 +552,7 @@ public:
     CaseStatement(Loc loc, Expression *exp, Statement *s);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    int compare(Object *obj);
+    int compare(RootObject *obj);
     int blockExit(bool mustNotThrow);
     bool comeFromImpl();
     Expression *interpret(InterState *istate);
@@ -775,7 +775,7 @@ public:
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 };
 
-class Catch : public Object
+class Catch : public RootObject
 {
 public:
     Loc loc;

--- a/src/template.c
+++ b/src/template.c
@@ -51,7 +51,7 @@ int arrayObjectMatch(Objects *oa1, Objects *oa2, TemplateDeclaration *tempdecl, 
  * on earlier versions of gcc.
  */
 
-Expression *isExpression(Object *o)
+Expression *isExpression(RootObject *o)
 {
     //return dynamic_cast<Expression *>(o);
     if (!o || o->dyncast() != DYNCAST_EXPRESSION)
@@ -59,7 +59,7 @@ Expression *isExpression(Object *o)
     return (Expression *)o;
 }
 
-Dsymbol *isDsymbol(Object *o)
+Dsymbol *isDsymbol(RootObject *o)
 {
     //return dynamic_cast<Dsymbol *>(o);
     if (!o || o->dyncast() != DYNCAST_DSYMBOL)
@@ -67,7 +67,7 @@ Dsymbol *isDsymbol(Object *o)
     return (Dsymbol *)o;
 }
 
-Type *isType(Object *o)
+Type *isType(RootObject *o)
 {
     //return dynamic_cast<Type *>(o);
     if (!o || o->dyncast() != DYNCAST_TYPE)
@@ -75,7 +75,7 @@ Type *isType(Object *o)
     return (Type *)o;
 }
 
-Tuple *isTuple(Object *o)
+Tuple *isTuple(RootObject *o)
 {
     //return dynamic_cast<Tuple *>(o);
     if (!o || o->dyncast() != DYNCAST_TUPLE)
@@ -83,7 +83,7 @@ Tuple *isTuple(Object *o)
     return (Tuple *)o;
 }
 
-Parameter *isParameter(Object *o)
+Parameter *isParameter(RootObject *o)
 {
     //return dynamic_cast<Parameter *>(o);
     if (!o || o->dyncast() != DYNCAST_PARAMETER)
@@ -94,7 +94,7 @@ Parameter *isParameter(Object *o)
 /**************************************
  * Is this Object an error?
  */
-int isError(Object *o)
+int isError(RootObject *o)
 {
     Type *t = isType(o);
     if (t)
@@ -118,7 +118,7 @@ int arrayObjectIsError(Objects *args)
 {
     for (size_t i = 0; i < args->dim; i++)
     {
-        Object *o = (*args)[i];
+        RootObject *o = (*args)[i];
         if (isError(o))
             return 1;
     }
@@ -129,7 +129,7 @@ int arrayObjectIsError(Objects *args)
  * Try to get arg as a type.
  */
 
-Type *getType(Object *o)
+Type *getType(RootObject *o)
 {
     Type *t = isType(o);
     if (!t)
@@ -140,7 +140,7 @@ Type *getType(Object *o)
     return t;
 }
 
-Dsymbol *getDsymbol(Object *oarg)
+Dsymbol *getDsymbol(RootObject *oarg)
 {
     //printf("getDsymbol()\n");
     //printf("e %p s %p t %p v %p\n", isExpression(oarg), isDsymbol(oarg), isType(oarg), isTuple(oarg));
@@ -207,7 +207,7 @@ Expression *getValue(Dsymbol *&s)
  * Else, return 0.
  */
 
-int match(Object *o1, Object *o2, TemplateDeclaration *tempdecl, Scope *sc)
+int match(RootObject *o1, RootObject *o2, TemplateDeclaration *tempdecl, Scope *sc)
 {
     Type *t1 = isType(o1);
     Type *t2 = isType(o2);
@@ -312,8 +312,8 @@ int arrayObjectMatch(Objects *oa1, Objects *oa2, TemplateDeclaration *tempdecl, 
     if (oa1->dim != oa2->dim)
         return 0;
     for (size_t j = 0; j < oa1->dim; j++)
-    {   Object *o1 = (*oa1)[j];
-        Object *o2 = (*oa2)[j];
+    {   RootObject *o1 = (*oa1)[j];
+        RootObject *o2 = (*oa2)[j];
         if (!match(o1, o2, tempdecl, sc))
         {
             return 0;
@@ -327,7 +327,7 @@ int arrayObjectMatch(Objects *oa1, Objects *oa2, TemplateDeclaration *tempdecl, 
  * It's analogous to genIdent() which makes a mangled version.
  */
 
-void ObjectToCBuffer(OutBuffer *buf, HdrGenState *hgs, Object *oarg)
+void ObjectToCBuffer(OutBuffer *buf, HdrGenState *hgs, RootObject *oarg)
 {
     //printf("ObjectToCBuffer()\n");
     Type *t = isType(oarg);
@@ -361,7 +361,7 @@ void ObjectToCBuffer(OutBuffer *buf, HdrGenState *hgs, Object *oarg)
         {
             if (i)
                 buf->writestring(", ");
-            Object *o = (*args)[i];
+            RootObject *o = (*args)[i];
             ObjectToCBuffer(buf, hgs, o);
         }
     }
@@ -379,7 +379,7 @@ void ObjectToCBuffer(OutBuffer *buf, HdrGenState *hgs, Object *oarg)
 }
 
 #if DMDV2
-Object *objectSyntaxCopy(Object *o)
+RootObject *objectSyntaxCopy(RootObject *o)
 {
     if (!o)
         return NULL;
@@ -875,7 +875,7 @@ MATCH TemplateDeclaration::matchWithInstance(TemplateInstance *ti,
         for (size_t i = 0; i < dedtypes_dim; i++)
         {
             TemplateParameter *tp = (*parameters)[i];
-            Object *oarg;
+            RootObject *oarg;
 
             printf(" [%d]", i);
 
@@ -942,7 +942,7 @@ MATCH TemplateDeclaration::leastAsSpecialized(TemplateDeclaration *td2, Expressi
     {
         TemplateParameter *tp = (*parameters)[i];
 
-        Object *p = (Object *)tp->dummyArg();
+        RootObject *p = (RootObject *)tp->dummyArg();
         if (p)
             (*ti.tiargs)[i] = p;
         else
@@ -1049,7 +1049,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objec
     for (size_t i = 0; i < dedargs->dim; i++)
     {
         printf("\tdedarg[%d] = ", i);
-        Object *oarg = (*dedargs)[i];
+        RootObject *oarg = (*dedargs)[i];
         if (oarg) printf("%s", oarg->toChars());
         printf("\n");
     }
@@ -1121,7 +1121,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objec
     for (size_t i = 0; i < dedargs->dim; i++)
     {
         printf("\tdedarg[%d] = ", i);
-        Object *oarg = (*dedargs)[i];
+        RootObject *oarg = (*dedargs)[i];
         if (oarg) printf("%s", oarg->toChars());
         printf("\n");
     }
@@ -1806,8 +1806,8 @@ Lmatch:
         /* For T:T*, the dedargs is the T*, dedtypes is the T
          * But for function templates, we really need them to match
          */
-        Object *oarg = (*dedargs)[i];
-        Object *oded = dedtypes[i];
+        RootObject *oarg = (*dedargs)[i];
+        RootObject *oded = dedtypes[i];
         //printf("1dedargs[%d] = %p, dedtypes[%d] = %p\n", i, oarg, i, oded);
         //if (oarg) printf("oarg: %s\n", oarg->toChars());
         //if (oded) printf("oded: %s\n", oded->toChars());
@@ -1838,7 +1838,7 @@ Lmatch:
                         fptupindex == IDX_NOTFOUND &&   // tuple parameter was not in function parameter list and
                         ntargs == dedargs->dim - 1)     // we're one argument short (i.e. no tuple argument)
                     {   // make tuple argument an empty tuple
-                        oded = (Object *)new Tuple();
+                        oded = (RootObject *)new Tuple();
                     }
                     else
                         goto Lnomatch;
@@ -1950,7 +1950,7 @@ Lnomatch:
  * Declare template parameter tp with value o, and install it in the scope sc.
  */
 
-Object *TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, Object *o)
+RootObject *TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, RootObject *o)
 {
     //printf("TemplateDeclaration::declareParameter('%s', o = %p)\n", tp->ident->toChars(), o);
 
@@ -2032,7 +2032,7 @@ Object *TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *tp, 
     /* So the caller's o gets updated with the result of semantic() being run on o
      */
     if (v)
-        return (Object *)v->init->toExpression();
+        return (RootObject *)v->init->toExpression();
     return o;
 }
 
@@ -2093,7 +2093,7 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Loc loc, Scope *sc,
     printf("    tiargs:\n");
     if (tiargs)
     {   for (size_t i = 0; i < tiargs->dim; i++)
-        {   Object *arg = (*tiargs)[i];
+        {   RootObject *arg = (*tiargs)[i];
             printf("\t%s\n", arg->toChars());
         }
     }
@@ -2373,7 +2373,7 @@ FuncDeclaration *TemplateDeclaration::deduceFunctionTemplate(Loc loc, Scope *sc,
             {
                 if (i)
                     bufa.writestring(", ");
-                Object *oarg = (*args)[i];
+                RootObject *oarg = (*args)[i];
                 ObjectToCBuffer(&bufa, &hgs, oarg);
             }
         }
@@ -2404,7 +2404,7 @@ FuncDeclaration *TemplateDeclaration::doHeaderInstantiation(Scope *sc,
 #if 0
     printf("doHeaderInstantiation this = %s\n", toChars());
     for (size_t i = 0; i < tdargs->dim; ++i)
-        printf("\ttdargs[%d] = %s\n", i, ((Object *)tdargs->data[i])->toChars());
+        printf("\ttdargs[%d] = %s\n", i, ((RootObject *)tdargs->data[i])->toChars());
 #endif
 
     assert(scope);
@@ -3219,7 +3219,7 @@ MATCH TypeFunction::deduceType(Scope *sc, Type *tparam, TemplateParameters *para
 
             /* See if existing tuple, and whether it matches or not
              */
-            Object *o = (*dedtypes)[tupi];
+            RootObject *o = (*dedtypes)[tupi];
             if (o)
             {   // Existing deduced argument must be a tuple, and must match
                 Tuple *t = isTuple(o);
@@ -3270,8 +3270,8 @@ MATCH TypeIdentifier::deduceType(Scope *sc, Type *tparam, TemplateParameters *pa
 
         for (size_t i = 0; i < idents.dim; i++)
         {
-            Object *id1 = idents[i];
-            Object *id2 = tp->idents[i];
+            RootObject *id1 = idents[i];
+            RootObject *id2 = tp->idents[i];
 
             if (!id1->equals(id2))
                 return MATCHnomatch;
@@ -3344,7 +3344,7 @@ MATCH TypeInstance::deduceType(Scope *sc,
         for (size_t i = 0; 1; i++)
         {
             //printf("\ttest: tempinst->tiargs[%d]\n", i);
-            Object *o1 = NULL;
+            RootObject *o1 = NULL;
             if (i < tempinst->tiargs->dim)
                 o1 = (*tempinst->tiargs)[i];
             else if (i < tempinst->tdtypes.dim && i < tp->tempinst->tiargs->dim)
@@ -3356,7 +3356,7 @@ MATCH TypeInstance::deduceType(Scope *sc,
             if (i >= tp->tempinst->tiargs->dim)
                 goto Lnomatch;
 
-            Object *o2 = (*tp->tempinst->tiargs)[i];
+            RootObject *o2 = (*tp->tempinst->tiargs)[i];
             Type *t2 = isType(o2);
 
             size_t j;
@@ -3382,7 +3382,7 @@ MATCH TypeInstance::deduceType(Scope *sc,
                 vt->objects.setDim(vtdim);
                 for (size_t k = 0; k < vtdim; k++)
                 {
-                    Object *o;
+                    RootObject *o;
                     if (k < tempinst->tiargs->dim)
                         o = (*tempinst->tiargs)[i + k];
                     else    // Pick up default arg
@@ -3533,7 +3533,7 @@ MATCH TypeStruct::deduceType(Scope *sc, Type *tparam, TemplateParameters *parame
          */
         TypeInstance *tpi = (TypeInstance *)tparam;
         if (tpi->idents.dim)
-        {   Object *id = tpi->idents[tpi->idents.dim - 1];
+        {   RootObject *id = tpi->idents[tpi->idents.dim - 1];
             if (id->dyncast() == DYNCAST_IDENTIFIER && sym->ident->equals((Identifier *)id))
             {
                 Type *tparent = sym->parent->getType();
@@ -3677,7 +3677,7 @@ MATCH TypeClass::deduceType(Scope *sc, Type *tparam, TemplateParameters *paramet
          */
         TypeInstance *tpi = (TypeInstance *)tparam;
         if (tpi->idents.dim)
-        {   Object *id = tpi->idents[tpi->idents.dim - 1];
+        {   RootObject *id = tpi->idents[tpi->idents.dim - 1];
             if (id->dyncast() == DYNCAST_IDENTIFIER && sym->ident->equals((Identifier *)id))
             {
                 Type *tparent = sym->parent->getType();
@@ -3877,7 +3877,7 @@ MATCH TemplateTypeParameter::matchArg(Scope *sc, Objects *tiargs,
         size_t i, TemplateParameters *parameters, Objects *dedtypes,
         Declaration **psparam)
 {
-    Object *oarg;
+    RootObject *oarg;
 
     if (i < tiargs->dim)
         oarg = (*tiargs)[i];
@@ -3902,7 +3902,7 @@ Lnomatch:
     return MATCHnomatch;
 }
 
-MATCH TemplateTypeParameter::matchArg(Scope *sc, Object *oarg,
+MATCH TemplateTypeParameter::matchArg(Scope *sc, RootObject *oarg,
         size_t i, TemplateParameters *parameters, Objects *dedtypes,
         Declaration **psparam)
 {
@@ -3965,7 +3965,7 @@ Lnomatch:
 }
 
 
-void TemplateTypeParameter::print(Object *oarg, Object *oded)
+void TemplateTypeParameter::print(RootObject *oarg, RootObject *oded)
 {
     printf(" %s\n", ident->toChars());
 
@@ -4014,13 +4014,13 @@ void *TemplateTypeParameter::dummyArg()
 }
 
 
-Object *TemplateTypeParameter::specialization()
+RootObject *TemplateTypeParameter::specialization()
 {
     return specType;
 }
 
 
-Object *TemplateTypeParameter::defaultArg(Loc loc, Scope *sc)
+RootObject *TemplateTypeParameter::defaultArg(Loc loc, Scope *sc)
 {
     Type *t;
 
@@ -4074,7 +4074,7 @@ void TemplateThisParameter::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 Dsymbol *TemplateAliasParameter::sdummy = NULL;
 
 TemplateAliasParameter::TemplateAliasParameter(Loc loc, Identifier *ident,
-        Type *specType, Object *specAlias, Object *defaultAlias)
+        Type *specType, RootObject *specAlias, RootObject *defaultAlias)
     : TemplateParameter(loc, ident)
 {
     this->ident = ident;
@@ -4106,7 +4106,7 @@ void TemplateAliasParameter::declareParameter(Scope *sc)
         error(loc, "parameter '%s' multiply defined", ident->toChars());
 }
 
-Object *aliasParameterSemantic(Loc loc, Scope *sc, Object *o, TemplateParameters *parameters)
+RootObject *aliasParameterSemantic(Loc loc, Scope *sc, RootObject *o, TemplateParameters *parameters)
 {
     if (o)
     {
@@ -4169,7 +4169,7 @@ Lnomatch:
  *  }                               // because Sym template cannot
  *  void main() { S s; s.foo(); }   // access to the valid 'this' symbol.
  */
-bool isPseudoDsymbol(Object *o)
+bool isPseudoDsymbol(RootObject *o)
 {
     Dsymbol *s = isDsymbol(o);
     Expression *e = isExpression(o);
@@ -4200,7 +4200,7 @@ MATCH TemplateAliasParameter::matchArg(Scope *sc, Objects *tiargs,
         size_t i, TemplateParameters *parameters, Objects *dedtypes,
         Declaration **psparam)
 {
-    Object *oarg;
+    RootObject *oarg;
 
     if (i < tiargs->dim)
         oarg = (*tiargs)[i];
@@ -4223,12 +4223,12 @@ Lnomatch:
     return MATCHnomatch;
 }
 
-MATCH TemplateAliasParameter::matchArg(Scope *sc, Object *oarg,
+MATCH TemplateAliasParameter::matchArg(Scope *sc, RootObject *oarg,
         size_t i, TemplateParameters *parameters, Objects *dedtypes,
         Declaration **psparam)
 {
     //printf("TemplateAliasParameter::matchArg()\n");
-    Object *sa = getDsymbol(oarg);
+    RootObject *sa = getDsymbol(oarg);
     Expression *ea = isExpression(oarg);
     if (ea && (ea->op == TOKthis || ea->op == TOKsuper))
         sa = ((ThisExp *)ea)->var;
@@ -4279,7 +4279,7 @@ MATCH TemplateAliasParameter::matchArg(Scope *sc, Object *oarg,
     }
     else if ((*dedtypes)[i])
     {   // Must match already deduced symbol
-        Object *si = (*dedtypes)[i];
+        RootObject *si = (*dedtypes)[i];
 
         if (!sa || si != sa)
             goto Lnomatch;
@@ -4314,7 +4314,7 @@ Lnomatch:
 }
 
 
-void TemplateAliasParameter::print(Object *oarg, Object *oded)
+void TemplateAliasParameter::print(RootObject *oarg, RootObject *oded)
 {
     printf(" %s\n", ident->toChars());
 
@@ -4347,7 +4347,7 @@ void TemplateAliasParameter::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
 
 void *TemplateAliasParameter::dummyArg()
-{   Object *s;
+{   RootObject *s;
 
     s = specAlias;
     if (!s)
@@ -4360,15 +4360,15 @@ void *TemplateAliasParameter::dummyArg()
 }
 
 
-Object *TemplateAliasParameter::specialization()
+RootObject *TemplateAliasParameter::specialization()
 {
     return specAlias;
 }
 
 
-Object *TemplateAliasParameter::defaultArg(Loc loc, Scope *sc)
+RootObject *TemplateAliasParameter::defaultArg(Loc loc, Scope *sc)
 {
-    Object *da = defaultAlias;
+    RootObject *da = defaultAlias;
     Type *ta = isType(defaultAlias);
     if (ta)
     {
@@ -4379,7 +4379,7 @@ Object *TemplateAliasParameter::defaultArg(Loc loc, Scope *sc)
        }
     }
 
-    Object *o = aliasParameterSemantic(loc, sc, da, NULL);
+    RootObject *o = aliasParameterSemantic(loc, sc, da, NULL);
     return o;
 }
 
@@ -4498,7 +4498,7 @@ MATCH TemplateValueParameter::matchArg(Scope *sc, Objects *tiargs,
         size_t i, TemplateParameters *parameters, Objects *dedtypes,
         Declaration **psparam)
 {
-    Object *oarg;
+    RootObject *oarg;
 
     if (i < tiargs->dim)
         oarg = (*tiargs)[i];
@@ -4521,7 +4521,7 @@ Lnomatch:
     return MATCHnomatch;
 }
 
-MATCH TemplateValueParameter::matchArg(Scope *sc, Object *oarg,
+MATCH TemplateValueParameter::matchArg(Scope *sc, RootObject *oarg,
         size_t i, TemplateParameters *parameters, Objects *dedtypes,
         Declaration **psparam)
 {
@@ -4626,7 +4626,7 @@ Lnomatch:
 }
 
 
-void TemplateValueParameter::print(Object *oarg, Object *oded)
+void TemplateValueParameter::print(RootObject *oarg, RootObject *oded)
 {
     printf(" %s\n", ident->toChars());
 
@@ -4670,13 +4670,13 @@ void *TemplateValueParameter::dummyArg()
 }
 
 
-Object *TemplateValueParameter::specialization()
+RootObject *TemplateValueParameter::specialization()
 {
     return specValue;
 }
 
 
-Object *TemplateValueParameter::defaultArg(Loc loc, Scope *sc)
+RootObject *TemplateValueParameter::defaultArg(Loc loc, Scope *sc)
 {
     Expression *e = defaultValue;
     if (e)
@@ -4766,7 +4766,7 @@ MATCH TemplateTupleParameter::matchArg(Scope *sc, Objects *tiargs,
     return matchArg(sc, ovar, i, parameters, dedtypes, psparam);
 }
 
-MATCH TemplateTupleParameter::matchArg(Scope *sc, Object *oarg,
+MATCH TemplateTupleParameter::matchArg(Scope *sc, RootObject *oarg,
         size_t i, TemplateParameters *parameters, Objects *dedtypes,
         Declaration **psparam)
 {
@@ -4782,7 +4782,7 @@ MATCH TemplateTupleParameter::matchArg(Scope *sc, Object *oarg,
 }
 
 
-void TemplateTupleParameter::print(Object *oarg, Object *oded)
+void TemplateTupleParameter::print(RootObject *oarg, RootObject *oded)
 {
     printf(" %s... [", ident->toChars());
     Tuple *v = isTuple(oded);
@@ -4794,7 +4794,7 @@ void TemplateTupleParameter::print(Object *oarg, Object *oded)
         if (i)
             printf(", ");
 
-        Object *o = v->objects[i];
+        RootObject *o = v->objects[i];
 
         Dsymbol *sa = isDsymbol(o);
         if (sa)
@@ -4827,13 +4827,13 @@ void *TemplateTupleParameter::dummyArg()
 }
 
 
-Object *TemplateTupleParameter::specialization()
+RootObject *TemplateTupleParameter::specialization()
 {
     return NULL;
 }
 
 
-Object *TemplateTupleParameter::defaultArg(Loc loc, Scope *sc)
+RootObject *TemplateTupleParameter::defaultArg(Loc loc, Scope *sc)
 {
     return NULL;
 }
@@ -5520,7 +5520,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
         return;
     for (size_t j = 0; j < tiargs->dim; j++)
     {
-        Object *o = (*tiargs)[j];
+        RootObject *o = (*tiargs)[j];
         Type *ta = isType(o);
         Expression *ea = isExpression(o);
         Dsymbol *sa = isDsymbol(o);
@@ -5699,7 +5699,7 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
     printf("-TemplateInstance::semanticTiargs()\n");
     for (size_t j = 0; j < tiargs->dim; j++)
     {
-        Object *o = (*tiargs)[j];
+        RootObject *o = (*tiargs)[j];
         Type *ta = isType(o);
         Expression *ea = isExpression(o);
         Dsymbol *sa = isDsymbol(o);
@@ -5958,7 +5958,7 @@ bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
     /* Cast any value arguments to be same type as value parameter
      */
     for (size_t i = 0; i < tiargs->dim; i++)
-    {   Object *o = (*tiargs)[i];
+    {   RootObject *o = (*tiargs)[i];
         Expression *ea = isExpression(o);       // value argument
         TemplateParameter *tp = (*tempdecl->parameters)[i];
         assert(tp);
@@ -5968,7 +5968,7 @@ bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
             assert(ea);
             ea = ea->castTo(tvp->valType);
             ea = ea->ctfeInterpret();
-            (*tiargs)[i] = (Object *)ea;
+            (*tiargs)[i] = (RootObject *)ea;
         }
     }
 #endif
@@ -5994,7 +5994,7 @@ int TemplateInstance::hasNestedArgs(Objects *args)
      * symbol that is on the stack.
      */
     for (size_t i = 0; i < args->dim; i++)
-    {   Object *o = (*args)[i];
+    {   RootObject *o = (*args)[i];
         Expression *ea = isExpression(o);
         Dsymbol *sa = isDsymbol(o);
         Tuple *va = isTuple(o);
@@ -6111,7 +6111,7 @@ Identifier *TemplateInstance::genIdent(Objects *args)
     char *id = tempdecl->ident->toChars();
     buf.printf("__T%llu%s", (ulonglong)strlen(id), id);
     for (size_t i = 0; i < args->dim; i++)
-    {   Object *o = (*args)[i];
+    {   RootObject *o = (*args)[i];
         Type *ta = isType(o);
         Expression *ea = isExpression(o);
         Dsymbol *sa = isDsymbol(o);
@@ -6258,8 +6258,8 @@ void TemplateInstance::declareParameters(Scope *sc)
     for (size_t i = 0; i < tdtypes.dim; i++)
     {
         TemplateParameter *tp = (*tempdecl->parameters)[i];
-        //Object *o = (*tiargs)[i];
-        Object *o = tdtypes[i];          // initializer for tp
+        //RootObject *o = (*tiargs)[i];
+        RootObject *o = tdtypes[i];          // initializer for tp
 
         //printf("\ttdtypes[%d] = %p\n", i, o);
         tempdecl->declareParameter(sc, tp, o);
@@ -6519,7 +6519,7 @@ void TemplateInstance::toCBufferTiargs(OutBuffer *buf, HdrGenState *hgs)
     {
         if (tiargs->dim == 1)
         {
-            Object *oarg = (*tiargs)[0];
+            RootObject *oarg = (*tiargs)[0];
             if (Type *t = isType(oarg))
             {
                 if (t->isTypeBasic() ||
@@ -6549,7 +6549,7 @@ void TemplateInstance::toCBufferTiargs(OutBuffer *buf, HdrGenState *hgs)
         {
             if (i)
                 buf->writestring(", ");
-            Object *oarg = (*tiargs)[i];
+            RootObject *oarg = (*tiargs)[i];
             ObjectToCBuffer(buf, hgs, oarg);
         }
         nest--;
@@ -6767,11 +6767,11 @@ void TemplateMixin::semantic(Scope *sc)
             continue;
 
         for (size_t i = 0; i < tiargs->dim; i++)
-        {   Object *o = (*tiargs)[i];
+        {   RootObject *o = (*tiargs)[i];
             Type *ta = isType(o);
             Expression *ea = isExpression(o);
             Dsymbol *sa = isDsymbol(o);
-            Object *tmo = (*tm->tiargs)[i];
+            RootObject *tmo = (*tm->tiargs)[i];
             if (ta)
             {
                 Type *tmta = isType(tmo);

--- a/src/template.h
+++ b/src/template.h
@@ -41,7 +41,7 @@ class Parameter;
 enum MATCH;
 enum PASS;
 
-class Tuple : public Object
+class Tuple : public RootObject
 {
 public:
     Objects objects;
@@ -98,7 +98,7 @@ public:
 
     MATCH deduceFunctionTemplateMatch(Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, Objects *dedargs);
     FuncDeclaration *deduceFunctionTemplate(Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, int flags = 0);
-    Object *declareParameter(Scope *sc, TemplateParameter *tp, Object *o);
+    RootObject *declareParameter(Scope *sc, TemplateParameter *tp, RootObject *o);
     FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs, Type *tthis, Expressions *fargs);
     TemplateInstance *findExistingInstance(TemplateInstance *tithis, Scope *sc, Expressions *fargs);
     size_t addInstance(TemplateInstance *ti);
@@ -145,10 +145,10 @@ public:
     virtual TemplateParameter *syntaxCopy() = 0;
     virtual void declareParameter(Scope *sc) = 0;
     virtual void semantic(Scope *sc, TemplateParameters *parameters) = 0;
-    virtual void print(Object *oarg, Object *oded) = 0;
+    virtual void print(RootObject *oarg, RootObject *oded) = 0;
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs) = 0;
-    virtual Object *specialization() = 0;
-    virtual Object *defaultArg(Loc loc, Scope *sc) = 0;
+    virtual RootObject *specialization() = 0;
+    virtual RootObject *defaultArg(Loc loc, Scope *sc) = 0;
 
     /* If TemplateParameter's match as far as overloading goes.
      */
@@ -157,7 +157,7 @@ public:
     /* Match actual argument against parameter.
      */
     virtual MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam) = 0;
-    virtual MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam) = 0;
+    virtual MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam) = 0;
 
     /* Create dummy argument based on parameter.
      */
@@ -181,13 +181,13 @@ public:
     TemplateParameter *syntaxCopy();
     void declareParameter(Scope *sc);
     void semantic(Scope *sc, TemplateParameters *parameters);
-    void print(Object *oarg, Object *oded);
+    void print(RootObject *oarg, RootObject *oded);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-    Object *specialization();
-    Object *defaultArg(Loc loc, Scope *sc);
+    RootObject *specialization();
+    RootObject *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
     MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
-    MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
+    MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -226,13 +226,13 @@ public:
     TemplateParameter *syntaxCopy();
     void declareParameter(Scope *sc);
     void semantic(Scope *sc, TemplateParameters *parameters);
-    void print(Object *oarg, Object *oded);
+    void print(RootObject *oarg, RootObject *oded);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-    Object *specialization();
-    Object *defaultArg(Loc loc, Scope *sc);
+    RootObject *specialization();
+    RootObject *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
     MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
-    MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
+    MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -244,24 +244,24 @@ public:
      */
 
     Type *specType;
-    Object *specAlias;
-    Object *defaultAlias;
+    RootObject *specAlias;
+    RootObject *defaultAlias;
 
     static Dsymbol *sdummy;
 
-    TemplateAliasParameter(Loc loc, Identifier *ident, Type *specType, Object *specAlias, Object *defaultAlias);
+    TemplateAliasParameter(Loc loc, Identifier *ident, Type *specType, RootObject *specAlias, RootObject *defaultAlias);
 
     TemplateAliasParameter *isTemplateAliasParameter();
     TemplateParameter *syntaxCopy();
     void declareParameter(Scope *sc);
     void semantic(Scope *sc, TemplateParameters *parameters);
-    void print(Object *oarg, Object *oded);
+    void print(RootObject *oarg, RootObject *oded);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-    Object *specialization();
-    Object *defaultArg(Loc loc, Scope *sc);
+    RootObject *specialization();
+    RootObject *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
     MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
-    MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
+    MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -278,13 +278,13 @@ public:
     TemplateParameter *syntaxCopy();
     void declareParameter(Scope *sc);
     void semantic(Scope *sc, TemplateParameters *parameters);
-    void print(Object *oarg, Object *oded);
+    void print(RootObject *oarg, RootObject *oded);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-    Object *specialization();
-    Object *defaultArg(Loc loc, Scope *sc);
+    RootObject *specialization();
+    RootObject *defaultArg(Loc loc, Scope *sc);
     int overloadMatch(TemplateParameter *);
     MATCH matchArg(Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
-    MATCH matchArg(Scope *sc, Object *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
+    MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
 };
 
@@ -388,17 +388,17 @@ public:
     TemplateMixin *isTemplateMixin() { return this; }
 };
 
-Expression *isExpression(Object *o);
-Dsymbol *isDsymbol(Object *o);
-Type *isType(Object *o);
-Tuple *isTuple(Object *o);
-Parameter *isParameter(Object *o);
+Expression *isExpression(RootObject *o);
+Dsymbol *isDsymbol(RootObject *o);
+Type *isType(RootObject *o);
+Tuple *isTuple(RootObject *o);
+Parameter *isParameter(RootObject *o);
 int arrayObjectIsError(Objects *args);
-int isError(Object *o);
-Type *getType(Object *o);
-Dsymbol *getDsymbol(Object *o);
+int isError(RootObject *o);
+Type *getType(RootObject *o);
+Dsymbol *getDsymbol(RootObject *o);
 
-void ObjectToCBuffer(OutBuffer *buf, HdrGenState *hgs, Object *oarg);
-Object *objectSyntaxCopy(Object *o);
+void ObjectToCBuffer(OutBuffer *buf, HdrGenState *hgs, RootObject *oarg);
+RootObject *objectSyntaxCopy(RootObject *o);
 
 #endif /* DMD_TEMPLATE_H */

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -667,7 +667,7 @@ void ClassDeclaration::toObjFile(int multiobj)
         {
             assert(j < b->vtbl.dim);
 #if 0
-            Object *o = b->vtbl[j];
+            RootObject *o = b->vtbl[j];
             if (o)
             {
                 printf("o = %p\n", o);

--- a/src/traits.c
+++ b/src/traits.c
@@ -152,7 +152,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 1)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Type *t = isType(o);
         StructDeclaration *sd;
         if (!t)
@@ -174,7 +174,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 1)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Dsymbol *s = getDsymbol(o);
         AggregateDeclaration *a;
         FuncDeclaration *f;
@@ -247,7 +247,7 @@ Expression *TraitsExp::semantic(Scope *sc)
 
         if (dim != 1)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Parameter *po = isParameter(o);
         Identifier *id;
         if (po)
@@ -271,7 +271,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 1)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Dsymbol *s = getDsymbol(o);
         if (!s)
         {
@@ -292,7 +292,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 1)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Dsymbol *s = getDsymbol(o);
         if (s)
         {
@@ -317,7 +317,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 2)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Expression *e = isExpression((*args)[1]);
         if (!e)
         {   error("expression expected as second argument of __traits %s", ident->toChars());
@@ -422,7 +422,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 1)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Dsymbol *s = getDsymbol(o);
         ClassDeclaration *cd;
         if (!s || (cd = s->isClassDeclaration()) == NULL)
@@ -436,7 +436,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 1)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Dsymbol *s = getDsymbol(o);
         if (!s)
         {
@@ -459,7 +459,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 1)
             goto Ldimerror;
-        Object *o = (*args)[0];
+        RootObject *o = (*args)[0];
         Dsymbol *s = getDsymbol(o);
         ScopeDsymbol *sd;
         if (!s)
@@ -578,7 +578,7 @@ Expression *TraitsExp::semantic(Scope *sc)
             goto Lfalse;
 
         for (size_t i = 0; i < dim; i++)
-        {   Object *o = (*args)[i];
+        {   RootObject *o = (*args)[i];
             Expression *e;
 
             unsigned errors = global.startGagging();
@@ -621,8 +621,8 @@ Expression *TraitsExp::semantic(Scope *sc)
         if (dim != 2)
             goto Ldimerror;
         TemplateInstance::semanticTiargs(loc, sc, args, 0);
-        Object *o1 = (*args)[0];
-        Object *o2 = (*args)[1];
+        RootObject *o1 = (*args)[0];
+        RootObject *o2 = (*args)[1];
         Dsymbol *s1 = getDsymbol(o1);
         Dsymbol *s2 = getDsymbol(o2);
 


### PR DESCRIPTION
Because it is not possible to have a class named `Object` in D, the class in the compiler must be renamed.  It is quite likely this class will be removed completely after the port is complete.

Better ideas welcome.
