### PR TITLE
[enh] Issue 10848 - Compiler should always try to inlining a direct lambda call

### DIFF
--- a/src/delegatize.c
+++ b/src/delegatize.c
@@ -85,6 +85,14 @@ void lambdaSetParent(Expression *e, Scope *sc)
         void visit(DeclarationExp *e)
         {
             e->declaration->parent = sc->parent;
+
+            // Same as lambdaCheckForNestedRefs
+            VarDeclaration *v = e->declaration->isVarDeclaration();
+            if (v && v->init && v->init->isExpInitializer())
+            {
+                Expression *ie = v->init->toExpression();
+                lambdaSetParent(ie, sc);
+            }
         }
 
         void visit(IndexExp *e)

--- a/src/expression.c
+++ b/src/expression.c
@@ -52,6 +52,10 @@ bool checkFrameAccess(Loc loc, Scope *sc, AggregateDeclaration *ad, size_t istar
 Symbol *toInitializer(AggregateDeclaration *ad);
 Expression *getTypeInfo(Type *t, Scope *sc);
 
+bool canInline(FuncDeclaration *fd, int hasthis, int hdrscan, int statementsToo);
+Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
+    Expression *eret, Expression *ethis, Expressions *arguments, Statement **ps);
+
 #define LOGSEMANTIC     0
 
 /*************************************************************
@@ -9015,6 +9019,17 @@ Lagain:
         sc->func && !sc->intypeof)
     {
         f->tookAddressOf = 0;
+
+        // Enforce direct lambda call inlining
+        if (canInline(f, 0, 0, 0))
+        {
+            Expression *e = expandInline(f, sc->func, NULL, NULL, arguments, NULL);
+            if (e)  // inlining may fail
+            {
+                //printf("f = %s -> e = %s\n", f->toChars(), e->toChars());
+                return e;
+            }
+        }
     }
 
     return combine(argprefix, this);

--- a/src/func.c
+++ b/src/func.c
@@ -4061,6 +4061,7 @@ Expression *addInvariant(Scope *sc, AggregateDeclaration *ad, VarDeclaration *vt
         se = se->semantic(sc);
         se->type = Type::tchar->arrayOf();
         e = new AssertExp(Loc(), v, se);
+        e->type = Type::tvoid;
     }
     return e;
 }

--- a/src/inline.c
+++ b/src/inline.c
@@ -31,7 +31,8 @@
 #include "module.h"
 #include "tokens.h"
 
-static Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
+bool canInline(FuncDeclaration *fd, int hasthis, int hdrscan, int statementsToo);
+Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
     Expression *eret, Expression *ethis, Expressions *arguments, Statement **ps);
 bool walkPostorder(Expression *e, StoppableVisitor *v);
 bool canInline(FuncDeclaration *fd, int hasthis, int hdrscan, int statementsToo);
@@ -1786,7 +1787,7 @@ Lno:
     return false;
 }
 
-static Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
+Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
         Expression *eret, Expression *ethis, Expressions *arguments, Statement **ps)
 {
     InlineDoState ids;
@@ -1891,7 +1892,7 @@ static Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
         else
         {
             Identifier* tmp = Identifier::generateId("__nrvoretval");
-            VarDeclaration* vd = new VarDeclaration(fd->loc, fd->nrvo_var->type, tmp, NULL);
+            VarDeclaration* vd = new VarDeclaration(fd->loc, fd->nrvo_var->type, tmp, new VoidInitializer(fd->loc));
             assert(!tf->isref);
             vd->storage_class = STCtemp | STCrvalue;
             vd->linkage = tf->linkage;

--- a/src/inline.c
+++ b/src/inline.c
@@ -1974,6 +1974,12 @@ Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
         if (tf->isref)
             e = e->toLvalue(NULL, NULL);
 
+        if (e && e->type != Type::tvoid && fd->type->nextOf() == Type::tvoid)
+        {
+            e = new CastExp(e->loc, e, Type::tvoid);
+            e->type = Type::tvoid;
+        }
+
         /* There's a problem if what the function returns is used subsequently as an
          * lvalue, as in a struct return that is then used as a 'this'.
          * If we take the address of the return value, we will be taking the address

--- a/src/statement.c
+++ b/src/statement.c
@@ -822,11 +822,13 @@ Statement *ExpStatement::semantic(Scope *sc)
             }
         }
 #endif
+        bool isCall = exp->op == TOKcall;
 
         exp = exp->semantic(sc);
         exp = resolveProperties(sc, exp);
         exp = exp->addDtorHook(sc);
-        discardValue(exp);
+        if (!isCall)
+            discardValue(exp);
         exp = exp->optimize(WANTvalue);
         exp = checkGC(sc, exp);
         if (exp->op == TOKerror)

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -159,22 +159,47 @@ void test10833()
 }
 
 /************************************/
-// Bugzilla 4825
 
-int a8() {
+auto fn8(Handlers...)(bool cond)
+{
+    // Infer return type from Handlers[n] call
+    if (cond)
+        return Handlers[0]();
+    else
+        return Handlers[1]();
+}
+
+void test8()
+{
+    int which;
+
+    void errorfunc() { which = -1; }
+
+    fn8!((){ which = 0; },  // <-- Expanded expr should have void type
+         errorfunc
+        )(true);
+}
+
+/************************************/
+// 4825
+
+int a4825()
+{
     int r;
     return r;
 }
 
-int b8() {
-    return a8();
+int b4825()
+{
+    return a4825();
 }
 
-void test8() {
+void test4825()
+{
     void d() {
-        auto e = b8();
+        auto e = b4825();
     }
-    static const int f = b8();
+    static const int f = b4825();
 }
 
 /************************************/
@@ -637,6 +662,7 @@ int main()
     test6();
     test7();
     test8();
+    test4825();
     test4841();
     test11201();
     test11223();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10848

I'd like to propose an additional spec for the direct lambda call inlining.
