### PR TITLE
[REG2.063] Issue 10573 - Weird linking problem with associative array cast

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9986,6 +9986,16 @@ Expression *CastExp::semantic(Scope *sc)
     }
 
 Lsafe:
+#if DMDV2
+    /* Instantiate AA implementations during semantic analysis.
+     */
+    Type *tfrom = e1->type->toBasetype();
+    Type *t = to->toBasetype();
+    if (tfrom->ty == Taarray)
+        ((TypeAArray *)tfrom)->getImpl();
+    if (t->ty == Taarray)
+        ((TypeAArray *)t)->getImpl();
+#endif
     Expression *e = e1->castTo(sc, to);
     return e;
 }

--- a/test/runnable/imports/test10573a.d
+++ b/test/runnable/imports/test10573a.d
@@ -1,0 +1,13 @@
+module imports.test10573a;
+
+abstract class base {}
+class mysql : base {}
+
+class handler
+{
+    private mysql[int] mysql_servers;
+    public void foo()
+    {
+        base[int] hServers = cast(base[int])mysql_servers;
+    }
+}

--- a/test/runnable/test10573.d
+++ b/test/runnable/test10573.d
@@ -1,0 +1,4 @@
+// EXTRA_SOURCES: imports/test10573a.d
+
+import imports.test10573a;
+void main(string[] args) {}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10573

CastExp would call `TypeAArray::getImpl()` in glue layer.

However if the AA type is just only used in the cast expression, the timing is too late to invoke `getImpl`, because the AA type instantiation may need more semantic analysis like deferred semantic3.

For the correct instantiation of the `AssociativeArray!(K, V)` type, `getImpl` should be invoked in front-end layer beforehand.
