### PR TITLE
[DDMD] Always create libs through named factory functions

### DIFF
--- a/src/lib.h
+++ b/src/lib.h
@@ -15,18 +15,32 @@
 #pragma once
 #endif /* __DMC__ */
 
+Library *LibMSCoff_factory();
+Library *LibOMF_factory();
+Library *LibElf_factory();
+Library *LibMach_factory();
+
 class Library
 {
   public:
-    static Library *factory();
+    static Library *factory()
+    {
+#if TARGET_WINDOS
+        return global.params.is64bit ? LibMSCoff_factory() : LibOMF_factory();
+#elif TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
+        return LibElf_factory();
+#elif TARGET_OSX
+        return LibMach_factory();
+#else
+        assert(0); // unsupported system
+#endif
+    }
 
     virtual void setFilename(const char *dir, const char *filename) = 0;
     virtual void addObject(const char *module_name, void *buf, size_t buflen) = 0;
     virtual void addLibrary(void *buf, size_t buflen) = 0;
     virtual void write() = 0;
 };
-
-Library *LibMSCoff_factory();
 
 #endif /* DMD_LIB_H */
 

--- a/src/libelf.c
+++ b/src/libelf.c
@@ -69,7 +69,7 @@ class LibElf : public Library
     Loc loc;
 };
 
-Library *Library::factory()
+Library *LibElf_factory()
 {
     return new LibElf();
 }

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -79,7 +79,7 @@ class LibMach : public Library
     Loc loc;
 };
 
-Library *Library::factory()
+Library *LibMach_factory()
 {
     return new LibMach();
 }

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -79,9 +79,9 @@ class LibOMF : public Library
     Loc loc;
 };
 
-Library *Library::factory()
+Library *LibOMF_factory()
 {
-    return global.params.is64bit ? LibMSCoff_factory() : new LibOMF();
+    return new LibOMF();
 }
 
 LibOMF::LibOMF()


### PR DESCRIPTION
@WalterBright I'm manually porting `lib*` and it does seem to work, but there are two downsides:
- It's hella tedious
- Now I'm going to have to manually port every change anyone makes to the C++ source

So please avoid any non-critical work on those files until after the D port.
