### PR TITLE
Remove error for asm statements in a nothrow function

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -692,8 +692,6 @@ int Statement::blockExit(FuncDeclaration *func, bool mustNotThrow)
 
         void visit(AsmStatement *s)
         {
-            if (mustNotThrow)
-                s->error("asm statements are assumed to throw", s->toChars());
             // Assume the worst
             result = BEfallthru | BEthrow | BEreturn | BEgoto | BEhalt;
         }


### PR DESCRIPTION
From discussion:
http://forum.dlang.org/post/m02c7p$226e$1@digitalmars.com

And this check is already impossible to hit because of:
https://github.com/D-Programming-Language/dmd/blob/master/src/func.c#L1778

There's already a test for this in: `test/compilable/test11471.d` - kinda, but druntime already depends on asm statements not causing this error in nothrow functions.

https://github.com/D-Programming-Language/druntime/blob/dbf3ff2a98208b21ee2d820df2c526af75ace863/src/core/thread.d#L2230
