### PR TITLE
[enh] fix issue 6549 - Implement contracts without implementation.

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -412,15 +412,11 @@ void FuncDeclaration::semantic(Scope *sc)
             error("function body only allowed in final functions in interface %s", id->toChars());
     }
 
-    /* Contracts can only appear without a body when they are virtual interface functions
-     */
-    if (!fbody && (fensure || frequire) && !(id && isVirtual()))
-        error("in and out contracts require function body");
-
     cd = parent->isClassDeclaration();
     if (cd)
     {
         size_t vi;
+
         if (isCtorDeclaration())
         {
 //          ctor = (CtorDeclaration *)this;
@@ -708,6 +704,11 @@ void FuncDeclaration::semantic(Scope *sc)
     }
     else if (isOverride() && !parent->isTemplateInstance())
         error("override only applies to class member functions");
+
+    /* Contracts can only appear without a body when they are virtual interface functions or abstract
+     */
+    if (!fbody && !isAbstract() && !(cd && cd->isAbstract()) && (fensure || frequire) && !(id && isVirtual()))
+        error("in and out contracts on non-virtual/non-abstract functions require function body");
 
     /* Do not allow template instances to add virtual functions
      * to a class.

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -357,6 +357,56 @@ class Foo5204 : IFoo5204
 }
 
 /*******************************************/
+// 6549
+
+class C6549
+{
+    static int ocount = 0;
+    static int icount = 0;
+
+    abstract int foo(int)
+    in { ++icount; }
+    out { ++ocount; }
+}
+
+class CD6549 : C6549
+{
+    override int foo(int)
+    in { assert(false); }
+    body { return 10; }
+}
+
+abstract class D6549
+{
+    static int icount = 0;
+    static int ocount = 0;
+
+    int foo(int)
+    in { ++icount; }
+    out { ++ocount; }
+}
+
+class DD6549 : D6549
+{
+    override int foo(int)
+    in { assert(false); }
+    body { return 10; }
+}
+
+void test6549()
+{
+    auto c = new CD6549;
+    c.foo(10);
+    assert(C6549.icount == 1);
+    assert(C6549.ocount == 1);
+
+    auto d = new DD6549;
+    d.foo(10);
+    assert(D6549.icount == 1);
+    assert(D6549.ocount == 1);
+}
+
+/*******************************************/
 // 7218
 
 void test7218()
@@ -585,6 +635,7 @@ int main()
     test8();
     test9();
     test4785();
+    test6549();
     test7218();
     test8073();
     test8093();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6549

Fixes the abstract stuff, I'm not sure about contracts in function forward references used by closed-source libraries:

``` d
void func(int i)
in { assert(i > 10); }
```
