### PR TITLE
Issue 12953 - Wrong alignment number in error messages

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -697,10 +697,26 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
 
                 if (pAttrs->alignment != 0)
                 {
+                    const char *s1 = "";
+                    OutBuffer buf1;
+                    if (n != STRUCTALIGN_DEFAULT)
+                    {
+                        buf1.printf("(%d)", n);
+                        s1 = buf1.peekString();
+                    }
                     if (pAttrs->alignment != n)
-                        error("conflicting alignment attribute align(%d) and align(%d)", pAttrs->alignment, n);
+                    {
+                        OutBuffer buf2;
+                        const char *s2 = "";
+                        if (pAttrs->alignment != STRUCTALIGN_DEFAULT)
+                        {
+                            buf2.printf("(%d)", pAttrs->alignment);
+                            s2 = buf2.peekString();
+                        }
+                        error("conflicting alignment attribute align%s and align%s", s2, s1);
+                    }
                     else
-                        error("redundant alignment attribute align(%d)", n);
+                        error("redundant alignment attribute align%s", s1);
                 }
 
                 pAttrs->alignment = n;

--- a/test/fail_compilation/parseStc2.d
+++ b/test/fail_compilation/parseStc2.d
@@ -53,9 +53,15 @@ public private void f10() {}
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc2.d(60): Error: redundant alignment attribute align(1)
-fail_compilation/parseStc2.d(61): Error: conflicting alignment attribute align(1) and align(2)
+fail_compilation/parseStc2.d(63): Error: redundant alignment attribute align
+fail_compilation/parseStc2.d(64): Error: redundant alignment attribute align(1)
+fail_compilation/parseStc2.d(65): Error: conflicting alignment attribute align and align(1)
+fail_compilation/parseStc2.d(66): Error: conflicting alignment attribute align(1) and align
+fail_compilation/parseStc2.d(67): Error: conflicting alignment attribute align(1) and align(2)
 ---
 */
-align(1) align(1) void f11() {}
-align(1) align(2) void f12() {}
+align    align    void f11() {}
+align(1) align(1) void f12() {}
+align    align(1) void f13() {}
+align(1) align    void f14() {}
+align(1) align(2) void f15() {}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12953
