### PR TITLE
add c_longdoublesize

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -544,8 +544,8 @@ public:
             case Tint32:    c = 'i';        break;
             case Tuns32:    c = 'j';        break;
             case Tfloat32:  c = 'f';        break;
-            case Tint64:    c = (Target::longsize == 8 ? 'l' : 'x'); break;
-            case Tuns64:    c = (Target::longsize == 8 ? 'm' : 'y'); break;
+            case Tint64:    c = (Target::c_longsize == 8 ? 'l' : 'x'); break;
+            case Tuns64:    c = (Target::c_longsize == 8 ? 'm' : 'y'); break;
             case Tfloat64:  c = 'd';        break;
             case Tfloat80:  c = (Target::realsize - Target::realpad == 16) ? 'g' : 'e'; break;
             case Tbool:     c = 'b';        break;

--- a/src/target.c
+++ b/src/target.c
@@ -20,7 +20,8 @@ int Target::realsize;
 int Target::realpad;
 int Target::realalignsize;
 bool Target::reverseCppOverloads;
-int Target::longsize;
+int Target::c_longsize;
+int Target::c_long_doublesize;
 
 
 void Target::init()
@@ -28,6 +29,8 @@ void Target::init()
     // These have default values for 32 bit code, they get
     // adjusted for 64 bit code.
     ptrsize = 4;
+    if (global.params.isLP64)
+        ptrsize = 8;
 
     if (global.params.isLinux || global.params.isFreeBSD
         || global.params.isOpenBSD || global.params.isSolaris)
@@ -35,14 +38,14 @@ void Target::init()
         realsize = 12;
         realpad = 2;
         realalignsize = 4;
-        longsize = 4;
+        c_longsize = 4;
     }
     else if (global.params.isOSX)
     {
         realsize = 16;
         realpad = 6;
         realalignsize = 16;
-        longsize = 4;
+        c_longsize = 4;
     }
     else if (global.params.isWindows)
     {
@@ -50,7 +53,7 @@ void Target::init()
         realpad = 0;
         realalignsize = 2;
         reverseCppOverloads = !global.params.is64bit;
-        longsize = 4;
+        c_longsize = 4;
     }
     else
         assert(0);
@@ -62,16 +65,17 @@ void Target::init()
             realsize = 16;
             realpad = 6;
             realalignsize = 16;
-            longsize = 8;
+            c_longsize = 8;
         }
         else if (global.params.isOSX)
         {
-            longsize = 8;
+            c_longsize = 8;
         }
     }
 
-    if (global.params.isLP64)
-        ptrsize = 8;
+    c_long_doublesize = realsize;
+    if (global.params.is64bit && global.params.isWindows)
+        c_long_doublesize = 8;
 }
 
 /******************************

--- a/src/target.h
+++ b/src/target.h
@@ -26,7 +26,8 @@ struct Target
     static int realpad;         // 'padding' added to the CPU real size to bring it up to realsize
     static int realalignsize;   // alignment for reals
     static bool reverseCppOverloads; // with dmc, overloaded functions are grouped and in reverse order
-    static int longsize;        // size of a C 'long' or 'unsigned long' type
+    static int c_longsize;           // size of a C 'long' or 'unsigned long' type
+    static int c_long_doublesize;    // size of a C 'long double'
 
     static void init();
     static unsigned alignsize(Type* type);


### PR DESCRIPTION
and also renames `longsize` to `c_longsize` to reduce confusion about what it represents.

One step towards support C++ name mangling of long double, long, and unsigned long.
