### PR TITLE
[REG2.066a] Issue 13087 - Error: no property 'xyz' for type 'Vec!4'

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -3425,7 +3425,7 @@ IntRange getIntRange(Expression *e)
             if (vd && vd->range)
                 range = vd->range->cast(e->type);
             else if (vd && vd->init && !vd->type->isMutable() &&
-                (ie = vd->getConstInitializer()))
+                (ie = vd->getConstInitializer()) != NULL)
                 ie->accept(this);
             else
                 visit((Expression *)e);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6510,7 +6510,9 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                 if (v->storage_class & (STCconst | STCimmutable | STCmanifest) ||
                     v->type->isConst() || v->type->isImmutable())
                 {
-                    goto L3;
+                    // Bugzilla 13087: this.field is not constant always
+                    if (!v->isThisDeclaration())
+                        goto L3;
                 }
             }
             if (!sm)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1038,6 +1038,20 @@ Type *Type::addSTC(StorageClass stc)
 }
 
 /************************************
+ * Convert MODxxxx to STCxxx
+ */
+
+StorageClass ModToStc(unsigned mod)
+{
+    StorageClass stc;
+    if (mod & MODimmutable) stc |= STCimmutable;
+    if (mod & MODconst)     stc |= STCconst;
+    if (mod & MODwild)      stc |= STCwild;
+    if (mod & MODshared)    stc |= STCshared;
+    return stc;
+}
+
+/************************************
  * Apply MODxxxx bits to existing type.
  */
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -54,6 +54,7 @@ class TypeTuple;
 void semanticTypeInfo(Scope *sc, Type *t);
 MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL, size_t inferStart = 0);
 Type *reliesOnTident(Type *t, TemplateParameters *tparams = NULL, size_t iStart = 0);
+StorageClass ModToStc(unsigned mod);
 
 enum ENUMTY
 {

--- a/src/template.c
+++ b/src/template.c
@@ -2597,7 +2597,10 @@ FuncDeclaration *TemplateDeclaration::doHeaderInstantiation(
                 hasttp = true;
         }
         if (hasttp)
-            tf = (TypeFunction *)tf->addMod(tthis->mod);
+        {
+            tf = (TypeFunction *)tf->addSTC(ModToStc(tthis->mod));
+            assert(!tf->deco);
+        }
     }
 
     Scope *scx = sc2->push();

--- a/test/compilable/ice13088.d
+++ b/test/compilable/ice13088.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+struct X
+{
+    void mfoo(this T)() {}
+}
+void test()
+{
+    shared const X scx;
+
+    scx.mfoo();
+}
+
+struct Vec
+{
+    int x;
+    void sc() shared const {}
+}

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -3457,6 +3457,28 @@ void f12880(T)(in T value) { static assert(is(T == string)); }
 void test12880() { f12880(string.init); }
 
 /******************************************/
+// 13087
+
+struct Vec13087
+{
+    int x;
+    void m()                      { auto n = component13087!(this, 'x'); }
+    void c() const                { auto n = component13087!(this, 'x'); }
+    void w() inout                { auto n = component13087!(this, 'x'); }
+    void wc() inout const         { auto n = component13087!(this, 'x'); }
+    void s() shared               { auto n = component13087!(this, 'x'); }
+    void sc() shared const        { auto n = component13087!(this, 'x'); }
+    void sw() shared inout        { auto n = component13087!(this, 'x'); }
+    void swc() shared inout const { auto n = component13087!(this, 'x'); }
+    void i() immutable            { auto n = component13087!(this, 'x'); }
+}
+
+template component13087(alias vec, char c)
+{
+    alias component13087 = vec.x;
+}
+
+/******************************************/
 
 int main()
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13087

While I fixing the bug, I found another ICE issue in `runnable/template9.d`.
[Issue 13088](https://issues.dlang.org/show_bug.cgi?id=13088) - Compiler segfaults with trivial case code.
