### PR TITLE
Issue 13484 - Template type deduction from delegate parameter fails

### DIFF
--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -4217,6 +4217,18 @@ void test13417()
 }
 
 /******************************************/
+// 13484
+
+int foo13484()(void delegate() hi) { return 1; }
+int foo13484(T)(void delegate(T) hi) { return 2; }
+
+void test13484()
+{
+    assert(foo13484({}) == 1);          // works
+    assert(foo13484((float v){}) == 2); // works <- throws error
+}
+
+/******************************************/
 
 int main()
 {
@@ -4321,6 +4333,7 @@ int main()
     test13374();
     test13378();
     test13379();
+    test13484();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13484

The implicit conversion of expressions to delegates was added in 0.165 (a2b1fa4978948ca4d293c38666bd607c03ba791a, http://www.digitalmars.com/d/1.0/changelog2.html#new0165), but it was replaced with lazy parameter.
