### PR TITLE
add switch jump tables for Win64, Linux, FreeBSD and OSX

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -72,6 +72,7 @@ void out_config_init(
         // Not sure we really need these two lines, try removing them later
         config.flags |= CFGnoebp;
         config.flags |= CFGalwaysframe;
+        config.flags |= CFGromable; // put switch tables in code segment
     }
     else
     {   config.exe = EX_NT;
@@ -88,7 +89,11 @@ void out_config_init(
         config.fpxmmregs = TRUE;
     }
     else
+    {
         config.exe = EX_LINUX;
+        if (!exe)
+            config.flags |= CFGromable; // put switch tables in code segment
+    }
     config.flags |= CFGnoebp;
     config.flags |= CFGalwaysframe;
     if (!exe)
@@ -106,6 +111,7 @@ void out_config_init(
     config.flags |= CFGalwaysframe;
     if (!exe)
         config.flags3 |= CFG3pic;
+    config.flags |= CFGromable; // put switch tables in code segment
 #endif
 #if TARGET_FREEBSD
     if (model == 64)
@@ -113,7 +119,11 @@ void out_config_init(
         config.fpxmmregs = TRUE;
     }
     else
+    {
         config.exe = EX_FREEBSD;
+        if (!exe)
+            config.flags |= CFGromable; // put switch tables in code segment
+    }
     config.flags |= CFGnoebp;
     config.flags |= CFGalwaysframe;
     if (!exe)
@@ -125,7 +135,11 @@ void out_config_init(
         config.fpxmmregs = TRUE;
     }
     else
+    {
         config.exe = EX_OPENBSD;
+        if (!exe)
+            config.flags |= CFGromable; // put switch tables in code segment
+    }
     config.flags |= CFGnoebp;
     config.flags |= CFGalwaysframe;
     if (!exe)
@@ -137,7 +151,11 @@ void out_config_init(
         config.fpxmmregs = TRUE;
     }
     else
+    {
         config.exe = EX_SOLARIS;
+        if (!exe)
+            config.flags |= CFGromable; // put switch tables in code segment
+    }
     config.flags |= CFGnoebp;
     config.flags |= CFGalwaysframe;
     if (!exe)

--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -541,8 +541,11 @@ typedef struct block
         // CODGEN
         struct
         {
-            targ_size_t Btablesize;     // BCswitch, BCjmptab
-            targ_size_t Btableoffset;   // BCswitch, BCjmptab
+            // For BCswitch, BCjmptab
+            targ_size_t Btablesize;     // size of generated table
+            targ_size_t Btableoffset;   // offset to start of table
+            targ_size_t Btablebase;     // offset to instruction pointer base
+
             targ_size_t Boffset;        // code offset of start of this block
             targ_size_t Bsize;          // code size of this block
             con_t       Bregcon;        // register state at block exit
@@ -550,6 +553,7 @@ typedef struct block
 
             #define Btablesize          _BLU._UD.Btablesize
             #define Btableoffset        _BLU._UD.Btableoffset
+            #define Btablebase          _BLU._UD.Btablebase
             #define Boffset             _BLU._UD.Boffset
             #define Bsize               _BLU._UD.Bsize
 //          #define Bcode               _BLU._UD.Bcode

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -404,7 +404,9 @@ tryagain:
         for (block* b = startblock; b; b = b->Bnext)
         {
             if (b->BC == BCjmptab || b->BC == BCswitch)
-            {   b->Btableoffset = swoffset;     /* offset of sw tab */
+            {
+                swoffset = align(0,swoffset);
+                b->Btableoffset = swoffset;     /* offset of sw tab */
                 swoffset += b->Btablesize;
             }
             jmpaddr(b->Bcode);          /* assign jump addresses        */

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1140,6 +1140,13 @@ void doswitch(block *b)
     unsigned msw;
 #endif
 
+#if TARGET_WINDOS
+    // If switch tables are in code segment and we need a CS: override to get at them
+    bool csseg = config.flags & CFGromable;
+#else
+    bool csseg = false;
+#endif
+
     e = b->Belem;
     elem_debug(e);
     cc = docommas(&e);
@@ -1178,6 +1185,24 @@ void doswitch(block *b)
     p -= ncases;
     //dbg_printf("vmax = x%lx, vmin = x%lx, vmax-vmin = x%lx\n",vmax,vmin,vmax - vmin);
 
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS || TARGET_OSX
+    if (//!(I64 && (config.flags3 & CFG3pic)) &&
+        ncases > 3 &&
+        (targ_ullong)(vmax - vmin) <= ncases * 2)  // then use jump table
+    {
+        goto Ljmptab;
+    }
+    else
+#endif
+#if TARGET_WINDOS
+    if (I64 &&
+        ncases > 3 &&
+        (targ_ullong)(vmax - vmin) <= ncases * 2)  // then use jump table
+    {
+        goto Ljmptab;
+    }
+    else
+#endif
     if (I64)
     {   // For now, just generate basic if-then sequence to get us running
         retregs = ALLREGS;
@@ -1256,16 +1281,30 @@ void doswitch(block *b)
                 c = cat(c,genjmp(CNIL,JMP,FLblock,list_block(b->Bsucc)));
         ce = NULL;
     }
-#if TARGET_WINDOS               // try and find relocation to support this
-    else if (config.exe != EX_WIN64 &&
+#if TARGET_WINDOS || TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS || TARGET_OSX
+    else if (
+#if TARGET_WINDOS
+        config.exe != EX_WIN64 &&
+#endif
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS || TARGET_OSX
+        I64 && !(config.flags3 & CFG3pic) &&
+#endif
              (targ_ullong)(vmax - vmin) <= ncases * 2)  // then use jump table
-    {   int modify;
+    {
+    Ljmptab:
+        //printf("Ljmptab:\n");
+        int modify;
 
         b->BC = BCjmptab;
+        b->Btablesize = (int) (vmax - vmin + 1) * tysize[TYnptr];
         retregs = IDXREGS;
         if (dword)
             retregs |= mMSW;
-        modify = (vmin || !I32);
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
+        if (I32 && config.flags3 & CFG3pic)
+            retregs &= ~mBX;                            // need EBX for GOT
+#endif
+        modify = (vmin || I16 || I64);
         c = scodelem(e,&retregs,0,!modify);
         reg = findreg(retregs & IDXREGS); /* reg that result is in      */
         if (dword)
@@ -1292,7 +1331,42 @@ void doswitch(block *b)
             c = genc2(c,0x81,modregrm(3,7,reg),vmax-vmin);
             genjmp(c,JA,FLblock,list_block(b->Bsucc));  /* JA default   */
         }
-        if (I32)
+        if (I64)
+        {
+            if (!vmin)
+            {   // Need to clear out high 32 bits of reg
+                c = genmovreg(c,reg,reg);                       // MOV reg,reg
+            }
+            if (config.flags3 & CFG3pic || config.exe == EX_WIN64)
+            {
+                /* LEA    R1,disp[RIP]          48 8D 05 00 00 00 00
+                 * MOVSXD R2,[reg*4][R1]        48 63 14 B8
+                 * LEA    R1,[R1][R2]           48 8D 04 02
+                 * JMP    R1                    FF E0
+                 */
+                unsigned r1;
+                regm_t scratchm = ALLREGS & ~mask[reg];
+                c = cat(c, allocreg(&scratchm,&r1,TYint));
+                unsigned r2;
+                scratchm = ALLREGS & ~(mask[reg] | mask[r1]);
+                c = cat(c, allocreg(&scratchm,&r2,TYint));
+
+                ce = genc1(CNIL,LEA,(REX_W << 16) | modregxrm(0,r1,5),FLswitch,0);        // LEA R1,disp[RIP]
+                gen2sib(ce,0x63,(REX_W << 16) | modregxrm(0,r2,4), modregxrmx(2,reg,r1)); // MOVSXD R2,[reg*4][R1]
+                gen2sib(ce,LEA,(REX_W << 16) | modregxrm(0,r1,4),modregxrmx(0,r1,r2));    // LEA R1,[R1][R2]
+                gen2(ce,0xFF,modregrmx(3,4,r1));                                          // JMP R1
+
+                b->Btablesize = (int) (vmax - vmin + 1) * 4;
+            }
+            else
+            {
+                ce = genc1(CNIL,0xFF,modregrm(0,4,4),FLswitch,0);   // JMP disp[reg*8]
+                ce->Isib = modregrm(3,reg & 7,5);
+                if (reg & 8)
+                    ce->Irex |= REX_X;
+            }
+        }
+        else if (I32)
         {
 #if JMPJMPTABLE
             /* LEA jreg,offset ctable[reg][reg * 4]
@@ -1334,20 +1408,61 @@ void doswitch(block *b)
             b->Btablesize = 0;
             goto L2;
 #else
-            ce = genc1(CNIL,0xFF,modregrm(0,4,4),FLswitch,0); /* JMP [CS:]disp[idxreg*4] */
-            ce->Isib = modregrm(2,reg,5);
+#if TARGET_OSX
+            /*     CALL L1
+             * L1: POP  R1
+             *     ADD  R1,disp[reg*4][R1]
+             *     JMP  R1
+             */
+            // Allocate scratch register r1
+            regm_t scratchm = ALLREGS & ~mask[reg];
+            unsigned r1;
+            c = cat(c, allocreg(&scratchm,&r1,TYint));
+
+            c = genc2(c,CALL,0,0);                               //     CALL L1
+            gen1(c, 0x58 + r1);                                  // L1: POP R1
+            ce = genc1(CNIL,0x03,modregrm(2,r1,4),FLswitch,0);   // ADD R1,disp[reg*4][EBX]
+            ce->Isib = modregrm(2,reg,r1);
+            gen2(ce,0xFF,modregrm(3,4,r1));                      // JMP R1
+#else
+            if (config.flags3 & CFG3pic)
+            {
+                /* MOV  R1,EBX
+                 * SUB  R1,funcsym_p@GOTOFF[offset][reg*4][EBX]
+                 * JMP  R1
+                 */
+
+                // Load GOT in EBX
+                c = cat(c,load_localgot());
+
+                // Allocate scratch register r1
+                regm_t scratchm = ALLREGS & ~(mask[reg] | mBX);
+                unsigned r1;
+                c = cat(c, allocreg(&scratchm,&r1,TYint));
+
+                c = genmovreg(c,r1,BX);                                 // MOV R1,EBX
+                ce = genc1(CNIL,0x2B,modregxrm(2,r1,4),FLswitch,0);     // SUB R1,disp[reg*4][EBX]
+                ce->Isib = modregrm(2,reg,BX);
+                gen2(ce,0xFF,modregrmx(3,4,r1));                        // JMP R1
+            }
+            else
+            {
+                ce = genc1(CNIL,0xFF,modregrm(0,4,4),FLswitch,0);       // JMP disp[idxreg*4]
+                ce->Isib = modregrm(2,reg,5);
+            }
+#endif
 #endif
         }
-        else
+        else if (I16)
         {
             c = gen2(c,0xD1,modregrm(3,4,reg)); /* SHL reg,1            */
             rm = getaddrmode(retregs) | modregrm(0,4,0);
             ce = genc1(CNIL,0xFF,rm,FLswitch,0);        /* JMP [CS:]disp[idxreg] */
         }
-        int flags = (config.flags & CFGromable) ? CFcs : 0; // table is in code seg
-        ce->Iflags |= flags;                    // segment override
+        else
+            assert(0);
+        ce->Iflags |= csseg ? CFcs : 0;                    // segment override
         ce->IEV1.Vswitch = b;
-        b->Btablesize = (int) (vmax - vmin + 1) * tysize[TYnptr];
     }
 #endif
     else                                /* else use switch table (BCswitch) */
@@ -1406,13 +1521,14 @@ void doswitch(block *b)
          * Therefore, load ES with proper segment value.
          */
         if (config.flags3 & CFG3eseqds)
-        {   assert(!(config.flags & CFGromable));
+        {
+            assert(!csseg);
             ce = cat(ce,getregs(mCX));          // allocate CX
         }
         else
         {
             ce = cat(ce,getregs(mES|mCX));      // allocate ES and CX
-            gen1(ce,(config.flags & CFGromable) ? 0x0E : 0x1E); // PUSH CS/DS
+            gen1(ce,csseg ? 0x0E : 0x1E);       // PUSH CS/DS
             gen1(ce,0x07);                      // POP  ES
         }
 
@@ -1428,15 +1544,13 @@ void doswitch(block *b)
              */
 
             mod = (disp > 127) ? 2 : 1;         /* displacement size    */
-            cloop = genc2(CNIL,0xE0,0,-7 - mod -
-                ((config.flags & CFGromable) ? 1 : 0)); /* LOOPNE scasw */
+            cloop = genc2(CNIL,0xE0,0,-7 - mod - csseg); // LOOPNE scasw
             ce = gen1(ce,0xAF);                         /* SCASW        */
             code_orflag(ce,CFtarg2);                    // target of jump
             genjmp(ce,JNE,FLcode,(block *) cloop);      /* JNE loop     */
                                                 /* CMP DX,[CS:]disp[DI] */
             ct = genc1(CNIL,0x39,modregrm(mod,DX,5),FLconst,disp);
-            int flags = (config.flags & CFGromable) ? CFcs : 0; // table is in code seg
-            ct->Iflags |= flags;                // possible seg override
+            ct->Iflags |= csseg ? CFcs : 0;             // possible seg override
             ce = cat3(ce,ct,cloop);
             disp += ncases * intsize;           /* skip over msw table  */
         }
@@ -1447,8 +1561,8 @@ void doswitch(block *b)
         }
         genjmp(ce,JNE,FLblock,list_block(b->Bsucc)); /* JNE default     */
         mod = (disp > 127) ? 2 : 1;     /* 1 or 2 byte displacement     */
-        if (config.flags & CFGromable)
-                gen1(ce,SEGCS);         /* table is in code segment     */
+        if (csseg)
+            gen1(ce,SEGCS);             // table is in code segment
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
         if (config.flags3 & CFG3pic)
         {                               // ADD EDX,(ncases-1)*2[EDI]
@@ -1460,8 +1574,7 @@ void doswitch(block *b)
 #endif
         {                               // JMP (ncases-1)*2[DI]
             ct = genc1(CNIL,0xFF,modregrm(mod,4,(I32 ? 7 : 5)),FLconst,disp);
-            int flags = (config.flags & CFGromable) ? CFcs : 0; // table is in code seg
-            ct->Iflags |= flags;
+            ct->Iflags |= csseg ? CFcs : 0;
         }
         ce = cat(ce,ct);
         b->Btablesize = disp + intsize + ncases * tysize[TYnptr];
@@ -1488,6 +1601,7 @@ void outjmptab(block *b)
   targ_llong u,vmin,vmax,val,*p;
   targ_size_t alignbytes,def,targ,*poffset;
   int jmpseg;
+  symbol *gotsym = NULL;
 
   poffset = (config.flags & CFGromable) ? &Coffset : &JMPOFF;
   p = b->BS.Bswitch;                    /* pointer to case data         */
@@ -1505,6 +1619,8 @@ void outjmptab(block *b)
   alignbytes = align(0,*poffset) - *poffset;
   objmod->lidata(jmpseg,*poffset,alignbytes);
 
+  assert(*poffset == b->Btableoffset);
+
   def = list_block(b->Bsucc)->Boffset;  /* default address              */
   assert(vmin <= vmax);
   for (u = vmin; ; u++)
@@ -1515,8 +1631,55 @@ void outjmptab(block *b)
                         break;
                 }
         }
-        objmod->reftocodeseg(jmpseg,*poffset,targ);
-        *poffset += tysize[TYnptr];
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
+        if (I64)
+        {
+            if (config.flags3 & CFG3pic)
+            {
+                objmod->reftodatseg(jmpseg,*poffset,targ + (u - vmin) * 4,funcsym_p->Sseg,CFswitch);
+                *poffset += 4;
+            }
+            else
+            {
+                objmod->reftodatseg(jmpseg,*poffset,targ,funcsym_p->Sxtrnnum,CFoffset64 | CFswitch);
+                *poffset += 8;
+            }
+        }
+        else
+        {
+            if (config.flags3 & CFG3pic)
+            {
+                assert(config.flags & CFGromable);
+                // Want a GOTPC fixup to _GLOBAL_OFFSET_TABLE_
+                if (!gotsym)
+                    gotsym = Obj::getGOTsym();
+                objmod->reftoident(jmpseg,*poffset,gotsym,*poffset - targ,CFswitch);
+            }
+            else
+                objmod->reftocodeseg(jmpseg,*poffset,targ);
+            *poffset += 4;
+        }
+#elif TARGET_OSX
+        targ_size_t val;
+        if (I64)
+            val = targ - b->Btableoffset;
+        else
+            val = targ - b->Btablebase;
+        objmod->write_bytes(SegData[jmpseg],4,&val);
+#elif TARGET_WINDOS
+        if (I64)
+        {
+            targ_size_t val = targ - b->Btableoffset;
+            objmod->write_bytes(SegData[jmpseg],4,&val);
+        }
+        else
+        {
+            objmod->reftocodeseg(jmpseg,*poffset,targ);
+            *poffset += tysize[TYnptr];
+        }
+#else
+        assert(0);
+#endif
         if (u == vmax)                  /* for case that (vmax == ~0)   */
                 break;
   }
@@ -3862,13 +4025,15 @@ void cod3_thunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
     }
     else
     {
+#if 0
         localgot = NULL;                // no local variables
         code *c1 = load_localgot();
         if (c1)
         {   assignaddrc(c1);
             c = cat(c, c1);
         }
-        c1 = gencs(CNIL,(LARGECODE ? 0xEA : 0xE9),0,FLfunc,sfunc); /* JMP sfunc */
+#endif
+        code *c1 = gencs(CNIL,(LARGECODE ? 0xEA : 0xE9),0,FLfunc,sfunc); /* JMP sfunc */
         c1->Iflags |= LARGECODE ? (CFseg | CFoff) : (CFselfrel | CFoff);
         c = cat(c,c1);
     }
@@ -6098,7 +6263,28 @@ STATIC void do32bit(enum FL fl,union evc *uev,int flags, int val)
         FLUSH();
         ad = uev->Vswitch->Btableoffset;
         if (config.flags & CFGromable)
+        {
+#if TARGET_OSX
+            // These are magic values based on the exact code generated for the switch jump
+            if (I64)
+                uev->Vswitch->Btablebase = OFFSET() + 4;
+            else
+                uev->Vswitch->Btablebase = OFFSET() + 4 - 8;
+            ad -= uev->Vswitch->Btablebase;
+            goto L1;
+#elif TARGET_WINDOS
+            if (I64)
+            {
+                uev->Vswitch->Btablebase = OFFSET() + 4;
+                ad -= uev->Vswitch->Btablebase;
+                goto L1;
+            }
+            else
                 objmod->reftocodeseg(cseg,offset,ad);
+#else
+            objmod->reftocodeseg(cseg,offset,ad);
+#endif
+        }
         else
                 objmod->reftodatseg(cseg,offset,ad,JMPSEG,CFoff);
         break;

--- a/src/backend/code_x86.h
+++ b/src/backend/code_x86.h
@@ -393,6 +393,7 @@ struct code
 #define CFvex3      0x200000    // 3 byte vex prefix
 
 #define CFjmp5      0x400000    // always a 5 byte jmp
+#define CFswitch    0x800000    // kludge for switch table fixups
 
 /* These are for CFpc32 fixups, they're the negative of the offset of the fixup
  * from the program counter


### PR DESCRIPTION
This adds the optimization for switch statements that result in jump tables. Previously, this was only done for Win32. For many switch statements, this should substantially increase speed.
