### PR TITLE
Remove unnecessary class BoolExp

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3754,12 +3754,6 @@ elem *PtrExp::toElem(IRState *irs)
     return e;
 }
 
-elem *BoolExp::toElem(IRState *irs)
-{
-    elem *e1 = this->e1->toElem(irs);
-    return el_una(OPbool,type->totym(),e1);
-}
-
 elem *DeleteExp::toElem(IRState *irs)
 {   elem *e;
     int rtl;

--- a/src/expression.c
+++ b/src/expression.c
@@ -9629,33 +9629,6 @@ int NotExp::isBit()
 
 /************************************************************/
 
-BoolExp::BoolExp(Loc loc, Expression *e, Type *t)
-        : UnaExp(loc, TOKtobool, sizeof(BoolExp), e)
-{
-    type = t;
-}
-
-Expression *BoolExp::semantic(Scope *sc)
-{
-    if (!type)
-    {   // Note there is no operator overload
-        UnaExp::semantic(sc);
-        e1 = resolveProperties(sc, e1);
-        e1 = e1->checkToBoolean(sc);
-        if (e1->type == Type::terror)
-            return e1;
-        type = Type::tboolean;
-    }
-    return this;
-}
-
-int BoolExp::isBit()
-{
-    return true;
-}
-
-/************************************************************/
-
 DeleteExp::DeleteExp(Loc loc, Expression *e)
         : UnaExp(loc, TOKdelete, sizeof(DeleteExp), e)
 {

--- a/src/expression.h
+++ b/src/expression.h
@@ -1173,16 +1173,6 @@ public:
     elem *toElem(IRState *irs);
 };
 
-class BoolExp : public UnaExp
-{
-public:
-    BoolExp(Loc loc, Expression *e, Type *type);
-    Expression *semantic(Scope *sc);
-    Expression *optimize(int result, bool keepLvalue = false);
-    int isBit();
-    elem *toElem(IRState *irs);
-};
-
 class DeleteExp : public UnaExp
 {
 public:

--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -889,12 +889,6 @@ elem *PtrExp::toElem(IRState *irs)
     return NULL;
 }
 
-elem *BoolExp::toElem(IRState *irs)
-{
-    assert(0);
-    return NULL;
-}
-
 elem *DeleteExp::toElem(IRState *irs)
 {
     assert(0);

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -291,19 +291,6 @@ Expression *NotExp::optimize(int result, bool keepLvalue)
     return e;
 }
 
-Expression *BoolExp::optimize(int result, bool keepLvalue)
-{   Expression *e;
-
-    e1 = e1->optimize(result);
-    if (e1->isConst() == 1)
-    {
-        e = Bool(type, e1);
-    }
-    else
-        e = this;
-    return e;
-}
-
 Expression *SymOffExp::optimize(int result, bool keepLvalue)
 {
     assert(var);
@@ -1123,9 +1110,7 @@ Expression *AndAndExp::optimize(int result, bool keepLvalue)
             }
             else if (e1->isBool(true))
             {
-                if (type->toBasetype()->ty == Tvoid)
-                    e = e2;
-                else e = new BoolExp(loc, e2, type);
+                e = e2;
             }
         }
     }
@@ -1163,10 +1148,7 @@ Expression *OrOrExp::optimize(int result, bool keepLvalue)
             }
             else if (e1->isBool(false))
             {
-                if (type->toBasetype()->ty == Tvoid)
-                    e = e2;
-                else
-                    e = new BoolExp(loc, e2, type);
+                e = e2;
             }
         }
     }


### PR DESCRIPTION
`AndAndExp`/`OrOrExp` has already cast `e2` to `bool` if necessary, so there is no point wrapping it in this class.
