### PR TITLE
[enh] fix issue 9640 - Add #line overload to restore natural line numbering / module name

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -270,6 +270,7 @@ public:
     static Token *freelist;
 
     Loc scanloc;                // for error messages
+    Loc trueloc;         // cannot be changed using #line
 
     const utf8_t *base;        // pointer to start of buffer
     const utf8_t *end;         // past end of buffer

--- a/test/compilable/test9640.d
+++ b/test/compilable/test9640.d
@@ -1,0 +1,32 @@
+enum file = __FILE__;
+
+#line 1 "a"
+static assert(__LINE__ == 1);
+static assert(__FILE__ == "a");
+
+#line 3
+#line 10 "b"
+static assert(__LINE__ == 10);
+static assert(__FILE__ == "b");
+
+#line 17
+static assert(__LINE__ == 17);
+static assert(__FILE__ == "b");
+
+#line
+static assert(__LINE__ == 24);
+static assert(__FILE__ == file);
+
+#line
+static assert(__LINE__ == 28);
+static assert(__FILE__ == file);
+
+#line 42
+static assert(__LINE__ == 42);
+static assert(__FILE__ == file);
+
+#line
+static assert(__LINE__ == 36);
+static assert(__FILE__ == file);
+
+void main() { }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9640
