### PR TITLE
[REG2.064a] Issue 11251 - Not able to link (Previous Definition Different)

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -291,6 +291,22 @@ void Module::genobjfile(int multiobj)
 
     //printf("Module::genobjfile(multiobj = %d) %s\n", multiobj, toChars());
 
+    if (ident == Id::entrypoint)
+    {
+        char v = global.params.verbose;
+        global.params.verbose = 0;
+
+        for (size_t i = 0; i < members->dim; i++)
+        {
+            Dsymbol *member = (*members)[i];
+            //printf("toObjFile %s %s\n", member->kind(), member->toChars());
+            member->toObjFile(global.params.multiobj);
+        }
+
+        global.params.verbose = v;
+        return;
+    }
+
     lastmname = srcfile->toChars();
 
     objmod->initfile(lastmname, NULL, toPrettyChars());

--- a/src/mars.c
+++ b/src/mars.c
@@ -1707,12 +1707,7 @@ Language changes listed by -transition=id:\n\
                 fprintf(global.stdmsg, "code      %s\n", m->toChars());
             m->genobjfile(0);
             if (entrypoint && m == entrypoint->importedFrom)
-            {
-                char v = global.params.verbose;
-                global.params.verbose = 0;
                 entrypoint->genobjfile(0);
-                global.params.verbose = v;
-            }
             if (!global.errors && global.params.doDocComments)
                 m->gendocfile();
         }
@@ -1733,12 +1728,7 @@ Language changes listed by -transition=id:\n\
                 obj_start(m->srcfile->toChars());
                 m->genobjfile(global.params.multiobj);
                 if (entrypoint && m == entrypoint->importedFrom)
-                {
-                    char v = global.params.verbose;
-                    global.params.verbose = 0;
                     entrypoint->genobjfile(global.params.multiobj);
-                    global.params.verbose = v;
-                }
                 obj_end(library, m->objfile);
                 obj_write_deferred(library);
             }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11251

By #2540 , implicitly defined C `main` has been moved to `__entrypoint` module. But, the codegen generates ModuleInfo symbol for the module. And vibe.d has its own main function in library. Then, compiling uer progam with vibe.d library will cause the conflict of two ModuleInfo symbols of `__entrypoint` module.

Due to avoid ModuleInfo symbol generation for `__entrypoint`, I added a special case in `Module::genobjfile` function. But, I'm not sure that the change won't cause any other problems...
