### PR TITLE
refactor - reduce CTFE memory consumption pt 1

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -14,6 +14,7 @@
 #include <assert.h>
 #include <string.h>                     // mem{cpy|set|cmp}()
 #include <math.h>
+#include <new>
 
 #include "rmem.h"
 #include "root.h"
@@ -69,26 +70,28 @@ int isConst(Expression *e)
 
 /* ========================================================================== */
 
-Expression *Neg(Type *type, Expression *e1)
+UnionExp Neg(Type *type, Expression *e1)
 {
-    Expression *e;
+    UnionExp ue;
     Loc loc = e1->loc;
 
     if (e1->type->isreal())
     {
-        e = new RealExp(loc, -e1->toReal(), type);
+        new(&ue) RealExp(loc, -e1->toReal(), type);
     }
     else if (e1->type->isimaginary())
     {
-        e = new RealExp(loc, -e1->toImaginary(), type);
+        new(&ue) RealExp(loc, -e1->toImaginary(), type);
     }
     else if (e1->type->iscomplex())
     {
-        e = new ComplexExp(loc, -e1->toComplex(), type);
+        new(&ue) ComplexExp(loc, -e1->toComplex(), type);
     }
     else
-        e = new IntegerExp(loc, -e1->toInteger(), type);
-    return e;
+    {
+        new(&ue) IntegerExp(loc, -e1->toInteger(), type);
+    }
+    return ue;
 }
 
 Expression *Com(Type *type, Expression *e1)

--- a/src/expression.h
+++ b/src/expression.h
@@ -1553,6 +1553,39 @@ public:
 
 /****************************************************************/
 
+/* A type meant as a union of all the Expression types,
+ * to serve essentially as a Variant that will sit on the stack
+ * during CTFE to reduce memory consumption.
+ */
+struct UnionExp
+{
+    /* Extract pointer to Expression
+     */
+    Expression *exp() { return (Expression *)&u; }
+
+    /* Convert to an allocated Expression
+     */
+    Expression *copy()
+    {
+        Expression *e = exp();
+        assert(e->size <= sizeof(u));
+        return e->copy();
+    }
+
+  private:
+    union U
+    {
+        char exp       [sizeof(Expression)];
+        char integerexp[sizeof(IntegerExp)];
+        char errorexp  [sizeof(ErrorExp)];
+        char realexp   [sizeof(RealExp)];
+        char complexexp[sizeof(ComplexExp)];
+    };
+    U u;
+};
+
+/****************************************************************/
+
 /* Special values used by the interpreter
  */
 extern Expression *EXP_CANT_INTERPRET;
@@ -1563,7 +1596,7 @@ extern Expression *EXP_VOID_INTERPRET;
 
 Expression *expType(Type *type, Expression *e);
 
-Expression *Neg(Type *type, Expression *e1);
+UnionExp Neg(Type *type, Expression *e1);
 Expression *Com(Type *type, Expression *e1);
 Expression *Not(Type *type, Expression *e1);
 Expression *Bool(Type *type, Expression *e1);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3206,12 +3206,12 @@ public:
         }
         switch (e->op)
         {
-        case TOKneg:    result = Neg(e->type, e1); break;
-        case TOKtilde:  result = Com(e->type, e1); break;
-        case TOKnot:    result = Not(e->type, e1); break;
-        case TOKtobool: result = Bool(e->type, e1); break;
-        case TOKvector: result = e; break; // do nothing
-        default: assert(0);
+            case TOKneg:    result = Neg(e->type, e1).copy(); break;
+            case TOKtilde:  result = Com(e->type, e1); break;
+            case TOKnot:    result = Not(e->type, e1); break;
+            case TOKtobool: result = Bool(e->type, e1); break;
+            case TOKvector: result = e; break; // do nothing
+            default: assert(0);
         }
     }
 

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -260,7 +260,7 @@ Expression *Expression_optimize(Expression *e, int result, bool keepLvalue)
             e->e1 = e->e1->optimize(result);
             if (e->e1->isConst() == 1)
             {
-                ret = Neg(e->type, e->e1);
+                ret = Neg(e->type, e->e1).copy();
             }
         }
 


### PR DESCRIPTION
Currently, CTFE allocates memory for every step in its computation. This can result in an enormous amount allocated. This is the first step towards using stack memory instead.
