### PR TITLE
10599 CTFE assert with bad struct initializer

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4657,7 +4657,14 @@ Expression *StructLiteralExp::semantic(Scope *sc)
             offset = v->offset + v->type->size();
         }
         if (e && e->op == TOKerror)
+        {
+            /* An error in the initializer needs to be recorded as an error
+             * in the enclosing function or template, since the initializer
+             * will be part of the stuct declaration.
+             */
+            global.increaseErrorCount();
             return e;
+        }
         elements->push(e);
     }
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -138,6 +138,13 @@ bool Global::isSpeculativeGagging()
     return gag && gag == speculativeGag;
 }
 
+void Global::increaseErrorCount()
+{
+    if (gag)
+        ++gaggedErrors;
+    ++errors;
+}
+
 
 char *Loc::toChars()
 {

--- a/src/mars.h
+++ b/src/mars.h
@@ -288,6 +288,12 @@ struct Global
      */
     bool endGagging(unsigned oldGagged);
 
+    /*  Increment the error count to record that an error
+     *  has occured in the current context. An error message
+     *  may or may not have been printed.
+     */
+    void increaseErrorCount();
+
     void init();
 };
 

--- a/test/fail_compilation/ice10599.d
+++ b/test/fail_compilation/ice10599.d
@@ -1,0 +1,12 @@
+﻿// 10599 ICE(interpret.c) 
+
+struct Bug {
+    int val = 3.45;
+}
+int bug10599()
+{
+    Bug p = Bug();
+    return 1;
+}
+
+static assert(bug10599());


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10599

This is an ErrorExp propagation/gagging bug which triggers an assert in the CTFE sanity checker.

Errors in struct initializers don't generate error messages when used, but we still need to let the enclosing function know that an error happened.

(Really we should refactor the way errors are done, so that we stop using global.errors to check if an error occurs. The whole thing is a bit hacky. I've done this incrementing via a member function in Global to make it slightly easier to refactor in the future).
