### PR TITLE
[cleanup] Clean up the way strings are created from `OutBuffer`

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -396,7 +396,7 @@ Expression *BinExp::arrayOp(Scope *sc)
      */
     buf.writestring(type->toBasetype()->nextOf()->toBasetype()->mutableOf()->deco);
 
-    char *name = buf.toChars();
+    char *name = buf.peekString();
     Identifier *ident = Lexer::idPool(name);
 
     ArrayOp **pOp = (ArrayOp **)_aaGet(&arrayfuncs, ident);

--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -396,7 +396,6 @@ Expression *BinExp::arrayOp(Scope *sc)
      */
     buf.writestring(type->toBasetype()->nextOf()->toBasetype()->mutableOf()->deco);
 
-    buf.writeByte(0);
     char *name = buf.toChars();
     Identifier *ident = Lexer::idPool(name);
 

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -419,8 +419,7 @@ public:
         {
             mangle_function(fd);
         }
-        buf.writeByte(0);
-        return (char *)buf.extractData();
+        return buf.extractString();
     }
 
     void visit(Type *t)

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1084,8 +1084,7 @@ Lnomatch:
 
             OutBuffer buf;
             buf.printf("_%s_field_%llu", ident->toChars(), (ulonglong)i);
-            buf.writeByte(0);
-            const char *name = (const char *)buf.extractData();
+            const char *name = buf.extractString();
             Identifier *id = Lexer::idPool(name);
 
             Initializer *ti;
@@ -2191,8 +2190,7 @@ char *TypeInfoDeclaration::toChars()
     buf.writestring("typeid(");
     buf.writestring(tinfo->toChars());
     buf.writeByte(')');
-    buf.writeByte(0);
-    return buf.extractData();
+    return buf.extractString();
 }
 
 /***************************** TypeInfoConstDeclaration **********************/

--- a/src/expression.c
+++ b/src/expression.c
@@ -9036,7 +9036,7 @@ Lagain:
             //printf("tf = %s, args = %s\n", tf->deco, (*arguments)[0]->type->deco);
             ::error(loc, "%s %s %s is not callable using argument types %s",
                 p, e1->toChars(), Parameter::argsTypesToChars(tf->parameters, tf->varargs),
-                buf.toChars());
+                buf.peekString());
 
             return new ErrorExp();
         }
@@ -9101,7 +9101,7 @@ Lagain:
                 //printf("tf = %s, args = %s\n", tf->deco, (*arguments)[0]->type->deco);
                 ::error(loc, "%s %s is not callable using argument types %s",
                     e1->toChars(), Parameter::argsTypesToChars(tf->parameters, tf->varargs),
-                    buf.toChars());
+                    buf.peekString());
 
                 return new ErrorExp();
             }

--- a/src/expression.c
+++ b/src/expression.c
@@ -1998,10 +1998,7 @@ char *Expression::toChars()
 
     OutBuffer buf;
     toCBuffer(&buf, &hgs);
-    buf.writeByte(0);
-    char *p = (char *)buf.data;
-    buf.data = NULL;
-    return p;
+    return buf.extractString();
 }
 
 void Expression::error(const char *format, ...)
@@ -13940,8 +13937,7 @@ Expression *PrettyFuncInitExp::resolveLoc(Loc loc, Scope *sc)
         HdrGenState hgs;
         OutBuffer buf;
         functionToCBuffer2((TypeFunction *)fd->type, &buf, &hgs, 0, funcStr);
-        buf.writeByte(0);
-        s = (const char *)buf.extractData();
+        s = buf.extractString();
     }
     else
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -4363,13 +4363,13 @@ StringExp *ArrayLiteralExp::toStringExp()
                 Expression *ch = (*elements)[i];
                 if (ch->op != TOKint64)
                     return NULL;
-                     if (sz == 1) buf.writebyte((unsigned)ch->toInteger());
+                     if (sz == 1) buf.writeByte((unsigned)ch->toInteger());
                 else if (sz == 2) buf.writeword((unsigned)ch->toInteger());
                 else              buf.write4((unsigned)ch->toInteger());
             }
         }
         char prefix;
-             if (sz == 1) { prefix = 'c'; buf.writebyte(0); }
+             if (sz == 1) { prefix = 'c'; buf.writeByte(0); }
         else if (sz == 2) { prefix = 'w'; buf.writeword(0); }
         else              { prefix = 'd'; buf.write4(0); }
 
@@ -13940,7 +13940,7 @@ Expression *PrettyFuncInitExp::resolveLoc(Loc loc, Scope *sc)
         HdrGenState hgs;
         OutBuffer buf;
         functionToCBuffer2((TypeFunction *)fd->type, &buf, &hgs, 0, funcStr);
-        buf.writebyte(0);
+        buf.writeByte(0);
         s = (const char *)buf.extractData();
     }
     else

--- a/src/func.c
+++ b/src/func.c
@@ -2062,9 +2062,9 @@ void FuncDeclaration::bodyToCBuffer(OutBuffer *buf, HdrGenState *hgs)
             buf->writestring("out");
             if (outId)
             {
-                buf->writebyte('(');
+                buf->writeByte('(');
                 buf->writestring(outId->toChars());
-                buf->writebyte(')');
+                buf->writeByte(')');
             }
             buf->writenl();
             fensure->toCBuffer(buf, hgs);
@@ -2076,12 +2076,12 @@ void FuncDeclaration::bodyToCBuffer(OutBuffer *buf, HdrGenState *hgs)
             buf->writenl();
         }
 
-        buf->writebyte('{');
+        buf->writeByte('{');
         buf->writenl();
         buf->level++;
         fbody->toCBuffer(buf, hgs);
         buf->level--;
-        buf->writebyte('}');
+        buf->writeByte('}');
         buf->writenl();
 
         hgs->tpltMember = savetlpt;

--- a/src/func.c
+++ b/src/func.c
@@ -262,7 +262,7 @@ void FuncDeclaration::semantic(Scope *sc)
         {
             OutBuffer buf;
             MODtoBuffer(&buf, tf->mod);
-            error("without 'this' cannot be %s", buf.toChars());
+            error("without 'this' cannot be %s", buf.peekString());
             tf->mod = 0;    // remove qualifiers
         }
 
@@ -2833,7 +2833,7 @@ Lerror:
         {
             ::error(loc, "%s %s.%s cannot deduce function from argument types !(%s)%s, candidates are:",
                     td->kind(), td->parent->toPrettyChars(), td->ident->toChars(),
-                    tiargsBuf.toChars(), fargsBuf.toChars());
+                    tiargsBuf.peekString(), fargsBuf.peekString());
 
             // Display candidate template functions
             int numToDisplay = 5; // sensible number to display
@@ -2863,7 +2863,7 @@ Lerror:
                 MODMatchToBuffer(&thisBuf, tthis->mod, tf->mod);
                 MODMatchToBuffer(&funcBuf, tf->mod, tthis->mod);
                 ::error(loc, "%smethod %s is not callable using a %sobject",
-                    funcBuf.toChars(), fd->toPrettyChars(), thisBuf.toChars());
+                    funcBuf.peekString(), fd->toPrettyChars(), thisBuf.peekString());
             }
             else
             {
@@ -2871,7 +2871,7 @@ Lerror:
                 fd->error(loc, "%s%s is not callable using argument types %s",
                     Parameter::argsTypesToChars(tf->parameters, tf->varargs),
                     tf->modToChars(),
-                    fargsBuf.toChars());
+                    fargsBuf.peekString());
             }
         }
     }
@@ -2884,7 +2884,7 @@ Lerror:
         ::error(loc, "%s.%s called with argument types %s matches both:\n"
                      "\t%s(%d): %s%s\nand:\n\t%s(%d): %s%s",
                 s->parent->toPrettyChars(), s->ident->toChars(),
-                fargsBuf.toChars(),
+                fargsBuf.peekString(),
                 m.lastf->loc.filename, m.lastf->loc.linnum, m.lastf->toPrettyChars(), lastprms,
                 m.nextf->loc.filename, m.nextf->loc.linnum, m.nextf->toPrettyChars(), nextprms);
     }
@@ -4620,7 +4620,7 @@ static Identifier *unitTestId(Loc loc)
 {
     OutBuffer buf;
     buf.printf("__unittestL%u_", loc.linnum);
-    return Lexer::uniqueId(buf.toChars());
+    return Lexer::uniqueId(buf.peekString());
 }
 
 UnitTestDeclaration::UnitTestDeclaration(Loc loc, Loc endloc, char *codedoc)

--- a/src/func.c
+++ b/src/func.c
@@ -3065,8 +3065,7 @@ const char *FuncDeclaration::toFullSignature()
     OutBuffer buf;
     HdrGenState hgs;
     functionToCBuffer2((TypeFunction *)type, &buf, &hgs, 0, toChars());
-    buf.writeByte(0);
-    return buf.extractData();
+    return buf.extractString();
 }
 
 bool FuncDeclaration::isMain()

--- a/src/glue.c
+++ b/src/glue.c
@@ -108,7 +108,7 @@ void obj_write_deferred(Library *library)
          */
         OutBuffer idbuf;
         idbuf.printf("%s.%d", m ? m->ident->toChars() : mname, count);
-        char *idstr = idbuf.toChars();
+        char *idstr = idbuf.peekString();
 
         if(!m)
         {

--- a/src/glue.c
+++ b/src/glue.c
@@ -145,9 +145,8 @@ void obj_write_deferred(Library *library)
         for (char *p = s->toChars(); *p; p++)
             hash += *p;
         namebuf.printf("%s_%x_%x.%s", fname, count, hash, global.obj_ext);
-        namebuf.writeByte(0);
         FileName::free((char *)fname);
-        fname = (char *)namebuf.extractData();
+        fname = namebuf.extractString();
 
         //printf("writing '%s'\n", fname);
         File *objfile = File::create(fname);

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -73,7 +73,7 @@ void Module::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     {
         buf->writestring("module ");
         buf->writestring(md->toChars());
-        buf->writebyte(';');
+        buf->writeByte(';');
         buf->writenl();
     }
 

--- a/src/identifier.c
+++ b/src/identifier.c
@@ -98,6 +98,5 @@ Identifier *Identifier::generateId(const char *prefix, size_t i)
     buf.printf("%llu", (ulonglong)i);
 
     char *id = buf.toChars();
-    buf.data = NULL;
     return Lexer::idPool(id);
 }

--- a/src/identifier.c
+++ b/src/identifier.c
@@ -97,6 +97,6 @@ Identifier *Identifier::generateId(const char *prefix, size_t i)
     buf.writestring(prefix);
     buf.printf("%llu", (ulonglong)i);
 
-    char *id = buf.toChars();
+    char *id = buf.peekString();
     return Lexer::idPool(id);
 }

--- a/src/import.c
+++ b/src/import.c
@@ -321,14 +321,14 @@ void Import::semantic(Scope *sc)
             escapePath(ob, mod->srcfile->toChars());
         else
             ob->writestring("???");
-        ob->writebyte(')');
+        ob->writeByte(')');
 
         for (size_t i = 0; i < names.dim; i++)
         {
             if (i == 0)
-                ob->writebyte(':');
+                ob->writeByte(':');
             else
-                ob->writebyte(',');
+                ob->writeByte(',');
 
             Identifier *name = names[i];
             Identifier *alias = aliases[i];

--- a/src/inifile.c
+++ b/src/inifile.c
@@ -247,7 +247,7 @@ const char *inifile(const char *argv0x, const char *inifilex, const char *envsec
             buf.offset--;
 
         {
-        char *p = buf.toChars();
+        char *p = buf.peekString();
 
         // The expanded line is in p.
         // Now parse it for meaning.

--- a/src/init.c
+++ b/src/init.c
@@ -70,8 +70,7 @@ char *Initializer::toChars()
 
     OutBuffer buf;
     toCBuffer(&buf, &hgs);
-    buf.writeByte(0);
-    return buf.extractData();
+    return buf.extractString();
 }
 
 /********************************** ErrorInitializer ***************************/

--- a/src/init.c
+++ b/src/init.c
@@ -70,7 +70,7 @@ char *Initializer::toChars()
 
     OutBuffer buf;
     toCBuffer(&buf, &hgs);
-    buf.writebyte(0);
+    buf.writeByte(0);
     return buf.extractData();
 }
 
@@ -318,7 +318,7 @@ Expression *StructInitializer::toExpression(Type *t)
 void StructInitializer::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     //printf("StructInitializer::toCBuffer()\n");
-    buf->writebyte('{');
+    buf->writeByte('{');
     for (size_t i = 0; i < field.dim; i++)
     {
         if (i > 0)
@@ -327,13 +327,13 @@ void StructInitializer::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
         if (id)
         {
             buf->writestring(id->toChars());
-            buf->writebyte(':');
+            buf->writeByte(':');
         }
         Initializer *iz = value[i];
         if (iz)
             iz->toCBuffer(buf, hgs);
     }
-    buf->writebyte('}');
+    buf->writeByte('}');
 }
 
 /********************************** ArrayInitializer ************************************/
@@ -703,7 +703,7 @@ Laa:
 
 void ArrayInitializer::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
-    buf->writebyte('[');
+    buf->writeByte('[');
     for (size_t i = 0; i < index.dim; i++)
     {
         if (i > 0)
@@ -712,13 +712,13 @@ void ArrayInitializer::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
         if (ex)
         {
             ex->toCBuffer(buf, hgs);
-            buf->writebyte(':');
+            buf->writeByte(':');
         }
         Initializer *iz = value[i];
         if (iz)
             iz->toCBuffer(buf, hgs);
     }
-    buf->writebyte(']');
+    buf->writeByte(']');
 }
 
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -176,8 +176,7 @@ const char *Token::toChars()
             buf.writeByte('"');
             if (postfix)
                 buf.writeByte(postfix);
-            buf.writeByte(0);
-            p = (char *)buf.extractData();
+            p = buf.extractString();
         }
             break;
 

--- a/src/link.c
+++ b/src/link.c
@@ -256,7 +256,7 @@ int runLINK()
             cmdbuf.writestring("lib\\x64\"");
         }
 
-        char *p = cmdbuf.toChars();
+        char *p = cmdbuf.peekString();
 
         const char *lnkfilename = NULL;
         size_t plen = strlen(p);
@@ -282,8 +282,7 @@ int runLINK()
                 OutBuffer linkcmdbuf;
                 linkcmdbuf.writestring(vcinstalldir);
                 linkcmdbuf.writestring("bin\\amd64\\link");
-                linkcmd = linkcmdbuf.toChars();
-                linkcmdbuf.extractData();
+                linkcmd = linkcmdbuf.extractString();
             }
             else
                 linkcmd = "link";
@@ -403,7 +402,7 @@ int runLINK()
         }
         cmdbuf.writeByte(';');
 
-        char *p = cmdbuf.toChars();
+        char *p = cmdbuf.peekString();
 
         const char *lnkfilename = NULL;
         size_t plen = strlen(p);

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -120,8 +120,7 @@ L1:
         tf->next = tn;
     }
 
-    id = buf.toChars();
-    buf.data = NULL;
+    id = buf.extractString();
     return id;
 }
 
@@ -163,8 +162,7 @@ const char *Declaration::mangle(bool isv)
         OutBuffer buf;
         buf.writestring("_D");
         buf.writestring(p);
-        p = buf.toChars();
-        buf.data = NULL;
+        p = buf.extractString();
         }
         //printf("Declaration::mangle(this = %p, '%s', parent = '%s', linkage = %d) = %s\n", this, toChars(), parent ? parent->toChars() : "null", linkage, p);
 
@@ -336,8 +334,7 @@ const char *TemplateInstance::mangle(bool isv)
         }
     }
     buf.printf("%llu%s", (ulonglong)strlen(id), id);
-    id = buf.toChars();
-    buf.data = NULL;
+    id = buf.extractString();
     //printf("TemplateInstance::mangle() %s = %s\n", toChars(), id);
     return id;
 }
@@ -365,8 +362,7 @@ const char *Dsymbol::mangle(bool isv)
         buf.writestring(p);
     }
     buf.printf("%llu%s", (ulonglong)strlen(id), id);
-    id = buf.toChars();
-    buf.data = NULL;
+    id = buf.extractString();
     //printf("Dsymbol::mangle() %s = %s\n", toChars(), id);
     return id;
 }

--- a/src/mars.c
+++ b/src/mars.c
@@ -179,8 +179,7 @@ char *Loc::toChars()
 
     if (linnum)
         buf.printf("(%d)", linnum);
-    buf.writeByte(0);
-    return (char *)buf.extractData();
+    return buf.extractString();
 }
 
 Loc::Loc(Module *mod, unsigned linnum)

--- a/src/mars.c
+++ b/src/mars.c
@@ -261,7 +261,7 @@ void verrorPrint(Loc loc, const char *header, const char *format, va_list ap,
         fprintf(stderr, "%s ", p2);
     OutBuffer tmp;
     tmp.vprintf(format, ap);
-    fprintf(stderr, "%s\n", tmp.toChars());
+    fprintf(stderr, "%s\n", tmp.peekString());
     fflush(stderr);
 }
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -1883,9 +1883,9 @@ void escapePath(OutBuffer *buf, const char *fname)
             case '(':
             case ')':
             case '\\':
-                buf->writebyte('\\');
+                buf->writeByte('\\');
             default:
-                buf->writebyte(*fname);
+                buf->writeByte(*fname);
                 break;
         }
         fname++;

--- a/src/module.c
+++ b/src/module.c
@@ -1080,8 +1080,7 @@ char *ModuleDeclaration::toChars()
         }
     }
     buf.writestring(id->toChars());
-    buf.writeByte(0);
-    return (char *)buf.extractData();
+    return buf.extractString();
 }
 
 /* =========================== Package ===================== */

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1546,8 +1546,7 @@ char *MODtoChars(unsigned char mod)
     OutBuffer buf;
     buf.reserve(16);
     MODtoBuffer(&buf, mod);
-    buf.writeByte(0);
-    return buf.extractData();
+    return buf.extractString();
 }
 
 /********************************
@@ -1576,8 +1575,7 @@ char *Type::toChars()
     HdrGenState hgs;
 
     toCBuffer(&buf, NULL, &hgs);
-    buf.writeByte(0);
-    return buf.extractData();
+    return buf.extractString();
 }
 
 void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
@@ -1652,8 +1650,7 @@ char *Type::modToChars()
     OutBuffer buf;
     buf.reserve(16);
     modToBuffer(&buf);
-    buf.writeByte(0);
-    return buf.extractData();
+    return buf.extractString();
 }
 
 /************************************

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1546,7 +1546,7 @@ char *MODtoChars(unsigned char mod)
     OutBuffer buf;
     buf.reserve(16);
     MODtoBuffer(&buf, mod);
-    buf.writebyte(0);
+    buf.writeByte(0);
     return buf.extractData();
 }
 
@@ -1576,7 +1576,7 @@ char *Type::toChars()
     HdrGenState hgs;
 
     toCBuffer(&buf, NULL, &hgs);
-    buf.writebyte(0);
+    buf.writeByte(0);
     return buf.extractData();
 }
 
@@ -1652,7 +1652,7 @@ char *Type::modToChars()
     OutBuffer buf;
     buf.reserve(16);
     modToBuffer(&buf);
-    buf.writebyte(0);
+    buf.writeByte(0);
     return buf.extractData();
 }
 
@@ -9784,7 +9784,7 @@ char *Parameter::argsTypesToChars(Parameters *args, int varargs)
     HdrGenState hgs;
     argsToCBuffer(&buf, &hgs, args, varargs);
 
-    buf.writebyte(0);
+    buf.writeByte(0);
     return buf.extractData();
 }
 

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -145,8 +145,7 @@ Strings *FileName::splitPath(const char *path)
             }
             if (buf.offset)             // if path is not empty
             {
-                buf.writeByte(0);       // to asciiz
-                array->push(buf.extractData());
+                array->push(buf.extractString());
             }
         } while (c);
     }

--- a/src/root/outbuffer.c
+++ b/src/root/outbuffer.c
@@ -405,7 +405,7 @@ void OutBuffer::remove(size_t offset, size_t nbytes)
     this->offset -= nbytes;
 }
 
-char *OutBuffer::toChars()
+char *OutBuffer::peekString()
 {
     if (!offset || data[offset-1] != '\0')
         writeByte(0);

--- a/src/root/outbuffer.c
+++ b/src/root/outbuffer.c
@@ -407,6 +407,14 @@ void OutBuffer::remove(size_t offset, size_t nbytes)
 
 char *OutBuffer::toChars()
 {
-    writeByte(0);
+    if (!offset || data[offset-1] != '\0')
+        writeByte(0);
     return (char *)data;
+}
+
+char *OutBuffer::extractString()
+{
+    if (!offset || data[offset-1] != '\0')
+        writeByte(0);
+    return extractData();
 }

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -63,6 +63,7 @@ struct OutBuffer
     size_t insert(size_t offset, const void *data, size_t nbytes);
     void remove(size_t offset, size_t nbytes);
     char *toChars();
+    // Append terminating null if necessary and take ownership of data
     char *extractString();
 };
 

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -45,7 +45,6 @@ struct OutBuffer
     void prependstring(const char *string);
     void writenl();                     // write newline
     void writeByte(unsigned b);
-    void writebyte(unsigned b) { writeByte(b); }
     void writeUTF8(unsigned b);
     void prependbyte(unsigned b);
     void writewchar(unsigned w);

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -62,7 +62,8 @@ struct OutBuffer
     void spread(size_t offset, size_t nbytes);
     size_t insert(size_t offset, const void *data, size_t nbytes);
     void remove(size_t offset, size_t nbytes);
-    char *toChars();
+    // Append terminating null if necessary and get view of internal buffer
+    char *peekString();
     // Append terminating null if necessary and take ownership of data
     char *extractString();
 };

--- a/src/statement.c
+++ b/src/statement.c
@@ -44,9 +44,8 @@ Identifier *fixupLabelName(Scope *sc, Identifier *ident)
         const char *prefix = flags == SCOPErequire ? "__in_" : "__out_";
         OutBuffer buf;
         buf.printf("%s%s", prefix, ident->toChars());
-        buf.writeByte(0);
 
-        const char *name = (const char *)buf.extractData();
+        const char *name = buf.extractString();
         ident = Lexer::idPool(name);
     }
     return ident;
@@ -88,8 +87,7 @@ char *Statement::toChars()
 
     OutBuffer buf;
     toCBuffer(&buf, &hgs);
-    buf.writeByte(0);
-    return buf.extractData();
+    return buf.extractString();
 }
 
 void Statement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)

--- a/src/statement.c
+++ b/src/statement.c
@@ -88,7 +88,7 @@ char *Statement::toChars()
 
     OutBuffer buf;
     toCBuffer(&buf, &hgs);
-    buf.writebyte(0);
+    buf.writeByte(0);
     return buf.extractData();
 }
 
@@ -1176,7 +1176,7 @@ void WhileStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("while (");
     condition->toCBuffer(buf, hgs);
-    buf->writebyte(')');
+    buf->writeByte(')');
     buf->writenl();
     if (body)
         body->toCBuffer(buf, hgs);
@@ -1418,24 +1418,24 @@ void ForStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
         hgs->FLinit.init--;
     }
     else
-        buf->writebyte(';');
+        buf->writeByte(';');
     if (condition)
-    {   buf->writebyte(' ');
+    {   buf->writeByte(' ');
         condition->toCBuffer(buf, hgs);
     }
-    buf->writebyte(';');
+    buf->writeByte(';');
     if (increment)
-    {   buf->writebyte(' ');
+    {   buf->writeByte(' ');
         increment->toCBuffer(buf, hgs);
     }
-    buf->writebyte(')');
+    buf->writeByte(')');
     buf->writenl();
-    buf->writebyte('{');
+    buf->writeByte('{');
     buf->writenl();
     buf->level++;
     body->toCBuffer(buf, hgs);
     buf->level--;
-    buf->writebyte('}');
+    buf->writeByte('}');
     buf->writenl();
 }
 
@@ -2390,15 +2390,15 @@ void ForeachStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     }
     buf->writestring("; ");
     aggr->toCBuffer(buf, hgs);
-    buf->writebyte(')');
+    buf->writeByte(')');
     buf->writenl();
-    buf->writebyte('{');
+    buf->writeByte('{');
     buf->writenl();
     buf->level++;
     if (body)
         body->toCBuffer(buf, hgs);
     buf->level--;
-    buf->writebyte('}');
+    buf->writeByte('}');
     buf->writenl();
 }
 
@@ -2602,15 +2602,15 @@ void ForeachRangeStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     lwr->toCBuffer(buf, hgs);
     buf->writestring(" .. ");
     upr->toCBuffer(buf, hgs);
-    buf->writebyte(')');
+    buf->writeByte(')');
     buf->writenl();
-    buf->writebyte('{');
+    buf->writeByte('{');
     buf->writenl();
     buf->level++;
     if (body)
         body->toCBuffer(buf, hgs);
     buf->level--;
-    buf->writebyte('}');
+    buf->writeByte('}');
     buf->writenl();
 }
 
@@ -2764,7 +2764,7 @@ void IfStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
         buf->writestring(" = ");
     }
     condition->toCBuffer(buf, hgs);
-    buf->writebyte(')');
+    buf->writeByte(')');
     buf->writenl();
     if (!ifbody->isScopeStatement())
         buf->level++;
@@ -3278,18 +3278,18 @@ void SwitchStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring(isFinal ? "final switch (" : "switch (");
     condition->toCBuffer(buf, hgs);
-    buf->writebyte(')');
+    buf->writeByte(')');
     buf->writenl();
     if (body)
     {
         if (!body->isScopeStatement())
         {
-            buf->writebyte('{');
+            buf->writeByte('{');
             buf->writenl();
             buf->level++;
             body->toCBuffer(buf, hgs);
             buf->level--;
-            buf->writebyte('}');
+            buf->writeByte('}');
             buf->writenl();
         }
         else
@@ -3408,7 +3408,7 @@ void CaseStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("case ");
     exp->toCBuffer(buf, hgs);
-    buf->writebyte(':');
+    buf->writeByte(':');
     buf->writenl();
     statement->toCBuffer(buf, hgs);
 }
@@ -3510,7 +3510,7 @@ void CaseRangeStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     first->toCBuffer(buf, hgs);
     buf->writestring(": .. case ");
     last->toCBuffer(buf, hgs);
-    buf->writebyte(':');
+    buf->writeByte(':');
     buf->writenl();
     statement->toCBuffer(buf, hgs);
 }
@@ -3648,10 +3648,10 @@ void GotoCaseStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("goto case");
     if (exp)
-    {   buf->writebyte(' ');
+    {   buf->writeByte(' ');
         exp->toCBuffer(buf, hgs);
     }
-    buf->writebyte(';');
+    buf->writeByte(';');
     buf->writenl();
 }
 
@@ -4147,10 +4147,10 @@ void BreakStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("break");
     if (ident)
-    {   buf->writebyte(' ');
+    {   buf->writeByte(' ');
         buf->writestring(ident->toChars());
     }
-    buf->writebyte(';');
+    buf->writeByte(';');
     buf->writenl();
 }
 
@@ -4250,10 +4250,10 @@ void ContinueStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("continue");
     if (ident)
-    {   buf->writebyte(' ');
+    {   buf->writeByte(' ');
         buf->writestring(ident->toChars());
     }
-    buf->writebyte(';');
+    buf->writeByte(';');
     buf->writenl();
 }
 
@@ -4419,13 +4419,13 @@ void SynchronizedStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("synchronized");
     if (exp)
-    {   buf->writebyte('(');
+    {   buf->writeByte('(');
         exp->toCBuffer(buf, hgs);
-        buf->writebyte(')');
+        buf->writeByte(')');
     }
     if (body)
     {
-        buf->writebyte(' ');
+        buf->writeByte(' ');
         body->toCBuffer(buf, hgs);
     }
 }
@@ -4778,18 +4778,18 @@ void Catch::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("catch");
     if (type)
-    {   buf->writebyte('(');
+    {   buf->writeByte('(');
         type->toCBuffer(buf, ident, hgs);
-        buf->writebyte(')');
+        buf->writeByte(')');
     }
     buf->writenl();
-    buf->writebyte('{');
+    buf->writeByte('{');
     buf->writenl();
     buf->level++;
     if (handler)
         handler->toCBuffer(buf, hgs);
     buf->level--;
-    buf->writebyte('}');
+    buf->writeByte('}');
     buf->writenl();
 }
 
@@ -4839,16 +4839,16 @@ void TryFinallyStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("try");
     buf->writenl();
-    buf->writebyte('{');
+    buf->writeByte('{');
     buf->writenl();
     buf->level++;
     body->toCBuffer(buf, hgs);
     buf->level--;
-    buf->writebyte('}');
+    buf->writeByte('}');
     buf->writenl();
     buf->writestring("finally");
     buf->writenl();
-    buf->writebyte('{');
+    buf->writeByte('{');
     buf->writenl();
     buf->level++;
     finalbody->toCBuffer(buf, hgs);
@@ -4914,7 +4914,7 @@ int OnScopeStatement::blockExit(bool mustNotThrow)
 void OnScopeStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring(Token::toChars(tok));
-    buf->writebyte(' ');
+    buf->writeByte(' ');
     statement->toCBuffer(buf, hgs);
 }
 
@@ -5187,7 +5187,7 @@ void GotoStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring("goto ");
     buf->writestring(ident->toChars());
-    buf->writebyte(';');
+    buf->writeByte(';');
     buf->writenl();
 }
 
@@ -5278,7 +5278,7 @@ int LabelStatement::blockExit(bool mustNotThrow)
 void LabelStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
     buf->writestring(ident->toChars());
-    buf->writebyte(':');
+    buf->writeByte(':');
     buf->writenl();
     if (statement)
         statement->toCBuffer(buf, hgs);
@@ -5352,7 +5352,7 @@ void AsmStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
            t->value != TOKdot               &&
            t->next->value != TOKdot)
         {
-            buf->writebyte(' ');
+            buf->writeByte(' ');
         }
         t = t->next;
     }

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -96,7 +96,7 @@ void StaticAssert::semantic2(Scope *sc)
                 msg = s;
             }
             msg->toCBuffer(&buf, &hgs);
-            error("%s", buf.toChars());
+            error("%s", buf.peekString());
         }
         else
             error("(%s) is false", exp->toChars());

--- a/src/template.c
+++ b/src/template.c
@@ -6772,8 +6772,7 @@ Identifier *TemplateInstance::genIdent(Objects *args)
             assert(0);
     }
     buf.writeByte('Z');
-    id = buf.toChars();
-    //buf.data = NULL;                          // we can free the string after call to idPool()
+    id = buf.peekString();
     //printf("\tgenIdent = %s\n", id);
     return Lexer::idPool(id);
 }

--- a/src/template.c
+++ b/src/template.c
@@ -2651,7 +2651,7 @@ void TemplateDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     {
         hgs->tpltMember++;
         buf->writenl();
-        buf->writebyte('{');
+        buf->writeByte('{');
         buf->writenl();
         buf->level++;
         for (size_t i = 0; i < members->dim; i++)
@@ -2660,7 +2660,7 @@ void TemplateDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
             s->toCBuffer(buf, hgs);
         }
         buf->level--;
-        buf->writebyte('}');
+        buf->writeByte('}');
         buf->writenl();
         hgs->tpltMember--;
     }
@@ -7691,10 +7691,10 @@ void TemplateMixin::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 
     if (ident && memcmp(ident->string, "__mixin", 7) != 0)
     {
-        buf->writebyte(' ');
+        buf->writeByte(' ');
         buf->writestring(ident->toChars());
     }
-    buf->writebyte(';');
+    buf->writeByte(';');
     buf->writenl();
 }
 

--- a/src/template.c
+++ b/src/template.c
@@ -7096,8 +7096,7 @@ char *TemplateInstance::toChars()
     char *s;
 
     toCBuffer(&buf, &hgs);
-    s = buf.toChars();
-    buf.data = NULL;
+    s = buf.extractString();
     return s;
 }
 
@@ -7676,8 +7675,7 @@ char *TemplateMixin::toChars()
     char *s;
 
     TemplateInstance::toCBuffer(&buf, &hgs);
-    s = buf.toChars();
-    buf.data = NULL;
+    s = buf.extractString();
     return s;
 }
 

--- a/src/template.c
+++ b/src/template.c
@@ -2704,8 +2704,7 @@ char *TemplateDeclaration::toChars()
         constraint->toCBuffer(&buf, &hgs);
         buf.writeByte(')');
     }
-    buf.writeByte(0);
-    return (char *)buf.extractData();
+    return buf.extractString();
 }
 
 PROT TemplateDeclaration::prot()


### PR DESCRIPTION
- Introduce `extractString` which appends a `'\0'` if necessary then takes ownership of the data
- Replace `toChars` with `peekString` which appends a `'\0'` if necessary then returns a reference to the internal buffer
- Remove `writebyte` which is just a less-popular alias of `writeByte`

`toChars` is especially nasty in that it does not return a unique heap-backed string unlike `Object::toChars`.

See also: https://d.puremagic.com/issues/show_bug.cgi?id=9421

@AndrejMitrovic
