### PR TITLE
[do not merge] fix issue 10329 - Attributes not inferred for indirectly templated methods

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -827,13 +827,22 @@ void FuncDeclaration::semantic(Scope *sc)
     }
 
 Ldone:
+    bool isTemplate = false;
+    for (Dsymbol *p = parent; p; p = p->parent)
+    {
+        if (p->isTemplateInstance())
+        {
+            isTemplate = true;
+            break;
+        }
+    }
+
     /* Purity and safety can be inferred for some functions by examining
      * the function body.
      */
     if (fbody &&
         (isFuncLiteralDeclaration() ||
-         parent->isTemplateInstance() ||
-         ad && ad->parent && ad->parent->isTemplateInstance() && !isVirtualMethod()))
+         (isTemplate && !isVirtualMethod())))
     {
         /* isVirtualMethod() needs setting correct foverrides
          */

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -1,3 +1,4 @@
+module testInference;
 
 /***************************************************/
 // 6265.
@@ -48,7 +49,7 @@ void fECPa() {
         }
         h();
     }
-    static assert( is(typeof(&g!()) == void delegate() pure));
+    static assert( is(typeof(&g!()) == void delegate() nothrow pure @safe));
     static assert(!is(typeof(&g!()) == void delegate()));
 }
 
@@ -104,10 +105,10 @@ void test7017a() pure
 {
     int bar7017(immutable int x) pure nothrow { return 1; }
 
-    static assert(!__traits(compiles, map7017!((){})()));   // should pass, but fails
-    static assert(!__traits(compiles, map7017!q{ 1 }()));   // pass, OK
-    static assert(!__traits(compiles, map7017!foo7017()));  // pass, OK
-    static assert( __traits(compiles, map7017!bar7017()));
+    static assert(__traits(compiles, map7017!((){})()));
+    static assert(__traits(compiles, map7017!q{ 1 }()));
+    static assert(__traits(compiles, map7017!foo7017()));
+    static assert(__traits(compiles, map7017!bar7017()));
 }
 
 /***************************************************/

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2867,7 +2867,6 @@ int main()
     test8833();
     test8976();
     test8940();
-    test9022();
     test9026();
     test9038();
     test9076();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10329
