### PR TITLE
[trival] Print postfix, not extra double quote

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -175,7 +175,7 @@ const char *Token::toChars()
             }
             buf.writeByte('"');
             if (postfix)
-                buf.writeByte('"');
+                buf.writeByte(postfix);
             buf.writeByte(0);
             p = (char *)buf.extractData();
         }


### PR DESCRIPTION
Ancient copy-paste bug, very hard to trigger as `Token::toChars` is mostly for debugging and printing string literals.
