### PR TITLE
[DDMD] Add casts when converting ubyte* to char*

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4314,7 +4314,7 @@ void StringExp::toMangleBuffer(OutBuffer *buf)
                 else
                     tmp.writeUTF8(c);
             }
-            q = tmp.data;
+            q = (utf8_t *)tmp.data;
             qlen = tmp.offset;
             break;
         case 4:
@@ -4327,7 +4327,7 @@ void StringExp::toMangleBuffer(OutBuffer *buf)
                 else
                     tmp.writeUTF8(c);
             }
-            q = tmp.data;
+            q = (utf8_t *)tmp.data;
             qlen = tmp.offset;
             break;
         default:
@@ -4337,7 +4337,7 @@ void StringExp::toMangleBuffer(OutBuffer *buf)
     buf->writeByte(m);
     buf->printf("%d_", (int)qlen); // nbytes <= 11
 
-    for (utf8_t *p = buf->data + buf->offset, *pend = p + 2 * qlen;
+    for (utf8_t *p = (utf8_t *)buf->data + buf->offset, *pend = p + 2 * qlen;
          p < pend; p += 2, ++q)
     {
         utf8_t hi = *q >> 4 & 0xF;

--- a/src/macro.c
+++ b/src/macro.c
@@ -259,7 +259,7 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
     arg = memdup(arg, arglen);
     for (size_t u = start; u + 1 < end; )
     {
-        utf8_t *p = buf->data;   // buf->data is not loop invariant
+        utf8_t *p = (utf8_t *)buf->data;   // buf->data is not loop invariant
 
         /* Look for $0, but not $$0, and replace it with arg.
          */
@@ -327,7 +327,7 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
      */
     for (size_t u = start; u + 4 < end; )
     {
-        utf8_t *p = buf->data;   // buf->data is not loop invariant
+        utf8_t *p = (utf8_t *)buf->data;   // buf->data is not loop invariant
 
         /* A valid start of macro expansion is $(c, where c is
          * an id start character, and not $$(c.

--- a/src/module.c
+++ b/src/module.c
@@ -321,7 +321,7 @@ void Module::parse()
     char *srcname = srcfile->name->toChars();
     //printf("Module::parse(srcname = '%s')\n", srcname);
 
-    utf8_t *buf = srcfile->buffer;
+    utf8_t *buf = (utf8_t *)srcfile->buffer;
     size_t buflen = srcfile->len;
 
     if (buflen >= 2)


### PR DESCRIPTION
Because in D they are not the same type, and the cast is required.  Every single one is an `OutBuffer` or `File` buffer entering being brought into the lexer/ddoc/etc.
