### PR TITLE
[REG2.066a] Issue 12924 - deprecated("foo"); and deprecated; should not compile

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -638,21 +638,10 @@ Scope *ProtDeclaration::newScope(Scope *sc)
     return createNewScope(sc, sc->stc, sc->linkage, this->protection, 1, sc->structalign);
 }
 
-void ProtDeclaration::protectionToCBuffer(OutBuffer *buf, PROT protection)
-{
-    const char *p;
-
-    p = Pprotectionnames[protection];
-
-    assert(p);
-
-    buf->writestring(p);
-    buf->writeByte(' ');
-}
-
 void ProtDeclaration::toCBuffer(OutBuffer *buf, HdrGenState *hgs)
 {
-    protectionToCBuffer(buf, protection);
+    protectionToBuffer(buf, protection);
+    buf->writeByte(' ');
     AttribDeclaration::toCBuffer(buf, hgs);
 }
 

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -111,8 +111,6 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-
-    static void protectionToCBuffer(OutBuffer *buf, PROT protection);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/doc.c
+++ b/src/doc.c
@@ -702,8 +702,7 @@ void emitMemberComments(ScopeDsymbol *sds, Scope *sc)
 
 void emitProtection(OutBuffer *buf, PROT prot)
 {
-    const char *p = (prot == PROTpublic) ? NULL : Pprotectionnames[prot];
-
+    const char *p = (prot == PROTpublic) ? NULL : protectionToChars(prot);
     if (p)
         buf->printf("%s ", p);
 }

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -34,8 +34,6 @@
 #include "attrib.h"
 #include "enum.h"
 
-const char* Pprotectionnames[] = {NULL, "none", "private", "package", "protected", "public", "export"};
-
 
 /****************************** Dsymbol ******************************/
 

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -99,8 +99,9 @@ enum PROT
     PROTexport,
 };
 
-// this is used for printing the protection in json, traits, docs, etc.
-extern const char* Pprotectionnames[];
+// in hdrgen.c
+void protectionToBuffer(OutBuffer *buf, PROT prot);
+const char *protectionToChars(PROT prot);
 
 /* State of symbol in winding its way through the passes of the compiler
  */

--- a/src/func.c
+++ b/src/func.c
@@ -610,7 +610,7 @@ void FuncDeclaration::semantic(Scope *sc)
         if (isStatic())
             sfunc = "static";
         else if (protection == PROTprivate || protection == PROTpackage)
-            sfunc = Pprotectionnames[protection];
+            sfunc = protectionToChars(protection);
         else
             sfunc = "non-virtual";
         error("%s functions cannot be abstract", sfunc);
@@ -619,7 +619,7 @@ void FuncDeclaration::semantic(Scope *sc)
     if (isOverride() && !isVirtual())
     {
         if ((prot() == PROTprivate || prot() == PROTpackage) && isMember())
-            error("%s method is not virtual and cannot override", Pprotectionnames[prot()]);
+            error("%s method is not virtual and cannot override", protectionToChars(prot()));
         else
             error("cannot override a non-virtual function");
     }

--- a/src/import.c
+++ b/src/import.c
@@ -309,7 +309,8 @@ void Import::semantic(Scope *sc)
 
         // use protection instead of sc->protection because it couldn't be
         // resolved yet, see the comment above
-        ProtDeclaration::protectionToCBuffer(ob, protection);
+        protectionToBuffer(ob, protection);
+        ob->writeByte(' ');
         if (isstatic)
             StorageClassDeclaration::stcToCBuffer(ob, STCstatic);
         ob->writestring(": ");

--- a/src/json.c
+++ b/src/json.c
@@ -451,7 +451,7 @@ public:
         }
 
         if (s->prot() != PROTpublic)
-            property("protection", Pprotectionnames[s->prot()]);
+            property("protection", protectionToChars(s->prot()));
 
         if (EnumMember *em = s->isEnumMember())
         {
@@ -557,7 +557,7 @@ public:
         property("comment", (const char *)s->comment);
         property("line", "char", &s->loc);
         if (s->prot() != PROTpublic)
-            property("protection", Pprotectionnames[s->prot()]);
+            property("protection", protectionToChars(s->prot()));
         if (s->aliasId)
             property("alias", s->aliasId->toChars());
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -340,6 +340,10 @@ enum LINK
     LINKpascal,
 };
 
+// in hdrgen.c
+void linkageToBuffer(OutBuffer *buf, LINK linkage);
+const char *linkageToChars(LINK linkage);
+
 enum DYNCAST
 {
     DYNCAST_OBJECT,

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6202,9 +6202,6 @@ Type *TypeFunction::addStorageClass(StorageClass stc)
     return t;
 }
 
-// in hdrgen.c
-void trustToBuffer(OutBuffer *buf, TRUST trust);
-
 /** For each active attribute (ref/const/nogc/etc) call fp with a void* for the
 work param and a string representation of the attribute. */
 int TypeFunction::attributesApply(void *param, int (*fp)(void *, const char *), TRUSTformat trustFormat)
@@ -6237,10 +6234,7 @@ int TypeFunction::attributesApply(void *param, int (*fp)(void *, const char *), 
             return res;  // avoid calling with an empty string
     }
 
-    OutBuffer buf;
-    trustToBuffer(&buf, trustAttrib);
-    res = fp(param, buf.extractString());
-    return res;
+    return fp(param, trustToChars(trustAttrib));
 }
 
 /***************************** TypeDelegate *****************************/

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -598,6 +598,10 @@ enum TRUST
     TRUSTsafe = 3,      // @safe
 };
 
+// in hdrgen.c
+void trustToBuffer(OutBuffer *buf, TRUST trust);
+const char *trustToChars(TRUST trust);
+
 enum TRUSTformat
 {
     TRUSTformatDefault,  // do not emit @system when trust == TRUSTdefault

--- a/src/parse.h
+++ b/src/parse.h
@@ -46,6 +46,7 @@ struct ModuleDeclaration;
 class TemplateDeclaration;
 class TemplateInstance;
 class StaticAssert;
+struct PrefixAttributes;
 
 /************************************
  * These control how parseStatement() works.
@@ -74,9 +75,9 @@ public:
     Parser(Module *module, const utf8_t *base, size_t length, int doDocComment);
 
     Dsymbols *parseModule();
-    Dsymbols *parseDeclDefs(int once, Dsymbol **pLastDecl = NULL);
+    Dsymbols *parseDeclDefs(int once, Dsymbol **pLastDecl = NULL, PrefixAttributes *pAttrs = NULL);
     Dsymbols *parseAutoDeclarations(StorageClass storageClass, const utf8_t *comment);
-    Dsymbols *parseBlock(Dsymbol **pLastDecl);
+    Dsymbols *parseBlock(Dsymbol **pLastDecl, PrefixAttributes *pAttrs = NULL);
     void composeStorageClass(StorageClass stc);
     StorageClass parseAttribute(Expressions **pexps);
     StorageClass parsePostfix(Expressions **pudas);

--- a/src/traits.c
+++ b/src/traits.c
@@ -476,10 +476,8 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
         }
         if (s->scope)
             s->semantic(s->scope);
-        PROT protection = s->prot();
 
-        const char *protName = Pprotectionnames[protection];
-
+        const char *protName = protectionToChars(s->prot());
         assert(protName);
         StringExp *se = new StringExp(e->loc, (char *) protName);
         return se->semantic(sc);

--- a/test/fail_compilation/parse12924.d
+++ b/test/fail_compilation/parse12924.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parse12924.d(14): Error: declaration expected following attribute, not ';'
+fail_compilation/parse12924.d(15): Error: declaration expected following attribute, not ';'
+fail_compilation/parse12924.d(16): Error: declaration expected following attribute, not ';'
+fail_compilation/parse12924.d(17): Error: declaration expected following attribute, not ';'
+fail_compilation/parse12924.d(18): Error: declaration expected following attribute, not ';'
+fail_compilation/parse12924.d(19): Error: declaration expected following attribute, not ';'
+fail_compilation/parse12924.d(20): Error: declaration expected following attribute, not ';'
+---
+*/
+
+static;         void f1() {}
+deprecated;     void f2() {}
+deprecated(""); void f3() {}
+extern(C);      void f4() {}
+public;         void f5() {}
+align(1);       void f6() {}
+@(1);           void f7() {}

--- a/test/fail_compilation/parseStc2.d
+++ b/test/fail_compilation/parseStc2.d
@@ -1,0 +1,61 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc2.d(11): Error: conflicting storage class const
+fail_compilation/parseStc2.d(12): Error: conflicting attribute @system
+fail_compilation/parseStc2.d(13): Error: conflicting attribute @safe
+fail_compilation/parseStc2.d(14): Error: conflicting attribute @trusted
+fail_compilation/parseStc2.d(15): Error: conflicting storage class __gshared
+---
+*/
+immutable const void f4() {}
+@safe @system void f4() {}
+@trusted @safe void f4() {}
+@system @trusted void f4() {}
+shared __gshared f4() {}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc2.d(26): Error: redundant storage class 'static'
+fail_compilation/parseStc2.d(27): Error: redundant storage class 'pure'
+fail_compilation/parseStc2.d(28): Error: redundant storage class '@property'
+fail_compilation/parseStc2.d(29): Error: redundant storage class '@safe'
+---
+*/
+static static void f1() {}
+pure nothrow pure void f2() {}
+@property extern(C) @property void f3() {}
+deprecated("") @safe @safe void f4() {}
+@(1) @(1) void f5() {}  // OK
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc2.d(39): Error: redundant linkage extern (C)
+fail_compilation/parseStc2.d(40): Error: conflicting linkage extern (C) and extern (C++)
+---
+*/
+extern(C) extern(C) void f6() {}
+extern(C) extern(C++) void f7() {}
+extern(C++, foo) extern(C++, bar) void f8() {}  // OK
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc2.d(50): Error: redundant protection attribute 'public'
+fail_compilation/parseStc2.d(51): Error: conflicting protection attribute 'public' and 'private'
+---
+*/
+public public void f9() {}
+public private void f10() {}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc2.d(60): Error: redundant alignment attribute align(1)
+fail_compilation/parseStc2.d(61): Error: conflicting alignment attribute align(1) and align(2)
+---
+*/
+align(1) align(1) void f11() {}
+align(1) align(2) void f12() {}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12924

'DeclarationBlock' that follows 'Attribute' should be parsed by `parseBlock`.

`PrefixAttribute` is used to check redundant/conflicting attributes over the mutual call between `parseDeclDefs` and `parseBlock`.
