### PR TITLE
fix Issue 10642 - Win64: wrong codegen comparing different sized integer...

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -3591,6 +3591,8 @@ code* prolog_loadparams(tym_t tyf, bool pushalloc, regm_t* namedargs)
                     c2->Iflags |= CFopsize; // operand size
                 if (I64 && sz >= REGSIZE)
                     c2->Irex |= REX_W;
+                if (I64 && sz == 1 && s->Sreglsw >= 4)
+                    c2->Irex |= REX;
                 if (!hasframe)
                 {   /* Convert to ESP relative address rather than EBP      */
                     assert(!I16);

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5752,6 +5752,50 @@ void test10633()
 
 /***************************************************/
 
+import std.stdio;
+
+void _assertEq (ubyte lhs, short rhs, string msg, string file, size_t line)
+{
+    immutable result = lhs == rhs;
+
+    if(!result)
+    {
+        string op = "==";
+        if(msg.length > 0)
+            writefln(`_assertEq failed: [%s] is not [%s].`, lhs, rhs);
+        else
+            writefln(`_assertEq failed: [%s] is not [%s]: %s`, lhs, rhs, msg);
+    }
+
+    assert(result);
+}
+
+struct Date
+{
+    short year;
+    ubyte month;
+    ubyte day;
+}
+
+struct MonthDay
+{
+    ubyte month;
+    short day;
+}
+
+void test10642()
+{
+    static void test(Date date, int day, MonthDay expected, size_t line = __LINE__)
+    {
+        _assertEq(date.day, expected.day, "", __FILE__, line);
+    }
+
+    test(Date(1999, 1, 1), 1, MonthDay(1,1));
+}
+
+
+/***************************************************/
+
 int main()
 {
     test1();
@@ -6038,6 +6082,7 @@ int main()
     test4414();
     test9844();
     test10633();
+    test10642();
 
     writefln("Success");
     return 0;


### PR DESCRIPTION
... arguments

fix http://d.puremagic.com/issues/show_bug.cgi?id=10642
