### PR TITLE
Issue 10221 - foreach(char c; 0..256) doesn't work even though the upper bound is 255

### DIFF
--- a/test/fail_compilation/diag10221.d
+++ b/test/fail_compilation/diag10221.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag10221.d(10): Error: cannot implicitly convert expression (256) of type int to ubyte
+---
+*/
+
+void main()
+{
+    foreach(ref ubyte i; 0..256) {}
+}

--- a/test/fail_compilation/diag10221a.d
+++ b/test/fail_compilation/diag10221a.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag10221a.d(10): Error: cannot implicitly convert expression (257) of type int to ubyte
+---
+*/
+
+void main()
+{
+    foreach(ubyte i; 0..257) {}
+}

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -403,6 +403,36 @@ void test6659c()
 }
 
 /***************************************/
+
+// 10221
+
+void test10221()
+{
+    // All of these should work, but most are too slow.  Just check they compile.
+    foreach(char i; char.min..char.max+1) {}
+    if (0) foreach(wchar i; wchar.min..wchar.max+1) {}
+    if (0) foreach(dchar i; dchar.min..dchar.max+1) {}
+    foreach(byte i; byte.min..byte.max+1) {}
+    foreach(ubyte i; ubyte.min..ubyte.max+1) {}
+    if (0) foreach(short i; short.min..short.max+1) {}
+    if (0) foreach(ushort i; ushort.min..ushort.max+1) {}
+    if (0) foreach(int i; int.min..int.max+1U) {}
+    if (0) foreach(uint i; uint.min..uint.max+1L) {}
+    if (0) foreach(long i; long.min..long.max+1UL) {}
+
+    foreach_reverse(char i; char.min..char.max+1) { assert(i == typeof(i).max); break; }
+    foreach_reverse(wchar i; wchar.min..wchar.max+1) { assert(i == typeof(i).max); break; }
+    foreach_reverse(dchar i; dchar.min..dchar.max+1) { assert(i == typeof(i).max); break; }
+    foreach_reverse(byte i; byte.min..byte.max+1) { assert(i == typeof(i).max); break; }
+    foreach_reverse(ubyte i; ubyte.min..ubyte.max+1) { assert(i == typeof(i).max); break; }
+    foreach_reverse(short i; short.min..short.max+1) { assert(i == typeof(i).max); break; }
+    foreach_reverse(ushort i; ushort.min..ushort.max+1) { assert(i == typeof(i).max); break; }
+    foreach_reverse(int i; int.min..int.max+1U) { assert(i == typeof(i).max); break; }
+    foreach_reverse(uint i; uint.min..uint.max+1L) { assert(i == typeof(i).max); break; }
+    foreach_reverse(long i; long.min..long.max+1UL) { assert(i == typeof(i).max); break; }
+}
+
+/***************************************/
 // 7814
 
 struct File7814
@@ -792,6 +822,7 @@ int main()
     test4090b();
     test5605();
     test7004();
+    test10221();
     test7406();
     test6659();
     test6659a();


### PR DESCRIPTION
In the extreme cases, do not force the hidden 'key' variable to be the asked for type.  This obviously doesn't work for ref index.

https://d.puremagic.com/issues/show_bug.cgi?id=10221
