### PR TITLE
mangle C++ ::std and ::std::allocator correctly

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -342,7 +342,10 @@ Msgtable msgtable[] =
     { "getAttributes" },
     { "getFunctionAttributes" },
     { "getUnitTests" },
-    { "getVirtualIndex" }
+    { "getVirtualIndex" },
+
+    // For C++ mangling
+    { "allocator" },
 };
 
 

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1,6 +1,6 @@
 // EXTRA_CPP_SOURCES: cppb.cpp
 
-import std.c.stdio;
+import core.stdc.stdio;
 import core.stdc.stdarg;
 
 extern (C++)
@@ -374,6 +374,36 @@ void test13161()
 
 /****************************************/
 
+extern (C++, std)
+{
+    struct vector(T, A = allocator!T) { }
+
+    struct allocator(T) { }
+}
+
+extern (C++)
+{
+    version (linux)
+        void foo14(std.vector!(int)* p);
+    version (OSX)
+        void foo14(std.vector!(int)* p);
+    version (FreeBSD)
+        void foo14(std.vector!(int)* p);
+}
+
+void test14()
+{
+    std.vector!int* p;
+    version (linux)
+        foo14(p);
+    version (OSX)
+        foo14(p);
+    version (FreeBSD)
+        foo14(p);
+}
+
+/****************************************/
+
 void main()
 {
     test1();
@@ -392,6 +422,7 @@ void main()
     testvalist();
     test12825();
     test13161();
+    test14();
 
     printf("Success\n");
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -240,16 +240,16 @@ void myvprintf(const char* format, va_list va)
 class C13161
 {
 public:
-	virtual void dummyfunc() {}
-	long long val_5;
-	unsigned val_9;
+        virtual void dummyfunc() {}
+        long long val_5;
+        unsigned val_9;
 };
 
 class Test : public C13161
 {
 public:
-	unsigned val_0;
-	long long val_1;
+        unsigned val_0;
+        long long val_1;
 };
 
 size_t getoffset13161()
@@ -261,15 +261,15 @@ size_t getoffset13161()
 class C13161a
 {
 public:
-	virtual void dummyfunc() {}
-	long double val_5;
-	unsigned val_9;
+        virtual void dummyfunc() {}
+        long double val_5;
+        unsigned val_9;
 };
 
 class Testa : public C13161a
 {
 public:
-	bool val_0;
+        bool val_0;
 };
 
 size_t getoffset13161a()
@@ -277,3 +277,11 @@ size_t getoffset13161a()
     Testa s;
     return (char *)&s.val_0 - (char *)&s;
 }
+
+/****************************************************/
+
+#if __linux__ || __APPLE__ || __FreeBSD__
+#include <vector>
+// _Z5foo14PSt6vectorIiSaIiEE
+void foo14(std::vector<int, std::allocator<int> > *p) { }
+#endif


### PR DESCRIPTION
On Linux, there are shortcut mangles for ::std and ::std::allocator which were not implemented.

Not done on Windows because C++ template mangling currently isn't done at all on Windows. Need to fix that with another PR.

Also wound up removing some tabs from the test files.
