### PR TITLE
Remove internals for typedef declaration

### DIFF
--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -476,11 +476,6 @@ TypeTuple *toArgTypes(Type *t)
             t->toBasetype()->accept(this);
         }
 
-        void visit(TypeTypedef *t)
-        {
-            t->sym->basetype->accept(this);
-        }
-
         void visit(TypeClass *)
         {
             result = new TypeTuple(Type::tvoidptr);

--- a/src/class.c
+++ b/src/class.c
@@ -106,13 +106,6 @@ ClassDeclaration::ClassDeclaration(Loc loc, Identifier *id, BaseClasses *basecla
                 Type::typeinfostruct = this;
             }
 
-            if (id == Id::TypeInfo_Typedef)
-            {
-                if (!inObject)
-                    error("%s", msg);
-                Type::typeinfotypedef = this;
-            }
-
             if (id == Id::TypeInfo_Pointer)
             {
                 if (!inObject)

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -781,11 +781,6 @@ public:
             store(t);
     }
 
-    void visit(TypeTypedef *t)
-    {
-        visit((Type *)t);
-    }
-
     void visit(TypeClass *t)
     {
         if (substitute(t)) return;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -187,30 +187,6 @@ public:
 
 /**************************************************************/
 
-class TypedefDeclaration : public Declaration
-{
-public:
-    Type *basetype;
-    Initializer *init;
-
-    TypedefDeclaration(Loc loc, Identifier *ident, Type *basetype, Initializer *init);
-    Dsymbol *syntaxCopy(Dsymbol *);
-    void semantic(Scope *sc);
-    void semantic2(Scope *sc);
-    const char *kind();
-    Type *getType();
-
-    void toObjFile(bool multiobj);                       // compile to .obj file
-
-    TypedefDeclaration *isTypedefDeclaration() { return this; }
-
-    Symbol *sinit;
-    Symbol *toInitializer();
-    void accept(Visitor *v) { v->visit(this); }
-};
-
-/**************************************************************/
-
 class AliasDeclaration : public Declaration
 {
 public:
@@ -379,15 +355,6 @@ class TypeInfoInterfaceDeclaration : public TypeInfoDeclaration
 public:
     TypeInfoInterfaceDeclaration(Type *tinfo);
     static TypeInfoInterfaceDeclaration *create(Type *tinfo);
-
-    void accept(Visitor *v) { v->visit(this); }
-};
-
-class TypeInfoTypedefDeclaration : public TypeInfoDeclaration
-{
-public:
-    TypeInfoTypedefDeclaration(Type *tinfo);
-    static TypeInfoTypedefDeclaration *create(Type *tinfo);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/doc.c
+++ b/src/doc.c
@@ -1179,20 +1179,6 @@ void toDocBuffer(Dsymbol *s, OutBuffer *buf, Scope *sc)
             }
         }
 
-        void visit(TypedefDeclaration *d)
-        {
-            if (d->ident)
-            {
-                if (d->isDeprecated())
-                    buf->writestring("deprecated ");
-
-                emitProtection(buf, d->protection);
-                buf->writestring("typedef ");
-                buf->writestring(d->toChars());
-                buf->writestring(";\n");
-            }
-        }
-
         void visit(FuncDeclaration *fd)
         {
             //printf("FuncDeclaration::toDocbuffer() %s\n", fd->toChars());

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -30,7 +30,6 @@ class Declaration;
 class ThisDeclaration;
 class TypeInfoDeclaration;
 class TupleDeclaration;
-class TypedefDeclaration;
 class AliasDeclaration;
 class AggregateDeclaration;
 class EnumDeclaration;
@@ -256,7 +255,6 @@ public:
     virtual ThisDeclaration *isThisDeclaration() { return NULL; }
     virtual TypeInfoDeclaration *isTypeInfoDeclaration() { return NULL; }
     virtual TupleDeclaration *isTupleDeclaration() { return NULL; }
-    virtual TypedefDeclaration *isTypedefDeclaration() { return NULL; }
     virtual AliasDeclaration *isAliasDeclaration() { return NULL; }
     virtual AggregateDeclaration *isAggregateDeclaration() { return NULL; }
     virtual FuncDeclaration *isFuncDeclaration() { return NULL; }

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4818,10 +4818,6 @@ elem *toElem(Expression *e, IRState *irs)
                     }
                 }
             }
-            else if (TypedefDeclaration *tyd = s->isTypedefDeclaration())
-            {
-                irs->deferToObj->push(tyd);
-            }
             else if (EnumDeclaration *ed = s->isEnumDeclaration())
             {
                 irs->deferToObj->push(ed);

--- a/src/expression.c
+++ b/src/expression.c
@@ -5700,7 +5700,6 @@ Expression *DeclarationExp::semantic(Scope *sc)
         {
             // Bugzilla 11720 - include Dataseg variables
             if ((s->isFuncDeclaration() ||
-                 s->isTypedefDeclaration() ||
                  s->isAggregateDeclaration() ||
                  s->isEnumDeclaration() ||
                  v && v->isDataseg()) &&
@@ -5933,10 +5932,7 @@ Expression *IsExp::semantic(Scope *sc)
         switch (tok2)
         {
             case TOKtypedef:
-                if (targ->ty != Ttypedef)
-                    goto Lno;
-                tded = ((TypeTypedef *)targ)->sym->basetype;
-                break;
+                goto Lno;
 
             case TOKstruct:
                 if (targ->ty != Tstruct)

--- a/src/glue.c
+++ b/src/glue.c
@@ -1400,7 +1400,6 @@ unsigned totym(Type *tx)
             break;
 
         case Tenum:
-        case Ttypedef:
             t = totym(tx->toBasetype());
             break;
 

--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -57,11 +57,6 @@ Symbol *AggregateDeclaration::toInitializer()
     return NULL;
 }
 
-Symbol *TypedefDeclaration::toInitializer()
-{
-    return NULL;
-}
-
 Symbol *EnumDeclaration::toInitializer()
 {
     return NULL;
@@ -134,11 +129,6 @@ void StructDeclaration::toObjFile(bool multiobj)
 }
 
 void VarDeclaration::toObjFile(bool multiobj)
-{
-    assert(0);
-}
-
-void TypedefDeclaration::toObjFile(bool multiobj)
 {
     assert(0);
 }
@@ -234,12 +224,6 @@ Expression *Type::getTypeInfo(Scope *sc)
 }
 
 TypeInfoDeclaration *Type::getTypeInfoDeclaration()
-{
-    assert(0);
-    return NULL;
-}
-
-TypeInfoDeclaration *TypeTypedef::getTypeInfoDeclaration()
 {
     assert(0);
     return NULL;

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -983,12 +983,6 @@ public:
         buf->writestring(t->sym->toChars());
     }
 
-    void visit(TypeTypedef *t)
-    {
-        //printf("TypeTypedef::toCBuffer2() '%s'\n", t->sym->toChars());
-        buf->writestring(t->sym->toChars());
-    }
-
     void visit(TypeStruct *t)
     {
         TemplateInstance *ti = t->sym->parent->isTemplateInstance();
@@ -1649,19 +1643,6 @@ public:
         }
     }
 
-    void visit(TypedefDeclaration *d)
-    {
-        buf->writestring("typedef ");
-        typeToBuffer(d->basetype, d->ident);
-        if (d->init)
-        {
-            buf->writestring(" = ");
-            d->init->accept(this);
-        }
-        buf->writeByte(';');
-        buf->writenl();
-    }
-
     void visit(AliasDeclaration *d)
     {
         buf->writestring("alias ");
@@ -2047,14 +2028,6 @@ public:
                     TypeEnum *te = (TypeEnum *)t;
                     buf->printf("cast(%s)", te->sym->toChars());
                     t = te->sym->memtype;
-                    goto L1;
-                }
-
-                case Ttypedef:
-                {
-                    TypeTypedef *tt = (TypeTypedef *)t;
-                    buf->printf("cast(%s)", tt->sym->toChars());
-                    t = tt->sym->basetype;
                     goto L1;
                 }
 

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -86,7 +86,6 @@ Msgtable msgtable[] =
     { "TypeInfo_Interface" },
     { "TypeInfo_Struct" },
     { "TypeInfo_Enum" },
-    { "TypeInfo_Typedef" },
     { "TypeInfo_Pointer" },
     { "TypeInfo_Vector" },
     { "TypeInfo_Array" },

--- a/src/inline.c
+++ b/src/inline.c
@@ -355,7 +355,6 @@ public:
         if (e->declaration->isStructDeclaration() ||
             e->declaration->isClassDeclaration() ||
             e->declaration->isFuncDeclaration() ||
-            e->declaration->isTypedefDeclaration() ||
             e->declaration->isAttribDeclaration() ||
             e->declaration->isTemplateMixin())
         {

--- a/src/json.c
+++ b/src/json.c
@@ -641,17 +641,6 @@ public:
         objectEnd();
     }
 
-    void visit(TypedefDeclaration *d)
-    {
-        objectStart();
-
-        jsonProperties(d);
-
-        property("base", "baseDeco", d->basetype);
-
-        objectEnd();
-    }
-
     void visit(AggregateDeclaration *d)
     {
         objectStart();

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -45,7 +45,6 @@ void initTypeMangle()
     mangleChar[Tclass] = 'C';
     mangleChar[Tstruct] = 'S';
     mangleChar[Tenum] = 'E';
-    mangleChar[Ttypedef] = 'T';
     mangleChar[Tdelegate] = 'D';
 
     mangleChar[Tnone] = 'n';
@@ -276,12 +275,6 @@ public:
     }
 
     void visit(TypeEnum *t)
-    {
-        visit((Type *)t);
-        t->sym->accept(this);
-    }
-
-    void visit(TypeTypedef *t)
     {
         visit((Type *)t);
         t->sym->accept(this);
@@ -567,12 +560,6 @@ public:
         visit((Declaration *)vd);
     }
 
-    void visit(TypedefDeclaration *td)
-    {
-        //printf("TypedefDeclaration::mangle() '%s'\n", toChars());
-        visit((Dsymbol *)td);
-    }
-
     void visit(AggregateDeclaration *ad)
     {
         ClassDeclaration *cd = ad->isClassDeclaration();
@@ -586,7 +573,6 @@ public:
                 cd->ident == Id::TypeInfo ||
                 cd->ident == Id::TypeInfo_Struct ||
                 cd->ident == Id::TypeInfo_Class ||
-                cd->ident == Id::TypeInfo_Typedef ||
                 cd->ident == Id::TypeInfo_Tuple ||
                 cd == ClassDeclaration::object ||
                 cd == Type::typeinfoclass ||

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -29,7 +29,6 @@ class Expression;
 class StructDeclaration;
 class ClassDeclaration;
 class EnumDeclaration;
-class TypedefDeclaration;
 class TypeInfoDeclaration;
 class Dsymbol;
 class TemplateInstance;
@@ -65,7 +64,6 @@ enum ENUMTY
     Tstruct,
     Tenum,
 
-    Ttypedef,
     Tdelegate,
     Tnone,
     Tvoid,
@@ -75,8 +73,8 @@ enum ENUMTY
     Tuns16,
     Tint32,
     Tuns32,
-
     Tint64,
+
     Tuns64,
     Tfloat32,
     Tfloat64,
@@ -86,8 +84,8 @@ enum ENUMTY
     Timaginary80,
     Tcomplex32,
     Tcomplex64,
-
     Tcomplex80,
+
     Tbool,
     Tchar,
     Twchar,
@@ -97,8 +95,8 @@ enum ENUMTY
     Ttypeof,
     Ttuple,
     Tslice,
-
     Treturn,
+
     Tnull,
     Tvector,
     Tint128,
@@ -202,7 +200,6 @@ public:
     static ClassDeclaration *typeinfoclass;
     static ClassDeclaration *typeinfointerface;
     static ClassDeclaration *typeinfostruct;
-    static ClassDeclaration *typeinfotypedef;
     static ClassDeclaration *typeinfopointer;
     static ClassDeclaration *typeinfoarray;
     static ClassDeclaration *typeinfostaticarray;
@@ -840,47 +837,6 @@ public:
     TypeInfoDeclaration *getTypeInfoDeclaration();
     int hasPointers();
     Type *nextOf();
-
-    void accept(Visitor *v) { v->visit(this); }
-};
-
-class TypeTypedef : public Type
-{
-public:
-    TypedefDeclaration *sym;
-
-    TypeTypedef(TypedefDeclaration *sym);
-    const char *kind();
-    Type *syntaxCopy();
-    d_uns64 size(Loc loc);
-    unsigned alignsize();
-    char *toChars();
-    Type *semantic(Loc loc, Scope *sc);
-    Dsymbol *toDsymbol(Scope *sc);
-    Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    structalign_t alignment();
-    Expression *getProperty(Loc loc, Identifier *ident, int flag);
-    bool isintegral();
-    bool isfloating();
-    bool isreal();
-    bool isimaginary();
-    bool iscomplex();
-    bool isscalar();
-    bool isunsigned();
-    bool checkBoolean();
-    bool isAssignable();
-    bool needsDestruction();
-    bool needsNested();
-    Type *toBasetype();
-    MATCH implicitConvTo(Type *to);
-    MATCH constConv(Type *to);
-    Type *toHeadMutable();
-    Expression *defaultInit(Loc loc);
-    Expression *defaultInitLiteral(Loc loc);
-    bool isZeroInit(Loc loc);
-    TypeInfoDeclaration *getTypeInfoDeclaration();
-    int hasPointers();
-    int hasWild();
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/parse.c
+++ b/src/parse.c
@@ -3694,7 +3694,7 @@ L2:
             }
             if (tok == TOKtypedef)
             {
-                v = new TypedefDeclaration(loc, ident, t, init);
+                v = new AliasDeclaration(loc, ident, t);    // dummy
             }
             else
             {
@@ -6526,7 +6526,8 @@ Expression *Parser::parsePrimaryExp()
                     if (token.value == TOKcomma)
                         tpl = parseTemplateParameterList(1);
                     else
-                    {   tpl = new TemplateParameters();
+                    {
+                        tpl = new TemplateParameters();
                         check(TOKrparen);
                     }
                 }
@@ -6534,7 +6535,8 @@ Expression *Parser::parsePrimaryExp()
                     check(TOKrparen);
             }
             else
-            {   error("(type identifier : specialization) expected following is");
+            {
+                error("(type identifier : specialization) expected following is");
                 goto Lerr;
             }
             e = new IsExp(loc, targ, ident, tok, tspec, tok2, tpl);

--- a/src/parse.c
+++ b/src/parse.c
@@ -6515,6 +6515,9 @@ Expression *Parser::parsePrimaryExp()
                     {
                         tok2 = token.value;
                         nextToken();
+
+                        if (tok2 == TOKtypedef)
+                            deprecation("typedef is removed");
                     }
                     else
                     {

--- a/src/statement.c
+++ b/src/statement.c
@@ -3191,11 +3191,8 @@ Statement *SwitchStatement::semantic(Scope *sc)
     }
 
     if (isFinal)
-    {   Type *t = condition->type;
-        while (t && t->ty == Ttypedef)
-        {   // Don't use toBasetype() because that will skip past enums
-            t = ((TypeTypedef *)t)->sym->basetype;
-        }
+    {
+        Type *t = condition->type;
         Dsymbol *ds;
         EnumDeclaration *ed = NULL;
         if (t && ((ds = t->toDsymbol(sc)) != NULL))

--- a/src/template.c
+++ b/src/template.c
@@ -3946,22 +3946,6 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
             visit((Type *)t);
         }
 
-        void visit(TypeTypedef *t)
-        {
-            // Extra check
-            if (tparam && tparam->ty == Ttypedef)
-            {
-                TypeTypedef *tp = (TypeTypedef *)tparam;
-
-                if (t->sym != tp->sym)
-                {
-                    result = MATCHnomatch;
-                    return;
-                }
-            }
-            visit((Type *)t);
-        }
-
         /* Helper for TypeClass::deduceType().
          * Classes can match with implicit conversion to a base class or interface.
          * This is complicated, because there may be more than one base class which

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -576,20 +576,6 @@ Symbol *AggregateDeclaration::toInitializer()
     return sinit;
 }
 
-Symbol *TypedefDeclaration::toInitializer()
-{
-    if (!sinit)
-    {
-        Classsym *stag = fake_classsym(Id::ClassInfo);
-        Symbol *s = toSymbolX("__init", SCextern, stag->Stype, "Z");
-        s->Sfl = FLextern;
-        s->Sflags |= SFLnodebug;
-        slist_add(s);
-        sinit = s;
-    }
-    return sinit;
-}
-
 Symbol *EnumDeclaration::toInitializer()
 {
     if (!sinit)

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -225,11 +225,6 @@ public:
         //printf("t = %p, Tflags = x%x\n", t, t->Tflags);
     }
 
-    void visit(TypeTypedef *t)
-    {
-        t->ctype = Type_toCtype(t->sym->basetype);
-    }
-
     void visit(TypeClass *t)
     {
         //printf("TypeClass::toCtype() %s\n", toChars());

--- a/src/tocvdebug.c
+++ b/src/tocvdebug.c
@@ -292,41 +292,6 @@ unsigned cv_align(unsigned char *p, unsigned n)
  * Emit symbolic debug info in CV format.
  */
 
-void toDebug(TypedefDeclaration *tdd)
-{
-    //printf("TypedefDeclaration::toDebug('%s')\n", tdd->toChars());
-
-    assert(config.fulltypes >= CV4);
-
-    // If it is a member, it is handled by cvMember()
-    if (!tdd->isMember())
-    {
-        if (tdd->basetype->ty == Ttuple)
-            return;
-
-        const char *id = tdd->toPrettyChars(true);
-        idx_t typidx = cv4_typidx(Type_toCtype(tdd->basetype));
-        if (config.fulltypes == CV8)
-            cv8_udt(id, typidx);
-        else
-        {
-            unsigned len = strlen(id);
-            unsigned char *debsym = (unsigned char *) alloca(39 + IDOHD + len);
-
-            // Output a 'user-defined type' for the tag name
-            TOWORD(debsym + 2,S_UDT);
-            TOIDX(debsym + 4,typidx);
-            unsigned length = 2 + 2 + cgcv.sz_idx;
-            length += cv_namestring(debsym + length,id);
-            TOWORD(debsym,length - 2);
-
-            assert(length <= 40 + len);
-            objmod->write_bytes(SegData[DEBSYM],length,debsym);
-        }
-    }
-}
-
-
 void toDebug(EnumDeclaration *ed)
 {
     //printf("EnumDeclaration::toDebug('%s')\n", ed->toChars());
@@ -860,13 +825,6 @@ int cvMember(Dsymbol *s, unsigned char *p)
                 assert(result == save);
             }
         #endif
-        }
-
-        void visit(TypedefDeclaration *tdd)
-        {
-            //printf("TypedefDeclaration::cvMember() '%s'\n", d->toChars());
-
-            cvMemberCommon(tdd, tdd->toChars(), cv4_typidx(Type_toCtype(tdd->basetype)));
         }
 
         void visit(EnumDeclaration *ed)

--- a/src/todt.c
+++ b/src/todt.c
@@ -742,21 +742,6 @@ dt_t **Type_toDt(Type *t, dt_t **pdt)
         {
             StructDeclaration_toDt(t->sym, pdt);
         }
-
-        void visit(TypeTypedef *t)
-        {
-            if (t->sym->init)
-            {
-                dt_t *dt = Initializer_toDt(t->sym->init);
-
-                pdt = dtend(pdt);
-                *pdt = dt;
-            }
-            else
-            {
-                Type_toDt(t->sym->basetype, pdt);
-            }
-        }
     };
 
     TypeToDt v(pdt);

--- a/src/toelfdebug.c
+++ b/src/toelfdebug.c
@@ -43,22 +43,14 @@
  * Emit symbolic debug info in Dwarf2 format.
  */
 
-void toDebug(TypedefDeclaration *tdd)
-{
-    //printf("TypedefDeclaration::toDebug('%s')\n", tdd->toChars());
-}
-
-
 void toDebug(EnumDeclaration *ed)
 {
     //printf("EnumDeclaration::toDebug('%s')\n", ed->toChars());
 }
 
-
 void toDebug(StructDeclaration *sd)
 {
 }
-
 
 void toDebug(ClassDeclaration *cd)
 {

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -53,7 +53,6 @@ void StructDeclaration_toDt(StructDeclaration *sd, dt_t **pdt);
 Symbol *toSymbol(Dsymbol *s);
 dt_t **Expression_toDt(Expression *e, dt_t **pdt);
 
-void toDebug(TypedefDeclaration *tdd);
 void toDebug(EnumDeclaration *ed);
 void toDebug(StructDeclaration *sd);
 void toDebug(ClassDeclaration *cd);
@@ -1005,41 +1004,6 @@ void VarDeclaration::toObjFile(bool multiobj)
             if (isExport())
             objmod->export_symbol(s,0);
         }
-    }
-}
-
-/* ================================================================== */
-
-void TypedefDeclaration::toObjFile(bool multiobj)
-{
-    //printf("TypedefDeclaration::toObjFile('%s')\n", toChars());
-
-    if (type->ty == Terror)
-    {   error("had semantic errors when compiling");
-        return;
-    }
-
-    if (global.params.symdebug)
-        toDebug(this);
-
-    type->genTypeInfo(NULL);
-
-    TypeTypedef *tc = (TypeTypedef *)type;
-    if (type->isZeroInit() || !tc->sym->init)
-        ;
-    else
-    {
-        enum_SC scclass = SCglobal;
-        if (isInstantiated())
-            scclass = SCcomdat;
-
-        // Generate static initializer
-        toInitializer();
-        sinit->Sclass = scclass;
-        sinit->Sfl = FLdata;
-        sinit->Sdt = Initializer_toDt(tc->sym->init);
-        out_readonly(sinit);
-        outdata(sinit);
     }
 }
 

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -74,7 +74,6 @@ class TypeTypeof;
 class TypeReturn;
 class TypeStruct;
 class TypeEnum;
-class TypeTypedef;
 class TypeClass;
 class TypeTuple;
 class TypeSlice;
@@ -123,7 +122,6 @@ class InterfaceDeclaration;
 
 class Declaration;
 class TupleDeclaration;
-class TypedefDeclaration;
 class AliasDeclaration;
 class OverDeclaration;
 class VarDeclaration;
@@ -135,7 +133,6 @@ class TypeInfoDeclaration;
 class TypeInfoStructDeclaration;
 class TypeInfoClassDeclaration;
 class TypeInfoInterfaceDeclaration;
-class TypeInfoTypedefDeclaration;
 class TypeInfoPointerDeclaration;
 class TypeInfoArrayDeclaration;
 class TypeInfoStaticArrayDeclaration;
@@ -363,7 +360,6 @@ public:
     virtual void visit(TypeReturn *t) { visit((TypeQualified *)t); }
     virtual void visit(TypeStruct *t) { visit((Type *)t); }
     virtual void visit(TypeEnum *t) { visit((Type *)t); }
-    virtual void visit(TypeTypedef *t) { visit((Type *)t); }
     virtual void visit(TypeClass *t) { visit((Type *)t); }
     virtual void visit(TypeTuple *t) { visit((Type *)t); }
     virtual void visit(TypeSlice *t) { visit((TypeNext *)t); }
@@ -412,7 +408,6 @@ public:
 
     virtual void visit(Declaration *s) { visit((Dsymbol *)s); }
     virtual void visit(TupleDeclaration *s) { visit((Declaration *)s); }
-    virtual void visit(TypedefDeclaration *s) { visit((Declaration *)s); }
     virtual void visit(AliasDeclaration *s) { visit((Declaration *)s); }
     virtual void visit(OverDeclaration *s) { visit((Declaration *)s); }
     virtual void visit(VarDeclaration *s) { visit((Declaration *)s); }
@@ -424,7 +419,6 @@ public:
     virtual void visit(TypeInfoStructDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoClassDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoInterfaceDeclaration *s) { visit((TypeInfoDeclaration *)s); }
-    virtual void visit(TypeInfoTypedefDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoPointerDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoArrayDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoStaticArrayDeclaration *s) { visit((TypeInfoDeclaration *)s); }

--- a/test/fail_compilation/fail10277.d
+++ b/test/fail_compilation/fail10277.d
@@ -7,7 +7,6 @@ fail_compilation/imports/fail10277.d(3): Error: class TypeInfo only object.d can
 fail_compilation/imports/fail10277.d(4): Error: class TypeInfo_Class only object.d can define this reserved class name
 fail_compilation/imports/fail10277.d(5): Error: class TypeInfo_Interface only object.d can define this reserved class name
 fail_compilation/imports/fail10277.d(6): Error: class TypeInfo_Struct only object.d can define this reserved class name
-fail_compilation/imports/fail10277.d(7): Error: class TypeInfo_Typedef only object.d can define this reserved class name
 fail_compilation/imports/fail10277.d(8): Error: class TypeInfo_Pointer only object.d can define this reserved class name
 fail_compilation/imports/fail10277.d(9): Error: class TypeInfo_Array only object.d can define this reserved class name
 fail_compilation/imports/fail10277.d(10): Error: class TypeInfo_AssociativeArray only object.d can define this reserved class name

--- a/test/win32/testmydll2.d
+++ b/test/win32/testmydll2.d
@@ -13,10 +13,10 @@ version(dynload)
 	extern(Windows) void* LoadLibraryA(in char* dll);
 	extern(Windows) void* GetProcAddress(void* lib, in char* name);
 
-	typedef void fnDllPrint();
-	typedef int fnGetglob();
-	typedef char* fnAlloc(int sz);
-	typedef void fnFree(char* p, int sz);
+	alias void fnDllPrint();
+	alias int fnGetglob();
+	alias char* fnAlloc(int sz);
+	alias void fnFree(char* p, int sz);
 
 	mixin(d2_shared ~ "fnDllPrint* pDllPrint;");
 	mixin(d2_shared ~ "fnGetglob* pGetglob;");


### PR DESCRIPTION
Supplemental PR for the change: https://github.com/D-Programming-Language/dmd/pull/4029

This PR also make the syntax `is(T == typedef)` an error. To do it, this PR needs corresponding Phobos fix:
https://github.com/D-Programming-Language/phobos/pull/2577
