### PR TITLE
Fix lexer/parser bugs to fix Issue 8825

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1597,7 +1597,7 @@ void CompileDeclaration::compileIt(Scope *sc)
     {
         se = se->toUTF8(sc);
         Parser p(sc->module, (utf8_t *)se->string, se->len, 0);
-        p.loc = loc;
+        p.scanloc = loc;
         p.nextToken();
         unsigned errors = global.errors;
         decl = p.parseDeclDefs(0);

--- a/src/expression.c
+++ b/src/expression.c
@@ -7280,7 +7280,7 @@ Expression *CompileExp::semantic(Scope *sc)
     }
     se = se->toUTF8(sc);
     Parser p(sc->module, (utf8_t *)se->string, se->len, 0);
-    p.loc = loc;
+    p.scanloc = loc;
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
     unsigned errors = global.errors;

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4410,14 +4410,17 @@ STATIC OPND *asm_primary_exp()
                 {
                     asm_token();
                     if (tok_value == TOKlparen)
-                    {   unsigned n;
-
+                    {
                         asm_token();
+                        if (tok_value == TOKint32v)
+                        {
+                            unsigned n = (unsigned)asmtok->uns64value;
+                            if (n > 7)
+                                asmerr(EM_bad_operand);
+                            else
+                                o1->base = &(aregFp[n]);
+                        }
                         asm_chktok(TOKint32v, EM_num);
-                        n = (unsigned)asmtok->uns64value;
-                        if (n > 7)
-                            asmerr(EM_bad_operand);
-                        o1->base = &(aregFp[n]);
                         asm_chktok(TOKrparen, EM_rpar);
                     }
                     else

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -226,6 +226,7 @@ enum TOK
 struct Token
 {
     Token *next;
+    Loc loc;
     utf8_t *ptr;         // pointer to first character of this token within buffer
     TOK value;
     utf8_t *blockComment; // doc comment string prior to this token
@@ -269,7 +270,7 @@ public:
     static OutBuffer stringbuffer;
     static Token *freelist;
 
-    Loc loc;                    // for error messages
+    Loc scanloc;                // for error messages
 
     utf8_t *base;        // pointer to start of buffer
     utf8_t *end;         // past end of buffer
@@ -316,8 +317,6 @@ public:
 
     static int isValidIdentifier(char *p);
     static utf8_t *combineComments(utf8_t *c1, utf8_t *c2);
-
-    Loc tokenLoc();
 };
 
 #endif /* DMD_LEXER_H */

--- a/src/mars.c
+++ b/src/mars.c
@@ -461,7 +461,7 @@ void genCmain(Scope *sc)
     Module *m = new Module("__entrypoint.d", id, 0, 0);
 
     Parser p(m, code, sizeof(code) / sizeof(code[0]), 0);
-    p.loc = Loc();
+    p.scanloc = Loc();
     p.nextToken();
     m->members = p.parseModule();
     assert(p.token.value == TOKeof);

--- a/src/module.c
+++ b/src/module.c
@@ -506,7 +506,7 @@ void Module::parse()
     srcfile->len = 0;
 
     md = p.md;
-    numlines = p.loc.linnum;
+    numlines = p.scanloc.linnum;
 
     /* The symbol table into which the module is to be inserted.
      */

--- a/src/parse.c
+++ b/src/parse.c
@@ -1708,13 +1708,13 @@ Dsymbol *Parser::parseAggregate()
 {
     AggregateDeclaration *a = NULL;
     int anon = 0;
-    TOK tok;
     Identifier *id;
     TemplateParameters *tpl = NULL;
     Expression *constraint = NULL;
+    Loc loc = token.loc;
+    TOK tok = token.value;
 
     //printf("Parser::parseAggregate()\n");
-    tok = token.value;
     nextToken();
     if (token.value != TOKidentifier)
     {   id = NULL;
@@ -1732,7 +1732,6 @@ Dsymbol *Parser::parseAggregate()
         }
     }
 
-    Loc loc = token.loc;
     switch (tok)
     {
         case TOKclass:

--- a/src/statement.c
+++ b/src/statement.c
@@ -520,7 +520,7 @@ Statements *CompileStatement::flatten(Scope *sc)
         {
             se = se->toUTF8(sc);
             Parser p(sc->module, (utf8_t *)se->string, se->len, 0);
-            p.loc = loc;
+            p.scanloc = loc;
             p.nextToken();
 
             while (p.token.value != TOKeof)

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -349,7 +349,7 @@
    {
     "name" : "S",
     "kind" : "struct",
-    "line" : 83,
+    "line" : 82,
     "members" : [
      {
       "kind" : "template",
@@ -422,7 +422,7 @@
    {
     "name" : "C_9755",
     "kind" : "class",
-    "line" : 93,
+    "line" : 92,
     "members" : [
      {
       "kind" : "template",

--- a/test/fail_compilation/diag7050c.d
+++ b/test/fail_compilation/diag7050c.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7050c.d(7): Error: safe function 'diag7050c.B.~this' cannot call system function 'diag7050c.A.~this'
+fail_compilation/diag7050c.d(6): Error: safe function 'diag7050c.B.~this' cannot call system function 'diag7050c.A.~this'
 ---
 */
 

--- a/test/fail_compilation/diag8825.d
+++ b/test/fail_compilation/diag8825.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag8825.d(13): Error: undefined identifier foo
+---
+*/
+
+template t(alias a){
+    alias int t;
+}
+
+void main(){
+    t!(foo // line 13
+
+
+
+
+
+    ) i; // line 19
+    return;
+}

--- a/test/fail_compilation/fail9773.d
+++ b/test/fail_compilation/fail9773.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9773.d(8): Error: "" is not an lvalue
+fail_compilation/fail9773.d(7): Error: "" is not an lvalue
 ---
 */
 void f(ref string a = "")


### PR DESCRIPTION
[Issue 8825](http://d.puremagic.com/issues/show_bug.cgi?id=8825) - Wrong line number of error message

Each tokens should have its own 'loc' to hold correct file location, even if it is look-ahead.

Additionally, fixed an iasm parser bug that had not been found.
