### PR TITLE
Added correct path for mspdb120.dll for VS2013.

### DIFF
--- a/ini/windows/bin/sc.ini
+++ b/ini/windows/bin/sc.ini
@@ -54,7 +54,7 @@ LINKCMD=%VCINSTALLDIR%\bin\link.exe
 ;VC2008 LINKCMD=%VCINSTALLDIR%\bin\amd64\link.exe
 
 ; needed with /DEBUG to find mspdb*.dll (only for VS2012 or VS2013)
-;VC2013 PATH=%PATH%;%VCINSTALLDIR%\bin\x86_amd64;%VCINSTALLDIR%\..\Common7\IDE
+;VC2013 PATH=%PATH%;%VCINSTALLDIR%\bin\x86_amd64;%VCINSTALLDIR%\..\Common7\IDE;%VCINSTALLDIR%\bin
 ;VC2012 PATH=%PATH%;%VCINSTALLDIR%\bin\x86_amd64;%VCINSTALLDIR%\..\Common7\IDE
 
 ; ----------------------------------------------------------------------------


### PR DESCRIPTION
The mspdb120.dll file for all architectures is now stored in %VCINSTALLDIR%\bin in VS2013. I've added that path to the VC2013 path.
