### PR TITLE
[DDMD] Replace WINDOWS_SEH code with a larger stack size

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -35,12 +35,6 @@
 #include "lib.h"
 #include "json.h"
 
-#if WINDOWS_SEH
-#include <windows.h>
-long __cdecl __ehfilter(LPEXCEPTION_POINTERS ep);
-#endif
-
-
 int response_expand(size_t *pargc, const char ***pargv);
 void browse(const char *url);
 void getenv_setargv(const char *envvar, size_t *pargc, const char** *pargv);
@@ -1740,19 +1734,9 @@ Language changes listed by -transition=id:\n\
 int main(int argc, const char *argv[])
 {
     int status = -1;
-#if WINDOWS_SEH
-  __try
-  {
+
     status = tryMain(argc, argv);
-  }
-  __except (__ehfilter(GetExceptionInformation()))
-  {
-    printf("Stack overflow\n");
-    fatal();
-  }
-#else
-  status = tryMain(argc, argv);
-#endif
+
     return status;
 }
 
@@ -1903,19 +1887,3 @@ static bool parse_arch(size_t argc, const char** argv, bool is64bit)
     }
     return is64bit;
 }
-
-#if WINDOWS_SEH
-
-long __cdecl __ehfilter(LPEXCEPTION_POINTERS ep)
-{
-    //printf("%x\n", ep->ExceptionRecord->ExceptionCode);
-    if (ep->ExceptionRecord->ExceptionCode == STATUS_STACK_OVERFLOW)
-    {
-#if 1 //ndef DEBUG
-        return EXCEPTION_EXECUTE_HANDLER;
-#endif
-    }
-    return EXCEPTION_CONTINUE_SEARCH;
-}
-
-#endif

--- a/src/mars.h
+++ b/src/mars.h
@@ -310,8 +310,6 @@ extern Global global;
 /* Set if Windows Structured Exception Handling C extensions are supported.
  * Apparently, VC has dropped support for these?
  */
-#define WINDOWS_SEH     _WIN32
-
 #include "longdouble.h"
 
 #include "complex_t.h"

--- a/src/template.c
+++ b/src/template.c
@@ -34,11 +34,6 @@
 #include "id.h"
 #include "attrib.h"
 
-#if WINDOWS_SEH
-#include <windows.h>
-long __cdecl __ehfilter(LPEXCEPTION_POINTERS ep);
-#endif
-
 #define LOG     0
 
 #define IDX_NOTFOUND (0x12345678)               // index is not found
@@ -5262,25 +5257,7 @@ void TemplateInstance::tryExpandMembers(Scope *sc2)
         fatal();
     }
 
-#if WINDOWS_SEH
-    if(nest == 1)
-    {
-        // do not catch at every nesting level, because generating the output error might cause more stack
-        //  errors in the __except block otherwise
-        __try
-        {
-            expandMembers(sc2);
-        }
-        __except (__ehfilter(GetExceptionInformation()))
-        {
-            global.gag = 0;                     // ensure error message gets printed
-            error("recursive expansion");
-            fatal();
-        }
-    }
-    else
-#endif
-        expandMembers(sc2);
+    expandMembers(sc2);
     nest--;
 }
 
@@ -5294,25 +5271,7 @@ void TemplateInstance::trySemantic3(Scope *sc2)
         error("recursive expansion");
         fatal();
     }
-#if WINDOWS_SEH
-    if(nest == 1)
-    {
-        // do not catch at every nesting level, because generating the output error might cause more stack
-        //  errors in the __except block otherwise
-        __try
-        {
-            semantic3(sc2);
-        }
-        __except (__ehfilter(GetExceptionInformation()))
-        {
-            global.gag = 0;            // ensure error message gets printed
-            error("recursive expansion");
-            fatal();
-        }
-    }
-    else
-#endif
-        semantic3(sc2);
+    semantic3(sc2);
 
     --nest;
 }

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -305,7 +305,7 @@ root.lib : $(ROOTOBJS)
 LIBS= frontend.lib glue.lib backend.lib root.lib
 
 $(TARGETEXE): mars.obj $(LIBS) win32.mak
-	$(CC) -o$(TARGETEXE) mars.obj $(LIBS) -cpp -mn -Ar $(LFLAGS)
+	$(CC) -o$(TARGETEXE) mars.obj $(LIBS) -cpp -mn -Ar -L/STACK:8388608 $(LFLAGS)
 
 ############################ Maintenance Targets #############################
 


### PR DESCRIPTION
This matches the non-windows implementation - 8M seems to be the default on many linux systems, and the error is  much more helpful there.
