### PR TITLE
Issue 11489 - Improper implicit cast to immutable.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8978,8 +8978,15 @@ MATCH TypeClass::constConv(Type *to)
     /* Conversion derived to const(base)
      */
     int offset = 0;
-    if (to->isBaseOf(this, &offset) && offset == 0 && !to->isMutable() && !to->isWild())
-        return MATCHconvert;
+    if (to->isBaseOf(this, &offset) && offset == 0 &&
+        MODimplicitConv(mod, to->mod))
+    {
+        // Disallow:
+        //  derived to base
+        //  inout(derived) to inout(base)
+        if (!to->isMutable() && !to->isWild())
+            return MATCHconvert;
+    }
 
     return MATCHnomatch;
 }

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -3272,6 +3272,79 @@ static assert(is(typeof(f11215(0)) == shared(void**)));
 static assert(is(typeof(f11215((const int).init)) == shared(const(void)**)));
 
 /************************************/
+// 11489
+
+void test11489(inout int = 0)
+{
+    static class B {}
+    static class D : B {}
+
+                 D [] dm;
+           const(D)[] dc;
+           inout(D)[] dw;
+          shared(D)[] dsm;
+    shared(const D)[] dsc;
+    shared(inout D)[] dsw;
+       immutable(D)[] di;
+
+    static assert(!__traits(compiles, {              B [] b = dm; }));
+    static assert( __traits(compiles, {        const(B)[] b = dm; }));
+    static assert(!__traits(compiles, {        inout(B)[] b = dm; }));
+    static assert(!__traits(compiles, {       shared(B)[] b = dm; }));
+    static assert(!__traits(compiles, { shared(const B)[] b = dm; }));
+    static assert(!__traits(compiles, { shared(inout B)[] b = dm; }));
+    static assert(!__traits(compiles, {    immutable(B)[] b = dm; }));
+
+    static assert(!__traits(compiles, {              B [] b = dc; }));
+    static assert( __traits(compiles, {        const(B)[] b = dc; }));
+    static assert(!__traits(compiles, {        inout(B)[] b = dc; }));
+    static assert(!__traits(compiles, {       shared(B)[] b = dc; }));
+    static assert(!__traits(compiles, { shared(const B)[] b = dc; }));
+    static assert(!__traits(compiles, { shared(inout B)[] b = dc; }));
+    static assert(!__traits(compiles, {    immutable(B)[] b = dc; }));
+
+    static assert(!__traits(compiles, {              B [] b = dw; }));
+    static assert( __traits(compiles, {        const(B)[] b = dw; }));
+    static assert(!__traits(compiles, {        inout(B)[] b = dw; }));
+    static assert(!__traits(compiles, {       shared(B)[] b = dw; }));
+    static assert(!__traits(compiles, { shared(const B)[] b = dw; }));
+    static assert(!__traits(compiles, { shared(inout B)[] b = dw; }));
+    static assert(!__traits(compiles, {    immutable(B)[] b = dw; }));
+
+    static assert(!__traits(compiles, {              B [] b = dsm; }));
+    static assert(!__traits(compiles, {        const(B)[] b = dsm; }));
+    static assert(!__traits(compiles, {        inout(B)[] b = dsm; }));
+    static assert(!__traits(compiles, {       shared(B)[] b = dsm; }));
+    static assert( __traits(compiles, { shared(const B)[] b = dsm; }));
+    static assert(!__traits(compiles, { shared(inout B)[] b = dsm; }));
+    static assert(!__traits(compiles, {    immutable(B)[] b = dsm; }));
+
+    static assert(!__traits(compiles, {              B [] b = dsc; }));
+    static assert(!__traits(compiles, {        const(B)[] b = dsc; }));
+    static assert(!__traits(compiles, {        inout(B)[] b = dsc; }));
+    static assert(!__traits(compiles, {       shared(B)[] b = dsc; }));
+    static assert( __traits(compiles, { shared(const B)[] b = dsc; }));
+    static assert(!__traits(compiles, { shared(inout B)[] b = dsc; }));
+    static assert(!__traits(compiles, {    immutable(B)[] b = dsc; }));
+
+    static assert(!__traits(compiles, {              B [] b = dsw; }));
+    static assert(!__traits(compiles, {        const(B)[] b = dsw; }));
+    static assert(!__traits(compiles, {        inout(B)[] b = dsw; }));
+    static assert(!__traits(compiles, {       shared(B)[] b = dsw; }));
+    static assert( __traits(compiles, { shared(const B)[] b = dsw; }));
+    static assert(!__traits(compiles, { shared(inout B)[] b = dsw; }));
+    static assert(!__traits(compiles, {    immutable(B)[] b = dsw; }));
+
+    static assert(!__traits(compiles, {              B [] b = di; }));
+    static assert( __traits(compiles, {        const(B)[] b = di; }));
+    static assert(!__traits(compiles, {        inout(B)[] b = di; }));
+    static assert(!__traits(compiles, {       shared(B)[] b = di; }));
+    static assert( __traits(compiles, { shared(const B)[] b = di; }));
+    static assert(!__traits(compiles, { shared(inout B)[] b = di; }));
+    static assert( __traits(compiles, {    immutable(B)[] b = di; }));
+}
+
+/************************************/
 
 int main()
 {


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11489

Nostalgic const conversion bug. We really need to effort to write exhaustive test.
