### PR TITLE
Fix bogus zero-length array test.

### DIFF
--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -6243,13 +6243,21 @@ void test161()
 }
 
 /***************************************************/
+// 7175
+
+void test7175()
+{
+    struct S { ubyte[0] arr; }
+    S s;
+    assert(s.arr.ptr !is null);
+    assert(cast(void*)s.arr.ptr is cast(void*)&s);
+}
+
+/***************************************************/
 // 8819
 
 void test8819()
 {
-    void[0] sa0 = (void[0]).init;
-    assert(sa0.ptr !is null); // 7175 - ptr should not be null
-
     void[1] sa1 = (void[1]).init;
     assert((cast(ubyte*)sa1.ptr)[0] == 0);
 
@@ -7203,6 +7211,7 @@ int main()
     test199();
     test8526();
     test161();
+    test7175();
     test8819();
     test8917();
     test8945();


### PR DESCRIPTION
Issue 7175 was about .ptr always giving null for a zero-length
static array in a struct, despite the fact that the struct has
size 1 and thus certainly a non-null address.

The test case as modified by 36c9b64, however, checks that a
free-standing zero-length static array on the stack has an
address, which is quite a different scenario. From the spec,
I don't see a reason why zero-sized objects should need any
memory associated with them, so I am reluctant to pessimize
LDC's codegen over this.
