### PR TITLE
[DDMD] Explicitly cast off_t to size_t

### DIFF
--- a/src/root/file.c
+++ b/src/root/file.c
@@ -86,7 +86,7 @@ int File::read()
     if (len)
         return 0;               // already read the file
 #if POSIX
-    off_t size;
+    size_t size;
     ssize_t numread;
     int fd;
     struct stat buf;
@@ -112,7 +112,7 @@ int File::read()
         printf("\tfstat error, errno = %d\n",errno);
         goto err2;
     }
-    size = buf.st_size;
+    size = (size_t)buf.st_size;
     buffer = (unsigned char *) ::malloc(size + 2);
     if (!buffer)
     {


### PR DESCRIPTION
In 32-bit D, `off_t` is 64 bits and doesn't implicitly convert to `size_t`.
