### PR TITLE
10858 CTFE wrong-code for array of pointers

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -367,6 +367,11 @@ Expression *paintTypeOntoLiteral(Type *type, Expression *lit)
 {
     if (lit->type->equals(type))
         return lit;
+
+    // If it is a cast to inout, retain the original type.
+    if (type->hasWild())
+        return lit;
+
     Expression *e;
     if (lit->op == TOKslice)
     {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2940,14 +2940,14 @@ Expression *BinExp::interpretCompareCommon(InterState *istate, CtfeGoal goal, fp
     Expression *e2;
 
 #if LOG
-    printf("%s BinExp::interpretCommon2() %s\n", loc.toChars(), toChars());
+    printf("%s BinExp::interpretCompareCommon() %s\n", loc.toChars(), toChars());
 #endif
     if (this->e1->type->ty == Tpointer && this->e2->type->ty == Tpointer)
     {
-        e1 = this->e1->interpret(istate, ctfeNeedLvalue);
+        e1 = this->e1->interpret(istate);
         if (exceptionOrCantInterpret(e1))
             return e1;
-        e2 = this->e2->interpret(istate, ctfeNeedLvalue);
+        e2 = this->e2->interpret(istate);
         if (exceptionOrCantInterpret(e2))
             return e2;
         dinteger_t ofs1, ofs2;
@@ -5656,7 +5656,9 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
             if (e->op == TOKaddress)
             {
                 e = ((AddrExp*)e)->e1;
-                if (e->op == TOKdotvar || e->op == TOKindex)
+                // *&p becomes p if p is a CTFE pointer, otherwise we need to
+                // simplify it.
+                if ((e->op == TOKdotvar || e->op == TOKindex) && !isPointer(e->type))
                     e = e->interpret(istate, goal);
             }
             else if (e->op == TOKvar)
@@ -5673,7 +5675,7 @@ Expression *PtrExp::interpret(InterState *istate, CtfeGoal goal)
             error("dereference of null pointer '%s'", e1->toChars());
             return EXP_CANT_INTERPRET;
         }
-        e->type = type;
+        e = paintTypeOntoLiteral(type, e);
     }
 
 #if LOG

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2552,6 +2552,19 @@ bool bug7216() {
 static assert(bug7216());
 
 /**************************************************
+    10858 Wrong code with array of pointers
+**************************************************/
+
+bool bug10858()
+{
+    int *[4] x;
+    x[0] = null;
+    assert(x[0] == null);
+    return true;
+}
+static assert(bug10858());
+
+/**************************************************
     9745 Allow pointers to static variables
 **************************************************/
 


### PR DESCRIPTION
Pointer comparison should be based on rvalues, not lvalues.
When I fixed that, two latent wrong-code bugs were exposed by the test suite.

http://d.puremagic.com/issues/show_bug.cgi?id=10858
