### PR TITLE
fix Issue 11365 - Allow D source file names to have no extension (or an arbitrary extension)

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -462,6 +462,34 @@ int runLINK()
     {
         argv.push(global.params.exefile);
     }
+    else if (global.params.run)
+    {
+#if 1
+        char name[] = P_tmpdir"/dmd_runXXXXXX";
+        int fd = mkstemp(name);
+        if (fd == -1)
+        {   error(Loc(), "error creating temporary file");
+            return 1;
+        }
+        else
+            close(fd);
+        global.params.exefile = mem.strdup(name);
+        argv.push(global.params.exefile);
+#else
+        /* The use of tmpnam raises the issue of "is this a security hole"?
+         * The hole is that after tmpnam and before the file is opened,
+         * the attacker modifies the file system to get control of the
+         * file with that name. I do not know if this is an issue in
+         * this context.
+         * We cannot just replace it with mkstemp, because this name is
+         * passed to the linker that actually opens the file and writes to it.
+         */
+        char s[L_tmpnam + 1];
+        char *n = tmpnam(s);
+        global.params.exefile = mem.strdup(n);
+        argv.push(global.params.exefile);
+#endif
+    }
     else
     {   // Generate exe file name from first obj name
         const char *n = (*global.params.objfiles)[0];

--- a/src/module.c
+++ b/src/module.c
@@ -93,7 +93,24 @@ Module::Module(const char *filename, Identifier *ident, int doDocComment, int do
     namelen = 0;
 
     srcfilename = FileName::defaultExt(filename, global.mars_ext);
-    if (!FileName::equalsExt(srcfilename, global.mars_ext) &&
+
+#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+    /* Allow 'script' D source files to have no extension.
+     */
+    bool allow_no_extension = true;
+#else
+    bool allow_no_extension = false;
+#endif
+    if (allow_no_extension &&
+        global.params.run &&
+        !FileName::ext(filename) &&
+        FileName::exists(srcfilename) == 0 &&
+        FileName::exists(filename) == 1)
+    {
+        FileName::free(srcfilename);
+        srcfilename = FileName::removeExt(filename);    // just does a mem.strdup(filename)
+    }
+    else if (!FileName::equalsExt(srcfilename, global.mars_ext) &&
         !FileName::equalsExt(srcfilename, global.hdr_ext) &&
         !FileName::equalsExt(srcfilename, "dd"))
     {


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11365

This does not allow an arbitrary extension, as source files need to be D identifiers.

It is not enabled for Windows, as Windows does not have executable files with no extension.

In order to avoid the default behavior of overwriting the source file with the executable file, it generates "a.out" instead.

This is a redo of https://github.com/D-Programming-Language/dmd/pull/2700
