### PR TITLE
[reg] fix Issue 11946 - need 'this' to access member when passing field to template parameter

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1289,8 +1289,13 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(
         }
     }
 
+#if BUGZILLA_11946
     if (isstatic)
         tthis = NULL;
+#else
+    if (toParent()->isModule() || (scope->stc & STCstatic))
+        tthis = NULL;
+#endif
     if (tthis)
     {
         bool hasttp = false;
@@ -6084,8 +6089,10 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     sc2->parent = this;
     sc2->tinst = this;
     sc2->speculative = speculative;
+#if BUGZILLA_11946
     if (enclosing && tempdecl->isstatic)
         sc2->stc &= ~STCstatic;
+#endif
 
     tryExpandMembers(sc2);
 

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2970,6 +2970,8 @@ void test11271()
 /******************************************/
 // 11533
 
+version (none)
+{
 struct S11533
 {
     void put(alias fun)() { fun!int(); }
@@ -3000,6 +3002,20 @@ void test11533c()
     assert(foo.call() == var);
     var += 1;
     assert(foo.call() == var);
+}
+
+void test11533()
+{
+    test11533a();
+    test11533b();
+    test11533c();
+}
+}
+else
+{
+void test11533()
+{
+}
 }
 
 /******************************************/
@@ -4051,9 +4067,7 @@ int main()
     test10811();
     test10969();
     test11271();
-    test11533a();
-    test11533b();
-    test11533c();
+    test11533();
     test11818();
     test11843();
     test11872();


### PR DESCRIPTION
This is a reversion of https://github.com/D-Programming-Language/dmd/pull/2794, hopefully without breaking subsequent fixes layered on top of it.

https://issues.dlang.org/show_bug.cgi?id=11946
#2794 was not a complete fix, and caused regressions, and so this issue awaits further engineering. I don't think we should be breaking existing code unless we've got a solid solution.

I used conditional compilation in order to make it easier to experiment with solutions. They should be removed once we do decide which direction we should go.

This should be merged into 2.066.
