### PR TITLE
Issue 12460 - Crash with goto and static if

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -3736,7 +3736,7 @@ Statement *BreakStatement::semantic(Scope *sc)
             {
                 Statement *s = ls->statement;
 
-                if (!s->hasBreak())
+                if (!s || !s->hasBreak())
                     error("label '%s' has no break", ident->toChars());
                 else if (ls->tf != sc->tf)
                     error("cannot break out of finally block");
@@ -3829,7 +3829,7 @@ Statement *ContinueStatement::semantic(Scope *sc)
             {
                 Statement *s = ls->statement;
 
-                if (!s->hasContinue())
+                if (!s || !s->hasContinue())
                     error("label '%s' has no continue", ident->toChars());
                 else if (ls->tf != sc->tf)
                     error("cannot continue out of finally block");
@@ -4693,7 +4693,7 @@ LabelStatement::LabelStatement(Loc loc, Identifier *ident, Statement *statement)
 
 Statement *LabelStatement::syntaxCopy()
 {
-    LabelStatement *s = new LabelStatement(loc, ident, statement->syntaxCopy());
+    LabelStatement *s = new LabelStatement(loc, ident, statement ? statement->syntaxCopy() : NULL);
     return s;
 }
 

--- a/test/compilable/parse10199.d
+++ b/test/compilable/parse10199.d
@@ -4,3 +4,20 @@ void main()
     goto label;
 label:
 }
+
+/***************************************************/
+// 12460
+
+void f12460(T)()
+{
+    static if (is(T == int))
+    {
+        goto end;
+    }
+end:
+}
+
+void test12460()
+{
+    f12460!int();
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12460

By implementing issue 10199, `LabelStatement::statement` may be NULL. So `LabelStatement::syntaxCopy` should consider the case.
