### PR TITLE
Change AAs to pow of 2 tables

### DIFF
--- a/src/root/aav.c
+++ b/src/root/aav.c
@@ -99,7 +99,7 @@ Value* _aaGet(AA** paa, Key key)
     *pe = e;
 
     //printf("length = %d, nodes = %d\n", (*paa)->b_length, nodes);
-    if (nodes > (*paa)->b_length*2)
+    if (nodes > (*paa)->b_length * 2)
     {
         //printf("rehash\n");
         _aaRehash(paa);
@@ -146,21 +146,6 @@ void _aaRehash(AA** paa)
         AA *aa = *paa;
         if (aa)
         {
-#if 0 
-            printf("Rehash of %d items in %d slots AA\n", aa->nodes, aa->b_length);
-            for (size_t i = 0; i < aa->b_length; i++)
-            {
-                aaA *e = aa->b[i];
-                size_t cnt=0;
-                while (e)
-                {
-                    e = e->next;
-                    cnt++;
-                }
-                printf("%d: %d\n", i, cnt);
-            }
-            printf("---\n");
-#endif
             size_t len = aa->b_length;
             if (len == 4)
                 len = 32;

--- a/src/root/aav.c
+++ b/src/root/aav.c
@@ -19,16 +19,12 @@
 
 #include "aav.h"
 
-static const size_t prime_list[] = {
-              31UL,
-              97UL,            389UL,
-            1543UL,           6151UL,
-           24593UL,          98317UL,
-          393241UL,        1572869UL,
-         6291469UL,       25165843UL,
-       100663319UL,      402653189UL,
-      1610612741UL,     4294967291UL,
-};
+
+inline size_t hash(size_t a)
+{
+    a ^= (a >> 20) ^ (a >> 12);
+    return a ^ (a >> 7) ^ (a >> 4);
+}
 
 struct aaA
 {
@@ -81,7 +77,7 @@ Value* _aaGet(AA** paa, Key key)
     //printf("paa = %p, *paa = %p\n", paa, *paa);
 
     assert((*paa)->b_length);
-    size_t i = (size_t)key % (*paa)->b_length;
+    size_t i = hash((size_t)key) & ((*paa)->b_length - 1);
     aaA** pe = &(*paa)->b[i];
     aaA *e;
     while ((e = *pe) != NULL)
@@ -103,7 +99,7 @@ Value* _aaGet(AA** paa, Key key)
     *pe = e;
 
     //printf("length = %d, nodes = %d\n", (*paa)->b_length, nodes);
-    if (nodes > (*paa)->b_length * 2)
+    if (nodes > (*paa)->b_length*2)
     {
         //printf("rehash\n");
         _aaRehash(paa);
@@ -125,12 +121,7 @@ Value _aaGetRvalue(AA* aa, Key key)
     {
         size_t i;
         size_t len = aa->b_length;
-        if (len == 4)
-            i = (size_t)key & 3;
-        else if (len == 31)
-            i = (size_t)key % 31;
-        else
-            i = (size_t)key % len;
+        i = hash((size_t)key) & (len-1);
         aaA* e = aa->b[i];
         while (e)
         {
@@ -153,16 +144,28 @@ void _aaRehash(AA** paa)
     if (*paa)
     {
         AA *aa = *paa;
-        size_t len = _aaLen(aa);
-        if (len)
-        {   size_t i;
-
-            for (i = 0; i < sizeof(prime_list)/sizeof(prime_list[0]) - 1; i++)
+        if (aa)
+        {
+#if 0 
+            printf("Rehash of %d items in %d slots AA\n", aa->nodes, aa->b_length);
+            for (size_t i = 0; i < aa->b_length; i++)
             {
-                if (len <= prime_list[i])
-                    break;
+                aaA *e = aa->b[i];
+                size_t cnt=0;
+                while (e)
+                {
+                    e = e->next;
+                    cnt++;
+                }
+                printf("%d: %d\n", i, cnt);
             }
-            len = prime_list[i];
+            printf("---\n");
+#endif
+            size_t len = aa->b_length;
+            if (len == 4)
+                len = 32;
+            else
+                len *= 4;
             aaA** newb = new aaA*[len];
             memset(newb, 0, len * sizeof(aaA*));
 
@@ -170,7 +173,7 @@ void _aaRehash(AA** paa)
             {   aaA *e = aa->b[k];
                 while (e)
                 {   aaA* enext = e->next;
-                    size_t j = (size_t)e->key % len;
+                    size_t j = hash((size_t)e->key) & (len-1);
                     e->next = newb[j];
                     newb[j] = e;
                     e = enext;


### PR DESCRIPTION
This is a performance tweak for aav.c.

Citing the commit message:

Brings in somewhere in the area of 1-2% increase in speed as measured by
dmd -unittest -c std\algorithm.d
on Linux x64

This closely follows the original prime sizes by using next pow-2 of primes
and reproducing roughly the same grow factor (=4).

Takes into account that key are aligned pointers to strings
and thus need a fair bit-shake to get a decent distribution.

And lastly my measurements with avgtime, see https://github.com/jmcabo/avgtime (neat tool written in D!).
This is on linux x64. Command line is: 
avgtime -d -r 30 dmd -unittest -c std/algorithm.d

dmd_E2 
The current pull, power of 2 tables with extra hashing of keys.

---

Total time (ms): 203185
Repetitions    : 30
Sample mode    : 6750 (6 ocurrences)
Median time    : 6760.67
Avg time       : 6772.83
Std dev.       : 61.7325
Minimum        : 6622.79
Maximum        : 6899.12
95% conf.int.  : [6651.83, 6893.82]  e = 120.994
99% conf.int.  : [6613.81, 6931.84]  e = 159.013
EstimatedAvg95%: [6750.74, 6794.92]  e = 22.0903
EstimatedAvg99%: [6743.79, 6801.86]  e = 29.0316

---

dmd_P3 
Original with primes, but a fix for small tables of 4 items to use better index then 2 lower bits 
or it'd be just a linked list! 
Hardly helps though, could it be that tables of 4 slots ain't that common by the time the storm of lookups comes?

---

Total time (ms): 204673
Repetitions    : 30
Sample mode    : 6810 (5 ocurrences)
Median time    : 6816.01
Avg time       : 6822.43
Std dev.       : 58.3656
Minimum        : 6645.7
Maximum        : 6919.68
95% conf.int.  : [6708.03, 6936.82]  e = 114.394
99% conf.int.  : [6672.09, 6972.77]  e = 150.34
EstimatedAvg95%: [6801.54, 6843.31]  e = 20.8855
EstimatedAvg99%: [6794.98, 6849.88]  e = 27.4482

---

dmd 
Vanila original

---

Total time (ms): 204676
Repetitions    : 30
Sample mode    : 6770 (5 ocurrences)
Median time    : 6826.8
Avg time       : 6822.55
Std dev.       : 61.4625
Minimum        : 6663.03
Maximum        : 6936.67
95% conf.int.  : [6702.08, 6943.01]  e = 120.464
99% conf.int.  : [6664.23, 6980.86]  e = 158.317
EstimatedAvg95%: [6800.55, 6844.54]  e = 21.9937
EstimatedAvg99%: [6793.64, 6851.45]  e = 28.9046

---
