### PR TITLE
Replace some calls to OutBuffer->printf with OutBuffer->writestring

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7349,7 +7349,7 @@ void TypeEnum::toDecoBuffer(OutBuffer *buf, int flag)
 {
     const char *name = sym->mangle();
     Type::toDecoBuffer(buf, flag);
-    buf->printf("%s", name);
+    buf->writestring(name);
 }
 
 void TypeEnum::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
@@ -7613,7 +7613,7 @@ void TypeTypedef::toDecoBuffer(OutBuffer *buf, int flag)
 {
     Type::toDecoBuffer(buf, flag);
     const char *name = sym->mangle();
-    buf->printf("%s", name);
+    buf->writestring(name);
 }
 
 void TypeTypedef::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
@@ -7917,7 +7917,7 @@ void TypeStruct::toDecoBuffer(OutBuffer *buf, int flag)
     const char *name = sym->mangle();
     //printf("TypeStruct::toDecoBuffer('%s') = '%s'\n", toChars(), name);
     Type::toDecoBuffer(buf, flag);
-    buf->printf("%s", name);
+    buf->writestring(name);
 }
 
 void TypeStruct::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
@@ -8451,7 +8451,7 @@ void TypeClass::toDecoBuffer(OutBuffer *buf, int flag)
     const char *name = sym->mangle();
     //printf("TypeClass::toDecoBuffer('%s' flag=%d mod=%x) = '%s'\n", toChars(), flag, mod, name);
     Type::toDecoBuffer(buf, flag);
-    buf->printf("%s", name);
+    buf->writestring(name);
 }
 
 void TypeClass::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)


### PR DESCRIPTION
Running the Windows version of DMD through a profiler shows vsprintf quite high up the call list (e.g. http://forum.dlang.org/post/ktgbft$m6i$1@digitalmars.com), and looking at the code a large chunk of those calls are from toDecoBuffer functions which just use a "%s" format string.

It should be more efficient to just call writestring instead - only makes a minor difference, but every little helps.
