### PR TITLE
Implement core design of property enforcement

### DIFF
--- a/src/aliasthis.d
+++ b/src/aliasthis.d
@@ -140,7 +140,7 @@ extern (C++) Expression resolveAliasThis(Scope* sc, Expression e, bool gag = fal
                             fd = f;     // use exact match
                         e = new VarExp(loc, fd, hasOverloads);
                         e.type = f.type;
-                        e = new CallExp(loc, e);
+                        e = new CallExp(loc, e, PROPmemget);
                         goto L1;
                     }
                 }

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1929,8 +1929,6 @@ public:
                     if (!e.type)
                         exp.error("%s has no value", e.toChars());
                     t = e.type.toBasetype();
-                    if (t && t.ty == Tfunction)
-                        e = new CallExp(e.loc, e);
                     v = new VarDeclaration(loc, null, Id.dollar, new ExpInitializer(Loc(), e));
                     v.storage_class |= STCtemp | STCctfe | STCrvalue;
                 }

--- a/src/expression.d
+++ b/src/expression.d
@@ -9776,6 +9776,17 @@ public:
             }
         }
 
+        // Transform prop(...) to prop()(...)
+        if (prop == PROPnone)
+        {
+            auto e = resolvePropertiesOnly(sc, e1);
+            if (e != e1 && e.op == TOKerror)
+                return e;
+            e1 = e;
+            if (e1.type)
+                t1 = e1.type.toBasetype();
+        }
+
         static FuncDeclaration resolveOverloadSet(Loc loc, Scope* sc,
             OverloadSet os, Objects* tiargs, Type tthis, Expressions* arguments)
         {
@@ -9806,7 +9817,8 @@ public:
             return f;
         }
 
-        if (e1.op == TOKdotvar && t1.ty == Tfunction || e1.op == TOKdottd)
+        if (e1.op == TOKdotvar && t1.ty == Tfunction ||
+            e1.op == TOKdottd)
         {
             UnaExp ue = cast(UnaExp)e1;
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -298,13 +298,11 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
                     if (f.errors)
                         return new ErrorExp();
                     fd = f;
-                    assert(fd.type.ty == Tfunction);
-                    TypeFunction tf = cast(TypeFunction)fd.type;
                 }
             }
             if (fd)
             {
-                Expression e = new CallExp(loc, e1, e2);
+                Expression e = new CallExp(loc, e1, e2, PROPmemset);
                 return e.semantic(sc);
             }
         }
@@ -317,15 +315,11 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
                     if (f.errors)
                         return new ErrorExp();
                     fd = f;
-                    assert(fd.type.ty == Tfunction);
-                    TypeFunction tf = cast(TypeFunction)fd.type;
-                    if (!tf.isref && e2)
-                        goto Leproplvalue;
                 }
             }
             if (fd)
             {
-                Expression e = new CallExp(loc, e1);
+                Expression e = new CallExp(loc, e1, PROPmemget);
                 if (e2)
                     e = new AssignExp(loc, e, e2);
                 return e.semantic(sc);
@@ -410,9 +404,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
             {
                 if (fd.errors)
                     return new ErrorExp();
-                assert(fd.type.ty == Tfunction);
-                TypeFunction tf = cast(TypeFunction)fd.type;
-                Expression e = new CallExp(loc, e1, e2);
+                Expression e = new CallExp(loc, e1, e2, PROPmemset);
                 return e.semantic(sc);
             }
         }
@@ -426,7 +418,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
                 TypeFunction tf = cast(TypeFunction)fd.type;
                 if (!e2 || tf.isref)
                 {
-                    Expression e = new CallExp(loc, e1);
+                    Expression e = new CallExp(loc, e1, PROPmemget);
                     if (e2)
                         e = new AssignExp(loc, e, e2);
                     return e.semantic(sc);
@@ -435,10 +427,8 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
         }
         if (FuncDeclaration fd = s.isFuncDeclaration())
         {
-            // Keep better diagnostic message for invalid property usage of functions
-            assert(fd.type.ty == Tfunction);
-            TypeFunction tf = cast(TypeFunction)fd.type;
-            Expression e = new CallExp(loc, e1, e2);
+            // Don't keep function as an expression in AST
+            Expression e = new CallExp(loc, e1, e2, e2 ? PROPmemset : PROPmemget);
             return e.semantic(sc);
         }
         if (e2)
@@ -495,12 +485,8 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
     }
     return e1;
 
-Leprop:
+Leprop: // necessary?
     error(loc, "not a property %s", e1.toChars());
-    return new ErrorExp();
-
-Leproplvalue:
-    error(loc, "%s is not an lvalue", e1.toChars());
     return new ErrorExp();
 }
 
@@ -511,41 +497,6 @@ extern (C++) Expression resolveProperties(Scope* sc, Expression e)
     if (e.checkRightThis(sc))
         return new ErrorExp();
     return e;
-}
-
-/******************************
- * Check the tail CallExp is really property function call.
- */
-extern (C++) bool checkPropertyCall(Expression e, Expression emsg)
-{
-    while (e.op == TOKcomma)
-        e = (cast(CommaExp)e).e2;
-
-    if (e.op == TOKcall)
-    {
-        CallExp ce = cast(CallExp)e;
-        TypeFunction tf;
-        if (ce.f)
-        {
-            tf = cast(TypeFunction)ce.f.type;
-            /* If a forward reference to ce->f, try to resolve it
-             */
-            if (!tf.deco && ce.f._scope)
-            {
-                ce.f.semantic(ce.f._scope);
-                tf = cast(TypeFunction)ce.f.type;
-            }
-        }
-        else if (ce.e1.type.ty == Tfunction)
-            tf = cast(TypeFunction)ce.e1.type;
-        else if (ce.e1.type.ty == Tdelegate)
-            tf = cast(TypeFunction)ce.e1.type.nextOf();
-        else if (ce.e1.type.ty == Tpointer && ce.e1.type.nextOf().ty == Tfunction)
-            tf = cast(TypeFunction)ce.e1.type.nextOf();
-        else
-            assert(0);
-    }
-    return false;
 }
 
 /******************************
@@ -917,26 +868,18 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
         /* f(e1) = e2
          */
         Expression ex = e.copy();
-        auto a1 = new Expressions();
-        a1.setDim(1);
-        (*a1)[0] = eleft;
-        ex = new CallExp(loc, ex, a1);
+        ex = new CallExp(loc, ex, eleft, PROPufcget);
         ex = ex.trySemantic(sc);
 
         /* f(e1, e2)
          */
-        auto a2 = new Expressions();
-        a2.setDim(2);
-        (*a2)[0] = eleft;
-        (*a2)[1] = e2;
-        e = new CallExp(loc, e, a2);
+        e = new CallExp(loc, e, eleft, e2, PROPufcset);
         if (ex)
         {
             // if fallback setter exists, gag errors
             e = e.trySemantic(sc);
             if (!e)
             {
-                checkPropertyCall(ex, e1);
                 ex = new AssignExp(loc, ex, e2);
                 return ex.semantic(sc);
             }
@@ -946,19 +889,14 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
             // strict setter prints errors if fails
             e = e.semantic(sc);
         }
-        checkPropertyCall(e, e1);
         return e;
     }
     else
     {
         /* f(e1)
          */
-        auto arguments = new Expressions();
-        arguments.setDim(1);
-        (*arguments)[0] = eleft;
-        e = new CallExp(loc, e, arguments);
+        e = new CallExp(loc, e, eleft, PROPufcget);
         e = e.semantic(sc);
-        checkPropertyCall(e, e1);
         return e.semantic(sc);
     }
 }
@@ -9414,6 +9352,21 @@ public:
     }
 }
 
+enum PROP
+{
+    PROPnone,       // func(...) or e1.func(...)
+    PROPmemget,     // e1.func       -> e1.func()
+    PROPmemset,     // e1.func = e2; -> e1.func(e2);
+    PROPufcget,     // e1.func;      -> .func(e1);
+    PROPufcset,     // e1.func = e2; -> .func(e1, e2);
+}
+
+alias PROPnone = PROP.PROPnone;
+alias PROPmemget = PROP.PROPmemget;
+alias PROPmemset = PROP.PROPmemset;
+alias PROPufcget = PROP.PROPufcget;
+alias PROPufcset = PROP.PROPufcset;
+
 /***********************************************************
  */
 extern (C++) final class CallExp : UnaExp
@@ -9421,20 +9374,23 @@ extern (C++) final class CallExp : UnaExp
 public:
     Expressions* arguments; // function arguments
     FuncDeclaration f;      // symbol to call
+    PROP prop;
     bool directcall;        // true if a virtual call is devirtualized
 
-    extern (D) this(Loc loc, Expression e, Expressions* exps)
+    extern (D) this(Loc loc, Expression e, Expressions* exps, PROP prop = PROPnone)
     {
         super(loc, TOKcall, __traits(classInstanceSize, CallExp), e);
         this.arguments = exps;
+        this.prop = prop;
     }
 
-    extern (D) this(Loc loc, Expression e)
+    extern (D) this(Loc loc, Expression e, PROP prop = PROPnone)
     {
         super(loc, TOKcall, __traits(classInstanceSize, CallExp), e);
+        this.prop = prop;
     }
 
-    extern (D) this(Loc loc, Expression e, Expression earg1)
+    extern (D) this(Loc loc, Expression e, Expression earg1, PROP prop = PROPnone)
     {
         super(loc, TOKcall, __traits(classInstanceSize, CallExp), e);
         auto arguments = new Expressions();
@@ -9444,16 +9400,19 @@ public:
             (*arguments)[0] = earg1;
         }
         this.arguments = arguments;
+        this.prop = prop;
     }
 
-    extern (D) this(Loc loc, Expression e, Expression earg1, Expression earg2)
+    extern (D) this(Loc loc, Expression e, Expression earg1, Expression earg2, PROP prop = PROPnone)
     {
         super(loc, TOKcall, __traits(classInstanceSize, CallExp), e);
         auto arguments = new Expressions();
         arguments.setDim(2);
         (*arguments)[0] = earg1;
         (*arguments)[1] = earg2;
+
         this.arguments = arguments;
+        this.prop = prop;
     }
 
     static CallExp create(Loc loc, Expression e, Expressions* exps)
@@ -9473,7 +9432,7 @@ public:
 
     override Expression syntaxCopy()
     {
-        return new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments));
+        return new CallExp(loc, e1.syntaxCopy(), arraySyntaxCopy(arguments), prop);
     }
 
     override Expression semantic(Scope* sc)
@@ -10292,6 +10251,47 @@ public:
             t1 = f.type;
         }
         assert(t1.ty == Tfunction);
+
+        if (f)  // && global.params.enforcePropertySyntax
+        {
+            auto tf = cast(TypeFunction)t1;
+            if (!tf.isproperty)
+            {
+                switch (prop)
+                {
+                    case PROPnone:
+                    case PROPmemget:    // e1.func;      -> e1.func();
+                    case PROPufcget:    // e1.func;      -> func(e1);
+                        break;
+
+                    case PROPmemset:    // e1.func = e2; -> e1.func(e2);
+                    case PROPufcset:    // e1.func = e2; -> func(e1, e2);
+                        e1.error("not a property %s", e1.toChars());
+                        break;
+
+                    default:
+                        assert(0);
+                }
+            }
+            else
+            {
+                switch (prop)
+                {
+                    case PROPnone:
+                        e1.error("is a property %s", e1.toChars());
+                        break;
+
+                    case PROPmemget:    // e1.func;      -> e1.func;
+                    case PROPmemset:    // e1.func = e2; -> e1.func(e2);
+                    case PROPufcget:    // e1.func;      -> func(e1);
+                    case PROPufcset:    // e1.func = e2; -> func(e1, e2);
+                        break;
+
+                    default:
+                        assert(0);
+                }
+            }
+        }
 
         Expression argprefix;
         if (!arguments)

--- a/src/expression.h
+++ b/src/expression.h
@@ -896,17 +896,27 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+enum PROP
+{
+    PROPnone,       // func(...) or e1.func(...)
+    PROPmemget,     // e1.func       -> e1.func()
+    PROPmemset,     // e1.func = e2; -> e1.func(e2);
+    PROPufcget,     // e1.func;      -> .func(e1);
+    PROPufcset,     // e1.func = e2; -> .func(e1, e2);
+};
+
 class CallExp : public UnaExp
 {
 public:
     Expressions *arguments;     // function arguments
     FuncDeclaration *f;         // symbol to call
+    PROP prop;
     bool directcall;            // true if a virtual call is devirtualized
 
-    CallExp(Loc loc, Expression *e, Expressions *exps);
-    CallExp(Loc loc, Expression *e);
-    CallExp(Loc loc, Expression *e, Expression *earg1);
-    CallExp(Loc loc, Expression *e, Expression *earg1, Expression *earg2);
+    CallExp(Loc loc, Expression *e, Expressions *exps, PROP prop = PROPnone);
+    CallExp(Loc loc, Expression *e, PROP prop = PROPnone);
+    CallExp(Loc loc, Expression *e, Expression *earg1, PROP prop = PROPnone);
+    CallExp(Loc loc, Expression *e, Expression *earg1, Expression *earg2, PROP prop = PROPnone);
 
     static CallExp *create(Loc loc, Expression *e, Expressions *exps);
     static CallExp *create(Loc loc, Expression *e);

--- a/src/expression.h
+++ b/src/expression.h
@@ -864,6 +864,7 @@ class DotTemplateInstanceExp : public UnaExp
 {
 public:
     TemplateInstance *ti;
+    bool isOpDispatch;
 
     DotTemplateInstanceExp(Loc loc, Expression *e, Identifier *name, Objects *tiargs);
     DotTemplateInstanceExp(Loc loc, Expression *e, TemplateInstance *ti);

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2600,7 +2600,8 @@ public:
                 tiargs.push(se);
                 auto dti = new DotTemplateInstanceExp(e.loc, e, Id.opDispatch, tiargs);
                 dti.ti.tempdecl = td;
-                /* opDispatch, which doesn't need IFTI,  may occur instantiate error.
+
+                /* opDispatch, which doesn't need IFTI, may occur instantiate error.
                  * It should be gagged if flag != 0.
                  * e.g.
                  *  tempalte opDispatch(name) if (isValid!name) { ... }
@@ -2609,6 +2610,8 @@ public:
                 e = dti.semanticY(sc, 0);
                 if (flag && global.endGagging(errors))
                     e = null;
+                if (e && e.op == TOKdotti)
+                    (cast(DotTemplateInstanceExp)e).isOpDispatch = true;
                 return e;
             }
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -5107,18 +5107,18 @@ class Base56
     private string mybar;
 
     // Get/set properties that will be overridden.
-    void foo(string s) { myfoo = s; }
-    string foo() { return myfoo; }
+    @property void foo(string s) { myfoo = s; }
+    @property string foo() { return myfoo; }
 
     // Get/set properties that will not be overridden.
-    void bar(string s) { mybar = s; }
-    string bar() { return mybar; }
+    @property void bar(string s) { mybar = s; }
+    @property string bar() { return mybar; }
 }
 
 class Derived56 : Base56
 {
     alias Base56.foo foo; // Bring in Base56's foo getter.
-    override void foo(string s) { super.foo = s; } // Override foo setter.
+    @property override void foo(string s) { super.foo = s; } // Override foo setter.
 }
 
 int testwith()

--- a/test/fail_compilation/diag10415.d
+++ b/test/fail_compilation/diag10415.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/diag10415.d(36): Error: none of the overloads of 'x' are callable using argument types (int) const, candidates are:
 fail_compilation/diag10415.d(13):        diag10415.C.x()
 fail_compilation/diag10415.d(18):        diag10415.C.x(int _param_0)
-fail_compilation/diag10415.d(39): Error: d.x is not an lvalue
+fail_compilation/diag10415.d(39): Error: d.x() is not an lvalue
 ---
 */
 

--- a/test/fail_compilation/diag8629.d
+++ b/test/fail_compilation/diag8629.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag8629.d(16): Error: not a property gunc
+---
+*/
+
+struct S {}
+
+auto gunc(S s, int n) { return 13; }
+@property grop(S s, int n) { return 14; }
+
+void main()
+{
+    S s;
+    assert((s.gunc = 1) == 13);
+    assert((s.grop = 1) == 14);
+}

--- a/test/fail_compilation/diag9241.d
+++ b/test/fail_compilation/diag9241.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag9241.d(16): Error: cannot implicitly convert expression (splitLines(s)) of type string[] to string
+---
+*/
+
+S[] splitLines(S)(S s)
+{
+    return null;
+}
+
+void main()
+{
+    string s;
+    s = s.splitLines;
+}

--- a/test/fail_compilation/fail335.d
+++ b/test/fail_compilation/fail335.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail335.d(9): Error: cannot overload both property and non-property functions
+fail_compilation/fail335.d(13): Error: is a property foo
 ---
 */
-
 void foo();
 @property void foo(int);
 

--- a/test/runnable/property.d
+++ b/test/runnable/property.d
@@ -6,8 +6,8 @@ struct Foo
 {
     int v;
 
-    int bar(int value) { return v = value + 2; }
-    int bar() { return 73; }
+    @property int bar(int value) { return v = value + 2; }
+    @property int bar() { return 73; }
 }
 
 int test1()
@@ -31,8 +31,8 @@ int test1()
 struct S6259
 {
     private int m_prop;
-    ref const(int) prop() { return m_prop; }
-    void prop(int v) { m_prop = v; }
+    @property ref const(int) prop() { return m_prop; }
+    @property void prop(int v) { m_prop = v; }
 }
 
 void test6259()

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -78,6 +78,16 @@ template iota(int begin, int end)
         alias seq!(begin, iota!(begin+1, end)) iota;
 }
 
+int function() callableProp1a() @property
+{
+    return () => 10;
+}
+
+string delegate(string s1, string s2) callableProp1b() @property
+{
+    return (s1, s2) => s1 ~ " " ~ s2;
+}
+
 void test1()
 {
     foreach (N; iota!(0, 8))
@@ -100,6 +110,12 @@ void test1()
             assert(s.getset == Test!N.result);
         }
     }
+
+    auto a = callableProp1a();
+    assert(a == 10);
+
+    auto b = callableProp1b("hello", "prop");
+    assert(b == "hello prop");
 }
 
 /*******************************************/

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -2,21 +2,7 @@
 
 extern (C) int printf(const char* fmt, ...);
 
-// Is -property option specified?
-enum enforceProperty = !__traits(compiles, {
-    int prop(){ return 1; }
-    int n = prop;
-});
-
 /*******************************************/
-
-template select(alias v1, alias v2)
-{
-    static if (enforceProperty)
-        enum select = v1;
-    else
-        enum select = v2;
-}
 
 struct Test(int N)
 {
@@ -27,33 +13,25 @@ struct Test(int N)
     {
         ref foo(){ getset = 1; return value; }
 
-        enum result = select!(0, 1);
-        // -property    test.d(xx): Error: not a property foo
-        // (no option)  prints "getter"
+        enum result = 1;    // prints "getter" (by optional parenthesis)
     }
     static if (N == 1)
     {
         ref foo(int x){ getset = 2; value = x; return value; }
 
-        enum result = select!(0, 2);
-        // -property    test.d(xx): Error: not a property foo
-        // (no option)  prints "setter"
+        enum result = 0;    // Error: not a property foo
     }
     static if (N == 2)
     {
         @property ref foo(){ getset = 1; return value; }
 
-        enum result = select!(1, 1);
-        // -property    prints "getter"
-        // (no option)  prints "getter"
+        enum result = 1;    // prints "getter"
     }
     static if (N == 3)
     {
         @property ref foo(int x){ getset = 2; value = x; return value; }
 
-        enum result = select!(2, 2);
-        // -property    prints "setter"
-        // (no option)  prints "setter"
+        enum result = 2;    // prints "setter"
     }
 
 
@@ -62,36 +40,28 @@ struct Test(int N)
         ref foo()     { getset = 1; return value; }
         ref foo(int x){ getset = 2; value = x; return value; }
 
-        enum result = select!(0, 2);
-        // -property    test.d(xx): Error: not a property foo
-        // (no option)  prints "setter"
+        enum result = 0;    // Error: not a property foo
     }
     static if (N == 5)
     {
         @property ref foo()     { getset = 1; return value; }
                   ref foo(int x){ getset = 2; value = x; return value; }
 
-        enum result = select!(0, 0);
-        // -property    test.d(xx): Error: cannot overload both property and non-property functions
-        // (no option)  test.d(xx): Error: cannot overload both property and non-property functions
+        enum result = 0;    // Error: cannot overload both property and non-property functions
     }
     static if (N == 6)
     {
                   ref foo()     { getset = 1; return value; }
         @property ref foo(int x){ getset = 2; value = x; return value; }
 
-        enum result = select!(0, 0);
-        // -property    test.d(xx): Error: cannot overload both property and non-property functions
-        // (no option)  test.d(xx): Error: cannot overload both property and non-property functions
+        enum result = 0;    // Error: cannot overload both property and non-property functions
     }
     static if (N == 7)
     {
         @property ref foo()     { getset = 1; return value; }
         @property ref foo(int x){ getset = 2; value = x; return value; }
 
-        enum result = select!(2, 2);
-        // -property    prints "setter"
-        // (no option)  prints "setter"
+        enum result = 2;    // prints "setter"
     }
 }
 
@@ -141,28 +111,17 @@ void spam7722(Foo7722 f) {}
 void test7722()
 {
     auto f = new Foo7722;
-    static if (enforceProperty)
-        static assert(!__traits(compiles, f.spam7722));
-    else
-        f.spam7722;
+    f.spam7722; // always valid so -property switch is now meaningless
 }
 
 /*******************************************/
 
-@property void check(alias v1, alias v2, alias dg)()
+@property void check(alias v, alias dg)()
 {
-    void checkImpl(alias v)()
-    {
-        static if (v == 0)
-            static assert(!__traits(compiles, dg(0)));
-        else
-            assert(dg(0) == v);
-    }
-
-    static if (enforceProperty)
-        checkImpl!(v1)();
+    static if (v == 0)
+        static assert(!__traits(compiles, dg(0)));
     else
-        checkImpl!(v2)();
+        assert(dg(0) == v);
 }
 
 struct S {}
@@ -190,33 +149,33 @@ void test7722a()
     int[] a;
     S s;
 
-    check!(1, 1, x =>    foo(4)     );      check!(1, 1, x =>    baz(4)     );
-    check!(1, 1, x =>  4.foo()      );      check!(1, 1, x =>  4.baz()      );
-    check!(0, 1, x =>  4.foo        );      check!(0, 1, x =>  4.baz        );
-    check!(2, 2, x =>    foo(4, 2)  );      check!(2, 2, x =>    baz(4, 2)  );
-    check!(2, 2, x =>  4.foo(2)     );      check!(2, 2, x =>  4.baz(2)     );
-    check!(0, 2, x => (4.foo = 2)   );      check!(0, 2, x => (4.baz = 2)   );
+    check!(1, x =>    foo(4)     );         check!(1, x =>    baz(4)     );
+    check!(1, x =>  4.foo()      );         check!(1, x =>  4.baz()      );
+    check!(1, x =>  4.foo        );         check!(1, x =>  4.baz        );
+    check!(2, x =>    foo(4, 2)  );         check!(2, x =>    baz(4, 2)  );
+    check!(2, x =>  4.foo(2)     );         check!(2, x =>  4.baz(2)     );
+    check!(0, x => (4.foo = 2)   );         check!(0, x => (4.baz = 2)   );
 
-    check!(1, 1, x =>    goo(a)     );      check!(1, 1, x =>    baz(a)     );
-    check!(1, 1, x =>  a.goo()      );      check!(1, 1, x =>  a.baz()      );
-    check!(0, 1, x =>  a.goo        );      check!(0, 1, x =>  a.baz        );
-    check!(2, 2, x =>    goo(a, 2)  );      check!(2, 2, x =>    baz(a, 2)  );
-    check!(2, 2, x =>  a.goo(2)     );      check!(2, 2, x =>  a.baz(2)     );
-    check!(0, 2, x => (a.goo = 2)   );      check!(0, 2, x => (a.baz = 2)   );
+    check!(1, x =>    goo(a)     );         check!(1, x =>    baz(a)     );
+    check!(1, x =>  a.goo()      );         check!(1, x =>  a.baz()      );
+    check!(1, x =>  a.goo        );         check!(1, x =>  a.baz        );
+    check!(2, x =>    goo(a, 2)  );         check!(2, x =>    baz(a, 2)  );
+    check!(2, x =>  a.goo(2)     );         check!(2, x =>  a.baz(2)     );
+    check!(0, x => (a.goo = 2)   );         check!(0, x => (a.baz = 2)   );
 
-    check!(1, 1, x =>    bar(s)     );      check!(1, 1, x =>    baz(s)     );
-    check!(1, 1, x =>  s.bar()      );      check!(1, 1, x =>  s.baz()      );
-    check!(0, 1, x =>  s.bar        );      check!(0, 1, x =>  s.baz        );
-    check!(2, 2, x =>    bar(s, 2)  );      check!(2, 2, x =>    baz(s, 2)  );
-    check!(2, 2, x =>  s.bar(2)     );      check!(2, 2, x =>  s.baz(2)     );
-    check!(0, 2, x => (s.bar = 2)   );      check!(0, 2, x => (s.baz = 2)   );
+    check!(1, x =>    bar(s)     );         check!(1, x =>    baz(s)     );
+    check!(1, x =>  s.bar()      );         check!(1, x =>  s.baz()      );
+    check!(1, x =>  s.bar        );         check!(1, x =>  s.baz        );
+    check!(2, x =>    bar(s, 2)  );         check!(2, x =>    baz(s, 2)  );
+    check!(2, x =>  s.bar(2)     );         check!(2, x =>  s.baz(2)     );
+    check!(0, x => (s.bar = 2)   );         check!(0, x => (s.baz = 2)   );
 
-    check!(2, 2, x => (  boo(4) = 2));      check!(2, 2, x => (  maz(4) = 2));
-    check!(0, 2, x => (4.boo    = 2));      check!(0, 2, x => (4.maz    = 2));
-    check!(2, 2, x => (  coo(a) = 2));      check!(2, 2, x => (  maz(a) = 2));
-    check!(0, 2, x => (a.coo    = 2));      check!(0, 2, x => (a.maz    = 2));
-    check!(2, 2, x => (  mar(s) = 2));      check!(2, 2, x => (  maz(s) = 2));
-    check!(0, 2, x => (s.mar    = 2));      check!(0, 2, x => (s.maz    = 2));
+    check!(2, x => (  boo(4) = 2));         check!(2, x => (  maz(4) = 2));
+    check!(2, x => (4.boo    = 2));         check!(2, x => (4.maz    = 2));
+    check!(2, x => (  coo(a) = 2));         check!(2, x => (  maz(a) = 2));
+    check!(2, x => (a.coo    = 2));         check!(2, x => (a.maz    = 2));
+    check!(2, x => (  mar(s) = 2));         check!(2, x => (  maz(s) = 2));
+    check!(2, x => (s.mar    = 2));         check!(2, x => (s.maz    = 2));
 }
 
 int hoo(T)(int n)          { return 1; }
@@ -242,33 +201,33 @@ void test7722b()
     int[] a;
     S s;
 
-    check!(1, 1, x =>    hoo!int(4)     );  check!(1, 1, x =>    vaz!int(4)     );
-    check!(1, 1, x =>  4.hoo!int()      );  check!(1, 1, x =>  4.vaz!int()      );
-    check!(0, 1, x =>  4.hoo!int        );  check!(0, 1, x =>  4.vaz!int        );
-    check!(2, 2, x =>    hoo!int(4, 2)  );  check!(2, 2, x =>    vaz!int(4, 2)  );
-    check!(2, 2, x =>  4.hoo!int(2)     );  check!(2, 2, x =>  4.vaz!int(2)     );
-    check!(0, 2, x => (4.hoo!int = 2)   );  check!(0, 2, x => (4.vaz!int = 2)   );
+    check!(1, x =>    hoo!int(4)     );     check!(1, x =>    vaz!int(4)     );
+    check!(1, x =>  4.hoo!int()      );     check!(1, x =>  4.vaz!int()      );
+    check!(1, x =>  4.hoo!int        );     check!(1, x =>  4.vaz!int        );
+    check!(2, x =>    hoo!int(4, 2)  );     check!(2, x =>    vaz!int(4, 2)  );
+    check!(2, x =>  4.hoo!int(2)     );     check!(2, x =>  4.vaz!int(2)     );
+    check!(0, x => (4.hoo!int = 2)   );     check!(0, x => (4.vaz!int = 2)   );
 
-    check!(1, 1, x =>    koo!int(a)     );  check!(1, 1, x =>    vaz!int(a)     );
-    check!(1, 1, x =>  a.koo!int()      );  check!(1, 1, x =>  a.vaz!int()      );
-    check!(0, 1, x =>  a.koo!int        );  check!(0, 1, x =>  a.vaz!int        );
-    check!(2, 2, x =>    koo!int(a, 2)  );  check!(2, 2, x =>    vaz!int(a, 2)  );
-    check!(2, 2, x =>  a.koo!int(2)     );  check!(2, 2, x =>  a.vaz!int(2)     );
-    check!(0, 2, x => (a.koo!int = 2)   );  check!(0, 2, x => (a.vaz!int = 2)   );
+    check!(1, x =>    koo!int(a)     );     check!(1, x =>    vaz!int(a)     );
+    check!(1, x =>  a.koo!int()      );     check!(1, x =>  a.vaz!int()      );
+    check!(1, x =>  a.koo!int        );     check!(1, x =>  a.vaz!int        );
+    check!(2, x =>    koo!int(a, 2)  );     check!(2, x =>    vaz!int(a, 2)  );
+    check!(2, x =>  a.koo!int(2)     );     check!(2, x =>  a.vaz!int(2)     );
+    check!(0, x => (a.koo!int = 2)   );     check!(0, x => (a.vaz!int = 2)   );
 
-    check!(1, 1, x =>    var!int(s)     );  check!(1, 1, x =>    vaz!int(s)     );
-    check!(1, 1, x =>  s.var!int()      );  check!(1, 1, x =>  s.vaz!int()      );
-    check!(0, 1, x =>  s.var!int        );  check!(0, 1, x =>  s.vaz!int        );
-    check!(2, 2, x =>    var!int(s, 2)  );  check!(2, 2, x =>    vaz!int(s, 2)  );
-    check!(2, 2, x =>  s.var!int(2)     );  check!(2, 2, x =>  s.vaz!int(2)     );
-    check!(0, 2, x => (s.var!int = 2)   );  check!(0, 2, x => (s.vaz!int = 2)   );
+    check!(1, x =>    var!int(s)     );     check!(1, x =>    vaz!int(s)     );
+    check!(1, x =>  s.var!int()      );     check!(1, x =>  s.vaz!int()      );
+    check!(1, x =>  s.var!int        );     check!(1, x =>  s.vaz!int        );
+    check!(2, x =>    var!int(s, 2)  );     check!(2, x =>    vaz!int(s, 2)  );
+    check!(2, x =>  s.var!int(2)     );     check!(2, x =>  s.vaz!int(2)     );
+    check!(0, x => (s.var!int = 2)   );     check!(0, x => (s.vaz!int = 2)   );
 
-    check!(2, 2, x => (  voo!int(4) = 2));  check!(2, 2, x => (  naz!int(4) = 2));
-    check!(0, 2, x => (4.voo!int    = 2));  check!(0, 2, x => (4.naz!int    = 2));
-    check!(2, 2, x => (  woo!int(a) = 2));  check!(2, 2, x => (  naz!int(a) = 2));
-    check!(0, 2, x => (a.woo!int    = 2));  check!(0, 2, x => (a.naz!int    = 2));
-    check!(2, 2, x => (  nar!int(s) = 2));  check!(2, 2, x => (  naz!int(s) = 2));
-    check!(0, 2, x => (s.nar!int    = 2));  check!(0, 2, x => (s.naz!int    = 2));
+    check!(2, x => (  voo!int(4) = 2));     check!(2, x => (  naz!int(4) = 2));
+    check!(2, x => (4.voo!int    = 2));     check!(2, x => (4.naz!int    = 2));
+    check!(2, x => (  woo!int(a) = 2));     check!(2, x => (  naz!int(a) = 2));
+    check!(2, x => (a.woo!int    = 2));     check!(2, x => (a.naz!int    = 2));
+    check!(2, x => (  nar!int(s) = 2));     check!(2, x => (  naz!int(s) = 2));
+    check!(2, x => (s.nar!int    = 2));     check!(2, x => (s.naz!int    = 2));
 }
 
 /*******************************************/
@@ -478,8 +437,8 @@ void test8251()
 {
     static assert(S8251.min == 123);    // OK
     static assert(T8251_Min == 456);    // OK
-    int a0 = T8251a!(S8251.min());      // OK
-    int b0 = T8251a!(T8251_Min());      // OK
+    static assert(!__traits(compiles, { int a0 = T8251a!(S8251.min()); })); // NG
+    static assert(!__traits(compiles, { int b0 = T8251a!(T8251_Min()); })); // NG
 
     // TemplateValueParameter
     int a1 = T8251a!(S8251.min);        // NG

--- a/test/runnable/template1.d
+++ b/test/runnable/template1.d
@@ -2027,8 +2027,8 @@ void test82()
 
 struct A83
 {
-    void foo(int) {}
-    void bar(T)(T) {}
+    @property void foo(int) {}
+    @property void bar(T)(T) {}
 }
 
 void test83()

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -1121,8 +1121,8 @@ struct V54
 class Foo54
 {
     static int y;
-    static V54 prop() { V54 val; return val; }
-    static void prop(V54 val) { y = val.x * 2; }
+    @property static V54 prop() { V54 val; return val; }
+    @property static void prop(V54 val) { y = val.x * 2; }
 }
 
 void test54()

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -110,14 +110,14 @@ void test6()
 {
   void f()
   {
-    void i6(float j)
+    @property void i6(float j)
     {
-	m6 = j;
+      m6 = j;
     }
 
     void g()
     {
-	i6 = 1;
+      i6 = 1;
     }
     g();
   }

--- a/test/runnable/test23.d
+++ b/test/runnable/test23.d
@@ -51,7 +51,7 @@ void test2()
 void test3()
 {
     size_t border = 8;
-    
+
     for(ulong i = 0; i < border; i++)
     {
 	ulong test = 1;
@@ -1131,36 +1131,36 @@ void test54()
 
 class Base56
 {
-        private string myfoo;
-        private string mybar;
+    private string myfoo;
+    private string mybar;
 
-        // Get/set properties that will be overridden.
-        void foo(string s) { myfoo = s; }
-        string foo() { return myfoo; }
+    // Get/set properties that will be overridden.
+    @property void foo(string s) { myfoo = s; }
+    @property string foo() { return myfoo; }
 
-        // Get/set properties that will not be overridden.
-        void bar(string s) { mybar = s; }
-        string bar() { return mybar; }
+    // Get/set properties that will not be overridden.
+    @property void bar(string s) { mybar = s; }
+    @property string bar() { return mybar; }
 }
 
 class Derived56: Base56
 {
-        alias Base56.foo foo; // Bring in Base56's foo getter.
-        override void foo(string s) { super.foo = s; } // Override foo setter.
+    alias Base56.foo foo; // Bring in Base56's foo getter.
+    override @property void foo(string s) { super.foo = s; } // Override foo setter.
 }
 
 void test56()
 {
-        Derived56 d = new Derived56;
-        with (d)
-        {
-                foo = "hi";
-                d.foo = "hi";
-                bar = "hi";
-		assert(foo == "hi");
-		assert(d.foo == "hi");
-		assert(bar == "hi");
-        }
+    Derived56 d = new Derived56;
+    with (d)
+    {
+        foo = "hi";
+        d.foo = "hi";
+        bar = "hi";
+        assert(foo == "hi");
+        assert(d.foo == "hi");
+        assert(bar == "hi");
+    }
 }
 
 /*******************************************/

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -1243,27 +1243,31 @@ void test49()
 
 /* ================================ */
 
-struct S50{
+struct S50
+{
 	int i;
 }
 
-class C50{
-	static S50 prop(){
-		S50 s;
-		return s;
-	}
+class C50
+{
+    static @property S50 prop()
+    {
+        S50 s;
+        return s;
+    }
 
-	static void prop(S50 s){
-	}
+    static @property void prop(S50 s)
+    {
+    }
 }
 
 void test50()
 {
-	C50 c = new C50();
-	c.prop = true ? C50.prop : C50.prop;
-	assert(c.prop.i == 0);
-	c.prop.i = 7;
-	assert(c.prop.i != 7);
+    C50 c = new C50();
+    c.prop = true ? C50.prop : C50.prop;
+    assert(c.prop.i == 0);
+    c.prop.i = 7;
+    assert(c.prop.i != 7);
 }
 
 /* ================================ */

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -931,7 +931,7 @@ void test62()
    auto t1 = typeid(typeof(foo));
    auto t2 = typeid(typeof(bar));
 
-   t1.tsize();
+   t1.tsize;
 }
 
 /***************************************************/

--- a/test/runnable/test8997.d
+++ b/test/runnable/test8997.d
@@ -9,7 +9,7 @@ void main()
 {
     auto a = new A();
 
-    foreach(key; a.foobar.byKey())
+    foreach(key; a.foobar.byKey)
     {
     }
 }

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -690,12 +690,12 @@ void test29()
     auto gammaFunc = [-1.5:2.363, -0.5:-3.545, 0.5:1.772];
 
     // write all keys
-    foreach (k; gammaFunc.byKey()) {
+    foreach (k; gammaFunc.byKey) {
        printf("%f\n", k);
     }
 
     // write all values
-    foreach (v; gammaFunc.byValue()) {
+    foreach (v; gammaFunc.byValue) {
        printf("%f\n", v);
     }
 }

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -348,7 +348,7 @@ void test15()
 
 class Parent16
 {
-	void test(int i){
+	@property void test(int i){
 	}
 }
 

--- a/test/runnable/testsignals.d
+++ b/test/runnable/testsignals.d
@@ -2,30 +2,32 @@ import std.stdio;
 import std.signals;
 
 class Observer
-{   // our slot
+{
+    // our slot
     void watch(string msg, int i)
     {
-	writefln("Observed msg '%s' and value %s", msg, i);
+        writefln("Observed msg '%s' and value %s", msg, i);
     }
 
     void watch2(int i, int j)
     {
-	writefln("Observed msg %s,%s", i, j);
+        writefln("Observed msg %s,%s", i, j);
     }
 }
 
 class Foo
 {
-    int value() { return _value; }
+    @property int value() { return _value; }
 
-    int value(int v)
+    @property int value(int v)
     {
-	if (v != _value)
-	{   _value = v;
-	    // call all the connected slots with the two parameters
-	    emit("setting new value", v);
-	}
-	return v;
+        if (v != _value)
+        {
+            _value = v;
+            // call all the connected slots with the two parameters
+            emit("setting new value", v);
+        }
+        return v;
     }
 
     // Mix in all the code we need to make Foo into a signal
@@ -40,15 +42,15 @@ void test1()
     Foo a = new Foo;
     Observer o = new Observer;
 
-    a.value = 3;		// should not call o.watch()
-    a.connect(&o.watch);	// o.watch is the slot
-    a.value = 4;		// should call o.watch()
-    a.disconnect(&o.watch);	// o.watch is no longer a slot
-    a.value = 5;		// so should not call o.watch()
-    a.connect(&o.watch);	// connect again
-    a.value = 6;		// should call o.watch()
-    delete o;			// destroying o should automatically disconnect it
-    a.value = 7;		// should not call o.watch()
+    a.value = 3;            // should not call o.watch()
+    a.connect(&o.watch);    // o.watch is the slot
+    a.value = 4;            // should call o.watch()
+    a.disconnect(&o.watch); // o.watch is no longer a slot
+    a.value = 5;            // so should not call o.watch()
+    a.connect(&o.watch);    // connect again
+    a.value = 6;            // should call o.watch()
+    delete o;               // destroying o should automatically disconnect it
+    a.value = 7;            // should not call o.watch()
 }
 
 /******************************************/
@@ -71,32 +73,32 @@ void test2()
 
 class Args3
 {
-        int foo;
+    int foo;
 }
 
 class Base3
 {
-        ~this()
-        {
-                writefln("Base3 dtor!");
-        }
+    ~this()
+    {
+            writefln("Base3 dtor!");
+    }
 }
 
 class Test3 : Base3
 {
-        mixin Signal!(Args3) A;
-        mixin Signal!(Args3) B;
+    mixin Signal!(Args3) A;
+    mixin Signal!(Args3) B;
 
-        ~this()
-        {
-                writefln("Test3 dtor");
-        }
+    ~this()
+    {
+            writefln("Test3 dtor");
+    }
 }
 
 
 void test3()
 {
-        auto test = new Test3;
+    auto test = new Test3;
 }
 
 

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -36,21 +36,21 @@ void test1()
     assert( 4.foo       == 1);      assert( 4.baz       == 1);
     assert(   foo(4, 2) == 2);      assert(   baz(4, 2) == 2);
     assert( 4.foo(2)    == 2);      assert( 4.baz(2)    == 2);
-    assert((4.foo = 2)  == 2);      assert((4.baz = 2)  == 2);
+//  assert((4.foo = 2)  == 2);      assert((4.baz = 2)  == 2);
 
     assert(   goo(a)    == 1);      assert(   baz(a)    == 1);
     assert( a.goo()     == 1);      assert( a.baz()     == 1);
     assert( a.goo       == 1);      assert( a.baz       == 1);
     assert(   goo(a, 2) == 2);      assert(   baz(a, 2) == 2);
     assert( a.goo(2)    == 2);      assert( a.baz(2)    == 2);
-    assert((a.goo = 2)  == 2);      assert((a.baz = 2)  == 2);
+//  assert((a.goo = 2)  == 2);      assert((a.baz = 2)  == 2);
 
     assert(   bar(s)    == 1);      assert(   baz(s)    == 1);
     assert( s.bar()     == 1);      assert( s.baz()     == 1);
     assert( s.bar       == 1);      assert( s.baz       == 1);
     assert(   bar(s, 2) == 2);      assert(   baz(s, 2) == 2);
     assert( s.bar(2)    == 2);      assert( s.baz(2)    == 2);
-    assert((s.bar = 2)  == 2);      assert((s.baz = 2)  == 2);
+//  assert((s.bar = 2)  == 2);      assert((s.baz = 2)  == 2);
 
     assert((  boo(4) = 2) == 2);    assert((  maz(4) = 2) == 2);
     assert((4.boo    = 2) == 2);    assert((4.maz    = 2) == 2);
@@ -88,21 +88,21 @@ void test2()
     assert( 4.hoo!int       == 1);  assert( 4.vaz!int       == 1);
     assert(   hoo!int(4, 2) == 2);  assert(   vaz!int(4, 2) == 2);
     assert( 4.hoo!int(2)    == 2);  assert( 4.vaz!int(2)    == 2);
-    assert((4.hoo!int = 2)  == 2);  assert((4.vaz!int = 2)  == 2);
+//  assert((4.hoo!int = 2)  == 2);  assert((4.vaz!int = 2)  == 2);
 
     assert(   koo!int(a)    == 1);  assert(   vaz!int(a)    == 1);
     assert( a.koo!int()     == 1);  assert( a.vaz!int()     == 1);
     assert( a.koo!int       == 1);  assert( a.vaz!int       == 1);
     assert(   koo!int(a, 2) == 2);  assert(   vaz!int(a, 2) == 2);
     assert( a.koo!int(2)    == 2);  assert( a.vaz!int(2)    == 2);
-    assert((a.koo!int = 2)  == 2);  assert((a.vaz!int = 2)  == 2);
+//  assert((a.koo!int = 2)  == 2);  assert((a.vaz!int = 2)  == 2);
 
     assert(   var!int(s)    == 1);  assert(   vaz!int(s)    == 1);
     assert( s.var!int()     == 1);  assert( s.vaz!int()     == 1);
     assert( s.var!int       == 1);  assert( s.vaz!int       == 1);
     assert(   var!int(s, 2) == 2);  assert(   vaz!int(s, 2) == 2);
     assert( s.var!int(2)    == 2);  assert( s.vaz!int(2)    == 2);
-    assert((s.var!int = 2)  == 2);  assert((s.vaz!int = 2)  == 2);
+//  assert((s.var!int = 2)  == 2);  assert((s.vaz!int = 2)  == 2);
 
     assert((  voo!int(4) = 2) == 2);    assert((  naz!int(4) = 2) == 2);
     assert((4.voo!int    = 2) == 2);    assert((4.naz!int    = 2) == 2);
@@ -524,7 +524,7 @@ struct A7670
 void test7670()
 {
     A7670 a1;
-    a1.y7670() = 2.0; // OK
+//  a1.y7670() = 2.0; // OK
     a1.y7670 = 2.0; // Error
 }
 
@@ -619,7 +619,7 @@ T[] sort8453(T)(T[] a) { return a; }
 void test8453()
 {
     int[int] foo;
-    auto bar1 = foo.keys().sort8453(); // OK
+//  auto bar1 = foo.keys().sort8453(); // OK
     auto bar2 = foo.keys.sort8453();   // Error
 }
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5190,7 +5190,7 @@ void test6837()
     assert(r2.front6837 == 1);      // ok
     r2.popFront6837();              // ng
     r2.get.popFront6837();          // ng
-    r2.get().popFront6837();        // ok
+//  r2.get().popFront6837();        // ok
 }
 
 /***************************************************/


### PR DESCRIPTION
Points:
- The `-property` switch gets deprecated
  
  After this change, it causes no semantic behavior change.
- Optional parenthesis stay in
  
  Non-property function call with zero arguments can omit parenthesis.
- Property functions cannot be called with parenthesis anymore.
  
  Enforce getter/setter syntax.
- Property name with parenthesis would call the returned value of property.
  
  `obj.prop(...)` is automatically translated to `obj.prop()(...)`

Some specific design decisions
- opDispatch function template which is automatically provided method name, would bypass property check.
  
  ``` d
  struct S1 { void opDispatch(string name, A...)(A args) {} }
  S1 s1;
  s1.foo;      // s1.opDispatch"foo"();
  s1.foo();    // s1.opDispatch"foo"();
  s1.foo(1);   // s1.opDispatch"foo"(1);
  s1.foo = 1;  // s1.opDispatch"foo"(1);  [bypass property check, OK]
  
  struct S2 { template opDispatch(string name) { void opDispatch(A...)(A args) {} } }
  S2 s2;
  s2.foo;      // s2.opDispatch"foo".opDispatch();
  s2.foo();    // s2.opDispatch"foo".opDispatch();
  s2.foo(1);   // s2.opDispatch"foo".opDispatch(1);
  //s2.foo = 1;  // s2.opDispatch"foo".opDispatch(1);  [cannot bypass property check, NG!]
  ```
- `typeof(prop)` returns the type of property result, but , `typeof(func)` returns function type
  
  Inside `typeof`, applying optional parenthesis rule would break much existing code AFAICS.
  Note that, there's no designed semantic change from current state.
  
  See also: https://github.com/D-Programming-Language/dmd/pull/2123#issuecomment-18831828
