### PR TITLE
10989 [CTFE] Uncaught exception messages are not pretty printed

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -157,7 +157,7 @@ char *ThrownExceptionExp::toChars()
 void ThrownExceptionExp::generateUncaughtError()
 {
     thrown->error("Uncaught CTFE exception %s(%s)", thrown->type->toChars(),
-        (*thrown->value->elements)[0]->toChars());
+        (*thrown->value->elements)[0]->toString()->toChars());
     /* Also give the line where the throw statement was. We won't have it
      * in the case where the ThrowStatement is generated internally
      * (eg, in ScopeStatement)

--- a/test/fail_compilation/ctfe10989.d
+++ b/test/fail_compilation/ctfe10989.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ctfe10989.d(11): Error: Uncaught CTFE exception object.Exception("abc"c)
+fail_compilation/ctfe10989.d(14):        called from here: throwing()
+fail_compilation/ctfe10989.d(14):        while evaluating: static assert(throwing())
+---
+*/
+int throwing() 
+{
+        throw new Exception(['a','b','c']); 
+        return 0; 
+}
+static assert(throwing());


### PR DESCRIPTION
Convert it to a StringExp before printing.
