### PR TITLE
Issue 13185 - Detect precondition violations at compile time when possible

### DIFF
--- a/test/fail_compilation/fail13185.d
+++ b/test/fail_compilation/fail13185.d
@@ -1,0 +1,33 @@
+/*
+REQUIRED_ARGS: -o-
+TEST_OUTPUT:
+---
+fail_compilation/fail13185.d(31): Error: function 'fail13185.func' called with 'func(3)' does not pass precondition assert(x > 5)
+fail_compilation/fail13185.d(32): Error: function 'fail13185.divide' called with 'divide(9, 0)' does not pass precondition assert(y != 0)
+---
+*/
+
+void func(int x)
+in
+{
+    assert(x > 5);
+}
+body
+{
+}
+
+int divide(int x, int y)
+in
+{
+    assert(y != 0);
+}
+body
+{
+    return x / y;
+}
+
+void main()
+{
+    func(3);
+    assert(divide(9, 0) != 0);
+}

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -34,9 +34,9 @@ void test1()
 
 void foo2()
 in{
-	assert(0);
 }
 body{
+	assert(0);
 }
 
 void test2()


### PR DESCRIPTION
Implement compile-time contract checks for preconditions with the following limitations:
- Precondition contains only a single assert
- Parameters are value types or immutable
- Arguments are constant expressions
- Assert condition consists of only integer constants, parameters and comparisons

https://issues.dlang.org/show_bug.cgi?id=13185
