### PR TITLE
Send all verbose messages to global.stdmsg.

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1050,7 +1050,7 @@ void PragmaDeclaration::semantic(Scope *sc)
                 memcpy(name, se->string, se->len);
                 name[se->len] = 0;
                 if (global.params.verbose)
-                    printf("library   %s\n", name);
+                    fprintf(global.stdmsg, "library   %s\n", name);
                 if (global.params.moduleDeps && !global.params.moduleDepsFile)
                 {
                     OutBuffer *ob = global.params.moduleDeps;
@@ -1168,7 +1168,7 @@ void PragmaDeclaration::semantic(Scope *sc)
         {
             /* Print unrecognized pragmas
              */
-            printf("pragma    %s", ident->toChars());
+            fprintf(global.stdmsg, "pragma    %s", ident->toChars());
             if (args)
             {
                 for (size_t i = 0; i < args->dim; i++)
@@ -1182,15 +1182,15 @@ void PragmaDeclaration::semantic(Scope *sc)
 
                     e = e->ctfeInterpret();
                     if (i == 0)
-                        printf(" (");
+                        fprintf(global.stdmsg, " (");
                     else
-                        printf(",");
-                    printf("%s", e->toChars());
+                        fprintf(global.stdmsg, ",");
+                    fprintf(global.stdmsg, "%s", e->toChars());
                 }
                 if (args->dim)
-                    printf(")");
+                    fprintf(global.stdmsg, ")");
             }
-            printf("\n");
+            fprintf(global.stdmsg, "\n");
         }
         goto Lnodecl;
     }

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1201,7 +1201,7 @@ Lnomatch:
             {
                 const char *p = loc.toChars();
                 const char *s = (storage_class & STCimmutable) ? "immutable" : "const";
-                fprintf(stderr, "%s: %s.%s is %s field\n", p ? p : "", ad->toPrettyChars(), toChars(), s);
+                fprintf(global.stdmsg, "%s: %s.%s is %s field\n", p ? p : "", ad->toPrettyChars(), toChars(), s);
             }
             storage_class |= STCfield;
 #if DMDV2

--- a/src/expression.c
+++ b/src/expression.c
@@ -7327,7 +7327,7 @@ Expression *FileExp::semantic(Scope *sc)
     }
 
     if (global.params.verbose)
-        printf("file      %s\t(%s)\n", (char *)se->string, name);
+        fprintf(global.stdmsg, "file      %s\t(%s)\n", (char *)se->string, name);
     if (global.params.moduleDeps != NULL && global.params.moduleDepsFile == NULL)
     {
         OutBuffer *ob = global.params.moduleDeps;

--- a/src/glue.c
+++ b/src/glue.c
@@ -622,7 +622,7 @@ void FuncDeclaration::toObjFile(int multiobj)
     semanticRun = PASSobj;
 
     if (global.params.verbose)
-        printf("function  %s\n",func->toPrettyChars());
+        fprintf(global.stdmsg, "function  %s\n",func->toPrettyChars());
 
     Symbol *s = func->toSymbol();
     func_t *f = s->Sfunc;

--- a/src/json.c
+++ b/src/json.c
@@ -82,7 +82,7 @@ void json_generate(OutBuffer *buf, Modules *modules)
     for (size_t i = 0; i < modules->dim; i++)
     {   Module *m = (*modules)[i];
         if (global.params.verbose)
-            printf("json gen %s\n", m->toChars());
+            fprintf(global.stdmsg, "json gen %s\n", m->toChars());
         m->toJson(&json);
     }
     json.arrayEnd();

--- a/src/libelf.c
+++ b/src/libelf.c
@@ -113,7 +113,7 @@ void LibElf::setFilename(char *dir, char *filename)
 void LibElf::write()
 {
     if (global.params.verbose)
-        printf("library   %s\n", libfile->name->toChars());
+        fprintf(global.stdmsg, "library   %s\n", libfile->name->toChars());
 
     OutBuffer libbuf;
     WriteLibToBuffer(&libbuf);

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -123,7 +123,7 @@ void LibMach::setFilename(char *dir, char *filename)
 void LibMach::write()
 {
     if (global.params.verbose)
-        printf("library   %s\n", libfile->name->toChars());
+        fprintf(global.stdmsg, "library   %s\n", libfile->name->toChars());
 
     OutBuffer libbuf;
     WriteLibToBuffer(&libbuf);

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -139,7 +139,7 @@ void LibMSCoff::setFilename(char *dir, char *filename)
 void LibMSCoff::write()
 {
     if (global.params.verbose)
-        printf("library   %s\n", libfile->name->toChars());
+        fprintf(global.stdmsg, "library   %s\n", libfile->name->toChars());
 
     OutBuffer libbuf;
     WriteLibToBuffer(&libbuf);

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -119,7 +119,7 @@ void LibOMF::setFilename(char *dir, char *filename)
 void LibOMF::write()
 {
     if (global.params.verbose)
-        printf("library   %s\n", libfile->name->toChars());
+        fprintf(global.stdmsg, "library   %s\n", libfile->name->toChars());
 
     OutBuffer libbuf;
     WriteLibToBuffer(&libbuf);

--- a/src/link.c
+++ b/src/link.c
@@ -608,9 +608,8 @@ int runLINK()
     {
         // Print it
         for (size_t i = 0; i < argv.dim; i++)
-            printf("%s ", argv[i]);
-        printf("\n");
-        fflush(stdout);
+            fprintf(global.stdmsg, "%s ", argv[i]);
+        fprintf(global.stdmsg, "\n");
     }
 
     argv.push(NULL);
@@ -700,10 +699,7 @@ int executecmd(char *cmd, char *args, int useenv)
     size_t len;
 
     if (!global.params.quiet || global.params.verbose)
-    {
-        printf("%s %s\n", cmd, args);
-        fflush(stdout);
-    }
+        fprintf(global.stdmsg, "%s %s\n", cmd, args);
 
     if (global.params.is64bit)
     {
@@ -757,7 +753,7 @@ int executecmd(char *cmd, char *args, int useenv)
         status = spawnlp(0,cmd,cmd,args,NULL);
 #endif
 //    if (global.params.verbose)
-//      printf("\n");
+//      fprintf(global.stdmsg, "\n");
     if (status)
     {
         if (status == -1)
@@ -826,10 +822,10 @@ int runProgram()
     //printf("runProgram()\n");
     if (global.params.verbose)
     {
-        printf("%s", global.params.exefile);
+        fprintf(global.stdmsg, "%s", global.params.exefile);
         for (size_t i = 0; i < global.params.runargs_length; i++)
-            printf(" %s", (char *)global.params.runargs[i]);
-        printf("\n");
+            fprintf(global.stdmsg, " %s", (char *)global.params.runargs[i]);
+        fprintf(global.stdmsg, "\n");
     }
 
     // Build argv[]

--- a/src/mars.c
+++ b/src/mars.c
@@ -127,6 +127,7 @@ void Global::init()
     ;
 
     compiler.vendor = "Digital Mars D";
+    stdmsg = stdout;
 
     main_d = "__main.d";
 
@@ -1244,9 +1245,9 @@ Language changes listed by -transition=id:\n\
     initPrecedence();
 
     if (global.params.verbose)
-    {   printf("binary    %s\n", argv[0]);
-        printf("version   %s\n", global.version);
-        printf("config    %s\n", inifilename ? inifilename : "(none)");
+    {   fprintf(global.stdmsg, "binary    %s\n", argv[0]);
+        fprintf(global.stdmsg, "version   %s\n", global.version);
+        fprintf(global.stdmsg, "config    %s\n", inifilename ? inifilename : "(none)");
     }
 
     //printf("%d source files\n",files.dim);
@@ -1460,7 +1461,7 @@ Language changes listed by -transition=id:\n\
     {
         m = modules[modi];
         if (global.params.verbose)
-            printf("parse     %s\n", m->toChars());
+            fprintf(global.stdmsg, "parse     %s\n", m->toChars());
         if (!Module::rootModule)
             Module::rootModule = m;
         m->importedFrom = m;    // m->isRoot() == true
@@ -1520,7 +1521,7 @@ Language changes listed by -transition=id:\n\
         {
             m = modules[i];
             if (global.params.verbose)
-                printf("import    %s\n", m->toChars());
+                fprintf(global.stdmsg, "import    %s\n", m->toChars());
             m->genhdrfile();
         }
     }
@@ -1532,7 +1533,7 @@ Language changes listed by -transition=id:\n\
     {
        m = modules[i];
        if (global.params.verbose)
-           printf("importall %s\n", m->toChars());
+           fprintf(global.stdmsg, "importall %s\n", m->toChars());
        m->importAll(NULL);
     }
     if (global.errors)
@@ -1545,7 +1546,7 @@ Language changes listed by -transition=id:\n\
     {
         m = modules[i];
         if (global.params.verbose)
-            printf("semantic  %s\n", m->toChars());
+            fprintf(global.stdmsg, "semantic  %s\n", m->toChars());
         m->semantic();
     }
     if (global.errors)
@@ -1559,7 +1560,7 @@ Language changes listed by -transition=id:\n\
     {
         m = modules[i];
         if (global.params.verbose)
-            printf("semantic2 %s\n", m->toChars());
+            fprintf(global.stdmsg, "semantic2 %s\n", m->toChars());
         m->semantic2();
     }
     if (global.errors)
@@ -1570,7 +1571,7 @@ Language changes listed by -transition=id:\n\
     {
         m = modules[i];
         if (global.params.verbose)
-            printf("semantic3 %s\n", m->toChars());
+            fprintf(global.stdmsg, "semantic3 %s\n", m->toChars());
         m->semantic3();
     }
     if (global.errors)
@@ -1591,7 +1592,7 @@ Language changes listed by -transition=id:\n\
             {
                 m = Module::amodules[i];
                 if (global.params.verbose)
-                    printf("semantic3 %s\n", m->toChars());
+                    fprintf(global.stdmsg, "semantic3 %s\n", m->toChars());
                 m->semantic3();
             }
             if (global.errors)
@@ -1622,7 +1623,7 @@ Language changes listed by -transition=id:\n\
         {
             m = modules[i];
             if (global.params.verbose)
-                printf("inline scan %s\n", m->toChars());
+                fprintf(global.stdmsg, "inline scan %s\n", m->toChars());
             m->inlineScan();
         }
     }
@@ -1703,7 +1704,7 @@ Language changes listed by -transition=id:\n\
         {
             m = modules[i];
             if (global.params.verbose)
-                printf("code      %s\n", m->toChars());
+                fprintf(global.stdmsg, "code      %s\n", m->toChars());
             m->genobjfile(0);
             if (entrypoint && m == entrypoint->importedFrom)
             {
@@ -1726,7 +1727,7 @@ Language changes listed by -transition=id:\n\
         {
             m = modules[i];
             if (global.params.verbose)
-                printf("code      %s\n", m->toChars());
+                fprintf(global.stdmsg, "code      %s\n", m->toChars());
             if (global.params.obj)
             {
                 obj_start(m->srcfile->toChars());

--- a/src/mars.h
+++ b/src/mars.h
@@ -275,6 +275,7 @@ struct Global
     Param params;
     unsigned errors;       // number of errors reported so far
     unsigned warnings;     // number of warnings reported so far
+    FILE *stdmsg;          // where to send verbose messages
     unsigned gag;          // !=0 means gag reporting of errors & warnings
     unsigned gaggedErrors; // number of errors reported while gagged
 

--- a/src/module.c
+++ b/src/module.c
@@ -222,15 +222,15 @@ Module *Module::load(Loc loc, Identifiers *packages, Identifier *ident)
 
     if (global.params.verbose)
     {
-        printf("import    ");
+        fprintf(global.stdmsg, "import    ");
         if (packages)
         {
             for (size_t i = 0; i < packages->dim; i++)
             {   Identifier *pid = (*packages)[i];
-                printf("%s.", pid->toChars());
+                fprintf(global.stdmsg, "%s.", pid->toChars());
             }
         }
-        printf("%s\t(%s)\n", ident->toChars(), m->srcfile->toChars());
+        fprintf(global.stdmsg, "%s\t(%s)\n", ident->toChars(), m->srcfile->toChars());
     }
 
     if (!m->read(loc))
@@ -816,7 +816,7 @@ void Module::inlineScan()
     for (size_t i = 0; i < members->dim; i++)
     {   Dsymbol *s = (*members)[i];
         //if (global.params.verbose)
-            //printf("inline scan symbol %s\n", s->toChars());
+            //fprintf(global.stdmsg, "inline scan symbol %s\n", s->toChars());
 
         s->inlineScan();
     }

--- a/src/statement.c
+++ b/src/statement.c
@@ -2928,7 +2928,7 @@ Statement *PragmaStatement::semantic(Scope *sc)
                 char *name = (char *)mem.malloc(se->len + 1);
                 memcpy(name, se->string, se->len);
                 name[se->len] = 0;
-                printf("library   %s\n", name);
+                fprintf(global.stdmsg, "library   %s\n", name);
                 mem.free(name);
             }
         }

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -218,7 +218,7 @@ Symbol *VarDeclaration::toSymbol()
                 if (global.params.vtls)
                 {
                     char *p = loc.toChars();
-                    fprintf(stderr, "%s: %s is thread local\n", p ? p : "", toChars());
+                    fprintf(global.stdmsg, "%s: %s is thread local\n", p ? p : "", toChars());
                     if (p)
                         mem.free(p);
                 }


### PR DESCRIPTION
Because stdout may not be the correct place to send them depending on compiler backend.  eg:  GDC sends assembly output to stdout if `-pipe` is specificied on the command-line.
