### PR TITLE
Issue 12909 & 12910 - fix purity level calculation for AA parameter

### DIFF
--- a/test/compilable/warn3882.d
+++ b/test/compilable/warn3882.d
@@ -46,3 +46,17 @@ struct K12760
     }
 }
 
+/******************************************/
+// 12909
+
+int f12909(immutable(int[])[int] aa) pure nothrow
+{
+    aa[0] = [];
+    return 0;
+}
+
+void test12909()
+{
+    immutable(int[])[int] aa;
+    f12909(aa);
+}

--- a/test/compilable/warn3882.d
+++ b/test/compilable/warn3882.d
@@ -1,0 +1,48 @@
+// PERMUTE_ARGS: -w -wi -debug
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+@safe pure nothrow void strictVoidReturn(T)(T x) {}
+@safe pure nothrow void nonstrictVoidReturn(T)(ref T x) {}
+
+void main()
+{
+    int x = 3;
+    strictVoidReturn(x);
+    nonstrictVoidReturn(x);
+}
+
+/******************************************/
+// 12619
+
+extern (C) @system nothrow pure void* memcpy(void* s1, in void* s2, size_t n);
+// -> weakly pure
+
+void test12619() pure
+{
+    ubyte[10] a, b;
+    debug memcpy(a.ptr, b.ptr, 5);  // memcpy call should have side effect
+}
+
+/******************************************/
+// 12760
+
+struct S12760(T)
+{
+    T i;
+    this(T j) inout {}
+}
+
+struct K12760
+{
+    S12760!int nullable;
+
+    this(int)
+    {
+        nullable = 0;   // weak purity
+    }
+}
+

--- a/test/compilable/warn3882.d
+++ b/test/compilable/warn3882.d
@@ -59,4 +59,8 @@ void test12909()
 {
     immutable(int[])[int] aa;
     f12909(aa);
+
+    // from 12910
+    const(int[])[int] makeAA() { return null; }  // to make r-value
+    makeAA().rehash();
 }

--- a/test/fail_compilation/fail3882.d
+++ b/test/fail_compilation/fail3882.d
@@ -1,20 +1,16 @@
 // REQUIRED_ARGS: -w
 // PERMUTE_ARGS: -debug
+
+/******************************************/
+// 3882
+
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3882.d(29): Warning: calling fail3882.strictlyPure!int.strictlyPure without side effects discards return value of type int, prepend a cast(void) if intentional
-fail_compilation/fail3882.d(33): Warning: calling fp without side effects discards return value of type int, prepend a cast(void) if intentional
+fail_compilation/fail3882.d(23): Warning: calling fail3882.strictlyPure!int.strictlyPure without side effects discards return value of type int, prepend a cast(void) if intentional
+fail_compilation/fail3882.d(27): Warning: calling fp without side effects discards return value of type int, prepend a cast(void) if intentional
 ---
 */
-
-@safe pure nothrow void strictVoidReturn(T)(T x)
-{
-}
-
-@safe pure nothrow void nonstrictVoidReturn(T)(ref T x)
-{
-}
 
 @safe pure nothrow T strictlyPure(T)(T x)
 {
@@ -24,42 +20,9 @@ fail_compilation/fail3882.d(33): Warning: calling fp without side effects discar
 void main()
 {
     int x = 3;
-    strictVoidReturn(x);
-    nonstrictVoidReturn(x);
     strictlyPure(x);
 
     // 12649
     auto fp = &strictlyPure!int;
     fp(x);
-}
-
-/******************************************/
-// 12619
-
-extern (C) @system nothrow pure void* memcpy(void* s1, in void* s2, size_t n);
-// -> weakly pure
-
-void test12619() pure
-{
-    ubyte[10] a, b;
-    debug memcpy(a.ptr, b.ptr, 5);  // memcpy call should have side effect
-}
-
-/******************************************/
-// 12760
-
-struct S12760(T)
-{
-    T i;
-    this(T j) inout {}
-}
-
-struct K12760
-{
-    S12760!int nullable;
-
-    this(int)
-    {
-        nullable = 0;   // weak purity
-    }
 }

--- a/test/fail_compilation/fail3882.d
+++ b/test/fail_compilation/fail3882.d
@@ -26,3 +26,23 @@ void main()
     auto fp = &strictlyPure!int;
     fp(x);
 }
+
+/******************************************/
+// bugfix in TypeFunction::purityLevel
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail3882.d(46): Warning: calling fail3882.f1 without side effects discards return value of type int, prepend a cast(void) if intentional
+fail_compilation/fail3882.d(47): Warning: calling fail3882.f2 without side effects discards return value of type int, prepend a cast(void) if intentional
+---
+*/
+
+nothrow pure int f1(immutable(int)[] a) { return 0; }
+nothrow pure int f2(immutable(int)*  p) { return 0; }
+
+void test_bug()
+{
+    f1([]);
+    f2(null);
+}


### PR DESCRIPTION
[Issue 12909](https://issues.dlang.org/show_bug.cgi?id=12909) - [AA] Function is incorrectly inferred as strongly pure for associative array with key of non-mutable array or pointer as argument
[Issue 12910](https://issues.dlang.org/show_bug.cgi?id=12910) - [AA] `rehash` is incorrectly inferred as strongly pure for some associative arrays
