### PR TITLE
Issue 12539 - Compiler crash when looking up a nonexistent tuple element in an associative array

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10269,7 +10269,8 @@ Expression *IndexExp::semantic(Scope *sc)
         }
 
         case Taarray:
-        {   TypeAArray *taa = (TypeAArray *)t1;
+        {
+            TypeAArray *taa = (TypeAArray *)t1;
             /* We can skip the implicit conversion if they differ only by
              * constness (Bugzilla 2684, see also bug 2954b)
              */
@@ -10293,7 +10294,8 @@ Expression *IndexExp::semantic(Scope *sc)
             TypeTuple *tup;
 
             if (e1->op == TOKtuple)
-            {   te = (TupleExp *)e1;
+            {
+                te = (TupleExp *)e1;
                 length = te->exps->dim;
             }
             else if (e1->op == TOKtype)
@@ -10319,7 +10321,7 @@ Expression *IndexExp::semantic(Scope *sc)
             {
                 error("array index [%llu] is outside array bounds [0 .. %llu]",
                         index, (ulonglong)length);
-                e = e1;
+                return new ErrorExp();
             }
             break;
         }

--- a/test/fail_compilation/fail125.d
+++ b/test/fail_compilation/fail125.d
@@ -2,11 +2,11 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail125.d(15): Error: array index [2] is outside array bounds [0 .. 2]
-fail_compilation/fail125.d(15): Error: cannot implicitly convert expression (tuple(a, b)) of type (int, int) to int
 fail_compilation/fail125.d(18): Error: template instance fail125.main.recMove!(1, a, b) error instantiating
 fail_compilation/fail125.d(25):        instantiated from here: recMove!(0, a, b)
 ---
 */
+
 
 template recMove(int i, X...)
 {

--- a/test/fail_compilation/ice12539.d
+++ b/test/fail_compilation/ice12539.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice12539.d(15): Error: array index [0] is outside array bounds [0 .. 0]
+---
+*/
+
+alias TypeTuple(E...) = E;
+
+void main ()
+{
+    int[string] map;
+
+    alias Foo = TypeTuple!();
+    auto a = map[Foo[0]];
+}


### PR DESCRIPTION
https://d.puremagic.com/issues/show_bug.cgi?id=12539
