### PR TITLE
Issue 11653 - No error when forgetting break with range cases

### DIFF
--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -60,7 +60,7 @@ typedef Array<struct File> Files;
 
 typedef Array<class CaseStatement> CaseStatements;
 
-typedef Array<class CompoundStatement> CompoundStatements;
+typedef Array<class ScopeStatement> ScopeStatements;
 
 typedef Array<class GotoCaseStatement> GotoCaseStatements;
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -5003,7 +5003,8 @@ Statements *DebugStatement::flatten(Scope *sc)
 {
     Statements *a = statement ? statement->flatten(sc) : NULL;
     if (a)
-    {   for (size_t i = 0; i < a->dim; i++)
+    {
+        for (size_t i = 0; i < a->dim; i++)
         {   Statement *s = (*a)[i];
 
             s = new DebugStatement(loc, s);
@@ -5149,14 +5150,14 @@ Statement *LabelStatement::syntaxCopy()
 }
 
 Statement *LabelStatement::semantic(Scope *sc)
-{   LabelDsymbol *ls;
+{
     FuncDeclaration *fd = sc->parent->isFuncDeclaration();
 
     this->lastVar = sc->lastVar;
     //printf("LabelStatement::semantic()\n");
     ident = fixupLabelName(sc, ident);
 
-    ls = fd->searchLabel(ident);
+    LabelDsymbol *ls = fd->searchLabel(ident);
     if (ls->statement)
     {
         error("Label '%s' already defined", ls->toChars());
@@ -5194,10 +5195,10 @@ Statements *LabelStatement::flatten(Scope *sc)
             {
                 a->push(new ExpStatement(loc, (Expression *)NULL));
             }
-            Statement *s = (*a)[0];
 
-            s = new LabelStatement(loc, ident, s);
-            (*a)[0] = s;
+            // reuse 'this' LabelStatement
+            this->statement = (*a)[0];
+            (*a)[0] = this;
         }
     }
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -399,7 +399,7 @@ public:
     FuncDeclaration *func;      // function we're lexically in
 
     Statements *cases;          // put breaks, continues, gotos and returns here
-    CompoundStatements *gotos;  // forward referenced goto's go here
+    ScopeStatements *gotos;     // forward referenced goto's go here
 
     ForeachStatement(Loc loc, TOK op, Parameters *arguments, Expression *aggr, Statement *body);
     Statement *syntaxCopy();

--- a/test/fail_compilation/fail11653.d
+++ b/test/fail_compilation/fail11653.d
@@ -1,0 +1,24 @@
+// REQUIRED_ARGS: -w
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11653.d(18): Error: switch case fallthrough - use 'goto case;' if intended
+---
+*/
+
+void main()
+{
+    int test = 12412;
+    int output = 0;
+    switch(test)
+    {
+        case 1:
+            output = 1;
+            //break; //Oops..
+        case 2: .. case 3:
+            output = 2;
+            break;
+        default:
+            output = 3;
+    }
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11653

Currently nested `CompoundStatement` (one of the element of `statements` field may be `CompoundStatement`) is allowed. However, "switch case fallthrough" warning, which is checked in `CompoundStatement::blockExit`, depends on the _completely_ flatten `CompoundStatement`. So, to make the warning check possible, flatten such nested `CompoundStatement` in its `semantic`.

But, just only doing it will break some existing assumptions. To avoid breakage,
1. Use `ScopeStatement` instead of `CompoundStatement` for the goto patch placeholder inside foreach.
   To replace goto-statement, which jump out to the foreach block, to the return-statement, CompoundStatement is used as placeholder. But nested CompoundStatement will be removed, so use ScopeStatement instead.
2. If `LabelStatement::flatten` is called after semantic, it will create new LabelStatement and will break internal semantic information (eg. LabelStatement::gotoTarget). To avoid breakage, reuse 'this'.
