### PR TITLE
Issue 13116: should reject returning `this` from a ref class member function

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -3455,22 +3455,18 @@ int ThisExp::isBool(int result)
 
 int ThisExp::isLvalue()
 {
-    return 1;
+    // Class `this` is an rvalue; struct `this` is an lvalue.
+    return (type->toBasetype()->ty != Tclass);
 }
 
 Expression *ThisExp::toLvalue(Scope *sc, Expression *e)
 {
-    return this;
-}
-
-Expression *ThisExp::modifiableLvalue(Scope *sc, Expression *e)
-{
     if (type->toBasetype()->ty == Tclass)
     {
-        error("cannot modify '%s' reference", toChars());
-        return toLvalue(sc, e);
+        // Class `this` is an rvalue; struct `this` is an lvalue.
+        return Expression::toLvalue(sc, e);
     }
-    return Expression::modifiableLvalue(sc, e);
+    return this;
 }
 
 /******************************** SuperExp **************************/

--- a/src/expression.h
+++ b/src/expression.h
@@ -367,7 +367,6 @@ public:
     int isBool(int result);
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
-    Expression *modifiableLvalue(Scope *sc, Expression *e);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/test/fail_compilation/diag4596.d
+++ b/test/fail_compilation/diag4596.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag4596.d(15): Error: cannot modify 'this' reference
-fail_compilation/diag4596.d(16): Error: cannot modify 'this' reference
-fail_compilation/diag4596.d(18): Error: cannot modify 'super' reference
-fail_compilation/diag4596.d(19): Error: cannot modify 'super' reference
+fail_compilation/diag4596.d(15): Error: this is not an lvalue
+fail_compilation/diag4596.d(16): Error: 1 ? this : this is not an lvalue
+fail_compilation/diag4596.d(18): Error: super is not an lvalue
+fail_compilation/diag4596.d(19): Error: 1 ? super : super is not an lvalue
 ---
 */
 

--- a/test/fail_compilation/fail13116.d
+++ b/test/fail_compilation/fail13116.d
@@ -1,0 +1,29 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13116.d(13): Error: this is not an lvalue
+---
+*/
+struct S
+{
+    ref S notEvil() { return this; } // this should be accepted
+}
+class C
+{
+    ref C evil() { return this; } // this should be rejected
+}
+void main()
+{
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13116.d(28): Error: super is not an lvalue
+---
+*/
+class Base { }
+class Derived : Base
+{
+    ref Base evil() { return super; } // should be rejected
+}

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2065,7 +2065,7 @@ class C9083
 
     void func()
     {
-        void templateFunc(T)(ref const T obj)
+        void templateFunc(T)(const T obj)
         {
             enum x1 = isFunction9083!(mixin("x"));  // NG
             enum x2 = isFunction9083!(x);           // NG


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=13116
Basically, for class members, `this` is a local reference to the class instance, so returning it by ref amounts to returning a reference to a local variable (due to classes being reference types).
For structs, returning `this` by ref returns the address of the original struct, so there is no problem.
There is an unresolved issue with this fix, though: the following valid case is now rejected:

```
class C {
    void func() {
        ref C helper() {
            return this; // should be OK
        }
        auto tmp = helper(); // reference hasn't escaped, shouldn't be rejected
    }
}
```

Not sure how to fix this. Any pointers from dmd experts? ;-)
