### PR TITLE
Use __linux__ to identify Linux-based systems.

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -22,13 +22,13 @@
 #endif
 #endif
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
 #include        <sys/types.h>
 #include        <sys/wait.h>
 #include        <unistd.h>
 #endif
 
-#if linux || __APPLE__
+#if __linux__ || __APPLE__
     #define HAS_POSIX_SPAWN 1
     #include        <spawn.h>
     #if __APPLE__
@@ -83,7 +83,7 @@ void writeFilename(OutBuffer *buf, const char *filename)
     writeFilename(buf, filename, strlen(filename));
 }
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
 
 /*****************************
  * As it forwards the linker error message to stderr, checks for the presence
@@ -430,7 +430,7 @@ int runLINK()
         }
         return status;
     }
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#elif __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
     pid_t childpid;
     int status;
 
@@ -448,7 +448,7 @@ int runLINK()
     // add the "-dynamiclib" flag
     if (global.params.dll)
         argv.push("-dynamiclib");
-#elif linux || __FreeBSD__ || __OpenBSD__ || __sun
+#elif __linux__ || __FreeBSD__ || __OpenBSD__ || __sun
     if (global.params.dll)
         argv.push("-shared");
 #endif
@@ -630,7 +630,7 @@ int runLINK()
 //    argv.push("-ldruntime");
     argv.push("-lpthread");
     argv.push("-lm");
-#if linux
+#if __linux__
     // Changes in ld for Ubuntu 11.10 require this to appear after phobos2
     argv.push("-lrt");
 #endif
@@ -855,7 +855,7 @@ int runProgram()
         ex = global.params.exefile;
     // spawnlp returns intptr_t in some systems, not int
     return spawnv(0,ex,argv.tdata());
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#elif __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
     pid_t childpid;
     int status;
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -15,7 +15,7 @@
 #include <limits.h>
 #include <string.h>
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
 #include <errno.h>
 #endif
 
@@ -574,7 +574,7 @@ int tryMain(size_t argc, const char *argv[])
 
 #if _WIN32
     inifilename = inifile(argv[0], "sc.ini", "Environment");
-#elif linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#elif __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
     inifilename = inifile(argv[0], "dmd.conf", "Environment");
 #else
 #error "fix this"
@@ -986,7 +986,7 @@ Language changes listed by -transition=id:\n\
 #if _WIN32
                 browse("http://dlang.org/dmd-windows.html");
 #endif
-#if linux
+#if __linux__
                 browse("http://dlang.org/dmd-linux.html");
 #endif
 #if __APPLE__

--- a/src/module.c
+++ b/src/module.c
@@ -94,7 +94,7 @@ Module::Module(const char *filename, Identifier *ident, int doDocComment, int do
 
     srcfilename = FileName::defaultExt(filename, global.mars_ext);
 
-#if linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
     /* Allow 'script' D source files to have no extension.
      */
     bool allow_no_extension = true;

--- a/src/root/async.c
+++ b/src/root/async.c
@@ -119,7 +119,7 @@ unsigned __stdcall startthread(void *p)
     return EXIT_SUCCESS;                // if skidding
 }
 
-#elif linux  // Posix
+#elif __linux__  // Posix
 
 #include <errno.h>
 #include <pthread.h>

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -667,11 +667,11 @@ void FileName::ensurePathToNameExists(const char *name)
  */
 const char *FileName::canonicalName(const char *name)
 {
-#if linux
+#if __linux__
     // Lovely glibc extension to do it for us
     return canonicalize_file_name(name);
 #elif POSIX
-  #if _POSIX_VERSION >= 200809L || defined (linux)
+  #if _POSIX_VERSION >= 200809L || defined (__linux__)
     // NULL destination buffer is allowed and preferred
     return realpath(name, NULL);
   #else

--- a/src/root/man.c
+++ b/src/root/man.c
@@ -26,7 +26,7 @@ void browse(const char *url)
 
 #endif
 
-#if linux || __FreeBSD__ || __OpenBSD__ || __sun
+#if __linux__ || __FreeBSD__ || __OpenBSD__ || __sun
 
 #include        <sys/types.h>
 #include        <sys/wait.h>

--- a/src/root/object.h
+++ b/src/root/object.h
@@ -10,7 +10,7 @@
 #ifndef OBJECT_H
 #define OBJECT_H
 
-#define POSIX (linux || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+#define POSIX (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
 
 #if __DMC__
 #pragma once


### PR DESCRIPTION
As per http://sourceforge.net/p/predef/wiki/OperatingSystems/

```
Type             Macro      Description
Identification   __linux__
Identification   linux      Obsolete (not POSIX compliant)
```

Replace `linux` with POSIX-compliant `__linux__`.
