### PR TITLE
[WIP] Refactor toCBuffer into a visitor

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -37,6 +37,8 @@
 #include "mtype.h"
 #include "utf.h"
 
+void functionToBufferFull(TypeFunction *tf, OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td);
+
 struct Escape
 {
     const char *strings[256];
@@ -899,7 +901,7 @@ void prefix(OutBuffer *buf, Dsymbol *s)
         else if (d->isAbstract())
             buf->writestring("abstract ");
 
-        if (!d->isFuncDeclaration())  // toCBufferWithAttributes handles this
+        if (!d->isFuncDeclaration())  // functionToBufferFull handles this
         {
             if (d->isConst())
                 buf->writestring("const ");
@@ -928,7 +930,7 @@ void declarationToDocBuffer(Declaration *decl, OutBuffer *buf, TemplateDeclarati
             if (origType->ty == Tfunction)
             {
                 TypeFunction *attrType = (TypeFunction*)(decl->ident == Id::ctor ? origType : decl->type);
-                ((TypeFunction*)origType)->toCBufferWithAttributes(buf, decl->ident, &hgs, attrType, td);
+                functionToBufferFull(((TypeFunction*)origType), buf, decl->ident, &hgs, attrType, td);
             }
             else
                 origType->toCBuffer(buf, decl->ident, &hgs);

--- a/src/expression.c
+++ b/src/expression.c
@@ -41,7 +41,7 @@
 bool isArrayOpValid(Expression *e);
 Expression *createTypeInfoArray(Scope *sc, Expression *args[], size_t dim);
 Expression *expandVar(int result, VarDeclaration *v);
-void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, int mod, const char *kind);
+void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, unsigned char mod, const char *kind);
 TypeTuple *toArgTypes(Type *t);
 
 #define LOGSEMANTIC     0

--- a/src/expression.c
+++ b/src/expression.c
@@ -41,7 +41,7 @@
 bool isArrayOpValid(Expression *e);
 Expression *createTypeInfoArray(Scope *sc, Expression *args[], size_t dim);
 Expression *expandVar(int result, VarDeclaration *v);
-void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, unsigned char mod, const char *kind);
+void functionToBufferWithIdent(TypeFunction *t, OutBuffer *buf, const char *ident);
 TypeTuple *toArgTypes(Type *t);
 
 #define LOGSEMANTIC     0
@@ -13932,9 +13932,8 @@ Expression *PrettyFuncInitExp::resolveLoc(Loc loc, Scope *sc)
     if (fd)
     {
         const char *funcStr = fd->Dsymbol::toPrettyChars();
-        HdrGenState hgs;
         OutBuffer buf;
-        functionToCBuffer2((TypeFunction *)fd->type, &buf, &hgs, 0, funcStr);
+        functionToBufferWithIdent((TypeFunction *)fd->type, &buf, funcStr);
         s = buf.extractString();
     }
     else

--- a/src/expression.c
+++ b/src/expression.c
@@ -43,6 +43,7 @@ Expression *createTypeInfoArray(Scope *sc, Expression *args[], size_t dim);
 Expression *expandVar(int result, VarDeclaration *v);
 void functionToBufferWithIdent(TypeFunction *t, OutBuffer *buf, const char *ident);
 TypeTuple *toArgTypes(Type *t);
+void toBufferShort(Type *t, OutBuffer *buf, HdrGenState *hgs);
 
 #define LOGSEMANTIC     0
 
@@ -1890,7 +1891,7 @@ void argExpTypesToCBuffer(OutBuffer *buf, Expressions *arguments, HdrGenState *h
             if (i)
                 buf->writestring(", ");
             argbuf.reset();
-            e->type->toCBuffer2(&argbuf, hgs, 0);
+            toBufferShort(e->type, &argbuf, hgs);
             buf->write(&argbuf);
         }
     }

--- a/src/func.c
+++ b/src/func.c
@@ -2025,7 +2025,7 @@ void FuncDeclaration::bodyToCBuffer(OutBuffer *buf, HdrGenState *hgs)
         {
             buf->writestring("in");
             buf->writenl();
-            frequire->toCBuffer(buf, hgs);
+            ::toCBuffer(frequire, buf, hgs);
         }
 
         // out{}
@@ -2039,7 +2039,7 @@ void FuncDeclaration::bodyToCBuffer(OutBuffer *buf, HdrGenState *hgs)
                 buf->writeByte(')');
             }
             buf->writenl();
-            fensure->toCBuffer(buf, hgs);
+            ::toCBuffer(fensure, buf, hgs);
         }
 
         if (frequire || fensure)
@@ -2051,7 +2051,7 @@ void FuncDeclaration::bodyToCBuffer(OutBuffer *buf, HdrGenState *hgs)
         buf->writeByte('{');
         buf->writenl();
         buf->level++;
-        fbody->toCBuffer(buf, hgs);
+        ::toCBuffer(fbody, buf, hgs);
         buf->level--;
         buf->writeByte('}');
         buf->writenl();

--- a/src/func.c
+++ b/src/func.c
@@ -28,7 +28,7 @@
 #include "parse.h"
 #include "rmem.h"
 
-void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, int mod, const char *kind);
+void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, unsigned char mod, const char *kind);
 void genCmain(Scope *sc);
 
 /********************************* FuncDeclaration ****************************/

--- a/src/func.c
+++ b/src/func.c
@@ -28,7 +28,7 @@
 #include "parse.h"
 #include "rmem.h"
 
-void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, unsigned char mod, const char *kind);
+void functionToBufferWithIdent(TypeFunction *t, OutBuffer *buf, const char *ident);
 void genCmain(Scope *sc);
 
 /********************************* FuncDeclaration ****************************/
@@ -3035,8 +3035,7 @@ const char *FuncDeclaration::toPrettyChars()
 const char *FuncDeclaration::toFullSignature()
 {
     OutBuffer buf;
-    HdrGenState hgs;
-    functionToCBuffer2((TypeFunction *)type, &buf, &hgs, 0, toChars());
+    functionToBufferWithIdent((TypeFunction *)type, &buf, toChars());
     return buf.extractString();
 }
 

--- a/src/func.c
+++ b/src/func.c
@@ -30,6 +30,7 @@
 
 void functionToBufferWithIdent(TypeFunction *t, OutBuffer *buf, const char *ident);
 void genCmain(Scope *sc);
+void toBufferShort(Type *t, OutBuffer *buf, HdrGenState *hgs);
 
 /********************************* FuncDeclaration ****************************/
 
@@ -3952,7 +3953,7 @@ void FuncLiteralDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     TypeFunction *tf = (TypeFunction *)type;
     // Don't print tf->mod, tf->trust, and tf->linkage
     if (!inferRetType && tf->next)
-        tf->next->toCBuffer2(buf, hgs, 0);
+        toBufferShort(tf->next, buf, hgs);
     Parameter::argsToCBuffer(buf, hgs, tf->parameters, tf->varargs);
 
     CompoundStatement *cs = fbody->isCompoundStatement();

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -1172,27 +1172,23 @@ void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, unsig
     }
     buf->writestring(kind);
     Parameter::argsToCBuffer(buf, hgs, t->parameters, t->varargs);
-    t->attributesToCBuffer(buf, modMask);
-}
 
-void TypeFunction::attributesToCBuffer(OutBuffer *buf, unsigned char modMask)
-{
     /* Use postfix style for attributes
      */
-    if (modMask != this->mod)
+    if (modMask != t->mod)
     {
-        modToBuffer(buf);
+        t->modToBuffer(buf);
     }
-    if (purity)
+    if (t->purity)
         buf->writestring(" pure");
-    if (isnothrow)
+    if (t->isnothrow)
         buf->writestring(" nothrow");
-    if (isproperty)
+    if (t->isproperty)
         buf->writestring(" @property");
-    if (isref)
+    if (t->isref)
         buf->writestring(" ref");
 
-    switch (trust)
+    switch (t->trust)
     {
         case TRUSTsystem:
             buf->writestring(" @system");

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -47,6 +47,7 @@ void sizeToCBuffer(OutBuffer *buf, HdrGenState *hgs, Expression *e);
 void trustToBuffer(OutBuffer *buf, TRUST trust);
 void linkageToBuffer(OutBuffer *buf, LINK linkage);
 void functionToBufferFull(TypeFunction *tf, OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td);
+void toBufferShort(Type *t, OutBuffer *buf, HdrGenState *hgs);
 
 void Module::genhdrfile()
 {
@@ -835,7 +836,7 @@ public:
 
         if (t->next)
         {
-            t->next->toCBuffer2(buf, hgs, 0);
+            visitWithMask(t->next, 0);
             buf->writeByte(' ');
         }
         buf->writestring(ident);
@@ -982,7 +983,7 @@ void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
         return;
     }
 
-    toCBuffer2(buf, hgs, 0);
+    toBufferShort(this, buf, hgs);
     if (ident)
     {
         buf->writeByte(' ');
@@ -990,10 +991,11 @@ void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
     }
 }
 
-void Type::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask)
+// Bypass the special printing of function and error types
+void toBufferShort(Type *t, OutBuffer *buf, HdrGenState *hgs)
 {
-    PrettyPrintVisitor v(buf, hgs, NULL, modMask);
-    v.visitWithMask(this, 0);
+    PrettyPrintVisitor v(buf, hgs, NULL, 0);
+    v.visitWithMask(t, 0);
 }
 
 void trustToBuffer(OutBuffer *buf, TRUST trust)
@@ -1072,7 +1074,7 @@ void functionToBufferFull(TypeFunction *tf, OutBuffer *buf, Identifier *ident, H
     if (!ident || ident->toHChars2() == ident->toChars())
     {
         if (tf->next)
-            tf->next->toCBuffer2(buf, hgs, 0);
+            toBufferShort(tf->next, buf, hgs);
         else if (hgs->ddoc)
             buf->writestring("auto");
     }

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -967,21 +967,21 @@ void toCBuffer(Statement *s, OutBuffer *buf, HdrGenState *hgs)
     s->accept(&v);
 }
 
-void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
+void toCBuffer(Type *t, OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
 {
-    if (ty == Tfunction)
+    if (t->ty == Tfunction)
     {
-        TypeFunction *tf = (TypeFunction *)this;
+        TypeFunction *tf = (TypeFunction *)t;
         functionToBufferFull(tf, buf, ident, hgs, tf, NULL);
         return;
     }
-    if (ty == Terror)
+    if (t->ty == Terror)
     {
         buf->writestring("_error_");
         return;
     }
 
-    toBufferShort(this, buf, hgs);
+    toBufferShort(t, buf, hgs);
     if (ident)
     {
         buf->writeByte(' ');

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -710,6 +710,14 @@ public:
 
     ////////////////////////////////////////////////////////////////////////////
 
+    void visitWithMask(Type *t, unsigned char mod)
+    {
+        unsigned char save = modMask;
+        modMask = mod;
+        t->accept(this);
+        modMask = save;
+    }
+
     void visit(Type *t)
     {
         if (modMask != t->mod)
@@ -740,7 +748,7 @@ public:
             return;
         }
         buf->writestring("__vector(");
-        t->basetype->toCBuffer2(buf, hgs, t->mod);
+        visitWithMask(t->basetype, t->mod);
         buf->writestring(")");
     }
 
@@ -751,7 +759,7 @@ public:
             t->toCBuffer3(buf, hgs, modMask);
             return;
         }
-        t->next->toCBuffer2(buf, hgs, t->mod);
+        visitWithMask(t->next, t->mod);
         buf->writeByte('[');
         sizeToCBuffer(buf, hgs, t->dim);
         buf->writeByte(']');
@@ -768,7 +776,7 @@ public:
             buf->writestring("string");
         else
         {
-            t->next->toCBuffer2(buf, hgs, t->mod);
+            visitWithMask(t->next, t->mod);
             buf->writestring("[]");
         }
     }
@@ -780,9 +788,9 @@ public:
             t->toCBuffer3(buf, hgs, modMask);
             return;
         }
-        t->next->toCBuffer2(buf, hgs, t->mod);
+        visitWithMask(t->next, t->mod);
         buf->writeByte('[');
-        t->index->toCBuffer2(buf, hgs, 0);
+        visitWithMask(t->index, 0);
         buf->writeByte(']');
     }
 
@@ -794,7 +802,7 @@ public:
             t->toCBuffer3(buf, hgs, modMask);
             return;
         }
-        t->next->toCBuffer2(buf, hgs, t->mod);
+        visitWithMask(t->next, t->mod);
         if (t->next->ty != Tfunction)
             buf->writeByte('*');
     }
@@ -806,7 +814,7 @@ public:
             t->toCBuffer3(buf, hgs, modMask);
             return;
         }
-        t->next->toCBuffer2(buf, hgs, t->mod);
+        visitWithMask(t->next, t->mod);
         buf->writeByte('&');
     }
 
@@ -941,7 +949,7 @@ public:
             t->toCBuffer3(buf, hgs, modMask);
             return;
         }
-        t->next->toCBuffer2(buf, hgs, t->mod);
+        visitWithMask(t->next, t->mod);
 
         buf->writeByte('[');
         sizeToCBuffer(buf, hgs, t->lwr);

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -757,7 +757,7 @@ public:
 
     void visit(Type *t)
     {
-        buf->writestring(t->toChars());
+        assert(0);
     }
 
     void visit(TypeBasic *t)

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -842,6 +842,23 @@ public:
         functionToCBuffer2((TypeFunction *)t->next, buf, hgs, modMask, "delegate");
     }
 
+    void visitTypeQualifiedHelper(TypeQualified *t)
+    {
+        for (size_t i = 0; i < t->idents.dim; i++)
+        {
+            RootObject *id = t->idents[i];
+            buf->writeByte('.');
+
+            if (id->dyncast() == DYNCAST_DSYMBOL)
+            {
+                TemplateInstance *ti = (TemplateInstance *)id;
+                ti->toCBuffer(buf, hgs);
+            }
+            else
+                buf->writestring(id->toChars());
+        }
+    }
+
     void visit(TypeIdentifier *t)
     {
         if (modMask != t->mod)
@@ -850,7 +867,7 @@ public:
             return;
         }
         buf->writestring(t->ident->toChars());
-        t->toCBuffer2Helper(buf, hgs);
+        visitTypeQualifiedHelper(t);
     }
 
     void visit(TypeInstance *t)
@@ -861,7 +878,7 @@ public:
             return;
         }
         t->tempinst->toCBuffer(buf, hgs);
-        t->toCBuffer2Helper(buf, hgs);
+        visitTypeQualifiedHelper(t);
     }
 
     void visit(TypeTypeof *t)
@@ -874,7 +891,7 @@ public:
         buf->writestring("typeof(");
         t->exp->toCBuffer(buf, hgs);
         buf->writeByte(')');
-        t->toCBuffer2Helper(buf, hgs);
+        visitTypeQualifiedHelper(t);
     }
 
     void visit(TypeReturn *t)
@@ -885,7 +902,7 @@ public:
             return;
         }
         buf->writestring("typeof(return)");
-        t->toCBuffer2Helper(buf, hgs);
+        visitTypeQualifiedHelper(t);
     }
 
     void visit(TypeEnum *t)
@@ -1189,22 +1206,5 @@ void TypeFunction::attributesToCBuffer(OutBuffer *buf, unsigned char modMask)
             buf->writestring(" @safe");
             break;
         default: break;
-    }
-}
-
-void TypeQualified::toCBuffer2Helper(OutBuffer *buf, HdrGenState *hgs)
-{
-    for (size_t i = 0; i < idents.dim; i++)
-    {   RootObject *id = idents[i];
-
-        buf->writeByte('.');
-
-        if (id->dyncast() == DYNCAST_DSYMBOL)
-        {
-            TemplateInstance *ti = (TemplateInstance *)id;
-            ti->toCBuffer(buf, hgs);
-        }
-        else
-            buf->writestring(id->toChars());
     }
 }

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -1031,17 +1031,24 @@ void toCBuffer(Statement *s, OutBuffer *buf, HdrGenState *hgs)
 
 void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
 {
+    if (ty == Tfunction)
+    {
+        TypeFunction *tf = (TypeFunction *)this;
+        functionToBufferFull(tf, buf, ident, hgs, tf, NULL);
+        return;
+    }
+    if (ty == Terror)
+    {
+        buf->writestring("_error_");
+        return;
+    }
+
     toCBuffer2(buf, hgs, 0);
     if (ident)
     {
         buf->writeByte(' ');
         buf->writestring(ident->toChars());
     }
-}
-
-void TypeError::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
-{
-    buf->writestring("_error_");
 }
 
 void Type::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask)
@@ -1080,11 +1087,6 @@ void Type::toCBuffer3(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask)
         if (m & MODshared)
             buf->writeByte(')');
     }
-}
-
-void TypeFunction::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
-{
-    functionToBufferFull(this, buf, ident, hgs, this, NULL);
 }
 
 void trustToBuffer(OutBuffer *buf, TRUST trust)

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -137,7 +137,7 @@ public:
         {
             Statement *sx = (*s->statements)[i];
             if (sx)
-                sx->toCBuffer(buf, hgs);
+                sx->accept(this);
         }
     }
 
@@ -205,7 +205,7 @@ public:
         {
             Statement *sx = (*s->statements)[i];
             if (sx)
-                sx->toCBuffer(buf, hgs);
+                sx->accept(this);
         }
 
         buf->level--;
@@ -220,7 +220,7 @@ public:
         buf->level++;
 
         if (s->statement)
-            s->statement->toCBuffer(buf, hgs);
+            s->statement->accept(this);
 
         buf->level--;
         buf->writeByte('}');
@@ -234,7 +234,7 @@ public:
         buf->writeByte(')');
         buf->writenl();
         if (s->body)
-            s->body->toCBuffer(buf, hgs);
+            s->body->accept(this);
     }
 
     void visit(DoStatement *s)
@@ -242,7 +242,7 @@ public:
         buf->writestring("do");
         buf->writenl();
         if (s->body)
-            s->body->toCBuffer(buf, hgs);
+            s->body->accept(this);
         buf->writestring("while (");
         s->condition->toCBuffer(buf, hgs);
         buf->writestring(");");
@@ -255,7 +255,7 @@ public:
         if (s->init)
         {
             hgs->FLinit.init++;
-            s->init->toCBuffer(buf, hgs);
+            s->init->accept(this);
             hgs->FLinit.init--;
         }
         else
@@ -276,7 +276,7 @@ public:
         buf->writeByte('{');
         buf->writenl();
         buf->level++;
-        s->body->toCBuffer(buf, hgs);
+        s->body->accept(this);
         buf->level--;
         buf->writeByte('}');
         buf->writenl();
@@ -306,7 +306,7 @@ public:
         buf->writenl();
         buf->level++;
         if (s->body)
-            s->body->toCBuffer(buf, hgs);
+            s->body->accept(this);
         buf->level--;
         buf->writeByte('}');
         buf->writenl();
@@ -332,7 +332,7 @@ public:
         buf->writenl();
         buf->level++;
         if (s->body)
-            s->body->toCBuffer(buf, hgs);
+            s->body->accept(this);
         buf->level--;
         buf->writeByte('}');
         buf->writenl();
@@ -357,7 +357,7 @@ public:
         buf->writenl();
         if (!s->ifbody->isScopeStatement())
             buf->level++;
-        s->ifbody->toCBuffer(buf, hgs);
+        s->ifbody->accept(this);
         if (!s->ifbody->isScopeStatement())
             buf->level--;
         if (s->elsebody)
@@ -366,7 +366,7 @@ public:
             buf->writenl();
             if (!s->elsebody->isScopeStatement())
                 buf->level++;
-            s->elsebody->toCBuffer(buf, hgs);
+            s->elsebody->accept(this);
             if (!s->elsebody->isScopeStatement())
                 buf->level--;
         }
@@ -380,7 +380,7 @@ public:
         buf->writenl();
         buf->level++;
         if (s->ifbody)
-            s->ifbody->toCBuffer(buf, hgs);
+            s->ifbody->accept(this);
         buf->level--;
         buf->writeByte('}');
         buf->writenl();
@@ -391,7 +391,7 @@ public:
             buf->writeByte('{');
             buf->level++;
             buf->writenl();
-            s->elsebody->toCBuffer(buf, hgs);
+            s->elsebody->accept(this);
             buf->level--;
             buf->writeByte('}');
             buf->writenl();
@@ -416,7 +416,7 @@ public:
             buf->writenl();
             buf->level++;
 
-            s->body->toCBuffer(buf, hgs);
+            s->body->accept(this);
 
             buf->level--;
             buf->writeByte('}');
@@ -447,14 +447,14 @@ public:
                 buf->writeByte('{');
                 buf->writenl();
                 buf->level++;
-                s->body->toCBuffer(buf, hgs);
+                s->body->accept(this);
                 buf->level--;
                 buf->writeByte('}');
                 buf->writenl();
             }
             else
             {
-                s->body->toCBuffer(buf, hgs);
+                s->body->accept(this);
             }
         }
     }
@@ -465,7 +465,7 @@ public:
         s->exp->toCBuffer(buf, hgs);
         buf->writeByte(':');
         buf->writenl();
-        s->statement->toCBuffer(buf, hgs);
+        s->statement->accept(this);
     }
 
     void visit(CaseRangeStatement *s)
@@ -476,14 +476,14 @@ public:
         s->last->toCBuffer(buf, hgs);
         buf->writeByte(':');
         buf->writenl();
-        s->statement->toCBuffer(buf, hgs);
+        s->statement->accept(this);
     }
 
     void visit(DefaultStatement *s)
     {
         buf->writestring("default:");
         buf->writenl();
-        s->statement->toCBuffer(buf, hgs);
+        s->statement->accept(this);
     }
 
     void visit(GotoDefaultStatement *s)
@@ -555,7 +555,7 @@ public:
         if (s->body)
         {
             buf->writeByte(' ');
-            s->body->toCBuffer(buf, hgs);
+            s->body->accept(this);
         }
     }
 
@@ -566,7 +566,7 @@ public:
         buf->writestring(")");
         buf->writenl();
         if (s->body)
-            s->body->toCBuffer(buf, hgs);
+            s->body->accept(this);
     }
 
     void visit(TryCatchStatement *s)
@@ -574,11 +574,11 @@ public:
         buf->writestring("try");
         buf->writenl();
         if (s->body)
-            s->body->toCBuffer(buf, hgs);
+            s->body->accept(this);
         for (size_t i = 0; i < s->catches->dim; i++)
         {
             Catch *c = (*s->catches)[i];
-            c->toCBuffer(buf, hgs);
+            visit(c);
         }
     }
 
@@ -589,7 +589,7 @@ public:
         buf->writeByte('{');
         buf->writenl();
         buf->level++;
-        s->body->toCBuffer(buf, hgs);
+        s->body->accept(this);
         buf->level--;
         buf->writeByte('}');
         buf->writenl();
@@ -598,7 +598,7 @@ public:
         buf->writeByte('{');
         buf->writenl();
         buf->level++;
-        s->finalbody->toCBuffer(buf, hgs);
+        s->finalbody->accept(this);
         buf->level--;
         buf->writeByte('}');
         buf->writenl();
@@ -608,7 +608,7 @@ public:
     {
         buf->writestring(Token::toChars(s->tok));
         buf->writeByte(' ');
-        s->statement->toCBuffer(buf, hgs);
+        s->statement->accept(this);
     }
 
     void visit(ThrowStatement *s)
@@ -623,7 +623,7 @@ public:
     {
         if (s->statement)
         {
-            s->statement->toCBuffer(buf, hgs);
+            s->statement->accept(this);
         }
     }
 
@@ -641,7 +641,7 @@ public:
         buf->writeByte(':');
         buf->writenl();
         if (s->statement)
-            s->statement->toCBuffer(buf, hgs);
+            s->statement->accept(this);
     }
 
     void visit(AsmStatement *s)
@@ -697,21 +697,15 @@ public:
         buf->writenl();
         buf->level++;
         if (c->handler)
-            c->handler->toCBuffer(buf, hgs);
+            c->handler->accept(this);
         buf->level--;
         buf->writeByte('}');
         buf->writenl();
     }
 };
 
-void Statement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
+void toCBuffer(Statement *s, OutBuffer *buf, HdrGenState *hgs)
 {
     PrettyPrintVisitor v(buf, hgs);
-    accept(&v);
-}
-
-void Catch::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    PrettyPrintVisitor v(buf, hgs);
-    v.visit(this);
+    s->accept(&v);
 }

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -83,3 +83,635 @@ void Module::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
         s->toCBuffer(buf, hgs);
     }
 }
+
+class PrettyPrintVisitor : public Visitor
+{
+public:
+    OutBuffer *buf;
+    HdrGenState *hgs;
+
+    PrettyPrintVisitor(OutBuffer *buf, HdrGenState *hgs)
+        : buf(buf), hgs(hgs)
+    {
+    }
+
+    void visit(Statement *s)
+    {
+        buf->printf("Statement::toCBuffer()");
+        buf->writenl();
+        assert(0);
+    }
+
+    void visit(ExpStatement *s)
+    {
+        if (s->exp)
+        {
+            s->exp->toCBuffer(buf, hgs);
+            if (s->exp->op != TOKdeclaration)
+            {
+                buf->writeByte(';');
+                if (!hgs->FLinit.init)
+                    buf->writenl();
+            }
+        }
+        else
+        {
+            buf->writeByte(';');
+            if (!hgs->FLinit.init)
+                buf->writenl();
+        }
+    }
+
+    void visit(CompileStatement *s)
+    {
+        buf->writestring("mixin(");
+        s->exp->toCBuffer(buf, hgs);
+        buf->writestring(");");
+        if (!hgs->FLinit.init)
+            buf->writenl();
+    }
+
+    void visit(CompoundStatement *s)
+    {
+        for (size_t i = 0; i < s->statements->dim; i++)
+        {
+            Statement *sx = (*s->statements)[i];
+            if (sx)
+                sx->toCBuffer(buf, hgs);
+        }
+    }
+
+    void visit(CompoundDeclarationStatement *s)
+    {
+        bool anywritten = false;
+        for (size_t i = 0; i < s->statements->dim; i++)
+        {
+            Statement *sx = (*s->statements)[i];
+            ExpStatement *ds;
+            if (sx &&
+                (ds = sx->isExpStatement()) != NULL &&
+                ds->exp->op == TOKdeclaration)
+            {
+                DeclarationExp *de = (DeclarationExp *)ds->exp;
+                Declaration *d = de->declaration->isDeclaration();
+                assert(d);
+                VarDeclaration *v = d->isVarDeclaration();
+                if (v)
+                {
+                    /* This essentially copies the part of VarDeclaration::toCBuffer()
+                     * that does not print the type.
+                     * Should refactor this.
+                     */
+                    if (anywritten)
+                    {
+                        buf->writestring(", ");
+                        buf->writestring(v->ident->toChars());
+                    }
+                    else
+                    {
+                        StorageClassDeclaration::stcToCBuffer(buf, v->storage_class);
+                        if (v->type)
+                            v->type->toCBuffer(buf, v->ident, hgs);
+                        else
+                            buf->writestring(v->ident->toChars());
+                    }
+
+                    if (v->init)
+                    {   buf->writestring(" = ");
+                        ExpInitializer *ie = v->init->isExpInitializer();
+                        if (ie && (ie->exp->op == TOKconstruct || ie->exp->op == TOKblit))
+                            ((AssignExp *)ie->exp)->e2->toCBuffer(buf, hgs);
+                        else
+                            v->init->toCBuffer(buf, hgs);
+                    }
+                }
+                else
+                    d->toCBuffer(buf, hgs);
+                anywritten = true;
+            }
+        }
+        buf->writeByte(';');
+        if (!hgs->FLinit.init)
+            buf->writenl();
+    }
+
+    void visit(UnrolledLoopStatement *s)
+    {
+        buf->writestring("unrolled {");
+        buf->writenl();
+        buf->level++;
+
+        for (size_t i = 0; i < s->statements->dim; i++)
+        {
+            Statement *sx = (*s->statements)[i];
+            if (sx)
+                sx->toCBuffer(buf, hgs);
+        }
+
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+    }
+
+    void visit(ScopeStatement *s)
+    {
+        buf->writeByte('{');
+        buf->writenl();
+        buf->level++;
+
+        if (s->statement)
+            s->statement->toCBuffer(buf, hgs);
+
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+    }
+
+    void visit(WhileStatement *s)
+    {
+        buf->writestring("while (");
+        s->condition->toCBuffer(buf, hgs);
+        buf->writeByte(')');
+        buf->writenl();
+        if (s->body)
+            s->body->toCBuffer(buf, hgs);
+    }
+
+    void visit(DoStatement *s)
+    {
+        buf->writestring("do");
+        buf->writenl();
+        if (s->body)
+            s->body->toCBuffer(buf, hgs);
+        buf->writestring("while (");
+        s->condition->toCBuffer(buf, hgs);
+        buf->writestring(");");
+        buf->writenl();
+    }
+
+    void visit(ForStatement *s)
+    {
+        buf->writestring("for (");
+        if (s->init)
+        {
+            hgs->FLinit.init++;
+            s->init->toCBuffer(buf, hgs);
+            hgs->FLinit.init--;
+        }
+        else
+            buf->writeByte(';');
+        if (s->condition)
+        {
+            buf->writeByte(' ');
+            s->condition->toCBuffer(buf, hgs);
+        }
+        buf->writeByte(';');
+        if (s->increment)
+        {
+            buf->writeByte(' ');
+            s->increment->toCBuffer(buf, hgs);
+        }
+        buf->writeByte(')');
+        buf->writenl();
+        buf->writeByte('{');
+        buf->writenl();
+        buf->level++;
+        s->body->toCBuffer(buf, hgs);
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+    }
+
+    void visit(ForeachStatement *s)
+    {
+        buf->writestring(Token::toChars(s->op));
+        buf->writestring(" (");
+        for (size_t i = 0; i < s->arguments->dim; i++)
+        {
+            Parameter *a = (*s->arguments)[i];
+            if (i)
+                buf->writestring(", ");
+            if (a->storageClass & STCref)
+                buf->writestring((char*)"ref ");
+            if (a->type)
+                a->type->toCBuffer(buf, a->ident, hgs);
+            else
+                buf->writestring(a->ident->toChars());
+        }
+        buf->writestring("; ");
+        s->aggr->toCBuffer(buf, hgs);
+        buf->writeByte(')');
+        buf->writenl();
+        buf->writeByte('{');
+        buf->writenl();
+        buf->level++;
+        if (s->body)
+            s->body->toCBuffer(buf, hgs);
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+    }
+
+    void visit(ForeachRangeStatement *s)
+    {
+        buf->writestring(Token::toChars(s->op));
+        buf->writestring(" (");
+
+        if (s->arg->type)
+            s->arg->type->toCBuffer(buf, s->arg->ident, hgs);
+        else
+            buf->writestring(s->arg->ident->toChars());
+
+        buf->writestring("; ");
+        s->lwr->toCBuffer(buf, hgs);
+        buf->writestring(" .. ");
+        s->upr->toCBuffer(buf, hgs);
+        buf->writeByte(')');
+        buf->writenl();
+        buf->writeByte('{');
+        buf->writenl();
+        buf->level++;
+        if (s->body)
+            s->body->toCBuffer(buf, hgs);
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+    }
+
+    void visit(IfStatement *s)
+    {
+        buf->writestring("if (");
+        if (s->arg)
+        {
+            if (s->arg->type)
+                s->arg->type->toCBuffer(buf, s->arg->ident, hgs);
+            else
+            {
+                buf->writestring("auto ");
+                buf->writestring(s->arg->ident->toChars());
+            }
+            buf->writestring(" = ");
+        }
+        s->condition->toCBuffer(buf, hgs);
+        buf->writeByte(')');
+        buf->writenl();
+        if (!s->ifbody->isScopeStatement())
+            buf->level++;
+        s->ifbody->toCBuffer(buf, hgs);
+        if (!s->ifbody->isScopeStatement())
+            buf->level--;
+        if (s->elsebody)
+        {
+            buf->writestring("else");
+            buf->writenl();
+            if (!s->elsebody->isScopeStatement())
+                buf->level++;
+            s->elsebody->toCBuffer(buf, hgs);
+            if (!s->elsebody->isScopeStatement())
+                buf->level--;
+        }
+    }
+
+    void visit(ConditionalStatement *s)
+    {
+        s->condition->toCBuffer(buf, hgs);
+        buf->writenl();
+        buf->writeByte('{');
+        buf->writenl();
+        buf->level++;
+        if (s->ifbody)
+            s->ifbody->toCBuffer(buf, hgs);
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+        if (s->elsebody)
+        {
+            buf->writestring("else");
+            buf->writenl();
+            buf->writeByte('{');
+            buf->level++;
+            buf->writenl();
+            s->elsebody->toCBuffer(buf, hgs);
+            buf->level--;
+            buf->writeByte('}');
+            buf->writenl();
+        }
+        buf->writenl();
+    }
+
+    void visit(PragmaStatement *s)
+    {
+        buf->writestring("pragma (");
+        buf->writestring(s->ident->toChars());
+        if (s->args && s->args->dim)
+        {
+            buf->writestring(", ");
+            argsToCBuffer(buf, s->args, hgs);
+        }
+        buf->writeByte(')');
+        if (s->body)
+        {
+            buf->writenl();
+            buf->writeByte('{');
+            buf->writenl();
+            buf->level++;
+
+            s->body->toCBuffer(buf, hgs);
+
+            buf->level--;
+            buf->writeByte('}');
+            buf->writenl();
+        }
+        else
+        {
+            buf->writeByte(';');
+            buf->writenl();
+        }
+    }
+
+    void visit(StaticAssertStatement *s)
+    {
+        s->sa->toCBuffer(buf, hgs);
+    }
+
+    void visit(SwitchStatement *s)
+    {
+        buf->writestring(s->isFinal ? "final switch (" : "switch (");
+        s->condition->toCBuffer(buf, hgs);
+        buf->writeByte(')');
+        buf->writenl();
+        if (s->body)
+        {
+            if (!s->body->isScopeStatement())
+            {
+                buf->writeByte('{');
+                buf->writenl();
+                buf->level++;
+                s->body->toCBuffer(buf, hgs);
+                buf->level--;
+                buf->writeByte('}');
+                buf->writenl();
+            }
+            else
+            {
+                s->body->toCBuffer(buf, hgs);
+            }
+        }
+    }
+
+    void visit(CaseStatement *s)
+    {
+        buf->writestring("case ");
+        s->exp->toCBuffer(buf, hgs);
+        buf->writeByte(':');
+        buf->writenl();
+        s->statement->toCBuffer(buf, hgs);
+    }
+
+    void visit(CaseRangeStatement *s)
+    {
+        buf->writestring("case ");
+        s->first->toCBuffer(buf, hgs);
+        buf->writestring(": .. case ");
+        s->last->toCBuffer(buf, hgs);
+        buf->writeByte(':');
+        buf->writenl();
+        s->statement->toCBuffer(buf, hgs);
+    }
+
+    void visit(DefaultStatement *s)
+    {
+        buf->writestring("default:");
+        buf->writenl();
+        s->statement->toCBuffer(buf, hgs);
+    }
+
+    void visit(GotoDefaultStatement *s)
+    {
+        buf->writestring("goto default;");
+        buf->writenl();
+    }
+
+    void visit(GotoCaseStatement *s)
+    {
+        buf->writestring("goto case");
+        if (s->exp)
+        {
+            buf->writeByte(' ');
+            s->exp->toCBuffer(buf, hgs);
+        }
+        buf->writeByte(';');
+        buf->writenl();
+    }
+
+    void visit(SwitchErrorStatement *s)
+    {
+        buf->writestring("SwitchErrorStatement::toCBuffer()");
+        buf->writenl();
+    }
+
+    void visit(ReturnStatement *s)
+    {
+        buf->printf("return ");
+        if (s->exp)
+            s->exp->toCBuffer(buf, hgs);
+        buf->writeByte(';');
+        buf->writenl();
+    }
+
+    void visit(BreakStatement *s)
+    {
+        buf->writestring("break");
+        if (s->ident)
+        {
+            buf->writeByte(' ');
+            buf->writestring(s->ident->toChars());
+        }
+        buf->writeByte(';');
+        buf->writenl();
+    }
+
+    void visit(ContinueStatement *s)
+    {
+        buf->writestring("continue");
+        if (s->ident)
+        {
+            buf->writeByte(' ');
+            buf->writestring(s->ident->toChars());
+        }
+        buf->writeByte(';');
+        buf->writenl();
+    }
+
+    void visit(SynchronizedStatement *s)
+    {
+        buf->writestring("synchronized");
+        if (s->exp)
+        {
+            buf->writeByte('(');
+            s->exp->toCBuffer(buf, hgs);
+            buf->writeByte(')');
+        }
+        if (s->body)
+        {
+            buf->writeByte(' ');
+            s->body->toCBuffer(buf, hgs);
+        }
+    }
+
+    void visit(WithStatement *s)
+    {
+        buf->writestring("with (");
+        s->exp->toCBuffer(buf, hgs);
+        buf->writestring(")");
+        buf->writenl();
+        if (s->body)
+            s->body->toCBuffer(buf, hgs);
+    }
+
+    void visit(TryCatchStatement *s)
+    {
+        buf->writestring("try");
+        buf->writenl();
+        if (s->body)
+            s->body->toCBuffer(buf, hgs);
+        for (size_t i = 0; i < s->catches->dim; i++)
+        {
+            Catch *c = (*s->catches)[i];
+            c->toCBuffer(buf, hgs);
+        }
+    }
+
+    void visit(TryFinallyStatement *s)
+    {
+        buf->writestring("try");
+        buf->writenl();
+        buf->writeByte('{');
+        buf->writenl();
+        buf->level++;
+        s->body->toCBuffer(buf, hgs);
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+        buf->writestring("finally");
+        buf->writenl();
+        buf->writeByte('{');
+        buf->writenl();
+        buf->level++;
+        s->finalbody->toCBuffer(buf, hgs);
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+    }
+
+    void visit(OnScopeStatement *s)
+    {
+        buf->writestring(Token::toChars(s->tok));
+        buf->writeByte(' ');
+        s->statement->toCBuffer(buf, hgs);
+    }
+
+    void visit(ThrowStatement *s)
+    {
+        buf->printf("throw ");
+        s->exp->toCBuffer(buf, hgs);
+        buf->writeByte(';');
+        buf->writenl();
+    }
+
+    void visit(DebugStatement *s)
+    {
+        if (s->statement)
+        {
+            s->statement->toCBuffer(buf, hgs);
+        }
+    }
+
+    void visit(GotoStatement *s)
+    {
+        buf->writestring("goto ");
+        buf->writestring(s->ident->toChars());
+        buf->writeByte(';');
+        buf->writenl();
+    }
+
+    void visit(LabelStatement *s)
+    {
+        buf->writestring(s->ident->toChars());
+        buf->writeByte(':');
+        buf->writenl();
+        if (s->statement)
+            s->statement->toCBuffer(buf, hgs);
+    }
+
+    void visit(AsmStatement *s)
+    {
+        buf->writestring("asm { ");
+        Token *t = s->tokens;
+        buf->level++;
+        while (t)
+        {
+            buf->writestring(t->toChars());
+            if (t->next                         &&
+               t->value != TOKmin               &&
+               t->value != TOKcomma             &&
+               t->next->value != TOKcomma       &&
+               t->value != TOKlbracket          &&
+               t->next->value != TOKlbracket    &&
+               t->next->value != TOKrbracket    &&
+               t->value != TOKlparen            &&
+               t->next->value != TOKlparen      &&
+               t->next->value != TOKrparen      &&
+               t->value != TOKdot               &&
+               t->next->value != TOKdot)
+            {
+                buf->writeByte(' ');
+            }
+            t = t->next;
+        }
+        buf->level--;
+        buf->writestring("; }");
+        buf->writenl();
+    }
+
+    void visit(ImportStatement *s)
+    {
+        for (size_t i = 0; i < s->imports->dim; i++)
+        {
+            Dsymbol *imp = (*s->imports)[i];
+            imp->toCBuffer(buf, hgs);
+        }
+    }
+
+    void visit(Catch *c)
+    {
+        buf->writestring("catch");
+        if (c->type)
+        {
+            buf->writeByte('(');
+            c->type->toCBuffer(buf, c->ident, hgs);
+            buf->writeByte(')');
+        }
+        buf->writenl();
+        buf->writeByte('{');
+        buf->writenl();
+        buf->level++;
+        if (c->handler)
+            c->handler->toCBuffer(buf, hgs);
+        buf->level--;
+        buf->writeByte('}');
+        buf->writenl();
+    }
+};
+
+void Statement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
+{
+    PrettyPrintVisitor v(buf, hgs);
+    accept(&v);
+}
+
+void Catch::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
+{
+    PrettyPrintVisitor v(buf, hgs);
+    v.visit(this);
+}

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -94,12 +94,10 @@ class PrettyPrintVisitor : public Visitor
 public:
     OutBuffer *buf;
     HdrGenState *hgs;
-
-    Identifier *ident; // for printing "Type ident" of variables/parameters
     unsigned char modMask;
 
-    PrettyPrintVisitor(OutBuffer *buf, HdrGenState *hgs, Identifier *ident, unsigned char modMask)
-        : buf(buf), hgs(hgs), ident(ident), modMask(modMask)
+    PrettyPrintVisitor(OutBuffer *buf, HdrGenState *hgs)
+        : buf(buf), hgs(hgs), modMask(0)
     {
     }
 
@@ -965,7 +963,7 @@ public:
 
 void toCBuffer(Statement *s, OutBuffer *buf, HdrGenState *hgs)
 {
-    PrettyPrintVisitor v(buf, hgs, NULL, 0);
+    PrettyPrintVisitor v(buf, hgs);
     s->accept(&v);
 }
 
@@ -994,7 +992,7 @@ void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
 // Bypass the special printing of function and error types
 void toBufferShort(Type *t, OutBuffer *buf, HdrGenState *hgs)
 {
-    PrettyPrintVisitor v(buf, hgs, NULL, 0);
+    PrettyPrintVisitor v(buf, hgs);
     v.visitWithMask(t, 0);
 }
 
@@ -1106,6 +1104,6 @@ void functionToBufferFull(TypeFunction *tf, OutBuffer *buf, Identifier *ident, H
 void functionToBufferWithIdent(TypeFunction *t, OutBuffer *buf, const char *ident)
 {
     HdrGenState hgs;
-    PrettyPrintVisitor v(buf, &hgs, NULL, 0);
+    PrettyPrintVisitor v(buf, &hgs);
     v.visitFuncIdent(t, ident);
 }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -44,6 +44,7 @@
 #include "hdrgen.h"
 
 FuncDeclaration *hasThis(Scope *sc);
+void toCBuffer(Type *t, OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
 
 #define LOGDOTEXP       0       // log ::dotExp()
 #define LOGDEFAULTINIT  0       // log ::defaultInit()
@@ -1577,6 +1578,11 @@ char *Type::toChars()
 
     toCBuffer(&buf, NULL, &hgs);
     return buf.extractString();
+}
+
+void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
+{
+    ::toCBuffer(this, buf, ident, hgs);
 }
 
 /*********************************

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -44,7 +44,6 @@
 #include "hdrgen.h"
 
 FuncDeclaration *hasThis(Scope *sc);
-void sizeToCBuffer(OutBuffer *buf, HdrGenState *hgs, Expression *e);
 
 #define LOGDOTEXP       0       // log ::dotExp()
 #define LOGDEFAULTINIT  0       // log ::defaultInit()
@@ -1580,58 +1579,6 @@ char *Type::toChars()
     return buf.extractString();
 }
 
-void Type::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
-{
-    toCBuffer2(buf, hgs, 0);
-    if (ident)
-    {
-        buf->writeByte(' ');
-        buf->writestring(ident->toChars());
-    }
-}
-
-void Type::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {
-        toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring(toChars());
-}
-
-void Type::toCBuffer3(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {
-        unsigned char m = this->mod & ~(this->mod & mod);
-        if (m & MODshared)
-        {
-            MODtoBuffer(buf, MODshared);
-            buf->writeByte('(');
-        }
-        if (m & MODwild)
-        {
-            MODtoBuffer(buf, MODwild);
-            buf->writeByte('(');
-        }
-        if (m & (MODconst | MODimmutable))
-        {
-            MODtoBuffer(buf, m & (MODconst | MODimmutable));
-            buf->writeByte('(');
-        }
-
-        toCBuffer2(buf, hgs, this->mod);
-
-        if (m & (MODconst | MODimmutable))
-            buf->writeByte(')');
-        if (m & MODwild)
-            buf->writeByte(')');
-        if (m & MODshared)
-            buf->writeByte(')');
-    }
-}
-
 /*********************************
  * Store this type's modifier name into buf.
  */
@@ -2570,11 +2517,6 @@ Type *TypeError::syntaxCopy()
     return this;
 }
 
-void TypeError::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
-{
-    buf->writestring("_error_");
-}
-
 d_uns64 TypeError::size(Loc loc) { return SIZE_INVALID; }
 Expression *TypeError::getProperty(Loc loc, Identifier *ident, int flag) { return new ErrorExp(); }
 Expression *TypeError::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag) { return new ErrorExp(); }
@@ -3046,16 +2988,6 @@ Type *TypeBasic::syntaxCopy()
 char *TypeBasic::toChars()
 {
     return Type::toChars();
-}
-
-void TypeBasic::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    //printf("TypeBasic::toCBuffer2(mod = %d, this->mod = %d)\n", mod, this->mod);
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring(dstring);
 }
 
 d_uns64 TypeBasic::size(Loc loc)
@@ -3695,18 +3627,6 @@ char *TypeVector::toChars()
     return Type::toChars();
 }
 
-void TypeVector::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    //printf("TypeVector::toCBuffer2(mod = %d, this->mod = %d)\n", mod, this->mod);
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring("__vector(");
-    basetype->toCBuffer2(buf, hgs, this->mod);
-    buf->writestring(")");
-}
-
 void TypeVector::toDecoBuffer(OutBuffer *buf, int flag)
 {
     if (flag != mod && flag != 0x100)
@@ -4293,18 +4213,6 @@ void TypeSArray::toDecoBuffer(OutBuffer *buf, int flag)
         next->toDecoBuffer(buf,  (flag & 0x100) ? flag : mod);
 }
 
-void TypeSArray::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    next->toCBuffer2(buf, hgs, this->mod);
-    buf->writeByte('[');
-    sizeToCBuffer(buf, hgs, dim);
-    buf->writeByte(']');
-}
-
 Expression *TypeSArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag)
 {
 #if LOGDOTEXP
@@ -4597,20 +4505,6 @@ void TypeDArray::toDecoBuffer(OutBuffer *buf, int flag)
     Type::toDecoBuffer(buf, flag);
     if (next)
         next->toDecoBuffer(buf, (flag & 0x100) ? 0 : mod);
-}
-
-void TypeDArray::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    if (equals(tstring))
-        buf->writestring("string");
-    else
-    {   next->toCBuffer2(buf, hgs, this->mod);
-        buf->writestring("[]");
-    }
 }
 
 Expression *TypeDArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag)
@@ -4990,18 +4884,6 @@ void TypeAArray::toDecoBuffer(OutBuffer *buf, int flag)
     next->toDecoBuffer(buf, (flag & 0x100) ? 0 : mod);
 }
 
-void TypeAArray::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    next->toCBuffer2(buf, hgs, this->mod);
-    buf->writeByte('[');
-    index->toCBuffer2(buf, hgs, 0);
-    buf->writeByte(']');
-}
-
 Expression *TypeAArray::defaultInit(Loc loc)
 {
 #if LOGDEFAULTINIT
@@ -5164,18 +5046,6 @@ d_uns64 TypePointer::size(Loc loc)
     return Target::ptrsize;
 }
 
-void TypePointer::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    //printf("TypePointer::toCBuffer2() next = %d\n", next->ty);
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    next->toCBuffer2(buf, hgs, this->mod);
-    if (next->ty != Tfunction)
-        buf->writeByte('*');
-}
-
 MATCH TypePointer::implicitConvTo(Type *to)
 {
     //printf("TypePointer::implicitConvTo(to = %s) %s\n", to->toChars(), toChars());
@@ -5305,16 +5175,6 @@ Type *TypeReference::semantic(Loc loc, Scope *sc)
 d_uns64 TypeReference::size(Loc loc)
 {
     return Target::ptrsize;
-}
-
-void TypeReference::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    next->toCBuffer2(buf, hgs, this->mod);
-    buf->writeByte('&');
 }
 
 Expression *TypeReference::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag)
@@ -5632,184 +5492,6 @@ void TypeFunction::toDecoBuffer(OutBuffer *buf, int flag)
     if (next != NULL)
         next->toDecoBuffer(buf);
     inuse--;
-}
-
-void TypeFunction::toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs)
-{
-    toCBufferWithAttributes(buf, ident, hgs, this, NULL);
-}
-
-void TypeFunction::toCBufferWithAttributes(OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td)
-{
-    //printf("TypeFunction::toCBuffer() this = %p\n", this);
-    if (inuse)
-    {   inuse = 2;              // flag error to caller
-        return;
-    }
-    inuse++;
-
-    /* Use 'storage class' style for attributes
-     */
-    if (attrs->mod)
-    {
-        MODtoBuffer(buf, attrs->mod);
-        buf->writeByte(' ');
-    }
-
-    if (attrs->purity)
-        buf->writestring("pure ");
-    if (attrs->isnothrow)
-        buf->writestring("nothrow ");
-    if (attrs->isproperty)
-        buf->writestring("@property ");
-    if (attrs->isref)
-        buf->writestring("ref ");
-
-    switch (attrs->trust)
-    {
-        case TRUSTsystem:
-            buf->writestring("@system ");
-            break;
-
-        case TRUSTtrusted:
-            buf->writestring("@trusted ");
-            break;
-
-        case TRUSTsafe:
-            buf->writestring("@safe ");
-            break;
-        default: break;
-    }
-
-    if (hgs->ddoc != 1)
-    {
-        const char *p = NULL;
-        switch (attrs->linkage)
-        {
-            case LINKd:         p = NULL;       break;
-            case LINKc:         p = "C";        break;
-            case LINKwindows:   p = "Windows";  break;
-            case LINKpascal:    p = "Pascal";   break;
-            case LINKcpp:       p = "C++";      break;
-            default:
-                assert(0);
-        }
-        if (!hgs->hdrgen && p)
-        {
-            buf->writestring("extern (");
-            buf->writestring(p);
-            buf->writestring(") ");
-        }
-    }
-
-    if (!ident || ident->toHChars2() == ident->toChars())
-    {   if (next)
-            next->toCBuffer2(buf, hgs, 0);
-        else if (hgs->ddoc)
-            buf->writestring("auto");
-    }
-
-    if (ident)
-    {
-        if (next || hgs->ddoc)
-            buf->writeByte(' ');
-        buf->writestring(ident->toHChars2());
-    }
-
-    if (td)
-    {   buf->writeByte('(');
-        for (size_t i = 0; i < td->origParameters->dim; i++)
-        {
-            TemplateParameter *tp = (*td->origParameters)[i];
-            if (i)
-                buf->writestring(", ");
-            tp->toCBuffer(buf, hgs);
-        }
-        buf->writeByte(')');
-    }
-    Parameter::argsToCBuffer(buf, hgs, parameters, varargs);
-    inuse--;
-}
-
-// kind is inserted before the argument list and will usually be "function" or "delegate".
-void functionToCBuffer2(TypeFunction *t, OutBuffer *buf, HdrGenState *hgs, int mod, const char *kind)
-{
-    if (hgs->ddoc != 1)
-    {
-        const char *p = NULL;
-        switch (t->linkage)
-        {
-            case LINKd:         p = NULL;       break;
-            case LINKc:         p = "C";        break;
-            case LINKwindows:   p = "Windows";  break;
-            case LINKpascal:    p = "Pascal";   break;
-            case LINKcpp:       p = "C++";      break;
-            default:
-                assert(0);
-        }
-        if (!hgs->hdrgen && p)
-        {
-            buf->writestring("extern (");
-            buf->writestring(p);
-            buf->writestring(") ");
-        }
-    }
-    if (t->next)
-    {
-        t->next->toCBuffer2(buf, hgs, 0);
-        buf->writeByte(' ');
-    }
-    buf->writestring(kind);
-    Parameter::argsToCBuffer(buf, hgs, t->parameters, t->varargs);
-    t->attributesToCBuffer(buf, mod);
-}
-
-void TypeFunction::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    //printf("TypeFunction::toCBuffer2() this = %p, ref = %d\n", this, isref);
-    if (inuse)
-    {   inuse = 2;              // flag error to caller
-        return;
-    }
-    inuse++;
-
-    functionToCBuffer2(this, buf, hgs, mod, "function");
-
-    inuse--;
-}
-
-void TypeFunction::attributesToCBuffer(OutBuffer *buf, int mod)
-{
-    /* Use postfix style for attributes
-     */
-    if (mod != this->mod)
-    {
-        modToBuffer(buf);
-    }
-    if (purity)
-        buf->writestring(" pure");
-    if (isnothrow)
-        buf->writestring(" nothrow");
-    if (isproperty)
-        buf->writestring(" @property");
-    if (isref)
-        buf->writestring(" ref");
-
-    switch (trust)
-    {
-        case TRUSTsystem:
-            buf->writestring(" @system");
-            break;
-
-        case TRUSTtrusted:
-            buf->writestring(" @trusted");
-            break;
-
-        case TRUSTsafe:
-            buf->writestring(" @safe");
-            break;
-        default: break;
-    }
 }
 
 Type *TypeFunction::semantic(Loc loc, Scope *sc)
@@ -6652,16 +6334,6 @@ MATCH TypeDelegate::implicitConvTo(Type *to)
     return MATCHnomatch;
 }
 
-void TypeDelegate::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-
-    functionToCBuffer2((TypeFunction *)next, buf, hgs, mod, "delegate");
-}
-
 Expression *TypeDelegate::defaultInit(Loc loc)
 {
 #if LOGDEFAULTINIT
@@ -6758,23 +6430,6 @@ void TypeQualified::addIdent(Identifier *ident)
 void TypeQualified::addInst(TemplateInstance *inst)
 {
     idents.push(inst);
-}
-
-void TypeQualified::toCBuffer2Helper(OutBuffer *buf, HdrGenState *hgs)
-{
-    for (size_t i = 0; i < idents.dim; i++)
-    {   RootObject *id = idents[i];
-
-        buf->writeByte('.');
-
-        if (id->dyncast() == DYNCAST_DSYMBOL)
-        {
-            TemplateInstance *ti = (TemplateInstance *)id;
-            ti->toCBuffer(buf, hgs);
-        }
-        else
-            buf->writestring(id->toChars());
-    }
 }
 
 d_uns64 TypeQualified::size(Loc loc)
@@ -7028,16 +6683,6 @@ void TypeIdentifier::toDecoBuffer(OutBuffer *buf, int flag)
     buf->printf("%u%s", (unsigned)len, name);
 }
 
-void TypeIdentifier::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring(this->ident->toChars());
-    toCBuffer2Helper(buf, hgs);
-}
-
 /*************************************
  * Takes an array of Identifiers and figures out if
  * it represents a Type or an Expression.
@@ -7220,17 +6865,6 @@ Type *TypeInstance::syntaxCopy()
     return t;
 }
 
-
-void TypeInstance::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    tempinst->toCBuffer(buf, hgs);
-    toCBuffer2Helper(buf, hgs);
-}
-
 void TypeInstance::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid)
 {
     // Note close similarity to TypeIdentifier::resolve()
@@ -7386,18 +7020,6 @@ Dsymbol *TypeTypeof::toDsymbol(Scope *sc)
     if (t == this)
         return NULL;
     return t->toDsymbol(sc);
-}
-
-void TypeTypeof::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring("typeof(");
-    exp->toCBuffer(buf, hgs);
-    buf->writeByte(')');
-    toCBuffer2Helper(buf, hgs);
 }
 
 void TypeTypeof::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid)
@@ -7646,17 +7268,6 @@ Type *TypeReturn::semantic(Loc loc, Scope *sc)
     return t;
 }
 
-void TypeReturn::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring("typeof(return)");
-    toCBuffer2Helper(buf, hgs);
-}
-
-
 /***************************** TypeEnum *****************************/
 
 TypeEnum::TypeEnum(EnumDeclaration *sym)
@@ -7720,15 +7331,6 @@ void TypeEnum::toDecoBuffer(OutBuffer *buf, int flag)
     const char *name = sym->mangle();
     Type::toDecoBuffer(buf, flag);
     buf->writestring(name);
-}
-
-void TypeEnum::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring(sym->toChars());
 }
 
 Expression *TypeEnum::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag)
@@ -7947,16 +7549,6 @@ void TypeTypedef::toDecoBuffer(OutBuffer *buf, int flag)
     Type::toDecoBuffer(buf, flag);
     const char *name = sym->mangle();
     buf->writestring(name);
-}
-
-void TypeTypedef::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    //printf("TypeTypedef::toCBuffer2() '%s'\n", sym->toChars());
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring(sym->toChars());
 }
 
 Expression *TypeTypedef::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag)
@@ -8251,20 +7843,6 @@ void TypeStruct::toDecoBuffer(OutBuffer *buf, int flag)
     //printf("TypeStruct::toDecoBuffer('%s') = '%s'\n", toChars(), name);
     Type::toDecoBuffer(buf, flag);
     buf->writestring(name);
-}
-
-void TypeStruct::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {
-        toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    TemplateInstance *ti = sym->parent->isTemplateInstance();
-    if (ti && ti->toAlias() == sym)
-        buf->writestring(ti->toChars());
-    else
-        buf->writestring(sym->toChars());
 }
 
 Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag)
@@ -8812,20 +8390,6 @@ void TypeClass::toDecoBuffer(OutBuffer *buf, int flag)
     //printf("TypeClass::toDecoBuffer('%s' flag=%d mod=%x) = '%s'\n", toChars(), flag, mod, name);
     Type::toDecoBuffer(buf, flag);
     buf->writestring(name);
-}
-
-void TypeClass::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {
-        toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    TemplateInstance *ti = sym->parent->isTemplateInstance();
-    if (ti && ti->toAlias() == sym)
-        buf->writestring(ti->toChars());
-    else
-        buf->writestring(sym->toChars());
 }
 
 Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident, int flag)
@@ -9483,11 +9047,6 @@ Type *TypeTuple::makeConst()
 }
 #endif
 
-void TypeTuple::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    Parameter::argsToCBuffer(buf, hgs, arguments, 0);
-}
-
 void TypeTuple::toDecoBuffer(OutBuffer *buf, int flag)
 {
     //printf("TypeTuple::toDecoBuffer() this = %p, %s\n", this, toChars());
@@ -9670,21 +9229,6 @@ void TypeSlice::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol 
     }
 }
 
-void TypeSlice::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {   toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    next->toCBuffer2(buf, hgs, this->mod);
-
-    buf->writeByte('[');
-    sizeToCBuffer(buf, hgs, lwr);
-    buf->writestring(" .. ");
-    sizeToCBuffer(buf, hgs, upr);
-    buf->writeByte(']');
-}
-
 /***************************** TypeNull *****************************/
 
 TypeNull::TypeNull()
@@ -9735,16 +9279,6 @@ void TypeNull::toDecoBuffer(OutBuffer *buf, int flag)
 {
     //tvoidptr->toDecoBuffer(buf, flag);
     Type::toDecoBuffer(buf, flag);
-}
-
-void TypeNull::toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod)
-{
-    if (mod != this->mod)
-    {
-        toCBuffer3(buf, hgs, mod);
-        return;
-    }
-    buf->writestring("typeof(null)");
 }
 
 d_uns64 TypeNull::size(Loc loc) { return tvoidptr->size(loc); }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -648,7 +648,6 @@ public:
     void purityLevel();
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
-    void toCBufferWithAttributes(OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL);
     TypeInfoDeclaration *getTypeInfoDeclaration();
     Type *reliesOnTident(TemplateParameters *tparams = NULL);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -248,7 +248,6 @@ public:
     Type *merge();
     Type *merge2();
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask);
     void modToBuffer(OutBuffer *buf);
     char *modToChars();
     virtual bool isintegral();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -248,8 +248,8 @@ public:
     Type *merge();
     Type *merge2();
     virtual void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
-    virtual void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
-    void toCBuffer3(OutBuffer *buf, HdrGenState *hgs, int mod);
+    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask);
+    void toCBuffer3(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask);
     void modToBuffer(OutBuffer *buf);
     char *modToChars();
     virtual bool isintegral();
@@ -413,7 +413,6 @@ public:
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     char *toChars();
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     bool isintegral();
     bool isfloating();
     bool isreal();
@@ -445,7 +444,6 @@ public:
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     char *toChars();
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toDecoBuffer(OutBuffer *buf, int flag);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL);
     Type *reliesOnTident(TemplateParameters *tparams);
@@ -486,7 +484,6 @@ public:
     Type *semantic(Loc loc, Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     int isString();
     int isZeroInit(Loc loc);
@@ -518,7 +515,6 @@ public:
     Type *semantic(Loc loc, Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     int isString();
     int isZeroInit(Loc loc);
@@ -551,7 +547,6 @@ public:
     StructDeclaration *getImpl();
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL);
@@ -578,7 +573,6 @@ public:
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     d_uns64 size(Loc loc);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
     bool isscalar();
@@ -598,7 +592,6 @@ public:
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     d_uns64 size(Loc loc);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     int isZeroInit(Loc loc);
@@ -656,8 +649,7 @@ public:
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
     void toCBufferWithAttributes(OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
-    void attributesToCBuffer(OutBuffer *buf, int mod);
+    void attributesToCBuffer(OutBuffer *buf, unsigned char mod);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL);
     TypeInfoDeclaration *getTypeInfoDeclaration();
     Type *reliesOnTident(TemplateParameters *tparams = NULL);
@@ -687,7 +679,6 @@ public:
     d_uns64 size(Loc loc);
     unsigned alignsize();
     MATCH implicitConvTo(Type *to);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *defaultInit(Loc loc);
     int isZeroInit(Loc loc);
     int checkBoolean();
@@ -728,7 +719,6 @@ public:
     Type *syntaxCopy();
     //char *toChars();
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Dsymbol *toDsymbol(Scope *sc);
     Type *semantic(Loc loc, Scope *sc);
@@ -750,7 +740,6 @@ public:
     Type *syntaxCopy();
     //char *toChars();
     //void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
@@ -770,7 +759,6 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Type *semantic(Loc loc, Scope *sc);
     d_uns64 size(Loc loc);
@@ -786,7 +774,6 @@ public:
     Dsymbol *toDsymbol(Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Type *semantic(Loc loc, Scope *sc);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -817,7 +804,6 @@ public:
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     structalign_t alignment();
     Expression *defaultInit(Loc loc);
@@ -853,7 +839,6 @@ public:
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     bool isintegral();
@@ -895,7 +880,6 @@ public:
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     structalign_t alignment();
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
@@ -939,7 +923,6 @@ public:
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     ClassDeclaration *isClassHandle();
     int isBaseOf(Type *t, int *poffset);
@@ -976,7 +959,6 @@ public:
     Type *semantic(Loc loc, Scope *sc);
     bool equals(RootObject *o);
     Type *reliesOnTident(TemplateParameters *tparams = NULL);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void toDecoBuffer(OutBuffer *buf, int flag);
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
@@ -995,7 +977,6 @@ public:
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1009,8 +990,6 @@ public:
     void toDecoBuffer(OutBuffer *buf, int flag);
     MATCH implicitConvTo(Type *to);
     int checkBoolean();
-
-    void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, int mod);
 
     d_uns64 size(Loc loc);
     Expression *defaultInit(Loc loc);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -249,7 +249,6 @@ public:
     Type *merge2();
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask);
-    void toCBuffer3(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask);
     void modToBuffer(OutBuffer *buf);
     char *modToChars();
     virtual bool isintegral();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -247,7 +247,7 @@ public:
     virtual void toDecoBuffer(OutBuffer *buf, int flag = 0);
     Type *merge();
     Type *merge2();
-    virtual void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
+    void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
     void toCBuffer2(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask);
     void toCBuffer3(OutBuffer *buf, HdrGenState *hgs, unsigned char modMask);
     void modToBuffer(OutBuffer *buf);
@@ -362,8 +362,6 @@ class TypeError : public Type
 public:
     TypeError();
     Type *syntaxCopy();
-
-    void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
 
     d_uns64 size(Loc loc);
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
@@ -647,7 +645,6 @@ public:
     Type *semantic(Loc loc, Scope *sc);
     void purityLevel();
     void toDecoBuffer(OutBuffer *buf, int flag);
-    void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL);
     TypeInfoDeclaration *getTypeInfoDeclaration();
     Type *reliesOnTident(TemplateParameters *tparams = NULL);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -649,7 +649,6 @@ public:
     void toDecoBuffer(OutBuffer *buf, int flag);
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
     void toCBufferWithAttributes(OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td);
-    void attributesToCBuffer(OutBuffer *buf, unsigned char mod);
     MATCH deduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL);
     TypeInfoDeclaration *getTypeInfoDeclaration();
     Type *reliesOnTident(TemplateParameters *tparams = NULL);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -701,7 +701,6 @@ public:
     void syntaxCopyHelper(TypeQualified *t);
     void addIdent(Identifier *ident);
     void addInst(TemplateInstance *inst);
-    void toCBuffer2Helper(OutBuffer *buf, HdrGenState *hgs);
     d_uns64 size(Loc loc);
     void resolveHelper(Loc loc, Scope *sc, Dsymbol *s, Dsymbol *scopesym,
         Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);

--- a/src/statement.c
+++ b/src/statement.c
@@ -88,7 +88,7 @@ char *Statement::toChars()
     HdrGenState hgs;
 
     OutBuffer buf;
-    toCBuffer(&buf, &hgs);
+    ::toCBuffer(this, &buf, &hgs);
     return buf.extractString();
 }
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -92,12 +92,6 @@ char *Statement::toChars()
     return buf.extractString();
 }
 
-void Statement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->printf("Statement::toCBuffer()");
-    buf->writenl();
-    assert(0);
-}
 
 Statement *Statement::semantic(Scope *sc)
 {
@@ -337,24 +331,6 @@ Statement *ExpStatement::syntaxCopy()
     return es;
 }
 
-void ExpStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    if (exp)
-    {   exp->toCBuffer(buf, hgs);
-        if (exp->op != TOKdeclaration)
-        {   buf->writeByte(';');
-            if (!hgs->FLinit.init)
-                buf->writenl();
-        }
-    }
-    else
-    {
-        buf->writeByte(';');
-        if (!hgs->FLinit.init)
-            buf->writenl();
-    }
-}
-
 Statement *ExpStatement::semantic(Scope *sc)
 {
     if (exp)
@@ -485,15 +461,6 @@ Statement *CompileStatement::syntaxCopy()
     Expression *e = exp->syntaxCopy();
     CompileStatement *es = new CompileStatement(loc, e);
     return es;
-}
-
-void CompileStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("mixin(");
-    exp->toCBuffer(buf, hgs);
-    buf->writestring(");");
-    if (!hgs->FLinit.init)
-        buf->writenl();
 }
 
 Statements *CompileStatement::flatten(Scope *sc)
@@ -788,15 +755,6 @@ Statement *CompoundStatement::last()
     return s;
 }
 
-void CompoundStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    for (size_t i = 0; i < statements->dim; i++)
-    {   Statement *s = (*statements)[i];
-        if (s)
-            s->toCBuffer(buf, hgs);
-    }
-}
-
 int CompoundStatement::blockExit(bool mustNotThrow)
 {
     //printf("CompoundStatement::blockExit(%p) %d\n", this, statements->dim);
@@ -868,59 +826,6 @@ Statement *CompoundDeclarationStatement::syntaxCopy()
     return cs;
 }
 
-void CompoundDeclarationStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    bool anywritten = false;
-    for (size_t i = 0; i < statements->dim; i++)
-    {   Statement *s = (*statements)[i];
-        ExpStatement *ds;
-        if (s &&
-            (ds = s->isExpStatement()) != NULL &&
-            ds->exp->op == TOKdeclaration)
-        {
-            DeclarationExp *de = (DeclarationExp *)ds->exp;
-            Declaration *d = de->declaration->isDeclaration();
-            assert(d);
-            VarDeclaration *v = d->isVarDeclaration();
-            if (v)
-            {
-                /* This essentially copies the part of VarDeclaration::toCBuffer()
-                 * that does not print the type.
-                 * Should refactor this.
-                 */
-                if (anywritten)
-                {
-                    buf->writestring(", ");
-                    buf->writestring(v->ident->toChars());
-                }
-                else
-                {
-                    StorageClassDeclaration::stcToCBuffer(buf, v->storage_class);
-                    if (v->type)
-                        v->type->toCBuffer(buf, v->ident, hgs);
-                    else
-                        buf->writestring(v->ident->toChars());
-                }
-
-                if (v->init)
-                {   buf->writestring(" = ");
-                    ExpInitializer *ie = v->init->isExpInitializer();
-                    if (ie && (ie->exp->op == TOKconstruct || ie->exp->op == TOKblit))
-                        ((AssignExp *)ie->exp)->e2->toCBuffer(buf, hgs);
-                    else
-                        v->init->toCBuffer(buf, hgs);
-                }
-            }
-            else
-                d->toCBuffer(buf, hgs);
-            anywritten = true;
-        }
-    }
-    buf->writeByte(';');
-    if (!hgs->FLinit.init)
-        buf->writenl();
-}
-
 /**************************** UnrolledLoopStatement ***************************/
 
 UnrolledLoopStatement::UnrolledLoopStatement(Loc loc, Statements *s)
@@ -968,26 +873,6 @@ Statement *UnrolledLoopStatement::semantic(Scope *sc)
 
     scd->pop();
     return serror ? serror : this;
-}
-
-void UnrolledLoopStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("unrolled {");
-    buf->writenl();
-    buf->level++;
-
-    for (size_t i = 0; i < statements->dim; i++)
-    {
-        Statement *s;
-
-        s = (*statements)[i];
-        if (s)
-            s->toCBuffer(buf, hgs);
-    }
-
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
 }
 
 bool UnrolledLoopStatement::hasBreak()
@@ -1101,21 +986,6 @@ int ScopeStatement::blockExit(bool mustNotThrow)
     return statement ? statement->blockExit(mustNotThrow) : BEfallthru;
 }
 
-
-void ScopeStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writeByte('{');
-    buf->writenl();
-    buf->level++;
-
-    if (statement)
-        statement->toCBuffer(buf, hgs);
-
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
-}
-
 /******************************** WhileStatement ***************************/
 
 WhileStatement::WhileStatement(Loc loc, Expression *c, Statement *b)
@@ -1156,17 +1026,6 @@ int WhileStatement::blockExit(bool mustNotThrow)
 {
     assert(global.errors);
     return BEfallthru;
-}
-
-
-void WhileStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("while (");
-    condition->toCBuffer(buf, hgs);
-    buf->writeByte(')');
-    buf->writenl();
-    if (body)
-        body->toCBuffer(buf, hgs);
 }
 
 /******************************** DoStatement ***************************/
@@ -1237,19 +1096,6 @@ int DoStatement::blockExit(bool mustNotThrow)
     }
     result &= ~(BEbreak | BEcontinue);
     return result;
-}
-
-
-void DoStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("do");
-    buf->writenl();
-    if (body)
-        body->toCBuffer(buf, hgs);
-    buf->writestring("while (");
-    condition->toCBuffer(buf, hgs);
-    buf->writestring(");");
-    buf->writenl();
 }
 
 /******************************** ForStatement ***************************/
@@ -1392,38 +1238,6 @@ int ForStatement::blockExit(bool mustNotThrow)
     if (increment && canThrow(increment, mustNotThrow))
         result |= BEthrow;
     return result;
-}
-
-
-void ForStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("for (");
-    if (init)
-    {
-        hgs->FLinit.init++;
-        init->toCBuffer(buf, hgs);
-        hgs->FLinit.init--;
-    }
-    else
-        buf->writeByte(';');
-    if (condition)
-    {   buf->writeByte(' ');
-        condition->toCBuffer(buf, hgs);
-    }
-    buf->writeByte(';');
-    if (increment)
-    {   buf->writeByte(' ');
-        increment->toCBuffer(buf, hgs);
-    }
-    buf->writeByte(')');
-    buf->writenl();
-    buf->writeByte('{');
-    buf->writenl();
-    buf->level++;
-    body->toCBuffer(buf, hgs);
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
 }
 
 /******************************** ForeachStatement ***************************/
@@ -2366,37 +2180,6 @@ int ForeachStatement::blockExit(bool mustNotThrow)
     return result;
 }
 
-
-void ForeachStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring(Token::toChars(op));
-    buf->writestring(" (");
-    for (size_t i = 0; i < arguments->dim; i++)
-    {
-        Parameter *a = (*arguments)[i];
-        if (i)
-            buf->writestring(", ");
-        if (a->storageClass & STCref)
-            buf->writestring((char*)"ref ");
-        if (a->type)
-            a->type->toCBuffer(buf, a->ident, hgs);
-        else
-            buf->writestring(a->ident->toChars());
-    }
-    buf->writestring("; ");
-    aggr->toCBuffer(buf, hgs);
-    buf->writeByte(')');
-    buf->writenl();
-    buf->writeByte('{');
-    buf->writenl();
-    buf->level++;
-    if (body)
-        body->toCBuffer(buf, hgs);
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
-}
-
 /**************************** ForeachRangeStatement ***************************/
 
 
@@ -2608,34 +2391,6 @@ int ForeachRangeStatement::blockExit(bool mustNotThrow)
     return BEfallthru;
 }
 
-
-void ForeachRangeStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring(Token::toChars(op));
-    buf->writestring(" (");
-
-    if (arg->type)
-        arg->type->toCBuffer(buf, arg->ident, hgs);
-    else
-        buf->writestring(arg->ident->toChars());
-
-    buf->writestring("; ");
-    lwr->toCBuffer(buf, hgs);
-    buf->writestring(" .. ");
-    upr->toCBuffer(buf, hgs);
-    buf->writeByte(')');
-    buf->writenl();
-    buf->writeByte('{');
-    buf->writenl();
-    buf->level++;
-    if (body)
-        body->toCBuffer(buf, hgs);
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
-}
-
-
 /******************************** IfStatement ***************************/
 
 IfStatement::IfStatement(Loc loc, Parameter *arg, Expression *condition, Statement *ifbody, Statement *elsebody)
@@ -2769,41 +2524,6 @@ int IfStatement::blockExit(bool mustNotThrow)
     return result;
 }
 
-
-void IfStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("if (");
-    if (arg)
-    {
-        if (arg->type)
-            arg->type->toCBuffer(buf, arg->ident, hgs);
-        else
-        {
-            buf->writestring("auto ");
-            buf->writestring(arg->ident->toChars());
-        }
-        buf->writestring(" = ");
-    }
-    condition->toCBuffer(buf, hgs);
-    buf->writeByte(')');
-    buf->writenl();
-    if (!ifbody->isScopeStatement())
-        buf->level++;
-    ifbody->toCBuffer(buf, hgs);
-    if (!ifbody->isScopeStatement())
-        buf->level--;
-    if (elsebody)
-    {
-        buf->writestring("else");
-        buf->writenl();
-        if (!elsebody->isScopeStatement())
-            buf->level++;
-        elsebody->toCBuffer(buf, hgs);
-        if (!elsebody->isScopeStatement())
-            buf->level--;
-    }
-}
-
 /******************************** ConditionalStatement ***************************/
 
 ConditionalStatement::ConditionalStatement(Loc loc, Condition *condition, Statement *ifbody, Statement *elsebody)
@@ -2881,34 +2601,6 @@ int ConditionalStatement::blockExit(bool mustNotThrow)
         result |= elsebody->blockExit(mustNotThrow);
     return result;
 }
-
-void ConditionalStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    condition->toCBuffer(buf, hgs);
-    buf->writenl();
-    buf->writeByte('{');
-    buf->writenl();
-    buf->level++;
-    if (ifbody)
-        ifbody->toCBuffer(buf, hgs);
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
-    if (elsebody)
-    {
-        buf->writestring("else");
-        buf->writenl();
-        buf->writeByte('{');
-        buf->level++;
-        buf->writenl();
-        elsebody->toCBuffer(buf, hgs);
-        buf->level--;
-        buf->writeByte('}');
-        buf->writenl();
-    }
-    buf->writenl();
-}
-
 
 /******************************** PragmaStatement ***************************/
 
@@ -3044,38 +2736,6 @@ int PragmaStatement::blockExit(bool mustNotThrow)
     return result;
 }
 
-
-void PragmaStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("pragma (");
-    buf->writestring(ident->toChars());
-    if (args && args->dim)
-    {
-        buf->writestring(", ");
-        argsToCBuffer(buf, args, hgs);
-    }
-    buf->writeByte(')');
-    if (body)
-    {
-        buf->writenl();
-        buf->writeByte('{');
-        buf->writenl();
-        buf->level++;
-
-        body->toCBuffer(buf, hgs);
-
-        buf->level--;
-        buf->writeByte('}');
-        buf->writenl();
-    }
-    else
-    {
-        buf->writeByte(';');
-        buf->writenl();
-    }
-}
-
-
 /******************************** StaticAssertStatement ***************************/
 
 StaticAssertStatement::StaticAssertStatement(StaticAssert *sa)
@@ -3100,12 +2760,6 @@ int StaticAssertStatement::blockExit(bool mustNotThrow)
 {
     return BEfallthru;
 }
-
-void StaticAssertStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    sa->toCBuffer(buf, hgs);
-}
-
 
 /******************************** SwitchStatement ***************************/
 
@@ -3294,32 +2948,6 @@ int SwitchStatement::blockExit(bool mustNotThrow)
     return result;
 }
 
-
-void SwitchStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring(isFinal ? "final switch (" : "switch (");
-    condition->toCBuffer(buf, hgs);
-    buf->writeByte(')');
-    buf->writenl();
-    if (body)
-    {
-        if (!body->isScopeStatement())
-        {
-            buf->writeByte('{');
-            buf->writenl();
-            buf->level++;
-            body->toCBuffer(buf, hgs);
-            buf->level--;
-            buf->writeByte('}');
-            buf->writenl();
-        }
-        else
-        {
-            body->toCBuffer(buf, hgs);
-        }
-    }
-}
-
 /******************************** CaseStatement ***************************/
 
 CaseStatement::CaseStatement(Loc loc, Expression *exp, Statement *s)
@@ -3424,16 +3052,6 @@ int CaseStatement::blockExit(bool mustNotThrow)
     return statement->blockExit(mustNotThrow);
 }
 
-
-void CaseStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("case ");
-    exp->toCBuffer(buf, hgs);
-    buf->writeByte(':');
-    buf->writenl();
-    statement->toCBuffer(buf, hgs);
-}
-
 /******************************** CaseRangeStatement ***************************/
 
 
@@ -3525,18 +3143,6 @@ Statement *CaseRangeStatement::semantic(Scope *sc)
     return s;
 }
 
-void CaseRangeStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("case ");
-    first->toCBuffer(buf, hgs);
-    buf->writestring(": .. case ");
-    last->toCBuffer(buf, hgs);
-    buf->writeByte(':');
-    buf->writenl();
-    statement->toCBuffer(buf, hgs);
-}
-
-
 /******************************** DefaultStatement ***************************/
 
 DefaultStatement::DefaultStatement(Loc loc, Statement *s)
@@ -3582,14 +3188,6 @@ int DefaultStatement::blockExit(bool mustNotThrow)
     return statement->blockExit(mustNotThrow);
 }
 
-
-void DefaultStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("default:");
-    buf->writenl();
-    statement->toCBuffer(buf, hgs);
-}
-
 /******************************** GotoDefaultStatement ***************************/
 
 GotoDefaultStatement::GotoDefaultStatement(Loc loc)
@@ -3615,13 +3213,6 @@ Statement *GotoDefaultStatement::semantic(Scope *sc)
 int GotoDefaultStatement::blockExit(bool mustNotThrow)
 {
     return BEgoto;
-}
-
-
-void GotoDefaultStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("goto default;");
-    buf->writenl();
 }
 
 /******************************** GotoCaseStatement ***************************/
@@ -3664,18 +3255,6 @@ int GotoCaseStatement::blockExit(bool mustNotThrow)
     return BEgoto;
 }
 
-
-void GotoCaseStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("goto case");
-    if (exp)
-    {   buf->writeByte(' ');
-        exp->toCBuffer(buf, hgs);
-    }
-    buf->writeByte(';');
-    buf->writenl();
-}
-
 /******************************** SwitchErrorStatement ***************************/
 
 SwitchErrorStatement::SwitchErrorStatement(Loc loc)
@@ -3687,13 +3266,6 @@ int SwitchErrorStatement::blockExit(bool mustNotThrow)
 {
     // Switch errors are non-recoverable
     return BEhalt;
-}
-
-
-void SwitchErrorStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("SwitchErrorStatement::toCBuffer()");
-    buf->writenl();
 }
 
 /******************************** ReturnStatement ***************************/
@@ -4073,16 +3645,6 @@ int ReturnStatement::blockExit(bool mustNotThrow)
     return result;
 }
 
-
-void ReturnStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->printf("return ");
-    if (exp)
-        exp->toCBuffer(buf, hgs);
-    buf->writeByte(';');
-    buf->writenl();
-}
-
 /******************************** BreakStatement ***************************/
 
 BreakStatement::BreakStatement(Loc loc, Identifier *ident)
@@ -4163,18 +3725,6 @@ int BreakStatement::blockExit(bool mustNotThrow)
 {
     //printf("BreakStatement::blockExit(%p) = x%x\n", this, ident ? BEgoto : BEbreak);
     return ident ? BEgoto : BEbreak;
-}
-
-
-void BreakStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("break");
-    if (ident)
-    {   buf->writeByte(' ');
-        buf->writestring(ident->toChars());
-    }
-    buf->writeByte(';');
-    buf->writenl();
 }
 
 /******************************** ContinueStatement ***************************/
@@ -4266,18 +3816,6 @@ Statement *ContinueStatement::semantic(Scope *sc)
 int ContinueStatement::blockExit(bool mustNotThrow)
 {
     return ident ? BEgoto : BEcontinue;
-}
-
-
-void ContinueStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("continue");
-    if (ident)
-    {   buf->writeByte(' ');
-        buf->writestring(ident->toChars());
-    }
-    buf->writeByte(';');
-    buf->writenl();
 }
 
 /******************************** SynchronizedStatement ***************************/
@@ -4437,22 +3975,6 @@ int SynchronizedStatement::blockExit(bool mustNotThrow)
     return body ? body->blockExit(mustNotThrow) : BEfallthru;
 }
 
-
-void SynchronizedStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("synchronized");
-    if (exp)
-    {   buf->writeByte('(');
-        exp->toCBuffer(buf, hgs);
-        buf->writeByte(')');
-    }
-    if (body)
-    {
-        buf->writeByte(' ');
-        body->toCBuffer(buf, hgs);
-    }
-}
-
 /******************************** WithStatement ***************************/
 
 WithStatement::WithStatement(Loc loc, Expression *exp, Statement *body)
@@ -4555,16 +4077,6 @@ Statement *WithStatement::semantic(Scope *sc)
     }
 
     return this;
-}
-
-void WithStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("with (");
-    exp->toCBuffer(buf, hgs);
-    buf->writestring(")");
-    buf->writenl();
-    if (body)
-        body->toCBuffer(buf, hgs);
 }
 
 int WithStatement::blockExit(bool mustNotThrow)
@@ -4702,20 +4214,6 @@ int TryCatchStatement::blockExit(bool mustNotThrow)
     return result | catchresult;
 }
 
-
-void TryCatchStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("try");
-    buf->writenl();
-    if (body)
-        body->toCBuffer(buf, hgs);
-    for (size_t i = 0; i < catches->dim; i++)
-    {
-        Catch *c = (*catches)[i];
-        c->toCBuffer(buf, hgs);
-    }
-}
-
 /******************************** Catch ***************************/
 
 Catch::Catch(Loc loc, Type *t, Identifier *id, Statement *handler)
@@ -4803,24 +4301,6 @@ int Catch::blockExit(bool mustNotThrow)
     return handler ? handler->blockExit(mustNotThrow) : BEfallthru;
 }
 
-void Catch::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("catch");
-    if (type)
-    {   buf->writeByte('(');
-        type->toCBuffer(buf, ident, hgs);
-        buf->writeByte(')');
-    }
-    buf->writenl();
-    buf->writeByte('{');
-    buf->writenl();
-    buf->level++;
-    if (handler)
-        handler->toCBuffer(buf, hgs);
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
-}
 
 /****************************** TryFinallyStatement ***************************/
 
@@ -4862,28 +4342,6 @@ Statement *TryFinallyStatement::semantic(Scope *sc)
         return s;
     }
     return this;
-}
-
-void TryFinallyStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("try");
-    buf->writenl();
-    buf->writeByte('{');
-    buf->writenl();
-    buf->level++;
-    body->toCBuffer(buf, hgs);
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
-    buf->writestring("finally");
-    buf->writenl();
-    buf->writeByte('{');
-    buf->writenl();
-    buf->level++;
-    finalbody->toCBuffer(buf, hgs);
-    buf->level--;
-    buf->writeByte('}');
-    buf->writenl();
 }
 
 bool TryFinallyStatement::hasBreak()
@@ -4938,13 +4396,6 @@ Statement *OnScopeStatement::semantic(Scope *sc)
 int OnScopeStatement::blockExit(bool mustNotThrow)
 {   // At this point, this statement is just an empty placeholder
     return BEfallthru;
-}
-
-void OnScopeStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring(Token::toChars(tok));
-    buf->writeByte(' ');
-    statement->toCBuffer(buf, hgs);
 }
 
 Statement *OnScopeStatement::scopeCode(Scope *sc, Statement **sentry, Statement **sexception, Statement **sfinally)
@@ -5051,15 +4502,6 @@ int ThrowStatement::blockExit(bool mustNotThrow)
     return BEthrow;
 }
 
-
-void ThrowStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->printf("throw ");
-    exp->toCBuffer(buf, hgs);
-    buf->writeByte(';');
-    buf->writenl();
-}
-
 /******************************** DebugStatement **************************/
 
 DebugStatement::DebugStatement(Loc loc, Statement *statement)
@@ -5102,15 +4544,6 @@ Statements *DebugStatement::flatten(Scope *sc)
 
     return a;
 }
-
-void DebugStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    if (statement)
-    {
-        statement->toCBuffer(buf, hgs);
-    }
-}
-
 
 /******************************** GotoStatement ***************************/
 
@@ -5211,15 +4644,6 @@ int GotoStatement::blockExit(bool mustNotThrow)
     return BEgoto;
 }
 
-
-void GotoStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("goto ");
-    buf->writestring(ident->toChars());
-    buf->writeByte(';');
-    buf->writenl();
-}
-
 /******************************** LabelStatement ***************************/
 
 LabelStatement::LabelStatement(Loc loc, Identifier *ident, Statement *statement)
@@ -5303,17 +4727,6 @@ int LabelStatement::blockExit(bool mustNotThrow)
     return statement ? statement->blockExit(mustNotThrow) : BEfallthru;
 }
 
-
-void LabelStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring(ident->toChars());
-    buf->writeByte(':');
-    buf->writenl();
-    if (statement)
-        statement->toCBuffer(buf, hgs);
-}
-
-
 /******************************** LabelDsymbol ***************************/
 
 LabelDsymbol::LabelDsymbol(Identifier *ident)
@@ -5358,36 +4771,6 @@ int AsmStatement::blockExit(bool mustNotThrow)
         error("asm statements are assumed to throw", toChars());
     // Assume the worst
     return BEfallthru | BEthrow | BEreturn | BEgoto | BEhalt;
-}
-
-void AsmStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    buf->writestring("asm { ");
-    Token *t = tokens;
-    buf->level++;
-    while (t)
-    {
-        buf->writestring(t->toChars());
-        if (t->next                         &&
-           t->value != TOKmin               &&
-           t->value != TOKcomma             &&
-           t->next->value != TOKcomma       &&
-           t->value != TOKlbracket          &&
-           t->next->value != TOKlbracket    &&
-           t->next->value != TOKrbracket    &&
-           t->value != TOKlparen            &&
-           t->next->value != TOKlparen      &&
-           t->next->value != TOKrparen      &&
-           t->value != TOKdot               &&
-           t->next->value != TOKdot)
-        {
-            buf->writeByte(' ');
-        }
-        t = t->next;
-    }
-    buf->level--;
-    buf->writestring("; }");
-    buf->writenl();
 }
 
 /************************ ImportStatement ***************************************/
@@ -5449,13 +4832,4 @@ Statement *ImportStatement::semantic(Scope *sc)
 int ImportStatement::blockExit(bool mustNotThrow)
 {
     return BEfallthru;
-}
-
-void ImportStatement::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    for (size_t i = 0; i < imports->dim; i++)
-    {
-        Dsymbol *s = (*imports)[i];
-        s->toCBuffer(buf, hgs);
-    }
 }

--- a/src/statement.h
+++ b/src/statement.h
@@ -82,6 +82,8 @@ enum BE
     BEany = (BEfallthru | BEthrow | BEreturn | BEgoto | BEhalt),
 };
 
+void toCBuffer(Statement *s, OutBuffer *buf, HdrGenState *hgs);
+
 class Statement : public RootObject
 {
 public:
@@ -96,7 +98,6 @@ public:
     void error(const char *format, ...);
     void warning(const char *format, ...);
     void deprecation(const char *format, ...);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual Statement *semantic(Scope *sc);
     Statement *semanticScope(Scope *sc, Statement *sbreak, Statement *scontinue);
     Statement *semanticNoScope(Scope *sc);
@@ -686,7 +687,6 @@ public:
     Catch *syntaxCopy();
     void semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 };
 
 class TryFinallyStatement : public Statement

--- a/src/statement.h
+++ b/src/statement.h
@@ -96,7 +96,7 @@ public:
     void error(const char *format, ...);
     void warning(const char *format, ...);
     void deprecation(const char *format, ...);
-    virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     virtual Statement *semantic(Scope *sc);
     Statement *semanticScope(Scope *sc, Statement *sbreak, Statement *scontinue);
     Statement *semanticNoScope(Scope *sc);
@@ -162,7 +162,6 @@ public:
     ExpStatement(Loc loc, Dsymbol *s);
     static ExpStatement *create(Loc loc, Expression *exp);
     Statement *syntaxCopy();
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
     Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
@@ -195,7 +194,6 @@ public:
 
     CompileStatement(Loc loc, Expression *exp);
     Statement *syntaxCopy();
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statements *flatten(Scope *sc);
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
@@ -212,7 +210,6 @@ public:
     CompoundStatement(Loc loc, Statement *s1, Statement *s2);
     static CompoundStatement *create(Loc loc, Statement *s1, Statement *s2);
     Statement *syntaxCopy();
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
     Statements *flatten(Scope *sc);
@@ -232,7 +229,6 @@ class CompoundDeclarationStatement : public CompoundStatement
 public:
     CompoundDeclarationStatement(Loc loc, Statements *s);
     Statement *syntaxCopy();
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -251,7 +247,6 @@ public:
     bool hasContinue();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Expression *doInline(InlineDoState *ids);
     Statement *doInlineStatement(InlineDoState *ids);
@@ -266,7 +261,6 @@ public:
 
     ScopeStatement(Loc loc, Statement *s);
     Statement *syntaxCopy();
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     ScopeStatement *isScopeStatement() { return this; }
     ReturnStatement *isReturnStatement();
     Statement *semantic(Scope *sc);
@@ -294,7 +288,6 @@ public:
     bool hasContinue();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -312,7 +305,6 @@ public:
     bool hasContinue();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -339,7 +331,6 @@ public:
     bool hasContinue();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Statement *doInlineStatement(InlineDoState *ids);
 
@@ -372,7 +363,6 @@ public:
     bool hasContinue();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -396,7 +386,6 @@ public:
     bool hasContinue();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -415,7 +404,6 @@ public:
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int blockExit(bool mustNotThrow);
     IfStatement *isIfStatement() { return this; }
 
@@ -438,7 +426,6 @@ public:
     Statements *flatten(Scope *sc);
     int blockExit(bool mustNotThrow);
 
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -454,8 +441,6 @@ public:
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
 
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -469,7 +454,6 @@ public:
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
 
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -493,7 +477,6 @@ public:
     bool hasBreak();
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -513,7 +496,6 @@ public:
     int compare(RootObject *obj);
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     CaseStatement *isCaseStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
@@ -530,7 +512,6 @@ public:
     CaseRangeStatement(Loc loc, Expression *first, Expression *last, Statement *s);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -548,7 +529,6 @@ public:
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     DefaultStatement *isDefaultStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
@@ -564,7 +544,6 @@ public:
     Statement *semantic(Scope *sc);
     Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -580,7 +559,6 @@ public:
     Statement *semantic(Scope *sc);
     Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -590,7 +568,6 @@ class SwitchErrorStatement : public Statement
 public:
     SwitchErrorStatement(Loc loc);
     int blockExit(bool mustNotThrow);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -603,7 +580,6 @@ public:
 
     ReturnStatement(Loc loc, Expression *exp);
     Statement *syntaxCopy();
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
@@ -625,7 +601,6 @@ public:
     Statement *semantic(Scope *sc);
     Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -640,7 +615,6 @@ public:
     Statement *semantic(Scope *sc);
     Expression *interpret(InterState *istate);
     int blockExit(bool mustNotThrow);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -657,7 +631,6 @@ public:
     bool hasBreak();
     bool hasContinue();
     int blockExit(bool mustNotThrow);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
 // Back end
     elem *esync;
@@ -675,7 +648,6 @@ public:
     WithStatement(Loc loc, Expression *exp, Statement *body);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
 
@@ -695,7 +667,6 @@ public:
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
 
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -727,7 +698,6 @@ public:
     TryFinallyStatement(Loc loc, Statement *body, Statement *finalbody);
     static TryFinallyStatement *create(Loc loc, Statement *body, Statement *finalbody);
     Statement *syntaxCopy();
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
     bool hasBreak();
     bool hasContinue();
@@ -746,7 +716,6 @@ public:
     OnScopeStatement(Loc loc, TOK tok, Statement *statement);
     Statement *syntaxCopy();
     int blockExit(bool mustNotThrow);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     Statement *semantic(Scope *sc);
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
     Expression *interpret(InterState *istate);
@@ -765,7 +734,6 @@ public:
     ThrowStatement(Loc loc, Expression *exp);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
 
@@ -781,7 +749,6 @@ public:
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     Statements *flatten(Scope *sc);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -801,7 +768,6 @@ public:
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
 
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -823,7 +789,6 @@ public:
     Statements *flatten(Scope *sc);
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     LabelStatement *isLabelStatement() { return this; }
 
@@ -857,8 +822,6 @@ public:
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
 
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-
     //Expression *doInline(InlineDoState *ids);
 
     void accept(Visitor *v) { v->visit(this); }
@@ -874,8 +837,6 @@ public:
     Statement *semantic(Scope *sc);
     int blockExit(bool mustNotThrow);
     Expression *interpret(InterState *istate);
-
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
     Expression *doInline(InlineDoState *ids);
     Statement *doInlineStatement(InlineDoState *ids);

--- a/src/template.c
+++ b/src/template.c
@@ -41,6 +41,7 @@
 size_t templateParameterLookup(Type *tparam, TemplateParameters *parameters);
 int arrayObjectMatch(Objects *oa1, Objects *oa2);
 hash_t arrayObjectHash(Objects *oa1);
+void functionToBufferFull(TypeFunction *tf, OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TypeFunction *attrs, TemplateDeclaration *td);
 
 /********************************************
  * These functions substitute for dynamic_cast. dynamic_cast does not work
@@ -2558,7 +2559,7 @@ void TemplateDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
         if (fd && fd->type && fd->type->ty == Tfunction && fd->ident == ident)
         {
             TypeFunction *tf = (TypeFunction *)fd->type;
-            tf->toCBufferWithAttributes(buf, ident, hgs, tf, this);
+            functionToBufferFull(tf, buf, ident, hgs, tf, this);
 
             if (constraint)
             {


### PR DESCRIPTION
Because it's a mess, and names like `toCBuffer`/`toCBuffer2`/`toCBuffer3` don't help.
