### PR TITLE
Issue 12051 - Wrong code with ?: resulting in char on x86-64

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -1951,6 +1951,8 @@ code *cdcond(elem *e,regm_t *pretregs)
         {
             v1 -= v2;
             c = genc2(c,opcode,grex | modregrmx(3,4,reg),v1);   // AND reg,v1-v2
+            if (I64 && sz1 == 1 && reg >= 4)
+                code_orrex(c, REX);
             if (v2 == 1 && !I64)
                 gen1(c,0x40 + reg);                     // INC reg
             else if (v2 == -1L && !I64)

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1038,6 +1038,25 @@ void test10678()
 
 ////////////////////////////////////////////////////////////////////////
 
+struct S12051
+{
+    this(char c)
+    {
+        assert(c == 'P' || c == 'M');
+    }
+}
+
+void test12051()
+{
+    auto ip = ["abc"];
+    foreach (i, s; ip)
+    {
+        S12051(i < ip.length ? 'P' : 'M');
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+
 void bug7565( double x) { assert(x == 3); }
 
 void test7565()
@@ -1073,6 +1092,7 @@ int main()
     test8658();
     testfastudiv();
     testfastdiv();
+    test12051();
     testdocond();
     testnegcom();
     test11565();


### PR DESCRIPTION
Another one like [bug 11565](https://d.puremagic.com/issues/show_bug.cgi?id=11565)

The optimizer turns
`c ? a : b`
into
`(0 - cast(bool)c) & (a - b) + b`
but forgets to put the correct prefix on the `and` instruction, leading to it accessing the wrong register sometimes, depending on which register is allocated.

https://d.puremagic.com/issues/show_bug.cgi?id=12051
