### PR TITLE
Issue 12382 - `opDollar` can't be used at CT

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1542,7 +1542,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
                 if (t && t->ty == Tfunction)
                     e = new CallExp(e->loc, e);
                 v = new VarDeclaration(loc, NULL, Id::dollar, new ExpInitializer(Loc(), e));
-                v->storage_class |= STCtemp;
+                v->storage_class |= STCtemp | STCctfe;
             }
             else
             {

--- a/src/expression.h
+++ b/src/expression.h
@@ -82,8 +82,8 @@ Expression *valueNoDtor(Expression *e);
 int modifyFieldVar(Loc loc, Scope *sc, VarDeclaration *var, Expression *e1);
 Expression *resolveAliasThis(Scope *sc, Expression *e);
 Expression *callCpCtor(Scope *sc, Expression *e);
-Expression *resolveOpDollar(Scope *sc, ArrayExp *ae);
-Expression *resolveOpDollar(Scope *sc, SliceExp *se);
+Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, Expression **pe0);
+Expression *resolveOpDollar(Scope *sc, SliceExp *se, Expression **pe0);
 Expression *integralPromotions(Expression *e, Scope *sc);
 void discardValue(Expression *e);
 

--- a/src/opover.c
+++ b/src/opover.c
@@ -232,6 +232,8 @@ Expression *op_overload(Expression *e, Scope *sc)
                 AggregateDeclaration *ad = isAggregate(ae->e1->type);
                 if (ad)
                 {
+                    Expression *e0 = NULL;
+
                     /* Rewrite as:
                      *  a.opIndexUnary!("+")(args);
                      */
@@ -239,7 +241,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                     if (fd)
                     {
                         // Deal with $
-                        Expression *ex = resolveOpDollar(sc, ae);
+                        Expression *ex = resolveOpDollar(sc, ae, &e0);
                         if (!ex)
                             goto Lfallback;
                         if (ex->op == TOKerror)
@@ -256,6 +258,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                             result = result->semantic(sc);
                         if (!result)
                             goto Lfallback;
+                        result = Expression::combine(e0, result);
                         return;
                     }
 
@@ -285,6 +288,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                         se->att1 = ae->att1;
                         e->e1 = se;
                         e->accept(this);
+                        result = Expression::combine(e0, result);
                         return;
                     }
                     if (ae->arguments->dim == 1 && (*ae->arguments)[0]->op == TOKinterval)
@@ -295,6 +299,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                         se->att1 = ae->att1;
                         e->e1 = se;
                         e->accept(this);
+                        result = Expression::combine(e0, result);
                         return;
                     }
                 }
@@ -315,7 +320,8 @@ Expression *op_overload(Expression *e, Scope *sc)
                     if (fd)
                     {
                         // Deal with $
-                        Expression *ex = resolveOpDollar(sc, se);
+                        Expression *e0 = NULL;
+                        Expression *ex = resolveOpDollar(sc, se, &e0);
                         if (ex->op == TOKerror)
                         {
                             result = ex;
@@ -332,6 +338,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                         result = new DotTemplateInstanceExp(e->loc, se->e1, fd->ident, tiargs);
                         result = new CallExp(e->loc, result, a);
                         result = result->semantic(sc);
+                        result = Expression::combine(e0, result);
                         return;
                     }
 
@@ -426,11 +433,13 @@ Expression *op_overload(Expression *e, Scope *sc)
             AggregateDeclaration *ad = isAggregate(ae->e1->type);
             if (ad)
             {
+                Expression *e0 = NULL;
+
                 Dsymbol *fd = search_function(ad, opId(ae));
                 if (fd)
                 {
                     // Deal with $
-                    Expression *ex = resolveOpDollar(sc, ae);
+                    Expression *ex = resolveOpDollar(sc, ae, &e0);
                     if (!ex)
                         goto Lfallback;
                     if (ex->op == TOKerror)
@@ -450,6 +459,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                         result = result->semantic(sc);
                     if (!result)
                         goto Lfallback;
+                    result = Expression::combine(e0, result);
                     return;
                 }
 
@@ -479,6 +489,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                     // a[]
                     SliceExp *se = new SliceExp(ae->loc, ae->e1, NULL, NULL);
                     result = se->semantic(sc);
+                    result = Expression::combine(e0, result);
                     return;
                 }
                 if (ae->arguments->dim == 1 && (*ae->arguments)[0]->op == TOKinterval)
@@ -487,6 +498,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                     IntervalExp *ie = (IntervalExp *)(*ae->arguments)[0];
                     SliceExp *se = new SliceExp(ae->loc, ae->e1, ie->lwr, ie->upr);
                     result = se->semantic(sc);
+                    result = Expression::combine(e0, result);
                     return;
                 }
             }
@@ -916,6 +928,8 @@ Expression *op_overload(Expression *e, Scope *sc)
                 AggregateDeclaration *ad = isAggregate(ae->e1->type);
                 if (ad)
                 {
+                    Expression *e0 = NULL;
+
                     /* Rewrite a[args]+=e2 as:
                      *  a.opIndexOpAssign!("+")(e2, args);
                      */
@@ -923,7 +937,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                     if (fd)
                     {
                         // Deal with $
-                        Expression *ex = resolveOpDollar(sc, ae);
+                        Expression *ex = resolveOpDollar(sc, ae, &e0);
                         if (!ex)
                             goto Lfallback;
                         if (ex->op == TOKerror)
@@ -944,6 +958,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                             result = result->semantic(sc);
                         if (!result)
                             goto Lfallback;
+                        result = Expression::combine(e0, result);
                         return;
                     }
 
@@ -973,6 +988,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                         se->att1 = ae->att1;
                         e->e1 = se;
                         e->accept(this);
+                        result = Expression::combine(e0, result);
                         return;
                     }
                     if (ae->arguments->dim == 1 && (*ae->arguments)[0]->op == TOKinterval)
@@ -983,6 +999,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                         se->att1 = ae->att1;
                         e->e1 = se;
                         e->accept(this);
+                        result = Expression::combine(e0, result);
                         return;
                     }
                 }
@@ -1003,7 +1020,8 @@ Expression *op_overload(Expression *e, Scope *sc)
                     if (fd)
                     {
                         // Deal with $
-                        Expression *ex = resolveOpDollar(sc, se);
+                        Expression *e0 = NULL;
+                        Expression *ex = resolveOpDollar(sc, se, &e0);
                         if (ex->op == TOKerror)
                         {
                             result = ex;
@@ -1022,6 +1040,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                         result = new DotTemplateInstanceExp(e->loc, se->e1, fd->ident, tiargs);
                         result = new CallExp(e->loc, result, a);
                         result = result->semantic(sc);
+                        result = Expression::combine(e0, result);
                         return;
                     }
 

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -996,6 +996,34 @@ void test6798()
 }
 
 /**************************************/
+// 12382
+
+struct S12382
+{
+    size_t opDollar() { return 0; }
+    size_t opIndex(size_t) { return 0; }
+}
+
+S12382 func12382() { return S12382(); }
+
+static assert(S12382.init[$] == 0);
+static assert(func12382()[$] == 0);
+enum e12382a = S12382.init[$];
+enum e12382b = func12382()[$];
+static v12382a = S12382.init[$];
+static v12382b = func12382()[$];
+
+void test12382()
+{
+    static assert(S12382.init[$] == 0);
+    static assert(func12382()[$] == 0);
+    enum e12382a = S12382.init[$];
+    enum e12382b = func12382()[$];
+    static v12382a = S12382.init[$];
+    static v12382b = func12382()[$];
+}
+
+/**************************************/
 // 7641
 
 mixin template Proxy7641(alias a)


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12382

Front-end should handle `opDollar` side-effect carefully, because CTFE engine cannot interpret `(auto __dollar = obj.opDollar(), obj).opIndex(__dollar)` without CTFE stack.
