### PR TITLE
Fix #13277 - Base class in JSON output is always unqualified

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -663,7 +663,7 @@ public:
         {
             if (cd->baseClass && cd->baseClass->ident != Id::Object)
             {
-                property("base", cd->baseClass->toChars());
+                property("base", cd->baseClass->toPrettyChars(true));
             }
             if (cd->interfaces_dim)
             {
@@ -672,7 +672,7 @@ public:
                 for (size_t i = 0; i < cd->interfaces_dim; i++)
                 {
                     BaseClass *b = cd->interfaces[i];
-                    item(b->base->toChars());
+                    item(b->base->toPrettyChars(true));
                 }
                 arrayEnd();
             }

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -149,9 +149,9 @@
     "kind" : "class",
     "line" : 22,
     "char" : 1,
-    "base" : "Bar",
+    "base" : "json.Bar!1.Bar",
     "interfaces" : [
-     "Baz"
+     "json.Baz!(int, 2, null).Baz"
     ],
     "members" : [
      {
@@ -219,7 +219,7 @@
     "kind" : "class",
     "line" : 31,
     "char" : 1,
-    "base" : "Bar2",
+    "base" : "json.Bar2",
     "members" : [
      {
       "name" : "val",


### PR DESCRIPTION
This fixes [#13277](http://issues.dlang.org/show_bug.cgi?id=13277) as well as expands the names of the interfaces it implements.
