### PR TITLE
[REG2.063] Disable enhancement feature 7444

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -11707,7 +11707,7 @@ Ltupleassign:
                 e2 = new SliceExp(e2->loc, e2, NULL, NULL);
                 e2 = e2->semantic(sc);
             }
-            else if (global.params.warnings && !global.gag && op == TOKassign &&
+            else if (0 && global.params.warnings && !global.gag && op == TOKassign &&
                      e2->op != TOKarrayliteral && e2->op != TOKstring &&
                      !e2->implicitConvTo(t1))
             {   // Disallow sa = da (Converted to sa[] = da[])
@@ -11837,7 +11837,7 @@ Ltupleassign:
         {
             e2->checkPostblit(sc, t2->nextOf());
         }
-        if (global.params.warnings && !global.gag && op == TOKassign &&
+        if (0 && global.params.warnings && !global.gag && op == TOKassign &&
             e2->op != TOKslice && e2->op != TOKassign &&
             e2->op != TOKarrayliteral && e2->op != TOKstring &&
             !(e2->op == TOKadd || e2->op == TOKmin ||
@@ -11861,7 +11861,7 @@ Ltupleassign:
     }
     else
     {
-        if (global.params.warnings && !global.gag && op == TOKassign &&
+        if (0 && global.params.warnings && !global.gag && op == TOKassign &&
             t1->ty == Tarray && t2->ty == Tsarray &&
             e2->op != TOKslice && //e2->op != TOKarrayliteral &&
             t2->implicitConvTo(t1))

--- a/test/fail_compilation/warn7444.d
+++ b/test/fail_compilation/warn7444.d
@@ -4,16 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn7444.d(30): Warning: explicit element-wise assignment (sa)[] = e is better than sa = e
-fail_compilation/warn7444.d(32): Error: cannot implicitly convert expression (e) of type int to int[]
-fail_compilation/warn7444.d(37): Warning: explicit element-wise assignment (sa)[] = sa[] is better than sa = sa[]
-fail_compilation/warn7444.d(38): Warning: explicit element-wise assignment sa[] = (sa)[] is better than sa[] = sa
-fail_compilation/warn7444.d(41): Warning: explicit element-wise assignment (sa)[] = (da)[] is better than sa = da
-fail_compilation/warn7444.d(42): Warning: explicit element-wise assignment (sa)[] = da[] is better than sa = da[]
-fail_compilation/warn7444.d(43): Warning: explicit element-wise assignment sa[] = (da)[] is better than sa[] = da
-fail_compilation/warn7444.d(47): Warning: explicit slice assignment da = (sa)[] is better than da = sa
-fail_compilation/warn7444.d(49): Warning: explicit element-wise assignment da[] = (sa)[] is better than da[] = sa
-fail_compilation/warn7444.d(54): Warning: explicit element-wise assignment da[] = (da)[] is better than da[] = da
+fail_compilation/warn7444.d(23): Error: cannot implicitly convert expression (e) of type int to int[]
 ---
 */
 
@@ -59,7 +50,7 @@ void test7444()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn7444.d(69): Warning: explicit element-wise assignment (arr)[] = 0 is better than arr = 0
+No warning
 ---
 */
 
@@ -67,6 +58,7 @@ void test10214()
 {
     bool[1] arr;
     arr = 0;
+    pragma(msg, "No warning");
 }
 
 /*


### PR DESCRIPTION
[The enhancement 7444](http://d.puremagic.com/issues/show_bug.cgi?id=7444) has been introduced in 2.063. But now, there's some issues which are not easy to immediately resolve.

I'd suggest to disable the feature 7444 in 2.064 release.

Existing issues:

[Issue 11276](http://d.puremagic.com/issues/show_bug.cgi?id=11276) - Spurious "explicit slice assignment ...[] is better" warning message in Phobos
To enforce slice + assign syntax `a[] = b[]` may cause problems with generic code.

[Issue 11244](http://d.puremagic.com/issues/show_bug.cgi?id=11244) - Invalid warning about slice assignment
A case yet difficult to make it clear - combination with operator overloading.
