### PR TITLE
Catch GCC ±Inf bugs.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3023,6 +3023,8 @@ void realToMangleBuffer(OutBuffer *buf, real_t value)
 
     if (Port::isNan(value))
         buf->writestring("NAN");        // no -NAN bugs
+    else if (Port::isInfinity(value))
+        buf->writestring(value < 0 ? "NINF" : "INF");
     else
     {
         char buffer[36];


### PR DESCRIPTION
GDC's ld_sprint will write `+Inf`/`-Inf` to buffer rather than `INF`/`NINF` (see gcc's real.c real_to_decimal_for_mode).

Better to catch infinity here so that mangling is correct.
