### PR TITLE
Fix 13048 - Solaris no longer needs -mt during linking

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -636,10 +636,6 @@ int runLINK()
         argv.push(buf);             // turns into /usr/lib/libphobos2.a
     }
 
-#ifdef __sun
-    argv.push("-mt");
-#endif
-
 //    argv.push("-ldruntime");
     argv.push("-lpthread");
     argv.push("-lm");


### PR DESCRIPTION
As stated in the bug issue, -mt is no longer needed as of Solaris 10 (I don't think it'd be worth trying to target earlier versions given the added complexity of separate single/multi-threaded process models and how old they are now).

It also prevents the use of non-Oracle/Sun studio compilers as they don't recognize the -mt option.

https://issues.dlang.org/show_bug.cgi?id=13048
