### PR TITLE
add Environment32mscoff section to sc.ini

### DIFF
--- a/ini/windows/bin/sc.ini
+++ b/ini/windows/bin/sc.ini
@@ -78,3 +78,43 @@ LIB=%LIB%;"%WindowsSdkDir%\Lib\x64"
 ; DirectX (newer versions are included in the Platform SDK but this
 ; will allow us to support older versions)
 LIB=%LIB%;"%DXSDK_DIR%\Lib\x64"
+
+
+; -----------------------------------------------------------------------------
+[Environment32mscoff]
+LIB="%@P%\..\lib32mscoff"
+
+; settings very much copied from Environment64, see comments there
+; needed to avoid COMDAT folding (bugzilla 10664)
+DFLAGS=%DFLAGS% -L/OPT:NOICF
+
+; Windows installer replaces the following lines with the actual paths
+;VCINSTALLDIR=
+;WindowsSdkDir=
+
+LINKCMD=%VCINSTALLDIR%\bin\link.exe
+
+; needed with /DEBUG to find mspdb*.dll (only for VS2012 or VS2013)
+;VC2013 PATH=%PATH%;%VCINSTALLDIR%\..\Common7\IDE;%VCINSTALLDIR%\bin
+;VC2012 PATH=%PATH%;%VCINSTALLDIR%\..\Common7\IDE
+
+; ----------------------------------------------------------------------------
+; Add the library subdirectories of all VC and Windows SDK versions so things
+; just work for users using dmd from the VS Command Prompt
+
+; C Runtime libraries
+LIB=%LIB%;"%VCINSTALLDIR%\lib"
+
+; Platform libraries (Windows SDK 8.1)
+LIB=%LIB%;"%WindowsSdkDir%\Lib\winv6.3\um"
+
+; Platform libraries (Windows SDK 8)
+LIB=%LIB%;"%WindowsSdkDir%\Lib\win8\um"
+
+; Platform libraries (Windows SDK 7 and 6)
+LIB=%LIB%;"%WindowsSdkDir%\Lib"
+
+; DirectX (newer versions are included in the Platform SDK but this
+; will allow us to support older versions)
+LIB=%LIB%;"%DXSDK_DIR%\Lib"
+


### PR DESCRIPTION
This is meant to help setting up a correct sc.ini when trying the COFF32 support.
The phobos library is expected to be in windows/lib32mscoff.
