### PR TITLE
Introduce correct default hash calculation that is consistent with object equality

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -56,6 +56,7 @@ bool needOpEquals(StructDeclaration *sd);
 FuncDeclaration *buildOpEquals(StructDeclaration *sd, Scope *sc);
 FuncDeclaration *buildXopEquals(StructDeclaration *sd, Scope *sc);
 FuncDeclaration *buildXopCmp(StructDeclaration *sd, Scope *sc);
+FuncDeclaration *buildXtoHash(StructDeclaration *ad, Scope *sc);
 FuncDeclaration *buildCpCtor(StructDeclaration *sd, Scope *sc);
 FuncDeclaration *buildPostBlit(StructDeclaration *sd, Scope *sc);
 FuncDeclaration *buildDtor(AggregateDeclaration *ad, Scope *sc);
@@ -151,6 +152,7 @@ public:
 
     FuncDeclaration *xeq;       // TypeInfo_Struct.xopEquals
     FuncDeclaration *xcmp;      // TypeInfo_Struct.xopCmp
+    FuncDeclaration *xhash;     // TypeInfo_Struct.xtoHash
     static FuncDeclaration *xerreq;      // object.xopEquals
     static FuncDeclaration *xerrcmp;     // object.xopCmp
 

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -104,6 +104,7 @@ Msgtable msgtable[] =
     { "postblit" },
     { "xopEquals", "__xopEquals" },
     { "xopCmp", "__xopCmp" },
+    { "xtoHash", "__xtoHash" },
 
     { "LINE", "__LINE__" },
     { "FILE", "__FILE__" },

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -826,12 +826,14 @@ void StructDeclaration::toObjFile(bool multiobj)
     //printf("StructDeclaration::toObjFile('%s')\n", toChars());
 
     if (type->ty == Terror)
-    {   error("had semantic errors when compiling");
+    {
+        error("had semantic errors when compiling");
         return;
     }
 
     if (multiobj && !hasStaticCtorOrDtor())
-    {   obj_append(this);
+    {
+        obj_append(this);
         return;
     }
 
@@ -878,6 +880,8 @@ void StructDeclaration::toObjFile(bool multiobj)
             xeq->toObjFile(multiobj);
         if (xcmp && xcmp != xerrcmp)
             xcmp->toObjFile(multiobj);
+        if (xhash)
+            xhash->toObjFile(multiobj);
     }
 }
 

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -131,11 +131,19 @@ void Type::genTypeInfo(Scope *sc)
             // Generate COMDAT
             if (sc)                     // if in semantic() pass
             {
-                // Find module that will go all the way to an object file
-                Module *m = sc->module->importedFrom;
-                m->members->push(t->vtinfo);
+                if (sc->func && !sc->func->isInstantiated() && sc->func->inNonRoot())
+                {
+                    // Bugzilla 13043: Avoid linking TypeInfo if it's not
+                    // necessary for root module compilation
+                }
+                else
+                {
+                    // Find module that will go all the way to an object file
+                    Module *m = sc->module->importedFrom;
+                    m->members->push(t->vtinfo);
 
-                semanticTypeInfo(sc, t);
+                    semanticTypeInfo(sc, t);
+                }
             }
             else                        // if in obj generation pass
             {

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -92,7 +92,6 @@ Expression *Type::getInternalTypeInfo(Scope *sc)
 }
 
 
-FuncDeclaration *search_toHash(StructDeclaration *sd);
 FuncDeclaration *search_toString(StructDeclaration *sd);
 
 /****************************************************
@@ -594,7 +593,7 @@ public:
         else
             dtxoff(pdt, sd->toInitializer(), 0);    // init.ptr
 
-        if (FuncDeclaration *fd = search_toHash(sd))
+        if (FuncDeclaration *fd = sd->xhash)
         {
             dtxoff(pdt, toSymbol(fd), 0);
             TypeFunction *tf = (TypeFunction *)fd->type;

--- a/test/runnable/imports/link13043a.d
+++ b/test/runnable/imports/link13043a.d
@@ -1,0 +1,17 @@
+module imports.lin13043a;
+
+struct QualifiedNameTests
+{
+    struct Inner
+    {
+        const int opCmp(ref const Inner) { return 0; }
+    }
+
+    shared(const(Inner[string])[]) data;
+
+  version(bug)
+    size_t toHash() const
+    {
+        return typeid(typeof(data)).getHash(cast(const void*)&data);
+    }
+}

--- a/test/runnable/link13043.d
+++ b/test/runnable/link13043.d
@@ -1,0 +1,5 @@
+// PERMUTE_ARGS: -g -inline -version=bug -release -O
+
+import imports.link13043a;
+
+void main() {}


### PR DESCRIPTION
[Issue 13045](https://issues.dlang.org/show_bug.cgi?id=13045) - TypeInfo.getHash should return consistent result with object equality by default
[Issue 13043](https://issues.dlang.org/show_bug.cgi?id=13043) - Redundant linking to TypeInfo in non-root module
