### PR TITLE
Fix issue 12968 - incorrect codegen

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -5153,7 +5153,8 @@ void pinholeopt(code *c,block *b)
                         break;
                     case 0x8F:  op = 0x58 + ereg; break;
                     case 0x87:
-                        if (reg == 0) op = 0x90 + ereg;
+                        if (reg == 0 && !(c->Irex & (REX_R | REX_B))) // Issue 12968: Needed to ensure it's referencing RAX, not R8
+                            op = 0x90 + ereg;
                         break;
                 }
                 c->Iop = op;

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -6616,6 +6616,38 @@ void test12849()
 
 /****************************************************/
 
+void test12968()
+{
+    int x;
+    ubyte* p;
+    static ubyte data[] =
+    [
+        0x48, 0x89, 0xF8,
+        0x4C, 0x87, 0xC2,
+        0xC3
+    ];
+
+    asm
+    {
+        call	L1			;
+
+        mov RAX, RDI;
+        xchg RDX, R8;
+        ret;
+
+L1:     pop     RAX;
+        mov     p[RBP],RAX;
+    }
+
+    foreach (ref i, b; data)
+    {
+        //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+        assert(p[i] == b);
+    }
+}
+
+/****************************************************/
+
 int main()
 {
     printf("Testing iasm64.d\n");
@@ -6686,6 +6718,7 @@ int main()
     testxadd();
     test9965();
     test12849();
+    test12968();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
This is a minor change to prevent DMD's backend from incorrectly assuming RAX is the register being referenced when a REX prefix is present.
