### PR TITLE
[REG2.066a] Issue 12296 - const compatible AA pointer conversion is wrongly rejected in CTFE

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -542,10 +542,8 @@ bool isSafePointerCast(Type *srcPointee, Type *destPointee)
         destPointee = destPointee->nextOf();
     }
 
-   // It's OK if both are the same (modulo const)
-    srcPointee = srcPointee->castMod(0);
-    destPointee = destPointee->castMod(0);
-    if (srcPointee == destPointee)
+    // It's OK if both are the same (modulo const)
+    if (srcPointee->constConv(destPointee))
         return true;
 
     // It's OK if function pointers differ only in safe/pure/nothrow

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3726,6 +3726,19 @@ int isItSafeToDance()
 static assert(isItSafeToDance());
 
 /**************************************************
+    12296 CTFE rejects const compatible AA pointer cast
+**************************************************/
+
+int test12296()
+{
+    immutable x = [5 : 4];
+    auto aa = &x;
+    const(int[int])* y = aa;
+    return 1;
+}
+static assert(test12296());
+
+/**************************************************
     9170 Allow reinterpret casts float<->int
 **************************************************/
 int f9170(float x) {


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12296
