### PR TITLE
Issue 11435 - -O optimization flag causes invalid 32 bit codegen

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -3726,7 +3726,7 @@ code *params(elem *e,unsigned stackalign)
         {   // Avoid PUSH MEM on the Pentium when optimizing for speed
             break;
         }
-        else if (movOnly(e))
+        else if (movOnly(e) || szb < 4)
             break;                      // no PUSH MEM
         else
         {   int regsize = REGSIZE;

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -975,6 +975,65 @@ void testor_combine()
 
 ////////////////////////////////////////////////////////////////////////
 
+void test11435a()
+{
+    alias T = byte;
+
+    static void fun(T c, T b, int v)
+    {
+    }
+
+    static void abc(T[] b)
+    {
+        fun(b[0], b[1], 0);
+    }
+
+    version(Windows)
+    {
+        import core.sys.windows.windows;
+        auto p = VirtualAlloc(null, 4096, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+    }
+    else
+    {
+        import core.sys.posix.sys.mman;
+        auto p = mmap(null, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0L);
+    }
+    assert(p);
+    auto px = (cast(T*)(p + 4096 - 2 * T.sizeof));
+    abc(px[0..2]);
+}
+
+void test11435b()
+{
+    import core.sys.windows.windows;
+    alias T = short;
+
+    static void fun(T c, T b, int v)
+    {
+    }
+
+    static void abc(T[] b)
+    {
+        fun(b[0], b[1], 0);
+    }
+
+    version(Windows)
+    {
+        import core.sys.windows.windows;
+        auto p = VirtualAlloc(null, 4096, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+    }
+    else
+    {
+        import core.sys.posix.sys.mman;
+        auto p = mmap(null, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANON, -1, 0L);
+    }
+    assert(p);
+    auto px = (cast(T*)(p + 4096 - 2 * T.sizeof));
+    abc(px[0..2]);
+}
+
+////////////////////////////////////////////////////////////////////////
+
 
 int shrshl(int i) {
   return ((i+1)>>1)<<1;
@@ -1158,6 +1217,8 @@ int main()
     test12051();
     testdocond();
     testnegcom();
+    test11435a();
+    test11435b();
     test11565();
     testoror();
     testbt();


### PR DESCRIPTION
Do not emit a push from memory instruction for 8 or 16-byte words, ever.

@WalterBright Is there some way to detect it's pushing from a stack slot? (and therefore is always safe)

https://issues.dlang.org/show_bug.cgi?id=11435
