### PR TITLE
[trivial] Remove debug printf

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8268,7 +8268,6 @@ Ldotti:
                     e1 = new DotTemplateExp(loc, se->e1, td);
                 else if (OverDeclaration *od = ti->tempdecl->isOverDeclaration())
                 {
-                    printf("call = %s od = %s\n", toChars(), od->toChars());
                     e1 = new DotVarExp(loc, se->e1, od);
                 }
                 else


### PR DESCRIPTION
It was accidentally introduced in #2417. We should cherry-picked to 2.066 release.
