### PR TITLE
Fix: Issue 10520 - [profile+nothrow] Building with profiler results in "...

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -1184,7 +1184,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
             Statement *sf = ExpStatement::create(loc, e);
 
             Statement *stf;
-            if (sbody->blockExit(this, tf->isnothrow) == BEfallthru)
+            if (sbody->blockExit(this, false) == BEfallthru)
                 stf = CompoundStatement::create(Loc(), sbody, sf);
             else
                 stf = TryFinallyStatement::create(Loc(), sbody, sf);

--- a/test/compilable/test10520.d
+++ b/test/compilable/test10520.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -debug -profile
+
+// Issue 10520 [profile+nothrow] Building with profiler results in "is not nothrow" error on some contracts
+
+void f() { }
+
+void g()()
+in { f(); } // OK <- Error: 'main.f' is not nothrow
+body { }
+
+alias gi = g!();


### PR DESCRIPTION
...is not nothrow" error on some contracts

When Statement#blockExit() checks if the statements may throw or not, it
can also emit compile error.
We turn the second argument of it, mustNotThrow, to false
so that the error is suppressed.
