### PR TITLE
[REG2.066a] Issue 13053 - Wrong warning on implicitly generated __xtoHash

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -518,7 +518,6 @@ FuncDeclaration *buildXopEquals(StructDeclaration *sd, Scope *sc)
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::p, NULL));
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::q, NULL));
     TypeFunction *tf = new TypeFunction(parameters, Type::tbool, 0, LINKd);
-    tf = (TypeFunction *)tf->semantic(loc, sc);
 
     Identifier *id = Id::xopEquals;
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
@@ -645,7 +644,6 @@ FuncDeclaration *buildXopCmp(StructDeclaration *sd, Scope *sc)
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::p, NULL));
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::q, NULL));
     TypeFunction *tf = new TypeFunction(parameters, Type::tint32, 0, LINKd);
-    tf = (TypeFunction *)tf->semantic(loc, sc);
 
     Identifier *id = Id::xopCmp;
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
@@ -756,7 +754,6 @@ FuncDeclaration *buildXtoHash(StructDeclaration *sd, Scope *sc)
     Parameters *parameters = new Parameters();
     parameters->push(new Parameter(STCref | STCconst, sd->type, Id::p, NULL));
     TypeFunction *tf = new TypeFunction(parameters, Type::thash_t, 0, LINKd, STCnothrow | STCtrusted);
-    tf = (TypeFunction *)tf->semantic(loc, sc);
 
     Identifier *id = Id::xtoHash;
     FuncDeclaration *fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);

--- a/test/compilable/test13053.d
+++ b/test/compilable/test13053.d
@@ -1,0 +1,13 @@
+// PERMUTE_ARGS: -w -wi
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+@system:
+
+struct S
+{
+    int[] a;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13053
