### PR TITLE
Move rmem.h out of frontend headers

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -26,6 +26,7 @@
 #include "hdrgen.h"
 #include "target.h"
 #include "parse.h"
+#include "rmem.h"
 
 void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, int mod, const char *kind);
 void genCmain(Scope *sc);

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -49,8 +49,7 @@ struct Array
 
     char *toChars()
     {
-        char **buf = (char **)malloc(dim * sizeof(char *));
-        assert(buf);
+        char **buf = (char **)mem.malloc(dim * sizeof(char *));
         size_t len = 2;
         for (size_t u = 0; u < dim; u++)
         {
@@ -71,7 +70,7 @@ struct Array
         }
         *p++ = ']';
         *p = 0;
-        free(buf);
+        mem.free(buf);
         return str;
     }
 

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -19,8 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "rmem.h"
 #include "object.h"
+#include "rmem.h"
 
 template <typename TYPE>
 struct Array

--- a/src/root/file.c
+++ b/src/root/file.c
@@ -36,6 +36,7 @@
 #include "filename.h"
 #include "array.h"
 #include "port.h"
+#include "rmem.h"
 
 /****************************** File ********************************/
 

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -15,6 +15,7 @@
 #include "outbuffer.h"
 #include "array.h"
 #include "file.h"
+#include "rmem.h"
 
 #if defined (__sun)
 #include <alloca.h>

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <assert.h>
 #include "port.h"
-#include "rmem.h"
 
 #if __DMC__
 #pragma once

--- a/src/scope.c
+++ b/src/scope.c
@@ -12,6 +12,7 @@
 #include <string.h>                     // strlen()
 
 #include "root.h"
+#include "rmem.h"
 #include "speller.h"
 
 #include "mars.h"


### PR DESCRIPTION
Until `ArrayBase<>` got dropped, `rmem.h` was quite safe to use in GDC because it was avoided to be used in the glue code - there's `#pragma GCC poison malloc realloc free` in GCC which prevents these from being used by code that interacts directly with it.

The internal use of `Array<>` has been removed from GDC https://github.com/D-Programming-GDC/GDC/commit/a41a2677a823aac742626e342b2c0584d3ce190f but unfortunately I still have to deal with the frontend using it. :-(

This patch makes the following changes in the frontend:
1. `rmem.h` is only included in source files.
The exception to this is `array.h`, in which there are changes in GDC that calls GCC-poison safe wrappers around `mem.malloc`, `mem.realloc`, and `mem.free`.
2. Use rmem's malloc and free in `Array::toChars`.

This fixes compilation of GDC so that only `array.h` needs to be patched to allow GDC glue code that interacts with GCC to use it.
