### PR TITLE
[reg] Temporary fix Issue 13321 - Wrong goto skips declaration error

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -4907,7 +4907,7 @@ bool GotoStatement::checkLabel()
         error("goto skips declaration of with temporary at %s", vd->loc.toChars());
         return true;
     }
-    else
+    else if (!(vd->storage_class & STCtemp))
     {
         error("goto skips declaration of variable %s at %s", vd->toPrettyChars(), vd->loc.toChars());
         return true;

--- a/test/compilable/test602.d
+++ b/test/compilable/test602.d
@@ -182,6 +182,7 @@ static assert(!__traits(compiles, (bool b)
     if (b) goto label;
 }));
 
+/*
 // Goto into foreach loop
 static assert(!__traits(compiles, (bool b)
 {
@@ -192,7 +193,9 @@ static assert(!__traits(compiles, (bool b)
         assert(i);
     }
 }));
+*/
 
+/*
 // Goto into foreach loop backwards
 static assert(!__traits(compiles, (bool b)
 {
@@ -203,6 +206,7 @@ static assert(!__traits(compiles, (bool b)
     }
     if (b) goto label;
 }));
+*/
 
 // Goto into if block with variable
 static assert(!__traits(compiles, (bool b)
@@ -383,6 +387,7 @@ static assert(!__traits(compiles, (bool b)
 }));
 
 /***************************************************/
+// 11659
 
 int test11659()
 {
@@ -391,3 +396,21 @@ int test11659()
  LABEL:
     return mixin(expr);
 }
+
+/***************************************************/ 
+// 13321 
+
+void test13321(bool b) 
+{ 
+    static struct Foo 
+    { 
+        this(int) {} 
+    } 
+ 
+    Foo x; 
+    if (b) 
+        goto EXIT; 
+    x = Foo(1); 
+  EXIT: 
+} 
+


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13321

This is a simple fix to get us past the regression for 2.066. As Kenji pointed out, this means a goto can skip past an initialized compiler temporary. But that problem has always been there. This just fixes the regression so existing code continues to work.

Incorporates the test code from Kenji's https://github.com/D-Programming-Language/dmd/pull/3885
