### PR TITLE
fix Issue 13117 - Executable size of hello world explodes from 472K to 2.7M

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -1601,7 +1601,8 @@ void Obj::ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym)
     symbol *ehtab_entry = symbol_generate(SCstatic,type_alloc(TYint));
     symbol_keep(ehtab_entry);
 
-    const int shf_flags = SHF_ALLOC | (config.flags3 & CFG3pic ? SHF_WRITE : 0);
+    // needs to be writeable for PIC code, see Bugzilla 13117
+    const int shf_flags = SHF_ALLOC | SHF_WRITE;
     ElfObj::getsegment(".deh_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
     int seg = ElfObj::getsegment(".deh_eh", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
     ehtab_entry->Sseg = seg;
@@ -1624,7 +1625,8 @@ void Obj::ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym)
 
 void Obj::ehsections()
 {
-    const int shf_flags = SHF_ALLOC | (config.flags3 & CFG3pic ? SHF_WRITE : 0);
+    // needs to be writeable for PIC code, see Bugzilla 13117
+    const int shf_flags = SHF_ALLOC | SHF_WRITE;
     int sec = ElfObj::getsegment(".deh_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
     //Obj::bytes(sec, 0, 4, NULL);
 
@@ -3117,7 +3119,8 @@ void Obj::moduleinfo(Symbol *scc)
     const int CFflags = I64 ? (CFoffset64 | CFoff) : CFoff;
 
     {
-        const int shf_flags = SHF_ALLOC | (config.flags3 & CFG3pic ? SHF_WRITE : 0);
+        // needs to be writeable for PIC code, see Bugzilla 13117
+        const int shf_flags = SHF_ALLOC | SHF_WRITE;
         ElfObj::getsegment(".minfo_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
         const int seg = ElfObj::getsegment(".minfo", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
         ElfObj::getsegment(".minfo_end", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
@@ -3183,7 +3186,8 @@ static void obj_rtinit()
     int seg;
 
     {
-    const int shf_flags = SHF_ALLOC | (config.flags3 & CFG3pic ? SHF_WRITE : 0);
+    // needs to be writeable for PIC code, see Bugzilla 13117
+    const int shf_flags = SHF_ALLOC | SHF_WRITE;
 
     seg = ElfObj::getsegment(".deh_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
     deh_beg = MAP_SEG2SYMIDX(seg);

--- a/test/runnable/test13117.d
+++ b/test/runnable/test13117.d
@@ -1,0 +1,13 @@
+// PERMUTE_ARGS: -O -release -g
+import std.file, std.stdio;
+
+int main()
+{
+    auto size = thisExePath.getSize();
+    writeln(size);
+    version (D_LP64)
+        enum limit = 1195096;
+    else
+        enum limit = 1042973;
+    return size > limit * 11 / 10;
+}

--- a/test/runnable/test13117b.d
+++ b/test/runnable/test13117b.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -inline
+// PERMUTE_ARGS: -O -release -g
+import std.file, std.stdio;
+
+int main()
+{
+    auto size = thisExePath.getSize();
+    writeln(size);
+    version (D_LP64)
+        enum limit = 2023652;
+    else
+        enum limit = 1763328;
+    return size > limit * 11 / 10;
+}


### PR DESCRIPTION
- This problem seems to stem from mixed writeable flags for the
  .deh/.minfo sections in PIC/non-PIC code. The ld.bfd linker would
  still try to bracket the sections, even though it previously mapped
  them to different segments, thereby creating one huge segment which
  contains all read-only and all writeable data plus the big hole in
  between them.
- fixed by always marking those sections as writeable

[Issue 13117](https://issues.dlang.org/show_bug.cgi?id=13117)
