### PR TITLE
[Refactoring] Remove unnecessary isVarDeclaration() call

### DIFF
--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -321,7 +321,8 @@ TypeTuple *TypeStruct::toArgTypes()
 #if 1
         t1 = NULL;
         for (size_t i = 0; i < sym->fields.dim; i++)
-        {   VarDeclaration *f = sym->fields[i];
+        {
+            VarDeclaration *f = sym->fields[i];
             //printf("f->type = %s\n", f->type->toChars());
 
             TypeTuple *tup = f->type->toArgTypes();
@@ -401,7 +402,8 @@ TypeTuple *TypeStruct::toArgTypes()
         }
 #else
         if (sym->fields.dim == 1)
-        {   VarDeclaration *f = sym->fields[0];
+        {
+            VarDeclaration *f = sym->fields[0];
             //printf("f->type = %s\n", f->type->toChars());
             TypeTuple *tup = f->type->toArgTypes();
             if (tup)

--- a/src/cast.c
+++ b/src/cast.c
@@ -934,8 +934,8 @@ MATCH NewExp::implicitConvTo(Type *t)
             goto Lnomatch;
 
         for (size_t i = 0; i < cd->fields.dim; i++)
-        {   Dsymbol *sm = cd->fields[i];
-            Declaration *d = sm->isDeclaration();
+        {
+            Declaration *d = cd->fields[i];
             if (d->storage_class & STCref || d->hasPointers())
                 goto Lnomatch;
         }
@@ -984,8 +984,8 @@ MATCH NewExp::implicitConvTo(Type *t)
                 goto Lnomatch;
 
             for (size_t i = 0; i < sd->fields.dim; i++)
-            {   Dsymbol *sm = sd->fields[i];
-                Declaration *d = sm->isDeclaration();
+            {
+                Declaration *d = sd->fields[i];
                 if (d->storage_class & STCref || d->hasPointers())
                     goto Lnomatch;
             }

--- a/src/class.c
+++ b/src/class.c
@@ -658,8 +658,8 @@ void ClassDeclaration::semantic(Scope *sc)
         // Unwind what we did, and defer it for later
         for (size_t i = 0; i < fields.dim; i++)
         {
-            if (VarDeclaration *v = fields[i])
-                v->offset = 0;
+            VarDeclaration *v = fields[i];
+            v->offset = 0;
         }
         fields.setDim(0);
         structsize = 0;
@@ -693,7 +693,7 @@ void ClassDeclaration::semantic(Scope *sc)
         // A class object is always created by constructor, so this check is legitimate.
         for (size_t i = 0; i < fields.dim; i++)
         {
-            VarDeclaration *v = fields[i]->isVarDeclaration();
+            VarDeclaration *v = fields[i];
             if (v->storage_class & STCnodefaultctor)
                 ::error(v->loc, "field %s must be initialized in constructor", v->toChars());
         }

--- a/src/clone.c
+++ b/src/clone.c
@@ -131,9 +131,7 @@ int StructDeclaration::needOpAssign()
      */
     for (size_t i = 0; i < fields.dim; i++)
     {
-        Dsymbol *s = fields[i];
-        VarDeclaration *v = s->isVarDeclaration();
-        assert(v && v->isField());
+        VarDeclaration *v = fields[i];
         if (v->storage_class & STCref)
             continue;
         Type *tv = v->type->baseElemOf();
@@ -207,9 +205,7 @@ FuncDeclaration *StructDeclaration::buildOpAssign(Scope *sc)
     {
         for (size_t i = 0; i < fields.dim; i++)
         {
-            Dsymbol *s = fields[i];
-            VarDeclaration *v = s->isVarDeclaration();
-            assert(v && v->isField());
+            VarDeclaration *v = fields[i];
             if (v->storage_class & STCref)
                 continue;
             Type *tv = v->type->baseElemOf();
@@ -277,9 +273,7 @@ FuncDeclaration *StructDeclaration::buildOpAssign(Scope *sc)
         //printf("\tmemberwise copy\n");
         for (size_t i = 0; i < fields.dim; i++)
         {
-            Dsymbol *s = fields[i];
-            VarDeclaration *v = s->isVarDeclaration();
-            assert(v && v->isField());
+            VarDeclaration *v = fields[i];
             // this.v = s.v;
             AssignExp *ec = new AssignExp(loc,
                 new DotVarExp(loc, new ThisExp(loc), v, 0),
@@ -365,9 +359,7 @@ int StructDeclaration::needOpEquals()
      */
     for (size_t i = 0; i < fields.dim; i++)
     {
-        Dsymbol *s = fields[i];
-        VarDeclaration *v = s->isVarDeclaration();
-        assert(v && v->isField());
+        VarDeclaration *v = fields[i];
         if (v->storage_class & STCref)
             continue;
         Type *tv = v->type->toBasetype();
@@ -774,9 +766,7 @@ FuncDeclaration *StructDeclaration::buildPostBlit(Scope *sc)
     Expression *e = NULL;
     for (size_t i = 0; i < fields.dim; i++)
     {
-        Dsymbol *s = fields[i];
-        VarDeclaration *v = s->isVarDeclaration();
-        assert(v && v->isField());
+        VarDeclaration *v = fields[i];
         if (v->storage_class & STCref)
             continue;
         Type *tv = v->type->toBasetype();
@@ -887,9 +877,7 @@ FuncDeclaration *AggregateDeclaration::buildDtor(Scope *sc)
     Expression *e = NULL;
     for (size_t i = 0; i < fields.dim; i++)
     {
-        Dsymbol *s = fields[i];
-        VarDeclaration *v = s->isVarDeclaration();
-        assert(v && v->isField());
+        VarDeclaration *v = fields[i];
         if (v->storage_class & STCref)
             continue;
         Type *tv = v->type->toBasetype();

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1183,10 +1183,8 @@ Expression *Cast(Type *type, Type *to, Expression *e1)
         assert(sd);
         Expressions *elements = new Expressions;
         for (size_t i = 0; i < sd->fields.dim; i++)
-        {   Dsymbol *s = sd->fields[i];
-            VarDeclaration *v = s->isVarDeclaration();
-            assert(v);
-
+        {
+            VarDeclaration *v = sd->fields[i];
             Expression *exp = new IntegerExp(0);
             exp = Cast(v->type, v->type, exp);
             if (exp == EXP_CANT_INTERPRET)

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -55,7 +55,8 @@ VarDeclaration *ClassReferenceExp::getFieldAt(unsigned index)
     ClassDeclaration *cd = originalClass();
     unsigned fieldsSoFar = 0;
     while (index - fieldsSoFar >= cd->fields.dim)
-    {   fieldsSoFar += cd->fields.dim;
+    {
+        fieldsSoFar += cd->fields.dim;
         cd = cd->baseClass;
     }
     return cd->fields[index - fieldsSoFar];
@@ -67,15 +68,17 @@ int ClassReferenceExp::getFieldIndex(Type *fieldtype, unsigned fieldoffset)
     ClassDeclaration *cd = originalClass();
     unsigned fieldsSoFar = 0;
     for (size_t j = 0; j < value->elements->dim; j++)
-    {   while (j - fieldsSoFar >= cd->fields.dim)
-        {   fieldsSoFar += cd->fields.dim;
+    {
+        while (j - fieldsSoFar >= cd->fields.dim)
+        {
+            fieldsSoFar += cd->fields.dim;
             cd = cd->baseClass;
         }
-        Dsymbol *s = cd->fields[j - fieldsSoFar];
-        VarDeclaration *v2 = s->isVarDeclaration();
+        VarDeclaration *v2 = cd->fields[j - fieldsSoFar];
         if (fieldoffset == v2->offset &&
             fieldtype->size() == v2->type->size())
-        {   return (int)(value->elements->dim - fieldsSoFar - cd->fields.dim + (j-fieldsSoFar));
+        {
+            return (int)(value->elements->dim - fieldsSoFar - cd->fields.dim + (j-fieldsSoFar));
         }
     }
     return -1;
@@ -88,14 +91,16 @@ int ClassReferenceExp::findFieldIndexByName(VarDeclaration *v)
     ClassDeclaration *cd = originalClass();
     size_t fieldsSoFar = 0;
     for (size_t j = 0; j < value->elements->dim; j++)
-    {   while (j - fieldsSoFar >= cd->fields.dim)
-        {   fieldsSoFar += cd->fields.dim;
+    {
+        while (j - fieldsSoFar >= cd->fields.dim)
+        {
+            fieldsSoFar += cd->fields.dim;
             cd = cd->baseClass;
         }
-        Dsymbol *s = cd->fields[j - fieldsSoFar];
-        VarDeclaration *v2 = s->isVarDeclaration();
+        VarDeclaration *v2 = cd->fields[j - fieldsSoFar];
         if (v == v2)
-        {   return (int)(value->elements->dim - fieldsSoFar - cd->fields.dim + (j-fieldsSoFar));
+        {
+            return (int)(value->elements->dim - fieldsSoFar - cd->fields.dim + (j-fieldsSoFar));
         }
     }
     return -1;
@@ -283,9 +288,7 @@ Expression *copyLiteral(Expression *e)
             Expression *m = (*oldelems)[i];
             // We need the struct definition to detect block assignment
             AggregateDeclaration *sd = se->sd;
-            Dsymbol *s = sd->fields[i];
-            VarDeclaration *v = s->isVarDeclaration();
-            assert(v);
+            VarDeclaration *v = sd->fields[i];
             // If it is a void assignment, use the default initializer
             if (!m)
                 m = v->type->voidInitLiteral(v);
@@ -2191,38 +2194,40 @@ void showCtfeExpr(Expression *e, int level)
         size_t fieldsSoFar = 0;
         for (size_t i = 0; i < elements->dim; i++)
         {   Expression *z = NULL;
-            Dsymbol *s = NULL;
+            VarDeclaration *v = NULL;
             if (i > 15) {
                 printf("...(total %d elements)\n", (int)elements->dim);
                 return;
             }
             if (sd)
-            {   s = sd->fields[i];
+            {
+                v = sd->fields[i];
                 z = (*elements)[i];
             }
             else if (cd)
-            {   while (i - fieldsSoFar >= cd->fields.dim)
-                {   fieldsSoFar += cd->fields.dim;
+            {
+                while (i - fieldsSoFar >= cd->fields.dim)
+                {
+                    fieldsSoFar += cd->fields.dim;
                     cd = cd->baseClass;
                     for (int j = level; j>0; --j) printf(" ");
                     printf(" BASE CLASS: %s\n", cd->toChars());
                 }
-                s = cd->fields[i - fieldsSoFar];
+                v = cd->fields[i - fieldsSoFar];
                 assert((elements->dim + i) >= (fieldsSoFar + cd->fields.dim));
                 size_t indx = (elements->dim - fieldsSoFar)- cd->fields.dim + i;
                 assert(indx < elements->dim);
                 z = (*elements)[indx];
             }
-            if (!z) {
+            if (!z)
+            {
                 for (int j = level; j>0; --j) printf(" ");
                 printf(" void\n");
                 continue;
             }
 
-            if (s)
+            if (v)
             {
-                VarDeclaration *v = s->isVarDeclaration();
-                assert(v);
                 // If it is a void assignment, use the default initializer
                 if ((v->type->ty != z->type->ty) && v->type->ty == Tsarray)
                 {

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -45,7 +45,8 @@ void checkFrameAccess(Loc loc, Scope *sc, AggregateDeclaration *ad)
             {
                 // Is it better moving this check to AggregateDeclaration:semantic?
                 for (size_t i = 0; i < ad->fields.dim; i++)
-                {   VarDeclaration *vd = ad->fields[i]->isVarDeclaration();
+                {
+                    VarDeclaration *vd = ad->fields[i];
                     if (vd)
                         if (AggregateDeclaration *ad2 = isAggregate(vd->type))
                             if (ad2->isStructDeclaration())

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -5128,9 +5128,7 @@ elem *StructLiteralExp::toElem(IRState *irs)
         size_t offset = 0;
         for (size_t i = 0; i < sd->fields.dim; i++)
         {
-            Dsymbol *s = sd->fields[i];
-            VarDeclaration *v = s->isVarDeclaration();
-            assert(v);
+            VarDeclaration *v = sd->fields[i];
 
             e = el_combine(e, fillHole(stmp, &offset, v->offset, sd->structsize));
             size_t vend = v->offset + v->type->size();
@@ -5150,9 +5148,7 @@ elem *StructLiteralExp::toElem(IRState *irs)
             if (!el)
                 continue;
 
-            Dsymbol *s = sd->fields[i];
-            VarDeclaration *v = s->isVarDeclaration();
-            assert(v);
+            VarDeclaration *v = sd->fields[i];
             assert(!v->isThisDeclaration() || el->op == TOKnull);
 
             elem *e1;
@@ -5209,9 +5205,7 @@ elem *StructLiteralExp::toElem(IRState *irs)
     {
         // Initialize the hidden 'this' pointer
         assert(sd->fields.dim);
-        Dsymbol *s = sd->fields[sd->fields.dim - 1];
-        ThisDeclaration *v = s->isThisDeclaration();
-        assert(v);
+        ThisDeclaration *v = sd->fields[sd->fields.dim - 1]->isThisDeclaration();
 
         elem *e1;
         if (tybasic(stmp->Stype->Tty) == TYnptr)

--- a/src/expression.c
+++ b/src/expression.c
@@ -4813,9 +4813,7 @@ int StructLiteralExp::getFieldIndex(Type *type, unsigned offset)
     {
         for (size_t i = 0; i < sd->fields.dim; i++)
         {
-            Dsymbol *s = sd->fields[i];
-            VarDeclaration *v = s->isVarDeclaration();
-            assert(v);
+            VarDeclaration *v = sd->fields[i];
 
             if (offset == v->offset &&
                 type->size() == v->type->size())

--- a/src/func.c
+++ b/src/func.c
@@ -1354,8 +1354,8 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (!(sc2->callSuper & CSXthis_ctor))
                 {
                     for (size_t i = 0; i < ad2->fields.dim; i++)
-                    {   VarDeclaration *v = ad2->fields[i];
-
+                    {
+                        VarDeclaration *v = ad2->fields[i];
                         if (v->ctorinit == 0)
                         {
                             /* Current bugs in the flow analysis:

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2942,9 +2942,7 @@ Expression *NewExp::interpret(InterState *istate, CtfeGoal goal)
             fieldsSoFar -= c->fields.dim;
             for (size_t i = 0; i < c->fields.dim; i++)
             {
-                Dsymbol *s = c->fields[i];
-                VarDeclaration *v = s->isVarDeclaration();
-                assert(v);
+                VarDeclaration *v = c->fields[i];
                 Expression *m;
                 if (v->init)
                 {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8368,9 +8368,8 @@ bool TypeStruct::needsNested()
 
     for (size_t i = 0; i < sym->fields.dim; i++)
     {
-        Dsymbol *s = sym->fields[i];
-        VarDeclaration *vd = s->isVarDeclaration();
-        if (vd && !vd->isDataseg() && vd->type->needsNested())
+        VarDeclaration *v = sym->fields[i];
+        if (!v->isDataseg() && v->type->needsNested())
             return true;
     }
     return false;
@@ -8419,8 +8418,7 @@ int TypeStruct::hasPointers()
     sym->size(Loc());               // give error for forward references
     for (size_t i = 0; i < s->fields.dim; i++)
     {
-        Dsymbol *sm = s->fields[i];
-        Declaration *d = sm->isDeclaration();
+        Declaration *d = s->fields[i];
         if (d->storage_class & STCref || d->hasPointers())
             return true;
     }

--- a/src/struct.c
+++ b/src/struct.c
@@ -483,13 +483,13 @@ int AggregateDeclaration::firstFieldInUnion(int indx)
 {
     if (isUnionDeclaration())
         return 0;
-    VarDeclaration * vd = fields[indx];
+    VarDeclaration *vd = fields[indx];
     int firstNonZero = indx; // first index in the union with non-zero size
     for (; ;)
     {
         if (indx == 0)
             return firstNonZero;
-        VarDeclaration * v = fields[indx - 1];
+        VarDeclaration *v = fields[indx - 1];
         if (v->offset != vd->offset)
             return firstNonZero;
         --indx;
@@ -508,7 +508,7 @@ int AggregateDeclaration::firstFieldInUnion(int indx)
  */
 int AggregateDeclaration::numFieldsInUnion(int firstIndex)
 {
-    VarDeclaration * vd = fields[firstIndex];
+    VarDeclaration *vd = fields[firstIndex];
     /* If it is a zero-length field, AND we can't find an earlier non-zero
      * sized field with the same offset, we assume it's not part of a union.
      */
@@ -518,7 +518,7 @@ int AggregateDeclaration::numFieldsInUnion(int firstIndex)
     int count = 1;
     for (size_t i = firstIndex+1; i < fields.dim; ++i)
     {
-        VarDeclaration * v = fields[i];
+        VarDeclaration *v = fields[i];
         // If offsets are different, they are not in the same union
         if (v->offset != vd->offset)
             break;
@@ -684,13 +684,13 @@ void StructDeclaration::semantic(Scope *sc)
     finalizeSize(sc2);
 
     if (sizeok == SIZEOKfwd)
-    {   // semantic() failed because of forward references.
+    {
+        // semantic() failed because of forward references.
         // Unwind what we did, and defer it for later
         for (size_t i = 0; i < fields.dim; i++)
-        {   Dsymbol *s = fields[i];
-            VarDeclaration *vd = s->isVarDeclaration();
-            if (vd)
-                vd->offset = 0;
+        {
+            VarDeclaration *vd = fields[i];
+            vd->offset = 0;
         }
         fields.setDim(0);
         structsize = 0;
@@ -714,9 +714,8 @@ void StructDeclaration::semantic(Scope *sc)
     zeroInit = 1;
     for (size_t i = 0; i < fields.dim; i++)
     {
-        Dsymbol *s = fields[i];
-        VarDeclaration *vd = s->isVarDeclaration();
-        if (vd && !vd->isDataseg())
+        VarDeclaration *vd = fields[i];
+        if (!vd->isDataseg())
         {
             if (vd->init)
             {
@@ -871,9 +870,7 @@ bool StructDeclaration::isPOD()
      */
     for (size_t i = 0; i < fields.dim; i++)
     {
-        Dsymbol *s = fields[i];
-        VarDeclaration *v = s->isVarDeclaration();
-        assert(v && v->isField());
+        VarDeclaration *v = fields[i];
         if (v->storage_class & STCref)
             continue;
         Type *tv = v->type->baseElemOf();

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -277,11 +277,13 @@ type *TypeClass::toCtype()
      * (after setting ctype to avoid infinite recursion)
      */
     if (global.params.symdebug)
+    {
         for (size_t i = 0; i < sym->fields.dim; i++)
-        {   VarDeclaration *v = sym->fields[i];
-
+        {
+            VarDeclaration *v = sym->fields[i];
             symbol_struct_addField(t->Ttag, v->ident->toChars(), v->type->toCtype(), v->offset);
         }
+    }
 
     return ctype;
 }


### PR DESCRIPTION
`AggregateDeclaration::fields` is typed as an array of `VarDeclaration`. Therefore, assignment its elements to `Dsymbol *` + invocation of `isVarDeclaration` are merely redundant operations.
