### PR TITLE
fix Issue 12523 - wrong type deduced for foreach ref argument

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1594,12 +1594,8 @@ Lagain:
                     value = var;
                     if (var->storage_class & STCref)
                     {
-                        /* Reference to immutable data should be marked as const
-                         */
                         if (aggr->checkModifiable(sc, 1) == 2)
                             var->storage_class |= STCctorinit;
-                        else if (!tn->isMutable())
-                            var->storage_class |= STCconst;
 
                         Type *t = tab->nextOf();
                         if (!t->immutableOf()->equals(arg->type->immutableOf()) ||

--- a/test/compilable/test12523.d
+++ b/test/compilable/test12523.d
@@ -1,0 +1,15 @@
+void test12523(inout(int))
+{
+    void check(T)()
+    {
+        T[] a;
+        foreach (ref e; a)
+            static assert(is(typeof(e) == T));
+    }
+
+    check!(int)();
+    check!(inout(int))();
+    check!(inout(const(int)))();
+    check!(const(int))();
+    check!(immutable(int))();
+}


### PR DESCRIPTION
- No need to change the storage class because the var type
  already has inferred modifiers.

[Issue 12523 – wrong foreach argument type with ref and inout](https://d.puremagic.com/issues/show_bug.cgi?id=12523)
