### PR TITLE
fix Issue 10207 - Alias and @attributes: Assertion failure: udas on line 3132 in file parse.c

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3291,7 +3291,9 @@ L2:
              * The grammar has already been fixed to preclude them.
              */
 
-            assert(!udas);
+            if (udas)
+                error("user defined attributes not allowed for %s declarations", Token::toChars(tok));
+
             if (token.value == TOKassign)
             {
                 nextToken();

--- a/test/fail_compilation/fail10207.d
+++ b/test/fail_compilation/fail10207.d
@@ -1,0 +1,7 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10207.d(7): Error: user defined attributes not allowed for alias declarations
+---
+*/
+alias @Safe int __externC;


### PR DESCRIPTION
.https://d.puremagic.com/issues/show_bug.cgi?id=10207
