### PR TITLE
[DDMD] Move Previous outside TemplateDeclaration

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -849,7 +849,7 @@ MATCH TemplateDeclaration::matchWithInstance(Scope *sc, TemplateInstance *ti,
          */
 
         int nmatches = 0;
-        for (Previous *p = previous; p; p = p->prev)
+        for (TemplatePrevious *p = previous; p; p = p->prev)
         {
             if (arrayObjectMatch(p->dedargs, dedtypes))
             {
@@ -867,7 +867,7 @@ MATCH TemplateDeclaration::matchWithInstance(Scope *sc, TemplateInstance *ti,
              */
         }
 
-        Previous pr;
+        TemplatePrevious pr;
         pr.prev = previous;
         pr.sc = paramscope;
         pr.dedargs = dedtypes;
@@ -1780,7 +1780,7 @@ Lmatch:
          * Recursive attempts are regarded as a constraint failure.
          */
         int nmatches = 0;
-        for (Previous *p = previous; p; p = p->prev)
+        for (TemplatePrevious *p = previous; p; p = p->prev)
         {
             if (arrayObjectMatch(p->dedargs, dedargs))
             {
@@ -1798,7 +1798,7 @@ Lmatch:
              */
         }
 
-        Previous pr;
+        TemplatePrevious pr;
         pr.prev = previous;
         pr.sc = paramscope;
         pr.dedargs = dedargs;
@@ -2181,7 +2181,7 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
                 Objects dedtypesX;  // empty tiargs
 
                 // Bugzilla 11553: Check for recursive instantiation of tdx.
-                for (TemplateDeclaration::Previous *p = tdx->previous; p; p = p->prev)
+                for (TemplatePrevious *p = tdx->previous; p; p = p->prev)
                 {
                     if (arrayObjectMatch(p->dedargs, &dedtypesX))
                     {
@@ -2202,7 +2202,7 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
                      */
                 }
 
-                TemplateDeclaration::Previous pr;
+                TemplatePrevious pr;
                 pr.prev = tdx->previous;
                 pr.sc = sc;
                 pr.dedargs = &dedtypesX;

--- a/src/template.h
+++ b/src/template.h
@@ -49,6 +49,12 @@ public:
     int dyncast() { return DYNCAST_TUPLE; } // kludge for template.isType()
 };
 
+struct TemplatePrevious
+{
+    TemplatePrevious *prev;
+    Scope *sc;
+    Objects *dedargs;
+};
 
 class TemplateDeclaration : public ScopeDsymbol
 {
@@ -73,12 +79,7 @@ public:
     bool isstatic;              // this is static template declaration
     PROT protection;
 
-    struct Previous
-    {   Previous *prev;
-        Scope *sc;
-        Objects *dedargs;
-    };
-    Previous *previous;         // threaded list of previous instantiation attempts on stack
+    TemplatePrevious *previous;         // threaded list of previous instantiation attempts on stack
 
     TemplateDeclaration(Loc loc, Identifier *id, TemplateParameters *parameters,
         Expression *constraint, Dsymbols *decldefs, bool ismixin = false, bool literal = false);


### PR DESCRIPTION
Some recent refactoring resulting in hitting some serious limitations in the ddmd converter's parser.  After hours wasted trying to fix it (C++ member parsing ambiguity that has so far been avoided), it's easier to just move this struct to module scope.
