### PR TITLE
Issue 11689 - deprecated local function does not work

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4020,6 +4020,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
         case TOKimmutable:
         case TOKshared:
         case TOKwild:
+        case TOKdeprecated:
         case TOKnothrow:
         case TOKpure:
         case TOKref:

--- a/test/compilable/parse11689.d
+++ b/test/compilable/parse11689.d
@@ -1,0 +1,4 @@
+void main()
+{
+    deprecated void foo() {}
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11689

I found this trivial bug while working on https://github.com/D-Programming-Language/dlang.org/pull/429.
