### PR TITLE
[tdpl] Multiple alias this

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -99,7 +99,7 @@ public:
     Dsymbol *ctor;                      // CtorDeclaration or TemplateDeclaration
     CtorDeclaration *defaultCtor;       // default constructor - should have no arguments, because
                                         // it would be stored in TypeInfo_Class.defaultConstructor
-    Dsymbol *aliasthis;                 // forward unresolved lookups to aliasthis
+    Dsymbols *aliasThisSymbols;         // forward unresolved lookups to aliasthis
     bool noDefaultCtor;         // no default construction
 
     FuncDeclarations dtors;     // Array of destructors

--- a/src/aliasthis.c
+++ b/src/aliasthis.c
@@ -21,18 +21,25 @@
 #include "mtype.h"
 #include "declaration.h"
 #include "tokens.h"
+#include "enum.h"
+#include "template.h"
+#include "arraytypes.h"
+#include "expression.h"
 
-Expression *resolveAliasThis(Scope *sc, Expression *e)
+/**
+ * Returns expression for the `num`-th alias this symbol ot `e`.
+ */
+Expression *resolveAliasThis(Scope *sc, Expression *e, size_t num)
 {
     AggregateDeclaration *ad = isAggregate(e->type);
 
-    if (ad && ad->aliasthis)
+    if (ad && ad->aliasThisSymbols)
     {
         Loc loc = e->loc;
         Type *tthis = (e->op == TOKtype ? e->type : NULL);
-        e = new DotIdExp(loc, e, ad->aliasthis->ident);
+        e = new DotIdExp(loc, e, (*ad->aliasThisSymbols)[num]->ident);
         e = e->semantic(sc);
-        if (tthis && ad->aliasthis->needThis())
+        if (tthis && (*ad->aliasThisSymbols)[num]->needThis())
         {
             if (e->op == TOKvar)
             {
@@ -67,6 +74,482 @@ Expression *resolveAliasThis(Scope *sc, Expression *e)
     }
 
     return e;
+}
+
+/**
+ * iterateAliasThis resolves alias this subtypes for `e` and applies it to `dg`.
+ * dg should return true, if appropriate subtype has been found.
+ * Otherwise it should returns 0.
+ * Also dg can get context through secong parameter `ctx`, which was passed through
+ * fourth argument of iterateAliasThis.  `dg` can return result expression through
+ * `outexpr` parameter, and if it is not NULL, it will be pushed to `ret` array.
+ * At the first stage iterateAliasThis iterates direct "alias this"-es and pushes non-null
+ * `outexpr`-es to `ret`. If `dg` for one of direct "alias this"-es returns true then
+ * `iterateAliasThis` breaks at this stage and returns true through return value and
+ * returned by `dg` expression array through `ret`.
+ * Even if true returned by first `dg` call, remaining direct "alias this"-es will be processed.
+ *
+ * If neither of the direct aliases did not return true iterateAliasThis
+ * is recursive applied to direct aliases and base classes and interfaces.
+ * If one of those `iterateAliasThis` calls returns true our `iterateAliasThis` will return true.
+ * Otherwise it will return 0.
+ *
+ * The last argument is needed for internal using and should be NULL in user call.
+ * It contains a hash table of visited types and used for avoiding of infinity recursion if
+ * processed type has a circular alias this subtyping:
+ * class A
+ * {
+ *      B b;
+ *      alias b this;
+ * }
+ *
+ * class B
+ * {
+ *      C c;
+ *      alias c this;
+ * }
+ *
+ * class C
+ * {
+ *      A a;
+ *      alias a this;
+ * }
+ */
+
+bool iterateAliasThis(Scope *sc, Expression *e, IterateAliasThisDg dg,
+                      void *ctx, Expressions *ret, bool gagerrors, StringTable *directtypes)
+{
+    //printf("iterateAliasThis: %s\n", e->toChars());
+
+    Dsymbols *aliasThisSymbols = NULL;
+    Type *baseType = e->type->toBasetype();
+    if (baseType->ty == Tstruct)
+    {
+        TypeStruct *ts = (TypeStruct *)baseType;
+        aliasThisSymbols = ts->sym->aliasThisSymbols;
+    }
+    else if (baseType->ty == Tclass)
+    {
+        TypeClass *ts = (TypeClass *)baseType;
+        if (ts->sym->aliasThisSymbols)
+        {
+            aliasThisSymbols = ts->sym->aliasThisSymbols;
+        }
+    }
+    else
+    {
+        return false;
+    }
+
+    if (!directtypes)
+    {
+        directtypes = new StringTable();
+        directtypes->_init();
+    }
+    StringValue *depth_counter = directtypes->lookup(e->type->deco, strlen(e->type->deco));
+    if (!depth_counter)
+    {
+        depth_counter = directtypes->insert(e->type->deco, strlen(e->type->deco));
+        depth_counter->ptrvalue = (void*)e;
+    }
+    else if (depth_counter->ptrvalue)
+    {
+        return false; //This type has already been visited.
+    }
+    else
+    {
+        depth_counter->ptrvalue = (void*)e;
+    }
+
+    bool r = false;
+
+    if (aliasThisSymbols)
+    {
+        for (size_t i = 0; i < aliasThisSymbols->dim; ++i)
+        {
+            unsigned olderrors = 0;
+            if (gagerrors)
+                olderrors = global.startGagging();
+            Expression *e1 = resolveAliasThis(sc, e, i);
+
+            if(gagerrors && global.endGagging(olderrors))
+                continue;
+            if (e1->type->ty == Terror)
+                continue;
+            assert(e1->type->deco);
+
+            Expression *e2 = NULL;
+            int success = dg(sc, e1, ctx, &e2);
+            r = r || success;
+
+            if (e2)
+            {
+                ret->push(e2);
+            }
+
+            if (!success)
+            {
+                r = iterateAliasThis(sc, e1, dg, ctx, ret, gagerrors, directtypes) || r;
+            }
+        }
+    }
+
+    if (e->type->ty == Tclass)
+    {
+        ClassDeclaration *cd = ((TypeClass *)e->type)->sym;
+        assert(cd->baseclasses);
+        for (size_t i = 0; i < cd->baseclasses->dim; ++i)
+        {
+            ClassDeclaration *bd = (*cd->baseclasses)[i]->base;
+            Type *bt = bd->type;
+            Expression *e1 = e->castTo(sc, bt);
+            r = iterateAliasThis(sc, e1, dg, ctx, ret, gagerrors, directtypes) || r;
+        }
+    }
+
+    depth_counter->ptrvalue = NULL;
+    return r;
+}
+
+/**
+ * Returns the type of the `idx`-th alias this symbol of the type `t`.
+ * If the `islvalue` is not null, `aliasThisOf` sets `*islvalue` to true
+ * if alias this symbol may be resolved to a L-value (if it variable of ref-property),
+ * otherwise it sets `*islvalue` to false.
+ */
+
+Type *aliasThisOf(Type *t, size_t idx, bool *islvalue = NULL)
+{
+    bool dummy;
+    if (!islvalue)
+        islvalue = &dummy;
+    *islvalue = false;
+    AggregateDeclaration *ad = isAggregate(t);
+    if (ad && ad->aliasThisSymbols && ad->aliasThisSymbols->dim > idx)
+    {
+        Dsymbol *s = (*ad->aliasThisSymbols)[idx];
+        if (s->isAliasDeclaration())
+            s = s->toAlias();
+        Declaration *d = s->isDeclaration();
+        if (d && !d->isTupleDeclaration())
+        {
+            assert(d->type);
+            Type *t2 = d->type;
+            if (d->isVarDeclaration() && d->needThis())
+            {
+                t2 = t2->addMod(t->mod);
+                *islvalue = true; //Variable is always l-value
+            }
+            else if (d->isFuncDeclaration())
+            {
+                FuncDeclaration *fd = resolveFuncCall(Loc(), NULL, d, NULL, t, NULL, 1);
+                if (fd && fd->errors)
+                    return Type::terror;
+                if (fd && !fd->type->nextOf() && !fd->functionSemantic())
+                    fd = NULL;
+                if (fd)
+                {
+                    t2 = fd->type->nextOf();
+                    if (!t2) // issue 14185
+                        return Type::terror;
+                    t2 = t2->substWildTo(t->mod == 0 ? MODmutable : t->mod);
+                    if (((TypeFunction *)fd->type)->isref)
+                        *islvalue = true;
+                }
+                else
+                    return Type::terror;
+            }
+            return t2;
+        }
+        EnumDeclaration *ed = s->isEnumDeclaration();
+        if (ed)
+        {
+            Type *t2 = ed->type;
+            return t2;
+        }
+        TemplateDeclaration *td = s->isTemplateDeclaration();
+        if (td)
+        {
+            assert(td->scope);
+            FuncDeclaration *fd = resolveFuncCall(Loc(), NULL, td, NULL, t, NULL, 1);
+            if (fd && fd->errors)
+                return Type::terror;
+            if (fd && fd->functionSemantic())
+            {
+                Type *t2 = fd->type->nextOf();
+                t2 = t2->substWildTo(t->mod == 0 ? MODmutable : t->mod);
+                if (((TypeFunction *)fd->type)->isref)
+                    *islvalue = true;
+                return t2;
+            }
+            else
+                return Type::terror;
+        }
+        //printf("%s\n", s->kind());
+    }
+    return NULL;
+}
+
+/**
+ * Walks over `from` basetype tree and search types,
+ * which can be converted (without alias this subtyping) to `to`.
+ * If there are many ways to convert `from` to `to`, this function
+ * raises an error and prints all those ways.
+ * To prevent infinity loop in types with circular subtyping,
+ * pattern "check a flag, lock a flag, do work is a flag wasn't locked, return flag back" is used.
+ * `root_from`, `fullSymbolName`, `state` and `matchname` are needed for internal
+ * using and should be NULL if the initial call.
+ * `root_from` contains the initial `from` type and it is needed for correct error
+ * message creating.
+ * `fullSymbolName` contains the current symbol name like `TypeA.symbolX.symbolY` and needed
+ * for the error message creating.
+ * `state` contains current state of the lookup: no matches, there is one match,
+ * there are many matches: even if we have found two matches and we are know that
+ * we will raise the error, we should find remaining matches for the correct error message.
+ * `matchname` contains the full name of the found alias this symbol. It is needed,
+ * if we will find anothers matches and will need to raise an error.
+ **/
+MATCH implicitConvToWithAliasThis(Loc loc, Type *from, Type *to, Type *root_from, OutBuffer *fullSymbolName,
+                                  int *state, OutBuffer *matchname)
+{
+    //printf("implicitConvToWithAliasThis, %s -> %s\n", from->toChars(), to->toChars());
+    if (from->aliasthislock & RECtracing)
+        return MATCHnomatch;
+
+    unsigned oldatlock = from->aliasthislock;
+    from->aliasthislock |= RECtracing;
+    if (!fullSymbolName)
+    {
+        fullSymbolName = new OutBuffer();
+        fullSymbolName->writestring(from->toChars());
+    }
+    int st = 0; //0 - no match
+                //1 - match
+                //2 - many matches
+    if (!state)
+        state = &st;
+
+    if (!matchname)
+    {
+        matchname = new OutBuffer();
+    }
+
+    if (!root_from)
+    {
+        root_from = from;
+    }
+    int a_count = 0;
+    AggregateDeclaration *ad = isAggregate(from);
+    if (!ad)
+        return MATCHnomatch;
+    AggregateDeclaration *err_ad = isAggregate(root_from);
+    assert(err_ad);
+    if (ad && ad->aliasThisSymbols)
+        a_count = (int)ad->aliasThisSymbols->dim;
+
+    MATCH mret = MATCHnomatch;
+    for (size_t i = 0; i < a_count; i++)
+    {
+        bool islvalue = false;
+        Type *a = aliasThisOf(from, i, &islvalue);
+        if (!a)
+            continue;
+
+        unsigned tatt = a->aliasthislock;
+        a->aliasthislock |= RECtracing;
+        MATCH m = a->implicitConvTo(to);
+        a->aliasthislock = tatt;
+
+        if (m != MATCHnomatch)
+        {
+            if (*state == 0)
+            {
+                // the first match
+                *state = 1;
+                mret = m;
+                matchname->printf("%s.%s", fullSymbolName->peekString(), (*ad->aliasThisSymbols)[i]->toChars());
+            }
+            else if (*state == 1)
+            {
+                // the second match
+                *state = 2;
+                err_ad->error(loc, "There are many candidates for cast %s to %s; Candidates:",
+                              root_from->toChars(), to->toChars());
+                err_ad->error(loc, " => %s", matchname->extractString());
+                matchname->printf("%s.%s", fullSymbolName->peekString(), (*ad->aliasThisSymbols)[i]->toChars());
+                err_ad->error(loc, " => %s", matchname->extractString());
+            }
+            else
+            {
+                matchname->printf("%s.%s", fullSymbolName->peekString(), (*ad->aliasThisSymbols)[i]->toChars());
+                err_ad->error(loc, " => %s", matchname->extractString());
+            }
+        }
+        else if (!(a->aliasthislock & RECtracing))
+        {
+            OutBuffer next_buff;
+            next_buff.printf("%s.%s", fullSymbolName->peekString(), (*ad->aliasThisSymbols)[i]->toChars());
+
+            MATCH m2 = implicitConvToWithAliasThis(loc, a, to, root_from, &next_buff, state, matchname);
+
+            if (mret == MATCHnomatch)
+                mret = m2;
+        }
+    }
+
+    if (ClassDeclaration *cd = ad ? ad->isClassDeclaration() : NULL)
+    {
+        for (size_t i = 0; i < cd->baseclasses->dim; i++)
+        {
+            ClassDeclaration *bd = (*cd->baseclasses)[i]->base;
+            Type *bt = (*cd->baseclasses)[i]->type;
+            if (!bt)
+                bt = bd->type;
+            if (!(bt->aliasthislock & RECtracing))
+            {
+                OutBuffer next_buff;
+                next_buff.printf("(cast(%s)%s)", bt->toChars(), fullSymbolName->peekString());
+
+                MATCH m2 = implicitConvToWithAliasThis(loc, bt, to, root_from, &next_buff, state, matchname);
+
+                if (mret == MATCHnomatch)
+                    mret = m2;
+            }
+        }
+    }
+    from->aliasthislock = oldatlock;
+    return mret;
+}
+
+/***
+ * Returns (through `ret`) all subtypes of `t`, which can be implied via
+ * alias this mechanism.
+ * The `islvalues` contains the array of bool values: the one value for a
+ * one `ret` value.
+ * This value is true if appropriate type from `ret` refers to L-value symbol,
+ * otherwise this value if false.
+ */
+void getAliasThisTypes(Type *t, Types *ret, Bools *islvalues)
+{
+    assert(ret);
+    int a_count = 0;
+    AggregateDeclaration *ad = isAggregate(t);
+    if (ad && ad->aliasThisSymbols)
+        a_count = (int)ad->aliasThisSymbols->dim;
+
+    for (size_t i = 0; i < a_count; i++)
+    {
+        bool islvalue = false;
+        Type *a = aliasThisOf(t, i, &islvalue);
+        if (!a)
+            continue;
+
+        bool duplicate = false;
+
+        for (size_t j = 0; j < ret->dim; ++j)
+        {
+            if ((*ret)[j]->equals(a))
+            {
+                duplicate = true;
+                break;
+            }
+        }
+        if (!duplicate)
+        {
+            ret->push(a);
+            if (islvalues)
+            {
+                islvalues->push(islvalue);
+            }
+            getAliasThisTypes(a, ret);
+        }
+    }
+
+    if (ClassDeclaration *cd = ad ? ad->isClassDeclaration() : NULL)
+    {
+        for (size_t i = 0; i < cd->baseclasses->dim; i++)
+        {
+            ClassDeclaration *bd = (*cd->baseclasses)[i]->base;
+            Type *bt = (*cd->baseclasses)[i]->type;
+            if (!bt)
+                bt = bd->type;
+            getAliasThisTypes(bt, ret, islvalues);
+        }
+    }
+}
+
+
+/****************************************
+ * Expand alias this tuples.
+ */
+
+TupleDeclaration *isAliasThisTuple(Expression *e)
+{
+    if (!e->type)
+        return NULL;
+
+    Type *t = e->type->toBasetype();
+    Lagain:
+    if (Dsymbol *s = t->toDsymbol(NULL))
+    {
+        AggregateDeclaration *ad = s->isAggregateDeclaration();
+        if (ad && ad->aliasThisSymbols)
+        {
+            s = (*ad->aliasThisSymbols)[0]; //Now it works only with single alias this
+            if (s && s->isVarDeclaration())
+            {
+                TupleDeclaration *td = s->isVarDeclaration()->toAlias()->isTupleDeclaration();
+                if (td && td->isexp)
+                    return td;
+            }
+            if (Type *att = aliasThisOf(t, 0))
+            {
+                t = att;
+                goto Lagain;
+            }
+        }
+    }
+    return NULL;
+}
+
+int expandAliasThisTuples(Expressions *exps, size_t starti)
+{
+    if (!exps || exps->dim == 0)
+        return -1;
+
+    for (size_t u = starti; u < exps->dim; u++)
+    {
+        Expression *exp = (*exps)[u];
+        TupleDeclaration *td = isAliasThisTuple(exp);
+        if (td)
+        {
+            exps->remove(u);
+            for (size_t i = 0; i<td->objects->dim; ++i)
+            {
+                Expression *e = isExpression((*td->objects)[i]);
+                assert(e);
+                assert(e->op == TOKdsymbol);
+                DsymbolExp *se = (DsymbolExp *)e;
+                Declaration *d = se->s->isDeclaration();
+                assert(d);
+                e = new DotVarExp(exp->loc, exp, d);
+                assert(d->type);
+                e->type = d->type;
+                exps->insert(u + i, e);
+            }
+    #if 0
+            printf("expansion ->\n");
+            for (size_t i = 0; i<exps->dim; ++i)
+            {
+                Expression *e = (*exps)[i];
+                printf("\texps[%d] e = %s %s\n", i, Token::tochars[e->op], e->toChars());
+            }
+    #endif
+            return (int)u;
+        }
+    }
+
+    return -1;
 }
 
 AliasThis::AliasThis(Loc loc, Identifier *ident)
@@ -107,25 +590,34 @@ void AliasThis::semantic(Scope *sc)
             ::error(loc, "undefined identifier %s", ident->toChars());
         return;
     }
-    else if (ad->aliasthis && s != ad->aliasthis)
+    TupleDeclaration *td = s->isVarDeclaration() ? s->isVarDeclaration()->toAlias()->isTupleDeclaration() : NULL;
+
+    if (ad->aliasThisSymbols && ad->aliasThisSymbols->dim > 0 && td && !(*ad->aliasThisSymbols)[0]->equals(td))
     {
-        ::error(loc, "there can be only one alias this");
-        return;
+        ::error(loc, "there can be only one tuple alias this", ident->toChars());
+    }
+    else if (ad->aliasThisSymbols && ad->aliasThisSymbols->dim > 0 && !td)
+    {
+        if ((*ad->aliasThisSymbols)[0]->isVarDeclaration() &&
+            (*ad->aliasThisSymbols)[0]->isVarDeclaration()->toAlias()->isTupleDeclaration())
+        {
+            ::error(loc, "there can be only one tuple alias this", ident->toChars());
+        }
     }
 
     if (ad->type->ty == Tstruct && ((TypeStruct *)ad->type)->sym != ad)
     {
         AggregateDeclaration *ad2 = ((TypeStruct *)ad->type)->sym;
         assert(ad2->type == Type::terror);
-        ad->aliasthis = ad2->aliasthis;
+        ad->aliasThisSymbols = ad2->aliasThisSymbols;
         return;
     }
 
     /* disable the alias this conversion so the implicit conversion check
      * doesn't use it.
      */
-    ad->aliasthis = NULL;
-
+    if (!ad->aliasThisSymbols)
+        ad->aliasThisSymbols = new Dsymbols();
     Dsymbol *sx = s;
     if (sx->isAliasDeclaration())
         sx = sx->toAlias();
@@ -134,13 +626,47 @@ void AliasThis::semantic(Scope *sc)
     {
         Type *t = d->type;
         assert(t);
-        if (ad->type->implicitConvTo(t) > MATCHnomatch)
+        if (d->isFuncDeclaration())
         {
-            ::error(loc, "alias this is not reachable as %s already converts to %s", ad->toChars(), t->toChars());
+            t = t->nextOf(); //t is return value;
+                             //t may be NULL, if d is a auto function
+        }
+
+        if (t)
+        {
+            /* disable the alias this conversion so the implicit conversion check
+            * doesn't use it.
+            */
+            unsigned oldatlock = ad->type->aliasthislock;
+            ad->type->aliasthislock |= RECtracing;
+            bool match = ad->type->implicitConvTo(t) > MATCHnomatch;
+            ad->type->aliasthislock = oldatlock;
+            if (match)
+            {
+                ::error(loc, "alias this is not reachable as %s already converts to %s", ad->toChars(), t->toChars());
+            }
+
+            for (size_t i = 0; i < ad->aliasThisSymbols->dim; ++i)
+            {
+                Dsymbol *sx2 = (*ad->aliasThisSymbols)[i];
+                if (sx2->isAliasDeclaration())
+                    sx2 = sx2->toAlias();
+                Declaration *d2 = sx2->isDeclaration();
+                if (d2 && !d2->isTupleDeclaration())
+                {
+                    Type *t2 = d2->type;
+                    assert(t2);
+                    if (t2->equals(t))
+                    {
+                        ::error(loc, "alias %s this tries to override another alias this with type %s",
+                                ident->toChars(), t2->toChars());
+                    }
+                }
+            }
         }
     }
 
-    ad->aliasthis = s;
+    ad->aliasThisSymbols->push(s);
 }
 
 const char *AliasThis::kind()

--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -72,4 +72,8 @@ typedef Array<struct block *> Blocks;
 
 typedef Array<struct Symbol *> Symbols;
 
+typedef Array<bool> Bools;
+
+typedef Array<const char *> Strings;
+
 #endif

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1346,33 +1346,94 @@ WithScopeSymbol::WithScopeSymbol(WithStatement *withstate)
     this->withstate = withstate;
 }
 
+struct FindMemberCtx
+{
+    Loc loc;
+    Identifier *ident;
+    int flags;
+    Dsymbols* candidates;
+};
+
+/**
+ * Should be called by iterateAliasThis.
+ * It tries to substitute subtyped expression to an DotIdExp inside an WithStatement.
+ * with(e) { ident } -> with(e) { aliasthisX.ident }
+ */
+static bool atSubstWithDotId(Scope *sc, Expression *e, void *ctx_, Expression **outexpr)
+{
+    FindMemberCtx *ctx = (FindMemberCtx*)ctx_;
+    Dsymbol *s = NULL;
+    if (e->op == TOKimport)
+    {
+        s = ((ScopeExp *)e)->sds;
+    }
+    else if (e->op == TOKtype)
+    {
+        s = e->type->toDsymbol(NULL);
+    }
+    else
+    {
+        Type *t = e->type->toBasetype();
+        s = t->toDsymbol(NULL);
+    }
+    if (s)
+    {
+        s = s->search(ctx->loc, ctx->ident);
+        if (s)
+        {
+            ctx->candidates->push(s);
+            return true;
+        }
+    }
+
+    return false;
+}
+
 Dsymbol *WithScopeSymbol::search(Loc loc, Identifier *ident, int flags)
 {
     // Acts as proxy to the with class declaration
     Dsymbol *s = NULL;
-    Expression *eold = NULL;
-    for (Expression *e = withstate->exp; e != eold; e = resolveAliasThis(scope, e))
+
+    Expression *e = withstate->exp;
+
+    if (e->op == TOKimport)
     {
-        if (e->op == TOKimport)
-        {
-            s = ((ScopeExp *)e)->sds;
-        }
-        else if (e->op == TOKtype)
-        {
-            s = e->type->toDsymbol(NULL);
-        }
-        else
-        {
-            Type *t = e->type->toBasetype();
-            s = t->toDsymbol(NULL);
-        }
+        s = ((ScopeExp *)e)->sds;
+    }
+    else if (e->op == TOKtype)
+    {
+        s = e->type->toDsymbol(NULL);
+    }
+    else
+    {
+        Type *t = e->type->toBasetype();
+        s = t->toDsymbol(NULL);
+    }
+    if (s)
+    {
+        s = s->search(loc, ident);
         if (s)
+            return s;
+    }
+
+    //try alias this-es
+    Dsymbols candidates;
+    Expressions results;
+
+    FindMemberCtx ctx = {loc, ident, flags, &candidates};
+    iterateAliasThis(scope, e, &atSubstWithDotId, &ctx, &results);
+
+    if (candidates.dim == 1)
+    {
+        return candidates[0];
+    }
+    else if (candidates.dim > 1)
+    {
+        e->error("There are many candidates to %s.%s resolve:", e->toChars(), ident->toChars());
+        for (size_t j = 0; j < results.dim; ++j)
         {
-            s = s->search(loc, ident);
-            if (s)
-                return s;
+            e->error("%s", results[j]->toChars());
         }
-        eold = e;
     }
     return NULL;
 }

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -986,7 +986,8 @@
                 "typedef GotoStatements",
                 "typedef TemplateInstances",
                 "typedef Blocks",
-                "typedef Symbols"
+                "typedef Symbols",
+                "typedef Bools"
             ]
         },
         {
@@ -1100,7 +1101,9 @@
                 "struct TypeTuple",
                 "struct TypeSlice",
                 "struct TypeNull",
-                "struct Parameter"
+                "struct Parameter",
+                "struct FindDotIdCtx",
+                "function atSubstDotId"
             ]
         },
         {
@@ -1937,7 +1940,9 @@
                 "struct WithScopeSymbol",
                 "struct ArrayScopeSymbol",
                 "struct OverloadSet",
-                "struct DsymbolTable"
+                "struct DsymbolTable",
+                "function atSubstWithDotId",
+                "struct FindMemberCtx"
             ]
         },
         {
@@ -2476,12 +2481,22 @@
                 "mtype",
                 "opover",
                 "root.outbuffer",
-                "visitor"
+                "root.stringtable",
+                "visitor",
+                "arraytypes",
+                "dclass",
+                "denum",
+                "dtemplate",
+                "core.stdc.string"
             ],
             "members" :
             [
                 "struct AliasThis",
-                "function resolveAliasThis"
+                "function resolveAliasThis",
+                "function iterateAliasThis",
+                "function getAliasThisTypes",
+                "function implicitConvToWithAliasThis",
+                "function aliasThisOf"
             ]
         },
         {
@@ -2861,7 +2876,19 @@
                 "struct LineInitExp",
                 "struct ModuleInitExp",
                 "struct FuncInitExp",
-                "struct PrettyFuncInitExp"
+                "struct PrettyFuncInitExp",
+                "typedef IterateAliasThisDg",
+                "function atSubstUna",
+                "function atSubstBinUna",
+                "function atSubstBinRhsConv",
+                "function atSubstUnaUna",
+                "function atSubstUnaDotId",
+                "function mergeAliasThis",
+                "function atCollectSubtypes",
+                "function atSubstCastTo",
+                "function findAliasThisSubtypes",
+                "function atSubstIdent",
+                "function atSubstCastToBool"
             ]
         },
         {
@@ -2912,7 +2939,8 @@
                 "globals",
                 "mtype",
                 "statement",
-                "visitor"
+                "visitor",
+                "aliasthis"
             ],
             "members" :
             [
@@ -2928,7 +2956,13 @@
                 "function inferAggregate",
                 "function inferApplyArgTypes",
                 "function inferApplyArgTypesX",
-                "function inferApplyArgTypesY"
+                "function inferApplyArgTypesY",
+                "function atSubstBinBoth",
+                "function atSubstBinRhs",
+                "function atSubstForeach",
+                "function resloveAliasThisForBinExp",
+                "function atSubstBinLhs",
+                "struct DoBothCtx"
             ]
         },
         {
@@ -3314,7 +3348,9 @@
         "PKG",
         "TRUSTformat",
         "Baseok",
-        "BOUNDSCHECK"
+        "BOUNDSCHECK",
+
+        "IterateAliasThisDg"
     ],
     "structTypes" :
     [
@@ -3345,7 +3381,9 @@
         "AsyncRead",
 
         "Strings",
-        "Sections"
+        "Sections",
+        "Bools",
+        "Strings"
     ],
     "classTypes" :
     [

--- a/src/struct.c
+++ b/src/struct.c
@@ -153,7 +153,7 @@ AggregateDeclaration::AggregateDeclaration(Loc loc, Identifier *id)
 
     ctor = NULL;
     defaultCtor = NULL;
-    aliasthis = NULL;
+    aliasThisSymbols = NULL;
     noDefaultCtor = false;
     dtor = NULL;
     getRTInfo = NULL;

--- a/src/template.c
+++ b/src/template.c
@@ -1313,7 +1313,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(
                 hasttp = true;
 
                 Type *t = new TypeIdentifier(Loc(), ttp->ident);
-                MATCH m = deduceType(tthis, paramscope, t, parameters, dedtypes);
+                MATCH m = deduceType(ti->loc, tthis, paramscope, t, parameters, dedtypes);
                 if (m <= MATCHnomatch)
                     goto Lnomatch;
                 if (m < match)
@@ -1681,7 +1681,7 @@ Lretry:
                 goto Lvarargs;
 
             unsigned wm = 0;
-            MATCH m = deduceType(oarg, paramscope, prmtype, parameters, dedtypes, &wm, inferStart);
+            MATCH m = deduceType(ti->loc, oarg, paramscope, prmtype, parameters, dedtypes, &wm, inferStart);
             //printf("\tL%d deduceType m = %d, wm = x%x, wildmatch = x%x\n", __LINE__, m, wm, wildmatch);
             wildmatch |= wm;
 
@@ -1693,18 +1693,19 @@ Lretry:
 
             if (m == MATCHnomatch)
             {
-                AggregateDeclaration *ad = isAggregate(farg->type);
-                if (ad && ad->aliasthis)
+                if (AggregateDeclaration *ad = isAggregate(farg->type))
                 {
-                    /* If a semantic error occurs while doing alias this,
-                     * eg purity(bug 7295), just regard it as not a match.
-                     */
-                    unsigned olderrors = global.startGagging();
-                    Expression *e = resolveAliasThis(sc, farg);
-                    if (!global.endGagging(olderrors))
+                    Expressions results;
+                    iterateAliasThis(sc, farg, &atSubstCastTo, (void*)prmtype, &results, true);
+
+                    if (results.dim == 1)
                     {
-                        farg = e;
+                        farg = results[0];
                         goto Lretry;
+                    }
+                    else if (results.dim > 1)
+                    {
+                        goto Lnomatch;
                     }
                 }
             }
@@ -1843,7 +1844,7 @@ Lretry:
                     else
                     {
                         unsigned wm = 0;
-                        m = deduceType(arg, paramscope, ta->next, parameters, dedtypes, &wm, inferStart);
+                        m = deduceType(ti->loc, arg, paramscope, ta->next, parameters, dedtypes, &wm, inferStart);
                         wildmatch |= wm;
                     }
                     if (m == MATCHnomatch)
@@ -2313,7 +2314,7 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
             return 0;
 
         if (!sc)
-            sc = td->scope; // workaround for Type::aliasthisOf
+            sc = td->scope; // workaround for aliasThisOf
 
         if (td->semanticRun == PASSinit && td->scope)
         {
@@ -3210,7 +3211,7 @@ MATCH deduceTypeHelper(Type *t, Type **at, Type *tparam)
  * Output:
  *      dedtypes = [ int ]      // Array of Expression/Type's
  */
-MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters,
+MATCH deduceType(Loc l, RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters,
         Objects *dedtypes, unsigned *wm, size_t inferStart)
 {
     class DeduceType : public Visitor
@@ -3223,9 +3224,9 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
         unsigned *wm;
         size_t inferStart;
         MATCH result;
-
-        DeduceType(Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm, size_t inferStart)
-            : sc(sc), tparam(tparam), parameters(parameters), dedtypes(dedtypes), wm(wm), inferStart(inferStart)
+        Loc loc;
+        DeduceType(Loc loc, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm, size_t inferStart)
+            : loc(loc), sc(sc), tparam(tparam), parameters(parameters), dedtypes(dedtypes), wm(wm), inferStart(inferStart)
         {
             result = MATCHnomatch;
         }
@@ -3266,7 +3267,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                      */
                     tparam = tparam->semantic(loc, sc);
                     assert(tparam->ty != Tident);
-                    result = deduceType(t, sc, tparam, parameters, dedtypes, wm);
+                    result = deduceType(loc, t, sc, tparam, parameters, dedtypes, wm);
                     return;
                 }
 
@@ -3446,31 +3447,39 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                         goto Lnomatch;
                 }
 
+                unsigned oldatlock1 = t->aliasthislock;
+                t->aliasthislock |= RECtracing;
                 MATCH m = t->implicitConvTo(tparam);
+                t->aliasthislock = oldatlock1;
                 if (m == MATCHnomatch)
                 {
-                    if (t->ty == Tclass)
+                    m = implicitConvToWithAliasThis(loc, t, tparam);
+                }
+                if (m == MATCHnomatch)
+                {
+                    if (!(tparam->aliasthislock & RECtracingDT))
                     {
-                        TypeClass *tc = (TypeClass *)t;
-                        if (tc->sym->aliasthis && !(tc->att & RECtracingDT))
+                        //do not call deduceType (with alias this) recursively.
+                        Types basetypes;
+                        getAliasThisTypes(t, &basetypes);
+
+                        for (size_t i = 0; i < basetypes.dim; i++)
                         {
-                            tc->att = (AliasThisRec)(tc->att | RECtracingDT);
-                            m = deduceType(t->aliasthisOf(), sc, tparam, parameters, dedtypes, wm);
-                            tc->att = (AliasThisRec)(tc->att & ~RECtracingDT);
-                        }
-                    }
-                    else if (t->ty == Tstruct)
-                    {
-                        TypeStruct *ts = (TypeStruct *)t;
-                        if (ts->sym->aliasthis && !(ts->att & RECtracingDT))
-                        {
-                            ts->att = (AliasThisRec)(ts->att | RECtracingDT);
-                            m = deduceType(t->aliasthisOf(), sc, tparam, parameters, dedtypes, wm);
-                            ts->att = (AliasThisRec)(ts->att & ~RECtracingDT);
+                            unsigned oldatlock2 = tparam->aliasthislock;
+                            tparam->aliasthislock |= RECtracingDT;
+                            m = deduceType(loc, basetypes[i], sc, tparam, parameters, dedtypes, wm);
+                            tparam->aliasthislock = oldatlock2;
+                            if (m != MATCHnomatch)
+                            {
+                                //Ok, now test, is there only one way exists
+                                m = implicitConvToWithAliasThis(loc, t, basetypes[i]);
+                                break;
+                            }
                         }
                     }
                 }
                 result = m;
+
                 return;
             }
 
@@ -3489,7 +3498,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                     tpn = tpn->substWildTo(MODmutable);
                 }
 
-                result = deduceType(t->nextOf(), sc, tpn, parameters, dedtypes, wm);
+                result = deduceType(loc, t->nextOf(), sc, tpn, parameters, dedtypes, wm);
                 return;
             }
 
@@ -3515,7 +3524,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
             if (tparam->ty == Tvector)
             {
                 TypeVector *tp = (TypeVector *)tparam;
-                result = deduceType(t->basetype, sc, tp->basetype, parameters, dedtypes, wm);
+                result = deduceType(loc, t->basetype, sc, tp->basetype, parameters, dedtypes, wm);
                 return;
             }
             visit((Type *)t);
@@ -3544,7 +3553,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
             {
                 if (tparam->ty == Tarray)
                 {
-                    MATCH m = deduceType(t->next, sc, tparam->nextOf(), parameters, dedtypes, wm);
+                    MATCH m = deduceType(loc, t->next, sc, tparam->nextOf(), parameters, dedtypes, wm);
                     result = (m >= MATCHconst) ? MATCHconvert : MATCHnomatch;
                     return;
                 }
@@ -3584,7 +3593,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                 if (tp && tp->matchArg(sc, t->dim, i, parameters, dedtypes, NULL) ||
                     edim && edim->toInteger() == t->dim->toInteger())
                 {
-                    result = deduceType(t->next, sc, tparam->nextOf(), parameters, dedtypes, wm);
+                    result = deduceType(loc, t->next, sc, tparam->nextOf(), parameters, dedtypes, wm);
                     return;
                 }
             }
@@ -3606,7 +3615,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
             if (tparam && tparam->ty == Taarray)
             {
                 TypeAArray *tp = (TypeAArray *)tparam;
-                if (!deduceType(t->index, sc, tp->index, parameters, dedtypes))
+                if (!deduceType(loc, t->index, sc, tp->index, parameters, dedtypes))
                 {
                     result = MATCHnomatch;
                     return;
@@ -3729,7 +3738,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                     Parameter *a = Parameter::getNth(t->parameters, i);
                     Parameter *ap = Parameter::getNth(tp->parameters, i);
                     if (a->storageClass != ap->storageClass ||
-                        !deduceType(a->type, sc, ap->type, parameters, dedtypes))
+                        !deduceType(loc, a->type, sc, ap->type, parameters, dedtypes))
                     {
                         result = MATCHnomatch;
                         return;
@@ -3930,7 +3939,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
 
                     if (t1 && t2)
                     {
-                        if (!deduceType(t1, sc, t2, parameters, dedtypes))
+                        if (!deduceType(loc, t1, sc, t2, parameters, dedtypes))
                             goto Lnomatch;
                     }
                     else if (e1 && e2)
@@ -4034,7 +4043,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                 if (ti && ti->toAlias() == t->sym)
                 {
                     TypeInstance *tx = new TypeInstance(Loc(), ti);
-                    result = deduceType(tx, sc, tparam, parameters, dedtypes, wm);
+                    result = deduceType(loc, tx, sc, tparam, parameters, dedtypes, wm);
                     return;
                 }
 
@@ -4053,7 +4062,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                             /* Slice off the .foo in S!(T).foo
                              */
                             tpi->idents.dim--;
-                            result = deduceType(tparent, sc, tpi, parameters, dedtypes, wm);
+                            result = deduceType(loc, tparent, sc, tpi, parameters, dedtypes, wm);
                             tpi->idents.dim++;
                             return;
                         }
@@ -4072,7 +4081,14 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                     result = MATCHconst;
                     return;
                 }
+                unsigned oldatlock = t->aliasthislock;
+                t->aliasthislock |= RECtracing;
                 result = t->implicitConvTo(tp);
+                t->aliasthislock = oldatlock;
+                if (!result)
+                {
+                    result = implicitConvToWithAliasThis(loc, t, tp);
+                }
                 return;
             }
             visit((Type *)t);
@@ -4094,7 +4110,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
             if (tb->ty == tparam->ty ||
                 tb->ty == Tsarray && tparam->ty == Taarray)
             {
-                result = deduceType(tb, sc, tparam, parameters, dedtypes, wm);
+                result = deduceType(loc, tb, sc, tparam, parameters, dedtypes, wm);
                 return;
             }
             visit((Type *)t);
@@ -4118,7 +4134,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
          * If a match occurs, numBaseClassMatches is incremented, and the new deduced
          * types are ANDed with the current 'best' estimate for dedtypes.
          */
-        static void deduceBaseClassParameters(BaseClass *b,
+        static void deduceBaseClassParameters(Loc loc, BaseClass *b,
             Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes,
             Objects *best, int &numBaseClassMatches)
         {
@@ -4131,7 +4147,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                 memcpy(tmpdedtypes->tdata(), dedtypes->tdata(), dedtypes->dim * sizeof(void *));
 
                 TypeInstance *t = new TypeInstance(Loc(), parti);
-                MATCH m = deduceType(t, sc, tparam, parameters, tmpdedtypes);
+                MATCH m = deduceType(loc, t, sc, tparam, parameters, tmpdedtypes);
                 if (m > MATCHnomatch)
                 {
                     // If this is the first ever match, it becomes our best estimate
@@ -4150,7 +4166,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
             // Now recursively test the inherited interfaces
             for (size_t j = 0; j < b->baseInterfaces_dim; ++j)
             {
-                deduceBaseClassParameters( &(b->baseInterfaces)[j],
+                deduceBaseClassParameters(loc, &(b->baseInterfaces)[j],
                     sc, tparam, parameters, dedtypes,
                     best, numBaseClassMatches);
             }
@@ -4172,7 +4188,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                 if (ti && ti->toAlias() == t->sym)
                 {
                     TypeInstance *tx = new TypeInstance(Loc(), ti);
-                    MATCH m = deduceType(tx, sc, tparam, parameters, dedtypes, wm);
+                    MATCH m = deduceType(loc, tx, sc, tparam, parameters, dedtypes, wm);
                     // Even if the match fails, there is still a chance it could match
                     // a base class.
                     if (m != MATCHnomatch)
@@ -4197,7 +4213,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                             /* Slice off the .foo in S!(T).foo
                              */
                             tpi->idents.dim--;
-                            result = deduceType(tparent, sc, tpi, parameters, dedtypes, wm);
+                            result = deduceType(loc, tparent, sc, tpi, parameters, dedtypes, wm);
                             tpi->idents.dim++;
                             return;
                         }
@@ -4224,7 +4240,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                 while (s && s->baseclasses->dim > 0)
                 {
                     // Test the base class
-                    deduceBaseClassParameters((*s->baseclasses)[0],
+                    deduceBaseClassParameters(loc, (*s->baseclasses)[0],
                         sc, tparam, parameters, dedtypes,
                         best, numBaseClassMatches);
 
@@ -4232,7 +4248,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                     for (size_t i = 0; i < s->interfaces_dim; ++i)
                     {
                         BaseClass *b = s->interfaces[i];
-                        deduceBaseClassParameters(b, sc, tparam, parameters, dedtypes,
+                        deduceBaseClassParameters(loc, b, sc, tparam, parameters, dedtypes,
                             best, numBaseClassMatches);
                     }
                     s = (*s->baseclasses)[0]->base;
@@ -4261,7 +4277,14 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                     result = MATCHconst;
                     return;
                 }
+                unsigned oldatlock = t->aliasthislock;
+                t->aliasthislock |= RECtracing;
                 result = t->implicitConvTo(tp);
+                t->aliasthislock = oldatlock;
+                if (!result)
+                {
+                    result = implicitConvToWithAliasThis(loc, t, tp);
+                }
                 return;
             }
             visit((Type *)t);
@@ -4276,7 +4299,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                 if (e == emptyArrayElement && tparam->ty == Tarray)
                 {
                     Type *tn = ((TypeNext *)tparam)->next;
-                    result = deduceType(emptyArrayElement, sc, tn, parameters, dedtypes, wm);
+                    result = deduceType(loc, emptyArrayElement, sc, tn, parameters, dedtypes, wm);
                     return;
                 }
                 e->type->accept(this);
@@ -4399,7 +4422,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
             assert(tparam->ty == Tarray);
 
             Type *tn = ((TypeNext *)tparam)->next;
-            return deduceType(emptyArrayElement, sc, tn, parameters, dedtypes, wm);
+            return deduceType(loc, emptyArrayElement, sc, tn, parameters, dedtypes, wm);
         }
 
         void visit(NullExp *e)
@@ -4445,7 +4468,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                 result = MATCHexact;
                 for (size_t i = 0; i < e->elements->dim; i++)
                 {
-                    MATCH m = deduceType((*e->elements)[i], sc, tn, parameters, dedtypes, wm);
+                    MATCH m = deduceType(loc, (*e->elements)[i], sc, tn, parameters, dedtypes, wm);
                     if (m < result)
                         result = m;
                     if (result <= MATCHnomatch)
@@ -4475,12 +4498,12 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                 result = MATCHexact;
                 for (size_t i = 0; i < e->keys->dim; i++)
                 {
-                    MATCH m1 = deduceType((*e->keys)[i], sc, taa->index, parameters, dedtypes, wm);
+                    MATCH m1 = deduceType(loc, (*e->keys)[i], sc, taa->index, parameters, dedtypes, wm);
                     if (m1 < result)
                         result = m1;
                     if (result <= MATCHnomatch)
                         break;
-                    MATCH m2 = deduceType((*e->values)[i], sc, taa->next, parameters, dedtypes, wm);
+                    MATCH m2 = deduceType(loc, (*e->values)[i], sc, taa->next, parameters, dedtypes, wm);
                     if (m2 < result)
                         result = m2;
                     if (result <= MATCHnomatch)
@@ -4599,7 +4622,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
         }
     };
 
-    DeduceType v(sc, tparam, parameters, dedtypes, wm, inferStart);
+    DeduceType v(l, sc, tparam, parameters, dedtypes, wm, inferStart);
     if (Type *t = isType(o))
         t->accept(&v);
     else
@@ -4886,7 +4909,7 @@ MATCH TemplateTypeParameter::matchArg(Scope *sc, RootObject *oarg,
             goto Lnomatch;
 
         //printf("\tcalling deduceType(): ta is %s, specType is %s\n", ta->toChars(), specType->toChars());
-        MATCH m2 = deduceType(ta, sc, specType, parameters, dedtypes);
+        MATCH m2 = deduceType(loc, ta, sc, specType, parameters, dedtypes);
         if (m2 <= MATCHnomatch)
         {
             //printf("\tfailed deduceType\n");
@@ -5178,7 +5201,7 @@ MATCH TemplateAliasParameter::matchArg(Scope *sc, RootObject *oarg,
                 goto Lnomatch;
 
             Type *t = new TypeInstance(Loc(), ti);
-            MATCH m2 = deduceType(t, sc, talias, parameters, dedtypes);
+            MATCH m2 = deduceType(loc, t, sc, talias, parameters, dedtypes);
             if (m2 <= MATCHnomatch)
                 goto Lnomatch;
         }

--- a/src/traits.c
+++ b/src/traits.c
@@ -862,8 +862,13 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
         }
 
         Expressions *exps = new Expressions();
-        if (ad->aliasthis)
-            exps->push(new StringExp(e->loc, ad->aliasthis->ident->toChars()));
+        if (ad->aliasThisSymbols)
+        {
+            for (size_t i = 0; i < ad->aliasThisSymbols->dim; i++)
+            {
+                exps->push(new StringExp(e->loc, (*ad->aliasThisSymbols)[i]->ident->toChars()));
+            }
+        }
 
         Expression *ex = new TupleExp(e->loc, exps);
         ex = ex->semantic(sc);

--- a/test/fail_compilation/aliasthis1.d
+++ b/test/fail_compilation/aliasthis1.d
@@ -1,0 +1,14 @@
+
+struct Foo
+{
+    int a;
+    int b;
+
+    alias a this;
+    alias b this;
+}
+
+void main()
+{
+
+} 

--- a/test/fail_compilation/fail5851a.d
+++ b/test/fail_compilation/fail5851a.d
@@ -1,0 +1,13 @@
+
+class Foo
+{
+    @property Object fun()
+    {
+        return null;
+    }
+    alias fun this;
+}
+
+void main()
+{
+}

--- a/test/fail_compilation/fail_casting.d
+++ b/test/fail_compilation/fail_casting.d
@@ -133,7 +133,7 @@ void test13959()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(144): Error: cannot cast expression mi.x of type int to MyUbyte14154
+fail_compilation/fail_casting.d(144): Error: cannot cast expression mi of type MyInt14154 to MyUbyte14154 because of different sizes
 ---
 */
 struct MyUbyte14154 { ubyte x; alias x this; }
@@ -144,11 +144,11 @@ void test14154()
     ubyte t = cast(MyUbyte14154)mi;
 }
 
+
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup$n$.__expand_field_0 of type int to object.Object
-fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup$n$.__expand_field_1 of type int to object.Object
+fail_compilation/fail_casting.d(179): Error: cannot cast expression point of type Tuple14093!(int, "x", int, "y") to object.Object
 ---
 */
 alias TypeTuple14093(T...) = T;


### PR DESCRIPTION
This PR introduces multiple alias this.
The old alias this implemenation doesn't imply alias this conflicts.
All alias this-es in old implementation are serializable: compiler successively applies a, a->aliasthis, a->aliasthis->aliasthis while right expression is not found.

This implementation allows tree of alias this subtypes.
Type can has a direct "alias this"-es and "alias this"-es, inherited from base classes/interfaces. Thus, there can be conflict between several matching "alias this"-es.
In common case compile should raise error if several "alias this"-es have found.
However, in the next situation conflict can be resolved:

```
struct Test9a
{
    int a;
    alias a this;
}

struct Test9b
{
    int a;
    alias a this;
}

struct Test9
{
    Test9a a;
    Test9b b;
    int c;
    alias a this;
    alias b this;
    alias c this;
}

void test()
{
    Test9 t9;
    int a = t9;
}
```

When we try to cast `Test9` to int we can find several variants: `t9.a.a`, `t9.b.a`, `t9.c`.
However, `t9.c` is preferred, because `Test9` author is explicitly pointed out that `Test9` should be converted to `int` through `c` field. This magic works only if we have exact match. `short a = t9;` causes error.

This PR have a one limitation: it doesn't support multiple tuple alias this. It don't clearly understand how them should works.   Multiple tuple alias this can be implemented in future in a separate PR.
