### PR TITLE
Fix issue 13434: segfault on indexing array with empty tuple

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10336,8 +10336,11 @@ Expression *IndexExp::semantic(Scope *sc)
     if (t1->ty == Ttuple) sc = sc->endCTFE();
     if (e2->type == Type::terror)
         return new ErrorExp();
-    if (e2->type->ty == Ttuple && ((TupleExp *)e2)->exps->dim == 1) // bug 4444 fix
+    if (e2->type->ty == Ttuple && ((TupleExp *)e2)->exps &&
+        ((TupleExp *)e2)->exps->dim == 1) // bug 4444 fix
+    {
         e2 = (*((TupleExp *)e2)->exps)[0];
+    }
 
     if (t1->ty == Tsarray || t1->ty == Tarray || t1->ty == Ttuple)
         sc = sc->pop();

--- a/test/fail_compilation/fail13434_m32.d
+++ b/test/fail_compilation/fail13434_m32.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -m32
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13434_m32.d(13): Error: cannot implicitly convert expression (()) of type () to uint
+---
+*/
+
+alias tuple(A...) = A;
+void main()
+{
+    float[] arr;
+    arr[tuple!()] = 0;
+}

--- a/test/fail_compilation/fail13434_m64.d
+++ b/test/fail_compilation/fail13434_m64.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -m64
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13434_m64.d(13): Error: cannot implicitly convert expression (()) of type () to ulong
+---
+*/
+
+alias tuple(A...) = A;
+void main()
+{
+    float[] arr;
+    arr[tuple!()] = 0;
+}


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=13434

Basically, the code failed to account for empty tuples being NULL, not just having `dim == 0`.
