### PR TITLE
Added .editorconfig file to automatically set proper tab settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+; Standard conventions for the D programming language repository are:
+;  no tab characters
+;  indents are by 4 spaces
+;  line endings are LF
+;  no trailing whitespace
+;  last character in file is an LF
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf


### PR DESCRIPTION
I for one constantly find myself wrecking the formating of files when working between different projects.
`.editorconfig` files are supported by many editors to automatically configure various format settings.

Are all files under the dmd repo using 4 spaces? If there are any exceptions in the repo, they can also be configured in this file.
