### PR TITLE
[DDMD] [trivial] Explicitly compare with zero

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -156,7 +156,7 @@ int Expression::apply(apply_fp_t fp, void *param)
         }
         void visit(Expression *e)
         {
-            stop = (*fp)(e, param);
+            stop = (*fp)(e, param) != 0;
         }
     };
 


### PR DESCRIPTION
This causes an error in D as int does not implicitly convert to bool.
