### PR TITLE
[REG2.065a] Issue 12047 - UDAs are not checked

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1661,35 +1661,79 @@ Dsymbol *UserAttributeDeclaration::syntaxCopy(Dsymbol *s)
     return new UserAttributeDeclaration(atts, Dsymbol::arraySyntaxCopy(decl));
 }
 
-void UserAttributeDeclaration::semantic(Scope *sc)
+void UserAttributeDeclaration::setScope(Scope *sc)
 {
-    //printf("UserAttributeDeclaration::semantic() %p\n", this);
-
-    /* Bugzilla 11844: Delay semantic analysis for UDAs.
-     * If attrs needs CTFE or template instantiation, they may not have
-     * valid scope yet for their fwdref resolution.
-     * Therefore running semantic analysis here is too early.
-     */
-    //arrayExpressionSemantic(atts, sc);
-
+    //printf("UserAttributeDeclaration::setScope() %p\n", this);
     if (decl)
     {
+        Dsymbol::setScope(sc);  // for forward reference of UDAs
+
         Scope *newsc = sc;
-#if 1
         if (atts && atts->dim)
         {
             // create new one for changes
-            newsc = new Scope(*sc);
-            newsc->flags &= ~SCOPEfree;
-
-            // Create new uda that is the concatenation of the previous
-            newsc->userAttributes = concat(newsc->userAttributes, atts);
+            newsc = sc->push();
+            newsc->userAttribDecl = this;
         }
-#endif
         for (size_t i = 0; i < decl->dim; i++)
-        {   Dsymbol *s = (*decl)[i];
+        {
+            Dsymbol *s = (*decl)[i];
+            s->setScope(newsc); // yes, the only difference from semantic()
+        }
+        if (newsc != sc)
+        {
+            sc->offset = newsc->offset;
+            newsc->pop();
+        }
+    }
+}
 
+void UserAttributeDeclaration::semantic(Scope *sc)
+{
+    //printf("UserAttributeDeclaration::semantic() %p\n", this);
+    if (decl)
+    {
+        Scope *newsc = sc;
+        if (atts && atts->dim)
+        {
+            // create new one for changes
+            newsc = sc->push();
+            newsc->userAttribDecl = this;
+        }
+        for (size_t i = 0; i < decl->dim; i++)
+        {
+            Dsymbol *s = (*decl)[i];
             s->semantic(newsc);
+        }
+        if (newsc != sc)
+        {
+            sc->offset = newsc->offset;
+            newsc->pop();
+        }
+    }
+}
+
+void UserAttributeDeclaration::semantic2(Scope *sc)
+{
+    if (decl)
+    {
+        Scope *newsc = sc;
+        if (atts && atts->dim)
+        {
+            if (scope)
+            {
+                scope = NULL;
+                arrayExpressionSemantic(atts, sc);  // run semantic
+            }
+
+            // create new one for changes
+            newsc = sc->push();
+            newsc->userAttribDecl = this;
+        }
+        for (size_t i = 0; i < decl->dim; i++)
+        {
+            Dsymbol *s = (*decl)[i];
+            s->semantic2(newsc);
         }
         if (newsc != sc)
         {
@@ -1718,43 +1762,22 @@ Expressions *UserAttributeDeclaration::concat(Expressions *udas1, Expressions *u
     return udas;
 }
 
-void UserAttributeDeclaration::setScope(Scope *sc)
+Expressions *UserAttributeDeclaration::getAttributes()
 {
-    //printf("UserAttributeDeclaration::setScope() %p\n", this);
-    if (decl)
+    if (scope)
     {
-        Scope *newsc = sc;
-#if 1
-        if (atts && atts->dim)
-        {
-            // create new one for changes
-            newsc = new Scope(*sc);
-            newsc->flags &= ~SCOPEfree;
-
-            // Append new atts to old one
-            if (!newsc->userAttributes || newsc->userAttributes->dim == 0)
-                newsc->userAttributes = atts;
-            else
-            {
-                // Create a tuple that combines them
-                Expressions *exps = new Expressions();
-                exps->push(new TupleExp(Loc(), newsc->userAttributes));
-                exps->push(new TupleExp(Loc(), atts));
-                newsc->userAttributes = exps;
-            }
-        }
-#endif
-        for (size_t i = 0; i < decl->dim; i++)
-        {   Dsymbol *s = (*decl)[i];
-
-            s->setScope(newsc); // yes, the only difference from semantic()
-        }
-        if (newsc != sc)
-        {
-            sc->offset = newsc->offset;
-            newsc->pop();
-        }
+        Scope *sc = scope;
+        scope = NULL;
+        arrayExpressionSemantic(atts, sc);
     }
+
+    Expressions *exps = new Expressions();
+    if (userAttribDecl)
+        exps->push(new TupleExp(Loc(), userAttribDecl->getAttributes()));
+    if (atts && atts->dim)
+        exps->push(new TupleExp(Loc(), atts));
+
+    return exps;
 }
 
 void UserAttributeDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -234,8 +234,10 @@ public:
     UserAttributeDeclaration(Expressions *atts, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);
+    void semantic2(Scope *sc);
     void setScope(Scope *sc);
     static Expressions *concat(Expressions *udas1, Expressions *udas2);
+    Expressions *getAttributes();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();
     void accept(Visitor *v) { v->visit(this); }

--- a/src/class.c
+++ b/src/class.c
@@ -290,12 +290,7 @@ void ClassDeclaration::semantic(Scope *sc)
     {
         isdeprecated = true;
     }
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     if (sc->linkage == LINKcpp)
         cpp = 1;
@@ -611,7 +606,7 @@ void ClassDeclaration::semantic(Scope *sc)
             sc->offset = Target::ptrsize * 2;   // allow room for __vptr and __monitor
         alignsize = Target::ptrsize;
     }
-    sc->userAttributes = NULL;
+    sc->userAttribDecl = NULL;
     structsize = sc->offset;
     Scope scsave = *sc;
     size_t members_dim = members->dim;
@@ -1285,12 +1280,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
     {
         isdeprecated = true;
     }
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     // Expand any tuples in baseclasses[]
     for (size_t i = 0; i < baseclasses->dim; )
@@ -1439,7 +1429,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
     sc->explicitProtection = 0;
 //    structalign = sc->structalign;
     sc->offset = Target::ptrsize * 2;
-    sc->userAttributes = NULL;
+    sc->userAttribDecl = NULL;
     structsize = sc->offset;
     inuse++;
 

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -347,12 +347,7 @@ void TypedefDeclaration::semantic(Scope *sc)
             return;
         }
         storage_class |= sc->stc & STCdeprecated;
-        userAttributes = sc->userAttributes;
-        if (userAttributes)
-        {
-            userAttributesScope = sc;
-            userAttributesScope->setNoFree();
-        }
+        userAttribDecl = sc->userAttribDecl;
     }
     else if (sem == SemanticIn)
     {
@@ -366,7 +361,8 @@ void TypedefDeclaration::semantic2(Scope *sc)
 {
     //printf("TypedefDeclaration::semantic2(%s) sem = %d\n", toChars(), sem);
     if (sem == SemanticDone)
-    {   sem = Semantic2Done;
+    {
+        sem = Semantic2Done;
         basetype->alignment();          // used to detect circular typedef declarations
         if (init)
         {
@@ -491,12 +487,7 @@ void AliasDeclaration::semantic(Scope *sc)
 
     storage_class |= sc->stc & STCdeprecated;
     protection = sc->protection;
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     // Given:
     //  alias foo.bar.abc def;
@@ -824,12 +815,7 @@ void VarDeclaration::semantic(Scope *sc)
     if (storage_class & STCextern && init)
         error("extern symbols cannot have initializers");
 
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     AggregateDeclaration *ad = isThis();
     if (ad)
@@ -1567,7 +1553,8 @@ void VarDeclaration::semantic2(Scope *sc)
         }
     }
     if (init && !toParent()->isFuncDeclaration())
-    {   inuse++;
+    {
+        inuse++;
 #if 0
         ExpInitializer *ei = init->isExpInitializer();
         if (ei)

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -51,8 +51,7 @@ Dsymbol::Dsymbol()
     this->semanticRun = PASSinit;
     this->errors = false;
     this->depmsg = NULL;
-    this->userAttributes = NULL;
-    this->userAttributesScope = NULL;
+    this->userAttribDecl = NULL;
     this->ddocUnittest = NULL;
 }
 
@@ -69,8 +68,7 @@ Dsymbol::Dsymbol(Identifier *ident)
     this->semanticRun = PASSinit;
     this->errors = false;
     this->depmsg = NULL;
-    this->userAttributes = NULL;
-    this->userAttributesScope = NULL;
+    this->userAttribDecl = NULL;
     this->ddocUnittest = NULL;
 }
 
@@ -348,8 +346,9 @@ void Dsymbol::setScope(Scope *sc)
     scope = sc;
     if (sc->depmsg)
         depmsg = sc->depmsg;
-    if (userAttributes)
-        userAttributesScope = sc;
+
+    if (!userAttribDecl)
+        userAttribDecl = sc->userAttribDecl;
 }
 
 void Dsymbol::importAll(Scope *sc)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -137,8 +137,7 @@ public:
     bool errors;                // this symbol failed to pass semantic()
     PASS semanticRun;
     char *depmsg;               // customized deprecation message
-    Expressions *userAttributes;        // user defined attributes from UserAttributeDeclaration
-    Scope *userAttributesScope;
+    UserAttributeDeclaration *userAttribDecl;   // user defined attributes
     UnitTestDeclaration *ddocUnittest; // !=NULL means there's a ddoc unittest associated with this symbol (only use this with ddoc)
 
     Dsymbol();

--- a/src/enum.c
+++ b/src/enum.c
@@ -144,12 +144,7 @@ void EnumDeclaration::semantic(Scope *sc)
 
     if (sc->stc & STCdeprecated)
         isdeprecated = true;
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     parent = sc->parent;
     protection = sc->protection;
@@ -727,8 +722,7 @@ Expression *EnumMember::getVarExp(Loc loc, Scope *sc)
 
         vd->protection = ed->isAnonymous() ? ed->protection : PROTpublic;
         vd->parent = ed->isAnonymous() ? ed->parent : ed;
-        vd->userAttributes = ed->isAnonymous() ? ed->userAttributes : NULL;
-        vd->userAttributesScope = ed->isAnonymous() ? ed->userAttributesScope : NULL;
+        vd->userAttribDecl = ed->isAnonymous() ? ed->userAttribDecl : NULL;
     }
     Expression *e = new VarExp(loc, vd);
     return e->semantic(sc);

--- a/src/expression.h
+++ b/src/expression.h
@@ -78,6 +78,7 @@ TupleDeclaration *isAliasThisTuple(Expression *e);
 int expandAliasThisTuples(Expressions *exps, size_t starti = 0);
 FuncDeclaration *hasThis(Scope *sc);
 Expression *fromConstInitializer(int result, Expression *e);
+bool arrayExpressionSemantic(Expressions *exps, Scope *sc);
 int arrayExpressionCanThrow(Expressions *exps, bool mustNotThrow);
 TemplateDeclaration *getFuncTemplateDecl(Dsymbol *s);
 Expression *valueNoDtor(Expression *e);

--- a/src/func.c
+++ b/src/func.c
@@ -191,12 +191,7 @@ void FuncDeclaration::semantic(Scope *sc)
     else
         linkage = sc->linkage;
     protection = sc->protection;
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     if (!originalType)
         originalType = type->syntaxCopy();
@@ -1049,7 +1044,7 @@ void FuncDeclaration::semantic3(Scope *sc)
         sc2->tf = NULL;
         sc2->noctor = 0;
         sc2->speculative = sc->speculative || isSpeculative() != NULL;
-        sc2->userAttributes = NULL;
+        sc2->userAttribDecl = NULL;
         if (sc2->intypeof == 1) sc2->intypeof = 2;
         sc2->fieldinit = NULL;
         sc2->fieldinit_dim = 0;
@@ -3912,8 +3907,7 @@ FuncAliasDeclaration::FuncAliasDeclaration(FuncDeclaration *funcalias, bool hasO
         assert(!funcalias->isFuncAliasDeclaration());
         this->hasOverloads = false;
     }
-    userAttributes = funcalias->userAttributes;
-    userAttributesScope = funcalias->userAttributesScope;
+    userAttribDecl = funcalias->userAttribDecl;
 }
 
 const char *FuncAliasDeclaration::kind()

--- a/src/scope.c
+++ b/src/scope.c
@@ -87,7 +87,7 @@ Scope::Scope()
     this->lastdc = NULL;
     this->lastoffset = 0;
     this->docbuf = NULL;
-    this->userAttributes = NULL;
+    this->userAttribDecl = NULL;
 }
 
 Scope::Scope(Scope *enclosing)
@@ -137,7 +137,7 @@ Scope::Scope(Scope *enclosing)
     this->lastdc = NULL;
     this->lastoffset = 0;
     this->docbuf = enclosing->docbuf;
-    this->userAttributes = enclosing->userAttributes;
+    this->userAttribDecl = enclosing->userAttribDecl;
     assert(this != enclosing);
 }
 

--- a/src/scope.h
+++ b/src/scope.h
@@ -26,6 +26,7 @@ class ForeachStatement;
 class ClassDeclaration;
 class AggregateDeclaration;
 class FuncDeclaration;
+class UserAttributeDeclaration;
 struct DocComment;
 class TemplateInstance;
 
@@ -106,7 +107,7 @@ struct Scope
 
     unsigned flags;
 
-    Expressions *userAttributes;        // user defined attributes
+    UserAttributeDeclaration *userAttribDecl;   // user defined attributes
 
     DocComment *lastdc;         // documentation comment for last symbol at this scope
     size_t lastoffset;        // offset in docbuf of where to insert next dec

--- a/src/struct.c
+++ b/src/struct.c
@@ -119,7 +119,8 @@ void AggregateDeclaration::semantic2(Scope *sc)
 {
     //printf("AggregateDeclaration::semantic2(%s)\n", toChars());
     if (scope && members)
-    {   error("has forward references");
+    {
+        error("has forward references");
         return;
     }
     if (members)
@@ -605,12 +606,7 @@ void StructDeclaration::semantic(Scope *sc)
     assert(!isAnonymous());
     if (sc->stc & STCabstract)
         error("structs, unions cannot be abstract");
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     if (sizeok == SIZEOKnone)            // if not already done the addMember step
     {
@@ -631,7 +627,7 @@ void StructDeclaration::semantic(Scope *sc)
     sc2->protection = PROTpublic;
     sc2->explicitProtection = 0;
     sc2->structalign = STRUCTALIGN_DEFAULT;
-    sc2->userAttributes = NULL;
+    sc2->userAttribDecl = NULL;
 
     /* Set scope so if there are forward references, we still might be able to
      * resolve individual members like enums.

--- a/src/traits.c
+++ b/src/traits.c
@@ -576,12 +576,9 @@ Expression *TraitsExp::semantic(Scope *sc)
             goto Lfalse;
         }
         //printf("getAttributes %s, attrs = %p, scope = %p\n", s->toChars(), s->userAttributes, s->userAttributesScope);
-        Expressions *exps;
-        if (!s->userAttributes)
-            s->userAttributes = new Expressions();
-        Scope *sc2 = s->userAttributesScope ? s->userAttributesScope : sc;
-        TupleExp *tup = new TupleExp(loc, s->userAttributes);
-        return tup->semantic(sc2);
+        UserAttributeDeclaration *udad = s->userAttribDecl;
+        TupleExp *tup = new TupleExp(loc, udad ? udad->getAttributes() : new Expressions());
+        return tup->semantic(sc);
     }
     else if (ident == Id::allMembers || ident == Id::derivedMembers)
     {

--- a/test/fail_compilation/fail12047.d
+++ b/test/fail_compilation/fail12047.d
@@ -1,0 +1,21 @@
+// REQUIRED_ARGS: -d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12047.d(15): Error: undefined identifier asdf
+fail_compilation/fail12047.d(16): Error: undefined identifier asdf
+fail_compilation/fail12047.d(17): Error: undefined identifier asdf
+fail_compilation/fail12047.d(18): Error: undefined identifier asdf
+fail_compilation/fail12047.d(19): Error: undefined identifier asdf
+fail_compilation/fail12047.d(20): Error: undefined identifier asdf
+fail_compilation/fail12047.d(21): Error: undefined identifier asdf
+---
+*/
+
+@asdf void func() { }
+@asdf int var = 1;
+@asdf enum E : int { a }
+@asdf struct S {}
+@asdf class C {}
+@asdf interface I {}
+@asdf typedef int myint;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12047

This is also a refactoring change for UDA semantic analysis.
1. Run UDAs in `semantic2` phase.
   Currently forward reference resolution mechanism is not perfect. UDAs often depends on other declarations in user code. Therefore analysing them in semantic1 phase would easily hit fwdref issues.
   On the other hand, if UDAs are not checked for conditional compilation, essentially they have no effect for final execution code. So, I think moving their analysis timing from semantic1 to semantic2 is not a problem.
2. Each `Dsymbol`s now have a pointer to the enclosing `UserAttributeDeclaration`.
   We can use `UserAttributeDeclaration::scope` for forward reference resolution of UDAs. So we can elide `Dsymbol::userAttributesScope`.
