### PR TITLE
[DDMD] Turn root classes into structs

### DIFF
--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -56,7 +56,7 @@ typedef Array<class AliasDeclaration> AliasDeclarations;
 
 typedef Array<class Module> Modules;
 
-typedef Array<class File> Files;
+typedef Array<struct File> Files;
 
 typedef Array<class CaseStatement> CaseStatements;
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -436,7 +436,7 @@ void halt();
 
 class Dsymbol;
 class Library;
-class File;
+struct File;
 void obj_start(char *srcfile);
 void obj_end(Library *library, File *objfile);
 void obj_append(Dsymbol *s);

--- a/src/root/root.c
+++ b/src/root/root.c
@@ -215,7 +215,7 @@ void String::print()
 /****************************** FileName ********************************/
 
 FileName::FileName(const char *str)
-    : String(str)
+    : str(mem.strdup(str))
 {
 }
 
@@ -365,7 +365,7 @@ hash_t FileName::hashCode()
     }
 #else
     // darwin HFS is case insensitive, though...
-    return String::hashCode();
+    return String::calcHash(str, strlen(str));
 #endif
 }
 
@@ -924,6 +924,11 @@ void FileName::free(const char *str)
         memset((void *)str, 0xAB, strlen(str) + 1);     // stomp
     }
     mem.free((void *)str);
+}
+
+char *FileName::toChars()
+{
+    return (char *)str;         // toChars() should really be const
 }
 
 

--- a/src/root/root.h
+++ b/src/root/root.h
@@ -31,7 +31,7 @@ struct OutBuffer;
 
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
-typedef Array<class File> Files;
+typedef Array<struct File> Files;
 typedef Array<const char> Strings;
 
 
@@ -69,7 +69,7 @@ public:
     virtual int dyncast();
 };
 
-class String : public RootObject
+struct String
 {
 public:
     const char *str;                  // the string itself
@@ -87,9 +87,10 @@ public:
     void print();
 };
 
-class FileName : public String
+struct FileName
 {
 public:
+    const char *str;
     FileName(const char *str);
     hash_t hashCode();
     bool equals(RootObject *obj);
@@ -122,9 +123,10 @@ public:
     static const char *canonicalName(const char *name);
 
     static void free(const char *str);
+    char *toChars();
 };
 
-class File : public RootObject
+struct File
 {
 public:
     int ref;                    // != 0 if this is a reference to someone else's buffer


### PR DESCRIPTION
These are never used as polymorphic types, and the inherited functionality is minimal.

Being structs allows easy stack construction in D.
