### PR TITLE
Add defaultInitLiteral() to TypeVector.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3433,6 +3433,11 @@ Expression *TypeVector::defaultInit(Loc loc)
     return basetype->defaultInit(loc);
 }
 
+Expression *TypeVector::defaultInitLiteral(Loc loc)
+{
+    return basetype->defaultInitLiteral(loc);
+}
+
 int TypeVector::isZeroInit(Loc loc)
 {
     return basetype->isZeroInit(loc);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -451,6 +451,7 @@ public:
     int checkBoolean();
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
+    Expression *defaultInitLiteral(Loc loc);
     TypeBasic *elementType();
     int isZeroInit(Loc loc);
     TypeInfoDeclaration *getTypeInfoDeclaration();


### PR DESCRIPTION
The default init literal of a `TypeVector` element should be an `ArrayLiteralExp` and not a scalar value.
