### PR TITLE
Issue 6359 - Pure/@safe-inference should not be affected by __traits(compiles)

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -674,6 +674,7 @@ public:
     bool hasOverloads();
     PURE isPure();
     PURE isPureBypassingInference();
+    bool isPureBypassingInferenceX();
     bool setImpure();
     bool isSafe();
     bool isSafeBypassingInference();

--- a/src/doc.c
+++ b/src/doc.c
@@ -2165,7 +2165,7 @@ bool isReservedName(utf8_t *str, size_t len)
     static const char *table[] = {
         "__ctor", "__dtor", "__cpctor", "__postblit", "__invariant", "__unitTest",
         "__require", "__ensure", "__dollar", "__ctfe", "__withSym", "__result",
-        "__returnLabel", "__vptr", "__monitor", "__xopEquals", "__xopCmp",
+        "__returnLabel", "__vptr", "__monitor", "__gate", "__xopEquals", "__xopCmp",
         "__LINE__", "__FILE__", "__MODULE__", "__FUNCTION__", "__PRETTY_FUNCTION__",
         "__DATE__", "__TIME__", "__TIMESTAMP__", "__VENDOR__", "__VERSION__",
         "__EOF__", "__LOCAL_SIZE", "___tls_get_addr", "__entrypoint", "__va_argsave_t",

--- a/src/expression.c
+++ b/src/expression.c
@@ -2341,7 +2341,7 @@ void Expression::checkPurity(Scope *sc, VarDeclaration *v)
     if (v->isDataseg())
     {
         // Bugzilla 7533: Accessing implicit generated __gate is pure.
-        if (strcmp(v->ident->toChars(), "__gate") == 0)
+        if (v->ident == Id::gate)
             return;
 
         /* Accessing global mutable state.

--- a/src/expression.c
+++ b/src/expression.c
@@ -2304,7 +2304,7 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
     // OR, they must have the same pure parent.
     if (!f->isPure() && calledparent != outerfunc)
     {
-        if (outerfunc->setImpure())
+        if (sc->flags & SCOPEcompile ? outerfunc->isPureBypassingInferenceX() : outerfunc->setImpure())
         {
             error("pure function '%s' cannot call impure function '%s'",
                 outerfunc->toPrettyChars(), f->toPrettyChars());
@@ -2353,7 +2353,7 @@ void Expression::checkPurity(Scope *sc, VarDeclaration *v)
             FuncDeclaration *ff = s->isFuncDeclaration();
             if (!ff)
                 break;
-            if (ff->setImpure())
+            if (sc->flags & SCOPEcompile ? ff->isPureBypassingInferenceX() : ff->setImpure())
             {
                 error("pure function '%s' cannot access mutable static data '%s'",
                     sc->func->toPrettyChars(), v->toChars());
@@ -2405,7 +2405,7 @@ void Expression::checkPurity(Scope *sc, VarDeclaration *v)
             FuncDeclaration *ff = s->isFuncDeclaration();
             if (!ff)
                 break;
-            if (ff->setImpure())
+            if (sc->flags & SCOPEcompile ? ff->isPureBypassingInferenceX() : ff->setImpure())
             {
                 error("pure nested function '%s' cannot access mutable data '%s'",
                     ff->toChars(), v->toChars());
@@ -2437,7 +2437,7 @@ void Expression::checkSafety(Scope *sc, FuncDeclaration *f)
 
     if (!f->isSafe() && !f->isTrusted())
     {
-        if (sc->func->setUnsafe())
+        if (sc->flags & SCOPEcompile ? sc->func->isSafeBypassingInference() : sc->func->setUnsafe())
         {
             if (loc.linnum == 0)  // e.g. implicitly generated dtor
                 loc = sc->func->loc;
@@ -2461,7 +2461,7 @@ void Expression::checkNogc(Scope *sc, FuncDeclaration *f)
 
     if (!f->isNogc())
     {
-        if (sc->func->setGC())
+        if (sc->flags & SCOPEcompile ? sc->func->isNogcBypassingInference() : sc->func->setGC())
         {
             if (loc.linnum == 0)  // e.g. implicitly generated dtor
                 loc = sc->func->loc;

--- a/src/func.c
+++ b/src/func.c
@@ -3661,6 +3661,11 @@ PURE FuncDeclaration::isPureBypassingInference()
         return isPure();
 }
 
+bool FuncDeclaration::isPureBypassingInferenceX()
+{
+    return !(flags & FUNCFLAGpurityInprocess) && isPure() != PUREimpure;
+}
+
 /**************************************
  * The function is doing something impure,
  * so mark it as impure.

--- a/src/func.c
+++ b/src/func.c
@@ -4851,13 +4851,12 @@ void StaticCtorDeclaration::semantic(Scope *sc)
          * Note that this is not thread safe; should not have threads
          * during static construction.
          */
-        Identifier *id = Lexer::idPool("__gate");
-        VarDeclaration *v = new VarDeclaration(Loc(), Type::tint32, id, NULL);
+        VarDeclaration *v = new VarDeclaration(Loc(), Type::tint32, Id::gate, NULL);
         v->storage_class = STCtemp | (isSharedStaticCtorDeclaration() ? STCstatic : STCtls);
         Statements *sa = new Statements();
         Statement *s = new ExpStatement(Loc(), v);
         sa->push(s);
-        Expression *e = new IdentifierExp(Loc(), id);
+        Expression *e = new IdentifierExp(Loc(), v->ident);
         e = new AddAssignExp(Loc(), e, new IntegerExp(1));
         e = new EqualExp(TOKnotequal, Loc(), e, new IntegerExp(1));
         s = new IfStatement(Loc(), NULL, e, new ReturnStatement(Loc(), NULL), NULL);
@@ -4983,13 +4982,12 @@ void StaticDtorDeclaration::semantic(Scope *sc)
          * Note that this is not thread safe; should not have threads
          * during static destruction.
          */
-        Identifier *id = Lexer::idPool("__gate");
-        VarDeclaration *v = new VarDeclaration(Loc(), Type::tint32, id, NULL);
+        VarDeclaration *v = new VarDeclaration(Loc(), Type::tint32, Id::gate, NULL);
         v->storage_class = STCtemp | (isSharedStaticDtorDeclaration() ? STCstatic : STCtls);
         Statements *sa = new Statements();
         Statement *s = new ExpStatement(Loc(), v);
         sa->push(s);
-        Expression *e = new IdentifierExp(Loc(), id);
+        Expression *e = new IdentifierExp(Loc(), v->ident);
         e = new AddAssignExp(Loc(), e, new IntegerExp(-1));
         e = new EqualExp(TOKnotequal, Loc(), e, new IntegerExp(0));
         s = new IfStatement(Loc(), NULL, e, new ReturnStatement(Loc(), NULL), NULL);

--- a/src/func.c
+++ b/src/func.c
@@ -1291,6 +1291,7 @@ void FuncDeclaration::semantic3(Scope *sc)
         sc2->structalign = STRUCTALIGN_DEFAULT;
         if (this->ident != Id::require && this->ident != Id::ensure)
             sc2->flags = sc->flags & ~SCOPEcontract;
+        sc2->flags &= ~SCOPEcompile;
         sc2->tf = NULL;
         sc2->os = NULL;
         sc2->noctor = 0;

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -75,6 +75,7 @@ Msgtable msgtable[] =
     { "q" },
     { "__vptr" },
     { "__monitor" },
+    { "gate", "__gate" },
 
     { "TypeInfo" },
     { "TypeInfo_Class" },

--- a/src/traits.c
+++ b/src/traits.c
@@ -902,6 +902,11 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
                 ex = ex->semantic(sc2);
                 ex = resolvePropertiesOnly(sc2, ex);
                 ex = ex->optimize(WANTvalue);
+                if (sc2->func && sc2->func->type->ty == Tfunction)
+                {
+                    TypeFunction *tf = (TypeFunction *)sc2->func->type;
+                    canThrow(ex, sc2->func, tf->isnothrow);
+                }
                 ex = checkGC(sc2, ex);
                 if (ex->op == TOKerror)
                     err = true;

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -85,6 +85,69 @@ void test6351()
 }
 
 /***************************************************/
+// 6359
+
+void    impure6359()      nothrow @safe @nogc {}
+void throwable6359() pure         @safe @nogc {}
+void    system6359() pure nothrow       @nogc {}
+void    gcable6359() pure nothrow @safe       {}
+
+int global6359;
+
+void f6359() pure nothrow @safe @nogc
+{
+    static assert(!__traits(compiles,    impure6359()));
+    static assert(!__traits(compiles, throwable6359()));
+    static assert(!__traits(compiles,    system6359()));
+    static assert(!__traits(compiles,    gcable6359()));
+    static assert(!__traits(compiles,    global6359++));
+
+  //static assert(!__traits(compiles, {    impure6359(); }())); // BUG: blocked by issue 9148.
+    static assert(!__traits(compiles, { throwable6359(); }()));
+    static assert(!__traits(compiles, {    system6359(); }()));
+    static assert(!__traits(compiles, {    gcable6359(); }()));
+    static assert(!__traits(compiles, {    global6359++; }()));
+}
+
+void g6359()() pure nothrow @safe @nogc
+{
+    static assert(!__traits(compiles,    impure6359()));
+    static assert(!__traits(compiles, throwable6359()));
+    static assert(!__traits(compiles,    system6359()));
+    static assert(!__traits(compiles,    gcable6359()));
+    static assert(!__traits(compiles,    global6359++));
+
+  //static assert(!__traits(compiles, {    impure6359(); }())); // BUG: blocked by issue 9148.
+    static assert(!__traits(compiles, { throwable6359(); }()));
+    static assert(!__traits(compiles, {    system6359(); }()));
+    static assert(!__traits(compiles, {    gcable6359(); }()));
+    static assert(!__traits(compiles, {    global6359++; }()));
+}
+
+// attribute inference is not affected by the expressions inside __traits(compiles)
+void h6359()()
+{
+    static assert( __traits(compiles,    impure6359()));
+    static assert( __traits(compiles, throwable6359()));
+    static assert( __traits(compiles,    system6359()));
+    static assert( __traits(compiles,    gcable6359()));
+    static assert( __traits(compiles,    global6359++));
+
+    static assert( __traits(compiles, {    impure6359(); }()));
+    static assert( __traits(compiles, { throwable6359(); }()));
+    static assert( __traits(compiles, {    system6359(); }()));
+    static assert( __traits(compiles, {    gcable6359(); }()));
+  //static assert( __traits(compiles, {    global6359++; }())); // BUG: blocked by issue 9148.
+}
+
+void test6359() pure nothrow @safe @nogc
+{
+    f6359();
+    g6359();
+    h6359();
+}
+
+/***************************************************/
 // 7017
 
 template map7017(fun...) if (fun.length >= 1)

--- a/test/runnable/statictor.d
+++ b/test/runnable/statictor.d
@@ -38,10 +38,8 @@ static this() nothrow pure @safe
     int* p;
     static assert(!__traits(compiles, ++p));
     static assert(!__traits(compiles, ++global6677));
-    // BUG (not related to this):
-    //auto throwit = { throw new Exception("sup"); };
-    //static assert(!__traits(compiles, throwit() )); // Should pass
-    //throwit() // This fails, but __traits(compiles, ...) claims it compiles
+    auto throwit = { throw new Exception("sup"); };
+    static assert(!__traits(compiles, throwit() ));
 }
 
 shared static this() nothrow pure @safe


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=6359
