### PR TITLE
Remove more irrelevant IN_GCC macros.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1506,16 +1506,6 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                     case Tsarray:
                     case Tarray:
                     {   // Create a static array variable v of type arg->type
-#ifdef IN_GCC
-                        /* GCC 4.0 does not like zero length arrays used like
-                           this; pass a null array value instead. Could also
-                           just make a one-element array. */
-                        if (nargs - i == 0)
-                        {
-                            arg = new NullExp(loc);
-                            break;
-                        }
-#endif
                         Identifier *id = Lexer::uniqueId("__arrayArg");
                         Type *t = new TypeSArray(((TypeArray *)tb)->next, new IntegerExp(nargs - i));
                         t = t->semantic(loc, sc);

--- a/src/mars.h
+++ b/src/mars.h
@@ -80,10 +80,6 @@ the target object file format:
 #endif
 void unittests();
 
-#ifdef IN_GCC
-/* Changes for the GDC compiler by David Friedman */
-#endif
-
 #define DMDV1   0
 #define DMDV2   1       // Version 2.0 features
 #define SNAN_DEFAULT_INIT DMDV2 // if floats are default initialized to signalling NaN


### PR DESCRIPTION
More code which can go from the front end.  Having tested gcc, and it handles this special case a lot better now than when this patch was initially created.
