### PR TITLE
[REG2.063] Issue 10628 - spurious "hidden by" deprecation warning

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -148,18 +148,10 @@ void FuncDeclaration::semantic(Scope *sc)
     Dsymbol *parent = toParent();
 
     if (semanticRun >= PASSsemanticdone)
-    {
-        if (!parent->isClassDeclaration())
-        {
-            return;
-        }
-        // need to re-run semantic() in order to set the class's vtbl[]
-    }
-    else
-    {
-        assert(semanticRun <= PASSsemantic);
-        semanticRun = PASSsemantic;
-    }
+        return;
+
+    assert(semanticRun <= PASSsemantic);
+    semanticRun = PASSsemantic;
 
     if (scope)
     {   sc = scope;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -2674,6 +2674,7 @@ enum FwdEnum : int
 }
 
 /***************************************************/
+// 3740
 
 abstract class Address {
     abstract int nameLen();
@@ -2689,7 +2690,8 @@ class Class171 : Address {
 
 void test171 ()
 {
-        Class171 xxx = new Class171;
+    Class171 xxx = new Class171;
+    assert(typeid(Class171).vtbl.length - typeid(Object).vtbl.length == 1);
 }
 
 /***************************************************/
@@ -5723,6 +5725,29 @@ void test9844() {
 }
 
 /***************************************************/
+// 10628
+
+abstract class B10628
+{
+    static if (! __traits(isVirtualMethod, foo))
+    {
+    }
+
+    private bool _bar;
+    public void foo();
+}
+
+class D10628 : B10628
+{
+    public override void foo() {}
+}
+
+void test10628()
+{
+    assert(typeid(D10628).vtbl.length - typeid(Object).vtbl.length == 1);
+}
+
+/***************************************************/
 
 struct TimeOfDay
 {
@@ -6081,6 +6106,7 @@ int main()
     test6962();
     test4414();
     test9844();
+    test10628();
     test10633();
     test10642();
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10628

In old days, the code was added to fix [regression 3740](http://d.puremagic.com/issues/show_bug.cgi?id=3740).
But from 2.063, enhancement 7511 (#1676) has introduced more forward reference and its resolving.

Today, forward reference is correctly resolved with `Dsymbol::scope`, so "re-run semantic() in order to set the class's vtbl[]" is not necessary.
