### PR TITLE
[DDMD] Use factory functions instead of calling constructors from the glue layer

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -2153,6 +2153,11 @@ TypeInfoDeclaration::TypeInfoDeclaration(Type *tinfo, int internal)
     linkage = LINKc;
 }
 
+TypeInfoDeclaration *TypeInfoDeclaration::create(Type *tinfo, int internal)
+{
+    return new TypeInfoDeclaration(tinfo, internal);
+}
+
 Dsymbol *TypeInfoDeclaration::syntaxCopy(Dsymbol *s)
 {
     assert(0);          // should never be produced by syntax
@@ -2187,6 +2192,11 @@ TypeInfoConstDeclaration::TypeInfoConstDeclaration(Type *tinfo)
     type = Type::typeinfoconst->type;
 }
 
+TypeInfoConstDeclaration *TypeInfoConstDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoConstDeclaration(tinfo);
+}
+
 /***************************** TypeInfoInvariantDeclaration **********************/
 
 TypeInfoInvariantDeclaration::TypeInfoInvariantDeclaration(Type *tinfo)
@@ -2197,6 +2207,11 @@ TypeInfoInvariantDeclaration::TypeInfoInvariantDeclaration(Type *tinfo)
         ObjectNotFound(Id::TypeInfo_Invariant);
     }
     type = Type::typeinfoinvariant->type;
+}
+
+TypeInfoInvariantDeclaration *TypeInfoInvariantDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoInvariantDeclaration(tinfo);
 }
 
 /***************************** TypeInfoSharedDeclaration **********************/
@@ -2211,6 +2226,11 @@ TypeInfoSharedDeclaration::TypeInfoSharedDeclaration(Type *tinfo)
     type = Type::typeinfoshared->type;
 }
 
+TypeInfoSharedDeclaration *TypeInfoSharedDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoSharedDeclaration(tinfo);
+}
+
 /***************************** TypeInfoWildDeclaration **********************/
 
 TypeInfoWildDeclaration::TypeInfoWildDeclaration(Type *tinfo)
@@ -2221,6 +2241,11 @@ TypeInfoWildDeclaration::TypeInfoWildDeclaration(Type *tinfo)
         ObjectNotFound(Id::TypeInfo_Wild);
     }
     type = Type::typeinfowild->type;
+}
+
+TypeInfoWildDeclaration *TypeInfoWildDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoWildDeclaration(tinfo);
 }
 
 /***************************** TypeInfoStructDeclaration **********************/
@@ -2235,6 +2260,11 @@ TypeInfoStructDeclaration::TypeInfoStructDeclaration(Type *tinfo)
     type = Type::typeinfostruct->type;
 }
 
+TypeInfoStructDeclaration *TypeInfoStructDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoStructDeclaration(tinfo);
+}
+
 /***************************** TypeInfoClassDeclaration ***********************/
 
 TypeInfoClassDeclaration::TypeInfoClassDeclaration(Type *tinfo)
@@ -2245,6 +2275,11 @@ TypeInfoClassDeclaration::TypeInfoClassDeclaration(Type *tinfo)
         ObjectNotFound(Id::TypeInfo_Class);
     }
     type = Type::typeinfoclass->type;
+}
+
+TypeInfoClassDeclaration *TypeInfoClassDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoClassDeclaration(tinfo);
 }
 
 /***************************** TypeInfoInterfaceDeclaration *******************/
@@ -2259,6 +2294,11 @@ TypeInfoInterfaceDeclaration::TypeInfoInterfaceDeclaration(Type *tinfo)
     type = Type::typeinfointerface->type;
 }
 
+TypeInfoInterfaceDeclaration *TypeInfoInterfaceDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoInterfaceDeclaration(tinfo);
+}
+
 /***************************** TypeInfoTypedefDeclaration *********************/
 
 TypeInfoTypedefDeclaration::TypeInfoTypedefDeclaration(Type *tinfo)
@@ -2269,6 +2309,11 @@ TypeInfoTypedefDeclaration::TypeInfoTypedefDeclaration(Type *tinfo)
         ObjectNotFound(Id::TypeInfo_Typedef);
     }
     type = Type::typeinfotypedef->type;
+}
+
+TypeInfoTypedefDeclaration *TypeInfoTypedefDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoTypedefDeclaration(tinfo);
 }
 
 /***************************** TypeInfoPointerDeclaration *********************/
@@ -2283,6 +2328,11 @@ TypeInfoPointerDeclaration::TypeInfoPointerDeclaration(Type *tinfo)
     type = Type::typeinfopointer->type;
 }
 
+TypeInfoPointerDeclaration *TypeInfoPointerDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoPointerDeclaration(tinfo);
+}
+
 /***************************** TypeInfoArrayDeclaration ***********************/
 
 TypeInfoArrayDeclaration::TypeInfoArrayDeclaration(Type *tinfo)
@@ -2293,6 +2343,11 @@ TypeInfoArrayDeclaration::TypeInfoArrayDeclaration(Type *tinfo)
         ObjectNotFound(Id::TypeInfo_Array);
     }
     type = Type::typeinfoarray->type;
+}
+
+TypeInfoArrayDeclaration *TypeInfoArrayDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoArrayDeclaration(tinfo);
 }
 
 /***************************** TypeInfoStaticArrayDeclaration *****************/
@@ -2307,6 +2362,11 @@ TypeInfoStaticArrayDeclaration::TypeInfoStaticArrayDeclaration(Type *tinfo)
     type = Type::typeinfostaticarray->type;
 }
 
+TypeInfoStaticArrayDeclaration *TypeInfoStaticArrayDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoStaticArrayDeclaration(tinfo);
+}
+
 /***************************** TypeInfoAssociativeArrayDeclaration ************/
 
 TypeInfoAssociativeArrayDeclaration::TypeInfoAssociativeArrayDeclaration(Type *tinfo)
@@ -2317,6 +2377,11 @@ TypeInfoAssociativeArrayDeclaration::TypeInfoAssociativeArrayDeclaration(Type *t
         ObjectNotFound(Id::TypeInfo_AssociativeArray);
     }
     type = Type::typeinfoassociativearray->type;
+}
+
+TypeInfoAssociativeArrayDeclaration *TypeInfoAssociativeArrayDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoAssociativeArrayDeclaration(tinfo);
 }
 
 /***************************** TypeInfoVectorDeclaration ***********************/
@@ -2331,6 +2396,11 @@ TypeInfoVectorDeclaration::TypeInfoVectorDeclaration(Type *tinfo)
     type = Type::typeinfovector->type;
 }
 
+TypeInfoVectorDeclaration *TypeInfoVectorDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoVectorDeclaration(tinfo);
+}
+
 /***************************** TypeInfoEnumDeclaration ***********************/
 
 TypeInfoEnumDeclaration::TypeInfoEnumDeclaration(Type *tinfo)
@@ -2341,6 +2411,11 @@ TypeInfoEnumDeclaration::TypeInfoEnumDeclaration(Type *tinfo)
         ObjectNotFound(Id::TypeInfo_Enum);
     }
     type = Type::typeinfoenum->type;
+}
+
+TypeInfoEnumDeclaration *TypeInfoEnumDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoEnumDeclaration(tinfo);
 }
 
 /***************************** TypeInfoFunctionDeclaration ********************/
@@ -2355,6 +2430,11 @@ TypeInfoFunctionDeclaration::TypeInfoFunctionDeclaration(Type *tinfo)
     type = Type::typeinfofunction->type;
 }
 
+TypeInfoFunctionDeclaration *TypeInfoFunctionDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoFunctionDeclaration(tinfo);
+}
+
 /***************************** TypeInfoDelegateDeclaration ********************/
 
 TypeInfoDelegateDeclaration::TypeInfoDelegateDeclaration(Type *tinfo)
@@ -2367,6 +2447,11 @@ TypeInfoDelegateDeclaration::TypeInfoDelegateDeclaration(Type *tinfo)
     type = Type::typeinfodelegate->type;
 }
 
+TypeInfoDelegateDeclaration *TypeInfoDelegateDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoDelegateDeclaration(tinfo);
+}
+
 /***************************** TypeInfoTupleDeclaration **********************/
 
 TypeInfoTupleDeclaration::TypeInfoTupleDeclaration(Type *tinfo)
@@ -2377,6 +2462,11 @@ TypeInfoTupleDeclaration::TypeInfoTupleDeclaration(Type *tinfo)
         ObjectNotFound(Id::TypeInfo_Tuple);
     }
     type = Type::typeinfotypelist->type;
+}
+
+TypeInfoTupleDeclaration *TypeInfoTupleDeclaration::create(Type *tinfo)
+{
+    return new TypeInfoTupleDeclaration(tinfo);
 }
 
 /********************************* ThisDeclaration ****************************/

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -358,6 +358,7 @@ public:
     Type *tinfo;
 
     TypeInfoDeclaration(Type *tinfo, int internal);
+    static TypeInfoDeclaration *create(Type *tinfo, int internal);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     char *toChars();
@@ -376,6 +377,7 @@ class TypeInfoStructDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoStructDeclaration(Type *tinfo);
+    static TypeInfoStructDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -385,6 +387,7 @@ class TypeInfoClassDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoClassDeclaration(Type *tinfo);
+    static TypeInfoClassDeclaration *create(Type *tinfo);
     Symbol *toSymbol();
 
     void toDt(dt_t **pdt);
@@ -395,6 +398,7 @@ class TypeInfoInterfaceDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoInterfaceDeclaration(Type *tinfo);
+    static TypeInfoInterfaceDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -404,6 +408,7 @@ class TypeInfoTypedefDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoTypedefDeclaration(Type *tinfo);
+    static TypeInfoTypedefDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -413,6 +418,7 @@ class TypeInfoPointerDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoPointerDeclaration(Type *tinfo);
+    static TypeInfoPointerDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -422,6 +428,7 @@ class TypeInfoArrayDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoArrayDeclaration(Type *tinfo);
+    static TypeInfoArrayDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -431,6 +438,7 @@ class TypeInfoStaticArrayDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoStaticArrayDeclaration(Type *tinfo);
+    static TypeInfoStaticArrayDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -440,6 +448,7 @@ class TypeInfoAssociativeArrayDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoAssociativeArrayDeclaration(Type *tinfo);
+    static TypeInfoAssociativeArrayDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -449,6 +458,7 @@ class TypeInfoEnumDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoEnumDeclaration(Type *tinfo);
+    static TypeInfoEnumDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -458,6 +468,7 @@ class TypeInfoFunctionDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoFunctionDeclaration(Type *tinfo);
+    static TypeInfoFunctionDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -467,6 +478,7 @@ class TypeInfoDelegateDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoDelegateDeclaration(Type *tinfo);
+    static TypeInfoDelegateDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -476,6 +488,7 @@ class TypeInfoTupleDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoTupleDeclaration(Type *tinfo);
+    static TypeInfoTupleDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -485,6 +498,7 @@ class TypeInfoConstDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoConstDeclaration(Type *tinfo);
+    static TypeInfoConstDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -494,6 +508,7 @@ class TypeInfoInvariantDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoInvariantDeclaration(Type *tinfo);
+    static TypeInfoInvariantDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -503,6 +518,7 @@ class TypeInfoSharedDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoSharedDeclaration(Type *tinfo);
+    static TypeInfoSharedDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -512,6 +528,7 @@ class TypeInfoWildDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoWildDeclaration(Type *tinfo);
+    static TypeInfoWildDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
@@ -521,6 +538,7 @@ class TypeInfoVectorDeclaration : public TypeInfoDeclaration
 {
 public:
     TypeInfoVectorDeclaration(Type *tinfo);
+    static TypeInfoVectorDeclaration *create(Type *tinfo);
 
     void toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -72,6 +72,11 @@ Dsymbol::Dsymbol(Identifier *ident)
     this->ddocUnittest = NULL;
 }
 
+Dsymbol *Dsymbol::create(Identifier *ident)
+{
+    return new Dsymbol(ident);
+}
+
 bool Dsymbol::equals(RootObject *o)
 {
     if (this == o)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -142,6 +142,7 @@ public:
 
     Dsymbol();
     Dsymbol(Identifier *);
+    static Dsymbol *create(Identifier *);
     char *toChars();
     Loc& getLoc();
     char *locToChars();

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4991,7 +4991,7 @@ elem *AssocArrayLiteralExp::toElem(IRState *irs)
         else
         {   // It's the AssociativeArray type.
             // Turn it back into a TypeAArray
-            ta = new TypeAArray((*values)[0]->type, (*keys)[0]->type);
+            ta = TypeAArray::create((*values)[0]->type, (*keys)[0]->type);
             ta = ta->semantic(loc, NULL);
         }
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -51,6 +51,7 @@ elem *eval_Darray(IRState *irs, Expression *e, bool alwaysCopy = false);
 elem *array_toPtr(Type *t, elem *e);
 elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi);
 elem *ExpressionsToStaticArray(IRState *irs, Loc loc, Expressions *exps, symbol **psym);
+VarDeclarations *VarDeclarations_create();
 
 #define el_setLoc(e,loc)        ((e)->Esrcpos.Sfilename = (char *)(loc).filename, \
                                  (e)->Esrcpos.Slinnum = (loc).linnum)
@@ -1170,7 +1171,7 @@ elem *Dsymbol_toElem(Dsymbol *s, IRState *irs)
 
                 // Put vd on list of things needing destruction
                 if (!irs->varsInScope)
-                    irs->varsInScope = new VarDeclarations();
+                    irs->varsInScope = VarDeclarations_create();
                 irs->varsInScope->push(vd);
             }
         }

--- a/src/expression.c
+++ b/src/expression.c
@@ -3252,6 +3252,11 @@ IdentifierExp::IdentifierExp(Loc loc, Identifier *ident)
     this->ident = ident;
 }
 
+IdentifierExp *IdentifierExp::create(Loc loc, Identifier *ident)
+{
+    return new IdentifierExp(loc, ident);
+}
+
 Expression *IdentifierExp::semantic(Scope *sc)
 {
     Dsymbol *s;
@@ -3897,6 +3902,11 @@ StringExp::StringExp(Loc loc, void *string, size_t len, utf8_t postfix)
     this->committed = 0;
     this->postfix = postfix;
     this->ownedByCtfe = false;
+}
+
+StringExp *StringExp::create(Loc loc, char *s)
+{
+    return new StringExp(loc, s);
 }
 
 #if 0
@@ -4546,6 +4556,11 @@ StructLiteralExp::StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *
     this->stageflags = 0;
     this->inlinecopy = NULL;
     //printf("StructLiteralExp::StructLiteralExp(%s)\n", toChars());
+}
+
+StructLiteralExp *StructLiteralExp::create(Loc loc, StructDeclaration *sd, void *elements, Type *stype)
+{
+    return new StructLiteralExp(loc, sd, (Expressions *)elements, stype);
 }
 
 bool StructLiteralExp::equals(RootObject *o)
@@ -5606,6 +5621,11 @@ VarExp::VarExp(Loc loc, Declaration *var, bool hasOverloads)
     //printf("VarExp(this = %p, '%s', loc = %s)\n", this, var->toChars(), loc.toChars());
     //if (strcmp(var->ident->toChars(), "func") == 0) halt();
     this->type = var->type;
+}
+
+VarExp *VarExp::create(Loc loc, Declaration *var, bool hasOverloads)
+{
+    return new VarExp(loc, var, hasOverloads);
 }
 
 bool VarExp::equals(RootObject *o)
@@ -7363,6 +7383,11 @@ DotIdExp::DotIdExp(Loc loc, Expression *e, Identifier *ident)
     this->ident = ident;
 }
 
+DotIdExp *DotIdExp::create(Loc loc, Expression *e, Identifier *ident)
+{
+    return new DotIdExp(loc, e, ident);
+}
+
 Expression *DotIdExp::semantic(Scope *sc)
 {
 #if LOGSEMANTIC
@@ -8361,6 +8386,21 @@ CallExp::CallExp(Loc loc, Expression *e, Expression *earg1, Expression *earg2)
     (*arguments)[1] = earg2;
 
     this->arguments = arguments;
+}
+
+CallExp *CallExp::create(Loc loc, Expression *e, Expressions *exps)
+{
+    return new CallExp(loc, e, exps);
+}
+
+CallExp *CallExp::create(Loc loc, Expression *e)
+{
+    return new CallExp(loc, e);
+}
+
+CallExp *CallExp::create(Loc loc, Expression *e, Expression *earg1)
+{
+    return new CallExp(loc, e, earg1);
 }
 
 Expression *CallExp::syntaxCopy()

--- a/src/expression.h
+++ b/src/expression.h
@@ -310,6 +310,7 @@ public:
     Declaration *var;
 
     IdentifierExp(Loc loc, Identifier *ident);
+    static IdentifierExp *create(Loc loc, Identifier *ident);
     Expression *semantic(Scope *sc);
     char *toChars();
     void dump(int indent);
@@ -404,6 +405,7 @@ public:
     StringExp(Loc loc, char *s);
     StringExp(Loc loc, void *s, size_t len);
     StringExp(Loc loc, void *s, size_t len, utf8_t postfix);
+    static StringExp *create(Loc loc, char *s);
     //Expression *syntaxCopy();
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
@@ -556,6 +558,7 @@ public:
                                   // (with infinite recursion) of this expression.
 
     StructLiteralExp(Loc loc, StructDeclaration *sd, Expressions *elements, Type *stype = NULL);
+    static StructLiteralExp *create(Loc loc, StructDeclaration *sd, void *elements, Type *stype = NULL);
     bool equals(RootObject *o);
     Expression *syntaxCopy();
     int apply(apply_fp_t fp, void *param);
@@ -705,6 +708,7 @@ class VarExp : public SymbolExp
 {
 public:
     VarExp(Loc loc, Declaration *var, bool hasOverloads = false);
+    static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = false);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result, bool keepLvalue = false);
@@ -977,6 +981,7 @@ public:
     Identifier *ident;
 
     DotIdExp(Loc loc, Expression *e, Identifier *ident);
+    static DotIdExp *create(Loc loc, Expression *e, Identifier *ident);
     Expression *semantic(Scope *sc);
     Expression *semanticX(Scope *sc);
     Expression *semanticY(Scope *sc, int flag);
@@ -1065,6 +1070,10 @@ public:
     CallExp(Loc loc, Expression *e);
     CallExp(Loc loc, Expression *e, Expression *earg1);
     CallExp(Loc loc, Expression *e, Expression *earg1, Expression *earg2);
+
+    static CallExp *create(Loc loc, Expression *e, Expressions *exps);
+    static CallExp *create(Loc loc, Expression *e);
+    static CallExp *create(Loc loc, Expression *e, Expression *earg1);
 
     Expression *syntaxCopy();
     int apply(apply_fp_t fp, void *param);

--- a/src/glue.c
+++ b/src/glue.c
@@ -118,9 +118,9 @@ void obj_write_deferred(Library *library)
         else
         {
             idbuf.data = NULL;
-            Identifier *id = new Identifier(idstr, TOKidentifier);
+            Identifier *id = Identifier::create(idstr, TOKidentifier);
 
-            Module *md = new Module(mname, id, 0, 0);
+            Module *md = Module::create(mname, id, 0, 0);
             md->members = new Dsymbols();
             md->members->push(s);   // its only 'member' is s
             md->doppelganger = 1;       // identify this module as doppelganger
@@ -147,7 +147,7 @@ void obj_write_deferred(Library *library)
         fname = (char *)namebuf.extractData();
 
         //printf("writing '%s'\n", fname);
-        File *objfile = new File(fname);
+        File *objfile = File::create(fname);
         obj_end(library, objfile);
     }
     obj_symbols_towrite.dim = 0;
@@ -1001,29 +1001,29 @@ void FuncDeclaration::toObjFile(int multiobj)
              *   finally
              *     _c_trace_epi();
              */
-            StringExp *se = new StringExp(Loc(), s->Sident);
-            se->type = new TypeDArray(Type::tchar->immutableOf());
+            StringExp *se = StringExp::create(Loc(), s->Sident);
+            se->type = Type::tstring;
             se->type = se->type->semantic(Loc(), NULL);
             Expressions *exps = new Expressions();
             exps->push(se);
             FuncDeclaration *fdpro = FuncDeclaration::genCfunc(NULL, Type::tvoid, "trace_pro");
-            Expression *ec = new VarExp(Loc(), fdpro);
-            Expression *e = new CallExp(Loc(), ec, exps);
+            Expression *ec = VarExp::create(Loc(), fdpro);
+            Expression *e = CallExp::create(Loc(), ec, exps);
             e->type = Type::tvoid;
-            Statement *sp = new ExpStatement(loc, e);
+            Statement *sp = ExpStatement::create(loc, e);
 
             FuncDeclaration *fdepi = FuncDeclaration::genCfunc(NULL, Type::tvoid, "_c_trace_epi");
-            ec = new VarExp(Loc(), fdepi);
-            e = new CallExp(Loc(), ec);
+            ec = VarExp::create(Loc(), fdepi);
+            e = CallExp::create(Loc(), ec);
             e->type = Type::tvoid;
-            Statement *sf = new ExpStatement(loc, e);
+            Statement *sf = ExpStatement::create(loc, e);
 
             Statement *stf;
             if (sbody->blockExit(tf->isnothrow) == BEfallthru)
-                stf = new CompoundStatement(Loc(), sbody, sf);
+                stf = CompoundStatement::create(Loc(), sbody, sf);
             else
-                stf = new TryFinallyStatement(Loc(), sbody, sf);
-            sbody = new CompoundStatement(Loc(), sp, stf);
+                stf = TryFinallyStatement::create(Loc(), sbody, sf);
+            sbody = CompoundStatement::create(Loc(), sp, stf);
         }
 
         buildClosure(&irs);

--- a/src/glue.c
+++ b/src/glue.c
@@ -46,6 +46,8 @@ void Statement_toIR(Statement *s, IRState *irs);
 #define STATICCTOR      0
 
 typedef Array<symbol *> symbols;
+Dsymbols *Dsymbols_create();
+Expressions *Expressions_create();
 
 elem *eictor;
 symbol *ictorlocalgot;
@@ -121,7 +123,7 @@ void obj_write_deferred(Library *library)
             Identifier *id = Identifier::create(idstr, TOKidentifier);
 
             Module *md = Module::create(mname, id, 0, 0);
-            md->members = new Dsymbols();
+            md->members = Dsymbols_create();
             md->members->push(s);   // its only 'member' is s
             md->doppelganger = 1;       // identify this module as doppelganger
             md->md = m->md;
@@ -1004,7 +1006,7 @@ void FuncDeclaration::toObjFile(int multiobj)
             StringExp *se = StringExp::create(Loc(), s->Sident);
             se->type = Type::tstring;
             se->type = se->type->semantic(Loc(), NULL);
-            Expressions *exps = new Expressions();
+            Expressions *exps = Expressions_create();
             exps->push(se);
             FuncDeclaration *fdpro = FuncDeclaration::genCfunc(NULL, Type::tvoid, "trace_pro");
             Expression *ec = VarExp::create(Loc(), fdpro);

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3670,7 +3670,7 @@ STATIC code *asm_db_parse(OP *pop)
 
             case TOKidentifier:
             {
-                Expression *e = new IdentifierExp(asmstate.loc, asmtok->ident);
+                Expression *e = IdentifierExp::create(asmstate.loc, asmtok->ident);
                 Scope *sc = asmstate.sc->startCTFE();
                 e = e->semantic(sc);
                 sc->endCTFE();
@@ -3747,7 +3747,7 @@ int asm_getnum()
 
         case TOKidentifier:
         {
-            Expression *e = new IdentifierExp(asmstate.loc, asmtok->ident);
+            Expression *e = IdentifierExp::create(asmstate.loc, asmtok->ident);
             Scope *sc = asmstate.sc->startCTFE();
             e = e->semantic(sc);
             sc->endCTFE();
@@ -4449,13 +4449,13 @@ STATIC OPND *asm_primary_exp()
                     {   Expression *e;
                         VarExp *v;
 
-                        e = new IdentifierExp(asmstate.loc, id);
+                        e = IdentifierExp::create(asmstate.loc, id);
                         while (1)
                         {
                             asm_token();
                             if (tok_value == TOKidentifier)
                             {
-                                e = new DotIdExp(asmstate.loc, e, asmtok->ident);
+                                e = DotIdExp::create(asmstate.loc, e, asmtok->ident);
                                 asm_token();
                                 if (tok_value != TOKdot)
                                     break;
@@ -4725,8 +4725,8 @@ Statement *AsmStatement::semantic(Scope *sc)
     {
         asmstate.bInit = TRUE;
         init_optab();
-        asmstate.psDollar = new LabelDsymbol(Id::__dollar);
-        asmstate.psLocalsize = new Dsymbol(Id::__LOCAL_SIZE);
+        asmstate.psDollar = LabelDsymbol::create(Id::__dollar);
+        asmstate.psLocalsize = Dsymbol::create(Id::__LOCAL_SIZE);
     }
 
     asmstate.loc = loc;

--- a/src/identifier.c
+++ b/src/identifier.c
@@ -25,6 +25,11 @@ Identifier::Identifier(const char *string, int value)
     this->len = strlen(string);
 }
 
+Identifier *Identifier::create(const char *string, int value)
+{
+    return new Identifier(string, value);
+}
+
 bool Identifier::equals(RootObject *o)
 {
     return this == o || memcmp(string,o->toChars(),len+1) == 0;

--- a/src/identifier.h
+++ b/src/identifier.h
@@ -25,6 +25,7 @@ public:
     size_t len;
 
     Identifier(const char *string, int value);
+    static Identifier* create(const char *string, int value);
     bool equals(RootObject *o);
     int compare(RootObject *o);
     void print();

--- a/src/mars.c
+++ b/src/mars.c
@@ -1913,3 +1913,10 @@ static bool parse_arch(size_t argc, const char** argv, bool is64bit)
     }
     return is64bit;
 }
+
+Dsymbols *Dsymbols_create() { return new Dsymbols(); }
+Parameters *Parameters_create() { return new Parameters(); }
+Symbols *Symbols_create() { return new Symbols(); }
+VarDeclarations *VarDeclarations_create() { return new VarDeclarations(); }
+Blocks *Blocks_create() { return new Blocks(); }
+Expressions *Expressions_create() { return new Expressions(); }

--- a/src/module.c
+++ b/src/module.c
@@ -125,6 +125,11 @@ Module::Module(const char *filename, Identifier *ident, int doDocComment, int do
     symfile = new File(symfilename);
 }
 
+Module *Module::create(const char *filename, Identifier *ident, int doDocComment, int doHdrGen)
+{
+    return new Module(filename, ident, doDocComment, doHdrGen);
+}
+
 void Module::setDocfile()
 {
     docfile = setOutfile(global.params.docname, global.params.docdir, arg, global.doc_ext);

--- a/src/module.h
+++ b/src/module.h
@@ -112,6 +112,7 @@ public:
     size_t namelen;             // length of module name in characters
 
     Module(const char *arg, Identifier *ident, int doDocComment, int doHdrGen);
+    static Module* create(const char *arg, Identifier *ident, int doDocComment, int doHdrGen);
 
     static Module *load(Loc loc, Identifiers *packages, Identifier *ident);
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4724,6 +4724,11 @@ TypeAArray::TypeAArray(Type *t, Type *index)
     this->sc = NULL;
 }
 
+TypeAArray *TypeAArray::create(Type *t, Type *index)
+{
+    return new TypeAArray(t, index);
+}
+
 const char *TypeAArray::kind()
 {
     return "aarray";
@@ -5343,6 +5348,11 @@ TypeFunction::TypeFunction(Parameters *parameters, Type *treturn, int varargs, L
         this->trust = TRUSTsystem;
     if (stc & STCtrusted)
         this->trust = TRUSTtrusted;
+}
+
+TypeFunction *TypeFunction::create(Parameters *parameters, Type *treturn, int varargs, LINK linkage, StorageClass stc)
+{
+    return new TypeFunction(parameters, treturn, varargs, linkage, stc);
 }
 
 const char *TypeFunction::kind()
@@ -9702,6 +9712,11 @@ Parameter::Parameter(StorageClass storageClass, Type *type, Identifier *ident, E
     this->ident = ident;
     this->storageClass = storageClass;
     this->defaultArg = defaultArg;
+}
+
+Parameter *Parameter::create(StorageClass storageClass, Type *type, Identifier *ident, Expression *defaultArg)
+{
+    return new Parameter(storageClass, type, ident, defaultArg);
 }
 
 Parameter *Parameter::syntaxCopy()

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -9315,6 +9315,11 @@ TypeTuple::TypeTuple(Expressions *exps)
     //printf("TypeTuple() %p, %s\n", this, toChars());
 }
 
+TypeTuple *TypeTuple::create(Parameters *arguments)
+{
+    return new TypeTuple(arguments);
+}
+
 /*******************************************
  * Type tuple with 0, 1 or 2 types in it.
  */

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -993,6 +993,7 @@ public:
 
     TypeTuple(Parameters *arguments);
     TypeTuple(Expressions *exps);
+    static TypeTuple *create(Parameters *arguments);
     TypeTuple();
     TypeTuple(Type *t1);
     TypeTuple(Type *t1, Type *t2);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -555,6 +555,7 @@ public:
     StructDeclaration *impl;    // implementation
 
     TypeAArray(Type *t, Type *index);
+    static TypeAArray *create(Type *t, Type *index);
     const char *kind();
     Type *syntaxCopy();
     d_uns64 size(Loc loc);
@@ -663,6 +664,7 @@ public:
     int inuse;
 
     TypeFunction(Parameters *parameters, Type *treturn, int varargs, LINK linkage, StorageClass stc = 0);
+    static TypeFunction *create(Parameters *parameters, Type *treturn, int varargs, LINK linkage, StorageClass stc = 0);
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
@@ -1057,6 +1059,7 @@ public:
     Expression *defaultArg;
 
     Parameter(StorageClass storageClass, Type *type, Identifier *ident, Expression *defaultArg);
+    static Parameter *create(StorageClass storageClass, Type *type, Identifier *ident, Expression *defaultArg);
     Parameter *syntaxCopy();
     Type *isLazyArray();
     void toDecoBuffer(OutBuffer *buf);

--- a/src/root/file.c
+++ b/src/root/file.c
@@ -48,6 +48,11 @@ File::File(const FileName *n)
     name = (FileName *)n;
 }
 
+File *File::create(const char *n)
+{
+    return new File(n);
+}
+
 File::File(const char *n)
 {
     ref = 0;

--- a/src/root/file.h
+++ b/src/root/file.h
@@ -32,6 +32,7 @@ struct File
     FileName *name;             // name of our file
 
     File(const char *);
+    static File *create(const char *);
     File(const FileName *);
     ~File();
 

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -54,7 +54,7 @@ elem *exp2_copytotemp(elem *e);
 elem *incUsageElem(IRState *irs, Loc loc);
 StructDeclaration *needsPostblit(Type *t);
 elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
-
+Blocks *Blocks_create();
 
 #define elem_setLoc(e,loc)      ((e)->Esrcpos.Sfilename = (char *)(loc).filename, \
                                  (e)->Esrcpos.Slinnum = (loc).linnum)
@@ -106,7 +106,7 @@ block *labelToBlock(Loc loc, Blockx *blx, LabelDsymbol *label, int flag = 0)
         {
             // Keep track of the forward reference to this block, so we can check it later
             if (!s->fwdrefs)
-                s->fwdrefs = new Blocks();
+                s->fwdrefs = Blocks_create();
             s->fwdrefs->push(blx->curblock);
         }
     }

--- a/src/statement.c
+++ b/src/statement.c
@@ -338,6 +338,11 @@ ExpStatement::ExpStatement(Loc loc, Dsymbol *declaration)
     this->exp = new DeclarationExp(loc, declaration);
 }
 
+ExpStatement *ExpStatement::create(Loc loc, Expression *exp)
+{
+    return new ExpStatement(loc, exp);
+}
+
 Statement *ExpStatement::syntaxCopy()
 {
     Expression *e = exp ? exp->syntaxCopy() : NULL;
@@ -580,6 +585,11 @@ CompoundStatement::CompoundStatement(Loc loc, Statement *s1)
 {
     statements = new Statements();
     statements->push(s1);
+}
+
+CompoundStatement *CompoundStatement::create(Loc loc, Statement *s1, Statement *s2)
+{
+    return new CompoundStatement(loc, s1, s2);
 }
 
 Statement *CompoundStatement::syntaxCopy()
@@ -4785,6 +4795,11 @@ TryFinallyStatement::TryFinallyStatement(Loc loc, Statement *body, Statement *fi
     this->finalbody = finalbody;
 }
 
+TryFinallyStatement *TryFinallyStatement::create(Loc loc, Statement *body, Statement *finalbody)
+{
+    return new TryFinallyStatement(loc, body, finalbody);
+}
+
 Statement *TryFinallyStatement::syntaxCopy()
 {
     TryFinallyStatement *s = new TryFinallyStatement(loc,
@@ -5269,6 +5284,11 @@ LabelDsymbol::LabelDsymbol(Identifier *ident)
         : Dsymbol(ident)
 {
     statement = NULL;
+}
+
+LabelDsymbol *LabelDsymbol::create(Identifier *ident)
+{
+    return new LabelDsymbol(ident);
 }
 
 LabelDsymbol *LabelDsymbol::isLabel()           // is this a LabelDsymbol()?

--- a/src/statement.h
+++ b/src/statement.h
@@ -172,6 +172,7 @@ public:
 
     ExpStatement(Loc loc, Expression *exp);
     ExpStatement(Loc loc, Dsymbol *s);
+    static ExpStatement *create(Loc loc, Expression *exp);
     Statement *syntaxCopy();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
@@ -225,6 +226,7 @@ public:
     CompoundStatement(Loc loc, Statements *s);
     CompoundStatement(Loc loc, Statement *s1);
     CompoundStatement(Loc loc, Statement *s1, Statement *s2);
+    static CompoundStatement *create(Loc loc, Statement *s1, Statement *s2);
     Statement *syntaxCopy();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
@@ -814,6 +816,7 @@ public:
     Statement *finalbody;
 
     TryFinallyStatement(Loc loc, Statement *body, Statement *finalbody);
+    static TryFinallyStatement *create(Loc loc, Statement *body, Statement *finalbody);
     Statement *syntaxCopy();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
@@ -940,6 +943,7 @@ public:
     LabelStatement *statement;
 
     LabelDsymbol(Identifier *ident);
+    static LabelDsymbol *create(Identifier *ident);
     LabelDsymbol *isLabel();
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -43,6 +43,7 @@ void slist_add(Symbol *s);
 void slist_reset();
 
 Classsym *fake_classsym(Identifier *id);
+Symbols *Symbols_create();
 
 /********************************* SymbolDeclaration ****************************/
 
@@ -707,7 +708,7 @@ Symbol *TypeAArray::aaGetSymbol(const char *func, int flags)
         char *id = (char *)alloca(3 + strlen(func) + 1);
         sprintf(id, "_aa%s", func);
         if (!sarray)
-            sarray = new Symbols();
+            sarray = Symbols_create();
 
         // See if symbol is already in sarray
         for (size_t i = 0; i < sarray->dim; i++)

--- a/src/todt.c
+++ b/src/todt.c
@@ -642,7 +642,7 @@ void ClassDeclaration::toDt2(dt_t **pdt, ClassDeclaration *cd)
 void StructDeclaration::toDt(dt_t **pdt)
 {
     //printf("StructDeclaration::toDt(), this='%s'\n", toChars());
-    StructLiteralExp *sle = new StructLiteralExp(loc, this, NULL);
+    StructLiteralExp *sle = StructLiteralExp::create(loc, this, NULL);
     if (!fill(loc, sle->elements, true))
         assert(0);
 

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -777,7 +777,7 @@ Expression *createTypeInfoArray(Scope *sc, Expression *exps[], size_t dim)
     {   Parameter *arg = new Parameter(STCin, exps[i]->type, NULL, NULL);
         (*args)[i] = arg;
     }
-    TypeTuple *tup = new TypeTuple(args);
+    TypeTuple *tup = TypeTuple::create(args);
     Expression *e = tup->getTypeInfo(sc);
     e = e->optimize(WANTvalue);
     assert(e->op == TOKsymoff);         // should be SymOffExp

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -88,10 +88,10 @@ Expression *Type::getInternalTypeInfo(Scope *sc)
         Linternal:
             tid = internalTI[t->ty];
             if (!tid)
-            {   tid = new TypeInfoDeclaration(t, 1);
+            {   tid = TypeInfoDeclaration::create(t, 1);
                 internalTI[t->ty] = tid;
             }
-            e = new VarExp(Loc(), tid);
+            e = VarExp::create(Loc(), tid);
             e = e->addressOf(sc);
             e->type = tid->type;        // do this so we don't get redundant dereference
             return e;
@@ -125,13 +125,13 @@ Expression *Type::getTypeInfo(Scope *sc)
     if (!t->vtinfo)
     {
         if (t->isShared())      // does both 'shared' and 'shared const'
-            t->vtinfo = new TypeInfoSharedDeclaration(t);
+            t->vtinfo = TypeInfoSharedDeclaration::create(t);
         else if (t->isConst())
-            t->vtinfo = new TypeInfoConstDeclaration(t);
+            t->vtinfo = TypeInfoConstDeclaration::create(t);
         else if (t->isImmutable())
-            t->vtinfo = new TypeInfoInvariantDeclaration(t);
+            t->vtinfo = TypeInfoInvariantDeclaration::create(t);
         else if (t->isWild())
-            t->vtinfo = new TypeInfoWildDeclaration(t);
+            t->vtinfo = TypeInfoWildDeclaration::create(t);
         else
             t->vtinfo = t->getTypeInfoDeclaration();
         assert(t->vtinfo);
@@ -172,7 +172,7 @@ Expression *Type::getTypeInfo(Scope *sc)
     }
     if (!vtinfo)
         vtinfo = t->vtinfo;     // Types aren't merged, but we can share the vtinfo's
-    Expression *e = new VarExp(Loc(), t->vtinfo);
+    Expression *e = VarExp::create(Loc(), t->vtinfo);
     e = e->addressOf(sc);
     e->type = t->vtinfo->type;          // do this so we don't get redundant dereference
     return e;
@@ -181,70 +181,70 @@ Expression *Type::getTypeInfo(Scope *sc)
 TypeInfoDeclaration *Type::getTypeInfoDeclaration()
 {
     //printf("Type::getTypeInfoDeclaration() %s\n", toChars());
-    return new TypeInfoDeclaration(this, 0);
+    return TypeInfoDeclaration::create(this, 0);
 }
 
 TypeInfoDeclaration *TypeTypedef::getTypeInfoDeclaration()
 {
-    return new TypeInfoTypedefDeclaration(this);
+    return TypeInfoTypedefDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypePointer::getTypeInfoDeclaration()
 {
-    return new TypeInfoPointerDeclaration(this);
+    return TypeInfoPointerDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeDArray::getTypeInfoDeclaration()
 {
-    return new TypeInfoArrayDeclaration(this);
+    return TypeInfoArrayDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeSArray::getTypeInfoDeclaration()
 {
-    return new TypeInfoStaticArrayDeclaration(this);
+    return TypeInfoStaticArrayDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeAArray::getTypeInfoDeclaration()
 {
-    return new TypeInfoAssociativeArrayDeclaration(this);
+    return TypeInfoAssociativeArrayDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeStruct::getTypeInfoDeclaration()
 {
-    return new TypeInfoStructDeclaration(this);
+    return TypeInfoStructDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeClass::getTypeInfoDeclaration()
 {
     if (sym->isInterfaceDeclaration())
-        return new TypeInfoInterfaceDeclaration(this);
+        return TypeInfoInterfaceDeclaration::create(this);
     else
-        return new TypeInfoClassDeclaration(this);
+        return TypeInfoClassDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeVector::getTypeInfoDeclaration()
 {
-    return new TypeInfoVectorDeclaration(this);
+    return TypeInfoVectorDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeEnum::getTypeInfoDeclaration()
 {
-    return new TypeInfoEnumDeclaration(this);
+    return TypeInfoEnumDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeFunction::getTypeInfoDeclaration()
 {
-    return new TypeInfoFunctionDeclaration(this);
+    return TypeInfoFunctionDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeDelegate::getTypeInfoDeclaration()
 {
-    return new TypeInfoDelegateDeclaration(this);
+    return TypeInfoDelegateDeclaration::create(this);
 }
 
 TypeInfoDeclaration *TypeTuple::getTypeInfoDeclaration()
 {
-    return new TypeInfoTupleDeclaration(this);
+    return TypeInfoTupleDeclaration::create(this);
 }
 
 /****************************************************
@@ -691,7 +691,7 @@ void TypeInfoInterfaceDeclaration::toDt(dt_t **pdt)
     Symbol *s;
 
     if (!tc->sym->vclassinfo)
-        tc->sym->vclassinfo = new TypeInfoClassDeclaration(tc);
+        tc->sym->vclassinfo = TypeInfoClassDeclaration::create(tc);
     s = tc->sym->vclassinfo->toSymbol();
     dtxoff(pdt, s, 0);          // ClassInfo for tinfo
 }
@@ -774,7 +774,7 @@ Expression *createTypeInfoArray(Scope *sc, Expression *exps[], size_t dim)
     Parameters *args = new Parameters;
     args->setDim(dim);
     for (size_t i = 0; i < dim; i++)
-    {   Parameter *arg = new Parameter(STCin, exps[i]->type, NULL, NULL);
+    {   Parameter *arg = Parameter::create(STCin, exps[i]->type, NULL, NULL);
         (*args)[i] = arg;
     }
     TypeTuple *tup = TypeTuple::create(args);
@@ -838,7 +838,7 @@ Expression *createTypeInfoArray(Scope *sc, Expression *exps[], size_t dim)
         v->parent = m;
         sc = sc->pop();
     }
-    e = new VarExp(Loc(), v);
+    e = VarExp::create(Loc(), v);
     e = e->semantic(sc);
     return e;
 #endif

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -29,6 +29,8 @@
 
 #include "dt.h"
 
+Parameters *Parameters_create();
+
 /*
  * Used in TypeInfo*::toDt to verify the runtime TypeInfo sizes
  */
@@ -771,7 +773,7 @@ Expression *createTypeInfoArray(Scope *sc, Expression *exps[], size_t dim)
      * at the start of the called function by offseting into the TypeInfo_Tuple
      * reference.
      */
-    Parameters *args = new Parameters;
+    Parameters *args = Parameters_create();
     args->setDim(dim);
     for (size_t i = 0; i < dim; i++)
     {   Parameter *arg = Parameter::create(STCin, exps[i]->type, NULL, NULL);


### PR DESCRIPTION
D and C++ constructors have an important difference: D expects the memory to already contain `.init`, C++ constructors do not.  This makes calling D constructors from C++ much more complicated than simply matching mangling, unlike other functions.

This pull avoids the problem by defining factory functions which `new` the structs/classes from the D side, guaranteeing correct initialization and use of the correct heap.

My hope is that the dmd glue layer will eventually be converted to D and/or all ast class creation will be removed from the glue layer.

I'm open to other ideas, but this problem need to be fixed one way or another.
