### PR TITLE
Issue 9245 - [CTFE] postblit not called on static array initialization

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1752,6 +1752,8 @@ void assignInPlace(Expression *dest, Expression *src)
         assert(dest->op == src->op);
         oldelems = ((StructLiteralExp *)dest)->elements;
         newelems = ((StructLiteralExp *)src)->elements;
+        if (((StructLiteralExp *)dest)->sd->isNested() && oldelems->dim == newelems->dim - 1)
+            oldelems->push(NULL);
     }
     else if (dest->op == TOKarrayliteral && src->op==TOKarrayliteral)
     {

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -5990,6 +5990,72 @@ bool test10929()
 static assert(test10929());
 
 /**************************************************
+    9245 - support postblit call on array assignments
+**************************************************/
+
+bool test9245()
+{
+    int postblits = 0;
+    struct S
+    {
+        this(this)
+        {
+            ++postblits;
+        }
+    }
+
+    S s;
+    S[2] a;
+    assert(postblits == 0);
+
+    {
+        S[2] arr = s;
+        assert(postblits == 2);
+        arr[] = s;
+        assert(postblits == 4);
+        postblits = 0;
+
+        S[2] arr2 = arr;
+        assert(postblits == 2);
+        arr2 = arr;
+        assert(postblits == 4);
+        postblits = 0;
+
+        const S[2] constArr = s;
+        assert(postblits == 2);
+        postblits = 0;
+
+        const S[2] constArr2 = arr;
+        assert(postblits == 2);
+        postblits = 0;
+    }
+    {
+        S[2][2] arr = s;
+        assert(postblits == 4);
+        arr[] = a;
+        assert(postblits == 8);
+        postblits = 0;
+
+        S[2][2] arr2 = arr;
+        assert(postblits == 4);
+        arr2 = arr;
+        assert(postblits == 8);
+        postblits = 0;
+
+        const S[2][2] constArr = s;
+        assert(postblits == 4);
+        postblits = 0;
+
+        const S[2][2] constArr2 = arr;
+        assert(postblits == 4);
+        postblits = 0;
+    }
+
+    return true;
+}
+static assert(test9245());
+
+/**************************************************
     11510 support overlapped field access in CTFE
 **************************************************/
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=9245

On element-wise or block assignment, currently postblit call is implicitly handled by glue-layer. Therefore, interpreter should have its own postblit handling.
