### PR TITLE
[REG2.066a] Issue 11471 - [profile+nothrow] `asm` statements rejected in `nothrow` functions if built with "-profile"

### DIFF
--- a/test/compilable/test11471.d
+++ b/test/compilable/test11471.d
@@ -1,0 +1,4 @@
+// REQUIRED_ARGS: -profile
+
+void main() nothrow
+{ asm { nop; } } // Error: asm statements are assumed to throw


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=11471

Workaround fix is introduced in e6c308938d02d1cbfc57c37c03d06bff0ec00c74, so just add a test case.
