### PR TITLE
Issue 11957 - extern inside function scope ignored

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3186,6 +3186,12 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, const utf8_t *co
             a = new Dsymbols();
             a->push(s);
         }
+        if (link != linkage)
+        {
+            s = new LinkDeclaration(link, a);
+            a = new Dsymbols();
+            a->push(s);
+        }
         if (udas)
         {
             s = new UserAttributeDeclaration(udas, a);

--- a/test/compilable/parse11957.d
+++ b/test/compilable/parse11957.d
@@ -1,0 +1,13 @@
+
+extern(C++) class C
+{
+    void x() {}
+}
+
+void main()
+{
+    extern(C++) class D : C
+    {
+        override void x() {}
+    }
+}


### PR DESCRIPTION
This case was just plain missing.

https://d.puremagic.com/issues/show_bug.cgi?id=11957
