### PR TITLE
[DDMD] Do not use array length trick

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -508,9 +508,10 @@ const char *StorageClassDeclaration::stcToChars(char tmp[], StorageClass& stc)
         { STCtrusted,      TOKat,       "trusted" },
         { STCsystem,       TOKat,       "system" },
         { STCdisable,      TOKat,       "disable" },
+        { 0,               TOKreserved }
     };
 
-    for (int i = 0; i < sizeof(table)/sizeof(table[0]); i++)
+    for (int i = 0; table[i].stc; i++)
     {
         StorageClass tbl = table[i].stc;
         assert(tbl & STCStorageClass);

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -539,11 +539,13 @@ const char *StorageClassDeclaration::stcToChars(char tmp[], StorageClass& stc)
 void StorageClassDeclaration::stcToCBuffer(OutBuffer *buf, StorageClass stc)
 {
     while (stc)
-    {   char tmp[20];
+    {
+        const size_t BUFFER_LEN = 20;
+        char tmp[BUFFER_LEN];
         const char *p = stcToChars(tmp, stc);
         if (!p)
             break;
-        assert(strlen(p) < sizeof(tmp) / sizeof(tmp[0]));
+        assert(strlen(p) < BUFFER_LEN);
         buf->writestring(p);
         buf->writeByte(' ');
     }

--- a/src/cond.c
+++ b/src/cond.c
@@ -234,9 +234,10 @@ bool VersionCondition::isPredefined(const char *ident)
         "assert",
         "all",
         "none",
+        NULL
     };
 
-    for (unsigned i = 0; i < sizeof(reserved) / sizeof(reserved[0]); i++)
+    for (unsigned i = 0; reserved[i]; i++)
     {
         if (strcmp(ident, reserved[i]) == 0)
             return true;

--- a/src/doc.c
+++ b/src/doc.c
@@ -1933,9 +1933,9 @@ Lno:
 
 int isKeyword(utf8_t *p, size_t len)
 {
-    static const char *table[] = { "true", "false", "null" };
+    static const char *table[] = { "true", "false", "null", NULL };
 
-    for (int i = 0; i < sizeof(table) / sizeof(table[0]); i++)
+    for (int i = 0; table[i]; i++)
     {
         if (cmp(table[i], p, len) == 0)
             return 1;

--- a/src/doc.c
+++ b/src/doc.c
@@ -1398,9 +1398,9 @@ void Section::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
         {       "AUTHORS", "BUGS", "COPYRIGHT", "DATE",
                 "DEPRECATED", "EXAMPLES", "HISTORY", "LICENSE",
                 "RETURNS", "SEE_ALSO", "STANDARDS", "THROWS",
-                "VERSION" };
+                "VERSION", NULL };
 
-        for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++)
+        for (size_t i = 0; table[i]; i++)
         {
             if (icmp(table[i], name, namelen) == 0)
             {

--- a/src/expression.c
+++ b/src/expression.c
@@ -3042,9 +3042,10 @@ void floatToBuffer(OutBuffer *buf, Type *type, real_t value)
      * "-1.18973e+4932\0".length == 17
      * "-0xf.fffffffffffffffp+16380\0".length == 28
      */
-    char buffer[32];
+    const size_t BUFFER_LEN = 32;
+    char buffer[BUFFER_LEN];
     ld_sprint(buffer, 'g', value);
-    assert(strlen(buffer) < sizeof(buffer) / sizeof(buffer[0]));
+    assert(strlen(buffer) < BUFFER_LEN);
 
     real_t r = Port::strtold(buffer, NULL);
     if (r != value)                     // if exact duplication

--- a/src/expression.c
+++ b/src/expression.c
@@ -3101,9 +3101,10 @@ void realToMangleBuffer(OutBuffer *buf, real_t value)
         buf->writestring(value < 0 ? "NINF" : "INF");
     else
     {
-        char buffer[36];
+        const size_t BUFFER_LEN = 36;
+        char buffer[BUFFER_LEN];
         size_t n = ld_sprint(buffer, 'A', value);
-        assert(n < sizeof(buffer) / sizeof(buffer[0]));
+        assert(n < BUFFER_LEN);
         for (int i = 0; i < n; i++)
         {   char c = buffer[i];
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -2953,14 +2953,15 @@ char *RealExp::toChars()
     of 256 (3 characters). The string will be "-M.MMMMe-4932".
     (ie, 8 chars more than mantissa). Plus one for trailing \0.
     Plus one for rounding. */
-    char buffer[sizeof(value) * 3 + 8 + 1 + 1];
+    const size_t BUFFER_LEN = sizeof(value) * 3 + 8 + 1 + 1;
+    char buffer[BUFFER_LEN];
 
     ld_sprint(buffer, 'g', value);
 
     if (type->isimaginary())
         strcat(buffer, "i");
 
-    assert(strlen(buffer) < sizeof(buffer) / sizeof(buffer[0]));
+    assert(strlen(buffer) < BUFFER_LEN);
     return mem.strdup(buffer);
 }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -3150,15 +3150,16 @@ ComplexExp::ComplexExp(Loc loc, complex_t value, Type *type)
 
 char *ComplexExp::toChars()
 {
-    char buffer[sizeof(value) * 3 + 8 + 1];
+    const size_t BUFFER_LEN = sizeof(value) * 3 + 8 + 1 + 1;
+    char buffer[BUFFER_LEN];
 
-    char buf1[sizeof(value) * 3 + 8 + 1];
-    char buf2[sizeof(value) * 3 + 8 + 1];
+    char buf1[BUFFER_LEN];
+    char buf2[BUFFER_LEN];
 
     ld_sprint(buf1, 'g', creall(value));
     ld_sprint(buf2, 'g', cimagl(value));
     sprintf(buffer, "(%s+%si)", buf1, buf2);
-    assert(strlen(buffer) < sizeof(buffer) / sizeof(buffer[0]));
+    assert(strlen(buffer) < BUFFER_LEN);
     return mem.strdup(buffer);
 }
 

--- a/src/imphint.c
+++ b/src/imphint.c
@@ -32,6 +32,7 @@ const char *importHint(const char *s)
         "std.stdio",
         "std.math",
         "core.vararg",
+        NULL
     };
     static const char *names[] =
     {
@@ -41,14 +42,15 @@ const char *importHint(const char *s)
         "__va_argsave_t", NULL,
     };
     int m = 0;
-    for (int n = 0; n < sizeof(names)/sizeof(names[0]); n++)
+    for (int n = 0; modules[m]; n++)
     {
         const char *p = names[n];
         if (p == NULL)
-        {   m++;
+        {
+            m++;
             continue;
         }
-        assert(m < sizeof(modules)/sizeof(modules[0]));
+        assert(modules[m]);
         if (strcmp(s, p) == 0)
             return modules[m];
     }

--- a/src/json.c
+++ b/src/json.c
@@ -339,10 +339,11 @@ public:
 
             while (stc)
             {
-                char tmp[20];
+                const size_t BUFFER_LEN = 20;
+                char tmp[BUFFER_LEN];
                 const char *p = StorageClassDeclaration::stcToChars(tmp, stc);
                 assert(p);
-                assert(strlen(p) < sizeof(tmp) / sizeof(tmp[0]));
+                assert(strlen(p) < BUFFER_LEN);
                 if (p[0] == '@')
                 {
                     indent();

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2644,6 +2644,7 @@ struct Keyword
     TOK value;
 };
 
+static size_t nkeywords;
 static Keyword keywords[] =
 {
 //    { "",             TOK     },
@@ -2775,11 +2776,12 @@ static Keyword keywords[] =
     {   "__PRETTY_FUNCTION__", TOKprettyfunc   },
     {   "shared",       TOKshared       },
     {   "immutable",    TOKimmutable    },
+    {   NULL,           TOKreserved     }
 };
 
 int Token::isKeyword()
 {
-    for (size_t u = 0; u < sizeof(keywords) / sizeof(keywords[0]); u++)
+    for (size_t u = 0; u < nkeywords; u++)
     {
         if (keywords[u].value == value)
             return 1;
@@ -2789,17 +2791,15 @@ int Token::isKeyword()
 
 void Lexer::initKeywords()
 {
-    size_t nkeywords = sizeof(keywords) / sizeof(keywords[0]);
-
     stringtable._init(6151);
 
     cmtable_init();
 
-    for (size_t u = 0; u < nkeywords; u++)
+    for (nkeywords = 0; keywords[nkeywords].name; nkeywords++)
     {
         //printf("keyword[%d] = '%s'\n",u, keywords[u].name);
-        const char *s = keywords[u].name;
-        TOK v = keywords[u].value;
+        const char *s = keywords[nkeywords].name;
+        TOK v = keywords[nkeywords].value;
         StringValue *sv = stringtable.insert(s, strlen(s));
         sv->ptrvalue = (char *)new Identifier(sv->toDchars(),v);
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -53,7 +53,7 @@ inline bool isidchar(utf8_t c) { return (cmtable[c] & CMidchar) != 0; }
 
 static void cmtable_init()
 {
-    for (unsigned c = 0; c < sizeof(cmtable) / sizeof(cmtable[0]); c++)
+    for (unsigned c = 0; c < 256; c++)
     {
         if ('0' <= c && c <= '7')
             cmtable[c] |= CMoctal;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2622,10 +2622,12 @@ Identifier *Lexer::idPool(const char *s)
  */
 
 Identifier *Lexer::uniqueId(const char *s, int num)
-{   char buffer[32];
+{
+    const size_t BUFFER_LEN = 32;
+    char buffer[BUFFER_LEN];
     size_t slen = strlen(s);
 
-    assert(slen + sizeof(num) * 3 + 1 <= sizeof(buffer) / sizeof(buffer[0]));
+    assert(slen + sizeof(num) * 3 + 1 <= BUFFER_LEN);
     sprintf(buffer, "%s%d", s, num);
     return idPool(buffer);
 }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -280,9 +280,9 @@ void Type::init()
           Timaginary32, Timaginary64, Timaginary80,
           Tcomplex32, Tcomplex64, Tcomplex80,
           Tbool,
-          Tchar, Twchar, Tdchar };
+          Tchar, Twchar, Tdchar, Terror };
 
-    for (size_t i = 0; i < sizeof(basetab) / sizeof(basetab[0]); i++)
+    for (size_t i = 0; basetab[i] != Terror; i++)
     {   Type *t = new TypeBasic(basetab[i]);
         t = t->merge();
         basic[basetab[i]] = t;

--- a/src/root/speller.c
+++ b/src/root/speller.c
@@ -247,11 +247,12 @@ void unittest_speller()
         { "hello", "ehlxxlo", "n" },
         { "hello", "heaao", "y" },
         { "_123456789_123456789_123456789_123456789", "_123456789_123456789_123456789_12345678", "y" },
+        { NULL, NULL, NULL }
     };
     //printf("unittest_speller()\n");
     const void *p = speller("hello", &speller_test, (void *)"hell", idchars);
     assert(p != NULL);
-    for (int i = 0; i < sizeof(cases)/sizeof(cases[0]); i++)
+    for (int i = 0; cases[i][0]; i++)
     {
         //printf("case [%d]\n", i);
         void *p = speller(cases[i][0], &speller_test, (void *)cases[i][1], idchars);

--- a/src/statement.c
+++ b/src/statement.c
@@ -2189,7 +2189,8 @@ Lagain:
                   "wc","cc","wd",
                   "dc","dw","dd"
                 };
-                char fdname[7+1+2+ sizeof(dim)*3 + 1];
+                const size_t BUFFER_LEN = 7+1+2+ sizeof(dim)*3 + 1;
+                char fdname[BUFFER_LEN];
                 int flag;
 
                 switch (tn->ty)
@@ -2208,7 +2209,7 @@ Lagain:
                 }
                 const char *r = (op == TOKforeach_reverse) ? "R" : "";
                 int j = sprintf(fdname, "_aApply%s%.*s%llu", r, 2, fntab[flag], (ulonglong)dim);
-                assert(j < sizeof(fdname) / sizeof(fdname[0]));
+                assert(j < BUFFER_LEN);
 
                 FuncDeclaration *fdapply;
                 TypeDelegate *dgty;

--- a/src/utf.c
+++ b/src/utf.c
@@ -82,8 +82,7 @@ bool utf_isValidDchar(dchar_t c)
 
 bool isUniAlpha(dchar_t c)
 {
-    static size_t const END = sizeof(ALPHA_TABLE) / sizeof(ALPHA_TABLE[0]);
-    size_t high = END - 1;
+    size_t high = ALPHA_TABLE_LENGTH - 1;
     // Shortcut search if c is out of range
     size_t low
         = (c < ALPHA_TABLE[0][0] || ALPHA_TABLE[high][1] < c) ? high + 1 : 0;

--- a/src/utf.h
+++ b/src/utf.h
@@ -20,7 +20,8 @@ typedef unsigned short  utf16_t;
 typedef unsigned int    utf32_t;
 typedef utf32_t         dchar_t;
 
-static utf16_t const ALPHA_TABLE[][2] =
+#define ALPHA_TABLE_LENGTH 245
+static utf16_t const ALPHA_TABLE[ALPHA_TABLE_LENGTH][2] =
 {
     { 0x00AA, 0x00AA }, { 0x00B5, 0x00B5 }, { 0x00B7, 0x00B7 }, { 0x00BA, 0x00BA },
     { 0x00C0, 0x00D6 }, { 0x00D8, 0x00F6 }, { 0x00F8, 0x01F5 }, { 0x01FA, 0x0217 },


### PR DESCRIPTION
Remove code that looks like this: `sizeof(arr) / sizeof(arr[0])`

Obviously this doesn't work as-is in D, and the hack to support it is really really really really really really really ugly.

New code either uses a constant for the length, or a sentinel value.
