### PR TITLE
[REG2.066a] Issue 12619 - Invalid warning for unused return value of debug memcpy

### DIFF
--- a/src/sideeffect.c
+++ b/src/sideeffect.c
@@ -173,9 +173,19 @@ void discardValue(Expression *e)
                     if (t->ty == Tfunction && ((TypeFunction *)t)->purity > PUREweak &&
                                               ((TypeFunction *)t)->isnothrow)
                     {
-                        e->warning("Call to function %s without side effects discards return value of type %s, prepend a cast(void) if intentional",
-                                   ce->f->toPrettyChars(),
-                                   e->type->toChars());
+                        const char *s;
+                        if (ce->f)
+                            s = ce->f->toPrettyChars();
+                        else if (ce->e1->op == TOKstar)
+                        {
+                            // print 'fp' if ce->e1 is (*fp)
+                            s = ((PtrExp *)ce->e1)->e1->toChars();
+                        }
+                        else
+                            s = ce->e1->toChars();
+
+                        e->warning("calling %s without side effects discards return value of type %s, prepend a cast(void) if intentional",
+                                   s, e->type->toChars());
                     }
                 }
             }

--- a/src/sideeffect.c
+++ b/src/sideeffect.c
@@ -90,12 +90,12 @@ bool lambdaHasSideEffect(Expression *e)
             if (ce->e1->type)
             {
                 Type *t = ce->e1->type->toBasetype();
-                if ((t->ty == Tfunction && ((TypeFunction *)t)->purity > PUREweak &&
-                                           ((TypeFunction *)t)->isnothrow)
-                    ||
-                    (t->ty == Tdelegate && ((TypeFunction *)((TypeDelegate *)t)->next)->purity > PUREweak &&
-                                           ((TypeFunction *)((TypeDelegate *)t)->next)->isnothrow)
-                   )
+                if (t->ty == Tdelegate)
+                    t = ((TypeDelegate *)t)->next;
+                if (t->ty == Tfunction)
+                    ((TypeFunction *)t)->purityLevel();
+                if (t->ty == Tfunction && ((TypeFunction *)t)->purity > PUREweak &&
+                                          ((TypeFunction *)t)->isnothrow)
                 {
                 }
                 else
@@ -152,6 +152,7 @@ void discardValue(Expression *e)
             /* Issue 3882: */
             if (global.params.warnings && !global.gag)
             {
+                CallExp *ce = (CallExp *)e;
                 if (e->type->ty == Tvoid)
                 {
                     /* Don't complain about calling void-returning functions with no side-effect,
@@ -162,12 +163,20 @@ void discardValue(Expression *e)
                      * never call assert (and or not called from inside unittest blocks)
                      */
                 }
-                else
+                else if (ce->e1->type)
                 {
-                    CallExp *ce = (CallExp *)e;
-                    e->warning("Call to function %s without side effects discards return value of type %s, prepend a cast(void) if intentional",
-                               ce->f->toPrettyChars(),
-                               e->type->toChars());
+                    Type *t = ce->e1->type->toBasetype();
+                    if (t->ty == Tdelegate)
+                        t = ((TypeDelegate *)t)->next;
+                    if (t->ty == Tfunction)
+                        ((TypeFunction *)t)->purityLevel();
+                    if (t->ty == Tfunction && ((TypeFunction *)t)->purity > PUREweak &&
+                                              ((TypeFunction *)t)->isnothrow)
+                    {
+                        e->warning("Call to function %s without side effects discards return value of type %s, prepend a cast(void) if intentional",
+                                   ce->f->toPrettyChars(),
+                                   e->type->toChars());
+                    }
                 }
             }
             return;

--- a/test/fail_compilation/fail3882.d
+++ b/test/fail_compilation/fail3882.d
@@ -1,8 +1,9 @@
 // REQUIRED_ARGS: -w
+// PERMUTE_ARGS: -debug
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3882.d(26): Warning: Call to function fail3882.strictlyPure!int.strictlyPure without side effects discards return value of type int, prepend a cast(void) if intentional
+fail_compilation/fail3882.d(28): Warning: Call to function fail3882.strictlyPure!int.strictlyPure without side effects discards return value of type int, prepend a cast(void) if intentional
 ---
 */
 
@@ -19,9 +20,22 @@ fail_compilation/fail3882.d(26): Warning: Call to function fail3882.strictlyPure
     return x*x;
 }
 
-void main(string args[]) {
+void main()
+{
     int x = 3;
     strictVoidReturn(x);
     nonstrictVoidReturn(x);
     strictlyPure(x);
+}
+
+/******************************************/
+// 12619
+
+extern (C) @system nothrow pure void* memcpy(void* s1, in void* s2, size_t n);
+// -> weakly pure
+
+void test12619() pure
+{
+    ubyte[10] a, b;
+    debug memcpy(a.ptr, b.ptr, 5);  // memcpy call should have side effect
 }

--- a/test/fail_compilation/fail3882.d
+++ b/test/fail_compilation/fail3882.d
@@ -3,7 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3882.d(28): Warning: Call to function fail3882.strictlyPure!int.strictlyPure without side effects discards return value of type int, prepend a cast(void) if intentional
+fail_compilation/fail3882.d(29): Warning: calling fail3882.strictlyPure!int.strictlyPure without side effects discards return value of type int, prepend a cast(void) if intentional
+fail_compilation/fail3882.d(33): Warning: calling fp without side effects discards return value of type int, prepend a cast(void) if intentional
 ---
 */
 
@@ -26,6 +27,10 @@ void main()
     strictVoidReturn(x);
     nonstrictVoidReturn(x);
     strictlyPure(x);
+
+    // 12649
+    auto fp = &strictlyPure!int;
+    fp(x);
 }
 
 /******************************************/


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12619

Stop reporting "Call to function %s without side effects discards return value of type" warning against the call of weakly pure function.
