### PR TITLE
add coverage tests for lexer.c

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -162,10 +162,13 @@ const char *Token::toChars()
                     case '\\':
                         buf.writeByte('\\');
                     default:
-                        if (isprint(c))
-                            buf.writeByte(c);
-                        else if (c <= 0x7F)
-                            buf.printf("\\x%02x", c);
+                        if (c <= 0x7F)
+                        {
+                            if (isprint(c))
+                                buf.writeByte(c);
+                            else
+                                buf.printf("\\x%02x", c);
+                        }
                         else if (c <= 0xFFFF)
                             buf.printf("\\u%04x", c);
                         else
@@ -1263,9 +1266,9 @@ unsigned Lexer::escapeSequence()
 
                         default:
                             if (isalpha(*p) ||
-                                (p != idstart + 1 && isdigit(*p)))
+                                (p != idstart && isdigit(*p)))
                                 continue;
-                            error("unterminated named entity");
+                            error("unterminated named entity &%.*s;", (int)(p - idstart + 1), idstart);
                             break;
                     }
                     break;
@@ -1290,7 +1293,7 @@ unsigned Lexer::escapeSequence()
                     } while (++n < 3 && isoctal((utf8_t)c));
                     c = v;
                     if (c > 0xFF)
-                        error("0%03o is larger than a byte", c);
+                        error("escape octal sequence \\%03o is larger than \\377", c);
                 }
                 else
                     error("undefined escape sequence \\%c",c);
@@ -1429,10 +1432,10 @@ TOK Lexer::hexStringConstant(Token *t)
                     if (u == PS || u == LS)
                         endOfLine();
                     else
-                        error("non-hex character \\u%04x", u);
+                        error("non-hex character \\u%04x in hex string", u);
                 }
                 else
-                    error("non-hex character '%c'", c);
+                    error("non-hex character '%c' in hex string", c);
                 if (n & 1)
                 {   v = (v << 4) | c;
                     stringbuffer.writeByte(v);
@@ -1501,7 +1504,11 @@ TOK Lexer::delimitedStringConstant(Token *t)
 
             case 0:
             case 0x1A:
-                goto Lerror;
+                error("unterminated delimited string constant starting at %s", start.toChars());
+                t->ustring = (utf8_t *)"";
+                t->len = 0;
+                t->postfix = 0;
+                return TOKstring;
 
             default:
                 if (c & 0x80)
@@ -1598,13 +1605,6 @@ Ldone:
     memcpy(t->ustring, stringbuffer.data, stringbuffer.offset);
     stringPostfix(t);
     return TOKstring;
-
-Lerror:
-    error("unterminated string constant starting at %s", start.toChars());
-    t->ustring = (utf8_t *)"";
-    t->len = 0;
-    t->postfix = 0;
-    return TOKstring;
 }
 
 /**************************************
@@ -1634,31 +1634,27 @@ TOK Lexer::tokenStringConstant(Token *t)
 
             case TOKrcurly:
                 if (--nest == 0)
-                    goto Ldone;
+                {
+                    t->len = (unsigned)(p - 1 - pstart);
+                    t->ustring = (utf8_t *)mem.malloc(t->len + 1);
+                    memcpy(t->ustring, pstart, t->len);
+                    t->ustring[t->len] = 0;
+                    stringPostfix(t);
+                    return TOKstring;
+                }
                 continue;
 
             case TOKeof:
-                goto Lerror;
+                error("unterminated token string constant starting at %s", start.toChars());
+                t->ustring = (utf8_t *)"";
+                t->len = 0;
+                t->postfix = 0;
+                return TOKstring;
 
             default:
                 continue;
         }
     }
-
-Ldone:
-    t->len = (unsigned)(p - 1 - pstart);
-    t->ustring = (utf8_t *)mem.malloc(t->len + 1);
-    memcpy(t->ustring, pstart, t->len);
-    t->ustring[t->len] = 0;
-    stringPostfix(t);
-    return TOKstring;
-
-Lerror:
-    error("unterminated token string constant starting at %s", start.toChars());
-    t->ustring = (utf8_t *)"";
-    t->len = 0;
-    t->postfix = 0;
-    return TOKstring;
 }
 
 
@@ -1780,6 +1776,7 @@ TOK Lexer::charConstant(Token *t, int wide)
         case 0x1A:
         case '\'':
             error("unterminated character constant");
+            t->uns64value = '?';
             return tk;
 
         default:
@@ -1800,7 +1797,9 @@ TOK Lexer::charConstant(Token *t, int wide)
     }
 
     if (*p != '\'')
-    {   error("unterminated character constant");
+    {
+        error("unterminated character constant");
+        t->uns64value = '?';
         return tk;
     }
     p++;
@@ -1927,7 +1926,7 @@ TOK Lexer::number(Token *t)
                 ++p;
                 if (base < 10 && !err)
                 {
-                    error("radix %d digit expected", base);
+                    error("radix %d digit expected, not '%c'", base, c);
                     err = true;
                 }
                 d = c - '0';
@@ -1942,7 +1941,7 @@ TOK Lexer::number(Token *t)
                         goto Lreal;
                     if (!err)
                     {
-                        error("radix %d digit expected", base);
+                        error("radix %d digit expected, not '%c'", base, c);
                         err = true;
                     }
                 }
@@ -2303,19 +2302,21 @@ TOK Lexer::inreal(Token *t)
 void Lexer::poundLine()
 {
     Token tok;
-    int linnum;
+    int linnum = this->scanloc.linnum;
     char *filespec = NULL;
     Loc loc = this->loc();
 
     scan(&tok);
     if (tok.value == TOKint32v || tok.value == TOKint64v)
-    {   linnum = (int)(tok.uns64value - 1);
-        if (linnum != tok.uns64value - 1)
-            error("line number out of range");
+    {
+        int lin = (int)(tok.uns64value - 1);
+        if (lin != tok.uns64value - 1)
+            error("line number %lld out of range", (unsigned long long)tok.uns64value);
+        else
+            linnum = lin;
     }
     else if (tok.value == TOKline)
     {
-        linnum = this->scanloc.linnum;
     }
     else
         goto Lerr;

--- a/test/fail_compilation/lexer1.d
+++ b/test/fail_compilation/lexer1.d
@@ -1,0 +1,52 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/lexer1.d(30): Error: declaration expected, not 'x"01 02 03"w'
+fail_compilation/lexer1.d(31): Error: declaration expected, not '2147483649U'
+fail_compilation/lexer1.d(32): Error: declaration expected, not '0.1'
+fail_compilation/lexer1.d(33): Error: declaration expected, not '0.1f'
+fail_compilation/lexer1.d(34): Error: declaration expected, not '0.1L'
+fail_compilation/lexer1.d(35): Error: declaration expected, not '0.1i'
+fail_compilation/lexer1.d(36): Error: declaration expected, not '0.1fi'
+fail_compilation/lexer1.d(37): Error: declaration expected, not '0.1Li'
+fail_compilation/lexer1.d(38): Error: declaration expected, not '32U'
+fail_compilation/lexer1.d(39): Error: declaration expected, not '55295U'
+fail_compilation/lexer1.d(40): Error: declaration expected, not '65536U'
+fail_compilation/lexer1.d(41): Error: declaration expected, not '"ab\\c\"\u1234a\U00011100a"d'
+fail_compilation/lexer1.d(43): Error: declaration expected, not 'module'
+fail_compilation/lexer1.d(45): Error: escape hex sequence has 1 hex digits instead of 2
+fail_compilation/lexer1.d(46): Error: undefined escape hex sequence \G
+fail_compilation/lexer1.d(47): Error: unnamed character entity &unnamedentity;
+fail_compilation/lexer1.d(48): Error: unterminated named entity &1;
+fail_compilation/lexer1.d(49): Error: unterminated named entity &*;
+fail_compilation/lexer1.d(50): Error: unterminated named entity &s1";
+fail_compilation/lexer1.d(51): Error: unterminated named entity &2;
+fail_compilation/lexer1.d(52): Error: escape octal sequence \400 is larger than \377
+---
+*/
+
+// https://dlang.dawg.eu/coverage/src/lexer.c.gcov.html
+
+x"01 02 03"w;
+0x80000001;
+0.1;
+0.1f;
+0.1L;
+0.1i;
+0.1fi;
+0.1Li;
+' ';
+'\uD7FF';
+'\U00010000';
+"ab\\c\"\u1234a\U00011100a\000ab"d;
+
+module x;
+
+static s1 = "\x1G";
+static s2 = "\xGG";
+static s3 = "\&unnamedentity;";
+static s4 = "\&1";
+static s5 = "\&*";
+static s6 = "\&s1";
+static s7 = "\&2;";
+static s7 = "\400;";

--- a/test/fail_compilation/lexer2.d
+++ b/test/fail_compilation/lexer2.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/lexer2.d(15): Error: odd number (3) of hex characters in hex string
+fail_compilation/lexer2.d(16): Error: non-hex character 'G' in hex string
+fail_compilation/lexer2.d(17): Error: identifier expected for heredoc, not 2067L
+fail_compilation/lexer2.d(19): Error: heredoc rest of line should be blank
+fail_compilation/lexer2.d(21): Error: unterminated delimited string constant starting at fail_compilation/lexer2.d(21)
+fail_compilation/lexer2.d(23): Error: semicolon expected following auto declaration, not 'EOF'
+---
+*/
+
+// https://dlang.dawg.eu/coverage/src/lexer.c.gcov.html
+
+static s1 = x"123";
+static s2 = x"123G";
+static s3 = q"__VERSION__
+ _";
+static s4 = q"here notblank
+here";
+static s5 = q"here
+";

--- a/test/fail_compilation/lexer3.d
+++ b/test/fail_compilation/lexer3.d
@@ -1,0 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/lexer3.d(9): Error: unterminated token string constant starting at fail_compilation/lexer3.d(9)
+fail_compilation/lexer3.d(10): Error: semicolon expected following auto declaration, not 'EOF'
+---
+*/
+
+static s1 = q{ asef;

--- a/test/fail_compilation/lexer4.d
+++ b/test/fail_compilation/lexer4.d
@@ -1,0 +1,43 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/lexer4.d(22): Error: unterminated character constant
+fail_compilation/lexer4.d(24): Error: unterminated character constant
+fail_compilation/lexer4.d(25): Error: unterminated character constant
+fail_compilation/lexer4.d(26): Error: binary digit expected
+fail_compilation/lexer4.d(27): Error: radix 8 digit expected, not '8'
+fail_compilation/lexer4.d(27): Error: octal literals 0130 are no longer supported, use std.conv.octal!130 instead
+fail_compilation/lexer4.d(28): Error: radix 10 digit expected, not 'a'
+fail_compilation/lexer4.d(29): Error: unrecognized token
+fail_compilation/lexer4.d(30): Error: exponent required for hex float
+fail_compilation/lexer4.d(31): Error: lower case integer suffix 'l' is not allowed. Please use 'L' instead
+fail_compilation/lexer4.d(32): Error: use 'i' suffix instead of 'I'
+fail_compilation/lexer4.d(34): Error: line number 1234567891234567879 out of range
+fail_compilation/lexer4.d(36): Error: #line integer ["filespec"]\n expected
+fail_compilation/lexer4.d(19): Error: #line integer ["filespec"]\n expected
+fail_compilation/lexer4.d(19): Error: declaration expected, not '"file"'
+---
+*/
+
+static c1 = '
+;
+static c2 = '';
+static c3 = 'a;
+int i = 0b12;
+int j = 0128;
+int k = 12a;
+int l = 12UU;
+int f = 0x1234.0;
+int m = 12l;
+static n = 12.1I;
+
+#line 1234567891234567879
+
+#line whatever
+
+#line 18 __FILE__
+
+#line 20 "file" "file"
+
+/** asdf *//** asdf2 */
+int o;


### PR DESCRIPTION
Given the low hanging fruit of

 https://dlang.dawg.eu/coverage/src/lexer.c.gcov.html

this adds more coverage tests. Found a couple bugs (!) doing it, improved some error messages, and refactored some unnecessary goto's.
