### PR TITLE
Fixed VC projects after the addition of colored output to DMD

### DIFF
--- a/src/dmd_msc.vcproj
+++ b/src/dmd_msc.vcproj
@@ -394,6 +394,14 @@
 				>
 			</File>
 			<File
+				RelativePath=".\color.c"
+				>
+			</File>
+			<File
+				RelativePath=".\color.h"
+				>
+			</File>
+			<File
 				RelativePath=".\complex_t.h"
 				>
 			</File>

--- a/src/dmd_msc.vcxproj.filters
+++ b/src/dmd_msc.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="cond.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="color.c">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="constfold.c">
       <Filter>src</Filter>
     </ClCompile>
@@ -522,6 +525,9 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="attrib.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="color.h">
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="complex_t.h">


### PR DESCRIPTION
The PR to add color to DMD output failed to add the files to the VC & XCode projects. This adds the files to the VC projects.
