### PR TITLE
Issue 3022 - scope x = new Foo; does not allocate on stack if Foo has allocator

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1461,7 +1461,7 @@ Lnomatch:
                     {
                         // See if initializer is a NewExp that can be allocated on the stack
                         NewExp *ne = (NewExp *)ex;
-                        if (!(ne->newargs && ne->newargs->dim) && type->toBasetype()->ty == Tclass)
+                        if (!(ne->newargs && ne->newargs->dim > 1) && type->toBasetype()->ty == Tclass)
                         {
                             ne->onstack = 1;
                             onstack = 1;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -2515,6 +2515,21 @@ void test124() {
 
 /***************************************************/
 
+void test3022()
+{
+    static class Foo3022
+    {
+        new(size_t)
+        {
+            assert(0);
+        }
+    }
+
+    scope x = new Foo3022;
+}
+
+/***************************************************/
+
 void doNothing() {}
 
 void bug5071(short d, ref short c) {
@@ -7286,6 +7301,7 @@ int main()
     test6733();
     test6813();
     test6859();
+    test3022();
     test6910();
     test6902();
     test6330();


### PR DESCRIPTION
If new only has one argument, then it must be the size.

https://issues.dlang.org/show_bug.cgi?id=3022
