### PR TITLE
[Refactoring] Rename variables for ScopeDsymbol to `sds`

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -105,7 +105,7 @@ void printDepsConditional(Scope *sc, DVCondition* condition, const char* depType
 }
 
 
-int DebugCondition::include(Scope *sc, ScopeDsymbol *s)
+int DebugCondition::include(Scope *sc, ScopeDsymbol *sds)
 {
     //printf("DebugCondition::include() level = %d, debuglevel = %d\n", level, global.params.debuglevel);
     if (inc == 0)
@@ -269,7 +269,7 @@ VersionCondition::VersionCondition(Module *mod, unsigned level, Identifier *iden
 {
 }
 
-int VersionCondition::include(Scope *sc, ScopeDsymbol *s)
+int VersionCondition::include(Scope *sc, ScopeDsymbol *sds)
 {
     //printf("VersionCondition::include() level = %d, versionlevel = %d\n", level, global.params.versionlevel);
     //if (ident) printf("\tident = '%s'\n", ident->toChars());
@@ -324,13 +324,13 @@ Condition *StaticIfCondition::syntaxCopy()
     return new StaticIfCondition(loc, exp->syntaxCopy());
 }
 
-int StaticIfCondition::include(Scope *sc, ScopeDsymbol *s)
+int StaticIfCondition::include(Scope *sc, ScopeDsymbol *sds)
 {
 #if 0
-    printf("StaticIfCondition::include(sc = %p, s = %p) this=%p inc = %d\n", sc, s, this, inc);
-    if (s)
+    printf("StaticIfCondition::include(sc = %p, sds = %p) this=%p inc = %d\n", sc, sds, this, inc);
+    if (sds)
     {
-        printf("\ts = '%s', kind = %s\n", s->toChars(), s->kind());
+        printf("\ts = '%s', kind = %s\n", sds->toChars(), sds->kind());
     }
 #endif
     if (inc == 0)
@@ -351,7 +351,7 @@ int StaticIfCondition::include(Scope *sc, ScopeDsymbol *s)
 
         ++nest;
         sc = sc->push(sc->scopesym);
-        sc->sd = s;                     // s gets any addMember()
+        sc->sds = sds;                  // sds gets any addMember()
         sc->flags |= SCOPEstaticif;
 
         sc = sc->startCTFE();

--- a/src/cond.h
+++ b/src/cond.h
@@ -36,7 +36,7 @@ public:
     Condition(Loc loc);
 
     virtual Condition *syntaxCopy() = 0;
-    virtual int include(Scope *sc, ScopeDsymbol *s) = 0;
+    virtual int include(Scope *sc, ScopeDsymbol *sds) = 0;
     virtual void toCBuffer(OutBuffer *buf, HdrGenState *hgs) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }
 };
@@ -61,7 +61,7 @@ public:
 
     DebugCondition(Module *mod, unsigned level, Identifier *ident);
 
-    int include(Scope *sc, ScopeDsymbol *s);
+    int include(Scope *sc, ScopeDsymbol *sds);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     DebugCondition *isDebugCondition() { return this; }
 };
@@ -81,7 +81,7 @@ public:
 
     VersionCondition(Module *mod, unsigned level, Identifier *ident);
 
-    int include(Scope *sc, ScopeDsymbol *s);
+    int include(Scope *sc, ScopeDsymbol *sds);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 };
 
@@ -93,7 +93,7 @@ public:
 
     StaticIfCondition(Loc loc, Expression *exp);
     Condition *syntaxCopy();
-    int include(Scope *sc, ScopeDsymbol *s);
+    int include(Scope *sc, ScopeDsymbol *sds);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 };
 

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -590,25 +590,23 @@ int Dsymbol::apply(Dsymbol_apply_ft_t fp, void *param)
     return (*fp)(this, param);
 }
 
-int Dsymbol::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
+int Dsymbol::addMember(Scope *sc, ScopeDsymbol *sds, int memnum)
 {
     //printf("Dsymbol::addMember('%s')\n", toChars());
-    //printf("Dsymbol::addMember(this = %p, '%s' scopesym = '%s')\n", this, toChars(), sd->toChars());
-    //printf("Dsymbol::addMember(this = %p, '%s' sd = %p, sd->symtab = %p)\n", this, toChars(), sd, sd->symtab);
-    parent = sd;
+    //printf("Dsymbol::addMember(this = %p, '%s' scopesym = '%s')\n", this, toChars(), sds->toChars());
+    //printf("Dsymbol::addMember(this = %p, '%s' sds = %p, sds->symtab = %p)\n", this, toChars(), sds, sds->symtab);
+    parent = sds;
     if (!isAnonymous())         // no name, so can't add it to symbol table
     {
-        if (!sd->symtabInsert(this))    // if name is already defined
+        if (!sds->symtabInsert(this))    // if name is already defined
         {
-            Dsymbol *s2;
-
-            s2 = sd->symtab->lookup(ident);
+            Dsymbol *s2 = sds->symtab->lookup(ident);
             if (!s2->overloadInsert(this))
             {
-                sd->multiplyDefined(Loc(), this, s2);
+                sds->multiplyDefined(Loc(), this, s2);
             }
         }
-        if (sd->isAggregateDeclaration() || sd->isEnumDeclaration())
+        if (sds->isAggregateDeclaration() || sds->isEnumDeclaration())
         {
             if (ident == Id::__sizeof || ident == Id::__xalignof || ident == Id::mangleof)
                 error(".%s property cannot be redefined", ident->toChars());
@@ -872,13 +870,13 @@ Dsymbol *ScopeDsymbol::syntaxCopy(Dsymbol *s)
 {
     //printf("ScopeDsymbol::syntaxCopy('%s')\n", toChars());
 
-    ScopeDsymbol *sd;
+    ScopeDsymbol *sds;
     if (s)
-        sd = (ScopeDsymbol *)s;
+        sds = (ScopeDsymbol *)s;
     else
-        sd = new ScopeDsymbol(ident);
-    sd->members = arraySyntaxCopy(members);
-    return sd;
+        sds = new ScopeDsymbol(ident);
+    sds->members = arraySyntaxCopy(members);
+    return sds;
 }
 
 /*****************************************

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -176,7 +176,7 @@ public:
     virtual const char *kind();
     virtual Dsymbol *toAlias();                 // resolve real symbol
     virtual int apply(Dsymbol_apply_ft_t fp, void *param);
-    virtual int addMember(Scope *sc, ScopeDsymbol *s, int memnum);
+    virtual int addMember(Scope *sc, ScopeDsymbol *sds, int memnum);
     virtual void setScope(Scope *sc);
     virtual void importAll(Scope *sc);
     virtual void semantic(Scope *sc);

--- a/src/enum.c
+++ b/src/enum.c
@@ -72,7 +72,7 @@ void EnumDeclaration::setScope(Scope *sc)
     ScopeDsymbol::setScope(sc);
 }
 
-int EnumDeclaration::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
+int EnumDeclaration::addMember(Scope *sc, ScopeDsymbol *sds, int memnum)
 {
 #if 0
     printf("EnumDeclaration::addMember() %s\n", toChars());
@@ -85,11 +85,11 @@ int EnumDeclaration::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
 
     /* Anonymous enum members get added to enclosing scope.
      */
-    ScopeDsymbol *scopesym = isAnonymous() ? sd : this;
+    ScopeDsymbol *scopesym = isAnonymous() ? sds : this;
 
     if (!isAnonymous())
     {
-        ScopeDsymbol::addMember(sc, sd, memnum);
+        ScopeDsymbol::addMember(sc, sds, memnum);
 
         if (!symtab)
             symtab = new DsymbolTable();

--- a/src/enum.h
+++ b/src/enum.h
@@ -51,7 +51,7 @@ public:
 
     EnumDeclaration(Loc loc, Identifier *id, Type *memtype);
     Dsymbol *syntaxCopy(Dsymbol *s);
-    int addMember(Scope *sc, ScopeDsymbol *sd, int memnum);
+    int addMember(Scope *sc, ScopeDsymbol *sds, int memnum);
     void setScope(Scope *sc);
     void semantic(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);

--- a/src/expression.c
+++ b/src/expression.c
@@ -6311,8 +6311,8 @@ Expression *IsExp::semantic(Scope *sc)
                 if (m <= MATCHnomatch)
                     goto Lno;
                 s->semantic(sc);
-                if (sc->sd)
-                    s->addMember(sc, sc->sd, 1);
+                if (sc->sds)
+                    s->addMember(sc, sc->sds, 1);
                 else if (!sc->insert(s))
                     error("declaration %s is already defined", s->toChars());
             }
@@ -6343,8 +6343,8 @@ Lyes:
          */
         if (!tup && !sc->insert(s))
             error("declaration %s is already defined", s->toChars());
-        if (sc->sd)
-            s->addMember(sc, sc->sd, 1);
+        if (sc->sds)
+            s->addMember(sc, sc->sds, 1);
     }
     //printf("Lyes\n");
     return new IntegerExp(loc, 1, Type::tbool);

--- a/src/import.h
+++ b/src/import.h
@@ -58,7 +58,7 @@ public:
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     Dsymbol *toAlias();
-    int addMember(Scope *sc, ScopeDsymbol *s, int memnum);
+    int addMember(Scope *sc, ScopeDsymbol *sds, int memnum);
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
     bool overloadInsert(Dsymbol *s);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7040,8 +7040,8 @@ void TypeTypeof::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol
         }
         else if (exp->op == TOKimport)
         {
-            ScopeDsymbol *s = ((ScopeExp *)exp)->sds;
-            if (s->isPackage())
+            ScopeDsymbol *sds = ((ScopeExp *)exp)->sds;
+            if (sds->isPackage())
             {
                 error(loc, "%s has no type", exp->toChars());
                 goto Lerr;

--- a/src/scope.c
+++ b/src/scope.c
@@ -55,7 +55,7 @@ Scope::Scope()
     //printf("Scope::Scope() %p\n", this);
     this->module = NULL;
     this->scopesym = NULL;
-    this->sd = NULL;
+    this->sds = NULL;
     this->enclosing = NULL;
     this->parent = NULL;
     this->sw = NULL;
@@ -97,7 +97,7 @@ Scope::Scope(Scope *enclosing)
     this->func   = enclosing->func;
     this->parent = enclosing->parent;
     this->scopesym = NULL;
-    this->sd = NULL;
+    this->sds = NULL;
     this->sw = enclosing->sw;
     this->tf = enclosing->tf;
     this->tinst = enclosing->tinst;

--- a/src/scope.h
+++ b/src/scope.h
@@ -68,8 +68,8 @@ struct Scope
 
     Module *module;             // Root module
     ScopeDsymbol *scopesym;     // current symbol
-    ScopeDsymbol *sd;           // if in static if, and declaring new symbols,
-                                // sd gets the addMember()
+    ScopeDsymbol *sds;          // if in static if, and declaring new symbols,
+                                // sds gets the addMember()
     FuncDeclaration *func;      // function we are in
     Dsymbol *parent;            // parent to use
     LabelStatement *slabel;     // enclosing labelled statement

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -40,7 +40,7 @@ Dsymbol *StaticAssert::syntaxCopy(Dsymbol *s)
     return sa;
 }
 
-int StaticAssert::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
+int StaticAssert::addMember(Scope *sc, ScopeDsymbol *sds, int memnum)
 {
     return 0;           // we didn't add anything
 }
@@ -52,8 +52,8 @@ void StaticAssert::semantic(Scope *sc)
 void StaticAssert::semantic2(Scope *sc)
 {
     //printf("StaticAssert::semantic2() %s\n", toChars());
-    ScopeDsymbol *sd = new ScopeDsymbol();
-    sc = sc->push(sd);
+    ScopeDsymbol *sds = new ScopeDsymbol();
+    sc = sc->push(sds);
     sc->flags |= SCOPEstaticassert;
 
     sc = sc->startCTFE();

--- a/src/staticassert.h
+++ b/src/staticassert.h
@@ -29,7 +29,7 @@ public:
     StaticAssert(Loc loc, Expression *exp, Expression *msg);
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    int addMember(Scope *sc, ScopeDsymbol *sd, int memnum);
+    int addMember(Scope *sc, ScopeDsymbol *sds, int memnum);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);

--- a/src/traits.c
+++ b/src/traits.c
@@ -757,7 +757,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             goto Ldimerror;
         RootObject *o = (*e->args)[0];
         Dsymbol *s = getDsymbol(o);
-        ScopeDsymbol *sd;
+        ScopeDsymbol *sds;
         if (!s)
         {
             e->error("argument has no members");
@@ -767,9 +767,9 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
         if ((import = s->isImport()) != NULL)
         {
             // Bugzilla 9692
-            sd = import->mod;
+            sds = import->mod;
         }
-        else if ((sd = s->isScopeDsymbol()) == NULL)
+        else if ((sds = s->isScopeDsymbol()) == NULL)
         {
             e->error("%s %s has no members", s->kind(), s->toChars());
             goto Lfalse;
@@ -824,9 +824,9 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
 
         Identifiers *idents = new Identifiers;
 
-        ScopeDsymbol::foreach(sc, sd->members, &PushIdentsDg::dg, idents);
+        ScopeDsymbol::foreach(sc, sds->members, &PushIdentsDg::dg, idents);
 
-        ClassDeclaration *cd = sd->isClassDeclaration();
+        ClassDeclaration *cd = sds->isClassDeclaration();
         if (cd && e->ident == Id::allMembers)
         {
             struct PushBaseMembers

--- a/src/version.c
+++ b/src/version.c
@@ -46,14 +46,13 @@ Dsymbol *DebugSymbol::syntaxCopy(Dsymbol *s)
     return ds;
 }
 
-int DebugSymbol::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
+int DebugSymbol::addMember(Scope *sc, ScopeDsymbol *sds, int memnum)
 {
-    //printf("DebugSymbol::addMember('%s') %s\n", sd->toChars(), toChars());
-    Module *m;
+    //printf("DebugSymbol::addMember('%s') %s\n", sds->toChars(), toChars());
+    Module *m = sds->isModule();
 
     // Do not add the member to the symbol table,
     // just make sure subsequent debug declarations work.
-    m = sd->isModule();
     if (ident)
     {
         if (!m)
@@ -135,14 +134,13 @@ Dsymbol *VersionSymbol::syntaxCopy(Dsymbol *s)
     return ds;
 }
 
-int VersionSymbol::addMember(Scope *sc, ScopeDsymbol *sd, int memnum)
+int VersionSymbol::addMember(Scope *sc, ScopeDsymbol *sds, int memnum)
 {
-    //printf("VersionSymbol::addMember('%s') %s\n", sd->toChars(), toChars());
-    Module *m;
+    //printf("VersionSymbol::addMember('%s') %s\n", sds->toChars(), toChars());
+    Module *m = sds->isModule();
 
     // Do not add the member to the symbol table,
     // just make sure subsequent debug declarations work.
-    m = sd->isModule();
     if (ident)
     {
         VersionCondition::checkPredefined(loc, ident->toChars());

--- a/src/version.h
+++ b/src/version.h
@@ -29,7 +29,7 @@ public:
     DebugSymbol(Loc loc, unsigned level);
     Dsymbol *syntaxCopy(Dsymbol *);
 
-    int addMember(Scope *sc, ScopeDsymbol *s, int memnum);
+    int addMember(Scope *sc, ScopeDsymbol *sds, int memnum);
     void semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();
@@ -45,7 +45,7 @@ public:
     VersionSymbol(Loc loc, unsigned level);
     Dsymbol *syntaxCopy(Dsymbol *);
 
-    int addMember(Scope *sc, ScopeDsymbol *s, int memnum);
+    int addMember(Scope *sc, ScopeDsymbol *sds, int memnum);
     void semantic(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();


### PR DESCRIPTION
A short variable name `sd` is currently used for `StructDeclaration` and `ScopeDsymbol`, but for the latter `sds` is also used. By renaming variables we can reduce confusion.
