### PR TITLE
fix Issue 10224:  core.simd ICE cgcv.c line 2162 when compiling with -g 

### DIFF
--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -2155,6 +2155,18 @@ L1:
             t = tspvoid;
             goto L1;
 
+        // vector types
+        case TYfloat4:  size = 16; next = dttab4[TYfloat];  goto Larray;
+        case TYdouble2: size = 16; next = dttab4[TYdouble]; goto Larray;
+        case TYschar16: size = 16; next = dttab4[TYschar];  goto Larray;
+        case TYuchar16: size = 16; next = dttab4[TYuchar];  goto Larray;
+        case TYshort8:  size = 16; next = dttab4[TYshort];  goto Larray;
+        case TYushort8: size = 16; next = dttab4[TYushort]; goto Larray;
+        case TYlong4:   size = 16; next = dttab4[TYlong];   goto Larray;
+        case TYulong4:  size = 16; next = dttab4[TYulong];  goto Larray;
+        case TYllong2:  size = 16; next = dttab4[TYllong];  goto Larray;
+        case TYullong2: size = 16; next = dttab4[TYullong]; goto Larray;
+
         default:
 #ifdef DEBUG
             WRTYxx(tym);


### PR DESCRIPTION
Codeview debug info: map __vector(T) types back to the static array T

https://d.puremagic.com/issues/show_bug.cgi?id=10224
