### PR TITLE
Issue 13019 - Different color for "Warning:"

### DIFF
--- a/src/color.h
+++ b/src/color.h
@@ -9,8 +9,21 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/mars.c
  */
 
+enum COLOR
+{
+    COLOR_BLACK     = 0,
+    COLOR_RED       = 1,
+    COLOR_GREEN     = 2,
+    COLOR_BLUE      = 4,
+
+    COLOR_YELLOW    = COLOR_RED | COLOR_GREEN,
+    COLOR_MAGENTA   = COLOR_RED | COLOR_BLUE,
+    COLOR_CYAN      = COLOR_GREEN | COLOR_BLUE,
+    COLOR_WHITE     = COLOR_RED | COLOR_GREEN | COLOR_BLUE,
+};
+
 extern bool isConsoleColorSupported();
-extern void setConsoleColorBright();
-extern void setConsoleColorError();
+extern void setConsoleColorBright(bool bright);
+extern void setConsoleColor(COLOR color, bool bright);
 extern void resetConsoleColor();
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -245,8 +245,8 @@ void deprecation(Loc loc, const char *format, ...)
 }
 
 // Just print, doesn't care about gagging
-void verrorPrint(Loc loc, const char *header, const char *format, va_list ap,
-                const char *p1, const char *p2)
+void verrorPrint(Loc loc, COLOR headerColor, const char *header, const char *format, va_list ap,
+                const char *p1 = NULL, const char *p2 = NULL)
 {
     char *p = loc.toChars();
 
@@ -257,7 +257,7 @@ void verrorPrint(Loc loc, const char *header, const char *format, va_list ap,
     mem.free(p);
 
     if (global.params.color)
-        setConsoleColor(COLOR_RED, true);
+        setConsoleColor(headerColor, true);
     fputs(header, stderr);
     if (global.params.color)
         resetConsoleColor();
@@ -277,7 +277,7 @@ void verror(Loc loc, const char *format, va_list ap,
 {
     if (!global.gag)
     {
-        verrorPrint(loc, header, format, ap, p1, p2);
+        verrorPrint(loc, COLOR_RED, header, format, ap, p1, p2);
         if (global.errors >= 20)        // moderate blizzard of cascading messages
                 fatal();
 //halt();
@@ -285,7 +285,7 @@ void verror(Loc loc, const char *format, va_list ap,
     else
     {
         //fprintf(stderr, "(gag:%d) ", global.gag);
-        //verrorPrint(loc, header, format, ap, p1, p2);
+        //verrorPrint(loc, COLOR_RED, header, format, ap, p1, p2);
         global.gaggedErrors++;
     }
     global.errors++;
@@ -295,14 +295,14 @@ void verror(Loc loc, const char *format, va_list ap,
 void verrorSupplemental(Loc loc, const char *format, va_list ap)
 {
     if (!global.gag)
-        verrorPrint(loc, "       ", format, ap);
+        verrorPrint(loc, COLOR_RED, "       ", format, ap);
 }
 
 void vwarning(Loc loc, const char *format, va_list ap)
 {
     if (global.params.warnings && !global.gag)
     {
-        verrorPrint(loc, "Warning: ", format, ap);
+        verrorPrint(loc, COLOR_YELLOW, "Warning: ", format, ap);
 //halt();
         if (global.params.warnings == 1)
             global.warnings++;  // warnings don't count if gagged
@@ -316,7 +316,7 @@ void vdeprecation(Loc loc, const char *format, va_list ap,
     if (global.params.useDeprecated == 0)
         verror(loc, format, ap, p1, p2, header);
     else if (global.params.useDeprecated == 2 && !global.gag)
-        verrorPrint(loc, header, format, ap, p1, p2);
+        verrorPrint(loc, COLOR_BLUE, header, format, ap, p1, p2);
 }
 
 void readFile(Loc loc, File *f)

--- a/src/mars.c
+++ b/src/mars.c
@@ -251,13 +251,13 @@ void verrorPrint(Loc loc, const char *header, const char *format, va_list ap,
     char *p = loc.toChars();
 
     if (global.params.color)
-        setConsoleColorBright();
+        setConsoleColorBright(true);
     if (*p)
         fprintf(stderr, "%s: ", p);
     mem.free(p);
 
     if (global.params.color)
-        setConsoleColorError();
+        setConsoleColor(COLOR_RED, true);
     fputs(header, stderr);
     if (global.params.color)
         resetConsoleColor();

--- a/src/mars.h
+++ b/src/mars.h
@@ -361,7 +361,6 @@ void errorSupplemental(Loc loc, const char *format, ...);
 void verror(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
 void vwarning(Loc loc, const char *format, va_list);
 void verrorSupplemental(Loc loc, const char *format, va_list ap);
-void verrorPrint(Loc loc, const char *header, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
 void vdeprecation(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
 
 #if defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13019

Choose colors: Warning -> light yellow, Deprecation -> light blue
