### PR TITLE
[reg] fix Issue 13113 - cannot build druntime's gc.d with -debug=INVARIANT, ba...

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -932,11 +932,14 @@ FuncDeclaration *buildPostBlit(StructDeclaration *sd, Scope *sc)
     if (e || (stc & STCdisable))
     {
         //printf("Building __fieldPostBlit()\n");
-        PostBlitDeclaration *dd = new PostBlitDeclaration(declLoc, Loc(), stc, Lexer::idPool("__fieldPostBlit"));
+        PostBlitDeclaration *dd = new PostBlitDeclaration(declLoc, Loc(), stc & STCdisable, Lexer::idPool("__fieldPostBlit"));
+        dd->inferAttributes = true;
         dd->fbody = new ExpStatement(loc, e);
         sd->postblits.shift(dd);
         sd->members->push(dd);
         dd->semantic(sc);
+        dd->semantic2(sc);
+        dd->semantic3(sc);
     }
 
     switch (sd->postblits.dim)
@@ -964,10 +967,13 @@ FuncDeclaration *buildPostBlit(StructDeclaration *sd, Scope *sc)
                 ex = new CallExp(loc, ex);
                 e = Expression::combine(e, ex);
             }
-            PostBlitDeclaration *dd = new PostBlitDeclaration(declLoc, Loc(), stc, Lexer::idPool("__aggrPostBlit"));
+            PostBlitDeclaration *dd = new PostBlitDeclaration(declLoc, Loc(), stc & STCdisable, Lexer::idPool("__aggrPostBlit"));
+            dd->inferAttributes = true;
             dd->fbody = new ExpStatement(loc, e);
             sd->members->push(dd);
             dd->semantic(sc);
+            dd->semantic2(sc);
+            dd->semantic3(sc);
             return dd;
     }
 }
@@ -1045,11 +1051,14 @@ FuncDeclaration *buildDtor(AggregateDeclaration *ad, Scope *sc)
     if (e || (stc & STCdisable))
     {
         //printf("Building __fieldDtor()\n");
-        DtorDeclaration *dd = new DtorDeclaration(declLoc, Loc(), stc, Lexer::idPool("__fieldDtor"));
+        DtorDeclaration *dd = new DtorDeclaration(declLoc, Loc(), stc & STCdisable, Lexer::idPool("__fieldDtor"));
+        dd->inferAttributes = true;
         dd->fbody = new ExpStatement(loc, e);
         ad->dtors.shift(dd);
         ad->members->push(dd);
         dd->semantic(sc);
+        dd->semantic2(sc);
+        dd->semantic3(sc);
     }
 
     switch (ad->dtors.dim)
@@ -1077,10 +1086,13 @@ FuncDeclaration *buildDtor(AggregateDeclaration *ad, Scope *sc)
                 ex = new CallExp(loc, ex);
                 e = Expression::combine(ex, e);
             }
-            DtorDeclaration *dd = new DtorDeclaration(declLoc, Loc(), stc, Lexer::idPool("__aggrDtor"));
+            DtorDeclaration *dd = new DtorDeclaration(declLoc, Loc(), stc & STCdisable, Lexer::idPool("__aggrDtor"));
+            dd->inferAttributes = true;
             dd->fbody = new ExpStatement(loc, e);
             ad->members->push(dd);
             dd->semantic(sc);
+            dd->semantic2(sc);
+            dd->semantic3(sc);
             return dd;
     }
 }

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -602,8 +602,9 @@ public:
     bool isArrayOp;                     // true if array operation
     bool semantic3Errors;               // true if errors in semantic3
                                         // this function's frame ptr
-    ForeachStatement *fes;              // if foreach body, this is the foreach
+    bool inferAttributes;               // set if infer purity/nothrow/nogc/safe
     bool introducing;                   // true if 'introducing' function
+    ForeachStatement *fes;              // if foreach body, this is the foreach
     Type *tintro;                       // if !=NULL, then this is the type
                                         // of the 'introducing' function
                                         // this one is overriding

--- a/src/func.c
+++ b/src/func.c
@@ -323,7 +323,8 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     isArrayOp = 0;
     semantic3Errors = false;
     fes = NULL;
-    introducing = 0;
+    inferAttributes = false;
+    introducing = false;
     tintro = NULL;
     /* The type given for "infer the return type" is a TypeFunction with
      * NULL for the return type.
@@ -1130,7 +1131,7 @@ Ldone:
      */
     TemplateInstance *ti;
     if (fbody &&
-        (isFuncLiteralDeclaration() ||
+        (inferAttributes ||
          isInstantiated() && !isVirtualMethod() &&
          !(ti = parent->isTemplateInstance(), ti && !ti->isTemplateMixin() && ti->tempdecl->ident != ident)))
     {
@@ -4388,6 +4389,7 @@ FuncLiteralDeclaration::FuncLiteralDeclaration(Loc loc, Loc endloc, Type *type,
     this->tok = tok;
     this->fes = fes;
     this->treq = NULL;
+    this->inferAttributes = true;
     //printf("FuncLiteralDeclaration() id = '%s', type = '%s'\n", this->ident->toChars(), type->toChars());
 }
 

--- a/test/runnable/nogc.d
+++ b/test/runnable/nogc.d
@@ -44,6 +44,21 @@ void test12642() @nogc
 }
 
 /***********************/
+// 13113
+
+class Gcx
+{
+	invariant() { }
+
+	Treap!int tr;
+}
+
+struct Treap(E)
+{
+    ~this() { }
+}
+
+/***********************/
 
 int main()
 {


### PR DESCRIPTION
...d @nogc inference?

Attributes can be inferred for generated functions just like for function literals. This is more accurate than having the parallel method of mergeFuncAttrs(), which was failing in this case because it wasn't taking invariants into account.

https://issues.dlang.org/show_bug.cgi?id=13113
