### PR TITLE
Reference types are non-POD

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -1080,7 +1080,7 @@ bool StructDeclaration::fill(Loc loc, Expressions *elements, bool ctorinit)
  * This is defined as:
  *      not nested
  *      no postblits, destructors, or assignment operators
- *      no fields that are themselves non-POD
+ *      no 'ref' fields or fields that are themselves non-POD
  * The idea being these are compatible with C structs.
  */
 bool StructDeclaration::isPOD()
@@ -1099,7 +1099,11 @@ bool StructDeclaration::isPOD()
     {
         VarDeclaration *v = fields[i];
         if (v->storage_class & STCref)
-            continue;
+        {
+            ispod = ISPODno;
+            break;
+        }
+
         Type *tv = v->type->baseElemOf();
         if (tv->ty == Tstruct)
         {


### PR DESCRIPTION
This is code that I'm sure never hits as:
1. A `ref` field is not permitted in D
2. The `this` field used to be marked as `STCref`, however this is no more.

However, _if_... **if** someone decides that it might be a good idea to add ref fields to D, then it should not be ignored.  Reference types are not compatible with C structs, so mark it as non-POD and break.
