### PR TITLE
fix  Issue 11546 - string import dependency failure

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7346,16 +7346,19 @@ Expression *FileExp::semantic(Scope *sc)
 
     if (global.params.verbose)
         fprintf(global.stdmsg, "file      %s\t(%s)\n", (char *)se->string, name);
-    if (global.params.moduleDeps != NULL && global.params.moduleDepsFile == NULL)
+    if (global.params.moduleDeps != NULL)
     {
         OutBuffer *ob = global.params.moduleDeps;
         Module* imod = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
 
-        ob->writestring("depsFile ");
+        if (!global.params.moduleDepsFile)
+            ob->writestring("depsFile ");
         ob->writestring(imod->toPrettyChars());
         ob->writestring(" (");
         escapePath(ob, imod->srcfile->toChars());
         ob->writestring(") : ");
+        if (global.params.moduleDepsFile)
+            ob->writestring("string : ");
         ob->writestring((char *) se->string);
         ob->writestring(" (");
         escapePath(ob, name);

--- a/src/import.c
+++ b/src/import.c
@@ -289,7 +289,7 @@ void Import::semantic(Scope *sc)
          *      ModuleAliasIdentifier ] "\n"
          *
          *      BasicImportDeclaration
-         *          ::= ModuleFullyQualifiedName " (" FilePath ") : " Protection
+         *          ::= ModuleFullyQualifiedName " (" FilePath ") : " Protection|"string"
          *              " [ " static" ] : " ModuleFullyQualifiedName " (" FilePath ")"
          *
          *      FilePath

--- a/src/mars.c
+++ b/src/mars.c
@@ -378,7 +378,7 @@ Usage:\n\
   -debuglib=name    set symbolic debug library to name\n\
   -defaultlib=name  set default library to name\n\
   -deps          print module dependencies (imports/file/version/debug/lib)\n\
-  -deps=filename write module dependencies to filename (only imports - deprecated)\n%s\
+  -deps=filename write module dependencies to filename (only imports)\n%s\
   -g             add symbolic debug info\n\
   -gc            add symbolic debug info, pretend to be C\n\
   -gs            always emit stack frame\n\


### PR DESCRIPTION
This patch adds writing string imports to the dependency file with the keyword "string" instead of the protection.

I also recommend to undeprecate the -deps=file option, as the alternative option to print to stdout is no good for tooling support, any other output can ruin it.

https://d.puremagic.com/issues/show_bug.cgi?id=11546
