### PR TITLE
Fix crash with -main and non-normalized Windows paths in Visual Studio build

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -47,7 +47,7 @@
 
 #include        "arraytypes.h"
 
-void toWinPath(char *src);
+const char * toWinPath(const char *src);
 int executecmd(const char *cmd, const char *args);
 int executearg0(const char *cmd, const char *args);
 
@@ -753,9 +753,7 @@ int executecmd(const char *cmd, const char *args)
     }
 
     // Normalize executable path separators, see Bugzilla 9330
-    char *p = mem.strdup(cmd);
-    toWinPath(p);
-    cmd = p;
+    cmd = toWinPath(cmd);
 
 #ifdef _MSC_VER
     if(strchr(cmd, ' '))

--- a/src/mars.c
+++ b/src/mars.c
@@ -52,17 +52,20 @@ static bool parse_arch(size_t argc, const char** argv, bool is64bit);
 void inlineScan(Module *m);
 
 /** Normalize path by turning forward slashes into backslashes */
-void toWinPath(char *src)
+const char * toWinPath(const char *src)
 {
     if (src == NULL)
-        return;
+        return NULL;
 
-    while (*src != '\0')
+    char *result = strdup(src);
+    char *p = result;
+    while (*p != '\0')
     {
-        if (*src == '/')
-            *src = '\\';
-        src++;
+        if (*p == '/')
+            *p = '\\';
+        p++;
     }
+    return result;
 }
 
 Ungag::~Ungag()
@@ -789,6 +792,7 @@ Language changes listed by -transition=id:\n\
                 global.params.optimize = 1;
             else if (p[1] == 'o')
             {
+                const char *path;
                 switch (p[2])
                 {
                     case '-':
@@ -798,19 +802,21 @@ Language changes listed by -transition=id:\n\
                     case 'd':
                         if (!p[3])
                             goto Lnoarg;
+                        path = p + 3;
 #if _WIN32
-                        toWinPath((char *)p + 3);
+                        path = toWinPath(path);
 #endif
-                        global.params.objdir = p + 3;
+                        global.params.objdir = path;
                         break;
 
                     case 'f':
                         if (!p[3])
                             goto Lnoarg;
+                        path = p + 3;
 #if _WIN32
-                        toWinPath((char *)p + 3);
+                        path = toWinPath(path);
 #endif
-                        global.params.objname = p + 3;
+                        global.params.objname = path;
                         break;
 
                     case 'p':
@@ -1291,11 +1297,11 @@ Language changes listed by -transition=id:\n\
     {
         const char *name;
 
-        const char *p = files[i];
-
 #if _WIN32
-        toWinPath((char *)p);
+        files[i] = toWinPath(files[i]);
 #endif
+
+        const char *p = files[i];
 
         p = FileName::name(p);          // strip path
         const char *ext = FileName::ext(p);


### PR DESCRIPTION
The constness casts were silencing a valid compiler warning.
