### PR TITLE
[REG2.065] Issue 12243 - "ICE: cannot append 'char' to 'string'" with -inline

### DIFF
--- a/src/inline.c
+++ b/src/inline.c
@@ -1417,12 +1417,15 @@ public:
             }
         }
 
-        if (eresult && e->type->ty != Tvoid &&
-            !e->type->equals(eresult->type) &&
-            eresult->type->hasWild() && !e->type->hasWild())
+        if (eresult && e->type->ty != Tvoid)
         {
-            eresult = eresult->copy();
-            eresult->type = e->type;
+            Expression *ex = eresult;
+            while (ex->op == TOKcomma)
+            {
+                ex->type = e->type;
+                ex = ((CommaExp *)ex)->e2;
+            }
+            ex->type = e->type;
         }
     }
 

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -286,6 +286,9 @@ struct Task
     }
 }
 
+/************************************/
+// 9356
+
 void test9356()
 {
     static inout(char)[] bar (inout(char)[] a)
@@ -306,6 +309,17 @@ void test12079()
     string[string][string] foo;
 
     foo.get("bar", null).get("baz", null);
+}
+
+/************************************/
+// 12243
+
+char f12243() { return 'a'; }
+
+void test12243()
+{
+    string s;
+    s ~= f12243();
 }
 
 /************************************/


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12243

Perhaps the root cause of the ICEs were the lack of the handling for comma expressions.
