### PR TITLE
fix Issue 12979 - Nothrow violation error is hidden by inline assembler

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4616,10 +4616,6 @@ Statement* asmSemantic(AsmStatement *s, Scope *sc)
 {
     //printf("AsmStatement::semantic()\n");
 
-    assert(sc->func);
-    if (sc->func->setUnsafe())
-        s->error("inline assembler not allowed in @safe function %s", sc->func->toChars());
-
     OP *o;
     OPND *o1 = NULL,*o2 = NULL, *o3 = NULL, *o4 = NULL;
     PTRNTAB ptb;
@@ -4806,4 +4802,3 @@ Statement* asmSemantic(AsmStatement *s, Scope *sc)
 }
 
 #endif
-

--- a/src/parse.c
+++ b/src/parse.c
@@ -5308,6 +5308,10 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
             Loc labelloc;
 
             nextToken();
+            StorageClass stc = parsePostfix(NULL);
+            if (stc & (STCconst | STCimmutable | STCshared | STCwild))
+                error("const/immutable/shared/inout attributes are not allowed on asm blocks");
+
             check(TOKlcurly);
             Token *toklist = NULL;
             Token **ptoklist = &toklist;

--- a/src/parse.c
+++ b/src/parse.c
@@ -5392,7 +5392,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
                 }
                 break;
             }
-            s = new CompoundStatement(loc, statements);
+            s = new AsmCompoundStatement(loc, statements, stc);
             nextToken();
             break;
         }

--- a/src/statement.h
+++ b/src/statement.h
@@ -747,6 +747,20 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+// a complete asm {} block
+class AsmCompoundStatement : public CompoundStatement
+{
+public:
+    StorageClass stc; // postfix attributes like nothrow/pure/@trusted
+
+    AsmCompoundStatement(Loc loc, Statements *s, StorageClass stc);
+    AsmCompoundStatement *syntaxCopy();
+    AsmCompoundStatement *semantic(Scope *sc);
+    Statements *flatten(Scope *sc);
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class ImportStatement : public Statement
 {
 public:

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -52,6 +52,7 @@ class DebugStatement;
 class GotoStatement;
 class LabelStatement;
 class AsmStatement;
+class AsmCompoundStatement;
 class ImportStatement;
 
 class Type;
@@ -341,6 +342,7 @@ public:
     virtual void visit(GotoStatement *s) { visit((Statement *)s); }
     virtual void visit(LabelStatement *s) { visit((Statement *)s); }
     virtual void visit(AsmStatement *s) { visit((Statement *)s); }
+    virtual void visit(AsmCompoundStatement *s) { visit((CompoundStatement *)s); }
     virtual void visit(ImportStatement *s) { visit((Statement *)s); }
 
     virtual void visit(Type *) { assert(0); }

--- a/test/compilable/test12979a.d
+++ b/test/compilable/test12979a.d
@@ -1,0 +1,5 @@
+void parse()
+{
+    asm pure nothrow @nogc @trusted {}
+    asm @safe {}
+}

--- a/test/compilable/test12979b.d
+++ b/test/compilable/test12979b.d
@@ -1,0 +1,34 @@
+// REQUIRED_ARGS: -w -de
+
+void foo() pure nothrow @nogc @safe
+{
+    asm pure nothrow @nogc @trusted
+    {
+        ret;
+    }
+}
+
+void bar()()
+{
+    asm pure nothrow @nogc @trusted
+    {
+        ret;
+    }
+}
+
+static assert(__traits(compiles, () pure nothrow @nogc @safe => bar()));
+
+void baz()()
+{
+    asm
+    {
+        ret;
+    }
+}
+
+// wait for deprecation of asm pure inference
+// static assert(!__traits(compiles, () pure => baz()));
+static assert(!__traits(compiles, () nothrow => baz()));
+// wait for deprecation of asm @nogc inference
+// static assert(!__traits(compiles, () @nogc => baz()));
+static assert(!__traits(compiles, () @safe => baz()));

--- a/test/fail_compilation/deprecate12979a.d
+++ b/test/fail_compilation/deprecate12979a.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/deprecate12979a.d(14): Deprecation: asm block is not nothrow
+fail_compilation/deprecate12979a.d(12): Deprecation: function 'deprecate12979a.foo' is nothrow yet may throw
+---
+*/
+
+void foo() nothrow
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/fail_compilation/deprecate12979b.d
+++ b/test/fail_compilation/deprecate12979b.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/deprecate12979b.d(13): Deprecation: asm block is not pure
+---
+*/
+
+void foo() pure
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/fail_compilation/deprecate12979c.d
+++ b/test/fail_compilation/deprecate12979c.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/deprecate12979c.d(13): Deprecation: asm block is not @nogc
+---
+*/
+
+void foo() @nogc
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/fail_compilation/deprecate12979d.d
+++ b/test/fail_compilation/deprecate12979d.d
@@ -1,0 +1,16 @@
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/deprecate12979d.d(12): Error: asm block is not @trusted or @safe
+---
+*/
+
+void foo() @safe
+{
+    asm
+    {
+        ret;
+    }
+}

--- a/test/fail_compilation/test12979.d
+++ b/test/fail_compilation/test12979.d
@@ -1,0 +1,16 @@
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test12979.d(13): Error: const/immutable/shared/inout attributes are not allowed on asm blocks
+---
+*/
+
+void foo()
+{
+    asm const shared
+    {
+        ret;
+    }
+}


### PR DESCRIPTION
- deprecate using unattributed asm in attributed functions
- add explicit attributes on asm statments (unverified by compiler)
  
  asm pure nothrow @nogc @trusted {
    //...
  }
- added new AsmCompoundStatement because the parser
  already splits asm blocks into many AsmStatements
