### PR TITLE
Adding support for __traits(documentation, ...)

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -321,6 +321,7 @@ Msgtable msgtable[] =
     { "isLazy" },
     { "hasMember" },
     { "identifier" },
+    { "documentation" },
     { "getProtection" },
     { "parent" },
     { "getMember" },

--- a/src/module.c
+++ b/src/module.c
@@ -509,7 +509,9 @@ void Module::parse()
         return;
     }
     {
-        Parser p(this, buf, buflen, docfile != NULL);
+        // Always lex comments; __traits(documentation, ...) might require it.
+        bool doDocComment = true;
+        Parser p(this, buf, buflen, doDocComment);
         p.nextToken();
         members = p.parseModule();
         md = p.md;

--- a/src/traits.c
+++ b/src/traits.c
@@ -237,6 +237,7 @@ const char* traits[] = {
     "isLazy",
     "hasMember",
     "identifier",
+    "documentation",
     "getProtection",
     "parent",
     "getMember",
@@ -451,6 +452,22 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             id = s->ident;
         }
         StringExp *se = new StringExp(e->loc, id->toChars());
+        return se->semantic(sc);
+    }
+    else if (e->ident == Id::documentation)
+    {
+        if (dim != 1)
+            goto Ldimerror;
+
+        RootObject *o = (*e->args)[0];
+        Dsymbol *s = getDsymbol(o);
+        if (!s)
+        {
+            e->error("argument %s is not a symbol", o->toChars());
+            goto Lfalse;
+        }
+        char *doc = s->comment ? (char *) s->comment : (char *) "";
+        StringExp *se = new StringExp(e->loc, doc, strlen(doc), 'c');
         return se->semantic(sc);
     }
     else if (e->ident == Id::getProtection)

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -312,6 +312,7 @@
    {
     "name" : "bar",
     "kind" : "function",
+    "comment" : " Documentation test\n",
     "line" : 52,
     "char" : 16,
     "deco" : "FNeKkC4json4Bar2Zi",
@@ -393,6 +394,7 @@
     "members" : [
      {
       "kind" : "template",
+      "comment" : " Issue 9480 - Template name should be stripped of parameters\n",
       "line" : 85,
       "char" : 5,
       "name" : "this",
@@ -425,6 +427,7 @@
    {
     "kind" : "template",
     "protection" : "private",
+    "comment" : " Issue 9755 - Protection not emitted properly for Templates.\n",
     "line" : 89,
     "char" : 9,
     "name" : "S1_9755",
@@ -499,6 +502,7 @@
    {
     "name" : "c_10011",
     "kind" : "variable",
+    "comment" : " Issue 10011 - init property is wrong for object initializer.\n",
     "line" : 98,
     "char" : 14,
     "storageClass" : [
@@ -511,6 +515,7 @@
    {
     "name" : "Numbers",
     "kind" : "enum",
+    "comment" : "\n",
     "line" : 101,
     "char" : 1,
     "baseDeco" : "i",

--- a/test/runnable/traits_documentation.d
+++ b/test/runnable/traits_documentation.d
@@ -1,0 +1,30 @@
+/**
+ * Module documentation.
+ */
+module traits_documentation;
+
+/**
+ * Function documentation.
+ */
+void documentedFunc() {}
+/++
+ + Enum documentation.
+ +/
+enum documentedEnum = 1;
+auto documentedVar = 2; /// Some unicode: Σ σ Π π.
+
+void main()
+{
+    enum funcDoc = __traits(documentation, documentedFunc);
+    enum enumDoc = __traits(documentation, documentedEnum);
+    enum varDoc = __traits(documentation, documentedVar);
+    enum modDoc = __traits(documentation, traits_documentation);
+
+    static assert(funcDoc == " Function documentation.\n");
+    static assert(enumDoc == " Enum documentation.\n");
+    static assert(varDoc == "Some unicode: Σ σ Π π.\n");
+    static assert(modDoc == " Module documentation.\n");
+
+    static assert(!__traits(compiles, __traits(documentation, 3)));
+    static assert(!__traits(compiles, __traits(documentation, "4")));
+}


### PR DESCRIPTION
`__traits(comment, expr)` now evaluates to the documentation comment on `expr`, if it exists and is available. Comments will only be available if DMD is invoked with the "-D" flag. If no comment is available for `expr`, `__traits(comment, expr)` evaluates to the empty string.

Unlike `__traits(identifier, expr)`, `__traits(comment, expr)` will not report an error if `expr` is not a symbol or anonymous function. It will instead evaluate to the empty string. This is in the interest of ease of use.

This feature is intended to aide automatic wrapper generation, metaprogramming (e.g. forwarding documentation from a template argument), and simplifying documentation generators. It is not intended to be involved in providing application functionality.
