### PR TITLE
Issue 12688 - Strange error if function call is in parentheses

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4541,7 +4541,7 @@ Expression *TypeExp::semantic(Scope *sc)
     Type *t;
     Dsymbol *s;
 
-    type->resolve(loc, sc, &e, &t, &s);
+    type->resolve(loc, sc, &e, &t, &s, true);
     if (e)
     {
         //printf("e = %s %s\n", Token::toChars(e->op), e->toChars());

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -595,3 +595,20 @@ class A12555(T)
 static assert(!__traits(compiles, {
     class C : A12555!C  { }
 }));
+
+/***************************************************/
+// 12688
+
+void writeln12688(A...)(A) {}
+
+struct S12688
+{
+    int foo() @property { return 1; }
+}
+
+void test12688()
+{
+    S12688 s;
+    s.foo.writeln12688;   // ok
+    (s.foo).writeln12688; // ok <- ng
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12688

`(s.foo).writeln` is parsed as `DotIdExp(TypeExp('s.foo'), 'writeln')`, but the type `s.foo` should be analyzed as dotvar expression.
