### PR TITLE
[DDMD] Use a base type for StorageClass that ulong mangles to consistently

### DIFF
--- a/src/mars.h
+++ b/src/mars.h
@@ -345,7 +345,7 @@ enum MATCH
     MATCHexact          // exact match
 };
 
-typedef uint64_t StorageClass;
+typedef uinteger_t StorageClass;
 
 #include "errors.h"
 


### PR DESCRIPTION
No stc used in functions called across the language boundary = no issues with mangling.
