### PR TITLE
Don't indent location part of diagnostic messages

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -3118,7 +3118,7 @@ Lerror:
         const char *lastprms = Parameter::argsTypesToChars(tf1->parameters, tf1->varargs);
         const char *nextprms = Parameter::argsTypesToChars(tf2->parameters, tf2->varargs);
         ::error(loc, "%s.%s called with argument types %s matches both:\n"
-                     "\t%s: %s%s\nand:\n\t%s: %s%s",
+                     "%s:     %s%s\nand:\n%s:     %s%s",
                 s->parent->toPrettyChars(), s->ident->toChars(),
                 fargsBuf.peekString(),
                 m.lastf->loc.toChars(), m.lastf->toPrettyChars(), lastprms,

--- a/src/opover.c
+++ b/src/opover.c
@@ -1733,7 +1733,7 @@ static Dsymbol *inferApplyArgTypesX(Expression *ethis, FuncDeclaration *fstart, 
     {
         inferApplyArgTypesY((TypeFunction *)p.fd_best->type, arguments);
         if (p.fd_ambig)
-        {   ::error(ethis->loc, "%s.%s matches more than one declaration:\n\t%s:%s\nand:\n\t%s:%s",
+        {   ::error(ethis->loc, "%s.%s matches more than one declaration:\n%s:     %s\nand:\n%s:     %s",
                     ethis->toChars(), fstart->ident->toChars(),
                     p.fd_best ->loc.toChars(), p.fd_best ->type->toChars(),
                     p.fd_ambig->loc.toChars(), p.fd_ambig->type->toChars());

--- a/src/template.c
+++ b/src/template.c
@@ -6759,7 +6759,7 @@ bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
 
         if (p.td_ambig)
         {
-            ::error(loc, "%s %s.%s matches more than one template declaration:\n\t%s:%s\nand\n\t%s:%s",
+            ::error(loc, "%s %s.%s matches more than one template declaration:\n%s:     %s\nand\n%s:     %s",
                     p.td_best->kind(), p.td_best->parent->toPrettyChars(), p.td_best->ident->toChars(),
                     p.td_best->loc.toChars() , p.td_best->toChars(),
                     p.td_ambig->loc.toChars(), p.td_ambig->toChars());

--- a/test/fail_compilation/diag11769.d
+++ b/test/fail_compilation/diag11769.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag11769.d(18): Error: diag11769.foo!string.bar called with argument types (string) matches both:
-	fail_compilation/diag11769.d(13): diag11769.foo!string.bar(immutable(wchar)[] _param_0)
+fail_compilation/diag11769.d(13):     diag11769.foo!string.bar(immutable(wchar)[] _param_0)
 and:
-	fail_compilation/diag11769.d(14): diag11769.foo!string.bar(immutable(dchar)[] _param_0)
+fail_compilation/diag11769.d(14):     diag11769.foo!string.bar(immutable(dchar)[] _param_0)
 ---
 */
 

--- a/test/fail_compilation/fail1900.d
+++ b/test/fail_compilation/fail1900.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail1900.d(26): Error: template fail1900.Mix1a!().Foo matches more than one template declaration:
-	fail_compilation/fail1900.d(13):Foo(ubyte x)
+fail_compilation/fail1900.d(13):     Foo(ubyte x)
 and
-	fail_compilation/fail1900.d(14):Foo(byte x)
+fail_compilation/fail1900.d(14):     Foo(byte x)
 ---
 */
 

--- a/test/fail_compilation/ice11518.d
+++ b/test/fail_compilation/ice11518.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11518.d(17): Error: class ice11518.B matches more than one template declaration:
-	fail_compilation/ice11518.d(12):B(T : A!T)
+fail_compilation/ice11518.d(12):     B(T : A!T)
 and
-	fail_compilation/ice11518.d(13):B(T : A!T)
+fail_compilation/ice11518.d(13):     B(T : A!T)
 ---
 */
 


### PR DESCRIPTION
Compiler output parsing tools will most likely expect that the location information (file/line/column) will always be at the start of the line. It's more consistent to indent the error message only, as is already done in other places.
