### PR TITLE
[new AA] aaLiteral support

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1993,6 +1993,7 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                     (*ae->keys)[i] = ex;
                 }
                 ae->type = t;
+                ae = ae->aaLiteralCreate(sc);
                 result = ae;
                 return;
             }

--- a/src/expression.c
+++ b/src/expression.c
@@ -4148,10 +4148,7 @@ Expression *AssocArrayLiteralExp::semantic(Scope *sc)
 #endif
     assert(sc);
     if (type)
-    {
-        aaLiteralCreate(sc);
         return this;
-    }
 
     // Run semantic() on each element
     bool err_keys = arrayExpressionSemantic(keys, sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -4137,7 +4137,7 @@ Expression *AssocArrayLiteralExp::syntaxCopy()
 {
     AssocArrayLiteralExp* ret = new AssocArrayLiteralExp(loc, arraySyntaxCopy(keys),
                                                          arraySyntaxCopy(values));
-    ret->init = init;
+    ret->init = init ? init->syntaxCopy() : NULL;
     return ret;
 }
 
@@ -4148,7 +4148,13 @@ Expression *AssocArrayLiteralExp::semantic(Scope *sc)
 #endif
     assert(sc);
     if (type)
+    {
+        // type has been setted somewhere (inside interpreter, for example),
+        // but AssocArrayLiteralExp::semantic has not been called yet.
+        if (!init)
+            aaLiteralCreate(sc);
         return this;
+    }
 
     // Run semantic() on each element
     bool err_keys = arrayExpressionSemantic(keys, sc);

--- a/src/expression.h
+++ b/src/expression.h
@@ -442,12 +442,15 @@ public:
     Expressions *keys;
     Expressions *values;
     bool ownedByCtfe;   // true = created in CTFE
+    Expression *init;
 
     AssocArrayLiteralExp(Loc loc, Expressions *keys, Expressions *values);
     bool equals(RootObject *o);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     int isBool(int result);
+
+    AssocArrayLiteralExp *aaLiteralCreate(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -65,6 +65,7 @@ Msgtable msgtable[] =
     { "outer" },
     { "Exception" },
     { "RTInfo" },
+    { "aaLiteral" },
     { "Throwable" },
     { "Error" },
     { "withSym", "__withSym" },

--- a/src/inline.c
+++ b/src/inline.c
@@ -1023,6 +1023,8 @@ Expression *doInline(Expression *e, InlineDoState *ids)
         {
             AssocArrayLiteralExp *ce = (AssocArrayLiteralExp *)e->copy();
 
+            assert(ce->init);
+            ce->init = doInline(ce->init, ids);
             ce->keys = arrayExpressiondoInline(e->keys);
             ce->values = arrayExpressiondoInline(e->values);
             result = ce;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2879,6 +2879,7 @@ public:
             ae = new AssocArrayLiteralExp(e->loc, keysx, valuesx);
             ae->type = e->type;
             ae->ownedByCtfe = true;
+            ae->init = e->init;
             result = ae;
             return;
         }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -2879,7 +2879,6 @@ public:
             ae = new AssocArrayLiteralExp(e->loc, keysx, valuesx);
             ae->type = e->type;
             ae->ownedByCtfe = true;
-            ae->init = e->init;
             result = ae;
             return;
         }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -75,6 +75,7 @@ ClassDeclaration *Type::typeinfoshared;
 ClassDeclaration *Type::typeinfowild;
 
 TemplateDeclaration *Type::rtinfo;
+TemplateDeclaration *Type::aaLiteral;
 
 Type *Type::tvoid;
 Type *Type::tint8;
@@ -4453,6 +4454,7 @@ TypeAArray::TypeAArray(Type *t, Type *index)
     this->index = index;
     this->loc = Loc();
     this->sc = NULL;
+    this->aanew = NULL;
 }
 
 TypeAArray *TypeAArray::create(Type *t, Type *index)
@@ -4475,6 +4477,8 @@ Type *TypeAArray::syntaxCopy()
     {
         t = new TypeAArray(t, ti);
         t->mod = mod;
+        ((TypeAArray *)t)->aanew = aanew;
+        ((TypeAArray *)t)->sc = sc;
     }
     return t;
 }
@@ -4482,6 +4486,92 @@ Type *TypeAArray::syntaxCopy()
 d_uns64 TypeAArray::size(Loc loc)
 {
     return Target::ptrsize;
+}
+
+void aaNewCreate(Type *t, Scope *sc)
+{
+    if (!Type::aaLiteral)
+    {
+        ObjectNotFound(Id::aaLiteral);
+        assert(0);
+    }
+
+    class AANewVisitor : public Visitor
+    {
+        Scope *sc;
+    public:
+        AANewVisitor(Scope *sc)
+        {
+            this->sc = sc;
+        }
+
+        void visit(Type *t)
+        {
+        }
+
+        void visit(TypeNext *n)
+        {
+            n->next->accept(this);
+        }
+
+        void visit(TypeEnum *e)
+        {
+            if (e->sym->isforwardRef())
+                return;
+            e->toBasetype()->accept(this);
+        }
+
+        void visit(TypeAArray *aa)
+        {
+            if (!aa->aanew && aa->next->ty != Terror && aa->index->ty != Terror)
+            {
+                Scope *sc2 = sc;
+                assert(aa->sc);
+                if (sc2 && !sc2->module->isRoot() && (!sc2->tinst || !sc2->tinst->needsCodegen()))
+                    return;
+
+                if (!sc2)
+                {
+                    sc2 = aa->sc->copy();
+                    sc2->tinst = NULL;
+                    sc2->minst = Module::rootModule;
+                }
+
+                assert(aa->deco);
+                Objects *tiargs = new Objects();
+                Type *tkey = aa->index;
+                Type *tvalue = aa->next;
+
+                if ((tkey->ty == Tclass || tkey->ty == Tstruct || tkey->ty == Tenum) &&
+                    tkey->toDsymbol(NULL)->isforwardRef())
+                    return;
+
+                if ((tvalue->ty == Tclass || tvalue->ty == Tstruct || tvalue->ty == Tenum) &&
+                    tvalue->toDsymbol(NULL)->isforwardRef())
+                    return;
+
+                tiargs->push(tkey);
+                tiargs->push(tvalue);
+                assert(tkey && tkey->deco);
+                assert(tvalue && tvalue->deco);
+
+                FuncDeclaration *aanewfunc = resolveFuncCall(aa->loc, sc2, Type::aaLiteral, tiargs, NULL, NULL);
+                assert(aanewfunc);
+                if (!aanewfunc->isInstantiated()->needsCodegen())
+                    return;
+
+                aa->aanew = new SymOffExp(aa->loc, aanewfunc, 0);
+                aa->aanew = aa->aanew->semantic(sc2);
+                aa->aanew = aa->aanew->optimize(WANTvalue);
+
+                aa->index->accept(this);
+                aa->next->accept(this);
+            }
+        }
+    };
+
+    AANewVisitor v(sc);
+    t->accept(&v);
 }
 
 Type *TypeAArray::semantic(Loc loc, Scope *sc)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -50,6 +50,7 @@ void semanticTypeInfo(Scope *sc, Type *t);
 MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL, size_t inferStart = 0);
 Type *reliesOnTident(Type *t, TemplateParameters *tparams = NULL, size_t iStart = 0);
 StorageClass ModToStc(unsigned mod);
+void aaNewCreate(Type *t, Scope *sc);
 
 enum ENUMTY
 {
@@ -215,6 +216,7 @@ public:
     static ClassDeclaration *typeinfowild;
 
     static TemplateDeclaration *rtinfo;
+    static TemplateDeclaration *aaLiteral;
 
     static Type *basic[TMAX];
     static unsigned char sizeTy[TMAX];
@@ -520,6 +522,7 @@ public:
     Type *index;                // key type
     Loc loc;
     Scope *sc;
+    Expression *aanew;
 
     TypeAArray(Type *t, Type *index);
     static TypeAArray *create(Type *t, Type *index);

--- a/src/template.c
+++ b/src/template.c
@@ -498,6 +498,8 @@ void TemplateDeclaration::semantic(Scope *sc)
     {
         if (ident == Id::RTInfo)
             Type::rtinfo = this;
+        else if (ident == Id::aaLiteral)
+            Type::aaLiteral = this;
     }
 
     if (Module *m = sc->module) // should use getModule() instead?


### PR DESCRIPTION
This PR depends on D-Programming-Language/druntime#933
This PR based on #3892, however in use zero AA init value.
I think, this way more pretty and safe.
New AA implemetation use template `object.aaLiteral` function to create AA.
This implemetation allows to return AA literals from CTFE, if `object.aaLiteral` can be evaluated at compile time. New aa implementation (D-Programming-Language/druntime#934) allow creating instances of AA at compile time (of cource, if hashes is CTFEable, and elements are eveluatable at compile time).
Template-based way implementation prevent using TypeInfo-based code, thus we need to know static Key and Value types to create AA instance.
As I said, this AA implementation doesn't use special initializer and empty AA like `int[int] aa;` doesn't know his static type.
When we try to insert value in AA, compiler generates call of a special function : `aaGetX` and if it takes `null` AA, it can't create new AA instance without auxilarity function.
Thus when compiler does it, it passes pointer to `aaLiteral(Key, Value)` (without arguments) to `aaGetX` and `aaGetX` can use this function to initialize empty AA.
