### PR TITLE
Issue 8658 - Passing large structs to function b value causes stack corruption

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -3846,7 +3846,23 @@ Lret:
         else
         {   // Stack is always aligned on register size boundary
             Para.offset = (Para.offset + (REGSIZE - 1)) & ~(REGSIZE - 1);
-            c = genc2(c,op,0,Para.offset);          // RET Para.offset
+            if (Para.offset >= 0x10000)
+            {
+                /*
+                    POP REG
+                    ADD ESP, Para.offset
+                    JMP REG
+                */
+                c = gen1(c, 0x58+regx);
+                c = genc2(c, 0x81, modregrm(3,0,SP), Para.offset);
+                if (I64)
+                    code_orrex(c, REX_W);
+                c = genc2(c, 0xFF, modregrm(3,4,regx), 0);
+                if (I64)
+                    code_orrex(c, REX_W);
+            }
+            else
+                c = genc2(c,op,0,Para.offset);          // RET Para.offset
         }
     }
 

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -741,6 +741,25 @@ void testdocond()
 
 ////////////////////////////////////////////////////////////////////////
 
+struct S8658
+{
+    int[16385] a;
+}
+
+void foo8658(S8658 s)
+{
+    int x;
+}
+
+void test8658()
+{
+    S8658 s;
+    for(int i = 0; i < 1000; i++)
+        foo8658(s);
+}
+
+////////////////////////////////////////////////////////////////////////
+
 uint neg(uint i)
 {
     return ~i + 1;
@@ -1051,6 +1070,7 @@ int main()
     testU();
     testulldiv();
     testbittest();
+    test8658();
     testfastudiv();
     testfastdiv();
     testdocond();


### PR DESCRIPTION
So, the frame size doesn't fit in the immediate field of RET, so we have to do it manually.

But wait!  If we just `add ESP, ...` we're throwing away the return value.

One option is

```
ADD ESP, Para.offset+REGSIZE
JMP [ESP-Para.offset-REGSIZE]
```

but I'm a little worried using JMP instead of RET will screw something up, branch prediction-wise.

Instead, put the return address in ECX and push it back before returning.

Is ECX ok?  D/C/stdcall don't care about it at this point, but I'm not sure what else the backend might support.

@WalterBright

https://d.puremagic.com/issues/show_bug.cgi?id=8658
