### PR TITLE
[DDMD] Move #defined constants outside class declaration

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -555,6 +555,11 @@ void add_builtin(const char *mangle, builtin_fp fp);
 void builtin_init();
 void buildClosure(FuncDeclaration *fd, IRState *irs);
 
+#define FUNCFLAGpurityInprocess 1   // working on determining purity
+#define FUNCFLAGsafetyInprocess 2   // working on determining safety
+#define FUNCFLAGnothrowInprocess 4  // working on determining nothrow
+#define FUNCFLAGnogcInprocess 8     // working on determining @nogc
+
 class FuncDeclaration : public Declaration
 {
 public:
@@ -631,10 +636,6 @@ public:
                                         // called this one
 
     unsigned flags;
-    #define FUNCFLAGpurityInprocess 1   // working on determining purity
-    #define FUNCFLAGsafetyInprocess 2   // working on determining safety
-    #define FUNCFLAGnothrowInprocess 4  // working on determining nothrow
-    #define FUNCFLAGnogcInprocess 8     // working on determining @nogc
 
     FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);


### PR DESCRIPTION
Because when converted to D these become enum constants, and will be scoped inside `FuncDeclaration`.  It wasn't a problem until recently when functions that aren't members of `FuncDeclaration` started referencing these constants.
