### PR TITLE
Issue 10492 - Illegal Instruction for mixin template with scope declarations

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -823,6 +823,31 @@ Statement *ExpStatement::semantic(Scope *sc)
         }
 #endif
 
+        if (exp->op == TOKdeclaration)
+        {
+            if (TemplateMixin *tm = ((DeclarationExp *)exp)->declaration->isTemplateMixin())
+            {
+                // Have to do semantic now to resolve the mixin
+                tm->semantic(sc);
+
+                // Rewrite as a CompoundStatement containing multiple ExpStatements
+                Statements *ss = new Statements();
+                if (tm->members)
+                {
+                    for (size_t i = 0; i < tm->members->dim; i++)
+                    {
+                        Declaration *decl = (*tm->members)[i]->isDeclaration();
+                        ss->push(new ExpStatement(loc, new DeclarationExp(loc, decl)));
+                    }
+                }
+                /* If not wrapped in a ScopeStatement, mixing in the same template twice
+                 * will cause conflicts */
+                Statement *wrap = new ScopeStatement(loc, new CompoundStatement(loc, ss));
+                // It's ok to re-run semantic on declarations, and every other node is new
+                return wrap->semantic(sc);
+            }
+        }
+
         exp = exp->semantic(sc);
         exp = exp->addDtorHook(sc);
         exp = resolveProperties(sc, exp);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1079,6 +1079,19 @@ void test54()
 
 /***************************************************/
 
+mixin template mtemplate10492()
+{
+    scope var = new Object;
+}
+
+void test10492()
+{
+    mixin mtemplate10492!();
+    mixin mtemplate10492!();
+}
+
+/***************************************************/
+
 class Foo55
 {
     synchronized void noop1() { }
@@ -7233,6 +7246,7 @@ int main()
     test161();
     test8819();
     test8917();
+    test10492();
     test8945();
     test11805();
     test163();


### PR DESCRIPTION
Decompose the declarations in the mixin (after running semantic) so scopeCode etc gets correctly run on variables.

https://issues.dlang.org/show_bug.cgi?id=10492
