### PR TITLE
Disambiguate type names for templates and arrays in cv8 debug symbols.

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -638,7 +638,7 @@ public:
     int getLevel(Loc loc, Scope *sc, FuncDeclaration *fd); // lexical nesting level difference
     void appendExp(Expression *e);
     void appendState(Statement *s);
-    const char *toPrettyChars();
+    const char *toPrettyChars(bool QualifyTypes = false);
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
     bool isMain();
     bool isWinMain();
@@ -725,7 +725,7 @@ public:
 
     FuncLiteralDeclaration *isFuncLiteralDeclaration() { return this; }
     const char *kind();
-    const char *toPrettyChars();
+    const char *toPrettyChars(bool QualifyTypes = false);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/doc.c
+++ b/src/doc.c
@@ -1298,7 +1298,8 @@ void toDocBuffer(Dsymbol *s, OutBuffer *buf, Scope *sc)
                 if (ed->memtype)
                 {
                     buf->writestring(": $(DDOC_ENUM_BASETYPE ");
-                    ed->memtype->toCBuffer(buf, NULL, NULL);
+                    HdrGenState hgs;
+                    ed->memtype->toCBuffer(buf, NULL, &hgs);
                     buf->writestring(")");
                 }
                 buf->writestring(";\n");

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -208,7 +208,12 @@ char *Dsymbol::toChars()
     return ident ? ident->toChars() : (char *)"__anonymous";
 }
 
-const char *Dsymbol::toPrettyChars()
+char *Dsymbol::toPrettyCharsHelper()
+{
+    return toChars();
+}
+
+const char *Dsymbol::toPrettyChars(bool QualifyTypes)
 {   Dsymbol *p;
     char *s;
     char *q;
@@ -220,14 +225,14 @@ const char *Dsymbol::toPrettyChars()
 
     len = 0;
     for (p = this; p; p = p->parent)
-        len += strlen(p->toChars()) + 1;
+        len += strlen(QualifyTypes ? p->toPrettyCharsHelper() : p->toChars()) + 1;
 
     s = (char *)mem.malloc(len);
     q = s + len - 1;
     *q = 0;
     for (p = this; p; p = p->parent)
     {
-        char *t = p->toChars();
+        char *t = QualifyTypes ? p->toPrettyCharsHelper() : p->toChars();
         len = strlen(t);
         q -= len;
         memcpy(q, t, len);

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -151,6 +151,7 @@ public:
     Dsymbol(Identifier *);
     static Dsymbol *create(Identifier *);
     char *toChars();
+    virtual char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc& getLoc();
     char *locToChars();
     bool equals(RootObject *o);
@@ -175,7 +176,7 @@ public:
     static Dsymbols *arraySyntaxCopy(Dsymbols *a);
 
     virtual Identifier *getIdent();
-    virtual const char *toPrettyChars();
+    virtual const char *toPrettyChars(bool QualifyTypes = false);
     virtual const char *kind();
     virtual Dsymbol *toAlias();                 // resolve real symbol
     virtual int apply(Dsymbol_apply_ft_t fp, void *param);

--- a/src/func.c
+++ b/src/func.c
@@ -3285,12 +3285,12 @@ void FuncDeclaration::appendState(Statement *s)
     }
 }
 
-const char *FuncDeclaration::toPrettyChars()
+const char *FuncDeclaration::toPrettyChars(bool QualifyTypes)
 {
     if (isMain())
         return "D main";
     else
-        return Dsymbol::toPrettyChars();
+        return Dsymbol::toPrettyChars(QualifyTypes);
 }
 
 /** for diagnostics, e.g. 'int foo(int x, int y) pure' */
@@ -4249,15 +4249,15 @@ void FuncLiteralDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     }
 }
 
-const char *FuncLiteralDeclaration::toPrettyChars()
+const char *FuncLiteralDeclaration::toPrettyChars(bool QualifyTypes)
 {
     if (parent)
     {
         TemplateInstance *ti = parent->isTemplateInstance();
         if (ti)
-            return ti->tempdecl->toPrettyChars();
+            return ti->tempdecl->toPrettyChars(QualifyTypes);
     }
-    return Dsymbol::toPrettyChars();
+    return Dsymbol::toPrettyChars(QualifyTypes);
 }
 
 /********************************* CtorDeclaration ****************************/

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -936,18 +936,18 @@ public:
     {
         TemplateInstance *ti = t->sym->parent->isTemplateInstance();
         if (ti && ti->toAlias() == t->sym)
-            buf->writestring(ti->toChars());
+            buf->writestring((hgs->fullQualification) ? ti->toPrettyChars() : ti->toChars());
         else
-            buf->writestring(t->sym->toChars());
+            buf->writestring((hgs->fullQualification) ? t->sym->toPrettyChars() : t->sym->toChars());
     }
 
     void visit(TypeClass *t)
     {
         TemplateInstance *ti = t->sym->parent->isTemplateInstance();
         if (ti && ti->toAlias() == t->sym)
-            buf->writestring(ti->toChars());
+            buf->writestring((hgs->fullQualification) ? ti->toPrettyChars() : ti->toChars());
         else
-            buf->writestring(t->sym->toChars());
+            buf->writestring((hgs->fullQualification) ? t->sym->toPrettyChars() : t->sym->toChars());
     }
 
     void visit(TypeTuple *t)

--- a/src/hdrgen.h
+++ b/src/hdrgen.h
@@ -26,6 +26,7 @@ struct HdrGenState
     int inArrExp;
     int emitInst;
     int autoMember;
+    bool fullQualification; // fully qualify types when printing
 
     struct
     {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1583,6 +1583,17 @@ char *Type::toChars()
     return buf.extractString();
 }
 
+char *Type::toPrettyChars(bool QualifyTypes)
+{
+    OutBuffer buf;
+    buf.reserve(16);
+    HdrGenState hgs;
+    hgs.fullQualification = QualifyTypes;
+
+    toCBuffer(&buf, NULL, &hgs);
+    return buf.extractString();
+}
+
 void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
 {
     ::toCBuffer(this, buf, ident, hgs);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -237,6 +237,7 @@ public:
     int dyncast() { return DYNCAST_TYPE; }
     int covariant(Type *t, StorageClass *pstc = NULL);
     char *toChars();
+    char *toPrettyChars(bool QualifyTypes = false);
     static char needThisPrefix();
     static void init();
 

--- a/src/template.c
+++ b/src/template.c
@@ -7550,6 +7550,16 @@ char *TemplateInstance::toChars()
     return s;
 }
 
+char *TemplateInstance::toPrettyCharsHelper()
+{
+    OutBuffer buf;
+    HdrGenState hgs;
+    hgs.fullQualification = 1;
+    toCBuffer(&buf, &hgs);
+
+    return buf.extractString();
+}
+
 int TemplateInstance::compare(RootObject *o)
 {
     TemplateInstance *ti = (TemplateInstance *)o;

--- a/src/template.h
+++ b/src/template.h
@@ -339,6 +339,7 @@ public:
     const char *kind();
     bool oneMember(Dsymbol **ps, Identifier *ident);
     char *toChars();
+    char* toPrettyCharsHelper();
     void printInstantiationTrace();
     Identifier *getIdent();
     int compare(RootObject *o);

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -54,7 +54,7 @@ public:
     void visit(TypeDArray *t)
     {
         t->ctype = type_dyn_array(Type_toCtype(t->next));
-        t->ctype->Tident = t->toChars(); // needed to generate sensible debug info for cv8
+        t->ctype->Tident = t->toPrettyChars(true);
     }
 
     void visit(TypeAArray *t)
@@ -136,7 +136,7 @@ public:
         else
         {
             StructDeclaration *sym = t->sym;
-            t->ctype = type_struct_class(sym->toPrettyChars(), sym->alignsize, sym->structsize,
+            t->ctype = type_struct_class(sym->toPrettyChars(true), sym->alignsize, sym->structsize,
                     sym->arg1type ? Type_toCtype(sym->arg1type) : NULL,
                     sym->arg2type ? Type_toCtype(sym->arg2type) : NULL,
                     sym->isUnionDeclaration() != 0,

--- a/src/tocvdebug.c
+++ b/src/tocvdebug.c
@@ -299,7 +299,7 @@ void toDebug(TypedefDeclaration *tdd)
         if (tdd->basetype->ty == Ttuple)
             return;
 
-        const char *id = tdd->toPrettyChars();
+        const char *id = tdd->toPrettyChars(true);
         idx_t typidx = cv4_typidx(Type_toCtype(tdd->basetype));
         if (config.fulltypes == CV8)
             cv8_udt(id, typidx);
@@ -331,7 +331,7 @@ void toDebug(EnumDeclaration *ed)
     // If it is a member, it is handled by cvMember()
     if (!ed->isMember())
     {
-        const char *id = ed->toPrettyChars();
+        const char *id = ed->toPrettyChars(true);
         idx_t typidx = cv4_Denum(ed);
         if (config.fulltypes == CV8)
             cv8_udt(id, typidx);
@@ -416,7 +416,7 @@ void toDebug(StructDeclaration *sd)
 //    if (st->Sopeq && !(st->Sopeq->Sfunc->Fflags & Fnodebug))
 //      property |= 0x20;               // class has overloaded assignment
 
-    const char *id = sd->toPrettyChars();
+    const char *id = sd->toPrettyChars(true);
 
     unsigned leaf = sd->isUnionDeclaration() ? LF_UNION : LF_STRUCTURE;
     if (config.fulltypes == CV8)
@@ -581,7 +581,7 @@ void toDebug(ClassDeclaration *cd)
 //    if (st->Sopeq && !(st->Sopeq->Sfunc->Fflags & Fnodebug))
 //      property |= 0x20;               // class has overloaded assignment
 
-    const char *id = cd->isCPPinterface() ? cd->ident->toChars() : cd->toPrettyChars();
+    const char *id = cd->isCPPinterface() ? cd->ident->toChars() : cd->toPrettyChars(true);
     unsigned leaf = config.fulltypes == CV8 ? LF_CLASS_V3 : LF_CLASS;
 
     unsigned numidx = (leaf == LF_CLASS_V3) ? 18 : 12;


### PR DESCRIPTION
Currently dmd will use the same type name in cv8 debug symbols for multiple different types, because instead of using the fully qualified type name, it uses a short form.

The following code will trigger this issue

```
class Hashmap(K,V)
{
  static struct Pair {
    K key;
    V value;
  }

  Pair[] m_Data;
}

void main(string[] args)
{  
  auto p = new Hashmap!(int, int)();
  auto p2 = new Hashmap!(float, float)();
}
```

When compiling this code for windows x64 and then inspecting the resulting .pdb with Dia2Dump there will be two definitions of a type named "Pair[]". This then confuses the debugger. After the fix, the types will be named "main.Hashmap!(int, int).Pair[]" and "main.Hashmap!(float, float).Pair[]" respectivly.

This fix should apply to any debugger, visual studio specific improvements for the cv8 debug symbols will follow in another pull request.
