### PR TITLE
Fix ICE (issue 8262).

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1246,8 +1246,20 @@ Type *Type::aliasthisOf()
         if (s->isAliasDeclaration())
             s = s->toAlias();
         Declaration *d = s->isDeclaration();
-        if (d && !d->isTupleDeclaration())
+        if (d)
         {
+            TupleDeclaration *td = d->isTupleDeclaration();
+            if (td)
+            {
+                assert(td->objects);
+                if (!td->objects || td->objects->dim != 1)
+                    return Type::terror;
+                RootObject *o = (*td->objects)[0];
+                if (o->dyncast() != DYNCAST_EXPRESSION)
+                    return Type::terror;
+                Expression *e = (Expression *)o;
+                return e->type;
+            }
             assert(d->type);
             Type *t = d->type;
             if (d->isVarDeclaration() && d->needThis())
@@ -1294,6 +1306,7 @@ Type *Type::aliasthisOf()
                 return Type::terror;
         }
         //printf("%s\n", s->kind());
+        return Type::terror;
     }
     return NULL;
 }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7187,6 +7187,26 @@ void test13476()
     assert(flag13476 == 2);
 }
 
+template Seq8262(T...) { alias T Seq8262; }
+
+void test8262()
+{
+    static struct S
+    {
+        int s;
+        alias Seq8262!s x;
+        alias x this;
+    }
+
+    //writeln(S.init); // from original test case
+
+    // The root of the original problem is that the nested alias this fails to
+    // make S implicitly convertible to S.s.
+    auto s = S(123);
+    static assert(is(typeof(s) : int));
+    assert(s == 123);
+}
+
 /***************************************************/
 
 int main()
@@ -7486,6 +7506,7 @@ int main()
     test13437();
     test13472();
     test13476();
+    test8262();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
FIxes: https://issues.dlang.org/show_bug.cgi?id=8262

This PR is still incomplete, as it still doesn't quite implement the `alias this` in the expected manner (the output of the test program in the bug is `S(0)` as opposed to `0`, which would be the case if the extra level of indirection via `Seq!s` was removed), and the error appears to be swallowed. At least the compiler won't segfault anymore, but probably this isn't the correct fix for the problem.
