### PR TITLE
Fix issue 13666: Undefined Symbols for __gshared data symbols in templates

### DIFF
--- a/src/scanmach.c
+++ b/src/scanmach.c
@@ -177,6 +177,8 @@ void scanMachObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, in
                     switch (s->n_type & N_TYPE)
                     {
                         case N_UNDF:
+                            if (s->n_type & N_EXT && s->n_value != 0) // comdef
+                                (*pAddSymbol)(pctx, name, 1);
                             break;
                         case N_ABS:
                             break;
@@ -220,6 +222,8 @@ void scanMachObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, in
                     switch (s->n_type & N_TYPE)
                     {
                         case N_UNDF:
+                            if (s->n_type & N_EXT && s->n_value != 0) // comdef
+                                (*pAddSymbol)(pctx, name, 1);
                             break;
                         case N_ABS:
                             break;

--- a/test/runnable/extra-files/lib13666.d
+++ b/test/runnable/extra-files/lib13666.d
@@ -1,0 +1,11 @@
+module lib13666;
+
+template drt_envvars()
+{
+    extern(C) __gshared bool enabled = false;
+}
+
+bool foo()
+{
+	return drt_envvars!().enabled;
+}

--- a/test/runnable/extra-files/test13666.d
+++ b/test/runnable/extra-files/test13666.d
@@ -1,0 +1,6 @@
+import lib13666;
+
+int main()
+{
+	return foo();
+}

--- a/test/runnable/test13666.sh
+++ b/test/runnable/test13666.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/test13666.sh.out
+
+if [ $OS == "win32" -o  $OS == "win64" ]; then
+	LIBEXT=.lib
+else
+	LIBEXT=.a
+fi
+libname=${dir}${SEP}lib13666${LIBEXT}
+
+$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}lib13666.d || exit 1
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}test13666${EXE} ${src}${SEP}test13666.d ${libname} || exit 1
+
+rm ${dir}/{lib13666${LIBEXT},test13666${OBJ},test13666${EXE}}
+
+echo Success >${output_file}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13666

OMF/MACH: do not ignore COMDEF records when scanning library for symbols
