### PR TITLE
Fix Issue 4483 - foreach over string or wstring, where element type not specified

### DIFF
--- a/src/opover.c
+++ b/src/opover.c
@@ -1376,6 +1376,12 @@ int ForeachStatement::inferApplyArgTypes(Scope *sc, Dsymbol *&sapply)
             if (!arg->type && tab->ty != Ttuple)
             {
                 arg->type = tab->nextOf();      // value type
+                if ((arg->storageClass & STCref) == 0 &&
+                    (arg->type->toBasetype()->ty == Tchar || arg->type->toBasetype()->ty == Twchar))
+                {
+                    // Infer the value for char[] and wchar[] as dchar
+                    arg->type = Type::tdchar;
+                }
                 arg->type = arg->type->addStorageClass(arg->storageClass);
             }
             break;

--- a/test/runnable/foreach6.d
+++ b/test/runnable/foreach6.d
@@ -1,0 +1,42 @@
+void main()
+{
+    int i;
+
+    foreach (c; "abcd")
+    {
+        static assert(is(typeof(c) == dchar));
+        switch (i++)
+        {   case 0:     assert(c == 'a');   break;
+            case 1:     assert(c == 'b');   break;
+            case 2:     assert(c == 'c');   break;
+            case 3:     assert(c == 'd');   break;
+            default:    assert(0);
+        }
+    }
+
+    i = 0;
+    foreach (ref c; "abcd".dup)
+    {
+        static assert(is(typeof(c) == char));
+        switch (i++)
+        {   case 0:     assert(c == 'a');   break;
+            case 1:     assert(c == 'b');   break;
+            case 2:     assert(c == 'c');   break;
+            case 3:     assert(c == 'd');   break;
+            default:    assert(0);
+        }
+    }
+
+    i = 0;
+    foreach (c; "世界你好")
+    {
+        static assert(is(typeof(c) == dchar));
+        switch (i++)
+        {   case 0:     assert(c == '世');   break;
+            case 1:     assert(c == '界');   break;
+            case 2:     assert(c == '你');   break;
+            case 3:     assert(c == '好');   break;
+            default:    assert(0);
+        }
+    }
+}


### PR DESCRIPTION
Infer the value type as dchar, to ensure correct UTF iteration/decoding.

https://d.puremagic.com/issues/show_bug.cgi?id=4483

This is a breaking change with limited impact. Please check the bug for some of the reasoning for this.
