### PR TITLE
Issue 10169 - duplicate error message: member is not accessible

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7838,14 +7838,13 @@ Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident, int 
     }
 
     if (e->op == TOKdotexp)
-    {   DotExp *de = (DotExp *)e;
-
+    {
+        DotExp *de = (DotExp *)e;
         if (de->e1->op == TOKimport)
         {
             assert(0);  // cannot find a case where this happens; leave
                         // assert in until we do
             ScopeExp *se = (ScopeExp *)de->e1;
-
             s = se->sds->search(e->loc, ident);
             e = de->e1;
             goto L1;
@@ -7999,9 +7998,9 @@ L1:
         if (v->toParent() != sym)
             sym->error(e->loc, "'%s' is not a member", v->toChars());
 
+#if 0
         // *(&e + offset)
         accessCheck(e->loc, sc, e, d);
-#if 0
         Expression *b = new AddrExp(e->loc, e);
         b->type = e->type->pointerTo();
         b = new AddExp(e->loc, b, new IntegerExp(e->loc, v->offset, Type::tint32));

--- a/test/fail_compilation/diag10169.d
+++ b/test/fail_compilation/diag10169.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag10169.d(11): Error: struct imports.a10169.B member x is not accessible
+---
+*/
+import imports.a10169;
+
+void main()
+{
+    auto a = B.init.x;
+}

--- a/test/fail_compilation/imports/a10169.d
+++ b/test/fail_compilation/imports/a10169.d
@@ -1,0 +1,6 @@
+module imports.a10169;
+
+struct B
+{
+    private int x;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=10169

The second `accessCheck` call is done in `DotVarExp::semantic`.
