### PR TITLE
Parser improvements to handle attributes

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -920,9 +920,18 @@ void VarDeclaration::semantic(Scope *sc)
     {
         if (!originalType)
             originalType = type->syntaxCopy();
+
+        /* Prefix function attributes of variable declaration can affect
+         * its type:
+         *      pure nothrow void function() fp;
+         *      static assert(is(typeof(fp) == void function() pure nothrow));
+         */
+        Scope *sc2 = sc->push();
+        sc2->stc |= (storage_class & STC_FUNCATTR);
         inuse++;
-        type = type->semantic(loc, sc);
+        type = type->semantic(loc, sc2);
         inuse--;
+        sc2->pop();
     }
     //printf(" semantic type = %s\n", type ? type->toChars() : "null");
 

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -379,7 +379,6 @@ public:
             s->elsebody->accept(this);
             buf->level--;
             buf->writeByte('}');
-            buf->writenl();
         }
         buf->writenl();
     }
@@ -1172,7 +1171,10 @@ public:
             buf->writestring("{}");
         }
         else if (d->decl->dim == 1)
+        {
             ((*d->decl)[0])->accept(this);
+            return;
+        }
         else
         {
             buf->writenl();
@@ -1744,13 +1746,15 @@ public:
                 hgs->autoMember--;
             }
             else if (hgs->tpltMember == 0 && !global.params.useInline)
+            {
                 buf->writeByte(';');
+                buf->writenl();
+            }
             else
                 bodyToBuffer(f);
         }
         else
             bodyToBuffer(f);
-        buf->writenl();
     }
 
     void bodyToBuffer(FuncDeclaration *f)

--- a/src/parse.c
+++ b/src/parse.c
@@ -3614,7 +3614,7 @@ L2:
     if (pAttrs)
     {
         storage_class |= pAttrs->storageClass;
-        pAttrs->storageClass = STCundefined;
+        //pAttrs->storageClass = STCundefined;
     }
 
     while (1)
@@ -3676,6 +3676,16 @@ L2:
                 v = new AliasDeclaration(loc, ident, t);
             }
             v->storage_class = storage_class;
+            if (pAttrs)
+            {
+                /* AliasDeclaration distinguish @safe, @system, @trusted atttributes
+                 * on prefix and postfix.
+                 *   @safe alias void function() FP1;
+                 *   alias @safe void function() FP2;    // FP2 is not @safe
+                 *   alias void function() @safe FP3;
+                 */
+                pAttrs->storageClass &= (STCsafe | STCsystem | STCtrusted);
+            }
             Dsymbol *s = v;
 
             if (link != linkage)
@@ -3717,6 +3727,8 @@ L2:
             //printf("%s funcdecl t = %s, storage_class = x%lx\n", loc.toChars(), t->toChars(), storage_class);
             FuncDeclaration *f =
                 new FuncDeclaration(loc, Loc(), ident, storage_class | (disable ? STCdisable : 0), t);
+            if (pAttrs)
+                pAttrs->storageClass = STCundefined;
             if (tpl)
                 constraint = parseConstraint();
             Dsymbol *s = parseContracts(f);
@@ -3768,6 +3780,9 @@ L2:
 
             VarDeclaration *v = new VarDeclaration(loc, t, ident, init);
             v->storage_class = storage_class;
+            if (pAttrs)
+                pAttrs->storageClass = STCundefined;
+
             Dsymbol *s = v;
 
             if (tpl && init)

--- a/src/parse.h
+++ b/src/parse.h
@@ -78,9 +78,9 @@ public:
     Dsymbols *parseDeclDefs(int once, Dsymbol **pLastDecl = NULL, PrefixAttributes *pAttrs = NULL);
     Dsymbols *parseAutoDeclarations(StorageClass storageClass, const utf8_t *comment);
     Dsymbols *parseBlock(Dsymbol **pLastDecl, PrefixAttributes *pAttrs = NULL);
-    void composeStorageClass(StorageClass stc);
+    StorageClass appendStorageClass(StorageClass storageClass, StorageClass stc);
     StorageClass parseAttribute(Expressions **pexps);
-    StorageClass parsePostfix(Expressions **pudas);
+    StorageClass parsePostfix(StorageClass storageClass, Expressions **pudas);
     StorageClass parseTypeCtor();
     Expression *parseConstraint();
     TemplateDeclaration *parseTemplateDeclaration(bool ismixin = false);

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -27,7 +27,6 @@ template Foo(T, int V)
 		auto aa = [1:1, 2:2, 3:3];
 		int n, m;
 	}
-
 	int bar(double d, int x)
 	{
 		if (d)
@@ -132,7 +131,6 @@ template Foo(T, int V)
 			toString();
 		}
 	}
-
 }
 static this();
 interface iFoo
@@ -207,7 +205,6 @@ void templ(T)(T val)
 	pragma (msg, "Invalid destination type.");
 }
 static char[] charArray = ['"', '\''];
-
 class Point
 {
 	auto x = 10;
@@ -224,23 +221,19 @@ template Foo2(bool bar)
 		else
 		{
 		}
-
 		static if (!bar)
 		{
 		}
 		else
 		{
 		}
-
 	}
-
 }
 template Foo4()
 {
 	void bar()
 	{
 	}
-
 }
 template Foo4x(T...)
 {
@@ -263,7 +256,6 @@ auto foo7(int x)
 {
 	return 5;
 }
-
 class D8
 {
 }
@@ -286,7 +278,6 @@ template V10(T)
 			}
 		}
 	}
-
 }
 int foo11(int function() fn);
 int bar11(T)()
@@ -306,7 +297,6 @@ struct S12
 {
 	nothrow this(int n);
 	nothrow this(string s);
-
 }
 struct T12
 {
@@ -316,7 +306,6 @@ struct T12
 	immutable this(A...)(A args)
 	{
 	}
-
 }
 import std.stdio : writeln, F = File;
 void foo6591()()

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -24,7 +24,6 @@ body
 	assert(i == 2147483648u);
 	return 0;
 }
-
 struct S
 {
 	int m;
@@ -46,7 +45,6 @@ template Foo(T, int V)
 		auto aa = [1:1, 2:2, 3:3];
 		int n, m;
 	}
-
 	int bar(double d, int x)
 	{
 		if (d)
@@ -127,7 +125,6 @@ template Foo(T, int V)
 				}
 			}
 		}
-
 		loop:
 		while (x)
 		{
@@ -169,7 +166,6 @@ template Foo(T, int V)
 			toString();
 		}
 	}
-
 }
 static this();
 interface iFoo
@@ -189,11 +185,9 @@ class Foo3
 	this(int a, ...)
 	{
 	}
-
 	this(int* a)
 	{
 	}
-
 }
 alias int myint;
 static notquit = 1;
@@ -202,127 +196,96 @@ class Test
 	void a()
 	{
 	}
-
 	void b()
 	{
 	}
-
 	void c()
 	{
 	}
-
 	void d()
 	{
 	}
-
 	void e()
 	{
 	}
-
 	void f()
 	{
 	}
-
 	void g()
 	{
 	}
-
 	void h()
 	{
 	}
-
 	void i()
 	{
 	}
-
 	void j()
 	{
 	}
-
 	void k()
 	{
 	}
-
 	void l()
 	{
 	}
-
 	void m()
 	{
 	}
-
 	void n()
 	{
 	}
-
 	void o()
 	{
 	}
-
 	void p()
 	{
 	}
-
 	void q()
 	{
 	}
-
 	void r()
 	{
 	}
-
 	void s()
 	{
 	}
-
 	void t()
 	{
 	}
-
 	void u()
 	{
 	}
-
 	void v()
 	{
 	}
-
 	void w()
 	{
 	}
-
 	void x()
 	{
 	}
-
 	void y()
 	{
 	}
-
 	void z()
 	{
 	}
-
 	void aa()
 	{
 	}
-
 	void bb()
 	{
 	}
-
 	void cc()
 	{
 	}
-
 	void dd()
 	{
 	}
-
 	void ee()
 	{
 	}
-
 	template A(T)
 	{
 	}
@@ -343,7 +306,6 @@ void templ(T)(T val)
 	pragma (msg, "Invalid destination type.");
 }
 static char[] charArray = ['"', '\''];
-
 class Point
 {
 	auto x = 10;
@@ -360,23 +322,19 @@ template Foo2(bool bar)
 		else
 		{
 		}
-
 		static if (!bar)
 		{
 		}
 		else
 		{
 		}
-
 	}
-
 }
 template Foo4()
 {
 	void bar()
 	{
 	}
-
 }
 template Foo4x(T...)
 {
@@ -398,12 +356,10 @@ bool foo6(int a, int b, int c, int d)
 {
 	return (a < b) != (c < d);
 }
-
 auto foo7(int x)
 {
 	return 5;
 }
-
 class D8
 {
 }
@@ -411,7 +367,6 @@ void func8()
 {
 	scope a = new D8;
 }
-
 T func9(T)() if (true)
 {
 	T i;
@@ -430,13 +385,11 @@ template V10(T)
 			}
 		}
 	}
-
 }
 int foo11(int function() fn)
 {
 	return fn();
 }
-
 int bar11(T)()
 {
 	return foo11(function int()
@@ -451,24 +404,19 @@ struct S6360
 	{
 		return 0;
 	}
-
 	const pure nothrow @property long weeks2()
 	{
 		return 0;
 	}
-
 }
 struct S12
 {
 	nothrow this(int n)
 	{
 	}
-
 	nothrow this(string s)
 	{
 	}
-
-
 }
 struct T12
 {
@@ -478,7 +426,6 @@ struct T12
 	immutable this(A...)(A args)
 	{
 	}
-
 }
 import std.stdio : writeln, F = File;
 void foo6591()()

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -4,16 +4,12 @@ class C
 void foo(const C c, const(char)[] s, const int* q, const(int*) p)
 {
 }
-
 void bar(in void* p)
 {
 }
-
 void f(void function() f2);
-
 class C2;
 void foo2(const C2 c);
-
 struct Foo3
 {
 	int k;
@@ -32,7 +28,6 @@ class C3
 	{
 		return 0;
 	}
-
 }
 T foo3(T)()
 {
@@ -195,4 +190,3 @@ void test13275()
 	{
 	}
 }
-

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -537,6 +537,31 @@ static assert(is(typeof(&f12970k) == void function() @system));
 static assert(is(typeof(&f12970l) == void function() @system));
 
 /***************************************************/
+// Parsing prefix STC_FUNCATTR for variable declaration
+
+__gshared immutable pure nothrow @property @nogc @safe void function() prefix_qualified_fp1;
+__gshared{immutable{pure{nothrow{@property{@nogc{@safe{void function() prefix_qualified_fp2;}}}}}}}
+static assert(typeof(prefix_qualified_fp1).stringof == typeof(prefix_qualified_fp2).stringof);
+static assert(typeof(prefix_qualified_fp1).stringof
+        == "immutable(void function() pure nothrow @nogc @property @safe)");
+
+const pure nothrow @property @nogc @safe void function()[] prefix_qualified_fp_array1;
+const{pure{nothrow{@property{@nogc{@safe{void function()[] prefix_qualified_fp_array2;}}}}}}
+static assert(typeof(prefix_qualified_fp_array1).stringof == typeof(prefix_qualified_fp_array2).stringof);
+static assert(typeof(prefix_qualified_fp_array1).stringof
+        == "const(void function() pure nothrow @nogc @property @safe[])");
+
+/***************************************************/
+// Parsing prefix, intermediate, or postfix @safe for alias declaration
+
+@safe alias void function() AliasDecl_FP1;
+alias @safe void function() AliasDecl_FP2;    // is not @safe
+alias void function() @safe AliasDecl_FP3;
+static assert(AliasDecl_FP1.stringof == "void function() @safe");
+static assert(AliasDecl_FP2.stringof == "void function()");
+static assert(AliasDecl_FP3.stringof == "void function() @safe");
+
+/***************************************************/
 // 13217
 
 void writeln13217(string) {}

--- a/test/fail_compilation/fail183.d
+++ b/test/fail_compilation/fail183.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail183.d(10): Error: redundant storage class 'const'
-fail_compilation/fail183.d(10): Error: redundant storage class 'scope'
-fail_compilation/fail183.d(11): Error: redundant storage class 'in'
+fail_compilation/fail183.d(10): Error: redundant attribute 'const'
+fail_compilation/fail183.d(10): Error: redundant attribute 'scope'
+fail_compilation/fail183.d(11): Error: redundant attribute 'in'
 ---
 */
 

--- a/test/fail_compilation/fail184.d
+++ b/test/fail_compilation/fail184.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail184.d(8): Error: redundant storage class 'final'
+fail_compilation/fail184.d(8): Error: redundant attribute 'final'
 ---
 */
 

--- a/test/fail_compilation/parseStc.d
+++ b/test/fail_compilation/parseStc.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/parseStc.d(10): Error: if (v; e) is deprecated, use if (auto v = e)
-fail_compilation/parseStc.d(11): Error: redundant storage class 'const'
+fail_compilation/parseStc.d(11): Error: redundant attribute 'const'
 ---
 */
 void test1()
@@ -14,9 +14,9 @@ void test1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc.d(24): Error: redundant storage class 'const'
-fail_compilation/parseStc.d(25): Error: redundant storage class 'const'
-fail_compilation/parseStc.d(26): Error: conflicting storage class immutable
+fail_compilation/parseStc.d(24): Error: redundant attribute 'const'
+fail_compilation/parseStc.d(25): Error: redundant attribute 'const'
+fail_compilation/parseStc.d(26): Error: conflicting attribute 'immutable'
 ---
 */
 void test2()
@@ -29,8 +29,8 @@ void test2()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc.d(36): Error: redundant storage class 'const'
-fail_compilation/parseStc.d(37): Error: redundant storage class 'const'
+fail_compilation/parseStc.d(36): Error: redundant attribute 'const'
+fail_compilation/parseStc.d(37): Error: redundant attribute 'const'
 ---
 */
 struct S3 { const const test3() {} }

--- a/test/fail_compilation/parseStc2.d
+++ b/test/fail_compilation/parseStc2.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc2.d(11): Error: conflicting storage class const
-fail_compilation/parseStc2.d(12): Error: conflicting attribute @system
-fail_compilation/parseStc2.d(13): Error: conflicting attribute @safe
-fail_compilation/parseStc2.d(14): Error: conflicting attribute @trusted
-fail_compilation/parseStc2.d(15): Error: conflicting storage class __gshared
+fail_compilation/parseStc2.d(11): Error: conflicting attribute 'const'
+fail_compilation/parseStc2.d(12): Error: conflicting attribute '@system'
+fail_compilation/parseStc2.d(13): Error: conflicting attribute '@safe'
+fail_compilation/parseStc2.d(14): Error: conflicting attribute '@trusted'
+fail_compilation/parseStc2.d(15): Error: conflicting attribute '__gshared'
 ---
 */
 immutable const void f4() {}
@@ -17,10 +17,10 @@ shared __gshared f4() {}
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc2.d(26): Error: redundant storage class 'static'
-fail_compilation/parseStc2.d(27): Error: redundant storage class 'pure'
-fail_compilation/parseStc2.d(28): Error: redundant storage class '@property'
-fail_compilation/parseStc2.d(29): Error: redundant storage class '@safe'
+fail_compilation/parseStc2.d(26): Error: redundant attribute 'static'
+fail_compilation/parseStc2.d(27): Error: redundant attribute 'pure'
+fail_compilation/parseStc2.d(28): Error: redundant attribute '@property'
+fail_compilation/parseStc2.d(29): Error: redundant attribute '@safe'
 ---
 */
 static static void f1() {}

--- a/test/fail_compilation/parseStc3.d
+++ b/test/fail_compilation/parseStc3.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc3.d(10): Error: redundant storage class 'pure'
-fail_compilation/parseStc3.d(11): Error: redundant storage class 'nothrow'
-fail_compilation/parseStc3.d(12): Error: redundant storage class '@nogc'
-fail_compilation/parseStc3.d(13): Error: redundant storage class '@property'
+fail_compilation/parseStc3.d(10): Error: redundant attribute 'pure'
+fail_compilation/parseStc3.d(11): Error: redundant attribute 'nothrow'
+fail_compilation/parseStc3.d(12): Error: redundant attribute '@nogc'
+fail_compilation/parseStc3.d(13): Error: redundant attribute '@property'
 ---
 */
 pure      void f1() pure      {}
@@ -16,9 +16,9 @@ nothrow   void f2() nothrow   {}
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc3.d(24): Error: redundant storage class '@safe'
-fail_compilation/parseStc3.d(25): Error: redundant storage class '@system'
-fail_compilation/parseStc3.d(26): Error: redundant storage class '@trusted'
+fail_compilation/parseStc3.d(24): Error: redundant attribute '@safe'
+fail_compilation/parseStc3.d(25): Error: redundant attribute '@system'
+fail_compilation/parseStc3.d(26): Error: redundant attribute '@trusted'
 ---
 */
 @safe     void f6() @safe    {}
@@ -28,12 +28,12 @@ fail_compilation/parseStc3.d(26): Error: redundant storage class '@trusted'
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc3.d(39): Error: conflicting storage class '@system'
-fail_compilation/parseStc3.d(40): Error: conflicting storage class '@trusted'
-fail_compilation/parseStc3.d(41): Error: conflicting storage class '@safe'
-fail_compilation/parseStc3.d(42): Error: conflicting storage class '@trusted'
-fail_compilation/parseStc3.d(43): Error: conflicting storage class '@safe'
-fail_compilation/parseStc3.d(44): Error: conflicting storage class '@system'
+fail_compilation/parseStc3.d(39): Error: conflicting attribute '@system'
+fail_compilation/parseStc3.d(40): Error: conflicting attribute '@trusted'
+fail_compilation/parseStc3.d(41): Error: conflicting attribute '@safe'
+fail_compilation/parseStc3.d(42): Error: conflicting attribute '@trusted'
+fail_compilation/parseStc3.d(43): Error: conflicting attribute '@safe'
+fail_compilation/parseStc3.d(44): Error: conflicting attribute '@system'
 ---
 */
 @safe     void f9()  @system  {}
@@ -46,14 +46,14 @@ fail_compilation/parseStc3.d(44): Error: conflicting storage class '@system'
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc3.d(59): Error: conflicting attribute @system
-fail_compilation/parseStc3.d(59): Error: conflicting storage class '@trusted'
-fail_compilation/parseStc3.d(60): Error: conflicting attribute @system
-fail_compilation/parseStc3.d(60): Error: redundant storage class '@system'
-fail_compilation/parseStc3.d(61): Error: conflicting attribute @safe
-fail_compilation/parseStc3.d(61): Error: redundant storage class '@system'
-fail_compilation/parseStc3.d(62): Error: conflicting attribute @safe
-fail_compilation/parseStc3.d(62): Error: redundant storage class '@trusted'
+fail_compilation/parseStc3.d(59): Error: conflicting attribute '@system'
+fail_compilation/parseStc3.d(59): Error: conflicting attribute '@trusted'
+fail_compilation/parseStc3.d(60): Error: conflicting attribute '@system'
+fail_compilation/parseStc3.d(60): Error: redundant attribute '@system'
+fail_compilation/parseStc3.d(61): Error: conflicting attribute '@safe'
+fail_compilation/parseStc3.d(61): Error: redundant attribute '@system'
+fail_compilation/parseStc3.d(62): Error: conflicting attribute '@safe'
+fail_compilation/parseStc3.d(62): Error: redundant attribute '@trusted'
 ---
 */
 @safe @system  void f15() @trusted {}

--- a/test/fail_compilation/parseStc4.d
+++ b/test/fail_compilation/parseStc4.d
@@ -1,0 +1,17 @@
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc4.d(14): Error: redundant attribute 'pure'
+fail_compilation/parseStc4.d(14): Error: redundant attribute 'nothrow'
+fail_compilation/parseStc4.d(14): Error: conflicting attribute '@system'
+fail_compilation/parseStc4.d(14): Error: redundant attribute '@nogc'
+fail_compilation/parseStc4.d(14): Error: redundant attribute '@property'
+---
+*/
+pure nothrow @safe   @nogc @property
+int foo()
+pure nothrow @system @nogc @property
+{
+    return 0;
+}

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3685,7 +3685,7 @@ auto ref boo(int i) pure nothrow { return i; }
 
 class A152 {
     auto hoo(int i) pure  { return i; }
-    const boo(int i) const { return i; }
+    const boo(int i) nothrow { return i; }
     auto coo(int i) const { return i; }
     auto doo(int i) immutable { return i; }
     auto eoo(int i) shared { return i; }


### PR DESCRIPTION
I replace "storage class" word with "attribute" in diagnostic messages, because the latter is more general word.
