### PR TITLE
[Refactoring] Clean up template semantic code

### DIFF
--- a/src/template.h
+++ b/src/template.h
@@ -343,7 +343,7 @@ public:
     Dsymbol *toAlias();                 // resolve real symbol
     const char *kind();
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    int needsTypeInference(Scope *sc, int flag = 0);
+    bool needsTypeInference(Scope *sc, int flag = 0);
     char *toChars();
     const char *mangle(bool isv = false);
     void printInstantiationTrace();
@@ -391,6 +391,8 @@ public:
     void toJson(JsonOut *json);
 
     void toObjFile(int multiobj);                       // compile to .obj file
+
+    bool findTemplateDeclaration(Scope *sc);
 
     TemplateMixin *isTemplateMixin() { return this; }
 };

--- a/src/template.h
+++ b/src/template.h
@@ -300,7 +300,6 @@ public:
      *      tiargs = args
      */
     Identifier *name;
-    //Identifiers idents;
     Objects *tiargs;            // Array of Types/Expressions of template
                                 // instance arguments [int*, char, 10*10]
 
@@ -308,8 +307,7 @@ public:
                                 // to TemplateDeclaration.parameters
                                 // [int, char, 100]
 
-    TemplateDeclaration *tempdecl;      // referenced by foo.bar.abc
-    OverloadSet *tempovers;             // template overload set
+    Dsymbol *tempdecl;                  // referenced by foo.bar.abc
     TemplateInstance *inst;             // refer to existing instance
     TemplateInstance *tinst;            // enclosing template instance
     ScopeDsymbol *argsym;               // argument symbol table


### PR DESCRIPTION
- Merge `TemplateDeclaration *tempdecl` and `OverloadSet *tempovers` into `Dsymbol *tempdecl` in `TemplateInstance` object
- Standardize three phases - `findTemplateDeclaration`, `semanticTiargs`, and `findBestMatch`
