### PR TITLE
uninitialized field in outbuf

### DIFF
--- a/src/backend/outbuf.c
+++ b/src/backend/outbuf.c
@@ -1,5 +1,5 @@
 // Copyright (C) 1994-1998 by Symantec
-// Copyright (C) 2000-2009 by Digital Mars
+// Copyright (C) 2000-2013 by Digital Mars
 // All Rights Reserved
 // http://www.digitalmars.com
 // Written by Walter Bright
@@ -33,6 +33,7 @@ Outbuffer::Outbuffer()
     p = NULL;
     len = 0;
     inc = 0;
+    origbuf = NULL;
 }
 
 Outbuffer::~Outbuffer()


### PR DESCRIPTION
Found by valgrind (all hail valgrind!). Critical - needs to be pulled as soon as it goes green.
