### PR TITLE
fix Issue 12979 - Nothrow violation error is hidden by inline assembler

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1776,16 +1776,12 @@ void FuncDeclaration::semantic3(Scope *sc)
             }
             else if (!hasReturnExp && f->next->ty != Tvoid)
                 error("has no return statement, but is expected to return a value of type %s", f->next->toChars());
-            else if (hasReturnExp & 8)               // if inline asm
-            {
-                flags &= ~FUNCFLAGnothrowInprocess;
-            }
             else
             {
                 // Check for errors related to 'nothrow'.
                 unsigned int nothrowErrors = global.errors;
                 int blockexit = fbody->blockExit(this, f->isnothrow);
-                if (f->isnothrow && (global.errors != nothrowErrors) )
+                if (f->isnothrow && (global.errors != nothrowErrors))
                     ::error(loc, "%s '%s' is nothrow yet may throw", kind(), toPrettyChars());
                 if (flags & FUNCFLAGnothrowInprocess)
                 {
@@ -1793,7 +1789,8 @@ void FuncDeclaration::semantic3(Scope *sc)
                     f->isnothrow = !(blockexit & BEthrow);
                 }
 
-                if ((blockexit & BEfallthru) && f->next->ty != Tvoid)
+                const bool inlineAsm = hasReturnExp & 8;
+                if ((blockexit & BEfallthru) && f->next->ty != Tvoid && !inlineAsm)
                 {
                     Expression *e;
                     error("no return exp; or assert(0); at end of function");

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4616,10 +4616,6 @@ Statement* asmSemantic(AsmStatement *s, Scope *sc)
 {
     //printf("AsmStatement::semantic()\n");
 
-    assert(sc->func);
-    if (sc->func->setUnsafe())
-        s->error("inline assembler not allowed in @safe function %s", sc->func->toChars());
-
     OP *o;
     OPND *o1 = NULL,*o2 = NULL, *o3 = NULL, *o4 = NULL;
     PTRNTAB ptb;
@@ -4806,4 +4802,3 @@ Statement* asmSemantic(AsmStatement *s, Scope *sc)
 }
 
 #endif
-

--- a/src/parse.c
+++ b/src/parse.c
@@ -5253,6 +5253,10 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
             Loc labelloc;
 
             nextToken();
+            StorageClass stc = parsePostfix(STCundefined, NULL);
+            if (stc & (STCconst | STCimmutable | STCshared | STCwild))
+                error("const/immutable/shared/inout attributes are not allowed on asm blocks");
+
             check(TOKlcurly);
             Token *toklist = NULL;
             Token **ptoklist = &toklist;
@@ -5333,7 +5337,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
                 }
                 break;
             }
-            s = new CompoundStatement(loc, statements);
+            s = new CompoundAsmStatement(loc, statements, stc);
             nextToken();
             break;
         }

--- a/src/statement.c
+++ b/src/statement.c
@@ -692,7 +692,7 @@ int Statement::blockExit(FuncDeclaration *func, bool mustNotThrow)
         void visit(CompoundAsmStatement *s)
         {
             if (mustNotThrow && !(s->stc & STCnothrow))
-                s->deprecation("asm block is not nothrow");
+                s->deprecation("asm statement is assumed to throw - mark it with 'nothrow' if it does not");
 
             // Assume the worst
             result = BEfallthru | BEreturn | BEgoto | BEhalt;
@@ -5069,11 +5069,11 @@ CompoundAsmStatement *CompoundAsmStatement::semantic(Scope *sc)
     // use setImpure/setGC when the deprecation cycle is over
     PURE pure;
     if (!(stc & STCpure) && (pure = sc->func->isPureBypassingInference()) != PUREimpure && pure != PUREfwdref)
-        deprecation("asm block is not pure");
+        deprecation("asm statement is assumed to be impure - mark it with 'pure' if it is not");
     if (!(stc & STCnogc) && sc->func->isNogcBypassingInference())
-        deprecation("asm block is not @nogc");
+        deprecation("asm statement is assumed to use the GC - mark it with '@nogc' if it does not");
     if (!(stc & (STCtrusted|STCsafe)) && sc->func->setUnsafe())
-        error("asm block is not @trusted or @safe");
+        error("asm statement is assumed to be @system - mark it with '@trusted' if it is not");
 
     return this;
 }

--- a/src/statement.h
+++ b/src/statement.h
@@ -747,6 +747,20 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+// a complete asm {} block
+class CompoundAsmStatement : public CompoundStatement
+{
+public:
+    StorageClass stc; // postfix attributes like nothrow/pure/@trusted
+
+    CompoundAsmStatement(Loc loc, Statements *s, StorageClass stc);
+    CompoundAsmStatement *syntaxCopy();
+    CompoundAsmStatement *semantic(Scope *sc);
+    Statements *flatten(Scope *sc);
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class ImportStatement : public Statement
 {
 public:

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -52,6 +52,7 @@ class DebugStatement;
 class GotoStatement;
 class LabelStatement;
 class AsmStatement;
+class CompoundAsmStatement;
 class ImportStatement;
 
 class Type;
@@ -341,6 +342,7 @@ public:
     virtual void visit(GotoStatement *s) { visit((Statement *)s); }
     virtual void visit(LabelStatement *s) { visit((Statement *)s); }
     virtual void visit(AsmStatement *s) { visit((Statement *)s); }
+    virtual void visit(CompoundAsmStatement *s) { visit((CompoundStatement *)s); }
     virtual void visit(ImportStatement *s) { visit((Statement *)s); }
 
     virtual void visit(Type *) { assert(0); }

--- a/test/compilable/deprecate12979a.d
+++ b/test/compilable/deprecate12979a.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/deprecate12979a.d(13): Deprecation: asm block is not nothrow
+compilable/deprecate12979a.d(13): Deprecation: asm statement is assumed to throw - mark it with 'nothrow' if it does not
 ---
 */
 

--- a/test/compilable/deprecate12979a.d
+++ b/test/compilable/deprecate12979a.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -dw
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+compilable/deprecate12979a.d(13): Deprecation: asm block is not nothrow
+---
+*/
+
+void foo() nothrow
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/compilable/test12979a.d
+++ b/test/compilable/test12979a.d
@@ -1,0 +1,5 @@
+void parse()
+{
+    asm pure nothrow @nogc @trusted {}
+    asm @safe {}
+}

--- a/test/compilable/test12979b.d
+++ b/test/compilable/test12979b.d
@@ -1,0 +1,34 @@
+// REQUIRED_ARGS: -w -de
+
+void foo() pure nothrow @nogc @safe
+{
+    asm pure nothrow @nogc @trusted
+    {
+        ret;
+    }
+}
+
+void bar()()
+{
+    asm pure nothrow @nogc @trusted
+    {
+        ret;
+    }
+}
+
+static assert(__traits(compiles, () pure nothrow @nogc @safe => bar()));
+
+void baz()()
+{
+    asm
+    {
+        ret;
+    }
+}
+
+// wait for deprecation of asm pure inference
+// static assert(!__traits(compiles, () pure => baz()));
+static assert(!__traits(compiles, () nothrow => baz()));
+// wait for deprecation of asm @nogc inference
+// static assert(!__traits(compiles, () @nogc => baz()));
+static assert(!__traits(compiles, () @safe => baz()));

--- a/test/fail_compilation/deprecate12979a.d
+++ b/test/fail_compilation/deprecate12979a.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/deprecate12979a.d(14): Deprecation: asm block is not nothrow
+fail_compilation/deprecate12979a.d(12): Error: function 'deprecate12979a.foo' is nothrow yet may throw
+---
+*/
+
+void foo() nothrow
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/fail_compilation/deprecate12979a.d
+++ b/test/fail_compilation/deprecate12979a.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979a.d(14): Deprecation: asm block is not nothrow
+fail_compilation/deprecate12979a.d(14): Deprecation: asm statement is assumed to throw - mark it with 'nothrow' if it does not
 fail_compilation/deprecate12979a.d(12): Error: function 'deprecate12979a.foo' is nothrow yet may throw
 ---
 */

--- a/test/fail_compilation/deprecate12979b.d
+++ b/test/fail_compilation/deprecate12979b.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979b.d(13): Deprecation: asm block is not pure
+fail_compilation/deprecate12979b.d(13): Deprecation: asm statement is assumed to be impure - mark it with 'pure' if it is not
 ---
 */
 

--- a/test/fail_compilation/deprecate12979b.d
+++ b/test/fail_compilation/deprecate12979b.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/deprecate12979b.d(13): Deprecation: asm block is not pure
+---
+*/
+
+void foo() pure
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/fail_compilation/deprecate12979c.d
+++ b/test/fail_compilation/deprecate12979c.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/deprecate12979c.d(13): Deprecation: asm block is not @nogc
+---
+*/
+
+void foo() @nogc
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/fail_compilation/deprecate12979c.d
+++ b/test/fail_compilation/deprecate12979c.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979c.d(13): Deprecation: asm block is not @nogc
+fail_compilation/deprecate12979c.d(13): Deprecation: asm statement is assumed to use the GC - mark it with '@nogc' if it does not
 ---
 */
 

--- a/test/fail_compilation/deprecate12979d.d
+++ b/test/fail_compilation/deprecate12979d.d
@@ -1,0 +1,16 @@
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/deprecate12979d.d(12): Error: asm block is not @trusted or @safe
+---
+*/
+
+void foo() @safe
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/fail_compilation/deprecate12979d.d
+++ b/test/fail_compilation/deprecate12979d.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979d.d(12): Error: asm block is not @trusted or @safe
+fail_compilation/deprecate12979d.d(12): Error: asm statement is assumed to be @system - mark it with '@trusted' if it is not
 ---
 */
 

--- a/test/fail_compilation/fail327.d
+++ b/test/fail_compilation/fail327.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail327.d(10): Error: asm block is not @trusted or @safe
+fail_compilation/fail327.d(10): Error: asm statement is assumed to be @system - mark it with '@trusted' if it is not
 ---
 */
 

--- a/test/fail_compilation/fail327.d
+++ b/test/fail_compilation/fail327.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail327.d(10): Error: inline assembler not allowed in @safe function foo
+fail_compilation/fail327.d(10): Error: asm block is not @trusted or @safe
 ---
 */
 

--- a/test/fail_compilation/test12979.d
+++ b/test/fail_compilation/test12979.d
@@ -1,0 +1,16 @@
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test12979.d(13): Error: const/immutable/shared/inout attributes are not allowed on asm blocks
+---
+*/
+
+void foo()
+{
+    asm const shared
+    {
+        ret;
+    }
+}


### PR DESCRIPTION
- deprecate using unattributed asm in attributed functions
- add explicit attributes on asm statments (unverified by compiler)
  
  asm pure nothrow @nogc @trusted {
    //...
  }
- added new CompoundAsmStatement because the parser
  already splits asm blocks into many AsmStatements
