### PR TITLE
Add internal checking of mangleChar

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -267,7 +267,8 @@ void Type::init()
     mangleChar[Tnull] = 'n';    // same as TypeNone
 
     for (size_t i = 0; i < TMAX; i++)
-    {   if (!mangleChar[i])
+    {
+        if (!mangleChar[i])
             fprintf(stderr, "ty = %llu\n", (ulonglong)i);
         assert(mangleChar[i]);
     }
@@ -1581,6 +1582,15 @@ void Type::toDecoBuffer(OutBuffer *buf, int flag)
     {
         MODtoDecoBuffer(buf, mod);
     }
+    mangleToBuffer(buf);
+}
+
+/********************************
+ * Store this type's mangle name into buf.
+ */
+void Type::mangleToBuffer(OutBuffer *buf)
+{
+    assert(mangleChar[ty] != '@');
     buf->writeByte(mangleChar[ty]);
 }
 
@@ -2427,9 +2437,13 @@ Identifier *Type::getTypeInfoIdent(int internal)
     buf.reserve(32);
 
     if (internal)
-    {   buf.writeByte(mangleChar[ty]);
+    {
+        mangleToBuffer(&buf);
         if (ty == Tarray)
-            buf.writeByte(mangleChar[((TypeArray *)this)->next->ty]);
+        {
+            Type *tn = ((TypeArray *)this)->next;
+            tn->mangleToBuffer(&buf);
+        }
     }
     else if (deco)
         buf.writestring(deco);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -257,6 +257,7 @@ public:
     virtual Type *semantic(Loc loc, Scope *sc);
     Type *trySemantic(Loc loc, Scope *sc);
     virtual void toDecoBuffer(OutBuffer *buf, int flag = 0);
+    void mangleToBuffer(OutBuffer *buf);
     Type *merge();
     Type *merge2();
     void toCBuffer(OutBuffer *buf, Identifier *ident, HdrGenState *hgs);


### PR DESCRIPTION
Not sure what to expect from the autotester, though I suspect is this will fail because symbol mangle names may be generated even in fail tests.

This sort of ty checking is useful for gdc, where the compiler emits assembly code rather than direct to object file.  Because the `@` character being invalid in most backends of gas, this change enforces that the frontend doesn't leak mangling of bad types to the backend.  The alternative being (this has happened in the past) bad code to be silently compiled and causing assembler errors for other compiler backends later down the line.
