### PR TITLE
Move C++ mangle to frontend in windows

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -718,10 +718,939 @@ char *toCppMangle(Dsymbol *s)
 
 #else
 
+// Windows DMC and Microsoft Visual C++ mangling
+#define VC_SAVED_TYPE_CNT 10
+#define VC_SAVED_IDENT_CNT 10
+
+class VisualCPPMangler : public Visitor
+{
+    const char *saved_idents[VC_SAVED_IDENT_CNT];
+    Type *saved_types[VC_SAVED_TYPE_CNT];
+    // when we mangling one argument, we can call visit several times (for base types of arg type)
+    // but we must save only arg type:
+    // For example: if we have an int** argument, we should save "int**" but visit will be called for "int**", "int*", "int"
+    // This flag is set up by the visit(NextType, ) function  and should be reset when the arg type output is finished.
+    bool is_not_top_type;
+
+    // in some cases we should ignore CV-modifiers, like array:
+    bool ignore_const;
+    OutBuffer buf;
+    bool is_dmc;
+
+    VisualCPPMangler(VisualCPPMangler *rvl)
+        : buf(),
+        is_dmc(rvl->is_dmc),
+        is_not_top_type(false),
+        ignore_const(false)
+    {
+        memcpy(&saved_idents, &rvl->saved_idents, sizeof(const char*) * VC_SAVED_IDENT_CNT);
+        memcpy(&saved_types, &rvl->saved_types, sizeof(Type*) * VC_SAVED_TYPE_CNT);
+    }
+public:
+
+    VisualCPPMangler(bool isdmc)
+        : buf(),
+        is_dmc(isdmc),
+        is_not_top_type(false),
+        ignore_const(false)
+    {
+        memset(&saved_idents, 0, sizeof(const char*) * VC_SAVED_IDENT_CNT);
+        memset(&saved_types, 0, sizeof(Type*) * VC_SAVED_TYPE_CNT);
+    }
+
+    void visit(Type *type)
+    {
+        if (type->isImmutable() || type->isShared())
+        {
+            type->error(Loc(), "ICE: shared or immutable types can not be mapped to C++ (%s)", type->toChars());
+        }
+        else
+        {
+            type->error(Loc(), "ICE: Unsupported type %s\n", type->toChars());
+        }
+        assert(0); // Assert, because this error should be handled in frontend
+    }
+
+    void visit(TypeBasic *type)
+    {
+        //printf("visit(TypeBasic); is_not_top_type = %d\n", (int)is_not_top_type);
+        if (type->isImmutable() || type->isShared())
+        {
+            visit((Type*)type);
+            return;
+        }
+
+        if (type->isConst() && (is_not_top_type || is_dmc))
+        {
+            if (checkTypeSaved(type)) return;
+        }
+
+        if ((type->ty == Tbool) && checkTypeSaved(type))// try to replace long name with number
+        {
+            return;
+        }
+        mangleModifier(type);
+        switch (type->ty)
+        {
+        case Tvoid:     buf.writeByte('X');        break;
+        case Tint8:     buf.writeByte('C');        break;
+        case Tuns8:     buf.writeByte('E');        break;
+        case Tint16:    buf.writeByte('F');        break;
+        case Tuns16:    buf.writeByte('G');        break;
+        case Tint32:    buf.writeByte('H');        break;
+        case Tuns32:    buf.writeByte('I');        break;
+        case Tfloat32:  buf.writeByte('M');        break;
+        case Tint64:    buf.writestring("_J");     break;
+        case Tuns64:    buf.writestring("_K");     break;
+        case Tfloat64:  buf.writeByte('N');        break;
+        case Tbool:     buf.writestring("_N");     break;
+        case Tchar:     buf.writeByte('D');        break;
+        case Twchar:    buf.writeByte('G');        break; // unsigned short
+
+        case Tfloat80:
+            if (is_dmc)
+                buf.writestring("_T"); // Intel long double
+            else
+                buf.writestring("_Z"); // DigitalMars long double
+            break;
+
+        case Tdchar:
+            if (is_dmc)
+                buf.writestring("_W"); // Visual C++ wchar_t
+            else
+                buf.writestring("_Y"); // DigitalMars wchar_t
+            break;
+
+        default:        visit((Type*)type); return;
+        }
+        is_not_top_type = false;
+        ignore_const = false;
+    }
+
+    void visit(TypeVector *type)
+    {
+        //printf("visit(TypeVector); is_not_top_type = %d\n", (int)is_not_top_type);
+        if (checkTypeSaved(type)) return;
+        buf.writestring("T__m128@@"); // may be better as __m128i or __m128d?
+        is_not_top_type = false;
+        ignore_const = false;
+    }
+
+    void visit(TypeSArray *type)
+    {
+        // This method can be called only for static variable type mangling.
+        //printf("visit(TypeSArray); is_not_top_type = %d\n", (int)is_not_top_type);
+        if (checkTypeSaved(type)) return;
+        // first dimension always mangled as const pointer
+        if (is_dmc)
+            buf.writeByte('Q');
+        else
+            buf.writeByte('P');
+
+        is_not_top_type = true;
+        assert(type->next);
+        if (type->next->ty == Tsarray)
+        {
+            mangleArray((TypeSArray*)type->next);
+        }
+        else
+        {
+            type->next->accept(this);
+        }
+    }
+
+    // attention: D int[1][2]* arr mapped to C++ int arr[][2][1]; (because it's more typical situation)
+    // There is not way to map int C++ (*arr)[2][1] to D
+    void visit(TypePointer *type)
+    {
+        //printf("visit(TypePointer); is_not_top_type = %d\n", (int)is_not_top_type);
+        if (type->isImmutable() || type->isShared())
+        {
+            visit((Type*)type);
+            return;
+        }
+
+        assert(type->next);
+        if (type->next->ty == Tfunction)
+        {
+            const char *arg = mangleFunctionType((TypeFunction*)type->next); // compute args before checking to save; args should be saved before function type
+            if (checkTypeSaved(type))  // If we've mangled this function early, previous call is meaningless.
+                return;                // However we should do it before checking to save types of function arguments before function type saving.
+                                       // If this function was already mangled, types of all it arguments are save too, thus previous can't save
+                                       // anything if function is saved.
+
+            if (type->isConst())
+                buf.writeByte('Q'); // const
+            else
+                buf.writeByte('P'); // mutable
+
+            buf.writeByte('6'); // pointer to a function
+            buf.writestring(arg);
+            is_not_top_type = false;
+            ignore_const = false;
+        }
+        else if (type->next->ty == Tsarray)
+        {
+            if (checkTypeSaved(type))
+                return;
+            mangleModifier(type);
+
+            if (type->isConst() || !is_dmc)
+                buf.writeByte('Q'); // const
+            else
+                buf.writeByte('P'); // mutable
+
+            if (global.params.is64bit)
+                buf.writeByte('E');
+            is_not_top_type = true;
+
+            mangleArray((TypeSArray*)type->next);
+        }
+        else
+        {
+            if (checkTypeSaved(type))
+                return;
+            mangleModifier(type);
+            
+            if (type->isConst())
+            {
+                buf.writeByte('Q'); // const
+            }
+            else
+            {
+                buf.writeByte('P'); // mutable
+            }
+            
+            if (global.params.is64bit)
+                buf.writeByte('E');
+            is_not_top_type = true;
+            type->next->accept(this);
+        }
+    }
+
+    void visit(TypeReference *type)
+    {
+        //printf("visit(TypeReference); type = %s\n", type->toChars());
+        if (checkTypeSaved(type)) return;
+
+        if (type->isImmutable() || type->isShared())
+        {
+            visit((Type*)type);
+            return;
+        }
+
+
+        buf.writeByte('A'); // mutable
+
+        if (global.params.is64bit)
+            buf.writeByte('E');
+        is_not_top_type = true;
+        assert(type->next);
+        if (type->next->ty == Tsarray)
+        {
+            mangleArray((TypeSArray*)type->next);
+        }
+        else
+        {
+            type->next->accept(this);
+        }
+    }
+
+    void visit(TypeFunction *type)
+    {
+        // We can mangle pointer to a function, not function.
+        visit((Type*)type);
+    }
+
+    void visit(TypeStruct *type)
+    {
+        if (checkTypeSaved(type)) return;
+        //printf("visit(TypeStruct); is_not_top_type = %d\n", (int)is_not_top_type);
+        mangleModifier(type);
+        if (type->sym->isUnionDeclaration())
+            buf.writeByte('T');
+        else
+            buf.writeByte('U');
+        mangleIdent(type->sym);
+        is_not_top_type = false;
+        ignore_const = false;
+    }
+
+    void visit(TypeEnum *type)
+    {
+        //printf("visit(TypeEnum); is_not_top_type = %d\n", (int)is_not_top_type);
+        if (checkTypeSaved(type)) return;
+        mangleModifier(type);
+        buf.writeByte('W');
+
+        switch (type->sym->memtype->ty)
+        {
+        case Tchar:
+        case Tint8:
+            buf.writeByte('0');
+            break;
+        case Tuns8:
+            buf.writeByte('1');
+            break;
+        case Tint16:
+            buf.writeByte('2');
+            break;
+        case Tuns16:
+            buf.writeByte('3');
+            break;
+        case Tint32:
+            buf.writeByte('4');
+            break;
+        case Tuns32:
+            buf.writeByte('5');
+            break;
+        case Tint64:
+            buf.writeByte('6');
+            break;
+        case Tuns64:
+            buf.writeByte('7');
+            break;
+        default:
+            visit((Type*)type);
+            break;
+        }
+
+        mangleIdent(type->sym);
+        is_not_top_type = false;
+        ignore_const = false;
+    }
+
+    // D class mangled as pointer to C++ class
+    // const(Object) mangled as Object const* const
+    void visit(TypeClass *type)
+    {
+        //printf("visit(TypeClass); is_not_top_type = %d\n", (int)is_not_top_type);
+        if (checkTypeSaved(type)) return;
+        if (is_not_top_type)
+            mangleModifier(type);
+
+        if (type->isConst())
+            buf.writeByte('Q');
+        else
+            buf.writeByte('P');
+
+        if (global.params.is64bit)
+            buf.writeByte('E');
+
+        is_not_top_type = true;
+        mangleModifier(type);
+
+        buf.writeByte('V');
+
+        mangleIdent(type->sym);
+        is_not_top_type = false;
+        ignore_const = false;
+    }
+
+    char *mangleOf(Dsymbol *s)
+    {
+        VarDeclaration *vd = s->isVarDeclaration();
+        FuncDeclaration *fd = s->isFuncDeclaration();
+        if (vd)
+        {
+            mangleVariable(vd);
+        }
+        else if (fd)
+        {
+            mangleFunction(fd);
+        }
+        else
+        {
+            assert(0);
+        }
+        return buf.extractString();
+    }
+private:
+
+    void mangleFunction(FuncDeclaration *d)
+    {
+        // <function mangle> ? <qualified name> <flags> <return type> <arg list>
+        assert(d);
+        buf.writeByte('?');
+        mangleIdent(d);
+
+        if (d->needThis()) // <flags> ::= <virtual/protection flag> <const/volatile flag> <calling convention flag>
+        {
+            // private non-final method can be not isVirtual() but we should mangle it as virtual
+            if (!d->isFinal() && d->isThis()->isClassDeclaration())
+            {
+                switch (d->protection)
+                {
+                case PROTprivate:
+                    buf.writeByte('E');
+                    break;
+                case PROTprotected:
+                    buf.writeByte('M');
+                    break;
+                default:
+                    buf.writeByte('U');
+                    break;
+                }
+            }
+            else
+            {
+                switch (d->protection)
+                {
+                case PROTprivate:
+                    buf.writeByte('A');
+                    break;
+                case PROTprotected:
+                    buf.writeByte('I');
+                    break;
+                default:
+                    buf.writeByte('Q');
+                    break;
+                }
+            }
+            if (global.params.is64bit)
+                buf.writeByte('E');
+            if (d->type->isConst())
+            {
+                buf.writeByte('B');
+            }
+            else
+            {
+                buf.writeByte('A');
+            }
+        }
+        else if (d->isMember2()) // static function
+        {                        // <flags> ::= <virtual/protection flag> <calling convention flag>
+            switch (d->protection)
+            {
+            case PROTprivate:
+                buf.writeByte('C');
+                break;
+            case PROTprotected:
+                buf.writeByte('K');
+                break;
+            default:
+                buf.writeByte('S');
+                break;
+            }
+        }
+        else // top-level function
+        {    // <flags> ::= Y <calling convention flag>
+            buf.writeByte('Y');
+        }
+
+        const char *args = mangleFunctionType((TypeFunction *)d->type, (bool)d->needThis(), d->isCtorDeclaration() || d->isDtorDeclaration());
+        buf.writestring(args);
+    }
+
+    void mangleVariable(VarDeclaration *d)
+    {
+        // <static variable mangle> ::= ? <qualified name> <protection flag> <const/volatile flag> <type>
+        assert(d);
+        if (!(d->storage_class & (STCextern | STCgshared)))
+        {
+            d->error("ICE: C++ static non- __gshared non-extern variables not supported");
+            assert(0);
+        }
+        buf.writeByte('?');
+        mangleIdent(d);
+
+        assert(!d->needThis());
+
+        if (d->parent && d->parent->isModule()) // static member
+        {
+            buf.writeByte('3');
+        }
+        else
+        {
+            switch (d->protection)
+            {
+            case PROTprivate:
+                buf.writeByte('0');
+                break;
+            case PROTprotected:
+                buf.writeByte('1');
+                break;
+            default:
+                buf.writeByte('2');
+                break;
+            }
+        }
+
+        char cv_mod = 0;
+        Type *t = d->type;
+
+        if (t->isImmutable() || t->isShared())
+        {
+            visit((Type*)t);
+            return;
+        }
+        if (t->isConst())
+        {
+            cv_mod = 'B'; // const
+        }
+        else
+        {
+            cv_mod = 'A'; // mutable
+        }
+
+        if (t->ty != Tpointer)
+            t = t->mutableOf();
+
+        t->accept(this);
+
+        if ((t->ty == Tpointer || t->ty == Treference) && global.params.is64bit)
+        {
+            buf.writeByte('E');
+        }
+
+        buf.writeByte(cv_mod);
+    }
+
+    void mangleName(Dsymbol *sym, bool dont_use_back_reference = false)
+    {
+        const char *name = NULL;
+        bool is_dmc_template = false;
+        if (sym->isDtorDeclaration())
+        {
+            buf.writestring("?1");
+            return;
+        }
+        if (TemplateInstance *ti = sym->isTemplateInstance())
+        {
+            VisualCPPMangler tmp(is_dmc);
+            tmp.buf.writeByte('?');
+            tmp.buf.writeByte('$');
+            tmp.buf.writestring(ti->name->toChars());
+            tmp.saved_idents[0] = ti->name->toChars();
+            tmp.buf.writeByte('@');
+            if (is_dmc)
+            {
+                tmp.mangleIdent(sym->parent, true);
+                is_dmc_template = true;
+            }
+
+            bool is_var_arg = false;
+            for (size_t i = 0; i < ti->tiargs->dim; i++)
+            {
+                RootObject *o = (*ti->tiargs)[i];
+
+                TemplateParameter *tp = NULL;
+                TemplateValueParameter *tv = NULL;
+                TemplateTupleParameter *tt = NULL;
+                if (!is_var_arg)
+                {
+                    TemplateDeclaration *td = ti->tempdecl->isTemplateDeclaration();
+                    assert(td);
+                    tp = (*td->parameters)[i];
+                    tv = tp->isTemplateValueParameter();
+                    tt = tp->isTemplateTupleParameter();
+                }
+
+                if (tt)
+                {
+                    is_var_arg = true;
+                    tp = NULL;
+                }
+                if (tv)
+                {
+                    if (tv->valType->isintegral())
+                    {
+
+                        tmp.buf.writeByte('$');
+                        tmp.buf.writeByte('0');
+
+                        Expression *e = isExpression(o);
+                        assert(e);
+
+                        if (tv->valType->isunsigned())
+                        {
+                            tmp.mangleNumber(e->toUInteger());
+                        }
+                        else
+                        {
+                            dinteger_t val = e->toInteger();
+                            if (val < 0)
+                            {
+                                val = -val;
+                                tmp.buf.writeByte('?');
+                            }
+                            tmp.mangleNumber(val);
+                        }
+                    }
+                    else
+                    {
+                        sym->error("ICE: C++ %s template value parameter is not supported", tv->valType->toChars());
+                        assert(0);
+                    }
+                }
+                else if (!tp || tp->isTemplateTypeParameter())
+                {
+                    Type *t = isType(o);
+                    assert(t);
+                    t->accept(&tmp);
+                }
+                else if (tp->isTemplateAliasParameter())
+                {
+                    Dsymbol *d = isDsymbol(o);
+                    Expression *e = isExpression(o);
+                    if (!d && !e)
+                    {
+                        sym->error("ICE: %s is unsupported parameter for C++ template", o->toChars());
+                        assert(0);
+                    }
+                    if (d && d->isFuncDeclaration())
+                    {
+                        tmp.buf.writeByte('$');
+                        tmp.buf.writeByte('1');
+                        tmp.mangleFunction(d->isFuncDeclaration());
+                    }
+                    else if (e && e->op == TOKvar && ((VarExp*)e)->var->isVarDeclaration())
+                    {
+                        tmp.buf.writeByte('$');
+                        if (is_dmc)
+                            tmp.buf.writeByte('1');
+                        else
+                            tmp.buf.writeByte('E');
+                        tmp.mangleVariable(((VarExp*)e)->var->isVarDeclaration());
+                    }
+                    else if (d && d->isTemplateDeclaration() && d->isTemplateDeclaration()->onemember)
+                    {
+
+                        Dsymbol *ds = d->isTemplateDeclaration()->onemember;
+                        if (is_dmc)
+                        {
+                            tmp.buf.writeByte('V');
+                        }
+                        else
+                        {
+                            if (ds->isUnionDeclaration())
+                            {
+                                tmp.buf.writeByte('T');
+                            }
+                            else if (ds->isStructDeclaration())
+                            {
+                                tmp.buf.writeByte('U');
+                            }
+                            else if (ds->isClassDeclaration())
+                            {
+                                tmp.buf.writeByte('V');
+                            }
+                            else
+                            {
+                                sym->error("ICE: C++ templates support only integral value , type parameters, alias templates and alias function parameters");
+                                assert(0);
+                            }
+                        }
+                        tmp.mangleIdent(d);
+                    }
+                    else
+                    {
+                        sym->error("ICE: %s is unsupported parameter for C++ template: (%s)", o->toChars());
+                        assert(0);
+                    }
+
+                }
+                else
+                {
+                    sym->error("ICE: C++ templates support only integral value , type parameters, alias templates and alias function parameters");
+                    assert(0);
+                }
+            }
+            name = tmp.buf.extractString();
+        }
+        else
+        {
+            name = sym->ident->toChars();
+        }
+        assert(name);
+        if (!is_dmc_template)
+        {
+            if (dont_use_back_reference)
+            {
+                saveIdent(name);
+            }
+            else
+            {
+                if (checkAndSaveIdent(name)) return;
+            }
+        }
+        buf.writestring(name);
+        buf.writeByte('@');
+    }
+
+    // returns true if name already saved
+    bool checkAndSaveIdent(const char *name)
+    {
+        for (size_t i = 0; i < VC_SAVED_IDENT_CNT; i++)
+        {
+            if (!saved_idents[i]) // no saved same name
+            {
+                saved_idents[i] = name;
+                break;
+            }
+
+            if (!strcmp(saved_idents[i], name)) // ok, we've found same name. use index instead of name
+            {
+                buf.writeByte(i + '0');
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void saveIdent(const char *name)
+    {
+        for (size_t i = 0; i < VC_SAVED_IDENT_CNT; i++)
+        {
+            if (!saved_idents[i]) // no saved same name
+            {
+                saved_idents[i] = name;
+                break;
+            }
+
+            if (!strcmp(saved_idents[i], name)) // ok, we've found same name. use index instead of name
+            {
+                return;
+            }
+        }
+    }
+
+    void mangleIdent(Dsymbol *sym, bool dont_use_back_reference = false)
+    {
+        // <qualified name> ::= <sub-name list> @
+        // <sub-name list>  ::= <sub-name> <name parts>
+        //                  ::= <sub-name>
+
+        // <sub-name> ::= <identifier> @
+        //            ::= ?$ <identifier> @ <template args> @
+        //            :: <back reference>
+
+        // <back reference> ::= 0-9
+
+        // <template args> ::= <template arg> <template args>
+        //                ::= <template arg>
+
+        // <template arg>  ::= <type>
+        //                ::= $0<encoded integral number>
+
+        Dsymbol *p = sym;
+        if (p->toParent() && p->toParent()->isTemplateInstance())
+        {
+            p = p->toParent();
+        }
+        while (p && !p->isModule())
+        {
+            mangleName(p, dont_use_back_reference);
+
+            p = p->toParent();
+            if (p->toParent() && p->toParent()->isTemplateInstance())
+            {
+                p = p->toParent();
+            }
+        }
+        if (!dont_use_back_reference)
+            buf.writeByte('@');
+    }
+
+    void mangleNumber(dinteger_t num)
+    {
+        if (!num) // 0 encoded as "A@"
+        {
+            buf.writeByte('A');
+            buf.writeByte('@');
+            return;
+        }
+        if (num <= 10) // 5 encoded as "4"
+        {
+            buf.writeByte((char)(num - 1 + '0'));
+            return;
+        }
+
+        char buff[17];
+        buff[16] = 0;
+        size_t i = 16;
+        while (num)
+        {
+            --i;
+            buff[i] = num % 16 + 'A';
+            num /=16;
+        }
+        buf.writestring(&buff[i]);
+        buf.writeByte('@');
+    }
+
+    bool checkTypeSaved(Type *type)
+    {
+        if (is_not_top_type) return false;
+        for (size_t i = 0; i < VC_SAVED_TYPE_CNT; i++)
+        {
+            if (!saved_types[i]) // no saved same type
+            {
+                saved_types[i] = type;
+                return false;
+            }
+            if (saved_types[i]->equals(type)) // ok, we've found same type. use index instead of type
+            {
+                buf.writeByte(i + '0');
+                is_not_top_type = false;
+                ignore_const = false;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void mangleModifier(Type *type)
+    {
+        if (ignore_const) return;
+        if (type->isImmutable() || type->isShared())
+        {
+            visit((Type*)type);
+            return;
+        }
+        if (type->isConst())
+        {
+            if (is_not_top_type)
+                buf.writeByte('B'); // const
+            else if (is_dmc && type->ty != Tpointer)
+                buf.writestring("_O");
+        }
+        else if (is_not_top_type)
+            buf.writeByte('A'); // mutable
+    }
+
+    void mangleArray(TypeSArray *type)
+    {
+        mangleModifier(type);
+        size_t i=0;
+        Type *cur = type;
+        while (cur && cur->ty == Tsarray)
+        {
+            i++;
+            cur = cur->nextOf();
+        }
+        buf.writeByte('Y');
+        mangleNumber(i); // count of dimensions
+        cur = type;
+        while (cur && cur->ty == Tsarray) // sizes of dimensions
+        {
+            TypeSArray *sa = (TypeSArray*)cur;
+            mangleNumber(sa->dim ? sa->dim->toInteger() : 0);
+            cur = cur->nextOf();
+        }
+        ignore_const = true;
+        cur->accept(this);
+    }
+
+    const char *mangleFunctionType(TypeFunction *type, bool needthis = false, bool noreturn = false)
+    {
+        VisualCPPMangler tmp(this);
+        // Calling convention
+        if (global.params.is64bit) // always Microsoft x64 calling convention
+        {
+            tmp.buf.writeByte('A');
+        }
+        else
+        {
+            switch (type->linkage)
+            {
+            case LINKc:
+                tmp.buf.writeByte('A');
+                break;
+            case LINKcpp:
+                if (needthis)
+                    tmp.buf.writeByte('E'); // thiscall
+                else
+                    tmp.buf.writeByte('A'); // cdecl
+                break;
+            case LINKwindows:
+                tmp.buf.writeByte('G'); // stdcall
+                break;
+            case LINKpascal:
+                tmp.buf.writeByte('C');
+                break;
+            default:
+                tmp.visit((Type*)type);
+                break;
+            }
+        }
+
+        tmp.is_not_top_type = false;
+        if (noreturn)
+        {
+            tmp.buf.writeByte('@');
+        }
+        else
+        {
+            Type *rettype = type->next;
+            if (type->isref)
+                rettype = rettype->referenceTo();
+            ignore_const = false;
+            if (rettype->ty == Tstruct || rettype->ty == Tenum)
+            {
+                tmp.buf.writeByte('?');
+                tmp.buf.writeByte('A');
+            }
+            rettype->accept(&tmp);
+        }
+        if (!type->parameters || !type->parameters->dim)
+        {
+            if (type->varargs == 1)
+                tmp.buf.writeByte('Z');
+            else
+                tmp.buf.writeByte('X');
+        }
+        else
+        {
+            for (size_t i = 0; i < type->parameters->dim; ++i)
+            {
+                tmp.mangleParameter((*type->parameters)[i]);
+            }
+            if (type->varargs == 1)
+            {
+                tmp.buf.writeByte('Z');
+            }
+            else
+            {
+                tmp.buf.writeByte('@');
+            }
+        }
+
+        tmp.buf.writeByte('Z');
+        const char *ret = tmp.buf.extractString();
+        memcpy(&saved_idents, &tmp.saved_idents, sizeof(const char*) * VC_SAVED_IDENT_CNT);
+        memcpy(&saved_types, &tmp.saved_types, sizeof(Type*) * VC_SAVED_TYPE_CNT);
+        return ret;
+    }
+
+    void mangleParameter(Parameter *p)
+    {
+        Type *t = p->type;
+        if (p->storageClass & (STCout | STCref))
+            t = t->referenceTo();
+        else if (p->storageClass & STClazy)
+        {
+            // Mangle as delegate
+            Type *td = new TypeFunction(NULL, t, 0, LINKd);
+            td = new TypeDelegate(td);
+            t = t->merge();
+        }
+        if (t->ty == Tsarray)
+        {
+            t->error(Loc(), "ICE: Unable to pass static array to extern(C++) function.");
+            t->error(Loc(), "Use pointer instead.");
+            assert(0);
+        }
+        is_not_top_type = false;
+        ignore_const = false;
+        t->accept(this);
+    }
+};
+
 char *toCppMangle(Dsymbol *s)
 {
-    // Windows C++ mangling is done by C++ back end
-    return s->ident->toChars();
+    VisualCPPMangler v(!global.params.is64bit);
+    return v.mangleOf(s);
 }
 
 #endif

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -170,11 +170,12 @@ Lret:
 #ifdef DEBUG
         size_t len = strlen(p);
         assert(len > 0);
-        //printf("mangle: '%s' => '%s'\n", toChars(), p);
         for (size_t i = 0; i < len; i++)
         {
             assert(p[i] == '_' ||
                    p[i] == '@' ||
+                   p[i] == '?' ||
+                   p[i] == '$' ||
                    isalnum(p[i]) || p[i] & 0x80);
         }
 #endif

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -276,32 +276,16 @@ Symbol *VarDeclaration::toSymbol()
                 break;
 
             case LINKd:
+            case LINKcpp:
                 m = mTYman_d;
                 break;
-
-            case LINKcpp:
-            {
-                m = mTYman_cpp;
-
-                s->Sflags |= SFLpublic;
-                Dsymbol *parent = toParent();
-                ClassDeclaration *cd = parent->isClassDeclaration();
-                if (cd)
-                {
-                    ::type *tc = Type_toCtype(cd->type);
-                    s->Sscope = tc->Tnext->Ttag;
-                }
-                StructDeclaration *sd = parent->isStructDeclaration();
-                if (sd)
-                {
-                    ::type *ts = Type_toCtype(sd->type);
-                    s->Sscope = ts->Ttag;
-                }
-                break;
-            }
             default:
                 printf("linkage = %d\n", linkage);
                 assert(0);
+        }
+        if (linkage == LINKcpp)
+        {
+            s->Sflags |= SFLpublic;
         }
         type_setmangle(&t, m);
         s->Stype = t;
@@ -413,41 +397,27 @@ Symbol *FuncDeclaration::toSymbol()
                 case LINKd:
                     t->Tmangle = mTYman_d;
                     break;
-
                 case LINKcpp:
-                {   t->Tmangle = mTYman_cpp;
+                    s->Sflags |= SFLpublic;
                     if (isThis() && !global.params.is64bit && global.params.isWindows)
                     {
                         if (((TypeFunction *)type)->varargs == 1)
+                        {
                             t->Tty = TYnfunc;
+                        }
                         else
+                        {
                             t->Tty = TYmfunc;
+                        }
                     }
-                    s->Sflags |= SFLpublic;
-                    Dsymbol *parent = toParent();
-                    ClassDeclaration *cd = parent->isClassDeclaration();
-                    if (cd)
-                    {
-                        ::type *tc = Type_toCtype(cd->type);
-                        s->Sscope = tc->Tnext->Ttag;
-                    }
-                    StructDeclaration *sd = parent->isStructDeclaration();
-                    if (sd)
-                    {
-                        ::type *ts = Type_toCtype(sd->type);
-                        s->Sscope = ts->Ttag;
-                    }
-                    if (isCtorDeclaration())
-                        s->Sfunc->Fflags |= Fctor;
-                    if (isDtorDeclaration())
-                        s->Sfunc->Fflags |= Fdtor;
+                    t->Tmangle = mTYman_d;
                     break;
-                }
                 default:
                     printf("linkage = %d\n", linkage);
                     assert(0);
             }
         }
+
         if (msave)
             assert(msave == t->Tmangle);
         //printf("Tty = %x, mangle = x%x\n", t->Tty, t->Tmangle);

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -276,17 +276,17 @@ Symbol *VarDeclaration::toSymbol()
                 break;
 
             case LINKd:
+                m = mTYman_d;
+                break;
             case LINKcpp:
+                s->Sflags |= SFLpublic;
                 m = mTYman_d;
                 break;
             default:
                 printf("linkage = %d\n", linkage);
                 assert(0);
         }
-        if (linkage == LINKcpp)
-        {
-            s->Sflags |= SFLpublic;
-        }
+
         type_setmangle(&t, m);
         s->Stype = t;
 

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1,17 +1,5 @@
 // EXTRA_CPP_SOURCES: cppb.cpp
 
-version (Win64)
-{
-// Name mangling isn't compatible with VC yet
-pragma(mangle, "?foo@@YAHHHH@Z")
-int foo(int i, int j, int k) { return 0; }
-
-void main() {}
-
-}
-else
-{
-
 import std.c.stdio;
 
 extern (C++)
@@ -139,7 +127,21 @@ extern(C++)
         int i;
         double d;
     }
+
+    union S6_2
+    {
+        int i;
+        double d;
+    }
+
+    enum S6_3
+    {
+        A, B
+    }
+
     S6 foo6();
+    S6_2 foo6_2();
+    S6_3 foo6_3();
 }
 
 extern (C) int foosize6();
@@ -154,6 +156,8 @@ version (X86)
     assert(f.i == 42);
     printf("f.d = %g\n", f.d);
     assert(f.d == 2.5);
+    assert(foo6_2().i == 42);
+    assert(foo6_3() == S6_3.A);
 }
 }
 
@@ -175,7 +179,7 @@ void test7()
 
 /****************************************/
 
-extern (C++) void foo8(const char *);
+extern (C++) void foo8(const(char)*);
 
 void test8()
 {
@@ -222,7 +226,13 @@ void test11802()
     auto x = new D11802();
     x.x = 0;
     test11802x(x);
-    assert(x.x == 9);
+    version(Win64)
+    {
+    }
+    else
+    {
+        assert(x.x == 9);
+    }
 }
 
 
@@ -231,9 +241,10 @@ void test11802()
 
 extern (C++)
 {
-    void foo10(const char*, const char*);
+    void foo10(const(char)*, const(char)*);
     void foo10(const int, const int);
     void foo10(const char, const char);
+    void foo10(bool, bool);
 
     struct MyStructType { }
     void foo10(const MyStructType s, const MyStructType t);
@@ -271,5 +282,4 @@ void main()
     test10();
 
     printf("Success\n");
-}
 }

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -139,6 +139,35 @@ interface Expression
 }
 
 //int test34(int[0][0]*);
+version(Win64){}
+else
+{
+    int test35(real arg);
+}
+
+const(char)* test36(const(char)*);
+
+final class Test37
+{
+    static Test37 create()
+    {
+        return new Test37;
+    }
+    
+    bool test()
+    {
+        return true;
+    }
+}
+
+bool test37();
+
+interface Test38
+{
+     final int test(int, ...);
+     public static Test38 create();
+     public static void dispose(ref Test38);
+}
 
 void main()
 {
@@ -214,4 +243,15 @@ void main()
     Expression.dispose(ee);
     assert(ee is null);
     //assert(test34(null) == 0);
+    version(Win64){}
+    else
+    {
+        assert(test35(3.14L) == 3);
+    }
+    const char* hello = "hello";
+    assert(test36(hello) == hello);
+    assert(test37());
+    auto t38 = Test38.create();
+    assert(t38.test(1, 2, 3) == 1);
+    Test38.dispose(t38);
 }

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -1,191 +1,217 @@
 // EXTRA_CPP_SOURCES: externmangle.cpp
 
-version(Windows)
-{
-    void main()
-    {
-    }
-}
-else
-{
-    extern(C++):
+extern(C++):
 
+struct Foo(X)
+{
+    X* v;
+}
+
+
+struct Boo(X)
+{
+    X* v;
+}
+
+
+void test1(Foo!int arg1);
+void test2(int* arg2, Boo!(int*) arg1);
+
+
+struct Test3(int X, int Y)
+{
+}
+
+void test3(Test3!(3,3) arg1);
+
+void test4(Foo!(int*) arg1, Boo!(int*) arg2, Boo!(int*) arg3, int*, Foo!(double));
+
+void test5(Foo!(int*) arg1, Boo!(int*) arg2, Boo!(int*) arg3);
+
+
+struct Goo
+{
     struct Foo(X)
     {
         X* v;
     }
 
-
     struct Boo(X)
     {
+        struct Xoo(Y)
+        {
+            Y* v;
+        };
         X* v;
     }
 
 
-    void test1(Foo!int arg1);
-    void test2(int* arg2, Boo!(int*) arg1);
+    void test6(Foo!(Boo!(Foo!(void))) arg1);
+    void test7(Boo!(void).Xoo!(int) arg1);
+}
 
-
-    struct Test3(int X, int Y)
+struct P1
+{
+    struct Mem(T)
     {
     }
+}
 
-    void test3(Test3!(3,3) arg1);
-
-    void test4(Foo!(int*) arg1, Boo!(int*) arg2, Boo!(int*) arg3, int*, Foo!(double));
-
-    void test5(Foo!(int*) arg1, Boo!(int*) arg2, Boo!(int*) arg3);
-
-
-    struct Goo
+struct P2
+{
+    struct Mem(T)
     {
-        struct Foo(X)
-        {
-            X* v;
-        }
-
-        struct Boo(X)
-        {
-            struct Xoo(Y)
-            {
-                Y* v;
-            };
-            X* v;
-        }
-
-
-        void test6(Foo!(Boo!(Foo!(void))) arg1);
-        void test7(Boo!(void).Xoo!(int) arg1);
     }
+}
 
-    struct P1
+void test8(P1.Mem!int, P2.Mem!int);
+void test9(Foo!(int**), Foo!(int*), int**, int*);
+
+
+interface Test10
+{
+    private final void test10();
+    public final void test11();
+    protected final void test12();
+    public final void test13() const;
+
+    private void test14();
+    public void test15();
+    protected void test16();
+
+    private static void test17();
+    public static void test18();
+    protected static void test19();
+};
+
+Test10 Test10Ctor();
+void Test10Dtor(ref Test10 ptr);
+
+struct Test20
+{
+    __gshared:
+    private extern int test20;
+    protected extern int test21;
+    public extern int test22;
+};
+
+
+int test23(Test10*, Test10, Test10**, const(Test10));
+int test23b(const Test10*, const Test10, Test10);
+
+void test24(int function(int,int));
+
+void test25(int[291][6][5]* arr);
+int test26(int[291][6]* arr);
+
+void test27(int, ...);
+void test28(int);
+
+void test29(float);
+void test30(const float);
+
+struct Array(T)
+{
+    int dim;
+}
+
+
+interface Module
+{
+    public static void imports(Module);
+    public static int dim(Array!Module*);
+};
+
+ulong testlongmangle(int a, uint b, long c, ulong d);
+
+__gshared extern int[2][2][2] test31;
+__gshared extern int* test32;
+
+
+alias int function(Expression , void* ) apply_fp_t;
+
+interface Expression
+{
+    public final int apply(apply_fp_t fp, apply_fp_t fp2, void* param);
+    public final int getType();
+    public static Expression create(int);
+    public static void dispose(ref Expression);
+}
+
+//int test34(int[0][0]*);
+
+void main()
+{
+    test1(Foo!int());
+    test2(null, Boo!(int*)());
+    test3(Test3!(3,3)());
+    test4(Foo!(int*)(), Boo!(int*)(), Boo!(int*)(), null, Foo!(double)());
+    test5(Foo!(int*)(), Boo!(int*)(), Boo!(int*)());
+    Goo goo;
+    goo.test6(Goo.Foo!(Goo.Boo!(Goo.Foo!(void)))());
+    goo.test7(Goo.Boo!(void).Xoo!(int)());
+
+    test8(P1.Mem!int(), P2.Mem!int());
+    test9(Foo!(int**)(), Foo!(int*)(), null, null);
+
+    auto t10 = Test10Ctor();
+    scope(exit) Test10Dtor(t10);
+
+    t10.test10();
+    t10.test11();
+    t10.test12();
+    t10.test13();
+    t10.test14();
+    t10.test15();
+    t10.test16();
+    t10.test17();
+    t10.test18();
+    t10.test19();
+
+    assert(Test20.test20 == 20);
+    assert(Test20.test21 == 21);
+    assert(Test20.test22 == 22);
+
+    assert(test23(null, null, null, null) == 1);
+    assert(test23b(null, null, null) == 1);
+
+    extern(C++) static int cb(int a, int b){return a+b;}
+
+    test24(&cb);
+    int[291][6][5] arr;
+    arr[1][1][1] = 42;
+    test25(&arr);
+    assert(test26(&arr[0]) == 42);
+
+    test27(3,4,5);
+    test28(3);
+
+    test29(3.14f);
+    test30(3.14f);
+
+    auto t32 = &Module.imports;
+    Array!Module arr2;
+    arr2.dim = 20;
+    assert(Module.dim(&arr2) == 20);
+
+    assert(testlongmangle(1, 2, 3, 4) == 10);
+    assert(test31 == [[[1, 1], [1, 1]], [[1, 1], [1, 1]]]);
+    assert(test32 == null);
+    
+    auto ee = Expression.create(42);
+    extern(C++) static int efun(Expression e, void* p)
     {
-        struct Mem(T)
-        {
-        }
+        return cast(int)(cast(size_t)p ^ e.getType());
     }
-
-    struct P2
+    
+    extern(C++) static int efun2(Expression e, void* p)
     {
-        struct Mem(T)
-        {
-        }
+        return cast(int)(cast(size_t)p * e.getType());
     }
-
-    void test8(P1.Mem!int, P2.Mem!int);
-    void test9(Foo!(int**), Foo!(int*), int**, int*);
-
-
-    interface Test10
-    {
-        private final void test10();
-        public final void test11();
-        protected final void test12();
-        public final void test13() const;
-
-        private void test14();
-        public void test15();
-        protected void test16();
-
-        private static void test17();
-        public static void test18();
-        protected static void test19();
-    };
-
-    Test10 Test10Ctor();
-    void Test10Dtor(ref Test10 ptr);
-
-    struct Test20
-    {
-        __gshared:
-        private extern int test20;
-        protected extern int test21;
-        public extern int test22;
-    };
-
-
-    int test23(Test10*, Test10, Test10**, const(Test10));
-    int test23b(const Test10*, const Test10, Test10);
-
-    void test24(int function(int,int));
-
-    void test25(int[291][6][5]* arr);
-    int test26(int[291][6]* arr);
-
-    void test27(int, ...);
-    void test28(int);
-
-    void test29(float);
-    void test30(const float);
-
-    struct Array(T)
-    {
-        int dim;
-    }
-
-
-    interface Module
-    {
-        public static void imports(Module);
-        public static int dim(Array!Module*);
-    };
-
-    ulong testlongmangle(int a, uint b, long c, ulong d);
-
-    void main()
-    {
-        test1(Foo!int());
-        test2(null, Boo!(int*)());
-        test3(Test3!(3,3)());
-        test4(Foo!(int*)(), Boo!(int*)(), Boo!(int*)(), null, Foo!(double)());
-        test5(Foo!(int*)(), Boo!(int*)(), Boo!(int*)());
-        Goo goo;
-        goo.test6(Goo.Foo!(Goo.Boo!(Goo.Foo!(void)))());
-        goo.test7(Goo.Boo!(void).Xoo!(int)());
-
-        test8(P1.Mem!int(), P2.Mem!int());
-        test9(Foo!(int**)(), Foo!(int*)(), null, null);
-
-        auto t10 = Test10Ctor();
-        scope(exit) Test10Dtor(t10);
-
-        t10.test10();
-        t10.test11();
-        t10.test12();
-        t10.test13();
-        t10.test14();
-        t10.test15();
-        t10.test16();
-        t10.test17();
-        t10.test18();
-        t10.test19();
-
-        assert(Test20.test20 == 20);
-        assert(Test20.test21 == 21);
-        assert(Test20.test22 == 22);
-
-        assert(test23(null, null, null, null) == 1);
-        assert(test23b(null, null, null) == 1);
-
-        extern(C++) static int cb(int a, int b){return a+b;}
-
-        test24(&cb);
-        int[291][6][5] arr;
-        arr[1][1][1] = 42;
-        test25(&arr);
-        assert(test26(&arr[0]) == 42);
-
-        test27(3,4,5);
-        test28(3);
-
-        test29(3.14f);
-        test30(3.14f);
-
-        auto t32 = &Module.imports;
-        Array!Module arr2;
-        arr2.dim = 20;
-        assert(Module.dim(&arr2) == 20);
-
-        assert(testlongmangle(1, 2, 3, 4) == 10);
-    }
+    
+    auto test33 = ee.apply(&efun, &efun2, cast(void*)&Expression.create);
+    assert(test33 == cast(int)(cast(size_t)cast(void*)&Expression.create ^ 42) * cast(int)(cast(size_t)cast(void*)&Expression.create * 42));
+    Expression.dispose(ee);
+    assert(ee is null);
+    //assert(test34(null) == 0);
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -29,15 +29,15 @@ class D
   public:
     virtual int bar(int i, int j, int k)
     {
-	printf("this = %p\n", this);
-	assert(this == dthis);
-	printf("D.bar: i = %d\n", i);
-	printf("D.bar: j = %d\n", j);
-	printf("D.bar: k = %d\n", k);
-	assert(i == 9);
-	assert(j == 10);
-	assert(k == 11);
-	return 8;
+    printf("this = %p\n", this);
+    assert(this == dthis);
+    printf("D.bar: i = %d\n", i);
+    printf("D.bar: j = %d\n", j);
+    printf("D.bar: k = %d\n", k);
+    assert(i == 9);
+    assert(j == 10);
+    assert(k == 11);
+    return 8;
     }
 };
 
@@ -127,11 +127,36 @@ typedef struct
     double d;
 } S6;
 
+union S6_2
+{
+    int i;
+    double d;
+};
+
+enum S6_3
+{
+    A, B
+};
+
+
 S6 foo6(void)
 {
     S6 s;
     s.i = 42;
     s.d = 2.5;
+    return s;
+}
+
+S6_2 foo6_2(void)
+{
+    S6_2 s;
+    s.i = 42;
+    return s;
+}
+
+S6_3 foo6_3(void)
+{
+    S6_3 s = A;
     return s;
 }
 
@@ -173,6 +198,7 @@ void foobar9(elem9*, elem9*) { }
 void foo10(const char*, const char*) { }
 void foo10(const int, const int) { }
 void foo10(const char, const char) { }
+void foo10(bool, bool) { }
 
 struct MyStructType { };
 void foo10(const MyStructType s, const MyStructType t) { }

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -1,4 +1,3 @@
-
 #include <stdint.h>
 
 template<class X>
@@ -157,7 +156,7 @@ void test24(int(*)(int,int))
 {
 }
 
-void test25(int(* arr)[5][6][291])
+void test25(int arr[2][5][6][291])
 {
 }
 
@@ -201,8 +200,56 @@ unsigned long testlongmangle(int32_t a, uint32_t b, long c, unsigned long d)
     return a + b + c + d;
 }
 #else
-unsigned long long testlongmangle(int32_t a, uint32_t b, long long c, unsigned long long d)
+unsigned long long testlongmangle(int a, unsigned int b, long long c, unsigned long long d)
 {
     return a + b + c + d;
 }
 #endif
+
+int test31[2][2][2] = {1, 1, 1, 1, 1, 1, 1, 1};
+int *test32 = 0;
+
+
+
+class Expression;
+
+typedef int (*apply_fp_t)(Expression*, void*);
+
+class Expression
+{
+    int type;
+public:
+    int apply(apply_fp_t fp, apply_fp_t fp2, void *param);
+    int getType();
+    static Expression* create(int v);
+    static void dispose(Expression*&);
+};
+
+int Expression::apply(apply_fp_t fp, apply_fp_t fp2, void *param)
+{
+    return fp(this, param) * fp2(this, param);
+}
+
+int Expression::getType()
+{
+    return type;
+}
+
+Expression* Expression::create(int v)
+{
+    Expression *e = new Expression();
+    e->type = v;
+    return e;
+}
+
+void Expression::dispose(Expression *&e)
+{
+    if (e)
+        delete e;
+    e = 0;
+}
+
+/*int test34(int v[0][0][0])
+{
+    return 0;
+}*/

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -253,3 +253,54 @@ void Expression::dispose(Expression *&e)
 {
     return 0;
 }*/
+
+#ifndef _MSC_VER
+    int test35(long double arg)
+    {
+        return (int)arg;
+    }
+#endif
+
+const char *test36(const char *arg)
+{
+    return arg;
+}
+
+class Test37
+{
+public:
+    static Test37 *create();
+    bool test();
+};
+
+bool test37()
+{
+    Test37 *o = Test37::create();
+    return o->test();
+}
+
+class Test38
+{
+public:
+     int test(int, ...);
+     static Test38* create();
+     static void dispose(Test38*&);
+};
+
+int Test38::test(int a, ...)
+{
+    return a;
+}
+
+Test38* Test38::create()
+{
+    Test38 *t = new Test38();
+    return t;
+}
+
+void Test38::dispose(Test38 *&t)
+{
+    if (t)
+        delete t;
+    t = 0;
+}


### PR DESCRIPTION
This PR introduces windows C++ mangling in frontend.

The main reasons for this work:
1. Current (backend) mangling doesn't always properly process symbols in x86_64 mode. (e.g. function pointers)
2. Current mangling implementation doesn't allow get correct `.mangleof` value (It returns symbol name instead of mangle).
3. Current mangling doesn't process templates.
