### PR TITLE
Issue 11955 - Aliased types not accepted in foreach over range of tuple

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -2008,7 +2008,7 @@ Lagain:
                 #endif
                     if (!arg->type)
                         arg->type = exp->type;
-                    arg->type = arg->type->addStorageClass(arg->storageClass);
+                    arg->type = arg->type->addStorageClass(arg->storageClass)->semantic(loc, sc);
                     if (!exp->implicitConvTo(arg->type))
                         goto Lrangeerr;
 

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -454,6 +454,24 @@ void test10049()
 }
 
 /******************************************/
+
+struct T11955(T...) { T field; alias field this; }
+
+alias X11955 = uint;
+
+struct S11955
+{
+    enum empty = false;
+    T11955!(uint, uint) front;
+    void popFront() {}
+}
+
+void test11955()
+{
+    foreach(X11955 i, v; S11955()) {}
+}
+
+/******************************************/
 // 6652
 
 void test6652()


### PR DESCRIPTION
Run semantic on the type before attempting implicit conversions.

https://d.puremagic.com/issues/show_bug.cgi?id=11955
