### PR TITLE
Export pure, safe and property to json

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -586,15 +586,7 @@ void FuncDeclaration::semantic(Scope *sc)
         tfo->purity     = tfx->purity;
         tfo->trust      = tfx->trust;
 
-        if (tfo->purity == PUREfwdref) {
-            storage_class |= STCpure;
-        }
-        if (tfo->trust == TRUSTsafe) {
-            storage_class |= STCsafe;
-        }
-        if (tfo->isproperty) {
-            storage_class |= STCproperty;
-        }
+        storage_class &= ~(STC_TYPECTOR | STC_FUNCATTR);
     }
 
     f = (TypeFunction *)type;

--- a/src/func.c
+++ b/src/func.c
@@ -586,7 +586,15 @@ void FuncDeclaration::semantic(Scope *sc)
         tfo->purity     = tfx->purity;
         tfo->trust      = tfx->trust;
 
-        storage_class &= ~(STC_TYPECTOR | STC_FUNCATTR);
+        if (tfo->purity == PUREfwdref) {
+            storage_class |= STCpure;
+        }
+        if (tfo->trust == TRUSTsafe) {
+            storage_class |= STCsafe;
+        }
+        if (tfo->isproperty) {
+            storage_class |= STCproperty;
+        }
     }
 
     f = (TypeFunction *)type;

--- a/src/json.c
+++ b/src/json.c
@@ -471,16 +471,16 @@ public:
         StorageClass stc = d->storage_class;
 
         if (d->originalType && d->originalType->ty == Tfunction) {
-          TypeFunction *tfo = (TypeFunction *)d->originalType;
-          if (tfo->purity == PUREfwdref) {
-            stc |= STCpure;
-          }
-          if (tfo->trust == TRUSTsafe) {
-            stc |= STCsafe;
-          }
-          if (tfo->isproperty) {
-            stc |= STCproperty;
-          }
+            TypeFunction *tfo = (TypeFunction *)d->originalType;
+            if (tfo->purity == PUREfwdref) {
+                stc |= STCpure;
+            }
+            if (tfo->trust == TRUSTsafe) {
+                stc |= STCsafe;
+            }
+            if (tfo->isproperty) {
+                stc |= STCproperty;
+            }
         }
 
         propertyStorageClass("storageClass", stc);

--- a/src/json.c
+++ b/src/json.c
@@ -468,7 +468,22 @@ public:
     {
         jsonProperties((Dsymbol *)d);
 
-        propertyStorageClass("storageClass", d->storage_class);
+        StorageClass stc = d->storage_class;
+
+        if (d->originalType && d->originalType->ty == Tfunction) {
+          TypeFunction *tfo = (TypeFunction *)d->originalType;
+          if (tfo->purity == PUREfwdref) {
+            stc |= STCpure;
+          }
+          if (tfo->trust == TRUSTsafe) {
+            stc |= STCsafe;
+          }
+          if (tfo->isproperty) {
+            stc |= STCproperty;
+          }
+        }
+
+        propertyStorageClass("storageClass", stc);
 
         property("type", "deco", d->type);
 

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -338,6 +338,9 @@
     "kind" : "function",
     "line" : 57,
     "char" : 15,
+    "storageClass" : [
+     "@property"
+    ],
     "deco" : "FNbNdZi",
     "endline" : 74,
     "endchar" : 1

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -319,7 +319,7 @@
       "name" : "foo1",
       "kind" : "function",
       "line" : 51,
-      "char" : 21,
+      "char" : 25,
       "storageClass" : [
        "pure",
        "@property",
@@ -327,33 +327,33 @@
       ],
       "deco" : "FNaNdNfZl",
       "endline" : 51,
-      "endchar" : 40
+      "endchar" : 44
      },
      {
       "name" : "foo2",
       "kind" : "function",
       "line" : 52,
-      "char" : 16,
+      "char" : 20,
       "storageClass" : [
        "@property",
        "@safe"
       ],
       "deco" : "FNdNfZl",
       "endline" : 52,
-      "endchar" : 35
+      "endchar" : 39
      },
      {
       "name" : "foo2",
       "kind" : "function",
       "line" : 53,
-      "char" : 15,
+      "char" : 19,
       "storageClass" : [
        "pure",
        "@property"
       ],
       "deco" : "FNaNdZl",
       "endline" : 53,
-      "endchar" : 34
+      "endchar" : 38
      }
     ]
    },

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -310,9 +310,57 @@
     ]
    },
    {
+    "name" : "Foo3",
+    "kind" : "struct",
+    "line" : 49,
+    "char" : 1,
+    "members" : [
+     {
+      "name" : "foo1",
+      "kind" : "function",
+      "line" : 51,
+      "char" : 21,
+      "storageClass" : [
+       "pure",
+       "@property",
+       "@safe"
+      ],
+      "deco" : "FNaNdNfZl",
+      "endline" : 51,
+      "endchar" : 40
+     },
+     {
+      "name" : "foo2",
+      "kind" : "function",
+      "line" : 52,
+      "char" : 16,
+      "storageClass" : [
+       "@property",
+       "@safe"
+      ],
+      "deco" : "FNdNfZl",
+      "endline" : 52,
+      "endchar" : 35
+     },
+     {
+      "name" : "foo2",
+      "kind" : "function",
+      "line" : 53,
+      "char" : 15,
+      "storageClass" : [
+       "pure",
+       "@property"
+      ],
+      "deco" : "FNaNdZl",
+      "endline" : 53,
+      "endchar" : 34
+     }
+    ]
+   },
+   {
     "name" : "bar",
     "kind" : "function",
-    "line" : 52,
+    "line" : 60,
     "char" : 16,
     "deco" : "FNeKkC4json4Bar2Zi",
     "originalType" : "@trusted myInt(ref uint blah, Bar2 foo = new Bar3(7))",
@@ -330,25 +378,26 @@
       "default" : "cast(Bar2)new Bar3(7)"
      }
     ],
-    "endline" : 55,
+    "endline" : 63,
     "endchar" : 1
    },
    {
     "name" : "outer",
     "kind" : "function",
-    "line" : 57,
-    "char" : 15,
+    "line" : 65,
+    "char" : 21,
     "storageClass" : [
-     "@property"
+     "@property",
+     "@safe"
     ],
-    "deco" : "FNbNdZi",
-    "endline" : 74,
+    "deco" : "FNbNdNfZi",
+    "endline" : 82,
     "endchar" : 1
    },
    {
     "name" : "imports.jsonimport1",
     "kind" : "import",
-    "line" : 77,
+    "line" : 85,
     "char" : 8,
     "protection" : "private",
     "selective" : [
@@ -359,7 +408,7 @@
    {
     "name" : "imports.jsonimport2",
     "kind" : "import",
-    "line" : 78,
+    "line" : 86,
     "char" : 8,
     "protection" : "private",
     "renamed" : {
@@ -370,7 +419,7 @@
    {
     "name" : "imports.jsonimport3",
     "kind" : "import",
-    "line" : 79,
+    "line" : 87,
     "char" : 8,
     "protection" : "private",
     "renamed" : {
@@ -384,19 +433,19 @@
    {
     "name" : "imports.jsonimport4",
     "kind" : "import",
-    "line" : 80,
+    "line" : 88,
     "char" : 8,
     "protection" : "private"
    },
    {
     "name" : "S",
     "kind" : "struct",
-    "line" : 82,
+    "line" : 90,
     "char" : 1,
     "members" : [
      {
       "kind" : "template",
-      "line" : 85,
+      "line" : 93,
       "char" : 5,
       "name" : "this",
       "parameters" : [
@@ -409,7 +458,7 @@
        {
         "name" : "this",
         "kind" : "constructor",
-        "line" : 85,
+        "line" : 93,
         "char" : 5,
         "type" : "(T t)",
         "parameters" : [
@@ -418,7 +467,7 @@
           "type" : "T"
          }
         ],
-        "endline" : 85,
+        "endline" : 93,
         "endchar" : 20
        }
       ]
@@ -428,7 +477,7 @@
    {
     "kind" : "template",
     "protection" : "private",
-    "line" : 89,
+    "line" : 97,
     "char" : 9,
     "name" : "S1_9755",
     "parameters" : [
@@ -441,7 +490,7 @@
      {
       "name" : "S1_9755",
       "kind" : "struct",
-      "line" : 89,
+      "line" : 97,
       "char" : 9,
       "members" : []
      }
@@ -450,7 +499,7 @@
    {
     "kind" : "template",
     "protection" : "package",
-    "line" : 90,
+    "line" : 98,
     "char" : 9,
     "name" : "S2_9755",
     "parameters" : [
@@ -463,7 +512,7 @@
      {
       "name" : "S2_9755",
       "kind" : "struct",
-      "line" : 90,
+      "line" : 98,
       "char" : 9,
       "members" : []
      }
@@ -472,13 +521,13 @@
    {
     "name" : "C_9755",
     "kind" : "class",
-    "line" : 92,
+    "line" : 100,
     "char" : 1,
     "members" : [
      {
       "kind" : "template",
       "protection" : "protected",
-      "line" : 94,
+      "line" : 102,
       "char" : 22,
       "name" : "CI_9755",
       "parameters" : [
@@ -491,7 +540,7 @@
        {
         "name" : "CI_9755",
         "kind" : "class",
-        "line" : 94,
+        "line" : 102,
         "char" : 22,
         "members" : []
        }
@@ -502,7 +551,7 @@
    {
     "name" : "c_10011",
     "kind" : "variable",
-    "line" : 98,
+    "line" : 106,
     "char" : 14,
     "storageClass" : [
      "const"
@@ -514,7 +563,7 @@
    {
     "name" : "Numbers",
     "kind" : "enum",
-    "line" : 101,
+    "line" : 109,
     "char" : 1,
     "baseDeco" : "i",
     "members" : [
@@ -522,49 +571,49 @@
       "name" : "unspecified1",
       "kind" : "enum member",
       "value" : "0",
-      "line" : 103,
+      "line" : 111,
       "char" : 5
      },
      {
       "name" : "one",
       "kind" : "enum member",
       "value" : "2",
-      "line" : 104,
+      "line" : 112,
       "char" : 5
      },
      {
       "name" : "two",
       "kind" : "enum member",
       "value" : "3",
-      "line" : 105,
+      "line" : 113,
       "char" : 5
      },
      {
       "name" : "FILE_NOT_FOUND",
       "kind" : "enum member",
       "value" : "101",
-      "line" : 106,
+      "line" : 114,
       "char" : 5
      },
      {
       "name" : "unspecified3",
       "kind" : "enum member",
       "value" : "102",
-      "line" : 107,
+      "line" : 115,
       "char" : 5
      },
      {
       "name" : "unspecified4",
       "kind" : "enum member",
       "value" : "103",
-      "line" : 108,
+      "line" : 116,
       "char" : 5
      },
      {
       "name" : "four",
       "kind" : "enum member",
       "value" : "4",
-      "line" : 109,
+      "line" : 117,
       "char" : 5
      }
     ]

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -47,11 +47,11 @@ struct Foo2 {
 }
 
 struct Foo3 {
-  @property {
-    @safe pure long foo1() { return 0; }
-    @safe long foo2() { return 0; }
-    pure long foo2() { return 0; }
-  };
+    @property {
+        @safe pure long foo1() { return 0; }
+        @safe long foo2() { return 0; }
+        pure long foo2() { return 0; }
+    };
 };
 
 /++

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -46,6 +46,14 @@ struct Foo2 {
 	}
 }
 
+struct Foo3 {
+  @property {
+    @safe pure long foo1() { return 0; }
+    @safe long foo2() { return 0; }
+    pure long foo2() { return 0; }
+  };
+};
+
 /++
  + Documentation test
  +/
@@ -54,7 +62,7 @@ struct Foo2 {
 	return -1;
 }
 
-@property int outer() nothrow
+@property @safe int outer() nothrow
 in {
 	assert(true);
 }


### PR DESCRIPTION
This information was previously exported,  before recent changes to `func.c`. I rely on it so it'd be nice to have it back, was it removed on purpose?

I'm not familiar with the codebase, but the tests I ran still pass after the change. Note that I'm only setting the flags which are ostensibly missing for my use-case, there might be other interesting ones I haven't noticed.
