### PR TITLE
Issue 12902 & 10904 - fix ICEs with opDollar and multidimensional operator overloading

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10986,6 +10986,10 @@ Expression *AssignExp::semantic(Scope *sc)
                 if (ex->op == TOKerror)
                     return ex;
 
+                e2 = e2->semantic(sc);
+                if (e2->op == TOKerror)
+                    return e2;
+
                 Expressions *a = (Expressions *)ae->arguments->copy();
                 a->insert(0, e2);
 

--- a/src/opover.c
+++ b/src/opover.c
@@ -956,6 +956,13 @@ Expression *op_overload(Expression *e, Scope *sc)
                             return;
                         }
 
+                        e->e2 = e->e2->semantic(sc);
+                        if (e->e2->op == TOKerror)
+                        {
+                            result = e->e2;
+                            return;
+                        }
+
                         Expressions *a = (Expressions *)ae->arguments->copy();
                         a->insert(0, e->e2);
 

--- a/test/fail_compilation/ice12902.d
+++ b/test/fail_compilation/ice12902.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice12902.d(20): Error: variable ice12902.main.__dollar type void is inferred from initializer s.opDollar(), and variables cannot be of type void
+fail_compilation/ice12902.d(20): Error: expression s.opDollar() is void and has no value
+---
+*/
+
+struct S
+{
+    void opDollar() { }
+    void opIndex() { }
+    void opIndexAssign() { }
+    void opSliceAssign() { }
+}
+
+void main()
+{
+    S s;
+    s[] = s[$];
+}

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1038,6 +1038,45 @@ void test12382()
 }
 
 /**************************************/
+// 12904
+
+struct S12904
+{
+    void opIndexAssign(U, A...)(U value, A args)
+    {
+        static assert(0);
+    }
+    void opSliceAssign(int n)
+    {
+        assert(n == 10);
+    }
+
+    size_t opDollar(size_t dim)()
+    {
+        return 7;
+    }
+
+    int opSlice(size_t dim)(size_t, size_t to)
+    {
+        assert(to == 7);
+        return 1;
+    }
+
+    int opIndex(int i1, int i2)
+    {
+        assert(i1 == 1 && i2 == 1);
+        return 10;
+    }
+}
+
+void test12904()
+{
+    S12904 s;
+    s[] = s[0..$, 1];
+    s[] = s[0..$, 0..$];
+}
+
+/**************************************/
 // 7641
 
 mixin template Proxy7641(alias a)
@@ -1792,6 +1831,7 @@ int main()
     test3789();
     test10037();
     test6798();
+    test12904();
     test7641();
     test8434();
     test18();


### PR DESCRIPTION
[Issue 12902](https://issues.dlang.org/show_bug.cgi?id=12902) - [ICE] Assertion failure '!ae->lengthVar' in 'expression.c' when using `opDollar`
[Issue 12904](https://issues.dlang.org/show_bug.cgi?id=12904) - Wrong-code for some slice to slice assignments when using `opDollar`
