### PR TITLE
Issue 12827 - DMD segfaults when affecting immutable member with himself

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3183,6 +3183,14 @@ Lagain:
 
     if (VarDeclaration *v = s->isVarDeclaration())
     {
+        // Detect recursive initializers.
+        // BUG: The check for speculative gagging is not correct
+        if (v->inuse && !global.isSpeculativeGagging())
+        {
+            error("circular initialization of %s", v->toChars());
+            return new ErrorExp();
+        }
+
         /* Bugzilla 12023: forward reference should be resolved
          * before 's->needThis()' is called.
          */
@@ -3237,14 +3245,6 @@ Lagain:
             }
             e = e->copy();
             e->loc = loc;   // for better error message
-
-            // Detect recursive initializers.
-            // BUG: The check for speculative gagging is not correct
-            if (v->inuse && !global.isSpeculativeGagging())
-            {
-                e->error("circular initialization of %s", v->toChars());
-                return new ErrorExp();
-            }
             e = e->semantic(sc);
             return e;
         }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2354,14 +2354,14 @@ public:
                 !hasValue(v) &&
                 v->init && !v->isCTFE())
             {
-                if(v->scope)
-                    v->init = v->init->semantic(v->scope, v->type, INITinterpret); // might not be run on aggregate members
-                e = v->init->toExpression(v->type);
                 if (v->inuse)
                 {
                     error(loc, "circular initialization of %s", v->toChars());
                     return EXP_CANT_INTERPRET;
                 }
+                if (v->scope)
+                    v->init = v->init->semantic(v->scope, v->type, INITinterpret); // might not be run on aggregate members
+                e = v->init->toExpression(v->type);
 
                 if (e && (e->op == TOKconstruct || e->op == TOKblit))
                 {

--- a/test/fail_compilation/ice12827.d
+++ b/test/fail_compilation/ice12827.d
@@ -1,0 +1,23 @@
+// REQUIRED_ARGS: -d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice12827.d(12): Error: circular initialization of i
+fail_compilation/ice12827.d(17): Error: circular initialization of i
+fail_compilation/ice12827.d(22): Error: circular initialization of i
+---
+*/
+struct S1
+{
+    int i = i;
+}
+
+struct S2
+{
+    immutable int i = i;
+}
+
+struct S3
+{
+    enum int i = i;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12827

`v->inuse` check should be done before the semantic of `v->init`.
