### PR TITLE
[DDMD] Align first offset of derived class correctly (matching C++)

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -592,6 +592,7 @@ void ClassDeclaration::semantic(Scope *sc)
     if (baseClass)
     {   sc->offset = baseClass->structsize;
         alignsize = baseClass->alignsize;
+        sc->offset = (sc->offset + alignsize - 1) & ~(alignsize - 1);
 //      if (enclosing)
 //          sc->offset += Target::ptrsize;      // room for uplevel context pointer
     }

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -781,7 +781,7 @@ void test36()
     printf("%d\n", a.d);
 
     version(D_LP64)
-        assert(a.classinfo.init.length == 36);
+        assert(a.classinfo.init.length == 40);
     else
         assert(a.classinfo.init.length == 28);
     assert(a.s == 1);


### PR DESCRIPTION
For whatever reason, in C++ the base class is padded by the base class' alignment.

eg:

``` d
class A
{
    long x;
    int a;
}
class B : A
{
    int b;
    long c;
}
```

A needs 8-byte alignment, but consumes 12 bytes.  B then starts at offset 12, when the C++ version would start at offset 16.

This is needed because `extern(C++)` classes (coming soon) need to match the alignment of the host C++ compiler.
