### PR TITLE
Inhibit GCC warning -Wmaybe-uninitialized in DMD_OBJS

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -251,7 +251,7 @@ FuncDeclaration *buildOpAssign(StructDeclaration *sd, Scope *sc)
          */
         //printf("\tswap copy\n");
         Identifier *idtmp = Lexer::uniqueId("__tmp");
-        VarDeclaration *tmp;
+        VarDeclaration *tmp = NULL;
         AssignExp *ec = NULL;
         if (sd->dtor)
         {
@@ -1037,4 +1037,3 @@ FuncDeclaration *buildInv(AggregateDeclaration *ad, Scope *sc)
             return inv;
     }
 }
-

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -133,12 +133,12 @@ Expression *Add(Type *type, Expression *e1, Expression *e2)
         // This rigamarole is necessary so that -0.0 doesn't get
         // converted to +0.0 by doing an extraneous add with +0.0
         complex_t c1;
-        real_t r1;
-        real_t i1;
+        real_t r1 = 0.0;
+        real_t i1 = 0.0;
 
         complex_t c2;
-        real_t r2;
-        real_t i2;
+        real_t r2 = 0.0;
+        real_t i2 = 0.0;
 
         complex_t v;
         int x;
@@ -218,12 +218,12 @@ Expression *Min(Type *type, Expression *e1, Expression *e2)
         // This rigamarole is necessary so that -0.0 doesn't get
         // converted to +0.0 by doing an extraneous add with +0.0
         complex_t c1;
-        real_t r1;
-        real_t i1;
+        real_t r1 = 0.0;
+        real_t i1 = 0.0;
 
         complex_t c2;
-        real_t r2;
-        real_t i2;
+        real_t r2 = 0.0;
+        real_t i2 = 0.0;
 
         complex_t v;
         int x;
@@ -1784,4 +1784,3 @@ Expression *Ptr(Type *type, Expression *e1)
     }
     return EXP_CANT_INTERPRET;
 }
-

--- a/src/doc.c
+++ b/src/doc.c
@@ -1576,17 +1576,17 @@ void ParamSection::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
     size_t len = bodylen;
     const utf8_t *pend = p + len;
 
-    const utf8_t *tempstart;
-    size_t templen;
+    const utf8_t *tempstart = NULL;
+    size_t templen = 0;
 
-    const utf8_t *namestart;
+    const utf8_t *namestart = NULL;
     size_t namelen = 0;       // !=0 if line continuation
 
-    const utf8_t *textstart;
-    size_t textlen;
+    const utf8_t *textstart = NULL;
+    size_t textlen = 0;
 
     size_t o, paramcount = 0;
-    Parameter *arg;
+    Parameter *arg = NULL;
 
     buf->writestring("$(DDOC_PARAMS ");
     while (p < pend)
@@ -1742,14 +1742,14 @@ void DocComment::parseMacros(Escape **pescapetable, Macro **pmacrotable, const u
     size_t len = mlen;
     const utf8_t *pend = p + len;
 
-    const utf8_t *tempstart;
-    size_t templen;
+    const utf8_t *tempstart = NULL;
+    size_t templen = 0;
 
-    const utf8_t *namestart;
+    const utf8_t *namestart = NULL;
     size_t namelen = 0;       // !=0 if line continuation
 
-    const utf8_t *textstart;
-    size_t textlen;
+    const utf8_t *textstart = NULL;
+    size_t textlen = 0;
 
     while (p < pend)
     {
@@ -2193,7 +2193,7 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, size_t offset)
     int leadingBlank = 1;
     int inCode = 0;
     //int inComment = 0;                  // in <!-- ... --> comment
-    size_t iCodeStart;                    // start of code section
+    size_t iCodeStart = 0;                    // start of code section
     size_t codeIndent = 0;
 
     size_t iLineStart = offset;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1450,6 +1450,10 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
                     {
                         dim = 0; // slices are currently always one-dimensional
                     }
+                    else
+                    {
+                        assert(0);
+                    }
 
                     Objects *tiargs = new Objects();
                     Expression *edim = new IntegerExp(Loc(), dim, Type::tsize_t);

--- a/src/expression.c
+++ b/src/expression.c
@@ -6065,7 +6065,7 @@ Expression *IsExp::semantic(Scope *sc)
         return new ErrorExp();
     }
 
-    Type *tded;
+    Type *tded = NULL;
     Type *t = targ->trySemantic(loc, sc);
     if (!t)
         goto Lno;                       // errors, so condition is false
@@ -8285,8 +8285,6 @@ Lagain:
     if (e1->op == TOKdotvar && t1->ty == Tfunction ||
         e1->op == TOKdottd)
     {
-        DotVarExp *dve;
-        DotTemplateExp *dte;
         UnaExp *ue = (UnaExp *)(e1);
 
         Expression *ue1 = ue->e1;
@@ -8300,15 +8298,20 @@ Lagain:
             ue1 = NULL;
         }
 
+        DotVarExp *dve;
+        DotTemplateExp *dte;
         Dsymbol *s;
         if (e1->op == TOKdotvar)
         {
             dve = (DotVarExp *)(e1);
+            dte = NULL;
             s = dve->var;
             tiargs = NULL;
         }
         else
-        {   dte = (DotTemplateExp *)(e1);
+        {
+            dve = NULL;
+            dte = (DotTemplateExp *)(e1);
             s = dte->td;
         }
 
@@ -9843,16 +9846,19 @@ Lagain:
         uinteger_t i1 = lwr->toUInteger();
         uinteger_t i2 = upr->toUInteger();
 
-        size_t length;
         TupleExp *te;
         TypeTuple *tup;
-
+        size_t length;
         if (e1->op == TOKtuple)         // slicing an expression tuple
-        {   te = (TupleExp *)e1;
+        {
+            te = (TupleExp *)e1;
+            tup = NULL;
             length = te->exps->dim;
         }
         else if (e1->op == TOKtype)     // slicing a type tuple
-        {   tup = (TypeTuple *)t;
+        {
+            te = NULL;
+            tup = (TypeTuple *)t;
             length = Parameter::dim(tup->arguments);
         }
         else
@@ -10383,17 +10389,19 @@ Expression *IndexExp::semantic(Scope *sc)
                 return new ErrorExp();
             e2 = e2->ctfeInterpret();
             uinteger_t index = e2->toUInteger();
-            size_t length;
+
             TupleExp *te;
             TypeTuple *tup;
-
+            size_t length;
             if (e1->op == TOKtuple)
             {
                 te = (TupleExp *)e1;
+                tup = NULL;
                 length = te->exps->dim;
             }
             else if (e1->op == TOKtype)
             {
+                te = NULL;
                 tup = (TypeTuple *)t1;
                 length = Parameter::dim(tup->arguments);
             }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4750,7 +4750,7 @@ public:
 
         // Save the pointer expressions and the comparison directions,
         // so we can use them later.
-        Expression *p1, *p2, *p3, *p4;
+        Expression *p1 = NULL, *p2 = NULL, *p3 = NULL, *p4 = NULL;
         int dir1 = isPointerCmpExp(e->e1, &p1, &p2);
         int dir2 = isPointerCmpExp(e->e2, &p3, &p4);
         if (dir1 == 0 || dir2 == 0)
@@ -7126,4 +7126,3 @@ void setValue(VarDeclaration *vd, Expression *newval)
     assert(isCtfeValueValid(newval));
     ctfeStack.setValue(vd, newval);
 }
-

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1399,7 +1399,7 @@ TOK Lexer::hexStringConstant(Token *t)
     unsigned c;
     Loc start = loc();
     unsigned n = 0;
-    unsigned v;
+    unsigned v = ~0; // dead assignment, needed to suppress warning
 
     p++;
     stringbuffer.reset();
@@ -1492,7 +1492,7 @@ TOK Lexer::delimitedStringConstant(Token *t)
     unsigned delimleft = 0;
     unsigned delimright = 0;
     unsigned nest = 1;
-    unsigned nestcount;
+    unsigned nestcount = ~0; // dead assignment, needed to suppress warning
     Identifier *hereid = NULL;
     unsigned blankrol = 0;
     unsigned startline = 0;
@@ -3002,4 +3002,3 @@ void unittest_lexer()
 }
 
 #endif
-

--- a/src/parse.c
+++ b/src/parse.c
@@ -3984,6 +3984,8 @@ Expression *Parser::parseDefaultInitExp()
                 e = new FuncInitExp(token.loc);
             else if (token.value == TOKprettyfunc)
                 e = new PrettyFuncInitExp(token.loc);
+            else
+                assert(0);
             nextToken();
             return e;
         }
@@ -7382,4 +7384,3 @@ void initPrecedence()
 
     precedence[TOKinterval] = PREC_assign;
 }
-

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -39,13 +39,26 @@ LDFLAGS=-lm -lstdc++ -lpthread
 CC=$(HOST_CC) $(MODEL_FLAG)
 GIT=git
 
+# Compiler Warnings
 ifdef ENABLE_WARNINGS
-WARNINGS := -Wall -Wextra -Wno-deprecated -Wstrict-aliasing \
-	-Wno-unused-parameter -Wno-unused-variable -Wno-unused-function \
+WARNINGS := -Wall -Wextra -Wno-deprecated -Wno-strict-aliasing -Wno-empty-body \
+	-Wno-unused-parameter -Wno-unused-value -Wno-unused-variable -Wno-unused-function -Wno-return-type \
 	-Wno-unused-label -Wno-unknown-pragmas -Wno-sign-compare \
 	-Wno-overloaded-virtual -Wno-missing-braces \
-	-Wno-missing-field-initializers -Wno-logical-op -Wno-parentheses
+	-Wno-missing-field-initializers -Wno-parentheses -Wno-format -Wno-attributes \
+	-Wno-char-subscripts -Wno-reorder \
+	-Wno-switch -Wno-type-limits
+# GCC Specific
+ifeq ($(HOST_CC), g++)
+WARNINGS := $(WARNINGS) -Wno-logical-op -Wno-narrowing -Wno-unused-but-set-variable -Wno-uninitialized
+endif
+# Clangn Specific
+ifeq ($(HOST_CC), clang++)
+WARNINGS := $(WARNINGS) -Wno-tautological-constant-out-of-range-compare -Wno-tautological-compare \
+			-Wno-constant-logical-operand -Wno-self-assign -Wno-self-assign # -Wno-sometimes-uninitialized
+endif
 else
+# Default Warnings
 WARNINGS := -Wno-deprecated -Wstrict-aliasing
 endif
 
@@ -75,7 +88,7 @@ CFLAGS += -O2
 endif
 
 # Uniqe extra flags if necessary
-DMD_FLAGS  :=           -I$(ROOT)
+DMD_FLAGS  :=           -I$(ROOT) -Wuninitialized
 GLUE_FLAGS := -DDMDV2=1 -I$(ROOT) -I$(TK) -I$(C)
 BACK_FLAGS := -DDMDV2=1 -I$(ROOT) -I$(TK) -I$(C) -I.
 ROOT_FLAGS := -DDMDV2=1 -I$(ROOT)
@@ -312,19 +325,19 @@ var.o: optab.c tytab.c
 # matching below.
 vpath %.c $(C)
 
-$(DMD_OBJS): %.o: %.c
+$(DMD_OBJS): %.o: %.c posix.mak
 	@echo "  (CC)  DMD_OBJS   $<"
 	$(CC) -c $(CFLAGS) $(DMD_FLAGS) $(MMD) $<
 
-$(BACK_OBJS): %.o: %.c
+$(BACK_OBJS): %.o: %.c posix.mak
 	@echo "  (CC)  BACK_OBJS  $<"
 	$(CC) -c $(CFLAGS) $(BACK_FLAGS) $(MMD) $<
 
-$(GLUE_OBJS): %.o: %.c
+$(GLUE_OBJS): %.o: %.c posix.mak
 	@echo "  (CC)  GLUE_OBJS  $<"
 	$(CC) -c $(CFLAGS) $(GLUE_FLAGS) $(MMD) $<
 
-$(ROOT_OBJS): %.o: $(ROOT)/%.c
+$(ROOT_OBJS): %.o: $(ROOT)/%.c posix.mak
 	@echo "  (CC)  ROOT_OBJS  $<"
 	$(CC) -c $(CFLAGS) $(ROOT_FLAGS) $(MMD) $<
 

--- a/src/template.c
+++ b/src/template.c
@@ -5915,7 +5915,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     // an error.
 #if 1
     Dsymbols *target_symbol_list = NULL;
-    size_t target_symbol_list_idx;
+    size_t target_symbol_list_idx = 0;
 
     {   Dsymbols *a;
 
@@ -8252,5 +8252,3 @@ void TemplateMixin::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
     buf->writeByte(';');
     buf->writenl();
 }
-
-


### PR DESCRIPTION
First of a bunch starting with possible Heisenbugs.

Should I fix GLUE, BACK and ROOT aswell in this commit? 

Floating points are nan-initialized when needed. I'm however unsure about the string arguments to `nan`, `nanl`, `nanf` so I've set them to `?` for now.

I've further explicitly added `-Wno...` to all issued by `-Wall` and `-Wextra` both a common set and those specific to either GCC or Clang. Each one can then be removed from `WARNINGS` and instead put into `(DMD|GLUE|BACK|ROOT)_FLAGS` instead.

This may require some logic as some of these flags are not compatible with both GCC and Clang. For now this -Wmaybe-uninitialized issue warnings when dmd is compiled using Clang. This logic needs to be fixed somehow. Tell me how you want this and I'll fix it :)

Update: I see now that the failure on test compile hosts with older GCC requires casing on compiler version instead if we want to use newer warnings such as `-Wmaybe-uninitialized`. Should we implement this casing or start inhibiting other warnings from -Wall and -Wextra that are compatible with previous GCC versions and then finally activate `-Wextra`?
