### PR TITLE
[DDMD] Use the A versions of WINAPI functions directly instead of using aliases

### DIFF
--- a/src/backend/os.c
+++ b/src/backend/os.c
@@ -250,7 +250,7 @@ void *vmem_mapfile(const char *filename,void *ptr,unsigned long size,int flag)
 
     dbg_printf("vmem_mapfile(filename = '%s', ptr = %p, size = x%lx, flag = %d)\n",filename,ptr,size,flag);
 
-    hFile = CreateFile(filename, GENERIC_READ | GENERIC_WRITE,
+    hFile = CreateFileA(filename, GENERIC_READ | GENERIC_WRITE,
                         FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
@@ -262,7 +262,7 @@ void *vmem_mapfile(const char *filename,void *ptr,unsigned long size,int flag)
     if (flag == 1 && OsVerInfo.dwPlatformId == 1)       // Windows 95, 98, ME
         hFileMap = NULL;
     else
-        hFileMap = CreateFileMapping(hFile,NULL,
+        hFileMap = CreateFileMappingA(hFile,NULL,
                 (flag == 1) ? PAGE_WRITECOPY : PAGE_READWRITE,0,size,NULL);
 
     if (hFileMap == NULL)               // mapping failed
@@ -706,7 +706,7 @@ long os_file_size(int fd)
 char *file_8dot3name(const char *filename)
 {
     HANDLE h;
-    WIN32_FIND_DATA fileinfo;
+    WIN32_FIND_DATAA fileinfo;
     char *buf;
     int i;
 
@@ -770,7 +770,7 @@ err:
     HANDLE h;
     DWORD numwritten;
 
-    h = CreateFile((LPTSTR)name,GENERIC_WRITE,0,NULL,CREATE_ALWAYS,
+    h = CreateFileA((LPTSTR)name,GENERIC_WRITE,0,NULL,CREATE_ALWAYS,
         FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,NULL);
     if (h == INVALID_HANDLE_VALUE)
     {
@@ -778,7 +778,7 @@ err:
         {
             if (!file_createdirs(name))
             {
-                h = CreateFile((LPTSTR)name,GENERIC_WRITE,0,NULL,CREATE_ALWAYS,
+                h = CreateFileA((LPTSTR)name,GENERIC_WRITE,0,NULL,CREATE_ALWAYS,
                     FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,NULL);
                 if (h != INVALID_HANDLE_VALUE)
                     goto Lok;

--- a/src/inifile.c
+++ b/src/inifile.c
@@ -85,7 +85,7 @@ const char *inifile(const char *argv0x, const char *inifilex, const char *envsec
             {
 #if _WIN32 // This fix by Tim Matthews
                 char resolved_name[MAX_PATH + 1];
-                if(GetModuleFileName(NULL, resolved_name, MAX_PATH + 1) && FileName::exists(resolved_name))
+                if(GetModuleFileNameA(NULL, resolved_name, MAX_PATH + 1) && FileName::exists(resolved_name))
                 {
                         filename = (char *)FileName::replaceName(resolved_name, inifile);
                         if(FileName::exists(filename))

--- a/src/root/file.c
+++ b/src/root/file.c
@@ -227,7 +227,7 @@ int File::mmread()
     char *name;
 
     name = this->name->toChars();
-    hFile = CreateFile(name, GENERIC_READ,
+    hFile = CreateFileA(name, GENERIC_READ,
                         FILE_SHARE_READ, NULL,
                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
@@ -235,7 +235,7 @@ int File::mmread()
     size = GetFileSize(hFile, NULL);
     //printf(" file created, size %d\n", size);
 
-    hFileMap = CreateFileMapping(hFile,NULL,PAGE_READONLY,0,size,NULL);
+    hFileMap = CreateFileMappingA(hFile,NULL,PAGE_READONLY,0,size,NULL);
     if (CloseHandle(hFile) != TRUE)
         goto Lerr;
 

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -652,11 +652,11 @@ const char *FileName::canonicalName(const char *name)
     /* Apparently, there is no good way to do this on Windows.
      * GetFullPathName isn't it, but use it anyway.
      */
-    DWORD result = GetFullPathName(name, 0, NULL, NULL);
+    DWORD result = GetFullPathNameA(name, 0, NULL, NULL);
     if (result)
     {
         char *buf = (char *)malloc(result);
-        result = GetFullPathName(name, result, buf, NULL);
+        result = GetFullPathNameA(name, result, buf, NULL);
         if (result == 0)
         {
             ::free(buf);


### PR DESCRIPTION
Druntime doesn't proved the suffix-less versions, and these calls won't work with `UNICODE` defined anyway.
