### PR TITLE
Issue 11375 - [profile+nothrow] Semantic 'no throw' error with -profile switch

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1324,15 +1324,6 @@ void FuncDeclaration::semantic3(Scope *sc)
                 ;
             else if (isCtorDeclaration() && ad2)
             {
-                // Check for errors related to 'nothrow'.
-                int nothrowErrors = global.errors;
-                int blockexit = fbody->blockExit(f->isnothrow);
-                if (f->isnothrow && (global.errors != nothrowErrors) )
-                    ::error(loc, "%s '%s' is nothrow yet may throw", kind(), toPrettyChars());
-                if (flags & FUNCFLAGnothrowInprocess)
-                    f->isnothrow = !(blockexit & BEthrow);
-                //printf("callSuper = x%x\n", sc2->callSuper);
-
                 ClassDeclaration *cd = ad2->isClassDeclaration();
 
                 // Verify that all the ctorinit fields got initialized
@@ -1392,6 +1383,15 @@ void FuncDeclaration::semantic3(Scope *sc)
                         fbody = new CompoundStatement(Loc(), s, fbody);
                     }
                 }
+
+                // Check for errors related to 'nothrow'.
+                int nothrowErrors = global.errors;
+                int blockexit = fbody->blockExit(f->isnothrow);
+                if (f->isnothrow && (global.errors != nothrowErrors) )
+                    ::error(loc, "%s '%s' is nothrow yet may throw", kind(), toPrettyChars());
+                if (flags & FUNCFLAGnothrowInprocess)
+                    f->isnothrow = !(blockexit & BEthrow);
+                //printf("callSuper = x%x\n", sc2->callSuper);
 
                 /* Append:
                  *  return this;

--- a/test/fail_compilation/fail11375.d
+++ b/test/fail_compilation/fail11375.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11375.d(17): Error: constructor this is not nothrow
+fail_compilation/fail11375.d(15): Error: function 'D main' is nothrow yet may throw
+---
+*/
+
+class B {
+    this() {}
+}
+
+class D() : B {}
+
+void main() nothrow
+{
+    auto d = new D!()();
+}


### PR DESCRIPTION
The check for throwing is run _before_ adding the implicit super call, so D.__ctor is inferred as nothrow.

https://d.puremagic.com/issues/show_bug.cgi?id=11375
