### PR TITLE
remove dependence on MATCHnomatch == 0

### DIFF
--- a/src/aliasthis.c
+++ b/src/aliasthis.c
@@ -110,7 +110,7 @@ void AliasThis::semantic(Scope *sc)
         {
             Type *t = d->type;
             assert(t);
-            if (ad->type->implicitConvTo(t))
+            if (ad->type->implicitConvTo(t) > MATCHnomatch)
             {
                 ::error(loc, "alias this is not reachable as %s already converts to %s", ad->toChars(), t->toChars());
             }

--- a/src/class.c
+++ b/src/class.c
@@ -1064,8 +1064,8 @@ FuncDeclaration *ClassDeclaration::findFunc(Identifier *ident, TypeFunction *tf)
 
                 {
                 // Function type matcing: exact > covariant
-                int m1 = tf->equals(fd     ->type) ? MATCHexact : MATCHnomatch;
-                int m2 = tf->equals(fdmatch->type) ? MATCHexact : MATCHnomatch;
+                MATCH m1 = tf->equals(fd     ->type) ? MATCHexact : MATCHnomatch;
+                MATCH m2 = tf->equals(fdmatch->type) ? MATCHexact : MATCHnomatch;
                 if (m1 > m2)
                     goto Lfd;
                 else if (m1 < m2)
@@ -1073,8 +1073,8 @@ FuncDeclaration *ClassDeclaration::findFunc(Identifier *ident, TypeFunction *tf)
                 }
 
                 {
-                int m1 = (tf->mod == fd     ->type->mod) ? MATCHexact : MATCHnomatch;
-                int m2 = (tf->mod == fdmatch->type->mod) ? MATCHexact : MATCHnomatch;
+                MATCH m1 = (tf->mod == fd     ->type->mod) ? MATCHexact : MATCHnomatch;
+                MATCH m2 = (tf->mod == fdmatch->type->mod) ? MATCHexact : MATCHnomatch;
                 if (m1 > m2)
                     goto Lfd;
                 else if (m1 < m2)
@@ -1083,8 +1083,8 @@ FuncDeclaration *ClassDeclaration::findFunc(Identifier *ident, TypeFunction *tf)
 
                 {
                 // The way of definition: non-mixin > mixin
-                int m1 = fd     ->parent->isClassDeclaration() ? MATCHexact : MATCHnomatch;
-                int m2 = fdmatch->parent->isClassDeclaration() ? MATCHexact : MATCHnomatch;
+                MATCH m1 = fd     ->parent->isClassDeclaration() ? MATCHexact : MATCHnomatch;
+                MATCH m2 = fdmatch->parent->isClassDeclaration() ? MATCHexact : MATCHnomatch;
                 if (m1 > m2)
                     goto Lfd;
                 else if (m1 < m2)

--- a/src/expression.c
+++ b/src/expression.c
@@ -1415,7 +1415,7 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             {
                 //printf("\t\tvarargs == 2, p->type = '%s'\n", p->type->toChars());
                 MATCH m;
-                if ((m = arg->implicitConvTo(p->type)) != MATCHnomatch)
+                if ((m = arg->implicitConvTo(p->type)) > MATCHnomatch)
                 {
                     if (p->type->nextOf() && arg->implicitConvTo(p->type->nextOf()) >= m)
                         goto L2;
@@ -6728,7 +6728,7 @@ Expression *IsExp::semantic(Scope *sc)
         MATCH m = targ->deduceType(sc, tspec, parameters, &dedtypes);
         //printf("targ: %s\n", targ->toChars());
         //printf("tspec: %s\n", tspec->toChars());
-        if (m == MATCHnomatch ||
+        if (m <= MATCHnomatch ||
             (m != MATCHexact && tok == TOKequal))
         {
             goto Lno;
@@ -6749,7 +6749,7 @@ Expression *IsExp::semantic(Scope *sc)
                 Declaration *s = NULL;
 
                 m = tp->matchArg(loc, sc, &tiargs, i, parameters, &dedtypes, &s);
-                if (m == MATCHnomatch)
+                if (m <= MATCHnomatch)
                     goto Lno;
                 s->semantic(sc);
                 if (sc->sd)

--- a/src/func.c
+++ b/src/func.c
@@ -2676,7 +2676,7 @@ MATCH FuncDeclaration::leastAsSpecialized(FuncDeclaration *g)
     }
 
     MATCH m = (MATCH) tg->callMatch(NULL, &args, 1);
-    if (m)
+    if (m > MATCHnomatch)
     {
         /* A variadic parameter list is less specialized than a
          * non-variadic one.
@@ -2750,7 +2750,7 @@ FuncDeclaration *resolveFuncCall(Loc loc, Scope *sc, Dsymbol *s,
             m.lastf->functionSemantic();
         return m.lastf;
     }
-    if (m.last != MATCHnomatch && (flags & 2) && !tthis && m.lastf->needThis())
+    if (m.last > MATCHnomatch && (flags & 2) && !tthis && m.lastf->needThis())
     {
         return m.lastf;
     }
@@ -2759,7 +2759,7 @@ Lerror:
     /* Failed to find a best match.
      * Do nothing or print error.
      */
-    if (m.last == MATCHnomatch && (flags & 1))
+    if (m.last <= MATCHnomatch && (flags & 1))
     {   // if do not print error messages
         return NULL;    // no match
     }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4171,7 +4171,7 @@ MATCH TypeSArray::implicitConvTo(Type *to)
         if (!MODimplicitConv(next->mod, tp->next->mod))
             return MATCHnomatch;
 
-        if (tp->next->ty == Tvoid || next->constConv(tp->next) != MATCHnomatch)
+        if (tp->next->ty == Tvoid || next->constConv(tp->next) > MATCHnomatch)
         {
             return MATCHconvert;
         }
@@ -4192,7 +4192,7 @@ MATCH TypeSArray::implicitConvTo(Type *to)
         }
 
         MATCH m = next->constConv(ta->next);
-        if (m != MATCHnomatch)
+        if (m > MATCHnomatch)
         {
             return MATCHconvert;
         }
@@ -4498,7 +4498,7 @@ MATCH TypeDArray::implicitConvTo(Type *to)
         }
 
         MATCH m = next->constConv(ta->next);
-        if (m != MATCHnomatch)
+        if (m > MATCHnomatch)
         {
             if (m == MATCHexact && mod != to->mod)
                 m = MATCHconst;
@@ -4850,7 +4850,7 @@ MATCH TypeAArray::implicitConvTo(Type *to)
 
         MATCH m = next->constConv(ta->next);
         MATCH mi = index->constConv(ta->index);
-        if (m != MATCHnomatch && mi != MATCHnomatch)
+        if (m > MATCHnomatch && mi > MATCHnomatch)
         {
             return MODimplicitConv(mod, to->mod) ? MATCHconst : MATCHnomatch;
         }
@@ -5018,7 +5018,7 @@ MATCH TypePointer::implicitConvTo(Type *to)
         }
 
         MATCH m = next->constConv(tp->next);
-        if (m != MATCHnomatch)
+        if (m > MATCHnomatch)
         {
             if (m == MATCHexact && mod != to->mod)
                 m = MATCHconst;
@@ -8446,12 +8446,12 @@ MATCH TypeStruct::implicitConvTo(Type *to)
                         ;
                     else if (v->offset == offset)
                     {
-                        if (m)
+                        if (m > MATCHnomatch)
                             continue;
                     }
                     else
                     {
-                        if (!m)
+                        if (m <= MATCHnomatch)
                             return m;
                     }
 
@@ -8465,7 +8465,7 @@ MATCH TypeStruct::implicitConvTo(Type *to)
                     MATCH mf = tvf->implicitConvTo(tv);
                     //printf("\t%s => %s, match = %d\n", v->type->toChars(), tv->toChars(), mf);
 
-                    if (mf == MATCHnomatch)
+                    if (mf <= MATCHnomatch)
                         return mf;
                     if (mf < m)         // if field match is worse
                         m = mf;
@@ -8987,7 +8987,7 @@ MATCH TypeClass::implicitConvTo(Type *to)
 {
     //printf("TypeClass::implicitConvTo(to = '%s') %s\n", to->toChars(), toChars());
     MATCH m = constConv(to);
-    if (m != MATCHnomatch)
+    if (m > MATCHnomatch)
         return m;
 
     ClassDeclaration *cdto = to->isClassHandle();
@@ -9466,7 +9466,7 @@ MATCH TypeNull::implicitConvTo(Type *to)
     //printf("from: %s\n", toChars());
     //printf("to  : %s\n", to->toChars());
     MATCH m = Type::implicitConvTo(to);
-    if (m)
+    if (m != MATCHnomatch)
         return m;
 
     // NULL implicitly converts to any pointer type or dynamic array

--- a/src/opover.c
+++ b/src/opover.c
@@ -562,7 +562,7 @@ Expression *BinExp::op_overload(Scope *sc)
                     m.nextf->type->toChars(),
                     m.lastf->toChars());
         }
-        else if (m.last == MATCHnomatch)
+        else if (m.last <= MATCHnomatch)
         {
             m.lastf = m.anyf;
             if (tiargs)
@@ -576,7 +576,7 @@ Expression *BinExp::op_overload(Scope *sc)
             // Rewrite (e1 ++ e2) as e1.postinc()
             // Rewrite (e1 -- e2) as e1.postdec()
             e = build_overload(loc, sc, e1, NULL, m.lastf ? m.lastf : s);
-        else if (lastf && m.lastf == lastf || !s_r && m.last == MATCHnomatch)
+        else if (lastf && m.lastf == lastf || !s_r && m.last <= MATCHnomatch)
             // Rewrite (e1 op e2) as e1.opfunc(e2)
             e = build_overload(loc, sc, e1, e2, m.lastf ? m.lastf : s);
         else
@@ -638,13 +638,13 @@ L1:
                         m.nextf->type->toChars(),
                         m.lastf->toChars());
             }
-            else if (m.last == MATCHnomatch)
+            else if (m.last <= MATCHnomatch)
             {
                 m.lastf = m.anyf;
             }
 
             Expression *e;
-            if (lastf && m.lastf == lastf || !s && m.last == MATCHnomatch)
+            if (lastf && m.lastf == lastf || !s && m.last <= MATCHnomatch)
                 // Rewrite (e1 op e2) as e1.opfunc_r(e2)
                 e = build_overload(loc, sc, e1, e2, m.lastf ? m.lastf : s_r);
             else
@@ -805,13 +805,13 @@ Expression *BinExp::compare_overload(Scope *sc, Identifier *id)
                     m.lastf->toChars());
             }
         }
-        else if (m.last == MATCHnomatch)
+        else if (m.last <= MATCHnomatch)
         {
             m.lastf = m.anyf;
         }
 
         Expression *e;
-        if (lastf && m.lastf == lastf || !s_r && m.last == MATCHnomatch)
+        if (lastf && m.lastf == lastf || !s_r && m.last <= MATCHnomatch)
             // Rewrite (e1 op e2) as e1.opfunc(e2)
             e = build_overload(loc, sc, e1, e2, m.lastf ? m.lastf : s);
         else
@@ -1099,7 +1099,7 @@ Expression *BinAssignExp::op_overload(Scope *sc)
                     m.nextf->type->toChars(),
                     m.lastf->toChars());
         }
-        else if (m.last == MATCHnomatch)
+        else if (m.last <= MATCHnomatch)
         {
             m.lastf = m.anyf;
             if (tiargs)


### PR DESCRIPTION
The plan is to add a new level, MATCHerror, which is less than MATCHnomatch. The point of that is to better propagate errors, like with TypeError and ErrorStatement.
