### PR TITLE
CTFE: Pointer cast wrong-code bug

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5337,7 +5337,7 @@ Expression *CastExp::interpret(InterState *istate, CtfeGoal goal)
             if (e1->op == TOKvar)
                 e = new VarExp(loc, ((VarExp *)e1)->var);
             else
-                e = new SymOffExp(loc, ((SymOffExp *)e1)->var, 0);
+                e = new SymOffExp(loc, ((SymOffExp *)e1)->var, ((SymOffExp *)e1)->offset);
             e->type = to;
             return e;
         }


### PR DESCRIPTION
This is a severe, obvious bug -- the pointer offset was ignored. So that  &var[5]  was becoming &var[0]  !

But as far as I know, the bug cannot be triggered at the moment, because this pointer type-painting is normally done by the constant folding in optimize.c.

This was causing the test suite to fail on Win32 when using CTFE to do const folding.
