### PR TITLE
[DDMD] Use memcpy to copy classes, not assignment

### DIFF
--- a/src/inline.c
+++ b/src/inline.c
@@ -765,7 +765,7 @@ Expression *DeclarationExp::doInline(InlineDoState *ids)
             VarDeclaration *vto;
 
             vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-            *vto = *vd;
+            memcpy(vto, vd, sizeof(VarDeclaration));
             vto->parent = ids->parent;
             vto->csym = NULL;
             vto->isym = NULL;
@@ -859,7 +859,7 @@ Expression *IndexExp::doInline(InlineDoState *ids)
         VarDeclaration *vto;
 
         vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-        *vto = *vd;
+        memcpy(vto, vd, sizeof(VarDeclaration));
         vto->parent = ids->parent;
         vto->csym = NULL;
         vto->isym = NULL;
@@ -896,7 +896,7 @@ Expression *SliceExp::doInline(InlineDoState *ids)
         VarDeclaration *vto;
 
         vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-        *vto = *vd;
+        memcpy(vto, vd, sizeof(VarDeclaration));
         vto->parent = ids->parent;
         vto->csym = NULL;
         vto->isym = NULL;


### PR DESCRIPTION
It is not valid D code to explicitly dereference a class reference.  memcpy can work in both D and C++.
