### PR TITLE
Issue 13574 - incorrect code for assignment to dollar in slice expression

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1491,7 +1491,7 @@ Dsymbol *ArrayScopeSymbol::search(Loc loc, Identifier *ident, int flags)
                 if (t && t->ty == Tfunction)
                     e = new CallExp(e->loc, e);
                 v = new VarDeclaration(loc, NULL, Id::dollar, new ExpInitializer(Loc(), e));
-                v->storage_class |= STCtemp | STCctfe;
+                v->storage_class |= STCtemp | STCctfe | STCrvalue;
             }
             else
             {

--- a/src/expression.c
+++ b/src/expression.c
@@ -5045,6 +5045,11 @@ Expression *VarExp::toLvalue(Scope *sc, Expression *e)
         error("compiler-generated variable __ctfe is not an lvalue");
         return new ErrorExp();
     }
+    if (var->ident == Id::dollar)   // Bugzilla 13574
+    {
+        error("'$' is not an lvalue");
+        return new ErrorExp();
+    }
     return this;
 }
 

--- a/test/fail_compilation/fail13574.d
+++ b/test/fail_compilation/fail13574.d
@@ -1,0 +1,29 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13574.d(21): Error: '$' is not an lvalue
+fail_compilation/fail13574.d(27): Error: '$' is not an lvalue
+---
+*/
+
+struct Foo
+{
+    void opSlice(size_t a, size_t b) {  }
+    alias opDollar = length;
+    size_t length;
+}
+
+void main()
+{
+    Foo foo;
+    foo[0 .. foo.length = 1];
+    assert(foo.length == 1);
+    foo[0 .. $ = 2]; // assigns to the temporary dollar variable
+    //assert(foo.length == 2);
+
+    int[] arr = [1,2,3];
+    auto x = arr[0 .. arr.length = 1];
+    assert(arr.length == 1);
+    auto y = arr[0 .. $ = 2]; // should also be disallowed
+    //assert(arr.length == 2);
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13574

`$` should be treated as an rvalue, and then assign to it should be disallowed.
