### PR TITLE
[REG2.066a] Issue 12727 - DMD hangs up on recursive alias declaration

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -677,8 +677,10 @@ Dsymbol *AliasDeclaration::toAlias()
 
         aliassym = new AliasDeclaration(loc, ident, Type::terror);
         type = Type::terror;
+        return aliassym;
     }
-    else if (aliassym || type->deco)
+
+    if (aliassym || type->deco)
         ;   // semantic is already done.
     else if (import && import->scope)
     {
@@ -689,7 +691,9 @@ Dsymbol *AliasDeclaration::toAlias()
     }
     else if (scope)
         semantic(scope);
+    inSemantic = true;
     Dsymbol *s = aliassym ? aliassym->toAlias() : this;
+    inSemantic = false;
     return s;
 }
 

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -129,8 +129,8 @@ bool Dsymbol::oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident)
     if (members)
     {
         for (size_t i = 0; i < members->dim; i++)
-        {   Dsymbol *sx = (*members)[i];
-
+        {
+            Dsymbol *sx = (*members)[i];
             bool x = sx->oneMember(ps, ident);
             //printf("\t[%d] kind %s = %d, s = %p\n", i, sx->kind(), x, *ps);
             if (!x)
@@ -166,7 +166,8 @@ bool Dsymbol::oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident)
                     }
                 }
                 else                    // more than one symbol
-                {   *ps = NULL;
+                {
+                    *ps = NULL;
                     //printf("\tfalse 2\n");
                     return false;
                 }

--- a/src/template.c
+++ b/src/template.c
@@ -6080,7 +6080,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
             //s->print();
             //printf("'%s', '%s'\n", s->ident->toChars(), tempdecl->ident->toChars());
             //printf("setting aliasdecl\n");
-            aliasdecl = new AliasDeclaration(loc, s->ident, s);
+            aliasdecl = s;
         }
     }
 
@@ -6088,7 +6088,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
      */
     if (fargs && aliasdecl)
     {
-        FuncDeclaration *fd = aliasdecl->toAlias()->isFuncDeclaration();
+        FuncDeclaration *fd = aliasdecl->isFuncDeclaration();
         if (fd)
         {
             /* Transmit fargs to type so that TypeFunction::semantic() can
@@ -6153,17 +6153,15 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
         Dsymbol *s;
         if (Dsymbol::oneMembers(members, &s, tempdecl->ident) && s)
         {
-            if (!aliasdecl || aliasdecl->toAlias() != s)
+            if (!aliasdecl || aliasdecl != s)
             {
                 //printf("s->kind = '%s'\n", s->kind());
                 //s->print();
                 //printf("'%s', '%s'\n", s->ident->toChars(), tempdecl->ident->toChars());
                 //printf("setting aliasdecl 2\n");
-                aliasdecl = new AliasDeclaration(loc, s->ident, s);
+                aliasdecl = s;
             }
         }
-        else if (aliasdecl)
-            aliasdecl = NULL;
     }
 
     /* The problem is when to parse the initializer for a variable.
@@ -7637,11 +7635,6 @@ Dsymbol *TemplateInstance::toAlias()
     }
 
     return inst;
-}
-
-AliasDeclaration *TemplateInstance::isAliasDeclaration()
-{
-    return aliasdecl;
 }
 
 const char *TemplateInstance::kind()

--- a/src/template.h
+++ b/src/template.h
@@ -318,7 +318,7 @@ public:
     TemplateInstance *inst;             // refer to existing instance
     TemplateInstance *tinst;            // enclosing template instance
     ScopeDsymbol *argsym;               // argument symbol table
-    AliasDeclaration *aliasdecl;        // !=NULL if instance is an alias for its sole member
+    Dsymbol *aliasdecl;                 // !=NULL if instance is an alias for its sole member
     int nest;                           // for recursion detection
     bool semantictiargsdone;            // has semanticTiargs() been done?
     bool havetempdecl;                  // if used second constructor
@@ -366,7 +366,6 @@ public:
     void trySemantic3(Scope *sc2);
 
     TemplateInstance *isTemplateInstance() { return this; }
-    AliasDeclaration *isAliasDeclaration();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/test/fail_compilation/ice12727.d
+++ b/test/fail_compilation/ice12727.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ----
-fail_compilation/ice12727.d(23): Error: alias IndexTuple recursive alias declaration
+fail_compilation/ice12727.d(16): Error: alias ice12727.IndexTuple!(1, 0).IndexTuple recursive alias declaration
 fail_compilation/ice12727.d(23): Error: template instance ice12727.IndexTuple!(1, 0) error instantiating
 fail_compilation/ice12727.d(27):        instantiated from here: Matrix!(float, 3)
 fail_compilation/ice12727.d(28):        instantiated from here: Vector!(float, 3)

--- a/test/fail_compilation/ice12727.d
+++ b/test/fail_compilation/ice12727.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+----
+fail_compilation/ice12727.d(23): Error: alias IndexTuple recursive alias declaration
+fail_compilation/ice12727.d(23): Error: template instance ice12727.IndexTuple!(1, 0) error instantiating
+fail_compilation/ice12727.d(27):        instantiated from here: Matrix!(float, 3)
+fail_compilation/ice12727.d(28):        instantiated from here: Vector!(float, 3)
+----
+*/
+
+template IndexTuple(int e, int s = 0, T...)
+{
+    static if (s == e)
+        alias IndexTuple = T;
+    else
+        alias IndexTuple = IndexTuple!(e);
+}
+
+struct Matrix(T, int N = M)
+{
+    pure decomposeLUP()
+    {
+        foreach (j; IndexTuple!(1)) {}
+    }
+}
+
+alias Vector(T, int M) = Matrix!(T, M);
+alias Vector3 = Vector!(float, 3);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12727

By the commit fd1762c33ac034ad3112e69f21421b5c75b3cc6c, now static-if declaration does nothing in `addMembers` phase, and conditional eponymous template instance cannot raise "recursive alias declaration" error in `TemplateInstance::semantic`, because `TemplateInstance::aliasdecl` is not set until the end of it.

By looking for circular aliasing not only in `AliasDeclaration::semantic` but also in `AliasDeclaration::toAlias`, we can defer the detection until appropriate timing.
