### PR TITLE
[REG2.051] Issue 12420 - [AA] Can't set associative array with array as key value using key type

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10701,10 +10701,13 @@ Expression *IndexExp::modifiableLvalue(Scope *sc, Expression *e)
     modifiable = 1;
     Type *t1 = e1->type->toBasetype();
     if (t1->ty == Taarray)
-    {   TypeAArray *taa = (TypeAArray *)t1;
+    {
+        TypeAArray *taa = (TypeAArray *)t1;
         Type *t2b = e2->type->toBasetype();
-        if (t2b->ty == Tarray && t2b->nextOf()->isMutable())
+        if (t2b->ty == Tarray && !e2->implicitConvTo(taa->index->immutableOf()))
+        {
             error("associative arrays can only be assigned values with immutable keys, not %s", e2->type->toChars());
+        }
         e1 = e1->modifiableLvalue(sc, e1);
         return toLvalue(sc, e);
     }

--- a/test/fail_compilation/fail2954.d
+++ b/test/fail_compilation/fail2954.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2954.d(13): Error: associative arrays can only be assigned values with immutable keys, not char[]
+fail_compilation/fail2954.d(16): Error: associative arrays can only be assigned values with immutable keys, not const(char[])
+---
+*/
+void main()
+{
+    uint[string] hash;
+    char[] a = "abc".dup;
+
+    hash[a] = 42;
+
+    const ca = a;
+    hash[ca] = 42;
+
+    a[0] = 'A';
+    //writeln(hash.keys);
+}

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -94,7 +94,7 @@ void test2()
 void test4()
 {
     int[const(ubyte)[]] b;
-    const(ubyte)[] x;
+    immutable(ubyte)[] x;
     b[x] = 3;
     assert(b[x] == 3);
 }
@@ -114,7 +114,7 @@ void test5()
 void test6()
 {
     int[const(int)[]] b;
-    const(int)[] x;
+    immutable(int)[] x;
     b[x] = 3;
     assert(b[x] == 3);
 }
@@ -1244,6 +1244,15 @@ void test11730()
 }
 
 /************************************************/
+// 12420
+
+void test12420()
+{
+    int[char[]] aa;
+    aa[new char[1]] = 5;
+}
+
+/************************************************/
 
 int main()
 {
@@ -1292,6 +1301,7 @@ int main()
     test6799();
     test11359();
     test11730();
+    test12420();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12420

And add test case for [issue 2954](https://d.puremagic.com/issues/show_bug.cgi?id=2954).
