### PR TITLE
fix Issue 10993: mangling of voldemort types with lambdas changes during return type inference

### DIFF
--- a/src/mangle.c
+++ b/src/mangle.c
@@ -337,7 +337,7 @@ const char *TemplateInstance::mangle(bool isv)
         Dsymbol *par = enclosing || isTemplateMixin() ? parent : tempdecl->parent;
         if (par)
         {
-            const char *p = par->mangle();
+            const char *p = par->mangle(isv);
             if (p[0] == '_' && p[1] == 'D')
                 p += 2;
             buf.writestring(p);

--- a/test/compilable/test10993.d
+++ b/test/compilable/test10993.d
@@ -1,0 +1,33 @@
+module test10993;
+
+auto foo(T)(T a)
+{
+	static immutable typeof(a) q;
+//	pragma(msg, "foo: " ~ typeof(q).mangleof);
+	return q;
+}
+
+struct test(alias fn)
+{
+	bool ini = true;
+	void* p;
+}
+
+auto fun()
+{
+	auto x = foo!()(test!(a=>a)());
+//	pragma(msg, "fun: " ~ typeof(x).mangleof);
+	
+	return x;
+}
+
+void main()
+{
+	const x = fun();
+	enum mangle_x = typeof(x).mangleof;
+//	pragma(msg, "x  : " ~ mangle_x);
+	auto y = cast()x;
+	enum mangle_y = typeof(y).mangleof;
+//	pragma(msg, "y  : " ~ mangle_y);
+	static assert (mangle_y == mangle_x[1..$]);
+}


### PR DESCRIPTION
I'm not really knowing what's going on here, but it looks like an oversight not to forward isv.
