### PR TITLE
Fix issue 10568 CTFE rejects function pointer safety casts

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -580,17 +580,23 @@ bool isSafePointerCast(Type *srcPointee, Type *destPointee)
         srcPointee = srcPointee->nextOf();
         destPointee = destPointee->nextOf();
     }
-   // It's OK if both are the same (modulo const)
+
 #if DMDV2
-    if (srcPointee->castMod(0) == destPointee->castMod(0))
-        return true;
-#else
+   // It's OK if both are the same (modulo const)
+    srcPointee = srcPointee->castMod(0);
+    destPointee = destPointee->castMod(0);
+#endif
     if (srcPointee == destPointee)
         return true;
-#endif
+
+    // It's OK if function pointers differ only in safe/pure/nothrow
+    if (srcPointee->ty == Tfunction && destPointee->ty == Tfunction)
+        return srcPointee->covariant(destPointee) == 1;
+
     // it's OK to cast to void*
     if (destPointee->ty == Tvoid)
         return true;
+
     // It's OK if they are the same size integers, eg int* and uint*
     return srcPointee->isintegral() && destPointee->isintegral()
            && srcPointee->size() == destPointee->size();

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3529,6 +3529,21 @@ int bug10211()
 static assert(bug10211());
 
 /**************************************************
+    10568 CTFE rejects function pointer safety casts
+**************************************************/
+
+@safe void safetyDance() {}
+
+int isItSafeToDance()
+{
+    void function() @trusted yourfriends = &safetyDance;
+    void function() @safe nofriendsOfMine = yourfriends;
+    return 1;
+}
+
+static assert(isItSafeToDance());
+
+/**************************************************
     9170 Allow reinterpret casts float<->int
 **************************************************/
 int f9170(float x) {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10568

When checking if a cast is safe, we need to check for function pointer covariance.
