### PR TITLE
Fix segfault with undefined template declaration errors

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -7324,10 +7324,13 @@ bool TemplateInstance::findBestMatch(Scope *sc, Expressions *fargs)
         else if (tdecl && !tdecl->overnext)
             // Only one template, so we can give better error message
             error("does not match template declaration %s", tdecl->toChars());
-        else
+        else if (tempdecl->parent)
             ::error(loc, "%s %s.%s does not match any template declaration",
                     tempdecl->kind(), tempdecl->parent->toPrettyChars(), tempdecl->ident->toChars());
-        return false;
+        else
+	    ::error(loc, "%s %s does not match any template declaration",
+		    tempdecl->kind(), tempdecl->ident->toChars());
+	return false;
     }
 
     /* The best match is td_last


### PR DESCRIPTION
As posted on : http://forum.dlang.org/thread/lvpj5j$auh$1@digitalmars.com#post-lvpm16:24dj0:241:40digitalmars.com

This ICE is a segfault when attempting to display what this (fixed dmd) shows as:

`Error: overload alias Array does not match any template declaration`

Which showed up when an invalid type was being used as a template parameter. e.g. `Array!wd` where `wd` is undefined.
