### PR TITLE
Issue 11906 - Compiler assertion when comparing function pointers

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1800,7 +1800,7 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                     FuncDeclaration *f = ve->var->isFuncDeclaration();
                     if (f)
                     {
-                        assert(0);      // should be SymOffExp instead
+                        assert(f->isImportedSymbol());
                         f = f->overloadExactMatch(tb->nextOf());
                         if (f)
                         {

--- a/test/compilable/ice11906.d
+++ b/test/compilable/ice11906.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+nothrow /*extern(Windows) */export int GetModuleHandleA(const char* lpModuleName);
+
+void main()
+{
+    /*extern(Windows) */int function(const char*) f;
+    assert(f != &GetModuleHandleA);
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=11906

If `f->isImportedSymbol()` is true, the translation from `AddrExp(VarExp(f))` to `SymOffExp(f)` in `AddrExp::optimize` will be skipped.
Therefore, the assertion is just wrong.
