### PR TITLE
require opEquals for AA keys

### DIFF
--- a/test/fail_compilation/fail11591b.d
+++ b/test/fail_compilation/fail11591b.d
@@ -1,0 +1,34 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11591b.d(16): Error: associative array key type S11591 does not have 'const bool opEquals(ref const S11591)' member function
+---
+*/
+
+struct S11591
+{
+    bool opEquals(int i) { return false; }
+    Object o; // needed to suppress compiler generated opEquals
+}
+
+void test11591()
+{
+    int[S11591] aa;
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11591b.d(30): Error: associative array key type S12307a does not have 'const bool opEquals(ref const S12307a)' member function
+fail_compilation/fail11591b.d(31): Error: associative array key type S12307b does not have 'const bool opEquals(ref const S12307b)' member function
+---
+*/
+struct S12307a { bool opEquals(T : typeof(this))(T) { return false; } }
+
+void test12307()
+{
+    int[S12307a] aa1;    // a
+    int[S12307b] aa2;    // b
+}
+
+struct S12307b { bool opEquals(T : typeof(this))(T) { return false; } }

--- a/test/runnable/imports/link12144a.d
+++ b/test/runnable/imports/link12144a.d
@@ -9,7 +9,7 @@ struct S8 { bool opEquals(T : typeof(this))(T) { return false; } }
 struct S9 { bool opEquals(T : typeof(this))(T) { return false; } }
 
 struct S10 { bool opEquals(T : typeof(this))(T) { return false; } }
-struct S11 { bool opEquals(T : typeof(this))(T) { return false; }
+struct S11 { bool opEquals(T : typeof(this))(T) const { return false; }
              int opCmp(T : typeof(this))(T) const { return 0; } }
 struct S12 { bool opEquals(T : typeof(this))(T) { return false; } }
 struct S13 { bool opEquals(T : typeof(this))(T) { return false; } }


### PR DESCRIPTION
- Check that the compiler can generate a runtime function to test AA keys for equality.
- This is necessary to switch the druntime implementation from opCmp to opEquals.
