### PR TITLE
[REG2.065a][enh] Issue 11946 - "need 'this' to access member" when passing field to template parameter

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -6684,6 +6684,22 @@ bool TemplateInstance::hasNestedArgs(Objects *args, bool isstatic)
                 if (isstatic)
                 {
                     Dsymbol *dparent = sa->toParent2();
+                    if (dparent->isAggregateDeclaration())
+                    {
+                        /* If 'sa' is a field or a member function, to capture the object reference
+                         * 'dparent' should appear in lexical scope of this template declaration.
+                         * If not, there is no way to supply context to the template instance, so
+                         * we can elide 'enclosing' pointer.
+                         */
+                        Dsymbol *p = tempdecl->parent;
+                        for (; p; p = p->parent)
+                        {
+                            if (p == dparent)
+                                break;
+                        }
+                        if (!p)
+                            continue;
+                    }
                     if (!enclosing)
                         enclosing = dparent;
                     else if (enclosing != dparent)

--- a/test/compilable/fail260.d
+++ b/test/compilable/fail260.d
@@ -1,13 +1,5 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail260.d(26): Error: template instance Static!(4u, 4u) Static!(4u, 4u) is nested in both Static and Static
-fail_compilation/fail260.d(32): Error: template instance fail260.Static!(1, 4).Static.MultReturn!(Static!(1, 4), Static!(4, 1)) error instantiating
-fail_compilation/fail260.d(45):        instantiated from here: opMultVectors!(Static!(4, 1))
-fail_compilation/fail260.d(45): Error: template instance fail260.Static!(1, 4).Static.opMultVectors!(Static!(4, 1)) error instantiating
----
-*/
 // REQUIRED_ARGS: -d
+
 struct Static(uint width2, uint height2)
 {
     immutable width = width2;

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2574,7 +2574,7 @@ void xmap(alias g)(int t)
 
 enum foo11297 = function (int x)
    {
-//	int bar(int y) { return x; } xmap!bar(7);
+        //int bar(int y) { return x; } xmap!bar(7);
         xmap!(y => x)(7);
    };
 
@@ -2585,6 +2585,19 @@ void xreduce(alias f)()
 
 void test11297() {
     xreduce!foo11297();
+}
+
+/*******************************************/
+// 11946
+
+static int f11946(A...)() { return 0; }
+       int g11946(A...)() { return 0; }
+
+struct S11946
+{
+    int x;
+    enum y = f11946!x();
+    enum z = g11946!x();    //  enhancement 7805
 }
 
 /*******************************************/


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=11946

If alias parameter takes nested argument but its context pointer is not really accessible, instantiated template should not have implicit enclosing context.

This is also a small language enhancement, and some ever unnecessarily rejected code will be accepted.
