### PR TITLE
fix issue 3490 - DMD Never Inlines Functions that Could Throw

### DIFF
--- a/src/inline.c
+++ b/src/inline.c
@@ -200,6 +200,12 @@ public:
         //printf("ForStatement: inlineCost = %d\n", cost);
     }
 
+    void visit(ThrowStatement *s)
+    {
+        cost += STATEMENT_COST;
+        s->exp->accept(this);
+    }
+
     /* -------------------------- */
 
     void expressionInlineCost(Expression *e)
@@ -499,6 +505,12 @@ Statement *inlineAsStatement(Statement *s, InlineDoState *ids)
             Expression *increment = s->increment ? doInline(s->increment, ids) : NULL;
             Statement *body = s->body ? inlineAsStatement(s->body, ids) : NULL;
             result = new ForStatement(s->loc, init, condition, increment, body);
+        }
+
+        void visit(ThrowStatement *s)
+        {
+            //printf("ThrowStatement::inlineAsStatement() '%s'\n", s->exp->toChars());
+            result = new ThrowStatement(s->loc, doInline(s->exp, ids));
         }
     };
 


### PR DESCRIPTION
Note: The issues the original bug reporter had with std.range and enforce have already been addressed at least several versions ago. See my ("Nick Sabalausky") comment in [issue 3490](https://d.puremagic.com/issues/show_bug.cgi?id=3490#c5).

This turned out to be pretty simple and straightforward, so I'm hoping that doesn't mean I've overlooked anything important. But it worked when I tried it and checked the disassembly.
