### PR TITLE
Require DSO for Linux

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -63,7 +63,7 @@ char *obj_mangle2(Symbol *s,char *dest);
  * section registration and will no longer create global bracket
  * symbols (_deh_beg,_deh_end,_tlsstart,_tlsend).
  */
-#define REQUIRE_DSO_REGISTRY 0
+#define REQUIRE_DSO_REGISTRY (DMDV2 && TARGET_LINUX)
 
 /***************************************************
  * Correspondence of relocation types

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -71,7 +71,7 @@ else
 endif
 
 CFLAGS = $(GFLAGS) -I$(ROOT) -DMARS=1 -DTARGET_$(OS)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1
-MFLAGS = $(GFLAGS) -I$C -I$(TK) -I$(ROOT) -DMARS=1 -DTARGET_$(OS)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1
+MFLAGS = $(GFLAGS) -I$C -I$(TK) -I$(ROOT) -DMARS=1 -DTARGET_$(OS)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 -DDMDV2=1
 
 CH= $C/cc.h $C/global.h $C/oper.h $C/code.h $C/type.h \
 	$C/dt.h $C/cgcv.h $C/el.h $C/obj.h $(TARGET_CH)


### PR DESCRIPTION
This can be done for Linux builds now that druntime is updated.

_Dmodule_ref was causing problems for the gold linker anyway - this should fix it.
