### PR TITLE
[cleanup] Normalize backend's elf structures with system headers.

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -517,7 +517,7 @@ void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset)
         /* movl ModuleReference*, %eax */
         buf->writeByte(0xB8);
         codeOffset += 1;
-        const unsigned reltype = I64 ? R_X86_64_32 : RI_TYPE_SYM32;
+        const unsigned reltype = I64 ? R_X86_64_32 : R_386_32;
         codeOffset += ElfObj::writerel(seg, codeOffset, reltype, 3 /*STI_DATA*/, refOffset);
 
         /* movl _Dmodule_ref, %ecx */

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -73,7 +73,7 @@ static char __file__[] = __FILE__;      // for tassert.h
 int dwarf_getsegment(const char *name, int align)
 {
 #if ELFOBJ
-    return ElfObj::getsegment(name, NULL, SHT_PROGDEF, 0, align * 4);
+    return ElfObj::getsegment(name, NULL, SHT_PROGBITS, 0, align * 4);
 #elif MACHOBJ
     return MachObj::getsegment(name, "__DWARF", align * 2, S_ATTR_DEBUG);
 #else
@@ -89,7 +89,7 @@ int dwarf_getsegment(const char *name, int align)
 void dwarf_addrel(int seg, targ_size_t offset, int targseg, targ_size_t val = 0)
 {
 #if ELFOBJ
-    ElfObj::addrel(seg, offset, I64 ? R_X86_64_32 : RI_TYPE_SYM32, MAP_SEG2SYMIDX(targseg), val);
+    ElfObj::addrel(seg, offset, I64 ? R_X86_64_32 : R_386_32, MAP_SEG2SYMIDX(targseg), val);
 #elif MACHOBJ
     MachObj::addrel(seg, offset, NULL, targseg, RELaddr, val);
 #else

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -82,15 +82,15 @@ char *obj_mangle2(Symbol *s,char *dest);
 /***************************************************
  * Correspondence of relocation types
  *      386             32 bit in 64      64 in 64
- *      RI_TYPE_SYM32   R_X86_64_32       R_X86_64_64
- *      RI_TYPE_GOTOFF  R_X86_64_PC32     R_X86_64_
- *      RI_TYPE_GOTPC   R_X86_64_         R_X86_64_
- *      RI_TYPE_GOT32   R_X86_64_         R_X86_64_
- *      RI_TYPE_TLS_GD  R_X86_64_TLSGD    R_X86_64_
- *      RI_TYPE_TLS_IE  R_X86_64_GOTTPOFF R_X86_64_
- *      RI_TYPE_TLS_LE  R_X86_64_TPOFF32  R_X86_64_
- *      RI_TYPE_PLT32   R_X86_64_PLT32    R_X86_64_
- *      RI_TYPE_PC32    R_X86_64_PC32     R_X86_64_
+ *      R_386_32        R_X86_64_32       R_X86_64_64
+ *      R_386_GOTOFF    R_X86_64_PC32     R_X86_64_
+ *      R_386_GOTPC     R_X86_64_         R_X86_64_
+ *      R_386_GOT32     R_X86_64_         R_X86_64_
+ *      R_386_TLS_GD    R_X86_64_TLSGD    R_X86_64_
+ *      R_386_TLS_IE    R_X86_64_GOTTPOFF R_X86_64_
+ *      R_386_TLS_LE    R_X86_64_TPOFF32  R_X86_64_
+ *      R_386_PLT32     R_X86_64_PLT32    R_X86_64_
+ *      R_386_PC32      R_X86_64_PC32     R_X86_64_
  */
 
 /******************************************
@@ -505,7 +505,7 @@ static IDXSYM elf_addsym(IDXSTR nam, targ_size_t val, unsigned sz,
         sym.st_name = nam;
         sym.st_value = val;
         sym.st_size = sz;
-        sym.st_info = ELF_ST_INFO(bind,typ);
+        sym.st_info = ELF64_ST_INFO(bind,typ);
         sym.st_other = 0;
         sym.st_shndx = sec;
         SYMbuf->write(&sym,sizeof(sym));
@@ -520,7 +520,7 @@ static IDXSYM elf_addsym(IDXSTR nam, targ_size_t val, unsigned sz,
         sym.st_name = nam;
         sym.st_value = val;
         sym.st_size = sz;
-        sym.st_info = ELF_ST_INFO(bind,typ);
+        sym.st_info = ELF32_ST_INFO(bind,typ);
         sym.st_other = 0;
         sym.st_shndx = sec;
         SYMbuf->write(&sym,sizeof(sym));
@@ -545,16 +545,16 @@ static IDXSYM elf_addsym(IDXSTR nam, targ_size_t val, unsigned sz,
  */
 
 static IDXSEC elf_newsection2(
-        elf_u32_f32 name,
-        elf_u32_f32 type,
-        elf_u32_f32 flags,
-        elf_add_f32 addr,
-        elf_off_f32 offset,
-        elf_u32_f32 size,
-        elf_u32_f32 link,
-        elf_u32_f32 info,
-        elf_u32_f32 addralign,
-        elf_u32_f32 entsize)
+        Elf32_Word name,
+        Elf32_Word type,
+        Elf32_Word flags,
+        Elf32_Addr addr,
+        Elf32_Off offset,
+        Elf32_Word size,
+        Elf32_Word link,
+        Elf32_Word info,
+        Elf32_Word addralign,
+        Elf32_Word entsize)
 {
     Elf32_Shdr sec;
 
@@ -586,7 +586,7 @@ static IDXSEC elf_newsection2(
 }
 
 static IDXSEC elf_newsection(const char *name, const char *suffix,
-        elf_u32_f32 type, elf_u32_f32 flags)
+        Elf32_Word type, Elf32_Word flags)
 {
     // dbg_printf("elf_newsection(%s,%s,type %d, flags x%x)\n",
     //        name?name:"",suffix?suffix:"",type,flags);
@@ -732,19 +732,19 @@ Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
 
         // name,type,flags,addr,offset,size,link,info,addralign,entsize
         elf_newsection2(0,               SHT_NULL,   0,                 0,0,0,0,0, 0,0);
-        elf_newsection2(NAMIDX_TEXT,SHT_PROGDEF,SHF_ALLOC|SHF_EXECINSTR,0,0,0,0,0, 4,0);
+        elf_newsection2(NAMIDX_TEXT,SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,0,0,0,0,0, 4,0);
         elf_newsection2(NAMIDX_RELTEXT,SHT_RELA, 0,0,0,0,SHN_SYMTAB,     SHN_TEXT, 8,0x18);
-        elf_newsection2(NAMIDX_DATA,SHT_PROGDEF,SHF_ALLOC|SHF_WRITE,    0,0,0,0,0, 8,0);
+        elf_newsection2(NAMIDX_DATA,SHT_PROGBITS,SHF_ALLOC|SHF_WRITE,   0,0,0,0,0, 8,0);
         elf_newsection2(NAMIDX_RELDATA64,SHT_RELA, 0,0,0,0,SHN_SYMTAB,   SHN_DATA, 8,0x18);
         elf_newsection2(NAMIDX_BSS, SHT_NOBITS,SHF_ALLOC|SHF_WRITE,     0,0,0,0,0, 16,0);
-        elf_newsection2(NAMIDX_RODATA,SHT_PROGDEF,SHF_ALLOC,            0,0,0,0,0, 16,0);
+        elf_newsection2(NAMIDX_RODATA,SHT_PROGBITS,SHF_ALLOC,           0,0,0,0,0, 16,0);
         elf_newsection2(NAMIDX_STRTAB,SHT_STRTAB, 0,                    0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX_SYMTAB,SHT_SYMTAB, 0,                    0,0,0,0,0, 8,0);
         elf_newsection2(NAMIDX_SHSTRTAB,SHT_STRTAB, 0,                  0,0,0,0,0, 1,0);
-        elf_newsection2(NAMIDX_COMMENT, SHT_PROGDEF,0,                  0,0,0,0,0, 1,0);
+        elf_newsection2(NAMIDX_COMMENT, SHT_PROGBITS,0,                 0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX_NOTE,SHT_NOTE,   0,                      0,0,0,0,0, 1,0);
-        elf_newsection2(NAMIDX_GNUSTACK,SHT_PROGDEF,0,                  0,0,0,0,0, 1,0);
-        elf_newsection2(NAMIDX_CDATAREL,SHT_PROGDEF,SHF_ALLOC|SHF_WRITE,0,0,0,0,0, 16,0);
+        elf_newsection2(NAMIDX_GNUSTACK,SHT_PROGBITS,0,                 0,0,0,0,0, 1,0);
+        elf_newsection2(NAMIDX_CDATAREL,SHT_PROGBITS,SHF_ALLOC|SHF_WRITE,0,0,0,0,0, 16,0);
 
         IDXSTR namidx;
         namidx = NAMIDX_TEXT;      *(IDXSTR *)section_names_hashtable->get(&namidx) = namidx;
@@ -780,19 +780,19 @@ Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
 
         // name,type,flags,addr,offset,size,link,info,addralign,entsize
         elf_newsection2(0,               SHT_NULL,   0,                 0,0,0,0,0, 0,0);
-        elf_newsection2(NAMIDX_TEXT,SHT_PROGDEF,SHF_ALLOC|SHF_EXECINSTR,0,0,0,0,0, 16,0);
+        elf_newsection2(NAMIDX_TEXT,SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,0,0,0,0,0, 16,0);
         elf_newsection2(NAMIDX_RELTEXT,SHT_REL, 0,0,0,0,SHN_SYMTAB,      SHN_TEXT, 4,8);
-        elf_newsection2(NAMIDX_DATA,SHT_PROGDEF,SHF_ALLOC|SHF_WRITE,    0,0,0,0,0, 4,0);
+        elf_newsection2(NAMIDX_DATA,SHT_PROGBITS,SHF_ALLOC|SHF_WRITE,   0,0,0,0,0, 4,0);
         elf_newsection2(NAMIDX_RELDATA,SHT_REL, 0,0,0,0,SHN_SYMTAB,      SHN_DATA, 4,8);
         elf_newsection2(NAMIDX_BSS, SHT_NOBITS,SHF_ALLOC|SHF_WRITE,     0,0,0,0,0, 32,0);
-        elf_newsection2(NAMIDX_RODATA,SHT_PROGDEF,SHF_ALLOC,            0,0,0,0,0, 1,0);
+        elf_newsection2(NAMIDX_RODATA,SHT_PROGBITS,SHF_ALLOC,           0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX_STRTAB,SHT_STRTAB, 0,                    0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX_SYMTAB,SHT_SYMTAB, 0,                    0,0,0,0,0, 4,0);
         elf_newsection2(NAMIDX_SHSTRTAB,SHT_STRTAB, 0,                  0,0,0,0,0, 1,0);
-        elf_newsection2(NAMIDX_COMMENT, SHT_PROGDEF,0,                  0,0,0,0,0, 1,0);
+        elf_newsection2(NAMIDX_COMMENT, SHT_PROGBITS,0,                 0,0,0,0,0, 1,0);
         elf_newsection2(NAMIDX_NOTE,SHT_NOTE,   0,                      0,0,0,0,0, 1,0);
-        elf_newsection2(NAMIDX_GNUSTACK,SHT_PROGDEF,0,                  0,0,0,0,0, 1,0);
-        elf_newsection2(NAMIDX_CDATAREL,SHT_PROGDEF,SHF_ALLOC|SHF_WRITE,0,0,0,0,0, 1,0);
+        elf_newsection2(NAMIDX_GNUSTACK,SHT_PROGBITS,0,                 0,0,0,0,0, 1,0);
+        elf_newsection2(NAMIDX_CDATAREL,SHT_PROGBITS,SHF_ALLOC|SHF_WRITE,0,0,0,0,0, 1,0);
 
         IDXSTR namidx;
         namidx = NAMIDX_TEXT;      *(IDXSTR *)section_names_hashtable->get(&namidx) = namidx;
@@ -889,7 +889,7 @@ void Obj::initfile(const char *filename, const char *csegname, const char *modna
         Elf32_Shdr *newtextsec;
         IDXSYM newsymidx;
         SegData[cseg]->SDshtidx = newsecidx =
-            elf_newsection(csegname,0,SHT_PROGDEF,SHF_ALLOC|SHF_EXECINSTR);
+            elf_newsection(csegname,0,SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR);
         newtextsec = &SecHdrTab[newsecidx];
         newtextsec->sh_addralign = 4;
         SegData[cseg]->SDsymidx =
@@ -926,7 +926,7 @@ void *elf_renumbersyms()
         int old_idx = 0;
         for(Elf64_Sym *s = oldsymtab; s != symtabend; s++)
         {   // reorder symbol and map new #s to old
-            int bind = ELF_ST_BIND(s->st_info);
+            int bind = ELF64_ST_BIND(s->st_info);
             if (bind == STB_LOCAL)
             {
                 *sl++ = *s;
@@ -953,7 +953,7 @@ void *elf_renumbersyms()
         int old_idx = 0;
         for(Elf32_Sym *s = oldsymtab; s != symtabend; s++)
         {   // reorder symbol and map new #s to old
-            int bind = ELF_ST_BIND(s->st_info);
+            int bind = ELF32_ST_BIND(s->st_info);
             if (bind == STB_LOCAL)
             {
                 *sl++ = *s;
@@ -1022,7 +1022,7 @@ void *elf_renumbersyms()
                 for (int r = 0; r < pseg->SDrelcnt; r++)
                 {
                     unsigned t = ELF32_R_TYPE(rel->r_info);
-                    unsigned si = ELF32_R_IDX(rel->r_info);
+                    unsigned si = ELF32_R_SYM(rel->r_info);
                     assert(si < symbol_idx);
                     rel->r_info = ELF32_R_INFO(sym_map[si],t);
                     rel++;
@@ -1076,60 +1076,23 @@ void Obj::term(const char *objfilename)
         return;
 #endif
 
-    // Write out the bytes for the header
-    static const char elf_string32[EI_NIDENT] =
-    {
-        ELFMAG0,ELFMAG1,ELFMAG2,ELFMAG3,
-        ELFCLASS32,             // EI_CLASS
-        ELFDATA2LSB,            // EI_DATA
-        EV_CURRENT,             // EI_VERSION
-        ELFOSABI,0,             // EI_OSABI,EI_ABIVERSION
-        0,0,0,0,0,0,0
-    };
-    static const char elf_string64[EI_NIDENT] =
-    {
-        ELFMAG0,ELFMAG1,ELFMAG2,ELFMAG3,
-        ELFCLASS64,             // EI_CLASS
-        ELFDATA2LSB,            // EI_DATA
-        EV_CURRENT,             // EI_VERSION
-        ELFOSABI,0,             // EI_OSABI,EI_ABIVERSION
-        0,0,0,0,0,0,0
-    };
-    fobjbuf->write(I64 ? elf_string64 : elf_string32, EI_NIDENT);
-
     long foffset;
     Elf32_Shdr *sechdr;
     seg_data *seg;
     void *symtab = elf_renumbersyms();
     FILE *fd = NULL;
 
-    // Output the ELF Header
-    // The section header is build in the static variable elf_header
-    static Elf64_Ehdr elf_header =
-    {
-        ET_REL,                         // e_type
-        EM_X86_64,                      // e_machine
-        EV_CURRENT,                     // e_version
-        0,                              // e_entry
-        0,                              // e_phoff
-        0,                              // e_shoff
-        0,                              // e_flags
-        sizeof(Elf64_Ehdr) + EI_NIDENT, // e_ehsize
-        sizeof(Elf64_Phdr),             // e_phentsize
-        0,                              // e_phnum
-        sizeof(Elf64_Shdr),             // e_shentsize
-        0,                              // e_shnum
-        0                               // e_shstrndx
-    };
-    int hdrsize = I64 ? sizeof(Elf64_Ehdr) : sizeof(Elf32_Hdr);
+    int hdrsize = (I64 ? sizeof(Elf64_Ehdr) : sizeof(Elf32_Ehdr));
 
+    uint16_t e_shnum;
     if (section_cnt < SHN_LORESERVE)
-        elf_header.e_shnum = section_cnt;
+        e_shnum = section_cnt;
     else
-    {   elf_header.e_shnum = SHN_UNDEF;
+    {
+        e_shnum = SHN_UNDEF;
         SecHdrTab[0].sh_size = section_cnt;
     }
-    elf_header.e_shstrndx = SHN_SECNAMES;
+    // uint16_t e_shstrndx = SHN_SECNAMES;
     fobjbuf->writezeros(hdrsize);
 
             // Walk through sections determining size and file offsets
@@ -1145,7 +1108,7 @@ void Obj::term(const char *objfilename)
             //  symbol table
             //  strings table
 
-    foffset = EI_NIDENT + hdrsize;      // start after header
+    foffset = hdrsize;      // start after header
                                     // section header table at end
 
     //
@@ -1296,7 +1259,7 @@ void Obj::term(const char *objfilename)
     //
     // Finish off with the section header table
     //
-    elf_header.e_shoff = foffset;       // remember location in elf header
+    uint64_t e_shoff = foffset;       // remember location in elf header
     //dbg_printf("output section header table\n");
 
     // Output the completed Section Header Table
@@ -1332,27 +1295,65 @@ void Obj::term(const char *objfilename)
     // Now that we have correct offset to section header table, e_shoff,
     //  go back and re-output the elf header
     //
-    fobjbuf->position(EI_NIDENT, hdrsize);
+    fobjbuf->position(0, hdrsize);
     if (I64)
     {
-        fobjbuf->write(&elf_header, hdrsize);
+        static Elf64_Ehdr h =
+        {
+            {
+                ELFMAG0,ELFMAG1,ELFMAG2,ELFMAG3,
+                ELFCLASS64,             // EI_CLASS
+                ELFDATA2LSB,            // EI_DATA
+                EV_CURRENT,             // EI_VERSION
+                ELFOSABI,0,             // EI_OSABI,EI_ABIVERSION
+                0,0,0,0,0,0,0
+            },
+            ET_REL,                         // e_type
+            EM_X86_64,                      // e_machine
+            EV_CURRENT,                     // e_version
+            0,                              // e_entry
+            0,                              // e_phoff
+            0,                              // e_shoff
+            0,                              // e_flags
+            sizeof(Elf64_Ehdr),             // e_ehsize
+            sizeof(Elf64_Phdr),             // e_phentsize
+            0,                              // e_phnum
+            sizeof(Elf64_Shdr),             // e_shentsize
+            0,                              // e_shnum
+            SHN_SECNAMES                    // e_shstrndx
+        };
+        h.e_shoff     = e_shoff;
+        h.e_shnum     = e_shnum;
+        fobjbuf->write(&h, hdrsize);
     }
     else
-    {   Elf32_Hdr h;
-        // Transfer to 32 bit header
-        h.e_type      = elf_header.e_type;
-        h.e_machine   = EM_386;
-        h.e_version   = elf_header.e_version;
-        h.e_entry     = elf_header.e_entry;
-        h.e_phoff     = elf_header.e_phoff;
-        h.e_shoff     = elf_header.e_shoff;
-        h.e_flags     = elf_header.e_flags;
-        h.e_ehsize    = sizeof(Elf32_Hdr) + EI_NIDENT;
-        h.e_phentsize = sizeof(elf_pht);
-        h.e_phnum     = elf_header.e_phnum;
-        h.e_shentsize = sizeof(Elf32_Shdr);
-        h.e_shnum     = elf_header.e_shnum;
-        h.e_shstrndx  = elf_header.e_shstrndx;
+    {
+        static Elf32_Ehdr h =
+        {
+            {
+                ELFMAG0,ELFMAG1,ELFMAG2,ELFMAG3,
+                ELFCLASS32,             // EI_CLASS
+                ELFDATA2LSB,            // EI_DATA
+                EV_CURRENT,             // EI_VERSION
+                ELFOSABI,0,             // EI_OSABI,EI_ABIVERSION
+                0,0,0,0,0,0,0
+            },
+            ET_REL,                         // e_type
+            EM_386,                         // e_machine
+            EV_CURRENT,                     // e_version
+            0,                              // e_entry
+            0,                              // e_phoff
+            0,                              // e_shoff
+            0,                              // e_flags
+            sizeof(Elf32_Ehdr),             // e_ehsize
+            sizeof(Elf32_Phdr),             // e_phentsize
+            0,                              // e_phnum
+            sizeof(Elf32_Shdr),             // e_shentsize
+            0,                              // e_shnum
+            SHN_SECNAMES                    // e_shstrndx
+        };
+        h.e_shoff     = e_shoff;
+        h.e_shnum     = e_shnum;
         fobjbuf->write(&h, hdrsize);
     }
     fobjbuf->position(foffset, 0);
@@ -1547,8 +1548,8 @@ void Obj::staticctor(Symbol *s,int dtor,int none)
     //dbg_printf("Obj::staticctor(%s) offset %x\n",s->Sident,s->Soffset);
     //symbol_print(s);
     const IDXSEC seg = s->Sseg =
-        ElfObj::getsegment(".ctors", NULL, SHT_PROGDEF, SHF_ALLOC|SHF_WRITE, 4);
-    const unsigned relinfo = I64 ? R_X86_64_64 : RI_TYPE_SYM32;
+        ElfObj::getsegment(".ctors", NULL, SHT_PROGBITS, SHF_ALLOC|SHF_WRITE, 4);
+    const unsigned relinfo = I64 ? R_X86_64_64 : R_386_32;
     const size_t sz = ElfObj::writerel(seg, SegData[seg]->SDoffset, relinfo, STI_TEXT, s->Soffset);
     SegData[seg]->SDoffset += sz;
 }
@@ -1567,8 +1568,8 @@ void Obj::staticdtor(Symbol *s)
     //symbol_print(s);
     // Why does this sequence differ from staticctor, looks like a bug?
     const IDXSEC seg =
-        ElfObj::getsegment(".dtors", NULL, SHT_PROGDEF, SHF_ALLOC|SHF_WRITE, 4);
-    const unsigned relinfo = I64 ? R_X86_64_64 : RI_TYPE_SYM32;
+        ElfObj::getsegment(".dtors", NULL, SHT_PROGBITS, SHF_ALLOC|SHF_WRITE, 4);
+    const unsigned relinfo = I64 ? R_X86_64_64 : R_386_32;
     const size_t sz = ElfObj::writerel(seg, SegData[seg]->SDoffset, relinfo, s->Sxtrnnum, s->Soffset);
     SegData[seg]->SDoffset += sz;
 }
@@ -1603,17 +1604,17 @@ void Obj::ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym)
 
     // needs to be writeable for PIC code, see Bugzilla 13117
     const int shf_flags = SHF_ALLOC | SHF_WRITE;
-    ElfObj::getsegment(".deh_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
-    int seg = ElfObj::getsegment(".deh_eh", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    ElfObj::getsegment(".deh_beg", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
+    int seg = ElfObj::getsegment(".deh_eh", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
     ehtab_entry->Sseg = seg;
     Outbuffer *buf = SegData[seg]->SDbuf;
-    ElfObj::getsegment(".deh_end", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    ElfObj::getsegment(".deh_end", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
     ehtab_entry->Stype->Tmangle = mTYman_c;
     ehsym->Stype->Tmangle = mTYman_c;
 
     assert(sfunc->Sxtrnnum && sfunc->Sseg);
     assert(ehsym->Sxtrnnum && ehsym->Sseg);
-    const unsigned relinfo = I64 ?  R_X86_64_64 : RI_TYPE_SYM32;
+    const unsigned relinfo = I64 ?  R_X86_64_64 : R_386_32;
     ElfObj::writerel(seg, buf->size(), relinfo, MAP_SEG2SYMIDX(sfunc->Sseg), sfunc->Soffset);
     ElfObj::writerel(seg, buf->size(), relinfo, MAP_SEG2SYMIDX(ehsym->Sseg), ehsym->Soffset);
     buf->write(&sfunc->Ssize, NPTRSIZE);
@@ -1627,16 +1628,16 @@ void Obj::ehsections()
 {
     // needs to be writeable for PIC code, see Bugzilla 13117
     const int shf_flags = SHF_ALLOC | SHF_WRITE;
-    int sec = ElfObj::getsegment(".deh_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    int sec = ElfObj::getsegment(".deh_beg", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
     //Obj::bytes(sec, 0, 4, NULL);
 
     IDXSTR namidx = Obj::addstr(symtab_strings,"_deh_beg");
     elf_addsym(namidx, 0, 4, STT_OBJECT, STB_GLOBAL, MAP_SEG2SECIDX(sec));
     //elf_addsym(namidx, 0, 4, STT_OBJECT, STB_GLOBAL, MAP_SEG2SECIDX(sec));
 
-    ElfObj::getsegment(".deh_eh", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    ElfObj::getsegment(".deh_eh", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
 
-    sec = ElfObj::getsegment(".deh_end", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    sec = ElfObj::getsegment(".deh_end", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
     namidx = Obj::addstr(symtab_strings,"_deh_end");
     elf_addsym(namidx, 0, 4, STT_OBJECT, STB_GLOBAL, MAP_SEG2SECIDX(sec));
 
@@ -1652,13 +1653,13 @@ void obj_tlssections()
     IDXSTR namidx;
     int align = I64 ? 16 : 4;
 
-    int sec = ElfObj::getsegment(".tdata", NULL, SHT_PROGDEF, SHF_ALLOC|SHF_WRITE|SHF_TLS, align);
+    int sec = ElfObj::getsegment(".tdata", NULL, SHT_PROGBITS, SHF_ALLOC|SHF_WRITE|SHF_TLS, align);
     Obj::bytes(sec, 0, align, NULL);
 
     namidx = Obj::addstr(symtab_strings,"_tlsstart");
     elf_addsym(namidx, 0, align, STT_TLS, STB_GLOBAL, MAP_SEG2SECIDX(sec));
 
-    ElfObj::getsegment(".tdata.", NULL, SHT_PROGDEF, SHF_ALLOC|SHF_WRITE|SHF_TLS, align);
+    ElfObj::getsegment(".tdata.", NULL, SHT_PROGBITS, SHF_ALLOC|SHF_WRITE|SHF_TLS, align);
 
     sec = ElfObj::getsegment(".tcommon", NULL, SHT_NOBITS, SHF_ALLOC|SHF_WRITE|SHF_TLS, align);
     namidx = Obj::addstr(symtab_strings,"_tlsend");
@@ -1689,7 +1690,7 @@ STATIC void setup_comdat(Symbol *s)
         //s->Sfl = FLcode;      // was FLoncecode
         //prefix = ".gnu.linkonce.t";   // doesn't work, despite documentation
         prefix = ".text.";              // undocumented, but works
-        type = SHT_PROGDEF;
+        type = SHT_PROGBITS;
         flags = SHF_ALLOC|SHF_EXECINSTR;
     }
     else if ((s->ty() & mTYLINK) == mTYthread)
@@ -1699,11 +1700,11 @@ STATIC void setup_comdat(Symbol *s)
          */
         if (I64)
             align = 16;
-        ElfObj::getsegment(".tdata", NULL, SHT_PROGDEF, SHF_ALLOC|SHF_WRITE|SHF_TLS, align);
+        ElfObj::getsegment(".tdata", NULL, SHT_PROGBITS, SHF_ALLOC|SHF_WRITE|SHF_TLS, align);
 
         s->Sfl = FLtlsdata;
         prefix = ".tdata.";
-        type = SHT_PROGDEF;
+        type = SHT_PROGBITS;
         flags = SHF_ALLOC|SHF_WRITE|SHF_TLS;
     }
     else
@@ -1713,7 +1714,7 @@ STATIC void setup_comdat(Symbol *s)
         s->Sfl = FLdata;
         //prefix = ".gnu.linkonce.d.";
         prefix = ".data.";
-        type = SHT_PROGDEF;
+        type = SHT_PROGBITS;
         flags = SHF_ALLOC|SHF_WRITE;
     }
 
@@ -1871,7 +1872,7 @@ int Obj::codeseg(char *name,int suffix)
         return cseg;
     }
 
-    seg = ElfObj::getsegment(name, sfx, SHT_PROGDEF, SHF_ALLOC|SHF_EXECINSTR, 4);
+    seg = ElfObj::getsegment(name, sfx, SHT_PROGBITS, SHF_ALLOC|SHF_EXECINSTR, 4);
                                     // find or create code segment
 
     cseg = seg;                         // new code segment index
@@ -1918,14 +1919,14 @@ seg_data *Obj::tlsseg()
     /* Ensure that ".tdata" precedes any other .tdata. section, as the ld
      * linker script fails to work right.
      */
-    ElfObj::getsegment(".tdata", NULL, SHT_PROGDEF, SHF_ALLOC|SHF_WRITE|SHF_TLS, 4);
+    ElfObj::getsegment(".tdata", NULL, SHT_PROGBITS, SHF_ALLOC|SHF_WRITE|SHF_TLS, 4);
 
     static const char tlssegname[] = ".tdata.";
     //dbg_printf("Obj::tlsseg(\n");
 
     if (seg_tlsseg == UNKNOWN)
     {
-        seg_tlsseg = ElfObj::getsegment(tlssegname, NULL, SHT_PROGDEF,
+        seg_tlsseg = ElfObj::getsegment(tlssegname, NULL, SHT_PROGBITS,
             SHF_ALLOC|SHF_WRITE|SHF_TLS, I64 ? 16 : 4);
     }
     return SegData[seg_tlsseg];
@@ -2118,7 +2119,7 @@ void Obj::func_start(Symbol *sfunc)
     if ((tybasic(sfunc->ty()) == TYmfunc) && (sfunc->Sclass == SCextern))
     {                                   // create a new code segment
         sfunc->Sseg =
-            ElfObj::getsegment(".gnu.linkonce.t.", cpp_mangle(sfunc), SHT_PROGDEF, SHF_ALLOC|SHF_EXECINSTR,4);
+            ElfObj::getsegment(".gnu.linkonce.t.", cpp_mangle(sfunc), SHT_PROGBITS, SHF_ALLOC|SHF_EXECINSTR,4);
 
     }
     else if (sfunc->Sseg == UNKNOWN)
@@ -2453,7 +2454,7 @@ unsigned Obj::bytes(int seg, targ_size_t offset, unsigned nbytes, void *p)
  * Input:
  *      seg =           where the address is going
  *      offset =        offset within seg
- *      type =          ELF relocation type RI_TYPE_XXXX
+ *      type =          ELF relocation type R_ARCH_XXXX
  *      index =         Related symbol table index
  *      val =           addend or displacement from address
  */
@@ -2620,37 +2621,37 @@ static size_t relsize32(unsigned type)
     assert(I32);
     switch (type)
     {
-    case RI_TYPE_NONE: return 0;
-    case RI_TYPE_SYM32: return 4;
-    case RI_TYPE_PC32: return 4;
-    case RI_TYPE_GOT32: return 4;
-    case RI_TYPE_PLT32: return 4;
-    case RI_TYPE_COPY: return 0;
-    case RI_TYPE_GLOBDAT: return 4;
-    case RI_TYPE_JMPSLOT: return 4;
-    case RI_TYPE_REL: return 4;
-    case RI_TYPE_GOTOFF: return 4;
-    case RI_TYPE_GOTPC: return 4;
-    case RI_TYPE_TLS_TPOFF: return 4;
-    case RI_TYPE_TLS_IE: return 4;
-    case RI_TYPE_TLS_GOTIE: return 4;
-    case RI_TYPE_TLS_LE: return 4;
-    case RI_TYPE_TLS_GD: return 4;
-    case RI_TYPE_TLS_LDM: return 4;
-    case RI_TYPE_TLS_GD_32: return 4;
-    case RI_TYPE_TLS_GD_PUSH: return 4;
-    case RI_TYPE_TLS_GD_CALL: return 4;
-    case RI_TYPE_TLS_GD_POP: return 4;
-    case RI_TYPE_TLS_LDM_32: return 4;
-    case RI_TYPE_TLS_LDM_PUSH: return 4;
-    case RI_TYPE_TLS_LDM_CALL: return 4;
-    case RI_TYPE_TLS_LDM_POP: return 4;
-    case RI_TYPE_TLS_LDO_32: return 4;
-    case RI_TYPE_TLS_IE_32: return 4;
-    case RI_TYPE_TLS_LE_32: return 4;
-    case RI_TYPE_TLS_DTPMOD32: return 4;
-    case RI_TYPE_TLS_DTPOFF32: return 4;
-    case RI_TYPE_TLS_TPOFF32: return 4;
+    case R_386_NONE: return 0;
+    case R_386_32: return 4;
+    case R_386_PC32: return 4;
+    case R_386_GOT32: return 4;
+    case R_386_PLT32: return 4;
+    case R_386_COPY: return 0;
+    case R_386_GLOB_DAT: return 4;
+    case R_386_JMP_SLOT: return 4;
+    case R_386_RELATIVE: return 4;
+    case R_386_GOTOFF: return 4;
+    case R_386_GOTPC: return 4;
+    case R_386_TLS_TPOFF: return 4;
+    case R_386_TLS_IE: return 4;
+    case R_386_TLS_GOTIE: return 4;
+    case R_386_TLS_LE: return 4;
+    case R_386_TLS_GD: return 4;
+    case R_386_TLS_LDM: return 4;
+    case R_386_TLS_GD_32: return 4;
+    case R_386_TLS_GD_PUSH: return 4;
+    case R_386_TLS_GD_CALL: return 4;
+    case R_386_TLS_GD_POP: return 4;
+    case R_386_TLS_LDM_32: return 4;
+    case R_386_TLS_LDM_PUSH: return 4;
+    case R_386_TLS_LDM_CALL: return 4;
+    case R_386_TLS_LDM_POP: return 4;
+    case R_386_TLS_LDO_32: return 4;
+    case R_386_TLS_IE_32: return 4;
+    case R_386_TLS_LE_32: return 4;
+    case R_386_TLS_DTPMOD32: return 4;
+    case R_386_TLS_DTPOFF32: return 4;
+    case R_386_TLS_TPOFF32: return 4;
     default:
         assert(0);
     }
@@ -2682,7 +2683,7 @@ static size_t writeaddrval(int targseg, size_t offset, targ_size_t val, size_t s
  * Input:
  *      targseg =       the target segment for the relocation
  *      offset =        offset within target segment
- *      reltype =       ELF relocation type RI_TYPE_XXXX
+ *      reltype =       ELF relocation type R_ARCH_XXXX
  *      symidx =        symbol base for relocation
  *      val =           addend or displacement from symbol
  */
@@ -2762,11 +2763,11 @@ void Obj::reftodatseg(int seg,targ_size_t offset,targ_size_t val,
     else
     {
         if (MAP_SEG2TYP(seg) == CODE && config.flags3 & CFG3pic)
-            relinfo = RI_TYPE_GOTOFF;
+            relinfo = R_386_GOTOFF;
         else if (MAP_SEG2SEC(targetdatum)->sh_flags & SHF_TLS)
-            relinfo = config.flags3 & CFG3pic ? RI_TYPE_TLS_GD : RI_TYPE_TLS_LE;
+            relinfo = config.flags3 & CFG3pic ? R_386_TLS_GD : R_386_TLS_LE;
         else
-            relinfo = RI_TYPE_SYM32;
+            relinfo = R_386_32;
     }
     ElfObj::writerel(seg, offset, relinfo, targetsymidx, val);
 }
@@ -2797,7 +2798,7 @@ void Obj::reftocodeseg(int seg,targ_size_t offset,targ_size_t val)
         if (I64)
             relinfo = (config.flags3 & CFG3pic) ? R_X86_64_PC32 : R_X86_64_32;
         else
-            relinfo = (config.flags3 & CFG3pic) ? RI_TYPE_GOTOFF : RI_TYPE_SYM32;
+            relinfo = (config.flags3 & CFG3pic) ? R_386_GOTOFF : R_386_32;
     }
     ElfObj::writerel(seg, offset, relinfo, funcsym_p->Sxtrnnum, val - funcsym_p->Soffset);
 }
@@ -2823,7 +2824,7 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
 {
     bool external = TRUE;
     Outbuffer *buf;
-    elf_u32_f32 relinfo=R_X86_64_NONE,refseg;
+    Elf32_Word relinfo=R_X86_64_NONE,refseg;
     int segtyp = MAP_SEG2TYP(seg);
     //assert(val == 0);
     int retsize = (flags & CFoffset64) ? 8 : 4;
@@ -2866,9 +2867,9 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
             else
             {
                 if (s->Sfl == FLtlsdata)
-                    relinfo = config.flags3 & CFG3pic ? RI_TYPE_TLS_GD : RI_TYPE_TLS_LE;
+                    relinfo = config.flags3 & CFG3pic ? R_386_TLS_GD : R_386_TLS_LE;
                 else
-                    relinfo = config.flags3 & CFG3pic ? RI_TYPE_GOTOFF : RI_TYPE_SYM32;
+                    relinfo = config.flags3 & CFG3pic ? R_386_GOTOFF : R_386_32;
             }
             if (flags & CFoffset64 && relinfo == R_X86_64_32)
             {
@@ -2923,7 +2924,7 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                         if (I64)
                             relinfo = config.flags3 & CFG3pic ?  R_X86_64_PLT32 : R_X86_64_PC32;
                         else
-                            relinfo = config.flags3 & CFG3pic ?  RI_TYPE_PLT32 : RI_TYPE_PC32;
+                            relinfo = config.flags3 & CFG3pic ?  R_386_PLT32 : R_386_PC32;
                         val = (targ_size_t)-4;
                     }
                 }
@@ -2940,20 +2941,20 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                             if (I64)
                                 relinfo = (flags & CFpc32) ? R_X86_64_PC32 : R_X86_64_32;
                             else
-                                relinfo = RI_TYPE_SYM32;
+                                relinfo = R_386_32;
                         }
                         else
                         {
-                            relinfo = I64 ? R_X86_64_PC32 : RI_TYPE_GOTOFF;
+                            relinfo = I64 ? R_X86_64_PC32 : R_386_GOTOFF;
                         }
                     }
                     else if (config.flags3 & CFG3pic && s == GOTsym)
                     {                   // relocation for Gbl Offset Tab
-                        relinfo =  I64 ? R_X86_64_NONE : RI_TYPE_GOTPC;
+                        relinfo =  I64 ? R_X86_64_NONE : R_386_GOTPC;
                     }
                     else if (segtyp == DATA)
                     {                   // relocation from within DATA seg
-                        relinfo = I64 ? R_X86_64_32 : RI_TYPE_SYM32;
+                        relinfo = I64 ? R_X86_64_32 : R_386_32;
                     }
                     else
                     {                   // relocation from within CODE seg
@@ -2964,7 +2965,7 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                                 relinfo = (flags & CFpc32) ? R_X86_64_PC32 : R_X86_64_32;
                         }
                         else
-                            relinfo = config.flags3 & CFG3pic ? RI_TYPE_GOT32 : RI_TYPE_SYM32;
+                            relinfo = config.flags3 & CFG3pic ? R_386_GOT32 : R_386_32;
                     }
                     if ((s->ty() & mTYLINK) & mTYthread)
                     {
@@ -2990,16 +2991,16 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                             if (config.flags3 & CFG3pic)
                             {
                                 if (s->Sclass == SCstatic)
-                                    relinfo = RI_TYPE_TLS_LE;  // TLS_GD?
+                                    relinfo = R_386_TLS_LE;  // TLS_GD?
                                 else
-                                    relinfo = RI_TYPE_TLS_IE;
+                                    relinfo = R_386_TLS_IE;
                             }
                             else
                             {
                                 if (s->Sclass == SCstatic)
-                                    relinfo = RI_TYPE_TLS_LE;
+                                    relinfo = R_386_TLS_LE;
                                 else
-                                    relinfo = RI_TYPE_TLS_IE;
+                                    relinfo = R_386_TLS_IE;
                             }
                         }
                     }
@@ -3121,9 +3122,9 @@ void Obj::moduleinfo(Symbol *scc)
     {
         // needs to be writeable for PIC code, see Bugzilla 13117
         const int shf_flags = SHF_ALLOC | SHF_WRITE;
-        ElfObj::getsegment(".minfo_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
-        const int seg = ElfObj::getsegment(".minfo", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
-        ElfObj::getsegment(".minfo_end", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+        ElfObj::getsegment(".minfo_beg", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
+        const int seg = ElfObj::getsegment(".minfo", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
+        ElfObj::getsegment(".minfo_end", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
         SegData[seg]->SDoffset +=
             reftoident(seg, SegData[seg]->SDoffset, scc, 0, CFflags);
     }
@@ -3161,9 +3162,9 @@ void Obj::moduleinfo(Symbol *scc)
 
     /* Add reference to constructor into ".ctors" segment
      */
-    const int seg = ElfObj::getsegment(".ctors", NULL, SHT_PROGDEF, SHF_ALLOC|SHF_WRITE, NPTRSIZE);
+    const int seg = ElfObj::getsegment(".ctors", NULL, SHT_PROGBITS, SHF_ALLOC|SHF_WRITE, NPTRSIZE);
 
-    const unsigned relinfo = I64 ? R_X86_64_64 : RI_TYPE_SYM32;
+    const unsigned relinfo = I64 ? R_X86_64_64 : R_386_32;
     const size_t sz = ElfObj::writerel(seg, SegData[seg]->SDoffset, relinfo, STI_TEXT, codeOffset);
     SegData[seg]->SDoffset += sz;
 #endif // !REQUIRE_DSO_REGISTRY
@@ -3189,21 +3190,21 @@ static void obj_rtinit()
     // needs to be writeable for PIC code, see Bugzilla 13117
     const int shf_flags = SHF_ALLOC | SHF_WRITE;
 
-    seg = ElfObj::getsegment(".deh_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    seg = ElfObj::getsegment(".deh_beg", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
     deh_beg = MAP_SEG2SYMIDX(seg);
 
-    ElfObj::getsegment(".deh_eh", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    ElfObj::getsegment(".deh_eh", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
 
-    seg = ElfObj::getsegment(".deh_end", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    seg = ElfObj::getsegment(".deh_end", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
     deh_end = MAP_SEG2SYMIDX(seg);
 
 
-    seg = ElfObj::getsegment(".minfo_beg", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    seg = ElfObj::getsegment(".minfo_beg", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
     minfo_beg = MAP_SEG2SYMIDX(seg);
 
-    ElfObj::getsegment(".minfo", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    ElfObj::getsegment(".minfo", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
 
-    seg = ElfObj::getsegment(".minfo_end", NULL, SHT_PROGDEF, shf_flags, NPTRSIZE);
+    seg = ElfObj::getsegment(".minfo_end", NULL, SHT_PROGBITS, shf_flags, NPTRSIZE);
     minfo_end = MAP_SEG2SYMIDX(seg);
     }
 
@@ -3224,7 +3225,7 @@ static void obj_rtinit()
          *     void       *data;
          * } DSORec;
          */
-        seg = ElfObj::getsegment(".data.d_dso_rec", NULL, SHT_PROGDEF,
+        seg = ElfObj::getsegment(".data.d_dso_rec", NULL, SHT_PROGBITS,
                          SHF_ALLOC|SHF_WRITE|SHF_GROUP, NPTRSIZE);
         dso_rec = MAP_SEG2SYMIDX(seg);
         Obj::bytes(seg, 0, NPTRSIZE, NULL);
@@ -3267,7 +3268,7 @@ static void obj_rtinit()
          */
         int codseg;
         {
-            codseg = ElfObj::getsegment(".text.d_dso_init", NULL, SHT_PROGDEF,
+            codseg = ElfObj::getsegment(".text.d_dso_init", NULL, SHT_PROGBITS,
                                     SHF_ALLOC|SHF_EXECINSTR|SHF_GROUP, NPTRSIZE);
             // add to section group
             SegData[groupseg]->SDbuf->write32(MAP_SEG2SECIDX(codseg));
@@ -3334,14 +3335,14 @@ static void obj_rtinit()
             buf->writeByte(0x81);
             buf->writeByte(modregrm(3,0,BX));
             off += 2;
-            off += ElfObj::writerel(codseg, off, RI_TYPE_GOTPC, Obj::external(Obj::getGOTsym()), 3);
+            off += ElfObj::writerel(codseg, off, R_386_GOTPC, Obj::external(Obj::getGOTsym()), 3);
         }
 
         int reltype;
         if (config.flags3 & CFG3pic)
-            reltype = I64 ? R_X86_64_PC32 : RI_TYPE_GOTOFF;
+            reltype = I64 ? R_X86_64_PC32 : R_386_GOTOFF;
         else
-            reltype = I64 ? R_X86_64_32 : RI_TYPE_SYM32;
+            reltype = I64 ? R_X86_64_32 : R_386_32;
 
         const IDXSYM syms[] = {dso_rec, minfo_beg, minfo_end, deh_beg, deh_end};
 
@@ -3408,7 +3409,7 @@ static void obj_rtinit()
         // call _d_dso_registry@PLT
         buf->writeByte(0xE8);
         off += 1;
-        off += ElfObj::writerel(codseg, off, I64 ? R_X86_64_PLT32 : RI_TYPE_PLT32, symidx, -4);
+        off += ElfObj::writerel(codseg, off, I64 ? R_X86_64_PLT32 : R_386_PLT32, symidx, -4);
 
 #else
 
@@ -3435,7 +3436,7 @@ static void obj_rtinit()
                 buf->writeByte(0x81);
                 buf->writeByte(modregrm(2,7,BX));
                 off += 2;
-                off += ElfObj::writerel(codseg, off, RI_TYPE_GOT32, symidx, 0);
+                off += ElfObj::writerel(codseg, off, R_386_GOT32, symidx, 0);
                 buf->write32(0);
                 off += 4;
             }
@@ -3447,14 +3448,14 @@ static void obj_rtinit()
             // call foo@PLT[RIP]
             buf->writeByte(0xE8);
             off += 1;
-            off += ElfObj::writerel(codseg, off, I64 ? R_X86_64_PLT32 : RI_TYPE_PLT32, symidx, -4);
+            off += ElfObj::writerel(codseg, off, I64 ? R_X86_64_PLT32 : R_386_PLT32, symidx, -4);
         }
         else
         {
             // mov ECX, offset foo
             buf->writeByte(0xB8 + CX);
             off += 1;
-            reltype = I64 ? R_X86_64_32 : RI_TYPE_SYM32;
+            reltype = I64 ? R_X86_64_32 : R_386_32;
             off += ElfObj::writerel(codseg, off, reltype, symidx, 0);
 
             // test ECX, ECX
@@ -3469,7 +3470,7 @@ static void obj_rtinit()
             // call _d_dso_registry[RIP]
             buf->writeByte(0xE8);
             off += 1;
-            off += ElfObj::writerel(codseg, off, I64 ? R_X86_64_PC32 : RI_TYPE_PC32, symidx, -4);
+            off += ElfObj::writerel(codseg, off, I64 ? R_X86_64_PC32 : R_386_PC32, symidx, -4);
         }
 
 #endif // REQUIRE_DSO_REGISTRY
@@ -3493,7 +3494,7 @@ static void obj_rtinit()
         const int flags = SHF_ALLOC|SHF_GROUP;
         for (size_t i = 0; i < 2; ++i)
         {
-            seg = ElfObj::getsegment(p[i], NULL, SHT_PROGDEF, flags, NPTRSIZE);
+            seg = ElfObj::getsegment(p[i], NULL, SHT_PROGBITS, flags, NPTRSIZE);
             assert(!SegData[seg]->SDbuf->size());
 
             // add to section group
@@ -3503,7 +3504,7 @@ static void obj_rtinit()
             if (I64)
                 reltype = R_X86_64_64;
             else
-                reltype = RI_TYPE_SYM32;
+                reltype = R_386_32;
 
             SegData[seg]->SDoffset += ElfObj::writerel(seg, 0, reltype, MAP_SEG2SYMIDX(codseg), 0);
         }

--- a/src/backend/melf.h
+++ b/src/backend/melf.h
@@ -1,17 +1,25 @@
 
+#if __linux__
+
+#include <elf.h>
+
+#else
+
+#include <stdint.h>
+
 /* ELF file format */
 
-typedef unsigned short  elf_u16_f32;
-typedef unsigned int    elf_u32_f32;
-typedef int             elf_s32_f32;
-typedef unsigned int    elf_add_f32;
-typedef unsigned int    elf_off_f32;
-typedef unsigned char   elf_u8_f32;
+typedef uint16_t Elf32_Half;
+typedef uint32_t Elf32_Word;
+typedef int32_t  Elf32_Sword;
+typedef uint32_t Elf32_Addr;
+typedef uint32_t Elf32_Off;
+typedef uint32_t elf_u8_f32;
 
 #define  EI_NIDENT 16
 typedef struct
     {
-//    unsigned char EHident[EI_NIDENT]; /* Header identification info */
+    unsigned char EHident[EI_NIDENT]; /* Header identification info */
         #define EI_MAG0         0           /* Identification byte offset 0*/
         #define EI_MAG1         1           /* Identification byte offset 1*/
         #define EI_MAG2         2           /* Identification byte offset 2*/
@@ -48,7 +56,7 @@ typedef struct
 
         #define EI_PAD  9           /* Byte to start of padding */
 
-    elf_u16_f32 e_type;             /* Object file type */
+    Elf32_Half e_type;             /* Object file type */
         #define ET_NONE     0       /* No specified file type */
         #define ET_REL      1       /* Relocatable object file */
         #define ET_EXEC     2       /* Executable file */
@@ -57,38 +65,38 @@ typedef struct
         #define ET_LOPROC   0xff00  /* Processor low index */
         #define ET_HIPROC   0xffff  /* Processor hi index */
 
-    elf_u16_f32 e_machine;          /* Machine architecture */
+    Elf32_Half e_machine;          /* Machine architecture */
         #define EM_386      3       /* Intel 80386 */
         #define EM_486      6       /* Intel 80486 */
         #define EM_X86_64   62      // Advanced Micro Devices X86-64 processor
 
-    elf_u32_f32 e_version;              /* File format version */
+    Elf32_Word e_version;              /* File format version */
             #define EV_NONE     0       // invalid version
             #define EV_CURRENT  1       // Current file format
 
-    elf_add_f32 e_entry;                /* Entry point virtual address */
-    elf_off_f32 e_phoff;                /* Program header table(PHT)offset */
-    elf_off_f32 e_shoff;                /* Section header table(SHT)offset */
-    elf_u32_f32 e_flags;                /* Processor-specific flags */
-    elf_u16_f32 e_ehsize;               /* Size of ELF header (bytes) */
+    Elf32_Addr e_entry;                /* Entry point virtual address */
+    Elf32_Off e_phoff;                /* Program header table(PHT)offset */
+    Elf32_Off e_shoff;                /* Section header table(SHT)offset */
+    Elf32_Word e_flags;                /* Processor-specific flags */
+    Elf32_Half e_ehsize;               /* Size of ELF header (bytes) */
         #define EH_HEADER_SIZE 0x34
-    elf_u16_f32 e_phentsize;            /* Size of PHT (bytes) */
+    Elf32_Half e_phentsize;            /* Size of PHT (bytes) */
         #define EH_PHTENT_SIZE 0x20
-    elf_u16_f32 e_phnum;                /* Number of PHT entries */
-    elf_u16_f32 e_shentsize;            /* Size of SHT entry in bytes */
+    Elf32_Half e_phnum;                /* Number of PHT entries */
+    Elf32_Half e_shentsize;            /* Size of SHT entry in bytes */
         #define EH_SHTENT_SIZE 0x28
-    elf_u16_f32 e_shnum;                /* Number of SHT entries */
-    elf_u16_f32 e_shstrndx;             /* SHT index for string table */
-  } Elf32_Hdr;
+    Elf32_Half e_shnum;                /* Number of SHT entries */
+    Elf32_Half e_shstrndx;             /* SHT index for string table */
+  } Elf32_Ehdr;
 
 /* Section header.  */
 
 typedef struct
 {
-  elf_u32_f32   sh_name;                /* String table offset for section name */
-  elf_u32_f32   sh_type;                /* Section type */
+  Elf32_Word   sh_name;                /* String table offset for section name */
+  Elf32_Word   sh_type;                /* Section type */
         #define SHT_NULL         0          /* SHT entry unused */
-        #define SHT_PROGDEF      1          /* Program defined data */
+        #define SHT_PROGBITS     1          /* Program defined data */
         #define SHT_SYMTAB       2          /* Symbol table */
         #define SHT_STRTAB       3          /* String table */
         #define SHT_RELA         4          /* Relocations with addends */
@@ -102,20 +110,20 @@ typedef struct
         #define SHT_DYNTAB       11         /* Dynamic linker symbol table */
         #define SHT_GROUP        17         /* Section group (COMDAT) */
         #define SHT_SYMTAB_SHNDX 18         /* Extended section indeces */
-  elf_u32_f32   sh_flags;               /* Section attribute flags */
+  Elf32_Word   sh_flags;               /* Section attribute flags */
         #define SHF_WRITE       (1 << 0)    /* Writable during execution */
         #define SHF_ALLOC       (1 << 1)    /* In memory during execution */
         #define SHF_EXECINSTR   (1 << 2)    /* Executable machine instructions*/
         #define SHF_GROUP       (1 << 9)    /* Member of a section group */
         #define SHF_TLS         (1 << 10)   /* Thread local */
         #define SHF_MASKPROC    0xf0000000  /* Mask for processor-specific */
-  elf_add_f32   sh_addr;                /* Starting virtual memory address */
-  elf_off_f32   sh_offset;              /* Offset to section in file */
-  elf_u32_f32   sh_size;                /* Size of section */
-  elf_u32_f32   sh_link;                /* Index to optional related section */
-  elf_u32_f32   sh_info;                /* Optional extra section information */
-  elf_u32_f32   sh_addralign;           /* Required section alignment */
-  elf_u32_f32   sh_entsize;             /* Size of fixed size section entries */
+  Elf32_Addr   sh_addr;                /* Starting virtual memory address */
+  Elf32_Off   sh_offset;              /* Offset to section in file */
+  Elf32_Word   sh_size;                /* Size of section */
+  Elf32_Word   sh_link;                /* Index to optional related section */
+  Elf32_Word   sh_info;                /* Optional extra section information */
+  Elf32_Word   sh_addralign;           /* Required section alignment */
+  Elf32_Word   sh_entsize;             /* Size of fixed size section entries */
 } Elf32_Shdr;
 
 // Special Section Header Table Indices
@@ -134,13 +142,13 @@ typedef struct
 
 typedef struct
 {
-    elf_u32_f32 st_name;                /* string table index for symbol name */
-    elf_add_f32 st_value;               /* Associated symbol value */
-    elf_u32_f32 st_size;                /* Symbol size */
+    Elf32_Word st_name;                /* string table index for symbol name */
+    Elf32_Addr st_value;               /* Associated symbol value */
+    Elf32_Word st_size;                /* Symbol size */
     unsigned char st_info;              /* Symbol type and binding */
-        #define ELF_ST_BIND(s) ((s)>>4)
-        #define ELF_ST_TYPE(s) ((s)&0xf)
-        #define ELF_ST_INFO(b,t) (((b) << 4) + ((t) & 0xf))
+        #define ELF32_ST_BIND(s) ((s)>>4)
+        #define ELF32_ST_TYPE(s) ((s)&0xf)
+        #define ELF32_ST_INFO(b,t) (((b) << 4) + ((t) & 0xf))
 
         #define STB_LOCAL       0           /* Local symbol */
         #define STB_GLOBAL      1           /* Global symbol */
@@ -166,7 +174,7 @@ typedef struct
 
 
     unsigned char st_other;     /* Currently not defined */
-    elf_u16_f32 st_shndx;       /* SHT index for symbol definition */
+    Elf32_Half st_shndx;       /* SHT index for symbol definition */
 } Elf32_Sym;
 
 
@@ -174,50 +182,50 @@ typedef struct
 
 typedef struct
 {
-    elf_add_f32 r_offset;               /* Address */
-    elf_u32_f32 r_info;                 /* Relocation type and symbol index */
-        #define ELF32_R_IDX(i) ((i) >> 8)       /* Symbol idx */
+    Elf32_Addr r_offset;               /* Address */
+    Elf32_Word r_info;                 /* Relocation type and symbol index */
+        #define ELF32_R_SYM(i) ((i) >> 8)       /* Symbol idx */
         #define ELF32_R_TYPE(i)((i) & 0xff)     /* Type of relocation */
         #define ELF32_R_INFO(i, t) (((i) << 8) + ((t) & 0xff))
 
-        #define RI_TYPE_NONE    0               /* No reloc */
-        #define RI_TYPE_SYM32   1               /* Symbol value 32 bit  */
-        #define RI_TYPE_PC32    2               /* PC relative 32 bit */
-        #define RI_TYPE_GOT32   3               /* 32 bit GOT entry */
-        #define RI_TYPE_PLT32   4               /* 32 bit PLT address */
-        #define RI_TYPE_COPY    5               /* Copy symbol at runtime */
-        #define RI_TYPE_GLOBDAT 6               /* Create GOT entry */
-        #define RI_TYPE_JMPSLOT 7               /* Create PLT entry */
-        #define RI_TYPE_REL     8               /* Adjust by program base */
-        #define RI_TYPE_GOTOFF  9               /* 32 bit offset to GOT */
-        #define RI_TYPE_GOTPC   10              /* 32 bit PC relative offset to GOT */
-        #define RI_TYPE_TLS_TPOFF 14
-        #define RI_TYPE_TLS_IE    15
-        #define RI_TYPE_TLS_GOTIE 16
-        #define RI_TYPE_TLS_LE    17            /* negative offset relative to static TLS */
-        #define RI_TYPE_TLS_GD    18
-        #define RI_TYPE_TLS_LDM   19
-        #define RI_TYPE_TLS_GD_32 24
-        #define RI_TYPE_TLS_GD_PUSH  25
-        #define RI_TYPE_TLS_GD_CALL  26
-        #define RI_TYPE_TLS_GD_POP   27
-        #define RI_TYPE_TLS_LDM_32   28
-        #define RI_TYPE_TLS_LDM_PUSH 29
-        #define RI_TYPE_TLS_LDM_CALL 30
-        #define RI_TYPE_TLS_LDM_POP  31
-        #define RI_TYPE_TLS_LDO_32   32
-        #define RI_TYPE_TLS_IE_32    33
-        #define RI_TYPE_TLS_LE_32    34
-        #define RI_TYPE_TLS_DTPMOD32 35
-        #define RI_TYPE_TLS_DTPOFF32 36
-        #define RI_TYPE_TLS_TPOFF32  37
+        #define R_386_NONE    0               /* No reloc */
+        #define R_386_32      1               /* Symbol value 32 bit  */
+        #define R_386_PC32    2               /* PC relative 32 bit */
+        #define R_386_GOT32   3               /* 32 bit GOT entry */
+        #define R_386_PLT32   4               /* 32 bit PLT address */
+        #define R_386_COPY    5               /* Copy symbol at runtime */
+        #define R_386_GLOB_DAT 6               /* Create GOT entry */
+        #define R_386_JMP_SLOT 7               /* Create PLT entry */
+        #define R_386_RELATIVE 8               /* Adjust by program base */
+        #define R_386_GOTOFF  9               /* 32 bit offset to GOT */
+        #define R_386_GOTPC   10              /* 32 bit PC relative offset to GOT */
+        #define R_386_TLS_TPOFF 14
+        #define R_386_TLS_IE    15
+        #define R_386_TLS_GOTIE 16
+        #define R_386_TLS_LE    17            /* negative offset relative to static TLS */
+        #define R_386_TLS_GD    18
+        #define R_386_TLS_LDM   19
+        #define R_386_TLS_GD_32 24
+        #define R_386_TLS_GD_PUSH  25
+        #define R_386_TLS_GD_CALL  26
+        #define R_386_TLS_GD_POP   27
+        #define R_386_TLS_LDM_32   28
+        #define R_386_TLS_LDM_PUSH 29
+        #define R_386_TLS_LDM_CALL 30
+        #define R_386_TLS_LDM_POP  31
+        #define R_386_TLS_LDO_32   32
+        #define R_386_TLS_IE_32    33
+        #define R_386_TLS_LE_32    34
+        #define R_386_TLS_DTPMOD32 35
+        #define R_386_TLS_DTPOFF32 36
+        #define R_386_TLS_TPOFF32  37
 } Elf32_Rel;
 
 /* stabs debug records */
 
 typedef struct
 {
-    elf_u32_f32 DBstring;               /* string table index for the symbol */
+    Elf32_Word DBstring;               /* string table index for the symbol */
     elf_u8_f32  DBtype;                 /* type of the symbol */
         #define DBT_UNDEF       0x00        /* undefined symbol */
         #define DBT_EXT         0x01        /* exernal modifier */
@@ -254,8 +262,8 @@ typedef struct
         #define DBT_PARAM       0xa0        /* parameter */
         #define DBT_INCE        0xa2        /* include file end */
     elf_u8_f32  DBmisc;                 /* misc. info */
-    elf_u16_f32 DBdesc;                 /* description field */
-    elf_u32_f32 DBvalu;                 /* symbol value */
+    Elf32_Half DBdesc;                 /* description field */
+    Elf32_Word DBvalu;                 /* symbol value */
 } elf_stab;
 
 
@@ -263,16 +271,16 @@ typedef struct
 
 typedef struct
 {
-  elf_u32_f32   PHtype;                 /* Program type */
+  Elf32_Word   PHtype;                 /* Program type */
         #define PHT_NULL         0          /* SHT entry unused */
-  elf_off_f32   PHoff;                  /* Offset to segment in file */
-  elf_add_f32   PHvaddr;                /* Starting virtual memory address */
-  elf_add_f32   PHpaddr;                /* Starting absolute memory address */
-  elf_u32_f32   PHfilesz;               /* Size of file image */
-  elf_u32_f32   PHmemsz;                /* Size of memory image */
-  elf_u32_f32   PHflags;                /* Program attribute flags */
-  elf_u32_f32   PHalign;                /* Program loading alignment */
-} elf_pht;
+  Elf32_Off   PHoff;                  /* Offset to segment in file */
+  Elf32_Addr   PHvaddr;                /* Starting virtual memory address */
+  Elf32_Addr   PHpaddr;                /* Starting absolute memory address */
+  Elf32_Word   PHfilesz;               /* Size of file image */
+  Elf32_Word   PHmemsz;                /* Size of memory image */
+  Elf32_Word   PHflags;                /* Program attribute flags */
+  Elf32_Word   PHalign;                /* Program loading alignment */
+} Elf32_Phdr;
 
 
 
@@ -280,16 +288,17 @@ typedef struct
 
 /***************************** 64 bit Elf *****************************************/
 
-typedef unsigned long long Elf64_Addr;
-typedef unsigned long long Elf64_Off;
-typedef unsigned long long Elf64_Xword;
-typedef          long long Elf64_Sxword;
-typedef          int       Elf64_Sword;
-typedef unsigned int       Elf64_Word;
-typedef unsigned short     Elf64_Half;
+typedef uint64_t Elf64_Addr;
+typedef uint64_t Elf64_Off;
+typedef uint64_t Elf64_Xword;
+typedef int64_t  Elf64_Sxword;
+typedef int32_t  Elf64_Sword;
+typedef uint32_t Elf64_Word;
+typedef uint16_t Elf64_Half;
 
 typedef struct
 {
+    unsigned char EHident[EI_NIDENT]; /* Header identification info */
     Elf64_Half  e_type;
     Elf64_Half  e_machine;
     Elf64_Word  e_version;
@@ -338,6 +347,10 @@ typedef struct {
     Elf64_Xword st_size;
 } Elf64_Sym;
 
+#define ELF64_ST_BIND(s) ELF32_ST_BIND(s)
+#define ELF64_ST_TYPE(s) ELF32_ST_TYPE(s)
+#define ELF64_ST_INFO(b,t) ELF32_ST_INFO(b,t)
+
 typedef struct {
     Elf64_Addr  r_offset;
     Elf64_Xword r_info;
@@ -384,4 +397,4 @@ typedef struct {
     Elf64_Sxword r_addend;
 } Elf64_Rela;
 
-
+#endif

--- a/src/scanelf.c
+++ b/src/scanelf.c
@@ -44,7 +44,7 @@ void scanElfObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, int
     unsigned char *buf = (unsigned char *)base;
     int reason = 0;
 
-    if (buflen < EI_NIDENT + sizeof(Elf32_Hdr))
+    if (buflen < sizeof(Elf32_Ehdr))
     {
         reason = __LINE__;
       Lcorrupt:
@@ -68,7 +68,7 @@ void scanElfObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, int
     }
     if (buf[EI_CLASS] == ELFCLASS32)
     {
-        Elf32_Hdr *eh = (Elf32_Hdr *)(buf + EI_NIDENT);
+        Elf32_Ehdr *eh = (Elf32_Ehdr *)buf;
         if (eh->e_type != ET_REL)
         {
             error(loc, "ELF object module %s is not relocatable", module_name);
@@ -112,8 +112,8 @@ void scanElfObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, int
     }
     else if (buf[EI_CLASS] == ELFCLASS64)
     {
-        Elf64_Ehdr *eh = (Elf64_Ehdr *)(buf + EI_NIDENT);
-        if (buflen < EI_NIDENT + sizeof(Elf64_Ehdr))
+        Elf64_Ehdr *eh = (Elf64_Ehdr *)buf;
+        if (buflen < sizeof(Elf64_Ehdr))
             goto Lcorrupt;
         if (eh->e_type != ET_REL)
         {


### PR DESCRIPTION
Forward to system headers when available.

I assume it was done this way because Walter was originally cross-compiling, and I left the non-system version in there to make it easier to go back that way.
