### PR TITLE
fix Issue 10677 - Win64: cfloat return value not forwarded correctly as ...

### DIFF
--- a/src/toir.c
+++ b/src/toir.c
@@ -854,6 +854,8 @@ RET TypeFunction::retStyle()
 
     if (global.params.isWindows && global.params.is64bit)
     {   // http://msdn.microsoft.com/en-us/library/7572ztz4(v=vs.80)
+        if (tns->ty == Tcomplex32)
+            return RETstack;
         if (tns->isscalar())
             return RETregs;
 

--- a/test/runnable/complex.d
+++ b/test/runnable/complex.d
@@ -324,6 +324,24 @@ void test8966()
 
 /***************************************/
 
+void formatTest2(cfloat s, double re, double im)
+{
+    assert(s.re == re);
+    assert(s.im == im);
+}
+
+cfloat getcf()
+{
+    return 2 + 1i;
+}
+
+void test10677()
+{
+    formatTest2( getcf(), 2, 1 );
+}
+
+/***************************************/
+
 int main(char[][] args)
 {
 
@@ -346,6 +364,7 @@ int main(char[][] args)
     test7593();
     test7591();
     test8966();
+    test10677();
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
...function argument

Fix http://d.puremagic.com/issues/show_bug.cgi?id=10677
