### PR TITLE
[REG2.061] Issue 11225 - Module dependency cycle causes import statements inside typeof() expressions inside templates to fail

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -5682,7 +5682,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             }
         }
     }
-    if (found_deferred_ad)
+    if (found_deferred_ad || Module::deferred.dim)
         goto Laftersemantic;
 
     /* ConditionalDeclaration may introduce eponymous declaration,

--- a/test/compilable/imports/test11225b.d
+++ b/test/compilable/imports/test11225b.d
@@ -1,0 +1,13 @@
+module imports.test11225b;
+import test11225a;
+
+interface J : I {} // remove this line to make it work
+
+static assert(is(typeof({ import imports.test11225c; }))); // OK
+pragma(msg, B!().result); // just instantiates the template
+
+template B()
+{
+    static assert(is(typeof({ import imports.test11225c; }))); // FAILS
+    enum result = "WORKS";
+}

--- a/test/compilable/imports/test11225c.d
+++ b/test/compilable/imports/test11225c.d
@@ -1,0 +1,2 @@
+module imports.test11225c;
+// empty

--- a/test/compilable/test11225a.d
+++ b/test/compilable/test11225a.d
@@ -1,0 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+WORKS
+---
+*/
+
+import imports.test11225b;
+interface I {}

--- a/test/fail_compilation/diag9210a.d
+++ b/test/fail_compilation/diag9210a.d
@@ -4,6 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/imports/diag9210stdcomplex.d(13): Error: template instance Complex!real does not match template declaration Complex(T) if (isFloatingPoint!T)
 fail_compilation/imports/diag9210b.d(6): Error: undefined identifier A, did you mean interface B?
 ---
 */


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11225

The bug was introduced by the commit:
https://github.com/D-Programming-Language/dmd/commit/4633b1336ba0aca1c260bcfd87fabb24f0d06692
