### PR TITLE
Fix trivial typo in DMD's man page

### DIFF
--- a/docs/man/man1/dmd.1
+++ b/docs/man/man1/dmd.1
@@ -89,7 +89,7 @@ Inline expand functions
 Where to look for string imports.
 .I path
 is a : separated list of paths. Multiple
-.B -I
+.B -J
 s can be used, and the paths are searched in the same
 order.
 .IP -L\fIlinkerflag\fR


### PR DESCRIPTION
`-I` was mention in the section on `-J`, probably because of c&p.
