### PR TITLE
remove std.math import

### DIFF
--- a/test/runnable/testappend.d
+++ b/test/runnable/testappend.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
 
 import core.stdc.stdio;
-import std.math;
+import core.stdc.math : isnan;
 
 void test12826()
 {


### PR DESCRIPTION
Reason: insnan is going to be deprecated in std.math.
