### PR TITLE
Issue 10526 - opDispatch with IFTI should not disable UFCS

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2125,6 +2125,11 @@ Expression *Type::noMember(Scope *sc, Expression *e, Identifier *ident, int flag
             DotTemplateInstanceExp *dti = new DotTemplateInstanceExp(e->loc, e, Id::opDispatch, tiargs);
             dti->ti->tempdecl = td;
 
+            /* opDispatch, which doesn't need IFTI,  may occur instantiate error.
+             * It should be gagged if flag != 0.
+             * e.g.
+             *  tempalte opDispatch(name) if (isValid!name) { ... }
+             */
             unsigned errors = flag ? global.startGagging() : 0;
             Expression *e = dti->semanticY(sc, 0);
             if (flag && global.endGagging(errors))

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -740,6 +740,35 @@ void bar10166(alias handler, T)(T t, int i)
 void buzz10166() {}
 
 /*******************************************/
+// 10526
+
+struct S10526
+{
+    int opDispatch(string s, A...)(A args)
+    if (s[0..3] == "foo")
+    {
+        return 1;
+    }
+}
+int bar10526(X)(X) { return 2; }
+int baz10526(T, X)(X) { return 3; }
+
+void test10526()
+{
+    S10526 s;
+
+    // with parenthesis
+    assert(s.foo10526() == 1);
+    assert(s.bar10526() == 2);
+    assert(s.baz10526!string() == 3);
+
+    // without parenthesis
+    assert(s.foo10526 == 1);
+    assert(s.bar10526 == 2);
+    assert(s.baz10526!string == 3);
+}
+
+/*******************************************/
 
 int main()
 {
@@ -766,6 +795,7 @@ int main()
     test10003();
     test10041();
     test10047();
+    test10526();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10526

When opDispatch result is a function template that requires IFTI, it would be kept on `DotTemplateInstanceExp` so `ti->needsTypeInference(sc)` returns TRUE in its semantic().

UFCS dispatch should check that the opDispatch result is really valid or not, by instantiating the function template.
