### PR TITLE
[REG2.064a] Issue 11424 - typedef on structs isn't caught

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3081,6 +3081,7 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, utf8_t *comment)
             break;
         }
         case TOKtypedef:
+            deprecation("use of typedef is deprecated; use alias instead");
             tok = token.value;
             nextToken();
             break;
@@ -3285,7 +3286,8 @@ L2:
             error("no identifier for declarator %s", t->toChars());
 
         if (tok == TOKtypedef || tok == TOKalias)
-        {   Declaration *v;
+        {
+            Declaration *v;
             Initializer *init = NULL;
 
             /* Aliases can no longer have multiple declarators, storage classes,
@@ -3303,7 +3305,6 @@ L2:
             }
             if (tok == TOKtypedef)
             {
-                deprecation("use of typedef is deprecated; use alias instead");
                 v = new TypedefDeclaration(loc, ident, t, init);
             }
             else

--- a/test/fail_compilation/fail6572.d
+++ b/test/fail_compilation/fail6572.d
@@ -7,3 +7,12 @@ fail_compilation/fail6572.d(9): Deprecation: use of typedef is deprecated; use a
 */
 
 typedef int y;
+
+// 11424
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail6572.d(18): Deprecation: use of typedef is deprecated; use alias instead
+---
+*/
+typedef struct S { }


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=11424

It should be caught even if the typedef keyword usage is meaningless.
