### PR TITLE
Destructor handling issues with internal generated temporary variables

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7919,7 +7919,9 @@ Expression *DotVarExp::semantic(Scope *sc)
                 Identifier *id = Lexer::uniqueId("__tup");
                 ExpInitializer *ei = new ExpInitializer(e1->loc, e1);
                 VarDeclaration *v = new VarDeclaration(e1->loc, NULL, id, ei);
-                v->storage_class |= STCctfe | STCref | STCforeach;
+                v->storage_class |= STCctfe;
+                if (e1->isLvalue())
+                    v->storage_class |= STCref | STCforeach;
                 e0 = new DeclarationExp(e1->loc, v);
                 ev = new VarExp(e1->loc, v);
                 e0 = e0->semantic(sc);
@@ -11465,7 +11467,9 @@ Ltupleassign:
             Identifier *id = Lexer::uniqueId("__tup");
             ExpInitializer *ei = new ExpInitializer(e2->loc, e2);
             VarDeclaration *v = new VarDeclaration(e2->loc, NULL, id, ei);
-            v->storage_class = STCctfe | STCref | STCforeach;
+            v->storage_class = STCctfe;
+            if (e2->isLvalue())
+                v->storage_class = STCref | STCforeach;
             Expression *e0 = new DeclarationExp(e2->loc, v);
             Expression *ev = new VarExp(e2->loc, v);
             ev->type = e2->type;

--- a/src/expression.c
+++ b/src/expression.c
@@ -14083,7 +14083,6 @@ Expression *BinExp::reorderSettingAAElem(Scope *sc)
     {
         Identifier *id = Lexer::uniqueId("__aatmp");
         VarDeclaration *vd = new VarDeclaration(ie->e1->loc, ie->e1->type, id, new ExpInitializer(ie->e1->loc, ie->e1));
-        vd->storage_class |= STCref | STCforeach;
         Expression *de = new DeclarationExp(ie->e1->loc, vd);
 
         ec = de;
@@ -14093,7 +14092,8 @@ Expression *BinExp::reorderSettingAAElem(Scope *sc)
     {
         Identifier *id = Lexer::uniqueId("__aakey");
         VarDeclaration *vd = new VarDeclaration(ie->e2->loc, ie->e2->type, id, new ExpInitializer(ie->e2->loc, ie->e2));
-        vd->storage_class |= STCref | STCforeach;
+        if (ie->e2->isLvalue())
+            vd->storage_class |= STCref | STCforeach;
         Expression *de = new DeclarationExp(ie->e2->loc, vd);
 
         ec = ec ? new CommaExp(loc, ec, de) : de;

--- a/src/expression.c
+++ b/src/expression.c
@@ -11560,6 +11560,8 @@ Ltupleassign:
                     VarDeclaration *v = new VarDeclaration(loc, ie->e2->type,
                         Lexer::uniqueId("__aakey"), new ExpInitializer(loc, ie->e2));
                     v->storage_class |= STCctfe;
+                    if (ek->isLvalue())
+                        v->storage_class |= STCforeach | STCref;
                     v->semantic(sc);
                     e0 = combine(e0, new DeclarationExp(loc, v));
                     ek = new VarExp(loc, v);
@@ -11569,6 +11571,8 @@ Ltupleassign:
                     VarDeclaration *v = new VarDeclaration(loc, e2->type,
                         Lexer::uniqueId("__aaval"), new ExpInitializer(loc, e2));
                     v->storage_class |= STCctfe;
+                    if (ev->isLvalue())
+                        v->storage_class |= STCforeach | STCref;
                     v->semantic(sc);
                     e0 = combine(e0, new DeclarationExp(loc, v));
                     ev = new VarExp(loc, v);

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -988,6 +988,51 @@ void test6178()
     test6178e();
 }
 
+void test6178x()
+{
+    static int ctor, cpctor, dtor;
+
+    static struct S
+    {
+        this(int)  { ++ctor;   printf("ctor\n");   }
+        this(this) { ++cpctor; printf("cpctor\n"); }
+        ~this()    { ++dtor;   printf("dtor\n");   }
+    }
+    static struct X
+    {
+        this(int) {}
+        void opAssign(int) {}
+    }
+
+    X[S] aa1;
+    S[int] aa2;
+
+    {
+        auto value = S(1);
+        assert(ctor==1 && cpctor==0 && dtor==0);
+
+        ref getRef(ref S s = value) { return s; }
+        auto getVal() { return value; }
+
+        aa1[value] = 10;
+        assert(ctor==1 && cpctor==0 && dtor==0);
+
+        aa1[getRef()] = 20;
+        assert(ctor==1 && cpctor==0 && dtor==0);
+
+        aa1[getVal()] = 20;
+        assert(ctor==1 && cpctor==1 && dtor==1);
+
+        aa2[1] = value;
+        assert(ctor==1 && cpctor==2 && dtor==1);
+
+        aa2[2] = getRef();
+        assert(ctor==1 && cpctor==3 && dtor==1);
+    }
+    assert(ctor==1 && cpctor==3 && dtor==2);
+    assert(ctor + cpctor - aa2.length == dtor);
+}
+
 /************************************************/
 // 10595
 
@@ -1188,6 +1233,7 @@ int main()
     test4826c();
     test5131();
     test6178();
+    test6178x();
     test10595();
     test10970();
     test6433();

--- a/test/runnable/testaa2.d
+++ b/test/runnable/testaa2.d
@@ -222,6 +222,38 @@ void test3825()
     bug8070();
 }
 
+void test3825x()
+{
+    static int ctor, cpctor, dtor;
+
+    static struct S
+    {
+        this(int)  { ++ctor; }
+        this(this) { ++cpctor; }
+        ~this()    { ++dtor; }
+    }
+
+    {
+        auto value = S(1);
+        assert(ctor==1 && cpctor==0 && dtor==0);
+
+        ref getRef(ref S s = value) { return s; }
+        auto getVal() { return value; }
+        int[S] aa;
+
+        aa[value] = 10;
+        assert(ctor==1 && cpctor==0 && dtor==0);
+
+        aa[getRef()] += 1;
+        assert(ctor==1 && cpctor==0 && dtor==0);
+
+        aa[getVal()] += 1;
+        assert(ctor==1 && cpctor==1 && dtor==1);
+    }
+    assert(ctor==1 && cpctor==1 && dtor==2);
+    assert(ctor + cpctor == dtor);
+}
+
 /************************************************/
 // 10106
 
@@ -252,6 +284,7 @@ int main()
     test1899();
     test4523();
     test3825();
+    test3825x();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
During bug 11311 fix, I found some similar dtor-handling issues related with internal generated temporaries.
These are not regressions, because they had not worked yet correctly.
However, bugfix for 6178 is done in 2.064alpha, so I want to fix these problems in 2.064 release.

See also commit log messages for the details.
