### PR TITLE
[DDMD] Add factory function for ErrorExp

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2769,6 +2769,11 @@ ErrorExp::ErrorExp()
     type = Type::terror;
 }
 
+ErrorExp *ErrorExp::create()
+{
+    return new ErrorExp();
+}
+
 Expression *ErrorExp::toLvalue(Scope *sc, Expression *e)
 {
     return this;

--- a/src/expression.h
+++ b/src/expression.h
@@ -281,6 +281,7 @@ class ErrorExp : public Expression
 {
 public:
     ErrorExp();
+    static ErrorExp *create();
 
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -150,7 +150,7 @@ void Type::genTypeInfo(Scope *sc)
 Expression *Type::getTypeInfo(Scope *sc)
 {
     if (ty == Terror)
-        return new ErrorExp();
+        return ErrorExp::create();
     genTypeInfo(sc);
     Expression *e = VarExp::create(Loc(), vtinfo);
     e = e->addressOf();


### PR DESCRIPTION
Because constructors can't be called directly over the language boundary.
