### PR TITLE
Issue 10905 - [CTFE] Fix [ICE](ctfeexpr.c line 355) with ulong2 in structs

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -317,7 +317,7 @@ Expression *copyLiteral(Expression *e)
             || e->op == TOKvar || e->op == TOKdotvar
             || e->op == TOKint64 || e->op == TOKfloat64
             || e->op == TOKchar || e->op == TOKcomplex80
-            || e->op == TOKvoid)
+            || e->op == TOKvoid || e->op == TOKvector)
     {
         // Simple value types
         Expression *r = e->copy();  // keep e1 for DelegateExp and DotVarExp

--- a/test/fail_compilation/fail10905.d
+++ b/test/fail_compilation/fail10905.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10905.d(19): Error: incompatible types for ((this.x) == (cast(const(__vector(long[2])))cast(__vector(long[2]))1L)): 'const(__vector(long[2]))' and 'const(__vector(long[2]))'
+---
+*/
+
+struct Foo
+{
+    enum __vector(long[2]) y = 1;
+}
+
+struct Bar
+{
+    __vector(long[2]) x;
+
+    bool spam() const
+    {
+        return x == Foo.y;
+    }
+}
+


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10905

Treat `TOKvector`'s as simple value types in CTFE on copyLiteral.
