### PR TITLE
[DDMD] Replace Scope's custom allocator with a normal function and clean up interface

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -350,7 +350,7 @@ void ClassDeclaration::semantic(Scope *sc)
         for (size_t i = 0; i < baseclasses->dim; )
         {
             if (!scx)
-                scx = new Scope(*sc);
+                scx = sc->copyExact();
             scope = scx;
             scope->setNoFree();
 
@@ -1336,7 +1336,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
         for (size_t i = 0; i < baseclasses->dim; )
         {
             if (!scx)
-                scx = new Scope(*sc);
+                scx = sc->copyExact();
             scope = scx;
             scope->setNoFree();
 

--- a/src/scope.h
+++ b/src/scope.h
@@ -113,12 +113,12 @@ struct Scope
     OutBuffer *docbuf;          // buffer for documentation output
 
     static Scope *freelist;
-    static void *operator new(size_t sz);
+    static Scope *alloc();
     static Scope *createGlobal(Module *module);
 
     Scope();
-    Scope(Scope *enclosing);
 
+    Scope *copyExact();
     Scope *copy();
 
     Scope *push();


### PR DESCRIPTION
The main motivation for this is so that DDMD can use the freelist without having to implement a custom allocator.  The only difference is invocation syntax, and `Scope` is only newed from a handful of places so it's not a big deal.

Reducing the number of lines is a nice side effect.

With this change DDMD can pass the phobos unittests on win32 - meaning even std.algorithm finally uses less than 2GB of memory!
