### PR TITLE
More conservative fix for issue 313 & 314

### DIFF
--- a/src/access.d
+++ b/src/access.d
@@ -243,7 +243,7 @@ extern (C++) bool hasPackageAccess(Scope* sc, Dsymbol s)
         {
             if (Module m = s.isModule())
             {
-                DsymbolTable dst = Package.resolve(m.md ? m.md.packages : null, null, null);
+                auto dst = Package.resolve(null, m.md ? m.md.packages : null, null, null);
                 assert(dst);
                 Dsymbol s2 = dst.lookup(m.ident);
                 assert(s2);

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -275,6 +275,7 @@ public:
     bool isabstract;                    // true if abstract class
     int inuse;                          // to prevent recursive attempts
     Baseok baseok;                      // set the progress of base classes resolving
+    Dsymbols *publicImports;            // array of public/protected import declarations
     Objc_ClassDeclaration objc;
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 

--- a/src/attrib.d
+++ b/src/attrib.d
@@ -521,9 +521,7 @@ public:
     {
         if (pkg_identifiers)
         {
-            Dsymbol tmp;
-            Package.resolve(pkg_identifiers, &tmp, null);
-            protection.pkg = tmp ? tmp.isPackage() : null;
+            Package.resolve(null, pkg_identifiers, null, &protection.pkg);
             pkg_identifiers = null;
         }
         if (protection.kind == PROTpackage && protection.pkg && sc._module)

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1137,7 +1137,10 @@ public:
                         error("base %s is forward referenced", b.sym.ident.toChars());
                     else
                     {
-                        s = b.sym.search(loc, ident, flags);
+                        int flags2 = flags | IgnoreImportedFQN;
+                        if (this.getAccessModule() != b.sym.getAccessModule())
+                            flags2 |= IgnorePrivateImports;
+                        s = b.sym.search(loc, ident, flags2);
                         if (s == this) // happens if s is nested in this and derives from this
                             s = null;
                         else if (s)

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -802,8 +802,33 @@ public:
             mod.semantic();
         }
 
-        // Forward it to the module
-        return mod.search(loc, ident, flags);       // FIXME
+        Dsymbol s = null;
+
+        if (names.dim)
+        {
+            for (size_t i = 0; i < names.dim; i++)
+            {
+                auto name = names[i];
+                auto aliasName = aliases[i];
+                if ((aliasName ? aliasName : name) is ident)
+                {
+                    // Forward it to the module
+                    s = mod.search(loc, name, flags | IgnoreImportedFQN | IgnorePrivateSymbols);
+                    break;
+                }
+            }
+        }
+        else
+        {
+            // Forward it to the module
+            s = mod.search(loc, ident, flags | IgnoreImportedFQN | IgnorePrivateSymbols);
+        }
+        if (!s && overnext && !(flags & IgnoreOverloadImports))
+        {
+            s = overnext.search(loc, ident, flags);
+        }
+
+        return s;
     }
 
     override bool overloadInsert(Dsymbol s)

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -128,7 +128,7 @@ public:
     {
         //printf("Import::load('%s') %p\n", toPrettyChars(), this);
         // See if existing module
-        DsymbolTable dst = Package.resolve(packages, null, &pkg);
+        auto dst = Package.resolve(null, packages, &pkg, null);
         version (none)
         {
             if (pkg && pkg.isModule())

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -8,6 +8,7 @@
 
 module ddmd.dimport;
 
+import core.stdc.stdio;
 import core.stdc.string;
 import core.stdc.stdio;
 
@@ -28,6 +29,27 @@ import ddmd.mtype;
 import ddmd.root.outbuffer;
 import ddmd.visitor;
 
+extern (C++) Package findPackage(DsymbolTable dst, Identifiers* packages, size_t dim)
+{
+    if (!packages || !dim)
+        return null;
+    assert(dim <= packages.dim);
+
+    Package pkg;
+    for (size_t i = 0; i < dim; i++)
+    {
+        assert(dst);
+        Identifier pid = (*packages)[i];
+        Dsymbol p = dst.lookup(pid);
+        if (!p)
+            return null;
+        pkg = p.isPackage();
+        assert(pkg);
+        dst = pkg.symtab;
+    }
+    return pkg;
+}
+
 /***********************************************************
  */
 extern (C++) final class Import : Dsymbol
@@ -46,7 +68,7 @@ public:
     Identifiers aliases;
 
     Module mod;
-    Package pkg;            // leftmost package/module
+    Import overnext;
 
     // corresponding AliasDeclarations for alias=name pairs
     AliasDeclarations aliasdecls;
@@ -74,6 +96,7 @@ public:
         this.aliasId = aliasId;
         this.isstatic = isstatic;
         this.protection = PROTprivate; // default to private
+
         // Set symbol name (bracketed)
         if (aliasId)
         {
@@ -128,18 +151,8 @@ public:
     {
         //printf("Import::load('%s') %p\n", toPrettyChars(), this);
         // See if existing module
-        auto dst = Package.resolve(null, packages, &pkg, null);
-        version (none)
-        {
-            if (pkg && pkg.isModule())
-            {
-                .error(loc, "can only import from a module, not from a member of module %s. Did you mean `import %s : %s`?", pkg.toChars(), pkg.toPrettyChars(), id.toChars());
-                mod = pkg.isModule(); // Error recovery - treat as import of that module
-                return;
-            }
-        }
-        Dsymbol s = dst.lookup(id);
-        if (s)
+        auto dst = Package.resolve(null, packages, null, null);
+        if (auto s = dst.lookup(id))
         {
             if (s.isModule())
                 mod = cast(Module)s;
@@ -171,10 +184,6 @@ public:
                         .error(loc, "can only import from a module, not from package %s.%s", p.toPrettyChars(), id.toChars());
                     }
                 }
-                else if (pkg)
-                {
-                    .error(loc, "can only import from a module, not from package %s.%s", pkg.toPrettyChars(), id.toChars());
-                }
                 else
                 {
                     .error(loc, "can only import from a module, not from package %s", id.toChars());
@@ -193,71 +202,399 @@ public:
         }
         if (mod && !mod.importedFrom)
             mod.importedFrom = sc ? sc._module.importedFrom : Module.rootModule;
-        if (!pkg)
-            pkg = mod;
+
         //printf("-Import::load('%s'), pkg = %p\n", toChars(), pkg);
+    }
+
+    /*****************************
+     * Add import to sds's symbol table.
+     */
+    override void addMember(Scope* sc, ScopeDsymbol sds)
+    {
+        if (!mod)
+        {
+            load(sc);
+            // filling mod will break some existing assumptions
+            if (!mod)
+                return;     // fails to load module
+        }
+
+        if (mod.md && mod.md.isdeprecated)
+        {
+            auto msg = mod.md.msg;
+            if (auto se = msg ? msg.toStringExp() : null)
+                mod.deprecation(loc, "is deprecated - %s", se.string);
+            else
+                mod.deprecation(loc, "is deprecated");
+        }
+
+        //printf("Import::addMember[%s]('%s'), prot = %d\n", loc.toChars(), toChars(), sc.explicitProtection ? sc.protection : protection);
+        if (sc.explicitProtection)
+            protection = sc.protection.kind;
+
+        // FQN is visible if this is not an unrenamed selective import.
+        if (this.ident)
+        {
+            addPackage(sc, sds);
+        }
+
+        /* Instead of adding the import to sds's symbol table,
+         * add each of the alias=name pairs
+         */
+        for (size_t i = 0; i < names.dim; i++)
+        {
+            auto name = names[i];
+            auto aliasName = aliases[i];
+            if (!aliasName)
+                aliasName = name;
+            auto tname = new TypeIdentifier(loc, name);
+            auto ad = new AliasDeclaration(loc, aliasName, tname);
+            ad._import = this;
+            ad.addMember(sc, sds);
+
+            aliasdecls.push(ad);
+        }
+    }
+
+    /********************************************
+     * Add fully qualified package name in scope
+     */
+    final void addPackage(Scope* sc, ScopeDsymbol sds)
+    {
+        assert(mod);
+
+        Scope* scx = null;  // Innermost enclosing scope of sds
+        for (Scope* scy = sc; scy; scy = scy.enclosing)
+        {
+            if (!scy.scopesym)
+                continue;
+            if (!scx && scy.scopesym !is sds)
+            {
+                if (sds is null)
+                    sds = scy.scopesym;
+                else
+                    scx = scy;
+            }
+            else if (scx && scy.scopesym == sds)
+                scx = null;
+        }
+        assert(sds);
+        assert(scx && scx.scopesym && scx.scopesym !is sds);
+
+        if (!sds.symtab)
+            sds.symtab = new DsymbolTable();
+
+        // `this.ident` is null if this is an unrenamed selective import.
+        auto leftmostId = this.ident;
+        if (!leftmostId)
+        {
+            if (aliasId)
+                leftmostId = aliasId;
+            else if (packages && packages.dim)
+                leftmostId = (*packages)[0];
+            else
+                leftmostId = id;
+        }
+
+        // Validate whether the leftmost package name is already exists in symtab?
+        assert(leftmostId);
+        if (auto ss = sds.symtab.lookup(leftmostId))
+        {
+            if (aliasId || !packages || packages.dim == 0)
+            {
+                auto imp = ss.isImport();
+                if (imp && imp.mod is mod)
+                {
+                    // OK
+                }
+                else
+                {
+                    ScopeDsymbol.multiplyDefined(loc, ss, mod);
+                    return;
+                }
+            }
+            else
+            {
+                if (ss.isPackage())
+                {
+                    // OK
+                }
+                else
+                {
+                    ScopeDsymbol.multiplyDefined(loc, ss, this);
+                    return;
+                }
+            }
+        }
+
+        /* Insert the fully qualified name of imported module
+         * in local package tree.
+         */
+        DsymbolTable dst;       // rightmost DsymbolTable
+        Identifier id;          // rightmost import identifier:
+        Dsymbol ss = this;      // local package tree stores Import instead of Module
+        if (aliasId)
+        {
+            dst = sds.symtab;
+            id = aliasId;               // import [A] = std.stdio;
+        }
+        else
+        {
+            Package ppack = null;
+            Package pparent = null;     // rightmost package
+            dst = Package.resolve(sds.symtab, packages, &ppack, &pparent);
+            id = this.id;               // import std.[stdio];
+
+            if (mod.isPackageFile)
+            {
+                Package p = new Package(id);
+                p.parent = pparent;     // may be NULL
+                p.isPkgMod = PKGmodule;
+                p.aliassym = this;
+                p.symtab = new DsymbolTable();
+                ss = p;
+
+                if (!pparent)
+                    ppack = p;
+            }
+        }
+        if (dst.insert(id, ss))
+        {
+            /* Make links from inner packages to the corresponding outer packages.
+             *
+             *  import std.algorithm;
+             *  // In here, symtab have a Package 'std' (a),
+             *  // and it contains a module 'algorithm'.
+             *
+             *  class C {
+             *    import std.range;
+             *    // In here, symtab contains a Package 'std' (b),
+             *    // and it contains a module 'range'.
+             *
+             *    void test() {
+             *      std.algorithm.map!(a=>a*2)(...);
+             *      // 'algorithm' doesn't exist in (b).symtab, so (b) should have
+             *      // a link to (a).
+             *    }
+             *  }
+             *
+             * After following, (b).enclosingPkg() will return (a).
+             */
+            if (aliasId || !packages || !packages.dim)
+                return;
+            assert(packages);
+            dst = sds.symtab;
+
+            for (size_t i = 0; i < packages.dim; i++)
+            {
+                assert(dst);
+                auto s = dst.lookup((*packages)[i]);
+                assert(s);
+                auto inn_pkg = s.isPackage();
+                assert(inn_pkg);
+                //printf("\t[%d] inn_pkg = %s\n", i, inn_pkg.toChars());
+
+                Package out_pkg = null;
+                for (; scx; scx = scx.enclosing)
+                {
+                    if (!scx.scopesym || !scx.scopesym.symtab)
+                        continue;
+
+                    out_pkg = findPackage(scx.scopesym.symtab, packages, i + 1);
+                    if (!out_pkg)
+                        continue;
+
+                    assert(inn_pkg !is out_pkg);
+                    //printf("\t[%d] out_pkg = %s\n", i, out_pkg.toChars());
+
+                    /* Importing package.d hides outer scope imports, so
+                     * further searching is not necessary.
+                     *
+                     *  import std.algorithm;
+                     *  class C1 {
+                     *    import std;
+                     *    // Here is 'scx.scopesym'
+                     *    // out_pkg == 'std' (isPackageMod() != NULL)
+                     *
+                     *    class C2 {
+                     *      import std.range;
+                     *      // Here is 'this'
+                     *      // inn_pkg == 'std' (isPackageMod() == NULL)
+                     *
+                     *      void test() {
+                     *        auto r1 = std.range.iota(10);   // OK
+                     *        auto r2 = std.algorithm.map!(a=>a*2)([1,2,3]);   // NG
+                     *        // std.range is accessible, but
+                     *        // std.algorithm isn't. Because identifier
+                     *        // 'algorithm' is found in std/package.d
+                     *      }
+                     *    }
+                     *  }
+                     */
+                    if (out_pkg.isPackageMod())
+                        return;
+
+                    //printf("link out(%s:%p) to (%s:%p)\n", out_pkg.toPrettyChars(), out_pkg, inn_pkg.toPrettyChars(), inn_pkg);
+                    inn_pkg.aliassym = out_pkg;
+                    break;
+                }
+
+                /* There's no corresponding package in enclosing scope, so
+                 * further searching is not necessary.
+                 */
+                if (!out_pkg)
+                    break;
+
+                dst = inn_pkg.symtab;
+            }
+        }
+        else
+        {
+            auto prev = dst.lookup(id);
+            assert(prev);
+            if (auto imp = prev.isImport())
+            {
+                if (imp.mod is mod)
+                {
+                    if (imp is this)
+                        return;
+
+                    /* OK:
+                     *  import A = std.algorithm : find;
+                     *  import A = std.algorithm : filter;
+                     */
+                    auto pimp = &imp.overnext;
+                    while (*pimp)
+                    {
+                        if (*pimp is this)
+                            return;
+                        pimp = &(*pimp).overnext;
+                    }
+                    (*pimp) = this;
+                }
+                else
+                {
+                    /* NG:
+                     *  import A = std.algorithm;
+                     *  import A = std.stdio;
+                     */
+                    error("import '%s' conflicts with import '%s'", toChars(), prev.toChars());
+                }
+            }
+            else
+            {
+                auto pkg = prev.isPackage();
+                assert(pkg);
+                //printf("[%s] pkg = %d, pkg.aliassym = %p, mod = %p, mod.isPackageFile = %d\n",
+                //        loc.toChars(), pkg.isPkgMod, pkg.aliassym, mod, mod.isPackageFile);
+                if (pkg.isPkgMod == PKGunknown && mod.isPackageFile)
+                {
+                    /* OK:
+                     *  import std.datetime;
+                     *  import std;  // std/package.d
+                     */
+                    pkg.isPkgMod = PKGmodule;
+                    pkg.aliassym = this;
+                }
+                else if (pkg.isPackageMod() == mod)
+                {
+                    /* OK:
+                     *  import std;  // std/package.d
+                     *  import std: writeln;
+                     */
+                    auto imp = pkg.aliassym.isImport();
+                    assert(imp);
+                    auto pimp = &imp.overnext;
+                    while (*pimp)
+                    {
+                        if (*pimp is this)
+                            return;
+                        pimp = &(*pimp).overnext;
+                    }
+                    (*pimp) = this;
+                }
+                else
+                {
+                    /* NG:
+                     *  import std.stdio;
+                     *  import std = std.algorithm;
+                     */
+                    error("import '%s' conflicts with package '%s'", toChars(), prev.toChars());
+                }
+            }
+        }
+    }
+
+    override void setScope(Scope* sc)
+    {
+        Dsymbol.setScope(sc);
+        if (aliasdecls.dim)
+        {
+            if (!mod)
+                importAll(sc);
+
+            sc = sc.push(mod);
+            /* BUG: Protection checks can't be enabled yet. The issue is
+             * that Dsymbol::search errors before overload resolution.
+             */
+            version (none)
+            {
+                sc.protection = protection;
+            }
+            else
+            {
+                sc.protection = Prot(PROTpublic);
+            }
+            foreach (ad; aliasdecls)
+            {
+                ad.setScope(sc);
+            }
+            sc = sc.pop();
+        }
     }
 
     override void importAll(Scope* sc)
     {
         if (!mod)
+            return;
+
+        mod.importAll(null);
+
+        ScopeDsymbol sds = null;
+        for (Scope* scx = sc; scx; scx = scx.enclosing)
         {
-            load(sc);
-            if (mod) // if successfully loaded module
-            {
-                if (mod.md && mod.md.isdeprecated)
-                {
-                    Expression msg = mod.md.msg;
-                    if (StringExp se = msg ? msg.toStringExp() : null)
-                        mod.deprecation(loc, "is deprecated - %s", se.string);
-                    else
-                        mod.deprecation(loc, "is deprecated");
-                }
-                mod.importAll(null);
-                if (!isstatic && !aliasId && !names.dim)
-                {
-                    if (sc.explicitProtection)
-                        protection = sc.protection.kind;
-                    sc.scopesym.importScope(mod, Prot(protection));
-                }
-            }
+            sds = scx.scopesym;
+            if (sds)
+                break;
+        }
+        assert(sds);
+
+        if (!isstatic && !aliasId && !names.dim)
+        {
+            sds.importScope(this, Prot(protection));
         }
     }
 
     override void semantic(Scope* sc)
     {
-        //printf("Import::semantic('%s') %s\n", toPrettyChars(), id.toChars());
+        //printf("Import::semantic[%s]('%s') prot = %d\n", loc.toChars(), toPrettyChars(), protection);
         if (_scope)
         {
             sc = _scope;
             _scope = null;
         }
+
         // Load if not already done so
-        if (!mod)
-        {
-            load(sc);
-            if (mod)
-                mod.importAll(null);
-        }
+        importAll(sc);
+
         if (mod)
         {
             // Modules need a list of each imported module
             //printf("%s imports %s\n", sc.module.toChars(), mod.toChars());
             sc._module.aimports.push(mod);
-            if (!isstatic && !aliasId && !names.dim)
-            {
-                if (sc.explicitProtection)
-                    protection = sc.protection.kind;
-                for (Scope* scd = sc; scd; scd = scd.enclosing)
-                {
-                    if (scd.scopesym)
-                    {
-                        scd.scopesym.importScope(mod, Prot(protection));
-                        break;
-                    }
-                }
-            }
+
             mod.semantic();
+
             if (mod.needmoduleinfo)
             {
                 //printf("module4 %s because of %s\n", sc.module.toChars(), mod.toChars());
@@ -269,7 +606,7 @@ public:
              */
             version (none)
             {
-                sc.protection = protection;
+                sc.protection = Preot(protection);
             }
             else
             {
@@ -364,7 +701,7 @@ public:
                 ob.printf(" -> %s", aliasId.toChars());
             ob.writenl();
         }
-        //printf("-Import::semantic('%s'), pkg = %p\n", toChars(), pkg);
+        //printf("-Import::semantic('%s')\n", toChars());
     }
 
     override void semantic2(Scope* sc)
@@ -388,72 +725,19 @@ public:
         return this;
     }
 
-    /*****************************
-     * Add import to sd's symbol table.
-     */
-    override void addMember(Scope* sc, ScopeDsymbol sd)
-    {
-        //printf("Import.addMember(this=%s, sd=%s, sc=%p)\n", toChars(), sd.toChars(), sc);
-        if (names.dim == 0)
-            return Dsymbol.addMember(sc, sd);
-        if (aliasId)
-            Dsymbol.addMember(sc, sd);
-        /* Instead of adding the import to sd's symbol table,
-         * add each of the alias=name pairs
-         */
-        for (size_t i = 0; i < names.dim; i++)
-        {
-            Identifier name = names[i];
-            Identifier _alias = aliases[i];
-            if (!_alias)
-                _alias = name;
-            auto tname = new TypeIdentifier(loc, name);
-            auto ad = new AliasDeclaration(loc, _alias, tname);
-            ad._import = this;
-            ad.addMember(sc, sd);
-            aliasdecls.push(ad);
-        }
-    }
-
-    override void setScope(Scope* sc)
-    {
-        Dsymbol.setScope(sc);
-        if (aliasdecls.dim)
-        {
-            if (!mod)
-                importAll(sc);
-
-            sc = sc.push(mod);
-            /* BUG: Protection checks can't be enabled yet. The issue is
-             * that Dsymbol::search errors before overload resolution.
-             */
-            version (none)
-            {
-                sc.protection = protection;
-            }
-            else
-            {
-                sc.protection = Prot(PROTpublic);
-            }
-            foreach (ad; aliasdecls)
-            {
-                ad.setScope(sc);
-            }
-            sc = sc.pop();
-        }
-    }
-
     override Dsymbol search(Loc loc, Identifier ident, int flags = IgnoreNone)
     {
-        //printf("%s.Import::search(ident = '%s', flags = x%x)\n", toChars(), ident.toChars(), flags);
-        if (!pkg)
+        //printf("%p [%s].Import::search(ident = '%s', flags = x%x)\n", this, loc.toChars(), ident.toChars(), flags);
+        //printf("%p\tfrom [%s] mod = %s\n", this, this.loc.toChars(), mod ? mod.toChars() : null);
+
+        if (mod && !mod._scope)
         {
-            load(null);
             mod.importAll(null);
             mod.semantic();
         }
-        // Forward it to the package/module
-        return pkg.search(loc, ident, flags);
+
+        // Forward it to the module
+        return mod.search(loc, ident, flags);       // FIXME
     }
 
     override bool overloadInsert(Dsymbol s)

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -315,6 +315,18 @@ public:
                 {
                     // OK
                 }
+                else if (sc.func && !sds.isAggregateDeclaration())
+                {
+                    /* For backward compatibility:
+                     *  void foo() {
+                     *    int std;
+                     *    import std.stdio;  // 'std' package is implicitly hidden
+                     *    std = 10;          // refer variable 'std'
+                     *    writeln("hello");  // refer imported symbol
+                     *  }
+                     */
+                    return;
+                }
                 else
                 {
                     ScopeDsymbol.multiplyDefined(loc, ss, mod);
@@ -326,6 +338,11 @@ public:
                 if (ss.isPackage())
                 {
                     // OK
+                }
+                else if (sc.func && !sds.isAggregateDeclaration())
+                {
+                    // For backward compatibility.
+                    return;
                 }
                 else
                 {

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -129,17 +129,21 @@ public:
 
     /****************************************************
      * Input:
+     *      dst             package tree root
      *      packages[]      the pkg1.pkg2 of pkg1.pkg2.mod
      * Returns:
      *      the symbol table that mod should be inserted into
      * Output:
-     *      *pparent        the rightmost package, i.e. pkg2, or NULL if no packages
      *      *ppkg           the leftmost package, i.e. pkg1, or NULL if no packages
+     *      *pparent        the rightmost package, i.e. pkg2, or NULL if no packages
      */
-    final static DsymbolTable resolve(Identifiers* packages, Dsymbol* pparent, Package* ppkg)
+    final static DsymbolTable resolve(DsymbolTable dst, Identifiers* packages, Package* ppkg, Package* pparent)
     {
-        DsymbolTable dst = Module.modules;
-        Dsymbol parent = null;
+        if (!dst)
+            dst = Module.modules;
+
+        Package parent = null;
+
         //printf("Package::resolve()\n");
         if (ppkg)
             *ppkg = null;
@@ -760,9 +764,12 @@ public:
              * the name of this module.
              */
             this.ident = md.id;
+            Package pparent = null;
             Package ppack = null;
-            dst = Package.resolve(md.packages, &this.parent, &ppack);
+            dst = Package.resolve(null, md.packages, &ppack, &pparent);
+            this.parent = pparent;
             assert(dst);
+
             Module m = ppack ? ppack.isModule() : null;
             if (m && strcmp(m.srcfile.name.name(), "package.d") != 0)
             {

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -130,6 +130,12 @@ public:
         return "package";
     }
 
+    override final Prot prot()
+    {
+        // local package tree is always private in each scope
+        return Prot(PROTprivate);
+    }
+
     /****************************************************
      * Input:
      *      dst             package tree root
@@ -255,6 +261,14 @@ public:
         }
 
         auto s = ScopeDsymbol.search(loc, ident, flags);
+        if (!s && !isPackageMod())
+        {
+            if (auto pkg = enclosingPkg())
+            {
+                assert(pkg !is this);
+                s = pkg.search(loc, ident, flags);
+            }
+        }
         return s;
     }
 
@@ -272,6 +286,13 @@ public:
             if (auto imp = aliassym.isImport())
                 return imp.mod;
         }
+        return null;
+    }
+
+    Package enclosingPkg()
+    {
+        if (isPkgMod != PKGmodule && aliassym)
+            return aliassym.isPackage();
         return null;
     }
 }

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -385,6 +385,8 @@ public:
     // way to an object file
     Module importedFrom;
 
+    Dsymbols* publicImports;    // array of public import declarations
+
     Dsymbols* decldefs;         // top level declarations for this Module
 
     Modules aimports;           // all imported modules

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -255,7 +255,7 @@ public:
              *      // std/algorithm.d would hit.
              *  }
              */
-            auto s = aliassym.search(loc, ident, flags);
+            auto s = aliassym.search(loc, ident, flags | IgnoreImportedFQN);
             if (s)
                 return s;
         }

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -678,6 +678,8 @@ public:
                 if (!sm)
                 {
                     sm = s.search_correct(ti.name);
+                    if (auto imp = s.isImport())
+                        s = imp.mod;
                     if (sm)
                         .error(loc, "template identifier '%s' is not a member of %s '%s', did you mean %s '%s'?", ti.name.toChars(), s.kind(), s.toPrettyChars(), sm.kind(), sm.toChars());
                     else
@@ -688,6 +690,8 @@ public:
                 TemplateDeclaration td = sm.isTemplateDeclaration();
                 if (!td)
                 {
+                    if (auto imp = s.isImport())
+                        s = imp.mod;
                     .error(loc, "%s.%s is not a template, it is a %s", s.toPrettyChars(), ti.name.toChars(), sm.kind());
                     return null;
                 }

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -138,6 +138,11 @@ enum
     IgnorePrivateMembers    = 0x01, // don't find private members
     IgnoreErrors            = 0x02, // don't give error messages
     IgnoreAmbiguous         = 0x04, // return NULL if ambiguous
+    IgnoreImportedFQN       = 0x08, // don't find imported FQNs
+    IgnorePrivateImports    = 0x10, // don't find privately imported symbols
+    IgnoreOverloadImports   = 0x20, // don't find overloaded imports
+
+    IgnorePrivateSymbols    = IgnorePrivateMembers | IgnorePrivateImports,
 };
 
 typedef int (*Dsymbol_apply_ft_t)(Dsymbol *, void *);

--- a/src/expression.d
+++ b/src/expression.d
@@ -3844,14 +3844,14 @@ public:
             //printf("'%s' is an overload set\n", o->toChars());
             return new OverExp(loc, o);
         }
-        if (Import imp = s.isImport())
+        if (auto imp = s.isImport())
         {
-            if (!imp.pkg)
+            if (!imp.mod)
             {
                 .error(loc, "forward reference of import %s", imp.toChars());
                 return new ErrorExp();
             }
-            auto ie = new ScopeExp(loc, imp.pkg);
+            auto ie = new ScopeExp(loc, imp.mod);
             return ie.semantic(sc);
         }
         if (Package pkg = s.isPackage())
@@ -8310,10 +8310,14 @@ public:
                         e = new DotExp(loc, eleft, e);
                     return e;
                 }
-                Import imp = s.isImport();
-                if (imp)
+                if (auto imp = s.isImport())
                 {
-                    ie = new ScopeExp(loc, imp.pkg);
+                    if (!imp.mod)
+                    {
+                        error("forward reference of import %s", imp.toChars());
+                        return new ErrorExp();
+                    }
+                    ie = new ScopeExp(loc, imp.mod);
                     return ie.semantic(sc);
                 }
                 // BUG: handle other cases like in IdentifierExp::semantic()

--- a/src/import.h
+++ b/src/import.h
@@ -42,7 +42,7 @@ public:
     Identifiers aliases;
 
     Module *mod;
-    Package *pkg;               // leftmost package/module
+    Import *overnext;
 
     AliasDeclarations aliasdecls; // corresponding AliasDeclarations for alias=name pairs
 
@@ -53,11 +53,13 @@ public:
     Prot prot();
     Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     void load(Scope *sc);
+    void addMember(Scope *sc, ScopeDsymbol *sds);
+    void addPackage(Scope *sc, ScopeDsymbol *sds);
+    void setScope(Scope *sc);
     void importAll(Scope *sc);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     Dsymbol *toAlias();
-    void addMember(Scope *sc, ScopeDsymbol *sds);
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
     bool overloadInsert(Dsymbol *s);
 

--- a/src/import.h
+++ b/src/import.h
@@ -51,6 +51,7 @@ public:
     void addAlias(Identifier *name, Identifier *alias);
     const char *kind();
     Prot prot();
+    Import *copy();
     Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     void load(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);

--- a/src/module.h
+++ b/src/module.h
@@ -37,7 +37,10 @@ class Package : public ScopeDsymbol
 {
 public:
     PKG isPkgMod;
-    Module *mod;        // != NULL if isPkgMod == PKGmodule
+
+    // isPkgMod == PKGmodule: Module/Import object corresponding to 'package.d'
+    // isPkgMod != PKGmodule: Package object in enclosing scope
+    Dsymbol *aliassym;
 
     Package(Identifier *ident);
     const char *kind();

--- a/src/module.h
+++ b/src/module.h
@@ -101,6 +101,7 @@ public:
     // i.e. a module that will be taken all the
     // way to an object file
     Module *importedFrom;
+    Dsymbols *publicImports;    // array of public import declarations
 
     Dsymbols *decldefs;         // top level declarations for this Module
 

--- a/src/module.h
+++ b/src/module.h
@@ -42,7 +42,7 @@ public:
     Package(Identifier *ident);
     const char *kind();
 
-    static DsymbolTable *resolve(Identifiers *packages, Dsymbol **pparent, Package **ppkg);
+    static DsymbolTable *resolve(DsymbolTable *dst, Identifiers *packages, Package **ppkg, Package **pparent);
 
     Package *isPackage() { return this; }
 

--- a/src/module.h
+++ b/src/module.h
@@ -44,6 +44,7 @@ public:
 
     Package(Identifier *ident);
     const char *kind();
+    Prot prot() { return Prot(PROTprivate); }   // local package tree is always private in each scope
 
     static DsymbolTable *resolve(DsymbolTable *dst, Identifiers *packages, Package **ppkg, Package **pparent);
 
@@ -56,6 +57,7 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 
     Module *isPackageMod();
+    Package *enclosingPkg();
 };
 
 class Module : public Package

--- a/src/traits.d
+++ b/src/traits.d
@@ -607,7 +607,13 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             if (auto fd = s.isFuncDeclaration()) // Bugzilla 8943
                 s = fd.toAliasFunc();
-            if (!s.isImport()) // Bugzilla 8922
+            if (s.isImport() || s.isPackage())
+            {
+                s = s.toParent();
+                if (s && !(s.isPackage() && !s.isModule()))
+                    s = null;
+            }
+            else
                 s = s.toParent();
         }
         if (!s || s.isImport())

--- a/test/compilable/extra-files/example7190/controllers/HomeController.d
+++ b/test/compilable/extra-files/example7190/controllers/HomeController.d
@@ -1,5 +1,6 @@
 module example7190.controllers.HomeController;
 
+import serenity7190.core.Model;
 import serenity7190.core.Controller;
 
 class HomeController : Controller {

--- a/test/compilable/extra-files/pkg_import3a/mod.d
+++ b/test/compilable/extra-files/pkg_import3a/mod.d
@@ -1,0 +1,3 @@
+module pkg_import3a.mod;
+
+int bar() { return 3; }

--- a/test/compilable/extra-files/pkg_import3a/package.d
+++ b/test/compilable/extra-files/pkg_import3a/package.d
@@ -1,0 +1,4 @@
+module pkg_import3a;
+
+int foo() { return 1; }
+int bar() { return 2; }

--- a/test/compilable/extra-files/pkg_import3b/mod.d
+++ b/test/compilable/extra-files/pkg_import3b/mod.d
@@ -1,0 +1,3 @@
+module pkg_import3b.mod;
+
+int bar() { return 3; }

--- a/test/compilable/extra-files/pkg_import3b/package.d
+++ b/test/compilable/extra-files/pkg_import3b/package.d
@@ -1,0 +1,6 @@
+module pkg_import3b;
+
+int foo() { return 1; }
+int bar() { return 2; }
+
+int mod;

--- a/test/compilable/imports/imp12735.d
+++ b/test/compilable/imports/imp12735.d
@@ -1,0 +1,13 @@
+module imports.imp12735;
+
+mixin template Mix12735()
+{
+    import imports.imp1b;   // bar function
+}
+mixin Mix12735!();
+
+void check12735()
+{
+    string str = "abc";
+    assert(bar() == 2);  // accessible
+}

--- a/test/compilable/imports/imp1a.d
+++ b/test/compilable/imports/imp1a.d
@@ -1,0 +1,3 @@
+module imports.imp1a;
+
+auto foo() { return 1; }

--- a/test/compilable/imports/imp1b.d
+++ b/test/compilable/imports/imp1b.d
@@ -1,0 +1,3 @@
+module imports.imp1b;
+
+auto bar() { return 2; }

--- a/test/compilable/imports/imp2a.d
+++ b/test/compilable/imports/imp2a.d
@@ -1,0 +1,7 @@
+module imports.imp2a;
+
+void foo() {}
+
+import imports.imp2b;
+
+public import imports.imp2c;

--- a/test/compilable/imports/imp2b.d
+++ b/test/compilable/imports/imp2b.d
@@ -1,0 +1,3 @@
+module imports.imp2b;
+
+void bar() {}

--- a/test/compilable/imports/imp2c.d
+++ b/test/compilable/imports/imp2c.d
@@ -1,0 +1,3 @@
+module imports.imp2c;
+
+void baz() {}

--- a/test/compilable/imports/imp4array.d
+++ b/test/compilable/imports/imp4array.d
@@ -1,0 +1,4 @@
+auto splitter(C)(C[] s) if (is(C : char)) {}
+
+void join() {}
+void split() {}

--- a/test/compilable/imports/imp4range.d
+++ b/test/compilable/imports/imp4range.d
@@ -1,0 +1,1 @@
+public import imports.imp4array;

--- a/test/compilable/imports/imp4string.d
+++ b/test/compilable/imports/imp4string.d
@@ -1,0 +1,2 @@
+import imports.imp4range;
+public import imports.imp4array : join, split;

--- a/test/compilable/imports/test7491c.d
+++ b/test/compilable/imports/test7491c.d
@@ -1,0 +1,22 @@
+module imports.test7491c;
+
+class B1
+{
+private:
+    import imports.test7491e;   // std.algorithm;
+    import algorithm = imports.test7491e;
+}
+
+class B2
+{
+protected:
+    import imports.test7491e;   // std.algorithm;
+    import algorithm = imports.test7491e;
+}
+
+class B3
+{
+public:
+    import imports.test7491e;   // std.algorithm;
+    import algorithm = imports.test7491e;
+}

--- a/test/compilable/imports/test7491d.d
+++ b/test/compilable/imports/test7491d.d
@@ -1,0 +1,3 @@
+module imports.test7491d;
+
+void writeln();

--- a/test/compilable/imports/test7491e.d
+++ b/test/compilable/imports/test7491e.d
@@ -1,0 +1,3 @@
+module imports.test7491e;
+
+void map(alias pred, R)(R) {}

--- a/test/compilable/test71.d
+++ b/test/compilable/test71.d
@@ -1,3 +1,5 @@
+// PERMUTE_ARGS:
+
 import imports.test71;
 
 void bar()

--- a/test/compilable/test7491.d
+++ b/test/compilable/test7491.d
@@ -1,8 +1,12 @@
+// PERMUTE_ARGS:
+
+module test7491;
+
 struct Struct
 {
     import object;
     import imports.test7491a;
-    import renamed=imports.test7491b;
+    import renamed = imports.test7491b;
 }
 
 struct AliasThis
@@ -15,7 +19,7 @@ class Base
 {
     import object;
     import imports.test7491a;
-    import renamed=imports.test7491b;
+    import renamed = imports.test7491b;
 }
 
 class Derived : Base
@@ -26,28 +30,76 @@ interface Interface
 {
     import object;
     import imports.test7491a;
-    import renamed=imports.test7491b;
+    import renamed = imports.test7491b;
 }
 
 class Impl : Interface
 {
 }
 
-static assert(__traits(compiles, Struct.object));
-static assert(__traits(compiles, Struct.imports));
-static assert(__traits(compiles, Struct.renamed));
-static assert(__traits(compiles, AliasThis.object));
-static assert(__traits(compiles, AliasThis.imports));
-static assert(__traits(compiles, AliasThis.renamed));
-static assert(__traits(compiles, Base.object));
-static assert(__traits(compiles, Base.imports));
-static assert(__traits(compiles, Base.renamed));
-static assert(__traits(compiles, Derived.object));
-static assert(__traits(compiles, Derived.imports));
-static assert(__traits(compiles, Derived.renamed));
-static assert(__traits(compiles, Interface.object));
-static assert(__traits(compiles, Interface.imports));
-static assert(__traits(compiles, Interface.renamed));
-static assert(__traits(compiles, Impl.object));
-static assert(__traits(compiles, Impl.imports));
-static assert(__traits(compiles, Impl.renamed));
+static assert(!__traits(compiles, Struct.object));
+static assert(!__traits(compiles, Struct.imports));
+static assert(!__traits(compiles, Struct.renamed));
+static assert(!__traits(compiles, AliasThis.object));
+static assert(!__traits(compiles, AliasThis.imports));
+static assert(!__traits(compiles, AliasThis.renamed));
+static assert(!__traits(compiles, Base.object));
+static assert(!__traits(compiles, Base.imports));
+static assert(!__traits(compiles, Base.renamed));
+static assert(!__traits(compiles, Derived.object));
+static assert(!__traits(compiles, Derived.imports));
+static assert(!__traits(compiles, Derived.renamed));
+static assert(!__traits(compiles, Interface.object));
+static assert(!__traits(compiles, Interface.imports));
+static assert(!__traits(compiles, Interface.renamed));
+static assert(!__traits(compiles, Impl.object));
+static assert(!__traits(compiles, Impl.imports));
+static assert(!__traits(compiles, Impl.renamed));
+
+/***************************************************/
+
+import imports.test7491c;
+import imports.test7491d;   // std.stdio;
+import io = imports.test7491d;
+
+class C1 : B1
+{
+    void foo()
+    {
+        writeln();
+        imports.test7491d.writeln();
+        io.writeln();
+
+        static assert(!__traits(compiles, map!(a=>a)([1,2,3])));
+        static assert(!__traits(compiles, imports.test7491e.map!(a=>a)([1,2,3])));
+        static assert(!__traits(compiles, algorithm.map!(a=>a)([1,2,3])));
+    }
+}
+
+class C2 : B2
+{
+    void foo()
+    {
+        writeln();
+        imports.test7491d.writeln();
+        io.writeln();
+
+        map!(a=>a)([1,2,3]);
+        imports.test7491e.map!(a=>a)([1,2,3]);
+        algorithm.map!(a=>a)([1,2,3]);
+    }
+}
+
+class C3 : B3
+{
+    void foo()
+    {
+        writeln();
+        imports.test7491d.writeln();
+        io.writeln();
+
+        map!(a=>a)([1,2,3]);
+        imports.test7491e.map!(a=>a)([1,2,3]);
+        algorithm.map!(a=>a)([1,2,3]);
+    }
+}

--- a/test/compilable/testDIP37.d
+++ b/test/compilable/testDIP37.d
@@ -13,7 +13,7 @@ void test3()
 {
     import pkgDIP37.datetime.common;
     def();
-    pkgDIP37.datetime.def();
+    static assert(!__traits(compiles, pkgDIP37.datetime.def()));
     pkgDIP37.datetime.common.def();
 }
 
@@ -21,7 +21,7 @@ void test4()
 {
     import pkgDIP37.datetime : def;
     def();
-    static assert(!__traits(compiles, pkgDIP37.datetime.def()));
+    pkgDIP37.datetime.def();
     static assert(!__traits(compiles, pkgDIP37.datetime.common.def()));
 }
 

--- a/test/compilable/testimport1.d
+++ b/test/compilable/testimport1.d
@@ -57,3 +57,14 @@ class C12413
         static assert(!__traits(compiles, imports.x));
     }
 }
+
+/***************************************************/
+// 12735
+
+void test12735()
+{
+    import imports.imp12735;
+
+    static assert(!__traits(compiles, bar()));   // should not be accessible
+    check12735();
+}

--- a/test/compilable/testimport1.d
+++ b/test/compilable/testimport1.d
@@ -1,0 +1,59 @@
+// PERMUTE_ARGS:
+
+module testimport1;
+
+import imports.imp1a;
+
+class C
+{
+    import imports.imp1b;
+
+    void test()
+    {
+        imports.imp1b.bar();
+        imports.imp1a.foo();
+    }
+}
+
+int global;
+
+void main()
+{
+    // From here, 1a is visible but 1b isn't.
+    imports.imp1a.foo();
+    static assert(!__traits(compiles, imports.imp1b.bar()));
+
+    testimport1.C c;
+    auto y1 = testimport1.global;
+
+    // A declaration always hide same name root of package hierarchy.
+    {
+        int imports;
+        static assert(!__traits(compiles, imports.imp1a.foo()));
+    }
+
+    // FQN access with Module Scope Operator works
+    .imports.imp1a.foo();
+    static assert(!__traits(compiles, { auto y2 = .testimport1.global; }));
+
+    // FQN access through class is not allowed
+    static assert(!__traits(compiles, { C.imports.imp1b.bar(); }));
+}
+
+/***************************************************/
+// 12413
+
+mixin template M12413()
+{
+    static import imports.imp1b;
+}
+
+class C12413
+{
+    mixin M12413!();
+
+    void f()
+    {
+        static assert(!__traits(compiles, imports.x));
+    }
+}

--- a/test/compilable/testimport2.d
+++ b/test/compilable/testimport2.d
@@ -1,0 +1,50 @@
+// REQUIRED_ARGS: -Icompilable/extra-files
+// PERMUTE_ARGS:
+// EXTRA_SOURCE: imports/imp2a.d
+// EXTRA_SOURCE: imports/imp2b.d
+// EXTRA_SOURCE: imports/imp2c.d
+
+import imports.imp2a;
+
+void main()
+{
+    // public symbols which directly imported are visible
+    foo();
+    imports.imp2a.foo(); // by FQN
+    {
+        alias A = imports.imp2a;
+        A.foo();
+        static assert(!__traits(compiles, A.bar()));
+        A.baz();
+    }
+
+    // public symbols through private import are invisible
+    static assert(!__traits(compiles, bar()));
+    static assert(!__traits(compiles, imports.imp2b.bar()));
+    // FQN of privately imported module is invisible
+    static assert(!__traits(compiles, imports.imp2b.stringof));
+    {
+        static assert(!__traits(compiles, { alias B = imports.imp2b; }));
+    }
+
+    // public symbols which indirectly imported through public import are visible
+    baz();
+    imports.imp2c.baz(); // by FQN
+    // FQN of publicly imported module is visible
+    static assert(imports.imp2c.stringof == "module imp2c");
+    {
+        alias C = imports.imp2c;
+        static assert(!__traits(compiles, C.foo()));
+        static assert(!__traits(compiles, C.bar()));
+        C.baz();
+    }
+
+    // Import Declaration itself should not have FQN
+    static assert(!__traits(compiles, imports.imp2a.imports.imp2b.bar()));
+    static assert(!__traits(compiles, imports.imp2a.imports.imp2c.baz()));
+
+    // Applying Module Scope Operator to package/module FQN
+    .imports.imp2a.foo();
+    static assert(!__traits(compiles, .imports.imp2b.bar()));
+    .imports.imp2c.baz();
+}

--- a/test/compilable/testimport3.d
+++ b/test/compilable/testimport3.d
@@ -1,0 +1,123 @@
+// REQUIRED_ARGS: -Icompilable/extra-files
+// PERMUTE_ARGS:
+// EXTRA_SOURCE: extra-files/pkg_import3a/package.d
+// EXTRA_SOURCE: extra-files/pkg_import3a/mod.d
+
+// Test1
+class Test1A
+{
+    import pkg_import3a;        // foo()==1, bar()==2
+    class C
+    {
+        import pkg_import3a.mod;    // bar()==3
+        void test()
+        {
+            static assert(foo() == 1);                      // OK, foo in pkg_import3a
+            static assert(bar() == 3);                      // OK, bar in pkg_import3a.mod
+
+            static assert(!__traits(compiles, pkg_import3a.foo()));
+            static assert(!__traits(compiles, pkg_import3a.bar()));
+            // --> both NG, inner sub-module import hides outer package.d FQN
+
+            static assert(pkg_import3a.mod.bar() == 3);     // OK, bar in pkg_import3a.mod
+        }
+    }
+}
+class Test1B
+{
+    class C
+    {
+        import pkg_import3a;        // foo()==1, bar()==2
+        import pkg_import3a.mod;    // bar()==3
+        void test()
+        {
+            static assert(foo() == 1);                      // OK, foo in pkg_import3a
+            static assert(!__traits(compiles, bar()));
+            // --> NG, ambiguous: pkg_import3a.bar and pkg_import3a.mod.bar
+
+            static assert(pkg_import3a.foo() == 1);         // OK
+            static assert(pkg_import3a.bar() == 2);         // OK
+
+            static assert(pkg_import3a.mod.bar() == 3);     // OK
+        }
+    }
+}
+class Test1C
+{
+    import pkg_import3a.mod;    // bar()==3
+    class C
+    {
+        import pkg_import3a;        // foo()==1, bar()==2
+        void test()
+        {
+            static assert(foo() == 1);                      // OK, foo in pkg_import3a
+            static assert(bar() == 2);                      // OK, bar in pkg_import3a
+
+            static assert(pkg_import3a.foo() == 1);         // OK
+            static assert(pkg_import3a.bar() == 2);         // OK
+
+            static assert(!__traits(compiles, pkg_import3a.mod.bar()));
+            // --> NG, package.d import 'import pkg_import3a' hides FQN 'pkg_import3a.mod'
+        }
+    }
+}
+
+// Test2 symbol name in pkg_import3b/package.d conflicts with sibling module name which under the pkg_import3b.
+class Test2A
+{
+    import pkg_import3b;        // foo()==1, bar()==2, int mod;
+    class C
+    {
+        import pkg_import3b.mod;    // bar()==3
+        void test()
+        {
+            static assert(foo() == 1);                      // OK, foo in pkg_import3b
+            static assert(bar() == 3);                      // OK, bar in pkg_import3b.mod
+
+            static assert(!__traits(compiles, pkg_import3b.foo()));
+            static assert(!__traits(compiles, pkg_import3b.bar()));
+            // --> both NG, inner sub-module import hides outer package.d FQN
+
+            static assert(pkg_import3b.mod.bar() == 3);     // OK, bar in pkg_import3b.mod
+        }
+    }
+}
+class Test2B
+{
+    class C
+    {
+        import pkg_import3b;        // foo()==1, bar()==2, int mod;
+        import pkg_import3b.mod;    // bar()==3
+        void test()
+        {
+            static assert(foo() == 1);                      // OK, foo in pkg_import3b
+            static assert(!__traits(compiles, bar()));
+            // --> NG, ambiguous: pkg_import3b.bar and pkg_import3b.mod.bar
+
+            static assert(pkg_import3b.foo() == 1);         // OK
+            static assert(pkg_import3b.bar() == 2);         // OK
+
+            static assert(!__traits(compiles, pkg_import3b.mod.bar()));
+            // --> NG, pkg_import3b.mod is int variable in pkg_import3b/package.d
+        }
+    }
+}
+class Test2C
+{
+    import pkg_import3b.mod;    // bar()==3
+    class C
+    {
+        import pkg_import3b;        // foo()==1, bar()==2, int mod;
+        void test()
+        {
+            static assert(foo() == 1);                      // OK, foo in pkg_import3b
+            static assert(bar() == 2);                      // OK, bar in pkg_import3b
+
+            static assert(pkg_import3b.foo() == 1);         // OK
+            static assert(pkg_import3b.bar() == 2);         // OK
+
+            static assert(!__traits(compiles, pkg_import3b.mod.bar()));
+            // --> NG, pkg_import3b.mod is int variable in pkg_import3b/package.d
+        }
+    }
+}

--- a/test/compilable/testimport4.d
+++ b/test/compilable/testimport4.d
@@ -1,0 +1,11 @@
+auto splitter(R, Sep)(R r, Sep s)
+{
+}
+
+void main()
+{
+    import imports.imp4string;
+
+    string input, sep;
+    splitter(input, sep);
+}

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -284,6 +284,8 @@ string genTempFilename(string result_path)
 
 int system(string command)
 {
+    import core.stdc.stdlib;
+
     if (!command) return core.stdc.stdlib.system(null);
     const commandz = toStringz(command);
     auto status = core.stdc.stdlib.system(commandz);

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10528.d(19): Error: module fail10528 variable a10528.a is private
-fail_compilation/fail10528.d(20): Error: variable a10528.a is not accessible from module fail10528
-fail_compilation/fail10528.d(22): Error: module fail10528 enum member a10528.b is private
-fail_compilation/fail10528.d(23): Error: enum member a10528.b is not accessible from module fail10528
+fail_compilation/fail10528.d(19): Error: undefined identifier 'a'
+fail_compilation/fail10528.d(20): Error: undefined identifier 'a' in module 'a10528'
+fail_compilation/fail10528.d(22): Error: undefined identifier 'b'
+fail_compilation/fail10528.d(23): Error: undefined identifier 'b' in module 'a10528'
 fail_compilation/fail10528.d(25): Error: variable a10528.S.c is not accessible from module fail10528
 fail_compilation/fail10528.d(26): Error: variable a10528.S.c is not accessible from module fail10528
 fail_compilation/fail10528.d(28): Error: variable a10528.C.d is not accessible from module fail10528

--- a/test/fail_compilation/imports/a313.d
+++ b/test/fail_compilation/imports/a313.d
@@ -1,0 +1,3 @@
+module imports.a313;
+
+private import core.stdc.stdio;

--- a/test/fail_compilation/imports/a314.d
+++ b/test/fail_compilation/imports/a314.d
@@ -1,0 +1,5 @@
+module imports.a314;
+
+private static import core.stdc.stdio;
+private import io = core.stdc.stdio;
+private import core.stdc.stdio : printf;

--- a/test/fail_compilation/test313.d
+++ b/test/fail_compilation/test313.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test313.d(14): Error: 'printf' is not defined, perhaps you need to import core.stdc.stdio; ?
+fail_compilation/test313.d(15): Error: undefined identifier 'core'
+---
+*/
+module test313;
+
+import imports.a313;
+
+void main()
+{
+    printf("foo\n");
+    core.stdc.stdio.printf("foo\n");
+}

--- a/test/fail_compilation/test314.d
+++ b/test/fail_compilation/test314.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test314.d(15): Error: undefined identifier 'core'
+fail_compilation/test314.d(16): Error: undefined identifier 'io'
+---
+*/
+
+module test314;
+
+import imports.a314;
+
+void main()
+{
+    core.stdc.stdio.printf("This should not work.\n");
+    io.printf("This should not work.\n");
+    printf("This should not work.\n");
+}

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -1569,7 +1569,7 @@ struct X95
 
 void test95()
 {
-   X95.core.stdc.stdio.printf("hello\n");
+    static assert(!__traits(compiles, X95.core.stdc.stdio.printf("hello\n")));
 }
 
 /***************************************************/


### PR DESCRIPTION
[Issue 313](https://d.puremagic.com/issues/show_bug.cgi?id=313) - [module] Fully qualified names bypass private imports
[Issue 314](https://d.puremagic.com/issues/show_bug.cgi?id=314) - [module] Static, renamed, and selective imports are always public

Unlike #2256, this PR will keep existing name lookup rule and import behaviors that is unrelated to the issues.

Two main points:
1. Most of import declarations will insert their fully qualified names in local symbol table.

Currently, it is stored only in one place - `Module::modules`. After this change, in addition to that, each `ScopeDsymbol::symtab` will have the "local package tree" which represents the scope local imports.

For example:

``` d
class C {
    import core.stdc.stdio;
    import core.stdc.stdlib : malloc;
    import core.stdc.stdlib : free;
    void func() {
        import core.stdc.string;
    }
}
```

`symtab` of class `C` and `C.func` will have following package object trees:

```
// in C
Package('core') <----------+
 + Package('stdc') <-------|--+
    + Import('stdio')      |  |
    + Import('stdlib')     |  |
        names = ["malloc"] |  |
  +---- overnext           |  |
  |                        |  |
  +-> Import('stdlib')     |  |
        names = ["free"]   |  |
                           |  |
// in C.func()             |  |
Package('core') aliassym --+  |
 + Package('stdc') aliassym -+
    + Import('string')
```

In there, `Import` object will be the leaf of the tree.

It's done by `Import::addPackage`.
1. A part of local package tree will be merged into other tree.

This example case of public import should work.

``` d
module a;
public import std.stdio;
```

``` d
module b;
import a;
import std.algorithm;
std.stdio.writeln();    // point
```

In module b, 'std.stdio' should be visible. To realize it, import declarations will pull the fully qualified name of public imports in the imported module. Finally, module b will have the package tree:

```
Package('std')
 + Package('algorithm')
 + Package('stdio')   <--- Pulled from module a, by `import a;`
```

Same work is necessary on class inheritance. Public/protected imports in base class scope should be pulled in the derived class scope.
