### PR TITLE
Give users some guidance on how to handle missing default cases.

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -2899,7 +2899,7 @@ Statement *SwitchStatement::semantic(Scope *sc)
     {   hasNoDefault = 1;
 
         if (!isFinal && !body->isErrorStatement())
-           deprecation("non-final switch statement without a default is deprecated");
+           deprecation("non-final switch statement without a default is deprecated; add 'default: assert(0);' or 'default: break;'");
 
         // Generate runtime error if the default is hit
         Statements *a = new Statements();

--- a/test/fail_compilation/fail287.d
+++ b/test/fail_compilation/fail287.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail287.d(14): Error: had 299 cases which is more than 256 cases in case range
-fail_compilation/fail287.d(12): Deprecation: non-final switch statement without a default is deprecated
+fail_compilation/fail287.d(12): Deprecation: non-final switch statement without a default is deprecated; add 'default: assert(0);' or 'default: break;'
 ---
 */
 


### PR DESCRIPTION
In light of this discussion [1], I think it would be a good idea to explicitly tell the user to put `assert(0)` in their default case, if they don't want to handle it.

Feel free to suggest a better phrasing or a nicer formatting.

[1] http://forum.dlang.org/thread/mailman.122.1392565409.6445.digitalmars-d@puremagic.com?page=6#post-ldvv6r:2431ha:241:40digitalmars.com
