### PR TITLE
Get rid of Expression::toElem forwarding function

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -55,12 +55,6 @@ enum TOK;
 struct IRState;
 struct dt_t;
 
-#ifdef IN_GCC
-typedef union tree_node elem;
-#else
-struct elem;
-#endif
-
 void initPrecedence();
 
 Expression *resolveProperties(Scope *sc, Expression *e);
@@ -97,7 +91,6 @@ bool hasSideEffect(Expression *e);
 bool canThrow(Expression *e, FuncDeclaration *func, bool mustNotThrow);
 Expression *Expression_optimize(Expression *e, int result, bool keepLvalue);
 dt_t **Expression_toDt(Expression *e, dt_t **pdt);
-elem *toElem(Expression *e, IRState *irs);
 MATCH implicitConvTo(Expression *e, Type *t);
 Expression *implicitCastTo(Expression *e, Scope *sc, Type *t);
 Expression *castTo(Expression *e, Scope *sc, Type *t);
@@ -234,7 +227,6 @@ public:
     }
 
     // Back end
-    elem *toElem(IRState *irs) { return ::toElem(this, irs); }
     dt_t **toDt(dt_t **pdt) { return ::Expression_toDt(this, pdt); }
     virtual void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/module.h
+++ b/src/module.h
@@ -26,13 +26,6 @@ struct Escape;
 class VarDeclaration;
 class Library;
 
-// Back end
-#ifdef IN_GCC
-typedef union tree_node elem;
-#else
-struct elem;
-#endif
-
 enum PKG
 {
     PKGunknown, // not yet determined whether it's a package.d or not


### PR DESCRIPTION
This is the last frontend function that references the backend's `elem`.
