### PR TITLE
Issue 9644 - Spell checker gives silly suggestions for 1-2 character symbols

### DIFF
--- a/src/root/speller.c
+++ b/src/root/speller.c
@@ -201,7 +201,8 @@ void *spellerX(const char *seed, size_t seedlen, fp_speller_t fp, void *fparg,
 void *speller(const char *seed, fp_speller_t fp, void *fparg, const char *charset)
 {
     size_t seedlen = strlen(seed);
-    for (int distance = 0; distance < 2; distance++)
+    size_t maxdist = seedlen < 3 ? seedlen - 1 : 2;
+    for (int distance = 0; distance < maxdist; distance++)
     {   void *p = spellerX(seed, seedlen, fp, fparg, charset, distance);
         if (p)
             return p;

--- a/test/fail_compilation/diag9210a.d
+++ b/test/fail_compilation/diag9210a.d
@@ -5,7 +5,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/imports/diag9210stdcomplex.d(13): Error: template instance Complex!real does not match template declaration Complex(T) if (isFloatingPoint!T)
-fail_compilation/imports/diag9210b.d(6): Error: undefined identifier A, did you mean interface B?
+fail_compilation/imports/diag9210b.d(6): Error: undefined identifier A
 ---
 */
 

--- a/test/fail_compilation/fail61.d
+++ b/test/fail_compilation/fail61.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail61.d(22): Error: no property 'B' for type 'fail61.A.B', did you mean 'C'?
-fail_compilation/fail61.d(23): Error: no property 'B' for type 'fail61.A.B', did you mean 'C'?
+fail_compilation/fail61.d(22): Error: no property 'B' for type 'fail61.A.B'
+fail_compilation/fail61.d(23): Error: no property 'B' for type 'fail61.A.B'
 fail_compilation/fail61.d(32): Error: no property 'A2' for type 'fail61.B2'
 fail_compilation/fail61.d(41): Error: this for foo needs to be type B3 not type fail61.C3
 ---

--- a/test/fail_compilation/gag4269b.d
+++ b/test/fail_compilation/gag4269b.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/gag4269b.d(10): Error: undefined identifier Y, did you mean variable y?
+fail_compilation/gag4269b.d(10): Error: undefined identifier Y
 ---
 */
 

--- a/test/fail_compilation/spell9644.d
+++ b/test/fail_compilation/spell9644.d
@@ -1,0 +1,26 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/spell9644.d(21): Error: undefined identifier b
+fail_compilation/spell9644.d(22): Error: undefined identifier xx
+fail_compilation/spell9644.d(23): Error: undefined identifier cb, did you mean variable ab?
+fail_compilation/spell9644.d(24): Error: undefined identifier bc, did you mean variable abc?
+fail_compilation/spell9644.d(25): Error: undefined identifier ccc, did you mean variable abc?
+---
+*/
+
+int a;
+int ab;
+int abc;
+
+int main()
+{
+    cast(void)b; // max distance 0, no match
+    cast(void)xx; // max distance 1, no match
+    cast(void)cb; // max distance 1, match
+    cast(void)bc; // max distance 1, match
+    cast(void)ccc; // max distance 2, match
+}


### PR DESCRIPTION
I've implemented the difference limit as `min(strlen(id) - 1, 2)`

https://d.puremagic.com/issues/show_bug.cgi?id=9644
