### PR TITLE
[experimental] guess how much memory will be needed and adjust chunk size

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -2132,25 +2132,7 @@ Expression *VarDeclaration::getConstInitializer(bool needFullType)
 
 bool VarDeclaration::canTakeAddressOf()
 {
-#if 0
-    /* Global variables and struct/class fields of the form:
-     *  const int x = 3;
-     * are not stored and hence cannot have their address taken.
-     */
-    if ((isConst() || isImmutable()) &&
-        storage_class & STCinit &&
-        (!(storage_class & (STCstatic | STCextern)) || isField()) &&
-        (!parent || toParent()->isModule() || toParent()->isTemplateInstance()) &&
-        type->toBasetype()->isTypeBasic()
-       )
-    {
-        return false;
-    }
-#else
-    if (storage_class & STCmanifest)
-        return false;
-#endif
-    return true;
+    return !(storage_class & STCmanifest);
 }
 
 
@@ -2166,18 +2148,17 @@ bool VarDeclaration::isDataseg()
     printf("%llx, isModule: %p, isTemplateInstance: %p\n", storage_class & (STCstatic | STCconst), parent->isModule(), parent->isTemplateInstance());
     printf("parent = '%s'\n", parent->toChars());
 #endif
-    if (storage_class & STCmanifest)
+    if (!canTakeAddressOf())
         return false;
-    Dsymbol *parent = this->toParent();
+    Dsymbol *parent = toParent();
     if (!parent && !(storage_class & STCstatic))
-    {   error("forward referenced");
+    {
+        error("forward referenced");
         type = Type::terror;
         return false;
     }
-    return canTakeAddressOf() &&
-        (storage_class & (STCstatic | STCextern | STCtls | STCgshared) ||
-         toParent()->isModule() ||
-         toParent()->isTemplateInstance());
+    return storage_class & (STCstatic | STCextern | STCtls | STCgshared) ||
+            parent->isModule() || parent->isTemplateInstance();
 }
 
 /************************************

--- a/src/mars.c
+++ b/src/mars.c
@@ -1371,7 +1371,7 @@ Language changes listed by -transition=id:\n\
         }
     }
 
-#define ASYNCREAD 1
+#define ASYNCREAD 0
 #if ASYNCREAD
     // Multi threaded
     AsyncRead *aw = AsyncRead::create(modules.dim);
@@ -1383,11 +1383,17 @@ Language changes listed by -transition=id:\n\
     aw->start();
 #else
     // Single threaded
+    size_t mem = 0;
     for (size_t i = 0; i < modules.dim; i++)
     {
         m = modules[i];
         m->read(Loc());
+        mem += m->srcfile->len;
     }
+    mem *= 64;
+    //printf("mem guess: %zu\n", mem);
+    memNeeded += mem;
+    guessMem(mem);
 #endif
 
     // Parse files
@@ -1681,6 +1687,15 @@ Language changes listed by -transition=id:\n\
     backend_term();
     if (global.errors)
         fatal();
+
+    //printf("mem needed: %zu (%f chunks)\n", memNeeded,
+    //       (double)memNeeded / (double)(4096 * 16));
+    //printf("mem guess/need ratio %f\n",
+    //       (double)mem / (double)(memNeeded - heapleft));
+    //printf("wasted %zu bytes (%f chunks)\n", heapleft,
+    //       (double)heapleft / (double)(4096 * 16));
+    //printf("mem allocated/needed ratio: %f\n",
+    //       double(memNeeded) / (double)(memNeeded - heapleft));
 
     int status = EXIT_SUCCESS;
     if (!global.params.objfiles->dim)

--- a/src/root/rmem.h
+++ b/src/root/rmem.h
@@ -54,4 +54,8 @@ struct Mem
 
 extern Mem mem;
 
+extern size_t heapleft;
+extern size_t memNeeded;
+void guessMem(size_t size);
+
 #endif /* ROOT_MEM_H */


### PR DESCRIPTION
The guessed memory is adequate to the total file size of sources given. I don't think it's a good idea but the results are rather good.

Benchmarked using `avgtime -d -r 10 dmd std/algorithm -unittest -o-`.

Default DMD:

```
Total time (ms): 60364.4
Repetitions    : 10
Sample mode    : 6190 (1 ocurrences)
Median time    : 6057.17
Avg time       : 6036.44
Std dev.       : 127.367
Minimum        : 5769.23
Maximum        : 6196.66
95% conf.int.  : [5786.8, 6286.07]  e = 249.634
99% conf.int.  : [5708.36, 6364.51]  e = 328.075
EstimatedAvg95%: [5957.5, 6115.38]  e = 78.9412
```

Guessing DMD:

```
Total time (ms): 51912.9
Repetitions    : 10
Sample mode    : 5170 (2 ocurrences)
Median time    : 5167.91
Avg time       : 5191.29
Std dev.       : 139.772
Minimum        : 5030.62
Maximum        : 5520.05
95% conf.int.  : [4917.34, 5465.23]  e = 273.947
99% conf.int.  : [4831.26, 5551.31]  e = 360.028
EstimatedAvg95%: [5104.66, 5277.92]  e = 86.6297
EstimatedAvg99%: [5077.44, 5305.14]  e = 113.851
```

Even though the guess/needed ratio is 0.017 so 0.17% of the memory needed is preallocated, there is a ~16% speedup. The allocated/needed ratio is at ~1.0054 which is quite good. There are some printfs you can use to adjust the magic numbers or to try different source files.
