### PR TITLE
Do not generate helpers with -betterC

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -495,6 +495,8 @@ void Module::genobjfile(bool multiobj)
 
 void Module::genhelpers(bool iscomdat)
 {
+    if (global.params.betterC)
+        return;
 
     // If module assert
     for (int i = 0; i < 3; i++)


### PR DESCRIPTION
This solves one aspect of [issue 13334](https://issues.dlang.org/show_bug.cgi?id=13334). It sort of takes advantage of the fact that `-betterC` is currently undocumented and poorly defined.

This is not the best possible implementation. Ideally, the strings should be emitted to their own linker section, but I don't know how to do that.
