### PR TITLE
Fix `toEmodulename` in 64bit version

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -1287,14 +1287,14 @@ elem *Module::toEmodulename()
 
         /* Class ModuleInfo is defined in std.moduleinfo.
          * The first member is the name of it, char name[],
-         * which will be at offset 8.
+         * which will be at offset 2 * Target::ptrsize.
          */
 
         si = toSymbol();
 #if 1
         // Use this instead so -fPIC will work
         efilename = el_ptr(si);
-        efilename = el_bin(OPadd, TYnptr, efilename, el_long(TYuint, 8));
+        efilename = el_bin(OPadd, TYnptr, efilename, el_long(TYuint, 2 * Target::ptrsize));
         if (config.exe != EX_WIN64)
             efilename = el_una(OPind, TYdarray, efilename);
 #else


### PR DESCRIPTION
`toEmodulename` didn't work with the 64bit build of dmd because of the fixed offset that's doubled in the 64 bit build. This caused very nasty (and very hard to isolate and reduce) bug when assertion or exception message only shows line number if there's a module constructor or destructor in any module imported in the project:

``` D
void main()
{
    int a[];
    a[5] = 5;
}
```

outputs:

```
terminated after throwing an uncaught instance of 'tango.core.Exception.ArrayBoundsException' at test.d:4
toString():  Array index out of bounds
```

but:

``` D
static this() {}
void main()
{
    int a[];
    a[5] = 5;
}
```

outputs: 

```
terminated after throwing an uncaught instance of 'tango.core.Exception.ArrayBoundsException'
toString():  Array index out of bounds
```

32bit build of dmd works fine. The PR was tested against both 64bit and 32bit builds.
