### PR TITLE
Issue 12555 - Incorrect error ungagging for speculatively instantiated class

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -258,7 +258,7 @@ void ClassDeclaration::semantic(Scope *sc)
 
     if (!sc)
         sc = scope;
-    if (!parent && sc->parent && !sc->parent->isModule())
+    if (!parent && sc->parent)
         parent = sc->parent;
 
     type = type->semantic(loc, sc);

--- a/src/mars.c
+++ b/src/mars.c
@@ -78,7 +78,7 @@ Ungag Dsymbol::ungagSpeculative()
 {
     unsigned oldgag = global.gag;
 
-    if (global.isSpeculativeGagging() && !isSpeculative())
+    if (global.isSpeculativeGagging() && !isSpeculative() && !toParent2()->isFuncDeclaration())
         global.gag = 0;
 
     return Ungag(oldgag);
@@ -294,8 +294,8 @@ void verror(Loc loc, const char *format, va_list ap,
     }
     else
     {
-        //fprintf(stderr, "(gag:%d) ", global.gag);
-        //verrorPrint(loc, header, format, ap, p1, p2);
+        fprintf(stderr, "(gag:%d) ", global.gag);
+        verrorPrint(loc, header, format, ap, p1, p2);
         global.gaggedErrors++;
     }
     global.errors++;

--- a/src/template.c
+++ b/src/template.c
@@ -34,7 +34,7 @@
 #include "id.h"
 #include "attrib.h"
 
-#define LOG     0
+#define LOG     1
 
 #define IDX_NOTFOUND (0x12345678)               // index is not found
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1161,6 +1161,7 @@ void TemplateInstance::toObjFile(bool multiobj)
 #endif
     if (!isError(this) && members)
     {
+        printf("TemplateInstance::toObjFile('%s', this = %p)\n", toChars(), this);
         if (multiobj)
             // Append to list of object files to be written later
             obj_append(this);

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -583,3 +583,15 @@ static assert(__traits(isSame, cb12476, A12476!int));
 import imports.a12506;
 private           bool[9] r12506a = f12506!(i => true)(); // OK
 private immutable bool[9] r12506b = f12506!(i => true)(); // OK <- error
+
+/***************************************************/
+// 12555
+
+class A12555(T)
+{
+    Undef12555 error;
+}
+
+static assert(!__traits(compiles, {
+    class C : A12555!C  { }
+}));


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12555

`ungagSpeculative()` should do nothing for function local symbols.
