### PR TITLE
fix Issue 13600 - ICE in dwarf.c line 1949 with -g enabled and lazy void...

### DIFF
--- a/src/toctype.c
+++ b/src/toctype.c
@@ -86,6 +86,11 @@ public:
             type *tp = Type_toCtype(arg->type);
             if (arg->storageClass & (STCout | STCref))
                 tp = type_allocn(TYref, tp);
+            else if (arg->storageClass & STClazy)
+            {   // Mangle as delegate
+                type *tf = type_function(TYnfunc, NULL, 0, false, tp);
+                tp = type_delegate(tf);
+            }
             ptypes[i] = tp;
         }
 

--- a/test/compilable/test13600.d
+++ b/test/compilable/test13600.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -g
+
+class Retry
+{
+    alias bool delegate ( lazy void ) SuccessDecider;
+
+    SuccessDecider success_decide;
+
+    void on_retry ( )
+    {
+    }
+}
+


### PR DESCRIPTION
... parameter

Caused by neglecting to handle lazy parameter types.

https://issues.dlang.org/show_bug.cgi?id=13600

Should cherry-pick into D1, too.
