### PR TITLE
issue 11457: add Windows SDK 8.1 library search path to sc.ini

### DIFF
--- a/ini/windows/bin/sc.ini
+++ b/ini/windows/bin/sc.ini
@@ -66,6 +66,9 @@ LINKCMD=%VCINSTALLDIR%\bin\link.exe
 ; C Runtime libraries
 LIB=%LIB%;"%VCINSTALLDIR%\lib\amd64"
 
+; Platform libraries (Windows SDK 8.1)
+LIB=%LIB%;"%WindowsSdkDir%\Lib\winv6.3\um\x64"
+
 ; Platform libraries (Windows SDK 8)
 LIB=%LIB%;"%WindowsSdkDir%\Lib\win8\um\x64"
 


### PR DESCRIPTION
The 8.1 SDK has a different path to the library folder again. This often bytes Win64 users.

It should be fixed for the 2.065 release. @eco: Does anything need to be done to the installer, too?

https://d.puremagic.com/issues/show_bug.cgi?id=11457
