### PR TITLE
Issue 12534 - ICE on using expression tuple as type tuple

### DIFF
--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -767,6 +767,7 @@ public:
 
     void visit(Type *t)
     {
+        printf("t = %p, ty = %d\n", t, t->ty);
         assert(0);
     }
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -9049,13 +9049,13 @@ Type *TypeSlice::syntaxCopy()
 Type *TypeSlice::semantic(Loc loc, Scope *sc)
 {
     //printf("TypeSlice::semantic() %s\n", toChars());
-    next = next->semantic(loc, sc);
-    transitive();
-    //printf("next: %s\n", next->toChars());
+    Type *tn = next->semantic(loc, sc);
+    //printf("next: %s\n", tn->toChars());
 
-    Type *tbn = next->toBasetype();
+    Type *tbn = tn->toBasetype();
     if (tbn->ty != Ttuple)
-    {   error(loc, "can only slice tuple types, not %s", tbn->toChars());
+    {
+        error(loc, "can only slice tuple types, not %s", tbn->toChars());
         return Type::terror;
     }
     TypeTuple *tt = (TypeTuple *)tbn;
@@ -9069,19 +9069,23 @@ Type *TypeSlice::semantic(Loc loc, Scope *sc)
     uinteger_t i2 = upr->toUInteger();
 
     if (!(i1 <= i2 && i2 <= tt->arguments->dim))
-    {   error(loc, "slice [%llu..%llu] is out of range of [0..%u]", i1, i2, tt->arguments->dim);
+    {
+        error(loc, "slice [%llu..%llu] is out of range of [0..%u]", i1, i2, tt->arguments->dim);
         return Type::terror;
     }
+
+    next = tn;
+    transitive();
 
     Parameters *args = new Parameters;
     args->reserve((size_t)(i2 - i1));
     for (size_t i = (size_t)i1; i < (size_t)i2; i++)
-    {   Parameter *arg = (*tt->arguments)[i];
+    {
+        Parameter *arg = (*tt->arguments)[i];
         args->push(arg);
     }
-
-    Type *t = (new TypeTuple(args))->semantic(loc, sc);
-    return t;
+    Type *t = new TypeTuple(args);
+    return t->semantic(loc, sc);
 }
 
 void TypeSlice::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid)

--- a/test/fail_compilation/ice12534.d
+++ b/test/fail_compilation/ice12534.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice12534.d(14): Error: static assert  (is(exprs[0 .. 0])) is false
+---
+*/
+
+alias TypeTuple(T...) = T;
+
+void main()
+{
+    int x, y;
+    alias exprs = TypeTuple!(x, y);
+    static assert(is(exprs[0..0]));
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12534

TypeSlice::next should be handled as same as TypeSArray and TypeDArray -
if the next part is reduced to error type, it should not be returned to
the original field.
