### PR TITLE
revert pull #2454

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -55,11 +55,11 @@ ifeq (OSX,$(OS))
 endif
 LDFLAGS=-lm -lstdc++ -lpthread
 
-ifeq (OSX,$(OS))
-	HOST_CC=clang++
-else
+#ifeq (OSX,$(OS))
+#	HOST_CC=clang++
+#else
 	HOST_CC=g++
-endif
+#endif
 CC=$(HOST_CC) $(MODEL_FLAG)
 GIT=git
 


### PR DESCRIPTION
clang is causing multiple bus errors and other failures on OS X.

It also produces a blizzard of warnings compiling dmd and zlib on phobos. These all need to be investigated.
