### PR TITLE
Issue 8848 - Array literals and AA literals are rejected as template value parameters

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -4749,12 +4749,6 @@ void TemplateValueParameter::semantic(Scope *sc, TemplateParameters *parameters)
         return;
     }
     valType = valType->semantic(loc, sc);
-    if (!(valType->isintegral() || valType->isfloating() || valType->isString()) &&
-        valType->ty != Tident)
-    {
-        if (valType != Type::terror)
-            error(loc, "arithmetic/string type expected for value-parameter, not %s", valType->toChars());
-    }
 
 #if 0   // defer semantic analysis to arg match
     if (specValue)

--- a/test/fail_compilation/fail128.d
+++ b/test/fail_compilation/fail128.d
@@ -1,8 +1,0 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail128.d(8): Error: arithmetic/string type expected for value-parameter, not void*
----
-*/
-
-template T(void *p) {}

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2508,6 +2508,16 @@ void test9977()
 }
 
 /******************************************/
+
+enum T8848a(int[] a) = a;
+enum T8848b(int[int] b) = b;
+enum T8848c(void* c) = c;
+
+static assert(T8848a!([1,2,3]) == [1,2,3]);
+static assert(T8848b!([1:2,3:4]) == [1:2,3:4]);
+static assert(T8848c!(null) == null);
+
+/******************************************/
 // 9990
 
 auto initS9990() { return "hi"; }


### PR DESCRIPTION
The check is unnecessary as pretty much everything can be passed, and expressions that can't will be detected when they are interpreted.

https://d.puremagic.com/issues/show_bug.cgi?id=8848
