### PR TITLE
fix strong purity deduction for pointers/arrays and const/immutable

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5779,7 +5779,7 @@ void TypeFunction::purityLevel()
                 Type *tn = t->nextOf();
                 if (tn)
                 {   tn = tn->toBasetype();
-                    if (tn->ty == Tpointer || tn->ty == Tarray)
+                    if (t->ty == Tpointer || t->ty == Tarray)
                     {   /* Accept immutable(T)* and immutable(T)[] as being strongly pure
                          */
                         if (tn->mod & MODimmutable)


### PR DESCRIPTION
I don't have an idea for a test case.
