### PR TITLE
[DDMD] Get rid of RootObject's destructor

### DIFF
--- a/src/root/object.h
+++ b/src/root/object.h
@@ -29,7 +29,6 @@ class RootObject
 {
 public:
     RootObject() { }
-    virtual ~RootObject() { }
 
     virtual bool equals(RootObject *o);
 


### PR DESCRIPTION
It's empty, no derived classes have destructors, and it can't be translated into D properly
