### PR TITLE
Puck up changes from master to 2.065 branch

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1675,35 +1675,79 @@ Dsymbol *UserAttributeDeclaration::syntaxCopy(Dsymbol *s)
     return new UserAttributeDeclaration(atts, Dsymbol::arraySyntaxCopy(decl));
 }
 
-void UserAttributeDeclaration::semantic(Scope *sc)
+void UserAttributeDeclaration::setScope(Scope *sc)
 {
-    //printf("UserAttributeDeclaration::semantic() %p\n", this);
-
-    /* Bugzilla 11844: Delay semantic analysis for UDAs.
-     * If attrs needs CTFE or template instantiation, they may not have
-     * valid scope yet for their fwdref resolution.
-     * Therefore running semantic analysis here is too early.
-     */
-    //arrayExpressionSemantic(atts, sc);
-
+    //printf("UserAttributeDeclaration::setScope() %p\n", this);
     if (decl)
     {
+        Dsymbol::setScope(sc);  // for forward reference of UDAs
+
         Scope *newsc = sc;
-#if 1
         if (atts && atts->dim)
         {
             // create new one for changes
-            newsc = new Scope(*sc);
-            newsc->flags &= ~SCOPEfree;
-
-            // Create new uda that is the concatenation of the previous
-            newsc->userAttributes = concat(newsc->userAttributes, atts);
+            newsc = sc->push();
+            newsc->userAttribDecl = this;
         }
-#endif
         for (size_t i = 0; i < decl->dim; i++)
-        {   Dsymbol *s = (*decl)[i];
+        {
+            Dsymbol *s = (*decl)[i];
+            s->setScope(newsc); // yes, the only difference from semantic()
+        }
+        if (newsc != sc)
+        {
+            sc->offset = newsc->offset;
+            newsc->pop();
+        }
+    }
+}
 
+void UserAttributeDeclaration::semantic(Scope *sc)
+{
+    //printf("UserAttributeDeclaration::semantic() %p\n", this);
+    if (decl)
+    {
+        Scope *newsc = sc;
+        if (atts && atts->dim)
+        {
+            // create new one for changes
+            newsc = sc->push();
+            newsc->userAttribDecl = this;
+        }
+        for (size_t i = 0; i < decl->dim; i++)
+        {
+            Dsymbol *s = (*decl)[i];
             s->semantic(newsc);
+        }
+        if (newsc != sc)
+        {
+            sc->offset = newsc->offset;
+            newsc->pop();
+        }
+    }
+}
+
+void UserAttributeDeclaration::semantic2(Scope *sc)
+{
+    if (decl)
+    {
+        Scope *newsc = sc;
+        if (atts && atts->dim)
+        {
+            if (scope)
+            {
+                scope = NULL;
+                arrayExpressionSemantic(atts, sc);  // run semantic
+            }
+
+            // create new one for changes
+            newsc = sc->push();
+            newsc->userAttribDecl = this;
+        }
+        for (size_t i = 0; i < decl->dim; i++)
+        {
+            Dsymbol *s = (*decl)[i];
+            s->semantic2(newsc);
         }
         if (newsc != sc)
         {
@@ -1732,43 +1776,22 @@ Expressions *UserAttributeDeclaration::concat(Expressions *udas1, Expressions *u
     return udas;
 }
 
-void UserAttributeDeclaration::setScope(Scope *sc)
+Expressions *UserAttributeDeclaration::getAttributes()
 {
-    //printf("UserAttributeDeclaration::setScope() %p\n", this);
-    if (decl)
+    if (scope)
     {
-        Scope *newsc = sc;
-#if 1
-        if (atts && atts->dim)
-        {
-            // create new one for changes
-            newsc = new Scope(*sc);
-            newsc->flags &= ~SCOPEfree;
-
-            // Append new atts to old one
-            if (!newsc->userAttributes || newsc->userAttributes->dim == 0)
-                newsc->userAttributes = atts;
-            else
-            {
-                // Create a tuple that combines them
-                Expressions *exps = new Expressions();
-                exps->push(new TupleExp(Loc(), newsc->userAttributes));
-                exps->push(new TupleExp(Loc(), atts));
-                newsc->userAttributes = exps;
-            }
-        }
-#endif
-        for (size_t i = 0; i < decl->dim; i++)
-        {   Dsymbol *s = (*decl)[i];
-
-            s->setScope(newsc); // yes, the only difference from semantic()
-        }
-        if (newsc != sc)
-        {
-            sc->offset = newsc->offset;
-            newsc->pop();
-        }
+        Scope *sc = scope;
+        scope = NULL;
+        arrayExpressionSemantic(atts, sc);
     }
+
+    Expressions *exps = new Expressions();
+    if (userAttribDecl)
+        exps->push(new TupleExp(Loc(), userAttribDecl->getAttributes()));
+    if (atts && atts->dim)
+        exps->push(new TupleExp(Loc(), atts));
+
+    return exps;
 }
 
 void UserAttributeDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1684,7 +1684,7 @@ void UserAttributeDeclaration::semantic(Scope *sc)
      * valid scope yet for their fwdref resolution.
      * Therefore running semantic analysis here is too early.
      */
-    //atts = arrayExpressionSemantic(atts, sc);
+    //arrayExpressionSemantic(atts, sc);
 
     if (decl)
     {

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -235,8 +235,10 @@ public:
     UserAttributeDeclaration(Expressions *atts, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);
+    void semantic2(Scope *sc);
     void setScope(Scope *sc);
     static Expressions *concat(Expressions *udas1, Expressions *udas2);
+    Expressions *getAttributes();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();
     void accept(Visitor *v) { v->visit(this); }

--- a/src/class.c
+++ b/src/class.c
@@ -290,12 +290,7 @@ void ClassDeclaration::semantic(Scope *sc)
     {
         isdeprecated = true;
     }
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     if (sc->linkage == LINKcpp)
         cpp = 1;
@@ -611,7 +606,7 @@ void ClassDeclaration::semantic(Scope *sc)
             sc->offset = Target::ptrsize * 2;   // allow room for __vptr and __monitor
         alignsize = Target::ptrsize;
     }
-    sc->userAttributes = NULL;
+    sc->userAttribDecl = NULL;
     structsize = sc->offset;
     Scope scsave = *sc;
     size_t members_dim = members->dim;
@@ -1285,12 +1280,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
     {
         isdeprecated = true;
     }
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     // Expand any tuples in baseclasses[]
     for (size_t i = 0; i < baseclasses->dim; )
@@ -1439,7 +1429,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
     sc->explicitProtection = 0;
 //    structalign = sc->structalign;
     sc->offset = Target::ptrsize * 2;
-    sc->userAttributes = NULL;
+    sc->userAttribDecl = NULL;
     structsize = sc->offset;
     inuse++;
 

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1626,7 +1626,7 @@ void VarDeclaration::semantic2(Scope *sc)
             ExpInitializer *ei = init->isExpInitializer();
             if (ei && ei->exp->op == TOKaddress && ((AddrExp *)ei->exp)->e1->op == TOKstructliteral)
             {
-                error("is a pointer to mutable struct. Only pointers to const, immutable or shared struct thread local variable are allowed are allowed, not %s", type->toChars());
+                error("is a pointer to mutable struct. Only pointers to const, immutable or shared struct thread local variable are allowed, not %s", type->toChars());
             }
         }
     }

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -347,12 +347,7 @@ void TypedefDeclaration::semantic(Scope *sc)
             return;
         }
         storage_class |= sc->stc & STCdeprecated;
-        userAttributes = sc->userAttributes;
-        if (userAttributes)
-        {
-            userAttributesScope = sc;
-            userAttributesScope->setNoFree();
-        }
+        userAttribDecl = sc->userAttribDecl;
     }
     else if (sem == SemanticIn)
     {
@@ -366,7 +361,8 @@ void TypedefDeclaration::semantic2(Scope *sc)
 {
     //printf("TypedefDeclaration::semantic2(%s) sem = %d\n", toChars(), sem);
     if (sem == SemanticDone)
-    {   sem = Semantic2Done;
+    {
+        sem = Semantic2Done;
         basetype->alignment();          // used to detect circular typedef declarations
         if (init)
         {
@@ -491,12 +487,7 @@ void AliasDeclaration::semantic(Scope *sc)
 
     storage_class |= sc->stc & STCdeprecated;
     protection = sc->protection;
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     // Given:
     //  alias foo.bar.abc def;
@@ -825,12 +816,7 @@ void VarDeclaration::semantic(Scope *sc)
     if (storage_class & STCextern && init)
         error("extern symbols cannot have initializers");
 
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     AggregateDeclaration *ad = isThis();
     if (ad)
@@ -1569,7 +1555,8 @@ void VarDeclaration::semantic2(Scope *sc)
         }
     }
     if (init && !toParent()->isFuncDeclaration())
-    {   inuse++;
+    {
+        inuse++;
 #if 0
         ExpInitializer *ei = init->isExpInitializer();
         if (ei)

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -51,8 +51,7 @@ Dsymbol::Dsymbol()
     this->semanticRun = PASSinit;
     this->errors = false;
     this->depmsg = NULL;
-    this->userAttributes = NULL;
-    this->userAttributesScope = NULL;
+    this->userAttribDecl = NULL;
     this->ddocUnittest = NULL;
 }
 
@@ -69,8 +68,7 @@ Dsymbol::Dsymbol(Identifier *ident)
     this->semanticRun = PASSinit;
     this->errors = false;
     this->depmsg = NULL;
-    this->userAttributes = NULL;
-    this->userAttributesScope = NULL;
+    this->userAttribDecl = NULL;
     this->ddocUnittest = NULL;
 }
 
@@ -348,8 +346,9 @@ void Dsymbol::setScope(Scope *sc)
     scope = sc;
     if (sc->depmsg)
         depmsg = sc->depmsg;
-    if (userAttributes)
-        userAttributesScope = sc;
+
+    if (!userAttribDecl)
+        userAttribDecl = sc->userAttribDecl;
 }
 
 void Dsymbol::importAll(Scope *sc)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -137,8 +137,7 @@ public:
     bool errors;                // this symbol failed to pass semantic()
     PASS semanticRun;
     char *depmsg;               // customized deprecation message
-    Expressions *userAttributes;        // user defined attributes from UserAttributeDeclaration
-    Scope *userAttributesScope;
+    UserAttributeDeclaration *userAttribDecl;   // user defined attributes
     UnitTestDeclaration *ddocUnittest; // !=NULL means there's a ddoc unittest associated with this symbol (only use this with ddoc)
 
     Dsymbol();

--- a/src/enum.c
+++ b/src/enum.c
@@ -144,12 +144,7 @@ void EnumDeclaration::semantic(Scope *sc)
 
     if (sc->stc & STCdeprecated)
         isdeprecated = true;
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     parent = sc->parent;
     protection = sc->protection;
@@ -727,8 +722,7 @@ Expression *EnumMember::getVarExp(Loc loc, Scope *sc)
 
         vd->protection = ed->isAnonymous() ? ed->protection : PROTpublic;
         vd->parent = ed->isAnonymous() ? ed->parent : ed;
-        vd->userAttributes = ed->isAnonymous() ? ed->userAttributes : NULL;
-        vd->userAttributesScope = ed->isAnonymous() ? ed->userAttributesScope : NULL;
+        vd->userAttribDecl = ed->isAnonymous() ? ed->userAttribDecl : NULL;
     }
     Expression *e = new VarExp(loc, vd);
     return e->semantic(sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -935,19 +935,24 @@ Expression *resolveUFCSProperties(Scope *sc, Expression *e1, Expression *e2 = NU
  * Perform semantic() on an array of Expressions.
  */
 
-Expressions *arrayExpressionSemantic(Expressions *exps, Scope *sc)
+bool arrayExpressionSemantic(Expressions *exps, Scope *sc)
 {
+    bool err = false;
     if (exps)
     {
         for (size_t i = 0; i < exps->dim; i++)
-        {   Expression *e = (*exps)[i];
+        {
+            Expression *e = (*exps)[i];
             if (e)
-            {   e = e->semantic(sc);
+            {
+                e = e->semantic(sc);
                 (*exps)[i] = e;
+                if (e->op == TOKerror)
+                    err = true;
             }
         }
     }
-    return exps;
+    return err;
 }
 
 
@@ -978,15 +983,18 @@ void expandTuples(Expressions *exps)
     if (exps)
     {
         for (size_t i = 0; i < exps->dim; i++)
-        {   Expression *arg = (*exps)[i];
+        {
+            Expression *arg = (*exps)[i];
             if (!arg)
                 continue;
 
             // Look for tuple with 0 members
             if (arg->op == TOKtype)
-            {   TypeExp *e = (TypeExp *)arg;
+            {
+                TypeExp *e = (TypeExp *)arg;
                 if (e->type->toBasetype()->ty == Ttuple)
-                {   TypeTuple *tt = (TypeTuple *)e->type->toBasetype();
+                {
+                    TypeTuple *tt = (TypeTuple *)e->type->toBasetype();
 
                     if (!tt->arguments || tt->arguments->dim == 0)
                     {
@@ -1198,7 +1206,8 @@ bool preFunctionParameters(Loc loc, Scope *sc, Expressions *exps)
         expandTuples(exps);
 
         for (size_t i = 0; i < exps->dim; i++)
-        {   Expression *arg = (*exps)[i];
+        {
+            Expression *arg = (*exps)[i];
 
             arg = resolveProperties(sc, arg);
             if (arg->op == TOKtype)
@@ -4306,7 +4315,8 @@ Expression *ArrayLiteralExp::semantic(Scope *sc)
     /* Perhaps an empty array literal [ ] should be rewritten as null?
      */
 
-    arrayExpressionSemantic(elements, sc);    // run semantic() on each element
+    if (arrayExpressionSemantic(elements, sc))  // run semantic() on each element
+        return new ErrorExp();
     expandTuples(elements);
 
     Type *t0;
@@ -4319,7 +4329,8 @@ Expression *ArrayLiteralExp::semantic(Scope *sc)
     /* Disallow array literals of type void being used.
      */
     if (elements->dim > 0 && t0->ty == Tvoid)
-    {   error("%s of type %s has no value", toChars(), type->toChars());
+    {
+        error("%s of type %s has no value", toChars(), type->toChars());
         return new ErrorExp();
     }
 
@@ -4445,8 +4456,10 @@ Expression *AssocArrayLiteralExp::semantic(Scope *sc)
         return this;
 
     // Run semantic() on each element
-    arrayExpressionSemantic(keys, sc);
-    arrayExpressionSemantic(values, sc);
+    bool err_keys = arrayExpressionSemantic(keys, sc);
+    bool err_vals = arrayExpressionSemantic(values, sc);
+    if (err_keys || err_vals)
+        return new ErrorExp();
     expandTuples(keys);
     expandTuples(values);
     if (keys->dim != values->dim)
@@ -4577,7 +4590,8 @@ Expression *StructLiteralExp::semantic(Scope *sc)
         return new ErrorExp();
     size_t nfields = sd->fields.dim - sd->isNested();
 
-    elements = arrayExpressionSemantic(elements, sc);   // run semantic() on each element
+    if (arrayExpressionSemantic(elements, sc))  // run semantic() on each element
+        return new ErrorExp();
     expandTuples(elements);
     size_t offset = 0;
     for (size_t i = 0; i < elements->dim; i++)
@@ -5111,12 +5125,16 @@ Lagain:
     tb = type->toBasetype();
     //printf("tb: %s, deco = %s\n", tb->toChars(), tb->deco);
 
-    arrayExpressionSemantic(newargs, sc);
-    if (preFunctionParameters(loc, sc, newargs))
+    if (arrayExpressionSemantic(newargs, sc) ||
+        preFunctionParameters(loc, sc, newargs))
+    {
         goto Lerr;
-    arrayExpressionSemantic(arguments, sc);
-    if (preFunctionParameters(loc, sc, arguments))
+    }
+    if (arrayExpressionSemantic(arguments, sc) ||
+        preFunctionParameters(loc, sc, arguments))
+    {
         goto Lerr;
+    }
 
     nargs = arguments ? arguments->dim : 0;
 
@@ -7322,6 +7340,10 @@ Expression *AssertExp::semantic(Scope *sc)
         msg = msg->implicitCastTo(sc, Type::tchar->constOf()->arrayOf());
         msg = msg->optimize(WANTvalue);
     }
+    if (e1->op == TOKerror)
+        return e1;
+    if (msg && msg->op == TOKerror)
+        return msg;
     if (e1->isBool(false))
     {
         FuncDeclaration *fd = sc->parent->isFuncDeclaration();
@@ -7329,7 +7351,8 @@ Expression *AssertExp::semantic(Scope *sc)
             fd->hasReturnExp |= 4;
 
         if (!global.params.useAssert)
-        {   Expression *e = new HaltExp(loc);
+        {
+            Expression *e = new HaltExp(loc);
             e = e->semantic(sc);
             return e;
         }
@@ -8408,9 +8431,11 @@ Expression *CallExp::semantic(Scope *sc)
 
     if (e1->op == TOKfunction)
     {
-        FuncExp *fe = (FuncExp *)e1;
-        arguments = arrayExpressionSemantic(arguments, sc);
+        arrayExpressionSemantic(arguments, sc);
         preFunctionParameters(loc, sc, arguments);
+
+        // Run e1 semantic even if arguments have any errors
+        FuncExp *fe = (FuncExp *)e1;
         e1 = fe->semantic(sc, arguments);
         if (e1->op == TOKerror)
             return e1;
@@ -8589,19 +8614,12 @@ Lagain:
 
     t1 = NULL;
     if (e1->type)
+    {
         t1 = e1->type->toBasetype();
 
-    arguments = arrayExpressionSemantic(arguments, sc);
-    preFunctionParameters(loc, sc, arguments);
-
-    // Check for call operator overload
-    if (t1)
-    {
-        AggregateDeclaration *ad;
         if (t1->ty == Tstruct)
         {
-            ad = ((TypeStruct *)t1)->sym;
-
+            AggregateDeclaration *ad = ((TypeStruct *)t1)->sym;
             if (ad->sizeok == SIZEOKnone)
             {
                 if (ad->scope)
@@ -8615,6 +8633,24 @@ Lagain:
                     return new ErrorExp();
                 }
             }
+        }
+    }
+
+    if (e1->op == TOKerror)
+        return e1;
+    if (arrayExpressionSemantic(arguments, sc) ||
+        preFunctionParameters(loc, sc, arguments))
+    {
+        return new ErrorExp();
+    }
+
+    // Check for call operator overload
+    if (t1)
+    {
+        AggregateDeclaration *ad;
+        if (t1->ty == Tstruct)
+        {
+            ad = ((TypeStruct *)t1)->sym;
 
             // First look for constructor
             if (e1->op == TOKtype && ad->ctor && (ad->noDefaultCtor || arguments && arguments->dim))
@@ -8688,30 +8724,6 @@ Lagain:
             e = new CallExp(loc, e, arguments);
             e = e->semantic(sc);
             return e;
-        }
-    }
-
-    // If there was an error processing any argument, or the call,
-    // return an error without trying to resolve the function call.
-    if (arguments && arguments->dim)
-    {
-        for (size_t k = 0; k < arguments->dim; k++)
-        {   Expression *checkarg = (*arguments)[k];
-            if (checkarg->op == TOKerror)
-                return checkarg;
-        }
-    }
-    if (e1->op == TOKerror)
-        return e1;
-
-    // If there was an error processing any template argument,
-    // return an error without trying to resolve the template.
-    if (tiargs && tiargs->dim)
-    {
-        for (size_t k = 0; k < tiargs->dim; k++)
-        {   RootObject *o = (*tiargs)[k];
-            if (isError(o))
-                return new ErrorExp();
         }
     }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -8653,8 +8653,11 @@ Lagain:
             ad = ((TypeStruct *)t1)->sym;
 
             // First look for constructor
-            if (e1->op == TOKtype && ad->ctor && (ad->noDefaultCtor || arguments && arguments->dim))
+            if (e1->op == TOKtype && ad->ctor)
             {
+                if (!ad->noDefaultCtor && !(arguments && arguments->dim))
+                    goto Lx;
+
                 // Create variable that will get constructed
                 Identifier *idtmp = Lexer::uniqueId("__ctmp");
 
@@ -8710,6 +8713,7 @@ Lagain:
 
             /* It's a struct literal
              */
+        Lx:
             Expression *e = new StructLiteralExp(loc, (StructDeclaration *)ad, arguments, e1->type);
             e = e->semantic(sc);
             return e;

--- a/src/expression.h
+++ b/src/expression.h
@@ -87,7 +87,6 @@ Expression *resolveAliasThis(Scope *sc, Expression *e);
 Expression *callCpCtor(Scope *sc, Expression *e);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae);
 Expression *resolveOpDollar(Scope *sc, SliceExp *se);
-Expressions *arrayExpressionSemantic(Expressions *exps, Scope *sc);
 
 AggregateDeclaration *isAggregate(Type *t);
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -79,6 +79,7 @@ TupleDeclaration *isAliasThisTuple(Expression *e);
 int expandAliasThisTuples(Expressions *exps, size_t starti = 0);
 FuncDeclaration *hasThis(Scope *sc);
 Expression *fromConstInitializer(int result, Expression *e);
+bool arrayExpressionSemantic(Expressions *exps, Scope *sc);
 int arrayExpressionCanThrow(Expressions *exps, bool mustNotThrow);
 TemplateDeclaration *getFuncTemplateDecl(Dsymbol *s);
 Expression *valueNoDtor(Expression *e);

--- a/src/func.c
+++ b/src/func.c
@@ -190,12 +190,7 @@ void FuncDeclaration::semantic(Scope *sc)
     else
         linkage = sc->linkage;
     protection = sc->protection;
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     if (!originalType)
         originalType = type->syntaxCopy();
@@ -1048,7 +1043,7 @@ void FuncDeclaration::semantic3(Scope *sc)
         sc2->tf = NULL;
         sc2->noctor = 0;
         sc2->speculative = sc->speculative || isSpeculative() != NULL;
-        sc2->userAttributes = NULL;
+        sc2->userAttribDecl = NULL;
         if (sc2->intypeof == 1) sc2->intypeof = 2;
         sc2->fieldinit = NULL;
         sc2->fieldinit_dim = 0;
@@ -3917,8 +3912,7 @@ FuncAliasDeclaration::FuncAliasDeclaration(FuncDeclaration *funcalias, bool hasO
         assert(!funcalias->isFuncAliasDeclaration());
         this->hasOverloads = false;
     }
-    userAttributes = funcalias->userAttributes;
-    userAttributesScope = funcalias->userAttributesScope;
+    userAttribDecl = funcalias->userAttribDecl;
 }
 
 const char *FuncAliasDeclaration::kind()

--- a/src/inline.c
+++ b/src/inline.c
@@ -1403,8 +1403,13 @@ Expression *CallExp::inlineScan(InlineScanState *iss, Expression *eret)
         }
     }
 
-    if (e && type->ty != Tvoid)
+    if (e && type->ty != Tvoid &&
+        !type->equals(e->type) &&
+        e->type->hasWild() && !type->hasWild())
+    {
+        e = e->copy();
         e->type = type;
+    }
     return e;
 }
 

--- a/src/inline.c
+++ b/src/inline.c
@@ -747,21 +747,16 @@ Expression *DeclarationExp::doInline(InlineDoState *ids)
                     if (vd == ids->from[i])
                     {
                         vto = (VarDeclaration *)ids->to[i];
-                        if ((vd->storage_class & STCref) == 0 &&
-                            (vto->storage_class & STCref))
+                        Expression *e;
+                        if (vd->init && !vd->init->isVoidInitializer())
                         {
-                            Expression *e;
-                            if (vd->init && !vd->init->isVoidInitializer())
-                            {
-                                e = vd->init->toExpression();
-                                assert(e);
-                                e = e->doInline(ids);
-                            }
-                            else
-                                e = new IntegerExp(vd->init->loc, 0, Type::tint32);
-                            return e;
+                            e = vd->init->toExpression();
+                            assert(e);
+                            e = e->doInline(ids);
                         }
-                        goto L1;
+                        else
+                            e = new IntegerExp(vd->init->loc, 0, Type::tint32);
+                        return e;
                     }
                 }
             }
@@ -1783,6 +1778,10 @@ Expression *FuncDeclaration::expandInline(InlineScanState *iss,
 
             ids.from.push(nrvo_var);
             ids.to.push(vd);
+
+            Expression *de = new DeclarationExp(Loc(), vd);
+            de->type = Type::tvoid;
+            e = Expression::combine(e, de);
         }
     }
     if (arguments && arguments->dim)
@@ -1893,7 +1892,7 @@ Expression *FuncDeclaration::expandInline(InlineScanState *iss,
             //fprintf(stderr, "CallExp::inlineScan: e = "); e->print();
         }
     }
-    //printf("%s->expandInline = { %s }\n", toChars(), e->toChars());
+    //printf("%s->expandInline = { %s }\n", fd->toChars(), e->toChars());
 
     // Need to reevaluate whether parent can now be inlined
     // in expressions, as we might have inlined statements

--- a/src/scope.c
+++ b/src/scope.c
@@ -86,7 +86,7 @@ Scope::Scope()
     this->lastdc = NULL;
     this->lastoffset = 0;
     this->docbuf = NULL;
-    this->userAttributes = NULL;
+    this->userAttribDecl = NULL;
 }
 
 Scope::Scope(Scope *enclosing)
@@ -136,7 +136,7 @@ Scope::Scope(Scope *enclosing)
     this->lastdc = NULL;
     this->lastoffset = 0;
     this->docbuf = enclosing->docbuf;
-    this->userAttributes = enclosing->userAttributes;
+    this->userAttribDecl = enclosing->userAttribDecl;
     assert(this != enclosing);
 }
 

--- a/src/scope.h
+++ b/src/scope.h
@@ -26,6 +26,7 @@ class ForeachStatement;
 class ClassDeclaration;
 class AggregateDeclaration;
 class FuncDeclaration;
+class UserAttributeDeclaration;
 struct DocComment;
 class TemplateInstance;
 
@@ -106,7 +107,7 @@ struct Scope
 
     unsigned flags;
 
-    Expressions *userAttributes;        // user defined attributes
+    UserAttributeDeclaration *userAttribDecl;   // user defined attributes
 
     DocComment *lastdc;         // documentation comment for last symbol at this scope
     size_t lastoffset;        // offset in docbuf of where to insert next dec

--- a/src/struct.c
+++ b/src/struct.c
@@ -119,7 +119,8 @@ void AggregateDeclaration::semantic2(Scope *sc)
 {
     //printf("AggregateDeclaration::semantic2(%s)\n", toChars());
     if (scope && members)
-    {   error("has forward references");
+    {
+        error("has forward references");
         return;
     }
     if (members)
@@ -619,12 +620,7 @@ void StructDeclaration::semantic(Scope *sc)
     assert(!isAnonymous());
     if (sc->stc & STCabstract)
         error("structs, unions cannot be abstract");
-    userAttributes = sc->userAttributes;
-    if (userAttributes)
-    {
-        userAttributesScope = sc;
-        userAttributesScope->setNoFree();
-    }
+    userAttribDecl = sc->userAttribDecl;
 
     if (sizeok == SIZEOKnone)            // if not already done the addMember step
     {
@@ -645,7 +641,7 @@ void StructDeclaration::semantic(Scope *sc)
     sc2->protection = PROTpublic;
     sc2->explicitProtection = 0;
     sc2->structalign = STRUCTALIGN_DEFAULT;
-    sc2->userAttributes = NULL;
+    sc2->userAttribDecl = NULL;
 
     /* Set scope so if there are forward references, we still might be able to
      * resolve individual members like enums.

--- a/src/traits.c
+++ b/src/traits.c
@@ -576,12 +576,9 @@ Expression *TraitsExp::semantic(Scope *sc)
             goto Lfalse;
         }
         //printf("getAttributes %s, attrs = %p, scope = %p\n", s->toChars(), s->userAttributes, s->userAttributesScope);
-        Expressions *exps;
-        if (!s->userAttributes)
-            s->userAttributes = new Expressions();
-        Scope *sc2 = s->userAttributesScope ? s->userAttributesScope : sc;
-        TupleExp *tup = new TupleExp(loc, s->userAttributes);
-        return tup->semantic(sc2);
+        UserAttributeDeclaration *udad = s->userAttribDecl;
+        TupleExp *tup = new TupleExp(loc, udad ? udad->getAttributes() : new Expressions());
+        return tup->semantic(sc);
     }
     else if (ident == Id::allMembers || ident == Id::derivedMembers)
     {

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3936,6 +3936,23 @@ static assert( is(typeof(compiles!(test7876(11)))));
 static assert(!is(typeof(compiles!(test7876(10)))));
 
 /**************************************************
+    11824
+**************************************************/
+
+int f11824(T)()
+{
+    T[] arr = new T[](1);
+    T* getAddr(ref T a)
+    {
+        return &a;
+    }
+    getAddr(arr[0]);
+    return 1;
+}
+static assert(f11824!int());        // OK
+static assert(f11824!(int[])());    // OK <- NG
+
+/**************************************************
     6817 if converted to &&, only with -inline
 **************************************************/
 static assert({

--- a/test/compilable/test11824.d
+++ b/test/compilable/test11824.d
@@ -1,0 +1,72 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+struct Take(R)
+{
+    public R source;
+    private size_t _maxAvailable;
+
+    alias R Source;
+
+    @property bool empty()
+    {
+        return _maxAvailable == 0 || source.empty;
+    }
+
+    @property auto ref front()
+    {
+        return source.front;
+    }
+
+    void popFront()
+    {
+        source.popFront();
+        --_maxAvailable;
+    }
+
+    @property size_t length() const
+    {
+        return _maxAvailable;
+    }
+}
+
+struct Repeat(T)
+{
+    private T _value;
+
+    enum bool empty = false;
+    @property inout(T) front() inout { return _value; }
+    void popFront() {}
+}
+
+Take!(Repeat!T) repeat(T)(T value, size_t n)
+{
+    return typeof(return)(Repeat!T(value), n);
+}
+
+auto array(Range)(Range r)
+{
+    alias E = typeof(r.front);
+    //static if (hasLength!Range)
+    {
+        if (r.length == 0)
+            return null;
+
+        auto result = new E[](r.length);
+
+        size_t i;
+        static auto trustedGetAddr(T)(ref T t) @trusted nothrow pure
+        {
+            return &t;
+        }
+        foreach (e; r)
+        {
+            *trustedGetAddr(result[i]) = e;
+            ++i;
+        }
+        return cast(E[])result;
+    }
+}
+
+enum r = [1].repeat(1).array;
+static assert(r == [[1]]);

--- a/test/fail_compilation/fail12047.d
+++ b/test/fail_compilation/fail12047.d
@@ -1,0 +1,21 @@
+// REQUIRED_ARGS: -d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12047.d(15): Error: undefined identifier asdf
+fail_compilation/fail12047.d(16): Error: undefined identifier asdf
+fail_compilation/fail12047.d(17): Error: undefined identifier asdf
+fail_compilation/fail12047.d(18): Error: undefined identifier asdf
+fail_compilation/fail12047.d(19): Error: undefined identifier asdf
+fail_compilation/fail12047.d(20): Error: undefined identifier asdf
+fail_compilation/fail12047.d(21): Error: undefined identifier asdf
+---
+*/
+
+@asdf void func() { }
+@asdf int var = 1;
+@asdf enum E : int { a }
+@asdf struct S {}
+@asdf class C {}
+@asdf interface I {}
+@asdf typedef int myint;

--- a/test/fail_compilation/ice11969.d
+++ b/test/fail_compilation/ice11969.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice11969.d(9): Error: undefined identifier index
+fail_compilation/ice11969.d(10): Error: undefined identifier cond
+fail_compilation/ice11969.d(11): Error: undefined identifier msg
+---
+*/
+void test1() { mixin ([index]); }
+void test2() { mixin (assert(cond)); }
+void test3() { mixin (assert(0, msg)); }

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -299,6 +299,16 @@ void test9356()
 }
 
 /************************************/
+// 12079
+
+void test12079()
+{
+    string[string][string] foo;
+
+    foo.get("bar", null).get("baz", null);
+}
+
+/************************************/
 // 11223
 
 struct Tuple11223(T...)

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -444,6 +444,42 @@ void test11394()
 }
 
 /**********************************/
+// 12080
+
+class TZ12080 {}
+
+struct ST12080
+{
+    ST12080 opBinary()() const pure nothrow
+    {
+        auto retval = ST12080();
+        return retval;  // NRVO
+    }
+
+    long  _stdTime;
+    immutable TZ12080 _timezone;
+}
+
+class Foo12080
+{
+
+    ST12080 bar;
+    bool quux;
+
+    public ST12080 sysTime()
+    out {}
+    body
+    {
+        if (quux)
+            return ST12080();
+
+        return bar.opBinary();
+        // returned value is set to __result
+        // --> Inliner wrongly created the second DeclarationExp for __result.
+    }
+}
+
+/**********************************/
 
 int main()
 {

--- a/test/runnable/opover3.d
+++ b/test/runnable/opover3.d
@@ -56,9 +56,9 @@ void test2c()
     }
 
     Foo2c foo2c;
-    Foo2c foo2c_3 = Foo2c(1);                       // user ctor call
+    Foo2c foo2c_2 = Foo2c(1);                       // user ctor call
     static assert(!__traits(compiles, Foo2c(1,2))); // user ctor hides static opCall.
-    static assert(!__traits(compiles, Foo2c()));    // static opCall hides literal syntax.
+    Foo2c foo2c_3 = Foo2c();                        // literal syntax
 
     static assert(!__traits(compiles, foo2c(1)));
     foo2c(1,2);                                     // static opCall from instance
@@ -76,8 +76,8 @@ void test3()
     }
 
     Foo3 foo3;
+    Foo3 foo3_2 = Foo3();                           // literal syntax (default construction)
     Foo3 foo3_3 = Foo3(1);                          // user ctor call
-    static assert(!__traits(compiles, Foo3()));     // instance opCall hides literal syntax...right?
 
     assert(foo3(1) == 0);                           // instance opCall
     static assert(!__traits(compiles, foo3()));
@@ -95,9 +95,9 @@ void test3c()
     }
 
     Foo3c foo3c;
+    Foo3c foo3c_2 = Foo3c();                        // literal syntax (default construction)
     Foo3c foo3c_3 = Foo3c(1);                       // user ctor call
     static assert(!__traits(compiles, Foo3c(1,2))); // user ctor hides static opCall
-    static assert(!__traits(compiles, Foo3c()));    // static opCall hides literal syntax
 
     assert(foo3c(1,2) == Foo3c.init);               // static opCall from instance
     assert(foo3c(1) == 0);                          // instance opCall
@@ -117,11 +117,46 @@ void test4()
     Foo4 foo4;
     Foo4 foo4_4 = Foo4(1,2);                        // static opCall
     static assert(!__traits(compiles, Foo4(1)));
-    static assert(!__traits(compiles, Foo4()));     // static opCall hides literal syntax
+    static assert(!__traits(compiles, Foo4()));     // static opCall without constructor hides literal syntax
 
     assert(foo4(1,2) == Foo4.init);                 // static opCall from instance
     assert(foo4(1) == 0);                           // instance opCall
     static assert(!__traits(compiles, foo4()));
+}
+
+/**************************************/
+// 12070
+
+void test12070()
+{
+    static string result;
+
+    struct S
+    {
+        this(T...)(T)
+        {
+            result ~= "c" ~ cast(char)('0' + T.length);
+        }
+
+        void opCall(A...)(A)
+        {
+            result ~= "x" ~ cast(char)('0' + A.length);
+        }
+    }
+
+    auto s0 = S();
+    s0();
+    s0(1);
+    s0(1, 2);
+    assert(result == "x0x1x2");
+
+    result = null;
+
+    auto s1 = S(1);
+    s1();
+    s1('a');
+    s1('a', 'b');
+    assert(result == "c1x0x1x2");
 }
 
 /**************************************/
@@ -135,4 +170,5 @@ void main()
     test3();
     test3c();
     test4();
+    test12070();
 }


### PR DESCRIPTION
Four regression fixes:
[REG2.065a] Issue 12079 - Internal error: backend/cod4.c 358 for associative array access
[REG2.065a] Issue 12080 - Internal error: backend/symbol.c 1035 for invariant
[REG2.065a] Issue 12070 - Variant opCall not static
[REG2.065a] Issue 11824 - A stack variable escaping problem in CTFE Phobos code

One ICE fix:
Issue 11969 - ICE(statement.c) When mixing in a string literal containing errors

One diagnostic fix:
Pull 3212 - Remove repeated words in error message
