### PR TITLE
Fix fallback from {sc,dmd}1.conf to {sc,dmd}.conf

### DIFF
--- a/src/inifile.c
+++ b/src/inifile.c
@@ -156,7 +156,7 @@ const char *inifile(const char *argv0x, const char *inifilex, const char *envsec
     File file(filename);
 
     if (file.read())
-        return filename;                        // error reading file
+        return NULL;                        // error reading file
 
     // Parse into lines
     int eof = 0;

--- a/src/mars.c
+++ b/src/mars.c
@@ -540,7 +540,8 @@ int main(size_t argc, char *argv[])
     is64bit = parse_arch(dflags_argc, dflags_argv, is64bit);
     global.params.is64bit = is64bit;
 
-    inifile(argv[0], inifilename, is64bit ? "Environment64" : "Environment32");
+    if (inifilename != NULL)
+        inifile(argv[0], inifilename, is64bit ? "Environment64" : "Environment32");
 
     getenv_setargv("DFLAGS", &argc, &argv);
 


### PR DESCRIPTION
When adding support for {sc,dmd1}.conf in b269a91, a bug prevented the
to really fallback to {sc,dmd}.conf. This commit fixes this.
