### PR TITLE
Fix clang warnings.

### DIFF
--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -24,7 +24,7 @@ typedef Array<class Expression> Expressions;
 
 typedef Array<class Statement> Statements;
 
-typedef Array<class BaseClass> BaseClasses;
+typedef Array<struct BaseClass> BaseClasses;
 
 typedef Array<class ClassDeclaration> ClassDeclarations;
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -241,7 +241,7 @@ struct Compiler
 };
 
 typedef unsigned structalign_t;
-#define STRUCTALIGN_DEFAULT ~0  // magic value means "match whatever the underlying C compiler does"
+#define STRUCTALIGN_DEFAULT ((structalign_t) ~0)  // magic value means "match whatever the underlying C compiler does"
 // other values are all powers of 2
 
 struct Ungag


### PR DESCRIPTION
This pull request fixes some simple warnings which clang emits:
- mismatch between class and struct declaration
- mismatch between unsigned type and signed value
- missing virtual destructor
