### PR TITLE
fix non-PIC relocation in 32-bit dso thunk

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -3271,7 +3271,7 @@ static void obj_rtinit()
         buf->writeByte(0);
         off += 4;
 
-        if (!I64)
+        if (config.flags3 & CFG3pic && I32)
         {   // see cod3_load_got() for reference
             // push EBX
             buf->writeByte(0x50 + BX);
@@ -3426,7 +3426,7 @@ static void obj_rtinit()
 
 #endif // REQUIRE_DSO_REGISTRY
 
-        if (!I64)
+        if (config.flags3 & CFG3pic && I32)
         {   // mov EBX,[EBP-4-align]
             buf->writeByte(0x8B);
             buf->writeByte(modregrm(1,BX,BP));

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -3289,27 +3289,45 @@ static void obj_rtinit()
             off += ElfObj::writerel(codseg, off, RI_TYPE_GOTPC, Obj::external(Obj::getGOTsym()), 3);
         }
 
-        int reltype = I64 ? R_X86_64_PC32 : RI_TYPE_SYM32;
+        int reltype;
+        if (config.flags3 & CFG3pic)
+            reltype = I64 ? R_X86_64_PC32 : RI_TYPE_GOTOFF;
+        else
+            reltype = I64 ? R_X86_64_32 : RI_TYPE_SYM32;
+
         const IDXSYM syms[] = {dso_rec, minfo_beg, minfo_end, deh_beg, deh_end};
+
         for (size_t i = sizeof(syms) / sizeof(syms[0]); i--; )
         {
             const IDXSYM sym = syms[i];
 
-            if (I64)
-            {  // lea RAX, sym[RIP]
-                buf->writeByte(REX | REX_W);
-                buf->writeByte(0x8D);
-                buf->writeByte(modregrm(0,AX,5));
-                off += 3;
-                off += ElfObj::writerel(codseg, off, reltype, syms[i], -4);
+            if (config.flags3 & CFG3pic)
+            {
+                if (I64)
+                {
+                    // lea RAX, sym[RIP]
+                    buf->writeByte(REX | REX_W);
+                    buf->writeByte(0x8D);
+                    buf->writeByte(modregrm(0,AX,5));
+                    off += 3;
+                    off += ElfObj::writerel(codseg, off, reltype, syms[i], -4);
+                }
+                else
+                {
+                    // lea EAX, sym[EBX]
+                    buf->writeByte(0x8D);
+                    buf->writeByte(modregrm(2,AX,BX));
+                    off += 2;
+                    off += ElfObj::writerel(codseg, off, reltype, syms[i], 0);
+                }
             }
             else
-            {  // mov EAX, sym
+            {
+                // mov EAX, sym
                 buf->writeByte(0xB8 + AX);
                 off += 1;
                 off += ElfObj::writerel(codseg, off, reltype, syms[i], 0);
             }
-
             // push RAX
             buf->writeByte(0x50 + AX);
             off += 1;


### PR DESCRIPTION
Related to #3187 which fixes text relocations for X86_64 PIC code.
This one fixes text relocations in the X86_32 DSO startup code.
Also see [Issue 11171 – Text relocations in Phobos shared library](https://d.puremagic.com/issues/show_bug.cgi?id=11171).
