### PR TITLE
Relax isPOD rules so ctors don't make structs non-POD

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -978,13 +978,9 @@ bool StructDeclaration::fill(Loc loc, Expressions *elements, bool ctorinit)
  * Return true if struct is POD (Plain Old Data).
  * This is defined as:
  *      not nested
- *      no postblits, constructors, destructors, or assignment operators
+ *      no postblits, destructors, or assignment operators
  *      no fields that are themselves non-POD
  * The idea being these are compatible with C structs.
- *
- * Note that D struct constructors can mean POD, since there is always default
- * construction with no ctor, but that interferes with OPstrpar which wants it
- * on the stack in memory, not in registers.
  */
 bool StructDeclaration::isPOD()
 {
@@ -994,7 +990,7 @@ bool StructDeclaration::isPOD()
 
     ispod = ISPODyes;
 
-    if (enclosing || cpctor || postblit || ctor || dtor)
+    if (enclosing || cpctor || postblit || dtor)
         ispod = ISPODno;
 
     // Recursively check all fields are POD.

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -356,6 +356,10 @@ struct S11224
         ptr11224 = &this;
         /*printf("ctor &this = %p\n", &this);*/
     }
+    this(this)
+    {
+        /*printf("cpctor &this = %p\n", &this);*/
+    }
     int num;
 }
 S11224 foo11224()

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1060,28 +1060,28 @@ void test9091()
 
 /********************************************************/
 
-struct CtorS_9237 { this(int x) { } }
-struct DtorS_9237 { ~this() { } }
-struct PostblitS_9237 { this(this) { } }
+struct CtorS_9237 { this(int x) { } }       // ctor -> POD
+struct DtorS_9237 { ~this() { } }           // dtor -> nonPOD
+struct PostblitS_9237 { this(this) { } }    // cpctor -> nonPOD
 
 struct NonPOD1_9237
 {
-    CtorS_9237 field;  // nonPOD -> ng
+    DtorS_9237 field;  // nonPOD -> ng
 }
 
 struct NonPOD2_9237
 {
-    CtorS_9237[2] field;  // static array of nonPOD -> ng
+    DtorS_9237[2] field;  // static array of nonPOD -> ng
 }
 
 struct POD1_9237
 {
-    CtorS_9237* field;  // pointer to nonPOD -> ok
+    DtorS_9237* field;  // pointer to nonPOD -> ok
 }
 
 struct POD2_9237
 {
-    CtorS_9237[] field;  // dynamic array of nonPOD -> ok
+    DtorS_9237[] field;  // dynamic array of nonPOD -> ok
 }
 
 struct POD3_9237
@@ -1105,7 +1105,7 @@ void test9237()
     static assert(!__traits(isPOD, NS_9237));
     static assert(__traits(isPOD, NonNS_9237));
     static assert(__traits(isPOD, StatNS_9237));
-    static assert(!__traits(isPOD, CtorS_9237));
+    static assert(__traits(isPOD, CtorS_9237));
     static assert(!__traits(isPOD, DtorS_9237));
     static assert(!__traits(isPOD, PostblitS_9237));
     static assert(!__traits(isPOD, NonPOD1_9237));


### PR DESCRIPTION
I was scratching my head at this for sometime as initially it seemed that C++ had two conflicting standards.

However it seems quite clear that a POD _Aggregate_ must not have user-defined constructors (aggregate being any non-scalar and non-vector type, eg: static array or a class) and a POD _Struct_ may have a user-defined constructor - though it does not say this in writing, it only says what a POD Struct should not have. That being no destructors, copy constructors or assignment operators.

To still be compatible with C++, non-PODs must be passed by hidden/invisible reference.  Someone with DMD-backend knowledge will have to check this is the case.
