### PR TITLE
Fixed "@disable this" propagating through references (issue 8296)

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1170,8 +1170,7 @@ Lnomatch:
             else
             {
                 storage_class |= STCfield;
-                if ((tbn->ty == Tstruct && ((TypeStruct *)tbn)->sym->noDefaultCtor) ||
-                    (tbn->ty == Tclass  && ((TypeClass  *)tbn)->sym->noDefaultCtor))
+                if ((tbn->ty == Tstruct && ((TypeStruct *)tbn)->sym->noDefaultCtor))
                 {
                     if (!isThisDeclaration() && !init)
                         aad->noDefaultCtor = true;

--- a/test/compilable/test8296.d
+++ b/test/compilable/test8296.d
@@ -1,0 +1,33 @@
+struct bar2
+{
+  int i;
+  @disable this();
+  this(int i)
+  {
+    this.i = i;
+  }
+}
+
+class InnerBar {
+  bar2 b;
+  
+  this()
+  {
+    b = bar2(0);
+  }
+}
+
+struct bar1
+{
+  InnerBar b;
+}
+  
+class Foo
+{
+  bar1 m_bar1;
+}
+
+void main(string[] args)
+{
+  auto foo = new Foo();
+}


### PR DESCRIPTION
As classes are reference types, disabeling the default constructor should not propagate through struct fields wich are actually references to objects.
https://d.puremagic.com/issues/show_bug.cgi?id=8296

Without this fix it is not allowed to instaniate bar1 using default construction. But this should be allowed as bar1 only contains a single field which is a reference and thus can be (default) initialized with null.
