### PR TITLE
[Trivial] Fix listener.d to work on 64 bits

### DIFF
--- a/samples/listener.d
+++ b/samples/listener.d
@@ -1,4 +1,3 @@
-
 /*
         D listener written by Christopher E. Miller
         This code is public domain.
@@ -50,7 +49,7 @@ next:
             if (sset.isSet(reads[i]))
             {
                 char[1024] buf;
-                int read = reads[i].receive(buf);
+                ptrdiff_t read = reads[i].receive(buf);
 
                 if (Socket.ERROR == read)
                 {


### PR DESCRIPTION
According to http://dlang.org/phobos/std_socket.html#.Socket.receive the return type of std.socket.receive is ptrdiff_t. Hence it won't compile on a 64 bits architecture.
