### PR TITLE
[REG2.064] Issue 11614 - Error: this for _expand_field_0 needs to be type Tuple not type Foo

### DIFF
--- a/test/runnable/testrightthis.d
+++ b/test/runnable/testrightthis.d
@@ -530,6 +530,30 @@ class Bar11245
 }
 
 /********************************************************/
+// 11614
+
+struct Tuple11614(T...)
+{
+    T field;
+    alias field this;
+}
+
+struct Foo11614
+{
+    alias Tuple11614!(int) NEW_ARGS;
+
+    NEW_ARGS args;
+
+    void foo()
+    {
+        static if (NEW_ARGS.length == 1)
+        {}
+        else
+            static assert(0);
+    }
+}
+
+/********************************************************/
 
 int main()
 {


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11614

Even if a variable has no valid context, it would be either:
1. a part of compile time evaluated expression, which is used as unreal context.
   enum x = Type.fieldvar.sizeof;
   // It's legitimate expression so fieldvar is not evaluated
   // in runtime.
2. or an invalid field access without valid 'this', in runtime evaluated expression.
   int y = Type.fieldvar;
   // It's invalid expression so fieldvar access has no valid 'this'.

For the case #2, it will be an error by `checkRightThis` later. Therefore `getRightThis` should not make it an error.
