### PR TITLE
Fix issue 6210

### DIFF
--- a/src/typinf.c
+++ b/src/typinf.c
@@ -790,7 +790,8 @@ int TypeDArray::builtinTypeInfo()
 #if DMDV2
     return !mod && (next->isTypeBasic() != NULL && !next->mod ||
         // strings are so common, make them builtin
-        next->ty == Tchar && next->mod == MODimmutable);
+        next->ty == Tchar && next->mod == MODimmutable ||
+        next->ty == Tchar && next->mod == MODconst);
 #else
     return next->isTypeBasic() != NULL;
 #endif


### PR DESCRIPTION
Use builtin typeinfo for const(char)[] as well. The cause of issue 6210 is that the typeinfo generated for const(char)[] uses a different hash function from char[] and string, causing a mismatch during key lookup in the AA.

Depends on https://github.com/D-Programming-Language/druntime/pull/573
