### PR TITLE
Fix issue 12965 - DMD sets ELFOSABI to ELFOSABI_LINUX on all systems

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -50,7 +50,8 @@
 #  define ELFOSABI ELFOSABI_SYSV
 # elif TARGET_OPENBSD
 #  define ELFOSABI ELFOSABI_OPENBSD
-# endif
+# else
+#  error "No ELF OS ABI defined.  Please fix"
 #endif
 
 //#define DEBSYM 0x7E
@@ -1079,18 +1080,18 @@ void Obj::term(const char *objfilename)
     {
         ELFMAG0,ELFMAG1,ELFMAG2,ELFMAG3,
         ELFCLASS32,             // EI_CLASS
-        ELFDATA2LSB,    // EI_DATA
+        ELFDATA2LSB,            // EI_DATA
         EV_CURRENT,             // EI_VERSION
-        ELFOSABI,0,       // EI_OSABI,EI_ABIVERSION
+        ELFOSABI,0,             // EI_OSABI,EI_ABIVERSION
         0,0,0,0,0,0,0
     };
     static const char elf_string64[EI_NIDENT] =
     {
         ELFMAG0,ELFMAG1,ELFMAG2,ELFMAG3,
         ELFCLASS64,             // EI_CLASS
-        ELFDATA2LSB,    // EI_DATA
+        ELFDATA2LSB,            // EI_DATA
         EV_CURRENT,             // EI_VERSION
-        ELFOSABI,0,       // EI_OSABI,EI_ABIVERSION
+        ELFOSABI,0,             // EI_OSABI,EI_ABIVERSION
         0,0,0,0,0,0,0
     };
     fobjbuf->write(I64 ? elf_string64 : elf_string32, EI_NIDENT);

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -41,6 +41,18 @@
 #include        "aa.h"
 #include        "tinfo.h"
 
+#ifndef ELFOSABI
+# if TARGET_LINUX
+#  define ELFOSABI ELFOSABI_LINUX
+# elif TARGET_FREEBSD
+#  define ELFOSABI ELFOSABI_FREEBSD
+# elif TARGET_SOLARIS
+#  define ELFOSABI ELFOSABI_SYSV
+# elif TARGET_OPENBSD
+#  define ELFOSABI ELFOSABI_OPENBSD
+# endif
+#endif
+
 //#define DEBSYM 0x7E
 
 static Outbuffer *fobjbuf;
@@ -1069,7 +1081,7 @@ void Obj::term(const char *objfilename)
         ELFCLASS32,             // EI_CLASS
         ELFDATA2LSB,    // EI_DATA
         EV_CURRENT,             // EI_VERSION
-        ELFOSABI_LINUX,0,       // EI_OSABI,EI_ABIVERSION
+        ELFOSABI,0,       // EI_OSABI,EI_ABIVERSION
         0,0,0,0,0,0,0
     };
     static const char elf_string64[EI_NIDENT] =
@@ -1078,7 +1090,7 @@ void Obj::term(const char *objfilename)
         ELFCLASS64,             // EI_CLASS
         ELFDATA2LSB,    // EI_DATA
         EV_CURRENT,             // EI_VERSION
-        ELFOSABI_LINUX,0,       // EI_OSABI,EI_ABIVERSION
+        ELFOSABI,0,       // EI_OSABI,EI_ABIVERSION
         0,0,0,0,0,0,0
     };
     fobjbuf->write(I64 ? elf_string64 : elf_string32, EI_NIDENT);

--- a/src/backend/melf.h
+++ b/src/backend/melf.h
@@ -40,6 +40,7 @@ typedef struct
             #define ELFOSABI_NETBSD     2
             #define ELFOSABI_LINUX      3
             #define ELFOSABI_FREEBSD    9
+            #define ELFOSABI_OPENBSD	12
             #define ELFOSABI_ARM        97      /* ARM */
             #define ELFOSABI_STANDALONE 255     /* Standalone/embedded */
 


### PR DESCRIPTION
This will properly set the ELF OSABI field based on the target (for ELF targets).

https://issues.dlang.org/show_bug.cgi?id=12965
