### PR TITLE
[D1] backport "Modules can't be marked as deprecated"

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -151,14 +151,27 @@ void Import::importAll(Scope *sc)
     if (!mod)
     {
        load(sc);
-       mod->importAll(0);
 
-       /* Default to private importing
-        */
-       enum PROT prot = sc->protection;
-       if (!sc->explicitProtection)
-           prot = PROTprivate;
-       sc->scopesym->importScope(this, prot);
+       if (mod)
+       {
+           if (mod->md && mod->md->isdeprecated)
+           {
+               Expression *msg = mod->md->msg;
+               if (StringExp *se = msg ? msg->toString() : NULL)
+                   mod->deprecation(loc, "is deprecated - %s", se->string);
+               else
+                   mod->deprecation(loc, "is deprecated");
+           }
+
+           mod->importAll(0);
+
+           /* Default to private importing
+            */
+           enum PROT prot = sc->protection;
+           if (!sc->explicitProtection)
+               prot = PROTprivate;
+           sc->scopesym->importScope(this, prot);
+       }
     }
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -36,6 +36,7 @@
 #include "dsymbol.h"
 #include "hdrgen.h"
 #include "lexer.h"
+#include "expression.h"
 
 #define MARS 1
 #include "html.h"
@@ -638,6 +639,14 @@ void Module::importAll(Scope *prevsc)
         return;
     }
 
+    if (md && md->msg)
+    {
+        if (StringExp *se = md->msg->toString())
+            md->msg = se;
+        else
+            md->msg->error("string expected, not '%s'", md->msg->toChars());
+    }
+
     /* Note that modules get their own scope, from scratch.
      * This is so regardless of where in the syntax a module
      * gets imported, it is unaffected by context.
@@ -1063,6 +1072,8 @@ ModuleDeclaration::ModuleDeclaration(Identifiers *packages, Identifier *id)
 {
     this->packages = packages;
     this->id = id;
+    this->isdeprecated = false;
+    this->msg = NULL;
 }
 
 char *ModuleDeclaration::toChars()

--- a/src/module.h
+++ b/src/module.h
@@ -181,6 +181,8 @@ struct ModuleDeclaration
     Identifier *id;
     Identifiers *packages;            // array of Identifier's representing packages
     bool safe;
+    bool isdeprecated;          // if it is a deprecated module
+    Expression *msg;
 
     ModuleDeclaration(Identifiers *packages, Identifier *id);
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -117,6 +117,7 @@ struct Parser : Lexer
     int isExpression(Token **pt);
     int isTemplateInstance(Token *t, Token **pt);
     int skipParens(Token *t, Token **pt);
+    int skipParensIf(Token *t, Token **pt);
 
     Expression *parseExpression();
     Expression *parsePrimaryExp();


### PR DESCRIPTION
Original D2 commit : 2af112ec0f156c19b63a9d8269b37ba0555c5857 "fix Issue 12567 - Modules can't be marked as deprecated "

It happens that we do many module deprecations lately and changeset of that pull request looked pretty simple. Apart from few minor tweaks dumb copy-pasting seemed to just work.
