### PR TITLE
Issue 13114 - old opCmp requirement for AA keys should be detected for classes

### DIFF
--- a/test/fail_compilation/diag13074.d
+++ b/test/fail_compilation/diag13074.d
@@ -32,3 +32,44 @@ void main()
     arr[s3] = true;
     arr[s4] = true;
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag13074.d(70): Error: AA key type C now requires equality rather than comparison
+fail_compilation/diag13074.d(70):        Please override Object.opEquals and toHash.
+---
+*/
+class C
+{
+    int x;
+    int y;
+    this(int x, int y)
+    {
+        this.x = x; this.y = y;
+    }
+
+    override int opCmp(Object other)
+    {
+        if (auto o = cast(C)other)
+            return x < o.x ? -1 : x > o.x ? 1 : 0;
+        return -1;
+    }
+    override hash_t toHash() const
+    {
+        return x;
+    }
+}
+
+void test13114()
+{
+    const c1 = new C(1,1);
+    const c2 = new C(1,2);
+    const c3 = new C(2,1);
+    const c4 = new C(2,2);
+    bool[const(C)] arr;
+    arr[c1] = true;
+    arr[c2] = true;
+    arr[c3] = true;
+    arr[c4] = true;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13114
