### PR TITLE
CTFE optimsation: Remember when constfolding has been done

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3879,7 +3879,7 @@ StringExp::StringExp(Loc loc, char *string)
     this->sz = 1;
     this->committed = 0;
     this->postfix = 0;
-    this->ownedByCtfe = false;
+    this->ctfeOwned = notCtfe;
 }
 
 StringExp::StringExp(Loc loc, void *string, size_t len)
@@ -3890,7 +3890,7 @@ StringExp::StringExp(Loc loc, void *string, size_t len)
     this->sz = 1;
     this->committed = 0;
     this->postfix = 0;
-    this->ownedByCtfe = false;
+    this->ctfeOwned = notCtfe;
 }
 
 StringExp::StringExp(Loc loc, void *string, size_t len, utf8_t postfix)
@@ -3901,7 +3901,7 @@ StringExp::StringExp(Loc loc, void *string, size_t len, utf8_t postfix)
     this->sz = 1;
     this->committed = 0;
     this->postfix = postfix;
-    this->ownedByCtfe = false;
+    this->ctfeOwned = notCtfe;
 }
 
 StringExp *StringExp::create(Loc loc, char *s)
@@ -4287,7 +4287,7 @@ ArrayLiteralExp::ArrayLiteralExp(Loc loc, Expressions *elements)
     : Expression(loc, TOKarrayliteral, sizeof(ArrayLiteralExp))
 {
     this->elements = elements;
-    this->ownedByCtfe = false;
+    this->ctfeOwned = notCtfe;
 }
 
 ArrayLiteralExp::ArrayLiteralExp(Loc loc, Expression *e)
@@ -4295,7 +4295,7 @@ ArrayLiteralExp::ArrayLiteralExp(Loc loc, Expression *e)
 {
     elements = new Expressions;
     elements->push(e);
-    this->ownedByCtfe = false;
+    this->ctfeOwned = notCtfe;
 }
 
 bool ArrayLiteralExp::equals(RootObject *o)
@@ -4429,7 +4429,7 @@ AssocArrayLiteralExp::AssocArrayLiteralExp(Loc loc,
     assert(keys->dim == values->dim);
     this->keys = keys;
     this->values = values;
-    this->ownedByCtfe = false;
+    this->ctfeOwned = notCtfe;
 }
 
 bool AssocArrayLiteralExp::equals(RootObject *o)
@@ -4551,7 +4551,7 @@ StructLiteralExp::StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *
     this->sym = NULL;
     this->soffset = 0;
     this->fillHoles = 1;
-    this->ownedByCtfe = false;
+    this->ctfeOwned = notCtfe;
     this->origin = this;
     this->stageflags = 0;
     this->inlinecopy = NULL;


### PR DESCRIPTION
When an array literal or struct literal originated in CTFE, interpreting it again will have no effect. 

Potentially this optimsation could have a large impact on compilation time, or may make almost no difference. Let's see,
