### PR TITLE
Pragma error/warning

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -159,6 +159,7 @@ public:
     const char *kind();
     void toObjFile(int multiobj);                       // compile to .obj file
     void errorPragma(const char *format, ...);
+    void warningPragma(const char *format, ...);
 };
 
 class ConditionalDeclaration : public AttribDeclaration

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -158,6 +158,7 @@ public:
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();
     void toObjFile(int multiobj);                       // compile to .obj file
+    void errorPragma(const char *format, ...);
 };
 
 class ConditionalDeclaration : public AttribDeclaration

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -265,6 +265,7 @@ Msgtable msgtable[] =
     // For pragma's
     { "lib" },
     { "msg" },
+    { "warning" },
     { "error" },
     { "startaddress" },
     { "mangle" },

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -265,6 +265,7 @@ Msgtable msgtable[] =
     // For pragma's
     { "lib" },
     { "msg" },
+    { "error" },
     { "startaddress" },
     { "mangle" },
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -2923,6 +2923,37 @@ Statement *PragmaStatement::semantic(Scope *sc)
             fprintf(stderr, "\n");
         }
     }
+    else if (ident == Id::warning)
+    {
+        if (args)
+        {
+            for (size_t i = 0; i < args->dim; i++)
+            {
+                Expression *e = (*args)[i];
+
+                sc = sc->startCTFE();
+                e = e->semantic(sc);
+                e = resolveProperties(sc, e);
+                sc = sc->endCTFE();
+                // pragma(msg) is allowed to contain types as well as expressions
+                e = ctfeInterpretForPragmaMsg(e);
+                if (e->op == TOKerror)
+                {   errorSupplemental(loc, "while evaluating pragma(error, %s)", (*args)[i]->toChars());
+                    goto Lerror;
+                }
+                StringExp *se = e->toString();
+                if (se)
+                {
+                    warningPragma((char *)se->string);
+                }
+                else
+                {
+                    warningPragma(e->toChars());
+                }
+            }
+            fprintf(stderr, "\n");
+        }
+    }
     else if (ident == Id::lib)
     {
 #if 1
@@ -3035,6 +3066,14 @@ void PragmaStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
         buf->writeByte(';');
         buf->writenl();
     }
+}
+
+void PragmaStatement::warningPragma(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    ::vwarning(loc, format, ap);
+    va_end(ap);
 }
 
 void PragmaStatement::errorPragma(const char *format, ...)

--- a/src/statement.h
+++ b/src/statement.h
@@ -512,6 +512,7 @@ public:
 
     void toIR(IRState *irs);
 
+    void warningPragma(const char *format, ...);
     void errorPragma(const char *format, ...);
 };
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -511,6 +511,8 @@ public:
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void toIR(IRState *irs);
+
+    void errorPragma(const char *format, ...);
 };
 
 class StaticAssertStatement : public Statement


### PR DESCRIPTION
With recent activity on DIP 50 I isolated two pragmas to make it work. Here is my attempt at:
pragma(error, "");
and
pragma(warning, "");

These pragma's should hook into compiler's error and warning mechanism already.

As stated on forums there is static assert(0, ""); However that does prepend static assert to the message and has a different purpose I believe.
