### PR TITLE
fix runnable/testzip

### DIFF
--- a/test/runnable/testzip.d
+++ b/test/runnable/testzip.d
@@ -53,7 +53,6 @@ int main(string[] args)
     am.name = "foo.bar";
     //am.extra = cast(ubyte[])"ExTrA";
     am.expandedData = cast(ubyte[])"We all live in a yellow submarine, a yellow submarine";
-    am.expandedSize = to!uint(am.expandedData.length);
     zr.addMember(am);
     void[] data2 = zr.build();
     std.file.write(outzipname, cast(byte[])data2);


### PR DESCRIPTION
The test write to the read-only member expandedSize.

Needed for https://github.com/D-Programming-Language/phobos/pull/1697.
