### PR TITLE
Issue 5908 - Optimizer generates wrong value with divide-by-zero.

### DIFF
--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1226,7 +1226,7 @@ elem * evalu8(elem *e, goal_t goal)
     case OPdiv:
         if (!boolres(e2))                       // divide by 0
         {
-#if SCPP
+#if SCPP || MARS
             if (!tyfloating(tym))
 #endif
                 goto div0;
@@ -1401,15 +1401,20 @@ elem * evalu8(elem *e, goal_t goal)
         }
         break;
     case OPmod:
-        if (!boolres(e2))
-        {
-            div0:
-#if SCPP
-                synerr(EM_divby0);
-#else // MARS
-                //error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, e->Esrcpos.Scharnum, "divide by zero");
+#if MARS
+        if (!tyfloating(tym))
 #endif
-                break;
+        {
+            if (!boolres(e2))
+            {
+                div0:
+#if SCPP
+                    synerr(EM_divby0);
+#elif MARS
+                    error(e->Esrcpos.Sfilename, e->Esrcpos.Slinnum, e->Esrcpos.Scharnum, "divide by zero");
+#endif
+                    break;
+            }
         }
         if (uns)
             e->EV.Vullong = ((targ_ullong) l1) % ((targ_ullong) l2);
@@ -1485,6 +1490,7 @@ elem * evalu8(elem *e, goal_t goal)
     {
         targ_llong rem, quo;
 
+        assert(!tyfloating(tym));
         if (!boolres(e2))
             goto div0;
         if (uns)

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -98,13 +98,13 @@ void modulus_bug6000b() {
 
 void modulus2() {
     short s;
-    byte b;
+    byte b = byte.max;
     byte c = s % b;
 }
 
 void modulus3() {
     int i;
-    short s;
+    short s = short.max;
     short t = i % s;
 }
 

--- a/test/fail_compilation/fail5908.d
+++ b/test/fail_compilation/fail5908.d
@@ -1,0 +1,18 @@
+/*
+REQUIRED_ARGS: -O
+TEST_OUTPUT:
+---
+fail_compilation/fail5908.d(16): Error: divide by zero
+fail_compilation/fail5908.d(17): Error: divide by zero
+---
+*/
+
+// This bug is caught by the dmd optimizer - other backends might not catch it or give a different message
+
+int main()
+{
+    int a = 1;
+    int b = 0;
+    return (a % b) +
+        (a / b);
+}


### PR DESCRIPTION
Reinstate optimizer error for integer division by zero

https://issues.dlang.org/show_bug.cgi?id=5908
