### PR TITLE
Remove unused storage class STCcomdat

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -55,7 +55,6 @@ enum PURE;
 #define STCout          0x1000LL        // out parameter
 #define STClazy         0x2000LL        // lazy parameter
 #define STCforeach      0x4000LL        // variable for foreach loop
-#define STCcomdat       0x8000LL        // should go into COMDAT record
 #define STCvariadic     0x10000LL       // variadic function argument
 #define STCctorinit     0x20000LL       // can only be set inside constructor
 #define STCtemplateparameter  0x40000LL // template parameter

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -928,10 +928,7 @@ void VarDeclaration::toObjFile(bool multiobj)
 
         parent = this->toParent();
         {
-            if (storage_class & STCcomdat)
-                s->Sclass = SCcomdat;
-            else
-                s->Sclass = SCglobal;
+            s->Sclass = SCglobal;
 
             do
             {


### PR DESCRIPTION
`STCcomdat` is a leftover from an ancient version of DMD.
