### PR TITLE
fix win32 warning in target.c

### DIFF
--- a/src/target.c
+++ b/src/target.c
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2013 by Digital Mars
 // All Rights Reserved
 // written by Iain Buclaw

--- a/src/target.c
+++ b/src/target.c
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2013 by Digital Mars
 // All Rights Reserved
 // written by Iain Buclaw
@@ -145,7 +144,7 @@ unsigned Target::critsecsize()
         // sizeof(pthread_mutex_t) for Solaris.
         return 24;
     }
-    else
-        assert(0);
+    assert(0);
+    return 0;
 }
 


### PR DESCRIPTION
This was creating a warning during a win32 build:

```
dmc -c -Iroot;\dm\include -o   -cpp -DDM_TARGET_CPU_X86=1  target
target.c(152) : Warning 18: implied return of Target::critsecsize at closing '}' does not return value
```

It looked an awful lot like a compile error on first glance. This change avoids emit a warning. Not checked on all OS'es yet (need to run unittests). Will squash once validated.
