### PR TITLE
'align' attribute without argument to mean largest useful alignment

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -14,6 +14,7 @@
 #include <string.h>                     // memcpy()
 
 #include "rmem.h"
+#include "target.h"
 
 #include "init.h"
 #include "declaration.h"
@@ -789,7 +790,12 @@ void AlignDeclaration::semantic(Scope *sc)
     //printf("\tAlignDeclaration::semantic '%s'\n",toChars());
     if (decl)
     {
-        semanticNewSc(sc, sc->stc, sc->linkage, sc->protection, sc->explicitProtection, salign);
+        unsigned alignsize;
+        if (salign == STRUCTALIGN_DEFAULT)
+            alignsize = Target::maxalignsize;
+        else
+            alignsize = salign;
+        semanticNewSc(sc, sc->stc, sc->linkage, sc->protection, sc->explicitProtection, alignsize);
     }
 }
 

--- a/src/target.c
+++ b/src/target.c
@@ -17,6 +17,7 @@ int Target::ptrsize;
 int Target::realsize;
 int Target::realpad;
 int Target::realalignsize;
+int Target::maxalignsize;
 bool Target::reverseCppOverloads;
 
 
@@ -25,6 +26,7 @@ void Target::init()
     // These have default values for 32 bit code, they get
     // adjusted for 64 bit code.
     ptrsize = 4;
+    maxalignsize = 16;
 
     if (global.params.isLinux || global.params.isFreeBSD
         || global.params.isOpenBSD || global.params.isSolaris)

--- a/src/target.h
+++ b/src/target.h
@@ -22,6 +22,7 @@ struct Target
     static int realsize;        // size a real consumes in memory
     static int realpad;         // 'padding' added to the CPU real size to bring it up to realsize
     static int realalignsize;   // alignment for reals
+    static int maxalignsize;    // largest alignment used on target
     static bool reverseCppOverloads; // with dmc, overloaded functions are grouped and in reverse order
 
     static void init();


### PR DESCRIPTION
Reasoning posted here.

https://d.puremagic.com/issues/show_bug.cgi?id=11883

This is target-specific so a test case would not be useful in the slightest, however could add one in wrapped in `version(X86)` much to my dismay...  :o)
