### PR TITLE
[cleanup] Move CPP_MANGLE into cppmangle.c

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -26,7 +26,7 @@
 #include "import.h"
 #include "aggregate.h"
 
-#if CPP_MANGLE
+#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
 
 /* Do mangling for C++ linkage.
  * Follows Itanium C++ ABI 1.86
@@ -466,6 +466,14 @@ char *toCppMangle(Dsymbol *s)
         v.argsCppMangle(tf->parameters, tf->varargs);
     }
     return v.finish();
+}
+
+#else
+
+char *toCppMangle(Dsymbol *s)
+{
+    // Windows C++ mangling is done by C++ back end
+    return s->ident->toChars();
 }
 
 #endif

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -24,9 +24,7 @@
 #include "id.h"
 #include "module.h"
 
-#if CPP_MANGLE
 char *toCppMangle(Dsymbol *s);
-#endif
 
 /******************************************************************************
  *  isv     : for the enclosing auto functions of an inner class/struct type.
@@ -147,12 +145,7 @@ const char *Declaration::mangle(bool isv)
                     goto Lret;
 
                 case LINKcpp:
-#if CPP_MANGLE
                     p = toCppMangle(this);
-#else
-                    // Windows C++ mangling is done by C++ back end
-                    p = ident->toChars();
-#endif
                     goto Lret;
 
                 case LINKdefault:

--- a/src/mars.h
+++ b/src/mars.h
@@ -77,9 +77,6 @@ void unittests();
 #define MODULEINFO_IS_STRUCT 1   // if ModuleInfo is a struct rather than a class
 #define PULL93  0       // controversial pull #93 for bugzilla 3449
 
-// Set if C++ mangling is done by the front end
-#define CPP_MANGLE (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
-
 struct OutBuffer;
 
 // Can't include arraytypes.h here, need to declare these directly.

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -142,7 +142,7 @@ FRONTOBJ= enum.obj struct.obj dsymbol.obj import.obj id.obj \
 	staticassert.obj identifier.obj mtype.obj expression.obj \
 	optimize.obj template.obj lexer.obj declaration.obj cast.obj \
 	init.obj func.obj utf.obj parse.obj statement.obj \
-	constfold.obj version.obj inifile.obj \
+	constfold.obj version.obj inifile.obj cppmangle.obj \
 	module.obj scope.obj dump.obj cond.obj inline.obj opover.obj \
 	entity.obj class.obj mangle.obj attrib.obj impcnvtab.obj \
 	link.obj access.obj doc.obj macro.obj hdrgen.obj delegatize.obj \
@@ -700,6 +700,7 @@ class.obj : $(TOTALH) enum.h class.c
 clone.obj : $(TOTALH) clone.c
 constfold.obj : $(TOTALH) expression.h constfold.c
 cond.obj : $(TOTALH) identifier.h declaration.h cond.h cond.c
+cppmangle.obj : $(TOTALH) mtype.h declaration.h mars.h
 declaration.obj : $(TOTALH) identifier.h attrib.h declaration.h declaration.c expression.h
 delegatize.obj : $(TOTALH) delegatize.c
 doc.obj : $(TOTALH) doc.h doc.c


### PR DESCRIPTION
Now that we don't have `toCppMangle` methods scattered through the frontend, there is no need for the rest of the code to care about this.
