### PR TITLE
Issue 10133 - ICE for templated static conditional lambda

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1061,7 +1061,7 @@ void PragmaDeclaration::semantic(Scope *sc)
                 if (global.params.moduleDeps && !global.params.moduleDepsFile)
                 {
                     OutBuffer *ob = global.params.moduleDeps;
-                    Module* imod = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
+                    Module *imod = sc->instantiatingModule();
                     ob->writestring("depsLib ");
                     ob->writestring(imod->toPrettyChars());
                     ob->writestring(" (");

--- a/src/clone.c
+++ b/src/clone.c
@@ -76,7 +76,6 @@ FuncDeclaration *AggregateDeclaration::hasIdentityOpAssign(Scope *sc)
         unsigned oldspec = global.speculativeGag;   // template opAssign fbody makes it.
         global.speculativeGag = global.gag;
         sc = sc->push();
-        sc->tinst = NULL;
         sc->speculative = true;
 
         for (size_t i = 0; i < 2; i++)
@@ -416,7 +415,6 @@ FuncDeclaration *AggregateDeclaration::hasIdentityOpEquals(Scope *sc)
             unsigned oldspec = global.speculativeGag;   // template opAssign fbody makes it.
             global.speculativeGag = global.gag;
             sc = sc->push();
-            sc->tinst = NULL;
             sc->speculative = true;
 
             for (size_t j = 0; j < 2; j++)

--- a/src/cond.c
+++ b/src/cond.c
@@ -90,7 +90,7 @@ void printDepsConditional(Scope *sc, DVCondition* condition, const char* depType
     if (!global.params.moduleDeps || global.params.moduleDepsFile)
         return;
     OutBuffer *ob = global.params.moduleDeps;
-    Module* imod = sc ? (sc->instantiatingModule ? sc->instantiatingModule : sc->module) : condition->mod;
+    Module* imod = sc ? sc->instantiatingModule() : condition->mod;
     if (!imod)
         return;
     ob->writestring(depType);

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -546,9 +546,9 @@ TypeAArray *toBuiltinAAType(Type *t)
     assert(t->ty == Tstruct);
     StructDeclaration *sym = ((TypeStruct *)t)->sym;
     assert(sym->ident == Id::AssociativeArray);
-    TemplateInstance *tinst = sym->parent->isTemplateInstance();
-    assert(tinst);
-    return new TypeAArray((Type *)(*tinst->tiargs)[1], (Type *)(*tinst->tiargs)[0]);
+    TemplateInstance *ti = sym->parent->isTemplateInstance();
+    assert(ti);
+    return new TypeAArray((Type *)(*ti->tiargs)[1], (Type *)(*ti->tiargs)[0]);
 #else
     assert(0);
     return NULL;

--- a/src/expression.c
+++ b/src/expression.c
@@ -7283,7 +7283,7 @@ Expression *FileExp::semantic(Scope *sc)
     if (global.params.moduleDeps != NULL)
     {
         OutBuffer *ob = global.params.moduleDeps;
-        Module* imod = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
+        Module* imod = sc->instantiatingModule();
 
         if (!global.params.moduleDepsFile)
             ob->writestring("depsFile ");

--- a/src/func.c
+++ b/src/func.c
@@ -2877,26 +2877,16 @@ Lerror:
     }
     else if (m.nextf)
     {
-        /* CAUTION: m.lastf and m.nextf might be incompletely instantiated functions
-         * (created by doHeaderInstantiation), so call toPrettyChars will segfault.
-         */
-        assert(m.lastf);
-        TypeFunction *t1 = (TypeFunction *)m.lastf->type;
-        TypeFunction *t2 = (TypeFunction *)m.nextf->type;
-        TemplateInstance *lastti = m.lastf->parent->isTemplateInstance();
-        TemplateInstance *nextti = m.nextf->parent->isTemplateInstance();
-        if (lastti && lastti->name != m.lastf->ident) lastti = NULL;
-        if (nextti && nextti->name != m.nextf->ident) nextti = NULL;
-        Dsymbol *lasts = lastti ? (Dsymbol *)lastti->tempdecl : (Dsymbol *)m.lastf;
-        Dsymbol *nexts = nextti ? (Dsymbol *)nextti->tempdecl : (Dsymbol *)m.nextf;
-        const char *lastprms = lastti ? "" : Parameter::argsTypesToChars(t1->parameters, t1->varargs);
-        const char *nextprms = nextti ? "" : Parameter::argsTypesToChars(t2->parameters, t2->varargs);
+        TypeFunction *tf1 = (TypeFunction *)m.lastf->type;
+        TypeFunction *tf2 = (TypeFunction *)m.nextf->type;
+        const char *lastprms = Parameter::argsTypesToChars(tf1->parameters, tf1->varargs);
+        const char *nextprms = Parameter::argsTypesToChars(tf2->parameters, tf2->varargs);
         ::error(loc, "%s.%s called with argument types %s matches both:\n"
                      "\t%s(%d): %s%s\nand:\n\t%s(%d): %s%s",
                 s->parent->toPrettyChars(), s->ident->toChars(),
                 fargsBuf.toChars(),
-                lasts->loc.filename, lasts->loc.linnum, lasts->toChars(), lastprms,
-                nexts->loc.filename, nexts->loc.linnum, nexts->toChars(), nextprms);
+                m.lastf->loc.filename, m.lastf->loc.linnum, m.lastf->toPrettyChars(), lastprms,
+                m.nextf->loc.filename, m.nextf->loc.linnum, m.nextf->toPrettyChars(), nextprms);
     }
     return NULL;
 }

--- a/src/glue.c
+++ b/src/glue.c
@@ -568,6 +568,9 @@ void FuncDeclaration::toObjFile(int multiobj)
     if (semanticRun >= PASSobj) // if toObjFile() already run
         return;
 
+    if (type && type->ty == Tfunction && ((TypeFunction *)type)->next == NULL)
+        return;
+
     // If errors occurred compiling it, such as bugzilla 6118
     if (type && type->ty == Tfunction && ((TypeFunction *)type)->next->ty == Terror)
         return;

--- a/src/import.c
+++ b/src/import.c
@@ -291,7 +291,7 @@ void Import::semantic(Scope *sc)
          */
 
         OutBuffer *ob = global.params.moduleDeps;
-        Module* imod = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
+        Module* imod = sc->instantiatingModule();
         if (!global.params.moduleDepsFile)
             ob->writestring("depsImport ");
         ob->writestring(imod->toPrettyChars());

--- a/src/mars.c
+++ b/src/mars.c
@@ -280,6 +280,8 @@ void verror(Loc loc, const char *format, va_list ap,
     }
     else
     {
+        //fprintf(stderr, "(gag:%d) ", global.gag);
+        //verrorPrint(loc, header, format, ap, p1, p2);
         global.gaggedErrors++;
     }
     global.errors++;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4899,8 +4899,11 @@ StructDeclaration *TypeAArray::getImpl()
         TemplateInstance *ti = dti->ti;
 #endif
         // Instantiate on the root module of import dependency graph.
-        Scope *scx = sc->push(sc->module->importedFrom);
-        scx->instantiatingModule = sc->module->importedFrom;
+        Module *mi = sc->module->importedFrom;
+        Scope *scx = sc->push(mi);
+        scx->module = mi;
+        scx->tinst = NULL;
+        assert(scx->instantiatingModule() == mi);
         ti->semantic(scx);
         ti->semantic2(scx);
         ti->semantic3(scx);

--- a/src/opover.c
+++ b/src/opover.c
@@ -1569,7 +1569,7 @@ void inferApplyArgTypesZ(TemplateDeclaration *tstart, Parameters *arguments)
             error("forward reference to template %s", td->toChars());
             return;
         }
-        if (!td->onemember || !td->onemember->toAlias()->isFuncDeclaration())
+        if (!td->onemember || !td->onemember->isFuncDeclaration())
         {
             error("is not a function template");
             return;

--- a/src/scope.c
+++ b/src/scope.c
@@ -27,6 +27,7 @@
 #include "module.h"
 #include "id.h"
 #include "lexer.h"
+#include "template.h"
 
 Scope *Scope::freelist = NULL;
 
@@ -48,11 +49,11 @@ void *Scope::operator new(size_t size)
 }
 
 Scope::Scope()
-{   // Create root scope
+{
+    // Create root scope
 
     //printf("Scope::Scope() %p\n", this);
     this->module = NULL;
-    this->instantiatingModule = NULL;
     this->scopesym = NULL;
     this->sd = NULL;
     this->enclosing = NULL;
@@ -94,7 +95,6 @@ Scope::Scope(Scope *enclosing)
     //printf("Scope::Scope(enclosing = %p) %p\n", enclosing, this);
     assert(!(enclosing->flags & SCOPEfree));
     this->module = enclosing->module;
-    this->instantiatingModule = enclosing->instantiatingModule;
     this->func   = enclosing->func;
     this->parent = enclosing->parent;
     this->scopesym = NULL;
@@ -397,6 +397,13 @@ void Scope::mergeFieldInit(Loc loc, unsigned *fies)
             }
         }
     }
+}
+
+Module *Scope::instantiatingModule()
+{
+    if (tinst && tinst->instantiatingModule)
+        return tinst->instantiatingModule;
+    return module;
 }
 
 Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym)

--- a/src/scope.h
+++ b/src/scope.h
@@ -66,7 +66,6 @@ struct Scope
     Scope *enclosing;           // enclosing Scope
 
     Module *module;             // Root module
-    Module *instantiatingModule; // top level module that started a chain of template instantiations
     ScopeDsymbol *scopesym;     // current symbol
     ScopeDsymbol *sd;           // if in static if, and declaring new symbols,
                                 // sd gets the addMember()
@@ -131,6 +130,8 @@ struct Scope
 
     unsigned *saveFieldInit();
     void mergeFieldInit(Loc loc, unsigned *cses);
+
+    Module *instantiatingModule();
 
     Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym);
     Dsymbol *search_correct(Identifier *ident);

--- a/src/struct.c
+++ b/src/struct.c
@@ -169,7 +169,7 @@ void AggregateDeclaration::semantic3(Scope *sc)
             Expression *e = new DsymbolExp(Loc(), s, 0);
 
             Scope *sc2 = ti->tempdecl->scope->startCTFE();
-            sc2->instantiatingModule = sc->instantiatingModule ? sc->instantiatingModule : sc->module;
+            sc2->tinst = sc->tinst;
             e = e->semantic(sc2);
             sc2->endCTFE();
 

--- a/src/template.c
+++ b/src/template.c
@@ -741,21 +741,21 @@ void TemplateDeclaration::makeParamNamesVisibleInConstraint(Scope *paramscope, E
 
 MATCH TemplateDeclaration::matchWithInstance(Scope *sc, TemplateInstance *ti,
         Objects *dedtypes, Expressions *fargs, int flag)
-{   MATCH m;
-    size_t dedtypes_dim = dedtypes->dim;
-
+{
 #define LOGM 0
 #if LOGM
     printf("\n+TemplateDeclaration::matchWithInstance(this = %s, ti = %s, flag = %d)\n", toChars(), ti->toChars(), flag);
 #endif
-
 #if 0
-    printf("dedtypes->dim = %d, parameters->dim = %d\n", dedtypes_dim, parameters->dim);
+    printf("dedtypes->dim = %d, parameters->dim = %d\n", dedtypes->dim, parameters->dim);
     if (ti->tiargs->dim)
         printf("ti->tiargs->dim = %d, [0] = %p\n",
             ti->tiargs->dim,
             (*ti->tiargs)[0]);
 #endif
+    MATCH m;
+    size_t dedtypes_dim = dedtypes->dim;
+
     dedtypes->zero();
 
     if (errors)
@@ -776,8 +776,9 @@ MATCH TemplateDeclaration::matchWithInstance(Scope *sc, TemplateInstance *ti,
     assert(dedtypes_dim == parameters_dim);
     assert(dedtypes_dim >= ti->tiargs->dim || variadic);
 
-    // Set up scope for parameters
     assert(scope);
+
+    // Set up scope for template parameters
     ScopeDsymbol *paramsym = new ScopeDsymbol();
     paramsym->parent = scope->parent;
     Scope *paramscope = scope->push(paramsym);
@@ -831,7 +832,8 @@ MATCH TemplateDeclaration::matchWithInstance(Scope *sc, TemplateInstance *ti,
         for (size_t i = 0; i < dedtypes_dim; i++)
         {
             if (!(*dedtypes)[i])
-            {   assert(i < ti->tiargs->dim);
+            {
+                assert(i < ti->tiargs->dim);
                 (*dedtypes)[i] = (Type *)(*ti->tiargs)[i];
             }
         }
@@ -1066,7 +1068,8 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(FuncDeclaration *f, Loc l
 #if 0
     printf("\nTemplateDeclaration::deduceFunctionTemplateMatch() %s\n", toChars());
     for (size_t i = 0; i < (fargs ? fargs->dim : 0); i++)
-    {   Expression *e = (*fargs)[i];
+    {
+        Expression *e = (*fargs)[i];
         printf("\tfarg[%d] is %s, type is %s\n", i, e->toChars(), e->type->toChars());
     }
     printf("fd = %s\n", fd->toChars());
@@ -1115,14 +1118,15 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(FuncDeclaration *f, Loc l
 
     ntargs = 0;
     if (tiargs)
-    {   // Set initial template arguments
-
+    {
+        // Set initial template arguments
         ntargs = tiargs->dim;
         size_t n = parameters->dim;
         if (tp)
             n--;
         if (ntargs > n)
-        {   if (!tp)
+        {
+            if (!tp)
                 goto Lnomatch;
 
             /* The extra initial template arguments
@@ -1147,11 +1151,10 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(FuncDeclaration *f, Loc l
         memcpy(dedargs->tdata(), tiargs->tdata(), n * sizeof(*dedargs->tdata()));
 
         for (size_t i = 0; i < n; i++)
-        {   assert(i < parameters->dim);
-            MATCH m;
+        {
+            assert(i < parameters->dim);
             Declaration *sparam = NULL;
-
-            m = (*parameters)[i]->matchArg(loc, paramscope, dedargs, i, parameters, &dedtypes, &sparam);
+            MATCH m = (*parameters)[i]->matchArg(loc, paramscope, dedargs, i, parameters, &dedtypes, &sparam);
             //printf("\tdeduceType m = %d\n", m);
             if (m <= MATCHnomatch)
                 goto Lnomatch;
@@ -1246,7 +1249,8 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(FuncDeclaration *f, Loc l
         {
             TemplateThisParameter *ttp = (*parameters)[i]->isTemplateThisParameter();
             if (ttp)
-            {   hasttp = true;
+            {
+                hasttp = true;
 
                 Type *t = new TypeIdentifier(Loc(), ttp->ident);
                 MATCH m = tthis->deduceType(paramscope, t, parameters, &dedtypes);
@@ -1432,7 +1436,8 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(FuncDeclaration *f, Loc l
         if (argi >= nfargs)                // if not enough arguments
         {
             if (fparam->defaultArg)
-            {   /* Default arguments do not participate in template argument
+            {
+                /* Default arguments do not participate in template argument
                  * deduction.
                  */
                 goto Lmatch;
@@ -1483,7 +1488,8 @@ Lretry:
             /* Allow implicit function literals to delegate conversion
              */
             if (farg->op == TOKfunction)
-            {   FuncExp *fe = (FuncExp *)farg;
+            {
+                FuncExp *fe = (FuncExp *)farg;
                 Expression *e = fe->inferType(prmtype, 1, paramscope, inferparams);
                 if (!e)
                     goto Lvarargs;
@@ -1522,7 +1528,8 @@ Lretry:
             /* If no match, see if there's a conversion to a delegate
              */
             if (m == MATCHnomatch)
-            {   Type *tbp = prmtype->toBasetype();
+            {
+                Type *tbp = prmtype->toBasetype();
                 Type *tba = farg->type->toBasetype();
                 if (tbp->ty == Tdelegate)
                 {
@@ -1563,14 +1570,16 @@ Lretry:
                     {
                     }
                     else if (farg->op == TOKslice && argtype->ty == Tsarray)
-                    {   // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
+                    {
+                        // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
                     }
                     else
                         goto Lnomatch;
                 }
             }
             if (m > MATCHnomatch && (fparam->storageClass & STCout))
-            {   if (!farg->isLvalue())
+            {
+                if (!farg->isLvalue())
                     goto Lnomatch;
             }
             if (m == MATCHnomatch && (fparam->storageClass & STClazy) && prmtype->ty == Tvoid &&
@@ -1578,7 +1587,8 @@ Lretry:
                 m = MATCHconvert;
 
             if (m != MATCHnomatch)
-            {   if (m < match)
+            {
+                if (m < match)
                     match = m;          // pick worst match
                 argi++;
                 continue;
@@ -1600,20 +1610,24 @@ Lretry:
             // 6764 fix - TypeAArray may be TypeSArray have not yet run semantic().
             case Tsarray:
             case Taarray:
-            {   // Perhaps we can do better with this, see TypeFunction::callMatch()
+            {
+                // Perhaps we can do better with this, see TypeFunction::callMatch()
                 if (tb->ty == Tsarray)
-                {   TypeSArray *tsa = (TypeSArray *)tb;
+                {
+                    TypeSArray *tsa = (TypeSArray *)tb;
                     dinteger_t sz = tsa->dim->toInteger();
                     if (sz != nfargs - argi)
                         goto Lnomatch;
                 }
                 else if (tb->ty == Taarray)
-                {   TypeAArray *taa = (TypeAArray *)tb;
+                {
+                    TypeAArray *taa = (TypeAArray *)tb;
                     Expression *dim = new IntegerExp(loc, nfargs - argi, Type::tsize_t);
 
                     size_t i = templateParameterLookup(taa->index, parameters);
                     if (i == IDX_NOTFOUND)
-                    {   Expression *e;
+                    {
+                        Expression *e;
                         Type *t;
                         Dsymbol *s;
                         taa->index->resolve(loc, sc, &e, &t, &s);
@@ -1626,7 +1640,8 @@ Lretry:
                             goto Lnomatch;
                     }
                     else
-                    {   // This code matches code in TypeInstance::deduceType()
+                    {
+                        // This code matches code in TypeInstance::deduceType()
                         TemplateParameter *tprm = (*parameters)[i];
                         TemplateValueParameter *tvp = tprm->isTemplateValueParameter();
                         if (!tvp)
@@ -1650,15 +1665,16 @@ Lretry:
                 /* fall through */
             }
             case Tarray:
-            {   TypeArray *ta = (TypeArray *)tb;
+            {
+                TypeArray *ta = (TypeArray *)tb;
                 for (; argi < nfargs; argi++)
                 {
                     Expression *arg = (*fargs)[argi];
                     assert(arg);
 
                     if (arg->op == TOKfunction)
-                    {   FuncExp *fe = (FuncExp *)arg;
-
+                    {
+                        FuncExp *fe = (FuncExp *)arg;
                         Expression *e = fe->inferType(tb->nextOf(), 1, paramscope, inferparams);
                         if (!e)
                             goto Lnomatch;
@@ -1673,7 +1689,8 @@ Lretry:
                     if (tret)
                     {
                         if (ta->next->equals(arg->type))
-                        {   m = MATCHexact;
+                        {
+                            m = MATCHexact;
                         }
                         else
                         {
@@ -1730,7 +1747,8 @@ Lmatch:
             if (oded)
             {
                 if (tparam->specialization() || !tparam->isTemplateTypeParameter())
-                {   /* The specialization can work as long as afterwards
+                {
+                    /* The specialization can work as long as afterwards
                      * the oded == oarg
                      */
                     (*dedargs)[i] = oded;
@@ -1750,13 +1768,15 @@ Lmatch:
                 }
             }
             else
-            {   oded = tparam->defaultArg(loc, paramscope);
+            {
+                oded = tparam->defaultArg(loc, paramscope);
                 if (!oded)
                 {
                     if (tp &&                           // if tuple parameter and
                         fptupindex == IDX_NOTFOUND &&   // tuple parameter was not in function parameter list and
                         ntargs == dedargs->dim - 1)     // we're one argument short (i.e. no tuple argument)
-                    {   // make tuple argument an empty tuple
+                    {
+                        // make tuple argument an empty tuple
                         oded = (RootObject *)new Tuple();
                     }
                     else
@@ -1849,7 +1869,8 @@ Lmatch:
 
 #if 0
     for (i = 0; i < dedargs->dim; i++)
-    {   Type *t = (*dedargs)[i];
+    {
+        Type *t = (*dedargs)[i];
         printf("\tdedargs[%d] = %d, %s\n", i, t->dyncast(), t->toChars());
     }
 #endif
@@ -1985,14 +2006,17 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
     printf("functionResolve() dstart = %s\n", dstart->toChars());
     printf("    tiargs:\n");
     if (tiargs)
-    {   for (size_t i = 0; i < tiargs->dim; i++)
-        {   RootObject *arg = (*tiargs)[i];
+    {
+        for (size_t i = 0; i < tiargs->dim; i++)
+        {
+            RootObject *arg = (*tiargs)[i];
             printf("\t%s\n", arg->toChars());
         }
     }
     printf("    fargs:\n");
     for (size_t i = 0; i < (fargs ? fargs->dim : 0); i++)
-    {   Expression *arg = (*fargs)[i];
+    {
+        Expression *arg = (*fargs)[i];
         printf("\t%s %s\n", arg->type->toChars(), arg->toChars());
         //printf("\tty = %d\n", arg->type->ty);
     }
@@ -2061,7 +2085,8 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
             if (MODimplicitConv(tf->mod, tthis_fd->mod) ||
                 tf->isWild() && tf->isShared() == tthis_fd->isShared() ||
                 fd->isolateReturn()/* && tf->isShared() == tthis_fd->isShared()*/)
-            {   // Uniquely constructed object can ignore shared qualifier.
+            {
+                // Uniquely constructed object can ignore shared qualifier.
                 // TODO: Is this appropriate?
                 tthis_fd = NULL;
             }
@@ -2529,7 +2554,8 @@ FuncDeclaration *TemplateDeclaration::doHeaderInstantiation(Scope *sc,
     {
         // Match 'tthis' to any TemplateThisParameter's
         for (size_t i = 0; i < parameters->dim; i++)
-        {   TemplateParameter *tp = (*parameters)[i];
+        {
+            TemplateParameter *tp = (*parameters)[i];
             TemplateThisParameter *ttp = tp->isTemplateThisParameter();
             if (ttp)
                 hasttp = true;
@@ -2565,7 +2591,8 @@ FuncDeclaration *TemplateDeclaration::doHeaderInstantiation(Scope *sc,
                 tret = Type::tvoid;
             }
             else
-            {   tret = ad->handle;
+            {
+                tret = ad->handle;
                 assert(tret);
                 tret = tret->addStorageClass(fd->storage_class | scx->stc);
                 tret = tret->addMod(fd->type->mod);
@@ -5594,7 +5621,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     argsym->parent = scope->parent;
     scope = scope->push(argsym);
     scope->instantiatingModule = mi;
-//    scope->stc = 0;
+    //scope->stc = 0;
 
     // Declare each template parameter as an alias for the argument type
     Scope *paramscope = scope->push();
@@ -6119,14 +6146,17 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
 
         Ltype:
             if (ta->ty == Ttuple)
-            {   // Expand tuple
+            {
+                // Expand tuple
                 TypeTuple *tt = (TypeTuple *)ta;
                 size_t dim = tt->arguments->dim;
                 tiargs->remove(j);
                 if (dim)
-                {   tiargs->reserve(dim);
+                {
+                    tiargs->reserve(dim);
                     for (size_t i = 0; i < dim; i++)
-                    {   Parameter *arg = (*tt->arguments)[i];
+                    {
+                        Parameter *arg = (*tt->arguments)[i];
                         if (flags & 2 && arg->ident)
                             tiargs->insert(j + i, arg);
                         else
@@ -6161,7 +6191,8 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                 }
             }
             else if (ea->op == TOKvar)
-            {   /* This test is to skip substituting a const var with
+            {
+                /* This test is to skip substituting a const var with
                  * its initializer. The problem is the initializer won't
                  * match with an 'alias' parameter. Instead, do the
                  * const substitution in TemplateValueParameter::matchArg().
@@ -6181,12 +6212,14 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
                 continue;
             }
             if (ea->op == TOKtuple)
-            {   // Expand tuple
+            {
+                // Expand tuple
                 TupleExp *te = (TupleExp *)ea;
                 size_t dim = te->exps->dim;
                 tiargs->remove(j);
                 if (dim)
-                {   tiargs->reserve(dim);
+                {
+                    tiargs->reserve(dim);
                     for (size_t i = 0; i < dim; i++)
                         tiargs->insert(j + i, (*te->exps)[i]);
                 }
@@ -6196,42 +6229,50 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
             (*tiargs)[j] = ea;
 
             if (ea->op == TOKtype)
-            {   ta = ea->type;
+            {
+                ta = ea->type;
                 goto Ltype;
             }
             if (ea->op == TOKimport)
-            {   sa = ((ScopeExp *)ea)->sds;
+            {
+                sa = ((ScopeExp *)ea)->sds;
                 goto Ldsym;
             }
             if (ea->op == TOKfunction)
-            {   FuncExp *fe = (FuncExp *)ea;
+            {
+                FuncExp *fe = (FuncExp *)ea;
                 /* A function literal, that is passed to template and
                  * already semanticed as function pointer, never requires
                  * outer frame. So convert it to global function is valid.
                  */
                 if (fe->fd->tok == TOKreserved && fe->type->ty == Tpointer)
-                {   // change to non-nested
+                {
+                    // change to non-nested
                     fe->fd->tok = TOKfunction;
                     fe->fd->vthis = NULL;
                 }
                 else if (fe->td)
-                {   /* If template argument is a template lambda,
+                {
+                    /* If template argument is a template lambda,
                      * get template declaration itself. */
                     //sa = fe->td;
                     //goto Ldsym;
                 }
             }
             if (ea->op == TOKdotvar)
-            {   // translate expression to dsymbol.
+            {
+                // translate expression to dsymbol.
                 sa = ((DotVarExp *)ea)->var;
                 goto Ldsym;
             }
             if (ea->op == TOKtemplate)
-            {   sa = ((TemplateExp *)ea)->td;
+            {
+                sa = ((TemplateExp *)ea)->td;
                 goto Ldsym;
             }
             if (ea->op == TOKdottd)
-            {   // translate expression to dsymbol.
+            {
+                // translate expression to dsymbol.
                 sa = ((DotTemplateExp *)ea)->td;
                 goto Ldsym;
             }
@@ -6246,7 +6287,8 @@ void TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
             }
             TupleDeclaration *d = sa->toAlias()->isTupleDeclaration();
             if (d)
-            {   // Expand tuple
+            {
+                // Expand tuple
                 size_t dim = d->objects->dim;
                 tiargs->remove(j);
                 tiargs->insert(j, d->objects);

--- a/src/template.c
+++ b/src/template.c
@@ -1835,6 +1835,7 @@ Lmatch:
         printf("\tdedargs[%d] = %d, %s\n", i, t->dyncast(), t->toChars());
     }
 #endif
+    ti->tiargs = &ti->tdtypes;  // for better error message
 
     paramscope->pop();
     //printf("\tmatch %d\n", match);
@@ -2319,7 +2320,7 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
 
           Lambig:   // td_best and td are ambiguous
             //printf("Lambig\n");
-            m->nextf = fd;  // Caution! m->nextf isn't complete instantiated fd, so must not call toPrettyChars()
+            m->nextf = fd;
             m->count++;
             continue;
 

--- a/src/template.h
+++ b/src/template.h
@@ -95,6 +95,8 @@ public:
     PROT prot();
 //    void toDocBuffer(OutBuffer *buf);
 
+    bool evaluateConstraint(Scope *sc, Scope *paramscope, Objects *dedtypes, FuncDeclaration *fd, Expressions *fargs);
+
     MATCH matchWithInstance(Scope *sc, TemplateInstance *ti, Objects *atypes, Expressions *fargs, int flag);
     MATCH leastAsSpecialized(Scope *sc, TemplateDeclaration *td2, Expressions *fargs);
 

--- a/src/template.h
+++ b/src/template.h
@@ -105,6 +105,8 @@ public:
     TemplateInstance *addInstance(TemplateInstance *ti);
     void removeInstance(TemplateInstance *handle);
 
+    TemplateInstance *getInstantiating(Scope *sc);
+
     TemplateDeclaration *isTemplateDeclaration() { return this; }
 
     TemplateTupleParameter *isVariadic();

--- a/src/template.h
+++ b/src/template.h
@@ -95,14 +95,14 @@ public:
     PROT prot();
 //    void toDocBuffer(OutBuffer *buf);
 
-    bool evaluateConstraint(Scope *sc, Scope *paramscope, Objects *dedtypes, FuncDeclaration *fd, Expressions *fargs);
+    bool evaluateConstraint(TemplateInstance *ti, Scope *sc, Scope *paramscope, Objects *dedtypes, FuncDeclaration *fd);
 
     MATCH matchWithInstance(Scope *sc, TemplateInstance *ti, Objects *atypes, Expressions *fargs, int flag);
     MATCH leastAsSpecialized(Scope *sc, TemplateDeclaration *td2, Expressions *fargs);
 
-    MATCH deduceFunctionTemplateMatch(FuncDeclaration *f, Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, Objects *dedargs);
+    MATCH deduceFunctionTemplateMatch(TemplateInstance *ti, Scope *sc, FuncDeclaration *&fd, Type *tthis, Expressions *fargs);
     RootObject *declareParameter(Scope *sc, TemplateParameter *tp, RootObject *o);
-    FuncDeclaration *doHeaderInstantiation(Scope *sc, Objects *tdargs, Type *tthis, Expressions *fargs);
+    FuncDeclaration *doHeaderInstantiation(TemplateInstance *ti, Scope *sc, FuncDeclaration *fd, Type *tthis, Expressions *fargs);
     TemplateInstance *findExistingInstance(TemplateInstance *tithis, Expressions *fargs);
     TemplateInstance *addInstance(TemplateInstance *ti);
     void removeInstance(TemplateInstance *handle);
@@ -114,7 +114,6 @@ public:
     TemplateTupleParameter *isVariadic();
     bool isOverloadable();
 
-    void makeParamNamesVisibleInConstraint(Scope *paramscope, Expressions *fargs);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1147,6 +1147,24 @@ void TemplateInstance::toObjFile(int multiobj)
 #endif
     if (!isError(this) && members)
     {
+        FuncDeclaration *fd = enclosing ? enclosing->isFuncDeclaration() : NULL;
+        if (fd && fd->fbody == NULL)
+        {
+            /* Prevent codegen if enclosing is an artificially instantiated function.
+             */
+            return;
+        }
+
+        TemplateDeclaration *tempdecl = this->tempdecl->isTemplateDeclaration();
+        assert(tempdecl);
+        if (tempdecl->literal && tempdecl->ident == Id::empty)
+        {
+            /* Bugzilla 10313: Template lambdas that instantiated in template constraint
+             * cannot appear in runnable code block. So, this skip won't cause linker failure.
+             */
+            return;
+        }
+
         if (multiobj)
             // Append to list of object files to be written later
             obj_append(this);

--- a/test/compilable/ice6538.d
+++ b/test/compilable/ice6538.d
@@ -1,0 +1,43 @@
+
+
+/**************************************/
+// 6538
+
+template allSatisfy(alias F, T...) { enum bool allSatisfy = true; }
+template isIntegral(T) { enum bool isIntegral = true; }
+
+void foo(I...)(I sizes)
+if (allSatisfy!(isIntegral, sizes)) {}
+
+void test6538a()
+{
+    foo(42, 86);
+}
+
+void bar(T1, T2)(T1 t1, T2 t2)
+if (allSatisfy!(isIntegral, t1, t2)) {}
+
+void test6538b()
+{
+    bar(42, 86);
+}
+
+/**************************************/
+// 9361
+
+template Sym(alias A)
+{
+    enum Sym = true;
+}
+
+struct S
+{
+    void foo()() if (Sym!(this)) {}
+    void bar()() { static assert(Sym!(this)); }   // OK
+}
+void test9361a()
+{
+    S s;
+    s.foo();    // fail
+    s.bar();    // OK
+}

--- a/test/fail_compilation/diag11769.d
+++ b/test/fail_compilation/diag11769.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag11769.d(18): Error: diag11769.foo!string.bar called with argument types (string) matches both:
-	fail_compilation/diag11769.d(13): bar(immutable(wchar)[] _param_0)
+	fail_compilation/diag11769.d(13): diag11769.foo!string.bar(immutable(wchar)[] _param_0)
 and:
-	fail_compilation/diag11769.d(14): bar(immutable(dchar)[] _param_0)
+	fail_compilation/diag11769.d(14): diag11769.foo!string.bar(immutable(dchar)[] _param_0)
 ---
 */
 

--- a/test/fail_compilation/diag9880.d
+++ b/test/fail_compilation/diag9880.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9880.d(9): Error: template instance foo!string does not match template declaration foo(T)(int) if (is(T == int))
+fail_compilation/diag9880.d(9): Error: template instance diag9880.foo!string does not match template declaration foo(T)(int) if (is(T == int))
 ---
 */
 

--- a/test/fail_compilation/fail319.d
+++ b/test/fail_compilation/fail319.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail319.d(13): Error: template instance f!(int, int) does not match template declaration f(T...)() if (T.length > 20)
+fail_compilation/fail319.d(13): Error: template instance fail319.f!(int, int) does not match template declaration f(T...)() if (T.length > 20)
 ---
 */
 

--- a/test/fail_compilation/ice6538.d
+++ b/test/fail_compilation/ice6538.d
@@ -1,80 +1,22 @@
 
 
 /**************************************/
-// 6538
-
-template allSatisfy(alias F, T...) { enum bool allSatisfy = true; }
-template isIntegral(T) { enum bool isIntegral = true; }
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/ice6538.d(17): Error: cannot take a not yet instantiated symbol 'sizes' inside template constraint
-fail_compilation/ice6538.d(22): Error: template ice6538.foo cannot deduce function from argument types !()(int, int), candidates are:
-fail_compilation/ice6538.d(17):        ice6538.foo(I...)(I sizes) if (allSatisfy!(isIntegral, sizes))
----
-*/
-void foo(I...)(I sizes)
-if (allSatisfy!(isIntegral, sizes)) {}
-
-void test6538a()
-{
-    foo(42, 86);
-}
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/ice6538.d(34): Error: cannot take a not yet instantiated symbol 't1' inside template constraint
-fail_compilation/ice6538.d(34): Error: cannot take a not yet instantiated symbol 't2' inside template constraint
-fail_compilation/ice6538.d(39): Error: template ice6538.bar cannot deduce function from argument types !()(int, int), candidates are:
-fail_compilation/ice6538.d(34):        ice6538.bar(T1, T2)(T1 t1, T2 t2) if (allSatisfy!(isIntegral, t1, t2))
----
-*/
-void bar(T1, T2)(T1 t1, T2 t2)
-if (allSatisfy!(isIntegral, t1, t2)) {}
-
-void test6538b()
-{
-    bar(42, 86);
-}
-
-/**************************************/
 // 9361
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice6538.d(23): Error: expression super is not a valid template value argument
+fail_compilation/ice6538.d(28): Error: template ice6538.D.foo cannot deduce function from argument types !()(), candidates are:
+fail_compilation/ice6538.d(23):        ice6538.D.foo()() if (Sym!(super))
+---
+*/
 
 template Sym(alias A)
 {
     enum Sym = true;
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/ice6538.d(60): Error: cannot take a not yet instantiated symbol 'this' inside template constraint
-fail_compilation/ice6538.d(66): Error: template ice6538.S.foo cannot deduce function from argument types !()(), candidates are:
-fail_compilation/ice6538.d(60):        ice6538.S.foo()() if (Sym!this)
----
-*/
-struct S
-{
-    void foo()() if (Sym!(this)) {}
-    void bar()() { static assert(Sym!(this)); }   // OK
-}
-void test9361a()
-{
-    S s;
-    s.foo();    // fail
-    s.bar();    // OK
-}
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/ice6538.d(81): Error: cannot take a not yet instantiated symbol 'super' inside template constraint
-fail_compilation/ice6538.d(86): Error: template ice6538.D.foo cannot deduce function from argument types !()(), candidates are:
-fail_compilation/ice6538.d(81):        ice6538.D.foo()() if (Sym!(super))
----
-*/
 class C {}
 class D : C
 {

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test8556.d(22): Error: template instance Grab!(Circle!(uint[])) does not match template declaration Grab(Range) if (!isSliceable!Range)
+fail_compilation/test8556.d(22): Error: template instance test8556.Grab!(Circle!(uint[])) does not match template declaration Grab(Range) if (!isSliceable!Range)
 fail_compilation/test8556.d(53): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
 ---
 */

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -793,6 +793,48 @@ void test9928()
 }
 
 /***************************************************/
+// 10133
+
+ptrdiff_t countUntil10133(alias pred, R)(R haystack)
+{
+    typeof(return) i;
+
+    alias T = dchar;
+
+    foreach (T elem; haystack)
+    {
+        if (pred(elem)) return i;
+        ++i;
+    }
+
+    return -1;
+}
+
+bool func10133(string s)() if (countUntil10133!(x => x == 'x')(s) == 1)
+{
+    return true;
+}
+
+bool func10133a(string s)() if (countUntil10133!(x => s == "x")(s) != -1)
+{
+    return true;
+}
+bool func10133b(string s)() if (countUntil10133!(x => s == "x")(s) != -1)
+{
+    return true;
+}
+
+void test10133()
+{
+    func10133!("ax")();
+
+    func10133a!("x")();
+    static assert(!is(typeof(func10133a!("ax")())));
+    static assert(!is(typeof(func10133b!("ax")())));
+    func10133b!("x")();
+}
+
+/***************************************************/
 // 10288
 
 T foo10288(T)(T x)
@@ -965,6 +1007,7 @@ int main()
     test9415();
     test9628();
     test9928();
+    test10133();
     test10288();
     test11661();
 


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=10133

Currently template constraint is evaluated under the following nested scope:

```
TemplateDeclaration
  + FuncDeclaration (if exists)
     + constraint
```

But this is very special hierarchy, because normally `TemplateDeclaration` does not appear in symbol tree. This PR changes it to:

```
TemplateInstance  (artificially made)
  + FuncDeclaration (artificially made, if exists)
     + constraint
```

by emulating template instantiation.
