### PR TITLE
[REG2.064a] Issue 10558 - Assertion failure on struct.c:741

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -335,7 +335,7 @@ hash_t arrayObjectHash(Objects *oa1)
                 FuncAliasDeclaration *fa1 = s1->isFuncAliasDeclaration();
                 if (fa1)
                     s1 = fa1->toAliasFunc();
-                hash += (size_t)(void *)s1->ident + (size_t)(void *)s1->parent;
+                hash += (size_t)(void *)s1->getIdent() + (size_t)(void *)s1->parent;
             }
             else if (Tuple *u1 = isTuple(o1))
                 hash += arrayObjectHash(&u1->objects);

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2652,6 +2652,25 @@ dstring rewriteCode10537(dstring code)
 }
 
 /******************************************/
+// 10558
+
+template Template10558() {}
+
+struct Struct10558(alias T){}
+
+alias bar10558 = foo10558!(Template10558!());
+
+template foo10558(alias T)
+{
+    alias foobar = Struct10558!T;
+
+    void fun()
+    {
+        alias a = foo10558!T;
+    }
+}
+
+/******************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10558

It's caused by #2239. A template instance on temlpate argument may not have yet valid `Dsymbol::ident`, so should use `Dsymbol::getIdent()` for hash calculation.
