### PR TITLE
Minor cleanup of the Inline ASM tests

### DIFF
--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -27,9 +27,9 @@ void test1()
 
     asm
     {
-	align x;		;
-	mov EAX, __LOCAL_SIZE	;
-	mov foo[EBP], EAX	;
+    align x;        ;
+    mov EAX, __LOCAL_SIZE   ;
+    mov foo[EBP], EAX   ;
     }
     assert(foo == 8);
 }
@@ -44,10 +44,10 @@ void test2()
 
     asm
     {
-	even			;
-	mov EAX,0		;
-	inc EAX			;
-	mov foo[EBP], EAX	;
+    even            ;
+    mov EAX,0       ;
+    inc EAX         ;
+    mov foo[EBP], EAX   ;
     }
     assert(foo == 1);
 }
@@ -63,10 +63,10 @@ void test3()
 
     asm
     {
-	mov	EAX,5		;
-	jmp	$ + 1		;
-	db	0x40,0x48	;	// inc EAX, dec EAX
-	mov	foo[EBP],EAX	;
+    mov EAX,5       ;
+    jmp $ + 1       ;
+    db  0x40,0x48   ;   // inc EAX, dec EAX
+    mov foo[EBP],EAX    ;
     }
     assert(foo == 4);
 }
@@ -81,13 +81,13 @@ void test4()
 
     asm
     {
-	xor	EAX,EAX		;
-	add	EAX,5		;
-	jne	L1		;
-	db	0x40,0x48	;	// inc EAX, dec EAX
+    xor EAX,EAX     ;
+    add EAX,5       ;
+    jne L1      ;
+    db  0x40,0x48   ;   // inc EAX, dec EAX
 L1:
-	db	0x48		;
-	mov	foo[EBP],EAX	;
+    db  0x48        ;
+    mov foo[EBP],EAX    ;
     }
     assert(foo == 4);
 }
@@ -111,18 +111,18 @@ void test5()
 
     asm
     {
-	call	L1		;
-	db	0x40,0x48	;	// inc EAX, dec EAX
-	db	"abc"		;
-	ds	"def"		;
-	di	"ghi"		;
-	dl	0x12345678ABCDEF ;
-	df	1.1		;
-	dd	1.2		;
-	de	1.3		;
+    call    L1      ;
+    db  0x40,0x48   ;   // inc EAX, dec EAX
+    db  "abc"       ;
+    ds  "def"       ;
+    di  "ghi"       ;
+    dl  0x12345678ABCDEF ;
+    df  1.1     ;
+    dd  1.2     ;
+    de  1.3     ;
 L1:
-	pop	EBX		;
-	mov	p[EBP],EBX	;
+    pop EBX     ;
+    mov p[EBP],EBX  ;
     }
     assert(p[0] == 0x40);
     assert(p[1] == 0x48);
@@ -153,64 +153,64 @@ L1:
 void test6()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x8B, 0x01,       	// mov	EAX,[ECX]
-	0x8B, 0x04, 0x19,    	// mov	EAX,[EBX][ECX]
-	0x8B, 0x04, 0x4B,    	// mov	EAX,[ECX*2][EBX]
-	0x8B, 0x04, 0x5A,    	// mov	EAX,[EBX*2][EDX]
-	0x8B, 0x04, 0x8E,    	// mov	EAX,[ECX*4][ESI]
-	0x8B, 0x04, 0xF9,    	// mov	EAX,[EDI*8][ECX]
+    0x8B, 0x01,         // mov  EAX,[ECX]
+    0x8B, 0x04, 0x19,       // mov  EAX,[EBX][ECX]
+    0x8B, 0x04, 0x4B,       // mov  EAX,[ECX*2][EBX]
+    0x8B, 0x04, 0x5A,       // mov  EAX,[EBX*2][EDX]
+    0x8B, 0x04, 0x8E,       // mov  EAX,[ECX*4][ESI]
+    0x8B, 0x04, 0xF9,       // mov  EAX,[EDI*8][ECX]
 
-	0x2B, 0x1C, 0x19,	// sub	EBX,[EBX][ECX]
-	0x3B, 0x0C, 0x4B,	// cmp	ECX,[ECX*2][EBX]
-	0x03, 0x14, 0x5A,	// add	EDX,[EBX*2][EDX]
-	0x33, 0x34, 0x8E,	// xor	ESI,[ECX*4][ESI]
+    0x2B, 0x1C, 0x19,   // sub  EBX,[EBX][ECX]
+    0x3B, 0x0C, 0x4B,   // cmp  ECX,[ECX*2][EBX]
+    0x03, 0x14, 0x5A,   // add  EDX,[EBX*2][EDX]
+    0x33, 0x34, 0x8E,   // xor  ESI,[ECX*4][ESI]
 
-	0x29, 0x1C, 0x19,    	// sub	[EBX][ECX],EBX
-	0x39, 0x0C, 0x4B,    	// cmp	[ECX*2][EBX],ECX
-	0x01, 0x24, 0x5A,    	// add	[EBX*2][EDX],ESP
-	0x31, 0x2C, 0x8E,    	// xor	[ECX*4][ESI],EBP
+    0x29, 0x1C, 0x19,       // sub  [EBX][ECX],EBX
+    0x39, 0x0C, 0x4B,       // cmp  [ECX*2][EBX],ECX
+    0x01, 0x24, 0x5A,       // add  [EBX*2][EDX],ESP
+    0x31, 0x2C, 0x8E,       // xor  [ECX*4][ESI],EBP
 
-	0xA8, 0x03,       		// test	AL,3
-	0x66, 0xA9, 0x04, 0x00,    	// test	AX,4
-	0xA9, 0x05, 0x00, 0x00, 0x00, 	// test	EAX,5
-	0x85, 0x3C, 0xF9,    		// test	[EDI*8][ECX],EDI
+    0xA8, 0x03,             // test AL,3
+    0x66, 0xA9, 0x04, 0x00,     // test AX,4
+    0xA9, 0x05, 0x00, 0x00, 0x00,   // test EAX,5
+    0x85, 0x3C, 0xF9,           // test [EDI*8][ECX],EDI
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	mov	EAX,[ECX]		;
-	mov	EAX,[ECX][EBX]		;
-	mov	EAX,[ECX*2][EBX]	;
-	mov	EAX,[EDX][EBX*2]	;
-	mov	EAX,[ECX*4][ESI]	;
-	mov	EAX,[ECX][EDI*8]	;
+    mov EAX,[ECX]       ;
+    mov EAX,[ECX][EBX]      ;
+    mov EAX,[ECX*2][EBX]    ;
+    mov EAX,[EDX][EBX*2]    ;
+    mov EAX,[ECX*4][ESI]    ;
+    mov EAX,[ECX][EDI*8]    ;
 
-	sub	EBX,[ECX][EBX]		;
-	cmp	ECX,[ECX*2][EBX]	;
-	add	EDX,[EDX][EBX*2]	;
-	xor	ESI,[ECX*4][ESI]	;
+    sub EBX,[ECX][EBX]      ;
+    cmp ECX,[ECX*2][EBX]    ;
+    add EDX,[EDX][EBX*2]    ;
+    xor ESI,[ECX*4][ESI]    ;
 
-	sub	[ECX][EBX],EBX		;
-	cmp	[ECX*2][EBX],ECX	;
-	add	[EDX][EBX*2],ESP	;
-	xor	[ECX*4][ESI],EBP	;
+    sub [ECX][EBX],EBX      ;
+    cmp [ECX*2][EBX],ECX    ;
+    add [EDX][EBX*2],ESP    ;
+    xor [ECX*4][ESI],EBP    ;
 
-	test	AL,3			;
-	test	AX,4			;
-	test	EAX,5			;
-	test	[ECX][EDI*8],EDI	;
+    test    AL,3            ;
+    test    AX,4            ;
+    test    EAX,5           ;
+    test    [ECX][EDI*8],EDI    ;
 L1:
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -220,35 +220,35 @@ L1:
 void test7()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x26,0xA1,0x24,0x13,0x00,0x00,		// mov	EAX,ES:[01324h]
-	0x36,0x66,0xA1,0x78,0x56,0x00,0x00, 	// mov	AX,SS:[05678h]
-	0xA0,0x78,0x56,0x00,0x00, 		// mov	AL,[05678h]
-	0x2E,0x8A,0x25,0x78,0x56,0x00,0x00, 	// mov	AH,CS:[05678h]
-	0x64,0x8A,0x1D,0x78,0x56,0x00,0x00, 	// mov	BL,FS:[05678h]
-	0x65,0x8A,0x3D,0x78,0x56,0x00,0x00, 	// mov	BH,GS:[05678h]
+    0x26,0xA1,0x24,0x13,0x00,0x00,      // mov  EAX,ES:[01324h]
+    0x36,0x66,0xA1,0x78,0x56,0x00,0x00,     // mov  AX,SS:[05678h]
+    0xA0,0x78,0x56,0x00,0x00,       // mov  AL,[05678h]
+    0x2E,0x8A,0x25,0x78,0x56,0x00,0x00,     // mov  AH,CS:[05678h]
+    0x64,0x8A,0x1D,0x78,0x56,0x00,0x00,     // mov  BL,FS:[05678h]
+    0x65,0x8A,0x3D,0x78,0x56,0x00,0x00,     // mov  BH,GS:[05678h]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	mov	EAX,ES:[0x1324]		;
-	mov	AX,SS:[0x5678]		;
-	mov	AL,DS:[0x5678]		;
-	mov	AH,CS:[0x5678]		;
-	mov	BL,FS:[0x5678]		;
-	mov	BH,GS:[0x5678]		;
+    mov EAX,ES:[0x1324]     ;
+    mov AX,SS:[0x5678]      ;
+    mov AL,DS:[0x5678]      ;
+    mov AH,CS:[0x5678]      ;
+    mov BL,FS:[0x5678]      ;
+    mov BH,GS:[0x5678]      ;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -258,106 +258,106 @@ L1:					;
 void test8()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x8C,0xD0,       	// mov	AX,SS
-	0x8C,0xDB,       	// mov	BX,DS
-	0x8C,0xC1,       	// mov	CX,ES
-	0x8C,0xCA,       	// mov	DX,CS
-	0x8C,0xE6,       	// mov	SI,FS
-	0x8C,0xEF,       	// mov	DI,GS
-	0x8E,0xD0,       	// mov	SS,AX
-	0x8E,0xDB,       	// mov	DS,BX
-	0x8E,0xC1,       	// mov	ES,CX
-	0x8E,0xCA,       	// mov	CS,DX
-	0x8E,0xE6,       	// mov	FS,SI
-	0x8E,0xEF,       	// mov	GS,DI
-	0x0F,0x22,0xC0,    	// mov	CR0,EAX
-	0x0F,0x22,0xD3,    	// mov	CR2,EBX
-	0x0F,0x22,0xD9,    	// mov	CR3,ECX
-	0x0F,0x22,0xE2,    	// mov	CR4,EDX
-	0x0F,0x20,0xC0,    	// mov	EAX,CR0
-	0x0F,0x20,0xD3,    	// mov	EBX,CR2
-	0x0F,0x20,0xD9,    	// mov	ECX,CR3
-	0x0F,0x20,0xE2,    	// mov	EDX,CR4
-	0x0F,0x23,0xC0,    	// mov	DR0,EAX
-	0x0F,0x23,0xCE,    	// mov	DR1,ESI
-	0x0F,0x23,0xD3,    	// mov	DR2,EBX
-	0x0F,0x23,0xD9,    	// mov	DR3,ECX
-	0x0F,0x23,0xE2,    	// mov	DR4,EDX
-	0x0F,0x23,0xEF,    	// mov	DR5,EDI
-	0x0F,0x23,0xF4,    	// mov	DR6,ESP
-	0x0F,0x23,0xFD,    	// mov	DR7,EBP
-	0x0F,0x21,0xC4,    	// mov	ESP,DR0
-	0x0F,0x21,0xCD,    	// mov	EBP,DR1
-	0x0F,0x21,0xD0,    	// mov	EAX,DR2
-	0x0F,0x21,0xDB,    	// mov	EBX,DR3
-	0x0F,0x21,0xE1,    	// mov	ECX,DR4
-	0x0F,0x21,0xEA,    	// mov	EDX,DR5
-	0x0F,0x21,0xF6,    	// mov	ESI,DR6
-	0x0F,0x21,0xFF,    	// mov	EDI,DR7
-	0xA4,     		// movsb
-	0x66,0xA5,		// movsw
-	0xA5,			// movsd
+    0x8C,0xD0,          // mov  AX,SS
+    0x8C,0xDB,          // mov  BX,DS
+    0x8C,0xC1,          // mov  CX,ES
+    0x8C,0xCA,          // mov  DX,CS
+    0x8C,0xE6,          // mov  SI,FS
+    0x8C,0xEF,          // mov  DI,GS
+    0x8E,0xD0,          // mov  SS,AX
+    0x8E,0xDB,          // mov  DS,BX
+    0x8E,0xC1,          // mov  ES,CX
+    0x8E,0xCA,          // mov  CS,DX
+    0x8E,0xE6,          // mov  FS,SI
+    0x8E,0xEF,          // mov  GS,DI
+    0x0F,0x22,0xC0,     // mov  CR0,EAX
+    0x0F,0x22,0xD3,     // mov  CR2,EBX
+    0x0F,0x22,0xD9,     // mov  CR3,ECX
+    0x0F,0x22,0xE2,     // mov  CR4,EDX
+    0x0F,0x20,0xC0,     // mov  EAX,CR0
+    0x0F,0x20,0xD3,     // mov  EBX,CR2
+    0x0F,0x20,0xD9,     // mov  ECX,CR3
+    0x0F,0x20,0xE2,     // mov  EDX,CR4
+    0x0F,0x23,0xC0,     // mov  DR0,EAX
+    0x0F,0x23,0xCE,     // mov  DR1,ESI
+    0x0F,0x23,0xD3,     // mov  DR2,EBX
+    0x0F,0x23,0xD9,     // mov  DR3,ECX
+    0x0F,0x23,0xE2,     // mov  DR4,EDX
+    0x0F,0x23,0xEF,     // mov  DR5,EDI
+    0x0F,0x23,0xF4,     // mov  DR6,ESP
+    0x0F,0x23,0xFD,     // mov  DR7,EBP
+    0x0F,0x21,0xC4,     // mov  ESP,DR0
+    0x0F,0x21,0xCD,     // mov  EBP,DR1
+    0x0F,0x21,0xD0,     // mov  EAX,DR2
+    0x0F,0x21,0xDB,     // mov  EBX,DR3
+    0x0F,0x21,0xE1,     // mov  ECX,DR4
+    0x0F,0x21,0xEA,     // mov  EDX,DR5
+    0x0F,0x21,0xF6,     // mov  ESI,DR6
+    0x0F,0x21,0xFF,     // mov  EDI,DR7
+    0xA4,           // movsb
+    0x66,0xA5,      // movsw
+    0xA5,           // movsd
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	mov	AX,SS			;
-	mov	BX,DS			;
-	mov	CX,ES			;
-	mov	DX,CS			;
-	mov	SI,FS			;
-	mov	DI,GS			;
+    mov AX,SS           ;
+    mov BX,DS           ;
+    mov CX,ES           ;
+    mov DX,CS           ;
+    mov SI,FS           ;
+    mov DI,GS           ;
 
-	mov	SS,AX			;
-	mov	DS,BX			;
-	mov	ES,CX			;
-	mov	CS,DX			;
-	mov	FS,SI			;
-	mov	GS,DI			;
+    mov SS,AX           ;
+    mov DS,BX           ;
+    mov ES,CX           ;
+    mov CS,DX           ;
+    mov FS,SI           ;
+    mov GS,DI           ;
 
-	mov	CR0,EAX			;
-	mov	CR2,EBX			;
-	mov	CR3,ECX			;
-	mov	CR4,EDX			;
+    mov CR0,EAX         ;
+    mov CR2,EBX         ;
+    mov CR3,ECX         ;
+    mov CR4,EDX         ;
 
-	mov	EAX,CR0			;
-	mov	EBX,CR2			;
-	mov	ECX,CR3			;
-	mov	EDX,CR4			;
+    mov EAX,CR0         ;
+    mov EBX,CR2         ;
+    mov ECX,CR3         ;
+    mov EDX,CR4         ;
 
-	mov	DR0,EAX			;
-	mov	DR1,ESI			;
-	mov	DR2,EBX			;
-	mov	DR3,ECX			;
-	mov	DR4,EDX			;
-	mov	DR5,EDI			;
-	mov	DR6,ESP			;
-	mov	DR7,EBP			;
+    mov DR0,EAX         ;
+    mov DR1,ESI         ;
+    mov DR2,EBX         ;
+    mov DR3,ECX         ;
+    mov DR4,EDX         ;
+    mov DR5,EDI         ;
+    mov DR6,ESP         ;
+    mov DR7,EBP         ;
 
-	mov	ESP,DR0			;
-	mov	EBP,DR1			;
-	mov	EAX,DR2			;
-	mov	EBX,DR3			;
-	mov	ECX,DR4			;
-	mov	EDX,DR5			;
-	mov	ESI,DR6			;
-	mov	EDI,DR7			;
+    mov ESP,DR0         ;
+    mov EBP,DR1         ;
+    mov EAX,DR2         ;
+    mov EBX,DR3         ;
+    mov ECX,DR4         ;
+    mov EDX,DR5         ;
+    mov ESI,DR6         ;
+    mov EDI,DR7         ;
 
-	movsb				;
-	movsw				;
-	movsd				;
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    movsb               ;
+    movsw               ;
+    movsd               ;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -367,73 +367,73 @@ L1:					;
 void test9()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x67,0x66,0x8B,0x00,       	// mov	AX,[BX+SI]
-	0x67,0x66,0x8B,0x01,       	// mov	AX,[BX+DI]
-	0x67,0x66,0x8B,0x02,       	// mov	AX,[BP+SI]
-	0x67,0x66,0x8B,0x03,       	// mov	AX,[BP+DI]
-	0x67,0x66,0x8B,0x04,       	// mov	AX,[SI]
-	0x67,0x66,0x8B,0x05,       	// mov	AX,[DI]
-	0x66,0xB8,0xD2,0x04,    	// mov	AX,04D2h
-	0x67,0x66,0x8B,0x07,       	// mov	AX,[BX]
-	0x67,0x66,0x8B,0x40,0x01,    	// mov	AX,1[BX+SI]
-	0x67,0x66,0x8B,0x41,0x02,    	// mov	AX,2[BX+DI]
-	0x67,0x66,0x8B,0x42,0x03,    	// mov	AX,3[BP+SI]
-	0x67,0x66,0x8B,0x43,0x04,    	// mov	AX,4[BP+DI]
-	0x67,0x66,0x8B,0x44,0x05,    	// mov	AX,5[SI]
-	0x67,0x66,0x8B,0x45,0x06,    	// mov	AX,6[DI]
-	0x67,0x66,0x8B,0x43,0x07,    	// mov	AX,7[BP+DI]
-	0x67,0x66,0x8B,0x47,0x08,    	// mov	AX,8[BX]
-	0x67,0x8B,0x80,0x21,0x01, 	// mov	EAX,0121h[BX+SI]
-	0x67,0x66,0x8B,0x81,0x22,0x01, 	// mov	AX,0122h[BX+DI]
-	0x67,0x66,0x8B,0x82,0x43,0x23, 	// mov	AX,02343h[BP+SI]
-	0x67,0x66,0x8B,0x83,0x54,0x45, 	// mov	AX,04554h[BP+DI]
-	0x67,0x66,0x8B,0x84,0x45,0x66,	// mov	AX,06645h[SI]
-	0x67,0x66,0x8B,0x85,0x36,0x12, 	// mov	AX,01236h[DI]
-	0x67,0x66,0x8B,0x86,0x67,0x45, 	// mov	AX,04567h[BP]
-	0x67,0x8A,0x87,0x08,0x01, 	// mov	AL,0108h[BX]
+    0x67,0x66,0x8B,0x00,        // mov  AX,[BX+SI]
+    0x67,0x66,0x8B,0x01,        // mov  AX,[BX+DI]
+    0x67,0x66,0x8B,0x02,        // mov  AX,[BP+SI]
+    0x67,0x66,0x8B,0x03,        // mov  AX,[BP+DI]
+    0x67,0x66,0x8B,0x04,        // mov  AX,[SI]
+    0x67,0x66,0x8B,0x05,        // mov  AX,[DI]
+    0x66,0xB8,0xD2,0x04,        // mov  AX,04D2h
+    0x67,0x66,0x8B,0x07,        // mov  AX,[BX]
+    0x67,0x66,0x8B,0x40,0x01,       // mov  AX,1[BX+SI]
+    0x67,0x66,0x8B,0x41,0x02,       // mov  AX,2[BX+DI]
+    0x67,0x66,0x8B,0x42,0x03,       // mov  AX,3[BP+SI]
+    0x67,0x66,0x8B,0x43,0x04,       // mov  AX,4[BP+DI]
+    0x67,0x66,0x8B,0x44,0x05,       // mov  AX,5[SI]
+    0x67,0x66,0x8B,0x45,0x06,       // mov  AX,6[DI]
+    0x67,0x66,0x8B,0x43,0x07,       // mov  AX,7[BP+DI]
+    0x67,0x66,0x8B,0x47,0x08,       // mov  AX,8[BX]
+    0x67,0x8B,0x80,0x21,0x01,   // mov  EAX,0121h[BX+SI]
+    0x67,0x66,0x8B,0x81,0x22,0x01,  // mov  AX,0122h[BX+DI]
+    0x67,0x66,0x8B,0x82,0x43,0x23,  // mov  AX,02343h[BP+SI]
+    0x67,0x66,0x8B,0x83,0x54,0x45,  // mov  AX,04554h[BP+DI]
+    0x67,0x66,0x8B,0x84,0x45,0x66,  // mov  AX,06645h[SI]
+    0x67,0x66,0x8B,0x85,0x36,0x12,  // mov  AX,01236h[DI]
+    0x67,0x66,0x8B,0x86,0x67,0x45,  // mov  AX,04567h[BP]
+    0x67,0x8A,0x87,0x08,0x01,   // mov  AL,0108h[BX]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	mov	AX,[BX+SI]		;
-	mov	AX,[BX+DI]		;
-	mov	AX,[BP+SI]		;
-	mov	AX,[BP+DI]		;
-	mov	AX,[SI]			;
-	mov	AX,[DI]			;
-	mov	AX,[1234]		;
-	mov	AX,[BX]			;
+    mov AX,[BX+SI]      ;
+    mov AX,[BX+DI]      ;
+    mov AX,[BP+SI]      ;
+    mov AX,[BP+DI]      ;
+    mov AX,[SI]         ;
+    mov AX,[DI]         ;
+    mov AX,[1234]       ;
+    mov AX,[BX]         ;
 
-	mov	AX,1[BX+SI]		;
-	mov	AX,2[BX+DI]		;
-	mov	AX,3[BP+SI]		;
-	mov	AX,4[BP+DI]		;
-	mov	AX,5[SI]		;
-	mov	AX,6[DI]		;
-	mov	AX,7[DI+BP]		;
-	mov	AX,8[BX]		;
+    mov AX,1[BX+SI]     ;
+    mov AX,2[BX+DI]     ;
+    mov AX,3[BP+SI]     ;
+    mov AX,4[BP+DI]     ;
+    mov AX,5[SI]        ;
+    mov AX,6[DI]        ;
+    mov AX,7[DI+BP]     ;
+    mov AX,8[BX]        ;
 
-	mov	EAX,0x121[BX+SI]	;
-	mov	AX,0x122[BX+DI]		;
-	mov	AX,0x2343[BP+SI]	;
-	mov	AX,0x4554[BP+DI]	;
-	mov	AX,0x6645[SI]		;
-	mov	AX,0x1236[DI]		;
-	mov	AX,0x4567[BP]		;
-	mov	AL,0x108[BX]		;
+    mov EAX,0x121[BX+SI]    ;
+    mov AX,0x122[BX+DI]     ;
+    mov AX,0x2343[BP+SI]    ;
+    mov AX,0x4554[BP+DI]    ;
+    mov AX,0x6645[SI]       ;
+    mov AX,0x1236[DI]       ;
+    mov AX,0x4567[BP]       ;
+    mov AL,0x108[BX]        ;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -447,17 +447,17 @@ void test10()
 {
     ubyte *p;
     int foo;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
     ];
     int i;
 
     asm
     {
-	mov	bar10,0x12		;
-	mov	baz10,0x13		;
-	mov	ESI,1			;
-	mov	baz10[ESI*4],0x14	;
+    mov bar10,0x12      ;
+    mov baz10,0x13      ;
+    mov ESI,1           ;
+    mov baz10[ESI*4],0x14   ;
     }
     assert(bar10 == 0x12);
     assert(baz10[0] == 0x13);
@@ -484,10 +484,10 @@ void test11()
 
     asm
     {
-	mov	x1,Foo11.a.sizeof	;
-	mov	x2,Foo11.b.offsetof	;
-	mov	x3,Foo11.sizeof		;
-	mov	x4,Foo11.sizeof + 7	;
+    mov x1,Foo11.a.sizeof   ;
+    mov x2,Foo11.b.offsetof ;
+    mov x3,Foo11.sizeof     ;
+    mov x4,Foo11.sizeof + 7 ;
     }
     assert(x1 == int.sizeof);
     assert(x2 == 8);
@@ -501,92 +501,92 @@ void test11()
 void test12()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x37,    			// aaa
-	0xD5,0x0A,      		// aad
-	0xD4,0x0A,      		// aam
-	0x3F,         			// aas
-	0x67,0x63,0x3C,      		// arpl	[SI],DI
-	0x14,0x05,      		// adc	AL,5
-	0x83,0xD0,0x14,   		// adc	EAX,014h
-	0x80,0x55,0xF8,0x17,		// adc	byte ptr -8[EBP],017h
-	0x83,0x55,0xFC,0x17,		// adc	dword ptr -4[EBP],017h
-	0x81,0x55,0xFC,0x34,0x12,0x00,0x00,	// adc	dword ptr -4[EBP],01234h
-	0x10,0x7D,0xF8,   		// adc	-8[EBP],BH
-	0x11,0x5D,0xFC,   		// adc	-4[EBP],EBX
-	0x12,0x5D,0xF8,   		// adc	BL,-8[EBP]
-	0x13,0x55,0xFC,   		// adc	EDX,-4[EBP]
-	0x04,0x05,      		// add	AL,5
-	0x83,0xC0,0x14,   		// add	EAX,014h
-	0x80,0x45,0xF8,0x17,		// add	byte ptr -8[EBP],017h
-	0x83,0x45,0xFC,0x17,		// add	dword ptr -4[EBP],017h
-	0x81,0x45,0xFC,0x34,0x12,0x00,0x00,	// add	dword ptr -4[EBP],01234h
-	0x00,0x7D,0xF8,   		// add	-8[EBP],BH
-	0x01,0x5D,0xFC,   		// add	-4[EBP],EBX
-	0x02,0x5D,0xF8,   		// add	BL,-8[EBP]
-	0x03,0x55,0xFC,   		// add	EDX,-4[EBP]
-	0x24,0x05,      		// and	AL,5
-	0x83,0xE0,0x14,   		// and	EAX,014h
-	0x80,0x65,0xF8,0x17,		// and	byte ptr -8[EBP],017h
-	0x83,0x65,0xFC,0x17,		// and	dword ptr -4[EBP],017h
-	0x81,0x65,0xFC,0x34,0x12,0x00,0x00,	// and	dword ptr -4[EBP],01234h
-	0x20,0x7D,0xF8,   		// and	-8[EBP],BH
-	0x21,0x5D,0xFC,   		// and	-4[EBP],EBX
-	0x22,0x5D,0xF8,   		// and	BL,-8[EBP]
-	0x23,0x55,0xFC,   		// and	EDX,-4[EBP]
-	0x3C,0x05,      		// cmp	AL,5
-	0x83,0xF8,0x14,   		// cmp	EAX,014h
-	0x80,0x7D,0xF8,0x17,		// cmp	byte ptr -8[EBP],017h
-	0x83,0x7D,0xFC,0x17,		// cmp	dword ptr -4[EBP],017h
-	0x81,0x7D,0xFC,0x34,0x12,0x00,0x00,	// cmp	dword ptr -4[EBP],01234h
-	0x38,0x7D,0xF8,   		// cmp	-8[EBP],BH
-	0x39,0x5D,0xFC,   		// cmp	-4[EBP],EBX
-	0x3A,0x5D,0xF8,   		// cmp	BL,-8[EBP]
-	0x3B,0x55,0xFC,   		// cmp	EDX,-4[EBP]
-	0x0C,0x05,     			// or	AL,5
-	0x83,0xC8,0x14,			// or	EAX,014h
-	0x80,0x4D,0xF8,0x17,		// or	byte ptr -8[EBP],017h
-	0x83,0x4D,0xFC,0x17,		// or	dword ptr -4[EBP],017h
-	0x81,0x4D,0xFC,0x34,0x12,0x00,0x00,	// or	dword ptr -4[EBP],01234h
-	0x08,0x7D,0xF8,   		// or	-8[EBP],BH
-	0x09,0x5D,0xFC,   		// or	-4[EBP],EBX
-	0x0A,0x5D,0xF8,   		// or	BL,-8[EBP]
-	0x0B,0x55,0xFC,   		// or	EDX,-4[EBP]
-	0x1C,0x05,      		// sbb	AL,5
-	0x83,0xD8,0x14,   		// sbb	EAX,014h
-	0x80,0x5D,0xF8,0x17,		// sbb	byte ptr -8[EBP],017h
-	0x83,0x5D,0xFC,0x17,		// sbb	dword ptr -4[EBP],017h
-	0x81,0x5D,0xFC,0x34,0x12,0x00,0x00,	// sbb	dword ptr -4[EBP],01234h
-	0x18,0x7D,0xF8,   		// sbb	-8[EBP],BH
-	0x19,0x5D,0xFC,   		// sbb	-4[EBP],EBX
-	0x1A,0x5D,0xF8,   		// sbb	BL,-8[EBP]
-	0x1B,0x55,0xFC,   		// sbb	EDX,-4[EBP]
-	0x2C,0x05,      		// sub	AL,5
-	0x83,0xE8,0x14,   		// sub	EAX,014h
-	0x80,0x6D,0xF8,0x17,		// sub	byte ptr -8[EBP],017h
-	0x83,0x6D,0xFC,0x17,		// sub	dword ptr -4[EBP],017h
-	0x81,0x6D,0xFC,0x34,0x12,0x00,0x00,	// sub	dword ptr -4[EBP],01234h
-	0x28,0x7D,0xF8,   		// sub	-8[EBP],BH
-	0x29,0x5D,0xFC,   		// sub	-4[EBP],EBX
-	0x2A,0x5D,0xF8,   		// sub	BL,-8[EBP]
-	0x2B,0x55,0xFC,   		// sub	EDX,-4[EBP]
-	0xA8,0x05,      		// test	AL,5
-	0xA9,0x14,0x00,0x00,0x00,	// test	EAX,014h
-	0xF6,0x45,0xF8,0x17,		// test	byte ptr -8[EBP],017h
-	0xF7,0x45,0xFC,0x17,0x00,0x00,0x00,	// test	dword ptr -4[EBP],017h
-	0xF7,0x45,0xFC,0x34,0x12,0x00,0x00,	// test	dword ptr -4[EBP],01234h
-	0x84,0x7D,0xF8,   		// test	-8[EBP],BH
-	0x85,0x5D,0xFC,   		// test	-4[EBP],EBX
-	0x34,0x05,      		// xor	AL,5
-	0x83,0xF0,0x14,   		// xor	EAX,014h
-	0x80,0x75,0xF8,0x17,		// xor	byte ptr -8[EBP],017h
-	0x83,0x75,0xFC,0x17,		// xor	dword ptr -4[EBP],017h
-	0x81,0x75,0xFC,0x34,0x12,0x00,0x00,	// xor	dword ptr -4[EBP],01234h
-	0x30,0x7D,0xF8,   		// xor	-8[EBP],BH
-	0x31,0x5D,0xFC,   		// xor	-4[EBP],EBX
-	0x32,0x5D,0xF8,   		// xor	BL,-8[EBP]
-	0x33,0x55,0xFC,   		// xor	EDX,-4[EBP]
+    0x37,               // aaa
+    0xD5,0x0A,              // aad
+    0xD4,0x0A,              // aam
+    0x3F,                   // aas
+    0x67,0x63,0x3C,             // arpl [SI],DI
+    0x14,0x05,              // adc  AL,5
+    0x83,0xD0,0x14,         // adc  EAX,014h
+    0x80,0x55,0xF8,0x17,        // adc  byte ptr -8[EBP],017h
+    0x83,0x55,0xFC,0x17,        // adc  dword ptr -4[EBP],017h
+    0x81,0x55,0xFC,0x34,0x12,0x00,0x00, // adc  dword ptr -4[EBP],01234h
+    0x10,0x7D,0xF8,         // adc  -8[EBP],BH
+    0x11,0x5D,0xFC,         // adc  -4[EBP],EBX
+    0x12,0x5D,0xF8,         // adc  BL,-8[EBP]
+    0x13,0x55,0xFC,         // adc  EDX,-4[EBP]
+    0x04,0x05,              // add  AL,5
+    0x83,0xC0,0x14,         // add  EAX,014h
+    0x80,0x45,0xF8,0x17,        // add  byte ptr -8[EBP],017h
+    0x83,0x45,0xFC,0x17,        // add  dword ptr -4[EBP],017h
+    0x81,0x45,0xFC,0x34,0x12,0x00,0x00, // add  dword ptr -4[EBP],01234h
+    0x00,0x7D,0xF8,         // add  -8[EBP],BH
+    0x01,0x5D,0xFC,         // add  -4[EBP],EBX
+    0x02,0x5D,0xF8,         // add  BL,-8[EBP]
+    0x03,0x55,0xFC,         // add  EDX,-4[EBP]
+    0x24,0x05,              // and  AL,5
+    0x83,0xE0,0x14,         // and  EAX,014h
+    0x80,0x65,0xF8,0x17,        // and  byte ptr -8[EBP],017h
+    0x83,0x65,0xFC,0x17,        // and  dword ptr -4[EBP],017h
+    0x81,0x65,0xFC,0x34,0x12,0x00,0x00, // and  dword ptr -4[EBP],01234h
+    0x20,0x7D,0xF8,         // and  -8[EBP],BH
+    0x21,0x5D,0xFC,         // and  -4[EBP],EBX
+    0x22,0x5D,0xF8,         // and  BL,-8[EBP]
+    0x23,0x55,0xFC,         // and  EDX,-4[EBP]
+    0x3C,0x05,              // cmp  AL,5
+    0x83,0xF8,0x14,         // cmp  EAX,014h
+    0x80,0x7D,0xF8,0x17,        // cmp  byte ptr -8[EBP],017h
+    0x83,0x7D,0xFC,0x17,        // cmp  dword ptr -4[EBP],017h
+    0x81,0x7D,0xFC,0x34,0x12,0x00,0x00, // cmp  dword ptr -4[EBP],01234h
+    0x38,0x7D,0xF8,         // cmp  -8[EBP],BH
+    0x39,0x5D,0xFC,         // cmp  -4[EBP],EBX
+    0x3A,0x5D,0xF8,         // cmp  BL,-8[EBP]
+    0x3B,0x55,0xFC,         // cmp  EDX,-4[EBP]
+    0x0C,0x05,              // or   AL,5
+    0x83,0xC8,0x14,         // or   EAX,014h
+    0x80,0x4D,0xF8,0x17,        // or   byte ptr -8[EBP],017h
+    0x83,0x4D,0xFC,0x17,        // or   dword ptr -4[EBP],017h
+    0x81,0x4D,0xFC,0x34,0x12,0x00,0x00, // or   dword ptr -4[EBP],01234h
+    0x08,0x7D,0xF8,         // or   -8[EBP],BH
+    0x09,0x5D,0xFC,         // or   -4[EBP],EBX
+    0x0A,0x5D,0xF8,         // or   BL,-8[EBP]
+    0x0B,0x55,0xFC,         // or   EDX,-4[EBP]
+    0x1C,0x05,              // sbb  AL,5
+    0x83,0xD8,0x14,         // sbb  EAX,014h
+    0x80,0x5D,0xF8,0x17,        // sbb  byte ptr -8[EBP],017h
+    0x83,0x5D,0xFC,0x17,        // sbb  dword ptr -4[EBP],017h
+    0x81,0x5D,0xFC,0x34,0x12,0x00,0x00, // sbb  dword ptr -4[EBP],01234h
+    0x18,0x7D,0xF8,         // sbb  -8[EBP],BH
+    0x19,0x5D,0xFC,         // sbb  -4[EBP],EBX
+    0x1A,0x5D,0xF8,         // sbb  BL,-8[EBP]
+    0x1B,0x55,0xFC,         // sbb  EDX,-4[EBP]
+    0x2C,0x05,              // sub  AL,5
+    0x83,0xE8,0x14,         // sub  EAX,014h
+    0x80,0x6D,0xF8,0x17,        // sub  byte ptr -8[EBP],017h
+    0x83,0x6D,0xFC,0x17,        // sub  dword ptr -4[EBP],017h
+    0x81,0x6D,0xFC,0x34,0x12,0x00,0x00, // sub  dword ptr -4[EBP],01234h
+    0x28,0x7D,0xF8,         // sub  -8[EBP],BH
+    0x29,0x5D,0xFC,         // sub  -4[EBP],EBX
+    0x2A,0x5D,0xF8,         // sub  BL,-8[EBP]
+    0x2B,0x55,0xFC,         // sub  EDX,-4[EBP]
+    0xA8,0x05,              // test AL,5
+    0xA9,0x14,0x00,0x00,0x00,   // test EAX,014h
+    0xF6,0x45,0xF8,0x17,        // test byte ptr -8[EBP],017h
+    0xF7,0x45,0xFC,0x17,0x00,0x00,0x00, // test dword ptr -4[EBP],017h
+    0xF7,0x45,0xFC,0x34,0x12,0x00,0x00, // test dword ptr -4[EBP],01234h
+    0x84,0x7D,0xF8,         // test -8[EBP],BH
+    0x85,0x5D,0xFC,         // test -4[EBP],EBX
+    0x34,0x05,              // xor  AL,5
+    0x83,0xF0,0x14,         // xor  EAX,014h
+    0x80,0x75,0xF8,0x17,        // xor  byte ptr -8[EBP],017h
+    0x83,0x75,0xFC,0x17,        // xor  dword ptr -4[EBP],017h
+    0x81,0x75,0xFC,0x34,0x12,0x00,0x00, // xor  dword ptr -4[EBP],01234h
+    0x30,0x7D,0xF8,         // xor  -8[EBP],BH
+    0x31,0x5D,0xFC,         // xor  -4[EBP],EBX
+    0x32,0x5D,0xF8,         // xor  BL,-8[EBP]
+    0x33,0x55,0xFC,         // xor  EDX,-4[EBP]
     ];
     int i;
     byte rm8;
@@ -595,108 +595,108 @@ void test12()
 
     asm
     {
-	call	L1			;
-	aaa				;
-	aad				;
-	aam				;
-	aas				;
-	arpl	[SI],DI			;
+    call    L1          ;
+    aaa             ;
+    aad             ;
+    aam             ;
+    aas             ;
+    arpl    [SI],DI         ;
 
-	adc	AL,5			;
-	adc	EAX,20			;
-	adc	rm8[EBP],23		;
-	adc	rm32[EBP],23		;
-	adc	rm32[EBP],0x1234	;
-	adc	rm8[EBP],BH		;
-	adc	rm32[EBP],EBX		;
-	adc	BL,rm8[EBP]		;
-	adc	EDX,rm32[EBP]		;
+    adc AL,5            ;
+    adc EAX,20          ;
+    adc rm8[EBP],23     ;
+    adc rm32[EBP],23        ;
+    adc rm32[EBP],0x1234    ;
+    adc rm8[EBP],BH     ;
+    adc rm32[EBP],EBX       ;
+    adc BL,rm8[EBP]     ;
+    adc EDX,rm32[EBP]       ;
 
-	add	AL,5			;
-	add	EAX,20			;
-	add	rm8[EBP],23		;
-	add	rm32[EBP],23		;
-	add	rm32[EBP],0x1234	;
-	add	rm8[EBP],BH		;
-	add	rm32[EBP],EBX		;
-	add	BL,rm8[EBP]		;
-	add	EDX,rm32[EBP]		;
+    add AL,5            ;
+    add EAX,20          ;
+    add rm8[EBP],23     ;
+    add rm32[EBP],23        ;
+    add rm32[EBP],0x1234    ;
+    add rm8[EBP],BH     ;
+    add rm32[EBP],EBX       ;
+    add BL,rm8[EBP]     ;
+    add EDX,rm32[EBP]       ;
 
-	and	AL,5			;
-	and	EAX,20			;
-	and	rm8[EBP],23		;
-	and	rm32[EBP],23		;
-	and	rm32[EBP],0x1234	;
-	and	rm8[EBP],BH		;
-	and	rm32[EBP],EBX		;
-	and	BL,rm8[EBP]		;
-	and	EDX,rm32[EBP]		;
+    and AL,5            ;
+    and EAX,20          ;
+    and rm8[EBP],23     ;
+    and rm32[EBP],23        ;
+    and rm32[EBP],0x1234    ;
+    and rm8[EBP],BH     ;
+    and rm32[EBP],EBX       ;
+    and BL,rm8[EBP]     ;
+    and EDX,rm32[EBP]       ;
 
-	cmp	AL,5			;
-	cmp	EAX,20			;
-	cmp	rm8[EBP],23		;
-	cmp	rm32[EBP],23		;
-	cmp	rm32[EBP],0x1234	;
-	cmp	rm8[EBP],BH		;
-	cmp	rm32[EBP],EBX		;
-	cmp	BL,rm8[EBP]		;
-	cmp	EDX,rm32[EBP]		;
+    cmp AL,5            ;
+    cmp EAX,20          ;
+    cmp rm8[EBP],23     ;
+    cmp rm32[EBP],23        ;
+    cmp rm32[EBP],0x1234    ;
+    cmp rm8[EBP],BH     ;
+    cmp rm32[EBP],EBX       ;
+    cmp BL,rm8[EBP]     ;
+    cmp EDX,rm32[EBP]       ;
 
-	or	AL,5			;
-	or	EAX,20			;
-	or	rm8[EBP],23		;
-	or	rm32[EBP],23		;
-	or	rm32[EBP],0x1234	;
-	or	rm8[EBP],BH		;
-	or	rm32[EBP],EBX		;
-	or	BL,rm8[EBP]		;
-	or	EDX,rm32[EBP]		;
+    or  AL,5            ;
+    or  EAX,20          ;
+    or  rm8[EBP],23     ;
+    or  rm32[EBP],23        ;
+    or  rm32[EBP],0x1234    ;
+    or  rm8[EBP],BH     ;
+    or  rm32[EBP],EBX       ;
+    or  BL,rm8[EBP]     ;
+    or  EDX,rm32[EBP]       ;
 
-	sbb	AL,5			;
-	sbb	EAX,20			;
-	sbb	rm8[EBP],23		;
-	sbb	rm32[EBP],23		;
-	sbb	rm32[EBP],0x1234	;
-	sbb	rm8[EBP],BH		;
-	sbb	rm32[EBP],EBX		;
-	sbb	BL,rm8[EBP]		;
-	sbb	EDX,rm32[EBP]		;
+    sbb AL,5            ;
+    sbb EAX,20          ;
+    sbb rm8[EBP],23     ;
+    sbb rm32[EBP],23        ;
+    sbb rm32[EBP],0x1234    ;
+    sbb rm8[EBP],BH     ;
+    sbb rm32[EBP],EBX       ;
+    sbb BL,rm8[EBP]     ;
+    sbb EDX,rm32[EBP]       ;
 
-	sub	AL,5			;
-	sub	EAX,20			;
-	sub	rm8[EBP],23		;
-	sub	rm32[EBP],23		;
-	sub	rm32[EBP],0x1234	;
-	sub	rm8[EBP],BH		;
-	sub	rm32[EBP],EBX		;
-	sub	BL,rm8[EBP]		;
-	sub	EDX,rm32[EBP]		;
+    sub AL,5            ;
+    sub EAX,20          ;
+    sub rm8[EBP],23     ;
+    sub rm32[EBP],23        ;
+    sub rm32[EBP],0x1234    ;
+    sub rm8[EBP],BH     ;
+    sub rm32[EBP],EBX       ;
+    sub BL,rm8[EBP]     ;
+    sub EDX,rm32[EBP]       ;
 
-	test	AL,5			;
-	test	EAX,20			;
-	test	rm8[EBP],23		;
-	test	rm32[EBP],23		;
-	test	rm32[EBP],0x1234	;
-	test	rm8[EBP],BH		;
-	test	rm32[EBP],EBX		;
+    test    AL,5            ;
+    test    EAX,20          ;
+    test    rm8[EBP],23     ;
+    test    rm32[EBP],23        ;
+    test    rm32[EBP],0x1234    ;
+    test    rm8[EBP],BH     ;
+    test    rm32[EBP],EBX       ;
 
-	xor	AL,5			;
-	xor	EAX,20			;
-	xor	rm8[EBP],23		;
-	xor	rm32[EBP],23		;
-	xor	rm32[EBP],0x1234	;
-	xor	rm8[EBP],BH		;
-	xor	rm32[EBP],EBX		;
-	xor	BL,rm8[EBP]		;
-	xor	EDX,rm32[EBP]		;
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    xor AL,5            ;
+    xor EAX,20          ;
+    xor rm8[EBP],23     ;
+    xor rm32[EBP],23        ;
+    xor rm32[EBP],0x1234    ;
+    xor rm8[EBP],BH     ;
+    xor rm32[EBP],EBX       ;
+    xor BL,rm8[EBP]     ;
+    xor EDX,rm32[EBP]       ;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	//printf("p[%d] = x%02x, data = x%02x\n", i, p[i], data[i]);
-	assert(p[i] == data[i]);
+    //printf("p[%d] = x%02x, data = x%02x\n", i, p[i], data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -709,409 +709,409 @@ void test13()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F,0x0B,		// ud2
-	0x0F,0x05,		// syscall
-	0x0F,0x34,		// sysenter
-	0x0F,0x35,		// sysexit
-	0x0F,0x07,		// sysret
-	0x0F,0xAE,0xE8,		// lfence
-	0x0F,0xAE,0xF0,		// mfence
-	0x0F,0xAE,0xF8,		// sfence
-	0x0F,0xAE,0x00,		// fxsave	[EAX]
-	0x0F,0xAE,0x08,		// fxrstor	[EAX]
-	0x0F,0xAE,0x10,		// ldmxcsr	[EAX]
-	0x0F,0xAE,0x18,		// stmxcsr	[EAX]
-	0x0F,0xAE,0x38,		// clflush	[EAX]
+    0x0F,0x0B,      // ud2
+    0x0F,0x05,      // syscall
+    0x0F,0x34,      // sysenter
+    0x0F,0x35,      // sysexit
+    0x0F,0x07,      // sysret
+    0x0F,0xAE,0xE8,     // lfence
+    0x0F,0xAE,0xF0,     // mfence
+    0x0F,0xAE,0xF8,     // sfence
+    0x0F,0xAE,0x00,     // fxsave   [EAX]
+    0x0F,0xAE,0x08,     // fxrstor  [EAX]
+    0x0F,0xAE,0x10,     // ldmxcsr  [EAX]
+    0x0F,0xAE,0x18,     // stmxcsr  [EAX]
+    0x0F,0xAE,0x38,     // clflush  [EAX]
 
-	0x0F,0x58,0x08,   	// addps	XMM1,[EAX]
-	0x0F,0x58,0xCA,   	// addps	XMM1,XMM2
-0x66,	0x0F,0x58,0x03,   	// addpd	XMM0,[EBX]
-0x66,	0x0F,0x58,0xD1,   	// addpd	XMM2,XMM1
-	0xF2,0x0F,0x58,0x08,	// addsd	XMM1,[EAX]
-	0xF2,0x0F,0x58,0xCA,	// addsd	XMM1,XMM2
-	0xF3,0x0F,0x58,0x2E,	// addss	XMM5,[ESI]
-	0xF3,0x0F,0x58,0xF7,	// addss	XMM6,XMM7
-	0x0F,0x54,0x08,   	// andps	XMM1,[EAX]
-	0x0F,0x54,0xCA,   	// andps	XMM1,XMM2
-0x66,	0x0F,0x54,0x03,   	// andpd	XMM0,[EBX]
-0x66,	0x0F,0x54,0xD1,   	// andpd	XMM2,XMM1
-	0x0F,0x55,0x08,   	// andnps	XMM1,[EAX]
-	0x0F,0x55,0xCA,   	// andnps	XMM1,XMM2
-0x66,	0x0F,0x55,0x03,   	// andnpd	XMM0,[EBX]
-0x66,	0x0F,0x55,0xD1,   	// andnpd	XMM2,XMM1
-	0xA7,          	// cmpsd
-	0x0F,0xC2,0x08,0x01,	// cmpps	XMM1,[EAX],1
-	0x0F,0xC2,0xCA,0x02,	// cmpps	XMM1,XMM2,2
-0x66,	0x0F,0xC2,0x03,0x03,	// cmppd	XMM0,[EBX],3
-0x66,	0x0F,0xC2,0xD1,0x04,	// cmppd	XMM2,XMM1,4
-	0xF2,0x0F,0xC2,0x08,0x05,	// cmpsd	XMM1,[EAX],5
-	0xF2,0x0F,0xC2,0xCA,0x06,	// cmpsd	XMM1,XMM2,6
-	0xF3,0x0F,0xC2,0x2E,0x07,	// cmpss	XMM5,[ESI],7
-	0xF3,0x0F,0xC2,0xF7,0x00,	// cmpss	XMM6,XMM7,0
-0x66,	0x0F,0x2F,0x08,   	// comisd	XMM1,[EAX]
-0x66,	0x0F,0x2F,0x4D,0xE0,	// comisd	XMM1,-020h[EBP]
-0x66,	0x0F,0x2F,0xCA,   	// comisd	XMM1,XMM2
-	0x0F,0x2F,0x2E,   	// comiss	XMM5,[ESI]
-	0x0F,0x2F,0xF7,   	// comiss	XMM6,XMM7
-	0xF3,0x0F,0xE6,0xDC,	// cvtdq2pd	XMM3,XMM4
-	0xF3,0x0F,0xE6,0x5D,0xE0,	// cvtdq2pd	XMM3,-020h[EBP]
-	0x0F,0x5B,0xDC,   	// cvtdq2ps	XMM3,XMM4
-	0x0F,0x5B,0x5D,0xE8,	// cvtdq2ps	XMM3,-018h[EBP]
-	0xF2,0x0F,0xE6,0xDC,	// cvtpd2dq	XMM3,XMM4
-	0xF2,0x0F,0xE6,0x5D,0xE8,	// cvtpd2dq	XMM3,-018h[EBP]
-0x66,	0x0F,0x2D,0xDC,   	// cvtpd2pi	MM3,XMM4
-0x66,	0x0F,0x2D,0x5D,0xE8,	// cvtpd2pi	MM3,-018h[EBP]
-0x66,	0x0F,0x5A,0xDC,   	// cvtpd2ps	XMM3,XMM4
-0x66,	0x0F,0x5A,0x5D,0xE8,	// cvtpd2ps	XMM3,-018h[EBP]
-0x66,	0x0F,0x2A,0xDC,   	// cvtpi2pd	XMM3,MM4
-0x66,	0x0F,0x2A,0x5D,0xE0,	// cvtpi2pd	XMM3,-020h[EBP]
-	0x0F,0x2A,0xDC,   	// cvtpi2ps	XMM3,MM4
-	0x0F,0x2A,0x5D,0xE0,	// cvtpi2ps	XMM3,-020h[EBP]
-0x66,	0x0F,0x5B,0xDC,   	// cvtps2dq	XMM3,XMM4
-0x66,	0x0F,0x5B,0x5D,0xE8,	// cvtps2dq	XMM3,-018h[EBP]
-	0x0F,0x5A,0xDC,   	// cvtps2pd	XMM3,XMM4
-	0x0F,0x5A,0x5D,0xE0,	// cvtps2pd	XMM3,-020h[EBP]
-	0x0F,0x2D,0xDC,   	// cvtps2pi	MM3,XMM4
-	0x0F,0x2D,0x5D,0xE0,	// cvtps2pi	MM3,-020h[EBP]
-	0xF2,0x0F,0x2D,0xCC,	// cvtsd2si	XMM1,XMM4
-	0xF2,0x0F,0x2D,0x55,0xE0,	// cvtsd2si	XMM2,-020h[EBP]
-	0xF2,0x0F,0x5A,0xDC,	// cvtsd2ss	XMM3,XMM4
-	0xF2,0x0F,0x5A,0x5D,0xE0,	// cvtsd2ss	XMM3,-020h[EBP]
-	0xF2,0x0F,0x2A,0xDA,	// cvtsi2sd	XMM3,EDX
-	0xF2,0x0F,0x2A,0x5D,0xD8,	// cvtsi2sd	XMM3,-028h[EBP]
-	0xF3,0x0F,0x2A,0xDA,	// cvtsi2ss	XMM3,EDX
-	0xF3,0x0F,0x2A,0x5D,0xD8,	// cvtsi2ss	XMM3,-028h[EBP]
-	0xF3,0x0F,0x5A,0xDC,	// cvtss2sd	XMM3,XMM4
-	0xF3,0x0F,0x5A,0x5D,0xD8,	// cvtss2sd	XMM3,-028h[EBP]
-	0xF3,0x0F,0x2D,0xFC,	// cvtss2si	XMM7,XMM4
-	0xF3,0x0F,0x2D,0x7D,0xD8,	// cvtss2si	XMM7,-028h[EBP]
-0x66,	0x0F,0x2C,0xDC,   	// cvttpd2pi	MM3,XMM4
-0x66,	0x0F,0x2C,0x7D,0xE8,	// cvttpd2pi	MM7,-018h[EBP]
-0x66,	0x0F,0xE6,0xDC,   	// cvttpd2dq	XMM3,XMM4
-0x66,	0x0F,0xE6,0x7D,0xE8,	// cvttpd2dq	XMM7,-018h[EBP]
-	0xF3,0x0F,0x5B,0xDC,	// cvttps2dq	XMM3,XMM4
-	0xF3,0x0F,0x5B,0x7D,0xE8,	// cvttps2dq	XMM7,-018h[EBP]
-	0x0F,0x2C,0xDC,   	// cvttps2pi	MM3,XMM4
-	0x0F,0x2C,0x7D,0xE0,	// cvttps2pi	MM7,-020h[EBP]
-	0xF2,0x0F,0x2C,0xC4,	// cvttsd2si	EAX,XMM4
-	0xF2,0x0F,0x2C,0x4D,0xE8,	// cvttsd2si	ECX,-018h[EBP]
-	0xF3,0x0F,0x2C,0xC4,	// cvttss2si	EAX,XMM4
-	0xF3,0x0F,0x2C,0x4D,0xD8,	// cvttss2si	ECX,-028h[EBP]
-0x66,	0x0F,0x5E,0xE8,   	// divpd	XMM5,XMM0
-0x66,	0x0F,0x5E,0x6D,0xE8,	// divpd	XMM5,-018h[EBP]
-	0x0F,0x5E,0xE8,   	// divps	XMM5,XMM0
-	0x0F,0x5E,0x6D,0xE8,	// divps	XMM5,-018h[EBP]
-	0xF2,0x0F,0x5E,0xE8,	// divsd	XMM5,XMM0
-	0xF2,0x0F,0x5E,0x6D,0xE0,	// divsd	XMM5,-020h[EBP]
-	0xF3,0x0F,0x5E,0xE8,	// divss	XMM5,XMM0
-	0xF3,0x0F,0x5E,0x6D,0xD8,	// divss	XMM5,-028h[EBP]
-0x66,	0x0F,0xF7,0xD1,   	// maskmovdqu	XMM2,XMM1
-	0x0F,0xF7,0xE3,   	// maskmovq	MM4,MM3
-0x66,	0x0F,0x5F,0xC0,   	// maxpd	XMM0,XMM0
-0x66,	0x0F,0x5F,0x4D,0xE8,	// maxpd	XMM1,-018h[EBP]
-	0x0F,0x5F,0xD1,   	// maxps	XMM2,XMM1
-	0x0F,0x5F,0x5D,0xE8,	// maxps	XMM3,-018h[EBP]
-	0xF2,0x0F,0x5F,0xE2,	// maxsd	XMM4,XMM2
-	0xF2,0x0F,0x5F,0x6D,0xE0,	// maxsd	XMM5,-020h[EBP]
-	0xF3,0x0F,0x5F,0xF3,	// maxss	XMM6,XMM3
-	0xF3,0x0F,0x5F,0x7D,0xD8,	// maxss	XMM7,-028h[EBP]
-0x66,	0x0F,0x5D,0xC0,   	// minpd	XMM0,XMM0
-0x66,	0x0F,0x5D,0x4D,0xE8,	// minpd	XMM1,-018h[EBP]
-	0x0F,0x5D,0xD1,   	// minps	XMM2,XMM1
-	0x0F,0x5D,0x5D,0xE8,	// minps	XMM3,-018h[EBP]
-	0xF2,0x0F,0x5D,0xE2,	// minsd	XMM4,XMM2
-	0xF2,0x0F,0x5D,0x6D,0xE0,	// minsd	XMM5,-020h[EBP]
-	0xF3,0x0F,0x5D,0xF3,	// minss	XMM6,XMM3
-	0xF3,0x0F,0x5D,0x7D,0xD8,	// minss	XMM7,-028h[EBP]
-0x66,	0x0F,0x28,0xCA,   	// movapd	XMM1,XMM2
-0x66,	0x0F,0x28,0x5D,0xE8,	// movapd	XMM3,-018h[EBP]
-0x66,	0x0F,0x29,0x65,0xE8,	// movapd	-018h[EBP],XMM4
-	0x0F,0x28,0xCA,   	// movaps	XMM1,XMM2
-	0x0F,0x28,0x5D,0xE8,	// movaps	XMM3,-018h[EBP]
-	0x0F,0x29,0x65,0xE8,	// movaps	-018h[EBP],XMM4
-	0x0F,0x6E,0xCB,   	// movd	MM1,EBX
-	0x0F,0x6E,0x55,0xD8,	// movd	MM2,-028h[EBP]
-	0x0F,0x7E,0xDB,   	// movd	EBX,MM3
-	0x0F,0x7E,0x65,0xD8,	// movd	-028h[EBP],MM4
-0x66,	0x0F,0x6E,0xCB,   	// movd	XMM1,EBX
-0x66,	0x0F,0x6E,0x55,0xD8,	// movd	XMM2,-028h[EBP]
-0x66,	0x0F,0x7E,0xDB,   	// movd	EBX,XMM3
-0x66,	0x0F,0x7E,0x65,0xD8,	// movd	-028h[EBP],XMM4
-0x66,	0x0F,0x6F,0xCA,   	// movdqa	XMM1,XMM2
-0x66,	0x0F,0x6F,0x55,0xE8,	// movdqa	XMM2,-018h[EBP]
-0x66,	0x0F,0x7F,0x65,0xE8,	// movdqa	-018h[EBP],XMM4
-	0xF3,0x0F,0x6F,0xCA,	// movdqu	XMM1,XMM2
-	0xF3,0x0F,0x6F,0x55,0xE8,	// movdqu	XMM2,-018h[EBP]
-	0xF3,0x0F,0x7F,0x65,0xE8,	// movdqu	-018h[EBP],XMM4
-	0xF2,0x0F,0xD6,0xDC,	// movdq2q	MM4,XMM3
-	0x0F,0x12,0xDC,   	// movhlps	XMM4,XMM3
-0x66,	0x0F,0x16,0x55,0xE0,	// movhpd	XMM2,-020h[EBP]
-0x66,	0x0F,0x17,0x7D,0xE0,	// movhpd	-020h[EBP],XMM7
-	0x0F,0x16,0x55,0xE0,	// movhps	XMM2,-020h[EBP]
-	0x0F,0x17,0x7D,0xE0,	// movhps	-020h[EBP],XMM7
-	0x0F,0x16,0xDC,   	// movlhps	XMM4,XMM3
-0x66,	0x0F,0x12,0x55,0xE0,	// movlpd	XMM2,-020h[EBP]
-0x66,	0x0F,0x13,0x7D,0xE0,	// movlpd	-020h[EBP],XMM7
-	0x0F,0x12,0x55,0xE0,	// movlps	XMM2,-020h[EBP]
-	0x0F,0x13,0x7D,0xE0,	// movlps	-020h[EBP],XMM7
-0x66,	0x0F,0x50,0xF3,   	// movmskpd	ESI,XMM3
-	0x0F,0x50,0xF3,   	// movmskps	ESI,XMM3
-0x66,	0x0F,0x59,0xC0,   	// mulpd	XMM0,XMM0
-0x66,	0x0F,0x59,0x4D,0xE8,	// mulpd	XMM1,-018h[EBP]
-	0x0F,0x59,0xD1,   	// mulps	XMM2,XMM1
-	0x0F,0x59,0x5D,0xE8,	// mulps	XMM3,-018h[EBP]
-	0xF2,0x0F,0x59,0xE2,	// mulsd	XMM4,XMM2
-	0xF2,0x0F,0x59,0x6D,0xE0,	// mulsd	XMM5,-020h[EBP]
-	0xF3,0x0F,0x59,0xF3,	// mulss	XMM6,XMM3
-	0xF3,0x0F,0x59,0x7D,0xD8,	// mulss	XMM7,-028h[EBP]
-0x66, 	0x0F,0x51,0xC4,    	  // sqrtpd	XMM0,XMM4
-0x66, 	0x0F,0x51,0x4D,0xE8, 	  // sqrtpd	XMM1,-018h[EBP]
-	0x0F,0x51,0xD5,    	  // sqrtps	XMM2,XMM5
-	0x0F,0x51,0x5D,0xE8, 	  // sqrtps	XMM3,-018h[EBP]
-	0xF2,0x0F,0x51,0xE6, 	  // sqrtsd	XMM4,XMM6
-	0xF2,0x0F,0x51,0x6D,0xE0, // sqrtsd	XMM5,-020h[EBP]
-	0xF3,0x0F,0x51,0xF7, 	  // sqrtss	XMM6,XMM7
-	0xF3,0x0F,0x51,0x7D,0xD8, // sqrtss	XMM7,-028h[EBP]
-0x66,	0x0F,0x5C,0xC4,   	// subpd	XMM0,XMM4
-0x66,	0x0F,0x5C,0x4D,0xE8,	// subpd	XMM1,-018h[EBP]
-	0x0F,0x5C,0xD5,   	// subps	XMM2,XMM5
-	0x0F,0x5C,0x5D,0xE8,	// subps	XMM3,-018h[EBP]
-	0xF2,0x0F,0x5C,0xE6,	// subsd	XMM4,XMM6
-	0xF2,0x0F,0x5C,0x6D,0xE0,	// subsd	XMM5,-020h[EBP]
-	0xF3,0x0F,0x5C,0xF7,	// subss	XMM6,XMM7
-	0xF3,0x0F,0x5C,0x7D,0xD8,	// subss	XMM7,-028h[EBP]
-	0x0F,0x01,0xE0,			// smsw EAX
+    0x0F,0x58,0x08,     // addps    XMM1,[EAX]
+    0x0F,0x58,0xCA,     // addps    XMM1,XMM2
+0x66,   0x0F,0x58,0x03,     // addpd    XMM0,[EBX]
+0x66,   0x0F,0x58,0xD1,     // addpd    XMM2,XMM1
+    0xF2,0x0F,0x58,0x08,    // addsd    XMM1,[EAX]
+    0xF2,0x0F,0x58,0xCA,    // addsd    XMM1,XMM2
+    0xF3,0x0F,0x58,0x2E,    // addss    XMM5,[ESI]
+    0xF3,0x0F,0x58,0xF7,    // addss    XMM6,XMM7
+    0x0F,0x54,0x08,     // andps    XMM1,[EAX]
+    0x0F,0x54,0xCA,     // andps    XMM1,XMM2
+0x66,   0x0F,0x54,0x03,     // andpd    XMM0,[EBX]
+0x66,   0x0F,0x54,0xD1,     // andpd    XMM2,XMM1
+    0x0F,0x55,0x08,     // andnps   XMM1,[EAX]
+    0x0F,0x55,0xCA,     // andnps   XMM1,XMM2
+0x66,   0x0F,0x55,0x03,     // andnpd   XMM0,[EBX]
+0x66,   0x0F,0x55,0xD1,     // andnpd   XMM2,XMM1
+    0xA7,           // cmpsd
+    0x0F,0xC2,0x08,0x01,    // cmpps    XMM1,[EAX],1
+    0x0F,0xC2,0xCA,0x02,    // cmpps    XMM1,XMM2,2
+0x66,   0x0F,0xC2,0x03,0x03,    // cmppd    XMM0,[EBX],3
+0x66,   0x0F,0xC2,0xD1,0x04,    // cmppd    XMM2,XMM1,4
+    0xF2,0x0F,0xC2,0x08,0x05,   // cmpsd    XMM1,[EAX],5
+    0xF2,0x0F,0xC2,0xCA,0x06,   // cmpsd    XMM1,XMM2,6
+    0xF3,0x0F,0xC2,0x2E,0x07,   // cmpss    XMM5,[ESI],7
+    0xF3,0x0F,0xC2,0xF7,0x00,   // cmpss    XMM6,XMM7,0
+0x66,   0x0F,0x2F,0x08,     // comisd   XMM1,[EAX]
+0x66,   0x0F,0x2F,0x4D,0xE0,    // comisd   XMM1,-020h[EBP]
+0x66,   0x0F,0x2F,0xCA,     // comisd   XMM1,XMM2
+    0x0F,0x2F,0x2E,     // comiss   XMM5,[ESI]
+    0x0F,0x2F,0xF7,     // comiss   XMM6,XMM7
+    0xF3,0x0F,0xE6,0xDC,    // cvtdq2pd XMM3,XMM4
+    0xF3,0x0F,0xE6,0x5D,0xE0,   // cvtdq2pd XMM3,-020h[EBP]
+    0x0F,0x5B,0xDC,     // cvtdq2ps XMM3,XMM4
+    0x0F,0x5B,0x5D,0xE8,    // cvtdq2ps XMM3,-018h[EBP]
+    0xF2,0x0F,0xE6,0xDC,    // cvtpd2dq XMM3,XMM4
+    0xF2,0x0F,0xE6,0x5D,0xE8,   // cvtpd2dq XMM3,-018h[EBP]
+0x66,   0x0F,0x2D,0xDC,     // cvtpd2pi MM3,XMM4
+0x66,   0x0F,0x2D,0x5D,0xE8,    // cvtpd2pi MM3,-018h[EBP]
+0x66,   0x0F,0x5A,0xDC,     // cvtpd2ps XMM3,XMM4
+0x66,   0x0F,0x5A,0x5D,0xE8,    // cvtpd2ps XMM3,-018h[EBP]
+0x66,   0x0F,0x2A,0xDC,     // cvtpi2pd XMM3,MM4
+0x66,   0x0F,0x2A,0x5D,0xE0,    // cvtpi2pd XMM3,-020h[EBP]
+    0x0F,0x2A,0xDC,     // cvtpi2ps XMM3,MM4
+    0x0F,0x2A,0x5D,0xE0,    // cvtpi2ps XMM3,-020h[EBP]
+0x66,   0x0F,0x5B,0xDC,     // cvtps2dq XMM3,XMM4
+0x66,   0x0F,0x5B,0x5D,0xE8,    // cvtps2dq XMM3,-018h[EBP]
+    0x0F,0x5A,0xDC,     // cvtps2pd XMM3,XMM4
+    0x0F,0x5A,0x5D,0xE0,    // cvtps2pd XMM3,-020h[EBP]
+    0x0F,0x2D,0xDC,     // cvtps2pi MM3,XMM4
+    0x0F,0x2D,0x5D,0xE0,    // cvtps2pi MM3,-020h[EBP]
+    0xF2,0x0F,0x2D,0xCC,    // cvtsd2si XMM1,XMM4
+    0xF2,0x0F,0x2D,0x55,0xE0,   // cvtsd2si XMM2,-020h[EBP]
+    0xF2,0x0F,0x5A,0xDC,    // cvtsd2ss XMM3,XMM4
+    0xF2,0x0F,0x5A,0x5D,0xE0,   // cvtsd2ss XMM3,-020h[EBP]
+    0xF2,0x0F,0x2A,0xDA,    // cvtsi2sd XMM3,EDX
+    0xF2,0x0F,0x2A,0x5D,0xD8,   // cvtsi2sd XMM3,-028h[EBP]
+    0xF3,0x0F,0x2A,0xDA,    // cvtsi2ss XMM3,EDX
+    0xF3,0x0F,0x2A,0x5D,0xD8,   // cvtsi2ss XMM3,-028h[EBP]
+    0xF3,0x0F,0x5A,0xDC,    // cvtss2sd XMM3,XMM4
+    0xF3,0x0F,0x5A,0x5D,0xD8,   // cvtss2sd XMM3,-028h[EBP]
+    0xF3,0x0F,0x2D,0xFC,    // cvtss2si XMM7,XMM4
+    0xF3,0x0F,0x2D,0x7D,0xD8,   // cvtss2si XMM7,-028h[EBP]
+0x66,   0x0F,0x2C,0xDC,     // cvttpd2pi    MM3,XMM4
+0x66,   0x0F,0x2C,0x7D,0xE8,    // cvttpd2pi    MM7,-018h[EBP]
+0x66,   0x0F,0xE6,0xDC,     // cvttpd2dq    XMM3,XMM4
+0x66,   0x0F,0xE6,0x7D,0xE8,    // cvttpd2dq    XMM7,-018h[EBP]
+    0xF3,0x0F,0x5B,0xDC,    // cvttps2dq    XMM3,XMM4
+    0xF3,0x0F,0x5B,0x7D,0xE8,   // cvttps2dq    XMM7,-018h[EBP]
+    0x0F,0x2C,0xDC,     // cvttps2pi    MM3,XMM4
+    0x0F,0x2C,0x7D,0xE0,    // cvttps2pi    MM7,-020h[EBP]
+    0xF2,0x0F,0x2C,0xC4,    // cvttsd2si    EAX,XMM4
+    0xF2,0x0F,0x2C,0x4D,0xE8,   // cvttsd2si    ECX,-018h[EBP]
+    0xF3,0x0F,0x2C,0xC4,    // cvttss2si    EAX,XMM4
+    0xF3,0x0F,0x2C,0x4D,0xD8,   // cvttss2si    ECX,-028h[EBP]
+0x66,   0x0F,0x5E,0xE8,     // divpd    XMM5,XMM0
+0x66,   0x0F,0x5E,0x6D,0xE8,    // divpd    XMM5,-018h[EBP]
+    0x0F,0x5E,0xE8,     // divps    XMM5,XMM0
+    0x0F,0x5E,0x6D,0xE8,    // divps    XMM5,-018h[EBP]
+    0xF2,0x0F,0x5E,0xE8,    // divsd    XMM5,XMM0
+    0xF2,0x0F,0x5E,0x6D,0xE0,   // divsd    XMM5,-020h[EBP]
+    0xF3,0x0F,0x5E,0xE8,    // divss    XMM5,XMM0
+    0xF3,0x0F,0x5E,0x6D,0xD8,   // divss    XMM5,-028h[EBP]
+0x66,   0x0F,0xF7,0xD1,     // maskmovdqu   XMM2,XMM1
+    0x0F,0xF7,0xE3,     // maskmovq MM4,MM3
+0x66,   0x0F,0x5F,0xC0,     // maxpd    XMM0,XMM0
+0x66,   0x0F,0x5F,0x4D,0xE8,    // maxpd    XMM1,-018h[EBP]
+    0x0F,0x5F,0xD1,     // maxps    XMM2,XMM1
+    0x0F,0x5F,0x5D,0xE8,    // maxps    XMM3,-018h[EBP]
+    0xF2,0x0F,0x5F,0xE2,    // maxsd    XMM4,XMM2
+    0xF2,0x0F,0x5F,0x6D,0xE0,   // maxsd    XMM5,-020h[EBP]
+    0xF3,0x0F,0x5F,0xF3,    // maxss    XMM6,XMM3
+    0xF3,0x0F,0x5F,0x7D,0xD8,   // maxss    XMM7,-028h[EBP]
+0x66,   0x0F,0x5D,0xC0,     // minpd    XMM0,XMM0
+0x66,   0x0F,0x5D,0x4D,0xE8,    // minpd    XMM1,-018h[EBP]
+    0x0F,0x5D,0xD1,     // minps    XMM2,XMM1
+    0x0F,0x5D,0x5D,0xE8,    // minps    XMM3,-018h[EBP]
+    0xF2,0x0F,0x5D,0xE2,    // minsd    XMM4,XMM2
+    0xF2,0x0F,0x5D,0x6D,0xE0,   // minsd    XMM5,-020h[EBP]
+    0xF3,0x0F,0x5D,0xF3,    // minss    XMM6,XMM3
+    0xF3,0x0F,0x5D,0x7D,0xD8,   // minss    XMM7,-028h[EBP]
+0x66,   0x0F,0x28,0xCA,     // movapd   XMM1,XMM2
+0x66,   0x0F,0x28,0x5D,0xE8,    // movapd   XMM3,-018h[EBP]
+0x66,   0x0F,0x29,0x65,0xE8,    // movapd   -018h[EBP],XMM4
+    0x0F,0x28,0xCA,     // movaps   XMM1,XMM2
+    0x0F,0x28,0x5D,0xE8,    // movaps   XMM3,-018h[EBP]
+    0x0F,0x29,0x65,0xE8,    // movaps   -018h[EBP],XMM4
+    0x0F,0x6E,0xCB,     // movd MM1,EBX
+    0x0F,0x6E,0x55,0xD8,    // movd MM2,-028h[EBP]
+    0x0F,0x7E,0xDB,     // movd EBX,MM3
+    0x0F,0x7E,0x65,0xD8,    // movd -028h[EBP],MM4
+0x66,   0x0F,0x6E,0xCB,     // movd XMM1,EBX
+0x66,   0x0F,0x6E,0x55,0xD8,    // movd XMM2,-028h[EBP]
+0x66,   0x0F,0x7E,0xDB,     // movd EBX,XMM3
+0x66,   0x0F,0x7E,0x65,0xD8,    // movd -028h[EBP],XMM4
+0x66,   0x0F,0x6F,0xCA,     // movdqa   XMM1,XMM2
+0x66,   0x0F,0x6F,0x55,0xE8,    // movdqa   XMM2,-018h[EBP]
+0x66,   0x0F,0x7F,0x65,0xE8,    // movdqa   -018h[EBP],XMM4
+    0xF3,0x0F,0x6F,0xCA,    // movdqu   XMM1,XMM2
+    0xF3,0x0F,0x6F,0x55,0xE8,   // movdqu   XMM2,-018h[EBP]
+    0xF3,0x0F,0x7F,0x65,0xE8,   // movdqu   -018h[EBP],XMM4
+    0xF2,0x0F,0xD6,0xDC,    // movdq2q  MM4,XMM3
+    0x0F,0x12,0xDC,     // movhlps  XMM4,XMM3
+0x66,   0x0F,0x16,0x55,0xE0,    // movhpd   XMM2,-020h[EBP]
+0x66,   0x0F,0x17,0x7D,0xE0,    // movhpd   -020h[EBP],XMM7
+    0x0F,0x16,0x55,0xE0,    // movhps   XMM2,-020h[EBP]
+    0x0F,0x17,0x7D,0xE0,    // movhps   -020h[EBP],XMM7
+    0x0F,0x16,0xDC,     // movlhps  XMM4,XMM3
+0x66,   0x0F,0x12,0x55,0xE0,    // movlpd   XMM2,-020h[EBP]
+0x66,   0x0F,0x13,0x7D,0xE0,    // movlpd   -020h[EBP],XMM7
+    0x0F,0x12,0x55,0xE0,    // movlps   XMM2,-020h[EBP]
+    0x0F,0x13,0x7D,0xE0,    // movlps   -020h[EBP],XMM7
+0x66,   0x0F,0x50,0xF3,     // movmskpd ESI,XMM3
+    0x0F,0x50,0xF3,     // movmskps ESI,XMM3
+0x66,   0x0F,0x59,0xC0,     // mulpd    XMM0,XMM0
+0x66,   0x0F,0x59,0x4D,0xE8,    // mulpd    XMM1,-018h[EBP]
+    0x0F,0x59,0xD1,     // mulps    XMM2,XMM1
+    0x0F,0x59,0x5D,0xE8,    // mulps    XMM3,-018h[EBP]
+    0xF2,0x0F,0x59,0xE2,    // mulsd    XMM4,XMM2
+    0xF2,0x0F,0x59,0x6D,0xE0,   // mulsd    XMM5,-020h[EBP]
+    0xF3,0x0F,0x59,0xF3,    // mulss    XMM6,XMM3
+    0xF3,0x0F,0x59,0x7D,0xD8,   // mulss    XMM7,-028h[EBP]
+0x66,   0x0F,0x51,0xC4,       // sqrtpd XMM0,XMM4
+0x66,   0x0F,0x51,0x4D,0xE8,      // sqrtpd XMM1,-018h[EBP]
+    0x0F,0x51,0xD5,       // sqrtps XMM2,XMM5
+    0x0F,0x51,0x5D,0xE8,      // sqrtps XMM3,-018h[EBP]
+    0xF2,0x0F,0x51,0xE6,      // sqrtsd XMM4,XMM6
+    0xF2,0x0F,0x51,0x6D,0xE0, // sqrtsd XMM5,-020h[EBP]
+    0xF3,0x0F,0x51,0xF7,      // sqrtss XMM6,XMM7
+    0xF3,0x0F,0x51,0x7D,0xD8, // sqrtss XMM7,-028h[EBP]
+0x66,   0x0F,0x5C,0xC4,     // subpd    XMM0,XMM4
+0x66,   0x0F,0x5C,0x4D,0xE8,    // subpd    XMM1,-018h[EBP]
+    0x0F,0x5C,0xD5,     // subps    XMM2,XMM5
+    0x0F,0x5C,0x5D,0xE8,    // subps    XMM3,-018h[EBP]
+    0xF2,0x0F,0x5C,0xE6,    // subsd    XMM4,XMM6
+    0xF2,0x0F,0x5C,0x6D,0xE0,   // subsd    XMM5,-020h[EBP]
+    0xF3,0x0F,0x5C,0xF7,    // subss    XMM6,XMM7
+    0xF3,0x0F,0x5C,0x7D,0xD8,   // subss    XMM7,-028h[EBP]
+    0x0F,0x01,0xE0,         // smsw EAX
     ];
     int i;
 
     asm
     {
-	call	L1			;
-	ud2				;
-	syscall				;
-	sysenter			;
-	sysexit				;
-	sysret				;
-	lfence				;
-	mfence				;
-	sfence				;
-	fxsave	[EAX]			;
-	fxrstor	[EAX]			;
-	ldmxcsr	[EAX]			;
-	stmxcsr	[EAX]			;
-	clflush	[EAX]			;
+    call    L1          ;
+    ud2             ;
+    syscall             ;
+    sysenter            ;
+    sysexit             ;
+    sysret              ;
+    lfence              ;
+    mfence              ;
+    sfence              ;
+    fxsave  [EAX]           ;
+    fxrstor [EAX]           ;
+    ldmxcsr [EAX]           ;
+    stmxcsr [EAX]           ;
+    clflush [EAX]           ;
 
-	addps XMM1,[EAX]		;
-	addps XMM1,XMM2			;
-	addpd XMM0,[EBX]		;
-	addpd XMM2,XMM1			;
-	addsd XMM1,[EAX]		;
-	addsd XMM1,XMM2			;
-	addss XMM5,[ESI]		;
-	addss XMM6,XMM7			;
+    addps XMM1,[EAX]        ;
+    addps XMM1,XMM2         ;
+    addpd XMM0,[EBX]        ;
+    addpd XMM2,XMM1         ;
+    addsd XMM1,[EAX]        ;
+    addsd XMM1,XMM2         ;
+    addss XMM5,[ESI]        ;
+    addss XMM6,XMM7         ;
 
-	andps XMM1,[EAX]		;
-	andps XMM1,XMM2			;
-	andpd XMM0,[EBX]		;
-	andpd XMM2,XMM1			;
+    andps XMM1,[EAX]        ;
+    andps XMM1,XMM2         ;
+    andpd XMM0,[EBX]        ;
+    andpd XMM2,XMM1         ;
 
-	andnps XMM1,[EAX]		;
-	andnps XMM1,XMM2		;
-	andnpd XMM0,[EBX]		;
-	andnpd XMM2,XMM1		;
+    andnps XMM1,[EAX]       ;
+    andnps XMM1,XMM2        ;
+    andnpd XMM0,[EBX]       ;
+    andnpd XMM2,XMM1        ;
 
-	cmpsd				;
-	cmpps XMM1,[EAX],1		;
-	cmpps XMM1,XMM2,2		;
-	cmppd XMM0,[EBX],3		;
-	cmppd XMM2,XMM1,4		;
-	cmpsd XMM1,[EAX],5		;
-	cmpsd XMM1,XMM2,6		;
-	cmpss XMM5,[ESI],7		;
-	cmpss XMM6,XMM7,0		;
+    cmpsd               ;
+    cmpps XMM1,[EAX],1      ;
+    cmpps XMM1,XMM2,2       ;
+    cmppd XMM0,[EBX],3      ;
+    cmppd XMM2,XMM1,4       ;
+    cmpsd XMM1,[EAX],5      ;
+    cmpsd XMM1,XMM2,6       ;
+    cmpss XMM5,[ESI],7      ;
+    cmpss XMM6,XMM7,0       ;
 
-	comisd XMM1,[EAX]		;
-	comisd XMM1,m64[EBP]		;
-	comisd XMM1,XMM2		;
-	comiss XMM5,[ESI]		;
-	comiss XMM6,XMM7		;
+    comisd XMM1,[EAX]       ;
+    comisd XMM1,m64[EBP]        ;
+    comisd XMM1,XMM2        ;
+    comiss XMM5,[ESI]       ;
+    comiss XMM6,XMM7        ;
 
-	cvtdq2pd XMM3,XMM4		;
-	cvtdq2pd XMM3,m64[EBP]		;
+    cvtdq2pd XMM3,XMM4      ;
+    cvtdq2pd XMM3,m64[EBP]      ;
 
-	cvtdq2ps XMM3,XMM4		;
-	cvtdq2ps XMM3,m128[EBP]		;
+    cvtdq2ps XMM3,XMM4      ;
+    cvtdq2ps XMM3,m128[EBP]     ;
 
-	cvtpd2dq XMM3,XMM4		;
-	cvtpd2dq XMM3,m128[EBP]		;
+    cvtpd2dq XMM3,XMM4      ;
+    cvtpd2dq XMM3,m128[EBP]     ;
 
-	cvtpd2pi MM3,XMM4		;
-	cvtpd2pi MM3,m128[EBP]		;
+    cvtpd2pi MM3,XMM4       ;
+    cvtpd2pi MM3,m128[EBP]      ;
 
-	cvtpd2ps XMM3,XMM4		;
-	cvtpd2ps XMM3,m128[EBP]		;
+    cvtpd2ps XMM3,XMM4      ;
+    cvtpd2ps XMM3,m128[EBP]     ;
 
-	cvtpi2pd XMM3,MM4		;
-	cvtpi2pd XMM3,m64[EBP]		;
+    cvtpi2pd XMM3,MM4       ;
+    cvtpi2pd XMM3,m64[EBP]      ;
 
-	cvtpi2ps XMM3,MM4		;
-	cvtpi2ps XMM3,m64[EBP]		;
+    cvtpi2ps XMM3,MM4       ;
+    cvtpi2ps XMM3,m64[EBP]      ;
 
-	cvtps2dq XMM3,XMM4		;
-	cvtps2dq XMM3,m128[EBP]		;
+    cvtps2dq XMM3,XMM4      ;
+    cvtps2dq XMM3,m128[EBP]     ;
 
-	cvtps2pd XMM3,XMM4		;
-	cvtps2pd XMM3,m64[EBP]		;
+    cvtps2pd XMM3,XMM4      ;
+    cvtps2pd XMM3,m64[EBP]      ;
 
-	cvtps2pi MM3,XMM4		;
-	cvtps2pi MM3,m64[EBP]		;
+    cvtps2pi MM3,XMM4       ;
+    cvtps2pi MM3,m64[EBP]       ;
 
-	cvtsd2si ECX,XMM4		;
-	cvtsd2si EDX,m64[EBP]		;
+    cvtsd2si ECX,XMM4       ;
+    cvtsd2si EDX,m64[EBP]       ;
 
-	cvtsd2ss XMM3,XMM4		;
-	cvtsd2ss XMM3,m64[EBP]		;
+    cvtsd2ss XMM3,XMM4      ;
+    cvtsd2ss XMM3,m64[EBP]      ;
 
-	cvtsi2sd XMM3,EDX		;
-	cvtsi2sd XMM3,m32[EBP]		;
+    cvtsi2sd XMM3,EDX       ;
+    cvtsi2sd XMM3,m32[EBP]      ;
 
-	cvtsi2ss XMM3,EDX		;
-	cvtsi2ss XMM3,m32[EBP]		;
+    cvtsi2ss XMM3,EDX       ;
+    cvtsi2ss XMM3,m32[EBP]      ;
 
-	cvtss2sd XMM3,XMM4		;
-	cvtss2sd XMM3,m32[EBP]		;
+    cvtss2sd XMM3,XMM4      ;
+    cvtss2sd XMM3,m32[EBP]      ;
 
-	cvtss2si EDI,XMM4		;
-	cvtss2si EDI,m32[EBP]		;
+    cvtss2si EDI,XMM4       ;
+    cvtss2si EDI,m32[EBP]       ;
 
-	cvttpd2pi MM3,XMM4		;
-	cvttpd2pi MM7,m128[EBP]		;
+    cvttpd2pi MM3,XMM4      ;
+    cvttpd2pi MM7,m128[EBP]     ;
 
-	cvttpd2dq XMM3,XMM4		;
-	cvttpd2dq XMM7,m128[EBP]	;
+    cvttpd2dq XMM3,XMM4     ;
+    cvttpd2dq XMM7,m128[EBP]    ;
 
-	cvttps2dq XMM3,XMM4		;
-	cvttps2dq XMM7,m128[EBP]	;
+    cvttps2dq XMM3,XMM4     ;
+    cvttps2dq XMM7,m128[EBP]    ;
 
-	cvttps2pi MM3,XMM4		;
-	cvttps2pi MM7,m64[EBP]		;
+    cvttps2pi MM3,XMM4      ;
+    cvttps2pi MM7,m64[EBP]      ;
 
-	cvttsd2si EAX,XMM4		;
-	cvttsd2si ECX,m128[EBP]		;
+    cvttsd2si EAX,XMM4      ;
+    cvttsd2si ECX,m128[EBP]     ;
 
-	cvttss2si EAX,XMM4		;
-	cvttss2si ECX,m32[EBP]		;
+    cvttss2si EAX,XMM4      ;
+    cvttss2si ECX,m32[EBP]      ;
 
-	divpd	XMM5,XMM0		;
-	divpd	XMM5,m128[EBP]		;
-	divps	XMM5,XMM0		;
-	divps	XMM5,m128[EBP]		;
-	divsd	XMM5,XMM0		;
-	divsd	XMM5,m64[EBP]		;
-	divss	XMM5,XMM0		;
-	divss	XMM5,m32[EBP]		;
+    divpd   XMM5,XMM0       ;
+    divpd   XMM5,m128[EBP]      ;
+    divps   XMM5,XMM0       ;
+    divps   XMM5,m128[EBP]      ;
+    divsd   XMM5,XMM0       ;
+    divsd   XMM5,m64[EBP]       ;
+    divss   XMM5,XMM0       ;
+    divss   XMM5,m32[EBP]       ;
 
-	maskmovdqu XMM1,XMM2		;
-	maskmovq   MM3,MM4		;
+    maskmovdqu XMM1,XMM2        ;
+    maskmovq   MM3,MM4      ;
 
-	maxpd	XMM0,XMM0		;
-	maxpd	XMM1,m128[EBP]		;
-	maxps	XMM2,XMM1		;
-	maxps	XMM3,m128[EBP]		;
-	maxsd	XMM4,XMM2		;
-	maxsd	XMM5,m64[EBP]		;
-	maxss	XMM6,XMM3		;
-	maxss	XMM7,m32[EBP]		;
+    maxpd   XMM0,XMM0       ;
+    maxpd   XMM1,m128[EBP]      ;
+    maxps   XMM2,XMM1       ;
+    maxps   XMM3,m128[EBP]      ;
+    maxsd   XMM4,XMM2       ;
+    maxsd   XMM5,m64[EBP]       ;
+    maxss   XMM6,XMM3       ;
+    maxss   XMM7,m32[EBP]       ;
 
-	minpd	XMM0,XMM0		;
-	minpd	XMM1,m128[EBP]		;
-	minps	XMM2,XMM1		;
-	minps	XMM3,m128[EBP]		;
-	minsd	XMM4,XMM2		;
-	minsd	XMM5,m64[EBP]		;
-	minss	XMM6,XMM3		;
-	minss	XMM7,m32[EBP]		;
+    minpd   XMM0,XMM0       ;
+    minpd   XMM1,m128[EBP]      ;
+    minps   XMM2,XMM1       ;
+    minps   XMM3,m128[EBP]      ;
+    minsd   XMM4,XMM2       ;
+    minsd   XMM5,m64[EBP]       ;
+    minss   XMM6,XMM3       ;
+    minss   XMM7,m32[EBP]       ;
 
-	movapd	XMM1,XMM2		;
-	movapd	XMM3,m128[EBP]		;
-	movapd	m128[EBP],XMM4		;
+    movapd  XMM1,XMM2       ;
+    movapd  XMM3,m128[EBP]      ;
+    movapd  m128[EBP],XMM4      ;
 
-	movaps	XMM1,XMM2		;
-	movaps	XMM3,m128[EBP]		;
-	movaps	m128[EBP],XMM4		;
+    movaps  XMM1,XMM2       ;
+    movaps  XMM3,m128[EBP]      ;
+    movaps  m128[EBP],XMM4      ;
 
-	movd	MM1,EBX			;
-	movd	MM2,m32[EBP]		;
-	movd	EBX,MM3			;
-	movd	m32[EBP],MM4		;
+    movd    MM1,EBX         ;
+    movd    MM2,m32[EBP]        ;
+    movd    EBX,MM3         ;
+    movd    m32[EBP],MM4        ;
 
-	movd	XMM1,EBX		;
-	movd	XMM2,m32[EBP]		;
-	movd	EBX,XMM3		;
-	movd	m32[EBP],XMM4		;
+    movd    XMM1,EBX        ;
+    movd    XMM2,m32[EBP]       ;
+    movd    EBX,XMM3        ;
+    movd    m32[EBP],XMM4       ;
 
-	movdqa	XMM1,XMM2		;
-	movdqa	XMM2,m128[EBP]		;
-	movdqa	m128[EBP],XMM4		;
+    movdqa  XMM1,XMM2       ;
+    movdqa  XMM2,m128[EBP]      ;
+    movdqa  m128[EBP],XMM4      ;
 
-	movdqu	XMM1,XMM2		;
-	movdqu	XMM2,m128[EBP]		;
-	movdqu	m128[EBP],XMM4		;
+    movdqu  XMM1,XMM2       ;
+    movdqu  XMM2,m128[EBP]      ;
+    movdqu  m128[EBP],XMM4      ;
 
-	movdq2q	MM3,XMM4		;
-	movhlps	XMM3,XMM4		;
-	movhpd	XMM2,m64[EBP]		;
-	movhpd	m64[EBP],XMM7		;
-	movhps	XMM2,m64[EBP]		;
-	movhps	m64[EBP],XMM7		;
-	movlhps	XMM3,XMM4		;
-	movlpd	XMM2,m64[EBP]		;
-	movlpd	m64[EBP],XMM7		;
-	movlps	XMM2,m64[EBP]		;
-	movlps	m64[EBP],XMM7		;
+    movdq2q MM3,XMM4        ;
+    movhlps XMM3,XMM4       ;
+    movhpd  XMM2,m64[EBP]       ;
+    movhpd  m64[EBP],XMM7       ;
+    movhps  XMM2,m64[EBP]       ;
+    movhps  m64[EBP],XMM7       ;
+    movlhps XMM3,XMM4       ;
+    movlpd  XMM2,m64[EBP]       ;
+    movlpd  m64[EBP],XMM7       ;
+    movlps  XMM2,m64[EBP]       ;
+    movlps  m64[EBP],XMM7       ;
 
-	movmskpd ESI,XMM3		;
-	movmskps ESI,XMM3		;
+    movmskpd ESI,XMM3       ;
+    movmskps ESI,XMM3       ;
 
-	mulpd	XMM0,XMM0		;
-	mulpd	XMM1,m128[EBP]		;
-	mulps	XMM2,XMM1		;
-	mulps	XMM3,m128[EBP]		;
-	mulsd	XMM4,XMM2		;
-	mulsd	XMM5,m64[EBP]		;
-	mulss	XMM6,XMM3		;
-	mulss	XMM7,m32[EBP]		;
+    mulpd   XMM0,XMM0       ;
+    mulpd   XMM1,m128[EBP]      ;
+    mulps   XMM2,XMM1       ;
+    mulps   XMM3,m128[EBP]      ;
+    mulsd   XMM4,XMM2       ;
+    mulsd   XMM5,m64[EBP]       ;
+    mulss   XMM6,XMM3       ;
+    mulss   XMM7,m32[EBP]       ;
 
-	sqrtpd	XMM0,XMM4		;
-	sqrtpd	XMM1,m128[EBP]		;
-	sqrtps	XMM2,XMM5		;
-	sqrtps	XMM3,m128[EBP]		;
-	sqrtsd	XMM4,XMM6		;
-	sqrtsd	XMM5,m64[EBP]		;
-	sqrtss	XMM6,XMM7		;
-	sqrtss	XMM7,m32[EBP]		;
+    sqrtpd  XMM0,XMM4       ;
+    sqrtpd  XMM1,m128[EBP]      ;
+    sqrtps  XMM2,XMM5       ;
+    sqrtps  XMM3,m128[EBP]      ;
+    sqrtsd  XMM4,XMM6       ;
+    sqrtsd  XMM5,m64[EBP]       ;
+    sqrtss  XMM6,XMM7       ;
+    sqrtss  XMM7,m32[EBP]       ;
 
-	subpd	XMM0,XMM4		;
-	subpd	XMM1,m128[EBP]		;
-	subps	XMM2,XMM5		;
-	subps	XMM3,m128[EBP]		;
-	subsd	XMM4,XMM6		;
-	subsd	XMM5,m64[EBP]		;
-	subss	XMM6,XMM7		;
-	subss	XMM7,m32[EBP]		;
+    subpd   XMM0,XMM4       ;
+    subpd   XMM1,m128[EBP]      ;
+    subps   XMM2,XMM5       ;
+    subps   XMM3,m128[EBP]      ;
+    subsd   XMM4,XMM6       ;
+    subsd   XMM5,m64[EBP]       ;
+    subss   XMM6,XMM7       ;
+    subss   XMM7,m32[EBP]       ;
 
-	smsw	EAX			;
+    smsw    EAX         ;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	//printf("[%d] = %02x %02x\n", i, p[i], data[i]);
-	assert(p[i] == data[i]);
+    //printf("[%d] = %02x %02x\n", i, p[i], data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -1126,742 +1126,742 @@ void test14()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-0x66,	0x0F,0x50,0xF3,   	// movmskpd	ESI,XMM3
-	0x0F,0x50,0xF3,   	// movmskps	ESI,XMM3
-0x66,	0x0F,0xE7,0x55,0xE8,	// movntdq	-018h[EBP],XMM2
-	0x0F,0xC3,0x4D,0xDC,	// movnti	-024h[EBP],ECX
-0x66,	0x0F,0x2B,0x5D,0xE8,	// movntpd	-018h[EBP],XMM3
-	0x0F,0x2B,0x65,0xE8,	// movntps	-018h[EBP],XMM4
-	0x0F,0xE7,0x6D,0xE0,	// movntq	-020h[EBP],MM5
-	0x0F,0x6F,0xCA,   	// movq	MM1,MM2
-	0x0F,0x6F,0x55,0xE0,	// movq	MM2,-020h[EBP]
-	0x0F,0x7F,0x5D,0xE0,	// movq	-020h[EBP],MM3
-	0xF3,0x0F,0x7E,0xCA,	// movq	XMM1,XMM2
-	0xF3,0x0F,0x7E,0x55,0xE0,	// movq	XMM2,-020h[EBP]
-0x66,	0x0F,0xD6,0x5D,0xE0,	// movq	-020h[EBP],XMM3
-	0xF3,0x0F,0xD6,0xDA,	// movq2dq	XMM3,MM2
-	0xA5,          	// movsd
-	0xF2,0x0F,0x10,0xCA,	// movsd	XMM1,XMM2
-	0xF2,0x0F,0x10,0x5D,0xE0,	// movsd	XMM3,-020h[EBP]
-	0xF2,0x0F,0x11,0x65,0xE0,	// movsd	-020h[EBP],XMM4
-	0xF3,0x0F,0x10,0xCA,	// movss	XMM1,XMM2
-	0xF3,0x0F,0x10,0x5D,0xDC,	// movss	XMM3,-024h[EBP]
-	0xF3,0x0F,0x11,0x65,0xDC,	// movss	-024h[EBP],XMM4
-0x66,	0x0F,0x10,0xCA,   	// movupd	XMM1,XMM2
-0x66,	0x0F,0x10,0x5D,0xE8,	// movupd	XMM3,-018h[EBP]
-0x66,	0x0F,0x11,0x65,0xE8,	// movupd	-018h[EBP],XMM4
-	0x0F,0x10,0xCA,   	// movups	XMM1,XMM2
-	0x0F,0x10,0x5D,0xE8,	// movups	XMM3,-018h[EBP]
-	0x0F,0x11,0x65,0xE8,	// movups	-018h[EBP],XMM4
-0x66,	0x0F,0x56,0xCA,   	// orpd	XMM1,XMM2
-0x66,	0x0F,0x56,0x5D,0xE8,	// orpd	XMM3,-018h[EBP]
-	0x0F,0x56,0xCA,   	// orps	XMM1,XMM2
-	0x0F,0x56,0x5D,0xE8,	// orps	XMM3,-018h[EBP]
-	0x0F,0x63,0xCA,   	// packsswb	MM1,MM2
-	0x0F,0x63,0x5D,0xE0,	// packsswb	MM3,-020h[EBP]
-0x66,	0x0F,0x63,0xCA,   	// packsswb	XMM1,XMM2
-0x66,	0x0F,0x63,0x5D,0xE8,	// packsswb	XMM3,-018h[EBP]
-	0x0F,0x6B,0xCA,   	// packssdw	MM1,MM2
-	0x0F,0x6B,0x5D,0xE0,	// packssdw	MM3,-020h[EBP]
-0x66,	0x0F,0x6B,0xCA,   	// packssdw	XMM1,XMM2
-0x66,	0x0F,0x6B,0x5D,0xE8,	// packssdw	XMM3,-018h[EBP]
-	0x0F,0x67,0xCA,   	// packuswb	MM1,MM2
-	0x0F,0x67,0x5D,0xE0,	// packuswb	MM3,-020h[EBP]
-0x66,	0x0F,0x67,0xCA,   	// packuswb	XMM1,XMM2
-0x66,	0x0F,0x67,0x5D,0xE8,	// packuswb	XMM3,-018h[EBP]
-	0x0F,0xFC,0xCA,   	// paddb	MM1,MM2
-	0x0F,0xFC,0x5D,0xE0,	// paddb	MM3,-020h[EBP]
-0x66,	0x0F,0xFC,0xCA,   	// paddb	XMM1,XMM2
-0x66,	0x0F,0xFC,0x5D,0xE8,	// paddb	XMM3,-018h[EBP]
-	0x0F,0xFD,0xCA,   	// paddw	MM1,MM2
-	0x0F,0xFD,0x5D,0xE0,	// paddw	MM3,-020h[EBP]
-0x66,	0x0F,0xFD,0xCA,   	// paddw	XMM1,XMM2
-0x66,	0x0F,0xFD,0x5D,0xE8,	// paddw	XMM3,-018h[EBP]
-	0x0F,0xFE,0xCA,   	// paddd	MM1,MM2
-	0x0F,0xFE,0x5D,0xE0,	// paddd	MM3,-020h[EBP]
-0x66,	0x0F,0xFE,0xCA,   	// paddd	XMM1,XMM2
-0x66,	0x0F,0xFE,0x5D,0xE8,	// paddd	XMM3,-018h[EBP]
-	0x0F,0xD4,0xCA,   	// paddq	MM1,MM2
-	0x0F,0xD4,0x5D,0xE0,	// paddq	MM3,-020h[EBP]
-0x66,	0x0F,0xD4,0xCA,   	// paddq	XMM1,XMM2
-0x66,	0x0F,0xD4,0x5D,0xE8,	// paddq	XMM3,-018h[EBP]
-	0x0F,0xEC,0xCA,   	// paddsb	MM1,MM2
-	0x0F,0xEC,0x5D,0xE0,	// paddsb	MM3,-020h[EBP]
-0x66,	0x0F,0xEC,0xCA,   	// paddsb	XMM1,XMM2
-0x66,	0x0F,0xEC,0x5D,0xE8,	// paddsb	XMM3,-018h[EBP]
-	0x0F,0xED,0xCA,   	// paddsw	MM1,MM2
-	0x0F,0xED,0x5D,0xE0,	// paddsw	MM3,-020h[EBP]
-0x66,	0x0F,0xED,0xCA,   	// paddsw	XMM1,XMM2
-0x66,	0x0F,0xED,0x5D,0xE8,	// paddsw	XMM3,-018h[EBP]
-	0x0F,0xDC,0xCA,   	// paddusb	MM1,MM2
-	0x0F,0xDC,0x5D,0xE0,	// paddusb	MM3,-020h[EBP]
-0x66,	0x0F,0xDC,0xCA,   	// paddusb	XMM1,XMM2
-0x66,	0x0F,0xDC,0x5D,0xE8,	// paddusb	XMM3,-018h[EBP]
-	0x0F,0xDD,0xCA,   	// paddusw	MM1,MM2
-	0x0F,0xDD,0x5D,0xE0,	// paddusw	MM3,-020h[EBP]
-0x66,	0x0F,0xDD,0xCA,   	// paddusw	XMM1,XMM2
-0x66,	0x0F,0xDD,0x5D,0xE8,	// paddusw	XMM3,-018h[EBP]
-	0x0F,0xDB,0xCA,   	// pand	MM1,MM2
-	0x0F,0xDB,0x5D,0xE0,	// pand	MM3,-020h[EBP]
-0x66,	0x0F,0xDB,0xCA,   	// pand	XMM1,XMM2
-0x66,	0x0F,0xDB,0x5D,0xE8,	// pand	XMM3,-018h[EBP]
-	0x0F,0xDF,0xCA,   	// pandn	MM1,MM2
-	0x0F,0xDF,0x5D,0xE0,	// pandn	MM3,-020h[EBP]
-0x66,	0x0F,0xDF,0xCA,   	// pandn	XMM1,XMM2
-0x66,	0x0F,0xDF,0x5D,0xE8,	// pandn	XMM3,-018h[EBP]
-	0x0F,0xE0,0xCA,   	// pavgb	MM1,MM2
-	0x0F,0xE0,0x5D,0xE0,	// pavgb	MM3,-020h[EBP]
-0x66,	0x0F,0xE0,0xCA,   	// pavgb	XMM1,XMM2
-0x66,	0x0F,0xE0,0x5D,0xE8,	// pavgb	XMM3,-018h[EBP]
-	0x0F,0xE3,0xCA,   	// pavgw	MM1,MM2
-	0x0F,0xE3,0x5D,0xE0,	// pavgw	MM3,-020h[EBP]
-0x66,	0x0F,0xE3,0xCA,   	// pavgw	XMM1,XMM2
-0x66,	0x0F,0xE3,0x5D,0xE8,	// pavgw	XMM3,-018h[EBP]
-	0x0F,0x74,0xCA,   	// pcmpeqb	MM1,MM2
-	0x0F,0x74,0x5D,0xE0,	// pcmpeqb	MM3,-020h[EBP]
-0x66,	0x0F,0x74,0xCA,   	// pcmpeqb	XMM1,XMM2
-0x66,	0x0F,0x74,0x5D,0xE8,	// pcmpeqb	XMM3,-018h[EBP]
-	0x0F,0x75,0xCA,   	// pcmpeqw	MM1,MM2
-	0x0F,0x75,0x5D,0xE0,	// pcmpeqw	MM3,-020h[EBP]
-0x66,	0x0F,0x75,0xCA,   	// pcmpeqw	XMM1,XMM2
-0x66,	0x0F,0x75,0x5D,0xE8,	// pcmpeqw	XMM3,-018h[EBP]
-	0x0F,0x76,0xCA,   	// pcmpeqd	MM1,MM2
-	0x0F,0x76,0x5D,0xE0,	// pcmpeqd	MM3,-020h[EBP]
-0x66,	0x0F,0x76,0xCA,   	// pcmpeqd	XMM1,XMM2
-0x66,	0x0F,0x76,0x5D,0xE8,	// pcmpeqd	XMM3,-018h[EBP]
-	0x0F,0x64,0xCA,   	// pcmpgtb	MM1,MM2
-	0x0F,0x64,0x5D,0xE0,	// pcmpgtb	MM3,-020h[EBP]
-0x66,	0x0F,0x64,0xCA,   	// pcmpgtb	XMM1,XMM2
-0x66,	0x0F,0x64,0x5D,0xE8,	// pcmpgtb	XMM3,-018h[EBP]
-	0x0F,0x65,0xCA,   	// pcmpgtw	MM1,MM2
-	0x0F,0x65,0x5D,0xE0,	// pcmpgtw	MM3,-020h[EBP]
-0x66,	0x0F,0x65,0xCA,   	// pcmpgtw	XMM1,XMM2
-0x66,	0x0F,0x65,0x5D,0xE8,	// pcmpgtw	XMM3,-018h[EBP]
-	0x0F,0x66,0xCA,   	// pcmpgtd	MM1,MM2
-	0x0F,0x66,0x5D,0xE0,	// pcmpgtd	MM3,-020h[EBP]
-0x66,	0x0F,0x66,0xCA,   	// pcmpgtd	XMM1,XMM2
-0x66,	0x0F,0x66,0x5D,0xE8,	// pcmpgtd	XMM3,-018h[EBP]
-	0x0F,0xC5,0xD6,0x07,	// pextrw	EDX,MM6,7
-0x66,	0x0F,0xC5,0xD6,0x07,	// pextrw	EDX,XMM6,7
-	0x0F,0xC4,0xF2,0x07,	// pinsrw	MM6,EDX,7
-	0x0F,0xC4,0x75,0xDA,0x07,	// pinsrw	MM6,-026h[EBP],7
-0x66,	0x0F,0xC4,0xF2,0x07,	// pinsrw	XMM6,EDX,7
-0x66,	0x0F,0xC4,0x75,0xDA,0x07,	// pinsrw	XMM6,-026h[EBP],7
-	0x0F,0xF5,0xCA,   	// pmaddwd	MM1,MM2
-	0x0F,0xF5,0x5D,0xE0,	// pmaddwd	MM3,-020h[EBP]
-0x66,	0x0F,0xF5,0xCA,   	// pmaddwd	XMM1,XMM2
-0x66,	0x0F,0xF5,0x5D,0xE8,	// pmaddwd	XMM3,-018h[EBP]
-	0x0F,0xEE,0xCA,   	// pmaxsw	MM1,XMM2
-	0x0F,0xEE,0x5D,0xE0,	// pmaxsw	MM3,-020h[EBP]
-0x66,	0x0F,0xEE,0xCA,   	// pmaxsw	XMM1,XMM2
-0x66,	0x0F,0xEE,0x5D,0xE8,	// pmaxsw	XMM3,-018h[EBP]
-	0x0F,0xDE,0xCA,   	// pmaxub	MM1,XMM2
-	0x0F,0xDE,0x5D,0xE0,	// pmaxub	MM3,-020h[EBP]
-0x66,	0x0F,0xDE,0xCA,   	// pmaxub	XMM1,XMM2
-0x66,	0x0F,0xDE,0x5D,0xE8,	// pmaxub	XMM3,-018h[EBP]
-	0x0F,0xEA,0xCA,   	// pminsw	MM1,MM2
-	0x0F,0xEA,0x5D,0xE0,	// pminsw	MM3,-020h[EBP]
-0x66,	0x0F,0xEA,0xCA,   	// pminsw	XMM1,XMM2
-0x66,	0x0F,0xEA,0x5D,0xE8,	// pminsw	XMM3,-018h[EBP]
-	0x0F,0xDA,0xCA,   	// pminub	MM1,MM2
-	0x0F,0xDA,0x5D,0xE0,	// pminub	MM3,-020h[EBP]
-0x66,	0x0F,0xDA,0xCA,   	// pminub	XMM1,XMM2
-0x66,	0x0F,0xDA,0x5D,0xE8,	// pminub	XMM3,-018h[EBP]
-	0x0F,0xD7,0xC8,   	// pmovmskb	ECX,MM0
-0x66,	0x0F,0xD7,0xCE,   	// pmovmskb	ECX,XMM6
-	0x0F,0xE4,0xCA,   	// pmulhuw	MM1,MM2
-	0x0F,0xE4,0x5D,0xE0,	// pmulhuw	MM3,-020h[EBP]
-0x66,	0x0F,0xE4,0xCA,   	// pmulhuw	XMM1,XMM2
-0x66,	0x0F,0xE4,0x5D,0xE8,	// pmulhuw	XMM3,-018h[EBP]
-	0x0F,0xE5,0xCA,   	// pmulhw	MM1,MM2
-	0x0F,0xE5,0x5D,0xE0,	// pmulhw	MM3,-020h[EBP]
-0x66,	0x0F,0xE5,0xCA,   	// pmulhw	XMM1,XMM2
-0x66,	0x0F,0xE5,0x5D,0xE8,	// pmulhw	XMM3,-018h[EBP]
-	0x0F,0xD5,0xCA,   	// pmullw	MM1,MM2
-	0x0F,0xD5,0x5D,0xE0,	// pmullw	MM3,-020h[EBP]
-0x66,	0x0F,0xD5,0xCA,   	// pmullw	XMM1,XMM2
-0x66,	0x0F,0xD5,0x5D,0xE8,	// pmullw	XMM3,-018h[EBP]
-	0x0F,0xF4,0xCA,   	// pmuludq	MM1,MM2
-	0x0F,0xF4,0x5D,0xE0,	// pmuludq	MM3,-020h[EBP]
-0x66,	0x0F,0xF4,0xCA,   	// pmuludq	XMM1,XMM2
-0x66,	0x0F,0xF4,0x5D,0xE8,	// pmuludq	XMM3,-018h[EBP]
-	0x0F,0xEB,0xCA,   	// por	MM1,MM2
-	0x0F,0xEB,0x5D,0xE0,	// por	MM3,-020h[EBP]
-0x66,	0x0F,0xEB,0xCA,   	// por	XMM1,XMM2
-0x66,	0x0F,0xEB,0x5D,0xE8,	// por	XMM3,-018h[EBP]
-	0x0F,0x18,0x4D,0xD8,	// prefetcht0	-028h[EBP]
-	0x0F,0x18,0x55,0xD8,	// prefetcht1	-028h[EBP]
-	0x0F,0x18,0x5D,0xD8,	// prefetcht2	-028h[EBP]
-	0x0F,0x18,0x45,0xD8,	// prefetchnta	-028h[EBP]
-	0x0F,0xF6,0xCA,   	// psadbw	MM1,MM2
-	0x0F,0xF6,0x5D,0xE0,	// psadbw	MM3,-020h[EBP]
-0x66,	0x0F,0xF6,0xCA,   	// psadbw	XMM1,XMM2
-0x66,	0x0F,0xF6,0x5D,0xE8,	// psadbw	XMM3,-018h[EBP]
-0x66,	0x0F,0x70,0xCA,0x03,	// pshufd	XMM1,XMM2
-0x66,	0x0F,0x70,0x5D,0xE8,0x03,	// pshufd	XMM3,-018h[EBP]
-	0xF3,0x0F,0x70,0xCA,0x03,	// pshufhw	XMM1,XMM2
-	0xF3,0x0F,0x70,0x5D,0xE8,0x03,	// pshufhw	XMM3,-018h[EBP]
-	0xF2,0x0F,0x70,0xCA,0x03,	// pshuflw	XMM1,XMM2
-	0xF2,0x0F,0x70,0x5D,0xE8,0x03,	// pshuflw	XMM3,-018h[EBP]
-	0x0F,0x70,0xCA,0x03,	// pshufw	MM1,MM2
-	0x0F,0x70,0x5D,0xE0,0x03,	// pshufw	MM3,-020h[EBP]
-0x66,	0x0F,0x73,0xF9,0x18,	// pslldq	XMM1,018h
-	0x0F,0xF1,0xCA,   	// psllw	MM1,MM2
-	0x0F,0xF1,0x4D,0xE0,	// psllw	MM1,-020h[EBP]
-0x66,	0x0F,0xF1,0xCA,   	// psllw	XMM1,XMM2
-0x66,	0x0F,0xF1,0x4D,0xE8,	// psllw	XMM1,-018h[EBP]
-	0x0F,0x71,0xF1,0x15,	// psraw	MM1,015h
-0x66,	0x0F,0x71,0xF1,0x15,	// psraw	XMM1,015h
-	0x0F,0xF2,0xCA,   	// pslld	MM1,MM2
-	0x0F,0xF2,0x4D,0xE0,	// pslld	MM1,-020h[EBP]
-0x66,	0x0F,0xF2,0xCA,   	// pslld	XMM1,XMM2
-0x66,	0x0F,0xF2,0x4D,0xE8,	// pslld	XMM1,-018h[EBP]
-	0x0F,0x72,0xF1,0x15,	// psrad	MM1,015h
-0x66,	0x0F,0x72,0xF1,0x15,	// psrad	XMM1,015h
-	0x0F,0xF3,0xCA,   	// psllq	MM1,MM2
-	0x0F,0xF3,0x4D,0xE0,	// psllq	MM1,-020h[EBP]
-0x66,	0x0F,0xF3,0xCA,   	// psllq	XMM1,XMM2
-0x66,	0x0F,0xF3,0x4D,0xE8,	// psllq	XMM1,-018h[EBP]
-	0x0F,0x73,0xF1,0x15,	// psllq	MM1,015h
-0x66,	0x0F,0x73,0xF1,0x15,	// psllq	XMM1,015h
-	0x0F,0xE1,0xCA,   	// psraw	MM1,MM2
-	0x0F,0xE1,0x4D,0xE0,	// psraw	MM1,-020h[EBP]
-0x66,	0x0F,0xE1,0xCA,   	// psraw	XMM1,XMM2
-0x66,	0x0F,0xE1,0x4D,0xE8,	// psraw	XMM1,-018h[EBP]
-	0x0F,0x71,0xE1,0x15,	// psraw	MM1,015h
-0x66,	0x0F,0x71,0xE1,0x15,	// psraw	XMM1,015h
-	0x0F,0xE2,0xCA,   	// psrad	MM1,MM2
-	0x0F,0xE2,0x4D,0xE0,	// psrad	MM1,-020h[EBP]
-0x66,	0x0F,0xE2,0xCA,   	// psrad	XMM1,XMM2
-0x66,	0x0F,0xE2,0x4D,0xE8,	// psrad	XMM1,-018h[EBP]
-	0x0F,0x72,0xE1,0x15,	// psrad	MM1,015h
-0x66,	0x0F,0x72,0xE1,0x15,	// psrad	XMM1,015h
-0x66,	0x0F,0x73,0xD9,0x18,	// psrldq	XMM1,018h
-	0x0F,0xD1,0xCA,   	// psrlw	MM1,MM2
-	0x0F,0xD1,0x4D,0xE0,	// psrlw	MM1,-020h[EBP]
-0x66,	0x0F,0xD1,0xCA,   	// psrlw	XMM1,XMM2
-0x66,	0x0F,0xD1,0x4D,0xE8,	// psrlw	XMM1,-018h[EBP]
-	0x0F,0x71,0xD1,0x15,	// psrlw	MM1,015h
-0x66,	0x0F,0x71,0xD1,0x15,	// psrlw	XMM1,015h
-	0x0F,0xD2,0xCA,   	// psrld	MM1,MM2
-	0x0F,0xD2,0x4D,0xE0,	// psrld	MM1,-020h[EBP]
-0x66,	0x0F,0xD2,0xCA,   	// psrld	XMM1,XMM2
-0x66,	0x0F,0xD2,0x4D,0xE8,	// psrld	XMM1,-018h[EBP]
-	0x0F,0x72,0xD1,0x15,	// psrld	MM1,015h
-0x66,	0x0F,0x72,0xD1,0x15,	// psrld	XMM1,015h
-	0x0F,0xD3,0xCA,   	// psrlq	MM1,MM2
-	0x0F,0xD3,0x4D,0xE0,	// psrlq	MM1,-020h[EBP]
-0x66,	0x0F,0xD3,0xCA,   	// psrlq	XMM1,XMM2
-0x66,	0x0F,0xD3,0x4D,0xE8,	// psrlq	XMM1,-018h[EBP]
-	0x0F,0x73,0xD1,0x15,	// psrlq	MM1,015h
-0x66,	0x0F,0x73,0xD1,0x15,	// psrlq	XMM1,015h
-	0x0F,0xF8,0xCA,   	// psubb	MM1,MM2
-	0x0F,0xF8,0x4D,0xE0,	// psubb	MM1,-020h[EBP]
-0x66,	0x0F,0xF8,0xCA,   	// psubb	XMM1,XMM2
-0x66,	0x0F,0xF8,0x4D,0xE8,	// psubb	XMM1,-018h[EBP]
-	0x0F,0xF9,0xCA,   	// psubw	MM1,MM2
-	0x0F,0xF9,0x4D,0xE0,	// psubw	MM1,-020h[EBP]
-0x66,	0x0F,0xF9,0xCA,   	// psubw	XMM1,XMM2
-0x66,	0x0F,0xF9,0x4D,0xE8,	// psubw	XMM1,-018h[EBP]
-	0x0F,0xFA,0xCA,   	// psubd	MM1,MM2
-	0x0F,0xFA,0x4D,0xE0,	// psubd	MM1,-020h[EBP]
-0x66,	0x0F,0xFA,0xCA,   	// psubd	XMM1,XMM2
-0x66,	0x0F,0xFA,0x4D,0xE8,	// psubd	XMM1,-018h[EBP]
-	0x0F,0xFB,0xCA,   	// psubq	MM1,MM2
-	0x0F,0xFB,0x4D,0xE0,	// psubq	MM1,-020h[EBP]
-0x66,	0x0F,0xFB,0xCA,   	// psubq	XMM1,XMM2
-0x66,	0x0F,0xFB,0x4D,0xE8,	// psubq	XMM1,-018h[EBP]
-	0x0F,0xE8,0xCA,   	// psubsb	MM1,MM2
-	0x0F,0xE8,0x4D,0xE0,	// psubsb	MM1,-020h[EBP]
-0x66,	0x0F,0xE8,0xCA,   	// psubsb	XMM1,XMM2
-0x66,	0x0F,0xE8,0x4D,0xE8,	// psubsb	XMM1,-018h[EBP]
-	0x0F,0xE9,0xCA,   	// psubsw	MM1,MM2
-	0x0F,0xE9,0x4D,0xE0,	// psubsw	MM1,-020h[EBP]
-0x66,	0x0F,0xE9,0xCA,   	// psubsw	XMM1,XMM2
-0x66,	0x0F,0xE9,0x4D,0xE8,	// psubsw	XMM1,-018h[EBP]
-	0x0F,0xD8,0xCA,   	// psubusb	MM1,MM2
-	0x0F,0xD8,0x4D,0xE0,	// psubusb	MM1,-020h[EBP]
-0x66,	0x0F,0xD8,0xCA,   	// psubusb	XMM1,XMM2
-0x66,	0x0F,0xD8,0x4D,0xE8,	// psubusb	XMM1,-018h[EBP]
-	0x0F,0xD9,0xCA,   	// psubusw	MM1,MM2
-	0x0F,0xD9,0x4D,0xE0,	// psubusw	MM1,-020h[EBP]
-0x66,	0x0F,0xD9,0xCA,   	// psubusw	XMM1,XMM2
-0x66,	0x0F,0xD9,0x4D,0xE8,	// psubusw	XMM1,-018h[EBP]
-	0x0F,0x68,0xCA,   	// punpckhbw	MM1,MM2
-	0x0F,0x68,0x4D,0xE0,	// punpckhbw	MM1,-020h[EBP]
-0x66,	0x0F,0x68,0xCA,   	// punpckhbw	XMM1,XMM2
-0x66,	0x0F,0x68,0x4D,0xE8,	// punpckhbw	XMM1,-018h[EBP]
-	0x0F,0x69,0xCA,   	// punpckhwd	MM1,MM2
-	0x0F,0x69,0x4D,0xE0,	// punpckhwd	MM1,-020h[EBP]
-0x66,	0x0F,0x69,0xCA,   	// punpckhwd	XMM1,XMM2
-0x66,	0x0F,0x69,0x4D,0xE8,	// punpckhwd	XMM1,-018h[EBP]
-	0x0F,0x6A,0xCA,   	// punpckhdq	MM1,MM2
-	0x0F,0x6A,0x4D,0xE0,	// punpckhdq	MM1,-020h[EBP]
-0x66,	0x0F,0x6A,0xCA,   	// punpckhdq	XMM1,XMM2
-0x66,	0x0F,0x6A,0x4D,0xE8,	// punpckhdq	XMM1,-018h[EBP]
-0x66,	0x0F,0x6D,0xCA,   	// punpckhqdq	XMM1,XMM2
-0x66,	0x0F,0x6D,0x4D,0xE8,	// punpckhqdq	XMM1,-018h[EBP]
-	0x0F,0x60,0xCA,   	// punpcklbw	MM1,MM2
-	0x0F,0x60,0x4D,0xE0,	// punpcklbw	MM1,-020h[EBP]
-0x66,	0x0F,0x60,0xCA,   	// punpcklbw	XMM1,XMM2
-0x66,	0x0F,0x60,0x4D,0xE8,	// punpcklbw	XMM1,-018h[EBP]
-	0x0F,0x61,0xCA,   	// punpcklwd	MM1,MM2
-	0x0F,0x61,0x4D,0xE0,	// punpcklwd	MM1,-020h[EBP]
-0x66,	0x0F,0x61,0xCA,   	// punpcklwd	XMM1,XMM2
-0x66,	0x0F,0x61,0x4D,0xE8,	// punpcklwd	XMM1,-018h[EBP]
-	0x0F,0x62,0xCA,   	// punpckldq	MM1,MM2
-	0x0F,0x62,0x4D,0xE0,	// punpckldq	MM1,-020h[EBP]
-0x66,	0x0F,0x62,0xCA,   	// punpckldq	XMM1,XMM2
-0x66,	0x0F,0x62,0x4D,0xE8,	// punpckldq	XMM1,-018h[EBP]
-0x66,	0x0F,0x6C,0xCA,   	// punpcklqdq	XMM1,XMM2
-0x66,	0x0F,0x6C,0x4D,0xE8,	// punpcklqdq	XMM1,-018h[EBP]
-	0x0F,0xEF,0xCA,   	// pxor	MM1,MM2
-	0x0F,0xEF,0x4D,0xE0,	// pxor	MM1,-020h[EBP]
-0x66,	0x0F,0xEF,0xCA,   	// pxor	XMM1,XMM2
-0x66,	0x0F,0xEF,0x4D,0xE8,	// pxor	XMM1,-018h[EBP]
-	0x0F,0x53,0xCA,   	// rcpps	XMM1,XMM2
-	0x0F,0x53,0x4D,0xE8,	// rcpps	XMM1,-018h[EBP]
-	0xF3,0x0F,0x53,0xCA,	// rcpss	XMM1,XMM2
-	0xF3,0x0F,0x53,0x4D,0xDC,	// rcpss	XMM1,-024h[EBP]
-	0x0F,0x52,0xCA,   	// rsqrtps	XMM1,XMM2
-	0x0F,0x52,0x4D,0xE8,	// rsqrtps	XMM1,-018h[EBP]
-	0xF3,0x0F,0x52,0xCA,	// rsqrtss	XMM1,XMM2
-	0xF3,0x0F,0x52,0x4D,0xDC,	// rsqrtss	XMM1,-024h[EBP]
-0x66,	0x0F,0xC6,0xCA,0x03,	// shufpd	XMM1,XMM2,3
-0x66,	0x0F,0xC6,0x4D,0xE8,0x04,	// shufpd	XMM1,-018h[EBP],4
-	0x0F,0xC6,0xCA,0x03,	// shufps	XMM1,XMM2,3
-	0x0F,0xC6,0x4D,0xE8,0x04,	// shufps	XMM1,-018h[EBP],4
-0x66,	0x0F,0x2E,0xE6,   	// ucimisd	XMM4,XMM6
-0x66,	0x0F,0x2E,0x6D,0xE0,	// ucimisd	XMM5,-020h[EBP]
-	0x0F,0x2E,0xF7,   	// ucomiss	XMM6,XMM7
-	0x0F,0x2E,0x7D,0xDC,	// ucomiss	XMM7,-024h[EBP]
-0x66,	0x0F,0x15,0xE6,   	// uppckhpd	XMM4,XMM6
-0x66,	0x0F,0x15,0x6D,0xE8,	// uppckhpd	XMM5,-018h[EBP]
-	0x0F,0x15,0xE6,   	// unpckhps	XMM4,XMM6
-	0x0F,0x15,0x6D,0xE8,	// unpckhps	XMM5,-018h[EBP]
-0x66,	0x0F,0x14,0xE6,   	// uppcklpd	XMM4,XMM6
-0x66,	0x0F,0x14,0x6D,0xE8,	// uppcklpd	XMM5,-018h[EBP]
-	0x0F,0x14,0xE6,   	// unpcklps	XMM4,XMM6
-	0x0F,0x14,0x6D,0xE8,	// unpcklps	XMM5,-018h[EBP]
-0x66,	0x0F,0x57,0xCA,   	// xorpd	XMM1,XMM2
-0x66,	0x0F,0x57,0x4D,0xE8,	// xorpd	XMM1,-018h[EBP]
-	0x0F,0x57,0xCA,   	// xorps	XMM1,XMM2
-	0x0F,0x57,0x4D,0xE8,	// xorps	XMM1,-018h[EBP]
+0x66,   0x0F,0x50,0xF3,     // movmskpd ESI,XMM3
+    0x0F,0x50,0xF3,     // movmskps ESI,XMM3
+0x66,   0x0F,0xE7,0x55,0xE8,    // movntdq  -018h[EBP],XMM2
+    0x0F,0xC3,0x4D,0xDC,    // movnti   -024h[EBP],ECX
+0x66,   0x0F,0x2B,0x5D,0xE8,    // movntpd  -018h[EBP],XMM3
+    0x0F,0x2B,0x65,0xE8,    // movntps  -018h[EBP],XMM4
+    0x0F,0xE7,0x6D,0xE0,    // movntq   -020h[EBP],MM5
+    0x0F,0x6F,0xCA,     // movq MM1,MM2
+    0x0F,0x6F,0x55,0xE0,    // movq MM2,-020h[EBP]
+    0x0F,0x7F,0x5D,0xE0,    // movq -020h[EBP],MM3
+    0xF3,0x0F,0x7E,0xCA,    // movq XMM1,XMM2
+    0xF3,0x0F,0x7E,0x55,0xE0,   // movq XMM2,-020h[EBP]
+0x66,   0x0F,0xD6,0x5D,0xE0,    // movq -020h[EBP],XMM3
+    0xF3,0x0F,0xD6,0xDA,    // movq2dq  XMM3,MM2
+    0xA5,           // movsd
+    0xF2,0x0F,0x10,0xCA,    // movsd    XMM1,XMM2
+    0xF2,0x0F,0x10,0x5D,0xE0,   // movsd    XMM3,-020h[EBP]
+    0xF2,0x0F,0x11,0x65,0xE0,   // movsd    -020h[EBP],XMM4
+    0xF3,0x0F,0x10,0xCA,    // movss    XMM1,XMM2
+    0xF3,0x0F,0x10,0x5D,0xDC,   // movss    XMM3,-024h[EBP]
+    0xF3,0x0F,0x11,0x65,0xDC,   // movss    -024h[EBP],XMM4
+0x66,   0x0F,0x10,0xCA,     // movupd   XMM1,XMM2
+0x66,   0x0F,0x10,0x5D,0xE8,    // movupd   XMM3,-018h[EBP]
+0x66,   0x0F,0x11,0x65,0xE8,    // movupd   -018h[EBP],XMM4
+    0x0F,0x10,0xCA,     // movups   XMM1,XMM2
+    0x0F,0x10,0x5D,0xE8,    // movups   XMM3,-018h[EBP]
+    0x0F,0x11,0x65,0xE8,    // movups   -018h[EBP],XMM4
+0x66,   0x0F,0x56,0xCA,     // orpd XMM1,XMM2
+0x66,   0x0F,0x56,0x5D,0xE8,    // orpd XMM3,-018h[EBP]
+    0x0F,0x56,0xCA,     // orps XMM1,XMM2
+    0x0F,0x56,0x5D,0xE8,    // orps XMM3,-018h[EBP]
+    0x0F,0x63,0xCA,     // packsswb MM1,MM2
+    0x0F,0x63,0x5D,0xE0,    // packsswb MM3,-020h[EBP]
+0x66,   0x0F,0x63,0xCA,     // packsswb XMM1,XMM2
+0x66,   0x0F,0x63,0x5D,0xE8,    // packsswb XMM3,-018h[EBP]
+    0x0F,0x6B,0xCA,     // packssdw MM1,MM2
+    0x0F,0x6B,0x5D,0xE0,    // packssdw MM3,-020h[EBP]
+0x66,   0x0F,0x6B,0xCA,     // packssdw XMM1,XMM2
+0x66,   0x0F,0x6B,0x5D,0xE8,    // packssdw XMM3,-018h[EBP]
+    0x0F,0x67,0xCA,     // packuswb MM1,MM2
+    0x0F,0x67,0x5D,0xE0,    // packuswb MM3,-020h[EBP]
+0x66,   0x0F,0x67,0xCA,     // packuswb XMM1,XMM2
+0x66,   0x0F,0x67,0x5D,0xE8,    // packuswb XMM3,-018h[EBP]
+    0x0F,0xFC,0xCA,     // paddb    MM1,MM2
+    0x0F,0xFC,0x5D,0xE0,    // paddb    MM3,-020h[EBP]
+0x66,   0x0F,0xFC,0xCA,     // paddb    XMM1,XMM2
+0x66,   0x0F,0xFC,0x5D,0xE8,    // paddb    XMM3,-018h[EBP]
+    0x0F,0xFD,0xCA,     // paddw    MM1,MM2
+    0x0F,0xFD,0x5D,0xE0,    // paddw    MM3,-020h[EBP]
+0x66,   0x0F,0xFD,0xCA,     // paddw    XMM1,XMM2
+0x66,   0x0F,0xFD,0x5D,0xE8,    // paddw    XMM3,-018h[EBP]
+    0x0F,0xFE,0xCA,     // paddd    MM1,MM2
+    0x0F,0xFE,0x5D,0xE0,    // paddd    MM3,-020h[EBP]
+0x66,   0x0F,0xFE,0xCA,     // paddd    XMM1,XMM2
+0x66,   0x0F,0xFE,0x5D,0xE8,    // paddd    XMM3,-018h[EBP]
+    0x0F,0xD4,0xCA,     // paddq    MM1,MM2
+    0x0F,0xD4,0x5D,0xE0,    // paddq    MM3,-020h[EBP]
+0x66,   0x0F,0xD4,0xCA,     // paddq    XMM1,XMM2
+0x66,   0x0F,0xD4,0x5D,0xE8,    // paddq    XMM3,-018h[EBP]
+    0x0F,0xEC,0xCA,     // paddsb   MM1,MM2
+    0x0F,0xEC,0x5D,0xE0,    // paddsb   MM3,-020h[EBP]
+0x66,   0x0F,0xEC,0xCA,     // paddsb   XMM1,XMM2
+0x66,   0x0F,0xEC,0x5D,0xE8,    // paddsb   XMM3,-018h[EBP]
+    0x0F,0xED,0xCA,     // paddsw   MM1,MM2
+    0x0F,0xED,0x5D,0xE0,    // paddsw   MM3,-020h[EBP]
+0x66,   0x0F,0xED,0xCA,     // paddsw   XMM1,XMM2
+0x66,   0x0F,0xED,0x5D,0xE8,    // paddsw   XMM3,-018h[EBP]
+    0x0F,0xDC,0xCA,     // paddusb  MM1,MM2
+    0x0F,0xDC,0x5D,0xE0,    // paddusb  MM3,-020h[EBP]
+0x66,   0x0F,0xDC,0xCA,     // paddusb  XMM1,XMM2
+0x66,   0x0F,0xDC,0x5D,0xE8,    // paddusb  XMM3,-018h[EBP]
+    0x0F,0xDD,0xCA,     // paddusw  MM1,MM2
+    0x0F,0xDD,0x5D,0xE0,    // paddusw  MM3,-020h[EBP]
+0x66,   0x0F,0xDD,0xCA,     // paddusw  XMM1,XMM2
+0x66,   0x0F,0xDD,0x5D,0xE8,    // paddusw  XMM3,-018h[EBP]
+    0x0F,0xDB,0xCA,     // pand MM1,MM2
+    0x0F,0xDB,0x5D,0xE0,    // pand MM3,-020h[EBP]
+0x66,   0x0F,0xDB,0xCA,     // pand XMM1,XMM2
+0x66,   0x0F,0xDB,0x5D,0xE8,    // pand XMM3,-018h[EBP]
+    0x0F,0xDF,0xCA,     // pandn    MM1,MM2
+    0x0F,0xDF,0x5D,0xE0,    // pandn    MM3,-020h[EBP]
+0x66,   0x0F,0xDF,0xCA,     // pandn    XMM1,XMM2
+0x66,   0x0F,0xDF,0x5D,0xE8,    // pandn    XMM3,-018h[EBP]
+    0x0F,0xE0,0xCA,     // pavgb    MM1,MM2
+    0x0F,0xE0,0x5D,0xE0,    // pavgb    MM3,-020h[EBP]
+0x66,   0x0F,0xE0,0xCA,     // pavgb    XMM1,XMM2
+0x66,   0x0F,0xE0,0x5D,0xE8,    // pavgb    XMM3,-018h[EBP]
+    0x0F,0xE3,0xCA,     // pavgw    MM1,MM2
+    0x0F,0xE3,0x5D,0xE0,    // pavgw    MM3,-020h[EBP]
+0x66,   0x0F,0xE3,0xCA,     // pavgw    XMM1,XMM2
+0x66,   0x0F,0xE3,0x5D,0xE8,    // pavgw    XMM3,-018h[EBP]
+    0x0F,0x74,0xCA,     // pcmpeqb  MM1,MM2
+    0x0F,0x74,0x5D,0xE0,    // pcmpeqb  MM3,-020h[EBP]
+0x66,   0x0F,0x74,0xCA,     // pcmpeqb  XMM1,XMM2
+0x66,   0x0F,0x74,0x5D,0xE8,    // pcmpeqb  XMM3,-018h[EBP]
+    0x0F,0x75,0xCA,     // pcmpeqw  MM1,MM2
+    0x0F,0x75,0x5D,0xE0,    // pcmpeqw  MM3,-020h[EBP]
+0x66,   0x0F,0x75,0xCA,     // pcmpeqw  XMM1,XMM2
+0x66,   0x0F,0x75,0x5D,0xE8,    // pcmpeqw  XMM3,-018h[EBP]
+    0x0F,0x76,0xCA,     // pcmpeqd  MM1,MM2
+    0x0F,0x76,0x5D,0xE0,    // pcmpeqd  MM3,-020h[EBP]
+0x66,   0x0F,0x76,0xCA,     // pcmpeqd  XMM1,XMM2
+0x66,   0x0F,0x76,0x5D,0xE8,    // pcmpeqd  XMM3,-018h[EBP]
+    0x0F,0x64,0xCA,     // pcmpgtb  MM1,MM2
+    0x0F,0x64,0x5D,0xE0,    // pcmpgtb  MM3,-020h[EBP]
+0x66,   0x0F,0x64,0xCA,     // pcmpgtb  XMM1,XMM2
+0x66,   0x0F,0x64,0x5D,0xE8,    // pcmpgtb  XMM3,-018h[EBP]
+    0x0F,0x65,0xCA,     // pcmpgtw  MM1,MM2
+    0x0F,0x65,0x5D,0xE0,    // pcmpgtw  MM3,-020h[EBP]
+0x66,   0x0F,0x65,0xCA,     // pcmpgtw  XMM1,XMM2
+0x66,   0x0F,0x65,0x5D,0xE8,    // pcmpgtw  XMM3,-018h[EBP]
+    0x0F,0x66,0xCA,     // pcmpgtd  MM1,MM2
+    0x0F,0x66,0x5D,0xE0,    // pcmpgtd  MM3,-020h[EBP]
+0x66,   0x0F,0x66,0xCA,     // pcmpgtd  XMM1,XMM2
+0x66,   0x0F,0x66,0x5D,0xE8,    // pcmpgtd  XMM3,-018h[EBP]
+    0x0F,0xC5,0xD6,0x07,    // pextrw   EDX,MM6,7
+0x66,   0x0F,0xC5,0xD6,0x07,    // pextrw   EDX,XMM6,7
+    0x0F,0xC4,0xF2,0x07,    // pinsrw   MM6,EDX,7
+    0x0F,0xC4,0x75,0xDA,0x07,   // pinsrw   MM6,-026h[EBP],7
+0x66,   0x0F,0xC4,0xF2,0x07,    // pinsrw   XMM6,EDX,7
+0x66,   0x0F,0xC4,0x75,0xDA,0x07,   // pinsrw   XMM6,-026h[EBP],7
+    0x0F,0xF5,0xCA,     // pmaddwd  MM1,MM2
+    0x0F,0xF5,0x5D,0xE0,    // pmaddwd  MM3,-020h[EBP]
+0x66,   0x0F,0xF5,0xCA,     // pmaddwd  XMM1,XMM2
+0x66,   0x0F,0xF5,0x5D,0xE8,    // pmaddwd  XMM3,-018h[EBP]
+    0x0F,0xEE,0xCA,     // pmaxsw   MM1,XMM2
+    0x0F,0xEE,0x5D,0xE0,    // pmaxsw   MM3,-020h[EBP]
+0x66,   0x0F,0xEE,0xCA,     // pmaxsw   XMM1,XMM2
+0x66,   0x0F,0xEE,0x5D,0xE8,    // pmaxsw   XMM3,-018h[EBP]
+    0x0F,0xDE,0xCA,     // pmaxub   MM1,XMM2
+    0x0F,0xDE,0x5D,0xE0,    // pmaxub   MM3,-020h[EBP]
+0x66,   0x0F,0xDE,0xCA,     // pmaxub   XMM1,XMM2
+0x66,   0x0F,0xDE,0x5D,0xE8,    // pmaxub   XMM3,-018h[EBP]
+    0x0F,0xEA,0xCA,     // pminsw   MM1,MM2
+    0x0F,0xEA,0x5D,0xE0,    // pminsw   MM3,-020h[EBP]
+0x66,   0x0F,0xEA,0xCA,     // pminsw   XMM1,XMM2
+0x66,   0x0F,0xEA,0x5D,0xE8,    // pminsw   XMM3,-018h[EBP]
+    0x0F,0xDA,0xCA,     // pminub   MM1,MM2
+    0x0F,0xDA,0x5D,0xE0,    // pminub   MM3,-020h[EBP]
+0x66,   0x0F,0xDA,0xCA,     // pminub   XMM1,XMM2
+0x66,   0x0F,0xDA,0x5D,0xE8,    // pminub   XMM3,-018h[EBP]
+    0x0F,0xD7,0xC8,     // pmovmskb ECX,MM0
+0x66,   0x0F,0xD7,0xCE,     // pmovmskb ECX,XMM6
+    0x0F,0xE4,0xCA,     // pmulhuw  MM1,MM2
+    0x0F,0xE4,0x5D,0xE0,    // pmulhuw  MM3,-020h[EBP]
+0x66,   0x0F,0xE4,0xCA,     // pmulhuw  XMM1,XMM2
+0x66,   0x0F,0xE4,0x5D,0xE8,    // pmulhuw  XMM3,-018h[EBP]
+    0x0F,0xE5,0xCA,     // pmulhw   MM1,MM2
+    0x0F,0xE5,0x5D,0xE0,    // pmulhw   MM3,-020h[EBP]
+0x66,   0x0F,0xE5,0xCA,     // pmulhw   XMM1,XMM2
+0x66,   0x0F,0xE5,0x5D,0xE8,    // pmulhw   XMM3,-018h[EBP]
+    0x0F,0xD5,0xCA,     // pmullw   MM1,MM2
+    0x0F,0xD5,0x5D,0xE0,    // pmullw   MM3,-020h[EBP]
+0x66,   0x0F,0xD5,0xCA,     // pmullw   XMM1,XMM2
+0x66,   0x0F,0xD5,0x5D,0xE8,    // pmullw   XMM3,-018h[EBP]
+    0x0F,0xF4,0xCA,     // pmuludq  MM1,MM2
+    0x0F,0xF4,0x5D,0xE0,    // pmuludq  MM3,-020h[EBP]
+0x66,   0x0F,0xF4,0xCA,     // pmuludq  XMM1,XMM2
+0x66,   0x0F,0xF4,0x5D,0xE8,    // pmuludq  XMM3,-018h[EBP]
+    0x0F,0xEB,0xCA,     // por  MM1,MM2
+    0x0F,0xEB,0x5D,0xE0,    // por  MM3,-020h[EBP]
+0x66,   0x0F,0xEB,0xCA,     // por  XMM1,XMM2
+0x66,   0x0F,0xEB,0x5D,0xE8,    // por  XMM3,-018h[EBP]
+    0x0F,0x18,0x4D,0xD8,    // prefetcht0   -028h[EBP]
+    0x0F,0x18,0x55,0xD8,    // prefetcht1   -028h[EBP]
+    0x0F,0x18,0x5D,0xD8,    // prefetcht2   -028h[EBP]
+    0x0F,0x18,0x45,0xD8,    // prefetchnta  -028h[EBP]
+    0x0F,0xF6,0xCA,     // psadbw   MM1,MM2
+    0x0F,0xF6,0x5D,0xE0,    // psadbw   MM3,-020h[EBP]
+0x66,   0x0F,0xF6,0xCA,     // psadbw   XMM1,XMM2
+0x66,   0x0F,0xF6,0x5D,0xE8,    // psadbw   XMM3,-018h[EBP]
+0x66,   0x0F,0x70,0xCA,0x03,    // pshufd   XMM1,XMM2
+0x66,   0x0F,0x70,0x5D,0xE8,0x03,   // pshufd   XMM3,-018h[EBP]
+    0xF3,0x0F,0x70,0xCA,0x03,   // pshufhw  XMM1,XMM2
+    0xF3,0x0F,0x70,0x5D,0xE8,0x03,  // pshufhw  XMM3,-018h[EBP]
+    0xF2,0x0F,0x70,0xCA,0x03,   // pshuflw  XMM1,XMM2
+    0xF2,0x0F,0x70,0x5D,0xE8,0x03,  // pshuflw  XMM3,-018h[EBP]
+    0x0F,0x70,0xCA,0x03,    // pshufw   MM1,MM2
+    0x0F,0x70,0x5D,0xE0,0x03,   // pshufw   MM3,-020h[EBP]
+0x66,   0x0F,0x73,0xF9,0x18,    // pslldq   XMM1,018h
+    0x0F,0xF1,0xCA,     // psllw    MM1,MM2
+    0x0F,0xF1,0x4D,0xE0,    // psllw    MM1,-020h[EBP]
+0x66,   0x0F,0xF1,0xCA,     // psllw    XMM1,XMM2
+0x66,   0x0F,0xF1,0x4D,0xE8,    // psllw    XMM1,-018h[EBP]
+    0x0F,0x71,0xF1,0x15,    // psraw    MM1,015h
+0x66,   0x0F,0x71,0xF1,0x15,    // psraw    XMM1,015h
+    0x0F,0xF2,0xCA,     // pslld    MM1,MM2
+    0x0F,0xF2,0x4D,0xE0,    // pslld    MM1,-020h[EBP]
+0x66,   0x0F,0xF2,0xCA,     // pslld    XMM1,XMM2
+0x66,   0x0F,0xF2,0x4D,0xE8,    // pslld    XMM1,-018h[EBP]
+    0x0F,0x72,0xF1,0x15,    // psrad    MM1,015h
+0x66,   0x0F,0x72,0xF1,0x15,    // psrad    XMM1,015h
+    0x0F,0xF3,0xCA,     // psllq    MM1,MM2
+    0x0F,0xF3,0x4D,0xE0,    // psllq    MM1,-020h[EBP]
+0x66,   0x0F,0xF3,0xCA,     // psllq    XMM1,XMM2
+0x66,   0x0F,0xF3,0x4D,0xE8,    // psllq    XMM1,-018h[EBP]
+    0x0F,0x73,0xF1,0x15,    // psllq    MM1,015h
+0x66,   0x0F,0x73,0xF1,0x15,    // psllq    XMM1,015h
+    0x0F,0xE1,0xCA,     // psraw    MM1,MM2
+    0x0F,0xE1,0x4D,0xE0,    // psraw    MM1,-020h[EBP]
+0x66,   0x0F,0xE1,0xCA,     // psraw    XMM1,XMM2
+0x66,   0x0F,0xE1,0x4D,0xE8,    // psraw    XMM1,-018h[EBP]
+    0x0F,0x71,0xE1,0x15,    // psraw    MM1,015h
+0x66,   0x0F,0x71,0xE1,0x15,    // psraw    XMM1,015h
+    0x0F,0xE2,0xCA,     // psrad    MM1,MM2
+    0x0F,0xE2,0x4D,0xE0,    // psrad    MM1,-020h[EBP]
+0x66,   0x0F,0xE2,0xCA,     // psrad    XMM1,XMM2
+0x66,   0x0F,0xE2,0x4D,0xE8,    // psrad    XMM1,-018h[EBP]
+    0x0F,0x72,0xE1,0x15,    // psrad    MM1,015h
+0x66,   0x0F,0x72,0xE1,0x15,    // psrad    XMM1,015h
+0x66,   0x0F,0x73,0xD9,0x18,    // psrldq   XMM1,018h
+    0x0F,0xD1,0xCA,     // psrlw    MM1,MM2
+    0x0F,0xD1,0x4D,0xE0,    // psrlw    MM1,-020h[EBP]
+0x66,   0x0F,0xD1,0xCA,     // psrlw    XMM1,XMM2
+0x66,   0x0F,0xD1,0x4D,0xE8,    // psrlw    XMM1,-018h[EBP]
+    0x0F,0x71,0xD1,0x15,    // psrlw    MM1,015h
+0x66,   0x0F,0x71,0xD1,0x15,    // psrlw    XMM1,015h
+    0x0F,0xD2,0xCA,     // psrld    MM1,MM2
+    0x0F,0xD2,0x4D,0xE0,    // psrld    MM1,-020h[EBP]
+0x66,   0x0F,0xD2,0xCA,     // psrld    XMM1,XMM2
+0x66,   0x0F,0xD2,0x4D,0xE8,    // psrld    XMM1,-018h[EBP]
+    0x0F,0x72,0xD1,0x15,    // psrld    MM1,015h
+0x66,   0x0F,0x72,0xD1,0x15,    // psrld    XMM1,015h
+    0x0F,0xD3,0xCA,     // psrlq    MM1,MM2
+    0x0F,0xD3,0x4D,0xE0,    // psrlq    MM1,-020h[EBP]
+0x66,   0x0F,0xD3,0xCA,     // psrlq    XMM1,XMM2
+0x66,   0x0F,0xD3,0x4D,0xE8,    // psrlq    XMM1,-018h[EBP]
+    0x0F,0x73,0xD1,0x15,    // psrlq    MM1,015h
+0x66,   0x0F,0x73,0xD1,0x15,    // psrlq    XMM1,015h
+    0x0F,0xF8,0xCA,     // psubb    MM1,MM2
+    0x0F,0xF8,0x4D,0xE0,    // psubb    MM1,-020h[EBP]
+0x66,   0x0F,0xF8,0xCA,     // psubb    XMM1,XMM2
+0x66,   0x0F,0xF8,0x4D,0xE8,    // psubb    XMM1,-018h[EBP]
+    0x0F,0xF9,0xCA,     // psubw    MM1,MM2
+    0x0F,0xF9,0x4D,0xE0,    // psubw    MM1,-020h[EBP]
+0x66,   0x0F,0xF9,0xCA,     // psubw    XMM1,XMM2
+0x66,   0x0F,0xF9,0x4D,0xE8,    // psubw    XMM1,-018h[EBP]
+    0x0F,0xFA,0xCA,     // psubd    MM1,MM2
+    0x0F,0xFA,0x4D,0xE0,    // psubd    MM1,-020h[EBP]
+0x66,   0x0F,0xFA,0xCA,     // psubd    XMM1,XMM2
+0x66,   0x0F,0xFA,0x4D,0xE8,    // psubd    XMM1,-018h[EBP]
+    0x0F,0xFB,0xCA,     // psubq    MM1,MM2
+    0x0F,0xFB,0x4D,0xE0,    // psubq    MM1,-020h[EBP]
+0x66,   0x0F,0xFB,0xCA,     // psubq    XMM1,XMM2
+0x66,   0x0F,0xFB,0x4D,0xE8,    // psubq    XMM1,-018h[EBP]
+    0x0F,0xE8,0xCA,     // psubsb   MM1,MM2
+    0x0F,0xE8,0x4D,0xE0,    // psubsb   MM1,-020h[EBP]
+0x66,   0x0F,0xE8,0xCA,     // psubsb   XMM1,XMM2
+0x66,   0x0F,0xE8,0x4D,0xE8,    // psubsb   XMM1,-018h[EBP]
+    0x0F,0xE9,0xCA,     // psubsw   MM1,MM2
+    0x0F,0xE9,0x4D,0xE0,    // psubsw   MM1,-020h[EBP]
+0x66,   0x0F,0xE9,0xCA,     // psubsw   XMM1,XMM2
+0x66,   0x0F,0xE9,0x4D,0xE8,    // psubsw   XMM1,-018h[EBP]
+    0x0F,0xD8,0xCA,     // psubusb  MM1,MM2
+    0x0F,0xD8,0x4D,0xE0,    // psubusb  MM1,-020h[EBP]
+0x66,   0x0F,0xD8,0xCA,     // psubusb  XMM1,XMM2
+0x66,   0x0F,0xD8,0x4D,0xE8,    // psubusb  XMM1,-018h[EBP]
+    0x0F,0xD9,0xCA,     // psubusw  MM1,MM2
+    0x0F,0xD9,0x4D,0xE0,    // psubusw  MM1,-020h[EBP]
+0x66,   0x0F,0xD9,0xCA,     // psubusw  XMM1,XMM2
+0x66,   0x0F,0xD9,0x4D,0xE8,    // psubusw  XMM1,-018h[EBP]
+    0x0F,0x68,0xCA,     // punpckhbw    MM1,MM2
+    0x0F,0x68,0x4D,0xE0,    // punpckhbw    MM1,-020h[EBP]
+0x66,   0x0F,0x68,0xCA,     // punpckhbw    XMM1,XMM2
+0x66,   0x0F,0x68,0x4D,0xE8,    // punpckhbw    XMM1,-018h[EBP]
+    0x0F,0x69,0xCA,     // punpckhwd    MM1,MM2
+    0x0F,0x69,0x4D,0xE0,    // punpckhwd    MM1,-020h[EBP]
+0x66,   0x0F,0x69,0xCA,     // punpckhwd    XMM1,XMM2
+0x66,   0x0F,0x69,0x4D,0xE8,    // punpckhwd    XMM1,-018h[EBP]
+    0x0F,0x6A,0xCA,     // punpckhdq    MM1,MM2
+    0x0F,0x6A,0x4D,0xE0,    // punpckhdq    MM1,-020h[EBP]
+0x66,   0x0F,0x6A,0xCA,     // punpckhdq    XMM1,XMM2
+0x66,   0x0F,0x6A,0x4D,0xE8,    // punpckhdq    XMM1,-018h[EBP]
+0x66,   0x0F,0x6D,0xCA,     // punpckhqdq   XMM1,XMM2
+0x66,   0x0F,0x6D,0x4D,0xE8,    // punpckhqdq   XMM1,-018h[EBP]
+    0x0F,0x60,0xCA,     // punpcklbw    MM1,MM2
+    0x0F,0x60,0x4D,0xE0,    // punpcklbw    MM1,-020h[EBP]
+0x66,   0x0F,0x60,0xCA,     // punpcklbw    XMM1,XMM2
+0x66,   0x0F,0x60,0x4D,0xE8,    // punpcklbw    XMM1,-018h[EBP]
+    0x0F,0x61,0xCA,     // punpcklwd    MM1,MM2
+    0x0F,0x61,0x4D,0xE0,    // punpcklwd    MM1,-020h[EBP]
+0x66,   0x0F,0x61,0xCA,     // punpcklwd    XMM1,XMM2
+0x66,   0x0F,0x61,0x4D,0xE8,    // punpcklwd    XMM1,-018h[EBP]
+    0x0F,0x62,0xCA,     // punpckldq    MM1,MM2
+    0x0F,0x62,0x4D,0xE0,    // punpckldq    MM1,-020h[EBP]
+0x66,   0x0F,0x62,0xCA,     // punpckldq    XMM1,XMM2
+0x66,   0x0F,0x62,0x4D,0xE8,    // punpckldq    XMM1,-018h[EBP]
+0x66,   0x0F,0x6C,0xCA,     // punpcklqdq   XMM1,XMM2
+0x66,   0x0F,0x6C,0x4D,0xE8,    // punpcklqdq   XMM1,-018h[EBP]
+    0x0F,0xEF,0xCA,     // pxor MM1,MM2
+    0x0F,0xEF,0x4D,0xE0,    // pxor MM1,-020h[EBP]
+0x66,   0x0F,0xEF,0xCA,     // pxor XMM1,XMM2
+0x66,   0x0F,0xEF,0x4D,0xE8,    // pxor XMM1,-018h[EBP]
+    0x0F,0x53,0xCA,     // rcpps    XMM1,XMM2
+    0x0F,0x53,0x4D,0xE8,    // rcpps    XMM1,-018h[EBP]
+    0xF3,0x0F,0x53,0xCA,    // rcpss    XMM1,XMM2
+    0xF3,0x0F,0x53,0x4D,0xDC,   // rcpss    XMM1,-024h[EBP]
+    0x0F,0x52,0xCA,     // rsqrtps  XMM1,XMM2
+    0x0F,0x52,0x4D,0xE8,    // rsqrtps  XMM1,-018h[EBP]
+    0xF3,0x0F,0x52,0xCA,    // rsqrtss  XMM1,XMM2
+    0xF3,0x0F,0x52,0x4D,0xDC,   // rsqrtss  XMM1,-024h[EBP]
+0x66,   0x0F,0xC6,0xCA,0x03,    // shufpd   XMM1,XMM2,3
+0x66,   0x0F,0xC6,0x4D,0xE8,0x04,   // shufpd   XMM1,-018h[EBP],4
+    0x0F,0xC6,0xCA,0x03,    // shufps   XMM1,XMM2,3
+    0x0F,0xC6,0x4D,0xE8,0x04,   // shufps   XMM1,-018h[EBP],4
+0x66,   0x0F,0x2E,0xE6,     // ucimisd  XMM4,XMM6
+0x66,   0x0F,0x2E,0x6D,0xE0,    // ucimisd  XMM5,-020h[EBP]
+    0x0F,0x2E,0xF7,     // ucomiss  XMM6,XMM7
+    0x0F,0x2E,0x7D,0xDC,    // ucomiss  XMM7,-024h[EBP]
+0x66,   0x0F,0x15,0xE6,     // uppckhpd XMM4,XMM6
+0x66,   0x0F,0x15,0x6D,0xE8,    // uppckhpd XMM5,-018h[EBP]
+    0x0F,0x15,0xE6,     // unpckhps XMM4,XMM6
+    0x0F,0x15,0x6D,0xE8,    // unpckhps XMM5,-018h[EBP]
+0x66,   0x0F,0x14,0xE6,     // uppcklpd XMM4,XMM6
+0x66,   0x0F,0x14,0x6D,0xE8,    // uppcklpd XMM5,-018h[EBP]
+    0x0F,0x14,0xE6,     // unpcklps XMM4,XMM6
+    0x0F,0x14,0x6D,0xE8,    // unpcklps XMM5,-018h[EBP]
+0x66,   0x0F,0x57,0xCA,     // xorpd    XMM1,XMM2
+0x66,   0x0F,0x57,0x4D,0xE8,    // xorpd    XMM1,-018h[EBP]
+    0x0F,0x57,0xCA,     // xorps    XMM1,XMM2
+    0x0F,0x57,0x4D,0xE8,    // xorps    XMM1,-018h[EBP]
     ];
     int i;
 
     asm
     {
-	call	L1			;
-
-	movmskpd ESI,XMM3		;
-	movmskps ESI,XMM3		;
-
-	movntdq	m128[EBP],XMM2		;
-	movnti	m32[EBP],ECX		;
-	movntpd	m128[EBP],XMM3		;
-	movntps	m128[EBP],XMM4		;
-	movntq	m64[EBP],MM5		;
-
-	movq	MM1,MM2			;
-	movq	MM2,m64[EBP]		;
-	movq	m64[EBP],MM3		;
-	movq	XMM1,XMM2		;
-	movq	XMM2,m64[EBP]		;
-	movq	m64[EBP],XMM3		;
-
-	movq2dq	XMM3,MM2		;
-
-	movsd				;
-	movsd	XMM1,XMM2		;
-	movsd	XMM3,m64[EBP]		;
-	movsd	m64[EBP],XMM4		;
-
-	movss	XMM1,XMM2		;
-	movss	XMM3,m32[EBP]		;
-	movss	m32[EBP],XMM4		;
-
-	movupd	XMM1,XMM2		;
-	movupd	XMM3,m128[EBP]		;
-	movupd	m128[EBP],XMM4		;
-
-	movups	XMM1,XMM2		;
-	movups	XMM3,m128[EBP]		;
-	movups	m128[EBP],XMM4		;
-
-	orpd	XMM1,XMM2		;
-	orpd	XMM3,m128[EBP]		;
-	orps	XMM1,XMM2		;
-	orps	XMM3,m128[EBP]		;
-
-	packsswb MM1,MM2		;
-	packsswb MM3,m64[EBP]		;
-	packsswb XMM1,XMM2		;
-	packsswb XMM3,m128[EBP]		;
-
-	packssdw MM1,MM2		;
-	packssdw MM3,m64[EBP]		;
-	packssdw XMM1,XMM2		;
-	packssdw XMM3,m128[EBP]		;
-
-	packuswb MM1,MM2		;
-	packuswb MM3,m64[EBP]		;
-	packuswb XMM1,XMM2		;
-	packuswb XMM3,m128[EBP]		;
-
-	paddb	MM1,MM2			;
-	paddb	MM3,m64[EBP]		;
-	paddb	XMM1,XMM2		;
-	paddb	XMM3,m128[EBP]		;
-
-	paddw	MM1,MM2			;
-	paddw	MM3,m64[EBP]		;
-	paddw	XMM1,XMM2		;
-	paddw	XMM3,m128[EBP]		;
-
-	paddd	MM1,MM2			;
-	paddd	MM3,m64[EBP]		;
-	paddd	XMM1,XMM2		;
-	paddd	XMM3,m128[EBP]		;
-
-	paddq	MM1,MM2			;
-	paddq	MM3,m64[EBP]		;
-	paddq	XMM1,XMM2		;
-	paddq	XMM3,m128[EBP]		;
-
-	paddsb	MM1,MM2			;
-	paddsb	MM3,m64[EBP]		;
-	paddsb	XMM1,XMM2		;
-	paddsb	XMM3,m128[EBP]		;
-
-	paddsw	MM1,MM2			;
-	paddsw	MM3,m64[EBP]		;
-	paddsw	XMM1,XMM2		;
-	paddsw	XMM3,m128[EBP]		;
-
-	paddusb	MM1,MM2			;
-	paddusb	MM3,m64[EBP]		;
-	paddusb	XMM1,XMM2		;
-	paddusb	XMM3,m128[EBP]		;
-
-	paddusw	MM1,MM2			;
-	paddusw	MM3,m64[EBP]		;
-	paddusw	XMM1,XMM2		;
-	paddusw	XMM3,m128[EBP]		;
-
-	pand	MM1,MM2			;
-	pand	MM3,m64[EBP]		;
-	pand	XMM1,XMM2		;
-	pand	XMM3,m128[EBP]		;
-
-	pandn	MM1,MM2			;
-	pandn	MM3,m64[EBP]		;
-	pandn	XMM1,XMM2		;
-	pandn	XMM3,m128[EBP]		;
-
-	pavgb	MM1,MM2			;
-	pavgb	MM3,m64[EBP]		;
-	pavgb	XMM1,XMM2		;
-	pavgb	XMM3,m128[EBP]		;
-
-	pavgw	MM1,MM2			;
-	pavgw	MM3,m64[EBP]		;
-	pavgw	XMM1,XMM2		;
-	pavgw	XMM3,m128[EBP]		;
-
-	pcmpeqb	MM1,MM2			;
-	pcmpeqb	MM3,m64[EBP]		;
-	pcmpeqb	XMM1,XMM2		;
-	pcmpeqb	XMM3,m128[EBP]		;
-
-	pcmpeqw	MM1,MM2			;
-	pcmpeqw	MM3,m64[EBP]		;
-	pcmpeqw	XMM1,XMM2		;
-	pcmpeqw	XMM3,m128[EBP]		;
-
-	pcmpeqd	MM1,MM2			;
-	pcmpeqd	MM3,m64[EBP]		;
-	pcmpeqd	XMM1,XMM2		;
-	pcmpeqd	XMM3,m128[EBP]		;
-
-	pcmpgtb	MM1,MM2			;
-	pcmpgtb	MM3,m64[EBP]		;
-	pcmpgtb	XMM1,XMM2		;
-	pcmpgtb	XMM3,m128[EBP]		;
-
-	pcmpgtw	MM1,MM2			;
-	pcmpgtw	MM3,m64[EBP]		;
-	pcmpgtw	XMM1,XMM2		;
-	pcmpgtw	XMM3,m128[EBP]		;
-
-	pcmpgtd	MM1,MM2			;
-	pcmpgtd	MM3,m64[EBP]		;
-	pcmpgtd	XMM1,XMM2		;
-	pcmpgtd	XMM3,m128[EBP]		;
-
-	pextrw	EDX,MM6,7		;
-	pextrw	EDX,XMM6,7		;
-
-	pinsrw	MM6,EDX,7		;
-	pinsrw	MM6,m16[EBP],7		;
-	pinsrw	XMM6,EDX,7		;
-	pinsrw	XMM6,m16[EBP],7		;
-
-	pmaddwd	MM1,MM2			;
-	pmaddwd	MM3,m64[EBP]		;
-	pmaddwd	XMM1,XMM2		;
-	pmaddwd	XMM3,m128[EBP]		;
-
-	pmaxsw	MM1,MM2			;
-	pmaxsw	MM3,m64[EBP]		;
-	pmaxsw	XMM1,XMM2		;
-	pmaxsw	XMM3,m128[EBP]		;
-
-	pmaxub	MM1,MM2			;
-	pmaxub	MM3,m64[EBP]		;
-	pmaxub	XMM1,XMM2		;
-	pmaxub	XMM3,m128[EBP]		;
-
-	pminsw	MM1,MM2			;
-	pminsw	MM3,m64[EBP]		;
-	pminsw	XMM1,XMM2		;
-	pminsw	XMM3,m128[EBP]		;
-
-	pminub	MM1,MM2			;
-	pminub	MM3,m64[EBP]		;
-	pminub	XMM1,XMM2		;
-	pminub	XMM3,m128[EBP]		;
-
-	pmovmskb ECX,MM0		;
-	pmovmskb ECX,XMM6		;
-
-	pmulhuw	MM1,MM2			;
-	pmulhuw	MM3,m64[EBP]		;
-	pmulhuw	XMM1,XMM2		;
-	pmulhuw	XMM3,m128[EBP]		;
-
-	pmulhw	MM1,MM2			;
-	pmulhw	MM3,m64[EBP]		;
-	pmulhw	XMM1,XMM2		;
-	pmulhw	XMM3,m128[EBP]		;
-
-	pmullw	MM1,MM2			;
-	pmullw	MM3,m64[EBP]		;
-	pmullw	XMM1,XMM2		;
-	pmullw	XMM3,m128[EBP]		;
-
-	pmuludq	MM1,MM2			;
-	pmuludq	MM3,m64[EBP]		;
-	pmuludq	XMM1,XMM2		;
-	pmuludq	XMM3,m128[EBP]		;
-
-	por	MM1,MM2			;
-	por	MM3,m64[EBP]		;
-	por	XMM1,XMM2		;
-	por	XMM3,m128[EBP]		;
-
-	prefetcht0  m8[EBP]		;
-	prefetcht1  m8[EBP]		;
-	prefetcht2  m8[EBP]		;
-	prefetchnta m8[EBP]		;
-
-	psadbw	MM1,MM2			;
-	psadbw	MM3,m64[EBP]		;
-	psadbw	XMM1,XMM2		;
-	psadbw	XMM3,m128[EBP]		;
-
-	pshufd	XMM1,XMM2,3		;
-	pshufd	XMM3,m128[EBP],3	;
-	pshufhw	XMM1,XMM2,3		;
-	pshufhw	XMM3,m128[EBP],3	;
-	pshuflw	XMM1,XMM2,3		;
-	pshuflw	XMM3,m128[EBP],3	;
-	pshufw	MM1,MM2,3		;
-	pshufw	MM3,m64[EBP],3		;
-
-	pslldq	XMM1,0x18		;
-
-	psllw	MM1,MM2			;
-	psllw	MM1,m64[EBP]		;
-	psllw	XMM1,XMM2		;
-	psllw	XMM1,m128[EBP]		;
-	psllw	MM1,0x15		;
-	psllw	XMM1,0x15		;
-
-	pslld	MM1,MM2			;
-	pslld	MM1,m64[EBP]		;
-	pslld	XMM1,XMM2		;
-	pslld	XMM1,m128[EBP]		;
-	pslld	MM1,0x15		;
-	pslld	XMM1,0x15		;
-
-	psllq	MM1,MM2			;
-	psllq	MM1,m64[EBP]		;
-	psllq	XMM1,XMM2		;
-	psllq	XMM1,m128[EBP]		;
-	psllq	MM1,0x15		;
-	psllq	XMM1,0x15		;
-
-	psraw	MM1,MM2			;
-	psraw	MM1,m64[EBP]		;
-	psraw	XMM1,XMM2		;
-	psraw	XMM1,m128[EBP]		;
-	psraw	MM1,0x15		;
-	psraw	XMM1,0x15		;
-
-	psrad	MM1,MM2			;
-	psrad	MM1,m64[EBP]		;
-	psrad	XMM1,XMM2		;
-	psrad	XMM1,m128[EBP]		;
-	psrad	MM1,0x15		;
-	psrad	XMM1,0x15		;
-
-	psrldq	XMM1,0x18		;
-
-	psrlw	MM1,MM2			;
-	psrlw	MM1,m64[EBP]		;
-	psrlw	XMM1,XMM2		;
-	psrlw	XMM1,m128[EBP]		;
-	psrlw	MM1,0x15		;
-	psrlw	XMM1,0x15		;
-
-	psrld	MM1,MM2			;
-	psrld	MM1,m64[EBP]		;
-	psrld	XMM1,XMM2		;
-	psrld	XMM1,m128[EBP]		;
-	psrld	MM1,0x15		;
-	psrld	XMM1,0x15		;
-
-	psrlq	MM1,MM2			;
-	psrlq	MM1,m64[EBP]		;
-	psrlq	XMM1,XMM2		;
-	psrlq	XMM1,m128[EBP]		;
-	psrlq	MM1,0x15		;
-	psrlq	XMM1,0x15		;
-
-	psubb	MM1,MM2			;
-	psubb	MM1,m64[EBP]		;
-	psubb	XMM1,XMM2		;
-	psubb	XMM1,m128[EBP]		;
-
-	psubw	MM1,MM2			;
-	psubw	MM1,m64[EBP]		;
-	psubw	XMM1,XMM2		;
-	psubw	XMM1,m128[EBP]		;
-
-	psubd	MM1,MM2			;
-	psubd	MM1,m64[EBP]		;
-	psubd	XMM1,XMM2		;
-	psubd	XMM1,m128[EBP]		;
-
-	psubq	MM1,MM2			;
-	psubq	MM1,m64[EBP]		;
-	psubq	XMM1,XMM2		;
-	psubq	XMM1,m128[EBP]		;
-
-	psubsb	MM1,MM2			;
-	psubsb	MM1,m64[EBP]		;
-	psubsb	XMM1,XMM2		;
-	psubsb	XMM1,m128[EBP]		;
-
-	psubsw	MM1,MM2			;
-	psubsw	MM1,m64[EBP]		;
-	psubsw	XMM1,XMM2		;
-	psubsw	XMM1,m128[EBP]		;
-
-	psubusb	MM1,MM2			;
-	psubusb	MM1,m64[EBP]		;
-	psubusb	XMM1,XMM2		;
-	psubusb	XMM1,m128[EBP]		;
-
-	psubusw	MM1,MM2			;
-	psubusw	MM1,m64[EBP]		;
-	psubusw	XMM1,XMM2		;
-	psubusw	XMM1,m128[EBP]		;
-
-	punpckhbw MM1,MM2		;
-	punpckhbw MM1,m64[EBP]		;
-	punpckhbw XMM1,XMM2		;
-	punpckhbw XMM1,m128[EBP]	;
-
-	punpckhwd MM1,MM2		;
-	punpckhwd MM1,m64[EBP]		;
-	punpckhwd XMM1,XMM2		;
-	punpckhwd XMM1,m128[EBP]	;
-
-	punpckhdq MM1,MM2		;
-	punpckhdq MM1,m64[EBP]		;
-	punpckhdq XMM1,XMM2		;
-	punpckhdq XMM1,m128[EBP]	;
-
-	punpckhqdq XMM1,XMM2		;
-	punpckhqdq XMM1,m128[EBP]	;
-
-	punpcklbw MM1,MM2		;
-	punpcklbw MM1,m64[EBP]		;
-	punpcklbw XMM1,XMM2		;
-	punpcklbw XMM1,m128[EBP]	;
-
-	punpcklwd MM1,MM2		;
-	punpcklwd MM1,m64[EBP]		;
-	punpcklwd XMM1,XMM2		;
-	punpcklwd XMM1,m128[EBP]	;
-
-	punpckldq MM1,MM2		;
-	punpckldq MM1,m64[EBP]		;
-	punpckldq XMM1,XMM2		;
-	punpckldq XMM1,m128[EBP]	;
-
-	punpcklqdq XMM1,XMM2		;
-	punpcklqdq XMM1,m128[EBP]	;
-
- 	pxor	MM1,MM2			;
-	pxor	MM1,m64[EBP]		;
-	pxor	XMM1,XMM2		;
-	pxor	XMM1,m128[EBP]		;
-
-	rcpps	XMM1,XMM2		;
-	rcpps	XMM1,m128[EBP]		;
-	rcpss	XMM1,XMM2		;
-	rcpss	XMM1,m32[EBP]		;
-
-	rsqrtps	XMM1,XMM2		;
-	rsqrtps	XMM1,m128[EBP]		;
-	rsqrtss	XMM1,XMM2		;
-	rsqrtss	XMM1,m32[EBP]		;
-
-	shufpd	XMM1,XMM2,3		;
-	shufpd	XMM1,m128[EBP],4	;
-	shufps	XMM1,XMM2,3		;
-	shufps	XMM1,m128[EBP],4	;
-
-	ucomisd	XMM4,XMM6		;
-	ucomisd	XMM5,m64[EBP]		;
-	ucomiss	XMM6,XMM7		;
-	ucomiss	XMM7,m32[EBP]		;
-
-	unpckhpd XMM4,XMM6		;
-	unpckhpd XMM5,m128[EBP]		;
-	unpckhps XMM4,XMM6		;
-	unpckhps XMM5,m128[EBP]		;
-	unpcklpd XMM4,XMM6		;
-	unpcklpd XMM5,m128[EBP]		;
-	unpcklps XMM4,XMM6		;
-	unpcklps XMM5,m128[EBP]		;
-
-	xorpd	XMM1,XMM2		;
-	xorpd	XMM1,m128[EBP]		;
-	xorps	XMM1,XMM2		;
-	xorps	XMM1,m128[EBP]		;
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    call    L1          ;
+
+    movmskpd ESI,XMM3       ;
+    movmskps ESI,XMM3       ;
+
+    movntdq m128[EBP],XMM2      ;
+    movnti  m32[EBP],ECX        ;
+    movntpd m128[EBP],XMM3      ;
+    movntps m128[EBP],XMM4      ;
+    movntq  m64[EBP],MM5        ;
+
+    movq    MM1,MM2         ;
+    movq    MM2,m64[EBP]        ;
+    movq    m64[EBP],MM3        ;
+    movq    XMM1,XMM2       ;
+    movq    XMM2,m64[EBP]       ;
+    movq    m64[EBP],XMM3       ;
+
+    movq2dq XMM3,MM2        ;
+
+    movsd               ;
+    movsd   XMM1,XMM2       ;
+    movsd   XMM3,m64[EBP]       ;
+    movsd   m64[EBP],XMM4       ;
+
+    movss   XMM1,XMM2       ;
+    movss   XMM3,m32[EBP]       ;
+    movss   m32[EBP],XMM4       ;
+
+    movupd  XMM1,XMM2       ;
+    movupd  XMM3,m128[EBP]      ;
+    movupd  m128[EBP],XMM4      ;
+
+    movups  XMM1,XMM2       ;
+    movups  XMM3,m128[EBP]      ;
+    movups  m128[EBP],XMM4      ;
+
+    orpd    XMM1,XMM2       ;
+    orpd    XMM3,m128[EBP]      ;
+    orps    XMM1,XMM2       ;
+    orps    XMM3,m128[EBP]      ;
+
+    packsswb MM1,MM2        ;
+    packsswb MM3,m64[EBP]       ;
+    packsswb XMM1,XMM2      ;
+    packsswb XMM3,m128[EBP]     ;
+
+    packssdw MM1,MM2        ;
+    packssdw MM3,m64[EBP]       ;
+    packssdw XMM1,XMM2      ;
+    packssdw XMM3,m128[EBP]     ;
+
+    packuswb MM1,MM2        ;
+    packuswb MM3,m64[EBP]       ;
+    packuswb XMM1,XMM2      ;
+    packuswb XMM3,m128[EBP]     ;
+
+    paddb   MM1,MM2         ;
+    paddb   MM3,m64[EBP]        ;
+    paddb   XMM1,XMM2       ;
+    paddb   XMM3,m128[EBP]      ;
+
+    paddw   MM1,MM2         ;
+    paddw   MM3,m64[EBP]        ;
+    paddw   XMM1,XMM2       ;
+    paddw   XMM3,m128[EBP]      ;
+
+    paddd   MM1,MM2         ;
+    paddd   MM3,m64[EBP]        ;
+    paddd   XMM1,XMM2       ;
+    paddd   XMM3,m128[EBP]      ;
+
+    paddq   MM1,MM2         ;
+    paddq   MM3,m64[EBP]        ;
+    paddq   XMM1,XMM2       ;
+    paddq   XMM3,m128[EBP]      ;
+
+    paddsb  MM1,MM2         ;
+    paddsb  MM3,m64[EBP]        ;
+    paddsb  XMM1,XMM2       ;
+    paddsb  XMM3,m128[EBP]      ;
+
+    paddsw  MM1,MM2         ;
+    paddsw  MM3,m64[EBP]        ;
+    paddsw  XMM1,XMM2       ;
+    paddsw  XMM3,m128[EBP]      ;
+
+    paddusb MM1,MM2         ;
+    paddusb MM3,m64[EBP]        ;
+    paddusb XMM1,XMM2       ;
+    paddusb XMM3,m128[EBP]      ;
+
+    paddusw MM1,MM2         ;
+    paddusw MM3,m64[EBP]        ;
+    paddusw XMM1,XMM2       ;
+    paddusw XMM3,m128[EBP]      ;
+
+    pand    MM1,MM2         ;
+    pand    MM3,m64[EBP]        ;
+    pand    XMM1,XMM2       ;
+    pand    XMM3,m128[EBP]      ;
+
+    pandn   MM1,MM2         ;
+    pandn   MM3,m64[EBP]        ;
+    pandn   XMM1,XMM2       ;
+    pandn   XMM3,m128[EBP]      ;
+
+    pavgb   MM1,MM2         ;
+    pavgb   MM3,m64[EBP]        ;
+    pavgb   XMM1,XMM2       ;
+    pavgb   XMM3,m128[EBP]      ;
+
+    pavgw   MM1,MM2         ;
+    pavgw   MM3,m64[EBP]        ;
+    pavgw   XMM1,XMM2       ;
+    pavgw   XMM3,m128[EBP]      ;
+
+    pcmpeqb MM1,MM2         ;
+    pcmpeqb MM3,m64[EBP]        ;
+    pcmpeqb XMM1,XMM2       ;
+    pcmpeqb XMM3,m128[EBP]      ;
+
+    pcmpeqw MM1,MM2         ;
+    pcmpeqw MM3,m64[EBP]        ;
+    pcmpeqw XMM1,XMM2       ;
+    pcmpeqw XMM3,m128[EBP]      ;
+
+    pcmpeqd MM1,MM2         ;
+    pcmpeqd MM3,m64[EBP]        ;
+    pcmpeqd XMM1,XMM2       ;
+    pcmpeqd XMM3,m128[EBP]      ;
+
+    pcmpgtb MM1,MM2         ;
+    pcmpgtb MM3,m64[EBP]        ;
+    pcmpgtb XMM1,XMM2       ;
+    pcmpgtb XMM3,m128[EBP]      ;
+
+    pcmpgtw MM1,MM2         ;
+    pcmpgtw MM3,m64[EBP]        ;
+    pcmpgtw XMM1,XMM2       ;
+    pcmpgtw XMM3,m128[EBP]      ;
+
+    pcmpgtd MM1,MM2         ;
+    pcmpgtd MM3,m64[EBP]        ;
+    pcmpgtd XMM1,XMM2       ;
+    pcmpgtd XMM3,m128[EBP]      ;
+
+    pextrw  EDX,MM6,7       ;
+    pextrw  EDX,XMM6,7      ;
+
+    pinsrw  MM6,EDX,7       ;
+    pinsrw  MM6,m16[EBP],7      ;
+    pinsrw  XMM6,EDX,7      ;
+    pinsrw  XMM6,m16[EBP],7     ;
+
+    pmaddwd MM1,MM2         ;
+    pmaddwd MM3,m64[EBP]        ;
+    pmaddwd XMM1,XMM2       ;
+    pmaddwd XMM3,m128[EBP]      ;
+
+    pmaxsw  MM1,MM2         ;
+    pmaxsw  MM3,m64[EBP]        ;
+    pmaxsw  XMM1,XMM2       ;
+    pmaxsw  XMM3,m128[EBP]      ;
+
+    pmaxub  MM1,MM2         ;
+    pmaxub  MM3,m64[EBP]        ;
+    pmaxub  XMM1,XMM2       ;
+    pmaxub  XMM3,m128[EBP]      ;
+
+    pminsw  MM1,MM2         ;
+    pminsw  MM3,m64[EBP]        ;
+    pminsw  XMM1,XMM2       ;
+    pminsw  XMM3,m128[EBP]      ;
+
+    pminub  MM1,MM2         ;
+    pminub  MM3,m64[EBP]        ;
+    pminub  XMM1,XMM2       ;
+    pminub  XMM3,m128[EBP]      ;
+
+    pmovmskb ECX,MM0        ;
+    pmovmskb ECX,XMM6       ;
+
+    pmulhuw MM1,MM2         ;
+    pmulhuw MM3,m64[EBP]        ;
+    pmulhuw XMM1,XMM2       ;
+    pmulhuw XMM3,m128[EBP]      ;
+
+    pmulhw  MM1,MM2         ;
+    pmulhw  MM3,m64[EBP]        ;
+    pmulhw  XMM1,XMM2       ;
+    pmulhw  XMM3,m128[EBP]      ;
+
+    pmullw  MM1,MM2         ;
+    pmullw  MM3,m64[EBP]        ;
+    pmullw  XMM1,XMM2       ;
+    pmullw  XMM3,m128[EBP]      ;
+
+    pmuludq MM1,MM2         ;
+    pmuludq MM3,m64[EBP]        ;
+    pmuludq XMM1,XMM2       ;
+    pmuludq XMM3,m128[EBP]      ;
+
+    por MM1,MM2         ;
+    por MM3,m64[EBP]        ;
+    por XMM1,XMM2       ;
+    por XMM3,m128[EBP]      ;
+
+    prefetcht0  m8[EBP]     ;
+    prefetcht1  m8[EBP]     ;
+    prefetcht2  m8[EBP]     ;
+    prefetchnta m8[EBP]     ;
+
+    psadbw  MM1,MM2         ;
+    psadbw  MM3,m64[EBP]        ;
+    psadbw  XMM1,XMM2       ;
+    psadbw  XMM3,m128[EBP]      ;
+
+    pshufd  XMM1,XMM2,3     ;
+    pshufd  XMM3,m128[EBP],3    ;
+    pshufhw XMM1,XMM2,3     ;
+    pshufhw XMM3,m128[EBP],3    ;
+    pshuflw XMM1,XMM2,3     ;
+    pshuflw XMM3,m128[EBP],3    ;
+    pshufw  MM1,MM2,3       ;
+    pshufw  MM3,m64[EBP],3      ;
+
+    pslldq  XMM1,0x18       ;
+
+    psllw   MM1,MM2         ;
+    psllw   MM1,m64[EBP]        ;
+    psllw   XMM1,XMM2       ;
+    psllw   XMM1,m128[EBP]      ;
+    psllw   MM1,0x15        ;
+    psllw   XMM1,0x15       ;
+
+    pslld   MM1,MM2         ;
+    pslld   MM1,m64[EBP]        ;
+    pslld   XMM1,XMM2       ;
+    pslld   XMM1,m128[EBP]      ;
+    pslld   MM1,0x15        ;
+    pslld   XMM1,0x15       ;
+
+    psllq   MM1,MM2         ;
+    psllq   MM1,m64[EBP]        ;
+    psllq   XMM1,XMM2       ;
+    psllq   XMM1,m128[EBP]      ;
+    psllq   MM1,0x15        ;
+    psllq   XMM1,0x15       ;
+
+    psraw   MM1,MM2         ;
+    psraw   MM1,m64[EBP]        ;
+    psraw   XMM1,XMM2       ;
+    psraw   XMM1,m128[EBP]      ;
+    psraw   MM1,0x15        ;
+    psraw   XMM1,0x15       ;
+
+    psrad   MM1,MM2         ;
+    psrad   MM1,m64[EBP]        ;
+    psrad   XMM1,XMM2       ;
+    psrad   XMM1,m128[EBP]      ;
+    psrad   MM1,0x15        ;
+    psrad   XMM1,0x15       ;
+
+    psrldq  XMM1,0x18       ;
+
+    psrlw   MM1,MM2         ;
+    psrlw   MM1,m64[EBP]        ;
+    psrlw   XMM1,XMM2       ;
+    psrlw   XMM1,m128[EBP]      ;
+    psrlw   MM1,0x15        ;
+    psrlw   XMM1,0x15       ;
+
+    psrld   MM1,MM2         ;
+    psrld   MM1,m64[EBP]        ;
+    psrld   XMM1,XMM2       ;
+    psrld   XMM1,m128[EBP]      ;
+    psrld   MM1,0x15        ;
+    psrld   XMM1,0x15       ;
+
+    psrlq   MM1,MM2         ;
+    psrlq   MM1,m64[EBP]        ;
+    psrlq   XMM1,XMM2       ;
+    psrlq   XMM1,m128[EBP]      ;
+    psrlq   MM1,0x15        ;
+    psrlq   XMM1,0x15       ;
+
+    psubb   MM1,MM2         ;
+    psubb   MM1,m64[EBP]        ;
+    psubb   XMM1,XMM2       ;
+    psubb   XMM1,m128[EBP]      ;
+
+    psubw   MM1,MM2         ;
+    psubw   MM1,m64[EBP]        ;
+    psubw   XMM1,XMM2       ;
+    psubw   XMM1,m128[EBP]      ;
+
+    psubd   MM1,MM2         ;
+    psubd   MM1,m64[EBP]        ;
+    psubd   XMM1,XMM2       ;
+    psubd   XMM1,m128[EBP]      ;
+
+    psubq   MM1,MM2         ;
+    psubq   MM1,m64[EBP]        ;
+    psubq   XMM1,XMM2       ;
+    psubq   XMM1,m128[EBP]      ;
+
+    psubsb  MM1,MM2         ;
+    psubsb  MM1,m64[EBP]        ;
+    psubsb  XMM1,XMM2       ;
+    psubsb  XMM1,m128[EBP]      ;
+
+    psubsw  MM1,MM2         ;
+    psubsw  MM1,m64[EBP]        ;
+    psubsw  XMM1,XMM2       ;
+    psubsw  XMM1,m128[EBP]      ;
+
+    psubusb MM1,MM2         ;
+    psubusb MM1,m64[EBP]        ;
+    psubusb XMM1,XMM2       ;
+    psubusb XMM1,m128[EBP]      ;
+
+    psubusw MM1,MM2         ;
+    psubusw MM1,m64[EBP]        ;
+    psubusw XMM1,XMM2       ;
+    psubusw XMM1,m128[EBP]      ;
+
+    punpckhbw MM1,MM2       ;
+    punpckhbw MM1,m64[EBP]      ;
+    punpckhbw XMM1,XMM2     ;
+    punpckhbw XMM1,m128[EBP]    ;
+
+    punpckhwd MM1,MM2       ;
+    punpckhwd MM1,m64[EBP]      ;
+    punpckhwd XMM1,XMM2     ;
+    punpckhwd XMM1,m128[EBP]    ;
+
+    punpckhdq MM1,MM2       ;
+    punpckhdq MM1,m64[EBP]      ;
+    punpckhdq XMM1,XMM2     ;
+    punpckhdq XMM1,m128[EBP]    ;
+
+    punpckhqdq XMM1,XMM2        ;
+    punpckhqdq XMM1,m128[EBP]   ;
+
+    punpcklbw MM1,MM2       ;
+    punpcklbw MM1,m64[EBP]      ;
+    punpcklbw XMM1,XMM2     ;
+    punpcklbw XMM1,m128[EBP]    ;
+
+    punpcklwd MM1,MM2       ;
+    punpcklwd MM1,m64[EBP]      ;
+    punpcklwd XMM1,XMM2     ;
+    punpcklwd XMM1,m128[EBP]    ;
+
+    punpckldq MM1,MM2       ;
+    punpckldq MM1,m64[EBP]      ;
+    punpckldq XMM1,XMM2     ;
+    punpckldq XMM1,m128[EBP]    ;
+
+    punpcklqdq XMM1,XMM2        ;
+    punpcklqdq XMM1,m128[EBP]   ;
+
+    pxor    MM1,MM2         ;
+    pxor    MM1,m64[EBP]        ;
+    pxor    XMM1,XMM2       ;
+    pxor    XMM1,m128[EBP]      ;
+
+    rcpps   XMM1,XMM2       ;
+    rcpps   XMM1,m128[EBP]      ;
+    rcpss   XMM1,XMM2       ;
+    rcpss   XMM1,m32[EBP]       ;
+
+    rsqrtps XMM1,XMM2       ;
+    rsqrtps XMM1,m128[EBP]      ;
+    rsqrtss XMM1,XMM2       ;
+    rsqrtss XMM1,m32[EBP]       ;
+
+    shufpd  XMM1,XMM2,3     ;
+    shufpd  XMM1,m128[EBP],4    ;
+    shufps  XMM1,XMM2,3     ;
+    shufps  XMM1,m128[EBP],4    ;
+
+    ucomisd XMM4,XMM6       ;
+    ucomisd XMM5,m64[EBP]       ;
+    ucomiss XMM6,XMM7       ;
+    ucomiss XMM7,m32[EBP]       ;
+
+    unpckhpd XMM4,XMM6      ;
+    unpckhpd XMM5,m128[EBP]     ;
+    unpckhps XMM4,XMM6      ;
+    unpckhps XMM5,m128[EBP]     ;
+    unpcklpd XMM4,XMM6      ;
+    unpcklpd XMM5,m128[EBP]     ;
+    unpcklps XMM4,XMM6      ;
+    unpcklps XMM5,m128[EBP]     ;
+
+    xorpd   XMM1,XMM2       ;
+    xorpd   XMM1,m128[EBP]      ;
+    xorps   XMM1,XMM2       ;
+    xorps   XMM1,m128[EBP]      ;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -1873,116 +1873,116 @@ void test15()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F,0x0F,0xDC,0xBF, 		// pavgusb	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xBF,	// pavgusb	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0x1D, 		// pf2id	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0x1D, 	// pf2id	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xAE, 		// pfacc	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xAE, 	// pfacc	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0x9E, 		// pfadd	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0x9E, 	// pfadd	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xB0, 		// pfcmpeq	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xB0, 	// pfcmpeq	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0x90, 		// pfcmpge	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0x90, 	// pfcmpge	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xA0, 		// pfcmpgt	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xA0, 	// pfcmpgt	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xA4, 		// pfmax	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0x94, 	// pfmin	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xB4, 		// pfmul	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xB4, 	// pfmul	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0x8A, 		// pfnacc	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0x8E, 	// pfpnacc	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0x96, 		// pfrcp	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0x96, 	// pfrcp	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xA6, 		// pfrcpit1	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xA6, 	// pfrcpit1	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xB6, 		// pfrcpit2	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xB6, 	// pfrcpit2	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0x97, 		// pfrsqrt	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xA7, 	// pfrsqit1	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0x9A, 		// pfsub	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0x9A, 	// pfsub	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xAA, 		// pfsubr	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xAA, 	// pfsubr	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0x0D, 		// pi2fd	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0x0D, 	// pi2fd	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xB7, 		// pmulhrw	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xB7, 	// pmulhrw	MM3,-020h[EBP]
-	0x0F,0x0F,0xDC,0xBB, 		// pswapd	MM3,MM4
-	0x0F,0x0F,0x5D,0xE0,0xBB, 	// pswapd	MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xBF,        // pavgusb  MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xBF,   // pavgusb  MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0x1D,        // pf2id    MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0x1D,   // pf2id    MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xAE,        // pfacc    MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xAE,   // pfacc    MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0x9E,        // pfadd    MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0x9E,   // pfadd    MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xB0,        // pfcmpeq  MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xB0,   // pfcmpeq  MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0x90,        // pfcmpge  MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0x90,   // pfcmpge  MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xA0,        // pfcmpgt  MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xA0,   // pfcmpgt  MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xA4,        // pfmax    MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0x94,   // pfmin    MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xB4,        // pfmul    MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xB4,   // pfmul    MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0x8A,        // pfnacc   MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0x8E,   // pfpnacc  MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0x96,        // pfrcp    MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0x96,   // pfrcp    MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xA6,        // pfrcpit1 MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xA6,   // pfrcpit1 MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xB6,        // pfrcpit2 MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xB6,   // pfrcpit2 MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0x97,        // pfrsqrt  MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xA7,   // pfrsqit1 MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0x9A,        // pfsub    MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0x9A,   // pfsub    MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xAA,        // pfsubr   MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xAA,   // pfsubr   MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0x0D,        // pi2fd    MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0x0D,   // pi2fd    MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xB7,        // pmulhrw  MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xB7,   // pmulhrw  MM3,-020h[EBP]
+    0x0F,0x0F,0xDC,0xBB,        // pswapd   MM3,MM4
+    0x0F,0x0F,0x5D,0xE0,0xBB,   // pswapd   MM3,-020h[EBP]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	pavgusb	MM3,MM4			;
-	pavgusb	MM3,m64[EBP]		;
+    pavgusb MM3,MM4         ;
+    pavgusb MM3,m64[EBP]        ;
 
-	pf2id	MM3,MM4			;
-	pf2id	MM3,m64[EBP]		;
+    pf2id   MM3,MM4         ;
+    pf2id   MM3,m64[EBP]        ;
 
-	pfacc	MM3,MM4			;
-	pfacc	MM3,m64[EBP]		;
+    pfacc   MM3,MM4         ;
+    pfacc   MM3,m64[EBP]        ;
 
-	pfadd	MM3,MM4			;
-	pfadd	MM3,m64[EBP]		;
+    pfadd   MM3,MM4         ;
+    pfadd   MM3,m64[EBP]        ;
 
-	pfcmpeq	MM3,MM4			;
-	pfcmpeq	MM3,m64[EBP]		;
+    pfcmpeq MM3,MM4         ;
+    pfcmpeq MM3,m64[EBP]        ;
 
-	pfcmpge	MM3,MM4			;
-	pfcmpge	MM3,m64[EBP]		;
+    pfcmpge MM3,MM4         ;
+    pfcmpge MM3,m64[EBP]        ;
 
-	pfcmpgt	MM3,MM4			;
-	pfcmpgt	MM3,m64[EBP]		;
+    pfcmpgt MM3,MM4         ;
+    pfcmpgt MM3,m64[EBP]        ;
 
-	pfmax	MM3,MM4			;
-	pfmin	MM3,m64[EBP]		;
+    pfmax   MM3,MM4         ;
+    pfmin   MM3,m64[EBP]        ;
 
-	pfmul	MM3,MM4			;
-	pfmul	MM3,m64[EBP]		;
+    pfmul   MM3,MM4         ;
+    pfmul   MM3,m64[EBP]        ;
 
-	pfnacc	MM3,MM4			;
-	pfpnacc	MM3,m64[EBP]		;
+    pfnacc  MM3,MM4         ;
+    pfpnacc MM3,m64[EBP]        ;
 
-	pfrcp	MM3,MM4			;
-	pfrcp	MM3,m64[EBP]		;
+    pfrcp   MM3,MM4         ;
+    pfrcp   MM3,m64[EBP]        ;
 
-	pfrcpit1 MM3,MM4		;
-	pfrcpit1 MM3,m64[EBP]		;
+    pfrcpit1 MM3,MM4        ;
+    pfrcpit1 MM3,m64[EBP]       ;
 
-	pfrcpit2 MM3,MM4		;
-	pfrcpit2 MM3,m64[EBP]		;
+    pfrcpit2 MM3,MM4        ;
+    pfrcpit2 MM3,m64[EBP]       ;
 
-	pfrsqrt	 MM3,MM4		;
-	pfrsqit1 MM3,m64[EBP]		;
+    pfrsqrt  MM3,MM4        ;
+    pfrsqit1 MM3,m64[EBP]       ;
 
-	pfsub	MM3,MM4			;
-	pfsub	MM3,m64[EBP]		;
+    pfsub   MM3,MM4         ;
+    pfsub   MM3,m64[EBP]        ;
 
-	pfsubr	MM3,MM4			;
-	pfsubr	MM3,m64[EBP]		;
+    pfsubr  MM3,MM4         ;
+    pfsubr  MM3,m64[EBP]        ;
 
-	pi2fd	MM3,MM4			;
-	pi2fd	MM3,m64[EBP]		;
+    pi2fd   MM3,MM4         ;
+    pi2fd   MM3,m64[EBP]        ;
 
-	pmulhrw	MM3,MM4			;
-	pmulhrw	MM3,m64[EBP]		;
+    pmulhrw MM3,MM4         ;
+    pmulhrw MM3,m64[EBP]        ;
 
-	pswapd	MM3,MM4			;
-	pswapd	MM3,m64[EBP]		;
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    pswapd  MM3,MM4         ;
+    pswapd  MM3,m64[EBP]        ;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -1995,36 +1995,36 @@ __gshared S17 xx17;
 void test17()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F, 0x01, 0x10,    	// lgdt	[EAX]
-	0x0F, 0x01, 0x18,   	// lidt	[EAX]
-	0x0F, 0x01, 0x00,    	// sgdt	[EAX]
-	0x0F, 0x01, 0x08,    	// sidt	[EAX]
+    0x0F, 0x01, 0x10,       // lgdt [EAX]
+    0x0F, 0x01, 0x18,       // lidt [EAX]
+    0x0F, 0x01, 0x00,       // sgdt [EAX]
+    0x0F, 0x01, 0x08,       // sidt [EAX]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	lgdt [EAX]			;
-	lidt [EAX]			;
-	sgdt [EAX]			;
-	sidt [EAX]			;
+    lgdt [EAX]          ;
+    lidt [EAX]          ;
+    sgdt [EAX]          ;
+    sidt [EAX]          ;
 
-	lgdt xx17			;
-	lidt xx17			;
-	sgdt xx17			;
-	sidt xx17			;
+    lgdt xx17           ;
+    lidt xx17           ;
+    sgdt xx17           ;
+    sidt xx17           ;
 
 L1:
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2035,53 +2035,53 @@ L1:
 void test18()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xDB, 0xF1,		// fcomi ST,ST(1)
-	0xDB, 0xF0,		// fcomi ST,ST(0)
-	0xDB, 0xF2,		// fcomi ST,ST(2)
+    0xDB, 0xF1,     // fcomi ST,ST(1)
+    0xDB, 0xF0,     // fcomi ST,ST(0)
+    0xDB, 0xF2,     // fcomi ST,ST(2)
 
-	0xDF, 0xF1,		// fcomip ST,ST(1)
-	0xDF, 0xF0,		// fcomip ST,ST(0)
-	0xDF, 0xF2,		// fcomip ST,ST(2)
+    0xDF, 0xF1,     // fcomip ST,ST(1)
+    0xDF, 0xF0,     // fcomip ST,ST(0)
+    0xDF, 0xF2,     // fcomip ST,ST(2)
 
-	0xDB, 0xE9,		// fucomi ST,ST(1)
-	0xDB, 0xE8,		// fucomi ST,ST(0)
-	0xDB, 0xEB,		// fucomi ST,ST(3)
+    0xDB, 0xE9,     // fucomi ST,ST(1)
+    0xDB, 0xE8,     // fucomi ST,ST(0)
+    0xDB, 0xEB,     // fucomi ST,ST(3)
 
-	0xDF, 0xE9,		// fucomip ST,ST(1)
-	0xDF, 0xED,		// fucomip ST,ST(5)
-	0xDF, 0xEC,		// fucomip ST,ST(4)
+    0xDF, 0xE9,     // fucomip ST,ST(1)
+    0xDF, 0xED,     // fucomip ST,ST(5)
+    0xDF, 0xEC,     // fucomip ST,ST(4)
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	fcomi				;
-	fcomi   ST(0)			;
-	fcomi   ST,ST(2)		;
+    fcomi               ;
+    fcomi   ST(0)           ;
+    fcomi   ST,ST(2)        ;
 
-	fcomip				;
-	fcomip  ST(0)			;
-	fcomip  ST,ST(2)		;
+    fcomip              ;
+    fcomip  ST(0)           ;
+    fcomip  ST,ST(2)        ;
 
-	fucomi				;
-	fucomi  ST(0)			;
-	fucomi  ST,ST(3)		;
+    fucomi              ;
+    fucomi  ST(0)           ;
+    fucomi  ST,ST(3)        ;
 
-	fucomip				;
-	fucomip ST(5)			;
-	fucomip ST,ST(4)		;
+    fucomip             ;
+    fucomip ST(5)           ;
+    fucomip ST,ST(4)        ;
 
 L1:
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2099,11 +2099,11 @@ void test19()
 
     asm
     {
-	lea	EAX, dword ptr [foo19];
-	mov	fp, EAX;
-	mov	x, EAX;
-	mov	p, EAX;
-	call	fp;
+    lea EAX, dword ptr [foo19];
+    mov fp, EAX;
+    mov x, EAX;
+    mov p, EAX;
+    call    fp;
     }
     (*fp)();
 }
@@ -2114,46 +2114,46 @@ void test19()
 void test20()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x9B, 0xDB, 0xE0,	// feni
-	0xDB, 0xE0,		// fneni
+    0x9B, 0xDB, 0xE0,   // feni
+    0xDB, 0xE0,     // fneni
 
-	0x9B, 0xDB, 0xE1,	// fdisi
-	0xDB, 0xE1,		// fndisi
+    0x9B, 0xDB, 0xE1,   // fdisi
+    0xDB, 0xE1,     // fndisi
 
-	0x9B, 0xDB, 0xE2,	// fclex
-	0xDB, 0xE2,		// fnclex
+    0x9B, 0xDB, 0xE2,   // fclex
+    0xDB, 0xE2,     // fnclex
 
-	0x9B, 0xDB, 0xE3,	// finit
-	0xDB, 0xE3,		// fninit
+    0x9B, 0xDB, 0xE3,   // finit
+    0xDB, 0xE3,     // fninit
 
-	0xDB, 0xE4,		// fsetpm
+    0xDB, 0xE4,     // fsetpm
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	feni				;
-	fneni				;
-	fdisi				;
-	fndisi				;
-	finit				;
-	fninit				;
-	fclex				;
-	fnclex				;
-	finit				;
-	fninit				;
-	fsetpm				;
+    feni                ;
+    fneni               ;
+    fdisi               ;
+    fndisi              ;
+    finit               ;
+    fninit              ;
+    fclex               ;
+    fnclex              ;
+    finit               ;
+    fninit              ;
+    fsetpm              ;
 L1:
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2164,47 +2164,47 @@ L1:
 void test21()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xE4, 0x06,       	// in	AL,6
-	0x66, 0xE5, 0x07,       // in	AX,7
-	0xE5, 0x08,       	// in	EAX,8
-	0xEC,          		// in	AL,DX
-	0x66, 0xED,          	// in	AX,DX
-	0xED,          		// in	EAX,DX
-	0xE6, 0x06,       	// out	6,AL
-	0x66, 0xE7, 0x07,       // out	7,AX
-	0xE7, 0x08,       	// out	8,EAX
-	0xEE,          		// out	DX,AL
-	0x66, 0xEF,          	// out	DX,AX
-	0xEF,          		// out	DX,EAX
+    0xE4, 0x06,         // in   AL,6
+    0x66, 0xE5, 0x07,       // in   AX,7
+    0xE5, 0x08,         // in   EAX,8
+    0xEC,               // in   AL,DX
+    0x66, 0xED,             // in   AX,DX
+    0xED,               // in   EAX,DX
+    0xE6, 0x06,         // out  6,AL
+    0x66, 0xE7, 0x07,       // out  7,AX
+    0xE7, 0x08,         // out  8,EAX
+    0xEE,               // out  DX,AL
+    0x66, 0xEF,             // out  DX,AX
+    0xEF,               // out  DX,EAX
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	in AL,6		;
-	in AX,7		;
-	in EAX,8	;
-	in AL,DX	;
-	in AX,DX	;
-	in EAX,DX	;
+    in AL,6     ;
+    in AX,7     ;
+    in EAX,8    ;
+    in AL,DX    ;
+    in AX,DX    ;
+    in EAX,DX   ;
 
-	out 6,AL	;
-	out 7,AX	;
-	out 8,EAX	;
-	out DX,AL	;
-	out DX,AX	;
-	out DX,EAX	;
+    out 6,AL    ;
+    out 7,AX    ;
+    out 8,EAX   ;
+    out DX,AL   ;
+    out DX,AX   ;
+    out DX,EAX  ;
 L1:
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2215,25 +2215,25 @@ L1:
 void test22()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F, 0xC7, 0x4D, 0xF8 	// cmpxchg8b
+    0x0F, 0xC7, 0x4D, 0xF8  // cmpxchg8b
     ];
     int i;
     M64 m64;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	cmpxchg8b m64			;
+    cmpxchg8b m64           ;
 L1:
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2247,96 +2247,96 @@ void test23()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xD9, 0xC9,		// fxch		ST(1), ST(0)
+    0xD9, 0xC9,     // fxch     ST(1), ST(0)
 
-	0xDF, 0x5D, 0xD8,    	// fistp	word ptr -018h[EBP]
-	0xDB, 0x5D, 0xDC,    	// fistp	dword ptr -014h[EBP]
-	0xDF, 0x7D, 0xE0,    	// fistp	long64 ptr -010h[EBP]
-	0xDF, 0x4D, 0xD8,    	// fisttp	short ptr -018h[EBP]
-	0xDB, 0x4D, 0xDC,    	// fisttp	word ptr -014h[EBP]
-	0xDD, 0x4D, 0xE0,    	// fisttp	long64 ptr -010h[EBP]
-	0x0F, 0x01, 0xC8,    	// monitor
-	0x0F, 0x01, 0xC9,    	// mwait
-	0x0F, 0x01, 0xD0,    	// xgetbv
+    0xDF, 0x5D, 0xD8,       // fistp    word ptr -018h[EBP]
+    0xDB, 0x5D, 0xDC,       // fistp    dword ptr -014h[EBP]
+    0xDF, 0x7D, 0xE0,       // fistp    long64 ptr -010h[EBP]
+    0xDF, 0x4D, 0xD8,       // fisttp   short ptr -018h[EBP]
+    0xDB, 0x4D, 0xDC,       // fisttp   word ptr -014h[EBP]
+    0xDD, 0x4D, 0xE0,       // fisttp   long64 ptr -010h[EBP]
+    0x0F, 0x01, 0xC8,       // monitor
+    0x0F, 0x01, 0xC9,       // mwait
+    0x0F, 0x01, 0xD0,       // xgetbv
 
-	0x66, 0x0F, 0xD0, 0xCA,    	// addsubpd	XMM1,XMM2
-	0x66, 0x0F, 0xD0, 0x4D, 0xE8, 	// addsubpd	XMM1,-010h[EBP]
-	0xF2, 0x0F, 0xD0, 0xCA, 	// addsubps	XMM1,XMM2
-	0xF2, 0x0F, 0xD0, 0x4D, 0xE8, 	// addsubps	XMM1,-010h[EBP]
-	0x66, 0x0F, 0x7C, 0xCA,    	// haddpd	XMM1,XMM2
-	0x66, 0x0F, 0x7C, 0x4D, 0xE8, 	// haddpd	XMM1,-010h[EBP]
-	0xF2, 0x0F, 0x7C, 0xCA, 	// haddps	XMM1,XMM2
-	0xF2, 0x0F, 0x7C, 0x4D, 0xE8, 	// haddps	XMM1,-010h[EBP]
-	0x66, 0x0F, 0x7D, 0xCA,    	// hsubpd	XMM1,XMM2
-	0x66, 0x0F, 0x7D, 0x4D, 0xE8, 	// hsubpd	XMM1,-010h[EBP]
-	0xF2, 0x0F, 0x7D, 0xCA, 	// hsubps	XMM1,XMM2
-	0xF2, 0x0F, 0x7D, 0x4D, 0xE8, 	// hsubps	XMM1,-010h[EBP]
-	0xF2, 0x0F, 0xF0, 0x4D, 0xE8, 	// lddqu	XMM1,-010h[EBP]
-	0xF2, 0x0F, 0x12, 0xCA, 	// movddup	XMM1,XMM2
-	0xF2, 0x0F, 0x12, 0x4D, 0xE0, 	// movddup	XMM1,-018h[EBP]
-	0xF3, 0x0F, 0x16, 0xCA, 	// movshdup	XMM1,XMM2
-	0xF3, 0x0F, 0x16, 0x4D, 0xE8, 	// movshdup	XMM1,-010h[EBP]
-	0xF3, 0x0F, 0x12, 0xCA, 	// movsldup	XMM1,XMM2
-	0xF3, 0x0F, 0x12, 0x4D, 0xE8, 	// movsldup	XMM1,-010h[EBP]
+    0x66, 0x0F, 0xD0, 0xCA,     // addsubpd XMM1,XMM2
+    0x66, 0x0F, 0xD0, 0x4D, 0xE8,   // addsubpd XMM1,-010h[EBP]
+    0xF2, 0x0F, 0xD0, 0xCA,     // addsubps XMM1,XMM2
+    0xF2, 0x0F, 0xD0, 0x4D, 0xE8,   // addsubps XMM1,-010h[EBP]
+    0x66, 0x0F, 0x7C, 0xCA,     // haddpd   XMM1,XMM2
+    0x66, 0x0F, 0x7C, 0x4D, 0xE8,   // haddpd   XMM1,-010h[EBP]
+    0xF2, 0x0F, 0x7C, 0xCA,     // haddps   XMM1,XMM2
+    0xF2, 0x0F, 0x7C, 0x4D, 0xE8,   // haddps   XMM1,-010h[EBP]
+    0x66, 0x0F, 0x7D, 0xCA,     // hsubpd   XMM1,XMM2
+    0x66, 0x0F, 0x7D, 0x4D, 0xE8,   // hsubpd   XMM1,-010h[EBP]
+    0xF2, 0x0F, 0x7D, 0xCA,     // hsubps   XMM1,XMM2
+    0xF2, 0x0F, 0x7D, 0x4D, 0xE8,   // hsubps   XMM1,-010h[EBP]
+    0xF2, 0x0F, 0xF0, 0x4D, 0xE8,   // lddqu    XMM1,-010h[EBP]
+    0xF2, 0x0F, 0x12, 0xCA,     // movddup  XMM1,XMM2
+    0xF2, 0x0F, 0x12, 0x4D, 0xE0,   // movddup  XMM1,-018h[EBP]
+    0xF3, 0x0F, 0x16, 0xCA,     // movshdup XMM1,XMM2
+    0xF3, 0x0F, 0x16, 0x4D, 0xE8,   // movshdup XMM1,-010h[EBP]
+    0xF3, 0x0F, 0x12, 0xCA,     // movsldup XMM1,XMM2
+    0xF3, 0x0F, 0x12, 0x4D, 0xE8,   // movsldup XMM1,-010h[EBP]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	fxch	ST(1), ST(0)		;
+    fxch    ST(1), ST(0)        ;
 
-	fistp	m16[EBP]		;
-	fistp	m32[EBP]		;
-	fistp	m64[EBP]		;
+    fistp   m16[EBP]        ;
+    fistp   m32[EBP]        ;
+    fistp   m64[EBP]        ;
 
-	fisttp	m16[EBP]		;
-	fisttp	m32[EBP]		;
-	fisttp	m64[EBP]		;
+    fisttp  m16[EBP]        ;
+    fisttp  m32[EBP]        ;
+    fisttp  m64[EBP]        ;
 
-	monitor				;
-	mwait				;
-	xgetbv				;
+    monitor             ;
+    mwait               ;
+    xgetbv              ;
 
-	addsubpd	XMM1,XMM2	;
-	addsubpd	XMM1,m128[EBP]	;
+    addsubpd    XMM1,XMM2   ;
+    addsubpd    XMM1,m128[EBP]  ;
 
-	addsubps	XMM1,XMM2	;
-	addsubps	XMM1,m128[EBP]	;
+    addsubps    XMM1,XMM2   ;
+    addsubps    XMM1,m128[EBP]  ;
 
-	haddpd		XMM1,XMM2	;
-	haddpd		XMM1,m128[EBP]	;
+    haddpd      XMM1,XMM2   ;
+    haddpd      XMM1,m128[EBP]  ;
 
-	haddps		XMM1,XMM2	;
-	haddps		XMM1,m128[EBP]	;
+    haddps      XMM1,XMM2   ;
+    haddps      XMM1,m128[EBP]  ;
 
-	hsubpd		XMM1,XMM2	;
-	hsubpd		XMM1,m128[EBP]	;
+    hsubpd      XMM1,XMM2   ;
+    hsubpd      XMM1,m128[EBP]  ;
 
-	hsubps		XMM1,XMM2	;
-	hsubps		XMM1,m128[EBP]	;
+    hsubps      XMM1,XMM2   ;
+    hsubps      XMM1,m128[EBP]  ;
 
-	lddqu		XMM1,m128[EBP]	;
+    lddqu       XMM1,m128[EBP]  ;
 
-	movddup		XMM1,XMM2	;
-	movddup		XMM1,m64[EBP]	;
+    movddup     XMM1,XMM2   ;
+    movddup     XMM1,m64[EBP]   ;
 
-	movshdup	XMM1,XMM2	;
-	movshdup	XMM1,m128[EBP]	;
+    movshdup    XMM1,XMM2   ;
+    movshdup    XMM1,m128[EBP]  ;
 
-	movsldup	XMM1,XMM2	;
-	movsldup	XMM1,m128[EBP]	;
+    movsldup    XMM1,XMM2   ;
+    movsldup    XMM1,m128[EBP]  ;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2346,14 +2346,14 @@ void test24()
 {
     version(D_InlineAsm)
     {
-	ushort i;
+    ushort i;
 
-	asm
-	{
-	    lea AX, i;
-	    mov i, AX;
-	}
-	assert(cast(ushort)&i == i);
+    asm
+    {
+        lea AX, i;
+        mov i, AX;
+    }
+    assert(cast(ushort)&i == i);
     }
 }
 
@@ -2366,158 +2366,158 @@ void test25()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x66, 0x0F, 0x7E, 0xC1,    	// movd	ECX,XMM0
-	0x66, 0x0F, 0x7E, 0xC9,    	// movd	ECX,XMM1
-	0x66, 0x0F, 0x7E, 0xD1,    	// movd	ECX,XMM2
-	0x66, 0x0F, 0x7E, 0xD9,    	// movd	ECX,XMM3
-	0x66, 0x0F, 0x7E, 0xE1,    	// movd	ECX,XMM4
-	0x66, 0x0F, 0x7E, 0xE9,    	// movd	ECX,XMM5
-	0x66, 0x0F, 0x7E, 0xF1,    	// movd	ECX,XMM6
-	0x66, 0x0F, 0x7E, 0xF9,    	// movd	ECX,XMM7
-	0x0F, 0x7E, 0xC1,	    	// movd	ECX,MM0
-	0x0F, 0x7E, 0xC9,	    	// movd	ECX,MM1
-	0x0F, 0x7E, 0xD1,	    	// movd	ECX,MM2
-	0x0F, 0x7E, 0xD9,	    	// movd	ECX,MM3
-	0x0F, 0x7E, 0xE1,	    	// movd	ECX,MM4
-	0x0F, 0x7E, 0xE9,	    	// movd	ECX,MM5
-	0x0F, 0x7E, 0xF1,	    	// movd	ECX,MM6
-	0x0F, 0x7E, 0xF9,	    	// movd	ECX,MM7
-	0x66, 0x0F, 0x6E, 0xC1,    	// movd	XMM0,ECX
-	0x66, 0x0F, 0x6E, 0xC9,    	// movd	XMM1,ECX
-	0x66, 0x0F, 0x6E, 0xD1,    	// movd	XMM2,ECX
-	0x66, 0x0F, 0x6E, 0xD9,    	// movd	XMM3,ECX
-	0x66, 0x0F, 0x6E, 0xE1,    	// movd	XMM4,ECX
-	0x66, 0x0F, 0x6E, 0xE9,    	// movd	XMM5,ECX
-	0x66, 0x0F, 0x6E, 0xF1,    	// movd	XMM6,ECX
-	0x66, 0x0F, 0x6E, 0xF9,    	// movd	XMM7,ECX
-	0x0F, 0x6E, 0xC1,	    	// movd	MM0,ECX
-	0x0F, 0x6E, 0xC9,	    	// movd	MM1,ECX
-	0x0F, 0x6E, 0xD1,	    	// movd	MM2,ECX
-	0x0F, 0x6E, 0xD9,	    	// movd	MM3,ECX
-	0x0F, 0x6E, 0xE1,	    	// movd	MM4,ECX
-	0x0F, 0x6E, 0xE9,	    	// movd	MM5,ECX
-	0x0F, 0x6E, 0xF1,	    	// movd	MM6,ECX
-	0x0F, 0x6E, 0xF9,	    	// movd	MM7,ECX
-	0x66, 0x0F, 0x7E, 0xC8,    	// movd	EAX,XMM1
-	0x66, 0x0F, 0x7E, 0xCB,    	// movd	EBX,XMM1
-	0x66, 0x0F, 0x7E, 0xC9,    	// movd	ECX,XMM1
-	0x66, 0x0F, 0x7E, 0xCA,    	// movd	EDX,XMM1
-	0x66, 0x0F, 0x7E, 0xCE,    	// movd	ESI,XMM1
-	0x66, 0x0F, 0x7E, 0xCF,    	// movd	EDI,XMM1
-	0x66, 0x0F, 0x7E, 0xCD,    	// movd	EBP,XMM1
-	0x66, 0x0F, 0x7E, 0xCC,    	// movd	ESP,XMM1
-	0x0F, 0x7E, 0xC8,	    	// movd	EAX,MM1
-	0x0F, 0x7E, 0xCB,	    	// movd	EBX,MM1
-	0x0F, 0x7E, 0xC9,	    	// movd	ECX,MM1
-	0x0F, 0x7E, 0xCA,	    	// movd	EDX,MM1
-	0x0F, 0x7E, 0xCE,	    	// movd	ESI,MM1
-	0x0F, 0x7E, 0xCF,	    	// movd	EDI,MM1
-	0x0F, 0x7E, 0xCD,	    	// movd	EBP,MM1
-	0x0F, 0x7E, 0xCC,	    	// movd	ESP,MM1
-	0x66, 0x0F, 0x6E, 0xC8,    	// movd	XMM1,EAX
-	0x66, 0x0F, 0x6E, 0xCB,    	// movd	XMM1,EBX
-	0x66, 0x0F, 0x6E, 0xC9,    	// movd	XMM1,ECX
-	0x66, 0x0F, 0x6E, 0xCA,    	// movd	XMM1,EDX
-	0x66, 0x0F, 0x6E, 0xCE,    	// movd	XMM1,ESI
-	0x66, 0x0F, 0x6E, 0xCF,    	// movd	XMM1,EDI
-	0x66, 0x0F, 0x6E, 0xCD,    	// movd	XMM1,EBP
-	0x66, 0x0F, 0x6E, 0xCC,    	// movd	XMM1,ESP
-	0x0F, 0x6E, 0xC8,	    	// movd	MM1,EAX
-	0x0F, 0x6E, 0xCB,	    	// movd	MM1,EBX
-	0x0F, 0x6E, 0xC9,	    	// movd	MM1,ECX
-	0x0F, 0x6E, 0xCA,	    	// movd	MM1,EDX
-	0x0F, 0x6E, 0xCE,	    	// movd	MM1,ESI
-	0x0F, 0x6E, 0xCF,	    	// movd	MM1,EDI
-	0x0F, 0x6E, 0xCD,	    	// movd	MM1,EBP
-	0x0F, 0x6E, 0xCC,	    	// movd	MM1,ESP
+    0x66, 0x0F, 0x7E, 0xC1,     // movd ECX,XMM0
+    0x66, 0x0F, 0x7E, 0xC9,     // movd ECX,XMM1
+    0x66, 0x0F, 0x7E, 0xD1,     // movd ECX,XMM2
+    0x66, 0x0F, 0x7E, 0xD9,     // movd ECX,XMM3
+    0x66, 0x0F, 0x7E, 0xE1,     // movd ECX,XMM4
+    0x66, 0x0F, 0x7E, 0xE9,     // movd ECX,XMM5
+    0x66, 0x0F, 0x7E, 0xF1,     // movd ECX,XMM6
+    0x66, 0x0F, 0x7E, 0xF9,     // movd ECX,XMM7
+    0x0F, 0x7E, 0xC1,           // movd ECX,MM0
+    0x0F, 0x7E, 0xC9,           // movd ECX,MM1
+    0x0F, 0x7E, 0xD1,           // movd ECX,MM2
+    0x0F, 0x7E, 0xD9,           // movd ECX,MM3
+    0x0F, 0x7E, 0xE1,           // movd ECX,MM4
+    0x0F, 0x7E, 0xE9,           // movd ECX,MM5
+    0x0F, 0x7E, 0xF1,           // movd ECX,MM6
+    0x0F, 0x7E, 0xF9,           // movd ECX,MM7
+    0x66, 0x0F, 0x6E, 0xC1,     // movd XMM0,ECX
+    0x66, 0x0F, 0x6E, 0xC9,     // movd XMM1,ECX
+    0x66, 0x0F, 0x6E, 0xD1,     // movd XMM2,ECX
+    0x66, 0x0F, 0x6E, 0xD9,     // movd XMM3,ECX
+    0x66, 0x0F, 0x6E, 0xE1,     // movd XMM4,ECX
+    0x66, 0x0F, 0x6E, 0xE9,     // movd XMM5,ECX
+    0x66, 0x0F, 0x6E, 0xF1,     // movd XMM6,ECX
+    0x66, 0x0F, 0x6E, 0xF9,     // movd XMM7,ECX
+    0x0F, 0x6E, 0xC1,           // movd MM0,ECX
+    0x0F, 0x6E, 0xC9,           // movd MM1,ECX
+    0x0F, 0x6E, 0xD1,           // movd MM2,ECX
+    0x0F, 0x6E, 0xD9,           // movd MM3,ECX
+    0x0F, 0x6E, 0xE1,           // movd MM4,ECX
+    0x0F, 0x6E, 0xE9,           // movd MM5,ECX
+    0x0F, 0x6E, 0xF1,           // movd MM6,ECX
+    0x0F, 0x6E, 0xF9,           // movd MM7,ECX
+    0x66, 0x0F, 0x7E, 0xC8,     // movd EAX,XMM1
+    0x66, 0x0F, 0x7E, 0xCB,     // movd EBX,XMM1
+    0x66, 0x0F, 0x7E, 0xC9,     // movd ECX,XMM1
+    0x66, 0x0F, 0x7E, 0xCA,     // movd EDX,XMM1
+    0x66, 0x0F, 0x7E, 0xCE,     // movd ESI,XMM1
+    0x66, 0x0F, 0x7E, 0xCF,     // movd EDI,XMM1
+    0x66, 0x0F, 0x7E, 0xCD,     // movd EBP,XMM1
+    0x66, 0x0F, 0x7E, 0xCC,     // movd ESP,XMM1
+    0x0F, 0x7E, 0xC8,           // movd EAX,MM1
+    0x0F, 0x7E, 0xCB,           // movd EBX,MM1
+    0x0F, 0x7E, 0xC9,           // movd ECX,MM1
+    0x0F, 0x7E, 0xCA,           // movd EDX,MM1
+    0x0F, 0x7E, 0xCE,           // movd ESI,MM1
+    0x0F, 0x7E, 0xCF,           // movd EDI,MM1
+    0x0F, 0x7E, 0xCD,           // movd EBP,MM1
+    0x0F, 0x7E, 0xCC,           // movd ESP,MM1
+    0x66, 0x0F, 0x6E, 0xC8,     // movd XMM1,EAX
+    0x66, 0x0F, 0x6E, 0xCB,     // movd XMM1,EBX
+    0x66, 0x0F, 0x6E, 0xC9,     // movd XMM1,ECX
+    0x66, 0x0F, 0x6E, 0xCA,     // movd XMM1,EDX
+    0x66, 0x0F, 0x6E, 0xCE,     // movd XMM1,ESI
+    0x66, 0x0F, 0x6E, 0xCF,     // movd XMM1,EDI
+    0x66, 0x0F, 0x6E, 0xCD,     // movd XMM1,EBP
+    0x66, 0x0F, 0x6E, 0xCC,     // movd XMM1,ESP
+    0x0F, 0x6E, 0xC8,           // movd MM1,EAX
+    0x0F, 0x6E, 0xCB,           // movd MM1,EBX
+    0x0F, 0x6E, 0xC9,           // movd MM1,ECX
+    0x0F, 0x6E, 0xCA,           // movd MM1,EDX
+    0x0F, 0x6E, 0xCE,           // movd MM1,ESI
+    0x0F, 0x6E, 0xCF,           // movd MM1,EDI
+    0x0F, 0x6E, 0xCD,           // movd MM1,EBP
+    0x0F, 0x6E, 0xCC,           // movd MM1,ESP
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	movd ECX, XMM0;	
-	movd ECX, XMM1;	
-	movd ECX, XMM2;
-	movd ECX, XMM3;
-	movd ECX, XMM4;
-	movd ECX, XMM5;
-	movd ECX, XMM6;
-	movd ECX, XMM7;
+    movd ECX, XMM0; 
+    movd ECX, XMM1; 
+    movd ECX, XMM2;
+    movd ECX, XMM3;
+    movd ECX, XMM4;
+    movd ECX, XMM5;
+    movd ECX, XMM6;
+    movd ECX, XMM7;
 
-	movd ECX, MM0;	
-	movd ECX, MM1;	
-	movd ECX, MM2;
-	movd ECX, MM3;
-	movd ECX, MM4;
-	movd ECX, MM5;
-	movd ECX, MM6;
-	movd ECX, MM7;
+    movd ECX, MM0;  
+    movd ECX, MM1;  
+    movd ECX, MM2;
+    movd ECX, MM3;
+    movd ECX, MM4;
+    movd ECX, MM5;
+    movd ECX, MM6;
+    movd ECX, MM7;
 
-	movd XMM0, ECX;
-	movd XMM1, ECX;
-	movd XMM2, ECX;
-	movd XMM3, ECX;
-	movd XMM4, ECX;
-	movd XMM5, ECX;
-	movd XMM6, ECX;
-	movd XMM7, ECX;
+    movd XMM0, ECX;
+    movd XMM1, ECX;
+    movd XMM2, ECX;
+    movd XMM3, ECX;
+    movd XMM4, ECX;
+    movd XMM5, ECX;
+    movd XMM6, ECX;
+    movd XMM7, ECX;
 
-	movd MM0, ECX;
-	movd MM1, ECX;
-	movd MM2, ECX;
-	movd MM3, ECX;
-	movd MM4, ECX;
-	movd MM5, ECX;
-	movd MM6, ECX;
-	movd MM7, ECX;
+    movd MM0, ECX;
+    movd MM1, ECX;
+    movd MM2, ECX;
+    movd MM3, ECX;
+    movd MM4, ECX;
+    movd MM5, ECX;
+    movd MM6, ECX;
+    movd MM7, ECX;
 
-	movd EAX, XMM1;	
-	movd EBX, XMM1;	
-	movd ECX, XMM1;
-	movd EDX, XMM1;
-	movd ESI, XMM1;
-	movd EDI, XMM1;
-	movd EBP, XMM1;
-	movd ESP, XMM1;
+    movd EAX, XMM1; 
+    movd EBX, XMM1; 
+    movd ECX, XMM1;
+    movd EDX, XMM1;
+    movd ESI, XMM1;
+    movd EDI, XMM1;
+    movd EBP, XMM1;
+    movd ESP, XMM1;
 
-	movd EAX, MM1;	
-	movd EBX, MM1;	
-	movd ECX, MM1;
-	movd EDX, MM1;
-	movd ESI, MM1;
-	movd EDI, MM1;
-	movd EBP, MM1;
-	movd ESP, MM1;
+    movd EAX, MM1;  
+    movd EBX, MM1;  
+    movd ECX, MM1;
+    movd EDX, MM1;
+    movd ESI, MM1;
+    movd EDI, MM1;
+    movd EBP, MM1;
+    movd ESP, MM1;
 
-	movd XMM1, EAX;	
-	movd XMM1, EBX;	
-	movd XMM1, ECX;
-	movd XMM1, EDX;
-	movd XMM1, ESI;
-	movd XMM1, EDI;
-	movd XMM1, EBP;
-	movd XMM1, ESP;
+    movd XMM1, EAX; 
+    movd XMM1, EBX; 
+    movd XMM1, ECX;
+    movd XMM1, EDX;
+    movd XMM1, ESI;
+    movd XMM1, EDI;
+    movd XMM1, EBP;
+    movd XMM1, ESP;
 
-	movd MM1, EAX;	
-	movd MM1, EBX;	
-	movd MM1, ECX;
-	movd MM1, EDX;
-	movd MM1, ESI;
-	movd MM1, EDI;
-	movd MM1, EBP;
-	movd MM1, ESP;
+    movd MM1, EAX;  
+    movd MM1, EBX;  
+    movd MM1, ECX;
+    movd MM1, EDX;
+    movd MM1, ESI;
+    movd MM1, EDI;
+    movd MM1, EBP;
+    movd MM1, ESP;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2553,8 +2553,8 @@ void test27()
     {
     asm
     {
-	    movdqu XMM0, a;
-	    pslldq XMM0, 2;
+        movdqu XMM0, a;
+        pslldq XMM0, 2;
     }
     }
 }
@@ -2590,23 +2590,23 @@ void test28()
 {
     version (Windows)
     {
-	cfloat[4] z;
-	static const ubyte[8] A = [3, 4, 9, 0, 1, 3, 7, 2];
-	ubyte[8] b;
+    cfloat[4] z;
+    static const ubyte[8] A = [3, 4, 9, 0, 1, 3, 7, 2];
+    ubyte[8] b;
 
-	asm{
-		movq MM0, z;
-		movq MM0, A;
-		movq b, MM0;
-	}
-	
-	for(size_t i = 0; i < A.length; i++)
-	{
-		if(A[i] != b[i])
-		{
-			assert(0);
-		}
-	}
+    asm{
+        movq MM0, z;
+        movq MM0, A;
+        movq b, MM0;
+    }
+    
+    for(size_t i = 0; i < A.length; i++)
+    {
+        if(A[i] != b[i])
+        {
+            assert(0);
+        }
+    }
     }
 }
 
@@ -2619,16 +2619,16 @@ void test29()
     int* x;
     asm
     {
-	push offsetof bar29;
-	pop EAX;
-	mov x, EAX;
+    push offsetof bar29;
+    pop EAX;
+    mov x, EAX;
     }
     assert(*x == 3);
 
     asm
     {
-	mov EAX, offsetof bar29;
-	mov x, EAX;
+    mov EAX, offsetof bar29;
+    mov x, EAX;
     }
     assert(*x == 3);
 }
@@ -2640,11 +2640,11 @@ const int CONST_OFFSET30 = 10;
 
 void foo30()
 {
-	asm
-	{
-		mov EDX, 10;
-		mov EAX, [EDX + CONST_OFFSET30];
-	}
+    asm
+    {
+        mov EDX, 10;
+        mov EAX, [EDX + CONST_OFFSET30];
+    }
 }
 
 void test30()
@@ -2656,35 +2656,35 @@ void test30()
 void test31()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xF7, 0xD8,       	// neg	EAX
-	0x74, 0x04,       	// je	L8
-	0xF7, 0xD8,       	// neg	EAX
-	0x75, 0xFC,       	// jne	L4
-	0x40,      	    	// inc	EAX
+    0xF7, 0xD8,         // neg  EAX
+    0x74, 0x04,         // je   L8
+    0xF7, 0xD8,         // neg  EAX
+    0x75, 0xFC,         // jne  L4
+    0x40,               // inc  EAX
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	neg     EAX;
-	je      L2;
+    neg     EAX;
+    je      L2;
     L3:
-	neg     EAX;
-	jne     L3;
+    neg     EAX;
+    jne     L3;
     L2:
-	inc     EAX;
+    inc     EAX;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2812,8 +2812,8 @@ void test33()
 
     asm
     {
-	mov EAX, x;
-	mov EAX, y;
+    mov EAX, x;
+    mov EAX, y;
     }
 }
 
@@ -2841,10 +2841,10 @@ void test35()
 
     asm
     {
-	mov ECX, foo35		;
-	mov q, ECX		;
-	lea EDX, foo35		;
-	mov p, EDX		;
+    mov ECX, foo35      ;
+    mov q, ECX      ;
+    lea EDX, foo35      ;
+    mov p, EDX      ;
     }
     assert(p == &foo35);
     assert(q == *cast(uint *)p);
@@ -2929,8 +2929,8 @@ void test40()
     printf("");
     const string s = "abcdefghi";
     asm
-    {	jmp L1;
-	ds s;
+    {   jmp L1;
+    ds s;
     L1:;
     }
     end: ;
@@ -2941,19 +2941,19 @@ void test40()
 void test41()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x66,0x0F,0x28,0x0C,0x06, 	// movapd	XMM1,[EAX][ESI]
-	0x66,0x0F,0x28,0x0C,0x06, 	// movapd	XMM1,[EAX][ESI]
-	0x66,0x0F,0x28,0x0C,0x46, 	// movapd	XMM1,[EAX*2][ESI]
-	0x66,0x0F,0x28,0x0C,0x86, 	// movapd	XMM1,[EAX*4][ESI]
-	0x66,0x0F,0x28,0x0C,0xC6, 	// movapd	XMM1,[EAX*8][ESI]
+    0x66,0x0F,0x28,0x0C,0x06,   // movapd   XMM1,[EAX][ESI]
+    0x66,0x0F,0x28,0x0C,0x06,   // movapd   XMM1,[EAX][ESI]
+    0x66,0x0F,0x28,0x0C,0x46,   // movapd   XMM1,[EAX*2][ESI]
+    0x66,0x0F,0x28,0x0C,0x86,   // movapd   XMM1,[EAX*4][ESI]
+    0x66,0x0F,0x28,0x0C,0xC6,   // movapd   XMM1,[EAX*8][ESI]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
         movapd XMM1, [ESI+EAX];
         movapd XMM1, [ESI+1*EAX];
@@ -2961,13 +2961,13 @@ void test41()
         movapd XMM1, [ESI+4*EAX];
         movapd XMM1, [ESI+8*EAX];
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2983,7 +2983,7 @@ void test42()
 {
     asm
     {
-	mov EAX, enumeration42;
+    mov EAX, enumeration42;
     }
 }
 
@@ -3030,41 +3030,41 @@ void test44()
 void test45()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xDA, 0xC0,       // fcmovb	ST(0)
-	0xDA, 0xC1,       // fcmovb
-	0xDA, 0xCA,       // fcmove	ST(2)
-	0xDA, 0xD3,       // fcmovbe	ST(3)
-	0xDA, 0xDC,       // fcmovu	ST(4)
-	0xDB, 0xC5,       // fcmovnb	ST(5)
-	0xDB, 0xCE,       // fcmovne	ST(6)
-	0xDB, 0xD7,       // fcmovnbe	ST(7)
-	0xDB, 0xD9,       // fcmovnu
+    0xDA, 0xC0,       // fcmovb ST(0)
+    0xDA, 0xC1,       // fcmovb
+    0xDA, 0xCA,       // fcmove ST(2)
+    0xDA, 0xD3,       // fcmovbe    ST(3)
+    0xDA, 0xDC,       // fcmovu ST(4)
+    0xDB, 0xC5,       // fcmovnb    ST(5)
+    0xDB, 0xCE,       // fcmovne    ST(6)
+    0xDB, 0xD7,       // fcmovnbe   ST(7)
+    0xDB, 0xD9,       // fcmovnu
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	fcmovb   ST, ST(0);
-	fcmovb   ST, ST(1);
-	fcmove   ST, ST(2);
-	fcmovbe  ST, ST(3);
-	fcmovu   ST, ST(4);
-	fcmovnb  ST, ST(5);
-	fcmovne  ST, ST(6);
-	fcmovnbe ST, ST(7);
-	fcmovnu  ST, ST(1);
+    fcmovb   ST, ST(0);
+    fcmovb   ST, ST(1);
+    fcmove   ST, ST(2);
+    fcmovbe  ST, ST(3);
+    fcmovu   ST, ST(4);
+    fcmovnb  ST, ST(5);
+    fcmovne  ST, ST(6);
+    fcmovnbe ST, ST(7);
+    fcmovnu  ST, ST(1);
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -3074,37 +3074,37 @@ L1:					;
 void test46()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x66, 0x0F, 0x3A, 0x41, 0xCA, 0x08,	// dppd XMM1,XMM2,8
-	0x66, 0x0F, 0x3A, 0x40, 0xDC, 0x07,	// dpps XMM3,XMM4,7
-	0x66, 0x0F, 0x50, 0xF3,			// movmskpd ESI,XMM3
-	0x66, 0x0F, 0x50, 0xC7,			// movmskpd EAX,XMM7
-	0x0F, 0x50, 0xC7,			// movmskps EAX,XMM7
-	0x0F, 0xD7, 0xC7,			// pmovmskb EAX,MM7
-	0x66, 0x0F, 0xD7, 0xC7,			// pmovmskb EAX,XMM7
+    0x66, 0x0F, 0x3A, 0x41, 0xCA, 0x08, // dppd XMM1,XMM2,8
+    0x66, 0x0F, 0x3A, 0x40, 0xDC, 0x07, // dpps XMM3,XMM4,7
+    0x66, 0x0F, 0x50, 0xF3,         // movmskpd ESI,XMM3
+    0x66, 0x0F, 0x50, 0xC7,         // movmskpd EAX,XMM7
+    0x0F, 0x50, 0xC7,           // movmskps EAX,XMM7
+    0x0F, 0xD7, 0xC7,           // pmovmskb EAX,MM7
+    0x66, 0x0F, 0xD7, 0xC7,         // pmovmskb EAX,XMM7
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	dppd	XMM1,XMM2,8		;
-	dpps	XMM3,XMM4,7		;
-	movmskpd ESI,XMM3		;
-	movmskpd EAX,XMM7		;
-	movmskps EAX,XMM7		;
-	pmovmskb EAX,MM7		;
-	pmovmskb EAX,XMM7		;
+    dppd    XMM1,XMM2,8     ;
+    dpps    XMM3,XMM4,7     ;
+    movmskpd ESI,XMM3       ;
+    movmskpd EAX,XMM7       ;
+    movmskps EAX,XMM7       ;
+    pmovmskb EAX,MM7        ;
+    pmovmskb EAX,XMM7       ;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -3150,438 +3150,438 @@ void test48()
 void test49()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x00, 0xC0,       	// add	AL,AL
-	0x00, 0xD8,       	// add	AL,BL
-	0x00, 0xC8,       	// add	AL,CL
-	0x00, 0xD0,       	// add	AL,DL
-	0x00, 0xE0,       	// add	AL,AH
-	0x00, 0xF8,       	// add	AL,BH
-	0x00, 0xE8,       	// add	AL,CH
-	0x00, 0xF0,       	// add	AL,DH
-	0x00, 0xC4,       	// add	AH,AL
-	0x00, 0xDC,       	// add	AH,BL
-	0x00, 0xCC,       	// add	AH,CL
-	0x00, 0xD4,       	// add	AH,DL
-	0x00, 0xE4,       	// add	AH,AH
-	0x00, 0xFC,       	// add	AH,BH
-	0x00, 0xEC,       	// add	AH,CH
-	0x00, 0xF4,       	// add	AH,DH
-	0x00, 0xC3,       	// add	BL,AL
-	0x00, 0xDB,       	// add	BL,BL
-	0x00, 0xCB,       	// add	BL,CL
-	0x00, 0xD3,       	// add	BL,DL
-	0x00, 0xE3,       	// add	BL,AH
-	0x00, 0xFB,       	// add	BL,BH
-	0x00, 0xEB,       	// add	BL,CH
-	0x00, 0xF3,       	// add	BL,DH
-	0x00, 0xC7,       	// add	BH,AL
-	0x00, 0xDF,       	// add	BH,BL
-	0x00, 0xCF,       	// add	BH,CL
-	0x00, 0xD7,       	// add	BH,DL
-	0x00, 0xE7,       	// add	BH,AH
-	0x00, 0xFF,       	// add	BH,BH
-	0x00, 0xEF,       	// add	BH,CH
-	0x00, 0xF7,       	// add	BH,DH
-	0x00, 0xC1,       	// add	CL,AL
-	0x00, 0xD9,       	// add	CL,BL
-	0x00, 0xC9,       	// add	CL,CL
-	0x00, 0xD1,       	// add	CL,DL
-	0x00, 0xE1,       	// add	CL,AH
-	0x00, 0xF9,       	// add	CL,BH
-	0x00, 0xE9,       	// add	CL,CH
-	0x00, 0xF1,       	// add	CL,DH
-	0x00, 0xC5,       	// add	CH,AL
-	0x00, 0xDD,       	// add	CH,BL
-	0x00, 0xCD,       	// add	CH,CL
-	0x00, 0xD5,       	// add	CH,DL
-	0x00, 0xE5,       	// add	CH,AH
-	0x00, 0xFD,       	// add	CH,BH
-	0x00, 0xED,       	// add	CH,CH
-	0x00, 0xF5,       	// add	CH,DH
-	0x00, 0xC2,       	// add	DL,AL
-	0x00, 0xDA,       	// add	DL,BL
-	0x00, 0xCA,       	// add	DL,CL
-	0x00, 0xD2,       	// add	DL,DL
-	0x00, 0xE2,       	// add	DL,AH
-	0x00, 0xFA,       	// add	DL,BH
-	0x00, 0xEA,       	// add	DL,CH
-	0x00, 0xF2,       	// add	DL,DH
-	0x00, 0xC6,       	// add	DH,AL
-	0x00, 0xDE,       	// add	DH,BL
-	0x00, 0xCE,       	// add	DH,CL
-	0x00, 0xD6,       	// add	DH,DL
-	0x00, 0xE6,       	// add	DH,AH
-	0x00, 0xFE,       	// add	DH,BH
-	0x00, 0xEE,       	// add	DH,CH
-	0x00, 0xF6,       	// add	DH,DH
-	0x66, 0x01, 0xC0,      	// add	AX,AX
-	0x66, 0x01, 0xD8,      	// add	AX,BX
-	0x66, 0x01, 0xC8,      	// add	AX,CX
-	0x66, 0x01, 0xD0,      	// add	AX,DX
-	0x66, 0x01, 0xF0,      	// add	AX,SI
-	0x66, 0x01, 0xF8,      	// add	AX,DI
-	0x66, 0x01, 0xE8,      	// add	AX,BP
-	0x66, 0x01, 0xE0,      	// add	AX,SP
-	0x66, 0x01, 0xC3,      	// add	BX,AX
-	0x66, 0x01, 0xDB,      	// add	BX,BX
-	0x66, 0x01, 0xCB,      	// add	BX,CX
-	0x66, 0x01, 0xD3,      	// add	BX,DX
-	0x66, 0x01, 0xF3,      	// add	BX,SI
-	0x66, 0x01, 0xFB,      	// add	BX,DI
-	0x66, 0x01, 0xEB,      	// add	BX,BP
-	0x66, 0x01, 0xE3,      	// add	BX,SP
-	0x66, 0x01, 0xC1,      	// add	CX,AX
-	0x66, 0x01, 0xD9,      	// add	CX,BX
-	0x66, 0x01, 0xC9,      	// add	CX,CX
-	0x66, 0x01, 0xD1,      	// add	CX,DX
-	0x66, 0x01, 0xF1,      	// add	CX,SI
-	0x66, 0x01, 0xF9,      	// add	CX,DI
-	0x66, 0x01, 0xE9,      	// add	CX,BP
-	0x66, 0x01, 0xE1,      	// add	CX,SP
-	0x66, 0x01, 0xC2,      	// add	DX,AX
-	0x66, 0x01, 0xDA,      	// add	DX,BX
-	0x66, 0x01, 0xCA,      	// add	DX,CX
-	0x66, 0x01, 0xD2,      	// add	DX,DX
-	0x66, 0x01, 0xF2,      	// add	DX,SI
-	0x66, 0x01, 0xFA,      	// add	DX,DI
-	0x66, 0x01, 0xEA,      	// add	DX,BP
-	0x66, 0x01, 0xE2,      	// add	DX,SP
-	0x66, 0x01, 0xC6,      	// add	SI,AX
-	0x66, 0x01, 0xDE,      	// add	SI,BX
-	0x66, 0x01, 0xCE,      	// add	SI,CX
-	0x66, 0x01, 0xD6,      	// add	SI,DX
-	0x66, 0x01, 0xF6,      	// add	SI,SI
-	0x66, 0x01, 0xFE,      	// add	SI,DI
-	0x66, 0x01, 0xEE,      	// add	SI,BP
-	0x66, 0x01, 0xE6,      	// add	SI,SP
-	0x66, 0x01, 0xC7,      	// add	DI,AX
-	0x66, 0x01, 0xDF,      	// add	DI,BX
-	0x66, 0x01, 0xCF,      	// add	DI,CX
-	0x66, 0x01, 0xD7,      	// add	DI,DX
-	0x66, 0x01, 0xF7,      	// add	DI,SI
-	0x66, 0x01, 0xFF,      	// add	DI,DI
-	0x66, 0x01, 0xEF,      	// add	DI,BP
-	0x66, 0x01, 0xE7,      	// add	DI,SP
-	0x66, 0x01, 0xC5,      	// add	BP,AX
-	0x66, 0x01, 0xDD,      	// add	BP,BX
-	0x66, 0x01, 0xCD,      	// add	BP,CX
-	0x66, 0x01, 0xD5,      	// add	BP,DX
-	0x66, 0x01, 0xF5,      	// add	BP,SI
-	0x66, 0x01, 0xFD,      	// add	BP,DI
-	0x66, 0x01, 0xED,      	// add	BP,BP
-	0x66, 0x01, 0xE5,      	// add	BP,SP
-	0x66, 0x01, 0xC4,      	// add	SP,AX
-	0x66, 0x01, 0xDC,      	// add	SP,BX
-	0x66, 0x01, 0xCC,      	// add	SP,CX
-	0x66, 0x01, 0xD4,      	// add	SP,DX
-	0x66, 0x01, 0xF4,      	// add	SP,SI
-	0x66, 0x01, 0xFC,      	// add	SP,DI
-	0x66, 0x01, 0xEC,      	// add	SP,BP
-	0x66, 0x01, 0xE4,      	// add	SP,SP
-	0x01, 0xC0,       	// add	EAX,EAX
-	0x01, 0xD8,       	// add	EAX,EBX
-	0x01, 0xC8,       	// add	EAX,ECX
-	0x01, 0xD0,       	// add	EAX,EDX
-	0x01, 0xF0,       	// add	EAX,ESI
-	0x01, 0xF8,       	// add	EAX,EDI
-	0x01, 0xE8,       	// add	EAX,EBP
-	0x01, 0xE0,       	// add	EAX,ESP
-	0x01, 0xC3,       	// add	EBX,EAX
-	0x01, 0xDB,       	// add	EBX,EBX
-	0x01, 0xCB,       	// add	EBX,ECX
-	0x01, 0xD3,       	// add	EBX,EDX
-	0x01, 0xF3,       	// add	EBX,ESI
-	0x01, 0xFB,       	// add	EBX,EDI
-	0x01, 0xEB,       	// add	EBX,EBP
-	0x01, 0xE3,       	// add	EBX,ESP
-	0x01, 0xC1,       	// add	ECX,EAX
-	0x01, 0xD9,       	// add	ECX,EBX
-	0x01, 0xC9,       	// add	ECX,ECX
-	0x01, 0xD1,       	// add	ECX,EDX
-	0x01, 0xF1,       	// add	ECX,ESI
-	0x01, 0xF9,       	// add	ECX,EDI
-	0x01, 0xE9,       	// add	ECX,EBP
-	0x01, 0xE1,       	// add	ECX,ESP
-	0x01, 0xC2,       	// add	EDX,EAX
-	0x01, 0xDA,       	// add	EDX,EBX
-	0x01, 0xCA,       	// add	EDX,ECX
-	0x01, 0xD2,       	// add	EDX,EDX
-	0x01, 0xF2,       	// add	EDX,ESI
-	0x01, 0xFA,       	// add	EDX,EDI
-	0x01, 0xEA,       	// add	EDX,EBP
-	0x01, 0xE2,       	// add	EDX,ESP
-	0x01, 0xC6,       	// add	ESI,EAX
-	0x01, 0xDE,       	// add	ESI,EBX
-	0x01, 0xCE,       	// add	ESI,ECX
-	0x01, 0xD6,       	// add	ESI,EDX
-	0x01, 0xF6,       	// add	ESI,ESI
-	0x01, 0xFE,       	// add	ESI,EDI
-	0x01, 0xEE,       	// add	ESI,EBP
-	0x01, 0xE6,       	// add	ESI,ESP
-	0x01, 0xC7,       	// add	EDI,EAX
-	0x01, 0xDF,       	// add	EDI,EBX
-	0x01, 0xCF,       	// add	EDI,ECX
-	0x01, 0xD7,       	// add	EDI,EDX
-	0x01, 0xF7,       	// add	EDI,ESI
-	0x01, 0xFF,       	// add	EDI,EDI
-	0x01, 0xEF,       	// add	EDI,EBP
-	0x01, 0xE7,       	// add	EDI,ESP
-	0x01, 0xC5,       	// add	EBP,EAX
-	0x01, 0xDD,       	// add	EBP,EBX
-	0x01, 0xCD,       	// add	EBP,ECX
-	0x01, 0xD5,       	// add	EBP,EDX
-	0x01, 0xF5,       	// add	EBP,ESI
-	0x01, 0xFD,       	// add	EBP,EDI
-	0x01, 0xED,       	// add	EBP,EBP
-	0x01, 0xE5,       	// add	EBP,ESP
-	0x01, 0xC4,       	// add	ESP,EAX
-	0x01, 0xDC,       	// add	ESP,EBX
-	0x01, 0xCC,       	// add	ESP,ECX
-	0x01, 0xD4,       	// add	ESP,EDX
-	0x01, 0xF4,       	// add	ESP,ESI
-	0x01, 0xFC,       	// add	ESP,EDI
-	0x01, 0xEC,       	// add	ESP,EBP
-	0x01, 0xE4,       	// add	ESP,ESP
+    0x00, 0xC0,         // add  AL,AL
+    0x00, 0xD8,         // add  AL,BL
+    0x00, 0xC8,         // add  AL,CL
+    0x00, 0xD0,         // add  AL,DL
+    0x00, 0xE0,         // add  AL,AH
+    0x00, 0xF8,         // add  AL,BH
+    0x00, 0xE8,         // add  AL,CH
+    0x00, 0xF0,         // add  AL,DH
+    0x00, 0xC4,         // add  AH,AL
+    0x00, 0xDC,         // add  AH,BL
+    0x00, 0xCC,         // add  AH,CL
+    0x00, 0xD4,         // add  AH,DL
+    0x00, 0xE4,         // add  AH,AH
+    0x00, 0xFC,         // add  AH,BH
+    0x00, 0xEC,         // add  AH,CH
+    0x00, 0xF4,         // add  AH,DH
+    0x00, 0xC3,         // add  BL,AL
+    0x00, 0xDB,         // add  BL,BL
+    0x00, 0xCB,         // add  BL,CL
+    0x00, 0xD3,         // add  BL,DL
+    0x00, 0xE3,         // add  BL,AH
+    0x00, 0xFB,         // add  BL,BH
+    0x00, 0xEB,         // add  BL,CH
+    0x00, 0xF3,         // add  BL,DH
+    0x00, 0xC7,         // add  BH,AL
+    0x00, 0xDF,         // add  BH,BL
+    0x00, 0xCF,         // add  BH,CL
+    0x00, 0xD7,         // add  BH,DL
+    0x00, 0xE7,         // add  BH,AH
+    0x00, 0xFF,         // add  BH,BH
+    0x00, 0xEF,         // add  BH,CH
+    0x00, 0xF7,         // add  BH,DH
+    0x00, 0xC1,         // add  CL,AL
+    0x00, 0xD9,         // add  CL,BL
+    0x00, 0xC9,         // add  CL,CL
+    0x00, 0xD1,         // add  CL,DL
+    0x00, 0xE1,         // add  CL,AH
+    0x00, 0xF9,         // add  CL,BH
+    0x00, 0xE9,         // add  CL,CH
+    0x00, 0xF1,         // add  CL,DH
+    0x00, 0xC5,         // add  CH,AL
+    0x00, 0xDD,         // add  CH,BL
+    0x00, 0xCD,         // add  CH,CL
+    0x00, 0xD5,         // add  CH,DL
+    0x00, 0xE5,         // add  CH,AH
+    0x00, 0xFD,         // add  CH,BH
+    0x00, 0xED,         // add  CH,CH
+    0x00, 0xF5,         // add  CH,DH
+    0x00, 0xC2,         // add  DL,AL
+    0x00, 0xDA,         // add  DL,BL
+    0x00, 0xCA,         // add  DL,CL
+    0x00, 0xD2,         // add  DL,DL
+    0x00, 0xE2,         // add  DL,AH
+    0x00, 0xFA,         // add  DL,BH
+    0x00, 0xEA,         // add  DL,CH
+    0x00, 0xF2,         // add  DL,DH
+    0x00, 0xC6,         // add  DH,AL
+    0x00, 0xDE,         // add  DH,BL
+    0x00, 0xCE,         // add  DH,CL
+    0x00, 0xD6,         // add  DH,DL
+    0x00, 0xE6,         // add  DH,AH
+    0x00, 0xFE,         // add  DH,BH
+    0x00, 0xEE,         // add  DH,CH
+    0x00, 0xF6,         // add  DH,DH
+    0x66, 0x01, 0xC0,       // add  AX,AX
+    0x66, 0x01, 0xD8,       // add  AX,BX
+    0x66, 0x01, 0xC8,       // add  AX,CX
+    0x66, 0x01, 0xD0,       // add  AX,DX
+    0x66, 0x01, 0xF0,       // add  AX,SI
+    0x66, 0x01, 0xF8,       // add  AX,DI
+    0x66, 0x01, 0xE8,       // add  AX,BP
+    0x66, 0x01, 0xE0,       // add  AX,SP
+    0x66, 0x01, 0xC3,       // add  BX,AX
+    0x66, 0x01, 0xDB,       // add  BX,BX
+    0x66, 0x01, 0xCB,       // add  BX,CX
+    0x66, 0x01, 0xD3,       // add  BX,DX
+    0x66, 0x01, 0xF3,       // add  BX,SI
+    0x66, 0x01, 0xFB,       // add  BX,DI
+    0x66, 0x01, 0xEB,       // add  BX,BP
+    0x66, 0x01, 0xE3,       // add  BX,SP
+    0x66, 0x01, 0xC1,       // add  CX,AX
+    0x66, 0x01, 0xD9,       // add  CX,BX
+    0x66, 0x01, 0xC9,       // add  CX,CX
+    0x66, 0x01, 0xD1,       // add  CX,DX
+    0x66, 0x01, 0xF1,       // add  CX,SI
+    0x66, 0x01, 0xF9,       // add  CX,DI
+    0x66, 0x01, 0xE9,       // add  CX,BP
+    0x66, 0x01, 0xE1,       // add  CX,SP
+    0x66, 0x01, 0xC2,       // add  DX,AX
+    0x66, 0x01, 0xDA,       // add  DX,BX
+    0x66, 0x01, 0xCA,       // add  DX,CX
+    0x66, 0x01, 0xD2,       // add  DX,DX
+    0x66, 0x01, 0xF2,       // add  DX,SI
+    0x66, 0x01, 0xFA,       // add  DX,DI
+    0x66, 0x01, 0xEA,       // add  DX,BP
+    0x66, 0x01, 0xE2,       // add  DX,SP
+    0x66, 0x01, 0xC6,       // add  SI,AX
+    0x66, 0x01, 0xDE,       // add  SI,BX
+    0x66, 0x01, 0xCE,       // add  SI,CX
+    0x66, 0x01, 0xD6,       // add  SI,DX
+    0x66, 0x01, 0xF6,       // add  SI,SI
+    0x66, 0x01, 0xFE,       // add  SI,DI
+    0x66, 0x01, 0xEE,       // add  SI,BP
+    0x66, 0x01, 0xE6,       // add  SI,SP
+    0x66, 0x01, 0xC7,       // add  DI,AX
+    0x66, 0x01, 0xDF,       // add  DI,BX
+    0x66, 0x01, 0xCF,       // add  DI,CX
+    0x66, 0x01, 0xD7,       // add  DI,DX
+    0x66, 0x01, 0xF7,       // add  DI,SI
+    0x66, 0x01, 0xFF,       // add  DI,DI
+    0x66, 0x01, 0xEF,       // add  DI,BP
+    0x66, 0x01, 0xE7,       // add  DI,SP
+    0x66, 0x01, 0xC5,       // add  BP,AX
+    0x66, 0x01, 0xDD,       // add  BP,BX
+    0x66, 0x01, 0xCD,       // add  BP,CX
+    0x66, 0x01, 0xD5,       // add  BP,DX
+    0x66, 0x01, 0xF5,       // add  BP,SI
+    0x66, 0x01, 0xFD,       // add  BP,DI
+    0x66, 0x01, 0xED,       // add  BP,BP
+    0x66, 0x01, 0xE5,       // add  BP,SP
+    0x66, 0x01, 0xC4,       // add  SP,AX
+    0x66, 0x01, 0xDC,       // add  SP,BX
+    0x66, 0x01, 0xCC,       // add  SP,CX
+    0x66, 0x01, 0xD4,       // add  SP,DX
+    0x66, 0x01, 0xF4,       // add  SP,SI
+    0x66, 0x01, 0xFC,       // add  SP,DI
+    0x66, 0x01, 0xEC,       // add  SP,BP
+    0x66, 0x01, 0xE4,       // add  SP,SP
+    0x01, 0xC0,         // add  EAX,EAX
+    0x01, 0xD8,         // add  EAX,EBX
+    0x01, 0xC8,         // add  EAX,ECX
+    0x01, 0xD0,         // add  EAX,EDX
+    0x01, 0xF0,         // add  EAX,ESI
+    0x01, 0xF8,         // add  EAX,EDI
+    0x01, 0xE8,         // add  EAX,EBP
+    0x01, 0xE0,         // add  EAX,ESP
+    0x01, 0xC3,         // add  EBX,EAX
+    0x01, 0xDB,         // add  EBX,EBX
+    0x01, 0xCB,         // add  EBX,ECX
+    0x01, 0xD3,         // add  EBX,EDX
+    0x01, 0xF3,         // add  EBX,ESI
+    0x01, 0xFB,         // add  EBX,EDI
+    0x01, 0xEB,         // add  EBX,EBP
+    0x01, 0xE3,         // add  EBX,ESP
+    0x01, 0xC1,         // add  ECX,EAX
+    0x01, 0xD9,         // add  ECX,EBX
+    0x01, 0xC9,         // add  ECX,ECX
+    0x01, 0xD1,         // add  ECX,EDX
+    0x01, 0xF1,         // add  ECX,ESI
+    0x01, 0xF9,         // add  ECX,EDI
+    0x01, 0xE9,         // add  ECX,EBP
+    0x01, 0xE1,         // add  ECX,ESP
+    0x01, 0xC2,         // add  EDX,EAX
+    0x01, 0xDA,         // add  EDX,EBX
+    0x01, 0xCA,         // add  EDX,ECX
+    0x01, 0xD2,         // add  EDX,EDX
+    0x01, 0xF2,         // add  EDX,ESI
+    0x01, 0xFA,         // add  EDX,EDI
+    0x01, 0xEA,         // add  EDX,EBP
+    0x01, 0xE2,         // add  EDX,ESP
+    0x01, 0xC6,         // add  ESI,EAX
+    0x01, 0xDE,         // add  ESI,EBX
+    0x01, 0xCE,         // add  ESI,ECX
+    0x01, 0xD6,         // add  ESI,EDX
+    0x01, 0xF6,         // add  ESI,ESI
+    0x01, 0xFE,         // add  ESI,EDI
+    0x01, 0xEE,         // add  ESI,EBP
+    0x01, 0xE6,         // add  ESI,ESP
+    0x01, 0xC7,         // add  EDI,EAX
+    0x01, 0xDF,         // add  EDI,EBX
+    0x01, 0xCF,         // add  EDI,ECX
+    0x01, 0xD7,         // add  EDI,EDX
+    0x01, 0xF7,         // add  EDI,ESI
+    0x01, 0xFF,         // add  EDI,EDI
+    0x01, 0xEF,         // add  EDI,EBP
+    0x01, 0xE7,         // add  EDI,ESP
+    0x01, 0xC5,         // add  EBP,EAX
+    0x01, 0xDD,         // add  EBP,EBX
+    0x01, 0xCD,         // add  EBP,ECX
+    0x01, 0xD5,         // add  EBP,EDX
+    0x01, 0xF5,         // add  EBP,ESI
+    0x01, 0xFD,         // add  EBP,EDI
+    0x01, 0xED,         // add  EBP,EBP
+    0x01, 0xE5,         // add  EBP,ESP
+    0x01, 0xC4,         // add  ESP,EAX
+    0x01, 0xDC,         // add  ESP,EBX
+    0x01, 0xCC,         // add  ESP,ECX
+    0x01, 0xD4,         // add  ESP,EDX
+    0x01, 0xF4,         // add  ESP,ESI
+    0x01, 0xFC,         // add  ESP,EDI
+    0x01, 0xEC,         // add  ESP,EBP
+    0x01, 0xE4,         // add  ESP,ESP
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	add	AL,AL	;
-	add	AL,BL	;
-	add	AL,CL	;
-	add	AL,DL	;
+    add AL,AL   ;
+    add AL,BL   ;
+    add AL,CL   ;
+    add AL,DL   ;
 
-	add	AL,AH	;
-	add	AL,BH	;
-	add	AL,CH	;
-	add	AL,DH	;
+    add AL,AH   ;
+    add AL,BH   ;
+    add AL,CH   ;
+    add AL,DH   ;
 
-	add	AH,AL	;
-	add	AH,BL	;
-	add	AH,CL	;
-	add	AH,DL	;
+    add AH,AL   ;
+    add AH,BL   ;
+    add AH,CL   ;
+    add AH,DL   ;
 
-	add	AH,AH	;
-	add	AH,BH	;
-	add	AH,CH	;
-	add	AH,DH	;
+    add AH,AH   ;
+    add AH,BH   ;
+    add AH,CH   ;
+    add AH,DH   ;
 
-	add	BL,AL	;
-	add	BL,BL	;
-	add	BL,CL	;
-	add	BL,DL	;
+    add BL,AL   ;
+    add BL,BL   ;
+    add BL,CL   ;
+    add BL,DL   ;
 
-	add	BL,AH	;
-	add	BL,BH	;
-	add	BL,CH	;
-	add	BL,DH	;
+    add BL,AH   ;
+    add BL,BH   ;
+    add BL,CH   ;
+    add BL,DH   ;
 
-	add	BH,AL	;
-	add	BH,BL	;
-	add	BH,CL	;
-	add	BH,DL	;
+    add BH,AL   ;
+    add BH,BL   ;
+    add BH,CL   ;
+    add BH,DL   ;
 
-	add	BH,AH	;
-	add	BH,BH	;
-	add	BH,CH	;
-	add	BH,DH	;
+    add BH,AH   ;
+    add BH,BH   ;
+    add BH,CH   ;
+    add BH,DH   ;
 
-	add	CL,AL	;
-	add	CL,BL	;
-	add	CL,CL	;
-	add	CL,DL	;
+    add CL,AL   ;
+    add CL,BL   ;
+    add CL,CL   ;
+    add CL,DL   ;
 
-	add	CL,AH	;
-	add	CL,BH	;
-	add	CL,CH	;
-	add	CL,DH	;
+    add CL,AH   ;
+    add CL,BH   ;
+    add CL,CH   ;
+    add CL,DH   ;
 
-	add	CH,AL	;
-	add	CH,BL	;
-	add	CH,CL	;
-	add	CH,DL	;
+    add CH,AL   ;
+    add CH,BL   ;
+    add CH,CL   ;
+    add CH,DL   ;
 
-	add	CH,AH	;
-	add	CH,BH	;
-	add	CH,CH	;
-	add	CH,DH	;
+    add CH,AH   ;
+    add CH,BH   ;
+    add CH,CH   ;
+    add CH,DH   ;
 
-	add	DL,AL	;
-	add	DL,BL	;
-	add	DL,CL	;
-	add	DL,DL	;
+    add DL,AL   ;
+    add DL,BL   ;
+    add DL,CL   ;
+    add DL,DL   ;
 
-	add	DL,AH	;
-	add	DL,BH	;
-	add	DL,CH	;
-	add	DL,DH	;
+    add DL,AH   ;
+    add DL,BH   ;
+    add DL,CH   ;
+    add DL,DH   ;
 
-	add	DH,AL	;
-	add	DH,BL	;
-	add	DH,CL	;
-	add	DH,DL	;
+    add DH,AL   ;
+    add DH,BL   ;
+    add DH,CL   ;
+    add DH,DL   ;
 
-	add	DH,AH	;
-	add	DH,BH	;
-	add	DH,CH	;
-	add	DH,DH	;
+    add DH,AH   ;
+    add DH,BH   ;
+    add DH,CH   ;
+    add DH,DH   ;
 
-	add	AX,AX	;
-	add	AX,BX	;
-	add	AX,CX	;
-	add	AX,DX	;
-	add	AX,SI	;
-	add	AX,DI	;
-	add	AX,BP	;
-	add	AX,SP	;
+    add AX,AX   ;
+    add AX,BX   ;
+    add AX,CX   ;
+    add AX,DX   ;
+    add AX,SI   ;
+    add AX,DI   ;
+    add AX,BP   ;
+    add AX,SP   ;
 
-	add	BX,AX	;
-	add	BX,BX	;
-	add	BX,CX	;
-	add	BX,DX	;
-	add	BX,SI	;
-	add	BX,DI	;
-	add	BX,BP	;
-	add	BX,SP	;
+    add BX,AX   ;
+    add BX,BX   ;
+    add BX,CX   ;
+    add BX,DX   ;
+    add BX,SI   ;
+    add BX,DI   ;
+    add BX,BP   ;
+    add BX,SP   ;
 
-	add	CX,AX	;
-	add	CX,BX	;
-	add	CX,CX	;
-	add	CX,DX	;
-	add	CX,SI	;
-	add	CX,DI	;
-	add	CX,BP	;
-	add	CX,SP	;
+    add CX,AX   ;
+    add CX,BX   ;
+    add CX,CX   ;
+    add CX,DX   ;
+    add CX,SI   ;
+    add CX,DI   ;
+    add CX,BP   ;
+    add CX,SP   ;
 
-	add	DX,AX	;
-	add	DX,BX	;
-	add	DX,CX	;
-	add	DX,DX	;
-	add	DX,SI	;
-	add	DX,DI	;
-	add	DX,BP	;
-	add	DX,SP	;
+    add DX,AX   ;
+    add DX,BX   ;
+    add DX,CX   ;
+    add DX,DX   ;
+    add DX,SI   ;
+    add DX,DI   ;
+    add DX,BP   ;
+    add DX,SP   ;
 
-	add	SI,AX	;
-	add	SI,BX	;
-	add	SI,CX	;
-	add	SI,DX	;
-	add	SI,SI	;
-	add	SI,DI	;
-	add	SI,BP	;
-	add	SI,SP	;
+    add SI,AX   ;
+    add SI,BX   ;
+    add SI,CX   ;
+    add SI,DX   ;
+    add SI,SI   ;
+    add SI,DI   ;
+    add SI,BP   ;
+    add SI,SP   ;
 
-	add	DI,AX	;
-	add	DI,BX	;
-	add	DI,CX	;
-	add	DI,DX	;
-	add	DI,SI	;
-	add	DI,DI	;
-	add	DI,BP	;
-	add	DI,SP	;
+    add DI,AX   ;
+    add DI,BX   ;
+    add DI,CX   ;
+    add DI,DX   ;
+    add DI,SI   ;
+    add DI,DI   ;
+    add DI,BP   ;
+    add DI,SP   ;
 
-	add	BP,AX	;
-	add	BP,BX	;
-	add	BP,CX	;
-	add	BP,DX	;
-	add	BP,SI	;
-	add	BP,DI	;
-	add	BP,BP	;
-	add	BP,SP	;
+    add BP,AX   ;
+    add BP,BX   ;
+    add BP,CX   ;
+    add BP,DX   ;
+    add BP,SI   ;
+    add BP,DI   ;
+    add BP,BP   ;
+    add BP,SP   ;
 
-	add	SP,AX	;
-	add	SP,BX	;
-	add	SP,CX	;
-	add	SP,DX	;
-	add	SP,SI	;
-	add	SP,DI	;
-	add	SP,BP	;
-	add	SP,SP	;
+    add SP,AX   ;
+    add SP,BX   ;
+    add SP,CX   ;
+    add SP,DX   ;
+    add SP,SI   ;
+    add SP,DI   ;
+    add SP,BP   ;
+    add SP,SP   ;
 
-	add	EAX,EAX	;
-	add	EAX,EBX	;
-	add	EAX,ECX	;
-	add	EAX,EDX	;
-	add	EAX,ESI	;
-	add	EAX,EDI	;
-	add	EAX,EBP	;
-	add	EAX,ESP	;
+    add EAX,EAX ;
+    add EAX,EBX ;
+    add EAX,ECX ;
+    add EAX,EDX ;
+    add EAX,ESI ;
+    add EAX,EDI ;
+    add EAX,EBP ;
+    add EAX,ESP ;
 
-	add	EBX,EAX	;
-	add	EBX,EBX	;
-	add	EBX,ECX	;
-	add	EBX,EDX	;
-	add	EBX,ESI	;
-	add	EBX,EDI	;
-	add	EBX,EBP	;
-	add	EBX,ESP	;
+    add EBX,EAX ;
+    add EBX,EBX ;
+    add EBX,ECX ;
+    add EBX,EDX ;
+    add EBX,ESI ;
+    add EBX,EDI ;
+    add EBX,EBP ;
+    add EBX,ESP ;
 
-	add	ECX,EAX	;
-	add	ECX,EBX	;
-	add	ECX,ECX	;
-	add	ECX,EDX	;
-	add	ECX,ESI	;
-	add	ECX,EDI	;
-	add	ECX,EBP	;
-	add	ECX,ESP	;
+    add ECX,EAX ;
+    add ECX,EBX ;
+    add ECX,ECX ;
+    add ECX,EDX ;
+    add ECX,ESI ;
+    add ECX,EDI ;
+    add ECX,EBP ;
+    add ECX,ESP ;
 
-	add	EDX,EAX	;
-	add	EDX,EBX	;
-	add	EDX,ECX	;
-	add	EDX,EDX	;
-	add	EDX,ESI	;
-	add	EDX,EDI	;
-	add	EDX,EBP	;
-	add	EDX,ESP	;
+    add EDX,EAX ;
+    add EDX,EBX ;
+    add EDX,ECX ;
+    add EDX,EDX ;
+    add EDX,ESI ;
+    add EDX,EDI ;
+    add EDX,EBP ;
+    add EDX,ESP ;
 
-	add	ESI,EAX	;
-	add	ESI,EBX	;
-	add	ESI,ECX	;
-	add	ESI,EDX	;
-	add	ESI,ESI	;
-	add	ESI,EDI	;
-	add	ESI,EBP	;
-	add	ESI,ESP	;
+    add ESI,EAX ;
+    add ESI,EBX ;
+    add ESI,ECX ;
+    add ESI,EDX ;
+    add ESI,ESI ;
+    add ESI,EDI ;
+    add ESI,EBP ;
+    add ESI,ESP ;
 
-	add	EDI,EAX	;
-	add	EDI,EBX	;
-	add	EDI,ECX	;
-	add	EDI,EDX	;
-	add	EDI,ESI	;
-	add	EDI,EDI	;
-	add	EDI,EBP	;
-	add	EDI,ESP	;
+    add EDI,EAX ;
+    add EDI,EBX ;
+    add EDI,ECX ;
+    add EDI,EDX ;
+    add EDI,ESI ;
+    add EDI,EDI ;
+    add EDI,EBP ;
+    add EDI,ESP ;
 
-	add	EBP,EAX	;
-	add	EBP,EBX	;
-	add	EBP,ECX	;
-	add	EBP,EDX	;
-	add	EBP,ESI	;
-	add	EBP,EDI	;
-	add	EBP,EBP	;
-	add	EBP,ESP	;
+    add EBP,EAX ;
+    add EBP,EBX ;
+    add EBP,ECX ;
+    add EBP,EDX ;
+    add EBP,ESI ;
+    add EBP,EDI ;
+    add EBP,EBP ;
+    add EBP,ESP ;
 
-	add	ESP,EAX	;
-	add	ESP,EBX	;
-	add	ESP,ECX	;
-	add	ESP,EDX	;
-	add	ESP,ESI	;
-	add	ESP,EDI	;
-	add	ESP,EBP	;
-	add	ESP,ESP	;
+    add ESP,EAX ;
+    add ESP,EBX ;
+    add ESP,ECX ;
+    add ESP,EDX ;
+    add ESP,ESI ;
+    add ESP,EDI ;
+    add ESP,EBP ;
+    add ESP,ESP ;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -3591,249 +3591,249 @@ L1:					;
 void test50()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x66, 0x98,     // cbw
-	0xF8,          	// clc
-	0xFC,          	// cld
-	0xFA,          	// cli
-	0xF5,          	// cmc
-	0xA6,          	// cmpsb
-	0x66, 0xA7,     // cmpsw
-	0xA7,          	// cmpsd
-	0x66, 0x99,     // cwd
-	0x27,          	// daa
-	0x2F,          	// das
-	0x48,          	// dec	EAX
-	0xF6, 0xF1,     // div	CL
-	0x66, 0xF7, 0xF3,  // div	BX
-	0xF7, 0xF2,     // div	EDX
-	0xF4,          	// hlt
-	0xF6, 0xFB,     // idiv	BL
-	0x66, 0xF7, 0xFA,  // idiv	DX
-	0xF7, 0xFE,     // idiv	ESI
-	0xF6, 0xEB,     // imul	BL
-	0x66, 0xF7, 0xEA,  // imul	DX
-	0xF7, 0xEE,     // imul	ESI
-	0xEC,          	// in	AL,DX
-	0x66, 0xED,     // in	AX,DX
-	0x43,          	// inc	EBX
-	0xCC,          	// int	3
-	0xCD, 0x67,     // int	067h
-	0xCE,          	// into
-	0x66, 0xCF,     // iret
-	0x77, 0xFC,     // ja	L30
-	0x77, 0xFA,     // ja	L30
-	0x73, 0xF8,     // jae	L30
-	0x73, 0xF6,     // jae	L30
-	0x73, 0xF4,     // jae	L30
-	0x72, 0xF2,     // jb	L30
-	0x72, 0xF0,     // jb	L30
-	0x76, 0xEE,     // jbe	L30
-	0x76, 0xEC,     // jbe	L30
-	0x72, 0xEA,     // jb	L30
-	0x67, 0xE3, 0xE7,  // jcxz	L30
-	0x74, 0xE5,     // je	L30
-	0x74, 0xE3,     // je	L30
-	0x7F, 0xE1,     // jg	L30
-	0x7F, 0xDF,     // jg	L30
-	0x7D, 0xDD,     // jge	L30
-	0x7D, 0xDB,     // jge	L30
-	0x7C, 0xD9,     // jl	L30
-	0x7C, 0xD7,     // jl	L30
-	0x7E, 0xD5,     // jle	L30
-	0x7E, 0xD3,     // jle	L30
-	0xEB, 0xD1,     // jmp short	L30
-	0x75, 0xCF,     // jne	L30
-	0x75, 0xCD,     // jne	L30
-	0x71, 0xCB,     // jno	L30
-	0x79, 0xC9,     // jns	L30
-	0x7B, 0xC7,     // jnp	L30
-	0x7B, 0xC5,     // jnp	L30
-	0x70, 0xC3,     // jo	L30
-	0x7A, 0xC1,     // jp	L30
-	0x7A, 0xBF,     // jp	L30
-	0x78, 0xBD,     // js	L30
-	0x9F,          	// lahf
-	0xC5, 0x30,     // lds	ESI,[EAX]
-	0x8B, 0xFB,     // mov	EDI,EBX
-	0xC4, 0x29,     // les	EBP,[ECX]
-	0xF0,          	// lock
-	0xAC,          	// lodsb
-	0x66, 0xAD,     // lodsw
-	0xAD,          	// lodsd
-	0xE2, 0xAF,     // loop	L30
-	0xE1, 0xAD,     // loope	L30
-	0xE1, 0xAB,     // loope	L30
-	0xE0, 0xA9,     // loopne	L30
-	0xE0, 0xA7,     // loopne	L30
-	0xA4,          	// movsb
-	0x66, 0xA5,     // movsw
-	0xA5,          	// movsd
-	0xF6, 0xE4,     // mul	AH
-	0x66, 0xF7, 0xE1,  // mul	CX
-	0xF7, 0xE5,     // mul	EBP
-	0x90,          	// nop
-	0xF7, 0xD7,     // not	EDI
-	0x66, 0xE7, 0x44,  // out	044h,AX
-	0xEE,          	// out	DX,AL
-	0x66, 0x9D,     // popf
-	0x66, 0x9C,     // pushf
-	0xD1, 0xDB,     // rcr	EBX,1
-	0xF3,          	// rep
-	0xF3,          	// rep
-	0xF2,          	// repne
-	0xF3,          	// rep
-	0xF2,          	// repne
-	0xC3,          	// ret
-	0xC2, 0x04, 0x00,  // ret  4
-	0xD1, 0xC1,     // rol	ECX,1
-	0xD1, 0xCA,     // ror	EDX,1
-	0x9E,          	// sahf
-	0xD1, 0xE5,     // shl	EBP,1
-	0xD1, 0xE4,     // shl	ESP,1
-	0xD1, 0xFF,     // sar	EDI,1
-	0xAE,          	// scasb
-	0x66, 0xAF,     // scasw
-	0xAF,          	// scasd
-	0xD1, 0xEE,     // shr	ESI,1
-	0xFD,          	// std
-	0xF9,          	// stc
-	0xFB,          	// sti
-	0xAA,          	// stosb
-	0x66, 0xAB,     // stosw
-	0xAB,          	// stosd
-	0x9B,          	// wait
-	0x91,          	// xchg	EAX,ECX
-	0xD7,          	// xlat
+    0x66, 0x98,     // cbw
+    0xF8,           // clc
+    0xFC,           // cld
+    0xFA,           // cli
+    0xF5,           // cmc
+    0xA6,           // cmpsb
+    0x66, 0xA7,     // cmpsw
+    0xA7,           // cmpsd
+    0x66, 0x99,     // cwd
+    0x27,           // daa
+    0x2F,           // das
+    0x48,           // dec  EAX
+    0xF6, 0xF1,     // div  CL
+    0x66, 0xF7, 0xF3,  // div   BX
+    0xF7, 0xF2,     // div  EDX
+    0xF4,           // hlt
+    0xF6, 0xFB,     // idiv BL
+    0x66, 0xF7, 0xFA,  // idiv  DX
+    0xF7, 0xFE,     // idiv ESI
+    0xF6, 0xEB,     // imul BL
+    0x66, 0xF7, 0xEA,  // imul  DX
+    0xF7, 0xEE,     // imul ESI
+    0xEC,           // in   AL,DX
+    0x66, 0xED,     // in   AX,DX
+    0x43,           // inc  EBX
+    0xCC,           // int  3
+    0xCD, 0x67,     // int  067h
+    0xCE,           // into
+    0x66, 0xCF,     // iret
+    0x77, 0xFC,     // ja   L30
+    0x77, 0xFA,     // ja   L30
+    0x73, 0xF8,     // jae  L30
+    0x73, 0xF6,     // jae  L30
+    0x73, 0xF4,     // jae  L30
+    0x72, 0xF2,     // jb   L30
+    0x72, 0xF0,     // jb   L30
+    0x76, 0xEE,     // jbe  L30
+    0x76, 0xEC,     // jbe  L30
+    0x72, 0xEA,     // jb   L30
+    0x67, 0xE3, 0xE7,  // jcxz  L30
+    0x74, 0xE5,     // je   L30
+    0x74, 0xE3,     // je   L30
+    0x7F, 0xE1,     // jg   L30
+    0x7F, 0xDF,     // jg   L30
+    0x7D, 0xDD,     // jge  L30
+    0x7D, 0xDB,     // jge  L30
+    0x7C, 0xD9,     // jl   L30
+    0x7C, 0xD7,     // jl   L30
+    0x7E, 0xD5,     // jle  L30
+    0x7E, 0xD3,     // jle  L30
+    0xEB, 0xD1,     // jmp short    L30
+    0x75, 0xCF,     // jne  L30
+    0x75, 0xCD,     // jne  L30
+    0x71, 0xCB,     // jno  L30
+    0x79, 0xC9,     // jns  L30
+    0x7B, 0xC7,     // jnp  L30
+    0x7B, 0xC5,     // jnp  L30
+    0x70, 0xC3,     // jo   L30
+    0x7A, 0xC1,     // jp   L30
+    0x7A, 0xBF,     // jp   L30
+    0x78, 0xBD,     // js   L30
+    0x9F,           // lahf
+    0xC5, 0x30,     // lds  ESI,[EAX]
+    0x8B, 0xFB,     // mov  EDI,EBX
+    0xC4, 0x29,     // les  EBP,[ECX]
+    0xF0,           // lock
+    0xAC,           // lodsb
+    0x66, 0xAD,     // lodsw
+    0xAD,           // lodsd
+    0xE2, 0xAF,     // loop L30
+    0xE1, 0xAD,     // loope    L30
+    0xE1, 0xAB,     // loope    L30
+    0xE0, 0xA9,     // loopne   L30
+    0xE0, 0xA7,     // loopne   L30
+    0xA4,           // movsb
+    0x66, 0xA5,     // movsw
+    0xA5,           // movsd
+    0xF6, 0xE4,     // mul  AH
+    0x66, 0xF7, 0xE1,  // mul   CX
+    0xF7, 0xE5,     // mul  EBP
+    0x90,           // nop
+    0xF7, 0xD7,     // not  EDI
+    0x66, 0xE7, 0x44,  // out   044h,AX
+    0xEE,           // out  DX,AL
+    0x66, 0x9D,     // popf
+    0x66, 0x9C,     // pushf
+    0xD1, 0xDB,     // rcr  EBX,1
+    0xF3,           // rep
+    0xF3,           // rep
+    0xF2,           // repne
+    0xF3,           // rep
+    0xF2,           // repne
+    0xC3,           // ret
+    0xC2, 0x04, 0x00,  // ret  4
+    0xD1, 0xC1,     // rol  ECX,1
+    0xD1, 0xCA,     // ror  EDX,1
+    0x9E,           // sahf
+    0xD1, 0xE5,     // shl  EBP,1
+    0xD1, 0xE4,     // shl  ESP,1
+    0xD1, 0xFF,     // sar  EDI,1
+    0xAE,           // scasb
+    0x66, 0xAF,     // scasw
+    0xAF,           // scasd
+    0xD1, 0xEE,     // shr  ESI,1
+    0xFD,           // std
+    0xF9,           // stc
+    0xFB,           // sti
+    0xAA,           // stosb
+    0x66, 0xAB,     // stosw
+    0xAB,           // stosd
+    0x9B,           // wait
+    0x91,           // xchg EAX,ECX
+    0xD7,           // xlat
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	cbw	;
-	clc	;
-	cld	;
-	cli	;
-	cmc	;
-	cmpsb	;
-	cmpsw	;
-	cmpsd	;
-	cwd	;
-	daa	;
-	das	;
-	dec	EAX	;
-	div	CL	;
-	div	BX	;
-	div	EDX	;
-	hlt		;
-	idiv	BL	;
-	idiv	DX	;
-	idiv	ESI	;
-	imul	BL	;
-	imul	DX	;
-	imul	ESI	;
-	in	AL,DX	;
-	in	AX,DX	;
-	inc	EBX	;
-	int	3	;
-	int	0x67	;
-	into		;
-L10:	iret		;
-	ja	L10	;
-	jnbe	L10	;
-	jae	L10	;
-	jnb	L10	;
-	jnc	L10	;
-	jb	L10	;
-	jnae	L10	;
-	jbe	L10	;
-	jna	L10	;
-	jc	L10	;
-	jcxz	L10	;
-	je	L10	;
-	jz	L10	;
-	jg	L10	;
-	jnle	L10	;
-	jge	L10	;
-	jnl	L10	;
-	jl	L10	;
-	jnge	L10	;
-	jle	L10	;
-	jng	L10	;
-	jmp	short L10	;
-	jne	L10	;
-	jnz	L10	;
-	jno	L10	;
-	jns	L10	;
-	jnp	L10	;
-	jpo	L10	;
-	jo	L10	;
-	jp	L10	;
-	jpe	L10	;
-	js	L10	;
-	lahf		;
-	lds	ESI,[EAX]	;
-	lea	EDI,[EBX]	;
-	les	EBP,[ECX]	;
-	lock	;
-	lodsb	;
-	lodsw	;
-	lodsd	;
-	loop	L10	;
-	loope	L10	;
-	loopz	L10	;
-	loopnz	L10	;
-	loopne	L10	;
-	movsb	;
-	movsw	;
-	movsd	;
-	mul	AH	;
-	mul	CX	;
-	mul	EBP	;
-	nop	;
-	not	EDI	;
-	out	0x44,AX	;
-	out	DX,AL	;
-	popf	;
-	pushf	;
-	rcr	EBX,1	;
-	rep	;
-	repe	;
-	repne	;
-	repz	;
-	repnz	;
-	ret	;
-	ret	4	;
-	rol	ECX,1	;
-	ror	EDX,1	;
-	sahf	;
-	sal	EBP,1	;
-	shl	ESP,1	;
-	sar	EDI,1	;
-	scasb	;
-	scasw	;
-	scasd	;
-	shr	ESI,1	;
-	std	;
-	stc	;
-	sti	;
-	stosb	;
-	stosw	;
-	stosd	;
-	wait	;
-	xchg	EAX,ECX	;
-	xlat	;
+    cbw ;
+    clc ;
+    cld ;
+    cli ;
+    cmc ;
+    cmpsb   ;
+    cmpsw   ;
+    cmpsd   ;
+    cwd ;
+    daa ;
+    das ;
+    dec EAX ;
+    div CL  ;
+    div BX  ;
+    div EDX ;
+    hlt     ;
+    idiv    BL  ;
+    idiv    DX  ;
+    idiv    ESI ;
+    imul    BL  ;
+    imul    DX  ;
+    imul    ESI ;
+    in  AL,DX   ;
+    in  AX,DX   ;
+    inc EBX ;
+    int 3   ;
+    int 0x67    ;
+    into        ;
+L10:    iret        ;
+    ja  L10 ;
+    jnbe    L10 ;
+    jae L10 ;
+    jnb L10 ;
+    jnc L10 ;
+    jb  L10 ;
+    jnae    L10 ;
+    jbe L10 ;
+    jna L10 ;
+    jc  L10 ;
+    jcxz    L10 ;
+    je  L10 ;
+    jz  L10 ;
+    jg  L10 ;
+    jnle    L10 ;
+    jge L10 ;
+    jnl L10 ;
+    jl  L10 ;
+    jnge    L10 ;
+    jle L10 ;
+    jng L10 ;
+    jmp short L10   ;
+    jne L10 ;
+    jnz L10 ;
+    jno L10 ;
+    jns L10 ;
+    jnp L10 ;
+    jpo L10 ;
+    jo  L10 ;
+    jp  L10 ;
+    jpe L10 ;
+    js  L10 ;
+    lahf        ;
+    lds ESI,[EAX]   ;
+    lea EDI,[EBX]   ;
+    les EBP,[ECX]   ;
+    lock    ;
+    lodsb   ;
+    lodsw   ;
+    lodsd   ;
+    loop    L10 ;
+    loope   L10 ;
+    loopz   L10 ;
+    loopnz  L10 ;
+    loopne  L10 ;
+    movsb   ;
+    movsw   ;
+    movsd   ;
+    mul AH  ;
+    mul CX  ;
+    mul EBP ;
+    nop ;
+    not EDI ;
+    out 0x44,AX ;
+    out DX,AL   ;
+    popf    ;
+    pushf   ;
+    rcr EBX,1   ;
+    rep ;
+    repe    ;
+    repne   ;
+    repz    ;
+    repnz   ;
+    ret ;
+    ret 4   ;
+    rol ECX,1   ;
+    ror EDX,1   ;
+    sahf    ;
+    sal EBP,1   ;
+    shl ESP,1   ;
+    sar EDI,1   ;
+    scasb   ;
+    scasw   ;
+    scasd   ;
+    shr ESI,1   ;
+    std ;
+    stc ;
+    sti ;
+    stosb   ;
+    stosw   ;
+    stosd   ;
+    wait    ;
+    xchg    EAX,ECX ;
+    xlat    ;
 
-L1:					;
-	pop	EBX			;
-	mov	p[EBP],EBX		;
+L1:                 ;
+    pop EBX         ;
+    mov p[EBP],EBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -3854,40 +3854,40 @@ class Test51
 void test52()
 {   int x;
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xF6, 0xD8,             	// neg	AL
-0x66, 	0xF7, 0xD8,             	// neg	AX
-	0xF7, 0xD8,             	// neg	EAX
-	0xF6, 0xDC,             	// neg	AH
+    0xF6, 0xD8,                 // neg  AL
+0x66,   0xF7, 0xD8,                 // neg  AX
+    0xF7, 0xD8,                 // neg  EAX
+    0xF6, 0xDC,                 // neg  AH
 
-	0xF7, 0x5D, 0xe8,          	// neg	dword ptr -8[EBP]
-	0xF6, 0x1B,             	// neg	byte ptr [EBX]
+    0xF7, 0x5D, 0xe8,           // neg  dword ptr -8[EBP]
+    0xF6, 0x1B,                 // neg  byte ptr [EBX]
     ];
 
     asm
     {
-	call	L1	;
+    call    L1  ;
 
-	neg	AL	;
-	neg	AX	;
-	neg	EAX	;
-	neg	AH	;
-//	neg	b	;
-//	neg	w	;
-//	neg	i	;
-//	neg	l	;
-	neg	x	;
-	neg	[EBX]	;
+    neg AL  ;
+    neg AX  ;
+    neg EAX ;
+    neg AH  ;
+//  neg b   ;
+//  neg w   ;
+//  neg i   ;
+//  neg l   ;
+    neg x   ;
+    neg [EBX]   ;
 
-L1:	pop	EAX	;
-	mov	p[EBP],EAX ;
+L1: pop EAX ;
+    mov p[EBP],EAX ;
     }
 
     foreach (ref i, b; data)
     {
-	//printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
-	assert(p[i] == b);
+    //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+    assert(p[i] == b);
     }
 }
 
@@ -3896,70 +3896,70 @@ L1:	pop	EAX	;
 void test53()
 {   int x;
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x8D, 0x04, 0x00,       	// lea	EAX,[EAX][EAX]
-	0x8D, 0x04, 0x08,       	// lea	EAX,[ECX][EAX]
-	0x8D, 0x04, 0x10,       	// lea	EAX,[EDX][EAX]
-	0x8D, 0x04, 0x18,       	// lea	EAX,[EBX][EAX]
-	0x8D, 0x04, 0x28,       	// lea	EAX,[EBP][EAX]
-	0x8D, 0x04, 0x30,       	// lea	EAX,[ESI][EAX]
-	0x8D, 0x04, 0x38,       	// lea	EAX,[EDI][EAX]
-	0x8D, 0x04, 0x00,       	// lea	EAX,[EAX][EAX]
-	0x8D, 0x04, 0x01,       	// lea	EAX,[EAX][ECX]
-	0x8D, 0x04, 0x02,       	// lea	EAX,[EAX][EDX]
-	0x8D, 0x04, 0x03,       	// lea	EAX,[EAX][EBX]
-	0x8D, 0x04, 0x04,       	// lea	EAX,[EAX][ESP]
-	0x8D, 0x44, 0x05, 0x00, 	// lea	EAX,0[EAX][EBP]
-	0x8D, 0x04, 0x06,       	// lea	EAX,[EAX][ESI]
-	0x8D, 0x04, 0x07,       	// lea	EAX,[EAX][EDI]
-	0x8D, 0x44, 0x01, 0x12,    			// lea	EAX,012h[EAX][ECX]
-	0x8D, 0x84, 0x01, 0x34, 0x12, 0x00, 0x00, 	// lea	EAX,01234h[EAX][ECX]
-	0x8D, 0x84, 0x01, 0x78, 0x56, 0x34, 0x12, 	// lea	EAX,012345678h[EAX][ECX]
-	0x8D, 0x44, 0x05, 0x12,    			// lea	EAX,012h[EAX][EBP]
-	0x8D, 0x84, 0x05, 0x34, 0x12, 0x00, 0x00, 	// lea	EAX,01234h[EAX][EBP]
-	0x8D, 0x84, 0x05, 0x78, 0x56, 0x34, 0x12, 	// lea	EAX,012345678h[EAX][EBP]
+    0x8D, 0x04, 0x00,           // lea  EAX,[EAX][EAX]
+    0x8D, 0x04, 0x08,           // lea  EAX,[ECX][EAX]
+    0x8D, 0x04, 0x10,           // lea  EAX,[EDX][EAX]
+    0x8D, 0x04, 0x18,           // lea  EAX,[EBX][EAX]
+    0x8D, 0x04, 0x28,           // lea  EAX,[EBP][EAX]
+    0x8D, 0x04, 0x30,           // lea  EAX,[ESI][EAX]
+    0x8D, 0x04, 0x38,           // lea  EAX,[EDI][EAX]
+    0x8D, 0x04, 0x00,           // lea  EAX,[EAX][EAX]
+    0x8D, 0x04, 0x01,           // lea  EAX,[EAX][ECX]
+    0x8D, 0x04, 0x02,           // lea  EAX,[EAX][EDX]
+    0x8D, 0x04, 0x03,           // lea  EAX,[EAX][EBX]
+    0x8D, 0x04, 0x04,           // lea  EAX,[EAX][ESP]
+    0x8D, 0x44, 0x05, 0x00,     // lea  EAX,0[EAX][EBP]
+    0x8D, 0x04, 0x06,           // lea  EAX,[EAX][ESI]
+    0x8D, 0x04, 0x07,           // lea  EAX,[EAX][EDI]
+    0x8D, 0x44, 0x01, 0x12,             // lea  EAX,012h[EAX][ECX]
+    0x8D, 0x84, 0x01, 0x34, 0x12, 0x00, 0x00,   // lea  EAX,01234h[EAX][ECX]
+    0x8D, 0x84, 0x01, 0x78, 0x56, 0x34, 0x12,   // lea  EAX,012345678h[EAX][ECX]
+    0x8D, 0x44, 0x05, 0x12,             // lea  EAX,012h[EAX][EBP]
+    0x8D, 0x84, 0x05, 0x34, 0x12, 0x00, 0x00,   // lea  EAX,01234h[EAX][EBP]
+    0x8D, 0x84, 0x05, 0x78, 0x56, 0x34, 0x12,   // lea  EAX,012345678h[EAX][EBP]
     ];
 
     asm
     {
-	call	L1	;
+    call    L1  ;
 
-	// Right
-	lea EAX, [EAX+EAX];
-	lea EAX, [EAX+ECX];
-	lea EAX, [EAX+EDX];
-	lea EAX, [EAX+EBX];
-	//lea EAX, [EAX+ESP]; ESP can't be on the right
-	lea EAX, [EAX+EBP];
-	lea EAX, [EAX+ESI];
-	lea EAX, [EAX+EDI];
-	// Left
-	lea EAX, [EAX+EAX];
-	lea EAX, [ECX+EAX];
-	lea EAX, [EDX+EAX];
-	lea EAX, [EBX+EAX];
-	lea EAX, [ESP+EAX];
-	lea EAX, [EBP+EAX]; // Good gets disp+8 correctly
-	lea EAX, [ESI+EAX];
-	lea EAX, [EDI+EAX];
+    // Right
+    lea EAX, [EAX+EAX];
+    lea EAX, [EAX+ECX];
+    lea EAX, [EAX+EDX];
+    lea EAX, [EAX+EBX];
+    //lea EAX, [EAX+ESP]; ESP can't be on the right
+    lea EAX, [EAX+EBP];
+    lea EAX, [EAX+ESI];
+    lea EAX, [EAX+EDI];
+    // Left
+    lea EAX, [EAX+EAX];
+    lea EAX, [ECX+EAX];
+    lea EAX, [EDX+EAX];
+    lea EAX, [EBX+EAX];
+    lea EAX, [ESP+EAX];
+    lea EAX, [EBP+EAX]; // Good gets disp+8 correctly
+    lea EAX, [ESI+EAX];
+    lea EAX, [EDI+EAX];
 
-	// Disp8/32 checks
-	lea EAX, [ECX+EAX+0x12];
-	lea EAX, [ECX+EAX+0x1234];
-	lea EAX, [ECX+EAX+0x1234_5678];
-	lea EAX, [EBP+EAX+0x12];
-	lea EAX, [EBP+EAX+0x1234];
-	lea EAX, [EBP+EAX+0x1234_5678];
+    // Disp8/32 checks
+    lea EAX, [ECX+EAX+0x12];
+    lea EAX, [ECX+EAX+0x1234];
+    lea EAX, [ECX+EAX+0x1234_5678];
+    lea EAX, [EBP+EAX+0x12];
+    lea EAX, [EBP+EAX+0x1234];
+    lea EAX, [EBP+EAX+0x1234_5678];
 
-L1:	pop	EAX	;
-	mov	p[EBP],EAX ;
+L1: pop EAX ;
+    mov p[EBP],EAX ;
     }
 
     foreach (i,b; data)
     {
-	//printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
-	assert(p[i] == b);
+    //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+    assert(p[i] == b);
     }
 }
 
@@ -3968,7 +3968,7 @@ L1:	pop	EAX	;
 void test54()
 {   int x;
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0xFE, 0xC8,                // dec    AL
         0xFE, 0xCC,                // dec    AH
@@ -4032,7 +4032,7 @@ void test55()
 {   int x;
     ubyte* p;
     enum NOP = 0x9090_9090_9090_9090;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x0F, 0x87, 0xFF, 0xFF, 0, 0,    //    ja    $ + 0xFFFF
         0x72, 0x18,                      //    jb    Lb
@@ -4113,7 +4113,7 @@ void test57()
     ubyte* p;
     M64  m64;
     M128 m128;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x0F, 0x3A, 0x0F, 0xCA,       0x03,    // palignr   MM1,  MM2, 3
   0x66, 0x0F, 0x3A, 0x0F, 0xCA,       0x03,    // palignr  XMM1, XMM2, 3
@@ -4288,7 +4288,7 @@ void test58()
     int   m32;
     M64   m64;
     M128 m128;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
   0x66,       0x0F, 0x3A, 0x0D, 0xCA,        3,// blendpd  XMM1,XMM2,0x3
   0x66,       0x0F, 0x3A, 0x0D, 0x5D, 0xE0,  3,// blendpd  XMM3,XMMWORD PTR [RBP-0x20],0x3
@@ -4582,7 +4582,7 @@ void test59()
     int   m32;
     M64   m64;
     M128 m128;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
 0xF2,       0x0F, 0x38, 0xF0, 0xC1,           // crc32   EAX,  CL
 0x66, 0xF2, 0x0F, 0x38, 0xF1, 0xC1,           // crc32   EAX,  CX
@@ -4658,7 +4658,7 @@ void test60()
     int   m32;
     M64   m64;
     M128 m128;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
 0x0F,       0x3A, 0xCC, 0xD1, 0x01,           // sha1rnds4 XMM2, XMM1, 1;
 0x0F,       0x3A, 0xCC, 0x10, 0x01,           // sha1rnds4 XMM2, [RAX], 1;
@@ -4715,7 +4715,7 @@ L1:     pop     EAX;
 void test9866()
 {
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x66, 0x0f, 0xbe, 0xc0, // movsx AX, AL;
         0x66, 0x0f, 0xbe, 0x00, // movsx AX, byte ptr [EAX];
@@ -4805,7 +4805,7 @@ int main()
     test13();
     test14();
     test15();
-    //test16();		// add this one from \cbx\test\iasm.c ?
+    //test16();     // add this one from \cbx\test\iasm.c ?
     test17();
     test18();
     test19();

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -34,9 +34,9 @@ void test1()
 
     asm
     {
-	align x;		;
-	mov EAX, __LOCAL_SIZE	;
-	mov foo[RBP], EAX	;
+    align x;        ;
+    mov EAX, __LOCAL_SIZE   ;
+    mov foo[RBP], EAX   ;
     }
     assert(foo == 16); // stack must be 16 byte aligned
 }
@@ -50,10 +50,10 @@ void test2()
 
     asm
     {
-	even			;
-	mov EAX,0		;
-	inc EAX			;
-	mov foo[RBP], EAX	;
+    even            ;
+    mov EAX,0       ;
+    inc EAX         ;
+    mov foo[RBP], EAX   ;
     }
     assert(foo == 1);
 }
@@ -67,10 +67,10 @@ void test3()
 
     asm
     {
-	mov	EAX,5		;
-	jmp	$ + 2		;
-	dw	0xC0FF,0xC8FF	;	// inc EAX, dec EAX
-	mov	foo[RBP],EAX	;
+    mov EAX,5       ;
+    jmp $ + 2       ;
+    dw  0xC0FF,0xC8FF   ;   // inc EAX, dec EAX
+    mov foo[RBP],EAX    ;
     }
     assert(foo == 4);
 }
@@ -84,13 +84,13 @@ void test4()
 
     asm
     {
-	xor	EAX,EAX		;
-	add	EAX,5		;
-	jne	L1		;
-	dw	0xC0FF,0xC8FF	;	// inc EAX, dec EAX
+    xor EAX,EAX     ;
+    add EAX,5       ;
+    jne L1      ;
+    dw  0xC0FF,0xC8FF   ;   // inc EAX, dec EAX
 L1:
-	dw	0xC8FF		;
-	mov	foo[RBP],EAX	;
+    dw  0xC8FF      ;
+    mov foo[RBP],EAX    ;
     }
     assert(foo == 4);
 }
@@ -114,18 +114,18 @@ void test5()
 
     asm
     {
-	call	L1		;
-	db	0xFF,0xC0;	;	// inc EAX
-	db	"abc"		;
-	ds	"def"		;
-	di	"ghi"		;
-	dl	0x12345678ABCDEF;
-	df	1.1		;
-	dd	1.2		;
-	de	1.3		;
+    call    L1      ;
+    db  0xFF,0xC0;  ;   // inc EAX
+    db  "abc"       ;
+    ds  "def"       ;
+    di  "ghi"       ;
+    dl  0x12345678ABCDEF;
+    df  1.1     ;
+    dd  1.2     ;
+    de  1.3     ;
 L1:
-	pop	RBX		;
-	mov	p[RBP],RBX	;
+    pop RBX     ;
+    mov p[RBP],RBX  ;
     }
     assert(p[0] == 0xFF);
     assert(p[1] == 0xC0);
@@ -155,64 +155,64 @@ L1:
 void test6()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x8B, 0x01,       	// mov	EAX,[RCX]
-	0x8B, 0x04, 0x19,    	// mov	EAX,[RBX][RCX]
-	0x8B, 0x04, 0x4B,    	// mov	EAX,[RCX*2][RBX]
-	0x8B, 0x04, 0x5A,    	// mov	EAX,[RBX*2][RDX]
-	0x8B, 0x04, 0x8E,    	// mov	EAX,[RCX*4][RSI]
-	0x8B, 0x04, 0xF9,    	// mov	EAX,[RDI*8][RCX]
+    0x8B, 0x01,         // mov  EAX,[RCX]
+    0x8B, 0x04, 0x19,       // mov  EAX,[RBX][RCX]
+    0x8B, 0x04, 0x4B,       // mov  EAX,[RCX*2][RBX]
+    0x8B, 0x04, 0x5A,       // mov  EAX,[RBX*2][RDX]
+    0x8B, 0x04, 0x8E,       // mov  EAX,[RCX*4][RSI]
+    0x8B, 0x04, 0xF9,       // mov  EAX,[RDI*8][RCX]
 
-	0x2B, 0x1C, 0x19,	// sub	EBX,[RBX][RCX]
-	0x3B, 0x0C, 0x4B,	// cmp	ECX,[RCX*2][RBX]
-	0x03, 0x14, 0x5A,	// add	EDX,[RBX*2][RDX]
-	0x33, 0x34, 0x8E,	// xor	ESI,[RCX*4][RSI]
+    0x2B, 0x1C, 0x19,   // sub  EBX,[RBX][RCX]
+    0x3B, 0x0C, 0x4B,   // cmp  ECX,[RCX*2][RBX]
+    0x03, 0x14, 0x5A,   // add  EDX,[RBX*2][RDX]
+    0x33, 0x34, 0x8E,   // xor  ESI,[RCX*4][RSI]
 
-	0x29, 0x1C, 0x19,    	// sub	[RBX][RCX],EBX
-	0x39, 0x0C, 0x4B,    	// cmp	[RCX*2][RBX],ECX
-	0x01, 0x24, 0x5A,    	// add	[RBX*2][RDX],ESP
-	0x31, 0x2C, 0x8E,    	// xor	[RCX*4][RSI],EBP
+    0x29, 0x1C, 0x19,       // sub  [RBX][RCX],EBX
+    0x39, 0x0C, 0x4B,       // cmp  [RCX*2][RBX],ECX
+    0x01, 0x24, 0x5A,       // add  [RBX*2][RDX],ESP
+    0x31, 0x2C, 0x8E,       // xor  [RCX*4][RSI],EBP
 
-	0xA8, 0x03,       		// test	AL,3
-	0x66, 0xA9, 0x04, 0x00,    	// test	AX,4
-	0xA9, 0x05, 0x00, 0x00, 0x00, 	// test	EAX,5
-	0x85, 0x3C, 0xF9,    		// test	[RDI*8][RCX],EDI
+    0xA8, 0x03,             // test AL,3
+    0x66, 0xA9, 0x04, 0x00,     // test AX,4
+    0xA9, 0x05, 0x00, 0x00, 0x00,   // test EAX,5
+    0x85, 0x3C, 0xF9,           // test [RDI*8][RCX],EDI
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	mov	EAX,[RCX]		;
-	mov	EAX,[RCX][RBX]		;
-	mov	EAX,[RCX*2][RBX]	;
-	mov	EAX,[RDX][RBX*2]	;
-	mov	EAX,[RCX*4][RSI]	;
-	mov	EAX,[RCX][RDI*8]	;
+    mov EAX,[RCX]       ;
+    mov EAX,[RCX][RBX]      ;
+    mov EAX,[RCX*2][RBX]    ;
+    mov EAX,[RDX][RBX*2]    ;
+    mov EAX,[RCX*4][RSI]    ;
+    mov EAX,[RCX][RDI*8]    ;
 
-	sub	EBX,[RCX][RBX]		;
-	cmp	ECX,[RCX*2][RBX]	;
-	add	EDX,[RDX][RBX*2]	;
-	xor	ESI,[RCX*4][RSI]	;
+    sub EBX,[RCX][RBX]      ;
+    cmp ECX,[RCX*2][RBX]    ;
+    add EDX,[RDX][RBX*2]    ;
+    xor ESI,[RCX*4][RSI]    ;
 
-	sub	[RCX][RBX],EBX		;
-	cmp	[RCX*2][RBX],ECX	;
-	add	[RDX][RBX*2],ESP	;
-	xor	[RCX*4][RSI],EBP	;
+    sub [RCX][RBX],EBX      ;
+    cmp [RCX*2][RBX],ECX    ;
+    add [RDX][RBX*2],ESP    ;
+    xor [RCX*4][RSI],EBP    ;
 
-	test	AL,3			;
-	test	AX,4			;
-	test	EAX,5			;
-	test	[RCX][RDI*8],EDI	;
+    test    AL,3            ;
+    test    AX,4            ;
+    test    EAX,5           ;
+    test    [RCX][RDI*8],EDI    ;
 L1:
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -221,35 +221,35 @@ L1:
 void test7()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x26,0xA1,0x24,0x13,0x00,0x00,		// mov	EAX,ES:[01324h]
-	0x36,0x66,0xA1,0x78,0x56,0x00,0x00, 	// mov	AX,SS:[05678h]
-	0xA0,0x78,0x56,0x00,0x00, 		// mov	AL,[05678h]
-	0x2E,0x8A,0x25,0x78,0x56,0x00,0x00, 	// mov	AH,CS:[05678h]
-	0x64,0x8A,0x1D,0x78,0x56,0x00,0x00, 	// mov	BL,FS:[05678h]
-	0x65,0x8A,0x3D,0x78,0x56,0x00,0x00, 	// mov	BH,GS:[05678h]
+    0x26,0xA1,0x24,0x13,0x00,0x00,      // mov  EAX,ES:[01324h]
+    0x36,0x66,0xA1,0x78,0x56,0x00,0x00,     // mov  AX,SS:[05678h]
+    0xA0,0x78,0x56,0x00,0x00,       // mov  AL,[05678h]
+    0x2E,0x8A,0x25,0x78,0x56,0x00,0x00,     // mov  AH,CS:[05678h]
+    0x64,0x8A,0x1D,0x78,0x56,0x00,0x00,     // mov  BL,FS:[05678h]
+    0x65,0x8A,0x3D,0x78,0x56,0x00,0x00,     // mov  BH,GS:[05678h]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	mov	EAX,ES:[0x1324]		;
-	mov	AX,SS:[0x5678]		;
-	mov	AL,DS:[0x5678]		;
-	mov	AH,CS:[0x5678]		;
-	mov	BL,FS:[0x5678]		;
-	mov	BH,GS:[0x5678]		;
+    mov EAX,ES:[0x1324]     ;
+    mov AX,SS:[0x5678]      ;
+    mov AL,DS:[0x5678]      ;
+    mov AH,CS:[0x5678]      ;
+    mov BL,FS:[0x5678]      ;
+    mov BH,GS:[0x5678]      ;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 +/
@@ -258,106 +258,106 @@ L1:					;
 void test8()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x8C,0xD0,       	// mov	AX,SS
-	0x8C,0xDB,       	// mov	BX,DS
-	0x8C,0xC1,       	// mov	CX,ES
-	0x8C,0xCA,       	// mov	DX,CS
-	0x8C,0xE6,       	// mov	SI,FS
-	0x8C,0xEF,       	// mov	DI,GS
-	0x8E,0xD0,       	// mov	SS,AX
-	0x8E,0xDB,       	// mov	DS,BX
-	0x8E,0xC1,       	// mov	ES,CX
-	0x8E,0xCA,       	// mov	CS,DX
-	0x8E,0xE6,       	// mov	FS,SI
-	0x8E,0xEF,       	// mov	GS,DI
-	0x0F,0x22,0xC0,    	// mov	CR0,EAX
-	0x0F,0x22,0xD3,    	// mov	CR2,EBX
-	0x0F,0x22,0xD9,    	// mov	CR3,ECX
-	0x0F,0x22,0xE2,    	// mov	CR4,EDX
-	0x0F,0x20,0xC0,    	// mov	EAX,CR0
-	0x0F,0x20,0xD3,    	// mov	EBX,CR2
-	0x0F,0x20,0xD9,    	// mov	ECX,CR3
-	0x0F,0x20,0xE2,    	// mov	EDX,CR4
-	0x0F,0x23,0xC0,    	// mov	DR0,EAX
-	0x0F,0x23,0xCE,    	// mov	DR1,ESI
-	0x0F,0x23,0xD3,    	// mov	DR2,EBX
-	0x0F,0x23,0xD9,    	// mov	DR3,ECX
-	0x0F,0x23,0xE2,    	// mov	DR4,EDX
-	0x0F,0x23,0xEF,    	// mov	DR5,EDI
-	0x0F,0x23,0xF4,    	// mov	DR6,ESP
-	0x0F,0x23,0xFD,    	// mov	DR7,EBP
-	0x0F,0x21,0xC4,    	// mov	ESP,DR0
-	0x0F,0x21,0xCD,    	// mov	EBP,DR1
-	0x0F,0x21,0xD0,    	// mov	EAX,DR2
-	0x0F,0x21,0xDB,    	// mov	EBX,DR3
-	0x0F,0x21,0xE1,    	// mov	ECX,DR4
-	0x0F,0x21,0xEA,    	// mov	EDX,DR5
-	0x0F,0x21,0xF6,    	// mov	ESI,DR6
-	0x0F,0x21,0xFF,    	// mov	EDI,DR7
-	0xA4,     		// movsb
-	0x66,0xA5,		// movsw
-	0xA5,			// movsd
+    0x8C,0xD0,          // mov  AX,SS
+    0x8C,0xDB,          // mov  BX,DS
+    0x8C,0xC1,          // mov  CX,ES
+    0x8C,0xCA,          // mov  DX,CS
+    0x8C,0xE6,          // mov  SI,FS
+    0x8C,0xEF,          // mov  DI,GS
+    0x8E,0xD0,          // mov  SS,AX
+    0x8E,0xDB,          // mov  DS,BX
+    0x8E,0xC1,          // mov  ES,CX
+    0x8E,0xCA,          // mov  CS,DX
+    0x8E,0xE6,          // mov  FS,SI
+    0x8E,0xEF,          // mov  GS,DI
+    0x0F,0x22,0xC0,     // mov  CR0,EAX
+    0x0F,0x22,0xD3,     // mov  CR2,EBX
+    0x0F,0x22,0xD9,     // mov  CR3,ECX
+    0x0F,0x22,0xE2,     // mov  CR4,EDX
+    0x0F,0x20,0xC0,     // mov  EAX,CR0
+    0x0F,0x20,0xD3,     // mov  EBX,CR2
+    0x0F,0x20,0xD9,     // mov  ECX,CR3
+    0x0F,0x20,0xE2,     // mov  EDX,CR4
+    0x0F,0x23,0xC0,     // mov  DR0,EAX
+    0x0F,0x23,0xCE,     // mov  DR1,ESI
+    0x0F,0x23,0xD3,     // mov  DR2,EBX
+    0x0F,0x23,0xD9,     // mov  DR3,ECX
+    0x0F,0x23,0xE2,     // mov  DR4,EDX
+    0x0F,0x23,0xEF,     // mov  DR5,EDI
+    0x0F,0x23,0xF4,     // mov  DR6,ESP
+    0x0F,0x23,0xFD,     // mov  DR7,EBP
+    0x0F,0x21,0xC4,     // mov  ESP,DR0
+    0x0F,0x21,0xCD,     // mov  EBP,DR1
+    0x0F,0x21,0xD0,     // mov  EAX,DR2
+    0x0F,0x21,0xDB,     // mov  EBX,DR3
+    0x0F,0x21,0xE1,     // mov  ECX,DR4
+    0x0F,0x21,0xEA,     // mov  EDX,DR5
+    0x0F,0x21,0xF6,     // mov  ESI,DR6
+    0x0F,0x21,0xFF,     // mov  EDI,DR7
+    0xA4,           // movsb
+    0x66,0xA5,      // movsw
+    0xA5,           // movsd
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	mov	AX,SS			;
-	mov	BX,DS			;
-	mov	CX,ES			;
-	mov	DX,CS			;
-	mov	SI,FS			;
-	mov	DI,GS			;
+    mov AX,SS           ;
+    mov BX,DS           ;
+    mov CX,ES           ;
+    mov DX,CS           ;
+    mov SI,FS           ;
+    mov DI,GS           ;
 
-	mov	SS,AX			;
-	mov	DS,BX			;
-	mov	ES,CX			;
-	mov	CS,DX			;
-	mov	FS,SI			;
-	mov	GS,DI			;
+    mov SS,AX           ;
+    mov DS,BX           ;
+    mov ES,CX           ;
+    mov CS,DX           ;
+    mov FS,SI           ;
+    mov GS,DI           ;
 
-	mov	CR0,EAX			;
-	mov	CR2,EBX			;
-	mov	CR3,ECX			;
-	mov	CR4,EDX			;
+    mov CR0,EAX         ;
+    mov CR2,EBX         ;
+    mov CR3,ECX         ;
+    mov CR4,EDX         ;
 
-	mov	EAX,CR0			;
-	mov	EBX,CR2			;
-	mov	ECX,CR3			;
-	mov	EDX,CR4			;
+    mov EAX,CR0         ;
+    mov EBX,CR2         ;
+    mov ECX,CR3         ;
+    mov EDX,CR4         ;
 
-	mov	DR0,EAX			;
-	mov	DR1,ESI			;
-	mov	DR2,EBX			;
-	mov	DR3,ECX			;
-	mov	DR4,EDX			;
-	mov	DR5,EDI			;
-	mov	DR6,ESP			;
-	mov	DR7,EBP			;
+    mov DR0,EAX         ;
+    mov DR1,ESI         ;
+    mov DR2,EBX         ;
+    mov DR3,ECX         ;
+    mov DR4,EDX         ;
+    mov DR5,EDI         ;
+    mov DR6,ESP         ;
+    mov DR7,EBP         ;
 
-	mov	ESP,DR0			;
-	mov	EBP,DR1			;
-	mov	EAX,DR2			;
-	mov	EBX,DR3			;
-	mov	ECX,DR4			;
-	mov	EDX,DR5			;
-	mov	ESI,DR6			;
-	mov	EDI,DR7			;
+    mov ESP,DR0         ;
+    mov EBP,DR1         ;
+    mov EAX,DR2         ;
+    mov EBX,DR3         ;
+    mov ECX,DR4         ;
+    mov EDX,DR5         ;
+    mov ESI,DR6         ;
+    mov EDI,DR7         ;
 
-	movsb				;
-	movsw				;
-	movsd				;
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    movsb               ;
+    movsw               ;
+    movsd               ;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -366,73 +366,73 @@ L1:					;
 void test9()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x67,0x66,0x8B,0x00,       	// mov	AX,[BX+SI]
-	0x67,0x66,0x8B,0x01,       	// mov	AX,[BX+DI]
-	0x67,0x66,0x8B,0x02,       	// mov	AX,[BP+SI]
-	0x67,0x66,0x8B,0x03,       	// mov	AX,[BP+DI]
-	0x67,0x66,0x8B,0x04,       	// mov	AX,[SI]
-	0x67,0x66,0x8B,0x05,       	// mov	AX,[DI]
-	0x66,0xB8,0xD2,0x04,    	// mov	AX,04D2h
-	0x67,0x66,0x8B,0x07,       	// mov	AX,[BX]
-	0x67,0x66,0x8B,0x40,0x01,    	// mov	AX,1[BX+SI]
-	0x67,0x66,0x8B,0x41,0x02,    	// mov	AX,2[BX+DI]
-	0x67,0x66,0x8B,0x42,0x03,    	// mov	AX,3[BP+SI]
-	0x67,0x66,0x8B,0x43,0x04,    	// mov	AX,4[BP+DI]
-	0x67,0x66,0x8B,0x44,0x05,    	// mov	AX,5[SI]
-	0x67,0x66,0x8B,0x45,0x06,    	// mov	AX,6[DI]
-	0x67,0x66,0x8B,0x43,0x07,    	// mov	AX,7[BP+DI]
-	0x67,0x66,0x8B,0x47,0x08,    	// mov	AX,8[BX]
-	0x67,0x8B,0x80,0x21,0x01, 	// mov	EAX,0121h[BX+SI]
-	0x67,0x66,0x8B,0x81,0x22,0x01, 	// mov	AX,0122h[BX+DI]
-	0x67,0x66,0x8B,0x82,0x43,0x23, 	// mov	AX,02343h[BP+SI]
-	0x67,0x66,0x8B,0x83,0x54,0x45, 	// mov	AX,04554h[BP+DI]
-	0x67,0x66,0x8B,0x84,0x45,0x66,	// mov	AX,06645h[SI]
-	0x67,0x66,0x8B,0x85,0x36,0x12, 	// mov	AX,01236h[DI]
-	0x67,0x66,0x8B,0x86,0x67,0x45, 	// mov	AX,04567h[BP]
-	0x67,0x8A,0x87,0x08,0x01, 	// mov	AL,0108h[BX]
+    0x67,0x66,0x8B,0x00,        // mov  AX,[BX+SI]
+    0x67,0x66,0x8B,0x01,        // mov  AX,[BX+DI]
+    0x67,0x66,0x8B,0x02,        // mov  AX,[BP+SI]
+    0x67,0x66,0x8B,0x03,        // mov  AX,[BP+DI]
+    0x67,0x66,0x8B,0x04,        // mov  AX,[SI]
+    0x67,0x66,0x8B,0x05,        // mov  AX,[DI]
+    0x66,0xB8,0xD2,0x04,        // mov  AX,04D2h
+    0x67,0x66,0x8B,0x07,        // mov  AX,[BX]
+    0x67,0x66,0x8B,0x40,0x01,       // mov  AX,1[BX+SI]
+    0x67,0x66,0x8B,0x41,0x02,       // mov  AX,2[BX+DI]
+    0x67,0x66,0x8B,0x42,0x03,       // mov  AX,3[BP+SI]
+    0x67,0x66,0x8B,0x43,0x04,       // mov  AX,4[BP+DI]
+    0x67,0x66,0x8B,0x44,0x05,       // mov  AX,5[SI]
+    0x67,0x66,0x8B,0x45,0x06,       // mov  AX,6[DI]
+    0x67,0x66,0x8B,0x43,0x07,       // mov  AX,7[BP+DI]
+    0x67,0x66,0x8B,0x47,0x08,       // mov  AX,8[BX]
+    0x67,0x8B,0x80,0x21,0x01,   // mov  EAX,0121h[BX+SI]
+    0x67,0x66,0x8B,0x81,0x22,0x01,  // mov  AX,0122h[BX+DI]
+    0x67,0x66,0x8B,0x82,0x43,0x23,  // mov  AX,02343h[BP+SI]
+    0x67,0x66,0x8B,0x83,0x54,0x45,  // mov  AX,04554h[BP+DI]
+    0x67,0x66,0x8B,0x84,0x45,0x66,  // mov  AX,06645h[SI]
+    0x67,0x66,0x8B,0x85,0x36,0x12,  // mov  AX,01236h[DI]
+    0x67,0x66,0x8B,0x86,0x67,0x45,  // mov  AX,04567h[BP]
+    0x67,0x8A,0x87,0x08,0x01,   // mov  AL,0108h[BX]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	mov	AX,[BX+SI]		;
-	mov	AX,[BX+DI]		;
-	mov	AX,[BP+SI]		;
-	mov	AX,[BP+DI]		;
-	mov	AX,[SI]			;
-//	mov	AX,[DI]			; Internal error: backend/cod3.c 4652
-	mov	AX,[1234]		;
-	mov	AX,[BX]			;
+    mov AX,[BX+SI]      ;
+    mov AX,[BX+DI]      ;
+    mov AX,[BP+SI]      ;
+    mov AX,[BP+DI]      ;
+    mov AX,[SI]         ;
+//  mov AX,[DI]         ; Internal error: backend/cod3.c 4652
+    mov AX,[1234]       ;
+    mov AX,[BX]         ;
 
-	mov	AX,1[BX+SI]		;
-	mov	AX,2[BX+DI]		;
-	mov	AX,3[BP+SI]		;
-	mov	AX,4[BP+DI]		;
-	mov	AX,5[SI]		;
-	mov	AX,6[DI]		;
-	mov	AX,7[DI+BP]		;
-	mov	AX,8[BX]		;
+    mov AX,1[BX+SI]     ;
+    mov AX,2[BX+DI]     ;
+    mov AX,3[BP+SI]     ;
+    mov AX,4[BP+DI]     ;
+    mov AX,5[SI]        ;
+    mov AX,6[DI]        ;
+    mov AX,7[DI+BP]     ;
+    mov AX,8[BX]        ;
 
-	mov	EAX,0x121[BX+SI]	;
-	mov	AX,0x122[BX+DI]		;
-	mov	AX,0x2343[BP+SI]	;
-	mov	AX,0x4554[BP+DI]	;
-	mov	AX,0x6645[SI]		;
-	mov	AX,0x1236[DI]		;
-	mov	AX,0x4567[BP]		;
-	mov	AL,0x108[BX]		;
+    mov EAX,0x121[BX+SI]    ;
+    mov AX,0x122[BX+DI]     ;
+    mov AX,0x2343[BP+SI]    ;
+    mov AX,0x4554[BP+DI]    ;
+    mov AX,0x6645[SI]       ;
+    mov AX,0x1236[DI]       ;
+    mov AX,0x4567[BP]       ;
+    mov AL,0x108[BX]        ;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -445,18 +445,18 @@ void test10()
 {
     ubyte *p;
     int foo;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
     ];
     int i;
 
     asm
     {
-	mov	bar10,0x12		;
-//	mov	baz10,0x13		;// does not compile, ( should it? )
-	mov	int ptr baz10,0x13	;// but this does
-	mov	ESI,1			;
-	mov	baz10[RSI*4],0x14	;
+    mov bar10,0x12      ;
+//  mov baz10,0x13      ;// does not compile, ( should it? )
+    mov int ptr baz10,0x13  ;// but this does
+    mov ESI,1           ;
+    mov baz10[RSI*4],0x14   ;
     }
     assert(bar10 == 0x12);
     assert(baz10[0] == 0x13);
@@ -482,10 +482,10 @@ void test11()
 
     asm
     {
-	mov	x1,Foo11.a.sizeof	;
-	mov	x2,Foo11.b.offsetof	;
-	mov	x3,Foo11.sizeof		;
-	mov	x4,Foo11.sizeof + 7	;
+    mov x1,Foo11.a.sizeof   ;
+    mov x2,Foo11.b.offsetof ;
+    mov x3,Foo11.sizeof     ;
+    mov x4,Foo11.sizeof + 7 ;
     }
     assert(x1 == int.sizeof);
     assert(x2 == 8);
@@ -498,87 +498,87 @@ void test11()
 void test12()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x14,0x05,      		// adc	AL,5
-	0x83,0xD0,0x14,   		// adc	EAX,014h
-	0x80,0x55,0xF8,0x17,		// adc	byte ptr -8[RBP],017h
-	0x83,0x55,0xFC,0x17,		// adc	dword ptr -4[RBP],017h
-	0x81,0x55,0xFC,0x34,0x12,0x00,0x00,	// adc	dword ptr -4[RBP],01234h
-	0x10,0x7D,0xF8,   		// adc	-8[RBP],BH
-	0x11,0x5D,0xFC,   		// adc	-4[RBP],EBX
-	0x12,0x5D,0xF8,   		// adc	BL,-8[RBP]
-	0x13,0x55,0xFC,   		// adc	EDX,-4[RBP]
-	0x04,0x05,      		// add	AL,5
-	0x83,0xC0,0x14,   		// add	EAX,014h
-	0x80,0x45,0xF8,0x17,		// add	byte ptr -8[RBP],017h
-	0x83,0x45,0xFC,0x17,		// add	dword ptr -4[RBP],017h
-	0x81,0x45,0xFC,0x34,0x12,0x00,0x00,	// add	dword ptr -4[RBP],01234h
-	0x00,0x7D,0xF8,   		// add	-8[RBP],BH
-	0x01,0x5D,0xFC,   		// add	-4[RBP],EBX
-	0x02,0x5D,0xF8,   		// add	BL,-8[RBP]
-	0x03,0x55,0xFC,   		// add	EDX,-4[RBP]
-	0x24,0x05,      		// and	AL,5
-	0x83,0xE0,0x14,   		// and	EAX,014h
-	0x80,0x65,0xF8,0x17,		// and	byte ptr -8[RBP],017h
-	0x83,0x65,0xFC,0x17,		// and	dword ptr -4[RBP],017h
-	0x81,0x65,0xFC,0x34,0x12,0x00,0x00,	// and	dword ptr -4[RBP],01234h
-	0x20,0x7D,0xF8,   		// and	-8[RBP],BH
-	0x21,0x5D,0xFC,   		// and	-4[RBP],EBX
-	0x22,0x5D,0xF8,   		// and	BL,-8[RBP]
-	0x23,0x55,0xFC,   		// and	EDX,-4[RBP]
-	0x3C,0x05,      		// cmp	AL,5
-	0x83,0xF8,0x14,   		// cmp	EAX,014h
-	0x80,0x7D,0xF8,0x17,		// cmp	byte ptr -8[RBP],017h
-	0x83,0x7D,0xFC,0x17,		// cmp	dword ptr -4[RBP],017h
-	0x81,0x7D,0xFC,0x34,0x12,0x00,0x00,	// cmp	dword ptr -4[RBP],01234h
-	0x38,0x7D,0xF8,   		// cmp	-8[RBP],BH
-	0x39,0x5D,0xFC,   		// cmp	-4[RBP],EBX
-	0x3A,0x5D,0xF8,   		// cmp	BL,-8[RBP]
-	0x3B,0x55,0xFC,   		// cmp	EDX,-4[RBP]
-	0x0C,0x05,     			// or	AL,5
-	0x83,0xC8,0x14,			// or	EAX,014h
-	0x80,0x4D,0xF8,0x17,		// or	byte ptr -8[RBP],017h
-	0x83,0x4D,0xFC,0x17,		// or	dword ptr -4[RBP],017h
-	0x81,0x4D,0xFC,0x34,0x12,0x00,0x00,	// or	dword ptr -4[RBP],01234h
-	0x08,0x7D,0xF8,   		// or	-8[RBP],BH
-	0x09,0x5D,0xFC,   		// or	-4[RBP],EBX
-	0x0A,0x5D,0xF8,   		// or	BL,-8[RBP]
-	0x0B,0x55,0xFC,   		// or	EDX,-4[RBP]
-	0x1C,0x05,      		// sbb	AL,5
-	0x83,0xD8,0x14,   		// sbb	EAX,014h
-	0x80,0x5D,0xF8,0x17,		// sbb	byte ptr -8[RBP],017h
-	0x83,0x5D,0xFC,0x17,		// sbb	dword ptr -4[RBP],017h
-	0x81,0x5D,0xFC,0x34,0x12,0x00,0x00,	// sbb	dword ptr -4[RBP],01234h
-	0x18,0x7D,0xF8,   		// sbb	-8[RBP],BH
-	0x19,0x5D,0xFC,   		// sbb	-4[RBP],EBX
-	0x1A,0x5D,0xF8,   		// sbb	BL,-8[RBP]
-	0x1B,0x55,0xFC,   		// sbb	EDX,-4[RBP]
-	0x2C,0x05,      		// sub	AL,5
-	0x83,0xE8,0x14,   		// sub	EAX,014h
-	0x80,0x6D,0xF8,0x17,		// sub	byte ptr -8[RBP],017h
-	0x83,0x6D,0xFC,0x17,		// sub	dword ptr -4[RBP],017h
-	0x81,0x6D,0xFC,0x34,0x12,0x00,0x00,	// sub	dword ptr -4[RBP],01234h
-	0x28,0x7D,0xF8,   		// sub	-8[RBP],BH
-	0x29,0x5D,0xFC,   		// sub	-4[RBP],EBX
-	0x2A,0x5D,0xF8,   		// sub	BL,-8[RBP]
-	0x2B,0x55,0xFC,   		// sub	EDX,-4[RBP]
-	0xA8,0x05,      		// test	AL,5
-	0xA9,0x14,0x00,0x00,0x00,	// test	EAX,014h
-	0xF6,0x45,0xF8,0x17,		// test	byte ptr -8[RBP],017h
-	0xF7,0x45,0xFC,0x17,0x00,0x00,0x00,	// test	dword ptr -4[RBP],017h
-	0xF7,0x45,0xFC,0x34,0x12,0x00,0x00,	// test	dword ptr -4[RBP],01234h
-	0x84,0x7D,0xF8,   		// test	-8[RBP],BH
-	0x85,0x5D,0xFC,   		// test	-4[RBP],EBX
-	0x34,0x05,      		// xor	AL,5
-	0x83,0xF0,0x14,   		// xor	EAX,014h
-	0x80,0x75,0xF8,0x17,		// xor	byte ptr -8[RBP],017h
-	0x83,0x75,0xFC,0x17,		// xor	dword ptr -4[RBP],017h
-	0x81,0x75,0xFC,0x34,0x12,0x00,0x00,	// xor	dword ptr -4[RBP],01234h
-	0x30,0x7D,0xF8,   		// xor	-8[RBP],BH
-	0x31,0x5D,0xFC,   		// xor	-4[RBP],EBX
-	0x32,0x5D,0xF8,   		// xor	BL,-8[RBP]
-	0x33,0x55,0xFC,   		// xor	EDX,-4[RBP]
+    0x14,0x05,              // adc  AL,5
+    0x83,0xD0,0x14,         // adc  EAX,014h
+    0x80,0x55,0xF8,0x17,        // adc  byte ptr -8[RBP],017h
+    0x83,0x55,0xFC,0x17,        // adc  dword ptr -4[RBP],017h
+    0x81,0x55,0xFC,0x34,0x12,0x00,0x00, // adc  dword ptr -4[RBP],01234h
+    0x10,0x7D,0xF8,         // adc  -8[RBP],BH
+    0x11,0x5D,0xFC,         // adc  -4[RBP],EBX
+    0x12,0x5D,0xF8,         // adc  BL,-8[RBP]
+    0x13,0x55,0xFC,         // adc  EDX,-4[RBP]
+    0x04,0x05,              // add  AL,5
+    0x83,0xC0,0x14,         // add  EAX,014h
+    0x80,0x45,0xF8,0x17,        // add  byte ptr -8[RBP],017h
+    0x83,0x45,0xFC,0x17,        // add  dword ptr -4[RBP],017h
+    0x81,0x45,0xFC,0x34,0x12,0x00,0x00, // add  dword ptr -4[RBP],01234h
+    0x00,0x7D,0xF8,         // add  -8[RBP],BH
+    0x01,0x5D,0xFC,         // add  -4[RBP],EBX
+    0x02,0x5D,0xF8,         // add  BL,-8[RBP]
+    0x03,0x55,0xFC,         // add  EDX,-4[RBP]
+    0x24,0x05,              // and  AL,5
+    0x83,0xE0,0x14,         // and  EAX,014h
+    0x80,0x65,0xF8,0x17,        // and  byte ptr -8[RBP],017h
+    0x83,0x65,0xFC,0x17,        // and  dword ptr -4[RBP],017h
+    0x81,0x65,0xFC,0x34,0x12,0x00,0x00, // and  dword ptr -4[RBP],01234h
+    0x20,0x7D,0xF8,         // and  -8[RBP],BH
+    0x21,0x5D,0xFC,         // and  -4[RBP],EBX
+    0x22,0x5D,0xF8,         // and  BL,-8[RBP]
+    0x23,0x55,0xFC,         // and  EDX,-4[RBP]
+    0x3C,0x05,              // cmp  AL,5
+    0x83,0xF8,0x14,         // cmp  EAX,014h
+    0x80,0x7D,0xF8,0x17,        // cmp  byte ptr -8[RBP],017h
+    0x83,0x7D,0xFC,0x17,        // cmp  dword ptr -4[RBP],017h
+    0x81,0x7D,0xFC,0x34,0x12,0x00,0x00, // cmp  dword ptr -4[RBP],01234h
+    0x38,0x7D,0xF8,         // cmp  -8[RBP],BH
+    0x39,0x5D,0xFC,         // cmp  -4[RBP],EBX
+    0x3A,0x5D,0xF8,         // cmp  BL,-8[RBP]
+    0x3B,0x55,0xFC,         // cmp  EDX,-4[RBP]
+    0x0C,0x05,              // or   AL,5
+    0x83,0xC8,0x14,         // or   EAX,014h
+    0x80,0x4D,0xF8,0x17,        // or   byte ptr -8[RBP],017h
+    0x83,0x4D,0xFC,0x17,        // or   dword ptr -4[RBP],017h
+    0x81,0x4D,0xFC,0x34,0x12,0x00,0x00, // or   dword ptr -4[RBP],01234h
+    0x08,0x7D,0xF8,         // or   -8[RBP],BH
+    0x09,0x5D,0xFC,         // or   -4[RBP],EBX
+    0x0A,0x5D,0xF8,         // or   BL,-8[RBP]
+    0x0B,0x55,0xFC,         // or   EDX,-4[RBP]
+    0x1C,0x05,              // sbb  AL,5
+    0x83,0xD8,0x14,         // sbb  EAX,014h
+    0x80,0x5D,0xF8,0x17,        // sbb  byte ptr -8[RBP],017h
+    0x83,0x5D,0xFC,0x17,        // sbb  dword ptr -4[RBP],017h
+    0x81,0x5D,0xFC,0x34,0x12,0x00,0x00, // sbb  dword ptr -4[RBP],01234h
+    0x18,0x7D,0xF8,         // sbb  -8[RBP],BH
+    0x19,0x5D,0xFC,         // sbb  -4[RBP],EBX
+    0x1A,0x5D,0xF8,         // sbb  BL,-8[RBP]
+    0x1B,0x55,0xFC,         // sbb  EDX,-4[RBP]
+    0x2C,0x05,              // sub  AL,5
+    0x83,0xE8,0x14,         // sub  EAX,014h
+    0x80,0x6D,0xF8,0x17,        // sub  byte ptr -8[RBP],017h
+    0x83,0x6D,0xFC,0x17,        // sub  dword ptr -4[RBP],017h
+    0x81,0x6D,0xFC,0x34,0x12,0x00,0x00, // sub  dword ptr -4[RBP],01234h
+    0x28,0x7D,0xF8,         // sub  -8[RBP],BH
+    0x29,0x5D,0xFC,         // sub  -4[RBP],EBX
+    0x2A,0x5D,0xF8,         // sub  BL,-8[RBP]
+    0x2B,0x55,0xFC,         // sub  EDX,-4[RBP]
+    0xA8,0x05,              // test AL,5
+    0xA9,0x14,0x00,0x00,0x00,   // test EAX,014h
+    0xF6,0x45,0xF8,0x17,        // test byte ptr -8[RBP],017h
+    0xF7,0x45,0xFC,0x17,0x00,0x00,0x00, // test dword ptr -4[RBP],017h
+    0xF7,0x45,0xFC,0x34,0x12,0x00,0x00, // test dword ptr -4[RBP],01234h
+    0x84,0x7D,0xF8,         // test -8[RBP],BH
+    0x85,0x5D,0xFC,         // test -4[RBP],EBX
+    0x34,0x05,              // xor  AL,5
+    0x83,0xF0,0x14,         // xor  EAX,014h
+    0x80,0x75,0xF8,0x17,        // xor  byte ptr -8[RBP],017h
+    0x83,0x75,0xFC,0x17,        // xor  dword ptr -4[RBP],017h
+    0x81,0x75,0xFC,0x34,0x12,0x00,0x00, // xor  dword ptr -4[RBP],01234h
+    0x30,0x7D,0xF8,         // xor  -8[RBP],BH
+    0x31,0x5D,0xFC,         // xor  -4[RBP],EBX
+    0x32,0x5D,0xF8,         // xor  BL,-8[RBP]
+    0x33,0x55,0xFC,         // xor  EDX,-4[RBP]
     ];
     int i;
     int padding;
@@ -588,110 +588,110 @@ void test12()
 
     asm
     {
-	call	L1			;
-	/*
-	aaa				;
-	aad				;
-	aam				;
-	aas				;
-	arpl	[SI],DI			;
-	*/
+    call    L1          ;
+    /*
+    aaa             ;
+    aad             ;
+    aam             ;
+    aas             ;
+    arpl    [SI],DI         ;
+    */
 
-	adc	AL,5			;
-	adc	EAX,20			;
-	adc	rm8[RBP],23		;
-	adc	rm32[RBP],23		;
-	adc	rm32[RBP],0x1234	;
-	adc	rm8[RBP],BH		;
-	adc	rm32[RBP],EBX		;
-	adc	BL,rm8[RBP]		;
-	adc	EDX,rm32[RBP]		;
+    adc AL,5            ;
+    adc EAX,20          ;
+    adc rm8[RBP],23     ;
+    adc rm32[RBP],23        ;
+    adc rm32[RBP],0x1234    ;
+    adc rm8[RBP],BH     ;
+    adc rm32[RBP],EBX       ;
+    adc BL,rm8[RBP]     ;
+    adc EDX,rm32[RBP]       ;
 
-	add	AL,5			;
-	add	EAX,20			;
-	add	rm8[RBP],23		;
-	add	rm32[RBP],23		;
-	add	rm32[RBP],0x1234	;
-	add	rm8[RBP],BH		;
-	add	rm32[RBP],EBX		;
-	add	BL,rm8[RBP]		;
-	add	EDX,rm32[RBP]		;
+    add AL,5            ;
+    add EAX,20          ;
+    add rm8[RBP],23     ;
+    add rm32[RBP],23        ;
+    add rm32[RBP],0x1234    ;
+    add rm8[RBP],BH     ;
+    add rm32[RBP],EBX       ;
+    add BL,rm8[RBP]     ;
+    add EDX,rm32[RBP]       ;
 
-	and	AL,5			;
-	and	EAX,20			;
-	and	rm8[RBP],23		;
-	and	rm32[RBP],23		;
-	and	rm32[RBP],0x1234	;
-	and	rm8[RBP],BH		;
-	and	rm32[RBP],EBX		;
-	and	BL,rm8[RBP]		;
-	and	EDX,rm32[RBP]		;
+    and AL,5            ;
+    and EAX,20          ;
+    and rm8[RBP],23     ;
+    and rm32[RBP],23        ;
+    and rm32[RBP],0x1234    ;
+    and rm8[RBP],BH     ;
+    and rm32[RBP],EBX       ;
+    and BL,rm8[RBP]     ;
+    and EDX,rm32[RBP]       ;
 
-	cmp	AL,5			;
-	cmp	EAX,20			;
-	cmp	rm8[RBP],23		;
-	cmp	rm32[RBP],23		;
-	cmp	rm32[RBP],0x1234	;
-	cmp	rm8[RBP],BH		;
-	cmp	rm32[RBP],EBX		;
-	cmp	BL,rm8[RBP]		;
-	cmp	EDX,rm32[RBP]		;
+    cmp AL,5            ;
+    cmp EAX,20          ;
+    cmp rm8[RBP],23     ;
+    cmp rm32[RBP],23        ;
+    cmp rm32[RBP],0x1234    ;
+    cmp rm8[RBP],BH     ;
+    cmp rm32[RBP],EBX       ;
+    cmp BL,rm8[RBP]     ;
+    cmp EDX,rm32[RBP]       ;
 
-	or	AL,5			;
-	or	EAX,20			;
-	or	rm8[RBP],23		;
-	or	rm32[RBP],23		;
-	or	rm32[RBP],0x1234	;
-	or	rm8[RBP],BH		;
-	or	rm32[RBP],EBX		;
-	or	BL,rm8[RBP]		;
-	or	EDX,rm32[RBP]		;
+    or  AL,5            ;
+    or  EAX,20          ;
+    or  rm8[RBP],23     ;
+    or  rm32[RBP],23        ;
+    or  rm32[RBP],0x1234    ;
+    or  rm8[RBP],BH     ;
+    or  rm32[RBP],EBX       ;
+    or  BL,rm8[RBP]     ;
+    or  EDX,rm32[RBP]       ;
 
-	sbb	AL,5			;
-	sbb	EAX,20			;
-	sbb	rm8[RBP],23		;
-	sbb	rm32[RBP],23		;
-	sbb	rm32[RBP],0x1234	;
-	sbb	rm8[RBP],BH		;
-	sbb	rm32[RBP],EBX		;
-	sbb	BL,rm8[RBP]		;
-	sbb	EDX,rm32[RBP]		;
+    sbb AL,5            ;
+    sbb EAX,20          ;
+    sbb rm8[RBP],23     ;
+    sbb rm32[RBP],23        ;
+    sbb rm32[RBP],0x1234    ;
+    sbb rm8[RBP],BH     ;
+    sbb rm32[RBP],EBX       ;
+    sbb BL,rm8[RBP]     ;
+    sbb EDX,rm32[RBP]       ;
 
-	sub	AL,5			;
-	sub	EAX,20			;
-	sub	rm8[RBP],23		;
-	sub	rm32[RBP],23		;
-	sub	rm32[RBP],0x1234	;
-	sub	rm8[RBP],BH		;
-	sub	rm32[RBP],EBX		;
-	sub	BL,rm8[RBP]		;
-	sub	EDX,rm32[RBP]		;
+    sub AL,5            ;
+    sub EAX,20          ;
+    sub rm8[RBP],23     ;
+    sub rm32[RBP],23        ;
+    sub rm32[RBP],0x1234    ;
+    sub rm8[RBP],BH     ;
+    sub rm32[RBP],EBX       ;
+    sub BL,rm8[RBP]     ;
+    sub EDX,rm32[RBP]       ;
 
-	test	AL,5			;
-	test	EAX,20			;
-	test	rm8[RBP],23		;
-	test	rm32[RBP],23		;
-	test	rm32[RBP],0x1234	;
-	test	rm8[RBP],BH		;
-	test	rm32[RBP],EBX		;
+    test    AL,5            ;
+    test    EAX,20          ;
+    test    rm8[RBP],23     ;
+    test    rm32[RBP],23        ;
+    test    rm32[RBP],0x1234    ;
+    test    rm8[RBP],BH     ;
+    test    rm32[RBP],EBX       ;
 
-	xor	AL,5			;
-	xor	EAX,20			;
-	xor	rm8[RBP],23		;
-	xor	rm32[RBP],23		;
-	xor	rm32[RBP],0x1234	;
-	xor	rm8[RBP],BH		;
-	xor	rm32[RBP],EBX		;
-	xor	BL,rm8[RBP]		;
-	xor	EDX,rm32[RBP]		;
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    xor AL,5            ;
+    xor EAX,20          ;
+    xor rm8[RBP],23     ;
+    xor rm32[RBP],23        ;
+    xor rm32[RBP],0x1234    ;
+    xor rm8[RBP],BH     ;
+    xor rm32[RBP],EBX       ;
+    xor BL,rm8[RBP]     ;
+    xor EDX,rm32[RBP]       ;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	//printf("p[%d] = x%02x, data = x%02x\n", i, p[i], data[i]);
-	assert(p[i] == data[i]);
+    //printf("p[%d] = x%02x, data = x%02x\n", i, p[i], data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -703,409 +703,409 @@ void test13()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F,0x0B,			// ud2
-	0x0F,0x05,			// syscall
-	0x0F,0x34,			// sysenter
-	0x0F,0x35,			// sysexit
-	0x0F,0x07,			// sysret
-	0x0F,0xAE,0xE8,			// lfence
-	0x0F,0xAE,0xF0,			// mfence
-	0x0F,0xAE,0xF8,			// sfence
-	0x0F,0xAE,0x00,			// fxsave	[RAX]
-	0x0F,0xAE,0x08,			// fxrstor	[RAX]
-	0x0F,0xAE,0x10,			// ldmxcsr	[RAX]
-	0x0F,0xAE,0x18,			// stmxcsr	[RAX]
-	0x0F,0xAE,0x38,			// clflush	[RAX]
+    0x0F,0x0B,          // ud2
+    0x0F,0x05,          // syscall
+    0x0F,0x34,          // sysenter
+    0x0F,0x35,          // sysexit
+    0x0F,0x07,          // sysret
+    0x0F,0xAE,0xE8,         // lfence
+    0x0F,0xAE,0xF0,         // mfence
+    0x0F,0xAE,0xF8,         // sfence
+    0x0F,0xAE,0x00,         // fxsave   [RAX]
+    0x0F,0xAE,0x08,         // fxrstor  [RAX]
+    0x0F,0xAE,0x10,         // ldmxcsr  [RAX]
+    0x0F,0xAE,0x18,         // stmxcsr  [RAX]
+    0x0F,0xAE,0x38,         // clflush  [RAX]
 
-	0x0F,0x58,0x08,			// addps	XMM1,[RAX]
-	0x0F,0x58,0xCA,			// addps	XMM1,XMM2
-0x66,	0x0F,0x58,0x03,			// addpd	XMM0,[RBX]
-0x66,	0x0F,0x58,0xD1,			// addpd	XMM2,XMM1
-	0xF2,0x0F,0x58,0x08,		// addsd	XMM1,[RAX]
-	0xF2,0x0F,0x58,0xCA,		// addsd	XMM1,XMM2
-	0xF3,0x0F,0x58,0x2E,		// addss	XMM5,[RSI]
-	0xF3,0x0F,0x58,0xF7,		// addss	XMM6,XMM7
-	0x0F,0x54,0x08,			// andps	XMM1,[RAX]
-	0x0F,0x54,0xCA,			// andps	XMM1,XMM2
-0x66,	0x0F,0x54,0x03,			// andpd	XMM0,[RBX]
-0x66,	0x0F,0x54,0xD1,			// andpd	XMM2,XMM1
-	0x0F,0x55,0x08,			// andnps	XMM1,[RAX]
-	0x0F,0x55,0xCA,			// andnps	XMM1,XMM2
-0x66,	0x0F,0x55,0x03,			// andnpd	XMM0,[RBX]
-0x66,	0x0F,0x55,0xD1,			// andnpd	XMM2,XMM1
-	0xA7,				// cmpsd
-	0x0F,0xC2,0x08,0x01,		// cmpps	XMM1,[RAX],1
-	0x0F,0xC2,0xCA,0x02,		// cmpps	XMM1,XMM2,2
-0x66,	0x0F,0xC2,0x03,0x03,		// cmppd	XMM0,[RBX],3
-0x66,	0x0F,0xC2,0xD1,0x04,		// cmppd	XMM2,XMM1,4
-	0xF2,0x0F,0xC2,0x08,0x05,	// cmpsd	XMM1,[RAX],5
-	0xF2,0x0F,0xC2,0xCA,0x06,	// cmpsd	XMM1,XMM2,6
-	0xF3,0x0F,0xC2,0x2E,0x07,	// cmpss	XMM5,[RSI],7
-	0xF3,0x0F,0xC2,0xF7,0x00,	// cmpss	XMM6,XMM7,0
-0x66,	0x0F,0x2F,0x08,			// comisd	XMM1,[RAX]
-0x66,	0x0F,0x2F,0x4D,0xD8,		// comisd	XMM1,-028h[RBP]
-0x66,	0x0F,0x2F,0xCA,			// comisd	XMM1,XMM2
-	0x0F,0x2F,0x2E,			// comiss	XMM5,[RSI]
-	0x0F,0x2F,0xF7,			// comiss	XMM6,XMM7
-	0xF3,0x0F,0xE6,0xDC,		// cvtdq2pd	XMM3,XMM4
-	0xF3,0x0F,0xE6,0x5D,0xD8,	// cvtdq2pd	XMM3,-028h[RBP]
-	0x0F,0x5B,0xDC,			// cvtdq2ps	XMM3,XMM4
-	0x0F,0x5B,0x5D,0xE0,		// cvtdq2ps	XMM3,-020h[RBP]
-	0xF2,0x0F,0xE6,0xDC,		// cvtpd2dq	XMM3,XMM4
-	0xF2,0x0F,0xE6,0x5D,0xE0,	// cvtpd2dq	XMM3,-020h[RBP]
-0x66,	0x0F,0x2D,0xDC,			// cvtpd2pi	MM3,XMM4
-0x66,	0x0F,0x2D,0x5D,0xE0,		// cvtpd2pi	MM3,-020h[RBP]
-0x66,	0x0F,0x5A,0xDC,			// cvtpd2ps	XMM3,XMM4
-0x66,	0x0F,0x5A,0x5D,0xE0,		// cvtpd2ps	XMM3,-020h[RBP]
-0x66,	0x0F,0x2A,0xDC,			// cvtpi2pd	XMM3,MM4
-0x66,	0x0F,0x2A,0x5D,0xD8,		// cvtpi2pd	XMM3,-028h[RBP]
-	0x0F,0x2A,0xDC,			// cvtpi2ps	XMM3,MM4
-	0x0F,0x2A,0x5D,0xD8,		// cvtpi2ps	XMM3,-028h[RBP]
-0x66,	0x0F,0x5B,0xDC,			// cvtps2dq	XMM3,XMM4
-0x66,	0x0F,0x5B,0x5D,0xE0,		// cvtps2dq	XMM3,-020h[RBP]
-	0x0F,0x5A,0xDC,			// cvtps2pd	XMM3,XMM4
-	0x0F,0x5A,0x5D,0xD8,		// cvtps2pd	XMM3,-028h[RBP]
-	0x0F,0x2D,0xDC,			// cvtps2pi	MM3,XMM4
-	0x0F,0x2D,0x5D,0xD8,		// cvtps2pi	MM3,-030h[RBP]
-	0xF2,0x0F,0x2D,0xCC,		// cvtsd2si	XMM1,XMM4
-	0xF2,0x0F,0x2D,0x55,0xD8,	// cvtsd2si	XMM2,-028h[RBP]
-	0xF2,0x0F,0x5A,0xDC,		// cvtsd2ss	XMM3,XMM4
-	0xF2,0x0F,0x5A,0x5D,0xD8,	// cvtsd2ss	XMM3,-028h[RBP]
-	0xF2,0x0F,0x2A,0xDA,		// cvtsi2sd	XMM3,EDX
-	0xF2,0x0F,0x2A,0x5D,0xD0,	// cvtsi2sd	XMM3,-030h[RBP]
-	0xF3,0x0F,0x2A,0xDA,		// cvtsi2ss	XMM3,EDX
-	0xF3,0x0F,0x2A,0x5D,0xD0,	// cvtsi2ss	XMM3,-030h[RBP]
-	0xF3,0x0F,0x5A,0xDC,		// cvtss2sd	XMM3,XMM4
-	0xF3,0x0F,0x5A,0x5D,0xD0,	// cvtss2sd	XMM3,-030h[RBP]
-	0xF3,0x0F,0x2D,0xFC,		// cvtss2si	XMM7,XMM4
-	0xF3,0x0F,0x2D,0x7D,0xD0,	// cvtss2si	XMM7,-030h[RBP]
-0x66,	0x0F,0x2C,0xDC,			// cvttpd2pi	MM3,XMM4
-0x66,	0x0F,0x2C,0x7D,0xE0,		// cvttpd2pi	MM7,-020h[RBP]
-0x66,	0x0F,0xE6,0xDC,			// cvttpd2dq	XMM3,XMM4
-0x66,	0x0F,0xE6,0x7D,0xE0,		// cvttpd2dq	XMM7,-020h[RBP]
-	0xF3,0x0F,0x5B,0xDC,		// cvttps2dq	XMM3,XMM4
-	0xF3,0x0F,0x5B,0x7D,0xE0,	// cvttps2dq	XMM7,-020h[RBP]
-	0x0F,0x2C,0xDC,			// cvttps2pi	MM3,XMM4
-	0x0F,0x2C,0x7D,0xD8,		// cvttps2pi	MM7,-028h[RBP]
-	0xF2,0x0F,0x2C,0xC4,		// cvttsd2si	EAX,XMM4
-	0xF2,0x0F,0x2C,0x4D,0xE0,	// cvttsd2si	ECX,-020h[RBP]
-	0xF3,0x0F,0x2C,0xC4,		// cvttss2si	EAX,XMM4
-	0xF3,0x0F,0x2C,0x4D,0xD0,	// cvttss2si	ECX,-030h[RBP]
-0x66,	0x0F,0x5E,0xE8,			// divpd	XMM5,XMM0
-0x66,	0x0F,0x5E,0x6D,0xE0,		// divpd	XMM5,-020h[RBP]
-	0x0F,0x5E,0xE8,			// divps	XMM5,XMM0
-	0x0F,0x5E,0x6D,0xE0,		// divps	XMM5,-020h[RBP]
-	0xF2,0x0F,0x5E,0xE8,		// divsd	XMM5,XMM0
-	0xF2,0x0F,0x5E,0x6D,0xD8,	// divsd	XMM5,-028h[RBP]
-	0xF3,0x0F,0x5E,0xE8,		// divss	XMM5,XMM0
-	0xF3,0x0F,0x5E,0x6D,0xD0,	// divss	XMM5,-030h[RBP]
-0x66,	0x0F,0xF7,0xD1,			// maskmovdqu	XMM2,XMM1
-	0x0F,0xF7,0xE3,			// maskmovq	MM4,MM3
-0x66,	0x0F,0x5F,0xC0,			// maxpd	XMM0,XMM0
-0x66,	0x0F,0x5F,0x4D,0xE0,		// maxpd	XMM1,-020h[RBP]
-	0x0F,0x5F,0xD1,			// maxps	XMM2,XMM1
-	0x0F,0x5F,0x5D,0xE0,		// maxps	XMM3,-020h[RBP]
-	0xF2,0x0F,0x5F,0xE2,		// maxsd	XMM4,XMM2
-	0xF2,0x0F,0x5F,0x6D,0xD8,	// maxsd	XMM5,-028h[RBP]
-	0xF3,0x0F,0x5F,0xF3,		// maxss	XMM6,XMM3
-	0xF3,0x0F,0x5F,0x7D,0xD0,	// maxss	XMM7,-030h[RBP]
-0x66,	0x0F,0x5D,0xC0,			// minpd	XMM0,XMM0
-0x66,	0x0F,0x5D,0x4D,0xE0,		// minpd	XMM1,-020h[RBP]
-	0x0F,0x5D,0xD1,			// minps	XMM2,XMM1
-	0x0F,0x5D,0x5D,0xE0,		// minps	XMM3,-020h[RBP]
-	0xF2,0x0F,0x5D,0xE2,		// minsd	XMM4,XMM2
-	0xF2,0x0F,0x5D,0x6D,0xD8,	// minsd	XMM5,-028h[RBP]
-	0xF3,0x0F,0x5D,0xF3,		// minss	XMM6,XMM3
-	0xF3,0x0F,0x5D,0x7D,0xD0,	// minss	XMM7,-030h[RBP]
-0x66,	0x0F,0x28,0xCA,			// movapd	XMM1,XMM2
-0x66,	0x0F,0x28,0x5D,0xE0,		// movapd	XMM3,-020h[RBP]
-0x66,	0x0F,0x29,0x65,0xE0,		// movapd	-020h[RBP],XMM4
-	0x0F,0x28,0xCA,			// movaps	XMM1,XMM2
-	0x0F,0x28,0x5D,0xE0,		// movaps	XMM3,-020h[RBP]
-	0x0F,0x29,0x65,0xE0,		// movaps	-020h[RBP],XMM4
-	0x0F,0x6E,0xCB,			// movd		MM1,EBX
-	0x0F,0x6E,0x55,0xD0,		// movd		MM2,-030h[RBP]
-	0x0F,0x7E,0xDB,			// movd		EBX,MM3
-	0x0F,0x7E,0x65,0xD0,		// movd		-030h[RBP],MM4
-0x66,	0x0F,0x6E,0xCB,			// movd		XMM1,EBX
-0x66,	0x0F,0x6E,0x55,0xD0,		// movd		XMM2,-030h[RBP]
-0x66,	0x0F,0x7E,0xDB,			// movd		EBX,XMM3
-0x66,	0x0F,0x7E,0x65,0xD0,		// movd		-030h[RBP],XMM4
-0x66,	0x0F,0x6F,0xCA,			// movdqa	XMM1,XMM2
-0x66,	0x0F,0x6F,0x55,0xE0,		// movdqa	XMM2,-020h[RBP]
-0x66,	0x0F,0x7F,0x65,0xE0,		// movdqa	-020h[RBP],XMM4
-	0xF3,0x0F,0x6F,0xCA,		// movdqu	XMM1,XMM2
-	0xF3,0x0F,0x6F,0x55,0xE0,	// movdqu	XMM2,-020h[RBP]
-	0xF3,0x0F,0x7F,0x65,0xE0,	// movdqu	-020h[RBP],XMM4
-	0xF2,0x0F,0xD6,0xDC,		// movdq2q	MM4,XMM3
-	0x0F,0x12,0xDC,			// movhlps	XMM4,XMM3
-0x66,	0x0F,0x16,0x55,0xD8,		// movhpd	XMM2,-028h[RBP]
-0x66,	0x0F,0x17,0x7D,0xD8,		// movhpd	-028h[RBP],XMM7
-	0x0F,0x16,0x55,0xD8,		// movhps	XMM2,-028h[RBP]
-	0x0F,0x17,0x7D,0xD8,		// movhps	-028h[RBP],XMM7
-	0x0F,0x16,0xDC,			// movlhps	XMM4,XMM3
-0x66,	0x0F,0x12,0x55,0xD8,		// movlpd	XMM2,-028h[RBP]
-0x66,	0x0F,0x13,0x7D,0xD8,		// movlpd	-028h[RBP],XMM7
-	0x0F,0x12,0x55,0xD8,		// movlps	XMM2,-028h[RBP]
-	0x0F,0x13,0x7D,0xD8,		// movlps	-028h[RBP],XMM7
-0x66,	0x0F,0x50,0xF3,			// movmskpd	ESI,XMM3
-	0x0F,0x50,0xF3,			// movmskps	ESI,XMM3
-0x66,	0x0F,0x59,0xC0,			// mulpd	XMM0,XMM0
-0x66,	0x0F,0x59,0x4D,0xE0,		// mulpd	XMM1,-020h[RBP]
-	0x0F,0x59,0xD1,			// mulps	XMM2,XMM1
-	0x0F,0x59,0x5D,0xE0,		// mulps	XMM3,-020h[RBP]
-	0xF2,0x0F,0x59,0xE2,		// mulsd	XMM4,XMM2
-	0xF2,0x0F,0x59,0x6D,0xD8,	// mulsd	XMM5,-028h[RBP]
-	0xF3,0x0F,0x59,0xF3,		// mulss	XMM6,XMM3
-	0xF3,0x0F,0x59,0x7D,0xD0,	// mulss	XMM7,-030h[RBP]
-0x66, 	0x0F,0x51,0xC4,			// sqrtpd	XMM0,XMM4
-0x66, 	0x0F,0x51,0x4D,0xE0,		// sqrtpd	XMM1,-020h[RBP]
-	0x0F,0x51,0xD5,			// sqrtps	XMM2,XMM5
-	0x0F,0x51,0x5D,0xE0,		// sqrtps	XMM3,-020h[RBP]
-	0xF2,0x0F,0x51,0xE6,		// sqrtsd	XMM4,XMM6
-	0xF2,0x0F,0x51,0x6D,0xD8,	// sqrtsd	XMM5,-028h[RBP]
-	0xF3,0x0F,0x51,0xF7,		// sqrtss	XMM6,XMM7
-	0xF3,0x0F,0x51,0x7D,0xD0,	// sqrtss	XMM7,-030h[RBP]
-0x66,	0x0F,0x5C,0xC4,			// subpd	XMM0,XMM4
-0x66,	0x0F,0x5C,0x4D,0xE0,		// subpd	XMM1,-020h[RBP]
-	0x0F,0x5C,0xD5,			// subps	XMM2,XMM5
-	0x0F,0x5C,0x5D,0xE0,		// subps	XMM3,-020h[RBP]
-	0xF2,0x0F,0x5C,0xE6,		// subsd	XMM4,XMM6
-	0xF2,0x0F,0x5C,0x6D,0xD8,	// subsd	XMM5,-028h[RBP]
-	0xF3,0x0F,0x5C,0xF7,		// subss	XMM6,XMM7
-	0xF3,0x0F,0x5C,0x7D,0xD0,	// subss	XMM7,-030h[RBP]
-	0x0F,0x01,0xE0,			// smsw EAX
+    0x0F,0x58,0x08,         // addps    XMM1,[RAX]
+    0x0F,0x58,0xCA,         // addps    XMM1,XMM2
+0x66,   0x0F,0x58,0x03,         // addpd    XMM0,[RBX]
+0x66,   0x0F,0x58,0xD1,         // addpd    XMM2,XMM1
+    0xF2,0x0F,0x58,0x08,        // addsd    XMM1,[RAX]
+    0xF2,0x0F,0x58,0xCA,        // addsd    XMM1,XMM2
+    0xF3,0x0F,0x58,0x2E,        // addss    XMM5,[RSI]
+    0xF3,0x0F,0x58,0xF7,        // addss    XMM6,XMM7
+    0x0F,0x54,0x08,         // andps    XMM1,[RAX]
+    0x0F,0x54,0xCA,         // andps    XMM1,XMM2
+0x66,   0x0F,0x54,0x03,         // andpd    XMM0,[RBX]
+0x66,   0x0F,0x54,0xD1,         // andpd    XMM2,XMM1
+    0x0F,0x55,0x08,         // andnps   XMM1,[RAX]
+    0x0F,0x55,0xCA,         // andnps   XMM1,XMM2
+0x66,   0x0F,0x55,0x03,         // andnpd   XMM0,[RBX]
+0x66,   0x0F,0x55,0xD1,         // andnpd   XMM2,XMM1
+    0xA7,               // cmpsd
+    0x0F,0xC2,0x08,0x01,        // cmpps    XMM1,[RAX],1
+    0x0F,0xC2,0xCA,0x02,        // cmpps    XMM1,XMM2,2
+0x66,   0x0F,0xC2,0x03,0x03,        // cmppd    XMM0,[RBX],3
+0x66,   0x0F,0xC2,0xD1,0x04,        // cmppd    XMM2,XMM1,4
+    0xF2,0x0F,0xC2,0x08,0x05,   // cmpsd    XMM1,[RAX],5
+    0xF2,0x0F,0xC2,0xCA,0x06,   // cmpsd    XMM1,XMM2,6
+    0xF3,0x0F,0xC2,0x2E,0x07,   // cmpss    XMM5,[RSI],7
+    0xF3,0x0F,0xC2,0xF7,0x00,   // cmpss    XMM6,XMM7,0
+0x66,   0x0F,0x2F,0x08,         // comisd   XMM1,[RAX]
+0x66,   0x0F,0x2F,0x4D,0xD8,        // comisd   XMM1,-028h[RBP]
+0x66,   0x0F,0x2F,0xCA,         // comisd   XMM1,XMM2
+    0x0F,0x2F,0x2E,         // comiss   XMM5,[RSI]
+    0x0F,0x2F,0xF7,         // comiss   XMM6,XMM7
+    0xF3,0x0F,0xE6,0xDC,        // cvtdq2pd XMM3,XMM4
+    0xF3,0x0F,0xE6,0x5D,0xD8,   // cvtdq2pd XMM3,-028h[RBP]
+    0x0F,0x5B,0xDC,         // cvtdq2ps XMM3,XMM4
+    0x0F,0x5B,0x5D,0xE0,        // cvtdq2ps XMM3,-020h[RBP]
+    0xF2,0x0F,0xE6,0xDC,        // cvtpd2dq XMM3,XMM4
+    0xF2,0x0F,0xE6,0x5D,0xE0,   // cvtpd2dq XMM3,-020h[RBP]
+0x66,   0x0F,0x2D,0xDC,         // cvtpd2pi MM3,XMM4
+0x66,   0x0F,0x2D,0x5D,0xE0,        // cvtpd2pi MM3,-020h[RBP]
+0x66,   0x0F,0x5A,0xDC,         // cvtpd2ps XMM3,XMM4
+0x66,   0x0F,0x5A,0x5D,0xE0,        // cvtpd2ps XMM3,-020h[RBP]
+0x66,   0x0F,0x2A,0xDC,         // cvtpi2pd XMM3,MM4
+0x66,   0x0F,0x2A,0x5D,0xD8,        // cvtpi2pd XMM3,-028h[RBP]
+    0x0F,0x2A,0xDC,         // cvtpi2ps XMM3,MM4
+    0x0F,0x2A,0x5D,0xD8,        // cvtpi2ps XMM3,-028h[RBP]
+0x66,   0x0F,0x5B,0xDC,         // cvtps2dq XMM3,XMM4
+0x66,   0x0F,0x5B,0x5D,0xE0,        // cvtps2dq XMM3,-020h[RBP]
+    0x0F,0x5A,0xDC,         // cvtps2pd XMM3,XMM4
+    0x0F,0x5A,0x5D,0xD8,        // cvtps2pd XMM3,-028h[RBP]
+    0x0F,0x2D,0xDC,         // cvtps2pi MM3,XMM4
+    0x0F,0x2D,0x5D,0xD8,        // cvtps2pi MM3,-030h[RBP]
+    0xF2,0x0F,0x2D,0xCC,        // cvtsd2si XMM1,XMM4
+    0xF2,0x0F,0x2D,0x55,0xD8,   // cvtsd2si XMM2,-028h[RBP]
+    0xF2,0x0F,0x5A,0xDC,        // cvtsd2ss XMM3,XMM4
+    0xF2,0x0F,0x5A,0x5D,0xD8,   // cvtsd2ss XMM3,-028h[RBP]
+    0xF2,0x0F,0x2A,0xDA,        // cvtsi2sd XMM3,EDX
+    0xF2,0x0F,0x2A,0x5D,0xD0,   // cvtsi2sd XMM3,-030h[RBP]
+    0xF3,0x0F,0x2A,0xDA,        // cvtsi2ss XMM3,EDX
+    0xF3,0x0F,0x2A,0x5D,0xD0,   // cvtsi2ss XMM3,-030h[RBP]
+    0xF3,0x0F,0x5A,0xDC,        // cvtss2sd XMM3,XMM4
+    0xF3,0x0F,0x5A,0x5D,0xD0,   // cvtss2sd XMM3,-030h[RBP]
+    0xF3,0x0F,0x2D,0xFC,        // cvtss2si XMM7,XMM4
+    0xF3,0x0F,0x2D,0x7D,0xD0,   // cvtss2si XMM7,-030h[RBP]
+0x66,   0x0F,0x2C,0xDC,         // cvttpd2pi    MM3,XMM4
+0x66,   0x0F,0x2C,0x7D,0xE0,        // cvttpd2pi    MM7,-020h[RBP]
+0x66,   0x0F,0xE6,0xDC,         // cvttpd2dq    XMM3,XMM4
+0x66,   0x0F,0xE6,0x7D,0xE0,        // cvttpd2dq    XMM7,-020h[RBP]
+    0xF3,0x0F,0x5B,0xDC,        // cvttps2dq    XMM3,XMM4
+    0xF3,0x0F,0x5B,0x7D,0xE0,   // cvttps2dq    XMM7,-020h[RBP]
+    0x0F,0x2C,0xDC,         // cvttps2pi    MM3,XMM4
+    0x0F,0x2C,0x7D,0xD8,        // cvttps2pi    MM7,-028h[RBP]
+    0xF2,0x0F,0x2C,0xC4,        // cvttsd2si    EAX,XMM4
+    0xF2,0x0F,0x2C,0x4D,0xE0,   // cvttsd2si    ECX,-020h[RBP]
+    0xF3,0x0F,0x2C,0xC4,        // cvttss2si    EAX,XMM4
+    0xF3,0x0F,0x2C,0x4D,0xD0,   // cvttss2si    ECX,-030h[RBP]
+0x66,   0x0F,0x5E,0xE8,         // divpd    XMM5,XMM0
+0x66,   0x0F,0x5E,0x6D,0xE0,        // divpd    XMM5,-020h[RBP]
+    0x0F,0x5E,0xE8,         // divps    XMM5,XMM0
+    0x0F,0x5E,0x6D,0xE0,        // divps    XMM5,-020h[RBP]
+    0xF2,0x0F,0x5E,0xE8,        // divsd    XMM5,XMM0
+    0xF2,0x0F,0x5E,0x6D,0xD8,   // divsd    XMM5,-028h[RBP]
+    0xF3,0x0F,0x5E,0xE8,        // divss    XMM5,XMM0
+    0xF3,0x0F,0x5E,0x6D,0xD0,   // divss    XMM5,-030h[RBP]
+0x66,   0x0F,0xF7,0xD1,         // maskmovdqu   XMM2,XMM1
+    0x0F,0xF7,0xE3,         // maskmovq MM4,MM3
+0x66,   0x0F,0x5F,0xC0,         // maxpd    XMM0,XMM0
+0x66,   0x0F,0x5F,0x4D,0xE0,        // maxpd    XMM1,-020h[RBP]
+    0x0F,0x5F,0xD1,         // maxps    XMM2,XMM1
+    0x0F,0x5F,0x5D,0xE0,        // maxps    XMM3,-020h[RBP]
+    0xF2,0x0F,0x5F,0xE2,        // maxsd    XMM4,XMM2
+    0xF2,0x0F,0x5F,0x6D,0xD8,   // maxsd    XMM5,-028h[RBP]
+    0xF3,0x0F,0x5F,0xF3,        // maxss    XMM6,XMM3
+    0xF3,0x0F,0x5F,0x7D,0xD0,   // maxss    XMM7,-030h[RBP]
+0x66,   0x0F,0x5D,0xC0,         // minpd    XMM0,XMM0
+0x66,   0x0F,0x5D,0x4D,0xE0,        // minpd    XMM1,-020h[RBP]
+    0x0F,0x5D,0xD1,         // minps    XMM2,XMM1
+    0x0F,0x5D,0x5D,0xE0,        // minps    XMM3,-020h[RBP]
+    0xF2,0x0F,0x5D,0xE2,        // minsd    XMM4,XMM2
+    0xF2,0x0F,0x5D,0x6D,0xD8,   // minsd    XMM5,-028h[RBP]
+    0xF3,0x0F,0x5D,0xF3,        // minss    XMM6,XMM3
+    0xF3,0x0F,0x5D,0x7D,0xD0,   // minss    XMM7,-030h[RBP]
+0x66,   0x0F,0x28,0xCA,         // movapd   XMM1,XMM2
+0x66,   0x0F,0x28,0x5D,0xE0,        // movapd   XMM3,-020h[RBP]
+0x66,   0x0F,0x29,0x65,0xE0,        // movapd   -020h[RBP],XMM4
+    0x0F,0x28,0xCA,         // movaps   XMM1,XMM2
+    0x0F,0x28,0x5D,0xE0,        // movaps   XMM3,-020h[RBP]
+    0x0F,0x29,0x65,0xE0,        // movaps   -020h[RBP],XMM4
+    0x0F,0x6E,0xCB,         // movd     MM1,EBX
+    0x0F,0x6E,0x55,0xD0,        // movd     MM2,-030h[RBP]
+    0x0F,0x7E,0xDB,         // movd     EBX,MM3
+    0x0F,0x7E,0x65,0xD0,        // movd     -030h[RBP],MM4
+0x66,   0x0F,0x6E,0xCB,         // movd     XMM1,EBX
+0x66,   0x0F,0x6E,0x55,0xD0,        // movd     XMM2,-030h[RBP]
+0x66,   0x0F,0x7E,0xDB,         // movd     EBX,XMM3
+0x66,   0x0F,0x7E,0x65,0xD0,        // movd     -030h[RBP],XMM4
+0x66,   0x0F,0x6F,0xCA,         // movdqa   XMM1,XMM2
+0x66,   0x0F,0x6F,0x55,0xE0,        // movdqa   XMM2,-020h[RBP]
+0x66,   0x0F,0x7F,0x65,0xE0,        // movdqa   -020h[RBP],XMM4
+    0xF3,0x0F,0x6F,0xCA,        // movdqu   XMM1,XMM2
+    0xF3,0x0F,0x6F,0x55,0xE0,   // movdqu   XMM2,-020h[RBP]
+    0xF3,0x0F,0x7F,0x65,0xE0,   // movdqu   -020h[RBP],XMM4
+    0xF2,0x0F,0xD6,0xDC,        // movdq2q  MM4,XMM3
+    0x0F,0x12,0xDC,         // movhlps  XMM4,XMM3
+0x66,   0x0F,0x16,0x55,0xD8,        // movhpd   XMM2,-028h[RBP]
+0x66,   0x0F,0x17,0x7D,0xD8,        // movhpd   -028h[RBP],XMM7
+    0x0F,0x16,0x55,0xD8,        // movhps   XMM2,-028h[RBP]
+    0x0F,0x17,0x7D,0xD8,        // movhps   -028h[RBP],XMM7
+    0x0F,0x16,0xDC,         // movlhps  XMM4,XMM3
+0x66,   0x0F,0x12,0x55,0xD8,        // movlpd   XMM2,-028h[RBP]
+0x66,   0x0F,0x13,0x7D,0xD8,        // movlpd   -028h[RBP],XMM7
+    0x0F,0x12,0x55,0xD8,        // movlps   XMM2,-028h[RBP]
+    0x0F,0x13,0x7D,0xD8,        // movlps   -028h[RBP],XMM7
+0x66,   0x0F,0x50,0xF3,         // movmskpd ESI,XMM3
+    0x0F,0x50,0xF3,         // movmskps ESI,XMM3
+0x66,   0x0F,0x59,0xC0,         // mulpd    XMM0,XMM0
+0x66,   0x0F,0x59,0x4D,0xE0,        // mulpd    XMM1,-020h[RBP]
+    0x0F,0x59,0xD1,         // mulps    XMM2,XMM1
+    0x0F,0x59,0x5D,0xE0,        // mulps    XMM3,-020h[RBP]
+    0xF2,0x0F,0x59,0xE2,        // mulsd    XMM4,XMM2
+    0xF2,0x0F,0x59,0x6D,0xD8,   // mulsd    XMM5,-028h[RBP]
+    0xF3,0x0F,0x59,0xF3,        // mulss    XMM6,XMM3
+    0xF3,0x0F,0x59,0x7D,0xD0,   // mulss    XMM7,-030h[RBP]
+0x66,   0x0F,0x51,0xC4,         // sqrtpd   XMM0,XMM4
+0x66,   0x0F,0x51,0x4D,0xE0,        // sqrtpd   XMM1,-020h[RBP]
+    0x0F,0x51,0xD5,         // sqrtps   XMM2,XMM5
+    0x0F,0x51,0x5D,0xE0,        // sqrtps   XMM3,-020h[RBP]
+    0xF2,0x0F,0x51,0xE6,        // sqrtsd   XMM4,XMM6
+    0xF2,0x0F,0x51,0x6D,0xD8,   // sqrtsd   XMM5,-028h[RBP]
+    0xF3,0x0F,0x51,0xF7,        // sqrtss   XMM6,XMM7
+    0xF3,0x0F,0x51,0x7D,0xD0,   // sqrtss   XMM7,-030h[RBP]
+0x66,   0x0F,0x5C,0xC4,         // subpd    XMM0,XMM4
+0x66,   0x0F,0x5C,0x4D,0xE0,        // subpd    XMM1,-020h[RBP]
+    0x0F,0x5C,0xD5,         // subps    XMM2,XMM5
+    0x0F,0x5C,0x5D,0xE0,        // subps    XMM3,-020h[RBP]
+    0xF2,0x0F,0x5C,0xE6,        // subsd    XMM4,XMM6
+    0xF2,0x0F,0x5C,0x6D,0xD8,   // subsd    XMM5,-028h[RBP]
+    0xF3,0x0F,0x5C,0xF7,        // subss    XMM6,XMM7
+    0xF3,0x0F,0x5C,0x7D,0xD0,   // subss    XMM7,-030h[RBP]
+    0x0F,0x01,0xE0,         // smsw EAX
     ];
     int i;
 
     asm
     {
-	call	L1			;
-	ud2				;
-	syscall				;
-	sysenter			;
-	sysexit				;
-	sysret				;
-	lfence				;
-	mfence				;
-	sfence				;
-	fxsave	[RAX]			;
-	fxrstor	[RAX]			;
-	ldmxcsr	[RAX]			;
-	stmxcsr	[RAX]			;
-	clflush	[RAX]			;
+    call    L1          ;
+    ud2             ;
+    syscall             ;
+    sysenter            ;
+    sysexit             ;
+    sysret              ;
+    lfence              ;
+    mfence              ;
+    sfence              ;
+    fxsave  [RAX]           ;
+    fxrstor [RAX]           ;
+    ldmxcsr [RAX]           ;
+    stmxcsr [RAX]           ;
+    clflush [RAX]           ;
 
-	addps XMM1,[RAX]		;
-	addps XMM1,XMM2			;
-	addpd XMM0,[RBX]		;
-	addpd XMM2,XMM1			;
-	addsd XMM1,[RAX]		;
-	addsd XMM1,XMM2			;
-	addss XMM5,[RSI]		;
-	addss XMM6,XMM7			;
+    addps XMM1,[RAX]        ;
+    addps XMM1,XMM2         ;
+    addpd XMM0,[RBX]        ;
+    addpd XMM2,XMM1         ;
+    addsd XMM1,[RAX]        ;
+    addsd XMM1,XMM2         ;
+    addss XMM5,[RSI]        ;
+    addss XMM6,XMM7         ;
 
-	andps XMM1,[RAX]		;
-	andps XMM1,XMM2			;
-	andpd XMM0,[RBX]		;
-	andpd XMM2,XMM1			;
+    andps XMM1,[RAX]        ;
+    andps XMM1,XMM2         ;
+    andpd XMM0,[RBX]        ;
+    andpd XMM2,XMM1         ;
 
-	andnps XMM1,[RAX]		;
-	andnps XMM1,XMM2		;
-	andnpd XMM0,[RBX]		;
-	andnpd XMM2,XMM1		;
+    andnps XMM1,[RAX]       ;
+    andnps XMM1,XMM2        ;
+    andnpd XMM0,[RBX]       ;
+    andnpd XMM2,XMM1        ;
 
-	cmpsd				;
-	cmpps XMM1,[RAX],1		;
-	cmpps XMM1,XMM2,2		;
-	cmppd XMM0,[RBX],3		;
-	cmppd XMM2,XMM1,4		;
-	cmpsd XMM1,[RAX],5		;
-	cmpsd XMM1,XMM2,6		;
-	cmpss XMM5,[RSI],7		;
-	cmpss XMM6,XMM7,0		;
+    cmpsd               ;
+    cmpps XMM1,[RAX],1      ;
+    cmpps XMM1,XMM2,2       ;
+    cmppd XMM0,[RBX],3      ;
+    cmppd XMM2,XMM1,4       ;
+    cmpsd XMM1,[RAX],5      ;
+    cmpsd XMM1,XMM2,6       ;
+    cmpss XMM5,[RSI],7      ;
+    cmpss XMM6,XMM7,0       ;
 
-	comisd XMM1,[RAX]		;
-	comisd XMM1,m64[RBP]		;
-	comisd XMM1,XMM2		;
-	comiss XMM5,[RSI]		;
-	comiss XMM6,XMM7		;
+    comisd XMM1,[RAX]       ;
+    comisd XMM1,m64[RBP]        ;
+    comisd XMM1,XMM2        ;
+    comiss XMM5,[RSI]       ;
+    comiss XMM6,XMM7        ;
 
-	cvtdq2pd XMM3,XMM4		;
-	cvtdq2pd XMM3,m64[RBP]		;
+    cvtdq2pd XMM3,XMM4      ;
+    cvtdq2pd XMM3,m64[RBP]      ;
 
-	cvtdq2ps XMM3,XMM4		;
-	cvtdq2ps XMM3,m128[RBP]		;
+    cvtdq2ps XMM3,XMM4      ;
+    cvtdq2ps XMM3,m128[RBP]     ;
 
-	cvtpd2dq XMM3,XMM4		;
-	cvtpd2dq XMM3,m128[RBP]		;
+    cvtpd2dq XMM3,XMM4      ;
+    cvtpd2dq XMM3,m128[RBP]     ;
 
-	cvtpd2pi MM3,XMM4		;
-	cvtpd2pi MM3,m128[RBP]		;
+    cvtpd2pi MM3,XMM4       ;
+    cvtpd2pi MM3,m128[RBP]      ;
 
-	cvtpd2ps XMM3,XMM4		;
-	cvtpd2ps XMM3,m128[RBP]		;
+    cvtpd2ps XMM3,XMM4      ;
+    cvtpd2ps XMM3,m128[RBP]     ;
 
-	cvtpi2pd XMM3,MM4		;
-	cvtpi2pd XMM3,m64[RBP]		;
+    cvtpi2pd XMM3,MM4       ;
+    cvtpi2pd XMM3,m64[RBP]      ;
 
-	cvtpi2ps XMM3,MM4		;
-	cvtpi2ps XMM3,m64[RBP]		;
+    cvtpi2ps XMM3,MM4       ;
+    cvtpi2ps XMM3,m64[RBP]      ;
 
-	cvtps2dq XMM3,XMM4		;
-	cvtps2dq XMM3,m128[RBP]		;
+    cvtps2dq XMM3,XMM4      ;
+    cvtps2dq XMM3,m128[RBP]     ;
 
-	cvtps2pd XMM3,XMM4		;
-	cvtps2pd XMM3,m64[RBP]		;
+    cvtps2pd XMM3,XMM4      ;
+    cvtps2pd XMM3,m64[RBP]      ;
 
-	cvtps2pi MM3,XMM4		;
-	cvtps2pi MM3,m64[RBP]		;
+    cvtps2pi MM3,XMM4       ;
+    cvtps2pi MM3,m64[RBP]       ;
 
-	cvtsd2si ECX,XMM4		;
-	cvtsd2si EDX,m64[RBP]		;
+    cvtsd2si ECX,XMM4       ;
+    cvtsd2si EDX,m64[RBP]       ;
 
-	cvtsd2ss XMM3,XMM4		;
-	cvtsd2ss XMM3,m64[RBP]		;
+    cvtsd2ss XMM3,XMM4      ;
+    cvtsd2ss XMM3,m64[RBP]      ;
 
-	cvtsi2sd XMM3,EDX		;
-	cvtsi2sd XMM3,m32[RBP]		;
+    cvtsi2sd XMM3,EDX       ;
+    cvtsi2sd XMM3,m32[RBP]      ;
 
-	cvtsi2ss XMM3,EDX		;
-	cvtsi2ss XMM3,m32[RBP]		;
+    cvtsi2ss XMM3,EDX       ;
+    cvtsi2ss XMM3,m32[RBP]      ;
 
-	cvtss2sd XMM3,XMM4		;
-	cvtss2sd XMM3,m32[RBP]		;
+    cvtss2sd XMM3,XMM4      ;
+    cvtss2sd XMM3,m32[RBP]      ;
 
-	cvtss2si EDI,XMM4		;
-	cvtss2si EDI,m32[RBP]		;
+    cvtss2si EDI,XMM4       ;
+    cvtss2si EDI,m32[RBP]       ;
 
-	cvttpd2pi MM3,XMM4		;
-	cvttpd2pi MM7,m128[RBP]		;
+    cvttpd2pi MM3,XMM4      ;
+    cvttpd2pi MM7,m128[RBP]     ;
 
-	cvttpd2dq XMM3,XMM4		;
-	cvttpd2dq XMM7,m128[RBP]	;
+    cvttpd2dq XMM3,XMM4     ;
+    cvttpd2dq XMM7,m128[RBP]    ;
 
-	cvttps2dq XMM3,XMM4		;
-	cvttps2dq XMM7,m128[RBP]	;
+    cvttps2dq XMM3,XMM4     ;
+    cvttps2dq XMM7,m128[RBP]    ;
 
-	cvttps2pi MM3,XMM4		;
-	cvttps2pi MM7,m64[RBP]		;
+    cvttps2pi MM3,XMM4      ;
+    cvttps2pi MM7,m64[RBP]      ;
 
-	cvttsd2si EAX,XMM4		;
-	cvttsd2si ECX,m128[RBP]		;
+    cvttsd2si EAX,XMM4      ;
+    cvttsd2si ECX,m128[RBP]     ;
 
-	cvttss2si EAX,XMM4		;
-	cvttss2si ECX,m32[RBP]		;
+    cvttss2si EAX,XMM4      ;
+    cvttss2si ECX,m32[RBP]      ;
 
-	divpd	XMM5,XMM0		;
-	divpd	XMM5,m128[RBP]		;
-	divps	XMM5,XMM0		;
-	divps	XMM5,m128[RBP]		;
-	divsd	XMM5,XMM0		;
-	divsd	XMM5,m64[RBP]		;
-	divss	XMM5,XMM0		;
-	divss	XMM5,m32[RBP]		;
+    divpd   XMM5,XMM0       ;
+    divpd   XMM5,m128[RBP]      ;
+    divps   XMM5,XMM0       ;
+    divps   XMM5,m128[RBP]      ;
+    divsd   XMM5,XMM0       ;
+    divsd   XMM5,m64[RBP]       ;
+    divss   XMM5,XMM0       ;
+    divss   XMM5,m32[RBP]       ;
 
-	maskmovdqu XMM1,XMM2		;
-	maskmovq   MM3,MM4		;
+    maskmovdqu XMM1,XMM2        ;
+    maskmovq   MM3,MM4      ;
 
-	maxpd	XMM0,XMM0		;
-	maxpd	XMM1,m128[RBP]		;
-	maxps	XMM2,XMM1		;
-	maxps	XMM3,m128[RBP]		;
-	maxsd	XMM4,XMM2		;
-	maxsd	XMM5,m64[RBP]		;
-	maxss	XMM6,XMM3		;
-	maxss	XMM7,m32[RBP]		;
+    maxpd   XMM0,XMM0       ;
+    maxpd   XMM1,m128[RBP]      ;
+    maxps   XMM2,XMM1       ;
+    maxps   XMM3,m128[RBP]      ;
+    maxsd   XMM4,XMM2       ;
+    maxsd   XMM5,m64[RBP]       ;
+    maxss   XMM6,XMM3       ;
+    maxss   XMM7,m32[RBP]       ;
 
-	minpd	XMM0,XMM0		;
-	minpd	XMM1,m128[RBP]		;
-	minps	XMM2,XMM1		;
-	minps	XMM3,m128[RBP]		;
-	minsd	XMM4,XMM2		;
-	minsd	XMM5,m64[RBP]		;
-	minss	XMM6,XMM3		;
-	minss	XMM7,m32[RBP]		;
+    minpd   XMM0,XMM0       ;
+    minpd   XMM1,m128[RBP]      ;
+    minps   XMM2,XMM1       ;
+    minps   XMM3,m128[RBP]      ;
+    minsd   XMM4,XMM2       ;
+    minsd   XMM5,m64[RBP]       ;
+    minss   XMM6,XMM3       ;
+    minss   XMM7,m32[RBP]       ;
 
-	movapd	XMM1,XMM2		;
-	movapd	XMM3,m128[RBP]		;
-	movapd	m128[RBP],XMM4		;
+    movapd  XMM1,XMM2       ;
+    movapd  XMM3,m128[RBP]      ;
+    movapd  m128[RBP],XMM4      ;
 
-	movaps	XMM1,XMM2		;
-	movaps	XMM3,m128[RBP]		;
-	movaps	m128[RBP],XMM4		;
+    movaps  XMM1,XMM2       ;
+    movaps  XMM3,m128[RBP]      ;
+    movaps  m128[RBP],XMM4      ;
 
-	movd	MM1,EBX			;
-	movd	MM2,m32[RBP]		;
-	movd	EBX,MM3			;
-	movd	m32[RBP],MM4		;
+    movd    MM1,EBX         ;
+    movd    MM2,m32[RBP]        ;
+    movd    EBX,MM3         ;
+    movd    m32[RBP],MM4        ;
 
-	movd	XMM1,EBX		;
-	movd	XMM2,m32[RBP]		;
-	movd	EBX,XMM3		;
-	movd	m32[RBP],XMM4		;
+    movd    XMM1,EBX        ;
+    movd    XMM2,m32[RBP]       ;
+    movd    EBX,XMM3        ;
+    movd    m32[RBP],XMM4       ;
 
-	movdqa	XMM1,XMM2		;
-	movdqa	XMM2,m128[RBP]		;
-	movdqa	m128[RBP],XMM4		;
+    movdqa  XMM1,XMM2       ;
+    movdqa  XMM2,m128[RBP]      ;
+    movdqa  m128[RBP],XMM4      ;
 
-	movdqu	XMM1,XMM2		;
-	movdqu	XMM2,m128[RBP]		;
-	movdqu	m128[RBP],XMM4		;
+    movdqu  XMM1,XMM2       ;
+    movdqu  XMM2,m128[RBP]      ;
+    movdqu  m128[RBP],XMM4      ;
 
-	movdq2q	MM3,XMM4		;
-	movhlps	XMM3,XMM4		;
-	movhpd	XMM2,m64[RBP]		;
-	movhpd	m64[RBP],XMM7		;
-	movhps	XMM2,m64[RBP]		;
-	movhps	m64[RBP],XMM7		;
-	movlhps	XMM3,XMM4		;
-	movlpd	XMM2,m64[RBP]		;
-	movlpd	m64[RBP],XMM7		;
-	movlps	XMM2,m64[RBP]		;
-	movlps	m64[RBP],XMM7		;
+    movdq2q MM3,XMM4        ;
+    movhlps XMM3,XMM4       ;
+    movhpd  XMM2,m64[RBP]       ;
+    movhpd  m64[RBP],XMM7       ;
+    movhps  XMM2,m64[RBP]       ;
+    movhps  m64[RBP],XMM7       ;
+    movlhps XMM3,XMM4       ;
+    movlpd  XMM2,m64[RBP]       ;
+    movlpd  m64[RBP],XMM7       ;
+    movlps  XMM2,m64[RBP]       ;
+    movlps  m64[RBP],XMM7       ;
 
-	movmskpd ESI,XMM3		;
-	movmskps ESI,XMM3		;
+    movmskpd ESI,XMM3       ;
+    movmskps ESI,XMM3       ;
 
-	mulpd	XMM0,XMM0		;
-	mulpd	XMM1,m128[RBP]		;
-	mulps	XMM2,XMM1		;
-	mulps	XMM3,m128[RBP]		;
-	mulsd	XMM4,XMM2		;
-	mulsd	XMM5,m64[RBP]		;
-	mulss	XMM6,XMM3		;
-	mulss	XMM7,m32[RBP]		;
+    mulpd   XMM0,XMM0       ;
+    mulpd   XMM1,m128[RBP]      ;
+    mulps   XMM2,XMM1       ;
+    mulps   XMM3,m128[RBP]      ;
+    mulsd   XMM4,XMM2       ;
+    mulsd   XMM5,m64[RBP]       ;
+    mulss   XMM6,XMM3       ;
+    mulss   XMM7,m32[RBP]       ;
 
-	sqrtpd	XMM0,XMM4		;
-	sqrtpd	XMM1,m128[RBP]		;
-	sqrtps	XMM2,XMM5		;
-	sqrtps	XMM3,m128[RBP]		;
-	sqrtsd	XMM4,XMM6		;
-	sqrtsd	XMM5,m64[RBP]		;
-	sqrtss	XMM6,XMM7		;
-	sqrtss	XMM7,m32[RBP]		;
+    sqrtpd  XMM0,XMM4       ;
+    sqrtpd  XMM1,m128[RBP]      ;
+    sqrtps  XMM2,XMM5       ;
+    sqrtps  XMM3,m128[RBP]      ;
+    sqrtsd  XMM4,XMM6       ;
+    sqrtsd  XMM5,m64[RBP]       ;
+    sqrtss  XMM6,XMM7       ;
+    sqrtss  XMM7,m32[RBP]       ;
 
-	subpd	XMM0,XMM4		;
-	subpd	XMM1,m128[RBP]		;
-	subps	XMM2,XMM5		;
-	subps	XMM3,m128[RBP]		;
-	subsd	XMM4,XMM6		;
-	subsd	XMM5,m64[RBP]		;
-	subss	XMM6,XMM7		;
-	subss	XMM7,m32[RBP]		;
+    subpd   XMM0,XMM4       ;
+    subpd   XMM1,m128[RBP]      ;
+    subps   XMM2,XMM5       ;
+    subps   XMM3,m128[RBP]      ;
+    subsd   XMM4,XMM6       ;
+    subsd   XMM5,m64[RBP]       ;
+    subss   XMM6,XMM7       ;
+    subss   XMM7,m32[RBP]       ;
 
-	smsw	EAX			;
+    smsw    EAX         ;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	//printf("[%d] = %02x %02x\n", i, p[i], data[i]);
-	assert(p[i] == data[i]);
+    //printf("[%d] = %02x %02x\n", i, p[i], data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -1119,743 +1119,743 @@ void test14()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-0x66,	0x0F,0x50,0xF3,			// movmskpd	ESI,XMM3
-	0x0F,0x50,0xF3,			// movmskps	ESI,XMM3
-0x66,	0x0F,0xE7,0x55,0xE0,		// movntdq	-020h[RBP],XMM2
-	0x0F,0xC3,0x4D,0xD4,		// movnti	-02Ch[RBP],ECX
-0x66,	0x0F,0x2B,0x5D,0xE0,		// movntpd	-020h[RBP],XMM3
-	0x0F,0x2B,0x65,0xE0,		// movntps	-020h[RBP],XMM4
-	0x0F,0xE7,0x6D,0xD8,		// movntq	-028h[RBP],MM5
-	0x0F,0x6F,0xCA,			// movq		MM1,MM2
-	0x0F,0x6F,0x55,0xD8,		// movq		MM2,-028h[RBP]
-	0x0F,0x7F,0x5D,0xD8,		// movq		-028h[RBP],MM3
-	0xF3,0x0F,0x7E,0xCA,		// movq		XMM1,XMM2
-	0xF3,0x0F,0x7E,0x55,0xD8,	// movq		XMM2,-028h[RBP]
-0x66,	0x0F,0xD6,0x5D,0xD8,		// movq		-028h[RBP],XMM3
-	0xF3,0x0F,0xD6,0xDA,		// movq2dq	XMM3,MM2
-	0xA5,				// movsd
-	0xF2,0x0F,0x10,0xCA,		// movsd	XMM1,XMM2
-	0xF2,0x0F,0x10,0x5D,0xD8,	// movsd	XMM3,-028h[RBP]
-	0xF2,0x0F,0x11,0x65,0xD8,	// movsd	-028h[RBP],XMM4
-	0xF3,0x0F,0x10,0xCA,		// movss	XMM1,XMM2
-	0xF3,0x0F,0x10,0x5D,0xD4,	// movss	XMM3,-02Ch[RBP]
-	0xF3,0x0F,0x11,0x65,0xD4,	// movss	-02Ch[RBP],XMM4
-0x66,	0x0F,0x10,0xCA,			// movupd	XMM1,XMM2
-0x66,	0x0F,0x10,0x5D,0xE0,		// movupd	XMM3,-020h[RBP]
-0x66,	0x0F,0x11,0x65,0xE0,		// movupd	-020h[RBP],XMM4
-	0x0F,0x10,0xCA,			// movups	XMM1,XMM2
-	0x0F,0x10,0x5D,0xE0,		// movups	XMM3,-020h[RBP]
-	0x0F,0x11,0x65,0xE0,		// movups	-020h[RBP],XMM4
-0x66,	0x0F,0x56,0xCA,			// orpd		XMM1,XMM2
-0x66,	0x0F,0x56,0x5D,0xE0,		// orpd		XMM3,-020h[RBP]
-	0x0F,0x56,0xCA,			// orps		XMM1,XMM2
-	0x0F,0x56,0x5D,0xE0,		// orps		XMM3,-020h[RBP]
-	0x0F,0x63,0xCA,			// packsswb	MM1,MM2
-	0x0F,0x63,0x5D,0xD8,		// packsswb	MM3,-028h[RBP]
-0x66,	0x0F,0x63,0xCA,			// packsswb	XMM1,XMM2
-0x66,	0x0F,0x63,0x5D,0xE0,		// packsswb	XMM3,-020h[RBP]
-	0x0F,0x6B,0xCA,			// packssdw	MM1,MM2
-	0x0F,0x6B,0x5D,0xD8,		// packssdw	MM3,-028h[RBP]
-0x66,	0x0F,0x6B,0xCA,			// packssdw	XMM1,XMM2
-0x66,	0x0F,0x6B,0x5D,0xE0,		// packssdw	XMM3,-020h[RBP]
-	0x0F,0x67,0xCA,			// packuswb	MM1,MM2
-	0x0F,0x67,0x5D,0xD8,		// packuswb	MM3,-028h[RBP]
-0x66,	0x0F,0x67,0xCA,			// packuswb	XMM1,XMM2
-0x66,	0x0F,0x67,0x5D,0xE0,		// packuswb	XMM3,-020h[RBP]
-	0x0F,0xFC,0xCA,			// paddb	MM1,MM2
-	0x0F,0xFC,0x5D,0xD8,		// paddb	MM3,-028h[RBP]
-0x66,	0x0F,0xFC,0xCA,			// paddb	XMM1,XMM2
-0x66,	0x0F,0xFC,0x5D,0xE0,		// paddb	XMM3,-020h[RBP]
-	0x0F,0xFD,0xCA,			// paddw	MM1,MM2
-	0x0F,0xFD,0x5D,0xD8,		// paddw	MM3,-028h[RBP]
-0x66,	0x0F,0xFD,0xCA,			// paddw	XMM1,XMM2
-0x66,	0x0F,0xFD,0x5D,0xE0,		// paddw	XMM3,-020h[RBP]
-	0x0F,0xFE,0xCA,			// paddd	MM1,MM2
-	0x0F,0xFE,0x5D,0xD8,		// paddd	MM3,-028h[RBP]
-0x66,	0x0F,0xFE,0xCA,			// paddd	XMM1,XMM2
-0x66,	0x0F,0xFE,0x5D,0xE0,		// paddd	XMM3,-020h[RBP]
-	0x0F,0xD4,0xCA,			// paddq	MM1,MM2
-	0x0F,0xD4,0x5D,0xD8,		// paddq	MM3,-028h[RBP]
-0x66,	0x0F,0xD4,0xCA,			// paddq	XMM1,XMM2
-0x66,	0x0F,0xD4,0x5D,0xE0,		// paddq	XMM3,-020h[RBP]
-	0x0F,0xEC,0xCA,			// paddsb	MM1,MM2
-	0x0F,0xEC,0x5D,0xD8,		// paddsb	MM3,-028h[RBP]
-0x66,	0x0F,0xEC,0xCA,			// paddsb	XMM1,XMM2
-0x66,	0x0F,0xEC,0x5D,0xE0,		// paddsb	XMM3,-020h[RBP]
-	0x0F,0xED,0xCA,			// paddsw	MM1,MM2
-	0x0F,0xED,0x5D,0xD8,		// paddsw	MM3,-028h[RBP]
-0x66,	0x0F,0xED,0xCA,			// paddsw	XMM1,XMM2
-0x66,	0x0F,0xED,0x5D,0xE0,		// paddsw	XMM3,-020h[RBP]
-	0x0F,0xDC,0xCA,			// paddusb	MM1,MM2
-	0x0F,0xDC,0x5D,0xD8,		// paddusb	MM3,-028h[RBP]
-0x66,	0x0F,0xDC,0xCA,			// paddusb	XMM1,XMM2
-0x66,	0x0F,0xDC,0x5D,0xE0,		// paddusb	XMM3,-020h[RBP]
-	0x0F,0xDD,0xCA,			// paddusw	MM1,MM2
-	0x0F,0xDD,0x5D,0xD8,		// paddusw	MM3,-028h[RBP]
-0x66,	0x0F,0xDD,0xCA,			// paddusw	XMM1,XMM2
-0x66,	0x0F,0xDD,0x5D,0xE0,		// paddusw	XMM3,-020h[RBP]
-	0x0F,0xDB,0xCA,			// pand		MM1,MM2
-	0x0F,0xDB,0x5D,0xD8,		// pand		MM3,-028h[RBP]
-0x66,	0x0F,0xDB,0xCA,			// pand		XMM1,XMM2
-0x66,	0x0F,0xDB,0x5D,0xE0,		// pand		XMM3,-020h[RBP]
-	0x0F,0xDF,0xCA,			// pandn	MM1,MM2
-	0x0F,0xDF,0x5D,0xD8,		// pandn	MM3,-028h[RBP]
-0x66,	0x0F,0xDF,0xCA,			// pandn	XMM1,XMM2
-0x66,	0x0F,0xDF,0x5D,0xE0,		// pandn	XMM3,-020h[RBP]
-	0x0F,0xE0,0xCA,			// pavgb	MM1,MM2
-	0x0F,0xE0,0x5D,0xD8,		// pavgb	MM3,-028h[RBP]
-0x66,	0x0F,0xE0,0xCA,			// pavgb	XMM1,XMM2
-0x66,	0x0F,0xE0,0x5D,0xE0,		// pavgb	XMM3,-020h[RBP]
-	0x0F,0xE3,0xCA,			// pavgw	MM1,MM2
-	0x0F,0xE3,0x5D,0xD8,		// pavgw	MM3,-028h[RBP]
-0x66,	0x0F,0xE3,0xCA,			// pavgw	XMM1,XMM2
-0x66,	0x0F,0xE3,0x5D,0xE0,		// pavgw	XMM3,-020h[RBP]
-	0x0F,0x74,0xCA,			// pcmpeqb	MM1,MM2
-	0x0F,0x74,0x5D,0xD8,		// pcmpeqb	MM3,-028h[RBP]
-0x66,	0x0F,0x74,0xCA,			// pcmpeqb	XMM1,XMM2
-0x66,	0x0F,0x74,0x5D,0xE0,		// pcmpeqb	XMM3,-020h[RBP]
-	0x0F,0x75,0xCA,			// pcmpeqw	MM1,MM2
-	0x0F,0x75,0x5D,0xD8,		// pcmpeqw	MM3,-028h[RBP]
-0x66,	0x0F,0x75,0xCA,			// pcmpeqw	XMM1,XMM2
-0x66,	0x0F,0x75,0x5D,0xE0,		// pcmpeqw	XMM3,-020h[RBP]
-	0x0F,0x76,0xCA,			// pcmpeqd	MM1,MM2
-	0x0F,0x76,0x5D,0xD8,		// pcmpeqd	MM3,-028h[RBP]
-0x66,	0x0F,0x76,0xCA,			// pcmpeqd	XMM1,XMM2
-0x66,	0x0F,0x76,0x5D,0xE0,		// pcmpeqd	XMM3,-020h[RBP]
-	0x0F,0x64,0xCA,			// pcmpgtb	MM1,MM2
-	0x0F,0x64,0x5D,0xD8,		// pcmpgtb	MM3,-028h[RBP]
-0x66,	0x0F,0x64,0xCA,			// pcmpgtb	XMM1,XMM2
-0x66,	0x0F,0x64,0x5D,0xE0,		// pcmpgtb	XMM3,-020h[RBP]
-	0x0F,0x65,0xCA,			// pcmpgtw	MM1,MM2
-	0x0F,0x65,0x5D,0xD8,		// pcmpgtw	MM3,-028h[RBP]
-0x66,	0x0F,0x65,0xCA,			// pcmpgtw	XMM1,XMM2
-0x66,	0x0F,0x65,0x5D,0xE0,		// pcmpgtw	XMM3,-020h[RBP]
-	0x0F,0x66,0xCA,			// pcmpgtd	MM1,MM2
-	0x0F,0x66,0x5D,0xD8,		// pcmpgtd	MM3,-028h[RBP]
-0x66,	0x0F,0x66,0xCA,			// pcmpgtd	XMM1,XMM2
-0x66,	0x0F,0x66,0x5D,0xE0,		// pcmpgtd	XMM3,-020h[RBP]
-	0x0F,0xC5,0xD6,0x07,		// pextrw	EDX,MM6,7
-0x66,	0x0F,0xC5,0xD6,0x07,		// pextrw	EDX,XMM6,7
-	0x0F,0xC4,0xF2,0x07,		// pinsrw	MM6,EDX,7
-	0x0F,0xC4,0x75,0xD2,0x07,	// pinsrw	MM6,-02Eh[RBP],7
-0x66,	0x0F,0xC4,0xF2,0x07,		// pinsrw	XMM6,EDX,7
-0x66,	0x0F,0xC4,0x75,0xD2,0x07,	// pinsrw	XMM6,-02Eh[RBP],7
-	0x0F,0xF5,0xCA,			// pmaddwd	MM1,MM2
-	0x0F,0xF5,0x5D,0xD8,		// pmaddwd	MM3,-028h[RBP]
-0x66,	0x0F,0xF5,0xCA,			// pmaddwd	XMM1,XMM2
-0x66,	0x0F,0xF5,0x5D,0xE0,		// pmaddwd	XMM3,-020h[RBP]
-	0x0F,0xEE,0xCA,			// pmaxsw	MM1,XMM2
-	0x0F,0xEE,0x5D,0xD8,		// pmaxsw	MM3,-028h[RBP]
-0x66,	0x0F,0xEE,0xCA,			// pmaxsw	XMM1,XMM2
-0x66,	0x0F,0xEE,0x5D,0xE0,		// pmaxsw	XMM3,-020h[RBP]
-	0x0F,0xDE,0xCA,			// pmaxub	MM1,XMM2
-	0x0F,0xDE,0x5D,0xD8,		// pmaxub	MM3,-028h[RBP]
-0x66,	0x0F,0xDE,0xCA,			// pmaxub	XMM1,XMM2
-0x66,	0x0F,0xDE,0x5D,0xE0,		// pmaxub	XMM3,-020h[RBP]
-	0x0F,0xEA,0xCA,			// pminsw	MM1,MM2
-	0x0F,0xEA,0x5D,0xD8,		// pminsw	MM3,-028h[RBP]
-0x66,	0x0F,0xEA,0xCA,			// pminsw	XMM1,XMM2
-0x66,	0x0F,0xEA,0x5D,0xE0,		// pminsw	XMM3,-020h[RBP]
-	0x0F,0xDA,0xCA,			// pminub	MM1,MM2
-	0x0F,0xDA,0x5D,0xD8,		// pminub	MM3,-028h[RBP]
-0x66,	0x0F,0xDA,0xCA,			// pminub	XMM1,XMM2
-0x66,	0x0F,0xDA,0x5D,0xE0,		// pminub	XMM3,-020h[RBP]
-	0x0F,0xD7,0xC8,			// pmovmskb	ECX,MM0
-0x66,	0x0F,0xD7,0xCE,			// pmovmskb	ECX,XMM6
-	0x0F,0xE4,0xCA,			// pmulhuw	MM1,MM2
-	0x0F,0xE4,0x5D,0xD8,		// pmulhuw	MM3,-028h[RBP]
-0x66,	0x0F,0xE4,0xCA,			// pmulhuw	XMM1,XMM2
-0x66,	0x0F,0xE4,0x5D,0xE0,		// pmulhuw	XMM3,-020h[RBP]
-	0x0F,0xE5,0xCA,			// pmulhw	MM1,MM2
-	0x0F,0xE5,0x5D,0xD8,		// pmulhw	MM3,-028h[RBP]
-0x66,	0x0F,0xE5,0xCA,			// pmulhw	XMM1,XMM2
-0x66,	0x0F,0xE5,0x5D,0xE0,		// pmulhw	XMM3,-020h[RBP]
-	0x0F,0xD5,0xCA,			// pmullw	MM1,MM2
-	0x0F,0xD5,0x5D,0xD8,		// pmullw	MM3,-028h[RBP]
-0x66,	0x0F,0xD5,0xCA,			// pmullw	XMM1,XMM2
-0x66,	0x0F,0xD5,0x5D,0xE0,		// pmullw	XMM3,-020h[RBP]
-	0x0F,0xF4,0xCA,			// pmuludq	MM1,MM2
-	0x0F,0xF4,0x5D,0xD8,		// pmuludq	MM3,-028h[RBP]
-0x66,	0x0F,0xF4,0xCA,			// pmuludq	XMM1,XMM2
-0x66,	0x0F,0xF4,0x5D,0xE0,		// pmuludq	XMM3,-020h[RBP]
-	0x0F,0xEB,0xCA,			// por		MM1,MM2
-	0x0F,0xEB,0x5D,0xD8,		// por		MM3,-028h[RBP]
-0x66,	0x0F,0xEB,0xCA,			// por		XMM1,XMM2
-0x66,	0x0F,0xEB,0x5D,0xE0,		// por		XMM3,-020h[RBP]
-	0x0F,0x18,0x4D,0xD0,		// prefetcht0	-030h[RBP]
-	0x0F,0x18,0x55,0xD0,		// prefetcht1	-030h[RBP]
-	0x0F,0x18,0x5D,0xD0,		// prefetcht2	-030h[RBP]
-	0x0F,0x18,0x45,0xD0,		// prefetchnta	-030h[RBP]
-	0x0F,0xF6,0xCA,			// psadbw	MM1,MM2
-	0x0F,0xF6,0x5D,0xD8,		// psadbw	MM3,-028h[RBP]
-0x66,	0x0F,0xF6,0xCA,			// psadbw	XMM1,XMM2
-0x66,	0x0F,0xF6,0x5D,0xE0,		// psadbw	XMM3,-020h[RBP]
-0x66,	0x0F,0x70,0xCA,0x03,		// pshufd	XMM1,XMM2,3
-0x66,	0x0F,0x70,0x5D,0xE0,0x03,	// pshufd	XMM3,-020h[RBP],3
-	0xF3,0x0F,0x70,0xCA,0x03,	// pshufhw	XMM1,XMM2,3
-	0xF3,0x0F,0x70,0x5D,0xE0,0x03,	// pshufhw	XMM3,-020h[RBP],3
-	0xF2,0x0F,0x70,0xCA,0x03,	// pshuflw	XMM1,XMM2,3
-	0xF2,0x0F,0x70,0x5D,0xE0,0x03,	// pshuflw	XMM3,-020h[RBP],3
-	0x0F,0x70,0xCA,0x03,		// pshufw	MM1,MM2,3
-	0x0F,0x70,0x5D,0xD8,0x03,	// pshufw	MM3,-028h[RBP],3
-0x66,	0x0F,0x73,0xF9,0x18,		// pslldq	XMM1,020h
-	0x0F,0xF1,0xCA,			// psllw	MM1,MM2
-	0x0F,0xF1,0x4D,0xD8,		// psllw	MM1,-028h[RBP]
-0x66,	0x0F,0xF1,0xCA,			// psllw	XMM1,XMM2
-0x66,	0x0F,0xF1,0x4D,0xE0,		// psllw	XMM1,-020h[RBP]
-	0x0F,0x71,0xF1,0x15,		// psraw	MM1,015h
-0x66,	0x0F,0x71,0xF1,0x15,		// psraw	XMM1,015h
-	0x0F,0xF2,0xCA,			// pslld	MM1,MM2
-	0x0F,0xF2,0x4D,0xD8,		// pslld	MM1,-028h[RBP]
-0x66,	0x0F,0xF2,0xCA,			// pslld	XMM1,XMM2
-0x66,	0x0F,0xF2,0x4D,0xE0,		// pslld	XMM1,-020h[RBP]
-	0x0F,0x72,0xF1,0x15,		// psrad	MM1,015h
-0x66,	0x0F,0x72,0xF1,0x15,		// psrad	XMM1,015h
-	0x0F,0xF3,0xCA,			// psllq	MM1,MM2
-	0x0F,0xF3,0x4D,0xD8,		// psllq	MM1,-028h[RBP]
-0x66,	0x0F,0xF3,0xCA,			// psllq	XMM1,XMM2
-0x66,	0x0F,0xF3,0x4D,0xE0,		// psllq	XMM1,-020h[RBP]
-	0x0F,0x73,0xF1,0x15,		// psllq	MM1,015h
-0x66,	0x0F,0x73,0xF1,0x15,		// psllq	XMM1,015h
-	0x0F,0xE1,0xCA,			// psraw	MM1,MM2
-	0x0F,0xE1,0x4D,0xD8,		// psraw	MM1,-028h[RBP]
-0x66,	0x0F,0xE1,0xCA,			// psraw	XMM1,XMM2
-0x66,	0x0F,0xE1,0x4D,0xE0,		// psraw	XMM1,-020h[RBP]
-	0x0F,0x71,0xE1,0x15,		// psraw	MM1,015h
-0x66,	0x0F,0x71,0xE1,0x15,		// psraw	XMM1,015h
-	0x0F,0xE2,0xCA,			// psrad	MM1,MM2
-	0x0F,0xE2,0x4D,0xD8,		// psrad	MM1,-028h[RBP]
-0x66,	0x0F,0xE2,0xCA,			// psrad	XMM1,XMM2
-0x66,	0x0F,0xE2,0x4D,0xE0,		// psrad	XMM1,-020h[RBP]
-	0x0F,0x72,0xE1,0x15,		// psrad	MM1,015h
-0x66,	0x0F,0x72,0xE1,0x15,		// psrad	XMM1,015h
-0x66,	0x0F,0x73,0xD9,0x18,		// psrldq	XMM1,020h
-	0x0F,0xD1,0xCA,			// psrlw	MM1,MM2
-	0x0F,0xD1,0x4D,0xD8,		// psrlw	MM1,-028h[RBP]
-0x66,	0x0F,0xD1,0xCA,			// psrlw	XMM1,XMM2
-0x66,	0x0F,0xD1,0x4D,0xE0,		// psrlw	XMM1,-020h[RBP]
-	0x0F,0x71,0xD1,0x15,		// psrlw	MM1,015h
-0x66,	0x0F,0x71,0xD1,0x15,		// psrlw	XMM1,015h
-	0x0F,0xD2,0xCA,			// psrld	MM1,MM2
-	0x0F,0xD2,0x4D,0xD8,		// psrld	MM1,-028h[RBP]
-0x66,	0x0F,0xD2,0xCA,			// psrld	XMM1,XMM2
-0x66,	0x0F,0xD2,0x4D,0xE0,		// psrld	XMM1,-020h[RBP]
-	0x0F,0x72,0xD1,0x15,		// psrld	MM1,015h
-0x66,	0x0F,0x72,0xD1,0x15,		// psrld	XMM1,015h
-	0x0F,0xD3,0xCA,			// psrlq	MM1,MM2
-	0x0F,0xD3,0x4D,0xD8,		// psrlq	MM1,-028h[RBP]
-0x66,	0x0F,0xD3,0xCA,			// psrlq	XMM1,XMM2
-0x66,	0x0F,0xD3,0x4D,0xE0,		// psrlq	XMM1,-020h[RBP]
-	0x0F,0x73,0xD1,0x15,		// psrlq	MM1,015h
-0x66,	0x0F,0x73,0xD1,0x15,		// psrlq	XMM1,015h
-	0x0F,0xF8,0xCA,			// psubb	MM1,MM2
-	0x0F,0xF8,0x4D,0xD8,		// psubb	MM1,-028h[RBP]
-0x66,	0x0F,0xF8,0xCA,			// psubb	XMM1,XMM2
-0x66,	0x0F,0xF8,0x4D,0xE0,		// psubb	XMM1,-020h[RBP]
-	0x0F,0xF9,0xCA,			// psubw	MM1,MM2
-	0x0F,0xF9,0x4D,0xD8,		// psubw	MM1,-028h[RBP]
-0x66,	0x0F,0xF9,0xCA,			// psubw	XMM1,XMM2
-0x66,	0x0F,0xF9,0x4D,0xE0,		// psubw	XMM1,-020h[RBP]
-	0x0F,0xFA,0xCA,			// psubd	MM1,MM2
-	0x0F,0xFA,0x4D,0xD8,		// psubd	MM1,-028h[RBP]
-0x66,	0x0F,0xFA,0xCA,			// psubd	XMM1,XMM2
-0x66,	0x0F,0xFA,0x4D,0xE0,		// psubd	XMM1,-020h[RBP]
-	0x0F,0xFB,0xCA,			// psubq	MM1,MM2
-	0x0F,0xFB,0x4D,0xD8,		// psubq	MM1,-028h[RBP]
-0x66,	0x0F,0xFB,0xCA,			// psubq	XMM1,XMM2
-0x66,	0x0F,0xFB,0x4D,0xE0,		// psubq	XMM1,-020h[RBP]
-	0x0F,0xE8,0xCA,			// psubsb	MM1,MM2
-	0x0F,0xE8,0x4D,0xD8,		// psubsb	MM1,-028h[RBP]
-0x66,	0x0F,0xE8,0xCA,			// psubsb	XMM1,XMM2
-0x66,	0x0F,0xE8,0x4D,0xE0,		// psubsb	XMM1,-020h[RBP]
-	0x0F,0xE9,0xCA,			// psubsw	MM1,MM2
-	0x0F,0xE9,0x4D,0xD8,		// psubsw	MM1,-028h[RBP]
-0x66,	0x0F,0xE9,0xCA,			// psubsw	XMM1,XMM2
-0x66,	0x0F,0xE9,0x4D,0xE0,		// psubsw	XMM1,-020h[RBP]
-	0x0F,0xD8,0xCA,			// psubusb	MM1,MM2
-	0x0F,0xD8,0x4D,0xD8,		// psubusb	MM1,-028h[RBP]
-0x66,	0x0F,0xD8,0xCA,			// psubusb	XMM1,XMM2
-0x66,	0x0F,0xD8,0x4D,0xE0,		// psubusb	XMM1,-020h[RBP]
-	0x0F,0xD9,0xCA,			// psubusw	MM1,MM2
-	0x0F,0xD9,0x4D,0xD8,		// psubusw	MM1,-028h[RBP]
-0x66,	0x0F,0xD9,0xCA,			// psubusw	XMM1,XMM2
-0x66,	0x0F,0xD9,0x4D,0xE0,		// psubusw	XMM1,-020h[RBP]
-	0x0F,0x68,0xCA,			// punpckhbw	MM1,MM2
-	0x0F,0x68,0x4D,0xD8,		// punpckhbw	MM1,-028h[RBP]
-0x66,	0x0F,0x68,0xCA,			// punpckhbw	XMM1,XMM2
-0x66,	0x0F,0x68,0x4D,0xE0,		// punpckhbw	XMM1,-020h[RBP]
-	0x0F,0x69,0xCA,			// punpckhwd	MM1,MM2
-	0x0F,0x69,0x4D,0xD8,		// punpckhwd	MM1,-028h[RBP]
-0x66,	0x0F,0x69,0xCA,			// punpckhwd	XMM1,XMM2
-0x66,	0x0F,0x69,0x4D,0xE0,		// punpckhwd	XMM1,-020h[RBP]
-	0x0F,0x6A,0xCA,			// punpckhdq	MM1,MM2
-	0x0F,0x6A,0x4D,0xD8,		// punpckhdq	MM1,-028h[RBP]
-0x66,	0x0F,0x6A,0xCA,			// punpckhdq	XMM1,XMM2
-0x66,	0x0F,0x6A,0x4D,0xE0,		// punpckhdq	XMM1,-020h[RBP]
-0x66,	0x0F,0x6D,0xCA,			// punpckhqdq	XMM1,XMM2
-0x66,	0x0F,0x6D,0x4D,0xE0,		// punpckhqdq	XMM1,-020h[RBP]
-	0x0F,0x60,0xCA,			// punpcklbw	MM1,MM2
-	0x0F,0x60,0x4D,0xD8,		// punpcklbw	MM1,-028h[RBP]
-0x66,	0x0F,0x60,0xCA,			// punpcklbw	XMM1,XMM2
-0x66,	0x0F,0x60,0x4D,0xE0,		// punpcklbw	XMM1,-020h[RBP]
-	0x0F,0x61,0xCA,			// punpcklwd	MM1,MM2
-	0x0F,0x61,0x4D,0xD8,		// punpcklwd	MM1,-028h[RBP]
-0x66,	0x0F,0x61,0xCA,			// punpcklwd	XMM1,XMM2
-0x66,	0x0F,0x61,0x4D,0xE0,		// punpcklwd	XMM1,-020h[RBP]
-	0x0F,0x62,0xCA,			// punpckldq	MM1,MM2
-	0x0F,0x62,0x4D,0xD8,		// punpckldq	MM1,-028h[RBP]
-0x66,	0x0F,0x62,0xCA,			// punpckldq	XMM1,XMM2
-0x66,	0x0F,0x62,0x4D,0xE0,		// punpckldq	XMM1,-020h[RBP]
-0x66,	0x0F,0x6C,0xCA,			// punpcklqdq	XMM1,XMM2
-0x66,	0x0F,0x6C,0x4D,0xE0,		// punpcklqdq	XMM1,-020h[RBP]
-	0x0F,0xEF,0xCA,			// pxor		MM1,MM2
-	0x0F,0xEF,0x4D,0xD8,		// pxor		MM1,-028h[RBP]
-0x66,	0x0F,0xEF,0xCA,			// pxor		XMM1,XMM2
-0x66,	0x0F,0xEF,0x4D,0xE0,		// pxor		XMM1,-020h[RBP]
-	0x0F,0x53,0xCA,			// rcpps	XMM1,XMM2
-	0x0F,0x53,0x4D,0xE0,		// rcpps	XMM1,-020h[RBP]
-	0xF3,0x0F,0x53,0xCA,		// rcpss	XMM1,XMM2
-	0xF3,0x0F,0x53,0x4D,0xD4,	// rcpss	XMM1,-02Ch[RBP]
-	0x0F,0x52,0xCA,			// rsqrtps	XMM1,XMM2
-	0x0F,0x52,0x4D,0xE0,		// rsqrtps	XMM1,-020h[RBP]
-	0xF3,0x0F,0x52,0xCA,		// rsqrtss	XMM1,XMM2
-	0xF3,0x0F,0x52,0x4D,0xD4,	// rsqrtss	XMM1,-02Ch[RBP]
-0x66,	0x0F,0xC6,0xCA,0x03,		// shufpd	XMM1,XMM2,3
-0x66,	0x0F,0xC6,0x4D,0xE0,0x04,	// shufpd	XMM1,-020h[RBP],4
-	0x0F,0xC6,0xCA,0x03,		// shufps	XMM1,XMM2,3
-	0x0F,0xC6,0x4D,0xE0,0x04,	// shufps	XMM1,-020h[RBP],4
-0x66,	0x0F,0x2E,0xE6,			// ucimisd	XMM4,XMM6
-0x66,	0x0F,0x2E,0x6D,0xD8,		// ucimisd	XMM5,-028h[RBP]
-	0x0F,0x2E,0xF7,			// ucomiss	XMM6,XMM7
-	0x0F,0x2E,0x7D,0xD4,		// ucomiss	XMM7,-02Ch[RBP]
-0x66,	0x0F,0x15,0xE6,			// uppckhpd	XMM4,XMM6
-0x66,	0x0F,0x15,0x6D,0xE0,		// uppckhpd	XMM5,-020h[RBP]
-	0x0F,0x15,0xE6,			// unpckhps	XMM4,XMM6
-	0x0F,0x15,0x6D,0xE0,		// unpckhps	XMM5,-020h[RBP]
-0x66,	0x0F,0x14,0xE6,			// uppcklpd	XMM4,XMM6
-0x66,	0x0F,0x14,0x6D,0xE0,		// uppcklpd	XMM5,-020h[RBP]
-	0x0F,0x14,0xE6,			// unpcklps	XMM4,XMM6
-	0x0F,0x14,0x6D,0xE0,		// unpcklps	XMM5,-020h[RBP]
-0x66,	0x0F,0x57,0xCA,			// xorpd	XMM1,XMM2
-0x66,	0x0F,0x57,0x4D,0xE0,		// xorpd	XMM1,-020h[RBP]
-	0x0F,0x57,0xCA,			// xorps	XMM1,XMM2
-	0x0F,0x57,0x4D,0xE0,		// xorps	XMM1,-020h[RBP]
+0x66,   0x0F,0x50,0xF3,         // movmskpd ESI,XMM3
+    0x0F,0x50,0xF3,         // movmskps ESI,XMM3
+0x66,   0x0F,0xE7,0x55,0xE0,        // movntdq  -020h[RBP],XMM2
+    0x0F,0xC3,0x4D,0xD4,        // movnti   -02Ch[RBP],ECX
+0x66,   0x0F,0x2B,0x5D,0xE0,        // movntpd  -020h[RBP],XMM3
+    0x0F,0x2B,0x65,0xE0,        // movntps  -020h[RBP],XMM4
+    0x0F,0xE7,0x6D,0xD8,        // movntq   -028h[RBP],MM5
+    0x0F,0x6F,0xCA,         // movq     MM1,MM2
+    0x0F,0x6F,0x55,0xD8,        // movq     MM2,-028h[RBP]
+    0x0F,0x7F,0x5D,0xD8,        // movq     -028h[RBP],MM3
+    0xF3,0x0F,0x7E,0xCA,        // movq     XMM1,XMM2
+    0xF3,0x0F,0x7E,0x55,0xD8,   // movq     XMM2,-028h[RBP]
+0x66,   0x0F,0xD6,0x5D,0xD8,        // movq     -028h[RBP],XMM3
+    0xF3,0x0F,0xD6,0xDA,        // movq2dq  XMM3,MM2
+    0xA5,               // movsd
+    0xF2,0x0F,0x10,0xCA,        // movsd    XMM1,XMM2
+    0xF2,0x0F,0x10,0x5D,0xD8,   // movsd    XMM3,-028h[RBP]
+    0xF2,0x0F,0x11,0x65,0xD8,   // movsd    -028h[RBP],XMM4
+    0xF3,0x0F,0x10,0xCA,        // movss    XMM1,XMM2
+    0xF3,0x0F,0x10,0x5D,0xD4,   // movss    XMM3,-02Ch[RBP]
+    0xF3,0x0F,0x11,0x65,0xD4,   // movss    -02Ch[RBP],XMM4
+0x66,   0x0F,0x10,0xCA,         // movupd   XMM1,XMM2
+0x66,   0x0F,0x10,0x5D,0xE0,        // movupd   XMM3,-020h[RBP]
+0x66,   0x0F,0x11,0x65,0xE0,        // movupd   -020h[RBP],XMM4
+    0x0F,0x10,0xCA,         // movups   XMM1,XMM2
+    0x0F,0x10,0x5D,0xE0,        // movups   XMM3,-020h[RBP]
+    0x0F,0x11,0x65,0xE0,        // movups   -020h[RBP],XMM4
+0x66,   0x0F,0x56,0xCA,         // orpd     XMM1,XMM2
+0x66,   0x0F,0x56,0x5D,0xE0,        // orpd     XMM3,-020h[RBP]
+    0x0F,0x56,0xCA,         // orps     XMM1,XMM2
+    0x0F,0x56,0x5D,0xE0,        // orps     XMM3,-020h[RBP]
+    0x0F,0x63,0xCA,         // packsswb MM1,MM2
+    0x0F,0x63,0x5D,0xD8,        // packsswb MM3,-028h[RBP]
+0x66,   0x0F,0x63,0xCA,         // packsswb XMM1,XMM2
+0x66,   0x0F,0x63,0x5D,0xE0,        // packsswb XMM3,-020h[RBP]
+    0x0F,0x6B,0xCA,         // packssdw MM1,MM2
+    0x0F,0x6B,0x5D,0xD8,        // packssdw MM3,-028h[RBP]
+0x66,   0x0F,0x6B,0xCA,         // packssdw XMM1,XMM2
+0x66,   0x0F,0x6B,0x5D,0xE0,        // packssdw XMM3,-020h[RBP]
+    0x0F,0x67,0xCA,         // packuswb MM1,MM2
+    0x0F,0x67,0x5D,0xD8,        // packuswb MM3,-028h[RBP]
+0x66,   0x0F,0x67,0xCA,         // packuswb XMM1,XMM2
+0x66,   0x0F,0x67,0x5D,0xE0,        // packuswb XMM3,-020h[RBP]
+    0x0F,0xFC,0xCA,         // paddb    MM1,MM2
+    0x0F,0xFC,0x5D,0xD8,        // paddb    MM3,-028h[RBP]
+0x66,   0x0F,0xFC,0xCA,         // paddb    XMM1,XMM2
+0x66,   0x0F,0xFC,0x5D,0xE0,        // paddb    XMM3,-020h[RBP]
+    0x0F,0xFD,0xCA,         // paddw    MM1,MM2
+    0x0F,0xFD,0x5D,0xD8,        // paddw    MM3,-028h[RBP]
+0x66,   0x0F,0xFD,0xCA,         // paddw    XMM1,XMM2
+0x66,   0x0F,0xFD,0x5D,0xE0,        // paddw    XMM3,-020h[RBP]
+    0x0F,0xFE,0xCA,         // paddd    MM1,MM2
+    0x0F,0xFE,0x5D,0xD8,        // paddd    MM3,-028h[RBP]
+0x66,   0x0F,0xFE,0xCA,         // paddd    XMM1,XMM2
+0x66,   0x0F,0xFE,0x5D,0xE0,        // paddd    XMM3,-020h[RBP]
+    0x0F,0xD4,0xCA,         // paddq    MM1,MM2
+    0x0F,0xD4,0x5D,0xD8,        // paddq    MM3,-028h[RBP]
+0x66,   0x0F,0xD4,0xCA,         // paddq    XMM1,XMM2
+0x66,   0x0F,0xD4,0x5D,0xE0,        // paddq    XMM3,-020h[RBP]
+    0x0F,0xEC,0xCA,         // paddsb   MM1,MM2
+    0x0F,0xEC,0x5D,0xD8,        // paddsb   MM3,-028h[RBP]
+0x66,   0x0F,0xEC,0xCA,         // paddsb   XMM1,XMM2
+0x66,   0x0F,0xEC,0x5D,0xE0,        // paddsb   XMM3,-020h[RBP]
+    0x0F,0xED,0xCA,         // paddsw   MM1,MM2
+    0x0F,0xED,0x5D,0xD8,        // paddsw   MM3,-028h[RBP]
+0x66,   0x0F,0xED,0xCA,         // paddsw   XMM1,XMM2
+0x66,   0x0F,0xED,0x5D,0xE0,        // paddsw   XMM3,-020h[RBP]
+    0x0F,0xDC,0xCA,         // paddusb  MM1,MM2
+    0x0F,0xDC,0x5D,0xD8,        // paddusb  MM3,-028h[RBP]
+0x66,   0x0F,0xDC,0xCA,         // paddusb  XMM1,XMM2
+0x66,   0x0F,0xDC,0x5D,0xE0,        // paddusb  XMM3,-020h[RBP]
+    0x0F,0xDD,0xCA,         // paddusw  MM1,MM2
+    0x0F,0xDD,0x5D,0xD8,        // paddusw  MM3,-028h[RBP]
+0x66,   0x0F,0xDD,0xCA,         // paddusw  XMM1,XMM2
+0x66,   0x0F,0xDD,0x5D,0xE0,        // paddusw  XMM3,-020h[RBP]
+    0x0F,0xDB,0xCA,         // pand     MM1,MM2
+    0x0F,0xDB,0x5D,0xD8,        // pand     MM3,-028h[RBP]
+0x66,   0x0F,0xDB,0xCA,         // pand     XMM1,XMM2
+0x66,   0x0F,0xDB,0x5D,0xE0,        // pand     XMM3,-020h[RBP]
+    0x0F,0xDF,0xCA,         // pandn    MM1,MM2
+    0x0F,0xDF,0x5D,0xD8,        // pandn    MM3,-028h[RBP]
+0x66,   0x0F,0xDF,0xCA,         // pandn    XMM1,XMM2
+0x66,   0x0F,0xDF,0x5D,0xE0,        // pandn    XMM3,-020h[RBP]
+    0x0F,0xE0,0xCA,         // pavgb    MM1,MM2
+    0x0F,0xE0,0x5D,0xD8,        // pavgb    MM3,-028h[RBP]
+0x66,   0x0F,0xE0,0xCA,         // pavgb    XMM1,XMM2
+0x66,   0x0F,0xE0,0x5D,0xE0,        // pavgb    XMM3,-020h[RBP]
+    0x0F,0xE3,0xCA,         // pavgw    MM1,MM2
+    0x0F,0xE3,0x5D,0xD8,        // pavgw    MM3,-028h[RBP]
+0x66,   0x0F,0xE3,0xCA,         // pavgw    XMM1,XMM2
+0x66,   0x0F,0xE3,0x5D,0xE0,        // pavgw    XMM3,-020h[RBP]
+    0x0F,0x74,0xCA,         // pcmpeqb  MM1,MM2
+    0x0F,0x74,0x5D,0xD8,        // pcmpeqb  MM3,-028h[RBP]
+0x66,   0x0F,0x74,0xCA,         // pcmpeqb  XMM1,XMM2
+0x66,   0x0F,0x74,0x5D,0xE0,        // pcmpeqb  XMM3,-020h[RBP]
+    0x0F,0x75,0xCA,         // pcmpeqw  MM1,MM2
+    0x0F,0x75,0x5D,0xD8,        // pcmpeqw  MM3,-028h[RBP]
+0x66,   0x0F,0x75,0xCA,         // pcmpeqw  XMM1,XMM2
+0x66,   0x0F,0x75,0x5D,0xE0,        // pcmpeqw  XMM3,-020h[RBP]
+    0x0F,0x76,0xCA,         // pcmpeqd  MM1,MM2
+    0x0F,0x76,0x5D,0xD8,        // pcmpeqd  MM3,-028h[RBP]
+0x66,   0x0F,0x76,0xCA,         // pcmpeqd  XMM1,XMM2
+0x66,   0x0F,0x76,0x5D,0xE0,        // pcmpeqd  XMM3,-020h[RBP]
+    0x0F,0x64,0xCA,         // pcmpgtb  MM1,MM2
+    0x0F,0x64,0x5D,0xD8,        // pcmpgtb  MM3,-028h[RBP]
+0x66,   0x0F,0x64,0xCA,         // pcmpgtb  XMM1,XMM2
+0x66,   0x0F,0x64,0x5D,0xE0,        // pcmpgtb  XMM3,-020h[RBP]
+    0x0F,0x65,0xCA,         // pcmpgtw  MM1,MM2
+    0x0F,0x65,0x5D,0xD8,        // pcmpgtw  MM3,-028h[RBP]
+0x66,   0x0F,0x65,0xCA,         // pcmpgtw  XMM1,XMM2
+0x66,   0x0F,0x65,0x5D,0xE0,        // pcmpgtw  XMM3,-020h[RBP]
+    0x0F,0x66,0xCA,         // pcmpgtd  MM1,MM2
+    0x0F,0x66,0x5D,0xD8,        // pcmpgtd  MM3,-028h[RBP]
+0x66,   0x0F,0x66,0xCA,         // pcmpgtd  XMM1,XMM2
+0x66,   0x0F,0x66,0x5D,0xE0,        // pcmpgtd  XMM3,-020h[RBP]
+    0x0F,0xC5,0xD6,0x07,        // pextrw   EDX,MM6,7
+0x66,   0x0F,0xC5,0xD6,0x07,        // pextrw   EDX,XMM6,7
+    0x0F,0xC4,0xF2,0x07,        // pinsrw   MM6,EDX,7
+    0x0F,0xC4,0x75,0xD2,0x07,   // pinsrw   MM6,-02Eh[RBP],7
+0x66,   0x0F,0xC4,0xF2,0x07,        // pinsrw   XMM6,EDX,7
+0x66,   0x0F,0xC4,0x75,0xD2,0x07,   // pinsrw   XMM6,-02Eh[RBP],7
+    0x0F,0xF5,0xCA,         // pmaddwd  MM1,MM2
+    0x0F,0xF5,0x5D,0xD8,        // pmaddwd  MM3,-028h[RBP]
+0x66,   0x0F,0xF5,0xCA,         // pmaddwd  XMM1,XMM2
+0x66,   0x0F,0xF5,0x5D,0xE0,        // pmaddwd  XMM3,-020h[RBP]
+    0x0F,0xEE,0xCA,         // pmaxsw   MM1,XMM2
+    0x0F,0xEE,0x5D,0xD8,        // pmaxsw   MM3,-028h[RBP]
+0x66,   0x0F,0xEE,0xCA,         // pmaxsw   XMM1,XMM2
+0x66,   0x0F,0xEE,0x5D,0xE0,        // pmaxsw   XMM3,-020h[RBP]
+    0x0F,0xDE,0xCA,         // pmaxub   MM1,XMM2
+    0x0F,0xDE,0x5D,0xD8,        // pmaxub   MM3,-028h[RBP]
+0x66,   0x0F,0xDE,0xCA,         // pmaxub   XMM1,XMM2
+0x66,   0x0F,0xDE,0x5D,0xE0,        // pmaxub   XMM3,-020h[RBP]
+    0x0F,0xEA,0xCA,         // pminsw   MM1,MM2
+    0x0F,0xEA,0x5D,0xD8,        // pminsw   MM3,-028h[RBP]
+0x66,   0x0F,0xEA,0xCA,         // pminsw   XMM1,XMM2
+0x66,   0x0F,0xEA,0x5D,0xE0,        // pminsw   XMM3,-020h[RBP]
+    0x0F,0xDA,0xCA,         // pminub   MM1,MM2
+    0x0F,0xDA,0x5D,0xD8,        // pminub   MM3,-028h[RBP]
+0x66,   0x0F,0xDA,0xCA,         // pminub   XMM1,XMM2
+0x66,   0x0F,0xDA,0x5D,0xE0,        // pminub   XMM3,-020h[RBP]
+    0x0F,0xD7,0xC8,         // pmovmskb ECX,MM0
+0x66,   0x0F,0xD7,0xCE,         // pmovmskb ECX,XMM6
+    0x0F,0xE4,0xCA,         // pmulhuw  MM1,MM2
+    0x0F,0xE4,0x5D,0xD8,        // pmulhuw  MM3,-028h[RBP]
+0x66,   0x0F,0xE4,0xCA,         // pmulhuw  XMM1,XMM2
+0x66,   0x0F,0xE4,0x5D,0xE0,        // pmulhuw  XMM3,-020h[RBP]
+    0x0F,0xE5,0xCA,         // pmulhw   MM1,MM2
+    0x0F,0xE5,0x5D,0xD8,        // pmulhw   MM3,-028h[RBP]
+0x66,   0x0F,0xE5,0xCA,         // pmulhw   XMM1,XMM2
+0x66,   0x0F,0xE5,0x5D,0xE0,        // pmulhw   XMM3,-020h[RBP]
+    0x0F,0xD5,0xCA,         // pmullw   MM1,MM2
+    0x0F,0xD5,0x5D,0xD8,        // pmullw   MM3,-028h[RBP]
+0x66,   0x0F,0xD5,0xCA,         // pmullw   XMM1,XMM2
+0x66,   0x0F,0xD5,0x5D,0xE0,        // pmullw   XMM3,-020h[RBP]
+    0x0F,0xF4,0xCA,         // pmuludq  MM1,MM2
+    0x0F,0xF4,0x5D,0xD8,        // pmuludq  MM3,-028h[RBP]
+0x66,   0x0F,0xF4,0xCA,         // pmuludq  XMM1,XMM2
+0x66,   0x0F,0xF4,0x5D,0xE0,        // pmuludq  XMM3,-020h[RBP]
+    0x0F,0xEB,0xCA,         // por      MM1,MM2
+    0x0F,0xEB,0x5D,0xD8,        // por      MM3,-028h[RBP]
+0x66,   0x0F,0xEB,0xCA,         // por      XMM1,XMM2
+0x66,   0x0F,0xEB,0x5D,0xE0,        // por      XMM3,-020h[RBP]
+    0x0F,0x18,0x4D,0xD0,        // prefetcht0   -030h[RBP]
+    0x0F,0x18,0x55,0xD0,        // prefetcht1   -030h[RBP]
+    0x0F,0x18,0x5D,0xD0,        // prefetcht2   -030h[RBP]
+    0x0F,0x18,0x45,0xD0,        // prefetchnta  -030h[RBP]
+    0x0F,0xF6,0xCA,         // psadbw   MM1,MM2
+    0x0F,0xF6,0x5D,0xD8,        // psadbw   MM3,-028h[RBP]
+0x66,   0x0F,0xF6,0xCA,         // psadbw   XMM1,XMM2
+0x66,   0x0F,0xF6,0x5D,0xE0,        // psadbw   XMM3,-020h[RBP]
+0x66,   0x0F,0x70,0xCA,0x03,        // pshufd   XMM1,XMM2,3
+0x66,   0x0F,0x70,0x5D,0xE0,0x03,   // pshufd   XMM3,-020h[RBP],3
+    0xF3,0x0F,0x70,0xCA,0x03,   // pshufhw  XMM1,XMM2,3
+    0xF3,0x0F,0x70,0x5D,0xE0,0x03,  // pshufhw  XMM3,-020h[RBP],3
+    0xF2,0x0F,0x70,0xCA,0x03,   // pshuflw  XMM1,XMM2,3
+    0xF2,0x0F,0x70,0x5D,0xE0,0x03,  // pshuflw  XMM3,-020h[RBP],3
+    0x0F,0x70,0xCA,0x03,        // pshufw   MM1,MM2,3
+    0x0F,0x70,0x5D,0xD8,0x03,   // pshufw   MM3,-028h[RBP],3
+0x66,   0x0F,0x73,0xF9,0x18,        // pslldq   XMM1,020h
+    0x0F,0xF1,0xCA,         // psllw    MM1,MM2
+    0x0F,0xF1,0x4D,0xD8,        // psllw    MM1,-028h[RBP]
+0x66,   0x0F,0xF1,0xCA,         // psllw    XMM1,XMM2
+0x66,   0x0F,0xF1,0x4D,0xE0,        // psllw    XMM1,-020h[RBP]
+    0x0F,0x71,0xF1,0x15,        // psraw    MM1,015h
+0x66,   0x0F,0x71,0xF1,0x15,        // psraw    XMM1,015h
+    0x0F,0xF2,0xCA,         // pslld    MM1,MM2
+    0x0F,0xF2,0x4D,0xD8,        // pslld    MM1,-028h[RBP]
+0x66,   0x0F,0xF2,0xCA,         // pslld    XMM1,XMM2
+0x66,   0x0F,0xF2,0x4D,0xE0,        // pslld    XMM1,-020h[RBP]
+    0x0F,0x72,0xF1,0x15,        // psrad    MM1,015h
+0x66,   0x0F,0x72,0xF1,0x15,        // psrad    XMM1,015h
+    0x0F,0xF3,0xCA,         // psllq    MM1,MM2
+    0x0F,0xF3,0x4D,0xD8,        // psllq    MM1,-028h[RBP]
+0x66,   0x0F,0xF3,0xCA,         // psllq    XMM1,XMM2
+0x66,   0x0F,0xF3,0x4D,0xE0,        // psllq    XMM1,-020h[RBP]
+    0x0F,0x73,0xF1,0x15,        // psllq    MM1,015h
+0x66,   0x0F,0x73,0xF1,0x15,        // psllq    XMM1,015h
+    0x0F,0xE1,0xCA,         // psraw    MM1,MM2
+    0x0F,0xE1,0x4D,0xD8,        // psraw    MM1,-028h[RBP]
+0x66,   0x0F,0xE1,0xCA,         // psraw    XMM1,XMM2
+0x66,   0x0F,0xE1,0x4D,0xE0,        // psraw    XMM1,-020h[RBP]
+    0x0F,0x71,0xE1,0x15,        // psraw    MM1,015h
+0x66,   0x0F,0x71,0xE1,0x15,        // psraw    XMM1,015h
+    0x0F,0xE2,0xCA,         // psrad    MM1,MM2
+    0x0F,0xE2,0x4D,0xD8,        // psrad    MM1,-028h[RBP]
+0x66,   0x0F,0xE2,0xCA,         // psrad    XMM1,XMM2
+0x66,   0x0F,0xE2,0x4D,0xE0,        // psrad    XMM1,-020h[RBP]
+    0x0F,0x72,0xE1,0x15,        // psrad    MM1,015h
+0x66,   0x0F,0x72,0xE1,0x15,        // psrad    XMM1,015h
+0x66,   0x0F,0x73,0xD9,0x18,        // psrldq   XMM1,020h
+    0x0F,0xD1,0xCA,         // psrlw    MM1,MM2
+    0x0F,0xD1,0x4D,0xD8,        // psrlw    MM1,-028h[RBP]
+0x66,   0x0F,0xD1,0xCA,         // psrlw    XMM1,XMM2
+0x66,   0x0F,0xD1,0x4D,0xE0,        // psrlw    XMM1,-020h[RBP]
+    0x0F,0x71,0xD1,0x15,        // psrlw    MM1,015h
+0x66,   0x0F,0x71,0xD1,0x15,        // psrlw    XMM1,015h
+    0x0F,0xD2,0xCA,         // psrld    MM1,MM2
+    0x0F,0xD2,0x4D,0xD8,        // psrld    MM1,-028h[RBP]
+0x66,   0x0F,0xD2,0xCA,         // psrld    XMM1,XMM2
+0x66,   0x0F,0xD2,0x4D,0xE0,        // psrld    XMM1,-020h[RBP]
+    0x0F,0x72,0xD1,0x15,        // psrld    MM1,015h
+0x66,   0x0F,0x72,0xD1,0x15,        // psrld    XMM1,015h
+    0x0F,0xD3,0xCA,         // psrlq    MM1,MM2
+    0x0F,0xD3,0x4D,0xD8,        // psrlq    MM1,-028h[RBP]
+0x66,   0x0F,0xD3,0xCA,         // psrlq    XMM1,XMM2
+0x66,   0x0F,0xD3,0x4D,0xE0,        // psrlq    XMM1,-020h[RBP]
+    0x0F,0x73,0xD1,0x15,        // psrlq    MM1,015h
+0x66,   0x0F,0x73,0xD1,0x15,        // psrlq    XMM1,015h
+    0x0F,0xF8,0xCA,         // psubb    MM1,MM2
+    0x0F,0xF8,0x4D,0xD8,        // psubb    MM1,-028h[RBP]
+0x66,   0x0F,0xF8,0xCA,         // psubb    XMM1,XMM2
+0x66,   0x0F,0xF8,0x4D,0xE0,        // psubb    XMM1,-020h[RBP]
+    0x0F,0xF9,0xCA,         // psubw    MM1,MM2
+    0x0F,0xF9,0x4D,0xD8,        // psubw    MM1,-028h[RBP]
+0x66,   0x0F,0xF9,0xCA,         // psubw    XMM1,XMM2
+0x66,   0x0F,0xF9,0x4D,0xE0,        // psubw    XMM1,-020h[RBP]
+    0x0F,0xFA,0xCA,         // psubd    MM1,MM2
+    0x0F,0xFA,0x4D,0xD8,        // psubd    MM1,-028h[RBP]
+0x66,   0x0F,0xFA,0xCA,         // psubd    XMM1,XMM2
+0x66,   0x0F,0xFA,0x4D,0xE0,        // psubd    XMM1,-020h[RBP]
+    0x0F,0xFB,0xCA,         // psubq    MM1,MM2
+    0x0F,0xFB,0x4D,0xD8,        // psubq    MM1,-028h[RBP]
+0x66,   0x0F,0xFB,0xCA,         // psubq    XMM1,XMM2
+0x66,   0x0F,0xFB,0x4D,0xE0,        // psubq    XMM1,-020h[RBP]
+    0x0F,0xE8,0xCA,         // psubsb   MM1,MM2
+    0x0F,0xE8,0x4D,0xD8,        // psubsb   MM1,-028h[RBP]
+0x66,   0x0F,0xE8,0xCA,         // psubsb   XMM1,XMM2
+0x66,   0x0F,0xE8,0x4D,0xE0,        // psubsb   XMM1,-020h[RBP]
+    0x0F,0xE9,0xCA,         // psubsw   MM1,MM2
+    0x0F,0xE9,0x4D,0xD8,        // psubsw   MM1,-028h[RBP]
+0x66,   0x0F,0xE9,0xCA,         // psubsw   XMM1,XMM2
+0x66,   0x0F,0xE9,0x4D,0xE0,        // psubsw   XMM1,-020h[RBP]
+    0x0F,0xD8,0xCA,         // psubusb  MM1,MM2
+    0x0F,0xD8,0x4D,0xD8,        // psubusb  MM1,-028h[RBP]
+0x66,   0x0F,0xD8,0xCA,         // psubusb  XMM1,XMM2
+0x66,   0x0F,0xD8,0x4D,0xE0,        // psubusb  XMM1,-020h[RBP]
+    0x0F,0xD9,0xCA,         // psubusw  MM1,MM2
+    0x0F,0xD9,0x4D,0xD8,        // psubusw  MM1,-028h[RBP]
+0x66,   0x0F,0xD9,0xCA,         // psubusw  XMM1,XMM2
+0x66,   0x0F,0xD9,0x4D,0xE0,        // psubusw  XMM1,-020h[RBP]
+    0x0F,0x68,0xCA,         // punpckhbw    MM1,MM2
+    0x0F,0x68,0x4D,0xD8,        // punpckhbw    MM1,-028h[RBP]
+0x66,   0x0F,0x68,0xCA,         // punpckhbw    XMM1,XMM2
+0x66,   0x0F,0x68,0x4D,0xE0,        // punpckhbw    XMM1,-020h[RBP]
+    0x0F,0x69,0xCA,         // punpckhwd    MM1,MM2
+    0x0F,0x69,0x4D,0xD8,        // punpckhwd    MM1,-028h[RBP]
+0x66,   0x0F,0x69,0xCA,         // punpckhwd    XMM1,XMM2
+0x66,   0x0F,0x69,0x4D,0xE0,        // punpckhwd    XMM1,-020h[RBP]
+    0x0F,0x6A,0xCA,         // punpckhdq    MM1,MM2
+    0x0F,0x6A,0x4D,0xD8,        // punpckhdq    MM1,-028h[RBP]
+0x66,   0x0F,0x6A,0xCA,         // punpckhdq    XMM1,XMM2
+0x66,   0x0F,0x6A,0x4D,0xE0,        // punpckhdq    XMM1,-020h[RBP]
+0x66,   0x0F,0x6D,0xCA,         // punpckhqdq   XMM1,XMM2
+0x66,   0x0F,0x6D,0x4D,0xE0,        // punpckhqdq   XMM1,-020h[RBP]
+    0x0F,0x60,0xCA,         // punpcklbw    MM1,MM2
+    0x0F,0x60,0x4D,0xD8,        // punpcklbw    MM1,-028h[RBP]
+0x66,   0x0F,0x60,0xCA,         // punpcklbw    XMM1,XMM2
+0x66,   0x0F,0x60,0x4D,0xE0,        // punpcklbw    XMM1,-020h[RBP]
+    0x0F,0x61,0xCA,         // punpcklwd    MM1,MM2
+    0x0F,0x61,0x4D,0xD8,        // punpcklwd    MM1,-028h[RBP]
+0x66,   0x0F,0x61,0xCA,         // punpcklwd    XMM1,XMM2
+0x66,   0x0F,0x61,0x4D,0xE0,        // punpcklwd    XMM1,-020h[RBP]
+    0x0F,0x62,0xCA,         // punpckldq    MM1,MM2
+    0x0F,0x62,0x4D,0xD8,        // punpckldq    MM1,-028h[RBP]
+0x66,   0x0F,0x62,0xCA,         // punpckldq    XMM1,XMM2
+0x66,   0x0F,0x62,0x4D,0xE0,        // punpckldq    XMM1,-020h[RBP]
+0x66,   0x0F,0x6C,0xCA,         // punpcklqdq   XMM1,XMM2
+0x66,   0x0F,0x6C,0x4D,0xE0,        // punpcklqdq   XMM1,-020h[RBP]
+    0x0F,0xEF,0xCA,         // pxor     MM1,MM2
+    0x0F,0xEF,0x4D,0xD8,        // pxor     MM1,-028h[RBP]
+0x66,   0x0F,0xEF,0xCA,         // pxor     XMM1,XMM2
+0x66,   0x0F,0xEF,0x4D,0xE0,        // pxor     XMM1,-020h[RBP]
+    0x0F,0x53,0xCA,         // rcpps    XMM1,XMM2
+    0x0F,0x53,0x4D,0xE0,        // rcpps    XMM1,-020h[RBP]
+    0xF3,0x0F,0x53,0xCA,        // rcpss    XMM1,XMM2
+    0xF3,0x0F,0x53,0x4D,0xD4,   // rcpss    XMM1,-02Ch[RBP]
+    0x0F,0x52,0xCA,         // rsqrtps  XMM1,XMM2
+    0x0F,0x52,0x4D,0xE0,        // rsqrtps  XMM1,-020h[RBP]
+    0xF3,0x0F,0x52,0xCA,        // rsqrtss  XMM1,XMM2
+    0xF3,0x0F,0x52,0x4D,0xD4,   // rsqrtss  XMM1,-02Ch[RBP]
+0x66,   0x0F,0xC6,0xCA,0x03,        // shufpd   XMM1,XMM2,3
+0x66,   0x0F,0xC6,0x4D,0xE0,0x04,   // shufpd   XMM1,-020h[RBP],4
+    0x0F,0xC6,0xCA,0x03,        // shufps   XMM1,XMM2,3
+    0x0F,0xC6,0x4D,0xE0,0x04,   // shufps   XMM1,-020h[RBP],4
+0x66,   0x0F,0x2E,0xE6,         // ucimisd  XMM4,XMM6
+0x66,   0x0F,0x2E,0x6D,0xD8,        // ucimisd  XMM5,-028h[RBP]
+    0x0F,0x2E,0xF7,         // ucomiss  XMM6,XMM7
+    0x0F,0x2E,0x7D,0xD4,        // ucomiss  XMM7,-02Ch[RBP]
+0x66,   0x0F,0x15,0xE6,         // uppckhpd XMM4,XMM6
+0x66,   0x0F,0x15,0x6D,0xE0,        // uppckhpd XMM5,-020h[RBP]
+    0x0F,0x15,0xE6,         // unpckhps XMM4,XMM6
+    0x0F,0x15,0x6D,0xE0,        // unpckhps XMM5,-020h[RBP]
+0x66,   0x0F,0x14,0xE6,         // uppcklpd XMM4,XMM6
+0x66,   0x0F,0x14,0x6D,0xE0,        // uppcklpd XMM5,-020h[RBP]
+    0x0F,0x14,0xE6,         // unpcklps XMM4,XMM6
+    0x0F,0x14,0x6D,0xE0,        // unpcklps XMM5,-020h[RBP]
+0x66,   0x0F,0x57,0xCA,         // xorpd    XMM1,XMM2
+0x66,   0x0F,0x57,0x4D,0xE0,        // xorpd    XMM1,-020h[RBP]
+    0x0F,0x57,0xCA,         // xorps    XMM1,XMM2
+    0x0F,0x57,0x4D,0xE0,        // xorps    XMM1,-020h[RBP]
     ];
     int i;
 
     asm
     {
-	call	L1			;
-
-	movmskpd ESI,XMM3		;
-	movmskps ESI,XMM3		;
-
-	movntdq	m128[RBP],XMM2		;
-	movnti	m32[RBP],ECX		;
-	movntpd	m128[RBP],XMM3		;
-	movntps	m128[RBP],XMM4		;
-	movntq	m64[RBP],MM5		;
-
-	movq	MM1,MM2			;
-	movq	MM2,m64[RBP]		;
-	movq	m64[RBP],MM3		;
-	movq	XMM1,XMM2		;
-	movq	XMM2,m64[RBP]		;
-	movq	m64[RBP],XMM3		;
-
-	movq2dq	XMM3,MM2		;
-
-	movsd				;
-	movsd	XMM1,XMM2		;
-	movsd	XMM3,m64[RBP]		;
-	movsd	m64[RBP],XMM4		;
-
-	movss	XMM1,XMM2		;
-	movss	XMM3,m32[RBP]		;
-	movss	m32[RBP],XMM4		;
-
-	movupd	XMM1,XMM2		;
-	movupd	XMM3,m128[RBP]		;
-	movupd	m128[RBP],XMM4		;
-
-	movups	XMM1,XMM2		;
-	movups	XMM3,m128[RBP]		;
-	movups	m128[RBP],XMM4		;
-
-	orpd	XMM1,XMM2		;
-	orpd	XMM3,m128[RBP]		;
-	orps	XMM1,XMM2		;
-	orps	XMM3,m128[RBP]		;
-
-	packsswb MM1,MM2		;
-	packsswb MM3,m64[RBP]		;
-	packsswb XMM1,XMM2		;
-	packsswb XMM3,m128[RBP]		;
-
-	packssdw MM1,MM2		;
-	packssdw MM3,m64[RBP]		;
-	packssdw XMM1,XMM2		;
-	packssdw XMM3,m128[RBP]		;
-
-	packuswb MM1,MM2		;
-	packuswb MM3,m64[RBP]		;
-	packuswb XMM1,XMM2		;
-	packuswb XMM3,m128[RBP]		;
-
-	paddb	MM1,MM2			;
-	paddb	MM3,m64[RBP]		;
-	paddb	XMM1,XMM2		;
-	paddb	XMM3,m128[RBP]		;
-
-	paddw	MM1,MM2			;
-	paddw	MM3,m64[RBP]		;
-	paddw	XMM1,XMM2		;
-	paddw	XMM3,m128[RBP]		;
-
-	paddd	MM1,MM2			;
-	paddd	MM3,m64[RBP]		;
-	paddd	XMM1,XMM2		;
-	paddd	XMM3,m128[RBP]		;
-
-	paddq	MM1,MM2			;
-	paddq	MM3,m64[RBP]		;
-	paddq	XMM1,XMM2		;
-	paddq	XMM3,m128[RBP]		;
-
-	paddsb	MM1,MM2			;
-	paddsb	MM3,m64[RBP]		;
-	paddsb	XMM1,XMM2		;
-	paddsb	XMM3,m128[RBP]		;
-
-	paddsw	MM1,MM2			;
-	paddsw	MM3,m64[RBP]		;
-	paddsw	XMM1,XMM2		;
-	paddsw	XMM3,m128[RBP]		;
-
-	paddusb	MM1,MM2			;
-	paddusb	MM3,m64[RBP]		;
-	paddusb	XMM1,XMM2		;
-	paddusb	XMM3,m128[RBP]		;
-
-	paddusw	MM1,MM2			;
-	paddusw	MM3,m64[RBP]		;
-	paddusw	XMM1,XMM2		;
-	paddusw	XMM3,m128[RBP]		;
-
-	pand	MM1,MM2			;
-	pand	MM3,m64[RBP]		;
-	pand	XMM1,XMM2		;
-	pand	XMM3,m128[RBP]		;
-
-	pandn	MM1,MM2			;
-	pandn	MM3,m64[RBP]		;
-	pandn	XMM1,XMM2		;
-	pandn	XMM3,m128[RBP]		;
-
-	pavgb	MM1,MM2			;
-	pavgb	MM3,m64[RBP]		;
-	pavgb	XMM1,XMM2		;
-	pavgb	XMM3,m128[RBP]		;
-
-	pavgw	MM1,MM2			;
-	pavgw	MM3,m64[RBP]		;
-	pavgw	XMM1,XMM2		;
-	pavgw	XMM3,m128[RBP]		;
-
-	pcmpeqb	MM1,MM2			;
-	pcmpeqb	MM3,m64[RBP]		;
-	pcmpeqb	XMM1,XMM2		;
-	pcmpeqb	XMM3,m128[RBP]		;
-
-	pcmpeqw	MM1,MM2			;
-	pcmpeqw	MM3,m64[RBP]		;
-	pcmpeqw	XMM1,XMM2		;
-	pcmpeqw	XMM3,m128[RBP]		;
-
-	pcmpeqd	MM1,MM2			;
-	pcmpeqd	MM3,m64[RBP]		;
-	pcmpeqd	XMM1,XMM2		;
-	pcmpeqd	XMM3,m128[RBP]		;
-
-	pcmpgtb	MM1,MM2			;
-	pcmpgtb	MM3,m64[RBP]		;
-	pcmpgtb	XMM1,XMM2		;
-	pcmpgtb	XMM3,m128[RBP]		;
-
-	pcmpgtw	MM1,MM2			;
-	pcmpgtw	MM3,m64[RBP]		;
-	pcmpgtw	XMM1,XMM2		;
-	pcmpgtw	XMM3,m128[RBP]		;
-
-	pcmpgtd	MM1,MM2			;
-	pcmpgtd	MM3,m64[RBP]		;
-	pcmpgtd	XMM1,XMM2		;
-	pcmpgtd	XMM3,m128[RBP]		;
-
-	pextrw	EDX,MM6,7		;
-	pextrw	EDX,XMM6,7		;
-
-	pinsrw	MM6,EDX,7		;
-	pinsrw	MM6,m16[RBP],7		;
-	pinsrw	XMM6,EDX,7		;
-	pinsrw	XMM6,m16[RBP],7		;
-
-	pmaddwd	MM1,MM2			;
-	pmaddwd	MM3,m64[RBP]		;
-	pmaddwd	XMM1,XMM2		;
-	pmaddwd	XMM3,m128[RBP]		;
-
-	pmaxsw	MM1,MM2			;
-	pmaxsw	MM3,m64[RBP]		;
-	pmaxsw	XMM1,XMM2		;
-	pmaxsw	XMM3,m128[RBP]		;
-
-	pmaxub	MM1,MM2			;
-	pmaxub	MM3,m64[RBP]		;
-	pmaxub	XMM1,XMM2		;
-	pmaxub	XMM3,m128[RBP]		;
-
-	pminsw	MM1,MM2			;
-	pminsw	MM3,m64[RBP]		;
-	pminsw	XMM1,XMM2		;
-	pminsw	XMM3,m128[RBP]		;
-
-	pminub	MM1,MM2			;
-	pminub	MM3,m64[RBP]		;
-	pminub	XMM1,XMM2		;
-	pminub	XMM3,m128[RBP]		;
-
-	pmovmskb ECX,MM0		;
-	pmovmskb ECX,XMM6		;
-
-	pmulhuw	MM1,MM2			;
-	pmulhuw	MM3,m64[RBP]		;
-	pmulhuw	XMM1,XMM2		;
-	pmulhuw	XMM3,m128[RBP]		;
-
-	pmulhw	MM1,MM2			;
-	pmulhw	MM3,m64[RBP]		;
-	pmulhw	XMM1,XMM2		;
-	pmulhw	XMM3,m128[RBP]		;
-
-	pmullw	MM1,MM2			;
-	pmullw	MM3,m64[RBP]		;
-	pmullw	XMM1,XMM2		;
-	pmullw	XMM3,m128[RBP]		;
-
-	pmuludq	MM1,MM2			;
-	pmuludq	MM3,m64[RBP]		;
-	pmuludq	XMM1,XMM2		;
-	pmuludq	XMM3,m128[RBP]		;
-
-	por	MM1,MM2			;
-	por	MM3,m64[RBP]		;
-	por	XMM1,XMM2		;
-	por	XMM3,m128[RBP]		;
-
-	prefetcht0  m8[RBP]		;
-	prefetcht1  m8[RBP]		;
-	prefetcht2  m8[RBP]		;
-	prefetchnta m8[RBP]		;
-
-	psadbw	MM1,MM2			;
-	psadbw	MM3,m64[RBP]		;
-	psadbw	XMM1,XMM2		;
-	psadbw	XMM3,m128[RBP]		;
-
-	pshufd	XMM1,XMM2,3		;
-	pshufd	XMM3,m128[RBP],3	;
-	pshufhw	XMM1,XMM2,3		;
-	pshufhw	XMM3,m128[RBP],3	;
-	pshuflw	XMM1,XMM2,3		;
-	pshuflw	XMM3,m128[RBP],3	;
-	pshufw	MM1,MM2,3		;
-	pshufw	MM3,m64[RBP],3		;
-
-	pslldq	XMM1,0x18		;
-
-	psllw	MM1,MM2			;
-	psllw	MM1,m64[RBP]		;
-	psllw	XMM1,XMM2		;
-	psllw	XMM1,m128[RBP]		;
-	psllw	MM1,0x15		;
-	psllw	XMM1,0x15		;
-
-	pslld	MM1,MM2			;
-	pslld	MM1,m64[RBP]		;
-	pslld	XMM1,XMM2		;
-	pslld	XMM1,m128[RBP]		;
-	pslld	MM1,0x15		;
-	pslld	XMM1,0x15		;
-
-	psllq	MM1,MM2			;
-	psllq	MM1,m64[RBP]		;
-	psllq	XMM1,XMM2		;
-	psllq	XMM1,m128[RBP]		;
-	psllq	MM1,0x15		;
-	psllq	XMM1,0x15		;
-
-	psraw	MM1,MM2			;
-	psraw	MM1,m64[RBP]		;
-	psraw	XMM1,XMM2		;
-	psraw	XMM1,m128[RBP]		;
-	psraw	MM1,0x15		;
-	psraw	XMM1,0x15		;
-
-	psrad	MM1,MM2			;
-	psrad	MM1,m64[RBP]		;
-	psrad	XMM1,XMM2		;
-	psrad	XMM1,m128[RBP]		;
-	psrad	MM1,0x15		;
-	psrad	XMM1,0x15		;
-
-	psrldq	XMM1,0x18		;
-
-	psrlw	MM1,MM2			;
-	psrlw	MM1,m64[RBP]		;
-	psrlw	XMM1,XMM2		;
-	psrlw	XMM1,m128[RBP]		;
-	psrlw	MM1,0x15		;
-	psrlw	XMM1,0x15		;
-
-	psrld	MM1,MM2			;
-	psrld	MM1,m64[RBP]		;
-	psrld	XMM1,XMM2		;
-	psrld	XMM1,m128[RBP]		;
-	psrld	MM1,0x15		;
-	psrld	XMM1,0x15		;
-
-	psrlq	MM1,MM2			;
-	psrlq	MM1,m64[RBP]		;
-	psrlq	XMM1,XMM2		;
-	psrlq	XMM1,m128[RBP]		;
-	psrlq	MM1,0x15		;
-	psrlq	XMM1,0x15		;
-
-	psubb	MM1,MM2			;
-	psubb	MM1,m64[RBP]		;
-	psubb	XMM1,XMM2		;
-	psubb	XMM1,m128[RBP]		;
-
-	psubw	MM1,MM2			;
-	psubw	MM1,m64[RBP]		;
-	psubw	XMM1,XMM2		;
-	psubw	XMM1,m128[RBP]		;
-
-	psubd	MM1,MM2			;
-	psubd	MM1,m64[RBP]		;
-	psubd	XMM1,XMM2		;
-	psubd	XMM1,m128[RBP]		;
-
-	psubq	MM1,MM2			;
-	psubq	MM1,m64[RBP]		;
-	psubq	XMM1,XMM2		;
-	psubq	XMM1,m128[RBP]		;
-
-	psubsb	MM1,MM2			;
-	psubsb	MM1,m64[RBP]		;
-	psubsb	XMM1,XMM2		;
-	psubsb	XMM1,m128[RBP]		;
-
-	psubsw	MM1,MM2			;
-	psubsw	MM1,m64[RBP]		;
-	psubsw	XMM1,XMM2		;
-	psubsw	XMM1,m128[RBP]		;
-
-	psubusb	MM1,MM2			;
-	psubusb	MM1,m64[RBP]		;
-	psubusb	XMM1,XMM2		;
-	psubusb	XMM1,m128[RBP]		;
-
-	psubusw	MM1,MM2			;
-	psubusw	MM1,m64[RBP]		;
-	psubusw	XMM1,XMM2		;
-	psubusw	XMM1,m128[RBP]		;
-
-	punpckhbw MM1,MM2		;
-	punpckhbw MM1,m64[RBP]		;
-	punpckhbw XMM1,XMM2		;
-	punpckhbw XMM1,m128[RBP]	;
-
-	punpckhwd MM1,MM2		;
-	punpckhwd MM1,m64[RBP]		;
-	punpckhwd XMM1,XMM2		;
-	punpckhwd XMM1,m128[RBP]	;
-
-	punpckhdq MM1,MM2		;
-	punpckhdq MM1,m64[RBP]		;
-	punpckhdq XMM1,XMM2		;
-	punpckhdq XMM1,m128[RBP]	;
-
-	punpckhqdq XMM1,XMM2		;
-	punpckhqdq XMM1,m128[RBP]	;
-
-	punpcklbw MM1,MM2		;
-	punpcklbw MM1,m64[RBP]		;
-	punpcklbw XMM1,XMM2		;
-	punpcklbw XMM1,m128[RBP]	;
-
-	punpcklwd MM1,MM2		;
-	punpcklwd MM1,m64[RBP]		;
-	punpcklwd XMM1,XMM2		;
-	punpcklwd XMM1,m128[RBP]	;
-
-	punpckldq MM1,MM2		;
-	punpckldq MM1,m64[RBP]		;
-	punpckldq XMM1,XMM2		;
-	punpckldq XMM1,m128[RBP]	;
-
-	punpcklqdq XMM1,XMM2		;
-	punpcklqdq XMM1,m128[RBP]	;
-
- 	pxor	MM1,MM2			;
-	pxor	MM1,m64[RBP]		;
-	pxor	XMM1,XMM2		;
-	pxor	XMM1,m128[RBP]		;
-
-	rcpps	XMM1,XMM2		;
-	rcpps	XMM1,m128[RBP]		;
-	rcpss	XMM1,XMM2		;
-	rcpss	XMM1,m32[RBP]		;
-
-	rsqrtps	XMM1,XMM2		;
-	rsqrtps	XMM1,m128[RBP]		;
-	rsqrtss	XMM1,XMM2		;
-	rsqrtss	XMM1,m32[RBP]		;
-
-	shufpd	XMM1,XMM2,3		;
-	shufpd	XMM1,m128[RBP],4	;
-	shufps	XMM1,XMM2,3		;
-	shufps	XMM1,m128[RBP],4	;
-
-	ucomisd	XMM4,XMM6		;
-	ucomisd	XMM5,m64[RBP]		;
-	ucomiss	XMM6,XMM7		;
-	ucomiss	XMM7,m32[RBP]		;
-
-	unpckhpd XMM4,XMM6		;
-	unpckhpd XMM5,m128[RBP]		;
-	unpckhps XMM4,XMM6		;
-	unpckhps XMM5,m128[RBP]		;
-	unpcklpd XMM4,XMM6		;
-	unpcklpd XMM5,m128[RBP]		;
-	unpcklps XMM4,XMM6		;
-	unpcklps XMM5,m128[RBP]		;
-
-	xorpd	XMM1,XMM2		;
-	xorpd	XMM1,m128[RBP]		;
-	xorps	XMM1,XMM2		;
-	xorps	XMM1,m128[RBP]		;
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    call    L1          ;
+
+    movmskpd ESI,XMM3       ;
+    movmskps ESI,XMM3       ;
+
+    movntdq m128[RBP],XMM2      ;
+    movnti  m32[RBP],ECX        ;
+    movntpd m128[RBP],XMM3      ;
+    movntps m128[RBP],XMM4      ;
+    movntq  m64[RBP],MM5        ;
+
+    movq    MM1,MM2         ;
+    movq    MM2,m64[RBP]        ;
+    movq    m64[RBP],MM3        ;
+    movq    XMM1,XMM2       ;
+    movq    XMM2,m64[RBP]       ;
+    movq    m64[RBP],XMM3       ;
+
+    movq2dq XMM3,MM2        ;
+
+    movsd               ;
+    movsd   XMM1,XMM2       ;
+    movsd   XMM3,m64[RBP]       ;
+    movsd   m64[RBP],XMM4       ;
+
+    movss   XMM1,XMM2       ;
+    movss   XMM3,m32[RBP]       ;
+    movss   m32[RBP],XMM4       ;
+
+    movupd  XMM1,XMM2       ;
+    movupd  XMM3,m128[RBP]      ;
+    movupd  m128[RBP],XMM4      ;
+
+    movups  XMM1,XMM2       ;
+    movups  XMM3,m128[RBP]      ;
+    movups  m128[RBP],XMM4      ;
+
+    orpd    XMM1,XMM2       ;
+    orpd    XMM3,m128[RBP]      ;
+    orps    XMM1,XMM2       ;
+    orps    XMM3,m128[RBP]      ;
+
+    packsswb MM1,MM2        ;
+    packsswb MM3,m64[RBP]       ;
+    packsswb XMM1,XMM2      ;
+    packsswb XMM3,m128[RBP]     ;
+
+    packssdw MM1,MM2        ;
+    packssdw MM3,m64[RBP]       ;
+    packssdw XMM1,XMM2      ;
+    packssdw XMM3,m128[RBP]     ;
+
+    packuswb MM1,MM2        ;
+    packuswb MM3,m64[RBP]       ;
+    packuswb XMM1,XMM2      ;
+    packuswb XMM3,m128[RBP]     ;
+
+    paddb   MM1,MM2         ;
+    paddb   MM3,m64[RBP]        ;
+    paddb   XMM1,XMM2       ;
+    paddb   XMM3,m128[RBP]      ;
+
+    paddw   MM1,MM2         ;
+    paddw   MM3,m64[RBP]        ;
+    paddw   XMM1,XMM2       ;
+    paddw   XMM3,m128[RBP]      ;
+
+    paddd   MM1,MM2         ;
+    paddd   MM3,m64[RBP]        ;
+    paddd   XMM1,XMM2       ;
+    paddd   XMM3,m128[RBP]      ;
+
+    paddq   MM1,MM2         ;
+    paddq   MM3,m64[RBP]        ;
+    paddq   XMM1,XMM2       ;
+    paddq   XMM3,m128[RBP]      ;
+
+    paddsb  MM1,MM2         ;
+    paddsb  MM3,m64[RBP]        ;
+    paddsb  XMM1,XMM2       ;
+    paddsb  XMM3,m128[RBP]      ;
+
+    paddsw  MM1,MM2         ;
+    paddsw  MM3,m64[RBP]        ;
+    paddsw  XMM1,XMM2       ;
+    paddsw  XMM3,m128[RBP]      ;
+
+    paddusb MM1,MM2         ;
+    paddusb MM3,m64[RBP]        ;
+    paddusb XMM1,XMM2       ;
+    paddusb XMM3,m128[RBP]      ;
+
+    paddusw MM1,MM2         ;
+    paddusw MM3,m64[RBP]        ;
+    paddusw XMM1,XMM2       ;
+    paddusw XMM3,m128[RBP]      ;
+
+    pand    MM1,MM2         ;
+    pand    MM3,m64[RBP]        ;
+    pand    XMM1,XMM2       ;
+    pand    XMM3,m128[RBP]      ;
+
+    pandn   MM1,MM2         ;
+    pandn   MM3,m64[RBP]        ;
+    pandn   XMM1,XMM2       ;
+    pandn   XMM3,m128[RBP]      ;
+
+    pavgb   MM1,MM2         ;
+    pavgb   MM3,m64[RBP]        ;
+    pavgb   XMM1,XMM2       ;
+    pavgb   XMM3,m128[RBP]      ;
+
+    pavgw   MM1,MM2         ;
+    pavgw   MM3,m64[RBP]        ;
+    pavgw   XMM1,XMM2       ;
+    pavgw   XMM3,m128[RBP]      ;
+
+    pcmpeqb MM1,MM2         ;
+    pcmpeqb MM3,m64[RBP]        ;
+    pcmpeqb XMM1,XMM2       ;
+    pcmpeqb XMM3,m128[RBP]      ;
+
+    pcmpeqw MM1,MM2         ;
+    pcmpeqw MM3,m64[RBP]        ;
+    pcmpeqw XMM1,XMM2       ;
+    pcmpeqw XMM3,m128[RBP]      ;
+
+    pcmpeqd MM1,MM2         ;
+    pcmpeqd MM3,m64[RBP]        ;
+    pcmpeqd XMM1,XMM2       ;
+    pcmpeqd XMM3,m128[RBP]      ;
+
+    pcmpgtb MM1,MM2         ;
+    pcmpgtb MM3,m64[RBP]        ;
+    pcmpgtb XMM1,XMM2       ;
+    pcmpgtb XMM3,m128[RBP]      ;
+
+    pcmpgtw MM1,MM2         ;
+    pcmpgtw MM3,m64[RBP]        ;
+    pcmpgtw XMM1,XMM2       ;
+    pcmpgtw XMM3,m128[RBP]      ;
+
+    pcmpgtd MM1,MM2         ;
+    pcmpgtd MM3,m64[RBP]        ;
+    pcmpgtd XMM1,XMM2       ;
+    pcmpgtd XMM3,m128[RBP]      ;
+
+    pextrw  EDX,MM6,7       ;
+    pextrw  EDX,XMM6,7      ;
+
+    pinsrw  MM6,EDX,7       ;
+    pinsrw  MM6,m16[RBP],7      ;
+    pinsrw  XMM6,EDX,7      ;
+    pinsrw  XMM6,m16[RBP],7     ;
+
+    pmaddwd MM1,MM2         ;
+    pmaddwd MM3,m64[RBP]        ;
+    pmaddwd XMM1,XMM2       ;
+    pmaddwd XMM3,m128[RBP]      ;
+
+    pmaxsw  MM1,MM2         ;
+    pmaxsw  MM3,m64[RBP]        ;
+    pmaxsw  XMM1,XMM2       ;
+    pmaxsw  XMM3,m128[RBP]      ;
+
+    pmaxub  MM1,MM2         ;
+    pmaxub  MM3,m64[RBP]        ;
+    pmaxub  XMM1,XMM2       ;
+    pmaxub  XMM3,m128[RBP]      ;
+
+    pminsw  MM1,MM2         ;
+    pminsw  MM3,m64[RBP]        ;
+    pminsw  XMM1,XMM2       ;
+    pminsw  XMM3,m128[RBP]      ;
+
+    pminub  MM1,MM2         ;
+    pminub  MM3,m64[RBP]        ;
+    pminub  XMM1,XMM2       ;
+    pminub  XMM3,m128[RBP]      ;
+
+    pmovmskb ECX,MM0        ;
+    pmovmskb ECX,XMM6       ;
+
+    pmulhuw MM1,MM2         ;
+    pmulhuw MM3,m64[RBP]        ;
+    pmulhuw XMM1,XMM2       ;
+    pmulhuw XMM3,m128[RBP]      ;
+
+    pmulhw  MM1,MM2         ;
+    pmulhw  MM3,m64[RBP]        ;
+    pmulhw  XMM1,XMM2       ;
+    pmulhw  XMM3,m128[RBP]      ;
+
+    pmullw  MM1,MM2         ;
+    pmullw  MM3,m64[RBP]        ;
+    pmullw  XMM1,XMM2       ;
+    pmullw  XMM3,m128[RBP]      ;
+
+    pmuludq MM1,MM2         ;
+    pmuludq MM3,m64[RBP]        ;
+    pmuludq XMM1,XMM2       ;
+    pmuludq XMM3,m128[RBP]      ;
+
+    por MM1,MM2         ;
+    por MM3,m64[RBP]        ;
+    por XMM1,XMM2       ;
+    por XMM3,m128[RBP]      ;
+
+    prefetcht0  m8[RBP]     ;
+    prefetcht1  m8[RBP]     ;
+    prefetcht2  m8[RBP]     ;
+    prefetchnta m8[RBP]     ;
+
+    psadbw  MM1,MM2         ;
+    psadbw  MM3,m64[RBP]        ;
+    psadbw  XMM1,XMM2       ;
+    psadbw  XMM3,m128[RBP]      ;
+
+    pshufd  XMM1,XMM2,3     ;
+    pshufd  XMM3,m128[RBP],3    ;
+    pshufhw XMM1,XMM2,3     ;
+    pshufhw XMM3,m128[RBP],3    ;
+    pshuflw XMM1,XMM2,3     ;
+    pshuflw XMM3,m128[RBP],3    ;
+    pshufw  MM1,MM2,3       ;
+    pshufw  MM3,m64[RBP],3      ;
+
+    pslldq  XMM1,0x18       ;
+
+    psllw   MM1,MM2         ;
+    psllw   MM1,m64[RBP]        ;
+    psllw   XMM1,XMM2       ;
+    psllw   XMM1,m128[RBP]      ;
+    psllw   MM1,0x15        ;
+    psllw   XMM1,0x15       ;
+
+    pslld   MM1,MM2         ;
+    pslld   MM1,m64[RBP]        ;
+    pslld   XMM1,XMM2       ;
+    pslld   XMM1,m128[RBP]      ;
+    pslld   MM1,0x15        ;
+    pslld   XMM1,0x15       ;
+
+    psllq   MM1,MM2         ;
+    psllq   MM1,m64[RBP]        ;
+    psllq   XMM1,XMM2       ;
+    psllq   XMM1,m128[RBP]      ;
+    psllq   MM1,0x15        ;
+    psllq   XMM1,0x15       ;
+
+    psraw   MM1,MM2         ;
+    psraw   MM1,m64[RBP]        ;
+    psraw   XMM1,XMM2       ;
+    psraw   XMM1,m128[RBP]      ;
+    psraw   MM1,0x15        ;
+    psraw   XMM1,0x15       ;
+
+    psrad   MM1,MM2         ;
+    psrad   MM1,m64[RBP]        ;
+    psrad   XMM1,XMM2       ;
+    psrad   XMM1,m128[RBP]      ;
+    psrad   MM1,0x15        ;
+    psrad   XMM1,0x15       ;
+
+    psrldq  XMM1,0x18       ;
+
+    psrlw   MM1,MM2         ;
+    psrlw   MM1,m64[RBP]        ;
+    psrlw   XMM1,XMM2       ;
+    psrlw   XMM1,m128[RBP]      ;
+    psrlw   MM1,0x15        ;
+    psrlw   XMM1,0x15       ;
+
+    psrld   MM1,MM2         ;
+    psrld   MM1,m64[RBP]        ;
+    psrld   XMM1,XMM2       ;
+    psrld   XMM1,m128[RBP]      ;
+    psrld   MM1,0x15        ;
+    psrld   XMM1,0x15       ;
+
+    psrlq   MM1,MM2         ;
+    psrlq   MM1,m64[RBP]        ;
+    psrlq   XMM1,XMM2       ;
+    psrlq   XMM1,m128[RBP]      ;
+    psrlq   MM1,0x15        ;
+    psrlq   XMM1,0x15       ;
+
+    psubb   MM1,MM2         ;
+    psubb   MM1,m64[RBP]        ;
+    psubb   XMM1,XMM2       ;
+    psubb   XMM1,m128[RBP]      ;
+
+    psubw   MM1,MM2         ;
+    psubw   MM1,m64[RBP]        ;
+    psubw   XMM1,XMM2       ;
+    psubw   XMM1,m128[RBP]      ;
+
+    psubd   MM1,MM2         ;
+    psubd   MM1,m64[RBP]        ;
+    psubd   XMM1,XMM2       ;
+    psubd   XMM1,m128[RBP]      ;
+
+    psubq   MM1,MM2         ;
+    psubq   MM1,m64[RBP]        ;
+    psubq   XMM1,XMM2       ;
+    psubq   XMM1,m128[RBP]      ;
+
+    psubsb  MM1,MM2         ;
+    psubsb  MM1,m64[RBP]        ;
+    psubsb  XMM1,XMM2       ;
+    psubsb  XMM1,m128[RBP]      ;
+
+    psubsw  MM1,MM2         ;
+    psubsw  MM1,m64[RBP]        ;
+    psubsw  XMM1,XMM2       ;
+    psubsw  XMM1,m128[RBP]      ;
+
+    psubusb MM1,MM2         ;
+    psubusb MM1,m64[RBP]        ;
+    psubusb XMM1,XMM2       ;
+    psubusb XMM1,m128[RBP]      ;
+
+    psubusw MM1,MM2         ;
+    psubusw MM1,m64[RBP]        ;
+    psubusw XMM1,XMM2       ;
+    psubusw XMM1,m128[RBP]      ;
+
+    punpckhbw MM1,MM2       ;
+    punpckhbw MM1,m64[RBP]      ;
+    punpckhbw XMM1,XMM2     ;
+    punpckhbw XMM1,m128[RBP]    ;
+
+    punpckhwd MM1,MM2       ;
+    punpckhwd MM1,m64[RBP]      ;
+    punpckhwd XMM1,XMM2     ;
+    punpckhwd XMM1,m128[RBP]    ;
+
+    punpckhdq MM1,MM2       ;
+    punpckhdq MM1,m64[RBP]      ;
+    punpckhdq XMM1,XMM2     ;
+    punpckhdq XMM1,m128[RBP]    ;
+
+    punpckhqdq XMM1,XMM2        ;
+    punpckhqdq XMM1,m128[RBP]   ;
+
+    punpcklbw MM1,MM2       ;
+    punpcklbw MM1,m64[RBP]      ;
+    punpcklbw XMM1,XMM2     ;
+    punpcklbw XMM1,m128[RBP]    ;
+
+    punpcklwd MM1,MM2       ;
+    punpcklwd MM1,m64[RBP]      ;
+    punpcklwd XMM1,XMM2     ;
+    punpcklwd XMM1,m128[RBP]    ;
+
+    punpckldq MM1,MM2       ;
+    punpckldq MM1,m64[RBP]      ;
+    punpckldq XMM1,XMM2     ;
+    punpckldq XMM1,m128[RBP]    ;
+
+    punpcklqdq XMM1,XMM2        ;
+    punpcklqdq XMM1,m128[RBP]   ;
+
+    pxor    MM1,MM2         ;
+    pxor    MM1,m64[RBP]        ;
+    pxor    XMM1,XMM2       ;
+    pxor    XMM1,m128[RBP]      ;
+
+    rcpps   XMM1,XMM2       ;
+    rcpps   XMM1,m128[RBP]      ;
+    rcpss   XMM1,XMM2       ;
+    rcpss   XMM1,m32[RBP]       ;
+
+    rsqrtps XMM1,XMM2       ;
+    rsqrtps XMM1,m128[RBP]      ;
+    rsqrtss XMM1,XMM2       ;
+    rsqrtss XMM1,m32[RBP]       ;
+
+    shufpd  XMM1,XMM2,3     ;
+    shufpd  XMM1,m128[RBP],4    ;
+    shufps  XMM1,XMM2,3     ;
+    shufps  XMM1,m128[RBP],4    ;
+
+    ucomisd XMM4,XMM6       ;
+    ucomisd XMM5,m64[RBP]       ;
+    ucomiss XMM6,XMM7       ;
+    ucomiss XMM7,m32[RBP]       ;
+
+    unpckhpd XMM4,XMM6      ;
+    unpckhpd XMM5,m128[RBP]     ;
+    unpckhps XMM4,XMM6      ;
+    unpckhps XMM5,m128[RBP]     ;
+    unpcklpd XMM4,XMM6      ;
+    unpcklpd XMM5,m128[RBP]     ;
+    unpcklps XMM4,XMM6      ;
+    unpcklps XMM5,m128[RBP]     ;
+
+    xorpd   XMM1,XMM2       ;
+    xorpd   XMM1,m128[RBP]      ;
+    xorps   XMM1,XMM2       ;
+    xorps   XMM1,m128[RBP]      ;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	//printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], data[i]);
-	assert(p[i] == data[i]);
+    //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -1867,116 +1867,116 @@ void test15()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F,0x0F,0xDC,0xBF, 		// pavgusb	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xBF,	// pavgusb	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0x1D, 		// pf2id	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0x1D, 	// pf2id	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xAE, 		// pfacc	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xAE, 	// pfacc	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0x9E, 		// pfadd	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0x9E, 	// pfadd	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xB0, 		// pfcmpeq	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xB0, 	// pfcmpeq	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0x90, 		// pfcmpge	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0x90, 	// pfcmpge	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xA0, 		// pfcmpgt	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xA0, 	// pfcmpgt	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xA4, 		// pfmax	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0x94, 	// pfmin	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xB4, 		// pfmul	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xB4, 	// pfmul	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0x8A, 		// pfnacc	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0x8E, 	// pfpnacc	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0x96, 		// pfrcp	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0x96, 	// pfrcp	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xA6, 		// pfrcpit1	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xA6, 	// pfrcpit1	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xB6, 		// pfrcpit2	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xB6, 	// pfrcpit2	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0x97, 		// pfrsqrt	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xA7, 	// pfrsqit1	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0x9A, 		// pfsub	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0x9A, 	// pfsub	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xAA, 		// pfsubr	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xAA, 	// pfsubr	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0x0D, 		// pi2fd	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0x0D, 	// pi2fd	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xB7, 		// pmulhrw	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xB7, 	// pmulhrw	MM3,-028h[RBP]
-	0x0F,0x0F,0xDC,0xBB, 		// pswapd	MM3,MM4
-	0x0F,0x0F,0x5D,0xD8,0xBB, 	// pswapd	MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xBF,        // pavgusb  MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xBF,   // pavgusb  MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0x1D,        // pf2id    MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0x1D,   // pf2id    MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xAE,        // pfacc    MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xAE,   // pfacc    MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0x9E,        // pfadd    MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0x9E,   // pfadd    MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xB0,        // pfcmpeq  MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xB0,   // pfcmpeq  MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0x90,        // pfcmpge  MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0x90,   // pfcmpge  MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xA0,        // pfcmpgt  MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xA0,   // pfcmpgt  MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xA4,        // pfmax    MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0x94,   // pfmin    MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xB4,        // pfmul    MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xB4,   // pfmul    MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0x8A,        // pfnacc   MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0x8E,   // pfpnacc  MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0x96,        // pfrcp    MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0x96,   // pfrcp    MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xA6,        // pfrcpit1 MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xA6,   // pfrcpit1 MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xB6,        // pfrcpit2 MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xB6,   // pfrcpit2 MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0x97,        // pfrsqrt  MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xA7,   // pfrsqit1 MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0x9A,        // pfsub    MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0x9A,   // pfsub    MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xAA,        // pfsubr   MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xAA,   // pfsubr   MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0x0D,        // pi2fd    MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0x0D,   // pi2fd    MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xB7,        // pmulhrw  MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xB7,   // pmulhrw  MM3,-028h[RBP]
+    0x0F,0x0F,0xDC,0xBB,        // pswapd   MM3,MM4
+    0x0F,0x0F,0x5D,0xD8,0xBB,   // pswapd   MM3,-028h[RBP]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	pavgusb	MM3,MM4			;
-	pavgusb	MM3,m64[RBP]		;
+    pavgusb MM3,MM4         ;
+    pavgusb MM3,m64[RBP]        ;
 
-	pf2id	MM3,MM4			;
-	pf2id	MM3,m64[RBP]		;
+    pf2id   MM3,MM4         ;
+    pf2id   MM3,m64[RBP]        ;
 
-	pfacc	MM3,MM4			;
-	pfacc	MM3,m64[RBP]		;
+    pfacc   MM3,MM4         ;
+    pfacc   MM3,m64[RBP]        ;
 
-	pfadd	MM3,MM4			;
-	pfadd	MM3,m64[RBP]		;
+    pfadd   MM3,MM4         ;
+    pfadd   MM3,m64[RBP]        ;
 
-	pfcmpeq	MM3,MM4			;
-	pfcmpeq	MM3,m64[RBP]		;
+    pfcmpeq MM3,MM4         ;
+    pfcmpeq MM3,m64[RBP]        ;
 
-	pfcmpge	MM3,MM4			;
-	pfcmpge	MM3,m64[RBP]		;
+    pfcmpge MM3,MM4         ;
+    pfcmpge MM3,m64[RBP]        ;
 
-	pfcmpgt	MM3,MM4			;
-	pfcmpgt	MM3,m64[RBP]		;
+    pfcmpgt MM3,MM4         ;
+    pfcmpgt MM3,m64[RBP]        ;
 
-	pfmax	MM3,MM4			;
-	pfmin	MM3,m64[RBP]		;
+    pfmax   MM3,MM4         ;
+    pfmin   MM3,m64[RBP]        ;
 
-	pfmul	MM3,MM4			;
-	pfmul	MM3,m64[RBP]		;
+    pfmul   MM3,MM4         ;
+    pfmul   MM3,m64[RBP]        ;
 
-	pfnacc	MM3,MM4			;
-	pfpnacc	MM3,m64[RBP]		;
+    pfnacc  MM3,MM4         ;
+    pfpnacc MM3,m64[RBP]        ;
 
-	pfrcp	MM3,MM4			;
-	pfrcp	MM3,m64[RBP]		;
+    pfrcp   MM3,MM4         ;
+    pfrcp   MM3,m64[RBP]        ;
 
-	pfrcpit1 MM3,MM4		;
-	pfrcpit1 MM3,m64[RBP]		;
+    pfrcpit1 MM3,MM4        ;
+    pfrcpit1 MM3,m64[RBP]       ;
 
-	pfrcpit2 MM3,MM4		;
-	pfrcpit2 MM3,m64[RBP]		;
+    pfrcpit2 MM3,MM4        ;
+    pfrcpit2 MM3,m64[RBP]       ;
 
-	pfrsqrt	 MM3,MM4		;
-	pfrsqit1 MM3,m64[RBP]		;
+    pfrsqrt  MM3,MM4        ;
+    pfrsqit1 MM3,m64[RBP]       ;
 
-	pfsub	MM3,MM4			;
-	pfsub	MM3,m64[RBP]		;
+    pfsub   MM3,MM4         ;
+    pfsub   MM3,m64[RBP]        ;
 
-	pfsubr	MM3,MM4			;
-	pfsubr	MM3,m64[RBP]		;
+    pfsubr  MM3,MM4         ;
+    pfsubr  MM3,m64[RBP]        ;
 
-	pi2fd	MM3,MM4			;
-	pi2fd	MM3,m64[RBP]		;
+    pi2fd   MM3,MM4         ;
+    pi2fd   MM3,m64[RBP]        ;
 
-	pmulhrw	MM3,MM4			;
-	pmulhrw	MM3,m64[RBP]		;
+    pmulhrw MM3,MM4         ;
+    pmulhrw MM3,m64[RBP]        ;
 
-	pswapd	MM3,MM4			;
-	pswapd	MM3,m64[RBP]		;
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    pswapd  MM3,MM4         ;
+    pswapd  MM3,m64[RBP]        ;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -1988,36 +1988,36 @@ __gshared S17 xx17;
 void test17()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F, 0x01, 0x10,    	// lgdt	[EAX]
-	0x0F, 0x01, 0x18,   	// lidt	[EAX]
-	0x0F, 0x01, 0x00,    	// sgdt	[EAX]
-	0x0F, 0x01, 0x08,    	// sidt	[EAX]
+    0x0F, 0x01, 0x10,       // lgdt [EAX]
+    0x0F, 0x01, 0x18,       // lidt [EAX]
+    0x0F, 0x01, 0x00,       // sgdt [EAX]
+    0x0F, 0x01, 0x08,       // sidt [EAX]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	lgdt [RAX]			;
-	lidt [RAX]			;
-	sgdt [RAX]			;
-	sidt [RAX]			;
+    lgdt [RAX]          ;
+    lidt [RAX]          ;
+    sgdt [RAX]          ;
+    sidt [RAX]          ;
 
-	lgdt xx17			;
-	lidt xx17			;
-	sgdt xx17			;
-	sidt xx17			;
+    lgdt xx17           ;
+    lidt xx17           ;
+    sgdt xx17           ;
+    sidt xx17           ;
 
 L1:
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2026,53 +2026,53 @@ L1:
 void test18()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xDB, 0xF1,		// fcomi ST,ST(1)
-	0xDB, 0xF0,		// fcomi ST,ST(0)
-	0xDB, 0xF2,		// fcomi ST,ST(2)
+    0xDB, 0xF1,     // fcomi ST,ST(1)
+    0xDB, 0xF0,     // fcomi ST,ST(0)
+    0xDB, 0xF2,     // fcomi ST,ST(2)
 
-	0xDF, 0xF1,		// fcomip ST,ST(1)
-	0xDF, 0xF0,		// fcomip ST,ST(0)
-	0xDF, 0xF2,		// fcomip ST,ST(2)
+    0xDF, 0xF1,     // fcomip ST,ST(1)
+    0xDF, 0xF0,     // fcomip ST,ST(0)
+    0xDF, 0xF2,     // fcomip ST,ST(2)
 
-	0xDB, 0xE9,		// fucomi ST,ST(1)
-	0xDB, 0xE8,		// fucomi ST,ST(0)
-	0xDB, 0xEB,		// fucomi ST,ST(3)
+    0xDB, 0xE9,     // fucomi ST,ST(1)
+    0xDB, 0xE8,     // fucomi ST,ST(0)
+    0xDB, 0xEB,     // fucomi ST,ST(3)
 
-	0xDF, 0xE9,		// fucomip ST,ST(1)
-	0xDF, 0xED,		// fucomip ST,ST(5)
-	0xDF, 0xEC,		// fucomip ST,ST(4)
+    0xDF, 0xE9,     // fucomip ST,ST(1)
+    0xDF, 0xED,     // fucomip ST,ST(5)
+    0xDF, 0xEC,     // fucomip ST,ST(4)
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	fcomi				;
-	fcomi   ST(0)			;
-	fcomi   ST,ST(2)		;
+    fcomi               ;
+    fcomi   ST(0)           ;
+    fcomi   ST,ST(2)        ;
 
-	fcomip				;
-	fcomip  ST(0)			;
-	fcomip  ST,ST(2)		;
+    fcomip              ;
+    fcomip  ST(0)           ;
+    fcomip  ST,ST(2)        ;
 
-	fucomi				;
-	fucomi  ST(0)			;
-	fucomi  ST,ST(3)		;
+    fucomi              ;
+    fucomi  ST(0)           ;
+    fucomi  ST,ST(3)        ;
 
-	fucomip				;
-	fucomip ST(5)			;
-	fucomip ST,ST(4)		;
+    fucomip             ;
+    fucomip ST(5)           ;
+    fucomip ST,ST(4)        ;
 
 L1:
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2089,11 +2089,11 @@ void test19()
 
     asm
     {
-	lea	RAX, qword ptr [foo19];
-	mov	fp, RAX;
-	mov	x, RAX;
-	mov	p, RAX;
-	call	fp;
+    lea RAX, qword ptr [foo19];
+    mov fp, RAX;
+    mov x, RAX;
+    mov p, RAX;
+    call    fp;
     }
     (*fp)();
 }
@@ -2103,46 +2103,46 @@ void test19()
 void test20()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x9B, 0xDB, 0xE0,	// feni
-	0xDB, 0xE0,		// fneni
+    0x9B, 0xDB, 0xE0,   // feni
+    0xDB, 0xE0,     // fneni
 
-	0x9B, 0xDB, 0xE1,	// fdisi
-	0xDB, 0xE1,		// fndisi
+    0x9B, 0xDB, 0xE1,   // fdisi
+    0xDB, 0xE1,     // fndisi
 
-	0x9B, 0xDB, 0xE2,	// fclex
-	0xDB, 0xE2,		// fnclex
+    0x9B, 0xDB, 0xE2,   // fclex
+    0xDB, 0xE2,     // fnclex
 
-	0x9B, 0xDB, 0xE3,	// finit
-	0xDB, 0xE3,		// fninit
+    0x9B, 0xDB, 0xE3,   // finit
+    0xDB, 0xE3,     // fninit
 
-	0xDB, 0xE4,		// fsetpm
+    0xDB, 0xE4,     // fsetpm
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	feni				;
-	fneni				;
-	fdisi				;
-	fndisi				;
-	finit				;
-	fninit				;
-	fclex				;
-	fnclex				;
-	finit				;
-	fninit				;
-	fsetpm				;
+    feni                ;
+    fneni               ;
+    fdisi               ;
+    fndisi              ;
+    finit               ;
+    fninit              ;
+    fclex               ;
+    fnclex              ;
+    finit               ;
+    fninit              ;
+    fsetpm              ;
 L1:
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 +/
@@ -2151,47 +2151,47 @@ L1:
 void test21()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xE4, 0x06,       	// in	AL,6
-	0x66, 0xE5, 0x07,       // in	AX,7
-	0xE5, 0x08,       	// in	EAX,8
-	0xEC,          		// in	AL,DX
-	0x66, 0xED,          	// in	AX,DX
-	0xED,          		// in	EAX,DX
-	0xE6, 0x06,       	// out	6,AL
-	0x66, 0xE7, 0x07,       // out	7,AX
-	0xE7, 0x08,       	// out	8,EAX
-	0xEE,          		// out	DX,AL
-	0x66, 0xEF,          	// out	DX,AX
-	0xEF,          		// out	DX,EAX
+    0xE4, 0x06,         // in   AL,6
+    0x66, 0xE5, 0x07,       // in   AX,7
+    0xE5, 0x08,         // in   EAX,8
+    0xEC,               // in   AL,DX
+    0x66, 0xED,             // in   AX,DX
+    0xED,               // in   EAX,DX
+    0xE6, 0x06,         // out  6,AL
+    0x66, 0xE7, 0x07,       // out  7,AX
+    0xE7, 0x08,         // out  8,EAX
+    0xEE,               // out  DX,AL
+    0x66, 0xEF,             // out  DX,AX
+    0xEF,               // out  DX,EAX
     ];
     int i;
 
     asm
     {
-	call	L1	;
+    call    L1  ;
 
-	in AL,6		;
-	in AX,7		;
-	in EAX,8	;
-	in AL,DX	;
-	in AX,DX	;
-	in EAX,DX	;
+    in AL,6     ;
+    in AX,7     ;
+    in EAX,8    ;
+    in AL,DX    ;
+    in AX,DX    ;
+    in EAX,DX   ;
 
-	out 6,AL	;
-	out 7,AX	;
-	out 8,EAX	;
-	out DX,AL	;
-	out DX,AX	;
-	out DX,EAX	;
+    out 6,AL    ;
+    out 7,AX    ;
+    out 8,EAX   ;
+    out DX,AL   ;
+    out DX,AX   ;
+    out DX,EAX  ;
 L1:
-	pop	RBX		;
-	mov	p[RBP],RBX	;
+    pop RBX     ;
+    mov p[RBP],RBX  ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2200,10 +2200,10 @@ L1:
 void test22()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F, 0xC7, 0x4D, 0xE0,	// cmpxchg8b
-0x48,	0x0F, 0xC7, 0x4D, 0xF0 	// cmpxchg16b
+    0x0F, 0xC7, 0x4D, 0xE0, // cmpxchg8b
+0x48,   0x0F, 0xC7, 0x4D, 0xF0  // cmpxchg16b
     ];
     int i;
     M64  m64;
@@ -2211,17 +2211,17 @@ void test22()
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	cmpxchg8b  m64			;
-	cmpxchg16b m128			;
+    cmpxchg8b  m64          ;
+    cmpxchg16b m128         ;
 L1:
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2234,96 +2234,96 @@ void test23()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xD9, 0xC9,		// fxch		ST(1), ST(0)
+    0xD9, 0xC9,     // fxch     ST(1), ST(0)
 
-	0xDF, 0x5D, 0xD0,    	// fistp	word ptr -030h[RBP]
-	0xDB, 0x5D, 0xD4,    	// fistp	dword ptr -02Ch[RBP]
-	0xDF, 0x7D, 0xD8,    	// fistp	long64 ptr -028h[RBP]
-	0xDF, 0x4D, 0xD0,    	// fisttp	short ptr -030h[RBP]
-	0xDB, 0x4D, 0xD4,    	// fisttp	word ptr -02Ch[RBP]
-	0xDD, 0x4D, 0xD8,    	// fisttp	long64 ptr -028h[RBP]
-	0x0F, 0x01, 0xC8,    	// monitor
-	0x0F, 0x01, 0xC9,    	// mwait
-	0x0F, 0x01, 0xD0,    	// xgetbv
+    0xDF, 0x5D, 0xD0,       // fistp    word ptr -030h[RBP]
+    0xDB, 0x5D, 0xD4,       // fistp    dword ptr -02Ch[RBP]
+    0xDF, 0x7D, 0xD8,       // fistp    long64 ptr -028h[RBP]
+    0xDF, 0x4D, 0xD0,       // fisttp   short ptr -030h[RBP]
+    0xDB, 0x4D, 0xD4,       // fisttp   word ptr -02Ch[RBP]
+    0xDD, 0x4D, 0xD8,       // fisttp   long64 ptr -028h[RBP]
+    0x0F, 0x01, 0xC8,       // monitor
+    0x0F, 0x01, 0xC9,       // mwait
+    0x0F, 0x01, 0xD0,       // xgetbv
 
-	0x66, 0x0F, 0xD0, 0xCA,    	// addsubpd	XMM1,XMM2
-	0x66, 0x0F, 0xD0, 0x4D, 0xE0, 	// addsubpd	XMM1,-020h[RBP]
-	0xF2, 0x0F, 0xD0, 0xCA, 	// addsubps	XMM1,XMM2
-	0xF2, 0x0F, 0xD0, 0x4D, 0xE0, 	// addsubps	XMM1,-020h[RBP]
-	0x66, 0x0F, 0x7C, 0xCA,    	// haddpd	XMM1,XMM2
-	0x66, 0x0F, 0x7C, 0x4D, 0xE0, 	// haddpd	XMM1,-020h[RBP]
-	0xF2, 0x0F, 0x7C, 0xCA, 	// haddps	XMM1,XMM2
-	0xF2, 0x0F, 0x7C, 0x4D, 0xE0, 	// haddps	XMM1,-020h[RBP]
-	0x66, 0x0F, 0x7D, 0xCA,    	// hsubpd	XMM1,XMM2
-	0x66, 0x0F, 0x7D, 0x4D, 0xE0, 	// hsubpd	XMM1,-020h[RBP]
-	0xF2, 0x0F, 0x7D, 0xCA, 	// hsubps	XMM1,XMM2
-	0xF2, 0x0F, 0x7D, 0x4D, 0xE0, 	// hsubps	XMM1,-020h[RBP]
-	0xF2, 0x0F, 0xF0, 0x4D, 0xE0, 	// lddqu	XMM1,-020h[RBP]
-	0xF2, 0x0F, 0x12, 0xCA, 	// movddup	XMM1,XMM2
-	0xF2, 0x0F, 0x12, 0x4D, 0xD8, 	// movddup	XMM1,-028h[RBP]
-	0xF3, 0x0F, 0x16, 0xCA, 	// movshdup	XMM1,XMM2
-	0xF3, 0x0F, 0x16, 0x4D, 0xE0, 	// movshdup	XMM1,-020h[RBP]
-	0xF3, 0x0F, 0x12, 0xCA, 	// movsldup	XMM1,XMM2
-	0xF3, 0x0F, 0x12, 0x4D, 0xE0, 	// movsldup	XMM1,-020h[RBP]
+    0x66, 0x0F, 0xD0, 0xCA,     // addsubpd XMM1,XMM2
+    0x66, 0x0F, 0xD0, 0x4D, 0xE0,   // addsubpd XMM1,-020h[RBP]
+    0xF2, 0x0F, 0xD0, 0xCA,     // addsubps XMM1,XMM2
+    0xF2, 0x0F, 0xD0, 0x4D, 0xE0,   // addsubps XMM1,-020h[RBP]
+    0x66, 0x0F, 0x7C, 0xCA,     // haddpd   XMM1,XMM2
+    0x66, 0x0F, 0x7C, 0x4D, 0xE0,   // haddpd   XMM1,-020h[RBP]
+    0xF2, 0x0F, 0x7C, 0xCA,     // haddps   XMM1,XMM2
+    0xF2, 0x0F, 0x7C, 0x4D, 0xE0,   // haddps   XMM1,-020h[RBP]
+    0x66, 0x0F, 0x7D, 0xCA,     // hsubpd   XMM1,XMM2
+    0x66, 0x0F, 0x7D, 0x4D, 0xE0,   // hsubpd   XMM1,-020h[RBP]
+    0xF2, 0x0F, 0x7D, 0xCA,     // hsubps   XMM1,XMM2
+    0xF2, 0x0F, 0x7D, 0x4D, 0xE0,   // hsubps   XMM1,-020h[RBP]
+    0xF2, 0x0F, 0xF0, 0x4D, 0xE0,   // lddqu    XMM1,-020h[RBP]
+    0xF2, 0x0F, 0x12, 0xCA,     // movddup  XMM1,XMM2
+    0xF2, 0x0F, 0x12, 0x4D, 0xD8,   // movddup  XMM1,-028h[RBP]
+    0xF3, 0x0F, 0x16, 0xCA,     // movshdup XMM1,XMM2
+    0xF3, 0x0F, 0x16, 0x4D, 0xE0,   // movshdup XMM1,-020h[RBP]
+    0xF3, 0x0F, 0x12, 0xCA,     // movsldup XMM1,XMM2
+    0xF3, 0x0F, 0x12, 0x4D, 0xE0,   // movsldup XMM1,-020h[RBP]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	fxch	ST(1), ST(0)		;
+    fxch    ST(1), ST(0)        ;
 
-	fistp	m16[RBP]		;
-	fistp	m32[RBP]		;
-	fistp	m64[RBP]		;
+    fistp   m16[RBP]        ;
+    fistp   m32[RBP]        ;
+    fistp   m64[RBP]        ;
 
-	fisttp	m16[RBP]		;
-	fisttp	m32[RBP]		;
-	fisttp	m64[RBP]		;
+    fisttp  m16[RBP]        ;
+    fisttp  m32[RBP]        ;
+    fisttp  m64[RBP]        ;
 
-	monitor				;
-	mwait				;
-	xgetbv				;
+    monitor             ;
+    mwait               ;
+    xgetbv              ;
 
-	addsubpd	XMM1,XMM2	;
-	addsubpd	XMM1,m128[RBP]	;
+    addsubpd    XMM1,XMM2   ;
+    addsubpd    XMM1,m128[RBP]  ;
 
-	addsubps	XMM1,XMM2	;
-	addsubps	XMM1,m128[RBP]	;
+    addsubps    XMM1,XMM2   ;
+    addsubps    XMM1,m128[RBP]  ;
 
-	haddpd		XMM1,XMM2	;
-	haddpd		XMM1,m128[RBP]	;
+    haddpd      XMM1,XMM2   ;
+    haddpd      XMM1,m128[RBP]  ;
 
-	haddps		XMM1,XMM2	;
-	haddps		XMM1,m128[RBP]	;
+    haddps      XMM1,XMM2   ;
+    haddps      XMM1,m128[RBP]  ;
 
-	hsubpd		XMM1,XMM2	;
-	hsubpd		XMM1,m128[RBP]	;
+    hsubpd      XMM1,XMM2   ;
+    hsubpd      XMM1,m128[RBP]  ;
 
-	hsubps		XMM1,XMM2	;
-	hsubps		XMM1,m128[RBP]	;
+    hsubps      XMM1,XMM2   ;
+    hsubps      XMM1,m128[RBP]  ;
 
-	lddqu		XMM1,m128[RBP]	;
+    lddqu       XMM1,m128[RBP]  ;
 
-	movddup		XMM1,XMM2	;
-	movddup		XMM1,m64[RBP]	;
+    movddup     XMM1,XMM2   ;
+    movddup     XMM1,m64[RBP]   ;
 
-	movshdup	XMM1,XMM2	;
-	movshdup	XMM1,m128[RBP]	;
+    movshdup    XMM1,XMM2   ;
+    movshdup    XMM1,m128[RBP]  ;
 
-	movsldup	XMM1,XMM2	;
-	movsldup	XMM1,m128[RBP]	;
+    movsldup    XMM1,XMM2   ;
+    movsldup    XMM1,m128[RBP]  ;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2331,14 +2331,14 @@ L1:					;
 
 void test24()
 {
-	ushort i;
+    ushort i;
 
-	asm
-	{
-	    lea AX, i;
-	    mov i, AX;
-	}
-	assert(cast(ushort)&i == i);
+    asm
+    {
+        lea AX, i;
+        mov i, AX;
+    }
+    assert(cast(ushort)&i == i);
 }
 
 /****************************************************/
@@ -2350,158 +2350,158 @@ void test25()
     long m64;
     M128 m128;
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x66, 0x0F, 0x7E, 0xC1,    	// movd	ECX,XMM0
-	0x66, 0x0F, 0x7E, 0xC9,    	// movd	ECX,XMM1
-	0x66, 0x0F, 0x7E, 0xD1,    	// movd	ECX,XMM2
-	0x66, 0x0F, 0x7E, 0xD9,    	// movd	ECX,XMM3
-	0x66, 0x0F, 0x7E, 0xE1,    	// movd	ECX,XMM4
-	0x66, 0x0F, 0x7E, 0xE9,    	// movd	ECX,XMM5
-	0x66, 0x0F, 0x7E, 0xF1,    	// movd	ECX,XMM6
-	0x66, 0x0F, 0x7E, 0xF9,    	// movd	ECX,XMM7
-	0x0F, 0x7E, 0xC1,	    	// movd	ECX,MM0
-	0x0F, 0x7E, 0xC9,	    	// movd	ECX,MM1
-	0x0F, 0x7E, 0xD1,	    	// movd	ECX,MM2
-	0x0F, 0x7E, 0xD9,	    	// movd	ECX,MM3
-	0x0F, 0x7E, 0xE1,	    	// movd	ECX,MM4
-	0x0F, 0x7E, 0xE9,	    	// movd	ECX,MM5
-	0x0F, 0x7E, 0xF1,	    	// movd	ECX,MM6
-	0x0F, 0x7E, 0xF9,	    	// movd	ECX,MM7
-	0x66, 0x0F, 0x6E, 0xC1,    	// movd	XMM0,ECX
-	0x66, 0x0F, 0x6E, 0xC9,    	// movd	XMM1,ECX
-	0x66, 0x0F, 0x6E, 0xD1,    	// movd	XMM2,ECX
-	0x66, 0x0F, 0x6E, 0xD9,    	// movd	XMM3,ECX
-	0x66, 0x0F, 0x6E, 0xE1,    	// movd	XMM4,ECX
-	0x66, 0x0F, 0x6E, 0xE9,    	// movd	XMM5,ECX
-	0x66, 0x0F, 0x6E, 0xF1,    	// movd	XMM6,ECX
-	0x66, 0x0F, 0x6E, 0xF9,    	// movd	XMM7,ECX
-	0x0F, 0x6E, 0xC1,	    	// movd	MM0,ECX
-	0x0F, 0x6E, 0xC9,	    	// movd	MM1,ECX
-	0x0F, 0x6E, 0xD1,	    	// movd	MM2,ECX
-	0x0F, 0x6E, 0xD9,	    	// movd	MM3,ECX
-	0x0F, 0x6E, 0xE1,	    	// movd	MM4,ECX
-	0x0F, 0x6E, 0xE9,	    	// movd	MM5,ECX
-	0x0F, 0x6E, 0xF1,	    	// movd	MM6,ECX
-	0x0F, 0x6E, 0xF9,	    	// movd	MM7,ECX
-	0x66, 0x0F, 0x7E, 0xC8,    	// movd	EAX,XMM1
-	0x66, 0x0F, 0x7E, 0xCB,    	// movd	EBX,XMM1
-	0x66, 0x0F, 0x7E, 0xC9,    	// movd	ECX,XMM1
-	0x66, 0x0F, 0x7E, 0xCA,    	// movd	EDX,XMM1
-	0x66, 0x0F, 0x7E, 0xCE,    	// movd	ESI,XMM1
-	0x66, 0x0F, 0x7E, 0xCF,    	// movd	EDI,XMM1
-	0x66, 0x0F, 0x7E, 0xCD,    	// movd	EBP,XMM1
-	0x66, 0x0F, 0x7E, 0xCC,    	// movd	ESP,XMM1
-	0x0F, 0x7E, 0xC8,	    	// movd	EAX,MM1
-	0x0F, 0x7E, 0xCB,	    	// movd	EBX,MM1
-	0x0F, 0x7E, 0xC9,	    	// movd	ECX,MM1
-	0x0F, 0x7E, 0xCA,	    	// movd	EDX,MM1
-	0x0F, 0x7E, 0xCE,	    	// movd	ESI,MM1
-	0x0F, 0x7E, 0xCF,	    	// movd	EDI,MM1
-	0x0F, 0x7E, 0xCD,	    	// movd	EBP,MM1
-	0x0F, 0x7E, 0xCC,	    	// movd	ESP,MM1
-	0x66, 0x0F, 0x6E, 0xC8,    	// movd	XMM1,EAX
-	0x66, 0x0F, 0x6E, 0xCB,    	// movd	XMM1,EBX
-	0x66, 0x0F, 0x6E, 0xC9,    	// movd	XMM1,ECX
-	0x66, 0x0F, 0x6E, 0xCA,    	// movd	XMM1,EDX
-	0x66, 0x0F, 0x6E, 0xCE,    	// movd	XMM1,ESI
-	0x66, 0x0F, 0x6E, 0xCF,    	// movd	XMM1,EDI
-	0x66, 0x0F, 0x6E, 0xCD,    	// movd	XMM1,EBP
-	0x66, 0x0F, 0x6E, 0xCC,    	// movd	XMM1,ESP
-	0x0F, 0x6E, 0xC8,	    	// movd	MM1,EAX
-	0x0F, 0x6E, 0xCB,	    	// movd	MM1,EBX
-	0x0F, 0x6E, 0xC9,	    	// movd	MM1,ECX
-	0x0F, 0x6E, 0xCA,	    	// movd	MM1,EDX
-	0x0F, 0x6E, 0xCE,	    	// movd	MM1,ESI
-	0x0F, 0x6E, 0xCF,	    	// movd	MM1,EDI
-	0x0F, 0x6E, 0xCD,	    	// movd	MM1,EBP
-	0x0F, 0x6E, 0xCC,	    	// movd	MM1,ESP
+    0x66, 0x0F, 0x7E, 0xC1,     // movd ECX,XMM0
+    0x66, 0x0F, 0x7E, 0xC9,     // movd ECX,XMM1
+    0x66, 0x0F, 0x7E, 0xD1,     // movd ECX,XMM2
+    0x66, 0x0F, 0x7E, 0xD9,     // movd ECX,XMM3
+    0x66, 0x0F, 0x7E, 0xE1,     // movd ECX,XMM4
+    0x66, 0x0F, 0x7E, 0xE9,     // movd ECX,XMM5
+    0x66, 0x0F, 0x7E, 0xF1,     // movd ECX,XMM6
+    0x66, 0x0F, 0x7E, 0xF9,     // movd ECX,XMM7
+    0x0F, 0x7E, 0xC1,           // movd ECX,MM0
+    0x0F, 0x7E, 0xC9,           // movd ECX,MM1
+    0x0F, 0x7E, 0xD1,           // movd ECX,MM2
+    0x0F, 0x7E, 0xD9,           // movd ECX,MM3
+    0x0F, 0x7E, 0xE1,           // movd ECX,MM4
+    0x0F, 0x7E, 0xE9,           // movd ECX,MM5
+    0x0F, 0x7E, 0xF1,           // movd ECX,MM6
+    0x0F, 0x7E, 0xF9,           // movd ECX,MM7
+    0x66, 0x0F, 0x6E, 0xC1,     // movd XMM0,ECX
+    0x66, 0x0F, 0x6E, 0xC9,     // movd XMM1,ECX
+    0x66, 0x0F, 0x6E, 0xD1,     // movd XMM2,ECX
+    0x66, 0x0F, 0x6E, 0xD9,     // movd XMM3,ECX
+    0x66, 0x0F, 0x6E, 0xE1,     // movd XMM4,ECX
+    0x66, 0x0F, 0x6E, 0xE9,     // movd XMM5,ECX
+    0x66, 0x0F, 0x6E, 0xF1,     // movd XMM6,ECX
+    0x66, 0x0F, 0x6E, 0xF9,     // movd XMM7,ECX
+    0x0F, 0x6E, 0xC1,           // movd MM0,ECX
+    0x0F, 0x6E, 0xC9,           // movd MM1,ECX
+    0x0F, 0x6E, 0xD1,           // movd MM2,ECX
+    0x0F, 0x6E, 0xD9,           // movd MM3,ECX
+    0x0F, 0x6E, 0xE1,           // movd MM4,ECX
+    0x0F, 0x6E, 0xE9,           // movd MM5,ECX
+    0x0F, 0x6E, 0xF1,           // movd MM6,ECX
+    0x0F, 0x6E, 0xF9,           // movd MM7,ECX
+    0x66, 0x0F, 0x7E, 0xC8,     // movd EAX,XMM1
+    0x66, 0x0F, 0x7E, 0xCB,     // movd EBX,XMM1
+    0x66, 0x0F, 0x7E, 0xC9,     // movd ECX,XMM1
+    0x66, 0x0F, 0x7E, 0xCA,     // movd EDX,XMM1
+    0x66, 0x0F, 0x7E, 0xCE,     // movd ESI,XMM1
+    0x66, 0x0F, 0x7E, 0xCF,     // movd EDI,XMM1
+    0x66, 0x0F, 0x7E, 0xCD,     // movd EBP,XMM1
+    0x66, 0x0F, 0x7E, 0xCC,     // movd ESP,XMM1
+    0x0F, 0x7E, 0xC8,           // movd EAX,MM1
+    0x0F, 0x7E, 0xCB,           // movd EBX,MM1
+    0x0F, 0x7E, 0xC9,           // movd ECX,MM1
+    0x0F, 0x7E, 0xCA,           // movd EDX,MM1
+    0x0F, 0x7E, 0xCE,           // movd ESI,MM1
+    0x0F, 0x7E, 0xCF,           // movd EDI,MM1
+    0x0F, 0x7E, 0xCD,           // movd EBP,MM1
+    0x0F, 0x7E, 0xCC,           // movd ESP,MM1
+    0x66, 0x0F, 0x6E, 0xC8,     // movd XMM1,EAX
+    0x66, 0x0F, 0x6E, 0xCB,     // movd XMM1,EBX
+    0x66, 0x0F, 0x6E, 0xC9,     // movd XMM1,ECX
+    0x66, 0x0F, 0x6E, 0xCA,     // movd XMM1,EDX
+    0x66, 0x0F, 0x6E, 0xCE,     // movd XMM1,ESI
+    0x66, 0x0F, 0x6E, 0xCF,     // movd XMM1,EDI
+    0x66, 0x0F, 0x6E, 0xCD,     // movd XMM1,EBP
+    0x66, 0x0F, 0x6E, 0xCC,     // movd XMM1,ESP
+    0x0F, 0x6E, 0xC8,           // movd MM1,EAX
+    0x0F, 0x6E, 0xCB,           // movd MM1,EBX
+    0x0F, 0x6E, 0xC9,           // movd MM1,ECX
+    0x0F, 0x6E, 0xCA,           // movd MM1,EDX
+    0x0F, 0x6E, 0xCE,           // movd MM1,ESI
+    0x0F, 0x6E, 0xCF,           // movd MM1,EDI
+    0x0F, 0x6E, 0xCD,           // movd MM1,EBP
+    0x0F, 0x6E, 0xCC,           // movd MM1,ESP
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	movd ECX, XMM0;
-	movd ECX, XMM1;
-	movd ECX, XMM2;
-	movd ECX, XMM3;
-	movd ECX, XMM4;
-	movd ECX, XMM5;
-	movd ECX, XMM6;
-	movd ECX, XMM7;
+    movd ECX, XMM0;
+    movd ECX, XMM1;
+    movd ECX, XMM2;
+    movd ECX, XMM3;
+    movd ECX, XMM4;
+    movd ECX, XMM5;
+    movd ECX, XMM6;
+    movd ECX, XMM7;
 
-	movd ECX, MM0;
-	movd ECX, MM1;
-	movd ECX, MM2;
-	movd ECX, MM3;
-	movd ECX, MM4;
-	movd ECX, MM5;
-	movd ECX, MM6;
-	movd ECX, MM7;
+    movd ECX, MM0;
+    movd ECX, MM1;
+    movd ECX, MM2;
+    movd ECX, MM3;
+    movd ECX, MM4;
+    movd ECX, MM5;
+    movd ECX, MM6;
+    movd ECX, MM7;
 
-	movd XMM0, ECX;
-	movd XMM1, ECX;
-	movd XMM2, ECX;
-	movd XMM3, ECX;
-	movd XMM4, ECX;
-	movd XMM5, ECX;
-	movd XMM6, ECX;
-	movd XMM7, ECX;
+    movd XMM0, ECX;
+    movd XMM1, ECX;
+    movd XMM2, ECX;
+    movd XMM3, ECX;
+    movd XMM4, ECX;
+    movd XMM5, ECX;
+    movd XMM6, ECX;
+    movd XMM7, ECX;
 
-	movd MM0, ECX;
-	movd MM1, ECX;
-	movd MM2, ECX;
-	movd MM3, ECX;
-	movd MM4, ECX;
-	movd MM5, ECX;
-	movd MM6, ECX;
-	movd MM7, ECX;
+    movd MM0, ECX;
+    movd MM1, ECX;
+    movd MM2, ECX;
+    movd MM3, ECX;
+    movd MM4, ECX;
+    movd MM5, ECX;
+    movd MM6, ECX;
+    movd MM7, ECX;
 
-	movd EAX, XMM1;
-	movd EBX, XMM1;
-	movd ECX, XMM1;
-	movd EDX, XMM1;
-	movd ESI, XMM1;
-	movd EDI, XMM1;
-	movd EBP, XMM1;
-	movd ESP, XMM1;
+    movd EAX, XMM1;
+    movd EBX, XMM1;
+    movd ECX, XMM1;
+    movd EDX, XMM1;
+    movd ESI, XMM1;
+    movd EDI, XMM1;
+    movd EBP, XMM1;
+    movd ESP, XMM1;
 
-	movd EAX, MM1;
-	movd EBX, MM1;
-	movd ECX, MM1;
-	movd EDX, MM1;
-	movd ESI, MM1;
-	movd EDI, MM1;
-	movd EBP, MM1;
-	movd ESP, MM1;
+    movd EAX, MM1;
+    movd EBX, MM1;
+    movd ECX, MM1;
+    movd EDX, MM1;
+    movd ESI, MM1;
+    movd EDI, MM1;
+    movd EBP, MM1;
+    movd ESP, MM1;
 
-	movd XMM1, EAX;
-	movd XMM1, EBX;
-	movd XMM1, ECX;
-	movd XMM1, EDX;
-	movd XMM1, ESI;
-	movd XMM1, EDI;
-	movd XMM1, EBP;
-	movd XMM1, ESP;
+    movd XMM1, EAX;
+    movd XMM1, EBX;
+    movd XMM1, ECX;
+    movd XMM1, EDX;
+    movd XMM1, ESI;
+    movd XMM1, EDI;
+    movd XMM1, EBP;
+    movd XMM1, ESP;
 
-	movd MM1, EAX;
-	movd MM1, EBX;
-	movd MM1, ECX;
-	movd MM1, EDX;
-	movd MM1, ESI;
-	movd MM1, EDI;
-	movd MM1, EBP;
-	movd MM1, ESP;
+    movd MM1, EAX;
+    movd MM1, EBX;
+    movd MM1, ECX;
+    movd MM1, EDX;
+    movd MM1, ESI;
+    movd MM1, EDI;
+    movd MM1, EBP;
+    movd MM1, ESP;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2537,8 +2537,8 @@ void test27()
     {
     asm
     {
-	    movdqu XMM0, a;
-	    pslldq XMM0, 2;
+        movdqu XMM0, a;
+        pslldq XMM0, 2;
     }
     }
 }
@@ -2573,23 +2573,23 @@ void test28()
 {
 //    version (Windows)
 //    {
-	cfloat[4] z = void;
-	static const ubyte[8] A = [3, 4, 9, 0, 1, 3, 7, 2];
-	ubyte[8] b;
+    cfloat[4] z = void;
+    static const ubyte[8] A = [3, 4, 9, 0, 1, 3, 7, 2];
+    ubyte[8] b;
 
-	asm{
-		movq MM0, z;
-		movq MM0, A;
-		movq b, MM0;
-	}
+    asm{
+        movq MM0, z;
+        movq MM0, A;
+        movq b, MM0;
+    }
 
-	for(size_t i = 0; i < A.length; i++)
-	{
-		if(A[i] != b[i])
-		{
-			assert(0);
-		}
-	}
+    for(size_t i = 0; i < A.length; i++)
+    {
+        if(A[i] != b[i])
+        {
+            assert(0);
+        }
+    }
 //    }
 }
 
@@ -2602,16 +2602,16 @@ void test29()
     int* x;
     asm
     {
-	push offsetof bar29;
-	pop EAX;
-	mov x, EAX;
+    push offsetof bar29;
+    pop EAX;
+    mov x, EAX;
     }
     assert(*x == 3);
 
     asm
     {
-	mov EAX, offsetof bar29;
-	mov x, EAX;
+    mov EAX, offsetof bar29;
+    mov x, EAX;
     }
     assert(*x == 3);
 }
@@ -2622,11 +2622,11 @@ const int CONST_OFFSET30 = 10;
 
 void foo30()
 {
-	asm
-	{
-		mov EDX, 10;
-		mov EAX, [RDX + CONST_OFFSET30];
-	}
+    asm
+    {
+        mov EDX, 10;
+        mov EAX, [RDX + CONST_OFFSET30];
+    }
 }
 
 void test30()
@@ -2638,35 +2638,35 @@ void test30()
 void test31()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xF7, 0xD8,       	// neg	EAX
-	0x74, 0x04,       	// je	L8
-	0xF7, 0xD8,       	// neg	EAX
-	0x75, 0xFC,       	// jne	L4
-	0xFF, 0xC0,       	// inc	EAX
+    0xF7, 0xD8,         // neg  EAX
+    0x74, 0x04,         // je   L8
+    0xF7, 0xD8,         // neg  EAX
+    0x75, 0xFC,         // jne  L4
+    0xFF, 0xC0,         // inc  EAX
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	neg     EAX;
-	je      L2;
+    neg     EAX;
+    je      L2;
     L3:
-	neg     EAX;
-	jne     L3;
+    neg     EAX;
+    jne     L3;
     L2:
-	inc     EAX;
+    inc     EAX;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2793,8 +2793,8 @@ void test33()
 
     asm
     {
-	mov EAX, x;
-	mov EAX, y;
+    mov EAX, x;
+    mov EAX, y;
     }
 }
 
@@ -2822,10 +2822,10 @@ void test35()
 
     asm
     {
-	mov ECX, foo35		;
-	mov q, ECX		;
-	lea EDX, foo35		;
-	mov p, EDX		;
+    mov ECX, foo35      ;
+    mov q, ECX      ;
+    lea EDX, foo35      ;
+    mov p, EDX      ;
     }
     assert(p == &foo35);
     assert(q == *cast(ulong *)p);
@@ -2909,8 +2909,8 @@ void test40()
     printf("");
     const string s = "abcdefghi";
     asm
-    {	jmp L1;
-	ds s;
+    {   jmp L1;
+    ds s;
     L1:;
     }
     end: ;
@@ -2921,19 +2921,19 @@ void test40()
 void test41()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x66,0x0F,0x28,0x0C,0x06, 	// movapd	XMM1,[RAX][RSI]
-	0x66,0x0F,0x28,0x0C,0x06, 	// movapd	XMM1,[RAX][RSI]
-	0x66,0x0F,0x28,0x0C,0x46, 	// movapd	XMM1,[RAX*2][RSI]
-	0x66,0x0F,0x28,0x0C,0x86, 	// movapd	XMM1,[RAX*4][RSI]
-	0x66,0x0F,0x28,0x0C,0xC6, 	// movapd	XMM1,[RAX*8][RSI]
+    0x66,0x0F,0x28,0x0C,0x06,   // movapd   XMM1,[RAX][RSI]
+    0x66,0x0F,0x28,0x0C,0x06,   // movapd   XMM1,[RAX][RSI]
+    0x66,0x0F,0x28,0x0C,0x46,   // movapd   XMM1,[RAX*2][RSI]
+    0x66,0x0F,0x28,0x0C,0x86,   // movapd   XMM1,[RAX*4][RSI]
+    0x66,0x0F,0x28,0x0C,0xC6,   // movapd   XMM1,[RAX*8][RSI]
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
         movapd XMM1, [RSI+RAX];
         movapd XMM1, [RSI+1*RAX];
@@ -2941,13 +2941,13 @@ void test41()
         movapd XMM1, [RSI+4*RAX];
         movapd XMM1, [RSI+8*RAX];
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -2963,7 +2963,7 @@ void test42()
 {
     asm
     {
-	mov EAX, enumeration42;
+    mov EAX, enumeration42;
     }
 }
 
@@ -3010,41 +3010,41 @@ void test44()
 void test45()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xDA, 0xC0,       // fcmovb	ST(0)
-	0xDA, 0xC1,       // fcmovb
-	0xDA, 0xCA,       // fcmove	ST(2)
-	0xDA, 0xD3,       // fcmovbe	ST(3)
-	0xDA, 0xDC,       // fcmovu	ST(4)
-	0xDB, 0xC5,       // fcmovnb	ST(5)
-	0xDB, 0xCE,       // fcmovne	ST(6)
-	0xDB, 0xD7,       // fcmovnbe	ST(7)
-	0xDB, 0xD9,       // fcmovnu
+    0xDA, 0xC0,       // fcmovb ST(0)
+    0xDA, 0xC1,       // fcmovb
+    0xDA, 0xCA,       // fcmove ST(2)
+    0xDA, 0xD3,       // fcmovbe    ST(3)
+    0xDA, 0xDC,       // fcmovu ST(4)
+    0xDB, 0xC5,       // fcmovnb    ST(5)
+    0xDB, 0xCE,       // fcmovne    ST(6)
+    0xDB, 0xD7,       // fcmovnbe   ST(7)
+    0xDB, 0xD9,       // fcmovnu
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	fcmovb   ST, ST(0);
-	fcmovb   ST, ST(1);
-	fcmove   ST, ST(2);
-	fcmovbe  ST, ST(3);
-	fcmovu   ST, ST(4);
-	fcmovnb  ST, ST(5);
-	fcmovne  ST, ST(6);
-	fcmovnbe ST, ST(7);
-	fcmovnu  ST, ST(1);
+    fcmovb   ST, ST(0);
+    fcmovb   ST, ST(1);
+    fcmove   ST, ST(2);
+    fcmovbe  ST, ST(3);
+    fcmovu   ST, ST(4);
+    fcmovnb  ST, ST(5);
+    fcmovne  ST, ST(6);
+    fcmovnbe ST, ST(7);
+    fcmovnu  ST, ST(1);
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -3053,37 +3053,37 @@ L1:					;
 void test46()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x66, 0x0F, 0x3A, 0x41, 0xCA, 0x08,	// dppd XMM1,XMM2,8
-	0x66, 0x0F, 0x3A, 0x40, 0xDC, 0x07,	// dpps XMM3,XMM4,7
-	0x66, 0x0F, 0x50, 0xF3,			// movmskpd ESI,XMM3
-	0x66, 0x0F, 0x50, 0xC7,			// movmskpd EAX,XMM7
-	0x0F, 0x50, 0xC7,			// movmskps EAX,XMM7
-	0x0F, 0xD7, 0xC7,			// pmovmskb EAX,MM7
-	0x66, 0x0F, 0xD7, 0xC7,			// pmovmskb EAX,XMM7
+    0x66, 0x0F, 0x3A, 0x41, 0xCA, 0x08, // dppd XMM1,XMM2,8
+    0x66, 0x0F, 0x3A, 0x40, 0xDC, 0x07, // dpps XMM3,XMM4,7
+    0x66, 0x0F, 0x50, 0xF3,         // movmskpd ESI,XMM3
+    0x66, 0x0F, 0x50, 0xC7,         // movmskpd EAX,XMM7
+    0x0F, 0x50, 0xC7,           // movmskps EAX,XMM7
+    0x0F, 0xD7, 0xC7,           // pmovmskb EAX,MM7
+    0x66, 0x0F, 0xD7, 0xC7,         // pmovmskb EAX,XMM7
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	dppd	XMM1,XMM2,8		;
-	dpps	XMM3,XMM4,7		;
-	movmskpd ESI,XMM3		;
-	movmskpd EAX,XMM7		;
-	movmskps EAX,XMM7		;
-	pmovmskb EAX,MM7		;
-	pmovmskb EAX,XMM7		;
+    dppd    XMM1,XMM2,8     ;
+    dpps    XMM3,XMM4,7     ;
+    movmskpd ESI,XMM3       ;
+    movmskpd EAX,XMM7       ;
+    movmskps EAX,XMM7       ;
+    pmovmskb EAX,MM7        ;
+    pmovmskb EAX,XMM7       ;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -3129,438 +3129,438 @@ void test48()
 void test49()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x00, 0xC0,       	// add	AL,AL
-	0x00, 0xD8,       	// add	AL,BL
-	0x00, 0xC8,       	// add	AL,CL
-	0x00, 0xD0,       	// add	AL,DL
-	0x00, 0xE0,       	// add	AL,AH
-	0x00, 0xF8,       	// add	AL,BH
-	0x00, 0xE8,       	// add	AL,CH
-	0x00, 0xF0,       	// add	AL,DH
-	0x00, 0xC4,       	// add	AH,AL
-	0x00, 0xDC,       	// add	AH,BL
-	0x00, 0xCC,       	// add	AH,CL
-	0x00, 0xD4,       	// add	AH,DL
-	0x00, 0xE4,       	// add	AH,AH
-	0x00, 0xFC,       	// add	AH,BH
-	0x00, 0xEC,       	// add	AH,CH
-	0x00, 0xF4,       	// add	AH,DH
-	0x00, 0xC3,       	// add	BL,AL
-	0x00, 0xDB,       	// add	BL,BL
-	0x00, 0xCB,       	// add	BL,CL
-	0x00, 0xD3,       	// add	BL,DL
-	0x00, 0xE3,       	// add	BL,AH
-	0x00, 0xFB,       	// add	BL,BH
-	0x00, 0xEB,       	// add	BL,CH
-	0x00, 0xF3,       	// add	BL,DH
-	0x00, 0xC7,       	// add	BH,AL
-	0x00, 0xDF,       	// add	BH,BL
-	0x00, 0xCF,       	// add	BH,CL
-	0x00, 0xD7,       	// add	BH,DL
-	0x00, 0xE7,       	// add	BH,AH
-	0x00, 0xFF,       	// add	BH,BH
-	0x00, 0xEF,       	// add	BH,CH
-	0x00, 0xF7,       	// add	BH,DH
-	0x00, 0xC1,       	// add	CL,AL
-	0x00, 0xD9,       	// add	CL,BL
-	0x00, 0xC9,       	// add	CL,CL
-	0x00, 0xD1,       	// add	CL,DL
-	0x00, 0xE1,       	// add	CL,AH
-	0x00, 0xF9,       	// add	CL,BH
-	0x00, 0xE9,       	// add	CL,CH
-	0x00, 0xF1,       	// add	CL,DH
-	0x00, 0xC5,       	// add	CH,AL
-	0x00, 0xDD,       	// add	CH,BL
-	0x00, 0xCD,       	// add	CH,CL
-	0x00, 0xD5,       	// add	CH,DL
-	0x00, 0xE5,       	// add	CH,AH
-	0x00, 0xFD,       	// add	CH,BH
-	0x00, 0xED,       	// add	CH,CH
-	0x00, 0xF5,       	// add	CH,DH
-	0x00, 0xC2,       	// add	DL,AL
-	0x00, 0xDA,       	// add	DL,BL
-	0x00, 0xCA,       	// add	DL,CL
-	0x00, 0xD2,       	// add	DL,DL
-	0x00, 0xE2,       	// add	DL,AH
-	0x00, 0xFA,       	// add	DL,BH
-	0x00, 0xEA,       	// add	DL,CH
-	0x00, 0xF2,       	// add	DL,DH
-	0x00, 0xC6,       	// add	DH,AL
-	0x00, 0xDE,       	// add	DH,BL
-	0x00, 0xCE,       	// add	DH,CL
-	0x00, 0xD6,       	// add	DH,DL
-	0x00, 0xE6,       	// add	DH,AH
-	0x00, 0xFE,       	// add	DH,BH
-	0x00, 0xEE,       	// add	DH,CH
-	0x00, 0xF6,       	// add	DH,DH
-	0x66, 0x01, 0xC0,      	// add	AX,AX
-	0x66, 0x01, 0xD8,      	// add	AX,BX
-	0x66, 0x01, 0xC8,      	// add	AX,CX
-	0x66, 0x01, 0xD0,      	// add	AX,DX
-	0x66, 0x01, 0xF0,      	// add	AX,SI
-	0x66, 0x01, 0xF8,      	// add	AX,DI
-	0x66, 0x01, 0xE8,      	// add	AX,BP
-	0x66, 0x01, 0xE0,      	// add	AX,SP
-	0x66, 0x01, 0xC3,      	// add	BX,AX
-	0x66, 0x01, 0xDB,      	// add	BX,BX
-	0x66, 0x01, 0xCB,      	// add	BX,CX
-	0x66, 0x01, 0xD3,      	// add	BX,DX
-	0x66, 0x01, 0xF3,      	// add	BX,SI
-	0x66, 0x01, 0xFB,      	// add	BX,DI
-	0x66, 0x01, 0xEB,      	// add	BX,BP
-	0x66, 0x01, 0xE3,      	// add	BX,SP
-	0x66, 0x01, 0xC1,      	// add	CX,AX
-	0x66, 0x01, 0xD9,      	// add	CX,BX
-	0x66, 0x01, 0xC9,      	// add	CX,CX
-	0x66, 0x01, 0xD1,      	// add	CX,DX
-	0x66, 0x01, 0xF1,      	// add	CX,SI
-	0x66, 0x01, 0xF9,      	// add	CX,DI
-	0x66, 0x01, 0xE9,      	// add	CX,BP
-	0x66, 0x01, 0xE1,      	// add	CX,SP
-	0x66, 0x01, 0xC2,      	// add	DX,AX
-	0x66, 0x01, 0xDA,      	// add	DX,BX
-	0x66, 0x01, 0xCA,      	// add	DX,CX
-	0x66, 0x01, 0xD2,      	// add	DX,DX
-	0x66, 0x01, 0xF2,      	// add	DX,SI
-	0x66, 0x01, 0xFA,      	// add	DX,DI
-	0x66, 0x01, 0xEA,      	// add	DX,BP
-	0x66, 0x01, 0xE2,      	// add	DX,SP
-	0x66, 0x01, 0xC6,      	// add	SI,AX
-	0x66, 0x01, 0xDE,      	// add	SI,BX
-	0x66, 0x01, 0xCE,      	// add	SI,CX
-	0x66, 0x01, 0xD6,      	// add	SI,DX
-	0x66, 0x01, 0xF6,      	// add	SI,SI
-	0x66, 0x01, 0xFE,      	// add	SI,DI
-	0x66, 0x01, 0xEE,      	// add	SI,BP
-	0x66, 0x01, 0xE6,      	// add	SI,SP
-	0x66, 0x01, 0xC7,      	// add	DI,AX
-	0x66, 0x01, 0xDF,      	// add	DI,BX
-	0x66, 0x01, 0xCF,      	// add	DI,CX
-	0x66, 0x01, 0xD7,      	// add	DI,DX
-	0x66, 0x01, 0xF7,      	// add	DI,SI
-	0x66, 0x01, 0xFF,      	// add	DI,DI
-	0x66, 0x01, 0xEF,      	// add	DI,BP
-	0x66, 0x01, 0xE7,      	// add	DI,SP
-	0x66, 0x01, 0xC5,      	// add	BP,AX
-	0x66, 0x01, 0xDD,      	// add	BP,BX
-	0x66, 0x01, 0xCD,      	// add	BP,CX
-	0x66, 0x01, 0xD5,      	// add	BP,DX
-	0x66, 0x01, 0xF5,      	// add	BP,SI
-	0x66, 0x01, 0xFD,      	// add	BP,DI
-	0x66, 0x01, 0xED,      	// add	BP,BP
-	0x66, 0x01, 0xE5,      	// add	BP,SP
-	0x66, 0x01, 0xC4,      	// add	SP,AX
-	0x66, 0x01, 0xDC,      	// add	SP,BX
-	0x66, 0x01, 0xCC,      	// add	SP,CX
-	0x66, 0x01, 0xD4,      	// add	SP,DX
-	0x66, 0x01, 0xF4,      	// add	SP,SI
-	0x66, 0x01, 0xFC,      	// add	SP,DI
-	0x66, 0x01, 0xEC,      	// add	SP,BP
-	0x66, 0x01, 0xE4,      	// add	SP,SP
-	0x01, 0xC0,       	// add	EAX,EAX
-	0x01, 0xD8,       	// add	EAX,EBX
-	0x01, 0xC8,       	// add	EAX,ECX
-	0x01, 0xD0,       	// add	EAX,EDX
-	0x01, 0xF0,       	// add	EAX,ESI
-	0x01, 0xF8,       	// add	EAX,EDI
-	0x01, 0xE8,       	// add	EAX,EBP
-	0x01, 0xE0,       	// add	EAX,ESP
-	0x01, 0xC3,       	// add	EBX,EAX
-	0x01, 0xDB,       	// add	EBX,EBX
-	0x01, 0xCB,       	// add	EBX,ECX
-	0x01, 0xD3,       	// add	EBX,EDX
-	0x01, 0xF3,       	// add	EBX,ESI
-	0x01, 0xFB,       	// add	EBX,EDI
-	0x01, 0xEB,       	// add	EBX,EBP
-	0x01, 0xE3,       	// add	EBX,ESP
-	0x01, 0xC1,       	// add	ECX,EAX
-	0x01, 0xD9,       	// add	ECX,EBX
-	0x01, 0xC9,       	// add	ECX,ECX
-	0x01, 0xD1,       	// add	ECX,EDX
-	0x01, 0xF1,       	// add	ECX,ESI
-	0x01, 0xF9,       	// add	ECX,EDI
-	0x01, 0xE9,       	// add	ECX,EBP
-	0x01, 0xE1,       	// add	ECX,ESP
-	0x01, 0xC2,       	// add	EDX,EAX
-	0x01, 0xDA,       	// add	EDX,EBX
-	0x01, 0xCA,       	// add	EDX,ECX
-	0x01, 0xD2,       	// add	EDX,EDX
-	0x01, 0xF2,       	// add	EDX,ESI
-	0x01, 0xFA,       	// add	EDX,EDI
-	0x01, 0xEA,       	// add	EDX,EBP
-	0x01, 0xE2,       	// add	EDX,ESP
-	0x01, 0xC6,       	// add	ESI,EAX
-	0x01, 0xDE,       	// add	ESI,EBX
-	0x01, 0xCE,       	// add	ESI,ECX
-	0x01, 0xD6,       	// add	ESI,EDX
-	0x01, 0xF6,       	// add	ESI,ESI
-	0x01, 0xFE,       	// add	ESI,EDI
-	0x01, 0xEE,       	// add	ESI,EBP
-	0x01, 0xE6,       	// add	ESI,ESP
-	0x01, 0xC7,       	// add	EDI,EAX
-	0x01, 0xDF,       	// add	EDI,EBX
-	0x01, 0xCF,       	// add	EDI,ECX
-	0x01, 0xD7,       	// add	EDI,EDX
-	0x01, 0xF7,       	// add	EDI,ESI
-	0x01, 0xFF,       	// add	EDI,EDI
-	0x01, 0xEF,       	// add	EDI,EBP
-	0x01, 0xE7,       	// add	EDI,ESP
-	0x01, 0xC5,       	// add	EBP,EAX
-	0x01, 0xDD,       	// add	EBP,EBX
-	0x01, 0xCD,       	// add	EBP,ECX
-	0x01, 0xD5,       	// add	EBP,EDX
-	0x01, 0xF5,       	// add	EBP,ESI
-	0x01, 0xFD,       	// add	EBP,EDI
-	0x01, 0xED,       	// add	EBP,EBP
-	0x01, 0xE5,       	// add	EBP,ESP
-	0x01, 0xC4,       	// add	ESP,EAX
-	0x01, 0xDC,       	// add	ESP,EBX
-	0x01, 0xCC,       	// add	ESP,ECX
-	0x01, 0xD4,       	// add	ESP,EDX
-	0x01, 0xF4,       	// add	ESP,ESI
-	0x01, 0xFC,       	// add	ESP,EDI
-	0x01, 0xEC,       	// add	ESP,EBP
-	0x01, 0xE4,       	// add	ESP,ESP
+    0x00, 0xC0,         // add  AL,AL
+    0x00, 0xD8,         // add  AL,BL
+    0x00, 0xC8,         // add  AL,CL
+    0x00, 0xD0,         // add  AL,DL
+    0x00, 0xE0,         // add  AL,AH
+    0x00, 0xF8,         // add  AL,BH
+    0x00, 0xE8,         // add  AL,CH
+    0x00, 0xF0,         // add  AL,DH
+    0x00, 0xC4,         // add  AH,AL
+    0x00, 0xDC,         // add  AH,BL
+    0x00, 0xCC,         // add  AH,CL
+    0x00, 0xD4,         // add  AH,DL
+    0x00, 0xE4,         // add  AH,AH
+    0x00, 0xFC,         // add  AH,BH
+    0x00, 0xEC,         // add  AH,CH
+    0x00, 0xF4,         // add  AH,DH
+    0x00, 0xC3,         // add  BL,AL
+    0x00, 0xDB,         // add  BL,BL
+    0x00, 0xCB,         // add  BL,CL
+    0x00, 0xD3,         // add  BL,DL
+    0x00, 0xE3,         // add  BL,AH
+    0x00, 0xFB,         // add  BL,BH
+    0x00, 0xEB,         // add  BL,CH
+    0x00, 0xF3,         // add  BL,DH
+    0x00, 0xC7,         // add  BH,AL
+    0x00, 0xDF,         // add  BH,BL
+    0x00, 0xCF,         // add  BH,CL
+    0x00, 0xD7,         // add  BH,DL
+    0x00, 0xE7,         // add  BH,AH
+    0x00, 0xFF,         // add  BH,BH
+    0x00, 0xEF,         // add  BH,CH
+    0x00, 0xF7,         // add  BH,DH
+    0x00, 0xC1,         // add  CL,AL
+    0x00, 0xD9,         // add  CL,BL
+    0x00, 0xC9,         // add  CL,CL
+    0x00, 0xD1,         // add  CL,DL
+    0x00, 0xE1,         // add  CL,AH
+    0x00, 0xF9,         // add  CL,BH
+    0x00, 0xE9,         // add  CL,CH
+    0x00, 0xF1,         // add  CL,DH
+    0x00, 0xC5,         // add  CH,AL
+    0x00, 0xDD,         // add  CH,BL
+    0x00, 0xCD,         // add  CH,CL
+    0x00, 0xD5,         // add  CH,DL
+    0x00, 0xE5,         // add  CH,AH
+    0x00, 0xFD,         // add  CH,BH
+    0x00, 0xED,         // add  CH,CH
+    0x00, 0xF5,         // add  CH,DH
+    0x00, 0xC2,         // add  DL,AL
+    0x00, 0xDA,         // add  DL,BL
+    0x00, 0xCA,         // add  DL,CL
+    0x00, 0xD2,         // add  DL,DL
+    0x00, 0xE2,         // add  DL,AH
+    0x00, 0xFA,         // add  DL,BH
+    0x00, 0xEA,         // add  DL,CH
+    0x00, 0xF2,         // add  DL,DH
+    0x00, 0xC6,         // add  DH,AL
+    0x00, 0xDE,         // add  DH,BL
+    0x00, 0xCE,         // add  DH,CL
+    0x00, 0xD6,         // add  DH,DL
+    0x00, 0xE6,         // add  DH,AH
+    0x00, 0xFE,         // add  DH,BH
+    0x00, 0xEE,         // add  DH,CH
+    0x00, 0xF6,         // add  DH,DH
+    0x66, 0x01, 0xC0,       // add  AX,AX
+    0x66, 0x01, 0xD8,       // add  AX,BX
+    0x66, 0x01, 0xC8,       // add  AX,CX
+    0x66, 0x01, 0xD0,       // add  AX,DX
+    0x66, 0x01, 0xF0,       // add  AX,SI
+    0x66, 0x01, 0xF8,       // add  AX,DI
+    0x66, 0x01, 0xE8,       // add  AX,BP
+    0x66, 0x01, 0xE0,       // add  AX,SP
+    0x66, 0x01, 0xC3,       // add  BX,AX
+    0x66, 0x01, 0xDB,       // add  BX,BX
+    0x66, 0x01, 0xCB,       // add  BX,CX
+    0x66, 0x01, 0xD3,       // add  BX,DX
+    0x66, 0x01, 0xF3,       // add  BX,SI
+    0x66, 0x01, 0xFB,       // add  BX,DI
+    0x66, 0x01, 0xEB,       // add  BX,BP
+    0x66, 0x01, 0xE3,       // add  BX,SP
+    0x66, 0x01, 0xC1,       // add  CX,AX
+    0x66, 0x01, 0xD9,       // add  CX,BX
+    0x66, 0x01, 0xC9,       // add  CX,CX
+    0x66, 0x01, 0xD1,       // add  CX,DX
+    0x66, 0x01, 0xF1,       // add  CX,SI
+    0x66, 0x01, 0xF9,       // add  CX,DI
+    0x66, 0x01, 0xE9,       // add  CX,BP
+    0x66, 0x01, 0xE1,       // add  CX,SP
+    0x66, 0x01, 0xC2,       // add  DX,AX
+    0x66, 0x01, 0xDA,       // add  DX,BX
+    0x66, 0x01, 0xCA,       // add  DX,CX
+    0x66, 0x01, 0xD2,       // add  DX,DX
+    0x66, 0x01, 0xF2,       // add  DX,SI
+    0x66, 0x01, 0xFA,       // add  DX,DI
+    0x66, 0x01, 0xEA,       // add  DX,BP
+    0x66, 0x01, 0xE2,       // add  DX,SP
+    0x66, 0x01, 0xC6,       // add  SI,AX
+    0x66, 0x01, 0xDE,       // add  SI,BX
+    0x66, 0x01, 0xCE,       // add  SI,CX
+    0x66, 0x01, 0xD6,       // add  SI,DX
+    0x66, 0x01, 0xF6,       // add  SI,SI
+    0x66, 0x01, 0xFE,       // add  SI,DI
+    0x66, 0x01, 0xEE,       // add  SI,BP
+    0x66, 0x01, 0xE6,       // add  SI,SP
+    0x66, 0x01, 0xC7,       // add  DI,AX
+    0x66, 0x01, 0xDF,       // add  DI,BX
+    0x66, 0x01, 0xCF,       // add  DI,CX
+    0x66, 0x01, 0xD7,       // add  DI,DX
+    0x66, 0x01, 0xF7,       // add  DI,SI
+    0x66, 0x01, 0xFF,       // add  DI,DI
+    0x66, 0x01, 0xEF,       // add  DI,BP
+    0x66, 0x01, 0xE7,       // add  DI,SP
+    0x66, 0x01, 0xC5,       // add  BP,AX
+    0x66, 0x01, 0xDD,       // add  BP,BX
+    0x66, 0x01, 0xCD,       // add  BP,CX
+    0x66, 0x01, 0xD5,       // add  BP,DX
+    0x66, 0x01, 0xF5,       // add  BP,SI
+    0x66, 0x01, 0xFD,       // add  BP,DI
+    0x66, 0x01, 0xED,       // add  BP,BP
+    0x66, 0x01, 0xE5,       // add  BP,SP
+    0x66, 0x01, 0xC4,       // add  SP,AX
+    0x66, 0x01, 0xDC,       // add  SP,BX
+    0x66, 0x01, 0xCC,       // add  SP,CX
+    0x66, 0x01, 0xD4,       // add  SP,DX
+    0x66, 0x01, 0xF4,       // add  SP,SI
+    0x66, 0x01, 0xFC,       // add  SP,DI
+    0x66, 0x01, 0xEC,       // add  SP,BP
+    0x66, 0x01, 0xE4,       // add  SP,SP
+    0x01, 0xC0,         // add  EAX,EAX
+    0x01, 0xD8,         // add  EAX,EBX
+    0x01, 0xC8,         // add  EAX,ECX
+    0x01, 0xD0,         // add  EAX,EDX
+    0x01, 0xF0,         // add  EAX,ESI
+    0x01, 0xF8,         // add  EAX,EDI
+    0x01, 0xE8,         // add  EAX,EBP
+    0x01, 0xE0,         // add  EAX,ESP
+    0x01, 0xC3,         // add  EBX,EAX
+    0x01, 0xDB,         // add  EBX,EBX
+    0x01, 0xCB,         // add  EBX,ECX
+    0x01, 0xD3,         // add  EBX,EDX
+    0x01, 0xF3,         // add  EBX,ESI
+    0x01, 0xFB,         // add  EBX,EDI
+    0x01, 0xEB,         // add  EBX,EBP
+    0x01, 0xE3,         // add  EBX,ESP
+    0x01, 0xC1,         // add  ECX,EAX
+    0x01, 0xD9,         // add  ECX,EBX
+    0x01, 0xC9,         // add  ECX,ECX
+    0x01, 0xD1,         // add  ECX,EDX
+    0x01, 0xF1,         // add  ECX,ESI
+    0x01, 0xF9,         // add  ECX,EDI
+    0x01, 0xE9,         // add  ECX,EBP
+    0x01, 0xE1,         // add  ECX,ESP
+    0x01, 0xC2,         // add  EDX,EAX
+    0x01, 0xDA,         // add  EDX,EBX
+    0x01, 0xCA,         // add  EDX,ECX
+    0x01, 0xD2,         // add  EDX,EDX
+    0x01, 0xF2,         // add  EDX,ESI
+    0x01, 0xFA,         // add  EDX,EDI
+    0x01, 0xEA,         // add  EDX,EBP
+    0x01, 0xE2,         // add  EDX,ESP
+    0x01, 0xC6,         // add  ESI,EAX
+    0x01, 0xDE,         // add  ESI,EBX
+    0x01, 0xCE,         // add  ESI,ECX
+    0x01, 0xD6,         // add  ESI,EDX
+    0x01, 0xF6,         // add  ESI,ESI
+    0x01, 0xFE,         // add  ESI,EDI
+    0x01, 0xEE,         // add  ESI,EBP
+    0x01, 0xE6,         // add  ESI,ESP
+    0x01, 0xC7,         // add  EDI,EAX
+    0x01, 0xDF,         // add  EDI,EBX
+    0x01, 0xCF,         // add  EDI,ECX
+    0x01, 0xD7,         // add  EDI,EDX
+    0x01, 0xF7,         // add  EDI,ESI
+    0x01, 0xFF,         // add  EDI,EDI
+    0x01, 0xEF,         // add  EDI,EBP
+    0x01, 0xE7,         // add  EDI,ESP
+    0x01, 0xC5,         // add  EBP,EAX
+    0x01, 0xDD,         // add  EBP,EBX
+    0x01, 0xCD,         // add  EBP,ECX
+    0x01, 0xD5,         // add  EBP,EDX
+    0x01, 0xF5,         // add  EBP,ESI
+    0x01, 0xFD,         // add  EBP,EDI
+    0x01, 0xED,         // add  EBP,EBP
+    0x01, 0xE5,         // add  EBP,ESP
+    0x01, 0xC4,         // add  ESP,EAX
+    0x01, 0xDC,         // add  ESP,EBX
+    0x01, 0xCC,         // add  ESP,ECX
+    0x01, 0xD4,         // add  ESP,EDX
+    0x01, 0xF4,         // add  ESP,ESI
+    0x01, 0xFC,         // add  ESP,EDI
+    0x01, 0xEC,         // add  ESP,EBP
+    0x01, 0xE4,         // add  ESP,ESP
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	add	AL,AL	;
-	add	AL,BL	;
-	add	AL,CL	;
-	add	AL,DL	;
+    add AL,AL   ;
+    add AL,BL   ;
+    add AL,CL   ;
+    add AL,DL   ;
 
-	add	AL,AH	;
-	add	AL,BH	;
-	add	AL,CH	;
-	add	AL,DH	;
+    add AL,AH   ;
+    add AL,BH   ;
+    add AL,CH   ;
+    add AL,DH   ;
 
-	add	AH,AL	;
-	add	AH,BL	;
-	add	AH,CL	;
-	add	AH,DL	;
+    add AH,AL   ;
+    add AH,BL   ;
+    add AH,CL   ;
+    add AH,DL   ;
 
-	add	AH,AH	;
-	add	AH,BH	;
-	add	AH,CH	;
-	add	AH,DH	;
+    add AH,AH   ;
+    add AH,BH   ;
+    add AH,CH   ;
+    add AH,DH   ;
 
-	add	BL,AL	;
-	add	BL,BL	;
-	add	BL,CL	;
-	add	BL,DL	;
+    add BL,AL   ;
+    add BL,BL   ;
+    add BL,CL   ;
+    add BL,DL   ;
 
-	add	BL,AH	;
-	add	BL,BH	;
-	add	BL,CH	;
-	add	BL,DH	;
+    add BL,AH   ;
+    add BL,BH   ;
+    add BL,CH   ;
+    add BL,DH   ;
 
-	add	BH,AL	;
-	add	BH,BL	;
-	add	BH,CL	;
-	add	BH,DL	;
+    add BH,AL   ;
+    add BH,BL   ;
+    add BH,CL   ;
+    add BH,DL   ;
 
-	add	BH,AH	;
-	add	BH,BH	;
-	add	BH,CH	;
-	add	BH,DH	;
+    add BH,AH   ;
+    add BH,BH   ;
+    add BH,CH   ;
+    add BH,DH   ;
 
-	add	CL,AL	;
-	add	CL,BL	;
-	add	CL,CL	;
-	add	CL,DL	;
+    add CL,AL   ;
+    add CL,BL   ;
+    add CL,CL   ;
+    add CL,DL   ;
 
-	add	CL,AH	;
-	add	CL,BH	;
-	add	CL,CH	;
-	add	CL,DH	;
+    add CL,AH   ;
+    add CL,BH   ;
+    add CL,CH   ;
+    add CL,DH   ;
 
-	add	CH,AL	;
-	add	CH,BL	;
-	add	CH,CL	;
-	add	CH,DL	;
+    add CH,AL   ;
+    add CH,BL   ;
+    add CH,CL   ;
+    add CH,DL   ;
 
-	add	CH,AH	;
-	add	CH,BH	;
-	add	CH,CH	;
-	add	CH,DH	;
+    add CH,AH   ;
+    add CH,BH   ;
+    add CH,CH   ;
+    add CH,DH   ;
 
-	add	DL,AL	;
-	add	DL,BL	;
-	add	DL,CL	;
-	add	DL,DL	;
+    add DL,AL   ;
+    add DL,BL   ;
+    add DL,CL   ;
+    add DL,DL   ;
 
-	add	DL,AH	;
-	add	DL,BH	;
-	add	DL,CH	;
-	add	DL,DH	;
+    add DL,AH   ;
+    add DL,BH   ;
+    add DL,CH   ;
+    add DL,DH   ;
 
-	add	DH,AL	;
-	add	DH,BL	;
-	add	DH,CL	;
-	add	DH,DL	;
+    add DH,AL   ;
+    add DH,BL   ;
+    add DH,CL   ;
+    add DH,DL   ;
 
-	add	DH,AH	;
-	add	DH,BH	;
-	add	DH,CH	;
-	add	DH,DH	;
+    add DH,AH   ;
+    add DH,BH   ;
+    add DH,CH   ;
+    add DH,DH   ;
 
-	add	AX,AX	;
-	add	AX,BX	;
-	add	AX,CX	;
-	add	AX,DX	;
-	add	AX,SI	;
-	add	AX,DI	;
-	add	AX,BP	;
-	add	AX,SP	;
+    add AX,AX   ;
+    add AX,BX   ;
+    add AX,CX   ;
+    add AX,DX   ;
+    add AX,SI   ;
+    add AX,DI   ;
+    add AX,BP   ;
+    add AX,SP   ;
 
-	add	BX,AX	;
-	add	BX,BX	;
-	add	BX,CX	;
-	add	BX,DX	;
-	add	BX,SI	;
-	add	BX,DI	;
-	add	BX,BP	;
-	add	BX,SP	;
+    add BX,AX   ;
+    add BX,BX   ;
+    add BX,CX   ;
+    add BX,DX   ;
+    add BX,SI   ;
+    add BX,DI   ;
+    add BX,BP   ;
+    add BX,SP   ;
 
-	add	CX,AX	;
-	add	CX,BX	;
-	add	CX,CX	;
-	add	CX,DX	;
-	add	CX,SI	;
-	add	CX,DI	;
-	add	CX,BP	;
-	add	CX,SP	;
+    add CX,AX   ;
+    add CX,BX   ;
+    add CX,CX   ;
+    add CX,DX   ;
+    add CX,SI   ;
+    add CX,DI   ;
+    add CX,BP   ;
+    add CX,SP   ;
 
-	add	DX,AX	;
-	add	DX,BX	;
-	add	DX,CX	;
-	add	DX,DX	;
-	add	DX,SI	;
-	add	DX,DI	;
-	add	DX,BP	;
-	add	DX,SP	;
+    add DX,AX   ;
+    add DX,BX   ;
+    add DX,CX   ;
+    add DX,DX   ;
+    add DX,SI   ;
+    add DX,DI   ;
+    add DX,BP   ;
+    add DX,SP   ;
 
-	add	SI,AX	;
-	add	SI,BX	;
-	add	SI,CX	;
-	add	SI,DX	;
-	add	SI,SI	;
-	add	SI,DI	;
-	add	SI,BP	;
-	add	SI,SP	;
+    add SI,AX   ;
+    add SI,BX   ;
+    add SI,CX   ;
+    add SI,DX   ;
+    add SI,SI   ;
+    add SI,DI   ;
+    add SI,BP   ;
+    add SI,SP   ;
 
-	add	DI,AX	;
-	add	DI,BX	;
-	add	DI,CX	;
-	add	DI,DX	;
-	add	DI,SI	;
-	add	DI,DI	;
-	add	DI,BP	;
-	add	DI,SP	;
+    add DI,AX   ;
+    add DI,BX   ;
+    add DI,CX   ;
+    add DI,DX   ;
+    add DI,SI   ;
+    add DI,DI   ;
+    add DI,BP   ;
+    add DI,SP   ;
 
-	add	BP,AX	;
-	add	BP,BX	;
-	add	BP,CX	;
-	add	BP,DX	;
-	add	BP,SI	;
-	add	BP,DI	;
-	add	BP,BP	;
-	add	BP,SP	;
+    add BP,AX   ;
+    add BP,BX   ;
+    add BP,CX   ;
+    add BP,DX   ;
+    add BP,SI   ;
+    add BP,DI   ;
+    add BP,BP   ;
+    add BP,SP   ;
 
-	add	SP,AX	;
-	add	SP,BX	;
-	add	SP,CX	;
-	add	SP,DX	;
-	add	SP,SI	;
-	add	SP,DI	;
-	add	SP,BP	;
-	add	SP,SP	;
+    add SP,AX   ;
+    add SP,BX   ;
+    add SP,CX   ;
+    add SP,DX   ;
+    add SP,SI   ;
+    add SP,DI   ;
+    add SP,BP   ;
+    add SP,SP   ;
 
-	add	EAX,EAX	;
-	add	EAX,EBX	;
-	add	EAX,ECX	;
-	add	EAX,EDX	;
-	add	EAX,ESI	;
-	add	EAX,EDI	;
-	add	EAX,EBP	;
-	add	EAX,ESP	;
+    add EAX,EAX ;
+    add EAX,EBX ;
+    add EAX,ECX ;
+    add EAX,EDX ;
+    add EAX,ESI ;
+    add EAX,EDI ;
+    add EAX,EBP ;
+    add EAX,ESP ;
 
-	add	EBX,EAX	;
-	add	EBX,EBX	;
-	add	EBX,ECX	;
-	add	EBX,EDX	;
-	add	EBX,ESI	;
-	add	EBX,EDI	;
-	add	EBX,EBP	;
-	add	EBX,ESP	;
+    add EBX,EAX ;
+    add EBX,EBX ;
+    add EBX,ECX ;
+    add EBX,EDX ;
+    add EBX,ESI ;
+    add EBX,EDI ;
+    add EBX,EBP ;
+    add EBX,ESP ;
 
-	add	ECX,EAX	;
-	add	ECX,EBX	;
-	add	ECX,ECX	;
-	add	ECX,EDX	;
-	add	ECX,ESI	;
-	add	ECX,EDI	;
-	add	ECX,EBP	;
-	add	ECX,ESP	;
+    add ECX,EAX ;
+    add ECX,EBX ;
+    add ECX,ECX ;
+    add ECX,EDX ;
+    add ECX,ESI ;
+    add ECX,EDI ;
+    add ECX,EBP ;
+    add ECX,ESP ;
 
-	add	EDX,EAX	;
-	add	EDX,EBX	;
-	add	EDX,ECX	;
-	add	EDX,EDX	;
-	add	EDX,ESI	;
-	add	EDX,EDI	;
-	add	EDX,EBP	;
-	add	EDX,ESP	;
+    add EDX,EAX ;
+    add EDX,EBX ;
+    add EDX,ECX ;
+    add EDX,EDX ;
+    add EDX,ESI ;
+    add EDX,EDI ;
+    add EDX,EBP ;
+    add EDX,ESP ;
 
-	add	ESI,EAX	;
-	add	ESI,EBX	;
-	add	ESI,ECX	;
-	add	ESI,EDX	;
-	add	ESI,ESI	;
-	add	ESI,EDI	;
-	add	ESI,EBP	;
-	add	ESI,ESP	;
+    add ESI,EAX ;
+    add ESI,EBX ;
+    add ESI,ECX ;
+    add ESI,EDX ;
+    add ESI,ESI ;
+    add ESI,EDI ;
+    add ESI,EBP ;
+    add ESI,ESP ;
 
-	add	EDI,EAX	;
-	add	EDI,EBX	;
-	add	EDI,ECX	;
-	add	EDI,EDX	;
-	add	EDI,ESI	;
-	add	EDI,EDI	;
-	add	EDI,EBP	;
-	add	EDI,ESP	;
+    add EDI,EAX ;
+    add EDI,EBX ;
+    add EDI,ECX ;
+    add EDI,EDX ;
+    add EDI,ESI ;
+    add EDI,EDI ;
+    add EDI,EBP ;
+    add EDI,ESP ;
 
-	add	EBP,EAX	;
-	add	EBP,EBX	;
-	add	EBP,ECX	;
-	add	EBP,EDX	;
-	add	EBP,ESI	;
-	add	EBP,EDI	;
-	add	EBP,EBP	;
-	add	EBP,ESP	;
+    add EBP,EAX ;
+    add EBP,EBX ;
+    add EBP,ECX ;
+    add EBP,EDX ;
+    add EBP,ESI ;
+    add EBP,EDI ;
+    add EBP,EBP ;
+    add EBP,ESP ;
 
-	add	ESP,EAX	;
-	add	ESP,EBX	;
-	add	ESP,ECX	;
-	add	ESP,EDX	;
-	add	ESP,ESI	;
-	add	ESP,EDI	;
-	add	ESP,EBP	;
-	add	ESP,ESP	;
+    add ESP,EAX ;
+    add ESP,EBX ;
+    add ESP,ECX ;
+    add ESP,EDX ;
+    add ESP,ESI ;
+    add ESP,EDI ;
+    add ESP,EBP ;
+    add ESP,ESP ;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -3570,252 +3570,252 @@ L1:					;
 void test50()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x66, 0x98,     // cbw
-	0xF8,          	// clc
-	0xFC,          	// cld
-	0xFA,          	// cli
-	0xF5,          	// cmc
-	0xA6,          	// cmpsb
-	0x66, 0xA7,     // cmpsw
-	0xA7,          	// cmpsd
-	0x66, 0x99,     // cwd
-//	0x27,          	// daa
-//	0x2F,          	// das
-	0xFF, 0xC8,    	// dec	EAX
-	0xF6, 0xF1,     // div	CL
-	0x66, 0xF7, 0xF3,  // div	BX
-	0xF7, 0xF2,     // div	EDX
-	0xF4,          	// hlt
-	0xF6, 0xFB,     // idiv	BL
-	0x66, 0xF7, 0xFA,  // idiv	DX
-	0xF7, 0xFE,     // idiv	ESI
-	0xF6, 0xEB,     // imul	BL
-	0x66, 0xF7, 0xEA,  // imul	DX
-	0xF7, 0xEE,     // imul	ESI
-	0xEC,          	// in	AL,DX
-	0x66, 0xED,     // in	AX,DX
-	0xFF, 0xC3,    	// inc	EBX
-	0xCC,          	// int	3
-	0xCD, 0x67,     // int	067h
-//	0xCE,          	// into
-	0x66, 0xCF,     // iret
-	0x77, 0xFC,     // ja	L30
-	0x77, 0xFA,     // ja	L30
-	0x73, 0xF8,     // jae	L30
-	0x73, 0xF6,     // jae	L30
-	0x73, 0xF4,     // jae	L30
-	0x72, 0xF2,     // jb	L30
-	0x72, 0xF0,     // jb	L30
-	0x76, 0xEE,     // jbe	L30
-	0x76, 0xEC,     // jbe	L30
-	0x72, 0xEA,     // jb	L30
-//	0x67, 0xE3, 0xE7,  // jcxz	L30
-	0x90, 0x90, 0x90,  // nop;nop;nop
-	0x74, 0xE5,     // je	L30
-	0x74, 0xE3,     // je	L30
-	0x7F, 0xE1,     // jg	L30
-	0x7F, 0xDF,     // jg	L30
-	0x7D, 0xDD,     // jge	L30
-	0x7D, 0xDB,     // jge	L30
-	0x7C, 0xD9,     // jl	L30
-	0x7C, 0xD7,     // jl	L30
-	0x7E, 0xD5,     // jle	L30
-	0x7E, 0xD3,     // jle	L30
-	0xEB, 0xD1,     // jmp short	L30
-	0x75, 0xCF,     // jne	L30
-	0x75, 0xCD,     // jne	L30
-	0x71, 0xCB,     // jno	L30
-	0x79, 0xC9,     // jns	L30
-	0x7B, 0xC7,     // jnp	L30
-	0x7B, 0xC5,     // jnp	L30
-	0x70, 0xC3,     // jo	L30
-	0x7A, 0xC1,     // jp	L30
-	0x7A, 0xBF,     // jp	L30
-	0x78, 0xBD,     // js	L30
-	0x9F,          	// lahf
-//	0xC5, 0x30,     // lds	ESI,[EAX]
-	0x90, 0x90,     // nop;nop
-	0x8B, 0xFB,     // mov	EDI,EBX
-//	0xC4, 0x29,     // les	EBP,[ECX]
-	0x90, 0x90,     // nop;nop
-	0xF0,          	// lock
-	0xAC,          	// lodsb
-	0x66, 0xAD,     // lodsw
-	0xAD,          	// lodsd
-	0xE2, 0xAF,     // loop	L30
-	0xE1, 0xAD,     // loope	L30
-	0xE1, 0xAB,     // loope	L30
-	0xE0, 0xA9,     // loopne	L30
-	0xE0, 0xA7,     // loopne	L30
-	0xA4,          	// movsb
-	0x66, 0xA5,     // movsw
-	0xA5,          	// movsd
-	0xF6, 0xE4,     // mul	AH
-	0x66, 0xF7, 0xE1,  // mul	CX
-	0xF7, 0xE5,     // mul	EBP
-	0x90,          	// nop
-	0xF7, 0xD7,     // not	EDI
-	0x66, 0xE7, 0x44,  // out	044h,AX
-	0xEE,          	// out	DX,AL
-	0x66, 0x9D,     // popf
-	0x66, 0x9C,     // pushf
-	0xD1, 0xDB,     // rcr	EBX,1
-	0xF3,          	// rep
-	0xF3,          	// rep
-	0xF2,          	// repne
-	0xF3,          	// rep
-	0xF2,          	// repne
-	0xC3,          	// ret
-	0xC2, 0x04, 0x00,  // ret  4
-	0xD1, 0xC1,     // rol	ECX,1
-	0xD1, 0xCA,     // ror	EDX,1
-	0x9E,          	// sahf
-	0xD1, 0xE5,     // shl	EBP,1
-	0xD1, 0xE4,     // shl	ESP,1
-	0xD1, 0xFF,     // sar	EDI,1
-	0xAE,          	// scasb
-	0x66, 0xAF,     // scasw
-	0xAF,          	// scasd
-	0xD1, 0xEE,     // shr	ESI,1
-	0xFD,          	// std
-	0xF9,          	// stc
-	0xFB,          	// sti
-	0xAA,          	// stosb
-	0x66, 0xAB,     // stosw
-	0xAB,          	// stosd
-	0x9B,          	// wait
-	0x91,          	// xchg	EAX,ECX
-	0xD7,          	// xlat
+    0x66, 0x98,     // cbw
+    0xF8,           // clc
+    0xFC,           // cld
+    0xFA,           // cli
+    0xF5,           // cmc
+    0xA6,           // cmpsb
+    0x66, 0xA7,     // cmpsw
+    0xA7,           // cmpsd
+    0x66, 0x99,     // cwd
+//  0x27,           // daa
+//  0x2F,           // das
+    0xFF, 0xC8,     // dec  EAX
+    0xF6, 0xF1,     // div  CL
+    0x66, 0xF7, 0xF3,  // div   BX
+    0xF7, 0xF2,     // div  EDX
+    0xF4,           // hlt
+    0xF6, 0xFB,     // idiv BL
+    0x66, 0xF7, 0xFA,  // idiv  DX
+    0xF7, 0xFE,     // idiv ESI
+    0xF6, 0xEB,     // imul BL
+    0x66, 0xF7, 0xEA,  // imul  DX
+    0xF7, 0xEE,     // imul ESI
+    0xEC,           // in   AL,DX
+    0x66, 0xED,     // in   AX,DX
+    0xFF, 0xC3,     // inc  EBX
+    0xCC,           // int  3
+    0xCD, 0x67,     // int  067h
+//  0xCE,           // into
+    0x66, 0xCF,     // iret
+    0x77, 0xFC,     // ja   L30
+    0x77, 0xFA,     // ja   L30
+    0x73, 0xF8,     // jae  L30
+    0x73, 0xF6,     // jae  L30
+    0x73, 0xF4,     // jae  L30
+    0x72, 0xF2,     // jb   L30
+    0x72, 0xF0,     // jb   L30
+    0x76, 0xEE,     // jbe  L30
+    0x76, 0xEC,     // jbe  L30
+    0x72, 0xEA,     // jb   L30
+//  0x67, 0xE3, 0xE7,  // jcxz  L30
+    0x90, 0x90, 0x90,  // nop;nop;nop
+    0x74, 0xE5,     // je   L30
+    0x74, 0xE3,     // je   L30
+    0x7F, 0xE1,     // jg   L30
+    0x7F, 0xDF,     // jg   L30
+    0x7D, 0xDD,     // jge  L30
+    0x7D, 0xDB,     // jge  L30
+    0x7C, 0xD9,     // jl   L30
+    0x7C, 0xD7,     // jl   L30
+    0x7E, 0xD5,     // jle  L30
+    0x7E, 0xD3,     // jle  L30
+    0xEB, 0xD1,     // jmp short    L30
+    0x75, 0xCF,     // jne  L30
+    0x75, 0xCD,     // jne  L30
+    0x71, 0xCB,     // jno  L30
+    0x79, 0xC9,     // jns  L30
+    0x7B, 0xC7,     // jnp  L30
+    0x7B, 0xC5,     // jnp  L30
+    0x70, 0xC3,     // jo   L30
+    0x7A, 0xC1,     // jp   L30
+    0x7A, 0xBF,     // jp   L30
+    0x78, 0xBD,     // js   L30
+    0x9F,           // lahf
+//  0xC5, 0x30,     // lds  ESI,[EAX]
+    0x90, 0x90,     // nop;nop
+    0x8B, 0xFB,     // mov  EDI,EBX
+//  0xC4, 0x29,     // les  EBP,[ECX]
+    0x90, 0x90,     // nop;nop
+    0xF0,           // lock
+    0xAC,           // lodsb
+    0x66, 0xAD,     // lodsw
+    0xAD,           // lodsd
+    0xE2, 0xAF,     // loop L30
+    0xE1, 0xAD,     // loope    L30
+    0xE1, 0xAB,     // loope    L30
+    0xE0, 0xA9,     // loopne   L30
+    0xE0, 0xA7,     // loopne   L30
+    0xA4,           // movsb
+    0x66, 0xA5,     // movsw
+    0xA5,           // movsd
+    0xF6, 0xE4,     // mul  AH
+    0x66, 0xF7, 0xE1,  // mul   CX
+    0xF7, 0xE5,     // mul  EBP
+    0x90,           // nop
+    0xF7, 0xD7,     // not  EDI
+    0x66, 0xE7, 0x44,  // out   044h,AX
+    0xEE,           // out  DX,AL
+    0x66, 0x9D,     // popf
+    0x66, 0x9C,     // pushf
+    0xD1, 0xDB,     // rcr  EBX,1
+    0xF3,           // rep
+    0xF3,           // rep
+    0xF2,           // repne
+    0xF3,           // rep
+    0xF2,           // repne
+    0xC3,           // ret
+    0xC2, 0x04, 0x00,  // ret  4
+    0xD1, 0xC1,     // rol  ECX,1
+    0xD1, 0xCA,     // ror  EDX,1
+    0x9E,           // sahf
+    0xD1, 0xE5,     // shl  EBP,1
+    0xD1, 0xE4,     // shl  ESP,1
+    0xD1, 0xFF,     // sar  EDI,1
+    0xAE,           // scasb
+    0x66, 0xAF,     // scasw
+    0xAF,           // scasd
+    0xD1, 0xEE,     // shr  ESI,1
+    0xFD,           // std
+    0xF9,           // stc
+    0xFB,           // sti
+    0xAA,           // stosb
+    0x66, 0xAB,     // stosw
+    0xAB,           // stosd
+    0x9B,           // wait
+    0x91,           // xchg EAX,ECX
+    0xD7,           // xlat
     ];
     int i;
 
     asm
     {
-	call	L1			;
+    call    L1          ;
 
-	cbw	;
-	clc	;
-	cld	;
-	cli	;
-	cmc	;
-	cmpsb	;
-	cmpsw	;
-	cmpsd	;
-	cwd	;
-	//daa	;
-	//das	;
-	dec	EAX	;
-	div	CL	;
-	div	BX	;
-	div	EDX	;
-	hlt		;
-	idiv	BL	;
-	idiv	DX	;
-	idiv	ESI	;
-	imul	BL	;
-	imul	DX	;
-	imul	ESI	;
-	in	AL,DX	;
-	in	AX,DX	;
-	inc	EBX	;
-	int	3	;
-	int	0x67	;
-	//into		;
-L10:	iret		;
-	ja	L10	;
-	jnbe	L10	;
-	jae	L10	;
-	jnb	L10	;
-	jnc	L10	;
-	jb	L10	;
-	jnae	L10	;
-	jbe	L10	;
-	jna	L10	;
-	jc	L10	;
-	nop;nop;nop;	// jcxz	L10;
-	je	L10	;
-	jz	L10	;
-	jg	L10	;
-	jnle	L10	;
-	jge	L10	;
-	jnl	L10	;
-	jl	L10	;
-	jnge	L10	;
-	jle	L10	;
-	jng	L10	;
-	jmp	short L10	;
-	jne	L10	;
-	jnz	L10	;
-	jno	L10	;
-	jns	L10	;
-	jnp	L10	;
-	jpo	L10	;
-	jo	L10	;
-	jp	L10	;
-	jpe	L10	;
-	js	L10	;
-	lahf		;
-	nop;nop;	//lds	ESI,[EAX];
-	lea	EDI,[EBX];
-	nop;nop;	//les	EBP,[ECX];
-	lock	;
-	lodsb	;
-	lodsw	;
-	lodsd	;
-	loop	L10	;
-	loope	L10	;
-	loopz	L10	;
-	loopnz	L10	;
-	loopne	L10	;
-	movsb	;
-	movsw	;
-	movsd	;
-	mul	AH	;
-	mul	CX	;
-	mul	EBP	;
-	nop	;
-	not	EDI	;
-	out	0x44,AX	;
-	out	DX,AL	;
-	popf	;
-	pushf	;
-	rcr	EBX,1	;
-	rep	;
-	repe	;
-	repne	;
-	repz	;
-	repnz	;
-	ret	;
-	ret	4	;
-	rol	ECX,1	;
-	ror	EDX,1	;
-	sahf	;
-	sal	EBP,1	;
-	shl	ESP,1	;
-	sar	EDI,1	;
-	scasb	;
-	scasw	;
-	scasd	;
-	shr	ESI,1	;
-	std	;
-	stc	;
-	sti	;
-	stosb	;
-	stosw	;
-	stosd	;
-	wait	;
-	xchg	EAX,ECX	;
-	xlat	;
+    cbw ;
+    clc ;
+    cld ;
+    cli ;
+    cmc ;
+    cmpsb   ;
+    cmpsw   ;
+    cmpsd   ;
+    cwd ;
+    //daa   ;
+    //das   ;
+    dec EAX ;
+    div CL  ;
+    div BX  ;
+    div EDX ;
+    hlt     ;
+    idiv    BL  ;
+    idiv    DX  ;
+    idiv    ESI ;
+    imul    BL  ;
+    imul    DX  ;
+    imul    ESI ;
+    in  AL,DX   ;
+    in  AX,DX   ;
+    inc EBX ;
+    int 3   ;
+    int 0x67    ;
+    //into      ;
+L10:    iret        ;
+    ja  L10 ;
+    jnbe    L10 ;
+    jae L10 ;
+    jnb L10 ;
+    jnc L10 ;
+    jb  L10 ;
+    jnae    L10 ;
+    jbe L10 ;
+    jna L10 ;
+    jc  L10 ;
+    nop;nop;nop;    // jcxz L10;
+    je  L10 ;
+    jz  L10 ;
+    jg  L10 ;
+    jnle    L10 ;
+    jge L10 ;
+    jnl L10 ;
+    jl  L10 ;
+    jnge    L10 ;
+    jle L10 ;
+    jng L10 ;
+    jmp short L10   ;
+    jne L10 ;
+    jnz L10 ;
+    jno L10 ;
+    jns L10 ;
+    jnp L10 ;
+    jpo L10 ;
+    jo  L10 ;
+    jp  L10 ;
+    jpe L10 ;
+    js  L10 ;
+    lahf        ;
+    nop;nop;    //lds   ESI,[EAX];
+    lea EDI,[EBX];
+    nop;nop;    //les   EBP,[ECX];
+    lock    ;
+    lodsb   ;
+    lodsw   ;
+    lodsd   ;
+    loop    L10 ;
+    loope   L10 ;
+    loopz   L10 ;
+    loopnz  L10 ;
+    loopne  L10 ;
+    movsb   ;
+    movsw   ;
+    movsd   ;
+    mul AH  ;
+    mul CX  ;
+    mul EBP ;
+    nop ;
+    not EDI ;
+    out 0x44,AX ;
+    out DX,AL   ;
+    popf    ;
+    pushf   ;
+    rcr EBX,1   ;
+    rep ;
+    repe    ;
+    repne   ;
+    repz    ;
+    repnz   ;
+    ret ;
+    ret 4   ;
+    rol ECX,1   ;
+    ror EDX,1   ;
+    sahf    ;
+    sal EBP,1   ;
+    shl ESP,1   ;
+    sar EDI,1   ;
+    scasb   ;
+    scasw   ;
+    scasd   ;
+    shr ESI,1   ;
+    std ;
+    stc ;
+    sti ;
+    stosb   ;
+    stosw   ;
+    stosd   ;
+    wait    ;
+    xchg    EAX,ECX ;
+    xlat    ;
 
-L1:					;
-	pop	RBX			;
-	mov	p[RBP],RBX		;
+L1:                 ;
+    pop RBX         ;
+    mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
-	assert(p[i] == data[i]);
+    assert(p[i] == data[i]);
     }
 }
 
@@ -3836,57 +3836,57 @@ class Test51
 void test52()
 {   int x;
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xF6, 0xD8,             	// neg	AL
-0x66, 	0xF7, 0xD8,             	// neg	AX
-	0xF7, 0xD8,             	// neg	EAX
-	0x48, 0xF7, 0xD8,          	// neg	RAX
-	0xF6, 0xDC,             	// neg	AH
-	0x41, 0xF6, 0xDC,          	// neg	R12B
-0x66, 	0x41, 0xF7, 0xDC,          	// neg	12D
-	0x41, 0xF7, 0xDC,          	// neg	R12D
-	0x49, 0xF7, 0xDB,          	// neg	R11
-//	0xF6, 0x1D, 0x00, 0x00, 0x00, 0x00, 	// neg	byte ptr _D6iasm641bg@PC32[RIP]
-//0x66, 	0xF7, 0x1D, 0x00, 0x00, 0x00, 0x00, 	// neg	word ptr _D6iasm641ws@PC32[RIP]
-//	0xF7, 0x1D, 0x00, 0x00, 0x00, 0x00, 	// neg	dword ptr _D6iasm641ii@PC32[RIP]
-//	0x48, 0xF7, 0x1D, 0x00, 0x00, 0x00, 0x00, 	// neg	qword ptr _D6iasm641ll@PC32[RIP]
-	0xF7, 0x5D, 0xD0,          	// neg	dword ptr -8[RBP]
-	0xF6, 0x1B,             	// neg	byte ptr [RBX]
-	0xF6, 0x1B,             	// neg	byte ptr [RBX]
-	0x49, 0xF7, 0xD8,          	// neg	R8
+    0xF6, 0xD8,                 // neg  AL
+0x66,   0xF7, 0xD8,                 // neg  AX
+    0xF7, 0xD8,                 // neg  EAX
+    0x48, 0xF7, 0xD8,           // neg  RAX
+    0xF6, 0xDC,                 // neg  AH
+    0x41, 0xF6, 0xDC,           // neg  R12B
+0x66,   0x41, 0xF7, 0xDC,           // neg  12D
+    0x41, 0xF7, 0xDC,           // neg  R12D
+    0x49, 0xF7, 0xDB,           // neg  R11
+//  0xF6, 0x1D, 0x00, 0x00, 0x00, 0x00,     // neg  byte ptr _D6iasm641bg@PC32[RIP]
+//0x66,     0xF7, 0x1D, 0x00, 0x00, 0x00, 0x00,     // neg  word ptr _D6iasm641ws@PC32[RIP]
+//  0xF7, 0x1D, 0x00, 0x00, 0x00, 0x00,     // neg  dword ptr _D6iasm641ii@PC32[RIP]
+//  0x48, 0xF7, 0x1D, 0x00, 0x00, 0x00, 0x00,   // neg  qword ptr _D6iasm641ll@PC32[RIP]
+    0xF7, 0x5D, 0xD0,           // neg  dword ptr -8[RBP]
+    0xF6, 0x1B,                 // neg  byte ptr [RBX]
+    0xF6, 0x1B,                 // neg  byte ptr [RBX]
+    0x49, 0xF7, 0xD8,           // neg  R8
     ];
 
     asm
     {
-	call	L1	;
+    call    L1  ;
 
-	neg	AL	;
-	neg	AX	;
-	neg	EAX	;
-	neg	RAX	;
-	neg	AH	;
-	neg	R12B	;
-	neg	R12W	;
-	neg	R12D	;
-	neg	R11	;
-//	neg	b	;
-//	neg	w	;
-//	neg	i	;
-//	neg	l	;
-	neg	x	;
-	neg	[EBX]	;
-	neg	[RBX]	;
-	neg	R8	;
+    neg AL  ;
+    neg AX  ;
+    neg EAX ;
+    neg RAX ;
+    neg AH  ;
+    neg R12B    ;
+    neg R12W    ;
+    neg R12D    ;
+    neg R11 ;
+//  neg b   ;
+//  neg w   ;
+//  neg i   ;
+//  neg l   ;
+    neg x   ;
+    neg [EBX]   ;
+    neg [RBX]   ;
+    neg R8  ;
 
-L1:	pop	RAX	;
-	mov	p[RBP],RAX ;
+L1: pop RAX ;
+    mov p[RBP],RAX ;
     }
 
     foreach (ref i, b; data)
     {
-	//printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
-	assert(p[i] == b);
+    //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+    assert(p[i] == b);
     }
 }
 
@@ -3895,133 +3895,133 @@ L1:	pop	RAX	;
 void test53()
 {   int x;
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x48, 0x8D, 0x04, 0x00,       	// lea	RAX,[RAX][RAX]
-	0x48, 0x8D, 0x04, 0x08,       	// lea	RAX,[RCX][RAX]
-	0x48, 0x8D, 0x04, 0x10,       	// lea	RAX,[RDX][RAX]
-	0x48, 0x8D, 0x04, 0x18,       	// lea	RAX,[RBX][RAX]
-	0x48, 0x8D, 0x04, 0x28,       	// lea	RAX,[RBP][RAX]
-	0x48, 0x8D, 0x04, 0x30,       	// lea	RAX,[RSI][RAX]
-	0x48, 0x8D, 0x04, 0x38,       	// lea	RAX,[RDI][RAX]
-	0x4A, 0x8D, 0x04, 0x00,       	// lea	RAX,[R8][RAX]
-	0x4A, 0x8D, 0x04, 0x08,       	// lea	RAX,[R9][RAX]
-	0x4A, 0x8D, 0x04, 0x10,       	// lea	RAX,[R10][RAX]
-	0x4A, 0x8D, 0x04, 0x18,       	// lea	RAX,[R11][RAX]
-	0x4A, 0x8D, 0x04, 0x20,       	// lea	RAX,[R12][RAX]
-	0x4A, 0x8D, 0x04, 0x28,       	// lea	RAX,[R13][RAX]
-	0x4A, 0x8D, 0x04, 0x30,       	// lea	RAX,[R14][RAX]
-	0x4A, 0x8D, 0x04, 0x38,       	// lea	RAX,[R15][RAX]
-	0x48, 0x8D, 0x04, 0x00,       	// lea	RAX,[RAX][RAX]
-	0x48, 0x8D, 0x04, 0x01,       	// lea	RAX,[RAX][RCX]
-	0x48, 0x8D, 0x04, 0x02,       	// lea	RAX,[RAX][RDX]
-	0x48, 0x8D, 0x04, 0x03,       	// lea	RAX,[RAX][RBX]
-	0x48, 0x8D, 0x04, 0x04,       	// lea	RAX,[RAX][RSP]
-	0x48, 0x8D, 0x44, 0x05, 0x00,   // lea	RAX,0[RAX][RBP]
-	0x48, 0x8D, 0x04, 0x06,       	// lea	RAX,[RAX][RSI]
-	0x48, 0x8D, 0x04, 0x07,       	// lea	RAX,[RAX][RDI]
-	0x49, 0x8D, 0x04, 0x00,       	// lea	RAX,[RAX][R8]
-	0x49, 0x8D, 0x04, 0x01,       	// lea	RAX,[RAX][R9]
-	0x49, 0x8D, 0x04, 0x02,       	// lea	RAX,[RAX][R10]
-	0x49, 0x8D, 0x04, 0x03,       	// lea	RAX,[RAX][R11]
-	0x49, 0x8D, 0x04, 0x04,       	// lea	RAX,[RAX][R12]
-	0x49, 0x8D, 0x44, 0x05, 0x00,   // lea	RAX,0[RAX][R13]
-	0x49, 0x8D, 0x04, 0x06,       	// lea	RAX,[RAX][R14]
-	0x49, 0x8D, 0x04, 0x07,       	// lea	RAX,[RAX][R15]
-	0x4B, 0x8D, 0x04, 0x24,       	// lea	RAX,[R12][R12]
-	0x4B, 0x8D, 0x44, 0x25, 0x00,   // lea	RAX,0[R12][R13]
-	0x4B, 0x8D, 0x04, 0x26,       	// lea	RAX,[R12][R14]
-	0x4B, 0x8D, 0x04, 0x2C,       	// lea	RAX,[R13][R12]
-	0x4B, 0x8D, 0x44, 0x2D, 0x00,   // lea	RAX,0[R13][R13]
-	0x4B, 0x8D, 0x04, 0x2E,       	// lea	RAX,[R13][R14]
-	0x4B, 0x8D, 0x04, 0x34,       	// lea	RAX,[R14][R12]
-	0x4B, 0x8D, 0x44, 0x35, 0x00,   // lea	RAX,0[R14][R13]
-	0x4B, 0x8D, 0x04, 0x36,       	// lea	RAX,[R14][R14]
-	0x48, 0x8D, 0x44, 0x01, 0x12,    			// lea	RAX,012h[RAX][RCX]
-	0x48, 0x8D, 0x84, 0x01, 0x34, 0x12, 0x00, 0x00, 	// lea	RAX,01234h[RAX][RCX]
-	0x48, 0x8D, 0x84, 0x01, 0x78, 0x56, 0x34, 0x12, 	// lea	RAX,012345678h[RAX][RCX]
-	0x48, 0x8D, 0x44, 0x05, 0x12,    			// lea	RAX,012h[RAX][RBP]
-	0x48, 0x8D, 0x84, 0x05, 0x34, 0x12, 0x00, 0x00, 	// lea	RAX,01234h[RAX][RBP]
-	0x48, 0x8D, 0x84, 0x05, 0x78, 0x56, 0x34, 0x12, 	// lea	RAX,012345678h[RAX][RBP]
-	0x49, 0x8D, 0x44, 0x05, 0x12,    			// lea	RAX,012h[RAX][R13]
-	0x49, 0x8D, 0x84, 0x05, 0x34, 0x12, 0x00, 0x00, 	// lea	RAX,01234h[RAX][R13]
-	0x49, 0x8D, 0x84, 0x05, 0x78, 0x56, 0x34, 0x12, 	// lea	RAX,012345678h[RAX][R13]
+    0x48, 0x8D, 0x04, 0x00,         // lea  RAX,[RAX][RAX]
+    0x48, 0x8D, 0x04, 0x08,         // lea  RAX,[RCX][RAX]
+    0x48, 0x8D, 0x04, 0x10,         // lea  RAX,[RDX][RAX]
+    0x48, 0x8D, 0x04, 0x18,         // lea  RAX,[RBX][RAX]
+    0x48, 0x8D, 0x04, 0x28,         // lea  RAX,[RBP][RAX]
+    0x48, 0x8D, 0x04, 0x30,         // lea  RAX,[RSI][RAX]
+    0x48, 0x8D, 0x04, 0x38,         // lea  RAX,[RDI][RAX]
+    0x4A, 0x8D, 0x04, 0x00,         // lea  RAX,[R8][RAX]
+    0x4A, 0x8D, 0x04, 0x08,         // lea  RAX,[R9][RAX]
+    0x4A, 0x8D, 0x04, 0x10,         // lea  RAX,[R10][RAX]
+    0x4A, 0x8D, 0x04, 0x18,         // lea  RAX,[R11][RAX]
+    0x4A, 0x8D, 0x04, 0x20,         // lea  RAX,[R12][RAX]
+    0x4A, 0x8D, 0x04, 0x28,         // lea  RAX,[R13][RAX]
+    0x4A, 0x8D, 0x04, 0x30,         // lea  RAX,[R14][RAX]
+    0x4A, 0x8D, 0x04, 0x38,         // lea  RAX,[R15][RAX]
+    0x48, 0x8D, 0x04, 0x00,         // lea  RAX,[RAX][RAX]
+    0x48, 0x8D, 0x04, 0x01,         // lea  RAX,[RAX][RCX]
+    0x48, 0x8D, 0x04, 0x02,         // lea  RAX,[RAX][RDX]
+    0x48, 0x8D, 0x04, 0x03,         // lea  RAX,[RAX][RBX]
+    0x48, 0x8D, 0x04, 0x04,         // lea  RAX,[RAX][RSP]
+    0x48, 0x8D, 0x44, 0x05, 0x00,   // lea  RAX,0[RAX][RBP]
+    0x48, 0x8D, 0x04, 0x06,         // lea  RAX,[RAX][RSI]
+    0x48, 0x8D, 0x04, 0x07,         // lea  RAX,[RAX][RDI]
+    0x49, 0x8D, 0x04, 0x00,         // lea  RAX,[RAX][R8]
+    0x49, 0x8D, 0x04, 0x01,         // lea  RAX,[RAX][R9]
+    0x49, 0x8D, 0x04, 0x02,         // lea  RAX,[RAX][R10]
+    0x49, 0x8D, 0x04, 0x03,         // lea  RAX,[RAX][R11]
+    0x49, 0x8D, 0x04, 0x04,         // lea  RAX,[RAX][R12]
+    0x49, 0x8D, 0x44, 0x05, 0x00,   // lea  RAX,0[RAX][R13]
+    0x49, 0x8D, 0x04, 0x06,         // lea  RAX,[RAX][R14]
+    0x49, 0x8D, 0x04, 0x07,         // lea  RAX,[RAX][R15]
+    0x4B, 0x8D, 0x04, 0x24,         // lea  RAX,[R12][R12]
+    0x4B, 0x8D, 0x44, 0x25, 0x00,   // lea  RAX,0[R12][R13]
+    0x4B, 0x8D, 0x04, 0x26,         // lea  RAX,[R12][R14]
+    0x4B, 0x8D, 0x04, 0x2C,         // lea  RAX,[R13][R12]
+    0x4B, 0x8D, 0x44, 0x2D, 0x00,   // lea  RAX,0[R13][R13]
+    0x4B, 0x8D, 0x04, 0x2E,         // lea  RAX,[R13][R14]
+    0x4B, 0x8D, 0x04, 0x34,         // lea  RAX,[R14][R12]
+    0x4B, 0x8D, 0x44, 0x35, 0x00,   // lea  RAX,0[R14][R13]
+    0x4B, 0x8D, 0x04, 0x36,         // lea  RAX,[R14][R14]
+    0x48, 0x8D, 0x44, 0x01, 0x12,               // lea  RAX,012h[RAX][RCX]
+    0x48, 0x8D, 0x84, 0x01, 0x34, 0x12, 0x00, 0x00,     // lea  RAX,01234h[RAX][RCX]
+    0x48, 0x8D, 0x84, 0x01, 0x78, 0x56, 0x34, 0x12,     // lea  RAX,012345678h[RAX][RCX]
+    0x48, 0x8D, 0x44, 0x05, 0x12,               // lea  RAX,012h[RAX][RBP]
+    0x48, 0x8D, 0x84, 0x05, 0x34, 0x12, 0x00, 0x00,     // lea  RAX,01234h[RAX][RBP]
+    0x48, 0x8D, 0x84, 0x05, 0x78, 0x56, 0x34, 0x12,     // lea  RAX,012345678h[RAX][RBP]
+    0x49, 0x8D, 0x44, 0x05, 0x12,               // lea  RAX,012h[RAX][R13]
+    0x49, 0x8D, 0x84, 0x05, 0x34, 0x12, 0x00, 0x00,     // lea  RAX,01234h[RAX][R13]
+    0x49, 0x8D, 0x84, 0x05, 0x78, 0x56, 0x34, 0x12,     // lea  RAX,012345678h[RAX][R13]
 
-	0x48, 0x8D, 0x04, 0x24,       	// lea	RAX,[RSP]
-	0x49, 0x8D, 0x04, 0x24,       	// lea	RAX,[R12]
+    0x48, 0x8D, 0x04, 0x24,         // lea  RAX,[RSP]
+    0x49, 0x8D, 0x04, 0x24,         // lea  RAX,[R12]
     ];
 
     asm
     {
-	call	L1	;
+    call    L1  ;
 
-	// Right
-	lea RAX, [RAX+RAX];
-	lea RAX, [RAX+RCX];
-	lea RAX, [RAX+RDX];
-	lea RAX, [RAX+RBX];
-	//lea RAX, [RAX+RSP]; RSP can't be on the right
-	lea RAX, [RAX+RBP];
-	lea RAX, [RAX+RSI];
-	lea RAX, [RAX+RDI];
-	lea RAX, [RAX+R8];
-	lea RAX, [RAX+R9];
-	lea RAX, [RAX+R10];
-	lea RAX, [RAX+R11];
-	lea RAX, [RAX+R12];
-	lea RAX, [RAX+R13];
-	lea RAX, [RAX+R14];
-	lea RAX, [RAX+R15];
-	// Left
-	lea RAX, [RAX+RAX];
-	lea RAX, [RCX+RAX];
-	lea RAX, [RDX+RAX];
-	lea RAX, [RBX+RAX];
-	lea RAX, [RSP+RAX];
-	lea RAX, [RBP+RAX]; // Good gets disp+8 correctly
-	lea RAX, [RSI+RAX];
-	lea RAX, [RDI+RAX];
-	lea RAX, [R8+RAX];
-	lea RAX, [R9+RAX];
-	lea RAX, [R10+RAX];
-	lea RAX, [R11+RAX];
-	lea RAX, [R12+RAX];
-	lea RAX, [R13+RAX]; // Good disp+8
-	lea RAX, [R14+RAX];
-	lea RAX, [R15+RAX];
-	// Right and Left
-	lea RAX, [R12+R12];
-	lea RAX, [R13+R12];
-	lea RAX, [R14+R12];
-	lea RAX, [R12+R13];
-	lea RAX, [R13+R13];
-	lea RAX, [R14+R13];
-	lea RAX, [R12+R14];
-	lea RAX, [R13+R14];
-	lea RAX, [R14+R14];
+    // Right
+    lea RAX, [RAX+RAX];
+    lea RAX, [RAX+RCX];
+    lea RAX, [RAX+RDX];
+    lea RAX, [RAX+RBX];
+    //lea RAX, [RAX+RSP]; RSP can't be on the right
+    lea RAX, [RAX+RBP];
+    lea RAX, [RAX+RSI];
+    lea RAX, [RAX+RDI];
+    lea RAX, [RAX+R8];
+    lea RAX, [RAX+R9];
+    lea RAX, [RAX+R10];
+    lea RAX, [RAX+R11];
+    lea RAX, [RAX+R12];
+    lea RAX, [RAX+R13];
+    lea RAX, [RAX+R14];
+    lea RAX, [RAX+R15];
+    // Left
+    lea RAX, [RAX+RAX];
+    lea RAX, [RCX+RAX];
+    lea RAX, [RDX+RAX];
+    lea RAX, [RBX+RAX];
+    lea RAX, [RSP+RAX];
+    lea RAX, [RBP+RAX]; // Good gets disp+8 correctly
+    lea RAX, [RSI+RAX];
+    lea RAX, [RDI+RAX];
+    lea RAX, [R8+RAX];
+    lea RAX, [R9+RAX];
+    lea RAX, [R10+RAX];
+    lea RAX, [R11+RAX];
+    lea RAX, [R12+RAX];
+    lea RAX, [R13+RAX]; // Good disp+8
+    lea RAX, [R14+RAX];
+    lea RAX, [R15+RAX];
+    // Right and Left
+    lea RAX, [R12+R12];
+    lea RAX, [R13+R12];
+    lea RAX, [R14+R12];
+    lea RAX, [R12+R13];
+    lea RAX, [R13+R13];
+    lea RAX, [R14+R13];
+    lea RAX, [R12+R14];
+    lea RAX, [R13+R14];
+    lea RAX, [R14+R14];
 
-	// Disp8/32 checks
-	lea RAX, [RCX+RAX+0x12];
-	lea RAX, [RCX+RAX+0x1234];
-	lea RAX, [RCX+RAX+0x1234_5678];
-	lea RAX, [RBP+RAX+0x12];
-	lea RAX, [RBP+RAX+0x1234];
-	lea RAX, [RBP+RAX+0x1234_5678];
-	lea RAX, [R13+RAX+0x12];
-	lea RAX, [R13+RAX+0x1234];
-	lea RAX, [R13+RAX+0x1234_5678];
+    // Disp8/32 checks
+    lea RAX, [RCX+RAX+0x12];
+    lea RAX, [RCX+RAX+0x1234];
+    lea RAX, [RCX+RAX+0x1234_5678];
+    lea RAX, [RBP+RAX+0x12];
+    lea RAX, [RBP+RAX+0x1234];
+    lea RAX, [RBP+RAX+0x1234_5678];
+    lea RAX, [R13+RAX+0x12];
+    lea RAX, [R13+RAX+0x1234];
+    lea RAX, [R13+RAX+0x1234_5678];
 
-	lea RAX, [RSP];
-	lea RAX, [R12];
+    lea RAX, [RSP];
+    lea RAX, [R12];
 
-L1:	pop	RAX	;
-	mov	p[RBP],RAX ;
+L1: pop RAX ;
+    mov p[RBP],RAX ;
     }
 
     foreach (ref i, b; data)
     {
-	//printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
-	assert(p[i] == b);
+    //printf("data[%d] = 0x%02x, should be 0x%02x\n", i, p[i], b);
+    assert(p[i] == b);
     }
 }
 
@@ -4030,7 +4030,7 @@ L1:	pop	RAX	;
 void test54()
 {   int x;
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
               0xFE, 0xC8,                // dec    AL
               0xFE, 0xCC,                // dec    AH
@@ -4110,7 +4110,7 @@ void test55()
 {   int x;
     ubyte* p;
     enum NOP = 0x9090_9090_9090_9090;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x0F, 0x87, 0xFF, 0xFF, 0, 0,    //    ja    $ + 0xFFFF
         0x72, 0x18,                      //    jb    Lb
@@ -4191,7 +4191,7 @@ void test57()
     ubyte* p;
     M64  m64;
     M128 m128;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x0F, 0x3A, 0x0F, 0xCA,       0x03,    // palignr   MM1,  MM2, 3
   0x66, 0x0F, 0x3A, 0x0F, 0xCA,       0x03,    // palignr  XMM1, XMM2, 3
@@ -4366,7 +4366,7 @@ void test58()
     int   m32;
     M64   m64;
     M128 m128;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
   0x66,       0x0F, 0x3A, 0x0D, 0xCA,        3,// blendpd  XMM1,XMM2,0x3
   0x66,       0x0F, 0x3A, 0x0D, 0x5D, 0xD0,  3,// blendpd  XMM3,XMMWORD PTR [RBP-0x30],0x3
@@ -4698,7 +4698,7 @@ void test59()
     int   m32;
     M64   m64;
     M128 m128;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
 0xF2,       0x0F, 0x38, 0xF0, 0xC1,           // crc32   EAX,  CL
 0x66, 0xF2, 0x0F, 0x38, 0xF1, 0xC1,           // crc32   EAX,  CX
@@ -4779,7 +4779,7 @@ L1:     pop     RAX;
 void test60()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x49, 0x8B, 0x00, // mov RAX, [R8]
         0x4D, 0x8B, 0x00, // mov R8, [R8]
@@ -4791,7 +4791,7 @@ void test60()
 
     asm
     {
-        call	L1;
+        call    L1;
 
         mov RAX, [R8];
         mov R8, [R8];
@@ -4816,7 +4816,7 @@ L1:
 void test61()
 {
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x0F, 0x01, 0xD0,                         // xgetbv
         0x0F, 0x01, 0xD1,                         // xsetbv
@@ -6409,7 +6409,7 @@ void test62()
     int   m32;
     M64   m64;
     M128 m128;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
 0x0F,       0x3A, 0xCC, 0xD1, 0x01,           // sha1rnds4 XMM2, XMM1, 1;
 0x0F,       0x3A, 0xCC, 0x10, 0x01,           // sha1rnds4 XMM2, [RAX], 1;
@@ -6467,21 +6467,21 @@ L1:     pop     RAX;
 void test2941()
 {
     ubyte *p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-        0x9B, 0xDF, 0xE0,	// fstsw AX;
+        0x9B, 0xDF, 0xE0,   // fstsw AX;
     ];
     int i;
 
     asm
     {
-        call	L1			;
+        call    L1          ;
 
         fstsw AX;
 
 L1:
-        pop	RBX			;
-        mov	p[RBP],RBX		;
+        pop RBX         ;
+        mov p[RBP],RBX      ;
     }
     for (i = 0; i < data.length; i++)
     {
@@ -6493,7 +6493,7 @@ L1:
 void test9866()
 {
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x48, 0x0f, 0xbe, 0xc0, // movsx RAX, AL
         0x48, 0x0f, 0xbe, 0x00, // movsx RAX, byte ptr [RAX]
@@ -6531,17 +6531,17 @@ L1:     pop     RAX;
 void testxadd()
 {   int x;
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0x0F, 0xC0, 0x10,
-	0x66, 0x0F, 0xC1, 0x10,
-	0x0F, 0xC1, 0x10,
-	0x48, 0x0F, 0xC1, 0x10,
+    0x0F, 0xC0, 0x10,
+    0x66, 0x0F, 0xC1, 0x10,
+    0x0F, 0xC1, 0x10,
+    0x48, 0x0F, 0xC1, 0x10,
     ];
 
     asm
     {
-        call	L1			;
+        call    L1          ;
 
         xadd byte ptr [RAX],DL;
         xadd word ptr [RAX],DX;
@@ -6564,26 +6564,26 @@ L1:     pop     RAX;
 void test9965()
 {
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
-	0xB7, 0x01,             // mov	BH,1
-	0x40, 0xB6, 0x01,       // mov	SIL,1
-	0x40, 0xB7, 0x01,       // mov	DIL,1
-	0x40, 0xB5, 0x01,       // mov	BPL,1
-	0x40, 0xB4, 0x01,       // mov	SPL,1
-	0x41, 0xB0, 0x01,       // mov	R8B,1
+    0xB7, 0x01,             // mov  BH,1
+    0x40, 0xB6, 0x01,       // mov  SIL,1
+    0x40, 0xB7, 0x01,       // mov  DIL,1
+    0x40, 0xB5, 0x01,       // mov  BPL,1
+    0x40, 0xB4, 0x01,       // mov  SPL,1
+    0x41, 0xB0, 0x01,       // mov  R8B,1
     ];
 
     asm
     {
         call L1;
 
-	mov BH, 1;
-	mov SIL, 1;
-	mov DIL, 1;
-	mov BPL, 1;
-	mov SPL, 1;
-	mov R8B, 1;
+    mov BH, 1;
+    mov SIL, 1;
+    mov DIL, 1;
+    mov BPL, 1;
+    mov SPL, 1;
+    mov R8B, 1;
 
 L1:     pop     RAX;
         mov     p[RBP],RAX;
@@ -6620,7 +6620,7 @@ void test12968()
 {
     int x;
     ubyte* p;
-    static ubyte data[] =
+    __gshared immutable ubyte[] data =
     [
         0x48, 0x89, 0xF8,
         0x4C, 0x87, 0xC2,
@@ -6629,7 +6629,7 @@ void test12968()
 
     asm
     {
-        call	L1			;
+        call    L1          ;
 
         mov RAX, RDI;
         xchg RDX, R8;
@@ -6666,7 +6666,7 @@ int main()
     test13();
     test14();
     test15();
-    //test16();		// add this one from \cbx\test\iasm.c ?
+    //test16();     // add this one from \cbx\test\iasm.c ?
     test17();
     test18();
     test19();


### PR DESCRIPTION
This converts the tests to use `__gshared immutable` data rather than the TLS data it was previously using. I also noticed that the tests files contained mixed tabs and spaces, so I also converted all the tabs to spaces to match phobos' style guide.
