### PR TITLE
Issue 12651 - TemplateArgsOf accepts nonsensical arguments

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -5486,10 +5486,10 @@ MATCH TemplateTupleParameter::matchArg(Loc loc, Scope *sc, Objects *tiargs,
     assert(i + 1 == dedtypes->dim);     // must be the last one
     Tuple *ovar;
 
-    if ((*dedtypes)[i] && isTuple((*dedtypes)[i]))
+    if (Tuple *u = isTuple((*dedtypes)[i]))
     {
         // It has already been deduced
-        ovar = isTuple((*dedtypes)[i]);
+        ovar = u;
     }
     else if (i + 1 == tiargs->dim && isTuple((*tiargs)[i]))
         ovar = isTuple((*tiargs)[i]);
@@ -5516,6 +5516,14 @@ MATCH TemplateTupleParameter::matchArg(Scope *sc, RootObject *oarg,
     Tuple *ovar = isTuple(oarg);
     if (!ovar)
         return MATCHnomatch;
+    if ((*dedtypes)[i])
+    {
+        Tuple *tup = isTuple((*dedtypes)[i]);
+        if (!tup)
+            return MATCHnomatch;
+        if (!match(tup, ovar))
+            return MATCHnomatch;
+    }
     (*dedtypes)[i] = ovar;
 
     if (psparam)

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -3374,6 +3374,15 @@ void test12376()
 }
 
 /******************************************/
+// 12651
+
+alias TemplateArgsOf12651(alias T : Base!Args, alias Base, Args...) = Args;
+
+struct S12651(T) { }
+
+static assert(!__traits(compiles, TemplateArgsOf12651!(S12651!int, S, float)));
+
+/******************************************/
 
 int main()
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12651

Implicitly deduced tuple and explicitly given tuple argument should be compared properly.
