### PR TITLE
Add semantic3a phase (fix 2.064a regressions 10726 and 10736)

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -90,6 +90,7 @@ public:
     void setScope(Scope *sc);
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
+    void semantic3a(Scope *sc);
     void inlineScan();
     unsigned size(Loc loc);
     static void alignmember(structalign_t salign, unsigned size, unsigned *poffset);

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -377,6 +377,15 @@ void Dsymbol::semantic3(Scope *sc)
 }
 
 /*************************************
+ * Does semantic analysis on templates, and functions used for runtime.
+ */
+
+void Dsymbol::semantic3a(Scope *sc)
+{
+    // Most Dsymbols have no further semantic analysis needed
+}
+
+/*************************************
  * Look for function inlining possibilities.
  */
 

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -161,6 +161,7 @@ public:
     virtual void semantic(Scope *sc);
     virtual void semantic2(Scope *sc);
     virtual void semantic3(Scope *sc);
+    virtual void semantic3a(Scope *sc);
     virtual void inlineScan();
     virtual Dsymbol *search(Loc loc, Identifier *ident, int flags);
     Dsymbol *search_correct(Identifier *id);

--- a/src/mars.c
+++ b/src/mars.c
@@ -1510,6 +1510,7 @@ Language changes listed by -transition=id:\n\
             printf("semantic3 %s\n", m->toChars());
         m->semantic3();
     }
+    Module::runDeferredSemantic3();
     if (global.errors)
         fatal();
 

--- a/src/module.c
+++ b/src/module.c
@@ -34,6 +34,7 @@ DsymbolTable *Module::modules;
 Modules Module::amodules;
 
 Dsymbols Module::deferred; // deferred Dsymbol's needing semantic() run on them
+Dsymbols Module::deferred3;
 unsigned Module::dprogress;
 
 const char *lookForSourceFile(const char *filename);
@@ -992,6 +993,39 @@ void Module::runDeferredSemantic()
     } while (deferred.dim < len || dprogress);  // while making progress
     nested--;
     //printf("-Module::runDeferredSemantic(), len = %d\n", deferred.dim);
+}
+
+void Module::addDeferredSemantic3(Dsymbol *s)
+{
+    // Don't add it if it is already there
+    for (size_t i = 0; i < deferred3.dim; i++)
+    {
+        Dsymbol *sd = deferred3[i];
+        if (sd == s)
+            return;
+    }
+    deferred3.push(s);
+}
+
+void Module::runDeferredSemantic3()
+{
+    Dsymbols *a = &Module::deferred3;
+    for (size_t i = 0; i < a->dim; i++)
+    {
+        Dsymbol *s = (*a)[i];
+        //printf("[%d] %s semantic3a\n", i, s->toPrettyChars());
+
+        Module *m = s->getModule()->importedFrom;
+        Scope *sc = Scope::createGlobal(m);      // create root scope
+
+        s->semantic3a(sc);
+
+        sc = sc->pop();
+        sc->pop();
+
+        if (global.errors)
+            break;
+    }
 }
 
 /************************************

--- a/src/module.h
+++ b/src/module.h
@@ -63,6 +63,7 @@ public:
     static DsymbolTable *modules;       // symbol table of all modules
     static Modules amodules;            // array of all modules
     static Dsymbols deferred;   // deferred Dsymbol's needing semantic() run on them
+    static Dsymbols deferred3;  // deferred Dsymbol's needing semantic3() run on them
     static unsigned dprogress;  // progress resolving the deferred list
     static void init();
 
@@ -143,8 +144,10 @@ public:
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
     Dsymbol *symtabInsert(Dsymbol *s);
     void deleteObjFile();
-    void addDeferredSemantic(Dsymbol *s);
+    static void addDeferredSemantic(Dsymbol *s);
     static void runDeferredSemantic();
+    static void addDeferredSemantic3(Dsymbol *s);
+    static void runDeferredSemantic3();
     static void clearCache();
     int imports(Module *m);
 

--- a/src/template.c
+++ b/src/template.c
@@ -2184,8 +2184,8 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
         printf("\t%s %s\n", arg->type->toChars(), arg->toChars());
         //printf("\tty = %d\n", arg->type->ty);
     }
-    printf("stc = %llx\n", dstart->scope->stc);
-    printf("match:t/f = %d/%d\n", ta_last, m->last);
+    //printf("stc = %llx\n", dstart->scope->stc);
+    //printf("match:t/f = %d/%d\n", ta_last, m->last);
 #endif
 
   struct ParamDeduce
@@ -5450,7 +5450,6 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     // in target_symbol_list(_idx) so we can remove it later if we encounter
     // an error.
 #if 1
-    int dosemantic3 = 0;
     Dsymbols *target_symbol_list = NULL;
     size_t target_symbol_list_idx;
 
@@ -5482,13 +5481,22 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         }
         else
         {
-            Module *m = (enclosing ? sc : tempdecl->scope)->module->importedFrom;
+            Module *m = (enclosing ? sc : tempdecl->scope)->module;
+            if (m->importedFrom != m)
+            {
+                //if (tinst && tinst->objFileModule)
+                //    m = tinst->objFileModule;
+                //else
+                    m = m->importedFrom;
+            }
             //printf("\t2: adding to module %s instead of module %s\n", m->toChars(), sc->module->toChars());
             a = m->members;
+
+            /* Defer semantic3 running in order to avoid mutual forward reference.
+             * See test/runnable/test10736.d
+             */
             if (m->semanticRun >= 3)
-            {
-                dosemantic3 = 1;
-            }
+                Module::addDeferredSemantic3(this);
         }
         for (size_t i = 0; 1; i++)
         {
@@ -5685,14 +5693,15 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
      * for initializers inside a function.
      */
 //    if (sc->parent->isFuncDeclaration())
-
+    {
         /* BUG 782: this has problems if the classes this depends on
          * are forward referenced. Find a way to defer semantic()
          * on this template.
          */
         semantic2(sc2);
+    }
 
-    if (sc->func || dosemantic3)
+    if (sc->func)
     {
         trySemantic3(sc2);
     }
@@ -6881,6 +6890,11 @@ void TemplateInstance::semantic3(Scope *sc)
         sc = sc->pop();
         sc->pop();
     }
+}
+
+void TemplateInstance::semantic3a(Scope *sc)
+{
+    semantic3(sc);
 }
 
 /**************************************

--- a/src/template.h
+++ b/src/template.h
@@ -326,7 +326,7 @@ public:
     /* On some targets, it is necessary to know whether a symbol
        will be emitted in the output or not before the symbol
        is used.  This can be different from getModule(). */
-    Module * objFileModule;
+    Module *objFileModule;
 #endif
 
     TemplateInstance(Loc loc, Identifier *temp_id);
@@ -337,6 +337,7 @@ public:
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
+    void semantic3a(Scope *sc);
     void inlineScan();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toCBufferTiargs(OutBuffer *buf, HdrGenState *hgs);

--- a/test/compilable/test10726.d
+++ b/test/compilable/test10726.d
@@ -1,0 +1,32 @@
+public struct CirBuff(T) {                                                // 01
+  private T[] data;                                                       // 02
+  private size_t head = 0;                                                // 03
+  private size_t size = 0;                                                // 04
+  public size_t length() const {return size;}                             // 05
+  public bool opEquals(CirBuff!T d) @trusted {                            // 06
+    if(length != d.length) return false;                                  // 07
+    for(size_t i=0; i!=size; ++i)                                         // 08
+      if(this.data[(this.head+i)%this.data.length] !=                     // 09
+     d.data[(d.head + i) % d.data.length]) return false;                  // 10
+    return true;                                                          // 11
+  }                                                                       // 12
+}                                                                         // 13
+class Once {                                                              // 14
+  Foo!Bar _bar;                                                           // 15
+}                                                                         // 16
+class Bar {                                                               // 17
+  static Once _once;                                                      // 18
+  mixin(sync!(Once, "_once"));                                            // 19
+}                                                                         // 20
+class Foo (T=int) {                                                       // 21
+  CirBuff!T _buff;                                                        // 22
+}                                                                         // 23
+template sync(T, string U="this", size_t ITER=0) {                        // 24
+  static if(ITER == __traits(derivedMembers, T).length) enum sync = "";   // 25
+  else {                                                                  // 26
+    enum string mem = __traits(derivedMembers, T)[ITER];                  // 27
+    enum string sync =                                                    // 28
+      "static if(! __traits(isVirtualMethod, " ~ U ~ "." ~ mem ~ ")) { }" // 29
+      ~ sync!(T, U, ITER+1);                                              // 30
+  }                                                                       // 31
+}                                                                         // 32

--- a/test/runnable/imports/test10736a.d
+++ b/test/runnable/imports/test10736a.d
@@ -1,0 +1,4 @@
+module imports.test10736a;
+
+version(A) import std.range;
+else       import imports.test10736c;

--- a/test/runnable/imports/test10736b.d
+++ b/test/runnable/imports/test10736b.d
@@ -1,0 +1,13 @@
+module imports.test10736b;
+
+version(A) import std.range;
+else       import imports.test10736c;
+
+void main()
+{
+    int[] arr = [0, 1, 2, 3];
+    auto x = chunks(arr, 4);  // error
+
+    import core.stdc.stdio;
+    printf("success\n");
+}

--- a/test/runnable/imports/test10736c.d
+++ b/test/runnable/imports/test10736c.d
@@ -1,0 +1,24 @@
+module imports.test10736c;
+
+struct Chunks(Source)
+{
+    this(Source source, size_t chunkSize)
+    {
+        _source = source;
+        _chunkSize = chunkSize;
+    }
+
+    typeof(this) opSlice(size_t, size_t)
+    {
+        return chunks(_source, _chunkSize);
+    }
+
+private:
+    Source _source;
+    size_t _chunkSize;
+}
+
+Chunks!Source chunks(Source)(Source source, size_t chunkSize)
+{
+    return typeof(return)(source, chunkSize);
+}

--- a/test/runnable/test10736.d
+++ b/test/runnable/test10736.d
@@ -1,0 +1,5 @@
+// EXTRA_SOURCES: imports/test10736a.d
+// EXTRA_SOURCES: imports/test10736b.d
+
+import imports.test10736a;
+import imports.test10736b;


### PR DESCRIPTION
[REG2.064a] [Issue 10726](http://d.puremagic.com/issues/show_bug.cgi?id=10726) - Bogus Circular Reference error if opEquals defined and has a loop

`TypeInfo` for struct types requires additional semantic3 to generate xopEquals and xopCmp, even if it is a non-template type that is merely imported. To handle it correctly, move the process into semantic3a phase.

[REG2.064a] [Issue 10736](http://d.puremagic.com/issues/show_bug.cgi?id=10736) - Regression (2.064 git-head): Instantiation failure triggered by module import and module order

Immediate semantic3 invocation would cause mutual forward reference. To avoid the problem, defer it to semantic3a phase.

---

This PR replaces #2421 and #2442.
