### PR TITLE
[2.065,Reg] fix Issue 11684 - SIGSEGV with ld.bfd version 2.22

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -3435,7 +3435,7 @@ static void obj_rtinit()
 
             // relocation
             if (I64)
-                reltype = (config.flags3 & CFG3pic) ? R_X86_64_64 : R_X86_64_32;
+                reltype = R_X86_64_64;
             else
                 reltype = RI_TYPE_SYM32;
 

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -1168,9 +1168,11 @@ void Obj::term(const char *objfilename)
         if (pseg->SDbuf && pseg->SDbuf->size())
         {
             //printf(" - size %d\n",pseg->SDbuf->size());
-            sechdr->sh_size = pseg->SDbuf->size();
-            fobjbuf->write(pseg->SDbuf->buf, sechdr->sh_size);
-            foffset += sechdr->sh_size;
+            const size_t size = pseg->SDbuf->size();
+            fobjbuf->write(pseg->SDbuf->buf, size);
+            const long nfoffset = elf_align(sechdr->sh_addralign, foffset + size);
+            sechdr->sh_size = nfoffset - foffset;
+            foffset = nfoffset;
         }
         //printf(" assigned offset %d, size %d\n",foffset,sechdr->sh_size);
     }


### PR DESCRIPTION
- Don't use zero extended relocations in data segment,
  because we need to write out the whole 8-byte address.
- Data relocations don't depend on PIC.
- This regression was introduced with
  0cba87c6330cd7853139f51448c0f98372fb76d7.
  Before this commit the code still wrote out
  an 8-byte address, so the zero extension worked
  happened to work for <4GB binaries.

[Issue 11684](https://d.puremagic.com/issues/show_bug.cgi?id=11684)
