### PR TITLE
DIP29: make dup functions pure

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -674,8 +674,8 @@ public:
     Statement *mergeFensure(Statement *, Identifier *oid);
     Parameters *getParameters(int *pvarargs);
 
-    static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name);
-    static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id);
+    static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc = 0);
+    static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc = 0);
 
     Symbol *toThunkSymbol(int offset);  // thunk version
     void toObjFile(int multiobj);                       // compile to .obj file

--- a/src/func.c
+++ b/src/func.c
@@ -3684,12 +3684,14 @@ bool FuncDeclaration::addPostInvariant()
  * Generate a FuncDeclaration for a runtime library function.
  */
 
-FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, const char *name)
+FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, const char *name,
+        StorageClass stc)
 {
-    return genCfunc(args, treturn, Lexer::idPool(name));
+    return genCfunc(args, treturn, Lexer::idPool(name), stc);
 }
 
-FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, Identifier *id)
+FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, Identifier *id,
+        StorageClass stc)
 {
     FuncDeclaration *fd;
     TypeFunction *tf;
@@ -3711,7 +3713,7 @@ FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, Iden
     }
     else
     {
-        tf = new TypeFunction(args, treturn, 0, LINKc);
+        tf = new TypeFunction(args, treturn, 0, LINKc, stc);
         fd = new FuncDeclaration(Loc(), Loc(), id, STCstatic, tf);
         fd->protection = PROTpublic;
         fd->linkage = LINKc;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3802,7 +3802,8 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
                 Parameters* args = new Parameters;
                 args->push(new Parameter(STCin, Type::dtypeinfo->type, NULL, NULL));
                 args->push(new Parameter(STCin, Type::tvoid->arrayOf(), NULL, NULL));
-                adDup_fd = FuncDeclaration::genCfunc(args, Type::tvoid->arrayOf(), Id::adDup);
+                adDup_fd = FuncDeclaration::genCfunc(args, Type::tvoid->arrayOf(), Id::adDup,
+                        STCpure | STCtrusted);
             }
             fd = adDup_fd;
         } else {

--- a/test/runnable/implicit.d
+++ b/test/runnable/implicit.d
@@ -161,6 +161,26 @@ void testDIP29_4()
 
 /***********************************/
 
+int[] test6(int[] a) pure @safe nothrow
+{
+    return a.dup;
+}
+
+/***********************************/
+
+int*[] pureFoo() pure { return null; }
+
+
+void testDIP29_5() pure
+{
+    { char[] s; immutable x = s.dup; }
+    { immutable x = (cast(int*[])null).dup; }
+    { immutable x = pureFoo(); }
+    { immutable x = pureFoo().dup; }
+}
+
+/***********************************/
+
 void main()
 {
     test1();
@@ -172,6 +192,7 @@ void main()
     testDIP29_2();
     testDIP29_3();
     testDIP29_4();
+    testDIP29_5();
 
     writefln("Success");
 }


### PR DESCRIPTION
This adds attributes pure, nothrow, and @trusted to the .dup internal function.

It also allows for better unique detection on the arguments to adDup(). For example, `adDup(null)` should be implicitly convertible.
