### PR TITLE
Static array of non-POD types should fail __traits(isPOD)

### DIFF
--- a/src/traits.c
+++ b/src/traits.c
@@ -261,8 +261,9 @@ Expression *TraitsExp::semantic(Scope *sc)
             error("type expected as second argument of __traits %s instead of %s", ident->toChars(), o->toChars());
             goto Lfalse;
         }
-        if (t->toBasetype()->ty == Tstruct
-              && ((sd = (StructDeclaration *)(((TypeStruct *)t->toBasetype())->sym)) != NULL))
+        Type *tb = t->baseElemOf();
+        if (tb->ty == Tstruct
+            && ((sd = (StructDeclaration *)(((TypeStruct *)tb)->sym)) != NULL))
         {
             if (sd->isPOD())
                 goto Ltrue;

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1114,6 +1114,19 @@ void test9237()
     static assert(__traits(isPOD, POD2_9237));
     static assert(__traits(isPOD, POD3_9237));
 
+    // static array of POD/non-POD types
+    static assert(!__traits(isPOD, NS_9237[2]));
+    static assert(__traits(isPOD, NonNS_9237[2]));
+    static assert(__traits(isPOD, StatNS_9237[2]));
+    static assert(__traits(isPOD, CtorS_9237[2]));
+    static assert(!__traits(isPOD, DtorS_9237[2]));
+    static assert(!__traits(isPOD, PostblitS_9237[2]));
+    static assert(!__traits(isPOD, NonPOD1_9237[2]));
+    static assert(!__traits(isPOD, NonPOD2_9237[2]));
+    static assert(__traits(isPOD, POD1_9237[2]));
+    static assert(__traits(isPOD, POD2_9237[2]));
+    static assert(__traits(isPOD, POD3_9237[2]));
+
     // non-structs are POD types
     static assert(__traits(isPOD, C_9273));
     static assert(__traits(isPOD, int));


### PR DESCRIPTION
Currently, all static arrays of non-POD types pass `__traits(isPOD)`.  This makes them an error.
