### PR TITLE
Fix issue 10388 - Compile DMD with Clang on Mac OS X.

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -55,7 +55,11 @@ ifeq (OSX,$(OS))
 endif
 LDFLAGS=-lm -lstdc++ -lpthread
 
-HOST_CC=g++
+ifeq (OSX,$(OS))
+	HOST_CC=clang++
+else
+	HOST_CC=g++
+endif
 CC=$(HOST_CC) $(MODEL_FLAG)
 GIT=git
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10388
