### PR TITLE
[DDMD] Add method to RootObject to copy classes

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1933,9 +1933,9 @@ Expression *Expression::copy()
 #endif
         assert(0);
     }
-    e = (Expression *)mem.malloc(size);
+    e = (Expression *)copyClass(size);
     //printf("Expression::copy(op = %d) e = %p\n", op, e);
-    return (Expression *)memcpy((void*)e, (void*)this, size);
+    return e;
 }
 
 /**************************

--- a/src/inline.c
+++ b/src/inline.c
@@ -778,8 +778,7 @@ Expression *DeclarationExp::doInline(InlineDoState *ids)
                     }
                 }
             }
-            vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-            memcpy((void *)vto, (void *)vd, sizeof(VarDeclaration));
+            vto = (VarDeclaration *)vd->copyClass(sizeof(VarDeclaration));
             vto->parent = ids->parent;
             vto->csym = NULL;
             vto->isym = NULL;
@@ -875,8 +874,7 @@ Expression *IndexExp::doInline(InlineDoState *ids)
         ExpInitializer *ieto;
         VarDeclaration *vto;
 
-        vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-        memcpy((void*)vto, (void*)vd, sizeof(VarDeclaration));
+        vto = (VarDeclaration *)vd->copyClass(sizeof(VarDeclaration));
         vto->parent = ids->parent;
         vto->csym = NULL;
         vto->isym = NULL;
@@ -912,8 +910,7 @@ Expression *SliceExp::doInline(InlineDoState *ids)
         ExpInitializer *ieto;
         VarDeclaration *vto;
 
-        vto = new VarDeclaration(vd->loc, vd->type, vd->ident, vd->init);
-        memcpy((void*)vto, (void*)vd, sizeof(VarDeclaration));
+        vto = (VarDeclaration *)vd->copyClass(sizeof(VarDeclaration));
         vto->parent = ids->parent;
         vto->csym = NULL;
         vto->isym = NULL;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -152,8 +152,7 @@ const char *Type::kind()
 
 Type *Type::copy()
 {
-    Type *t = (Type *)mem.malloc(sizeTy[ty]);
-    memcpy((void*)t, (void*)this, sizeTy[ty]);
+    Type *t = (Type *)copyClass(sizeTy[ty]);
     return t;
 }
 
@@ -390,9 +389,7 @@ Type *Type::trySemantic(Loc loc, Scope *sc)
 
 Type *Type::nullAttributes()
 {
-    unsigned sz = sizeTy[ty];
-    Type *t = (Type *)mem.malloc(sz);
-    memcpy((void*)t, (void*)this, sz);
+    Type *t = copy();
     // t->mod = NULL;  // leave mod unchanged
     t->deco = NULL;
     t->arrayof = NULL;
@@ -5599,8 +5596,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
     {   tf->parameters = (Parameters *)parameters->copy();
         for (size_t i = 0; i < parameters->dim; i++)
         {   Parameter *arg = (*parameters)[i];
-            Parameter *cpy = (Parameter *)mem.malloc(sizeof(Parameter));
-            memcpy((void*)cpy, (void*)arg, sizeof(Parameter));
+            Parameter *cpy = (Parameter *)arg->copyClass(sizeof(Parameter));
             (*tf->parameters)[i] = cpy;
         }
     }

--- a/src/root/root.c
+++ b/src/root/root.c
@@ -127,6 +127,12 @@ void RootObject::toBuffer(OutBuffer *b)
     b->writestring("Object");
 }
 
+void *RootObject::copyClass(size_t sz)
+{
+    void *p = mem.malloc(sz);
+    memcpy(p, (void *)this, sz);
+}
+
 /****************************** String ********************************/
 
 String::String(const char *str)

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -67,6 +67,8 @@ public:
      * defined by the library user. For Object, the return value is 0.
      */
     virtual int dyncast();
+
+    void *copyClass(size_t sz);
 };
 
 class String : public RootObject


### PR DESCRIPTION
The current method to copying ast classes does not work in D - it relies on sizeof and memcpy.

In D, sizeof(Class) gives the reference size instead of the object size, resulting in memory corruption all over the place.

Instead, do all copying with a function in RootObject, allowing the D implementation to provide a new implementation like this:

``` d
    final void *copyClass(size_t sz)
    {
        auto realsize = GC.sizeOf(cast(void*)this);
        void* p = GC.malloc(realsize, GC.getAttr(cast(void*)this));
        memcpy(p, cast(void*)this, realsize);
        return p;
    }
```

This ignores the passed size and gets the real size directly from the GC.  Problem soved!
