### PR TITLE
[REG2.060] Issue 11767 - doubly mixed-in struct "failed semantic analysis"

### DIFF
--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -1234,6 +1234,32 @@ class C11487
 }
 
 /*******************************************/
+// 11767
+
+mixin template M11767()
+{
+    struct S11767 {}
+}
+mixin M11767!();
+mixin M11767!();    // OK
+static assert(!__traits(compiles, S11767));
+
+void test11767()
+{
+    mixin M11767!();
+    alias S1 = S11767;
+    {
+        mixin M11767!();
+        alias S2 = S11767;
+        static assert(!is(S1 == S2));
+        static assert(S1.mangleof == "S6mixin19test11767FZv8__mixin16S11767");
+        static assert(S2.mangleof == "S6mixin19test11767FZv8__mixin26S11767");
+    }
+    mixin M11767!();
+    static assert(!__traits(compiles, S11767));
+}
+
+/*******************************************/
 
 int main()
 {
@@ -1282,6 +1308,7 @@ int main()
     test2740();
     test42();
     test9417();
+    test11767();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11767

Inherently this is a mangling issue, which had been hidden since 2a3db5d7afd0c26e8a0ec58ff6fb6a8cd9647de6, and then detected by [the assertion for AST sanity](20fe5e8600498fed322a7d5d8305acb2de852cde).

Each mixed-in symbols are in independent scope, and their mangled names should also be different.
To fix the issue, assign scope-local unique name for each unnamed `TemplateMixin`s, as same as lambdas.
