### PR TITLE
[REG2.066] Issue 13415 - '-inline' causes wrong enclosing scope pointer for nested function called from templated struct

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -7790,6 +7790,18 @@ bool TemplateInstance::needsCodegen()
         global.params.allInst ||
         global.params.debuglevel)
     {
+        //printf("%s instantiatingModule = %s, speculative = %d, enclosing in nonRoot = %d\n",
+        //    toPrettyChars(), instantiatingModule ? instantiatingModule->toChars() : NULL, speculative,
+        //    enclosing && !enclosing->isInstantiated() && enclosing->inNonRoot());
+        if (enclosing)
+        {
+            // Bugzilla 13415: If and only if the enclosing scope needs codegen,
+            // the nested templates would need code generation.
+            if (TemplateInstance *ti = enclosing->isInstantiated())
+                return ti->needsCodegen();
+            else
+                return !enclosing->inNonRoot();
+        }
         return true;
     }
 

--- a/test/runnable/imports/link13415a.d
+++ b/test/runnable/imports/link13415a.d
@@ -1,0 +1,19 @@
+struct S(alias func)
+{
+    void call()
+    {
+        func();
+    }
+}
+
+extern(C) int printf(in char*, ...);
+
+void f(int i = 77)
+{
+    void g()
+    {
+        printf("i = %d;\n", i);
+        assert(i == 77);
+    }
+    S!g().call();
+}

--- a/test/runnable/link13415.d
+++ b/test/runnable/link13415.d
@@ -1,0 +1,11 @@
+// EXTRA_SOURCES: imports/link13415a.d
+// REQUIRED_ARGS: -inline
+// PERMUTE_ARGS: -allinst -unittest -debug
+// COMPILE_SEPARATELY
+
+import imports.link13415a;
+
+void main()
+{
+    f();
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13415
