### PR TITLE
Issue 10329 - Attributes not inferred for indirectly templated methods

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -499,6 +499,7 @@ FuncDeclaration *StructDeclaration::buildXopEquals(Scope *sc)
 
     if (!xerreq)
     {
+        // object._xopEquals
         Identifier *id = Lexer::idPool("_xopEquals");
         Expression *e = new IdentifierExp(loc, Id::empty);
         e = new DotIdExp(loc, e, Id::object);
@@ -523,7 +524,7 @@ FuncDeclaration *StructDeclaration::buildXopEquals(Scope *sc)
     TypeFunction *tf = new TypeFunction(parameters, Type::tbool, 0, LINKd);
     tf = (TypeFunction *)tf->semantic(loc, sc);
 
-    Identifier *id = Lexer::idPool("__xopEquals");
+    Identifier *id = Id::xopEquals;
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
 
     Expression *e1 = new IdentifierExp(loc, Id::p);
@@ -625,6 +626,7 @@ FuncDeclaration *StructDeclaration::buildXopCmp(Scope *sc)
 
     if (!xerrcmp)
     {
+        // object._xopCmp
         Identifier *id = Lexer::idPool("_xopCmp");
         Expression *e = new IdentifierExp(loc, Id::empty);
         e = new DotIdExp(loc, e, Id::object);
@@ -649,7 +651,7 @@ FuncDeclaration *StructDeclaration::buildXopCmp(Scope *sc)
     TypeFunction *tf = new TypeFunction(parameters, Type::tint32, 0, LINKd);
     tf = (TypeFunction *)tf->semantic(loc, sc);
 
-    Identifier *id = Lexer::idPool("__xopCmp");
+    Identifier *id = Id::xopCmp;
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
 
     Expression *e1 = new IdentifierExp(loc, Id::p);

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -305,7 +305,7 @@ TemplateInstance *Dsymbol::isInstantiated()
     for (Dsymbol *s = parent; s; s = s->parent)
     {
         TemplateInstance *ti = s->isTemplateInstance();
-        if (ti)
+        if (ti && !ti->isTemplateMixin())
             return ti;
     }
     return NULL;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -300,11 +300,11 @@ Dsymbol *Dsymbol::toParent2()
     return s;
 }
 
-TemplateInstance *Dsymbol::inTemplateInstance()
+TemplateInstance *Dsymbol::isInstantiated()
 {
-    for (Dsymbol *parent = this->parent; parent; parent = parent->parent)
+    for (Dsymbol *s = parent; s; s = s->parent)
     {
-        TemplateInstance *ti = parent->isTemplateInstance();
+        TemplateInstance *ti = s->isTemplateInstance();
         if (ti)
             return ti;
     }
@@ -317,7 +317,7 @@ TemplateInstance *Dsymbol::inTemplateInstance()
 // or NULL if not speculative.
 TemplateInstance *Dsymbol::isSpeculative()
 {
-    Dsymbol * par = parent;
+    Dsymbol *par = parent;
     while (par)
     {
         TemplateInstance *ti = par->isTemplateInstance();

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -158,7 +158,7 @@ public:
     Dsymbol *pastMixin();
     Dsymbol *toParent();
     Dsymbol *toParent2();
-    TemplateInstance *inTemplateInstance();
+    TemplateInstance *isInstantiated();
     TemplateInstance *isSpeculative();
     Ungag ungagSpeculative();
 

--- a/src/func.c
+++ b/src/func.c
@@ -206,11 +206,11 @@ void FuncDeclaration::semantic(Scope *sc)
          */
         if (tf->trust == TRUSTdefault &&
             !(//isFuncLiteralDeclaration() ||
-              parent->isTemplateInstance() ||
-              ad && ad->parent && ad->parent->isTemplateInstance()))
+              isInstantiated()))
         {
             for (Dsymbol *p = sc->func; p; p = p->toParent2())
-            {   FuncDeclaration *fd = p->isFuncDeclaration();
+            {
+                FuncDeclaration *fd = p->isFuncDeclaration();
                 if (fd)
                 {
                     if (fd->isSafeBypassingInference())
@@ -891,13 +891,12 @@ Ldone:
     /* Purity and safety can be inferred for some functions by examining
      * the function body.
      */
+    TemplateInstance *ti;
     if (fbody &&
         (isFuncLiteralDeclaration() ||
-         parent->isTemplateInstance() ||
-         ad && ad->parent && ad->parent->isTemplateInstance() && !isVirtualMethod()))
+         isInstantiated() && !isVirtualMethod() &&
+         !(ti = parent->isTemplateInstance(), ti && !ti->isTemplateMixin() && ti->name != ident)))
     {
-        /* isVirtualMethod() needs setting correct foverrides
-         */
         if (f->purity == PUREimpure)        // purity not specified
             flags |= FUNCFLAGpurityInprocess;
 
@@ -1896,14 +1895,12 @@ bool FuncDeclaration::functionSemantic()
     if (inferRetType && type && !type->nextOf())
         return functionSemantic3();
 
-    TemplateInstance *ti = parent->isTemplateInstance();
-    if (ti && !ti->isTemplateMixin() && ti->name == ident)
-        return functionSemantic3();
-
-    AggregateDeclaration *ad = isThis();
-    if (ad && ad->parent && ad->parent->isTemplateInstance() && !isVirtualMethod())
+    TemplateInstance *ti;
+    if (isInstantiated() && !isVirtualMethod() &&
+        !(ti = parent->isTemplateInstance(), ti && !ti->isTemplateMixin() && ti->name != ident))
     {
-        if (ad->sizeok != SIZEOKdone)
+        AggregateDeclaration *ad = isThis();
+        if (ad && ad->sizeok != SIZEOKdone)
         {
             /* Currently dmd cannot resolve forward references per methods,
              * then setting SIZOKfwd is too conservative and would break existing code.

--- a/src/func.c
+++ b/src/func.c
@@ -4246,7 +4246,7 @@ void StaticCtorDeclaration::semantic(Scope *sc)
      * it could get called multiple times by the module constructors
      * for different modules. Thus, protect it with a gate.
      */
-    if (inTemplateInstance() && semanticRun < PASSsemantic)
+    if (isInstantiated() && semanticRun < PASSsemantic)
     {
         /* Add this prefix to the function:
          *      static int gate;
@@ -4377,7 +4377,7 @@ void StaticDtorDeclaration::semantic(Scope *sc)
      * it could get called multiple times by the module constructors
      * for different modules. Thus, protect it with a gate.
      */
-    if (inTemplateInstance() && semanticRun < PASSsemantic)
+    if (isInstantiated() && semanticRun < PASSsemantic)
     {
         /* Add this prefix to the function:
          *      static int gate;

--- a/src/func.c
+++ b/src/func.c
@@ -1840,7 +1840,7 @@ void FuncDeclaration::semantic3(Scope *sc)
         f->deco = NULL;
 
     // Do semantic type AFTER pure/nothrow inference.
-    if (!f->deco)
+    if (!f->deco && ident != Lexer::idPool("__xopEquals") && ident != Lexer::idPool("__xopCmp"))
     {
         sc = sc->push();
         sc->stc = 0;

--- a/src/func.c
+++ b/src/func.c
@@ -1840,7 +1840,7 @@ void FuncDeclaration::semantic3(Scope *sc)
         f->deco = NULL;
 
     // Do semantic type AFTER pure/nothrow inference.
-    if (!f->deco && ident != Lexer::idPool("__xopEquals") && ident != Lexer::idPool("__xopCmp"))
+    if (!f->deco && ident != Id::xopEquals && ident != Id::xopCmp)
     {
         sc = sc->push();
         sc->stc = 0;

--- a/src/glue.c
+++ b/src/glue.c
@@ -600,13 +600,13 @@ void FuncDeclaration::toObjFile(int multiobj)
     assert(semanticRun == PASSsemantic3done);
     assert(ident != Id::empty);
 
-    if (!inTemplateInstance() && inNonRoot(this))
+    if (!isInstantiated() && inNonRoot(this))
         return;
 
     /* Skip generating code if this part of a TemplateInstance that is instantiated
      * only by non-root modules (i.e. modules not listed on the command line).
      */
-    TemplateInstance *ti = inTemplateInstance();
+    TemplateInstance *ti = isInstantiated();
     if (!global.params.useUnitTests &&
         !global.params.allInst &&
         /* The issue is that if the importee is compiled with a different -debug

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -105,6 +105,8 @@ Msgtable msgtable[] =
     { "_match" },
     { "destroy" },
     { "postblit" },
+    { "xopEquals", "__xopEquals" },
+    { "xopCmp", "__xopCmp" },
 
     { "LINE", "__LINE__" },
     { "FILE", "__FILE__" },

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -9054,7 +9054,7 @@ L1:
          */
 
         // If Class is in a failed template, return an error
-        TemplateInstance *tiparent = d->inTemplateInstance();
+        TemplateInstance *tiparent = d->isInstantiated();
         if (tiparent && tiparent->errors)
             return new ErrorExp();
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -34,6 +34,8 @@ bool inNonRoot(Dsymbol *s)
     {
         if (TemplateInstance *ti = s->isTemplateInstance())
         {
+            if (ti->isTemplateMixin())
+                continue;
             if (!ti->instantiatingModule || !ti->instantiatingModule->isRoot())
                 return true;
             return false;

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -218,7 +218,7 @@ void ClassDeclaration::toObjFile(int multiobj)
     assert(!scope);     // semantic() should have been run to completion
 
     scclass = SCglobal;
-    if (inTemplateInstance())
+    if (isInstantiated())
         scclass = SCcomdat;
 
     // Put out the members
@@ -641,7 +641,7 @@ void InterfaceDeclaration::toObjFile(int multiobj)
         toDebug();
 
     scclass = SCglobal;
-    if (inTemplateInstance())
+    if (isInstantiated())
         scclass = SCcomdat;
 
     // Put out the members
@@ -823,7 +823,7 @@ void StructDeclaration::toObjFile(int multiobj)
         {
             // Generate static initializer
             toInitializer();
-            if (inTemplateInstance())
+            if (isInstantiated())
             {
                 sinit->Sclass = SCcomdat;
             }
@@ -993,7 +993,7 @@ void TypedefDeclaration::toObjFile(int multiobj)
     else
     {
         enum_SC scclass = SCglobal;
-        if (inTemplateInstance())
+        if (isInstantiated())
             scclass = SCcomdat;
 
         // Generate static initializer
@@ -1033,7 +1033,7 @@ void EnumDeclaration::toObjFile(int multiobj)
     else
     {
         enum_SC scclass = SCglobal;
-        if (inTemplateInstance())
+        if (isInstantiated())
             scclass = SCcomdat;
 
         // Generate static initializer

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -48,7 +48,7 @@ void fECPa() {
         }
         h();
     }
-    static assert( is(typeof(&g!()) == void delegate() pure));
+    static assert( is(typeof(&g!()) == void delegate() pure nothrow @safe));
     static assert(!is(typeof(&g!()) == void delegate()));
 }
 
@@ -92,9 +92,9 @@ template map7017(fun...) if (fun.length >= 1)
     auto map7017()
     {
         struct Result {
-            this(int dummy){}   // impure member function
+            this(int dummy){}   // impure member function -> inferred to pure by fixing issue 10329
         }
-        return Result(0);   // impure call
+        return Result(0);   // impure call -> inferred to pure by fixing issue 10329
     }
 }
 
@@ -104,10 +104,10 @@ void test7017a() pure
 {
     int bar7017(immutable int x) pure nothrow { return 1; }
 
-    static assert(!__traits(compiles, map7017!((){})()));   // should pass, but fails
-    static assert(!__traits(compiles, map7017!q{ 1 }()));   // pass, OK
-    static assert(!__traits(compiles, map7017!foo7017()));  // pass, OK
-    static assert( __traits(compiles, map7017!bar7017()));
+    static assert(__traits(compiles, map7017!((){})()));
+    static assert(__traits(compiles, map7017!q{ 1 }()));
+    static assert(__traits(compiles, map7017!foo7017()));
+    static assert(__traits(compiles, map7017!bar7017()));
 }
 
 /***************************************************/

--- a/test/runnable/test7511.d
+++ b/test/runnable/test7511.d
@@ -294,6 +294,38 @@ void test10373()
 }
 
 /**********************************/
+// 10329
+
+auto foo10329(T)(T arg)
+{
+    auto bar()
+    {
+        return arg;
+    }
+    static assert(is(typeof(&bar) == T delegate() nothrow @safe));
+    return bar();
+}
+
+auto make10329(T)(T arg)
+{
+    struct S
+    {
+        auto front() { return T.init; }
+    }
+    S s;
+    static assert(is(typeof(&s.front) == T delegate() pure nothrow @safe));
+    return s;
+}
+
+void test10329() pure nothrow @safe
+{
+    assert(foo10329(1) == 1);
+
+    auto s = make10329(1);
+    assert(s.front() == 0);
+}
+
+/**********************************/
 
 int main()
 {
@@ -303,6 +335,7 @@ int main()
     test7511d();
     test9952();
     test10373();
+    test10329();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10329

This is the last step for the pure/@safe algorithms and ranges.

Except following two cases, all of instantiated function attributes will be inferred.
1. Virtual methods
   
   ``` d
   class C(T) {
       void foo() {}
   }
   pragma(msg, typeof(&C!int.foo));    // void function()
   ```
2. Non-eponymous functions which declared in template scope
   
   ``` d
   template X(T) {
       void foo(T) {}
   }
   pragma(msg, typeof(&X!int.foo));    // void function(int)
   ```
   
   (I'm not still sure this is an essential restriction, but currently it's necessary to avoid [bug 10134](https://d.puremagic.com/issues/show_bug.cgi?id=10134)).

After merging this PR, for example, following code will be runnable with git-head Phobos.

``` d
import std.algorithm, std.range;
void main() pure @safe
{
    int[][] ror =[[1,2,3]];
    auto r = joiner(ror);

    string res;
    foreach (e; chain("a", "b"))
        res ~= e;
    assert(res == "ab");
}
```
