### PR TITLE
Add POPCNT intrinsics

### DIFF
--- a/src/backend/cgcs.c
+++ b/src/backend/cgcs.c
@@ -368,7 +368,7 @@ STATIC void ecom(elem **pe)
     case OPstrctor: case OPu16_d: case OPd_u16:
     case OParrow:
     case OPvoid: case OPnullcheck:
-    case OPbsf: case OPbsr: case OPbswap: case OPvector:
+    case OPbsf: case OPbsr: case OPbswap: case OPpopcnt: case OPvector:
     case OPld_u64:
 #if TX86
     case OPsqrt: case OPsin: case OPcos:

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -20,6 +20,7 @@
 #include        "code.h"
 #include        "type.h"
 #include        "global.h"
+#include        "xmm.h"
 
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
@@ -3646,6 +3647,63 @@ code *cdbscan(elem *e, regm_t *pretregs)
 
     return cat3(cl,cg,fixresult(e,retregs,pretregs));
 }
+
+/************************
+ * OPpopcnt operator
+ */
+
+code *cdpopcnt(elem *e,regm_t *pretregs)
+{
+    code *cl,*cg;
+    code cs;
+
+    //printf("cdpopcnt()\n");
+    //elem_print(e);
+    assert(!I16);
+    if (*pretregs == 0)
+        return codelem(e->E1,pretregs,FALSE);
+
+    tym_t tyml = tybasic(e->E1->Ety);
+
+    int sz = tysize[tyml];
+    assert(sz == 2 || sz == 4 || (sz == 8 && I64));     // no byte op
+
+    if ((e->E1->Eoper == OPind && !e->E1->Ecount) || e->E1->Eoper == OPvar)
+    {
+        cl = getlvalue(&cs, e->E1, RMload);     // get addressing mode
+    }
+    else
+    {
+        regm_t retregs = allregs;
+        cl = codelem(e->E1, &retregs, FALSE);
+        reg_t reg = findreg(retregs);
+        cs.Irm = modregrm(3,0,reg & 7);
+        cs.Iflags = 0;
+        cs.Irex = 0;
+        if (reg & 8)
+            cs.Irex |= REX_B;
+    }
+
+    regm_t retregs = *pretregs & allregs;
+    if  (!retregs)
+        retregs = allregs;
+    unsigned reg;
+    cg = allocreg(&retregs, &reg, e->Ety);
+
+    cs.Iop = POPCNT;            // POPCNT reg,EA
+    code_newreg(&cs, reg);
+    if (sz == SHORTSIZE)
+        cs.Iflags |= CFopsize;
+    if (*pretregs & mPSW)
+        cs.Iflags |= CFpsw;
+    cg = gen(cg,&cs);
+    if (sz == 8)
+        code_orrex(cg, REX_W);
+    *pretregs &= mBP | ALLREGS;             // flags already set
+
+    return cat3(cl,cg,fixresult(e,retregs,pretregs));
+}
+
 
 /*******************************************
  * Generate code for OPpair, OPrpair.

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -286,6 +286,7 @@ cd_t cdmul;
 cd_t cdnot;
 cd_t cdcom;
 cd_t cdbswap;
+cd_t cdpopcnt;
 cd_t cdcond;
 void WRcodlst (code *c );
 cd_t cdcomma;

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1991,6 +1991,29 @@ elem * evalu8(elem *e, goal_t goal)
                      ((i1 <<  8) & 0x00FF0000) |
                      ((i1 << 24) & 0xFF000000);
         break;
+
+    case OPpopcnt:
+    {
+        // Eliminate any unwanted sign extension
+        switch (tysize(tym))
+        {
+            case 1:     l1 &= 0xFF;       break;
+            case 2:     l1 &= 0xFFFF;     break;
+            case 4:     l1 &= 0xFFFFFFFF; break;
+            case 8:     break;
+            default:    assert(0);
+        }
+
+        int popcnt = 0;
+        while (l1)
+        {   // Not efficient, but don't need efficiency here
+            popcnt += (l1 & 1);
+            l1 = (targ_ullong)l1 >> 1;  // shift is unsigned
+        }
+        e->EV.Vllong = popcnt;
+        break;
+    }
+
     case OProl:
     case OPror:
     {   unsigned n = i2;

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1056,6 +1056,7 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPbsf:
         case OPbsr:
         case OPbswap:
+        case OPpopcnt:
 #if TX86
         case OPsqrt:
         case OPsin:

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -77,6 +77,7 @@ enum OPER
         OProl,                  // rotate left
         OPror,                  // rotate right
         OPbtst,                 // bit test
+        OPpopcnt,               // count of number of bits set to 1
 
         OPstreq,                /* structure assignment         */
 

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -62,7 +62,7 @@ int _unary[] =
          OPucall,OPucallns,OPstrpar,OPstrctor,OPu16_d,OPd_u16,
          OParrow,OPnegass,
          OPctor,OPdtor,OPsetjmp,OPvoid,OParraylength,
-         OPbsf,OPbsr,OPbswap,
+         OPbsf,OPbsr,OPbswap,OPpopcnt,
          OPddtor,
          OPvector,
 #if TX86
@@ -146,7 +146,7 @@ int _ae[] = {OPvar,OPconst,OPrelconst,OPneg,
                 OP128_64,OPs64_128,OPu64_128,
                 OPsizeof,OParray,OPfield,OPinstanceof,OPfinalinstanceof,OPcheckcast,OParraylength,
                 OPcallns,OPucallns,OPnullcheck,OPpair,OPrpair,
-                OPbsf,OPbsr,OPbt,OPbswap,OPb_8,OPbtst,
+                OPbsf,OPbsr,OPbt,OPbswap,OPb_8,OPbtst,OPpopcnt,
                 OPgot,OPremquo,
                 OPnullptr,
                 OProl,OPror,
@@ -176,7 +176,7 @@ int _exp[] = {OPvar,OPconst,OPrelconst,OPneg,OPabs,OPrndtol,OPrint,
                 OPcall,OPcallns,OPeq,OPstreq,OPpostinc,OPpostdec,
                 OPaddass,OPminass,OPmulass,OPdivass,OPmodass,OPandass,
                 OPorass,OPxorass,OPshlass,OPshrass,OPashrass,OPoror,OPandand,OPcond,
-                OPbsf,OPbsr,OPbt,OPbtc,OPbtr,OPbts,OPbswap,OPbtst,
+                OPbsf,OPbsr,OPbt,OPbtc,OPbtr,OPbts,OPbswap,OPbtst,OPpopcnt,
                 OProl,OPror,OPvector,
                 OPpair,OPrpair,OPframeptr,OPgot,OPremquo,
                 OPcolon,OPcolon2,OPasm,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,OPnegass,
@@ -644,6 +644,7 @@ void dotab()
         case OPbts:     X("bts",        elzot,  cdbt);
 
         case OPbswap:   X("bswap",      evalu8, cdbswap);
+        case OPpopcnt:  X("popcnt",     evalu8, cdpopcnt);
         case OPvector:  X("vector",     elzot,  cdvector);
         case OPvecsto:  X("vecsto",     elzot,  cdvecsto);
 

--- a/src/toir.c
+++ b/src/toir.c
@@ -411,6 +411,10 @@ int intrinsic_op(char *name)
         "5bitop5bswapFNaNbNiNfkZk",
         "5bitop5outplFNbNikkZk",
         "5bitop5outpwFNbNiktZt",
+
+        "5bitop7_popcntFNaNbNiNfkZi",
+        "5bitop7_popcntFNaNbNiNfmxx", // don't find 64 bit version in 32 bit code
+        "5bitop7_popcntFNaNbNiNftZt",
     };
     static const char *core_namearray64[] =
     {
@@ -458,6 +462,10 @@ int intrinsic_op(char *name)
         "5bitop5bswapFNaNbNiNfkZk",
         "5bitop5outplFNbNikkZk",
         "5bitop5outpwFNbNiktZt",
+
+        "5bitop7_popcntFNaNbNiNfkZi",
+        "5bitop7_popcntFNaNbNiNfmZi",
+        "5bitop7_popcntFNaNbNiNftZt",
     };
     static unsigned char core_ioptab[] =
     {
@@ -506,6 +514,10 @@ int intrinsic_op(char *name)
         OPbswap,
         OPoutp,
         OPoutp,
+
+        OPpopcnt,
+        OPpopcnt,
+        OPpopcnt,
     };
 
 #ifdef DEBUG


### PR DESCRIPTION
Adds intrinsics that generate the POPCNT instruction.

I'll add them to core.bitop next, but this one will have to be pulled first. The tests are in core.bitop.
