### PR TITLE
fix Issue 6107 - ICE(expression.c) when a non-template member named '__c...

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -105,6 +105,7 @@ public:
     bool isNested();
     void makeNested();
     bool isExport();
+    void searchCtor();
 
     void emitComment(Scope *sc);
     void toJson(JsonOut *json);

--- a/src/class.c
+++ b/src/class.c
@@ -687,11 +687,7 @@ void ClassDeclaration::semantic(Scope *sc)
     /* Look for special member functions.
      * They must be in this class, not in a base class.
      */
-    ctor = search(Loc(), Id::ctor, 0);
-#if DMDV1
-    if (ctor && (ctor->toParent() != this || !ctor->isCtorDeclaration()))
-        ctor = NULL;
-#else
+    searchCtor();
     if (ctor && (ctor->toParent() != this || !(ctor->isCtorDeclaration() || ctor->isTemplateDeclaration())))
         ctor = NULL;    // search() looks through ancestor classes
     if (!ctor && noDefaultCtor)
@@ -704,11 +700,6 @@ void ClassDeclaration::semantic(Scope *sc)
                 ::error(v->loc, "field %s must be initialized in constructor", v->toChars());
         }
     }
-#endif
-
-//    dtor = (DtorDeclaration *)search(Id::dtor, 0);
-//    if (dtor && dtor->toParent() != this)
-//      dtor = NULL;
 
     inv = buildInv(sc);
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -529,6 +529,25 @@ int AggregateDeclaration::numFieldsInUnion(int firstIndex)
     return count;
 }
 
+/*******************************************
+ * Look for constructor declaration.
+ */
+void AggregateDeclaration::searchCtor()
+{
+    ctor = search(Loc(), Id::ctor, 0);
+    if (ctor)
+    {
+        if (!(ctor->isCtorDeclaration() ||
+              ctor->isTemplateDeclaration() ||
+              ctor->isOverloadSet()))
+        {
+            error("%s %s is not a constructor; identifiers starting with __ are reserved for the implementation", ctor->kind(), ctor->toChars());
+            errors = true;
+            ctor = NULL;
+        }
+    }
+}
+
 /********************************* StructDeclaration ****************************/
 
 StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
@@ -817,9 +836,7 @@ void StructDeclaration::semantic(Scope *sc)
 
     /* Look for special member functions.
      */
-#if DMDV2
-    ctor = search(Loc(), Id::ctor, 0);
-#endif
+    searchCtor();
     aggNew =       (NewDeclaration *)search(Loc(), Id::classNew,       0);
     aggDelete = (DeleteDeclaration *)search(Loc(), Id::classDelete,    0);
 

--- a/test/fail_compilation/fail6107.d
+++ b/test/fail_compilation/fail6107.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail6107.d(8): Error: struct fail6107.Foo variable __ctor is not a constructor; identifiers starting with __ are reserved for the implementation
+fail_compilation/fail6107.d(11): Error: class fail6107.Bar variable __ctor is not a constructor; identifiers starting with __ are reserved for the implementation
+---
+*/
+struct Foo {
+    enum __ctor = 4;
+}
+class Bar {
+    int __ctor = 4;
+}
+


### PR DESCRIPTION
...tor' exists in a struct, and the constructor is attempted to be invoked.
