### PR TITLE
[CTFE] Implement yl2x and yl2xp1 builtin functions

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -24,6 +24,7 @@
 #include "identifier.h"
 #include "id.h"
 #include "module.h"
+#include "root/port.h"
 
 StringTable builtins;
 
@@ -143,9 +144,35 @@ Expression *eval_popcnt(Loc loc, FuncDeclaration *fd, Expressions *arguments)
     return new IntegerExp(loc, cnt, arg0->type);
 }
 
+Expression *eval_yl2x(Loc loc, FuncDeclaration *fd, Expressions *arguments)
+{
+    Expression *arg0 = (*arguments)[0];
+    assert(arg0->op == TOKfloat64);
+    Expression *arg1 = (*arguments)[1];
+    assert(arg1->op == TOKfloat64);
+    longdouble x = arg0->toReal();
+    longdouble y = arg1->toReal();
+    longdouble result;
+    Port::yl2x_impl(&x, &y, &result);
+    return new RealExp(loc, result, arg0->type);
+}
+
+Expression *eval_yl2xp1(Loc loc, FuncDeclaration *fd, Expressions *arguments)
+{
+    Expression *arg0 = (*arguments)[0];
+    assert(arg0->op == TOKfloat64);
+    Expression *arg1 = (*arguments)[1];
+    assert(arg1->op == TOKfloat64);
+    longdouble x = arg0->toReal();
+    longdouble y = arg1->toReal();
+    longdouble result;
+    Port::yl2xp1_impl(&x, &y, &result);
+    return new RealExp(loc, result, arg0->type);
+}
+
 void builtin_init()
 {
-    builtins._init(45);
+    builtins._init(53);
 
     // @safe @nogc pure nothrow real function(real)
     add_builtin("_D4core4math3sinFNaNbNiNfeZe", &eval_sin);
@@ -229,6 +256,11 @@ void builtin_init()
     // @safe @nogc pure nothrow int function(ulong)
     if (global.params.is64bit)
         add_builtin("_D4core5bitop7_popcntFNaNbNiNfmZi", &eval_popcnt);
+
+    if (Port::yl2x_supported)
+        add_builtin("_D4core4math4yl2xFNaNbNiNfeeZe", &eval_yl2x);
+    if (Port::yl2xp1_supported)
+        add_builtin("_D4core4math6yl2xp1FNaNbNiNfeeZe", &eval_yl2xp1);
 }
 
 /**********************************

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -29,6 +29,9 @@ double Port::dbl_max = DBL_MAX;
 double Port::dbl_min = DBL_MIN;
 longdouble Port::ldbl_max = LDBL_MAX;
 
+bool Port::yl2x_supported = true;
+bool Port::yl2xp1_supported = true;
+
 struct PortInitializer
 {
     PortInitializer();
@@ -93,6 +96,16 @@ int Port::fequal(longdouble x, longdouble y)
      * so be sure and ignore them.
      */
     return memcmp(&x, &y, 10) == 0;
+}
+
+void Port::yl2x_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    *res = _inline_yl2x(*x, *y);
+}
+
+void Port::yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    *res = _inline_yl2xp1(*x, *y);
 }
 
 char *Port::strupr(char *s)
@@ -168,6 +181,14 @@ double Port::dbl_max = DBL_MAX;
 double Port::dbl_min = DBL_MIN;
 longdouble Port::ldbl_max = LDBL_MAX;
 
+#ifdef _M_IX86
+bool Port::yl2x_supported = true;
+bool Port::yl2xp1_supported = true;
+#else
+bool Port::yl2x_supported = false;
+bool Port::yl2xp1_supported = false;
+#endif
+
 struct PortInitializer
 {
     PortInitializer();
@@ -237,6 +258,50 @@ int Port::fequal(longdouble x, longdouble y)
     return memcmp(&x, &y, 10) == 0;
 }
 
+#ifdef _M_IX86
+void Port::yl2x_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    __asm
+    {
+        mov eax, y
+        mov ebx, x
+        mov ecx, res
+        finit
+        fld tbyte ptr [eax]
+        fld tbyte ptr [ebx]
+        fyl2x
+        fwait
+        fstp tbyte ptr [ecx]
+    }
+}
+
+void Port::yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    __asm
+    {
+        mov eax, y
+        mov ebx, x
+        mov ecx, res
+        finit
+        fld tbyte ptr [eax]
+        fld tbyte ptr [ebx]
+        fyl2xp1
+        fwait
+        fstp tbyte ptr [ecx]
+    }
+}
+#else
+void Port::yl2x_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    assert(0);
+}
+
+void Port::yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    assert(0);
+}
+#endif
+
 char *Port::strupr(char *s)
 {
     return ::strupr(s);
@@ -297,6 +362,14 @@ longdouble Port::ldbl_infinity = 1 / zero;
 double Port::dbl_max = 1.7976931348623157e308;
 double Port::dbl_min = 5e-324;
 longdouble Port::ldbl_max = LDBL_MAX;
+
+#if _X86_ || __x86_64__
+bool Port::yl2x_supported = true;
+bool Port::yl2xp1_supported = true;
+#else
+bool Port::yl2x_supported = false;
+bool Port::yl2xp1_supported = false;
+#endif
 
 struct PortInitializer
 {
@@ -379,6 +452,28 @@ int Port::fequal(longdouble x, longdouble y)
      */
     return memcmp(&x, &y, 10) == 0;
 }
+
+#ifdef _X86_ || __x86_64__
+void Port::yl2x_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+
+}
+
+void Port::yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+
+}
+#else
+void Port::yl2x_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    assert(0);
+}
+
+void Port::yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    assert(0);
+}
+#endif
 
 char *Port::strupr(char *s)
 {
@@ -484,6 +579,14 @@ longdouble Port::ldbl_infinity = 1 / zero;
 double Port::dbl_max = 1.7976931348623157e308;
 double Port::dbl_min = 5e-324;
 longdouble Port::ldbl_max = LDBL_MAX;
+
+#if __i386 || __x86_64__
+bool Port::yl2x_supported = true;
+bool Port::yl2xp1_supported = true;
+#else
+bool Port::yl2x_supported = false;
+bool Port::yl2xp1_supported = false;
+#endif
 
 struct PortInitializer
 {
@@ -609,6 +712,28 @@ int Port::fequal(longdouble x, longdouble y)
     return memcmp(&x, &y, 10) == 0;
 }
 
+#ifdef __i386 || __x86_64__
+void Port::yl2x_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    __asm__ ("fyl2x": "=t" (*res): "u" (*y), "0" (*x) : "st(1)" );
+}
+
+void Port::yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    __asm__ ("fyl2xp1": "=t" (*res): "u" (*y), "0" (*x) : "st(1)" );
+}
+#else
+void Port::yl2x_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    assert(0);
+}
+
+void Port::yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    assert(0);
+}
+#endif
+
 char *Port::strupr(char *s)
 {
     char *t = s;
@@ -709,6 +834,14 @@ double Port::dbl_max = 1.7976931348623157e308;
 double Port::dbl_min = 5e-324;
 longdouble Port::ldbl_max = LDBL_MAX;
 
+#if __i386 || __x86_64__
+bool Port::yl2x_supported = true;
+bool Port::yl2xp1_supported = true;
+#else
+bool Port::yl2x_supported = false;
+bool Port::yl2xp1_supported = false;
+#endif
+
 struct PortInitializer
 {
     PortInitializer();
@@ -790,6 +923,18 @@ int Port::fequal(longdouble x, longdouble y)
      */
     return memcmp(&x, &y, 10) == 0;
 }
+
+#ifdef __i386 || __x86_64__
+void Port::yl2x_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    __asm__ ("fyl2x": "=t" (*res): "u" (*y), "0" (*x) : "st(1)" );
+}
+
+void Port::yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res)
+{
+    __asm__ ("fyl2xp1": "=t" (*res): "u" (*y), "0" (*x) : "st(1)" );
+}
+#else
 
 char *Port::strupr(char *s)
 {

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -42,6 +42,9 @@ struct Port
     static double dbl_min;
     static longdouble ldbl_max;
 
+    static bool yl2x_supported;
+    static bool yl2xp1_supported;
+
     static int isNan(double);
     static int isNan(longdouble);
 
@@ -53,6 +56,9 @@ struct Port
     static longdouble fmodl(longdouble x, longdouble y);
     static longdouble sqrt(longdouble x);
     static int fequal(longdouble x, longdouble y);
+
+    static void yl2x_impl(longdouble* x, longdouble* y, longdouble* res);
+    static void yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res);
 
     static char *strupr(char *);
 

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3178,6 +3178,49 @@ void test10687()
 }
 
 /************************************************/
+
+void test113()
+{
+    import core.math;
+
+    static void compare(real a, real b)
+    {
+        writefln("compare(%30.30f, %30.30f);", a, b);
+        assert(fabs(a - b) < 128*real.epsilon);
+    }
+
+    static if(__traits(compiles, (){enum real ctval1 = yl2x(3.14, 1);}))
+    {
+        enum real ctval1 = yl2x(3.14, 1);
+        enum real ctval2 = yl2x(2e1500L, 3);
+        enum real ctval3 = yl2x(1, 5);
+
+        real rtval1 = yl2x(3.14, 1);
+        real rtval2 = yl2x(2e1500L, 3);
+        real rtval3 = yl2x(1, 5);
+
+        compare(ctval1, rtval1);
+        compare(ctval2, rtval2);
+        compare(ctval3, rtval3);
+    }
+
+    static if(__traits(compiles, (){enum real ctval4 = yl2xp1(3.14, 1);}))
+    {
+        enum real ctval4 = yl2xp1(3.14, 1);
+        enum real ctval5 = yl2xp1(2e1500L, 3);
+        enum real ctval6 = yl2xp1(1, 5);
+
+        real rtval4 = yl2xp1(3.14, 1);
+        real rtval5 = yl2xp1(2e1500L, 3);
+
+        compare(ctval4, rtval4);
+        compare(ctval5, rtval5);
+        compare(ctval6, rtval6);
+    }
+}
+
+/************************************************/
+
 int main()
 {
     test1();
@@ -3290,6 +3333,7 @@ int main()
     //test108(); 
     test109();
     test112();
+    test113();
     test6439();
     test6504();
     test8818();


### PR DESCRIPTION
Need for computing exponent of float number at compile time. This pull allow to implement to real->ubyte[] conversion in CTFE, formatting float number in CTFE et c.
