### PR TITLE
Issue 8903 - Bad code for enum array members

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -50,6 +50,7 @@ elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
 elem *eval_Darray(IRState *irs, Expression *e, bool alwaysCopy = false);
 elem *array_toPtr(Type *t, elem *e);
 elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi);
+elem *ExpressionsToStaticArray(IRState *irs, Loc loc, Expressions *exps, symbol **psym);
 
 #define el_setLoc(e,loc)        ((e)->Esrcpos.Sfilename = (char *)(loc).filename, \
                                  (e)->Esrcpos.Slinnum = (loc).linnum)
@@ -4832,7 +4833,6 @@ elem *tree_insert(Elems *args, size_t low, size_t high)
 elem *ArrayLiteralExp::toElem(IRState *irs)
 {   elem *e;
     size_t dim;
-    elem *earg = NULL;
 
     //printf("ArrayLiteralExp::toElem() %s, type = %s\n", toChars(), type->toChars());
     Type *tb = type->toBasetype();
@@ -4840,7 +4840,13 @@ elem *ArrayLiteralExp::toElem(IRState *irs)
     {   // Convert void[n] to ubyte[n]
         tb = TypeSArray::makeType(loc, Type::tuns8, ((TypeSArray *)tb)->dim->toUInteger());
     }
-    if (elements)
+    if (tb->ty == Tsarray && elements && elements->dim)
+    {
+        Symbol *sdata;
+        e = ExpressionsToStaticArray(irs, loc, elements, &sdata);
+        e = el_combine(e, el_ptr(sdata));
+    }
+    else if (elements)
     {
         /* Instead of passing the initializers on the stack, allocate the
          * array and assign the members inline.
@@ -4903,7 +4909,6 @@ elem *ArrayLiteralExp::toElem(IRState *irs)
     }
 
     el_setLoc(e,loc);
-    e = el_combine(earg, e);
     return e;
 }
 


### PR DESCRIPTION
There is no special casing for static array typed array literals, but there should be.  They should be created on the stack, then indexed.  This is in line with `T[N]` behaving like `struct { T[N] }`.

No behavior change, performance only.

https://d.puremagic.com/issues/show_bug.cgi?id=8903
