### PR TITLE
Issue 8425 - Missing line number and module name that can't use core.simd

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -1432,22 +1432,7 @@ unsigned totym(Type *tx)
                     assert(0);
                     break;
             }
-            static bool once = false;
-            if (!once)
-            {
-                if (global.params.is64bit || global.params.isOSX)
-                    ;
-                else
-                {
-                    error(Loc(), "SIMD vector types not supported on this platform");
-                    once = true;
-                }
-                if (tv->size(Loc()) == 32)
-                {
-                    error(Loc(), "AVX vector types not supported");
-                    once = true;
-                }
-            }
+            assert(global.params.is64bit || global.params.isOSX);
             break;
         }
 

--- a/src/target.c
+++ b/src/target.c
@@ -332,3 +332,36 @@ Expression *Target::paintAsType(Expression *e, Type *type)
 
     return NULL;    // avoid warning
 }
+
+/*
+ * Return true if the given type is supported for this target
+ */
+
+int Target::checkvectortype(int sz, Type *type)
+{
+    if (!global.params.is64bit && !global.params.isOSX)
+        return 1; // not supported
+
+    if (sz != 16 && sz != 32)
+        return 2; // wrong size
+
+    switch (type->ty)
+    {
+    case Tvoid:
+    case Tint8:
+    case Tuns8:
+    case Tint16:
+    case Tuns16:
+    case Tint32:
+    case Tuns32:
+    case Tfloat32:
+    case Tint64:
+    case Tuns64:
+    case Tfloat64:
+        break;
+    default:
+        return 3; // wrong base type
+    }
+
+    return 0;
+}

--- a/src/target.h
+++ b/src/target.h
@@ -34,6 +34,7 @@ struct Target
     static unsigned critsecsize();
     static Type *va_listType();  // get type of va_list
     static Expression *paintAsType(Expression *e, Type *type);
+    static int checkvectortype(int sz, Type *type);
 };
 
 #endif

--- a/test/compilable/nogc.d
+++ b/test/compilable/nogc.d
@@ -88,9 +88,12 @@ void test12630() @nogc
 /******************************************/
 // 12642
 
-import core.simd;
-
-ulong2 test12642() @nogc
+static if (is(__vector(ulong[2])))
 {
-    return [0, 0];
+    import core.simd;
+
+    ulong2 test12642() @nogc
+    {
+        return [0, 0];
+    }
 }

--- a/test/fail_compilation/diag8425.d
+++ b/test/fail_compilation/diag8425.d
@@ -1,0 +1,16 @@
+/*
+REQUIRED_ARGS: -m64 -o-
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/diag8425.d(13): Error: T in __vector(T) must be a static array, not void
+fail_compilation/diag8425.d(14): Error: 1 byte vector type __vector(void[1]) is not supported on this platform
+fail_compilation/diag8425.d(15): Error: 99 byte vector type __vector(void[99]) is not supported on this platform
+fail_compilation/diag8425.d(16): Error: vector type __vector(void*[4]) is not supported on this platform
+---
+*/
+
+alias a = __vector(void); // not static array
+alias b = __vector(void[1]); // wrong size
+alias c = __vector(void[99]); // wrong size
+alias d = __vector(void*[4]); // wrong base type

--- a/test/fail_compilation/fail10905.d
+++ b/test/fail_compilation/fail10905.d
@@ -1,9 +1,3 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail10905.d(19): Error: incompatible types for ((this.x) == (cast(const(__vector(long[2])))cast(__vector(long[2]))1L)): 'const(__vector(long[2]))' and 'const(__vector(long[2]))'
----
-*/
 
 struct Foo
 {

--- a/test/fail_compilation/fail9301.d
+++ b/test/fail_compilation/fail9301.d
@@ -1,10 +1,6 @@
 /*
 REQUIRED_ARGS: -o-
 PERMUTE_ARGS:
-TEST_OUTPUT:
----
-fail_compilation/fail9301.d(12): Error: cannot implicitly convert expression (0) of type int to __vector(void[16])
----
 */
 
 void main()


### PR DESCRIPTION
Fix the line number, fix `is(__vector(XXX))`, fix `-o-`

@ibuclaw @redstar @klickverbot

How should I fix it so it works for compilers that support more than x86?
Do you need more fine-grained support variables or what?

https://d.puremagic.com/issues/show_bug.cgi?id=8425
