### PR TITLE
Fix associative arrays

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -2688,6 +2688,16 @@ Lcc:
         e2 = e2->castTo(sc, t);
         goto Lret;
     }
+    else if (t2->ty == Tnull &&
+        (t1->ty == Tpointer || t1->ty == Taarray || t1->ty == Tarray))
+    {
+        goto Lt1;
+    }
+    else if (t1->ty == Tnull &&
+        (t2->ty == Tpointer || t2->ty == Taarray || t2->ty == Tarray))
+    {
+        goto Lt2;
+    }
     else if (isArrayOperand(e1) && t1->ty == Tarray &&
              e2->implicitConvTo(t1->nextOf()))
     {   // T[] op T

--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -195,7 +195,7 @@ bool isFloatIntPaint(Type *to, Type *from);
 // Reinterpret float/int value 'fromVal' as a float/integer of type 'to'.
 Expression *paintFloatInt(Expression *fromVal, Type *to);
 
-/// Return true if t is an AA, or AssociativeArray!(key, value)
+/// Return true if t is an AA
 bool isAssocArray(Type *t);
 
 /// Given a template AA type, extract the corresponding built-in AA type

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -508,21 +508,12 @@ StringExp *createBlockDuplicatedStringLiteral(Loc loc, Type *type,
     return se;
 }
 
-// Return true if t is an AA, or AssociativeArray!(key, value)
+// Return true if t is an AA
 bool isAssocArray(Type *t)
 {
     t = t->toBasetype();
     if (t->ty == Taarray)
         return true;
-    if (t->ty != Tstruct)
-        return false;
-    StructDeclaration *sym = ((TypeStruct *)t)->sym;
-    if (sym->ident == Id::AssociativeArray && sym->parent &&
-        sym->parent->parent &&
-        sym->parent->parent->ident == Id::object)
-    {
-        return true;
-    }
     return false;
 }
 
@@ -532,12 +523,8 @@ TypeAArray *toBuiltinAAType(Type *t)
     t = t->toBasetype();
     if (t->ty == Taarray)
         return (TypeAArray *)t;
-    assert(t->ty == Tstruct);
-    StructDeclaration *sym = ((TypeStruct *)t)->sym;
-    assert(sym->ident == Id::AssociativeArray);
-    TemplateInstance *ti = sym->parent->isTemplateInstance();
-    assert(ti);
-    return new TypeAArray((Type *)(*ti->tiargs)[1], (Type *)(*ti->tiargs)[0]);
+    assert(0);
+    return NULL;
 }
 
 /************** TypeInfo operations ************************************/
@@ -591,6 +578,10 @@ bool isSafePointerCast(Type *srcPointee, Type *destPointee)
 
     // it's OK to cast to void*
     if (destPointee->ty == Tvoid)
+        return true;
+
+    // It's OK to cast from V[K] to void*
+    if (srcPointee->ty == Taarray && destPointee == Type::tvoidptr)
         return true;
 
     // It's OK if they are the same size (static array of) integers, eg:

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1279,10 +1279,7 @@ Dsymbol *WithScopeSymbol::search(Loc loc, Identifier *ident, int flags)
         else
         {
             Type *t = e->type->toBasetype();
-            if (t->ty == Taarray)
-                s = ((TypeAArray *)t)->getImpl();
-            else
-                s = t->toDsymbol(NULL);
+            s = t->toDsymbol(NULL);
         }
         if (s)
         {

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4562,6 +4562,7 @@ Lagain:
                 goto Lagain;
 
         case X(Tnull, Tarray):
+        case X(Tnull, Taarray):
             goto Lzero;
 
         /* ============================= */

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3943,11 +3943,6 @@ elem *CastExp::toElem(IRState *irs)
     Type *tfrom = e1->type->toBasetype();
     Type *t = to->toBasetype();         // skip over typedef's
 
-    if (tfrom->ty == Taarray)
-        tfrom = ((TypeAArray*)tfrom)->getImpl()->type;
-    if (t->ty == Taarray)
-        t = ((TypeAArray*)t)->getImpl()->type;
-
     if (t->equals(tfrom))
         goto Lret;
 
@@ -5015,15 +5010,8 @@ elem *AssocArrayLiteralExp::toElem(IRState *irs)
         // call _d_assocarrayliteralTX(TypeInfo_AssociativeArray ti, void[] keys, void[] values)
         // Prefer this to avoid the varargs fiasco in 64 bit code
 
-        Type *ta;
-        if (t->ty == Taarray)
-            ta = t;
-        else
-        {   // It's the AssociativeArray type.
-            // Turn it back into a TypeAArray
-            ta = TypeAArray::create((*values)[0]->type, (*keys)[0]->type);
-            ta = ta->semantic(loc, NULL);
-        }
+        assert(t->ty == Taarray);
+        Type *ta = t;
 
         symbol *skeys = NULL;
         elem *ekeys = ExpressionsToStaticArray(irs, loc, keys, &skeys);

--- a/src/expression.c
+++ b/src/expression.c
@@ -797,19 +797,6 @@ Expression *resolveUFCS(Scope *sc, CallExp *ce)
 
                 return new RemoveExp(loc, eleft, key);
             }
-            else if (ident == Id::apply || ident == Id::applyReverse)
-            {
-                return NULL;
-            }
-            else
-            {
-                TypeAArray *taa = (TypeAArray *)t;
-                assert(taa->ty == Taarray);
-                StructDeclaration *sd = taa->getImpl();
-                Dsymbol *s = sd->search(Loc(), ident, IgnoreErrors);
-                if (s)
-                    return NULL;
-            }
         }
         else
         {
@@ -10011,16 +9998,7 @@ Expression *CastExp::semantic(Scope *sc)
     }
 
 Lsafe:
-    /* Instantiate AA implementations during semantic analysis.
-     */
     {
-        Type *tfrom = e1->type->toBasetype();
-        Type *t = to->toBasetype();
-        if (tfrom->ty == Taarray)
-            ((TypeAArray *)tfrom)->getImpl();
-        if (t->ty == Taarray)
-            ((TypeAArray *)t)->getImpl();
-
         if (to->ty == Tvoid)
         {
             type = to;

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -63,7 +63,6 @@ Msgtable msgtable[] =
     { "typeinfo" },
     { "outer" },
     { "Exception" },
-    { "AssociativeArray" },
     { "RTInfo" },
     { "Throwable" },
     { "Error" },

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -209,7 +209,6 @@ public:
     static ClassDeclaration *typeinfoshared;
     static ClassDeclaration *typeinfowild;
 
-    static TemplateDeclaration *associativearray;
     static TemplateDeclaration *rtinfo;
 
     static Type *basic[TMAX];
@@ -540,15 +539,12 @@ public:
     Loc loc;
     Scope *sc;
 
-    StructDeclaration *impl;    // implementation
-
     TypeAArray(Type *t, Type *index);
     static TypeAArray *create(Type *t, Type *index);
     const char *kind();
     Type *syntaxCopy();
     d_uns64 size(Loc loc);
     Type *semantic(Loc loc, Scope *sc);
-    StructDeclaration *getImpl();
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);

--- a/src/statement.c
+++ b/src/statement.c
@@ -1880,11 +1880,7 @@ Lagain:
                 error("only one or two arguments for associative array foreach");
                 goto Lerror2;
             }
-
-            /* This only works if Key or Value is a static array.
-             */
-            tab = taa->getImpl()->type;
-            goto Lagain;
+            goto Lapply;
 
         case Tclass:
         case Tstruct:

--- a/src/template.c
+++ b/src/template.c
@@ -499,9 +499,7 @@ void TemplateDeclaration::semantic(Scope *sc)
     // Remember templates defined in module object that we need to know about
     if (sc->module && sc->module->ident == Id::object)
     {
-        if (ident == Id::AssociativeArray)
-            Type::associativearray = this;
-        else if (ident == Id::RTInfo)
+        if (ident == Id::RTInfo)
             Type::rtinfo = this;
     }
 
@@ -3343,10 +3341,6 @@ MATCH Type::deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters,
             if (sym->isforwardRef() && !tparam->deco)
                 goto Lnomatch;
         }
-
-        // Can't instantiate AssociativeArray!() without a scope
-        if (tparam->ty == Taarray && !((TypeAArray*)tparam)->sc)
-            ((TypeAArray*)tparam)->sc = sc;
 
         MATCH m = implicitConvTo(tparam);
         if (m == MATCHnomatch)

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -485,7 +485,7 @@ public:
     void visit(TypeInfoAssociativeArrayDeclaration *d)
     {
         //printf("TypeInfoAssociativeArrayDeclaration::toDt()\n");
-        verifyStructSize(Type::typeinfoassociativearray, 5 * Target::ptrsize);
+        verifyStructSize(Type::typeinfoassociativearray, 4 * Target::ptrsize);
 
         dtxoff(pdt, Type::typeinfoassociativearray->toVtblSymbol(), 0); // vtbl for TypeInfo_AssociativeArray
         dtsize_t(pdt, 0);                        // monitor
@@ -499,9 +499,6 @@ public:
 
         tc->index->getTypeInfo(NULL);
         dtxoff(pdt, tc->index->vtinfo->toSymbol(), 0); // TypeInfo for array of type
-
-        tc->getImpl()->type->getTypeInfo(NULL);
-        dtxoff(pdt, tc->getImpl()->type->vtinfo->toSymbol(), 0);    // impl
     }
 
     void visit(TypeInfoFunctionDeclaration *d)

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -400,6 +400,25 @@ struct Bug7058
 
 /***************************************************/
 
+void test12094()
+{
+    auto n = null;
+    int *a;
+    int[int] b;
+    int[] c;
+    auto u = true ? null : a;
+    auto v = true ? null : b;
+    auto w = true ? null : c;
+    auto x = true ? n : a;
+    auto y = true ? n : b;
+    auto z = true ? n : c;
+    a = n;
+    b = n;
+    c = n;
+}
+
+/***************************************************/
+
 template test8163(T...)
 {
     struct Point

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -946,39 +946,6 @@ void test6711()
         i = 42;
     }
     assert(c.i == 42);
-
-    struct Foo
-    {
-        string[string] strs;
-        alias strs this;
-    }
-
-    struct Bar
-    {
-        Foo f;
-        alias f this;
-    }
-
-    void test(T)()
-    {
-        T f;
-        f = ["first" : "a", "second" : "b"];
-        with (f)
-        {
-            assert(length == 2);
-            rehash;
-            auto vs = values;
-            assert(vs == ["a", "b"] || vs == ["b", "a"]);
-            auto ks = keys;
-            assert(ks == ["first", "second"] || ks == ["second", "first"]);
-            foreach (k; byKey) { }
-            foreach (v; byValue) { }
-            assert(get("a", "default") == "default");
-        }
-    }
-
-    test!Foo;
-    test!Bar;
 }
 
 /**********************************************/

--- a/test/runnable/testaa3.d
+++ b/test/runnable/testaa3.d
@@ -1,0 +1,126 @@
+
+/* Test all aa properties (length, values, keys, opApply(Key, Value), opApply_r(Value),
+ * dup, byKey, byValue, rehash, opIndex, opIndexAssign, opIn_r)
+ *
+ * With all aas: literal, variable, ref parameter, rvalue
+ */
+
+int testLiteral()
+{
+    assert([5 : 4].length == 1);
+    assert([5 : 4].values == [4]);
+    assert([5 : 4].keys == [5]);
+    foreach(k, v; [5 : 4])
+        assert(k == 5 && v == 4);
+    foreach(v; [5 : 4])
+        assert(v == 4);
+    assert([5 : 4].dup == [5 : 4]);
+    assert([5 : 4].dup);
+    if (!__ctfe)
+    foreach(k; [5 : 4].byKey)
+        assert(k == 5);
+    if (!__ctfe)
+    foreach(v; [5 : 4].byValue)
+        assert(v == 4);
+    assert([5 : 4].rehash == [5 : 4]);
+    assert([5 : 4][5] == 4);
+    //assert(([5 : 4][3] = 7) == 7);
+    assert(*(5 in [5 : 4]) == 4);
+    return 1;
+}
+
+int testVar()
+{
+    auto aa = [5 : 4];
+    assert(aa.length == 1);
+    assert(aa.values == [4]);
+    assert(aa.keys == [5]);
+    foreach(k, v; aa)
+        assert(k == 5 && v == 4);
+    foreach(v; aa)
+        assert(v == 4);
+    assert(aa.dup == aa);
+    assert(aa.dup);
+    if (!__ctfe)
+    foreach(k; aa.byKey)
+        assert(k == 5);
+    if (!__ctfe)
+    foreach(v; aa.byValue)
+        assert(v == 4);
+    // assert(aa.rehash == aa);
+    assert(aa[5] == 4);
+    assert(*(5 in aa) == 4);
+    assert((aa[3] = 7) == 7);
+    return 1;
+}
+
+int testRef()
+{
+    auto aa = [5 : 4];
+    return testRefx(aa);
+}
+int testRefx(ref int[int] aa)
+{
+    assert(aa.length == 1);
+    assert(aa.values == [4]);
+    assert(aa.keys == [5]);
+    foreach(k, v; aa)
+        assert(k == 5 && v == 4);
+    foreach(v; aa)
+        assert(v == 4);
+    assert(aa.dup == aa);
+    assert(aa.dup);
+    if (!__ctfe)
+    foreach(k; aa.byKey)
+        assert(k == 5);
+    if (!__ctfe)
+    foreach(v; aa.byValue)
+        assert(v == 4);
+    // assert(aa.rehash == aa);
+    assert(aa[5] == 4);
+    assert((aa[3] = 7) == 7);
+    assert(*(5 in aa) == 4);
+    return 1;
+}
+
+int testRet()
+{
+    assert(testRetx().length == 1);
+    assert(testRetx().values == [4]);
+    assert(testRetx().keys == [5]);
+    foreach(k, v; testRetx())
+        assert(k == 5 && v == 4);
+    foreach(v; testRetx())
+        assert(v == 4);
+    assert(testRetx().dup == testRetx());
+    assert(testRetx().dup);
+    if (!__ctfe)
+    foreach(k; testRetx().byKey)
+        assert(k == 5);
+    if (!__ctfe)
+    foreach(v; testRetx().byValue)
+        assert(v == 4);
+    assert(testRetx().rehash == testRetx());
+    assert(testRetx()[5] == 4);
+    //assert((testRetx()[3] = 7) == 7);
+    assert(*(5 in testRetx()) == 4);
+    return 1;
+}
+int[int] testRetx()
+{
+    return [5 : 4];
+}
+
+void aafunc(int[int] aa) {}
+
+void main()
+{
+    assert(testLiteral());
+    static assert(testLiteral());
+    assert(testVar());
+    static assert(testVar());
+    assert(testRef());
+    static assert(testRef());
+    assert(testRet());
+    static assert(testRet());
+}


### PR DESCRIPTION
- Remove `AssociativeArray`
- Implement extensions as UFCS methods
- Revert https://d.puremagic.com/issues/show_bug.cgi?id=9807

druntime pull:
https://github.com/D-Programming-Language/druntime/pull/668
