### PR TITLE
[DDMD] Move sqrt into Port

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -69,7 +69,7 @@ Expression *eval_sqrt(Loc loc, FuncDeclaration *fd, Expressions *arguments)
 {
     Expression *arg0 = (*arguments)[0];
     assert(arg0->op == TOKfloat64);
-    return new RealExp(loc, sqrtl(arg0->toReal()), arg0->type);
+    return new RealExp(loc, Port::sqrt(arg0->toReal()), arg0->type);
 }
 
 Expression *eval_fabs(Loc loc, FuncDeclaration *fd, Expressions *arguments)

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -77,6 +77,11 @@ int Port::isInfinity(double r)
     return (::fpclassify(r) == FP_INFINITE);
 }
 
+longdouble Port::sqrt(longdouble x)
+{
+    return ::sqrtl(x);
+}
+
 longdouble Port::fmodl(longdouble x, longdouble y)
 {
     return ::fmodl(x, y);
@@ -212,6 +217,11 @@ int Port::isSignallingNan(longdouble r)
 int Port::isInfinity(double r)
 {
     return (::_fpclass(r) & (_FPCLASS_NINF | _FPCLASS_PINF));
+}
+
+longdouble Port::sqrt(longdouble x)
+{
+    return ::sqrtl(x);
 }
 
 longdouble Port::fmodl(longdouble x, longdouble y)
@@ -350,6 +360,11 @@ int Port::isSignallingNan(longdouble r)
 int Port::isInfinity(double r)
 {
     return isinf(r);
+}
+
+longdouble Port::sqrt(longdouble x)
+{
+    return ::sqrtl(x);
 }
 
 longdouble Port::fmodl(longdouble x, longdouble y)
@@ -572,6 +587,11 @@ int Port::isInfinity(double r)
 #endif
 }
 
+longdouble Port::sqrt(longdouble x)
+{
+    return ::sqrtl(x);
+}
+
 longdouble Port::fmodl(longdouble x, longdouble y)
 {
 #if __FreeBSD__ && __FreeBSD_version < 800000 || __OpenBSD__
@@ -751,6 +771,11 @@ int Port::isSignallingNan(longdouble r)
 int Port::isInfinity(double r)
 {
     return isinf(r);
+}
+
+longdouble Port::sqrt(longdouble x)
+{
+    return ::sqrtl(x);
 }
 
 longdouble Port::fmodl(longdouble x, longdouble y)

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -51,6 +51,7 @@ struct Port
     static int isInfinity(double);
 
     static longdouble fmodl(longdouble x, longdouble y);
+    static longdouble sqrt(longdouble x);
     static int fequal(longdouble x, longdouble y);
 
     static char *strupr(char *);


### PR DESCRIPTION
In DDMD on freebsd, calling sqrtl directly causes static asserts in phobos to fail, presumably because of the legendary lack of precision in freebsd math functions.

Moving the sqrt call into port allows for the DDMD version of port to call `core.math.sqrt` which always gives 80-bit precision.
