### PR TITLE
Reduce memory overhead caused by chunk allocation

### DIFF
--- a/src/root/rmem.c
+++ b/src/root/rmem.c
@@ -143,7 +143,11 @@ void Mem::addroots(char* pStart, char* pEnd)
 /* Allocate, but never release
  */
 
-#define CHUNK_SIZE (4096 * 16 - 64) // let it fit into 64kB, even if the runtime adds some overhead
+// Allocate a little less than 64kB because the C runtime adds some overhead that
+// causes the actual memory block to be larger than 64kB otherwise. E.g. the dmc
+// runtime rounds the size up to 128kB, but the remaining space in the chunk is less 
+// than 64kB, so it cannot be used by another chunk.
+#define CHUNK_SIZE (4096 * 16 - 64)
 
 static size_t heapleft = 0;
 static void *heapp;

--- a/src/root/rmem.c
+++ b/src/root/rmem.c
@@ -143,7 +143,7 @@ void Mem::addroots(char* pStart, char* pEnd)
 /* Allocate, but never release
  */
 
-#define CHUNK_SIZE (4096 * 16)
+#define CHUNK_SIZE (4096 * 16 - 64) // let it fit into 64kB, even if the runtime adds some overhead
 
 static size_t heapleft = 0;
 static void *heapp;


### PR DESCRIPTION
The recent overload of operator new caused a decrease in usable memory (at least with the dmc runtime) because the C runtime overhead causes an allocation larger than 64kB, probably rounding up to the 128kB. As the remaining space in the chunk is less than 64kB, it cannot be used by another chunk.

This patch allocates a little less than 64kB per chunk to avoid larger allocations due to C runtime overhead
