### PR TITLE
Issue 11247 - Error: typeof(i).sizeof is used as a type

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4564,7 +4564,8 @@ Type *TypeAArray::semantic(Loc loc, Scope *sc)
 
     // Deal with the case where we thought the index was a type, but
     // in reality it was an expression.
-    if (index->ty == Tident || index->ty == Tinstance || index->ty == Tsarray)
+    if (index->ty == Tident || index->ty == Tinstance || index->ty == Tsarray ||
+        index->ty == Ttypeof || index->ty == Treturn)
     {
         Expression *e;
         Type *t;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2193,6 +2193,15 @@ static assert(A110.s == "Boo!int");
 
 /***************************************************/
 
+int test11247()
+{
+    static assert(is(byte[typeof(int.init).sizeof] == byte[4]));
+    static assert(is(byte[typeof(return).sizeof] == byte[4]));
+    return 0;
+}
+
+/***************************************************/
+
 // 3716
 void test111()
 {


### PR DESCRIPTION
`typeof(X).Y` is parsed as `TypeTypeof(X, [Y])` as `TypeTypeof` derives from `TypeQualified`.  When reinterpreting a possible associative array type as a static array type `TypeTypeof` needs to be considered.  Same for `TypeReturn`

https://d.puremagic.com/issues/show_bug.cgi?id=11247
