### PR TITLE
[DDMD] [refactor] Move Expression::toDt into a visitor class

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -49,7 +49,6 @@ public:
     /// Return index of the field, or -1 if not found
     /// Same as getFieldIndex, but checks for a direct match with the VarDeclaration
     int findFieldIndexByName(VarDeclaration *v);
-    dt_t **toDt(dt_t **pdt);
     dt_t **toDtI(dt_t **pdt, int offset);
     Symbol* toSymbol();
     dt_t **toInstanceDt(dt_t **pdt);

--- a/src/expression.h
+++ b/src/expression.h
@@ -99,6 +99,7 @@ Expression *arrayOp(BinAssignExp *e, Scope *sc);
 bool hasSideEffect(Expression *e);
 bool canThrow(Expression *e, bool mustNotThrow);
 Expression *Expression_optimize(Expression *e, int result, bool keepLvalue);
+dt_t **Expression_toDt(Expression *e, dt_t **pdt);
 
 /* Run CTFE on the expression, but allow the expression to be a TypeExp
  * or a tuple containing a TypeExp. (This is required by pragma(msg)).
@@ -207,7 +208,7 @@ public:
     // Back end
     virtual elem *toElem(IRState *irs);
     elem *toElemDtor(IRState *irs);
-    virtual dt_t **toDt(dt_t **pdt);
+    virtual dt_t **toDt(dt_t **pdt) { return ::Expression_toDt(this, pdt); }
     virtual void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -232,7 +233,6 @@ public:
     void toMangleBuffer(OutBuffer *buf);
     Expression *toLvalue(Scope *sc, Expression *e);
     elem *toElem(IRState *irs);
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -269,7 +269,6 @@ public:
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     elem *toElem(IRState *irs);
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -293,7 +292,6 @@ public:
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     elem *toElem(IRState *irs);
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -382,7 +380,6 @@ public:
     Expression *castTo(Scope *sc, Type *t);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     elem *toElem(IRState *irs);
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -419,7 +416,6 @@ public:
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void toMangleBuffer(OutBuffer *buf);
     elem *toElem(IRState *irs);
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -475,7 +471,6 @@ public:
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     Expression *inferType(Type *t, int flag = 0, Scope *sc = NULL, TemplateParameters *tparams = NULL);
-    dt_t **toDt(dt_t **pdt);
 
     Expression *doInline(InlineDoState *ids);
     void accept(Visitor *v) { v->visit(this); }
@@ -559,7 +554,6 @@ public:
     void toMangleBuffer(OutBuffer *buf);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
     Expression *addDtorHook(Scope *sc);
-    dt_t **toDt(dt_t **pdt);
     Symbol *toSymbol();
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
@@ -684,7 +678,6 @@ public:
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
 
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -706,7 +699,6 @@ public:
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    dt_t **toDt(dt_t **pdt);
 
     Expression *doInline(InlineDoState *ids);
     void accept(Visitor *v) { v->visit(this); }
@@ -748,7 +740,6 @@ public:
     char *toChars();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     elem *toElem(IRState *irs);
-    dt_t **toDt(dt_t **pdt);
 
     //Expression *doInline(InlineDoState *ids);
     void accept(Visitor *v) { v->visit(this); }
@@ -1073,7 +1064,6 @@ public:
     MATCH implicitConvTo(Type *t);
     Expression *castTo(Scope *sc, Type *t);
     Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue);
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1172,7 +1162,6 @@ public:
 
     // For operator overloading
     Expression *op_overload(Scope *sc);
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1187,7 +1176,6 @@ public:
     Expression *semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     elem *toElem(IRState *irs);
-    dt_t **toDt(dt_t **pdt);
     void accept(Visitor *v) { v->visit(this); }
 };
 


### PR DESCRIPTION
Getting rid of `ClassReferenceExp::toDt` unfortunately means touching `ctfe.h`.

@WalterBright @donc Can we start breaking D1 compatibility in `ctfe.h`/`interpret.c`/`ctfeexpr.c` yet?  Switching to D will mean breaking that for sure, and we're quite close to that point now.

I'm going to need to visitor-ise `*::interpret` and `*::ctfeCompile` in the near future, probably in the next few days.
