### PR TITLE
Remove special handling of `delete aa[key]`.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9480,26 +9480,8 @@ Expression *DeleteExp::semantic(Scope *sc)
             break;
         }
         default:
-            if (e1->op == TOKindex)
-            {
-                IndexExp *ae = (IndexExp *)(e1);
-                Type *tb1 = ae->e1->type->toBasetype();
-                if (tb1->ty == Taarray)
-                    break;
-            }
             error("cannot delete type %s", e1->type->toChars());
             goto Lerr;
-    }
-
-    if (e1->op == TOKindex)
-    {
-        IndexExp *ae = (IndexExp *)(e1);
-        Type *tb1 = ae->e1->type->toBasetype();
-        if (tb1->ty == Taarray)
-        {
-            error("use 'aa.remove(key)' instead of 'delete aa[key]'");
-            goto Lerr;
-        }
     }
 
     return this;

--- a/test/fail_compilation/faildeleteaa.d
+++ b/test/fail_compilation/faildeleteaa.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/faildeleteaa.d(11): Error: cannot delete type int
+---
+*/
+
+void main()
+{
+    int[int] aa = [1 : 2];
+    delete aa[1];
+}


### PR DESCRIPTION
This has been an error for a couple of years, and has been deprecated since pre D 1.0.

I couldn't find a bugzilla report as (I'm guessing) the deprecation predates bugzilla.
