### PR TITLE
Issue 13200 - Assertion `protName' failed

### DIFF
--- a/src/enum.c
+++ b/src/enum.c
@@ -99,9 +99,6 @@ void EnumDeclaration::semantic(Scope *sc)
 {
     //printf("EnumDeclaration::semantic(sd = %p, '%s') %s\n", sc->scopesym, sc->scopesym->toChars(), toChars());
     //printf("EnumDeclaration::semantic() %p %s\n", this, toChars());
-    if (!members && !memtype)               // enum ident;
-        return;
-
     if (semanticRun >= PASSsemanticdone)
         return;             // semantic() already completed
     if (semanticRun == PASSsemantic)
@@ -112,10 +109,7 @@ void EnumDeclaration::semantic(Scope *sc)
         semanticRun = PASSsemanticdone;
         return;
     }
-    semanticRun = PASSsemantic;
-
-    if (!symtab)
-        symtab = new DsymbolTable();
+    unsigned dprogress_save = Module::dprogress;
 
     Scope *scx = NULL;
     if (scope)
@@ -125,14 +119,24 @@ void EnumDeclaration::semantic(Scope *sc)
         scope = NULL;
     }
 
-    unsigned dprogress_save = Module::dprogress;
+    parent = sc->parent;
+    type = type->semantic(loc, sc);
 
+    protection = sc->protection;
     if (sc->stc & STCdeprecated)
         isdeprecated = true;
     userAttribDecl = sc->userAttribDecl;
 
-    parent = sc->parent;
-    protection = sc->protection;
+    semanticRun = PASSsemantic;
+
+    if (!members && !memtype)               // enum ident;
+    {
+        semanticRun = PASSsemanticdone;
+        return;
+    }
+
+    if (!symtab)
+        symtab = new DsymbolTable();
 
     /* The separate, and distinct, cases are:
      *  1. enum { ... }
@@ -142,8 +146,6 @@ void EnumDeclaration::semantic(Scope *sc)
      *  5. enum ident : memtype;
      *  6. enum ident;
      */
-
-    type = type->semantic(loc, sc);
 
     if (memtype)
     {
@@ -244,8 +246,10 @@ void EnumDeclaration::semantic(Scope *sc)
             }
         }
         else
+        {
             // Otherwise enum members are in the EnumDeclaration's symbol table
             scopesym = this;
+        }
 
         for (size_t i = 0; i < members->dim; i++)
         {

--- a/test/runnable/testenum.d
+++ b/test/runnable/testenum.d
@@ -412,6 +412,21 @@ void test8()
 }
 
 /**********************************************/
+// 13220
+
+enum E13220a;
+@(1) enum E13220b;
+
+void test13220()
+{
+    auto prot = __traits(getProtection, E13220a);
+    assert(prot == "public");
+
+    auto udas = __traits(getAttributes, E13220b);
+    assert(udas[0] == 1);
+}
+
+/**********************************************/
 
 int main()
 {
@@ -425,6 +440,7 @@ int main()
     test10113();
     test10561();
     test8();
+    test13220();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13200

(Sorry, I had mistaken the base branch name, so I open a new fix with the correct branch name. The content is just identical with #4178.)

Set `parent`, `protection`, `isdeprecated`, and `userAttribDecl` members of `EnumDeclaration` as same as class and struct declarations, even if its definition is opaque.
