### PR TITLE
[D1] -v2: warn about const storage class

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -779,6 +779,16 @@ void VarDeclaration::semantic(Scope *sc)
     }
 
     storage_class |= sc->stc;
+
+    if (global.params.Dversion >= 3)
+    {
+        if (storage_class & STCconst && !init)
+        {
+            warning(loc, "There is no const storage class in D2, make variable '%s'' non-const",
+                toChars());
+        }
+    }
+
     if (storage_class & STCextern && init)
         error("extern symbols cannot have initializers");
 


### PR DESCRIPTION
As const is qualifier in D2 there is no striaghtforward
replacement for this D1 pattern. Most simple approach is to make
those variables mutable for transitional period and re-qualify
later on case by case basis.
