### PR TITLE
Refactor PowExp to error about unimplemented ^^ in the backend.

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3499,14 +3499,10 @@ elem *PowAssignExp::toElem(IRState *irs)
 {
     Type *tb1 = e1->type->toBasetype();
     if (tb1->ty == Tarray || tb1->ty == Tsarray)
-    {
         error("Array operation %s not implemented", toChars());
-        return el_long(type->totym(), 0);  // error recovery
-    }
     else
-    {   assert(0);
-        return NULL;
-    }
+        error("must import std.math to use ^^ operator");
+    return el_long(type->totym(), 0);  // error recovery
 }
 
 
@@ -3564,12 +3560,10 @@ elem *PowExp::toElem(IRState *irs)
 {
     Type *tb1 = e1->type->toBasetype();
     if (tb1->ty == Tarray || tb1->ty == Tsarray)
-    {
         error("Array operation %s not implemented", toChars());
-        return el_long(type->totym(), 0);  // error recovery
-    }
-    assert(0);
-    return NULL;
+    else
+        error("must import std.math to use ^^ operator");
+    return el_long(type->totym(), 0);  // error recovery
 }
 
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -12438,21 +12438,16 @@ Expression *PowExp::semantic(Scope *sc)
                 !mi->parent->parent)
             {
                 importMath = true;
-                goto L1;
+                break;
             }
         }
-        error("must import std.math to use ^^ operator");
-        return new ErrorExp();
-
-     L1: ;
     }
-    else
-    {
-        if (!importMath)
-        {
-            error("must import std.math to use ^^ operator");
-            return new ErrorExp();
-        }
+    if (!importMath)
+    {   // Leave handling of PowExp to the backend, or throw
+        // an error gracefully if no backend support exists.
+        typeCombine(sc);
+        e = this;
+        return e;
     }
 
     e = new IdentifierExp(loc, Id::empty);


### PR DESCRIPTION
Leaving it to the auto-tester to check this doesn't fail any existing the tests.

This moves a frontend error to the backend for those of us who are able to handle PowExp without requiring to import std.math.

Only change this would make that I can think of is that strange testsuite-style code like `__traits(compiles, x ^^ y)` would return `true` instead of `false`.  Which seems reasonable to me, but what do you guys/gals think?
