### PR TITLE
fix Issue 13774 - Multiple definition of ...

### DIFF
--- a/src/scanomf.c
+++ b/src/scanomf.c
@@ -248,7 +248,7 @@ void scanOmfObjModule(void* pctx, void (*pAddSymbol)(void* pctx, const char* nam
                     parseName(&p, name);
                     parseIdx(&p);               // type index
                     skipDataType(&p);           // data type
-                    (*pAddSymbol)(pctx, name, 0);
+                    (*pAddSymbol)(pctx, name, 1);
                 }
                 break;
             }
@@ -423,5 +423,3 @@ void writeOMFObj(OutBuffer *buf, const void *base, unsigned length, const char *
     }
     buf->write(base, length);
 }
-
-


### PR DESCRIPTION
- COMDEF symbols should set pickAny when being added to a library

[Issue 13774](https://issues.dlang.org/show_bug.cgi?id=13774)
