### PR TITLE
fix Issue 9466 - Compiler crash with code-coverage generation with large files

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1591,8 +1591,7 @@ void CompileDeclaration::compileIt(Scope *sc)
     else
     {
         se = se->toUTF8(sc);
-        Parser p(sc->module, (utf8_t *)se->string, se->len, 0);
-        p.scanloc = loc;
+        Parser p(loc, sc->module, (utf8_t *)se->string, se->len, 0);
         p.nextToken();
         unsigned errors = global.errors;
         decl = p.parseDeclDefs(0);

--- a/src/expression.c
+++ b/src/expression.c
@@ -7256,8 +7256,7 @@ Expression *CompileExp::semantic(Scope *sc)
         return new ErrorExp();
     }
     se = se->toUTF8(sc);
-    Parser p(sc->module, (utf8_t *)se->string, se->len, 0);
-    p.scanloc = loc;
+    Parser p(loc, sc->module, (utf8_t *)se->string, se->len, 0);
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
     unsigned errors = global.errors;

--- a/src/parse.c
+++ b/src/parse.c
@@ -67,6 +67,35 @@ Parser::Parser(Module *module, const utf8_t *base, size_t length, int doDocComme
     //nextToken();              // start up the scanner
 }
 
+/*********************
+ * Use this constructor for string mixins.
+ * Input:
+ *      loc     location in source file of mixin
+ */
+Parser::Parser(Loc loc, Module *module, const utf8_t *base, size_t length, int doDocComment)
+    : Lexer(module, base, 0, length, doDocComment, 0)
+{
+    //printf("Parser::Parser()\n");
+    scanloc = loc;
+
+    if (loc.filename)
+    {
+        /* Create a pseudo-filename for the mixin string, as it may not even exist
+         * in the source file.
+         */
+        char *filename = (char *)mem.malloc(strlen(loc.filename) + 7 + sizeof(loc.linnum) * 3 + 1);
+        sprintf(filename, "%s-mixin-%d", loc.filename, (int)loc.linnum);
+        scanloc.filename = filename;
+    }
+
+    md = NULL;
+    linkage = LINKd;
+    endloc = Loc();
+    inBrackets = 0;
+    lookingForElse = Loc();
+    //nextToken();              // start up the scanner
+}
+
 Dsymbols *Parser::parseModule()
 {
     Dsymbols *decldefs;

--- a/src/parse.h
+++ b/src/parse.h
@@ -69,6 +69,7 @@ public:
     int inBrackets;             // inside [] of array index or slice
     Loc lookingForElse;         // location of lonely if looking for an else
 
+    Parser(Loc loc, Module *module, const utf8_t *base, size_t length, int doDocComment);
     Parser(Module *module, const utf8_t *base, size_t length, int doDocComment);
 
     Dsymbols *parseModule();

--- a/src/statement.c
+++ b/src/statement.c
@@ -519,8 +519,7 @@ Statements *CompileStatement::flatten(Scope *sc)
         else
         {
             se = se->toUTF8(sc);
-            Parser p(sc->module, (utf8_t *)se->string, se->len, 0);
-            p.scanloc = loc;
+            Parser p(loc, sc->module, (utf8_t *)se->string, se->len, 0);
             p.nextToken();
 
             while (p.token.value != TOKeof)

--- a/src/toir.c
+++ b/src/toir.c
@@ -72,6 +72,7 @@ elem *incUsageElem(IRState *irs, Loc loc)
     unsigned *p = irs->blx->module->covb;
     if (p)      // covb can be NULL if it has already been written out to its .obj file
     {
+        assert(linnum < irs->blx->module->numlines);
         p += linnum / (sizeof(*p) * 8);
         *p |= 1 << (linnum & (sizeof(*p) * 8 - 1));
     }

--- a/test/fail_compilation/ice8795.d
+++ b/test/fail_compilation/ice8795.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8795.d(13): Error: found 'EOF' when expecting '('
-fail_compilation/ice8795.d(13): Error: expression expected, not 'EOF'
-fail_compilation/ice8795.d(13): Error: found 'EOF' when expecting ')'
-fail_compilation/ice8795.d(13): Error: found 'EOF' instead of statement
-fail_compilation/ice8795.d(14): Error: anonymous classes not allowed
+fail_compilation/ice8795.d-mixin-13(13): Error: found 'EOF' when expecting '('
+fail_compilation/ice8795.d-mixin-13(13): Error: expression expected, not 'EOF'
+fail_compilation/ice8795.d-mixin-13(13): Error: found 'EOF' when expecting ')'
+fail_compilation/ice8795.d-mixin-13(13): Error: found 'EOF' instead of statement
+fail_compilation/ice8795.d-mixin-14(14): Error: anonymous classes not allowed
 ---
 */
 void main()

--- a/test/fail_compilation/ice8795b.d
+++ b/test/fail_compilation/ice8795b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8795b.d(7): Error: anonymous classes not allowed
+fail_compilation/ice8795b.d-mixin-7(7): Error: anonymous classes not allowed
 ---
 */
 mixin("interface;");


### PR DESCRIPTION
valgrind once again found the problem.

https://d.puremagic.com/issues/show_bug.cgi?id=9466
