### PR TITLE
Remove some more dead IN_GCC code.

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -326,11 +326,7 @@ Expression *Mul(Type *type, Expression *e1, Expression *e2)
 
     if (type->isfloating())
     {   complex_t c;
-#ifdef IN_GCC
-        real_t r;
-#else
         d_float80 r;
-#endif
 
         if (e1->type->isreal())
         {
@@ -397,11 +393,7 @@ Expression *Div(Type *type, Expression *e1, Expression *e2)
 
     if (type->isfloating())
     {   complex_t c;
-#ifdef IN_GCC
-        real_t r;
-#else
         d_float80 r;
-#endif
 
         //e1->type->print();
         //e2->type->print();

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -239,11 +239,7 @@ struct Token
         d_uns64 uns64value;
 
         // Floats
-#ifdef IN_GCC
-        // real_t float80value; // can't use this in a union!
-#else
         d_float80 float80value;
-#endif
 
         struct
         {   unsigned char *ustring;     // UTF8 string
@@ -253,9 +249,6 @@ struct Token
 
         Identifier *ident;
     };
-#ifdef IN_GCC
-    real_t float80value; // can't use this in a union!
-#endif
 
     static const char *tochars[TOKMAX];
     static void *operator new(size_t sz);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2784,11 +2784,7 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
 {
     Expression *e;
     d_int64 ivalue;
-#ifdef IN_GCC
-    real_t    fvalue;
-#else
     d_float80 fvalue;
-#endif
 
     //printf("TypeBasic::getProperty('%s')\n", ident->toChars());
     if (ident == Id::max)


### PR DESCRIPTION
Have fixed mars.h in #2196 and made changes on gdc's side so that d_float80 is safe to use in the frontend.  No longer need to explicitly use real_t.

The change to `lexer.h` hasn't been fixed in gdc.  But I am looking to remove all constructors defined in gdc's longdouble class to allow it to be possible.
