### PR TITLE
Add predefined version identifiers for ELFv1 and ELFv2.

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -213,6 +213,8 @@ bool VersionCondition::isPredefined(const char *ident)
         "Alpha_HardFloat",
         "LittleEndian",
         "BigEndian",
+        "ELFv1",
+        "ELFv2",
         "D_Coverage",
         "D_Ddoc",
         "D_InlineAsm_X86",

--- a/src/mars.c
+++ b/src/mars.c
@@ -444,10 +444,12 @@ int tryMain(size_t argc, const char *argv[])
 #elif TARGET_LINUX
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("linux");
+    VersionCondition::addPredefinedGlobalIdent("ELFv1");
     global.params.isLinux = true;
 #elif TARGET_OSX
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("OSX");
+    VersionCondition::addPredefinedGlobalIdent("ELFv1");
     global.params.isOSX = true;
 
     // For legacy compatibility
@@ -455,14 +457,17 @@ int tryMain(size_t argc, const char *argv[])
 #elif TARGET_FREEBSD
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("FreeBSD");
+    VersionCondition::addPredefinedGlobalIdent("ELFv1");
     global.params.isFreeBSD = true;
 #elif TARGET_OPENBSD
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("OpenBSD");
+    VersionCondition::addPredefinedGlobalIdent("ELFv1");
     global.params.isFreeBSD = true;
 #elif TARGET_SOLARIS
     VersionCondition::addPredefinedGlobalIdent("Posix");
     VersionCondition::addPredefinedGlobalIdent("Solaris");
+    VersionCondition::addPredefinedGlobalIdent("ELFv1");
     global.params.isSolaris = true;
 #else
 #error "fix this"


### PR DESCRIPTION
For PPC64 LittleEndian a new ELF version was defined. While the common usage is ELFv1 with big endian and ELFv2 with little endian, the other uses are also possible.
In fact gcc defines a command line switch `--with-abi=elfv1` /`--with-abi=elfv2` to choose the ELF ABI.
The new predefined version identifiers ELFv1 / ELFv2 reflect that this information cannot be determined elsewhere.
See http://llvm.org/devmtg/2014-04/PDFs/Talks/Euro-LLVM-2014-Weigand.pdf for more information on ELFv2.
