### PR TITLE
DWARF: Emit address of __gshared variable correctly on I64

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1392,7 +1392,7 @@ void cv_outsym(symbol *s)
 
             infobuf->writeByte(DW_OP_addr);
             dwarf_addrel(infoseg,infobuf->size(),s->Sseg);
-            infobuf->write32(0);        // address of global
+            append_addr(infobuf, 0);    // address of global
 
             infobuf->buf[soffset] = infobuf->size() - soffset - 1;
             break;


### PR DESCRIPTION
Picked up when testing gdb development with D patches.

When writing out `DW_AT_location` of a 64bit `DW_OP_addr`, DMD only pads out the value to 32bits.

eg: `<8a>   DW_AT_location    : 5 byte block: 3 0 0 0 0  (DW_OP_addr: 0)`

This could cause a debugger to read the variable data incorrectly, so best writing out the location with the correct length.  `<8a>   DW_AT_location    : 9 byte block: 3 0 0 0 0 0 0 0 0  (DW_OP_addr: 0)`
