### PR TITLE
Disable custom ctrlc handler

### DIFF
--- a/src/backend/util2.c
+++ b/src/backend/util2.c
@@ -107,6 +107,8 @@ static void __cdecl controlc_handler(void)
  * Trap control C interrupts.
  */
 
+#if !MARS
+
 void _STI_controlc()
 {
     //printf("_STI_controlc()\n");
@@ -120,6 +122,7 @@ void _STD_controlc()
     controlc_close();
 }
 
+#endif
 
 /***********************************
  * Send progress report.


### PR DESCRIPTION
All calls to `util_progress` were removed from the frontend, resulting ctrl+c becoming unresponsive on win32.

eg you can't kill this with ctrl+c

``` d
void bun() {}

int fun()
{
    foreach(i; 0..0x1000000)
        bun();
    return 1;
}

void main()
{
    enum x = fun();
}
```
