### PR TITLE
[REG2.064] Issue 11730 - associative array with Nullable!SysTime values: Called `get' on null Nullable!SysTime

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10104,8 +10104,16 @@ Lsafe:
             ((TypeAArray *)tfrom)->getImpl();
         if (t->ty == Taarray)
             ((TypeAArray *)t)->getImpl();
-        Expression *e = e1->castTo(sc, to);
-        return e;
+
+        if (to->ty == Tvoid)
+        {
+            type = to;
+            return this;
+        }
+        else
+        {
+            return e1->castTo(sc, to);
+        }
     }
 
 Lfail:

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -1211,6 +1211,39 @@ void test11359()
 }
 
 /************************************************/
+// 11730
+
+struct SysTime11730
+{
+    ref SysTime11730 opAssign(SysTime11730 rhs)
+    {
+        assert(0);
+    }
+}
+
+struct Nullable11730(T)
+{
+    T _value;
+
+    void opAssign()(T value)
+    {
+        assert(0);
+    }
+
+    @property ref inout(T) get() inout
+    {
+        assert(0);
+    }
+    alias get this;
+}
+
+void test11730()
+{
+    Nullable11730!SysTime11730[string] map;
+    map["foo"] = Nullable11730!SysTime11730();
+}
+
+/************************************************/
 
 int main()
 {
@@ -1258,6 +1291,7 @@ int main()
     test5520();
     test6799();
     test11359();
+    test11730();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11730

When I fixed [bug 6178](https://d.puremagic.com/issues/show_bug.cgi?id=6178), I internally used `cast(void)exp)` to suppress unexpected "has no side effect" error. [here](https://github.com/D-Programming-Language/dmd/blob/117fc133f078de7bfb312d547378e32ca4f17b51/src/expression.c#L11623)

But, `CastExp` always try to resolve alias this of its operand to find most matching type to `void` via `Expression::castTo`. It should be disabled.
