### PR TITLE
[REG2.063] Issue 10964 - Static array assign/blit exception slips through catch block

### DIFF
--- a/src/canthrow.c
+++ b/src/canthrow.c
@@ -56,14 +56,15 @@ int lambdaCanThrow(Expression *e, void *param)
     switch (e->op)
     {
         case TOKdeclaration:
-        {   DeclarationExp *de = (DeclarationExp *)e;
+        {
+            DeclarationExp *de = (DeclarationExp *)e;
             pct->can = Dsymbol_canThrow(de->declaration, pct->mustnot);
             break;
         }
 
         case TOKcall:
-        {   CallExp *ce = (CallExp *)e;
-
+        {
+            CallExp *ce = (CallExp *)e;
             if (global.errors && !ce->e1->type)
                 break;                       // error recovery
 
@@ -86,7 +87,8 @@ int lambdaCanThrow(Expression *e, void *param)
         }
 
         case TOKnew:
-        {   NewExp *ne = (NewExp *)e;
+        {
+            NewExp *ne = (NewExp *)e;
             if (ne->member)
             {
                 // See if constructor call can throw
@@ -99,6 +101,33 @@ int lambdaCanThrow(Expression *e, void *param)
                 }
             }
             // regard storage allocation failures as not recoverable
+            break;
+        }
+
+        case TOKassign:
+        case TOKconstruct:
+        {
+            /* Element-wise assignment could invoke postblits.
+             */
+            AssignExp *ae = (AssignExp *)e;
+            if (ae->e1->op != TOKslice)
+                break;
+
+            Type *tv = ae->e1->type->toBasetype()->nextOf()->baseElemOf();
+            if (tv->ty != Tstruct)
+                break;
+            StructDeclaration *sd = ((TypeStruct *)tv)->sym;
+            if (!sd->postblit || sd->postblit->type->ty != Tfunction)
+                break;
+
+            if (((TypeFunction *)sd->postblit->type)->isnothrow)
+                ;
+            else
+            {
+                if (pct->mustnot)
+                    e->error("'%s' is not nothrow", sd->postblit->toPrettyChars());
+                pct->can = TRUE;
+            }
             break;
         }
 

--- a/src/clone.c
+++ b/src/clone.c
@@ -135,13 +135,10 @@ int StructDeclaration::needOpAssign()
         assert(v && v->isField());
         if (v->storage_class & STCref)
             continue;
-        Type *tv = v->type->toBasetype();
-        while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
-            tv = tv->nextOf()->toBasetype();
-        }
+        Type *tv = v->type->baseElemOf();
         if (tv->ty == Tstruct)
-        {   TypeStruct *ts = (TypeStruct *)tv;
+        {
+            TypeStruct *ts = (TypeStruct *)tv;
             StructDeclaration *sd = ts->sym;
             if (sd->needOpAssign())
                 goto Lneed;
@@ -210,13 +207,10 @@ FuncDeclaration *StructDeclaration::buildOpAssign(Scope *sc)
             assert(v && v->isField());
             if (v->storage_class & STCref)
                 continue;
-            Type *tv = v->type->toBasetype();
-            while (tv->ty == Tsarray)
-            {   TypeSArray *ta = (TypeSArray *)tv;
-                tv = tv->nextOf()->toBasetype();
-            }
+            Type *tv = v->type->baseElemOf();
             if (tv->ty == Tstruct)
-            {   TypeStruct *ts = (TypeStruct *)tv;
+            {
+                TypeStruct *ts = (TypeStruct *)tv;
                 StructDeclaration *sd = ts->sym;
                 if (FuncDeclaration *f = sd->hasIdentityOpAssign(sc))
                     stc = mergeFuncAttrs(stc, f->storage_class);
@@ -380,12 +374,10 @@ int StructDeclaration::needOpEquals()
             goto Lneed;
         if (tv->ty == Tclass)
             goto Lneed;
-        while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
-            tv = tv->nextOf()->toBasetype();
-        }
+        tv = tv->baseElemOf();
         if (tv->ty == Tstruct)
-        {   TypeStruct *ts = (TypeStruct *)tv;
+        {
+            TypeStruct *ts = (TypeStruct *)tv;
             StructDeclaration *sd = ts->sym;
             if (sd->needOpEquals())
                 goto Lneed;
@@ -785,12 +777,14 @@ FuncDeclaration *StructDeclaration::buildPostBlit(Scope *sc)
         Type *tv = v->type->toBasetype();
         dinteger_t dim = 1;
         while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
-            dim *= ((TypeSArray *)tv)->dim->toInteger();
-            tv = tv->nextOf()->toBasetype();
+        {
+            TypeSArray *tsa = (TypeSArray *)tv;
+            dim *= tsa->dim->toInteger();
+            tv = tsa->next->toBasetype();
         }
         if (tv->ty == Tstruct)
-        {   TypeStruct *ts = (TypeStruct *)tv;
+        {
+            TypeStruct *ts = (TypeStruct *)tv;
             StructDeclaration *sd = ts->sym;
             if (sd->postblit && dim)
             {
@@ -899,12 +893,14 @@ FuncDeclaration *AggregateDeclaration::buildDtor(Scope *sc)
         Type *tv = v->type->toBasetype();
         dinteger_t dim = 1;
         while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
-            dim *= ((TypeSArray *)tv)->dim->toInteger();
-            tv = tv->nextOf()->toBasetype();
+        {
+            TypeSArray *tsa = (TypeSArray *)tv;
+            dim *= tsa->dim->toInteger();
+            tv = tsa->next->toBasetype();
         }
         if (tv->ty == Tstruct)
-        {   TypeStruct *ts = (TypeStruct *)tv;
+        {
+            TypeStruct *ts = (TypeStruct *)tv;
             StructDeclaration *sd = ts->sym;
             if (sd->dtor && dim)
             {

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -962,9 +962,7 @@ void VarDeclaration::semantic(Scope *sc)
     FuncDeclaration *fd = parent->isFuncDeclaration();
 
     Type *tb = type->toBasetype();
-    Type *tbn = tb;
-    while (tbn->ty == Tsarray)
-        tbn = tbn->nextOf()->toBasetype();
+    Type *tbn = tb->baseElemOf();
     if (tb->ty == Tvoid && !(storage_class & STClazy))
     {
         if (inferred)
@@ -1863,11 +1861,7 @@ void VarDeclaration::setFieldOffset(AggregateDeclaration *ad, unsigned *poffset,
     }
     if (t->ty == Tstruct || t->ty == Tsarray)
     {
-        Type *tv = t;
-        while (tv->ty == Tsarray)
-        {
-            tv = tv->nextOf()->toBasetype();
-        }
+        Type *tv = t->baseElemOf();
         if (tv->ty == Tstruct)
         {
             TypeStruct *ts = (TypeStruct *)tv;
@@ -2252,19 +2246,14 @@ Expression *VarDeclaration::callScopeDtor(Scope *sc)
     }
 
     // Destructors for structs and arrays of structs
-    bool array = false;
-    Type *tv = type->toBasetype();
-    while (tv->ty == Tsarray)
-    {   TypeSArray *ta = (TypeSArray *)tv;
-        array = true;
-        tv = tv->nextOf()->toBasetype();
-    }
+    Type *tv = type->baseElemOf();
     if (tv->ty == Tstruct)
-    {   TypeStruct *ts = (TypeStruct *)tv;
+    {
+        TypeStruct *ts = (TypeStruct *)tv;
         StructDeclaration *sd = ts->sym;
         if (sd->dtor)
         {
-            if (array)
+            if (type->toBasetype()->ty == Tsarray)
             {
                 // Typeinfo.destroy(cast(void*)&v);
                 Expression *ea = new SymOffExp(loc, this, 0, 0);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -616,11 +616,10 @@ elem *sarray_toDarray(Loc loc, Type *tfrom, Type *tto, elem *e)
 
 StructDeclaration *needsPostblit(Type *t)
 {
-    t = t->toBasetype();
-    while (t->ty == Tsarray)
-        t = t->nextOf()->toBasetype();
+    t = t->baseElemOf();
     if (t->ty == Tstruct)
-    {   StructDeclaration *sd = ((TypeStruct *)t)->sym;
+    {
+        StructDeclaration *sd = ((TypeStruct *)t)->sym;
         if (sd->postblit)
             return sd;
     }
@@ -3977,13 +3976,10 @@ elem *DeleteExp::toElem(IRState *irs)
             /* See if we need to run destructors on the array contents
              */
             elem *et = NULL;
-            Type *tv = tb->nextOf()->toBasetype();
-            while (tv->ty == Tsarray)
-            {   TypeSArray *ta = (TypeSArray *)tv;
-                tv = tv->nextOf()->toBasetype();
-            }
+            Type *tv = tb->nextOf()->baseElemOf();
             if (tv->ty == Tstruct)
-            {   TypeStruct *ts = (TypeStruct *)tv;
+            {
+                TypeStruct *ts = (TypeStruct *)tv;
                 StructDeclaration *sd = ts->sym;
                 if (sd->dtor)
                     et = tb->nextOf()->getTypeInfo(NULL)->toElem(irs);

--- a/src/expression.h
+++ b/src/expression.h
@@ -86,7 +86,6 @@ int modifyFieldVar(Loc loc, Scope *sc, VarDeclaration *var, Expression *e1);
 #if DMDV2
 Expression *resolveAliasThis(Scope *sc, Expression *e);
 Expression *callCpCtor(Scope *sc, Expression *e);
-bool checkPostblit(Loc loc, Type *t);
 #endif
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae);
 Expression *resolveOpDollar(Scope *sc, SliceExp *se);
@@ -169,6 +168,7 @@ public:
     void checkPurity(Scope *sc, FuncDeclaration *f);
     void checkPurity(Scope *sc, VarDeclaration *v, Expression *e1);
     void checkSafety(Scope *sc, FuncDeclaration *f);
+    bool checkPostblit(Scope *sc, Type *t);
     virtual int checkModifiable(Scope *sc, int flag = 0);
     virtual Expression *checkToBoolean(Scope *sc);
     virtual Expression *addDtorHook(Scope *sc);

--- a/src/func.c
+++ b/src/func.c
@@ -3220,12 +3220,7 @@ bool FuncDeclaration::setUnsafe()
 
 Type *getIndirection(Type *t)
 {
-    t = t->toBasetype();
-
-    if (t->ty == Tsarray)
-    {   while (t->ty == Tsarray)
-            t = t->nextOf()->toBasetype();
-    }
+    t = t->baseElemOf();
     if (t->ty == Tarray || t->ty == Tpointer)
         return t->nextOf()->toBasetype();
     if (t->ty == Taarray || t->ty == Tclass)
@@ -3276,10 +3271,7 @@ int traverseIndirections(Type *ta, Type *tb, void *p = NULL, bool a2b = true)
     if (tbb != tb)
         return traverseIndirections(ta, tbb, ctxt, a2b);
 
-    if (tb->ty == Tsarray)
-    {   while (tb->toBasetype()->ty == Tsarray)
-            tb = tb->toBasetype()->nextOf();
-    }
+    tb = tb->baseElemOf();
     if (tb->ty == Tclass || tb->ty == Tstruct)
     {
         for (Ctxt *c = ctxt; c; c = c->prev)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2380,6 +2380,18 @@ Type *Type::nextOf()
     return NULL;
 }
 
+/*************************************
+ * If this is a type of static array, return its base element type.
+ */
+
+Type *Type::baseElemOf()
+{
+    Type *t = toBasetype();
+    while (t->ty == Tsarray)
+        t = ((TypeSArray *)t)->next->toBasetype();
+    return t;
+}
+
 /****************************************
  * Return the mask that an integral type will
  * fit into.

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -332,6 +332,7 @@ public:
     virtual int hasPointers();
     virtual TypeTuple *toArgTypes();
     virtual Type *nextOf();
+    Type *baseElemOf();
     uinteger_t sizemask();
     virtual int needsDestruction();
     virtual bool needsNested();

--- a/src/struct.c
+++ b/src/struct.c
@@ -863,13 +863,10 @@ bool StructDeclaration::isPOD()
         assert(v && v->isField());
         if (v->storage_class & STCref)
             continue;
-        Type *tv = v->type->toBasetype();
-        while (tv->ty == Tsarray)
-        {   TypeSArray *ta = (TypeSArray *)tv;
-            tv = tv->nextOf()->toBasetype();
-        }
+        Type *tv = v->type->baseElemOf();
         if (tv->ty == Tstruct)
-        {   TypeStruct *ts = (TypeStruct *)tv;
+        {
+            TypeStruct *ts = (TypeStruct *)tv;
             StructDeclaration *sd = ts->sym;
             if (!sd->isPOD())
                 return false;

--- a/src/todt.c
+++ b/src/todt.c
@@ -893,8 +893,8 @@ dt_t **TypeSArray::toDtElem(dt_t **pdt, Expression *e)
         Type *tnext = next;
         Type *tbn = tnext->toBasetype();
         while (tbn->ty == Tsarray && (!e || tbn != e->type->nextOf()))
-        {   TypeSArray *tsa = (TypeSArray *)tbn;
-
+        {
+            TypeSArray *tsa = (TypeSArray *)tbn;
             len *= tsa->dim->toInteger();
             tnext = tbn->nextOf();
             tbn = tnext->toBasetype();

--- a/src/toir.c
+++ b/src/toir.c
@@ -853,22 +853,17 @@ RET TypeFunction::retStyle()
     Type *tns = tn;
 
     if (global.params.isWindows && global.params.is64bit)
-    {   // http://msdn.microsoft.com/en-us/library/7572ztz4(v=vs.80)
+    {
+        // http://msdn.microsoft.com/en-us/library/7572ztz4(v=vs.80)
         if (tns->ty == Tcomplex32)
             return RETstack;
         if (tns->isscalar())
             return RETregs;
 
-        if (tns->ty == Tsarray)
-        {
-            do
-            {
-                tns = tns->nextOf()->toBasetype();
-            } while (tns->ty == Tsarray);
-        }
-
+        tns = tns->baseElemOf();
         if (tns->ty == Tstruct)
-        {   StructDeclaration *sd = ((TypeStruct *)tns)->sym;
+        {
+            StructDeclaration *sd = ((TypeStruct *)tns)->sym;
             if (!sd->isPOD() || sz >= 8)
                 return RETstack;
         }
@@ -880,11 +875,7 @@ RET TypeFunction::retStyle()
 Lagain:
     if (tns->ty == Tsarray)
     {
-        do
-        {
-            tns = tns->nextOf()->toBasetype();
-        } while (tns->ty == Tsarray);
-
+        tns = tns->baseElemOf();
         if (tns->ty != Tstruct)
         {
 L2:

--- a/test/fail_compilation/fail10964.d
+++ b/test/fail_compilation/fail10964.d
@@ -1,0 +1,36 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10964.d(28): Error: 'fail10964.S.__cpctor' is not nothrow
+fail_compilation/fail10964.d(29): Error: 'fail10964.S.__postblit' is not nothrow
+fail_compilation/fail10964.d(30): Error: 'fail10964.S.__postblit' is not nothrow
+fail_compilation/fail10964.d(33): Error: 'fail10964.S.__cpctor' is not nothrow
+fail_compilation/fail10964.d(34): Error: 'fail10964.S.__postblit' is not nothrow
+fail_compilation/fail10964.d(35): Error: 'fail10964.S.__postblit' is not nothrow
+fail_compilation/fail10964.d(22): Error: function 'fail10964.foo' is nothrow yet may throw
+---
+*/
+
+struct S
+{
+    this(this)
+    {
+        throw new Exception("BOOM!");
+    }
+}
+
+void foo() nothrow
+{
+    S    ss;
+    S[1] sa;
+
+    // TOKassign
+    ss = ss;
+    sa = ss;
+    sa = sa;
+
+    // TOKconstruct
+    S    ss2 = ss;
+    S[1] sa2 = ss;
+    S[1] sa3 = sa;
+}

--- a/test/fail_compilation/fail10968.d
+++ b/test/fail_compilation/fail10968.d
@@ -1,0 +1,74 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10968.d(33): Error: pure function 'fail10968.bar' cannot call impure function 'fail10968.SA.__cpctor'
+fail_compilation/fail10968.d(33): Error: safe function 'fail10968.bar' cannot call system function 'fail10968.SA.__cpctor'
+fail_compilation/fail10968.d(34): Error: pure function 'fail10968.bar' cannot call impure function 'fail10968.SA.__postblit'
+fail_compilation/fail10968.d(34): Error: safe function 'fail10968.bar' cannot call system function 'fail10968.SA.__postblit'
+fail_compilation/fail10968.d(35): Error: pure function 'fail10968.bar' cannot call impure function 'fail10968.SA.__postblit'
+fail_compilation/fail10968.d(35): Error: safe function 'fail10968.bar' cannot call system function 'fail10968.SA.__postblit'
+fail_compilation/fail10968.d(38): Error: pure function 'fail10968.bar' cannot call impure function 'fail10968.SA.__cpctor'
+fail_compilation/fail10968.d(38): Error: safe function 'fail10968.bar' cannot call system function 'fail10968.SA.__cpctor'
+fail_compilation/fail10968.d(39): Error: pure function 'fail10968.bar' cannot call impure function 'fail10968.SA.__postblit'
+fail_compilation/fail10968.d(39): Error: safe function 'fail10968.bar' cannot call system function 'fail10968.SA.__postblit'
+fail_compilation/fail10968.d(40): Error: pure function 'fail10968.bar' cannot call impure function 'fail10968.SA.__postblit'
+fail_compilation/fail10968.d(40): Error: safe function 'fail10968.bar' cannot call system function 'fail10968.SA.__postblit'
+---
+*/
+
+struct SA
+{
+    this(this)
+    {
+        throw new Exception("BOOM!");
+    }
+}
+
+void bar() pure @safe
+{
+    SA    ss;
+    SA[1] sa;
+
+    // TOKassign
+    ss = ss;
+    sa = ss;
+    sa = sa;
+
+    // TOKconstruct
+    SA    ss2 = ss;
+    SA[1] sa2 = ss;
+    SA[1] sa3 = sa;
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10968.d(66): Error: struct fail10968.SD is not copyable because it is annotated with @disable
+fail_compilation/fail10968.d(67): Error: struct fail10968.SD is not copyable because it is annotated with @disable
+fail_compilation/fail10968.d(68): Error: struct fail10968.SD is not copyable because it is annotated with @disable
+fail_compilation/fail10968.d(71): Error: struct fail10968.SD is not copyable because it is annotated with @disable
+fail_compilation/fail10968.d(72): Error: struct fail10968.SD is not copyable because it is annotated with @disable
+fail_compilation/fail10968.d(73): Error: struct fail10968.SD is not copyable because it is annotated with @disable
+---
+*/
+
+struct SD
+{
+    this(this) @disable;
+}
+
+void baz()
+{
+    SD    ss;
+    SD[1] sa;
+
+    // TOKassign
+    ss = ss;
+    sa = ss;
+    sa = sa;
+
+    // TOKconstruct
+    SD    ss2 = ss;
+    SD[1] sa2 = ss;
+    SD[1] sa3 = sa;
+}

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -23,29 +23,29 @@ void foo(int x)
 L6:
     try
     {
-	printf("try 1\n");
-	y += 4;
-	if (y == 5)
-	    goto L6;
-	y += 3;
+        printf("try 1\n");
+        y += 4;
+        if (y == 5)
+            goto L6;
+        y += 3;
     }
     finally
     {
-	y += 5;
-	printf("finally 1\n");
+        y += 5;
+        printf("finally 1\n");
     }
     try
     {
-	printf("try 2\n");
-	y = 1;
-	if (y == 4)
-	    goto L6;
-	y++;
+        printf("try 2\n");
+        y = 1;
+        if (y == 4)
+            goto L6;
+        y++;
     }
     catch (Abc c)
     {
-	printf("catch 2\n");
-	y = 2 + c.i;
+        printf("catch 2\n");
+        y = 2 + c.i;
     }
     y++;
     printf("done\n");
@@ -58,13 +58,13 @@ class IntException : Exception
 {
     this(int i)
     {
-	m_i = i;
+        m_i = i;
     super("");
     }
 
     int getValue()
     {
-	return m_i;
+        return m_i;
     }
 
     int m_i;
@@ -73,35 +73,35 @@ class IntException : Exception
 
 void test2()
 {
-    int	cIterations	=	10;
+    int     cIterations =   10;
 
-    int	i;
-    long	total_x		=	0;
-    long	total_nox	=	0;
+    int     i;
+    long    total_x     =   0;
+    long    total_nox   =   0;
 
     for(int WARMUPS = 2; WARMUPS-- > 0; )
     {
-	for(total_x = 0, i = 0; i < cIterations; ++i)
-	{
-	    total_nox += fn2_nox();
-	}
+        for(total_x = 0, i = 0; i < cIterations; ++i)
+        {
+            total_nox += fn2_nox();
+        }
 printf("foo\n");
 
-	for(total_nox = 0, i = 0; i < cIterations; ++i)
-	{
+        for(total_nox = 0, i = 0; i < cIterations; ++i)
+        {
 printf("i = %d\n", i);
-	    try
-	    {
-		int z = 1;
+            try
+            {
+                int z = 1;
 
-		throw new IntException(z);
-	    }
-	    catch(IntException x)
-	    {
+                throw new IntException(z);
+            }
+            catch(IntException x)
+            {
 printf("catch, i = %d\n", i);
-		total_x += x.getValue();
-	    }
-	}
+                total_x += x.getValue();
+            }
+        }
     }
 
     printf("iterations %d totals: %ld, %ld\n", cIterations, total_x, total_nox);
@@ -123,22 +123,22 @@ void test3()
     }
     finally
     {
-	printf("a\n");
-	assert(x == 0);
-	x++;
+        printf("a\n");
+        assert(x == 0);
+        x++;
     }
     printf("--\n");
     assert(x == 1);
     try
     {
-	printf("tb\n");
-	assert(x == 1);
+        printf("tb\n");
+        assert(x == 1);
     }
     finally
     {
-	printf("b\n");
-	assert(x == 1);
-	x++;
+        printf("b\n");
+        assert(x == 1);
+        x++;
     }
     assert(x == 2);
 }
@@ -147,123 +147,123 @@ void test3()
 
 class Tester
 {
-	this(void delegate() dg_) { dg = dg_; }
-	void delegate() dg;
-	void stuff() { dg(); }
+    this(void delegate() dg_) { dg = dg_; }
+    void delegate() dg;
+    void stuff() { dg(); }
 }
 
 void test4()
 {
-	printf("Starting test\n");
+    printf("Starting test\n");
 
-	int a = 0;
-	int b = 0;
-	int c = 0;
-	int d = 0;
+    int a = 0;
+    int b = 0;
+    int c = 0;
+    int d = 0;
 
-	try
-	{
-		a++;
-		throw new Exception("test1");
-		a++;
-	}
-	catch(Exception e)
-	{
-		auto es = e.toString();
+    try
+    {
+        a++;
+        throw new Exception("test1");
+        a++;
+    }
+    catch(Exception e)
+    {
+        auto es = e.toString();
                 printf("%.*s\n", es.length, es.ptr);
-		b++;
-	}
-	finally
-	{
-		c++;
-	}
+        b++;
+    }
+    finally
+    {
+        c++;
+    }
 
-	printf("initial test.\n");
+    printf("initial test.\n");
 
-	assert(a == 1);
-	assert(b == 1);
-	assert(c == 1);
+    assert(a == 1);
+    assert(b == 1);
+    assert(c == 1);
 
-	printf("pass\n");
+    printf("pass\n");
 
-	Tester t = new Tester(
-	delegate void()
-	{
-		try
-		{
-			a++;
-			throw new Exception("test2");
-			a++;
-		}
-		catch(Exception e)
-		{
-			b++;
-			throw e;
-			b++;
-		}
-	});
+    Tester t = new Tester(
+    delegate void()
+    {
+        try
+        {
+            a++;
+            throw new Exception("test2");
+            a++;
+        }
+        catch(Exception e)
+        {
+            b++;
+            throw e;
+            b++;
+        }
+    });
 
-	try
-	{
-		c++;
-		t.stuff();
-		c++;
-	}
-	catch(Exception e)
-	{
-		d++;
-		string es = e.toString;
-		printf("%.*s\n", es.length, es.ptr);
-	}
+    try
+    {
+        c++;
+        t.stuff();
+        c++;
+    }
+    catch(Exception e)
+    {
+        d++;
+        string es = e.toString;
+        printf("%.*s\n", es.length, es.ptr);
+    }
 
-	assert(a == 2);
-	assert(b == 2);
-	assert(c == 2);
-	assert(d == 1);
+    assert(a == 2);
+    assert(b == 2);
+    assert(c == 2);
+    assert(d == 1);
 
 
-	int q0 = 0;
-	int q1 = 0;
-	int q2 = 0;
-	int q3 = 0;
-	
-	Tester t2 = new Tester(
-	delegate void()
-	{
-		try
-		{
-			q0++;
-			throw new Exception("test3");
-			q0++;
-		}
-		catch(Exception e)
-		{
-			printf("Never called.\n");
-			q1++;
-			throw e;
-			q1++;
-		}
-	});
+    int q0 = 0;
+    int q1 = 0;
+    int q2 = 0;
+    int q3 = 0;
 
-	try
-	{
-		q2++;
-		t2.stuff();
-		q2++;
-	}
-	catch(Exception e)
-	{
-		q3++;
+    Tester t2 = new Tester(
+    delegate void()
+    {
+        try
+        {
+            q0++;
+            throw new Exception("test3");
+            q0++;
+        }
+        catch(Exception e)
+        {
+            printf("Never called.\n");
+            q1++;
+            throw e;
+            q1++;
+        }
+    });
+
+    try
+    {
+        q2++;
+        t2.stuff();
+        q2++;
+    }
+    catch(Exception e)
+    {
+        q3++;
                 string es = e.toString;
-		printf("%.*s\n", es.length, es.ptr);
-	}
+        printf("%.*s\n", es.length, es.ptr);
+    }
 
-	assert(q0 == 1);
-	assert(q1 == 1);
-	assert(q2 == 1);
-	assert(q3 == 1);
+    assert(q0 == 1);
+    assert(q1 == 1);
+    assert(q2 == 1);
+    assert(q3 == 1);
 
-	printf("Passed!\n");
+    printf("Passed!\n");
 }
 
 /****************************************************/
@@ -274,47 +274,48 @@ void test5()
     int i = 3;
     while(i--)
     {
-	try
-	{
-	    printf("i: %d\n", i);
-	    result ~= 't';
-	    if (i == 1)
-		continue;
-	}
-	finally
-	{
-	    printf("finally\n");
-	    result ~= cast(char)('a' + i);
-	}
+        try
+        {
+            printf("i: %d\n", i);
+            result ~= 't';
+            if (i == 1)
+                continue;
+        }
+        finally
+        {
+            printf("finally\n");
+            result ~= cast(char)('a' + i);
+        }
     }
     printf("--- %.*s", result.length, result.ptr);
     if (result != "tctbta")
-	assert(0);
+        assert(0);
 }
 
 /****************************************************/
 
 void test6()
-{   char[] result;
+{
+    char[] result;
 
     while (true)
     {
         try
         {
             printf("one\n");
-	    result ~= 'a';
+            result ~= 'a';
             break;
         }
         finally
         {
             printf("two\n");
-	    result ~= 'b';
+            result ~= 'b';
         }
     }
     printf("three\n");
     result ~= 'c';
     if (result != "abc")
-	assert(0);
+        assert(0);
 }
 
 /****************************************************/
@@ -323,29 +324,29 @@ string a7;
 
 void doScan(int i)
 {
-  a7 ~= "a";
-  try
-  {
+    a7 ~= "a";
     try
     {
-	a7 ~= "b";
-        return;
+        try
+        {
+            a7 ~= "b";
+            return;
+        }
+        finally
+        {
+            a7 ~= "c";
+        }
     }
     finally
     {
-      a7 ~= "c";
+        a7 ~= "d";
     }
-  }
-  finally
-  {
-    a7 ~= "d";
-  }
 }
 
 void test7()
 {
-        doScan(0);
-	assert(a7 == "abcd");
+    doScan(0);
+    assert(a7 == "abcd");
 }
 
 
@@ -356,7 +357,7 @@ int result1513;
 
 void bug1513a()
 {
-     throw new Exception("d");        
+     throw new Exception("d");
 }
 
 void bug1513b()
@@ -371,11 +372,10 @@ void bug1513b()
         {
             result1513 |=4;
            throw new Exception("f");
-            
         }
     }
     catch(Exception e)
-    { 
+    {
         assert(e.msg == "d");
         assert(e.next.msg == "f");
         assert(!e.next.next);
@@ -395,7 +395,7 @@ void bug1513c()
             result1513 |= 1;
             throw new Exception("b");
         }
-    }    
+    }
     finally
     {
         bug1513b();
@@ -408,8 +408,8 @@ void bug1513()
 {
     result1513 = 0;
     try
-    {        
-        bug1513c();        
+    {
+        bug1513c();
     }
     catch(Exception e)
     {
@@ -459,7 +459,7 @@ void doublecollide()
             assert(e.next.next.msg == "x");
             assert(e.next.next.next.msg == "y");
             assert(!e.next.next.next.next);
-    }        
+    }
 }
 
 void collidetwo()
@@ -489,7 +489,7 @@ void collideMixed()
         try
         {
             try
-            {                
+            {
                 throw new Exception("e");
             }
             finally
@@ -497,7 +497,7 @@ void collideMixed()
                 throw new Error("t");
             }
         }
-        catch(Exception f) 
+        catch(Exception f)
         {    // Doesn't catch, because Error is chained to it.
             works += 2;
         }
@@ -558,7 +558,7 @@ void multicollide()
         assert(e.next.next.msg == "x");
         assert(e.next.next.next.msg == "y");
         assert(!e.next.next.next.next);
-    }        
+    }
 }
 
 /****************************************************/
@@ -629,7 +629,7 @@ int main()
     test5();
     test6();
     test7();
-    
+
     bug1513();
     doublecollide();
     collideMixed();

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -618,6 +618,52 @@ void test9()
 }
 
 /****************************************************/
+// 10964
+
+void test10964()
+{
+    static struct S
+    {
+        this(this)
+        {
+            throw new Exception("BOOM!");
+        }
+    }
+
+    S    ss;
+    S[1] sa;
+    int result;
+
+    result = 0;
+    try
+    {
+        ss = ss;
+    }
+    catch (Exception e) result = 1;
+    catch (Error     e) result = 2;
+    catch (Throwable e) result = 3;
+    assert(result == 1);
+
+    try
+    {
+        sa = ss;
+    }
+    catch (Exception e) result = 1;
+    catch (Error     e) result = 2;
+    catch (Throwable e) result = 3;
+    assert(result == 1);
+
+    try
+    {
+        sa = sa;
+    }
+    catch (Exception e) result = 1;
+    catch (Error     e) result = 2;
+    catch (Throwable e) result = 3;
+    assert(result == 1);
+}
+
+/****************************************************/
 
 int main()
 {
@@ -638,6 +684,7 @@ int main()
 
     test8();
     test9();
+    test10964();
 
     printf("finish\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10964

`canThrow` check should see the array operations.
