### PR TITLE
Fixed issue 11155

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -679,9 +679,37 @@ Lagain:
         Fast.size -= 5 * 4;
 #endif
 #endif
-    Fast.size = -align(REGSIZE,-Fast.size + Fast.offset);
+
+    /* Despite what the comment above says, aligning Fast section to size greater
+     * than REGSIZE does not break contract implementation. Fast.offset and 
+     * Fast.alignment must be the same for the overriding and 
+     * the overriden function, since they have the same parameters. Fast.size
+     * must be the same because otherwise, contract inheritance wouldn't work
+     * even if we didn't align Fast section to size greater than REGSIZE. Therefore, 
+     * the only way aligning the section could cause problems with contract 
+     * inheritance is if bias (declared below) differed for the overriden 
+     * and the overriding function. 
+     *
+     * Bias depends on Para.size and needframe. The value of Para.size depends on 
+     * whether the function is an interrupt handler and whether it is a farfunc. 
+     * DMD does not have _interrupt attribute and D does not make a distinction 
+     * between near and far functions, so Para.size should always be 2 * REGSIZE
+     * for D.
+     *
+     * The value of needframe depends on a global setting that is only set 
+     * during backend's initialization and on function flag Ffakeeh. On Windows,
+     * that flag is always set for virtual functions, for which contracts are
+     * defined and on other platforms, it is never set. Because of that 
+     * the value of neadframe should always be the same for the overriden 
+     * and the overriding function, and so bias should be the same too.
+    */
 
     int bias = Para.size + (needframe ? 0 : REGSIZE);
+    if (Fast.alignment < REGSIZE) 
+        Fast.alignment = REGSIZE;
+    
+    Fast.size = alignsection(Fast.size - Fast.offset, Fast.alignment, bias);
+
     if (Auto.alignment < REGSIZE)
         Auto.alignment = REGSIZE;       // necessary because localsize must be REGSIZE aligned
     Auto.size = alignsection(Fast.size - Auto.offset, Auto.alignment, bias);

--- a/test/runnable/bug11155.d
+++ b/test/runnable/bug11155.d
@@ -1,0 +1,19 @@
+// PERMUTE_ARGS:
+
+version(D_SIMD)
+{
+    alias float4 = __vector(float[4]);
+
+    void foo(float4* ptr, float4 val)
+    {
+        assert((cast(ulong) &val & 0xf) == 0);
+    }
+
+    void main()
+    { 
+        float4 v;
+        foo(&v, v); 
+    }
+}
+else
+    void main(){}


### PR DESCRIPTION
This fixes [issue 11155](http://forum.dlang.org/thread/bug-11155-3@http.d.puremagic.com/issues/).

I aligned the Fast section in prolog(). Some comments in the source code indicate that aligning this section to more than REGSIZE breaks contract implementation. I don't believe that to be the case (see the comment I have added to cgcod.c), but still, this pull request should definitely be reviewed by someone who knows the backend well.
