### PR TITLE
no codegen for parts of failed template instantiations

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -104,7 +104,7 @@ int isError(RootObject *o)
     Dsymbol *s = isDsymbol(o);
     if (s->errors)
         return 1;
-    return 0;
+    return s && s->parent ? isError(s->parent) : 0;
 }
 
 /**************************************

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1145,7 +1145,7 @@ void TemplateInstance::toObjFile(int multiobj)
 #if LOG
     printf("TemplateInstance::toObjFile('%s', this = %p)\n", toChars(), this);
 #endif
-    if (!errors && members)
+    if (!isError(this) && members)
     {
         if (multiobj)
             // Append to list of object files to be written later


### PR DESCRIPTION
do not write failed template instantiations or parts of these to the object file.

This solves the duplicate COMDAT error in https://github.com/D-Programming-Language/phobos/pull/1411
