### PR TITLE
Do not mark mutable parameters as STCin for internal library calls

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3763,7 +3763,7 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
             Parameters *args = new Parameters;
             Type *next = n->ty == Twchar ? Type::twchar : Type::tchar;
             Type *arrty = next->arrayOf();
-            args->push(new Parameter(STCin, arrty, NULL, NULL));
+            args->push(new Parameter(0, arrty, NULL, NULL));
             reverseFd[i] = FuncDeclaration::genCfunc(args, arrty, reverseName[i]);
         }
 
@@ -3784,7 +3784,7 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
             Parameters *args = new Parameters;
             Type *next = n->ty == Twchar ? Type::twchar : Type::tchar;
             Type *arrty = next->arrayOf();
-            args->push(new Parameter(STCin, arrty, NULL, NULL));
+            args->push(new Parameter(0, arrty, NULL, NULL));
             sortFd[i] = FuncDeclaration::genCfunc(args, arrty, sortName[i]);
         }
 
@@ -3808,8 +3808,8 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
         static FuncDeclaration *adReverse_fd = NULL;
         if (!adReverse_fd) {
             Parameters* args = new Parameters;
-            args->push(new Parameter(STCin, Type::tvoid->arrayOf(), NULL, NULL));
-            args->push(new Parameter(STCin, Type::tsize_t, NULL, NULL));
+            args->push(new Parameter(0, Type::tvoid->arrayOf(), NULL, NULL));
+            args->push(new Parameter(0, Type::tsize_t, NULL, NULL));
             adReverse_fd = FuncDeclaration::genCfunc(args, Type::tvoid->arrayOf(), Id::adReverse);
         }
         fd = adReverse_fd;
@@ -3830,8 +3830,8 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
 
         if (!fd) {
             Parameters* args = new Parameters;
-            args->push(new Parameter(STCin, Type::tvoid->arrayOf(), NULL, NULL));
-            args->push(new Parameter(STCin, Type::dtypeinfo->type, NULL, NULL));
+            args->push(new Parameter(0, Type::tvoid->arrayOf(), NULL, NULL));
+            args->push(new Parameter(0, Type::dtypeinfo->type, NULL, NULL));
             fd = FuncDeclaration::genCfunc(args, Type::tvoid->arrayOf(), "_adSort");
         }
         ec = new VarExp(Loc(), fd);

--- a/src/statement.c
+++ b/src/statement.c
@@ -2300,14 +2300,14 @@ Lagain:
                 unsigned char i = dim == 2;
                 if (!fdapply[i]) {
                     args = new Parameters;
-                    args->push(new Parameter(STCin, Type::tvoid->pointerTo(), NULL, NULL));
+                    args->push(new Parameter(0, Type::tvoid->pointerTo(), NULL, NULL));
                     args->push(new Parameter(STCin, Type::tsize_t, NULL, NULL));
                     Parameters* dgargs = new Parameters;
-                    dgargs->push(new Parameter(STCin, Type::tvoidptr, NULL, NULL));
+                    dgargs->push(new Parameter(0, Type::tvoidptr, NULL, NULL));
                     if (dim == 2)
-                        dgargs->push(new Parameter(STCin, Type::tvoidptr, NULL, NULL));
+                        dgargs->push(new Parameter(0, Type::tvoidptr, NULL, NULL));
                     fldeTy[i] = new TypeDelegate(new TypeFunction(dgargs, Type::tint32, 0, LINKd));
-                    args->push(new Parameter(STCin, fldeTy[i], NULL, NULL));
+                    args->push(new Parameter(0, fldeTy[i], NULL, NULL));
                     fdapply[i] = FuncDeclaration::genCfunc(args, Type::tint32, name[i]);
                 }
 
@@ -2363,11 +2363,11 @@ Lagain:
                 args = new Parameters;
                 args->push(new Parameter(STCin, tn->arrayOf(), NULL, NULL));
                 Parameters* dgargs = new Parameters;
-                dgargs->push(new Parameter(STCin, Type::tvoidptr, NULL, NULL));
+                dgargs->push(new Parameter(0, Type::tvoidptr, NULL, NULL));
                 if (dim == 2)
-                    dgargs->push(new Parameter(STCin, Type::tvoidptr, NULL, NULL));
+                    dgargs->push(new Parameter(0, Type::tvoidptr, NULL, NULL));
                 dgty = new TypeDelegate(new TypeFunction(dgargs, Type::tint32, 0, LINKd));
-                args->push(new Parameter(STCin, dgty, NULL, NULL));
+                args->push(new Parameter(0, dgty, NULL, NULL));
                 fdapply = FuncDeclaration::genCfunc(args, Type::tint32, fdname);
 
                 ec = new VarExp(Loc(), fdapply);
@@ -4060,7 +4060,7 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
         cs->push(new ExpStatement(loc, tmp));
 
         Parameters* args = new Parameters;
-        args->push(new Parameter(STCin, ClassDeclaration::object->type, NULL, NULL));
+        args->push(new Parameter(0, ClassDeclaration::object->type, NULL, NULL));
 
         FuncDeclaration *fdenter = FuncDeclaration::genCfunc(args, Type::tvoid, Id::monitorenter);
         Expression *e = new CallExp(loc, new VarExp(loc, fdenter), new VarExp(loc, tmp));
@@ -4101,7 +4101,7 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
         cs->push(new ExpStatement(loc, v));
 
         Parameters* args = new Parameters;
-        args->push(new Parameter(STCin, t->pointerTo(), NULL, NULL));
+        args->push(new Parameter(0, t->pointerTo(), NULL, NULL));
 
         FuncDeclaration *fdenter = FuncDeclaration::genCfunc(args, Type::tvoid, Id::criticalenter);
         Expression *e = new DotIdExp(loc, new VarExp(loc, tmp), Id::ptr);


### PR DESCRIPTION
For a compiler that could optimise around the use of `in`, setting these as `STCin` would be dangerous.

eg:

```
int[] arr = [3,2,1,4];
arr.sort();           // Calls internal function:  _adSort(in int[] arr);
assert(arr[0] == 1);  // Assumed false because of 'in'
```

This pull updates the storage class set on parameters so that it reflects what is defined in druntime.  There are some cases identified where we **should** mark the parameters as `in`.  This has been raised against druntime here https://github.com/D-Programming-Language/druntime/pull/771 - which is an accompanying PR to this one.
