### PR TITLE
Issue 11453 - Compiling packages has a dependency on order of modules passed to the compiler

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -616,7 +616,7 @@ void Module::parse()
                 pkg->mod = this;
             }
             else
-                error(pkg->loc, "from file %s conflicts with package name %s",
+                error(md ? md->loc : loc, "from file %s conflicts with package name %s",
                     srcname, pkg->toChars());
         }
         else

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -322,7 +322,7 @@ string unifyNewLine(string str)
 
 string unifyDirSep(string str, string sep)
 {
-    return std.regex.replace(str, regex(`(?<=\w\w*)/(?=\w[\w/]*\.di?\b)`, "g"), sep);
+    return std.regex.replace(str, regex(`(?<=[-\w][-\w]*)/(?=[-\w][-\w/]*\.di?\b)`, "g"), sep);
 }
 unittest
 {

--- a/test/fail_compilation/extra-files/bar11453.d
+++ b/test/fail_compilation/extra-files/bar11453.d
@@ -1,0 +1,1 @@
+module foo11453.bar11453;

--- a/test/fail_compilation/extra-files/foo11453.d
+++ b/test/fail_compilation/extra-files/foo11453.d
@@ -1,0 +1,1 @@
+module foo11453;

--- a/test/fail_compilation/fail11453a.d
+++ b/test/fail_compilation/fail11453a.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -Ifail_compilation/extra-files
+// EXTRA_SOURCES: extra-files/foo11453.d extra-files/bar11453.d
+/*
+TEST_OUTPUT
+---
+fail_compilation/extra-files/bar11453.d(1): Error: package name 'foo11453' conflicts with usage as a module name in file fail_compilation/extra-files/foo11453.d
+---
+*/
+
+void main() {}

--- a/test/fail_compilation/fail11453b.d
+++ b/test/fail_compilation/fail11453b.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -Ifail_compilation/extra-files
+// EXTRA_SOURCES: extra-files/bar11453.d extra-files/foo11453.d
+/*
+TEST_OUTPUT
+---
+fail_compilation/extra-files/foo11453.d(1): Error: module foo11453 from file fail_compilation/extra-files/foo11453.d conflicts with package name foo11453
+---
+*/
+
+void main() {}

--- a/test/fail_compilation/test64.d
+++ b/test/fail_compilation/test64.d
@@ -1,19 +1,19 @@
 /*
 TEST_OUTPUT:
 ---
-Error: module imports from file fail_compilation/imports/test64a.d conflicts with package name imports
+fail_compilation/imports/test64a.d(1): Error: module imports from file fail_compilation/imports/test64a.d conflicts with package name imports
 ---
 */
 
 // PERMUTE_ARGS:
 
-import std.stdio;
+//import std.stdio;
 
 import imports.test64a;
 
-int main(char[][] args)
+int main(string[] args)
 {
-    writefln(file1);
+    //writefln(file1);
     return 0;
 }
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=11453
