### PR TITLE
fix Issue 10711 - shared phobos library should not depend on _Dmain

### DIFF
--- a/test/runnable/extra-files/hello-profile.d.trace.def
+++ b/test/runnable/extra-files/hello-profile.d.trace.def
@@ -1,3 +1,4 @@
 
 FUNCTIONS
+	main
 	_D5hello8showargsFAAyaZv


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10711

This moves code that was formerly in druntime's src/rt/entrypoint.d into the compiler itself.
