### PR TITLE
[new AA] AA tests harmonization with new AA implementation

### DIFF
--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2395,7 +2395,7 @@ Foo9320 test9320(Foo9320 a, Foo9320 b, Foo9320 c) {
 struct Test9386
 {
     string name;
-    static char[21] op;
+    static char[25] op;
     static size_t i;
 
     static @property string sop() { return cast(string)op[0..i]; }
@@ -2474,7 +2474,6 @@ void test9386()
               Test9386("3") : Test9386("three"),
               Test9386("4") : Test9386("four") ];
 
-        assert(Test9386.sop == "aaaaaaaa");
         Test9386.op[] = 0;
         Test9386.i = 0;
 

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -990,6 +990,7 @@ void test6178()
 
 void test6178x()
 {
+    return; // depends on AA implementation
     static int ctor, cpctor, dtor;
 
     static struct S
@@ -1015,22 +1016,22 @@ void test6178x()
         auto getVal() { return value; }
 
         aa1[value] = 10;
-        assert(ctor==1 && cpctor==0 && dtor==0);
+        assert(ctor==1 && cpctor==1 && dtor==0); //call copy ctor when we putting 'value' to aa1
 
         aa1[getRef()] = 20;
-        assert(ctor==1 && cpctor==0 && dtor==0);
+        assert(ctor==1 && cpctor==1 && dtor==0); //copy ctor wasn't called because we didn't create a new entry in aa, using an existing key
 
         aa1[getVal()] = 20;
-        assert(ctor==1 && cpctor==1 && dtor==1);
+        assert(ctor==1 && cpctor==2 && dtor==1); //call copy ctor and dtor, because we pass key by value
 
         aa2[1] = value;
-        assert(ctor==1 && cpctor==2 && dtor==1);
+        assert(ctor==1 && cpctor==3 && dtor==1); //call copy ctor when we putting `value` to aa2[1]
 
         aa2[2] = getRef();
-        assert(ctor==1 && cpctor==3 && dtor==1);
+        assert(ctor==1 && cpctor==4 && dtor==1); //call copy ctor when we putting `value` to aa2[2]
     }
-    assert(ctor==1 && cpctor==3 && dtor==2);
-    assert(ctor + cpctor - aa2.length == dtor);
+    assert(ctor==1 && cpctor==4 && dtor==2);     //We've got 3 "S" instances that aren't destroyed yet: the key in aa1, aa2[1], aa2[2].
+    assert(ctor + cpctor - aa2.length - aa1.length == dtor);
 }
 
 /************************************************/

--- a/test/runnable/testaa2.d
+++ b/test/runnable/testaa2.d
@@ -224,6 +224,7 @@ void test3825()
 
 void test3825x()
 {
+    return; // depends on AA implementation
     static int ctor, cpctor, dtor;
 
     static struct S
@@ -233,25 +234,25 @@ void test3825x()
         ~this()    { ++dtor; }
     }
 
+    int[S] aa;
     {
         auto value = S(1);
         assert(ctor==1 && cpctor==0 && dtor==0);
 
         ref getRef(ref S s = value) { return s; }
         auto getVal() { return value; }
-        int[S] aa;
 
         aa[value] = 10;
-        assert(ctor==1 && cpctor==0 && dtor==0);
+        assert(ctor==1 && cpctor==1 && dtor==0);
 
         aa[getRef()] += 1;
-        assert(ctor==1 && cpctor==0 && dtor==0);
+        assert(ctor==1 && cpctor==1 && dtor==0);
 
         aa[getVal()] += 1;
-        assert(ctor==1 && cpctor==1 && dtor==1);
+        assert(ctor==1 && cpctor==2 && dtor==1);
     }
-    assert(ctor==1 && cpctor==1 && dtor==2);
-    assert(ctor + cpctor == dtor);
+    assert(ctor==1 && cpctor==2 && dtor==2);
+    assert(ctor + cpctor - aa.length == dtor);
 }
 
 /************************************************/


### PR DESCRIPTION
This PR harmonize tests for the new AA implementation with the old implementation. It is part of #3904
Diff is not very large.

~~`test/runnable/imports/link12144a.d`: New AA implemetation requires `bool opEquals(...) const` for key equality check. It is logical, AA shouldn't allow to change the key during AA work, thus AA should require const `opEquals` and `toHash`.~~

`test/runnable/sdtor.d`: This test is bit strange. I think, test shouldn't assert that compiler must skip postblit calls in some cases. Tests should declare cases when postblit must be called. Anywhere, template AA implemetation can't skip postblit calls for r-value args. See the [Issue 13492](https://issues.dlang.org/show_bug.cgi?id=13492).
In new AA implementation removed `Test9386.sop` == `"aaaaaaaabbbbbbbbcccccccc"`

`test/runnable/testaa.d` and `test/runnable/testaa2.d`:
This tests approves the wrong AA behaviour: postblit isn't called, when new key adding to AA.

```
struct Test
{
    int* p;
    this(int a)
    {
        p = new int;
        *p = a;
    }

    this(this)
    {
        int a = *p;
        p = new int;
        *p = a;
    }

    ~this()
    {
        *p = -1;
    }

    size_t toHash() const
    {
        return *p;
    }

    bool opEquals(const ref Test t) const
    {
        return *t.p == *p;
    }

    string toString() const
    {
        return to!string(*p);
    }
}

void main()
{
    int[Test] aa;
    {
        auto key = Test(42);
        aa[key] = 1;
        writeln(aa); //prints [42:1] as expected
    }
    writeln(aa); //prints [-1:1] because key is already destroyed
}
```

This tests is disabled now, because old AA implementation doesn't pass them, but new AA impementation does it.
