### PR TITLE
Issue 12720: Non-int integral template parameters not mangled correctly

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -7241,17 +7241,29 @@ Identifier *TemplateInstance::genIdent(Objects *args)
             ea = ea->ctfeInterpret();
             if (ea->op == TOKerror || olderr != global.errors)
                 continue;
-#if 1
+#if 0
             /* Use deco that matches what it would be for a function parameter
              */
             buf.writestring(ea->type->deco);
 #else
-            // Use type of parameter, not type of argument
-            TemplateParameter *tp = (*tempdecl->parameters)[i];
-            assert(tp);
-            TemplateValueParameter *tvp = tp->isTemplateValueParameter();
-            assert(tvp);
-            buf.writestring(tvp->valType->deco);
+            // Issue 12720: Name mangling should use parameter type
+            // The declared parameter list might be shorter because of variadic arguments
+            if (((TemplateDeclaration*)tempdecl)->parameters->dim > i)
+            {
+                // Use type of parameter, not type of argument
+                TemplateParameter *tp = (*((TemplateDeclaration*)tempdecl)->parameters)[i];
+                assert(tp);
+                TemplateValueParameter *tvp = tp->isTemplateValueParameter();
+                if (tvp && tvp->valType->deco)
+                    buf.writestring(tvp->valType->deco);
+                else
+                    goto Lvalue;
+            }
+            else
+            {
+              Lvalue:
+                buf.writestring(ea->type->deco);
+            }
 #endif
             ea->toMangleBuffer(&buf);
         }

--- a/test/compilable/issue12720.d
+++ b/test/compilable/issue12720.d
@@ -1,0 +1,30 @@
+﻿struct sliceULong(ulong from, ulong to)
+{
+}
+
+static assert(sliceULong!( 6 , 9 ).mangleof == "S10issue1272024__T10sliceULongVmi6Vmi9Z10sliceULong");
+static assert(sliceULong!( 0 , 6 ).mangleof == "S10issue1272024__T10sliceULongVmi0Vmi6Z10sliceULong");
+static assert(sliceULong!( 6L, 9L).mangleof == "S10issue1272024__T10sliceULongVmi6Vmi9Z10sliceULong");
+static assert(sliceULong!( 0L, 6L).mangleof == "S10issue1272024__T10sliceULongVmi0Vmi6Z10sliceULong");
+static assert(sliceULong!( 6u, 9L).mangleof == "S10issue1272024__T10sliceULongVmi6Vmi9Z10sliceULong");
+static assert(sliceULong!( 0u, 6L).mangleof == "S10issue1272024__T10sliceULongVmi0Vmi6Z10sliceULong");
+static assert(sliceULong!( 6u, 9u).mangleof == "S10issue1272024__T10sliceULongVmi6Vmi9Z10sliceULong");
+static assert(sliceULong!( 0u, 6u).mangleof == "S10issue1272024__T10sliceULongVmi0Vmi6Z10sliceULong");
+
+struct sliceInt(int from, int to)
+{
+}
+
+static assert(sliceInt!( 6 , 9 ).mangleof == "S10issue1272021__T8sliceIntVii6Vii9Z8sliceInt");
+static assert(sliceInt!( 0 , 6 ).mangleof == "S10issue1272021__T8sliceIntVii0Vii6Z8sliceInt");
+
+struct sliceAny(T...)
+{
+}
+
+static assert(sliceAny!( 6, 9 ).mangleof == "S10issue1272021__T8sliceAnyVii6Vii9Z8sliceAny");
+static assert(sliceAny!( 0, 6 ).mangleof == "S10issue1272021__T8sliceAnyVii0Vii6Z8sliceAny");
+static assert(sliceAny!( 6UL, 9UL).mangleof == "S10issue1272021__T8sliceAnyVmi6Vmi9Z8sliceAny");
+static assert(sliceAny!( 0UL, 6UL).mangleof == "S10issue1272021__T8sliceAnyVmi0Vmi6Z8sliceAny");
+static assert(sliceAny!( 6L, 9UL).mangleof == "S10issue1272021__T8sliceAnyVli6Vmi9Z8sliceAny");
+static assert(sliceAny!( 0L, 6UL).mangleof == "S10issue1272021__T8sliceAnyVli0Vmi6Z8sliceAny");


### PR DESCRIPTION
The name mangling of templates should use the parameter type if given.

E.g. `struct sliceBits(size_t from, size_t to)` should mangle the type parameter as `size_t` even if an int value is given.

The code which is currently commented out does not compile and is incomplete. This commit fixes this.
