### PR TITLE
fix Issue 11237

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -2310,7 +2310,7 @@ int Obj::common_block(Symbol *s,targ_size_t size,targ_size_t count)
         s->Sfl = FLtlsdata;
         SegData[s->Sseg]->SDsym = s;
         SegData[s->Sseg]->SDoffset += size * count;
-        Obj::pubdef(s->Sseg, s, 0);
+        Obj::pubdefsize(s->Sseg, s, 0, size * count);
         searchfixlist(s);
         return s->Sseg;
     }
@@ -2321,7 +2321,7 @@ int Obj::common_block(Symbol *s,targ_size_t size,targ_size_t count)
         s->Sfl = FLudata;
         SegData[s->Sseg]->SDsym = s;
         SegData[s->Sseg]->SDoffset += size * count;
-        Obj::pubdef(s->Sseg, s, 0);
+        Obj::pubdefsize(s->Sseg, s, 0, size * count);
         searchfixlist(s);
         return s->Sseg;
     }

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -978,24 +978,7 @@ void StructDeclaration::toObjFile(int multiobj)
             sinit->Sfl = FLdata;
             toDt(&sinit->Sdt);
             dt_optimize(sinit->Sdt);
-
-            /* The following does not work for 32 bit Windows because COMDEFs are not
-             * put in a library's symbol table.
-             */
-            if (
-#if TARGET_WINDOS
-                global.params.is64bit == 1 &&
-#endif
-                dtallzeros(sinit->Sdt))
-            {
-                /* Since this is immutable data, a further optimization would be
-                 * to overlap all these 0 sinit's.
-                 */
-                sinit->Sclass = SCglobal;
-                dt2common(&sinit->Sdt); // put in BSS segment
-            }
-            else
-                out_readonly(sinit);    // put in read-only segment
+            out_readonly(sinit);    // put in read-only segment
             outdata(sinit);
         }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -61,7 +61,7 @@ ifeq (,$(OS))
         OS:=osx
     else
         ifeq (Linux,$(OS))
-            OS:=posix
+            OS:=linux
         else
             ifeq (FreeBSD,$(OS))
                 OS:=freebsd

--- a/test/compilable/extra-files/test11237.sh
+++ b/test/compilable/extra-files/test11237.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if [[ $OS == linux || $OS == freebsd ]]; then
+    nm -S ${RESULTS_DIR}/compilable/test11237_0.o | grep "00010000 B _D9test112376Buffer6__initZ"
+fi

--- a/test/compilable/test11237.d
+++ b/test/compilable/test11237.d
@@ -1,0 +1,4 @@
+// PERMUTE_ARGS:
+// POST_SCRIPT: compilable/extra-files/test11237.sh
+
+struct Buffer { ubyte[64 * 1024] buffer; }


### PR DESCRIPTION
- On ELF struct initializers had always a size of 1 byte and were weak
  objects.
