### PR TITLE
Issue 13023 - optimizer produces wrong code for comparision and division of ulong

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -2213,6 +2213,8 @@ code* gen_testcse(code *c, unsigned sz, targ_uns i)
                 FLcs,i, FLconst,(targ_uns) 0);
     if ((I64 || I32) && sz == 2)
         c->Iflags |= CFopsize;
+    if (I64 && sz == 8)
+        code_orrex(c, REX_W);
     return c;
 }
 

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -218,6 +218,20 @@ void testarrayinit()
 
 ///////////////////////
 
+void test13023(ulong n)
+{
+    static void func(bool b) {}
+
+    ulong k = 0;
+
+    func(k >= n / 2);
+
+    if (k >= n / 2)
+        assert(0);
+}
+
+///////////////////////
+
 struct U { int a; union { char c; int d; } long b; }
 
 U f = { b:3, d:2, a:1 };
@@ -1200,6 +1214,7 @@ int main()
     test10715();
     test10678();
     test7565();
+    test13023(0x10_0000_0000);
     test12833();
     test9449();
     test12057();


### PR DESCRIPTION
The common sub-expression loader decides that "32-bits is enough for anybody" and doesn't bother loading all 64-bits of the ulong.

https://issues.dlang.org/show_bug.cgi?id=13023
