### PR TITLE
Add -boundscheck=[on|safeonly|off] option

### DIFF
--- a/test/runnable/testbounds_off.d
+++ b/test/runnable/testbounds_off.d
@@ -1,0 +1,27 @@
+// REQUIRED_ARGS: -boundscheck=off
+// PERMUTE_ARGS: -inline -g -O
+
+import core.exception : RangeError;
+
+// Check for RangeError is thrown
+bool thrown(T)(lazy T cond)
+{
+    import core.exception;
+    bool f = false;
+    try { cond(); } catch (RangeError e) { f = true; }
+    return f;
+}
+
+@safe    int safeIndex   (int[] arr) { return arr[2]; }
+@trusted int trustedIndex(int[] arr) { return arr[2]; }
+@system  int systemIndex (int[] arr) { return arr[2]; }
+
+void main()
+{
+    int[3] data = [1,2,3];
+    int[] arr = data[0..2];
+
+    assert(arr.   safeIndex() == 3);
+    assert(arr.trustedIndex() == 3);
+    assert(arr. systemIndex() == 3);
+}

--- a/test/runnable/testbounds_on.d
+++ b/test/runnable/testbounds_on.d
@@ -1,0 +1,27 @@
+// REQUIRED_ARGS: -boundscheck=on
+// PERMUTE_ARGS: -inline -g -O
+
+import core.exception : RangeError;
+
+// Check for RangeError is thrown
+bool thrown(T)(lazy T cond)
+{
+    import core.exception;
+    bool f = false;
+    try { cond(); } catch (RangeError e) { f = true; }
+    return f;
+}
+
+@safe    int safeIndex   (int[] arr) { return arr[2]; }
+@trusted int trustedIndex(int[] arr) { return arr[2]; }
+@system  int systemIndex (int[] arr) { return arr[2]; }
+
+void main()
+{
+    int[3] data = [1,2,3];
+    int[] arr = data[0..2];
+
+    assert(arr.   safeIndex().thrown);
+    assert(arr.trustedIndex().thrown);
+    assert(arr. systemIndex().thrown);
+}

--- a/test/runnable/testbounds_safeonly.d
+++ b/test/runnable/testbounds_safeonly.d
@@ -1,0 +1,27 @@
+// REQUIRED_ARGS: -boundscheck=safeonly
+// PERMUTE_ARGS: -inline -g -O
+
+import core.exception : RangeError;
+
+// Check for RangeError is thrown
+bool thrown(T)(lazy T cond)
+{
+    import core.exception;
+    bool f = false;
+    try { cond(); } catch (RangeError e) { f = true; }
+    return f;
+}
+
+@safe    int safeIndex   (int[] arr) { return arr[2]; }
+@trusted int trustedIndex(int[] arr) { return arr[2]; }
+@system  int systemIndex (int[] arr) { return arr[2]; }
+
+void main()
+{
+    int[3] data = [1,2,3];
+    int[] arr = data[0..2];
+
+    assert(arr.   safeIndex().thrown);
+    assert(arr.trustedIndex() == 3);
+    assert(arr. systemIndex() == 3);
+}


### PR DESCRIPTION
Replaces `-noboundscheck` (which becomes deprecated)

Fixes #12550 (bugzilla is currently down for maintenance so I'll reproduce the rationale here)
1. What `-noboundscheck` actually does is confusing. Its purpose is to turn off bounds checking in `@safe` code (and all other code) which comes as a surprise to a lot of people. `-release` turns off bounds checking in non-`@safe` code (which also surprises some people) but leaves it on for `@safe` code.
2. There is currently no way to turn on bounds checking for release builds.
3. There is currently no way to turn off bounds checking for non-`@safe` code without pulling in everything else `-release` does (or turning off bounds checking for `@safe` code too).

Documentation pull request: https://github.com/D-Programming-Language/dlang.org/pull/537

**Needed before merge**
- [x] Unit tests
- [x] Update docs
