### PR TITLE
Track column numbers, add `-vcolumns` to display them in diagnostics

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -201,6 +201,7 @@ extern Config config;
 typedef struct Srcpos
 {
     unsigned Slinnum;           // 0 means no info available
+    unsigned Scharnum;
 #if SPP || SCPP
     struct Sfile **Sfilptr;     // file
     #define srcpos_sfile(p)     (**(p).Sfilptr)

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -27,7 +27,7 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
-extern void error(const char *filename, unsigned linnum, const char *format, ...);
+extern void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 
 STATIC elem * optelem(elem *,goal_t);
 STATIC elem * elarray(elem *e);
@@ -2192,7 +2192,7 @@ STATIC elem * elremquo(elem *e, goal_t goal)
 {
 #if 0 && MARS
     if (cnst(e->E2) && !boolres(e->E2))
-        error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, "divide by zero\n");
+        error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, e->Esrcpos.Scharnum, "divide by zero\n");
 #endif
     return e;
 }
@@ -2229,7 +2229,7 @@ STATIC elem * eldiv(elem *e, goal_t goal)
     {
 #if 0 && MARS
       if (!boolres(e2))
-        error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, "divide by zero\n");
+        error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, e->Esrcpos.Scharnum, "divide by zero\n");
 #endif
       if (uns)
       { int i;
@@ -5293,8 +5293,7 @@ elem *doptelem(elem *e, goal_t goal)
 
 void postoptelem(elem *e)
 {
-    int linnum = 0;
-    const char *filename = NULL;
+    Srcpos pos = {0};
 
     elem_debug(e);
     while (1)
@@ -5304,10 +5303,8 @@ void postoptelem(elem *e)
             /* This is necessary as the optimizer tends to lose this information
              */
 #if MARS
-            if (e->Esrcpos.Slinnum > linnum)
-            {   linnum = e->Esrcpos.Slinnum;
-                filename = e->Esrcpos.Sfilename;
-            }
+            if (e->Esrcpos.Slinnum > pos.Slinnum)
+                pos = e->Esrcpos;
 #endif
             if (e->Eoper == OPind)
             {
@@ -5315,7 +5312,7 @@ void postoptelem(elem *e)
                 if (e->E1->Eoper == OPconst &&
                     el_tolong(e->E1) >= 0 && el_tolong(e->E1) < 4096)
                 {
-                    error(filename, linnum, "null dereference in function %s", funcsym_p->Sident);
+                    error(pos.Sfilename, pos.Slinnum, pos.Scharnum, "null dereference in function %s", funcsym_p->Sident);
                     e->E1->EV.Vlong = 4096;     // suppress redundant messages
                 }
 #endif
@@ -5327,10 +5324,8 @@ void postoptelem(elem *e)
 #if MARS
             /* This is necessary as the optimizer tends to lose this information
              */
-            if (e->Esrcpos.Slinnum > linnum)
-            {   linnum = e->Esrcpos.Slinnum;
-                filename = e->Esrcpos.Sfilename;
-            }
+            if (e->Esrcpos.Slinnum > pos.Slinnum)
+                pos = e->Esrcpos;
 #endif
             if (e->Eoper == OPparam)
             {

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -34,10 +34,12 @@ struct Loc
 {
     char *filename;
     unsigned linnum;
+    unsigned charnum;
 
-    Loc(int x)
+    Loc(int y, int x)
     {
-        linnum = x;
+        linnum = y;
+        charnum = x;
         filename = NULL;
     }
 };
@@ -364,7 +366,7 @@ void objrecord(unsigned rectyp,const char *record,unsigned reclen)
  *      # of bytes stored
  */
 
-extern void error(const char *filename, unsigned linnum, const char *format, ...);
+extern void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 extern void fatal();
 
 void too_many_symbols()
@@ -372,7 +374,7 @@ void too_many_symbols()
 #if SCPP
     err_fatal(EM_too_many_symbols, 0x7FFF);
 #else // MARS
-    error(NULL, 0, "more than %d symbols in object file", 0x7FFF);
+    error(NULL, 0, 0, "more than %d symbols in object file", 0x7FFF);
     fatal();
 #endif
 }

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -61,7 +61,7 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
-extern void error(const char *filename, unsigned linnum, const char *format, ...);
+extern void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 
 #if __DMC__
     #define HAVE_FLOAT_EXCEPT 1
@@ -1407,7 +1407,7 @@ elem * evalu8(elem *e, goal_t goal)
 #if SCPP
                 synerr(EM_divby0);
 #else // MARS
-                //error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, "divide by zero");
+                //error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, e->Esrcpos.Scharnum, "divide by zero");
 #endif
                 break;
         }
@@ -2029,7 +2029,8 @@ elem * evalu8(elem *e, goal_t goal)
          */
         if (l1 >= 0 && l1 < 4096)
         {
-            error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, "dereference of null pointer");
+            error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, e->Esrcpos.Scharnum,
+                "dereference of null pointer");
             e->E1->EV.Vlong = 4096;     // suppress redundant messages
         }
 #endif

--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -29,7 +29,7 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
-extern void error(const char *filename, unsigned linnum, const char *format, ...);
+extern void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 
 STATIC void rd_free_elem(elem *e);
 STATIC void rd_compute();
@@ -427,7 +427,8 @@ STATIC void chkrd(elem *n,list_t rdlist)
             auto y = x;
         }
      */
-    error(n->Esrcpos.Sfilename, n->Esrcpos.Slinnum, "variable %s used before set", sv->Sident);
+    error(n->Esrcpos.Sfilename, n->Esrcpos.Slinnum, n->Esrcpos.Scharnum,
+        "variable %s used before set", sv->Sident);
 #endif
 
     sv->Sflags |= SFLnord;              // no redundant messages

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -55,7 +55,8 @@ VarDeclarations *VarDeclarations_create();
 type *Type_toCtype(Type *t);
 
 #define el_setLoc(e,loc)        ((e)->Esrcpos.Sfilename = (char *)(loc).filename, \
-                                 (e)->Esrcpos.Slinnum = (loc).linnum)
+                                 (e)->Esrcpos.Slinnum = (loc).linnum, \
+                                 (e)->Esrcpos.Scharnum = (loc).charnum)
 
 /* If variable var of type typ is a reference
  */

--- a/src/eh.c
+++ b/src/eh.c
@@ -40,7 +40,7 @@ static char __file__[] = __FILE__;      /* for tassert.h                */
 #error fix
 #endif
 
-extern void error(const char *filename, unsigned linnum, const char *format, ...);
+extern void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 
 /****************************
  * Generate and output scope table.
@@ -54,7 +54,7 @@ symbol *except_gentables()
         // BUG: alloca() changes the stack size, which is not reflected
         // in the fixed eh tables.
         if (usedalloca)
-            error(NULL, 0, "cannot mix core.std.stdlib.alloca() and exception handling in %s()", funcsym_p->Sident);
+            error(NULL, 0, 0, "cannot mix core.std.stdlib.alloca() and exception handling in %s()", funcsym_p->Sident);
 
         char name[13+5+1];
         static int tmpnum;

--- a/src/func.c
+++ b/src/func.c
@@ -2882,11 +2882,11 @@ Lerror:
         const char *lastprms = Parameter::argsTypesToChars(tf1->parameters, tf1->varargs);
         const char *nextprms = Parameter::argsTypesToChars(tf2->parameters, tf2->varargs);
         ::error(loc, "%s.%s called with argument types %s matches both:\n"
-                     "\t%s(%d): %s%s\nand:\n\t%s(%d): %s%s",
+                     "\t%s: %s%s\nand:\n\t%s: %s%s",
                 s->parent->toPrettyChars(), s->ident->toChars(),
                 fargsBuf.peekString(),
-                m.lastf->loc.filename, m.lastf->loc.linnum, m.lastf->toPrettyChars(), lastprms,
-                m.nextf->loc.filename, m.nextf->loc.linnum, m.nextf->toPrettyChars(), nextprms);
+                m.lastf->loc.toChars(), m.lastf->toPrettyChars(), lastprms,
+                m.nextf->loc.toChars(), m.nextf->toPrettyChars(), nextprms);
     }
     return NULL;
 }

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2142,6 +2142,7 @@ code *asm_genloc(Loc loc, code *c)
 
         memset(&srcpos, 0, sizeof(srcpos));
         srcpos.Slinnum = loc.linnum;
+        srcpos.Scharnum = loc.charnum;
         srcpos.Sfilename = (char *)loc.filename;
         pcLin = genlinnum(NULL, srcpos);
         c = cat(pcLin, c);

--- a/src/json.c
+++ b/src/json.c
@@ -360,7 +360,7 @@ public:
         }
     }
 
-    void property(const char *name, Loc *loc)
+    void property(const char *linename, const char *charname, Loc *loc)
     {
         if (loc)
         {
@@ -375,7 +375,11 @@ public:
             }
 
             if (loc->linnum)
-                property(name, loc->linnum);
+            {
+                property(linename, loc->linnum);
+                if (loc->charnum)
+                    property(charname, loc->charnum);
+            }
         }
     }
 
@@ -449,7 +453,7 @@ public:
 
         property("comment", (const char *)s->comment);
 
-        property("line", &s->loc);
+        property("line", "char", &s->loc);
     }
 
     void jsonProperties(Declaration *d)
@@ -543,7 +547,7 @@ public:
 
         property("kind", s->kind());
         property("comment", (const char *)s->comment);
-        property("line", &s->loc);
+        property("line", "char", &s->loc);
         if (s->prot() != PROTpublic)
             property("protection", Pprotectionnames[s->prot()]);
         if (s->aliasId)
@@ -691,7 +695,7 @@ public:
         if (tf && tf->ty == Tfunction)
             property("parameters", tf->parameters);
 
-        property("endline", &d->endloc);
+        property("endline", "endchar", &d->endloc);
 
         if (d->foverrides.dim)
         {

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -234,6 +234,7 @@ public:
     const utf8_t *base;        // pointer to start of buffer
     const utf8_t *end;         // past end of buffer
     const utf8_t *p;           // current character
+    const utf8_t *line;        // start of current line
     Token token;
     Module *mod;
     int doDocComment;           // collect doc comment information
@@ -265,6 +266,7 @@ public:
     void stringPostfix(Token *t);
     TOK number(Token *t);
     TOK inreal(Token *t);
+    Loc loc();
     void error(const char *format, ...);
     void error(Loc loc, const char *format, ...);
     void deprecation(const char *format, ...);
@@ -274,6 +276,9 @@ public:
 
     static int isValidIdentifier(const char *p);
     static const utf8_t *combineComments(const utf8_t *c1, const utf8_t *c2);
+
+private:
+    void endOfLine();
 };
 
 #endif /* DMD_LEXER_H */

--- a/src/libelf.c
+++ b/src/libelf.c
@@ -108,6 +108,7 @@ void LibElf::setFilename(const char *dir, const char *filename)
 
     loc.filename = libfile->name->toChars();
     loc.linnum = 0;
+    loc.charnum = 0;
 }
 
 void LibElf::write()

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -118,6 +118,7 @@ void LibMach::setFilename(const char *dir, const char *filename)
 
     loc.filename = libfile->name->toChars();
     loc.linnum = 0;
+    loc.charnum = 0;
 }
 
 void LibMach::write()

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -134,6 +134,7 @@ void LibMSCoff::setFilename(const char *dir, const char *filename)
 
     loc.filename = libfile->name->toChars();
     loc.linnum = 0;
+    loc.charnum = 0;
 }
 
 void LibMSCoff::write()

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -69,6 +69,7 @@ class LibOMF : public Library
         {
             loc.filename = libfile->name->toChars();
             loc.linnum = 0;
+            loc.charnum = 0;
         }
         va_list ap;
         va_start(ap, format);
@@ -114,6 +115,7 @@ void LibOMF::setFilename(const char *dir, const char *filename)
 
     loc.filename = libfile->name->toChars();
     loc.linnum = 0;
+    loc.charnum = 0;
 }
 
 void LibOMF::write()

--- a/src/mars.h
+++ b/src/mars.h
@@ -94,6 +94,7 @@ struct Param
     bool trace;         // insert profiling hooks
     char quiet;         // suppress non-error messages
     char verbose;       // verbose compile
+    char showColumns;   // print character (column) numbers in diagnostics
     char vtls;          // identify thread local variables
     char vfield;        // identify non-mutable field variables
     char symdebug;      // insert debug symbolic information
@@ -305,14 +306,16 @@ struct Loc
 {
     const char *filename;
     unsigned linnum;
+    unsigned charnum;
 
     Loc()
     {
         linnum = 0;
+        charnum = 0;
         filename = NULL;
     }
 
-    Loc(Module *mod, unsigned linnum);
+    Loc(Module *mod, unsigned linnum, unsigned charnum);
 
     char *toChars();
     bool equals(const Loc& loc);

--- a/src/opover.c
+++ b/src/opover.c
@@ -1491,10 +1491,10 @@ static Dsymbol *inferApplyArgTypesX(Expression *ethis, FuncDeclaration *fstart, 
     {
         inferApplyArgTypesY((TypeFunction *)p.fd_best->type, arguments);
         if (p.fd_ambig)
-        {   ::error(ethis->loc, "%s.%s matches more than one declaration:\n\t%s(%d):%s\nand:\n\t%s(%d):%s",
+        {   ::error(ethis->loc, "%s.%s matches more than one declaration:\n\t%s:%s\nand:\n\t%s:%s",
                     ethis->toChars(), fstart->ident->toChars(),
-                    p.fd_best ->loc.filename, p.fd_best ->loc.linnum, p.fd_best ->type->toChars(),
-                    p.fd_ambig->loc.filename, p.fd_ambig->loc.linnum, p.fd_ambig->type->toChars());
+                    p.fd_best ->loc.toChars(), p.fd_best ->type->toChars(),
+                    p.fd_ambig->loc.toChars(), p.fd_ambig->type->toChars());
             p.fd_best = NULL;
         }
     }

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -58,7 +58,8 @@ Blocks *Blocks_create();
 type *Type_toCtype(Type *t);
 
 #define elem_setLoc(e,loc)      ((e)->Esrcpos.Sfilename = (char *)(loc).filename, \
-                                 (e)->Esrcpos.Slinnum = (loc).linnum)
+                                 (e)->Esrcpos.Slinnum = (loc).linnum, \
+                                 (e)->Esrcpos.Scharnum = (loc).charnum)
 
 #define SEH     (TARGET_WINDOS)
 

--- a/src/template.c
+++ b/src/template.c
@@ -6334,10 +6334,10 @@ bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
 
         if (p.td_ambig)
         {
-            ::error(loc, "%s %s.%s matches more than one template declaration:\n\t%s(%d):%s\nand\n\t%s(%d):%s",
+            ::error(loc, "%s %s.%s matches more than one template declaration:\n\t%s:%s\nand\n\t%s:%s",
                     p.td_best->kind(), p.td_best->parent->toPrettyChars(), p.td_best->ident->toChars(),
-                    p.td_best->loc.filename,  p.td_best->loc.linnum,  p.td_best->toChars(),
-                    p.td_ambig->loc.filename, p.td_ambig->loc.linnum, p.td_ambig->toChars());
+                    p.td_best->loc.toChars() , p.td_best->toChars(),
+                    p.td_ambig->loc.toChars(), p.td_ambig->toChars());
             return false;
         }
         if (p.td_best)

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -375,13 +375,16 @@ Symbol *FuncDeclaration::toSymbol()
             else if (isMember2() && isStatic())
                 f->Fflags |= Fstatic;
             f->Fstartline.Slinnum = loc.linnum;
+            f->Fstartline.Scharnum = loc.charnum;
             f->Fstartline.Sfilename = (char *)loc.filename;
             if (endloc.linnum)
             {   f->Fendline.Slinnum = endloc.linnum;
+                f->Fendline.Scharnum = endloc.charnum;
                 f->Fendline.Sfilename = (char *)endloc.filename;
             }
             else
             {   f->Fendline.Slinnum = loc.linnum;
+                f->Fendline.Scharnum = loc.charnum;
                 f->Fendline.Sfilename = (char *)loc.filename;
             }
             t = Type_toCtype(type);

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -7,38 +7,45 @@
     "name" : "_staticCtor1",
     "kind" : "function",
     "line" : 8,
+    "char" : 8,
     "storageClass" : [
      "static"
     ],
     "deco" : "FZv",
-    "endline" : 8
+    "endline" : 8,
+    "endchar" : 16
    },
    {
     "name" : "_staticDtor2",
     "kind" : "function",
     "line" : 10,
+    "char" : 8,
     "storageClass" : [
      "static"
     ],
     "deco" : "FZv",
-    "endline" : 10
+    "endline" : 10,
+    "endchar" : 17
    },
    {
     "name" : "myInt",
     "kind" : "alias",
     "line" : 13,
+    "char" : 11,
     "deco" : "i"
    },
    {
     "name" : "x",
     "kind" : "variable",
     "line" : 14,
+    "char" : 7,
     "deco" : "i",
     "originalType" : "myInt"
    },
    {
     "kind" : "template",
     "line" : 16,
+    "char" : 1,
     "name" : "Foo",
     "parameters" : [
      {
@@ -51,11 +58,13 @@
       "name" : "Foo",
       "kind" : "struct",
       "line" : 16,
+      "char" : 1,
       "members" : [
        {
         "name" : "t",
         "kind" : "variable",
         "line" : 16,
+        "char" : 19,
         "type" : "T"
        }
       ]
@@ -65,6 +74,7 @@
    {
     "kind" : "template",
     "line" : 17,
+    "char" : 1,
     "name" : "Bar",
     "parameters" : [
      {
@@ -78,11 +88,13 @@
       "name" : "Bar",
       "kind" : "class",
       "line" : 17,
+      "char" : 1,
       "members" : [
        {
         "name" : "t",
         "kind" : "variable",
         "line" : 17,
+        "char" : 25,
         "deco" : "i",
         "init" : "T"
        }
@@ -93,6 +105,7 @@
    {
     "kind" : "template",
     "line" : 18,
+    "char" : 1,
     "name" : "Baz",
     "parameters" : [
      {
@@ -105,11 +118,13 @@
       "name" : "Baz",
       "kind" : "interface",
       "line" : 18,
+      "char" : 1,
       "members" : [
        {
         "name" : "t",
         "kind" : "function",
         "line" : 18,
+        "char" : 28,
         "type" : "const T[0]()"
        }
       ]
@@ -119,6 +134,7 @@
    {
     "kind" : "template",
     "line" : 20,
+    "char" : 1,
     "name" : "P",
     "parameters" : [
      {
@@ -132,6 +148,7 @@
     "name" : "Bar2",
     "kind" : "class",
     "line" : 22,
+    "char" : 1,
     "base" : "Bar",
     "interfaces" : [
      "Baz"
@@ -141,33 +158,40 @@
       "name" : "this",
       "kind" : "constructor",
       "line" : 23,
+      "char" : 5,
       "deco" : "FZC4json4Bar2",
       "originalType" : "()",
-      "endline" : 23
+      "endline" : 23,
+      "endchar" : 13
      },
      {
       "name" : "~this",
       "kind" : "destructor",
       "line" : 24,
+      "char" : 5,
       "deco" : "FZv",
-      "endline" : 24
+      "endline" : 24,
+      "endchar" : 14
      },
      {
       "name" : "foo",
       "kind" : "function",
       "line" : 26,
+      "char" : 12,
       "storageClass" : [
        "static"
       ],
       "deco" : "FZv",
       "originalType" : "()",
-      "endline" : 26
+      "endline" : 26,
+      "endchar" : 19
      },
      {
       "name" : "baz",
       "kind" : "function",
       "protection" : "protected",
       "line" : 27,
+      "char" : 32,
       "storageClass" : [
        "abstract"
       ],
@@ -177,11 +201,13 @@
       "name" : "t",
       "kind" : "function",
       "line" : 28,
+      "char" : 18,
       "storageClass" : [
        "override"
       ],
       "deco" : "xFZi",
       "endline" : 28,
+      "endchar" : 40,
       "overrides" : [
        "json.Baz!(int, 2, null).Baz.t"
       ]
@@ -192,6 +218,7 @@
     "name" : "Bar3",
     "kind" : "class",
     "line" : 31,
+    "char" : 1,
     "base" : "Bar2",
     "members" : [
      {
@@ -199,12 +226,14 @@
       "kind" : "variable",
       "protection" : "private",
       "line" : 32,
+      "char" : 14,
       "deco" : "i",
      },
      {
       "name" : "this",
       "kind" : "constructor",
       "line" : 33,
+      "char" : 5,
       "deco" : "FiZC4json4Bar3",
       "originalType" : "(int i)",
       "parameters" : [
@@ -213,18 +242,21 @@
         "deco" : "i"
        }
       ],
-      "endline" : 33
+      "endline" : 33,
+      "endchar" : 28
      },
      {
       "name" : "baz",
       "kind" : "function",
       "protection" : "protected",
       "line" : 35,
+      "char" : 32,
       "storageClass" : [
        "override"
       ],
       "deco" : "FZS4json10__T3FooTiZ3Foo",
       "endline" : 35,
+      "endchar" : 61,
       "overrides" : [
        "json.Bar2.baz"
       ]
@@ -235,11 +267,13 @@
     "name" : "Foo2",
     "kind" : "struct",
     "line" : 38,
+    "char" : 1,
     "members" : [
      {
       "name" : "bar2",
       "kind" : "variable",
       "line" : 39,
+      "char" : 7,
       "deco" : "C4json4Bar2",
       "originalType" : "Bar2",
      },
@@ -247,23 +281,27 @@
       "name" : "U",
       "kind" : "union",
       "line" : 40,
+      "char" : 2,
       "members" : [
        {
         "name" : "s",
         "kind" : "variable",
         "line" : 42,
+        "char" : 10,
         "deco" : "s",
        },
        {
         "name" : "i",
         "kind" : "variable",
         "line" : 43,
+        "char" : 8,
         "deco" : "i",
        },
        {
         "name" : "o",
         "kind" : "variable",
         "line" : 45,
+        "char" : 10,
         "deco" : "C6Object",
         "originalType" : "Object",
        }
@@ -275,6 +313,7 @@
     "name" : "bar",
     "kind" : "function",
     "line" : 52,
+    "char" : 16,
     "storageClass" : [
      "@trusted"
     ],
@@ -294,23 +333,27 @@
       "default" : "cast(Bar2)new Bar3(7)"
      }
     ],
-    "endline" : 55
+    "endline" : 55,
+    "endchar" : 1
    },
    {
     "name" : "outer",
     "kind" : "function",
     "line" : 57,
+    "char" : 15,
     "storageClass" : [
      "@property"
     ],
     "deco" : "FNbNdZi",
     "originalType" : "nothrow int()",
-    "endline" : 74
+    "endline" : 74,
+    "endchar" : 1
    },
    {
     "name" : "imports.jsonimport1",
     "kind" : "import",
     "line" : 77,
+    "char" : 8,
     "protection" : "private",
     "selective" : [
      "target1",
@@ -321,6 +364,7 @@
     "name" : "imports.jsonimport2",
     "kind" : "import",
     "line" : 78,
+    "char" : 8,
     "protection" : "private",
     "renamed" : {
      "alias1" : "target1",
@@ -331,6 +375,7 @@
     "name" : "imports.jsonimport3",
     "kind" : "import",
     "line" : 79,
+    "char" : 8,
     "protection" : "private",
     "renamed" : {
      "alias3" : "target1",
@@ -344,16 +389,19 @@
     "name" : "imports.jsonimport4",
     "kind" : "import",
     "line" : 80,
+    "char" : 8,
     "protection" : "private"
    },
    {
     "name" : "S",
     "kind" : "struct",
     "line" : 82,
+    "char" : 1,
     "members" : [
      {
       "kind" : "template",
       "line" : 85,
+      "char" : 5,
       "name" : "this",
       "parameters" : [
        {
@@ -366,6 +414,7 @@
         "name" : "this",
         "kind" : "constructor",
         "line" : 85,
+        "char" : 5,
         "type" : "(T t)",
         "parameters" : [
          {
@@ -373,7 +422,8 @@
           "type" : "T"
          }
         ],
-        "endline" : 85
+        "endline" : 85,
+        "endchar" : 20
        }
       ]
      }
@@ -383,6 +433,7 @@
     "kind" : "template",
     "protection" : "private",
     "line" : 89,
+    "char" : 9,
     "name" : "S1_9755",
     "parameters" : [
      {
@@ -395,6 +446,7 @@
       "name" : "S1_9755",
       "kind" : "struct",
       "line" : 89,
+      "char" : 9,
       "members" : []
      }
     ]
@@ -403,6 +455,7 @@
     "kind" : "template",
     "protection" : "package",
     "line" : 90,
+    "char" : 9,
     "name" : "S2_9755",
     "parameters" : [
      {
@@ -415,6 +468,7 @@
       "name" : "S2_9755",
       "kind" : "struct",
       "line" : 90,
+      "char" : 9,
       "members" : []
      }
     ]
@@ -423,11 +477,13 @@
     "name" : "C_9755",
     "kind" : "class",
     "line" : 92,
+    "char" : 1,
     "members" : [
      {
       "kind" : "template",
       "protection" : "protected",
       "line" : 94,
+      "char" : 22,
       "name" : "CI_9755",
       "parameters" : [
        {
@@ -440,6 +496,7 @@
         "name" : "CI_9755",
         "kind" : "class",
         "line" : 94,
+        "char" : 22,
         "members" : []
        }
       ]
@@ -450,6 +507,7 @@
     "name" : "c_10011",
     "kind" : "variable",
     "line" : 98,
+    "char" : 14,
     "storageClass" : [
      "const"
     ],

--- a/test/fail_compilation/testCols.d
+++ b/test/fail_compilation/testCols.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -vcolumns
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/testCols.d(13,5): Error: undefined identifier nonexistent
+---
+*/
+
+void test()
+{
+    nonexistent();
+}


### PR DESCRIPTION
This commit adds tracking of column numbers in most places where the compiler is already tracking line numbers, includes them in JSON output, as well as introduces a new compiler switch (`-columns`) which enables their display in diagnostic messages.

Rationale:
- Column information can be helpful in identifying the source of compilation errors, especially in long lines (as is common with e.g. chained UFCS calls).
- IDEs will benefit the most from this change. Most IDEs and some graphical text editors are capable of parsing compiler output and allowing the user to navigate directly to the source code position causing the diagnostic messages. Some of them even overlay markers on top of the source code, to indicate the exact positions where compilation errors occurred.
- Some debugging formats support column information (e.g. DWARF has `DW_AT_decl_column`). This patch doesn't add support for that though.
- Other compiler backends/toolchains already have ways to make use of column information. Recent GCC versions will display columns in diagnostic messages by default, as well as reproduce the source code line and print a caret pointing out the exact location of the error. In fact, because this information was not being tracked by the DMD frontend, GDC currently deviates from the standard diagnostic output of the GCC toolchain by forcibly enabling the options `-fno-show-column` and `-fno-diagnostics-show-caret`. (Possibly some of this also applies to LDC, haven't checked.)

The compiler switch was added because:
- Changing the diagnostic output format at this point is likely to break lots of tools
- IDEs can opt in to the new format by transparently adding a switch to the compiler command line
- Users running the compiler directly from the command line are less likely to make use of the column number
- It would break all the `fail_compilation` tests :)

Related issue: https://d.puremagic.com/issues/show_bug.cgi?id=5521
