### PR TITLE
Issue 11217 - Header generation does not output 'inout' storage class on parameters

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -499,6 +499,7 @@ const char *StorageClassDeclaration::stcToChars(char tmp[], StorageClass& stc)
         { STCimmutable,    TOKimmutable },
         { STCshared,       TOKshared },
         { STCnothrow,      TOKnothrow },
+        { STCwild,         TOKwild },
         { STCpure,         TOKpure },
         { STCref,          TOKref },
         { STCtls },

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -90,7 +90,7 @@ enum PURE;
 const StorageClass STCStorageClass = (STCauto | STCscope | STCstatic | STCextern | STCconst | STCfinal |
     STCabstract | STCsynchronized | STCdeprecated | STCoverride | STClazy | STCalias |
     STCout | STCin |
-    STCmanifest | STCimmutable | STCshared | STCnothrow | STCpure | STCref | STCtls |
+    STCmanifest | STCimmutable | STCshared | STCwild | STCnothrow | STCpure | STCref | STCtls |
     STCgshared | STCproperty | STCsafe | STCtrusted | STCsystem | STCdisable);
 
 struct Match

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -9543,7 +9543,7 @@ void Parameter::argsToCBuffer(OutBuffer *buf, HdrGenState *hgs, Parameters *argu
                 stc &= ~STCshared;
 
             StorageClassDeclaration::stcToCBuffer(buf,
-                stc & (STCconst | STCimmutable | STCshared | STCscope));
+                stc & (STCconst | STCimmutable | STCwild | STCshared | STCscope));
 
             argbuf.reset();
             if (arg->storageClass & STCalias)

--- a/test/compilable/extra-files/xheader.di
+++ b/test/compilable/extra-files/xheader.di
@@ -39,3 +39,59 @@ template C4(T)
 	}
 }
 auto flit = 3 / 2.00000;
+template foo11217()
+{
+	void foo11217(const int[] arr)
+	{
+	}
+
+}
+template foo11217()
+{
+	void foo11217(immutable int[] arr)
+	{
+	}
+
+}
+template foo11217()
+{
+	void foo11217(ref int[] arr)
+	{
+	}
+
+}
+template foo11217()
+{
+	void foo11217(lazy int[] arr)
+	{
+	}
+
+}
+template foo11217()
+{
+	void foo11217(auto ref int[] arr)
+	{
+	}
+
+}
+template foo11217()
+{
+	void foo11217(scope int[] arr)
+	{
+	}
+
+}
+template foo11217()
+{
+	void foo11217(in int[] arr)
+	{
+	}
+
+}
+template foo11217()
+{
+	void foo11217(inout int[] arr)
+	{
+	}
+
+}

--- a/test/compilable/xheader.d
+++ b/test/compilable/xheader.d
@@ -43,3 +43,13 @@ class C4(T)
 
 
 auto flit = 3 / 2.0;
+
+// 11217
+void foo11217()(    const int[] arr) {}
+void foo11217()(immutable int[] arr) {}
+void foo11217()(      ref int[] arr) {}
+void foo11217()(     lazy int[] arr) {}
+void foo11217()( auto ref int[] arr) {}
+void foo11217()(    scope int[] arr) {}
+void foo11217()(       in int[] arr) {}
+void foo11217()(    inout int[] arr) {}


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11217
