### PR TITLE
[REG2.066a] Issue 13008 - 'deprecated' is not allowed to refer another deprecated when it is a function declaration

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -442,7 +442,7 @@ void FuncDeclaration::semantic(Scope *sc)
     if (!type->deco)
     {
         sc = sc->push();
-        sc->stc |= storage_class & STCdisable;  // forward to function type
+        sc->stc |= storage_class & (STCdisable | STCdeprecated);  // forward to function type
         TypeFunction *tf = (TypeFunction *)type;
 #if 1
         /* If the parent is @safe, then this function defaults to safe

--- a/test/compilable/test13008.d
+++ b/test/compilable/test13008.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS: -d -de -dw
+/*
+TEST_OUTPUT*
+---
+---
+*/
+deprecated class Dep { }
+deprecated Dep depFunc1(); // error
+deprecated void depFunc2(Dep); // error


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13008
