### PR TITLE
Fix 11745: Private unit tests can not be invoked.

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -423,6 +423,11 @@ void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
         printf("accessCheck(%s)\n", d->toPrettyChars());
     }
 #endif
+    if(d->isUnitTestDeclaration()) 
+    {
+        // Unittests are always accessible.
+        return;
+    }
     if (!e)
     {
         if (d->prot() == PROTprivate && d->getAccessModule() != sc->module ||

--- a/test/runnable/imports/test11745b.d
+++ b/test/runnable/imports/test11745b.d
@@ -1,0 +1,17 @@
+module imports.test11745b;
+
+unittest 
+{
+		
+}
+
+private unittest 
+{
+	
+}
+
+private:
+unittest 
+{
+	
+}

--- a/test/runnable/test11745.d
+++ b/test/runnable/test11745.d
@@ -1,0 +1,14 @@
+// EXTRA_SOURCES: imports/test11745b.d
+// REQUIRED_ARGS: -unittest
+// PERMUTE_ARGS:
+import imports.test11745b;
+
+void main() 
+{
+	// Test that we can invoke all unittests, including private ones.
+	assert(__traits(getUnitTests, imports.test11745b).length == 3);
+	foreach(test; __traits(getUnitTests, imports.test11745b))
+	{
+		test();
+	}
+}


### PR DESCRIPTION
Fix Issue 11745 (https://d.puremagic.com/issues/show_bug.cgi?id=11745) - Unittests should always be able to be accessed, otherwise custom unittest runners will never be able to run tests the built in ones can.
