### PR TITLE
Re-enable runnable/test17 and runnable/test39 on freebsd

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -119,10 +119,6 @@ DISABLED_TESTS += builtin
 
 DISABLED_TESTS += dhry
 # runnable/dhry.d(488): Error: undefined identifier dtime
-
-# 64 bit test failures
-DISABLED_TESTS += test17
-DISABLED_SH_TESTS += test39
 endif
 
 ifeq ($(OS),win64)


### PR DESCRIPTION
They seem to pass now.
