### PR TITLE
(Retry) Issue 9073 - In manifest constant initializer, && and || should evaluate their operands lazily.

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -352,7 +352,7 @@ int StaticIfCondition::include(Scope *sc, ScopeDsymbol *s)
         ++nest;
         sc = sc->push(sc->scopesym);
         sc->sd = s;                     // s gets any addMember()
-        sc->flags |= SCOPEstaticif;
+        sc->flags |= SCOPEcondition;
 
         sc = sc->startCTFE();
         Expression *e = exp->semantic(sc);

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -848,13 +848,21 @@ void VarDeclaration::semantic(Scope *sc)
                 e = new ErrorExp();
             }
             init = new ExpInitializer(e->loc, e);
+
+            sc = sc->push();
+            if (storage_class & STCmanifest) sc->flags |= SCOPEcondition;
             type = init->inferType(sc);
+            sc = sc->pop();
+
             if (type->ty == Tsarray)
                 type = type->nextOf()->arrayOf();
         }
         else
         {
+            sc = sc->push();
+            if (storage_class & STCmanifest) sc->flags |= SCOPEcondition;
             type = init->inferType(sc);
+            sc = sc->pop();
         }
 
         if (needctfe) sc = sc->endCTFE();
@@ -1358,6 +1366,7 @@ Lnomatch:
     {
         sc = sc->push();
         sc->stc &= ~(STC_TYPECTOR | STCpure | STCnothrow | STCref | STCdisable);
+        if (storage_class & STCmanifest) sc->flags |= SCOPEcondition;
 
         ExpInitializer *ei = init->isExpInitializer();
         if (ei && isScope())

--- a/src/expression.c
+++ b/src/expression.c
@@ -6008,7 +6008,7 @@ Expression *IsExp::semantic(Scope *sc)
      */
 
     //printf("IsExp::semantic(%s)\n", toChars());
-    if (id && !(sc->flags & (SCOPEstaticif | SCOPEstaticassert)))
+    if (id && !(sc->flags & SCOPEcondition))
     {
         error("can only declare type aliases within static if conditionals or static asserts");
         return new ErrorExp();
@@ -12655,7 +12655,7 @@ Expression *OrOrExp::semantic(Scope *sc)
     e1 = e1->checkToBoolean(sc);
     unsigned cs1 = sc->callSuper;
 
-    if (sc->flags & SCOPEstaticif)
+    if (sc->flags & SCOPEcondition)
     {
         /* If in static if, don't evaluate e2 if we don't have to.
          */
@@ -12713,7 +12713,7 @@ Expression *AndAndExp::semantic(Scope *sc)
     e1 = e1->checkToBoolean(sc);
     unsigned cs1 = sc->callSuper;
 
-    if (sc->flags & SCOPEstaticif)
+    if (sc->flags & SCOPEcondition)
     {
         /* If in static if, don't evaluate e2 if we don't have to.
          */

--- a/src/func.c
+++ b/src/func.c
@@ -3244,12 +3244,8 @@ int FuncDeclaration::getLevel(Loc loc, Scope *sc, FuncDeclaration *fd)
     return level;
 
 Lerr:
-    Dsymbol *p = toParent2();
-    while (p->toParent2()->isFuncDeclaration())
-        p = p->toParent2();
-
     // Don't give error if in template constraint
-    if (!(sc->flags & SCOPEstaticif) && !p->parent->isTemplateDeclaration())
+    if (!(sc->flags & SCOPEconstraint))
     {
         const char *xstatic = isStatic() ? "static " : "";
         // better diagnostics for static functions

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6975,7 +6975,6 @@ void TypeTypeof::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
         Scope *sc2 = sc->push();
         sc2->intypeof = 1;
         sc2->speculative = true;
-        sc2->flags |= sc->flags & SCOPEstaticif;
         unsigned oldspecgag = global.speculativeGag;
         if (global.gag)
             global.speculativeGag = global.gag;

--- a/src/scope.c
+++ b/src/scope.c
@@ -133,7 +133,7 @@ Scope::Scope(Scope *enclosing)
     this->callSuper = enclosing->callSuper;
     this->fieldinit = enclosing->saveFieldInit();
     this->fieldinit_dim = enclosing->fieldinit_dim;
-    this->flags = (enclosing->flags & (SCOPEcontract | SCOPEdebug | SCOPEctfe | SCOPEcompile));
+    this->flags = (enclosing->flags & (SCOPEcontract | SCOPEdebug | SCOPEctfe | SCOPEcompile | SCOPEconstraint));
     this->lastdc = NULL;
     this->lastoffset = 0;
     this->docbuf = enclosing->docbuf;

--- a/src/scope.h
+++ b/src/scope.h
@@ -47,20 +47,22 @@ enum PROT;
 #define CSXreturn       0x20    // seen a return statement
 #define CSXany_ctor     0x40    // either this() or super() was called
 
+// Flags that would not be inherited beyond scope nesting
 #define SCOPEctor           0x0001  // constructor type
-#define SCOPEstaticif       0x0002  // inside static if
-#define SCOPEfree           0x0004  // is on free list
-#define SCOPEstaticassert   0x0008  // inside static assert
-#define SCOPEdebug          0x0010  // inside debug conditional
+#define SCOPEnoaccesscheck  0x0002  // don't do access checks
+#define SCOPEcondition      0x0004  // inside static if/assert condition
+#define SCOPEdebug          0x0008  // inside debug conditional
 
+// Flags that would be inherited beyond scope nesting
+#define SCOPEconstraint     0x0010  // inside template constraint
 #define SCOPEinvariant      0x0020  // inside invariant code
 #define SCOPErequire        0x0040  // inside in contract code
 #define SCOPEensure         0x0060  // inside out contract code
 #define SCOPEcontract       0x0060  // [mask] we're inside contract code
-
 #define SCOPEctfe           0x0080  // inside a ctfe-only expression
-#define SCOPEnoaccesscheck  0x0100  // don't do access checks
-#define SCOPEcompile        0x0200  // inside __traits(compile)
+#define SCOPEcompile        0x0100  // inside __traits(compile)
+
+#define SCOPEfree           0x8000  // is on free list
 
 struct Scope
 {

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -54,7 +54,7 @@ void StaticAssert::semantic2(Scope *sc)
     //printf("StaticAssert::semantic2() %s\n", toChars());
     ScopeDsymbol *sd = new ScopeDsymbol();
     sc = sc->push(sd);
-    sc->flags |= SCOPEstaticassert;
+    sc->flags |= SCOPEcondition;
 
     sc = sc->startCTFE();
     Expression *e = exp->semantic(sc);

--- a/src/template.c
+++ b/src/template.c
@@ -803,7 +803,7 @@ bool TemplateDeclaration::evaluateConstraint(
     Expression *e = constraint->syntaxCopy();
 
     scx = scx->startCTFE();
-    scx->flags |= SCOPEstaticif;
+    scx->flags |= SCOPEcondition | SCOPEconstraint;
     assert(ti->inst == NULL);
     ti->inst = ti;  // temporary instantiation to enable genIdent()
 
@@ -2495,7 +2495,7 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
 
         if (FuncLiteralDeclaration *fld = m->lastf->isFuncLiteralDeclaration())
         {
-            if ((sc->flags & SCOPEstaticif) || sc->intypeof)
+            if ((sc->flags & SCOPEconstraint) || sc->intypeof)
             {
                 // Inside template constraint, or inside typeof,
                 // nested reference check doesn't work correctly.

--- a/src/traits.c
+++ b/src/traits.c
@@ -729,7 +729,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             global.speculativeGag = global.gag;
             Scope *sc2 = sc->push();
             sc2->speculative = true;
-            sc2->flags = sc->flags & ~SCOPEctfe | SCOPEcompile;
+            sc2->flags = sc->flags & ~(SCOPEctfe | SCOPEcondition) | SCOPEcompile;
             bool err = false;
 
             RootObject *o = (*e->args)[i];

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -512,6 +512,30 @@ static if (is(object.ModuleInfo == class))
 }
 
 /***************************************************/
+// 11042
+
+static if           ((true  || error) == true ) {} else { static assert(0); }
+static if           ((false && error) == false) {} else { static assert(0); }
+static assert       ((true  || error) == true );
+static assert       ((false && error) == false);
+int f11042a1()() if ((true  || error) == true ) { return 0; }   enum x11042a1 = f11042a1();
+int f11042b1()() if ((false && error) == false) { return 0; }   enum x11042b1 = f11042b1();
+
+static if           (is(typeof(true  || error)) == false) {} else { static assert(0); }
+static if           (is(typeof(false && error)) == false) {} else { static assert(0); }
+static assert       (is(typeof(true  || error)) == false);
+static assert       (is(typeof(false && error)) == false);
+int f11042a2()() if (is(typeof(true  || error)) == false) { return 0; }   enum x11042a2 = f11042a2();
+int f11042b2()() if (is(typeof(false && error)) == false) { return 0; }   enum x11042b2 = f11042b2();
+
+static if           (__traits(compiles, true  || error) == false) {} else { static assert(0); }
+static if           (__traits(compiles, false && error) == false) {} else { static assert(0); }
+static assert       (__traits(compiles, true  || error) == false);
+static assert       (__traits(compiles, false && error) == false);
+int f11042a3()() if (__traits(compiles, true  || error) == false) { return 0; }   enum x11042a3 = f11042a3();
+int f11042b3()() if (__traits(compiles, false && error) == false) { return 0; }   enum x11042b3 = f11042b3();
+
+/***************************************************/
 // 11554
 
 enum E11554;

--- a/test/fail_compilation/fail11042.d
+++ b/test/fail_compilation/fail11042.d
@@ -1,0 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11042.d(8): Error: undefined identifier error, did you mean class Error?
+fail_compilation/fail11042.d(9): Error: undefined identifier error, did you mean class Error?
+---
+*/
+static if ({ return true  || error; }()) {} // NG
+static if ({ return false && error; }()) {} // NG

--- a/test/fail_compilation/ice10949.d
+++ b/test/fail_compilation/ice10949.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10949.d(9): Error: array index 3 is out of bounds [5, 5][0 .. 2]
-fail_compilation/ice10949.d(9): Error: array index 17 is out of bounds [2, 3][0 .. 2]
+fail_compilation/ice10949.d(10): Error: array index 3 is out of bounds [5, 5][0 .. 2]
+fail_compilation/ice10949.d(10): Error: array index 17 is out of bounds [2, 3][0 .. 2]
+fail_compilation/ice10949.d(10): Error: array index 9 is out of bounds [3, 3, 3][0 .. 3]
 ---
 */
 int global;

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -217,6 +217,48 @@ void test8942()
 }
 
 /***************************************************/
+// 9073
+
+bool foo9073(bool expected, alias pred)()
+{
+    static if (expected)
+    {
+        enum isLessThan = (is(typeof(pred) : string) && pred == "a < b");
+    }
+    else
+    {
+        static if (is(typeof(pred) : string) && pred == "a < b")
+            enum isLessThan = true;
+        else
+            enum isLessThan = false;
+    }
+    return isLessThan;
+}
+
+template Failure9073() { static assert(0); enum Failure9073 = false; }
+template AndAnd9073a(alias pred) { enum bool AndAnd9073a = (is(typeof(pred) : string) && pred == "a < b"); }
+template AndAnd9073b(alias pred) { enum      AndAnd9073b = (is(typeof(pred) : string) && pred == "a < b"); }
+template   OrOr9073a(alias pred) { enum bool   OrOr9073a = (is(typeof(pred) : string) || Failure9073!()); }
+template   OrOr9073b(alias pred) { enum        OrOr9073b = (is(typeof(pred) : string) || Failure9073!()); }
+
+void test9073()
+{
+    assert(foo9073!(true,  "a < b")() == true);
+    assert(foo9073!(false, "a < b")() == true);
+    assert(foo9073!(true,  (a,b) => a<b)() == false);
+    assert(foo9073!(false, (a,b) => a<b)() == false);
+
+    static assert( AndAnd9073a!("a < b"));
+    static assert( AndAnd9073b!("a < b"));
+    static assert(!AndAnd9073a!((a,b)=>true));
+    static assert(!AndAnd9073b!((a,b)=>true));
+    static assert( OrOr9073a!("a < b"));
+    static assert( OrOr9073b!("a < b"));
+    static assert(!__traits(compiles, OrOr9073a!((a,b)=>true)));
+    static assert(!__traits(compiles, OrOr9073b!((a,b)=>true)));
+}
+
+/***************************************************/
 // 10144
 
 final class TNFA10144(char_t)
@@ -289,6 +331,7 @@ int main()
     test8147();
     test8410();
     test8942();
+    test9073();
     test10142();
 
     printf("Success\n");


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9073

The old one: https://github.com/D-Programming-Language/dmd/pull/1325

Based on #2558.
