### PR TITLE
[DDMD] Remove #ifdef around BUILTINgcc

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -544,9 +544,7 @@ enum BUILTIN
     BUILTINbsr,                 // core.bitop.bsr
     BUILTINbsf,                 // core.bitop.bsf
     BUILTINbswap,               // core.bitop.bswap
-#ifdef IN_GCC
     BUILTINgcc,                 // GCC builtin
-#endif
 };
 
 Expression *eval_builtin(Loc loc, BUILTIN builtin, Expressions *arguments);


### PR DESCRIPTION
You can't do this in D, and it doesn't hurt anything to have this defined but not used.
