### PR TITLE
Issue 12185 - Spellchecker matches symbols that are more than 50% different

### DIFF
--- a/src/root/speller.c
+++ b/src/root/speller.c
@@ -201,7 +201,7 @@ void *spellerX(const char *seed, size_t seedlen, fp_speller_t fp, void *fparg,
 void *speller(const char *seed, fp_speller_t fp, void *fparg, const char *charset)
 {
     size_t seedlen = strlen(seed);
-    size_t maxdist = seedlen < 3 ? seedlen - 1 : 2;
+    size_t maxdist = seedlen < 4 ? seedlen / 2 : 2;
     for (int distance = 0; distance < maxdist; distance++)
     {   void *p = spellerX(seed, seedlen, fp, fparg, charset, distance);
         if (p)

--- a/test/fail_compilation/diag9191.d
+++ b/test/fail_compilation/diag9191.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag9191.d(16): Error: function diag9191.C1.aaa does not override any function, did you mean to override 'diag9191.B1.aa'?
-fail_compilation/diag9191.d(21): Error: function diag9191.C2.aaa does not override any function, did you mean to override 'diag9191.I1.a'?
+fail_compilation/diag9191.d(21): Error: function diag9191.C2.aaa does not override any function
 fail_compilation/diag9191.d(31): Error: function diag9191.C3.foo does not override any function, did you mean to override 'diag9191.B2._foo'?
 fail_compilation/diag9191.d(36): Error: function diag9191.C4.toStringa does not override any function, did you mean to override 'object.Object.toString'?
 ---

--- a/test/fail_compilation/spell9644.d
+++ b/test/fail_compilation/spell9644.d
@@ -8,7 +8,7 @@ fail_compilation/spell9644.d(21): Error: undefined identifier b
 fail_compilation/spell9644.d(22): Error: undefined identifier xx
 fail_compilation/spell9644.d(23): Error: undefined identifier cb, did you mean variable ab?
 fail_compilation/spell9644.d(24): Error: undefined identifier bc, did you mean variable abc?
-fail_compilation/spell9644.d(25): Error: undefined identifier ccc, did you mean variable abc?
+fail_compilation/spell9644.d(25): Error: undefined identifier ccc
 ---
 */
 


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12185
