### PR TITLE
[REG2.065a] Issue 11554 - `is(T == enum);` produces an error if T is an enum defined with no members

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3408,6 +3408,12 @@ MATCH Type::deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters,
 
     if (ty != tparam->ty)
     {
+        if (Dsymbol *sym = toDsymbol(sc))
+        {
+            if (sym->isforwardRef() && !tparam->deco)
+                goto Lnomatch;
+        }
+
         // Can't instantiate AssociativeArray!() without a scope
         if (tparam->ty == Taarray && !((TypeAArray*)tparam)->sc)
             ((TypeAArray*)tparam)->sc = sc;

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -443,3 +443,11 @@ static if (is(object.ModuleInfo == class))
                   __traits(classInstanceSize, ModuleInfo));
 }
 
+/***************************************************/
+// 11554
+
+enum E11554;
+static assert(is(E11554 == enum));
+
+struct Bro11554(N...) {}
+static assert(!is(E11554 unused : Bro11554!M, M...));

--- a/test/fail_compilation/ice10770.d
+++ b/test/fail_compilation/ice10770.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10770.d(13): Error: enum ice10770.E2 is forward referenced looking for base type
+fail_compilation/ice10770.d(12): Error: enum ice10770.E2 is forward referenced looking for base type
 ---
 */
 
@@ -9,5 +9,4 @@ enum E1 : int;
 static assert(is(E1 e == enum) && is(e == int));
 
 enum E2;
-static assert(is(E2   == enum));    // Bugzilla 11554: should not cause error
 static assert(is(E2 e == enum));


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11554

The issue was partially fixed in #2829, but was not enough.
