### PR TITLE
Extend DIP42 proposal to more generic

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -5616,7 +5616,7 @@ int Parser::skipParens(Token *t, Token **pt)
     }
 
   Ldone:
-    if (*pt)
+    if (pt)
         *pt = t;
     return 1;
 
@@ -5723,7 +5723,7 @@ int Parser::skipAttributes(Token *t, Token **pt)
     }
 
   Ldone:
-    if (*pt)
+    if (pt)
         *pt = t;
     return 1;
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -130,6 +130,7 @@ public:
     int isParameters(Token **pt);
     int isExpression(Token **pt);
     int skipParens(Token *t, Token **pt);
+    int skipParensIf(Token *t, Token **pt);
     int skipAttributes(Token *t, Token **pt);
 
     Expression *parseExpression();

--- a/test/compilable/testDIP42.d
+++ b/test/compilable/testDIP42.d
@@ -22,6 +22,14 @@ static assert( anySatisfy!(isIntegral, int, double));
 static assert(!anySatisfy!(isIntegral, int[], double));
 }
 
+void test1()
+{
+    // statement
+    enum isIntegral2(T) = is(T == int) || is(T == long);
+    static assert(isIntegral2!int);
+}
+
+/******************************************/
 // alias ident(tpl) = Type;
 
 alias TypeTuple(TL...) = TL;
@@ -31,3 +39,15 @@ static assert(is(TypeTuple!(int, long)[1] == long));
 alias Id(T) = T, Id(alias A) = A;
 static assert(is(Id!int == int));
 static assert(__traits(isSame, Id!TypeTuple, TypeTuple));
+
+void test2()
+{
+    // statement
+    alias TypeTuple2(TL...) = TL;
+    static assert(is(TypeTuple2!(int, long)[0] == int));
+    static assert(is(TypeTuple2!(int, long)[1] == long));
+
+    alias IdT(T) = T, IdA(alias A) = A;
+    static assert(is(IdT!int == int));
+    static assert(__traits(isSame, IdA!TypeTuple, TypeTuple));
+}

--- a/test/compilable/testDIP42.d
+++ b/test/compilable/testDIP42.d
@@ -51,3 +51,28 @@ void test2()
     static assert(is(IdT!int == int));
     static assert(__traits(isSame, IdA!TypeTuple, TypeTuple));
 }
+
+/******************************************/
+// template auto declaration
+
+auto tynameLen(T) = T.stringof.length;
+
+void test3()
+{
+    assert(tynameLen!int == 3);
+    assert(tynameLen!long == 4);
+    tynameLen!int = 4;
+    tynameLen!long = 5;
+    assert(tynameLen!int == 4);
+    assert(tynameLen!long == 5);
+
+    // statement
+    auto tynameLen2(T) = T.stringof.length;
+
+    assert(tynameLen2!int == 3);
+    assert(tynameLen2!long == 4);
+    tynameLen2!int = 4;
+    tynameLen2!long = 5;
+    assert(tynameLen2!int == 4);
+    assert(tynameLen2!long == 5);
+}

--- a/test/compilable/testDIP42.d
+++ b/test/compilable/testDIP42.d
@@ -76,3 +76,22 @@ void test3()
     assert(tynameLen2!int == 4);
     assert(tynameLen2!long == 5);
 }
+
+/******************************************/
+// template variable declaration
+
+static T math_pi(T) = cast(T)3.1415;
+
+enum bool isFloatingPoint(T) = is(T == float) || is(T == double);
+static assert( isFloatingPoint!double);
+static assert(!isFloatingPoint!string);
+
+void main()
+{
+    assert(math_pi!int == 3);
+    assert(math_pi!double == 3.1415);
+
+    enum bool isFloatingPoint2(T) = is(T == float) || is(T == double);
+    static assert( isFloatingPoint2!double);
+    static assert(!isFloatingPoint2!string);
+}

--- a/test/fail_compilation/diag10792.d
+++ b/test/fail_compilation/diag10792.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10792.d(2): Error: semicolon expected to close enum declaration
+fail_compilation/diag10792.d(2): Error: semicolon expected following auto declaration, not 'EOF'
 ---
 */
 


### PR DESCRIPTION
When I implemented DIP42 in #2368, I treated specially the case of parameterized enum declaration. As its result, current DIP42 feature is mostly a grammatical anomaly and difficult to document it correctly.

And, current implementation does not accept following declaration.

``` d
enum bool isIntegral(T) = is(T == int);
```

I think not supporting this would be unnatural.

---

For more consistent behavior and clean syntax, I'd propose to allow optional template parameters for _all_ variable declarations. For example:

``` d
auto var(T) = initializer;    // template auto declaration
T var(T) = initializer;   // template variable declaration
enum bool isIntergral(T) = initializer;   // template variable declaration with prefix storage class 'enum'
```
