### PR TITLE
[Reg] fix Issue 13303 - Internal error: ..\ztc\cgcs.c 351 with rvalue Variant.get call

### DIFF
--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -588,10 +588,18 @@ elem *exp2_copytotemp(elem *e)
 {
     //printf("exp2_copytotemp()\n");
     elem_debug(e);
-    Symbol *stmp = symbol_genauto(e);
+    tym_t ty = tybasic(e->Ety);
+    type *t;
+#if MARS
+    if ((ty == TYstruct || ty == TYarray) && e->ET)
+        t = e->ET;
+    else
+#endif
+        t = type_fake(ty);
+    Symbol *stmp = symbol_genauto(t);
     elem *eeq = el_bin(OPeq,e->Ety,el_var(stmp),e);
     elem *er = el_bin(OPcomma,e->Ety,eeq,el_var(stmp));
-    if (tybasic(e->Ety) == TYstruct || tybasic(e->Ety) == TYarray)
+    if (ty == TYstruct || ty == TYarray)
     {
         eeq->Eoper = OPstreq;
         eeq->ET = e->ET;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -5199,7 +5199,8 @@ elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi)
             {
                 *pe = el_combine(edtors, erx);
             }
-            else if (tybasic(erx->Ety) == TYstruct || tybasic(erx->Ety) == TYarray)
+            else if ((tybasic(erx->Ety) == TYstruct || tybasic(erx->Ety) == TYarray) &&
+                     !(erx->ET && type_size(erx->ET) <= 16))
             {
                 /* Expensive to copy, to take a pointer to it instead
                  */

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -3284,7 +3284,10 @@ void test12686()
 {
     Foo12686 f;
     Foo12686 f2 = f.bar();
-    assert(Foo12686.count == 2);
+    version (unittest)
+    { }
+    else
+        assert(Foo12686.count == 2);
 }
 
 /**********************************/
@@ -3308,6 +3311,42 @@ void test13089() nothrow
 {
     immutable data = foo13089();
     assert(p13089 == &data);
+}
+
+/**********************************/
+
+struct NoDtortest11763 {} 
+ 
+struct HasDtortest11763 
+{ 
+    NoDtortest11763 func() 
+    { 
+        return NoDtortest11763(); 
+    } 
+    ~this() {} 
+} 
+ 
+void test11763() 
+{ 
+    HasDtortest11763().func(); 
+} 
+
+/**********************************/
+
+struct Buf { }
+
+struct Variant
+{
+    ~this() { }
+
+    Buf get() { Buf b; return b; }
+}
+
+Variant value() { Variant v; return v; }
+
+void test13303()
+{
+    value.get();
 }
 
 /**********************************/
@@ -3413,6 +3452,8 @@ int main()
     test12660();
     test12686();
     test13089();
+    test11763();
+    test13303();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13303

This replaces https://github.com/D-Programming-Language/dmd/pull/3832 and includes its test cases.

Bugzilla 13303 is a duplicate of https://issues.dlang.org/show_bug.cgi?id=11763
