### PR TITLE
Issue 12928 - Range check dropped for array[length]

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10765,7 +10765,7 @@ Expression *IndexExp::semantic(Scope *sc)
             e2 = e2->optimize(WANTvalue);
             dinteger_t length = el->toInteger();
             if (length)
-                skipboundscheck = IntRange(SignExtendedNumber(0), SignExtendedNumber(length)).contains(getIntRange(e2));
+                skipboundscheck = IntRange(SignExtendedNumber(0), SignExtendedNumber(length-1)).contains(getIntRange(e2));
         }
     }
 

--- a/test/runnable/bug12928.d
+++ b/test/runnable/bug12928.d
@@ -1,0 +1,13 @@
+// PERMUTE_ARGS: -inline -g -O
+import core.exception : RangeError;
+void main(string[] args)
+{
+  int[2] a;
+  try
+  {
+    foreach(const i; 0..3)
+      a[i] = i;
+    assert(0);
+  }
+  catch(RangeError){}
+}


### PR DESCRIPTION
IntRanges in DMD are inclusive. The range check would get dropped if the expression for the index was contained within [0..length]-inclusive. This would drop the range check for [length].

https://issues.dlang.org/show_bug.cgi?id=12928
