### PR TITLE
Possible fix for bug #11595 - __traits(allMembers, packageName) behaves oddly

### DIFF
--- a/src/traits.c
+++ b/src/traits.c
@@ -841,7 +841,44 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
 #endif
                     }
 
-                    idents->push(sm->ident);
+                    // Use the default identifier from the symbol.
+                    // Allows for customization identify for types if the default is not correct.
+                    Identifier* ident = sm->ident;
+
+                    // Checks to see if the symbol is an import.
+                    // Imports require package information to be added.
+                    // It is removed from the ident.
+                    Import* import = sm->isImport();
+                    if (import && import->packages != NULL)
+                    {
+                        OutBuffer moduleName;
+
+                        // Foreach package concactenate it onto the module name.
+                        for (size_t i = 0; i < import->packages->dim; i++)
+                        {
+                            // grab all package names and push them into the moduleName
+
+                            Identifier *id = (*(import->packages))[i];
+
+                            moduleName.writestring(id->toChars());
+                            moduleName.writestring(".");
+                        }
+
+                        // grab the module name itself and push into into the moduleName
+                        moduleName.writestring(import->id->toChars());
+
+                        // Changes the identifier to be the custom package included one.
+                        // Note: The value used (ident->value) is probably not required.
+                        ident = new Identifier(moduleName.extractString(), ident->value);
+                    }
+
+                    // Check to make sure the identifier is not empty.
+                    // Can cause extra allMembers member that is empty.
+                    if (strlen(ident->toChars()) > 0)
+                    {
+                        // Add on to the tuple returned with the current identifier.
+                        idents->push(ident);
+                    }
                 }
                 else
                 {

--- a/test/compilable/imports/test11595a.d
+++ b/test/compilable/imports/test11595a.d
@@ -1,0 +1,6 @@
+module imports.test11595a;
+import imports.test11595b;
+
+struct Foo{}
+
+static assert([__traits(allMembers, imports.test11595b)] == ["object", "Bar"]);

--- a/test/compilable/imports/test11595b.d
+++ b/test/compilable/imports/test11595b.d
@@ -1,0 +1,3 @@
+module imports.test11595b;
+
+class Bar{}

--- a/test/compilable/test11595.d
+++ b/test/compilable/test11595.d
@@ -1,0 +1,3 @@
+import imports.test11595a;
+
+static assert([__traits(allMembers, imports.test11595a)] == ["object", "imports.test11595b", "Foo"]);


### PR DESCRIPTION
I'm not 100% on this, mostly for the string stuff.
But I think it is a fix for https://issues.dlang.org/show_bug.cgi?id=11595
