### PR TITLE
CallExp::f should be initialized in its constructor

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7953,6 +7953,7 @@ CallExp::CallExp(Loc loc, Expression *e)
         : UnaExp(loc, TOKcall, sizeof(CallExp), e)
 {
     this->arguments = NULL;
+    this->f = NULL;
 }
 
 CallExp::CallExp(Loc loc, Expression *e, Expression *earg1)
@@ -7960,10 +7961,12 @@ CallExp::CallExp(Loc loc, Expression *e, Expression *earg1)
 {
     Expressions *arguments = new Expressions();
     if (earg1)
-    {   arguments->setDim(1);
+    {
+        arguments->setDim(1);
         (*arguments)[0] = earg1;
     }
     this->arguments = arguments;
+    this->f = NULL;
 }
 
 CallExp::CallExp(Loc loc, Expression *e, Expression *earg1, Expression *earg2)
@@ -7975,6 +7978,7 @@ CallExp::CallExp(Loc loc, Expression *e, Expression *earg1, Expression *earg2)
     (*arguments)[1] = earg2;
 
     this->arguments = arguments;
+    this->f = NULL;
 }
 
 CallExp *CallExp::create(Loc loc, Expression *e, Expressions *exps)

--- a/src/sideeffect.c
+++ b/src/sideeffect.c
@@ -154,9 +154,8 @@ bool lambdaHasSideEffect(Expression *e)
                 if (t->ty == Tdelegate)
                     t = ((TypeDelegate *)t)->next;
                 if (t->ty == Tfunction &&
-                    (ce->f && ce->f->type->ty == Tfunction
-                        ? callSideEffectLevel(ce->f)
-                        : callSideEffectLevel(ce->e1->type)) > 0)
+                    (ce->f ? callSideEffectLevel(ce->f)
+                           : callSideEffectLevel(ce->e1->type)) > 0)
                 {
                 }
                 else
@@ -230,9 +229,8 @@ void discardValue(Expression *e)
                     if (t->ty == Tdelegate)
                         t = ((TypeDelegate *)t)->next;
                     if (t->ty == Tfunction &&
-                        (ce->f && ce->f->type->ty == Tfunction
-                            ? callSideEffectLevel(ce->f)
-                            : callSideEffectLevel(ce->e1->type)) > 0)
+                        (ce->f ? callSideEffectLevel(ce->f)
+                               : callSideEffectLevel(ce->e1->type)) > 0)
                     {
                         const char *s;
                         if (ce->f)


### PR DESCRIPTION
It has caused Heisenberg Bug.
