### PR TITLE
fix Issue 1955 - debug info for temp variables

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1005,6 +1005,8 @@ void dwarf_func_term(Symbol *sfunc)
    //printf("dwarf_func_term(sfunc = '%s')\n", sfunc->Sident);
 
 #if MARS
+    if (sfunc->Sflags & SFLnodebug)
+        return;
     const char* filename = sfunc->Sfunc->Fstartline.Sfilename;
     if (!filename)
         return;
@@ -1121,7 +1123,11 @@ void dwarf_func_term(Symbol *sfunc)
         unsigned autocode = 0;
         SYMIDX si;
         for (si = 0; si < globsym.top; si++)
-        {   symbol *sa = globsym.tab[si];
+        {
+            symbol *sa = globsym.tab[si];
+#if MARS
+            if (sa->Sflags & SFLnodebug) continue;
+#endif
 
             static unsigned char formal[] =
             {
@@ -1222,7 +1228,12 @@ void dwarf_func_term(Symbol *sfunc)
         if (haveparameters)
         {
             for (si = 0; si < globsym.top; si++)
-            {   symbol *sa = globsym.tab[si];
+            {
+                symbol *sa = globsym.tab[si];
+#if MARS
+                if (sa->Sflags & SFLnodebug) continue;
+#endif
+
                 unsigned vcode;
 
                 switch (sa->Sclass)

--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -336,13 +336,12 @@ symbol * symbol_generate(int sclass,type *t)
 
     //printf("symbol_generate(_TMP%d)\n", tmpnum);
     sprintf(name,"_TMP%d",tmpnum++);
-#ifdef DEBUG
     symbol *s = symbol_name(name,sclass,t);
     //symbol_print(s);
-    return s;
-#else
-    return symbol_name(name,sclass,t);
+#if MARS
+    s->Sflags |= SFLnodebug;
 #endif
+    return s;
 }
 
 /****************************************


### PR DESCRIPTION
- refactor STCtemp and STCrvalue
- fix DWARF SFLnodebug
- annotate temp vars with STCtemp/SFLnodebug

[Issue 1955](https://d.puremagic.com/issues/show_bug.cgi?id=1955)
