### PR TITLE
[REG2.064a] Issue 10394 - opBinaryRight!"in" and tuple

### DIFF
--- a/src/opover.c
+++ b/src/opover.c
@@ -549,8 +549,10 @@ Expression *BinExp::op_overload(Scope *sc)
 
         args1.setDim(1);
         args1[0] = e1;
+        expandTuples(&args1);
         args2.setDim(1);
         args2[0] = e2;
+        expandTuples(&args2);
         argsset = 1;
 
         Match m;
@@ -620,10 +622,13 @@ L1:
              */
 
             if (!argsset)
-            {   args1.setDim(1);
+            {
+                args1.setDim(1);
                 args1[0] = e1;
+                expandTuples(&args1);
                 args2.setDim(1);
                 args2[0] = e2;
+                expandTuples(&args2);
             }
 
             Match m;
@@ -769,8 +774,10 @@ Expression *BinExp::compare_overload(Scope *sc, Identifier *id)
 
         args1.setDim(1);
         args1[0] = e1;
+        expandTuples(&args1);
         args2.setDim(1);
         args2[0] = e2;
+        expandTuples(&args2);
 
         Match m;
         memset(&m, 0, sizeof(m));
@@ -1094,6 +1101,7 @@ Expression *BinAssignExp::op_overload(Scope *sc)
 
         args2.setDim(1);
         args2[0] = e2;
+        expandTuples(&args2);
 
         Match m;
         memset(&m, 0, sizeof(m));

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1208,6 +1208,35 @@ void test10064()
 }
 
 /**************************************/
+// 10394
+
+void test10394()
+{
+    alias Seq!(int, int) Pair;
+    Pair pair;
+
+    struct S1
+    {
+        int opBinary(string op)(Pair) { return 1;  }
+        bool opEquals(Pair) { return true; }
+        int opOpAssign(string op)(Pair) { return 1; }
+    }
+    S1 s1;
+    assert((s1 + pair) == 1);
+    assert((s1 == pair) == true);
+    assert((s1 *= pair) == 1);
+
+    struct S2
+    {
+        int opBinaryRight(string op)(Pair lhs) { return 1;  }
+        int opCmp(Pair) { return -1; }
+    }
+    S2 s2;
+    assert((pair in s2) == 1);
+    assert(s2 < pair);
+}
+
+/**************************************/
 // 10597
 
 struct R10597
@@ -1397,6 +1426,7 @@ int main()
     test9689();
     test9694();
     test10064();
+    test10394();
     test10567();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10394

Allow using built-in tuple on both of the binary operators and the right hand side of binary-assign operators in operator overloading. 

I don't know whether it was explicitly allowed or not, but historically it has been accepted.
However in 2.064dev, unintentionally, that was changed to not-accepted
by [this change](https://github.com/D-Programming-Language/dmd/commit/391addfda30738089ca220f0d9f025e3842deb1f#L0R2250).

This change implements the same behavior with 2.063 to fix a _regression_. But I still have a doubt that this should be allowed in spec.
