### PR TITLE
Issue 11322 - ICE with -inline cgcs.c 221

### DIFF
--- a/src/inline.c
+++ b/src/inline.c
@@ -1856,6 +1856,10 @@ Expression *FuncDeclaration::expandInline(InlineScanState *iss,
         //eb->print();
         //eb->dump(0);
 
+        // Bugzilla 11322:
+        if (tf->isref)
+            e = e->toLvalue(NULL, NULL);
+
         /* There's a problem if what the function returns is used subsequently as an
          * lvalue, as in a struct return that is then used as a 'this'.
          * If we take the address of the return value, we will be taking the address

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -358,6 +358,28 @@ void test11224()
 }
 
 /************************************/
+// 11322
+
+bool b11322;
+uint n11322;
+
+ref uint fun11322()
+{
+    if (b11322)
+        return n11322;
+    else
+        return n11322;
+}
+
+void test11322()
+{
+    fun11322()++;
+    assert(n11322 == 1);
+    fun11322() *= 5;
+    assert(n11322 == 5);
+}
+
+/************************************/
 // 11394
 
 debug(NRVO) static void* p11394a, p11394b, p11394c;
@@ -409,6 +431,7 @@ int main()
     test11223();
     test11314();
     test11224();
+    test11322();
     test11394();
 
     printf("Success\n");


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11322

Use `Expression::toLvalue` to handle lvalue `CondExp` properly.
