### PR TITLE
Add TypeVector::toDt to generate correct default initialiser for vectors

### DIFF
--- a/src/mtype.h
+++ b/src/mtype.h
@@ -454,6 +454,7 @@ public:
     Expression *defaultInitLiteral(Loc loc);
     TypeBasic *elementType();
     int isZeroInit(Loc loc);
+    dt_t **toDt(dt_t **pdt);
     TypeInfoDeclaration *getTypeInfoDeclaration();
     TypeTuple *toArgTypes();
 

--- a/src/todt.c
+++ b/src/todt.c
@@ -667,6 +667,12 @@ dt_t **Type::toDt(dt_t **pdt)
     return e->toDt(pdt);
 }
 
+dt_t **TypeVector::toDt(dt_t **pdt)
+{
+    assert(basetype->ty == Tsarray);
+    return ((TypeSArray *)basetype)->toDtElem(pdt, NULL);
+}
+
 dt_t **TypeSArray::toDt(dt_t **pdt)
 {
     return toDtElem(pdt, NULL);


### PR DESCRIPTION
Given the code:

```
import core.simd;
float4 x;
```

The logic through VarDeclaration::toObjFile goes as such:

```
if (init)
 {
    /* init == NULL in the above so this is not hit. */
 }
else
  type->toDt(&s->Sdt);
```

Which because of Type::toDt, only the first element is set for the decl.

```
float4 x = +SNaN;
```

This harms gdc which expects the decl and initialiser size to match up almost always.  If the initialiser is smaller than the type, then the backend will fill the rest of the decl with zeroes when it comes to emitting the assembly.

```
float4 x = [+SNaN, 0, 0, 0];  // Wrong!
```

This change makes it so type->toDt generates the correct constructor.

```
float4 y = [+SNaN, +SNaN, +SNaN, +SNaN];
```
