### PR TITLE
Fix Issue 13212 - Trailing Windows line endings not stripped from .ddoc macros 

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -1779,6 +1779,7 @@ void DocComment::parseMacros(Escape **pescapetable, Macro **pmacrotable, const u
                     p++;
                     continue;
 
+                case '\r':
                 case '\n':
                     p++;
                     goto Lcont;
@@ -1843,13 +1844,9 @@ void DocComment::parseMacros(Escape **pescapetable, Macro **pmacrotable, const u
         textstart = p;
 
       Ltext:
-        while (p < pend && *p != '\n')
+        while (p < pend && *p != '\r' && *p != '\n')
             p++;
         textlen = p - textstart;
-
-        // Remove trailing \r if there is one
-        if (p > m && p[-1] == '\r')
-            textlen--;
 
         p++;
         //printf("p = %p, pend = %p\n", p, pend);
@@ -1859,8 +1856,8 @@ void DocComment::parseMacros(Escape **pescapetable, Macro **pmacrotable, const u
 
      Lskipline:
         // Ignore this line
-        while (p < pend && *p++ != '\n')
-            ;
+        while (p < pend && *p != '\r' && *p != '\n')
+            p++;
     }
 Ldone:
     if (namelen)

--- a/test/compilable/extra-files/ddoc3.ddoc
+++ b/test/compilable/extra-files/ddoc3.ddoc
@@ -1,1 +1,3 @@
 HELLO = world
+
+UNUSED=unused


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13212

Handle `\r` as `\n` in macro definitions to prevent a trailing carriage return on a macro with an empty line following it.
Previously `FOO=BAR\r\n\r\n` would define `FOO` as `BAR\r\n`, when it should be just `BAR`.

Note: This only happens when the macros are defined in a separate .ddoc file.
