### PR TITLE
Issue 12004 and issue 13174: Disallow shared destructors and always call the unshared one.

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -4589,7 +4589,7 @@ void DtorDeclaration::semantic(Scope *sc)
         type = new TypeFunction(NULL, Type::tvoid, false, LINKd, storage_class);
 
     sc = sc->push();
-    sc->stc &= ~STCstatic;              // not a static destructor
+    sc->stc &= ~(STCstatic|STCshared);  // not a static or shared destructor
     sc->linkage = LINKd;
 
     FuncDeclaration::semantic(sc);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1575,6 +1575,8 @@ Dsymbol *Parser::parseDtor(PrefixAttributes *pAttrs)
             ::error(loc, "use 'static ~this()' to declare a static destructor");
         else if (ss == (STCshared | STCstatic))
             ::error(loc, "use 'shared static ~this()' to declare a shared static destructor");
+        else if (ss == STCshared)
+            ::error(loc, "destructors cannot be shared");
     }
 
     DtorDeclaration *f = new DtorDeclaration(loc, Loc(), stc, Id::dtor);

--- a/test/compilable/test12004.d
+++ b/test/compilable/test12004.d
@@ -1,0 +1,32 @@
+// PERMUTE_ARGS:
+
+// Tests calling unshared dtors from shared objects.
+// See issues 12004 and 13174.
+
+struct B
+{
+    ~this() {}
+}
+
+struct C
+{
+    shared B b;
+}
+
+class D
+{
+    ~this() {}
+}
+
+class E
+{
+    shared D d;
+
+    this(shared D d) { this.d = d; }
+}
+
+void test12004()
+{
+    C(shared(B)());
+    new E(new shared(D)()); 
+}

--- a/test/fail_compilation/fail12004.d
+++ b/test/fail_compilation/fail12004.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12004.d(9): Error: destructors cannot be shared
+---
+*/
+
+struct S {
+    ~this() shared {}
+}


### PR DESCRIPTION
When using shared structs, the compiler asks for a shared ~this() which should not exist in the language at all. The destructor for these value types must be run when all threads that could reference it have finished and only the owner thread is left. It is a logical error to have a destructor run in a "shared" environment.

https://issues.dlang.org/show_bug.cgi?id=12004
https://issues.dlang.org/show_bug.cgi?id=13174

It's only 6 lines of changes, but the indentation level change in src/template.c makes it look wild. What it says is basically:

``` D
if (fd->isDtorDeclaration() && tthis_fd->isShared())
{
    tthis_fd = tthis_fd->unSharedOf();
}
```

Since I hit the bug once again and there was now someone else struggling with it and `shared` needs some love, I decided to peek into the dmd code and make some quick adjustments. There is one thing I'm not sure about: Is calling an unshared dtor with a `shared this` kosher? It all works as expected, and I ran the test suite and unittests, so I'm quite confident it didn't cause major shockwaves inside the compiler.
