### PR TITLE
Issue 3022 - scope x = new Foo; does not allocate on stack if Foo has allocator

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1561,18 +1561,22 @@ Lnomatch:
                 canassign--;
                 ei->exp->optimize(WANTvalue);
 
-                if (isScope())
+                if (isScope() && ei->exp->op != TOKerror)
                 {
                     Expression *ex = ei->exp;
                     while (ex->op == TOKcomma)
                         ex = ((CommaExp *)ex)->e2;
                     assert(ex->op == TOKblit || ex->op == TOKconstruct);
                     ex = ((AssignExp *)ex)->e2;
-                    if (ex->op == TOKnew)
+                    if (ex->op == TOKnew && type->toBasetype()->ty == Tclass)
                     {
                         // See if initializer is a NewExp that can be allocated on the stack
                         NewExp *ne = (NewExp *)ex;
-                        if (!(ne->newargs && ne->newargs->dim) && type->toBasetype()->ty == Tclass)
+                        if (ne->newargs && ne->newargs->dim > 1)
+                        {
+                            error("conflict stack allocation and allocator call");
+                        }
+                        else
                         {
                             ne->onstack = 1;
                             onstack = 1;

--- a/test/fail_compilation/fail3022.d
+++ b/test/fail_compilation/fail3022.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail3022.d(15): Error: variable fail3022.main.x conflict stack allocation and allocator call
+---
+*/
+
+class Foo
+{
+    new(size_t, int) { return null; }
+}
+
+void main()
+{
+    scope x = new(1) Foo();
+}

--- a/test/runnable/nogc.d
+++ b/test/runnable/nogc.d
@@ -9,6 +9,21 @@ extern(C) int printf(const char*, ...);
 }
 
 /***********************/
+// 3022
+
+class Foo3022
+{
+    new(size_t) { assert(0); }
+    delete(void*) { assert(0); }
+}
+
+void test3022() @nogc
+{
+    int n;
+    scope x = new Foo3022;
+}
+
+/***********************/
 // 3032
 
 void test3032() @nogc
@@ -48,6 +63,7 @@ void test12642() @nogc
 int main()
 {
     test1();
+    test3022();
     test3032();
     test12642();
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=3022

Ignore arguments for allocator call if the `NewExp` is allocated on stack.
