### PR TITLE
[LDC] Add TypeFunction::sym

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -98,6 +98,13 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     flags = 0;
 #endif
     returns = NULL;
+    if (type)
+    {
+        assert(type->ty == Tfunction && "invalid function type");
+        TypeFunction *tf = (TypeFunction*)type;
+        if (tf->sym == NULL)
+            tf->sym = this;
+    }
 }
 
 Dsymbol *FuncDeclaration::syntaxCopy(Dsymbol *s)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5125,6 +5125,7 @@ TypeFunction::TypeFunction(Parameters *parameters, Type *treturn, int varargs, L
     this->isref = false;
     this->iswild = false;
     this->fargs = NULL;
+    this->sym = NULL;
 
     if (stc & STCpure)
         this->purity = PUREfwdref;
@@ -6262,6 +6263,7 @@ Type *TypeFunction::addStorageClass(StorageClass stc)
         tf->isref = t->isref;
         tf->trust = t->trust;
         tf->iswild = t->iswild;
+        tf->sym = t->sym;
 
         if (stc & STCpure)
             tf->purity = PUREfwdref;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -656,6 +656,7 @@ class TypeFunction : public TypeNext
 public:
     // .next is the return type
 
+    FuncDeclaration *sym;
     Parameters *parameters;     // function parameters
     int varargs;        // 1: T t, ...) style for variable number of arguments
                         // 2: T t ...) style for variable number of arguments


### PR DESCRIPTION
There are a few cases when TypeFunction::sym is used by LDC backend, but most important one that could not be avoided is when determining what kind of context pointer a function type has.
