### PR TITLE
fix paren error from #3755

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -1423,7 +1423,7 @@ void DocComment::parseSections(const utf8_t *comment)
                     p++;
                 }
                 // BUG: handle UTF PS and LS too
-                if (!*p || *p == '\r' || *p == '\n' && numdash >= 3)
+                if ((!*p || *p == '\r' || *p == '\n') && numdash >= 3)
                     inCode ^= 1;
                 pend = p;
             }


### PR DESCRIPTION
Fixes parenthesis error discovered by @lionello in https://github.com/D-Programming-Language/dmd/pull/3755
