### PR TITLE
[DDMD] Explicitly cast FuncDeclaration to void*

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1012,7 +1012,7 @@ int ClassDeclaration::isFuncHidden(FuncDeclaration *fd)
         for (size_t i = 0; i < os->a.dim; i++)
         {   Dsymbol *s2 = os->a[i];
             FuncDeclaration *f2 = s2->isFuncDeclaration();
-            if (f2 && overloadApply(f2, &isf, fd))
+            if (f2 && overloadApply(f2, &isf, (void *)fd))
                 return 0;
         }
         return 1;
@@ -1021,7 +1021,7 @@ int ClassDeclaration::isFuncHidden(FuncDeclaration *fd)
     {
         FuncDeclaration *fdstart = s->isFuncDeclaration();
         //printf("%s fdstart = %p\n", s->kind(), fdstart);
-        if (overloadApply(fdstart, &isf, fd))
+        if (overloadApply(fdstart, &isf, (void *)fd))
             return 0;
 
         return !fd->parent->isTemplateMixin();


### PR DESCRIPTION
Classes don't implicitly convert to `void*` in D.
