### PR TITLE
Implement Target::mangle for target-specific C++ mangling.

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -25,7 +25,6 @@
 #include "enum.h"
 #include "import.h"
 #include "aggregate.h"
-#include "target.h"
 
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
 
@@ -477,7 +476,7 @@ public:
             case Tint64:    c = 'x';        break;
             case Tuns64:    c = 'y';        break;
             case Tfloat64:  c = 'd';        break;
-            case Tfloat80:  c = (Target::realsize - Target::realpad == 16) ? 'g' : 'e'; break;
+            case Tfloat80:  c = 'e';        break;
             case Tbool:     c = 'b';        break;
             case Tchar:     c = 'c';        break;
             case Twchar:    c = 't';        break;

--- a/src/target.c
+++ b/src/target.c
@@ -154,3 +154,13 @@ unsigned Target::critsecsize()
     return 0;
 }
 
+/***********************************
+ * For a target-specific types, return a string containing the
+ * C++ mangling for the type. In all other cases, return NULL.
+ */
+
+const char *Target::mangle(Type *type)
+{
+    return NULL;
+}
+

--- a/src/target.h
+++ b/src/target.h
@@ -28,6 +28,7 @@ struct Target
     static unsigned alignsize(Type* type);
     static unsigned fieldalign(Type* type);
     static unsigned critsecsize();
+    static const char *mangle(Type *type);
 };
 
 #endif


### PR DESCRIPTION
Target-specific mangling shouldn't go in cppmangle.

At last check, only TypeStruct, TypeVector or TypeBasic types have target mangling.

TypeStruct - va_list types on ARM and AArch64.
TypeVector - ARM and various other archs may mangle this specially.
TypeBasic - Platforms that support __float128 as "g"
