### PR TITLE
[DDMD] Issue 13707 - msvc32 C++ struct return ABI not followed for structs with constructors

### DIFF
--- a/src/toir.c
+++ b/src/toir.c
@@ -914,6 +914,15 @@ L2:
             //printf("  2 RETstack\n");
             return RETstack;            // 32 bit C/C++ structs always on stack
         }
+        if (global.params.isWindows && tf->linkage == LINKcpp && !global.params.is64bit &&
+                 sd->isPOD() && sd->ctor)
+        {
+            // win32 returns otherwise POD structs with ctors via memory
+            // unless it's not really a struct
+            if (sd->ident == Id::__c_long || sd->ident == Id::__c_ulong)
+                return RETregs;
+            return RETstack;
+        }
         if (sd->arg1type && !sd->arg2type)
         {
             tns = sd->arg1type;

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -609,6 +609,28 @@ void test16()
 
 /****************************************/
 
+struct S13707
+{
+    void* a;
+    void* b;
+    this(void* a, void* b)
+    {
+        this.a = a;
+        this.b = b;
+    }
+}
+
+extern(C++) S13707 func13707();
+
+void test13707()
+{
+    auto p = func13707();
+    assert(p.a == null);
+    assert(p.b == null);
+}
+
+/****************************************/
+
 void main()
 {
     test1();
@@ -631,6 +653,7 @@ void main()
     test13289();
     test15();
     test16();
+    func13707();
 
     printf("Success\n");
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -373,3 +373,22 @@ unsigned long testul(unsigned long ul)
 
 /******************************************/
 
+struct S13707
+{
+    void* a;
+    void* b;
+    S13707(void *a, void* b)
+    {
+        this->a = a;
+        this->b = b;
+    }
+};
+
+S13707 func13707()
+{
+    S13707 pt(NULL, NULL);
+    return pt;
+}
+
+/******************************************/
+


### PR DESCRIPTION
A constructor should stop a struct from being passed in registers on win32/C++.

https://issues.dlang.org/show_bug.cgi?id=13707
