### PR TITLE
Issue 10244 - ICE: expression.c:8364: virtual Expression* CallExp::semantic(Scope*): Assertion `td' failed

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8367,14 +8367,20 @@ Lagain:
                 av = new CommaExp(loc, av, new VarExp(loc, tmp));
 
                 Expression *e;
-                CtorDeclaration *cf = ad->ctor->isCtorDeclaration();
-                if (cf)
+                if (CtorDeclaration *cf = ad->ctor->isCtorDeclaration())
+                {
                     e = new DotVarExp(loc, av, cf, 1);
-                else
-                {   TemplateDeclaration *td = ad->ctor->isTemplateDeclaration();
-                    assert(td);
+                }
+                else if (TemplateDeclaration *td = ad->ctor->isTemplateDeclaration())
+                {
                     e = new DotTemplateExp(loc, av, td);
                 }
+                else if (OverloadSet *os = ad->ctor->isOverloadSet())
+                {
+                    e = new DotExp(loc, av, new OverExp(loc, os));
+                }
+                else
+                    assert(0);
                 e = new CallExp(loc, e, arguments);
                 e = e->semantic(sc);
                 return e;

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2891,6 +2891,34 @@ static assert(__traits(compiles, &check10079!S10079e));
 static assert(__traits(compiles, &check10079!S10079f));
 
 /**********************************/
+// 10244
+
+void test10244()
+{
+    static struct Foo
+    {
+        string _str;
+        long _num;
+
+        template DeclareConstructor(string fieldName)
+        {
+            enum code =
+                `this(typeof(_` ~ fieldName ~ `) value)` ~
+                `{ this._` ~ fieldName ~ ` = value; }`;
+            mixin(code);
+        }
+
+        mixin DeclareConstructor!"str";
+        mixin DeclareConstructor!"num";
+    }
+
+    Foo value1 = Foo("D");
+    Foo value2 = Foo(128);
+    assert(value1._str == "D");
+    assert(value2._num == 128);
+}
+
+/**********************************/
 
 int main()
 {
@@ -2981,6 +3009,7 @@ int main()
     test9985();
     test9994();
     test10094();
+    test10244();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10244
