### PR TITLE
Make comma operator return void when warnings are enabled

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10190,8 +10190,8 @@ Expression *DotExp::semantic(Scope *sc)
 
 /************************* CommaExp ***********************************/
 
-CommaExp::CommaExp(Loc loc, Expression *e1, Expression *e2)
-        : BinExp(loc, TOKcomma, sizeof(CommaExp), e1, e2)
+CommaExp::CommaExp(Loc loc, Expression *e1, Expression *e2, bool isInternal)
+        : BinExp(loc, TOKcomma, sizeof(CommaExp), e1, e2), isInternal(isInternal)
 {
 }
 
@@ -10205,7 +10205,16 @@ Expression *CommaExp::semantic(Scope *sc)
     e1 = e1->addDtorHook(sc);
 
     type = e2->type;
-    return this;
+
+    if (!isInternal && global.params.warnings)
+    {
+        Expression *ex = new CastExp(this->loc, this, Type::tvoid);
+        ex = ex->semantic(sc);
+        type = ex->type;
+        return ex;
+    }
+    else
+        return this;
 }
 
 void CommaExp::checkEscape()

--- a/src/expression.h
+++ b/src/expression.h
@@ -1129,7 +1129,9 @@ public:
 class CommaExp : public BinExp
 {
 public:
-    CommaExp(Loc loc, Expression *e1, Expression *e2);
+    bool isInternal;
+
+    CommaExp(Loc loc, Expression *e1, Expression *e2, bool isInternal = true);
     Expression *semantic(Scope *sc);
     void checkEscape();
     void checkEscapeRef();

--- a/src/parse.c
+++ b/src/parse.c
@@ -7373,7 +7373,7 @@ Expression *Parser::parseExpression()
     {
         nextToken();
         e2 = parseAssignExp();
-        e = new CommaExp(loc, e, e2);
+        e = new CommaExp(loc, e, e2, false);
         loc = token.loc;
     }
     return e;

--- a/test/compilable/test2659.d
+++ b/test/compilable/test2659.d
@@ -1,0 +1,6 @@
+// REQUIRED ARGS:
+
+int test2659()
+{
+    return (0, 1);
+}

--- a/test/fail_compilation/fail2659.d
+++ b/test/fail_compilation/fail2659.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -w
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2659.d(11): Error: e2ir: cannot cast cast(void)1 of type void to type int
+---
+*/
+
+int test2659()
+{
+    return (0, 1);
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/D-Programming-Language/dmd/pull/3399.

As suggested by Andrei [1], the comma operator is changed to return `void` in `-w` mode. This partially fixes https://issues.dlang.org/show_bug.cgi?id=2659. Thanks go to @yebblies for his suggestions about the implementation.

[1] http://forum.dlang.org/thread/lgsel0%2429fd%241@digitalmars.com
