### PR TITLE
fix issue 10834 - cannot use cast(void)expr if the type of expr is a struct

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9780,6 +9780,10 @@ Expression *CastExp::semantic(Scope *sc)
         if (e1->type->ty == Terror)
             return new ErrorExp();
 
+        // cast(void) is used to mark e1 as unused, so it is safe
+        if (to->ty == Tvoid)
+            goto Lsafe;
+
         if (!to->equals(e1->type))
         {
             Expression *e = op_overload(sc);

--- a/test/runnable/casting.d
+++ b/test/runnable/casting.d
@@ -47,12 +47,34 @@ void test10646()
 }
 
 /***************************************************/
+// 10834
+
+void test10834()
+{
+    struct S { int i; }
+    S s;
+    cast(void)s;
+
+    class C { int i; }
+    C c;
+    cast(void)c;
+
+    enum E { a, b }
+    E e;
+    cast(void)e;
+
+    int[] ia;
+    cast(void)ia;
+}
+
+/***************************************************/
 
 int main()
 {
     test8119();
     test8645();
     test10646();
+    test10834();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10834
