### PR TITLE
Issue 12231 - ICE on the class declaration within lambda inside template constraint

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -707,7 +707,8 @@ void ClassDeclaration::semantic(Scope *sc)
     //    this() { }
     if (!ctor && baseClass && baseClass->ctor)
     {
-        if (FuncDeclaration *fd = resolveFuncCall(loc, sc, baseClass->ctor, NULL, NULL, NULL, 1))
+        FuncDeclaration *fd = resolveFuncCall(loc, sc, baseClass->ctor, NULL, NULL, NULL, 1);
+        if (fd && !fd->errors)
         {
             //printf("Creating default this(){} for class %s\n", toChars());
             TypeFunction *btf = (TypeFunction *)fd->type;

--- a/src/clone.c
+++ b/src/clone.c
@@ -105,6 +105,8 @@ FuncDeclaration *hasIdentityOpAssign(AggregateDeclaration *ad, Scope *sc)
 
         if (f)
         {
+            if (f->errors)
+                return NULL;
             int varargs;
             Parameters *fparams = f->getParameters(&varargs);
             if (fparams->dim >= 1)
@@ -438,7 +440,11 @@ FuncDeclaration *hasIdentityOpEquals(AggregateDeclaration *ad,  Scope *sc)
             global.endGagging(errors);
 
             if (f)
+            {
+                if (f->errors)
+                    return NULL;
                 return f;
+            }
         }
     }
     return NULL;

--- a/src/expression.c
+++ b/src/expression.c
@@ -5477,12 +5477,13 @@ void FuncExp::genIdent(Scope *sc)
         DsymbolTable *symtab;
         if (FuncDeclaration *func = sc->parent->isFuncDeclaration())
         {
-            symtab = func->localsymtab;
-            if (symtab)
+            if (func->localsymtab == NULL)
             {
                 // Inside template constraint, symtab is not set yet.
-                goto L1;
+                // Initialize it lazily.
+                func->localsymtab = new DsymbolTable();
             }
+            symtab = func->localsymtab;
         }
         else
         {
@@ -5496,9 +5497,7 @@ void FuncExp::genIdent(Scope *sc)
             }
             symtab = sds->symtab;
         }
-        if (!symtab)
-            return;
-    L1:
+        assert(symtab);
         int num = (int)_aaLen(symtab->tab) + 1;
         Identifier *id = Lexer::uniqueId(s, num);
         fd->ident = id;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1293,6 +1293,8 @@ Type *Type::aliasthisOf()
             else if (d->isFuncDeclaration())
             {
                 FuncDeclaration *fd = resolveFuncCall(Loc(), NULL, d, NULL, this, NULL, 1);
+                if (fd && fd->errors)
+                    return Type::terror;
                 if (fd && !fd->type->nextOf() && !fd->functionSemantic())
                     fd = NULL;
                 if (fd)
@@ -1316,6 +1318,8 @@ Type *Type::aliasthisOf()
         {
             assert(td->scope);
             FuncDeclaration *fd = resolveFuncCall(Loc(), NULL, td, NULL, this, NULL, 1);
+            if (fd && fd->errors)
+                return Type::terror;
             if (fd && fd->functionSemantic())
             {
                 Type *t = fd->type->nextOf();

--- a/src/opover.c
+++ b/src/opover.c
@@ -569,12 +569,26 @@ Expression *op_overload(Expression *e, Scope *sc)
                 m.last = MATCHnomatch;
 
                 if (s)
+                {
                     functionResolve(&m, s, e->loc, sc, tiargs, e->e1->type, &args2);
+                    if (m.lastf && m.lastf->errors)
+                    {
+                        result = new ErrorExp();
+                        return;
+                    }
+                }
 
                 FuncDeclaration *lastf = m.lastf;
 
                 if (s_r)
+                {
                     functionResolve(&m, s_r, e->loc, sc, tiargs, e->e2->type, &args1);
+                    if (m.lastf && m.lastf->errors)
+                    {
+                        result = new ErrorExp();
+                        return;
+                    }
+                }
 
                 if (m.count > 1)
                 {
@@ -650,12 +664,26 @@ Expression *op_overload(Expression *e, Scope *sc)
                     m.last = MATCHnomatch;
 
                     if (s_r)
+                    {
                         functionResolve(&m, s_r, e->loc, sc, tiargs, e->e1->type, &args2);
+                        if (m.lastf && m.lastf->errors)
+                        {
+                            result = new ErrorExp();
+                            return;
+                        }
+                    }
 
                     FuncDeclaration *lastf = m.lastf;
 
                     if (s)
+                    {
                         functionResolve(&m, s, e->loc, sc, tiargs, e->e2->type, &args1);
+                        if (m.lastf && m.lastf->errors)
+                        {
+                            result = new ErrorExp();
+                            return;
+                        }
+                    }
 
                     if (m.count > 1)
                     {
@@ -971,7 +999,14 @@ Expression *op_overload(Expression *e, Scope *sc)
                 m.last = MATCHnomatch;
 
                 if (s)
+                {
                     functionResolve(&m, s, e->loc, sc, tiargs, e->e1->type, &args2);
+                    if (m.lastf && m.lastf->errors)
+                    {
+                        result = new ErrorExp();
+                        return;
+                    }
+                }
 
                 if (m.count > 1)
                 {
@@ -1094,13 +1129,21 @@ Expression *compare_overload(BinExp *e, Scope *sc, Identifier *id)
         }
 
         if (s)
+        {
             functionResolve(&m, s, e->loc, sc, tiargs, e->e1->type, &args2);
+            if (m.lastf && m.lastf->errors)
+                return new ErrorExp();
+        }
 
         FuncDeclaration *lastf = m.lastf;
         int count = m.count;
 
         if (s_r)
+        {
             functionResolve(&m, s_r, e->loc, sc, tiargs, e->e2->type, &args1);
+            if (m.lastf && m.lastf->errors)
+                return new ErrorExp();
+        }
 
         if (m.count > 1)
         {

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1161,24 +1161,6 @@ void TemplateInstance::toObjFile(int multiobj)
 #endif
     if (!isError(this) && members)
     {
-        FuncDeclaration *fd = enclosing ? enclosing->isFuncDeclaration() : NULL;
-        if (fd && fd->fbody == NULL)
-        {
-            /* Prevent codegen if enclosing is an artificially instantiated function.
-             */
-            return;
-        }
-
-        TemplateDeclaration *tempdecl = this->tempdecl->isTemplateDeclaration();
-        assert(tempdecl);
-        if (tempdecl->literal && tempdecl->ident == Id::empty)
-        {
-            /* Bugzilla 10313: Template lambdas that instantiated in template constraint
-             * cannot appear in runnable code block. So, this skip won't cause linker failure.
-             */
-            return;
-        }
-
         if (multiobj)
             // Append to list of object files to be written later
             obj_append(this);

--- a/src/traits.c
+++ b/src/traits.c
@@ -748,6 +748,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             if (ex)
             {
                 ex = ex->semantic(sc2);
+                ex = resolvePropertiesOnly(sc2, ex);
                 ex = ex->optimize(WANTvalue);
                 if (ex->op == TOKerror)
                     err = true;

--- a/test/fail_compilation/diag8648.d
+++ b/test/fail_compilation/diag8648.d
@@ -1,15 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8648.d(18): Error: undefined identifier X
-fail_compilation/diag8648.d(29): Error: template diag8648.foo cannot deduce function from argument types !()(Foo!(int, 1)), candidates are:
-fail_compilation/diag8648.d(18):        diag8648.foo(T, n)(X!(T, n))
-fail_compilation/diag8648.d(20): Error: undefined identifier a
-fail_compilation/diag8648.d(31): Error: template diag8648.bar cannot deduce function from argument types !()(Foo!(int, 1)), candidates are:
-fail_compilation/diag8648.d(20):        diag8648.bar(T)(Foo!(T, a))
-fail_compilation/diag8648.d(20): Error: undefined identifier a
-fail_compilation/diag8648.d(32): Error: template diag8648.bar cannot deduce function from argument types !()(Foo!(int, f)), candidates are:
-fail_compilation/diag8648.d(20):        diag8648.bar(T)(Foo!(T, a))
+fail_compilation/diag8648.d(12): Error: undefined identifier X
+fail_compilation/diag8648.d(14): Error: undefined identifier a
+fail_compilation/diag8648.d(14): Error: undefined identifier a
 ---
 */
 

--- a/test/fail_compilation/fail10346.d
+++ b/test/fail_compilation/fail10346.d
@@ -1,9 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10346.d(11): Error: undefined identifier T
-fail_compilation/fail10346.d(15): Error: template fail10346.bar cannot deduce function from argument types !(10)(Foo!int), candidates are:
-fail_compilation/fail10346.d(11):        fail10346.bar(T x, T)(Foo!T)
+fail_compilation/fail10346.d(9): Error: undefined identifier T
 ---
 */
 

--- a/test/fail_compilation/fail10481.d
+++ b/test/fail_compilation/fail10481.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10481.d(11): Error: undefined identifier T1, did you mean alias T0?
-fail_compilation/fail10481.d(15): Error: cannot resolve type for get!(A)
+fail_compilation/fail10481.d(10): Error: undefined identifier T1, did you mean alias T0?
 ---
 */
 

--- a/test/fail_compilation/fail236.d
+++ b/test/fail_compilation/fail236.d
@@ -1,9 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail236.d(14): Error: undefined identifier x
-fail_compilation/fail236.d(22): Error: template fail236.Templ2 cannot deduce function from argument types !()(int), candidates are:
-fail_compilation/fail236.d(12):        fail236.Templ2(alias a)(x)
+fail_compilation/fail236.d(12): Error: undefined identifier x
 ---
 */
 

--- a/test/fail_compilation/ice11553.d
+++ b/test/fail_compilation/ice11553.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11553.d(22): Error: recursive template expansion while looking for A!().A()
-fail_compilation/ice11553.d(22): Error: expression template A() of type void does not have a boolean value
+fail_compilation/ice11553.d(21): Error: recursive template expansion while looking for A!().A()
 ---
 */
 

--- a/test/fail_compilation/ice11850.d
+++ b/test/fail_compilation/ice11850.d
@@ -1,12 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11850.d(17): Error: incompatible types for ((a) < ([0])): 'uint[]' and 'int[]'
+fail_compilation/ice11850.d(15): Error: incompatible types for ((a) < ([0])): 'uint[]' and 'int[]'
 fail_compilation/imports/a11850.d(9):        instantiated from here: FilterResult!(__lambda1, uint[][])
-fail_compilation/ice11850.d(17):        instantiated from here: filter!(uint[][])
-fail_compilation/ice11850.d(17): Error: template instance ice11850.main.filter!((a) => a < [0]).filter!(uint[][]) error instantiating
-fail_compilation/ice11850.d(17): Error: template imports.a11850.filter cannot deduce function from argument types !((a) => a < [0])(uint[][]), candidates are:
-fail_compilation/imports/a11850.d(5):        imports.a11850.filter(alias pred)
+fail_compilation/ice11850.d(15):        instantiated from here: filter!(uint[][])
+fail_compilation/ice11850.d(15): Error: template instance ice11850.main.filter!((a) => a < [0]).filter!(uint[][]) error instantiating
 ---
 */
 

--- a/test/fail_compilation/ice11919.d
+++ b/test/fail_compilation/ice11919.d
@@ -2,7 +2,6 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11919.d(20): Error: Cannot interpret foo at compile time
-fail_compilation/ice11919.d(20): Error: Cannot interpret foo at compile time
 fail_compilation/imports/a11919.d(4): Error: template instance a11919.doBar!(Foo).doBar.zoo!(t) error instantiating
 fail_compilation/imports/a11919.d(11):        instantiated from here: doBar!(Foo)
 fail_compilation/ice11919.d(28):        instantiated from here: doBar!(Bar)
@@ -11,6 +10,7 @@ fail_compilation/ice11919.d(28):        instantiated from here: doBar!(Bar)
 fail_compilation/ice11919.d(28): Error: template instance a11919.doBar!(Bar) error instantiating
 ---
 */
+
 import imports.a11919;
 
 enum foo;

--- a/test/fail_compilation/ice6538.d
+++ b/test/fail_compilation/ice6538.d
@@ -6,9 +6,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice6538.d(23): Error: expression super is not a valid template value argument
-fail_compilation/ice6538.d(28): Error: template ice6538.D.foo cannot deduce function from argument types !()(), candidates are:
-fail_compilation/ice6538.d(23):        ice6538.D.foo()() if (Sym!(super))
+fail_compilation/ice6538.d(21): Error: expression super is not a valid template value argument
 ---
 */
 

--- a/test/fail_compilation/ice9806.d
+++ b/test/fail_compilation/ice9806.d
@@ -25,15 +25,12 @@ void test1() {
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9806.d(39): Error: undefined identifier undefined_expr
-fail_compilation/ice9806.d(42): Error: CTFE failed because of previous errors in foo2
-fail_compilation/ice9806.d(47): Error: template instance ice9806.S2!() error instantiating
-fail_compilation/ice9806.d(40): Error: undefined identifier undefined_expr
-fail_compilation/ice9806.d(43): Error: CTFE failed because of previous errors in bar2
-fail_compilation/ice9806.d(49): Error: template instance ice9806.C2!() error instantiating
-fail_compilation/ice9806.d(41): Error: undefined identifier undefined_expr
-fail_compilation/ice9806.d(44): Error: CTFE failed because of previous errors in baz2
-fail_compilation/ice9806.d(51): Error: template instance ice9806.I2!() error instantiating
+fail_compilation/ice9806.d(36): Error: undefined identifier undefined_expr
+fail_compilation/ice9806.d(44): Error: template instance ice9806.S2!() error instantiating
+fail_compilation/ice9806.d(37): Error: undefined identifier undefined_expr
+fail_compilation/ice9806.d(46): Error: template instance ice9806.C2!() error instantiating
+fail_compilation/ice9806.d(38): Error: undefined identifier undefined_expr
+fail_compilation/ice9806.d(48): Error: template instance ice9806.I2!() error instantiating
 ---
 */
 int foo2()() { return undefined_expr; }

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -394,6 +394,75 @@ void test12217(int)
 void test12217() {}
 
 /***************************************************/
+// 12231
+
+void func12231a()()
+if (is(typeof({
+        class C {}
+        static assert(C.mangleof ==
+            "C6mangle16__U10func12231aZ10func12231aFZ9__lambda1MFZ1C");
+            //         ###            L                       #
+    })))
+{}
+
+void func12231b()()
+if (is(typeof({
+        class C {}
+        static assert(C.mangleof ==
+            "C6mangle16__U10func12231bZ10func12231bFZ9__lambda1MFZ1C");
+            //         L__L           L                       LL
+    })) &&
+    is(typeof({
+        class C {}
+        static assert(C.mangleof ==
+            "C6mangle16__U10func12231bZ10func12231bFZ9__lambda2MFZ1C");
+            //         L__L           L                       LL
+    })))
+{}
+
+void func12231c()()
+if (is(typeof({
+        class C {}
+        static assert(C.mangleof ==
+            "C6mangle16__U10func12231cZ10func12231cFZ9__lambda1MFZ1C");
+            //         L__L           L                       LL
+    })))
+{
+    (){
+        class C {}
+        static assert(C.mangleof ==
+            "C6mangle16__T10func12231cZ10func12231cFZ9__lambda1MFZ1C");
+            //         L__L           L                       LL
+    }();
+}
+
+void func12231c(X)()
+if (is(typeof({
+        class C {}
+        static assert(C.mangleof ==
+            "C6mangle20__U10func12231cTAyaZ10func12231cFZ9__lambda1MFZ1C");
+            //         L__L           L___L                       LL
+    })))
+{
+    (){
+        class C {}
+        static assert(C.mangleof ==
+            "C6mangle20__T10func12231cTAyaZ10func12231cFZ9__lambda1MFZ1C");
+            //         L__L           L___L                       LL
+    }();
+}
+
+void test12231()
+{
+    func12231a();
+
+    func12231b();
+
+    func12231c();
+    func12231c!string();
+}
+
+/***************************************************/
 
 void main()
 {

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1652,6 +1652,21 @@ void test14()
 }
 
 /**********************************/
+// test for evaluateConstraint assertion
+
+bool canSearchInCodeUnits15(C)(dchar c)
+if (is(C == char))
+{
+    return true;
+}
+
+void test15()
+{
+    int needle = 0;
+    auto b = canSearchInCodeUnits15!char(needle);
+}
+
+/**********************************/
 // 8129
 
 class X8129 {}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12231
- If some sort of symbols are declared inside template constraint, the _instantiating_ template should be specially mangled to avoid name collision. (Use `__U` instead of `__T`)
- Even inside constraints, lambdas should have unique names.

See the detailed test cases in `test/runnable/mangle.d`.

By this change, theoretically all of mangled name collisions will be solved.
