### PR TITLE
fix Issue 10634 - Win64: wrong codegen with .int of small structs

### DIFF
--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -3020,8 +3020,6 @@ elem * elstruct(elem *e, goal_t goal)
         return optelem(e, goal);
     }
 
-    //printf("\tnumbytes = %d\n", (int)e->Enumbytes);
-
     if (!e->ET)
         return e;
     //printf("\tnumbytes = %d\n", (int)type_size(e->ET));
@@ -3038,6 +3036,7 @@ elem * elstruct(elem *e, goal_t goal)
     }
 
     unsigned sz = type_size(e->ET);
+    //printf("\tsz = %d\n", (int)sz);
     switch ((int)sz)
     {
         case 1:  tym = TYchar;   goto L1;
@@ -3052,7 +3051,7 @@ elem * elstruct(elem *e, goal_t goal)
         case 6:
         case 7:  tym = TYllong;
         L2:
-            if (config.exe == EX_WIN64)
+            if (e->Eoper == OPstrpar && config.exe == EX_WIN64)
             {
                  goto L1;
             }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -6446,6 +6446,37 @@ void test10539()
 
 /***************************************************/
 
+struct TimeOfDay
+{
+    ubyte h, m, s;
+}
+
+__gshared byte glob;
+
+struct DateTime
+{
+    this(ubyte _d, ubyte _m, ubyte _y, TimeOfDay _tod = TimeOfDay.init)
+    {
+        d = _d;
+        m = _m;
+        y = _y;
+        tod = _tod;
+    }
+    TimeOfDay tod;
+    ubyte d, m, y;
+}
+
+
+void test10634()
+{
+    glob = 123;
+    DateTime date1 = DateTime(0, 0, 0);
+    DateTime date2;
+    assert(date1 == date2);
+}
+
+/***************************************************/
+
 int main()
 {
     test1();
@@ -6715,6 +6746,7 @@ int main()
     test9130();
     test10542();
     test10539();
+    test10634();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
fix http://d.puremagic.com/issues/show_bug.cgi?id=10634
