### PR TITLE
ARM test suite fixes

### DIFF
--- a/test/runnable/builtin.d
+++ b/test/runnable/builtin.d
@@ -11,13 +11,13 @@ void test1()
     auto f = 6.8L;
     writefln("%a", sin(f));
     assert(sin(f) == sin(6.8));
-    static assert(sin(6.8) == 0x1.f9f8d9aea10fdf1cp-2);
+    static assert(approxEqual(sin(6.8), 0x1.f9f8d9aea10fdf1cp-2));
 
     writefln("%a", cos(6.8));
     f = 6.8L;
     writefln("%a", cos(f));
     assert(cos(f) == cos(6.8));
-    static assert(cos(6.8) == 0x1.bd21aaf88dcfa13ap-1);
+    static assert(approxEqual(cos(6.8), 0x1.bd21aaf88dcfa13ap-1));
 
     writefln("%a", tan(6.8));
     f = 6.8L;
@@ -26,7 +26,7 @@ void test1()
     { }
     else
 	assert(tan(f) == tan(6.8));
-    static assert(tan(6.8) == 0x1.22fd752af75cd08cp-1);
+    static assert(approxEqual(tan(6.8), 0x1.22fd752af75cd08cp-1));
 }
 
 /*******************************************/

--- a/test/runnable/template1.d
+++ b/test/runnable/template1.d
@@ -1456,6 +1456,8 @@ void test60()
             assert(thing1.sizeof == 16);
         else version (X86_64)
             assert(thing1.sizeof == 16);
+        else version(ARM)
+            assert(thing1.sizeof == 16);
         else
             assert(thing1.sizeof == 12);
 	assert(thing2.sizeof == 8);

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -244,6 +244,16 @@ else version (X86_64)
     assert(TRECT6.BottomRight.offsetof == 16);
     assert(TRECT6.foo2.offsetof == 24);
 }
+else version(ARM)
+{
+    assert(TRECT6.Left.offsetof == 8);
+    assert(TRECT6.Top.offsetof == 12);
+    assert(TRECT6.Right.offsetof == 16);
+    assert(TRECT6.Bottom.offsetof == 20);
+    assert(TRECT6.TopLeft.offsetof == 8);
+    assert(TRECT6.BottomRight.offsetof == 16);
+    assert(TRECT6.foo2.offsetof == 24);
+}
 else
 {
     assert(TRECT6.Left.offsetof == 4);

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -1651,6 +1651,7 @@ void test100()
     printf("d = %llx, ulong.max = %llx\n", d, ulong.max);
     assert(d == ulong.max);
   }
+  static if(real.mant_dig == 64)
   {
     real r = ulong.max - 1;
     printf("r = %Lg, ulong.max = %llu\n", r, ulong.max);
@@ -1658,6 +1659,11 @@ void test100()
     printf("d = %llx, ulong.max = %llx\n", d, ulong.max);
     assert(d == ulong.max - 1);
   }
+  else static if(real.mant_dig == 53)
+  { //can't store ulong.max-1 in double
+  }
+  else
+     static assert(false, "Test not implemented for this platform");
 }
 
 /***************************************************/
@@ -5420,7 +5426,12 @@ void testdbl_to_ulong()
     real adjust = 1.0L/real.epsilon;
     u = d2ulong(adjust);
     //writefln("%s %s", adjust, u);
-    assert(u == 9223372036854775808UL);
+    static if(real.mant_dig == 64)
+        assert(u == 9223372036854775808UL);
+    else static if(real.mant_dig == 53)
+        assert(u == 4503599627370496UL);
+    else
+        static assert(false, "Test not implemented for this architecture");
 
     auto v = d2ulong(adjust * 1.1);
     //writefln("%s %s %s", adjust, v, u + u/10);
@@ -5462,7 +5473,12 @@ void testreal_to_ulong()
     real adjust = 1.0L/real.epsilon;
     u = r2ulong(adjust);
     //writefln("%s %s", adjust, u);
-    assert(u == 9223372036854775808UL);
+    static if(real.mant_dig == 64)
+        assert(u == 9223372036854775808UL);
+    else static if(real.mant_dig == 53)
+        assert(u == 4503599627370496UL);
+    else
+        static assert(false, "Test not implemented for this architecture");
 
     auto v = r2ulong(adjust * 1.1);
     writefln("%s %s %s", adjust, v, u + u/10);


### PR DESCRIPTION
These changes are necessary to make the test suite pass on ARM.
It's mostly reducing the required precision of math tests or changes the test values if they're not valid for real==double systems.

Note: This is part of a set of changes which are required to get test suite & unit tests passing on ARM GDC. All necessary changes for GDC are here for reference:
https://github.com/jpf91/GDC/commits/arm-old

Once these pull requests are merged upstream I'll merge them into GDC as well.
