### PR TITLE
The frontend should not know or care which array ops are implemented in druntime

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -38,208 +38,10 @@ AA *arrayfuncs;
  * Structure to contain information needed to insert an array op call
  */
 
-struct ArrayOp
-{
-    FuncDeclaration *cFunc; // Stub for optimized druntime version
-    FuncDeclaration *dFunc; // Full D version for ctfe
-};
-
-/**************************************
- * Search for a druntime array op
- */
-int isDruntimeArrayOp(Identifier *ident)
-{
-    /* Some of the array op functions are written as library functions,
-     * presumably to optimize them with special CPU vector instructions.
-     * List those library functions here, in alpha order.
-     */
-    static const char *libArrayopFuncs[] =
-    {
-        "_arrayExpSliceAddass_a",
-        "_arrayExpSliceAddass_d",           // T[]+=T
-        "_arrayExpSliceAddass_f",           // T[]+=T
-        "_arrayExpSliceAddass_g",
-        "_arrayExpSliceAddass_h",
-        "_arrayExpSliceAddass_i",
-        "_arrayExpSliceAddass_k",
-        "_arrayExpSliceAddass_s",
-        "_arrayExpSliceAddass_t",
-        "_arrayExpSliceAddass_u",
-        "_arrayExpSliceAddass_w",
-
-        "_arrayExpSliceDivass_d",           // T[]/=T
-        "_arrayExpSliceDivass_f",           // T[]/=T
-
-        "_arrayExpSliceMinSliceAssign_a",
-        "_arrayExpSliceMinSliceAssign_d",   // T[]=T-T[]
-        "_arrayExpSliceMinSliceAssign_f",   // T[]=T-T[]
-        "_arrayExpSliceMinSliceAssign_g",
-        "_arrayExpSliceMinSliceAssign_h",
-        "_arrayExpSliceMinSliceAssign_i",
-        "_arrayExpSliceMinSliceAssign_k",
-        "_arrayExpSliceMinSliceAssign_s",
-        "_arrayExpSliceMinSliceAssign_t",
-        "_arrayExpSliceMinSliceAssign_u",
-        "_arrayExpSliceMinSliceAssign_w",
-
-        "_arrayExpSliceMinass_a",
-        "_arrayExpSliceMinass_d",           // T[]-=T
-        "_arrayExpSliceMinass_f",           // T[]-=T
-        "_arrayExpSliceMinass_g",
-        "_arrayExpSliceMinass_h",
-        "_arrayExpSliceMinass_i",
-        "_arrayExpSliceMinass_k",
-        "_arrayExpSliceMinass_s",
-        "_arrayExpSliceMinass_t",
-        "_arrayExpSliceMinass_u",
-        "_arrayExpSliceMinass_w",
-
-        "_arrayExpSliceMulass_d",           // T[]*=T
-        "_arrayExpSliceMulass_f",           // T[]*=T
-        "_arrayExpSliceMulass_i",
-        "_arrayExpSliceMulass_k",
-        "_arrayExpSliceMulass_s",
-        "_arrayExpSliceMulass_t",
-        "_arrayExpSliceMulass_u",
-        "_arrayExpSliceMulass_w",
-
-        "_arraySliceExpAddSliceAssign_a",
-        "_arraySliceExpAddSliceAssign_d",   // T[]=T[]+T
-        "_arraySliceExpAddSliceAssign_f",   // T[]=T[]+T
-        "_arraySliceExpAddSliceAssign_g",
-        "_arraySliceExpAddSliceAssign_h",
-        "_arraySliceExpAddSliceAssign_i",
-        "_arraySliceExpAddSliceAssign_k",
-        "_arraySliceExpAddSliceAssign_s",
-        "_arraySliceExpAddSliceAssign_t",
-        "_arraySliceExpAddSliceAssign_u",
-        "_arraySliceExpAddSliceAssign_w",
-
-        "_arraySliceExpDivSliceAssign_d",   // T[]=T[]/T
-        "_arraySliceExpDivSliceAssign_f",   // T[]=T[]/T
-
-        "_arraySliceExpMinSliceAssign_a",
-        "_arraySliceExpMinSliceAssign_d",   // T[]=T[]-T
-        "_arraySliceExpMinSliceAssign_f",   // T[]=T[]-T
-        "_arraySliceExpMinSliceAssign_g",
-        "_arraySliceExpMinSliceAssign_h",
-        "_arraySliceExpMinSliceAssign_i",
-        "_arraySliceExpMinSliceAssign_k",
-        "_arraySliceExpMinSliceAssign_s",
-        "_arraySliceExpMinSliceAssign_t",
-        "_arraySliceExpMinSliceAssign_u",
-        "_arraySliceExpMinSliceAssign_w",
-
-        "_arraySliceExpMulSliceAddass_d",   // T[] += T[]*T
-        "_arraySliceExpMulSliceAddass_f",
-        "_arraySliceExpMulSliceAddass_r",
-
-        "_arraySliceExpMulSliceAssign_d",   // T[]=T[]*T
-        "_arraySliceExpMulSliceAssign_f",   // T[]=T[]*T
-        "_arraySliceExpMulSliceAssign_i",
-        "_arraySliceExpMulSliceAssign_k",
-        "_arraySliceExpMulSliceAssign_s",
-        "_arraySliceExpMulSliceAssign_t",
-        "_arraySliceExpMulSliceAssign_u",
-        "_arraySliceExpMulSliceAssign_w",
-
-        "_arraySliceExpMulSliceMinass_d",   // T[] -= T[]*T
-        "_arraySliceExpMulSliceMinass_f",
-        "_arraySliceExpMulSliceMinass_r",
-
-        "_arraySliceSliceAddSliceAssign_a",
-        "_arraySliceSliceAddSliceAssign_d", // T[]=T[]+T[]
-        "_arraySliceSliceAddSliceAssign_f", // T[]=T[]+T[]
-        "_arraySliceSliceAddSliceAssign_g",
-        "_arraySliceSliceAddSliceAssign_h",
-        "_arraySliceSliceAddSliceAssign_i",
-        "_arraySliceSliceAddSliceAssign_k",
-        "_arraySliceSliceAddSliceAssign_r", // T[]=T[]+T[]
-        "_arraySliceSliceAddSliceAssign_s",
-        "_arraySliceSliceAddSliceAssign_t",
-        "_arraySliceSliceAddSliceAssign_u",
-        "_arraySliceSliceAddSliceAssign_w",
-
-        "_arraySliceSliceAddass_a",
-        "_arraySliceSliceAddass_d",         // T[]+=T[]
-        "_arraySliceSliceAddass_f",         // T[]+=T[]
-        "_arraySliceSliceAddass_g",
-        "_arraySliceSliceAddass_h",
-        "_arraySliceSliceAddass_i",
-        "_arraySliceSliceAddass_k",
-        "_arraySliceSliceAddass_s",
-        "_arraySliceSliceAddass_t",
-        "_arraySliceSliceAddass_u",
-        "_arraySliceSliceAddass_w",
-
-        "_arraySliceSliceMinSliceAssign_a",
-        "_arraySliceSliceMinSliceAssign_d", // T[]=T[]-T[]
-        "_arraySliceSliceMinSliceAssign_f", // T[]=T[]-T[]
-        "_arraySliceSliceMinSliceAssign_g",
-        "_arraySliceSliceMinSliceAssign_h",
-        "_arraySliceSliceMinSliceAssign_i",
-        "_arraySliceSliceMinSliceAssign_k",
-        "_arraySliceSliceMinSliceAssign_r", // T[]=T[]-T[]
-        "_arraySliceSliceMinSliceAssign_s",
-        "_arraySliceSliceMinSliceAssign_t",
-        "_arraySliceSliceMinSliceAssign_u",
-        "_arraySliceSliceMinSliceAssign_w",
-
-        "_arraySliceSliceMinass_a",
-        "_arraySliceSliceMinass_d",         // T[]-=T[]
-        "_arraySliceSliceMinass_f",         // T[]-=T[]
-        "_arraySliceSliceMinass_g",
-        "_arraySliceSliceMinass_h",
-        "_arraySliceSliceMinass_i",
-        "_arraySliceSliceMinass_k",
-        "_arraySliceSliceMinass_s",
-        "_arraySliceSliceMinass_t",
-        "_arraySliceSliceMinass_u",
-        "_arraySliceSliceMinass_w",
-
-        "_arraySliceSliceMulSliceAssign_d", // T[]=T[]*T[]
-        "_arraySliceSliceMulSliceAssign_f", // T[]=T[]*T[]
-        "_arraySliceSliceMulSliceAssign_i",
-        "_arraySliceSliceMulSliceAssign_k",
-        "_arraySliceSliceMulSliceAssign_s",
-        "_arraySliceSliceMulSliceAssign_t",
-        "_arraySliceSliceMulSliceAssign_u",
-        "_arraySliceSliceMulSliceAssign_w",
-
-        "_arraySliceSliceMulass_d",         // T[]*=T[]
-        "_arraySliceSliceMulass_f",         // T[]*=T[]
-        "_arraySliceSliceMulass_i",
-        "_arraySliceSliceMulass_k",
-        "_arraySliceSliceMulass_s",
-        "_arraySliceSliceMulass_t",
-        "_arraySliceSliceMulass_u",
-        "_arraySliceSliceMulass_w",
-    };
-    char *name = ident->toChars();
-    int i = binary(name, libArrayopFuncs, sizeof(libArrayopFuncs) / sizeof(char *));
-    if (i != -1)
-        return 1;
-
-#ifdef DEBUG    // Make sure our array is alphabetized
-    for (i = 0; i < sizeof(libArrayopFuncs) / sizeof(char *); i++)
-    {
-        if (strcmp(name, libArrayopFuncs[i]) == 0)
-            assert(0);
-    }
-#endif
-    return 0;
-}
-
-ArrayOp *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc)
+FuncDeclaration *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc)
 {
     Parameters *fparams = new Parameters();
     Expression *loopbody = buildArrayLoop(exp, fparams);
-
-    ArrayOp *op = new ArrayOp;
-    if (isDruntimeArrayOp(ident))
-        op->cFunc = FuncDeclaration::genCfunc(fparams, exp->type, ident);
-    else
-        op->cFunc = NULL;
 
     /* Construct the function body:
      *  foreach (i; 0 .. p.length)    for (size_t i = 0; i < p.length; i++)
@@ -272,8 +74,7 @@ ArrayOp *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc)
     fd->linkage = LINKc;
     fd->isArrayOp = 1;
 
-    if (!op->cFunc)
-        sc->module->importedFrom->members->push(fd);
+    sc->module->importedFrom->members->push(fd);
 
     sc = sc->push();
     sc->parent = sc->module->importedFrom;
@@ -291,13 +92,7 @@ ArrayOp *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc)
     }
     sc->pop();
 
-    if (op->cFunc)
-    {
-        op->cFunc->dArrayOp = fd;
-        op->cFunc->type = fd->type;
-    }
-    op->dFunc = fd;
-    return op;
+    return fd;
 }
 
 /**********************************************
@@ -401,13 +196,13 @@ Expression *arrayOp(BinExp *e, Scope *sc)
     char *name = buf.peekString();
     Identifier *ident = Lexer::idPool(name);
 
-    ArrayOp **pOp = (ArrayOp **)_aaGet(&arrayfuncs, ident);
-    ArrayOp *op = *pOp;
+    FuncDeclaration **pFd = (FuncDeclaration **)_aaGet(&arrayfuncs, ident);
+    FuncDeclaration *fd = *pFd;
 
-    if (!op)
-        op = buildArrayOp(ident, e, sc, e->loc);
+    if (!fd)
+        fd = buildArrayOp(ident, e, sc, e->loc);
 
-    if (op->dFunc && op->dFunc->errors)
+    if (fd && fd->errors)
     {
         const char *fmt;
         if (tbn->ty == Tstruct || tbn->ty == Tclass)
@@ -421,9 +216,8 @@ Expression *arrayOp(BinExp *e, Scope *sc)
         return new ErrorExp();
     }
 
-    *pOp = op;
+    *pFd = fd;
 
-    FuncDeclaration *fd = op->cFunc ? op->cFunc : op->dFunc;
     Expression *ev = new VarExp(e->loc, fd);
     Expression *ec = new CallExp(e->loc, ev, arguments);
 

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -597,7 +597,6 @@ public:
     CompiledCtfeFunction *ctfeCode;     // Compiled code for interpreter
     int inlineNest;                     // !=0 if nested inline
     bool isArrayOp;                     // true if array operation
-    FuncDeclaration *dArrayOp;          // D version of array op for ctfe
     bool semantic3Errors;               // true if errors in semantic3
                                         // this function's frame ptr
     ForeachStatement *fes;              // if foreach body, this is the foreach

--- a/src/func.c
+++ b/src/func.c
@@ -74,7 +74,6 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     inlineNest = 0;
     ctfeCode = NULL;
     isArrayOp = 0;
-    dArrayOp = NULL;
     semantic3Errors = false;
     fes = NULL;
     introducing = 0;

--- a/src/glue.c
+++ b/src/glue.c
@@ -539,6 +539,192 @@ void Module::genobjfile(int multiobj)
 }
 
 
+/**************************************
+ * Search for a druntime array op
+ */
+int isDruntimeArrayOp(Identifier *ident)
+{
+    /* Some of the array op functions are written as library functions,
+     * presumably to optimize them with special CPU vector instructions.
+     * List those library functions here, in alpha order.
+     */
+    static const char *libArrayopFuncs[] =
+    {
+        "_arrayExpSliceAddass_a",
+        "_arrayExpSliceAddass_d",
+        "_arrayExpSliceAddass_f",           // T[]+=T
+        "_arrayExpSliceAddass_g",
+        "_arrayExpSliceAddass_h",
+        "_arrayExpSliceAddass_i",
+        "_arrayExpSliceAddass_k",
+        "_arrayExpSliceAddass_s",
+        "_arrayExpSliceAddass_t",
+        "_arrayExpSliceAddass_u",
+        "_arrayExpSliceAddass_w",
+
+        "_arrayExpSliceDivass_d",           // T[]/=T
+        "_arrayExpSliceDivass_f",           // T[]/=T
+
+        "_arrayExpSliceMinSliceAssign_a",
+        "_arrayExpSliceMinSliceAssign_d",   // T[]=T-T[]
+        "_arrayExpSliceMinSliceAssign_f",   // T[]=T-T[]
+        "_arrayExpSliceMinSliceAssign_g",
+        "_arrayExpSliceMinSliceAssign_h",
+        "_arrayExpSliceMinSliceAssign_i",
+        "_arrayExpSliceMinSliceAssign_k",
+        "_arrayExpSliceMinSliceAssign_s",
+        "_arrayExpSliceMinSliceAssign_t",
+        "_arrayExpSliceMinSliceAssign_u",
+        "_arrayExpSliceMinSliceAssign_w",
+
+        "_arrayExpSliceMinass_a",
+        "_arrayExpSliceMinass_d",           // T[]-=T
+        "_arrayExpSliceMinass_f",           // T[]-=T
+        "_arrayExpSliceMinass_g",
+        "_arrayExpSliceMinass_h",
+        "_arrayExpSliceMinass_i",
+        "_arrayExpSliceMinass_k",
+        "_arrayExpSliceMinass_s",
+        "_arrayExpSliceMinass_t",
+        "_arrayExpSliceMinass_u",
+        "_arrayExpSliceMinass_w",
+
+        "_arrayExpSliceMulass_d",           // T[]*=T
+        "_arrayExpSliceMulass_f",           // T[]*=T
+        "_arrayExpSliceMulass_i",
+        "_arrayExpSliceMulass_k",
+        "_arrayExpSliceMulass_s",
+        "_arrayExpSliceMulass_t",
+        "_arrayExpSliceMulass_u",
+        "_arrayExpSliceMulass_w",
+
+        "_arraySliceExpAddSliceAssign_a",
+        "_arraySliceExpAddSliceAssign_d",   // T[]=T[]+T
+        "_arraySliceExpAddSliceAssign_f",   // T[]=T[]+T
+        "_arraySliceExpAddSliceAssign_g",
+        "_arraySliceExpAddSliceAssign_h",
+        "_arraySliceExpAddSliceAssign_i",
+        "_arraySliceExpAddSliceAssign_k",
+        "_arraySliceExpAddSliceAssign_s",
+        "_arraySliceExpAddSliceAssign_t",
+        "_arraySliceExpAddSliceAssign_u",
+        "_arraySliceExpAddSliceAssign_w",
+
+        "_arraySliceExpDivSliceAssign_d",   // T[]=T[]/T
+        "_arraySliceExpDivSliceAssign_f",   // T[]=T[]/T
+
+        "_arraySliceExpMinSliceAssign_a",
+        "_arraySliceExpMinSliceAssign_d",   // T[]=T[]-T
+        "_arraySliceExpMinSliceAssign_f",   // T[]=T[]-T
+        "_arraySliceExpMinSliceAssign_g",
+        "_arraySliceExpMinSliceAssign_h",
+        "_arraySliceExpMinSliceAssign_i",
+        "_arraySliceExpMinSliceAssign_k",
+        "_arraySliceExpMinSliceAssign_s",
+        "_arraySliceExpMinSliceAssign_t",
+        "_arraySliceExpMinSliceAssign_u",
+        "_arraySliceExpMinSliceAssign_w",
+
+        "_arraySliceExpMulSliceAddass_d",   // T[] += T[]*T
+        "_arraySliceExpMulSliceAddass_f",
+        "_arraySliceExpMulSliceAddass_r",
+
+        "_arraySliceExpMulSliceAssign_d",   // T[]=T[]*T
+        "_arraySliceExpMulSliceAssign_f",   // T[]=T[]*T
+        "_arraySliceExpMulSliceAssign_i",
+        "_arraySliceExpMulSliceAssign_k",
+        "_arraySliceExpMulSliceAssign_s",
+        "_arraySliceExpMulSliceAssign_t",
+        "_arraySliceExpMulSliceAssign_u",
+        "_arraySliceExpMulSliceAssign_w",
+
+        "_arraySliceExpMulSliceMinass_d",   // T[] -= T[]*T
+        "_arraySliceExpMulSliceMinass_f",
+        "_arraySliceExpMulSliceMinass_r",
+
+        "_arraySliceSliceAddSliceAssign_a",
+        "_arraySliceSliceAddSliceAssign_d", // T[]=T[]+T[]
+        "_arraySliceSliceAddSliceAssign_f", // T[]=T[]+T[]
+        "_arraySliceSliceAddSliceAssign_g",
+        "_arraySliceSliceAddSliceAssign_h",
+        "_arraySliceSliceAddSliceAssign_i",
+        "_arraySliceSliceAddSliceAssign_k",
+        "_arraySliceSliceAddSliceAssign_r", // T[]=T[]+T[]
+        "_arraySliceSliceAddSliceAssign_s",
+        "_arraySliceSliceAddSliceAssign_t",
+        "_arraySliceSliceAddSliceAssign_u",
+        "_arraySliceSliceAddSliceAssign_w",
+
+        "_arraySliceSliceAddass_a",
+        "_arraySliceSliceAddass_d",         // T[]+=T[]
+        "_arraySliceSliceAddass_f",         // T[]+=T[]
+        "_arraySliceSliceAddass_g",
+        "_arraySliceSliceAddass_h",
+        "_arraySliceSliceAddass_i",
+        "_arraySliceSliceAddass_k",
+        "_arraySliceSliceAddass_s",
+        "_arraySliceSliceAddass_t",
+        "_arraySliceSliceAddass_u",
+        "_arraySliceSliceAddass_w",
+
+        "_arraySliceSliceMinSliceAssign_a",
+        "_arraySliceSliceMinSliceAssign_d", // T[]=T[]-T[]
+        "_arraySliceSliceMinSliceAssign_f", // T[]=T[]-T[]
+        "_arraySliceSliceMinSliceAssign_g",
+        "_arraySliceSliceMinSliceAssign_h",
+        "_arraySliceSliceMinSliceAssign_i",
+        "_arraySliceSliceMinSliceAssign_k",
+        "_arraySliceSliceMinSliceAssign_r", // T[]=T[]-T[]
+        "_arraySliceSliceMinSliceAssign_s",
+        "_arraySliceSliceMinSliceAssign_t",
+        "_arraySliceSliceMinSliceAssign_u",
+        "_arraySliceSliceMinSliceAssign_w",
+
+        "_arraySliceSliceMinass_a",
+        "_arraySliceSliceMinass_d",         // T[]-=T[]
+        "_arraySliceSliceMinass_f",         // T[]-=T[]
+        "_arraySliceSliceMinass_g",
+        "_arraySliceSliceMinass_h",
+        "_arraySliceSliceMinass_i",
+        "_arraySliceSliceMinass_k",
+        "_arraySliceSliceMinass_s",
+        "_arraySliceSliceMinass_t",
+        "_arraySliceSliceMinass_u",
+        "_arraySliceSliceMinass_w",
+
+        "_arraySliceSliceMulSliceAssign_d", // T[]=T[]*T[]
+        "_arraySliceSliceMulSliceAssign_f", // T[]=T[]*T[]
+        "_arraySliceSliceMulSliceAssign_i",
+        "_arraySliceSliceMulSliceAssign_k",
+        "_arraySliceSliceMulSliceAssign_s",
+        "_arraySliceSliceMulSliceAssign_t",
+        "_arraySliceSliceMulSliceAssign_u",
+        "_arraySliceSliceMulSliceAssign_w",
+
+        "_arraySliceSliceMulass_d",         // T[]*=T[]
+        "_arraySliceSliceMulass_f",         // T[]*=T[]
+        "_arraySliceSliceMulass_i",
+        "_arraySliceSliceMulass_k",
+        "_arraySliceSliceMulass_s",
+        "_arraySliceSliceMulass_t",
+        "_arraySliceSliceMulass_u",
+        "_arraySliceSliceMulass_w",
+    };
+    char *name = ident->toChars();
+    int i = binary(name, libArrayopFuncs, sizeof(libArrayopFuncs) / sizeof(char *));
+    if (i != -1)
+        return 1;
+
+#ifdef DEBUG    // Make sure our array is alphabetized
+    for (i = 0; i < sizeof(libArrayopFuncs) / sizeof(char *); i++)
+    {
+        if (strcmp(name, libArrayopFuncs[i]) == 0)
+            assert(0);
+    }
+#endif
+    return 0;
+}
+
 /* ================================================================== */
 
 void FuncDeclaration::toObjFile(int multiobj)
@@ -622,6 +808,12 @@ void FuncDeclaration::toObjFile(int multiobj)
                 return;
             }
         }
+    }
+
+    if (isArrayOp && isDruntimeArrayOp(ident))
+    {
+        // Implementation is in druntime
+        return;
     }
 
     // start code generation

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4900,8 +4900,6 @@ Expression *CallExp::interpret(InterState *istate, CtfeGoal goal)
         }
         return e;
     }
-    if (fd->dArrayOp)
-        return fd->dArrayOp->interpret(istate, arguments, pthis);
     if (!fd->fbody)
     {
         error("%s cannot be interpreted at compile time,"


### PR DESCRIPTION
@ibuclaw @klickverbot @redstar

Is this going to cause problems for the other backends?

Essentially it just skips emitting the function if it knows it's already defined in the backend.  The calling code has a reference to the `FuncDeclaration` that was never emitted, where before it referenced a body-less `FuncDeclaration` created by `getCfunc`.

The Digital Mars backends doesn't care.
