### PR TITLE
Add license to visitor header

### DIFF
--- a/src/visitor.h
+++ b/src/visitor.h
@@ -1,3 +1,10 @@
+// Compiler implementation of the D programming language
+// Copyright (c) 2013-2014 by Digital Mars
+// All Rights Reserved
+// http://www.digitalmars.com
+// License for redistribution is by either the Artistic License
+// in artistic.txt, or the GNU General Public License in gnu.txt.
+// See the included readme.txt for details.
 
 #ifndef DMD_VISITOR_H
 #define DMD_VISITOR_H


### PR DESCRIPTION
Just noticed this when reviewing changes for merge into GDC.

All front-end sources (that are legally significant, ie: more than around 15 lines of code) require to be clearly licensed, otherwise I cannot accept them in GDC.

@yebblies - You are the contributor, so you must agree to this.  Thanks.

NB: I am aware that this will change to boost pretty soon.
