### PR TITLE
Regression fix Issue 11591 - std.typecons.Tuple -s with classes fails at runtime as associative array keys

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4820,6 +4820,19 @@ printf("index->ito->ito = x%x\n", index->ito->ito);
             error(loc, "can't have associative array key of %s", index->toBasetype()->toChars());
         case Terror:
             return Type::terror;
+        case Tstruct:
+        {
+            /* AA's need opCmp. Issue error if not correctly set up.
+             */
+            TypeStruct *ts = (TypeStruct *)index->toBasetype();
+            if (ts->sym->xcmp == ts->sym->xerrcmp)
+            {
+                error(loc, "associative array key type %s does not have 'const int opCmp(ref const %s)' member function",
+                        index->toBasetype()->toChars(), ts->sym->toChars());
+                return Type::terror;
+            }
+            break;
+        }
     }
     next = next->semantic(loc,sc)->merge2();
     transitive();

--- a/test/fail_compilation/fail11591.d
+++ b/test/fail_compilation/fail11591.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11591.d(13): Error: associative array key type T does not have 'const int opCmp(ref const T)' member function
+---
+*/
+
+struct T {
+    bool opCmp(int i) { return false; }
+}
+
+void main() {
+    int[T] aa;
+}

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2415,6 +2415,11 @@ struct Test9386
         printf("Deleted %.*s\n", name.length, name.ptr);
         op ~= "c";
     }
+
+    const int opCmp(ref const Test9386 t)
+    {
+	return op[0] - t.op[0];
+    }
 }
 
 void test9386()

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -914,6 +914,7 @@ struct Property
 struct Value
 {
     int a,b,c,d;
+    const int opCmp(ref const Value v) { return 0; }
 }
 
 struct PropTable


### PR DESCRIPTION
This pushes a runtime error to a compile time error. It therefore has the potential to break existing code, but I suspect any such code was already broken (like the test12.d test case, see below).

The new error message also helpfully gives the correct form for the required opCmp function.

https://d.puremagic.com/issues/show_bug.cgi?id=11591
