### PR TITLE
[Refactoring] around lambda type deduction

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -2194,23 +2194,19 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
  * Set type inference target
  *      t       Target type
  *      flag    1: don't put an error when inference fails
- *      sc      it is used for the semantic of t, when != NULL
- *      tparams template parameters should be inferred
  */
 
-Expression *inferType(Expression *e, Type *t, int flag, Scope *sc, TemplateParameters *tparams)
+Expression *inferType(Expression *e, Type *t, int flag)
 {
     class InferType : public Visitor
     {
     public:
         Type *t;
         int flag;
-        Scope *sc;
-        TemplateParameters *tparams;
         Expression *result;
 
-        InferType(Type *t, int flag, Scope *sc, TemplateParameters *tparams)
-            : t(t), flag(flag), sc(sc), tparams(tparams)
+        InferType(Type *t, int flag)
+            : t(t), flag(flag)
         {
             result = NULL;
         }
@@ -2234,7 +2230,7 @@ Expression *inferType(Expression *e, Type *t, int flag, Scope *sc, TemplateParam
                         Expression *e = (*ale->elements)[i];
                         if (e)
                         {
-                            e = inferType(e, tn, flag, sc, tparams);
+                            e = inferType(e, tn, flag);
                             (*ale->elements)[i] = e;
                         }
                     }
@@ -2254,10 +2250,11 @@ Expression *inferType(Expression *e, Type *t, int flag, Scope *sc, TemplateParam
                     Type *ti = taa->index;
                     Type *tv = taa->nextOf();
                     for (size_t i = 0; i < aale->keys->dim; i++)
-                    {   Expression *e = (*aale->keys)[i];
+                    {
+                        Expression *e = (*aale->keys)[i];
                         if (e)
                         {
-                            e = inferType(e, ti, flag, sc, tparams);
+                            e = inferType(e, ti, flag);
                             (*aale->keys)[i] = e;
                         }
                     }
@@ -2265,7 +2262,8 @@ Expression *inferType(Expression *e, Type *t, int flag, Scope *sc, TemplateParam
                     {
                         Expression *e = (*aale->values)[i];
                         if (e)
-                        {   e = inferType(e, tv, flag, sc, tparams);
+                        {
+                            e = inferType(e, tv, flag);
                             (*aale->values)[i] = e;
                         }
                     }
@@ -2340,10 +2338,6 @@ Expression *inferType(Expression *e, Type *t, int flag, Scope *sc, TemplateParam
                                 {
                                     p = Parameter::getNth(tfv->parameters, u);
                                     Type *tprm = p->type;
-                                    if (reliesOnTident(tprm, tparams))
-                                        goto L1;
-                                    if (sc)
-                                        tprm = tprm->semantic(fe->loc, sc);
                                     if (tprm->ty == Terror)
                                         goto L1;
                                     tiargs->push(tprm);
@@ -2408,14 +2402,14 @@ Expression *inferType(Expression *e, Type *t, int flag, Scope *sc, TemplateParam
             if (t)
             {
                 t = t->toBasetype();
-                ce->e1 = inferType(ce->e1, t, flag, sc, tparams);
-                ce->e2 = inferType(ce->e2, t, flag, sc, tparams);
+                ce->e1 = inferType(ce->e1, t, flag);
+                ce->e2 = inferType(ce->e2, t, flag);
             }
             result = ce;
         }
     };
 
-    InferType v(t, flag, sc, tparams);
+    InferType v(t, flag);
     e->accept(&v);
     return v.result;
 }

--- a/src/cast.c
+++ b/src/cast.c
@@ -86,8 +86,8 @@ Expression *implicitCastTo(Expression *e, Scope *sc, Type *t)
                      */
                     e->error("forward reference to type %s", t->toChars());
                 }
-                else if (t->reliesOnTident())
-                    e->error("forward reference to type %s", t->reliesOnTident()->toChars());
+                else if (Type *tx = reliesOnTident(t))
+                    e->error("forward reference to type %s", tx->toChars());
 
                 //printf("type %p ty %d deco %p\n", type, type->ty, type->deco);
                 //type = type->semantic(loc, sc);
@@ -2340,7 +2340,7 @@ Expression *inferType(Expression *e, Type *t, int flag, Scope *sc, TemplateParam
                                 {
                                     p = Parameter::getNth(tfv->parameters, u);
                                     Type *tprm = p->type;
-                                    if (tprm->reliesOnTident(tparams))
+                                    if (reliesOnTident(tprm, tparams))
                                         goto L1;
                                     if (sc)
                                         tprm = tprm->semantic(fe->loc, sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -1468,7 +1468,8 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                 {
                     case Tsarray:
                     case Tarray:
-                    {   // Create a static array variable v of type arg->type
+                    {
+                        // Create a static array variable v of type arg->type
                         Identifier *id = Lexer::uniqueId("__arrayArg");
                         Type *t = new TypeSArray(((TypeArray *)tb)->next, new IntegerExp(nargs - i));
                         t = t->semantic(loc, sc);
@@ -1477,28 +1478,23 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                         v->storage_class |= STCtemp | STCctfe;
                         v->semantic(sc);
                         v->parent = sc->parent;
-                        //sc->insert(v);
 
-                        Expression *c = new DeclarationExp(Loc(), v);
+                        Expression *c = new DeclarationExp(loc, v);
                         c->type = v->type;
 
                         for (size_t u = i; u < nargs; u++)
                         {
                             Expression *a = (*arguments)[u];
                             TypeArray *ta = (TypeArray *)tb;
-                            a = inferType(a, ta->next);
                             (*arguments)[u] = a;
-                            if (tret && !ta->next->equals(a->type))
+                            if (tret && a->implicitConvTo(tret))
                             {
-                                if (tret->toBasetype()->ty == Tvoid ||
-                                    a->implicitConvTo(tret))
-                                {
-                                    a = a->implicitCastTo(sc, tret);
-                                    a = a->optimize(WANTvalue);
-                                    a = toDelegate(a, sc);
-                                }
+                                a = a->implicitCastTo(sc, tret);
+                                a = a->optimize(WANTvalue);
+                                a = toDelegate(a, sc);
                             }
-
+                            else
+                                a = a->implicitCastTo(sc, ta->next);
                             Expression *e = new VarExp(loc, v);
                             e = new IndexExp(loc, e, new IntegerExp(u + 1 - nparams));
                             ConstructExp *ae = new ConstructExp(loc, e, a);
@@ -1513,7 +1509,8 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                         break;
                     }
                     case Tclass:
-                    {   /* Set arg to be:
+                    {
+                        /* Set arg to be:
                          *      new Tclass(arg0, arg1, ..., argn)
                          */
                         Expressions *args = new Expressions();
@@ -1525,7 +1522,8 @@ Type *functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                     }
                     default:
                         if (!arg)
-                        {   error(loc, "not enough arguments");
+                        {
+                            error(loc, "not enough arguments");
                             return Type::terror;
                         }
                         break;
@@ -5659,29 +5657,25 @@ Expression *FuncExp::semantic(Scope *sc)
             td->semantic(sc);
             type = Type::tvoid; // temporary type
 
-            if (fd->treq)  // defer type determination
-                e = inferType(this, fd->treq);
+            if (fd->treq)       // defer type determination
+            {
+                FuncExp *fe;
+                if (matchType(fd->treq, sc, &fe) > MATCHnomatch)
+                    e = fe;
+                else
+                    e = new ErrorExp();
+            }
             goto Ldone;
         }
 
         unsigned olderrors = global.errors;
         fd->semantic(sc);
-        //fd->parent = sc->parent;
-        if (olderrors != global.errors)
-        {
-        }
-        else
+        if (olderrors == global.errors)
         {
             fd->semantic2(sc);
-            // no errors or need to infer return type
-            if ( (olderrors == global.errors) ||
-                (fd->type && fd->type->ty == Tfunction && !fd->type->nextOf()))
-            {
+            if (olderrors == global.errors)
                 fd->semantic3(sc);
-            }
         }
-
-        // need to infer return type
         if (olderrors != global.errors)
         {
             if (fd->type && fd->type->ty == Tfunction && !fd->type->nextOf())
@@ -5714,7 +5708,8 @@ Expression *FuncExp::semantic(Scope *sc)
              * So, should keep fd->tok == TOKreserve if fd->treq == NULL.
              */
             if (fd->treq && fd->treq->ty == Tpointer)
-            {   // change to non-nested
+            {
+                // change to non-nested
                 fd->tok = TOKfunction;
                 fd->vthis = NULL;
             }
@@ -5725,6 +5720,146 @@ Ldone:
     sc->flags |=  SCOPEctfe;
     sc = sc->endCTFE();
     return e;
+}
+
+MATCH FuncExp::matchType(Type *to, Scope *sc, FuncExp **presult, int flag)
+{
+    //printf("FuncExp::matchType('%s'), to=%s\n", type ? type->toChars() : "null", to->toChars());
+    if (presult)
+        *presult = NULL;
+
+    TypeFunction *tof = NULL;
+    if (to->ty == Tdelegate)
+    {
+        if (tok == TOKfunction)
+        {
+            if (!flag)
+                error("cannot match function literal to delegate type '%s'", to->toChars());
+            return MATCHnomatch;
+        }
+        tof = (TypeFunction *)to->nextOf();
+    }
+    else if (to->ty == Tpointer && to->nextOf()->ty == Tfunction)
+    {
+        if (tok == TOKdelegate)
+        {
+            if (!flag)
+                error("cannot match delegate literal to function pointer type '%s'", to->toChars());
+            return MATCHnomatch;
+        }
+        tof = (TypeFunction *)to->nextOf();
+    }
+
+    if (td)
+    {
+        if (!tof)
+        {
+        L1:
+            if (!flag)
+                error("cannot infer parameter types from %s", to->toChars());
+            return MATCHnomatch;
+        }
+
+        // Parameter types inference from 'tof'
+        assert(td->scope);
+        TypeFunction *tf = (TypeFunction *)fd->type;
+        //printf("\ttof = %s\n", tof->toChars());
+        //printf("\ttf  = %s\n", tf->toChars());
+        size_t dim = Parameter::dim(tf->parameters);
+
+        if (Parameter::dim(tof->parameters) != dim ||
+            tof->varargs != tf->varargs)
+            goto L1;
+
+        Objects *tiargs = new Objects();
+        tiargs->reserve(td->parameters->dim);
+
+        for (size_t i = 0; i < td->parameters->dim; i++)
+        {
+            TemplateParameter *tp = (*td->parameters)[i];
+            size_t u = 0;
+            for (; u < dim; u++)
+            {
+                Parameter *p = Parameter::getNth(tf->parameters, u);
+                if (p->type->ty == Tident &&
+                    ((TypeIdentifier *)p->type)->ident == tp->ident)
+                {
+                    break;
+                }
+            }
+            assert(u < dim);
+            Parameter *pto = Parameter::getNth(tof->parameters, u);
+            Type *t = pto->type;
+            if (t->ty == Terror)
+                goto L1;
+            tiargs->push(t);
+        }
+
+        // Set target of return type inference
+        if (!tf->next && tof->next)
+            fd->treq = to;
+
+        TemplateInstance *ti = new TemplateInstance(loc, td, tiargs);
+        Expression *ex = (new ScopeExp(loc, ti))->semantic(td->scope);
+
+        // Reset inference target for the later re-semantic
+        fd->treq = NULL;
+
+        if (ex->op == TOKerror)
+            return MATCHnomatch;
+        if (ex->op != TOKfunction)
+            goto L1;
+        return ((FuncExp *)ex)->matchType(to, sc, presult, flag);
+    }
+
+    if (!tof || !tof->next)
+        return MATCHnomatch;
+
+    assert(type && type != Type::tvoid);
+    TypeFunction *tfx = (TypeFunction *)fd->type;
+
+    Type *tx;
+    if (tok == TOKdelegate ||
+        tok == TOKreserved && (type->ty == Tdelegate ||
+                               type->ty == Tpointer && to->ty == Tdelegate))
+    {
+        // Allow conversion from implicit function pointer to delegate
+        tx = new TypeDelegate(tfx);
+        tx->deco = tx->merge()->deco;
+    }
+    else
+    {
+        assert(tok == TOKfunction ||
+               tok == TOKreserved && type->ty == Tpointer);
+        tx = tfx->pointerTo();
+    }
+    //printf("\ttx = %s, to = %s\n", tx->toChars(), to->toChars());
+
+    MATCH m = tx->implicitConvTo(to);
+    if (m > MATCHnomatch)
+    {
+        bool convertMatch = (type->ty != to->ty);
+
+        // MATCHexact:      exact type match
+        // MATCHconst:      covairiant type match (eg. attributes difference)
+        // MATCHconvert:    context conversion
+        m = convertMatch ? MATCHconvert : tx->equals(to) ? MATCHexact : MATCHconst;
+
+        if (presult)
+        {
+            (*presult) = (FuncExp *)copy();
+            (*presult)->type = to;
+
+            // Bugzilla 12508: Tweak function body for covariant returns.
+            (*presult)->fd->modifyReturns(sc, tof->next);
+        }
+    }
+    else if (!flag)
+    {
+        error("cannot implicitly convert expression (%s) of type %s to %s",
+                toChars(), tx->toChars(), to->toChars());
+    }
+    return m;
 }
 
 // used from CallExp::semantic()
@@ -11685,19 +11820,17 @@ Expression *CatAssignExp::semantic(Scope *sc)
     e1 = e1->modifiableLvalue(sc, e1);
     if (e1->op == TOKerror)
         return e1;
+    if (e2->op == TOKerror)
+        return e2;
 
-    Type *tb1 = e1->type->toBasetype();
-    Type *tb1next = tb1->nextOf();
-
-    e2 = inferType(e2, tb1next);
-    if (!e2->rvalue())
-        return new ErrorExp();
     if (isNonAssignmentArrayOp(e2))
     {
         error("array operation %s without assignment not implemented", e2->toChars());
         return new ErrorExp();
     }
 
+    Type *tb1 = e1->type->toBasetype();
+    Type *tb1next = tb1->nextOf();
     Type *tb2 = e2->type->toBasetype();
 
     if ((tb1->ty == Tarray) &&
@@ -11712,7 +11845,6 @@ Expression *CatAssignExp::semantic(Scope *sc)
         // Append array
         e1->checkPostblit(sc, tb1next);
         e2 = e2->castTo(sc, e1->type);
-        type = e1->type;
     }
     else if ((tb1->ty == Tarray) &&
         e2->implicitConvTo(tb1next)
@@ -11722,7 +11854,6 @@ Expression *CatAssignExp::semantic(Scope *sc)
         e2->checkPostblit(sc, tb2);
         e2 = e2->castTo(sc, tb1next);
         e2 = e2->isLvalue() ? callCpCtor(sc, e2) : valueNoDtor(e2);
-        type = e1->type;
     }
     else if (tb1->ty == Tarray &&
         (tb1next->ty == Tchar || tb1next->ty == Twchar) &&
@@ -11731,7 +11862,6 @@ Expression *CatAssignExp::semantic(Scope *sc)
        )
     {   // Append dchar to char[] or wchar[]
         e2 = e2->castTo(sc, Type::tdchar);
-        type = e1->type;
 
         /* Do not allow appending wchar to char[] because if wchar happens
          * to be a surrogate pair, nothing good can result.
@@ -11739,10 +11869,13 @@ Expression *CatAssignExp::semantic(Scope *sc)
     }
     else
     {
-        if (tb1 != Type::terror && tb2 != Type::terror)
-            error("cannot append type %s to type %s", tb2->toChars(), tb1->toChars());
+        error("cannot append type %s to type %s", tb2->toChars(), tb1->toChars());
         return new ErrorExp();
     }
+    if (!e2->rvalue())
+        return new ErrorExp();
+
+    type = e1->type;
     return reorderSettingAAElem(sc);
 }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -109,7 +109,7 @@ Expression *op_overload(Expression *e, Scope *sc);
 Type *toStaticArrayType(SliceExp *e);
 Expression *scaleFactor(BinExp *be, Scope *sc);
 Expression *typeCombine(BinExp *be, Scope *sc);
-Expression *inferType(Expression *e, Type *t, int flag = 0, Scope *sc = NULL, TemplateParameters *tparams = NULL);
+Expression *inferType(Expression *e, Type *t, int flag = 0);
 Expression *semanticTraits(TraitsExp *e, Scope *sc);
 Type *getIndirection(Type *t);
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -687,6 +687,7 @@ public:
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *semantic(Scope *sc, Expressions *arguments);
+    MATCH matchType(Type *to, Scope *sc, FuncExp **pfe, int flag = 0);
     char *toChars();
 
     void accept(Visitor *v) { v->visit(this); }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5870,14 +5870,6 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
         {
         Expression *arg = (*args)[u];
         assert(arg);
-
-        if (arg->op == TOKfunction)
-        {
-            arg = inferType(((FuncExp *)arg), p->type, 1);
-            if (!arg)
-                goto L1;    // try typesafe variadics
-        }
-
         //printf("arg: %s, type: %s\n", arg->toChars(), arg->type->toChars());
 
         Type *targ = arg->type;
@@ -5981,17 +5973,12 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
                         if (sz != nargs - u)
                             goto Nomatch;
                     case Tarray:
-                    {   TypeArray *ta = (TypeArray *)tb;
+                    {
+                        TypeArray *ta = (TypeArray *)tb;
                         for (; u < nargs; u++)
                         {
                             Expression *arg = (*args)[u];
                             assert(arg);
-                            if (arg->op == TOKfunction)
-                            {
-                                arg = inferType(((FuncExp *)arg), tb->nextOf(), 1);
-                                if (!arg)
-                                    goto Nomatch;
-                            }
 
                             /* If lazy array of delegates,
                              * convert arg(s) to delegate(s)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -51,8 +51,8 @@ struct Symbol;
 class TypeTuple;
 
 void semanticTypeInfo(Scope *sc, Type *t);
-MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL);
-Type *reliesOnTident(Type *t, TemplateParameters *tparams = NULL);
+MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL, size_t inferStart = 0);
+Type *reliesOnTident(Type *t, TemplateParameters *tparams = NULL, size_t iStart = 0);
 
 enum ENUMTY
 {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -52,6 +52,7 @@ class TypeTuple;
 
 void semanticTypeInfo(Scope *sc, Type *t);
 MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL);
+Type *reliesOnTident(Type *t, TemplateParameters *tparams = NULL);
 
 enum ENUMTY
 {
@@ -336,7 +337,6 @@ public:
     void genTypeInfo(Scope *sc);
     virtual TypeInfoDeclaration *getTypeInfoDeclaration();
     virtual int builtinTypeInfo();
-    virtual Type *reliesOnTident(TemplateParameters *tparams = NULL);
     virtual int hasWild();
     virtual Expression *toExpression();
     virtual int hasPointers();
@@ -376,7 +376,6 @@ public:
     TypeNext(TY ty, Type *next);
     void toDecoBuffer(OutBuffer *buf, int flag);
     void checkDeprecated(Loc loc, Scope *sc);
-    Type *reliesOnTident(TemplateParameters *tparams = NULL);
     int hasWild();
     Type *nextOf();
     Type *makeConst();
@@ -440,7 +439,6 @@ public:
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     char *toChars();
     void toDecoBuffer(OutBuffer *buf, int flag);
-    Type *reliesOnTident(TemplateParameters *tparams);
     bool isintegral();
     bool isfloating();
     bool isscalar();
@@ -540,7 +538,6 @@ public:
     bool isZeroInit(Loc loc);
     bool checkBoolean();
     TypeInfoDeclaration *getTypeInfoDeclaration();
-    Type *reliesOnTident(TemplateParameters *tparams);
     Expression *toExpression();
     int hasPointers();
     MATCH implicitConvTo(Type *to);
@@ -644,7 +641,6 @@ public:
     void purityLevel();
     void toDecoBuffer(OutBuffer *buf, int flag);
     TypeInfoDeclaration *getTypeInfoDeclaration();
-    Type *reliesOnTident(TemplateParameters *tparams = NULL);
     bool hasLazyParameters();
     bool parameterEscapes(Parameter *p);
     Type *addStorageClass(StorageClass stc);
@@ -714,7 +710,6 @@ public:
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Dsymbol *toDsymbol(Scope *sc);
     Type *semantic(Loc loc, Scope *sc);
-    Type *reliesOnTident(TemplateParameters *tparams = NULL);
     Expression *toExpression();
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -734,7 +729,6 @@ public:
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
-    Type *reliesOnTident(TemplateParameters *tparams = NULL);
     Expression *toExpression();
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -942,7 +936,6 @@ public:
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     bool equals(RootObject *o);
-    Type *reliesOnTident(TemplateParameters *tparams = NULL);
     void toDecoBuffer(OutBuffer *buf, int flag);
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);


### PR DESCRIPTION
In git-head, `deduceType` can directly handle argument expression in IFTI. So move some code in it, and simplify `inferType` function.
