### PR TITLE
[new AA] aaLiteral compiler support

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -133,6 +133,13 @@ Expression *implicitCastTo(Expression *e, Scope *sc, Type *t)
             visit((Expression *)e);
         }
 
+        void visit(AssocArrayLiteralExp *e)
+        {
+            //printf("AssocArrayLiteralExp::implicitCastTo(%s of type %s) => %s\n", e->toChars(), e->type->toChars(), t->toChars());
+            visit((Expression *)e);
+            aaLiteralCreate(sc, t);
+        }
+
         void visit(ArrayLiteralExp *e)
         {
             visit((Expression *)e);
@@ -1993,6 +2000,7 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                     (*ae->keys)[i] = ex;
                 }
                 ae->type = t;
+                aaLiteralCreate(sc, t);
                 result = ae;
                 return;
             }

--- a/src/expression.c
+++ b/src/expression.c
@@ -2589,7 +2589,7 @@ void Expression::checkNogc(Scope *sc, FuncDeclaration *f)
     if (sc->flags & SCOPEctfe)
         return;
 
-    if (!f->isNogc())
+    if (!f->isNogc() && f->ident != Id::aaLiteral)
     {
         if (sc->flags & SCOPEcompile ? sc->func->isNogcBypassingInference() : sc->func->setGC())
         {
@@ -4163,10 +4163,10 @@ Expression *AssocArrayLiteralExp::semantic(Scope *sc)
     type = type->semantic(loc, sc);
 
     semanticTypeInfo(sc, type);
+    aaLiteralCreate(sc, type);
 
     return this;
 }
-
 
 int AssocArrayLiteralExp::isBool(int result)
 {
@@ -10669,6 +10669,7 @@ Expression *IndexExp::semantic(Scope *sc)
             return new ErrorExp();
     }
 
+    aaLiteralCreate(sc, t1b);
     if (t1b->ty == Tsarray || t1b->ty == Tarray)
     {
         Expression *el = new ArrayLengthExp(loc, e1);

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -65,6 +65,7 @@ Msgtable msgtable[] =
     { "outer" },
     { "Exception" },
     { "RTInfo" },
+    { "aaLiteral" },
     { "Throwable" },
     { "Error" },
     { "withSym", "__withSym" },

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -75,6 +75,7 @@ ClassDeclaration *Type::typeinfoshared;
 ClassDeclaration *Type::typeinfowild;
 
 TemplateDeclaration *Type::rtinfo;
+TemplateDeclaration *Type::aaLiteral;
 
 Type *Type::tvoid;
 Type *Type::tint8;
@@ -4459,6 +4460,7 @@ TypeAArray::TypeAArray(Type *t, Type *index)
     this->index = index;
     this->loc = Loc();
     this->sc = NULL;
+    this->aaLiteral = NULL;
 }
 
 TypeAArray *TypeAArray::create(Type *t, Type *index)
@@ -4481,6 +4483,8 @@ Type *TypeAArray::syntaxCopy()
     {
         t = new TypeAArray(t, ti);
         t->mod = mod;
+        ((TypeAArray *)t)->aaLiteral = aaLiteral;
+        ((TypeAArray *)t)->sc = sc;
     }
     return t;
 }
@@ -4488,6 +4492,82 @@ Type *TypeAArray::syntaxCopy()
 d_uns64 TypeAArray::size(Loc loc)
 {
     return Target::ptrsize;
+}
+
+void aaLiteralCreate(Scope *sc, Type *t)
+{
+    if (!Type::aaLiteral)
+    {
+        ObjectNotFound(Id::aaLiteral);
+        assert(0);
+    }
+
+    class AALiteralVisitor : public Visitor
+    {
+        Scope *sc;
+    public:
+        AALiteralVisitor(Scope *sc)
+        {
+            this->sc = sc;
+        }
+
+        void visit(Type *t)
+        {
+        }
+
+        void visit(TypeNext *n)
+        {
+            n->next->accept(this);
+        }
+
+        void visit(TypeEnum *e)
+        {
+            if (e->sym->isforwardRef())
+                return;
+            e->toBasetype()->accept(this);
+        }
+
+        void visit(TypeAArray *aa)
+        {
+            if (!aa->aaLiteral && aa->next->ty != Terror && aa->index->ty != Terror)
+            {
+                //printf("TypeAArray::aaLiteralCreate() %s; %p\n", aa->toChars(), aa);
+                assert(sc);
+
+                if (sc && !sc->module->isRoot() && (!sc->tinst || !sc->tinst->needsCodegen()))
+                    return;
+
+                assert(aa->deco);
+                Objects *tiargs = new Objects();
+                Type *tkey = aa->index;
+                Type *tvalue = aa->next;
+
+                if ((tkey->ty == Tclass || tkey->ty == Tstruct || tkey->ty == Tenum) &&
+                    tkey->toDsymbol(NULL)->isforwardRef())
+                    return;
+
+                if ((tvalue->ty == Tclass || tvalue->ty == Tstruct || tvalue->ty == Tenum) &&
+                    tvalue->toDsymbol(NULL)->isforwardRef())
+                    return;
+
+                tiargs->push(tkey);
+                tiargs->push(tvalue);
+                assert(tkey && tkey->deco);
+                assert(tvalue && tvalue->deco);
+                Expressions *fargs = new Expressions();
+                fargs->push(new NullExp(aa->loc, tkey->arrayOf()));
+                fargs->push(new NullExp(aa->loc, tvalue->arrayOf()));
+                FuncDeclaration *aaliteralfunc = resolveFuncCall(aa->loc, sc, Type::aaLiteral, tiargs, NULL, fargs);
+                assert(aaliteralfunc);
+                if (!aaliteralfunc->isInstantiated()->needsCodegen())
+                    return;
+                aa->aaLiteral = aaliteralfunc;
+            }
+        }
+    };
+
+    AALiteralVisitor v(sc);
+    t->accept(&v);
 }
 
 Type *TypeAArray::semantic(Loc loc, Scope *sc)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -50,6 +50,7 @@ void semanticTypeInfo(Scope *sc, Type *t);
 MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL, size_t inferStart = 0);
 Type *reliesOnTident(Type *t, TemplateParameters *tparams = NULL, size_t iStart = 0);
 StorageClass ModToStc(unsigned mod);
+void aaLiteralCreate(Scope *sc, Type *t);
 
 enum ENUMTY
 {
@@ -215,6 +216,7 @@ public:
     static ClassDeclaration *typeinfowild;
 
     static TemplateDeclaration *rtinfo;
+    static TemplateDeclaration *aaLiteral;
 
     static Type *basic[TMAX];
     static unsigned char sizeTy[TMAX];
@@ -520,6 +522,7 @@ public:
     Type *index;                // key type
     Loc loc;
     Scope *sc;
+    FuncDeclaration *aaLiteral;
 
     TypeAArray(Type *t, Type *index);
     static TypeAArray *create(Type *t, Type *index);

--- a/src/template.c
+++ b/src/template.c
@@ -498,6 +498,8 @@ void TemplateDeclaration::semantic(Scope *sc)
     {
         if (ident == Id::RTInfo)
             Type::rtinfo = this;
+        else if (ident == Id::aaLiteral)
+            Type::aaLiteral = this;
     }
 
     if (Module *m = sc->module) // should use getModule() instead?


### PR DESCRIPTION
This is a dmd part of the new AA implementation. 
This PR depends on D-Programming-Language/druntime#1046 and uses new aaLiteral version (with arrays of keys and arguments)
