### PR TITLE
DDOC fully-qualified anchors for template members of template structs/classes

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -529,9 +529,7 @@ static bool emitAnchorName(OutBuffer *buf, Dsymbol *s, Scope *sc)
     if (s->parent)
         dot = emitAnchorName(buf, s->parent, sc);
     else if (sc)
-    {
         dot = emitAnchorName(buf, sc->scopesym, skipNonQualScopes(sc->enclosing));
-    }
 
     // Eponymous template members can share the parent anchor name
     if (s->parent && (td = s->parent->isTemplateDeclaration()) != NULL &&

--- a/src/doc.c
+++ b/src/doc.c
@@ -527,7 +527,7 @@ static bool emitAnchorName(OutBuffer *buf, Dsymbol *s, Scope *sc)
 
     // Add parent names first
     if (s->parent)
-        dot = emitAnchorName(buf, s->parent, NULL);
+        dot = emitAnchorName(buf, s->parent, sc);
     else if (sc)
     {
         dot = emitAnchorName(buf, sc->scopesym, skipNonQualScopes(sc->enclosing));

--- a/test/compilable/extra-files/ddoc13.html
+++ b/test/compilable/extra-files/ddoc13.html
@@ -8,7 +8,7 @@
 </big></dt>
 <dd>struct doc<br><br>
 
-<dl><dt><big><a name="foo"></a>void <u>foo</u>(U)(U <i>u</i>);
+<dl><dt><big><a name="Bug4107.foo"></a>void <u>foo</u>(U)(U <i>u</i>);
 </big></dt>
 <dd>templated function doc<br><br>
 
@@ -19,19 +19,19 @@
 </big></dt>
 <dd>alpha<br><br>
 
-<dl><dt><big><a name="B"></a>struct <u>B</u>(U);
+<dl><dt><big><a name="Bug4107b.B"></a>struct <u>B</u>(U);
 </big></dt>
 <dd>beta<br><br>
 
-<dl><dt><big><a name="C"></a>struct <u>C</u>(V);
+<dl><dt><big><a name="Bug4107b.B.C"></a>struct <u>C</u>(V);
 </big></dt>
 <dd>gamma<br><br>
 
-<dl><dt><big><a name="D"></a>struct <u>D</u>(W);
+<dl><dt><big><a name="Bug4107b.B.C.D"></a>struct <u>D</u>(W);
 </big></dt>
 <dd>delta<br><br>
 
-<dl><dt><big><a name="e"></a>B!W <u>e</u>(X)(C!V <i>c</i>, X[] <i>x</i>...);
+<dl><dt><big><a name="Bug4107b.B.C.D.e"></a>B!W <u>e</u>(X)(C!V <i>c</i>, X[] <i>x</i>...);
 </big></dt>
 <dd>epsilon<br><br>
 


### PR DESCRIPTION
This is a supplementary fix of [pull 3693](https://github.com/D-Programming-Language/dmd/pull/3693). The previous pull failed to address the case of a templated member of a templated struct.

This completes the fix for [issue 10366](https://issues.dlang.org/show_bug.cgi?id=10366) (hopefully!).
