### PR TITLE
Improve inout substitution algorithm for function pointer and delegate types

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1910,10 +1910,17 @@ Type *Type::substWildTo(unsigned mod)
     //printf("+Type::substWildTo this = %s, mod = x%x\n", toChars(), mod);
     Type *t;
 
-    if (nextOf())
+    if (Type *tn = nextOf())
     {
-        t = nextOf()->substWildTo(mod);
-        if (t == nextOf())
+        // substitution has no effect on function pointer type.
+        if (ty == Tpointer && tn->ty == Tfunction)
+        {
+            t = this;
+            goto L1;
+        }
+
+        t = tn->substWildTo(mod);
+        if (t == tn)
             t = this;
         else
         {
@@ -1928,6 +1935,10 @@ Type *Type::substWildTo(unsigned mod)
                 t = new TypeAArray(t, ((TypeAArray *)this)->index->syntaxCopy());
                 ((TypeAArray *)t)->sc = ((TypeAArray *)this)->sc;   // duplicate scope
             }
+            else if (ty == Tdelegate)
+            {
+                t = new TypeDelegate(t);
+            }
             else
                 assert(0);
 
@@ -1937,6 +1948,7 @@ Type *Type::substWildTo(unsigned mod)
     else
         t = this;
 
+L1:
     if (isWild())
     {
         if (mod & MODconst)
@@ -1951,6 +1963,47 @@ Type *Type::substWildTo(unsigned mod)
 
     //printf("-Type::substWildTo t = %s\n", t->toChars());
     return t;
+}
+
+Type *TypeFunction::substWildTo(unsigned)
+{
+    if (!iswild && !(mod & MODwild))
+        return this;
+
+    // Substitude inout qualifier of function type to mutable or immutable
+    // would break type system. Instead substitude inout to the most weak
+    // qualifer - const.
+    unsigned m = MODconst;
+
+    assert(next);
+    Type *tret = next->substWildTo(m);
+    Parameters *params = parameters;
+    if (mod & MODwild)
+        params = parameters->copy();
+    for (size_t i = 0; i < params->dim; i++)
+    {
+        Parameter *p = (*params)[i];
+        Type *t = p->type->substWildTo(m);
+        if (t == p->type)
+            continue;
+        if (params == parameters)
+            params = parameters->copy();
+        (*params)[i] = new Parameter(p->storageClass, t, NULL, NULL);
+    }
+    if (next == tret && params == parameters)
+        return this;
+
+    // Similar to TypeFunction::syntaxCopy;
+    TypeFunction *t = new TypeFunction(params, tret, varargs, linkage);
+    t->mod = ((mod & MODwild) ? (mod & ~MODwild) | MODconst : mod);
+    t->isnothrow = isnothrow;
+    t->purity = purity;
+    t->isproperty = isproperty;
+    t->isref = isref;
+    t->iswild = false;  // done
+    t->trust = trust;
+    t->fargs = fargs;
+    return t->merge();
 }
 
 /**************************
@@ -5107,6 +5160,7 @@ Type *TypeFunction::syntaxCopy()
     t->purity = purity;
     t->isproperty = isproperty;
     t->isref = isref;
+    t->iswild = iswild;
     t->trust = trust;
     t->fargs = fargs;
     return t;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -307,7 +307,7 @@ public:
     virtual MATCH implicitConvTo(Type *to);
     virtual MATCH constConv(Type *to);
     virtual unsigned wildConvTo(Type *tprm);
-    Type *substWildTo(unsigned mod);
+    virtual Type *substWildTo(unsigned mod);
     virtual Type *toHeadMutable();
     virtual ClassDeclaration *isClassHandle();
     virtual Expression *getProperty(Loc loc, Identifier *ident, int flag);
@@ -691,6 +691,7 @@ public:
     bool parameterEscapes(Parameter *p);
     Type *addStorageClass(StorageClass stc);
 
+    Type *substWildTo(unsigned mod);
     MATCH callMatch(Type *tthis, Expressions *toargs, int flag = 0);
     type *toCtype();
     RET retStyle();

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2992,6 +2992,118 @@ void test9209() {
 }
 
 /************************************/
+// 10758
+
+struct X10758
+{
+static:
+        inout(int)   screwUpVal(ref inout(int) wx) { return wx; }
+    ref inout(int)   screwUpRef(ref inout(int) wx) { return wx; }
+        inout(int)*  screwUpPtr(ref inout(int) wx) { return &wx; }
+        inout(int)[] screwUpArr(ref inout(int) wx) { return (&wx)[0 .. 1]; }
+}
+
+struct S10758
+{
+    int x;
+        inout(int)   screwUpVal(ref inout(int) _) inout { return x; }
+    ref inout(int)   screwUpRef(ref inout(int) _) inout { return x; }
+        inout(int)*  screwUpPtr(ref inout(int) _) inout { return &x; }
+        inout(int)[] screwUpArr(ref inout(int) _) inout { return (&x)[0 .. 1]; }
+}
+
+void test10758(ref inout(int) wx, inout(int)* wp, inout(int)[] wa, inout(S10758) ws)
+{
+        inout(int)   screwUpVal(inout(int) _) { return wx; }
+    ref inout(int)   screwUpRef(inout(int) _) { return wx; }
+        inout(int)*  screwUpPtr(inout(int) _) { return &wx; }
+        inout(int)[] screwUpArr(inout(int) _) { return (&wx)[0 .. 1]; }
+
+              int  mx = 1;
+        const(int) cx = 1;
+    immutable(int) ix = 1;
+
+    // nested inout function may return an inout reference of the context,
+    // so substitude inout to mutable or immutable should be disallowed.
+    {
+        // value return does not leak any inout reference, so safe.
+        screwUpVal(mx);
+        screwUpVal(ix);
+        screwUpVal(wx);
+        screwUpVal(cx);
+
+        static assert(!__traits(compiles, screwUpRef(mx)));
+        static assert(!__traits(compiles, screwUpRef(ix)));
+        screwUpRef(wx);
+        screwUpRef(cx);
+
+        static assert(!__traits(compiles, screwUpPtr(mx)));
+        static assert(!__traits(compiles, screwUpPtr(ix)));
+        screwUpPtr(wx);
+        screwUpPtr(cx);
+
+        static assert(!__traits(compiles, screwUpArr(mx)));
+        static assert(!__traits(compiles, screwUpArr(ix)));
+        screwUpArr(cx);
+        screwUpArr(wx);
+    }
+
+    // function pointer holds no context, so there's no screw up.
+    {
+        auto fp_screwUpVal = &X10758.screwUpVal;
+        fp_screwUpVal(mx);
+        fp_screwUpVal(ix);
+        fp_screwUpVal(wx);
+        fp_screwUpVal(cx);
+
+        auto fp_screwUpRef = &X10758.screwUpRef;
+        fp_screwUpRef(mx);
+        fp_screwUpRef(ix);
+        fp_screwUpRef(wx);
+        fp_screwUpRef(cx);
+
+        auto fp_screwUpPtr = &X10758.screwUpVal;
+        fp_screwUpPtr(mx);
+        fp_screwUpPtr(ix);
+        fp_screwUpPtr(wx);
+        fp_screwUpPtr(cx);
+
+        auto fp_screwUpArr = &X10758.screwUpVal;
+        fp_screwUpArr(mx);
+        fp_screwUpArr(ix);
+        fp_screwUpArr(wx);
+        fp_screwUpArr(cx);
+    }
+
+    // inout delegate behaves same as nested functions.
+    {
+        auto dg_screwUpVal = &ws.screwUpVal;
+        dg_screwUpVal(mx);
+        dg_screwUpVal(ix);
+        dg_screwUpVal(wx);
+        dg_screwUpVal(cx);
+
+        auto dg_screwUpRef = &ws.screwUpRef;
+        static assert(!__traits(compiles, dg_screwUpRef(mx)));
+        static assert(!__traits(compiles, dg_screwUpRef(ix)));
+        dg_screwUpRef(wx);
+        dg_screwUpRef(cx);
+
+        auto dg_screwUpPtr = &ws.screwUpPtr;
+        static assert(!__traits(compiles, dg_screwUpPtr(mx)));
+        static assert(!__traits(compiles, dg_screwUpPtr(ix)));
+        dg_screwUpPtr(wx);
+        dg_screwUpPtr(cx);
+
+        auto dg_screwUpArr = &ws.screwUpArr;
+        static assert(!__traits(compiles, dg_screwUpArr(mx)));
+        static assert(!__traits(compiles, dg_screwUpArr(ix)));
+        dg_screwUpArr(cx);
+        dg_screwUpArr(wx);
+    }
+}
+
+/************************************/
 // 10761
 
 inout(int)* function(inout(int)*) fptr10761(inout(int)*)


### PR DESCRIPTION
[Issue 10758](http://d.puremagic.com/issues/show_bug.cgi?id=10758) - Unsound type checking for inout
[Issue 10761](http://d.puremagic.com/issues/show_bug.cgi?id=10761) - DMD crashes on unspecified inout matching

Fill a hole in type system for inout and nested function
