### PR TITLE
Issue 1829 - Allow labels as inline asm operands

### DIFF
--- a/test/compilable/iasm_labeloperand.d
+++ b/test/compilable/iasm_labeloperand.d
@@ -1,0 +1,35 @@
+﻿
+version (D_InlineAsm_X86)
+    version = TestInlineAsm;
+else version (D_InlineAsm_X86_64)
+    version = TestInlineAsm;
+else
+    pragma(msg, "Inline asm not supported, not testing.");
+
+version (TestInlineAsm)
+{
+    void testInlineAsm()
+    {
+        asm
+        {
+		L1:
+			nop;
+			nop;
+			nop;
+			nop;
+			
+			mov EAX, dword ptr L1; // Check back references
+			mov EAX, dword ptr L2; // Check forward references
+			mov EAX, dword ptr DS:L1; // Not really useful in standard use, but who knows.
+			mov EAX, dword ptr FS:L2; // Once again, not really useful, but it is valid.
+			mov EAX, dword ptr CS:L1; // This is what the first test case should implicitly be.
+			
+		L2:
+			nop;
+			nop;
+			nop;
+			nop;
+			
+        }
+    }
+}

--- a/test/fail_compilation/fail12635.d
+++ b/test/fail_compilation/fail12635.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12635.d(19): Error: Cannot generate a segment prefix for a branching instruction
+---
+*/
+
+void foo()
+{
+    enum NOP = 0x9090_9090_9090_9090;
+
+    asm
+    {
+    L1:
+        dq NOP,NOP,NOP,NOP;    //  32
+        dq NOP,NOP,NOP,NOP;    //  64
+        dq NOP,NOP,NOP,NOP;    //  96
+        dq NOP,NOP,NOP,NOP;    // 128
+        jmp DS:L1;
+    }
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=1829

This PR allows labels to be used as an operand for any op-code that would normally accept a memory location. The backend is able to handle it perfectly fine, but for some reason the frontend only lets you use labels as an operand to branching instructions. The use of this is quite simple: It's currently impossible to create a jump-table within inline-asm without creating a huge amount of boilerplate code resulting in a separate function for each and every case, as well as the default case, and the code after the default case, which is not, in any form of the word, maintainable. This PR makes the default segment for labels being resolved `CS`, however it does still allow you to manually override this segment, just as you would with a normal memory operand. Tests are included.
