### PR TITLE
Regression 10397 ICE with __error in concatenation

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -418,6 +418,11 @@ Lno:
     return MATCHnomatch;
 }
 
+MATCH ErrorExp::implicitConvTo(Type *t)
+{
+    return MATCHnomatch;
+}
+
 MATCH NullExp::implicitConvTo(Type *t)
 {
 #if 0

--- a/src/expression.h
+++ b/src/expression.h
@@ -253,6 +253,7 @@ public:
     ErrorExp();
 
     Expression *implicitCastTo(Scope *sc, Type *t);
+    MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *toLvalue(Scope *sc, Expression *e);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1123,6 +1123,13 @@ int wconcat(wstring replace)
 static assert(wconcat("X"w));
 
 /*******************************************
+    10397 string concat
+*******************************************/
+
+static assert(!is(typeof(compiles!("abc" ~ undefined))));
+static assert(!is(typeof(compiles!(otherundefined ~ "abc"))));
+
+/*******************************************
     9634 struct concat
 *******************************************/
 


### PR DESCRIPTION
ErrorExp was allowing implicit conversions in some cases, because it is derived from IntegerExp! This made errors become un-errors again in some circumstances.

http://d.puremagic.com/issues/show_bug.cgi?id=10397
Better bug report:
http://d.puremagic.com/issues/show_bug.cgi?id=10412
