### PR TITLE
add __c_long_double to support Win64 long double

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -1392,7 +1392,12 @@ unsigned totym(Type *tx)
         case Tdelegate: t = TYdelegate; break;
         case Tarray:    t = TYdarray;   break;
         case Tsarray:   t = TYstruct;   break;
-        case Tstruct:   t = TYstruct;   break;
+
+        case Tstruct:
+            t = TYstruct;
+            if (tx->toDsymbol(NULL)->ident == Id::__c_long_double)
+                t = TYdouble;
+            break;
 
         case Tenum:
         case Ttypedef:

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -77,6 +77,7 @@ Msgtable msgtable[] =
     { "__vptr" },
     { "__monitor" },
     { "gate", "__gate" },
+    { "__c_long_double" },
 
     { "TypeInfo" },
     { "TypeInfo_Class" },

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -21,6 +21,7 @@
 #include "declaration.h"
 #include "enum.h"
 #include "aggregate.h"
+#include "id.h"
 
 #include "cc.h"
 #include "global.h"
@@ -138,6 +139,12 @@ public:
         else
         {
             StructDeclaration *sym = t->sym;
+            if (sym->ident == Id::__c_long_double)
+            {
+                t->ctype = type_fake(TYdouble);
+                t->ctype->Tcount++;
+                return;
+            }
             t->ctype = type_struct_class(sym->toPrettyChars(true), sym->alignsize, sym->structsize,
                     sym->arg1type ? Type_toCtype(sym->arg1type) : NULL,
                     sym->arg2type ? Type_toCtype(sym->arg2type) : NULL,

--- a/src/toir.c
+++ b/src/toir.c
@@ -840,6 +840,8 @@ RET retStyle(TypeFunction *tf)
         if (tns->ty == Tstruct)
         {
             StructDeclaration *sd = ((TypeStruct *)tns)->sym;
+            if (sd->ident == Id::__c_long_double)
+                return RETregs;
             if (!sd->isPOD() || sz >= 8)
                 return RETstack;
         }

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -487,6 +487,32 @@ extern(C++)
 
 /****************************************/
 
+version (CRuntime_Microsoft)
+{
+    struct __c_long_double
+    {
+	this(double d) { ld = d; }
+	double ld;
+	alias ld this;
+    }
+
+    alias __c_long_double myld;
+}
+else
+    alias c_long_double myld;
+
+extern (C++) myld testld(myld);
+
+
+void test15()
+{
+    myld ld = 5.0;
+    ld = testld(ld);
+    assert(ld == 6.0);
+}
+
+/****************************************/
+
 void main()
 {
     test1();
@@ -507,6 +533,7 @@ void main()
     test13161();
     test14();
     test13289();
+    test15();
 
     printf("Success\n");
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -341,3 +341,11 @@ bool f13289_cpp_test()
     return false;
 #endif
 }
+
+/******************************************/
+
+long double testld(long double ld)
+{
+    assert(ld == 5);
+    return ld + 1;
+}


### PR DESCRIPTION
I gave up on the idea of making a new basic type for  this, it turned out to be way too intrusive and disruptive. Instead, I created a special `__c_long_double` struct using D's wrapping capabilities. Then, the problem devolved into putting in special cases for the name mangling, and function call/return sequences.

After this is pulled, I'll add the alias to `core.stdc.config`:

```
alias __c_long_double c_long_double;
```

for Win64 only. If this works out, we'll do the same for `c_long` and `c_ulong`.
