### PR TITLE
refactor enum code to do forward references of members

### DIFF
--- a/src/enum.h
+++ b/src/enum.h
@@ -27,7 +27,13 @@ class VarDeclaration;
 class EnumDeclaration : public ScopeDsymbol
 {
 public:
-    /* enum id : memtype { ... }
+    /* The separate, and distinct, cases are:
+     *  1. enum { ... }
+     *  2. enum : memtype { ... }
+     *  3. enum id { ... }
+     *  4. enum id : memtype { ... }
+     *  5. enum id : memtype;
+     *  6. enum id;
      */
     Type *type;                 // the TypeEnum
     Type *memtype;              // type of the members
@@ -40,7 +46,7 @@ private:
 
 public:
     bool isdeprecated;
-    Scope *sce;                 // scope for evaluating members
+    bool added;
 
     EnumDeclaration(Loc loc, Identifier *id, Type *memtype);
     Dsymbol *syntaxCopy(Dsymbol *s);
@@ -78,9 +84,15 @@ public:
 class EnumMember : public Dsymbol
 {
 public:
-    EnumDeclaration *ed;
+    /* Can take the following forms:
+     *  1. id
+     *  2. id = value
+     *  3. type id = value
+     */
     Expression *value;
     Type *type;
+
+    EnumDeclaration *ed;
     VarDeclaration *vd;
 
     EnumMember(Loc loc, Identifier *id, Expression *value, Type *type);

--- a/src/expression.c
+++ b/src/expression.c
@@ -3540,18 +3540,6 @@ Lagain:
     em = s->isEnumMember();
     if (em)
     {
-        if (em->ed->semanticRun == PASSinit)
-        {
-            assert(em->ed->scope);
-            em->ed->semantic(NULL);
-        }
-        e = em->value;
-        if (!e)
-        {
-            em->errors = true;
-            error("forward reference of %s %s", s->kind(), s->toChars());
-            return new ErrorExp();
-        }
         return em->getVarExp(loc, sc);
     }
     v = s->isVarDeclaration();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7386,11 +7386,8 @@ Type *TypeEnum::syntaxCopy()
 Type *TypeEnum::semantic(Loc loc, Scope *sc)
 {
     //printf("TypeEnum::semantic() %s\n", toChars());
-    if (sym->semanticRun == PASSinit)
-    {
-        assert(sym->scope);
-        sym->semantic(sym->scope);
-    }
+    if (deco)
+        return this;
     return merge();
 }
 
@@ -7592,6 +7589,11 @@ int TypeEnum::hasPointers()
 
 Type *TypeEnum::nextOf()
 {
+    if (sym->semanticRun == PASSinit)
+    {
+        assert(sym->scope);
+        sym->semantic(sym->scope);
+    }
     assert(sym->memtype);
     return sym->memtype->nextOf();
 }

--- a/test/fail_compilation/fail9892.d
+++ b/test/fail_compilation/fail9892.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9892.d(11): Error: forward reference of enum member b
+fail_compilation/fail9892.d(11): Error: enum member fail9892.a circular reference to enum member
 ---
 */
 

--- a/test/runnable/testenum.d
+++ b/test/runnable/testenum.d
@@ -378,6 +378,41 @@ enum : int { e10788 }
 
 /**********************************************/
 
+class C7
+{
+    enum Policy
+    {
+        PREFER_READERS,
+        PREFER_WRITERS
+    }
+
+    void foo1( Policy policy = Policy.PREFER_READERS ) { }
+    void foo2( Policy policy = Policy.PREFER_WRITERS ) { }
+}
+
+/**********************************************/
+
+void test8()
+{
+    enum E
+    {
+        A = B,
+	E = D + 7,
+        B = 3,
+	C,
+	D,
+    }
+
+    assert(E.A == 3);
+    assert(E.B == 3);
+    assert(E.C == 4);
+    assert(E.D == 5);
+    assert(E.E == 12);
+    assert(E.max == 12);
+}
+
+/**********************************************/
+
 int main()
 {
     test1();
@@ -389,6 +424,7 @@ int main()
     test2407();
     test10113();
     test10561();
+    test8();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Refactored to switch to lazy evaluation of enum members, which also enables enum members to be evaluated in any order.
