### PR TITLE
fix issue 11656: property offsetof does not work with __vector fields

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3532,6 +3532,12 @@ Expression *TypeVector::dotExp(Scope *sc, Expression *e, Identifier *ident, int 
         e = e->castTo(sc, basetype);
         return e;
     }
+    if (ident == Id::offsetof || ident == Id::offset || ident == Id::stringof)
+    {
+        // offsetof does not work on a cast expression, so use the basetype directly
+        // stringof should not add a cast to the output
+        return basetype->dotExp(sc, e, ident, flag);
+    }
     return basetype->dotExp(sc, e->castTo(sc, basetype), ident, flag);
 }
 

--- a/test/compilable/test11656.d
+++ b/test/compilable/test11656.d
@@ -1,0 +1,10 @@
+
+version(D_SIMD)
+{
+	struct Foo
+	{
+		__vector(float[4]) x;
+	}
+	static assert(Foo.x.offsetof == 0);
+	static assert(Foo.x.stringof == "x");
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11656

do not create intermediate cast expression for __vector.offsetof and stringof
