### PR TITLE
Visitor refactor fix

### DIFF
--- a/src/optimize.c
+++ b/src/optimize.c
@@ -1202,7 +1202,7 @@ Expression *Expression_optimize(Expression *e, int result, bool keepLvalue)
             Expression *e1 = fromConstInitializer(result, e->e1);
             Expression *e2 = fromConstInitializer(result, e->e2);
 
-            ret = Cmp(e->op, e->type, e->e1, e->e2);
+            ret = Cmp(e->op, e->type, e1, e2);
             if (ret == EXP_CANT_INTERPRET)
                 ret = e;
         }


### PR DESCRIPTION
Follow up on "Fix minor warning issues #3598". Refactoring in 0215b46 missed shadowing local variable name e1 and e2 for CmpExp and EqualExp vistor methods.
