### PR TITLE
[REG2.065] Issue 12860 - typeid(_error_) symbols leaked to backend

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6066,6 +6066,8 @@ Expression *TypeidExp::semantic(Scope *sc)
         /* Get the static type
          */
         e = ta->getTypeInfo(sc);
+        if (e->op == TOKerror)
+            return e;
         if (e->loc.linnum == 0)
             e->loc = loc;               // so there's at least some line number info
         if (ea)

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -258,6 +258,7 @@ Symbol *toSymbol(Dsymbol *s)
         void visit(TypeInfoDeclaration *tid)
         {
             //printf("TypeInfoDeclaration::toSymbol(%s), linkage = %d\n", tid->toChars(), tid->linkage);
+            assert(tid->tinfo->ty != Terror);
             visit((VarDeclaration *)tid);
         }
 

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -149,6 +149,8 @@ void Type::genTypeInfo(Scope *sc)
 
 Expression *Type::getTypeInfo(Scope *sc)
 {
+    if (ty == Terror)
+        return new ErrorExp();
     genTypeInfo(sc);
     Expression *e = VarExp::create(Loc(), vtinfo);
     e = e->addressOf();


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12860
