### PR TITLE
Fix Issue 13738 - RTInfo generation on deprecated struct causes deprecation message

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -73,6 +73,7 @@ public:
     Sizeok sizeok;         // set when structsize contains valid data
     Dsymbol *deferred;          // any deferred semantic2() or semantic3() symbol
     bool isdeprecated;          // true if deprecated
+    bool mutedeprecation;       // true while analysing RTInfo to avoid deprecation message
 
     Dsymbol *enclosing;         /* !=NULL if is nested
                                  * pointing to the dsymbol that directly enclosing it.
@@ -112,6 +113,7 @@ public:
     int firstFieldInUnion(int indx); // first field in union that includes indx
     int numFieldsInUnion(int firstIndex); // #fields in union starting at index
     bool isDeprecated();         // is aggregate deprecated?
+    bool muteDeprecationMessage(); // disable deprecation message on Dsymbol?
     bool isNested();
     void makeNested();
     bool isExport();

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -567,6 +567,11 @@ bool Dsymbol::isDeprecated()
     return false;
 }
 
+bool Dsymbol::muteDeprecationMessage()
+{
+    return false;
+}
+
 bool Dsymbol::isOverloadable()
 {
     return false;
@@ -665,7 +670,7 @@ void Dsymbol::deprecation(const char *format, ...)
 
 void Dsymbol::checkDeprecated(Loc loc, Scope *sc)
 {
-    if (global.params.useDeprecated != 1 && isDeprecated())
+    if (global.params.useDeprecated != 1 && isDeprecated() && !muteDeprecationMessage())
     {
         // Don't complain if we're inside a deprecated symbol's scope
         for (Dsymbol *sp = sc->parent; sp; sp = sp->parent)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -215,6 +215,7 @@ public:
     virtual bool isExport();                    // is Dsymbol exported?
     virtual bool isImportedSymbol();            // is Dsymbol imported?
     virtual bool isDeprecated();                // is Dsymbol deprecated?
+    virtual bool muteDeprecationMessage();      // disable deprecation message on Dsymbol?
     virtual bool isOverloadable();
     virtual bool hasOverloads();
     virtual LabelDsymbol *isLabel();            // is this a LabelDsymbol?


### PR DESCRIPTION
assume aggregate to be non-deprecated during RTInfo generation

https://issues.dlang.org/show_bug.cgi?id=13738
