### PR TITLE
[DDMD] MODxxx is unsigned char, not unsigned

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1971,7 +1971,7 @@ MATCH Type::constConv(Type *to)
  * Return MOD bits matching this type to wild parameter type (tprm).
  */
 
-unsigned Type::deduceWild(Type *t, bool isRef)
+unsigned char Type::deduceWild(Type *t, bool isRef)
 {
     //printf("Type::deduceWild this = '%s', tprm = '%s'\n", toChars(), tprm->toChars());
 
@@ -2879,12 +2879,12 @@ MATCH TypeNext::constConv(Type *to)
     return m;
 }
 
-unsigned TypeNext::deduceWild(Type *t, bool isRef)
+unsigned char TypeNext::deduceWild(Type *t, bool isRef)
 {
     if (ty == Tfunction)
         return 0;
 
-    unsigned wm;
+    unsigned char wm;
 
     Type *tn = t->nextOf();
     if (!isRef && (ty == Tarray || ty == Tpointer) && tn)
@@ -6208,7 +6208,7 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
 {
     //printf("TypeFunction::callMatch() %s\n", toChars());
     MATCH match = MATCHexact;           // assume exact match
-    unsigned wildmatch = 0;
+    unsigned char wildmatch = 0;
 
     if (tthis)
     {   Type *t = tthis;
@@ -8723,12 +8723,12 @@ MATCH TypeStruct::constConv(Type *to)
     return MATCHnomatch;
 }
 
-unsigned TypeStruct::deduceWild(Type *t, bool isRef)
+unsigned char TypeStruct::deduceWild(Type *t, bool isRef)
 {
     if (ty == t->ty && sym == ((TypeStruct *)t)->sym)
         return Type::deduceWild(t, isRef);
 
-    unsigned wm = 0;
+    unsigned char wm = 0;
 
     if (sym->aliasthis && !(att & RECtracing))
     {
@@ -9266,13 +9266,13 @@ MATCH TypeClass::constConv(Type *to)
     return MATCHnomatch;
 }
 
-unsigned TypeClass::deduceWild(Type *t, bool isRef)
+unsigned char TypeClass::deduceWild(Type *t, bool isRef)
 {
     ClassDeclaration *cd = t->isClassHandle();
     if (cd && (sym == cd || cd->isBaseOf(sym, NULL)))
         return Type::deduceWild(t, isRef);
 
-    unsigned wm = 0;
+    unsigned char wm = 0;
 
     if (sym->aliasthis && !(att & RECtracing))
     {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -309,7 +309,7 @@ public:
     virtual int isBaseOf(Type *t, int *poffset);
     virtual MATCH implicitConvTo(Type *to);
     virtual MATCH constConv(Type *to);
-    virtual unsigned deduceWild(Type *t, bool isRef);
+    virtual unsigned char deduceWild(Type *t, bool isRef);
     virtual Type *substWildTo(unsigned mod);
 
     Type *unqualify(unsigned m);
@@ -343,7 +343,7 @@ public:
     virtual int needsDestruction();
     virtual bool needsNested();
 
-    unsigned deduceWildHelper(Type **at, Type *tparam);
+    unsigned char deduceWildHelper(Type **at, Type *tparam);
     MATCH deduceTypeHelper(Type **at, Type *tparam);
 
     static void error(Loc loc, const char *format, ...);
@@ -396,7 +396,7 @@ public:
     Type *makeSharedWildConst();
     Type *makeMutable();
     MATCH constConv(Type *to);
-    unsigned deduceWild(Type *t, bool isRef);
+    unsigned char deduceWild(Type *t, bool isRef);
     void transitive();
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -846,7 +846,7 @@ public:
     TypeTuple *toArgTypes();
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
-    unsigned deduceWild(Type *t, bool isRef);
+    unsigned char deduceWild(Type *t, bool isRef);
     Type *toHeadMutable();
 
     void accept(Visitor *v) { v->visit(this); }
@@ -961,7 +961,7 @@ public:
     int isBaseOf(Type *t, int *poffset);
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
-    unsigned deduceWild(Type *t, bool isRef);
+    unsigned char deduceWild(Type *t, bool isRef);
     Type *toHeadMutable();
     Expression *defaultInit(Loc loc);
     int isZeroInit(Loc loc);

--- a/src/template.c
+++ b/src/template.c
@@ -1380,7 +1380,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(
 
                     if (tid->mod & MODwild)
                     {
-                        unsigned wm = farg->type->deduceWildHelper(&tt, tid);
+                        unsigned char wm = farg->type->deduceWildHelper(&tt, tid);
                         if (wm)
                         {
                             wildmatch |= wm;
@@ -2863,7 +2863,7 @@ size_t templateParameterLookup(Type *tparam, TemplateParameters *parameters)
     return IDX_NOTFOUND;
 }
 
-unsigned Type::deduceWildHelper(Type **at, Type *tparam)
+unsigned char Type::deduceWildHelper(Type **at, Type *tparam)
 {
     assert(tparam->mod & MODwild);
     *at = NULL;
@@ -2888,10 +2888,10 @@ unsigned Type::deduceWildHelper(Type **at, Type *tparam)
         case X(MODshared | MODwildconst,    MODshared | MODconst):
         case X(MODshared | MODwildconst,    MODimmutable):
         {
-            unsigned wm = (mod & ~MODshared);
+            unsigned char wm = (mod & ~MODshared);
             if (wm == 0)
                 wm = MODmutable;
-            unsigned m = (mod & (MODconst | MODimmutable)) | (tparam->mod & mod & MODshared);
+            unsigned char m = (mod & (MODconst | MODimmutable)) | (tparam->mod & mod & MODshared);
             *at = unqualify(m);
             return wm;
         }
@@ -3254,7 +3254,7 @@ MATCH Type::deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters,
 
         if (wm && (tparam->mod & MODwild))
         {
-            unsigned wx = deduceWildHelper(&tt, tparam);
+            unsigned char wx = deduceWildHelper(&tt, tparam);
             if (wx)
             {
                 if (!at)


### PR DESCRIPTION
Exposed by #2992 as `deduceType` now calls into other functions taking a MOD
