### PR TITLE
Issue 13468 - Wrong code when comparing class reference with typeof(null)

### DIFF
--- a/src/opover.c
+++ b/src/opover.c
@@ -912,7 +912,15 @@ Expression *op_overload(Expression *e, Scope *sc)
                 }
             }
 
-            result = compare_overload(e, sc, Id::eq);
+            // Comparing a class with typeof(null) should not call opEquals
+            if (t1->ty == Tclass && t2->ty == Tnull ||
+                t1->ty == Tnull && t2->ty == Tclass)
+            {
+            }
+            else
+            {
+                result = compare_overload(e, sc, Id::eq);
+            }
         }
 
         void visit(CmpExp *e)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1892,6 +1892,18 @@ void test91()
 
 /***************************************************/
 
+bool fun13468(Object e, typeof(null) needle)
+{
+    return (e == needle);
+}
+
+void test13468()
+{
+    assert(fun13468(null, null));
+}
+
+/***************************************************/
+
 auto ref foo92(ref int x) { return x; }
 int bar92(ref int x) { return x; }
 
@@ -7502,6 +7514,7 @@ int main()
     test10539();
     test10634();
     test7254();
+    test13468();
     test11075();
     test11181();
     test11317();


### PR DESCRIPTION
One possible way to fix this bug.  This way still allows `==` to be used to compare objects in generic code, which requiring `is` between objects and `typeof(null)` would break.

https://issues.dlang.org/show_bug.cgi?id=13468
