### PR TITLE
[Refactoring] Remove `Expression::isTemp`

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -176,7 +176,6 @@ public:
     Expression *addressOf(Scope *sc);
     Expression *deref();
     Expression *integralPromotions(Scope *sc);
-    Expression *isTemp();
 
     Expression *toDelegate(Scope *sc, Type *t);
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5804,8 +5804,6 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 if (fargs && i < fargs->dim)
                 {
                     Expression *farg = (*fargs)[i];
-                    if (Expression *e = farg->isTemp())
-                        farg = e;
                     if (farg->isLvalue())
                         ;                               // ref parameter
                     else
@@ -6013,9 +6011,8 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
     }
 
     for (size_t u = 0; u < nparams; u++)
-    {   MATCH m;
-
-        // BUG: what about out and ref?
+    {
+        MATCH m;
 
         Parameter *p = Parameter::getNth(parameters, u);
         assert(p);
@@ -6028,8 +6025,6 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
         {
         Expression *arg = (*args)[u];
         assert(arg);
-        if (Expression *e = arg->isTemp())
-            arg = e;
 
         if (arg->op == TOKfunction)
         {

--- a/src/statement.c
+++ b/src/statement.c
@@ -3699,9 +3699,6 @@ Statement *ReturnStatement::semantic(Scope *sc)
             exp = exp->inferType(fld->treq->nextOf()->nextOf());
         exp = exp->semantic(sc);
         exp = resolveProperties(sc, exp);
-
-        if (Expression *e = exp->isTemp())
-            exp = e;                // don't need temporary
         if (exp->op == TOKcall)
             exp = valueNoDtor(exp);
 

--- a/src/template.c
+++ b/src/template.c
@@ -7221,8 +7221,6 @@ int TemplateInstance::compare(RootObject *o)
             {
                 Parameter *fparam = Parameter::getNth(fparameters, j);
                 Expression *farg = (*fargs)[j];
-                if (Expression *e = farg->isTemp())
-                    farg = e;
                 if (fparam->storageClass & STCauto)         // if "auto ref"
                 {
                     if (farg->isLvalue())


### PR DESCRIPTION
By fixing bug 11286 in #2677, `StructLiteralExp` stopped to make temporary variable for destructor handling. Therefore, `Expression::isTemp` call is now unnecessary for lvalue/rvalue check.
