### PR TITLE
[REG2.065] Issue 13502 - Stray '(' warning not emitted for documentation of enum templates

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3445,14 +3445,10 @@ Dsymbols *Parser::parseDeclarations(bool autodecl, PrefixAttributes *pAttrs, con
                         error("user defined attributes not allowed for %s declarations", Token::toChars(tok));
 
                     t = parseType();
-                    Dsymbol *s = new AliasDeclaration(loc, ident, t);
-                    ((Declaration *)s)->storage_class = storage_class;
-                    if (link != linkage)
-                    {
-                        Dsymbols *a2 = new Dsymbols();
-                        a2->push(s);
-                        s = new LinkDeclaration(link, a2);
-                    }
+                    Declaration *v = new AliasDeclaration(loc, ident, t);
+                    v->storage_class = storage_class;
+
+                    Dsymbol *s = v;
                     if (tpl)
                     {
                         Dsymbols *a2 = new Dsymbols();
@@ -3460,6 +3456,12 @@ Dsymbols *Parser::parseDeclarations(bool autodecl, PrefixAttributes *pAttrs, con
                         TemplateDeclaration *tempdecl =
                             new TemplateDeclaration(loc, ident, tpl, NULL, a2);
                         s = tempdecl;
+                    }
+                    if (link != linkage)
+                    {
+                        Dsymbols *a2 = new Dsymbols();
+                        a2->push(s);
+                        s = new LinkDeclaration(link, a2);
                     }
                     a->push(s);
                     switch (token.value)
@@ -3641,15 +3643,15 @@ L2:
                 v = new AliasDeclaration(loc, ident, t);
             }
             v->storage_class = storage_class;
-            if (link == linkage)
-                a->push(v);
-            else
+            Dsymbol *s = v;
+
+            if (link != linkage)
             {
                 Dsymbols *ax = new Dsymbols();
                 ax->push(v);
-                Dsymbol *s = new LinkDeclaration(link, ax);
-                a->push(s);
+                s = new LinkDeclaration(link, ax);
             }
+            a->push(s);
             switch (token.value)
             {
                 case TOKsemicolon:
@@ -3786,8 +3788,8 @@ L2:
                 ax->push(s);
                 s = new UserAttributeDeclaration(udas, ax);
             }
-            addComment(s, comment);
             a->push(s);
+            addComment(s, comment);
         }
         else if (ident)
         {
@@ -3810,7 +3812,6 @@ L2:
                     new TemplateDeclaration(loc, ident, tpl, NULL, a2, 0);
                 s = tempdecl;
             }
-
             if (link != linkage)
             {
                 Dsymbols *ax = new Dsymbols();
@@ -3884,28 +3885,30 @@ Dsymbols *Parser::parseAutoDeclarations(StorageClass storageClass, const utf8_t 
                 new TemplateDeclaration(loc, ident, tpl, NULL, a2, 0);
             s = tempdecl;
         }
-
         a->push(s);
-        if (token.value == TOKsemicolon)
+        switch (token.value)
         {
-            nextToken();
-            addComment(v, comment);
-        }
-        else if (token.value == TOKcomma)
-        {
-            nextToken();
-            if (token.value == TOKidentifier &&
-                skipParensIf(peek(&token), &tk) &&
-                tk->value == TOKassign)
-            {
+            case TOKsemicolon:
+                nextToken();
+                addComment(v, comment);
+                break;
+
+            case TOKcomma:
+                nextToken();
+                if (!(token.value == TOKidentifier &&
+                      skipParensIf(peek(&token), &tk) &&
+                      tk->value == TOKassign))
+                {
+                    error("Identifier expected following comma");
+                    break;
+                }
                 addComment(v, comment);
                 continue;
-            }
-            else
-                error("Identifier expected following comma");
+
+            default:
+                error("semicolon expected following auto declaration, not '%s'", token.toChars());
+                break;
         }
-        else
-            error("semicolon expected following auto declaration, not '%s'", token.toChars());
         break;
     }
     return a;

--- a/src/parse.c
+++ b/src/parse.c
@@ -3656,12 +3656,12 @@ L2:
             {
                 case TOKsemicolon:
                     nextToken();
-                    addComment(v, comment);
+                    addComment(s, comment);
                     break;
 
                 case TOKcomma:
                     nextToken();
-                    addComment(v, comment);
+                    addComment(s, comment);
                     continue;
 
                 default:
@@ -3749,11 +3749,9 @@ L2:
 
             FuncDeclaration *f =
                 new FuncDeclaration(loc, Loc(), ident, storage_class | (disable ? STCdisable : 0), t);
-            addComment(f, comment);
             if (tpl)
                 constraint = parseConstraint();
             Dsymbol *s = parseContracts(f);
-            addComment(s, NULL);
 
             /* A template parameter list means it's a function template
              */
@@ -3829,12 +3827,12 @@ L2:
             {
                 case TOKsemicolon:
                     nextToken();
-                    addComment(v, comment);
+                    addComment(s, comment);
                     break;
 
                 case TOKcomma:
                     nextToken();
-                    addComment(v, comment);
+                    addComment(s, comment);
                     continue;
 
                 default:
@@ -3890,7 +3888,7 @@ Dsymbols *Parser::parseAutoDeclarations(StorageClass storageClass, const utf8_t 
         {
             case TOKsemicolon:
                 nextToken();
-                addComment(v, comment);
+                addComment(s, comment);
                 break;
 
             case TOKcomma:
@@ -3902,7 +3900,7 @@ Dsymbols *Parser::parseAutoDeclarations(StorageClass storageClass, const utf8_t 
                     error("Identifier expected following comma");
                     break;
                 }
-                addComment(v, comment);
+                addComment(s, comment);
                 continue;
 
             default:

--- a/test/compilable/ddoc13502.d
+++ b/test/compilable/ddoc13502.d
@@ -1,0 +1,24 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -w -o-
+/*
+TEST_OUTPUT:
+---
+compilable/ddoc13502.d(14): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
+compilable/ddoc13502.d(17): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
+compilable/ddoc13502.d(21): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
+compilable/ddoc13502.d(24): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
+---
+*/
+
+/// (
+enum isSomeString(T) = true;
+
+/// (
+enum bool isArray(T) = true;
+
+
+/// (
+extern(C) alias int T1;
+
+/// (
+extern(C) alias T2 = int;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13502
