### PR TITLE
Issue 11552 - Missing label is not caught during semantic

### DIFF
--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -64,6 +64,8 @@ typedef Array<class CompoundStatement> CompoundStatements;
 
 typedef Array<class GotoCaseStatement> GotoCaseStatements;
 
+typedef Array<class GotoStatement> GotoStatements;
+
 typedef Array<class ReturnStatement> ReturnStatements;
 
 typedef Array<class TemplateInstance> TemplateInstances;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -612,6 +612,7 @@ public:
     Symbol *shidden;                    // hidden pointer passed to function
 
     ReturnStatements *returns;
+    GotoStatements *gotos;              // Gotos with forward references
 
     BUILTIN builtin;               // set if this is a known, builtin
                                         // function we can evaluate at compile

--- a/src/func.c
+++ b/src/func.c
@@ -92,6 +92,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     requiresClosure = false;
     flags = 0;
     returns = NULL;
+    gotos = NULL;
 }
 
 Dsymbol *FuncDeclaration::syntaxCopy(Dsymbol *s)
@@ -1760,6 +1761,15 @@ void FuncDeclaration::semantic3(Scope *sc)
                 {
                     error("synchronized function %s must be a member of a class", toChars());
                 }
+            }
+        }
+
+        // Fix up forward-referenced gotos
+        if (gotos)
+        {
+            for (size_t i = 0; i < gotos->dim; ++i)
+            {
+                (*gotos)[i]->checkLabel();
             }
         }
 

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -371,10 +371,7 @@ void GotoStatement::toIR(IRState *irs)
 {
     Blockx *blx = irs->blx;
 
-    if (!label->statement)
-    {   error("label %s is undefined", label->toChars());
-        return;
-    }
+    assert(label->statement);
     if (tf != label->statement->tf)
         error("cannot goto forward out of or into finally block");
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -5036,8 +5036,8 @@ Statement *GotoStatement::syntaxCopy()
 }
 
 Statement *GotoStatement::semantic(Scope *sc)
-{   FuncDeclaration *fd = sc->parent->isFuncDeclaration();
-
+{
+    FuncDeclaration *fd = sc->func;
     //printf("GotoStatement::semantic()\n");
     ident = fixupLabelName(sc, ident);
 
@@ -5059,12 +5059,30 @@ Statement *GotoStatement::semantic(Scope *sc)
         sc->fes->gotos->push(s);         // 'look at this later' list
         return s;
     }
+
+    // Add to fwdref list to check later
+    if (!label->statement)
+    {
+        if (!fd->gotos)
+            fd->gotos = new GotoStatements();
+        fd->gotos->push(this);
+    }
+
     if (label->statement && label->statement->tf != sc->tf)
     {
         error("cannot goto in or out of finally block");
         return new ErrorStatement();
     }
+
     return this;
+}
+
+void GotoStatement::checkLabel()
+{
+    if (!label->statement)
+    {
+        error("label '%s' is undefined", label->toChars());
+    }
 }
 
 int GotoStatement::blockExit(bool mustNotThrow)

--- a/src/statement.h
+++ b/src/statement.h
@@ -890,6 +890,7 @@ public:
     GotoStatement(Loc loc, Identifier *ident);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
+    void checkLabel();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
     void ctfeCompile(CompiledCtfeFunction *ccf);

--- a/test/fail_compilation/fail11552.d
+++ b/test/fail_compilation/fail11552.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -o-
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/fail11552.d(12): Error: label 'label' is undefined
+---
+*/
+
+void main()
+{
+    goto label;
+}

--- a/test/fail_compilation/ice11552.d
+++ b/test/fail_compilation/ice11552.d
@@ -1,0 +1,17 @@
+/*
+REQUIRED_ARGS: -o-
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/ice11552.d(14): Error: label 'label' is undefined
+fail_compilation/ice11552.d(17):        called from here: test11552()
+fail_compilation/ice11552.d(17):        while evaluating: static assert(test11552())
+---
+*/
+
+int test11552()
+{
+    goto label;
+    return 1;
+}
+static assert(test11552());


### PR DESCRIPTION
When a forward-referenced goto is encountered, add it to a list in the enclosing function and process them after body semantic (and adding the magic return label for out contracts/invariants) is complete.

This catches missing labels during semantic, preventing ctfe from icing.

https://d.puremagic.com/issues/show_bug.cgi?id=11552
