### PR TITLE
Issue 10439 - Deprecate float.min, double.min, real.min

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2988,7 +2988,7 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                deprecation(loc, ".min property is deprecated, use .min_normal instead");
+                error(loc, ".min property is deprecated, use .min_normal instead");
                 goto Lmin_normal;
         }
     }

--- a/test/fail_compilation/fail10439.d
+++ b/test/fail_compilation/fail10439.d
@@ -1,0 +1,29 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10439.d(18): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(19): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(20): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(22): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(23): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(24): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(26): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(27): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(28): Error: .min property is deprecated, use .min_normal instead
+---
+*/
+
+void main()
+{
+    auto a = float.min;
+    auto b = double.min;
+    auto c = real.min;
+
+    auto d = ifloat.min;
+    auto e = idouble.min;
+    auto f = ireal.min;
+
+    auto g = cfloat.min;
+    auto h = cdouble.min;
+    auto i = creal.min;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=10439

It was deprecated in 2.065 (February 24, 2014).
