### PR TITLE
Trivial constructors should allow the struct to be passed as POD

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -42,6 +42,13 @@ enum Sizeok
     SIZEOKfwd,          // error in computing size of aggregate
 };
 
+enum StructPOD
+{
+    ISPODno,            // struct is not POD
+    ISPODyes,           // struct is POD
+    ISPODfwd,           // POD not yet computed
+};
+
 class AggregateDeclaration : public ScopeDsymbol
 {
 public:
@@ -152,6 +159,7 @@ public:
     static FuncDeclaration *xerrcmp;     // object.xopCmp
 
     structalign_t alignment;    // alignment applied outside of the struct
+    StructPOD ispod;            // if struct is POD
 
     // For 64 bit Efl function call/return ABI
     Type *arg1type;

--- a/src/struct.c
+++ b/src/struct.c
@@ -981,6 +981,7 @@ bool StructDeclaration::fill(Loc loc, Expressions *elements, bool ctorinit)
  * This is defined as:
  *      not nested
  *      no postblits, constructors, destructors, or assignment operators
+ *      no private or protected fields
  *      no fields that are themselves non-POD
  * The idea being these are compatible with C structs.
  */
@@ -999,8 +1000,14 @@ bool StructDeclaration::isPOD()
     for (size_t i = 0; i < fields.dim; i++)
     {
         VarDeclaration *v = fields[i];
+        if (v->prot() != PROTpublic)
+        {
+            ispod = ISPODno;
+            break;
+        }
         if (v->storage_class & STCref)
             continue;
+
         Type *tv = v->type->baseElemOf();
         if (tv->ty == Tstruct)
         {


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11740

Improvements to be done:
1. `isPOD` does not check for assignment operators at all.
2. ~~`isPOD` does not cache its return value.~~
3. ~~Can not infer whether the ctor is nothrow as fbody might not have fully ran its semantic.~~
