### PR TITLE
[Trivial] fix AA tests

### DIFF
--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -873,9 +873,9 @@ void test6711()
             assert(length == 2);
             rehash;
             auto vs = values;
-            assert(vs == ["a", "b"]);
+            assert(vs == ["a", "b"] || vs == ["b", "a"]);
             auto ks = keys;
-            assert(ks == ["first", "second"]);
+            assert(ks == ["first", "second"] || ks == ["second", "first"]);
             foreach (k; byKey) { }
             foreach (v; byValue) { }
             assert(get("a", "default") == "default");


### PR DESCRIPTION
Order of AA elements is not determined.
Need for D-Programming-Language/druntime#482
