### PR TITLE
[DDMD] Do not call constructors from the glue layer (lib*)

### DIFF
--- a/src/libelf.c
+++ b/src/libelf.c
@@ -105,7 +105,7 @@ void LibElf::setFilename(const char *dir, const char *filename)
         arg = FileName::combine(dir, arg);
     const char *libfilename = FileName::defaultExt(arg, global.lib_ext);
 
-    libfile = new File(libfilename);
+    libfile = File::create(libfilename);
 
     loc.filename = libfile->name->toChars();
     loc.linnum = 0;
@@ -312,12 +312,11 @@ void LibElf::addObject(const char *module_name, void *buf, size_t buflen)
     int fromfile = 0;
     if (!buf)
     {   assert(module_name[0]);
-        FileName f((char *)module_name);
-        File file(&f);
-        readFile(Loc(), &file);
-        buf = file.buffer;
-        buflen = file.len;
-        file.ref = 1;
+        File *file = File::create((char *)module_name);
+        readFile(Loc(), file);
+        buf = file->buffer;
+        buflen = file->len;
+        file->ref = 1;
         fromfile = 1;
     }
     int reason = 0;

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -115,7 +115,7 @@ void LibMach::setFilename(const char *dir, const char *filename)
         arg = FileName::combine(dir, arg);
     const char *libfilename = FileName::defaultExt(arg, global.lib_ext);
 
-    libfile = new File(libfilename);
+    libfile = File::create(libfilename);
 
     loc.filename = libfile->name->toChars();
     loc.linnum = 0;
@@ -323,12 +323,11 @@ void LibMach::addObject(const char *module_name, void *buf, size_t buflen)
     int fromfile = 0;
     if (!buf)
     {   assert(module_name[0]);
-        FileName f((char *)module_name);
-        File file(&f);
-        readFile(Loc(), &file);
-        buf = file.buffer;
-        buflen = file.len;
-        file.ref = 1;
+        File *file = File::create((char *)module_name);
+        readFile(Loc(), file);
+        buf = file->buffer;
+        buflen = file->len;
+        file->ref = 1;
         fromfile = 1;
     }
     int reason = 0;

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -131,7 +131,7 @@ void LibMSCoff::setFilename(const char *dir, const char *filename)
         arg = FileName::combine(dir, arg);
     const char *libfilename = FileName::defaultExt(arg, global.lib_ext);
 
-    libfile = new File(libfilename);
+    libfile = File::create(libfilename);
 
     loc.filename = libfile->name->toChars();
     loc.linnum = 0;
@@ -343,12 +343,11 @@ void LibMSCoff::addObject(const char *module_name, void *buf, size_t buflen)
     int fromfile = 0;
     if (!buf)
     {   assert(module_name[0]);
-        FileName f((char *)module_name);
-        File file(&f);
-        readFile(Loc(), &file);
-        buf = file.buffer;
-        buflen = file.len;
-        file.ref = 1;
+        File *file = File::create((char *)module_name);
+        readFile(Loc(), file);
+        buf = file->buffer;
+        buflen = file->len;
+        file->ref = 1;
         fromfile = 1;
     }
     int reason = 0;

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -111,7 +111,7 @@ void LibOMF::setFilename(const char *dir, const char *filename)
         arg = FileName::combine(dir, arg);
     const char *libfilename = FileName::defaultExt(arg, global.lib_ext);
 
-    libfile = new File(libfilename);
+    libfile = File::create(libfilename);
 
     loc.filename = libfile->name->toChars();
     loc.linnum = 0;
@@ -236,12 +236,11 @@ void LibOMF::addObject(const char *module_name, void *buf, size_t buflen)
 #endif
     if (!buf)
     {   assert(module_name);
-        FileName f((char *)module_name);
-        File file(&f);
-        readFile(Loc(), &file);
-        buf = file.buffer;
-        buflen = file.len;
-        file.ref = 1;
+        File *file = File::create((char *)module_name);
+        readFile(Loc(), file);
+        buf = file->buffer;
+        buflen = file->len;
+        file->ref = 1;
     }
 
     unsigned g_page_size;


### PR DESCRIPTION
None of these are performance-critical, and the allocation is dwarfed by the file buffer it allocates immediately afterwards.
