### PR TITLE
Fix #2529: explicit protection package

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -37,12 +37,12 @@ bool hasPrivateAccess(AggregateDeclaration *ad, Dsymbol *smember);
 bool isFriendOf(AggregateDeclaration *ad, AggregateDeclaration *cd);
 
 /****************************************
- * Return PROT access for Dsymbol smember in this declaration.
+ * Return Prot access for Dsymbol smember in this declaration.
  */
 
-PROT getAccess(AggregateDeclaration *ad, Dsymbol *smember)
+Prot getAccess(AggregateDeclaration *ad, Dsymbol *smember)
 {
-    PROT access_ret = PROTnone;
+    Prot access_ret = PROTnone;
 
 #if LOG
     printf("+AggregateDeclaration::getAccess(this = '%s', smember = '%s')\n",
@@ -64,8 +64,8 @@ PROT getAccess(AggregateDeclaration *ad, Dsymbol *smember)
         {
             BaseClass *b = (*cd->baseclasses)[i];
 
-            PROT access = getAccess(b->base, smember);
-            switch (access)
+            Prot access = getAccess(b->base, smember);
+            switch (access.kind)
             {
                 case PROTnone:
                     break;
@@ -79,11 +79,11 @@ PROT getAccess(AggregateDeclaration *ad, Dsymbol *smember)
                 case PROTpublic:
                 case PROTexport:
                     // If access is to be tightened
-                    if (b->protection < access)
+                    if (b->protection.isMoreRestrictiveThan(access))
                         access = b->protection;
 
                     // Pick path with loosest access
-                    if (access > access_ret)
+                    if (access_ret.isMoreRestrictiveThan(access))
                         access_ret = access;
                     break;
 
@@ -133,8 +133,8 @@ static int accessCheckX(
             {
                 for (size_t i = 0; i < cdthis->baseclasses->dim; i++)
                 {   BaseClass *b = (*cdthis->baseclasses)[i];
-                    PROT access = getAccess(b->base, smember);
-                    if (access >= PROTprotected ||
+                    Prot access = getAccess(b->base, smember);
+                    if (access.kind >= PROTprotected ||
                         accessCheckX(smember, sfunc, b->base, cdscope)
                        )
                         return 1;
@@ -173,7 +173,7 @@ void accessCheck(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember)
 
     FuncDeclaration *f = sc->func;
     AggregateDeclaration *cdscope = sc->getStructClassScope();
-    PROT access;
+    Prot access;
 
 #if LOG
     printf("AggregateDeclaration::accessCheck() for %s.%s in function %s() in scope %s\n",
@@ -196,24 +196,24 @@ void accessCheck(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember)
 
     if (smemberparent == ad)
     {
-        PROT access2 = smember->prot();
-        result = access2 >= PROTpublic ||
+        Prot access2 = smember->prot();
+        result = access2.kind >= PROTpublic ||
                 hasPrivateAccess(ad, f) ||
                 isFriendOf(ad, cdscope) ||
-                (access2 == PROTpackage && hasPackageAccess(sc, ad)) ||
+                (access2.kind == PROTpackage && hasPackageAccess(sc, ad)) ||
                 ad->getAccessModule() == sc->module;
 #if LOG
         printf("result1 = %d\n", result);
 #endif
     }
-    else if ((access = getAccess(ad, smember)) >= PROTpublic)
+    else if ((access = getAccess(ad, smember)).kind >= PROTpublic)
     {
         result = 1;
 #if LOG
         printf("result2 = %d\n", result);
 #endif
     }
-    else if (access == PROTpackage && hasPackageAccess(sc, ad))
+    else if (access.kind == PROTpackage && hasPackageAccess(sc, ad))
     {
         result = 1;
 #if LOG
@@ -415,8 +415,8 @@ void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
     }
     if (!e)
     {
-        if (d->prot() == PROTprivate && d->getAccessModule() != sc->module ||
-            d->prot() == PROTpackage && !hasPackageAccess(sc, d))
+        if (d->prot().kind == PROTprivate && d->getAccessModule() != sc->module ||
+            d->prot().kind == PROTpackage && !hasPackageAccess(sc, d))
         {
             error(loc, "%s %s is not accessible from module %s",
                 d->kind(), d->toPrettyChars(), sc->module->toChars());

--- a/src/access.c
+++ b/src/access.c
@@ -272,7 +272,7 @@ bool hasPackageAccess(Scope *sc, Dsymbol *s)
 #if LOG
     printf("hasPackageAccess(s = '%s', sc = '%p', s->protection.pkg = '%s')\n",
             s->toChars(), sc,
-            s->protection.pkg ? s->protection.pkg->toChars() : "NULL");
+            s->prot().pkg ? s->prot().pkg->toChars() : "NULL");
 #endif
 
     Package *pkg = NULL;

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -67,7 +67,7 @@ class AggregateDeclaration : public ScopeDsymbol
 public:
     Type *type;
     StorageClass storage_class;
-    PROT protection;
+    Prot protection;
     unsigned structsize;        // size of struct
     unsigned alignsize;         // size of struct for alignment purposes
     VarDeclarations fields;     // VarDeclaration fields
@@ -118,7 +118,7 @@ public:
     bool isExport();
     Dsymbol *searchCtor();
 
-    PROT prot();
+    Prot prot();
 
     Type *handleType() { return type; } // 'this' type
 
@@ -194,7 +194,7 @@ public:
 struct BaseClass
 {
     Type *type;                         // (before semantic processing)
-    PROT protection;               // protection for the base interface
+    Prot protection;               // protection for the base interface
 
     ClassDeclaration *base;
     unsigned offset;                    // 'this' pointer offset
@@ -207,7 +207,7 @@ struct BaseClass
     BaseClass *baseInterfaces;
 
     BaseClass();
-    BaseClass(Type *type, PROT protection);
+    BaseClass(Type *type, Prot protection);
 
     bool fillVtbl(ClassDeclaration *cd, FuncDeclarations *vtbl, int newinstance);
     void copyBaseInterfaces(BaseClasses *);

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -70,13 +70,14 @@ int AttribDeclaration::apply(Dsymbol_apply_ft_t fp, void *param)
  * the scope after it used.
  */
 Scope *AttribDeclaration::createNewScope(Scope *sc,
-        StorageClass stc, LINK linkage, PROT protection, int explicitProtection,
+        StorageClass stc, LINK linkage, Prot protection, int explicitProtection,
         structalign_t structalign)
 {
     Scope *sc2 = sc;
     if (stc != sc->stc ||
         linkage != sc->linkage ||
-        protection != sc->protection ||
+        //protection.isMoreRestrictiveThan(sc->protection) ||
+        !protection.isIdenticalTo(sc->protection) ||
         explicitProtection != sc->explicitProtection ||
         structalign != sc->structalign)
     {
@@ -540,7 +541,7 @@ char *LinkDeclaration::toChars()
 
 /********************************* ProtDeclaration ****************************/
 
-ProtDeclaration::ProtDeclaration(PROT p, Dsymbols *decl)
+ProtDeclaration::ProtDeclaration(Prot p, Dsymbols *decl)
         : AttribDeclaration(decl)
 {
     protection = p;

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -540,28 +540,64 @@ char *LinkDeclaration::toChars()
 
 /********************************* ProtDeclaration ****************************/
 
+/**
+* Params:
+*  loc = source location of attribute token
+*  p = protection attribute data
+*  decl = declarations which are affected by this protection attribute
+*/
 ProtDeclaration::ProtDeclaration(Loc loc, Prot p, Dsymbols *decl)
         : AttribDeclaration(decl)
 {
     this->loc = loc;
     this->protection = p;
+    this->pkg_identifiers = NULL;
     //printf("decl = %p\n", decl);
+}
+
+/**
+* Params:
+*  loc = source location of attribute token
+*  pkg_identifiers = list of identifiers for a qualified package name
+*  decl = declarations which are affected by this protection attribute
+*/
+ProtDeclaration::ProtDeclaration(Loc loc, Identifiers* pkg_identifiers, Dsymbols *decl)
+        : AttribDeclaration(decl)
+{
+    this->loc = loc;
+    this->protection.kind = PROTpackage;
+    this->protection.pkg  = NULL;
+    this->pkg_identifiers = pkg_identifiers;
 }
 
 Dsymbol *ProtDeclaration::syntaxCopy(Dsymbol *s)
 {
     assert(!s);
-    return new ProtDeclaration(this->loc, protection, Dsymbol::arraySyntaxCopy(decl));
+    if (protection.kind == PROTpackage)
+    	return new ProtDeclaration(this->loc, pkg_identifiers, Dsymbol::arraySyntaxCopy(decl));
+    else
+    	return new ProtDeclaration(this->loc, protection, Dsymbol::arraySyntaxCopy(decl));
 }
 
 Scope *ProtDeclaration::newScope(Scope *sc)
 {
+    if (pkg_identifiers)
+        semantic(sc);
     return createNewScope(sc, sc->stc, sc->linkage, this->protection, 1, sc->structalign);
 }
 
 void ProtDeclaration::semantic(Scope* sc)
 {
+    if (pkg_identifiers)
+    {
+        Dsymbol* tmp;
+        Package::resolve(pkg_identifiers, &tmp, NULL);
+        protection.pkg = tmp ? tmp->isPackage() : NULL;
+        pkg_identifiers = NULL;
+    }
+
     AttribDeclaration::semantic(sc);
+
     if ((protection.kind == PROTpackage) && (protection.pkg != NULL) && sc->module)
     {
         Package* pkg =  sc->module->parent->isPackage();

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -76,8 +76,7 @@ Scope *AttribDeclaration::createNewScope(Scope *sc,
     Scope *sc2 = sc;
     if (stc != sc->stc ||
         linkage != sc->linkage ||
-        //protection.isMoreRestrictiveThan(sc->protection) ||
-        !protection.isIdenticalTo(sc->protection) ||
+        !protection.isSubsetOf(sc->protection) ||
         explicitProtection != sc->explicitProtection ||
         structalign != sc->structalign)
     {

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -540,10 +540,11 @@ char *LinkDeclaration::toChars()
 
 /********************************* ProtDeclaration ****************************/
 
-ProtDeclaration::ProtDeclaration(Prot p, Dsymbols *decl)
+ProtDeclaration::ProtDeclaration(Loc loc, Prot p, Dsymbols *decl)
         : AttribDeclaration(decl)
 {
-    protection = p;
+    this->loc = loc;
+    this->protection = p;
     //printf("decl = %p\n", decl);
 }
 
@@ -573,8 +574,43 @@ void ProtDeclaration::semantic(Scope* sc)
         Package* pkg =  sc->module->parent->isPackage();
         assert(pkg);
         if (pkg && !protection.pkg->isAncestorPackageOf(pkg))
-            error("'%s' is not one of ancestor packages of module '%s'",
-                protection.pkg->toChars(), sc->module->toPrettyChars(true));
+            error("does not bind to one of ancestor packages of module '%s'",
+               sc->module->toPrettyChars(true));
+    }
+}
+
+
+const char *ProtDeclaration::kind()
+{
+    return "protection attribute";
+}
+
+const char *ProtDeclaration::toPrettyChars(bool unused)
+{
+    assert(protection.kind > PROTundefined);
+
+    const char* kind = protectionToChars(this->protection);
+
+    OutBuffer buffer;
+
+    if ((protection.kind == PROTpackage) && protection.pkg)
+    {
+        // 'package(name)'
+        const char* name = protection.pkg->toPrettyChars(true);
+        buffer.writestring("'");
+        buffer.writestring(kind);
+        buffer.writestring("(");
+        buffer.writestring(name);
+        buffer.writestring(")'");
+        return buffer.extractString();
+    }
+    else
+    {
+        // 'attrkind'
+        buffer.writestring("'");
+        buffer.writestring(kind);
+        buffer.writestring("'");
+        return buffer.extractString();
     }
 }
 

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -551,19 +551,12 @@ ProtDeclaration::ProtDeclaration(Loc loc, Prot p, Dsymbols *decl)
 Dsymbol *ProtDeclaration::syntaxCopy(Dsymbol *s)
 {
     assert(!s);
-    return new ProtDeclaration(protection, Dsymbol::arraySyntaxCopy(decl));
+    return new ProtDeclaration(this->loc, protection, Dsymbol::arraySyntaxCopy(decl));
 }
 
 Scope *ProtDeclaration::newScope(Scope *sc)
 {
     return createNewScope(sc, sc->stc, sc->linkage, this->protection, 1, sc->structalign);
-}
-
-void ProtDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
-{
-    protectionToBuffer(buf, protection);
-    buf->writeByte(' ');
-    AttribDeclaration::toCBuffer(buf, hgs);
 }
 
 void ProtDeclaration::semantic(Scope* sc)

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -558,6 +558,26 @@ Scope *ProtDeclaration::newScope(Scope *sc)
     return createNewScope(sc, sc->stc, sc->linkage, this->protection, 1, sc->structalign);
 }
 
+void ProtDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
+{
+    protectionToBuffer(buf, protection);
+    buf->writeByte(' ');
+    AttribDeclaration::toCBuffer(buf, hgs);
+}
+
+void ProtDeclaration::semantic(Scope* sc)
+{
+    AttribDeclaration::semantic(sc);
+    if ((protection.kind == PROTpackage) && (protection.pkg != NULL) && sc->module)
+    {
+        Package* pkg =  sc->module->parent->isPackage();
+        assert(pkg);
+        if (pkg && !protection.pkg->isAncestorPackageOf(pkg))
+            error("'%s' is not one of ancestor packages of module '%s'",
+                protection.pkg->toChars(), sc->module->toPrettyChars(true));
+    }
+}
+
 /********************************* AlignDeclaration ****************************/
 
 AlignDeclaration::AlignDeclaration(unsigned sa, Dsymbols *decl)

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -110,6 +110,8 @@ public:
     ProtDeclaration(Prot p, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
+    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    void semantic(Scope* sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -102,6 +102,11 @@ class ProtDeclaration : public AttribDeclaration
 public:
     Prot protection;
 
+    /**
+    * Params:
+    *  p = protection attribute data
+    *  decl = declarations which are affected by this protection attribute
+    */
     ProtDeclaration(Prot p, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -112,7 +112,6 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();
     const char *toPrettyChars(bool unused);
     void semantic(Scope* sc);

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -104,13 +104,17 @@ public:
 
     /**
     * Params:
+    *  loc = source location of attribute token
     *  p = protection attribute data
     *  decl = declarations which are affected by this protection attribute
     */
-    ProtDeclaration(Prot p, Dsymbols *decl);
+    ProtDeclaration(Loc loc, Prot p, Dsymbols *decl);
+
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
+    const char *kind();
+    const char *toPrettyChars(bool unused);
     void semantic(Scope* sc);
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -101,14 +101,10 @@ class ProtDeclaration : public AttribDeclaration
 {
 public:
     Prot protection;
+    Identifiers* pkg_identifiers;
 
-    /**
-    * Params:
-    *  loc = source location of attribute token
-    *  p = protection attribute data
-    *  decl = declarations which are affected by this protection attribute
-    */
     ProtDeclaration(Loc loc, Prot p, Dsymbols *decl);
+    ProtDeclaration(Loc loc, Identifiers* pkg_identifiers, Dsymbols *decl);
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -36,7 +36,7 @@ public:
     virtual Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
     int apply(Dsymbol_apply_ft_t fp, void *param);
     static Scope *createNewScope(Scope *sc,
-        StorageClass newstc, LINK linkage, PROT protection, int explictProtection,
+        StorageClass newstc, LINK linkage, Prot protection, int explictProtection,
         structalign_t structalign);
     virtual Scope *newScope(Scope *sc);
     int addMember(Scope *sc, ScopeDsymbol *sds, int memnum);
@@ -100,9 +100,9 @@ public:
 class ProtDeclaration : public AttribDeclaration
 {
 public:
-    PROT protection;
+    Prot protection;
 
-    ProtDeclaration(PROT p, Dsymbols *decl);
+    ProtDeclaration(Prot p, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }

--- a/src/class.c
+++ b/src/class.c
@@ -359,7 +359,7 @@ void ClassDeclaration::semantic(Scope *sc)
             if (tb->ty == Ttuple)
             {
                 TypeTuple *tup = (TypeTuple *)tb;
-                PROT protection = b->protection;
+                Prot protection = b->protection;
                 baseclasses->remove(i);
                 size_t dim = Parameter::dim(tup->arguments);
                 for (size_t j = 0; j < dim; j++)
@@ -1299,7 +1299,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
             if (tb->ty == Ttuple)
             {
                 TypeTuple *tup = (TypeTuple *)tb;
-                PROT protection = b->protection;
+                Prot protection = b->protection;
                 baseclasses->remove(i);
                 size_t dim = Parameter::dim(tup->arguments);
                 for (size_t j = 0; j < dim; j++)
@@ -1656,7 +1656,7 @@ BaseClass::BaseClass()
     memset(this, 0, sizeof(BaseClass));
 }
 
-BaseClass::BaseClass(Type *type, PROT protection)
+BaseClass::BaseClass(Type *type, Prot protection)
 {
     //printf("BaseClass(this = %p, '%s')\n", this, type->toChars());
     this->type = type;

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -1143,7 +1143,7 @@ private:
             // Pivate methods always non-virtual in D and it should be mangled as non-virtual in C++
             if (d->isVirtual() && d->vtblIndex != -1)
             {
-                switch (d->protection)
+                switch (d->protection.kind)
                 {
                     case PROTprivate:
                         buf.writeByte('E');
@@ -1158,7 +1158,7 @@ private:
             }
             else
             {
-                switch (d->protection)
+                switch (d->protection.kind)
                 {
                     case PROTprivate:
                         buf.writeByte('A');
@@ -1184,7 +1184,7 @@ private:
         }
         else if (d->isMember2()) // static function
         {                        // <flags> ::= <virtual/protection flag> <calling convention flag>
-            switch (d->protection)
+            switch (d->protection.kind)
             {
                 case PROTprivate:
                     buf.writeByte('C');
@@ -1226,7 +1226,7 @@ private:
         }
         else
         {
-            switch (d->protection)
+            switch (d->protection.kind)
             {
                 case PROTprivate:
                     buf.writeByte('0');

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -126,7 +126,7 @@ bool Declaration::isCodeseg()
     return false;
 }
 
-PROT Declaration::prot()
+Prot Declaration::prot()
 {
     return protection;
 }
@@ -1796,12 +1796,12 @@ bool VarDeclaration::needThis()
 
 bool VarDeclaration::isExport()
 {
-    return protection == PROTexport;
+    return protection.kind == PROTexport;
 }
 
 bool VarDeclaration::isImportedSymbol()
 {
-    if (protection == PROTexport && !init &&
+    if (protection.kind == PROTexport && !init &&
         (storage_class & STCstatic || parent->isModule()))
         return true;
     return false;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -33,7 +33,6 @@ struct InterState;
 struct IRState;
 struct CompiledCtfeFunction;
 
-enum PROT;
 enum LINK;
 enum TOK;
 enum MATCH;
@@ -123,7 +122,7 @@ public:
     Type *type;
     Type *originalType;         // before semantic analysis
     StorageClass storage_class;
-    PROT protection;
+    Prot protection;
     LINK linkage;
     int inuse;                  // used to detect cycles
     const char *mangleOverride;      // overridden symbol with pragma(mangle, "...")
@@ -161,7 +160,7 @@ public:
     bool isOut()   { return (storage_class & STCout) != 0; }
     bool isRef()   { return (storage_class & STCref) != 0; }
 
-    PROT prot();
+    Prot prot();
 
     Declaration *isDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/doc.c
+++ b/src/doc.c
@@ -581,7 +581,7 @@ void emitUnittestComment(Scope *sc, Dsymbol *s, size_t ofs)
 
     for (UnitTestDeclaration *utd = s->ddocUnittest; utd; utd = utd->ddocUnittest)
     {
-        if (utd->protection == PROTprivate || !utd->comment || !utd->fbody)
+        if (utd->protection.kind == PROTprivate || !utd->comment || !utd->fbody)
             continue;
 
         // Strip whitespaces to avoid showing empty summary
@@ -713,9 +713,9 @@ void emitMemberComments(ScopeDsymbol *sds, Scope *sc)
     }
 }
 
-void emitProtection(OutBuffer *buf, PROT prot)
+void emitProtection(OutBuffer *buf, Prot prot)
 {
-    const char *p = (prot == PROTpublic) ? NULL : protectionToChars(prot);
+    const char *p = (prot.kind == PROTpublic) ? NULL : protectionToChars(prot);
     if (p)
         buf->printf("%s ", p);
 }
@@ -747,7 +747,7 @@ void emitComment(Dsymbol *s, Scope *sc)
             //printf("Declaration::emitComment(%p '%s'), comment = '%s'\n", d, d->toChars(), d->comment);
             //printf("type = %p\n", d->type);
 
-            if (d->protection == PROTprivate || sc->protection == PROTprivate ||
+            if (d->protection.kind == PROTprivate || sc->protection.kind == PROTprivate ||
                 !d->ident || (!d->type && !d->isCtorDeclaration() && !d->isAliasDeclaration()))
                 return;
             if (!d->comment)
@@ -778,7 +778,7 @@ void emitComment(Dsymbol *s, Scope *sc)
         void visit(AggregateDeclaration *ad)
         {
             //printf("AggregateDeclaration::emitComment() '%s'\n", ad->toChars());
-            if (ad->prot() == PROTprivate || sc->protection == PROTprivate)
+            if (ad->prot().kind == PROTprivate || sc->protection.kind == PROTprivate)
                 return;
             if (!ad->comment)
                 return;
@@ -809,7 +809,7 @@ void emitComment(Dsymbol *s, Scope *sc)
         void visit(TemplateDeclaration *td)
         {
             //printf("TemplateDeclaration::emitComment() '%s', kind = %s\n", td->toChars(), td->kind());
-            if (td->prot() == PROTprivate || sc->protection == PROTprivate)
+            if (td->prot().kind == PROTprivate || sc->protection.kind == PROTprivate)
                 return;
 
             const utf8_t *com = td->comment;
@@ -865,7 +865,7 @@ void emitComment(Dsymbol *s, Scope *sc)
 
         void visit(EnumDeclaration *ed)
         {
-            if (ed->prot() == PROTprivate || sc->protection == PROTprivate)
+            if (ed->prot().kind == PROTprivate || sc->protection.kind == PROTprivate)
                 return;
             if (ed->isAnonymous() && ed->members)
             {
@@ -907,7 +907,7 @@ void emitComment(Dsymbol *s, Scope *sc)
         void visit(EnumMember *em)
         {
             //printf("EnumMember::emitComment(%p '%s'), comment = '%s'\n", em, em->toChars(), em->comment);
-            if (em->prot() == PROTprivate || sc->protection == PROTprivate)
+            if (em->prot().kind == PROTprivate || sc->protection.kind == PROTprivate)
                 return;
             if (!em->comment)
                 return;
@@ -1284,7 +1284,7 @@ void toDocBuffer(Dsymbol *s, OutBuffer *buf, Scope *sc)
                 {
                     BaseClass *bc = (*cd->baseclasses)[i];
 
-                    if (bc->protection == PROTprivate)
+                    if (bc->protection.kind == PROTprivate)
                         continue;
                     if (bc->base && bc->base->ident == Id::Object)
                         continue;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1552,7 +1552,9 @@ Dsymbol *DsymbolTable::update(Dsymbol *s)
 Prot::Prot(PROTKIND kind)
 {
     this->kind = kind;
+    this->pkg = NULL;
 }
+
 
 bool Prot::isMoreRestrictiveThan(Prot other)
 {

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1561,7 +1561,31 @@ bool Prot::isMoreRestrictiveThan(Prot other)
     return this->kind < other.kind;
 }
 
-bool Prot::isIdenticalTo(Prot other)
+bool Prot::operator==(Prot other)
 {
-    return this->kind == other.kind;
+    if (this->kind == other.kind)
+    {
+        if (this->kind == PROTpackage)
+            return this->pkg == other.pkg;
+        return true;
+    }
+    return false;
+}
+
+bool Prot::isSubsetOf(Prot parent)
+{
+    if (this->kind != parent.kind)
+        return false;
+
+    if (this->kind == PROTpackage)
+    {
+        if (!this->pkg)
+            return true;
+        if (!parent.pkg)
+            return false;
+        if (parent.pkg->isAncestorPackageOf(this->pkg))
+            return true;
+    }
+
+    return true;
 }

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -106,6 +106,7 @@ enum PROTKIND
 struct Prot
 {
     PROTKIND kind;
+    Package* pkg;
 
     Prot(PROTKIND kind = PROTundefined);
 

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -92,7 +92,7 @@ struct Ungag
 const char *mangle(Dsymbol *s);
 const char *mangleExact(FuncDeclaration *fd);
 
-enum PROT
+enum PROTKIND
 {
     PROTundefined,
     PROTnone,           // no access
@@ -103,9 +103,26 @@ enum PROT
     PROTexport,
 };
 
+struct Prot
+{
+    PROTKIND kind;
+
+    Prot(PROTKIND kind = PROTundefined);
+
+    /**
+     * Checks if `this` is superset of `other` restrictions.
+     * For example, "protected" is more restrictive than "public".
+     */
+    bool isMoreRestrictiveThan(Prot other);
+    /**
+     * Checks if `this` is absolutely identical protection attribute to `other`
+     */
+    bool isIdenticalTo(Prot other);
+};
+
 // in hdrgen.c
-void protectionToBuffer(OutBuffer *buf, PROT prot);
-const char *protectionToChars(PROT prot);
+void protectionToBuffer(OutBuffer *buf, Prot prot);
+const char *protectionToChars(Prot prot);
 
 /* State of symbol in winding its way through the passes of the compiler
  */
@@ -209,7 +226,7 @@ public:
     virtual AggregateDeclaration *isMember();   // is this symbol a member of an AggregateDeclaration?
     virtual Type *getType();                    // is this a type?
     virtual bool needThis();                    // need a 'this' pointer?
-    virtual PROT prot();
+    virtual Prot prot();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     virtual bool oneMember(Dsymbol **ps, Identifier *ident);
     static bool oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident);
@@ -287,7 +304,7 @@ public:
 
 private:
     Dsymbols *imports;          // imported Dsymbol's
-    PROT *prots;                // array of PROT, one for each import
+    PROTKIND *prots;            // array of PROTKIND, one for each import
 
 public:
     ScopeDsymbol();
@@ -295,7 +312,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
     OverloadSet *mergeOverloadSet(OverloadSet *os, Dsymbol *s);
-    void importScope(Dsymbol *s, PROT protection);
+    void importScope(Dsymbol *s, Prot protection);
     bool isforwardRef();
     static void multiplyDefined(Loc loc, Dsymbol *s1, Dsymbol *s2);
     const char *kind();

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -118,7 +118,18 @@ struct Prot
     /**
      * Checks if `this` is absolutely identical protection attribute to `other`
      */
-    bool isIdenticalTo(Prot other);
+    bool operator==(Prot other);
+    /**
+     * Checks if parent defines different access restrictions than this one.
+     *
+     * Params:
+     *  parent = protection attribute for scope that hosts this one
+     *
+     * Returns:
+     *  'true' if parent is already more restrictive than this one and thus
+     *  no differentiation is needed.
+     */
+    bool isSubsetOf(Prot other);
 };
 
 // in hdrgen.c

--- a/src/enum.c
+++ b/src/enum.c
@@ -441,7 +441,7 @@ bool EnumDeclaration::isDeprecated()
     return isdeprecated;
 }
 
-PROT EnumDeclaration::prot()
+Prot EnumDeclaration::prot()
 {
     return protection;
 }

--- a/src/enum.h
+++ b/src/enum.h
@@ -37,7 +37,7 @@ public:
      */
     Type *type;                 // the TypeEnum
     Type *memtype;              // type of the members
-    PROT protection;
+    Prot protection;
 
 private:
     Expression *maxval;
@@ -59,7 +59,7 @@ public:
     const char *kind();
     Dsymbol *search(Loc, Identifier *ident, int flags = IgnoreNone);
     bool isDeprecated();                // is Dsymbol deprecated?
-    PROT prot();
+    Prot prot();
     Expression *getMaxMinValue(Loc loc, Identifier *id);
     Expression *getDefaultValue(Loc loc);
     Type *getMemtype(Loc loc);

--- a/src/func.c
+++ b/src/func.c
@@ -607,7 +607,7 @@ void FuncDeclaration::semantic(Scope *sc)
         const char *sfunc;
         if (isStatic())
             sfunc = "static";
-        else if (protection == PROTprivate || protection == PROTpackage)
+        else if (protection.kind == PROTprivate || protection.kind == PROTpackage)
             sfunc = protectionToChars(protection);
         else
             sfunc = "non-virtual";
@@ -616,7 +616,7 @@ void FuncDeclaration::semantic(Scope *sc)
 
     if (isOverride() && !isVirtual())
     {
-        if ((prot() == PROTprivate || prot() == PROTpackage) && isMember())
+        if ((prot().kind == PROTprivate || prot().kind == PROTpackage) && isMember())
             error("%s method is not virtual and cannot override", protectionToChars(prot()));
         else
             error("cannot override a non-virtual function");
@@ -742,7 +742,7 @@ void FuncDeclaration::semantic(Scope *sc)
                         if (f2)
                         {
                             f2 = f2->overloadExactMatch(type);
-                            if (f2 && f2->isFinalFunc() && f2->prot() != PROTprivate)
+                            if (f2 && f2->isFinalFunc() && f2->prot().kind != PROTprivate)
                                 error("cannot override final function %s", f2->toPrettyChars());
                         }
                     }
@@ -981,7 +981,7 @@ void FuncDeclaration::semantic(Scope *sc)
                     if (f2)
                     {
                         f2 = f2->overloadExactMatch(type);
-                        if (f2 && f2->isFinalFunc() && f2->prot() != PROTprivate)
+                        if (f2 && f2->isFinalFunc() && f2->prot().kind != PROTprivate)
                             error("cannot override final function %s.%s", b->base->toChars(), f2->toPrettyChars());
                     }
                 }
@@ -3413,14 +3413,14 @@ bool FuncDeclaration::isDllMain()
 
 bool FuncDeclaration::isExport()
 {
-    return protection == PROTexport;
+    return protection.kind == PROTexport;
 }
 
 bool FuncDeclaration::isImportedSymbol()
 {
     //printf("isImportedSymbol()\n");
     //printf("protection = %d\n", protection);
-    return (protection == PROTexport) && !fbody;
+    return (protection.kind == PROTexport) && !fbody;
 }
 
 // Determine if function goes into virtual function pointer table
@@ -3441,7 +3441,7 @@ bool FuncDeclaration::isVirtual()
         !(p->isInterfaceDeclaration() && isFinalFunc()));
 #endif
     return isMember() &&
-        !(isStatic() || protection == PROTprivate || protection == PROTpackage) &&
+        !(isStatic() || protection.kind == PROTprivate || protection.kind == PROTpackage) &&
         p->isClassDeclaration() &&
         !(p->isInterfaceDeclaration() && isFinalFunc());
 }
@@ -3802,7 +3802,7 @@ bool FuncDeclaration::addPreInvariant()
     ClassDeclaration *cd = ad ? ad->isClassDeclaration() : NULL;
     return (ad && !(cd && cd->isCPPclass()) &&
             global.params.useInvariants &&
-            (protection == PROTprotected || protection == PROTpublic || protection == PROTexport) &&
+            (protection.kind == PROTprotected || protection.kind == PROTpublic || protection.kind == PROTexport) &&
             !naked &&
             ident != Id::cpctor);
 }
@@ -3814,7 +3814,7 @@ bool FuncDeclaration::addPostInvariant()
     return (ad && !(cd && cd->isCPPclass()) &&
             ad->inv &&
             global.params.useInvariants &&
-            (protection == PROTprotected || protection == PROTpublic || protection == PROTexport) &&
+            (protection.kind == PROTprotected || protection.kind == PROTpublic || protection.kind == PROTexport) &&
             !naked &&
             ident != Id::cpctor);
 }

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -2994,10 +2994,28 @@ const char *linkageToChars(LINK linkage)
 void protectionToBuffer(OutBuffer *buf, Prot prot)
 {
     const char *p = protectionToChars(prot);
+
     if (p)
         buf->writestring(p);
-}
 
+    if ((prot.kind == PROTpackage) && (prot.pkg))
+    {
+        Package* ppkg = prot.pkg;
+
+        if (ppkg)
+        {
+            buf->writeByte('(');
+            while (ppkg)
+            {
+                buf->writestring(ppkg->ident->string);
+                ppkg = ppkg->parent ? ppkg->parent->isPackage() : NULL;
+                if (ppkg)
+                    buf->writeByte('.');
+            }
+            buf->writeByte(')');
+        }
+    }
+}
 
 const char *protectionToChars(Prot prot)
 {

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -2991,16 +2991,17 @@ const char *linkageToChars(LINK linkage)
     return NULL;    // never reached
 }
 
-void protectionToBuffer(OutBuffer *buf, PROT prot)
+void protectionToBuffer(OutBuffer *buf, Prot prot)
 {
     const char *p = protectionToChars(prot);
     if (p)
         buf->writestring(p);
 }
 
-const char *protectionToChars(PROT prot)
+
+const char *protectionToChars(Prot prot)
 {
-    switch (prot)
+    switch (prot.kind)
     {
         case PROTundefined: return NULL;
         case PROTnone:      return "none";

--- a/src/import.c
+++ b/src/import.c
@@ -86,9 +86,9 @@ const char *Import::kind()
     return isstatic ? (char *)"static import" : (char *)"import";
 }
 
-PROT Import::prot()
+Prot Import::prot()
 {
-    return protection;
+    return Prot(protection);
 }
 
 Dsymbol *Import::syntaxCopy(Dsymbol *s)
@@ -194,7 +194,7 @@ void Import::importAll(Scope *sc)
             if (!isstatic && !aliasId && !names.dim)
             {
                 if (sc->explicitProtection)
-                    protection = sc->protection;
+                    protection = sc->protection.kind;
                 sc->scopesym->importScope(mod, protection);
             }
         }
@@ -228,7 +228,7 @@ void Import::semantic(Scope *sc)
         if (!isstatic && !aliasId && !names.dim)
         {
             if (sc->explicitProtection)
-                protection = sc->protection;
+                protection = sc->protection.kind;
             for (Scope *scd = sc; scd; scd = scd->enclosing)
             {
                 if (scd->scopesym)

--- a/src/import.h
+++ b/src/import.h
@@ -35,7 +35,7 @@ public:
     Identifier *id;             // module Identifier
     Identifier *aliasId;
     int isstatic;               // !=0 if static import
-    PROT protection;
+    PROTKIND protection;
 
     // Pairs of alias=name to bind into current namespace
     Identifiers names;
@@ -50,7 +50,7 @@ public:
         int isstatic);
     void addAlias(Identifier *name, Identifier *alias);
     const char *kind();
-    PROT prot();
+    Prot prot();
     Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     void load(Scope *sc);
     void importAll(Scope *sc);

--- a/src/json.c
+++ b/src/json.c
@@ -450,7 +450,7 @@ public:
             property("kind", s->kind());
         }
 
-        if (s->prot() != PROTpublic)
+        if (s->prot().kind != PROTpublic)
             property("protection", protectionToChars(s->prot()));
 
         if (EnumMember *em = s->isEnumMember())
@@ -556,7 +556,7 @@ public:
         property("kind", s->kind());
         property("comment", (const char *)s->comment);
         property("line", "char", &s->loc);
-        if (s->prot() != PROTpublic)
+        if (s->prot().kind != PROTpublic)
             property("protection", protectionToChars(s->prot()));
         if (s->aliasId)
             property("alias", s->aliasId->toChars());

--- a/src/module.c
+++ b/src/module.c
@@ -1051,6 +1051,21 @@ Module *Package::isPackageMod()
     return NULL;
 }
 
+bool Package::isAncestorPackageOf(Package* pkg)
+{
+   if (!pkg)
+       return false;
+
+   while (pkg)
+   {
+       if (this == pkg)
+           return true;
+       pkg = pkg->parent ? pkg->parent->isPackage() : NULL;
+   }
+
+   return false;
+}
+
 /****************************************************
  * Input:
  *      packages[]      the pkg1.pkg2 of pkg1.pkg2.mod

--- a/src/module.c
+++ b/src/module.c
@@ -1066,14 +1066,15 @@ Module *Package::isPackageMod()
  */
 bool Package::isAncestorPackageOf(Package* pkg)
 {
-   if (!pkg)
-       return false;
-
    while (pkg)
    {
        if (this == pkg)
            return true;
-       pkg = pkg->parent ? pkg->parent->isPackage() : NULL;
+
+       if (!pkg->parent)
+           break;
+
+       pkg = pkg->parent->isPackage();
    }
 
    return false;

--- a/src/module.c
+++ b/src/module.c
@@ -1051,6 +1051,19 @@ Module *Package::isPackageMod()
     return NULL;
 }
 
+/**
+ * Checks if pkg is a sub-package of this
+ *
+ * For example, if this qualifies to 'a1.a2' and pkg - to 'a1.a2.a3',
+ * this function returns 'true'. If it is other way around or qualified
+ * package paths conflict function returns 'false'.
+ *
+ * Params:
+ *  pkg = possible subpackage
+ *
+ * Returns:
+ *  see description
+ */
 bool Package::isAncestorPackageOf(Package* pkg)
 {
    if (!pkg)

--- a/src/module.h
+++ b/src/module.h
@@ -53,19 +53,6 @@ public:
 
     Package *isPackage() { return this; }
 
-    /**
-     * Checks if pkg is a sub-package of this
-     *
-     * For example, if this qualifies to 'a1.a2' and pkg - to 'a1.a2.a3',
-     * this function returns 'true'. If it is other way around or qualified
-     * package paths conflict function returns 'false'.
-     *
-     * Params:
-     *  pkg = possible subpackage
-     *
-     * Returns:
-     *  see description
-     */
     bool isAncestorPackageOf(Package* pkg);
 
     void semantic(Scope *sc) { }

--- a/src/module.h
+++ b/src/module.h
@@ -53,6 +53,21 @@ public:
 
     Package *isPackage() { return this; }
 
+    /**
+     * Checks if pkg is a sub-package of this
+     *
+     * For example, if this qualifies to 'a1.a2' and pkg - to 'a1.a2.a3',
+     * this function returns 'true'. If it is other way around or qualified
+     * package paths conflict function returns 'false'.
+     *
+     * Params:
+     *  pkg = possible subpackage
+     *
+     * Returns:
+     *  see description
+     */
+    bool isAncestorPackageOf(Package* pkg);
+
     void semantic(Scope *sc) { }
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
     void accept(Visitor *v) { v->visit(this); }

--- a/src/parse.c
+++ b/src/parse.c
@@ -678,13 +678,10 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                     if (pAttrs->protection.kind != PROTundefined)
                     {
                         if ((pAttrs->protection.kind == PROTpackage) && pkg_prot_idents)
-                        {
-                            Dsymbol* tmp;
-                            Package::resolve(pkg_prot_idents, &tmp, NULL);
-                            pAttrs->protection.pkg = tmp ? tmp->isPackage() : NULL;
-                        }
+                            s = new ProtDeclaration(attrloc, pkg_prot_idents,  a);
+                        else
+                            s = new ProtDeclaration(attrloc, pAttrs->protection, a);
 
-                        s = new ProtDeclaration(attrloc, pAttrs->protection, a);
                         pAttrs->protection = Prot();
                     }
                 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -661,29 +661,32 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
 
                 nextToken();
 
-                if (pAttrs->protection.kind == PROTpackage)
                 {
-                    // optional qualified package identifier to bind
-                    // protection to
-                    if ((pAttrs->protection.kind == PROTpackage) && (token.value == TOKlparen))
+                    if (pAttrs->protection.kind == PROTpackage)
                     {
-                            pkg_prot_idents = parseQualifiedIdentifier("protection package");
-                        check(TOKrparen);
-                    }
-                }
-
-                a = parseBlock(pLastDecl, pAttrs);
-                if (pAttrs->protection.kind != PROTundefined)
-                {
-                    if ((pAttrs->protection.kind == PROTpackage) && pkg_prot_idents)
-                    {
-                        Dsymbol* tmp;
-                        Package::resolve(pkg_prot_idents, &tmp, NULL);
-                        pAttrs->protection.pkg = tmp ? tmp->isPackage() : NULL;
+                        // optional qualified package identifier to bind
+                        // protection to
+                        if ((pAttrs->protection.kind == PROTpackage) && (token.value == TOKlparen))
+                        {
+                                pkg_prot_idents = parseQualifiedIdentifier("protection package");
+                            check(TOKrparen);
+                        }
                     }
 
-                    s = new ProtDeclaration(pAttrs->protection, a);
-                    pAttrs->protection = Prot();
+                    Loc attrloc = token.loc;
+                    a = parseBlock(pLastDecl, pAttrs);
+                    if (pAttrs->protection.kind != PROTundefined)
+                    {
+                        if ((pAttrs->protection.kind == PROTpackage) && pkg_prot_idents)
+                        {
+                            Dsymbol* tmp;
+                            Package::resolve(pkg_prot_idents, &tmp, NULL);
+                            pAttrs->protection.pkg = tmp ? tmp->isPackage() : NULL;
+                        }
+
+                        s = new ProtDeclaration(attrloc, pAttrs->protection, a);
+                        pAttrs->protection = Prot();
+                    }
                 }
                 break;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -668,7 +668,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                         // protection to
                         if ((pAttrs->protection.kind == PROTpackage) && (token.value == TOKlparen))
                         {
-                                pkg_prot_idents = parseQualifiedIdentifier("protection package");
+                            pkg_prot_idents = parseQualifiedIdentifier("protection package");
                             check(TOKrparen);
                         }
                     }

--- a/src/parse.c
+++ b/src/parse.c
@@ -178,7 +178,7 @@ struct PrefixAttributes
     StorageClass storageClass;
     Expression *depmsg;
     LINK link;
-    PROT protection;
+    Prot protection;
     unsigned alignment;
     Expressions *udas;
     const utf8_t *comment;
@@ -217,7 +217,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
             pAttrs = &attrs;
             pAttrs->comment = token.blockComment;
         }
-        PROT prot;
+        PROTKIND prot;
         StorageClass stc;
         Condition *condition;
 
@@ -649,20 +649,20 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
             case TOKexport:     prot = PROTexport;      goto Lprot;
             Lprot:
                 nextToken();
-                if (pAttrs->protection != PROTundefined)
+                if (pAttrs->protection.kind != PROTundefined)
                 {
-                    if (pAttrs->protection != prot)
+                    if (pAttrs->protection.kind != prot)
                         error("conflicting protection attribute '%s' and '%s'",
-                            protectionToChars(pAttrs->protection), protectionToChars(prot));
+                            protectionToChars(pAttrs->protection.kind), protectionToChars(prot));
                     else
                         error("redundant protection attribute '%s'", protectionToChars(prot));
                 }
-                pAttrs->protection = prot;
+                pAttrs->protection.kind = prot;
                 a = parseBlock(pLastDecl, pAttrs);
-                if (pAttrs->protection != PROTundefined)
+                if (pAttrs->protection.kind != PROTundefined)
                 {
                     s = new ProtDeclaration(pAttrs->protection, a);
-                    pAttrs->protection = PROTundefined;
+                    pAttrs->protection.kind = PROTundefined;
                 }
                 break;
 
@@ -2060,7 +2060,7 @@ BaseClasses *Parser::parseBaseClasses()
     for (; 1; nextToken())
     {
         bool prot = false;
-        PROT protection = PROTpublic;
+        Prot protection = PROTpublic;
         switch (token.value)
         {
             case TOKprivate:

--- a/src/parse.c
+++ b/src/parse.c
@@ -669,7 +669,16 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                         if ((pAttrs->protection.kind == PROTpackage) && (token.value == TOKlparen))
                         {
                             pkg_prot_idents = parseQualifiedIdentifier("protection package");
-                            check(TOKrparen);
+
+                            if (pkg_prot_idents)
+                            	check(TOKrparen);
+                            else
+                            {
+                                while (token.value != TOKsemicolon && token.value != TOKeof)
+                                    nextToken();
+                                nextToken();
+                                break;
+                            }
                         }
                     }
 
@@ -1245,6 +1254,8 @@ Identifiers* Parser::parseQualifiedIdentifier(const char* entity)
                 entity,
                 token.toChars()
             );
+
+            return NULL;
         }
 
         Identifier *id = token.ident;

--- a/src/parse.h
+++ b/src/parse.h
@@ -93,6 +93,7 @@ public:
     TypeQualified *parseTypeof();
     Type *parseVector();
     LINK parseLinkage(Identifiers **);
+    Identifiers* parseQualifiedIdentifier(const char* entity);
     Condition *parseDebugCondition();
     Condition *parseVersionCondition();
     Condition *parseStaticIfCondition();

--- a/src/scope.h
+++ b/src/scope.h
@@ -32,13 +32,13 @@ class UserAttributeDeclaration;
 struct DocComment;
 class TemplateInstance;
 
-#if __GNUC__
-// Requires a full definition for PROT and LINK
 #include "dsymbol.h"
+
+#if __GNUC__
+// Requires a full definition for LINK
 #include "mars.h"
 #else
 enum LINK;
-enum PROT;
 #endif
 
 #define CSXthis_ctor    1       // called this()
@@ -97,7 +97,7 @@ struct Scope
     structalign_t structalign;       // alignment for struct members
     LINK linkage;          // linkage for external functions
 
-    PROT protection;       // protection for class members
+    Prot protection;       // protection for class members
     int explicitProtection;     // set if in an explicit protection attribute
 
     StorageClass stc;           // storage class

--- a/src/struct.c
+++ b/src/struct.c
@@ -154,7 +154,7 @@ AggregateDeclaration::AggregateDeclaration(Loc loc, Identifier *id)
     getRTInfo = NULL;
 }
 
-PROT AggregateDeclaration::prot()
+Prot AggregateDeclaration::prot()
 {
     return protection;
 }
@@ -384,7 +384,7 @@ bool AggregateDeclaration::isDeprecated()
 
 bool AggregateDeclaration::isExport()
 {
-    return protection == PROTexport;
+    return protection.kind == PROTexport;
 }
 
 /****************************

--- a/src/template.c
+++ b/src/template.c
@@ -2104,7 +2104,7 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
             if (tf->equals(m->lastf->type) &&
                 fd->storage_class == m->lastf->storage_class &&
                 fd->parent == m->lastf->parent &&
-                fd->protection == m->lastf->protection &&
+                fd->protection.isIdenticalTo(m->lastf->protection) &&
                 fd->linkage == m->lastf->linkage)
             {
                 if ( fd->fbody && !m->lastf->fbody) goto LfIsBetter;
@@ -2630,7 +2630,7 @@ char *TemplateDeclaration::toChars()
     return buf.extractString();
 }
 
-PROT TemplateDeclaration::prot()
+Prot TemplateDeclaration::prot()
 {
     return protection;
 }

--- a/src/template.c
+++ b/src/template.c
@@ -2104,7 +2104,7 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
             if (tf->equals(m->lastf->type) &&
                 fd->storage_class == m->lastf->storage_class &&
                 fd->parent == m->lastf->parent &&
-                fd->protection.isIdenticalTo(m->lastf->protection) &&
+                (fd->protection == m->lastf->protection) &&
                 fd->linkage == m->lastf->linkage)
             {
                 if ( fd->fbody && !m->lastf->fbody) goto LfIsBetter;

--- a/src/template.h
+++ b/src/template.h
@@ -78,7 +78,7 @@ public:
     bool literal;               // this template declaration is a literal
     bool ismixin;               // template declaration is only to be used as a mixin
     bool isstatic;              // this is static template declaration
-    PROT protection;
+    Prot protection;
 
     TemplatePrevious *previous;         // threaded list of previous instantiation attempts on stack
 
@@ -91,7 +91,7 @@ public:
     const char *kind();
     char *toChars();
 
-    PROT prot();
+    Prot prot();
 
     bool evaluateConstraint(TemplateInstance *ti, Scope *sc, Scope *paramscope, Objects *dedtypes, FuncDeclaration *fd);
 

--- a/src/tocvdebug.c
+++ b/src/tocvdebug.c
@@ -55,11 +55,11 @@ int cvMember(Dsymbol *s, unsigned char *p);
  * Convert D protection attribute to cv attribute.
  */
 
-unsigned PROTtoATTR(PROT prot)
+unsigned PROTtoATTR(Prot prot)
 {
     unsigned attribute;
 
-    switch (prot)
+    switch (prot.kind)
     {
         case PROTprivate:       attribute = 1;  break;
         case PROTpackage:       attribute = 2;  break;

--- a/test/compilable/protattr.d
+++ b/test/compilable/protattr.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
 import protection.basic.tests;
 import protection.subpkg.tests;
 import protection.subpkg2.tests;

--- a/test/compilable/protattr.d
+++ b/test/compilable/protattr.d
@@ -1,0 +1,3 @@
+import protection.basic.tests;
+import protection.subpkg.tests;
+import protection.subpkg2.tests;

--- a/test/compilable/protection/basic/mod1.d
+++ b/test/compilable/protection/basic/mod1.d
@@ -1,0 +1,13 @@
+module protection.basic.mod1;
+
+public void publicFoo() {}
+package void packageFoo() {}
+private void privateFoo() {}
+
+class Test
+{
+    public void publicFoo();
+    protected void protectedFoo();
+    package void packageFoo();
+    private void privateFoo();
+}

--- a/test/compilable/protection/basic/tests.d
+++ b/test/compilable/protection/basic/tests.d
@@ -1,0 +1,23 @@
+module protection.basic.tests;
+
+import protection.basic.mod1;
+
+static assert ( is(typeof(publicFoo())));
+static assert ( is(typeof(packageFoo())));
+static assert (!is(typeof(privateFoo())));
+
+static assert ( is(typeof(Test.init.publicFoo())));
+static assert (!is(typeof(Test.init.protectedFoo())));
+static assert ( is(typeof(Test.init.packageFoo())));
+static assert (!is(typeof(Test.init.privateFoo())));
+
+class Deriv : Test
+{
+    void stub()
+    {
+        static assert ( is(typeof(this.publicFoo())));
+        static assert ( is(typeof(this.protectedFoo())));
+        static assert ( is(typeof(this.packageFoo())));
+        static assert (!is(typeof(this.privateFoo())));
+    }
+}

--- a/test/compilable/protection/subpkg/explicit.d
+++ b/test/compilable/protection/subpkg/explicit.d
@@ -2,5 +2,3 @@ module protection.subpkg.explicit;
 
 package(protection) void commonAncestorFoo();
 package(protection.subpkg) void samePkgFoo();
-package(protection.subpkg2) void differentSubPkgFoo();
-package(unknown) void unknownPkgFoo();

--- a/test/compilable/protection/subpkg/explicit.d
+++ b/test/compilable/protection/subpkg/explicit.d
@@ -1,0 +1,6 @@
+module protection.subpkg.explicit;
+
+package(protection) void commonAncestorFoo();
+package(protection.subpkg) void samePkgFoo();
+package(protection.subpkg2) void differentSubPkgFoo();
+package(unknown) void unknownPkgFoo();

--- a/test/compilable/protection/subpkg/tests.d
+++ b/test/compilable/protection/subpkg/tests.d
@@ -1,0 +1,14 @@
+module protection.subpkg.tests;
+
+import crosspkg = protection.basic.mod1;
+
+static assert ( is(typeof(crosspkg.publicFoo())));
+static assert (!is(typeof(crosspkg.packageFoo())));
+static assert (!is(typeof(crosspkg.privateFoo())));
+
+import samepkg = protection.subpkg.explicit;
+
+static assert ( is(typeof(samepkg.commonAncestorFoo())));
+static assert ( is(typeof(samepkg.samePkgFoo())));
+static assert (!is(typeof(samepkg.differentSubPkgFoo())));
+static assert (!is(typeof(samepkg.unknownPkgFoo())));

--- a/test/compilable/protection/subpkg/tests.d
+++ b/test/compilable/protection/subpkg/tests.d
@@ -10,5 +10,3 @@ import samepkg = protection.subpkg.explicit;
 
 static assert ( is(typeof(samepkg.commonAncestorFoo())));
 static assert ( is(typeof(samepkg.samePkgFoo())));
-static assert (!is(typeof(samepkg.differentSubPkgFoo())));
-static assert (!is(typeof(samepkg.unknownPkgFoo())));

--- a/test/compilable/protection/subpkg2/tests.d
+++ b/test/compilable/protection/subpkg2/tests.d
@@ -2,7 +2,4 @@ module protection.subpkg2.tests;
 
 import pkg = protection.subpkg.explicit;
 
-static assert ( is(typeof(pkg.commonAncestorFoo())));
-static assert (!is(typeof(pkg.samePkgFoo())));
-static assert ( is(typeof(pkg.differentSubPkgFoo())));
-static assert (!is(typeof(pkg.unknownPkgFoo())));
+static assert (is(typeof(pkg.commonAncestorFoo())));

--- a/test/compilable/protection/subpkg2/tests.d
+++ b/test/compilable/protection/subpkg2/tests.d
@@ -1,0 +1,8 @@
+module protection.subpkg2.tests;
+
+import pkg = protection.subpkg.explicit;
+
+static assert ( is(typeof(pkg.commonAncestorFoo())));
+static assert (!is(typeof(pkg.samePkgFoo())));
+static assert ( is(typeof(pkg.differentSubPkgFoo())));
+static assert (!is(typeof(pkg.unknownPkgFoo())));

--- a/test/fail_compilation/protattr1.d
+++ b/test/fail_compilation/protattr1.d
@@ -1,0 +1,7 @@
+/*
+TEST_OUTPUT:
+---
+Error: attribute __anonymous 'undefined' is not one of ancestor packages of module 'protection.subpkg.test1'
+---
+*/
+import protection.subpkg.test1;

--- a/test/fail_compilation/protattr1.d
+++ b/test/fail_compilation/protattr1.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-Error: attribute __anonymous 'undefined' is not one of ancestor packages of module 'protection.subpkg.test1'
+fail_compilation/protection/subpkg/test1.d(3): Error: protection attribute 'package(undefined)' does not bind to one of ancestor packages of module 'protection.subpkg.test1'
 ---
 */
 import protection.subpkg.test1;

--- a/test/fail_compilation/protattr2.d
+++ b/test/fail_compilation/protattr2.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-Error: attribute __anonymous 'subpkg2' is not one of ancestor packages of module 'protection.subpkg.test2'
+fail_compilation/protection/subpkg/test2.d(3): Error: protection attribute 'package(protection.subpkg2)' does not bind to one of ancestor packages of module 'protection.subpkg.test2'
 ---
 */
 import protection.subpkg.test2;

--- a/test/fail_compilation/protattr2.d
+++ b/test/fail_compilation/protattr2.d
@@ -1,0 +1,7 @@
+/*
+TEST_OUTPUT:
+---
+Error: attribute __anonymous 'subpkg2' is not one of ancestor packages of module 'protection.subpkg.test2'
+---
+*/
+import protection.subpkg.test2;

--- a/test/fail_compilation/protattr3.d
+++ b/test/fail_compilation/protattr3.d
@@ -1,0 +1,7 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/protection/subpkg/test3.d(3): Error: protection package expected as dot-separated identifiers, got '123'
+---
+*/
+import protection.subpkg.test3;

--- a/test/fail_compilation/protection/subpkg/test1.d
+++ b/test/fail_compilation/protection/subpkg/test1.d
@@ -1,0 +1,3 @@
+module protection.subpkg.test1;
+
+package(undefined) void foo1();

--- a/test/fail_compilation/protection/subpkg/test2.d
+++ b/test/fail_compilation/protection/subpkg/test2.d
@@ -1,0 +1,3 @@
+module protection.subpkg.test2;
+
+package(protection.subpkg2) void foo2();

--- a/test/fail_compilation/protection/subpkg/test3.d
+++ b/test/fail_compilation/protection/subpkg/test3.d
@@ -1,0 +1,3 @@
+module protection.subpkg.test3;
+
+package(123) void foo3();


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=2529

This does not implement original proposal from linked bugzilla entry but addresses same goal.

Currently there is no way to use `package` protection attribute with deeply nested package hierarchy, forcing to either use flat one or `public` protection. This is one of blocking issues for further usage of `package.d` in Phobos and one of reasons why namespace hacks are so popular.

For example, if helpers in `std.internal` will be marked as `package`, only `std.internal` will be able to access those, but not rest of `std`. This PR fixes it by allowing `package(<pkgname>)` syntax to explicitly define owning package.

This new syntax will work:

``` D
module std.internal.mod1;
package(std) void foo() {}
```

``` D
module std.mod2;
import std.internal.mod2;
void bar() { foo(); }
```

Exact semantics can are described by added "protection" tests to `test/compilable` (last commit in this PR).

Plain `package` behavior is unchanged and thus no breaking changes introduced.
