### PR TITLE
Don't treat `body` as a keyword.

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -154,6 +154,8 @@ Msgtable msgtable[] =
     { "system" },
     { "disable" },
 
+    { "body" },
+
     // For inline assembler
     { "___out", "out" },
     { "___in", "in" },

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2769,7 +2769,6 @@ static Keyword keywords[] =
     {   "public",       TOKpublic       },
     {   "export",       TOKexport       },
 
-    {   "body",         TOKbody         },
     {   "invariant",    TOKinvariant    },
     {   "unittest",     TOKunittest     },
     {   "version",      TOKversion      },

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -148,7 +148,7 @@ enum TOK
         TOKon_scope_exit, TOKon_scope_failure, TOKon_scope_success,
 
         // Contracts
-        TOKbody, TOKinvariant,
+        TOKinvariant,
 
         // Testing
         TOKunittest,

--- a/src/parse.c
+++ b/src/parse.c
@@ -525,7 +525,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl)
                      tk->value == TOKlcurly ||
                      tk->value == TOKin ||
                      tk->value == TOKout ||
-                     tk->value == TOKbody)
+                     (tk->value == TOKidentifier && tk->ident == Id::body))
                    )
                 {
                     a = parseDeclarations(storageClass, comment);
@@ -3248,7 +3248,7 @@ Dsymbols *Parser::parseDeclarations(StorageClass storage_class, const utf8_t *co
          tk->value == TOKlcurly ||
          tk->value == TOKin ||
          tk->value == TOKout ||
-         tk->value == TOKbody)
+         (tk->value == TOKidentifier && tk->ident == Id::body))
        )
     {
         ts = NULL;
@@ -3546,7 +3546,9 @@ L1:
             f->endloc = endloc;
             break;
 
-        case TOKbody:
+        case TOKidentifier:
+            if (token.ident != Id::body)
+                goto _default;
             nextToken();
             f->fbody = parseStatement(PScurly);
             f->endloc = endloc;
@@ -3614,6 +3616,7 @@ L1:
             /* fall through */
 
         default:
+        _default:
             if (literal)
             {
                 const char *sbody = (f->frequire || f->fensure) ? "body " : "";
@@ -5405,6 +5408,10 @@ int Parser::isDeclarator(Token **pt, int *haveId, int *haveTpl, TOK endtok)
                 continue;
 
             // Valid tokens that follow a declaration
+            case TOKidentifier:
+                if (t->ident != Id::body)
+                    goto _default;
+                /* fall through */
             case TOKrparen:
             case TOKrbracket:
             case TOKassign:
@@ -5414,7 +5421,6 @@ int Parser::isDeclarator(Token **pt, int *haveId, int *haveTpl, TOK endtok)
             case TOKlcurly:
             case TOKin:
             case TOKout:
-            case TOKbody:
                 // The !parens is to disallow unnecessary parentheses
                 if (!parens && (endtok == TOKreserved || endtok == t->value))
                 {   *pt = t;
@@ -5425,6 +5431,7 @@ int Parser::isDeclarator(Token **pt, int *haveId, int *haveTpl, TOK endtok)
                 return haveTpl ? true : false;
 
             default:
+            _default:
                 return false;
         }
     }


### PR DESCRIPTION
Just recently a user wanted to use `body` as a member in his HTML document class:
http://forum.dlang.org/thread/vbfrootcxaecjgciwlvb@forum.dlang.org
I believe I've seen similar discussions several times in the forums.

Someone suggested to only treat `body` as a keyword where it makes sense. I tried implementing that, and, while not exactly beautiful, it turned out to be surprisingly non-invasive. It's not a keyword at all anymore, but a special identifier.

This same technique is also used for e.g. `scope(success)` among others, and could potentially be applied to other keywords too, but I guess `body` is the one with the greatest potential of conflict, because there is no nice alternative word (apart from capitalization and appending underscores etc.), and it's not a keyword in C/C++, so is freely used in some libraries.
