### PR TITLE
[REG2.064a] fix Issue 10736 - Regression (2.064 git-head): Instantiation failure triggered by module import and module order

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -1510,6 +1510,7 @@ Language changes listed by -transition=id:\n\
             printf("semantic3 %s\n", m->toChars());
         m->semantic3();
     }
+    Module::runDeferredSemantic3();
     if (global.errors)
         fatal();
 

--- a/src/module.c
+++ b/src/module.c
@@ -34,6 +34,7 @@ DsymbolTable *Module::modules;
 Modules Module::amodules;
 
 Dsymbols Module::deferred; // deferred Dsymbol's needing semantic() run on them
+Dsymbols Module::deferred3;
 unsigned Module::dprogress;
 
 const char *lookForSourceFile(const char *filename);
@@ -992,6 +993,33 @@ void Module::runDeferredSemantic()
     } while (deferred.dim < len || dprogress);  // while making progress
     nested--;
     //printf("-Module::runDeferredSemantic(), len = %d\n", deferred.dim);
+}
+
+void Module::addDeferredSemantic3(Dsymbol *s)
+{
+    // Don't add it if it is already there
+    for (size_t i = 0; i < deferred3.dim; i++)
+    {
+        Dsymbol *sd = deferred3[i];
+        if (sd == s)
+            return;
+    }
+    deferred3.push(s);
+}
+
+void Module::runDeferredSemantic3()
+{
+    Dsymbols *a = &Module::deferred3;
+    for (size_t i = 0; i < a->dim; i++)
+    {
+        Dsymbol *s = (*a)[i];
+        //printf("[%d] %s semantic3a\n", i, s->toPrettyChars());
+
+        s->semantic3(NULL);
+
+        if (global.errors)
+            break;
+    }
 }
 
 /************************************

--- a/src/module.h
+++ b/src/module.h
@@ -63,6 +63,7 @@ public:
     static DsymbolTable *modules;       // symbol table of all modules
     static Modules amodules;            // array of all modules
     static Dsymbols deferred;   // deferred Dsymbol's needing semantic() run on them
+    static Dsymbols deferred3;  // deferred Dsymbol's needing semantic3() run on them
     static unsigned dprogress;  // progress resolving the deferred list
     static void init();
 
@@ -143,8 +144,10 @@ public:
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
     Dsymbol *symtabInsert(Dsymbol *s);
     void deleteObjFile();
-    void addDeferredSemantic(Dsymbol *s);
+    static void addDeferredSemantic(Dsymbol *s);
     static void runDeferredSemantic();
+    static void addDeferredSemantic3(Dsymbol *s);
+    static void runDeferredSemantic3();
     static void clearCache();
     int imports(Module *m);
 

--- a/test/runnable/imports/test10736a.d
+++ b/test/runnable/imports/test10736a.d
@@ -1,0 +1,4 @@
+module imports.test10736a;
+
+version(A) import std.range;
+else       import imports.test10736c;

--- a/test/runnable/imports/test10736b.d
+++ b/test/runnable/imports/test10736b.d
@@ -1,0 +1,13 @@
+module imports.test10736b;
+
+version(A) import std.range;
+else       import imports.test10736c;
+
+void main()
+{
+    int[] arr = [0, 1, 2, 3];
+    auto x = chunks(arr, 4);  // error
+
+    import core.stdc.stdio;
+    printf("success\n");
+}

--- a/test/runnable/imports/test10736c.d
+++ b/test/runnable/imports/test10736c.d
@@ -1,0 +1,24 @@
+module imports.test10736c;
+
+struct Chunks(Source)
+{
+    this(Source source, size_t chunkSize)
+    {
+        _source = source;
+        _chunkSize = chunkSize;
+    }
+
+    typeof(this) opSlice(size_t, size_t)
+    {
+        return chunks(_source, _chunkSize);
+    }
+
+private:
+    Source _source;
+    size_t _chunkSize;
+}
+
+Chunks!Source chunks(Source)(Source source, size_t chunkSize)
+{
+    return typeof(return)(source, chunkSize);
+}

--- a/test/runnable/test10736.d
+++ b/test/runnable/test10736.d
@@ -1,0 +1,5 @@
+// EXTRA_SOURCES: imports/test10736a.d
+// EXTRA_SOURCES: imports/test10736b.d
+
+import imports.test10736a;
+import imports.test10736b;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10736

The regression is introduced by recent [Phobos change](https://github.com/D-Programming-Language/phobos/pull/992), but the root cause is premature semantic3 invocation for template instances.

In the reduced test case, `test10736b` instantiates `chunks` template function, then it instantiates `Chunks!(int[])`. The instance object will be inserted to `test10736a` member because it is the first module that importing `test10736c`. But in this time, `test10736a` module's semantic3 is already done, then `Chunks!(int[])` would immediately invoke its semantic3, then `Chunks!(int[]).opSlice` refers _not yet instantiation finished_ `chunks` template.

To avoid the forward reference problem, we should defer semantic3 of template instances which inserted to module scope.
