### PR TITLE
Fixed offsets in comments for enum TOK

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -80,7 +80,7 @@ enum TOK
         TOKindex,       TOKis,
         TOKtobool,
 
-// 60
+// 63
         // NCEG floating point compares
         // !<>=     <>    <>=    !>     !>=   !<     !<=   !<>
         TOKunord,TOKlg,TOKleg,TOKule,TOKul,TOKuge,TOKug,TOKue,
@@ -100,7 +100,7 @@ enum TOK
         TOKquestion,    TOKandand,      TOKoror,
         TOKpreplusplus, TOKpreminusminus,
 
-// 106
+// 110
         // Numeric literals
         TOKint32v, TOKuns32v,
         TOKint64v, TOKuns64v,
@@ -128,7 +128,7 @@ enum TOK
         TOKcomplex32, TOKcomplex64, TOKcomplex80,
         TOKchar, TOKwchar, TOKdchar, TOKbool,
 
-// 152
+// 155
         // Aggregates
         TOKstruct, TOKclass, TOKinterface, TOKunion, TOKenum, TOKimport,
         TOKtypedef, TOKalias, TOKoverride, TOKdelegate, TOKfunction,


### PR DESCRIPTION
The comments were wrong. Updated to the right enum values.
