### PR TITLE
[REG2.065a] Issue 12010 - Undefined template symbols for static library linked with debug symbols

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -215,6 +215,20 @@ void AggregateDeclaration::semantic3(Scope *sc)
             {
                 ftohash->semantic3(ftohash->scope);
             }
+
+            if (sd->postblit &&
+                sd->postblit->scope &&
+                sd->postblit->semanticRun < PASSsemantic3done)
+            {
+                sd->postblit->semantic3(sd->postblit->scope);
+            }
+
+            if (sd->dtor &&
+                sd->dtor->scope &&
+                sd->dtor->semanticRun < PASSsemantic3done)
+            {
+                sd->dtor->semantic3(sd->dtor->scope);
+            }
         }
     }
 }

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -141,6 +141,8 @@ Expression *Type::getTypeInfo(Scope *sc)
                     StructDeclaration *sd = ((TypeStruct *)this)->sym;
                     if ((sd->xeq  && sd->xeq  != sd->xerreq  ||
                          sd->xcmp && sd->xcmp != sd->xerrcmp ||
+                         (sd->postblit && !(sd->postblit->storage_class & STCdisable)) ||
+                         sd->dtor ||
                          search_toHash(sd) ||
                          search_toString(sd)
                         ) && sd->inNonRoot())

--- a/test/runnable/imports/a12010.d
+++ b/test/runnable/imports/a12010.d
@@ -1,0 +1,2 @@
+import imports.std12010container : Array, BinaryHeap;
+BinaryHeap!(Array!int) test;

--- a/test/runnable/imports/std12010container.d
+++ b/test/runnable/imports/std12010container.d
@@ -1,0 +1,69 @@
+struct Array(T)
+{
+    private struct Payload
+    {
+        size_t _capacity;
+        T[] _payload;
+
+        ~this()
+        {
+        }
+
+        this(this)
+        {
+        }
+    }
+    private alias RefCounted!(Payload) Data;
+    private Data _data;
+
+    bool opEquals(ref const Array rhs) const
+    {
+        return true;
+    }
+}
+
+
+struct BinaryHeap(Store)
+{
+    private static struct Data
+    {
+        Store _store;
+        size_t _length;
+    }
+    private RefCounted!(Data) _payload;
+}
+
+
+struct RefCounted(T)
+{
+    struct RefCountedStore
+    {
+        private struct Impl
+        {
+            T _payload;
+            size_t _count;
+        }
+
+        private Impl* _store;
+
+    }
+    RefCountedStore _refCounted;
+
+    this(this)
+    {
+    }
+
+    ~this()
+    {
+        .destroy(_refCounted._store._payload);
+    }
+
+    void opAssign(typeof(this) rhs)
+    {
+    }
+
+    void opAssign(T rhs)
+    {
+        typeid(T).destroy(&rhs);
+    }
+}

--- a/test/runnable/link12010.d
+++ b/test/runnable/link12010.d
@@ -1,0 +1,7 @@
+// COMPILE_SEPARATELY
+// EXTRA_SOURCES: imports/a12010.d
+// REQUIRED_ARGS: -release
+// -release is necessary to avoid __assert.
+
+import imports.a12010;
+void main() {}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12010

Struct destructors and postblits will be stored in `TypeInfo`. So, partial semantic3 running for structs declared in non-root modules should also consider them.
