### PR TITLE
Issue 11565 - [Optimizer] Zeroes out the higher 32bits of register in ?: expression

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -1942,7 +1942,11 @@ code *cdcond(elem *e,regm_t *pretregs)
         }
 
         if (v1 == 0 && v2 == ~(targ_size_t)0)
+        {
             c = gen2(c,0xF6 + (opcode & 1),grex | modregrmx(3,2,reg));  // NOT reg
+            if (I64 && sz2 == REGSIZE)
+                code_orrex(c, REX_W);
+        }
         else
         {
             v1 -= v2;

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -195,6 +195,18 @@ void testsizes()
 
 ///////////////////////
 
+size_t cond11565(size_t val)
+{
+    return val ? size_t.max : 0;
+}
+
+void test11565()
+{
+    assert(cond11565(true) == size_t.max);
+}
+
+///////////////////////
+
 int array1[3] = [1:1,2,0:3];
 
 void testarrayinit()
@@ -1043,6 +1055,7 @@ int main()
     testfastdiv();
     testdocond();
     testnegcom();
+    test11565();
     testoror();
     testbt();
     testandand();


### PR DESCRIPTION
This:

``` d
uint cond10703(uint val)
{
    return val ? uint.max : 0;
}
```

becomes

```
_D5testx9cond10703FmZm PROC
        push    rbp                                     ; 0000 _ 55
        mov     rbp, rsp                                ; 0001 _ 48: 8B. EC
        cmp     rcx, 1                                  ; 0004 _ 48: 83. F9, 01
        sbb     rax, rax                                ; 0008 _ 48: 19. C0
        not     eax                                     ; 000B _ F7. D0
        pop     rbp                                     ; 000D _ 5D
        ret                                             ; 000E _ C3
_D5testx9cond10703FmZm ENDP
```

Which is missing the REX_W prefix on the `not`.

https://d.puremagic.com/issues/show_bug.cgi?id=11565
