### PR TITLE
fix Issue 11330 - Directory named as imported module should not stop module search

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1192,8 +1192,12 @@ const char *lookForSourceFile(const char *filename)
     {
         /* The filename exists and it's a directory.
          * Therefore, the result should be: filename/package.d
+         * iff filename/package.d is a file
          */
-        return FileName::combine(filename, "package.d");
+        const char *n = FileName::combine(filename, "package.d");
+        if (FileName::exists(n) == 1)
+            return n;
+        FileName::free(n);
     }
 
     if (FileName::absolute(filename))
@@ -1220,7 +1224,12 @@ const char *lookForSourceFile(const char *filename)
         n = FileName::combine(p, b);
         FileName::free(b);
         if (FileName::exists(n) == 2)
-            return FileName::combine(n, "package.d");
+        {
+            const char *n2 = FileName::combine(n, "package.d");
+            if (FileName::exists(n2) == 1)
+                return n2;
+            FileName::free(n2);
+        }
         FileName::free(n);
     }
     return NULL;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11330

The fix opted for is if a directory does not contain a package.d file, then it is not considered to be an implicit package.
