### PR TITLE
fix Issue 11310 - Fix RIP relative offset calculation for TEST instruction

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -6045,7 +6045,7 @@ unsigned codout(code *c)
                                 unsigned reg = rm & modregrm(0,7,0);
                                 if (ins & T ||
                                     ((op == 0xF6 || op == 0xF7) && (reg == modregrm(0,0,0) || reg == modregrm(0,1,0))))
-                                {   if (ins & E)
+                                {   if (ins & E || op == 0xF6)
                                         val = -5;
                                     else if (c->Iflags & CFopsize)
                                         val = -6;

--- a/test/runnable/testpic.d
+++ b/test/runnable/testpic.d
@@ -1,0 +1,32 @@
+// PERMUTE_ARGS: -O -inline
+// REQUIRED_ARGS: -fPIC
+
+extern (C) int printf(const char*, ...);
+
+/***************************************************/
+
+align(16) struct S41
+{
+    int[4] a;
+}
+
+shared int x41;
+shared S41 s41;
+
+void test11310()
+{
+    printf("&x = %p\n", &x41);
+    printf("&s = %p\n", &s41);
+    assert((cast(int)&s41 & 0xF) == 0);
+}
+
+/***************************************************/
+
+int main()
+{
+    test11310();
+
+    writefln("Success");
+    return 0;
+}
+


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11310
This should fix test42.d test failures on Linux 64 bit.
