### PR TITLE
Issue 10768 - DMD does not show deprecation message for missing 'override' keyword 

### DIFF
--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -144,6 +144,7 @@ public:
     Dsymbol *toParent2();
     TemplateInstance *inTemplateInstance();
     TemplateInstance *isSpeculative();
+    Ungag ungagSpeculative();
 
     int dyncast() { return DYNCAST_DSYMBOL; }   // kludge for template.isSymbol()
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -65,6 +65,22 @@ void toWinPath(char *src)
     }
 }
 
+Ungag::~Ungag()
+{
+    //printf("+ungag dtor gag %d => %d\n", global.gag, oldgag);
+    global.gag = oldgag;
+}
+
+Ungag Dsymbol::ungagSpeculative()
+{
+    unsigned oldgag = global.gag;
+
+    if (global.isSpeculativeGagging() && !isSpeculative())
+        global.gag = 0;
+
+    return Ungag(oldgag);
+}
+
 Global global;
 
 void Global::init()

--- a/src/mars.h
+++ b/src/mars.h
@@ -243,6 +243,14 @@ typedef unsigned structalign_t;
 #define STRUCTALIGN_DEFAULT ~0  // magic value means "match whatever the underlying C compiler does"
 // other values are all powers of 2
 
+struct Ungag
+{
+    unsigned oldgag;
+
+    Ungag(unsigned old) : oldgag(old) {}
+    ~Ungag();
+};
+
 struct Global
 {
     const char *mars_ext;

--- a/src/struct.c
+++ b/src/struct.c
@@ -533,14 +533,13 @@ void StructDeclaration::semantic(Scope *sc)
 
     Scope *scx = NULL;
     if (scope)
-    {   sc = scope;
+    {
+        sc = scope;
         scx = scope;            // save so we don't make redundant copies
         scope = NULL;
     }
-
-    int errors = global.errors;
-
     unsigned dprogress_save = Module::dprogress;
+    int errors = global.errors;
 
     parent = sc->parent;
     type = type->semantic(loc, sc);
@@ -600,14 +599,10 @@ void StructDeclaration::semantic(Scope *sc)
             if (sizeok == SIZEOKnone && s->isAliasDeclaration())
                 finalizeSize(sc2);
         }
+
         // Ungag errors when not speculative
-        unsigned oldgag = global.gag;
-        if (global.isSpeculativeGagging() && !isSpeculative())
-        {
-            global.gag = 0;
-        }
+        Ungag ungag = ungagSpeculative();
         s->semantic(sc2);
-        global.gag = oldgag;
     }
     finalizeSize(sc2);
 

--- a/src/template.c
+++ b/src/template.c
@@ -2329,11 +2329,8 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
             if (td->scope)
             {
                 // Try to fix forward reference. Ungag errors while doing so.
-                int oldgag = global.gag;
-                if (global.isSpeculativeGagging() && !td->isSpeculative())
-                    global.gag = 0;
+                Ungag ungag = td->ungagSpeculative();
                 td->semantic(td->scope);
-                global.gag = oldgag;
             }
         }
         if (!td->semanticRun)
@@ -6116,13 +6113,8 @@ bool TemplateInstance::findTemplateDeclaration(Scope *sc)
             if (td->scope)
             {
                 // Try to fix forward reference. Ungag errors while doing so.
-                int oldgag = global.gag;
-                if (global.isSpeculativeGagging() && !td->isSpeculative())
-                    global.gag = 0;
-
+                Ungag ungag = td->ungagSpeculative();
                 td->semantic(td->scope);
-
-                global.gag = oldgag;
             }
             if (!td->semanticRun)
             {

--- a/test/compilable/diag10768.d
+++ b/test/compilable/diag10768.d
@@ -1,0 +1,42 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+compilable/diag10768.d(36): Deprecation: overriding base class function without using override attribute is deprecated (diag10768.Foo.frop overrides diag10768.Frop.frop)
+---
+*/
+
+struct CirBuff(T)
+{
+    import std.traits: isArray;
+    CirBuff!T opAssign(R)(R) if (isArray!R)
+    {}
+
+    T[] toArray()
+    {
+        T[] ret; //  = new T[this.length];
+        return ret;
+    }
+    alias toArray this;
+}
+
+class Bar(T=int)
+{
+    CirBuff!T _bar;
+}
+
+class Once
+{
+    Bar!Foo _foobar;
+}
+
+class Foo : Frop
+{
+    // override
+    public int frop() { return 1; }
+}
+
+class Frop
+{
+    public int frop() { return 0; }
+}

--- a/test/fail_compilation/gag4269a.d
+++ b/test/fail_compilation/gag4269a.d
@@ -1,11 +1,13 @@
 ﻿// REQUIRED_ARGS: -c -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/gag4269a.d(12): Error: undefined identifier B
+---
+*/
 
 static if(is(typeof(A4269.sizeof))) {}
-
 class A4269
 {
     void foo(B b);
 }
-
-
- 

--- a/test/fail_compilation/gag4269b.d
+++ b/test/fail_compilation/gag4269b.d
@@ -1,6 +1,10 @@
 ﻿// REQUIRED_ARGS: -c -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/gag4269b.d(10): Error: undefined identifier Y, did you mean variable y?
+---
+*/
 
 static if(is(typeof(X2.init))) {}
 struct X2 { Y y; }
-
- 

--- a/test/fail_compilation/gag4269c.d
+++ b/test/fail_compilation/gag4269c.d
@@ -1,5 +1,10 @@
 ﻿// REQUIRED_ARGS: -c -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/gag4269c.d(10): Error: undefined identifier T3, did you mean function X3?
+---
+*/
 
 static if(is(typeof(X3.init))) {}
 void X3(T3) { }
- 

--- a/test/fail_compilation/gag4269d.d
+++ b/test/fail_compilation/gag4269d.d
@@ -1,5 +1,10 @@
 ﻿// REQUIRED_ARGS: -c -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/gag4269d.d(10): Error: undefined identifier Y4, did you mean function X4?
+---
+*/
 
 static if(is(typeof(X4.init))) {}
 Y4 X4() { return typeof(return).init; }
- 

--- a/test/fail_compilation/gag4269e.d
+++ b/test/fail_compilation/gag4269e.d
@@ -1,4 +1,10 @@
 ﻿// REQUIRED_ARGS: -c -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/gag4269e.d(10): Error: undefined identifier Y8, did you mean class X8?
+---
+*/
 
 static if(is(typeof(X8.init))) {}
-class X8 : Y8 {} 
+class X8 : Y8 {}

--- a/test/fail_compilation/gag4269f.d
+++ b/test/fail_compilation/gag4269f.d
@@ -1,4 +1,11 @@
 ﻿// REQUIRED_ARGS: -c -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/gag4269f.d(11): Error: undefined identifier Y9, did you mean interface X9?
+fail_compilation/gag4269f.d(11): Error: variable gag4269f.X9.y field not allowed in interface
+---
+*/
 
 static if(is(typeof(X9.init))) {}
 interface X9 { Y9 y; }

--- a/test/fail_compilation/gag4269g.d
+++ b/test/fail_compilation/gag4269g.d
@@ -1,4 +1,10 @@
 ﻿// REQUIRED_ARGS: -c -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/gag4269g.d(10): Error: undefined identifier Y13, did you mean template X13(Y13 y)?
+---
+*/
 
 static if(is(typeof(X13!(0).init))) {}
 template X13(Y13 y) {}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10768

If a class/struct/template is not speculatively instantiated, error gagging should be ungagged temporarily during its semantic.
Use RAII idiom to do it reliably.
