### PR TITLE
Add test case for issue 13478.

### DIFF
--- a/test/runnable/imports/template13478a.d
+++ b/test/runnable/imports/template13478a.d
@@ -1,0 +1,8 @@
+module imports.template13478a;
+
+bool foo(T)() {
+    // Make sure this is not inlined so template13478.o actually
+    // needs to reference it.
+    asm { nop; }
+    return false;
+}

--- a/test/runnable/imports/template13478b.d
+++ b/test/runnable/imports/template13478b.d
@@ -1,0 +1,7 @@
+import imports.template13478b;
+
+import imports.template13478a;
+
+// Note that foo is only used in the template constraint here.
+T barImpl(T)(T t) if (is(typeof({ foo!T(); }))) { return t; }
+int bar(int a) { return barImpl(a); }

--- a/test/runnable/template13478.d
+++ b/test/runnable/template13478.d
@@ -1,0 +1,10 @@
+/// Tests emission of templates also referenced in speculative contexts.
+/// Failure triggered with -inline.
+module template13478;
+
+import imports.template13478a;
+import imports.template13478b;
+
+int main() {
+   return foo!int();
+}


### PR DESCRIPTION
The issue was a 2.066 regression that has been fixed differently
on master in the meantime. This adds the test case from the
2.066 branch commit 972c90f.

https://issues.dlang.org/show_bug.cgi?id=13478
