### PR TITLE
Move allow_no_extension to global

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -120,6 +120,15 @@ void Global::init()
 #error "fix this"
 #endif
 
+#if TARGET_WINDOS
+    run_noext = false;
+#elif TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
+    // Allow 'script' D source files to have no extension.
+    run_noext = true;
+#else
+#error "fix this"
+#endif
+
     copyright = "Copyright (c) 1999-2013 by Digital Mars";
     written = "written by Walter Bright";
     version = "v"

--- a/src/mars.h
+++ b/src/mars.h
@@ -264,6 +264,8 @@ struct Global
     const char *hdr_ext;        // for D 'header' import files
     const char *json_ext;       // for JSON files
     const char *map_ext;        // for .map files
+    bool run_noext;             // allow -run sources without extensions.
+
     const char *copyright;
     const char *written;
     const char *main_d;         // dummy filename for dummy main()

--- a/src/module.c
+++ b/src/module.c
@@ -94,15 +94,7 @@ Module::Module(const char *filename, Identifier *ident, int doDocComment, int do
 
     srcfilename = FileName::defaultExt(filename, global.mars_ext);
 
-#if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
-    /* Allow 'script' D source files to have no extension.
-     */
-    bool allow_no_extension = true;
-#else
-    bool allow_no_extension = false;
-#endif
-    if (allow_no_extension &&
-        global.params.run &&
+    if (global.run_noext && global.params.run &&
         !FileName::ext(filename) &&
         FileName::exists(srcfilename) == 0 &&
         FileName::exists(filename) == 1)


### PR DESCRIPTION
Though, if we have `rdmd` - wouldn't that make `-run` a deprecated feature of dmd?

Just thinking out loud.
