### PR TITLE
[DDMD] Rename isFinal to isFinalFunc to not conflict with Declaration::isFinal

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -705,7 +705,7 @@ public:
     bool needThis();
     bool isVirtualMethod();
     virtual bool isVirtual();
-    virtual bool isFinal();
+    virtual bool isFinalFunc();
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
     Expression *interpret(InterState *istate, Expressions *arguments, Expression *thisexp = NULL);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -258,7 +258,7 @@ elem *callfunc(Loc loc,
 
         if (!fd->isVirtual() ||
             directcall ||               // BUG: fix
-            fd->isFinal()
+            fd->isFinalFunc()
            /* Future optimization: || (whole program analysis && not overridden)
             */
            )
@@ -3747,7 +3747,7 @@ elem *DelegateExp::toElem(IRState *irs)
 
         if (!func->isVirtual() ||
             directcall ||
-            func->isFinal())
+            func->isFinalFunc())
         {
             ep = el_ptr(sfunc);
         }

--- a/src/func.c
+++ b/src/func.c
@@ -344,7 +344,7 @@ void FuncDeclaration::semantic(Scope *sc)
             error("cannot override a non-virtual function");
     }
 
-    if (isAbstract() && isFinal())
+    if (isAbstract() && isFinalFunc())
         error("cannot be both final and abstract");
 #if 0
     if (isAbstract() && fbody)
@@ -481,13 +481,13 @@ void FuncDeclaration::semantic(Scope *sc)
                         if (f)
                         {
                             f = f->overloadExactMatch(type);
-                            if (f && f->isFinal() && f->prot() != PROTprivate)
+                            if (f && f->isFinalFunc() && f->prot() != PROTprivate)
                                 error("cannot override final function %s", f->toPrettyChars());
                         }
                     }
                 }
 
-                if (isFinal())
+                if (isFinalFunc())
                 {
                     // Don't check here, as it may override an interface function
                     //if (isOverride())
@@ -534,7 +534,7 @@ void FuncDeclaration::semantic(Scope *sc)
                 }
 
                 // This function overrides fdv
-                if (fdv->isFinal())
+                if (fdv->isFinalFunc())
                     error("cannot override final function %s", fdv->toPrettyChars());
 
                 doesoverride = TRUE;
@@ -699,7 +699,7 @@ void FuncDeclaration::semantic(Scope *sc)
                     if (f)
                     {
                         f = f->overloadExactMatch(type);
-                        if (f && f->isFinal() && f->prot() != PROTprivate)
+                        if (f && f->isFinalFunc() && f->prot() != PROTprivate)
                             error("cannot override final function %s.%s", b->base->toChars(), f->toPrettyChars());
                     }
                 }
@@ -3183,12 +3183,12 @@ bool FuncDeclaration::isVirtual()
         isMember() &&
         !(isStatic() || protection == PROTprivate || protection == PROTpackage) &&
         p->isClassDeclaration() &&
-        !(p->isInterfaceDeclaration() && isFinal()));
+        !(p->isInterfaceDeclaration() && isFinalFunc()));
 #endif
     return isMember() &&
         !(isStatic() || protection == PROTprivate || protection == PROTpackage) &&
         p->isClassDeclaration() &&
-        !(p->isInterfaceDeclaration() && isFinal());
+        !(p->isInterfaceDeclaration() && isFinalFunc());
 }
 
 // Determine if a function is pedantically virtual
@@ -3202,21 +3202,21 @@ bool FuncDeclaration::isVirtualMethod()
     if (!isVirtual())
         return false;
     // If it's a final method, and does not override anything, then it is not virtual
-    if (isFinal() && foverrides.dim == 0)
+    if (isFinalFunc() && foverrides.dim == 0)
     {
         return false;
     }
     return true;
 }
 
-bool FuncDeclaration::isFinal()
+bool FuncDeclaration::isFinalFunc()
 {
     if (toAliasFunc() != this)
-        return toAliasFunc()->isFinal();
+        return toAliasFunc()->isFinalFunc();
 
     ClassDeclaration *cd;
 #if 0
-    printf("FuncDeclaration::isFinal(%s), %x\n", toChars(), Declaration::isFinal());
+    printf("FuncDeclaration::isFinalFunc(%s), %x\n", toChars(), Declaration::isFinal());
     printf("%p %d %d %d\n", isMember(), isStatic(), Declaration::isFinal(), ((cd = toParent()->isClassDeclaration()) != NULL && cd->storage_class & STCfinal));
     printf("result is %d\n",
         isMember() &&

--- a/src/inline.c
+++ b/src/inline.c
@@ -1563,7 +1563,7 @@ int FuncDeclaration::canInline(int hasthis, int hdrscan, int statementsToo)
         isSynchronized() ||
         isImportedSymbol() ||
         hasNestedFrameRefs() ||      // no nested references to this frame
-        (isVirtual() && !isFinal())
+        (isVirtual() && !isFinalFunc())
        ))
     {
         goto Lno;

--- a/src/traits.c
+++ b/src/traits.c
@@ -262,7 +262,7 @@ Expression *TraitsExp::semantic(Scope *sc)
     else if (ident == Id::isFinalFunction)
     {
         FuncDeclaration *f;
-        ISDSYMBOL((f = s->isFuncDeclaration()) != NULL && f->isFinal())
+        ISDSYMBOL((f = s->isFuncDeclaration()) != NULL && f->isFinalFunc())
     }
 #if DMDV2
     else if (ident == Id::isStaticFunction)


### PR DESCRIPTION
It is an error in D to override a non-virtual function... as it should be.
