### PR TITLE
Issue 9271 - Forwarding lambda predicate with type inference causes segfault 

### DIFF
--- a/src/mangle.c
+++ b/src/mangle.c
@@ -67,7 +67,12 @@ char *mangle(Declaration *sthis, bool isv)
         }
         else
             buf.prependstring("0");
-        s = s->parent;
+
+        TemplateInstance *ti = s->isTemplateInstance();
+        if (ti && !ti->isTemplateMixin())
+            s = ti->tempdecl->parent;
+        else
+            s = s->parent;
     } while (s);
 
 //    buf.prependstring("_D");
@@ -323,7 +328,7 @@ const char *TemplateInstance::mangle(bool isv)
         error("is not defined");
     else
     {
-        Dsymbol *par = enclosing || isTemplateMixin() ? parent : tempdecl->parent;
+        Dsymbol *par = isTemplateMixin() ? parent : tempdecl->parent;
         if (par)
         {
             const char *p = par->mangle(isv);

--- a/test/runnable/imports/test9271a.d
+++ b/test/runnable/imports/test9271a.d
@@ -1,0 +1,6 @@
+module imports.test9271a;
+
+bool any(alias pred, Range)(Range range)
+{
+    return true;
+}

--- a/test/runnable/test9271.d
+++ b/test/runnable/test9271.d
@@ -1,0 +1,14 @@
+// PERMUTE_ARGS:
+
+import algorithm = imports.test9271a;
+
+bool any(alias predicate, Range)(Range range)
+{
+    return algorithm.any!(predicate)(range);
+}
+
+void main()
+{
+    auto arr = ["foo"];
+    any!(e => e == "asd")(arr); // infinite recursive call -> OK
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=9271

Root cause is in the wrong mangling scheme for nested templates.

Currently, if `TemplateInstance::enclosing != NULL`, `enclosing` is preferentially used for the `parent` of mangled name.
However, if same name templates are instantiated with same nested arguments, their mangled name will conflict.

It can be checked by using dmd debug print at the end of `FuncDeclaration::semantic3`.

Current:

```
-FuncDeclaration::semantic3('any!(__lambda1, string[]).any', sc = 003D92A0, loc = imports\test9271a.d(3))
        mangle() = _D8test92714mainFZv30__T3anyS14main9__lambda1TAAyaZ3anyMFNaNbNfAAyaZb**
-FuncDeclaration::semantic3('any!((e) => e == "asd", string[]).any', sc = 003D8100, loc = test9271.d(5))
        mangle() = _D8test92714mainFZv30__T3anyS14main9__lambda1TAAyaZ3anyMFNaNbNfAAyaZb
```

After merging this PR, they will be fixed to:

```
-FuncDeclaration::semantic3('any!(__lambda1, string[]).any', sc = 01B192A0, loc = imports\test9271a.d(3))
        mangle() = _D7imports9test9271a3any30__T3anyS14main9__lambda1TAAyaZ3anyMFNaNbNfAAyaZb
-FuncDeclaration::semantic3('any!((e) => e == "asd", string[]).any', sc = 01B18100, loc = test9271.d(5))
        mangle() = _D8test92713any30__T3anyS14main9__lambda1TAAyaZ3anyMFNaNbNfAAyaZb
```
