### PR TITLE
More error propagation

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -2850,6 +2850,7 @@ Lt2:
 
 /************************************
  * Bring leaves to common type.
+ * Returns ErrorExp if error occurs. otherwise returns NULL.
  */
 
 Expression *typeCombine(BinExp *be, Scope *sc)
@@ -2875,7 +2876,7 @@ Expression *typeCombine(BinExp *be, Scope *sc)
         return be->e1;
     if (be->e2->op == TOKerror)
         return be->e2;
-    return be;
+    return NULL;
 
 Lerror:
     Expression *ex = be->incompatibleTypes();

--- a/src/cast.c
+++ b/src/cast.c
@@ -2878,10 +2878,9 @@ Expression *typeCombine(BinExp *be, Scope *sc)
     return be;
 
 Lerror:
-    be->incompatibleTypes();
-    be->type = Type::terror;
-    be->e1 = new ErrorExp();
-    be->e2 = new ErrorExp();
+    Expression *ex = be->incompatibleTypes();
+    if (ex->op == TOKerror)
+        return ex;
     return new ErrorExp();
 }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -6492,8 +6492,8 @@ Expression *BinExp::incompatibleTypes()
         else
         {
             error("incompatible types for ((%s) %s (%s)): '%s' and '%s'",
-             e1->toChars(), Token::toChars(thisOp), e2->toChars(),
-             e1->type->toChars(), e2->type->toChars());
+                e1->toChars(), Token::toChars(thisOp), e2->toChars(),
+                e1->type->toChars(), e2->type->toChars());
         }
         return new ErrorExp();
     }
@@ -6520,9 +6520,11 @@ Expression *BinAssignExp::semantic(Scope *sc)
     if (e1->op == TOKslice || e1->type->ty == Tarray || e1->type->ty == Tsarray)
     {
         // T[] op= ...
-        e = typeCombine(this, sc);
-        if (e->op == TOKerror)
-            return e;
+        if (Expression *ex = typeCombine(this, sc))
+        {
+            if (ex->op == TOKerror)
+                return ex;
+        }
         type = e1->type;
         return arrayOp(this, sc);
     }
@@ -6548,7 +6550,11 @@ Expression *BinAssignExp::semantic(Scope *sc)
         e2->type->toBasetype()->isintegral())
         return scaleFactor(this, sc);
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     if (arith)
     {
@@ -11470,9 +11476,11 @@ Expression *PowAssignExp::semantic(Scope *sc)
     if (e1->op == TOKslice || e1->type->ty == Tarray || e1->type->ty == Tsarray)
     {
         // T[] ^^= ...
-        e = typeCombine(this, sc);
-        if (e->op == TOKerror)
-            return e;
+        if (Expression *ex = typeCombine(this, sc))
+        {
+            if (ex->op == TOKerror)
+                return ex;
+        }
 
         // Check element types are arithmetic
         Type *tb1 = e1->type->nextOf()->toBasetype();
@@ -11574,7 +11582,11 @@ Expression *AddExp::semantic(Scope *sc)
         return incompatibleTypes();
     }
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -11664,7 +11676,12 @@ Expression *MinExp::semantic(Scope *sc)
             // Replace (ptr - ptr) with (ptr - ptr) / stride
             d_int64 stride;
 
-            typeCombine(this, sc);            // make sure pointer types are compatible
+            // make sure pointer types are compatible
+            if (Expression *ex = typeCombine(this, sc))
+            {
+                if (ex->op == TOKerror)
+                    return ex;
+            }
 
             type = Type::tptrdiff_t;
             stride = t2->nextOf()->size();
@@ -11694,7 +11711,11 @@ Expression *MinExp::semantic(Scope *sc)
         return new ErrorExp();
     }
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -11837,7 +11858,11 @@ Expression *CatExp::semantic(Scope *sc)
             e2 = e2->castTo(sc, t2);
     }
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
     type = type->toHeadMutable();
 
     Type *tb = type->toBasetype();
@@ -11901,7 +11926,11 @@ Expression *MulExp::semantic(Scope *sc)
     if (e)
         return e;
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -11988,7 +12017,11 @@ Expression *DivExp::semantic(Scope *sc)
     if (e)
         return e;
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12074,7 +12107,11 @@ Expression *ModExp::semantic(Scope *sc)
     if (e)
         return e;
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12148,7 +12185,11 @@ Expression *PowExp::semantic(Scope *sc)
     if (e)
         return e;
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12216,9 +12257,12 @@ Expression *PowExp::semantic(Scope *sc)
 
         // Leave handling of PowExp to the backend, or throw
         // an error gracefully if no backend support exists.
-        typeCombine(this, sc);
-        e = this;
-        return e;
+        if (Expression *ex = typeCombine(this, sc))
+        {
+            if (ex->op == TOKerror)
+                return ex;
+        }
+        return this;
     }
     e = new ScopeExp(loc, mmath);
 
@@ -12355,7 +12399,11 @@ Expression *AndExp::semantic(Scope *sc)
         return this;
     }
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12403,7 +12451,11 @@ Expression *OrExp::semantic(Scope *sc)
         return this;
     }
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12451,7 +12503,11 @@ Expression *XorExp::semantic(Scope *sc)
         return this;
     }
 
-    typeCombine(this, sc);
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12699,9 +12755,11 @@ Expression *CmpExp::semantic(Scope *sc)
         return new ErrorExp();
     }
 
-    e = typeCombine(this, sc);
-    if (e->op == TOKerror)
-        return e;
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     type = Type::tboolean;
 
@@ -12720,7 +12778,6 @@ Expression *CmpExp::semantic(Scope *sc)
             error("array comparison type mismatch, %s vs %s", t1next->toChars(), t2next->toChars());
             return new ErrorExp();
         }
-        e = this;
     }
     else if (t1->ty == Tstruct || t2->ty == Tstruct ||
              (t1->ty == Tclass && t2->ty == Tclass))
@@ -12749,7 +12806,6 @@ Expression *CmpExp::semantic(Scope *sc)
     {
         if (!e1->rvalue() || !e2->rvalue())
             return new ErrorExp();
-        e = this;
     }
 
     TOK altop;
@@ -12797,7 +12853,7 @@ Expression *CmpExp::semantic(Scope *sc)
     }
 
     //printf("CmpExp: %s, type = %s\n", e->toChars(), e->type->toChars());
-    return e;
+    return this;
 }
 
 /************************************************************/
@@ -12978,9 +13034,11 @@ Expression *EqualExp::semantic(Scope *sc)
         return e->semantic(sc);
     }
 
-    e = typeCombine(this, sc);
-    if (e->op == TOKerror)
-        return e;
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     type = Type::tboolean;
 
@@ -13000,7 +13058,7 @@ Expression *EqualExp::semantic(Scope *sc)
     if (e1->type->toBasetype()->ty == Tvector)
         return incompatibleTypes();
 
-    return e;
+    return this;
 }
 
 /************************************************************/
@@ -13019,9 +13077,11 @@ Expression *IdentityExp::semantic(Scope *sc)
         return ex;
     type = Type::tboolean;
 
-    Expression *e = typeCombine(this, sc);
-    if (e->op == TOKerror)
-        return e;
+    if (Expression *ex = typeCombine(this, sc))
+    {
+        if (ex->op == TOKerror)
+            return ex;
+    }
 
     if (e1->type != e2->type && e1->type->isfloating() && e2->type->isfloating())
     {
@@ -13095,7 +13155,11 @@ Expression *CondExp::semantic(Scope *sc)
         type = t1;
     else
     {
-        typeCombine(this, sc);
+        if (Expression *ex = typeCombine(this, sc))
+        {
+            if (ex->op == TOKerror)
+                return ex;
+        }
         switch (e1->type->toBasetype()->ty)
         {
             case Tcomplex32:
@@ -13139,7 +13203,6 @@ Expression *CondExp::toLvalue(Scope *sc, Expression *ex)
     PtrExp *e = new PtrExp(loc, this, type);
     e1 = e1->toLvalue(sc, NULL)->addressOf();
     e2 = e2->toLvalue(sc, NULL)->addressOf();
-    //typeCombine(this, sc);
     type = e2->type;
     return e;
 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -11877,8 +11877,7 @@ Expression *CatExp::semantic(Scope *sc)
     else
     {
         //printf("(%s) ~ (%s)\n", e1->toChars(), e2->toChars());
-        incompatibleTypes();
-        return new ErrorExp();
+        return incompatibleTypes();
     }
 
     e->type = e->type->semantic(loc, sc);
@@ -12268,7 +12267,9 @@ Expression *ShlExp::semantic(Scope *sc)
     e2 = e2->checkIntegral();
     if (e1->type->toBasetype()->ty == Tvector ||
         e2->type->toBasetype()->ty == Tvector)
+    {
         return incompatibleTypes();
+    }
     e1 = integralPromotions(e1, sc);
     e2 = e2->castTo(sc, Type::tshiftcnt);
 
@@ -12298,7 +12299,9 @@ Expression *ShrExp::semantic(Scope *sc)
     e2 = e2->checkIntegral();
     if (e1->type->toBasetype()->ty == Tvector ||
         e2->type->toBasetype()->ty == Tvector)
+    {
         return incompatibleTypes();
+    }
     e1 = integralPromotions(e1, sc);
     e2 = e2->castTo(sc, Type::tshiftcnt);
 
@@ -12707,8 +12710,7 @@ Expression *CmpExp::semantic(Scope *sc)
     if (e1->op == TOKslice && t1->ty == Tarray && e2->implicitConvTo(t1->nextOf()) ||
         e2->op == TOKslice && t2->ty == Tarray && e1->implicitConvTo(t2->nextOf()))
     {
-        incompatibleTypes();
-        return new ErrorExp();
+        return incompatibleTypes();
     }
 
     if (Expression *ex = typeCombine(this, sc))
@@ -12926,8 +12928,7 @@ Expression *EqualExp::semantic(Scope *sc)
     if (e1->op == TOKslice && t1->ty == Tarray && e2->implicitConvTo(t1->nextOf()) ||
         e2->op == TOKslice && t2->ty == Tarray && e1->implicitConvTo(t2->nextOf()))
     {
-        incompatibleTypes();
-        return new ErrorExp();
+        return incompatibleTypes();
     }
 
     if (t1->ty == Tstruct && t2->ty == Tstruct)

--- a/src/expression.c
+++ b/src/expression.c
@@ -6513,6 +6513,7 @@ Expression *BinAssignExp::semantic(Scope *sc)
 
     if (e1->op == TOKarraylength)
     {
+        // arr.length op= e2;
         e = ArrayLengthExp::rewriteOpAssign(this);
         e = e->semantic(sc);
         return e;
@@ -6521,10 +6522,7 @@ Expression *BinAssignExp::semantic(Scope *sc)
     {
         // T[] op= ...
         if (Expression *ex = typeCombine(this, sc))
-        {
-            if (ex->op == TOKerror)
-                return ex;
-        }
+            return ex;
         type = e1->type;
         return arrayOp(this, sc);
     }
@@ -6551,10 +6549,7 @@ Expression *BinAssignExp::semantic(Scope *sc)
         return scaleFactor(this, sc);
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     if (arith)
     {
@@ -11477,10 +11472,7 @@ Expression *PowAssignExp::semantic(Scope *sc)
     {
         // T[] ^^= ...
         if (Expression *ex = typeCombine(this, sc))
-        {
-            if (ex->op == TOKerror)
-                return ex;
-        }
+            return ex;
 
         // Check element types are arithmetic
         Type *tb1 = e1->type->nextOf()->toBasetype();
@@ -11583,10 +11575,7 @@ Expression *AddExp::semantic(Scope *sc)
     }
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -11678,10 +11667,7 @@ Expression *MinExp::semantic(Scope *sc)
 
             // make sure pointer types are compatible
             if (Expression *ex = typeCombine(this, sc))
-            {
-                if (ex->op == TOKerror)
-                    return ex;
-            }
+                return ex;
 
             type = Type::tptrdiff_t;
             stride = t2->nextOf()->size();
@@ -11712,10 +11698,7 @@ Expression *MinExp::semantic(Scope *sc)
     }
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -11859,10 +11842,7 @@ Expression *CatExp::semantic(Scope *sc)
     }
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
     type = type->toHeadMutable();
 
     Type *tb = type->toBasetype();
@@ -11927,10 +11907,7 @@ Expression *MulExp::semantic(Scope *sc)
         return e;
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12018,10 +11995,7 @@ Expression *DivExp::semantic(Scope *sc)
         return e;
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12108,10 +12082,7 @@ Expression *ModExp::semantic(Scope *sc)
         return e;
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12186,10 +12157,7 @@ Expression *PowExp::semantic(Scope *sc)
         return e;
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12258,10 +12226,7 @@ Expression *PowExp::semantic(Scope *sc)
         // Leave handling of PowExp to the backend, or throw
         // an error gracefully if no backend support exists.
         if (Expression *ex = typeCombine(this, sc))
-        {
-            if (ex->op == TOKerror)
-                return ex;
-        }
+            return ex;
         return this;
     }
     e = new ScopeExp(loc, mmath);
@@ -12400,10 +12365,7 @@ Expression *AndExp::semantic(Scope *sc)
     }
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12452,10 +12414,7 @@ Expression *OrExp::semantic(Scope *sc)
     }
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12504,10 +12463,7 @@ Expression *XorExp::semantic(Scope *sc)
     }
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     Type *tb = type->toBasetype();
     if (tb->ty == Tarray || tb->ty == Tsarray)
@@ -12756,10 +12712,7 @@ Expression *CmpExp::semantic(Scope *sc)
     }
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     type = Type::tboolean;
 
@@ -13035,10 +12988,7 @@ Expression *EqualExp::semantic(Scope *sc)
     }
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     type = Type::tboolean;
 
@@ -13078,10 +13028,7 @@ Expression *IdentityExp::semantic(Scope *sc)
     type = Type::tboolean;
 
     if (Expression *ex = typeCombine(this, sc))
-    {
-        if (ex->op == TOKerror)
-            return ex;
-    }
+        return ex;
 
     if (e1->type != e2->type && e1->type->isfloating() && e2->type->isfloating())
     {
@@ -13156,10 +13103,7 @@ Expression *CondExp::semantic(Scope *sc)
     else
     {
         if (Expression *ex = typeCombine(this, sc))
-        {
-            if (ex->op == TOKerror)
-                return ex;
-        }
+            return ex;
         switch (e1->type->toBasetype()->ty)
         {
             case Tcomplex32:

--- a/src/expression.c
+++ b/src/expression.c
@@ -6261,22 +6261,15 @@ Expression *UnaExp::syntaxCopy()
     return e;
 }
 
-Expression *UnaExp::semantic(Scope *sc)
-{
-#if LOGSEMANTIC
-    printf("UnaExp::semantic('%s')\n", toChars());
-#endif
-    if (Expression *ex = unaSemantic(sc))
-        return ex;
-    return this;
-}
-
 /**************************
  * Helper function for easy error propagation.
  * If error occurs, returns ErrorExp. Otherwise returns NULL.
  */
 Expression *UnaExp::unaSemantic(Scope *sc)
 {
+#if LOGSEMANTIC
+    printf("UnaExp::semantic('%s')\n", toChars());
+#endif
     Expression *e1x = e1->semantic(sc);
     if (e1x->op == TOKerror)
         return e1x;
@@ -6311,22 +6304,15 @@ Expression *BinExp::syntaxCopy()
     return e;
 }
 
-Expression *BinExp::semantic(Scope *sc)
-{
-#if LOGSEMANTIC
-    printf("BinExp::semantic('%s')\n", toChars());
-#endif
-    if (Expression *ex = binSemantic(sc))
-        return ex;
-    return this;
-}
-
 /**************************
  * Helper function for easy error propagation.
  * If error occurs, returns ErrorExp. Otherwise returns NULL.
  */
 Expression *BinExp::binSemantic(Scope *sc)
 {
+#if LOGSEMANTIC
+    printf("BinExp::semantic('%s')\n", toChars());
+#endif
     Expression *e1x = e1->semantic(sc);
     Expression *e2x = e2->semantic(sc);
     if (e1x->op == TOKerror)
@@ -7190,6 +7176,13 @@ DotTemplateExp::DotTemplateExp(Loc loc, Expression *e, TemplateDeclaration *td)
     this->td = td;
 }
 
+Expression *DotTemplateExp::semantic(Scope *sc)
+{
+    if (Expression *ex = unaSemantic(sc))
+        return ex;
+    return this;
+}
+
 /************************************************************/
 
 DotVarExp::DotVarExp(Loc loc, Expression *e, Declaration *v, bool hasOverloads)
@@ -7736,7 +7729,9 @@ Expression *DotTypeExp::semantic(Scope *sc)
 #if LOGSEMANTIC
     printf("DotTypeExp::semantic('%s')\n", toChars());
 #endif
-    return UnaExp::semantic(sc);
+    if (Expression *ex = unaSemantic(sc))
+        return ex;
+    return this;
 }
 
 /************************************************************/
@@ -12661,6 +12656,13 @@ RemoveExp::RemoveExp(Loc loc, Expression *e1, Expression *e2)
         : BinExp(loc, TOKremove, sizeof(RemoveExp), e1, e2)
 {
     type = Type::tboolean;
+}
+
+Expression *RemoveExp::semantic(Scope *sc)
+{
+    if (Expression *ex = binSemantic(sc))
+        return ex;
+    return this;
 }
 
 /************************************************************/

--- a/src/expression.h
+++ b/src/expression.h
@@ -757,6 +757,7 @@ public:
     UnaExp(Loc loc, TOK op, int size, Expression *e1);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
+    Expression *unaSemantic(Scope *sc);
     Expression *resolveLoc(Loc loc, Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
@@ -777,7 +778,8 @@ public:
     BinExp(Loc loc, TOK op, int size, Expression *e1, Expression *e2);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    Expression *semanticp(Scope *sc);
+    Expression *binSemantic(Scope *sc);
+    Expression *binSemanticProp(Scope *sc);
     Expression *checkComplexOpAssign(Scope *sc);
     int isunsigned();
     Expression *incompatibleTypes();

--- a/src/expression.h
+++ b/src/expression.h
@@ -756,7 +756,7 @@ public:
 
     UnaExp(Loc loc, TOK op, int size, Expression *e1);
     Expression *syntaxCopy();
-    Expression *semantic(Scope *sc);
+    Expression *semantic(Scope *sc) = 0;
     Expression *unaSemantic(Scope *sc);
     Expression *resolveLoc(Loc loc, Scope *sc);
 
@@ -777,7 +777,7 @@ public:
 
     BinExp(Loc loc, TOK op, int size, Expression *e1, Expression *e2);
     Expression *syntaxCopy();
-    Expression *semantic(Scope *sc);
+    Expression *semantic(Scope *sc) = 0;
     Expression *binSemantic(Scope *sc);
     Expression *binSemanticProp(Scope *sc);
     Expression *checkComplexOpAssign(Scope *sc);
@@ -854,6 +854,7 @@ public:
     TemplateDeclaration *td;
 
     DotTemplateExp(Loc loc, Expression *e, TemplateDeclaration *td);
+    Expression *semantic(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1419,6 +1420,7 @@ class RemoveExp : public BinExp
 {
 public:
     RemoveExp(Loc loc, Expression *e1, Expression *e2);
+    Expression *semantic(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/opover.c
+++ b/src/opover.c
@@ -906,7 +906,14 @@ Expression *op_overload(Expression *e, Scope *sc)
                 }
             }
 
-            e->BinExp::semantic(sc);
+            if (Expression *ex = e->BinExp::semantic(sc))
+            {
+                if (ex->op == TOKerror)
+                {
+                    result = ex;
+                    return;
+                }
+            }
             e->e1 = resolveProperties(sc, e->e1);
             e->e2 = resolveProperties(sc, e->e2);
 

--- a/src/opover.c
+++ b/src/opover.c
@@ -906,16 +906,9 @@ Expression *op_overload(Expression *e, Scope *sc)
                 }
             }
 
-            if (Expression *ex = e->BinExp::semantic(sc))
-            {
-                if (ex->op == TOKerror)
-                {
-                    result = ex;
-                    return;
-                }
-            }
-            e->e1 = resolveProperties(sc, e->e1);
-            e->e2 = resolveProperties(sc, e->e2);
+            result = e->binSemanticProp(sc);
+            if (result)
+                return;
 
             // Don't attempt 'alias this' if an error occured
             if (e->e1->type->ty == Terror || e->e2->type->ty == Terror)

--- a/src/statement.c
+++ b/src/statement.c
@@ -2273,10 +2273,7 @@ Statement *ForeachRangeStatement::semantic(Scope *sc)
         {
             AddExp ea(loc, lwr, upr);
             if (Expression *ex = typeCombine(&ea, sc))
-            {
-                if (ex->op == TOKerror)
-                    return new ErrorStatement();
-            }
+                return new ErrorStatement();
             arg->type = ea.type;
             lwr = ea.e1;
             upr = ea.e2;

--- a/src/statement.c
+++ b/src/statement.c
@@ -2272,7 +2272,11 @@ Statement *ForeachRangeStatement::semantic(Scope *sc)
         else
         {
             AddExp ea(loc, lwr, upr);
-            Expression *e = typeCombine(&ea, sc);
+            if (Expression *ex = typeCombine(&ea, sc))
+            {
+                if (ex->op == TOKerror)
+                    return new ErrorStatement();
+            }
             arg->type = ea.type;
             lwr = ea.e1;
             upr = ea.e2;

--- a/test/fail_compilation/diag_err1.d
+++ b/test/fail_compilation/diag_err1.d
@@ -1,21 +1,25 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag_err1.d(18): Error: undefined identifier x
-fail_compilation/diag_err1.d(18):        while evaluating pragma(msg, [1, 2, x].length)
-fail_compilation/diag_err1.d(19): Error: undefined identifier x
-fail_compilation/diag_err1.d(19): Error: undefined identifier y
-fail_compilation/diag_err1.d(19):        while evaluating pragma(msg, (x + y).sizeof)
-fail_compilation/diag_err1.d(20): Error: undefined identifier x
-fail_compilation/diag_err1.d(20):        while evaluating pragma(msg, (n += x).sizeof)
+fail_compilation/diag_err1.d(21): Error: undefined identifier x
+fail_compilation/diag_err1.d(21):        while evaluating pragma(msg, [1, 2, x].length)
+fail_compilation/diag_err1.d(22): Error: undefined identifier x
+fail_compilation/diag_err1.d(22): Error: undefined identifier y
+fail_compilation/diag_err1.d(22):        while evaluating pragma(msg, (x + y).sizeof)
+fail_compilation/diag_err1.d(23): Error: undefined identifier x
+fail_compilation/diag_err1.d(23):        while evaluating pragma(msg, (n += x).sizeof)
+fail_compilation/diag_err1.d(24): Error: incompatible types for ((s) ~ (n)): 'string' and 'int'
+fail_compilation/diag_err1.d(24):        while evaluating pragma(msg, (s ~ n).sizeof)
 ---
 */
 
 void main()
 {
     int n;
+    string s;
 
     pragma(msg, [1,2,x].length);
     pragma(msg, (x + y).sizeof);
     pragma(msg, (n += x).sizeof);
+    pragma(msg, (s ~ n).sizeof);
 }

--- a/test/fail_compilation/diag_err1.d
+++ b/test/fail_compilation/diag_err1.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag_err1.d(18): Error: undefined identifier x
+fail_compilation/diag_err1.d(18):        while evaluating pragma(msg, [1, 2, x].length)
+fail_compilation/diag_err1.d(19): Error: undefined identifier x
+fail_compilation/diag_err1.d(19): Error: undefined identifier y
+fail_compilation/diag_err1.d(19):        while evaluating pragma(msg, (x + y).sizeof)
+fail_compilation/diag_err1.d(20): Error: undefined identifier x
+fail_compilation/diag_err1.d(20):        while evaluating pragma(msg, (n += x).sizeof)
+---
+*/
+
+void main()
+{
+    int n;
+
+    pragma(msg, [1,2,x].length);
+    pragma(msg, (x + y).sizeof);
+    pragma(msg, (n += x).sizeof);
+}


### PR DESCRIPTION
If a sub-expression `semantic` generates an `ErrorExp`, it should not be stored in the AST.

This change is not perfect, but in many cases diagnostic message will be improved.
