### PR TITLE
Fixed most clang warnings

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -413,8 +413,8 @@ void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d)
     }
     if (!e)
     {
-        if (d->prot() == PROTprivate && d->getAccessModule() != sc->module ||
-            d->prot() == PROTpackage && !hasPackageAccess(sc, d))
+        if ((d->prot() == PROTprivate && d->getAccessModule() != sc->module) ||
+            (d->prot() == PROTpackage && !hasPackageAccess(sc, d)))
         {
             error(loc, "%s %s is not accessible from module %s",
                 d->kind(), d->toPrettyChars(), sc->module->toChars());

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1012,10 +1012,10 @@ void PragmaDeclaration::semantic(Scope *sc)
                 dchar_t c = p[i];
                 if (c < 0x80)
                 {
-                    if (c >= 'A' && c <= 'Z' ||
-                        c >= 'a' && c <= 'z' ||
-                        c >= '0' && c <= '9' ||
-                        c != 0 && strchr("$%().:?@[]_", c))
+                    if ((c >= 'A' && c <= 'Z') ||
+                        (c >= 'a' && c <= 'z') ||
+                        (c >= '0' && c <= '9') ||
+                        (c != 0 && strchr("$%().:?@[]_", c)))
                     {
                         ++i;
                         continue;

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -1959,10 +1959,10 @@ STATIC code * cse_save(regm_t ms)
                     tym_t tym = e->Ety;
                     unsigned sz = tysize(tym);
                     if (sz <= REGSIZE ||
-                        sz <= 2 * REGSIZE &&
-                            (regm & mMSW && csextab[i].regm & mMSW ||
-                             regm & mLSW && csextab[i].regm & mLSW) ||
-                        sz == 4 * REGSIZE && regm == csextab[i].regm
+                        (sz <= 2 * REGSIZE &&
+                            ((regm & mMSW && csextab[i].regm & mMSW) ||
+                             (regm & mLSW && csextab[i].regm & mLSW))) ||
+                        (sz == 4 * REGSIZE && regm == csextab[i].regm)
                        )
                     {
                         ms &= ~regm;

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -1262,9 +1262,9 @@ STATIC elem * elbitwise(elem *e, goal_t goal)
 
                 if (
                     /* OK for unsigned if AND or high bits of i are 0   */
-                    op == OPu8_16 && (e->Eoper == OPand || !(i & ~0xFF)) ||
+                    (op == OPu8_16 && (e->Eoper == OPand || !(i & ~0xFF))) ||
                     /* OK for signed if i is 'sign-extended'    */
-                    op == OPs8_16 && (targ_short)(targ_schar)i == i
+                    (op == OPs8_16 && (targ_short)(targ_schar)i == i)
                    )
                 {
                         /* Convert ((u8int) e) & i) to (u8int)(e & (int8) i) */
@@ -1324,12 +1324,12 @@ STATIC elem * elbitwise(elem *e, goal_t goal)
                 }
             }
 
-            if (op == OPs16_32 && (ul & 0xFFFFFFFFFFFF8000LL) == 0 ||
-                op == OPu16_32 && (ul & 0xFFFFFFFFFFFF0000LL) == 0 ||
-                op == OPs8_16  && (ul & 0xFFFFFFFFFFFFFF80LL) == 0 ||
-                op == OPu8_16  && (ul & 0xFFFFFFFFFFFFFF00LL) == 0 ||
-                op == OPs32_64 && (ul & 0xFFFFFFFF80000000LL) == 0 ||
-                op == OPu32_64 && (ul & 0xFFFFFFFF00000000LL) == 0
+            if ((op == OPs16_32 && (ul & 0xFFFFFFFFFFFF8000LL) == 0) ||
+                (op == OPu16_32 && (ul & 0xFFFFFFFFFFFF0000LL) == 0) ||
+                (op == OPs8_16  && (ul & 0xFFFFFFFFFFFFFF80LL) == 0) ||
+                (op == OPu8_16  && (ul & 0xFFFFFFFFFFFFFF00LL) == 0) ||
+                (op == OPs32_64 && (ul & 0xFFFFFFFF80000000LL) == 0) ||
+                (op == OPu32_64 && (ul & 0xFFFFFFFF00000000LL) == 0)
                )
             {
                 if (e->Eoper == OPand)
@@ -3914,9 +3914,9 @@ L1:
         tym_t tym;
         int sz;
 
-        if (e1->Eoper == OPu16_32 && e2->EV.Vulong <= (targ_ulong) SHORTMASK ||
-                 e1->Eoper == OPs16_32 &&
-                 e2->EV.Vlong == (targ_short) e2->EV.Vlong)
+        if ((e1->Eoper == OPu16_32 && e2->EV.Vulong <= (targ_ulong) SHORTMASK) ||
+                 (e1->Eoper == OPs16_32 &&
+                 e2->EV.Vlong == (targ_short) e2->EV.Vlong))
         {
                 tym = (uns || e1->Eoper == OPu16_32) ? TYushort : TYshort;
                 e->E2 = el_una(OP32_16,tym,e2);
@@ -3970,9 +3970,9 @@ L1:
             }
         }
 
-        if (e1->Eoper == OPu8_16 && e2->EV.Vuns < 256 ||
-                 e1->Eoper == OPs8_16 &&
-                 e2->EV.Vint == (targ_schar) e2->EV.Vint)
+        if ((e1->Eoper == OPu8_16 && e2->EV.Vuns < 256) ||
+                 (e1->Eoper == OPs8_16 &&
+                 e2->EV.Vint == (targ_schar) e2->EV.Vint))
         {
                 tym = (uns || e1->Eoper == OPu8_16) ? TYuchar : TYschar;
                 e->E2 = el_una(OP16_8,tym,e2);
@@ -4418,8 +4418,8 @@ STATIC elem * el64_32(elem *e, goal_t goal)
 
     case OPshr:                 // OP64_32(x >> 32) => OPmsw(x)
         if (e1->E2->Eoper == OPconst &&
-            (e->Eoper == OP64_32 && el_tolong(e1->E2) == 32 && !I64 ||
-             e->Eoper == OP128_64 && el_tolong(e1->E2) == 64 && I64)
+            ((e->Eoper == OP64_32 && el_tolong(e1->E2) == 32 && !I64) ||
+             (e->Eoper == OP128_64 && el_tolong(e1->E2) == 64 && I64))
            )
         {
             e->Eoper = OPmsw;

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -634,7 +634,7 @@ L1:
   code_newreg(cs, reg);                         // OR in reg field
   if (!I16)
   {
-      if (reg == 6 && op == 0xFF ||             /* don't PUSH a word    */
+      if ((reg == 6 && op == 0xFF) ||           /* don't PUSH a word    */
           op == 0x0FB7 || op == 0x0FBF ||       /* MOVZX/MOVSX          */
           (op & 0xFFF8) == 0xD8 ||              /* 8087 instructions    */
           op == 0x8D)                           /* LEA                  */
@@ -1390,8 +1390,8 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
              * the opcode. The only way to deal with this is to prevent enregistering
              * such variables.
              */
-            if (tyxmmreg(ty) && !(s->Sregm & XMMREGS) ||
-                !tyxmmreg(ty) && (s->Sregm & XMMREGS))
+            if ((tyxmmreg(ty) && !(s->Sregm & XMMREGS)) ||
+                (!tyxmmreg(ty) && (s->Sregm & XMMREGS)))
                 cgreg_unregister(s->Sregm);
 
             if (
@@ -2836,22 +2836,26 @@ code *cdfunc(elem *e,regm_t *pretregs)
                     if (v ^ (preg != mreg))
                     {
                         if (preg != lreg)
+                        {
                             if (mask[preg] & XMMREGS)
                             {   unsigned op = xmmload(ty1);            // MOVSS/D preg,lreg
                                 c1 = gen2(c1,op,modregxrmx(3,preg-XMM0,lreg-XMM0));
                             }
                             else
                                 c1 = genmovreg(c1, preg, lreg);
+                        }
                     }
                     else
                     {
                         if (preg2 != mreg)
+                        {
                             if (mask[preg2] & XMMREGS)
                             {   unsigned op = xmmload(ty2);            // MOVSS/D preg2,mreg
                                 c1 = gen2(c1,op,modregxrmx(3,preg2-XMM0,mreg-XMM0));
                             }
                             else
                                 c1 = genmovreg(c1, preg2, mreg);
+                        }
                     }
                 }
 
@@ -4211,7 +4215,7 @@ code *loaddata(elem *e,regm_t *pretregs)
                 ce = movregconst(CNIL,sreg,lsw,0);
                 reg = findregmsw(forregs);
                 /* Decide if we need to set flags when we load msw      */
-                if (flags && (msw && msw|lsw || !(msw|lsw)))
+                if (flags && ((msw && msw|lsw) || !(msw|lsw)))
                 {   mswflags = mPSW;
                     flags = 0;
                 }

--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -331,8 +331,8 @@ code *cdorth(elem *e,regm_t *pretregs)
         // Handle the case of ((e + c) + e2)
         if (!I16 &&
             e1oper == OPadd &&
-            (e1->E2->Eoper == OPconst && el_signx32(e1->E2) ||
-             e2oper == OPconst && el_signx32(e2)) &&
+            ((e1->E2->Eoper == OPconst && el_signx32(e1->E2)) ||
+             (e2oper == OPconst && el_signx32(e2))) &&
             !e1->Ecount
            )
         {   elem *e11;
@@ -3898,7 +3898,7 @@ code *cdstreq(elem *e,regm_t *pretregs)
         {
             c1a = cdrelconst(e2,&srcregs);
             segreg = segfl[el_fl(e2)];
-            if ((config.wflags & WFssneds) && segreg == SEG_SS || /* if source is on stack */
+            if (((config.wflags & WFssneds) && segreg == SEG_SS) || /* if source is on stack */
                 segreg == SEG_CS)               /* if source is in CS */
             {   code *c;
 

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -2545,7 +2545,7 @@ code *movregconst(code *c,unsigned reg,targ_size_t value,regm_t flags)
             {
                 if ((regcon.immed.value[r] & 0xFF) == value)
                 {   c = genregs(c,0x8A,reg,r);          // MOV regL,rL
-                    if (I64 && reg >= 4 || r >= 4)
+                    if ((I64 && reg >= 4) || r >= 4)
                         code_orrex(c, REX);
                     goto L2;
                 }
@@ -4201,7 +4201,7 @@ int branch(block *bl,int flag)
         csize = calccodsize(c);
         cn = code_next(c);
         op = c->Iop;
-        if ((op & ~0x0F) == 0x70 && c->Iflags & CFjmp16 ||
+        if (((op & ~0x0F) == 0x70 && c->Iflags & CFjmp16) ||
             (op == JMP && !(c->Iflags & CFjmp5)))
         {
           L1:
@@ -4513,7 +4513,7 @@ void assignaddrc(code *c)
         {
 
             if (
-                ((rm & 0xC0) == 0 && !((rm & 7) == 4 && (c->Isib & 7) == 5 || (rm & 7) == 5))
+                ((rm & 0xC0) == 0 && !(((rm & 7) == 4 && (c->Isib & 7) == 5) || (rm & 7) == 5))
                )
                 goto do2;       /* if no first operand  */
         }
@@ -5001,9 +5001,9 @@ void pinholeopt(code *c,block *b)
 
                 /* Look for TEST or OR or XOR with an immediate constant */
                 /* that we can replace with a byte operation            */
-                if (op == 0xF7 && reg == modregrm(0,0,0) ||
-                    op == 0x81 && reg == modregrm(0,6,0) && !flags ||
-                    op == 0x81 && reg == modregrm(0,1,0))
+                if ((op == 0xF7 && reg == modregrm(0,0,0)) ||
+                    (op == 0x81 && reg == modregrm(0,6,0) && !flags) ||
+                    (op == 0x81 && reg == modregrm(0,1,0)))
                 {
                     // See if we can replace a dword with a word
                     // (avoid for 32 bit instructions, because CFopsize
@@ -5641,7 +5641,7 @@ Lmodrm:
                 size++;
             switch (mod)
             {   case 0:
-                    if (issib(rm) && (c->Isib & 7) == 5 ||
+                    if ((issib(rm) && (c->Isib & 7) == 5) ||
                         (rm & 7) == 5)
                         size += 4;      /* disp32                       */
                     if (c->Irex & REX_B && (rm & 7) == 5)
@@ -6046,7 +6046,7 @@ unsigned codout(code *c)
                         do8bit((enum FL) c->IFL1,&c->IEV1);     // 8 bit
                         break;
                     case 0:
-                        if (!(issib(rm) && (c->Isib & 7) == 5 ||
+                        if (!((issib(rm) && (c->Isib & 7) == 5) ||
                               (rm & 7) == 5))
                             break;
                     case 0x80:

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -361,14 +361,14 @@ code *cdeq(elem *e,regm_t *pretregs)
   {     int fl;
 
         if ((e2oper == OPconst ||       /* if rvalue is a constant      */
-             e2oper == OPrelconst &&
-             !(I64 && (config.flags3 & CFG3pic || config.exe == EX_WIN64)) &&
-             ((fl = el_fl(e2)) == FLdata ||
-              fl==FLudata || fl == FLextern)
+             (e2oper == OPrelconst
+              && !(I64 && (config.flags3 & CFG3pic || config.exe == EX_WIN64))
+              && ((fl = el_fl(e2)) == FLdata ||
+                   fl == FLudata || fl == FLextern)
 #if TARGET_SEGMENTED
               && !(e2->EV.sp.Vsym->ty() & mTYcs)
 #endif
-            ) &&
+            )) &&
             !evalinregister(e2) &&
             !e1->Ecount)        /* and no CSE headaches */
         {
@@ -1874,8 +1874,8 @@ code *cdcmp(elem *e,regm_t *pretregs)
   /* routine, because we don't know the target of the signed branch     */
   /* (have to set up flags so that jmpopcode() will do it right)        */
   if (!eqorne &&
-        (I16 && tym == TYlong  && tybasic(e2->Ety) == TYlong ||
-         I32 && tym == TYllong && tybasic(e2->Ety) == TYllong)
+        ((I16 && tym == TYlong  && tybasic(e2->Ety) == TYlong) ||
+         (I32 && tym == TYllong && tybasic(e2->Ety) == TYllong))
      )
   {
         assert(jop != JC && jop != JNC);
@@ -2119,8 +2119,8 @@ code *cdcmp(elem *e,regm_t *pretregs)
          * common subexpression
          */
 
-        if ((e1->Eoper == OPvar && datafl[el_fl(e1)] ||
-             e1->Eoper == OPind) &&
+        if (((e1->Eoper == OPvar && datafl[el_fl(e1)]) ||
+              e1->Eoper == OPind) &&
             !evalinregister(e1))
         {       cl = getlvalue(&cs,e1,RMload);
                 freenode(e1);
@@ -2484,8 +2484,8 @@ code *longcmp(elem *e,bool jcond,unsigned fltarg,code *targ)
          * common subexpression
          */
 
-        if ((e1->Eoper == OPvar && datafl[el_fl(e1)] ||
-             e1->Eoper == OPind) &&
+        if (((e1->Eoper == OPvar && datafl[el_fl(e1)]) ||
+              e1->Eoper == OPind) &&
             !evalinregister(e1))
         {       cl = getlvalue(&cs,e1,0);
                 freenode(e1);
@@ -2848,7 +2848,7 @@ code *cdshtlng(elem *e,regm_t *pretregs)
         c = cat(c1,c2);
   }
   else if (!I16 && (op == OPs16_32 || op == OPu16_32) ||
-            I64 && op == OPs32_64)
+            (I64 && op == OPs32_64))
   {
     elem *e11;
 
@@ -3154,8 +3154,8 @@ code *cdlngsht(elem *e,regm_t *pretregs)
             bool isOff = false;
 #endif
             if (I16 ||
-                I32 && (isOff || e->Eoper == OP64_32) ||
-                I64 && (isOff || e->Eoper == OP128_64))
+                (I32 && (isOff || e->Eoper == OP64_32)) ||
+                (I64 && (isOff || e->Eoper == OP128_64)))
                 retregs &= mLSW;                /* want LSW only        */
         }
   }

--- a/src/backend/glocal.c
+++ b/src/backend/glocal.c
@@ -406,8 +406,8 @@ Loop:
                     f2 = local_getflags(e->E2,s);
                     if (f1 & f2 & LFsymref ||   // if both reference or
                         (f1 | f2) & LFsymdef || // either define
-                        f & LFambigref && (f1 | f2) & LFambigdef ||
-                        f & LFambigdef && (f1 | f2) & (LFambigref | LFambigdef)
+                        (f & LFambigref && (f1 | f2) & LFambigdef) ||
+                        (f & LFambigdef && (f1 | f2) & (LFambigref | LFambigdef))
                        )
                         local_rem(u);
                     else if (f & LFunambigdef && local_chkrem(e,eu->E2))

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -2180,7 +2180,7 @@ STATIC void findbasivs(loop *l)
                 if ((n->Eoper == OPaddass || n->Eoper == OPminass ||
                      n->Eoper == OPpostinc || n->Eoper == OPpostdec) &&
                         (cnst(n->E2) || /* if x += c or x -= c          */
-                         n->E2->Eoper == OPvar && isLI(n->E2)))
+                         (n->E2->Eoper == OPvar && isLI(n->E2))))
                 {       if (vec_testbit(v,poss))
                                 /* We've already seen this def elem,    */
                                 /* therefore there is more than one     */
@@ -2507,7 +2507,7 @@ STATIC void ivfamelems(register Iv *biv,register elem **pn)
                         fl->c1 = el_una(op,ty,fl->c1); /* c1 = -1       */
                 }
                 else if (n2->Eoper == OPconst ||
-                         isLI(n2) && (op == OPadd || op == OPmin))
+                         (isLI(n2) && (op == OPadd || op == OPmin)))
                 {       register famlist *fl;
 
 #ifdef DEBUG
@@ -2575,7 +2575,7 @@ STATIC void ivfamelems(register Iv *biv,register elem **pn)
 
                 }
                 else if (n2->Eoper == OPconst ||
-                         isLI(n2) && (op == OPadd || op == OPmin))
+                         (isLI(n2) && (op == OPadd || op == OPmin)))
                 {
 #ifdef DEBUG
                         if (debugc)
@@ -3014,8 +3014,8 @@ STATIC void elimbasivs(register loop *l)
                    by -1
                  */
                 if (!tyuns(ty) &&
-                    (tyintegral(ty) && el_tolong(fl->c1) < 0 ||
-                     tyfloating(ty) && el_toldouble(fl->c1) < 0.0))
+                    ((tyintegral(ty) && el_tolong(fl->c1) < 0) ||
+                     (tyfloating(ty) && el_toldouble(fl->c1) < 0.0)))
                         refEoper = swaprel(refEoper);
 
                 /* Replace (X relop e) with (X relop (short)e)
@@ -3341,7 +3341,7 @@ STATIC famlist * flcmp(famlist *f1,famlist *f2)
             case TYschar:
             case TYuchar:
                 if (t2->Vuchar == 1 ||
-                    t1->Vuchar != 1 && f2->c2->EV.Vuchar == 0)
+                    (t1->Vuchar != 1 && f2->c2->EV.Vuchar == 0))
                         goto Lf2;
                 break;
             case TYshort:
@@ -3350,7 +3350,7 @@ STATIC famlist * flcmp(famlist *f1,famlist *f2)
             case TYwchar_t:     // BUG: what about 4 byte wchar_t's?
             case_short:
                 if (t2->Vshort == 1 ||
-                    t1->Vshort != 1 && f2->c2->EV.Vshort == 0)
+                    (t1->Vshort != 1 && f2->c2->EV.Vshort == 0))
                         goto Lf2;
                 break;
 
@@ -3379,29 +3379,29 @@ STATIC famlist * flcmp(famlist *f1,famlist *f2)
 #endif
             case_long:
                 if (t2->Vlong == 1 ||
-                    t1->Vlong != 1 && f2->c2->EV.Vlong == 0)
+                    (t1->Vlong != 1 && f2->c2->EV.Vlong == 0))
                         goto Lf2;
                 break;
             case TYfloat:
                 if (t2->Vfloat == 1 ||
-                    t1->Vfloat != 1 && f2->c2->EV.Vfloat == 0)
+                    (t1->Vfloat != 1 && f2->c2->EV.Vfloat == 0))
                         goto Lf2;
                 break;
             case TYdouble:
             case TYdouble_alias:
                 if (t2->Vdouble == 1.0 ||
-                    t1->Vdouble != 1.0 && f2->c2->EV.Vdouble == 0)
+                    (t1->Vdouble != 1.0 && f2->c2->EV.Vdouble == 0))
                         goto Lf2;
                 break;
             case TYldouble:
                 if (t2->Vldouble == 1.0 ||
-                    t1->Vldouble != 1.0 && f2->c2->EV.Vldouble == 0)
+                    (t1->Vldouble != 1.0 && f2->c2->EV.Vldouble == 0))
                         goto Lf2;
                 break;
             case TYllong:
             case TYullong:
                 if (t2->Vllong == 1 ||
-                    t1->Vllong != 1 && f2->c2->EV.Vllong == 0)
+                    (t1->Vllong != 1 && f2->c2->EV.Vllong == 0))
                         goto Lf2;
                 break;
             default:
@@ -3497,8 +3497,8 @@ STATIC void countrefs(register elem **pn,bool flag)
                 /* Check both subtrees to see if n is the comparison node,
                  * that is, if X is a leaf of the comparison.
                  */
-                if (e1->Eoper == OPvar && e1->EV.sp.Vsym == X && !countrefs2(n->E2) ||
-                    n->E2->Eoper == OPvar && n->E2->EV.sp.Vsym == X && !countrefs2(e1))
+                if ((e1->Eoper == OPvar && e1->EV.sp.Vsym == X && !countrefs2(n->E2)) ||
+                    (n->E2->Eoper == OPvar && n->E2->EV.sp.Vsym == X && !countrefs2(e1)))
                         nd = pn;                /* found the relop node */
         }
     L1:

--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -507,8 +507,8 @@ STATIC elem * chkprop(elem *n,list_t rdlist)
                 /* (in case of assigning to overlapping unions, etc.)   */
                 if (t->EV.sp.Voffset != noff ||
                     /* If sizes match, we are ok        */
-                    size(t->Ety) != nsize &&
-                        !(d->E2->Eoper == OPconst && size(t->Ety) > nsize && !tyfloating(d->E2->Ety)))
+                    (size(t->Ety) != nsize &&
+                        !(d->E2->Eoper == OPconst && size(t->Ety) > nsize && !tyfloating(d->E2->Ety))))
                     goto noprop;
             }
             else
@@ -758,7 +758,7 @@ STATIC void intranges()
             rd2 = list_elem(list_next(iel->rdlist));
             /* The rd's for the relational elem (rdeq,rdinc) must be    */
             /* the same as the rd's for tne increment elem (rd1,rd2).   */
-            if (rd1 == rdeq && rd2 == rdinc || rd1 == rdinc && rd2 == rdeq)
+            if ((rd1 == rdeq && rd2 == rdinc) || (rd1 == rdinc && rd2 == rdeq))
                 break;
         }
 

--- a/src/backend/outbuf.c
+++ b/src/backend/outbuf.c
@@ -275,8 +275,8 @@ void Outbuffer::writesLEB128(int value)
         unsigned char b = value & 0x7F;
 
         value >>= 7;            // arithmetic right shift
-        if (value == 0 && !(b & 0x40) ||
-            value == -1 && (b & 0x40))
+        if ((value == 0 && !(b & 0x40)) ||
+            (value == -1 && (b & 0x40)))
         {
              writeByte(b);
              break;

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -1567,8 +1567,8 @@ int typematch(type *t1, type *t2, int relax);
 static int paramlstmatch(param_t *p1,param_t *p2)
 {
         return p1 == p2 ||
-            p1 && p2 && typematch(p1->Ptype,p2->Ptype,0) &&
-            paramlstmatch(p1->Pnext,p2->Pnext)
+            (p1 && p2 && typematch(p1->Ptype,p2->Ptype,0) &&
+            paramlstmatch(p1->Pnext,p2->Pnext))
             ;
 }
 
@@ -1588,7 +1588,7 @@ int typematch(type *t1,type *t2,int relax)
   tym = ~(mTYimport | mTYnaked);
 
   return t1 == t2 ||
-            t1 && t2 &&
+            (t1 && t2 &&
 
             (
                 /* ignore name mangling */
@@ -1600,11 +1600,12 @@ int typematch(type *t1,type *t2,int relax)
              t1->Tflags & TFsizeunknown || t2->Tflags & TFsizeunknown)
                  &&
 
-            (tybasic(t1ty) != TYstruct
+            ((tybasic(t1ty) != TYstruct
                 && tybasic(t1ty) != TYenum
 #if !MARS
                 && tybasic(t1ty) != TYmemptr
 #endif
+             )
              || t1->Ttag == t2->Ttag)
                  &&
 
@@ -1614,7 +1615,7 @@ int typematch(type *t1,type *t2,int relax)
             (!tyfunc(t1ty) ||
              ((t1->Tflags & TFfixed) == (t2->Tflags & TFfixed) &&
                  paramlstmatch(t1->Tparamtypes,t2->Tparamtypes) ))
-         ;
+         );
 }
 
 #endif

--- a/src/cast.c
+++ b/src/cast.c
@@ -59,7 +59,7 @@ Expression *implicitCastTo(Expression *e, Scope *sc, Type *t)
             {
                 if (match == MATCHconst &&
                     (e->type->constConv(t) ||
-                     !e->isLvalue() && e->type->immutableOf()->equals(t->immutableOf())))
+                     (!e->isLvalue() && e->type->immutableOf()->equals(t->immutableOf()))))
                 {
                     /* Do not emit CastExp for const conversions and
                      * unique conversions on rvalue.
@@ -2247,7 +2247,7 @@ Expression *inferType(Expression *e, Type *t, int flag)
         {
             //printf("FuncExp::inferType('%s'), to=%s\n", fe->type ? fe->type->toChars() : "null", t->toChars());
             if (t->ty == Tdelegate ||
-                t->ty == Tpointer && t->nextOf()->ty == Tfunction)
+                (t->ty == Tpointer && t->nextOf()->ty == Tfunction))
             {
                 fe->fd->treq = t;
             }
@@ -2384,7 +2384,7 @@ int typeMerge(Scope *sc, Expression *e, Type **pt, Expression **pe1, Expression 
     Type *t2b = e2->type->toBasetype();
 
     if (e->op != TOKquestion ||
-        t1b->ty != t2b->ty && (t1b->isTypeBasic() && t2b->isTypeBasic()))
+        (t1b->ty != t2b->ty && (t1b->isTypeBasic() && t2b->isTypeBasic())))
     {
         e1 = integralPromotions(e1, sc);
         e2 = integralPromotions(e2, sc);
@@ -2568,8 +2568,8 @@ Lagain:
         }
     }
     else if ((t1->ty == Tsarray || t1->ty == Tarray) &&
-             (e2->op == TOKnull && t2->ty == Tpointer && t2->nextOf()->ty == Tvoid ||
-              e2->op == TOKarrayliteral && t2->ty == Tsarray && t2->nextOf()->ty == Tvoid && ((TypeSArray *)t2)->dim->toInteger() == 0 ||
+             ((e2->op == TOKnull && t2->ty == Tpointer && t2->nextOf()->ty == Tvoid) ||
+              (e2->op == TOKarrayliteral && t2->ty == Tsarray && t2->nextOf()->ty == Tvoid && ((TypeSArray *)t2)->dim->toInteger() == 0) ||
               isVoidArrayLiteral(e2, t1))
             )
     {
@@ -2583,8 +2583,8 @@ Lagain:
         goto Lx1;
     }
     else if ((t2->ty == Tsarray || t2->ty == Tarray) &&
-             (e1->op == TOKnull && t1->ty == Tpointer && t1->nextOf()->ty == Tvoid ||
-              e1->op == TOKarrayliteral && t1->ty == Tsarray && t1->nextOf()->ty == Tvoid && ((TypeSArray *)t1)->dim->toInteger() == 0 ||
+             ((e1->op == TOKnull && t1->ty == Tpointer && t1->nextOf()->ty == Tvoid) ||
+              (e1->op == TOKarrayliteral && t1->ty == Tsarray && t1->nextOf()->ty == Tvoid && ((TypeSArray *)t1)->dim->toInteger() == 0) ||
               isVoidArrayLiteral(e1, t2))
             )
     {

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -157,7 +157,7 @@ class CppMangleVisitor : public Visitor
                         }
                         else
                         {
-                            dinteger_t val = e->toInteger();
+                            sinteger_t val = e->toInteger();
                             if (val < 0)
                             {
                                 val = -val;

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1507,7 +1507,7 @@ Lnomatch:
                 {
                     ArrayInitializer *ai = init->isArrayInitializer();
                     Expression *e;
-                    if (ai && (tb->ty == Taarray || tb->ty == Tstruct && ai->isAssociativeArray()))
+                    if (ai && (tb->ty == Taarray || (tb->ty == Tstruct && ai->isAssociativeArray())))
                         e = ai->toAssocArrayLiteral();
                     else
                         e = init->toExpression();

--- a/src/doc.c
+++ b/src/doc.c
@@ -1423,7 +1423,7 @@ void DocComment::parseSections(const utf8_t *comment)
                     p++;
                 }
                 // BUG: handle UTF PS and LS too
-                if (!*p || *p == '\r' || *p == '\n' && numdash >= 3)
+                if ((!*p || *p == '\r' || *p == '\n') && numdash >= 3)
                     inCode ^= 1;
                 pend = p;
             }

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -918,7 +918,7 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
             else if (s2 && s != s2)
             {
                 if (s->toAlias() == s2->toAlias() ||
-                    s->getType() == s2->getType() && s->getType())
+                    (s->getType() == s2->getType() && s->getType()))
                 {
                     /* After following aliases, we found the same
                      * symbol, so it's not an ambiguity.  But if one
@@ -926,7 +926,7 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
                      * the other.
                      */
                     if (s->isDeprecated() ||
-                        s2->prot() > s->prot() && s2->prot() != PROTnone)
+                        (s2->prot() > s->prot() && s2->prot() != PROTnone))
                         s = s2;
                 }
                 else
@@ -970,7 +970,7 @@ Dsymbol *ScopeDsymbol::search(Loc loc, Identifier *ident, int flags)
                                 if (s2->toAlias() == s3->toAlias())
                                 {
                                     if (s3->isDeprecated() ||
-                                        s2->prot() > s3->prot() && s2->prot() != PROTnone)
+                                        (s2->prot() > s3->prot() && s2->prot() != PROTnone))
                                         a->a[j] = s2;
                                     goto Lcontinue;
                                 }

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1754,7 +1754,7 @@ elem *toElem(Expression *e, IRState *irs)
                     ts = symbol_genauto(Type_toCtype(t1));
                     int rtl;
                     if (global.params.isLinux || global.params.isFreeBSD || global.params.isSolaris ||
-                        I64 && global.params.isWindows)
+                        (I64 && global.params.isWindows))
                         rtl = RTLSYM__DINVARIANT;
                     else
                         rtl = RTLSYM_DINVARIANT;
@@ -2466,9 +2466,9 @@ elem *toElem(Expression *e, IRState *irs)
                      */
                     int postblit = 0;
                     if (needsPostblit(t1->nextOf()) &&
-                        (ae->e2->op == TOKslice && ((UnaExp *)ae->e2)->e1->isLvalue() ||
-                         ae->e2->op == TOKcast  && ((UnaExp *)ae->e2)->e1->isLvalue() ||
-                         ae->e2->op != TOKslice && ae->e2->isLvalue()))
+                        ((ae->e2->op == TOKslice && ((UnaExp *)ae->e2)->e1->isLvalue()) ||
+                         (ae->e2->op == TOKcast  && ((UnaExp *)ae->e2)->e1->isLvalue()) ||
+                         (ae->e2->op != TOKslice && ae->e2->isLvalue())))
                     {
                         postblit = 1;
                     }
@@ -2767,9 +2767,9 @@ elem *toElem(Expression *e, IRState *irs)
                 /* Determine if we need to do postblit
                  */
                 if (postblit &&
-                    !(ae->e2->op == TOKslice && ((UnaExp *)ae->e2)->e1->isLvalue() ||
-                      ae->e2->op == TOKcast  && ((UnaExp *)ae->e2)->e1->isLvalue() ||
-                      ae->e2->op != TOKslice && ae->e2->isLvalue()))
+                    !((ae->e2->op == TOKslice && ((UnaExp *)ae->e2)->e1->isLvalue()) ||
+                      (ae->e2->op == TOKcast  && ((UnaExp *)ae->e2)->e1->isLvalue()) ||
+                      (ae->e2->op != TOKslice && ae->e2->isLvalue())))
                 {
                     postblit = false;
                 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -5420,7 +5420,7 @@ bool TupleExp::equals(RootObject *o)
         TupleExp *te = (TupleExp *)o;
         if (exps->dim != te->exps->dim)
             return false;
-        if (e0 && !e0->equals(te->e0) || !e0 && te->e0)
+        if ((e0 && !e0->equals(te->e0)) || (!e0 && te->e0))
             return false;
         for (size_t i = 0; i < exps->dim; i++)
         {
@@ -5800,8 +5800,8 @@ MATCH FuncExp::matchType(Type *to, Scope *sc, FuncExp **presult, int flag)
 
     Type *tx;
     if (tok == TOKdelegate ||
-        tok == TOKreserved && (type->ty == Tdelegate ||
-                               type->ty == Tpointer && to->ty == Tdelegate))
+        (tok == TOKreserved && (type->ty == Tdelegate ||
+                               (type->ty == Tpointer && to->ty == Tdelegate))))
     {
         // Allow conversion from implicit function pointer to delegate
         tx = new TypeDelegate(tfx);
@@ -5970,7 +5970,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                  s->isTypedefDeclaration() ||
                  s->isAggregateDeclaration() ||
                  s->isEnumDeclaration() ||
-                 v && v->isDataseg()) &&
+                 (v && v->isDataseg())) &&
                 !sc->func->localsymtab->insert(s))
             {
                 error("declaration %s is already defined in another scope in %s",
@@ -8519,7 +8519,7 @@ Lagain:
         }
     }
 
-    if (e1->op == TOKdotvar && t1->ty == Tfunction ||
+    if ((e1->op == TOKdotvar && t1->ty == Tfunction) ||
         e1->op == TOKdottd)
     {
         UnaExp *ue = (UnaExp *)(e1);
@@ -9834,8 +9834,8 @@ Expression *CastExp::semantic(Scope *sc)
             Type* tobn = tob->nextOf()->toBasetype();
             Type* t1bn = t1b->nextOf()->toBasetype();
             // If the struct is opaque we don't know about the struct members and the cast becomes unsafe
-            bool sfwrd = tobn->ty == Tstruct && !((StructDeclaration *)((TypeStruct *)tobn)->sym)->members ||
-                    t1bn->ty == Tstruct && !((StructDeclaration *)((TypeStruct *)t1bn)->sym)->members;
+            bool sfwrd = (tobn->ty == Tstruct && !((StructDeclaration *)((TypeStruct *)tobn)->sym)->members) ||
+                    (t1bn->ty == Tstruct && !((StructDeclaration *)((TypeStruct *)t1bn)->sym)->members);
             if (!sfwrd && !tobn->hasPointers() &&
                 tobn->ty != Tfunction && t1bn->ty != Tfunction &&
                 tobn->size() <= t1bn->size() &&
@@ -10089,8 +10089,8 @@ Lagain:
         if (t->ty == Ttuple) sc2 = sc2->endCTFE();
         upr = upr->implicitCastTo(sc2, Type::tsize_t);
     }
-    if (lwr && lwr->type == Type::terror ||
-        upr && upr->type == Type::terror)
+    if ((lwr && lwr->type == Type::terror) ||
+        (upr && upr->type == Type::terror))
     {
         goto Lerr;
     }
@@ -11548,9 +11548,9 @@ Expression *AssignExp::semantic(Scope *sc)
         if (e2x->implicitConvTo(e1x->type))
         {
             if (op != TOKblit &&
-                (e2x->op == TOKslice && ((UnaExp *)e2x)->e1->isLvalue() ||
-                 e2x->op == TOKcast  && ((UnaExp *)e2x)->e1->isLvalue() ||
-                 e2x->op != TOKslice && e2x->isLvalue()))
+                ((e2x->op == TOKslice && ((UnaExp *)e2x)->e1->isLvalue()) ||
+                 (e2x->op == TOKcast  && ((UnaExp *)e2x)->e1->isLvalue()) ||
+                 (e2x->op != TOKslice && e2x->isLvalue())))
             {
                 e1x->checkPostblit(sc, t1);
             }
@@ -11705,9 +11705,9 @@ Expression *AssignExp::semantic(Scope *sc)
         }
 
         if (op != TOKblit &&
-            (e2x->op == TOKslice && ((UnaExp *)e2x)->e1->isLvalue() ||
-             e2x->op == TOKcast  && ((UnaExp *)e2x)->e1->isLvalue() ||
-             e2x->op != TOKslice && e2x->isLvalue()))
+            ((e2x->op == TOKslice && ((UnaExp *)e2x)->e1->isLvalue()) ||
+             (e2x->op == TOKcast  && ((UnaExp *)e2x)->e1->isLvalue()) ||
+             (e2x->op != TOKslice && e2x->isLvalue())))
         {
             e1->checkPostblit(sc, t1->nextOf());
         }
@@ -11732,7 +11732,7 @@ Expression *AssignExp::semantic(Scope *sc)
         Type *t1n = t1->nextOf();
         int offset;
         if (t2n->immutableOf()->equals(t1n->immutableOf()) ||
-            t1n->isBaseOf(t2n, &offset) && offset == 0)
+            (t1n->isBaseOf(t2n, &offset) && offset == 0))
         {
             /* Allow copy of distinct qualifier elements.
              * eg.
@@ -12133,20 +12133,20 @@ Expression *AddExp::semantic(Scope *sc)
     Type *tb2 = e2->type->toBasetype();
 
     if (tb1->ty == Tdelegate ||
-        tb1->ty == Tpointer && tb1->nextOf()->ty == Tfunction)
+        (tb1->ty == Tpointer && tb1->nextOf()->ty == Tfunction))
     {
         e = e1->checkArithmetic();
     }
     if (tb2->ty == Tdelegate ||
-        tb2->ty == Tpointer && tb2->nextOf()->ty == Tfunction)
+        (tb2->ty == Tpointer && tb2->nextOf()->ty == Tfunction))
     {
         e = e2->checkArithmetic();
     }
     if (e)
         return e;
 
-    if (tb1->ty == Tpointer && e2->type->isintegral() ||
-        tb2->ty == Tpointer && e1->type->isintegral())
+    if ((tb1->ty == Tpointer && e2->type->isintegral()) ||
+        (tb2->ty == Tpointer && e1->type->isintegral()))
     {
         return scaleFactor(this, sc);
     }
@@ -12227,12 +12227,12 @@ Expression *MinExp::semantic(Scope *sc)
     Type *t2 = e2->type->toBasetype();
 
     if (t1->ty == Tdelegate ||
-        t1->ty == Tpointer && t1->nextOf()->ty == Tfunction)
+        (t1->ty == Tpointer && t1->nextOf()->ty == Tfunction))
     {
         e = e1->checkArithmetic();
     }
     if (t2->ty == Tdelegate ||
-        t2->ty == Tpointer && t2->nextOf()->ty == Tfunction)
+        (t2->ty == Tpointer && t2->nextOf()->ty == Tfunction))
     {
         e = e2->checkArithmetic();
     }
@@ -13269,8 +13269,8 @@ Expression *CmpExp::semantic(Scope *sc)
         return ex;
     Type *t1 = e1->type->toBasetype();
     Type *t2 = e2->type->toBasetype();
-    if (t1->ty == Tclass && e2->op == TOKnull ||
-        t2->ty == Tclass && e1->op == TOKnull)
+    if ((t1->ty == Tclass && e2->op == TOKnull) ||
+        (t2->ty == Tclass && e1->op == TOKnull))
     {
         error("do not use null when comparing class types");
         return new ErrorExp();
@@ -13294,8 +13294,8 @@ Expression *CmpExp::semantic(Scope *sc)
 
     /* Disallow comparing T[]==T and T==T[]
      */
-    if (e1->op == TOKslice && t1->ty == Tarray && e2->implicitConvTo(t1->nextOf()) ||
-        e2->op == TOKslice && t2->ty == Tarray && e1->implicitConvTo(t2->nextOf()))
+    if ((e1->op == TOKslice && t1->ty == Tarray && e2->implicitConvTo(t1->nextOf())) ||
+        (e2->op == TOKslice && t2->ty == Tarray && e1->implicitConvTo(t2->nextOf())))
     {
         return incompatibleTypes();
     }
@@ -13468,8 +13468,8 @@ Expression *EqualExp::semantic(Scope *sc)
 
     Type *t1 = e1->type->toBasetype();
     Type *t2 = e2->type->toBasetype();
-    if (t1->ty == Tclass && e2->op == TOKnull ||
-        t2->ty == Tclass && e1->op == TOKnull)
+    if ((t1->ty == Tclass && e2->op == TOKnull) ||
+        (t2->ty == Tclass && e1->op == TOKnull))
     {
         error("use '%s' instead of '%s' when comparing with null",
                 Token::toChars(op == TOKequal ? TOKidentity : TOKnotidentity),
@@ -13512,8 +13512,8 @@ Expression *EqualExp::semantic(Scope *sc)
 
     /* Disallow comparing T[]==T and T==T[]
      */
-    if (e1->op == TOKslice && t1->ty == Tarray && e2->implicitConvTo(t1->nextOf()) ||
-        e2->op == TOKslice && t2->ty == Tarray && e1->implicitConvTo(t2->nextOf()))
+    if ((e1->op == TOKslice && t1->ty == Tarray && e2->implicitConvTo(t1->nextOf())) ||
+        (e2->op == TOKslice && t2->ty == Tarray && e1->implicitConvTo(t2->nextOf())))
     {
         return incompatibleTypes();
     }

--- a/src/func.c
+++ b/src/func.c
@@ -1131,8 +1131,8 @@ Ldone:
     TemplateInstance *ti;
     if (fbody &&
         (isFuncLiteralDeclaration() ||
-         isInstantiated() && !isVirtualMethod() &&
-         !(ti = parent->isTemplateInstance(), ti && !ti->isTemplateMixin() && ti->tempdecl->ident != ident)))
+         (isInstantiated() && !isVirtualMethod() &&
+         !(ti = parent->isTemplateInstance(), ti && !ti->isTemplateMixin() && ti->tempdecl->ident != ident))))
     {
         if (f->purity == PUREimpure)        // purity not specified
             flags |= FUNCFLAGpurityInprocess;
@@ -2085,7 +2085,7 @@ void FuncDeclaration::semantic3(Scope *sc)
 
             // If declaration has no body, don't set sbody to prevent incorrect codegen.
             InterfaceDeclaration *id = parent->isInterfaceDeclaration();
-            if (fbody || id && (fdensure || fdrequire) && isVirtual())
+            if (fbody || (id && (fdensure || fdrequire) && isVirtual()))
                 fbody = sbody;
         }
 
@@ -3177,8 +3177,8 @@ FuncDeclaration *resolveFuncCall(Loc loc, Scope *sc, Dsymbol *s,
     }
 #endif
 
-    if (tiargs && arrayObjectIsError(tiargs) ||
-        fargs  && arrayObjectIsError((Objects *)fargs))
+    if ((tiargs && arrayObjectIsError(tiargs)) ||
+        (fargs  && arrayObjectIsError((Objects *)fargs)))
     {
         return NULL;
     }

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -1380,9 +1380,9 @@ static code *asm_emit(Loc loc,
               )
             {
                 if ((popndTmp->pregDisp1 &&
-                        popndTmp->pregDisp1->val == _BP) ||
-                        popndTmp->pregDisp2 &&
-                        popndTmp->pregDisp2->val == _BP)
+                     popndTmp->pregDisp1->val == _BP) ||
+                    (popndTmp->pregDisp2 &&
+                     popndTmp->pregDisp2->val == _BP))
                         usDefaultseg = _SS;
                 else
                         usDefaultseg = _DS;
@@ -1442,7 +1442,7 @@ static code *asm_emit(Loc loc,
                     pc,
                     ptb.pptb1->usFlags,
                     popnd1, popnd2);
-            else if (usNumops == 2 || usNumops == 3 && aoptyTable3 == _imm)
+            else if (usNumops == 2 || (usNumops == 3 && aoptyTable3 == _imm))
                 asm_make_modrm_byte(
 #ifdef DEBUG
                     auchOpcode, &usIdx,
@@ -3037,9 +3037,9 @@ static bool asm_match_flags(opflag_t usOp, opflag_t usTable)
                                   aoptyOp == _rel))
             goto Lok;
         if (aoptyTable == _mnoi && aoptyOp == _m &&
-            (uSizemaskOp == _32 && amodOp == _addr16 ||
-             uSizemaskOp == _48 && amodOp == _addr32 ||
-             uSizemaskOp == _48 && amodOp == _normal)
+            ((uSizemaskOp == _32 && amodOp == _addr16) ||
+             (uSizemaskOp == _48 && amodOp == _addr32) ||
+             (uSizemaskOp == _48 && amodOp == _normal))
           )
             goto Lok;
         goto EXIT;

--- a/src/init.c
+++ b/src/init.c
@@ -276,7 +276,7 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t, NeedInterpret needI
         ExpInitializer *ie = new ExpInitializer(loc, sle);
         return ie->semantic(sc, t, needInterpret);
     }
-    else if ((t->ty == Tdelegate || t->ty == Tpointer && t->nextOf()->ty == Tfunction) && value.dim == 0)
+    else if ((t->ty == Tdelegate || (t->ty == Tpointer && t->nextOf()->ty == Tfunction)) && value.dim == 0)
     {
         TOK tok = (t->ty == Tdelegate) ? TOKdelegate : TOKfunction;
         /* Rewrite as empty delegate literal { }

--- a/src/inline.c
+++ b/src/inline.c
@@ -1680,13 +1680,13 @@ int canInline(FuncDeclaration *fd, int hasthis, int hdrscan, int statementsToo)
         (fd->ident == Id::require &&
          fd->toParent()->isFuncDeclaration() &&
          fd->toParent()->isFuncDeclaration()->needThis()) ||
-        !hdrscan &&
+        (!hdrscan &&
         (
         fd->isSynchronized() ||
         fd->isImportedSymbol() ||
         fd->hasNestedFrameRefs() ||
         (fd->isVirtual() && !fd->isFinalFunc())
-       ))
+       )))
     {
         goto Lno;
     }

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -300,7 +300,7 @@ public:
             /* These are reserved to the compiler, so keep simple
              * names for them.
              */
-            if (cd->ident == Id::Exception && cd->parent->ident == Id::object ||
+            if ((cd->ident == Id::Exception && cd->parent->ident == Id::object) ||
                 cd->ident == Id::TypeInfo ||
                 cd->ident == Id::TypeInfo_Struct ||
                 cd->ident == Id::TypeInfo_Class ||

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -678,7 +678,7 @@ void Type::fixTo(Type *t)
     // cache t to this->xto won't break transitivity.
     Type *mto = NULL;
     Type *tn = nextOf();
-    if (!tn || ty != Tsarray && tn->mod == t->nextOf()->mod)
+    if (!tn || (ty != Tsarray && tn->mod == t->nextOf()->mod))
     {
         switch (t->mod)
         {
@@ -1043,7 +1043,7 @@ Type *Type::addSTC(StorageClass stc)
 
 StorageClass ModToStc(unsigned mod)
 {
-    StorageClass stc;
+    StorageClass stc = 0;
     if (mod & MODimmutable) stc |= STCimmutable;
     if (mod & MODconst)     stc |= STCconst;
     if (mod & MODwild)      stc |= STCwild;
@@ -2449,7 +2449,7 @@ Identifier *Type::getTypeInfoIdent(int internal)
     assert(strlen(name) < namelen);     // don't overflow the buffer
 
     size_t off = 0;
-    if (global.params.isOSX || global.params.isWindows && !global.params.is64bit)
+    if (global.params.isOSX || (global.params.isWindows && !global.params.is64bit))
         ++off;                 // C mangling will add '_' back in
     Identifier *id = Lexer::idPool(name + off);
 
@@ -6567,7 +6567,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                     Expression *e;
                     VarDeclaration *v = s->isVarDeclaration();
                     FuncDeclaration *f = s->isFuncDeclaration();
-                    if (intypeid || !v && !f)
+                    if (intypeid || (!v && !f))
                         e = new DsymbolExp(loc, s);
                     else
                         e = new VarExp(loc, s->isDeclaration());
@@ -8076,7 +8076,7 @@ L1:
     }
 
     bool unreal = e->op == TOKvar && ((VarExp *)e)->var->isField();
-    if (d->isDataseg() || unreal && d->isField())
+    if (d->isDataseg() || (unreal && d->isField()))
     {
         // (e, d)
         accessCheck(e->loc, sc, e, d);
@@ -8783,7 +8783,7 @@ L1:
     }
 
     bool unreal = e->op == TOKvar && ((VarExp *)e)->var->isField();
-    if (d->isDataseg() || unreal && d->isField())
+    if (d->isDataseg() || (unreal && d->isField()))
     {
         // (e, d)
         accessCheck(e->loc, sc, e, d);

--- a/src/nogc.c
+++ b/src/nogc.c
@@ -215,7 +215,7 @@ Expression *checkGC(Scope *sc, Expression *e)
     FuncDeclaration *f = sc->func;
     if (e && e->op != TOKerror &&
         f && sc->intypeof != 1 && !(sc->flags & SCOPEctfe) &&
-        (f->type->ty == Tfunction && ((TypeFunction *)f->type)->isnogc ||
+        ((f->type->ty == Tfunction && ((TypeFunction *)f->type)->isnogc) ||
          (f->flags & FUNCFLAGnogcInprocess) ||
          global.params.vgc))
     {

--- a/src/opover.c
+++ b/src/opover.c
@@ -167,7 +167,7 @@ AggregateDeclaration *isAggregate(Type *t)
 /*******************************************
  * Helper function to turn operator into template argument list
  */
-Objects *opToArg(Scope *sc, TOK op)
+static Objects *opToArg(Scope *sc, TOK op)
 {
     /* Remove the = from op=
      */
@@ -186,6 +186,7 @@ Objects *opToArg(Scope *sc, TOK op)
         case TOKushrass: op = TOKushr; break;
         case TOKcatass: op = TOKcat; break;
         case TOKpowass: op = TOKpow; break;
+        default: break;
     }
     Expression *e = new StringExp(Loc(), (char *)Token::toChars(op));
     e = e->semantic(sc);
@@ -705,7 +706,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                     // Rewrite (e1 -- e2) as e1.postdec()
                     result = build_overload(e->loc, sc, e->e1, NULL, m.lastf ? m.lastf : s);
                 }
-                else if (lastf && m.lastf == lastf || !s_r && m.last <= MATCHnomatch)
+                else if ((lastf && m.lastf == lastf) || (!s_r && m.last <= MATCHnomatch))
                 {
                     // Rewrite (e1 op e2) as e1.opfunc(e2)
                     result = build_overload(e->loc, sc, e->e1, e->e2, m.lastf ? m.lastf : s);
@@ -792,7 +793,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                         m.lastf = m.anyf;
                     }
 
-                    if (lastf && m.lastf == lastf || !s && m.last <= MATCHnomatch)
+                    if ((lastf && m.lastf == lastf) || (!s && m.last <= MATCHnomatch))
                     {
                         // Rewrite (e1 op e2) as e1.opfunc_r(e2)
                         result = build_overload(e->loc, sc, e->e1, e->e2, m.lastf ? m.lastf : s_r);
@@ -824,6 +825,9 @@ Expression *op_overload(Expression *e, Scope *sc)
                         case TOKleg:
                         case TOKue:
                             break;
+
+                        default:
+                            assert(0);
                     }
 
                     return;
@@ -1320,7 +1324,7 @@ Expression *compare_overload(BinExp *e, Scope *sc, Identifier *id)
         }
 
         Expression *result;
-        if (lastf && m.lastf == lastf || !s_r && m.last <= MATCHnomatch)
+        if ((lastf && m.lastf == lastf) || (!s_r && m.last <= MATCHnomatch))
         {
             // Rewrite (e1 op e2) as e1.opfunc(e2)
             result = build_overload(e->loc, sc, e->e1, e->e2, m.lastf ? m.lastf : s);

--- a/src/parse.c
+++ b/src/parse.c
@@ -327,7 +327,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
             case TOKinvariant:
             {
                 Token *t = peek(&token);
-                if (t->value == TOKlparen && peek(t)->value == TOKrparen ||
+                if ((t->value == TOKlparen && peek(t)->value == TOKrparen) ||
                     t->value == TOKlcurly)
                 {
                     // invariant {}
@@ -4216,7 +4216,7 @@ void Parser::checkDanglingElse(Loc elseloc)
 
 Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
 {
-    Statement *s;
+    Statement *s = NULL;
     Condition *cond;
     Statement *ifbody;
     Statement *elsebody;
@@ -6378,10 +6378,10 @@ Expression *Parser::parsePrimaryExp()
                          token.value == TOKinterface ||
                          token.value == TOKargTypes ||
                          token.value == TOKparameters ||
-                         token.value == TOKconst && peek(&token)->value == TOKrparen ||
-                         token.value == TOKimmutable && peek(&token)->value == TOKrparen ||
-                         token.value == TOKshared && peek(&token)->value == TOKrparen ||
-                         token.value == TOKwild && peek(&token)->value == TOKrparen ||
+                         (token.value == TOKconst && peek(&token)->value == TOKrparen) ||
+                         (token.value == TOKimmutable && peek(&token)->value == TOKrparen) ||
+                         (token.value == TOKshared && peek(&token)->value == TOKrparen) ||
+                         (token.value == TOKwild && peek(&token)->value == TOKrparen) ||
                          token.value == TOKfunction ||
                          token.value == TOKdelegate ||
                          token.value == TOKreturn))

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -654,7 +654,7 @@ const char *FileName::canonicalName(const char *name)
 void FileName::free(const char *str)
 {
     if (str)
-    {   assert(str[0] != 0xAB);
+    {   assert(str[0] != (char)0xAB);
         memset((void *)str, 0xAB, strlen(str) + 1);     // stomp
     }
     mem.free((void *)str);

--- a/src/statement.c
+++ b/src/statement.c
@@ -1539,9 +1539,9 @@ Statement *ForStatement::semantic(Scope *sc)
 
     sc->pop();
 
-    if (condition && condition->op == TOKerror ||
-        increment && increment->op == TOKerror ||
-        body      && body->isErrorStatement())
+    if ((condition && condition->op == TOKerror) ||
+        (increment && increment->op == TOKerror) ||
+        (body      && body->isErrorStatement()))
         return new ErrorStatement();
 
     return this;
@@ -1745,7 +1745,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
             }
             // Declare value
             if (arg->storageClass & (STCout | STClazy) ||
-                arg->storageClass & STCref && !te)
+                (arg->storageClass & STCref && !te))
             {
                 error("no storage class for value %s", arg->ident->toChars());
                 goto Lerror;
@@ -3643,7 +3643,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
             exp = inferType(exp, fld->treq->nextOf()->nextOf());
         exp = exp->semantic(sc);
         exp = resolveProperties(sc, exp);
-        if (exp->type && exp->type->ty != Tvoid ||
+        if ((exp->type && exp->type->ty != Tvoid) ||
             exp->op == TOKfunction || exp->op == TOKtype || exp->op == TOKtemplate)
         {
             if (!exp->rvalue()) // don't make error for void expression

--- a/src/struct.c
+++ b/src/struct.c
@@ -90,8 +90,8 @@ void semanticTypeInfo(Scope *sc, Type *t)
         {
             StructDeclaration *sd = t->sym;
             if (sd->members &&
-                (sd->xeq  && sd->xeq  != sd->xerreq  ||
-                 sd->xcmp && sd->xcmp != sd->xerrcmp ||
+                ((sd->xeq  && sd->xeq  != sd->xerreq)  ||
+                 (sd->xcmp && sd->xcmp != sd->xerrcmp) ||
                  (sd->postblit && !(sd->postblit->storage_class & STCdisable)) ||
                  sd->dtor ||
                  sd->xhash ||
@@ -1115,7 +1115,7 @@ bool StructDeclaration::fill(Loc loc, Expressions *elements, bool ctorinit)
                  * union U { int a; int b = 2; }
                  * U u;    // OK (u.b == 2)
                  */
-                if (!vx || !vx->init && v2->init)
+                if (!vx || (!vx->init && v2->init))
                     vx = v2, fieldi = j;
                 else if (vx != vd &&
                     !(vx->offset < v2->offset + v2->type->size() &&

--- a/src/traits.c
+++ b/src/traits.c
@@ -876,7 +876,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             global.speculativeGag = global.gag;
             Scope *sc2 = sc->push();
             sc2->speculative = true;
-            sc2->flags = sc->flags & ~SCOPEctfe | SCOPEcompile;
+            sc2->flags = (sc->flags & ~SCOPEctfe) | SCOPEcompile;
             bool err = false;
 
             RootObject *o = (*e->args)[i];

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -761,10 +761,10 @@ int TypeBasic::builtinTypeInfo()
 
 int TypeDArray::builtinTypeInfo()
 {
-    return !mod && (next->isTypeBasic() != NULL && !next->mod ||
+    return !mod && ((next->isTypeBasic() != NULL && !next->mod) ||
         // strings are so common, make them builtin
-        next->ty == Tchar && next->mod == MODimmutable ||
-        next->ty == Tchar && next->mod == MODconst);
+        (next->ty == Tchar && next->mod == MODimmutable) ||
+        (next->ty == Tchar && next->mod == MODconst));
 }
 
 int TypeClass::builtinTypeInfo()


### PR DESCRIPTION
This fixes the numerous "warning: '&&' within '||'  (and some others) while building dmd with clang [on OSX].

There's one occasion that actually fixes a bug: doc.c line 1426!
