### PR TITLE
[REG2.066] Issue 13417 - segmentation fault when deduce template type

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -3849,6 +3849,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                             // (it may be from a parent template, for example)
                         }
 
+                        e2 = e2->semantic(sc);      // Bugzilla 13417
                         e2 = e2->ctfeInterpret();
 
                         //printf("e1 = %s, type = %s %d\n", e1->toChars(), e1->type->toChars(), e1->type->ty);

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -4189,6 +4189,23 @@ MinType13379!T min13379(T...)(T args)   // #4 MinType!uint (speculative && thist
 }
 
 /******************************************/
+// 13417
+
+struct V13417(size_t N, E, alias string AS)
+{
+}
+
+auto f13417(E)(in V13417!(4, E, "ijka"))
+{
+    return V13417!(3, E, "xyz")();
+}
+
+void test13417()
+{
+    f13417(V13417!(4, float, "ijka")());
+}
+
+/******************************************/
 
 int main()
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13417

The ICE has been caused by the lack of `semantic` call on the argument of `TypeInstance` parameter. It's essentially a bug in `TypeInstance::deduceType`.
