### PR TITLE
Generate TypeInfo objects as in template instances

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -56,7 +56,9 @@ FuncDeclaration *search_toString(StructDeclaration *sd)
  */
 void semanticTypeInfo(Scope *sc, Type *t)
 {
-#if 0
+    if (!global.params.allInst)
+        return;
+
     class FullTypeInfoVisitor : public Visitor
     {
     public:
@@ -125,7 +127,6 @@ void semanticTypeInfo(Scope *sc, Type *t)
     FullTypeInfoVisitor v;
     v.sc = sc;
     t->accept(&v);
-#endif
 }
 
 /********************************* AggregateDeclaration ****************************/
@@ -216,7 +217,7 @@ void AggregateDeclaration::semantic3(Scope *sc)
     StructDeclaration *sd = isStructDeclaration();
     if (!sc)    // from runDeferredSemantic3 for TypeInfo generation
     {
-        assert(sd);
+        assert(sd && global.params.allInst);
         sd->semanticTypeInfoMembers();
         return;
     }

--- a/src/struct.c
+++ b/src/struct.c
@@ -56,6 +56,7 @@ FuncDeclaration *search_toString(StructDeclaration *sd)
  */
 void semanticTypeInfo(Scope *sc, Type *t)
 {
+#if 0
     class FullTypeInfoVisitor : public Visitor
     {
     public:
@@ -124,6 +125,7 @@ void semanticTypeInfo(Scope *sc, Type *t)
     FullTypeInfoVisitor v;
     v.sc = sc;
     t->accept(&v);
+#endif
 }
 
 /********************************* AggregateDeclaration ****************************/
@@ -837,15 +839,6 @@ void StructDeclaration::semantic(Scope *sc)
     xcmp = buildXopCmp(this, sc2);
     xhash = buildXtoHash(this, sc2);
 
-    /* Even if the struct is merely imported and its semantic3 is not run,
-     * the TypeInfo object would be speculatively stored in each object
-     * files. To set correct function pointer, run semantic3 for xeq and xcmp.
-     */
-    //if ((xeq && xeq != xerreq || xcmp && xcmp != xerrcmp) && isImportedSym(this))
-    //    Module::addDeferredSemantic3(this);
-    /* Defer requesting semantic3 until TypeInfo generation is actually invoked.
-     * See semanticTypeInfo().
-     */
     inv = buildInv(this, sc2);
 
     sc2->pop();

--- a/src/template.c
+++ b/src/template.c
@@ -7891,10 +7891,9 @@ bool TemplateInstance::needsCodegen()
         {
             // Bugzilla 13415: If and only if the enclosing scope needs codegen,
             // the nested templates would need code generation.
-            if (TemplateInstance *ti = enclosing->isInstantiated())
-                return ti->needsCodegen();
-            else
-                return !enclosing->inNonRoot();
+            TemplateInstance *ti = enclosing->isInstantiated();
+            if (ti ? !ti->needsCodegen() : enclosing->inNonRoot())
+                return false;
         }
         return true;
     }

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1018,7 +1018,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             if (tid->semanticRun >= PASSobj)    // already written
                 return;
         
-            if (tid->tinfo->mod == 0)
+            if (tid->tinfo->mod == 0 && !global.params.allInst)
             {
                 Dsymbol *sym = tid->tinfo->toDsymbol(NULL);
                 if (sym)

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1015,6 +1015,22 @@ void toObjFile(Dsymbol *ds, bool multiobj)
         void visit(TypeInfoDeclaration *tid)
         {
             //printf("TypeInfoDeclaration::toObjFile(%p '%s') protection %d\n", tid, tid->toChars(), tid->protection);
+            if (tid->semanticRun >= PASSobj)    // already written
+                return;
+        
+            if (tid->tinfo->mod == 0)
+            {
+                Dsymbol *sym = tid->tinfo->toDsymbol(NULL);
+                if (sym)
+                {
+                    TemplateInstance *ti = sym->isInstantiated();
+                    if (ti ? !ti->needsCodegen() : sym->inNonRoot())
+                    {
+                        tid->semanticRun = PASSobj;
+                        return;
+                    }
+                }
+            }
 
             if (multiobj)
             {
@@ -1042,6 +1058,8 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             outdata(s);
             if (tid->isExport())
                 objmod->export_symbol(s, 0);
+
+            tid->semanticRun = PASSobj;
         }
 
         void visit(AttribDeclaration *ad)


### PR DESCRIPTION
`TypeInfo`s and template instances are very similar, they are "generated" when the type is used ≒ the template is instantiated. And they are placed in COMDAT section to allow objcode duplication from each compilations.

From 2.064, dmd has supported strict instantiation algorithm (#2550) to reduce executable size. I think we should modify `TypeInfo` generation algorithm to follow it.

From Walter's suggestion (https://github.com/D-Programming-Language/dmd/pull/2480#issuecomment-54687757), this PR still supports old sloppy TypeInfo generation algorithm by `-allinst` switch. 

This PR is based on #3948.
