### PR TITLE
Set DWARF Version: 3 in .debug_info section

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -417,7 +417,7 @@ struct DebugInfoHeader
 
 static DebugInfoHeader debuginfo_init =
 {       0,      // total_length
-        2,      // version
+        3,      // version
         0,      // abbrev_offset
         4       // address_size
 };


### PR DESCRIPTION
Something noticed when evaluating the output of `objdump -g` from dmd object files.

The `DW_LANG_D` attribute was introduced in the DWARFv3 spec, meaning it is somewhat undefined what happens if a debugger reads the `.debug_info` section treating it as DWARFv2.
