### PR TITLE
Issue 9301 - using XMM.PSHUFD results in an internal compiler error

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -193,6 +193,8 @@ MATCH IntegerExp::implicitConvTo(Type *t)
     if (t->ty == Tvector)
     {   TypeVector *tv = (TypeVector *)t;
         TypeBasic *tb = tv->elementType();
+        if (tb->ty == Tvoid)
+            goto Lno;
         toty = tb->ty;
     }
 

--- a/test/fail_compilation/fail9301.d
+++ b/test/fail_compilation/fail9301.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -o-
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/fail9301.d(12): Error: cannot implicitly convert expression (0) of type int to __vector(void[16])
+---
+*/
+
+void main()
+{
+    __vector(void[16]) x = 0x0;
+}


### PR DESCRIPTION
Generate the same error you get with `void[16] = 0x0;`.

https://d.puremagic.com/issues/show_bug.cgi?id=9301
