### PR TITLE
Set INCLUDE environment when MSVC++ compiler called (Use /I=dir option)

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -425,7 +425,7 @@ int main(string[] args)
                 }
                 else if (envData.os == "win64")
                 {
-                    command ~= ` /c /nologo `~curSrc~` /Fo`~curObj;
+                    command ~= ` /c /nologo `~curSrc~` /Fo`~curObj~` /I"\Program Files (x86)\Microsoft Visual Studio 10.0\VC\INCLUDE`;
                 }
                 else
                 {


### PR DESCRIPTION
This may be a help for #2537
