### PR TITLE
Issue 602 - Compiler allows a goto statement to skip an initalization

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -732,6 +732,7 @@ VarDeclaration::VarDeclaration(Loc loc, Type *type, Identifier *id, Initializer 
     aliassym = NULL;
     onstack = 0;
     canassign = 0;
+    lastVar = NULL;
     ctfeAdrOnStack = -1;
     rundtor = NULL;
     edtor = NULL;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -266,6 +266,7 @@ public:
                                 // 2: on stack, run destructor anyway
     int canassign;              // it can be assigned to
     Dsymbol *aliassym;          // if redone as alias to another symbol
+    VarDeclaration *lastVar;    // Linked list of variables for goto-skips-init detection
 
     // When interpreting, these point to the value (NULL if value not determinable)
     // The index of this variable on the CTFE stack, -1 if not allocated

--- a/src/scope.c
+++ b/src/scope.c
@@ -77,6 +77,7 @@ Scope::Scope()
     this->noctor = 0;
     this->intypeof = 0;
     this->speculative = 0;
+    this->lastVar = NULL;
     this->callSuper = 0;
     this->fieldinit = NULL;
     this->fieldinit_dim = 0;
@@ -127,6 +128,7 @@ Scope::Scope(Scope *enclosing)
     this->noctor = enclosing->noctor;
     this->intypeof = enclosing->intypeof;
     this->speculative = enclosing->speculative;
+    this->lastVar = enclosing->lastVar;
     this->callSuper = enclosing->callSuper;
     this->fieldinit = enclosing->saveFieldInit();
     this->fieldinit_dim = enclosing->fieldinit_dim;
@@ -450,6 +452,12 @@ Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym)
 Dsymbol *Scope::insert(Dsymbol *s)
 {   Scope *sc;
 
+    if (VarDeclaration *vd = s->isVarDeclaration())
+    {
+        if (lastVar)
+            vd->lastVar = lastVar;
+        lastVar = vd;
+    }
     for (sc = this; sc; sc = sc->enclosing)
     {
         //printf("\tsc = %p\n", sc);

--- a/src/scope.c
+++ b/src/scope.c
@@ -458,6 +458,14 @@ Dsymbol *Scope::insert(Dsymbol *s)
             vd->lastVar = lastVar;
         lastVar = vd;
     }
+    else if (WithScopeSymbol *ss = s->isWithScopeSymbol())
+    {
+        VarDeclaration *vd = ss->withstate->wthis;
+        if (lastVar)
+            vd->lastVar = lastVar;
+        lastVar = vd;
+        return NULL;
+    }
     for (sc = this; sc; sc = sc->enclosing)
     {
         //printf("\tsc = %p\n", sc);

--- a/src/scope.h
+++ b/src/scope.h
@@ -89,6 +89,7 @@ struct Scope
     int noctor;                 // set if constructor calls aren't allowed
     int intypeof;               // in typeof(exp)
     bool speculative;            // in __traits(compiles) or typeof(exp)
+    VarDeclaration *lastVar;    // Previous symbol used to prevent goto-skips-init
 
     unsigned callSuper;         // primitive flow analysis for constructors
     unsigned *fieldinit;

--- a/src/statement.c
+++ b/src/statement.c
@@ -4457,6 +4457,7 @@ Statement *WithStatement::semantic(Scope *sc)
     if (body)
     {
         sc = sc->push(sym);
+        sc->insert(sym);
         body = body->semantic(sc);
         sc->pop();
         if (body && body->isErrorStatement())
@@ -5094,6 +5095,11 @@ bool GotoStatement::checkLabel()
     if (last == vd)
     {
         // All good, the label's scope has no variables
+    }
+    else if (vd->ident == Id::withSym)
+    {
+        error("goto skips declaration of with temporary at %s", vd->loc.toChars());
+        return true;
     }
     else
     {

--- a/src/statement.c
+++ b/src/statement.c
@@ -5023,6 +5023,8 @@ GotoStatement::GotoStatement(Loc loc, Identifier *ident)
     this->ident = ident;
     this->label = NULL;
     this->tf = NULL;
+    this->lastVar = NULL;
+    this->fd = NULL;
 }
 
 Statement *GotoStatement::syntaxCopy()
@@ -5037,6 +5039,8 @@ Statement *GotoStatement::semantic(Scope *sc)
     //printf("GotoStatement::semantic()\n");
     ident = fixupLabelName(sc, ident);
 
+    this->lastVar = sc->lastVar;
+    this->fd = sc->func;
     tf = sc->tf;
     label = fd->searchLabel(ident);
     if (!label->statement && sc->fes)
@@ -5063,29 +5067,41 @@ Statement *GotoStatement::semantic(Scope *sc)
             fd->gotos = new GotoStatements();
         fd->gotos->push(this);
     }
-
-    if (label->statement && label->statement->tf != sc->tf)
-    {
-        error("cannot goto in or out of finally block");
+    else if (checkLabel())
         return new ErrorStatement();
-    }
 
     return this;
 }
 
-void GotoStatement::checkLabel()
+bool GotoStatement::checkLabel()
 {
     if (!label->statement)
     {
         error("label '%s' is undefined", label->toChars());
-        return;
+        return true;
     }
 
     if (label->statement->tf != tf)
     {
         error("cannot goto in or out of finally block");
-        return;
+        return true;
     }
+
+    VarDeclaration *last = lastVar;
+    VarDeclaration *vd = label->statement->lastVar;
+    while (last && last != vd)
+        last = last->lastVar;
+    if (last == vd)
+    {
+        // All good, the label's scope has no variables
+    }
+    else
+    {
+        error("goto skips declaration of variable %s at %s", vd->toPrettyChars(), vd->loc.toChars());
+        return true;
+    }
+
+    return false;
 }
 
 int GotoStatement::blockExit(bool mustNotThrow)
@@ -5112,6 +5128,7 @@ LabelStatement::LabelStatement(Loc loc, Identifier *ident, Statement *statement)
     this->statement = statement;
     this->tf = NULL;
     this->gotoTarget = NULL;
+    this->lastVar = NULL;
     this->lblock = NULL;
     this->fwdrefs = NULL;
 }
@@ -5126,6 +5143,7 @@ Statement *LabelStatement::semantic(Scope *sc)
 {   LabelDsymbol *ls;
     FuncDeclaration *fd = sc->parent->isFuncDeclaration();
 
+    this->lastVar = sc->lastVar;
     //printf("LabelStatement::semantic()\n");
     ident = fixupLabelName(sc, ident);
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -886,11 +886,13 @@ public:
     Identifier *ident;
     LabelDsymbol *label;
     TryFinallyStatement *tf;
+    VarDeclaration *lastVar;
+    FuncDeclaration *fd;
 
     GotoStatement(Loc loc, Identifier *ident);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    void checkLabel();
+    bool checkLabel();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
     void ctfeCompile(CompiledCtfeFunction *ccf);
@@ -906,6 +908,7 @@ public:
     Statement *statement;
     TryFinallyStatement *tf;
     Statement *gotoTarget;      // interpret
+    VarDeclaration *lastVar;
     block *lblock;              // back end
 
     Blocks *fwdrefs;            // forward references to this LabelStatement

--- a/test/compilable/test602.d
+++ b/test/compilable/test602.d
@@ -1,0 +1,383 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+// Disallow skipping variable decl
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    int x;
+    label: {}
+    assert(!x);
+}));
+
+// Disallow skipping variable in block backwards
+static assert(!__traits(compiles, (bool b)
+{
+    {
+        int x;
+        label: {}
+        assert(!x);
+    }
+    if (b) goto label;
+}));
+
+// Disallow skipping backwards int block
+static assert(!__traits(compiles, (bool b)
+{
+    {
+    int x;
+    label: {}
+    assert(!x);
+    }
+    if (b) goto label;
+}));
+
+// Variable inside try block
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    try
+    {
+        int x;
+    label: {}
+        assert(!x);
+    }
+    catch
+    {
+    }
+}));
+
+// Variable inside catch block
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    try
+    {
+    }
+    catch
+    {
+        int x;
+    label: {}
+        assert(!x);
+    }
+}));
+
+// Goto into catch block with unnamed exception
+static assert(__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    try
+    {
+    }
+    catch(Exception)
+    {
+    label: {}
+    }
+}));
+
+// Goto into catch block with named exception
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    try
+    {
+    }
+    catch(Exception e)
+    {
+    label: {}
+        assert(e);
+    }
+}));
+
+// Goto into finally block
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    try
+    {
+    }
+    finally
+    {
+    label: {}
+    }
+}));
+
+// Goto into variable with block
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    struct S
+    {
+        int x;
+    }
+    with (S())
+    {
+    label: {}
+        assert(!x);
+    }
+}));
+
+// Goto backwards into variable with block
+static assert(!__traits(compiles, (bool b)
+{
+    struct S
+    {
+        int x;
+    }
+    with (S())
+    {
+    label: {}
+        assert(!x);
+    }
+    if (b) goto label;
+}));
+
+// Goto into symbolic with block
+static assert(__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    struct S
+    {
+        int x;
+    }
+    with (S)
+    {
+    label: {}
+    }
+}));
+
+// Goto backwards into symbolic with block
+static assert(__traits(compiles, (bool b)
+{
+    struct S
+    {
+        int x;
+    }
+    with (S)
+    {
+    label: {}
+    }
+    if (b) goto label;
+}));
+
+// Goto into for loop
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    for (int i = 0; i < 8; ++i)
+    {
+    label: {}
+        assert(i);
+    }
+}));
+
+// Goto into for loop backwards
+static assert(!__traits(compiles, (bool b)
+{
+    for (int i = 0; i < 8; ++i)
+    {
+    label: {}
+        assert(i);
+    }
+    if (b) goto label;
+}));
+
+// Goto into foreach loop
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    foreach(i; 0..8)
+    {
+    label: {}
+        assert(i);
+    }
+}));
+
+// Goto into foreach loop backwards
+static assert(!__traits(compiles, (bool b)
+{
+    foreach(i; 0..8)
+    {
+    label: {}
+        assert(i);
+    }
+    if (b) goto label;
+}));
+
+// Goto into if block with variable
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    if (auto x = b)
+    {
+    label: {}
+        assert(x);
+    }
+}));
+
+// Goto backwards into if block with variable
+static assert(!__traits(compiles, (bool b)
+{
+    if (auto x = b)
+    {
+    label: {}
+        assert(x);
+    }
+    if (b) goto label;
+}));
+
+// Goto into if block without variable
+static assert(__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    if (b)
+    {
+    label: {}
+    }
+}));
+
+// Goto into else block
+static assert(__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    if (auto x = b)
+    {
+    }
+    else
+    {
+    label: {}
+    }
+}));
+
+// Goto backwards into else with variable
+static assert(!__traits(compiles, (bool b)
+{
+    if (auto x = b)
+    {
+    }
+    else
+    {
+        int y;
+    label: {}
+    }
+    if (b) goto label;
+}));
+
+// Goto into while block
+static assert(__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    while (b)
+    {
+    label: {}
+    }
+}));
+
+// Goto into while block with internal variable
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    while (b)
+    {
+        int x;
+    label: {}
+        assert(!x);
+    }
+}));
+
+// Goto into do block
+static assert(__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    do
+    {
+    label: {}
+    }
+    while (b);
+}));
+
+// Goto over switch variable
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    switch(0)
+    {
+    default:
+        break;
+        int x;
+    label: {}
+    }
+}));
+
+// Goto over switch variable
+static assert(!__traits(compiles, (bool b)
+{
+    if (b) goto label;
+    switch(0)
+    {
+    default:
+        break;
+    case 0:
+        int x;
+    label: {}
+    }
+}));
+
+// Goto into synchronized statement
+static assert(!__traits(compiles, (bool b)
+{
+    if (b)
+        goto label;
+    synchronized
+    {
+    label: {}
+    }
+}));
+
+// Goto into scope(success) with variable
+static assert(!__traits(compiles, (bool b)
+{
+    scope(success) { int x; label: {} assert(!x); }
+    if (b)
+        goto label;
+}));
+
+// Goto into scope(failure)
+static assert(__traits(compiles, (bool b)
+{
+    if (b)
+        goto label;
+    scope(failure) { label: {} }
+}));
+
+// Goto into scope(failure) with variable
+static assert(!__traits(compiles, (bool b)
+{
+    scope(failure) { int x; label: {} assert(!x); }
+    if (b)
+        goto label;
+}));
+
+// Goto into scope(exit)
+static assert(!__traits(compiles, (bool b)
+{
+    if (b)
+        goto label;
+    scope(exit) { label: {} }
+}));
+
+// Goto into scope(exit)
+static assert(!__traits(compiles, (bool b)
+{
+    scope(exit) { label: {} }
+    if (b)
+        goto label;
+}));
+
+// Goto into scope(exit) with variable
+static assert(!__traits(compiles, (bool b)
+{
+    scope(exit) { int x; label: {} assert(!x); }
+    if (b)
+        goto label;
+}));

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -436,13 +436,17 @@ void test2781()
     {
         Tuple2781b!(int[]) bar1;
         foreach(elem; bar1) goto L1;
+    L1:
+        ;
 
         Tuple2781b!(int[int]) bar2;
-        foreach(key, elem; bar2) goto L1;
+        foreach(key, elem; bar2) goto L2;
+    L2:
+        ;
 
         Tuple2781b!(string) bar3;
-        foreach(dchar elem; bar3) goto L1;
-    L1:
+        foreach(dchar elem; bar3) goto L3;
+    L3:
         ;
     }
 

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -588,7 +588,7 @@ void test8()
   try {
       a += 2;
   }
-  catch (Exception e) {
+  catch (Exception) {
       a += 3;
 L2: ;
       a += 100;

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -2916,8 +2916,8 @@ void test38()
 
 void test39()
 {
-    goto end;
     const byte z = 35;
+    goto end;
     asm { db z; }
     end: ;
 }

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -2896,8 +2896,8 @@ void test38()
 
 void test39()
 {
-    goto end;
     const byte z = 35;
+    goto end;
     asm { db z; }
     end: ;
 }


### PR DESCRIPTION
Create a linked list of variables in the current scope, and when a goto is encountered check the goto's list includes the label's list.

Should this exclude `= void` initialized variables?  I'm not sure on this.

https://d.puremagic.com/issues/show_bug.cgi?id=602
