### PR TITLE
Fix Issue 10311 - GDB prints wrong value for variable updated from closure

### DIFF
--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -133,7 +133,7 @@ void symbol_print(symbol *s)
 #endif
     dbg_printf(" Sl      = %p",s->Sl);
     dbg_printf(" Sr      = %p\n",s->Sr);
-#if SCPP
+#if SCPP || MARS
     if (s->Sscope)
         dbg_printf(" Sscope = '%s'\n",s->Sscope->Sident);
 #endif


### PR DESCRIPTION
Redone https://github.com/D-Programming-Language/dmd/pull/4063, now using struct type for closure and Sscope for pointer.
