### PR TITLE
Workaround regression 11777.

### DIFF
--- a/src/scope.c
+++ b/src/scope.c
@@ -191,7 +191,10 @@ Scope *Scope::pop()
             size_t dim = fieldinit_dim;
             for (size_t i = 0; i < dim; i++)
                 enclosing->fieldinit[i] |= fieldinit[i];
+            /* Workaround regression @@@BUG11777@@@.
+            Probably this memory is used in future.
             mem.free(fieldinit);
+            */
             fieldinit = NULL;
         }
     }


### PR DESCRIPTION
Probably freed memory is used in future and refactoring commit triggered the issue by changing allocation functions.

Issue URL: https://d.puremagic.com/issues/show_bug.cgi?id=11777
Causing commit: 1e99eed73c06ae450c1c13352021e4b629d2bba8
