### PR TITLE
Issue 13787 - Error without line number when slicing function pointer

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9989,14 +9989,13 @@ Lagain:
         if (t->ty == Ttuple) sc2 = sc2->endCTFE();
         upr = upr->implicitCastTo(sc2, Type::tsize_t);
     }
+    if (sc2 != sc)
+        sc2->pop();
     if (lwr && lwr->type == Type::terror ||
         upr && upr->type == Type::terror)
     {
         goto Lerr;
     }
-
-    if (sc2 != sc)
-        sc2->pop();
     }
 
     if (t->ty == Ttuple)
@@ -10549,16 +10548,15 @@ Expression *IndexExp::semantic(Scope *sc)
     e2 = e2->semantic(sc);
     e2 = resolveProperties(sc, e2);
     if (t1->ty == Ttuple) sc = sc->endCTFE();
-    if (e2->type == Type::terror)
-        return new ErrorExp();
     if (e2->type->ty == Ttuple && ((TupleExp *)e2)->exps &&
         ((TupleExp *)e2)->exps->dim == 1) // bug 4444 fix
     {
         e2 = (*((TupleExp *)e2)->exps)[0];
     }
-
     if (t1->ty == Tsarray || t1->ty == Tarray || t1->ty == Ttuple)
         sc = sc->pop();
+    if (e2->type == Type::terror)
+        return new ErrorExp();
 
     switch (t1->ty)
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -9892,6 +9892,11 @@ Lagain:
     AggregateDeclaration *ad = isAggregate(t1b);
     if (t1b->ty == Tpointer)
     {
+        if (((TypePointer *)t1b)->next->ty == Tfunction)
+        {
+            error("cannot slice function pointer %s", e1->toChars());
+            return new ErrorExp();
+        }
         if (!lwr || !upr)
         {
             error("need upper and lower bound to slice pointer");
@@ -10562,6 +10567,11 @@ Expression *IndexExp::semantic(Scope *sc)
     switch (t1b->ty)
     {
         case Tpointer:
+            if (((TypePointer *)t1b)->next->ty == Tfunction)
+            {
+                error("cannot index function pointer %s", e1->toChars());
+                return new ErrorExp();
+            }
             e2 = e2->implicitCastTo(sc, Type::tsize_t);
             if (e2->type == Type::terror)
                 return new ErrorExp();

--- a/test/fail_compilation/diag13787.d
+++ b/test/fail_compilation/diag13787.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag13787.d(12): Error: cannot slice function pointer & main
+fail_compilation/diag13787.d(13): Error: cannot index function pointer & main
+---
+*/
+
+void main()
+{
+    auto a = (&main)[0..1];
+    auto x = (&main)[0];
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13787

While fixing the diagnostic bug, I found an unlisted issue in both `semantic` functions of `SliceExp` and `IndexExp`. See the first commit.

Then I've improved maintainability of those `semantic` functions by refactoring. See the following three commits.

Finally I fixed issue 13787 by disallowing a slicing and indexing of function pointer.
