### PR TITLE
Partial fix for Issue 10567 - Typeinfo.compare has unreasonable signature requirements on opCmp

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -143,7 +143,9 @@ public:
     FuncDeclaration *postblit;  // aggregate postblit
 
     FuncDeclaration *xeq;       // TypeInfo_Struct.xopEquals
+    FuncDeclaration *xcmp;      // TypeInfo_Struct.xopCmp
     static FuncDeclaration *xerreq;      // object.xopEquals
+    static FuncDeclaration *xerrcmp;     // object.xopCmp
 
     structalign_t alignment;    // alignment applied outside of the struct
 #endif
@@ -172,6 +174,7 @@ public:
     FuncDeclaration *buildCpCtor(Scope *sc);
     FuncDeclaration *buildOpEquals(Scope *sc);
     FuncDeclaration *buildXopEquals(Scope *sc);
+    FuncDeclaration *buildXopCmp(Scope *sc);
 #endif
     void toDocBuffer(OutBuffer *buf, Scope *sc);
 

--- a/src/clone.c
+++ b/src/clone.c
@@ -485,6 +485,28 @@ FuncDeclaration *StructDeclaration::buildXopEquals(Scope *sc)
         return NULL;        // bitwise comparison would work
 
     //printf("StructDeclaration::buildXopEquals() %s\n", toChars());
+    if (Dsymbol *eq = search_function(this, Id::eq))
+    {
+        if (FuncDeclaration *fd = eq->isFuncDeclaration())
+        {
+            TypeFunction *tfeqptr;
+            {
+                Scope sc;
+
+                /* const bool opEquals(ref const S s);
+                 */
+                Parameters *parameters = new Parameters;
+                parameters->push(new Parameter(STCref | STCconst, type, NULL, NULL));
+                tfeqptr = new TypeFunction(parameters, Type::tbool, 0, LINKd);
+                tfeqptr->mod = MODconst;
+                tfeqptr = (TypeFunction *)tfeqptr->semantic(Loc(), &sc);
+            }
+            fd = fd->overloadExactMatch(tfeqptr);
+            if (fd)
+                return fd;
+        }
+    }
+
     Loc declLoc = Loc();    // loc is unnecessary so __xopEquals is never called directly
     Loc loc = Loc();        // loc is unnecessary so errors are gagged
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -22,6 +22,7 @@
 #include "template.h"
 
 FuncDeclaration *StructDeclaration::xerreq;     // object.xopEquals
+FuncDeclaration *StructDeclaration::xerrcmp;    // object.xopCmp
 
 /********************************* AggregateDeclaration ****************************/
 
@@ -111,6 +112,8 @@ void AggregateDeclaration::semantic3(Scope *sc)
             //assert(sd->xeq == NULL);
             if (sd->xeq == NULL)
                 sd->xeq = sd->buildXopEquals(sc);
+            if (sd->xcmp == NULL)
+                sd->xcmp = sd->buildXopCmp(sc);
         }
         sc = sc->pop();
 
@@ -432,6 +435,7 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
     postblit = NULL;
 
     xeq = NULL;
+    xcmp = NULL;
     alignment = 0;
 #endif
     arg1type = NULL;

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -587,23 +587,6 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
         tftostring = (TypeFunction *)tftostring->semantic(Loc(), &sc);
     }
 
-    TypeFunction *tfcmpptr;
-    {
-        Scope sc;
-
-        /* const int opCmp(ref const KeyType s);
-         */
-        Parameters *arguments = new Parameters;
-
-        // arg type is ref const T
-        Parameter *arg = new Parameter(STCref, tc->constOf(), NULL, NULL);
-
-        arguments->push(arg);
-        tfcmpptr = new TypeFunction(arguments, Type::tint32, 0, LINKd);
-        tfcmpptr->mod = MODconst;
-        tfcmpptr = (TypeFunction *)tfcmpptr->semantic(Loc(), &sc);
-    }
-
     s = search_function(sd, Id::tohash);
     fdx = s ? s->isFuncDeclaration() : NULL;
     if (fdx)
@@ -635,20 +618,8 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
     else
         dtsize_t(pdt, 0);
 
-    s = search_function(sd, Id::cmp);
-    fdx = s ? s->isFuncDeclaration() : NULL;
-    if (fdx)
-    {
-        //printf("test1 %s, %s, %s\n", fdx->toChars(), fdx->type->toChars(), tfeqptr->toChars());
-        fd = fdx->overloadExactMatch(tfcmpptr);
-        if (fd)
-        {   dtxoff(pdt, fd->toSymbol(), 0);
-            //printf("test2\n");
-        }
-        else
-            //fdx->error("must be declared as extern (D) int %s(%s*)", fdx->toChars(), sd->toChars());
-            dtsize_t(pdt, 0);
-    }
+    if (sd->xcmp)
+        dtxoff(pdt, sd->xcmp->toSymbol(), 0);
     else
         dtsize_t(pdt, 0);
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10567

If needed, generate `__xopEquals` method in order to adapt `opCmp` member function (even if it's a template) to the function pointer `TypeInfo_Struct.xopCmp`.

BUG: Searching `opCmp` member doesn't work with alias this.
