### PR TITLE
Improve parsing issues around attributes

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -840,7 +840,7 @@ public:
     // toObjFile() these nested functions after this one
     FuncDeclarations deferredNested;
 
-    UnitTestDeclaration(Loc loc, Loc endloc, char *codedoc);
+    UnitTestDeclaration(Loc loc, Loc endloc, StorageClass stc, char *codedoc);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     AggregateDeclaration *isThis();
@@ -858,7 +858,7 @@ public:
     Parameters *arguments;
     int varargs;
 
-    NewDeclaration(Loc loc, Loc endloc, Parameters *arguments, int varargs);
+    NewDeclaration(Loc loc, Loc endloc, StorageClass stc, Parameters *arguments, int varargs);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     const char *kind();
@@ -876,7 +876,7 @@ class DeleteDeclaration : public FuncDeclaration
 public:
     Parameters *arguments;
 
-    DeleteDeclaration(Loc loc, Loc endloc, Parameters *arguments);
+    DeleteDeclaration(Loc loc, Loc endloc, StorageClass stc, Parameters *arguments);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     const char *kind();

--- a/src/func.c
+++ b/src/func.c
@@ -4676,21 +4676,6 @@ void StaticCtorDeclaration::semantic(Scope *sc)
         scope = NULL;
     }
 
-    if (storage_class & STCshared && !isSharedStaticCtorDeclaration())
-    {
-        ::error(loc, "to create a shared static constructor, use 'shared static this'");
-        storage_class &= ~STCshared;
-    }
-
-    if (storage_class & (STCimmutable | STCconst | STCshared | STCwild))
-    {
-        OutBuffer buf;
-        StorageClassDeclaration::stcToCBuffer(&buf, storage_class & (STCimmutable | STCconst | STCshared | STCwild));
-        ::error(loc, "static constructors cannot be %s", buf.peekString());
-    }
-
-    storage_class &= ~STC_TYPECTOR; // remove qualifiers
-
     if (!type)
         type = new TypeFunction(NULL, Type::tvoid, false, LINKd, storage_class);
 

--- a/src/func.c
+++ b/src/func.c
@@ -4949,8 +4949,8 @@ static Identifier *unitTestId(Loc loc)
     return Lexer::uniqueId(buf.peekString());
 }
 
-UnitTestDeclaration::UnitTestDeclaration(Loc loc, Loc endloc, char *codedoc)
-    : FuncDeclaration(loc, endloc, unitTestId(loc), STCundefined, NULL)
+UnitTestDeclaration::UnitTestDeclaration(Loc loc, Loc endloc, StorageClass stc, char *codedoc)
+    : FuncDeclaration(loc, endloc, unitTestId(loc), stc, NULL)
 {
     this->codedoc = codedoc;
 }
@@ -4958,7 +4958,7 @@ UnitTestDeclaration::UnitTestDeclaration(Loc loc, Loc endloc, char *codedoc)
 Dsymbol *UnitTestDeclaration::syntaxCopy(Dsymbol *s)
 {
     assert(!s);
-    UnitTestDeclaration *utd = new UnitTestDeclaration(loc, endloc, codedoc);
+    UnitTestDeclaration *utd = new UnitTestDeclaration(loc, endloc, storage_class, codedoc);
     return FuncDeclaration::syntaxCopy(utd);
 }
 
@@ -4978,7 +4978,7 @@ void UnitTestDeclaration::semantic(Scope *sc)
     if (global.params.useUnitTests)
     {
         if (!type)
-            type = new TypeFunction(NULL, Type::tvoid, false, LINKd);
+            type = new TypeFunction(NULL, Type::tvoid, false, LINKd, storage_class);
         Scope *sc2 = sc->push();
         sc2->linkage = LINKd;
         FuncDeclaration::semantic(sc2);
@@ -5023,8 +5023,8 @@ bool UnitTestDeclaration::addPostInvariant()
 
 /********************************* NewDeclaration ****************************/
 
-NewDeclaration::NewDeclaration(Loc loc, Loc endloc, Parameters *arguments, int varargs)
-    : FuncDeclaration(loc, endloc, Id::classNew, STCstatic, NULL)
+NewDeclaration::NewDeclaration(Loc loc, Loc endloc, StorageClass stc, Parameters *arguments, int varargs)
+    : FuncDeclaration(loc, endloc, Id::classNew, STCstatic | stc, NULL)
 {
     this->arguments = arguments;
     this->varargs = varargs;
@@ -5033,8 +5033,8 @@ NewDeclaration::NewDeclaration(Loc loc, Loc endloc, Parameters *arguments, int v
 Dsymbol *NewDeclaration::syntaxCopy(Dsymbol *s)
 {
     assert(!s);
-    NewDeclaration *f = new NewDeclaration(loc, endloc, NULL, varargs);
-    f->arguments = Parameter::arraySyntaxCopy(arguments);
+    NewDeclaration *f = new NewDeclaration(loc, endloc,
+        storage_class, Parameter::arraySyntaxCopy(arguments), varargs);
     return FuncDeclaration::syntaxCopy(f);
 }
 
@@ -5057,7 +5057,7 @@ void NewDeclaration::semantic(Scope *sc)
     }
     Type *tret = Type::tvoid->pointerTo();
     if (!type)
-        type = new TypeFunction(arguments, tret, varargs, LINKd);
+        type = new TypeFunction(arguments, tret, varargs, LINKd, storage_class);
 
     type = type->semantic(loc, sc);
     assert(type->ty == Tfunction);
@@ -5100,8 +5100,8 @@ bool NewDeclaration::addPostInvariant()
 
 /********************************* DeleteDeclaration ****************************/
 
-DeleteDeclaration::DeleteDeclaration(Loc loc, Loc endloc, Parameters *arguments)
-    : FuncDeclaration(loc, endloc, Id::classDelete, STCstatic, NULL)
+DeleteDeclaration::DeleteDeclaration(Loc loc, Loc endloc, StorageClass stc, Parameters *arguments)
+    : FuncDeclaration(loc, endloc, Id::classDelete, STCstatic | stc, NULL)
 {
     this->arguments = arguments;
 }
@@ -5109,8 +5109,8 @@ DeleteDeclaration::DeleteDeclaration(Loc loc, Loc endloc, Parameters *arguments)
 Dsymbol *DeleteDeclaration::syntaxCopy(Dsymbol *s)
 {
     assert(!s);
-    DeleteDeclaration *f = new DeleteDeclaration(loc, endloc, NULL);
-    f->arguments = Parameter::arraySyntaxCopy(arguments);
+    DeleteDeclaration *f = new DeleteDeclaration(loc, endloc,
+            storage_class, Parameter::arraySyntaxCopy(arguments));
     return FuncDeclaration::syntaxCopy(f);
 }
 
@@ -5132,7 +5132,7 @@ void DeleteDeclaration::semantic(Scope *sc)
         error("new allocators only are for class or struct definitions");
     }
     if (!type)
-        type = new TypeFunction(arguments, Type::tvoid, 0, LINKd);
+        type = new TypeFunction(arguments, Type::tvoid, 0, LINKd, storage_class);
 
     type = type->semantic(loc, sc);
     assert(type->ty == Tfunction);

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -1828,22 +1828,24 @@ public:
 
     void visit(StaticCtorDeclaration *d)
     {
+        StorageClassDeclaration::stcToCBuffer(buf, d->storage_class & ~STCstatic);
         if (d->isSharedStaticCtorDeclaration())
             buf->writestring("shared ");
+        buf->writestring("static this()");
         if (hgs->hdrgen && !hgs->tpltMember)
         {
-            buf->writestring("static this();");
+            buf->writeByte(';');
             buf->writenl();
-            return;
         }
-        buf->writestring("static this()");
-        bodyToBuffer(d);
+        else
+            bodyToBuffer(d);
     }
 
     void visit(StaticDtorDeclaration *d)
     {
         if (hgs->hdrgen)
             return;
+        StorageClassDeclaration::stcToCBuffer(buf, d->storage_class & ~STCstatic);
         if (d->isSharedStaticDtorDeclaration())
             buf->writestring("shared ");
         buf->writestring("static ~this()");
@@ -1854,6 +1856,7 @@ public:
     {
         if (hgs->hdrgen)
             return;
+        StorageClassDeclaration::stcToCBuffer(buf, d->storage_class);
         buf->writestring("invariant");
         bodyToBuffer(d);
     }
@@ -1862,12 +1865,14 @@ public:
     {
         if (hgs->hdrgen)
             return;
+        StorageClassDeclaration::stcToCBuffer(buf, d->storage_class);
         buf->writestring("unittest");
         bodyToBuffer(d);
     }
 
     void visit(NewDeclaration *d)
     {
+        StorageClassDeclaration::stcToCBuffer(buf, d->storage_class & ~STCstatic);
         buf->writestring("new");
         parametersToBuffer(d->arguments, d->varargs);
         bodyToBuffer(d);
@@ -1875,6 +1880,7 @@ public:
 
     void visit(DeleteDeclaration *d)
     {
+        StorageClassDeclaration::stcToCBuffer(buf, d->storage_class & ~STCstatic);
         buf->writestring("delete");
         parametersToBuffer(d->arguments, 0);
         bodyToBuffer(d);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1582,29 +1582,6 @@ Dsymbol *Parser::parseStaticCtor()
 }
 
 /*****************************************
- * Parse a shared static constructor definition:
- *      shared static this() { body }
- * Current token is 'shared'.
- */
-
-Dsymbol *Parser::parseSharedStaticCtor()
-{
-    //Expressions *udas = NULL;
-    Loc loc = token.loc;
-
-    nextToken();
-    nextToken();
-    nextToken();
-    check(TOKlparen);
-    check(TOKrparen);
-    StorageClass stc = parsePostfix(STCundefined, NULL);
-
-    SharedStaticCtorDeclaration *f = new SharedStaticCtorDeclaration(loc, Loc(), stc);
-    Dsymbol *s = parseContracts(f);
-    return s;
-}
-
-/*****************************************
  * Parse a static destructor definition:
  *      static ~this() { body }
  * Current token is 'static'.
@@ -1633,6 +1610,29 @@ Dsymbol *Parser::parseStaticDtor()
         a->push(f);
         s = new UserAttributeDeclaration(udas, a);
     }
+    return s;
+}
+
+/*****************************************
+ * Parse a shared static constructor definition:
+ *      shared static this() { body }
+ * Current token is 'shared'.
+ */
+
+Dsymbol *Parser::parseSharedStaticCtor()
+{
+    //Expressions *udas = NULL;
+    Loc loc = token.loc;
+
+    nextToken();
+    nextToken();
+    nextToken();
+    check(TOKlparen);
+    check(TOKrparen);
+    StorageClass stc = parsePostfix(STCundefined, NULL);
+
+    SharedStaticCtorDeclaration *f = new SharedStaticCtorDeclaration(loc, Loc(), stc);
+    Dsymbol *s = parseContracts(f);
     return s;
 }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -97,12 +97,12 @@ public:
     Condition *parseDebugCondition();
     Condition *parseVersionCondition();
     Condition *parseStaticIfCondition();
-    Dsymbol *parseCtor();
-    Dsymbol *parseDtor();
-    Dsymbol *parseStaticCtor();
-    Dsymbol *parseStaticDtor();
-    Dsymbol *parseSharedStaticCtor();
-    Dsymbol *parseSharedStaticDtor();
+    Dsymbol *parseCtor(PrefixAttributes *pAttrs);
+    Dsymbol *parseDtor(PrefixAttributes *pAttrs);
+    Dsymbol *parseStaticCtor(PrefixAttributes *pAttrs);
+    Dsymbol *parseStaticDtor(PrefixAttributes *pAttrs);
+    Dsymbol *parseSharedStaticCtor(PrefixAttributes *pAttrs);
+    Dsymbol *parseSharedStaticDtor(PrefixAttributes *pAttrs);
     InvariantDeclaration *parseInvariant();
     UnitTestDeclaration *parseUnitTest();
     NewDeclaration *parseNew();

--- a/src/parse.h
+++ b/src/parse.h
@@ -103,10 +103,10 @@ public:
     Dsymbol *parseStaticDtor(PrefixAttributes *pAttrs);
     Dsymbol *parseSharedStaticCtor(PrefixAttributes *pAttrs);
     Dsymbol *parseSharedStaticDtor(PrefixAttributes *pAttrs);
-    InvariantDeclaration *parseInvariant();
-    UnitTestDeclaration *parseUnitTest();
-    NewDeclaration *parseNew();
-    DeleteDeclaration *parseDelete();
+    Dsymbol *parseInvariant(PrefixAttributes *pAttrs);
+    Dsymbol *parseUnitTest(PrefixAttributes *pAttrs);
+    Dsymbol *parseNew(PrefixAttributes *pAttrs);
+    Dsymbol *parseDelete(PrefixAttributes *pAttrs);
     Parameters *parseParameters(int *pvarargs, TemplateParameters **tpl = NULL);
     EnumDeclaration *parseEnum();
     Dsymbol *parseAggregate();

--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -158,6 +158,16 @@ static ~this()
 {
 }
 
+pure nothrow @safe @nogc static  this() {}
+pure nothrow @safe @nogc static ~this() {}
+static  this() pure nothrow @safe @nogc {}
+static ~this() pure nothrow @safe @nogc {}
+
+pure nothrow @safe @nogc shared static  this() {}
+pure nothrow @safe @nogc shared static ~this() {}
+shared static  this() pure nothrow @safe @nogc {}
+shared static ~this() pure nothrow @safe @nogc {}
+
 interface iFoo{}
 class xFoo: iFoo{}
 
@@ -222,6 +232,12 @@ class Test
     alias A!(short) getHShort;
     alias A!(ushort) getHUShort;
     alias A!(real) getHReal;
+
+    pure nothrow @safe @nogc unittest {}
+    pure nothrow @safe @nogc invariant {}
+
+    pure nothrow @safe @nogc new (size_t sz) { return null; }
+    pure nothrow @safe @nogc delete (void* p) { }
 }
 
 template templ( T )

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -133,6 +133,10 @@ template Foo(T, int V)
 	}
 }
 static this();
+nothrow pure @nogc @safe static this();
+nothrow pure @nogc @safe static this();
+nothrow pure @nogc @safe shared static this();
+nothrow pure @nogc @safe shared static this();
 interface iFoo
 {
 }
@@ -199,6 +203,8 @@ class Test
 	alias A!short getHShort;
 	alias A!ushort getHUShort;
 	alias A!real getHReal;
+	nothrow pure @nogc @safe new(size_t sz);
+	nothrow pure @nogc @safe delete(void* p);
 }
 void templ(T)(T val)
 {
@@ -314,8 +320,6 @@ void foo6591()()
 }
 version (unittest)
 {
-	nothrow pure {}
-	nothrow pure {}
 	public {}
 	extern (C) {}
 	align{}

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -168,6 +168,10 @@ template Foo(T, int V)
 	}
 }
 static this();
+nothrow pure @nogc @safe static this();
+nothrow pure @nogc @safe static this();
+nothrow pure @nogc @safe shared static this();
+nothrow pure @nogc @safe shared static this();
 interface iFoo
 {
 }
@@ -300,6 +304,13 @@ class Test
 	alias A!short getHShort;
 	alias A!ushort getHUShort;
 	alias A!real getHReal;
+	nothrow pure @nogc @safe new(size_t sz)
+	{
+		return null;
+	}
+	nothrow pure @nogc @safe delete(void* p)
+	{
+	}
 }
 void templ(T)(T val)
 {
@@ -434,8 +445,6 @@ void foo6591()()
 }
 version (unittest)
 {
-	nothrow pure {}
-	nothrow pure {}
 	public {}
 	extern (C) {}
 	align{}

--- a/test/fail_compilation/diag6677.d
+++ b/test/fail_compilation/diag6677.d
@@ -1,21 +1,20 @@
+// REQUIRED_ARGS:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag6677.d(1): Error: static constructors cannot be const 
-fail_compilation/diag6677.d(2): Error: static constructors cannot be inout 
-fail_compilation/diag6677.d(3): Error: static constructors cannot be immutable 
-fail_compilation/diag6677.d(4): Error: to create a shared static constructor, use 'shared static this'
-fail_compilation/diag6677.d(5): Error: to create a shared static constructor, use 'shared static this'
-fail_compilation/diag6677.d(5): Error: static constructors cannot be const 
-fail_compilation/diag6677.d(7): Error: static constructors cannot be const 
-fail_compilation/diag6677.d(8): Error: static constructors cannot be inout 
-fail_compilation/diag6677.d(9): Error: static constructors cannot be immutable 
-fail_compilation/diag6677.d(10): Error: static constructors cannot be shared 
-fail_compilation/diag6677.d(11): Error: static constructors cannot be const shared
+fail_compilation/diag6677.d(18): Error: static constructor cannot be const
+fail_compilation/diag6677.d(19): Error: static constructor cannot be inout
+fail_compilation/diag6677.d(20): Error: static constructor cannot be immutable
+fail_compilation/diag6677.d(21): Error: use 'shared static this()' to declare a shared static constructor
+fail_compilation/diag6677.d(22): Error: use 'shared static this()' to declare a shared static constructor
+fail_compilation/diag6677.d(24): Error: shared static constructor cannot be const
+fail_compilation/diag6677.d(25): Error: shared static constructor cannot be inout
+fail_compilation/diag6677.d(26): Error: shared static constructor cannot be immutable
+fail_compilation/diag6677.d(27): Error: redundant attribute 'shared'
+fail_compilation/diag6677.d(28): Error: redundant attribute 'shared'
 ---
 */
 
-#line 1
 static this() const { }
 static this() inout { }
 static this() immutable { }

--- a/test/fail_compilation/fail7848.d
+++ b/test/fail_compilation/fail7848.d
@@ -3,16 +3,51 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7848.d(17): Error: pure function 'fail7848.__unittestL15_1' cannot call impure function 'fail7848.func'
-fail_compilation/fail7848.d(17): Error: safe function 'fail7848.__unittestL15_1' cannot call system function 'fail7848.func'
-fail_compilation/fail7848.d(17): Error: 'fail7848.func' is not nothrow
-fail_compilation/fail7848.d(15): Error: function 'fail7848.__unittestL15_1' is nothrow yet may throw
+fail_compilation/fail7848.d(35): Error: pure function 'fail7848.C.__unittestL33_1' cannot call impure function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: safe function 'fail7848.C.__unittestL33_1' cannot call system function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: @nogc function 'fail7848.C.__unittestL33_1' cannot call non-@nogc function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: 'fail7848.func' is not nothrow
+fail_compilation/fail7848.d(33): Error: function 'fail7848.C.__unittestL33_1' is nothrow yet may throw
+fail_compilation/fail7848.d(40): Error: pure function 'fail7848.C.__invariant1' cannot call impure function 'fail7848.func'
+fail_compilation/fail7848.d(40): Error: safe function 'fail7848.C.__invariant1' cannot call system function 'fail7848.func'
+fail_compilation/fail7848.d(40): Error: @nogc function 'fail7848.C.__invariant1' cannot call non-@nogc function 'fail7848.func'
+fail_compilation/fail7848.d(40): Error: 'fail7848.func' is not nothrow
+fail_compilation/fail7848.d(38): Error: function 'fail7848.C.__invariant1' is nothrow yet may throw
+fail_compilation/fail7848.d(45): Error: pure function 'fail7848.C.new' cannot call impure function 'fail7848.func'
+fail_compilation/fail7848.d(45): Error: safe function 'fail7848.C.new' cannot call system function 'fail7848.func'
+fail_compilation/fail7848.d(45): Error: @nogc function 'fail7848.C.new' cannot call non-@nogc function 'fail7848.func'
+fail_compilation/fail7848.d(45): Error: 'fail7848.func' is not nothrow
+fail_compilation/fail7848.d(43): Error: allocator 'fail7848.C.new' is nothrow yet may throw
+fail_compilation/fail7848.d(51): Error: pure function 'fail7848.C.delete' cannot call impure function 'fail7848.func'
+fail_compilation/fail7848.d(51): Error: safe function 'fail7848.C.delete' cannot call system function 'fail7848.func'
+fail_compilation/fail7848.d(51): Error: @nogc function 'fail7848.C.delete' cannot call non-@nogc function 'fail7848.func'
+fail_compilation/fail7848.d(51): Error: 'fail7848.func' is not nothrow
+fail_compilation/fail7848.d(49): Error: deallocator 'fail7848.C.delete' is nothrow yet may throw
 ---
 */
 
 void func() {}
 
-@safe pure nothrow unittest
+class C
 {
-    func();
+    @safe pure nothrow @nogc unittest
+    {
+        func();
+    }
+
+    @safe pure nothrow @nogc invariant
+    {
+        func();
+    }
+
+    @safe pure nothrow @nogc new (size_t sz)
+    {
+        func();
+        return null;
+    }
+
+    @safe pure nothrow @nogc delete (void* p)
+    {
+        func();
+    }
 }

--- a/test/fail_compilation/parseStc4.d
+++ b/test/fail_compilation/parseStc4.d
@@ -15,3 +15,28 @@ pure nothrow @system @nogc @property
 {
     return 0;
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc4.d(34): Error: redundant attribute 'const'
+fail_compilation/parseStc4.d(35): Error: redundant attribute 'const'
+fail_compilation/parseStc4.d(36): Error: redundant attribute 'const'
+fail_compilation/parseStc4.d(38): Error: redundant attribute 'pure'
+fail_compilation/parseStc4.d(39): Error: redundant attribute '@safe'
+fail_compilation/parseStc4.d(40): Error: redundant attribute 'nothrow'
+fail_compilation/parseStc4.d(41): Error: conflicting attribute '@trusted'
+---
+*/
+
+struct S
+{
+    const this(int) const {}
+    const this(this) const {}
+    const ~this() const {}
+
+    pure static this() pure {}
+    @safe static ~this() @safe {}
+    nothrow shared static this() nothrow {}
+    @system shared static ~this() @trusted {}
+}

--- a/test/fail_compilation/parseStc5.d
+++ b/test/fail_compilation/parseStc5.d
@@ -1,0 +1,88 @@
+// REQUIRED_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc5.d(11): Error: constructor cannot be static
+fail_compilation/parseStc5.d(12): Error: postblit cannot be static
+---
+*/
+class C1
+{
+    static pure this(int) {}        // 'static pure' + 'this(int)'
+    static pure this(this) {}       // 'static pure' + 'this(this)'
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc5.d(28): Error: use 'shared static this()' to declare a shared static constructor
+fail_compilation/parseStc5.d(29): Error: use 'shared static this()' to declare a shared static constructor
+fail_compilation/parseStc5.d(31): Error: use 'shared static this()' to declare a shared static constructor
+fail_compilation/parseStc5.d(33): Error: use 'shared static ~this()' to declare a shared static destructor
+fail_compilation/parseStc5.d(34): Error: use 'shared static ~this()' to declare a shared static destructor
+fail_compilation/parseStc5.d(36): Error: use 'shared static ~this()' to declare a shared static destructor
+---
+*/
+class C2    // wrong combinations of 'shared', 'static', and '~?this()'
+{
+    shared pure static this() {}    // 'shared pure' + 'static this()'
+    shared static pure this() {}    // 'shared static pure' + 'this()'
+
+    static this() shared {}         // 'shared pure' + 'static this()'
+
+    shared pure static ~this() {}   // 'shared pure' + 'static ~this()'
+    shared static pure ~this() {}   // 'shared static pure' + '~this()'
+
+    static ~this() shared {}        // 'shared' + 'static ~this()'
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc5.d(48): Error: use 'static this()' to declare a static constructor
+fail_compilation/parseStc5.d(49): Error: use 'static ~this()' to declare a static destructor
+---
+*/
+class C3    // wrong combinations of 'static' and '~?this()'
+{
+    static pure this() {}           // 'static pure' + 'this()'
+    static pure ~this() {}          // 'static pure' + '~this()'
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc5.d(64): Error: redundant attribute 'shared'
+fail_compilation/parseStc5.d(65): Error: redundant attribute 'shared'
+fail_compilation/parseStc5.d(67): Error: redundant attribute 'static'
+fail_compilation/parseStc5.d(69): Error: redundant attribute 'static shared'
+fail_compilation/parseStc5.d(70): Error: redundant attribute 'static shared'
+---
+*/
+class C4    // redundancy of 'shared' and/or 'static'
+{
+    shared shared static this() {}                  // 'shared' + 'shared static this()'
+    shared static this() shared {}                  // 'shared' + 'shared static this()'
+
+    static static this() {}                         // 'static' + 'shared static this()'
+
+    shared static shared static this() {}           // shared static + 'shared static this()'
+    shared static shared static this() shared {}    // shared shared static + 'shared static this()'
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc5.d(84): Error: static constructor cannot be const
+fail_compilation/parseStc5.d(85): Error: static destructor cannot be const
+fail_compilation/parseStc5.d(86): Error: shared static constructor cannot be const
+fail_compilation/parseStc5.d(87): Error: shared static destructor cannot be const
+---
+*/
+class C5    // wrong MemberFunctionAttributes on 'shared? static (con|de)structor'
+{
+    static this() const {}
+    static ~this() const {}
+    shared static this() const {}
+    shared static ~this() const {}
+}


### PR DESCRIPTION
By the strict handling of prefix attributes, we can improve situations of some parsing issues.
1. Detect more redundant/conflicting attributes around constructors and destructors, .
   
   ``` d
   pure  this(int) pure {}       // no error -> Error: redundant attributes
   @safe this(this) @trusted {}  // no error -> Error: conflicting attributes
   ```
2. Improve diagnostic for the [issue 6677](https://issues.dlang.org/show_bug.cgi?id=6677).
   
   ``` d
   shared pure static this() {}
   // no error -> Error: use 'shared static this()' to declare a shared static constructor
   ```
3. Partial fix for [issue 8081](https://issues.dlang.org/show_bug.cgi?id=8081).
   
   ``` d
   pure nothrow unittest {}
   // -> Will not appear in generated header file anymore.
   ```
