### PR TITLE
Issue 12529 - Function/delegate type alias picks up @safe attribute from surrounding scope

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -373,17 +373,15 @@ void AliasDeclaration::semantic(Scope *sc)
         goto L2;                        // it's a symbolic alias
 
     type = type->addStorageClass(storage_class);
-    if (storage_class & (STCref | STCnothrow | STCnogc | STCpure | STCdisable))
-    {
-        // For 'ref' to be attached to function types, and picked
-        // up by Type::resolve(), it has to go into sc.
-        sc = sc->push();
-        sc->stc |= storage_class & (STCref | STCnothrow | STCnogc | STCpure | STCshared | STCdisable);
-        type->resolve(loc, sc, &e, &t, &s);
-        sc = sc->pop();
-    }
-    else
-        type->resolve(loc, sc, &e, &t, &s);
+
+    // For 'ref', 'pure', 'nothrow', '@safe', etc. to be attached to function types,
+    // and picked up by Type::resolve(), it has to go into sc.
+    // And, prevent picking up function attributes from surrounding scope.
+    sc = sc->push();
+    sc->stc = storage_class & STC_FUNCATTR;
+    type->resolve(loc, sc, &e, &t, &s);
+    sc = sc->pop();
+
     if (s)
     {
         goto L2;

--- a/src/parse.c
+++ b/src/parse.c
@@ -3795,7 +3795,7 @@ L2:
                 /* AliasDeclaration distinguish @safe, @system, @trusted atttributes
                  * on prefix and postfix.
                  *   @safe alias void function() FP1;
-                 *   alias @safe void function() FP2;    // FP2 is not @safe
+                 *   alias @safe void function() FP2;    // changed to be @safe with bugzilla 12529
                  *   alias void function() @safe FP3;
                  */
                 pAttrs->storageClass &= (STCsafe | STCsystem | STCtrusted);

--- a/test/compilable/aliasdecl.d
+++ b/test/compilable/aliasdecl.d
@@ -11,10 +11,10 @@ alias X4 = void delegate() const, X5 = Test!int;
 static assert(is(X4 == void delegate() const));
 static assert(is(X5.Type == int));
 
-alias FP5 = extern(C) pure nothrow @safe @nogc void function(),
-      DG5 = extern(D) pure nothrow @safe @nogc void delegate();
-static assert(FP5.stringof == "extern (C) void function() pure nothrow " /* ~ "@safe " */ ~ "@nogc");
-static assert(DG5.stringof ==            "void delegate() pure nothrow " /* ~ "@safe " */ ~ "@nogc");
+alias FP5 = extern(C) pure nothrow @nogc @safe void function(),
+      DG5 = extern(D) pure nothrow @nogc @safe void delegate();
+static assert(FP5.stringof == "extern (C) void function() pure nothrow @nogc @safe");
+static assert(DG5.stringof ==            "void delegate() pure nothrow @nogc @safe");
 
 void main()
 {

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -743,7 +743,7 @@ static assert(typeof(prefix_qualified_fp_array1).stringof
 alias @safe void function() AliasDecl_FP2;    // is not @safe
 alias void function() @safe AliasDecl_FP3;
 static assert(AliasDecl_FP1.stringof == "void function() @safe");
-static assert(AliasDecl_FP2.stringof == "void function()");
+static assert(AliasDecl_FP2.stringof == "void function() @safe");
 static assert(AliasDecl_FP3.stringof == "void function() @safe");
 
 /***************************************************/

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -295,6 +295,35 @@ void test11421()
 }
 
 /***************************************************/
+// 12529
+
+pure nothrow ref @safe @nogc @property { alias int function() FP12529x1; }
+pure nothrow ref @safe @nogc @property { alias FP12529x2 = int function(); }
+static assert(FP12529x1.stringof == "int function()");
+static assert(FP12529x2.stringof == "int function()");
+
+alias pure nothrow @nogc @property ref @safe int function() FP12529y1;
+alias FP12529y2 = pure nothrow @nogc @property ref @safe int function();
+static assert(FP12529y1.stringof == "int function() pure nothrow @nogc @property ref @safe");
+static assert(FP12529y2.stringof == "int function() pure nothrow @nogc @property ref @safe");
+
+ref immutable(int) test12529() pure nothrow @safe @nogc @property
+{
+    alias int delegate() DG12529x1;
+    alias DG12529x2 = int delegate();
+    static assert(DG12529x1.stringof == "int delegate()");
+    static assert(DG12529x2.stringof == "int delegate()");
+
+    alias pure nothrow @nogc @property ref @safe int delegate() DG12529y1;
+    alias DG12529y2 = pure nothrow @nogc @property ref @safe int delegate();
+    static assert(DG12529y1.stringof == "int delegate() pure nothrow @nogc @property ref @safe");
+    static assert(DG12529y2.stringof == "int delegate() pure nothrow @nogc @property ref @safe");
+
+    immutable static int x = 10;
+    return x;
+}
+
+/***************************************************/
 // 13776
 
 enum a13776(T) = __traits(compiles, { T; });


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12529
