### PR TITLE
[DDMD] [trivial] Remove some comments inside expressions

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -247,7 +247,7 @@ ArrayOp *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc)
      *  return p;
      */
 
-    Parameter *p = (*fparams)[0 /*fparams->dim - 1*/];
+    Parameter *p = (*fparams)[0];
     // foreach (i; 0 .. p.length)
     Statement *s1 = new ForeachRangeStatement(Loc(), TOKforeach,
         new Parameter(0, NULL, Id::p, NULL),

--- a/src/parse.c
+++ b/src/parse.c
@@ -4547,7 +4547,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
             {
                 Loc lookingForElseSave = lookingForElse;
                 lookingForElse = loc;
-                ifbody = parseStatement(0 /*PSsemi*/);
+                ifbody = parseStatement(0);
                 lookingForElse = lookingForElseSave;
             }
             elsebody = NULL;
@@ -4555,7 +4555,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
             {
                 Loc elseloc = token.loc;
                 nextToken();
-                elsebody = parseStatement(0 /*PSsemi*/);
+                elsebody = parseStatement(0);
                 checkDanglingElse(elseloc);
             }
             s = new ConditionalStatement(loc, cond, ifbody, elsebody);


### PR DESCRIPTION
Keeping these while converting does not seem worth the effort - they are dead code that was commented instead of deleted.
