### PR TITLE
Issue 10922 - Compiler segfaults when using __traits(parent, {})

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8452,6 +8452,7 @@ Expression *CallExp::semantic(Scope *sc)
     Objects *tiargs = NULL;     // initial list of template arguments
     Expression *ethis = NULL;
     Type *tthis = NULL;
+    Expression *e1org = e1;
 
 #if LOGSEMANTIC
     printf("CallExp::semantic() %s\n", toChars());
@@ -9220,6 +9221,7 @@ Lagain:
 
     if (!type)
     {
+        e1 = e1org;     // Bugzilla 10922, avoid recursive expression printing
         error("forward reference to inferred return type of function call %s", toChars());
         return new ErrorExp();
     }

--- a/test/fail_compilation/ice10922.d
+++ b/test/fail_compilation/ice10922.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice10922.d(11): Error: forward reference to inferred return type of function call self(n - 1u)
+fail_compilation/ice10922.d(11): Error: forward reference to inferred return type of function call self(n - 2u)
+---
+*/
+
+auto fib = (in uint n) pure nothrow {
+    enum self = __traits(parent, {});
+    return (n < 2) ? n : self(n - 1) + self(n - 2);
+};
+
+void main()
+{
+    auto n = fib(39);
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10922
