### PR TITLE
[DDMD] Rename toString to toStringExp to avoid conflict with D's toString

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -575,7 +575,7 @@ void DeprecatedDeclaration::setScope(Scope *sc)
 {
     assert(msg);
     char *depmsg = NULL;
-    StringExp *se = msg->toString();
+    StringExp *se = msg->toStringExp();
     if (se)
         depmsg = (char *)se->string;
     else
@@ -1018,7 +1018,7 @@ void PragmaDeclaration::semantic(Scope *sc)
                 {   errorSupplemental(loc, "while evaluating pragma(msg, %s)", (*args)[i]->toChars());
                     return;
                 }
-                StringExp *se = e->toString();
+                StringExp *se = e->toStringExp();
                 if (se)
                 {
                     se = se->toUTF8(sc);
@@ -1048,7 +1048,7 @@ void PragmaDeclaration::semantic(Scope *sc)
             (*args)[0] = e;
             if (e->op == TOKerror)
                 goto Lnodecl;
-            StringExp *se = e->toString();
+            StringExp *se = e->toStringExp();
             if (!se)
                 error("string expected for library name, not '%s'", e->toChars());
             else
@@ -1111,7 +1111,7 @@ void PragmaDeclaration::semantic(Scope *sc)
             if (e->op == TOKerror)
                 goto Lnodecl;
 
-            StringExp *se = e->toString();
+            StringExp *se = e->toStringExp();
 
             if (!se)
             {
@@ -1213,7 +1213,7 @@ Ldecl:
 
             if (ident == Id::mangle)
             {
-                StringExp *e = (*args)[0]->toString();
+                StringExp *e = (*args)[0]->toStringExp();
 
                 char *name = (char *)mem.malloc(e->len + 1);
                 memcpy(name, e->string, e->len);
@@ -1595,7 +1595,7 @@ void CompileDeclaration::compileIt(Scope *sc)
     exp = resolveProperties(sc, exp);
     sc = sc->endCTFE();
     exp = exp->ctfeInterpret();
-    StringExp *se = exp->toString();
+    StringExp *se = exp->toStringExp();
     if (!se)
     {
         exp->error("argument to mixin must be a string, not (%s)", exp->toChars());

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -162,7 +162,7 @@ char *ThrownExceptionExp::toChars()
 void ThrownExceptionExp::generateUncaughtError()
 {
     Expression *e = (*thrown->value->elements)[0];
-    StringExp* se = e->toString();
+    StringExp* se = e->toStringExp();
     thrown->error("Uncaught CTFE exception %s(%s)", thrown->type->toChars(), se ? se->toChars() : e->toChars());
 
     /* Also give the line where the throw statement was. We won't have it

--- a/src/expression.c
+++ b/src/expression.c
@@ -2112,7 +2112,7 @@ complex_t Expression::toComplex()
     return (complex_t)0.0;
 }
 
-StringExp *Expression::toString()
+StringExp *Expression::toStringExp()
 {
     return NULL;
 }
@@ -3852,7 +3852,7 @@ int NullExp::isBool(int result)
     return result ? false : true;
 }
 
-StringExp *NullExp::toString()
+StringExp *NullExp::toStringExp()
 {
     if (implicitConvTo(Type::tstring))
     {
@@ -4057,7 +4057,7 @@ size_t StringExp::length()
     return result;
 }
 
-StringExp *StringExp::toString()
+StringExp *StringExp::toStringExp()
 {
     return this;
 }
@@ -4367,7 +4367,7 @@ int ArrayLiteralExp::isBool(int result)
     return result ? (dim != 0) : (dim == 0);
 }
 
-StringExp *ArrayLiteralExp::toString()
+StringExp *ArrayLiteralExp::toStringExp()
 {
     TY telem = type->nextOf()->toBasetype()->ty;
 
@@ -7207,7 +7207,7 @@ Expression *CompileExp::semantic(Scope *sc)
         return new ErrorExp();
     }
     e1 = e1->ctfeInterpret();
-    StringExp *se = e1->toString();
+    StringExp *se = e1->toStringExp();
     if (!se)
     {   error("argument to mixin must be a string, not (%s)", e1->toChars());
         return new ErrorExp();

--- a/src/expression.h
+++ b/src/expression.h
@@ -146,7 +146,7 @@ public:
     virtual real_t toReal();
     virtual real_t toImaginary();
     virtual complex_t toComplex();
-    virtual StringExp *toString();
+    virtual StringExp *toStringExp();
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual void toMangleBuffer(OutBuffer *buf);
     virtual int isLvalue();
@@ -382,7 +382,7 @@ public:
     Expression *semantic(Scope *sc);
     int isBool(int result);
     int isConst();
-    StringExp *toString();
+    StringExp *toStringExp();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     MATCH implicitConvTo(Type *t);
@@ -411,7 +411,7 @@ public:
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     size_t length();
-    StringExp *toString();
+    StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
     Expression *implicitCastTo(Scope *sc, Type *t);
     MATCH implicitConvTo(Type *t);
@@ -476,7 +476,7 @@ public:
     Expression *semantic(Scope *sc);
     int isBool(int result);
     elem *toElem(IRState *irs);
-    StringExp *toString();
+    StringExp *toStringExp();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     Expression *optimize(int result, bool keepLvalue = false);

--- a/src/statement.c
+++ b/src/statement.c
@@ -521,7 +521,7 @@ Statements *CompileStatement::flatten(Scope *sc)
     Statements *a = new Statements();
     if (exp->op != TOKerror)
     {
-        StringExp *se = exp->toString();
+        StringExp *se = exp->toStringExp();
         if (!se)
            error("argument to mixin must be a string, not (%s)", exp->toChars());
         else
@@ -2931,7 +2931,7 @@ Statement *PragmaStatement::semantic(Scope *sc)
                 {   errorSupplemental(loc, "while evaluating pragma(msg, %s)", (*args)[i]->toChars());
                     goto Lerror;
                 }
-                StringExp *se = e->toString();
+                StringExp *se = e->toStringExp();
                 if (se)
                 {
                     fprintf(stderr, "%.*s", (int)se->len, (char *)se->string);
@@ -2962,7 +2962,7 @@ Statement *PragmaStatement::semantic(Scope *sc)
 
             e = e->ctfeInterpret();
             (*args)[0] = e;
-            StringExp *se = e->toString();
+            StringExp *se = e->toStringExp();
             if (!se)
                 error("string expected for library name, not '%s'", e->toChars());
             else if (global.params.verbose)

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -90,7 +90,7 @@ void StaticAssert::semantic2(Scope *sc)
             sc = sc->endCTFE();
             msg = msg->ctfeInterpret();
             hgs.console = 1;
-            StringExp * s = msg->toString();
+            StringExp * s = msg->toStringExp();
             if (s)
             {   s->postfix = 0; // Don't display a trailing 'c'
                 msg = s;

--- a/src/traits.c
+++ b/src/traits.c
@@ -429,7 +429,7 @@ Expression *TraitsExp::semantic(Scope *sc)
             goto Lfalse;
         }
         e = e->ctfeInterpret();
-        StringExp *se = e->toString();
+        StringExp *se = e->toStringExp();
         if (!se || se->length() == 0)
         {   error("string expected as second argument of __traits %s instead of %s", ident->toChars(), e->toChars());
             goto Lfalse;


### PR DESCRIPTION
The name is better too - that's exactly what it does.
