### PR TITLE
Revert "change install target to match current release structure"

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -370,10 +370,10 @@ $(ROOT_OBJS): %.o: $(ROOT)/%.c posix.mak
 ######################################################
 
 install: all
+	mkdir -p $(INSTALL_DIR)/bin
+	cp dmd $(INSTALL_DIR)/bin/dmd
 	$(eval bin_dir=$(if $(filter $(OS),osx), bin, bin$(MODEL)))
-	mkdir -p $(INSTALL_DIR)/$(OS)/$(bin_dir)
-	cp dmd $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd
-	cp ../ini/$(OS)/$(bin_dir)/dmd.conf $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd.conf
+	cp ../ini/$(OS)/$(bin_dir)/dmd.conf $(INSTALL_DIR)/bin/dmd.conf
 	cp backendlicense.txt $(INSTALL_DIR)/dmd-backendlicense.txt
 	cp artistic.txt $(INSTALL_DIR)/dmd-artistic.txt
 


### PR DESCRIPTION
This reverts D-Programming-Language/dmd#3798, as no argument in favor of the change has appeared so far. @braddr, what was your original motivation for the change?

It's not a huge issue, so if there is a good reason for the change, I don't mind it. It's just that the change broke a CI tool I'm working on, and in general I'd rather not complicate life for everyone and part with wide-spread Linux/*nix conventions without a good reason.
