### PR TITLE
[REG2.065a] Issue 11751 - Hex float exponents should be decimal

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2182,10 +2182,10 @@ TOK Lexer::inreal(Token *t)
         {
             c = *p++;
         }
-        bool anyexp;
+        bool anyexp = false;
         while (1)
         {
-            if (isdigit(c) || (hex && isxdigit(c)))
+            if (isdigit(c))
             {
                 anyexp = true;
                 c = *p++;

--- a/test/compilable/parse11751.d
+++ b/test/compilable/parse11751.d
@@ -1,0 +1,1 @@
+static assert(is(float == typeof(0x0.1p1F)));

--- a/test/fail_compilation/fail11751.d
+++ b/test/fail_compilation/fail11751.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11751.d(10): Error: missing exponent
+fail_compilation/fail11751.d(10): Error: semicolon expected following auto declaration, not 'ABC'
+fail_compilation/fail11751.d(10): Error: no identifier for declarator ABC
+---
+*/
+
+auto x = 0x1.FFFFFFFFFFFFFpABC;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11751

Ping: @WalterBright 
