### PR TITLE
fix the bit patterns of double.nan and real.nan and real.inf for MS compilation

### DIFF
--- a/src/root/longdouble.c
+++ b/src/root/longdouble.c
@@ -481,9 +481,9 @@ FM1:    // We don't use fprem1 because for some inexplicable
 
 //////////////////////////////////////////////////////////////
 
-longdouble ld_qnan = { 0x8000000000000000ULL, 0x7fff, 0 };
-longdouble ld_snan = { 0x0000000000000001ULL, 0x7fff, 0 };
-longdouble ld_inf  = { 0x0000000000000000ULL, 0x7fff, 0 };
+longdouble ld_qnan = { 0xC000000000000000ULL, 0x7fff, 0 };
+longdouble ld_snan = { 0xC000000000000001ULL, 0x7fff, 0 };
+longdouble ld_inf  = { 0x8000000000000000ULL, 0x7fff, 0 };
 
 longdouble ld_zero  = { 0, 0, 0 };
 longdouble ld_one   = { 0x8000000000000000ULL, 0x3fff, 0 };

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -145,7 +145,7 @@ PortInitializer::PortInitializer()
     union {
         unsigned long ul[2];
         double d;
-    } nan = {{ 0xFFFFFFFF, 0x7FFFFFFF }};
+    } nan = {{ 0, 0x7FF80000 }};
 
     Port::nan = nan.d;
     Port::ldbl_nan = ld_qnan;


### PR DESCRIPTION
The old values were "pseudo" infinite and nan according to wikipedia, but this got undetected because they were never used.

This was caught when actually running the test suite with the MS compiled dmd.
