### PR TITLE
[DDMD] Rename dmd associative array functions to avoid conflict with similarly named druntime functions

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -228,7 +228,7 @@ Expression *arrayOp(BinExp *e, Scope *sc)
     char *name = buf.peekString();
     Identifier *ident = Lexer::idPool(name);
 
-    FuncDeclaration **pFd = (FuncDeclaration **)_aaGet(&arrayfuncs, ident);
+    FuncDeclaration **pFd = (FuncDeclaration **)dmd_aaGet(&arrayfuncs, (void *)ident);
     FuncDeclaration *fd = *pFd;
 
     if (!fd)

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1482,14 +1482,14 @@ DsymbolTable::DsymbolTable()
 Dsymbol *DsymbolTable::lookup(Identifier *ident)
 {
     //printf("DsymbolTable::lookup(%s)\n", (char*)ident->string);
-    return (Dsymbol *)_aaGetRvalue(tab, ident);
+    return (Dsymbol *)dmd_aaGetRvalue(tab, (void *)ident);
 }
 
 Dsymbol *DsymbolTable::insert(Dsymbol *s)
 {
     //printf("DsymbolTable::insert(this = %p, '%s')\n", this, s->ident->toChars());
     Identifier *ident = s->ident;
-    Dsymbol **ps = (Dsymbol **)_aaGet(&tab, ident);
+    Dsymbol **ps = (Dsymbol **)dmd_aaGet(&tab, (void *)ident);
     if (*ps)
         return NULL;            // already in table
     *ps = s;
@@ -1499,7 +1499,7 @@ Dsymbol *DsymbolTable::insert(Dsymbol *s)
 Dsymbol *DsymbolTable::insert(Identifier *ident, Dsymbol *s)
 {
     //printf("DsymbolTable::insert()\n");
-    Dsymbol **ps = (Dsymbol **)_aaGet(&tab, ident);
+    Dsymbol **ps = (Dsymbol **)dmd_aaGet(&tab, (void *)ident);
     if (*ps)
         return NULL;            // already in table
     *ps = s;
@@ -1509,7 +1509,7 @@ Dsymbol *DsymbolTable::insert(Identifier *ident, Dsymbol *s)
 Dsymbol *DsymbolTable::update(Dsymbol *s)
 {
     Identifier *ident = s->ident;
-    Dsymbol **ps = (Dsymbol **)_aaGet(&tab, ident);
+    Dsymbol **ps = (Dsymbol **)dmd_aaGet(&tab, (void *)ident);
     *ps = s;
     return s;
 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -5535,7 +5535,7 @@ void FuncExp::genIdent(Scope *sc)
             symtab = sds->symtab;
         }
         assert(symtab);
-        int num = (int)_aaLen(symtab->tab) + 1;
+        int num = (int)dmd_aaLen(symtab->tab) + 1;
         Identifier *id = Lexer::uniqueId(s, num);
         fd->ident = id;
         if (td) td->ident = id;

--- a/src/root/aav.c
+++ b/src/root/aav.c
@@ -47,7 +47,7 @@ struct AA
  * Determine number of entries in associative array.
  */
 
-size_t _aaLen(AA* aa)
+size_t dmd_aaLen(AA* aa)
 {
     return aa ? aa->nodes : 0;
 }
@@ -58,7 +58,7 @@ size_t _aaLen(AA* aa)
  * Add entry for key if it is not already there.
  */
 
-Value* _aaGet(AA** paa, Key key)
+Value* dmd_aaGet(AA** paa, Key key)
 {
     //printf("paa = %p\n", paa);
 
@@ -102,7 +102,7 @@ Value* _aaGet(AA** paa, Key key)
     if (nodes > (*paa)->b_length * 2)
     {
         //printf("rehash\n");
-        _aaRehash(paa);
+        dmd_aaRehash(paa);
     }
 
     return &e->value;
@@ -114,7 +114,7 @@ Value* _aaGet(AA** paa, Key key)
  * Returns NULL if it is not already there.
  */
 
-Value _aaGetRvalue(AA* aa, Key key)
+Value dmd_aaGetRvalue(AA* aa, Key key)
 {
     //printf("_aaGetRvalue(key = %p)\n", key);
     if (aa)
@@ -138,7 +138,7 @@ Value _aaGetRvalue(AA* aa, Key key)
  * Rehash an array.
  */
 
-void _aaRehash(AA** paa)
+void dmd_aaRehash(AA** paa)
 {
     //printf("Rehash\n");
     if (*paa)
@@ -179,12 +179,12 @@ void _aaRehash(AA** paa)
 void unittest_aa()
 {
     AA* aa = NULL;
-    Value v = _aaGetRvalue(aa, NULL);
+    Value v = dmd_aaGetRvalue(aa, NULL);
     assert(!v);
-    Value *pv = _aaGet(&aa, NULL);
+    Value *pv = dmd_aaGet(&aa, NULL);
     assert(pv);
     *pv = (void *)3;
-    v = _aaGetRvalue(aa, NULL);
+    v = dmd_aaGetRvalue(aa, NULL);
     assert(v == (void *)3);
 }
 

--- a/src/root/aav.h
+++ b/src/root/aav.h
@@ -12,8 +12,8 @@ typedef void* Key;
 
 struct AA;
 
-size_t _aaLen(AA* aa);
-Value* _aaGet(AA** aa, Key key);
-Value _aaGetRvalue(AA* aa, Key key);
-void _aaRehash(AA** paa);
+size_t dmd_aaLen(AA* aa);
+Value* dmd_aaGet(AA** aa, Key key);
+Value dmd_aaGetRvalue(AA* aa, Key key);
+void dmd_aaRehash(AA** paa);
 

--- a/src/template.c
+++ b/src/template.c
@@ -5554,7 +5554,7 @@ MATCH TemplateValueParameter::matchArg(Scope *sc, RootObject *oarg,
 
     if (specValue)
     {
-        if (!ei || _aaGetRvalue(edummies, ei->type) == ei)
+        if (!ei || (Expression *)dmd_aaGetRvalue(edummies, (void *)ei->type) == ei)
             goto Lnomatch;
 
         Expression *e = specValue;
@@ -5641,7 +5641,7 @@ void *TemplateValueParameter::dummyArg()
     if (!e)
     {
         // Create a dummy value
-        Expression **pe = (Expression **)_aaGet(&edummies, valType);
+        Expression **pe = (Expression **)dmd_aaGet(&edummies, (void *)valType);
         if (!*pe)
             *pe = valType->defaultInit();
         e = *pe;
@@ -8140,7 +8140,7 @@ void TemplateMixin::semantic(Scope *sc)
             symtab = sc->parent->isScopeDsymbol()->symtab;
         L1:
             assert(symtab);
-            int num = (int)_aaLen(symtab->tab) + 1;
+            int num = (int)dmd_aaLen(symtab->tab) + 1;
             ident = Lexer::uniqueId(s, num);
             symtab->insert(this);
         }

--- a/src/traits.c
+++ b/src/traits.c
@@ -102,13 +102,13 @@ static void collectUnitTests(Dsymbols *symbols, AA *uniqueUnitTests, Expressions
         UnitTestDeclaration *unitTest = symbol->isUnitTestDeclaration();
         if (unitTest)
         {
-            if (!_aaGetRvalue(uniqueUnitTests, unitTest))
+            if (!dmd_aaGetRvalue(uniqueUnitTests, (void *)unitTest))
             {
                 FuncAliasDeclaration* alias = new FuncAliasDeclaration(unitTest, 0);
                 alias->protection = unitTest->protection;
                 Expression* e = new DsymbolExp(Loc(), alias);
                 unitTests->push(e);
-                bool* value = (bool*) _aaGet(&uniqueUnitTests, unitTest);
+                bool* value = (bool*) dmd_aaGet(&uniqueUnitTests, (void *)unitTest);
                 *value = true;
             }
         }


### PR DESCRIPTION
When ddmd accidentally calls the wrong functions really really really bad things happen.
