### PR TITLE
Add a new compiler switch -verrors=num to control error report limit

### DIFF
--- a/src/errors.c
+++ b/src/errors.c
@@ -188,12 +188,12 @@ void verrorPrint(Loc loc, COLOR headerColor, const char *header, const char *for
 void verror(Loc loc, const char *format, va_list ap,
                 const char *p1, const char *p2, const char *header)
 {
+    global.errors++;
     if (!global.gag)
     {
         verrorPrint(loc, COLOR_RED, header, format, ap, p1, p2);
-        if (global.errors >= 20)        // moderate blizzard of cascading messages
-                fatal();
-//halt();
+        if (global.errorLimit && global.errors >= global.errorLimit)
+            fatal();    // moderate blizzard of cascading messages
     }
     else
     {
@@ -201,7 +201,6 @@ void verror(Loc loc, const char *format, va_list ap,
         //verrorPrint(loc, COLOR_RED, header, format, ap, p1, p2);
         global.gaggedErrors++;
     }
-    global.errors++;
 }
 
 // Doesn't increase error count, doesn't print "Error:".

--- a/src/mars.c
+++ b/src/mars.c
@@ -135,6 +135,8 @@ void Global::init()
     main_d = "__main.d";
 
     memset(&params, 0, sizeof(Param));
+
+    errorLimit = 20;
 }
 
 unsigned Global::startGagging()
@@ -313,6 +315,7 @@ Usage:\n\
   -version=ident compile in version code identified by ident\n\
   -vtls          list all variables going into thread local storage\n\
   -vgc           list all gc allocations including hidden ones\n\
+  -verrors=num   limit the number of error messages (0 means unlimited)\n\
   -w             warnings as errors (compilation will halt)\n\
   -wi            warnings as messages (compilation will continue)\n\
   -X             generate JSON file\n\
@@ -633,6 +636,21 @@ int tryMain(size_t argc, const char *argv[])
                 global.params.showColumns = true;
             else if (strcmp(p + 1, "vgc") == 0)
                 global.params.vgc = true;
+            else if (memcmp(p + 1, "verrors", 7) == 0)
+            {
+                if (p[8] == '=' && isdigit((utf8_t)p[9]))
+                {
+                    long num;
+                    errno = 0;
+                    num = strtol(p + 9, (char **)&p, 10);
+                    if (*p || errno || num > INT_MAX)
+                        goto Lerror;
+                    // Bugzilla issue number
+                    global.errorLimit = (unsigned) num;
+                }
+                else
+                    goto Lerror;
+            }
             else if (memcmp(p + 1, "transition", 10) == 0)
             {
                 // Parse:

--- a/src/mars.c
+++ b/src/mars.c
@@ -315,7 +315,6 @@ Usage:\n\
   -version=ident compile in version code identified by ident\n\
   -vtls          list all variables going into thread local storage\n\
   -vgc           list all gc allocations including hidden ones\n\
-  -verrors=num   limit the number of error messages (0 means unlimited)\n\
   -w             warnings as errors (compilation will halt)\n\
   -wi            warnings as messages (compilation will continue)\n\
   -X             generate JSON file\n\

--- a/src/mars.h
+++ b/src/mars.h
@@ -233,6 +233,8 @@ struct Global
     unsigned gag;          // !=0 means gag reporting of errors & warnings
     unsigned gaggedErrors; // number of errors reported while gagged
 
+    unsigned errorLimit;
+
     /* Start gagging. Return the current number of gagged errors
      */
     unsigned startGagging();

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -464,7 +464,7 @@ int main(string[] args)
 
     auto f = File(output_file, "a");
 
-    foreach(i, c; combinations(testArgs.permuteArgs))
+    foreach (i, c; combinations(testArgs.permuteArgs))
     {
         string test_app_dmd = test_app_dmd_base ~ to!string(i) ~ envData.exe;
 
@@ -482,6 +482,11 @@ int main(string[] args)
                 removeIfExists(thisRunName);
             }
 
+            // can override -verrors by using REQUIRED_ARGS
+            auto reqArgs =
+                (testArgs.mode == TestMode.FAIL_COMPILE ? "-verrors=0 " : null) ~
+                testArgs.requiredArgs;
+
             string compile_output;
             if (!testArgs.compileSeparately)
             {
@@ -489,7 +494,7 @@ int main(string[] args)
                 toCleanup ~= objfile;
 
                 string command = format("%s -m%s -I%s %s %s -od%s -of%s %s%s", envData.dmd, envData.model, input_dir,
-                        testArgs.requiredArgs, c, output_dir,
+                        reqArgs, c, output_dir,
                         (testArgs.mode == TestMode.RUN ? test_app_dmd : objfile),
                         (testArgs.mode == TestMode.RUN ? "" : "-c "),
                         join(testArgs.sources, " "));
@@ -505,7 +510,7 @@ int main(string[] args)
                     toCleanup ~= newo;
 
                     string command = format("%s -m%s -I%s %s %s -od%s -c %s", envData.dmd, envData.model, input_dir,
-                        testArgs.requiredArgs, c, output_dir, filename);
+                        reqArgs, c, output_dir, filename);
                     compile_output ~= execute(fThisRun, command, testArgs.mode != TestMode.FAIL_COMPILE, result_path);
                 }
 

--- a/test/fail_compilation/diag1730.d
+++ b/test/fail_compilation/diag1730.d
@@ -22,6 +22,7 @@ fail_compilation/diag1730.d(83): Error: non-shared mutable method diag1730.S.fun
 fail_compilation/diag1730.d(84): Error: non-shared const method diag1730.S.cFunc is not callable using a shared const object
 fail_compilation/diag1730.d(85): Error: immutable method diag1730.S.iFunc is not callable using a shared const object
 fail_compilation/diag1730.d(86): Error: shared mutable method diag1730.S.sFunc is not callable using a shared const object
+fail_compilation/diag1730.d(88): Error: non-shared inout method diag1730.S.wFunc is not callable using a shared const object
 ---
 */
 struct S
@@ -32,7 +33,6 @@ struct S
     void sFunc() shared { }
     void scFunc() shared const { }
     void wFunc() inout { }
-
     static void test(inout(S) s)
     {
         s.func();   // ng

--- a/test/fail_compilation/verrors0.d
+++ b/test/fail_compilation/verrors0.d
@@ -1,0 +1,60 @@
+// REQUIRED_ARGS: -verrors=0
+
+void main()
+{
+    { T a; }    // 1
+    { T a; }    // 2
+    { T a; }    // 3
+    { T a; }    // 4
+    { T a; }    // 5
+    { T a; }    // 6
+    { T a; }    // 7
+    { T a; }    // 8
+    { T a; }    // 9
+    { T a; }    // 10
+    { T a; }    // 11
+    { T a; }    // 12
+    { T a; }    // 13
+    { T a; }    // 14
+    { T a; }    // 15
+    { T a; }    // 16
+    { T a; }    // 17
+    { T a; }    // 18
+    { T a; }    // 19
+    { T a; }    // 20 (default limit)
+    { T a; }    // 21
+    { T a; }    // 22
+    { T a; }    // 23
+    { T a; }    // 24
+    { T a; }    // 25
+}
+/*
+TEST_OUTPUT:
+---
+fail_compilation/verrors0.d(5): Error: undefined identifier T
+fail_compilation/verrors0.d(6): Error: undefined identifier T
+fail_compilation/verrors0.d(7): Error: undefined identifier T
+fail_compilation/verrors0.d(8): Error: undefined identifier T
+fail_compilation/verrors0.d(9): Error: undefined identifier T
+fail_compilation/verrors0.d(10): Error: undefined identifier T
+fail_compilation/verrors0.d(11): Error: undefined identifier T
+fail_compilation/verrors0.d(12): Error: undefined identifier T
+fail_compilation/verrors0.d(13): Error: undefined identifier T
+fail_compilation/verrors0.d(14): Error: undefined identifier T
+fail_compilation/verrors0.d(15): Error: undefined identifier T
+fail_compilation/verrors0.d(16): Error: undefined identifier T
+fail_compilation/verrors0.d(17): Error: undefined identifier T
+fail_compilation/verrors0.d(18): Error: undefined identifier T
+fail_compilation/verrors0.d(19): Error: undefined identifier T
+fail_compilation/verrors0.d(20): Error: undefined identifier T
+fail_compilation/verrors0.d(21): Error: undefined identifier T
+fail_compilation/verrors0.d(22): Error: undefined identifier T
+fail_compilation/verrors0.d(23): Error: undefined identifier T
+fail_compilation/verrors0.d(24): Error: undefined identifier T
+fail_compilation/verrors0.d(25): Error: undefined identifier T
+fail_compilation/verrors0.d(26): Error: undefined identifier T
+fail_compilation/verrors0.d(27): Error: undefined identifier T
+fail_compilation/verrors0.d(28): Error: undefined identifier T
+fail_compilation/verrors0.d(29): Error: undefined identifier T
+---
+*/

--- a/test/fail_compilation/verrors5.d
+++ b/test/fail_compilation/verrors5.d
@@ -1,0 +1,40 @@
+// REQUIRED_ARGS: -verrors=5
+
+void main()
+{
+    { T a; }    // 1
+    { T a; }    // 2
+    { T a; }    // 3
+    { T a; }    // 4
+    { T a; }    // 5
+    { T a; }    // 6
+    { T a; }    // 7
+    { T a; }    // 8
+    { T a; }    // 9
+    { T a; }    // 10
+    { T a; }    // 11
+    { T a; }    // 12
+    { T a; }    // 13
+    { T a; }    // 14
+    { T a; }    // 15
+    { T a; }    // 16
+    { T a; }    // 17
+    { T a; }    // 18
+    { T a; }    // 19
+    { T a; }    // 20 (default limit)
+    { T a; }    // 21
+    { T a; }    // 22
+    { T a; }    // 23
+    { T a; }    // 24
+    { T a; }    // 25
+}
+/*
+TEST_OUTPUT:
+---
+fail_compilation/verrors5.d(5): Error: undefined identifier T
+fail_compilation/verrors5.d(6): Error: undefined identifier T
+fail_compilation/verrors5.d(7): Error: undefined identifier T
+fail_compilation/verrors5.d(8): Error: undefined identifier T
+fail_compilation/verrors5.d(9): Error: undefined identifier T
+---
+*/


### PR DESCRIPTION
Unlimited error report (`-verrors=0`) is useful for the fail_compilation tests.
