### PR TITLE
ini: Add support to define undefined variables

### DIFF
--- a/docs/man/man5/dmd.conf.5
+++ b/docs/man/man5/dmd.conf.5
@@ -18,9 +18,12 @@ conflicting use of environment variables.
 
 .SH SYNTAX
 Environment variables follow the [Environment] section heading, in
-name=value pairs. Comments are lines that start with ;. Variable names
-are always converted to uppercase, so if you use name=value, actually
-the variable with name NAME will be written.
+name=value or name?=value pairs. Comments are lines that start with ;.
+Variable names are always converted to uppercase, so if you use
+name=value, actually the variable with name NAME will be written.  If
+the name?=value syntax is used, the variable with NAME will only be
+written if it was defined before (in that case the original value is
+preserved).
 .PP
 
 .SH EXAMPLE

--- a/docs/man/man5/dmd.conf.5
+++ b/docs/man/man5/dmd.conf.5
@@ -17,9 +17,10 @@ This is handy to make dmd independent of programs with
 conflicting use of environment variables.
 
 .SH SYNTAX
-Environment variables follow the [Environment] section
-heading, in name=value pairs. Comments are lines that start
-with ;.
+Environment variables follow the [Environment] section heading, in
+name=value pairs. Comments are lines that start with ;. Variable names
+are always converted to uppercase, so if you use name=value, actually
+the variable with name NAME will be written.
 .PP
 
 .SH EXAMPLE

--- a/src/inifile.c
+++ b/src/inifile.c
@@ -289,6 +289,20 @@ const char *inifile(const char *argv0x, const char *inifilex, const char *envsec
                             memmove(p, p + 1, strlen(p));
                             p--;
                         }
+                        else if (p[0] == '?' && p[1] == '=')
+                        {
+                            *p = '\0';
+                            if (getenv(p))
+                            {
+                                pn = NULL;
+                                break;
+                            }
+                            // remove the '?' and resume parsing starting from
+                            // '=' again so the regular variable format is
+                            // parsed
+                            memmove(p, p + 1, strlen(p + 1) + 1);
+                            p--;
+                        }
                         else if (*p == '=')
                         {
                             p++;
@@ -298,11 +312,14 @@ const char *inifile(const char *argv0x, const char *inifilex, const char *envsec
                         }
                     }
 
-                    putenv(strdup(pn));
+                    if (pn)
+                    {
+                        putenv(strdup(pn));
 #if LOG
-                    printf("\tputenv('%s')\n", pn);
-                    //printf("getenv(\"TEST\") = '%s'\n",getenv("TEST"));
+                        printf("\tputenv('%s')\n", pn);
+                        //printf("getenv(\"TEST\") = '%s'\n",getenv("TEST"));
 #endif
+                    }
                 }
                 break;
         }

--- a/src/inifile.c
+++ b/src/inifile.c
@@ -285,7 +285,10 @@ const char *inifile(const char *argv0x, const char *inifilex, const char *envsec
                     {   if (islower((utf8_t)*p))
                             *p &= ~0x20;
                         else if (isspace((utf8_t)*p))
+                        {
                             memmove(p, p + 1, strlen(p));
+                            p--;
+                        }
                         else if (*p == '=')
                         {
                             p++;


### PR DESCRIPTION
Similarly to Make files, the syntax `VAR ?= value` is added to define
variables only when they were previously undefined.

In this case, if the environment variable `VAR` was undefined, then it
will be defined with the value `value`, otherwise the previous content
of `VAR` will be preserved.

This is useful to define default flags in the config file that can be
easily overridden by using environment variables.

This pull request also includes a bug fix and a dmd.conf man page
improvement.
