### PR TITLE
[DDMD] Fixup for main generation code

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -443,7 +443,7 @@ void genCmain(Scope *sc)
     /* The D code to be generated is provided as D source code in the form of a string.
      * Note that Solaris, for unknown reasons, requires both a main() and an _main()
      */
-    static utf8_t code[] = "extern(C) {\n\
+    static const utf8_t cmaincode[] = "extern(C) {\n\
         int _d_run_main(int argc, char **argv, void* mainFunc);\n\
         int _Dmain(char[][] args);\n\
         int main(int argc, char **argv) { return _d_run_main(argc, argv, &_Dmain); }\n\
@@ -454,7 +454,7 @@ void genCmain(Scope *sc)
     Identifier *id = Id::entrypoint;
     Module *m = new Module("__entrypoint.d", id, 0, 0);
 
-    Parser p(m, code, sizeof(code) / sizeof(code[0]), 0);
+    Parser p(m, cmaincode, strlen((const char *)cmaincode), 0);
     p.scanloc = Loc();
     p.nextToken();
     m->members = p.parseModule();


### PR DESCRIPTION
`code` is the name of a backend type, and therefore confuses the converter.  Not easy to fix, and not worth it.

Use strlen instead of sizeof hack - `code` is a `const(utf8_t)*` in D and has no length available.

Add const.
