### PR TITLE
Fix-up type inference for function literals whose returns have been modified

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -4371,6 +4371,12 @@ void FuncLiteralDeclaration::modifyReturns(Scope *sc, Type *tret)
     w.tret = tret;
     w.fld = this;
     fbody->accept(&w);
+
+    // Also update the inferred function type to match the new return type.
+    // This is required so the code generator does not try to cast the
+    // modified returns back to the original type.
+    if (inferRetType && type->nextOf() != tret)
+        ((TypeFunction *)type)->next = tret;
 }
 
 const char *FuncLiteralDeclaration::kind()


### PR DESCRIPTION
@9rnsr - can you check this.  I can't think of a better place to put it.

What's happening is this:

```
void foo(I delegate(C) dg)
{
    C c = new C;
    void *ptr = dg(c);
}

foo(c => c);
```

1) Our lambda `c => c` is delegatized as:

```
auto __lambda(C c)
{
  return c;
}
```

2) `FuncDeclaration::semantic3` infers the return type as C

```
C __lambda(C c)
{
  return c;
}
```

3) `FuncLiteralDeclaration::modifyReturns` changes the return type.

```
C __lambda(C c)
{
  return cast(I) c;
}
```

4) When we reach the code generator, it (gdc) spots the mismatch between the returning type `I` and the function type `C` and implicitly casts it back (in this case, a call to _d_dynamic_cast).

```
C __lambda(C c)
{
  return cast(C)(cast(I) c);
}
```

This change fixes up the function type to match the modified return, evading this trap.

```
I __lambda(C c)
{
  return cast(I) c;
}
```
