### PR TITLE
Fix issue 12849: pmovmskb instruction cannot store to 64-bit registers

### DIFF
--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -2692,7 +2692,8 @@ PTRNTAB3 aptb3VPMINUB[] = /* VPMINUB */ {
 
 PTRNTAB2 aptb2PMOVMSKB[] = /* PMOVMSKB */ {
         { 0x0FD7, _r,_r32,_mm },
-        { PMOVMSKB, _r,_r,_xmm },
+        { PMOVMSKB, _r, _r32, _xmm },
+        { PMOVMSKB, _r|_64_bit, _r64, _xmm },
         { ASM_END }
 };
 

--- a/src/backend/ptrntab.c
+++ b/src/backend/ptrntab.c
@@ -2692,7 +2692,7 @@ PTRNTAB3 aptb3VPMINUB[] = /* VPMINUB */ {
 
 PTRNTAB2 aptb2PMOVMSKB[] = /* PMOVMSKB */ {
         { 0x0FD7, _r,_r32,_mm },
-        { PMOVMSKB, _r,_r32,_xmm },
+        { PMOVMSKB, _r,_r,_xmm },
         { ASM_END }
 };
 

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -6599,6 +6599,23 @@ L1:     pop     RAX;
 
 /****************************************************/
 
+void test12849()
+{
+    ulong a = 0xff00ff00ff00ff00L;
+    ulong result;
+    ulong expected = 0b10101010;
+    asm
+    {
+        pxor XMM0, XMM0;
+        movq XMM0, a;
+        pmovmskb RAX, XMM0;
+        mov result, RAX;
+    }
+    assert (result == expected);
+}
+
+/****************************************************/
+
 int main()
 {
     printf("Testing iasm64.d\n");
@@ -6668,6 +6685,7 @@ int main()
     test9866();
     testxadd();
     test9965();
+    test12849();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12849
