### PR TITLE
[DDMD] Remove a 'delete' from the glue layer

### DIFF
--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -437,7 +437,6 @@ void LabelStatement::toIR(IRState *irs)
                 }
 
             }
-            delete fwdrefs;
             fwdrefs = NULL;
         }
     }


### PR DESCRIPTION
`fwdrefs` is allocated using `new` (it is an `Array<Block>`), and this is done in the frontend D code.  (it must be to get construction right)

Then it is free'd with C++'s free, potentially causing memory corruption and crashes.  Or it used to, now delete does nothing so this is completely dead code.
