### PR TITLE
Issue 12820 - DMD can inline calls to functions that use alloca, allocating the memory in the caller function instead.

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -270,6 +270,7 @@ Msgtable msgtable[] =
     { "getmembers", "getMembers" },
 
     // Special functions
+    { "__alloca", "alloca" },
     { "main" },
     { "WinMain" },
     { "DllMain" },

--- a/src/inline.c
+++ b/src/inline.c
@@ -370,6 +370,8 @@ public:
         // can't handle that at present.
         if (e->e1->op == TOKdotvar && ((DotVarExp *)e->e1)->e1->op == TOKsuper)
             cost = COST_MAX;
+        else if (e->f && e->f->ident == Id::__alloca && e->f->linkage == LINKc)
+            cost = COST_MAX; // inlining alloca may cause stack overflows
         else
             cost++;
     }

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -365,6 +365,23 @@ void test11223()
 }
 
 /************************************/
+
+
+void foo3918()
+{
+    import core.stdc.stdlib : alloca;
+    void[] mem = alloca(1024)[0..1024];
+}
+
+void test3918()
+{
+    foreach(i; 0 .. 10_000_000)
+    {
+        foo3918();
+    }
+}
+
+/************************************/
 // 11314
 
 struct Tuple11314(T...)
@@ -520,6 +537,7 @@ int main()
     test1();
     test2();
     test3();
+    test3918();
     test4();
     test5();
     test9356();


### PR DESCRIPTION
Simply do not inline direct calls to alloca.

https://issues.dlang.org/show_bug.cgi?id=12820
