### PR TITLE
Fix Issue 4181 - GDB prints wrong value of TLS variables

### DIFF
--- a/src/backend/dwarf.h
+++ b/src/backend/dwarf.h
@@ -5,6 +5,7 @@
 /* ==================== Dwarf debug ======================= */
 
 // #define USE_DWARF_D_EXTENSIONS
+#define DWARF_VERSION 2
 
 void dwarf_initfile(const char *filename);
 void dwarf_termfile();

--- a/src/backend/dwarf2.h
+++ b/src/backend/dwarf2.h
@@ -272,6 +272,9 @@ enum
         DW_OP_bit_piece         = 0x9d,
         DW_OP_lo_user   = 0xe0,
         DW_OP_hi_user   = 0xff,
+
+        /* GNU extensions. */
+        DW_OP_GNU_push_tls_address = 0xe0,
 };
 
 enum


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=4181

Add DW_OP_GNU_push_tls_address to dwarf debug info for tls vars and also add offset to the address in append_addr() which fixes shared global vars.

I'm novice in dmd and dwarf hacking, so please review thoroughly.

Works for me on Debian wheezy x86 and x86_64, dmd 2.066 and master, gdb 7.8.50.
