### PR TITLE
Issue 4899 - Ddoc: Warnings about stray parens do not include file and line numbers for module comments

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -414,9 +414,16 @@ void escapeDdocString(OutBuffer *buf, size_t start)
 
  * Fix by replacing unmatched ( with $(LPAREN) and unmatched ) with $(RPAREN).
  */
-void escapeStrayParenthesis(OutBuffer *buf, size_t start, Loc loc)
+void escapeStrayParenthesis(OutBuffer *buf, size_t start, Dsymbol *s)
 {
     unsigned par_open = 0;
+    Loc loc = s->loc;
+
+    if (Module *m = s->isModule())
+    {
+        if (m->md)
+            loc = m->md->loc;
+    }
 
     for (size_t u = start; u < buf->offset; u++)
     {
@@ -1374,7 +1381,7 @@ void DocComment::writeSections(Scope *sc, Dsymbol *s, OutBuffer *buf)
                 buf->writestring("$(DDOC_SUMMARY ");
                     size_t o = buf->offset;
                     buf->write(sec->body, sec->bodylen);
-                    escapeStrayParenthesis(buf, o, s->loc);
+                    escapeStrayParenthesis(buf, o, s);
                     highlightText(sc, s, buf, o);
                 buf->writestring(")\n");
             }
@@ -1419,7 +1426,7 @@ void Section::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
             {   unsigned char c = name[u];
                 buf->writeByte((c == '_') ? ' ' : c);
             }
-            escapeStrayParenthesis(buf, o, s->loc);
+            escapeStrayParenthesis(buf, o, s);
             buf->writestring(":)\n");
     }
     else
@@ -1429,7 +1436,7 @@ void Section::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
   L1:
     size_t o = buf->offset;
     buf->write(body, bodylen);
-    escapeStrayParenthesis(buf, o, s->loc);
+    escapeStrayParenthesis(buf, o, s);
     highlightText(sc, s, buf, o);
     buf->writestring(")\n");
 }
@@ -1511,14 +1518,14 @@ void ParamSection::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
                         arg->type->toCBuffer(buf, arg->ident, &hgs);
                     else
                         buf->write(namestart, namelen);
-                    escapeStrayParenthesis(buf, o, s->loc);
+                    escapeStrayParenthesis(buf, o, s);
                     highlightCode(sc, s, buf, o, false);
                 buf->writestring(")\n");
 
                 buf->writestring("$(DDOC_PARAM_DESC ");
                     o = buf->offset;
                     buf->write(textstart, textlen);
-                    escapeStrayParenthesis(buf, o, s->loc);
+                    escapeStrayParenthesis(buf, o, s);
                     highlightText(sc, s, buf, o);
                 buf->writestring(")");
             buf->writestring(")\n");

--- a/src/module.c
+++ b/src/module.c
@@ -1045,8 +1045,9 @@ int Module::selfImports()
 
 /* =========================== ModuleDeclaration ===================== */
 
-ModuleDeclaration::ModuleDeclaration(Identifiers *packages, Identifier *id, bool safe)
+ModuleDeclaration::ModuleDeclaration(Loc loc, Identifiers *packages, Identifier *id, bool safe)
 {
+    this->loc = loc;
     this->packages = packages;
     this->id = id;
     this->safe = safe;

--- a/src/module.h
+++ b/src/module.h
@@ -184,11 +184,12 @@ public:
 
 struct ModuleDeclaration
 {
+    Loc loc;
     Identifier *id;
     Identifiers *packages;            // array of Identifier's representing packages
     bool safe;
 
-    ModuleDeclaration(Identifiers *packages, Identifier *id, bool safe);
+    ModuleDeclaration(Loc loc, Identifiers *packages, Identifier *id, bool safe);
 
     char *toChars();
 };

--- a/src/parse.c
+++ b/src/parse.c
@@ -74,6 +74,7 @@ Dsymbols *Parser::parseModule()
     // ModuleDeclation leads off
     if (token.value == TOKmodule)
     {
+        Loc loc = this->loc;
         unsigned char *comment = token.blockComment;
         bool safe = FALSE;
 
@@ -120,7 +121,7 @@ Dsymbols *Parser::parseModule()
                 id = token.ident;
             }
 
-            md = new ModuleDeclaration(a, id, safe);
+            md = new ModuleDeclaration(loc, a, id, safe);
 
             if (token.value != TOKsemicolon)
                 error("';' expected following module declaration instead of %s", token.toChars());

--- a/test/compilable/ddoc4899.d
+++ b/test/compilable/ddoc4899.d
@@ -1,0 +1,20 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -w -o-
+
+/*
+TEST_OUTPUT:
+---
+compilable/ddoc4899.d(16): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
+compilable/ddoc4899.d(16): Warning: Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.
+---
+*/
+
+/++
+       (See accompanying file LICENSE_1_0.txt or copy at
+        http://www.boost.org/LICENSE_1_0.txt)
++/
+module d;
+
+void main()
+{
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=4899

Add `ModuleDeclaration::loc` and use it for "Stray paren" ddoc warning.
