### PR TITLE
Issue 9570 - Wrong foreach index implicit conversion error

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -3400,7 +3400,15 @@ IntRange getIntRange(Expression *e)
                 ir2 = IntRange(SignExtendedNumber(0), SignExtendedNumber(64));
 
             range = IntRange(ir1.imin >> ir2.imax, ir1.imax >> ir2.imin).cast(e->type);
+        }
 
+        void visit(VarExp *e)
+        {
+            VarDeclaration* vd = e->var->isVarDeclaration();
+            if (vd && vd->range)
+                range = *vd->range;
+            else
+                visit((Expression *)e);
         }
 
         void visit(CommaExp *e)

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -895,6 +895,7 @@ VarDeclaration::VarDeclaration(Loc loc, Type *type, Identifier *id, Initializer 
     ctfeAdrOnStack = -1;
     rundtor = NULL;
     edtor = NULL;
+    range = NULL;
 }
 
 Dsymbol *VarDeclaration::syntaxCopy(Dsymbol *s)

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -290,6 +290,7 @@ public:
                                 // if the destructor should be run. Used to prevent
                                 // dtor calls on postblitted vars
     Expression *edtor;          // if !=NULL, does the destruction of the variable
+    IntRange *range;            // if !NULL, the variable is known to be within the range
 
     VarDeclaration(Loc loc, Type *t, Identifier *id, Initializer *init);
     Dsymbol *syntaxCopy(Dsymbol *);

--- a/test/compilable/test9570.d
+++ b/test/compilable/test9570.d
@@ -1,0 +1,19 @@
+void main() {
+    ubyte[256] data;
+    foreach (immutable i; 0..256)
+        data[i] = i;
+    foreach (const i; 0..256)
+        data[i] = i;
+    foreach (immutable i, x; data)
+        data[i] = i;
+    foreach (const i, x; data)
+        data[i] = i;
+    foreach_reverse (immutable i; 0..256)
+        data[i] = i;
+    foreach_reverse (const i; 0..256)
+        data[i] = i;
+    foreach_reverse (immutable i, x; data)
+        data[i] = i;
+    foreach_reverse (const i, x; data)
+        data[i] = i;
+}


### PR DESCRIPTION
Initial attempt to fix bug 9570.

Added a IntRange\* to VarDeclaration which tracks the range for variables for which the range is known, in this case foreach over range, array and sarray. This range will only be used when the iterator is declared const or immutable.

Added a simple test case, based on bug report. This PR is also needed to fix bug 259 (prevent false positives.)
