### PR TITLE
excise .dup and .idup from compiler

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -778,33 +778,6 @@ MATCH implicitConvTo(Expression *e, Type *t)
                 return;
             }
 
-            /* The result of arr.dup and arr.idup can be unique essentially.
-             * So deal with this case specially.
-             */
-            if (!e->f && e->e1->op == TOKvar && ((VarExp *)e->e1)->var->ident == Id::adDup &&
-                t->toBasetype()->ty == Tarray)
-            {
-                assert(e->type->toBasetype()->ty == Tarray);
-                assert(e->arguments->dim == 2);
-                Expression *eorg = (*e->arguments)[1];
-                Type *tn = t->nextOf();
-                if (e->type->nextOf()->implicitConvTo(tn) < MATCHconst)
-                {
-                    /* If the operand is an unique array literal, then allow conversion.
-                     */
-                    if (eorg->op != TOKarrayliteral)
-                        return;
-                    Expressions *elements = ((ArrayLiteralExp *)eorg)->elements;
-                    for (size_t i = 0; i < elements->dim; i++)
-                    {
-                        if (!(*elements)[i]->implicitConvTo(tn))
-                            return;
-                    }
-                }
-                result = e->type->immutableOf()->implicitConvTo(t);
-                return;
-            }
-
             /* Conversion is 'const' conversion if:
              * 1. function is pure (weakly pure is ok)
              * 2. implicit conversion only fails because of mod bits

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -144,8 +144,6 @@ Msgtable msgtable[] =
 
     { "sort" },
     { "reverse" },
-    { "dup" },
-    { "idup" },
 
     { "property" },
     { "safe" },
@@ -243,7 +241,6 @@ Msgtable msgtable[] =
     { "FpopFront", "popFront" },
     { "FpopBack", "popBack" },
 
-    { "adDup", "_adDupT" },
     { "adReverse", "_adReverse" },
 
     // For internal functions

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5166,25 +5166,6 @@ public:
         if (result)
             return;
 
-        // Inline .dup. Special case because it needs the return type.
-        if (!pthis && fd->ident == Id::adDup && e->arguments && e->arguments->dim == 2)
-        {
-            Expression *ex = (*e->arguments)[1];
-            ex = ex->interpret(istate);
-            if (exceptionOrCantInterpret(ex))
-            {
-                result = ex;
-                return;
-            }
-            if (ex != EXP_CANT_INTERPRET)
-            {
-                if (ex->op == TOKslice)
-                    ex = resolveSlice(ex);
-                ex = paintTypeOntoLiteral(e->type, copyLiteral(ex));
-            }
-            result = ex;
-            return;
-        }
         if (!fd->fbody)
         {
             e->error("%s cannot be interpreted at compile time,"

--- a/src/nogc.c
+++ b/src/nogc.c
@@ -145,22 +145,6 @@ public:
     }
     void visit(CallExp *e)
     {
-        if (e->e1 && e->e1->op == TOKvar)
-        {
-            VarExp *ve = (VarExp*)e->e1;
-            if (ve->var && ve->var->isFuncDeclaration() && ve->var->isFuncDeclaration()->ident)
-            {
-                Identifier *ident = ve->var->isFuncDeclaration()->ident;
-
-                if (ident == Id::adDup)
-                {
-                    if (func->setGCUse(e->loc, "'dup' causes gc allocation"))
-                    {
-                        e->error("Can not use 'dup' in @nogc code");
-                    }
-                }
-            }
-        }
     }
     void visit(CatExp *e)
     {

--- a/test/compilable/nogc_warn.d
+++ b/test/compilable/nogc_warn.d
@@ -19,10 +19,6 @@ compilable/nogc_warn.d(76): vgc: Concatenation may cause gc allocation
 compilable/nogc_warn.d(79): vgc: Concatenation may cause gc allocation
 compilable/nogc_warn.d(80): vgc: Concatenation may cause gc allocation
 compilable/nogc_warn.d(85): vgc: Using closure causes gc allocation
-compilable/nogc_warn.d(100): vgc: 'dup' causes gc allocation
-compilable/nogc_warn.d(101): vgc: 'dup' causes gc allocation
-compilable/nogc_warn.d(107): vgc: 'dup' causes gc allocation
-compilable/nogc_warn.d(108): vgc: 'dup' causes gc allocation
 compilable/nogc_warn.d-mixin-114(114): vgc: 'new' causes gc allocation
 compilable/nogc_warn.d(120): vgc: Indexing an associative array may cause gc allocation
 ---

--- a/test/fail_compilation/fail9562.d
+++ b/test/fail_compilation/fail9562.d
@@ -6,8 +6,8 @@ TEST_OUTPUT:
 fail_compilation/fail9562.d(17): Error: int[] is not an expression
 fail_compilation/fail9562.d(18): Error: int[] is not an expression
 fail_compilation/fail9562.d(19): Error: int[] is not an expression
-fail_compilation/fail9562.d(20): Error: int[] is not an expression
-fail_compilation/fail9562.d(21): Error: int[] is not an expression
+fail_compilation/fail9562.d(20): Error: no property 'dup' for type 'int[]'
+fail_compilation/fail9562.d(21): Error: no property 'idup' for type 'int[]'
 ---
 */
 

--- a/test/runnable/implicit.d
+++ b/test/runnable/implicit.d
@@ -161,6 +161,26 @@ void testDIP29_4()
 
 /***********************************/
 
+int[] test6(int[] a) pure @safe nothrow
+{
+    return a.dup;
+}
+
+/***********************************/
+
+int*[] pureFoo() pure { return null; }
+
+
+void testDIP29_5() pure
+{
+    { char[] s; immutable x = s.dup; }
+    { immutable x = (cast(int*[])null).dup; }
+    { immutable x = pureFoo(); }
+    { immutable x = pureFoo().dup; }
+}
+
+/***********************************/
+
 void main()
 {
     test1();
@@ -172,6 +192,7 @@ void main()
     testDIP29_2();
     testDIP29_3();
     testDIP29_4();
+    testDIP29_5();
 
     writefln("Success");
 }

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1255,7 +1255,7 @@ void test18()
     }
     assert(dollar!q{@property size_t opDollar() { return 8; }}() == 8);
     assert(dollar!q{template opDollar(size_t dim) { enum opDollar = dim; }}() == 0);
-    assert(dollar!q{const size_t opDollar = 8;}() == 8);
+    assert(dollar!q{static const size_t opDollar = 8;}() == 8);
     assert(dollar!q{enum opDollar = 8;}() == 8);
     assert(dollar!q{size_t length() { return 8; } alias length opDollar;}() == 8);
 }


### PR DESCRIPTION
.dup and .idup are now in druntime as templates.

Requires https://github.com/D-Programming-Language/druntime/pull/761
