### PR TITLE
Issue 11215 - `inout` lose enclosing `shared` on resolution

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1953,14 +1953,16 @@ L1:
     if (isWild())
     {
         if (mod & MODconst)
-            t = isShared() ? t->sharedConstOf() : t->constOf();
+            t = t->constOf();
         else if (mod & MODimmutable)
             t = t->immutableOf();
         else if (mod & MODwild)
-            t = isShared() ? t->sharedWildOf() : t->wildOf();
+            t = t->wildOf();
         else
-            t = isShared() ? t->sharedOf() : t->mutableOf();
+            t = t->mutableOf();
     }
+    if (isShared())
+        t = t->addMod(MODshared);
 
     //printf("-Type::substWildTo t = %s\n", t->toChars());
     return t;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -3236,6 +3236,14 @@ void test11257()
 }
 
 /************************************/
+// 11215
+
+shared(inout(void)**) f11215(inout int);
+
+static assert(is(typeof(f11215(0)) == shared(void**)));
+static assert(is(typeof(f11215((const int).init)) == shared(const(void)**)));
+
+/************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11215
