### PR TITLE
Fix 13736 - Spellchecker should prefer symbols from inner scopes

### DIFF
--- a/src/root/speller.h
+++ b/src/root/speller.h
@@ -7,7 +7,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/speller.h
  */
 
-typedef void *(fp_speller_t)(void *, const char *);
+typedef void *(fp_speller_t)(void *, const char *, int*);
 
 extern const char idchars[];
 

--- a/src/scope.h
+++ b/src/scope.h
@@ -145,7 +145,7 @@ struct Scope
 
     Module *instantiatingModule();
 
-    Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym);
+    Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym, int flags = IgnoreNone);
     Dsymbol *search_correct(Identifier *ident);
     Dsymbol *insert(Dsymbol *s);
 

--- a/src/traits.c
+++ b/src/traits.c
@@ -272,13 +272,14 @@ void initTraitsStringTable()
     }
 }
 
-void *trait_search_fp(void *arg, const char *seed)
+void *trait_search_fp(void *arg, const char *seed, int* cost)
 {
     //printf("trait_search_fp('%s')\n", seed);
     size_t len = strlen(seed);
     if (!len)
         return NULL;
 
+    *cost = 0;
     StringValue *sv = traitsStringTable.lookup(seed, len);
     return sv ? (void*)sv->ptrvalue : NULL;
 }

--- a/test/fail_compilation/imports/spell9644a.d
+++ b/test/fail_compilation/imports/spell9644a.d
@@ -1,0 +1,7 @@
+module imports.spell9644a;
+
+public import imports.spell9644b;
+
+int cora;
+int pub;
+private int priv;

--- a/test/fail_compilation/imports/spell9644b.d
+++ b/test/fail_compilation/imports/spell9644b.d
@@ -1,0 +1,3 @@
+module imports.spell9644b;
+
+private int prib;

--- a/test/fail_compilation/spell9644.d
+++ b/test/fail_compilation/spell9644.d
@@ -4,17 +4,23 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/spell9644.d(21): Error: undefined identifier b
-fail_compilation/spell9644.d(22): Error: undefined identifier xx
-fail_compilation/spell9644.d(23): Error: undefined identifier cb, did you mean variable ab?
-fail_compilation/spell9644.d(24): Error: undefined identifier bc, did you mean variable abc?
-fail_compilation/spell9644.d(25): Error: undefined identifier ccc
+fail_compilation/spell9644.d(27): Error: undefined identifier b
+fail_compilation/spell9644.d(28): Error: undefined identifier xx
+fail_compilation/spell9644.d(29): Error: undefined identifier cb, did you mean variable ab?
+fail_compilation/spell9644.d(30): Error: undefined identifier bc, did you mean variable abc?
+fail_compilation/spell9644.d(31): Error: undefined identifier ccc
+fail_compilation/spell9644.d(33): Error: undefined identifier cor2, did you mean variable cor1?
+fail_compilation/spell9644.d(34): Error: undefined identifier pua, did you mean variable pub?
+fail_compilation/spell9644.d(35): Error: undefined identifier priw
 ---
 */
+
+import imports.spell9644a;
 
 int a;
 int ab;
 int abc;
+int cor1;
 
 int main()
 {
@@ -23,4 +29,8 @@ int main()
     cast(void)cb; // max distance 1, match
     cast(void)bc; // max distance 1, match
     cast(void)ccc; // max distance 2, match
+
+    cast(void)cor2; // max distance 1, match "cor1", but not cora from import (bug 13736)
+    cast(void)pua;  // max distance 1, match "pub" from import
+    cast(void)priw; // max distance 1, match "priv" from import, but do not report (bug 5839)
 }


### PR DESCRIPTION
spell checker: find the "closest" symbol for the minimum levenshtein distance by counting levels of scopes between the identifier and the found symbol. If the symbol is found through an import, another level is added.

This is needed to let the precise GC pass the test suite, otherwise "gc" is easily reported for spell checker tests.

https://issues.dlang.org/show_bug.cgi?id=13736
