### PR TITLE
Remove objFileModule from TemplateInstance

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -5507,10 +5507,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             Module *m = (Module *)s;
             if (!m->isRoot())
             {
-                //if (tinst && tinst->objFileModule)
-                //    m = tinst->objFileModule;
-                //else
-                    m = m->importedFrom;
+                m = m->importedFrom;
             }
             //printf("\t2: adding to module %s instead of module %s\n", m->toChars(), sc->module->toChars());
             a = m->members;

--- a/src/template.h
+++ b/src/template.h
@@ -317,12 +317,6 @@ public:
     hash_t hash;                        // cached result of hashCode()
     Expressions *fargs;                 // for function template, these are the function arguments
     Module *instantiatingModule;        // the top module that instantiated this instance
-#ifdef IN_GCC
-    /* On some targets, it is necessary to know whether a symbol
-       will be emitted in the output or not before the symbol
-       is used.  This can be different from getModule(). */
-    Module * objFileModule;
-#endif
 
     TemplateInstance(Loc loc, Identifier *temp_id);
     TemplateInstance(Loc loc, TemplateDeclaration *tempdecl, Objects *tiargs);


### PR DESCRIPTION
`-femit-templates` is planned to be mapped to `-allinst` and have made some improvements to template emission that should remove the need for this to be kept around anymore for gdc's sake.
