### PR TITLE
optimize sequence of ||

### DIFF
--- a/src/backend/el.h
+++ b/src/backend/el.h
@@ -211,6 +211,11 @@ elem *el_convert(elem *e);
 int el_isdependent(elem *);
 unsigned el_alignsize(elem *);
 
+size_t el_opN(elem *e, unsigned op);
+void el_opArray(elem ***parray, elem *e, unsigned op);
+void el_opFree(elem *e, unsigned op);
+elem *el_opCombine(elem **args, size_t length, unsigned op, unsigned ty);
+
 void elem_print(elem *);
 void el_hydrate(elem **);
 void el_dehydrate(elem **);


### PR DESCRIPTION
This replaces a sequence of:

```
e == c1 || c == c2 || e == c3 || e == c4
```

with a BT instruction on a bit mask made from c1..c4

There aren't too many cases of this in the wild, but there'll be more when I get to doing this for switches.
