### PR TITLE
Add DirectX library path

### DIFF
--- a/ini/windows/bin/sc.ini
+++ b/ini/windows/bin/sc.ini
@@ -75,3 +75,6 @@ LIB=%LIB%;"%WindowsSdkDir%\Lib\win8\um\x64"
 ; Platform libraries (Windows SDK 7 and 6)
 LIB=%LIB%;"%WindowsSdkDir%\Lib\x64"
 
+; DirectX (newer versions are included in the Platform SDK but this
+; will allow us to support older versions)
+LIB=%LIB%;"%DXSDK_DIR%\Lib\x64"


### PR DESCRIPTION
64-bit only. If 32-bit COFF support is ever added we can add that to the `Environment32` section as well.

Fixes https://issues.dlang.org/show_bug.cgi?id=13265
