### PR TITLE
[DDMD] Rename Type::typeinfo to dtypeinfo so it can be accessed across language boundaries

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -78,7 +78,7 @@ ClassDeclaration::ClassDeclaration(Loc loc, Identifier *id, BaseClasses *basecla
             if (id == Id::TypeInfo)
             {   if (!inObject)
                     error("%s", msg);
-                Type::typeinfo = this;
+                Type::dtypeinfo = this;
             }
 
             if (id == Id::TypeInfo_Class)

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -548,8 +548,8 @@ TypeAArray *toBuiltinAAType(Type *t)
 bool isTypeInfo_Class(Type *type)
 {
     return type->ty == Tclass &&
-        (( Type::typeinfo == ((TypeClass*)type)->sym)
-        || Type::typeinfo->isBaseOf(((TypeClass*)type)->sym, NULL));
+        (( Type::dtypeinfo == ((TypeClass*)type)->sym)
+        || Type::dtypeinfo->isBaseOf(((TypeClass*)type)->sym, NULL));
 }
 
 /************** Pointer operations ************************************/

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -2345,7 +2345,7 @@ void ClassInfoDeclaration::semantic(Scope *sc)
 /********************************* TypeInfoDeclaration ****************************/
 
 TypeInfoDeclaration::TypeInfoDeclaration(Type *tinfo, int internal)
-    : VarDeclaration(Loc(), Type::typeinfo->type, tinfo->getTypeInfoIdent(internal), NULL)
+    : VarDeclaration(Loc(), Type::dtypeinfo->type, tinfo->getTypeInfoIdent(internal), NULL)
 {
     this->tinfo = tinfo;
     storage_class = STCstatic | STCgshared;

--- a/src/func.c
+++ b/src/func.c
@@ -1028,7 +1028,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 v_arguments->parent = this;
 
                 //t = Type::typeinfo->type->constOf()->arrayOf();
-                t = Type::typeinfo->type->arrayOf();
+                t = Type::dtypeinfo->type->arrayOf();
                 _arguments = new VarDeclaration(Loc(), t, Id::_arguments, NULL);
                 _arguments->semantic(sc2);
                 sc2->insert(_arguments);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -59,7 +59,7 @@ int Tptrdiff_t = Tint32;
 
 /***************************** Type *****************************/
 
-ClassDeclaration *Type::typeinfo;
+ClassDeclaration *Type::dtypeinfo;
 ClassDeclaration *Type::typeinfoclass;
 ClassDeclaration *Type::typeinfointerface;
 ClassDeclaration *Type::typeinfostruct;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -189,7 +189,7 @@ public:
     static Type *thash_t;               // matches hash_t alias
     static Type *tindex;                // array/ptr index
 
-    static ClassDeclaration *typeinfo;
+    static ClassDeclaration *dtypeinfo;
     static ClassDeclaration *typeinfoclass;
     static ClassDeclaration *typeinfointerface;
     static ClassDeclaration *typeinfostruct;

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -111,7 +111,7 @@ Expression *Type::getInternalTypeInfo(Scope *sc)
 Expression *Type::getTypeInfo(Scope *sc)
 {
     //printf("Type::getTypeInfo() %p, %s\n", this, toChars());
-    if (!Type::typeinfo)
+    if (!Type::dtypeinfo)
     {
         error(Loc(), "TypeInfo not found. object.d may be incorrectly installed or corrupt, compile with -v switch");
         fatal();
@@ -234,9 +234,9 @@ TypeInfoDeclaration *TypeTuple::getTypeInfoDeclaration()
 void TypeInfoDeclaration::toDt(dt_t **pdt)
 {
     //printf("TypeInfoDeclaration::toDt() %s\n", toChars());
-    verifyStructSize(Type::typeinfo, 2 * Target::ptrsize);
+    verifyStructSize(Type::dtypeinfo, 2 * Target::ptrsize);
 
-    dtxoff(pdt, Type::typeinfo->toVtblSymbol(), 0); // vtbl for TypeInfo
+    dtxoff(pdt, Type::dtypeinfo->toVtblSymbol(), 0); // vtbl for TypeInfo
     dtsize_t(pdt, 0);                        // monitor
 }
 


### PR DESCRIPTION
`typeinfo` is a built-in property in D, so this variable must be renamed for the resulting D code to be valid.  Because it must be accessed from `typinf.c` which is written in C++, the name must be changed in the C++ source, and cannot be done automatically during conversion.
