### PR TITLE
[fix] Use return pointers from fromConstInitializer in EqualExp-visitor

### DIFF
--- a/src/optimize.c
+++ b/src/optimize.c
@@ -1020,7 +1020,7 @@ Expression *Expression_optimize(Expression *e, int result, bool keepLvalue)
                 return;
             }
 
-            ret = Equal(e->op, e->type, e->e1, e->e2).copy();
+            ret = Equal(e->op, e->type, e1, e2).copy();
             if (CTFEExp::isCantExp(ret))
                 ret = e;
         }


### PR DESCRIPTION
After refactoring in 0215b469 member variables e1/e2 from input argument e were used. So to keep the old behaviour, e1 and e2 from fromConstInitializer should be used instead.

I was not able to create a test to trigger any differences between e->e1/e2 and e1/e2 in an EqualExp but I assume it should be possible.
