### PR TITLE
Build Win32 DMD as Large Address Aware.

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -273,13 +273,13 @@ release:
 	$(DMDMAKE) clean
 
 debdmd:
-	$(DMDMAKE) "OPT=" "DEBUG=-D -g -DUNITTEST" "LFLAGS=-L/ma/co" $(TARGETEXE)
+	$(DMDMAKE) "OPT=" "DEBUG=-D -g -DUNITTEST" "LFLAGS=-L/ma/co/la" $(TARGETEXE)
 
 reldmd:
-	$(DMDMAKE) "OPT=-o" "DEBUG=" "LFLAGS=-L/delexe" $(TARGETEXE)
+	$(DMDMAKE) "OPT=-o" "DEBUG=" "LFLAGS=-L/delexe/la" $(TARGETEXE)
 
 trace:
-	$(DMDMAKE) "OPT=-o" "DEBUG=-gt -Nc" "LFLAGS=-L/ma/co/delexe" $(TARGETEXE)
+	$(DMDMAKE) "OPT=-o" "DEBUG=-gt -Nc" "LFLAGS=-L/ma/co/delexe/la" $(TARGETEXE)
 
 ################################ Libraries ##################################
 


### PR DESCRIPTION
This allows Win32 DMD to use more than 2GB on 64-bit Windows (http://support.microsoft.com/default.aspx?scid=889654), which has become necessary for building Phobos, as well as other larger projects.

This requires the latest master of OPTLINK ([this commit](https://github.com/DigitalMars/optlink/commit/475bc5c1fa28eaf899ba4ac1dcfe2ab415db16c6) or newer). For convenience, I've posted a [pre-built OPTLINK](http://semitwist.com/download/app/optlink-laa.zip) and [a wiki page for manually building OPTLINK](http://wiki.dlang.org/Building_OPTLINK).
