### PR TITLE
allocate in 16 byte chunks

### DIFF
--- a/src/root/root.c
+++ b/src/root/root.c
@@ -1493,6 +1493,7 @@ void OutBuffer::reserve(size_t nbytes)
     if (size - offset < nbytes)
     {
         size = (offset + nbytes) * 2;
+        size = (size + 15) & ~15;
         data = (unsigned char *)mem.realloc(data, size);
     }
 }


### PR DESCRIPTION
malloc's return 16 byte aligned data anyway, so round up allocation sizes to 16 byte boundaries. This should reduce the number of realloc's.
