### PR TITLE
skip some redundant symbol resets

### DIFF
--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -2330,6 +2330,8 @@ void slist_reset()
     for (size_t i = 0; i < slist_length; ++i)
     {
         Symbol *s = slist[i];
+        // symbol wasn't used since last reset
+        if (!s->Sxtrnnum) continue;
 
 #if MACHOBJ
         s->Soffset = 0;


### PR DESCRIPTION
- saves 4-5% compilation time for libphobos2.a
