### PR TITLE
[D1] fix issue 13521 : -di ignores variable shadowing

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -4733,7 +4733,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
                 error("declaration %s is already defined in another scope in %s",
                     s->toPrettyChars(), sc->func->toChars());
             }
-            else if (!global.params.useDeprecated)
+            else if (global.params.useDeprecated != 1)
             {   // Disallow shadowing
 
                 for (Scope *scx = sc->enclosing; scx && scx->func == sc->func; scx = scx->enclosing)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13521

``` D
void f()
{
    int i;
    { int i; }
}
```

```
$ dmd1 -c shadow.d
shadow.d(4): Deprecation: shadowing declaration shadow.f.i is deprecated
$ dmd1 -c -di shadow.d
```
