### PR TITLE
Add Port::fequal for longdouble comparisons.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3006,10 +3006,7 @@ complex_t RealExp::toComplex()
 int RealEquals(real_t x1, real_t x2)
 {
     return (Port::isNan(x1) && Port::isNan(x2)) ||
-        /* In some cases, the REALPAD bytes get garbage in them,
-         * so be sure and ignore them.
-         */
-        memcmp(&x1, &x2, Target::realsize - Target::realpad) == 0;
+        Port::fequal(x1, x2);
 }
 
 bool RealExp::equals(RootObject *o)

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -79,6 +79,14 @@ longdouble Port::fmodl(longdouble x, longdouble y)
     return ::fmodl(x, y);
 }
 
+int Port::fequal(longdouble x, longdouble y)
+{
+    /* In some cases, the REALPAD bytes get garbage in them,
+     * so be sure and ignore them.
+     */
+    return memcmp(&x, &y, 10) == 0;
+}
+
 char *Port::strupr(char *s)
 {
     return ::strupr(s);
@@ -208,6 +216,14 @@ longdouble Port::fmodl(longdouble x, longdouble y)
     return ::fmodl(x, y);
 }
 
+int Port::fequal(longdouble x, longdouble y)
+{
+    /* In some cases, the REALPAD bytes get garbage in them,
+     * so be sure and ignore them.
+     */
+    return memcmp(&x, &y, 10) == 0;
+}
+
 char *Port::strupr(char *s)
 {
     return ::strupr(s);
@@ -249,6 +265,7 @@ longdouble Port::strtold(const char *p, char **endp)
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 #include <wchar.h>
 #include <float.h>
@@ -333,6 +350,14 @@ int Port::isInfinity(double r)
 longdouble Port::fmodl(longdouble x, longdouble y)
 {
     return ::fmodl(x, y);
+}
+
+int Port::fequal(longdouble x, longdouble y)
+{
+    /* In some cases, the REALPAD bytes get garbage in them,
+     * so be sure and ignore them.
+     */
+    return memcmp(&x, &y, 10) == 0;
 }
 
 char *Port::strupr(char *s)
@@ -422,6 +447,7 @@ longdouble Port::strtold(const char *p, char **endp)
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 #include <wchar.h>
 #include <float.h>
@@ -550,6 +576,14 @@ longdouble Port::fmodl(longdouble x, longdouble y)
 #endif
 }
 
+int Port::fequal(longdouble x, longdouble y)
+{
+    /* In some cases, the REALPAD bytes get garbage in them,
+     * so be sure and ignore them.
+     */
+    return memcmp(&x, &y, 10) == 0;
+}
+
 char *Port::strupr(char *s)
 {
     char *t = s;
@@ -631,6 +665,7 @@ longdouble Port::strtold(const char *p, char **endp)
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 #include <wchar.h>
 #include <float.h>
@@ -715,6 +750,14 @@ int Port::isInfinity(double r)
 longdouble Port::fmodl(longdouble x, longdouble y)
 {
     return ::fmodl(x, y);
+}
+
+int Port::fequal(longdouble x, longdouble y)
+{
+    /* In some cases, the REALPAD bytes get garbage in them,
+     * so be sure and ignore them.
+     */
+    return memcmp(&x, &y, 10) == 0;
 }
 
 char *Port::strupr(char *s)

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -48,6 +48,7 @@ struct Port
     static int isInfinity(double);
 
     static longdouble fmodl(longdouble x, longdouble y);
+    static int fequal(longdouble x, longdouble y);
 
     static char *strupr(char *);
 


### PR DESCRIPTION
This makes me a little nervous inside to change, as it would be useful to have access to `realsize` and `realpad` from port for the sake of portability, but this is not possible due to the ties target has with the front-end.

Maybe should change real comparisons to:
`return abs(x, y) <= MAX(LDBL_EPSILON, LDBL_EPSILON * MAX(abs(x), abs(y)));`

...
