### PR TITLE
faster string table

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2821,7 +2821,7 @@ int Token::isKeyword()
 
 void Lexer::initKeywords()
 {
-    stringtable._init(6151);
+    stringtable._init(28000);
 
     cmtable_init();
 

--- a/src/libelf.c
+++ b/src/libelf.c
@@ -78,7 +78,7 @@ Library *LibElf_factory()
 LibElf::LibElf()
 {
     libfile = NULL;
-    tab._init();
+    tab._init(14000);
 }
 
 /***********************************

--- a/src/libmach.c
+++ b/src/libmach.c
@@ -88,7 +88,7 @@ Library *LibMach_factory()
 LibMach::LibMach()
 {
     libfile = NULL;
-    tab._init();
+    tab._init(14000);
 }
 
 /***********************************

--- a/src/libmscoff.c
+++ b/src/libmscoff.c
@@ -104,7 +104,7 @@ Library *LibMSCoff_factory()
 LibMSCoff::LibMSCoff()
 {
     libfile = NULL;
-    tab._init();
+    tab._init(14000);
 }
 
 /***********************************
@@ -867,4 +867,3 @@ void LibMSCoff::WriteLibToBuffer(OutBuffer *libbuf)
 #endif
     assert(libbuf->offset == moffset);
 }
-

--- a/src/libomf.c
+++ b/src/libomf.c
@@ -88,7 +88,7 @@ Library *LibOMF_factory()
 LibOMF::LibOMF()
 {
     libfile = NULL;
-    tab._init();
+    tab._init(14000);
 }
 
 /***********************************

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -193,7 +193,7 @@ char Type::needThisPrefix()
 
 void Type::init()
 {
-    stringtable._init(1543);
+    stringtable._init(14000);
     Lexer::initKeywords();
 
     for (size_t i = 0; i < TMAX; i++)

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -119,7 +119,7 @@ void StringTable::_init(size_t size)
 
 StringTable::~StringTable()
 {
-    for (size_t i = 0; i < count; i++)
+    for (size_t i = 0; i < tabledim; i++)
         if (table[i].value)
             mem.free(table[i].value);
 

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -131,11 +131,14 @@ StringTable::~StringTable()
 
 size_t StringTable::findSlot(hash_t hash, const char *s, size_t length)
 {
-    size_t i = hash & (tabledim - 1);
-    // linear probing
-    while (table[i].value && !(table[i].equals(hash, s, length)))
-        i = (i + 1) & (tabledim - 1);
-    return i;
+    // quadratic probing using triangular numbers
+    // http://stackoverflow.com/questions/2348187/moving-from-linear-probing-to-quadratic-probing-hash-collisons/2349774#2349774
+    for (size_t i = hash & (tabledim - 1), j = 1; ;++j)
+    {
+        if (!table[i].value || (table[i].equals(hash, s, length)))
+            return i;
+        i = (i + j) & (tabledim - 1);
+    }
 }
 
 StringValue *StringTable::lookup(const char *s, size_t length)

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -40,19 +40,18 @@ public:
 private:
     friend struct StringEntry;
     StringValue();  // not constructible
-    // This is more like a placement new c'tor
-    void ctor(const char *p, size_t length);
+    static StringValue *alloc(const char *p, size_t length);
 };
 
 struct StringTable
 {
 private:
-    void **table;
-    size_t count;
+    StringEntry *table;
     size_t tabledim;
+    size_t count;
 
 public:
-    void _init(size_t size = 37);
+    void _init(size_t size = 0);
     ~StringTable();
 
     StringValue *lookup(const char *s, size_t len);
@@ -60,7 +59,8 @@ public:
     StringValue *update(const char *s, size_t len);
 
 private:
-    void **search(const char *s, size_t len);
+    size_t findSlot(hash_t hash, const char *s, size_t len);
+    void grow();
 };
 
 #endif

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -38,7 +38,6 @@ public:
     const char *toDchars() const { return lstring; }
 
 private:
-    friend struct StringEntry;
     friend struct StringTable;
     StringValue();  // not constructible
 };

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -39,8 +39,8 @@ public:
 
 private:
     friend struct StringEntry;
+    friend struct StringTable;
     StringValue();  // not constructible
-    static StringValue *alloc(const char *p, size_t length);
 };
 
 struct StringTable
@@ -48,6 +48,10 @@ struct StringTable
 private:
     StringEntry *table;
     size_t tabledim;
+
+    uint8_t **pools;
+    size_t npools, nfill;
+
     size_t count;
 
 public:
@@ -59,6 +63,8 @@ public:
     StringValue *update(const char *s, size_t len);
 
 private:
+    uint32_t allocValue(const char *p, size_t length);
+    StringValue *getValue(uint32_t validx);
     size_t findSlot(hash_t hash, const char *s, size_t len);
     void grow();
 };

--- a/src/traits.c
+++ b/src/traits.c
@@ -253,20 +253,19 @@ const char* traits[] = {
     "getAttributes",
     "getFunctionAttributes",
     "getUnitTests",
-    "getVirtualIndex",
-    NULL
+    "getVirtualIndex"
 };
 
 StringTable traitsStringTable;
 
 void initTraitsStringTable()
 {
-    traitsStringTable._init();
+    const size_t ntraits = sizeof(traits) / sizeof(traits[0]);
+    traitsStringTable._init(ntraits);
 
-    for (size_t idx = 0; ; idx++)
+    for (size_t idx = 0; idx < ntraits; idx++)
     {
         const char *s = traits[idx];
-        if (!s) break;
         StringValue *sv = traitsStringTable.insert(s, strlen(s));
         sv->ptrvalue = (void *)traits[idx];
     }


### PR DESCRIPTION
- use a hash table with open addressing and [quadratic probing](http://en.wikipedia.org/wiki/Quadratic_probing) (triangular numbers) 
- adapt initial capacity (to phobos)
- better hash function (MurmurHash2)
- StringValue pool allocator for locality and 4-byte indices

This StringTable is much faster, but even though `StringTable::search` was high up the profile a change from `1.6%` to `0.8%` accumulated CPU usage will go unnoticed for dmd users.
