### PR TITLE
Issue 11542 & 12809 - Improve blockExit calculation on try-catch-finally statement

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -573,26 +573,34 @@ int Statement::blockExit(FuncDeclaration *func, bool mustNotThrow)
                 if (c->type == Type::terror)
                     continue;
 
+                int cresult;
                 if (c->handler)
-                    catchresult |= c->handler->blockExit(func, mustNotThrow);
+                    cresult = c->handler->blockExit(func, mustNotThrow);
                 else
-                    catchresult |= BEfallthru;
+                    cresult = BEfallthru;
 
                 /* If we're catching Object, then there is no throwing
                  */
                 Identifier *id = c->type->toBasetype()->isClassHandle()->ident;
-                if (id == Id::Object || id == Id::Throwable)
+                if (c->internalCatch && (cresult & BEfallthru))
+                {
+                    // Bugzilla 11542: leave blockExit flags of the body
+                    cresult &= ~BEfallthru;
+                }
+                else if (id == Id::Object || id == Id::Throwable)
                 {
                     result &= ~(BEthrow | BEerrthrow);
                 }
-                if (id == Id::Exception)
+                else if (id == Id::Exception)
                 {
                     result &= ~BEthrow;
                 }
+                catchresult |= cresult;
             }
             if (mustNotThrow && (result & BEthrow))
             {
-                s->body->blockExit(func, mustNotThrow); // now explain why this is nothrow
+                // now explain why this is nothrow
+                s->body->blockExit(func, mustNotThrow);
             }
             result |= catchresult;
         }
@@ -614,7 +622,7 @@ int Statement::blockExit(FuncDeclaration *func, bool mustNotThrow)
             if (finalresult == BEhalt)
                 result = BEnone;
 
-            if (mustNotThrow && (result & BEthrow))
+            if (mustNotThrow)
             {
                 // now explain why this is nothrow
                 if (s->body && (result & BEthrow))
@@ -642,6 +650,13 @@ int Statement::blockExit(FuncDeclaration *func, bool mustNotThrow)
 
         void visit(ThrowStatement *s)
         {
+            if (s->internalThrow)
+            {
+                // Bugzilla 8675: Allow throwing 'Throwable' object even if mustNotThrow.
+                result = BEfallthru;
+                return;
+            }
+
             Type *t = s->exp->type->toBasetype();
             ClassDeclaration *cd = t->isClassHandle();
             assert(cd);
@@ -652,9 +667,7 @@ int Statement::blockExit(FuncDeclaration *func, bool mustNotThrow)
                 result = BEerrthrow;
                 return;
             }
-            // Bugzilla 8675
-            // Throwing Errors is allowed even if mustNotThrow
-            if (!s->internalThrow && mustNotThrow)
+            if (mustNotThrow)
                 s->error("%s is thrown but not caught", s->exp->type->toChars());
 
             result = BEthrow;

--- a/test/fail_compilation/fail11542.d
+++ b/test/fail_compilation/fail11542.d
@@ -1,0 +1,73 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11542.d(16): Error: object.Exception is thrown but not caught
+fail_compilation/fail11542.d(13): Error: function 'fail11542.test_success1' is nothrow yet may throw
+fail_compilation/fail11542.d(26): Error: object.Exception is thrown but not caught
+fail_compilation/fail11542.d(23): Error: function 'fail11542.test_success3' is nothrow yet may throw
+---
+*/
+void test_success1() nothrow
+{
+    scope(success) {}
+    throw new Exception("");    // error
+}
+void test_success2() nothrow
+{
+    scope(success) {}
+    throw new Error("");        // no error
+}
+void test_success3() nothrow
+{
+    scope(success) assert(0);
+    throw new Exception("");    // error
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11542.d(39): Error: object.Exception is thrown but not caught
+fail_compilation/fail11542.d(36): Error: function 'fail11542.test_failure1' is nothrow yet may throw
+---
+*/
+void test_failure1() nothrow
+{
+    scope(failure) {}
+    throw new Exception("");    // error
+}
+void test_failure2() nothrow
+{
+    scope(failure) {}
+    throw new Error("");        // no error
+}
+void est_failure3() nothrow
+{
+    scope(failure) assert(0);
+    throw new Exception("");    // no error
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11542.d(62): Error: object.Exception is thrown but not caught
+fail_compilation/fail11542.d(59): Error: function 'fail11542.test_exit1' is nothrow yet may throw
+---
+*/
+void test_exit1() nothrow
+{
+    scope(exit) {}
+    throw new Exception("");    // error
+}
+void test_exit2() nothrow
+{
+    scope(exit) {}
+    throw new Error("");        // no error
+}
+void test_exit3() nothrow
+{
+    scope(exit) assert(0);
+    throw new Exception("");    // no error
+}

--- a/test/fail_compilation/fail12809.d
+++ b/test/fail_compilation/fail12809.d
@@ -1,0 +1,80 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+bool cond;
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12809.d(19): Error: object.Exception is thrown but not caught
+fail_compilation/fail12809.d(16): Error: function 'fail12809.test_finally1' is nothrow yet may throw
+fail_compilation/fail12809.d(35): Error: object.Exception is thrown but not caught
+fail_compilation/fail12809.d(39): Error: object.Exception is thrown but not caught
+fail_compilation/fail12809.d(32): Error: function 'fail12809.test_finally3' is nothrow yet may throw
+---
+*/
+void test_finally1() nothrow
+{
+    try
+        throw new Exception("");        // error
+    finally
+    {}
+}
+
+void test_finally2() nothrow
+{
+    try
+        throw new Exception("");        // no error
+    finally
+        assert(0);  // unconditional halt
+}
+
+void test_finally3() nothrow
+{
+    try
+        throw new Exception("");        // error
+    finally
+    {
+        if (cond)
+            throw new Exception("");    // error
+        assert(0);  // conditional halt
+    }
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12809.d(59): Error: object.Exception is thrown but not caught
+fail_compilation/fail12809.d(54): Error: function 'fail12809.test_finally4' is nothrow yet may throw
+fail_compilation/fail12809.d(75): Error: object.Exception is thrown but not caught
+fail_compilation/fail12809.d(79): Error: object.Exception is thrown but not caught
+fail_compilation/fail12809.d(70): Error: function 'fail12809.test_finally6' is nothrow yet may throw
+---
+*/
+void test_finally4() nothrow
+{
+    try
+    {}
+    finally
+        throw new Exception("");        // error
+}
+
+void test_finally5() nothrow
+{
+    try
+        assert(0);  // unconditional halt
+    finally
+        throw new Exception("");        // no error
+}
+
+void test_finally6() nothrow
+{
+    try
+    {
+        if (cond)
+            throw new Exception("");    // error
+        assert(0);  // conditional halt
+    }
+    finally
+        throw new Exception("");        // error
+}

--- a/test/fail_compilation/fail4082.d
+++ b/test/fail_compilation/fail4082.d
@@ -1,0 +1,34 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail4082.d(14): Error: 'fail4082.Foo.~this' is not nothrow
+fail_compilation/fail4082.d(12): Error: function 'fail4082.test1' is nothrow yet may throw
+---
+*/
+struct Foo
+{
+    ~this() { throw new Exception(""); }
+}
+nothrow void test1()
+{
+    Foo f;
+
+    goto NEXT;
+NEXT:
+    ;
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail4082.d(32): Error: 'fail4082.Bar.~this' is not nothrow
+fail_compilation/fail4082.d(32): Error: function 'fail4082.test2' is nothrow yet may throw
+---
+*/
+struct Bar
+{
+    ~this() { throw new Exception(""); }
+}
+nothrow void test2(Bar t)
+{
+}

--- a/test/fail_compilation/fail4082a.d
+++ b/test/fail_compilation/fail4082a.d
@@ -1,8 +1,0 @@
-struct Foo {
-    ~this() { throw new Exception(""); }
-}
-nothrow void main() {
-    Foo f;
-    goto NEXT;
-    NEXT:;
-}

--- a/test/fail_compilation/fail4082b.d
+++ b/test/fail_compilation/fail4082b.d
@@ -1,4 +1,0 @@
-struct Foo {
-    ~this() { throw new Exception(""); }
-}
-nothrow void b(Foo t) {}

--- a/test/fail_compilation/warn12809.d
+++ b/test/fail_compilation/warn12809.d
@@ -1,0 +1,34 @@
+// REQUIRED_ARGS: -o- -w
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/warn12809.d(16): Warning: statement is not reachable
+fail_compilation/warn12809.d(25): Warning: statement is not reachable
+fail_compilation/warn12809.d(33): Warning: statement is not reachable
+---
+*/
+void test_unrachable1()
+{
+    try assert(0);
+    finally
+    {
+        int x = 1;  // unreachable
+    }
+}
+
+void test_unrachable2()
+{
+    try assert(0);
+    finally {}
+
+    int x = 1;      // unreachable
+}
+
+void test_unrachable3()
+{
+    try {}
+    finally assert(0);
+
+    int x = 1;      // unreachable
+}


### PR DESCRIPTION
[Issue 11542](https://issues.dlang.org/show_bug.cgi?id=11542) - scope(failure) messes up nothrow checking
[Issue 12809](https://issues.dlang.org/show_bug.cgi?id=12809) - More strict nothrow check for try-finally statement
