### PR TITLE
Issue 10643 - Refused const array struct field initialized with void

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1161,7 +1161,7 @@ Lnomatch:
         {
 #if PULL93
             assert(!(storage_class & (STCextern | STCstatic | STCtls | STCgshared)));
-            if (storage_class & (STCconst | STCimmutable) && init &&
+            if (storage_class & (STCconst | STCimmutable) && init && !init->isVoidInitializer() &&
                 global.params.vfield)
             {
                 const char *p = loc.toChars();
@@ -1176,7 +1176,7 @@ Lnomatch:
                     aad->noDefaultCtor = true;
             }
 #else
-            if (storage_class & (STCconst | STCimmutable) && init)
+            if (storage_class & (STCconst | STCimmutable) && init && !init->isVoidInitializer())
             {
                 StorageClass stc = storage_class & (STCconst | STCimmutable);
                 warning(loc, "%s field with initializer should be static, __gshared, or an enum",

--- a/test/runnable/test3449.d
+++ b/test/runnable/test3449.d
@@ -1,3 +1,7 @@
+
+/******************************************/
+// 3449
+
 version (PULL93)
 {
 template TypeTuple(T...) { alias TypeTuple = T; }
@@ -33,7 +37,7 @@ static assert(!__traits(compiles, { static assert(mg2 == 1); }));
                                     static assert(ig2 == 1);    // possible
 
 // For aggregate fields, compiler behavior will be changed.
-void main()
+void test3449()
 {
     static struct S(T)
     {
@@ -86,7 +90,26 @@ void main()
     }
 }
 }
-else
+
+/******************************************/
+// 10643
+
+struct S10643
 {
-    void main() { }
+    const int[1000] x = void;
+
+    this(int n)
+    {
+        x[] = n;
+    }
+}
+static assert(S10643.sizeof == int.sizeof * 1000);
+
+/******************************************/
+
+int main()
+{
+    version(PULL93) test3449();
+
+    return 0;
 }


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10643

Void initialized non-mutable aggregate members should become instance fields.

Essentially this is a part of [issue 3449](https://d.puremagic.com/issues/show_bug.cgi?id=3449), but because of [bug 11742](https://d.puremagic.com/issues/show_bug.cgi?id=11742), we can fix the issue in advance of the 3449 completion, without breaking any existing code..
