### PR TITLE
Recognize shared libraries as valid files when linking

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -601,6 +601,12 @@ int runLINK()
         }
     }
 
+    for (size_t i = 0; i < global.params.dllfiles->dim; i++)
+    {
+        const char *p = (*global.params.dllfiles)[i];
+        argv.push(p);
+    }
+
     /* Standard libraries must go after user specified libraries
      * passed with -l.
      */

--- a/src/mars.c
+++ b/src/mars.c
@@ -1326,12 +1326,14 @@ Language changes listed by -transition=id:\n\
                 continue;
             }
 
+#ifndef _WIN32
             if (FileName::equals(ext, global.dll_ext))
             {
                 global.params.dllfiles->push(files[i]);
                 libmodules.push(files[i]);
                 continue;
             }
+#endif
 
             if (strcmp(ext, global.ddoc_ext) == 0)
             {

--- a/src/mars.c
+++ b/src/mars.c
@@ -1326,7 +1326,7 @@ Language changes listed by -transition=id:\n\
                 continue;
             }
 
-#ifndef _WIN32
+#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
             if (FileName::equals(ext, global.dll_ext))
             {
                 global.params.dllfiles->push(files[i]);

--- a/src/mars.c
+++ b/src/mars.c
@@ -571,6 +571,7 @@ int tryMain(size_t argc, const char *argv[])
 
     global.params.linkswitches = new Strings();
     global.params.libfiles = new Strings();
+    global.params.dllfiles = new Strings();
     global.params.objfiles = new Strings();
     global.params.ddocfiles = new Strings();
 
@@ -1321,6 +1322,13 @@ Language changes listed by -transition=id:\n\
             if (FileName::equals(ext, global.lib_ext))
             {
                 global.params.libfiles->push(files[i]);
+                libmodules.push(files[i]);
+                continue;
+            }
+
+            if (FileName::equals(ext, global.dll_ext))
+            {
+                global.params.dllfiles->push(files[i]);
                 libmodules.push(files[i]);
                 continue;
             }

--- a/src/mars.h
+++ b/src/mars.h
@@ -186,6 +186,7 @@ struct Param
     Strings *objfiles;
     Strings *linkswitches;
     Strings *libfiles;
+    Strings *dllfiles;
     const char *deffile;
     const char *resfile;
     const char *exefile;


### PR DESCRIPTION
Fixes commands like `dmd -ofmain main.o libfoo.so` outputting `Error: unrecognized file extension so`
Doesn't have code for windows, but I have a feeling that linking DLLs is completely different.
