### PR TITLE
Issue 11383 - Some array casts incorrectly rejected in safe code

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10017,13 +10017,6 @@ Expression *CastExp::semantic(Scope *sc)
         if (t1b->implicitConvTo(tob))
             goto Lsafe;
 
-        if (!t1b->isMutable() && tob->isMutable())
-            goto Lunsafe;
-
-        if (t1b->isShared() && !tob->isShared())
-            // Cast away shared
-            goto Lunsafe;
-
         if (!tob->hasPointers())
             goto Lsafe;
 
@@ -10040,6 +10033,8 @@ Expression *CastExp::semantic(Scope *sc)
                 cdto->isCPPinterface())
                 goto Lunsafe;
 
+            if (!MODimplicitConv(t1b->mod, tob->mod))
+                goto Lunsafe;
             goto Lsafe;
         }
 

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -306,6 +306,16 @@ void arraycast()
     int[3] a; 
     int[] b = cast(int[])a; 
     uint[3] c = cast(uint[3])a; 
+
+    const char[] cc;
+    static assert( __traits(compiles, cast(const(ubyte)[])cc));
+    static assert( __traits(compiles, cast(const(ubyte[]))cc));
+    static assert(!__traits(compiles, cast(shared(ubyte)[])cc));
+
+    shared char[] sc;
+    static assert( __traits(compiles, cast(shared(ubyte)[])sc));
+    static assert( __traits(compiles, cast(shared(ubyte[]))sc));
+    static assert(!__traits(compiles, cast(const(ubyte)[])sc));
 } 
  
 @safe 
@@ -355,6 +365,19 @@ void classcast()
     static assert( __traits(compiles, cast(B)a));
     static assert( __traits(compiles, cast(A)b));
     static assert( __traits(compiles, cast(B)b));
+
+    const A ca;
+    const B cb;
+
+    static assert( __traits(compiles, cast(const(A))ca));
+    static assert( __traits(compiles, cast(const(B))ca));
+    static assert( __traits(compiles, cast(const(A))cb));
+    static assert( __traits(compiles, cast(const(B))cb));
+
+    static assert(!__traits(compiles, cast(A)ca));
+    static assert(!__traits(compiles, cast(B)ca));
+    static assert(!__traits(compiles, cast(A)cb));
+    static assert(!__traits(compiles, cast(B)cb));
 
     interface C {};
     interface D : C {};


### PR DESCRIPTION
The existing rules banned non-mutable -> mutable and non-shared -> shared, but that was too strict.  That restriction is only necessary for classes, due to the implicit reference.

Move modifier check into class-only code and add tests.

https://d.puremagic.com/issues/show_bug.cgi?id=11383
