### PR TITLE
[D1] Few changes to -v2 diagnostics

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2970,7 +2970,6 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
             if (tf->inuse == 1) tf->inuse--;
 
             Type *t = fparam->type->toBasetype();
-printf("t = %s\n", t->toChars());
 
             if (fparam->storageClass & (STCout | STCref | STClazy))
             {

--- a/src/parse.c
+++ b/src/parse.c
@@ -2185,7 +2185,7 @@ Dsymbols *Parser::parseDeclarations()
         case TOKtypedef:
             if (global.params.Dversion >= 3 && mod && mod->isRoot())
             {
-                warning(loc, "use alias for D2 rather than typedef");
+                warning(loc, "typedef is deprecated in D2, use either alias or custom struct wrapper");
             }
         case TOKalias:
             tok = token.value;

--- a/src/parse.c
+++ b/src/parse.c
@@ -3575,7 +3575,7 @@ Statement *Parser::parseStatement(int flags)
             s = parseStatement(PSsemi | PScurlyscope);
             if (global.params.Dversion >= 3 && mod && mod->isRoot())
             {
-                warning(loc, "for D2 use 'synchronized' instead of 'volatile'");
+                warning(loc, "'volatile' is deprecated in D2, consult with module maintainer for appropriate replacement");
             }
             s = new VolatileStatement(loc, s);
             break;


### PR DESCRIPTION
As previously discussed in e-mail, updated messages better reflect what we are
actually going to do. Also removes accidental debug printf.
