### PR TITLE
add missing visitor for ErrorStatement

### DIFF
--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -114,6 +114,12 @@ public:
         assert(0);
     }
 
+    void visit(ErrorStatement *s)
+    {
+        buf->printf("__error__");
+        buf->writenl();
+    }
+
     void visit(ExpStatement *s)
     {
         if (s->exp)


### PR DESCRIPTION
better than the assert(0) it'd otherwise do.
