### PR TITLE
Fix Issue 13478 - [REG2.066] Templates not emitted when also referenced in speculative contexts

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -6259,8 +6259,13 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
 #if LOG
             printf("\tit's a match with instance %p, %d\n", inst, inst->semanticRun);
 #endif
-            if (!inst->instantiatingModule || inst->instantiatingModule->isRoot())
+            // If this is not a speculative instantiation, it might allow us to
+            // elide codegen for the template instance.
+            if (!speculative &&
+                (!inst->instantiatingModule || inst->instantiatingModule->isRoot()))
+            {
                 inst->instantiatingModule = mi;
+            }
             errors = inst->errors;
             return;
         }

--- a/test/runnable/imports/template13478a.d
+++ b/test/runnable/imports/template13478a.d
@@ -1,0 +1,8 @@
+module imports.template13478a;
+
+bool foo(T)() {
+    // Make sure this is not inlined so template13478.o actually
+    // needs to reference it.
+    asm { nop; }
+    return false;
+}

--- a/test/runnable/imports/template13478b.d
+++ b/test/runnable/imports/template13478b.d
@@ -1,0 +1,7 @@
+import imports.template13478b;
+
+import imports.template13478a;
+
+// Note that foo is only used in the template constraint here.
+T barImpl(T)(T t) if (is(typeof({ foo!T(); }))) { return t; }
+int bar(int a) { return barImpl(a); }

--- a/test/runnable/template13478.d
+++ b/test/runnable/template13478.d
@@ -1,0 +1,10 @@
+/// Tests emission of templates also referenced in speculative contexts.
+/// Failure triggered with -inline.
+module template13478;
+
+import imports.template13478a;
+import imports.template13478b;
+
+int main() {
+   return foo!int();
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13478
