### PR TITLE
Support LINKCMD for Win64 Environment64

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -275,6 +275,8 @@ int runLINK()
 
         char *linkcmd = getenv("LINKCMD64");
         if (!linkcmd)
+            linkcmd = getenv("LINKCMD"); // backward compatible
+        if (!linkcmd)
         {
             if (vcinstalldir)
             {


### PR DESCRIPTION
Part of the effort to make win64 "just work" ([see installer pull 22](https://github.com/D-Programming-Language/installer/pull/22)).  Not strictly required but might as well solve this inconsistency before this release gets out.
