### PR TITLE
[REG2.064] Issue 12144 - Unresolved xopEquals when referenced by dynamic array constructor

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -119,6 +119,15 @@ Expression *implicitCastTo(Expression *e, Scope *sc, Type *t)
             //printf("FuncExp::implicitCastTo type = %p %s, t = %s\n", e->type, e->type ? e->type->toChars() : NULL, t->toChars());
             visit((Expression *)e->inferType(t));
         }
+
+        void visit(ArrayLiteralExp *e)
+        {
+            visit((Expression *)e);
+
+            Type *tb = result->type->toBasetype();
+            if (tb->ty == Tarray)
+                semanticTypeInfo(sc, ((TypeDArray *)tb)->next);
+        }
     };
 
     ImplicitCastTo v(sc, t);

--- a/src/expression.c
+++ b/src/expression.c
@@ -1281,8 +1281,7 @@ bool Expression::checkPostblit(Scope *sc, Type *t)
     if (t->ty == Tstruct)
     {
         // Bugzilla 11395: Require TypeInfo generation for array concatenation
-        if (!t->vtinfo)
-            t->getTypeInfo(sc);
+        semanticTypeInfo(sc, t);
 
         StructDeclaration *sd = ((TypeStruct *)t)->sym;
         if (sd->postblit)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -326,6 +326,7 @@ public:
     virtual void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Expression *getInternalTypeInfo(Scope *sc);
     Expression *getTypeInfo(Scope *sc);
+    void genTypeInfo(Scope *sc);
     virtual TypeInfoDeclaration *getTypeInfoDeclaration();
     virtual int builtinTypeInfo();
     virtual Type *reliesOnTident(TemplateParameters *tparams = NULL);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -50,6 +50,8 @@ typedef struct TYPE type;
 struct Symbol;
 class TypeTuple;
 
+void semanticTypeInfo(Scope *sc, Type *t);
+
 enum ENUMTY
 {
     Tarray,             // slice array, aka T[]

--- a/src/struct.c
+++ b/src/struct.c
@@ -72,6 +72,79 @@ FuncDeclaration *search_toString(StructDeclaration *sd)
     return fd;
 }
 
+/***************************************
+ * Request additonal semantic analysis for TypeInfo generation.
+ */
+void semanticTypeInfo(Scope *sc, Type *t)
+{
+    class FullTypeInfoVisitor : public Visitor
+    {
+    public:
+        Scope *sc;
+
+        void visit(Type *t)
+        {
+            Type *tb = t->toBasetype();
+            if (tb != t)
+                tb->accept(this);
+        }
+        void visit(TypeNext *t)
+        {
+            if (t->next)
+                t->next->accept(this);
+        }
+        void visit(TypeBasic *t) { }
+        void visit(TypeVector *t)
+        {
+            t->basetype->accept(this);
+        }
+        void visit(TypeAArray *t)
+        {
+            t->index->accept(this);
+            visit((TypeNext *)t);
+        }
+        void visit(TypeFunction *t)
+        {
+            visit((TypeNext *)t);
+            // Currently TypeInfo_Function doesn't store parameter types.
+        }
+        void visit(TypeStruct *t)
+        {
+            Dsymbol *s;
+            StructDeclaration *sd = t->sym;
+            if (sd->members &&
+                (sd->xeq  && sd->xeq  != sd->xerreq  ||
+                 sd->xcmp && sd->xcmp != sd->xerrcmp ||
+                 (sd->postblit && !(sd->postblit->storage_class & STCdisable)) ||
+                 sd->dtor ||
+                 search_toHash(sd) ||
+                 search_toString(sd)
+                ) &&
+                sd->inNonRoot())
+            {
+                //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd->toChars(), sd->inNonRoot());
+                Module::addDeferredSemantic3(sd);
+            }
+        }
+        void visit(TypeClass *t) { }
+        void visit(TypeTuple *t)
+        {
+            if (t->arguments)
+            {
+                for (size_t i = 0; i < t->arguments->dim; i++)
+                {
+                    Type *tprm = (*t->arguments)[i]->type;
+                    if (tprm)
+                        tprm->accept(this);
+                }
+            }
+        }
+    };
+    FullTypeInfoVisitor v;
+    v.sc = sc;
+    t->accept(&v);
+}
+
 /********************************* AggregateDeclaration ****************************/
 
 AggregateDeclaration::AggregateDeclaration(Loc loc, Identifier *id)
@@ -741,7 +814,7 @@ void StructDeclaration::semantic(Scope *sc)
     //if ((xeq && xeq != xerreq || xcmp && xcmp != xerrcmp) && isImportedSym(this))
     //    Module::addDeferredSemantic3(this);
     /* Defer requesting semantic3 until TypeInfo generation is actually invoked.
-     * See Type::getTypeInfo().
+     * See semanticTypeInfo().
      */
     inv = buildInv(sc2);
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -252,7 +252,7 @@ void ClassDeclaration::toObjFile(int multiobj)
     //////////////////////////////////////////////
 
     // Put out the TypeInfo
-    type->getTypeInfo(NULL);
+    type->genTypeInfo(NULL);
     //type->vtinfo->toObjFile(multiobj);
 
     //////////////////////////////////////////////
@@ -661,7 +661,7 @@ void InterfaceDeclaration::toObjFile(int multiobj)
     //////////////////////////////////////////////
 
     // Put out the TypeInfo
-    type->getTypeInfo(NULL);
+    type->genTypeInfo(NULL);
     type->vtinfo->toObjFile(multiobj);
 
     //////////////////////////////////////////////
@@ -821,7 +821,7 @@ void StructDeclaration::toObjFile(int multiobj)
         if (global.params.symdebug)
             toDebug();
 
-        type->getTypeInfo(NULL);        // generate TypeInfo
+        type->genTypeInfo(NULL);
 
         if (1)
         {
@@ -990,7 +990,7 @@ void TypedefDeclaration::toObjFile(int multiobj)
     if (global.params.symdebug)
         toDebug();
 
-    type->getTypeInfo(NULL);    // generate TypeInfo
+    type->genTypeInfo(NULL);
 
     TypeTypedef *tc = (TypeTypedef *)type;
     if (type->isZeroInit() || !tc->sym->init)
@@ -1030,7 +1030,7 @@ void EnumDeclaration::toObjFile(int multiobj)
     if (global.params.symdebug)
         toDebug();
 
-    type->getTypeInfo(NULL);    // generate TypeInfo
+    type->genTypeInfo(NULL);
 
     TypeEnum *tc = (TypeEnum *)type;
     if (!tc->sym->members || type->isZeroInit())

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -134,22 +134,7 @@ void Type::genTypeInfo(Scope *sc)
                 Module *m = sc->module->importedFrom;
                 m->members->push(t->vtinfo);
 
-                if (ty == Tstruct)
-                {
-                    Dsymbol *s;
-                    StructDeclaration *sd = ((TypeStruct *)this)->sym;
-                    if ((sd->xeq  && sd->xeq  != sd->xerreq  ||
-                         sd->xcmp && sd->xcmp != sd->xerrcmp ||
-                         (sd->postblit && !(sd->postblit->storage_class & STCdisable)) ||
-                         sd->dtor ||
-                         search_toHash(sd) ||
-                         search_toString(sd)
-                        ) && sd->inNonRoot())
-                    {
-                        //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd->toChars(), sd->inNonRoot());
-                        Module::addDeferredSemantic3(sd);
-                    }
-                }
+                semanticTypeInfo(sc, t);
             }
             else                        // if in obj generation pass
             {
@@ -167,7 +152,7 @@ Expression *Type::getTypeInfo(Scope *sc)
     genTypeInfo(sc);
     Expression *e = VarExp::create(Loc(), vtinfo);
     e = e->addressOf(sc);
-    e->type = t->vtinfo->type;          // do this so we don't get redundant dereference
+    e->type = vtinfo->type;     // do this so we don't get redundant dereference
     return e;
 }
 

--- a/test/runnable/imports/link12144a.d
+++ b/test/runnable/imports/link12144a.d
@@ -1,0 +1,47 @@
+struct S1 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S2 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S3 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S4 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S5 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S6 { bool opEquals(T : typeof(this))(T) { return false; } ~this(){} }
+struct S7 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S8 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S9 { bool opEquals(T : typeof(this))(T) { return false; } }
+
+struct S10 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S11 { int opCmp(T : typeof(this))(T) { return 0; } }
+struct S12 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S13 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S14 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S15 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S16 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S17 { bool opEquals(T : typeof(this))(T) { return false; } }
+struct S18 { bool opEquals(T : typeof(this))(T) { return false; } }
+
+void fun()()
+{
+    { auto a = new S1[1]; }
+    { auto p = new S2(); }
+    { alias P = S3*; auto p = new P; }
+    { S4[int] aa; auto b = (aa == aa); }
+    { S5[] a; a.length = 10; }
+    { S6[] a; delete a; }
+    { S7[] a = []; }
+    { S8[] a = [S8.init]; }
+    { S9[int] aa = [1:S9.init]; }
+
+    { auto ti = typeid(S10[int]); }
+    { auto ti = typeid(int[S11]); }
+    { auto ti = typeid(S12[]); }
+    { auto ti = typeid(S13*); }
+    { auto ti = typeid(S14[3]); }
+    { auto ti = typeid(S15 function()); }
+    { auto ti = typeid(S16 delegate()); }
+    { auto ti = typeid(void function(S17)); }   // TypeInfo_Function doesn't have parameter types
+    { auto ti = typeid(void delegate(S18)); }   // ditto
+}
+
+struct B12146
+{
+    bool opCmp(ubyte val) { return false; }
+}

--- a/test/runnable/link12144.d
+++ b/test/runnable/link12144.d
@@ -1,0 +1,20 @@
+// COMPILE_SEPARATELY: -g
+// EXTRA_SOURCES: imports/link12144a.d
+
+import imports.link12144a;
+
+void main()
+{
+    fun();
+}
+
+struct A12146
+{
+    B12146[] tokens;
+    // implicitly generated
+    //   bool opEquals(const ref Appender rhs) const
+    // will make
+    //   tokens == rhs.tokens
+    // references TypeInfo of B12146
+    // and it references __xopCmp
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12144

Run `semantic3` for TypeInfo-related struct member functions.
