### PR TITLE
10840 CTFE *this._data.arr is not yet implemented

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4824,7 +4824,7 @@ Expression *CondExp::interpret(InterState *istate, CtfeGoal goal)
     Expression *e;
     if ( isPointer(econd->type) )
     {
-        e = econd->interpret(istate, ctfeNeedLvalue);
+        e = econd->interpret(istate);
         if (exceptionOrCantInterpret(e))
             return e;
         if (e->op != TOKnull)
@@ -5704,6 +5704,10 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
         }
         if (ex->op == TOKnull && ex->type->toBasetype()->ty == Tclass)
         {   error("class '%s' is null and cannot be dereferenced", e1->toChars());
+            return EXP_CANT_INTERPRET;
+        }
+        if (ex->op == TOKnull)
+        {   error("dereference of null pointer '%s'", e1->toChars());
             return EXP_CANT_INTERPRET;
         }
         if (ex->op == TOKstructliteral || ex->op == TOKclassreference)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2222,6 +2222,35 @@ bool nullptrcmp()
 static assert(nullptrcmp());
 
 /**************************************************
+ 10840 null pointer in dotvar
+**************************************************/
+
+struct Data10840
+{
+   bool xxx;
+}
+
+struct Bug10840
+{
+    Data10840* _data;
+}
+
+bool bug10840(int n)
+{
+    Bug10840 stack;
+    if (n == 1)
+    {   // detect deref through null pointer
+        return stack._data.xxx;
+    }
+    // Wrong-code for ?:
+    return stack._data ? false : true;
+}
+
+static assert(bug10840(0));
+static assert(!is(typeof(Compileable!(bug10840(1)))));
+
+
+/**************************************************
   8216 ptr inside a pointer range
 **************************************************/
 


### PR DESCRIPTION
This is a wrong-code bug in ? : cond expressions, and a failure to detect null pointers in DotVar expressions.

http://d.puremagic.com/issues/show_bug.cgi?id=10840
