### PR TITLE
Fix private method C++ mangling

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -1089,12 +1089,8 @@ private:
 
         if (d->needThis()) // <flags> ::= <virtual/protection flag> <const/volatile flag> <calling convention flag>
         {
-
-            //Pivate methods can be non-virtual in D but mangled as virtual in C++
-            if ((d->isVirtual() && d->vtblIndex != -1) ||
-                (d->protection == PROTprivate &&
-                d->isThis()->isClassDeclaration() &&
-                !d->isFinal() && !(d->isThis()->isClassDeclaration()->storage_class & STCfinal)))
+            // Pivate methods always non-virtual in D and it should be mangled as non-virtual in C++
+            if (d->isVirtual() && d->vtblIndex != -1)
             {
                 switch (d->protection)
                 {

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -100,7 +100,7 @@ class Test10
     protected: void test12();
     public: void test13() const;
 
-    private: virtual void test14();
+    private: void test14(); // Private methods in D are always non-virtual
     public: virtual void test15();
     protected: virtual void test16();
 


### PR DESCRIPTION
D `private void foo();` should be mangled as C++ `private: void foo()`, not as  `private: virtual void foo()` even if `foo` is not marked with `final`.
