### PR TITLE
Issue 13404 - heap-allocating a struct passes TypeInfo_Pointer to the GC, not TypeInfo_struct

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1526,7 +1526,7 @@ elem *toElem(Expression *e, IRState *irs)
                     d_uns64 elemsize = sd->size(ne->loc);
 
                     // call _d_newitemT(ti)
-                    e = ne->type->getTypeInfo(NULL)->toElem(irs);
+                    e = ne->newtype->getTypeInfo(NULL)->toElem(irs);
 
                     int rtl = t->isZeroInit() ? RTLSYM_NEWITEMT : RTLSYM_NEWITEMIT;
                     ex = el_bin(OPcall,TYnptr,el_var(rtlsym[rtl]),e);
@@ -1622,7 +1622,7 @@ elem *toElem(Expression *e, IRState *irs)
                 Expression *di = tp->next->defaultInit();
 
                 // call _d_newitemT(ti)
-                e = ne->type->getTypeInfo(NULL)->toElem(irs);
+                e = ne->newtype->getTypeInfo(NULL)->toElem(irs);
 
                 int rtl = tp->next->isZeroInit() ? RTLSYM_NEWITEMT : RTLSYM_NEWITEMIT;
                 e = el_bin(OPcall,TYnptr,el_var(rtlsym[rtl]),e);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13404

When allocating a struct with "new", do not pass the pointer type info to the runtime, but the struct type info.

This PR needs https://github.com/D-Programming-Language/druntime/pull/941 to be merged at the same time.
