### PR TITLE
Issue 13281 - Print type suffix of real/complex literals in pragma(msg) and error diagnostic

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2623,11 +2623,6 @@ bool IntegerExp::equals(RootObject *o)
     return false;
 }
 
-char *IntegerExp::toChars()
-{
-    return Expression::toChars();
-}
-
 void IntegerExp::setInteger(dinteger_t value)
 {
     this->value = value;
@@ -2749,11 +2744,6 @@ RealExp::RealExp(Loc loc, real_t value, Type *type)
     //printf("RealExp::RealExp(%Lg)\n", value);
     this->value = value;
     this->type = type;
-}
-
-char *RealExp::toChars()
-{
-    return Expression::toChars();
 }
 
 dinteger_t RealExp::toInteger()
@@ -2887,11 +2877,6 @@ ComplexExp::ComplexExp(Loc loc, complex_t value, Type *type)
     this->value = value;
     this->type = type;
     //printf("ComplexExp::ComplexExp(%s)\n", toChars());
-}
-
-char *ComplexExp::toChars()
-{
-    return Expression::toChars();
 }
 
 dinteger_t ComplexExp::toInteger()
@@ -3097,11 +3082,6 @@ Expression *IdentifierExp::semantic(Scope *sc)
             error("undefined identifier %s", ident->toChars());
     }
     return new ErrorExp();
-}
-
-char *IdentifierExp::toChars()
-{
-    return ident->toChars();
 }
 
 int IdentifierExp::isLvalue()
@@ -3320,11 +3300,6 @@ Lagain:
 
     error("%s '%s' is not a variable", s->kind(), s->toChars());
     return new ErrorExp();
-}
-
-char *DsymbolExp::toChars()
-{
-    return s->toChars();
 }
 
 int DsymbolExp::isLvalue()
@@ -5206,11 +5181,6 @@ Expression *VarExp::semantic(Scope *sc)
     }
 
     return this;
-}
-
-char *VarExp::toChars()
-{
-    return var->toChars();
 }
 
 void VarExp::checkEscape()

--- a/src/expression.c
+++ b/src/expression.c
@@ -2753,20 +2753,7 @@ RealExp::RealExp(Loc loc, real_t value, Type *type)
 
 char *RealExp::toChars()
 {
-    /** sizeof(value)*3 is because each byte of mantissa is max
-    of 256 (3 characters). The string will be "-M.MMMMe-4932".
-    (ie, 8 chars more than mantissa). Plus one for trailing \0.
-    Plus one for rounding. */
-    const size_t BUFFER_LEN = sizeof(value) * 3 + 8 + 1 + 1;
-    char buffer[BUFFER_LEN];
-
-    ld_sprint(buffer, 'g', value);
-
-    if (type->isimaginary())
-        strcat(buffer, "i");
-
-    assert(strlen(buffer) < BUFFER_LEN);
-    return mem.strdup(buffer);
+    return Expression::toChars();
 }
 
 dinteger_t RealExp::toInteger()
@@ -2904,17 +2891,7 @@ ComplexExp::ComplexExp(Loc loc, complex_t value, Type *type)
 
 char *ComplexExp::toChars()
 {
-    const size_t BUFFER_LEN = sizeof(value) * 3 + 8 + 1 + 1;
-    char buffer[BUFFER_LEN];
-
-    char buf1[BUFFER_LEN];
-    char buf2[BUFFER_LEN];
-
-    ld_sprint(buf1, 'g', creall(value));
-    ld_sprint(buf2, 'g', cimagl(value));
-    sprintf(buffer, "(%s+%si)", buf1, buf2);
-    assert(strlen(buffer) < BUFFER_LEN);
-    return mem.strdup(buffer);
+    return Expression::toChars();
 }
 
 dinteger_t ComplexExp::toInteger()

--- a/src/expression.h
+++ b/src/expression.h
@@ -250,7 +250,6 @@ public:
     IntegerExp(dinteger_t value);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
-    char *toChars();
     dinteger_t toInteger();
     real_t toReal();
     real_t toImaginary();
@@ -283,7 +282,6 @@ public:
     RealExp(Loc loc, real_t value, Type *type);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
-    char *toChars();
     dinteger_t toInteger();
     uinteger_t toUInteger();
     real_t toReal();
@@ -302,7 +300,6 @@ public:
     ComplexExp(Loc loc, complex_t value, Type *type);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
-    char *toChars();
     dinteger_t toInteger();
     uinteger_t toUInteger();
     real_t toReal();
@@ -322,7 +319,6 @@ public:
     IdentifierExp(Loc loc, Identifier *ident);
     static IdentifierExp *create(Loc loc, Identifier *ident);
     Expression *semantic(Scope *sc);
-    char *toChars();
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
@@ -343,7 +339,6 @@ public:
 
     DsymbolExp(Loc loc, Dsymbol *s, bool hasOverloads = false);
     Expression *semantic(Scope *sc);
-    char *toChars();
     int isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
@@ -645,7 +640,6 @@ public:
     static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = false);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
-    char *toChars();
     void checkEscape();
     void checkEscapeRef();
     int checkModifiable(Scope *sc, int flag);

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -1981,22 +1981,21 @@ public:
 
     void floatToBuffer(Type *type, real_t value)
     {
-        /* In order to get an exact representation, try converting it
-         * to decimal then back again. If it matches, use it.
-         * If it doesn't, fall back to hex, which is
-         * always exact.
-         * Longest string is for -real.max:
-         * "-1.18973e+4932\0".length == 17
-         * "-0xf.fffffffffffffffp+16380\0".length == 28
-         */
-        const size_t BUFFER_LEN = 32;
+        /** sizeof(value)*3 is because each byte of mantissa is max
+        of 256 (3 characters). The string will be "-M.MMMMe-4932".
+        (ie, 8 chars more than mantissa). Plus one for trailing \0.
+        Plus one for rounding. */
+        const size_t BUFFER_LEN = sizeof(value) * 3 + 8 + 1 + 1;
         char buffer[BUFFER_LEN];
         ld_sprint(buffer, 'g', value);
         assert(strlen(buffer) < BUFFER_LEN);
 
-        real_t r = Port::strtold(buffer, NULL);
-        if (r != value)                     // if exact duplication
-            ld_sprint(buffer, 'a', value);
+        if (hgs->hdrgen)
+        {
+            real_t r = Port::strtold(buffer, NULL);
+            if (r != value)                     // if exact duplication
+                ld_sprint(buffer, 'a', value);
+        }
         buf->writestring(buffer);
 
         if (type)

--- a/test/compilable/test13281.d
+++ b/test/compilable/test13281.d
@@ -1,0 +1,47 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+123
+123u
+123L
+123LU
+123.4
+123.4F
+123.4L
+123.4i
+123.4Fi
+123.4Li
+(123.4+5.6i)
+(123.4F+5.6Fi)
+(123.4L+5.6Li)
+---
+*/
+pragma(msg, 123);
+pragma(msg, 123u);
+pragma(msg, 123L);
+pragma(msg, 123uL);
+pragma(msg, 123.4);
+pragma(msg, 123.4f);
+pragma(msg, 123.4L);
+pragma(msg, 123.4i);
+pragma(msg, 123.4fi);
+pragma(msg, 123.4Li);
+pragma(msg, 123.4 +5.6i);
+pragma(msg, 123.4f+5.6fi);
+pragma(msg, 123.4L+5.6Li);
+
+static assert((123  ).stringof == "123");
+static assert((123u ).stringof == "123u");
+static assert((123L ).stringof == "123L");
+static assert((123uL).stringof == "123LU");
+static assert((123.4  ).stringof == "123.4");
+static assert((123.4f ).stringof == "123.4F");
+static assert((123.4L ).stringof == "123.4L");
+static assert((123.4i ).stringof == "123.4i");
+static assert((123.4fi).stringof == "123.4Fi");
+static assert((123.4Li).stringof == "123.4Li");
+static assert((123.4 +5.6i ).stringof == "123.4 + 5.6i");
+static assert((123.4f+5.6fi).stringof == "123.4F + 5.6Fi");
+static assert((123.4L+5.6Li).stringof == "123.4L + 5.6Li");

--- a/test/fail_compilation/diag13281.d
+++ b/test/fail_compilation/diag13281.d
@@ -1,0 +1,32 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag13281.d(20): Error: cannot implicitly convert expression (123) of type int to string
+fail_compilation/diag13281.d(21): Error: cannot implicitly convert expression (123u) of type uint to string
+fail_compilation/diag13281.d(22): Error: cannot implicitly convert expression (123L) of type long to string
+fail_compilation/diag13281.d(23): Error: cannot implicitly convert expression (123LU) of type ulong to string
+fail_compilation/diag13281.d(24): Error: cannot implicitly convert expression (123.4) of type double to int
+fail_compilation/diag13281.d(25): Error: cannot implicitly convert expression (123.4F) of type float to int
+fail_compilation/diag13281.d(26): Error: cannot implicitly convert expression (123.4L) of type real to int
+fail_compilation/diag13281.d(27): Error: cannot implicitly convert expression (123.4i) of type idouble to int
+fail_compilation/diag13281.d(28): Error: cannot implicitly convert expression (123.4Fi) of type ifloat to int
+fail_compilation/diag13281.d(29): Error: cannot implicitly convert expression (123.4Li) of type ireal to int
+fail_compilation/diag13281.d(30): Error: cannot implicitly convert expression ((123.4+5.6i)) of type cdouble to int
+fail_compilation/diag13281.d(31): Error: cannot implicitly convert expression ((123.4F+5.6Fi)) of type cfloat to int
+fail_compilation/diag13281.d(32): Error: cannot implicitly convert expression ((123.4L+5.6Li)) of type creal to int
+---
+*/
+
+string x1 = 123;
+string x2 = 123u;
+string x3 = 123L;
+string x4 = 123uL;
+int y1 = 123.4;
+int y2 = 123.4f;
+int y3 = 123.4L;
+int y4 = 123.4i;
+int y5 = 123.4fi;
+int y6 = 123.4Li;
+int y7 = 123.4 +5.6i;
+int y8 = 123.4f+5.6fi;
+int y9 = 123.4L+5.6Li;

--- a/test/fail_compilation/diag9357.d
+++ b/test/fail_compilation/diag9357.d
@@ -5,8 +5,8 @@ fail_compilation/diag9357.d(14): Error: cannot implicitly convert expression (1.
 fail_compilation/diag9357.d(15): Error: cannot implicitly convert expression (10.0000) of type double to int
 fail_compilation/diag9357.d(16): Error: cannot implicitly convert expression (11.0000) of type double to int
 fail_compilation/diag9357.d(17): Error: cannot implicitly convert expression (99.0000) of type double to int
-fail_compilation/diag9357.d(18): Error: cannot implicitly convert expression (1.04858e+06) of type real to int
-fail_compilation/diag9357.d(19): Error: cannot implicitly convert expression (1.04858e+06) of type real to int
+fail_compilation/diag9357.d(18): Error: cannot implicitly convert expression (1.04858e+06L) of type real to int
+fail_compilation/diag9357.d(19): Error: cannot implicitly convert expression (1.04858e+06L) of type real to int
 ---
 */
 void main()

--- a/test/runnable/functype.d
+++ b/test/runnable/functype.d
@@ -131,7 +131,7 @@ void testti()
     static assert(StringOf!(typeof(test)) == "int[](int[])");
 
     float function(float x = 0F) fp = x => x;
-    static assert(typeof(fp).stringof == "float function(float x = " ~ (0F).stringof ~ "F)");
+    static assert(typeof(fp).stringof == "float function(float x = " ~ (0F).stringof ~ ")");
     static assert(StringOf!(typeof(fp)) == "float function(float)");
 
     double delegate(double x = 0.0) dg = x => x;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13281

Use `PrittyPrintVisitor` for consistent integer/real/complex value printing.
