### PR TITLE
Issue 8309 - ICE in typeMerge on 'void main(){auto x = [()=>1.0, ()=>1];}'

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -2633,6 +2633,9 @@ Lagain:
         {
             TypeFunction *tf1 = (TypeFunction *)t1n;
             TypeFunction *tf2 = (TypeFunction *)t2n;
+            tf1->purityLevel();
+            tf2->purityLevel();
+
             TypeFunction *d = (TypeFunction *)tf1->syntaxCopy();
 
             if (tf1->purity != tf2->purity)

--- a/src/cast.c
+++ b/src/cast.c
@@ -2833,14 +2833,17 @@ Lcc:
 
             if (i2)
             {
+                e2 = e2->castTo(sc, t2);
                 goto Lt2;
             }
             else if (i1)
             {
+                e1 = e1->castTo(sc, t1);
                 goto Lt1;
             }
             else if (t1->ty == Tclass && t2->ty == Tclass)
-            {   TypeClass *tc1 = (TypeClass *)t1;
+            {
+                TypeClass *tc1 = (TypeClass *)t1;
                 TypeClass *tc2 = (TypeClass *)t2;
 
                 /* Pick 'tightest' type
@@ -2849,7 +2852,8 @@ Lcc:
                 ClassDeclaration *cd2 = tc2->sym->baseClass;
 
                 if (cd1 && cd2)
-                {   t1 = cd1->type;
+                {
+                    t1 = cd1->type;
                     t2 = cd2->type;
                 }
                 else if (cd1)

--- a/src/expression.c
+++ b/src/expression.c
@@ -1144,14 +1144,10 @@ Expressions *arrayExpressionToCommonType(Scope *sc, Expressions *exps, Type **pt
                 condexp.loc = e->loc;
                 condexp.semantic(sc);
                 (*exps)[j0] = condexp.e1;
-                if (condexp.e1->op == TOKfunction &&
-                    condexp.e2->op == TOKfunction)
-                    t0 = condexp.e2->type;
-                else
-                    t0 = condexp.type;
                 e = condexp.e2;
                 j0 = i;
                 e0 = e;
+                t0 = e0->type;
             }
         }
         else

--- a/test/fail_compilation/ice8309.d
+++ b/test/fail_compilation/ice8309.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice8309.d(10): Error: incompatible types for ((__lambda1) : (__lambda2)): 'double function() pure nothrow @nogc @safe' and 'int function() pure nothrow @nogc @safe'
+---
+*/
+
+void main()
+{
+    auto x = [()=>1.0, ()=>1];
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=8309

And tweak `arrayExpressionToCommonType` function to avoid redundant messages.
