### PR TITLE
Win64: fix bad merging of non-COMDAT data into COMDAT segment

### DIFF
--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -1485,13 +1485,16 @@ segidx_t MsCoffObj::getsegment(const char *sectname, unsigned long flags)
 {
     //printf("getsegment(%s)\n", sectname);
     assert(strlen(sectname) <= 8);      // so it won't go into string_table
-    for (segidx_t seg = 1; seg <= seg_count; seg++)
-    {   seg_data *pseg = SegData[seg];
-        if (!(flags & IMAGE_SCN_LNK_COMDAT) &&
-            strncmp(ScnhdrTab[pseg->SDshtidx].s_name, sectname, 8) == 0)
-        {
-            //printf("\t%s\n", sectname);
-            return seg;         // return existing segment
+    if (!(flags & IMAGE_SCN_LNK_COMDAT))
+    {
+        for (segidx_t seg = 1; seg <= seg_count; seg++)
+        {   seg_data *pseg = SegData[seg];
+            if (!(ScnhdrTab[pseg->SDshtidx].s_flags & IMAGE_SCN_LNK_COMDAT) &&
+                strncmp(ScnhdrTab[pseg->SDshtidx].s_name, sectname, 8) == 0)
+            {
+                //printf("\t%s\n", sectname);
+                return seg;         // return existing segment
+            }
         }
     }
 


### PR DESCRIPTION
I don't have an easy test case for this, but I guess this is the main reason why the phobos unittests are mostly disabled for Win64 (see unittest.d).

The problem is that if the first segment created for tls is actually a COMDAT segment (say with symbol S), all non-COMDAT data is merged into this segment. If another object file defines the same symbol S, but without or other non-COMDAT data, the additional data might be discarded by the "pick-any" strategy.
