### PR TITLE
Issue 11047 - UDA + getAttributes bypass purity/safety check

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -225,9 +225,10 @@ public:
     UserAttributeDeclaration(Expressions *atts, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
+    void setScope(Scope *sc);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
-    void setScope(Scope *sc);
+    void semanticAttributes(Scope *sc);
     static Expressions *concat(Expressions *udas1, Expressions *udas2);
     Expressions *getAttributes();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);

--- a/src/traits.c
+++ b/src/traits.c
@@ -702,7 +702,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             e->error("first argument is not a symbol");
             goto Lfalse;
         }
-        //printf("getAttributes %s, attrs = %p, scope = %p\n", s->toChars(), s->userAttributes, s->userAttributesScope);
+        //printf("getAttributes %s, userAttribDecl = %p\n", s->toChars(), s->userAttribDecl);
         UserAttributeDeclaration *udad = s->userAttribDecl;
         TupleExp *tup = new TupleExp(e->loc, udad ? udad->getAttributes() : new Expressions());
         return tup->semantic(sc);

--- a/test/fail_compilation/fail11047.d
+++ b/test/fail_compilation/fail11047.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11047.d(14): Error: expression write(x++) is void and has no value
+fail_compilation/fail11047.d(15): Error: expression writeln() is void and has no value
+fail_compilation/fail11047.d(16): Error: static variable x cannot be read at compile time
+---
+*/
+
+void write(T, A...)(T arg0, A args) {}
+void writeln(A...)(A args) {}
+int x;
+
+@(write(x++),
+  writeln(),
+  x
+ ) void foo(){}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=11047

All value elements in UDAs should be evaluated in compile time.
