### PR TITLE
Issue 4014 - CodeView debug type info not linked in from library

### DIFF
--- a/src/backend.d
+++ b/src/backend.d
@@ -43,7 +43,7 @@ extern extern (C++) type* type_delegate(type* tnext);
 extern extern (C) type* type_function(tym_t tyf, type** ptypes, size_t nparams, bool variadic, type* tret);
 extern extern (C++) type* type_enum(const(char)* name, type* tbase);
 extern extern (C++) type* type_struct_class(const(char)* name, uint alignsize, uint structsize,
-    type* arg1type, type* arg2type, bool isUnion, bool isClass, bool isPOD);
+    type* arg1type, type* arg2type, bool isUnion, bool isClass, bool isPOD, Symbol* init);
 
 extern extern (C++) void symbol_struct_addField(Symbol* s, const(char)* name, type* t, uint offset);
 

--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1025,6 +1025,8 @@ typedef struct STRUCT
                                 // of a template class, this is the
                                 // template class Symbol
 
+    Symbol* Sinit;              // symbol for the init data
+
     // For 64 bit Elf function ABI
     type *Sarg1type;
     type *Sarg2type;

--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -791,11 +791,10 @@ void cv4_initref(Classsym *s)
         unsigned char debsym[12];
 
         TOWORD(debsym, length - 2);
-        TOWORD(debsym + 2, S_LABEL32);
+        TOWORD(debsym + 2, S_SKIP);
         TOLONG(debsym + 4, 0); // offset
         TOWORD(debsym + 8, 0); // seg
-        debsym[10] = 0;     // flags
-        debsym[11] = 0;     // name-length
+        TOWORD(debsym + 10, 0); // pad
 
         unsigned soffset = Offset(DEBSYM);
         objmod->write_bytes(SegData[DEBSYM],length,debsym);

--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -778,6 +778,31 @@ STATIC char * cv4_prettyident(symbol *s)
 
 #endif
 
+/*********************************************
+ * debug info for a struct/class/union is built with
+ * the initializer, so make sure it is dragged in by the linker
+ * by adding an debug record with a relocation to the init symbol
+ */
+void cv4_initref(Classsym *s)
+{
+    if (s->Sstruct->Sinit && s->Sstruct->Sstructsize > 0) // no reference for empty/forward referenced structs
+    {
+        const int length = 12;
+        unsigned char debsym[12];
+
+        TOWORD(debsym, length - 2);
+        TOWORD(debsym + 2, S_LABEL32);
+        TOLONG(debsym + 4, 0); // offset
+        TOWORD(debsym + 8, 0); // seg
+        debsym[10] = 0;     // flags
+        debsym[11] = 0;     // name-length
+
+        unsigned soffset = Offset(DEBSYM);
+        objmod->write_bytes(SegData[DEBSYM],length,debsym);
+        objmod->reftoident(DEBSYM, soffset + 4, s->Sstruct->Sinit, 0, CFseg | CFoff);
+    }
+}
+
 /****************************
  * Return type index of struct.
  * Input:
@@ -1031,6 +1056,9 @@ printf("fwd struct ref\n");
         {   TOLONG(d->data + 6,0);              // field list is 0
             TOWORD(d->data + 4,property);
         }
+#if MARS
+        cv4_initref(s);
+#endif
         return s->Stypidx;
     }
 

--- a/src/backend/cgcv.h
+++ b/src/backend/cgcv.h
@@ -83,7 +83,7 @@ void cv8_linnum(Srcpos srcpos, targ_size_t offset);
 void cv8_outsym(Symbol *s);
 void cv8_udt(const char *id, idx_t typidx);
 int cv8_regnum(Symbol *s);
-idx_t cv8_fwdref(Symbol *s);
+idx_t cv8_fwdref(Classsym *s);
 idx_t cv8_darray(type *tnext, idx_t etypidx);
 idx_t cv8_ddelegate(type *t, idx_t functypidx);
 idx_t cv8_daarray(type *t, idx_t keyidx, idx_t validx);

--- a/src/backend/cv8.c
+++ b/src/backend/cv8.c
@@ -793,9 +793,9 @@ void cv8_flushinitref()
         Classsym* s = *(Classsym**)(initFixup->buf + u);
 
         Outbuffer *buf = currentfuncdata.f1buf;
-        buf->reserve(2 + 2 + 2 + 4 + 1 + 1);
-        buf->writeWordn( 2 + 2 + 4 + 1 + 1);
-        buf->writeWordn(S_LABEL32);
+        buf->reserve(2 + 2 + 2 + 4 + 2);
+        buf->writeWordn( 2 + 2 + 4 + 2);
+        buf->writeWordn(S_SKIP);
 
         F1_Fixups f1f;
         f1f.s = s->Sstruct->Sinit;
@@ -804,8 +804,7 @@ void cv8_flushinitref()
 
         buf->write32(0);            // offset
         buf->writeWordn(0);         // seg
-        buf->writeByten(0);         // flags
-        buf->writeByten(0);         // name.length
+        buf->writeWordn(0);         // pad
     }
     initFixup->reset();
 }

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -480,7 +480,8 @@ type *type_enum(const char *name, type *tbase)
  *      Tcount already incremented
  */
 type *type_struct_class(const char *name, unsigned alignsize, unsigned structsize,
-        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD)
+        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD,
+        Symbol* init)
 {
     Symbol *s = symbol_calloc(name);
     s->Sclass = SCstruct;
@@ -490,6 +491,7 @@ type *type_struct_class(const char *name, unsigned alignsize, unsigned structsiz
     s->Sstruct->Sstructsize = structsize;
     s->Sstruct->Sarg1type = arg1type;
     s->Sstruct->Sarg2type = arg2type;
+    s->Sstruct->Sinit = init;
 
     if (!isPOD)
         s->Sstruct->Sflags |= STRnotpod;

--- a/src/backend/type.h
+++ b/src/backend/type.h
@@ -198,6 +198,7 @@ type *type_delegate(type *tnext);
 extern "C" type *type_function(tym_t tyf, type **ptypes, size_t nparams, bool variadic, type *tret);
 type *type_enum(const char *name, type *tbase);
 type *type_struct_class(const char *name, unsigned alignsize, unsigned structsize,
-        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD);
+        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD,
+        Symbol* init);
 
 #endif

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1459,6 +1459,8 @@ elem *toElem(Expression *e, IRState *irs)
 
                 if (ne->allocator || ne->onstack)
                 {
+                    Symbol *si = toInitializer(tclass->sym);
+
                     if (ne->onstack)
                     {
                         /* Create an instance of the class on the stack,
@@ -1468,7 +1470,7 @@ elem *toElem(Expression *e, IRState *irs)
                         ::type *tc = type_struct_class(tclass->sym->toChars(),
                                 tclass->sym->alignsize, tclass->sym->structsize,
                                 NULL, NULL,
-                                false, false, true);
+                                false, false, true, si);
                         tc->Tcount--;
                         Symbol *stmp = symbol_genauto(tc);
                         ex = el_ptr(stmp);
@@ -1480,7 +1482,6 @@ elem *toElem(Expression *e, IRState *irs)
                                 ne->allocator, ne->allocator->type, NULL, ne->newargs);
                     }
 
-                    Symbol *si = toInitializer(tclass->sym);
                     elem *ei = el_var(si);
 
                     if (cd->isNested())

--- a/src/glue.c
+++ b/src/glue.c
@@ -1196,7 +1196,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
             if (global.params.is64bit &&
                 !global.params.isWindows)
             {
-                type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3, NULL, NULL, false, false, true);
+                type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3, NULL, NULL, false, false, true, NULL);
                 // The backend will pick this up by name
                 Symbol *s = symbol_name("__va_argsave", SCauto, t);
                 s->Stype->Tty |= mTYvolatile;

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -504,7 +504,7 @@ Classsym *fake_classsym(Identifier *id)
 {
     TYPE *t = type_struct_class(id->toChars(),8,0,
         NULL,NULL,
-        false, false, true);
+        false, false, true, NULL);
 
     t->Ttag->Sstruct->Sflags = STRglobal;
     t->Tflags |= TFsizeunknown | TFforward;
@@ -541,7 +541,7 @@ Symbol *toVtblSymbol(ClassDeclaration *cd)
 
 Symbol *toInitializer(AggregateDeclaration *ad)
 {
-    if (!ad->sinit)
+    if (!ad->sinit && !ad->isInterfaceDeclaration()) // an interface does not have an initializer
     {
         Classsym *stag = fake_classsym(Id::ClassInfo);
         Symbol *s = toSymbolX(ad, "__init", SCextern, stag->Stype, "Z");

--- a/src/toctype.d
+++ b/src/toctype.d
@@ -10,6 +10,7 @@ module ddmd.toctype;
 
 import core.stdc.stdlib;
 
+import ddmd.aggregate;
 import ddmd.backend;
 import ddmd.declaration;
 import ddmd.dstruct;
@@ -19,6 +20,7 @@ import ddmd.mtype;
 import ddmd.visitor;
 
 extern extern (C++) uint totym(Type tx);
+extern extern (C++) Symbol* toInitializer(AggregateDeclaration ad);
 
 extern (C++) final class ToCtypeVisitor : Visitor
 {
@@ -127,7 +129,11 @@ public:
                 t.ctype.Tcount++;
                 return;
             }
-            t.ctype = type_struct_class(sym.toPrettyChars(true), sym.alignsize, sym.structsize, sym.arg1type ? Type_toCtype(sym.arg1type) : null, sym.arg2type ? Type_toCtype(sym.arg2type) : null, sym.isUnionDeclaration() !is null, false, sym.isPOD() != 0);
+            t.ctype = type_struct_class(sym.toPrettyChars(true), sym.alignsize, sym.structsize,
+                                        sym.arg1type ? Type_toCtype(sym.arg1type) : null,
+                                        sym.arg2type ? Type_toCtype(sym.arg2type) : null,
+                                        sym.isUnionDeclaration() !is null, false,
+                                        sym.isPOD() != 0, toInitializer(sym));
             /* Add in fields of the struct
              * (after setting ctype to avoid infinite recursion)
              */
@@ -196,7 +202,8 @@ public:
     override void visit(TypeClass t)
     {
         //printf("TypeClass::toCtype() %s\n", toChars());
-        type* tc = type_struct_class(t.sym.toPrettyChars(true), t.sym.alignsize, t.sym.structsize, null, null, false, true, true);
+        type* tc = type_struct_class(t.sym.toPrettyChars(true), t.sym.alignsize, t.sym.structsize,
+                                     null, null, false, true, true, toInitializer(t.sym));
         t.ctype = type_pointer(tc);
         /* Add in fields of the class
          * (after setting ctype to avoid infinite recursion)

--- a/src/toir.c
+++ b/src/toir.c
@@ -782,7 +782,7 @@ void buildClosure(FuncDeclaration *fd, IRState *irs)
         strcat(strcat(closname, name1), name2);
 
         /* Build type for closure */
-        type *Closstru = type_struct_class(closname, Target::ptrsize, 0, NULL, NULL, false, false, true);
+        type *Closstru = type_struct_class(closname, Target::ptrsize, 0, NULL, NULL, false, false, true, NULL);
         free(closname);
         symbol_struct_addField(Closstru->Ttag, "__chain", Type_toCtype(Type::tvoidptr), 0);
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=4014

This PR adds a relocation to S.init if S is referred to by the debug info. It assumes the debug info is found there and will be linked in if S.init is linked in.

Currently only implemented for Win32/Win64.

This is an alternative to https://github.com/D-Programming-Language/dmd/pull/398

Advantages:
- debug info doesn't have to be rebuilt every time it is referred to
- small overhead in debug-section only

Disadvantages:
- no debug info, if library is built without
- assumes that S.init is found in the library, i.e. files with declarations only still need to be compiled (very much as proposed by https://github.com/D-Programming-Language/dmd/pull/3958)
- ~~abuses S_LABEL32 debug record, maybe some other unrecognized record is better~~
