### PR TITLE
Fix Issue 13583: Inconsistent naming of template arguments in debug symbols

### DIFF
--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -191,7 +191,7 @@ Symbol *toSymbol(Dsymbol *s)
                      * It applies to PDB format, but should apply to CV as PDB derives from CV.
                      *    http://msdn.microsoft.com/en-us/library/ff553493(VS.85).aspx
                      */
-                    s->prettyIdent = vd->toPrettyChars();
+                    s->prettyIdent = vd->toPrettyChars(true);
                 }
                 else
                 {
@@ -290,7 +290,7 @@ Symbol *toSymbol(Dsymbol *s)
                 Symbol *s = symbol_calloc(id);
                 slist_add(s);
 
-                s->prettyIdent = fd->toPrettyChars();
+                s->prettyIdent = fd->toPrettyChars(true);
                 s->Sclass = SCglobal;
                 symbol_func(s);
                 func_t *f = s->Sfunc;

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -214,7 +214,7 @@ public:
         }
         else if (t->sym->memtype->toBasetype()->ty == Tint32)
         {
-            t->ctype = type_enum(t->sym->toPrettyChars(), Type_toCtype(t->sym->memtype));
+            t->ctype = type_enum(t->sym->toPrettyChars(true), Type_toCtype(t->sym->memtype));
             tm->ctype = t->ctype;
         }
         else
@@ -233,7 +233,7 @@ public:
     void visit(TypeClass *t)
     {
         //printf("TypeClass::toCtype() %s\n", toChars());
-        type *tc = type_struct_class(t->sym->toPrettyChars(), t->sym->alignsize, t->sym->structsize,
+        type *tc = type_struct_class(t->sym->toPrettyChars(true), t->sym->alignsize, t->sym->structsize,
                 NULL,
                 NULL,
                 false,


### PR DESCRIPTION
debug symbols should always use the fully qualified names for template arguments

https://issues.dlang.org/show_bug.cgi?id=13583
