### PR TITLE
incorrect strlen usage

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -739,7 +739,7 @@ int dwarf_line_addfile(const char* filename)
 
     Abuf abuf;
     abuf.buf = (const unsigned char*)filename;
-    abuf.length = strlen(filename)-1;
+    abuf.length = strlen(filename);
 
     unsigned *pidx = (unsigned *)infoFileName_table->get(&abuf);
     if (!*pidx)                 // if no idx assigned yet


### PR DESCRIPTION
- causes overflow for empty string

[Issue 11750 – ICE with debug info and empty #line Filespec](https://d.puremagic.com/issues/show_bug.cgi?id=11750)
