### PR TITLE
Fix issue 10551 CTFE array pointer passed by ref

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4854,6 +4854,15 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
                     indx+ofs, len);
                 return EXP_CANT_INTERPRET;
             }
+            if (goal == ctfeNeedLvalueRef)
+            {
+                // if we need a reference, IndexExp shouldn't be interpreting
+                // the expression to a value, it should stay as a reference
+                Expression *e = new IndexExp(loc, agg,
+                    ofs ? new IntegerExp(loc,indx + ofs, e2->type) : e2);
+                e->type = type;
+                return e;
+            }
             return ctfeIndex(loc, type, agg, indx+ofs);
         }
         else
@@ -4868,6 +4877,10 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
                 error("pointer index [%lld] lies outside memory block [0..1]",
                     indx+ofs);
                 return EXP_CANT_INTERPRET;
+            }
+            if (goal == ctfeNeedLvalueRef)
+            {
+                return paintTypeOntoLiteral(type, agg);
             }
             return agg->interpret(istate);
         }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1541,16 +1541,28 @@ static assert(bug6001h());
 
 /**************************************************
    10243 wrong code *&arr as ref parameter
+   10551 wrong code (&arr)[0] as ref parameter
 **************************************************/
 
 void bug10243(ref int n)
 { n = 3; }
+
+void bug10551(int *p)
+{
+   bug10243(p[0]);
+}
 
 bool test10243()
 {
     int[1] arr;
     bug10243(*arr.ptr);
     assert(arr[0] == 3);
+    int [1] arr2;
+    bug10551(arr2.ptr);
+    assert(arr2[0] == 3);
+    int v;
+    bug10551(&v);
+    assert(v == 3);
     return true;
 }
 


### PR DESCRIPTION
if we need a reference, IndexExp shouldn't be interpreting the expression to a value, it should stay as a reference
