### PR TITLE
[cleanup] Untangle the rat's nest in inifile.c

### DIFF
--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -622,10 +622,7 @@ int FileName::ensurePathExists(const char *path)
  */
 const char *FileName::canonicalName(const char *name)
 {
-#if __linux__
-    // Lovely glibc extension to do it for us
-    return canonicalize_file_name(name);
-#elif POSIX
+#if POSIX
   #if _POSIX_VERSION >= 200809L || defined (__linux__)
     // NULL destination buffer is allowed and preferred
     return realpath(name, NULL);


### PR DESCRIPTION
- There is ancient const-confused code
- The code to actually find the ini file is quite messy
- `realpath` is already implemented in `root/filename.h` (and realpath does the exact same thing as `canonicalize_file_name`)
- The code already allocates every second line, so jumping through hoops to save memory is a waste of time
- `goto` makes the flow much harder to reason about
