### PR TITLE
[DDMD] Remove #ifed out code

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1305,13 +1305,8 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(
         }
     }
 
-#if BUGZILLA_11946
-    if (isstatic)
-        tthis = NULL;
-#else
     if (toParent()->isModule() || (scope->stc & STCstatic))
         tthis = NULL;
-#endif
     if (tthis)
     {
         bool hasttp = false;
@@ -6179,10 +6174,6 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     sc2->parent = this;
     sc2->tinst = this;
     sc2->speculative = speculative;
-#if BUGZILLA_11946
-    if (enclosing && tempdecl->isstatic)
-        sc2->stc &= ~STCstatic;
-#endif
 
     tryExpandMembers(sc2);
 


### PR DESCRIPTION
Undefined preprocessor symbols don't translate well to D, and dead code shouldn't be in master, it's nicely saved in version control etc
