### PR TITLE
Forgot that the main VC project needed the file as well.

### DIFF
--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="cast.c" />
     <ClCompile Include="class.c" />
     <ClCompile Include="clone.c" />
+    <ClCompile Include="color.c" />
     <ClCompile Include="cond.c" />
     <ClCompile Include="constfold.c" />
     <ClCompile Include="cppmangle.c" />
@@ -285,6 +286,7 @@
     <ClInclude Include="aliasthis.h" />
     <ClInclude Include="arraytypes.h" />
     <ClInclude Include="attrib.h" />
+    <ClInclude Include="color.h" />
     <ClInclude Include="complex_t.h" />
     <ClInclude Include="cond.h" />
     <ClInclude Include="declaration.h" />


### PR DESCRIPTION
Well, the previous PR did fix the VC 2008 project, as well as make color.c and color.h show up in the project in Visual Studio, but I failed to add it to the main project file for VC 2010, so it wasn't actually being compiled. This fixes that.
