### PR TITLE
fix Issue 12485 - [REG2.065] DMD crashes when recursive template expansion

### DIFF
--- a/src/root/outbuffer.c
+++ b/src/root/outbuffer.c
@@ -310,17 +310,16 @@ void OutBuffer::align(size_t size)
 
 void OutBuffer::vprintf(const char *format, va_list args)
 {
-    char buffer[128];
-    char *p;
-    unsigned psize;
     int count;
 
-    p = buffer;
-    psize = sizeof(buffer);
+    if (doindent)
+        write(NULL, 0); // perform indent
+    unsigned psize = 128;
     for (;;)
     {
+        reserve(psize);
 #if _WIN32
-        count = _vsnprintf(p,psize,format,args);
+        count = _vsnprintf((char *)data + offset,psize,format,args);
         if (count != -1)
             break;
         psize *= 2;
@@ -336,7 +335,7 @@ void OutBuffer::vprintf(const char *format, va_list args)
   of ap is undefined after the call. The application should call
   va_end(ap) itself afterwards.
  */
-        count = vsnprintf(p,psize,format,va);
+        count = vsnprintf((char *)data + offset,psize,format,va);
         va_end(va);
         if (count == -1)
             psize *= 2;
@@ -345,11 +344,10 @@ void OutBuffer::vprintf(const char *format, va_list args)
         else
             break;
 #else
-    assert(0);
+        assert(0);
 #endif
-        p = (char *) alloca(psize);     // buffer too small, try again with larger size
     }
-    write(p,count);
+    offset += count;
 }
 
 void OutBuffer::printf(const char *format, ...)

--- a/src/template.c
+++ b/src/template.c
@@ -5951,6 +5951,7 @@ void TemplateInstance::tryExpandMembers(Scope *sc2)
     }
 
     expandMembers(sc2);
+
     nest--;
 }
 
@@ -5958,6 +5959,7 @@ void TemplateInstance::trySemantic3(Scope *sc2)
 {
     // extracted to a function to allow windows SEH to work without destructors in the same function
     static int nest;
+    //printf("%d\n", nest);
     if (++nest > 300)
     {
         global.gag = 0;            // ensure error message gets printed

--- a/test/fail_compilation/fail12485.d
+++ b/test/fail_compilation/fail12485.d
@@ -1,0 +1,11 @@
+void dorecursive()
+{
+    recursive([0]);
+}
+
+void recursive(R)(R r)
+{
+    import std.algorithm;
+    recursive( r.filter!(e=>true) );
+}
+


### PR DESCRIPTION
Fix https://issues.dlang.org/show_bug.cgi?id=12485

Partial reversion of https://github.com/D-Programming-Language/dmd/pull/2982
