### PR TITLE
[DDMD] Do not set typeinfo flag 0x1 for c++ classes as it causes them to not be scanned by the gc

### DIFF
--- a/src/toobj.c
+++ b/src/toobj.c
@@ -400,7 +400,7 @@ void ClassDeclaration::toObjFile(int multiobj)
         dtsize_t(&dt, 0);
 
     // flags
-    int flags = 4 | isCOMclass() | isCPPclass();
+    int flags = 4 | isCOMclass();
 #if DMDV2
     flags |= 16;
 #endif

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1882,6 +1882,8 @@ extern(C++) class C1687
 void test1687()
 {
     auto c = new C1687();
+    import core.memory;
+    GC.clrAttr(cast(void*)c, GC.BlkAttr.FINALIZE);
     assert(c.__vptr[0] == (&c.func).funcptr);
 }
 


### PR DESCRIPTION
This was sitting in my local branch but I forgot to add it to #2441

The flag causes classes to be mallocated when they should be put on the gc heap.  I mistakenly thought it simply cleared the finalize bit.
