### PR TITLE
Issue 5299 - Turn base class protection into an error

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2172,7 +2172,7 @@ BaseClasses *Parser::parseBaseClasses()
             default: break;
         }
         if (prot)
-            deprecation("use of base class protection is deprecated");
+            error("use of base class protection is no longer supported");
         BaseClass *b = new BaseClass(parseBasicType(), protection);
         baseclasses->push(b);
         if (token.value != TOKcomma)

--- a/test/fail_compilation/fail5299.d
+++ b/test/fail_compilation/fail5299.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail5299.d(12): Error: use of base class protection is no longer supported
+---
+*/
+
+class A
+{
+}
+
+class B : private A
+{
+}


### PR DESCRIPTION
It was deprecated over two years ago.

https://issues.dlang.org/show_bug.cgi?id=5299
