### PR TITLE
[critical] fix small bug introduced by #1660

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8382,8 +8382,9 @@ Expression *CallExp::semantic(Scope *sc)
             /* Attempt to instantiate ti. If that works, go with it.
              * If not, go with partial explicit specialization.
              */
-            if (ti->semanticTiargs(sc) &&
-                ti->needsTypeInference(sc, 1))
+            if (!ti->semanticTiargs(sc))
+                return new ErrorExp();
+            if (ti->needsTypeInference(sc, 1))
             {
                 /* Go with partial explicit specialization
                  */
@@ -8414,9 +8415,10 @@ Ldotti:
             /* Attempt to instantiate ti. If that works, go with it.
              * If not, go with partial explicit specialization.
              */
-            if (se->findTempDecl(sc) &&
-                ti->semanticTiargs(sc) &&
-                ti->needsTypeInference(sc, 1))
+            if (!se->findTempDecl(sc) ||
+                !ti->semanticTiargs(sc))
+                return new ErrorExp();
+            if (ti->needsTypeInference(sc, 1))
             {
                 /* Go with partial explicit specialization
                  */


### PR DESCRIPTION
If `ti->semanticTiargs(sc)` returns false, CallExp should return ErrorExp.

---

While I'm rebasing #2256, I found a [test result](http://d.puremagic.com/test-results/pull.ghtml?projectid=1&runid=673517) breaking from auto tester. The cause was a _hidden_ regression introduced by #1660.

The problematic change (from #1660)
https://github.com/D-Programming-Language/dmd/pull/1660/files#L0L8323

I couldn't make actually broken test case, but the bug is obvious. That's definitely my mistake...
