### PR TITLE
[DDMD] Allocate File objects on the heap in lib*

### DIFF
--- a/src/libelf.c
+++ b/src/libelf.c
@@ -309,11 +309,11 @@ void LibElf::addObject(const char *module_name, void *buf, size_t buflen)
     if (!buf)
     {   assert(module_name[0]);
         FileName f((char *)module_name);
-        File file(&f);
-        readFile(Loc(), &file);
-        buf = file.buffer;
-        buflen = file.len;
-        file.ref = 1;
+        File *file = new File(&f);
+        readFile(Loc(), file);
+        buf = file->buffer;
+        buflen = file->len;
+        file->ref = 1;
         fromfile = 1;
     }
     int reason = 0;

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -322,11 +322,11 @@ void LibMach::addObject(const char *module_name, void *buf, size_t buflen)
     if (!buf)
     {   assert(module_name[0]);
         FileName f((char *)module_name);
-        File file(&f);
-        readFile(Loc(), &file);
-        buf = file.buffer;
-        buflen = file.len;
-        file.ref = 1;
+        File *file = new File(&f);
+        readFile(Loc(), file);
+        buf = file->buffer;
+        buflen = file->len;
+        file->ref = 1;
         fromfile = 1;
     }
     int reason = 0;

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -342,11 +342,11 @@ void LibMSCoff::addObject(const char *module_name, void *buf, size_t buflen)
     if (!buf)
     {   assert(module_name[0]);
         FileName f((char *)module_name);
-        File file(&f);
-        readFile(Loc(), &file);
-        buf = file.buffer;
-        buflen = file.len;
-        file.ref = 1;
+        File *file = new File(&f);
+        readFile(Loc(), file);
+        buf = file->buffer;
+        buflen = file->len;
+        file->ref = 1;
         fromfile = 1;
     }
     int reason = 0;

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -235,11 +235,11 @@ void LibOMF::addObject(const char *module_name, void *buf, size_t buflen)
     if (!buf)
     {   assert(module_name);
         FileName f((char *)module_name);
-        File file(&f);
-        readFile(Loc(), &file);
-        buf = file.buffer;
-        buflen = file.len;
-        file.ref = 1;
+        File *file = new File(&f);
+        readFile(Loc(), file);
+        buf = file->buffer;
+        buflen = file->len;
+        file->ref = 1;
     }
 
     unsigned g_page_size;


### PR DESCRIPTION
With `File` defined in D, calling the destructor does not work.  The buffer is always leaked, so leaking the `File` is a very small additional overhead.
