### PR TITLE
fix Issue 10462 - call through function pointer might trash EBX

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -3113,6 +3113,10 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
         assert(!I16 || (e11ty == TYnptr));
 #endif
         c = cat(c, load_localgot());
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
+        if (config.flags3 & CFG3pic && I32)
+            keepmsk |= mBX;
+#endif
 
         /* Mask of registers destroyed by the function call
          */


### PR DESCRIPTION
add EBX to the keepmsk after GOT was loaded

This is a followup to #2278. The fix feels a little hacky to me so please have a look @WalterBright whether it's appropriate.

[Bugzilla 10462](http://d.puremagic.com/issues/show_bug.cgi?id=10462)
