### PR TITLE
Fix issue 11365: Allow D scripts have arbitrary names

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -1374,12 +1374,12 @@ Language changes listed by -transition=id:\n\
             /* Examine extension to see if it is a valid
              * D source file extension
              */
-            if (FileName::equals(ext, global.mars_ext) ||
+            if (global.params.run ||
+                FileName::equals(ext, global.mars_ext) ||
                 FileName::equals(ext, global.hdr_ext) ||
                 FileName::equals(ext, "dd"))
             {
                 ext--;                  // skip onto '.'
-                assert(*ext == '.');
                 name = (char *)mem.malloc((ext - p) + 1);
                 memcpy(name, p, ext - p);
                 name[ext - p] = 0;              // strip extension

--- a/src/module.c
+++ b/src/module.c
@@ -92,8 +92,12 @@ Module::Module(char *filename, Identifier *ident, int doDocComment, int doHdrGen
     nameoffset = 0;
     namelen = 0;
 
-    srcfilename = FileName::defaultExt(filename, global.mars_ext);
-    if (!FileName::equalsExt(srcfilename, global.mars_ext) &&
+    if (global.params.run && FileName::exists(filename))
+        srcfilename = FileName::dup(filename);
+    else
+        srcfilename = FileName::defaultExt(filename, global.mars_ext);
+    if (!global.params.run &&
+        !FileName::equalsExt(srcfilename, global.mars_ext) &&
         !FileName::equalsExt(srcfilename, global.hdr_ext) &&
         !FileName::equalsExt(srcfilename, "dd"))
     {

--- a/src/root/root.c
+++ b/src/root/root.c
@@ -593,6 +593,15 @@ const char *FileName::replaceName(const char *path, const char *name)
  * Free returned value with FileName::free()
  */
 
+const char *FileName::dup(const char *name)
+{
+    return  mem.strdup(name);
+}
+
+/***************************
+ * Free returned value with FileName::free()
+ */
+
 const char *FileName::defaultExt(const char *name, const char *ext)
 {
     const char *e = FileName::ext(name);

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -114,6 +114,7 @@ public:
 
     static const char *combine(const char *path, const char *name);
     static Strings *splitPath(const char *path);
+    static const char *dup(const char *name);
     static const char *defaultExt(const char *name, const char *ext);
     static const char *forceExt(const char *name, const char *ext);
     static int equalsExt(const char *name, const char *ext);


### PR DESCRIPTION
When -run is used, don't check for the filename to end with .d, allow
any file names. Normal compilation will still check for file names to
have standard extensions.

This seems to be a good compromise, people thinking allowing arbitrary
names always can be harmful shouldn't fear this test, as it only affect
"scripts", but scripts still can be flexible enough to use whatever name
they like (as it should be).

This might need a documentation update, and extra review is welcome as
I'm not sure there are hidden interactions I missed.
