### PR TITLE
[REG2.063] Issue 11487 - dmd segfaults on writefln in nested template

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -5282,9 +5282,11 @@ void TemplateInstance::semantic(Scope *sc)
 void TemplateInstance::expandMembers(Scope *sc2)
 {
     for (size_t i = 0; i < members->dim; i++)
-    {   Dsymbol *s = (*members)[i];
+    {
+        Dsymbol *s = (*members)[i];
         s->setScope(sc2);
     }
+
     for (size_t i = 0; i < members->dim; i++)
     {
         Dsymbol *s = (*members)[i];
@@ -7546,6 +7548,12 @@ void TemplateMixin::semantic(Scope *sc)
         global.gag = 0;                 // ensure error message gets printed
         error("recursive expansion");
         fatal();
+    }
+
+    for (size_t i = 0; i < members->dim; i++)
+    {
+        Dsymbol *s = (*members)[i];
+        s->setScope(sc2);
     }
 
     for (size_t i = 0; i < members->dim; i++)

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -1186,6 +1186,33 @@ void test9417()
 }
 
 /*******************************************/
+// 11487
+
+template X11487()
+{
+    struct R()
+    {
+        C11487 c;
+
+        ~this()
+        {
+            static assert(is(typeof(c.front) == void));
+        }
+    }
+    template Mix(alias R)
+    {
+        R!() range;
+        @property front() inout {}
+    }
+}
+
+class C11487
+{
+    alias X11487!() M;
+    mixin M.Mix!(M.R);
+}
+
+/*******************************************/
 
 int main()
 {


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11487

`TemplateMixin` should call `setScope` for its members.
