### PR TITLE
[DDMD] [refactor] Move Expression::apply into a visitor class

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -13,6 +13,7 @@
 
 #include "mars.h"
 #include "expression.h"
+#include "visitor.h"
 
 
 /**************************************
@@ -26,127 +27,139 @@
  * Creating an iterator for this would be much more complex.
  */
 
+class PostorderExpressionVisitor : public StoppableVisitor
+{
+public:
+    StoppableVisitor *v;
+    PostorderExpressionVisitor(StoppableVisitor *v) : v(v) {}
+
+    bool doCond(Expression *e)
+    {
+        if (!stop && e)
+            e->accept(this);
+        return stop;
+    }
+    bool doCond(Expressions *e)
+    {
+        if (!e)
+            return false;
+        for (size_t i = 0; i < e->dim && !stop; i++)
+            doCond((*e)[i]);
+        return stop;
+    }
+    bool applyTo(Expression *e)
+    {
+        e->accept(v);
+        stop = v->stop;
+        return true;
+    }
+
+    void visit(Expression *e)
+    {
+        applyTo(e);
+    }
+
+    void visit(NewExp *e)
+    {
+        //printf("NewExp::apply(): %s\n", toChars());
+
+        doCond(e->thisexp) || doCond(e->newargs) || doCond(e->arguments) || applyTo(e);
+    }
+
+    void visit(NewAnonClassExp *e)
+    {
+        //printf("NewAnonClassExp::apply(): %s\n", toChars());
+
+        doCond(e->thisexp) || doCond(e->newargs) || doCond(e->arguments) || applyTo(e);
+    }
+
+    void visit(UnaExp *e)
+    {
+        doCond(e->e1) || applyTo(e);
+    }
+
+    void visit(BinExp *e)
+    {
+        doCond(e->e1) || doCond(e->e2) || applyTo(e);
+    }
+
+    void visit(AssertExp *e)
+    {
+        //printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        doCond(e->e1) || doCond(e->msg) || applyTo(e);
+    }
+
+    void visit(CallExp *e)
+    {
+        //printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        doCond(e->e1) || doCond(e->arguments) || applyTo(e);
+    }
+
+    void visit(ArrayExp *e)
+    {
+        //printf("ArrayExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        doCond(e->e1) || doCond(e->arguments) || applyTo(e);
+    }
+
+    void visit(SliceExp *e)
+    {
+        doCond(e->e1) || doCond(e->lwr) || doCond(e->upr) || applyTo(e);
+    }
+
+    void visit(ArrayLiteralExp *e)
+    {
+        doCond(e->elements) || applyTo(e);
+    }
+
+    void visit(AssocArrayLiteralExp *e)
+    {
+        doCond(e->keys) || doCond(e->values) || applyTo(e);
+    }
+
+    void visit(StructLiteralExp *e)
+    {
+        if (e->stageflags & stageApply) return;
+        int old = e->stageflags;
+        e->stageflags |= stageApply;
+        doCond(e->elements) || applyTo(e);
+        e->stageflags = old;
+    }
+
+    void visit(TupleExp *e)
+    {
+        doCond(e->e0) || doCond(e->exps) || applyTo(e);
+    }
+
+    void visit(CondExp *e)
+    {
+        doCond(e->econd) || doCond(e->e1) || doCond(e->e2) || applyTo(e);
+    }
+};
+
+bool walkPostorder(Expression *e, StoppableVisitor *v)
+{
+    PostorderExpressionVisitor pv(v);
+    e->accept(&pv);
+    return v->stop;
+}
+
 int Expression::apply(apply_fp_t fp, void *param)
 {
-    return (*fp)(this, param);
+    class ApplyFpVisitor : public StoppableVisitor
+    {
+        apply_fp_t fp;
+        void *param;
+    public:
+        ApplyFpVisitor(apply_fp_t fp, void *param)
+            : fp(fp), param(param)
+        {
+        }
+        void visit(Expression *e)
+        {
+            stop = (*fp)(e, param);
+        }
+    };
+
+    ApplyFpVisitor v(fp, param);
+    return walkPostorder(this, &v);
 }
-
-/******************************
- * Perform apply() on an t if not null
- */
-#define condApply(t, fp, param) (t ? t->apply(fp, param) : 0)
-
-int NewExp::apply(apply_fp_t fp, void *param)
-{
-    //printf("NewExp::apply(): %s\n", toChars());
-
-    return condApply(thisexp, fp, param) ||
-           condApply(newargs, fp, param) ||
-           condApply(arguments, fp, param) ||
-           (*fp)(this, param);
-}
-
-int NewAnonClassExp::apply(apply_fp_t fp, void *param)
-{
-    //printf("NewAnonClassExp::apply(): %s\n", toChars());
-
-    return condApply(thisexp, fp, param) ||
-           condApply(newargs, fp, param) ||
-           condApply(arguments, fp, param) ||
-           (*fp)(this, param);
-}
-
-int UnaExp::apply(apply_fp_t fp, void *param)
-{
-    return e1->apply(fp, param) ||
-           (*fp)(this, param);
-}
-
-int BinExp::apply(apply_fp_t fp, void *param)
-{
-    return e1->apply(fp, param) ||
-           e2->apply(fp, param) ||
-           (*fp)(this, param);
-}
-
-int AssertExp::apply(apply_fp_t fp, void *param)
-{
-    //printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
-    return e1->apply(fp, param) ||
-           condApply(msg, fp, param) ||
-           (*fp)(this, param);
-}
-
-
-int CallExp::apply(apply_fp_t fp, void *param)
-{
-    //printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
-    return e1->apply(fp, param) ||
-           condApply(arguments, fp, param) ||
-           (*fp)(this, param);
-}
-
-
-int ArrayExp::apply(apply_fp_t fp, void *param)
-{
-    //printf("ArrayExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
-    return e1->apply(fp, param) ||
-           condApply(arguments, fp, param) ||
-           (*fp)(this, param);
-}
-
-
-int SliceExp::apply(apply_fp_t fp, void *param)
-{
-    return e1->apply(fp, param) ||
-           condApply(lwr, fp, param) ||
-           condApply(upr, fp, param) ||
-           (*fp)(this, param);
-}
-
-
-int ArrayLiteralExp::apply(apply_fp_t fp, void *param)
-{
-    return condApply(elements, fp, param) ||
-           (*fp)(this, param);
-}
-
-
-int AssocArrayLiteralExp::apply(apply_fp_t fp, void *param)
-{
-    return condApply(keys, fp, param) ||
-           condApply(values, fp, param) ||
-           (*fp)(this, param);
-}
-
-
-int StructLiteralExp::apply(apply_fp_t fp, void *param)
-{
-    if(stageflags & stageApply) return 0;
-    int old = stageflags;
-    stageflags |= stageApply;
-    int ret = condApply(elements, fp, param) ||
-           (*fp)(this, param);
-    stageflags = old;
-    return ret;
-}
-
-
-int TupleExp::apply(apply_fp_t fp, void *param)
-{
-    return (e0 ? (*fp)(e0, param) : 0) ||
-           condApply(exps, fp, param) ||
-           (*fp)(this, param);
-}
-
-
-int CondExp::apply(apply_fp_t fp, void *param)
-{
-    return econd->apply(fp, param) ||
-           e1->apply(fp, param) ||
-           e2->apply(fp, param) ||
-           (*fp)(this, param);
-}
-
-
-

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1260,7 +1260,7 @@ Expression *Index(Type *type, Expression *e1, Expression *e2)
             e = (*ale->elements)[(size_t)i];
             e->type = type;
             e->loc = loc;
-            if (e->hasSideEffect())
+            if (hasSideEffect(e))
                 e = EXP_CANT_INTERPRET;
         }
     }
@@ -1279,7 +1279,7 @@ Expression *Index(Type *type, Expression *e1, Expression *e2)
             {   e = (*ale->elements)[(size_t)i];
                 e->type = type;
                 e->loc = loc;
-                if (e->hasSideEffect())
+                if (hasSideEffect(e))
                     e = EXP_CANT_INTERPRET;
             }
         }
@@ -1300,7 +1300,7 @@ Expression *Index(Type *type, Expression *e1, Expression *e2)
             {   e = (*ae->values)[i];
                 e->type = type;
                 e->loc = loc;
-                if (e->hasSideEffect())
+                if (hasSideEffect(e))
                     e = EXP_CANT_INTERPRET;
                 break;
             }
@@ -1353,7 +1353,7 @@ Expression *Slice(Type *type, Expression *e1, Expression *lwr, Expression *upr)
     }
     else if (e1->op == TOKarrayliteral &&
             lwr->op == TOKint64 && upr->op == TOKint64 &&
-            !e1->hasSideEffect())
+            !hasSideEffect(e1))
     {   ArrayLiteralExp *es1 = (ArrayLiteralExp *)e1;
         uinteger_t ilwr = lwr->toInteger();
         uinteger_t iupr = upr->toInteger();

--- a/src/expression.c
+++ b/src/expression.c
@@ -7766,7 +7766,7 @@ Expression *DotVarExp::semantic(Scope *sc)
             Expressions *exps = new Expressions;
             Expression *e0 = NULL;
             Expression *ev = e1;
-            if (sc->func && e1->hasSideEffect())
+            if (sc->func && hasSideEffect(e1))
             {
                 Identifier *id = Lexer::uniqueId("__tup");
                 ExpInitializer *ei = new ExpInitializer(e1->loc, e1);
@@ -11467,7 +11467,7 @@ Ltupleassign:
                 Expression *ea = ie->e1;
                 Expression *ek = ie->e2;
                 Expression *ev = e2;
-                if (ea->hasSideEffect())
+                if (hasSideEffect(ea))
                 {
                     VarDeclaration *v = new VarDeclaration(loc, ie->e1->type,
                         Lexer::uniqueId("__aatmp"), new ExpInitializer(loc, ie->e1));
@@ -11478,7 +11478,7 @@ Ltupleassign:
                     e0 = combine(e0, new DeclarationExp(loc, v));
                     ea = new VarExp(loc, v);
                 }
-                if (ek->hasSideEffect())
+                if (hasSideEffect(ek))
                 {
                     VarDeclaration *v = new VarDeclaration(loc, ie->e2->type,
                         Lexer::uniqueId("__aakey"), new ExpInitializer(loc, ie->e2));
@@ -11489,7 +11489,7 @@ Ltupleassign:
                     e0 = combine(e0, new DeclarationExp(loc, v));
                     ek = new VarExp(loc, v);
                 }
-                if (ev->hasSideEffect())
+                if (hasSideEffect(ev))
                 {
                     VarDeclaration *v = new VarDeclaration(loc, e2->type,
                         Lexer::uniqueId("__aaval"), new ExpInitializer(loc, e2));
@@ -13941,7 +13941,7 @@ Expression *PrettyFuncInitExp::resolveLoc(Loc loc, Scope *sc)
 Expression *extractOpDollarSideEffect(Scope *sc, UnaExp *ue)
 {
     Expression *e0 = NULL;
-    if (ue->e1->hasSideEffect())
+    if (hasSideEffect(ue->e1))
     {
         /* Even if opDollar is needed, 'ue->e1' should be evaluate only once. So
          * Rewrite:
@@ -14072,7 +14072,7 @@ Expression *BinExp::reorderSettingAAElem(Scope *sc)
      *     __aatmp[__aakey] op= __aaval;  // assignment
      */
     Expression *ec = NULL;
-    if (ie->e1->hasSideEffect())
+    if (hasSideEffect(ie->e1))
     {
         Identifier *id = Lexer::uniqueId("__aatmp");
         VarDeclaration *vd = new VarDeclaration(ie->e1->loc, ie->e1->type, id, new ExpInitializer(ie->e1->loc, ie->e1));
@@ -14083,7 +14083,7 @@ Expression *BinExp::reorderSettingAAElem(Scope *sc)
         ec = de;
         ie->e1 = new VarExp(ie->e1->loc, vd);
     }
-    if (ie->e2->hasSideEffect())
+    if (hasSideEffect(ie->e2))
     {
         Identifier *id = Lexer::uniqueId("__aakey");
         VarDeclaration *vd = new VarDeclaration(ie->e2->loc, ie->e2->type, id, new ExpInitializer(ie->e2->loc, ie->e2));

--- a/src/expression.h
+++ b/src/expression.h
@@ -126,7 +126,7 @@ public:
     static void init();
     Expression *copy();
     virtual Expression *syntaxCopy();
-    virtual int apply(apply_fp_t fp, void *param);
+    int apply(apply_fp_t fp, void *param);
     virtual Expression *semantic(Scope *sc);
     Expression *trySemantic(Scope *sc);
 
@@ -440,7 +440,6 @@ public:
     TupleExp(Loc loc, Expressions *exps);
     TupleExp(Loc loc, TupleDeclaration *tup);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -464,7 +463,6 @@ public:
     ArrayLiteralExp(Loc loc, Expression *e);
 
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
     int isBool(int result);
@@ -493,7 +491,6 @@ public:
     AssocArrayLiteralExp(Loc loc, Expressions *keys, Expressions *values);
     bool equals(RootObject *o);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     int isBool(int result);
     elem *toElem(IRState *irs);
@@ -551,7 +548,6 @@ public:
     static StructLiteralExp *create(Loc loc, StructDeclaration *sd, void *elements, Type *stype = NULL);
     bool equals(RootObject *o);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     Expression *getField(Type *type, unsigned offset);
     int getFieldIndex(Type *type, unsigned offset);
@@ -630,7 +626,6 @@ public:
     NewExp(Loc loc, Expression *thisexp, Expressions *newargs,
         Type *newtype, Expressions *arguments);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     Expression *optimize(int result, bool keepLvalue = false);
@@ -655,7 +650,6 @@ public:
     NewAnonClassExp(Loc loc, Expression *thisexp, Expressions *newargs,
         ClassDeclaration *cd, Expressions *arguments);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }
@@ -851,7 +845,6 @@ public:
 
     UnaExp(Loc loc, TOK op, int size, Expression *e1);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Expression *optimize(int result, bool keepLvalue = false);
@@ -878,7 +871,6 @@ public:
 
     BinExp(Loc loc, TOK op, int size, Expression *e1, Expression *e2);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     Expression *semanticp(Scope *sc);
     Expression *checkComplexOpAssign(Scope *sc);
@@ -952,7 +944,6 @@ public:
 
     AssertExp(Loc loc, Expression *e, Expression *msg = NULL);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
@@ -1065,7 +1056,6 @@ public:
     static CallExp *create(Loc loc, Expression *e, Expression *earg1);
 
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result, bool keepLvalue = false);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
@@ -1224,7 +1214,6 @@ public:
 
     SliceExp(Loc loc, Expression *e1, Expression *lwr, Expression *upr);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     void checkEscape();
     void checkEscapeRef();
@@ -1270,7 +1259,6 @@ public:
 
     ArrayExp(Loc loc, Expression *e1, Expressions *arguments);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -1731,7 +1719,6 @@ public:
 
     CondExp(Loc loc, Expression *econd, Expression *e1, Expression *e2);
     Expression *syntaxCopy();
-    int apply(apply_fp_t fp, void *param);
     Expression *semantic(Scope *sc);
     Expression *optimize(int result, bool keepLvalue = false);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);

--- a/src/expression.h
+++ b/src/expression.h
@@ -92,6 +92,7 @@ IntRange getIntRange(Expression *e);
 bool isArrayOperand(Expression *e);
 Expression *arrayOp(BinExp *e, Scope *sc);
 Expression *arrayOp(BinAssignExp *e, Scope *sc);
+bool hasSideEffect(Expression *e);
 
 /* Run CTFE on the expression, but allow the expression to be a TypeExp
  * or a tuple containing a TypeExp. (This is required by pragma(msg)).
@@ -190,7 +191,6 @@ public:
 
     virtual int isConst();
     virtual int isBool(int result);
-    bool hasSideEffect();
     void discardValue();
     void useValue();
     bool canThrow(bool mustNotThrow);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8290,7 +8290,7 @@ Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident, int 
 
         Expression *e0 = NULL;
         Expression *ev = e->op == TOKtype ? NULL : e;
-        if (sc->func && ev && ev->hasSideEffect())
+        if (sc->func && ev && hasSideEffect(ev))
         {
             Identifier *id = Lexer::uniqueId("__tup");
             ExpInitializer *ei = new ExpInitializer(e->loc, ev);
@@ -8867,7 +8867,7 @@ Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
 
         Expression *e0 = NULL;
         Expression *ev = e->op == TOKtype ? NULL : e;
-        if (sc->func && ev && ev->hasSideEffect())
+        if (sc->func && ev && hasSideEffect(ev))
         {
             Identifier *id = Lexer::uniqueId("__tup");
             ExpInitializer *ei = new ExpInitializer(e->loc, ev);

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -939,7 +939,7 @@ Expression *CommaExp::optimize(int result, bool keepLvalue)
     e2 = e2->optimize(result, keepLvalue);
     if (e1->op == TOKerror)
         return e1;
-    if (!e1 || e1->op == TOKint64 || e1->op == TOKfloat64 || !e1->hasSideEffect())
+    if (!e1 || e1->op == TOKint64 || e1->op == TOKfloat64 || !hasSideEffect(e1))
     {
         e = e2;
         if (e)

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -236,21 +236,6 @@ struct Array
         memcpy(a->data, data, dim * sizeof(*data));
         return a;
     }
-
-    typedef int (*Array_apply_ft_t)(TYPE, void *);
-    int apply(Array_apply_ft_t fp, void *param)
-    {
-        for (size_t i = 0; i < dim; i++)
-        {   TYPE e = (*this)[i];
-
-            if (e)
-            {
-                if (e->apply(fp, param))
-                    return 1;
-            }
-        }
-        return 0;
-    }
 };
 
 #endif


### PR DESCRIPTION
I've only moved the first few `apply` consumers in this pull, because there are lots and I still have to work out what to do with the ones in interpret.c.

The old apply api is supported with a trivial wrapper visitor in `Expression::apply` for now.
