### PR TITLE
Fix 32 bit build.

### DIFF
--- a/src/toir.c
+++ b/src/toir.c
@@ -447,9 +447,9 @@ int intrinsic_op(char *name)
 
         "5bitop3bsfFNaNbNfkZi",
         "5bitop3bsrFNaNbNfkZi",
-        "5bitop3btcFNaNbPmmZi",
-        "5bitop3btrFNaNbPmmZi",
-        "5bitop3btsFNaNbPmmZi",
+        "5bitop3btcFNaNbPkkZi",
+        "5bitop3btrFNaNbPkkZi",
+        "5bitop3btsFNaNbPkkZi",
         "5bitop3inpFNbkZh",
         "5bitop4inplFNbkZk",
         "5bitop4inpwFNbkZt",


### PR DESCRIPTION
This fixes GitHub pull request #2503.

Sorry for the breakage, I only tested the pull request on x86_64 locally, and the auto-tester couldn't be used because of the dependency to D-Programming-Language/druntime#596.
