### PR TITLE
Deprecate support for the comma operator outside of for() conditions and increments

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4379,7 +4379,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
                 nextToken();
             }
             else
-            {   increment = parseExpression();
+            {   increment = parseCommaExpression();
                 check(TOKrparen);
             }
             body = parseStatement(PSscope);
@@ -7113,6 +7113,25 @@ Expression *Parser::parseExpression()
     Loc loc = token.loc;
 
     //printf("Parser::parseExpression() loc = %d\n", loc.linnum);
+    e = parseAssignExp();
+    while (token.value == TOKcomma)
+    {
+        warning(token.loc, "The comma operator will be deprecated");
+        nextToken();
+        e2 = parseAssignExp();
+        e = new CommaExp(loc, e, e2);
+        loc = token.loc;
+    }
+    return e;
+}
+
+Expression *Parser::parseCommaExpression()
+{
+    Expression *e;
+    Expression *e2;
+    Loc loc = token.loc;
+
+    //printf("Parser::parseCommaExpression() loc = %d\n", loc.linnum);
     e = parseAssignExp();
     while (token.value == TOKcomma)
     {

--- a/src/parse.h
+++ b/src/parse.h
@@ -135,6 +135,7 @@ public:
     int skipAttributes(Token *t, Token **pt);
 
     Expression *parseExpression();
+    Expression *parseCommaExpression();
     Expression *parsePrimaryExp();
     Expression *parseUnaryExp();
     Expression *parsePostExp(Expression *e);

--- a/test/compilable/parse2659.d
+++ b/test/compilable/parse2659.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -w
+
+void test2659()
+{
+    for (int i = 0; i < 10; i++, i++) { }
+}

--- a/test/fail_compilation/fail2659.d
+++ b/test/fail_compilation/fail2659.d
@@ -1,0 +1,15 @@
+// REQUIRED_ARGS: -w
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2659.d(13): Warning: The comma operator will be deprecated
+fail_compilation/fail2659.d(14): Warning: The comma operator will be deprecated
+---
+*/
+
+void main()
+{
+    int x;
+    x = 1, 2;
+    x = 1, x = 2;
+}


### PR DESCRIPTION
See issue 2659 [1]. The comma operator is a source of hard-to-detect bugs, is mostly unnecessary, and blocks the path to a nice template literal syntax. The only place where it makes sense to keep it is in the condition and increment parts of `for` statements.

Is it better to keep the functionality and deprecate it first?

(This PR depends on https://github.com/D-Programming-Language/phobos/pull/2041 for Phobos to compile again.)

[1] https://d.puremagic.com/issues/show_bug.cgi?id=2659
