### PR TITLE
[REG2.064a] Issue 10687 - Refused cast from uint[] to array of uint-based enums at compile-time

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -600,9 +600,12 @@ bool isSafePointerCast(Type *srcPointee, Type *destPointee)
     if (destPointee->ty == Tvoid)
         return true;
 
-    // It's OK if they are the same size integers, eg int* and uint*
-    return srcPointee->isintegral() && destPointee->isintegral()
-           && srcPointee->size() == destPointee->size();
+    // It's OK if they are the same size (static array of) integers, eg:
+    //     int*     --> uint*
+    //     int[5][] --> uint[5][]
+    return srcPointee->baseElemOf()->isintegral() &&
+           destPointee->baseElemOf()->isintegral() &&
+           srcPointee->size() == destPointee->size();
 }
 
 Expression *getAggregateFromPointer(Expression *e, dinteger_t *ofs)

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3113,12 +3113,16 @@ void test112()
 // 10687
 
 enum Foo10687 : uint { A, B, C, D, E }
+immutable uint[5][] m10687 = [[0, 1, 2, 3, 4]];
 
 void test10687()
 {
     static immutable uint[5] a1 = [0, 1, 2, 3, 4];
-    auto a2 = cast(immutable(Foo10687[5]))a1;
+    auto   a2 = cast(immutable(Foo10687[5]))a1;
     static a3 = cast(immutable(Foo10687[5]))a1;
+
+    auto   foos1 = cast(immutable(Foo10687[5][]))m10687;
+    static foos2 = cast(immutable(Foo10687[5][]))m10687;
 }
 
 /************************************************/


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10687

Fixup of `isSafePointerCast` in `ctfeexpr.c`.
@donc, could you please review this?
