### PR TITLE
New sc.ini with expanded 64-bit support

### DIFF
--- a/ini/windows/bin/sc.ini
+++ b/ini/windows/bin/sc.ini
@@ -1,10 +1,74 @@
 [Version]
 version=7.51 Build 020
 
+
+; environment for both 32/64 bit
 [Environment]
-LIB="%@P%\..\lib";\dm\lib
 DFLAGS="-I%@P%\..\..\src\phobos" "-I%@P%\..\..\src\druntime\import"
+
+; optlink only reads from the Environment section so we need this redundancy
+; from the Environment32 section (bugzilla 11302)
+LIB="%@P%\..\lib"
+
+
+[Environment32]
+LIB="%@P%\..\lib"
 LINKCMD=%@P%\link.exe
-LINKCMD64=%VCINSTALLDIR%bin\amd64\link.exe
-VCINSTALLDIR=%VCINSTALLDIR%
-WindowsSdkDir=%WindowsSdkDir%
+
+
+[Environment64]
+LIB="%@P%\..\lib64"
+
+; needed to avoid COMDAT folding (bugzilla 10664)
+DFLAGS=%DFLAGS% -L/OPT:NOICF
+
+; default to 32-bit linker (can generate 64-bit code) that has a common path
+; for VS2008, VS2010, VS2012, and VS2013. This will be overridden below if the
+; installer detects VS.
+LINKCMD=%VCINSTALLDIR%\bin\link.exe
+
+
+; -----------------------------------------------------------------------------
+; This enclosed section is specially crafted to be activated by the Windows
+; installer when it detects the actual paths to VC and SDK installations so
+; modify this in the default sc.ini within the dmd git repo with care.
+;
+; End users: You can fill in the path to VC and Windows SDK and uncomment out
+; the appropriate LINKCMD to manually enable support yourself.
+;
+; Users using Visual Studio 2010 Express with SDK 7.0A: The installer cannot
+; determine the path to the 64-bit compiler included with SDK 7.0A. It's
+; recommended to install the Windows SDK 7.1A. Alternatively you can set
+; LINKCMD as the path to link.exe SDK 7.0A installs. It would typically be:
+;   C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\amd64\link.exe
+
+
+; Windows installer replaces the following lines with the actual paths
+;VCINSTALLDIR=
+;WindowsSdkDir=
+
+; Windows installer uncomments the version detected
+;VC2013 LINKCMD=%VCINSTALLDIR%\bin\x86_amd64\link.exe
+;VC2012 LINKCMD=%VCINSTALLDIR%\bin\x86_amd64\link.exe
+;VC2010 LINKCMD=%VCINSTALLDIR%\bin\amd64\link.exe
+;VC2008 LINKCMD=%VCINSTALLDIR%\bin\amd64\link.exe
+
+; needed with /DEBUG to find mspdb*.dll (only for VS2012 or VS2013)
+;VC2013 PATH=%PATH%;%VCINSTALLDIR%\bin\x86_amd64;%VCINSTALLDIR%\..\Common7\IDE
+;VC2012 PATH=%PATH%;%VCINSTALLDIR%\bin\x86_amd64;%VCINSTALLDIR%\..\Common7\IDE
+
+; ----------------------------------------------------------------------------
+
+
+; Add the library subdirectories of all VC and Windows SDK versions so things
+; just work for users using dmd from the VS 64-bit Command Prompt
+
+; C Runtime libraries
+LIB=%LIB%;"%VCINSTALLDIR%\lib\amd64"
+
+; Platform libraries (Windows SDK 8)
+LIB=%LIB%;"%WindowsSdkDir%\Lib\win8\um\x64"
+
+; Platform libraries (Windows SDK 7 and 6)
+LIB=%LIB%;"%WindowsSdkDir%\Lib\x64"
+


### PR DESCRIPTION
Note: Requires phobos64.lib to be in lib64 rather than lib (see [phobos pull 1652](https://github.com/D-Programming-Language/phobos/pull/1652))

Fixes issue #11266

Should work for all versions of Visual Studio 2008+ when dmd is used within the Visual Studio Command Prompt.

Works in conjunction with the Windows dmd installer (see [installer pull 22](https://github.com/D-Programming-Language/installer/pull/22)) to automatically set appropriate paths so 64-bit dmd compilation can be used outside of the Visual Studio Command Prompt
