### PR TITLE
Issue 11508 - [REG 2.064] Wrong code with -O on x86_64 for char comparisons

### DIFF
--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -3454,6 +3454,8 @@ code *cdbtst(elem *e, regm_t *pretregs)
         cs.Iop = 0x0F00 | op;                     // BT rm,reg
         code_newreg(&cs,reg);
         cs.Iflags |= CFpsw | word;
+        if (I64 && tysize[ty1] == 8)
+            cs.Irex |= REX_W;
         c2 = gen(c2,&cs);
     }
 

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -906,6 +906,18 @@ void testandand()
 
 ////////////////////////////////////////////////////////////////////////
 
+bool bittest11508(char c)
+{
+    return c=='_' || c=='-' || c=='+' || c=='.';
+}
+
+void testbittest()
+{
+    assert(bittest11508('_'));
+}
+
+////////////////////////////////////////////////////////////////////////
+
 uint or1(ubyte x)
 {
     return x | (x<<8) | (x<<16) | (x<<24) | (x * 3);
@@ -1026,6 +1038,7 @@ int main()
     testarrayinit();
     testU();
     testulldiv();
+    testbittest();
     testfastudiv();
     testfastdiv();
     testdocond();


### PR DESCRIPTION
After checking the lower bound, the compiler does a bt against a mask - when the mask is > 32 bits it is still using the 32-bit bt instruction.

```
        mov     rcx, 1000000000000DH                    ; 0013 _ 48: B9, 001000000000000D
        bt      ecx, eax                                ; 001D _  0F A3. C1
```

Should be

```
        mov     rcx, 1000000000000DH                    ; 0013 _ 48: B9, 001000000000000D
        bt      rcx, rax                                ; 001D _ 48: 0F A3. C1
```

https://d.puremagic.com/issues/show_bug.cgi?id=11508
