### PR TITLE
Move CTFE paintFloatInt to Target::paintAsType

### DIFF
--- a/src/target.h
+++ b/src/target.h
@@ -16,6 +16,7 @@
 // At present it is incomplete, but in future it should grow to contain
 // most or all target machine and target O/S specific information.
 
+class Expression;
 class Type;
 
 struct Target
@@ -32,6 +33,7 @@ struct Target
     static unsigned fieldalign(Type* type);
     static unsigned critsecsize();
     static Type *va_listType();  // get type of va_list
+    static Expression *paintAsType(Expression *e, Type *type);
 };
 
 #endif


### PR DESCRIPTION
This code is compiler-implementation specific.

All floating point math in GDC is done using a synthetic type, one that can't be converted to/from native float/double, and certain one that can't be type-punned to/from native int/long.

To future proof this, one should really split this up as two functions, one to encode the fromVal into a char[] buffer, and another to interpret the char[] buffer as another type.  This would be useful in performing CTFE paints between any scalar type, or even a static array type of the same size.
