### PR TITLE
[REG2.065a] Issue 11822 - `-de` switch causees ICE with `auto` return and other stuff

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8466,8 +8466,6 @@ Lagain:
         error("function expected before (), not '%s'", e1->toChars());
         return new ErrorExp();
     }
-    else if (t1->ty == Terror)
-        return new ErrorExp();
     else if (t1->ty != Tfunction)
     {
         TypeFunction *tf;
@@ -8578,6 +8576,11 @@ Lagain:
             e1 = e;
         }
         t1 = tf;
+    }
+    else if (t1->nextOf() == Type::terror)
+    {
+        assert(t1->ty == Tfunction);
+        return new ErrorExp();
     }
     else if (e1->op == TOKvar)
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -8260,7 +8260,7 @@ Lagain:
 
         // Do overload resolution
         f = resolveFuncCall(loc, sc, s, tiargs, ue1 ? ue1->type : NULL, arguments);
-        if (!f || f->errors || f->type->ty == Terror)
+        if (!f || f->errors)
             return new ErrorExp();
 
         if (f->needThis())

--- a/src/expression.c
+++ b/src/expression.c
@@ -2217,8 +2217,6 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
                 outerfunc->toParent2()->isFuncDeclaration())
         {
             outerfunc = outerfunc->toParent2()->isFuncDeclaration();
-            if (outerfunc->type->ty == Terror)
-                return;
         }
 
         // Find the closest pure parent of the called function
@@ -2237,8 +2235,6 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
                 calledparent->toParent2()->isFuncDeclaration())
         {
             calledparent = calledparent->toParent2()->isFuncDeclaration();
-            if (calledparent->type->ty == Terror)
-                return;
         }
 
         /* Both escape!allocator and escapeImpl!allocator are impure at [a],

--- a/src/func.c
+++ b/src/func.c
@@ -571,17 +571,14 @@ void FuncDeclaration::semantic(Scope *sc)
         type = type->semantic(loc, sc);
         sc = sc->pop();
     }
-    if (type->ty != Tfunction)
+    assert(type->ty == Tfunction);
+    f = (TypeFunction *)type;
+    if (f->next == Type::terror)
     {
-        if (type->ty != Terror)
-        {
-            error("%s must be a function instead of %s", toChars(), type->toChars());
-            type = Type::terror;
-        }
         errors = true;
         return;
     }
-    else
+
     {
         // Merge back function attributes into 'originalType'.
         // It's used for mangling, ddoc, and json output.
@@ -597,7 +594,6 @@ void FuncDeclaration::semantic(Scope *sc)
         storage_class &= ~(STC_TYPECTOR | STC_FUNCATTR);
     }
 
-    f = (TypeFunction *)type;
     size_t nparams = Parameter::dim(f->parameters);
 
     if (storage_class & STCscope)
@@ -2136,6 +2132,7 @@ void FuncDeclaration::semantic3(Scope *sc)
         type = f->semantic(loc, sc);
         sc = sc->pop();
     }
+    assert(type->ty == Tfunction);
 
     /* If this function had speculatively instantiated, error reproduction will be
      * done by TemplateInstance::semantic.
@@ -2143,7 +2140,7 @@ void FuncDeclaration::semantic3(Scope *sc)
      */
     semanticRun = PASSsemantic3done;
     semantic3Errors = (global.errors != nerrors) || (fbody && fbody->isErrorStatement());
-    if (type->ty == Terror)
+    if (type->nextOf() == Type::terror)
         errors = true;
     //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", parent->toChars(), toChars(), sc, loc.toChars());
     //fflush(stdout);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6178,9 +6178,6 @@ Type *TypeDelegate::semantic(Loc loc, Scope *sc)
         return this;
     }
     next = next->semantic(loc,sc);
-    if (next->ty != Tfunction)
-        return terror;
-
     /* In order to deal with Bugzilla 4028, perhaps default arguments should
      * be removed from next before the merge.
      */

--- a/src/template.c
+++ b/src/template.c
@@ -2328,6 +2328,9 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
             if (!fd)
                 return 0;
 
+            if (fd->errors)
+                goto Lerror;
+
             Type *tthis_fd = fd->needThis() && !fd->isCtorDeclaration() ? tthis : NULL;
 
             TypeFunction *tf = (TypeFunction *)fd->type;
@@ -2531,9 +2534,9 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
         p.tthis_best = m->lastf->needThis() && !m->lastf->isCtorDeclaration() ? tthis : NULL;
 
         TypeFunction *tf = (TypeFunction *)m->lastf->type;
-        if (tf->ty == Terror)
-            goto Lerror;
         assert(tf->ty == Tfunction);
+        if (tf->next == Type::terror)
+            goto Lerror;
         if (!tf->callMatch(p.tthis_best, fargs))
         {
             m->count = 0;
@@ -2657,7 +2660,8 @@ FuncDeclaration *TemplateDeclaration::doHeaderInstantiation(
 
     scx = scx->pop();
 
-    return fd->type->ty == Tfunction ? fd : NULL;
+    assert(fd->type->ty == Tfunction);
+    return ((TypeFunction *)fd->type)->next == Type::terror ? NULL : fd;
 }
 
 bool TemplateDeclaration::hasStaticCtorOrDtor()

--- a/src/template.c
+++ b/src/template.c
@@ -2328,9 +2328,6 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
             if (!fd)
                 return 0;
 
-            if (fd->type->ty != Tfunction)
-                goto Lerror;
-
             Type *tthis_fd = fd->needThis() && !fd->isCtorDeclaration() ? tthis : NULL;
 
             TypeFunction *tf = (TypeFunction *)fd->type;
@@ -2356,9 +2353,6 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
         //printf("td = %s\n", td->toChars());
         for (size_t ovi = 0; f; f = f->overnext0, ovi++)
         {
-            if (f->type->ty != Tfunction || f->errors)
-                goto Lerror;
-
             /* This is a 'dummy' instance to evaluate constraint properly.
              */
             TemplateInstance *ti = new TemplateInstance(loc, td, tiargs);

--- a/test/fail_compilation/ice11822.d
+++ b/test/fail_compilation/ice11822.d
@@ -1,12 +1,10 @@
-
-
 // REQUIRED_ARGS: -de
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11822.d(32): Deprecation: function ice11822.d is deprecated
-fail_compilation/ice11822.d(21):        instantiated from here: S!(__lambda1)
-fail_compilation/ice11822.d(32):        instantiated from here: g!((n) => d(i))
+fail_compilation/ice11822.d(30): Deprecation: function ice11822.d is deprecated
+fail_compilation/ice11822.d(19):        instantiated from here: S!(__lambda1)
+fail_compilation/ice11822.d(30):        instantiated from here: g!((n) => d(i))
 ---
 */
 

--- a/test/fail_compilation/ice11850.d
+++ b/test/fail_compilation/ice11850.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11850.d(14): Error: incompatible types for ((a) < ([0])): 'uint[]' and 'int[]'
-fail_compilation/imports/a11850.d(9):        instantiated from here: FilterResult!(__lambda1, uint[][])
+fail_compilation/imports/a11850.d(8):        instantiated from here: FilterResult!(__lambda1, uint[][])
 fail_compilation/ice11850.d(14):        instantiated from here: filter!(uint[][])
 ---
 */

--- a/test/fail_compilation/ice11857.d
+++ b/test/fail_compilation/ice11857.d
@@ -1,19 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11857.d(10): Error: cannot have const out parameter of type const(int)
+fail_compilation/ice11857.d(9): Error: cannot have const out parameter of type const(int)
 ---
 */
 
-
 void t11857(T)(T) { }
 void t11857(T)(out T) if(false) { }
-
 
 void main()
 {
     const int n = 1;
     t11857(n); // causes ICE
 }
-
-

--- a/test/fail_compilation/imports/a11850.d
+++ b/test/fail_compilation/imports/a11850.d
@@ -1,7 +1,6 @@
 //import std.array, std.range;
 module imports.a11850;
 
-
 template filter(alias pred)
 {
     auto filter(Range)(Range rs)
@@ -10,12 +9,10 @@ template filter(alias pred)
     }
 }
 
-
 private struct FilterResult(alias pred, Range)
 {
     alias Range R;
     R _input;
-
 
     this(R r)
     {
@@ -26,12 +23,9 @@ private struct FilterResult(alias pred, Range)
         }
     }
 
-
     auto opSlice() { return this; }
 
-
     @property bool empty() { return _input.length == 0; }
-
 
     void popFront()
     {
@@ -41,11 +35,8 @@ private struct FilterResult(alias pred, Range)
         } while (_input.length != 0 && !pred(_input[0]));
     }
 
-
     @property auto ref front()
     {
         return _input[0];
     }
 }
-
-


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11822

This is caused by #2850.

`TypeFunction` is also used for the extra payload of function attributes. Therefore, even if function signature or its body has errors, we would be better to leave that `fd->type->ty == Tfunction`.
