### PR TITLE
Fix Issue 13273 - ddoc can't handle \r in unittests and ESCAPES properly

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -563,7 +563,7 @@ static void emitAnchor(OutBuffer *buf, Dsymbol *s, Scope *sc)
 /** Get leading indentation from 'src' which represents lines of code. */
 static size_t getCodeIndent(const char *src)
 {
-    while (src && *src == '\n')
+    while (src && (*src == '\r' || *src == '\n'))
         ++src;  // skip until we find the first non-empty line
 
     size_t codeIndent = 0;

--- a/src/doc.c
+++ b/src/doc.c
@@ -1893,7 +1893,7 @@ void DocComment::parseEscapes(Escape **pescapetable, const utf8_t *textstart, si
         {
             if (p + 4 >= pend)
                 return;
-            if (!(*p == ' ' || *p == '\t' || *p == '\n' || *p == ','))
+            if (!(*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n' || *p == ','))
                 break;
             p++;
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -1574,7 +1574,7 @@ UnitTestDeclaration *Parser::parseUnitTest()
     {
         /* Remove trailing whitespaces */
         for (const utf8_t *p = endPtr - 1;
-             begPtr <= p && (*p == ' ' || *p == '\n' || *p == '\t'); --p)
+             begPtr <= p && (*p == ' ' || *p == '\r' || *p == '\n' || *p == '\t'); --p)
         {
             endPtr = p;
         }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13273

Simple fixes for documented unittest and ESCAPES in a .ddoc file when using `\r\n?` line endings.

Without these, the `compilable/ddoc*` dmd tests fail on my Windows setup, because Git checks out the files with `\r\n` line endings. This is the default Git behaviour now, presumably the autotester is **not** doing this, and it should (how to fix that?).

I haven't added any tests, because the needed tests (`ddocunittest.d` and `ddoc9369.d`) are already present! (see above)
