### PR TITLE
Issue 9050 - Too early instantiation of template structs

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -76,6 +76,7 @@ FuncDeclaration *AggregateDeclaration::hasIdentityOpAssign(Scope *sc)
         unsigned oldspec = global.speculativeGag;   // template opAssign fbody makes it.
         global.speculativeGag = global.gag;
         sc = sc->push();
+        sc->tinst = NULL;
         sc->speculative = true;
 
         for (size_t i = 0; i < 2; i++)
@@ -419,6 +420,7 @@ FuncDeclaration *AggregateDeclaration::hasIdentityOpEquals(Scope *sc)
             unsigned oldspec = global.speculativeGag;   // template opAssign fbody makes it.
             global.speculativeGag = global.gag;
             sc = sc->push();
+            sc->tinst = NULL;
             sc->speculative = true;
 
             for (size_t j = 0; j < 2; j++)

--- a/src/template.h
+++ b/src/template.h
@@ -315,6 +315,8 @@ public:
     Expressions *fargs;                 // for function template, these are the function arguments
     Module *instantiatingModule;        // the top module that instantiated this instance
 
+    TemplateInstances* deferred;
+
     TemplateInstance(Loc loc, Identifier *temp_id);
     TemplateInstance(Loc loc, TemplateDeclaration *tempdecl, Objects *tiargs);
     static Objects *arraySyntaxCopy(Objects *objs);

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1914,6 +1914,42 @@ void test9038()
 }
 
 /**********************************/
+// 9050
+
+struct A9050(T) {}
+
+struct B9050(T)
+{
+    void f() { foo9050(A9050!int()); }
+}
+
+auto foo9050()(A9050!int base) pure
+{
+    return B9050!int();
+}
+
+auto s9050 = foo9050(A9050!int());
+
+/**********************************/
+// 10936 (dup of 9050)
+
+struct Vec10936(string s)
+{
+    auto foo(string v)()
+    {
+        return Vec10936!(v)();
+    }
+
+    static void bar()
+    {
+        Vec10936!"" v;
+        auto p = v.foo!"sup";
+    }
+}
+
+Vec10936!"" v;
+
+/**********************************/
 // 9076
 
 template forward9076(args...)


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=9050

Running semantic3 for template structs will cause unnecessary forward reference.
