### PR TITLE
Issue 10811 - Order dependent IFTI failure

### DIFF
--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2781,6 +2781,24 @@ void test10592()
 }
 
 /******************************************/
+// 10811
+
+void foo10811a(R1, R2)(R1, R2) {}
+template foo10811a(alias pred) { void foo10811a(R1, R2)(R1, R2) {} }
+
+template foo10811b(alias pred) { void foo10811b(R1, R2)(R1, R2) {} }
+void foo10811b(R1, R2)(R1, R2) {}
+
+void test10811()
+{
+    foo10811a(1, 2);
+    foo10811a!(a => a)(1, 2);
+
+    foo10811b(1, 2);
+    foo10811b!(a => a)(1, 2);
+}
+
+/******************************************/
 
 int main()
 {
@@ -2868,6 +2886,7 @@ int main()
     test9977();
     test10083();
     test10592();
+    test10811();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10811

Recognize following code pattern as that IFTI is necessary.

``` d
template foo(alias pred) {
    void foo(R)(R range) {}
}
foo!(a => a)(r);
```
