### PR TITLE
Issue 11518 - DMD segfault on multiple template match

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3660,12 +3660,12 @@ MATCH TypeInstance::deduceType(Scope *sc,
     printf("\tthis   = %d, ", ty); print();
     printf("\ttparam = %d, ", tparam->ty); tparam->print();
 #endif
-    TemplateDeclaration *tempdecl = tempinst->tempdecl->isTemplateDeclaration();
-    assert(tempdecl);
-
     // Extra check
-    if (tparam && tparam->ty == Tinstance)
+    if (tparam && tparam->ty == Tinstance && tempinst->tempdecl)
     {
+        TemplateDeclaration *tempdecl = tempinst->tempdecl->isTemplateDeclaration();
+        assert(tempdecl);
+
         TypeInstance *tp = (TypeInstance *)tparam;
 
         //printf("tempinst->tempdecl = %p\n", tempdecl);
@@ -4375,12 +4375,13 @@ void TemplateTypeParameter::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
 
 void *TemplateTypeParameter::dummyArg()
-{   Type *t;
-
+{
+    Type *t;
     if (specType)
         t = specType;
     else
-    {   // Use this for alias-parameter's too (?)
+    {
+        // Use this for alias-parameter's too (?)
         if (!tdummy)
             tdummy = new TypeIdentifier(loc, ident);
         t = tdummy;

--- a/test/fail_compilation/ice11518.d
+++ b/test/fail_compilation/ice11518.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice11518.d(17): Error: class ice11518.B matches more than one template declaration:
+	fail_compilation/ice11518.d(12):B(T : A!T)
+and
+	fail_compilation/ice11518.d(13):B(T : A!T)
+---
+*/
+
+class A(T) {}
+class B(T : A!T) {}
+class B(T : A!T) {}
+
+void main()
+{
+    new B!(A!void);
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11518

Incomplete `specType`, like as (T : A!T), should not be used during determination of template partial specialization order.
