### PR TITLE
Fix genCmain code to remove ambiguity of `&main` expression

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -457,7 +457,8 @@ void genCmain(Scope *sc)
         }\n\
         ";
 
-    Module *m = new Module("__entrypoint.d", NULL, 0, 0);
+    Identifier *id = Lexer::idPool("__entrypoint");
+    Module *m = new Module("__entrypoint.d", id, 0, 0);
 
     Parser p(m, code, sizeof(code) / sizeof(code[0]), 0);
     p.loc = Loc();

--- a/test/compilable/testlibmain.d
+++ b/test/compilable/testlibmain.d
@@ -1,0 +1,4 @@
+// REQUIRED_ARGS: -lib
+// PERMUTE_ARGS:
+
+void main() {}


### PR DESCRIPTION
It was introduced by pull #2476, but the expression `&main` which is implicitly
inserted would conflict with two extern(C) and (D) "main" functions in
user module.

Instead, separate the entry-point code in the hidden module `__entrypoint.d`
