### PR TITLE
[REG2.066a] Issue 12390 - "has no effect in expression" diagnostic regression

### DIFF
--- a/test/fail_compilation/fail12390.d
+++ b/test/fail_compilation/fail12390.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12390.d(14): Error: == has no effect in expression (fun().i == 4)
+---
+*/
+
+struct S { int i; }
+
+S fun() { return S(42); }
+
+void main()
+{
+    fun().i == 4;
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12390

When value discarding check on statements, the side-effect check should not be done deeply.
