### PR TITLE
[D1] Issue 13260 : ICE accessing non-existent member

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3452,7 +3452,8 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                 {
                     sm = t->toDsymbol(sc);
                     if (sm)
-                    {   assert(id->dyncast() == DYNCAST_IDENTIFIER);
+                    {   if (id->dyncast() != DYNCAST_IDENTIFIER)
+                            error(loc, "'%s' is not an identifier", id->toChars());
                         sm = sm->search(loc, (Identifier *)id, 0);
                         if (sm)
                             goto L2;


### PR DESCRIPTION
Replaces assertion with an error. Does not change language
semantics but makes possible to check for presence of such
members in `is` expression.

Quite a big issue actually in absence of `__traits` :)
