### PR TITLE
emit a warning about missing opEquals for AA keys...

### DIFF
--- a/src/errors.c
+++ b/src/errors.c
@@ -148,6 +148,14 @@ void errorSupplemental(Loc loc, const char *format, ...)
     va_end( ap );
 }
 
+void warningSupplemental(Loc loc, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vwarningSupplemental(loc, format, ap);
+    va_end( ap );
+}
+
 void deprecation(Loc loc, const char *format, ...)
 {
     va_list ap;
@@ -220,6 +228,12 @@ void vwarning(Loc loc, const char *format, va_list ap)
         if (global.params.warnings == 1)
             global.warnings++;  // warnings don't count if gagged
     }
+}
+
+void vwarningSupplemental(Loc loc, const char *format, va_list ap)
+{
+    if (global.params.warnings && !global.gag)
+        verrorPrint(loc, COLOR_YELLOW, "         ", format, ap);
 }
 
 void vdeprecation(Loc loc, const char *format, va_list ap,

--- a/src/errors.h
+++ b/src/errors.h
@@ -21,12 +21,14 @@
 bool isConsoleColorSupported();
 
 void warning(Loc loc, const char *format, ...);
+void warningSupplemental(Loc loc, const char *format, ...);
 void deprecation(Loc loc, const char *format, ...);
 void error(Loc loc, const char *format, ...);
 void errorSupplemental(Loc loc, const char *format, ...);
 void verror(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
 void vwarning(Loc loc, const char *format, va_list);
 void verrorSupplemental(Loc loc, const char *format, va_list ap);
+void vwarningSupplemental(Loc loc, const char *format, va_list);
 void vdeprecation(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4582,6 +4582,29 @@ printf("index->ito->ito = x%x\n", index->ito->ito);
             //   AA assumes that its result is consistent with bitwise equality.
             // else:
             //   bitwise equality & hashing
+
+        #if 1
+            /* Note that this diagnostic error report should be removed in near future.
+             * See also bugzilla 13074.
+             */
+
+            // duplicate a part of StructDeclaration::semanticTypeInfoMembers
+            if (sd->xcmp &&
+                sd->xcmp->scope &&
+                sd->xcmp->semanticRun < PASSsemantic3done)
+            {
+                unsigned errors = global.startGagging();
+                sd->xcmp->semantic3(sd->xcmp->scope);
+                if (global.endGagging(errors))
+                    sd->xcmp = sd->xerrcmp;
+            }
+            if (sd->xcmp && sd->xcmp != sd->xerrcmp)
+            {
+                error(loc, "%sAA key type %s now requires equality rather than comparison",
+                    s, sd->toChars());
+                errorSupplemental(loc, "Please define opEquals, or remove opCmp to also rely on default memberwise comparison.");
+            }
+        #endif
         }
         else if (sd->xeq == sd->xerreq)
         {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4600,9 +4600,9 @@ printf("index->ito->ito = x%x\n", index->ito->ito);
             }
             if (sd->xcmp && sd->xcmp != sd->xerrcmp)
             {
-                error(loc, "%sAA key type %s now requires equality rather than comparison",
+                warning(loc, "%sAA key type %s now requires equality rather than comparison",
                     s, sd->toChars());
-                errorSupplemental(loc, "Please define opEquals, or remove opCmp to also rely on default memberwise comparison.");
+                warningSupplemental(loc, "Please define opEquals, or remove opCmp to also rely on default memberwise comparison.");
             }
         #endif
         }
@@ -4672,9 +4672,9 @@ printf("index->ito->ito = x%x\n", index->ito->ito);
             if (fcmp->vtblIndex < cd->vtbl.dim && cd->vtbl[fcmp->vtblIndex] != fcmp)
             {
                 const char *s = (index->toBasetype()->ty != Tclass) ? "bottom of " : "";
-                error(loc, "%sAA key type %s now requires equality rather than comparison",
+                warning(loc, "%sAA key type %s now requires equality rather than comparison",
                     s, cd->toChars());
-                errorSupplemental(loc, "Please override Object.opEquals and toHash.");
+                warningSupplemental(loc, "Please override Object.opEquals and toHash.");
             }
         #endif
         }

--- a/test/compilable/test12593.d
+++ b/test/compilable/test12593.d
@@ -4,8 +4,8 @@ struct R
 {
     int opCmp(ref const R) const { return 0; }
 
-    //bool opEquals(ref const R) const { return true; }
-    //size_t toHash() const nothrow @safe { return 0; }
+    bool opEquals(ref const R) const { return true; }
+    size_t toHash() const nothrow @safe { return 0; }
 }
 
 void main()

--- a/test/fail_compilation/diag13074.d
+++ b/test/fail_compilation/diag13074.d
@@ -1,0 +1,75 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag13074.d(29): Error: AA key type S now requires equality rather than comparison
+fail_compilation/diag13074.d(29):        Please define opEquals, or remove opCmp to also rely on default memberwise comparison.
+---
+*/
+struct S
+{
+    int x;
+    int y;
+
+    int opCmp(ref const S other) const
+    {
+        return x < other.x ? -1 : x > other.x ? 1 : 0;
+    }
+    hash_t toHash() const
+    {
+        return x;
+    }
+}
+
+void main()
+{
+    S s1 = S(1, 1);
+    S s2 = S(1, 2);
+    S s3 = S(2, 1);
+    S s4 = S(2, 2);
+    bool[S] arr;
+    arr[s1] = true;
+    arr[s2] = true;
+    arr[s3] = true;
+    arr[s4] = true;
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag13074.d(70): Error: AA key type C now requires equality rather than comparison
+fail_compilation/diag13074.d(70):        Please override Object.opEquals and toHash.
+---
+*/
+class C
+{
+    int x;
+    int y;
+    this(int x, int y)
+    {
+        this.x = x; this.y = y;
+    }
+
+    override int opCmp(Object other)
+    {
+        if (auto o = cast(C)other)
+            return x < o.x ? -1 : x > o.x ? 1 : 0;
+        return -1;
+    }
+    override hash_t toHash() const
+    {
+        return x;
+    }
+}
+
+void test13114()
+{
+    const c1 = new C(1,1);
+    const c2 = new C(1,2);
+    const c3 = new C(2,1);
+    const c4 = new C(2,2);
+    bool[const(C)] arr;
+    arr[c1] = true;
+    arr[c2] = true;
+    arr[c3] = true;
+    arr[c4] = true;
+}

--- a/test/fail_compilation/diag13074.d
+++ b/test/fail_compilation/diag13074.d
@@ -1,8 +1,9 @@
 /*
+REQUIRED_ARGS: -w
 TEST_OUTPUT:
 ---
-fail_compilation/diag13074.d(29): Error: AA key type S now requires equality rather than comparison
-fail_compilation/diag13074.d(29):        Please define opEquals, or remove opCmp to also rely on default memberwise comparison.
+fail_compilation/diag13074.d(30): Warning: AA key type S now requires equality rather than comparison
+fail_compilation/diag13074.d(30):          Please define opEquals, or remove opCmp to also rely on default memberwise comparison.
 ---
 */
 struct S
@@ -36,8 +37,8 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag13074.d(70): Error: AA key type C now requires equality rather than comparison
-fail_compilation/diag13074.d(70):        Please override Object.opEquals and toHash.
+fail_compilation/diag13074.d(71): Warning: AA key type C now requires equality rather than comparison
+fail_compilation/diag13074.d(71):          Please override Object.opEquals and toHash.
 ---
 */
 class C


### PR DESCRIPTION
...when a user defined opCmp exists
