### PR TITLE
CTFE cannot handle member allocators

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3007,6 +3007,13 @@ public:
         printf("%s NewExp::interpret() %s\n", e->loc.toChars(), e->toChars());
     #endif
 
+        if (e->allocator)
+        {
+            e->error("member allocators not supported by CTFE");
+            result = EXP_CANT_INTERPRET;
+            return;
+        }
+
         if (e->argprefix)
         {
             result = e->argprefix->interpret(istate, ctfeNeedNothing);

--- a/test/fail_compilation/failmemalloc.d
+++ b/test/fail_compilation/failmemalloc.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/failmemalloc.d(13): Error: member allocators not supported by CTFE
+---
+*/
+
+struct S
+{
+    new(size_t sz) { return null; }
+}
+
+S* s = new S();


### PR DESCRIPTION
CTFE never could handle this, but this fixes its silent failure.
