### PR TITLE
Issue 13783 - Function overload with rvalue `inout` parameter not selected when `enum` parameter implicitly converted to its base type

### DIFF
--- a/test/runnable/overload.d
+++ b/test/runnable/overload.d
@@ -1054,6 +1054,20 @@ void test11916()
 }
 
 /***************************************************/
+// 13783
+
+enum E13783 { a = 5 }
+
+    inout(int) f(    inout(int) t) { return t * 2; }
+ref inout(int) f(ref inout(int) t) { return t; }
+
+void test13783()
+{
+    const E13783 e = E13783.a;
+    assert(f(e) == 10);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -1086,6 +1100,7 @@ int main()
     test11785();
     test11915();
     test11916();
+    test13783();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13783

The root issue is a flaw in the overload resolution mechanism.
For the function `auto f(ref T);`, an lvalue of `enum E : T` should not match.

Requires phobos tweaking: https://github.com/D-Programming-Language/phobos/pull/2773
