### PR TITLE
foreach range uses same logic as ?: for type deduction

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -2430,17 +2430,22 @@ Statement *ForeachRangeStatement::semantic(Scope *sc)
             /* Just picking the first really isn't good enough.
              */
             arg->type = lwr->type;
-            arg->type = arg->type->addStorageClass(arg->storageClass);
+        }
+        else if (lwr->type == upr->type)
+        {
+            /* Same logic as CondExp ?lwr:upr
+             */
+            arg->type = lwr->type;
         }
         else
         {
             AddExp ea(loc, lwr, upr);
             Expression *e = ea.typeCombine(sc);
             arg->type = ea.type;
-            arg->type = arg->type->addStorageClass(arg->storageClass);
             lwr = ea.e1;
             upr = ea.e2;
         }
+        arg->type = arg->type->addStorageClass(arg->storageClass);
     }
 
     /* Convert to a for loop:

--- a/test/compilable/test1878a.d
+++ b/test/compilable/test1878a.d
@@ -1,0 +1,8 @@
+void main()
+{
+  ubyte from, to;
+  foreach(i; from..to)
+  {
+    static assert(is(typeof(i) == ubyte));
+  }
+}

--- a/test/compilable/test1878a.d
+++ b/test/compilable/test1878a.d
@@ -5,4 +5,8 @@ void main()
   {
     static assert(is(typeof(i) == ubyte));
   }
+  foreach(i; 'a'..'l')
+  {
+    static assert(is(typeof(i) == char));
+  }
 }

--- a/test/compilable/test1878a.d
+++ b/test/compilable/test1878a.d
@@ -9,4 +9,8 @@ void main()
   {
     static assert(is(typeof(i) == char));
   }
+  foreach(i; 'א' .. 'ת')
+  {
+    static assert(is(typeof(i) == wchar));
+  }
 }


### PR DESCRIPTION
This pull request partly addresses the issue raised by bug 1878. When both types in the range expression are the same, that type will be used for the iteration variable. This is similar to the way ?: deduces types.

Both ?: and range expression should use VRP logic, eventually.
