### PR TITLE
Issue 7942 - Appending different string types corrupts memory

### DIFF
--- a/src/backend/rtlsym.h
+++ b/src/backend/rtlsym.h
@@ -110,6 +110,12 @@ SYMBOL_MARS(ARRAYAPPENDCT,  FLfunc,FREGSAVED,"_d_arrayappendcT", 0, tv) \
 SYMBOL_MARS(ARRAYAPPENDCTX, FLfunc,FREGSAVED,"_d_arrayappendcTX", 0, t) \
 SYMBOL_MARS(ARRAYAPPENDCD,  FLfunc,FREGSAVED,"_d_arrayappendcd", 0, t) \
 SYMBOL_MARS(ARRAYAPPENDWD,  FLfunc,FREGSAVED,"_d_arrayappendwd", 0, t) \
+SYMBOL_MARS(ARRAYAPPENDCWA, FLfunc,FREGSAVED,"_d_arrayappendcwa", 0, t) \
+SYMBOL_MARS(ARRAYAPPENDCDA, FLfunc,FREGSAVED,"_d_arrayappendcda", 0, t) \
+SYMBOL_MARS(ARRAYAPPENDWCA, FLfunc,FREGSAVED,"_d_arrayappendwca", 0, t) \
+SYMBOL_MARS(ARRAYAPPENDWDA, FLfunc,FREGSAVED,"_d_arrayappendwda", 0, t) \
+SYMBOL_MARS(ARRAYAPPENDDCA, FLfunc,FREGSAVED,"_d_arrayappenddca", 0, t) \
+SYMBOL_MARS(ARRAYAPPENDDWA, FLfunc,FREGSAVED,"_d_arrayappenddwa", 0, t) \
 SYMBOL_MARS(ARRAYSETLENGTHT,FLfunc,FREGSAVED,"_d_arraysetlengthT", 0, t) \
 SYMBOL_MARS(ARRAYSETLENGTHIT,FLfunc,FREGSAVED,"_d_arraysetlengthiT", 0, t) \
 SYMBOL_MARS(ARRAYCOPY,     FLfunc,FREGSAVED,"_d_arraycopy", 0, t) \

--- a/src/expression.c
+++ b/src/expression.c
@@ -11890,13 +11890,13 @@ Expression *CatAssignExp::semantic(Scope *sc)
     Type *tb1 = e1->type->toBasetype();
     Type *tb1next = tb1->nextOf();
     Type *tb2 = e2->type->toBasetype();
+    Type *tb2next = tb2->nextOf();
 
     if ((tb1->ty == Tarray) &&
         (tb2->ty == Tarray || tb2->ty == Tsarray) &&
         (e2->implicitConvTo(e1->type)
          || (tb2->nextOf()->implicitConvTo(tb1next) &&
-             (tb2->nextOf()->size(Loc()) == tb1next->size(Loc()) ||
-             tb1next->ty == Tchar || tb1next->ty == Twchar || tb1next->ty == Tdchar))
+             (tb2->nextOf()->size(Loc()) == tb1next->size(Loc())))
         )
        )
     {
@@ -11924,6 +11924,12 @@ Expression *CatAssignExp::semantic(Scope *sc)
         /* Do not allow appending wchar to char[] because if wchar happens
          * to be a surrogate pair, nothing good can result.
          */
+    }
+    else if (tb1->ty == Tarray && (tb2->ty == Tarray || tb2->ty == Tsarray) &&
+        (tb1next->ty == Tchar || tb1next->ty == Twchar || tb1next->ty == Tdchar) &&
+        (tb2next->ty == Tchar || tb2next->ty == Twchar || tb2next->ty == Tdchar))
+    {
+        // Concatenating strings with different character widths together is allowed
     }
     else
     {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1655,6 +1655,29 @@ void test82()
 
 /***************************************************/
 
+void test7942()
+{
+    string a = "a";
+    wstring b = "b";
+    dstring c = "c";
+
+    a ~= "a"c;
+    a ~= "b"w;
+    a ~= "c"d;
+    b ~= "a"c;
+    b ~= "b"w;
+    b ~= "c"d;
+    c ~= "a"c;
+    c ~= "b"w;
+    c ~= "c"d;
+
+    assert(a == "aabc");
+    assert(b == "babc");
+    assert(c == "cabc");
+}
+
+/***************************************************/
+
 void bump(ref int x) { ++x; }
 
 void test83()
@@ -7166,6 +7189,7 @@ int main()
     test6228();
     test3733();
     test4392();
+    test7942();
     test6220();
     test5799();
     test157();


### PR DESCRIPTION
Appending string types with different char sizes requires decoding and re-encoding.

https://issues.dlang.org/show_bug.cgi?id=7942
