### PR TITLE
Issue 13336 - auto ref return deduced to be ref despite return value coercion

### DIFF
--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -62,6 +62,8 @@ typedef Array<class ScopeStatement *> ScopeStatements;
 
 typedef Array<class GotoCaseStatement *> GotoCaseStatements;
 
+typedef Array<class ReturnStatement *> ReturnStatements;
+
 typedef Array<class GotoStatement *> GotoStatements;
 
 typedef Array<class TemplateInstance *> TemplateInstances;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -563,7 +563,6 @@ public:
     Identifier *outId;                  // identifier for out statement
     VarDeclaration *vresult;            // variable corresponding to outId
     LabelDsymbol *returnLabel;          // where the return goes
-    Scope *scout;                       // out contract scope for vresult->semantic
 
     DsymbolTable *localsymtab;          // used to prevent symbols in different
                                         // scopes from having the same name
@@ -608,9 +607,11 @@ public:
     VarDeclaration *nrvo_var;           // variable to replace with shidden
     Symbol *shidden;                    // hidden pointer passed to function
 
+    ReturnStatements *returns;
+
     GotoStatements *gotos;              // Gotos with forward references
 
-    BUILTIN builtin;               // set if this is a known, builtin
+    BUILTIN builtin;                    // set if this is a known, builtin
                                         // function we can evaluate at compile
                                         // time
 
@@ -685,7 +686,7 @@ public:
     void checkNestedReference(Scope *sc, Loc loc);
     bool needsClosure();
     bool hasNestedFrameRefs();
-    void buildResultVar();
+    void buildResultVar(Scope *sc, Type *tret);
     Statement *mergeFrequire(Statement *);
     Statement *mergeFensure(Statement *, Identifier *oid);
     Parameters *getParameters(int *pvarargs);

--- a/src/expression.c
+++ b/src/expression.c
@@ -1997,25 +1997,33 @@ Expression *Expression::combine(Expression *e1, Expression *e2)
  */
 Expression *Expression::extractLast(Expression *e, Expression **pe0)
 {
-    if (e->op == TOKcomma)
+    if (e->op != TOKcomma)
     {
-        CommaExp *ce = (CommaExp *)e;
-        *pe0 = ce;
+        *pe0 = NULL;
+        return e;
+    }
 
-        Expression **pe = &e;
-        while (((CommaExp *)(*pe))->e2->op == TOKcomma)
-        {
-            ce = (CommaExp *)(*pe);
-            pe = &ce->e2;
-        }
-
-        *pe = ce->e2;
-        if (pe == &e)
-            *pe0 = ce->e1;
+    CommaExp *ce = (CommaExp *)e;
+    if (ce->e2->op != TOKcomma)
+    {
+        *pe0 = ce->e1;
+        return ce->e2;
     }
     else
-        *pe0 = NULL;
-    return e;
+    {
+        *pe0 = e;
+
+        Expression **pce = &ce->e2;
+        while (((CommaExp *)(*pce))->e2->op == TOKcomma)
+        {
+            pce = &((CommaExp *)(*pce))->e2;
+        }
+        assert((*pce)->op == TOKcomma);
+        ce = (CommaExp *)(*pce);
+        *pce = ce->e1;
+
+        return ce->e2;
+    }
 }
 
 dinteger_t Expression::toInteger()

--- a/src/func.c
+++ b/src/func.c
@@ -203,28 +203,22 @@ public:
 
     void visit(ReturnStatement *s)
     {
-        Expression *exp = s->exp;
-        if (exp)
+        // See if all returns are instead to be replaced with a goto returnLabel;
+        if (fd->returnLabel)
         {
-            TypeFunction *tf = (TypeFunction *)fd->type;
-
-            /* Bugzilla 10789:
-             * If NRVO is not possible, all returned lvalues should call their postblits.
+            /* Rewrite:
+             *  return exp;
+             * as:
+             *  vresult = exp; goto Lresult;
              */
-            if (!fd->nrvo_can && !tf->isref && exp->isLvalue())
-                exp = callCpCtor(sc, exp);
+            GotoStatement *gs = new GotoStatement(s->loc, Id::returnLabel);
+            gs->label = fd->returnLabel;
 
-            /* Bugzilla 8665:
-             * If auto function has multiple return statements, returned values
-             * should be fixed to the determined return type.
-             */
-            if (!fd->tintro && !tf->next->immutableOf()->equals(exp->type->immutableOf()))
-            {
-                exp = exp->castTo(sc, tf->next);
-                exp = exp->optimize(WANTvalue);
-            }
+            Statement *s1 = gs;
+            if (s->exp)
+                s1 = new CompoundStatement(s->loc, new ExpStatement(s->loc, s->exp), gs);
 
-            s->exp = exp;
+            replaceCurrent(s1);
         }
     }
     void visit(TryFinallyStatement *s)
@@ -296,7 +290,6 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     outId = NULL;
     vresult = NULL;
     returnLabel = NULL;
-    scout = NULL;
     fensure = NULL;
     fbody = NULL;
     localsymtab = NULL;
@@ -336,6 +329,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     tookAddressOf = 0;
     requiresClosure = false;
     flags = 0;
+    returns = NULL;
     gotos = NULL;
 }
 
@@ -1571,6 +1565,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 fpostinv = new ExpStatement(Loc(), e);
         }
 
+        Scope *scout = NULL;
         if (fensure || addPostInvariant())
         {
             if ((fensure && global.params.useOut) || fpostinv)
@@ -1611,6 +1606,8 @@ void FuncDeclaration::semantic3(Scope *sc)
             if (!inferRetType && retStyle(f) != RETstack)
                 nrvo_can = 0;
 
+            bool inferRef = (f->isref && (storage_class & STCauto));
+
             fbody = fbody->semantic(sc2);
             if (!fbody)
                 fbody = new CompoundStatement(Loc(), new Statements());
@@ -1621,12 +1618,28 @@ void FuncDeclaration::semantic3(Scope *sc)
             if (inferRetType && !f->next)
                 f->next = Type::tvoid;
 
-            if (f->next->ty != Tvoid)
+            if (returns && !fbody->isErrorStatement())
             {
-                NrvoWalker nw;
-                nw.fd = this;
-                nw.sc = sc2;
-                nw.visitStmt(fbody);
+                for (size_t i = 0; i < returns->dim; )
+                {
+                    Expression *exp = (*returns)[i]->exp;
+                    if (exp->op == TOKvar && ((VarExp *)exp)->var == vresult)
+                    {
+                        exp->type = f->next;
+                        // Remove `return vresult;` from returns
+                        returns->remove(i);
+                        continue;
+                    }
+                    if (inferRef && f->isref && !exp->type->constConv(f->next))     // Bugzilla 13336
+                        f->isref = false;
+                    i++;
+                }
+            }
+            if (f->isref)   // Function returns a reference
+            {
+                if (storage_class & STCauto)
+                    storage_class &= ~STCauto;
+                nrvo_can = 0;
             }
 
             if (isStaticCtorDeclaration())
@@ -1732,10 +1745,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                  */
                 if (blockexit & BEfallthru)
                 {
-                    Expression *e = new ThisExp(loc);
-                    if (cd)
-                        e->type = cd->type;
-                    Statement *s = new ReturnStatement(loc, e);
+                    Statement *s = new ReturnStatement(loc, NULL);
                     s = s->semantic(sc2);
                     fbody = new CompoundStatement(loc, fbody, s);
                 }
@@ -1807,6 +1817,83 @@ void FuncDeclaration::semantic3(Scope *sc)
                 }
             }
 
+            if (returns && !fbody->isErrorStatement())
+            {
+                bool implicit0 = (f->next->ty == Tvoid && isMain());
+                Type *tret = implicit0 ? Type::tint32 : f->next;
+                assert(tret->ty != Tvoid);
+                if (vresult || returnLabel)
+                    buildResultVar(scout ? scout : sc2, tret);
+
+                /* Cannot move this loop into NrvoWalker, because
+                 * returns[i] may be in the nested delegate for foreach-body.
+                 */
+                for (size_t i = 0; i < returns->dim; i++)
+                {
+                    ReturnStatement *rs = (*returns)[i];
+                    Expression *exp = rs->exp;
+
+                    if (!exp->implicitConvTo(tret) &&
+                        parametersIntersect(exp->type))
+                    {
+                        if (exp->type->immutableOf()->implicitConvTo(tret))
+                            exp = exp->castTo(sc2, exp->type->immutableOf());
+                        else if (exp->type->wildOf()->implicitConvTo(tret))
+                            exp = exp->castTo(sc2, exp->type->wildOf());
+                    }
+                    else
+                        exp = exp->implicitCastTo(sc2, tret);
+
+                    if (f->isref)
+                    {
+                        // Function returns a reference
+                        exp = exp->toLvalue(sc2, exp);
+                        exp->checkEscapeRef();
+                    }
+                    else
+                    {
+                        exp = exp->optimize(WANTvalue);
+
+                        /* Bugzilla 10789:
+                         * If NRVO is not possible, all returned lvalues should call their postblits.
+                         */
+                        if (!nrvo_can && exp->isLvalue())
+                            exp = callCpCtor(sc2, exp);
+
+                        exp->checkEscape();
+                    }
+
+                    exp = checkGC(sc, exp);
+
+                    if (vresult)
+                    {
+                        // Create: return vresult = exp;
+                        VarExp *ve = new VarExp(Loc(), vresult);
+                        ve->type = vresult->type;
+                        if (f->isref)
+                            exp = new ConstructExp(rs->loc, ve, exp);
+                        else
+                            exp = new BlitExp(rs->loc, ve, exp);
+                        exp->type = ve->type;
+
+                        if (rs->caseDim)
+                            exp = Expression::combine(exp, new IntegerExp(rs->caseDim));
+                    }
+                    else if (tintro && !tret->equals(tintro->nextOf()))
+                    {
+                        exp = exp->implicitCastTo(sc2, tintro->nextOf());
+                    }
+                    rs->exp = exp;
+                }
+            }
+            if (nrvo_var || returnLabel)
+            {
+                NrvoWalker nw;
+                nw.fd = this;
+                nw.sc = sc2;
+                nw.visitStmt(fbody);
+            }
+
             if (fieldinit)
                 mem.free(fieldinit);
             sc2 = sc2->pop();
@@ -1846,8 +1933,8 @@ void FuncDeclaration::semantic3(Scope *sc)
             if (f->next->ty == Tvoid && outId)
                 error("void functions have no result");
 
-            if (f->next->ty != Tvoid)
-                buildResultVar();
+            if (fensure && f->next->ty != Tvoid)
+                buildResultVar(scout, f->next);
 
             sc2 = scout;    //push
             sc2->flags = (sc2->flags & ~SCOPEcontract) | SCOPEensure;
@@ -2345,41 +2432,43 @@ bool FuncDeclaration::equals(RootObject *o)
  * Declare result variable lazily.
  */
 
-void FuncDeclaration::buildResultVar()
+void FuncDeclaration::buildResultVar(Scope *sc, Type *tret)
 {
-    if (vresult)
-        return;
-
-    assert(type->nextOf());
-    assert(type->nextOf()->toBasetype()->ty != Tvoid);
-    TypeFunction *tf = (TypeFunction *)type;
-
-    Loc loc = this->loc;
-
-    if (fensure)
-        loc = fensure->loc;
-
-    if (!outId)
-        outId = Id::result;         // provide a default
-
-    VarDeclaration *v = new VarDeclaration(loc, type->nextOf(), outId, NULL);
-    if (outId == Id::result) v->storage_class |= STCtemp;
-    v->noscope = 1;
-    v->storage_class |= STCresult;
-    if (!isVirtual())
-        v->storage_class |= STCconst;
-    if (tf->isref)
+    if (!vresult)
     {
-        v->storage_class |= STCref | STCforeach;
-    }
-    v->semantic(scout);
-    if (!scout->insert(v))
-        error("out result %s is already defined", v->toChars());
-    v->parent = this;
-    vresult = v;
+        Loc loc = fensure ? fensure->loc : loc;
 
-    // vresult gets initialized with the function return value
-    // in ReturnStatement::semantic()
+        /* If inferRetType is true, tret may not be a correct return type yet.
+         * So, in here it may be a temporary type for vresult, and after
+         * fbody->semantic() running, vresult->type might be modified.
+         */
+        vresult = new VarDeclaration(loc, tret, outId ? outId : Id::result, NULL);
+        vresult->noscope = true;
+
+        if (outId == Id::result)
+            vresult->storage_class |= STCtemp;
+        if (!isVirtual())
+            vresult->storage_class |= STCconst;
+        vresult->storage_class |= STCresult;
+
+        // set before the semantic() for checkNestedReference()
+        vresult->parent = this;
+    }
+
+    if (sc && vresult->sem == SemanticStart)
+    {
+        assert(type->ty == Tfunction);
+        TypeFunction *tf = (TypeFunction *)type;
+        if (tf->isref)
+            vresult->storage_class |= STCref | STCforeach;
+        vresult->type = tret;
+
+        vresult->semantic(sc);
+
+        if (!sc->insert(vresult))
+            error("out result %s is already defined", vresult->toChars());
+        assert(vresult->parent == this);
+    }
 }
 
 /****************************************************
@@ -4287,6 +4376,9 @@ void FuncLiteralDeclaration::modifyReturns(Scope *sc, Type *tret)
     };
 
     if (semanticRun < PASSsemantic3done)
+        return;
+
+    if (fes)
         return;
 
     RetWalker w;

--- a/src/func.c
+++ b/src/func.c
@@ -4323,13 +4323,9 @@ CtorDeclaration::CtorDeclaration(Loc loc, Loc endloc, StorageClass stc, Type *ty
 
 Dsymbol *CtorDeclaration::syntaxCopy(Dsymbol *s)
 {
+    assert(!s);
     CtorDeclaration *f = new CtorDeclaration(loc, endloc, storage_class, type->syntaxCopy());
-    f->outId = outId;
-    f->frequire = frequire ? frequire->syntaxCopy() : NULL;
-    f->fensure  = fensure  ? fensure->syntaxCopy()  : NULL;
-    f->fbody    = fbody    ? fbody->syntaxCopy()    : NULL;
-    assert(!fthrows); // deprecated
-    return f;
+    return FuncDeclaration::syntaxCopy(f);
 }
 
 void CtorDeclaration::semantic(Scope *sc)

--- a/src/func.c
+++ b/src/func.c
@@ -41,8 +41,8 @@ class StatementRewriteWalker : public Visitor
      * By using replaceCurrent() method, you can replace AST during walking.
      */
     Statement **ps;
-    void visitStmt(Statement *&s) { ps = &s; s->accept(this); }
 public:
+    void visitStmt(Statement *&s) { ps = &s; s->accept(this); }
     void replaceCurrent(Statement *s) { *ps = s; }
 
     void visit(ErrorStatement *s) {  }
@@ -1630,7 +1630,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 NrvoWalker nw;
                 nw.fd = this;
                 nw.sc = sc2;
-                fbody->accept(&nw);
+                nw.visitStmt(fbody);
             }
             assert(type == f);
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -522,6 +522,7 @@ class ReturnStatement : public Statement
 {
 public:
     Expression *exp;
+    size_t caseDim;
 
     ReturnStatement(Loc loc, Expression *exp);
     Statement *syntaxCopy();

--- a/test/fail_compilation/fail1313a.d
+++ b/test/fail_compilation/fail1313a.d
@@ -1,3 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail1313a.d(13): Error: escaping reference to local a
+---
+*/
+
 int[] test()
 //out{}
 body

--- a/test/fail_compilation/fail1313b.d
+++ b/test/fail_compilation/fail1313b.d
@@ -1,3 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail1313b.d(13): Error: escaping reference to local a
+---
+*/
+
 int[] test()
 out{}
 body

--- a/test/fail_compilation/fail13336a.d
+++ b/test/fail_compilation/fail13336a.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13336a.d(27): Error: choose(true) is not an lvalue
+---
+*/
+
+class Animal {}
+class Cat : Animal {}
+class Dog : Animal {}
+
+Animal animal;
+Cat cat;
+
+auto ref choose(bool f)
+{
+    if (f)
+        return cat;
+    else
+        return animal;
+}
+
+void main()
+{
+    static assert(is(typeof(&choose) == Animal function(bool)));    // pass
+
+    choose(true) = new Dog();
+}

--- a/test/fail_compilation/fail13336b.d
+++ b/test/fail_compilation/fail13336b.d
@@ -1,0 +1,31 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+int sx;
+double sy;
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13336b.d(16): Error: cast(double)sx is not an lvalue
+---
+*/
+ref f1(bool f)
+{
+    if (f)
+        return sx;
+    return sy;
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13336b.d(30): Error: cast(double)sx is not an lvalue
+---
+*/
+ref f2(bool f)
+{
+    if (f)
+        return sy;
+    return sx;
+}

--- a/test/fail_compilation/fail351.d
+++ b/test/fail_compilation/fail351.d
@@ -1,9 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail351.d(14): Error: cast(uint)this.num[index] is not an lvalue
+---
+*/
+
 // 2780
 
 struct Immutable {
     immutable uint[2] num;
 
-    ref uint opIndex(uint index) immutable {
+    ref uint opIndex(size_t index) immutable {
         return num[index];
     }
 }

--- a/test/fail_compilation/fail41.d
+++ b/test/fail_compilation/fail41.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail41.d(17): Error: cannot implicitly convert expression (mc) of type fail41.MyClass to void
+fail_compilation/fail41.d(17): Error: cannot return non-void from void function
 ---
 */
 

--- a/test/fail_compilation/ice10212.d
+++ b/test/fail_compilation/ice10212.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10212.d(13): Error: mismatched function return type inference of int function() pure nothrow @nogc @safe and int
-fail_compilation/ice10212.d(13): Error: cannot implicitly convert expression (__lambda1) of type int function() pure nothrow @nogc @safe to int
+fail_compilation/ice10212.d(12): Error: mismatched function return type inference of int function() pure nothrow @nogc @safe and int
 ---
 */
 

--- a/test/runnable/testreturn.d
+++ b/test/runnable/testreturn.d
@@ -1,0 +1,160 @@
+extern(C) int printf(const char*, ...);
+
+alias TypeTuple(T...) = T;
+
+/***************************************************/
+// 13336
+
+struct S13336
+{
+    int opApply(scope int delegate(int) dg)
+    {
+        return dg(0);
+    }
+}
+
+double result13336;
+
+enum fbody13336 =
+q{
+    static if (n == 1)
+    {
+        if (f)
+            return sx;
+        return sy;
+    }
+    static if (n == 2)
+    {
+        foreach (e; S13336())
+        {
+            if (f)
+                return sx;
+            return sy;
+        }
+        assert(0);
+    }
+    static if (n == 3)
+    {
+        if (f)
+            return sx;
+        foreach (e; S13336())
+        {
+            return sy;
+        }
+        assert(0);
+    }
+    static if (n == 4)
+    {
+        foreach (e; S13336())
+        {
+            if (f)
+                return sx;
+        }
+        return sy;
+    }
+    static if (n == 5)
+    {
+        if (false)
+            return 99;
+        foreach (e; S13336())
+        {
+            if (f)
+                return sx;
+            return sy;
+        }
+        assert(0);
+    }
+    static if (n == 6)
+    {
+        foreach (e; S13336())
+        {
+            if (f)
+                return sx;
+            return sy;
+        }
+        return 99;
+    }
+};
+
+// auto ref without out contract
+auto ref f13336a(int n, alias sx, alias sy)(bool f)
+{
+    mixin(fbody13336);
+}
+
+// auto without out contract
+auto f13336b(int n, alias sx, alias sy)(bool f)
+{
+    mixin(fbody13336);
+}
+
+// auto ref with out contract
+auto ref f13336c(int n, alias sx, alias sy)(bool f)
+out(r)
+{
+    static assert(is(typeof(r) == const double));
+    assert(r == (f ? sx : sy));
+    result13336 = r;
+}
+body
+{
+    mixin(fbody13336);
+}
+
+// auto with out contract
+auto f13336d(int n, alias sx, alias sy)(bool f)
+out(r)
+{
+    static assert(is(typeof(r) == const double));
+    assert(r == (f ? sx : sy));
+    result13336 = r;
+}
+body
+{
+    mixin(fbody13336);
+}
+
+void test13336()
+{
+    static int sx = 1;
+    static double sy = 2.5;
+
+    foreach (num; TypeTuple!(1, 2, 3, 4, 5, 6))
+    {
+        foreach (foo; TypeTuple!(f13336a, f13336b))
+        {
+            alias fooxy = foo!(num, sx, sy);
+            static assert(is(typeof(&fooxy) : double function(bool)));
+            assert(fooxy(1) == 1.0);
+            assert(fooxy(0) == 2.5);
+
+            alias fooyx = foo!(num, sy, sx);
+            static assert(is(typeof(&fooyx) : double function(bool)));
+            assert(fooyx(1) == 2.5);
+            assert(fooyx(0) == 1.0);
+        }
+
+        foreach (foo; TypeTuple!(f13336c, f13336d))
+        {
+            alias fooxy = foo!(num, sx, sy);
+            static assert(is(typeof(&fooxy) : double function(bool)));
+            assert(fooxy(1) == 1.0 && result13336 == 1.0);
+            assert(fooxy(0) == 2.5 && result13336 == 2.5);
+
+            alias fooyx = foo!(num, sy, sx);
+            static assert(is(typeof(&fooyx) : double function(bool)));
+            assert(fooyx(1) == 2.5 && result13336 == 2.5);
+            assert(fooyx(0) == 1.0 && result13336 == 1.0);
+        }
+    }
+}
+
+/***************************************************/
+
+int main()
+{
+    test13336();
+
+    printf("Success\n");
+    return 0;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13336

Deduce `auto ref` from all return statements, as same as return type inference.
