### PR TITLE
Issue 11881 - -betterC switch suffers from bit rot

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1233,7 +1233,8 @@ void FuncDeclaration::semantic3(Scope *sc)
                 }
             }
             else
-            {   // Call invariant virtually
+            {
+                // Call invariant virtually
                 Expression *v = new ThisExp(Loc());
                 v->type = vthis->type;
                 if (ad->isStructDeclaration())

--- a/src/mars.c
+++ b/src/mars.c
@@ -511,9 +511,9 @@ int tryMain(size_t argc, const char *argv[])
     Strings files;
     Strings libmodules;
     size_t argcstart = argc;
-    int setdebuglib = 0;
     char noboundscheck = 0;
-        int setdefaultlib = 0;
+    int setdebuglib = 0;
+    int setdefaultlib = 0;
     const char *inifilename = NULL;
     global.init();
 
@@ -1105,7 +1105,8 @@ Language changes listed by -transition=id:\n\
 #endif
 
     if (global.params.release)
-    {   global.params.useInvariants = 0;
+    {
+        global.params.useInvariants = 0;
         global.params.useIn = 0;
         global.params.useOut = 0;
         global.params.useAssert = 0;

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1052,6 +1052,9 @@ void TypeInfoDeclaration::toObjFile(int multiobj)
 {
     //printf("TypeInfoDeclaration::toObjFile(%p '%s') protection %d\n", this, toChars(), protection);
 
+    if (global.params.betterC)
+        return;
+
     if (multiobj)
     {
         obj_append(this);

--- a/test/runnable/test11881.d
+++ b/test/runnable/test11881.d
@@ -1,0 +1,46 @@
+// REQUIRED_ARGS: -defaultlib= -betterC
+
+import core.stdc.stdio : printf;
+
+struct S
+{
+    void foo()
+    {
+        printf("call S.foo, &this = %p\n", &this);
+    }
+}
+
+void test1()
+{
+    import std.algorithm : map;
+    int[3] sa = [1,2,3];
+    int[3] r;
+    size_t i = 0;
+    foreach (e; sa[].map!(a => a * 2))
+    {
+        r[i] = e;
+        printf("[%d] e = %d\n", i, e);
+        ++i;
+    }
+    assert(r[0] == 2 && r[1] == 4 && r[2] == 6);
+}
+
+extern(C) int main(int argc, char** argv)
+{
+    S s;
+    s.foo();
+
+    assert(1);
+
+    int[3] sa;
+    int[] a = sa[];
+    //a[] = 1;  // requires _memset32
+
+    int[] b = a[0..1];
+
+    int n = a[0];
+
+    test1();
+
+    return 0;
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11881

Try to implement my idea.

If `-betterC` switch is specified:
- Do not generate TypeInfo
- Use HLT for assertion failure and range violations.
