### PR TITLE
Issue 10985 - Compiler doesn't attempt to inline non-templated functions from libraries (even having the full source)

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -5152,9 +5152,13 @@ void UnitTestDeclaration::semantic(Scope *sc)
     protection = sc->protection;
 
     if (scope)
-    {   sc = scope;
+    {
+        sc = scope;
         scope = NULL;
     }
+
+    if (!isInstantiated() && inNonRoot())
+        return;
 
     if (global.params.useUnitTests)
     {

--- a/src/mars.c
+++ b/src/mars.c
@@ -1632,26 +1632,19 @@ Language changes listed by -transition=id:\n\
         fatal();
     if (global.params.useInline)
     {
-        /* The problem with useArrayBounds and useAssert is that the
-         * module being linked to may not have generated them, so if
-         * we inline functions from those modules, the symbols for them will
-         * not be found at link time.
+        /* Do pass 3 semantic analysis on all imported modules,
+         * since otherwise functions in them cannot be inlined
          * We must do this BEFORE generating the .deps file!
          */
-        if (!global.params.useArrayBounds && !global.params.useAssert)
+        for (size_t i = 0; i < Module::amodules.dim; i++)
         {
-            // Do pass 3 semantic analysis on all imported modules,
-            // since otherwise functions in them cannot be inlined
-            for (size_t i = 0; i < Module::amodules.dim; i++)
-            {
-                Module *m = Module::amodules[i];
-                if (global.params.verbose)
-                    fprintf(global.stdmsg, "semantic3 %s\n", m->toChars());
-                m->semantic3();
-            }
-            if (global.errors)
-                fatal();
+            Module *m = Module::amodules[i];
+            if (global.params.verbose)
+                fprintf(global.stdmsg, "semantic3 %s\n", m->toChars());
+            m->semantic3();
         }
+        if (global.errors)
+            fatal();
     }
     Module::runDeferredSemantic3();
     if (global.errors)


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10985

<del>
This PR requires druntime fix: https://github.com/D-Programming-Language/druntime/pull/608

Today, implicitly generated code for assertions/array-bounds-check uses ModuleInfo object.
However `ModuleInfo` object won't be generated if the module is not in root - even though the code in module could be directly used by template instantiation and/or inlining.

To fix the issues:
1. Stop using ModuleInfo for assertion and array bounds check.
2. Relax the condition for inlining, due to fix bug 10985.
</del>

---

<del>
During the work, I found a wrong-code [bug 11049](http://d.puremagic.com/issues/show_bug.cgi?id=11049), and this PR also fixes it.
</del>
