### PR TITLE
Issue 11763 - [ICE] Internal error: ../ztc/cgcs.c 351

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -5192,7 +5192,7 @@ elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi)
             {
                 /* Expensive to copy, to take a pointer to it instead
                  */
-                elem *ep = el_una(OPaddr, TYnptr, erx);
+                elem *ep = addressElem(erx, Type::tvoidptr);
                 elem *e = el_same(&ep);
                 ep = el_combine(ep, edtors);
                 ep = el_combine(ep, e);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1571,6 +1571,24 @@ void test79()
 
 /***************************************************/
 
+struct NoDtortest11763 {}
+
+struct HasDtortest11763
+{
+    NoDtortest11763 func()
+    {
+        return NoDtortest11763();
+    }
+    ~this() {}
+}
+
+void test11763()
+{
+    HasDtortest11763().func();
+}
+
+/***************************************************/
+
 void test6317()
 {
     int b = 12345;


### PR DESCRIPTION
Taking the address of `&function_returning_struct(...)` needs to be done with `addressElem`, because the struct needs to be saved somewhere before it can be addressed.

https://issues.dlang.org/show_bug.cgi?id=11763
