### PR TITLE
10995 CTFE failure for void initialized members

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -996,12 +996,6 @@ Expression *FuncDeclaration::interpret(InterState *istate, Expressions *argument
         return EXP_CANT_INTERPRET;
     }
 
-    // If we're about to leave CTFE, make sure we don't crash the
-    // compiler by returning a CTFE-internal expression.
-    if (!istate && !evaluatingArgs)
-    {
-        e = scrubReturnValue(loc, e);
-    }
     return e;
 }
 
@@ -5765,7 +5759,7 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
             }
             if (!e)
             {
-                error("couldn't find field %s in %s", v->toChars(), type->toChars());
+                error("Internal Compiler Error: Null field %s", v->toChars());
                 return EXP_CANT_INTERPRET;
             }
             // If it is an rvalue literal, return it...
@@ -5775,8 +5769,7 @@ Expression *DotVarExp::interpret(InterState *istate, CtfeGoal goal)
             if (e->op == TOKvoid)
             {
                 VoidInitExp *ve = (VoidInitExp *)e;
-                error("cannot read uninitialized variable %s in ctfe", toChars());
-                ve->var->error("was uninitialized and used before set");
+                error("cannot read uninitialized variable %s in CTFE", ve->var->toChars());
                 return EXP_CANT_INTERPRET;
             }
             if ( isPointer(type) )

--- a/test/fail_compilation/ctfe10995.d
+++ b/test/fail_compilation/ctfe10995.d
@@ -1,0 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ctfe10995.d(19): Error: cannot read uninitialized variable a in CTFE
+fail_compilation/ctfe10995.d(25): Error: cannot read uninitialized variable a in CTFE
+---
+*/
+struct T
+{
+    short a = void;
+}
+
+T foo()
+{
+    auto t = T.init;
+    return t;
+}
+
+enum i = foo().a;
+
+struct T2
+{
+    short a = void;
+}
+enum i2 = T2.init.a;


### PR DESCRIPTION
Fix the duplicate error message, and don't scrub twice -- only scrub when CTFE is actually finished.

http://d.puremagic.com/issues/show_bug.cgi?id=10995
