### PR TITLE
add C++ mangling c_long and c_ulong

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -77,6 +77,8 @@ Msgtable msgtable[] =
     { "__vptr" },
     { "__monitor" },
     { "gate", "__gate" },
+    { "__c_long" },
+    { "__c_ulong" },
     { "__c_long_double" },
 
     { "TypeInfo" },

--- a/src/toir.c
+++ b/src/toir.c
@@ -858,7 +858,9 @@ Lagain:
         {
 L2:
             if (global.params.isLinux && tf->linkage != LINKd && !global.params.is64bit)
+            {
                 ;                               // 32 bit C/C++ structs always on stack
+            }
             else
             {
                 switch (sz)
@@ -884,6 +886,9 @@ L2:
         StructDeclaration *sd = ((TypeStruct *)tns)->sym;
         if (global.params.isLinux && tf->linkage != LINKd && !global.params.is64bit)
         {
+            if (sd->ident == Id::__c_long || sd->ident == Id::__c_ulong)
+                return RETregs;
+
             //printf("  2 RETstack\n");
             return RETstack;            // 32 bit C/C++ structs always on stack
         }

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -513,6 +513,62 @@ void test15()
 
 /****************************************/
 
+version( Windows )
+{
+    alias int   x_long;
+    alias uint  x_ulong;
+}
+else
+{
+  static if( (void*).sizeof > int.sizeof )
+  {
+    alias long  x_long;
+    alias ulong x_ulong;
+  }
+  else
+  {
+    alias int   x_long;
+    alias uint  x_ulong;
+  }
+}
+
+struct __c_long
+{
+    this(x_long d) { ld = d; }
+    x_long ld;
+    alias ld this;
+}
+
+struct __c_ulong
+{
+    this(x_ulong d) { ld = d; }
+    x_ulong ld;
+    alias ld this;
+}
+
+alias __c_long mylong;
+alias __c_ulong myulong;
+
+extern (C++) mylong testl(mylong);
+extern (C++) myulong testul(myulong);
+
+
+void test16()
+{
+  {
+    mylong ld = 5;
+    ld = testl(ld);
+    assert(ld == 5 + mylong.sizeof);
+  }
+  {
+    myulong ld = 5;
+    ld = testul(ld);
+    assert(ld == 5 + myulong.sizeof);
+  }
+}
+
+/****************************************/
+
 void main()
 {
     test1();
@@ -534,6 +590,7 @@ void main()
     test14();
     test13289();
     test15();
+    test16();
 
     printf("Success\n");
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -349,3 +349,18 @@ long double testld(long double ld)
     assert(ld == 5);
     return ld + 1;
 }
+
+long testl(long lng)
+{
+    assert(lng == 5);
+    return lng + sizeof(long);
+}
+
+unsigned long testul(unsigned long ul)
+{
+    assert(ul == 5);
+    return ul + sizeof(unsigned long);
+}
+
+/******************************************/
+


### PR DESCRIPTION
Similar to the c_long_double change.
Also changes the Elf mangling of `long` and `ulong` on 64 bit Elf to be `x` and `y`, so it won't conflict with the long mangling.
