### PR TITLE
[Refactoring] Remove Scope::offset

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -106,10 +106,7 @@ void AttribDeclaration::setScopeNewSc(Scope *sc,
             s->setScope(newsc); // yes, the only difference from semanticNewSc()
         }
         if (newsc != sc)
-        {
-            sc->offset = newsc->offset;
             newsc->pop();
-        }
     }
 }
 
@@ -141,10 +138,7 @@ void AttribDeclaration::semanticNewSc(Scope *sc,
             s->semantic(newsc);
         }
         if (newsc != sc)
-        {
-            sc->offset = newsc->offset;
             newsc->pop();
-        }
     }
 }
 
@@ -215,7 +209,8 @@ void AttribDeclaration::setFieldOffset(AggregateDeclaration *ad, unsigned *poffs
     if (d)
     {
         for (size_t i = 0; i < d->dim; i++)
-        {   Dsymbol *s = (*d)[i];
+        {
+            Dsymbol *s = (*d)[i];
             s->setFieldOffset(ad, poffset, isunion);
         }
     }
@@ -806,7 +801,6 @@ void AnonDeclaration::semantic(Scope *sc)
         sc = sc->push();
         sc->stc &= ~(STCauto | STCscope | STCstatic | STCtls | STCgshared);
         sc->inunion = isunion;
-        sc->offset = 0;
         sc->flags = 0;
 
         for (size_t i = 0; i < decl->dim; i++)
@@ -1633,10 +1627,7 @@ void UserAttributeDeclaration::setScope(Scope *sc)
             s->setScope(newsc); // yes, the only difference from semantic()
         }
         if (newsc != sc)
-        {
-            sc->offset = newsc->offset;
             newsc->pop();
-        }
     }
 }
 
@@ -1661,10 +1652,7 @@ void UserAttributeDeclaration::semantic(Scope *sc)
             s->semantic(newsc);
         }
         if (newsc != sc)
-        {
-            sc->offset = newsc->offset;
             newsc->pop();
-        }
     }
 }
 
@@ -1691,10 +1679,7 @@ void UserAttributeDeclaration::semantic2(Scope *sc)
             s->semantic2(newsc);
         }
         if (newsc != sc)
-        {
-            sc->offset = newsc->offset;
             newsc->pop();
-        }
     }
 }
 

--- a/src/scope.c
+++ b/src/scope.c
@@ -73,7 +73,6 @@ Scope::Scope()
     this->explicitProtection = 0;
     this->stc = 0;
     this->depmsg = NULL;
-    this->offset = 0;
     this->inunion = 0;
     this->nofree = 0;
     this->noctor = 0;
@@ -123,7 +122,6 @@ Scope::Scope(Scope *enclosing)
     this->explicitProtection = enclosing->explicitProtection;
     this->depmsg = enclosing->depmsg;
     this->stc = enclosing->stc;
-    this->offset = 0;
     this->inunion = enclosing->inunion;
     this->nofree = 0;
     this->noctor = enclosing->noctor;

--- a/src/scope.h
+++ b/src/scope.h
@@ -80,11 +80,6 @@ struct Scope
     Statement *scontinue;       // enclosing statement that supports "continue"
     ForeachStatement *fes;      // if nested function for ForeachStatement, this is it
     Scope *callsc;              // used for __FUNCTION__, __PRETTY_FUNCTION__ and __MODULE__
-    unsigned offset;            // next offset to use in aggregate
-                                // This really shouldn't be a part of Scope, because it requires
-                                // semantic() to be done in the lexical field order. It should be
-                                // set in a pass after semantic() on all fields so they can be
-                                // semantic'd in any order.
     int inunion;                // we're processing members of a union
     int nofree;                 // set if shouldn't free it
     int noctor;                 // set if constructor calls aren't allowed

--- a/src/struct.c
+++ b/src/struct.c
@@ -773,7 +773,6 @@ void StructDeclaration::semantic(Scope *sc)
         fields.setDim(0);
         structsize = 0;
         alignsize = 0;
-//        structalign = 0;
 
         scope = scx ? scx : sc->copy();
         scope->setNoFree();
@@ -924,7 +923,8 @@ void StructDeclaration::finalizeSize(Scope *sc)
     unsigned offset = 0;
     bool isunion = isUnionDeclaration() != NULL;
     for (size_t i = 0; i < members->dim; i++)
-    {   Dsymbol *s = (*members)[i];
+    {
+        Dsymbol *s = (*members)[i];
         s->setFieldOffset(this, &offset, isunion);
     }
     if (sizeok == SIZEOKfwd)

--- a/src/template.c
+++ b/src/template.c
@@ -7541,14 +7541,7 @@ Dsymbol *TemplateInstance::toAlias()
         // Maybe we can resolve it
         if (scope)
         {
-            /* Anything that affects scope->offset must be
-             * done in lexical order. Fwd ref error if it is affected, otherwise allow.
-             */
-            unsigned offset = scope->offset;
-            Scope *sc = scope;
             semantic(scope);
-//            if (offset != sc->offset)
-//                inst = NULL;            // trigger fwd ref error
         }
         if (!inst)
         {
@@ -7966,10 +7959,7 @@ void TemplateMixin::semantic(Scope *sc)
 #if LOG
     printf("\tdo semantic() on template instance members '%s'\n", toChars());
 #endif
-    Scope *sc2;
-    sc2 = argscope->push(this);
-    sc2->offset = sc->offset;
-
+    Scope *sc2 = argscope->push(this);
     size_t deferred_dim = Module::deferred.dim;
 
     static int nest;
@@ -8000,8 +7990,6 @@ void TemplateMixin::semantic(Scope *sc)
     }
 
     nest--;
-
-    sc->offset = sc2->offset;
 
     if (!sc->func && Module::deferred.dim > deferred_dim)
     {
@@ -8160,7 +8148,8 @@ void TemplateMixin::setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, 
     if (members)
     {
         for (size_t i = 0; i < members->dim; i++)
-        {   Dsymbol *s = (*members)[i];
+        {
+            Dsymbol *s = (*members)[i];
             //printf("\t%s\n", s->toChars());
             s->setFieldOffset(ad, poffset, isunion);
         }


### PR DESCRIPTION
Currently instance field offset determination is handled by `Dsymbol::setFieldOffset` and `AggregateDeclaration::placeField`. So we can remove `Scope::offset`.
