### PR TITLE
Mark if(__ctfe) blocks as SCOPEctfe

### DIFF
--- a/test/fail_compilation/nogc4.d
+++ b/test/fail_compilation/nogc4.d
@@ -1,0 +1,47 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+/***************** if(__ctfe) *******************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/nogc4.d(19): Error: cannot use operator ~= in @nogc function test1
+fail_compilation/nogc4.d(33): Error: cannot use operator ~= in @nogc function test2
+fail_compilation/nogc4.d(45): Error: cannot use operator ~= in @nogc function test3
+---
+*/
+@nogc void test1()
+{
+    if(!__ctfe)
+    {
+        int[] arr;
+        arr ~= 42;
+    }
+}
+
+@nogc void test2()
+{
+    if(__ctfe)
+    {
+        int[] arr;
+        arr ~= 42;
+    }
+    else
+    {
+        int[] arr;
+        arr ~= 42;
+    }
+}
+
+@nogc void test3()
+{
+    if(__ctfe)
+    {
+    }
+    else
+    {
+        int[] arr;
+        arr ~= 42;
+    }
+}

--- a/test/runnable/nogc.d
+++ b/test/runnable/nogc.d
@@ -8,6 +8,27 @@ extern(C) int printf(const char*, ...);
     return 3;
 }
 
+@nogc void test2()
+{
+    if(__ctfe)
+    {
+        int[] arr;
+        arr ~= 42;
+    }
+}
+
+@nogc void test3()
+{
+    if(!__ctfe)
+    {
+    }
+    else
+    {
+        int[] arr;
+        arr ~= 42;
+    }
+}
+
 /***********************/
 // 12642
 
@@ -34,6 +55,8 @@ void test12642() @nogc
 int main()
 {
     test1();
+    test2();
+    test3();
     test12642();
 
     printf("Success\n");


### PR DESCRIPTION
Allows e.g. allocating in an if(__ctfe) block in a @nogc function
