### PR TITLE
Fix bug 7209: Stack overflow on circular enum with explicit type

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3201,6 +3201,14 @@ Lagain:
             }
             e = e->copy();
             e->loc = loc;   // for better error message
+
+            // Detect recursive initializers.
+            // BUG: The check for speculative gagging is not correct
+            if (v->inuse && !global.isSpeculativeGagging())
+            {
+                e->error("circular initialization of %s", v->toChars());
+                return new ErrorExp();
+            }
             e = e->semantic(sc);
             return e;
         }

--- a/test/fail_compilation/fail269.d
+++ b/test/fail_compilation/fail269.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail269.d(11): Error: circular initialization of b
+fail_compilation/fail269.d(12): Error: circular initialization of a
+fail_compilation/fail269.d(19): Error: circular initialization of bug7209
 ---
 */
 
@@ -15,3 +16,4 @@ else
     const int a = .b;
     const int b = .a;
 }
+enum int bug7209 = bug7209;

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -1,8 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test8556.d(22): Error: template instance test8556.Grab!(Circle!(uint[])) does not match template declaration Grab(Range) if (!isSliceable!Range)
-fail_compilation/test8556.d(53): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
+fail_compilation/test8556.d(33): Error: circular initialization of isSliceable
+fail_compilation/test8556.d(34): Error: circular initialization of isSliceable
+fail_compilation/test8556.d(22): Error: template instance test8556.isSliceable!(Circle!(uint[])) error instantiating
+fail_compilation/test8556.d(27):        instantiated from here: Grab!(Circle!(uint[]))
+fail_compilation/test8556.d(58):        instantiated from here: grab!(Circle!(uint[]))
+fail_compilation/test8556.d(27):        while looking for match for Grab!(Circle!(uint[]))
+fail_compilation/test8556.d(61): Error: Circle!(uint[]) cannot be sliced with []
 ---
 */
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=7209

Detect the error in the semantic pass. This slightly changes the error message for one existing test (it was previously detected inside CTFE) -- now the _first_ circular definition generates the error, which makes
more sense.
