### PR TITLE
Commit 1169754 updated TOK enum without fixing up the offset comments

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -75,6 +75,7 @@ enum TOK
         TOKdelegateptr,
         TOKdelegatefuncptr,
 
+// 54
         // Operators
         TOKlt,          TOKgt,
         TOKle,          TOKge,
@@ -83,11 +84,12 @@ enum TOK
         TOKindex,       TOKis,
         TOKtobool,
 
-// 63
+// 65
         // NCEG floating point compares
         // !<>=     <>    <>=    !>     !>=   !<     !<=   !<>
         TOKunord,TOKlg,TOKleg,TOKule,TOKul,TOKuge,TOKug,TOKue,
 
+// 73
         TOKshl,         TOKshr,
         TOKshlass,      TOKshrass,
         TOKushr,        TOKushrass,
@@ -103,7 +105,7 @@ enum TOK
         TOKquestion,    TOKandand,      TOKoror,
         TOKpreplusplus, TOKpreminusminus,
 
-// 110
+// 112
         // Numeric literals
         TOKint32v, TOKuns32v,
         TOKint64v, TOKuns64v,
@@ -131,7 +133,7 @@ enum TOK
         TOKcomplex32, TOKcomplex64, TOKcomplex80,
         TOKchar, TOKwchar, TOKdchar, TOKbool,
 
-// 155
+// 157
         // Aggregates
         TOKstruct, TOKclass, TOKinterface, TOKunion, TOKenum, TOKimport,
         TOKtypedef, TOKalias, TOKoverride, TOKdelegate, TOKfunction,


### PR DESCRIPTION
That's the commit where @yebblies added `TOKdelegateptr` and `TOKdelegatefuncptr`, so offset += 2
