### PR TITLE
[enh] Issue 12931 - Make const, immutable, inout, and shared illegal as function attributes on the left-hand side of a function

### DIFF
--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -674,7 +674,7 @@ public:
     {
         if (t->ty == Tfunction)
         {
-            visitFuncIdentWithPrefix((TypeFunction *)t, ident, NULL, true);
+            visitFuncIdentWithPrefix((TypeFunction *)t, ident, NULL);
             return;
         }
 
@@ -869,7 +869,7 @@ public:
 
         t->inuse--;
     }
-    void visitFuncIdentWithPrefix(TypeFunction *t, Identifier *ident, TemplateDeclaration *td, bool isPostfixStyle)
+    void visitFuncIdentWithPrefix(TypeFunction *t, Identifier *ident, TemplateDeclaration *td)
     {
         if (t->inuse)
         {
@@ -885,11 +885,6 @@ public:
 
         /* Use 'storage class' (prefix) style for attributes
          */
-        if (t->mod)
-        {
-            MODtoBuffer(buf, t->mod);
-            buf->writeByte(' ');
-        }
         t->attributesApply(&pas, &PrePostAppendStrings::fp);
 
         if (t->linkage > LINKd && hgs->ddoc != 1 && !hgs->hdrgen)
@@ -926,6 +921,14 @@ public:
             buf->writeByte(')');
         }
         parametersToBuffer(t->parameters, t->varargs);
+
+        /* Use postfix style for attributes
+         */
+        if (t->mod)
+        {
+            buf->writeByte(' ');
+            MODtoBuffer(buf, t->mod);
+        }
 
         t->inuse--;
     }
@@ -3038,7 +3041,7 @@ void functionToBufferFull(TypeFunction *tf, OutBuffer *buf, Identifier *ident,
 {
     //printf("TypeFunction::toCBuffer() this = %p\n", this);
     PrettyPrintVisitor v(buf, hgs);
-    v.visitFuncIdentWithPrefix(tf, ident, td, true);
+    v.visitFuncIdentWithPrefix(tf, ident, td);
 }
 
 // ident is inserted before the argument list and will be "function" or "delegate" for a type

--- a/src/parse.c
+++ b/src/parse.c
@@ -3809,6 +3809,16 @@ L2:
             v->storage_class = storage_class;
             if (pAttrs)
             {
+                if (t->ty == Tfunction &&
+                    ((pAttrs->storageClass | storage_class) & STC_TYPECTOR))
+                {
+                    /* Disallow both:
+                     *   alias const int f1();
+                     *   const alias int f2();
+                     */
+                    ::deprecation(loc, "prefix type qualifier on function type is deprecated");
+                }
+
                 /* AliasDeclaration distinguish @safe, @system, @trusted atttributes
                  * on prefix and postfix.
                  *   @safe alias void function() FP1;
@@ -3859,7 +3869,11 @@ L2:
             FuncDeclaration *f =
                 new FuncDeclaration(loc, Loc(), ident, storage_class | (disable ? STCdisable : 0), t);
             if (pAttrs)
+            {
+                if (pAttrs->storageClass & STC_TYPECTOR)
+                    ::deprecation(loc, "prefix type qualifier on function is deprecated");
                 pAttrs->storageClass = STCundefined;
+            }
             if (tpl)
                 constraint = parseConstraint();
             Dsymbol *s = parseContracts(f);

--- a/test/compilable/ddoc10.d
+++ b/test/compilable/ddoc10.d
@@ -140,11 +140,11 @@ struct S
 
     /****
      */
-    const pure nothrow this(this) { }
+    pure nothrow this(this) const { }
 
     /****
      */
-    const pure nothrow ~this() { }
+    pure nothrow ~this() const { }
 
     /****
      */

--- a/test/compilable/extra-files/ddoc10.html
+++ b/test/compilable/extra-files/ddoc10.html
@@ -94,11 +94,11 @@ Attempt one:  Doc outside static if.<br><br>
 <dt><big><a name="S"></a>struct <u>S</u>;
 </big></dt>
 <dd><br><br>
-<dl><dt><big><a name="S.this"></a>const pure nothrow this(long <i>ticks</i>);
+<dl><dt><big><a name="S.this"></a>pure nothrow this(long <i>ticks</i>) const;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="S.foo"></a>const pure nothrow void <u>foo</u>(long <i>ticks</i>);
+<dt><big><a name="S.foo"></a>pure nothrow void <u>foo</u>(long <i>ticks</i>) const;
 </big></dt>
 <dd><br><br>
 </dd>

--- a/test/compilable/extra-files/ddoc10869.html
+++ b/test/compilable/extra-files/ddoc10869.html
@@ -7,19 +7,19 @@
 <dl><dt><big><a name="C"></a>class <u>C</u>;
 </big></dt>
 <dd><br><br>
-<dl><dt><big><a name="C.c1Foo"></a>const void <u>c1Foo</u>();
+<dl><dt><big><a name="C.c1Foo"></a>void <u>c1Foo</u>() const;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="C.i1Foo"></a>immutable void <u>i1Foo</u>();
+<dt><big><a name="C.i1Foo"></a>void <u>i1Foo</u>() immutable;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="C.c2Foo"></a>immutable void <u>c2Foo</u>();
+<dt><big><a name="C.c2Foo"></a>void <u>c2Foo</u>() immutable;
 </big></dt>
 <dd><br><br>
 </dd>
-<dt><big><a name="C.i2Foo"></a>immutable void <u>i2Foo</u>();
+<dt><big><a name="C.i2Foo"></a>void <u>i2Foo</u>() immutable;
 </big></dt>
 <dd><br><br>
 </dd>

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -296,8 +296,8 @@ int bar11(T)()
 }
 struct S6360
 {
-	const pure nothrow @property long weeks1();
-	const pure nothrow @property long weeks2();
+	pure nothrow @property long weeks1() const;
+	pure nothrow @property long weeks2() const;
 }
 struct S12
 {
@@ -306,10 +306,10 @@ struct S12
 }
 struct T12
 {
-	immutable this()(int args)
+	this()(int args) immutable
 	{
 	}
-	immutable this(A...)(A args)
+	this(A...)(A args) immutable
 	{
 	}
 }

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -411,11 +411,11 @@ int bar11(T)()
 }
 struct S6360
 {
-	const pure nothrow @property long weeks1()
+	pure nothrow @property long weeks1() const
 	{
 		return 0;
 	}
-	const pure nothrow @property long weeks2()
+	pure nothrow @property long weeks2() const
 	{
 		return 0;
 	}
@@ -431,10 +431,10 @@ struct S12
 }
 struct T12
 {
-	immutable this()(int args)
+	this()(int args) immutable
 	{
 	}
-	immutable this(A...)(A args)
+	this(A...)(A args) immutable
 	{
 	}
 }

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -125,7 +125,7 @@
         "kind" : "function",
         "line" : 18,
         "char" : 28,
-        "type" : "const T[0]()"
+        "type" : "T[0]() const"
        }
       ]
      }

--- a/test/fail_compilation/fail180.d
+++ b/test/fail_compilation/fail180.d
@@ -18,7 +18,7 @@ struct S59
     {
         x = 3;
     }
-    const void bar()
+    void bar() const
     {
         x = 4;
         this.x = 5;
@@ -33,7 +33,7 @@ class C
     {
         x = 3;
     }
-    const void bar()
+    void bar() const
     {
         x = 4;
         this.x = 5;

--- a/test/fail_compilation/fail262.d
+++ b/test/fail_compilation/fail262.d
@@ -7,12 +7,12 @@ fail_compilation/fail262.d(23): Error: function fail262.B.f does not override an
 
 // Issue 1645 - can override base class' const method with non-const method
 
-import std.c.stdio;
+extern(C) int printf(const char*, ...);
 
 class A
 {
     int x;
-    shared const void f()
+    void f() shared const
     {
         printf("A\n");
     }
@@ -20,7 +20,7 @@ class A
 
 class B : A
 {
-    override const void f()
+    override void f() const
     {
         //x = 2;
         printf("B\n");

--- a/test/fail_compilation/parse12931.d
+++ b/test/fail_compilation/parse12931.d
@@ -1,0 +1,49 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parse12931.d(29): Deprecation: prefix type qualifier on function is deprecated
+fail_compilation/parse12931.d(30): Deprecation: prefix type qualifier on function is deprecated
+fail_compilation/parse12931.d(31): Deprecation: prefix type qualifier on function is deprecated
+fail_compilation/parse12931.d(32): Deprecation: prefix type qualifier on function is deprecated
+fail_compilation/parse12931.d(33): Deprecation: prefix type qualifier on function is deprecated
+fail_compilation/parse12931.d(34): Deprecation: prefix type qualifier on function is deprecated
+fail_compilation/parse12931.d(37): Deprecation: prefix type qualifier on function is deprecated
+---
+*/
+
+class C
+{
+    // OK
+    const int x;
+
+    // OK
+    int post_c()  const        { return 1; }
+    int post_w()  inout        { return 1; }
+    int post_s()  shared       { return 1; }
+    int post_sc() shared const { return 1; }
+    int post_sw() shared inout { return 1; }
+    int post_i()  immutable    { return 1; }
+
+    // deprecated
+    const        int pre_c()  { return 1; }
+    inout        int pre_w()  { return 1; }
+    shared       int pre_s()  { return 1; }
+    shared const int pre_sc() { return 1; }
+    shared inout int pre_sw() { return 1; }
+    immutable    int pre_i()  { return 1; }
+
+    // deprecated
+    const T foo(T)() { return T.init; }
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parse12931.d(47): Deprecation: prefix type qualifier on function type is deprecated
+fail_compilation/parse12931.d(48): Deprecation: prefix type qualifier on function type is deprecated
+---
+*/
+const alias int f2();
+alias const int f1();
+alias int f3() const;

--- a/test/fail_compilation/parse12967a.d
+++ b/test/fail_compilation/parse12967a.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -d
+#line 1
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/parse12967b.d
+++ b/test/fail_compilation/parse12967b.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -d
+#line 1
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/parseStc.d
+++ b/test/fail_compilation/parseStc.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -d
+#line 1
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/parseStc2.d
+++ b/test/fail_compilation/parseStc2.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -d
+#line 1
 /*
 TEST_OUTPUT:
 ---

--- a/test/runnable/statictor.d
+++ b/test/runnable/statictor.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
 // POST_SCRIPT: runnable/extra-files/statictor-postscript.sh
 
-private import std.stdio;
+extern(C) int printf(const char*, ...);
 
 class Foo
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12931

A try to detect misleading prefix attributes.
