### PR TITLE
Fix Issue 9356 - -inline with inout and append generates wrong code

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -918,6 +918,7 @@ public:
     bool addPreInvariant();
     bool addPostInvariant();
     void emitComment(Scope *sc);
+    void inlineScan();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     UnitTestDeclaration *isUnitTestDeclaration() { return this; }

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1926,6 +1926,7 @@ elem *NewExp::toElem(IRState *irs)
     }
     else
     {
+        error("ICE: cannot new type %s\n", t->toChars());
         assert(0);
     }
 
@@ -3330,9 +3331,10 @@ elem *CatAssignExp::toElem(IRState *irs)
             elem *ep = el_params(e2, e1, this->e1->type->getTypeInfo(NULL)->toElem(irs), NULL);
             e = el_bin(OPcall, TYdarray, el_var(rtlsym[RTLSYM_ARRAYAPPENDT]), ep);
         }
-        else
+        else if (tb1n->equals(tb2))
         {
             // Append element
+
             elem *e2x = NULL;
 
             if (e2->Eoper != OPvar && e2->Eoper != OPconst)
@@ -3392,6 +3394,12 @@ elem *CatAssignExp::toElem(IRState *irs)
             e = el_combine(e, eeq);
             e = el_combine(e, el_var(stmp));
         }
+        else
+        {
+            error("ICE: cannot append '%s' to '%s'", tb2->toChars(), tb1->toChars());
+            assert(0);
+        }
+
         el_setLoc(e,loc);
     }
     else

--- a/src/inline.c
+++ b/src/inline.c
@@ -1385,6 +1385,8 @@ Expression *CallExp::inlineScan(InlineScanState *iss)
         }
     }
 
+    if (e && type->ty != Tvoid)
+        e->type = type;
     return e;
 }
 

--- a/src/inline.c
+++ b/src/inline.c
@@ -1822,6 +1822,13 @@ Expression *FuncDeclaration::expandInline(InlineScanState *iss, Expression *ethi
     return e;
 }
 
+void UnitTestDeclaration::inlineScan()
+{
+    if (global.params.useUnitTests)
+    {
+        FuncDeclaration::inlineScan();
+    }
+}
 
 /****************************************************
  * Perform the "inline copying" of a default argument for a function parameter.

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -269,6 +269,18 @@ struct Task
     }
 }
 
+void test9356()
+{
+    static inout(char)[] bar (inout(char)[] a)
+    {
+        return a;
+    }
+
+    string result;
+    result ~= bar("abc");
+    assert(result == "abc");
+}
+
 /************************************/
 // 11223
 
@@ -300,6 +312,7 @@ int main()
     test3();
     test4();
     test5();
+    test9356();
     test6();
     test7();
     test8();


### PR DESCRIPTION
Force the result expression from inlining a function to match the type of the call expression.

eg the inlined expression from
`inout(char)[] bar (inout(char)[] a) { return a; }`
called with:
`bar("abc")`
should be
`immutable(char)[]`
but the type of the actual return expression is
`inout(char)[]`.

Coupled with an optimistic if/else in e2ir, this generates wrong code.

http://d.puremagic.com/issues/show_bug.cgi?id=9356
