### PR TITLE
Issue 9620 - Error messages of failed pure enforcement

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2229,7 +2229,6 @@ void Expression::checkDeprecated(Scope *sc, Dsymbol *s)
  */
 void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
 {
-#if 1
     if (sc->func && !sc->intypeof && !(sc->flags & SCOPEdebug))
     {
         /* Given:
@@ -2262,7 +2261,7 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
             // always itself.
             if (!f->isPure() && outerfunc->setImpure() && !(sc->flags & SCOPEctfe))
                 error("pure function '%s' cannot call impure function '%s'",
-                    outerfunc->toPrettyChars(), f->toPrettyChars());
+                    sc->func->toPrettyChars(), f->toPrettyChars());
             return;
         }
         FuncDeclaration *calledparent = f;
@@ -2304,14 +2303,9 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
         {
             if (outerfunc->setImpure())
                 error("pure function '%s' cannot call impure function '%s'",
-                    outerfunc->toPrettyChars(), f->toPrettyChars());
+                    sc->func->toPrettyChars(), f->toPrettyChars());
         }
     }
-#else
-    if (sc->func && sc->func->isPure() && !sc->intypeof && !f->isPure())
-        error("pure function '%s' cannot call impure function '%s'",
-            sc->func->toPrettyChars(), f->toPrettyChars());
-#endif
 }
 
 /*******************************************

--- a/test/fail_compilation/diag9620.d
+++ b/test/fail_compilation/diag9620.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag9620.d(16): Error: pure function 'diag9620.main.bar' cannot call impure function 'diag9620.foot!().foot'
+fail_compilation/diag9620.d(17): Error: pure function 'diag9620.main.bar' cannot call impure function 'diag9620.foo'
+---
+*/
+
+int x;
+
+void foot()() { x = 3; }
+void foo() { }
+
+void main() pure {
+    void bar() {
+        foot();
+        foo();
+    }
+}


### PR DESCRIPTION
Print name of failing function, not enclosing function.

https://d.puremagic.com/issues/show_bug.cgi?id=9620
