### PR TITLE
Mtypecleanup

### DIFF
--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -99,7 +99,7 @@ TypeTuple *TypeBasic::toArgTypes()
             t2 = Type::tfloat80;
             break;
 
-        case Tascii:
+        case Tchar:
             t1 = Type::tuns8;
             break;
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -252,7 +252,7 @@ void Type::init()
     mangleChar[Tcomplex80] = 'c';
 
     mangleChar[Tbool] = 'b';
-    mangleChar[Tascii] = 'a';
+    mangleChar[Tchar] = 'a';
     mangleChar[Twchar] = 'u';
     mangleChar[Tdchar] = 'w';
 
@@ -283,7 +283,7 @@ void Type::init()
           Timaginary32, Timaginary64, Timaginary80,
           Tcomplex32, Tcomplex64, Tcomplex80,
           Tbool,
-          Tascii, Twchar, Tdchar };
+          Tchar, Twchar, Tdchar };
 
     for (size_t i = 0; i < sizeof(basetab) / sizeof(basetab[0]); i++)
     {   Type *t = new TypeBasic(basetab[i]);
@@ -2802,7 +2802,7 @@ TypeBasic::TypeBasic(TY ty)
                         flags |= TFLAGSintegral | TFLAGSunsigned;
                         break;
 
-        case Tascii:    d = Token::toChars(TOKchar);
+        case Tchar:     d = Token::toChars(TOKchar);
                         flags |= TFLAGSintegral | TFLAGSunsigned;
                         break;
 
@@ -2886,7 +2886,7 @@ d_uns64 TypeBasic::size(Loc loc)
             break;
 
         case Tbool:     size = 1;               break;
-        case Tascii:    size = 1;               break;
+        case Tchar:     size = 1;               break;
         case Twchar:    size = 2;               break;
         case Tdchar:    size = 4;               break;
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -105,8 +105,6 @@ enum ENUMTY
 };
 typedef unsigned char TY;       // ENUMTY
 
-#define Tascii Tchar
-
 extern int Tsize_t;
 extern int Tptrdiff_t;
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -1100,9 +1100,6 @@ public:
     static int foreach(Parameters *args, ForeachDg dg, void *ctx, size_t *pn=NULL);
 };
 
-extern int Tsize_t;
-extern int Tptrdiff_t;
-
 int arrayTypeCompatible(Loc loc, Type *t1, Type *t2);
 int arrayTypeCompatibleWithoutCasting(Loc loc, Type *t1, Type *t2);
 void MODtoBuffer(OutBuffer *buf, unsigned char mod);


### PR DESCRIPTION
Just some cleanup.  `Tascii` is a bit silly since `char` does not represent ascii, and `Tsize_t`/`Tptrdiff_t` already appear earlier in `mtype.h`.
