### PR TITLE
fix Issue 11216 - Make synchronized statement `nothrow`

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -659,8 +659,8 @@ public:
     Statement *mergeFensure(Statement *, Identifier *oid);
     Parameters *getParameters(int *pvarargs);
 
-    static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name);
-    static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id);
+    static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
+    static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
 
     Symbol *toThunkSymbol(int offset);  // thunk version
     void toObjFile(bool multiobj);                       // compile to .obj file

--- a/src/func.c
+++ b/src/func.c
@@ -3919,12 +3919,12 @@ bool FuncDeclaration::addPostInvariant()
  * Generate a FuncDeclaration for a runtime library function.
  */
 
-FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, const char *name)
+FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc)
 {
-    return genCfunc(args, treturn, Lexer::idPool(name));
+    return genCfunc(args, treturn, Lexer::idPool(name), stc);
 }
 
-FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, Identifier *id)
+FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc)
 {
     FuncDeclaration *fd;
     TypeFunction *tf;
@@ -3946,7 +3946,7 @@ FuncDeclaration *FuncDeclaration::genCfunc(Parameters *args, Type *treturn, Iden
     }
     else
     {
-        tf = new TypeFunction(args, treturn, 0, LINKc);
+        tf = new TypeFunction(args, treturn, 0, LINKc, stc);
         fd = new FuncDeclaration(Loc(), Loc(), id, STCstatic, tf);
         fd->protection = Prot(PROTpublic);
         fd->linkage = LINKc;

--- a/src/statement.c
+++ b/src/statement.c
@@ -4185,12 +4185,12 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
         Parameters* args = new Parameters;
         args->push(new Parameter(0, ClassDeclaration::object->type, NULL, NULL));
 
-        FuncDeclaration *fdenter = FuncDeclaration::genCfunc(args, Type::tvoid, Id::monitorenter);
+        FuncDeclaration *fdenter = FuncDeclaration::genCfunc(args, Type::tvoid, Id::monitorenter, STCnothrow);
         Expression *e = new CallExp(loc, new VarExp(loc, fdenter), new VarExp(loc, tmp));
         e->type = Type::tvoid;                  // do not run semantic on e
         cs->push(new ExpStatement(loc, e));
 
-        FuncDeclaration *fdexit = FuncDeclaration::genCfunc(args, Type::tvoid, Id::monitorexit);
+        FuncDeclaration *fdexit = FuncDeclaration::genCfunc(args, Type::tvoid, Id::monitorexit, STCnothrow);
         e = new CallExp(loc, new VarExp(loc, fdexit), new VarExp(loc, tmp));
         e->type = Type::tvoid;                  // do not run semantic on e
         Statement *s = new ExpStatement(loc, e);


### PR DESCRIPTION
- mark _d_monitorenter/exit as nothrow

[Issue 11216](https://issues.dlang.org/show_bug.cgi?id=11216)
