### PR TITLE
Use non-serialized Win32 Heap API with DMC

### DIFF
--- a/src/root/winmem.c
+++ b/src/root/winmem.c
@@ -143,15 +143,11 @@ void Mem::addroots(char* pStart, char* pEnd)
 
 /* =================================================== */
 
-#if 1
-
 /* Allocate, but never release
  */
 
-// Allocate a little less than 64kB because the C runtime adds some overhead that
-// causes the actual memory block to be larger than 64kB otherwise. E.g. the dmc
-// runtime rounds the size up to 128kB, but the remaining space in the chunk is less 
-// than 64kB, so it cannot be used by another chunk.
+// Allocate a little less than 64kB because the Heap code adds some overhead that
+// causes the actual memory block to be larger than 64kB otherwise.
 #define CHUNK_SIZE (4096 * 16 - 64)
 
 static size_t heapleft = 0;
@@ -195,22 +191,3 @@ void * operator new(size_t m_size)
 void operator delete(void *p)
 {
 }
-
-#else
-
-void * operator new(size_t m_size)
-{
-    void *p = malloc(m_size);
-    if (p)
-        return p;
-    printf("Error: out of memory\n");
-    exit(EXIT_FAILURE);
-    return p;
-}
-
-void operator delete(void *p)
-{
-    free(p);
-}
-
-#endif

--- a/src/root/winmem.c
+++ b/src/root/winmem.c
@@ -1,0 +1,216 @@
+
+// Copyright (c) 2000-2012 by Digital Mars
+// All Rights Reserved
+// written by Walter Bright
+// http://www.digitalmars.com
+// License for redistribution is by either the Artistic License
+// in artistic.txt, or the GNU General Public License in gnu.txt.
+// See the included readme.txt for details.
+
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rmem.h"
+
+/* This implementation of the storage allocator uses Win32 Heap API.
+ * HEAP_NO_SERIALIZE makes it intentionaly NOT thread-safe as DMD 
+ * is single-threaded and async.c bypasses this heap anyway.
+ */
+
+
+Mem mem;
+
+void Mem::init()
+{
+    gc = (GC*)HeapCreate(HEAP_NO_SERIALIZE, 100*4096, 0);
+    if (!gc)
+        error();
+}
+
+
+char *Mem::strdup(const char *s)
+{
+    char *p;
+
+    if (s)
+    {
+        size_t sz = ::strlen(s)+1;
+        p = (char*)mallocdup((void*)s, sz);
+        return p;
+    }
+    return NULL;
+}
+
+void *Mem::malloc(size_t size)
+{   void *p;
+
+    if (!size)
+        p = NULL;
+    else
+    {
+        p = HeapAlloc((HANDLE)gc, 0, size);
+        if (!p)
+            error();
+    }
+    return p;
+}
+
+void *Mem::calloc(size_t size, size_t n)
+{   void *p;
+
+    if (!size || !n)
+        p = NULL;
+    else
+    {
+        p = HeapAlloc((HANDLE)gc, HEAP_ZERO_MEMORY, size*n);
+        if (!p)
+            error();
+    }
+    return p;
+}
+
+void *Mem::realloc(void *p, size_t size)
+{
+    if (!size)
+    {   if (p)
+        {   free(p);
+            p = NULL;
+        }
+    }
+    else if (!p)
+    {
+        p = malloc(size);
+    }
+    else
+    {
+        void *psave = p;
+        p = HeapReAlloc((HANDLE)gc, 0, psave, size);
+        if (!p)
+        {   free(psave);
+            error();
+        }
+    }
+    return p;
+}
+
+void Mem::free(void *p)
+{
+    if (p)
+        HeapFree((HANDLE)gc, 0, p);
+}
+
+void *Mem::mallocdup(void *o, size_t size)
+{   void *p;
+
+    if (!size)
+        p = NULL;
+    else
+    {
+        p = malloc(size);
+        if (!p)
+            error();
+        else
+            memcpy(p,o,size);
+    }
+    return p;
+}
+
+void Mem::error()
+{
+    printf("Error: out of memory\n");
+    exit(EXIT_FAILURE);
+}
+
+void Mem::fullcollect()
+{
+}
+
+void Mem::mark(void *pointer)
+{
+    (void) pointer;             // necessary for VC /W4
+}
+
+void Mem::setStackBottom(void *bottom)
+{
+}
+
+void Mem::addroots(char* pStart, char* pEnd)
+{
+}
+
+
+/* =================================================== */
+
+#if 1
+
+/* Allocate, but never release
+ */
+
+// Allocate a little less than 64kB because the C runtime adds some overhead that
+// causes the actual memory block to be larger than 64kB otherwise. E.g. the dmc
+// runtime rounds the size up to 128kB, but the remaining space in the chunk is less 
+// than 64kB, so it cannot be used by another chunk.
+#define CHUNK_SIZE (4096 * 16 - 64)
+
+static size_t heapleft = 0;
+static void *heapp;
+
+void * operator new(size_t m_size)
+{
+    // 16 byte alignment is better (and sometimes needed) for doubles
+    m_size = (m_size + 15) & ~15;
+
+    // The layout of the code is selected so the most common case is straight through
+    if (m_size <= heapleft)
+    {
+     L1:
+        heapleft -= m_size;
+        void *p = heapp;
+        heapp = (void *)((char *)heapp + m_size);
+        return p;
+    }
+
+    if (m_size > CHUNK_SIZE)
+    {
+        void *p = mem.malloc(m_size);
+        if (p)
+            return p;
+        printf("Error: out of memory\n");
+        exit(EXIT_FAILURE);
+        return p;
+    }
+
+    heapleft = CHUNK_SIZE;
+    heapp = mem.malloc(CHUNK_SIZE);
+    if (!heapp)
+    {
+        printf("Error: out of memory\n");
+        exit(EXIT_FAILURE);
+    }
+    goto L1;
+}
+
+void operator delete(void *p)
+{
+}
+
+#else
+
+void * operator new(size_t m_size)
+{
+    void *p = malloc(m_size);
+    if (p)
+        return p;
+    printf("Error: out of memory\n");
+    exit(EXIT_FAILURE);
+    return p;
+}
+
+void operator delete(void *p)
+{
+    free(p);
+}
+
+#endif

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -173,7 +173,7 @@ BACKOBJ= go.obj gdag.obj gother.obj gflow.obj gloop.obj var.obj el.obj \
 
 
 # Root package
-GCOBJS=rmem.obj
+GCOBJS=winmem.obj
 # Removed garbage collector (look in history)
 #GCOBJS=dmgcmem.obj bits.obj win32.obj gc.obj
 ROOTOBJS= man.obj root.obj port.obj \
@@ -233,7 +233,7 @@ TKSRCC=	$(TK)\filespec.c $(TK)\mem.c $(TK)\vec.c $(TK)\list.c
 TKSRC= $(TK)\filespec.h $(TK)\mem.h $(TK)\list.h $(TK)\vec.h $(TKSRCC)
 
 # Root package
-ROOTSRCC=$(ROOT)\root.c $(ROOT)\rmem.c $(ROOT)\stringtable.c \
+ROOTSRCC=$(ROOT)\root.c $(ROOT)\winmem.c $(ROOT)\stringtable.c \
 	$(ROOT)\man.c $(ROOT)\port.c $(ROOT)\async.c $(ROOT)\response.c \
 	$(ROOT)\speller.c $(ROOT)\aav.c $(ROOT)\longdouble.c $(ROOT)\dmgcmem.c
 ROOTSRC= $(ROOT)\root.h \
@@ -639,8 +639,8 @@ dmgcmem.obj : $(ROOT)\dmgcmem.c
 man.obj : $(ROOT)\man.c
 	$(CC) -c $(CFLAGS) $(ROOT)\man.c
 
-rmem.obj : $(ROOT)\rmem.c
-	$(CC) -c $(CFLAGS) $(ROOT)\rmem.c
+winmem.obj : $(ROOT)\winmem.c
+	$(CC) -c $(CFLAGS) $(ROOT)\winmem.c
 
 port.obj : $(ROOT)\port.c
 	$(CC) -c $(CFLAGS) $(ROOT)\port.c

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -173,7 +173,7 @@ BACKOBJ= go.obj gdag.obj gother.obj gflow.obj gloop.obj var.obj el.obj \
 
 
 # Root package
-GCOBJS=winmem.obj
+GCOBJS=rmem.obj winmem.obj
 # Removed garbage collector (look in history)
 #GCOBJS=dmgcmem.obj bits.obj win32.obj gc.obj
 ROOTOBJS= man.obj root.obj port.obj \


### PR DESCRIPTION
Create an alternative implementstion of rmem.c that uses Win32 Heap API.

Use it instead of rmem.c when buidling with DMC (win32.mak).

This alone brings 
dmd -unittest -c std\algorithm.d

from ~13.3 sec to ~8.0 sec

Could serve as an interim solution, the alternative is to tweak DMC's allocator..
