### PR TITLE
[Refactoring] Fix incorrect wording 'arg' 'argument' for Parameter objects

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -115,8 +115,8 @@ FuncDeclaration *hasIdentityOpAssign(AggregateDeclaration *ad, Scope *sc)
             Parameters *fparams = f->getParameters(&varargs);
             if (fparams->dim >= 1)
             {
-                Parameter *arg0 = Parameter::getNth(fparams, 0);
-                if (arg0->type->toDsymbol(NULL) != ad)
+                Parameter *fparam0 = Parameter::getNth(fparams, 0);
+                if (fparam0->type->toDsymbol(NULL) != ad)
                     f = NULL;
             }
         }

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -492,21 +492,23 @@ class CppMangleVisitor : public Visitor
         }
     }
 
-    static int argsCppMangleDg(void *ctx, size_t n, Parameter *arg)
+    static int paramsCppMangleDg(void *ctx, size_t n, Parameter *fparam)
     {
         CppMangleVisitor *mangler = (CppMangleVisitor *)ctx;
 
-        Type *t = arg->type->merge2();
-        if (arg->storageClass & (STCout | STCref))
+        Type *t = fparam->type->merge2();
+        if (fparam->storageClass & (STCout | STCref))
             t = t->referenceTo();
-        else if (arg->storageClass & STClazy)
-        {   // Mangle as delegate
+        else if (fparam->storageClass & STClazy)
+        {
+            // Mangle as delegate
             Type *td = new TypeFunction(NULL, t, 0, LINKd);
             td = new TypeDelegate(td);
             t = t->merge();
         }
         if (t->ty == Tsarray)
-        {   // Mangle static arrays as pointers
+        {
+            // Mangle static arrays as pointers
             t->error(Loc(), "ICE: Unable to pass static array to extern(C++) function.");
             t->error(Loc(), "Use pointer instead.");
             assert(0);
@@ -525,15 +527,15 @@ class CppMangleVisitor : public Visitor
         return 0;
     }
 
-    void argsCppMangle(Parameters *arguments, int varargs)
+    void argsCppMangle(Parameters *parameters, int varargs)
     {
-        if (arguments)
-            Parameter::foreach(arguments, &argsCppMangleDg, (void*)this);
+        if (parameters)
+            Parameter::foreach(parameters, &paramsCppMangleDg, (void*)this);
 
         if (varargs)
             buf.writestring("z");
-        else if (!arguments || !arguments->dim)
-            buf.writeByte('v');            // encode ( ) arguments
+        else if (!parameters || !parameters->dim)
+            buf.writeByte('v');            // encode ( ) parameters
     }
 
 public:

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -856,7 +856,7 @@ public:
 class NewDeclaration : public FuncDeclaration
 {
 public:
-    Parameters *arguments;
+    Parameters *parameters;
     int varargs;
 
     NewDeclaration(Loc loc, Loc endloc, StorageClass stc, Parameters *arguments, int varargs);
@@ -875,7 +875,7 @@ public:
 class DeleteDeclaration : public FuncDeclaration
 {
 public:
-    Parameters *arguments;
+    Parameters *parameters;
 
     DeleteDeclaration(Loc loc, Loc endloc, StorageClass stc, Parameters *arguments);
     Dsymbol *syntaxCopy(Dsymbol *);

--- a/src/doc.c
+++ b/src/doc.c
@@ -1603,7 +1603,7 @@ void ParamSection::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
     size_t textlen = 0;
 
     size_t o, paramcount = 0;
-    Parameter *arg = NULL;
+    Parameter *fparam = NULL;
 
     buf->writestring("$(DDOC_PARAMS ");
     while (p < pend)
@@ -1661,15 +1661,15 @@ void ParamSection::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
             buf->writestring("$(DDOC_PARAM_ROW ");
                 buf->writestring("$(DDOC_PARAM_ID ");
                     o = buf->offset;
-                    arg = isFunctionParameter(s, namestart, namelen);
+                    fparam = isFunctionParameter(s, namestart, namelen);
                     bool isCVariadic = isCVariadicParameter(s, namestart, namelen);
                     if (isCVariadic)
                     {
                         buf->writestring("...");
                     }
-                    else if (arg && arg->type && arg->ident)
+                    else if (fparam && fparam->type && fparam->ident)
                     {
-                        ::toCBuffer(arg->type, buf, arg->ident, &hgs);
+                        ::toCBuffer(fparam->type, buf, fparam->ident, &hgs);
                     }
                     else
                     {
@@ -1678,7 +1678,7 @@ void ParamSection::write(DocComment *dc, Scope *sc, Dsymbol *s, OutBuffer *buf)
                             // 10236: Don't count template parameters for params check
                             --paramcount;
                         }
-                        else if (!arg)
+                        else if (!fparam)
                         {
                             warning(s->loc, "Ddoc: function declaration has no parameter '%.*s'", namelen, namestart);
                         }
@@ -2142,10 +2142,10 @@ Parameter *isFunctionParameter(Dsymbol *s, const utf8_t *p, size_t len)
     {
         for (size_t k = 0; k < tf->parameters->dim; k++)
         {
-            Parameter *arg = (*tf->parameters)[k];
-            if (arg->ident && cmp(arg->ident->toChars(), p, len) == 0)
+            Parameter *fparam = (*tf->parameters)[k];
+            if (fparam->ident && cmp(fparam->ident->toChars(), p, len) == 0)
             {
-                return arg;
+                return fparam;
             }
         }
     }
@@ -2162,10 +2162,10 @@ TemplateParameter *isTemplateParameter(Dsymbol *s, const utf8_t *p, size_t len)
     {
         for (size_t k = 0; k < td->origParameters->dim; k++)
         {
-            TemplateParameter *arg = (*td->origParameters)[k];
-            if (arg->ident && cmp(arg->ident->toChars(), p, len) == 0)
+            TemplateParameter *tp = (*td->origParameters)[k];
+            if (tp->ident && cmp(tp->ident->toChars(), p, len) == 0)
             {
-                return arg;
+                return tp;
             }
         }
     }

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1251,12 +1251,12 @@ FuncDeclaration *ScopeDsymbol::findGetMembers()
     if (!tfgetmembers)
     {
         Scope sc;
-        Parameters *arguments = new Parameters;
-        Parameters *arg = new Parameter(STCin, Type::tchar->constOf()->arrayOf(), NULL, NULL);
-        arguments->push(arg);
+        Parameters *parameters = new Parameters;
+        Parameters *p = new Parameter(STCin, Type::tchar->constOf()->arrayOf(), NULL, NULL);
+        parameters->push(p);
 
         Type *tret = NULL;
-        tfgetmembers = new TypeFunction(arguments, tret, 0, LINKd);
+        tfgetmembers = new TypeFunction(parameters, tret, 0, LINKd);
         tfgetmembers = (TypeFunction *)tfgetmembers->semantic(Loc(), &sc);
     }
     if (fdx)

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -249,16 +249,16 @@ public:
     {
         buf->writestring(Token::toChars(s->op));
         buf->writestring(" (");
-        for (size_t i = 0; i < s->arguments->dim; i++)
+        for (size_t i = 0; i < s->parameters->dim; i++)
         {
-            Parameter *a = (*s->arguments)[i];
+            Parameter *p = (*s->parameters)[i];
             if (i)
                 buf->writestring(", ");
-            StorageClassDeclaration::stcToCBuffer(buf, a->storageClass);
-            if (a->type)
-                typeToBuffer(a->type, a->ident);
+            StorageClassDeclaration::stcToCBuffer(buf, p->storageClass);
+            if (p->type)
+                typeToBuffer(p->type, p->ident);
             else
-                buf->writestring(a->ident->toChars());
+                buf->writestring(p->ident->toChars());
         }
         buf->writestring("; ");
         s->aggr->accept(this);
@@ -279,10 +279,10 @@ public:
         buf->writestring(Token::toChars(s->op));
         buf->writestring(" (");
 
-        if (s->arg->type)
-            typeToBuffer(s->arg->type, s->arg->ident);
+        if (s->prm->type)
+            typeToBuffer(s->prm->type, s->prm->ident);
         else
-            buf->writestring(s->arg->ident->toChars());
+            buf->writestring(s->prm->ident->toChars());
 
         buf->writestring("; ");
         s->lwr->accept(this);
@@ -303,16 +303,16 @@ public:
     void visit(IfStatement *s)
     {
         buf->writestring("if (");
-        if (Parameter *a = s->arg)
+        if (Parameter *p = s->prm)
         {
-            StorageClass stc = a->storageClass;
-            if (!a->type && !stc)
+            StorageClass stc = p->storageClass;
+            if (!p->type && !stc)
                 stc = STCauto;
             StorageClassDeclaration::stcToCBuffer(buf, stc);
-            if (a->type)
-                typeToBuffer(a->type, a->ident);
+            if (p->type)
+                typeToBuffer(p->type, p->ident);
             else
-                buf->writestring(a->ident->toChars());
+                buf->writestring(p->ident->toChars());
             buf->writestring(" = ");
         }
         s->condition->accept(this);
@@ -1874,7 +1874,7 @@ public:
     {
         StorageClassDeclaration::stcToCBuffer(buf, d->storage_class & ~STCstatic);
         buf->writestring("new");
-        parametersToBuffer(d->arguments, d->varargs);
+        parametersToBuffer(d->parameters, d->varargs);
         bodyToBuffer(d);
     }
 
@@ -1882,7 +1882,7 @@ public:
     {
         StorageClassDeclaration::stcToCBuffer(buf, d->storage_class & ~STCstatic);
         buf->writestring("delete");
-        parametersToBuffer(d->arguments, 0);
+        parametersToBuffer(d->parameters, 0);
         bodyToBuffer(d);
     }
 

--- a/src/init.c
+++ b/src/init.c
@@ -262,8 +262,8 @@ Initializer *StructInitializer::semantic(Scope *sc, Type *t, NeedInterpret needI
         TOK tok = (t->ty == Tdelegate) ? TOKdelegate : TOKfunction;
         /* Rewrite as empty delegate literal { }
          */
-        Parameters *arguments = new Parameters;
-        Type *tf = new TypeFunction(arguments, NULL, 0, LINKd);
+        Parameters *parameters = new Parameters;
+        Type *tf = new TypeFunction(parameters, NULL, 0, LINKd);
         FuncLiteralDeclaration *fd = new FuncLiteralDeclaration(loc, Loc(), tf, tok, NULL);
         fd->fbody = new CompoundStatement(loc, new Statements());
         fd->endloc = loc;

--- a/src/inline.c
+++ b/src/inline.c
@@ -138,7 +138,7 @@ public:
         /* Can't declare variables inside ?: expressions, so
          * we cannot inline if a variable is declared.
          */
-        if (s->arg)
+        if (s->prm)
         {
             cost = COST_MAX;
             return;
@@ -479,7 +479,7 @@ Statement *inlineAsStatement(Statement *s, InlineDoState *ids)
 
         void visit(IfStatement *s)
         {
-            assert(!s->arg);
+            assert(!s->prm);
 
             Expression *condition = s->condition ? doInline(s->condition, ids) : NULL;
             Statement *ifbody = s->ifbody ? inlineAsStatement(s->ifbody, ids) : NULL;
@@ -488,7 +488,7 @@ Statement *inlineAsStatement(Statement *s, InlineDoState *ids)
             Statement *elsebody = s->elsebody ? inlineAsStatement(s->elsebody, ids) : NULL;
             ids->foundReturn = ids->foundReturn && bodyReturn;
 
-            result = new IfStatement(s->loc, s->arg, condition, ifbody, elsebody);
+            result = new IfStatement(s->loc, s->prm, condition, ifbody, elsebody);
         }
 
         void visit(ReturnStatement *s)
@@ -597,7 +597,7 @@ Expression *doInline(Statement *s, InlineDoState *ids)
 
         void visit(IfStatement *s)
         {
-            assert(!s->arg);
+            assert(!s->prm);
             Expression *econd = doInline(s->condition, ids);
             assert(econd);
             Expression *e1 = s->ifbody ? doInline(s->ifbody, ids) : NULL;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -6544,8 +6544,8 @@ Expression *interpret_aaApply(InterState *istate, Expression *aa, Expression *de
     size_t numParams = fd->parameters->dim;
     assert(numParams == 1 || numParams == 2);
 
-    Parameter *valueArg = Parameter::getNth(((TypeFunction *)fd->type)->parameters, numParams - 1);
-    bool wantRefValue = 0 != (valueArg->storageClass & (STCout | STCref));
+    Parameter *fparam = Parameter::getNth(((TypeFunction *)fd->type)->parameters, numParams - 1);
+    bool wantRefValue = 0 != (fparam->storageClass & (STCout | STCref));
 
     Expressions args;
     args.setDim(numParams);

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -257,7 +257,7 @@ public:
         }
 
         // Write argument types
-        argsToDecoBuffer(t->parameters);
+        paramsToDecoBuffer(t->parameters);
         //if (buf->data[buf->offset - 1] == '@') halt();
         buf->writeByte('Z' - t->varargs);   // mark end of arg list
         if (tret != NULL)
@@ -302,7 +302,7 @@ public:
         OutBuffer buf2;
         buf2.reserve(32);
         Mangler v(&buf2);
-        v.argsToDecoBuffer(t->arguments);
+        v.paramsToDecoBuffer(t->arguments);
         int len = (int)buf2.offset;
         buf->printf("%d%.*s", len, len, buf2.extractData());
     }
@@ -810,15 +810,15 @@ public:
 
     ////////////////////////////////////////////////////////////////////////////
 
-    void argsToDecoBuffer(Parameters *arguments)
+    void paramsToDecoBuffer(Parameters *parameters)
     {
-        //printf("Parameter::argsToDecoBuffer()\n");
-        Parameter::foreach(arguments, &argsToDecoBufferDg, (void *)this);
+        //printf("Parameter::paramsToDecoBuffer()\n");
+        Parameter::foreach(parameters, &paramsToDecoBufferDg, (void *)this);
     }
 
-    static int argsToDecoBufferDg(void *ctx, size_t n, Parameter *arg)
+    static int paramsToDecoBufferDg(void *ctx, size_t n, Parameter *p)
     {
-        arg->accept((Visitor *)ctx);
+        p->accept((Visitor *)ctx);
         return 0;
     }
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -943,13 +943,13 @@ public:
     int dyncast() { return DYNCAST_PARAMETER; }
     virtual void accept(Visitor *v) { v->visit(this); }
 
-    static Parameters *arraySyntaxCopy(Parameters *args);
-    static int isTPL(Parameters *arguments);
-    static size_t dim(Parameters *arguments);
-    static Parameter *getNth(Parameters *arguments, size_t nth, size_t *pn = NULL);
+    static Parameters *arraySyntaxCopy(Parameters *parameters);
+    static int isTPL(Parameters *parameters);
+    static size_t dim(Parameters *parameters);
+    static Parameter *getNth(Parameters *parameters, size_t nth, size_t *pn = NULL);
 
     typedef int (*ForeachDg)(void *ctx, size_t paramidx, Parameter *param);
-    static int foreach(Parameters *args, ForeachDg dg, void *ctx, size_t *pn=NULL);
+    static int foreach(Parameters *parameters, ForeachDg dg, void *ctx, size_t *pn=NULL);
 };
 
 int arrayTypeCompatible(Loc loc, Type *t1, Type *t2);

--- a/src/statement.h
+++ b/src/statement.h
@@ -304,8 +304,8 @@ public:
 class ForeachStatement : public Statement
 {
 public:
-    TOK op;                // TOKforeach or TOKforeach_reverse
-    Parameters *arguments;      // array of Parameter*'s
+    TOK op;                     // TOKforeach or TOKforeach_reverse
+    Parameters *parameters;     // array of Parameter*'s
     Expression *aggr;
     Statement *body;
 
@@ -317,7 +317,7 @@ public:
     Statements *cases;          // put breaks, continues, gotos and returns here
     ScopeStatements *gotos;     // forward referenced goto's go here
 
-    ForeachStatement(Loc loc, TOK op, Parameters *arguments, Expression *aggr, Statement *body);
+    ForeachStatement(Loc loc, TOK op, Parameters *parameters, Expression *aggr, Statement *body);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     bool checkForArgTypes();
@@ -330,15 +330,15 @@ public:
 class ForeachRangeStatement : public Statement
 {
 public:
-    TOK op;                // TOKforeach or TOKforeach_reverse
-    Parameter *arg;             // loop index variable
+    TOK op;                     // TOKforeach or TOKforeach_reverse
+    Parameter *prm;             // loop index variable
     Expression *lwr;
     Expression *upr;
     Statement *body;
 
     VarDeclaration *key;
 
-    ForeachRangeStatement(Loc loc, TOK op, Parameter *arg,
+    ForeachRangeStatement(Loc loc, TOK op, Parameter *prm,
         Expression *lwr, Expression *upr, Statement *body);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
@@ -351,14 +351,14 @@ public:
 class IfStatement : public Statement
 {
 public:
-    Parameter *arg;
+    Parameter *prm;
     Expression *condition;
     Statement *ifbody;
     Statement *elsebody;
 
     VarDeclaration *match;      // for MatchExpression results
 
-    IfStatement(Loc loc, Parameter *arg, Expression *condition, Statement *ifbody, Statement *elsebody);
+    IfStatement(Loc loc, Parameter *prm, Expression *condition, Statement *ifbody, Statement *elsebody);
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
     IfStatement *isIfStatement() { return this; }

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -82,12 +82,13 @@ public:
 
         for (size_t i = 0; i < nparams; i++)
         {
-            Parameter *arg = Parameter::getNth(t->parameters, i);
-            type *tp = Type_toCtype(arg->type);
-            if (arg->storageClass & (STCout | STCref))
+            Parameter *p = Parameter::getNth(t->parameters, i);
+            type *tp = Type_toCtype(p->type);
+            if (p->storageClass & (STCout | STCref))
                 tp = type_allocn(TYref, tp);
-            else if (arg->storageClass & STClazy)
-            {   // Mangle as delegate
+            else if (p->storageClass & STClazy)
+            {
+                // Mangle as delegate
                 type *tf = type_function(TYnfunc, NULL, 0, false, tp);
                 tp = type_delegate(tf);
             }


### PR DESCRIPTION
From the @WalterBright 's comment: https://github.com/D-Programming-Language/dmd/pull/4165#issuecomment-64509292

An exception is the around of TypeTuple. It stores types and expressions
merely using Parameter. So the wording 'arg' is not incorrect at least.
