### PR TITLE
Issue 11726 - ICE with ufcs on undefined identifier and opDispatch

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -812,7 +812,7 @@ Expression *resolveUFCS(Scope *sc, CallExp *ce)
                 if (isDotOpDispatch(ey))
                 {
                     unsigned errors = global.startGagging();
-                    e = ce->semantic(sc);
+                    e = ce->syntaxCopy()->semantic(sc);
                     if (global.endGagging(errors))
                     {}  /* fall down to UFCS */
                     else

--- a/src/statement.c
+++ b/src/statement.c
@@ -96,6 +96,7 @@ void Statement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->printf("Statement::toCBuffer()");
     buf->writenl();
+    assert(0);
 }
 
 Statement *Statement::semantic(Scope *sc)
@@ -289,6 +290,7 @@ Statements *Statement::flatten(Scope *sc)
 ErrorStatement::ErrorStatement()
     : Statement(Loc())
 {
+    assert(global.gaggedErrors || global.errors);
 }
 
 Statement *ErrorStatement::syntaxCopy()

--- a/test/fail_compilation/ice11726.d
+++ b/test/fail_compilation/ice11726.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice11726.d(16): Error: undefined identifier x
+---
+*/
+
+struct S
+{
+    auto opDispatch(string fn, Args...)(Args args)
+    {
+    }
+}
+
+void main() {
+    S().reserve(x.foo());
+}


### PR DESCRIPTION
Running semantic on ce may modify it, so work on a copy.  The ice occurs because semantic on the arguments is gagged, so an ErrorExp gets leaked without incrementing global.errors.

https://d.puremagic.com/issues/show_bug.cgi?id=11726
