### PR TITLE
[BLOCKER] add missing color.* to win32.mak

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -186,7 +186,7 @@ SRCS= mars.c enum.c struct.c dsymbol.c import.c idgen.c impcnvgen.c utf.h \
 	declaration.h lexer.h expression.h statement.h doc.h doc.c \
 	macro.h macro.c hdrgen.h hdrgen.c arraytypes.h \
 	delegatize.c interpret.c ctfeexpr.c traits.c builtin.c \
-	clone.c lib.h arrayop.c nspace.h nspace.c \
+	clone.c lib.h arrayop.c nspace.h nspace.c color.h color.c \
 	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c argtypes.c \
 	apply.c sapply.c sideeffect.c ctfe.h \
 	intrange.h intrange.c canthrow.c target.c target.h visitor.h
@@ -681,6 +681,7 @@ canthrow.obj : $(TOTALH) canthrow.c
 cast.obj : $(TOTALH) expression.h mtype.h cast.c
 class.obj : $(TOTALH) enum.h class.c
 clone.obj : $(TOTALH) clone.c
+color.obj : $(TOTALH) color.h color.c
 constfold.obj : $(TOTALH) expression.h constfold.c
 cond.obj : $(TOTALH) identifier.h declaration.h cond.h cond.c
 cppmangle.obj : $(TOTALH) mtype.h declaration.h mars.h


### PR DESCRIPTION
A recent pull added color.*, but neglected to add them to win32.mak.
