### PR TITLE
fix Issue 11956 - dmd doesn't lookup /etc/dmd.conf

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -1,5 +1,4 @@
 INSTALL_DIR=$(PWD)/../install
-SYSCONFDIR="/etc/"
 
 .PHONY: all clean test install
 

--- a/src/inifile.c
+++ b/src/inifile.c
@@ -34,10 +34,6 @@
 
 #define LOG     0
 
-#ifndef SYSCONFDIR
-#define SYSCONFDIR "/etc/"
-#endif
-
 char *skipspace(const char *p);
 
 
@@ -139,9 +135,12 @@ const char *inifile(const char *argv0x, const char *inifilex, const char *envsec
                     }
                     // Search /etc/ for inifile
                 Letc:
+#ifndef SYSCONFDIR
+# error SYSCONFDIR not defined
 #endif
+                    assert(SYSCONFDIR != NULL && strlen(SYSCONFDIR));
                     filename = (char *)FileName::combine((char *)SYSCONFDIR, inifile);
-
+#endif // __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
                 Ldone:
                     ;
                 }

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -19,6 +19,8 @@ else
 endif
 
 INSTALL_DIR=../../install
+# can be set to override the default /etc/
+SYSCONFDIR=/etc/
 
 C=backend
 TK=tk


### PR DESCRIPTION
- define variable in src/posix.mak instead of posix.mak
- fix quotes
- assert that SYSCONFDIR was set to a non-empty string

[Issue 11956 – dmd doesn't lookup /etc/dmd.conf](https://d.puremagic.com/issues/show_bug.cgi?id=11956)
