### PR TITLE
fix Issue 4757 - A forward reference error with return of inner defined struct

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -861,10 +861,7 @@ void StructDeclaration::semantic(Scope *sc)
     }
 
     if (sc->func)
-    {
         semantic2(sc);
-        semantic3(sc);
-    }
 
     if (global.errors != errors)
     {   // The type is no good.

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -446,6 +446,26 @@ alias test8163!(ubyte, ubyte, ushort, float) _BBSf;
 
 
 /***************************************************/
+// 4757
+
+auto foo4757(T)(T)
+{
+    static struct Bar(T)
+    {
+        void spam()
+        {
+            foo4757(1);
+        }
+    }
+    return Bar!T();
+}
+
+void test4757()
+{
+    foo4757(1);
+}
+
+/***************************************************/
 // 9348
 
 void test9348()


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=4757

It looks like semantic3 of nested structs was done too eagerly. It appears to be redundant.
