### PR TITLE
Issue 11317 - glue.c:1218: virtual unsigned int Type::totym(): Assertion `0' failed.

### DIFF
--- a/test/fail_compilation/ice10212.d
+++ b/test/fail_compilation/ice10212.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10212.d(12): Error: mismatched function return type inference of int function() pure nothrow @safe and int
+fail_compilation/ice10212.d(13): Error: mismatched function return type inference of int function() pure nothrow @safe and int
+fail_compilation/ice10212.d(13): Error: cannot implicitly convert expression (__lambda1) of type int function() pure nothrow @safe to int
 ---
 */
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -6713,6 +6713,22 @@ void test11075()
 
 
 /***************************************************/
+// 11317
+
+void test11317()
+{
+    auto ref uint fun()
+    {
+        return 0;
+    }
+
+    void test(ref uint x) {}
+    static assert(!__traits(compiles, test(fun())));
+
+    assert(fun() == 0);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -6990,6 +7006,7 @@ int main()
     test10634();
     test7254();
     test11075();
+    test11317();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11317

Make ref-ness deduction and return type inference orthogonal.
