### PR TITLE
Issue 11371 - [CTFE] vector literals are not valid values

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -2065,6 +2065,9 @@ bool isCtfeValueValid(Expression *newval)
     if (newval->op == TOKfunction)
         return true; // function literal or delegate literal
 
+    if (newval->op == TOKvector)
+        return true; // vector literal
+
     if (newval->op == TOKdelegate)
     {
         Expression *dge = ((DelegateExp *)newval)->e1;

--- a/test/compilable/test11371.d
+++ b/test/compilable/test11371.d
@@ -1,0 +1,11 @@
+
+version(D_SIMD)
+{
+    __vector(long[2]) f()
+    {
+        __vector(long[2]) q;
+        return q;
+    }
+
+    enum __vector(long[2]) v = f();
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11371

Makes vector literals valid as CTFE-able values.  Waiting for autotester before adding test.
