### PR TITLE
[DDMD] Remove redundant FuncDeclaration::isAbstract

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -685,7 +685,6 @@ public:
     BUILTIN isBuiltin();
     bool isExport();
     bool isImportedSymbol();
-    bool isAbstract();
     bool isCodeseg();
     bool isOverloadable();
     bool hasOverloads();

--- a/src/func.c
+++ b/src/func.c
@@ -3134,11 +3134,6 @@ bool FuncDeclaration::isFinal()
          ((cd = toParent()->isClassDeclaration()) != NULL && cd->storage_class & STCfinal));
 }
 
-bool FuncDeclaration::isAbstract()
-{
-    return (storage_class & STCabstract) != 0;
-}
-
 bool FuncDeclaration::isCodeseg()
 {
     return true;                // functions are always in the code segment


### PR DESCRIPTION
`Declaration::isAbstract` does _exactly_ the same thing.

This situation is impossible in D, because you cannot have two non-virtual functions in a class hierarchy with the same signature.
