### PR TITLE
(1/2) Deprecate -gc in favour of -g

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -705,7 +705,10 @@ int tryMain(size_t argc, const char *argv[])
             else if (strcmp(p + 1, "g") == 0)
                 global.params.symdebug = 1;
             else if (strcmp(p + 1, "gc") == 0)
+            {
+                deprecation(Loc(), "-gc has been deprecated, use -g instead");
                 global.params.symdebug = 2;
+            }
             else if (strcmp(p + 1, "gs") == 0)
                 global.params.alwaysframe = 1;
             else if (strcmp(p + 1, "gx") == 0)


### PR DESCRIPTION
Start the deprecation process of `-gc`.  There is almost no difference now between -g and -gc other than.
1. On MSCOFF/OMF targets, `dchar` is emitted as `ulong`
2. On ELF/DWARF targets, `DW_LANG_C89` is emitted instead of `DW_LANG_D`.

I would strongly suggest that all known bugs in `-g` be fixed before pushing this.  For DWARF, this means that if you can't reproduce the debugging issue in `-gc`, then it probably isn't a (sic) DMD problem, and needs to be fixed in GDB.

**KNOWN BUGS EXTERNAL TO DMD**
- https://d.puremagic.com/issues/show_bug.cgi?id=4181

Related pull request #3083 
