### PR TITLE
Remove missed cppunit line in make file that causes 'make clean' to continue forever.

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -310,7 +310,6 @@ clean:
 	$(DEL) impcnvtab.c
 	$(DEL) id.h id.c
 	$(DEL) verstr.h
-	$(MAKE) clean
 
 install: detab install-copy
 


### PR DESCRIPTION
The line above used to 'cd' into the cppunit directory.
