### PR TITLE
fix Issue 10673 - memory corruption in interpret.c

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -5035,6 +5035,7 @@ LabelStatement::LabelStatement(Loc loc, Identifier *ident, Statement *statement)
     this->ident = ident;
     this->statement = statement;
     this->tf = NULL;
+    this->gotoTarget = NULL;
     this->lblock = NULL;
     this->fwdrefs = NULL;
 }


### PR DESCRIPTION
- the gotoTarget field of LabelStatement was never initialized

[Bugzilla 10673](http://d.puremagic.com/issues/show_bug.cgi?id=10673)
