### PR TITLE
fix issue 3657: add lexical scope to CodeView debug info

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1290,6 +1290,9 @@ struct Symbol
     }_SXR;
     regm_t      Sregsaved;      // mask of registers not affected by this func
 
+    unsigned lnoscopestart;     // life time of var
+    unsigned lnoscopeend;       // the line after the scope
+
     char Sident[1];             // identifier string (dynamic array)
 
     int needThis();             // !=0 if symbol needs a 'this' pointer

--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1290,8 +1290,10 @@ struct Symbol
     }_SXR;
     regm_t      Sregsaved;      // mask of registers not affected by this func
 
+#if MARS
     unsigned lnoscopestart;     // life time of var
     unsigned lnoscopeend;       // the line after the scope
+#endif
 
     char Sident[1];             // identifier string (dynamic array)
 

--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -23,7 +23,9 @@
 #include        "cgcv.h"
 #include        "cv4.h"
 #include        "global.h"
+#if MARS
 #include        "varstats.h"
+#endif
 #if SCPP
 #include        "parser.h"
 #include        "cpp.h"
@@ -2531,6 +2533,7 @@ STATIC void cv_outlist()
         cv_outsym((Symbol *) list_pop(&cgcv.list));
 }
 
+#if MARS
 // record for CV record S_BLOCK32
 struct block32_data
 {
@@ -2585,6 +2588,7 @@ void cv4_writeLexicalScope(Funcsym *s, symbol *sa, VarStatistics* vs)
         vs->nextVarStatsLine++;
     }
 }
+#endif
 
 /******************************************
  * Write out symbol table for current function.

--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -23,6 +23,7 @@
 #include        "cgcv.h"
 #include        "cv4.h"
 #include        "global.h"
+#include        "varstats.h"
 #if SCPP
 #include        "parser.h"
 #include        "cpp.h"
@@ -2530,6 +2531,61 @@ STATIC void cv_outlist()
         cv_outsym((Symbol *) list_pop(&cgcv.list));
 }
 
+// record for CV record S_BLOCK32
+struct block32_data
+{
+    unsigned short len;
+    unsigned short id;
+    unsigned int pParent;
+    unsigned int pEnd;
+    unsigned int length;
+    unsigned int offset;
+    unsigned short seg;
+    unsigned char name[2];
+};
+
+/******************************************
+ * write lexical scope records up to the line where the symbol sa is created
+ * if sa == NULL, flush all remaining records
+ */
+void cv4_writeLexicalScope(Funcsym *s, symbol *sa, VarStatistics* vs)
+{
+    if (vs->cntUsedVarStats == 0)
+        return;
+
+    unsigned line;
+    if(sa)
+    {
+        line = sa->lnoscopestart + 1;
+    }
+    else
+    {
+        // flush all
+        line = vs->firstVarStatsLine + vs->cntUsedVarStats;
+    }
+    while (vs->nextVarStatsLine < line && vs->nextVarStatsLine < vs->firstVarStatsLine + vs->cntUsedVarStats)
+    {
+        unsigned idx = vs->nextVarStatsLine - vs->firstVarStatsLine;
+        for(int d = 0; d < vs->varStats[idx].numDel; d++)
+        {
+            static unsigned short s_end[] = { 2, S_END };
+            objmod->write_bytes(SegData[DEBSYM], sizeof(s_end), s_end);
+        }
+        for(int n = 0; n < vs->varStats[idx].numNew; n++)
+        {
+            unsigned offset = vs->varStats[idx].offset;
+            unsigned length = vs->varStats[vs->varStats[idx].endLine - vs->firstVarStatsLine].offset - offset;
+            unsigned soffset = Offset(DEBSYM);
+            // parent and end to be filled by linker
+            block32_data block32 = { sizeof(block32_data) - 2, S_BLOCK32, 0, 0, length, 0, 0, { 0, '\0' } };
+            objmod->write_bytes(SegData[DEBSYM], sizeof(block32), &block32);
+            size_t offOffset = (char*)&block32.offset - (char*)&block32;
+            objmod->reftoident(DEBSYM, soffset + offOffset, s, offset + s->Soffset, CFseg | CFoff);
+        }
+        vs->nextVarStatsLine++;
+    }
+}
+
 /******************************************
  * Write out symbol table for current function.
  */
@@ -2540,6 +2596,9 @@ STATIC void cv4_func(Funcsym *s)
     int endarg;
 
     cv4_outsym(s);              // put out function symbol
+#if MARS
+    varStats.calcLexicalScope(s, &globsym);
+#endif
 
     // Put out local symbols
     endarg = 0;
@@ -2553,9 +2612,15 @@ STATIC void cv4_func(Funcsym *s)
             objmod->write_bytes(SegData[DEBSYM],sizeof(endargs),endargs);
             endarg = 1;
         }
+        if (varStats.isLexVar[si])
+            cv4_writeLexicalScope(s, sa, &varStats);
 #endif
         cv4_outsym(sa);
     }
+
+#if MARS
+    cv4_writeLexicalScope(s, 0, &varStats); // flush remaining entries
+#endif
 
     // Put out function return record
     if (1)

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -26,6 +26,7 @@
 #include        "code.h"
 #include        "type.h"
 #include        "outbuf.h"
+#include        "varstats.h"
 
 #include        "md5.h"
 
@@ -849,6 +850,8 @@ void Obj::term(const char *objfilename)
 
 void Obj::linnum(Srcpos srcpos,targ_size_t offset)
 {
+    varStats.recordLineOffset(srcpos, offset);
+
     unsigned linnum = srcpos.Slinnum;
 
 #if 0
@@ -2427,6 +2430,8 @@ void Obj::func_start(Symbol *sfunc)
     symbol_debug(sfunc);
     sfunc->Sseg = cseg;             // current code seg
     sfunc->Soffset = Coffset;       // offset of start of function
+
+    varStats.startFunction();
 }
 
 /*******************************

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -26,11 +26,12 @@
 #include        "code.h"
 #include        "type.h"
 #include        "outbuf.h"
-#include        "varstats.h"
 
 #include        "md5.h"
 
 #if MARS
+#include        "varstats.h"
+
 struct Loc
 {
     char *filename;
@@ -850,7 +851,9 @@ void Obj::term(const char *objfilename)
 
 void Obj::linnum(Srcpos srcpos,targ_size_t offset)
 {
+#if MARS
     varStats.recordLineOffset(srcpos, offset);
+#endif
 
     unsigned linnum = srcpos.Slinnum;
 
@@ -2431,7 +2434,9 @@ void Obj::func_start(Symbol *sfunc)
     sfunc->Sseg = cseg;             // current code seg
     sfunc->Soffset = Coffset;       // offset of start of function
 
+#if MARS
     varStats.startFunction();
+#endif
 }
 
 /*******************************

--- a/src/backend/var.c
+++ b/src/backend/var.c
@@ -21,7 +21,9 @@
 #include        "go.h"
 #include        "ty.h"
 #include        "code.h"
+#if MARS
 #include        "varstats.h"
+#endif
 #if SPP || SCPP
 #include        "parser.h"
 #endif
@@ -206,4 +208,6 @@ type *chartype;                 /* default 'char' type                  */
 
 Obj *objmod = NULL;
 
+#if MARS
 VarStatistics varStats;
+#endif

--- a/src/backend/var.c
+++ b/src/backend/var.c
@@ -21,6 +21,7 @@
 #include        "go.h"
 #include        "ty.h"
 #include        "code.h"
+#include        "varstats.h"
 #if SPP || SCPP
 #include        "parser.h"
 #endif
@@ -204,3 +205,5 @@ const char *regstring[32] = {"AX","CX","DX","BX","SP","BP","SI","DI",
 type *chartype;                 /* default 'char' type                  */
 
 Obj *objmod = NULL;
+
+VarStatistics varStats;

--- a/src/backend/varstats.c
+++ b/src/backend/varstats.c
@@ -1,0 +1,201 @@
+// Compiler implementation of the D programming language
+// Copyright (c) 2015-2015 by Digital Mars
+// All Rights Reserved
+// http://www.digitalmars.com
+// Written by Rainer Schuetze
+// Distributed under the Boost Software License, Version 1.0.
+// http://www.boost.org/LICENSE_1_0.txt
+
+/******************************************
+ * support for lexical scope of local variables
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "varstats.h"
+#include "global.h"
+#include "code.h"
+
+VarStatistics::VarStatistics()
+{
+    memset (this, 0, sizeof (VarStatistics));
+}
+
+void VarStatistics::startFunction()
+{
+    cntUsedLineOffsets = 0;
+    srcfile = NULL;
+}
+
+// record lines of creation and destruction of a variable
+void VarStatistics::markVarStats(int startLine, int endLine)
+{
+    if (endLine <= startLine) // single line functions
+        endLine = startLine + 1;
+    if (cntUsedVarStats == 0)
+        firstVarStatsLine = startLine;
+
+    if(startLine < firstVarStatsLine)
+    {
+        int cnt = firstVarStatsLine - startLine;
+        if (cnt + cntUsedVarStats > cntAllocVarStats)
+        {
+            cntAllocVarStats = cnt + cntUsedVarStats;
+            varStats = (VarStats*) util_realloc(varStats, cntAllocVarStats, sizeof(*varStats));
+        }
+        memmove(varStats + cnt, varStats, cntUsedVarStats * sizeof(*varStats));
+        memset(varStats, 0, cnt * sizeof(*varStats));
+        cntUsedVarStats += cnt;
+        firstVarStatsLine = startLine;
+    }
+
+    int cnt = endLine - firstVarStatsLine + 1;
+    if (cnt > cntAllocVarStats)
+    {
+        varStats = (VarStats*) util_realloc(varStats, cnt, sizeof(*varStats));
+        cntAllocVarStats = cnt;
+    }
+    if (cnt > cntUsedVarStats)
+    {
+        memset(varStats + cntUsedVarStats, 0, (cnt - cntUsedVarStats) * sizeof(*varStats));
+        cntUsedVarStats = cnt;
+    }
+
+    varStats[startLine - firstVarStatsLine].numNew++;
+    varStats[endLine   - firstVarStatsLine].numDel++;
+    varStats[startLine - firstVarStatsLine].endLine = endLine;
+}
+
+// figure if can we can add a lexical scope for the variable
+// (this should exclude variables from inlined functions as there is
+//  no support for gathering stats from different files)
+bool VarStatistics::isLexicalScopeVar(symbol* sa)
+{
+    if (sa->lnoscopestart <= 0 || sa->lnoscopestart > sa->lnoscopeend)
+        return false;
+
+    // is it inside the function? Unfortunately we cannot verify the source file in case of inlining
+    if (sa->lnoscopestart < funcsym_p->Sfunc->Fstartline.Slinnum)
+        return false;
+    if (sa->lnoscopeend > funcsym_p->Sfunc->Fendline.Slinnum)
+        return false;
+
+    // verify that the variable does not violate the assumption that scopes are stacked inside
+    // each other (might happen with optimizations/inlining)
+    int start = (sa->lnoscopestart < firstVarStatsLine ? firstVarStatsLine : sa->lnoscopestart + 1);
+    int end   = firstVarStatsLine + cntUsedVarStats;
+    end = (sa->lnoscopeend < end ? sa->lnoscopeend : end);
+    for (int i = start; i < end; i++)
+        if (varStats[i - firstVarStatsLine].numNew || varStats[i - firstVarStatsLine].numDel)
+            return false;
+    return true;
+}
+
+// compare function to sort line offsets by line
+static int cmpLineOffsets(const void* off1, const void* off2)
+{
+    const LineOffset* loff1 = (const LineOffset*)off1;
+    const LineOffset* loff2 = (const LineOffset*)off2;
+
+    if (loff1->linnum == loff2->linnum)
+        return loff1->offset - loff2->offset;
+    return loff1->linnum - loff2->linnum;
+}
+
+// gather statistics about creation and destructions of variables that are
+//  used by the current function
+void VarStatistics::calcLexicalScope(Funcsym *s, symtab_t* symtab)
+{
+    // sort line records and remove duplicate lines
+    qsort(lineOffsets, cntUsedLineOffsets, sizeof(*lineOffsets), &cmpLineOffsets);
+    int j = 0;
+    for (int i = 1; i < cntUsedLineOffsets; i++)
+        if (lineOffsets[i].linnum > lineOffsets[j].linnum)
+            lineOffsets[++j] = lineOffsets[i];
+    cntUsedLineOffsets = j + 1;
+
+    cntUsedVarStats = 0;
+    if (cntAllocLexVars < symtab->top)
+    {
+        isLexVar = (bool*) util_realloc(isLexVar, symtab->top, sizeof(*isLexVar));
+        cntAllocLexVars = symtab->top;
+    }
+    memset(isLexVar, 0, symtab->top);
+
+    SYMIDX si;
+    for (si = 0; si < symtab->top; si++)
+    {
+        symbol *sa = symtab->tab[si];
+        isLexVar[si] = isLexicalScopeVar(sa);
+        if(isLexVar[si])
+            markVarStats(sa->lnoscopestart, sa->lnoscopeend);
+    }
+    // todo: optimize out multiple blocks for multiple variables added and removed at the same locations
+
+    Srcpos src = funcsym_p->Sfunc->Fstartline;
+    for (int i = 0; i < cntUsedVarStats; i++)
+        if (varStats[i].numDel > 0 || varStats[i].numNew > 0)
+        {
+            src.Slinnum = firstVarStatsLine + i;
+            varStats[i].offset = getLineOffset (src);
+        }
+
+    nextVarStatsLine = firstVarStatsLine;
+}
+
+targ_size_t VarStatistics::getLineOffset(Srcpos src)
+{
+    if (!src.Sfilename || !srcfile)
+        return 0;
+    if (src.Sfilename != srcfile && strcmp (src.Sfilename, srcfile) != 0)
+        return 0;
+    int idx = findLineIndex(src.Slinnum);
+    if (idx >= cntUsedLineOffsets || lineOffsets[idx].linnum < src.Slinnum)
+        return retoffset + retsize; // function length
+    return lineOffsets[idx].offset;
+}
+
+int VarStatistics::findLineIndex(unsigned line)
+{
+    int low = 0;
+    int high = cntUsedLineOffsets - 1;
+    while (low <= high)
+    {
+        int mid = (low + high) >> 1;
+        int ln = lineOffsets[mid].linnum;
+        if (line < ln)
+            high = mid - 1;
+        else if (line > ln)
+            low = mid + 1;
+        else
+            return mid;
+    }
+    return low;
+}
+
+void VarStatistics::recordLineOffset(Srcpos src, targ_size_t off)
+{
+    if (!src.Sfilename || !src.Slinnum)
+        return;
+    if (!srcfile)
+        srcfile = src.Sfilename;
+    if (srcfile != src.Sfilename && strcmp (srcfile, src.Sfilename) != 0)
+        return;
+
+    if (cntUsedLineOffsets > 0 && lineOffsets[cntUsedLineOffsets-1].linnum == src.Slinnum)
+    {
+        // optimize common case: new offset on same line, use minimum
+        if (off < lineOffsets[cntUsedLineOffsets-1].offset)
+            lineOffsets[cntUsedLineOffsets-1].offset = off;
+        return;
+    }
+    if (cntUsedLineOffsets >= cntAllocLineOffsets)
+    {
+        cntAllocLineOffsets = 2 * cntUsedLineOffsets + 16;
+        lineOffsets = (LineOffset*) util_realloc(lineOffsets, cntAllocLineOffsets, sizeof(*lineOffsets));
+    }
+    lineOffsets[cntUsedLineOffsets].linnum = src.Slinnum;
+    lineOffsets[cntUsedLineOffsets].offset = off;
+    cntUsedLineOffsets++;
+}

--- a/src/backend/varstats.h
+++ b/src/backend/varstats.h
@@ -1,0 +1,63 @@
+// Compiler implementation of the D programming language
+// Copyright (c) 2015-2015 by Digital Mars
+// All Rights Reserved
+// http://www.digitalmars.com
+// Written by Rainer Schuetze
+// Distributed under the Boost Software License, Version 1.0.
+// http://www.boost.org/LICENSE_1_0.txt
+
+/******************************************
+ * support for lexical scope of local variables
+ */
+
+#ifndef VARSTATS_H
+#define VARSTATS_H   1
+
+#include        "cc.h"
+
+// variable creation/destruction information per line
+struct VarStats
+{
+    int numNew;  // number of variables introduced at this line
+    int numDel;  // number of variables which are destroyed at this line
+    int endLine; // closing line for variables introduced at this line
+    int offset;  // code offset in function (only evaluated for lines that are the beginning or the end of a scope)
+};
+
+struct LineOffset
+{
+    unsigned linnum;
+    targ_size_t offset;
+};
+
+struct VarStatistics
+{
+    VarStatistics();
+
+    // statistics for the current functions
+    VarStats* varStats; // keeps information for the lines [firstVarStatsLine, firstVarStatsLine+cntUsedVarStats[
+    int cntAllocVarStats;
+    int cntUsedVarStats;
+    int firstVarStatsLine;
+
+    bool* isLexVar;       // is the variable handled? (variables from inlined functions usually excluded)
+    int cntAllocLexVars;
+    int nextVarStatsLine; // line not yet emitted during variable dump
+
+    LineOffset* lineOffsets;
+    int cntAllocLineOffsets;
+    int cntUsedLineOffsets;
+    const char* srcfile;  // only one file supported, no inline
+
+    void startFunction();
+    void recordLineOffset(Srcpos src, targ_size_t off);
+    targ_size_t getLineOffset(Srcpos src);
+    int findLineIndex(unsigned line);
+    void markVarStats(int startLine, int endLine);
+    bool isLexicalScopeVar(symbol* sa);
+    void calcLexicalScope(Funcsym *s, symtab_t* symtab);
+};
+
+extern VarStatistics varStats;
+
+#endif // VARSTATS_H

--- a/src/backend/varstats.h
+++ b/src/backend/varstats.h
@@ -56,6 +56,7 @@ struct VarStatistics
     void markVarStats(int startLine, int endLine);
     bool isLexicalScopeVar(symbol* sa);
     void calcLexicalScope(Funcsym *s, symtab_t* symtab);
+    void sanitizeLineOffsets();
 };
 
 extern VarStatistics varStats;

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -984,6 +984,7 @@ public:
     bool overlapped;                // if it is a field and has overlapping
     Dsymbol aliassym;               // if redone as alias to another symbol
     VarDeclaration lastVar;         // Linked list of variables for goto-skips-init detection
+    uint endlinnum;                 // line number of end of scope that this var lives in
 
     // When interpreting, these point to the value (NULL if value not determinable)
     // The index of this variable on the CTFE stack, -1 if not allocated
@@ -1741,6 +1742,13 @@ public:
 
         if (type.toBasetype().ty == Terror)
             errors = true;
+
+        if(sc.scopesym && !sc.scopesym.isAggregateDeclaration())
+        {
+            for (ScopeDsymbol sym = sc.scopesym; sym && endlinnum == 0;
+                 sym = sym.parent ? sym.parent.isScopeDsymbol() : null)
+                endlinnum = sym.endlinnum;
+        }
     }
 
     override final void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -247,6 +247,7 @@ public:
     bool overlapped;            // if it is a field and has overlapping
     Dsymbol *aliassym;          // if redone as alias to another symbol
     VarDeclaration *lastVar;    // Linked list of variables for goto-skips-init detection
+    unsigned endlinnum;         // line number of end of scope that this var lives in
 
     // When interpreting, these point to the value (NULL if value not determinable)
     // The index of this variable on the CTFE stack, -1 if not allocated

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1263,6 +1263,7 @@ extern (C++) class ScopeDsymbol : Dsymbol
 public:
     Dsymbols* members;          // all Dsymbol's in this scope
     DsymbolTable symtab;        // members[] sorted into table
+    uint endlinnum;             // the linnumber of the statement after the scope (0 if unknown)
 
 private:
     /// symbols whose members have been imported, i.e. imported modules and template mixins
@@ -1287,6 +1288,7 @@ public:
         //printf("ScopeDsymbol::syntaxCopy('%s')\n", toChars());
         ScopeDsymbol sds = s ? cast(ScopeDsymbol)s : new ScopeDsymbol(ident);
         sds.members = arraySyntaxCopy(members);
+        sds.endlinnum = endlinnum;
         return sds;
     }
 

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -290,6 +290,7 @@ class ScopeDsymbol : public Dsymbol
 public:
     Dsymbols *members;          // all Dsymbol's in this scope
     DsymbolTable *symtab;       // members[] sorted into table
+    unsigned endlinnum;         // the linnumber of the statement after the scope (0 if unknown)
 
 private:
     Dsymbols *importedScopes;   // imported Dsymbol's

--- a/src/func.d
+++ b/src/func.d
@@ -1430,6 +1430,8 @@ public:
             // Establish function scope
             auto ss = new ScopeDsymbol();
             ss.parent = sc.scopesym;
+            ss.loc = loc;
+            ss.endlinnum = endloc.linnum;
             Scope* sc2 = sc.push(ss);
             sc2.func = this;
             sc2.parent = this;
@@ -1636,6 +1638,8 @@ public:
                 // scope of out contract (need for vresult->semantic)
                 auto sym = new ScopeDsymbol();
                 sym.parent = sc2.scopesym;
+                sym.loc = loc;
+                sym.endlinnum = endloc.linnum;
                 scout = sc2.push(sym);
             }
 
@@ -1643,6 +1647,8 @@ public:
             {
                 auto sym = new ScopeDsymbol();
                 sym.parent = sc2.scopesym;
+                sym.loc = loc;
+                sym.endlinnum = endloc.linnum;
                 sc2 = sc2.push(sym);
 
                 auto ad2 = isMember2();
@@ -1958,6 +1964,8 @@ public:
                  */
                 auto sym = new ScopeDsymbol();
                 sym.parent = sc2.scopesym;
+                sym.loc = loc;
+                sym.endlinnum = endloc.linnum;
                 sc2 = sc2.push(sym);
                 sc2.flags = (sc2.flags & ~SCOPEcontract) | SCOPErequire;
 
@@ -5021,7 +5029,7 @@ public:
             Expression e = new IdentifierExp(Loc(), v.ident);
             e = new AddAssignExp(Loc(), e, new IntegerExp(1));
             e = new EqualExp(TOKnotequal, Loc(), e, new IntegerExp(1));
-            s = new IfStatement(Loc(), null, e, new ReturnStatement(Loc(), null), null);
+            s = new IfStatement(Loc(), null, e, new ReturnStatement(Loc(), null), null, Loc());
 
             sa.push(s);
             if (fbody)
@@ -5177,7 +5185,7 @@ public:
             Expression e = new IdentifierExp(Loc(), v.ident);
             e = new AddAssignExp(Loc(), e, new IntegerExp(-1));
             e = new EqualExp(TOKnotequal, Loc(), e, new IntegerExp(0));
-            s = new IfStatement(Loc(), null, e, new ReturnStatement(Loc(), null), null);
+            s = new IfStatement(Loc(), null, e, new ReturnStatement(Loc(), null), null, Loc());
 
             sa.push(s);
             if (fbody)

--- a/src/inline.d
+++ b/src/inline.d
@@ -581,7 +581,7 @@ public:
         //printf("ScopeStatement.doInlineAs!%s() %d\n", Result.stringof.ptr, s.statement.dim);
         auto r = doInlineAs!Result(s.statement, ids);
         static if (asStatements)
-            result = new ScopeStatement(s.loc, r);
+            result = new ScopeStatement(s.loc, r, s.endloc);
         else
             result = r;
     }
@@ -600,7 +600,7 @@ public:
 
         static if (asStatements)
         {
-            result = new IfStatement(s.loc, s.prm, econd, ifbody, elsebody);
+            result = new IfStatement(s.loc, s.prm, econd, ifbody, elsebody, s.endloc);
         }
         else
         {
@@ -1210,7 +1210,7 @@ public:
                     return null;
                 auto ifbody   = !s1 ? new ExpStatement(e.e1.loc, e.e1) : s1;
                 auto elsebody = !s2 ? new ExpStatement(e.e2.loc, e.e2) : s2;
-                return new IfStatement(exp.loc, null, e.econd, ifbody, elsebody);
+                return new IfStatement(exp.loc, null, e.econd, ifbody, elsebody, exp.loc);
             }
             if (exp.op == TOKcomma)
             {
@@ -2263,7 +2263,7 @@ void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration parent, Expre
                         new DtorExpStatement(callLoc, vthis.edtor, vthis)));
         }
 
-        sresult = new ScopeStatement(callLoc, new CompoundStatement(callLoc, as));
+        sresult = new ScopeStatement(callLoc, new CompoundStatement(callLoc, as), callLoc);
 
         static if (EXPANDINLINE_LOG)
             printf("\n[%s] %s expandInline sresult =\n%s\n",

--- a/src/parse.d
+++ b/src/parse.d
@@ -4935,7 +4935,7 @@ public:
                     Dsymbols* imports = parseImport();
                     s = new ImportStatement(loc, imports);
                     if (flags & PSscope)
-                        s = new ScopeStatement(loc, s);
+                        s = new ScopeStatement(loc, s, token.loc);
                     break;
                 }
                 goto Ldeclaration;
@@ -5022,7 +5022,7 @@ public:
                 else
                     s = new ExpStatement(loc, cast(Expression)null);
                 if (flags & PSscope)
-                    s = new ScopeStatement(loc, s);
+                    s = new ScopeStatement(loc, s, token.loc);
                 break;
             }
         case TOKenum:
@@ -5046,7 +5046,7 @@ public:
                 }
                 s = new ExpStatement(loc, d);
                 if (flags & PSscope)
-                    s = new ScopeStatement(loc, s);
+                    s = new ScopeStatement(loc, s, token.loc);
                 break;
             }
         case TOKmixin:
@@ -5071,7 +5071,7 @@ public:
                 Dsymbol d = parseMixin();
                 s = new ExpStatement(loc, d);
                 if (flags & PSscope)
-                    s = new ScopeStatement(loc, s);
+                    s = new ScopeStatement(loc, s, token.loc);
                 break;
             }
         case TOKlcurly:
@@ -5094,7 +5094,7 @@ public:
                     *pEndloc = token.loc;
                 s = new CompoundStatement(loc, statements);
                 if (flags & (PSscope | PScurlyscope))
-                    s = new ScopeStatement(loc, s);
+                    s = new ScopeStatement(loc, s, token.loc);
                 check(TOKrcurly, "compound statement");
                 lookingForElse = lookingForElseSave;
                 break;
@@ -5140,7 +5140,7 @@ public:
                     nextToken();
                 else
                     error("terminating ';' required after do-while statement");
-                s = new DoStatement(loc, _body, condition);
+                s = new DoStatement(loc, _body, condition, token.loc);
                 break;
             }
         case TOKfor:
@@ -5392,7 +5392,7 @@ public:
                 else
                     elsebody = null;
                 if (condition && ifbody)
-                    s = new IfStatement(loc, param, condition, ifbody, elsebody);
+                    s = new IfStatement(loc, param, condition, ifbody, elsebody, token.loc);
                 else
                     s = null; // don't propagate parsing errors
                 break;
@@ -5467,7 +5467,7 @@ public:
             }
             s = new ConditionalStatement(loc, cond, ifbody, elsebody);
             if (flags & PSscope)
-                s = new ScopeStatement(loc, s);
+                s = new ScopeStatement(loc, s, token.loc);
             break;
 
         case TOKpragma:
@@ -5552,7 +5552,7 @@ public:
                 }
                 else
                     s = parseStatement(PSsemi | PScurlyscope);
-                s = new ScopeStatement(loc, s);
+                s = new ScopeStatement(loc, s, token.loc);
 
                 if (last)
                 {
@@ -5585,7 +5585,7 @@ public:
                 }
                 else
                     s = parseStatement(PSsemi | PScurlyscope);
-                s = new ScopeStatement(loc, s);
+                s = new ScopeStatement(loc, s, token.loc);
                 s = new DefaultStatement(loc, s);
                 break;
             }
@@ -5691,13 +5691,14 @@ public:
             {
                 Expression exp;
                 Statement _body;
+                Loc endloc = loc;
 
                 nextToken();
                 check(TOKlparen);
                 exp = parseExpression();
                 check(TOKrparen);
-                _body = parseStatement(PSscope);
-                s = new WithStatement(loc, exp, _body);
+                _body = parseStatement(PSscope, null, &endloc);
+                s = new WithStatement(loc, exp, _body, endloc);
                 break;
             }
         case TOKtry:
@@ -5870,7 +5871,7 @@ public:
                 Dsymbols* imports = parseImport();
                 s = new ImportStatement(loc, imports);
                 if (flags & PSscope)
-                    s = new ScopeStatement(loc, s);
+                    s = new ScopeStatement(loc, s, token.loc);
                 break;
             }
         case TOKtemplate:

--- a/src/parse.d
+++ b/src/parse.d
@@ -4803,7 +4803,7 @@ public:
      * Input:
      *      flags   PSxxxx
      * Output:
-     *      pEndloc if { ... statements ... }, store location of closing brace
+     *      pEndloc if { ... statements ... }, store location of closing brace, otherwise loc of first token of next statement
      */
     Statement parseStatement(int flags, const(char)** endPtr = null, Loc* pEndloc = null)
     {
@@ -5091,7 +5091,10 @@ public:
                     *endPtr = token.ptr;
                 endloc = token.loc;
                 if (pEndloc)
+                {
                     *pEndloc = token.loc;
+                    pEndloc = null; // don't set it again
+                }
                 s = new CompoundStatement(loc, statements);
                 if (flags & (PSscope | PScurlyscope))
                     s = new ScopeStatement(loc, s, token.loc);
@@ -5892,6 +5895,8 @@ public:
             s = null;
             break;
         }
+        if (pEndloc)
+            *pEndloc = token.loc;
         return s;
     }
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -245,7 +245,7 @@ BACK_OBJS = go.o gdag.o gother.o gflow.o gloop.o var.o el.o \
 	cgcod.o cod5.o outbuf.o compress.o \
 	bcomplex.o aa.o ti_achar.o \
 	ti_pvoid.o pdata.o cv8.o backconfig.o \
-	divcoeff.o dwarf.o dwarfeh.o \
+	divcoeff.o dwarf.o dwarfeh.o varstats.o \
 	ph2.o util2.o eh.o tk.o strtold.o \
 	$(TARGET_OBJS)
 
@@ -293,6 +293,7 @@ BACK_SRC = \
 	$C/ti_pvoid.c $C/platform_stub.c $C/code_x86.h $C/code_stub.h \
 	$C/machobj.c $C/mscoffobj.c \
 	$C/xmm.h $C/obj.h $C/pdata.c $C/cv8.c $C/backconfig.c $C/divcoeff.c \
+	$C/varstats.c $C/varstats.h \
 	$C/md5.c $C/md5.h \
 	$C/ph2.c $C/util2.c $C/dwarfeh.c \
 	$(TARGET_CH)

--- a/src/statement.d
+++ b/src/statement.d
@@ -1459,7 +1459,7 @@ public:
                                 a.push((*statements)[j]);
                             }
                             Statement _body = new CompoundStatement(Loc(), a);
-                            _body = new ScopeStatement(Loc(), _body);
+                            _body = new ScopeStatement(Loc(), _body, Loc());
 
                             Identifier id = Identifier.generateId("__o");
 
@@ -1700,16 +1700,18 @@ extern (C++) final class ScopeStatement : Statement
 {
 public:
     Statement statement;
+    Loc endloc;                 // location of closing curly bracket
 
-    extern (D) this(Loc loc, Statement s)
+    extern (D) this(Loc loc, Statement s, Loc endloc)
     {
         super(loc);
         this.statement = s;
+        this.endloc = endloc;
     }
 
     override Statement syntaxCopy()
     {
-        return new ScopeStatement(loc, statement ? statement.syntaxCopy() : null);
+        return new ScopeStatement(loc, statement ? statement.syntaxCopy() : null, endloc);
     }
 
     override ScopeStatement isScopeStatement()
@@ -1732,6 +1734,7 @@ public:
         {
             sym = new ScopeDsymbol();
             sym.parent = sc.scopesym;
+            sym.endlinnum = endloc.linnum;
             sc = sc.push(sym);
 
             Statements* a = statement.flatten(sc);
@@ -1843,19 +1846,22 @@ extern (C++) final class DoStatement : Statement
 public:
     Statement _body;
     Expression condition;
+    Loc endloc;                 // location of ';' after while
 
-    extern (D) this(Loc loc, Statement b, Expression c)
+    extern (D) this(Loc loc, Statement b, Expression c, Loc endloc)
     {
         super(loc);
         _body = b;
         condition = c;
+        this.endloc = endloc;
     }
 
     override Statement syntaxCopy()
     {
         return new DoStatement(loc,
             _body ? _body.syntaxCopy() : null,
-            condition.syntaxCopy());
+            condition.syntaxCopy(),
+            endloc);
     }
 
     override Statement semantic(Scope* sc)
@@ -1961,7 +1967,7 @@ public:
             _init = null;
             ainit.push(this);
             Statement s = new CompoundStatement(loc, ainit);
-            s = new ScopeStatement(loc, s);
+            s = new ScopeStatement(loc, s, endloc);
             s = s.semantic(sc);
             if (!s.isErrorStatement())
             {
@@ -1975,6 +1981,7 @@ public:
 
         auto sym = new ScopeDsymbol();
         sym.parent = sc.scopesym;
+        sym.endlinnum = endloc.linnum;
         sc = sc.push(sym);
 
         sc.noctor++;
@@ -2340,7 +2347,7 @@ public:
 
                 st.push(_body.syntaxCopy());
                 s = new CompoundStatement(loc, st);
-                s = new ScopeStatement(loc, s);
+                s = new ScopeStatement(loc, s, endloc);
                 statements.push(s);
             }
 
@@ -2357,6 +2364,7 @@ public:
 
         sym = new ScopeDsymbol();
         sym.parent = sc.scopesym;
+        sym.endlinnum = endloc.linnum;
         auto sc2 = sc.push(sym);
 
         sc2.noctor++;
@@ -3364,14 +3372,16 @@ public:
     Statement ifbody;
     Statement elsebody;
     VarDeclaration match;   // for MatchExpression results
+    Loc endloc;                 // location of closing curly bracket
 
-    extern (D) this(Loc loc, Parameter prm, Expression condition, Statement ifbody, Statement elsebody)
+    extern (D) this(Loc loc, Parameter prm, Expression condition, Statement ifbody, Statement elsebody, Loc endloc)
     {
         super(loc);
         this.prm = prm;
         this.condition = condition;
         this.ifbody = ifbody;
         this.elsebody = elsebody;
+        this.endloc = endloc;
     }
 
     override Statement syntaxCopy()
@@ -3380,7 +3390,8 @@ public:
             prm ? prm.syntaxCopy() : null,
             condition.syntaxCopy(),
             ifbody ? ifbody.syntaxCopy() : null,
-            elsebody ? elsebody.syntaxCopy() : null);
+            elsebody ? elsebody.syntaxCopy() : null,
+            endloc);
     }
 
     override Statement semantic(Scope* sc)
@@ -3396,6 +3407,7 @@ public:
 
         auto sym = new ScopeDsymbol();
         sym.parent = sc.scopesym;
+        sym.endlinnum = endloc.linnum;
         Scope* scd = sc.push(sym);
         if (prm)
         {
@@ -5077,17 +5089,19 @@ public:
     Expression exp;
     Statement _body;
     VarDeclaration wthis;
+    Loc endloc;
 
-    extern (D) this(Loc loc, Expression exp, Statement _body)
+    extern (D) this(Loc loc, Expression exp, Statement _body, Loc endloc)
     {
         super(loc);
         this.exp = exp;
         this._body = _body;
+        this.endloc = endloc;
     }
 
     override Statement syntaxCopy()
     {
-        return new WithStatement(loc, exp.syntaxCopy(), _body ? _body.syntaxCopy() : null);
+        return new WithStatement(loc, exp.syntaxCopy(), _body ? _body.syntaxCopy() : null, endloc);
     }
 
     override Statement semantic(Scope* sc)
@@ -5106,6 +5120,7 @@ public:
         {
             sym = new WithScopeSymbol(this);
             sym.parent = sc.scopesym;
+            sym.endlinnum = endloc.linnum;
         }
         else if (exp.op == TOKtype)
         {
@@ -5117,6 +5132,7 @@ public:
             }
             sym = new WithScopeSymbol(this);
             sym.parent = sc.scopesym;
+            sym.endlinnum = endloc.linnum;
         }
         else
         {
@@ -5140,6 +5156,7 @@ public:
 
                 sym = new WithScopeSymbol(this);
                 sym.parent = sc.scopesym;
+                sym.endlinnum = endloc.linnum;
             }
             else if (t.ty == Tstruct)
             {
@@ -5157,7 +5174,7 @@ public:
                     auto tmp = copyToTemp(0, "__withtmp", exp);
                     auto es = new ExpStatement(loc, tmp);
                     this.exp = new VarExp(loc, tmp);
-                    Statement ss = new ScopeStatement(loc, new CompoundStatement(loc, es, this));
+                    Statement ss = new ScopeStatement(loc, new CompoundStatement(loc, es, this), endloc);
                     return ss.semantic(sc);
                 }
                 Expression e = exp.addressOf();
@@ -5168,6 +5185,7 @@ public:
                 // Need to set the scope to make use of resolveAliasThis
                 sym.setScope(sc);
                 sym.parent = sc.scopesym;
+                sym.endlinnum = endloc.linnum;
             }
             else
             {
@@ -5593,7 +5611,7 @@ public:
 
                 e = new VarExp(Loc(), v);
                 e = new NotExp(Loc(), e);
-                *sfinally = new IfStatement(Loc(), null, e, s, null);
+                *sfinally = new IfStatement(Loc(), null, e, s, null, Loc());
 
                 break;
             }
@@ -5750,7 +5768,7 @@ public:
              * so we can patch it later, and add it to a 'look at this later'
              * list.
              */
-            auto ss = new ScopeStatement(loc, this);
+            auto ss = new ScopeStatement(loc, this, loc);
             sc.fes.gotos.push(ss); // 'look at this later' list
             return ss;
         }

--- a/src/statement.d
+++ b/src/statement.d
@@ -2121,6 +2121,7 @@ public:
         {
             // Bugzilla 14653: Extend the life of rvalue aggregate till the end of foreach.
             vinit = copyToTemp(STCrvalue, "__aggr", aggr);
+            vinit.endlinnum = endloc.linnum;
             vinit.semantic(sc);
             aggr = new VarExp(aggr.loc, vinit);
         }

--- a/src/statement.h
+++ b/src/statement.h
@@ -229,8 +229,9 @@ class ScopeStatement : public Statement
 {
 public:
     Statement *statement;
+    Loc endloc;                 // location of closing curly bracket
 
-    ScopeStatement(Loc loc, Statement *s);
+    ScopeStatement(Loc loc, Statement *s, Loc endloc);
     Statement *syntaxCopy();
     ScopeStatement *isScopeStatement() { return this; }
     ReturnStatement *isReturnStatement();
@@ -262,8 +263,9 @@ class DoStatement : public Statement
 public:
     Statement *_body;
     Expression *condition;
+    Loc endloc;                 // location of ';' after while
 
-    DoStatement(Loc loc, Statement *b, Expression *c);
+    DoStatement(Loc loc, Statement *b, Expression *c, Loc endloc);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     bool hasBreak();
@@ -353,10 +355,11 @@ public:
     Expression *condition;
     Statement *ifbody;
     Statement *elsebody;
+    Loc endloc;                 // location of closing curly bracket
 
     VarDeclaration *match;      // for MatchExpression results
 
-    IfStatement(Loc loc, Parameter *prm, Expression *condition, Statement *ifbody, Statement *elsebody);
+    IfStatement(Loc loc, Parameter *prm, Expression *condition, Statement *ifbody, Statement *elsebody, Loc endloc);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     IfStatement *isIfStatement() { return this; }
@@ -564,8 +567,9 @@ public:
     Expression *exp;
     Statement *_body;
     VarDeclaration *wthis;
+    Loc endloc;
 
-    WithStatement(Loc loc, Expression *exp, Statement *body);
+    WithStatement(Loc loc, Expression *exp, Statement *body, Loc endloc);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
 

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -259,6 +259,8 @@ Symbol *toSymbol(Dsymbol *s)
             type_setmangle(&t, m);
             s->Stype = t;
 
+            s->lnoscopestart = vd->loc.linnum;
+            s->lnoscopeend = vd->endlinnum;
             result = s;
         }
 

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -79,6 +79,7 @@
     <ClCompile Include="..\backend\pdata.c" />
     <ClCompile Include="..\backend\ph2.c" />
     <ClCompile Include="..\backend\util2.c" />
+    <ClCompile Include="..\backend\varstats.c" />
     <ClCompile Include="..\e2ir.c" />
     <ClCompile Include="..\eh.c" />
     <ClCompile Include="..\glue.c" />
@@ -187,6 +188,7 @@ popd</Command>
     <ClInclude Include="..\aliasthis.h" />
     <ClInclude Include="..\arraytypes.h" />
     <ClInclude Include="..\attrib.h" />
+    <ClInclude Include="..\backend\varstats.h" />
     <ClInclude Include="..\complex_t.h" />
     <ClInclude Include="..\cond.h" />
     <ClInclude Include="..\declaration.h" />

--- a/src/vcbuild/dmd_backend.vcxproj.filters
+++ b/src/vcbuild/dmd_backend.vcxproj.filters
@@ -237,6 +237,9 @@
     <ClCompile Include="..\backend\pdata.c">
       <Filter>src\backend</Filter>
     </ClCompile>
+    <ClCompile Include="..\backend\varstats.c">
+      <Filter>src\backend</Filter>
+    </ClCompile>
     <ClCompile Include="..\objc_glue_stubs.c">
       <Filter>src</Filter>
     </ClCompile>
@@ -411,6 +414,9 @@
       <Filter>src\backend</Filter>
     </ClInclude>
     <ClInclude Include="..\backend\type.h">
+      <Filter>src\backend</Filter>
+    </ClInclude>
+    <ClInclude Include="..\backend\varstats.h">
       <Filter>src\backend</Filter>
     </ClInclude>
     <ClInclude Include="..\tk\filespec.h">

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -172,7 +172,7 @@ BACKOBJ= go.obj gdag.obj gother.obj gflow.obj gloop.obj var.obj el.obj \
 	cgcod.obj cod1.obj cod2.obj cod3.obj cod4.obj cod5.obj outbuf.obj \
 	bcomplex.obj ptrntab.obj aa.obj ti_achar.obj md5.obj \
 	ti_pvoid.obj mscoffobj.obj pdata.obj cv8.obj backconfig.obj \
-	divcoeff.obj dwarf.obj compress.obj \
+	divcoeff.obj dwarf.obj compress.obj varstats.obj \
 	ph2.obj util2.obj eh.obj tk.obj \
 
 # Root package
@@ -218,7 +218,7 @@ BACKSRC= $C\cdef.h $C\cc.h $C\oper.h $C\ty.h $C\optabgen.c \
 	$C\strtold.c $C\aa.h $C\aa.c $C\tinfo.h $C\ti_achar.c \
 	$C\md5.h $C\md5.c $C\ti_pvoid.c $C\xmm.h $C\ph2.c $C\util2.c \
 	$C\mscoffobj.c $C\obj.h $C\pdata.c $C\cv8.c $C\backconfig.c \
-	$C\divcoeff.c $C\dwarfeh.c \
+	$C\divcoeff.c $C\dwarfeh.c $C\varstats.c $C\varstats.h \
 	$C\backend.txt
 
 # Toolkit
@@ -579,6 +579,9 @@ util2.obj : $C\util2.c
 
 var.obj : $C\var.c optab.c
 	$(CC) -c $(MFLAGS) -I. $C\var
+
+varstats.obj : $C\varstats.c
+	$(CC) -c $(MFLAGS) -I. $C\varstats
 
 
 tk.obj : tk.c


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=3657

This pull request consists of two parts:
- save the end of a scope block during parsing 
- reconstruct life time information of variables from line information

~~This is implemented for Win32 only, but should be adaptable to Win64 pretty easily.~~ This is implemented for Win32 and Win64, I don't know about the other platforms, though.
