### PR TITLE
Added optimization of debug symbols for microsoft debuggers to -gc

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -48,7 +48,7 @@ void out_config_init(
                         // 1: D
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
-        bool stackstomp // add stack stomping code
+        bool stackstomp         // add stack stomping code
         )
 {
 #if MARS
@@ -193,6 +193,8 @@ void out_config_init(
         {
             configv.addlinenumbers = 1;
             config.fulltypes = CV8;
+            if(symdebug > 1)
+                config.flags2 |= CFG2gms;
         }
         else
         {

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -770,9 +770,10 @@ struct Config
 #define CFG2expand      0x8000  // expanded output to list file
 #define CFG2seh         0x10000 // use Win32 SEH to support any exception handling
 #define CFG2stomp       0x20000 // enable stack stomping code
+#define CFG2gms         0x40000 // optimize debug symbols for microsoft debuggers
 #define CFGX2   (CFG2warniserr | CFG2phuse | CFG2phgen | CFG2phauto | \
                  CFG2once | CFG2hdrdebug | CFG2noobj | CFG2noerrmax | \
-                 CFG2expand | CFG2nodeflib | CFG2stomp)
+                 CFG2expand | CFG2nodeflib | CFG2stomp | CFG2gms)
     unsigned flags3;
 #define CFG3ju          1       // char == unsigned char
 #define CFG3eh          4       // generate exception handling stuff

--- a/src/backend/cgcv.h
+++ b/src/backend/cgcv.h
@@ -60,7 +60,7 @@ int cv_stringbytes(const char *name);
 unsigned cv4_numericbytes(targ_size_t value);
 void cv4_storenumeric(unsigned char *p,targ_size_t value);
 idx_t cv_debtyp ( debtyp_t *d );
-int cv_namestring ( unsigned char *p , const char *name );
+int cv_namestring ( unsigned char *p , const char *name, int length = -1);
 unsigned cv4_typidx(type *t);
 idx_t cv4_arglist(type *t,unsigned *pnparam);
 unsigned char cv4_callconv(type *t);

--- a/src/backend/cv8.c
+++ b/src/backend/cv8.c
@@ -92,6 +92,33 @@ static Outbuffer *linepair;     // array of offset/line pairs
 unsigned cv8_addfile(const char *filename);
 void cv8_writesection(int seg, unsigned type, Outbuffer *buf);
 
+void cv8_writename(Outbuffer *buf, const char* name, size_t len)
+{
+    if(config.flags2 & CFG2gms)
+    {
+        const char* start = name;
+        const char* cur = strchr(start, '.');
+        const char* end = start + len;
+        while(cur != NULL)
+        {
+            if(cur >= end)
+            {
+                buf->writen(start, end - start);
+                return;
+            }
+            buf->writen(start, cur - start);
+            buf->writeByte('@');
+            start = cur + 1;
+            if(start >= end)
+                return;
+            cur = strchr(start, '.');
+        }
+        buf->writen(start, end - start);
+    }
+    else
+        buf->writen(name, len);
+}
+
 /************************************************
  * Called at the start of an object file generation.
  * One source file can generate multiple object files; this starts an object file.
@@ -551,6 +578,7 @@ void cv8_outsym(Symbol *s)
     //printf("typidx = %x\n", typidx);
     const char *id = s->prettyIdent ? s->prettyIdent : prettyident(s);
     size_t len = strlen(id);
+
     if(len > CV8_MAX_SYMBOL_LENGTH)
         len = CV8_MAX_SYMBOL_LENGTH;
 
@@ -587,7 +615,7 @@ void cv8_outsym(Symbol *s)
             buf->write32(s->Soffset + base + BPoff);
             buf->write32(typidx);
             buf->writeWordn(334);       // relative to RBP
-            buf->writen(id, len);
+            cv8_writename(buf, id, len);
             buf->writeByte(0);
 #else
             // This is supposed to work, implicit BP relative addressing, but it does not
@@ -596,7 +624,7 @@ void cv8_outsym(Symbol *s)
             buf->writeWordn(0x1006);
             buf->write32(s->Soffset + base + BPoff);
             buf->write32(typidx);
-            buf->writen(id, len);
+            cv8_writename(buf, id, len);
             buf->writeByte(0);
 #endif
             break;
@@ -623,12 +651,12 @@ void cv8_outsym(Symbol *s)
             buf->writeWordn(S_REGISTER_V3);
             buf->write32(typidx);
             buf->writeWordn(cv8_regnum(s));
-            buf->writen(id, len);
+            cv8_writename(buf, id, len);
             buf->writeByte(0);
             break;
 
         case SCextern:
-            return;
+            break;
 
         case SCstatic:
         case SClocstat:
@@ -661,12 +689,12 @@ void cv8_outsym(Symbol *s)
             buf->write32(0);
             buf->writeWordn(0);
 
-            buf->writen(id, len);
+            cv8_writename(buf, id, len);
             buf->writeByte(0);
             break;
 
         default:
-            return;
+            break;
     }
 }
 
@@ -682,13 +710,14 @@ void cv8_udt(const char *id, idx_t typidx)
     //printf("cv8_udt('%s', %x)\n", id, typidx);
     Outbuffer *buf = currentfuncdata.f1buf;
     size_t len = strlen(id);
+
     if (len > CV8_MAX_SYMBOL_LENGTH)
         len = CV8_MAX_SYMBOL_LENGTH;
     buf->reserve(2 + 2 + 4 + len + 1);
     buf->writeWordn( 2 + 4 + len + 1);
     buf->writeWordn(S_UDT_V3);
     buf->write32(typidx);
-    buf->writen(id, len);
+    cv8_writename(buf, id, len);
     buf->writeByte(0);
 }
 
@@ -762,6 +791,7 @@ idx_t cv8_fwdref(Symbol *s)
     }
     unsigned len = numidx + cv4_numericbytes(0);
     int idlen = strlen(s->Sident);
+
     if (idlen > CV8_MAX_SYMBOL_LENGTH)
         idlen = CV8_MAX_SYMBOL_LENGTH;
 
@@ -776,10 +806,11 @@ idx_t cv8_fwdref(Symbol *s)
         TOLONG(d->data + 14, 0);        // vshape
     }
     cv4_storenumeric(d->data + numidx, 0);
-    memcpy(d->data + len, s->Sident, idlen);
+    cv_namestring(d->data + len, s->Sident, idlen); 
     d->data[len + idlen] = 0;
     idx_t typidx = cv_debtyp(d);
     s->Stypidx = typidx;
+
     return typidx;
 }
 
@@ -857,6 +888,7 @@ idx_t cv8_darray(type *t, idx_t etypidx)
     }
 
     int idlen = strlen(id);
+
     if (idlen > CV8_MAX_SYMBOL_LENGTH)
         idlen = CV8_MAX_SYMBOL_LENGTH;
 
@@ -868,7 +900,7 @@ idx_t cv8_darray(type *t, idx_t etypidx)
     TOLONG(d->data + 10, 0);    // dList
     TOLONG(d->data + 14, 0);    // vtshape
     TOWORD(d->data + 18, 16);   // size
-    memcpy(d->data + 20, id, idlen);
+    cv_namestring(d->data + 20, id, idlen);
     d->data[20 + idlen] = 0;
 
     idx_t top = cv_numdebtypes();

--- a/src/mars.c
+++ b/src/mars.c
@@ -415,7 +415,7 @@ Usage:\n\
   -deps          print module dependencies (imports/file/version/debug/lib)\n\
   -deps=filename write module dependencies to filename (only imports)\n%s\
   -g             add symbolic debug info\n\
-  -gc            add symbolic debug info, pretend to be C\n\
+  -gc            add symbolic debug info, optimize for non D debuggers\n\
   -gs            always emit stack frame\n\
   -gx            add stack stomp code\n\
   -H             generate 'header' file\n\


### PR DESCRIPTION
When this optimization is enabled, '.' is replaced with '@' for type names within the symbolic debug information, becuase the '.' character confuses the visual studio debugger. Also when passing D-Arrays as arguments to functions on 64-bit, they have to be passed as pointers because the ABI demands so. This however triggers a bug inside the visual studio debugger, which causes D arrays to be incorrectly displayed when passed as a function argument. Marking the array as (c++) reference instead of pointer fixes this problem.

The calls to cv_namestring within cv8.c have been added to ensure that all releveant name strings go through cv_namestring before they are written to the object file, so they can be patched as needed.
