### PR TITLE
[REG2.065a] Issue 11718 - Unintended mangled names conflict of nested template structs

### DIFF
--- a/src/mangle.c
+++ b/src/mangle.c
@@ -114,7 +114,10 @@ L1:
         if (!fd->inferRetType)
             printf("%s\n", fd->toChars());
 #endif
-        assert(fd && fd->inferRetType);
+        assert(fd && fd->inferRetType && fd->type->ty == Tfunction);
+        TypeFunction *tf = (TypeFunction *)sthis->type;
+        assert(tf->next == NULL);
+        tf->toDecoBuffer(&buf, 0);
     }
 
     id = buf.toChars();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5374,16 +5374,19 @@ Lnotcovariant:
 }
 
 void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
-{   unsigned char mc;
-
+{
     //printf("TypeFunction::toDecoBuffer() this = %p %s\n", this, toChars());
     //static int nest; if (++nest == 50) *(char*)0=0;
     if (inuse)
-    {   inuse = 2;              // flag error to caller
+    {
+        inuse = 2;              // flag error to caller
         return;
     }
     inuse++;
+
     MODtoDecoBuffer(buf, mod);
+
+    unsigned char mc;
     switch (linkage)
     {
         case LINKd:             mc = 'F';       break;
@@ -5395,6 +5398,7 @@ void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
             assert(0);
     }
     buf->writeByte(mc);
+
     if (purity || isnothrow || isproperty || isref || trust)
     {
         if (purity)
@@ -5416,11 +5420,12 @@ void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
             default: break;
         }
     }
+
     // Write argument types
     Parameter::argsToDecoBuffer(buf, parameters);
     //if (buf->data[buf->offset - 1] == '@') halt();
     buf->writeByte('Z' - varargs);      // mark end of arg list
-    if(next != NULL)
+    if (next != NULL)
         next->toDecoBuffer(buf);
     inuse--;
 }

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2348,6 +2348,38 @@ void test9525()
 }
 
 /*******************************************/
+// 11718
+
+struct Ty11718(alias sym) {}
+
+auto fn11718(T)(T a)   { return Ty11718!(a).mangleof; }
+auto fn11718(T)() { T a; return Ty11718!(a).mangleof; }
+
+void test11718()
+{
+    string TyName(string tail)()
+    {
+        enum s = "__T7Ty11718" ~ tail;
+        enum int len = s.length;
+        return "S6nested" ~ len.stringof ~ s;
+    }
+    string fnName(string paramPart)()
+    {
+        enum s = "_D6nested36__T7fn11718T"~
+                 "S6nested9test11718FZv1AZ7fn11718"~paramPart~"1a"~
+                 "S6nested9test11718FZv1A";
+        enum int len = s.length;
+        return len.stringof ~ s;
+    }
+    enum result1 = TyName!("S" ~ fnName!("F"~"S6nested9test11718FZv1A"~"Z") ~ "Z") ~ "7Ty11718";
+    enum result2 = TyName!("S" ~ fnName!("F"~""                       ~"Z") ~ "Z") ~ "7Ty11718";
+
+    struct A {}
+    static assert(fn11718(A.init) == result1);
+    static assert(fn11718!A()     == result2);
+}
+
+/*******************************************/
 
 /+
 auto fun8863(T)(T* ret) { *ret = T(); }


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11718
If a symbol has parent, the parent part of the mangled name should also be unique in each scopes.

Function symbols can have same identifiers in scope, so their parameters part must be always encoded in their mangled name to distinguish overloads.

When I fixed [bug 9271](https://d.puremagic.com/issues/show_bug.cgi?id=9271) in #2877, I had naturally expected that behavior. However sadly `mangle` function had had a bug.
