### PR TITLE
Different fixes for #3116

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -285,7 +285,6 @@ class CppMangleVisitor : public Visitor
             source_name(s);
     }
 
-
     void mangle_variable(VarDeclaration *d, bool is_temp_arg_ref)
     {
 
@@ -318,7 +317,6 @@ class CppMangleVisitor : public Visitor
             }
         }
     }
-
 
     void mangle_function(FuncDeclaration *d)
     {
@@ -389,7 +387,7 @@ class CppMangleVisitor : public Visitor
             t->mutableOf()->accept(mangler);
         else
             t->accept(mangler);
-
+        mangler->is_top_level = false;
         return 0;
     }
 
@@ -406,7 +404,7 @@ class CppMangleVisitor : public Visitor
 
 public:
     CppMangleVisitor()
-        : buf(), components()
+        : buf(), components(), is_top_level(false)
     {
     }
 
@@ -444,7 +442,6 @@ public:
 
     void visit(TypeBasic *t)
     {
-        is_top_level = false;
         /* ABI spec says:
          * v        void
          * w        wchar_t
@@ -516,9 +513,6 @@ public:
             }
         }
 
-        if (t->isShared())
-            buf.writeByte('V'); //shared -> volatile
-
         if (t->isConst())
             buf.writeByte('K');
 
@@ -545,7 +539,6 @@ public:
         //buf.printf("Dv%llu_", ((TypeSArray *)t->basetype)->dim->toInteger());// -- Gnu ABI v.4
         buf.writestring("U8__vector"); //-- Gnu ABI v.3
         t->basetype->nextOf()->accept(this);
-
     }
 
     void visit(TypeSArray *t)
@@ -561,7 +554,6 @@ public:
             buf.writeByte('K');
         buf.printf("A%llu_", t->dim ? t->dim->toInteger() : 0);
         t->next->accept(this);
-
     }
 
     void visit(TypeDArray *t)
@@ -587,8 +579,6 @@ public:
         buf.writeByte('P');
         t->next->accept(this);
         store(t);
-
-
     }
 
     void visit(TypeReference *t)
@@ -636,8 +626,6 @@ public:
         argsCppMangle(t->parameters, t->varargs);
         buf.writeByte('E');
         store(t);
-
-
     }
 
     void visit(TypeDelegate *t)
@@ -675,8 +663,6 @@ public:
     {
         is_top_level = false;
         if (substitute(t)) return;
-        if (t->isShared())
-            buf.writeByte('V');
         if (t->isConst())
             buf.writeByte('K');
 
@@ -693,7 +679,6 @@ public:
 
         if (t->isConst())
             store(t);
-
     }
 
     void visit(TypeTypedef *t)

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -46,7 +46,7 @@ else
 
         struct Boo(X)
         {
-            struct Xoo(Y) 
+            struct Xoo(Y)
             {
                 Y* v;
             };
@@ -85,7 +85,7 @@ else
 
         private void test14();
         public void test15();
-        protected void test16();   
+        protected void test16();
 
         private static void test17();
         public static void test18();
@@ -106,7 +106,7 @@ else
 
     int test23(Test10*, Test10, Test10**, const(Test10));
     int test23b(const Test10*, const Test10, Test10);
-    
+
     void test24(int function(int,int));
 
     void test25(int[291][6][5]* arr);
@@ -128,7 +128,7 @@ else
     {
         public static void imports(Module);
         public static int dim(Array!Module*);
-    }; 
+    };
 
     void main()
     {
@@ -140,13 +140,13 @@ else
         Goo goo;
         goo.test6(Goo.Foo!(Goo.Boo!(Goo.Foo!(void)))());
         goo.test7(Goo.Boo!(void).Xoo!(int)());
-        
+
         test8(P1.Mem!int(), P2.Mem!int());
         test9(Foo!(int**)(), Foo!(int*)(), null, null);
-        
+
         auto t10 = Test10Ctor();
         scope(exit) Test10Dtor(t10);
-        
+
         t10.test10();
         t10.test11();
         t10.test12();
@@ -157,28 +157,28 @@ else
         t10.test17();
         t10.test18();
         t10.test19();
-        
+
         assert(Test20.test20 == 20);
         assert(Test20.test21 == 21);
         assert(Test20.test22 == 22);
-        
+
         assert(test23(null, null, null, null) == 1);
         assert(test23b(null, null, null) == 1);
-        
+
         extern(C++) static int cb(int a, int b){return a+b;}
-        
+
         test24(&cb);
         int[291][6][5] arr;
         arr[1][1][1] = 42;
         test25(&arr);
         assert(test26(&arr[0]) == 42);
-        
+
         test27(3,4,5);
         test28(3);
-        
+
         test29(3.14f);
         test30(3.14f);
-        
+
         auto t32 = &Module.imports;
         Array!Module arr2;
         arr2.dim = 20;

--- a/test/runnable/externmangle2.d
+++ b/test/runnable/externmangle2.d
@@ -12,13 +12,13 @@ else
 
     struct Test32NS1
     {
-        struct Foo(X) 
+        struct Foo(X)
         {
             X *v;
         }
 
 
-        struct Bar(X) 
+        struct Bar(X)
         {
             X *v;
         }
@@ -27,7 +27,7 @@ else
 
     struct Test32NS2
     {
-        struct Foo(X) 
+        struct Foo(X)
         {
             X *v;
         }
@@ -103,12 +103,24 @@ else
 
     version(none)
     {
-        version(Posix) //Only for g++ with -std=c++0x
+        version(Posix) //Only for g++ with -std=c++0x and Visual Studio 2013+
         {
 
             struct Test40(T, V...)
             {
-                
+
+            }
+
+            void test40(Test40!(int, double, void))
+            {
+            }
+        }
+        else version(Win64) //Only for g++ with -std=c++0x and Visual Studio 2013+
+        {
+
+            struct Test40(T, V...)
+            {
+
             }
 
             void test40(Test40!(int, double, void))
@@ -116,6 +128,16 @@ else
             }
         }
     }
+
+
+    __gshared extern const XXX test41;
+    struct Test42
+    {
+        __gshared extern const XXX test42;
+    }
+    __gshared extern int[4] test43;
+    const(XXX) test44();
+
     void main()
     {
         test32a(Test32!(Test32NS1.Foo, Test32NS1.Foo)());
@@ -125,14 +147,18 @@ else
 
         //test33a(null, null);
         //test33(null, Test33!(test33a, test33a)(), null);
-        
+
         //test34(Test34!(Test34A.foo)());
-        
+
         assert(test36 == 36);
-        
+
         //test37(Test37!(test36)());
         //test38(Test37!(Test37A.t38)());
         test39(Test39.T39A!(.T39A)());
-        
+
+        assert(test41 is null);
+        assert(Test42.test42 is null);
+        assert(test43 == [1, 2, 3, 4]);
+        auto ptr = &test44;
     }
 }

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -142,12 +142,12 @@ int Test20::test20 = 20;
 int Test20::test21 = 21;
 int Test20::test22 = 22;
 
-int test23(Test10**, Test10*, Test10***, const Test10*)
+int test23(Test10**, Test10*, Test10***, Test10 const *const)
 {
     return 1;
 }
 
-int test23b(const Test10**, const Test10*, Test10*)
+int test23b(Test10 const *const *const,  Test10 const* const, Test10*)
 {
     return 1;
 }

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -1,16 +1,16 @@
 
 
 template<class X>
-struct Foo 
+struct Foo
 {
-	X *v;
+    X *v;
 };
 
 template<class X>
-struct Boo 
+struct Boo
 {
-	X *v;
-}; 
+    X *v;
+};
 
 void test1(Foo<int> arg1)
 {
@@ -25,7 +25,7 @@ template<int X, int Y>
 struct Test3
 {
 
-}; 
+};
 
 void test3(Test3<3,3> arg1)
 {
@@ -42,26 +42,26 @@ void test5(Foo<int*> arg1, Boo<int*> arg2, Boo<int*> arg3)
 struct Goo
 {
 
-	template<class X>
-	struct Foo 
-	{
-		X* v;
-	};
+    template<class X>
+    struct Foo
+    {
+        X* v;
+    };
 
-	template<class X>
-	struct Boo 
-	{
-		template<class Y>
-		struct Xoo 
-		{
-			Y* v;
-		};
-		X* v;
-	}; 
+    template<class X>
+    struct Boo
+    {
+        template<class Y>
+        struct Xoo
+        {
+            Y* v;
+        };
+        X* v;
+    };
 
 
-	void test6(Foo<Boo<Foo<void> > > arg1);
-	void test7(Boo<void>::Xoo<int> arg1);
+    void test6(Foo<Boo<Foo<void> > > arg1);
+    void test7(Boo<void>::Xoo<int> arg1);
 };
 
 void Goo::test6(Goo::Foo<Goo::Boo<Goo::Foo<void> > > arg1)
@@ -74,18 +74,18 @@ void Goo::test7(Goo::Boo<void>::Xoo<int> arg1)
 
 struct P1
 {
-	template<class T>
-	struct Mem
-	{
-	};
+    template<class T>
+    struct Mem
+    {
+    };
 };
 
 struct P2
 {
-	template<class T>
-	struct Mem
-	{
-	};
+    template<class T>
+    struct Mem
+    {
+    };
 };
 
 void test8(P1::Mem<int>, P2::Mem<int>){}
@@ -102,7 +102,7 @@ class Test10
 
     private: virtual void test14();
     public: virtual void test15();
-    protected: virtual void test16();   
+    protected: virtual void test16();
 
     private: static void test17();
     public: static void test18();
@@ -122,14 +122,14 @@ void Test10Dtor(Test10*& ptr)
 
 void Test10::test10(){}
 void Test10::test11(){}
-void Test10::test12(){} 
-void Test10::test13() const{} 
+void Test10::test12(){}
+void Test10::test13() const{}
 void Test10::test14(){}
 void Test10::test15(){}
-void Test10::test16(){} 
+void Test10::test16(){}
 void Test10::test17(){}
 void Test10::test18(){}
-void Test10::test19(){} 
+void Test10::test19(){}
 
 struct Test20
 {
@@ -179,10 +179,10 @@ struct Array
 
 class Module
 {
-public: 
+public:
     static void imports(Module*);
     static int dim(Array<Module*>*);
-}; 
+};
 
 
 void Module::imports(Module*)

--- a/test/runnable/extra-files/externmangle2.cpp
+++ b/test/runnable/extra-files/externmangle2.cpp
@@ -1,33 +1,33 @@
 
 struct Test32NS1
 {
-	template<class X>
-	struct Foo 
-	{
-		X *v;
-	};
+    template<class X>
+    struct Foo
+    {
+        X *v;
+    };
 
-	template<class X>
-	struct Bar 
-	{
-		X *v;
-	};
+    template<class X>
+    struct Bar
+    {
+        X *v;
+    };
 
 };
 
 struct Test32NS2
 {
-	template<class X>
-	struct Foo 
-	{
-		X *v;
-	};
+    template<class X>
+    struct Foo
+    {
+        X *v;
+    };
 };
 
 template <template <class X> class Y, template <class X> class Z>
 struct Test32
 {
-	Y<int>* field;
+    Y<int>* field;
 };
 
 
@@ -101,10 +101,10 @@ void test38(Test37<Test37A::t38> arg)
 
 struct Test39
 {
-	template <class X>
-	struct T39A
-	{
-	};
+    template <class X>
+    struct T39A
+    {
+    };
 };
 
 struct T39A
@@ -115,14 +115,31 @@ void test39(Test39::T39A< ::T39A >)
 {
 }
 
-#if 0 //only for g++ with -std=c++0x
-    #ifdef __GNUG__
-        template<class... VarArg> struct Test40
-        {
-        };
+#if 0 //only for g++ with -std=c++0x and Visual C++ >= 2013
+    #if defined(__GNUG__) || (defined(_MSC_VER) && _MSC_VER >= 1200)
+    template<class... VarArg> struct Test40
+    {
+    };
 
-        void test40(Test40<int, double, void> arg)
-        {
-        }
+    void test40(Test40<int, double, void> arg)
+    {
+    }
     #endif
+
+
 #endif
+
+
+extern XXX const * const  test41 = 0;
+
+namespace Test42
+{
+    extern XXX const * const  test42 = 0;
+}
+
+int test43[4] = {1, 2, 3, 4};
+
+XXX const* const test44()
+{
+    return new XXX;
+}


### PR DESCRIPTION
This PR is following the next goals:
1. Fix mangling for constant classes. D `const(Foo)` should be mapped to C++ `Foo const * const`, however g++ mangling rules say that top const-modifier should be discarded. Thus `void foo(Foo const * const)` and `void foo(Foo const *)` have a same mangle.
2. Get whitespaces in order: remove trailing whitespaces, change `Type* var` to `Type *var`.
3. Remove remainig cases of D `shared` to C++ `volatile` mappings.
4. Add some asserts (small reassurance).
5. Add disabled test to check the D variadic templates to С++11 variadic templates mapping. (It really works, but I have not decided make this test mandatory yet.)
6. Add test for a global static array variable.
