### PR TITLE
Increase temp space in mtype.c/Type::getTypeInfoIdent(int)

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2421,7 +2421,7 @@ Identifier *Type::getTypeInfoIdent(int internal)
     buf.writeByte(0);
 
     // Allocate buffer on stack, fail over to using malloc()
-    char namebuf[40];
+    char namebuf[128];
     size_t namelen = 19 + sizeof(len) * 3 + len + 1;
     char *name = namelen <= sizeof(namebuf) ? namebuf : (char *)malloc(namelen);
     assert(name);


### PR DESCRIPTION
Compiling druntime+phobos, this method is called 1245 times. 1104 times malloc()
is called - that's 89%! Increasing the size from 40 to 128, malloc() is only
called 128 times, which looks better. (Average length is 66.)
This may still too small - compiling some unit tests I have seen mangled names
with length up to 16745.

Alternatives are:
- use always malloc()
- use always alloca()

The same seems to be true variable out of type OutBuffer. But I do not have
collected the numbers here.

What do you think?
