### PR TITLE
[DDMD] Issue 13190 - Optimizer breaks comparison with zero

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -2822,6 +2822,7 @@ code *cdind(elem *e,regm_t *pretregs)
                     gen2(ce,0xD1,modregrm(3,4,reg));    /* SHL reg,1    */
         L4:     cs.Iop = 0x0B;
                 getlvalue_lsw(&cs);
+                cs.Iflags |= CFpsw;
                 gen(ce,&cs);                    /* OR reg,lsw           */
         }
         else if (!I32 && sz == 8)

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1088,6 +1088,36 @@ int bug8525(int[] devt)
 
 ////////////////////////////////////////////////////////////////////////
 
+void func13190(int) {}
+
+struct Struct13190
+{
+    ulong a;
+    uint b;
+};
+
+__gshared Struct13190* table13190 =
+[
+    Struct13190(1, 1),
+    Struct13190(0, 2)
+];
+
+void test13190()
+{
+    for (int i = 0; table13190[i].a; i++)
+    {
+        ulong tbl = table13190[i].a;
+        func13190(i);
+        if (1 + tbl)
+        {
+            if (tbl == 0x80000)
+                return;
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+
 void test12833a(int a)
 {
     long x = cast(long)a;
@@ -1165,6 +1195,7 @@ int main()
     testandand();
     testor_combine();
     testshrshl();
+    test13190();
     test10639();
     test10715();
     test10678();


### PR DESCRIPTION
@WalterBright The scheduler ignores the conflict between the loop's inc and the condition's psw-setting because the 0x0B (or) instruction is not marked with CFpsw.  This does fix the problem, but is there somewhere better to put this?

https://issues.dlang.org/show_bug.cgi?id=13190
