### PR TITLE
[REG2.064a] Issue 11265 - Segfault while calling instance method of class defined inside struct

### DIFF
--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5705,6 +5705,28 @@ void test10628()
 }
 
 /***************************************************/
+// 11265
+
+struct S11265
+{
+    class InnerClass
+    {
+        S11265 s;
+
+        bool empty()
+        {
+            return true;
+        }
+    }
+}
+
+void test11265()
+{
+    S11265.InnerClass trav = new S11265.InnerClass();
+    trav.empty();
+}
+
+/***************************************************/
 
 struct TimeOfDay
 {
@@ -6073,6 +6095,7 @@ int main()
     test4414();
     test9844();
     test10628();
+    test11265();
     test10633();
     test10642();
     test7436();


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11265

The regression was introduced by the commit:
https://github.com/D-Programming-Language/dmd/commit/671b7c20b96b580ee1dc2b3f5e3ee66c63d079b6#diff-43282ebf5a2de5fdbcb3b5083ddf949dR147

vtbl[] calculation is essentially unrelated to the class instance size.
So, just only once initializing of vtbl[] and running semantic on member functions is sufficient.
