### PR TITLE
fix warnings emitted by clang

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -2163,8 +2163,8 @@ STATIC code * comsub(elem *e,regm_t *pretregs)
     //printf("comsub(e = %p, *pretregs = %s)\n",e,regm_str(*pretregs));
     elem_debug(e);
 #ifdef DEBUG
-    if (e->Ecomsub > e->Ecount)
-        elem_print(e);
+    //if (e->Ecomsub > e->Ecount)
+        //elem_print(e);
 #endif
     assert(e->Ecomsub <= e->Ecount);
 
@@ -2201,7 +2201,7 @@ if (debugw)
 {
 printf("comsub(e=%p): *pretregs=%s, emask=%s, csemask=%s, regcon.cse.mval=%s, regcon.mvar=%s\n",
         e,regm_str(*pretregs),regm_str(emask),regm_str(csemask),regm_str(regcon.cse.mval),regm_str(regcon.mvar));
-if (regcon.cse.mval & 1) elem_print(regcon.cse.value[i]);
+if (regcon.cse.mval & 1) elem_print(regcon.cse.value[0]);
 }
 #endif
 

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -2506,8 +2506,8 @@ STATIC bool optim_loglog(elem **pe)
             if (0 && eq->E2->Eoper != OPconst)
             {
                 printf("eq = %p, eq->E2 = %p\n", eq, eq->E2);
-                printf("first = %d, i = %d, last = %d, Eoper = %d\n", first, i, last, eq->E2->Eoper);
-                printf("any = %d, n = %d, count = %d, min = %d, max = %d\n", any, (int)n, last - first + 1, (int)emin, (int)emax);
+                printf("first = %d, i = %d, last = %d, Eoper = %d\n", (int)first, (int)i, (int)last, eq->E2->Eoper);
+                printf("any = %d, n = %d, count = %d, min = %d, max = %d\n", any, (int)n, (int)(last - first + 1), (int)emin, (int)emax);
             }
             assert(eq->E2->Eoper == OPconst);
             bits |= (targ_ullong)1 << (el_tolong(eq->E2) - emin);

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -1793,7 +1793,7 @@ int el_noreturn(elem *e)
     {   elem_debug(e);
         switch (e->Eoper)
         {   case OPcomma:
-                if (result |= el_noreturn(e->E1))
+                if ((result |= el_noreturn(e->E1)) != 0)
                     break;
                 e = e->E2;
                 continue;

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -886,8 +886,8 @@ restart:
             if (dfo[i]->Belem)
             {   // If there is any hope of making an improvement
                 if (domexit || l->Llis)
-                {   if (dfo[i] != l->Lhead)
-                        ; //domexit |= 2;
+                {   //if (dfo[i] != l->Lhead)
+                        //domexit |= 2;
                     movelis(dfo[i]->Belem, dfo[i], l, &domexit);
                 }
             }

--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -1315,9 +1315,9 @@ STATIC void accumda(elem *n,vec_t DEAD, vec_t POSS)
                         POSS[i] = tmp1 | tmp2;
                 }
 #else
-                {       DEAD[i] |= POSS[i] & Dl[i] & Dr[i] |
-                                   ~POSS[i] & (Dl[i] | Dr[i]);
-                        POSS[i] = Pl[i] & Pr[i] | ~POSS[i] & (Pl[i] | Pr[i]);
+                {       DEAD[i] |= (POSS[i] & Dl[i] & Dr[i]) |
+                                   (~POSS[i] & (Dl[i] | Dr[i]));
+                        POSS[i] = (Pl[i] & Pr[i]) | (~POSS[i] & (Pl[i] | Pr[i]));
                 }
 #endif
                 vec_free(Pl); vec_free(Pr); vec_free(Dl); vec_free(Dr);

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -2148,6 +2148,7 @@ int Obj::external(Symbol *s)
     symbol_debug(s);
     extern_symbuf->write(&s, sizeof(s));
     s->Sxtrnnum = 1;
+    return 0;
 }
 
 /*******************************

--- a/src/backend/nteh.c
+++ b/src/backend/nteh.c
@@ -344,7 +344,7 @@ code *nteh_prolog()
     cs.IEV2.Vint = -1;
     c1 = gen(CNIL,&cs);                 // PUSH -1
 
-    if (usednteh & NTEHcpp || MARS)
+    if ((usednteh & NTEHcpp) || MARS)
     {
         // PUSH &framehandler
         cs.IFL2 = FLframehandler;

--- a/src/backend/util2.c
+++ b/src/backend/util2.c
@@ -55,6 +55,9 @@ void util_assert(const char *file, int line)
     fflush(stdout);
     printf("Internal error: %s %d\n",file,line);
     err_exit();
+#if __clang__
+    __builtin_unreachable();
+#endif
 }
 
 /****************************

--- a/src/clone.c
+++ b/src/clone.c
@@ -715,7 +715,7 @@ FuncDeclaration *StructDeclaration::buildCpCtor(Scope *sc)
 
     stc = mergeFuncAttrs(stc, postblit->storage_class);
     if (stc & STCsafe)  // change to @trusted for unsafe casts
-        stc = stc & ~STCsafe | STCtrusted;
+        stc = (stc & ~STCsafe) | STCtrusted;
 
     Parameters *fparams = new Parameters;
     fparams->push(new Parameter(STCref, type->constOf(), Id::p, NULL));

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -808,6 +808,8 @@ int comparePointers(Loc loc, TOK op, Type *type, Expression *agg1, dinteger_t of
         case TOKnotequal:
             cmp = (null1 == null2);
             break;
+        default:
+            assert(0);
         }
     }
     else
@@ -904,6 +906,9 @@ void intUnary(TOK op, IntegerExp *e)
         break;
     case TOKtilde:
         e->value = ~e->value;
+        break;
+    default:
+        assert(0);
         break;
     }
 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -1932,7 +1932,7 @@ Expression *Expression::copy()
     }
     e = (Expression *)mem.malloc(size);
     //printf("Expression::copy(op = %d) e = %p\n", op, e);
-    return (Expression *)memcpy(e, this, size);
+    return (Expression *)memcpy((void*)e, (void*)this, size);
 }
 
 /**************************

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3981,6 +3981,8 @@ STATIC OPND *asm_rel_exp()
                         case TOKle:
                             o1->disp = o1->disp <= o2->disp;
                             break;
+                        default:
+                            assert(0);
                     }
                 }
                 else
@@ -4562,6 +4564,9 @@ STATIC OPND *asm_primary_exp()
                 o1->s = asmstate.psLocalsize;
                 o1->ptype = Type::tint32;
                 asm_token();
+                break;
+
+             default:
                 break;
         }
 Lret:

--- a/src/inline.c
+++ b/src/inline.c
@@ -765,7 +765,7 @@ Expression *DeclarationExp::doInline(InlineDoState *ids)
             VarDeclaration *vto;
 
             vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-            memcpy(vto, vd, sizeof(VarDeclaration));
+            memcpy((void*)vto, (void*)vd, sizeof(VarDeclaration));
             vto->parent = ids->parent;
             vto->csym = NULL;
             vto->isym = NULL;
@@ -859,7 +859,7 @@ Expression *IndexExp::doInline(InlineDoState *ids)
         VarDeclaration *vto;
 
         vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-        memcpy(vto, vd, sizeof(VarDeclaration));
+        memcpy((void*)vto, (void*)vd, sizeof(VarDeclaration));
         vto->parent = ids->parent;
         vto->csym = NULL;
         vto->isym = NULL;
@@ -896,7 +896,7 @@ Expression *SliceExp::doInline(InlineDoState *ids)
         VarDeclaration *vto;
 
         vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-        memcpy(vto, vd, sizeof(VarDeclaration));
+        memcpy((void*)vto, (void*)vd, sizeof(VarDeclaration));
         vto->parent = ids->parent;
         vto->csym = NULL;
         vto->isym = NULL;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3961,7 +3961,7 @@ Expression *interpretAssignToSlice(InterState *istate, CtfeGoal goal, Loc loc,
         return newval;
 
     Expression *aggregate = resolveReferences(sexp->e1);
-    dinteger_t firstIndex = lowerbound;
+    sinteger_t firstIndex = lowerbound;
 
     ArrayLiteralExp *existingAE = NULL;
     StringExp *existingSE = NULL;
@@ -4894,7 +4894,7 @@ Expression *IndexExp::interpret(InterState *istate, CtfeGoal goal)
         {
             dinteger_t len = ArrayLength(Type::tsize_t, agg)->toInteger();
             //Type *pointee = ((TypePointer *)agg->type)->next;
-            if ((indx + ofs) < 0 || (indx+ofs) > len)
+            if ((sinteger_t)(indx + ofs) < 0 || (indx+ofs) > len)
             {
                 error("pointer index [%lld] exceeds allocated memory block [0..%lld]",
                     indx+ofs, len);

--- a/src/mars.c
+++ b/src/mars.c
@@ -1541,14 +1541,14 @@ Language changes listed by -transition=id:\n\
     if (global.params.moduleDeps)
     {
         OutBuffer* ob = global.params.moduleDeps;
-        if (global.params.moduleDepsFile) 
+        if (global.params.moduleDepsFile)
         {
             File deps(global.params.moduleDepsFile);
             deps.setbuffer((void*)ob->data, ob->offset);
             deps.writev();
         }
         else
-            printf("%.*s", ob->offset, ob->data);
+            printf("%.*s", (int)ob->offset, ob->data);
     }
 
     // Scan for functions to inline

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -157,7 +157,7 @@ const char *Type::kind()
 Type *Type::copy()
 {
     Type *t = (Type *)mem.malloc(sizeTy[ty]);
-    memcpy(t, this, sizeTy[ty]);
+    memcpy((void*)t, (void*)this, sizeTy[ty]);
     return t;
 }
 
@@ -396,7 +396,7 @@ Type *Type::nullAttributes()
 {
     unsigned sz = sizeTy[ty];
     Type *t = (Type *)mem.malloc(sz);
-    memcpy(t, this, sz);
+    memcpy((void*)t, (void*)this, sz);
     // t->mod = NULL;  // leave mod unchanged
     t->deco = NULL;
     t->arrayof = NULL;
@@ -5534,7 +5534,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
         for (size_t i = 0; i < parameters->dim; i++)
         {   Parameter *arg = (*parameters)[i];
             Parameter *cpy = (Parameter *)mem.malloc(sizeof(Parameter));
-            memcpy(cpy, arg, sizeof(Parameter));
+            memcpy((void*)cpy, (void*)arg, sizeof(Parameter));
             (*tf->parameters)[i] = cpy;
         }
     }

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -354,7 +354,7 @@ Expression *AddrExp::optimize(int result, bool keepLvalue)
 
         if (ae->e2->op == TOKint64 && ae->e1->op == TOKvar)
         {
-            dinteger_t index = ae->e2->toInteger();
+            sinteger_t index = ae->e2->toInteger();
             VarExp *ve = (VarExp *)ae->e1;
             if (ve->type->ty == Tsarray
                 && !ve->var->isImportedSymbol())

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -765,12 +765,12 @@ void ReturnStatement::toIR(IRState *irs)
             if (exp->op == TOKstructliteral)
             {   StructLiteralExp *se = (StructLiteralExp *)exp;
                 char save[sizeof(StructLiteralExp)];
-                memcpy(save, se, sizeof(StructLiteralExp));
+                memcpy(save, (void*)se, sizeof(StructLiteralExp));
                 se->sym = irs->shidden;
                 se->soffset = 0;
                 se->fillHoles = 1;
                 e = exp->toElemDtor(irs);
-                memcpy(se, save, sizeof(StructLiteralExp));
+                memcpy((void*)se, save, sizeof(StructLiteralExp));
 
             }
             else

--- a/src/scanmach.c
+++ b/src/scanmach.c
@@ -167,10 +167,12 @@ void scanMachObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, in
                     ; //printf(" N_STAB");
                 else
                 {
+#if 0
                     if (s->n_type & N_PEXT)
                         ;
                     if (s->n_type & N_EXT)
                         ;
+#endif
                     switch (s->n_type & N_TYPE)
                     {
                         case N_UNDF:
@@ -208,10 +210,12 @@ void scanMachObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, in
                     ; //printf(" N_STAB");
                 else
                 {
+#if 0
                     if (s->n_type & N_PEXT)
                         ;
                     if (s->n_type & N_EXT)
                         ;
+#endif
                     switch (s->n_type & N_TYPE)
                     {
                         case N_UNDF:


### PR DESCRIPTION
Ready to pull once it turns green.

The rest of the warnings I regard as noise and should be disabled using a command line switch.
