### PR TITLE
[REG2.065a] Issue 12089 - std.utf.validate and inout(char[]) failts to compile

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2095,6 +2095,8 @@ L1:
                 t = t->mutableOf();
         }
     }
+    if (isConst())
+        t = t->addMod(MODconst);
     if (isShared())
         t = t->addMod(MODshared);
 

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2757,6 +2757,20 @@ void test11966()
 }
 
 /************************************/
+// 12089
+
+void foo12089(inout(char[]) a)
+{
+    validate12089(a);
+}
+void validate12089(S)(in S str)
+{
+    decodeImpl12089(str);
+}
+void decodeImpl12089(S)(auto ref S str)
+{}
+
+/************************************/
 // 6941
 
 static assert((const(shared(int[])[])).stringof == "const(shared(int[])[])");	// fail


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12089

Tweak for the new language feature `inout(const(T))`.
