### PR TITLE
Add support for static if, debug, and version blocks within inline asm

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -4286,6 +4286,160 @@ Expression *Parser::parseDefaultInitExp()
 }
 
 /*****************************************
+ * Parses the body of an inline asm statement.
+ */
+
+CompoundStatement *Parser::parseAsmStatementBody(size_t pnestlevel)
+{
+    // Parse the asm block into a sequence of AsmStatements,
+    // each AsmStatement is one instruction.
+    // Separate out labels.
+    // Defer parsing of AsmStatements until semantic processing.
+
+    Loc labelloc;
+    Loc loc = token.loc;
+
+    Token *toklist = NULL;
+    Token **ptoklist = &toklist;
+    Identifier *label = NULL;
+    Condition *cond = NULL;
+    Statements *statements = new Statements();
+    size_t nestlevel = pnestlevel;
+    while (1)
+    {
+        switch (token.value)
+        {
+            case TOKstatic:
+            {
+                // Look ahead to see if it is a static if,
+                // otherwise it's an error.
+                Token *t = peek(&token);
+                if (t->value != TOKif)
+                    goto Ldefault;
+
+                cond = parseStaticIfCondition();
+                goto Lconditional;
+            }
+
+            case TOKversion:
+                nextToken();
+                cond = parseVersionCondition();
+                goto Lconditional;
+
+            case TOKdebug:
+                nextToken();
+                cond = parseDebugCondition();
+                goto Lconditional;
+
+            Lconditional:
+            {
+                Loc lookingForElseSave = lookingForElse;
+                lookingForElse = loc;
+                Statement *ifbody = parseAsmStatementBody(0);
+                lookingForElse = lookingForElseSave;
+                Statement *elsebody = NULL;
+                if (token.value == TOKelse)
+                {
+                    Loc elseloc = token.loc;
+                    nextToken();
+                    elsebody = parseAsmStatementBody(0);
+                    checkDanglingElse(elseloc);
+                }
+                statements->push(new ConditionalStatement(loc, cond, ifbody, elsebody));
+                cond = NULL;
+                continue;
+            }
+
+            case TOKidentifier:
+                if (!toklist)
+                {
+                    // Look ahead to see if it is a label
+                    Token *t = peek(&token);
+                    if (t->value == TOKcolon)
+                    {   // It's a label
+                        label = token.ident;
+                        labelloc = token.loc;
+                        nextToken();
+                        nextToken();
+                        continue;
+                    }
+                }
+                goto Ldefault;
+
+            case TOKlcurly:
+                ++nestlevel;
+                nextToken();
+                continue;
+
+            case TOKrcurly:
+                if (nestlevel > 1)
+                {
+                    nextToken();
+                    --nestlevel;
+                    continue;
+                }
+
+                if (toklist || label)
+                {
+                    // This will occur if a static if block was the last
+                    // in a statement.
+                    // Create AsmStatement from list of tokens we've saved
+                    Statement *s = new AsmStatement(token.loc, toklist);
+                    toklist = NULL;
+                    ptoklist = &toklist;
+                    if (label)
+                    {
+                        s = new LabelStatement(labelloc, label, s);
+                        label = NULL;
+                    }
+                    statements->push(s);
+                }
+                // Make sure we're not consuming a closing curly
+                // that doesn't belong to us.
+                if (nestlevel != 0)
+                    nextToken();
+                break;
+
+            case TOKsemicolon:
+                if (toklist || label)
+                {
+                    // Create AsmStatement from list of tokens we've saved
+                    Statement *s = new AsmStatement(token.loc, toklist);
+                    toklist = NULL;
+                    ptoklist = &toklist;
+                    if (label)
+                    {
+                        s = new LabelStatement(labelloc, label, s);
+                        label = NULL;
+                    }
+                    statements->push(s);
+                }
+                nextToken();
+                if (nestlevel == 0)
+                    break;
+                continue;
+
+            case TOKeof:
+                /* { */
+                error("matching '}' expected, not end of file");
+                return NULL;
+
+            default:
+            Ldefault:
+                *ptoklist = new Token();
+                memcpy(*ptoklist, &token, sizeof(Token));
+                ptoklist = &(*ptoklist)->next;
+                *ptoklist = NULL;
+
+                nextToken();
+                continue;
+        }
+        break;
+    }
+    return new CompoundStatement(loc, statements); 
+}
+
+/*****************************************
  */
 
 void Parser::checkDanglingElse(Loc elseloc)
@@ -5265,96 +5419,12 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
 
         case TOKasm:
         {
-            // Parse the asm block into a sequence of AsmStatements,
-            // each AsmStatement is one instruction.
-            // Separate out labels.
-            // Defer parsing of AsmStatements until semantic processing.
-
-            Loc labelloc;
-
+            // The body of the asm statement doesn't include 
+            // the outer-most curly brackets.
             nextToken();
             check(TOKlcurly);
-            Token *toklist = NULL;
-            Token **ptoklist = &toklist;
-            Identifier *label = NULL;
-            Statements *statements = new Statements();
-            size_t nestlevel = 0;
-            while (1)
-            {
-                switch (token.value)
-                {
-                    case TOKidentifier:
-                        if (!toklist)
-                        {
-                            // Look ahead to see if it is a label
-                            Token *t = peek(&token);
-                            if (t->value == TOKcolon)
-                            {   // It's a label
-                                label = token.ident;
-                                labelloc = token.loc;
-                                nextToken();
-                                nextToken();
-                                continue;
-                            }
-                        }
-                        goto Ldefault;
-
-                    case TOKlcurly:
-                        ++nestlevel;
-                        goto Ldefault;
-
-                    case TOKrcurly:
-                        if (nestlevel > 0)
-                        {
-                            --nestlevel;
-                            goto Ldefault;
-                        }
-
-                        if (toklist || label)
-                        {
-                            error("asm statements must end in ';'");
-                        }
-                        break;
-
-                    case TOKsemicolon:
-                        if (nestlevel != 0)
-                            error("mismatched number of curly brackets");
-
-                        s = NULL;
-                        if (toklist || label)
-                        {
-                            // Create AsmStatement from list of tokens we've saved
-                            s = new AsmStatement(token.loc, toklist);
-                            toklist = NULL;
-                            ptoklist = &toklist;
-                            if (label)
-                            {   s = new LabelStatement(labelloc, label, s);
-                                label = NULL;
-                            }
-                            statements->push(s);
-                        }
-                        nextToken();
-                        continue;
-
-                    case TOKeof:
-                        /* { */
-                        error("matching '}' expected, not end of file");
-                        goto Lerror;
-
-                    default:
-                    Ldefault:
-                        *ptoklist = Token::alloc();
-                        memcpy(*ptoklist, &token, sizeof(Token));
-                        ptoklist = &(*ptoklist)->next;
-                        *ptoklist = NULL;
-
-                        nextToken();
-                        continue;
-                }
-                break;
-            }
-            s = new CompoundStatement(loc, statements);
-            nextToken();
+            s = parseAsmStatementBody(1);
+            // The closing curly is already consumed.
             break;
         }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -125,6 +125,7 @@ public:
     Statement *parseStatement(int flags, const utf8_t** endPtr = NULL);
     Initializer *parseInitializer();
     Expression *parseDefaultInitExp();
+    CompoundStatement *parseAsmStatementBody(size_t nestlevel);
     void check(Loc loc, TOK value);
     void check(TOK value);
     void check(TOK value, const char *string);

--- a/test/compilable/iasm_staticcond.d
+++ b/test/compilable/iasm_staticcond.d
@@ -1,0 +1,131 @@
+﻿
+version (D_InlineAsm_X86)
+    version = TestInlineAsm;
+else version (D_InlineAsm_X86_64)
+    version = TestInlineAsm;
+else
+    pragma(msg, "Inline asm not supported, not testing.");
+
+version (TestInlineAsm)
+{
+    void testInlineAsm()
+    {
+        asm
+        {
+            naked;
+
+            // static if - brackets
+            static if (1 != 0)
+                mov EAX, ECX;
+
+            mov EDX, ECX;
+
+            // static if - brackets + else
+            static if (3 == 3)
+                add EAX, 0x03;
+            else
+                mov EDX, EAX;
+
+            // static if + brackets
+            static if (0 == 1)
+            {
+                mov EAX, ECX;
+            }
+
+            nop;
+
+            // static if + brackets + else
+            static if (4 == 2)
+            {
+                add EAX, 0x0548;
+            }
+            else
+            {
+                sub EAX, 0x0548;
+            }
+
+            // Note that this needs to be 
+            // the last block in the asm
+            // block in order to test for
+            // a specific regression.
+
+            // chained static if
+            static if (3 < 2)
+                nop;
+            else static if (5 > 3)
+                nop;
+            else
+                ret 3;
+        }
+
+        asm
+        {
+            nop;
+            version (D_InlineAsm_X86_64)
+                push RBP;
+
+            version (D_InlineAsm_X86)
+                push ESP;
+            else
+                push RBP;
+
+            version (D_HardFloat)
+            {
+                finit;
+                fadd ST, ST(1);
+            }
+
+            // Take for example a 128-bit mem->mem
+            // copy operation.
+            version (D_SIMD)
+            {
+                movdqa XMM1, [ESP + 16];
+                movdqa [EBP + 16], XMM1;
+            }
+            else version(D_InlineAsm_X86_64)
+            {
+                mov RAX, [ESP + 8];
+                mov [EBP + 8], RAX;
+                mov RAX, [ESP + 16];
+                mov [EBP + 16], RAX;
+            }
+            else
+            {
+                mov EAX, [ESP + 4];
+                mov [EBP + 4], EAX;
+                mov EAX, [ESP + 8];
+                mov [EBP + 8], EAX;
+                mov EAX, [ESP + 12];
+                mov [EBP + 12], EAX;
+                mov EAX, [ESP + 16];
+                mov [EBP + 16], EAX;
+            }
+
+            debug (1)
+                nop;
+
+            debug (2)
+            {
+                nop;
+            }
+
+            debug (3)
+                nop;
+            else
+                mov EAX, ECX;
+
+            debug (4)
+            {
+                mov EAX, ECX;
+            }
+            else debug (5)
+            {
+                mov EAX, EBX;
+            }
+            else
+            {
+                mov EAX, EDX;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a fairly simply change to the parser to allow `static if`, `debug`, and `version` blocks within inline asm statements. Allowing these within inline asm statements allows for significantly cleaner templated inline asm. Feel free to discuss whether this is actually a good thing or not. A test suite is included.
