### PR TITLE
Issue 12586 - redundant error messages for tuple index exceeding

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3981,7 +3981,9 @@ void TypeSArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
             if (d >= td->objects->dim)
             {
                 error(loc, "tuple index %llu exceeds length %u", d, td->objects->dim);
-                goto Ldefault;
+                *ps = NULL;
+                *pt = Type::terror;
+                return;
             }
             RootObject *o = (*td->objects)[(size_t)d];
             if (o->dyncast() == DYNCAST_DSYMBOL)

--- a/test/fail_compilation/ice12574.d
+++ b/test/fail_compilation/ice12574.d
@@ -1,9 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12574.d(41): Error: tuple index 2 exceeds length 2
-fail_compilation/ice12574.d(41): Error: tuple index 2 exceeds 2
-fail_compilation/ice12574.d(54): Error: template instance ice12574.reduce!("a", "a").reduce!(Tuple!(int, int, int)) error instantiating
+fail_compilation/ice12574.d(40): Error: tuple index 2 exceeds length 2
+fail_compilation/ice12574.d(53): Error: template instance ice12574.reduce!("a", "a").reduce!(Tuple!(int, int, int)) error instantiating
 ---
 */
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12586
