### PR TITLE
[trivial] Use a different token type for hex strings

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -181,6 +181,25 @@ const char *Token::toChars()
         }
             break;
 
+        case TOKxstring:
+        {
+            OutBuffer buf;
+            buf.writeByte('x');
+            buf.writeByte('"');
+            for (size_t i = 0; i < len; i++)
+            {
+                if (i)
+                    buf.writeByte(' ');
+                buf.printf("%02x", ustring[i]);
+            }
+            buf.writeByte('"');
+            if (postfix)
+                buf.writeByte(postfix);
+            buf.writeByte(0);
+            p = (char *)buf.extractData();
+            break;
+        }
+
         case TOKidentifier:
         case TOKenum:
         case TOKstruct:
@@ -1401,7 +1420,7 @@ TOK Lexer::hexStringConstant(Token *t)
                 t->ustring = (utf8_t *)"";
                 t->len = 0;
                 t->postfix = 0;
-                return TOKstring;
+                return TOKxstring;
 
             case '"':
                 if (n & 1)
@@ -1413,7 +1432,7 @@ TOK Lexer::hexStringConstant(Token *t)
                 t->ustring = (utf8_t *)mem.malloc(stringbuffer.offset);
                 memcpy(t->ustring, stringbuffer.data, stringbuffer.offset);
                 stringPostfix(t);
-                return TOKstring;
+                return TOKxstring;
 
             default:
                 if (c >= '0' && c <= '9')

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -111,7 +111,7 @@ enum TOK
         TOKcharv, TOKwcharv, TOKdcharv,
 
         // Leaf operators
-        TOKidentifier,  TOKstring,
+        TOKidentifier,  TOKstring, TOKxstring,
         TOKthis,        TOKsuper,
         TOKhalt,        TOKtuple,
         TOKerror,

--- a/src/parse.c
+++ b/src/parse.c
@@ -2353,6 +2353,7 @@ Objects *Parser::parseTemplateArgument()
         case TOKwcharv:
         case TOKdcharv:
         case TOKstring:
+        case TOKxstring:
         case TOKfile:
         case TOKline:
         case TOKmodulestring:
@@ -3968,6 +3969,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
         case TOKtrue:
         case TOKfalse:
         case TOKstring:
+        case TOKxstring:
         case TOKlparen:
         case TOKcast:
         case TOKmul:
@@ -5171,6 +5173,7 @@ int Parser::isBasicType(Token **pt)
                         case TOKwcharv:
                         case TOKdcharv:
                         case TOKstring:
+                        case TOKxstring:
                         case TOKfile:
                         case TOKline:
                         case TOKmodulestring:
@@ -5924,6 +5927,7 @@ Expression *Parser::parsePrimaryExp()
             break;
 
         case TOKstring:
+        case TOKxstring:
         {
             // cat adjacent strings
             utf8_t *s = token.ustring;
@@ -5932,7 +5936,8 @@ Expression *Parser::parsePrimaryExp()
             while (1)
             {
                 nextToken();
-                if (token.value == TOKstring)
+                if (token.value == TOKstring ||
+                    token.value == TOKxstring)
                 {
                     if (token.postfix)
                     {   if (token.postfix != postfix)


### PR DESCRIPTION
Treating normal string literals and hex literals as the same token leads to a few of problems:
- `Token::toChars` prints them wrong
- [Bogus invalid utf errors](https://d.puremagic.com/issues/show_bug.cgi?id=10454)
- [Makes implicit conversion to `ubyte[]` impossible](https://d.puremagic.com/issues/show_bug.cgi?id=5909)

This only fixes the first problem, but it makes the information available to the parser to fix the others.
