### PR TITLE
Fix Issue 11714 - Improve error message for wrongly initialized thread-local class instances

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1630,7 +1630,7 @@ void VarDeclaration::semantic2(Scope *sc)
         {
             ExpInitializer *ei = init->isExpInitializer();
             if (ei->exp->op == TOKclassreference)
-                error("is mutable. Only const or immutable class thread local variable are allowed, not %s", type->toChars());
+                error("is a thread-local class variable and cannot be initialized with a mutable (not known at compile time) value. Only const or immutable initial values are allowed (e.g. null), not %s", type->toChars());
         }
         else if (type->ty == Tpointer && type->nextOf()->ty == Tstruct && type->nextOf()->isMutable() &&!type->nextOf()->isShared())
         {


### PR DESCRIPTION
The existing error message can give the impression that the thread-local class instance itself must be const or immutable, not its initial value.  This revised version aims to make clearer what is wrong and how to solve it.

Background to this patch: http://forum.dlang.org/post/mailman.408.1386663198.3242.digitalmars-d-learn@puremagic.com

https://d.puremagic.com/issues/show_bug.cgi?id=11714
