### PR TITLE
Issue 8543 - [CTFE] simd literals need better support

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3887,7 +3887,7 @@ bool interpretAssignToIndex(InterState *istate, Loc loc,
      */
     if (aggregate->op == TOKindex || aggregate->op == TOKdotvar ||
         aggregate->op == TOKslice || aggregate->op == TOKcall ||
-        aggregate->op == TOKstar)
+        aggregate->op == TOKstar || aggregate->op == TOKcast)
     {
         aggregate = aggregate->interpret(istate, ctfeNeedLvalue);
         if (exceptionOrCantInterpret(aggregate))
@@ -4090,9 +4090,8 @@ Expression *interpretAssignToSlice(InterState *istate, CtfeGoal goal, Loc loc,
     /* The only possible slicable LValue aggregates are array literals,
      * and slices of array literals.
      */
-
     if (aggregate->op == TOKindex || aggregate->op == TOKdotvar ||
-        aggregate->op == TOKslice ||
+        aggregate->op == TOKslice || aggregate->op == TOKcast ||
         aggregate->op == TOKstar  || aggregate->op == TOKcall)
     {
         aggregate = aggregate->interpret(istate, ctfeNeedLvalue);

--- a/test/compilable/test8543.d
+++ b/test/compilable/test8543.d
@@ -1,0 +1,32 @@
+
+version (D_SIMD)
+{
+    struct vfloat
+    {
+    public:
+        __vector(float[4]) f32;
+
+        this(float X) nothrow
+        {
+            f32.ptr[0] = X;
+            f32.ptr[1] = X;
+            f32.ptr[2] = X;
+            f32.ptr[3] = X;
+        }
+        this(float X, float Y, float Z, float W) nothrow
+        {
+            f32.array[0] = X;
+            f32.array[1] = Y;
+            f32.array[2] = Z;
+            f32.array[3] = W;
+        }
+        this(float[4] values) nothrow
+        {
+            f32.array = values;
+        }
+    }
+
+    immutable GvfGlobal_ThreeA = vfloat(3.0f);
+    immutable GvfGlobal_ThreeB = vfloat(3.0f, 3.0f, 3.0f, 3.0f);
+    immutable GvfGlobal_ThreeC = vfloat([3.0f, 3.0f, 3.0f, 3.0f]);
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=8543

Vector expressions in D are represented as `cast(T[N])exp` - this change lets CTFE be able to run interpret on the expression to expand it to it's underlying array literal.

Will add a test to the testsuite once have confirmed that there is no regressions from the autotester.
