### PR TITLE
Issue 11125 - UFCS instantiation of template causes template constraint to be skipped

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8445,7 +8445,6 @@ Expression *CallExp::semantic(Scope *sc)
     Type *t1;
     int istemp;
     Objects *tiargs = NULL;     // initial list of template arguments
-    TemplateInstance *tierror = NULL;
     Expression *ethis = NULL;
     Type *tthis = NULL;
 
@@ -8519,7 +8518,6 @@ Expression *CallExp::semantic(Scope *sc)
                 /* Go with partial explicit specialization
                  */
                 tiargs = ti->tiargs;
-                tierror = ti;                   // for error reporting
                 assert(ti->tempdecl);
                 if (TemplateDeclaration *td = ti->tempdecl->isTemplateDeclaration())
                     e1 = new TemplateExp(loc, td);
@@ -8559,7 +8557,6 @@ Ldotti:
                 /* Go with partial explicit specialization
                  */
                 tiargs = ti->tiargs;
-                tierror = ti;                   // for error reporting
                 assert(ti->tempdecl);
                 if (TemplateDeclaration *td = ti->tempdecl->isTemplateDeclaration())
                     e1 = new DotTemplateExp(loc, se->e1, td);
@@ -9061,10 +9058,7 @@ Lagain:
             TemplateExp *te = (TemplateExp *)e1;
             f = resolveFuncCall(loc, sc, te->td, tiargs, NULL, arguments);
             if (!f)
-            {   if (tierror)
-                    tierror->error("errors instantiating template");    // give better error message
                 return new ErrorExp();
-            }
             if (f->needThis())
             {
                 if (hasThis(sc))

--- a/src/func.c
+++ b/src/func.c
@@ -3837,16 +3837,24 @@ void FuncLiteralDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
     TypeFunction *tf = (TypeFunction *)type;
     // Don't print tf->mod, tf->trust, and tf->linkage
-    if (tf->next)
+    if (!inferRetType && tf->next)
         tf->next->toCBuffer2(buf, hgs, 0);
     Parameter::argsToCBuffer(buf, hgs, tf->parameters, tf->varargs);
 
-    ReturnStatement *ret = !fbody->isCompoundStatement() ?
-                            fbody->isReturnStatement() : NULL;
-    if (ret && ret->exp)
+    CompoundStatement *cs = fbody->isCompoundStatement();
+    Statement *s1;
+    if (semanticRun >= PASSsemantic3done)
+    {
+        assert(cs);
+        s1 = (*cs->statements)[cs->statements->dim - 1];
+    }
+    else
+        s1 = !cs ? fbody : NULL;
+    ReturnStatement *rs = s1 ? s1->isReturnStatement() : NULL;
+    if (rs && rs->exp)
     {
         buf->writestring(" => ");
-        ret->exp->toCBuffer(buf, hgs);
+        rs->exp->toCBuffer(buf, hgs);
     }
     else
     {

--- a/src/template.c
+++ b/src/template.c
@@ -2072,6 +2072,13 @@ RootObject *TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *
         sa = ((ScopeExp *)ea)->sds;
     else if (ea && (ea->op == TOKthis || ea->op == TOKsuper))
         sa = ((ThisExp *)ea)->var;
+    else if (ea && ea->op == TOKfunction)
+    {
+        if (((FuncExp *)ea)->td)
+            sa = ((FuncExp *)ea)->td;
+        else
+            sa = ((FuncExp *)ea)->fd;
+    }
 
     if (targ)
     {
@@ -2081,14 +2088,6 @@ RootObject *TemplateDeclaration::declareParameter(Scope *sc, TemplateParameter *
     else if (sa)
     {
         //printf("Alias %s %s;\n", sa->ident->toChars(), tp->ident->toChars());
-        s = new AliasDeclaration(Loc(), tp->ident, sa);
-    }
-    else if (ea && ea->op == TOKfunction)
-    {
-        if (((FuncExp *)ea)->td)
-            sa = ((FuncExp *)ea)->td;
-        else
-            sa = ((FuncExp *)ea)->fd;
         s = new AliasDeclaration(Loc(), tp->ident, sa);
     }
     else if (ea)
@@ -6166,8 +6165,8 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                 else if (fe->td)
                 {   /* If template argument is a template lambda,
                      * get template declaration itself. */
-                    sa = fe->td;
-                    goto Ldsym;
+                    //sa = fe->td;
+                    //goto Ldsym;
                 }
             }
             if (ea->op == TOKdotvar)

--- a/test/fail_compilation/fail10346.d
+++ b/test/fail_compilation/fail10346.d
@@ -1,17 +1,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10346.d(13): Error: undefined identifier T
+fail_compilation/fail10346.d(12): Error: undefined identifier T
 fail_compilation/fail10346.d(16): Error: template fail10346.bar does not match any function template declaration. Candidates are:
-fail_compilation/fail10346.d(13):        fail10346.bar(T x, T)(Foo!T)
+fail_compilation/fail10346.d(12):        fail10346.bar(T x, T)(Foo!T)
 fail_compilation/fail10346.d(16): Error: template fail10346.bar(T x, T)(Foo!T) cannot deduce template function from argument types !(10)(Foo!int)
-fail_compilation/fail10346.d(16): Error: template instance bar!10 errors instantiating template
 ---
 */
 
 struct Foo(T) {}
 void bar(T x, T)(Foo!T) {}
-void main() {
+void main()
+{
     Foo!int spam;
     bar!10(spam);
 }

--- a/test/fail_compilation/fail11125.d
+++ b/test/fail_compilation/fail11125.d
@@ -1,0 +1,26 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11125.d(24): Error: template fail11125.filter does not match any function template declaration. Candidates are:
+fail_compilation/fail11125.d(15):        fail11125.filter(alias predfun) if (is(ReturnType!predfun == bool))
+fail_compilation/fail11125.d(24): Error: template fail11125.filter(alias predfun) if (is(ReturnType!predfun == bool)) cannot deduce template function from argument types !(function (int a) => a + 1)(int[])
+fail_compilation/fail11125.d(25): Error: template fail11125.filter does not match any function template declaration. Candidates are:
+fail_compilation/fail11125.d(15):        fail11125.filter(alias predfun) if (is(ReturnType!predfun == bool))
+fail_compilation/fail11125.d(25): Error: template fail11125.filter(alias predfun) if (is(ReturnType!predfun == bool)) cannot deduce template function from argument types !(function (int a) => a + 1)(int[])
+---
+*/
+
+template ReturnType(alias fun) { alias int ReturnType; }
+
+template filter(alias predfun)
+    if (is(ReturnType!predfun == bool))
+{
+    static assert(is(ReturnType!predfun == bool));
+    auto filter(Range)(Range r) { }
+}
+
+void main()
+{
+    filter!((int a) => a + 1)([1]);  // fails in constraint
+    [1].filter!((int a) => a + 1);   // fails internally in static assert!
+}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11125
- Just add test case for issue 11125.
- Improve diagnostic messages for function literals and function template call failure.
