### PR TITLE
[enh] implement UDA for module declaration

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -208,7 +208,7 @@ public:
 
 /**
  * User defined attributes look like:
- *      [ args, ... ]
+ *      @(args, ...)
  */
 class UserAttributeDeclaration : public AttribDeclaration
 {

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -62,29 +62,7 @@ void genhdrfile(Module *m)
     HdrGenState hgs;
     hgs.hdrgen = true;
 
-    if (m->md)
-    {
-        if (m->md->isdeprecated)
-        {
-            if (m->md->msg)
-            {
-                buf.writestring("deprecated(");
-                toCBuffer(m->md->msg, &buf, &hgs);
-                buf.writestring(") ");
-            }
-            else
-                buf.writestring("deprecated ");
-        }
-        buf.writestring("module ");
-        buf.writestring(m->md->toChars());
-        buf.writeByte(';');
-        buf.writenl();
-    }
-    for (size_t i = 0; i < m->members->dim; i++)
-    {
-        Dsymbol *s = (*m->members)[i];
-        toCBuffer(s, &buf, &hgs);
-    }
+    toCBuffer(m, &buf, &hgs);
 
     // Transfer image to file
     m->hdrfile->setbuffer(buf.data, buf.offset);
@@ -2922,6 +2900,41 @@ public:
             }
         }
         buf->writeByte(')');
+    }
+
+    void visit(Module *m)
+    {
+        if (m->md)
+        {
+            if (m->userAttribDecl)
+            {
+                buf->writestring("@(");
+                argsToBuffer(m->userAttribDecl->atts);
+                buf->writeByte(')');
+                buf->writenl();
+            }
+            if (m->md->isdeprecated)
+            {
+                if (m->md->msg)
+                {
+                    buf->writestring("deprecated(");
+                    m->md->msg->accept(this);
+                    buf->writestring(") ");
+                }
+                else
+                    buf->writestring("deprecated ");
+            }
+
+            buf->writestring("module ");
+            buf->writestring(m->md->toChars());
+            buf->writeByte(';');
+            buf->writenl();
+        }
+        for (size_t i = 0; i < m->members->dim; i++)
+        {
+            Dsymbol *s = (*m->members)[i];
+            s->accept(this);
+        }
     }
 };
 

--- a/src/module.c
+++ b/src/module.c
@@ -23,6 +23,7 @@
 #include "dsymbol.h"
 #include "expression.h"
 #include "lexer.h"
+#include "attrib.h"
 
 #ifdef IN_GCC
 #include "d-dmd-gcc.h"
@@ -726,6 +727,11 @@ void Module::semantic()
         runDeferredSemantic();
     }
 
+    if (userAttribDecl)
+    {
+        userAttribDecl->semantic(sc);
+    }
+
     if (!scope)
     {
         sc = sc->pop();
@@ -755,6 +761,11 @@ void Module::semantic2()
         s->semantic2(sc);
     }
 
+    if (userAttribDecl)
+    {
+        userAttribDecl->semantic2(sc);
+    }
+
     sc = sc->pop();
     sc->pop();
     semanticRun = PASSsemantic2done;
@@ -780,6 +791,11 @@ void Module::semantic3()
         Dsymbol *s = (*members)[i];
         //printf("Module %s: %s.semantic3()\n", toChars(), s->toChars());
         s->semantic3(sc);
+    }
+
+    if (userAttribDecl)
+    {
+        userAttribDecl->semantic3(sc);
     }
 
     sc = sc->pop();

--- a/src/traits.c
+++ b/src/traits.c
@@ -735,6 +735,10 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
             e->error("first argument is not a symbol");
             goto Lfalse;
         }
+        if (s->isImport())
+        {
+            s = s->isImport()->mod;
+        }
         //printf("getAttributes %s, attrs = %p, scope = %p\n", s->toChars(), s->userAttribDecl, s->scope);
         UserAttributeDeclaration *udad = s->userAttribDecl;
         TupleExp *tup = new TupleExp(e->loc, udad ? udad->getAttributes() : new Expressions());

--- a/test/compilable/extra-files/testheaderudamodule.di
+++ b/test/compilable/extra-files/testheaderudamodule.di
@@ -1,0 +1,7 @@
+@(1, UDA(2))
+module testheaderudamodule;
+struct UDA
+{
+	int a;
+}
+void main();

--- a/test/compilable/imports/udamodule1.d
+++ b/test/compilable/imports/udamodule1.d
@@ -1,0 +1,5 @@
+@(1) deprecated("This module will be removed.") @(2) module imports.udamodule1;
+
+void foo()
+{
+}

--- a/test/compilable/imports/udamodule2.d
+++ b/test/compilable/imports/udamodule2.d
@@ -1,0 +1,7 @@
+@UDA(1) @UDA(2) module imports.udamodule2;
+
+import imports.udamodule2a;
+
+void foo()
+{
+}

--- a/test/compilable/imports/udamodule2a.d
+++ b/test/compilable/imports/udamodule2a.d
@@ -1,0 +1,6 @@
+module imports.udamodule2a;
+
+struct UDA
+{
+    int a;
+}

--- a/test/compilable/testheaderudamodule.d
+++ b/test/compilable/testheaderudamodule.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -o- -H -Hf${RESULTS_DIR}/compilable/testheaderudamodule.di
+// PERMUTE_ARGS:
+// POST_SCRIPT: compilable/extra-files/header-postscript.sh testheaderudamodule
+
+@(1, UDA(2))
+module testheaderudamodule;
+
+struct UDA
+{
+    int a;
+}
+
+void main() {}

--- a/test/compilable/udamodule1.d
+++ b/test/compilable/udamodule1.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+compilable/udamodule1.d(9): Deprecation: module imports.udamodule1 is deprecated - This module will be removed.
+---
+*/
+import imports.udamodule1;
+
+void main() { foo(); }

--- a/test/compilable/udamodule2.d
+++ b/test/compilable/udamodule2.d
@@ -1,0 +1,5 @@
+import imports.udamodule2;
+import imports.udamodule2a;
+
+enum Attrib = __traits(getAttributes, imports.udamodule2);
+static assert(Attrib[0] == UDA(1) && Attrib[1] == UDA(2));

--- a/test/fail_compilation/moduleundefuda.d
+++ b/test/fail_compilation/moduleundefuda.d
@@ -1,0 +1,7 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/moduleundefuda.d(7): Error: undefined identifier undef
+---
+*/
+@undef module moduleundefuda; 


### PR DESCRIPTION
This PR introduce UDA for module declaration.
Usage:

```
///test.d
@UDA(42) module test;
struct UDA
{
    int a;
}

pragma(msg, __traits(getAttributes, test)); //prints "tuple(UDA(42))"

///test2.d
import test;
pragma(msg, __traits(getAttributes, test)); //prints "tuple(UDA(42))"
```

In other words, when __traits(getAttributes, ...) is applied to import statement, it returns attributes of corresponding module.

Mulitple UDAs are allowed:

```
@UDA(42) @UDA(24) module test; //OK
```

```
@(UDA(42), UDA(24)) module test; //OK
```

UDAs can be mixed with `deprecated` attribute:

```
@UDA(42) deprecated module test; //OK
```

```
deprecated @UDA(42) module test; //OK
```
