### PR TITLE
[Trivial] Some DMD warning fixes

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -2315,7 +2315,7 @@ void highlightCode3(Scope *sc, OutBuffer *buf, unsigned char *p, unsigned char *
 
 void highlightCode2(Scope *sc, Dsymbol *s, OutBuffer *buf, size_t offset)
 {
-    char *sid = s->ident->toChars();
+    const char *sid = s->ident->toChars();
     FuncDeclaration *f = s->isFuncDeclaration();
     unsigned errorsave = global.errors;
     Lexer lex(NULL, buf->data, 0, buf->offset - 1, 0, 1);

--- a/src/template.c
+++ b/src/template.c
@@ -2863,9 +2863,9 @@ MATCH Type::deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters,
         {
             //printf("matching %s to %s\n", tparam->toChars(), toChars());
             Dsymbol *s = this->toDsymbol(sc);
-            for (size_t i = tident->idents.dim; i-- > 0; )
+            for (size_t j = tident->idents.dim; j-- > 0; )
             {
-                RootObject *id = tident->idents[i];
+                RootObject *id = tident->idents[j];
                 if (id->dyncast() == DYNCAST_IDENTIFIER)
                 {
                     if (!s || !s->parent)
@@ -2874,7 +2874,7 @@ MATCH Type::deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters,
                     if (!s2)
                         goto Lnomatch;
                     s2 = s2->toAlias();
-                    //printf("[%d] s = %s %s, s2 = %s %s\n", i, s->kind(), s->toChars(), s2->kind(), s2->toChars());
+                    //printf("[%d] s = %s %s, s2 = %s %s\n", j, s->kind(), s->toChars(), s2->kind(), s2->toChars());
                     if (s != s2)
                     {
                         if (Type *t = s2->getType())


### PR DESCRIPTION
Fix warning: `deprecated conversion from string constant to ‘char*’`
Fix warning: `template.c:2899:48: warning: name lookup of ‘i’ changed [enabled by default]
        template.c:2836:16: warning:   matches this ‘i’ under ISO standard rules [enabled by default]
        template.c:2866:25: warning:   matches this ‘i’ under old rules [enabled by default]`
