### PR TITLE
[REG2.065a] Issue 11554 - `is(T == enum);` produces an error if T is an enum defined with no members

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6651,7 +6651,10 @@ Expression *IsExp::semantic(Scope *sc)
             case TOKenum:
                 if (targ->ty != Tenum)
                     goto Lno;
-                tded = ((TypeEnum *)targ)->sym->getMemtype(loc);
+                if (id)
+                    tded = ((TypeEnum *)targ)->sym->getMemtype(loc);
+                else
+                    tded = targ;
                 if (tded->ty == Terror)
                     return new ErrorExp();
                 break;

--- a/test/fail_compilation/ice10770.d
+++ b/test/fail_compilation/ice10770.d
@@ -1,12 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10770.d(9): Error: enum ice10770.E1 is forward referenced looking for base type
+fail_compilation/ice10770.d(13): Error: enum ice10770.E2 is forward referenced looking for base type
 ---
 */
 
-enum E1;
-static assert(is(E1 e == enum));
+enum E1 : int;
+static assert(is(E1 e == enum) && is(e == int));
 
-enum E2 : int;
-static assert(is(E2 e == enum) && is(e == int));
+enum E2;
+static assert(is(E2   == enum));    // Bugzilla 11554: should not cause error
+static assert(is(E2 e == enum));

--- a/test/runnable/testenum.d
+++ b/test/runnable/testenum.d
@@ -397,10 +397,10 @@ void test8()
     enum E
     {
         A = B,
-	E = D + 7,
+        E = D + 7,
         B = 3,
-	C,
-	D,
+        C,
+        D,
     }
 
     assert(E.A == 3);


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11554

The regression was caused by #2795.
