### PR TITLE
add some array bounds check optimizations

### DIFF
--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -660,8 +660,6 @@ void el_replace_sym(elem *e,symbol *s1,symbol *s2)
  *      0       no
  */
 
-#if MARS
-
 int el_appears(elem *e,Symbol *s)
 {
     symbol_debug(s);
@@ -687,6 +685,8 @@ int el_appears(elem *e,Symbol *s)
     }
     return 0;
 }
+
+#if MARS
 
 /*****************************************
  * Look for symbol that is a base of addressing mode e.
@@ -1792,12 +1792,7 @@ int el_noreturn(elem *e)
     while (1)
     {   elem_debug(e);
         switch (e->Eoper)
-        {   case OPcomma:
-                if ((result |= el_noreturn(e->E1)) != 0)
-                    break;
-                e = e->E2;
-                continue;
-
+        {
             case OPcall:
             case OPucall:
                 e = e->E1;
@@ -1809,7 +1804,28 @@ int el_noreturn(elem *e)
                 result = 1;
                 break;
 
+            case OPandand:
+            case OPoror:
+                e = e->E1;
+                continue;
+
+            case OPcolon:
+            case OPcolon2:
+                return el_noreturn(e->E1) && el_noreturn(e->E2);
+
             default:
+                if (EBIN(e))
+                {
+                    if (el_noreturn(e->E2))
+                        return 1;
+                    e = e->E1;
+                    continue;
+                }
+                if (EUNA(e))
+                {
+                    e = e->E1;
+                    continue;
+                }
                 break;
         }
         break;

--- a/src/backend/gflow.c
+++ b/src/backend/gflow.c
@@ -1,5 +1,5 @@
 // Copyright (C) 1985-1998 by Symantec
-// Copyright (C) 2000-2009 by Digital Mars
+// Copyright (C) 2000-2014 by Digital Mars
 // All Rights Reserved
 // http://www.digitalmars.com
 // Written by Walter Bright

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -215,8 +215,8 @@ enum OPER
         OPnullptr,              // null pointer
         OPasm,                  /* in-line assembly code        */
         OPinfo,                 // attach info (used to attach ctor/dtor
-        OPhalt,                 // insert HLT instruction
                                 // info for exception handling)
+        OPhalt,                 // insert HLT instruction
         OPctor,
         OPdtor,
         OPmark,

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -650,7 +650,7 @@ Symbol *Module::toModuleArray()
 
         marray = toSymbolX("__array", SCextern, t, "Z");
         marray->Sfl = FLextern;
-        marray->Sflags |= SFLnodebug;
+        marray->Sflags |= SFLnodebug | SFLexit;
         slist_add(marray);
     }
     return marray;


### PR DESCRIPTION
This does some data flow analysis to eliminate some low hanging fruit on redundant array bounds checks. For example,

```
void test(int[] a) {
    for (size_t i = 0; i < 10; ++i)
        a[i] = a[i] + 1;
}
```

now only gets one bounds check inside the loop rather than 2.
