### PR TITLE
fix C++ linkage with MS-COFF32

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -1673,7 +1673,7 @@ private:
 
 char *toCppMangle(Dsymbol *s)
 {
-    VisualCPPMangler v(!global.params.is64bit);
+    VisualCPPMangler v(!global.params.mscoff);
     return v.mangleOf(s);
 }
 

--- a/test/runnable/cabi1.d
+++ b/test/runnable/cabi1.d
@@ -80,25 +80,24 @@ void test2()
 
 /******************************************/
 
+version (CRuntime_Microsoft)
+    alias long_double = double;
+else
+    alias long_double = real;
+
 extern (C)
 {
-    void ctestrir(int x1, int x2, int x3, int x4, int x5, int x6, real a, int b, real c);
+    void ctestrir(int x1, int x2, int x3, int x4, int x5, int x6, long_double a, int b, long_double c);
 }
 
 void test3()
 {
-version (Win64)
-{
-}
-else
-{
     ctestrir(1,2,3,4,5,6, 100.0, 67, 200.0);
-}
 }
 
 /******************************************/
 
-extern (C) void dtestrir(int x1, int x2, int x3, int x4, int x5, int x6, real a, int b, real c)
+extern (C) void dtestrir(int x1, int x2, int x3, int x4, int x5, int x6, long_double a, int b, long_double c)
 {
     assert(a == 300.0);
     assert(b == 68);

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -279,10 +279,15 @@ void test11()
 }
 /****************************************/
 
+version(CRuntime_Microsoft)
+    alias long_double = double;
+else
+    alias long_double = real;
+
 struct Struct10071
 {
     void *p;
-    real r;
+    long_double r;
 }
 
 extern(C++) size_t offset10071();
@@ -355,7 +360,7 @@ extern(C++) size_t getoffset13161();
 extern(C++) class C13161a
 {
 	void dummyfunc() {}
-	real val_5;
+	long_double val_5;
 	uint val_9;
 }
 

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -139,7 +139,7 @@ interface Expression
 }
 
 //int test34(int[0][0]*);
-version(Win64){}
+version(CRuntime_Microsoft){}
 else
 {
     int test35(real arg);
@@ -243,7 +243,7 @@ void main()
     Expression.dispose(ee);
     assert(ee is null);
     //assert(test34(null) == 0);
-    version(Win64){}
+    version(CRuntime_Microsoft){}
     else
     {
         assert(test35(3.14L) == 3);

--- a/test/runnable/functype.d
+++ b/test/runnable/functype.d
@@ -263,13 +263,15 @@ version(Win32)
 
 extern(Windows)
 {
-    export uint DefWindowProcA(void*, uint, uint, ptrdiff_t);
-    alias uint function (void*, uint, uint, ptrdiff_t) WNDPROC;
+    // use a symbol from kernel32.lib, not user32.lib. The latter might not
+    //  be passed automatically on the command line
+    export void* GetModuleHandleA(const(char)*moduleName);
+    alias void* function(const(char)*moduleName) PROC;
 }
 
 void test10734()
 {
-    WNDPROC lpfnWndProc = &DefWindowProcA;
+    PROC lpfnProc = &GetModuleHandleA;
 }
 
 }

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2691,7 +2691,7 @@ void test10083()
     assert(foo10083a(1) == 2);
     assert(foo10083a!int(1) == 2);
     assert(foo10083a!int(1.0) == 1);
-    version (Win64) {}  // workaround
+    version (CRuntime_Microsoft) {}  // workaround, the linker is complaining about duplicate COMDAT
     else
     {
     static assert(!__traits(compiles, foo10083a!double(1)));


### PR DESCRIPTION
Also allows running the test suite.

Run tests with appropriate sc.ini (I'll make a pull for the one in the ini folder):

```
make quick CC="%VCInstallDir%\bin\cl.exe" MODEL=32mscoff
```
