### PR TITLE
fix Issue 12223 - __traits(getMember,...) needed for aliases

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -323,6 +323,7 @@ Msgtable msgtable[] =
     { "identifier" },
     { "getProtection" },
     { "parent" },
+    { "child" },
     { "getMember" },
     { "getOverloads" },
     { "getVirtualFunctions" },

--- a/src/traits.c
+++ b/src/traits.c
@@ -524,6 +524,63 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
 
         return (new DsymbolExp(e->loc, s))->semantic(sc);
     }
+    else if (e->ident == Id::child)
+    {
+        if (dim != 2)
+            goto Ldimerror;
+
+        RootObject *o1 = (*e->args)[0];
+        Expression *ex;
+        if (Dsymbol *sym = getDsymbol(o1))
+            ex = new DsymbolExp(e->loc, sym);
+        else
+        if ((ex = isExpression(o1)) != NULL)
+            {}
+        else
+        {
+            e->error("symbol or expression expected as first argument of __traits %s instead of %s", e->ident->toChars(), o1->toChars());
+            goto Lfalse;
+        }
+
+        if (ex->op == TOKdotexp)
+        {
+            DotExp *de = (DotExp*)ex;
+            if (de->e2->op == TOKimport)
+                ex = de->e1;
+            else
+            {
+                de->e2->error("cannot resolve child of %s", de->e2->toChars());
+                goto Lfalse;
+            }
+        }
+
+        ex = ex->semantic(sc);
+
+        Dsymbol *sym2 = getDsymbol((*e->args)[1]);
+        if (!sym2)
+        {
+            e->error("symbol expected as second argument of __traits %s instead of %s", e->ident->toChars(), (*e->args)[1]->toChars());
+            goto Lfalse;
+        }
+
+        if (Declaration *d = sym2->isDeclaration())
+            ex = new DotVarExp(e->loc, ex, d);
+        else
+        if (ScopeDsymbol *ti = sym2->isScopeDsymbol())
+        {
+            Expression *ex2 = new DotExp(e->loc, ex, new ScopeExp(e->loc, ti));
+            ex2->type = ex->type->copy();
+            ex = ex2;
+        }
+        else
+        {
+            e->error("invalid second argument of __traits %s", e->ident->toChars());
+            goto Lfalse;
+        }
+
+        ex = ex->semantic(sc);
+        return ex;
+    }
     else if (e->ident == Id::hasMember ||
              e->ident == Id::getMember ||
              e->ident == Id::getOverloads ||

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1514,6 +1514,79 @@ void test12237()
 
 /********************************************************/
 
+struct Child
+{
+static:
+
+    static template T(alias x)
+    {
+        void set(int n) { x = n; }
+    }
+    mixin template M(alias x)
+    {
+        void set(int n) { x = n; }
+    }
+
+    struct S
+    {
+        int i;
+        alias t = T!i;
+        mixin M!i m;
+    }
+
+    alias v = S.i;
+    alias t = S.t;
+    alias tf = t.set;
+    alias m = S.m;
+    alias mf = m.set;
+
+    void test(alias s)()
+    {
+        s.i = 0;
+
+        __traits(child, s, v) = 1;
+        assert(s.i == 1);
+
+        __traits(child, s, t).set(2);
+        assert(s.i == 2);
+        __traits(child, s, tf)(3);
+        assert(s.i == 3);
+        __traits(child, __traits(child, s, t), tf)(4);
+        assert(s.i == 4);
+
+        __traits(child, s, m).set(5);
+        assert(s.i == 5);
+        __traits(child, s, mf)(6);
+        assert(s.i == 6);
+        __traits(child, __traits(child, s, m), mf)(7);
+        assert(s.i == 7);
+    }
+
+    void testAll()
+    {
+        S s;
+        test!s();
+
+        static struct W
+        {
+            S s;
+            void testW()
+            {
+                test!s();
+            }
+        }
+        W w;
+        w.testW();
+    }
+}
+
+void testChild()
+{
+    Child.testAll();
+}
+
+/********************************************************/
+
 int main()
 {
     test1();
@@ -1552,6 +1625,7 @@ int main()
     test_getUnitTests();
     test_getFunctionAttributes();
     test_isOverrideFunction();
+    testChild();
     test12237();
 
     writeln("Success");


### PR DESCRIPTION
This is my attempt at implementing [issue 12223](https://d.puremagic.com/issues/show_bug.cgi?id=12223), a `__traits` primitive to evaluate a symbol with a given `this`.

~~This implementation works - mostly. However, it doesn't work when chaining the `child` trait - the `DotExp` never seems to get lowered, and the backend chokes on it. See the commented out lines in the test for an example. Perhaps someone can give me a hint at what am I doing wrong?~~

Will do a doc pull when this is merged.
