### PR TITLE
[DDMD] Explicitly cast to unsigned

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -308,7 +308,7 @@ void Lexer::endOfLine()
 
 Loc Lexer::loc()
 {
-    scanloc.charnum = 1 + p-line;
+    scanloc.charnum = (unsigned)(1 + p-line);
     return scanloc;
 }
 


### PR DESCRIPTION
Because this isn't valid on 64-bit with D.
