### PR TITLE
fix misleading deprecation messages

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2249,7 +2249,7 @@ TOK Lexer::inreal(Token *t)
             break;
 
         case 'l':
-            error("'l' suffix is deprecated, use 'L' instead");
+            error("use 'L' suffix instead of 'l'");
         case 'L':
             result = TOKfloat80v;
             p++;
@@ -2258,7 +2258,7 @@ TOK Lexer::inreal(Token *t)
     if (*p == 'i' || *p == 'I')
     {
         if (*p == 'I')
-            error("'I' suffix is deprecated, use 'i' instead");
+            error("use 'i' suffix instead of 'I'");
         p++;
         switch (result)
         {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2988,7 +2988,7 @@ Expression *TypeBasic::getProperty(Loc loc, Identifier *ident, int flag)
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                error(loc, ".min property is deprecated, use .min_normal instead");
+                error(loc, "use .min_normal property instead of .min");
                 goto Lmin_normal;
         }
     }

--- a/src/parse.c
+++ b/src/parse.c
@@ -4970,7 +4970,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr)
                 arg = new Parameter(0, NULL, token.ident, NULL);
                 nextToken();
                 nextToken();
-                error("if (v; e) is deprecated, use if (auto v = e)");
+                error("use 'if (auto v = e)' instead of 'if (v; e)'");
             }
             else if (isDeclaration(&token, 2, TOKassign, NULL))
             {

--- a/test/fail_compilation/fail10439.d
+++ b/test/fail_compilation/fail10439.d
@@ -1,15 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10439.d(18): Error: .min property is deprecated, use .min_normal instead
-fail_compilation/fail10439.d(19): Error: .min property is deprecated, use .min_normal instead
-fail_compilation/fail10439.d(20): Error: .min property is deprecated, use .min_normal instead
-fail_compilation/fail10439.d(22): Error: .min property is deprecated, use .min_normal instead
-fail_compilation/fail10439.d(23): Error: .min property is deprecated, use .min_normal instead
-fail_compilation/fail10439.d(24): Error: .min property is deprecated, use .min_normal instead
-fail_compilation/fail10439.d(26): Error: .min property is deprecated, use .min_normal instead
-fail_compilation/fail10439.d(27): Error: .min property is deprecated, use .min_normal instead
-fail_compilation/fail10439.d(28): Error: .min property is deprecated, use .min_normal instead
+fail_compilation/fail10439.d(18): Error: use .min_normal property instead of .min
+fail_compilation/fail10439.d(19): Error: use .min_normal property instead of .min
+fail_compilation/fail10439.d(20): Error: use .min_normal property instead of .min
+fail_compilation/fail10439.d(22): Error: use .min_normal property instead of .min
+fail_compilation/fail10439.d(23): Error: use .min_normal property instead of .min
+fail_compilation/fail10439.d(24): Error: use .min_normal property instead of .min
+fail_compilation/fail10439.d(26): Error: use .min_normal property instead of .min
+fail_compilation/fail10439.d(27): Error: use .min_normal property instead of .min
+fail_compilation/fail10439.d(28): Error: use .min_normal property instead of .min
 ---
 */
 

--- a/test/fail_compilation/parseStc.d
+++ b/test/fail_compilation/parseStc.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc.d(10): Error: if (v; e) is deprecated, use if (auto v = e)
+fail_compilation/parseStc.d(10): Error: use 'if (auto v = e)' instead of 'if (v; e)'
 fail_compilation/parseStc.d(11): Error: redundant attribute 'const'
 ---
 */


### PR DESCRIPTION
These are errors, not deprecations, and that should be reflected in the message.
