### PR TITLE
more mangling for std::allocator

### DIFF
--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -379,11 +379,31 @@ void test13161()
 
 /****************************************/
 
+version (linux)
+{
+    extern(C++, __gnu_cxx)
+    {
+	struct new_allocator(T)
+	{
+	    alias size_type = size_t;
+	    void deallocate(T*, size_type);
+	}
+    }
+}
+
 extern (C++, std)
 {
     struct vector(T, A = allocator!T) { }
 
-    struct allocator(T) { }
+    struct allocator(T)
+    {
+	version (linux)
+	{
+	    alias size_type = size_t;
+	    void deallocate(T* p, size_type sz)
+	    {   (cast(__gnu_cxx.new_allocator!T*)&this).deallocate(p, sz); }
+	}
+    }
 }
 
 extern (C++)
@@ -405,6 +425,14 @@ void test14()
         foo14(p);
     version (FreeBSD)
         foo14(p);
+}
+
+version (linux)
+{
+    void test14a(std.allocator!int * pa)
+    {
+	pa.deallocate(null, 0);
+    }
 }
 
 /****************************************/

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -282,6 +282,18 @@ size_t getoffset13161a()
 
 #if __linux__ || __APPLE__ || __FreeBSD__
 #include <vector>
+
+#if __linux__
+template struct std::allocator<int>;
+
+void foo15()
+{
+    std::allocator<int>* p;
+    p->deallocate(0, 0);
+}
+#endif
+
 // _Z5foo14PSt6vectorIiSaIiEE
 void foo14(std::vector<int, std::allocator<int> > *p) { }
+
 #endif


### PR DESCRIPTION
This makes calling std::allocator.deallocator() work.

Interfacing with C++ templates is never going to be pretty, but it seems we can make it work.
