### PR TITLE
Issue 4567: display dmd.conf path being used if object.d can't be found

### DIFF
--- a/src/mars.c
+++ b/src/mars.c
@@ -243,6 +243,7 @@ void usage()
         global.version, global.copyright, global.written);
     printf("\
 Documentation: http://dlang.org/\n\
+Config file: %s\n\
 Usage:\n\
   dmd files.d ... { -switch }\n\
 \n\
@@ -310,7 +311,7 @@ Usage:\n\
   -wi            warnings as messages (compilation will continue)\n\
   -X             generate JSON file\n\
   -Xffilename    write JSON file to filename\n\
-", fpic);
+", FileName::canonicalName(global.inifilename), fpic);
 }
 
 extern signed char tyalignsize[];

--- a/src/mars.c
+++ b/src/mars.c
@@ -80,6 +80,7 @@ Global global;
 
 void Global::init()
 {
+    inifilename = NULL;
     mars_ext = "d";
     hdr_ext  = "di";
     doc_ext  = "html";
@@ -374,7 +375,6 @@ int tryMain(size_t argc, const char *argv[])
 #if TARGET_WINDOS
     bool setdefaultlib = false;
 #endif
-    const char *inifilename = NULL;
     global.init();
 
 #ifdef DEBUG
@@ -479,9 +479,9 @@ int tryMain(size_t argc, const char *argv[])
     VersionCondition::addPredefinedGlobalIdent("all");
 
 #if _WIN32
-    inifilename = inifile(argv[0], "sc.ini", "Environment");
+    global.inifilename = inifile(argv[0], "sc.ini", "Environment");
 #elif __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
-    inifilename = inifile(argv[0], "dmd.conf", "Environment");
+    global.inifilename = inifile(argv[0], "dmd.conf", "Environment");
 #else
 #error "fix this"
 #endif
@@ -497,7 +497,7 @@ int tryMain(size_t argc, const char *argv[])
 
     char envsection[80];
     sprintf(envsection, "Environment%s", arch);
-    inifile(argv[0], inifilename, envsection);
+    inifile(argv[0], global.inifilename, envsection);
 
     getenv_setargv("DFLAGS", &argc, &argv);
 
@@ -1024,7 +1024,7 @@ Language changes listed by -transition=id:\n\
 
     if(global.params.is64bit != is64bit)
         error(Loc(), "the architecture must not be changed in the %s section of %s",
-              envsection, inifilename);
+              envsection, global.inifilename);
 
     // Target uses 64bit pointers.
     global.params.isLP64 = global.params.is64bit;
@@ -1181,7 +1181,8 @@ Language changes listed by -transition=id:\n\
     if (global.params.verbose)
     {   fprintf(global.stdmsg, "binary    %s\n", argv[0]);
         fprintf(global.stdmsg, "version   %s\n", global.version);
-        fprintf(global.stdmsg, "config    %s\n", inifilename ? inifilename : "(none)");
+        fprintf(global.stdmsg, "config    %s\n", global.inifilename ? global.inifilename
+                                                                    : "(none)");
     }
 
     //printf("%d source files\n",files.dim);

--- a/src/mars.h
+++ b/src/mars.h
@@ -205,6 +205,7 @@ typedef unsigned structalign_t;
 
 struct Global
 {
+    const char *inifilename;
     const char *mars_ext;
     const char *obj_ext;
     const char *lib_ext;

--- a/src/module.c
+++ b/src/module.c
@@ -266,6 +266,7 @@ bool Module::read(Loc loc)
         {
             ::error(loc, "cannot find source code for runtime library file 'object.d'");
             errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
+            errorSupplemental(loc, "config file: %s", FileName::canonicalName(global.inifilename));
         }
         else
         {


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=4567

This is to help troubleshoot problems caused by stray copies of `dmd.conf` lying around in the wrong places.
