### PR TITLE
[DDMD] Do not create any scopes on the stack in the glue layer

### DIFF
--- a/src/typinf.c
+++ b/src/typinf.c
@@ -575,16 +575,14 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
 
     if (!tftohash)
     {
-        Scope sc;
-
         /* const hash_t toHash();
          */
         tftohash = new TypeFunction(NULL, Type::thash_t, 0, LINKd);
         tftohash->mod = MODconst;
-        tftohash = (TypeFunction *)tftohash->semantic(Loc(), &sc);
+        tftohash = (TypeFunction *)tftohash->merge();
 
         tftostring = new TypeFunction(NULL, Type::tstring, 0, LINKd);
-        tftostring = (TypeFunction *)tftostring->semantic(Loc(), &sc);
+        tftostring = (TypeFunction *)tftostring->merge();
     }
 
     s = search_function(sd, Id::tohash);


### PR DESCRIPTION
C++ and D constructors and destructors have different semantics, so avoid calling them across the frontend/glue boundary.  `merge` is all that is needed here because the argument and return types do not need checking.
