### PR TITLE
Issue 11662 - Template constraint evaluation should not look eponymous template function parameters if it's unnecessary

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -737,6 +737,9 @@ void TemplateDeclaration::makeParamNamesVisibleInConstraint(Scope *paramscope, E
         onemember->toAlias()->isFuncDeclaration() : NULL;
     if (fd)
     {
+        if (!fd->type->reliesOnTident(parameters))
+            return;
+
         /*
             Making parameters is similar to FuncDeclaration::semantic3
          */
@@ -751,7 +754,10 @@ void TemplateDeclaration::makeParamNamesVisibleInConstraint(Scope *paramscope, E
 
         // Resolve parameter types and 'auto ref's.
         tf->fargs = fargs;
-        tf = (TypeFunction *)tf->semantic(loc, paramscope);
+        Type *t = tf->semantic(loc, paramscope);
+        if (t->ty != Tfunction)
+            return;
+        tf = (TypeFunction *)t;
 
         Parameters *fparameters = tf->parameters;
         int fvarargs = tf->varargs;

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2957,6 +2957,28 @@ void test11533c()
 }
 
 /******************************************/
+// 11662
+
+template func11662a(T)
+{
+    alias Type = T*;
+    void func11662a(Type data) {}
+}
+
+template func11662b(T) if (!is(T == class))
+{
+    alias Type = T*;
+    void func11662b(Type data) {}
+}
+
+void test11662()
+{
+    int* p;
+    func11662a!int(p);
+    func11662b!int(p);
+}
+
+/******************************************/
 
 int main()
 {
@@ -3051,6 +3073,7 @@ int main()
     test11533a();
     test11533b();
     test11533c();
+    test11662();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11662
