### PR TITLE
Cleanup -vgc implementation

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -611,7 +611,6 @@ public:
     #define FUNCFLAGpurityInprocess 1   // working on determining purity
     #define FUNCFLAGsafetyInprocess 2   // working on determining safety
     #define FUNCFLAGnothrowInprocess 4  // working on determining nothrow
-    #define FUNCFLAGgcuseInprocess  8   // working on determining gc usage
 
     FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);
@@ -656,9 +655,7 @@ public:
     bool isSafeBypassingInference();
     bool isTrusted();
     bool setUnsafe();
-    bool isNOGC();
-    bool setGCUse(Loc loc, const char *warn);
-    bool setGCUse();
+    void printGCUsage(Loc loc, const char *warn);
     bool isolateReturn();
     bool parametersIntersect(Type *t);
     virtual bool isNested();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2098,7 +2098,6 @@ Type *TypeFunction::substWildTo(unsigned)
     t->isref = isref;
     t->iswild = 0;
     t->trust = trust;
-    t->gcuse = gcuse;
     t->fargs = fargs;
     return t->merge();
 }
@@ -5151,7 +5150,6 @@ TypeFunction::TypeFunction(Parameters *parameters, Type *treturn, int varargs, L
         this->isref = true;
 
     this->trust = TRUSTdefault;
-    this->gcuse = GCUSEdefault;
     if (stc & STCsafe)
         this->trust = TRUSTsafe;
     if (stc & STCsystem)
@@ -5182,7 +5180,6 @@ Type *TypeFunction::syntaxCopy()
     t->isref = isref;
     t->iswild = iswild;
     t->trust = trust;
-    t->gcuse = gcuse;
     t->fargs = fargs;
     return t;
 }
@@ -6164,7 +6161,6 @@ Type *TypeFunction::addStorageClass(StorageClass stc)
         tf->isproperty = t->isproperty;
         tf->isref = t->isref;
         tf->trust = t->trust;
-        tf->gcuse = t->gcuse;
         tf->iswild = t->iswild;
 
         if (stc & STCpure)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -594,13 +594,6 @@ enum TRUST
     TRUSTsafe = 3,      // @safe
 };
 
-enum GCUSE
-{
-    GCUSEdefault = 0,
-    GCUSEgc     = 1,    // @gc (same as GCUSEdefault)
-    GCUSEnogc   = 2,    // @nogc
-};
-
 enum PURE
 {
     PUREimpure = 0,     // not pure at all
@@ -625,7 +618,6 @@ public:
     bool isref;         // true: returns a reference
     LINK linkage;  // calling convention
     TRUST trust;   // level of trust
-    GCUSE gcuse;   // is gc used?
     PURE purity;   // PURExxxx
     unsigned char iswild;   // bit0: inout on params, bit1: inout on qualifier
     Expressions *fargs; // function arguments

--- a/src/nogc.c
+++ b/src/nogc.c
@@ -14,9 +14,19 @@
 #include "statement.h"
 #include "declaration.h"
 #include "id.h"
+#include "module.h"
 
 bool walkPostorder(Statement *s, StoppableVisitor *v);
 bool walkPostorder(Expression *e, StoppableVisitor *v);
+
+void FuncDeclaration::printGCUsage(Loc loc, const char* warn)
+{
+    if (global.params.vgc && getModule() && getModule()->isRoot()
+        && !inUnittest())
+    {
+        fprintf(global.stdmsg, "%s: vgc: %s\n", loc.toChars(), warn);
+    }
+}
 
 /**************************************
  * Look for GC-allocations
@@ -153,55 +163,40 @@ public:
                 Identifier *ident = ve->var->isFuncDeclaration()->ident;
 
                 if (ident == Id::adDup)
-                {
-                    if (func->setGCUse(e->loc, "'dup' causes gc allocation"))
-                    {
-                        e->error("Can not use 'dup' in @nogc code");
-                    }
-                }
+                    func->printGCUsage(e->loc, "'dup' causes gc allocation");
             }
         }
     }
     void visit(CatExp *e)
     {
-        if (func->setGCUse(e->loc, "Concatenation may cause gc allocation"))
-            e->error("Can not use concatenation in @nogc code");
+        func->printGCUsage(e->loc, "Concatenation may cause gc allocation");
     }
     void visit(CatAssignExp *e)
     {
-        if (func->setGCUse(e->loc, "Concatenation may cause gc allocation"))
-            e->error("Can not use concatenation in @nogc code");
+        func->printGCUsage(e->loc, "Concatenation may cause gc allocation");
     }
     void visit(AssignExp *e)
     {
-        if (e->e1->op == TOKarraylength
-           && func->setGCUse(e->loc, "Setting 'length' may cause gc allocation"))
-        {
-            e->error("Can not set 'length' in @nogc code");
-        }
+        if (e->e1->op == TOKarraylength)
+           func->printGCUsage(e->loc, "Setting 'length' may cause gc allocation");
     }
     void visit(DeleteExp *e)
     {
-        if (func->setGCUse(e->loc, "'delete' requires gc"))
-            e->error("Can not use 'delete' in @nogc code");
+        func->printGCUsage(e->loc, "'delete' requires gc");
     }
     void visit(NewExp *e)
     {
-        if (!e->allocator && !e->onstack && func->setGCUse(e->loc, "'new' causes gc allocation"))
-            e->error("Can not use 'new' in @nogc code");
+        if (!e->allocator && !e->onstack)
+            func->printGCUsage(e->loc, "'new' causes gc allocation");
     }
     void visit(NewAnonClassExp *e)
     {
-        if (func->setGCUse(e->loc, "'new' causes gc allocation"))
-            e->error("Can not use 'new' in @nogc code");
+        func->printGCUsage(e->loc, "'new' causes gc allocation");
     }
     void visit(AssocArrayLiteralExp *e)
     {
-        if (e->keys->dim
-            && func->setGCUse(e->loc, "Associative array literals cause gc allocation"))
-        {
-            e->error("Can not use associative array literals in @nogc code");
-        }
+        if (e->keys->dim)
+            func->printGCUsage(e->loc, "Associative array literals cause gc allocation");
     }
     void visit(ArrayLiteralExp *e)
     {
@@ -218,19 +213,13 @@ public:
                 }
             }
         }
-        if (e->elements && e->elements->dim != 0 && e->type->ty != Tsarray && !init_const &&
-            func->setGCUse(e->loc, "Array literals cause gc allocation"))
-        {
-                e->error("Can not use array literals in @nogc code");
-        }
+        if (e->elements && e->elements->dim != 0 && e->type->ty != Tsarray && !init_const)
+            func->printGCUsage(e->loc, "Array literals cause gc allocation");
     }
     void visit(IndexExp* e)
     {
-        if (e->e1->type->ty == Taarray && func->setGCUse(e->loc, "Indexing an associative"
-            " array may cause gc allocation"))
-        {
-            e->error("Can not index an associative array in @nogc code");
-        }
+        if (e->e1->type->ty == Taarray)
+            func->printGCUsage(e->loc, "Indexing an associative array may cause gc allocation");
     }
 };
 


### PR DESCRIPTION
Removes some code which is not necessary for the `-vgc` switch and actually belongs to a `@nogc` attribute implementation. @klickverbot made a good point that this code would likely suffer from bit rot otherwise.
