### PR TITLE
Check for NULL when looking up getenv("HOME").

### DIFF
--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -127,8 +127,14 @@ Strings *FileName::splitPath(const char *path)
 
 #if POSIX
                     case '~':
-                        buf.writestring(getenv("HOME"));
+                    {
+                        char *home = getenv("HOME");
+                        if (home)
+                            buf.writestring(home);
+                        else
+                            buf.writestring("~");
                         continue;
+                    }
 #endif
 
 #if 0


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=12130

This bug is caused by dmd attempting to look up a literal '~' in `$PATH`, but when `HOME` is not set, `getenv("HOME")` returns NULL, which causes `strlen` to segfault. Note that this only happens if the user's `$PATH` environment variable contains a literal `~`; usually, in bash, attempting to set `~` in HOME will cause the `~` to be autoexpanded to the value of HOME, so to reproduce this bug, you have to escape the `~`, like so:

```
export PATH=\~:$PATH
unset HOME
dmd  # <--- segfaults
```

Question: This bug requires a specific runtime environment for dmd; does the testsuite provide facilities for testing this sort of thing?
