### PR TITLE
[REG2.066] Issue 13424 - Initialization of delegate to do-nothing default causes segfault at runtime

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1404,6 +1404,8 @@ Lnomatch:
         sc->stc &= ~(STC_TYPECTOR | STCpure | STCnothrow | STCnogc | STCref | STCdisable);
 
         ExpInitializer *ei = init->isExpInitializer();
+        if (ei)     // Bugzilla 13424: Preset the required type to fail in FuncLiteralDeclaration::semantic3
+            ei->exp = inferType(ei->exp, type);
 
         // If inside function, there is no semantic3() call
         if (sc->func)

--- a/test/fail_compilation/fail13424.d
+++ b/test/fail_compilation/fail13424.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13424.d(10): Error: delegate fail13424.S.__lambda2 cannot be class members
+---
+*/
+
+struct S
+{
+    void delegate(dchar) onChar = (dchar) {};
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13424
