### PR TITLE
Issue 9665 - Structure constant members can not be initialized if have opAssign

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -2526,9 +2526,6 @@ static unsigned storelength(unsigned long length,unsigned i)
     if (length >= 128)  // Microsoft docs say 129, but their linker
                         // won't take >=128, so accommodate it
     {   obj.extdata[i] = 129;
-#ifdef DEBUG
-        assert(length <= 0xFFFF);
-#endif
         TOWORD(obj.extdata + i + 1,length);
         if (length >= 0x10000)
         {   obj.extdata[i] = 132;

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -148,7 +148,7 @@ int Declaration::checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int fl
             {
                 const char *s = isParameter() && parent->ident != Id::ensure ? "parameter" : "result";
                 if (!flag) error(loc, "cannot modify %s '%s' in contract", s, toChars());
-                return 0;
+                return 2;   // do not report type related errors
             }
         }
     }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8388,20 +8388,34 @@ MATCH TypeStruct::implicitConvTo(Type *to)
     }
 
     if (ty == to->ty && sym == ((TypeStruct *)to)->sym)
-    {   m = MATCHexact;         // exact match
+    {
+        m = MATCHexact;         // exact match
         if (mod != to->mod)
         {
             m = MATCHconst;
             if (MODimplicitConv(mod, to->mod))
                 ;
             else
-            {   /* Check all the fields. If they can all be converted,
+            {
+                /* Check all the fields. If they can all be converted,
                  * allow the conversion.
                  */
+                unsigned offset;
                 for (size_t i = 0; i < sym->fields.dim; i++)
-                {   Dsymbol *s = sym->fields[i];
-                    VarDeclaration *v = s->isVarDeclaration();
-                    assert(v && v->isField());
+                {
+                    VarDeclaration *v = sym->fields[i];
+                    if (i == 0)
+                        ;
+                    else if (v->offset == offset)
+                    {
+                        if (m)
+                            continue;
+                    }
+                    else
+                    {
+                        if (!m)
+                            return m;
+                    }
 
                     // 'from' type
                     Type *tvf = v->type->addMod(mod);
@@ -8417,6 +8431,7 @@ MATCH TypeStruct::implicitConvTo(Type *to)
                         return mf;
                     if (mf < m)         // if field match is worse
                         m = mf;
+                    offset = v->offset;
                 }
             }
         }

--- a/src/scope.h
+++ b/src/scope.h
@@ -91,6 +91,8 @@ struct Scope
     bool speculative;            // in __traits(compiles) or typeof(exp)
 
     unsigned callSuper;         // primitive flow analysis for constructors
+    unsigned *fieldinit;
+    unsigned fieldinit_dim;
 
     structalign_t structalign;       // alignment for struct members
     LINK linkage;          // linkage for external functions
@@ -124,6 +126,9 @@ struct Scope
     Scope *endCTFE();
 
     void mergeCallSuper(Loc loc, unsigned cs);
+
+    unsigned *saveFieldInit();
+    void mergeFieldInit(Loc loc, unsigned *cses);
 
     Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym);
     Dsymbol *search_correct(Identifier *ident);

--- a/src/statement.c
+++ b/src/statement.c
@@ -928,7 +928,6 @@ Statement *UnrolledLoopStatement::semantic(Scope *sc)
 {
     //printf("UnrolledLoopStatement::semantic(this = %p, sc = %p)\n", this, sc);
 
-    sc->noctor++;
     Scope *scd = sc->push();
     scd->sbreak = this;
     scd->scontinue = this;
@@ -948,7 +947,6 @@ Statement *UnrolledLoopStatement::semantic(Scope *sc)
     }
 
     scd->pop();
-    sc->noctor--;
     return serror ? serror : this;
 }
 
@@ -2610,6 +2608,8 @@ Statement *IfStatement::semantic(Scope *sc)
     // Evaluate at runtime
     unsigned cs0 = sc->callSuper;
     unsigned cs1;
+    unsigned *fi0 = fi0 = sc->saveFieldInit();
+    unsigned *fi1 = NULL;
 
     ScopeDsymbol *sym = new ScopeDsymbol();
     sym->parent = sc->scopesym;
@@ -2656,10 +2656,13 @@ Statement *IfStatement::semantic(Scope *sc)
     scd->pop();
 
     cs1 = sc->callSuper;
+    fi1 = sc->fieldinit;
     sc->callSuper = cs0;
+    sc->fieldinit = fi0;
     if (elsebody)
         elsebody = elsebody->semanticScope(sc, NULL, NULL);
     sc->mergeCallSuper(loc, cs1);
+    sc->mergeFieldInit(loc, fi1);
 
     if (condition->op == TOKerror ||
         (ifbody && ifbody->isErrorStatement()) ||
@@ -3961,8 +3964,23 @@ Statement *ReturnStatement::semantic(Scope *sc)
     if (sc->callSuper & CSXany_ctor &&
         !(sc->callSuper & (CSXthis_ctor | CSXsuper_ctor)))
         error("return without calling constructor");
-
     sc->callSuper |= CSXreturn;
+    if (sc->fieldinit)
+    {
+        AggregateDeclaration *ad = fd->isAggregateMember2();
+        assert(ad);
+        size_t dim = sc->fieldinit_dim;
+        for (size_t i = 0; i < dim; i++)
+        {
+            VarDeclaration *v = ad->fields[i];
+            bool mustInit = (v->storage_class & STCnodefaultctor ||
+                             v->type->needsNested());
+            if (mustInit && !(sc->fieldinit[i] & CSXthis_ctor))
+                error("an earlier return statement skips field %s initialization", v->toChars());
+
+            sc->fieldinit[i] |= CSXreturn;
+        }
+    }
 
     // See if all returns are instead to be replaced with a goto returnLabel;
     if (fd->returnLabel)
@@ -5140,6 +5158,12 @@ Statement *LabelStatement::semantic(Scope *sc)
     sc = sc->push();
     sc->scopesym = sc->enclosing->scopesym;
     sc->callSuper |= CSXlabel;
+    if (sc->fieldinit)
+    {
+        size_t dim = sc->fieldinit_dim;
+        for (size_t i = 0; i < dim; i++)
+            sc->fieldinit[i] |= CSXlabel;
+    }
     sc->slabel = this;
     if (statement)
         statement = statement->semanticNoScope(sc);

--- a/test/fail_compilation/fail9665a.d
+++ b/test/fail_compilation/fail9665a.d
@@ -1,0 +1,159 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS:
+
+/***************************************************/
+// immutable field
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/fail9665a.d(106): Error: multiple field v initialization
+fail_compilation/fail9665a.d(116): Error: multiple field v initialization
+fail_compilation/fail9665a.d(121): Error: multiple field v initialization
+fail_compilation/fail9665a.d(126): Error: multiple field v initialization
+fail_compilation/fail9665a.d(136): Error: multiple field v initialization
+fail_compilation/fail9665a.d(141): Error: multiple field v initialization
+fail_compilation/fail9665a.d(146): Error: multiple field v initialization
+---
++/
+#line 100
+struct S1A
+{
+    immutable int v;
+    this(int)
+    {
+        v = 1;
+        v = 2;  // multiple initialization
+    }
+}
+
+struct S1B
+{
+    immutable int v;
+    this(int)
+    {
+        if (true) v = 1; else v = 2;
+        v = 3;  // multiple initialization
+    }
+    this(long)
+    {
+        if (true) v = 1;
+        v = 3;  // multiple initialization
+    }
+    this(string)
+    {
+        if (true) {} else v = 2;
+        v = 3;  // multiple initialization
+    }
+}
+
+struct S1C
+{
+    immutable int v;
+    this(int)
+    {
+        true ? (v = 1) : (v = 2);
+        v = 3;  // multiple initialization
+    }
+    this(long)
+    {
+        auto x = true ? (v = 1) : 2;
+        v = 3;  // multiple initialization
+    }
+    this(string)
+    {
+        auto x = true ? 1 : (v = 2);
+        v = 3;  // multiple initialization
+    }
+}
+
+/***************************************************/
+// with control flow
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/fail9665a.d(206): Error: field v initializing not allowed in loops or after labels
+fail_compilation/fail9665a.d(211): Error: field v initializing not allowed in loops or after labels
+fail_compilation/fail9665a.d(216): Error: multiple field v initialization
+fail_compilation/fail9665a.d(221): Error: multiple field v initialization
+fail_compilation/fail9665a.d(226): Error: multiple field v initialization
+---
++/
+#line 200
+struct S2
+{
+    immutable int v;
+    this(int)
+    {
+    L:
+        v = 1;  // after labels
+    }
+    this(long)
+    {
+        foreach (i; 0..1)
+            v = 1;  // in loops
+    }
+    this(string)
+    {
+        v = 1;  // initialization
+    L:  v = 2;  // assignment after labels
+    }
+    this(wstring)
+    {
+        v = 1;  // initialization
+        foreach (i; 0..1) v = 2;  // assignment in loops
+    }
+    this(dstring)
+    {
+        v = 1; return;
+        v = 2;  // multiple initialization
+    }
+}
+
+/***************************************************/
+// with immutable constructor
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/fail9665a.d(307): Error: multiple field v initialization
+fail_compilation/fail9665a.d(311): Error: multiple field w initialization
+---
++/
+#line 300
+struct S3
+{
+    int v;
+    int w;
+    this(int) immutable
+    {
+        v = 1;
+        v = 2;  // multiplie initialization
+
+        if (true)
+            w = 1;
+        w = 2;  // multiplie initialization
+    }
+}
+
+/***************************************************/
+// in __traits(compiles)
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/fail9665a.d(406): Error: multiple field v initialization
+---
++/
+#line 400
+struct S4
+{
+    immutable int v;
+    this(int)
+    {
+        static assert(__traits(compiles, v = 1));
+        v = 1;  // multiplie initialization
+    }
+}
+

--- a/test/fail_compilation/fail9665b.d
+++ b/test/fail_compilation/fail9665b.d
@@ -1,0 +1,79 @@
+/***************************************************/
+// with disable this() struct
+
+struct X
+{
+    @disable this();
+
+    this(int) {}
+}
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/fail9665b.d(110): Error: one path skips field x2
+fail_compilation/fail9665b.d(111): Error: one path skips field x3
+fail_compilation/fail9665b.d(113): Error: one path skips field x5
+fail_compilation/fail9665b.d(114): Error: one path skips field x6
+fail_compilation/fail9665b.d(108): Error: constructor fail9665b.S1.this field x1 must be initialized in constructor
+fail_compilation/fail9665b.d(108): Error: constructor fail9665b.S1.this field x4 must be initialized in constructor
+---
++/
+#line 100
+struct S1
+{
+    X x1;
+    X x2;
+    X x3;
+    X[2] x4;
+    X[2] x5;
+    X[2] x6;
+    this(int)
+    {
+        if (true) x2 = X(1);
+        auto n = true ? (x3 = X(1), 1) : 2;
+
+        if (true) x5 = X(1);
+        auto m = true ? (x6 = X(1), 1) : 2;
+    }
+}
+
+/***************************************************/
+// with nested struct
+
+/+
+TEST_OUTPUT:
+---
+fail_compilation/fail9665b.d(210): Error: one path skips field x2
+fail_compilation/fail9665b.d(211): Error: one path skips field x3
+fail_compilation/fail9665b.d(213): Error: one path skips field x5
+fail_compilation/fail9665b.d(214): Error: one path skips field x6
+fail_compilation/fail9665b.d(208): Error: constructor fail9665b.S2!(X).S2.this field x1 must be initialized in constructor, because it is nested struct
+fail_compilation/fail9665b.d(208): Error: constructor fail9665b.S2!(X).S2.this field x4 must be initialized in constructor, because it is nested struct
+fail_compilation/fail9665b.d(221): Error: template instance fail9665b.S2!(X) error instantiating
+---
++/
+#line 200
+struct S2(X)
+{
+    X x1;
+    X x2;
+    X x3;
+    X[2] x4;
+    X[2] x5;
+    X[2] x6;
+    this(int)
+    {
+        if (true) x2 = X(1);
+        auto x = true ? (x3 = X(1), 1) : 2;
+
+        if (true) x5 = X(1);
+        auto m = true ? (x6 = X(1), 1) : 2;
+    }
+}
+void test2()
+{
+    struct X { this(int) {} }
+    static assert(X.tupleof.length == 1);
+    S2!(X) s;
+}

--- a/test/runnable/arrayop.d
+++ b/test/runnable/arrayop.d
@@ -611,13 +611,14 @@ void test9656()
     static class C {}
     static struct S
     {
-        immutable int[] narr;
-        immutable C[] carr;
+        immutable int[] narr1;
+        immutable int[] narr2;
+        immutable C[] carr1;
         immutable C[] carr2;
         this(int n) {
-            narr = new int[](3); // OK, expected
-            narr = [1,2,3].dup;  // NG -> OK
-            carr = [new C].dup;  // NG -> OK
+            narr1 = new int[](3); // OK, expected
+            narr2 = [1,2,3].dup;  // NG -> OK
+            carr1 = [new C].dup;  // NG -> OK
 
             C c = new C;
             static assert(!__traits(compiles, carr2 = [c]));

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -245,81 +245,81 @@ struct CtorTest6174(Data)
         // As long as you don't try to rewrite values beyond the indirections,
         // an assignment will always be succeeded inside constructor.
 
-        static assert( __traits(compiles, { data        = a;        }));    // OK
+        static assert( is(typeof( data        = a         )));    // OK
       static if (is(Data == struct))
       {
-        static assert( __traits(compiles, { data.x      = 1;        }));    // OK
-        static assert( __traits(compiles, { data.y      = 2;        }));    // OK
+        static assert( is(typeof( data.x      = 1         )));    // OK
+        static assert( is(typeof( data.y      = 2         )));    // OK
       }
-        static assert(!__traits(compiles, { *pdata      = a;        }));    // NG
-        static assert( __traits(compiles, { *&data      = a;        }));    // OK
+        static assert(!is(typeof( *pdata      = a         )));    // NG
+        static assert( is(typeof( *&data      = a         )));    // OK
 
-        static assert( __traits(compiles, { sa1         = [a,a];    }));    // OK
-        static assert( __traits(compiles, { sa1[0]      = a;        }));    // OK
-        static assert( __traits(compiles, { sa1[]       = a;        }));    // OK
-        static assert( __traits(compiles, { sa1[][]     = a;        }));    // OK
+        static assert( is(typeof( sa1         = [a,a]     )));    // OK
+        static assert( is(typeof( sa1[0]      = a         )));    // OK
+        static assert( is(typeof( sa1[]       = a         )));    // OK
+        static assert( is(typeof( sa1[][]     = a         )));    // OK
 
-        static assert( __traits(compiles, { sa2         = [[a,a]];  }));    // OK
-        static assert( __traits(compiles, { sa2[0][0]   = a;        }));    // OK
-        static assert( __traits(compiles, { sa2[][0][]  = a;        }));    // OK
-        static assert( __traits(compiles, { sa2[0][][0] = a;        }));    // OK
+        static assert( is(typeof( sa2         = [[a,a]]   )));    // OK
+        static assert( is(typeof( sa2[0][0]   = a         )));    // OK
+        static assert( is(typeof( sa2[][0][]  = a         )));    // OK
+        static assert( is(typeof( sa2[0][][0] = a         )));    // OK
 
-        static assert( __traits(compiles, { sa3         = [[a],[]]; }));    // OK
-        static assert( __traits(compiles, { sa3[0]      = [a,a];    }));    // OK
-        static assert(!__traits(compiles, { sa3[0][0]   = a;        }));    // NG
-        static assert( __traits(compiles, { sa3[]       = [a];      }));    // OK
-        static assert( __traits(compiles, { sa3[][0]    = [a];      }));    // OK
-        static assert(!__traits(compiles, { sa3[][0][0] = a;        }));    // NG
+        static assert( is(typeof( sa3         = [[a],[]]  )));    // OK
+        static assert( is(typeof( sa3[0]      = [a,a]     )));    // OK
+        static assert(!is(typeof( sa3[0][0]   = a         )));    // NG
+        static assert( is(typeof( sa3[]       = [a]       )));    // OK
+        static assert( is(typeof( sa3[][0]    = [a]       )));    // OK
+        static assert(!is(typeof( sa3[][0][0] = a         )));    // NG
 
-        static assert( __traits(compiles, { da1         = [a,a];    }));    // OK
-        static assert(!__traits(compiles, { da1[0]      = a;        }));    // NG
-        static assert(!__traits(compiles, { da1[]       = a;        }));    // NG
+        static assert( is(typeof( da1         = [a,a]     )));    // OK
+        static assert(!is(typeof( da1[0]      = a         )));    // NG
+        static assert(!is(typeof( da1[]       = a         )));    // NG
 
-        static assert( __traits(compiles, { da2         = [[a,a]];  }));    // OK
-        static assert(!__traits(compiles, { da2[0][0]   = a;        }));    // NG
-        static assert(!__traits(compiles, { da2[]       = [a,a];    }));    // NG
-        static assert(!__traits(compiles, { da2[][0]    = a;        }));    // NG
-        static assert(!__traits(compiles, { da2[0][]    = a;        }));    // NG
+        static assert( is(typeof( da2         = [[a,a]]   )));    // OK
+        static assert(!is(typeof( da2[0][0]   = a         )));    // NG
+        static assert(!is(typeof( da2[]       = [a,a]     )));    // NG
+        static assert(!is(typeof( da2[][0]    = a         )));    // NG
+        static assert(!is(typeof( da2[0][]    = a         )));    // NG
     }
     void func(Data a)
     {
         auto pdata = &data;
 
-        static assert(!__traits(compiles, { data        = a;        }));    // NG
+        static assert(!is(typeof( data        = a         )));    // NG
       static if (is(Data == struct))
       {
-        static assert(!__traits(compiles, { data.x      = 1;        }));    // NG
-        static assert(!__traits(compiles, { data.y      = 2;        }));    // NG
+        static assert(!is(typeof( data.x      = 1         )));    // NG
+        static assert(!is(typeof( data.y      = 2         )));    // NG
       }
-        static assert(!__traits(compiles, { *pdata      = a;        }));    // NG
-        static assert(!__traits(compiles, { *&data      = a;        }));    // NG
+        static assert(!is(typeof( *pdata      = a         )));    // NG
+        static assert(!is(typeof( *&data      = a         )));    // NG
 
-        static assert(!__traits(compiles, { sa1         = [a,a];    }));    // NG
-        static assert(!__traits(compiles, { sa1[0]      = a;        }));    // NG
-        static assert(!__traits(compiles, { sa1[]       = a;        }));    // NG
-        static assert(!__traits(compiles, { sa1[][]     = a;        }));    // NG
+        static assert(!is(typeof( sa1         = [a,a]     )));    // NG
+        static assert(!is(typeof( sa1[0]      = a         )));    // NG
+        static assert(!is(typeof( sa1[]       = a         )));    // NG
+        static assert(!is(typeof( sa1[][]     = a         )));    // NG
 
-        static assert(!__traits(compiles, { sa2         = [[a,a]];  }));    // NG
-        static assert(!__traits(compiles, { sa2[0][0]   = a;        }));    // NG
-        static assert(!__traits(compiles, { sa2[][0][]  = a;        }));    // NG
-        static assert(!__traits(compiles, { sa2[0][][0] = a;        }));    // NG
+        static assert(!is(typeof( sa2         = [[a,a]]   )));    // NG
+        static assert(!is(typeof( sa2[0][0]   = a         )));    // NG
+        static assert(!is(typeof( sa2[][0][]  = a         )));    // NG
+        static assert(!is(typeof( sa2[0][][0] = a         )));    // NG
 
-        static assert(!__traits(compiles, { sa3         = [[a],[]]; }));    // NG
-        static assert(!__traits(compiles, { sa3[0]      = [a,a];    }));    // NG
-        static assert(!__traits(compiles, { sa3[0][0]   = a;        }));    // NG
-        static assert(!__traits(compiles, { sa3[]       = [a];      }));    // NG
-        static assert(!__traits(compiles, { sa3[][0]    = [a];      }));    // NG
-        static assert(!__traits(compiles, { sa3[][0][0] = a;        }));    // NG
+        static assert(!is(typeof( sa3         = [[a],[]]  )));    // NG
+        static assert(!is(typeof( sa3[0]      = [a,a]     )));    // NG
+        static assert(!is(typeof( sa3[0][0]   = a         )));    // NG
+        static assert(!is(typeof( sa3[]       = [a]       )));    // NG
+        static assert(!is(typeof( sa3[][0]    = [a]       )));    // NG
+        static assert(!is(typeof( sa3[][0][0] = a         )));    // NG
 
-        static assert(!__traits(compiles, { da1         = [a,a];    }));    // NG
-        static assert(!__traits(compiles, { da1[0]      = a;        }));    // NG
-        static assert(!__traits(compiles, { da1[]       = a;        }));    // NG
+        static assert(!is(typeof( da1         = [a,a]     )));    // NG
+        static assert(!is(typeof( da1[0]      = a         )));    // NG
+        static assert(!is(typeof( da1[]       = a         )));    // NG
 
-        static assert(!__traits(compiles, { da2         = [[a,a]];  }));    // NG
-        static assert(!__traits(compiles, { da2[0][0]   = a;        }));    // NG
-        static assert(!__traits(compiles, { da2[]       = [a,a];    }));    // NG
-        static assert(!__traits(compiles, { da2[][0]    = a;        }));    // NG
-        static assert(!__traits(compiles, { da2[0][]    = a;        }));    // NG
+        static assert(!is(typeof( da2         = [[a,a]]   )));    // NG
+        static assert(!is(typeof( da2[0][0]   = a         )));    // NG
+        static assert(!is(typeof( da2[]       = [a,a]     )));    // NG
+        static assert(!is(typeof( da2[][0]    = a         )));    // NG
+        static assert(!is(typeof( da2[0][]    = a         )));    // NG
     }
 }
 
@@ -334,11 +334,12 @@ struct Foo6174
 {
     const char cc;
     const char[1] array;
+    const char[1] arr;
     this(char c)
     {
         cc = c;       // OK
         array = [c];  // line 12, Err
-        array[0] = c; // line 12, Err
+        arr[0] = c;   // line 12, Err
     }
 }
 void test6174a()
@@ -391,16 +392,16 @@ void test6174b()
         {
             // If F has an identity `opAssign`,it is used even for initializing.
             // Otherwise, initializing  will always succeed, by bypassing const qualifier.
-            static assert(__traits(compiles, f = F()) == (
+            static assert(is(typeof( f = F() )) == (
                             F.assignKind == none ||
                             F.assignKind == unrelated ||
-                            F.assignKind == mutable && !fieldConst ||
+                            F.assignKind == mutable ||
                             F.assignKind == constant));
 
-            static assert(__traits(compiles,   w = 1000) == true);
-            static assert(__traits(compiles, f.x = 1000) == true);
-            static assert(__traits(compiles, f.y = 1000) == true);
-            static assert(__traits(compiles,   z = 1000) == true);
+            static assert(is(typeof(   w = 1000 )) == true);
+            static assert(is(typeof( f.x = 1000 )) == true);
+            static assert(is(typeof( f.y = 1000 )) == true);
+            static assert(is(typeof(   z = 1000 )) == true);
         }
         void func()
         {

--- a/test/runnable/sctor.d
+++ b/test/runnable/sctor.d
@@ -1,0 +1,173 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS: -w -d -de -dw
+
+extern(C) int printf(const char*, ...);
+
+/***************************************************/
+// mutable field
+
+struct S1A
+{
+    int v;
+    this(int)
+    {
+        v = 1;
+        v = 2;  // multiple initialization
+    }
+}
+
+struct S1B
+{
+    int v;
+    this(int)
+    {
+        if (true) v = 1; else v = 2;
+        v = 3;  // multiple initialization
+    }
+    this(long)
+    {
+        if (true) v = 1;
+        v = 3;  // multiple initialization
+    }
+    this(string)
+    {
+        if (true) {} else v = 2;
+        v = 3;  // multiple initialization
+    }
+}
+
+struct S1C
+{
+    int v;
+    this(int)
+    {
+        true ? (v = 1) : (v = 2);
+        v = 3;  // multiple initialization
+    }
+    this(long)
+    {
+        auto x = true ? (v = 1) : 2;
+        v = 3;  // multiple initialization
+    }
+    this(string)
+    {
+        auto x = true ? 1 : (v = 2);
+        v = 3;  // multiple initialization
+    }
+}
+
+/***************************************************/
+// with control flow
+
+struct S2
+{
+    immutable int v;
+    immutable int w;
+    int x;
+    this(int)
+    {
+        if (true) v = 1;
+        else      v = 2;
+
+        true ? (w = 1) : (w = 2);
+
+        x = 1;  // initialization
+    L:  x = 2;  // assignment after labels
+    }
+    this(long n)
+    {
+        if (n > 0)
+            return;
+        v = 1;  // skipped initialization
+
+        // w skipped initialization
+
+        x = 1;  // initialization
+        foreach (i; 0..1) x = 2;  // assignment in loops
+    }
+}
+
+/***************************************************/
+// with immutable constructor
+
+struct S3
+{
+    int v;
+    int w;
+    this(int) immutable
+    {
+        if (true) v = 1;
+        else      v = 2;
+
+        true ? (w = 1) : (w = 2);
+    }
+}
+
+/***************************************************/
+// in typeof
+
+struct S4
+{
+    immutable int v;
+    this(int)
+    {
+        static assert(is(typeof(v = 1)));
+        v = 1;
+    }
+}
+
+/***************************************************/
+// 9665
+
+struct X9665
+{
+    static uint count;
+    ulong payload;
+    this(int n) { payload = n; count += 1; }
+    this(string s) immutable { payload = s.length; count += 10; }
+    void opAssign(X9665 x) { payload = 100; count += 100; }
+}
+
+struct S9665
+{
+              X9665 mval;
+    immutable X9665 ival;
+    this(int n)
+    {
+        X9665.count = 0;
+        mval = X9665(n);                // 1st, initializing
+        ival = immutable X9665("hi");   // 1st, initializing
+        mval = X9665(1);                // 2nd, assignment
+        static assert(!__traits(compiles, ival = immutable X9665(1)));  // 2nd, assignment
+        //printf("X9665.count = %d\n", X9665.count);
+        assert(X9665.count == 112);
+    }
+    this(int[])
+    {
+        X9665.count = 0;
+        mval = 1;       // 1st, initializing (implicit constructor call)
+        ival = "hoo";   // ditto
+        assert(X9665.count == 11);
+    }
+}
+
+void test9665()
+{
+    S9665 s1 = S9665(1);
+    assert(s1.mval.payload == 100);
+    assert(s1.ival.payload == 2);
+
+    S9665 s2 = S9665([]);
+    assert(s2.mval.payload == 1);
+    assert(s2.ival.payload == 3);
+}
+
+/***************************************************/
+
+int main()
+{
+    test9665();
+
+    printf("Success\n");
+    return 0;
+}

--- a/test/runnable/sctor.d
+++ b/test/runnable/sctor.d
@@ -163,10 +163,52 @@ void test9665()
 }
 
 /***************************************************/
+// 11246
+
+struct Foo11246
+{
+    static int ctor = 0;
+    static int dtor = 0;
+    this(int i)
+    {
+        ++ctor;
+    }
+
+    ~this()
+    {
+        ++dtor;
+    }
+}
+
+struct Bar11246
+{
+    Foo11246 foo;
+
+    this(int)
+    {
+        foo = Foo11246(5);
+        assert(Foo11246.ctor == 1);
+        assert(Foo11246.dtor == 0);
+    }
+}
+
+void test11246()
+{
+    {
+        auto bar = Bar11246(1);
+        assert(Foo11246.ctor == 1);
+        assert(Foo11246.dtor == 0);
+    }
+    assert(Foo11246.ctor == 1);
+    assert(Foo11246.dtor == 1);
+}
+
+/***************************************************/
 
 int main()
 {
     test9665();
+    test11246();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -3219,6 +3219,23 @@ void test10761()
 }
 
 /************************************/
+// 11257
+
+struct R11257
+{
+    union
+    {
+        const(Object) original;
+        Object stripped;
+    }
+}
+void test11257()
+{
+    const(R11257) cr;
+    R11257 mr = cr;  // Error: cannot implicitly convert expression (cr) of type const(R) to R
+}
+
+/************************************/
 
 int main()
 {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9665

Issue 9665 is a root cause of some newly appeared regressions from 2.061-2.063.

[Issue 11257](http://d.puremagic.com/issues/show_bug.cgi?id=11257) - Allow whole implicit conversion if one or more overlapped field could
This is necessary for `std.typecons.Rebindable`, and `std.datetime.Systime` that's using `Rebindable`.

Regressions which will be fixed:
[Issue 11186](http://d.puremagic.com/issues/show_bug.cgi?id=11186) - Regression (2.061): Presence of Variant and const field invokes opAssign
[Issue 11246](http://d.puremagic.com/issues/show_bug.cgi?id=11246) - [REG 2.063] Struct initialized in constructor is destroyed first
[Issue 10357](http://d.puremagic.com/issues/show_bug.cgi?id=10357) - std.typecons.Nullable!(SysTime).Nullable.__ctor!() error instantiating
