### PR TITLE
[enh] fix issue 10491 - Type inference for function arguments with default value

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1325,6 +1325,10 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(FuncDeclaration *f, Loc l
     {
         Parameter *fparam = Parameter::getNth(fparameters, parami);
 
+        // If inferred by default initializer, skip.
+        if (!fparam->type)
+            goto Lmatch;
+
         // Apply function parameter storage classes to parameter types
         Type *prmtype = fparam->type->addStorageClass(fparam->storageClass);
 

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -375,6 +375,50 @@ pure void test10296()
 }
 
 /***************************************************/
+// 10491
+
+void foo10491(a = 10, b = null)
+{
+    static assert(is(typeof(a) == int));
+    static assert(is(typeof(b) == typeof(null)));
+}
+
+class C10491 { }
+
+void bar10491(const c = new C10491, immutable i = 42, f = 44.34f, in j = "yo")
+{
+    static assert(is(typeof(c) == const C10491));
+    static assert(is(typeof(i) == immutable int));
+    static assert(is(typeof(f) == float));
+    static assert(is(typeof(j) == const string));
+}
+
+struct S10491(T) { T val; }
+
+void baz10491(T)(s = S10491!T("test"))
+{
+    static assert(is(typeof(s) == S10491!T));
+}
+
+class V10491(T...) { }
+
+void qux10491(T...)(const v = new V10491!T(), i = 43)
+{
+    static assert(is(typeof(v) == const V10491!T));
+    static assert(is(typeof(i) == int));
+}
+
+void test10491()
+{
+    foo10491;
+    foo10491(10);
+    bar10491;
+    bar10491(null, 10);
+    baz10491!string;
+    qux10491!(int, double, V10491);
+}
+
+/***************************************************/
 
 // Add more tests regarding inferences later.
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10491

``` d
void foo(i = 10, immutable f = 10.0f, const d = 10.0)
{
    static assert(is(typeof(i) == int));
    static assert(is(typeof(f) == immutable float));
    static assert(is(typeof(d) == const double));
}

struct S(T) { T val; }

void bar(T)(x = S!T("str"))
{
    static assert(is(typeof(x) == S!T));
}
```
