### PR TITLE
fix Issue 10441 - Static libraries too big

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -131,7 +131,7 @@ void obj_write_deferred(Library *library)
 
             md->genobjfile(0);
         }
-     
+
         /* Set object file name to be source name with sequence number,
          * as mangled symbol names get way too long.
          */
@@ -532,6 +532,7 @@ void FuncDeclaration::toObjFile(int multiobj)
     int has_arguments;
 
     //printf("FuncDeclaration::toObjFile(%p, %s.%s)\n", func, parent->toChars(), func->toChars());
+
     //if (type) printf("type = %s\n", func->type->toChars());
 #if 0
     //printf("line = %d\n",func->getWhere() / LINEINC);
@@ -579,6 +580,17 @@ void FuncDeclaration::toObjFile(int multiobj)
     }
     assert(semanticRun == PASSsemantic3done);
     semanticRun = PASSobj;
+
+    /* Skip generating code if this part of a TemplateInstance that is instantiated
+     * only by non-root modules (i.e. modules not listed on the command line).
+     */
+    TemplateInstance *ti = inTemplateInstance();
+    if (!global.params.useUnitTests &&
+        ti && ti->instantiatingModule && !ti->instantiatingModule->root)
+    {
+        //printf("instantiated by %s   %s\n", ti->instantiatingModule->toChars(), ti->toChars());
+        return;
+    }
 
     if (global.params.verbose)
         printf("function  %s\n",func->toPrettyChars());

--- a/src/mars.c
+++ b/src/mars.c
@@ -1459,6 +1459,7 @@ Language changes listed by -transition=id:\n\
     for (size_t filei = 0, modi = 0; filei < filecount; filei++, modi++)
     {
         m = modules[modi];
+        m->root = TRUE;
         if (global.params.verbose)
             printf("parse     %s\n", m->toChars());
         if (!Module::rootModule)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4680,6 +4680,7 @@ StructDeclaration *TypeAArray::getImpl()
 #endif
         // Instantiate on the root module of import dependency graph.
         Scope *scx = sc->push(sc->module->importedFrom);
+        scx->instantiatingModule = sc->module->importedFrom;
         ti->semantic(scx);
         ti->semantic2(scx);
         ti->semantic3(scx);

--- a/src/scope.c
+++ b/src/scope.c
@@ -50,6 +50,7 @@ Scope::Scope()
 
     //printf("Scope::Scope() %p\n", this);
     this->module = NULL;
+    this->instantiatingModule = NULL;
     this->scopesym = NULL;
     this->sd = NULL;
     this->enclosing = NULL;
@@ -88,6 +89,7 @@ Scope::Scope(Scope *enclosing)
     //printf("Scope::Scope(enclosing = %p) %p\n", enclosing, this);
     assert(!(enclosing->flags & SCOPEfree));
     this->module = enclosing->module;
+    this->instantiatingModule = enclosing->instantiatingModule;
     this->func   = enclosing->func;
     this->parent = enclosing->parent;
     this->scopesym = NULL;

--- a/src/scope.h
+++ b/src/scope.h
@@ -1,5 +1,5 @@
 
-// Copyright (c) 1999-2012 by Digital Mars
+// Copyright (c) 1999-2013 by Digital Mars
 // All Rights Reserved
 // written by Walter Bright
 // http://www.digitalmars.com
@@ -65,6 +65,7 @@ struct Scope
     Scope *enclosing;           // enclosing Scope
 
     Module *module;             // Root module
+    Module *instantiatingModule; // top level module that started a chain of template instantiations
     ScopeDsymbol *scopesym;     // current symbol
     ScopeDsymbol *sd;           // if in static if, and declaring new symbols,
                                 // sd gets the addMember()

--- a/src/struct.c
+++ b/src/struct.c
@@ -144,9 +144,10 @@ void AggregateDeclaration::semantic3(Scope *sc)
             Dsymbol *s = ti->toAlias();
             Expression *e = new DsymbolExp(Loc(), s, 0);
 
-            Scope *sc = ti->tempdecl->scope->startCTFE();
-            e = e->semantic(sc);
-            sc->endCTFE();
+            Scope *sc2 = ti->tempdecl->scope->startCTFE();
+            sc2->instantiatingModule = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
+            e = e->semantic(sc2);
+            sc2->endCTFE();
 
             e = e->ctfeInterpret();
             getRTInfo = e;

--- a/src/template.h
+++ b/src/template.h
@@ -95,8 +95,8 @@ public:
     PROT prot();
 //    void toDocBuffer(OutBuffer *buf);
 
-    MATCH matchWithInstance(TemplateInstance *ti, Objects *atypes, Expressions *fargs, int flag);
-    MATCH leastAsSpecialized(TemplateDeclaration *td2, Expressions *fargs);
+    MATCH matchWithInstance(Scope *sc, TemplateInstance *ti, Objects *atypes, Expressions *fargs, int flag);
+    MATCH leastAsSpecialized(Scope *sc, TemplateDeclaration *td2, Expressions *fargs);
 
     MATCH deduceFunctionTemplateMatch(FuncDeclaration *f, Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, Objects *dedargs);
     RootObject *declareParameter(Scope *sc, TemplateParameter *tp, RootObject *o);
@@ -319,6 +319,7 @@ public:
     Dsymbol *enclosing;                 // if referencing local symbols, this is the context
     hash_t hash;                        // cached result of hashCode()
     Expressions *fargs;                 // for function template, these are the function arguments
+    Module *instantiatingModule;        // the top module that instantiated this instance
 #ifdef IN_GCC
     /* On some targets, it is necessary to know whether a symbol
        will be emitted in the output or not before the symbol

--- a/test/runnable/imports/test10441b.d
+++ b/test/runnable/imports/test10441b.d
@@ -1,0 +1,9 @@
+
+public import test10441c;
+
+auto foo()()
+    if (boo(1))
+{
+    return 1;
+}
+

--- a/test/runnable/imports/test10441c.d
+++ b/test/runnable/imports/test10441c.d
@@ -1,0 +1,6 @@
+
+auto boo(T)(T t)
+{
+    return 1;
+}
+

--- a/test/runnable/test10441.d
+++ b/test/runnable/test10441.d
@@ -1,0 +1,10 @@
+// EXTRA_SOURCES: imports/test10441b.d imports/test10441c.d
+
+import test10441b;
+
+void main()
+{
+    boo(1);
+    foo();
+}
+


### PR DESCRIPTION
I have given up complaining about importing std.stdio (and others) and getting a vast object file of bloat from templates that were instantiated simply by the import, and decided it was a dmd problem. This change addresses it by not generating code from functions that were instantiated by templates from imports, if the standalone import instantiates those same templates.

This should also speed up compiles.

The semantic analysis is still done. In the future I'd like to address this by going "full lazy" on the semantic analysis of imports (currently it is done "full eager"). Such will also produce a big compile time speedup.

This change has a risk of my having missed cases, the symptom of which will be undefined symbols at link time.

This only deals with functions. If it works out, we can extend it to not generating data, either.
