### PR TITLE
Issue 10805 - wrong error message for wrong delimited string

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1585,6 +1585,8 @@ TOK Lexer::delimitedStringConstant(Token *t)
 Ldone:
     if (*p == '"')
         p++;
+    else if (hereid)
+        error("delimited string must end in %s\"", hereid->toChars());
     else
         error("delimited string must end in %c\"", delimright);
     t->len = stringbuffer.offset;

--- a/test/fail_compilation/diag10805.d
+++ b/test/fail_compilation/diag10805.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag10805.d(10): Error: delimited string must end in FOO"
+fail_compilation/diag10805.d(12): Error: unterminated string constant starting at fail_compilation/diag10805.d(12)
+fail_compilation/diag10805.d(13): Error: semicolon expected following auto declaration, not 'EOF'
+---
+*/
+
+enum s = q"FOO
+FOO
+";


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10805
