### PR TITLE
Issue 12212 - Static array assignment makes slice implicitly

### DIFF
--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -427,8 +427,11 @@ STATIC void chkrd(elem *n,list_t rdlist)
             auto y = x;
         }
      */
-    error(n->Esrcpos.Sfilename, n->Esrcpos.Slinnum, n->Esrcpos.Scharnum,
-        "variable %s used before set", sv->Sident);
+    if (type_size(sv->Stype) != 0)
+    {
+        error(n->Esrcpos.Sfilename, n->Esrcpos.Slinnum, n->Esrcpos.Scharnum,
+            "variable %s used before set", sv->Sident);
+    }
 #endif
 
     sv->Sflags |= SFLnord;              // no redundant messages

--- a/src/canthrow.c
+++ b/src/canthrow.c
@@ -104,10 +104,15 @@ bool canThrow(Expression *e, FuncDeclaration *func, bool mustNotThrow)
 
             /* Element-wise assignment could invoke postblits.
              */
-            if (ae->e1->op != TOKslice)
+            Type *t;
+            if (ae->type->toBasetype()->ty == Tsarray)
+                t = ae->type;
+            else if (ae->e1->op == TOKslice)
+                t = ((SliceExp *)ae->e1)->e1->type;
+            else
                 return;
 
-            Type *tv = ae->e1->type->toBasetype()->nextOf()->baseElemOf();
+            Type *tv = t->baseElemOf();
             if (tv->ty != Tstruct)
                 return;
             StructDeclaration *sd = ((TypeStruct *)tv)->sym;

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1310,6 +1310,7 @@ Lnomatch:
             Expression *e = tv->defaultInitLiteral(loc);
             Expression *e1 = new VarExp(loc, this);
             e = new ConstructExp(loc, e1, e);
+            e->op = TOKblit;
             e = e->semantic(sc);
             init = new ExpInitializer(loc, e);
             goto Ldtor;
@@ -1327,6 +1328,7 @@ Lnomatch:
             Expression *e1;
             e1 = new VarExp(loc, this);
             e = new ConstructExp(loc, e1, e);
+            e->op = TOKblit;
             e->type = e1->type;         // don't type check this, it would fail
             init = new ExpInitializer(loc, e);
             goto Ldtor;

--- a/src/expression.c
+++ b/src/expression.c
@@ -11146,59 +11146,36 @@ Expression *AssignExp::semantic(Scope *sc)
         Expression *e2x = e2;
         Type *t2 = e2x->type->toBasetype();
 
-        if (e1x->op == TOKindex &&
-            ((IndexExp *)e1x)->e1->type->toBasetype()->ty == Taarray)
+        if (op == TOKconstruct)
         {
-            // Assignment to an AA of fixed-length arrays.
-            // Convert T[n][U] = T[] into T[n][U] = T[n]
-            e2x = e2x->implicitCastTo(sc, e1x->type);
-            if (e2x->op == TOKerror)
-                return e2x;
-        }
-        else if (op == TOKconstruct)
-        {
-            if (e2x->op == TOKslice)
+            if (e2x->implicitConvTo(e1x->type))
             {
-                SliceExp *se = (SliceExp *)e2x;
-                if (se->lwr == NULL && se->e1->implicitConvTo(e1x->type))
+                if (op != TOKblit &&
+                    (e2x->op == TOKslice && ((UnaExp *)e2x)->e1->isLvalue() ||
+                     e2x->op == TOKcast  && ((UnaExp *)e2x)->e1->isLvalue() ||
+                     e2x->op != TOKslice && e2x->isLvalue()))
                 {
-                    e2x = se->e1;
+                    e1x->checkPostblit(sc, t1);
                 }
-            }
-            if (e2x->op == TOKcall && !e2x->isLvalue() &&
-                e2x->implicitConvTo(e1x->type))
-            {
-                // Keep the expression form for NRVO
-                e2x = e2x->implicitCastTo(sc, e1x->type);
-                if (e2x->op == TOKerror)
-                    return e2x;
             }
             else
             {
-                /* Rewrite:
+                /* Block/element-wise initializing
+                 * Rewrite:
                  *  sa = e;     as: sa[] = e;
-                 *  sa = arr;   as: sa[] = arr[];
-                 *  sa = [...]; as: sa[] = [...];
+                 *  sa = da;    as: sa[] = da;
                  */
-                // Convert e2 to e2[], if t2 is impllicitly convertible to t1.
-                if (e2x->op != TOKarrayliteral && t2->ty == Tsarray && t2->implicitConvTo(t1))
+
+                // If multidimensional static array, treat as one large array
+                dinteger_t dim = ((TypeSArray *)t1)->dim->toInteger();
+                Type *t = t1;
+                while (1)
                 {
-                    e2x = new SliceExp(e2x->loc, e2x, NULL, NULL);
-                    e2x = e2x->semantic(sc);
-                }
-                else if (!e2x->implicitConvTo(e1x->type))
-                {
-                    // If multidimensional static array, treat as one large array
-                    dinteger_t dim = ((TypeSArray *)t1)->dim->toInteger();
-                    Type *t = t1;
-                    while (1)
-                    {
-                        t = t->nextOf()->toBasetype();
-                        if (t->ty != Tsarray)
-                            break;
-                        dim *= ((TypeSArray *)t)->dim->toInteger();
-                        e1x->type = t->nextOf()->sarrayOf(dim);
-                    }
+                    t = t->nextOf()->toBasetype();
+                    if (t->ty != Tsarray)
+                        break;
+                    dim *= ((TypeSArray *)t)->dim->toInteger();
+                    e1x->type = t->nextOf()->sarrayOf(dim);
                 }
 
                 // Convert e1 to e1[]
@@ -11208,49 +11185,37 @@ Expression *AssignExp::semantic(Scope *sc)
         }
         else if (op == TOKassign)
         {
-            /* Rewrite:
-             *  sa = e;     as: sa[] = e;
-             *  sa = arr;   as: sa[] = arr[];
-             *  sa = [...]; as: sa[] = [...];
-             */
-
-            // Convert e2 to e2[], unless e2-> e1[0]
-            if (e2x->op != TOKarrayliteral && t2->ty == Tsarray && !t2->implicitConvTo(t1->nextOf()))
+            if (e2x->implicitConvTo(e1x->type))
             {
-                e2x = new SliceExp(e2x->loc, e2x, NULL, NULL);
-                e2x = e2x->semantic(sc);
-            }
-            else if (0 && global.params.warnings && !global.gag && op == TOKassign &&
-                     e2x->op != TOKarrayliteral && e2x->op != TOKstring &&
-                     !e2x->implicitConvTo(t1))
-            {   // Disallow sa = da (Converted to sa[] = da[])
-                // Disallow sa = e  (Converted to sa[] = e)
-                const char* e1str = e1x->toChars();
-                const char* e2str = e2x->toChars();
-                if (e2x->op == TOKslice || e2x->implicitConvTo(t1->nextOf()))
-                    warning("explicit element-wise assignment (%s)[] = %s is better than %s = %s",
-                        e1str, e2str, e1str, e2str);
-                else
-                    warning("explicit element-wise assignment (%s)[] = (%s)[] is better than %s = %s",
-                        e1str, e2str, e1str, e2str);
-
-                // Convert e2 to e2[] to avoid duplicated error message.
-                if (t2->ty == Tarray)
+                if (op != TOKblit &&
+                    (e2x->op == TOKslice && ((UnaExp *)e2x)->e1->isLvalue() ||
+                     e2x->op == TOKcast  && ((UnaExp *)e2x)->e1->isLvalue() ||
+                     e2x->op != TOKslice && e2x->isLvalue()))
                 {
-                    e2x = new SliceExp(e2x->loc, e2x, NULL, NULL);
-                    e2x = e2x->semantic(sc);
+                    e1x->checkPostblit(sc, t1);
                 }
             }
+            else
+            {
+                /* Block/element-wise assignment
+                 * Rewrite:
+                 *  sa = e;     as: sa[] = e;
+                 *  sa = da;    as: sa[] = da;
+                 */
 
-            // Convert e1 to e1[]
-            e1x = new SliceExp(e1x->loc, e1x, NULL, NULL);
-            e1x = e1x->semantic(sc);
+                // Convert e1 to e1[]
+                e1x = new SliceExp(e1x->loc, e1x, NULL, NULL);
+                e1x = e1x->semantic(sc);
+            }
         }
         else
         {
             assert(op == TOKblit);
 
-            if (!e2x->implicitConvTo(e1x->type))
+            if (e2x->implicitConvTo(e1x->type))
+            {
+            }
+            else
             {
                 /* Internal handling for the default initialization
                  * of multi-dimensional static array:
@@ -11267,9 +11232,10 @@ Expression *AssignExp::semantic(Scope *sc)
                     dim *= ((TypeSArray *)t)->dim->toInteger();
                     e1x->type = t->nextOf()->sarrayOf(dim);
                 }
+
+                e1x = new SliceExp(loc, e1x, NULL, NULL);
+                e1x = e1x->semantic(sc);
             }
-            e1x = new SliceExp(loc, e1x, NULL, NULL);
-            e1x = e1x->semantic(sc);
         }
         if (e1x->op == TOKerror)
             return e1x;
@@ -11339,19 +11305,7 @@ Expression *AssignExp::semantic(Scope *sc)
         ismemset = 1;   // make it easy for back end to tell what this is
         e2 = e2->implicitCastTo(sc, t1->nextOf());
         if (op != TOKblit && e2->isLvalue())
-            e2->checkPostblit(sc, t1->nextOf());
-    }
-    else if (t1->ty == Tsarray)
-    {
-        /* Should have already converted e1 => e1[]
-         * unless it is an AA
-         */
-        if (e1->op == TOKindex && t2->ty == Tsarray &&
-            ((IndexExp *)e1)->e1->type->toBasetype()->ty == Taarray)
-        {
-        }
-        else
-            assert(op != TOKassign);
+            e1->checkPostblit(sc, t1->nextOf());
     }
     else if (e1->op == TOKslice &&
              (t2->ty == Tarray || t2->ty == Tsarray) &&
@@ -11395,7 +11349,7 @@ Expression *AssignExp::semantic(Scope *sc)
              e2->op == TOKcast  && ((UnaExp *)e2)->e1->isLvalue() ||
              e2->op != TOKslice && e2->isLvalue()))
         {
-            e2->checkPostblit(sc, t2->nextOf());
+            e1->checkPostblit(sc, t1->nextOf());
         }
         if (0 && global.params.warnings && !global.gag && op == TOKassign &&
             e2->op != TOKslice && e2->op != TOKassign &&

--- a/src/inline.c
+++ b/src/inline.c
@@ -1896,6 +1896,8 @@ static Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
             ve->type = arg->type;
 
             ei->exp = new ConstructExp(vto->loc, ve, arg);
+            if ((vfrom->storage_class & (STCout | STCref)) == 0)
+                ei->exp->op = TOKblit;
             ei->exp->type = ve->type;
             //ve->type->print();
             //arg->type->print();

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4068,6 +4068,15 @@ public:
                 newval, wantRef, isBlockAssignment, e);
             return;
         }
+        else if (e1->op == TOKarrayliteral && e1->type->toBasetype()->ty == Tsarray)
+        {
+            // Bugzilla 12212: Support direct assignment of static arrays.
+            // Rewrite as: (e1[] = newval)
+            SliceExp *se = new SliceExp(e1->loc, e1, NULL, NULL);
+            result = interpretAssignToSlice(e->loc, se,
+                newval, wantRef, isBlockAssignment, e);
+            return;
+        }
         else
         {
             e->error("%s cannot be evaluated at compile time", e->toChars());

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3656,7 +3656,10 @@ Expression *TypeVector::dotExp(Scope *sc, Expression *e, Identifier *ident, int 
 #endif
     if (ident == Id::array)
     {
-        e = e->castTo(sc, basetype);
+        //e = e->castTo(sc, basetype);
+        // Keep lvalue-ness
+        e = e->copy();
+        e->type = basetype;
         return e;
     }
     if (ident == Id::offsetof || ident == Id::offset || ident == Id::stringof)

--- a/test/fail_compilation/fail11426.d
+++ b/test/fail_compilation/fail11426.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail11426.d(15): Error: cannot implicitly convert expression (udarr) of type uint[] to int[]
-fail_compilation/fail11426.d(16): Error: cannot implicitly convert expression (usarr[]) of type uint[] to int[]
+fail_compilation/fail11426.d(16): Error: cannot implicitly convert expression (usarr) of type uint[1] to int[]
 fail_compilation/fail11426.d(18): Error: cannot implicitly convert expression (udarr) of type uint[] to int[]
 fail_compilation/fail11426.d(19): Error: cannot implicitly convert expression (usarr) of type uint[1] to int[]
 ---

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -852,6 +852,94 @@ void test12131() pure
 }
 
 /***************************************************/
+// 12212
+
+void test12212()
+{
+    struct S
+    {
+        int x, y;
+        static int cpctor;
+        this(this) { cpctor++; }
+    }
+
+    void funcVal(E)(E[3] x) {}
+    auto funcRef(E)(ref E[3] x) { return &x; }
+    ref get(E)(ref E[3] a){ return a; }
+
+    {
+        int[3] a, b;
+        funcVal(a = b);
+
+        auto p = funcRef(a = b);
+        assert(p == &a);
+    }
+
+    {
+        S.cpctor = 0;
+
+        S[3] a, b;
+        assert(S.cpctor == 0);
+
+        S[3] c = a;
+        //printf("cpctpr = %d\n", S.cpctor);
+        assert(S.cpctor == 3);
+        S.cpctor = 0;
+
+        c = a;
+        //printf("cpctpr = %d\n", S.cpctor);
+        assert(S.cpctor == 3);
+        S.cpctor = 0;
+
+        c = (a = b);
+        //printf("cpctpr = %d\n", S.cpctor);
+        assert(S.cpctor == 6);
+        S.cpctor = 0;
+
+        c = (get(a) = b);
+        //printf("cpctpr = %d\n", S.cpctor);
+        assert(S.cpctor == 6);
+        S.cpctor = 0;
+    }
+    {
+        S.cpctor = 0;
+
+        S[3] a, b;
+        assert(S.cpctor == 0);
+
+        funcVal(a = b);
+        //printf("cpctpr = %d\n", S.cpctor);
+        assert(S.cpctor == 6);
+        S.cpctor = 0;
+
+        funcVal(get(a) = b);
+        //printf("cpctpr = %d\n", S.cpctor);
+        assert(S.cpctor == 6);
+        S.cpctor = 0;
+    }
+    {
+        S.cpctor = 0;
+
+        S[3] a, b;
+        assert(S.cpctor == 0);
+
+        S[3]* p;
+
+        p = funcRef(a = b);
+        //printf("cpctpr = %d\n", S.cpctor);
+        assert(p == &a);
+        assert(S.cpctor == 3);
+        S.cpctor = 0;
+
+        p = funcRef(get(a) = b);
+        assert(p == &a);
+        //printf("cpctpr = %d\n", S.cpctor);
+        assert(S.cpctor == 3);
+        S.cpctor = 0;
+    }
+}
+
+/***************************************************/
 
 int main()
 {
@@ -875,6 +963,7 @@ int main()
     test9416();
     test11187();
     test12131();
+    test12212();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12212

Directly handle static array assigments.

As a byproduct, some array literal allocation will be removed. For example:

``` d
int[3] sa;
sa = [1,2,3];
// ArrayLiteralExp is changed to be typed as static array.
// Therefore it will be allocated on stack.
```
