### PR TITLE
Fix Issue 11559 - Optlink crash with more than 2048 modules generated and debug info

### DIFF
--- a/test/compilable/test11559upgradeoptlink.d
+++ b/test/compilable/test11559upgradeoptlink.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -g
+
+// If this is failing, you need optlink 8.00.14 or higher
+
+string gen()
+{
+    string m;
+    foreach(i; 0..4096)
+        m ~= "mixin(\"assert(0);\n\n\n\n\");\n";
+    return m;
+}
+
+void main()
+{
+    mixin(gen());
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11559
