### PR TITLE
Fix 11877 : static opSlice not possible

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9609,17 +9609,18 @@ Lagain:
     if (Expression *ex = unaSemantic(sc))
         return ex;
     e1 = resolveProperties(sc, e1);
-    if (e1->op == TOKtype && e1->type->ty != Ttuple)
+
+    bool noBounds = (!lwr && !upr);
+
+    // if no bounds are mentioned explicitly, interpret it as array type declaration
+    // (when applied to types)
+    if (e1->op == TOKtype && e1->type->ty != Ttuple && noBounds)
     {
-        if (lwr || upr)
-        {
-            error("cannot slice type '%s'", e1->toChars());
-            return new ErrorExp();
-        }
         e = new TypeExp(loc, e1->type->arrayOf());
         return e->semantic(sc);
     }
-    if (!lwr && !upr)
+
+    if (noBounds)
     {
         if (e1->op == TOKarrayliteral)
         {   // Convert [a,b,c][] to [a,b,c]
@@ -9644,6 +9645,14 @@ Lagain:
 
     Type *t = e1->type->toBasetype();
     AggregateDeclaration *ad = isAggregate(t);
+
+    // opSlice can be overriden only for aggregate types
+    if ((e1->op == TOKtype) && (e1->type->ty != Ttuple) && (!ad))
+    {
+        error("Attempt to slice non-aggregate type (%s)", e1->toChars());
+        return new ErrorExp();
+    }
+
     if (t->ty == Tpointer)
     {
         if (!lwr || !upr)

--- a/test/compilable/test11877.d
+++ b/test/compilable/test11877.d
@@ -1,0 +1,19 @@
+struct X
+{
+    static size_t opSlice(size_t a, size_t b)
+    {
+        return a + b;
+    }
+
+    static size_t opDollar()
+    {
+        return 42;
+    }
+}
+
+static assert ( X[1..2]   == 3 );
+static assert ( X[1..$]   == 43 );
+static assert ( X[1..$-1] == 42 );
+
+// array type syntax still has priority
+static assert ( is(X[]) );


### PR DESCRIPTION
Relaxes requirements for opSlice syntax rewrites, details in bugzilla : https://d.puremagic.com/issues/show_bug.cgi?id=11877

``` D
struct X
{
    static int opSlice(size_t a, size_t b)
    {
        return 42;
    }
}

static assert ( X[1..2] == 42 );
```
