### PR TITLE
[REG2.065a] Issue 11925 - ICE in CompoundStatement::semantic

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -734,7 +734,7 @@ Statement *CompoundStatement::semantic(Scope *sc)
     }
     for (size_t i = 0; i < statements->dim; ++i)
     {
-    L1:
+    Lagain:
         Statement *s = (*statements)[i];
         if (!s)
             continue;
@@ -751,7 +751,9 @@ Statement *CompoundStatement::semantic(Scope *sc)
         {
             statements->remove(i);
             statements->insert(i, flt);
-            goto L1;
+            if (statements->dim <= i)
+                break;
+            goto Lagain;
         }
     }
     if (statements->dim == 1)

--- a/test/compilable/ice11925.d
+++ b/test/compilable/ice11925.d
@@ -1,0 +1,38 @@
+void test11925a()
+{
+    try
+    {
+        try
+        {
+            L1: {}
+        }
+        finally
+        {
+        }
+    }
+    finally
+    {
+    }
+    goto L1;
+}
+
+void test11925b()
+{
+    switch (1)
+    {
+        case 1:
+            goto L1;
+            break;
+
+        default:
+            break;
+    }
+
+    try
+    {
+        L1: { }
+    }
+    finally
+    {
+    }
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11925

@ibuclaw As far as I know, `void insert(size_t index, Array *a)` should work even if `a->dim == 0`. The root issue exists in `CompoundStatement::semantic`. That's the case I had overlooked.
