### PR TITLE
[enh] Issue 12567 - Modules can't be marked as deprecated

### DIFF
--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -62,6 +62,17 @@ void genhdrfile(Module *m)
 
     if (m->md)
     {
+        if (m->md->isdeprecated)
+        {
+            if (m->md->msg)
+            {
+                buf.writestring("deprecated(");
+                toCBuffer(m->md->msg, &buf, &hgs);
+                buf.writestring(") ");
+            }
+            else
+                buf.writestring("deprecated ");
+        }
         buf.writestring("module ");
         buf.writestring(m->md->toChars());
         buf.writeByte(';');

--- a/src/import.c
+++ b/src/import.c
@@ -189,6 +189,15 @@ void Import::importAll(Scope *sc)
         load(sc);
         if (mod)                // if successfully loaded module
         {
+            if (mod->md && mod->md->isdeprecated)
+            {
+                Expression *msg = mod->md->msg;
+                if (StringExp *se = msg ? msg->toStringExp() : NULL)
+                    mod->deprecation(loc, "is deprecated - %s", se->string);
+                else
+                    mod->deprecation(loc, "is deprecated");
+            }
+
             mod->importAll(NULL);
 
             if (!isstatic && !aliasId && !names.dim)

--- a/src/module.c
+++ b/src/module.c
@@ -21,6 +21,7 @@
 #include "id.h"
 #include "import.h"
 #include "dsymbol.h"
+#include "expression.h"
 #include "lexer.h"
 
 #ifdef IN_GCC
@@ -637,6 +638,14 @@ void Module::importAll(Scope *prevsc)
         return;
     }
 
+    if (md && md->msg)
+    {
+        if (StringExp *se = md->msg->toStringExp())
+            md->msg = se;
+        else
+            md->msg->error("string expected, not '%s'", md->msg->toChars());
+    }
+
     /* Note that modules get their own scope, from scratch.
      * This is so regardless of where in the syntax a module
      * gets imported, it is unaffected by context.
@@ -1008,6 +1017,8 @@ ModuleDeclaration::ModuleDeclaration(Loc loc, Identifiers *packages, Identifier 
     this->packages = packages;
     this->id = id;
     this->safe = safe;
+    this->isdeprecated = false;
+    this->msg = NULL;
 }
 
 char *ModuleDeclaration::toChars()

--- a/src/module.h
+++ b/src/module.h
@@ -187,6 +187,8 @@ struct ModuleDeclaration
     Identifier *id;
     Identifiers *packages;            // array of Identifier's representing packages
     bool safe;
+    bool isdeprecated;  // if it is a deprecated module
+    Expression *msg;
 
     ModuleDeclaration(Loc loc, Identifiers *packages, Identifier *id, bool safe);
 

--- a/test/compilable/extra-files/header12567a.di
+++ b/test/compilable/extra-files/header12567a.di
@@ -1,0 +1,2 @@
+deprecated module header12567a;
+void main();

--- a/test/compilable/extra-files/header12567b.di
+++ b/test/compilable/extra-files/header12567b.di
@@ -1,0 +1,2 @@
+deprecated("message") module header12567b;
+void main();

--- a/test/compilable/imports/a12567.d
+++ b/test/compilable/imports/a12567.d
@@ -1,0 +1,4 @@
+deprecated("This module will be removed in future release.")
+module imports.a12567;
+
+void foo() {}

--- a/test/compilable/test12567a.d
+++ b/test/compilable/test12567a.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+---
+*/
+deprecated
+module test12567a;
+
+void main() {}

--- a/test/compilable/test12567b.d
+++ b/test/compilable/test12567b.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+---
+*/
+deprecated("message")
+module test12567b;
+
+void main() {}

--- a/test/compilable/test12567c.d
+++ b/test/compilable/test12567c.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+compilable/test12567c.d(9): Deprecation: module imports.a12567 is deprecated - This module will be removed in future release.
+---
+*/
+import imports.a12567;
+
+void main() { foo(); }

--- a/test/compilable/test12567d.d
+++ b/test/compilable/test12567d.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -d
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+---
+*/
+import imports.a12567;
+
+void main() { foo(); }

--- a/test/compilable/testheader12567a.d
+++ b/test/compilable/testheader12567a.d
@@ -1,0 +1,7 @@
+// REQUIRED_ARGS: -o- -H -Hf${RESULTS_DIR}/compilable/header12567a.di
+// PERMUTE_ARGS:
+// POST_SCRIPT: compilable/extra-files/header-postscript.sh header12567a
+
+deprecated module header12567a;
+
+void main() {}

--- a/test/compilable/testheader12567b.d
+++ b/test/compilable/testheader12567b.d
@@ -1,0 +1,7 @@
+// REQUIRED_ARGS: -o- -H -Hf${RESULTS_DIR}/compilable/header12567b.di
+// PERMUTE_ARGS:
+// POST_SCRIPT: compilable/extra-files/header-postscript.sh header12567b
+
+deprecated("message") module header12567b;
+
+void main() {}

--- a/test/fail_compilation/fail12567.d
+++ b/test/fail_compilation/fail12567.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12567.d(8): Error: string expected, not '"a" ~ "b"'
+---
+*/
+deprecated("a" ~ "b") module fail12567;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12567

Points:
1. Compiler checks the deprecation when the module is imported.
   
   ``` d
   deprecated("std.regexp is deprecated. Please use std.regex instead.")
   module std.regexp
   ```
   
   ``` d
   module test;
   import std.regexp;  // This line will report the message
   ```
2. `ModuleDeclaraion` is necessary if you want to make the module deprecated.
3. Deprecating a module does not deprecate its members automatically.
   
   It's useful if you want to merely rename modules.
   
   ``` d
   deprecated("std.regexp is renamed to std.regex.")
   module std.regexp;
   /* All members are not implicitly marked as deprecated */
   ```
   
   ``` d
   module std.regex;
   /* Exactly same contents with in std.regexp. */
   ```
