### PR TITLE
Add version identifier for Nvidia Parallel Thread Execution (NVPTX).

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -202,6 +202,8 @@ bool VersionCondition::isPredefined(const char *ident)
         "MIPS_EABI",
         "MIPS_SoftFloat",
         "MIPS_HardFloat",
+        "NVPTX",
+        "NVPTX64",
         "SPARC",
         "SPARC_V8Plus",
         "SPARC_SoftFloat",


### PR DESCRIPTION
This is another LLVM backend. Maybe it is possible to run D on graphic cards, too.
