### PR TITLE
Android: Packed TLS for ELF

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -50,7 +50,8 @@ void out_config_init(
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
         bool stackstomp,        // add stack stomping code
-        bool dwarfeh            // use Dwarf eh
+        bool dwarfeh,            // use Dwarf eh
+        bool isAndroid          // make TLS adjustments for Android
         )
 {
 #if MARS
@@ -110,6 +111,8 @@ void out_config_init(
         config.flags3 |= CFG3pic;
         config.flags |= CFGalwaysframe; // PIC needs a frame for TLS fixups
     }
+    if (isAndroid)
+        config.flags3 |= CFG3android;
     config.objfmt = OBJ_ELF;
 #endif
 #if TARGET_OSX

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -795,6 +795,7 @@ struct Config
 #endif
 #define CFG3pic         0x80000 // position independent code
 #define CFGX3   (CFG3strcod | CFG3ptrchk)
+#define CFG3android     0x100000 // make TLS adjustments for Android
 
     unsigned flags4;
 #define CFG4speed       1       // optimized for speed

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -3011,7 +3011,12 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                                     // Could use 'local dynamic (LD)' to optimize multiple local TLS reads
                                     relinfo = R_386_TLS_GD;
                                 else
-                                    relinfo = R_386_TLS_GD;
+                                {
+                                    if (config.flags3 & CFG3android)
+                                        relinfo = R_386_GOT32;
+                                    else
+                                        relinfo = R_386_TLS_GD;
+                                }
                             }
                             else
                             {

--- a/src/globals.d
+++ b/src/globals.d
@@ -79,6 +79,8 @@ struct Param
     bool is64bit;           // generate 64 bit code
     bool isLP64;            // generate code for LP64
     bool isLinux;           // generate code for linux
+    bool isAndroid;         // generate code for linux with some modifications
+                            // for Android
     bool isOSX;             // generate code for Mac OSX
     bool isWindows;         // generate code for Windows
     bool isFreeBSD;         // generate code for FreeBSD

--- a/src/globals.h
+++ b/src/globals.h
@@ -57,6 +57,8 @@ struct Param
     bool is64bit;       // generate 64 bit code
     bool isLP64;        // generate code for LP64
     bool isLinux;       // generate code for linux
+    bool isAndroid;     // generate code for linux with some modifications
+                        // for Android
     bool isOSX;         // generate code for Mac OSX
     bool isWindows;     // generate code for Windows
     bool isFreeBSD;     // generate code for FreeBSD

--- a/src/msc.c
+++ b/src/msc.c
@@ -49,7 +49,8 @@ void out_config_init(
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
         bool stackstomp,        // add stack stomping code
-        bool dwarfeh            // use Dwarf exception handling
+        bool dwarfeh,            // use Dwarf exception handling
+        bool isAndroid          // make TLS adjustments for Android
         );
 
 void out_config_debug(
@@ -100,7 +101,8 @@ void backend_init()
         params->symdebug,
         params->alwaysframe,
         params->stackstomp,
-        params->dwarfeh
+        params->dwarfeh,
+        params->isAndroid
     );
 
 #ifdef DEBUG


### PR DESCRIPTION
Never heard back from Walter about the dmd patch I used for Android/x86 and I know he's very careful about copyright, so I'm submitting it as a pull request.  Right now, I'm just looking to find out if some sort of packed TLS for ELF pull like this would be considered for merging and if I made any mistakes in my approach.  If so, I'll clean this pull up and figure out a way to work it into the existing build, but I don't want to do that cleanup if the basic concept is not deemed worthwhile for dmd.

I used this pull to compile druntime and phobos for Android/x86, with almost all modules' unit tests passing.  I'm not sure if this pull will work for shared libraries on Android, as I had problems in `___tls_get_addr` in druntime when I tried that, will update when I figure out what's going wrong there.

Let me know if this sort of packed TLS for ELF approach would be worth merging and I'll clean up this pull.
