### PR TITLE
[REG2.066a] Issue 12906 - [CTFE] Static array of structs causes postblit call

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4017,7 +4017,7 @@ public:
                 else
                 {
                     setValue(v, newval);
-                    if (tyE1 == Tsarray && e->e2->isLvalue())
+                    if (e->op != TOKblit && tyE1 == Tsarray && e->e2->isLvalue())
                     {
                         assert(newval->op == TOKarrayliteral);
                         ArrayLiteralExp *ale = (ArrayLiteralExp *)newval;
@@ -4560,7 +4560,7 @@ public:
             {
                 (*oldelems)[(size_t)(j + firstIndex)] = paintTypeOntoLiteral(elemtype, (*newelems)[j]);
             }
-            if (originalExp->e2->isLvalue())
+            if (originalExp->op != TOKblit && originalExp->e2->isLvalue())
             {
                 Expression *x = evaluatePostblits(istate, existingAE, 0, oldelems->dim);
                 if (exceptionOrCantInterpret(x))
@@ -4644,7 +4644,7 @@ public:
                         assignInPlace((*existingAE->elements)[(size_t)(j+firstIndex)], newval);
                 }
             }
-            if (!wantRef && !cow && originalExp->e2->isLvalue())
+            if (!wantRef && !cow && originalExp->op != TOKblit && originalExp->e2->isLvalue())
             {
                 Expression *x = evaluatePostblits(istate, existingAE, (size_t)firstIndex, (size_t)(firstIndex+upperbound-lowerbound));
                 if (exceptionOrCantInterpret(x))

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -6089,6 +6089,17 @@ bool test9245()
 static assert(test9245());
 
 /**************************************************
+    12906 don't call postblit on blit initializing
+**************************************************/
+
+struct S12906 { this(this) { assert(0); } }
+
+static assert({
+    S12906[1] arr;
+    return true;
+}());
+
+/**************************************************
     11510 support overlapped field access in CTFE
 **************************************************/
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12906
