### PR TITLE
[REG2.066a] Issue 11919 - GitHub HEAD regression for getAttributes trait (DMD CORE DUMP)

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -291,6 +291,11 @@ void ClassDeclaration::semantic(Scope *sc)
         isdeprecated = true;
     }
     userAttributes = sc->userAttributes;
+    if (userAttributes)
+    {
+        userAttributesScope = sc;
+        userAttributesScope->setNoFree();
+    }
 
     if (sc->linkage == LINKcpp)
         cpp = 1;
@@ -1281,6 +1286,11 @@ void InterfaceDeclaration::semantic(Scope *sc)
         isdeprecated = true;
     }
     userAttributes = sc->userAttributes;
+    if (userAttributes)
+    {
+        userAttributesScope = sc;
+        userAttributesScope->setNoFree();
+    }
 
     // Expand any tuples in baseclasses[]
     for (size_t i = 0; i < baseclasses->dim; )

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -320,9 +320,9 @@ Dsymbol *TypedefDeclaration::syntaxCopy(Dsymbol *s)
 void TypedefDeclaration::semantic(Scope *sc)
 {
     //printf("TypedefDeclaration::semantic(%s) sem = %d\n", toChars(), sem);
-    userAttributes = sc->userAttributes;
     if (sem == SemanticStart)
-    {   sem = SemanticIn;
+    {
+        sem = SemanticIn;
         parent = sc->parent;
         int errors = global.errors;
         Type *savedbasetype = basetype;
@@ -348,6 +348,11 @@ void TypedefDeclaration::semantic(Scope *sc)
         }
         storage_class |= sc->stc & STCdeprecated;
         userAttributes = sc->userAttributes;
+        if (userAttributes)
+        {
+            userAttributesScope = sc;
+            userAttributesScope->setNoFree();
+        }
     }
     else if (sem == SemanticIn)
     {
@@ -487,6 +492,11 @@ void AliasDeclaration::semantic(Scope *sc)
     storage_class |= sc->stc & STCdeprecated;
     protection = sc->protection;
     userAttributes = sc->userAttributes;
+    if (userAttributes)
+    {
+        userAttributesScope = sc;
+        userAttributesScope->setNoFree();
+    }
 
     // Given:
     //  alias foo.bar.abc def;
@@ -815,6 +825,11 @@ void VarDeclaration::semantic(Scope *sc)
         error("extern symbols cannot have initializers");
 
     userAttributes = sc->userAttributes;
+    if (userAttributes)
+    {
+        userAttributesScope = sc;
+        userAttributesScope->setNoFree();
+    }
 
     AggregateDeclaration *ad = isThis();
     if (ad)

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -52,6 +52,7 @@ Dsymbol::Dsymbol()
     this->errors = false;
     this->depmsg = NULL;
     this->userAttributes = NULL;
+    this->userAttributesScope = NULL;
     this->ddocUnittest = NULL;
 }
 
@@ -69,6 +70,7 @@ Dsymbol::Dsymbol(Identifier *ident)
     this->errors = false;
     this->depmsg = NULL;
     this->userAttributes = NULL;
+    this->userAttributesScope = NULL;
     this->ddocUnittest = NULL;
 }
 
@@ -346,6 +348,8 @@ void Dsymbol::setScope(Scope *sc)
     scope = sc;
     if (sc->depmsg)
         depmsg = sc->depmsg;
+    if (userAttributes)
+        userAttributesScope = sc;
 }
 
 void Dsymbol::importAll(Scope *sc)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -138,6 +138,7 @@ public:
     PASS semanticRun;
     char *depmsg;               // customized deprecation message
     Expressions *userAttributes;        // user defined attributes from UserAttributeDeclaration
+    Scope *userAttributesScope;
     UnitTestDeclaration *ddocUnittest; // !=NULL means there's a ddoc unittest associated with this symbol (only use this with ddoc)
 
     Dsymbol();

--- a/src/enum.c
+++ b/src/enum.c
@@ -145,6 +145,11 @@ void EnumDeclaration::semantic(Scope *sc)
     if (sc->stc & STCdeprecated)
         isdeprecated = true;
     userAttributes = sc->userAttributes;
+    if (userAttributes)
+    {
+        userAttributesScope = sc;
+        userAttributesScope->setNoFree();
+    }
 
     parent = sc->parent;
     protection = sc->protection;
@@ -723,6 +728,7 @@ Expression *EnumMember::getVarExp(Loc loc, Scope *sc)
         vd->protection = ed->isAnonymous() ? ed->protection : PROTpublic;
         vd->parent = ed->isAnonymous() ? ed->parent : ed;
         vd->userAttributes = ed->isAnonymous() ? ed->userAttributes : NULL;
+        vd->userAttributesScope = ed->isAnonymous() ? ed->userAttributesScope : NULL;
     }
     Expression *e = new VarExp(loc, vd);
     return e->semantic(sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -5888,16 +5888,22 @@ Expression *TupleExp::semantic(Scope *sc)
         e0 = e0->semantic(sc);
 
     // Run semantic() on each argument
+    bool err = false;
     for (size_t i = 0; i < exps->dim; i++)
-    {   Expression *e = (*exps)[i];
-
+    {
+        Expression *e = (*exps)[i];
         e = e->semantic(sc);
         if (!e->type)
-        {   error("%s has no value", e->toChars());
-            return new ErrorExp();
+        {
+            error("%s has no value", e->toChars());
+            err = true;
         }
+        else if (e->op == TOKerror)
+            err = true;
         (*exps)[i] = e;
     }
+    if (err)
+        return new ErrorExp();
 
     expandTuples(exps);
     type = new TypeTuple(exps);

--- a/src/func.c
+++ b/src/func.c
@@ -191,6 +191,11 @@ void FuncDeclaration::semantic(Scope *sc)
         linkage = sc->linkage;
     protection = sc->protection;
     userAttributes = sc->userAttributes;
+    if (userAttributes)
+    {
+        userAttributesScope = sc;
+        userAttributesScope->setNoFree();
+    }
 
     if (!originalType)
         originalType = type->syntaxCopy();
@@ -3850,6 +3855,7 @@ FuncAliasDeclaration::FuncAliasDeclaration(FuncDeclaration *funcalias, bool hasO
         this->hasOverloads = false;
     }
     userAttributes = funcalias->userAttributes;
+    userAttributesScope = funcalias->userAttributesScope;
 }
 
 const char *FuncAliasDeclaration::kind()

--- a/src/struct.c
+++ b/src/struct.c
@@ -631,6 +631,11 @@ void StructDeclaration::semantic(Scope *sc)
     if (sc->stc & STCabstract)
         error("structs, unions cannot be abstract");
     userAttributes = sc->userAttributes;
+    if (userAttributes)
+    {
+        userAttributesScope = sc;
+        userAttributesScope->setNoFree();
+    }
 
     if (sizeok == SIZEOKnone)            // if not already done the addMember step
     {

--- a/src/traits.c
+++ b/src/traits.c
@@ -575,11 +575,13 @@ Expression *TraitsExp::semantic(Scope *sc)
             error("first argument is not a symbol");
             goto Lfalse;
         }
-        //printf("getAttributes %s, %p\n", s->toChars(), s->userAttributes);
+        //printf("getAttributes %s, attrs = %p, scope = %p\n", s->toChars(), s->userAttributes, s->userAttributesScope);
+        Expressions *exps;
         if (!s->userAttributes)
             s->userAttributes = new Expressions();
+        Scope *sc2 = s->userAttributesScope ? s->userAttributesScope : sc;
         TupleExp *tup = new TupleExp(loc, s->userAttributes);
-        return tup->semantic(sc);
+        return tup->semantic(sc2);
     }
     else if (ident == Id::allMembers || ident == Id::derivedMembers)
     {

--- a/test/fail_compilation/ice11919.d
+++ b/test/fail_compilation/ice11919.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice11919.d(19): Error: undefined identifier foo, did you mean variable zoo?
+fail_compilation/imports/a11919.d(4): Error: template instance a11919.doBar!(Foo).doBar.zoo!(t) error instantiating
+fail_compilation/imports/a11919.d(11):        instantiated from here: doBar!(Foo)
+fail_compilation/ice11919.d(27):        instantiated from here: doBar!(Bar)
+fail_compilation/imports/a11919.d(11): Error: template instance a11919.doBar!(Foo) error instantiating
+fail_compilation/ice11919.d(27):        instantiated from here: doBar!(Bar)
+fail_compilation/ice11919.d(27): Error: template instance a11919.doBar!(Bar) error instantiating
+---
+*/
+import imports.a11919;
+
+enum foo;
+
+class Foo
+{
+    @foo bool _foo;
+}
+
+class Bar : Foo {}
+
+void main()
+{
+    auto bar = new Bar();
+    bar.doBar;
+}

--- a/test/fail_compilation/ice11919.d
+++ b/test/fail_compilation/ice11919.d
@@ -1,13 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11919.d(19): Error: undefined identifier foo, did you mean variable zoo?
+fail_compilation/ice11919.d(20): Error: Cannot interpret foo at compile time
+fail_compilation/ice11919.d(20): Error: Cannot interpret foo at compile time
 fail_compilation/imports/a11919.d(4): Error: template instance a11919.doBar!(Foo).doBar.zoo!(t) error instantiating
 fail_compilation/imports/a11919.d(11):        instantiated from here: doBar!(Foo)
-fail_compilation/ice11919.d(27):        instantiated from here: doBar!(Bar)
+fail_compilation/ice11919.d(28):        instantiated from here: doBar!(Bar)
 fail_compilation/imports/a11919.d(11): Error: template instance a11919.doBar!(Foo) error instantiating
-fail_compilation/ice11919.d(27):        instantiated from here: doBar!(Bar)
-fail_compilation/ice11919.d(27): Error: template instance a11919.doBar!(Bar) error instantiating
+fail_compilation/ice11919.d(28):        instantiated from here: doBar!(Bar)
+fail_compilation/ice11919.d(28): Error: template instance a11919.doBar!(Bar) error instantiating
 ---
 */
 import imports.a11919;

--- a/test/fail_compilation/imports/a11919.d
+++ b/test/fail_compilation/imports/a11919.d
@@ -1,0 +1,17 @@
+void doBar(T)(T t)
+{
+    static if (t.tupleof.length)
+        if (zoo!t.length == 0) {}
+    static if (is(T B == super)
+            && is(B[0] == class)
+            && is(B[])
+            )
+    {
+        B[0] b = t;
+        doBar(b);
+    }
+}
+template zoo(alias t)
+{
+    enum zoo = __traits(getAttributes, t.tupleof);
+}

--- a/test/runnable/imports/a9741.d
+++ b/test/runnable/imports/a9741.d
@@ -1,0 +1,7 @@
+module imports.a9741b;
+
+template ShowAttributes(alias X)
+{
+    pragma(msg, X.stringof);
+    pragma(msg, __traits(getAttributes, X));
+}

--- a/test/runnable/uda.d
+++ b/test/runnable/uda.d
@@ -262,9 +262,9 @@ void test9178()
 }
 
 /************************************************/
-// 9741
+// 9652
 
-struct Bug9741
+struct Bug9652
 {
     pragma(msg, __traits(getAttributes, enum_field));
     alias Tuple!(__traits(getAttributes, enum_field)) Tenum_field;
@@ -273,7 +273,7 @@ struct Bug9741
     static assert(Tenum_field[0] == 10);
     static assert(__traits(getAttributes, enum_field)[0] == 10);
     static assert(__traits(getProtection, enum_field) == "private");
-    static assert(__traits(isSame, __traits(parent, enum_field), Bug9741));
+    static assert(__traits(isSame, __traits(parent, enum_field), Bug9652));
     static assert(__traits(isSame, enum_field, enum_field));
 
     pragma(msg, __traits(getAttributes, anon_enum_member));
@@ -283,7 +283,7 @@ struct Bug9741
     static assert(Tanon_enum_member[0] == 20);
     static assert(__traits(getAttributes, anon_enum_member)[0] == 20);
     static assert(__traits(getProtection, anon_enum_member) == "private");
-    static assert(__traits(isSame, __traits(parent, anon_enum_member), Bug9741));
+    static assert(__traits(isSame, __traits(parent, anon_enum_member), Bug9652));
     static assert(__traits(isSame, anon_enum_member, anon_enum_member));
 
     pragma(msg, __traits(getAttributes, Foo.enum_member));
@@ -302,7 +302,7 @@ struct Bug9741
     static assert(Tanon_enum_member_2[0] == 40);
     static assert(__traits(getAttributes, anon_enum_member_2)[0] == 40);
     static assert(__traits(getProtection, anon_enum_member_2) == "private");
-    static assert(__traits(isSame, __traits(parent, anon_enum_member_2), Bug9741));
+    static assert(__traits(isSame, __traits(parent, anon_enum_member_2), Bug9652));
     static assert(__traits(isSame, anon_enum_member_2, anon_enum_member_2));
 
     template Bug(alias X, bool is_exp)
@@ -316,6 +316,17 @@ struct Bug9741
     enum dummy1 = Bug!(5, true);
     enum dummy2 = Bug!(en, false);
 }
+
+/************************************************/
+// 9741
+
+import imports.a9741;
+
+struct A9741 {}
+
+alias X9741 = ShowAttributes!(B9741);
+
+@A9741 struct B9741 {}
 
 /************************************************/
 // 10208


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11919

There's multiple factors.
1. By fixing [issue 8244](http://d.puremagic.com/issues/show_bug.cgi?id=8244)(#2855), `is(B[])` at line 7 in foobar.d is changed to return true from 2.065.
   Then, `doBar!Bar` will instantiate `doBar!Foo` and `doBar!Object`, unlike 2.064.
2. By fixing [issue 11844](http://d.puremagic.com/issues/show_bug.cgi?id=11844)(#3056), semantic analysis timing for UDAs has been changed, and it had accidentally introduced ICE issue with the OP test case.
3. Even if we fix the ICE in 2, [bug 9741](http://d.puremagic.com/issues/show_bug.cgi?id=9741) will report incorrect 'undefined identifier' error. To fundamentally fix the root issue, I fix the bug in this PR, too.

Therefore, also fixes [Issue 9741](http://d.puremagic.com/issues/show_bug.cgi?id=9741) - undefined identifier with User Defined Attribute
