### PR TITLE
[REG2.065] Issue 13311 - ICE, CtorDeclaration::semantic(Scope*): Assertion `tf && tf->ty == Tfunction' failed

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -4313,9 +4313,6 @@ Dsymbol *CtorDeclaration::syntaxCopy(Dsymbol *s)
 void CtorDeclaration::semantic(Scope *sc)
 {
     //printf("CtorDeclaration::semantic() %s\n", toChars());
-    TypeFunction *tf = (TypeFunction *)type;
-    assert(tf && tf->ty == Tfunction);
-
     if (scope)
     {
         sc = scope;
@@ -4330,6 +4327,12 @@ void CtorDeclaration::semantic(Scope *sc)
 
     sc->pop();
 
+    if (errors)
+        return;
+
+    TypeFunction *tf = (TypeFunction *)type;
+    assert(tf && tf->ty == Tfunction);
+
     Dsymbol *parent = toParent2();
     AggregateDeclaration *ad = parent->isAggregateDeclaration();
 
@@ -4343,7 +4346,8 @@ void CtorDeclaration::semantic(Scope *sc)
         if (sd)
         {
             if (fbody || !(storage_class & STCdisable))
-            {   error("default constructor for structs only allowed with @disable and no body");
+            {
+                error("default constructor for structs only allowed with @disable and no body");
                 storage_class |= STCdisable;
                 fbody = NULL;
             }

--- a/test/fail_compilation/ice13311.d
+++ b/test/fail_compilation/ice13311.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/imports/a13311.d(8): Error: undefined identifier PieceTree
+---
+*/
+module ice13311;
+
+struct TextPiece
+{
+    import imports.a13311;
+}

--- a/test/fail_compilation/imports/a13311.d
+++ b/test/fail_compilation/imports/a13311.d
@@ -1,0 +1,9 @@
+module imports.a13311;
+
+import ice13311;
+
+class Z
+{
+    TextPiece piece;
+    this(PieceTree owner) {}
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13311
