### PR TITLE
fix Issue 5854 - Built-in array sort doesn't sort SysTime correctly

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -652,7 +652,7 @@ FuncDeclaration *buildXopCmp(StructDeclaration *sd, Scope *sc)
 
     Expression *e1 = new IdentifierExp(loc, Id::p);
     Expression *e2 = new IdentifierExp(loc, Id::q);
-    Expression *e = new CallExp(loc, new DotIdExp(loc, e1, Id::cmp), e2);
+    Expression *e = new CallExp(loc, new DotIdExp(loc, e2, Id::cmp), e1);
 
     fop->fbody = new ReturnStatement(loc, e);
 

--- a/test/runnable/test5854.d
+++ b/test/runnable/test5854.d
@@ -1,20 +1,45 @@
-import std.datetime;
+struct S1
+{
+    long x1, x2;
 
+    int opCmp(ref const S1 s) const
+    {
+        if (x2 - s.x2 != 0)
+            return x2 < s.x2 ? -1 : 1;
+
+        return x1 < s.x1 ? -1 : x1 == s.x1 ? 0 : 1;
+    }
+}
+
+struct S2
+{
+    long x1, x2;
+
+    int opCmp(in S2 s) const
+    {
+        if (x2 - s.x2 != 0)
+            return x2 < s.x2 ? -1 : 1;
+
+        return x1 < s.x1 ? -1 : x1 == s.x1 ? 0 : 1;
+    }
+}
+void test5854()
+{
+    auto arr1 = [S1(4, 4), S1(1, 3), S1(2, 9), S1(3, 22)].sort;
+
+    foreach (i; 0 .. arr1.length - 1)
+    {
+        assert(arr1[i] < arr1[i + 1]);
+    }
+
+    auto arr2 = [S2(4, 4), S2(1, 3), S2(2, 9), S2(3, 22)].sort;
+
+    foreach (i; 0 .. arr2.length - 1)
+    {
+        assert(arr2[i] < arr2[i + 1]);
+    }
+}
 void main()
 {
-    DateTime[] datetimes = [
-        DateTime(Date(2014, 5, 21)),
-        DateTime(Date(2014, 5, 20)),
-        DateTime(Date(2014, 5, 23)),
-        DateTime(Date(2014, 5, 22)),
-    ];
-
-    DateTime[] expected = [
-        DateTime(Date(2014, 5, 20)),
-        DateTime(Date(2014, 5, 21)),
-        DateTime(Date(2014, 5, 22)),
-        DateTime(Date(2014, 5, 23)),
-    ];
-
-    assert(datetimes.sort == expected);
+    test5854();
 }

--- a/test/runnable/test5854.d
+++ b/test/runnable/test5854.d
@@ -1,0 +1,20 @@
+import std.datetime;
+
+void main()
+{
+    DateTime[] datetimes = [
+        DateTime(Date(2014, 5, 21)),
+        DateTime(Date(2014, 5, 20)),
+        DateTime(Date(2014, 5, 23)),
+        DateTime(Date(2014, 5, 22)),
+    ];
+
+    DateTime[] expected = [
+        DateTime(Date(2014, 5, 20)),
+        DateTime(Date(2014, 5, 21)),
+        DateTime(Date(2014, 5, 22)),
+        DateTime(Date(2014, 5, 23)),
+    ];
+
+    assert(datetimes.sort == expected);
+}


### PR DESCRIPTION
When creating the adaption of `int opCmp(in S other) const` to be called as `int opCmp(ref const S other) const` the compare parameters need to be reversed, otherwise `array.sort` will sort descending.
