### PR TITLE
[Refactoring] Unify semantic analysis steps around aggregates

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -273,6 +273,10 @@ void ClassDeclaration::semantic(Scope *sc)
 
     //{ static int n;  if (++n == 20) *(char*)0=0; }
 
+    if (semanticRun >= PASSsemanticdone)
+        return;
+    semanticRun = PASSsemantic;
+
     if (!ident)         // if anonymous class
     {
         const char *id = "__anonclass";
@@ -824,6 +828,8 @@ void ClassDeclaration::semantic(Scope *sc)
       }
 #endif
     assert(type->ty != Tclass || ((TypeClass *)type)->sym == this);
+
+    semanticRun = PASSsemanticdone;
 }
 
 void ClassDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
@@ -1280,6 +1286,10 @@ void InterfaceDeclaration::semantic(Scope *sc)
     if (inuse)
         return;
 
+    if (semanticRun >= PASSsemanticdone)
+        return;
+    semanticRun = PASSsemantic;
+
     if (!sc)
         sc = scope;
     if (!parent && sc->parent && !sc->parent->isModule())
@@ -1526,6 +1536,8 @@ void InterfaceDeclaration::semantic(Scope *sc)
       }
 #endif
     assert(type->ty != Tclass || ((TypeClass *)type)->sym == this);
+
+    semanticRun = PASSsemanticdone;
 }
 
 

--- a/src/class.c
+++ b/src/class.c
@@ -308,6 +308,9 @@ void ClassDeclaration::semantic(Scope *sc)
             ((TypeClass *)type)->sym = this;
     }
 
+    // Ungag errors when not speculative
+    Ungag ungag = ungagSpeculative();
+
     if (semanticRun == PASSinit)
     {
         protection = sc->protection;
@@ -337,9 +340,6 @@ void ClassDeclaration::semantic(Scope *sc)
     // Expand any tuples in baseclasses[]
     for (size_t i = 0; i < baseclasses->dim; )
     {
-        // Ungag errors when not speculative
-        Ungag ungag = ungagSpeculative();
-
         BaseClass *b = (*baseclasses)[i];
         b->type = b->type->semantic(loc, sc);
 
@@ -364,9 +364,6 @@ void ClassDeclaration::semantic(Scope *sc)
     // See if there's a base class as first in baseclasses[]
     if (baseclasses->dim)
     {
-        // Ungag errors when not speculative
-        Ungag ungag = ungagSpeculative();
-
         BaseClass *b = (*baseclasses)[0];
         //b->type = b->type->semantic(loc, sc);
 
@@ -443,9 +440,6 @@ void ClassDeclaration::semantic(Scope *sc)
     // Check for errors, handle forward references
     for (size_t i = (baseClass ? 1 : 0); i < baseclasses->dim; )
     {
-        // Ungag errors when not speculative
-        Ungag ungag = ungagSpeculative();
-
         BaseClass *b = (*baseclasses)[i];
         b->type = b->type->semantic(loc, sc);
 
@@ -661,9 +655,6 @@ void ClassDeclaration::semantic(Scope *sc)
     for (size_t i = 0; i < members_dim; i++)
     {
         Dsymbol *s = (*members)[i];
-
-        // Ungag errors when not speculative
-        Ungag ungag = ungagSpeculative();
         s->semantic(sc2);
     }
 
@@ -1308,6 +1299,9 @@ void InterfaceDeclaration::semantic(Scope *sc)
             ((TypeClass *)type)->sym = this;
     }
 
+    // Ungag errors when not speculative
+    Ungag ungag = ungagSpeculative();
+
     if (semanticRun == PASSinit)
     {
         protection = sc->protection;
@@ -1328,9 +1322,6 @@ void InterfaceDeclaration::semantic(Scope *sc)
     // Expand any tuples in baseclasses[]
     for (size_t i = 0; i < baseclasses->dim; )
     {
-        // Ungag errors when not speculative
-        Ungag ungag = ungagSpeculative();
-
         BaseClass *b = (*baseclasses)[i];
         b->type = b->type->semantic(loc, sc);
 
@@ -1358,9 +1349,6 @@ void InterfaceDeclaration::semantic(Scope *sc)
     // Check for errors, handle forward references
     for (size_t i = 0; i < baseclasses->dim; )
     {
-        // Ungag errors when not speculative
-        Ungag ungag = ungagSpeculative();
-
         BaseClass *b = (*baseclasses)[i];
         b->type = b->type->semantic(loc, sc);
 
@@ -1500,9 +1488,6 @@ void InterfaceDeclaration::semantic(Scope *sc)
     for (size_t i = 0; i < members->dim; i++)
     {
         Dsymbol *s = (*members)[i];
-
-        // Ungag errors when not speculative
-        Ungag ungag = ungagSpeculative();
         s->semantic(sc2);
     }
 

--- a/src/class.c
+++ b/src/class.c
@@ -331,16 +331,7 @@ void ClassDeclaration::semantic(Scope *sc)
 
     if (!members)               // if opaque declaration
         return;
-
-    if (symtab)
-    {
-        if (sizeok == SIZEOKdone || !scope)
-        {
-            //printf("\tsemantic for '%s' is already completed\n", toChars());
-            return;             // semantic() already completed
-        }
-    }
-    else
+    if (!symtab)
         symtab = new DsymbolTable();
 
     // Expand any tuples in baseclasses[]
@@ -1331,13 +1322,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
 
     if (!members)               // if opaque declaration
         return;
-
-    if (symtab)                 // if already done
-    {
-        if (!scope)
-            return;
-    }
-    else
+    if (!symtab)
         symtab = new DsymbolTable();
 
     // Expand any tuples in baseclasses[]

--- a/src/mars.c
+++ b/src/mars.c
@@ -81,7 +81,7 @@ Ungag Dsymbol::ungagSpeculative()
 {
     unsigned oldgag = global.gag;
 
-    if (global.isSpeculativeGagging() && !isSpeculative())
+    if (global.isSpeculativeGagging() && !isSpeculative() && !toParent2()->isFuncDeclaration())
         global.gag = 0;
 
     return Ungag(oldgag);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7792,6 +7792,8 @@ Type *TypeStruct::semantic(Loc loc, Scope *sc)
     /* Don't semantic for sym because it should be deferred until
      * sizeof needed or its members accessed.
      */
+    // instead, parent should be set correctly
+    assert(sym->parent);
 
     return merge();
 }
@@ -8338,6 +8340,8 @@ Type *TypeClass::semantic(Loc loc, Scope *sc)
     /* Don't semantic for sym because it should be deferred until
      * sizeof needed or its members accessed.
      */
+    // instead, parent should be set correctly
+    assert(sym->parent);
 
     return merge();
 }

--- a/src/struct.c
+++ b/src/struct.c
@@ -695,6 +695,9 @@ void StructDeclaration::semantic(Scope *sc)
             ((TypeStruct *)type)->sym = this;
     }
 
+    // Ungag errors when not speculative
+    Ungag ungag = ungagSpeculative();
+
     if (semanticRun == PASSinit)
     {
         protection = sc->protection;
@@ -767,9 +770,6 @@ void StructDeclaration::semantic(Scope *sc)
             if (sizeok == SIZEOKnone && s->isAliasDeclaration())
                 finalizeSize(sc2);
         }
-
-        // Ungag errors when not speculative
-        Ungag ungag = ungagSpeculative();
         s->semantic(sc2);
     }
     finalizeSize(sc2);

--- a/src/struct.c
+++ b/src/struct.c
@@ -666,6 +666,12 @@ void StructDeclaration::semantic(Scope *sc)
 
     //static int count; if (++count == 20) halt();
 
+    if (semanticRun >= PASSsemanticdone)
+        return;
+    semanticRun = PASSsemantic;
+
+    assert(!isAnonymous());
+
     assert(type);
     if (!members)               // if opaque declaration
     {
@@ -709,7 +715,6 @@ void StructDeclaration::semantic(Scope *sc)
     storage_class |= sc->stc;
     if (sc->stc & STCdeprecated)
         isdeprecated = true;
-    assert(!isAnonymous());
     if (sc->stc & STCabstract)
         error("structs, unions cannot be abstract");
     userAttribDecl = sc->userAttribDecl;
@@ -908,6 +913,8 @@ void StructDeclaration::semantic(Scope *sc)
     }
 #endif
     assert(type->ty != Tstruct || ((TypeStruct *)type)->sym == this);
+
+    semanticRun = PASSsemanticdone;
 }
 
 Dsymbol *StructDeclaration::search(Loc loc, Identifier *ident, int flags)

--- a/src/struct.c
+++ b/src/struct.c
@@ -697,6 +697,16 @@ void StructDeclaration::semantic(Scope *sc)
 
     if (semanticRun == PASSinit)
     {
+        protection = sc->protection;
+
+        alignment = sc->structalign;
+
+        storage_class |= sc->stc;
+        if (storage_class & STCdeprecated)
+            isdeprecated = true;
+        if (storage_class & STCabstract)
+            error("structs, unions cannot be abstract");
+        userAttribDecl = sc->userAttribDecl;
     }
     semanticRun = PASSsemantic;
 
@@ -713,17 +723,6 @@ void StructDeclaration::semantic(Scope *sc)
     }
     else
         symtab = new DsymbolTable();
-
-    protection = sc->protection;
-
-    alignment = sc->structalign;
-
-    storage_class |= sc->stc;
-    if (sc->stc & STCdeprecated)
-        isdeprecated = true;
-    if (sc->stc & STCabstract)
-        error("structs, unions cannot be abstract");
-    userAttribDecl = sc->userAttribDecl;
 
     if (sizeok == SIZEOKnone)            // if not already done the addMember step
     {

--- a/src/struct.c
+++ b/src/struct.c
@@ -713,15 +713,7 @@ void StructDeclaration::semantic(Scope *sc)
     if (!members)               // if opaque declaration
         return;
 
-    if (symtab)
-    {
-        if (sizeok == SIZEOKdone || !scope)
-        {
-            //printf("already completed\n");
-            return;             // semantic() already completed
-        }
-    }
-    else
+    if (!symtab)
         symtab = new DsymbolTable();
 
     if (sizeok == SIZEOKnone)            // if not already done the addMember step

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -583,3 +583,15 @@ static assert(__traits(isSame, cb12476, A12476!int));
 import imports.a12506;
 private           bool[9] r12506a = f12506!(i => true)(); // OK
 private immutable bool[9] r12506b = f12506!(i => true)(); // OK <- error
+
+/***************************************************/
+// 12555
+
+class A12555(T)
+{
+    Undef12555 error;
+}
+
+static assert(!__traits(compiles, {
+    class C : A12555!C  { }
+}));


### PR DESCRIPTION
This is a separated pull request from #3384 due to reduce reviewing difficulty.

Points:
- Use `semanticRun` rather than `symtab != NULL` to handle reentrant of semantic analysis properly.
- Use more clean way to get valid scope and parent.
- Fix the timing for gathering various aggregate attributes.
- More better position to call `ungagSpeculative()`.
