### PR TITLE
fix 12826: make a copy of the second argument to _d_arrayappendT to avoid aliasing

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2876,7 +2876,7 @@ elem *toElem(Expression *e, IRState *irs)
                     // Append array
                     e1 = el_una(OPaddr, TYnptr, e1);
                     if (config.exe == EX_WIN64)
-                        e2 = addressElem(e2, tb2);
+                        e2 = addressElem(e2, tb2, true);
                     else
                         e2 = useOPstrpar(e2);
                     elem *ep = el_params(e2, e1, ce->e1->type->getTypeInfo(NULL)->toElem(irs), NULL);

--- a/test/runnable/testappend.d
+++ b/test/runnable/testappend.d
@@ -3,27 +3,39 @@
 import std.c.stdio;
 import std.math;
 
+void test12826()
+{
+    string s, t;
+    t = t ~ "1234567";
+    s = s ~ "1234567";
+
+    s ~= s;
+    assert(s == "12345671234567", s);
+    assert(t == "1234567", t);
+}
+
+
 int main()
 {
     int[] a;
 
     for (int i = 0; i < 1000; i++)
     {
-	a.length = a.length + 100;
+        a.length = a.length + 100;
     }
     foreach (v; a)
     {
-	assert(v == 0);
+        assert(v == 0);
     }
 
     float[] b;
     for (int i = 0; i < 2000; i++)
     {
-	b.length = b.length + 100;
+        b.length = b.length + 100;
     }
     foreach (v; b)
     {
-	assert(isnan(v));
+        assert(isnan(v));
     }
     delete a;
     delete b;
@@ -31,25 +43,26 @@ int main()
     a = null;
     for (int i = 0; i < 100000; i++)
     {
-	a ~= i;
+        a ~= i;
     }
     foreach (k, v; a)
     {
-	assert(v == k);
+        assert(v == k);
     }
 
     b = null;
     for (int i = 0; i < 200000; i++)
     {
-	b ~= i;
+        b ~= i;
     }
     foreach (k, v; b)
     {
-	assert(v == k);
+        assert(v == k);
     }
     delete a;
     delete b;
 
+    test12826();
     printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12826

If it is possible to figure out that the second argument is not an alias to the first, the copy could be avoided.
