### PR TITLE
fix issue 6952 - Pass linker switches to gcc instead of to ld

### DIFF
--- a/ini/freebsd/bin32/dmd.conf
+++ b/ini/freebsd/bin32/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L-Xlinker -L--export-dynamic
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L-Xlinker -L--export-dynamic

--- a/ini/freebsd/bin64/dmd.conf
+++ b/ini/freebsd/bin64/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L-Xlinker -L--export-dynamic
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L-Xlinker -L--export-dynamic

--- a/ini/linux/bin32/dmd.conf
+++ b/ini/linux/bin32/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L-Xlinker -L--export-dynamic
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L-Xlinker -L--export-dynamic

--- a/ini/linux/bin64/dmd.conf
+++ b/ini/linux/bin64/dmd.conf
@@ -1,5 +1,5 @@
 [Environment32]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L-Xlinker -L--export-dynamic
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L-Xlinker -L--export-dynamic

--- a/src/link.c
+++ b/src/link.c
@@ -583,11 +583,6 @@ int runLINK()
 
     for (size_t i = 0; i < global.params.linkswitches->dim; i++)
     {   const char *p = (*global.params.linkswitches)[i];
-        if (!p || !p[0] || !(p[0] == '-' && (p[1] == 'l' || p[1] == 'L')))
-            // Don't need -Xlinker if switch starts with -l or -L.
-            // Eliding -Xlinker is significant for -L since it allows our paths
-            // to take precedence over gcc defaults.
-            argv.push("-Xlinker");
         argv.push(p);
     }
 


### PR DESCRIPTION
This provides a fix for https://issues.dlang.org/show_bug.cgi?id=6952.

`dmd` uses `gcc` for its linker, not `ld`.  Currently `dmd` appends `-Xlinker` to linker switches (i.e. switches that begin with `-L`) so they bypass `gcc` and are passed directly to `ld`.  

In GCC, some options are passed transparently to `ld` (e.g. -lmylib), some are recognized only by `gcc` but not by `ld`, and some seem to have a different affect if passed to `gcc` than if passed to `ld`. (See https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html for a description of GCC's linker options).

By passing `dmd`'s linker options directly to `ld`, it prevents users from leveraging options that are only recognized by `gcc` but affect the linking process, or options that have different effect in `gcc` than in `ld`.  Such switches include `-static`, `-nodefaultlibs` and `-nostdlib`. (There may be others).

This pull request modifies the way `dmd` passes linker options to `gcc`.  It removes the `-Xlinker` prefix for any `dmd` switch prefixed with `-L`.  If users still wish to bypass `gcc` and pass switches directly to `ld`, they can use `-L-Xlinker -L-ldswitch` in their `dmd` command.  This commit modifies dmd.conf to pass `--export-dynamic` directly to `ld`, since `--export-dynamic` is not recognized by `gcc`.

This change has the potential to break users' build scripts if they are depending on `ld`-specific options to be passed directly to `ld` using the `-L` prefix.  But, I think this is the best way forward, as it allows users to control all aspects of the linking process.  That is users can choose which options go to `gcc` and which options bypass `gcc` and go directly to `ld`.  Currently, users don't have this capability.

I also looked into using `ld`, instead of `gcc`, as the linker for `dmd`, but that would involve adding quite a bit of platform specific logic to DMD.  So, I think using `gcc` as the linker is appropriate.
