### PR TITLE
[cleanup] Remove PULL93 versioned-out code

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1159,23 +1159,6 @@ Lnomatch:
         AggregateDeclaration *aad = parent->isAggregateDeclaration();
         if (aad)
         {
-#if PULL93
-            assert(!(storage_class & (STCextern | STCstatic | STCtls | STCgshared)));
-            if (storage_class & (STCconst | STCimmutable) && init && !init->isVoidInitializer() &&
-                global.params.vfield)
-            {
-                const char *p = loc.toChars();
-                const char *s = (storage_class & STCimmutable) ? "immutable" : "const";
-                fprintf(global.stdmsg, "%s: %s.%s is %s field\n", p ? p : "", ad->toPrettyChars(), toChars(), s);
-            }
-            storage_class |= STCfield;
-            if (tbn->ty == Tstruct && ((TypeStruct *)tbn)->sym->noDefaultCtor ||
-                tbn->ty == Tclass  && ((TypeClass  *)tbn)->sym->noDefaultCtor)
-            {
-                if (!isThisDeclaration() && !init)
-                    aad->noDefaultCtor = true;
-            }
-#else
             if (storage_class & (STCconst | STCimmutable) && init && !init->isVoidInitializer())
             {
                 StorageClass stc = storage_class & (STCconst | STCimmutable);
@@ -1194,7 +1177,6 @@ Lnomatch:
                         aad->noDefaultCtor = true;
                 }
             }
-#endif
         }
 
         InterfaceDeclaration *id = parent->isInterfaceDeclaration();
@@ -1757,10 +1739,8 @@ AggregateDeclaration *VarDeclaration::isThis()
     if (!(storage_class & (STCstatic | STCextern | STCmanifest | STCtemplateparameter |
                            STCtls | STCgshared | STCctfe)))
     {
-#if !PULL93
         if ((storage_class & (STCconst | STCimmutable | STCwild)) && init)
             return NULL;
-#endif
         for (Dsymbol *s = this; s; s = s->parent)
         {
             ad = s->isMember();

--- a/src/expression.c
+++ b/src/expression.c
@@ -7819,12 +7819,9 @@ Expression *DotVarExp::semantic(Scope *sc)
             accessCheck(loc, sc, e1, var);
 
             VarDeclaration *v = var->isVarDeclaration();
-            if (!PULL93 || v && (v->isDataseg() || (v->storage_class & STCmanifest)))
-            {
-                Expression *e = expandVar(WANTvalue, v);
-                if (e)
-                    return e;
-            }
+            Expression *e = expandVar(WANTvalue, v);
+            if (e)
+                return e;
 
             if (v && v->isDataseg())     // fix bugzilla 8238
             {

--- a/src/mars.c
+++ b/src/mars.c
@@ -729,18 +729,10 @@ int tryMain(size_t argc, const char *argv[])
                 {
                     if (strcmp(p + 12, "?") == 0)
                     {
-#if PULL93
-                        printf("\
-Language changes listed by -transition=id:\n\
-  =field,3449    do list all non-mutable fields occupies object instance\n\
-  =tls           do list all variables going into thread local storage\n\
-");
-#else
                         printf("\
 Language changes listed by -transition=id:\n\
   =tls           do list all variables going into thread local storage\n\
 ");
-#endif
                         return EXIT_FAILURE;
                     }
                     if (isdigit((utf8_t)p[12]))
@@ -763,10 +755,6 @@ Language changes listed by -transition=id:\n\
                     {
                         if (strcmp(p + 12, "tls") == 0)
                             global.params.vtls = 1;
-#if PULL93
-                        if (strcmp(p + 12, "field") == 0)
-                            global.params.vfield = 1;
-#endif
                     }
                     else
                         goto Lerror;

--- a/src/mars.h
+++ b/src/mars.h
@@ -74,7 +74,6 @@ void unittests();
 
 #define DMDV1   0
 #define DMDV2   1       // Version 2.0 features
-#define PULL93  0       // controversial pull #93 for bugzilla 3449
 
 // Set if C++ mangling is done by the front end
 #define CPP_MANGLE (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)


### PR DESCRIPTION
It's still available in version control when we need to activate it etc

@9rnsr
