### PR TITLE
Issue 11618 - Internal Compiler Error

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -314,12 +314,13 @@ Expression *copyLiteral(Expression *e)
     }
     else if (e->op == TOKfunction || e->op == TOKdelegate
             || e->op == TOKsymoff || e->op == TOKnull
-            || e->op == TOKvar
+            || e->op == TOKvar || e->op == TOKdotvar
             || e->op == TOKint64 || e->op == TOKfloat64
             || e->op == TOKchar || e->op == TOKcomplex80
             || e->op == TOKvoid)
-    {   // Simple value types
-        Expression *r = e->syntaxCopy();
+    {
+        // Simple value types
+        Expression *r = e->copy();  // keep e1 for DelegateExp and DotVarExp
         r->type = e->type;
         return r;
     }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4937,6 +4937,23 @@ enum s9982 = Bug9982(3);
 enum p9982 = SS9982(s9982);
 
 /**************************************************
+    11618 dotvar assign through casted pointer
+**************************************************/
+
+struct Tuple11618(T...)
+{
+    T field;
+    alias field this;
+}
+
+static assert({
+    Tuple11618!(immutable dchar) result = void;
+    auto addr = cast(dchar*) &result[0];
+    *addr = dchar.init;
+    return (result[0] == dchar.init);
+}());
+
+/**************************************************
     7143 'is' for classes
 **************************************************/
 


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11618

`copyLiteral` function, which is called from `paintTypeOntoLiteral`, should make shallow copy for `DotVarExp`.

And, for that should use `Expression::copy` rather than `syntaxCopy`, because it will make `e1->type` to `NULL` if expression is `DelegateExp` or `DotVarExp`.

To @donc: Is this legitimate fix?
