### PR TITLE
Adjust Target::checkvectortype to naming convention.

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3473,7 +3473,7 @@ Type *TypeVector::semantic(Loc loc, Scope *sc)
     }
     TypeSArray *t = (TypeSArray *)basetype;
     int sz = (int)t->size(loc);
-    switch (Target::checkvectortype(sz, t->nextOf()))
+    switch (Target::checkVectorType(sz, t->nextOf()))
     {
     case 0: // valid
         break;

--- a/src/target.c
+++ b/src/target.c
@@ -337,7 +337,7 @@ Expression *Target::paintAsType(Expression *e, Type *type)
  * Return true if the given type is supported for this target
  */
 
-int Target::checkvectortype(int sz, Type *type)
+int Target::checkVectorType(int sz, Type *type)
 {
     if (!global.params.is64bit && !global.params.isOSX)
         return 1; // not supported

--- a/src/target.h
+++ b/src/target.h
@@ -34,7 +34,7 @@ struct Target
     static unsigned critsecsize();
     static Type *va_listType();  // get type of va_list
     static Expression *paintAsType(Expression *e, Type *type);
-    static int checkvectortype(int sz, Type *type);
+    static int checkVectorType(int sz, Type *type);
 };
 
 #endif


### PR DESCRIPTION
Cosmetic fix-up for pull rqeuest #2879.
