### PR TITLE
Fix CppMangleVisitor::substitute and Remove CppMangleVisitor::exist

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -77,18 +77,6 @@ class CppMangleVisitor : public Visitor
         return 0;
     }
 
-    int exist(RootObject *p)
-    {
-        for (size_t i = 0; i < components.dim; i++)
-        {
-            if (p == components[i])
-            {
-                return 1;
-            }
-        }
-        return 0;
-    }
-
     void store(RootObject *p)
     {
         components.push(p);
@@ -278,26 +266,22 @@ public:
 
     void visit(TypePointer *t)
     {
-        if (!exist(t))
+        if (!substitute(t))
         {
             buf.writeByte('P');
             t->next->accept(this);
             store(t);
         }
-        else
-            substitute(t);
     }
 
     void visit(TypeReference *t)
     {
-        if (!exist(t))
+        if (!substitute(t))
         {
             buf.writeByte('R');
             t->next->accept(this);
             store(t);
         }
-        else
-            substitute(t);
     }
 
     void visit(TypeFunction *t)
@@ -324,7 +308,7 @@ public:
             TypeFunctions for non-static member functions, and non-static
             member functions of different classes.
          */
-        if (!exist(t))
+        if (!substitute(t))
         {
             buf.writeByte('F');
             if (t->linkage == LINKc)
@@ -334,8 +318,6 @@ public:
             buf.writeByte('E');
             store(t);
         }
-        else
-            substitute(t);
     }
 
     void visit(TypeDelegate *t)
@@ -345,7 +327,7 @@ public:
 
     void visit(TypeStruct *t)
     {
-        if (!exist(t))
+        if (!substitute(t))
         {
             if (t->isConst())
                 buf.writeByte('K');
@@ -359,13 +341,11 @@ public:
             if (t->isConst())
                 store(t);
         }
-        else
-            substitute(t);
     }
 
     void visit(TypeEnum *t)
     {
-        if (!exist(t))
+        if (!substitute(t))
         {
             if (t->isConst())
                 buf.writeByte('K');
@@ -379,8 +359,6 @@ public:
             if (t->isConst())
                 store(t);
         }
-        else
-            substitute(t);
     }
 
     void visit(TypeTypedef *t)
@@ -390,7 +368,7 @@ public:
 
     void visit(TypeClass *t)
     {
-        if (!exist(t))
+        if (!substitute(t))
         {
             buf.writeByte('P');
 
@@ -402,8 +380,6 @@ public:
 
             store(t);
         }
-        else
-            substitute(t);
     }
 
     struct ArgsCppMangleCtx

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -74,7 +74,6 @@ class CppMangleVisitor : public Visitor
                 return 1;
             }
         }
-        components.push(p);
         return 0;
     }
 
@@ -107,10 +106,10 @@ class CppMangleVisitor : public Visitor
         {
             Dsymbol *p = s->toParent();
             if (p && !p->isModule())
-            {
                 prefix_name(p);
-            }
+
             source_name(s);
+            store(s);
         }
     }
 
@@ -166,8 +165,10 @@ public:
          * u <source-name>
          */
         if (!substitute(t))
-        {   assert(t->deco);
+        {
+            assert(t->deco);
             buf.printf("u%d%s", strlen(t->deco), t->deco);
+            store(t);
         }
     }
 
@@ -232,6 +233,7 @@ public:
         {
             if (substitute(t))
                 return;
+            store(t);
         }
 
         if (t->isConst())
@@ -250,6 +252,7 @@ public:
         {
             buf.writestring("U8__vector");
             t->basetype->accept(this);
+            store(t);
         }
     }
 
@@ -259,6 +262,7 @@ public:
         {
             buf.printf("A%llu_", t->dim ? t->dim->toInteger() : 0);
             t->next->accept(this);
+            store(t);
         }
     }
 
@@ -347,7 +351,10 @@ public:
                 buf.writeByte('K');
 
             if (!substitute(t->sym))
+            {
                 cpp_mangle_name(t->sym);
+                store(t->sym);
+            }
 
             if (t->isConst())
                 store(t);
@@ -364,7 +371,10 @@ public:
                 buf.writeByte('K');
 
             if (!substitute(t->sym))
+            {
                 cpp_mangle_name(t->sym);
+                store(t->sym);
+            }
 
             if (t->isConst())
                 store(t);
@@ -385,7 +395,10 @@ public:
             buf.writeByte('P');
 
             if (!substitute(t->sym))
+            {
                 cpp_mangle_name(t->sym);
+                store(t->sym);
+            }
 
             store(t);
         }


### PR DESCRIPTION
`CppMangleVisitor::substitute` has been the reason behind a lot of mangling bugs, in particular, when the use of `const` comes into the mix, or when the type is complex in depth.  TypeEnum, TypeStruct, TypeClass, TypePointer, TypeFunction, etc are victims to this.

The fix for this has always been to replace:

```
if (!substitute(t))
{
  /* ... */
}
```

with

```
if (!exist(t))
{
  /* ... */
  store(t);
}
else
  substitute(t);
```

This is because the way C++ mangling works, it's always in the logic of:

```
if (found substitute)
  => write substitute
else
  => write mangle
  => store substitute
```

Where 'write mangle' is recursive and checks 'found substitute' at each nested level.  But doing it in the way it's currently done creates a bit of unwanted overhead in both runtime and baggage in the source code.

So I say lets just clear up this confusion with `substitute` and make it behave more like `exists` when it comes to dealing with a symbol not yet `stored`'d. This then hands over the storing of the substitute to the caller of `substitute`.  We then get the benefit of cleaning up the code and ensuring correct behaviour.  :)

This pull has three patches, I'm just committing them one at a time to ensure things don't break at each step in the process (and to make it absolutely clear what is happening).

The third commit is best viewed with `?w=1`
