### PR TITLE
[Refactoring] Remove `Scope *sc` from `Expression::addressOf`

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -189,7 +189,7 @@ elem *callfunc(Loc loc,
                 {
                     // Convert argument to a pointer,
                     // use AddrExp::toElem()
-                    Expression *ae = arg->addressOf(NULL);
+                    Expression *ae = arg->addressOf();
                     ea = ae->toElem(irs);
                     goto L1;
                 }

--- a/src/expression.h
+++ b/src/expression.h
@@ -204,7 +204,7 @@ public:
     virtual Expression *checkToBoolean(Scope *sc);
     virtual Expression *addDtorHook(Scope *sc);
     Expression *checkToPointer();
-    Expression *addressOf(Scope *sc);
+    Expression *addressOf();
     Expression *deref();
 
     Expression *optimize(int result, bool keepLvalue = false)

--- a/src/func.c
+++ b/src/func.c
@@ -1454,7 +1454,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 Expression *v = new ThisExp(Loc());
                 v->type = vthis->type;
                 if (ad->isStructDeclaration())
-                    v = v->addressOf(sc);
+                    v = v->addressOf();
                 Expression *se = new StringExp(Loc(), (char *)"null this");
                 se = se->semantic(sc);
                 se->type = Type::tchar->arrayOf();
@@ -1494,7 +1494,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 Expression *v = new ThisExp(Loc());
                 v->type = vthis->type;
                 if (ad->isStructDeclaration())
-                    v = v->addressOf(sc);
+                    v = v->addressOf();
                 e = new AssertExp(Loc(), v);
             }
             if (e)

--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -325,7 +325,7 @@ Expression *Type::getTypeInfo(Scope *sc)
 {
     Declaration *ti = new TypeInfoDeclaration(this, 1);
     Expression *e = new VarExp(Loc(), ti);
-    e = e->addressOf(sc);
+    e = e->addressOf();
     e->type = ti->type;
     return e;
 }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6286,7 +6286,7 @@ Expression *TypeDelegate::dotExp(Scope *sc, Expression *e, Identifier *ident, in
             e = new CommaExp(e->loc, e, new VarExp(e->loc, tmp));
             e = e->semantic(sc);
         }
-        e = e->addressOf(sc);
+        e = e->addressOf();
         e->type = tvoidptr;
         e = new AddExp(e->loc, e, new IntegerExp(Target::ptrsize));
         e->type = tvoidptr;
@@ -8404,7 +8404,7 @@ L1:
                 if (!sym->vclassinfo)
                     sym->vclassinfo = new TypeInfoClassDeclaration(sym->type);
                 e = new VarExp(e->loc, sym->vclassinfo);
-                e = e->addressOf(sc);
+                e = e->addressOf();
                 e->type = t;    // do this so we don't get redundant dereference
             }
             else

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -793,8 +793,9 @@ public:
                 e = el_bin(OPcomma, e->Ety, es, e);
             }
             else if (tf->isref)
-            {   // Reference return, so convert to a pointer
-                Expression *ae = s->exp->addressOf(NULL);
+            {
+                // Reference return, so convert to a pointer
+                Expression *ae = s->exp->addressOf();
                 e = toElemDtor(ae, irs);
             }
             else

--- a/src/statement.c
+++ b/src/statement.c
@@ -4048,7 +4048,7 @@ Statement *WithStatement::semantic(Scope *sc)
                 exp = new CommaExp(loc, new DeclarationExp(loc, wthis), new VarExp(loc, wthis));
                 exp = exp->semantic(sc);
             }
-            Expression *e = exp->addressOf(sc);
+            Expression *e = exp->addressOf();
             init = new ExpInitializer(loc, e);
             wthis = new VarDeclaration(loc, e->type, Id::withSym, init);
             wthis->semantic(sc);

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -79,7 +79,7 @@ Expression *Type::getInternalTypeInfo(Scope *sc)
                 internalTI[t->ty] = tid;
             }
             e = VarExp::create(Loc(), tid);
-            e = e->addressOf(sc);
+            e = e->addressOf();
             e->type = tid->type;        // do this so we don't get redundant dereference
             return e;
 
@@ -151,7 +151,7 @@ Expression *Type::getTypeInfo(Scope *sc)
 {
     genTypeInfo(sc);
     Expression *e = VarExp::create(Loc(), vtinfo);
-    e = e->addressOf(sc);
+    e = e->addressOf();
     e->type = vtinfo->type;     // do this so we don't get redundant dereference
     return e;
 }


### PR DESCRIPTION
`Expression::addressOf` does not need to have `Scope *sc` parameter.
