### PR TITLE
Issue 10938 - ICE on recursive instantiation in opDispatch 

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8161,25 +8161,6 @@ L1:
         Declaration *v = s->isDeclaration();
         if (v && (v->isFuncDeclaration() || v->isVarDeclaration()))
         {
-            /* Fix for Bugzilla 4003
-             * The problem is a class template member function v returning a reference to the same
-             * type as the enclosing template instantiation. This results in a nested instantiation,
-             * which of course gets short circuited. The return type then gets set to
-             * the template instance type before instantiation, rather than after.
-             * We can detect this by the deco not being set. If so, go ahead and retry
-             * the return type semantic.
-             * The offending code is the return type from std.typecons.Tuple.slice:
-             *    ref Tuple!(Types[from .. to]) slice(uint from, uint to)()
-             *    {
-             *        return *cast(typeof(return) *) &(field[from]);
-             *    }
-             * and this line from the following unittest:
-             *    auto s = a.slice!(1, 3);
-             * where s's type wound up not having semantic() run on it.
-             */
-            if (v->type && !v->type->deco)
-                v->type = v->type->semantic(v->loc, sc);
-
             e = new DotVarExp(loc, eleft, v);
             e = e->semantic(sc);
             return e;

--- a/test/compilable/imports/stdio4003.d
+++ b/test/compilable/imports/stdio4003.d
@@ -1,0 +1,3 @@
+module imports.stdio4003;
+
+import imports.typecons4003;

--- a/test/compilable/imports/test4003a.d
+++ b/test/compilable/imports/test4003a.d
@@ -1,0 +1,6 @@
+module imports.test4003a;
+
+import imports.typecons4003;
+
+Tuple!(string) t;
+

--- a/test/compilable/imports/test65a.d
+++ b/test/compilable/imports/test65a.d
@@ -1,6 +1,0 @@
-module imports.test65a;
-
-import std.typecons;
-
-Tuple!(string) t;
-

--- a/test/compilable/imports/typecons4003.d
+++ b/test/compilable/imports/typecons4003.d
@@ -1,0 +1,22 @@
+module imports.typecons4003;
+
+struct Tuple(T...)
+{
+    alias T Types;
+    Types field;
+
+    ref Tuple!(Types[from .. to]) slice(uint from, uint to)()
+    {
+        return *cast(typeof(return) *) &(field[from]);
+    }
+
+    void test() //unittest
+    {
+        .Tuple!(int, string, float, double) a;
+        a.field[1] = "abc";
+        a.field[2] = 4.5;
+        auto s = a.slice!(1, 3);
+        static assert(is(typeof(s) == Tuple!(string, float)));
+        //assert(s.field[0] == "abc" && s.field[1] == 4.5);
+    }
+}

--- a/test/compilable/test4003.d
+++ b/test/compilable/test4003.d
@@ -1,0 +1,6 @@
+// EXTRA_SOURCES: imports/test4003a.d
+// PERMUTE_ARGS:
+
+import imports.stdio4003;
+void main(){}
+

--- a/test/compilable/test65.d
+++ b/test/compilable/test65.d
@@ -1,8 +1,0 @@
-// 4003
-// EXTRA_SOURCES: imports/test65a.d
-// PERMUTE_ARGS:
-// REQUIRED_ARGS: -unittest
-
-import std.stdio;
-void main(){}
-

--- a/test/fail_compilation/ice10938.d
+++ b/test/fail_compilation/ice10938.d
@@ -1,0 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice10938.d(12): Error: no property 'opts' for type 'ice10938.C'
+---
+*/
+
+class C
+{
+    this()
+    {
+        this.opts["opts"] = 1;
+    }
+
+    auto opDispatch(string field : "opts")()
+    {
+        return this.opts;  // ICE -> compile time error
+    }
+}
+
+void main()
+{
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10938

By fixing issue 10736 (314a1cca9ff56775b9e2a9cf81564135be0726b1), all of template instance semantic are reliably finished by the deferred mechanism.
And it had removed the necessity of the code in `DotTemplateInstanceExp::semanticY` for the issue 4003.

Therefore, just remove the unnecessary code to fix the ICE.
