### PR TITLE
Issue 7892 - Compiler-generated struct copies can result in errors when ctor is @disable'd

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1296,11 +1296,12 @@ Lnomatch:
         }
     }
 
-    if (!(storage_class & (STCctfe | STCref)) && tbn->ty == Tstruct &&
+    if (!(storage_class & (STCctfe | STCref | STCresult)) && tbn->ty == Tstruct &&
         ((TypeStruct *)tbn)->sym->noDefaultCtor)
     {
         if (!init)
-        {   if (isField())
+        {
+            if (isField())
                 /* For fields, we'll check the constructor later to make sure it is initialized
                  */
                 storage_class |= STCnodefaultctor;

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -458,6 +458,36 @@ class DC7883 : CC7883
 }
 
 /*******************************************/
+// 7892
+
+struct S7892
+{
+    @disable this();
+    this(int x) {}
+}
+
+S7892 f7892()
+out (result) {}     // case 1
+body
+{
+    return S7892(1);
+}
+
+interface I7892
+{
+    S7892 f();
+}
+class C7892
+{
+    invariant() {}  // case 2
+
+    S7892 f()
+    {
+        return S7892(1);
+    }
+}
+
+/*******************************************/
 // 8066
 
 struct CLCommandQueue


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=7892
