### PR TITLE
fix issue 10752 - accessing a private cached symbol a second time doesn't cause an error in __traits(compiles, ...)

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -420,7 +420,6 @@ void *symbol_search_fp(void *arg, const char *seed)
     assert(id);
 
     Dsymbol *s = (Dsymbol *)arg;
-    Module::clearCache();
     return (void *)s->search(Loc(), id, 4|2);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -60,9 +60,6 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
     needmoduleinfo = 0;
     selfimports = 0;
     insearch = 0;
-    searchCacheIdent = NULL;
-    searchCacheSymbol = NULL;
-    searchCacheFlags = 0;
     semanticstarted = 0;
     semanticRun = 0;
     decldefs = NULL;
@@ -889,36 +886,13 @@ Dsymbol *Module::search(Loc loc, Identifier *ident, int flags)
     Dsymbol *s;
     if (insearch)
         s = NULL;
-    else if (searchCacheIdent == ident && searchCacheFlags == flags)
-    {
-        s = searchCacheSymbol;
-        //printf("%s Module::search('%s', flags = %d) insearch = %d searchCacheSymbol = %s\n", toChars(), ident->toChars(), flags, insearch, searchCacheSymbol ? searchCacheSymbol->toChars() : "null");
-    }
     else
     {
         insearch = 1;
         s = ScopeDsymbol::search(loc, ident, flags);
         insearch = 0;
-
-        searchCacheIdent = ident;
-        searchCacheSymbol = s;
-        searchCacheFlags = flags;
     }
     return s;
-}
-
-Dsymbol *Module::symtabInsert(Dsymbol *s)
-{
-    searchCacheIdent = NULL;       // symbol is inserted, so invalidate cache
-    return Package::symtabInsert(s);
-}
-
-void Module::clearCache()
-{
-    for (size_t i = 0; i < amodules.dim; i++)
-    {   Module *m = amodules[i];
-        m->searchCacheIdent = NULL;
-    }
 }
 
 /*******************************************

--- a/src/module.h
+++ b/src/module.h
@@ -86,9 +86,6 @@ public:
     int selfImports();          // returns !=0 if module imports itself
 
     int insearch;
-    Identifier *searchCacheIdent;
-    Dsymbol *searchCacheSymbol; // cached value of search
-    int searchCacheFlags;       // cached flags
 
     int semanticstarted;        // has semantic() been started?
     int semanticRun;            // has semantic() been done?
@@ -142,13 +139,11 @@ public:
     void gendocfile();
     int needModuleInfo();
     Dsymbol *search(Loc loc, Identifier *ident, int flags);
-    Dsymbol *symtabInsert(Dsymbol *s);
     void deleteObjFile();
     static void addDeferredSemantic(Dsymbol *s);
     static void runDeferredSemantic();
     static void addDeferredSemantic3(Dsymbol *s);
     static void runDeferredSemantic3();
-    static void clearCache();
     int imports(Module *m);
 
     // Back end

--- a/src/scope.c
+++ b/src/scope.c
@@ -418,7 +418,6 @@ void *scope_search_fp(void *arg, const char *seed)
     assert(id);
 
     Scope *sc = (Scope *)arg;
-    Module::clearCache();
     Dsymbol *s = sc->search(Loc(), id, NULL);
     return (void*)s;
 }

--- a/test/compilable/imports/test10752.d
+++ b/test/compilable/imports/test10752.d
@@ -1,0 +1,2 @@
+module imports.test10752;
+private int priv;

--- a/test/compilable/test10752.d
+++ b/test/compilable/test10752.d
@@ -1,0 +1,6 @@
+import imports.test10752;
+void main()
+{
+    static assert(!__traits(compiles, priv));
+    static assert(!__traits(compiles, priv));
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10752
