### PR TITLE
[Refactoring] around protection code fixed in the PR #3651

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -541,11 +541,11 @@ char *LinkDeclaration::toChars()
 /********************************* ProtDeclaration ****************************/
 
 /**
-* Params:
-*  loc = source location of attribute token
-*  p = protection attribute data
-*  decl = declarations which are affected by this protection attribute
-*/
+ * Params:
+ *  loc = source location of attribute token
+ *  p = protection attribute data
+ *  decl = declarations which are affected by this protection attribute
+ */
 ProtDeclaration::ProtDeclaration(Loc loc, Prot p, Dsymbols *decl)
         : AttribDeclaration(decl)
 {
@@ -556,11 +556,11 @@ ProtDeclaration::ProtDeclaration(Loc loc, Prot p, Dsymbols *decl)
 }
 
 /**
-* Params:
-*  loc = source location of attribute token
-*  pkg_identifiers = list of identifiers for a qualified package name
-*  decl = declarations which are affected by this protection attribute
-*/
+ * Params:
+ *  loc = source location of attribute token
+ *  pkg_identifiers = list of identifiers for a qualified package name
+ *  decl = declarations which are affected by this protection attribute
+ */
 ProtDeclaration::ProtDeclaration(Loc loc, Identifiers* pkg_identifiers, Dsymbols *decl)
         : AttribDeclaration(decl)
 {
@@ -574,9 +574,9 @@ Dsymbol *ProtDeclaration::syntaxCopy(Dsymbol *s)
 {
     assert(!s);
     if (protection.kind == PROTpackage)
-    	return new ProtDeclaration(this->loc, pkg_identifiers, Dsymbol::arraySyntaxCopy(decl));
+        return new ProtDeclaration(this->loc, pkg_identifiers, Dsymbol::arraySyntaxCopy(decl));
     else
-    	return new ProtDeclaration(this->loc, protection, Dsymbol::arraySyntaxCopy(decl));
+        return new ProtDeclaration(this->loc, protection, Dsymbol::arraySyntaxCopy(decl));
 }
 
 Scope *ProtDeclaration::newScope(Scope *sc)
@@ -598,23 +598,22 @@ void ProtDeclaration::semantic(Scope* sc)
 
     AttribDeclaration::semantic(sc);
 
-    if ((protection.kind == PROTpackage) && (protection.pkg != NULL) && sc->module)
+    if (protection.kind == PROTpackage && protection.pkg && sc->module)
     {
         Module *m = sc->module;
-        Package* pkg =  m->parent ? m->parent->isPackage() : NULL;
+        Package* pkg = m->parent ? m->parent->isPackage() : NULL;
         if (!pkg || !protection.pkg->isAncestorPackageOf(pkg))
             error("does not bind to one of ancestor packages of module '%s'",
                m->toPrettyChars(true));
     }
 }
 
-
 const char *ProtDeclaration::kind()
 {
     return "protection attribute";
 }
 
-const char *ProtDeclaration::toPrettyChars(bool unused)
+const char *ProtDeclaration::toPrettyChars(bool)
 {
     assert(protection.kind > PROTundefined);
 
@@ -622,7 +621,7 @@ const char *ProtDeclaration::toPrettyChars(bool unused)
 
     OutBuffer buffer;
 
-    if ((protection.kind == PROTpackage) && protection.pkg)
+    if (protection.kind == PROTpackage && protection.pkg)
     {
         // 'package(name)'
         const char* name = protection.pkg->toPrettyChars(true);

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -617,29 +617,11 @@ const char *ProtDeclaration::toPrettyChars(bool)
 {
     assert(protection.kind > PROTundefined);
 
-    const char* kind = protectionToChars(this->protection);
-
-    OutBuffer buffer;
-
-    if (protection.kind == PROTpackage && protection.pkg)
-    {
-        // 'package(name)'
-        const char* name = protection.pkg->toPrettyChars(true);
-        buffer.writestring("'");
-        buffer.writestring(kind);
-        buffer.writestring("(");
-        buffer.writestring(name);
-        buffer.writestring(")'");
-        return buffer.extractString();
-    }
-    else
-    {
-        // 'attrkind'
-        buffer.writestring("'");
-        buffer.writestring(kind);
-        buffer.writestring("'");
-        return buffer.extractString();
-    }
+    OutBuffer buf;
+    buf.writeByte('\'');
+    protectionToBuffer(&buf, protection);
+    buf.writeByte('\'');
+    return buf.extractString();
 }
 
 /********************************* AlignDeclaration ****************************/

--- a/src/doc.c
+++ b/src/doc.c
@@ -715,9 +715,11 @@ void emitMemberComments(ScopeDsymbol *sds, Scope *sc)
 
 void emitProtection(OutBuffer *buf, Prot prot)
 {
-    const char *p = (prot.kind == PROTpublic) ? NULL : protectionToChars(prot);
-    if (p)
-        buf->printf("%s ", p);
+    if (prot.kind != PROTundefined && prot.kind != PROTpublic)
+    {
+        protectionToBuffer(buf, prot);
+        buf->writeByte(' ');
+    }
 }
 
 void emitComment(Dsymbol *s, Scope *sc)

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1028,10 +1028,9 @@ OverloadSet *ScopeDsymbol::mergeOverloadSet(OverloadSet *os, Dsymbol *s)
             Dsymbol *s2 = os->a[j];
             if (s->toAlias() == s2->toAlias())
             {
-
                 if (s2->isDeprecated() ||
                     (s2->prot().isMoreRestrictiveThan(s->prot()) &&
-                        s->prot().kind != PROTnone))
+                     s->prot().kind != PROTnone))
                 {
                     os->a[j] = s;
                 }
@@ -1555,12 +1554,18 @@ Prot::Prot(PROTKIND kind)
     this->pkg = NULL;
 }
 
-
+/**
+ * Checks if `this` is superset of `other` restrictions.
+ * For example, "protected" is more restrictive than "public".
+ */
 bool Prot::isMoreRestrictiveThan(Prot other)
 {
     return this->kind < other.kind;
 }
 
+/**
+ * Checks if `this` is absolutely identical protection attribute to `other`
+ */
 bool Prot::operator==(Prot other)
 {
     if (this->kind == other.kind)
@@ -1572,6 +1577,16 @@ bool Prot::operator==(Prot other)
     return false;
 }
 
+/**
+ * Checks if parent defines different access restrictions than this one.
+ *
+ * Params:
+ *  parent = protection attribute for scope that hosts this one
+ *
+ * Returns:
+ *  'true' if parent is already more restrictive than this one and thus
+ *  no differentiation is needed.
+ */
 bool Prot::isSubsetOf(Prot parent)
 {
     if (this->kind != parent.kind)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -106,29 +106,12 @@ enum PROTKIND
 struct Prot
 {
     PROTKIND kind;
-    Package* pkg;
+    Package *pkg;
 
     Prot(PROTKIND kind = PROTundefined);
 
-    /**
-     * Checks if `this` is superset of `other` restrictions.
-     * For example, "protected" is more restrictive than "public".
-     */
     bool isMoreRestrictiveThan(Prot other);
-    /**
-     * Checks if `this` is absolutely identical protection attribute to `other`
-     */
     bool operator==(Prot other);
-    /**
-     * Checks if parent defines different access restrictions than this one.
-     *
-     * Params:
-     *  parent = protection attribute for scope that hosts this one
-     *
-     * Returns:
-     *  'true' if parent is already more restrictive than this one and thus
-     *  no differentiation is needed.
-     */
     bool isSubsetOf(Prot other);
 };
 
@@ -171,7 +154,7 @@ public:
     Dsymbol *parent;
     Symbol *csym;               // symbol for code generator
     Symbol *isym;               // import version of csym
-    const utf8_t *comment;     // documentation comment for this Dsymbol
+    const utf8_t *comment;      // documentation comment for this Dsymbol
     Loc loc;                    // where defined
     Scope *scope;               // !=NULL means context to use for semantic()
     bool errors;                // this symbol failed to pass semantic()

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -117,7 +117,7 @@ struct Prot
 
 // in hdrgen.c
 void protectionToBuffer(OutBuffer *buf, Prot prot);
-const char *protectionToChars(Prot prot);
+const char *protectionToChars(PROTKIND kind);
 
 /* State of symbol in winding its way through the passes of the compiler
  */

--- a/src/func.c
+++ b/src/func.c
@@ -608,7 +608,7 @@ void FuncDeclaration::semantic(Scope *sc)
         if (isStatic())
             sfunc = "static";
         else if (protection.kind == PROTprivate || protection.kind == PROTpackage)
-            sfunc = protectionToChars(protection);
+            sfunc = protectionToChars(protection.kind);
         else
             sfunc = "non-virtual";
         error("%s functions cannot be abstract", sfunc);
@@ -616,8 +616,9 @@ void FuncDeclaration::semantic(Scope *sc)
 
     if (isOverride() && !isVirtual())
     {
-        if ((prot().kind == PROTprivate || prot().kind == PROTpackage) && isMember())
-            error("%s method is not virtual and cannot override", protectionToChars(prot()));
+        PROTKIND kind = prot().kind;
+        if ((kind == PROTprivate || kind == PROTpackage) && isMember())
+            error("%s method is not virtual and cannot override", protectionToChars(kind));
         else
             error("cannot override a non-virtual function");
     }

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -3005,7 +3005,6 @@ const char *linkageToChars(LINK linkage)
 void protectionToBuffer(OutBuffer *buf, Prot prot)
 {
     const char *p = protectionToChars(prot);
-
     if (p)
         buf->writestring(p);
 
@@ -3013,18 +3012,15 @@ void protectionToBuffer(OutBuffer *buf, Prot prot)
     {
         Package *ppkg = prot.pkg;
 
-        if (ppkg)
+        buf->writeByte('(');
+        while (ppkg)
         {
-            buf->writeByte('(');
-            while (ppkg)
-            {
-                buf->writestring(ppkg->ident->string);
-                ppkg = ppkg->parent ? ppkg->parent->isPackage() : NULL;
-                if (ppkg)
-                    buf->writeByte('.');
-            }
-            buf->writeByte(')');
+            buf->writestring(ppkg->ident->string);
+            ppkg = ppkg->parent ? ppkg->parent->isPackage() : NULL;
+            if (ppkg)
+                buf->writeByte('.');
         }
+        buf->writeByte(')');
     }
 }
 

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -3013,13 +3013,7 @@ void protectionToBuffer(OutBuffer *buf, Prot prot)
         Package *ppkg = prot.pkg;
 
         buf->writeByte('(');
-        while (ppkg)
-        {
-            buf->writestring(ppkg->ident->string);
-            ppkg = ppkg->parent ? ppkg->parent->isPackage() : NULL;
-            if (ppkg)
-                buf->writeByte('.');
-        }
+        buf->writestring(prot.pkg->toPrettyChars(true));
         buf->writeByte(')');
     }
 }

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -3004,7 +3004,7 @@ const char *linkageToChars(LINK linkage)
 
 void protectionToBuffer(OutBuffer *buf, Prot prot)
 {
-    const char *p = protectionToChars(prot);
+    const char *p = protectionToChars(prot.kind);
     if (p)
         buf->writestring(p);
 
@@ -3024,9 +3024,9 @@ void protectionToBuffer(OutBuffer *buf, Prot prot)
     }
 }
 
-const char *protectionToChars(Prot prot)
+const char *protectionToChars(PROTKIND kind)
 {
-    switch (prot.kind)
+    switch (kind)
     {
         case PROTundefined: return NULL;
         case PROTnone:      return "none";

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -3009,9 +3009,9 @@ void protectionToBuffer(OutBuffer *buf, Prot prot)
     if (p)
         buf->writestring(p);
 
-    if ((prot.kind == PROTpackage) && (prot.pkg))
+    if (prot.kind == PROTpackage && prot.pkg)
     {
-        Package* ppkg = prot.pkg;
+        Package *ppkg = prot.pkg;
 
         if (ppkg)
         {

--- a/src/json.c
+++ b/src/json.c
@@ -450,8 +450,8 @@ public:
             property("kind", s->kind());
         }
 
-        if (s->prot().kind != PROTpublic)
-            property("protection", protectionToChars(s->prot()));
+        if (s->prot().kind != PROTpublic)   // TODO: How about package(names)?
+            property("protection", protectionToChars(s->prot().kind));
 
         if (EnumMember *em = s->isEnumMember())
         {
@@ -557,7 +557,7 @@ public:
         property("comment", (const char *)s->comment);
         property("line", "char", &s->loc);
         if (s->prot().kind != PROTpublic)
-            property("protection", protectionToChars(s->prot()));
+            property("protection", protectionToChars(s->prot().kind));
         if (s->aliasId)
             property("alias", s->aliasId->toChars());
 

--- a/src/module.c
+++ b/src/module.c
@@ -1077,18 +1077,18 @@ Module *Package::isPackageMod()
  */
 bool Package::isAncestorPackageOf(Package* pkg)
 {
-   while (pkg)
-   {
-       if (this == pkg)
-           return true;
+    while (pkg)
+    {
+        if (this == pkg)
+            return true;
 
-       if (!pkg->parent)
-           break;
+        if (!pkg->parent)
+            break;
 
-       pkg = pkg->parent->isPackage();
-   }
+        pkg = pkg->parent->isPackage();
+    }
 
-   return false;
+    return false;
 }
 
 /****************************************************

--- a/src/module.h
+++ b/src/module.h
@@ -53,7 +53,7 @@ public:
 
     Package *isPackage() { return this; }
 
-    bool isAncestorPackageOf(Package* pkg);
+    bool isAncestorPackageOf(Package *pkg);
 
     void semantic(Scope *sc) { }
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);

--- a/src/parse.c
+++ b/src/parse.c
@@ -242,7 +242,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
             pAttrs->comment = token.blockComment;
         }
         PROTKIND prot;
-        Identifiers* pkg_prot_idents = NULL;
+        Identifiers *pkg_prot_idents = NULL;
         StorageClass stc;
         Condition *condition;
 
@@ -690,12 +690,12 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                     {
                         // optional qualified package identifier to bind
                         // protection to
-                        if ((pAttrs->protection.kind == PROTpackage) && (token.value == TOKlparen))
+                        if (pAttrs->protection.kind == PROTpackage && token.value == TOKlparen)
                         {
                             pkg_prot_idents = parseQualifiedIdentifier("protection package");
 
                             if (pkg_prot_idents)
-                            	check(TOKrparen);
+                                check(TOKrparen);
                             else
                             {
                                 while (token.value != TOKsemicolon && token.value != TOKeof)
@@ -710,7 +710,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                     a = parseBlock(pLastDecl, pAttrs);
                     if (pAttrs->protection.kind != PROTundefined)
                     {
-                        if ((pAttrs->protection.kind == PROTpackage) && pkg_prot_idents)
+                        if (pAttrs->protection.kind == PROTpackage && pkg_prot_idents)
                             s = new ProtDeclaration(attrloc, pkg_prot_idents,  a);
                         else
                             s = new ProtDeclaration(attrloc, pAttrs->protection, a);
@@ -1263,22 +1263,17 @@ LINK Parser::parseLinkage(Identifiers **pidents)
  * Returns:
  *     array of identifiers with actual qualified one stored last
  */
-Identifiers* Parser::parseQualifiedIdentifier(const char* entity)
+Identifiers *Parser::parseQualifiedIdentifier(const char *entity)
 {
     Identifiers *qualified = new Identifiers();
 
     do
     {
         nextToken();
-
         if (token.value != TOKidentifier)
         {
-            error(
-                "%s expected as dot-separated identifiers, got '%s'",
-                entity,
-                token.toChars()
-            );
-
+            error("%s expected as dot-separated identifiers, got '%s'",
+                    entity, token.toChars());
             return NULL;
         }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -93,7 +93,7 @@ public:
     TypeQualified *parseTypeof();
     Type *parseVector();
     LINK parseLinkage(Identifiers **);
-    Identifiers* parseQualifiedIdentifier(const char* entity);
+    Identifiers *parseQualifiedIdentifier(const char *entity);
     Condition *parseDebugCondition();
     Condition *parseVersionCondition();
     Condition *parseStaticIfCondition();

--- a/src/template.c
+++ b/src/template.c
@@ -2141,7 +2141,7 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
             if (tf->equals(m->lastf->type) &&
                 fd->storage_class == m->lastf->storage_class &&
                 fd->parent == m->lastf->parent &&
-                (fd->protection == m->lastf->protection) &&
+                fd->protection == m->lastf->protection &&
                 fd->linkage == m->lastf->linkage)
             {
                 if ( fd->fbody && !m->lastf->fbody) goto LfIsBetter;

--- a/src/traits.c
+++ b/src/traits.c
@@ -512,7 +512,7 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
         if (s->scope)
             s->semantic(s->scope);
 
-        const char *protName = protectionToChars(s->prot());
+        const char *protName = protectionToChars(s->prot().kind);   // TODO: How about package(names)
         assert(protName);
         StringExp *se = new StringExp(e->loc, (char *) protName);
         return se->semantic(sc);


### PR DESCRIPTION
Tweak code style, slim up code logic, and a trivial bug fix.

@Dicebot I found two questions while refactoring.
1. How `__traite(getProtection)` should print the new protection `package(names)`?
2. How should the JSON property `protection` print `package(names)`?
