### PR TITLE
Improve failing foreach reporting for struct and class aggregates

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1591,7 +1591,18 @@ Statement *ForeachStatement::semantic(Scope *sc)
 
     if (!inferAggregate(this, sc, sapply))
     {
-        error("invalid foreach aggregate %s", aggr->toChars());
+        const char *s;
+        if (aggr->type && isAggregate(aggr->type))
+        {
+            s = ", define opApply(), range primitives, or use .tupleof";
+        }
+        else
+        {
+            // dumb else switch needed because recent GCC doesn't allow s to
+            // default inititalized because of jumps to Lerror
+            s = "";
+        }
+        error("invalid foreach aggregate %s%s", aggr->toChars(), s);
     Lerror:
         return new ErrorStatement();
     }

--- a/test/fail_compilation/fail118.d
+++ b/test/fail_compilation/fail118.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail118.d(26): Error: invalid foreach aggregate Iter
-fail_compilation/fail118.d(27): Error: invalid foreach aggregate Iter
+fail_compilation/fail118.d(26): Error: invalid foreach aggregate Iter, define opApply(), range primitives, or use .tupleof
+fail_compilation/fail118.d(27): Error: invalid foreach aggregate Iter, define opApply(), range primitives, or use .tupleof
 ---
 */
 

--- a/test/fail_compilation/fail261.d
+++ b/test/fail_compilation/fail261.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail261.d(18): Error: invalid foreach aggregate range
+fail_compilation/fail261.d(18): Error: invalid foreach aggregate range, define opApply(), range primitives, or use .tupleof
 ---
 */
 


### PR DESCRIPTION
Should I, similarly for enums, add tip for `__traits(members)`?
