### PR TITLE
Issue 13427 - [REG2.066] cannot inline default argument alloca(...)

### DIFF
--- a/src/inline.c
+++ b/src/inline.c
@@ -57,6 +57,7 @@ public:
     int nested;
     int hasthis;
     int hdrscan;    // !=0 if inline scan for 'header' content
+    bool allowAlloca;
     FuncDeclaration *fd;
     int cost;
 
@@ -65,6 +66,7 @@ public:
         nested = 0;
         hasthis = 0;
         hdrscan = 0;
+        allowAlloca = false;
         fd = NULL;
         cost = 0;
     }
@@ -74,6 +76,7 @@ public:
         nested = icv->nested;
         hasthis = icv->hasthis;
         hdrscan = icv->hdrscan;
+        allowAlloca = icv->allowAlloca;
         fd = icv->fd;
         cost = 0;   // zero start for subsequent AST
     }
@@ -370,7 +373,7 @@ public:
         // can't handle that at present.
         if (e->e1->op == TOKdotvar && ((DotVarExp *)e->e1)->e1->op == TOKsuper)
             cost = COST_MAX;
-        else if (e->f && e->f->ident == Id::__alloca && e->f->linkage == LINKc)
+        else if (e->f && e->f->ident == Id::__alloca && e->f->linkage == LINKc && !allowAlloca)
             cost = COST_MAX; // inlining alloca may cause stack overflows
         else
             cost++;
@@ -2025,6 +2028,7 @@ Expression *inlineCopy(Expression *e, Scope *sc)
 
     InlineCostVisitor icv;
     icv.hdrscan = 1;
+    icv.allowAlloca = true;
     icv.expressionInlineCost(e);
     int cost = icv.cost;
     if (cost >= COST_MAX)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5689,6 +5689,14 @@ mixin template ProxyOf(alias a)
 }
 
 /***************************************************/
+
+import core.stdc.stdlib;
+
+void test13427(void* buffer = alloca(100))
+{
+}
+
+/***************************************************/
 // 7583
 
 template Tup7583(E...) { alias E Tup7583; }
@@ -7316,6 +7324,7 @@ int main()
     test13182();
     test8269();
     test8395();
+    test13427();
     test5749();
     test8396();
     test160();


### PR DESCRIPTION
Apart from inlining, `inlineCost` is also used for default argument copying.  When using it from there, don't block inlining of `alloca`.

https://issues.dlang.org/show_bug.cgi?id=13427
