### PR TITLE
Fix Issue 12164 - Function returning ptrdiff_t.min in 64-bit returning 0 when -O is set

### DIFF
--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1034,6 +1034,27 @@ void test10715()
 
 ////////////////////////////////////////////////////////////////////////
 
+ptrdiff_t compare12164(A12164* rhsPA, A12164* zis)
+{
+    if (*rhsPA == *zis)
+        return 0;
+    return ptrdiff_t.min;
+}
+
+struct A12164
+{
+    int a;
+}
+
+void test12164()
+{
+    auto a = A12164(3);
+    auto b = A12164(2);
+    assert(compare12164(&a, &b));
+}
+
+////////////////////////////////////////////////////////////////////////
+
 int foo10678(char[5] txt)
 {
     return txt[0] + txt[1] + txt[4];
@@ -1147,6 +1168,7 @@ int main()
     testbreak();
     teststringswitch();
     teststrarg();
+    test12164();
     testsizes();
     testarrayinit();
     testU();


### PR DESCRIPTION
@WalterBright

The trick used to optimize ?const:const doesn't work when you can't actually express the value as immediates.  They were silently truncated leading to incorrect results.

Values were also truncated due to a typo.

https://issues.dlang.org/show_bug.cgi?id=12164
