### PR TITLE
9634 [CTFE] wrong code concatenating arrays of structs

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1580,6 +1580,32 @@ Expression *ctfeCat(Type *type, Expression *e1, Expression *e2)
         e = es;
         return e;
     }
+    else if (e1->op == TOKarrayliteral && e2->op == TOKarrayliteral &&
+        t1->nextOf()->equals(t2->nextOf()))
+    {
+        //  [ e1 ] ~ [ e2 ] ---> [ e1, e2 ]
+        ArrayLiteralExp *es1 = (ArrayLiteralExp *)e1;
+        ArrayLiteralExp *es2 = (ArrayLiteralExp *)e2;
+
+        es1 = new ArrayLiteralExp(es1->loc, copyLiteralArray(es1->elements));
+        es1->elements->insert(es1->elements->dim, copyLiteralArray(es2->elements));
+        e = es1;
+        e->type = type;
+        return e;
+    }
+    else if (e1->op == TOKarrayliteral && e2->op == TOKnull &&
+        t1->nextOf()->equals(t2->nextOf()))
+    {
+        //  [ e1 ] ~ null ----> [ e1 ].dup
+        return paintTypeOntoLiteral(type, copyLiteral(e1));
+    }
+    else if (e1->op == TOKnull && e2->op == TOKarrayliteral &&
+        t1->nextOf()->equals(t2->nextOf()))
+    {
+        //  null ~ [ e2 ] ----> [ e2 ].dup
+        return paintTypeOntoLiteral(type, copyLiteral(e2));
+    }
+
     return Cat(type, e1, e2);
 }
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1123,6 +1123,33 @@ int wconcat(wstring replace)
 static assert(wconcat("X"w));
 
 /*******************************************
+    9634 struct concat
+*******************************************/
+
+struct Bug9634
+{
+    int raw;
+}
+
+bool bug9634()
+{
+    Bug9634[] jr = [Bug9634(42)];
+
+    Bug9634[] ir = null ~ jr;
+    Bug9634[] kr = jr ~ null;
+    Bug9634[] mr = jr ~ jr;
+
+    jr[0].raw = 6;
+    assert(ir[0].raw == 42);
+    assert(kr[0].raw == 42);
+    assert(jr[0].raw == 6);
+    assert(&mr[0] != &mr[1]);
+    return true;
+}
+
+static assert(bug9634());
+
+/*******************************************
     Bug 4001: A Space Oddity
 *******************************************/
 


### PR DESCRIPTION
When concatenating, the array literals need to be duplicated, if they are CTFE values.
