### PR TITLE
refactor IntegerExp

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -300,39 +300,16 @@ MATCH implicitConvTo(Expression *e, Type *t)
             switch (ty)
             {
                 case Tbool:
-                    e->value &= 1;
-                    ty = Tint32;
-                    break;
-
                 case Tint8:
-                    e->value = (signed char)e->value;
-                    ty = Tint32;
-                    break;
-
                 case Tchar:
                 case Tuns8:
-                    e->value &= 0xFF;
-                    ty = Tint32;
-                    break;
-
                 case Tint16:
-                    e->value = (short)e->value;
-                    ty = Tint32;
-                    break;
-
                 case Tuns16:
                 case Twchar:
-                    e->value &= 0xFFFF;
                     ty = Tint32;
                     break;
 
-                case Tint32:
-                    e->value = (int)e->value;
-                    break;
-
-                case Tuns32:
                 case Tdchar:
-                    e->value &= 0xFFFFFFFF;
                     ty = Tuns32;
                     break;
 
@@ -341,41 +318,42 @@ MATCH implicitConvTo(Expression *e, Type *t)
             }
 
             // Only allow conversion if no change in value
+            dinteger_t value = e->toInteger();
             switch (toty)
             {
                 case Tbool:
-                    if ((e->value & 1) != e->value)
+                    if ((value & 1) != value)
                         return;
                     break;
 
                 case Tint8:
-                    if (ty == Tuns64 && e->value & ~0x7FUL)
+                    if (ty == Tuns64 && value & ~0x7FUL)
                         return;
-                    else if ((signed char)e->value != e->value)
+                    else if ((signed char)value != value)
                         return;
                     break;
 
                 case Tchar:
-                    if ((oldty == Twchar || oldty == Tdchar) && e->value > 0x7F)
+                    if ((oldty == Twchar || oldty == Tdchar) && value > 0x7F)
                         return;
                 case Tuns8:
-                    //printf("value = %llu %llu\n", (dinteger_t)(unsigned char)e->value, e->value);
-                    if ((unsigned char)e->value != e->value)
+                    //printf("value = %llu %llu\n", (dinteger_t)(unsigned char)value, value);
+                    if ((unsigned char)value != value)
                         return;
                     break;
 
                 case Tint16:
-                    if (ty == Tuns64 && e->value & ~0x7FFFUL)
+                    if (ty == Tuns64 && value & ~0x7FFFUL)
                         return;
-                    else if ((short)e->value != e->value)
+                    else if ((short)value != value)
                         return;
                     break;
 
                 case Twchar:
-                    if (oldty == Tdchar && e->value > 0xD7FF && e->value < 0xE000)
+                    if (oldty == Tdchar && value > 0xD7FF && value < 0xE000)
                         return;
                 case Tuns16:
-                    if ((unsigned short)e->value != e->value)
+                    if ((unsigned short)value != value)
                         return;
                     break;
 
@@ -383,9 +361,9 @@ MATCH implicitConvTo(Expression *e, Type *t)
                     if (ty == Tuns32)
                     {
                     }
-                    else if (ty == Tuns64 && e->value & ~0x7FFFFFFFUL)
+                    else if (ty == Tuns64 && value & ~0x7FFFFFFFUL)
                         return;
-                    else if ((int)e->value != e->value)
+                    else if ((int)value != value)
                         return;
                     break;
 
@@ -393,12 +371,12 @@ MATCH implicitConvTo(Expression *e, Type *t)
                     if (ty == Tint32)
                     {
                     }
-                    else if ((unsigned)e->value != e->value)
+                    else if ((unsigned)value != value)
                         return;
                     break;
 
                 case Tdchar:
-                    if (e->value > 0x10FFFFUL)
+                    if (value > 0x10FFFFUL)
                         return;
                     break;
 
@@ -407,14 +385,14 @@ MATCH implicitConvTo(Expression *e, Type *t)
                     volatile float f;
                     if (e->type->isunsigned())
                     {
-                        f = (float)e->value;
-                        if (f != e->value)
+                        f = (float)value;
+                        if (f != value)
                             return;
                     }
                     else
                     {
-                        f = (float)(sinteger_t)e->value;
-                        if (f != (sinteger_t)e->value)
+                        f = (float)(sinteger_t)value;
+                        if (f != (sinteger_t)value)
                             return;
                     }
                     break;
@@ -425,14 +403,14 @@ MATCH implicitConvTo(Expression *e, Type *t)
                     volatile double f;
                     if (e->type->isunsigned())
                     {
-                        f = (double)e->value;
-                        if (f != e->value)
+                        f = (double)value;
+                        if (f != value)
                             return;
                     }
                     else
                     {
-                        f = (double)(sinteger_t)e->value;
-                        if (f != (sinteger_t)e->value)
+                        f = (double)(sinteger_t)value;
+                        if (f != (sinteger_t)value)
                             return;
                     }
                     break;
@@ -443,14 +421,14 @@ MATCH implicitConvTo(Expression *e, Type *t)
                     volatile_longdouble f;
                     if (e->type->isunsigned())
                     {
-                        f = ldouble(e->value);
-                        if (f != e->value) // isn't this a noop, because the compiler prefers ld
+                        f = ldouble(value);
+                        if (f != value) // isn't this a noop, because the compiler prefers ld
                             return;
                     }
                     else
                     {
-                        f = ldouble((sinteger_t)e->value);
-                        if (f != (sinteger_t)e->value)
+                        f = ldouble((sinteger_t)value);
+                        if (f != (sinteger_t)value)
                             return;
                     }
                     break;
@@ -3237,7 +3215,7 @@ IntRange getIntRange(Expression *e)
 
         void visit(IntegerExp *e)
         {
-            range = IntRange(SignExtendedNumber(e->value)).cast(e->type);
+            range = IntRange(SignExtendedNumber(e->getInteger())).cast(e->type);
         }
 
         void visit(CastExp *e)

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -873,10 +873,10 @@ void intUnary(TOK op, IntegerExp *e)
     switch (op)
     {
     case TOKneg:
-        e->value = -e->value;
+        e->setInteger(-e->getInteger());
         break;
     case TOKtilde:
-        e->value = ~e->value;
+        e->setInteger(~e->getInteger());
         break;
     default:
         assert(0);
@@ -892,26 +892,27 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
     switch (op)
     {
     case TOKand:
-        result = e1->value & e2->value;
+        result = e1->getInteger() & e2->getInteger();
         break;
     case TOKor:
-        result = e1->value | e2->value;
+        result = e1->getInteger() | e2->getInteger();
         break;
     case TOKxor:
-        result = e1->value ^ e2->value;
+        result = e1->getInteger() ^ e2->getInteger();
         break;
     case TOKadd:
-        result = e1->value + e2->value;
+        result = e1->getInteger() + e2->getInteger();
         break;
     case TOKmin:
-        result = e1->value - e2->value;
+        result = e1->getInteger() - e2->getInteger();
         break;
     case TOKmul:
-        result = e1->value * e2->value;
+        result = e1->getInteger() * e2->getInteger();
         break;
     case TOKdiv:
-        {   sinteger_t n1 = e1->value;
-            sinteger_t n2 = e2->value;
+        {
+            sinteger_t n1 = e1->getInteger();
+            sinteger_t n2 = e2->getInteger();
 
             if (n2 == 0)
             {   e2->error("divide by 0");
@@ -924,8 +925,8 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
         }
         break;
     case TOKmod:
-        {   sinteger_t n1 = e1->value;
-            sinteger_t n2 = e2->value;
+        {   sinteger_t n1 = e1->getInteger();
+            sinteger_t n2 = e2->getInteger();
 
             if (n2 == 0)
             {   e2->error("divide by 0");
@@ -951,13 +952,13 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
         }
         break;
     case TOKpow:
-        {   dinteger_t n = e2->value;
+        {   dinteger_t n = e2->getInteger();
             if (!e2->type->isunsigned() && (sinteger_t)n < 0)
             {
                 e2->error("integer ^^ -integer: total loss of precision");
                 n = 1;
             }
-            uinteger_t r = e1->value;
+            uinteger_t r = e1->getInteger();
             result = 1;
             while (n != 0)
             {
@@ -969,11 +970,11 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
         }
         break;
     case TOKshl:
-        result = e1->value << e2->value;
+        result = e1->getInteger() << e2->getInteger();
         break;
     case TOKshr:
-        {   dinteger_t value = e1->value;
-            dinteger_t dcount = e2->value;
+        {   dinteger_t value = e1->getInteger();
+            dinteger_t dcount = e2->getInteger();
             assert(dcount <= 0xFFFFFFFF);
             unsigned count = (unsigned)dcount;
             switch (e1->type->toBasetype()->ty)
@@ -1018,8 +1019,8 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
         }
         break;
     case TOKushr:
-        {   dinteger_t value = e1->value;
-            dinteger_t dcount = e2->value;
+        {   dinteger_t value = e1->getInteger();
+            dinteger_t dcount = e2->getInteger();
             assert(dcount <= 0xFFFFFFFF);
             unsigned count = (unsigned)dcount;
             switch (e1->type->toBasetype()->ty)
@@ -1056,16 +1057,16 @@ void intBinary(TOK op, IntegerExp *dest, Type *type, IntegerExp *e1, IntegerExp 
         break;
     case TOKequal:
     case TOKidentity:
-        result = (e1->value == e2->value);
+        result = (e1->getInteger() == e2->getInteger());
         break;
     case TOKnotequal:
     case TOKnotidentity:
-        result = (e1->value != e2->value);
+        result = (e1->getInteger() != e2->getInteger());
         break;
     default:
         assert(0);
     }
-    dest->value = result;
+    dest->setInteger(result);
     dest->type = type;
 }
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1101,7 +1101,7 @@ elem *toElem(Expression *e, IRState *irs)
 
         void visit(IntegerExp *ie)
         {
-            elem *e = el_long(totym(ie->type), ie->value);
+            elem *e = el_long(totym(ie->type), ie->getInteger());
             el_setLoc(e,ie->loc);
             result = e;
         }

--- a/src/expression.h
+++ b/src/expression.h
@@ -245,9 +245,10 @@ public:
 
 class IntegerExp : public Expression
 {
-public:
+private:
     dinteger_t value;
 
+public:
     IntegerExp(Loc loc, dinteger_t value, Type *type);
     IntegerExp(dinteger_t value);
     bool equals(RootObject *o);
@@ -261,6 +262,11 @@ public:
     void toMangleBuffer(OutBuffer *buf);
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
+    dinteger_t getInteger() { return value; }
+    void setInteger(dinteger_t value);
+
+private:
+    void normalize();
 };
 
 class ErrorExp : public Expression

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -6677,7 +6677,7 @@ Expression *interpret_aaApply(InterState *istate, Expression *aa, Expression *de
             return eresult;
 
         assert(eresult->op == TOKint64);
-        if (((IntegerExp *)eresult)->value != 0)
+        if (((IntegerExp *)eresult)->getInteger() != 0)
             return eresult;
     }
     return eresult;
@@ -6770,7 +6770,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
                     {
                         Expression * r = (*ale->elements)[indx];
                         assert(r->op == TOKint64);
-                        utf8_t x = (utf8_t)(((IntegerExp *)r)->value);
+                        utf8_t x = (utf8_t)(((IntegerExp *)r)->getInteger());
                         if ( (x & 0xC0) != 0x80)
                             break;
                         ++buflen;
@@ -6782,7 +6782,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
                 {
                     Expression * r = (*ale->elements)[indx + i];
                     assert(r->op == TOKint64);
-                    utf8buf[i] = (utf8_t)(((IntegerExp *)r)->value);
+                    utf8buf[i] = (utf8_t)(((IntegerExp *)r)->getInteger());
                 }
                 n = 0;
                 errmsg = utf_decodeChar(&utf8buf[0], buflen, &n, &rawvalue);
@@ -6794,7 +6794,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
                     buflen = 1;
                     Expression * r = (*ale->elements)[indx];
                     assert(r->op == TOKint64);
-                    unsigned short x = (unsigned short)(((IntegerExp *)r)->value);
+                    unsigned short x = (unsigned short)(((IntegerExp *)r)->getInteger());
                     if (indx > 0 && x >= 0xDC00 && x <= 0xDFFF)
                     {
                         --indx;
@@ -6807,7 +6807,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
                 {
                     Expression * r = (*ale->elements)[indx + i];
                     assert(r->op == TOKint64);
-                    utf16buf[i] = (unsigned short)(((IntegerExp *)r)->value);
+                    utf16buf[i] = (unsigned short)(((IntegerExp *)r)->getInteger());
                 }
                 n = 0;
                 errmsg = utf_decodeWchar(&utf16buf[0], buflen, &n, &rawvalue);
@@ -6819,7 +6819,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
 
                     Expression * r = (*ale->elements)[indx];
                     assert(r->op == TOKint64);
-                    rawvalue = (dchar_t)((IntegerExp *)r)->value;
+                    rawvalue = (dchar_t)((IntegerExp *)r)->getInteger();
                     n = 1;
                 }
                 break;
@@ -6931,7 +6931,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
             if (exceptionOrCantInterpret(eresult))
                 return eresult;
             assert(eresult->op == TOKint64);
-            if (((IntegerExp *)eresult)->value != 0)
+            if (((IntegerExp *)eresult)->getInteger() != 0)
                 return eresult;
         }
     }

--- a/src/statement.c
+++ b/src/statement.c
@@ -1921,7 +1921,7 @@ Lagain:
             if (op == TOKforeach_reverse)
                 key->init = new ExpInitializer(loc, tmp_length);
             else
-                key->init = new ExpInitializer(loc, new IntegerExp(loc, 0, NULL));
+                key->init = new ExpInitializer(loc, new IntegerExp(loc, 0, key->type));
 
             Statements *cs = new Statements();
             cs->push(new ExpStatement(loc, tmp));
@@ -1943,7 +1943,7 @@ Lagain:
             Expression *increment = NULL;
             if (op == TOKforeach)
                 // key += 1
-                increment = new AddAssignExp(loc, new VarExp(loc, key), new IntegerExp(loc, 1, NULL));
+                increment = new AddAssignExp(loc, new VarExp(loc, key), new IntegerExp(loc, 1, key->type));
 
             // T value = tmp[key];
             value->init = new ExpInitializer(loc, new IndexExp(loc, new VarExp(loc, tmp), new VarExp(loc, key)));

--- a/src/template.c
+++ b/src/template.c
@@ -380,7 +380,7 @@ hash_t arrayObjectHash(Objects *oa1)
                 if (e1->op == TOKint64)
                 {
                     IntegerExp *ne = (IntegerExp *)e1;
-                    hash += (size_t)ne->value;
+                    hash += (size_t)ne->getInteger();
                 }
             }
             else if (s1)

--- a/src/todt.c
+++ b/src/todt.c
@@ -260,10 +260,11 @@ dt_t **Expression_toDt(Expression *e, dt_t **pdt)
         {
             //printf("IntegerExp::toDt() %d\n", e->op);
             unsigned sz = e->type->size();
-            if (e->value == 0)
+            dinteger_t value = e->getInteger();
+            if (value == 0)
                 pdt = dtnzeros(pdt, sz);
             else
-                pdt = dtnbytes(pdt, sz, (char *)&e->value);
+                pdt = dtnbytes(pdt, sz, (char *)&value);
         }
 
         void visit(RealExp *e)


### PR DESCRIPTION
Eliminates duplicate code, and some dead code. Simplifies the logic. Makes assumptions explicit with assert. Steps towards making IntegerExp copy-on-write. No semantic changes.
