### PR TITLE
Use short form of imul when src was in mAX anyway

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -1552,7 +1552,10 @@ code *cdmul(elem *e,regm_t *pretregs)
                     retregs = ALLREGS;
                 cl = codelem(e1,&retregs,FALSE);        /* eval left leaf */
                 resreg = retregs;
-                cr = loadea(e2,&cs,0x0FAF,findreg(resreg),0,retregs,retregs);
+                if (resreg == mAX) // imul r/m
+                    cr = loadea(e2,&cs,0xF7,op,0, mAX, mAX | mDX);
+                else // imul r, r/m
+                    cr = loadea(e2,&cs,0x0FAF,findreg(resreg),0,retregs,retregs);
                 freenode(e2);
                 goto L3;
             }


### PR DESCRIPTION
The existing code generates silly stuff like

```
        mov     eax, dword ptr [ebp-8H]                 ; 0031 _ 8B. 45, F8
        imul    eax, dword ptr [ebp-0CH]                ; 0034 _ 0F AF. 45, F4
```

Which should use the one-operand form of mul

```
        mov     eax, dword ptr [ebp-8H]                 ; 0031 _ 8B. 45, F8
        imul    dword ptr [ebp-0CH]                     ; 0034 _ F7. 6D, F4
```

This seems to be an attempt to avoid a useless mov if the result is not already in mAX, but we might as well use the short instruction form when we can.

In theory it could be done in the peephole optimizer, but matching all the instructions that could possibly produce a result in mAX does not look easy...
