### PR TITLE
Fix COFF32 library paths for Windows 8 SDK and DX-SDK

### DIFF
--- a/ini/windows/bin/sc.ini
+++ b/ini/windows/bin/sc.ini
@@ -106,15 +106,15 @@ LINKCMD=%VCINSTALLDIR%\bin\link.exe
 LIB=%LIB%;"%VCINSTALLDIR%\lib"
 
 ; Platform libraries (Windows SDK 8.1)
-LIB=%LIB%;"%WindowsSdkDir%\Lib\winv6.3\um"
+LIB=%LIB%;"%WindowsSdkDir%\Lib\winv6.3\um\x86"
 
 ; Platform libraries (Windows SDK 8)
-LIB=%LIB%;"%WindowsSdkDir%\Lib\win8\um"
+LIB=%LIB%;"%WindowsSdkDir%\Lib\win8\um\x86"
 
 ; Platform libraries (Windows SDK 7 and 6)
 LIB=%LIB%;"%WindowsSdkDir%\Lib"
 
 ; DirectX (newer versions are included in the Platform SDK but this
 ; will allow us to support older versions)
-LIB=%LIB%;"%DXSDK_DIR%\Lib"
+LIB=%LIB%;"%DXSDK_DIR%\Lib\x86"
 


### PR DESCRIPTION
These are missing the x86 sub directories in the default sc.ini.
