### PR TITLE
Fix Issue 13195 - Delete calls destructor but doesn't free

### DIFF
--- a/src/backend/rtlsym.h
+++ b/src/backend/rtlsym.h
@@ -94,6 +94,7 @@ SYMBOL_MARS(CALLFINALIZER, FLfunc,FREGSAVED,"_d_callfinalizer", 0, t) \
 SYMBOL_MARS(CALLINTERFACEFINALIZER, FLfunc,FREGSAVED,"_d_callinterfacefinalizer", 0, t) \
 SYMBOL_MARS(DELCLASS,      FLfunc,FREGSAVED,"_d_delclass", 0, t) \
 SYMBOL_MARS(DELINTERFACE,  FLfunc,FREGSAVED,"_d_delinterface", 0, t) \
+SYMBOL_MARS(DELSTRUCT,     FLfunc,FREGSAVED,"_d_delstruct", 0, t) \
 SYMBOL_MARS(ALLOCMEMORY,   FLfunc,FREGSAVED,"_d_allocmemory", 0, t) \
 SYMBOL_MARS(DELARRAY,      FLfunc,FREGSAVED,"_d_delarray", 0, t) \
 SYMBOL_MARS(DELARRAYT,     FLfunc,FREGSAVED,"_d_delarray_t", 0, t) \

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3579,6 +3579,17 @@ elem *toElem(Expression *e, IRState *irs)
                 case Tpointer:
                     e = addressElem(e, de->e1->type);
                     rtl = RTLSYM_DELMEMORY;
+                    tb = ((TypePointer *)tb)->next->toBasetype();
+                    if (tb->ty == Tstruct)
+                    {
+                        TypeStruct *ts = (TypeStruct *)tb;
+                        if (ts->sym->dtor)
+                        {
+                            rtl = RTLSYM_DELSTRUCT;
+                            elem *et = tb->getTypeInfo(NULL)->toElem(irs);
+                            e = el_params(et, e, NULL);
+                        }
+                    }
                     break;
 
                 default:

--- a/src/expression.c
+++ b/src/expression.c
@@ -9547,7 +9547,7 @@ Expression *DeleteExp::semantic(Scope *sc)
                 FuncDeclaration *f = sd->aggDelete;
                 FuncDeclaration *fd = sd->dtor;
 
-                if (!f && !fd)
+                if (!f)
                     break;
 
                 /* Construct:

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2395,32 +2395,44 @@ Foo9320 test9320(Foo9320 a, Foo9320 b, Foo9320 c) {
 struct Test9386
 {
     string name;
-    static string op;
+    static char[21] op;
+    static size_t i;
+
+    static @property string sop() { return cast(string)op[0..i]; }
 
     this(string name)
     {
         this.name = name;
         printf("Created %.*s...\n", name.length, name.ptr);
-        op ~= "a";
+        assert(i + 1 < op.length);
+        op[i++] = 'a';
     }
 
     this(this)
     {
         printf("Copied %.*s...\n", name.length, name.ptr);
-        op ~= "b";
+        assert(i + 1 < op.length);
+        op[i++] = 'b';
     }
 
     ~this()
     {
         printf("Deleted %.*s\n", name.length, name.ptr);
-        op ~= "c";
+        assert(i + 1 < op.length);
+        op[i++] = 'c';
+    }
+
+    const int opCmp(ref const Test9386 t)
+    {
+        return op[0] - t.op[0];
     }
 }
 
 void test9386()
 {
     {
-        Test9386.op = null;
+        Test9386.op[] = 0;
+        Test9386.i = 0;
 
         Test9386[] tests =
             [ Test9386("one"),
@@ -2428,30 +2440,33 @@ void test9386()
               Test9386("three"),
               Test9386("four") ];
 
-        assert(Test9386.op == "aaaa");
-        Test9386.op = null;
+        assert(Test9386.sop == "aaaa");
+        Test9386.op[] = 0;
+        Test9386.i = 0;
 
         printf("----\n");
         foreach (Test9386 test; tests)
         {
             printf("\tForeach %.*s\n", test.name.length, test.name.ptr);
-            Test9386.op ~= "x";
+            Test9386.op[Test9386.i++] = 'x';
         }
 
-        assert(Test9386.op == "bxcbxcbxcbxc");
-        Test9386.op = null;
+        assert(Test9386.sop == "bxcbxcbxcbxc");
+        Test9386.op[] = 0;
+        Test9386.i = 0;
 
         printf("----\n");
         foreach (ref Test9386 test; tests)
         {
             printf("\tForeach %.*s\n", test.name.length, test.name.ptr);
-            Test9386.op ~= "x";
+            Test9386.op[Test9386.i++] = 'x';
         }
-        assert(Test9386.op == "xxxx");
+        assert(Test9386.sop == "xxxx");
     }
     printf("====\n");
     {
-        Test9386.op = null;
+        Test9386.op[] = 0;
+        Test9386.i = 0;
 
         Test9386[Test9386] tests =
             [ Test9386("1") : Test9386("one"),
@@ -2459,28 +2474,32 @@ void test9386()
               Test9386("3") : Test9386("three"),
               Test9386("4") : Test9386("four") ];
 
-        assert(Test9386.op == "aaaaaaaa");
-        Test9386.op = null;
+        assert(Test9386.sop == "aaaaaaaa");
+        Test9386.op[] = 0;
+        Test9386.i = 0;
 
         printf("----\n");
         foreach (Test9386 k, Test9386 v; tests)
         {
             printf("\tForeach %.*s : %.*s\n", k.name.length, k.name.ptr,
                                               v.name.length, v.name.ptr);
-            Test9386.op ~= "x";
+            Test9386.op[Test9386.i++] = 'x';
         }
 
-        assert(Test9386.op == "bbxccbbxccbbxccbbxcc");
-        Test9386.op = null;
+        assert(Test9386.sop == "bbxccbbxccbbxccbbxcc");
+        Test9386.op[] = 0;
+        Test9386.i = 0;
 
         printf("----\n");
         foreach (Test9386 k, ref Test9386 v; tests)
         {
             printf("\tForeach %.*s : %.*s\n", k.name.length, k.name.ptr,
                                               v.name.length, v.name.ptr);
-            Test9386.op ~= "x";
+            Test9386.op[Test9386.i++] = 'x';
         }
-        assert(Test9386.op == "bxcbxcbxcbxc");
+        assert(Test9386.sop == "bxcbxcbxcbxc");
+        Test9386.op[] = 0;
+        Test9386.i = 0;
     }
 }
 


### PR DESCRIPTION
~~This is the accompanying PR (which this requires) to D-Programming-Language/druntime#864, which includes the fix to the delete operator so that it will free the memory of pointers to structures that only have a destructor defined. Due to the overlap in required code between my fix for the delete issue and the fix to call destructors on structs, it would be very difficult to make them 2 separate PRs, so I have instead opted to stay with 1 PR which fixes both.~~

Originally this PR was part of fixing the GC, but I did finally separate the druntime code required for this PR so that it can be done independently of the main PR.
