### PR TITLE
Add new SHA1 and SHA256 instructions to integrate assembler.

### DIFF
--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -4651,6 +4651,42 @@ PTRNTAB3 aptb3VFMSUB231SS[] = /* VFMSUB231SS */ {
         { ASM_END },
 };
 
+/* ======================= SHA ======================= */
+
+PTRNTAB3 aptb3SHA1RNDS4[] = /* SHA1RNDS4 */ {
+        { 0x0F3ACC, _ib, _xmm, _xmm_m128, _imm8 },
+        { ASM_END },
+};
+
+PTRNTAB2 aptb2SHA1NEXTE[] = /* SHA1NEXTE */ {
+        { 0x0F38C8, _r, _xmm, _xmm_m128 },
+        { ASM_END }
+};
+
+PTRNTAB2 aptb2SHA1MSG1[] = /* SHA1MSG1 */ {
+        { 0x0F38C9, _r, _xmm, _xmm_m128 },
+        { ASM_END }
+};
+
+PTRNTAB2 aptb2SHA1MSG2[] = /* SHA1MSG2 */ {
+        { 0x0F38CA, _r, _xmm, _xmm_m128 },
+        { ASM_END }
+};
+
+PTRNTAB2 aptb2SHA256RNDS2[] = /* SHA256RNDS2 */ {
+        { 0x0F38CB, _r, _xmm, _xmm_m128 },
+        { ASM_END }
+};
+
+PTRNTAB2 aptb2SHA256MSG1[] = /* SHA256MSG1 */ {
+        { 0x0F38CC, _r, _xmm, _xmm_m128 },
+        { ASM_END }
+};
+
+PTRNTAB2 aptb2SHA256MSG2[] = /* SHA256MSG2 */ {
+        { 0x0F38CD, _r, _xmm, _xmm_m128 },
+        { ASM_END }
+};
 //////////////////////////////////////////////////////////////////////
 
 
@@ -5313,6 +5349,13 @@ PTRNTAB3 aptb3VFMSUB231SS[] = /* VFMSUB231SS */ {
         X("setz",           1,              (P) aptb1SETZ )                 \
         X("sfence",         0,              aptb0SFENCE)                    \
         X("sgdt",           1,              (P) aptb1SGDT )                 \
+        X("sha1msg1",       2,              (P) aptb2SHA1MSG1 )             \
+        X("sha1msg2",       2,              (P) aptb2SHA1MSG2 )             \
+        X("sha1nexte",      2,              (P) aptb2SHA1NEXTE )            \
+        X("sha1rnds4",      3,              (P) aptb3SHA1RNDS4 )            \
+        X("sha256msg1",     2,              (P) aptb2SHA256MSG1 )           \
+        X("sha256msg2",     2,              (P) aptb2SHA256MSG2 )           \
+        X("sha256rnds2",    2,              (P) aptb2SHA256RNDS2 )          \
         X("shl",            ITshift | 2,    (P) aptb2SHL )                  \
         X("shld",           3,              (P) aptb3SHLD )                 \
         X("shr",            ITshift | 2,    (P) aptb2SHR )                  \

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -4648,6 +4648,69 @@ L1:     pop     EAX;
     }
 }
 
+/* ======================= SHA ========================== */
+
+void test60()
+{
+    ubyte* p;
+    byte   m8;
+    short m16;
+    int   m32;
+    M64   m64;
+    M128 m128;
+    static ubyte data[] =
+    [
+0x0F,       0x3A, 0xCC, 0xD1, 0x01,           // sha1rnds4 XMM2, XMM1, 1;
+0x0F,       0x3A, 0xCC, 0x10, 0x01,           // sha1rnds4 XMM2, [RAX], 1;
+0x0F,       0x38, 0xC8, 0xD1,                 // sha1nexte XMM2, XMM1;
+0x0F,       0x38, 0xC8, 0x10,                 // sha1nexte XMM2, [RAX];
+0x0F,       0x38, 0xC9, 0xD1,                 // sha1msg1 XMM2, XMM1;
+0x0F,       0x38, 0xC9, 0x10,                 // sha1msg1 XMM2, [RAX];
+0x0F,       0x38, 0xCA, 0xD1,                 // sha1msg2 XMM2, XMM1;
+0x0F,       0x38, 0xCA, 0x10,                 // sha1msg2 XMM2, [RAX];
+0x0F,       0x38, 0xCB, 0xD1,                 // sha256rnds2 XMM2, XMM1;
+0x0F,       0x38, 0xCB, 0x10,                 // sha256rnds2 XMM2, [RAX];
+0x0F,       0x38, 0xCC, 0xD1,                 // sha256msg1 XMM2, XMM1;
+0x0F,       0x38, 0xCC, 0x10,                 // sha256msg1 XMM2, [RAX];
+0x0F,       0x38, 0xCD, 0xD1,                 // sha256msg2 XMM2, XMM1;
+0x0F,       0x38, 0xCD, 0x10,                 // sha256msg2 XMM2, [RAX];
+    ];
+
+    asm
+    {
+        call  L1;
+
+        sha1rnds4 XMM2, XMM1, 1;
+        sha1rnds4 XMM2, [EAX], 1;
+
+        sha1nexte XMM2, XMM1;
+        sha1nexte XMM2, [EAX];
+
+        sha1msg1 XMM2, XMM1;
+        sha1msg1 XMM2, [EAX];
+
+        sha1msg2 XMM2, XMM1;
+        sha1msg2 XMM2, [EAX];
+
+        sha256rnds2 XMM2, XMM1;
+        sha256rnds2 XMM2, [EAX];
+
+        sha256msg1 XMM2, XMM1;
+        sha256msg1 XMM2, [EAX];
+
+        sha256msg2 XMM2, XMM1;
+        sha256msg2 XMM2, [EAX];
+
+L1:     pop     EAX;
+        mov     p[EBP],EAX;
+    }
+
+    foreach (ref i, b; data)
+    {
+        //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+        assert(p[i] == b);
+    }
+}
 
 void test9866()
 {
@@ -4776,6 +4839,7 @@ int main()
     test57();
     test58();
     test59();
+    test60();
     test9866();
   }
     printf("Success\n");

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -6399,6 +6399,70 @@ L1:     pop     RAX;
     assert(p[data.length] == 0x58); // pop RAX
 }
 
+/* ======================= SHA ========================== */
+
+void test62()
+{
+    ubyte* p;
+    byte   m8;
+    short m16;
+    int   m32;
+    M64   m64;
+    M128 m128;
+    static ubyte data[] =
+    [
+0x0F,       0x3A, 0xCC, 0xD1, 0x01,           // sha1rnds4 XMM2, XMM1, 1;
+0x0F,       0x3A, 0xCC, 0x10, 0x01,           // sha1rnds4 XMM2, [RAX], 1;
+0x0F,       0x38, 0xC8, 0xD1,                 // sha1nexte XMM2, XMM1;
+0x0F,       0x38, 0xC8, 0x10,                 // sha1nexte XMM2, [RAX];
+0x0F,       0x38, 0xC9, 0xD1,                 // sha1msg1 XMM2, XMM1;
+0x0F,       0x38, 0xC9, 0x10,                 // sha1msg1 XMM2, [RAX];
+0x0F,       0x38, 0xCA, 0xD1,                 // sha1msg2 XMM2, XMM1;
+0x0F,       0x38, 0xCA, 0x10,                 // sha1msg2 XMM2, [RAX];
+0x0F,       0x38, 0xCB, 0xD1,                 // sha256rnds2 XMM2, XMM1;
+0x0F,       0x38, 0xCB, 0x10,                 // sha256rnds2 XMM2, [RAX];
+0x0F,       0x38, 0xCC, 0xD1,                 // sha256msg1 XMM2, XMM1;
+0x0F,       0x38, 0xCC, 0x10,                 // sha256msg1 XMM2, [RAX];
+0x0F,       0x38, 0xCD, 0xD1,                 // sha256msg2 XMM2, XMM1;
+0x0F,       0x38, 0xCD, 0x10,                 // sha256msg2 XMM2, [RAX];
+    ];
+
+    asm
+    {
+        call  L1;
+
+        sha1rnds4 XMM2, XMM1, 1;
+        sha1rnds4 XMM2, [RAX], 1;
+
+        sha1nexte XMM2, XMM1;
+        sha1nexte XMM2, [RAX];
+
+        sha1msg1 XMM2, XMM1;
+        sha1msg1 XMM2, [RAX];
+
+        sha1msg2 XMM2, XMM1;
+        sha1msg2 XMM2, [RAX];
+
+        sha256rnds2 XMM2, XMM1;
+        sha256rnds2 XMM2, [RAX];
+
+        sha256msg1 XMM2, XMM1;
+        sha256msg1 XMM2, [RAX];
+
+        sha256msg2 XMM2, XMM1;
+        sha256msg2 XMM2, [RAX];
+
+L1:     pop     RAX;
+        mov     p[RBP],RAX;
+    }
+
+    foreach (ref i, b; data)
+    {
+        //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+        assert(p[i] == b);
+    }
+}
+
 
 void test2941()
 {
@@ -6599,6 +6663,7 @@ int main()
     test59();
     test60();
     test61();
+    test62();
     test2941();
     test9866();
     testxadd();


### PR DESCRIPTION
These instruction were added to the latest Intel CPUs. `core.cpuid` is already able to detect presence of these instructions.
