### PR TITLE
[DDMD] Make OutBuffer into a struct that can be initialized with memset

### DIFF
--- a/src/cond.h
+++ b/src/cond.h
@@ -13,7 +13,7 @@
 
 class Expression;
 class Identifier;
-class OutBuffer;
+struct OutBuffer;
 class Module;
 struct Scope;
 class ScopeDsymbol;

--- a/src/import.h
+++ b/src/import.h
@@ -20,7 +20,7 @@
 
 class Identifier;
 struct Scope;
-class OutBuffer;
+struct OutBuffer;
 class Module;
 class Package;
 class AliasDeclaration;

--- a/src/json.h
+++ b/src/json.h
@@ -18,7 +18,7 @@
 
 #include "arraytypes.h"
 
-class OutBuffer;
+struct OutBuffer;
 
 void json_generate(OutBuffer *, Modules *);
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -116,7 +116,7 @@ void unittests();
 #endif
 
 
-class OutBuffer;
+struct OutBuffer;
 
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;

--- a/src/root/root.c
+++ b/src/root/root.c
@@ -1463,7 +1463,7 @@ OutBuffer::OutBuffer()
 
     doindent = 0;
     level = 0;
-    linehead = 1;
+    notlinehead = 0;
 }
 
 OutBuffer::~OutBuffer()
@@ -1510,7 +1510,7 @@ void OutBuffer::setsize(size_t size)
 
 void OutBuffer::write(const void *data, size_t nbytes)
 {
-    if (doindent && linehead)
+    if (doindent && !notlinehead)
     {
         if (level)
         {
@@ -1521,7 +1521,7 @@ void OutBuffer::write(const void *data, size_t nbytes)
                 offset++;
             }
         }
-        linehead = 0;
+        notlinehead = 1;
     }
     reserve(nbytes);
     memcpy(this->data + offset, data, nbytes);
@@ -1555,12 +1555,12 @@ void OutBuffer::writenl()
     writeByte('\n');
 #endif
     if (doindent)
-        linehead = 1;
+        notlinehead = 0;
 }
 
 void OutBuffer::writeByte(unsigned b)
 {
-    if (doindent && linehead
+    if (doindent && !notlinehead
         && b != '\n')
     {
         if (level)
@@ -1572,7 +1572,7 @@ void OutBuffer::writeByte(unsigned b)
                 offset++;
             }
         }
-        linehead = 0;
+        notlinehead = 1;
     }
     reserve(1);
     this->data[offset] = (unsigned char)b;
@@ -1650,7 +1650,7 @@ void OutBuffer::writewchar(unsigned w)
 
 void OutBuffer::writeword(unsigned w)
 {
-    if (doindent && linehead
+    if (doindent && !notlinehead
 #if _WIN32
         && w != 0x0A0D)
 #else
@@ -1666,7 +1666,7 @@ void OutBuffer::writeword(unsigned w)
                 offset++;
             }
         }
-        linehead = 0;
+        notlinehead = 1;
     }
     reserve(2);
     *(unsigned short *)(this->data + offset) = (unsigned short)w;
@@ -1693,7 +1693,7 @@ void OutBuffer::writeUTF16(unsigned w)
 
 void OutBuffer::write4(unsigned w)
 {
-    if (doindent && linehead
+    if (doindent && !notlinehead
 #if _WIN32
         && w != 0x000A000D)
 #else
@@ -1709,7 +1709,7 @@ void OutBuffer::write4(unsigned w)
                 offset++;
             }
         }
-        linehead = 0;
+        notlinehead = 1;
     }
     reserve(4);
     *(unsigned *)(this->data + offset) = w;

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -27,7 +27,7 @@ typedef size_t hash_t;
  * Root of our class library.
  */
 
-class OutBuffer;
+struct OutBuffer;
 
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
@@ -237,14 +237,15 @@ public:
     void remove();              // delete file
 };
 
-class OutBuffer : public RootObject
+struct OutBuffer
 {
-public:
     unsigned char *data;
     size_t offset;
     size_t size;
 
-    int doindent, level, linehead;
+    int doindent;
+    int level;
+    int notlinehead;
 
     OutBuffer();
     ~OutBuffer();

--- a/src/statement.h
+++ b/src/statement.h
@@ -21,7 +21,7 @@
 #include "dsymbol.h"
 #include "lexer.h"
 
-class OutBuffer;
+struct OutBuffer;
 struct Scope;
 class Expression;
 class LabelDsymbol;

--- a/src/template.h
+++ b/src/template.h
@@ -20,7 +20,7 @@
 #include "dsymbol.h"
 
 
-class OutBuffer;
+struct OutBuffer;
 class Identifier;
 class TemplateInstance;
 class TemplateParameter;

--- a/src/version.h
+++ b/src/version.h
@@ -17,7 +17,7 @@
 
 #include "dsymbol.h"
 
-class OutBuffer;
+struct OutBuffer;
 struct HdrGenState;
 
 class DebugSymbol : public Dsymbol


### PR DESCRIPTION
OutBuffer is allocated on the stack all over the place, it makes a much better struct than class in D.
