### PR TITLE
Re-enable runnable/a20 and runnable/cov2 on freebsd

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -114,10 +114,6 @@ export SEP=/
 endif
 
 ifeq ($(OS),freebsd)
-DISABLED_TESTS += a20
-DISABLED_TESTS += cov2
-# coverage issues, see bug 5619
-
 DISABLED_TESTS += builtin
 # precision related bug: Error: static assert  (0x1.f9f8d9aea10fb28ep-2L == 0x1.f9f8d9aea10fdf1cp-2L) is false
 


### PR DESCRIPTION
They seem to work now.

Fixes [Issue 5619](https://issues.dlang.org/show_bug.cgi?id=5619)
