### PR TITLE
Add .travis.xml to test if the project builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+branches:
+  only:
+    - master
+script: make -C src -f posix.mak

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Build Status](https://travis-ci.org/D-Programming-Language/dmd.png?branch=dmd-1.x)](https://travis-ci.org/D-Programming-Language/dmd)


### PR DESCRIPTION
Currently the dmd-1.x branch is broken because it doesn't even compile. Having
Travis at least compiling this branch can help detecting these breakages.

Here is an example (failed) job:
https://travis-ci.org/llucax/dmd/jobs/16076233

To make this work, you need to also enable Travis for the repo, is very simple,
someone with access to the blessed repo needs to login to travis with the
GitHub account and enable travis for the dmd repository. Only the dmd-1.x
branch will be tested.
http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in

This also adds a simple README.md that shows the current build status.
