### PR TITLE
[REG2.061] Issue 11563 - Module dependency cycle causes unrelated template instantiations to fail

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -369,10 +369,10 @@ void ClassDeclaration::semantic(Scope *sc)
                         goto L7;
                     }
                 }
-                if (!tc->sym->symtab || tc->sym->sizeok == SIZEOKnone)
-                {   // Try to resolve forward reference
-                    if (/*doAncestorsSemantic == SemanticIn &&*/ tc->sym->scope)
-                        tc->sym->semantic(NULL);
+                if (tc->sym->scope)
+                {
+                    // Try to resolve forward reference
+                    tc->sym->semantic(NULL);
                 }
 
                 if (tc->sym->symtab && tc->sym->scope == NULL)
@@ -443,10 +443,10 @@ void ClassDeclaration::semantic(Scope *sc)
                     error("inherits from duplicate interface %s", b2->base->toChars());
             }
 
-            if (!tc->sym->symtab)
-            {   // Try to resolve forward reference
-                if (/*doAncestorsSemantic == SemanticIn &&*/ tc->sym->scope)
-                    tc->sym->semantic(NULL);
+            if (tc->sym->scope)
+            {
+                // Try to resolve forward reference
+                tc->sym->semantic(NULL);
             }
 
             b->base = tc->sym;
@@ -1350,10 +1350,10 @@ void InterfaceDeclaration::semantic(Scope *sc)
                 baseclasses->remove(i);
                 continue;
             }
-            if (!b->base->symtab)
-            {   // Try to resolve forward reference
-                if (doAncestorsSemantic == SemanticIn && b->base->scope)
-                    b->base->semantic(NULL);
+            if (b->base->scope)
+            {
+                // Try to resolve forward reference
+                b->base->semantic(NULL);
             }
             if (!b->base->symtab || b->base->scope || b->base->inuse)
             {

--- a/test/compilable/imports/test11563core_bitop.d
+++ b/test/compilable/imports/test11563core_bitop.d
@@ -1,0 +1,1 @@
+module test11563core_bitop;

--- a/test/compilable/imports/test11563std_array.d
+++ b/test/compilable/imports/test11563std_array.d
@@ -1,0 +1,6 @@
+module imports.test11563std_array;
+
+void popFront(S)(ref S str)// @trusted pure nothrow
+{
+    import imports.test11563core_bitop;
+}

--- a/test/compilable/imports/test11563std_range.d
+++ b/test/compilable/imports/test11563std_range.d
@@ -1,0 +1,12 @@
+module imports.test11563std_range;
+
+public import imports.test11563std_array;
+
+template isInputRange(R)
+{
+    enum bool isInputRange = is(typeof(
+    {
+        R r = void;
+        r.popFront();
+    }));
+}

--- a/test/compilable/imports/test11563std_traits.d
+++ b/test/compilable/imports/test11563std_traits.d
@@ -1,0 +1,22 @@
+module imports.test11563std_traits;
+
+import imports.test11563std_range;
+
+bool startsWith(R1, R2)(R1 doesThisStart, R2 withThis)
+if (isInputRange!R1)
+{
+    return true;
+}
+
+template moduleName(alias T)
+{
+    static if (T.stringof.startsWith("module "))
+    {
+        enum moduleName = "b";
+    }
+    else
+    {
+        pragma(msg, "--error--");
+    }
+}
+

--- a/test/compilable/test11563.d
+++ b/test/compilable/test11563.d
@@ -1,0 +1,9 @@
+import imports.test11563std_traits;
+
+interface J : I {} // comment out to let compilation succeed
+
+struct A { }
+pragma(msg, moduleName!A);
+
+
+interface I {}

--- a/test/fail_compilation/diag9210a.d
+++ b/test/fail_compilation/diag9210a.d
@@ -4,7 +4,6 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/imports/diag9210stdcomplex.d(13): Error: template instance Complex!real does not match template declaration Complex(T) if (isFloatingPoint!T)
 fail_compilation/imports/diag9210b.d(6): Error: undefined identifier A
 ---
 */


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11563

Using `!b->base->symtab` seems an old way to detect forward reference of base interfaces. Instead use `b->base->scope` for that.
