### PR TITLE
simpler method for obtaining \ in makefile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -103,8 +103,7 @@ export DMD=../src/dmd.exe
 export EXE=.exe
 export OBJ=.obj
 export DSEP=\\
-export SEP=$(shell echo '\')
-# bug in vim syntax hilighting, needed to kick it back into life: ')
+export SEP=$(subst /,\,/)
 else
 export ARGS=-inline -release -gc -O -unittest -fPIC
 export DMD=../src/dmd


### PR DESCRIPTION
This small change improves running the tests without having a full unix shell environment installed. All it takes is a unix-like make.
I also speculate that this makes the VIM workaround obsolete.
