### PR TITLE
Deprecate old attribute syntax

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -601,7 +601,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
             {
                 if (peekNext() == TOKrbracket)
                     error("empty attribute list is not allowed");
-                warning(token.loc, "use @(attributes) instead of [attributes]");
+                deprecation("use @(attributes) instead of [attributes]");
                 Expressions *exps = parseArguments();
                 // no redundant/conflicting check for UDAs
 

--- a/test/fail_compilation/parse13361.d
+++ b/test/fail_compilation/parse13361.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parse13361.d(10): Error: empty attribute list is not allowed
-fail_compilation/parse13361.d(13): Error: empty attribute list is not allowed
+fail_compilation/parse13361.d(11): Error: empty attribute list is not allowed
+fail_compilation/parse13361.d(14): Error: empty attribute list is not allowed
+fail_compilation/parse13361.d(14): Deprecation: use @(attributes) instead of [attributes]
 ---
 */
 struct A


### PR DESCRIPTION
It has been a warning for almost 2 years.
