### PR TITLE
[2.066b] Issue 13194 - ICE when initializing static class members to void

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1753,10 +1753,10 @@ void VarDeclaration::semantic2(Scope *sc)
     }
     else if (init && isThreadlocal())
     {
-        if ((type->ty == Tclass)&&type->isMutable()&&!type->isShared())
+        if ((type->ty == Tclass) && type->isMutable() && !type->isShared())
         {
             ExpInitializer *ei = init->isExpInitializer();
-            if (ei->exp->op == TOKclassreference)
+            if (ei && ei->exp->op == TOKclassreference)
                 error("is mutable. Only const or immutable class thread local variable are allowed, not %s", type->toChars());
         }
         else if (type->ty == Tpointer && type->nextOf()->ty == Tstruct && type->nextOf()->isMutable() &&!type->nextOf()->isShared())

--- a/test/compilable/test13194.d
+++ b/test/compilable/test13194.d
@@ -1,0 +1,17 @@
+module test13194;
+
+class C13194
+{
+    static Object o = void;
+}
+
+struct S13194
+{
+    static Object o = void;
+}
+
+union U13194
+{
+    static Object o = void;
+}
+


### PR DESCRIPTION
Raised against GDC (hence the low bug number), but also causes an ICE in DMD.

http://bugzilla.gdcproject.org/show_bug.cgi?id=145

This should be pulled and included with 2.066 release.
