### PR TITLE
Issue 10528 - Private constant (enum) properties not private

### DIFF
--- a/src/enum.c
+++ b/src/enum.c
@@ -681,6 +681,7 @@ Expression *EnumMember::getVarExp(Loc loc, Scope *sc)
         vd->parent = ed->isAnonymous() ? ed->parent : ed;
         vd->userAttribDecl = ed->isAnonymous() ? ed->userAttribDecl : NULL;
     }
+    accessCheck(loc, sc, NULL, vd);
     Expression *e = new VarExp(loc, vd);
     return e->semantic(sc);
 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -3122,6 +3122,13 @@ Expression *IdentifierExp::semantic(Scope *sc)
         }
         else
         {
+            if (withsym)
+            {
+                Declaration *d = s->isDeclaration();
+                if (d)
+                    accessCheck(loc, sc, NULL, d);
+            }
+
             /* If f is really a function template,
              * then replace f with the function template declaration.
              */

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7448,6 +7448,7 @@ L1:
     }
     if (v && !v->isDataseg() && (v->storage_class & STCmanifest))
     {
+        accessCheck(e->loc, sc, NULL, v);
         Expression *ve = new VarExp(e->loc, v);
         ve = ve->semantic(sc);
         return ve;
@@ -8095,6 +8096,7 @@ L1:
     }
     if (v && !v->isDataseg() && (v->storage_class & STCmanifest))
     {
+        accessCheck(e->loc, sc, NULL, v);
         Expression *ve = new VarExp(e->loc, v);
         ve = ve->semantic(sc);
         return ve;

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -1,0 +1,30 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10528.d(19): Error: module fail10528 variable a10528.a is private
+fail_compilation/fail10528.d(20): Error: variable a10528.a is not accessible from module fail10528
+fail_compilation/fail10528.d(22): Error: variable a10528.b is not accessible from module fail10528
+fail_compilation/fail10528.d(23): Error: variable a10528.b is not accessible from module fail10528
+fail_compilation/fail10528.d(25): Error: variable a10528.S.c is not accessible from module fail10528
+fail_compilation/fail10528.d(26): Error: variable a10528.S.c is not accessible from module fail10528
+fail_compilation/fail10528.d(28): Error: variable a10528.C.d is not accessible from module fail10528
+fail_compilation/fail10528.d(29): Error: variable a10528.C.d is not accessible from module fail10528
+---
+*/
+
+import imports.a10528;
+
+void main()
+{
+    auto a1 = a;
+    auto a2 = imports.a10528.a;
+
+    auto b1 = b;
+    auto b2 = imports.a10528.b;
+
+    auto c1 = S.c;
+    with (S) auto c2 = c;
+
+    auto d1 = C.d;
+    with (C) auto d2 = d;
+}

--- a/test/fail_compilation/imports/a10528.d
+++ b/test/fail_compilation/imports/a10528.d
@@ -1,0 +1,6 @@
+private enum string a = "asdfgh";
+private enum { b = "asdfgh" }
+
+struct S { private enum string c = "qwerty"; }
+class  C { private enum string d = "qwerty"; }
+


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=10528

Call `accessCheck` in some places.
