### PR TITLE
Issue 3882: Add warning for unused non-void returns of strictly pure function calls

### DIFF
--- a/src/sideeffect.c
+++ b/src/sideeffect.c
@@ -144,10 +144,27 @@ void discardValue(Expression *e)
             return;
 
         case TOKcall:
-            /* Don't complain about calling functions with no effect,
-             * because purity and nothrow are inferred, and because some of the
-             * runtime library depends on it. Needs more investigation.
-             */
+            /* Issue 3882: */
+            if (global.params.warnings && !global.gag)
+            {
+                if (e->type->ty == Tvoid)
+                {
+                    /* Don't complain about calling void-returning functions with no side-effect,
+                     * because purity and nothrow are inferred, and because some of the
+                     * runtime library depends on it. Needs more investigation.
+                     *
+                     * One possible solution is to restrict this message to only be called in hierarchies that
+                     * never call assert (and or not called from inside unittest blocks)
+                     */
+                }
+                else
+                {
+                    CallExp *ce = (CallExp *)e;
+                    e->warning("Call to strictly pure function %s discards return value of type %s, prepend a cast(void) if intentional",
+                               ce->f->toPrettyChars(),
+                               e->type->toChars());
+                }
+            }
             return;
 
         case TOKimport:

--- a/test/fail_compilation/fail3882.d
+++ b/test/fail_compilation/fail3882.d
@@ -1,0 +1,27 @@
+// REQUIRED_ARGS: -w
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail3882.d(26): Warning: Call to strictly pure function fail3882.strictlyPure!int.strictlyPure discards return value of type int, prepend a cast(void) if intentional
+---
+*/
+
+@safe pure nothrow void strictVoidReturn(T)(T x)
+{
+}
+
+@safe pure nothrow void nonstrictVoidReturn(T)(ref T x)
+{
+}
+
+@safe pure nothrow T strictlyPure(T)(T x)
+{
+    return x*x;
+}
+
+void main(string args[]) {
+    int x = 3;
+    strictVoidReturn(x);
+    nonstrictVoidReturn(x);
+    strictlyPure(x);
+}


### PR DESCRIPTION
This works for me in my projects and actually detected two bugs for me.

I'm new to Git and I have accidentally added support for Exuberant Ctags tag generation. If you don't like it tell me and I'll remove and do a new pull request.

An acompanying pull request for Phobos to prevent a handful of warnings generated by this change is pending aswell.
