### PR TITLE
Fix Issue 10311 - GDB prints wrong value for variable updated from closure

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1226,6 +1226,7 @@ struct Symbol
         #define SFLwasstatic    0x800000 // was an uninitialized static
         #define SFLweak         0x1000000 // resolve to NULL if not found
         #define SFLartifical    0x4000000 // compiler generated symbol
+        #define SFLclosurevar   0x8000000 // is closure variable
 
         // CPP
         #define SFLnodtor       0x10    // set if destructor for Symbol is already called
@@ -1275,6 +1276,8 @@ struct Symbol
     vec_t       Slvreg;         // when symbol is in register
     targ_size_t Ssize;          // tyfunc: size of function
     targ_size_t Soffset;        // variables: offset of Symbol in its storage class
+    SYMIDX      closptr_idx;    // variables: index of closure pointer in global symbol table
+    targ_size_t closvar_off;    // variables: offset of closure variable
 
     // CPP || OPTIMIZER
     SYMIDX Ssymnum;             // Symbol number (index into globsym.tab[])

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -1033,7 +1033,7 @@ typedef unsigned SYMFLGS;
          (symbol *)0,(symbol *)0,(symbol *)0,(dt_t *)0,0,(type *)0,{0},\
          SYMBOLZERO\
          UNIXFIELDS\
-         SCextern,(fl),(flags),0,0,0,0,0,0,0,{0},(regsaved),{name}}
+         SCextern,(fl),(flags),0,0,0,0,0,0,0,0,0,{0},(regsaved),{name}}
 
 /**********************************
  * Storage classes

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1256,6 +1256,17 @@ void dwarf_func_term(Symbol *sfunc)
                         {   // BUG: register pairs not supported in Dwarf?
                             infobuf->writeByte(DW_OP_reg0 + sa->Sreglsw);
                         }
+                        else if (sa->Sflags & SFLclosurevar)
+                        {
+                            //printf("dwarf closure: closptr_idx: %i (%s), closvar_off: %llx\n",
+                            //    sa->closptr_idx, globsym.tab[sa->closptr_idx]->Sident, sa->closvar_off);
+                            targ_size_t closptr_off = sa->closptr_idx < globsym.top ? globsym.tab[sa->closptr_idx]->Soffset : 0;
+                            infobuf->writeByte(DW_OP_fbreg);
+                            infobuf->writesLEB128(Auto.size + BPoff - Para.size + closptr_off); // closure pointer offset from frame base
+                            infobuf->writeByte(DW_OP_deref);
+                            infobuf->writeByte(DW_OP_plus_uconst);
+                            infobuf->writeByte(sa->closvar_off); // closure var offset
+                        }
                         else
                         {
                             infobuf->writeByte(DW_OP_fbreg);

--- a/src/toir.c
+++ b/src/toir.c
@@ -672,7 +672,7 @@ void buildClosure(FuncDeclaration *fd, IRState *irs)
         Symbol *sclosure;
         sclosure = symbol_name("__closptr", SCauto, Type_toCtype(Type::tvoidptr));
         sclosure->Sflags |= SFLtrue | SFLfree;
-        symbol_add(sclosure);
+        SYMIDX closptr_idx = symbol_add(sclosure);
         irs->sclosure = sclosure;
 
         unsigned offset = Target::ptrsize;      // leave room for previous sthis
@@ -733,6 +733,12 @@ void buildClosure(FuncDeclaration *fd, IRState *irs)
             AggregateDeclaration::alignmember(xalign, memalignsize, &offset);
             v->offset = offset;
             offset += memsize;
+
+            /* Flag symbol as closure variable */
+            Symbol *vsym = toSymbol(v);
+            vsym->Sflags |= SFLclosurevar;
+            vsym->closptr_idx = closptr_idx; // index of closure pointer in symbol table
+            vsym->closvar_off = v->offset;   // offset of closure variable
 
             /* Can't do nrvo if the variable is put in a closure, since
              * what the shidden points to may no longer exist.


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=10311

The main problem is how to get the offset data from toir.c to dwarf.c. I have modified struct Symbol to do this, not sure if it is the proper approach. Comment please.
