### PR TITLE
[WIP] DIP63 : operator overloading for raw templates

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1300,6 +1300,7 @@ ArrayScopeSymbol::ArrayScopeSymbol(Scope *sc, Expression *e)
     exp = e;
     type = NULL;
     td = NULL;
+    ti = NULL;
     this->sc = sc;
 }
 
@@ -1309,6 +1310,7 @@ ArrayScopeSymbol::ArrayScopeSymbol(Scope *sc, TypeTuple *t)
     exp = NULL;
     type = t;
     td = NULL;
+    ti = NULL;
     this->sc = sc;
 }
 
@@ -1318,6 +1320,17 @@ ArrayScopeSymbol::ArrayScopeSymbol(Scope *sc, TupleDeclaration *s)
     exp = NULL;
     type = NULL;
     td = s;
+    ti = NULL;
+    this->sc = sc;
+}
+
+ArrayScopeSymbol::ArrayScopeSymbol(Scope *sc, TemplateInstance *s)
+    : ScopeDsymbol()
+{
+    exp = NULL;
+    type = NULL;
+    td = NULL;
+    ti = s;
     this->sc = sc;
 }
 
@@ -1352,6 +1365,30 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
             v->storage_class |= STCtemp | STCstatic | STCconst;
             v->semantic(sc);
             return v;
+        }
+
+        if (ti)
+        {
+            /* $ resolves to nested opDollar member
+             */
+            Dsymbol* opDollar = search_function(ti, Id::opDollar, true);
+            if (!opDollar)
+                error("$ can only be used to index/slice template if it has opDollar member defined");
+            {
+                VarDeclaration* var = opDollar->isVarDeclaration();
+                if (var)
+                {
+                    return var;
+                }
+            }
+            {
+                TemplateDeclaration* td = opDollar->isTemplateDeclaration();
+                if (td)
+                {
+                        // TODO:
+                }
+            }
+            error("opDollar must resolve to either enum or alias");
         }
 
         if (exp->op == TOKindex)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -347,11 +347,13 @@ public:
     Expression *exp;    // IndexExp or SliceExp
     TypeTuple *type;    // for tuple[length]
     TupleDeclaration *td;       // for tuples of objects
+    TemplateInstance* ti; // for non-eponymous templates
     Scope *sc;
 
     ArrayScopeSymbol(Scope *sc, Expression *e);
     ArrayScopeSymbol(Scope *sc, TypeTuple *t);
     ArrayScopeSymbol(Scope *sc, TupleDeclaration *td);
+    ArrayScopeSymbol(Scope *sc, TemplateInstance *ti);
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
 
     ArrayScopeSymbol *isArrayScopeSymbol() { return this; }

--- a/src/expression.h
+++ b/src/expression.h
@@ -67,7 +67,7 @@ Expression *resolveProperties(Scope *sc, Expression *e);
 Expression *resolvePropertiesOnly(Scope *sc, Expression *e1);
 void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d);
 Expression *build_overload(Loc loc, Scope *sc, Expression *ethis, Expression *earg, Dsymbol *d);
-Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid);
+Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid, bool allow_variables = false);
 void expandTuples(Expressions *exps);
 TupleDeclaration *isAliasThisTuple(Expression *e);
 int expandAliasThisTuples(Expressions *exps, size_t starti = 0);

--- a/src/opover.c
+++ b/src/opover.c
@@ -1419,14 +1419,14 @@ Expression *build_overload(Loc loc, Scope *sc, Expression *ethis, Expression *ea
  * Search for function funcid in aggregate ad.
  */
 
-Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid)
+Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid, bool allow_variables)
 {
     Dsymbol *s = ad->search(Loc(), funcid);
     if (s)
     {
-        //printf("search_function: s = '%s'\n", s->kind());
+        // printf("search_function: s = '%s' (%s)\n", s->kind(), s->toChars());
         Dsymbol *s2 = s->toAlias();
-        //printf("search_function: s2 = '%s'\n", s2->kind());
+        // printf("search_function: s2 = '%s' (%s)\n", s2->kind(), s2->toChars());
         FuncDeclaration *fd = s2->isFuncDeclaration();
         if (fd && fd->type->ty == Tfunction)
             return fd;
@@ -1434,6 +1434,12 @@ Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid)
         TemplateDeclaration *td = s2->isTemplateDeclaration();
         if (td)
             return td;
+
+        if (allow_variables)
+        {
+            VarDeclaration* vd = s2->isVarDeclaration();
+            return vd;
+        }
     }
     return NULL;
 }

--- a/test/compilable/dip63.d
+++ b/test/compilable/dip63.d
@@ -3,12 +3,16 @@ template Pack(T...)
     alias expand = T;
 
     alias opIndex(size_t index) = T[index];
-//    alias opSlice(size_t lower, size_t upper) = Pack!(T[lower..upper]);
+    alias opSlice(size_t lower, size_t upper) = Pack!(T[lower..upper]);
     enum opDollar = T.length;
 }
 
 alias element1 = Pack!(int, double)[1]; 
 alias element2 = Pack!(int, double)[$-1];
 
+alias slice1 = Pack!(int, double, string)[1 .. $];
+
 pragma(msg, element1);
 pragma(msg, element2);
+
+pragma(msg, slice1);

--- a/test/compilable/dip63.d
+++ b/test/compilable/dip63.d
@@ -1,0 +1,14 @@
+template Pack(T...)
+{
+    alias expand = T;
+
+    alias opIndex(size_t index) = T[index];
+//    alias opSlice(size_t lower, size_t upper) = Pack!(T[lower..upper]);
+    enum opDollar = T.length;
+}
+
+alias element1 = Pack!(int, double)[1]; 
+alias element2 = Pack!(int, double)[$-1];
+
+pragma(msg, element1);
+pragma(msg, element2);


### PR DESCRIPTION
http://wiki.dlang.org/DIP63

After countless trial & error cycles I got most basic version that works for `opIndex` + `opDollar`. However my DMD hacking skills are horrible and before cleaning everything and adding more operator support I'd love to read some feedback if the way it is implemented is acceptable.

Please do not pay attention to all the debug stuff, just how it fits DMD architecture in general.
@9rnsr your feedback is most appreciated.

@WalterBright this DIP still needs your approval / rejection

``` D
template Pack(T...)
{
    alias opIndex(size_t index) = T[index];
    enum opDollar = T.length;
}

alias element1 = Pack!(int, double)[1]; 
alias element2 = Pack!(int, double)[$-1];

pragma(msg, element1);
pragma(msg, element2);
```
