### PR TITLE
Add regression test for bug 7068.

### DIFF
--- a/test/runnable/bug7068.d
+++ b/test/runnable/bug7068.d
@@ -1,0 +1,11 @@
+// PERMUTE_ARGS: -inline -g -O -d
+void main()
+{
+    auto darray1 = new int*[](10);
+    foreach(ref v; darray1)
+        v = new int;
+    auto darray2 = new int*[](10);
+    darray2[] = darray1[]; // calls memset instead of memcpy
+    foreach(i; 0 .. 10)
+        assert(darray1[i] == darray2[i]);
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=7068

This bug was closed without adding a test, adding the test now so that the work-around can be removed from druntime (https://github.com/D-Programming-Language/druntime/pull/875 .)
