### PR TITLE
[DDMD] Make Array take the actual type of the stored element

### DIFF
--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -18,63 +18,62 @@
 
 #include "root.h"
 
-typedef Array<class TemplateParameter> TemplateParameters;
+typedef Array<class TemplateParameter *> TemplateParameters;
 
-typedef Array<class Expression> Expressions;
+typedef Array<class Expression *> Expressions;
 
-typedef Array<class Statement> Statements;
+typedef Array<class Statement *> Statements;
 
-typedef Array<struct BaseClass> BaseClasses;
+typedef Array<struct BaseClass *> BaseClasses;
 
-typedef Array<class ClassDeclaration> ClassDeclarations;
+typedef Array<class ClassDeclaration *> ClassDeclarations;
 
-typedef Array<class Dsymbol> Dsymbols;
+typedef Array<class Dsymbol *> Dsymbols;
 
-typedef Array<class RootObject> Objects;
+typedef Array<class RootObject *> Objects;
 
-typedef Array<class FuncDeclaration> FuncDeclarations;
+typedef Array<class FuncDeclaration *> FuncDeclarations;
 
-typedef Array<class Parameter> Parameters;
+typedef Array<class Parameter *> Parameters;
 
-typedef Array<class Identifier> Identifiers;
+typedef Array<class Identifier *> Identifiers;
 
-typedef Array<class Initializer> Initializers;
+typedef Array<class Initializer *> Initializers;
 
-typedef Array<class VarDeclaration> VarDeclarations;
+typedef Array<class VarDeclaration *> VarDeclarations;
 
-typedef Array<class Type> Types;
+typedef Array<class Type *> Types;
 
-typedef Array<class ScopeDsymbol> ScopeDsymbols;
+typedef Array<class ScopeDsymbol *> ScopeDsymbols;
 
-typedef Array<class Catch> Catches;
+typedef Array<class Catch *> Catches;
 
-typedef Array<class StaticDtorDeclaration> StaticDtorDeclarations;
+typedef Array<class StaticDtorDeclaration *> StaticDtorDeclarations;
 
-typedef Array<class SharedStaticDtorDeclaration> SharedStaticDtorDeclarations;
+typedef Array<class SharedStaticDtorDeclaration *> SharedStaticDtorDeclarations;
 
-typedef Array<class AliasDeclaration> AliasDeclarations;
+typedef Array<class AliasDeclaration *> AliasDeclarations;
 
-typedef Array<class Module> Modules;
+typedef Array<class Module *> Modules;
 
-typedef Array<struct File> Files;
+typedef Array<struct File *> Files;
 
-typedef Array<class CaseStatement> CaseStatements;
+typedef Array<class CaseStatement *> CaseStatements;
 
-typedef Array<class ScopeStatement> ScopeStatements;
+typedef Array<class ScopeStatement *> ScopeStatements;
 
-typedef Array<class GotoCaseStatement> GotoCaseStatements;
+typedef Array<class GotoCaseStatement *> GotoCaseStatements;
 
-typedef Array<class GotoStatement> GotoStatements;
+typedef Array<class GotoStatement *> GotoStatements;
 
-typedef Array<class ReturnStatement> ReturnStatements;
+typedef Array<class ReturnStatement *> ReturnStatements;
 
-typedef Array<class TemplateInstance> TemplateInstances;
+typedef Array<class TemplateInstance *> TemplateInstances;
 
-//typedef Array<char> Strings;
+typedef Array<struct block *> Blocks;
 
-typedef Array<struct block> Blocks;
+typedef Array<struct Symbol *> Symbols;
 
-typedef Array<struct Symbol> Symbols;
+typedef Array<struct dt_t *> Dts;
 
-typedef Array<struct dt_t> Dts;
 #endif

--- a/src/doc.c
+++ b/src/doc.c
@@ -70,7 +70,7 @@ public:
     void write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf);
 };
 
-typedef Array<Section> Sections;
+typedef Array<Section *> Sections;
 
 struct DocComment
 {

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -44,7 +44,7 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
-typedef Array<elem> Elems;
+typedef Array<elem *> Elems;
 
 elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
 elem *eval_Darray(IRState *irs, Expression *e, bool alwaysCopy = false);

--- a/src/glue.c
+++ b/src/glue.c
@@ -44,7 +44,7 @@ elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
 
 #define STATICCTOR      0
 
-typedef Array<symbol> symbols;
+typedef Array<symbol *> symbols;
 
 elem *eictor;
 symbol *ictorlocalgot;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -58,9 +58,9 @@ private:
     */
     Expressions values;   // values on the stack
     VarDeclarations vars; // corresponding variables
-    Array<void> savedId; // id of the previous state of that var
+    Array<void *> savedId; // id of the previous state of that var
 
-    Array<void> frames;  // all previous frame pointers
+    Array<void *> frames;  // all previous frame pointers
     Expressions savedThis;   // all previous values of localThis
 
     /* Global constants get saved here after evaluation, so we never

--- a/src/libelf.c
+++ b/src/libelf.c
@@ -35,8 +35,8 @@ struct ObjSymbol
 
 #include "arraytypes.h"
 
-typedef Array<ObjModule> ObjModules;
-typedef Array<ObjSymbol> ObjSymbols;
+typedef Array<ObjModule *> ObjModules;
+typedef Array<ObjSymbol *> ObjSymbols;
 
 class LibElf : public Library
 {

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -45,8 +45,8 @@ struct ObjSymbol
 
 #include "arraytypes.h"
 
-typedef Array<ObjModule> ObjModules;
-typedef Array<ObjSymbol> ObjSymbols;
+typedef Array<ObjModule *> ObjModules;
+typedef Array<ObjSymbol *> ObjSymbols;
 
 class LibMach : public Library
 {

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -54,8 +54,8 @@ int ObjSymbol_cmp(const void *p, const void *q)
 
 #include "arraytypes.h"
 
-typedef Array<ObjModule> ObjModules;
-typedef Array<ObjSymbol> ObjSymbols;
+typedef Array<ObjModule *> ObjModules;
+typedef Array<ObjSymbol *> ObjSymbols;
 
 class LibMSCoff : public Library
 {

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -37,8 +37,8 @@ struct ObjSymbol
 
 #include "arraytypes.h"
 
-typedef Array<ObjModule> ObjModules;
-typedef Array<ObjSymbol> ObjSymbols;
+typedef Array<ObjModule *> ObjModules;
+typedef Array<ObjSymbol *> ObjSymbols;
 
 class LibOMF : public Library
 {

--- a/src/mars.h
+++ b/src/mars.h
@@ -120,8 +120,8 @@ struct OutBuffer;
 
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
-typedef Array<class Identifier> Identifiers;
-typedef Array<const char> Strings;
+typedef Array<class Identifier *> Identifiers;
+typedef Array<const char *> Strings;
 
 // Put command line switches in here
 struct Param

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -26,12 +26,12 @@ template <typename TYPE>
 struct Array
 {
     size_t dim;
-    TYPE **data;
+    TYPE *data;
 
   private:
     size_t allocdim;
     #define SMALLARRAYCAP       1
-    TYPE *smallarray[SMALLARRAYCAP];    // inline storage for small arrays
+    TYPE smallarray[SMALLARRAYCAP];    // inline storage for small arrays
 
   public:
     Array()
@@ -88,18 +88,18 @@ struct Array
                 }
                 else
                 {   allocdim = nentries;
-                    data = (TYPE **)mem.malloc(allocdim * sizeof(*data));
+                    data = (TYPE *)mem.malloc(allocdim * sizeof(*data));
                 }
             }
             else if (allocdim == SMALLARRAYCAP)
             {
                 allocdim = dim + nentries;
-                data = (TYPE **)mem.malloc(allocdim * sizeof(*data));
+                data = (TYPE *)mem.malloc(allocdim * sizeof(*data));
                 memcpy(data, &smallarray[0], dim * sizeof(*data));
             }
             else
             {   allocdim = dim + nentries;
-                data = (TYPE **)mem.realloc(data, allocdim * sizeof(*data));
+                data = (TYPE *)mem.realloc(data, allocdim * sizeof(*data));
             }
         }
     }
@@ -125,18 +125,18 @@ struct Array
                     mem.free(data);
                 }
                 else
-                    data = (TYPE **)mem.realloc(data, dim * sizeof(*data));
+                    data = (TYPE *)mem.realloc(data, dim * sizeof(*data));
             }
             allocdim = dim;
         }
     }
 
-    TYPE *pop()
+    TYPE pop()
     {
         return data[--dim];
     }
 
-    void shift(TYPE *ptr)
+    void shift(TYPE ptr)
     {
         reserve(1);
         memmove(data + 1, data, dim * sizeof(*data));
@@ -156,7 +156,7 @@ struct Array
         memset(data,0,dim * sizeof(data[0]));
     }
 
-    TYPE *tos()
+    TYPE tos()
     {
         return dim ? data[dim - 1] : NULL;
     }
@@ -184,12 +184,12 @@ struct Array
         }
     }
 
-    TYPE **tdata()
+    TYPE *tdata()
     {
         return data;
     }
 
-    TYPE*& operator[] (size_t index)
+    TYPE& operator[] (size_t index)
     {
 #ifdef DEBUG
         assert(index < dim);
@@ -197,7 +197,7 @@ struct Array
         return data[index];
     }
 
-    void insert(size_t index, TYPE *v)
+    void insert(size_t index, TYPE v)
     {
         reserve(1);
         memmove(data + index + 1, data + index, (dim - index) * sizeof(*data));
@@ -223,7 +223,7 @@ struct Array
         insert(dim, a);
     }
 
-    void push(TYPE *a)
+    void push(TYPE a)
     {
         reserve(1);
         data[dim++] = a;
@@ -238,11 +238,11 @@ struct Array
         return a;
     }
 
-    typedef int (*Array_apply_ft_t)(TYPE *, void *);
+    typedef int (*Array_apply_ft_t)(TYPE, void *);
     int apply(Array_apply_ft_t fp, void *param)
     {
         for (size_t i = 0; i < dim; i++)
-        {   TYPE *e = (*this)[i];
+        {   TYPE e = (*this)[i];
 
             if (e)
             {

--- a/src/root/file.h
+++ b/src/root/file.h
@@ -18,8 +18,7 @@
 
 #include "array.h"
 
-template <typename TYPE> struct Array;
-typedef Array<struct File> Files;
+typedef Array<struct File *> Files;
 
 struct FileName;
 

--- a/src/root/filename.h
+++ b/src/root/filename.h
@@ -19,7 +19,7 @@
 class RootObject;
 
 template <typename TYPE> struct Array;
-typedef Array<const char> Strings;
+typedef Array<const char *> Strings;
 
 struct FileName
 {

--- a/src/template.h
+++ b/src/template.h
@@ -59,7 +59,7 @@ public:
     Expression *constraint;
 
     // Hash table to look up TemplateInstance's of this TemplateDeclaration
-    Array<TemplateInstances> buckets;
+    Array<TemplateInstances *> buckets;
     size_t numinstances;                // number of instances in the hash table
 
     TemplateDeclaration *overnext;      // next overloaded TemplateDeclaration


### PR DESCRIPTION
`extern(C++)` classes translate to `Class *`, but D is incapable of passing the raw class type to a template.  The types passed must match exactly for mangling to be compatible.
