### PR TITLE
(2/2) Remove remaining uses of -gc in backend.

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -45,8 +45,6 @@ void out_config_init(
         bool verbose,   // verbose compile
         bool optimize,  // optimize code
         int symdebug,   // add symbolic debug information
-                        // 1: D
-                        // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
         bool stackstomp // add stack stomping code
         )
@@ -186,7 +184,7 @@ void out_config_init(
     {
 #if SYMDEB_DWARF
         configv.addlinenumbers = 1;
-        config.fulltypes = (symdebug == 1) ? CVDWARF_D : CVDWARF_C;
+        config.fulltypes = CVDWARF_D;
 #endif
 #if SYMDEB_CODEVIEW
         if (model == 64)

--- a/src/glue.c
+++ b/src/glue.c
@@ -1202,14 +1202,7 @@ unsigned Type::totym()
         case Tbool:     t = TYbool;     break;
         case Tchar:     t = TYchar;     break;
         case Twchar:    t = TYwchar_t;  break;
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
         case Tdchar:    t = TYdchar;    break;
-#else
-        case Tdchar:
-                t = (global.params.symdebug == 1) ? TYdchar : TYulong;
-                break;
-#endif
-
         case Taarray:   t = TYaarray;   break;
         case Tclass:
         case Treference:

--- a/src/msc.c
+++ b/src/msc.c
@@ -43,8 +43,6 @@ void out_config_init(
         bool verbose,   // verbose compile
         bool optimize,  // optimize code
         int symdebug,   // add symbolic debug information
-                        // 1: D
-                        // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
         bool stackstomp         // add stack stomping code
         );


### PR DESCRIPTION
Once `-gc` is deprecated, remove its functionality in the backend.  After this, we can start to think about making `-gc` a warning, then possibly error.

Related pull request #3082.
