### PR TITLE
fix  Issue 11749 - switch case fallthrough error is enabled with -w, but cannot be made informational warning

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -825,7 +825,7 @@ int CompoundStatement::blockExit(bool mustNotThrow)
                     else
                     {
                         const char *gototype = s->isCaseStatement() ? "case" : "default";
-                        s->error("switch case fallthrough - use 'goto %s;' if intended", gototype);
+                        s->warning("switch case fallthrough - use 'goto %s;' if intended", gototype);
                     }
                 }
             }

--- a/test/fail_compilation/fail11653.d
+++ b/test/fail_compilation/fail11653.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11653.d(18): Error: switch case fallthrough - use 'goto case;' if intended
+fail_compilation/fail11653.d(18): Warning: switch case fallthrough - use 'goto case;' if intended
 ---
 */
 


### PR DESCRIPTION
switch case fallthrough is enabled with -w, but calls error

https://d.puremagic.com/issues/show_bug.cgi?id=11749
