### PR TITLE
[REG2.063][enh] Issue 10684 - Refused array op with array literal

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -486,6 +486,9 @@ public:
     Expression *inferType(Type *t, int flag = 0, Scope *sc = NULL, TemplateParameters *tparams = NULL);
     dt_t **toDt(dt_t **pdt);
 
+    void buildArrayIdent(OutBuffer *buf, Expressions *arguments);
+    Expression *buildArrayLoop(Parameters *fparams);
+
     Expression *doInline(InlineDoState *ids);
     Expression *inlineScan(InlineScanState *iss);
 };

--- a/test/runnable/arrayop.d
+++ b/test/runnable/arrayop.d
@@ -665,6 +665,38 @@ void test10433()
 }
 
 /************************************************************************/
+// 10684
+
+void test10684a()
+{
+    int[] a = [0, 0];
+    a[] += [10, 20][];
+}
+
+void test10684b()
+{
+    int[] a = [1, 2, 3];
+    int[] b = [4, 5, 6];
+
+    // Allow array literal as the operand of array oeration
+    a[] += [1, 2, 3];
+    assert(a == [2, 4, 6]);
+
+    a[] *= b[] + [1, 1, 1];
+    assert(a == [2*(4+1), 4*(5+1), 6*(6+1)]);
+
+    a[] = [9, 8, 7] - [1, 2, 3];
+    assert(a == [8, 6, 4]);
+
+    a[] = [2, 4, 6] / 2;
+    assert(a == [1,2,3]);
+
+    // Disallow: [1,2,3] is not an lvalue
+    static assert(!__traits(compiles, { [1,2,3] = a[] * 2; }));
+    static assert(!__traits(compiles, { [1,2,3] += a[] * b[]; }));
+}
+
+/************************************************************************/
 
 int main()
 {
@@ -678,6 +710,8 @@ int main()
     test8651();
     test9656();
     test10433();
+    test10684a();
+    test10684b();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10684

This change will accept array literals as the operand of array-ops.

---

Since, array-ops had required explicit slice to the array literal operands, eg. `a[] = [1,2][] + c[];`

By the commit:
https://github.com/9rnsr/dmd/commit/f703c5c6551affddd9213f759657a2b3e391b935
now the redundant slice operators at the right side of an array literal is entirely removed - `[1,2,3][][]` is rewritten to `[1,2,3]`.

Although it has broke existing code using array-ops, I still cannot think the optimization was incorrect.

On the other hand, I could not find the description about the necessity of explicit slice on array literal from the language spec.
http://dlang.org/arrays.html#array-operations
It looked to me that is just an implementation-specific restriction.

So, I implemented this as the easiest way to fix the issue. Therefore this is not only a regression fix, but also is a language enhancement.

Is this acceptable?
