### PR TITLE
Issue 11198 - Error messages for declaring a 'version' inside main() and other functions are unclear

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4435,11 +4435,27 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
 
         case TOKdebug:
             nextToken();
+            if (token.value == TOKassign)
+            {
+                error("debug conditions can only be declared at module scope");
+                nextToken();
+                nextToken();
+                check(TOKsemicolon);
+                break;
+            }
             cond = parseDebugCondition();
             goto Lcondition;
 
         case TOKversion:
             nextToken();
+            if (token.value == TOKassign)
+            {
+                error("version conditions can only be declared at module scope");
+                nextToken();
+                nextToken();
+                check(TOKsemicolon);
+                break;
+            }
             cond = parseVersionCondition();
             goto Lcondition;
 

--- a/test/fail_compilation/diag11198.d
+++ b/test/fail_compilation/diag11198.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag11198.d(11): Error: version conditions can only be declared at module scope
+fail_compilation/diag11198.d(12): Error: debug conditions can only be declared at module scope
+---
+*/
+
+void main()
+{
+    version = blah;
+    debug = blah;
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11198
