### PR TITLE
[DDMD] Do not use implicit int -> bool conversion (not valid in D)

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -799,7 +799,7 @@ void AlignDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
 /********************************* AnonDeclaration ****************************/
 
-AnonDeclaration::AnonDeclaration(Loc loc, int isunion, Dsymbols *decl)
+AnonDeclaration::AnonDeclaration(Loc loc, bool isunion, Dsymbols *decl)
         : AttribDeclaration(decl)
 {
     this->loc = loc;

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -137,7 +137,7 @@ public:
     structalign_t alignment;
     int sem;                    // 1 if successful semantic()
 
-    AnonDeclaration(Loc loc, int isunion, Dsymbols *decl);
+    AnonDeclaration(Loc loc, bool isunion, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1783,7 +1783,7 @@ Dsymbol *Parser::parseAggregate()
         {
             /* Anonymous structs/unions are more like attributes.
              */
-            return new AnonDeclaration(loc, anon - 1, decl);
+            return new AnonDeclaration(loc, anon == 2, decl);
         }
         else
             a->members = decl;


### PR DESCRIPTION
In `parseAggregate`, `anon` is set to 1 for an anon struct, and 2 for an anon union.  Compare with 2 directly instead of subtracting 1.
