### PR TITLE
Remove special case powexp optimisation

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -536,16 +536,6 @@ Expression *Pow(Type *type, Expression *e1, Expression *e2)
         {
             e = new RealExp(loc, Port::ldbl_nan, type);
         }
-        else if (e2->toReal() == 0.5)
-        {
-            // Special case: call sqrt directly.
-            Expressions args;
-            args.setDim(1);
-            args[0] = e1;
-            e = eval_builtin(loc, BUILTINsqrt, &args);
-            if (!e)
-                e = EXP_CANT_INTERPRET;
-        }
         else
             e = EXP_CANT_INTERPRET;
     }

--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -3,7 +3,7 @@
 static assert(__LINE__ == 3); // fails as __LINE__ is 2
 
 import std.stdio;
-import std.math : signbit;
+import std.math : signbit, sqrt;
 
 
 /************************************/


### PR DESCRIPTION
Changes:

```
enum foo = x ^^ 0.5;
```

to:

```
import std.math;
enum foo = x ^^ 0.5
```

Is not really a nice optimisation to have special-cased internally, and blocks #2811
