### PR TITLE
[DDMD] Allow extern(C++) classes

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -257,6 +257,9 @@ public:
     TypeInfoClassDeclaration *vclassinfo;       // the ClassInfo object for this ClassDeclaration
     int com;                            // !=0 if this is a COM class (meaning
                                         // it derives from IUnknown)
+#if DMDV2
+    int cpp;                            // !=0 if this is a C++ interface
+#endif
     int isscope;                        // !=0 if this is an auto class
     int isabstract;                     // !=0 if abstract class
     int inuse;                          // to prevent recursive attempts
@@ -284,6 +287,7 @@ public:
     int isCOMclass();
     virtual int isCOMinterface();
 #if DMDV2
+    int isCPPclass();
     virtual int isCPPinterface();
 #endif
     bool isAbstract();
@@ -313,9 +317,6 @@ public:
 class InterfaceDeclaration : public ClassDeclaration
 {
 public:
-#if DMDV2
-    int cpp;                            // !=0 if this is a C++ interface
-#endif
     InterfaceDeclaration(Loc loc, Identifier *id, BaseClasses *baseclasses);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);

--- a/src/class.c
+++ b/src/class.c
@@ -524,7 +524,8 @@ void ClassDeclaration::semantic(Scope *sc)
     {
         // No base class, so this is the root of the class hierarchy
         vtbl.setDim(0);
-        vtbl.push(this);                // leave room for classinfo as first member
+        if (vtblOffset())
+            vtbl.push(this);            // leave room for classinfo as first member
     }
 
     protection = sc->protection;
@@ -1214,7 +1215,7 @@ bool ClassDeclaration::isAbstract()
 
 int ClassDeclaration::vtblOffset()
 {
-    return 1;
+    return (com || cpp) ? 0 : 1;
 }
 
 /****************************************

--- a/src/class.c
+++ b/src/class.c
@@ -225,6 +225,7 @@ ClassDeclaration::ClassDeclaration(Loc loc, Identifier *id, BaseClasses *basecla
     }
 
     com = 0;
+    cpp = 0;
     isscope = 0;
     isabstract = 0;
     inuse = 0;
@@ -306,7 +307,7 @@ void ClassDeclaration::semantic(Scope *sc)
     userAttributes = sc->userAttributes;
 
     if (sc->linkage == LINKcpp)
-        error("cannot create C++ classes");
+        cpp = 1;
 
     // Expand any tuples in baseclasses[]
     for (size_t i = 0; i < baseclasses->dim; )
@@ -473,7 +474,7 @@ void ClassDeclaration::semantic(Scope *sc)
 
 
     // If no base class, and this is not an Object, use Object as base class
-    if (!baseClass && ident != Id::Object)
+    if (!baseClass && ident != Id::Object && !cpp)
     {
         if (!object)
         {
@@ -512,6 +513,8 @@ void ClassDeclaration::semantic(Scope *sc)
 
         // Inherit properties from base class
         com = baseClass->isCOMclass();
+        if (baseClass->isCPPclass())
+            cpp = 1;
         isscope = baseClass->isscope;
         vthis = baseClass->vthis;
         enclosing = baseClass->enclosing;
@@ -604,7 +607,11 @@ void ClassDeclaration::semantic(Scope *sc)
 //          sc->offset += Target::ptrsize;      // room for uplevel context pointer
     }
     else
-    {   sc->offset = Target::ptrsize * 2;       // allow room for __vptr and __monitor
+    {
+        if (cpp)
+            sc->offset = Target::ptrsize;       // allow room for __vptr
+        else
+            sc->offset = Target::ptrsize * 2;  // allow room for __vptr and __monitor
         alignsize = Target::ptrsize;
     }
     sc->userAttributes = NULL;
@@ -1142,8 +1149,8 @@ void ClassDeclaration::interfaceSemantic(Scope *sc)
         if (b->base->isCOMinterface())
             com = 1;
 
-        if (b->base->isCPPinterface() && id)
-            id->cpp = 1;
+        if (b->base->isCPPinterface())
+            cpp = 1;
 
         vtblInterfaces->push(b);
         b->copyBaseInterfaces(vtblInterfaces);
@@ -1164,6 +1171,11 @@ int ClassDeclaration::isCOMinterface()
 }
 
 #if DMDV2
+int ClassDeclaration::isCPPclass()
+{
+    return cpp;
+}
+
 int ClassDeclaration::isCPPinterface()
 {
     return 0;
@@ -1226,8 +1238,6 @@ void ClassDeclaration::addLocalClass(ClassDeclarations *aclasses)
 InterfaceDeclaration::InterfaceDeclaration(Loc loc, Identifier *id, BaseClasses *baseclasses)
     : ClassDeclaration(loc, id, baseclasses)
 {
-    com = 0;
-    cpp = 0;
     if (id == Id::IUnknown)     // IUnknown is the root of all COM interfaces
     {   com = 1;
         cpp = 1;                // IUnknown is also a C++ interface
@@ -1422,9 +1432,9 @@ void InterfaceDeclaration::semantic(Scope *sc)
     sc = sc->push(this);
     sc->stc &= STCsafe | STCtrusted | STCsystem;
     sc->parent = this;
-    if (isCOMinterface())
+    if (com)
         sc->linkage = LINKwindows;
-    else if (isCPPinterface())
+    else if (cpp)
         sc->linkage = LINKcpp;
     sc->structalign = STRUCTALIGN_DEFAULT;
     sc->protection = PROTpublic;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2049,7 +2049,8 @@ elem *AssertExp::toElem(IRState *irs)
 
         // If e1 is a class object, call the class invariant on it
         if (global.params.useInvariants && t1->ty == Tclass &&
-            !((TypeClass *)t1)->sym->isInterfaceDeclaration())
+            !((TypeClass *)t1)->sym->isInterfaceDeclaration() &&
+            !((TypeClass *)t1)->sym->isCPPclass())
         {
             ts = symbol_genauto(t1->toCtype());
             int rtl;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4196,30 +4196,30 @@ elem *CastExp::toElem(IRState *irs)
 
         ClassDeclaration *cdfrom = tfrom->isClassHandle();
         ClassDeclaration *cdto   = t->isClassHandle();
+        if (cdfrom->cpp)
+        {
+            if (cdto->cpp)
+            {
+                /* Casting from a C++ interface to a C++ interface
+                 * is always a 'paint' operation
+                 */
+                goto Lret;                  // no-op
+            }
+
+            /* Casting from a C++ interface to a class
+             * always results in null because there is no runtime
+             * information available to do it.
+             *
+             * Casting from a C++ interface to a non-C++ interface
+             * always results in null because there's no way one
+             * can be derived from the other.
+             */
+            e = el_bin(OPcomma, TYnptr, e, el_long(TYnptr, 0));
+            goto Lret;
+        }
         if (cdfrom->isInterfaceDeclaration())
         {
             rtl = RTLSYM_INTERFACE_CAST;
-            if (cdfrom->isCPPinterface())
-            {
-                if (cdto->isCPPinterface())
-                {
-                    /* Casting from a C++ interface to a C++ interface
-                     * is always a 'paint' operation
-                     */
-                    goto Lret;                  // no-op
-                }
-
-                /* Casting from a C++ interface to a class
-                 * always results in null because there is no runtime
-                 * information available to do it.
-                 *
-                 * Casting from a C++ interface to a non-C++ interface
-                 * always results in null because there's no way one
-                 * can be derived from the other.
-                 */
-                e = el_bin(OPcomma, TYnptr, e, el_long(TYnptr, 0));
-                goto Lret;
-            }
         }
         if (cdto->isBaseOf(cdfrom, &offset) && offset != OFFSET_RUNTIME)
         {

--- a/src/func.c
+++ b/src/func.c
@@ -3381,7 +3381,8 @@ bool FuncDeclaration::needThis()
 bool FuncDeclaration::addPreInvariant()
 {
     AggregateDeclaration *ad = isThis();
-    return (ad &&
+    ClassDeclaration *cd = ad ? ad->isClassDeclaration() : NULL;
+    return (ad && !(cd && cd->isCPPclass()) &&
             //ad->isClassDeclaration() &&
             global.params.useInvariants &&
             (protection == PROTprotected || protection == PROTpublic || protection == PROTexport) &&
@@ -3392,7 +3393,8 @@ bool FuncDeclaration::addPreInvariant()
 bool FuncDeclaration::addPostInvariant()
 {
     AggregateDeclaration *ad = isThis();
-    return (ad &&
+    ClassDeclaration *cd = ad ? ad->isClassDeclaration() : NULL;
+    return (ad && !(cd && cd->isCPPclass()) &&
             ad->inv &&
             //ad->isClassDeclaration() &&
             global.params.useInvariants &&

--- a/src/opover.c
+++ b/src/opover.c
@@ -897,7 +897,7 @@ Expression *EqualExp::op_overload(Scope *sc)
     {   ClassDeclaration *cd1 = t1->isClassHandle();
         ClassDeclaration *cd2 = t2->isClassHandle();
 
-        if (!(cd1->isCPPinterface() || cd2->isCPPinterface()))
+        if (!(cd1->cpp || cd2->cpp))
         {
             /* Rewrite as:
              *      .object.opEquals(e1, e2)

--- a/src/todt.c
+++ b/src/todt.c
@@ -712,7 +712,8 @@ void ClassDeclaration::toDt(dt_t **pdt)
 
     // Put in first two members, the vtbl[] and the monitor
     dtxoff(pdt, toVtblSymbol(), 0);
-    dtsize_t(pdt, 0);                    // monitor
+    if (!cpp)
+        dtsize_t(pdt, 0);                    // monitor
 
     // Put in the rest
     toDt2(pdt, this);

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -635,8 +635,9 @@ void ClassDeclaration::toObjFile(int multiobj)
     // Put out the vtbl[]
     //printf("putting out %s.vtbl[]\n", toChars());
     dt = NULL;
-    dtxoff(&dt, csym, 0, TYnptr);           // first entry is ClassInfo reference
-    for (size_t i = 1; i < vtbl.dim; i++)
+    if (vtblOffset())
+        dtxoff(&dt, csym, 0, TYnptr);           // first entry is ClassInfo reference
+    for (size_t i = vtblOffset(); i < vtbl.dim; i++)
     {
         FuncDeclaration *fd = vtbl[i]->isFuncDeclaration();
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -356,7 +356,7 @@ void ClassDeclaration::toObjFile(int multiobj)
     dtsize_t(&dt, 0);                    // monitor
 
     // initializer[]
-    assert(structsize >= 8);
+    assert(structsize >= 8 || (cpp && structsize >= 4));
     dtsize_t(&dt, structsize);           // size
     dtxoff(&dt, sinit, 0, TYnptr);      // initializer
 
@@ -400,7 +400,7 @@ void ClassDeclaration::toObjFile(int multiobj)
         dtsize_t(&dt, 0);
 
     // flags
-    int flags = 4 | isCOMclass();
+    int flags = 4 | isCOMclass() | isCPPclass();
 #if DMDV2
     flags |= 16;
 #endif

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1873,6 +1873,20 @@ void test93()
 
 /***************************************************/
 
+
+extern(C++) class C1687
+{
+    void func() {}
+}
+
+void test1687()
+{
+    auto c = new C1687();
+    assert(c.__vptr[0] == (&c.func).funcptr);
+}
+
+/***************************************************/
+
 struct Foo94
 {
     int x, y;
@@ -6731,6 +6745,7 @@ int main()
     test5046();
     test1471();
     test6335();
+    test1687();
     test6228();
     test2774();
     test3733();


### PR DESCRIPTION
Changes include:
- Removing the error on marking a class `extern(C++)`
- Not reserving space for the monitor pointer
- Not reserving vtbl offset 0 for the classinfo pointer
- Marking the class as non-finalize (calling destructors currently requires classinfo)
- Making casts to/from C++ classes a no-op
- Not calling invariants for C++ classes
- Making `==` a raw pointer comparison
