### PR TITLE
Issue 11317 - glue.c:1218: virtual unsigned int Type::totym(): Assertion `0' failed.

### DIFF
--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -795,7 +795,7 @@ void ReturnStatement::toIR(IRState *irs)
             e = el_var(irs->shidden);
             e = el_bin(OPcomma, e->Ety, es, e);
         }
-        else if (tf->isref)
+        else if (isRefReturn)
         {   // Reference return, so convert to a pointer
             Expression *ae = exp->addressOf(NULL);
             e = ae->toElemDtor(irs);

--- a/src/statement.c
+++ b/src/statement.c
@@ -3628,6 +3628,7 @@ ReturnStatement::ReturnStatement(Loc loc, Expression *exp)
 {
     this->exp = exp;
     this->implicit0 = 0;
+    this->isRefReturn = false;
 }
 
 Statement *ReturnStatement::syntaxCopy()
@@ -3652,7 +3653,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
 
     TypeFunction *tf = (TypeFunction *)fd->type;
     assert(tf->ty == Tfunction);
-    bool isRefReturn = tf->isref && !(fd->storage_class & STCauto);
+    isRefReturn = tf->isref && !(fd->storage_class & STCauto);
     // Until 'ref' deduction finished, 'auto ref' is treated as a 'value return'.
 
     Type *tret = tf->next;

--- a/src/statement.h
+++ b/src/statement.h
@@ -668,6 +668,7 @@ class ReturnStatement : public Statement
 public:
     Expression *exp;
     bool implicit0;             // this is an implicit "return 0;"
+    bool isRefReturn;
 
     ReturnStatement(Loc loc, Expression *exp);
     Statement *syntaxCopy();

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4006,6 +4006,17 @@ static assert(test7544());
 
 /***************************************************/
 
+void test11317()
+{
+    auto ref uint fun11317()
+    {
+        return 0;
+    }
+    assert(fun11317() == 0);
+}
+
+/***************************************************/
+
 struct S6230 {
     int p;
     int q() const pure {
@@ -6922,6 +6933,7 @@ int main()
     test6630();
     test6690();
     test2953();
+    test11317();
     test2997();
     test4647();
     test5696();


### PR DESCRIPTION
The result of inferring auto-refness is discarded, it should be retained and used by the glue layer when deciding whether to take the address of the expression or not.

https://d.puremagic.com/issues/show_bug.cgi?id=11317
