### PR TITLE
close Issue 6010 - fPIC is broken on FreeBSD/64

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -174,8 +174,8 @@ void gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     }
     replaceResultsDir(testArgs.permuteArgs, envData);
 
-    // win(32|64) doesn't support pic, nor does freebsd/64 currently
-    if (envData.os == "win32" || envData.os == "win64" || envData.os == "freebsd")
+    // win(32|64) doesn't support pic
+    if (envData.os == "win32" || envData.os == "win64")
     {
         auto index = std.string.indexOf(testArgs.permuteArgs, "-fPIC");
         if (index != -1)


### PR DESCRIPTION
- The ABI doesn't differ from linux so reenable the tests.
  [Issue 6010](https://d.puremagic.com/issues/show_bug.cgi?id=6010)
