### PR TITLE
Issue 10199 - labels cannot be used without a statement

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3930,7 +3930,9 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
                 Identifier *ident = token.ident;
                 nextToken();
                 nextToken();
-                if (token.value == TOKlcurly)
+                if (token.value == TOKrcurly)
+                    s = NULL;
+                else if (token.value == TOKlcurly)
                     s = parseStatement(PScurly | PSscope);
                 else
                     s = parseStatement(PSsemi_ok);

--- a/test/compilable/parse10199.d
+++ b/test/compilable/parse10199.d
@@ -1,0 +1,6 @@
+
+void main()
+{
+    goto label;
+label:
+}


### PR DESCRIPTION
Printing `label: {}` everywhere makes the ddmd generated code look fugly.

https://d.puremagic.com/issues/show_bug.cgi?id=10199
