### PR TITLE
use c_long_double instead of adhoc definitions in tests

### DIFF
--- a/test/runnable/cabi1.d
+++ b/test/runnable/cabi1.d
@@ -2,6 +2,7 @@
 // EXTRA_CPP_SOURCES: cabi2.cpp
 
 import core.stdc.stdio;
+import core.stdc.config;
 
 struct Foo1 { char c; }
 struct Foo2 { short s; }
@@ -80,14 +81,9 @@ void test2()
 
 /******************************************/
 
-version (CRuntime_Microsoft)
-    alias long_double = double;
-else
-    alias long_double = real;
-
 extern (C)
 {
-    void ctestrir(int x1, int x2, int x3, int x4, int x5, int x6, long_double a, int b, long_double c);
+    void ctestrir(int x1, int x2, int x3, int x4, int x5, int x6, c_long_double a, int b, c_long_double c);
 }
 
 void test3()
@@ -97,7 +93,7 @@ void test3()
 
 /******************************************/
 
-extern (C) void dtestrir(int x1, int x2, int x3, int x4, int x5, int x6, long_double a, int b, long_double c)
+extern (C) void dtestrir(int x1, int x2, int x3, int x4, int x5, int x6, c_long_double a, int b, c_long_double c)
 {
     assert(a == 300.0);
     assert(b == 68);

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -2,6 +2,7 @@
 
 import core.stdc.stdio;
 import core.stdc.stdarg;
+import core.stdc.config;
 
 extern (C++)
         int foob(int i, int j, int k);
@@ -279,15 +280,10 @@ void test11()
 }
 /****************************************/
 
-version(CRuntime_Microsoft)
-    alias long_double = double;
-else
-    alias long_double = real;
-
 struct Struct10071
 {
     void *p;
-    long_double r;
+    c_long_double r;
 }
 
 extern(C++) size_t offset10071();
@@ -360,7 +356,7 @@ extern(C++) size_t getoffset13161();
 extern(C++) class C13161a
 {
 	void dummyfunc() {}
-	long_double val_5;
+	c_long_double val_5;
 	uint val_9;
 }
 

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -2691,12 +2691,8 @@ void test10083()
     assert(foo10083a(1) == 2);
     assert(foo10083a!int(1) == 2);
     assert(foo10083a!int(1.0) == 1);
-    version (CRuntime_Microsoft) {}  // workaround, the linker is complaining about duplicate COMDAT
-    else
-    {
     static assert(!__traits(compiles, foo10083a!double(1)));
     static assert(!__traits(compiles, foo10083a!double(1.0)));
-    }
     static assert(!__traits(compiles, foo10083a!real(1)));
     assert(foo10083a!real(1.0) == 1);
     assert(foo10083a!real(1.0L) == 2);


### PR DESCRIPTION
https://github.com/D-Programming-Language/dmd/pull/3843/files introduced long_double definitions which can now be replaced with c_long_double from core.stdc.config.
This also enables a test in template9 now that the "duplicate COMDAT" problem is fixed
