### PR TITLE
Split mangle test into two files

### DIFF
--- a/test/runnable/imports/mangle1.d
+++ b/test/runnable/imports/mangle1.d
@@ -1,0 +1,7 @@
+//UTF-8 chars
+__gshared pragma(mangle, "test_эльфийские_письмена_9") ubyte test9_1;
+
+void setTest91()
+{
+    test9_1 = 42;
+}

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -1,4 +1,7 @@
 // PERMUTE_ARGS:
+// EXTRA_SOURCES: imports/mangle1.d
+
+import mangle1;
 
 pragma(mangle, "_test1_") int test1;
 
@@ -39,12 +42,11 @@ void test8()
 }
 
 //UTF-8 chars
-__gshared pragma(mangle, "test_эльфийские_письмена_9") ubyte test9_1;
 __gshared extern pragma(mangle, "test_эльфийские_письмена_9") ubyte test9_1_e;
 
 void test9()
 {
-    test9_1 = 42;
+    setTest91();
     assert(test9_1_e == 42);
 }
 


### PR DESCRIPTION
We currently have two VarDeclarations in mangle.d which reference the same symbol. This causes problems in the GCC backend as it does not realize it actually deals with the same symbol and therefore
reorders reads and writes. It's not clear if this will be fixed in the GCC backend at all as the fix would break other stuff. It's also kind of weird to reference a symbol in this way. The correct way is to use aliases.
http://gcc.gnu.org/bugzilla/show_bug.cgi?id=60214

Anyway, this test was likely not supposed to test if the compiler recognizes that these are the same variables, it was probably just to test that we can read/write to a symbol with a specific mangle.

@IgorStepanov can you comment on the intention of the test?
