### PR TITLE
Use longdouble for Port::nan and Port::infinity.

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -603,7 +603,7 @@ Expression *Pow(Type *type, Expression *e1, Expression *e2)
         // x ^^ y for x < 0 and y not an integer is not defined
         if (e1->toReal() < 0.0)
         {
-            e = new RealExp(loc, ldouble(Port::nan), type);
+            e = new RealExp(loc, Port::ldbl_nan, type);
         }
         else if (e2->toReal() == 0.5)
         {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2875,7 +2875,7 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tfloat64:
             case Tfloat80:
             {
-                fvalue = Port::nan;
+                fvalue = Port::ldbl_nan;
                 goto Lfvalue;
             }
         }
@@ -2893,7 +2893,7 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tfloat32:
             case Tfloat64:
             case Tfloat80:
-                fvalue = Port::infinity;
+                fvalue = Port::ldbl_infinity;
                 goto Lfvalue;
         }
     }

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -10,9 +10,10 @@
 // Portable wrapper around compiler/system specific things.
 // The idea is to minimize #ifdef's in the app code.
 
-#include "longdouble.h"
-
 #include <stdlib.h> // for alloca
+#include <stdint.h>
+
+#include "longdouble.h"
 
 #if _MSC_VER
 #include <alloca.h>
@@ -26,7 +27,11 @@ typedef unsigned long long ulonglong;
 struct Port
 {
     static double nan;
+    static longdouble ldbl_nan;
+
     static double infinity;
+    static longdouble ldbl_infinity;
+
     static double dbl_max;
     static double dbl_min;
     static longdouble ldbl_max;


### PR DESCRIPTION
Knocking on wood that this doesn't break for any host platforms that have their own longdouble implementation (eg: MSVC).

If this works fine, I will add a raise a new pull for `Port::snan` to replace the Signalling NaN handling in mtype.c
