### PR TITLE
Fix compile1.bug6720 already defined error

### DIFF
--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -218,9 +218,9 @@ static assert(!is(typeof(A!(int))));
 **************************************************/
 void bug6720() { }
 
-//static assert(!is(typeof(
-//cast(bool)bug6720()
-//)));
+static assert(!is(typeof(
+cast(bool)bug6720()
+)));
 
 /**************************************************
     1099
@@ -417,29 +417,4 @@ static if (is(object.ModuleInfo == class))
     static assert(__traits(classInstanceSize, object.ModuleInfo) !=
                   __traits(classInstanceSize, ModuleInfo));
 }
-
-/**************************************************
-    5796
-**************************************************/
-
-
-template A(B) {
-    pragma(msg, "missing ;")
-    enum X = 0;
-}
-
-
-static assert(!is(typeof(A!(int))));
-
-
-/**************************************************
-    6720
-**************************************************/
-void bug6720() { }
-
-
-static assert(!is(typeof(
-cast(bool)bug6720()
-)));
-
 


### PR DESCRIPTION
Don't know how I didn't get this before when running the testsuite on gdc, and only noticed post 2.064 merge... but it's a bug in the testsuite alright.  The already defined error I get is an assembler error message, which dmd doesn't get it because it emits straight code to object file.
