### PR TITLE
Add enhanced unittest support

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -141,6 +141,8 @@ struct StructFlags
 class StructDeclaration : public AggregateDeclaration
 {
 public:
+    static StructDeclaration *UnitTest;
+
     int zeroInit;               // !=0 if initialize with 0 fill
     bool hasIdentityAssign;     // true if has identity opAssign
     bool hasIdentityEquals;     // true if has identity opEquals

--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -34,6 +34,8 @@ typedef Array<class RootObject *> Objects;
 
 typedef Array<class FuncDeclaration *> FuncDeclarations;
 
+typedef Array<class UnitTestDeclaration *> UnitTestDeclarations;
+
 typedef Array<class Parameter *> Parameters;
 
 typedef Array<class Identifier *> Identifiers;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -904,6 +904,7 @@ public:
     bool addPostInvariant();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
+    ExpInitializer *toUnitTestInfo();
     UnitTestDeclaration *isUnitTestDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -891,11 +891,12 @@ class UnitTestDeclaration : public FuncDeclaration
 {
 public:
     char *codedoc; /** For documented unittest. */
+    Identifier *id;
 
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;
 
-    UnitTestDeclaration(Loc loc, Loc endloc, char *codedoc);
+    UnitTestDeclaration(Loc loc, Loc endloc, char *codedoc, Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     AggregateDeclaration *isThis();

--- a/src/func.c
+++ b/src/func.c
@@ -5141,17 +5141,27 @@ void InvariantDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
  * instances per module.
  */
 
-static Identifier *unitTestId(Loc loc)
+static Identifier *unitTestId(Loc loc, Identifier *id)
 {
     OutBuffer buf;
-    buf.printf("__unittestL%u_", loc.linnum);
-    return Lexer::uniqueId(buf.peekString());
+    if (id)
+    {
+        const char* name = id->toChars();
+        buf.printf("__unittestL%u_N%llu%s", loc.linnum, (ulonglong)strlen(name), name);
+        return Lexer::idPool(buf.peekString());
+    }
+    else
+    {
+        buf.printf("__unittestL%u_", loc.linnum);
+        return Lexer::uniqueId(buf.peekString());
+    }
 }
 
-UnitTestDeclaration::UnitTestDeclaration(Loc loc, Loc endloc, char *codedoc)
-    : FuncDeclaration(loc, endloc, unitTestId(loc), STCundefined, NULL)
+UnitTestDeclaration::UnitTestDeclaration(Loc loc, Loc endloc, char *codedoc, Identifier *id)
+    : FuncDeclaration(loc, endloc, unitTestId(loc, id), STCundefined, NULL)
 {
     this->codedoc = codedoc;
+    this->id = id;
 }
 
 Dsymbol *UnitTestDeclaration::syntaxCopy(Dsymbol *s)
@@ -5159,7 +5169,7 @@ Dsymbol *UnitTestDeclaration::syntaxCopy(Dsymbol *s)
     UnitTestDeclaration *utd;
 
     assert(!s);
-    utd = new UnitTestDeclaration(loc, endloc, codedoc);
+    utd = new UnitTestDeclaration(loc, endloc, codedoc, id);
     return FuncDeclaration::syntaxCopy(utd);
 }
 
@@ -5239,8 +5249,9 @@ void UnitTestDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
  *     string file;
  *     uint line;
  *     bool disabled;
+ *     string name;
  * }
- * 
+ *
  * Generates struct initializer
  * __UnitTest(&testFunc, file, line, disabled, name)
  */
@@ -5254,6 +5265,8 @@ ExpInitializer *UnitTestDeclaration::toUnitTestInfo()
     inits->push(new StringExp(loc, (char*)loc.filename)); //fileName
     inits->push(new IntegerExp(loc, loc.linnum, TypeBasic::tuns32)); //line
     inits->push(new IntegerExp(loc, disabled, TypeBasic::tbool)); //disabled
+    const char* name = id ? id->toChars() : "";
+    inits->push(new StringExp(loc, (char*)name)); //name
 
     StructLiteralExp *exp = new StructLiteralExp(loc, StructDeclaration::UnitTest,
         inits, StructDeclaration::UnitTest->type);

--- a/src/func.c
+++ b/src/func.c
@@ -5231,6 +5231,35 @@ void UnitTestDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     bodyToCBuffer(buf, hgs);
 }
 
+/*
+ * Mirrored with druntime
+ * struct __UnitTest
+ * {
+ *     void function() func;
+ *     string file;
+ *     uint line;
+ *     bool disabled;
+ * }
+ * 
+ * Generates struct initializer
+ * __UnitTest(&testFunc, file, line, disabled, name)
+ */
+ExpInitializer *UnitTestDeclaration::toUnitTestInfo()
+{
+    Expressions *inits = new Expressions();
+
+    bool disabled = storage_class & STCdisable;
+
+    inits->push((Expression*)new AddrExp(loc, new VarExp(loc, this))); //testFunc
+    inits->push(new StringExp(loc, (char*)loc.filename)); //fileName
+    inits->push(new IntegerExp(loc, loc.linnum, TypeBasic::tuns32)); //line
+    inits->push(new IntegerExp(loc, disabled, TypeBasic::tbool)); //disabled
+
+    StructLiteralExp *exp = new StructLiteralExp(loc, StructDeclaration::UnitTest,
+        inits, StructDeclaration::UnitTest->type);
+    return new ExpInitializer(loc, exp);
+}
+
 /********************************* NewDeclaration ****************************/
 
 NewDeclaration::NewDeclaration(Loc loc, Loc endloc, Parameters *arguments, int varargs)

--- a/src/glue.c
+++ b/src/glue.c
@@ -57,7 +57,8 @@ symbol *ictorlocalgot;
 symbols sctors;
 StaticDtorDeclarations ectorgates;
 symbols sdtors;
-symbols stests;
+symbols oldstests;
+UnitTestDeclarations stests;
 
 symbols ssharedctors;
 SharedStaticDtorDeclarations esharedctorgates;
@@ -326,6 +327,7 @@ void Module::genobjfile(bool multiobj)
     ssharedctors.setDim(0);
     esharedctorgates.setDim(0);
     sshareddtors.setDim(0);
+    oldstests.setDim(0);
     stests.setDim(0);
     dtorcount = 0;
     shareddtorcount = 0;
@@ -454,7 +456,36 @@ void Module::genobjfile(bool multiobj)
 
         ssharedctor = callFuncsAndGates(this, &ssharedctors, (StaticDtorDeclarations *)&esharedctorgates, "__modsharedctor");
         sshareddtor = callFuncsAndGates(this, &sshareddtors, NULL, "__modshareddtor");
-        stest = callFuncsAndGates(this, &stests, NULL, "__modtest");
+        stest = callFuncsAndGates(this, &oldstests, NULL, "__modtest");
+        /*
+         * Unittest V2: Generate static array of UnitTests (see druntime)
+         */
+        if (stests.dim)
+        {
+            if (!StructDeclaration::UnitTest)
+            {
+                warning(loc, "mismatch between compiler and object.d or object.di found. "
+                    "struct UnitTest was not found, advanced unittest information won't "
+                    "be available. "
+                    "Check installation and import paths with -v compiler switch.");
+            }
+            else
+            {
+                unitTests = new UnitTestDeclarations(stests);
+                Type *ttype = new TypeSArray(StructDeclaration::UnitTest->type,
+                    new IntegerExp(loc, stests.dim, Type::tsize_t));
+
+                ArrayInitializer *init = new ArrayInitializer(loc);
+                for (unsigned i = 0; i < stests.dim; i++)
+                {
+                    init->addInit(NULL, stests[i]->toUnitTestInfo());
+                }
+                init->semantic(this->scope, ttype, INITnointerpret);
+                unitTestArr = new VarDeclaration(loc, ttype, new Identifier("__modtestArray", 0), init);
+                unitTestArr->storage_class |= STCgshared | STCimmutable;
+                unitTestArr->semantic(this->scope);
+            }
+        }
 
         if (doppelganger)
             genmoduleinfo();
@@ -1273,7 +1304,8 @@ void FuncDeclaration::toObjFile(bool multiobj)
     // If unit test
     if (ud)
     {
-        stests.push(s);
+        oldstests.push(s);
+        stests.push(this->isUnitTestDeclaration());
     }
 
     if (global.errors)

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -58,6 +58,7 @@ Msgtable msgtable[] =
     { "offset" },
     { "offsetof" },
     { "ModuleInfo" },
+    { "UnitTest", "__UnitTest" },
     { "ClassInfo" },
     { "classinfo" },
     { "typeinfo" },

--- a/src/module.c
+++ b/src/module.c
@@ -71,6 +71,8 @@ Module::Module(const char *filename, Identifier *ident, int doDocComment, int do
     ssharedctor = NULL;
     sshareddtor = NULL;
     stest = NULL;
+    unitTestArr = NULL;
+    unitTests = NULL;
     sfilename = NULL;
     importedFrom = NULL;
     srcfile = NULL;

--- a/src/module.h
+++ b/src/module.h
@@ -140,6 +140,9 @@ public:
     static void runDeferredSemantic3();
     int imports(Module *m);
 
+    Declaration *unitTestArr; //Static array of UnitTests (see druntime)
+    UnitTestDeclarations *unitTests; //All unitTests in this module
+
     bool isRoot() { return this->importedFrom == this; }
                                 // true if the module source file is directly
                                 // listed in command line.

--- a/src/parse.c
+++ b/src/parse.c
@@ -1497,6 +1497,7 @@ InvariantDeclaration *Parser::parseInvariant()
 /*****************************************
  * Parse a unittest definition:
  *      unittest { body }
+ *      unittest identifier { body }
  * Current token is 'unittest'.
  */
 
@@ -1505,8 +1506,14 @@ UnitTestDeclaration *Parser::parseUnitTest()
     UnitTestDeclaration *f;
     Statement *body;
     Loc loc = token.loc;
+    Identifier *id = NULL;
 
     nextToken();
+    if(token.value == TOKidentifier)
+    {
+        id = token.ident;
+        nextToken();
+    }
     const utf8_t *begPtr = token.ptr + 1;  // skip '{'
     const utf8_t *endPtr = NULL;
     body = parseStatement(PScurly, &endPtr);
@@ -1533,7 +1540,7 @@ UnitTestDeclaration *Parser::parseUnitTest()
         }
     }
 
-    f = new UnitTestDeclaration(loc, token.loc, docline);
+    f = new UnitTestDeclaration(loc, token.loc, docline, id);
     f->fbody = body;
     return f;
 }

--- a/src/struct.c
+++ b/src/struct.c
@@ -26,6 +26,7 @@ TypeTuple *toArgTypes(Type *t);
 
 FuncDeclaration *StructDeclaration::xerreq;     // object.xopEquals
 FuncDeclaration *StructDeclaration::xerrcmp;    // object.xopCmp
+StructDeclaration *StructDeclaration::UnitTest;
 
 /***************************************
  * Search toHash member function for TypeInfo_Struct.
@@ -664,6 +665,9 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
 
     if (id == Id::ModuleInfo && !Module::moduleinfo)
         Module::moduleinfo = this;
+
+    if(id == Id::UnitTest && !UnitTest)
+        UnitTest = this;
 }
 
 Dsymbol *StructDeclaration::syntaxCopy(Dsymbol *s)


### PR DESCRIPTION
As discussed in the newsgroup this reboots https://github.com/D-Programming-Language/druntime/pull/308
and  https://github.com/D-Programming-Language/dmd/pull/1131

Ping @andralex
This provides enough to run unittests separately and in different threads, no support for naming tests yet. @andralex what's the preferred syntax for that?
### Detailed description

The new information is available from the `unitTests` member of every ModuleInfo.
`unitTests` is an array of `__UnitTest` structs. The `__UnitTest` struct provides the unittest function, location, etc.
#### Example

``` d
bool tester()
{
    import std.stdio;
    //iterate all modules
    foreach(info; ModuleInfo)
    {
        //iterate unit test in modules
        foreach(test; info.unitTests)
        {
            //access unittest information
            writefln("ver=%s file=%s:%s disabled=%s func=%s", test.ver, test.file, test.line, test.disabled, test.func);
            //execute unittest
            test.func();
        }
    }
    return true;
}

shared static this()
{
    Runtime.moduleUnitTester = &tester;
}
```
#### Example test runners

Simple example: http://dpaste.dzfl.pl/56697348500c
Output: http://dpaste.dzfl.pl/c0c706b0cea4

Parallel runner: http://dpaste.dzfl.pl/cef0a42936d6
Output: http://dpaste.dzfl.pl/d2445d87a9d7
### Available information

The following information is emitted for every unittest:
-  `void function() func`. Call it, pass it to another thread, disassemble, ...
-  `string file`: file name. nice for IDE cause not all unittests always belong to the module (for example, importing `std.stdio` imports two unittests from `std.format`)
- `uint line`: line of test declaration. For IDE
- `bool disabled` true if test is marked `@disable`. (This can be removed if it's controversial)
