### PR TITLE
10381 Nonsense associative array comparison

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -13118,6 +13118,11 @@ Expression *CmpExp::semantic(Scope *sc)
         error("compare not defined for complex operands");
         e = new ErrorExp();
     }
+    else if (t1->ty == Taarray || t2->ty == Taarray)
+    {
+        error("%s is not defined for associative arrays", Token::toChars(op));
+        e = new ErrorExp();
+    }
     else if (t1->ty == Tvector)
         return incompatibleTypes();
     else

--- a/test/fail_compilation/aacmp10381.d
+++ b/test/fail_compilation/aacmp10381.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/aacmp10381.d(12): Error: > is not defined for associative arrays
+---
+*/
+
+bool test10381()
+{
+    int[int] aa1 = [0: 1];
+    int[int] aa2 = [0: 1];
+    return aa1 > aa2;
+}


### PR DESCRIPTION
Make aa1 > aa2 illegal. It doesn't make sense.
http://d.puremagic.com/issues/show_bug.cgi?id=10381
