### PR TITLE
Issue 11312 - Avoid auto-dereference for UFCS functions

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -7303,12 +7303,21 @@ Expression *DotIdExp::semanticY(Scope *sc, int flag)
              ident != Id::init && ident != Id::__sizeof &&
              ident != Id::__xalignof && ident != Id::offsetof &&
              ident != Id::mangleof && ident != Id::stringof)
-    {   /* Rewrite:
+    {
+        Type *t1bn = t1b->nextOf();
+        if (flag)
+        {
+            AggregateDeclaration *ad = isAggregate(t1bn);
+            if (ad && !ad->members)   // Bugzilla 11312
+                return NULL;
+        }
+
+        /* Rewrite:
          *   p.ident
          * as:
          *   (*p).ident
          */
-        if (flag && t1b->nextOf()->ty == Tvoid)
+        if (flag && t1bn->ty == Tvoid)
             return NULL;
         e = new PtrExp(loc, e1);
         e = e->semantic(sc);

--- a/test/runnable/ufcs.d
+++ b/test/runnable/ufcs.d
@@ -795,6 +795,21 @@ void test10609()
 }
 
 /*******************************************/
+// 11312
+
+struct S11312;
+
+S11312* getS11312() { return null; }
+int getValue(S11312*) { return 10; }
+
+void test11312()
+{
+    S11312* op = getS11312();
+    int x = op.getValue();
+    assert(x == 10);
+}
+
+/*******************************************/
 
 int main()
 {
@@ -823,6 +838,7 @@ int main()
     test10041();
     test10047();
     test10526();
+    test11312();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=11312
