### PR TITLE
Set TARGET_WINDOS on the command line

### DIFF
--- a/src/mars.h
+++ b/src/mars.h
@@ -55,11 +55,6 @@ the target object file format:
     It is expected that the compiler for each platform will be able
     to generate 32 and 64 bit code from the same compiler binary.
 
-    Target object module format:
-        OMFOBJ          Intel Object Module Format, used on Windows
-        ELFOBJ          Elf Object Module Format, used on linux, FreeBSD, OpenBSD and Solaris
-        MACHOBJ         Mach-O Object Module Format, used on Mac OSX
-
     There are currently no macros for byte endianness order.
  */
 
@@ -88,26 +83,6 @@ void unittests();
 
 // Set if C++ mangling is done by the front end
 #define CPP_MANGLE (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
-
-// All targets are set on the command line via the compiler makefile.
-#if TARGET_WINDOS
-#ifndef OMFOBJ
-#define OMFOBJ 1
-#endif
-#endif
-
-#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-#ifndef ELFOBJ
-#define ELFOBJ 1
-#endif
-#endif
-
-#if TARGET_OSX
-#ifndef MACHOBJ
-#define MACHOBJ 1
-#endif
-#endif
-
 
 struct OutBuffer;
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -89,17 +89,10 @@ void unittests();
 // Set if C++ mangling is done by the front end
 #define CPP_MANGLE (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
 
-/* Other targets are TARGET_LINUX, TARGET_OSX, TARGET_FREEBSD, TARGET_OPENBSD and
- * TARGET_SOLARIS, which are
- * set on the command line via the compiler makefile.
- */
-
-#if _WIN32
-#ifndef TARGET_WINDOS
-#define TARGET_WINDOS 1         // Windows dmd generates Windows targets
-#endif
+// All targets are set on the command line via the compiler makefile.
+#if TARGET_WINDOS
 #ifndef OMFOBJ
-#define OMFOBJ TARGET_WINDOS
+#define OMFOBJ 1
 #endif
 #endif
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -128,9 +128,9 @@ BFLAGS=
 ##### Implementation variables (do not modify)
 
 # Compile flags
-CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DDM_TARGET_CPU_X86=1
+CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
 # Compile flags for modules with backend/toolkit dependencies
-MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DDM_TARGET_CPU_X86=1
+MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
 # Recursive make
 DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT)
 


### PR DESCRIPTION
Self explanatory.

Also, remove the `*OBJ` macros as the frontend should never need to know this information (and if it should, then we'll go through target.h for that).
