### PR TITLE
fix Issue 12896 - ld.gold complains about bad relocations when building libphobos2.so

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -2687,6 +2687,8 @@ static size_t writeaddrval(int targseg, size_t offset, targ_size_t val, size_t s
 size_t ElfObj::writerel(int targseg, size_t offset, unsigned reltype,
                         IDXSYM symidx, targ_size_t val)
 {
+    assert(reltype != R_X86_64_NONE);
+
     size_t sz;
     if (I64)
     {
@@ -3176,7 +3178,7 @@ static void obj_rtinit()
 {
 #if TX86
     // create brackets for .deh_eh and .minfo sections
-    IDXSYM deh_beg, deh, deh_end, minfo_beg, minfo, minfo_end, dso_rec;
+    IDXSYM deh_beg, deh_end, minfo_beg, minfo_end, dso_rec;
     IDXSTR namidx;
     int seg;
 
@@ -3186,8 +3188,7 @@ static void obj_rtinit()
     seg = ElfObj::getsegment(".deh_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
     deh_beg = MAP_SEG2SYMIDX(seg);
 
-    seg = ElfObj::getsegment(".deh_eh", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
-    deh = MAP_SEG2SYMIDX(seg);
+    ElfObj::getsegment(".deh_eh", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
 
     seg = ElfObj::getsegment(".deh_end", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
     deh_end = MAP_SEG2SYMIDX(seg);
@@ -3196,8 +3197,7 @@ static void obj_rtinit()
     seg = ElfObj::getsegment(".minfo_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
     minfo_beg = MAP_SEG2SYMIDX(seg);
 
-    seg = ElfObj::getsegment(".minfo", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
-    minfo = MAP_SEG2SYMIDX(seg);
+    ElfObj::getsegment(".minfo", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
 
     seg = ElfObj::getsegment(".minfo_end", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
     minfo_end = MAP_SEG2SYMIDX(seg);
@@ -3482,12 +3482,6 @@ static void obj_rtinit()
         // ret
         buf->writeByte(0xC3);
         off += 2;
-
-        // add fake references to pin .minfo and .deh_eh sections (--gc-sections)
-        reltype = I64 ? R_X86_64_NONE : RI_TYPE_NONE;
-        off += ElfObj::writerel(codseg, off, reltype, minfo, 0);
-        off += ElfObj::writerel(codseg, off, reltype, deh, 0);
-
         Offset(codseg) = off;
 
         // put a reference into .ctors/.dtors each

--- a/src/link.c
+++ b/src/link.c
@@ -556,21 +556,21 @@ int runLINK()
         argv.push(global.params.mapfile);
     }
 
-    /* This switch enables what is known as 'smart linking'
-     * in the Windows world, where unreferenced sections
-     * are removed from the executable. It eliminates unreferenced
-     * functions, essentially making a 'library' out of a module.
-     * Although it is documented to work with ld version 2.13,
-     * in practice it does not, but just seems to be ignored.
-     * Thomas Kuehne has verified that it works with ld 2.16.1.
-     */
-#if __linux__
-    /* Only works on linux because the linkers shipped with other
-     * OSes don't yet support this flag.
-     */
-    argv.push("-Xlinker");
-    argv.push("--gc-sections");
-#endif
+    if (0 && global.params.exefile)
+    {
+        /* This switch enables what is known as 'smart linking'
+         * in the Windows world, where unreferenced sections
+         * are removed from the executable. It eliminates unreferenced
+         * functions, essentially making a 'library' out of a module.
+         * Although it is documented to work with ld version 2.13,
+         * in practice it does not, but just seems to be ignored.
+         * Thomas Kuehne has verified that it works with ld 2.16.1.
+         * BUG: disabled because it causes exception handling to fail
+         * because EH sections are "unreferenced" and elided
+         */
+        argv.push("-Xlinker");
+        argv.push("--gc-sections");
+    }
 
     for (size_t i = 0; i < global.params.linkswitches->dim; i++)
     {   const char *p = (*global.params.linkswitches)[i];


### PR DESCRIPTION
Revert "Merge pull request #3597 from MartinNowak/fix879"

This reverts commit dc0cd23ac22bec6818d0f907aefe6fd1f58dd7b8, reversing
changes made to e01af42edb9b3d6c718940dfa04bd29649b7254f.
