### PR TITLE
Issue 12235 & 12236 & 12237 - fix issues around lambda

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6979,6 +6979,15 @@ Expression *DotIdExp::semanticX(Scope *sc)
                 ds = ((OverExp *)e1)->vars;
             L1:
             {
+                assert(ds);
+                if (FuncDeclaration *f = ds->isFuncDeclaration())
+                {
+                    if (!f->type->deco)
+                    {
+                        error("forward reference to %s", f->toChars());
+                        return new ErrorExp();
+                    }
+                }
                 const char* s = mangle(ds);
                 Expression *e = new StringExp(loc, (void*)s, strlen(s), 'c');
                 e = e->semantic(sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -6977,6 +6977,12 @@ Expression *DotIdExp::semanticX(Scope *sc)
                 goto L1;
             case TOKoverloadset:
                 ds = ((OverExp *)e1)->vars;
+                goto L1;
+            case TOKtemplate:
+            {
+                TemplateExp *te = (TemplateExp *)e1;
+                ds = te->fd ? (Dsymbol *)te->fd : te->td;
+            }
             L1:
             {
                 assert(ds);

--- a/src/traits.c
+++ b/src/traits.c
@@ -505,6 +505,15 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
 
         if (FuncDeclaration *f = s->isFuncDeclaration())
         {
+            if (TemplateDeclaration *td = getFuncTemplateDecl(f))
+            {
+                if (td->overroot)       // if not start of overloaded list of TemplateDeclaration's
+                    td = td->overroot;  // then get the start
+                Expression *ex = new TemplateExp(e->loc, td, f);
+                ex = ex->semantic(sc);
+                return ex;
+            }
+
             if (FuncLiteralDeclaration *fld = f->isFuncLiteralDeclaration())
             {
                 // Directly translate to VarExp instead of FuncExp

--- a/src/traits.c
+++ b/src/traits.c
@@ -502,6 +502,17 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             e->error("argument %s has no parent", o->toChars());
             goto Lfalse;
         }
+
+        if (FuncDeclaration *f = s->isFuncDeclaration())
+        {
+            if (FuncLiteralDeclaration *fld = f->isFuncLiteralDeclaration())
+            {
+                // Directly translate to VarExp instead of FuncExp
+                Expression *ex = new VarExp(e->loc, fld, 1);
+                return ex->semantic(sc);
+            }
+        }
+
         return (new DsymbolExp(e->loc, s))->semantic(sc);
     }
     else if (e->ident == Id::hasMember ||

--- a/test/fail_compilation/fail12236.d
+++ b/test/fail_compilation/fail12236.d
@@ -1,0 +1,33 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12236.d(16): Error: forward reference to inferred return type of function call 'f1'
+fail_compilation/fail12236.d(16):        while evaluating pragma(msg, f1.mangleof)
+fail_compilation/fail12236.d(21): Error: forward reference to f2
+fail_compilation/fail12236.d(21):        while evaluating pragma(msg, f2(T)(T).mangleof)
+fail_compilation/fail12236.d(27): Error: template instance fail12236.f2!int error instantiating
+fail_compilation/fail12236.d(31): Error: forward reference to __lambda1
+fail_compilation/fail12236.d(31):        while evaluating pragma(msg, __lambda1.mangleof)
+---
+*/
+
+auto f1(int)
+{
+    pragma(msg, f1.mangleof);  // forward reference error
+}
+
+auto f2(T)(T)
+{
+    pragma(msg, f2.mangleof);  // error <- weird output: "v"
+}
+
+void main()
+{
+    f1(1);
+    f2(1);
+
+    (a) {
+        int x;
+        pragma(msg, __traits(parent, x).mangleof);
+    } (1);
+}

--- a/test/fail_compilation/ice10922.d
+++ b/test/fail_compilation/ice10922.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10922.d(11): Error: forward reference to inferred return type of function call self(n - 1u)
-fail_compilation/ice10922.d(11): Error: forward reference to inferred return type of function call self(n - 2u)
+fail_compilation/ice10922.d(9): Error: delegate ice10922.__lambda4 (const(uint) n) is not callable using argument types ()
 ---
 */
 

--- a/test/fail_compilation/ice12235.d
+++ b/test/fail_compilation/ice12235.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice12235.d(14): Error: forward reference to __lambda1
+fail_compilation/ice12235.d(15): Error: forward reference to __lambda1
+fail_compilation/ice12235.d(15):        while evaluating pragma(msg, __lambda1.mangleof)
+---
+*/
+
+void main()
+{
+    (){
+        int x;
+        enum s = __traits(parent, x).mangleof;
+        pragma(msg, __traits(parent, x).mangleof);
+    }();
+}

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1136,11 +1136,13 @@ void test9237()
 }
 
 /*************************************************************/
+// 5978
 
-void test5978() {
+void test5978()
+{
     () {
         int x;
-        pragma(msg, __traits(parent, x));
+        pragma(msg, __traits(identifier, __traits(parent, x)));
     } ();
 }
 

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1487,6 +1487,32 @@ void test12571()
 }
 
 /********************************************************/
+// 12237
+
+auto f12237(T)(T a)
+{
+    static if (is(typeof(a) == int))
+        return f12237("");
+    else
+        return 10;
+}
+
+void test12237()
+{
+    assert(f12237(1) == 10);
+
+    assert((a){
+        static if (is(typeof(a) == int))
+        {
+            int x;
+            return __traits(parent, x)("");
+        }
+        else
+            return 10;
+    }(1) == 10);
+}
+
+/********************************************************/
 
 int main()
 {
@@ -1526,6 +1552,7 @@ int main()
     test_getUnitTests();
     test_getFunctionAttributes();
     test_isOverrideFunction();
+    test12237();
 
     writeln("Success");
     return 0;


### PR DESCRIPTION
[Issue 12235](https://d.puremagic.com/issues/show_bug.cgi?id=12235) - ICE on printing mangled name of forward reference lambda by pragma(msg) 
[Issue 12236](https://d.puremagic.com/issues/show_bug.cgi?id=12236) - Inconsistent mangleof result
[Issue 12237](https://d.puremagic.com/issues/show_bug.cgi?id=12237) - Inconsistent behavior of the instantiating enclosing template function
