### PR TITLE
[REG2.066a] Issue 12650 - Invalid codegen on taking lvalue of instance field initializing

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -11536,44 +11536,17 @@ int AssignExp::isLvalue()
 
 Expression *AssignExp::toLvalue(Scope *sc, Expression *ex)
 {
-    Expression *e;
-
-    if (e1->op == TOKvar)
+    if (e1->op == TOKslice ||
+        e1->op == TOKarraylength)
     {
-        /* Convert (e1 = e2) to
-         *    e1 = e2;
-         *    e1
-         */
-        e = e1->copy();
-        e = Expression::combine(this, e);
+        return Expression::toLvalue(sc, ex);
     }
-    else
-    {
-        // toLvalue may be called from inline.c with sc == NULL,
-        // but this branch should not be reached at that time.
-        assert(sc);
 
-        /* Convert (e1 = e2) to
-         *    ref v = e1;
-         *    v = e2;
-         *    v
-         */
-
-        // ref v = e1;
-        Identifier *id = Lexer::uniqueId("__assignop");
-        ExpInitializer *ei = new ExpInitializer(loc, e1);
-        VarDeclaration *v = new VarDeclaration(loc, e1->type, id, ei);
-        v->storage_class |= STCtemp | STCref | STCforeach;
-        Expression *de = new DeclarationExp(loc, v);
-
-        // v = e2
-        this->e1 = new VarExp(e1->loc, v);
-
-        e = new CommaExp(loc, de, this);
-        e = new CommaExp(loc, e, new VarExp(loc, v));
-        e = e->semantic(sc);
-    }
-    return e;
+    /* In front-end level, AssignExp should make an lvalue of e1.
+     * Taking the address of e1 will be handled in low level layer,
+     * so this function does nothing.
+     */
+    return this;
 }
 
 Expression *AssignExp::checkToBoolean(Scope *sc)

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -1,4 +1,4 @@
-import std.c.stdio;
+import core.stdc.stdio;
 
 template TypeTuple(T...){ alias T TypeTuple; }
 
@@ -964,6 +964,76 @@ void test12212()
 }
 
 /***************************************************/
+// 12650
+
+void test12650()
+{
+    // AssignExp::toElem should make an lvalue of e1.
+    static class A1
+    {
+        struct S { int a; }
+
+        static foo(ref const(S) s)
+        {
+            assert(s.a == 2);
+            return &s;
+        }
+
+        S s;
+
+        this()
+        {
+            const v = S(2);
+
+            // (this.s = v) will become ConstructExp
+            auto p = foo(s = v);
+            assert(p == &s);
+        }
+    }
+    assert(new A1().s.a == 2);
+
+    static class A2
+    {
+        static foo(ref int[2] sa)
+        {
+            assert(sa[1] == 2);
+            return &sa;
+        }
+
+        int[2] sa;
+
+        this()
+        {
+            // (this.sa = [1,2]) will become ConstructExp
+            auto p = foo(sa = [1,2]);
+            assert(p == &sa);
+        }
+    }
+    assert(new A2().sa[1] == 2);
+
+    static class A3
+    {
+        static foo(ref int n)
+        {
+            assert(n == 2);
+            return &n;
+        }
+
+        int n;
+
+        this()
+        {
+            const v = 2;
+
+            // (this.n = v) will become ConstructExp
+            auto p = foo(n = v);
+            assert(p == &n);
+        }
+    }
+    assert(new A3().n == 2);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -989,6 +1059,7 @@ int main()
     test12131();
     test12211();
     test12212();
+    test12650();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/assignable.d
+++ b/test/runnable/assignable.d
@@ -852,6 +852,30 @@ void test12131() pure
 }
 
 /***************************************************/
+// 12211
+
+void test12211()
+{
+    int a = 0;
+    void foo(ref int x)
+    {
+        assert(x == 10);
+        assert(&x == &a);
+        x = 3;
+    }
+    foo(a = 10);
+    assert(a == 3);
+    foo(a += 7);
+    assert(a == 3);
+
+    // array ops should make rvalue
+    int[3] sa, sb;
+    void bar(ref int[]) {}
+    static assert(!__traits(compiles, bar(sa[]  = sb[])));
+    static assert(!__traits(compiles, bar(sa[] += sb[])));
+}
+
+/***************************************************/
 // 12212
 
 void test12212()
@@ -963,6 +987,7 @@ int main()
     test9416();
     test11187();
     test12131();
+    test12211();
     test12212();
 
     printf("Success\n");

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5825,30 +5825,6 @@ void test7436()
 }
 
 /***************************************************/
-// 12211
-
-void test12211()
-{
-    int a = 0;
-    void foo(ref int x)
-    {
-        assert(x == 10);
-        assert(&x == &a);
-        x = 3;
-    }
-    foo(a = 10);
-    assert(a == 3);
-    foo(a += 7);
-    assert(a == 3);
-
-    // array ops should make rvalue
-    int[3] sa, sb;
-    void bar(ref int[]) {}
-    static assert(!__traits(compiles, bar(sa[]  = sb[])));
-    static assert(!__traits(compiles, bar(sa[] += sb[])));
-}
-
-/***************************************************/
 
 int main()
 {
@@ -6139,7 +6115,6 @@ int main()
     test10633();
     test10642();
     test7436();
-    test12211();
 
     writefln("Success");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12650

By `AssignExp::toLvalue`, one `ConstructExp` of field initializing `this.s = v` will be rewritten to _two_ `ConstructExp`s:

``` d
ref __assignop = this.s;
ref __assignop = v;
```

Then the second TOKconstruct is unintendedly handled as reference initializing.

To fix the bug, `AssignExp::toLvalue` should directly return `this` and rely on glue layer translation.
