### PR TITLE
Issue 10630 - Structs with disabled default construction can't be used as `out` parameters

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5705,6 +5705,8 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
 
             Type *t = fparam->type->toBasetype();
 
+            if (!(fparam->storageClass & STClazy) && t->ty == Tvoid)
+                error(loc, "cannot have parameter of type %s", fparam->type->toChars());
             if (fparam->storageClass & (STCout | STCref | STClazy))
             {
                 //if (t->ty == Tsarray)
@@ -5712,8 +5714,6 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 if (fparam->storageClass & STCout && fparam->type->mod & (STCconst | STCimmutable))
                     error(loc, "cannot have const or immutable out parameter of type %s", t->toChars());
             }
-            if (!(fparam->storageClass & STClazy) && t->ty == Tvoid)
-                error(loc, "cannot have parameter of type %s", fparam->type->toChars());
 
             if (t->hasWild() &&
                 !(t->ty == Tpointer && t->nextOf()->ty == Tfunction || t->ty == Tdelegate))

--- a/test/fail_compilation/fail10115.d
+++ b/test/fail_compilation/fail10115.d
@@ -1,12 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10115.d(40): Error: struct fail10115.S default construction is disabled
-fail_compilation/fail10115.d(41): Error: struct fail10115.S default construction is disabled
-fail_compilation/fail10115.d(42): Error: union fail10115.U default construction is disabled
-fail_compilation/fail10115.d(45): Error: struct fail10115.S default construction is disabled
-fail_compilation/fail10115.d(46): Error: struct fail10115.S default construction is disabled
-fail_compilation/fail10115.d(47): Error: union fail10115.U default construction is disabled
+fail_compilation/fail10115.d(38): Error: cannot have out parameter of type S because the default construction is disbaled
+fail_compilation/fail10115.d(38): Error: cannot have out parameter of type E because the default construction is disbaled
+fail_compilation/fail10115.d(38): Error: cannot have out parameter of type U because the default construction is disbaled
+fail_compilation/fail10115.d(43): Error: struct fail10115.S default construction is disabled
+fail_compilation/fail10115.d(44): Error: struct fail10115.S default construction is disabled
+fail_compilation/fail10115.d(45): Error: union fail10115.U default construction is disabled
+fail_compilation/fail10115.d(48): Error: struct fail10115.S default construction is disabled
+fail_compilation/fail10115.d(49): Error: struct fail10115.S default construction is disabled
+fail_compilation/fail10115.d(50): Error: union fail10115.U default construction is disabled
 ---
 */
 
@@ -30,10 +33,10 @@ union U
     ~this() { assert (s.a !is 0); }
 }
 
-void foo(out S s, out E e, out U u) { }
-
 void main()
 {
+    void foo(out S s, out E e, out U u) { }
+
     S[] a;
     E[] e;
     U[] u;

--- a/test/fail_compilation/fail10630.d
+++ b/test/fail_compilation/fail10630.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10630.d(12): Error: cannot have out parameter of type S because the default construction is disbaled
+---
+*/
+
+struct S
+{
+    @disable this();
+}
+void foo(out S) {}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10630

`out` parameter with disabled default construction struct should report error on function declaration.
