### PR TITLE
[DDMD] Make char unsigned

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -69,7 +69,7 @@ else
 	GFLAGS:=$(WARNINGS) -D__pascal= -fno-exceptions -O2
 endif
 
-CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(OS)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1
+CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(OS)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 -funsigned-char
 MFLAGS = $(GFLAGS) -I$C -I$(TK) -I$(ROOT) -DMARS=1 -DTARGET_$(OS)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1
 
 CH= $C/cc.h $C/global.h $C/oper.h $C/code.h $C/type.h \

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -128,9 +128,9 @@ BFLAGS=
 ##### Implementation variables (do not modify)
 
 # Compile flags
-CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DDM_TARGET_CPU_X86=1
+CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DDM_TARGET_CPU_X86=1 -J
 # Compile flags for modules with backend/toolkit dependencies
-MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DDM_TARGET_CPU_X86=1
+MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DDM_TARGET_CPU_X86=1 -J
 # Recursive make
 DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT)
 


### PR DESCRIPTION
C++ has the annoying situation of three char variants - `signed char`, `unsigned char`, and `char`.  Obviously `char` is either signed or unsigned, but it gets its own unique mangling anyway.

For the translation, I'm converting `signed char` to `byte`, `unsigned char` to `ubyte`, and `char` to `char`.

For this mapping to be accurate, the C++ `char` needs to be unsigned, which is enabled for gcc and dmc with the switches below.

The compiler currently uses `char` when the sign doesn't matter, and `unsigned char` when it does (eg for unicode stuff).  This is problematic in D as string literals do not convert to `const(ubyte)*`, only `const(char)*`.

The plan is to change all strings to `const(char)*` or `char*` inside the compiler, and this is the first step.
