### PR TITLE
Fix uninitialized variable

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1043,7 +1043,7 @@ Type *Type::addSTC(StorageClass stc)
 
 StorageClass ModToStc(unsigned mod)
 {
-    StorageClass stc;
+    StorageClass stc = 0;
     if (mod & MODimmutable) stc |= STCimmutable;
     if (mod & MODconst)     stc |= STCconst;
     if (mod & MODwild)      stc |= STCwild;


### PR DESCRIPTION
```
mtype.c: In function ‘StorageClass ModToStc(unsigned int)’:
mtype.c:1047:48: warning: ‘stc’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (mod & MODimmutable) stc |= STCimmutable;
```
