### PR TITLE
Issue 9546 - getProtection trait does not work with mixin or getMember

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -410,6 +410,9 @@ int AggregateDeclaration::hasPrivateAccess(Dsymbol *smember)
 
 void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
 {
+    if (sc->flags & SCOPEnoaccesscheck)
+        return;
+
 #if LOG
     if (e)
     {   printf("accessCheck(%s . %s)\n", e->toChars(), d->toChars());
@@ -430,7 +433,8 @@ void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
         }
     }
     else if (e->type->ty == Tclass)
-    {   // Do access check
+    {
+        // Do access check
         ClassDeclaration *cd = (ClassDeclaration *)(((TypeClass *)e->type)->sym);
         if (e->op == TOKsuper)
         {
@@ -441,7 +445,8 @@ void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
         cd->accessCheck(loc, sc, d);
     }
     else if (e->type->ty == Tstruct)
-    {   // Do access check
+    {
+        // Do access check
         StructDeclaration *cd = (StructDeclaration *)(((TypeStruct *)e->type)->sym);
         cd->accessCheck(loc, sc, d);
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -7805,8 +7805,7 @@ Expression *DotVarExp::semantic(Scope *sc)
             Dsymbol *vparent = var->toParent();
             AggregateDeclaration *ad = vparent ? vparent->isAggregateDeclaration() : NULL;
             e1 = getRightThis(loc, sc, ad, e1, var);
-            if (!sc->noaccesscheck)
-                accessCheck(loc, sc, e1, var);
+            accessCheck(loc, sc, e1, var);
 
             VarDeclaration *v = var->isVarDeclaration();
 #if PULL93

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7964,10 +7964,10 @@ Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident, int 
             exps->push(new DotVarExp(ev->loc, ev, v));
         }
         e = new TupleExp(e->loc, e0, exps);
-        sc = sc->push();
-        sc->noaccesscheck = 1;
-        e = e->semantic(sc);
-        sc->pop();
+        Scope *sc2 = sc->push();
+        sc2->flags = sc->flags | SCOPEnoaccesscheck;
+        e = e->semantic(sc2);
+        sc2->pop();
         return e;
     }
 
@@ -8504,17 +8504,18 @@ Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
             ev = new VarExp(e->loc, vd);
         }
         for (size_t i = 0; i < sym->fields.dim; i++)
-        {   VarDeclaration *v = sym->fields[i];
+        {
+            VarDeclaration *v = sym->fields[i];
             // Don't include hidden 'this' pointer
             if (v->isThisDeclaration())
                 continue;
             exps->push(new DotVarExp(ev->loc, ev, v));
         }
         e = new TupleExp(e->loc, e0, exps);
-        sc = sc->push();
-        sc->noaccesscheck = 1;
-        e = e->semantic(sc);
-        sc->pop();
+        Scope *sc2 = sc->push();
+        sc2->flags = sc->flags | SCOPEnoaccesscheck;
+        e = e->semantic(sc2);
+        sc2->pop();
         return e;
     }
 

--- a/src/scope.c
+++ b/src/scope.c
@@ -73,7 +73,6 @@ Scope::Scope()
     this->inunion = 0;
     this->nofree = 0;
     this->noctor = 0;
-    this->noaccesscheck = 0;
     this->intypeof = 0;
     this->speculative = 0;
     this->callSuper = 0;
@@ -121,7 +120,6 @@ Scope::Scope(Scope *enclosing)
     this->inunion = enclosing->inunion;
     this->nofree = 0;
     this->noctor = enclosing->noctor;
-    this->noaccesscheck = enclosing->noaccesscheck;
     this->intypeof = enclosing->intypeof;
     this->speculative = enclosing->speculative;
     this->callSuper = enclosing->callSuper;

--- a/src/scope.h
+++ b/src/scope.h
@@ -46,18 +46,19 @@ enum PROT;
 #define CSXreturn       0x20    // seen a return statement
 #define CSXany_ctor     0x40    // either this() or super() was called
 
-#define SCOPEctor       1       // constructor type
-#define SCOPEstaticif   2       // inside static if
-#define SCOPEfree       4       // is on free list
-#define SCOPEstaticassert 8     // inside static assert
-#define SCOPEdebug      0x10    // inside debug conditional
+#define SCOPEctor           0x0001  // constructor type
+#define SCOPEstaticif       0x0002  // inside static if
+#define SCOPEfree           0x0004  // is on free list
+#define SCOPEstaticassert   0x0008  // inside static assert
+#define SCOPEdebug          0x0010  // inside debug conditional
 
-#define SCOPEinvariant  0x20    // inside invariant code
-#define SCOPErequire    0x40    // inside in contract code
-#define SCOPEensure     0x60    // inside out contract code
-#define SCOPEcontract   0x60    // [mask] we're inside contract code
+#define SCOPEinvariant      0x0020  // inside invariant code
+#define SCOPErequire        0x0040  // inside in contract code
+#define SCOPEensure         0x0060  // inside out contract code
+#define SCOPEcontract       0x0060  // [mask] we're inside contract code
 
-#define SCOPEctfe       0x80    // inside a ctfe-only expression
+#define SCOPEctfe           0x0080  // inside a ctfe-only expression
+#define SCOPEnoaccesscheck  0x0100  // don't do access checks
 
 struct Scope
 {
@@ -87,7 +88,6 @@ struct Scope
     int noctor;                 // set if constructor calls aren't allowed
     int intypeof;               // in typeof(exp)
     bool speculative;            // in __traits(compiles) or typeof(exp)
-    int noaccesscheck;          // don't do access checks
 
     unsigned callSuper;         // primitive flow analysis for constructors
 

--- a/src/traits.c
+++ b/src/traits.c
@@ -125,7 +125,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     printf("TraitsExp::semantic() %s\n", toChars());
 #endif
     if (ident != Id::compiles && ident != Id::isSame &&
-        ident != Id::identifier)
+        ident != Id::identifier && ident != Id::getProtection)
     {
         TemplateInstance::semanticTiargs(loc, sc, args, 1);
     }
@@ -317,6 +317,12 @@ Expression *TraitsExp::semantic(Scope *sc)
     {
         if (dim != 1)
             goto Ldimerror;
+
+        Scope *sc2 = sc->push();
+        sc2->flags = sc->flags | SCOPEnoaccesscheck;
+        TemplateInstance::semanticTiargs(loc, sc2, args, 1);
+        sc2->pop();
+
         RootObject *o = (*args)[0];
         Dsymbol *s = getDsymbol(o);
         if (!s)

--- a/test/runnable/imports/a9546.d
+++ b/test/runnable/imports/a9546.d
@@ -1,0 +1,12 @@
+module imports.a9546;
+
+struct S
+{
+    private   int privA;
+    protected int protA;
+    package   int packA;
+
+    private   void privF() {}
+    protected void protF() {}
+    package   void packF() {}
+}

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -939,6 +939,57 @@ void getProtection()
 }
 
 /********************************************************/
+// 9546
+
+void test9546()
+{
+    import imports.a9546;
+
+    S s;
+    static assert(__traits(getProtection, s.privA) == "private");
+    static assert(__traits(getProtection, s.protA) == "protected");
+    static assert(__traits(getProtection, s.packA) == "package");
+    static assert(__traits(getProtection, S.privA) == "private");
+    static assert(__traits(getProtection, S.protA) == "protected");
+    static assert(__traits(getProtection, S.packA) == "package");
+
+    static assert(__traits(getProtection, mixin("s.privA")) == "private");
+    static assert(__traits(getProtection, mixin("s.protA")) == "protected");
+    static assert(__traits(getProtection, mixin("s.packA")) == "package");
+    static assert(__traits(getProtection, mixin("S.privA")) == "private");
+    static assert(__traits(getProtection, mixin("S.protA")) == "protected");
+    static assert(__traits(getProtection, mixin("S.packA")) == "package");
+
+    static assert(__traits(getProtection, __traits(getMember, s, "privA")) == "private");
+    static assert(__traits(getProtection, __traits(getMember, s, "protA")) == "protected");
+    static assert(__traits(getProtection, __traits(getMember, s, "packA")) == "package");
+    static assert(__traits(getProtection, __traits(getMember, S, "privA")) == "private");
+    static assert(__traits(getProtection, __traits(getMember, S, "protA")) == "protected");
+    static assert(__traits(getProtection, __traits(getMember, S, "packA")) == "package");
+
+    static assert(__traits(getProtection, s.privF) == "private");
+    static assert(__traits(getProtection, s.protF) == "protected");
+    static assert(__traits(getProtection, s.packF) == "package");
+    static assert(__traits(getProtection, S.privF) == "private");
+    static assert(__traits(getProtection, S.protF) == "protected");
+    static assert(__traits(getProtection, S.packF) == "package");
+
+    static assert(__traits(getProtection, mixin("s.privF")) == "private");
+    static assert(__traits(getProtection, mixin("s.protF")) == "protected");
+    static assert(__traits(getProtection, mixin("s.packF")) == "package");
+    static assert(__traits(getProtection, mixin("S.privF")) == "private");
+    static assert(__traits(getProtection, mixin("S.protF")) == "protected");
+    static assert(__traits(getProtection, mixin("S.packF")) == "package");
+
+    static assert(__traits(getProtection, __traits(getMember, s, "privF")) == "private");
+    static assert(__traits(getProtection, __traits(getMember, s, "protF")) == "protected");
+    static assert(__traits(getProtection, __traits(getMember, s, "packF")) == "package");
+    static assert(__traits(getProtection, __traits(getMember, S, "privF")) == "private");
+    static assert(__traits(getProtection, __traits(getMember, S, "protF")) == "protected");
+    static assert(__traits(getProtection, __traits(getMember, S, "packF")) == "package");
+}
+
+/********************************************************/
 // 9091
 
 template isVariable9091(X...) if (X.length == 1)


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9546

Stop access check during `__traits(getProtection)` evaluated.
