### PR TITLE
[DDMD] Mangle C++ long and ulong correctly on 64-bit linux/osx

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -474,8 +474,8 @@ public:
             case Tint32:    c = 'i';        break;
             case Tuns32:    c = 'j';        break;
             case Tfloat32:  c = 'f';        break;
-            case Tint64:    c = 'x';        break;
-            case Tuns64:    c = 'y';        break;
+            case Tint64:    c = (Target::longsize == 8 ? 'l' : 'x'); break;
+            case Tuns64:    c = (Target::longsize == 8 ? 'm' : 'y'); break;
             case Tfloat64:  c = 'd';        break;
             case Tfloat80:  c = (Target::realsize - Target::realpad == 16) ? 'g' : 'e'; break;
             case Tbool:     c = 'b';        break;

--- a/src/target.c
+++ b/src/target.c
@@ -18,6 +18,7 @@ int Target::realsize;
 int Target::realpad;
 int Target::realalignsize;
 bool Target::reverseCppOverloads;
+int Target::longsize;
 
 
 void Target::init()
@@ -32,12 +33,14 @@ void Target::init()
         realsize = 12;
         realpad = 2;
         realalignsize = 4;
+        longsize = 4;
     }
     else if (global.params.isOSX)
     {
         realsize = 16;
         realpad = 6;
         realalignsize = 16;
+        longsize = 4;
     }
     else if (global.params.isWindows)
     {
@@ -45,6 +48,7 @@ void Target::init()
         realpad = 0;
         realalignsize = 2;
         reverseCppOverloads = !global.params.is64bit;
+        longsize = 4;
     }
     else
         assert(0);
@@ -56,6 +60,11 @@ void Target::init()
             realsize = 16;
             realpad = 6;
             realalignsize = 16;
+            longsize = 8;
+        }
+        else if (global.params.isOSX)
+        {
+            longsize = 8;
         }
     }
 

--- a/src/target.h
+++ b/src/target.h
@@ -23,6 +23,7 @@ struct Target
     static int realpad;         // 'padding' added to the CPU real size to bring it up to realsize
     static int realalignsize;   // alignment for reals
     static bool reverseCppOverloads; // with dmc, overloaded functions are grouped and in reverse order
+    static int longsize;        // size of a C 'long' or 'unsigned long' type
 
     static void init();
     static unsigned alignsize(Type* type);

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -130,6 +130,8 @@ else
         public static int dim(Array!Module*);
     }; 
 
+    ulong testlongmangle(int a, uint b, long c, ulong d);
+
     void main()
     {
         test1(Foo!int());
@@ -183,5 +185,7 @@ else
         Array!Module arr2;
         arr2.dim = 20;
         assert(Module.dim(&arr2) == 20);
+
+        assert(testlongmangle(1, 2, 3, 4) == 10);
     }
 }

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -1,4 +1,5 @@
 
+#include <stdint.h>
 
 template<class X>
 struct Foo 
@@ -193,3 +194,15 @@ int Module::dim(Array<Module*>* arr)
 {
     return arr->dim;
 }
+
+#if _LP64
+unsigned long testlongmangle(int32_t a, uint32_t b, long c, unsigned long d)
+{
+    return a + b + c + d;
+}
+#else
+unsigned long long testlongmangle(int32_t a, uint32_t b, long long c, unsigned long long d)
+{
+    return a + b + c + d;
+}
+#endif


### PR DESCRIPTION
On 32-bit linux/OSX `long`/`int64_t` map to `long long` types, but they map to `long` on 64-bit.
