### PR TITLE
Fix bug 9937 CTFE floats don't overflow correctly

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -196,6 +196,9 @@ bool isFloatIntPaint(Type *to, Type *from);
 // Reinterpret float/int value 'fromVal' as a float/integer of type 'to'.
 Expression *paintFloatInt(Expression *fromVal, Type *to);
 
+// Reduce the precision of the expression, to the expression of the type
+Expression *discardExcessFloatPrecision(Expression *val);
+
 /// Return true if t is an AA
 bool isAssocArray(Type *t);
 

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -823,6 +823,48 @@ bool isFloatIntPaint(Type *to, Type *from)
         || (from->isfloating() && to->isintegral()) );
 }
 
+// Discard extra bits from a floating point number, that cannot be stored
+// in a variable of that type. For example, float.max*2 cannot be stored
+// in a float.
+Expression *discardExcessFloatPrecision(Expression *val)
+{
+    if (exceptionOrCantInterpret(val))
+        return val;
+    if (val->type->ty == Tfloat32 || val->type->ty == Timaginary32)
+    {
+        UnionFloatInt u;
+        u.f = val->type->isreal() ? val->toReal() : val->toImaginary();
+        return new RealExp(val->loc, ldouble(u.f), val->type);
+    }
+    if (val->type->ty == Tfloat64 || val->type->ty == Timaginary64)
+    {
+        UnionDoubleLong u;
+        u.f = val->type->isreal() ? val->toReal() : val->toImaginary();
+        return new RealExp(val->loc, ldouble(u.f), val->type);
+    }
+    if (val->type->ty == Tcomplex32)
+    {
+        complex_t cvalue;
+        UnionFloatInt ur, ui;
+        ur.f = val->toReal();
+        ui.f = val->toImaginary();
+        cvalue.re = ur.f;
+        cvalue.im = ui.f;
+        return new ComplexExp(val->loc, cvalue, val->type);
+    }
+    if (val->type->ty == Tcomplex64)
+    {
+        complex_t cvalue;
+        UnionDoubleLong ur, ui;
+        ur.f = val->toReal();
+        ui.f = val->toImaginary();
+        cvalue.re = ur.f;
+        cvalue.im = ui.f;
+        return new ComplexExp(val->loc, cvalue, val->type);
+    }
+    return val;
+}
+
 // Reinterpret float/int value 'fromVal' as a float/integer of type 'to'.
 Expression *paintFloatInt(Expression *fromVal, Type *to)
 {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -6549,6 +6549,11 @@ Expression *scrubReturnValue(Loc loc, Expression *e)
             return EXP_CANT_INTERPRET;
         aae->type = toBuiltinAAType(aae->type);
     }
+    if (e->type->isfloating())
+    {
+        // Discard bits which aren't representable at runtime
+        e = discardExcessFloatPrecision(e);
+    }
     return e;
 }
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3845,6 +3845,30 @@ bool bug9170()
 static assert(bug9170());
 
 /**************************************************
+    9937 Excess float precision shouldn't pass from CTFE to runtime
+**************************************************/
+const float bug9937a = float.max*2;
+const float bug9937b = float.infinity;
+static assert(bug9937a == bug9937b);
+
+const double bug9937c = double.max*2;
+const double bug9937d = double.infinity;
+static assert(bug9937c == bug9937d);
+
+const idouble bug9937e = double.max*2i;
+const idouble bug9937f = idouble.infinity;
+static assert(bug9937e == bug9937f);
+static assert(bug9937e.im == double.infinity);
+
+const cfloat bug9937g = float.max*-2 + double.max*2i;
+const cfloat bug9937h = -float.infinity + ifloat.infinity;
+static assert(bug9937g == bug9937h);
+
+const cdouble bug9937i = idouble.max*-2i + idouble.max*2;
+const cdouble bug9937j = double.infinity + idouble.infinity;
+static assert(bug9937i == bug9937j);
+
+/**************************************************
     6792 ICE with pointer cast of indexed array
 **************************************************/
 


### PR DESCRIPTION
This fixes the bug in comment 4 of bug 9937.
https://issues.dlang.org/show_bug.cgi?id=9937#c4

Although CTFE floats may use higher precision than is available on the target machine, it is impossible for that extra precision to survive to runtime.
This commit forces the extra bits to be discarded at the end of CTFE, rather than in the glue layer. This eliminates the bizarre anomalies in bug 9937 where a variable has two values at the same time (!) It also opens the way for CTFE to calculate with much higher precision than is available at runtime.

This pull request does _not_ affect floating point overflow inside CTFE, which is what Walter found controversial in that big report. It's only the transition from CTFE to runtime which is affected.
