### PR TITLE
[DDMD] Make Scope a struct

### DIFF
--- a/src/cond.h
+++ b/src/cond.h
@@ -15,7 +15,7 @@ class Expression;
 class Identifier;
 class OutBuffer;
 class Module;
-class Scope;
+struct Scope;
 class ScopeDsymbol;
 class DebugCondition;
 #include "lexer.h" // dmdhg

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -22,7 +22,7 @@
 #include "arraytypes.h"
 
 class Identifier;
-class Scope;
+struct Scope;
 class DsymbolTable;
 class Declaration;
 class ThisDeclaration;

--- a/src/expression.h
+++ b/src/expression.h
@@ -19,7 +19,7 @@
 
 class Type;
 class TypeVector;
-class Scope;
+struct Scope;
 class TupleDeclaration;
 class VarDeclaration;
 class FuncDeclaration;

--- a/src/import.h
+++ b/src/import.h
@@ -19,7 +19,7 @@
 
 
 class Identifier;
-class Scope;
+struct Scope;
 class OutBuffer;
 class Module;
 class Package;

--- a/src/init.h
+++ b/src/init.h
@@ -18,7 +18,7 @@
 
 class Identifier;
 class Expression;
-class Scope;
+struct Scope;
 class Type;
 struct dt_t;
 class AggregateDeclaration;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -21,7 +21,7 @@
 #include "arraytypes.h"
 #include "expression.h"
 
-class Scope;
+struct Scope;
 class Identifier;
 class Expression;
 class StructDeclaration;

--- a/src/scope.h
+++ b/src/scope.h
@@ -57,9 +57,8 @@ enum PROT;
 #define SCOPEensure     0x60    // inside out contract code
 #define SCOPEcontract   0x60    // [mask] we're inside contract code
 
-class Scope
+struct Scope
 {
-public:
     Scope *enclosing;           // enclosing Scope
 
     Module *module;             // Root module

--- a/src/statement.h
+++ b/src/statement.h
@@ -22,7 +22,7 @@
 #include "lexer.h"
 
 class OutBuffer;
-class Scope;
+struct Scope;
 class Expression;
 class LabelDsymbol;
 class Identifier;

--- a/src/template.h
+++ b/src/template.h
@@ -32,7 +32,7 @@ class TemplateTupleParameter;
 class Type;
 class TypeQualified;
 class TypeTypeof;
-class Scope;
+struct Scope;
 class Expression;
 class AliasDeclaration;
 class FuncDeclaration;


### PR DESCRIPTION
Scope is frequently allocated on the stack, copied, and doesn't have any virtual functions.  This makes it a good fit for a D struct.
