### PR TITLE
Fixed compilation of DMD with MSVC

### DIFF
--- a/src/dmd_msc.vcproj
+++ b/src/dmd_msc.vcproj
@@ -626,6 +626,14 @@
 				>
 			</File>
 			<File
+				RelativePath=".\nspace.c"
+				>
+			</File>
+			<File
+				RelativePath=".\nspace.h"
+				>
+			</File>
+			<File
 				RelativePath=".\objfile.h"
 				>
 			</File>

--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -126,6 +126,7 @@
     <ClCompile Include="msc.c" />
     <ClCompile Include="mtype.c" />
     <ClCompile Include="nogc.c" />
+    <ClCompile Include="nspace.c" />
     <ClCompile Include="opover.c" />
     <ClCompile Include="optimize.c" />
     <ClCompile Include="parse.c" />
@@ -304,6 +305,7 @@
     <ClInclude Include="mars.h" />
     <ClInclude Include="module.h" />
     <ClInclude Include="mtype.h" />
+    <ClInclude Include="nspace.h" />
     <ClInclude Include="objfile.h" />
     <ClInclude Include="parse.h" />
     <ClInclude Include="scope.h" />


### PR DESCRIPTION
Because we keep failing to add new files to the external build system's project files.
