### PR TITLE
Fix Issue 9728 - Ddoc anchors non-unique across overloads 

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -130,6 +130,14 @@ bool isCVariadicParameter(Dsymbol *s, const utf8_t *p, size_t len)
     return tf && tf->varargs == 1 && cmp("...", p, len) == 0;
 }
 
+static TemplateDeclaration *getEponymousParentTemplate(Dsymbol *s)
+{
+    if (!s->parent)
+        return NULL;
+    TemplateDeclaration *td = s->parent->isTemplateDeclaration();
+    return (td && td->onemember == s) ? td : NULL;
+}
+
 static const char ddoc_default[] = "\
 DDOC =  <html><head>\n\
         <META http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">\n\
@@ -523,22 +531,21 @@ static bool emitAnchorName(OutBuffer *buf, Dsymbol *s, Scope *sc)
     if (!s || s->isPackage() || s->isModule())
         return false;
 
-    TemplateDeclaration *td;
-    bool dot = false;
-
     // Add parent names first
+    bool dot = false;
     if (s->parent)
         dot = emitAnchorName(buf, s->parent, sc);
     else if (sc)
         dot = emitAnchorName(buf, sc->scopesym, skipNonQualScopes(sc->enclosing));
 
     // Eponymous template members can share the parent anchor name
-    if (s->parent && (td = s->parent->isTemplateDeclaration()) != NULL &&
-        td->onemember == s)
+    if (getEponymousParentTemplate(s))
         return dot;
     if (dot)
         buf->writeByte('.');
+    
     // Use "this" not "__ctor"
+    TemplateDeclaration *td;
     if (s->isCtorDeclaration() || ((td = s->isTemplateDeclaration()) != NULL &&
         td->onemember && td->onemember->isCtorDeclaration()))
     {
@@ -649,13 +656,7 @@ void emitDitto(Dsymbol *s, Scope *sc)
     /* If 'this' is a function template, then highlightCode() was
      * already run by FuncDeclaration::toDocbuffer().
      */
-    TemplateDeclaration *td;
-    if (s->parent &&
-        (td = s->parent->isTemplateDeclaration()) != NULL &&
-        td->onemember == s)
-    {
-    }
-    else
+    if (!getEponymousParentTemplate(s))
         highlightCode(sc, s, &b, o);
     b.writeByte(')');
     buf->spread(sc->lastoffset, b.offset);
@@ -1220,18 +1221,14 @@ void toDocBuffer(Dsymbol *s, OutBuffer *buf, Scope *sc)
             //printf("FuncDeclaration::toDocbuffer() %s\n", fd->toChars());
             if (fd->ident)
             {
-                TemplateDeclaration *td;
+                TemplateDeclaration *td = getEponymousParentTemplate(fd);
 
-                if (fd->parent &&
-                    (td = fd->parent->isTemplateDeclaration()) != NULL &&
-                    td->onemember == fd)
+                if (td)
                 {
                     /* It's a function template
                      */
                     size_t o = buf->offset;
-
                     declarationToDocBuffer(fd, td);
-
                     highlightCode(sc, fd, buf, o);
                 }
                 else
@@ -1261,11 +1258,9 @@ void toDocBuffer(Dsymbol *s, OutBuffer *buf, Scope *sc)
         #if 0
                 emitProtection(buf, sd->protection);
         #endif
-                TemplateDeclaration *td;
+                TemplateDeclaration *td = getEponymousParentTemplate(sd);
 
-                if (sd->parent &&
-                    (td = sd->parent->isTemplateDeclaration()) != NULL &&
-                    td->onemember == sd)
+                if (td)
                 {
                     size_t o = buf->offset;
                     toDocBuffer(td, buf, sc);
@@ -1287,11 +1282,9 @@ void toDocBuffer(Dsymbol *s, OutBuffer *buf, Scope *sc)
         #if 0
                 emitProtection(buf, cd->protection);
         #endif
-                TemplateDeclaration *td;
+                TemplateDeclaration *td = getEponymousParentTemplate(cd);
 
-                if (cd->parent &&
-                    (td = cd->parent->isTemplateDeclaration()) != NULL &&
-                    td->onemember == cd)
+                if (td)
                 {
                     size_t o = buf->offset;
                     toDocBuffer(td, buf, sc);

--- a/src/scope.c
+++ b/src/scope.c
@@ -87,6 +87,8 @@ Scope::Scope()
     this->lastdc = NULL;
     this->lastoffset = 0;
     this->docbuf = NULL;
+    this->anchorCounts = NULL;
+    this->prevAnchor = NULL;
     this->userAttribDecl = NULL;
 }
 

--- a/src/scope.h
+++ b/src/scope.h
@@ -30,6 +30,7 @@ class AggregateDeclaration;
 class FuncDeclaration;
 class UserAttributeDeclaration;
 struct DocComment;
+struct AA;
 class TemplateInstance;
 
 #include "dsymbol.h"
@@ -119,6 +120,8 @@ struct Scope
     size_t lastoffset;          // offset in docbuf of where to insert next dec (for ditto)
     size_t lastoffset2;         // offset in docbuf of where to insert next dec (for unittest)
     OutBuffer *docbuf;          // buffer for documentation output
+    AA *anchorCounts;           // lookup duplicate anchor name count
+    Identifier *prevAnchor;     // qualified symbol name of last doc anchor
 
     static Scope *freelist;
     static Scope *alloc();

--- a/test/compilable/ddoc10.d
+++ b/test/compilable/ddoc10.d
@@ -23,6 +23,8 @@ int func2(T,U)(T x, U y) {}
 /// ditto
 int func2(T)(T x) {}
 
+/// Separate overload item.
+int func2()() {}
 
 
 ///
@@ -169,4 +171,7 @@ struct T
     /****
      */
     this(A...)(A args) { }
+    
+    ///
+    this(int){}
 }

--- a/test/compilable/extra-files/ddoc10.html
+++ b/test/compilable/extra-files/ddoc10.html
@@ -5,7 +5,7 @@
         <h1>ddoc10</h1>
 <br><br>
 <dl><dt><big><a name="Foo"></a>struct <u>Foo</u>(T);
-<br><a name="Foo"></a>struct <u>Foo</u>(T, U);
+<br>struct <u>Foo</u>(T, U);
 </big></dt>
 <dd>The foo<br><br>
 
@@ -18,14 +18,19 @@
 
 </dd>
 <dt><big><a name="func2"></a>int <u>func2</u>(T, U)(T <i>x</i>, U <i>y</i>);
-<br><a name="func2"></a>int <u>func2</u>(T)(T <i>x</i>);
+<br>int <u>func2</u>(T)(T <i>x</i>);
 </big></dt>
 <dd>This comment is also repeated twice, and the second function signature is
  not very well documented.<br><br>
 
 </dd>
+<dt><big><a name="func2.2"></a>int <u>func2</u>()();
+</big></dt>
+<dd>Separate overload item.<br><br>
+
+</dd>
 <dt><big><a name="func3"></a>int <u>func3</u>(T, U)(T <i>x</i>, U <i>y</i>);
-<br><a name="func3"></a>int <u>func3</u>(T, U = int, V : long)(T <i>x</i>);
+<br>int <u>func3</u>(T, U = int, V : long)(T <i>x</i>);
 </big></dt>
 <dd>This used to work adequately and documented both <u>func3</u> templates
  simultaneously. Now, it documents the first template twice and
@@ -33,13 +38,13 @@
 
 </dd>
 <dt><big><a name="map"></a>void <u>map</u>(char <i>rs</i>);
-<br><a name="map"></a>void <u>map</u>(int <i>rs</i>);
+<br>void <u>map</u>(int <i>rs</i>);
 </big></dt>
 <dd>blah<br><br>
 
 </dd>
 <dt><big><a name="map2"></a>void <u>map2</u>()(char <i>rs</i>);
-<br><a name="map2"></a>void <u>map2</u>()(int <i>rs</i>);
+<br>void <u>map2</u>()(int <i>rs</i>);
 </big></dt>
 <dd>blah<br><br>
 
@@ -122,6 +127,10 @@ Attempt one:  Doc outside static if.<br><br>
 </big></dt>
 <dd><br><br>
 <dl><dt><big><a name="T.this"></a>this(A...)(A <i>args</i>);
+</big></dt>
+<dd><br><br>
+</dd>
+<dt><big><a name="T.this.2"></a>this(int);
 </big></dt>
 <dd><br><br>
 </dd>

--- a/test/compilable/extra-files/ddoc10334.html
+++ b/test/compilable/extra-files/ddoc10334.html
@@ -7,55 +7,55 @@
 <dl><dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!())</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!100)</big></dt>
+<dt><big><a name="Foo10334.2"></a>template <u>Foo10334</u>(T) if (Bar10334!100)</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!3.14)</big></dt>
+<dt><big><a name="Foo10334.3"></a>template <u>Foo10334</u>(T) if (Bar10334!3.14)</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!"str")</big></dt>
+<dt><big><a name="Foo10334.4"></a>template <u>Foo10334</u>(T) if (Bar10334!"str")</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!1.4i)</big></dt>
+<dt><big><a name="Foo10334.5"></a>template <u>Foo10334</u>(T) if (Bar10334!1.4i)</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!null)</big></dt>
+<dt><big><a name="Foo10334.6"></a>template <u>Foo10334</u>(T) if (Bar10334!null)</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!true)</big></dt>
+<dt><big><a name="Foo10334.7"></a>template <u>Foo10334</u>(T) if (Bar10334!true)</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!false)</big></dt>
+<dt><big><a name="Foo10334.8"></a>template <u>Foo10334</u>(T) if (Bar10334!false)</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!'A')</big></dt>
+<dt><big><a name="Foo10334.9"></a>template <u>Foo10334</u>(T) if (Bar10334!'A')</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!int)</big></dt>
+<dt><big><a name="Foo10334.10"></a>template <u>Foo10334</u>(T) if (Bar10334!int)</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!string)</big></dt>
+<dt><big><a name="Foo10334.11"></a>template <u>Foo10334</u>(T) if (Bar10334!string)</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!([1, 2, 3]))</big></dt>
+<dt><big><a name="Foo10334.12"></a>template <u>Foo10334</u>(T) if (Bar10334!([1, 2, 3]))</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!(Baz10334!()))</big></dt>
+<dt><big><a name="Foo10334.13"></a>template <u>Foo10334</u>(T) if (Bar10334!(Baz10334!()))</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!(Baz10334!T))</big></dt>
+<dt><big><a name="Foo10334.14"></a>template <u>Foo10334</u>(T) if (Bar10334!(Baz10334!T))</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!(Baz10334!100))</big></dt>
+<dt><big><a name="Foo10334.15"></a>template <u>Foo10334</u>(T) if (Bar10334!(Baz10334!100))</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!(.foo))</big></dt>
+<dt><big><a name="Foo10334.16"></a>template <u>Foo10334</u>(T) if (Bar10334!(.foo))</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!(const(int)))</big></dt>
+<dt><big><a name="Foo10334.17"></a>template <u>Foo10334</u>(T) if (Bar10334!(const(int)))</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="Foo10334"></a>template <u>Foo10334</u>(T) if (Bar10334!(shared(T)))</big></dt>
+<dt><big><a name="Foo10334.18"></a>template <u>Foo10334</u>(T) if (Bar10334!(shared(T)))</big></dt>
 <dd><br><br>
 </dd>
 <dt><big><a name="Test10334"></a>template <u>Test10334</u>(T...)</big></dt>

--- a/test/compilable/extra-files/ddoc11511.html
+++ b/test/compilable/extra-files/ddoc11511.html
@@ -16,7 +16,7 @@
 </table><br>
 
 </dd>
-<dt><big><a name="foo"></a>void <u>foo</u>(int <i>abcd</i>, int <i>bcdef</i>, int[] <i>arr</i>...);
+<dt><big><a name="foo.2"></a>void <u>foo</u>(int <i>abcd</i>, int <i>bcdef</i>, int[] <i>arr</i>...);
 </big></dt>
 <dd><b>Params:</b><br>
 <table><tr><td>int <i>abcd</i></td>

--- a/test/compilable/extra-files/ddoc9305.html
+++ b/test/compilable/extra-files/ddoc9305.html
@@ -9,12 +9,12 @@
 <dd><u>foo</u>()<br><br>
 
 </dd>
-<dt><big><a name="X"></a>template <u>X</u>(alias pred = (x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = (x)
+<dt><big><a name="X"></a>template <u>X</u>(alias pred = (x) =&gt; x)<br>template <u>X</u>(alias pred = (x)
 {
 int y;
 return y;
 }
-)<br><a name="X"></a>template <u>X</u>(alias pred = (int x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = (int x)
+)<br>template <u>X</u>(alias pred = (int x) =&gt; x)<br>template <u>X</u>(alias pred = (int x)
 {
 int y;
 return y;
@@ -22,38 +22,38 @@ return y;
 )</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="X"></a>template <u>X</u>(alias pred = function (x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = function (x)
+<dt><big><a name="X.2"></a>template <u>X</u>(alias pred = function (x) =&gt; x)<br>template <u>X</u>(alias pred = function (x)
 {
 return x + 1;
 }
-)<br><a name="X"></a>template <u>X</u>(alias pred = function (int x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = function (int x)
+)<br>template <u>X</u>(alias pred = function (int x) =&gt; x)<br>template <u>X</u>(alias pred = function (int x)
 {
 return x + 1;
 }
-)<br><a name="X"></a>template <u>X</u>(alias pred = function int(x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = function int(x)
+)<br>template <u>X</u>(alias pred = function int(x) =&gt; x)<br>template <u>X</u>(alias pred = function int(x)
 {
 return x + 1;
 }
-)<br><a name="X"></a>template <u>X</u>(alias pred = function int(int x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = function int(int x)
+)<br>template <u>X</u>(alias pred = function int(int x) =&gt; x)<br>template <u>X</u>(alias pred = function int(int x)
 {
 return x + 1;
 }
 )</big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="X"></a>template <u>X</u>(alias pred = delegate (x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = delegate (x)
+<dt><big><a name="X.3"></a>template <u>X</u>(alias pred = delegate (x) =&gt; x)<br>template <u>X</u>(alias pred = delegate (x)
 {
 return x + 1;
 }
-)<br><a name="X"></a>template <u>X</u>(alias pred = delegate (int x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = delegate (int x)
+)<br>template <u>X</u>(alias pred = delegate (int x) =&gt; x)<br>template <u>X</u>(alias pred = delegate (int x)
 {
 return x + 1;
 }
-)<br><a name="X"></a>template <u>X</u>(alias pred = delegate int(x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = delegate int(x)
+)<br>template <u>X</u>(alias pred = delegate int(x) =&gt; x)<br>template <u>X</u>(alias pred = delegate int(x)
 {
 return x + 1;
 }
-)<br><a name="X"></a>template <u>X</u>(alias pred = delegate int(int x) =&gt; x)<br><a name="X"></a>template <u>X</u>(alias pred = delegate int(int x)
+)<br>template <u>X</u>(alias pred = delegate int(int x) =&gt; x)<br>template <u>X</u>(alias pred = delegate int(int x)
 {
 return x + 1;
 }

--- a/test/compilable/extra-files/ddocunittest.html
+++ b/test/compilable/extra-files/ddocunittest.html
@@ -94,7 +94,7 @@ placeholder
 <dd><u>foobar</u> - no examples<br><br>
 
 </dd>
-<dt><big><a name="foo"></a>void <u>foo</u>(int <i>x</i>);
+<dt><big><a name="foo.2"></a>void <u>foo</u>(int <i>x</i>);
 </big></dt>
 <dd>func - 4 examples
 <br><br>
@@ -281,8 +281,8 @@ Example
 <br><br>
 </dd>
 <dt><big><a name="redBlackTree"></a>auto <u>redBlackTree</u>(E)(E[] <i>elems</i>...);
-<br><a name="redBlackTree"></a>auto <u>redBlackTree</u>(bool allowDuplicates, E)(E[] <i>elems</i>...);
-<br><a name="redBlackTree"></a>auto <u>redBlackTree</u>(alias less, E)(E[] <i>elems</i>...);
+<br>auto <u>redBlackTree</u>(bool allowDuplicates, E)(E[] <i>elems</i>...);
+<br>auto <u>redBlackTree</u>(alias less, E)(E[] <i>elems</i>...);
 </big></dt>
 <dd>with template functions<br><br>
 <b>Examples:</b><br>
@@ -294,7 +294,7 @@ Example
 </pre>
 <br><br>
 </dd>
-<dt><big><a name="foo"></a>void <u>foo</u>();
+<dt><big><a name="foo.3"></a>void <u>foo</u>();
 </big></dt>
 <dd>test<br><br>
 <b>Examples:</b><br>


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=9728

This keeps the first anchor the same for hyperlink compatibility, subsequent anchors get `.N` appended.

The Jump-to JS code for Phobos will need updating too: https://github.com/D-Programming-Language/dlang.org/issues/646.
