### PR TITLE
Issue 10439 - Deprecate float.min, double.min, real.min

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2957,7 +2957,7 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                warning(loc, "min property is deprecated, use min_normal instead");
+                deprecation(loc, "min property is deprecated, use min_normal instead");
                 goto Lmin_normal;
         }
     }


### PR DESCRIPTION
These have been a warning for over a year, time to move to deprecated.

https://d.puremagic.com/issues/show_bug.cgi?id=10439
