### PR TITLE
[REG2.065a] Issue 12016 - implicit immutable upcast becomes null in CTFE

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1754,10 +1754,11 @@ Expression *ctfeCast(Loc loc, Type *type, Type *to, Expression *e)
     if (e->op == TOKnull)
         return paintTypeOntoLiteral(to, e);
     if (e->op == TOKclassreference)
-    {   // Disallow reinterpreting class casts. Do this by ensuring that
+    {
+        // Disallow reinterpreting class casts. Do this by ensuring that
         // the original class can implicitly convert to the target class
         ClassDeclaration *originalClass = ((ClassReferenceExp *)e)->originalClass();
-        if (originalClass->type->implicitConvTo(to))
+        if (originalClass->type->implicitConvTo(to->mutableOf()))
             return paintTypeOntoLiteral(to, e);
         else
             return new NullExp(loc, to);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4140,6 +4140,22 @@ int classtest3()
 static assert(classtest3());
 
 /**************************************************
+    12016 class cast and qualifier reinterpret
+**************************************************/
+
+class B12016 { }
+
+class C12016 : B12016 { }
+
+bool f12016(immutable B12016 b)
+{
+    assert(b);
+    return true;
+}
+
+static assert(f12016(new immutable C12016));
+
+/**************************************************
     11587 AA compare
 **************************************************/
 


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12016

It is an interpreter bug that revealed by the change #2749.
