### PR TITLE
[REG2.065a] Issue 11755 - Operator <>= and !<>= with arrays make internal error in e2ir

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -13209,10 +13209,11 @@ Expression *CmpExp::semantic(Scope *sc)
         if (!e->type->isscalar() && e->type->equals(e1->type))
         {
             error("recursive opCmp expansion");
-            e = new ErrorExp();
+            return new ErrorExp();
         }
-        else if (e->op == TOKcall)
-        {   e = new CmpExp(op, loc, e, new IntegerExp(loc, 0, Type::tint32));
+        if (e->op == TOKcall)
+        {
+            e = new CmpExp(op, loc, e, new IntegerExp(loc, 0, Type::tint32));
             e = e->semantic(sc);
         }
         return e;
@@ -13233,12 +13234,6 @@ Expression *CmpExp::semantic(Scope *sc)
 
     type = Type::tboolean;
 
-    if (op == TOKunord || op == TOKlg || op == TOKleg || op == TOKule ||
-        op == TOKul || op == TOKuge || op == TOKug || op == TOKue)
-    {
-        warning("use std.math.isNaN to deal with NaN operands rather than floating point operator '%s'", Token::toChars(op));
-    }
-
     // Special handling for array comparisons
     t1 = e1->type->toBasetype();
     t2 = e2->type->toBasetype();
@@ -13250,7 +13245,10 @@ Expression *CmpExp::semantic(Scope *sc)
         if (t1next->implicitConvTo(t2next) < MATCHconst &&
             t2next->implicitConvTo(t1next) < MATCHconst &&
             (t1next->ty != Tvoid && t2next->ty != Tvoid))
+        {
             error("array comparison type mismatch, %s vs %s", t1next->toChars(), t2next->toChars());
+            return new ErrorExp();
+        }
         e = this;
     }
     else if (t1->ty == Tstruct || t2->ty == Tstruct ||
@@ -13260,25 +13258,73 @@ Expression *CmpExp::semantic(Scope *sc)
             error("need member function opCmp() for %s %s to compare", t2->toDsymbol(sc)->kind(), t2->toChars());
         else
             error("need member function opCmp() for %s %s to compare", t1->toDsymbol(sc)->kind(), t1->toChars());
-        e = new ErrorExp();
+        return new ErrorExp();
     }
     else if (t1->iscomplex() || t2->iscomplex())
     {
         error("compare not defined for complex operands");
-        e = new ErrorExp();
+        return new ErrorExp();
     }
     else if (t1->ty == Taarray || t2->ty == Taarray)
     {
         error("%s is not defined for associative arrays", Token::toChars(op));
-        e = new ErrorExp();
+        return new ErrorExp();
     }
     else if (t1->ty == Tvector)
+    {
         return incompatibleTypes();
+    }
     else
-    {   if (!e1->rvalue() || !e2->rvalue())
+    {
+        if (!e1->rvalue() || !e2->rvalue())
             return new ErrorExp();
         e = this;
     }
+
+    TOK altop;
+    switch (op)
+    {
+        // Refer rel_integral[] table
+        case TOKunord:  altop = TOKerror;       break;
+        case TOKlg:     altop = TOKnotequal;    break;
+        case TOKleg:    altop = TOKerror;       break;
+        case TOKule:    altop = TOKle;          break;
+        case TOKul:     altop = TOKlt;          break;
+        case TOKuge:    altop = TOKge;          break;
+        case TOKug:     altop = TOKgt;          break;
+        case TOKue:     altop = TOKequal;       break;
+        default:        altop = TOKreserved;    break;
+    }
+    if (altop == TOKerror &&
+        (t1->ty == Tarray || t1->ty == Tsarray ||
+         t2->ty == Tarray || t2->ty == Tsarray))
+    {
+        error("'%s' is not defined for array comparisons", Token::toChars(op));
+        return new ErrorExp();
+    }
+    if (altop != TOKreserved)
+    {
+        if (!t1->isfloating())
+        {
+            if (altop == TOKerror)
+            {
+                const char *s = op == TOKunord ? "false" : "true";
+                warning("floating point operator '%s' always returns %s for non-floating comparisons",
+                    Token::toChars(op), s);
+            }
+            else
+            {
+                warning("use '%s' for non-floating comparisons rather than floating point operator '%s'",
+                    Token::toChars(altop), Token::toChars(op));
+            }
+        }
+        else
+        {
+            warning("use std.math.isNaN to deal with NaN operands rather than floating point operator '%s'",
+                Token::toChars(op));
+        }
+    }
+
     //printf("CmpExp: %s, type = %s\n", e->toChars(), e->type->toChars());
     return e;
 }

--- a/test/fail_compilation/ice11755.d
+++ b/test/fail_compilation/ice11755.d
@@ -1,0 +1,30 @@
+// REQUIRED_ARGS: -w
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice11755.d(20): Error: '!<>=' is not defined for array comparisons
+fail_compilation/ice11755.d(21): Warning: use '==' for non-floating comparisons rather than floating point operator '!<>'
+fail_compilation/ice11755.d(22): Warning: use '!=' for non-floating comparisons rather than floating point operator '<>'
+fail_compilation/ice11755.d(23): Error: '<>=' is not defined for array comparisons
+fail_compilation/ice11755.d(24): Warning: use '<=' for non-floating comparisons rather than floating point operator '!>'
+fail_compilation/ice11755.d(25): Warning: use '<' for non-floating comparisons rather than floating point operator '!>='
+fail_compilation/ice11755.d(26): Warning: use '>=' for non-floating comparisons rather than floating point operator '!<'
+fail_compilation/ice11755.d(27): Warning: use '>' for non-floating comparisons rather than floating point operator '!<='
+fail_compilation/ice11755.d(28): Warning: floating point operator '<>=' always returns true for non-floating comparisons
+fail_compilation/ice11755.d(29): Warning: floating point operator '!<>=' always returns false for non-floating comparisons
+---
+*/
+void main()
+{
+    int[] a, b;
+    auto r4 = a !<>= b; // TOKunord
+    auto r2 = a !<>  b; // TOKue
+    auto r1 = a  <>  b; // TOKlg
+    auto r3 = a  <>= b; // TOKleg
+    auto r8 = a !>   b; // TOKule
+    auto r7 = a !>=  b; // TOKul
+    auto r6 = a !<   b; // TOKuge
+    auto r5 = a !<=  b; // TOKug
+    assert((5 <>= 3) == 1);
+    assert((5 !<>= 3) == 0);
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11755

It's a git-head regression caused by #2960.

Currently backend layer implicitly translates NCEG operators to the corresponding integer operators in non-floating comparisons. If no corresponding operator exists, it had been reported backend error, and now ICE causes.
