### PR TITLE
Issue 10086 & 10857 - Adjust instantiated template process order, and fix ICE in glue.c

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -792,6 +792,7 @@ void FuncDeclaration::toObjFile(int multiobj)
 
     if (vthis)
     {
+        assert(!vthis->csym);
         sthis = vthis->toSymbol();
         irs.sthis = sthis;
         if (!(f->Fflags3 & Fnested))
@@ -821,12 +822,9 @@ void FuncDeclaration::toObjFile(int multiobj)
     if (parameters)
     {
         for (size_t i = 0; i < parameters->dim; i++)
-        {   VarDeclaration *v = (*parameters)[i];
-            if (v->csym)
-            {
-                error("compiler error, parameter '%s', bugzilla 2962?", v->toChars());
-                assert(0);
-            }
+        {
+            VarDeclaration *v = (*parameters)[i];
+            assert(!v->csym);
             params[pi + i] = v->toSymbol();
         }
         pi += parameters->dim;

--- a/src/template.c
+++ b/src/template.c
@@ -5481,7 +5481,14 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         }
         else
         {
-            Module *m = (enclosing ? sc : tempdecl->scope)->module;
+            Dsymbol *s = enclosing ? enclosing : tempdecl->parent;
+            for (; s; s = s->toParent2())
+            {
+                if (s->isModule())
+                    break;
+            }
+            assert(s);
+            Module *m = (Module *)s;
             if (m->importedFrom != m)
             {
                 //if (tinst && tinst->objFileModule)

--- a/test/compilable/ice4481.d
+++ b/test/compilable/ice4481.d
@@ -1,5 +1,0 @@
-// EXTRA_SOURCES: imports/b4481.d
-import imports.a4481;
-import imports.b4481;
-
-void main() {}

--- a/test/fail_compilation/fail2962.d
+++ b/test/fail_compilation/fail2962.d
@@ -1,0 +1,41 @@
+// EXTRA_SOURCES: imports/fail2962a.d
+
+// comment 6
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2962.d(14): Error: variable y cannot be read at compile time
+fail_compilation/fail2962.d(14):        while looking for match for baz6!(int, y)
+fail_compilation/fail2962.d(22): Error: template instance fail2962.bar6!int error instantiating
+---
+*/
+T bar6(T)(T y)
+{
+    return baz6!(T, y)();
+}
+T baz6(T, T z)()
+{
+    return z * z;
+}
+void test6()
+{
+    assert(bar6(4) != 0);
+}
+
+// comment 4
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2962.d(36): Error: variable x cannot be read at compile time
+fail_compilation/fail2962.d(36):        while looking for match for baz4!(int, x)
+fail_compilation/imports/fail2962a.d(6): Error: template instance fail2962.bar4!int error instantiating
+---
+*/
+T bar4(T)(T x)
+{
+    return baz4!(T, x)();
+}
+T baz4(T, T x)()
+{
+    return x;
+}

--- a/test/fail_compilation/imports/fail2962a.d
+++ b/test/fail_compilation/imports/fail2962a.d
@@ -1,0 +1,7 @@
+import fail2962;
+
+// comment 4
+int foo4()
+{
+    return bar4(0);
+}

--- a/test/runnable/ice10086a.d
+++ b/test/runnable/ice10086a.d
@@ -1,0 +1,7 @@
+// EXTRA_SOURCES: imports/ice10086x.d
+// EXTRA_SOURCES: imports/ice10086y.d
+
+import imports.ice10086x;
+import imports.ice10086y;
+
+void main() { test(); }

--- a/test/runnable/ice10086b.d
+++ b/test/runnable/ice10086b.d
@@ -1,0 +1,7 @@
+// EXTRA_SOURCES: imports/ice10086y.d
+// EXTRA_SOURCES: imports/ice10086x.d
+
+import imports.ice10086y;
+import imports.ice10086x;
+
+void main() { test(); }

--- a/test/runnable/ice10857.d
+++ b/test/runnable/ice10857.d
@@ -1,0 +1,3 @@
+// EXTRA_SOURCES: imports/ice10857b.d
+
+import imports.ice10857a;

--- a/test/runnable/ice4481.d
+++ b/test/runnable/ice4481.d
@@ -1,0 +1,11 @@
+// EXTRA_SOURCES: imports/ice4481a.d
+// EXTRA_SOURCES: imports/ice4481b.d
+
+import imports.ice4481a;
+import imports.ice4481b;
+
+void main()
+{
+    auto f = new Font();
+    assert(f.textHeight("str"));
+}

--- a/test/runnable/imports/ice10086x.d
+++ b/test/runnable/imports/ice10086x.d
@@ -1,0 +1,34 @@
+module imports.ice10086x;
+
+import imports.ice10086y;
+
+struct S1
+{
+    int a1 = 123;
+}
+
+@safe auto f1(S1 r)
+{
+    return r;
+}
+
+@safe auto f2a()(S1 r)
+{
+    return bind!(f1, r);
+}
+
+@safe auto f2b(S1 r)
+{
+    return bind!(f1, r);
+}
+
+void test()
+{
+    S1 s1;
+
+    auto za = bind!(f2a, s1)();
+    assert(za.a1 == 123);
+
+    auto zb = bind!(f2b, s1)();
+    assert(zb.a1 == 123);
+}

--- a/test/runnable/imports/ice10086y.d
+++ b/test/runnable/imports/ice10086y.d
@@ -1,0 +1,10 @@
+module imports.ice10086y;
+
+auto bind(alias f, bindValues...)()
+{
+    auto bind(Types...)(Types values)
+    {
+        return f(bindValues, values);
+    }
+    return bind();
+}

--- a/test/runnable/imports/ice10857a.d
+++ b/test/runnable/imports/ice10857a.d
@@ -1,0 +1,19 @@
+module imports.ice10857a;
+
+template filter(alias pred)
+{
+    auto filter(Range)(Range rs)
+    {
+        return FilterResult!(pred, Range)(rs);
+    }
+}
+
+private struct FilterResult(alias pred, R)
+{
+    R _input;
+
+    void popFront()
+    {
+        assert(pred(_input[0]) == 123);
+    }
+}

--- a/test/runnable/imports/ice10857b.d
+++ b/test/runnable/imports/ice10857b.d
@@ -1,0 +1,14 @@
+module imports.ice10857b;
+
+import imports.ice10857a;
+import imports.ice10857b;
+
+void foo(int outer)
+{
+    int[] infos = [1];
+    auto f1 = filter!(s => outer)(infos);     // NG: error is triggered here
+    f1.popFront();
+    auto f2 = filter!((int s)=>outer)(infos); // OK
+    f2.popFront();
+}
+void main() { foo(123); }

--- a/test/runnable/imports/ice4481a.d
+++ b/test/runnable/imports/ice4481a.d
@@ -1,4 +1,4 @@
-module imports.a4481;
+module imports.ice4481a;
 
 template reduce(alias pred)
 {

--- a/test/runnable/imports/ice4481b.d
+++ b/test/runnable/imports/ice4481b.d
@@ -1,11 +1,11 @@
-module imports.b4481;
+module imports.ice4481b;
 
-import imports.a4481;
+import imports.ice4481a;
 
 class Font
 {
 public:
-    int charHeight(dchar c) { return 0; }
+    int charHeight(dchar c) { return c == 's'; }
     int textHeight(in string text)
     {
         auto maxHeight = (dchar ch) { return charHeight(ch); };


### PR DESCRIPTION
[Issue 10086](http://d.puremagic.com/issues/show_bug.cgi?id=10086) - ICE(glue.c) or wrong code on passing variable as template value parameter
[Issue 10857](http://d.puremagic.com/issues/show_bug.cgi?id=10857) - ICE(glue.c,　bugzilla 2962?) or compiles, depending on the files order
