### PR TITLE
Copying scope object should fill filedinit to NULL, due to avoid issue 11777

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -349,9 +349,7 @@ void ClassDeclaration::semantic(Scope *sc)
         // Expand any tuples in baseclasses[]
         for (size_t i = 0; i < baseclasses->dim; )
         {
-            if (!scx)
-                scx = sc->copyExact();
-            scope = scx;
+            scope = scx ? scx : sc->copy();
             scope->setNoFree();
 
             BaseClass *b = (*baseclasses)[i];
@@ -1335,9 +1333,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
         // Expand any tuples in baseclasses[]
         for (size_t i = 0; i < baseclasses->dim; )
         {
-            if (!scx)
-                scx = sc->copyExact();
-            scope = scx;
+            scope = scx ? scx : sc->copy();
             scope->setNoFree();
 
             BaseClass *b = (*baseclasses)[i];

--- a/src/scope.c
+++ b/src/scope.c
@@ -90,16 +90,10 @@ Scope::Scope()
     this->userAttribDecl = NULL;
 }
 
-Scope *Scope::copyExact()
+Scope *Scope::copy()
 {
     Scope *sc = Scope::alloc();
     memcpy(sc, this, sizeof(Scope));
-    return sc;
-}
-
-Scope *Scope::copy()
-{
-    Scope *sc = copyExact();
 
     /* Bugzilla 11777: The copied scope should not inherit fieldinit.
      */
@@ -137,10 +131,9 @@ Scope *Scope::createGlobal(Module *module)
 
 Scope *Scope::push()
 {
-    //printf("Scope::push()\n");
-    Scope *s = copyExact();
+    Scope *s = copy();
 
-    //printf("Scope::Scope(enclosing = %p) %p\n", enclosing, this);
+    //printf("Scope::push(this = %p) new = %p\n", this, s);
     assert(!(flags & SCOPEfree));
     s->scopesym = NULL;
     s->sds = NULL;

--- a/src/scope.h
+++ b/src/scope.h
@@ -118,7 +118,6 @@ struct Scope
 
     Scope();
 
-    Scope *copyExact();
     Scope *copy();
 
     Scope *push();


### PR DESCRIPTION
The bug was introduced by the commit 41b2ba393d879613cdb12b05f143bdf4fef35f6a in the PR #3384, because I had forgotten to pull my issue 11777 fix (done in #3423) into that PR.
