### PR TITLE
Issue 9565 - Index of static array should not print literal suffix

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -47,6 +47,7 @@
 #include "hdrgen.h"
 
 FuncDeclaration *hasThis(Scope *sc);
+void sizeToCBuffer(OutBuffer *buf, HdrGenState *hgs, Expression *e);
 
 #define LOGDOTEXP       0       // log ::dotExp()
 #define LOGDEFAULTINIT  0       // log ::defaultInit()
@@ -4099,7 +4100,9 @@ void TypeSArray::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
         return;
     }
     next->toCBuffer2(buf, hgs, this->mod);
-    buf->printf("[%s]", dim->toChars());
+    buf->writeByte('[');
+    sizeToCBuffer(buf, hgs, dim);
+    buf->writeByte(']');
 }
 
 Expression *TypeSArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag)
@@ -9392,8 +9395,11 @@ void TypeSlice::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
     }
     next->toCBuffer2(buf, hgs, this->mod);
 
-    buf->printf("[%s .. ", lwr->toChars());
-    buf->printf("%s]", upr->toChars());
+    buf->writeByte('[');
+    sizeToCBuffer(buf, hgs, lwr);
+    buf->writestring(" .. ");
+    sizeToCBuffer(buf, hgs, upr);
+    buf->writeByte(']');
 }
 
 /***************************** TypeNull *****************************/

--- a/test/compilable/test9565.d
+++ b/test/compilable/test9565.d
@@ -1,0 +1,86 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+template TypeTuple(T...) { alias TypeTuple = T; }
+
+bool startsWith(string s, string m) { return s[0 .. m.length] == m; }
+
+void main()
+{
+    enum string castPrefix = "cast(" ~ size_t.stringof ~ ")";
+
+    // TypeSArray
+    static assert((int[10]).stringof == "int[10]", T.stringof);
+
+    int[] arr;
+
+    // IndexExp
+    {
+        // index == IntegerExp
+        static assert((arr[ 4  ]).stringof == "arr[4]");
+        static assert((arr[ 4U ]).stringof == "arr[4]");
+        static assert((arr[ 4L ]).stringof == "arr[4]");
+        static assert((arr[ 4LU]).stringof == "arr[4]");
+
+        // index == UAddExp
+        static assert((arr[+4  ]).stringof == "arr[4]");
+        static assert((arr[+4U ]).stringof == "arr[4]");
+        static assert((arr[+4L ]).stringof == "arr[4]");
+        static assert((arr[+4LU]).stringof == "arr[4]");
+
+        // index == NegExp
+        static assert((arr[-4  ]).stringof == "arr[" ~ castPrefix ~ "-4]");
+        static assert((arr[-4U ]).stringof == "arr[4294967292]");
+        static assert((arr[int.min] ).stringof == "arr[" ~ castPrefix ~ "-2147483648]");
+      static if (is(size_t == ulong))
+      {
+        static assert((arr[-4L ]).stringof == "arr[" ~ castPrefix ~ "-4L]");
+        static assert((arr[-4LU]).stringof == "arr[-4LU]");
+
+        // IntegerLiteral needs suffix if the value is greater than long.max
+        static assert((arr[long.max + 0]).stringof == "arr[9223372036854775807]");
+        static assert((arr[long.max + 1]).stringof == "arr[" ~ castPrefix ~ "(9223372036854775807L + 1L)]");
+      }
+
+        foreach (Int; TypeTuple!(byte, ubyte, short, ushort, int, uint, long, ulong))
+        {
+            enum Int p4 = +4;
+            enum string result1 = (arr[p4]).stringof;
+            static assert(result1 == "arr[4]");
+
+            enum string result2 = (arr[cast(Int)+4]).stringof;
+            static assert(result2 == "arr[4]");
+        }
+        foreach (Int; TypeTuple!(byte, short, int, long))
+        {
+            // keep "cast(Type)" in the string representation
+
+            enum Int m4 = -4;
+            static if (is(typeof({ size_t x = m4; })))
+            {
+                enum string result1 = (arr[m4]).stringof;
+                static assert(result1.startsWith("arr[" ~ castPrefix));
+            }
+            else
+                static assert(!__traits(compiles, arr[m4]));
+
+            enum string result2 = (arr[cast(Int)-4]).stringof;
+            static assert(result2.startsWith("arr[" ~ castPrefix));
+        }
+    }
+
+    // SliceExp
+    {
+        // lwr,upr == IntegerExp
+        static assert((arr[4   .. 8  ]).stringof == "arr[4..8]");
+        static assert((arr[4U  .. 8U ]).stringof == "arr[4..8]");
+        static assert((arr[4L  .. 8L ]).stringof == "arr[4..8]");
+        static assert((arr[4LU .. 8LU]).stringof == "arr[4..8]");
+
+        // lwr,upr == UAddExp
+        static assert((arr[+4   .. +8  ]).stringof == "arr[4..8]");
+        static assert((arr[+4U  .. +8U ]).stringof == "arr[4..8]");
+        static assert((arr[+4L  .. +8L ]).stringof == "arr[4..8]");
+        static assert((arr[+4LU .. +8LU]).stringof == "arr[4..8]");
+    }
+}

--- a/test/fail_compilation/diag7420.d
+++ b/test/fail_compilation/diag7420.d
@@ -9,9 +9,9 @@ fail_compilation/diag7420.d(4):        while evaluating: static assert(y == "abc
 fail_compilation/diag7420.d(5): Error: static variable y cannot be read at compile time
 fail_compilation/diag7420.d(5):        while evaluating: static assert(cast(ubyte[])y != null)
 fail_compilation/diag7420.d(6): Error: static variable y cannot be read at compile time
-fail_compilation/diag7420.d(6):        while evaluating: static assert(cast(int)y[0u] == 1)
+fail_compilation/diag7420.d(6):        while evaluating: static assert(cast(int)y[0] == 1)
 fail_compilation/diag7420.d(7): Error: static variable y cannot be read at compile time
-fail_compilation/diag7420.d(7):        while evaluating: static assert(y[0u..1u].length == 1u)
+fail_compilation/diag7420.d(7):        while evaluating: static assert(y[0..1].length == 1u)
 ---
 */
 

--- a/test/fail_compilation/diag8892.d
+++ b/test/fail_compilation/diag8892.d
@@ -1,8 +1,7 @@
-// REQUIRED_ARGS: -m32
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8892.d(15): Error: cannot implicitly convert expression (['A']) of type char[] to char[2u]
+fail_compilation/diag8892.d(14): Error: cannot implicitly convert expression (['A']) of type char[] to char[2]
 ---
 */
 struct Foo

--- a/test/fail_compilation/fail10102.d
+++ b/test/fail_compilation/fail10102.d
@@ -2,12 +2,12 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail10102.d(48): Error: variable fail10102.main.m initializer required for type NotNull!(int*)
-fail_compilation/fail10102.d(49): Error: variable fail10102.main.a initializer required for type NotNull!(int*)[3u]
+fail_compilation/fail10102.d(49): Error: variable fail10102.main.a initializer required for type NotNull!(int*)[3]
 fail_compilation/fail10102.d(50): Error: default construction is disabled for type NotNull!(int*)
 fail_compilation/fail10102.d(51): Error: field S.m must be initialized because it has no default constructor
 ---
 */
-// REQUIRED_ARGS: -m32
+
 struct NotNull(T)
 {
     T p;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9565

Static array type index is always size_t, so unnecessary suffix is harmful for platform independent diagnostic message.
(Note that: In 64bit platform, size_t is ulong, and if the value is greater than `long.max`, suffix is _necessary_.)

Same problem exists in `IndexExp` and `SliceExp` printing.
