### PR TITLE
Fix Issue 10926 - Wrong expression printed when ternary operator used as lvalue

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -13838,7 +13838,7 @@ Expression *CondExp::modifiableLvalue(Scope *sc, Expression *e)
 {
     //error("conditional expression %s is not a modifiable lvalue", toChars());
     e1 = e1->modifiableLvalue(sc, e1);
-    e2 = e2->modifiableLvalue(sc, e1);
+    e2 = e2->modifiableLvalue(sc, e2);
     return toLvalue(sc, this);
 }
 

--- a/test/fail_compilation/diag10926.d
+++ b/test/fail_compilation/diag10926.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag10926.d(11): Error: cast(const(int)[])c is not an lvalue
+---
+*/
+
+void main() {
+    const(int)[] a, b;
+    int[] c, d;
+    (true ? a : c) ~= 20; // line 6, Error: a is not an lvalue
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10926
