### PR TITLE
Issue 12719 - struct.c:705: virtual void StructDeclaration::semantic(Scope*): Assertion `parent && parent == sc->parent' failed.

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -297,8 +297,7 @@ void ClassDeclaration::semantic(Scope *sc)
             ident = Identifier::generateId(id);
         }
     }
-    assert(parent && parent == sc->parent);
-    assert(!isAnonymous());
+    assert(parent && !isAnonymous());
     type = type->semantic(loc, sc);
 
     if (type->ty == Tclass && ((TypeClass *)type)->sym != this)
@@ -330,10 +329,21 @@ void ClassDeclaration::semantic(Scope *sc)
         if (sc->linkage == LINKcpp)
             cpp = true;
     }
+    else if (symtab)
+    {
+        if (sizeok == SIZEOKdone || !scx)
+        {
+            semanticRun = PASSsemanticdone;
+            return;
+        }
+    }
     semanticRun = PASSsemantic;
 
     if (!members)               // if opaque declaration
+    {
+        semanticRun = PASSsemanticdone;
         return;
+    }
     if (!symtab)
         symtab = new DsymbolTable();
 
@@ -1280,8 +1290,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
         assert(sc->parent && sc->func);
         parent = sc->parent;
     }
-    assert(parent && parent == sc->parent);
-    assert(!isAnonymous());
+    assert(parent && !isAnonymous());
     type = type->semantic(loc, sc);
 
     if (type->ty == Tclass && ((TypeClass *)type)->sym != this)
@@ -1304,10 +1313,21 @@ void InterfaceDeclaration::semantic(Scope *sc)
 
         userAttribDecl = sc->userAttribDecl;
     }
+    else if (symtab)
+    {
+        if (sizeok == SIZEOKdone || !scx)
+        {
+            semanticRun = PASSsemanticdone;
+            return;
+        }
+    }
     semanticRun = PASSsemantic;
 
     if (!members)               // if opaque declaration
+    {
+        semanticRun = PASSsemanticdone;
         return;
+    }
     if (!symtab)
         symtab = new DsymbolTable();
 

--- a/src/struct.c
+++ b/src/struct.c
@@ -702,8 +702,7 @@ void StructDeclaration::semantic(Scope *sc)
         assert(sc->parent && sc->func);
         parent = sc->parent;
     }
-    assert(parent && parent == sc->parent);
-    assert(!isAnonymous());
+    assert(parent && !isAnonymous());
     type = type->semantic(loc, sc);
 
     if (type->ty == Tstruct && ((TypeStruct *)type)->sym != this)
@@ -729,11 +728,21 @@ void StructDeclaration::semantic(Scope *sc)
             error("structs, unions cannot be abstract");
         userAttribDecl = sc->userAttribDecl;
     }
+    else if (symtab)
+    {
+        if (sizeok == SIZEOKdone || !scx)
+        {
+            semanticRun = PASSsemanticdone;
+            return;
+        }
+    }
     semanticRun = PASSsemantic;
 
     if (!members)               // if opaque declaration
+    {
+        semanticRun = PASSsemanticdone;
         return;
-
+    }
     if (!symtab)
         symtab = new DsymbolTable();
 

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -3399,6 +3399,18 @@ struct B12719(T)
     }
 }
 
+// --------
+
+enum canDoIt12719(R) = is(typeof(W12719!R));
+
+struct W12719(R)
+{
+    R r;
+    static if (canDoIt12719!R) {}
+}
+
+W12719!int a12719;
+
 /******************************************/
 
 int main()


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12719

Fix the case reported by @monarchdodra .
