### PR TITLE
Refactor optimize

### DIFF
--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -728,12 +728,28 @@ void test13978()
 }
 
 /************************************/
+// Pull Request 3697
+
+void test3697and()
+{
+    enum x = 0;
+    auto y = x && 1 / x;
+}
+
+void test3697or()
+{
+    enum x = 0;
+    enum y = 1;
+    auto z = y || 1 / x;
+}
 
 int main()
 {
     test1();
     test2();
     test3();
+    test3697and();
+    test3697or();
     test6077();
     test8400();
     test8939();


### PR DESCRIPTION
Refactoring of visitors in optimize.c to simplify (perhaps) and remove boiler plate code. A lot of the visitors uses the exact same code pattern to optimize and check for errors.

In commit baef3a1 a fail compilation test fails but the change should provide a more correct solution. Both lhs and rhs should be checked for errors in a "foo || bar" expression.
