### PR TITLE
COFF support for Win32

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -64,7 +64,7 @@ void out_config_init(
     config.memmodel = 0;
     config.flags |= CFGuchar;   // make sure TYchar is unsigned
     tytab[TYchar] |= TYFLuns;
-    bool coff = model & 1;
+    bool mscoff = model & 1;
     model &= ~0x1f;
 #if TARGET_WINDOS
     if (model == 64)
@@ -75,12 +75,12 @@ void out_config_init(
         config.flags |= CFGnoebp;
         config.flags |= CFGalwaysframe;
         config.flags |= CFGromable; // put switch tables in code segment
-        config.objfmt = OBJ_COFF;
+        config.objfmt = OBJ_MSCOFF;
     }
     else
     {   config.exe = EX_NT;
         config.flags2 |= CFG2seh;       // Win32 eh
-        config.objfmt = coff ? OBJ_COFF : OBJ_OMF;
+        config.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;
     }
 
     if (exe)
@@ -198,7 +198,7 @@ void out_config_init(
         config.fulltypes = (symdebug == 1) ? CVDWARF_D : CVDWARF_C;
 #endif
 #if SYMDEB_CODEVIEW
-        if (config.objfmt == OBJ_COFF)
+        if (config.objfmt == OBJ_MSCOFF)
         {
             configv.addlinenumbers = 1;
             config.fulltypes = CV8;

--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -64,6 +64,8 @@ void out_config_init(
     config.memmodel = 0;
     config.flags |= CFGuchar;   // make sure TYchar is unsigned
     tytab[TYchar] |= TYFLuns;
+    config.objfmt = model & 0x1f;
+    model &= ~0x1f;
 #if TARGET_WINDOS
     if (model == 64)
     {   config.exe = EX_WIN64;
@@ -189,7 +191,7 @@ void out_config_init(
         config.fulltypes = (symdebug == 1) ? CVDWARF_D : CVDWARF_C;
 #endif
 #if SYMDEB_CODEVIEW
-        if (model == 64)
+        if (config.objfmt == OBJ_COFF)
         {
             configv.addlinenumbers = 1;
             config.fulltypes = CV8;

--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -38,6 +38,7 @@ extern void ph_init();
 void out_config_init(
         int model,      // 32: 32 bit code
                         // 64: 64 bit code
+                        // Windows: set bit 0 to generate MS-COFF instead of OMF
         bool exe,       // true: exe file
                         // false: dll or shared library (generate PIC code)
         bool trace,     // add profiling code
@@ -65,7 +66,7 @@ void out_config_init(
     config.flags |= CFGuchar;   // make sure TYchar is unsigned
     tytab[TYchar] |= TYFLuns;
     bool mscoff = model & 1;
-    model &= ~0x1f;
+    model &= 32 | 64;
 #if TARGET_WINDOS
     if (model == 64)
     {   config.exe = EX_WIN64;

--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -64,7 +64,7 @@ void out_config_init(
     config.memmodel = 0;
     config.flags |= CFGuchar;   // make sure TYchar is unsigned
     tytab[TYchar] |= TYFLuns;
-    config.objfmt = model & 0x1f;
+    bool coff = model & 1;
     model &= ~0x1f;
 #if TARGET_WINDOS
     if (model == 64)
@@ -75,10 +75,12 @@ void out_config_init(
         config.flags |= CFGnoebp;
         config.flags |= CFGalwaysframe;
         config.flags |= CFGromable; // put switch tables in code segment
+        config.objfmt = OBJ_COFF;
     }
     else
     {   config.exe = EX_NT;
         config.flags2 |= CFG2seh;       // Win32 eh
+        config.objfmt = coff ? OBJ_COFF : OBJ_OMF;
     }
 
     if (exe)
@@ -100,6 +102,7 @@ void out_config_init(
     config.flags |= CFGalwaysframe;
     if (!exe)
         config.flags3 |= CFG3pic;
+    config.objfmt = OBJ_ELF;
 #endif
 #if TARGET_OSX
     config.fpxmmregs = TRUE;
@@ -114,6 +117,7 @@ void out_config_init(
     if (!exe)
         config.flags3 |= CFG3pic;
     config.flags |= CFGromable; // put switch tables in code segment
+    config.objfmt = OBJ_MACH;
 #endif
 #if TARGET_FREEBSD
     if (model == 64)
@@ -130,6 +134,7 @@ void out_config_init(
     config.flags |= CFGalwaysframe;
     if (!exe)
         config.flags3 |= CFG3pic;
+    config.objfmt = OBJ_ELF;
 #endif
 #if TARGET_OPENBSD
     if (model == 64)
@@ -146,6 +151,7 @@ void out_config_init(
     config.flags |= CFGalwaysframe;
     if (!exe)
         config.flags3 |= CFG3pic;
+    config.objfmt = OBJ_ELF;
 #endif
 #if TARGET_SOLARIS
     if (model == 64)
@@ -162,6 +168,7 @@ void out_config_init(
     config.flags |= CFGalwaysframe;
     if (!exe)
         config.flags3 |= CFG3pic;
+    config.objfmt = OBJ_ELF;
 #endif
     config.flags2 |= CFG2nodeflib;      // no default library
     config.flags3 |= CFG3eseqds;

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -703,6 +703,11 @@ struct Config
                                    2:   fast inline 8087 code
                                  */
     short memmodel;             // 0:S,X,N,F, 1:M, 2:C, 3:L, 4:V
+    unsigned objfmt;            // target object format
+#define OBJ_OMF         1
+#define OBJ_COFF        2
+#define OBJ_ELF         3
+#define OBJ_MACH        4
     unsigned exe;               // target operating system
 #define EX_DOSX         1       // DOSX 386 program
 #define EX_ZPM          2       // ZPM 286 program

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -705,7 +705,7 @@ struct Config
     short memmodel;             // 0:S,X,N,F, 1:M, 2:C, 3:L, 4:V
     unsigned objfmt;            // target object format
 #define OBJ_OMF         1
-#define OBJ_COFF        2
+#define OBJ_MSCOFF      2
 #define OBJ_ELF         3
 #define OBJ_MACH        4
     unsigned exe;               // target operating system

--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -525,7 +525,7 @@ size_t addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int fl
         static char zeros[8];
 
         //printf("addtofixlist(%p '%s')\n",s,s->Sident);
-        assert(flags);
+        assert(I32 || flags);
         fixlist *ln = (fixlist *) mem_calloc(sizeof(fixlist));
         //ln->Lsymbol = s;
         ln->Loffset = soffset;

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -2213,7 +2213,7 @@ code *callclib(elem *e,unsigned clib,regm_t *pretregs,regm_t keepmask)
                 info[CLIBullngdbl].retregs32 = mAX;
                 info[CLIBdblullng].retregs32 = mAX;
             }
-            else if (config.objfmt == OBJ_COFF)
+            else if (config.objfmt == OBJ_MSCOFF)
             {
                 strcpy(lib[CLIBldiv].Sident, "_ms_alldiv");
                 strcpy(lib[CLIBlmod].Sident, "_ms_allrem");   info[CLIBlmod].retregs32 = mAX|mDX;

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -2213,6 +2213,13 @@ code *callclib(elem *e,unsigned clib,regm_t *pretregs,regm_t keepmask)
                 info[CLIBullngdbl].retregs32 = mAX;
                 info[CLIBdblullng].retregs32 = mAX;
             }
+            else if (config.objfmt == OBJ_COFF)
+            {
+                strcpy(lib[CLIBldiv].Sident, "_ms_alldiv");
+                strcpy(lib[CLIBlmod].Sident, "_ms_allrem");   info[CLIBlmod].retregs32 = mAX|mDX;
+                strcpy(lib[CLIBuldiv].Sident, "_ms_aulldiv");
+                strcpy(lib[CLIBulmod].Sident, "_ms_aullrem"); info[CLIBulmod].retregs32 = mAX|mDX;
+            }
         }
         clib_inited++;
   }

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -4152,7 +4152,7 @@ void cod3_thunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
     objmod->pubdef(cseg,sthunk,sthunk->Soffset);
 #endif
 #if TARGET_WINDOS
-    if (config.exe == EX_WIN64)
+    if (config.objfmt == OBJ_COFF)
         objmod->pubdef(cseg,sthunk,sthunk->Soffset);
 #endif
     searchfixlist(sthunk);              /* resolve forward refs */

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -4152,7 +4152,7 @@ void cod3_thunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
     objmod->pubdef(cseg,sthunk,sthunk->Soffset);
 #endif
 #if TARGET_WINDOS
-    if (config.objfmt == OBJ_COFF)
+    if (config.objfmt == OBJ_MSCOFF)
         objmod->pubdef(cseg,sthunk,sthunk->Soffset);
 #endif
     searchfixlist(sthunk);              /* resolve forward refs */

--- a/src/backend/cv8.c
+++ b/src/backend/cv8.c
@@ -277,7 +277,7 @@ void cv8_initmodule(const char *filename, const char *modulename)
 void cv8_termmodule()
 {
     //printf("cv8_termmodule()\n");
-    assert(config.exe == EX_WIN64);
+    assert(config.objfmt == OBJ_COFF);
 }
 
 /******************************************
@@ -614,14 +614,14 @@ void cv8_outsym(Symbol *s)
             buf->writeWordn(0x1111);
             buf->write32(s->Soffset + base + BPoff);
             buf->write32(typidx);
-            buf->writeWordn(334);       // relative to RBP
+            buf->writeWordn(I64 ? 334 : 22);       // relative to RBP/EBP
             cv8_writename(buf, id, len);
             buf->writeByte(0);
 #else
             // This is supposed to work, implicit BP relative addressing, but it does not
             buf->reserve(2 + 2 + 4 + 4 + len + 1);
             buf->writeWordn( 2 + 4 + 4 + len + 1);
-            buf->writeWordn(0x1006);
+            buf->writeWordn(S_BPREL_V3);
             buf->write32(s->Soffset + base + BPoff);
             buf->write32(typidx);
             cv8_writename(buf, id, len);
@@ -864,7 +864,9 @@ idx_t cv8_darray(type *t, idx_t etypidx)
 
     debtyp_t *f = debtyp_alloc(sizeof(fl));
     memcpy(f->data,fl,sizeof(fl));
+    TOLONG(f->data + 6, I64 ? 0x23 : 0x22); // size_t
     TOLONG(f->data + 26, ptridx);
+    TOWORD(f->data + 30, NPTRSIZE);
     idx_t fieldlist = cv_debtyp(f);
 
     const char *id;
@@ -899,7 +901,7 @@ idx_t cv8_darray(type *t, idx_t etypidx)
     TOLONG(d->data + 6, fieldlist);
     TOLONG(d->data + 10, 0);    // dList
     TOLONG(d->data + 14, 0);    // vtshape
-    TOWORD(d->data + 18, 16);   // size
+    TOWORD(d->data + 18, 2 * NPTRSIZE);   // size
     cv_namestring(d->data + 20, id, idlen);
     d->data[20 + idlen] = 0;
 
@@ -966,6 +968,7 @@ idx_t cv8_ddelegate(type *t, idx_t functypidx)
     memcpy(f->data,fl,sizeof(fl));
     TOLONG(f->data + 6, pvidx);
     TOLONG(f->data + 22, ptridx);
+    TOWORD(f->data + 26, NPTRSIZE);
     idx_t fieldlist = cv_debtyp(f);
 
     const char *id = "dDelegate";
@@ -980,7 +983,7 @@ idx_t cv8_ddelegate(type *t, idx_t functypidx)
     TOLONG(d->data + 6, fieldlist);
     TOLONG(d->data + 10, 0);    // dList
     TOLONG(d->data + 14, 0);    // vtshape
-    TOWORD(d->data + 18, 16);   // size
+    TOWORD(d->data + 18, 2 * NPTRSIZE);   // size
     memcpy(d->data + 20, id, idlen);
     d->data[20 + idlen] = 0;
 #endif

--- a/src/backend/cv8.c
+++ b/src/backend/cv8.c
@@ -277,7 +277,7 @@ void cv8_initmodule(const char *filename, const char *modulename)
 void cv8_termmodule()
 {
     //printf("cv8_termmodule()\n");
-    assert(config.objfmt == OBJ_COFF);
+    assert(config.objfmt == OBJ_MSCOFF);
 }
 
 /******************************************
@@ -806,7 +806,7 @@ idx_t cv8_fwdref(Symbol *s)
         TOLONG(d->data + 14, 0);        // vshape
     }
     cv4_storenumeric(d->data + numidx, 0);
-    cv_namestring(d->data + len, s->Sident, idlen); 
+    cv_namestring(d->data + len, s->Sident, idlen);
     d->data[len + idlen] = 0;
     idx_t typidx = cv_debtyp(d);
     s->Stypidx = typidx;

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -326,7 +326,7 @@ symbol * MsCoffObj::sym_cdata(tym_t ty,char *p,int len)
 int MsCoffObj::data_readonly(char *p, int len, segidx_t *pseg)
 {
     int oldoff;
-    if (I64)
+    if (I64 || I32)
     {
         oldoff = Doffset;
         SegData[DATA]->SDbuf->reserve(len);
@@ -930,19 +930,61 @@ void MsCoffObj::term(const char *objfilename)
                             }
 #endif
                         }
+                        else if (I32)
+                        {
+                            rel.r_type = (r->rtype == RELrel)
+                                    ? IMAGE_REL_I386_REL32
+                                    : IMAGE_REL_I386_DIR32;
+
+                            if (s->Stype->Tty & mTYthread)
+                                rel.r_type = IMAGE_REL_I386_SECREL;
+
+                            if (s->Sclass == SCextern ||
+                                s->Sclass == SCcomdef ||
+                                s->Sclass == SCcomdat ||
+                                s->Sclass == SCglobal)
+                            {
+                                rel.r_vaddr = r->offset;
+                                rel.r_symndx = s->Sxtrnnum;
+                            }
+                            else
+                            {
+                                rel.r_vaddr = r->offset;
+                                rel.r_symndx = s->Sxtrnnum;
+                            }
+                        }
+                        else
+                            assert(false); // not implemented for I16
                     }
                     else
                     {
 //printf("test2\n");
-                        if (pdata)
-                            rel.r_type = IMAGE_REL_AMD64_ADDR32NB;
-                        else
-                            rel.r_type = IMAGE_REL_AMD64_ADDR64;
+                        if (I64)
+                        {
+                            if (pdata)
+                                rel.r_type = IMAGE_REL_AMD64_ADDR32NB;
+                            else
+                                rel.r_type = IMAGE_REL_AMD64_ADDR64;
 
-                        if (r->rtype == RELseg)
-                            rel.r_type = IMAGE_REL_AMD64_SECTION;
-                        else if (r->rtype == RELaddr32)
-                            rel.r_type = IMAGE_REL_AMD64_SECREL;
+                            if (r->rtype == RELseg)
+                                rel.r_type = IMAGE_REL_AMD64_SECTION;
+                            else if (r->rtype == RELaddr32)
+                                rel.r_type = IMAGE_REL_AMD64_SECREL;
+                        }
+                        else if (I32)
+                        {
+                            if (pdata)
+                                rel.r_type = IMAGE_REL_I386_DIR32NB;
+                            else
+                                rel.r_type = IMAGE_REL_I386_DIR32;
+
+                            if (r->rtype == RELseg)
+                                rel.r_type = IMAGE_REL_I386_SECTION;
+                            else if (r->rtype == RELaddr32)
+                                rel.r_type = IMAGE_REL_I386_SECREL;
+                        }
+                        else
+                            assert(false); // not implemented for I16
 
                         rel.r_vaddr = r->offset;
                         rel.r_symndx = s->Sxtrnnum;
@@ -1075,7 +1117,7 @@ printf("test4\n");
                  */
                 //assert(rel.r_symndx <= 20000);
 
-                assert(rel.r_type <= 0x10);
+                assert(rel.r_type <= 0x14);
                 fobjbuf->write(&rel, sizeof(rel));
                 foffset += sizeof(rel);
             }
@@ -1780,34 +1822,36 @@ char *obj_mangle2(Symbol *s,char *dest)
             {
                 char *pstr = unsstr(type_paramsize(s->Stype));
                 size_t pstrlen = strlen(pstr);
-                size_t destlen = len + 1 + pstrlen + 1;
+                size_t prelen = I32 ? 1 : 0;
+                size_t destlen = prelen + len + 1 + pstrlen + 1;
 
                 if (destlen > DEST_LEN)
                     dest = (char *)mem_malloc(destlen);
-                memcpy(dest,name,len);
-                dest[len] = '@';
-                memcpy(dest + 1 + len, pstr, pstrlen + 1);
+                dest[0] = '_';
+                memcpy(dest + prelen,name,len);
+                dest[prelen + len] = '@';
+                memcpy(dest + prelen + 1 + len, pstr, pstrlen + 1);
                 break;
             }
         case mTYman_cpp:
         case mTYman_d:
         case mTYman_sys:
-        case mTYman_c:
+        case_mTYman_c64:
         case 0:
             if (len >= DEST_LEN)
                 dest = (char *)mem_malloc(len + 1);
             memcpy(dest,name,len+1);// copy in name and trailing 0
             break;
 
-#if 0
         case mTYman_c:
+            if(I64)
+                goto case_mTYman_c64;
             // Prepend _ to identifier
             if (len >= DEST_LEN - 1)
                 dest = (char *)mem_malloc(1 + len + 1);
             dest[0] = '_';
             memcpy(dest + 1,name,len+1);// copy in name and trailing 0
             break;
-#endif
 
         default:
 #ifdef DEBUG
@@ -1827,9 +1871,12 @@ char *obj_mangle2(Symbol *s,char *dest)
 
 void MsCoffObj::export_symbol(Symbol *s,unsigned argsize)
 {
+    char dest[DEST_LEN+1];
+    char *destr = obj_mangle2(s, dest);
+
     //printf("MsCoffObj::export_symbol(%s,%d)\n",s->Sident,argsize);
     SegData[segidx_drectve]->SDbuf->write(" /EXPORT:", 9);
-    SegData[segidx_drectve]->SDbuf->write(s->Sident, strlen(s->Sident));
+    SegData[segidx_drectve]->SDbuf->write(dest, strlen(dest));
 }
 
 /*******************************
@@ -2285,6 +2332,8 @@ void MsCoffObj::reftocodeseg(segidx_t seg,targ_size_t offset,targ_size_t val)
     int save = buf->size();
     buf->setsize(offset);
     val -= funcsym_p->Soffset;
+    if (I32)
+        MsCoffObj::addrel(seg, offset, funcsym_p, 0, RELaddr, 0);
 //    MsCoffObj::addrel(seg, offset, funcsym_p, 0, RELaddr);
 //    if (I64)
 //        buf->write64(val);
@@ -2331,7 +2380,7 @@ int MsCoffObj::reftoident(segidx_t seg, targ_size_t offset, Symbol *s, targ_size
     }
     else
     {
-        if (I64)
+        if (I64 || I32)
         {
             //if (s->Sclass != SCcomdat)
                 //val += s->Soffset;

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -192,7 +192,7 @@ void outdata(symbol *s)
                             objmod->lidata(pseg->SDseg, pseg->SDoffset, datasize);
 #endif
 #if OMFOBJ
-                            if (config.objfmt == OBJ_COFF)
+                            if (config.objfmt == OBJ_MSCOFF)
                                 objmod->lidata(pseg->SDseg, pseg->SDoffset, datasize);
                             else
                                 pseg->SDoffset += datasize;
@@ -212,7 +212,7 @@ void outdata(symbol *s)
                     if (s->Sclass == SCglobal || s->Sclass == SCstatic) // if a pubdef to be done
 #endif
 #if OMFOBJ
-                    if (s->Sclass == SCglobal || (s->Sclass == SCstatic && config.objfmt == OBJ_COFF)) // if a pubdef to be done
+                    if (s->Sclass == SCglobal || (s->Sclass == SCstatic && config.objfmt == OBJ_MSCOFF)) // if a pubdef to be done
 #endif
                         objmod->pubdefsize(s->Sseg,s,s->Soffset,datasize);   // do the definition
                     searchfixlist(s);
@@ -334,7 +334,7 @@ void outdata(symbol *s)
         || s->Sclass == SCstatic
 #endif
 #if OMFOBJ
-        || (s->Sclass == SCstatic && config.objfmt == OBJ_COFF)
+        || (s->Sclass == SCstatic && config.objfmt == OBJ_MSCOFF)
 #endif
         )
     {
@@ -480,7 +480,7 @@ void outcommon(symbol *s,targ_size_t n)
             objmod->common_block(s, 0, n, 1);
 #endif
 #if OMFOBJ
-            if (config.objfmt == OBJ_COFF)
+            if (config.objfmt == OBJ_MSCOFF)
                 objmod->common_block(s, 0, n, 1);
             else
             {

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -192,7 +192,7 @@ void outdata(symbol *s)
                             objmod->lidata(pseg->SDseg, pseg->SDoffset, datasize);
 #endif
 #if OMFOBJ
-                            if (config.exe == EX_WIN64)
+                            if (config.objfmt == OBJ_COFF)
                                 objmod->lidata(pseg->SDseg, pseg->SDoffset, datasize);
                             else
                                 pseg->SDoffset += datasize;
@@ -212,7 +212,7 @@ void outdata(symbol *s)
                     if (s->Sclass == SCglobal || s->Sclass == SCstatic) // if a pubdef to be done
 #endif
 #if OMFOBJ
-                    if (s->Sclass == SCglobal || (s->Sclass == SCstatic && I64)) // if a pubdef to be done
+                    if (s->Sclass == SCglobal || (s->Sclass == SCstatic && config.objfmt == OBJ_COFF)) // if a pubdef to be done
 #endif
                         objmod->pubdefsize(s->Sseg,s,s->Soffset,datasize);   // do the definition
                     searchfixlist(s);
@@ -334,7 +334,7 @@ void outdata(symbol *s)
         || s->Sclass == SCstatic
 #endif
 #if OMFOBJ
-        || (s->Sclass == SCstatic && I64)
+        || (s->Sclass == SCstatic && config.objfmt == OBJ_COFF)
 #endif
         )
     {
@@ -480,7 +480,7 @@ void outcommon(symbol *s,targ_size_t n)
             objmod->common_block(s, 0, n, 1);
 #endif
 #if OMFOBJ
-            if (I64)
+            if (config.objfmt == OBJ_COFF)
                 objmod->common_block(s, 0, n, 1);
             else
             {

--- a/src/glue.c
+++ b/src/glue.c
@@ -238,8 +238,8 @@ void obj_start(char *srcfile)
 #if TARGET_WINDOS
     // Produce Ms COFF files for 64 bit code, OMF for 32 bit code
     assert(objbuf.size() == 0);
-    objmod = global.params.is64bit ? MsCoffObj::init(&objbuf, srcfile, NULL)
-                                   :       Obj::init(&objbuf, srcfile, NULL);
+    objmod = global.params.objfmt == OBJ_COFF ? MsCoffObj::init(&objbuf, srcfile, NULL)
+                                              :       Obj::init(&objbuf, srcfile, NULL);
 #else
     objmod = Obj::init(&objbuf, srcfile, NULL);
 #endif
@@ -904,7 +904,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
             objmod->ehsections();   // initialize exception handling sections
 #endif
 #if TARGET_WINDOS
-            if (I64)
+            if (global.params.objfmt == OBJ_COFF)
             {
                 objmod->external_def("main");
                 objmod->ehsections();   // initialize exception handling sections
@@ -921,7 +921,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
         else if (strcmp(s->Sident, "main") == 0 && linkage == LINKc)
         {
 #if TARGET_WINDOS
-            if (I64)
+            if (global.params.objfmt == OBJ_COFF)
             {
                 objmod->includelib("LIBCMT");
                 objmod->includelib("OLDNAMES");
@@ -937,7 +937,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
 #if TARGET_WINDOS
         else if (func->isWinMain() && onlyOneMain(loc))
         {
-            if (I64)
+            if (global.params.objfmt == OBJ_COFF)
             {
                 objmod->includelib("uuid");
                 objmod->includelib("LIBCMT");
@@ -955,7 +955,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
         // Pull in RTL startup code
         else if (func->isDllMain() && onlyOneMain(loc))
         {
-            if (I64)
+            if (global.params.objfmt == OBJ_COFF)
             {
                 objmod->includelib("uuid");
                 objmod->includelib("LIBCMT");

--- a/src/glue.c
+++ b/src/glue.c
@@ -238,8 +238,8 @@ void obj_start(char *srcfile)
 #if TARGET_WINDOS
     // Produce Ms COFF files for 64 bit code, OMF for 32 bit code
     assert(objbuf.size() == 0);
-    objmod = global.params.coff ? MsCoffObj::init(&objbuf, srcfile, NULL)
-                                :       Obj::init(&objbuf, srcfile, NULL);
+    objmod = global.params.mscoff ? MsCoffObj::init(&objbuf, srcfile, NULL)
+                                  :       Obj::init(&objbuf, srcfile, NULL);
 #else
     objmod = Obj::init(&objbuf, srcfile, NULL);
 #endif
@@ -904,7 +904,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
             objmod->ehsections();   // initialize exception handling sections
 #endif
 #if TARGET_WINDOS
-            if (global.params.coff)
+            if (global.params.mscoff)
             {
                 objmod->external_def("main");
                 objmod->ehsections();   // initialize exception handling sections
@@ -921,7 +921,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
         else if (strcmp(s->Sident, "main") == 0 && linkage == LINKc)
         {
 #if TARGET_WINDOS
-            if (global.params.coff)
+            if (global.params.mscoff)
             {
                 objmod->includelib("LIBCMT");
                 objmod->includelib("OLDNAMES");
@@ -937,7 +937,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
 #if TARGET_WINDOS
         else if (func->isWinMain() && onlyOneMain(loc))
         {
-            if (global.params.coff)
+            if (global.params.mscoff)
             {
                 objmod->includelib("uuid");
                 objmod->includelib("LIBCMT");
@@ -955,7 +955,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
         // Pull in RTL startup code
         else if (func->isDllMain() && onlyOneMain(loc))
         {
-            if (global.params.coff)
+            if (global.params.mscoff)
             {
                 objmod->includelib("uuid");
                 objmod->includelib("LIBCMT");

--- a/src/glue.c
+++ b/src/glue.c
@@ -238,8 +238,8 @@ void obj_start(char *srcfile)
 #if TARGET_WINDOS
     // Produce Ms COFF files for 64 bit code, OMF for 32 bit code
     assert(objbuf.size() == 0);
-    objmod = global.params.objfmt == OBJ_COFF ? MsCoffObj::init(&objbuf, srcfile, NULL)
-                                              :       Obj::init(&objbuf, srcfile, NULL);
+    objmod = global.params.coff ? MsCoffObj::init(&objbuf, srcfile, NULL)
+                                :       Obj::init(&objbuf, srcfile, NULL);
 #else
     objmod = Obj::init(&objbuf, srcfile, NULL);
 #endif
@@ -904,7 +904,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
             objmod->ehsections();   // initialize exception handling sections
 #endif
 #if TARGET_WINDOS
-            if (global.params.objfmt == OBJ_COFF)
+            if (global.params.coff)
             {
                 objmod->external_def("main");
                 objmod->ehsections();   // initialize exception handling sections
@@ -921,7 +921,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
         else if (strcmp(s->Sident, "main") == 0 && linkage == LINKc)
         {
 #if TARGET_WINDOS
-            if (global.params.objfmt == OBJ_COFF)
+            if (global.params.coff)
             {
                 objmod->includelib("LIBCMT");
                 objmod->includelib("OLDNAMES");
@@ -937,7 +937,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
 #if TARGET_WINDOS
         else if (func->isWinMain() && onlyOneMain(loc))
         {
-            if (global.params.objfmt == OBJ_COFF)
+            if (global.params.coff)
             {
                 objmod->includelib("uuid");
                 objmod->includelib("LIBCMT");
@@ -955,7 +955,7 @@ void FuncDeclaration::toObjFile(bool multiobj)
         // Pull in RTL startup code
         else if (func->isDllMain() && onlyOneMain(loc))
         {
-            if (global.params.objfmt == OBJ_COFF)
+            if (global.params.coff)
             {
                 objmod->includelib("uuid");
                 objmod->includelib("LIBCMT");

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -24,6 +24,7 @@
 
 #include "mars.h"
 #include "lib.h"
+#include "backend/cdef.h"
 
 #define LOG 0
 
@@ -82,7 +83,7 @@ class LibOMF : public Library
 
 Library *LibOMF_factory()
 {
-    return new LibOMF();
+    return global.params.objfmt == OBJ_COFF ? LibMSCoff_factory() : new LibOMF();
 }
 
 LibOMF::LibOMF()

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -82,7 +82,7 @@ class LibOMF : public Library
 
 Library *LibOMF_factory()
 {
-    return global.params.coff ? LibMSCoff_factory() : new LibOMF();
+    return global.params.mscoff ? LibMSCoff_factory() : new LibOMF();
 }
 
 LibOMF::LibOMF()

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -24,7 +24,6 @@
 
 #include "mars.h"
 #include "lib.h"
-#include "backend/cdef.h"
 
 #define LOG 0
 
@@ -83,7 +82,7 @@ class LibOMF : public Library
 
 Library *LibOMF_factory()
 {
-    return global.params.objfmt == OBJ_COFF ? LibMSCoff_factory() : new LibOMF();
+    return global.params.coff ? LibMSCoff_factory() : new LibOMF();
 }
 
 LibOMF::LibOMF()

--- a/src/link.c
+++ b/src/link.c
@@ -47,10 +47,6 @@
 
 #include        "arraytypes.h"
 
-#if _WIN32
-#include        "backend/cdef.h"
-#endif
-
 const char * toWinPath(const char *src);
 int executecmd(const char *cmd, const char *args);
 int executearg0(const char *cmd, const char *args);
@@ -148,7 +144,7 @@ int findNoMainError(int fd)
 int runLINK()
 {
 #if _WIN32
-    if (global.params.objfmt == OBJ_COFF)
+    if (global.params.coff)
     {
         OutBuffer cmdbuf;
 
@@ -753,7 +749,7 @@ int executecmd(const char *cmd, const char *args)
     if (global.params.verbose)
         fprintf(global.stdmsg, "%s %s\n", cmd, args);
 
-    if (global.params.objfmt != OBJ_COFF)
+    if (!global.params.coff)
     {
         if ((len = strlen(args)) > 255)
         {

--- a/src/link.c
+++ b/src/link.c
@@ -144,7 +144,7 @@ int findNoMainError(int fd)
 int runLINK()
 {
 #if _WIN32
-    if (global.params.coff)
+    if (global.params.mscoff)
     {
         OutBuffer cmdbuf;
 
@@ -749,7 +749,7 @@ int executecmd(const char *cmd, const char *args)
     if (global.params.verbose)
         fprintf(global.stdmsg, "%s %s\n", cmd, args);
 
-    if (!global.params.coff)
+    if (!global.params.mscoff)
     {
         if ((len = strlen(args)) > 255)
         {

--- a/src/mars.c
+++ b/src/mars.c
@@ -597,7 +597,7 @@ int tryMain(size_t argc, const char *argv[])
     global.params.is64bit = (sizeof(size_t) == 8);
 
 #if TARGET_WINDOS
-	global.params.coff = false;
+	global.params.mscoff = false;
     global.params.is64bit = false;
     global.params.defaultlibname = "phobos";
 #elif TARGET_LINUX
@@ -766,18 +766,18 @@ int tryMain(size_t argc, const char *argv[])
             else if (strcmp(p + 1, "m32") == 0)
             {
                 global.params.is64bit = false;
-                global.params.coff = false;
+                global.params.mscoff = false;
             }
             else if (strcmp(p + 1, "m64") == 0)
             {
                 global.params.is64bit = true;
-                global.params.coff = true;
+                global.params.mscoff = true;
             }
 #if TARGET_WINDOS
-            else if (strcmp(p + 1, "m32coff") == 0)
+            else if (strcmp(p + 1, "m32mscoff") == 0)
             {
                 global.params.is64bit = 0;
-                global.params.coff = true;
+                global.params.mscoff = true;
             }
 #endif
             else if (strcmp(p + 1, "profile") == 0)
@@ -1299,16 +1299,16 @@ Language changes listed by -transition=id:\n\
 #endif
 #if TARGET_WINDOS
         VersionCondition::addPredefinedGlobalIdent("Win32");
-        if (!setdefaultlib && global.params.coff)
+        if (!setdefaultlib && global.params.mscoff)
         {
-            global.params.defaultlibname = "phobos32coff";
+            global.params.defaultlibname = "phobos32mscoff";
             if (!setdebuglib)
                 global.params.debuglibname = global.params.defaultlibname;
         }
 #endif
     }
 #if TARGET_WINDOS
-    if (global.params.coff)
+    if (global.params.mscoff)
         VersionCondition::addPredefinedGlobalIdent("CRuntime_Microsoft");
     else
         VersionCondition::addPredefinedGlobalIdent("CRuntime_DigitalMars");
@@ -2046,7 +2046,7 @@ static const char* parse_arch(size_t argc, const char** argv, const char* arch)
     {   const char* p = argv[i];
         if (p[0] == '-')
         {
-            if (strcmp(p + 1, "m32") == 0 || strcmp(p + 1, "m32coff") == 0 || strcmp(p + 1, "m64") == 0)
+            if (strcmp(p + 1, "m32") == 0 || strcmp(p + 1, "m32mscoff") == 0 || strcmp(p + 1, "m64") == 0)
                 arch = p + 2;
             else if (strcmp(p + 1, "run") == 0)
                 break;

--- a/src/mars.h
+++ b/src/mars.h
@@ -110,7 +110,7 @@ struct Param
     bool isFreeBSD;     // generate code for FreeBSD
     bool isOpenBSD;     // generate code for OpenBSD
     bool isSolaris;     // generate code for Solaris
-    bool coff;          // for Win32: write COFF object files instead of OMF
+    bool mscoff;        // for Win32: write COFF object files instead of OMF
     char useDeprecated; // 0: don't allow use of deprecated features
                         // 1: silently allow use of deprecated features
                         // 2: warn about the use of deprecated features

--- a/src/mars.h
+++ b/src/mars.h
@@ -110,6 +110,7 @@ struct Param
     bool isFreeBSD;     // generate code for FreeBSD
     bool isOpenBSD;     // generate code for OpenBSD
     bool isSolaris;     // generate code for Solaris
+    char objfmt;        // object file format as defined in cdef.h
     char useDeprecated; // 0: don't allow use of deprecated features
                         // 1: silently allow use of deprecated features
                         // 2: warn about the use of deprecated features

--- a/src/mars.h
+++ b/src/mars.h
@@ -110,7 +110,7 @@ struct Param
     bool isFreeBSD;     // generate code for FreeBSD
     bool isOpenBSD;     // generate code for OpenBSD
     bool isSolaris;     // generate code for Solaris
-    char objfmt;        // object file format as defined in cdef.h
+    bool coff;          // for Win32: write COFF object files instead of OMF
     char useDeprecated; // 0: don't allow use of deprecated features
                         // 1: silently allow use of deprecated features
                         // 2: warn about the use of deprecated features

--- a/src/msc.c
+++ b/src/msc.c
@@ -89,7 +89,7 @@ void backend_init()
 #endif
 
     out_config_init(
-        params->is64bit ? 64 : 32,
+        (params->is64bit ? 64 : 32) | params->objfmt,
         exe,
         false, //params->trace,
         params->nofloat,

--- a/src/msc.c
+++ b/src/msc.c
@@ -37,6 +37,7 @@ struct Environment;
 void out_config_init(
         int model,      // 32: 32 bit code
                         // 64: 64 bit code
+                        // Windows: bit 0 set to generate MS-COFF instead of OMF
         bool exe,       // true: exe file
                         // false: dll or shared library (generate PIC code)
         bool trace,     // add profiling code

--- a/src/msc.c
+++ b/src/msc.c
@@ -89,7 +89,7 @@ void backend_init()
 #endif
 
     out_config_init(
-        (params->is64bit ? 64 : 32) | (params->coff ? 1 : 0),
+        (params->is64bit ? 64 : 32) | (params->mscoff ? 1 : 0),
         exe,
         false, //params->trace,
         params->nofloat,

--- a/src/msc.c
+++ b/src/msc.c
@@ -89,7 +89,7 @@ void backend_init()
 #endif
 
     out_config_init(
-        (params->is64bit ? 64 : 32) | params->objfmt,
+        (params->is64bit ? 64 : 32) | (params->coff ? 1 : 0),
         exe,
         false, //params->trace,
         params->nofloat,

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -392,6 +392,8 @@ int main(string[] args)
             default:      envData.ccompiler = "g++"; break;
         }
     }
+    bool msc = envData.ccompiler.toLower.endsWith("cl.exe");
+
     gatherTestParameters(testArgs, input_dir, input_file, envData);
 
     //prepare cpp extra sources
@@ -420,13 +422,13 @@ int main(string[] args)
             string command = envData.ccompiler;
             if (envData.compiler == "dmd")
             {
-                if (envData.os == "win32")
-                {
-                    command ~= " -c "~curSrc~" -o"~curObj;
-                }
-                else if (envData.os == "win64")
+                if (msc)
                 {
                     command ~= ` /c /nologo `~curSrc~` /Fo`~curObj;
+                }
+                else if (envData.os == "win32")
+                {
+                    command ~= " -c "~curSrc~" -o"~curObj;
                 }
                 else
                 {
@@ -535,7 +537,7 @@ int main(string[] args)
             {
                 toCleanup ~= test_app_dmd;
                 version(Windows)
-                    if (envData.model == "64")
+                    if (msc)
                     {
                         toCleanup ~= test_app_dmd_base ~ to!string(i) ~ ".ilk";
                         toCleanup ~= test_app_dmd_base ~ to!string(i) ~ ".pdb";

--- a/test/runnable/testthread.d
+++ b/test/runnable/testthread.d
@@ -3,7 +3,7 @@
 import std.c.stdio;
 import core.thread;
 
-version (Win32)
+version (CRuntime_DigitalMars)
 {
     extern (C)
     {
@@ -25,7 +25,7 @@ class Foo
         tlsx = 5;
         Thread t = Thread.getThis();
 
-        version (Win32)
+        version (CRuntime_DigitalMars)
             printf("thread ptr=%p, %p &tlsx = %p %p\n", t, &_tlsstart, &tlsx, &_tlsend);
         x = 3;
         printf("-bar()\n");


### PR DESCRIPTION
As this comes up in the NG now and then, these are the compiler patches to build COFF files for Win32.
- use command line option -m32coff
- it defines versions CRuntime_DigitalMars and CRuntime_Microsoft (and CRuntime_GNU) as it is no longer possible to detect the C runtime from the OS. This can also replace all the similar adhoc versionings in druntime/phobos.
- C++ interfacing isn't adjusted yet, the rest of the test suite seems to succeed

The corresponding druntime and phobos changes are here (mostly dealing with the CRuntime versions):

https://github.com/rainers/druntime/tree/coff32
https://github.com/rainers/phobos/tree/coff32

If there is a chance of this getting merged, I can make them pull requests, too.
