### PR TITLE
Issue 13113 - cannot build druntime's gc.d with -debug=INVARIANT, bad @nogc inference?

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1471,9 +1471,20 @@ void FuncDeclaration::semantic3(Scope *sc)
                 }
                 if (inv)
                 {
-                    e = new DsymbolExp(Loc(), inv);
+                    //e = new DsymbolExp(Loc(), inv);
+                    //e = new CallExp(Loc(), e);
+                    //e = e->semantic(sc2);
+
+                    /* Bugzilla 13113: Currently virtual invariant calls completely
+                     * bypass attribute enforcement.
+                     * Change the behavior of pre-invariant call by following it.
+                     */
+                    e = new ThisExp(Loc());
+                    e->type = vthis->type;
+                    e = new DotVarExp(Loc(), e, inv, 0);
+                    e->type = inv->type;
                     e = new CallExp(Loc(), e);
-                    e = e->semantic(sc2);
+                    e->type = Type::tvoid;
                 }
             }
             else
@@ -1512,9 +1523,19 @@ void FuncDeclaration::semantic3(Scope *sc)
                 }
                 if (inv)
                 {
-                    e = new DsymbolExp(Loc(), inv);
+                    //e = new DsymbolExp(Loc(), inv);
+                    //e = new CallExp(Loc(), e);
+                    //e = e->semantic(sc2);
+
+                    /* Bugzilla 13113: As same as pre-invariant in destructor,
+                     * change the behavior of post-invariant call.
+                     */
+                    e = new ThisExp(Loc());
+                    e->type = vthis->type;
+                    e = new DotVarExp(Loc(), e, inv, 0);
+                    e->type = inv->type;
                     e = new CallExp(Loc(), e);
-                    e = e->semantic(sc2);
+                    e->type = Type::tvoid;
                 }
             }
             else

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -107,9 +107,43 @@ void test6453()
 }
 
 /***************************************************/
+// 13113
+
+struct S13113
+{
+    static int count;
+    invariant() // impure, throwable, system, and gc-able
+    {
+        ++count;    // impure
+    }
+
+    this(int) pure nothrow @safe @nogc {}
+    // post invaiant is called directly but doesn't interfere with constructor attributes
+
+    ~this() pure nothrow @safe @nogc {}
+    // pre invaiant is called directly but doesn't interfere with destructor attributes
+
+    void foo() pure nothrow @safe @nogc {}
+    // pre & post invariant calls don't interfere with method attributes
+}
+
+void test13113()
+{
+    assert(S13113.count == 0);
+    {
+        auto s = S13113(1);
+        assert(S13113.count == 1);
+        s.foo();
+        assert(S13113.count == 3);
+    }
+    assert(S13113.count == 4);
+}
+
+/***************************************************/
 
 void main()
 {
     testinvariant();
     test6453();
+    test13113();
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13113

Bypass attribute check on direct invariant calls.
