### PR TITLE
[DDMD] Work around va_list mess

### DIFF
--- a/src/root/outbuffer.c
+++ b/src/root/outbuffer.c
@@ -304,7 +304,7 @@ void OutBuffer::align(size_t size)
     fill0(nbytes);
 }
 
-void OutBuffer::vprintf(const char *format, va_list args)
+void OutBuffer::vprintf(const char *format, void *args)
 {
     char buffer[128];
     char *p;
@@ -316,13 +316,13 @@ void OutBuffer::vprintf(const char *format, va_list args)
     for (;;)
     {
 #if _WIN32
-        count = _vsnprintf(p,psize,format,args);
+        count = _vsnprintf(p,psize,format,(va_list)args);
         if (count != -1)
             break;
         psize *= 2;
 #elif POSIX
         va_list va;
-        va_copy(va, args);
+        va_copy(va, (va_list)args);
 /*
   The functions vprintf(), vfprintf(), vsprintf(), vsnprintf()
   are equivalent to the functions printf(), fprintf(), sprintf(),

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -55,7 +55,7 @@ struct OutBuffer
     void write(RootObject *obj);
     void fill0(size_t nbytes);
     void align(size_t size);
-    void vprintf(const char *format, va_list args);
+    void vprintf(const char *format, void *args);
     void printf(const char *format, ...);
     void bracket(char left, char right);
     size_t bracket(size_t i, const char *left, size_t j, const char *right);


### PR DESCRIPTION
The type used for `va_list` in D may not (and frequently does not) match the one used in C++.  Since it is always `void*` or `char*` on x86 we can sidestep the mangling issue by just taking a `void*` and casting it to the correct type internally.
