### PR TITLE
ErrorExp should not inherit from IntegerExp

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2922,9 +2922,9 @@ void IntegerExp::toMangleBuffer(OutBuffer *buf)
  */
 
 ErrorExp::ErrorExp()
-    : IntegerExp(Loc(), 0, Type::terror)
+    : Expression(Loc(), TOKerror, sizeof(ErrorExp))
 {
-    op = TOKerror;
+    type = Type::terror;
 }
 
 Expression *ErrorExp::toLvalue(Scope *sc, Expression *e)

--- a/src/expression.h
+++ b/src/expression.h
@@ -243,7 +243,7 @@ public:
     dt_t **toDt(dt_t **pdt);
 };
 
-class ErrorExp : public IntegerExp
+class ErrorExp : public Expression
 {
 public:
     ErrorExp();

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2352,7 +2352,7 @@ Expression *getVarExp(Loc loc, InterState *istate, Declaration *d, CtfeGoal goal
             {
                 if (e && !e->type)
                     e->type = v->type;
-                if (e)
+                if (e && e->op != TOKerror)
                 {
                     v->inuse++;
                     e = e->interpret(istate, ctfeNeedAnyValue);


### PR DESCRIPTION
Because, it's not an integer, does not behave like one, etc.

The interpret change is to keep the error messages identical in the test suite.  It could possibly be an improvement to let them change.
