### PR TITLE
fix build with VS2013

### DIFF
--- a/src/backend/strtold.c
+++ b/src/backend/strtold.c
@@ -135,7 +135,7 @@ static longdouble postab[] =
  * Terminates on first unrecognized character.
  */
 
-longdouble strtold(const char *p,char **endp)
+longdouble strtold_dm(const char *p,char **endp)
 {
         longdouble ldval;
         int exp;
@@ -564,7 +564,7 @@ longdouble strtold(const char *p,char **endp)
 
 #else
 
-longdouble strtold(const char *p,char **endp)
+longdouble strtold_dm(const char *p,char **endp)
 {
     return strtod(p, endp);
 }
@@ -579,7 +579,7 @@ longdouble strtold(const char *p,char **endp)
 #include <float.h>
 #include <errno.h>
 
-extern "C" longdouble strtold(const char *p,char **endp);
+longdouble strtold_dm(const char *p,char **endp);
 
 struct longdouble
 {
@@ -593,8 +593,8 @@ void main()
     int i;
 
     errno = 0;
-//  ld = strtold("0x1.FFFFFFFFFFFFFFFEp16383", NULL);
-    ld = strtold("0x1.FFFFFFFFFFFFFFFEp-16382", NULL);
+//  ld = strtold_dm("0x1.FFFFFFFFFFFFFFFEp16383", NULL);
+    ld = strtold_dm("0x1.FFFFFFFFFFFFFFFEp-16382", NULL);
     x = *(struct longdouble *)&ld;
     for (i = 4; i >= 0; i--)
     {
@@ -602,7 +602,7 @@ void main()
     }
     printf("\t%d\n", errno);
 
-    ld = strtold("1.0e5", NULL);
+    ld = strtold_dm("1.0e5", NULL);
     x = *(struct longdouble *)&ld;
     for (i = 4; i >= 0; i--)
     {

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -94,7 +94,7 @@ DMD_OBJS = \
 	cppmangle.o opover.o optimize.o \
 	parse.o scope.o statement.o \
 	struct.o template.o \
-	version.o strtold.o utf.o staticassert.o \
+	version.o utf.o staticassert.o \
 	entity.o doc.o macro.o \
 	hdrgen.o delegatize.o interpret.o traits.o \
 	builtin.o ctfeexpr.o clone.o aliasthis.o \
@@ -129,7 +129,7 @@ BACK_OBJS = go.o gdag.o gother.o gflow.o gloop.o var.o el.o \
 	bcomplex.o aa.o ti_achar.o \
 	ti_pvoid.o pdata.o cv8.o backconfig.o \
 	divcoeff.o dwarf.o \
-	ph2.o util2.o eh.o tk.o \
+	ph2.o util2.o eh.o tk.o strtold.o \
 	$(TARGET_OBJS)
 
 ifeq (osx,$(OS))

--- a/src/root/longdouble.h
+++ b/src/root/longdouble.h
@@ -196,7 +196,6 @@ longdouble tanl (longdouble ld);
 
 longdouble fmodl(longdouble x, longdouble y);
 longdouble ldexpl(longdouble ldval, int exp); // see strtold
-longdouble strtold(const char *p,char **endp);
 
 inline longdouble fabs (longdouble ld) { return fabsl(ld); }
 inline longdouble sqrt (longdouble ld) { return sqrtl(ld); }

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -252,10 +252,12 @@ double Port::strtod(const char *p, char **endp)
     return ::strtod(p, endp);
 }
 
-// See backend/strtold.c.
+// from backend/strtold.c, renamed to avoid clash with decl in stdlib.h
+longdouble strtold_dm(const char *p,char **endp);
+
 longdouble Port::strtold(const char *p, char **endp)
 {
-    return ::strtold(p, endp);
+    return ::strtold_dm(p, endp);
 }
 
 #endif


### PR DESCRIPTION
strtold now also found in stdlib.h for C++11 conformance, but "long double" is still 64-bit only.
