### PR TITLE
do dead code elimination in release with debug info mode

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -228,6 +228,10 @@ int runLINK()
         {
             cmdbuf.writeByte(' ');
             cmdbuf.writestring("/DEBUG");
+
+            // in release mode we need to reactivate /OPT:REF after /DEBUG
+            if (global.params.release)
+                cmdbuf.writestring(" /OPT:REF");
         }
 
         if (global.params.dll)


### PR DESCRIPTION
```
dmd -v -release -m64 test.d
link.exe /NOLOGO test  /OPT:NOICF
```

There's an implicit /OPT:REF involved.

```
dmd -v -release -g -m64 test.d
link.exe /NOLOGO test  /DEBUG /OPT:NOICF
```

/DEBUG implies /OPT:NOREF /OPT:NOICF thus we need to enable it again.

The /OPT:NOICF is coming from sc.ini btw to prevent merging EH sections. Was very puzzling for me.
