### PR TITLE
Allow eponymous template syntax with variables only for manifest constant declarations

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3405,6 +3405,8 @@ L2:
 
             if (tpl && init)
             {
+                if ((v->storage_class & STCmanifest) == 0)
+                    error("eponymous template syntax with variables is allowed only for enums");
                 Dsymbols *a2 = new Dsymbols();
                 a2->push(s);
                 TemplateDeclaration *tempdecl =
@@ -3479,6 +3481,8 @@ Dsymbols *Parser::parseAutoDeclarations(StorageClass storageClass, const utf8_t 
         Dsymbol *s = v;
         if (tpl)
         {
+            if ((v->storage_class & STCmanifest) == 0)
+                error("eponymous template syntax with variables is allowed only for enums");
             Dsymbols *a2 = new Dsymbols();
             a2->push(v);
             TemplateDeclaration *tempdecl =

--- a/test/compilable/testDIP42.d
+++ b/test/compilable/testDIP42.d
@@ -53,34 +53,7 @@ void test2()
 }
 
 /******************************************/
-// template auto declaration
-
-auto tynameLen(T) = T.stringof.length;
-
-void test3()
-{
-    assert(tynameLen!int == 3);
-    assert(tynameLen!long == 4);
-    tynameLen!int = 4;
-    tynameLen!long = 5;
-    assert(tynameLen!int == 4);
-    assert(tynameLen!long == 5);
-
-    // statement
-    auto tynameLen2(T) = T.stringof.length;
-
-    assert(tynameLen2!int == 3);
-    assert(tynameLen2!long == 4);
-    tynameLen2!int = 4;
-    tynameLen2!long = 5;
-    assert(tynameLen2!int == 4);
-    assert(tynameLen2!long == 5);
-}
-
-/******************************************/
 // template variable declaration
-
-static T math_pi(T) = cast(T)3.1415;
 
 enum bool isFloatingPoint(T) = is(T == float) || is(T == double);
 static assert( isFloatingPoint!double);
@@ -88,9 +61,6 @@ static assert(!isFloatingPoint!string);
 
 void main()
 {
-    assert(math_pi!int == 3);
-    assert(math_pi!double == 3.1415);
-
     enum bool isFloatingPoint2(T) = is(T == float) || is(T == double);
     static assert( isFloatingPoint2!double);
     static assert(!isFloatingPoint2!string);

--- a/test/fail_compilation/failDIP42.d
+++ b/test/fail_compilation/failDIP42.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/failDIP42.d(9): Error: eponymous template syntax with variables is allowed only for enums
+fail_compilation/failDIP42.d(10): Error: eponymous template syntax with variables is allowed only for enums
+---
+*/
+
+string v1(T) = T.stringof;
+static v2(T) = T.stringof;


### PR DESCRIPTION
I implemented the idea which came out from the discussion in #2467.
