### PR TITLE
[REG2.066a] Issue 13027 - Assertion `ex->op == TOKblit || ex->op == TOKconstruct' failed.

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1541,8 +1541,8 @@ Lnomatch:
                     Expression *ex = ei->exp;
                     while (ex->op == TOKcomma)
                         ex = ((CommaExp *)ex)->e2;
-                    assert(ex->op == TOKblit || ex->op == TOKconstruct);
-                    ex = ((AssignExp *)ex)->e2;
+                    if (ex->op == TOKblit || ex->op == TOKconstruct)
+                        ex = ((AssignExp *)ex)->e2;
                     if (ex->op == TOKnew)
                     {
                         // See if initializer is a NewExp that can be allocated on the stack

--- a/test/fail_compilation/ice13027.d
+++ b/test/fail_compilation/ice13027.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice13027.d(9): Error: template instance b!"c" template 'b' is not defined
+---
+*/
+void main()
+{
+    scope a = b!"c";
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13027
