### PR TITLE
Implement Statement::toIR in terms of a visitor interface

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -41,6 +41,7 @@ void slist_reset();
 void clearStringTab();
 
 elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
+void Statement_toIR(Statement *s, IRState *irs);
 
 #define STATICCTOR      0
 
@@ -1033,7 +1034,7 @@ void FuncDeclaration::toObjFile(int multiobj)
         }
 #endif
 
-        sbody->toIR(&irs);
+        Statement_toIR(sbody, &irs);
         bx.curblock->BC = BCret;
 
         f->Fstartblock = bx.startblock;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -139,7 +139,7 @@ SRC = win32.mak posix.mak \
 	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c \
 	argtypes.c apply.c sapply.c sideeffect.c \
 	intrange.h intrange.c canthrow.c target.c target.h \
-	scanmscoff.c scanomf.c ctfe.h ctfeexpr.c \
+	scanmscoff.c scanomf.c ctfe.h ctfeexpr.c visitor.h \
 	$C/cdef.h $C/cc.h $C/oper.h $C/ty.h $C/optabgen.c \
 	$C/global.h $C/code.h $C/type.h $C/dt.h $C/cgcv.h \
 	$C/el.h $C/iasm.h $C/rtlsym.h \
@@ -584,7 +584,7 @@ rtlsym.o: $C/rtlsym.c $C/rtlsym.h
 sapply.o: sapply.c
 	$(CC) -c $(CFLAGS) $<
 
-s2ir.o: s2ir.c $C/rtlsym.h statement.h
+s2ir.o: s2ir.c $C/rtlsym.h statement.h visitor.h
 	$(CC) -c $(MFLAGS) -I$(ROOT) $<
 
 scanelf.o: scanelf.c $C/melf.h

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -34,6 +34,7 @@
 
 #include        "rmem.h"
 #include        "target.h"
+#include        "visitor.h"
 
 static char __file__[] = __FILE__;      // for tassert.h
 #include        "tassert.h"
@@ -125,1136 +126,1140 @@ void incUsage(IRState *irs, Loc loc)
     }
 }
 
-/****************************************
- * This should be overridden by each statement class.
- */
+void Statement_toIR(Statement *s, IRState *irs);
 
-void Statement::toIR(IRState *irs)
+class S2irVisitor : public Visitor
 {
-    print();
-    assert(0);
-}
+    IRState *irs;
+public:
+    S2irVisitor(IRState *irs) : irs(irs) {}
 
-/*************************************
- */
+    /****************************************
+     * This should be overridden by each statement class.
+     */
 
-void OnScopeStatement::toIR(IRState *irs)
-{
-}
-
-/****************************************
- */
-
-void IfStatement::toIR(IRState *irs)
-{
-    elem *e;
-    Blockx *blx = irs->blx;
-
-    //printf("IfStatement::toIR('%s')\n", condition->toChars());
-
-    IRState mystate(irs, this);
-
-    // bexit is the block that gets control after this IfStatement is done
-    block *bexit = mystate.breakBlock ? mystate.breakBlock : block_calloc();
-
-    incUsage(irs, loc);
-    e = condition->toElemDtor(&mystate);
-    block_appendexp(blx->curblock, e);
-    block *bcond = blx->curblock;
-    block_next(blx, BCiftrue, NULL);
-
-    bcond->appendSucc(blx->curblock);
-    if (ifbody)
-        ifbody->toIR(&mystate);
-    blx->curblock->appendSucc(bexit);
-
-    if (elsebody)
+    void visit(Statement *s)
     {
-        block_next(blx, BCgoto, NULL);
+        s->print();
+        assert(0);
+    }
+
+    /*************************************
+     */
+
+    void visit(OnScopeStatement *s)
+    {
+    }
+
+    /****************************************
+     */
+
+    void visit(IfStatement *s)
+    {
+        elem *e;
+        Blockx *blx = irs->blx;
+
+        //printf("IfStatement::toIR('%s')\n", condition->toChars());
+
+        IRState mystate(irs, s);
+
+        // bexit is the block that gets control after this IfStatement is done
+        block *bexit = mystate.breakBlock ? mystate.breakBlock : block_calloc();
+
+        incUsage(irs, s->loc);
+        e = s->condition->toElemDtor(&mystate);
+        block_appendexp(blx->curblock, e);
+        block *bcond = blx->curblock;
+        block_next(blx, BCiftrue, NULL);
+
         bcond->appendSucc(blx->curblock);
-        elsebody->toIR(&mystate);
+        if (s->ifbody)
+            Statement_toIR(s->ifbody, &mystate);
         blx->curblock->appendSucc(bexit);
-    }
-    else
-        bcond->appendSucc(bexit);
 
-    block_next(blx, BCgoto, bexit);
-
-}
-
-/**************************************
- */
-
-void PragmaStatement::toIR(IRState *irs)
-{
-    //printf("PragmaStatement::toIR()\n");
-    if (ident == Id::startaddress)
-    {
-        assert(args && args->dim == 1);
-        Expression *e = (*args)[0];
-        Dsymbol *sa = getDsymbol(e);
-        FuncDeclaration *f = sa->isFuncDeclaration();
-        assert(f);
-        Symbol *s = f->toSymbol();
-        while (irs->prev)
-            irs = irs->prev;
-        irs->startaddress = s;
-    }
-}
-
-/***********************
- */
-
-void WhileStatement::toIR(IRState *irs)
-{
-    assert(0); // was "lowered"
-}
-
-/******************************************
- */
-
-void DoStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-
-    IRState mystate(irs,this);
-    mystate.breakBlock = block_calloc(blx);
-    mystate.contBlock = block_calloc(blx);
-
-    block *bpre = blx->curblock;
-    block_next(blx, BCgoto, NULL);
-    bpre->appendSucc(blx->curblock);
-
-    mystate.contBlock->appendSucc(blx->curblock);
-    mystate.contBlock->appendSucc(mystate.breakBlock);
-
-    if (body)
-        body->toIR(&mystate);
-    blx->curblock->appendSucc(mystate.contBlock);
-
-    block_next(blx, BCgoto, mystate.contBlock);
-    incUsage(irs, condition->loc);
-    block_appendexp(mystate.contBlock, condition->toElemDtor(&mystate));
-    block_next(blx, BCiftrue, mystate.breakBlock);
-
-}
-
-/*****************************************
- */
-
-void ForStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-
-    IRState mystate(irs,this);
-    mystate.breakBlock = block_calloc(blx);
-    mystate.contBlock = block_calloc(blx);
-
-    if (init)
-        init->toIR(&mystate);
-    block *bpre = blx->curblock;
-    block_next(blx,BCgoto,NULL);
-    block *bcond = blx->curblock;
-    bpre->appendSucc(bcond);
-    mystate.contBlock->appendSucc(bcond);
-    if (condition)
-    {
-        incUsage(irs, condition->loc);
-        block_appendexp(bcond, condition->toElemDtor(&mystate));
-        block_next(blx,BCiftrue,NULL);
-        bcond->appendSucc(blx->curblock);
-        bcond->appendSucc(mystate.breakBlock);
-    }
-    else
-    {   /* No conditional, it's a straight goto
-         */
-        block_next(blx,BCgoto,NULL);
-        bcond->appendSucc(blx->curblock);
-    }
-
-    if (body)
-        body->toIR(&mystate);
-    /* End of the body goes to the continue block
-     */
-    blx->curblock->appendSucc(mystate.contBlock);
-    block_next(blx, BCgoto, mystate.contBlock);
-
-    if (increment)
-    {
-        incUsage(irs, increment->loc);
-        block_appendexp(mystate.contBlock, increment->toElemDtor(&mystate));
-    }
-
-    /* The 'break' block follows the for statement.
-     */
-    block_next(blx,BCgoto, mystate.breakBlock);
-}
-
-
-/**************************************
- */
-
-void ForeachStatement::toIR(IRState *irs)
-{
-    printf("ForeachStatement::toIR() %s\n", toChars());
-    assert(0);  // done by "lowering" in the front end
-}
-
-
-/**************************************
- */
-
-void ForeachRangeStatement::toIR(IRState *irs)
-{
-    assert(0);
-}
-
-
-/****************************************
- */
-
-void BreakStatement::toIR(IRState *irs)
-{
-    block *bbreak;
-    block *b;
-    Blockx *blx = irs->blx;
-
-    bbreak = irs->getBreakBlock(ident);
-    assert(bbreak);
-    b = blx->curblock;
-    incUsage(irs, loc);
-
-    // Adjust exception handler scope index if in different try blocks
-    if (b->Btry != bbreak->Btry)
-    {
-        //setScopeIndex(blx, b, bbreak->Btry ? bbreak->Btry->Bscope_index : -1);
-    }
-
-    /* Nothing more than a 'goto' to the current break destination
-     */
-    b->appendSucc(bbreak);
-    block_next(blx, BCgoto, NULL);
-}
-
-/************************************
- */
-
-void ContinueStatement::toIR(IRState *irs)
-{
-    block *bcont;
-    block *b;
-    Blockx *blx = irs->blx;
-
-    //printf("ContinueStatement::toIR() %p\n", this);
-    bcont = irs->getContBlock(ident);
-    assert(bcont);
-    b = blx->curblock;
-    incUsage(irs, loc);
-
-    // Adjust exception handler scope index if in different try blocks
-    if (b->Btry != bcont->Btry)
-    {
-        //setScopeIndex(blx, b, bcont->Btry ? bcont->Btry->Bscope_index : -1);
-    }
-
-    /* Nothing more than a 'goto' to the current continue destination
-     */
-    b->appendSucc(bcont);
-    block_next(blx, BCgoto, NULL);
-}
-
-
-/**************************************
- */
-
-void GotoStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-
-    assert(label->statement);
-    assert(tf == label->statement->tf);
-
-    block *bdest = labelToBlock(loc, blx, label, 1);
-    if (!bdest)
-        return;
-    block *b = blx->curblock;
-    incUsage(irs, loc);
-
-    if (b->Btry != bdest->Btry)
-    {
-        // Check that bdest is in an enclosing try block
-        for (block *bt = b->Btry; bt != bdest->Btry; bt = bt->Btry)
+        if (s->elsebody)
         {
-            if (!bt)
-            {
-                //printf("b->Btry = %p, bdest->Btry = %p\n", b->Btry, bdest->Btry);
-                error("cannot goto into try block");
-                break;
-            }
+            block_next(blx, BCgoto, NULL);
+            bcond->appendSucc(blx->curblock);
+            Statement_toIR(s->elsebody, &mystate);
+            blx->curblock->appendSucc(bexit);
+        }
+        else
+            bcond->appendSucc(bexit);
+
+        block_next(blx, BCgoto, bexit);
+
+    }
+
+    /**************************************
+     */
+
+    void visit(PragmaStatement *s)
+    {
+        //printf("PragmaStatement::toIR()\n");
+        if (s->ident == Id::startaddress)
+        {
+            assert(s->args && s->args->dim == 1);
+            Expression *e = (*s->args)[0];
+            Dsymbol *sa = getDsymbol(e);
+            FuncDeclaration *f = sa->isFuncDeclaration();
+            assert(f);
+            Symbol *sym = f->toSymbol();
+            while (irs->prev)
+                irs = irs->prev;
+            irs->startaddress = sym;
         }
     }
 
-    b->appendSucc(bdest);
-    block_next(blx,BCgoto,NULL);
-}
+    /***********************
+     */
 
-void LabelStatement::toIR(IRState *irs)
-{
-    //printf("LabelStatement::toIR() %p, statement = %p\n", this, statement);
-    Blockx *blx = irs->blx;
-    block *bc = blx->curblock;
-    IRState mystate(irs,this);
-    mystate.ident = ident;
-
-    if (lblock)
+    void visit(WhileStatement *s)
     {
-        // At last, we know which try block this label is inside
-        lblock->Btry = blx->tryblock;
+        assert(0); // was "lowered"
+    }
 
-        /* Go through the forward references and check.
-         */
-        if (fwdrefs)
+    /******************************************
+     */
+
+    void visit(DoStatement *s)
+    {
+        Blockx *blx = irs->blx;
+
+        IRState mystate(irs,s);
+        mystate.breakBlock = block_calloc(blx);
+        mystate.contBlock = block_calloc(blx);
+
+        block *bpre = blx->curblock;
+        block_next(blx, BCgoto, NULL);
+        bpre->appendSucc(blx->curblock);
+
+        mystate.contBlock->appendSucc(blx->curblock);
+        mystate.contBlock->appendSucc(mystate.breakBlock);
+
+        if (s->body)
+            Statement_toIR(s->body, &mystate);
+        blx->curblock->appendSucc(mystate.contBlock);
+
+        block_next(blx, BCgoto, mystate.contBlock);
+        incUsage(irs, s->condition->loc);
+        block_appendexp(mystate.contBlock, s->condition->toElemDtor(&mystate));
+        block_next(blx, BCiftrue, mystate.breakBlock);
+
+    }
+
+    /*****************************************
+     */
+
+    void visit(ForStatement *s)
+    {
+        Blockx *blx = irs->blx;
+
+        IRState mystate(irs,s);
+        mystate.breakBlock = block_calloc(blx);
+        mystate.contBlock = block_calloc(blx);
+
+        if (s->init)
+            Statement_toIR(s->init, &mystate);
+        block *bpre = blx->curblock;
+        block_next(blx,BCgoto,NULL);
+        block *bcond = blx->curblock;
+        bpre->appendSucc(bcond);
+        mystate.contBlock->appendSucc(bcond);
+        if (s->condition)
         {
-            for (size_t i = 0; i < fwdrefs->dim; i++)
-            {   block *b = (*fwdrefs)[i];
+            incUsage(irs, s->condition->loc);
+            block_appendexp(bcond, s->condition->toElemDtor(&mystate));
+            block_next(blx,BCiftrue,NULL);
+            bcond->appendSucc(blx->curblock);
+            bcond->appendSucc(mystate.breakBlock);
+        }
+        else
+        {   /* No conditional, it's a straight goto
+             */
+            block_next(blx,BCgoto,NULL);
+            bcond->appendSucc(blx->curblock);
+        }
 
-                if (b->Btry != lblock->Btry)
+        if (s->body)
+            Statement_toIR(s->body, &mystate);
+        /* End of the body goes to the continue block
+         */
+        blx->curblock->appendSucc(mystate.contBlock);
+        block_next(blx, BCgoto, mystate.contBlock);
+
+        if (s->increment)
+        {
+            incUsage(irs, s->increment->loc);
+            block_appendexp(mystate.contBlock, s->increment->toElemDtor(&mystate));
+        }
+
+        /* The 'break' block follows the for statement.
+         */
+        block_next(blx,BCgoto, mystate.breakBlock);
+    }
+
+
+    /**************************************
+     */
+
+    void visit(ForeachStatement *s)
+    {
+        printf("ForeachStatement::toIR() %s\n", s->toChars());
+        assert(0);  // done by "lowering" in the front end
+    }
+
+
+    /**************************************
+     */
+
+    void visit(ForeachRangeStatement *s)
+    {
+        assert(0);
+    }
+
+
+    /****************************************
+     */
+
+    void visit(BreakStatement *s)
+    {
+        block *bbreak;
+        block *b;
+        Blockx *blx = irs->blx;
+
+        bbreak = irs->getBreakBlock(s->ident);
+        assert(bbreak);
+        b = blx->curblock;
+        incUsage(irs, s->loc);
+
+        // Adjust exception handler scope index if in different try blocks
+        if (b->Btry != bbreak->Btry)
+        {
+            //setScopeIndex(blx, b, bbreak->Btry ? bbreak->Btry->Bscope_index : -1);
+        }
+
+        /* Nothing more than a 'goto' to the current break destination
+         */
+        b->appendSucc(bbreak);
+        block_next(blx, BCgoto, NULL);
+    }
+
+    /************************************
+     */
+
+    void visit(ContinueStatement *s)
+    {
+        block *bcont;
+        block *b;
+        Blockx *blx = irs->blx;
+
+        //printf("ContinueStatement::toIR() %p\n", this);
+        bcont = irs->getContBlock(s->ident);
+        assert(bcont);
+        b = blx->curblock;
+        incUsage(irs, s->loc);
+
+        // Adjust exception handler scope index if in different try blocks
+        if (b->Btry != bcont->Btry)
+        {
+            //setScopeIndex(blx, b, bcont->Btry ? bcont->Btry->Bscope_index : -1);
+        }
+
+        /* Nothing more than a 'goto' to the current continue destination
+         */
+        b->appendSucc(bcont);
+        block_next(blx, BCgoto, NULL);
+    }
+
+
+    /**************************************
+     */
+
+    void visit(GotoStatement *s)
+    {
+        Blockx *blx = irs->blx;
+
+        assert(s->label->statement);
+        assert(s->tf == s->label->statement->tf);
+
+        block *bdest = labelToBlock(s->loc, blx, s->label, 1);
+        if (!bdest)
+            return;
+        block *b = blx->curblock;
+        incUsage(irs, s->loc);
+
+        if (b->Btry != bdest->Btry)
+        {
+            // Check that bdest is in an enclosing try block
+            for (block *bt = b->Btry; bt != bdest->Btry; bt = bt->Btry)
+            {
+                if (!bt)
                 {
-                    // Check that lblock is in an enclosing try block
-                    for (block *bt = b->Btry; bt != lblock->Btry; bt = bt->Btry)
+                    //printf("b->Btry = %p, bdest->Btry = %p\n", b->Btry, bdest->Btry);
+                    s->error("cannot goto into try block");
+                    break;
+                }
+            }
+        }
+
+        b->appendSucc(bdest);
+        block_next(blx,BCgoto,NULL);
+    }
+
+    void visit(LabelStatement *s)
+    {
+        //printf("LabelStatement::toIR() %p, statement = %p\n", this, statement);
+        Blockx *blx = irs->blx;
+        block *bc = blx->curblock;
+        IRState mystate(irs,s);
+        mystate.ident = s->ident;
+
+        if (s->lblock)
+        {
+            // At last, we know which try block this label is inside
+            s->lblock->Btry = blx->tryblock;
+
+            /* Go through the forward references and check.
+             */
+            if (s->fwdrefs)
+            {
+                for (size_t i = 0; i < s->fwdrefs->dim; i++)
+                {   block *b = (*s->fwdrefs)[i];
+
+                    if (b->Btry != s->lblock->Btry)
                     {
-                        if (!bt)
+                        // Check that lblock is in an enclosing try block
+                        for (block *bt = b->Btry; bt != s->lblock->Btry; bt = bt->Btry)
                         {
-                            //printf("b->Btry = %p, lblock->Btry = %p\n", b->Btry, lblock->Btry);
-                            error("cannot goto into try block");
-                            break;
+                            if (!bt)
+                            {
+                                //printf("b->Btry = %p, s->lblock->Btry = %p\n", b->Btry, s->lblock->Btry);
+                                s->error("cannot goto into try block");
+                                break;
+                            }
                         }
                     }
+
                 }
-
+                s->fwdrefs = NULL;
             }
-            fwdrefs = NULL;
         }
+        else
+            s->lblock = block_calloc(blx);
+        block_next(blx,BCgoto,s->lblock);
+        bc->appendSucc(blx->curblock);
+        if (s->statement)
+            Statement_toIR(s->statement, &mystate);
     }
-    else
-        lblock = block_calloc(blx);
-    block_next(blx,BCgoto,lblock);
-    bc->appendSucc(blx->curblock);
-    if (statement)
-        statement->toIR(&mystate);
-}
 
-/**************************************
- */
-
-void SwitchStatement::toIR(IRState *irs)
-{
-    int string;
-    Blockx *blx = irs->blx;
-
-    //printf("SwitchStatement::toIR()\n");
-    IRState mystate(irs,this);
-
-    mystate.switchBlock = blx->curblock;
-
-    /* Block for where "break" goes to
+    /**************************************
      */
-    mystate.breakBlock = block_calloc(blx);
 
-    /* Block for where "default" goes to.
-     * If there is a default statement, then that is where default goes.
-     * If not, then do:
-     *   default: break;
-     * by making the default block the same as the break block.
-     */
-    mystate.defaultBlock = sdefault ? block_calloc(blx) : mystate.breakBlock;
+    void visit(SwitchStatement *s)
+    {
+        int string;
+        Blockx *blx = irs->blx;
 
-    size_t numcases = 0;
-    if (cases)
-        numcases = cases->dim;
+        //printf("SwitchStatement::toIR()\n");
+        IRState mystate(irs,s);
 
-    incUsage(irs, loc);
-    elem *econd = condition->toElemDtor(&mystate);
-    if (hasVars)
-    {   /* Generate a sequence of if-then-else blocks for the cases.
+        mystate.switchBlock = blx->curblock;
+
+        /* Block for where "break" goes to
          */
-        if (econd->Eoper != OPvar)
-        {
-            elem *e = exp2_copytotemp(econd);
-            block_appendexp(mystate.switchBlock, e);
-            econd = e->E2;
-        }
+        mystate.breakBlock = block_calloc(blx);
 
-        for (size_t i = 0; i < numcases; i++)
-        {   CaseStatement *cs = (*cases)[i];
+        /* Block for where "default" goes to.
+         * If there is a default statement, then that is where default goes.
+         * If not, then do:
+         *   default: break;
+         * by making the default block the same as the break block.
+         */
+        mystate.defaultBlock = s->sdefault ? block_calloc(blx) : mystate.breakBlock;
 
-            elem *ecase = cs->exp->toElemDtor(&mystate);
-            elem *e = el_bin(OPeqeq, TYbool, el_copytree(econd), ecase);
+        size_t numcases = 0;
+        if (s->cases)
+            numcases = s->cases->dim;
+
+        incUsage(irs, s->loc);
+        elem *econd = s->condition->toElemDtor(&mystate);
+        if (s->hasVars)
+        {   /* Generate a sequence of if-then-else blocks for the cases.
+             */
+            if (econd->Eoper != OPvar)
+            {
+                elem *e = exp2_copytotemp(econd);
+                block_appendexp(mystate.switchBlock, e);
+                econd = e->E2;
+            }
+
+            for (size_t i = 0; i < numcases; i++)
+            {   CaseStatement *cs = (*s->cases)[i];
+
+                elem *ecase = cs->exp->toElemDtor(&mystate);
+                elem *e = el_bin(OPeqeq, TYbool, el_copytree(econd), ecase);
+                block *b = blx->curblock;
+                block_appendexp(b, e);
+                block *bcase = block_calloc(blx);
+                cs->cblock = bcase;
+                block_next(blx, BCiftrue, NULL);
+                b->appendSucc(bcase);
+                b->appendSucc(blx->curblock);
+            }
+
+            /* The final 'else' clause goes to the default
+             */
             block *b = blx->curblock;
-            block_appendexp(b, e);
-            block *bcase = block_calloc(blx);
-            cs->cblock = bcase;
-            block_next(blx, BCiftrue, NULL);
-            b->appendSucc(bcase);
-            b->appendSucc(blx->curblock);
+            block_next(blx, BCgoto, NULL);
+            b->appendSucc(mystate.defaultBlock);
+
+            Statement_toIR(s->body, &mystate);
+
+            /* Have the end of the switch body fall through to the block
+             * following the switch statement.
+             */
+            block_goto(blx, BCgoto, mystate.breakBlock);
+            return;
         }
 
-        /* The final 'else' clause goes to the default
-         */
-        block *b = blx->curblock;
-        block_next(blx, BCgoto, NULL);
-        b->appendSucc(mystate.defaultBlock);
+        if (s->condition->type->isString())
+        {
+            // Number the cases so we can unscramble things after the sort()
+            for (size_t i = 0; i < numcases; i++)
+            {   CaseStatement *cs = (*s->cases)[i];
+                cs->index = i;
+            }
 
-        body->toIR(&mystate);
+            s->cases->sort();
+
+            /* Create a sorted array of the case strings, and si
+             * will be the symbol for it.
+             */
+            dt_t *dt = NULL;
+            Symbol *si = symbol_generate(SCstatic,type_fake(TYdarray));
+            dtsize_t(&dt, numcases);
+            dtxoff(&dt, si, Target::ptrsize * 2, TYnptr);
+
+            for (size_t i = 0; i < numcases; i++)
+            {   CaseStatement *cs = (*s->cases)[i];
+
+                if (cs->exp->op != TOKstring)
+                {   s->error("case '%s' is not a string", cs->exp->toChars()); // BUG: this should be an assert
+                }
+                else
+                {
+                    StringExp *se = (StringExp *)(cs->exp);
+                    unsigned len = se->len;
+                    dtsize_t(&dt, len);
+                    dtabytes(&dt, TYnptr, 0, se->len * se->sz, (char *)se->string);
+                }
+            }
+
+            si->Sdt = dt;
+            si->Sfl = FLdata;
+            outdata(si);
+
+            /* Call:
+             *      _d_switch_string(string[] si, string econd)
+             */
+            if (config.exe == EX_WIN64)
+                econd = addressElem(econd, s->condition->type, true);
+            elem *eparam = el_param(econd, (config.exe == EX_WIN64) ? el_ptr(si) : el_var(si));
+            switch (s->condition->type->nextOf()->ty)
+            {
+                case Tchar:
+                    econd = el_bin(OPcall, TYint, el_var(rtlsym[RTLSYM_SWITCH_STRING]), eparam);
+                    break;
+                case Twchar:
+                    econd = el_bin(OPcall, TYint, el_var(rtlsym[RTLSYM_SWITCH_USTRING]), eparam);
+                    break;
+                case Tdchar:        // BUG: implement
+                    econd = el_bin(OPcall, TYint, el_var(rtlsym[RTLSYM_SWITCH_DSTRING]), eparam);
+                    break;
+                default:
+                    assert(0);
+            }
+            elem_setLoc(econd, s->loc);
+            string = 1;
+        }
+        else
+            string = 0;
+        block_appendexp(mystate.switchBlock, econd);
+        block_next(blx,BCswitch,NULL);
+
+        // Corresponding free is in block_free
+        targ_llong *pu = (targ_llong *) ::malloc(sizeof(*pu) * (numcases + 1));
+        mystate.switchBlock->BS.Bswitch = pu;
+        /* First pair is the number of cases, and the default block
+         */
+        *pu++ = numcases;
+        mystate.switchBlock->appendSucc(mystate.defaultBlock);
+
+        /* Fill in the first entry in each pair, which is the case value.
+         * CaseStatement::toIR() will fill in
+         * the second entry for each pair with the block.
+         */
+        for (size_t i = 0; i < numcases; i++)
+        {
+            CaseStatement *cs = (*s->cases)[i];
+            if (string)
+            {
+                pu[cs->index] = i;
+            }
+            else
+            {
+                pu[i] = cs->exp->toInteger();
+            }
+        }
+
+        Statement_toIR(s->body, &mystate);
 
         /* Have the end of the switch body fall through to the block
          * following the switch statement.
          */
         block_goto(blx, BCgoto, mystate.breakBlock);
-        return;
     }
 
-    if (condition->type->isString())
-    {
-        // Number the cases so we can unscramble things after the sort()
-        for (size_t i = 0; i < numcases; i++)
-        {   CaseStatement *cs = (*cases)[i];
-            cs->index = i;
-        }
-
-        cases->sort();
-
-        /* Create a sorted array of the case strings, and si
-         * will be the symbol for it.
-         */
-        dt_t *dt = NULL;
-        Symbol *si = symbol_generate(SCstatic,type_fake(TYdarray));
-        dtsize_t(&dt, numcases);
-        dtxoff(&dt, si, Target::ptrsize * 2, TYnptr);
-
-        for (size_t i = 0; i < numcases; i++)
-        {   CaseStatement *cs = (*cases)[i];
-
-            if (cs->exp->op != TOKstring)
-            {   error("case '%s' is not a string", cs->exp->toChars()); // BUG: this should be an assert
-            }
-            else
-            {
-                StringExp *se = (StringExp *)(cs->exp);
-                unsigned len = se->len;
-                dtsize_t(&dt, len);
-                dtabytes(&dt, TYnptr, 0, se->len * se->sz, (char *)se->string);
-            }
-        }
-
-        si->Sdt = dt;
-        si->Sfl = FLdata;
-        outdata(si);
-
-        /* Call:
-         *      _d_switch_string(string[] si, string econd)
-         */
-        if (config.exe == EX_WIN64)
-            econd = addressElem(econd, condition->type, true);
-        elem *eparam = el_param(econd, (config.exe == EX_WIN64) ? el_ptr(si) : el_var(si));
-        switch (condition->type->nextOf()->ty)
-        {
-            case Tchar:
-                econd = el_bin(OPcall, TYint, el_var(rtlsym[RTLSYM_SWITCH_STRING]), eparam);
-                break;
-            case Twchar:
-                econd = el_bin(OPcall, TYint, el_var(rtlsym[RTLSYM_SWITCH_USTRING]), eparam);
-                break;
-            case Tdchar:        // BUG: implement
-                econd = el_bin(OPcall, TYint, el_var(rtlsym[RTLSYM_SWITCH_DSTRING]), eparam);
-                break;
-            default:
-                assert(0);
-        }
-        elem_setLoc(econd, loc);
-        string = 1;
-    }
-    else
-        string = 0;
-    block_appendexp(mystate.switchBlock, econd);
-    block_next(blx,BCswitch,NULL);
-
-    // Corresponding free is in block_free
-    targ_llong *pu = (targ_llong *) ::malloc(sizeof(*pu) * (numcases + 1));
-    mystate.switchBlock->BS.Bswitch = pu;
-    /* First pair is the number of cases, and the default block
-     */
-    *pu++ = numcases;
-    mystate.switchBlock->appendSucc(mystate.defaultBlock);
-
-    /* Fill in the first entry in each pair, which is the case value.
-     * CaseStatement::toIR() will fill in
-     * the second entry for each pair with the block.
-     */
-    for (size_t i = 0; i < numcases; i++)
-    {
-        CaseStatement *cs = (*cases)[i];
-        if (string)
-        {
-            pu[cs->index] = i;
-        }
-        else
-        {
-            pu[i] = cs->exp->toInteger();
-        }
-    }
-
-    body->toIR(&mystate);
-
-    /* Have the end of the switch body fall through to the block
-     * following the switch statement.
-     */
-    block_goto(blx, BCgoto, mystate.breakBlock);
-}
-
-void CaseStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-    block *bcase = blx->curblock;
-    if (!cblock)
-        cblock = block_calloc(blx);
-    block_next(blx,BCgoto,cblock);
-    block *bsw = irs->getSwitchBlock();
-    if (bsw->BC == BCswitch)
-        bsw->appendSucc(cblock);        // second entry in pair
-    bcase->appendSucc(cblock);
-    if (blx->tryblock != bsw->Btry)
-        error("case cannot be in different try block level from switch");
-    incUsage(irs, loc);
-    if (statement)
-        statement->toIR(irs);
-}
-
-void DefaultStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-    block *bcase = blx->curblock;
-    block *bdefault = irs->getDefaultBlock();
-    block_next(blx,BCgoto,bdefault);
-    bcase->appendSucc(blx->curblock);
-    if (blx->tryblock != irs->getSwitchBlock()->Btry)
-        error("default cannot be in different try block level from switch");
-    incUsage(irs, loc);
-    if (statement)
-        statement->toIR(irs);
-}
-
-void GotoDefaultStatement::toIR(IRState *irs)
-{
-    block *b;
-    Blockx *blx = irs->blx;
-    block *bdest = irs->getDefaultBlock();
-
-    b = blx->curblock;
-
-    // The rest is equivalent to GotoStatement
-
-    // Adjust exception handler scope index if in different try blocks
-    if (b->Btry != bdest->Btry)
-    {
-        // Check that bdest is in an enclosing try block
-        for (block *bt = b->Btry; bt != bdest->Btry; bt = bt->Btry)
-        {
-            if (!bt)
-            {
-                //printf("b->Btry = %p, bdest->Btry = %p\n", b->Btry, bdest->Btry);
-                error("cannot goto into try block");
-                break;
-            }
-        }
-
-        //setScopeIndex(blx, b, bdest->Btry ? bdest->Btry->Bscope_index : -1);
-    }
-
-    b->appendSucc(bdest);
-    incUsage(irs, loc);
-    block_next(blx,BCgoto,NULL);
-}
-
-void GotoCaseStatement::toIR(IRState *irs)
-{
-    block *b;
-    Blockx *blx = irs->blx;
-    block *bdest = cs->cblock;
-
-    if (!bdest)
-    {
-        bdest = block_calloc(blx);
-        cs->cblock = bdest;
-    }
-
-    b = blx->curblock;
-
-    // The rest is equivalent to GotoStatement
-
-    // Adjust exception handler scope index if in different try blocks
-    if (b->Btry != bdest->Btry)
-    {
-        // Check that bdest is in an enclosing try block
-        for (block *bt = b->Btry; bt != bdest->Btry; bt = bt->Btry)
-        {
-            if (!bt)
-            {
-                //printf("b->Btry = %p, bdest->Btry = %p\n", b->Btry, bdest->Btry);
-                error("cannot goto into try block");
-                break;
-            }
-        }
-
-        //setScopeIndex(blx, b, bdest->Btry ? bdest->Btry->Bscope_index : -1);
-    }
-
-    b->appendSucc(bdest);
-    incUsage(irs, loc);
-    block_next(blx,BCgoto,NULL);
-}
-
-void SwitchErrorStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-
-    //printf("SwitchErrorStatement::toIR()\n");
-
-    elem *efilename = el_ptr(blx->module->toSymbol());
-    elem *elinnum = el_long(TYint, loc.linnum);
-    elem *e = el_bin(OPcall, TYvoid, el_var(rtlsym[RTLSYM_DSWITCHERR]), el_param(elinnum, efilename));
-    block_appendexp(blx->curblock, e);
-}
-
-/**************************************
- */
-
-void ReturnStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-    enum BC bc;
-
-    incUsage(irs, loc);
-    if (exp)
-    {   elem *e;
-
-        FuncDeclaration *func = irs->getFunc();
-        assert(func);
-        assert(func->type->ty == Tfunction);
-        TypeFunction *tf = (TypeFunction *)(func->type);
-
-        RET retmethod = tf->retStyle();
-        if (retmethod == RETstack)
-        {
-            elem *es;
-
-            /* If returning struct literal, write result
-             * directly into return value
-             */
-            if (exp->op == TOKstructliteral)
-            {   StructLiteralExp *se = (StructLiteralExp *)exp;
-                char save[sizeof(StructLiteralExp)];
-                memcpy(save, (void*)se, sizeof(StructLiteralExp));
-                se->sym = irs->shidden;
-                se->soffset = 0;
-                se->fillHoles = 1;
-                e = exp->toElemDtor(irs);
-                memcpy((void*)se, save, sizeof(StructLiteralExp));
-
-            }
-            else
-                e = exp->toElemDtor(irs);
-            assert(e);
-
-            if (exp->op == TOKstructliteral ||
-                (func->nrvo_can && func->nrvo_var))
-            {
-                // Return value via hidden pointer passed as parameter
-                // Write exp; return shidden;
-                es = e;
-            }
-            else
-            {
-                // Return value via hidden pointer passed as parameter
-                // Write *shidden=exp; return shidden;
-                int op;
-                tym_t ety;
-
-                ety = e->Ety;
-                es = el_una(OPind,ety,el_var(irs->shidden));
-                op = (tybasic(ety) == TYstruct) ? OPstreq : OPeq;
-                es = el_bin(op, ety, es, e);
-                if (op == OPstreq)
-                    es->ET = exp->type->toCtype();
-            }
-            e = el_var(irs->shidden);
-            e = el_bin(OPcomma, e->Ety, es, e);
-        }
-        else if (tf->isref)
-        {   // Reference return, so convert to a pointer
-            Expression *ae = exp->addressOf(NULL);
-            e = ae->toElemDtor(irs);
-        }
-        else
-        {
-            e = exp->toElemDtor(irs);
-            assert(e);
-        }
-        elem_setLoc(e, loc);
-        block_appendexp(blx->curblock, e);
-        bc = BCretexp;
-    }
-    else
-        bc = BCret;
-
-    block *btry = blx->curblock->Btry;
-    if (btry)
-    {
-        // A finally block is a successor to a return block inside a try-finally
-        if (btry->numSucc() == 2)      // try-finally
-        {
-            block *bfinally = btry->nthSucc(1);
-            assert(bfinally->BC == BC_finally);
-            blx->curblock->appendSucc(bfinally);
-        }
-    }
-    block_next(blx, bc, NULL);
-}
-
-/**************************************
- */
-
-void ExpStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-
-    //printf("ExpStatement::toIR(), exp = %s\n", exp ? exp->toChars() : "");
-    incUsage(irs, loc);
-    if (exp)
-        block_appendexp(blx->curblock,exp->toElemDtor(irs));
-}
-
-/**************************************
- */
-
-void DtorExpStatement::toIR(IRState *irs)
-{
-    //printf("DtorExpStatement::toIR(), exp = %s\n", exp ? exp->toChars() : "");
-
-    FuncDeclaration *fd = irs->getFunc();
-    assert(fd);
-    if (fd->nrvo_can && fd->nrvo_var == var)
-        /* Do not call destructor, because var is returned as the nrvo variable.
-         * This is done at this stage because nrvo can be turned off at a
-         * very late stage in semantic analysis.
-         */
-        ;
-    else
-    {
-        ExpStatement::toIR(irs);
-    }
-}
-
-/**************************************
- */
-
-void CompoundStatement::toIR(IRState *irs)
-{
-    if (statements)
-    {
-        size_t dim = statements->dim;
-        for (size_t i = 0 ; i < dim ; i++)
-        {
-            Statement *s = (*statements)[i];
-            if (s != NULL)
-            {
-                s->toIR(irs);
-            }
-        }
-    }
-}
-
-
-/**************************************
- */
-
-void UnrolledLoopStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-
-    IRState mystate(irs, this);
-    mystate.breakBlock = block_calloc(blx);
-
-    block *bpre = blx->curblock;
-    block_next(blx, BCgoto, NULL);
-
-    block *bdo = blx->curblock;
-    bpre->appendSucc(bdo);
-
-    block *bdox;
-
-    size_t dim = statements->dim;
-    for (size_t i = 0 ; i < dim ; i++)
-    {
-        Statement *s = (*statements)[i];
-        if (s != NULL)
-        {
-            mystate.contBlock = block_calloc(blx);
-
-            s->toIR(&mystate);
-
-            bdox = blx->curblock;
-            block_next(blx, BCgoto, mystate.contBlock);
-            bdox->appendSucc(mystate.contBlock);
-        }
-    }
-
-    bdox = blx->curblock;
-    block_next(blx, BCgoto, mystate.breakBlock);
-    bdox->appendSucc(mystate.breakBlock);
-}
-
-
-/**************************************
- */
-
-void ScopeStatement::toIR(IRState *irs)
-{
-    if (statement)
+    void visit(CaseStatement *s)
     {
         Blockx *blx = irs->blx;
-        IRState mystate(irs,this);
-
-        if (mystate.prev->ident)
-            mystate.ident = mystate.prev->ident;
-
-        statement->toIR(&mystate);
-
-        if (mystate.breakBlock)
-            block_goto(blx,BCgoto,mystate.breakBlock);
+        block *bcase = blx->curblock;
+        if (!s->cblock)
+            s->cblock = block_calloc(blx);
+        block_next(blx,BCgoto,s->cblock);
+        block *bsw = irs->getSwitchBlock();
+        if (bsw->BC == BCswitch)
+            bsw->appendSucc(s->cblock);        // second entry in pair
+        bcase->appendSucc(s->cblock);
+        if (blx->tryblock != bsw->Btry)
+            s->error("case cannot be in different try block level from switch");
+        incUsage(irs, s->loc);
+        if (s->statement)
+            Statement_toIR(s->statement, irs);
     }
-}
 
-/***************************************
- */
-
-void WithStatement::toIR(IRState *irs)
-{
-    Symbol *sp;
-    elem *e;
-    elem *ei;
-    ExpInitializer *ie;
-    Blockx *blx = irs->blx;
-
-    //printf("WithStatement::toIR()\n");
-    if (exp->op == TOKimport || exp->op == TOKtype)
+    void visit(DefaultStatement *s)
     {
+        Blockx *blx = irs->blx;
+        block *bcase = blx->curblock;
+        block *bdefault = irs->getDefaultBlock();
+        block_next(blx,BCgoto,bdefault);
+        bcase->appendSucc(blx->curblock);
+        if (blx->tryblock != irs->getSwitchBlock()->Btry)
+            s->error("default cannot be in different try block level from switch");
+        incUsage(irs, s->loc);
+        if (s->statement)
+            Statement_toIR(s->statement, irs);
     }
-    else
+
+    void visit(GotoDefaultStatement *s)
     {
-        // Declare with handle
-        sp = wthis->toSymbol();
-        symbol_add(sp);
-
-        // Perform initialization of with handle
-        ie = wthis->init->isExpInitializer();
-        assert(ie);
-        ei = ie->exp->toElemDtor(irs);
-        e = el_var(sp);
-        e = el_bin(OPeq,e->Ety, e, ei);
-        elem_setLoc(e, loc);
-        incUsage(irs, loc);
-        block_appendexp(blx->curblock,e);
-    }
-    // Execute with block
-    if (body)
-        body->toIR(irs);
-}
-
-
-/***************************************
- */
-
-void ThrowStatement::toIR(IRState *irs)
-{
-    // throw(exp)
-
-    Blockx *blx = irs->blx;
-
-    incUsage(irs, loc);
-    elem *e = exp->toElemDtor(irs);
-    e = el_bin(OPcall, TYvoid, el_var(rtlsym[RTLSYM_THROWC]),e);
-    block_appendexp(blx->curblock, e);
-}
-
-/***************************************
- * Builds the following:
- *      _try
- *      block
- *      jcatch
- *      handler
- * A try-catch statement.
- */
-
-void TryCatchStatement::toIR(IRState *irs)
-{
-    Blockx *blx = irs->blx;
-
-#if SEH
-    if (!global.params.is64bit)
-        nteh_declarvars(blx);
-#endif
-
-    IRState mystate(irs, this);
-
-    block *tryblock = block_goto(blx,BCgoto,NULL);
-
-    int previndex = blx->scope_index;
-    tryblock->Blast_index = previndex;
-    blx->scope_index = tryblock->Bscope_index = blx->next_index++;
-
-    // Set the current scope index
-    setScopeIndex(blx,tryblock,tryblock->Bscope_index);
-
-    // This is the catch variable
-    tryblock->jcatchvar = symbol_genauto(type_fake(mTYvolatile | TYnptr));
-
-    blx->tryblock = tryblock;
-    block *breakblock = block_calloc(blx);
-    block_goto(blx,BC_try,NULL);
-    if (body)
-    {
-        body->toIR(&mystate);
-    }
-    blx->tryblock = tryblock->Btry;
-
-    // break block goes here
-    block_goto(blx, BCgoto, breakblock);
-
-    setScopeIndex(blx,blx->curblock, previndex);
-    blx->scope_index = previndex;
-
-    // create new break block that follows all the catches
-    breakblock = block_calloc(blx);
-
-    blx->curblock->appendSucc(breakblock);
-    block_next(blx,BCgoto,NULL);
-
-    assert(catches);
-    for (size_t i = 0 ; i < catches->dim; i++)
-    {
-        Catch *cs = (*catches)[i];
-        if (cs->var)
-            cs->var->csym = tryblock->jcatchvar;
-        block *bcatch = blx->curblock;
-        if (cs->type)
-            bcatch->Bcatchtype = cs->type->toBasetype()->toSymbol();
-        tryblock->appendSucc(bcatch);
-        block_goto(blx, BCjcatch, NULL);
-        if (cs->handler != NULL)
-        {
-            IRState catchState(irs, this);
-
-            /* Append to block:
-             *   *(sclosure + cs.offset) = cs;
-             */
-            if (cs->var && cs->var->offset)
-            {
-                tym_t tym = cs->var->type->totym();
-                elem *ex = el_var(irs->sclosure);
-                ex = el_bin(OPadd, TYnptr, ex, el_long(TYsize_t, cs->var->offset));
-                ex = el_una(OPind, tym, ex);
-                ex = el_bin(OPeq, tym, ex, el_var(cs->var->toSymbol()));
-                block_appendexp(catchState.blx->curblock, ex);
-            }
-            cs->handler->toIR(&catchState);
-        }
-        blx->curblock->appendSucc(breakblock);
-        block_next(blx, BCgoto, NULL);
-    }
-
-    block_next(blx,(enum BC)blx->curblock->BC, breakblock);
-}
-
-/****************************************
- * A try-finally statement.
- * Builds the following:
- *      _try
- *      block
- *      _finally
- *      finalbody
- *      _ret
- */
-
-void TryFinallyStatement::toIR(IRState *irs)
-{
-    //printf("TryFinallyStatement::toIR()\n");
-
-    Blockx *blx = irs->blx;
-
-#if SEH
-    if (!global.params.is64bit)
-        nteh_declarvars(blx);
-#endif
-
-    block *tryblock = block_goto(blx, BCgoto, NULL);
-
-    int previndex = blx->scope_index;
-    tryblock->Blast_index = previndex;
-    tryblock->Bscope_index = blx->next_index++;
-    blx->scope_index = tryblock->Bscope_index;
-
-    // Current scope index
-    setScopeIndex(blx,tryblock,tryblock->Bscope_index);
-
-    blx->tryblock = tryblock;
-    block_goto(blx,BC_try,NULL);
-
-    IRState bodyirs(irs, this);
-    block *breakblock = block_calloc(blx);
-    block *contblock = block_calloc(blx);
-    tryblock->appendSucc(contblock);
-    contblock->BC = BC_finally;
-
-    if (body)
-        body->toIR(&bodyirs);
-    blx->tryblock = tryblock->Btry;     // back to previous tryblock
-
-    setScopeIndex(blx,blx->curblock,previndex);
-    blx->scope_index = previndex;
-
-    block_goto(blx,BCgoto, breakblock);
-    block *finallyblock = block_goto(blx,BCgoto,contblock);
-    assert(finallyblock == contblock);
-
-    block_goto(blx,BC_finally,NULL);
-
-    IRState finallyState(irs, this);
-    breakblock = block_calloc(blx);
-    contblock = block_calloc(blx);
-
-    setScopeIndex(blx, blx->curblock, previndex);
-    if (finalbody)
-        finalbody->toIR(&finallyState);
-    block_goto(blx, BCgoto, contblock);
-    block_goto(blx, BCgoto, breakblock);
-
-    block *retblock = blx->curblock;
-    block_next(blx,BC_ret,NULL);
-
-    finallyblock->appendSucc(blx->curblock);
-    retblock->appendSucc(blx->curblock);
-}
-
-/****************************************
- */
-
-void SynchronizedStatement::toIR(IRState *irs)
-{
-    assert(0);
-}
-
-
-/****************************************
- */
-
-void AsmStatement::toIR(IRState *irs)
-{
-    block *bpre;
-    block *basm;
-    Declaration *d;
-    Symbol *s;
-    Blockx *blx = irs->blx;
-
-    //printf("AsmStatement::toIR(asmcode = %x)\n", asmcode);
-    bpre = blx->curblock;
-    block_next(blx,BCgoto,NULL);
-    basm = blx->curblock;
-    bpre->appendSucc(basm);
-    basm->Bcode = asmcode;
-    basm->Balign = asmalign;
-#if 0
-    if (label)
-    {   block *b;
-
-        b = labelToBlock(loc, blx, label);
-        printf("AsmStatement::toIR() %p\n", b);
-        if (b)
-            basm->appendSucc(b);
-    }
-#endif
-    // Loop through each instruction, fixing Dsymbols into Symbol's
-    for (code *c = asmcode; c; c = c->next)
-    {   LabelDsymbol *label;
         block *b;
+        Blockx *blx = irs->blx;
+        block *bdest = irs->getDefaultBlock();
 
-        switch (c->IFL1)
+        b = blx->curblock;
+
+        // The rest is equivalent to GotoStatement
+
+        // Adjust exception handler scope index if in different try blocks
+        if (b->Btry != bdest->Btry)
         {
-            case FLblockoff:
-            case FLblock:
-                // FLblock and FLblockoff have LabelDsymbol's - convert to blocks
-                label = c->IEVlsym1;
-                b = labelToBlock(loc, blx, label);
-                basm->appendSucc(b);
-                c->IEV1.Vblock = b;
-                break;
+            // Check that bdest is in an enclosing try block
+            for (block *bt = b->Btry; bt != bdest->Btry; bt = bt->Btry)
+            {
+                if (!bt)
+                {
+                    //printf("b->Btry = %p, bdest->Btry = %p\n", b->Btry, bdest->Btry);
+                    s->error("cannot goto into try block");
+                    break;
+                }
+            }
 
-            case FLdsymbol:
-            case FLfunc:
-                s = c->IEVdsym1->toSymbol();
-                if (s->Sclass == SCauto && s->Ssymnum == -1)
-                    symbol_add(s);
-                c->IEVsym1 = s;
-                c->IFL1 = s->Sfl ? s->Sfl : FLauto;
-                break;
+            //setScopeIndex(blx, b, bdest->Btry ? bdest->Btry->Bscope_index : -1);
         }
+
+        b->appendSucc(bdest);
+        incUsage(irs, s->loc);
+        block_next(blx,BCgoto,NULL);
+    }
+
+    void visit(GotoCaseStatement *s)
+    {
+        block *b;
+        Blockx *blx = irs->blx;
+        block *bdest = s->cs->cblock;
+
+        if (!bdest)
+        {
+            bdest = block_calloc(blx);
+            s->cs->cblock = bdest;
+        }
+
+        b = blx->curblock;
+
+        // The rest is equivalent to GotoStatement
+
+        // Adjust exception handler scope index if in different try blocks
+        if (b->Btry != bdest->Btry)
+        {
+            // Check that bdest is in an enclosing try block
+            for (block *bt = b->Btry; bt != bdest->Btry; bt = bt->Btry)
+            {
+                if (!bt)
+                {
+                    //printf("b->Btry = %p, bdest->Btry = %p\n", b->Btry, bdest->Btry);
+                    s->error("cannot goto into try block");
+                    break;
+                }
+            }
+
+            //setScopeIndex(blx, b, bdest->Btry ? bdest->Btry->Bscope_index : -1);
+        }
+
+        b->appendSucc(bdest);
+        incUsage(irs, s->loc);
+        block_next(blx,BCgoto,NULL);
+    }
+
+    void visit(SwitchErrorStatement *s)
+    {
+        Blockx *blx = irs->blx;
+
+        //printf("SwitchErrorStatement::toIR()\n");
+
+        elem *efilename = el_ptr(blx->module->toSymbol());
+        elem *elinnum = el_long(TYint, s->loc.linnum);
+        elem *e = el_bin(OPcall, TYvoid, el_var(rtlsym[RTLSYM_DSWITCHERR]), el_param(elinnum, efilename));
+        block_appendexp(blx->curblock, e);
+    }
+
+    /**************************************
+     */
+
+    void visit(ReturnStatement *s)
+    {
+        Blockx *blx = irs->blx;
+        enum BC bc;
+
+        incUsage(irs, s->loc);
+        if (s->exp)
+        {   elem *e;
+
+            FuncDeclaration *func = irs->getFunc();
+            assert(func);
+            assert(func->type->ty == Tfunction);
+            TypeFunction *tf = (TypeFunction *)(func->type);
+
+            RET retmethod = tf->retStyle();
+            if (retmethod == RETstack)
+            {
+                elem *es;
+
+                /* If returning struct literal, write result
+                 * directly into return value
+                 */
+                if (s->exp->op == TOKstructliteral)
+                {   StructLiteralExp *se = (StructLiteralExp *)s->exp;
+                    char save[sizeof(StructLiteralExp)];
+                    memcpy(save, (void*)se, sizeof(StructLiteralExp));
+                    se->sym = irs->shidden;
+                    se->soffset = 0;
+                    se->fillHoles = 1;
+                    e = s->exp->toElemDtor(irs);
+                    memcpy((void*)se, save, sizeof(StructLiteralExp));
+
+                }
+                else
+                    e = s->exp->toElemDtor(irs);
+                assert(e);
+
+                if (s->exp->op == TOKstructliteral ||
+                    (func->nrvo_can && func->nrvo_var))
+                {
+                    // Return value via hidden pointer passed as parameter
+                    // Write exp; return shidden;
+                    es = e;
+                }
+                else
+                {
+                    // Return value via hidden pointer passed as parameter
+                    // Write *shidden=exp; return shidden;
+                    int op;
+                    tym_t ety;
+
+                    ety = e->Ety;
+                    es = el_una(OPind,ety,el_var(irs->shidden));
+                    op = (tybasic(ety) == TYstruct) ? OPstreq : OPeq;
+                    es = el_bin(op, ety, es, e);
+                    if (op == OPstreq)
+                        es->ET = s->exp->type->toCtype();
+                }
+                e = el_var(irs->shidden);
+                e = el_bin(OPcomma, e->Ety, es, e);
+            }
+            else if (tf->isref)
+            {   // Reference return, so convert to a pointer
+                Expression *ae = s->exp->addressOf(NULL);
+                e = ae->toElemDtor(irs);
+            }
+            else
+            {
+                e = s->exp->toElemDtor(irs);
+                assert(e);
+            }
+            elem_setLoc(e, s->loc);
+            block_appendexp(blx->curblock, e);
+            bc = BCretexp;
+        }
+        else
+            bc = BCret;
+
+        block *btry = blx->curblock->Btry;
+        if (btry)
+        {
+            // A finally block is a successor to a return block inside a try-finally
+            if (btry->numSucc() == 2)      // try-finally
+            {
+                block *bfinally = btry->nthSucc(1);
+                assert(bfinally->BC == BC_finally);
+                blx->curblock->appendSucc(bfinally);
+            }
+        }
+        block_next(blx, bc, NULL);
+    }
+
+    /**************************************
+     */
+
+    void visit(ExpStatement *s)
+    {
+        Blockx *blx = irs->blx;
+
+        //printf("ExpStatement::toIR(), exp = %s\n", exp ? exp->toChars() : "");
+        incUsage(irs, s->loc);
+        if (s->exp)
+            block_appendexp(blx->curblock,s->exp->toElemDtor(irs));
+    }
+
+    /**************************************
+     */
+
+    void visit(DtorExpStatement *s)
+    {
+        //printf("DtorExpStatement::toIR(), exp = %s\n", exp ? exp->toChars() : "");
+
+        FuncDeclaration *fd = irs->getFunc();
+        assert(fd);
+        if (fd->nrvo_can && fd->nrvo_var == s->var)
+            /* Do not call destructor, because var is returned as the nrvo variable.
+             * This is done at this stage because nrvo can be turned off at a
+             * very late stage in semantic analysis.
+             */
+            ;
+        else
+        {
+            visit((ExpStatement *)s);
+        }
+    }
+
+    /**************************************
+     */
+
+    void visit(CompoundStatement *s)
+    {
+        if (s->statements)
+        {
+            size_t dim = s->statements->dim;
+            for (size_t i = 0 ; i < dim ; i++)
+            {
+                Statement *s2 = (*s->statements)[i];
+                if (s2 != NULL)
+                {
+                    Statement_toIR(s2, irs);
+                }
+            }
+        }
+    }
+
+
+    /**************************************
+     */
+
+    void visit(UnrolledLoopStatement *s)
+    {
+        Blockx *blx = irs->blx;
+
+        IRState mystate(irs, s);
+        mystate.breakBlock = block_calloc(blx);
+
+        block *bpre = blx->curblock;
+        block_next(blx, BCgoto, NULL);
+
+        block *bdo = blx->curblock;
+        bpre->appendSucc(bdo);
+
+        block *bdox;
+
+        size_t dim = s->statements->dim;
+        for (size_t i = 0 ; i < dim ; i++)
+        {
+            Statement *s2 = (*s->statements)[i];
+            if (s2 != NULL)
+            {
+                mystate.contBlock = block_calloc(blx);
+
+                Statement_toIR(s2, &mystate);
+
+                bdox = blx->curblock;
+                block_next(blx, BCgoto, mystate.contBlock);
+                bdox->appendSucc(mystate.contBlock);
+            }
+        }
+
+        bdox = blx->curblock;
+        block_next(blx, BCgoto, mystate.breakBlock);
+        bdox->appendSucc(mystate.breakBlock);
+    }
+
+
+    /**************************************
+     */
+
+    void visit(ScopeStatement *s)
+    {
+        if (s->statement)
+        {
+            Blockx *blx = irs->blx;
+            IRState mystate(irs,s);
+
+            if (mystate.prev->ident)
+                mystate.ident = mystate.prev->ident;
+
+            Statement_toIR(s->statement, &mystate);
+
+            if (mystate.breakBlock)
+                block_goto(blx,BCgoto,mystate.breakBlock);
+        }
+    }
+
+    /***************************************
+     */
+
+    void visit(WithStatement *s)
+    {
+        Symbol *sp;
+        elem *e;
+        elem *ei;
+        ExpInitializer *ie;
+        Blockx *blx = irs->blx;
+
+        //printf("WithStatement::toIR()\n");
+        if (s->exp->op == TOKimport || s->exp->op == TOKtype)
+        {
+        }
+        else
+        {
+            // Declare with handle
+            sp = s->wthis->toSymbol();
+            symbol_add(sp);
+
+            // Perform initialization of with handle
+            ie = s->wthis->init->isExpInitializer();
+            assert(ie);
+            ei = ie->exp->toElemDtor(irs);
+            e = el_var(sp);
+            e = el_bin(OPeq,e->Ety, e, ei);
+            elem_setLoc(e, s->loc);
+            incUsage(irs, s->loc);
+            block_appendexp(blx->curblock,e);
+        }
+        // Execute with block
+        if (s->body)
+            Statement_toIR(s->body, irs);
+    }
+
+
+    /***************************************
+     */
+
+    void visit(ThrowStatement *s)
+    {
+        // throw(exp)
+
+        Blockx *blx = irs->blx;
+
+        incUsage(irs, s->loc);
+        elem *e = s->exp->toElemDtor(irs);
+        e = el_bin(OPcall, TYvoid, el_var(rtlsym[RTLSYM_THROWC]),e);
+        block_appendexp(blx->curblock, e);
+    }
+
+    /***************************************
+     * Builds the following:
+     *      _try
+     *      block
+     *      jcatch
+     *      handler
+     * A try-catch statement.
+     */
+
+    void visit(TryCatchStatement *s)
+    {
+        Blockx *blx = irs->blx;
+
+#if SEH
+        if (!global.params.is64bit)
+            nteh_declarvars(blx);
+#endif
+
+        IRState mystate(irs, s);
+
+        block *tryblock = block_goto(blx,BCgoto,NULL);
+
+        int previndex = blx->scope_index;
+        tryblock->Blast_index = previndex;
+        blx->scope_index = tryblock->Bscope_index = blx->next_index++;
+
+        // Set the current scope index
+        setScopeIndex(blx,tryblock,tryblock->Bscope_index);
+
+        // This is the catch variable
+        tryblock->jcatchvar = symbol_genauto(type_fake(mTYvolatile | TYnptr));
+
+        blx->tryblock = tryblock;
+        block *breakblock = block_calloc(blx);
+        block_goto(blx,BC_try,NULL);
+        if (s->body)
+        {
+            Statement_toIR(s->body, &mystate);
+        }
+        blx->tryblock = tryblock->Btry;
+
+        // break block goes here
+        block_goto(blx, BCgoto, breakblock);
+
+        setScopeIndex(blx,blx->curblock, previndex);
+        blx->scope_index = previndex;
+
+        // create new break block that follows all the catches
+        breakblock = block_calloc(blx);
+
+        blx->curblock->appendSucc(breakblock);
+        block_next(blx,BCgoto,NULL);
+
+        assert(s->catches);
+        for (size_t i = 0 ; i < s->catches->dim; i++)
+        {
+            Catch *cs = (*s->catches)[i];
+            if (cs->var)
+                cs->var->csym = tryblock->jcatchvar;
+            block *bcatch = blx->curblock;
+            if (cs->type)
+                bcatch->Bcatchtype = cs->type->toBasetype()->toSymbol();
+            tryblock->appendSucc(bcatch);
+            block_goto(blx, BCjcatch, NULL);
+            if (cs->handler != NULL)
+            {
+                IRState catchState(irs, s);
+
+                /* Append to block:
+                 *   *(sclosure + cs.offset) = cs;
+                 */
+                if (cs->var && cs->var->offset)
+                {
+                    tym_t tym = cs->var->type->totym();
+                    elem *ex = el_var(irs->sclosure);
+                    ex = el_bin(OPadd, TYnptr, ex, el_long(TYsize_t, cs->var->offset));
+                    ex = el_una(OPind, tym, ex);
+                    ex = el_bin(OPeq, tym, ex, el_var(cs->var->toSymbol()));
+                    block_appendexp(catchState.blx->curblock, ex);
+                }
+                Statement_toIR(cs->handler, &catchState);
+            }
+            blx->curblock->appendSucc(breakblock);
+            block_next(blx, BCgoto, NULL);
+        }
+
+        block_next(blx,(enum BC)blx->curblock->BC, breakblock);
+    }
+
+    /****************************************
+     * A try-finally statement.
+     * Builds the following:
+     *      _try
+     *      block
+     *      _finally
+     *      finalbody
+     *      _ret
+     */
+
+    void visit(TryFinallyStatement *s)
+    {
+        //printf("TryFinallyStatement::toIR()\n");
+
+        Blockx *blx = irs->blx;
+
+#if SEH
+        if (!global.params.is64bit)
+            nteh_declarvars(blx);
+#endif
+
+        block *tryblock = block_goto(blx, BCgoto, NULL);
+
+        int previndex = blx->scope_index;
+        tryblock->Blast_index = previndex;
+        tryblock->Bscope_index = blx->next_index++;
+        blx->scope_index = tryblock->Bscope_index;
+
+        // Current scope index
+        setScopeIndex(blx,tryblock,tryblock->Bscope_index);
+
+        blx->tryblock = tryblock;
+        block_goto(blx,BC_try,NULL);
+
+        IRState bodyirs(irs, s);
+        block *breakblock = block_calloc(blx);
+        block *contblock = block_calloc(blx);
+        tryblock->appendSucc(contblock);
+        contblock->BC = BC_finally;
+
+        if (s->body)
+            Statement_toIR(s->body, &bodyirs);
+        blx->tryblock = tryblock->Btry;     // back to previous tryblock
+
+        setScopeIndex(blx,blx->curblock,previndex);
+        blx->scope_index = previndex;
+
+        block_goto(blx,BCgoto, breakblock);
+        block *finallyblock = block_goto(blx,BCgoto,contblock);
+        assert(finallyblock == contblock);
+
+        block_goto(blx,BC_finally,NULL);
+
+        IRState finallyState(irs, s);
+        breakblock = block_calloc(blx);
+        contblock = block_calloc(blx);
+
+        setScopeIndex(blx, blx->curblock, previndex);
+        if (s->finalbody)
+            Statement_toIR(s->finalbody, &finallyState);
+        block_goto(blx, BCgoto, contblock);
+        block_goto(blx, BCgoto, breakblock);
+
+        block *retblock = blx->curblock;
+        block_next(blx,BC_ret,NULL);
+
+        finallyblock->appendSucc(blx->curblock);
+        retblock->appendSucc(blx->curblock);
+    }
+
+    /****************************************
+     */
+
+    void visit(SynchronizedStatement *s)
+    {
+        assert(0);
+    }
+
+
+    /****************************************
+     */
+
+    void visit(AsmStatement *s)
+    {
+        block *bpre;
+        block *basm;
+        Declaration *d;
+        Symbol *sym;
+        Blockx *blx = irs->blx;
+
+        //printf("AsmStatement::toIR(asmcode = %x)\n", asmcode);
+        bpre = blx->curblock;
+        block_next(blx,BCgoto,NULL);
+        basm = blx->curblock;
+        bpre->appendSucc(basm);
+        basm->Bcode = s->asmcode;
+        basm->Balign = s->asmalign;
+
+        // Loop through each instruction, fixing Dsymbols into Symbol's
+        for (code *c = s->asmcode; c; c = c->next)
+        {   LabelDsymbol *label;
+            block *b;
+
+            switch (c->IFL1)
+            {
+                case FLblockoff:
+                case FLblock:
+                    // FLblock and FLblockoff have LabelDsymbol's - convert to blocks
+                    label = c->IEVlsym1;
+                    b = labelToBlock(s->loc, blx, label);
+                    basm->appendSucc(b);
+                    c->IEV1.Vblock = b;
+                    break;
+
+                case FLdsymbol:
+                case FLfunc:
+                    sym = c->IEVdsym1->toSymbol();
+                    if (sym->Sclass == SCauto && sym->Ssymnum == -1)
+                        symbol_add(sym);
+                    c->IEVsym1 = sym;
+                    c->IFL1 = sym->Sfl ? sym->Sfl : FLauto;
+                    break;
+            }
 
 #if TX86
-        // Repeat for second operand
-        switch (c->IFL2)
-        {
-            case FLblockoff:
-            case FLblock:
-                label = c->IEVlsym2;
-                b = labelToBlock(loc, blx, label);
-                basm->appendSucc(b);
-                c->IEV2.Vblock = b;
-                break;
+            // Repeat for second operand
+            switch (c->IFL2)
+            {
+                case FLblockoff:
+                case FLblock:
+                    label = c->IEVlsym2;
+                    b = labelToBlock(s->loc, blx, label);
+                    basm->appendSucc(b);
+                    c->IEV2.Vblock = b;
+                    break;
 
-            case FLdsymbol:
-            case FLfunc:
-                d = c->IEVdsym2;
-                s = d->toSymbol();
-                if (s->Sclass == SCauto && s->Ssymnum == -1)
-                    symbol_add(s);
-                c->IEVsym2 = s;
-                c->IFL2 = s->Sfl ? s->Sfl : FLauto;
-                if (d->isDataseg())
-                    s->Sflags |= SFLlivexit;
-                break;
-        }
+                case FLdsymbol:
+                case FLfunc:
+                    d = c->IEVdsym2;
+                    sym = d->toSymbol();
+                    if (sym->Sclass == SCauto && sym->Ssymnum == -1)
+                        symbol_add(sym);
+                    c->IEVsym2 = sym;
+                    c->IFL2 = sym->Sfl ? sym->Sfl : FLauto;
+                    if (d->isDataseg())
+                        sym->Sflags |= SFLlivexit;
+                    break;
+            }
 #endif
-        //c->print();
+            //c->print();
+        }
+
+        basm->bIasmrefparam = s->refparam;             // are parameters reference?
+        basm->usIasmregs = s->regs;                    // registers modified
+
+        block_next(blx,BCasm, NULL);
+        basm->prependSucc(blx->curblock);
+
+        if (s->naked)
+        {
+            blx->funcsym->Stype->Tty |= mTYnaked;
+        }
     }
 
-    basm->bIasmrefparam = refparam;             // are parameters reference?
-    basm->usIasmregs = regs;                    // registers modified
+    /****************************************
+     */
 
-    block_next(blx,BCasm, NULL);
-    basm->prependSucc(blx->curblock);
-
-    if (naked)
+    void visit(ImportStatement *s)
     {
-        blx->funcsym->Stype->Tty |= mTYnaked;
     }
-}
 
-/****************************************
- */
+};
 
-void ImportStatement::toIR(IRState *irs)
+void Statement_toIR(Statement *s, IRState *irs)
 {
+    S2irVisitor v(irs);
+    s->accept(&v);
 }
-
-
-

--- a/src/statement.h
+++ b/src/statement.h
@@ -20,6 +20,7 @@
 #include "arraytypes.h"
 #include "dsymbol.h"
 #include "lexer.h"
+#include "visitor.h"
 
 struct OutBuffer;
 struct Scope;
@@ -125,9 +126,6 @@ public:
     virtual Statement *doInlineStatement(InlineDoState *ids);
     virtual Statement *inlineScan(InlineScanState *iss);
 
-    // Back end
-    virtual void toIR(IRState *irs);
-
     // Avoid dynamic_cast
     virtual ErrorStatement *isErrorStatement() { return NULL; }
     virtual ScopeStatement *isScopeStatement() { return NULL; }
@@ -138,6 +136,7 @@ public:
     virtual CaseStatement *isCaseStatement() { return NULL; }
     virtual DefaultStatement *isDefaultStatement() { return NULL; }
     virtual LabelStatement *isLabelStatement() { return NULL; }
+    virtual void accept(Visitor *v) { v->visit(this); }
 };
 
 /** Any Statement that fails semantic() or has a component that is an ErrorExp or
@@ -152,6 +151,7 @@ public:
     int blockExit(bool mustNotThrow);
 
     ErrorStatement *isErrorStatement() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class PeelStatement : public Statement
@@ -162,6 +162,7 @@ public:
     PeelStatement(Statement *s);
     Statement *semantic(Scope *sc);
     bool apply(sapply_fp_t fp, void *param);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ExpStatement : public Statement
@@ -185,9 +186,8 @@ public:
     Statement *doInlineStatement(InlineDoState *ids);
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
-
     ExpStatement *isExpStatement() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class DtorExpStatement : public ExpStatement
@@ -200,7 +200,7 @@ public:
 
     DtorExpStatement(Loc loc, Expression *exp, VarDeclaration *v);
     Statement *syntaxCopy();
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class CompileStatement : public Statement
@@ -214,6 +214,7 @@ public:
     Statements *flatten(Scope *sc);
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class CompoundStatement : public Statement
@@ -241,9 +242,8 @@ public:
     Statement *doInlineStatement(InlineDoState *ids);
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
-
     CompoundStatement *isCompoundStatement() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class CompoundDeclarationStatement : public CompoundStatement
@@ -252,6 +252,7 @@ public:
     CompoundDeclarationStatement(Loc loc, Statements *s);
     Statement *syntaxCopy();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 /* The purpose of this is so that continue will go to the next
@@ -278,7 +279,7 @@ public:
     Statement *doInlineStatement(InlineDoState *ids);
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ScopeStatement : public Statement
@@ -305,7 +306,7 @@ public:
     Statement *doInlineStatement(InlineDoState *ids);
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class WhileStatement : public Statement
@@ -327,7 +328,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class DoStatement : public Statement
@@ -349,7 +350,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ForStatement : public Statement
@@ -382,7 +383,7 @@ public:
     Statement *inlineScan(InlineScanState *iss);
     Statement *doInlineStatement(InlineDoState *ids);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ForeachStatement : public Statement
@@ -417,7 +418,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ForeachRangeStatement : public Statement
@@ -445,7 +446,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class IfStatement : public Statement
@@ -473,7 +474,7 @@ public:
     Statement *doInlineStatement(InlineDoState *ids);
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ConditionalStatement : public Statement
@@ -491,6 +492,7 @@ public:
     bool apply(sapply_fp_t fp, void *param);
 
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class PragmaStatement : public Statement
@@ -508,7 +510,7 @@ public:
 
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class StaticAssertStatement : public Statement
@@ -522,6 +524,7 @@ public:
     int blockExit(bool mustNotThrow);
 
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class SwitchStatement : public Statement
@@ -550,7 +553,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class CaseStatement : public Statement
@@ -576,7 +579,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 
@@ -592,6 +595,7 @@ public:
     Statement *semantic(Scope *sc);
     bool apply(sapply_fp_t fp, void *param);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 
@@ -616,7 +620,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class GotoDefaultStatement : public Statement
@@ -632,7 +636,7 @@ public:
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class GotoCaseStatement : public Statement
@@ -649,7 +653,7 @@ public:
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class SwitchErrorStatement : public Statement
@@ -660,7 +664,7 @@ public:
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void ctfeCompile(CompiledCtfeFunction *ccf);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ReturnStatement : public Statement
@@ -682,9 +686,8 @@ public:
     Statement *doInlineStatement(InlineDoState *ids);
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
-
     ReturnStatement *isReturnStatement() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class BreakStatement : public Statement
@@ -700,7 +703,7 @@ public:
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ContinueStatement : public Statement
@@ -716,7 +719,7 @@ public:
     int blockExit(bool mustNotThrow);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class SynchronizedStatement : public Statement
@@ -740,7 +743,7 @@ public:
 // Back end
     elem *esync;
     SynchronizedStatement(Loc loc, elem *esync, Statement *body);
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class WithStatement : public Statement
@@ -761,7 +764,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class TryCatchStatement : public Statement
@@ -782,8 +785,8 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class Catch : public RootObject
@@ -824,7 +827,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class OnScopeStatement : public Statement
@@ -844,7 +847,7 @@ public:
     bool apply(sapply_fp_t fp, void *param);
     void ctfeCompile(CompiledCtfeFunction *ccf);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ThrowStatement : public Statement
@@ -864,7 +867,7 @@ public:
 
     Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class DebugStatement : public Statement
@@ -878,6 +881,7 @@ public:
     Statements *flatten(Scope *sc);
     bool apply(sapply_fp_t fp, void *param);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class GotoStatement : public Statement
@@ -897,8 +901,8 @@ public:
     Expression *interpret(InterState *istate);
     void ctfeCompile(CompiledCtfeFunction *ccf);
 
-    void toIR(IRState *irs);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class LabelStatement : public Statement
@@ -927,7 +931,7 @@ public:
     Statement *inlineScan(InlineScanState *iss);
     LabelStatement *isLabelStatement() { return this; }
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class LabelDsymbol : public Dsymbol
@@ -963,7 +967,7 @@ public:
     //Expression *doInline(InlineDoState *ids);
     //Statement *inlineScan(InlineScanState *iss);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class ImportStatement : public Statement
@@ -985,7 +989,7 @@ public:
     Expression *doInline(InlineDoState *ids);
     Statement *doInlineStatement(InlineDoState *ids);
 
-    void toIR(IRState *irs);
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_STATEMENT_H */

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -1,0 +1,93 @@
+
+#ifndef DMD_VISITOR_H
+#define DMD_VISITOR_H
+
+#include <assert.h>
+
+class Statement;
+class ErrorStatement;
+class PeelStatement;
+class ExpStatement;
+class DtorExpStatement;
+class CompileStatement;
+class CompoundStatement;
+class CompoundDeclarationStatement;
+class UnrolledLoopStatement;
+class ScopeStatement;
+class WhileStatement;
+class DoStatement;
+class ForStatement;
+class ForeachStatement;
+class ForeachRangeStatement;
+class IfStatement;
+class ConditionalStatement;
+class PragmaStatement;
+class StaticAssertStatement;
+class SwitchStatement;
+class CaseStatement;
+class CaseRangeStatement;
+class DefaultStatement;
+class GotoDefaultStatement;
+class GotoCaseStatement;
+class SwitchErrorStatement;
+class ReturnStatement;
+class BreakStatement;
+class ContinueStatement;
+class SynchronizedStatement;
+class WithStatement;
+class TryCatchStatement;
+class TryFinallyStatement;
+class OnScopeStatement;
+class ThrowStatement;
+class DebugStatement;
+class GotoStatement;
+class LabelStatement;
+class AsmStatement;
+class ImportStatement;
+
+class Visitor
+{
+public:
+    virtual void visit(Statement *s) { assert(0); }
+    virtual void visit(ErrorStatement *s) { visit((Statement *)s); }
+    virtual void visit(PeelStatement *s) { visit((Statement *)s); }
+    virtual void visit(ExpStatement *s) { visit((Statement *)s); }
+    virtual void visit(DtorExpStatement *s) { visit((ExpStatement *)s); }
+    virtual void visit(CompileStatement *s) { visit((Statement *)s); }
+    virtual void visit(CompoundStatement *s) { visit((Statement *)s); }
+    virtual void visit(CompoundDeclarationStatement *s) { visit((CompoundStatement *)s); }
+    virtual void visit(UnrolledLoopStatement *s) { visit((Statement *)s); }
+    virtual void visit(ScopeStatement *s) { visit((Statement *)s); }
+    virtual void visit(WhileStatement *s) { visit((Statement *)s); }
+    virtual void visit(DoStatement *s) { visit((Statement *)s); }
+    virtual void visit(ForStatement *s) { visit((Statement *)s); }
+    virtual void visit(ForeachStatement *s) { visit((Statement *)s); }
+    virtual void visit(ForeachRangeStatement *s) { visit((Statement *)s); }
+    virtual void visit(IfStatement *s) { visit((Statement *)s); }
+    virtual void visit(ConditionalStatement *s) { visit((Statement *)s); }
+    virtual void visit(PragmaStatement *s) { visit((Statement *)s); }
+    virtual void visit(StaticAssertStatement *s) { visit((Statement *)s); }
+    virtual void visit(SwitchStatement *s) { visit((Statement *)s); }
+    virtual void visit(CaseStatement *s) { visit((Statement *)s); }
+    virtual void visit(CaseRangeStatement *s) { visit((Statement *)s); }
+    virtual void visit(DefaultStatement *s) { visit((Statement *)s); }
+    virtual void visit(GotoDefaultStatement *s) { visit((Statement *)s); }
+    virtual void visit(GotoCaseStatement *s) { visit((Statement *)s); }
+    virtual void visit(SwitchErrorStatement *s) { visit((Statement *)s); }
+    virtual void visit(ReturnStatement *s) { visit((Statement *)s); }
+    virtual void visit(BreakStatement *s) { visit((Statement *)s); }
+    virtual void visit(ContinueStatement *s) { visit((Statement *)s); }
+    virtual void visit(SynchronizedStatement *s) { visit((Statement *)s); }
+    virtual void visit(WithStatement *s) { visit((Statement *)s); }
+    virtual void visit(TryCatchStatement *s) { visit((Statement *)s); }
+    virtual void visit(TryFinallyStatement *s) { visit((Statement *)s); }
+    virtual void visit(OnScopeStatement *s) { visit((Statement *)s); }
+    virtual void visit(ThrowStatement *s) { visit((Statement *)s); }
+    virtual void visit(DebugStatement *s) { visit((Statement *)s); }
+    virtual void visit(GotoStatement *s) { visit((Statement *)s); }
+    virtual void visit(LabelStatement *s) { visit((Statement *)s); }
+    virtual void visit(AsmStatement *s) { visit((Statement *)s); }
+    virtual void visit(ImportStatement *s) { visit((Statement *)s); }
+};
+
+#endif /* DMD_VISITOR_H */

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -197,7 +197,7 @@ SRCS= mars.c enum.c struct.c dsymbol.c import.c idgen.c impcnvgen.c utf.h \
 	clone.c lib.h arrayop.c \
 	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c argtypes.c \
 	apply.c sapply.c sideeffect.c ctfe.h \
-	intrange.h intrange.c canthrow.c target.c target.h
+	intrange.h intrange.c canthrow.c target.c target.h visitor.h
 
 # Glue layer
 GLUESRC= glue.c msc.c s2ir.c todt.c e2ir.c tocsym.c \
@@ -607,7 +607,7 @@ typinf.obj : $(CH) $(TOTALH) $C\rtlsym.h mars.h module.h typinf.c
 todt.obj : mtype.h expression.h $C\dt.h todt.c
 	$(CC) -c -I$(ROOT) $(MFLAGS) todt
 
-s2ir.obj : $C\rtlsym.h statement.h s2ir.c
+s2ir.obj : $C\rtlsym.h statement.h s2ir.c visitor.h
 	$(CC) -c -I$(ROOT) $(MFLAGS) s2ir
 
 e2ir.obj : $C\rtlsym.h expression.h toir.h e2ir.c


### PR DESCRIPTION
Discussion in #2074 hasn't gone anywhere in the last four months, so hopefully this will start things up again.

This is basically the same thing as the pull @IgorStepanov did, but with statement and one pass converted to make things a little clearer.

This pull demonstrates what I hope to achieve:
- Being able to add a pass without modifying the frontend headers
- Putting all the related methods in the same class, so they can be in the same file in the D port

@ibuclaw @klickverbot @redstar Does this look right for non-dmd backends?

@WalterBright @andralex What are your objections and how can we overcome them?

@dawgfoto Could you port this code to your version of visitor so we can see how they compare?
