### PR TITLE
Implement static array literals : DIP34

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4392,6 +4392,41 @@ void ArrayLiteralExp::toMangleBuffer(OutBuffer *buf)
     }
 }
 
+/************************ StaticArrayLiteralExp ************************************/
+
+// [ e1, e2, e3, ... ]s
+StaticArrayLiteralExp::StaticArrayLiteralExp(Loc loc, Expressions *elements)
+    : ArrayLiteralExp(loc, elements)
+{
+
+}
+
+StaticArrayLiteralExp::StaticArrayLiteralExp(Loc loc, Expression *e)
+    : ArrayLiteralExp(loc, e)
+{
+
+}
+
+StaticArrayLiteralExp::StaticArrayLiteralExp(ArrayLiteralExp* ale)
+: ArrayLiteralExp(ale->loc, ale->elements)
+{
+
+}
+
+Expression *StaticArrayLiteralExp::semantic(Scope *sc)
+{
+    Expression* e = ArrayLiteralExp::semantic(sc);
+
+    TypeDArray* td = (TypeDArray*) type;
+    if (td != NULL)
+    {
+        TypeSArray* ts = new TypeSArray(td->next, new IntegerExp(elements->dim));
+        type = ts->merge();
+    }
+
+    return e;
+}
+
 /************************ AssocArrayLiteralExp ************************************/
 
 // [ key0 : value0, key1 : value1, ... ]

--- a/src/expression.h
+++ b/src/expression.h
@@ -492,6 +492,15 @@ public:
     Expression *inlineScan(InlineScanState *iss);
 };
 
+class StaticArrayLiteralExp : public ArrayLiteralExp
+{
+public:
+    StaticArrayLiteralExp(Loc loc, Expressions *elements);
+    StaticArrayLiteralExp(Loc loc, Expression *e);
+    StaticArrayLiteralExp(ArrayLiteralExp* ale);
+    Expression *semantic(Scope *sc);
+};
+
 class AssocArrayLiteralExp : public Expression
 {
 public:

--- a/src/parse.c
+++ b/src/parse.c
@@ -3419,6 +3419,27 @@ L2:
             {
                 nextToken();
                 init = parseInitializer();
+				
+                if ((t->ty == Tarray || t->ty == Tsarray))
+                {
+                   /*printf("\tType: %s, Identifier: %s, Init: %s [t->ty = %d]. Next token = %s.",
+                        t->toChars(), ident->toChars(), init->toChars(), t->ty, token.toChars());*/
+
+                   if (token.value == TOKidentifier && strcmp(token.toChars(), "s") == 0)
+                   {
+                        nextToken(); // jump over 's'
+
+                        ArrayInitializer* ai = init->isArrayInitializer();
+                        if (ai && t->ty == Tarray)
+                        {
+                            // printf("Make static...\n");
+                            TypeDArray* td = (TypeDArray*) t;
+                            assert(td != NULL);
+
+                            t = new TypeSArray(td->next, new IntegerExp(ai->value.dim));
+                        }
+                    }
+                }
             }
 
             VarDeclaration *v = new VarDeclaration(loc, t, ident, init);
@@ -3499,7 +3520,32 @@ Dsymbols *Parser::parseAutoDeclarations(StorageClass storageClass, const utf8_t 
                 error("Identifier expected following comma");
         }
         else
-            error("semicolon expected following auto declaration, not '%s'", token.toChars());
+		{
+            ArrayInitializer* ai = init->isArrayInitializer();
+            if (ai && token.value == TOKidentifier  && strcmp(token.toChars(), "s") == 0)
+            {
+                nextToken();
+                
+                Expression *e = init->toExpression();
+                init = new ExpInitializer(e->loc, e);
+                Type* type = init->inferType(NULL);
+
+                // printf("\t > %s :: %s :: %s.\n", v->toChars(), ai->toChars(), type->toChars());
+                /// Auto infer type
+                if (type != NULL)
+                {
+                    TypeDArray* td = (TypeDArray*) type;
+                    if (td != NULL)
+                    {
+                        v->type = new TypeSArray(td->next, new IntegerExp(ai->value.dim));
+
+                        if (v->storage_class & STCauto)
+                            v->storage_class &= ~STCauto;
+                    }
+                }
+            } else
+				error("semicolon expected following auto declaration, not '%s'", token.toChars());
+		}
         break;
     }
     return a;
@@ -3724,7 +3770,8 @@ Initializer *Parser::parseInitializer()
                             if (t->value != TOKsemicolon &&
                                 t->value != TOKcomma &&
                                 t->value != TOKrbracket &&
-                                t->value != TOKrcurly)
+                                t->value != TOKrcurly
+								&& (t->value != TOKidentifier && strcmp(t->toChars(), "s") != 0)) // avoid [number, ...]s
                                 goto Lexpression;
                             break;
                         }
@@ -6922,8 +6969,18 @@ Expressions *Parser::parseArguments()
         nextToken();
         while (token.value != endtok && token.value != TOKeof)
         {
-                arg = parseAssignExp();
-                arguments->push(arg);
+            arg = parseAssignExp();
+            if (token.value == TOKidentifier && strcmp(token.toChars(), "s") == 0)
+            {
+                ArrayLiteralExp* ale = (ArrayLiteralExp*) arg;
+                if (ale != NULL)
+                {
+                    nextToken();
+                    // printf("\t :: %s\n", ale->toChars());
+                    arg = new StaticArrayLiteralExp(ale);
+                }
+            }
+            arguments->push(arg);
                 if (token.value == endtok)
                     break;
                 check(TOKcomma);

--- a/src/parse.c
+++ b/src/parse.c
@@ -3429,15 +3429,15 @@ L2:
                    {
                         nextToken(); // jump over 's'
 
-                        ArrayInitializer* ai = init->isArrayInitializer();
-                        if (ai && t->ty == Tarray)
-                        {
-                            // printf("Make static...\n");
-                            TypeDArray* td = (TypeDArray*) t;
-                            assert(td != NULL);
+                        // ArrayInitializer* ai = init->isArrayInitializer();
+                        // if (ai && t->ty == Tarray)
+                        // {
+                        //     // printf("Make static...\n");
+                        //     TypeDArray* td = (TypeDArray*) t;
+                        //     assert(td != NULL);
 
-                            t = new TypeSArray(td->next, new IntegerExp(ai->value.dim));
-                        }
+                        //     t = new TypeSArray(td->next, new IntegerExp(ai->value.dim));
+                        // }
                     }
                 }
             }

--- a/src/parse.c
+++ b/src/parse.c
@@ -3522,7 +3522,7 @@ Dsymbols *Parser::parseAutoDeclarations(StorageClass storageClass, const utf8_t 
         else
 		{
             ArrayInitializer* ai = init->isArrayInitializer();
-            if (ai && token.value == TOKidentifier  && strcmp(token.toChars(), "s") == 0)
+            if (ai && token.value == TOKidentifier && strcmp(token.toChars(), "s") == 0)
             {
                 nextToken();
                 


### PR DESCRIPTION
Add the syntax <code>[1, 2, 3]s</code> for static array literals. I'm sure it's far from perfect but it's a start.
See also DIP34 and <a href="http://forum.dlang.org/thread/tizepidvtrraxsvcfpxc@forum.dlang.org?page=3#post-mnmotjaywyewdcbhtrgy:40forum.dlang.org">the thread in the NG</a>.
@9rnsr : Could you take a look at it?

Next step would be to add auto determination of static array dimension with <code>int[$] arr = [1, 2, 3];</code>
See: https://github.com/Dgame/dmd/commit/12ac0413cb29c6015c40d5218c7b691a7dcd6143
