### PR TITLE
10610 ICE with CTFE after failed template

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8807,6 +8807,12 @@ L1:
         /* It's:
          *    Class.d
          */
+
+        // If Class is in a failed template, return an error
+        TemplateInstance *tiparent = d->inTemplateInstance();
+        if (tiparent && tiparent->errors)
+            return new ErrorExp();
+
         if (TupleDeclaration *tup = d->isTupleDeclaration())
         {
             e = new TupleExp(e->loc, tup);

--- a/test/fail_compilation/ice10610.d
+++ b/test/fail_compilation/ice10610.d
@@ -1,0 +1,15 @@
+// 10610 CTFE ice
+
+class Bug10610(T)
+{
+    int baz() immutable {
+        return 1;
+    }
+    static immutable(Bug10610!T) min = new Bug10610!T();
+}
+
+void ice10610()
+{
+   alias T10610 = Bug10610!(int);
+   static assert (T10610.min.baz());
+}


### PR DESCRIPTION
This is an error propagation bug. Class.staticmember should become
an ErrorExp, if Class was a failed template instantiation.

http://d.puremagic.com/issues/show_bug.cgi?id=10610
