### PR TITLE
support for templated AAs

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4625,21 +4625,25 @@ elem *toElem(Expression *e, IRState *irs)
                 elem *valuesize = el_long(TYsize_t, vsize);
                 //printf("valuesize: "); elem_print(valuesize);
                 Symbol *s;
+                //printf("taa->index = %s\n", taa->index->toChars());
+                elem* keyti = toElem(taa->index->getInternalTypeInfo(NULL), irs);
+                elem* ep;
                 if (ie->modifiable)
                 {
                     n1 = el_una(OPaddr, TYnptr, n1);
-                    s = taa->aaGetSymbol("GetX", 1);
+                    s = taa->aaGetSymbol("GetZ", 1);
+                    // pass pointer to aaLiteral!(Key, Value) so that aaGetZ can create a new AA
+                    elem *aaLiteral = el_ptr(toSymbol(taa->aaLiteral));
+                    ep = el_params(aaLiteral, n2, valuesize, keyti, n1, NULL);
                 }
                 else
                 {
                     s = taa->aaGetSymbol("GetRvalueX", 1);
+                    ep = el_params(n2, valuesize, keyti, n1, NULL);
                 }
-                //printf("taa->index = %s\n", taa->index->toChars());
-                elem* keyti = toElem(taa->index->getInternalTypeInfo(NULL), irs);
                 //keyti = toElem(taa->index->getTypeInfo(NULL), irs);
                 //printf("keyti:\n");
                 //elem_print(keyti);
-                elem* ep = el_params(n2, valuesize, keyti, n1, NULL);
                 e = el_bin(OPcall, TYnptr, el_var(s), ep);
                 if (irs->arrayBoundsCheck())
                 {
@@ -5015,12 +5019,10 @@ elem *toElem(Expression *e, IRState *irs)
                     ev = addressElem(ev, Type::tvoid->arrayOf());
                     ek = addressElem(ek, Type::tvoid->arrayOf());
                 }
-                elem *e = el_params(ev, ek,
-                                    toElem(ta->getTypeInfo(NULL), irs),
-                                    NULL);
+                elem *e = el_params(ek, ev, NULL);
 
-                // call _d_assocarrayliteralTX(ti, keys, values)
-                e = el_bin(OPcall,TYnptr,el_var(rtlsym[RTLSYM_ASSOCARRAYLITERALTX]),e);
+                // call extern(D) aaLiteral!(Key, Value)(keys, values)
+                e = el_bin(OPcall,TYnptr,el_var(toSymbol(((TypeAArray *)t)->aaLiteral)),e);
                 if (t != ta)
                     e = addressElem(e, ta);
                 el_setLoc(e, aale->loc);

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -65,6 +65,7 @@ Msgtable msgtable[] =
     { "outer" },
     { "Exception" },
     { "RTInfo" },
+    { "aaLiteral" },
     { "Throwable" },
     { "Error" },
     { "withSym", "__withSym" },

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -75,6 +75,7 @@ ClassDeclaration *Type::typeinfoshared;
 ClassDeclaration *Type::typeinfowild;
 
 TemplateDeclaration *Type::rtinfo;
+TemplateDeclaration *Type::aaLiteral;
 
 Type *Type::tvoid;
 Type *Type::tint8;
@@ -4459,6 +4460,7 @@ TypeAArray::TypeAArray(Type *t, Type *index)
     this->index = index;
     this->loc = Loc();
     this->sc = NULL;
+    this->aaLiteral = NULL;
 }
 
 TypeAArray *TypeAArray::create(Type *t, Type *index)
@@ -4481,6 +4483,7 @@ Type *TypeAArray::syntaxCopy()
     {
         t = new TypeAArray(t, ti);
         t->mod = mod;
+        ((TypeAArray *)t)->aaLiteral = aaLiteral;
     }
     return t;
 }
@@ -4679,7 +4682,19 @@ printf("index->ito->ito = x%x\n", index->ito->ito);
     {   error(loc, "cannot have array of scope %s", next->toChars());
         return Type::terror;
     }
-    return merge();
+    TypeAArray *res = (TypeAArray *)merge();
+    if (!res->aaLiteral)
+    {
+        // resolve aaLiteral!(Key, Value)(Key[] keys, Value[] values)
+        Objects *tiargs = new Objects();
+        tiargs->push(index);
+        tiargs->push(next);
+        Expressions *fargs = new Expressions();
+        fargs->push(new NullExp(loc, index->arrayOf()));
+        fargs->push(new NullExp(loc, next->arrayOf()));
+        res->aaLiteral = resolveFuncCall(loc, sc, Type::aaLiteral, tiargs, NULL, fargs);
+    }
+    return res;
 }
 
 void TypeAArray::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -215,6 +215,7 @@ public:
     static ClassDeclaration *typeinfowild;
 
     static TemplateDeclaration *rtinfo;
+    static TemplateDeclaration *aaLiteral;
 
     static Type *basic[TMAX];
     static unsigned char sizeTy[TMAX];
@@ -518,6 +519,7 @@ class TypeAArray : public TypeArray
 {
 public:
     Type *index;                // key type
+    FuncDeclaration *aaLiteral;
     Loc loc;
     Scope *sc;
 

--- a/src/template.c
+++ b/src/template.c
@@ -498,6 +498,8 @@ void TemplateDeclaration::semantic(Scope *sc)
     {
         if (ident == Id::RTInfo)
             Type::rtinfo = this;
+        if (ident == Id::aaLiteral)
+            Type::aaLiteral = this;
     }
 
     if (Module *m = sc->module) // should use getModule() instead?


### PR DESCRIPTION
- call templated aaLiteral!(Key, Value)(Key[], Value[])
  to create array literals
- pass pointer to aaLiteral!(Key, Value) function to
  _aaGetZ (because it might have to initialize a null AA).
