### PR TITLE
fix Issue 11081: duplicate COMDAT with failed compilation with lambdas

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -766,6 +766,7 @@ public:
         ForeachStatement *fes, Identifier *id = NULL);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Dsymbol *syntaxCopy(Dsymbol *);
+    void genIdent(Scope *sc, TemplateDeclaration *td);
     bool isNested();
     bool isVirtual();
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -6018,15 +6018,15 @@ FuncExp::FuncExp(Loc loc, FuncLiteralDeclaration *fd, TemplateDeclaration *td)
     tok = fd->tok;  // save original kind of function/delegate/(infer)
 }
 
-void FuncExp::genIdent(Scope *sc)
+void FuncLiteralDeclaration::genIdent(Scope *sc, TemplateDeclaration *td)
 {
-    if (fd->ident == Id::empty)
+    if (ident == Id::empty)
     {
         const char *s;
-        if (fd->fes)                        s = "__foreachbody";
-        else if (fd->tok == TOKreserved)    s = "__lambda";
-        else if (fd->tok == TOKdelegate)    s = "__dgliteral";
-        else                                s = "__funcliteral";
+        if (fes)                        s = "__foreachbody";
+        else if (tok == TOKreserved)    s = "__lambda";
+        else if (tok == TOKdelegate)    s = "__dgliteral";
+        else                            s = "__funcliteral";
 
         DsymbolTable *symtab;
         if (sc->flags & (SCOPEstaticif | SCOPEstaticassert))
@@ -6045,9 +6045,9 @@ void FuncExp::genIdent(Scope *sc)
             assert(symtab);
             int num = _aaLen(symtab->tab) + 1;
             Identifier *id = Lexer::uniqueId(s, num);
-            fd->ident = id;
+            ident = id;
             if (td) td->ident = id;
-            symtab->insert(td ? (Dsymbol *)td : (Dsymbol *)fd);
+            symtab->insert(td ? (Dsymbol *)td : (Dsymbol *)this);
         }
     }
 }
@@ -6092,7 +6092,7 @@ Expression *FuncExp::semantic(Scope *sc)
         //if (fd->treq)
         //    fd->treq = fd->treq->semantic(loc, sc);
 
-        genIdent(sc);
+        fd->genIdent(sc, td);
 
         // Set target of return type inference
         if (fd->treq && !fd->type->nextOf())
@@ -6191,7 +6191,7 @@ Expression *FuncExp::semantic(Scope *sc, Expressions *arguments)
                 return checkarg;
         }
 
-        genIdent(sc);
+        fd->genIdent(sc, td);
 
         assert(td->parameters && td->parameters->dim);
         td->semantic(sc);

--- a/src/expression.h
+++ b/src/expression.h
@@ -751,7 +751,6 @@ public:
     TOK tok;
 
     FuncExp(Loc loc, FuncLiteralDeclaration *fd, TemplateDeclaration *td = NULL);
-    void genIdent(Scope *sc);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *semantic(Scope *sc, Expressions *arguments);

--- a/src/func.c
+++ b/src/func.c
@@ -1833,6 +1833,9 @@ bool FuncDeclaration::functionSemantic()
             return false;
     }
 
+    if(FuncLiteralDeclaration* fld = isFuncLiteralDeclaration())
+        fld->genIdent(scope, 0);
+
     // if inferring return type, sematic3 needs to be run
     if (inferRetType && type && !type->nextOf())
         return functionSemantic3();

--- a/src/glue.c
+++ b/src/glue.c
@@ -563,6 +563,8 @@ void FuncDeclaration::toObjFile(int multiobj)
     }
     if (func->isUnitTestDeclaration() && !global.params.useUnitTests)
         return;
+    if (func->isFuncLiteralDeclaration() && func->ident->len == 0)
+        return; // function literal never referenced from an expression, do not emit
 
     if (multiobj && !isStaticDtorDeclaration() && !isStaticCtorDeclaration())
     {   obj_append(this);

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1310,8 +1310,12 @@ void TemplateInstance::toObjFile(int multiobj)
 #if LOG
     printf("TemplateInstance::toObjFile('%s', this = %p)\n", toChars(), this);
 #endif
-    if (!errors && members)
+    if (members)
     {
+        for (Dsymbol* p = this; p; p = p->parent)
+            if (p->errors)
+                return; // will fail to build correct symbols anyway
+
         if (multiobj)
             // Append to list of object files to be written later
             obj_append(this);

--- a/test/runnable/test11081.d
+++ b/test/runnable/test11081.d
@@ -1,0 +1,18 @@
+module test11081;
+
+T ifThrown2(E : Throwable, T)(T delegate(E) errorHandler)
+{
+	return errorHandler();
+}
+
+static if (__traits(compiles, ifThrown2!Exception(e => 0))) //This will only work with a fix that was not yet pulled
+{
+}
+
+static if (__traits(compiles, ifThrown2!Exception(e => 0))) //This will only work with a fix that was not yet pulled
+{
+}
+
+void main()
+{
+}


### PR DESCRIPTION
This patch avoids code generation for template instances with erronous parents. This mostly happens for !__traits(compiles) expressions.
At the same time it fixes mangled names for function literals used as alias template parameters.

http://d.puremagic.com/issues/show_bug.cgi?id=11081
