### PR TITLE
[D1] disable -v2 message for typedef

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2205,10 +2205,6 @@ Dsymbols *Parser::parseDeclarations()
     switch (token.value)
     {
         case TOKtypedef:
-            if (global.params.Dversion >= 3 && mod && mod->isRoot())
-            {
-                warning(loc, "typedef is deprecated in D2, use either alias or custom struct wrapper");
-            }
         case TOKalias:
             tok = token.value;
             nextToken();


### PR DESCRIPTION
After some experimenting with different transitional typedef implementation we have settled with mixin that injects same `typedef` for D1 version of the code and struct with same name and `alias this` for D2 version. This doesn't work very well with -v2 diagnostic as `typedef` statement still gets used and warned about.

As it is impossible to get a decent library implementation of typedef
in D1 (in absence of `alias this`) it is better to not warn about it and
rely on deprecation message of D2 compiler instead (which is essentially the same so nothing is lost here)
