### PR TITLE
[Refactoring] Remove interpret member function from Expression and Statement

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -41,7 +41,6 @@ class TemplateInstance;
 class TemplateDeclaration;
 class ClassDeclaration;
 class BinExp;
-struct InterState;
 struct Symbol;          // back end symbol
 class OverloadSet;
 class Initializer;
@@ -110,18 +109,6 @@ Expression *checkGC(Scope *sc, Expression *e);
  * or a tuple containing a TypeExp. (This is required by pragma(msg)).
  */
 Expression *ctfeInterpretForPragmaMsg(Expression *e);
-
-/* Interpreter: what form of return value expression is required?
- */
-enum CtfeGoal
-{   ctfeNeedRvalue,   // Must return an Rvalue
-    ctfeNeedLvalue,   // Must return an Lvalue
-    ctfeNeedAnyValue, // Can return either an Rvalue or an Lvalue
-    ctfeNeedLvalueRef,// Must return a reference to an Lvalue (for ref types)
-    ctfeNeedNothing   // The return value is not required
-};
-
-Expression *interpret(Expression *e, InterState *istate, CtfeGoal goal);
 
 #define WANTflags   1
 #define WANTvalue   2
@@ -213,10 +200,6 @@ public:
     Expression *ctfeInterpret()
     {
         return ::ctfeInterpret(this);
-    }
-    Expression *interpret(InterState *istate, CtfeGoal goal = ctfeNeedRvalue)
-    {
-        return ::interpret(this, istate, goal);
     }
 
     int isConst() { return ::isConst(this); }

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1906,7 +1906,7 @@ public:
         // If it is with(Enum) {...}, just execute the body.
         if (s->exp->op == TOKimport || s->exp->op == TOKtype)
         {
-            result = s->body ? s->body->interpret(istate) : CTFEExp::voidexp;
+            result = s->body ? s->body->interpret(istate) : NULL;
             return;
         }
 
@@ -1945,7 +1945,7 @@ public:
             }
         }
         else
-            e = CTFEExp::voidexp;
+            e = NULL;
         ctfeStack.pop(s->wthis);
         result = e;
     }

--- a/src/statement.h
+++ b/src/statement.h
@@ -48,8 +48,6 @@ class TryFinallyStatement;
 class CaseStatement;
 class DefaultStatement;
 class LabelStatement;
-struct InterState;
-struct CompiledCtfeFunction;
 
 enum TOK;
 
@@ -61,7 +59,6 @@ struct block;
 #endif
 struct code;
 
-Expression *interpret(Statement *s, InterState *istate);
 bool inferAggregate(ForeachStatement *fes, Scope *sc, Dsymbol *&sapply);
 bool inferApplyArgTypes(ForeachStatement *fes, Scope *sc, Dsymbol *&sapply);
 
@@ -107,10 +104,6 @@ public:
     bool hasCode();
     virtual Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
     virtual Statements *flatten(Scope *sc);
-    Expression *interpret(InterState *istate)
-    {
-        return ::interpret(this, istate);
-    }
     virtual Statement *last();
 
     // Avoid dynamic_cast


### PR DESCRIPTION
Directly using free functions has a benefit that can handle `NULL` Expression and Statement. And `ctfeNeedXXX` enum declaration can be placed in `interpret.c`.
