### PR TITLE
Clarify what -noboundscheck actually does in help

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -445,7 +445,7 @@ Usage:\n\
   -main          add default main() (e.g. for unittesting)\n\
   -man           open web browser on manual page\n\
   -map           generate linker .map file\n\
-  -noboundscheck turns off array bounds checking for all functions\n\
+  -noboundscheck turns off array bounds checking for all functions (including @safe)\n\
   -O             optimize\n\
   -o-            do not write object file\n\
   -odobjdir      write object & library files to directory objdir\n\


### PR DESCRIPTION
I'd prefer to rename the option personally (`-nosafeboundscheck` or something) because it's too easy to assume you need to use it to turn off bounds checks at all (instead of just using `-release`). This should help clear up what it's for a little by mentioning @safe specifically.
