### PR TITLE
[refactor] Generate C main directly instead of invoking the parser

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -294,22 +294,6 @@ void Module::genobjfile(int multiobj)
 
     //printf("Module::genobjfile(multiobj = %d) %s\n", multiobj, toChars());
 
-    if (ident == Id::entrypoint)
-    {
-        char v = global.params.verbose;
-        global.params.verbose = 0;
-
-        for (size_t i = 0; i < members->dim; i++)
-        {
-            Dsymbol *member = (*members)[i];
-            //printf("toObjFile %s %s\n", member->kind(), member->toChars());
-            member->toObjFile(global.params.multiobj);
-        }
-
-        global.params.verbose = v;
-        return;
-    }
-
     lastmname = srcfile->toChars();
 
     objmod->initfile(lastmname, NULL, toPrettyChars());

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -274,7 +274,6 @@ Msgtable msgtable[] =
     { "WinMain" },
     { "DllMain" },
     { "tls_get_addr", "___tls_get_addr" },
-    { "entrypoint", "__entrypoint" },
 
     // varargs implementation
     { "va_argsave_t", "__va_argsave_t" },

--- a/src/import.c
+++ b/src/import.c
@@ -273,8 +273,6 @@ void Import::semantic(Scope *sc)
     if (global.params.moduleDeps != NULL &&
         // object self-imports itself, so skip that (Bugzilla 7547)
         !(id == Id::object && sc->module->ident == Id::object) &&
-        // don't list pseudo modules __entrypoint.d, __main.d (Bugzilla 11117, 11164)
-        sc->module->ident != Id::entrypoint &&
         strcmp(sc->module->ident->string, "__main") != 0)
     {
         /* The grammar of the file is:


### PR DESCRIPTION
The way code moves from a bunch of different functions into one should speak for itself, but in case it doesn't:
- If we create a special module we then have to treat it differently
- Less mess means less to remember
- Invoking the parser is just hideous
