### PR TITLE
fix Issue 9948 - -deps dependency printing incorrect for templates

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1054,10 +1054,11 @@ void PragmaDeclaration::semantic(Scope *sc)
                 if (global.params.moduleDeps && !global.params.moduleDepsFile)
                 {
                     OutBuffer *ob = global.params.moduleDeps;
+                    Module* imod = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
                     ob->writestring("depsLib ");
-                    ob->writestring(sc->module->toPrettyChars());
+                    ob->writestring(imod->toPrettyChars());
                     ob->writestring(" (");
-                    escapePath(ob, sc->module->srcfile->toChars());
+                    escapePath(ob, imod->srcfile->toChars());
                     ob->writestring(") : ");
                     ob->writestring((char *) name);
                     ob->writenl();

--- a/src/cond.c
+++ b/src/cond.c
@@ -90,13 +90,13 @@ void printDepsConditional(Scope *sc, DVCondition* condition, const char* depType
     if (!global.params.moduleDeps || global.params.moduleDepsFile)
         return;
     OutBuffer *ob = global.params.moduleDeps;
-    Module* md = sc && sc->module ? sc->module : condition->mod;
-    if (!md)
+    Module* imod = sc ? (sc->instantiatingModule ? sc->instantiatingModule : sc->module) : condition->mod;
+    if (!imod)
         return;
     ob->writestring(depType);
-    ob->writestring(md->toPrettyChars());
+    ob->writestring(imod->toPrettyChars());
     ob->writestring(" (");
-    escapePath(ob, md->srcfile->toChars());
+    escapePath(ob, imod->srcfile->toChars());
     ob->writestring(") : ");
     if (condition->ident)
         ob->printf("%s\n", condition->ident->toChars());

--- a/src/expression.c
+++ b/src/expression.c
@@ -7281,10 +7281,12 @@ Expression *FileExp::semantic(Scope *sc)
     if (global.params.moduleDeps != NULL && global.params.moduleDepsFile == NULL)
     {
         OutBuffer *ob = global.params.moduleDeps;
+        Module* imod = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
+
         ob->writestring("depsFile ");
-        ob->writestring(sc->module->toPrettyChars());
+        ob->writestring(imod->toPrettyChars());
         ob->writestring(" (");
-        escapePath(ob, sc->module->srcfile->toChars());
+        escapePath(ob, imod->srcfile->toChars());
         ob->writestring(") : ");
         ob->writestring((char *) se->string);
         ob->writestring(" (");

--- a/src/import.c
+++ b/src/import.c
@@ -294,11 +294,12 @@ void Import::semantic(Scope *sc)
          */
 
         OutBuffer *ob = global.params.moduleDeps;
+        Module* imod = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
         if (!global.params.moduleDepsFile)
             ob->writestring("depsImport ");
-        ob->writestring(sc->module->toPrettyChars());
+        ob->writestring(imod->toPrettyChars());
         ob->writestring(" (");
-        escapePath(ob, sc->module->srcfile->toChars());
+        escapePath(ob,  imod->srcfile->toChars());
         ob->writestring(") : ");
 
         // use protection instead of sc->protection because it couldn't be

--- a/test/compilable/depsOutput9948.d
+++ b/test/compilable/depsOutput9948.d
@@ -6,6 +6,7 @@
 module depsOutput9948;
 import depsOutput9948a;
 
-void main() {
+void main()
+{
    templateFunc!("import std.string;")();
 }

--- a/test/compilable/depsOutput9948.d
+++ b/test/compilable/depsOutput9948.d
@@ -1,0 +1,11 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -deps=test_results/compilable/depsOutput9948.deps
+// POST_SCRIPT: compilable/extra-files/depsOutput.sh 
+// EXTRA_SOURCES: /extra-files/depsOutput9948a.d
+
+module depsOutput9948;
+import depsOutput9948a;
+
+void main() {
+   templateFunc!("import std.string;")();
+}

--- a/test/compilable/depsOutput9948.d
+++ b/test/compilable/depsOutput9948.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -deps=test_results/compilable/depsOutput9948.deps
+// REQUIRED_ARGS: -deps=${RESULTS_DIR}/compilable/depsOutput9948.deps
 // POST_SCRIPT: compilable/extra-files/depsOutput.sh 
 // EXTRA_SOURCES: /extra-files/depsOutput9948a.d
 

--- a/test/compilable/extra-files/depsOutput.sh
+++ b/test/compilable/extra-files/depsOutput.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+grep  'depsOutput9948 (.*depsOutput9948.d) : private : std.string'  ${RESULTS_DIR}/compilable/depsOutput9948.deps || exit 1
+grep  'depsOutput9948a (.*depsOutput9948a.d) : private : std.string'  ${RESULTS_DIR}/compilable/depsOutput9948.deps && exit 1
+rm -f ${RESULTS_DIR}/compilable/depsOutput9948.deps
+exit 0

--- a/test/compilable/extra-files/depsOutput9948a.d
+++ b/test/compilable/extra-files/depsOutput9948a.d
@@ -1,4 +1,6 @@
 module depsOutput9948a;
-void templateFunc(string myImport)() {
+
+void templateFunc(string myImport)()
+{
    mixin(myImport);
 }

--- a/test/compilable/extra-files/depsOutput9948a.d
+++ b/test/compilable/extra-files/depsOutput9948a.d
@@ -1,0 +1,4 @@
+module depsOutput9948a;
+void templateFunc(string myImport)() {
+   mixin(myImport);
+}


### PR DESCRIPTION
This fix is based on the just merged pull request:

 https://github.com/D-Programming-Language/dmd/pull/2550

by @WalterBright 
It made this fix trivial (at least the test case in the bug report is working correctly now).
