### PR TITLE
[DDMD] Do not use octal literals in dmd

### DIFF
--- a/src/root/file.c
+++ b/src/root/file.c
@@ -279,7 +279,7 @@ int File::write()
     char *name;
 
     name = this->name->toChars();
-    fd = open(name, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    fd = open(name, O_CREAT | O_WRONLY | O_TRUNC, (6 << 6) | (4 << 3) | 4);
     if (fd == -1)
         goto err;
 

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -600,7 +600,7 @@ int FileName::ensurePathExists(const char *path)
                 int r = _mkdir(path);
 #endif
 #if POSIX
-                int r = mkdir(path, 0777);
+                int r = mkdir(path, (7 << 6) | (7 << 3) | 7);
 #endif
                 if (r)
                 {


### PR DESCRIPTION
Because dmd itself won't compile them any more.
