### PR TITLE
[reg] fix Issue 13084 - ModuleInfo.opApply delegate expects immutable parameter

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -59,6 +59,7 @@ Msgtable msgtable[] =
     { "offset" },
     { "offsetof" },
     { "ModuleInfo" },
+    { "_ModuleInfo" },
     { "ClassInfo" },
     { "classinfo" },
     { "typeinfo" },

--- a/src/struct.c
+++ b/src/struct.c
@@ -634,7 +634,11 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
     // For forward references
     type = new TypeStruct(this);
 
-    if (id == Id::ModuleInfo && !Module::moduleinfo)
+    /* Recognize both identifiers for the moment so that testing with druntine
+     * is easier.
+     */
+    if ((id == Id::ModuleInfo ||
+         id == Id::_ModuleInfo) && !Module::moduleinfo)
         Module::moduleinfo = this;
 }
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13084

Also requires https://github.com/D-Programming-Language/druntime/pull/886

The changes are pretty self-explanatory, it avoids breaking ModuleInfo code because it is now immutable.
