### PR TITLE
fix Issue 13095 - Sometimes struct  destructor is called if constructor throws

### DIFF
--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -3435,6 +3435,27 @@ void test13586()
 
 /**********************************/
 
+__gshared bool b13095 = false;
+
+void bar13095() { throw new Exception(""); }
+
+struct S13095
+{
+    this(int) { printf("ctor %p\n", &this); bar13095(); }
+
+    ~this() { b13095 = true; printf("dtor %p\n", &this); }
+}
+
+void test13095()
+{
+    try {
+        S13095(0);
+    } catch(Exception) { printf("catch\n"); }
+    assert(!b13095);
+}
+
+/**********************************/
+
 int main()
 {
     test1();
@@ -3539,6 +3560,7 @@ int main()
     test11763();
     test13303();
     test13586();
+    test13095();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
I tried and failed to fix this in the front end. Doing so would entail a rather extensive rewrite of things. The semantic processing shouldn't be this sensitive, but it is.
