### PR TITLE
Issue 3990 - Deferencing a dynamic array as pointer

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9185,7 +9185,7 @@ Expression *PtrExp::semantic(Scope *sc)
 
         case Tsarray:
         case Tarray:
-            deprecation("using * on an array is deprecated; use *(%s).ptr instead", e1->toChars());
+            error("using * on an array is no longer supported; use *(%s).ptr instead", e1->toChars());
             type = ((TypeArray *)tb)->next;
             e1 = e1->castTo(sc, type->pointerTo());
             break;

--- a/test/fail_compilation/fail3990.d
+++ b/test/fail_compilation/fail3990.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail3990.d(12): Error: using * on an array is no longer supported; use *(arr1).ptr instead
+fail_compilation/fail3990.d(14): Error: using * on an array is no longer supported; use *(arr2).ptr instead
+---
+*/
+
+void main()
+{
+    int[] arr1 = [1, 2, 3];
+    assert(*arr1 == 1);
+    int[3] arr2 = [1, 2, 3];
+    assert(*arr2 == 1);
+}

--- a/test/runnable/deprecate1.d
+++ b/test/runnable/deprecate1.d
@@ -1225,22 +1225,6 @@ void test4237()
 }
 
 /******************************************/
-// 3990
-
-void test3990()
-{
-    int[] a1 = [5, 4, 3];
-    assert(*a1 == 5);
-    alias typeof(a1) T1;
-    assert(is(typeof(*T1)));
-
-    int[3] a2 = [5, 4, 3];
-    assert(*a2 == 5);
-    alias typeof(a2) T2;
-    assert(is(typeof(*T2)));
-}
-
-/******************************************/
 // from extra-files/test2.d
 
 typedef void* HANDLE18;
@@ -1311,7 +1295,6 @@ int main()
     test23_test67();
     test34_test14();
     test34_test52();
-    test3990();
     test6289();
     test4237();
     test18();


### PR DESCRIPTION
It was deprecated almost 3 years ago.

https://issues.dlang.org/show_bug.cgi?id=3990
