### PR TITLE
Enhancement: add trait getPointerBitmap to help precise scanning

### DIFF
--- a/src/idgen.c
+++ b/src/idgen.c
@@ -345,6 +345,7 @@ Msgtable msgtable[] =
     { "getFunctionAttributes" },
     { "getUnitTests" },
     { "getVirtualIndex" },
+    { "getPointerBitmap" },
 
     // For C++ mangling
     { "allocator" },

--- a/src/traits.c
+++ b/src/traits.c
@@ -254,6 +254,7 @@ const char* traits[] = {
     "getFunctionAttributes",
     "getUnitTests",
     "getVirtualIndex",
+    "getPointerBitmap",
     NULL
 };
 
@@ -314,6 +315,155 @@ Expression *isSymbolX(TraitsExp *e, bool (*fp)(Dsymbol *s))
     result = 1;
 Lfalse:
     return new IntegerExp(e->loc, result, Type::tbool);
+}
+
+/**
+ * get an array of size_t values that indicate possible pointer words in memory 
+ *  if interpreted as the type given as argument
+ * the first array element is the size of the type for independent interpretation
+ *  of the array
+ * following elements bits represent one word (4/8 bytes depending on the target 
+ *  architecture). If set the corresponding memory might contain a pointer/reference.
+ *
+ *  [T.sizeof, pointerbit0-31/63, pointerbit32/64-63/128, ...]
+ */
+Expression *pointerBitmap(TraitsExp *e)
+{
+    int result = 0;
+    if (!e->args || e->args->dim != 1)
+    {
+        error(e->loc, "a single type expected for trait pointerBitmap");
+        return new ErrorExp();
+    }
+    Type *t = getType((*e->args)[0]);
+    if (!t)
+    {
+        error(e->loc, "%s is not a type", (*e->args)[0]->toChars());
+        return new ErrorExp();
+    }
+    d_uns64 sz = t->size(e->loc);
+    if (t->ty == Tclass && !((TypeClass*)t)->sym->isInterfaceDeclaration())
+        sz = ((TypeClass*)t)->sym->AggregateDeclaration::size(e->loc);
+
+    d_uns64 sz_size_t = Type::tsize_t->size(e->loc);
+    d_uns64 bitsPerWord = sz_size_t * 8;
+    d_uns64 cntptr = (sz + sz_size_t - 1) / sz_size_t;
+    d_uns64 cntdata = (cntptr + bitsPerWord - 1) / bitsPerWord;
+    d_uns64* data = new d_uns64[cntdata];
+    memset(data, 0, cntdata * sizeof(d_uns64));
+
+    class PointerBitmapVisitor : public Visitor
+    {
+    public:
+        PointerBitmapVisitor(d_uns64* _data, d_uns64 _sz_size_t) 
+            : data(_data), offset(0), sz_size_t(_sz_size_t) 
+        {}
+        
+        void setpointer(d_uns64 off)
+        {
+            d_uns64 ptroff = off / sz_size_t;
+            data[ptroff / (8 * sz_size_t)] |= 1LL << (ptroff % (8 * sz_size_t));
+        }
+        virtual void visit(Type *t) 
+        {
+            Type *tb = t->toBasetype();
+            if (tb != t)
+                tb->accept(this);
+        }
+        virtual void visit(TypeError *t) { visit((Type *)t); }
+        virtual void visit(TypeNext *t) { assert(0); }
+        virtual void visit(TypeBasic *t)
+        {
+            if (t->ty == Tvoid)
+                setpointer(offset);
+        }
+        virtual void visit(TypeVector *t) { }
+        virtual void visit(TypeArray *t) { assert(0); }
+        virtual void visit(TypeSArray *t)
+        {
+            d_uns64 arrayoff = offset;
+            d_uns64 nextsize = t->next->size();
+            d_uns64 dim = t->dim->toInteger();
+            for (size_t i = 0; i < dim; i++)
+            {
+                offset = arrayoff + i * nextsize;
+                t->next->accept(this);
+            }
+            offset = arrayoff;
+        }
+        virtual void visit(TypeDArray *t) { setpointer(offset + sz_size_t); } // dynamic array is {length,ptr}
+        virtual void visit(TypeAArray *t) { setpointer(offset); }
+        virtual void visit(TypePointer *t) 
+        {
+            if (t->nextOf()->ty != Tfunction) // don't mark function pointers
+                setpointer(offset);
+        }
+        virtual void visit(TypeReference *t) { setpointer(offset); }
+        virtual void visit(TypeClass *t) { setpointer(offset); }
+        virtual void visit(TypeFunction *t) { }
+        virtual void visit(TypeDelegate *t) { setpointer(offset); } // delegate is {context, function}
+        virtual void visit(TypeQualified *t) { assert(0); } // assume resolved
+        virtual void visit(TypeIdentifier *t) { assert(0); }
+        virtual void visit(TypeInstance *t) { assert(0); }
+        virtual void visit(TypeTypeof *t) { assert(0); }
+        virtual void visit(TypeReturn *t) { assert(0); }
+        virtual void visit(TypeEnum *t) { visit((Type *)t); }
+        virtual void visit(TypeTuple *t) { visit((Type *)t); }
+        virtual void visit(TypeSlice *t) { assert(0); }
+        virtual void visit(TypeNull *t) { assert(0); }
+
+        virtual void visit(TypeStruct *t)
+        {
+            d_uns64 structoff = offset;
+            for (size_t i = 0; i < t->sym->fields.dim; i++)
+            {
+                VarDeclaration *v = t->sym->fields[i];
+                offset = structoff + v->offset;
+                if (v->type->ty == Tclass)
+                    setpointer(offset);
+                else
+                    v->type->accept(this);
+            }
+            offset = structoff;
+        }
+
+        // a "toplevel" class is treated as an instance, while TypeClass fields are treated as references
+        void visitClass(TypeClass* t)
+        {
+            d_uns64 classoff = offset;
+
+            // skip vtable-ptr and monitor
+            if (t->sym->baseClass)
+                visitClass((TypeClass*)t->sym->baseClass->type);
+
+            for (size_t i = 0; i < t->sym->fields.dim; i++)
+            {
+                VarDeclaration *v = t->sym->fields[i];
+                offset = classoff + v->offset;
+                v->type->accept(this);
+            }
+            offset = classoff;
+        }
+
+        d_uns64* data;
+        d_uns64 offset;
+        d_uns64 sz_size_t;
+    };
+
+    PointerBitmapVisitor pbv(data, sz_size_t);
+    if (t->ty == Tclass)
+        pbv.visitClass((TypeClass*)t);
+    else
+        t->accept(&pbv);
+
+    Expressions* exps = new Expressions;
+    exps->push(new IntegerExp(e->loc, sz, Type::tsize_t));
+    for (d_uns64 i = 0; i < cntdata; i++)
+        exps->push(new IntegerExp(e->loc, data[i], Type::tsize_t));
+
+    ArrayLiteralExp* ale = new ArrayLiteralExp(e->loc, exps);
+    ale->type = Type::tsize_t->sarrayOf(cntdata + 1);
+    return ale;
 }
 
 Expression *semanticTraits(TraitsExp *e, Scope *sc)
@@ -1070,6 +1220,10 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
         }
         fd = fd->toAliasFunc(); // Neccessary to support multiple overloads.
         return new IntegerExp(e->loc, fd->vtblIndex, Type::tptrdiff_t);
+    }
+    else if (e->ident == Id::getPointerBitmap)
+    {
+        return pointerBitmap(e);
     }
     else
     {

--- a/test/runnable/traits_getPointerBitmap.d
+++ b/test/runnable/traits_getPointerBitmap.d
@@ -1,0 +1,204 @@
+// REQUIRED_ARGS: -unittest
+
+module traits_getPointerBitmap;
+
+import std.stdio;
+static import std.traits;
+
+// version = RTInfo;
+// debug = LOG;
+
+version(RTInfo)
+    import gc.rtinfo;
+else
+    enum bool RTInfoMark__Monitor = false; // is __monitor GC allocated?
+    
+
+enum bytesPerPtr = (size_t.sizeof);
+enum bytesPerBitmapWord = bytesPerPtr * bytesPerPtr * 8;
+
+template allocatedSize(T)
+{
+    static if (is (T == class))
+        enum allocatedSize = __traits(classInstanceSize, T);
+    else
+        enum allocatedSize = T.sizeof;
+}
+
+bool testBit(const(size_t)* p, size_t biti)
+{
+    enum BITS_SHIFT = (size_t.sizeof == 8 ? 6 : 5);
+    enum BITS_MASK = (bytesPerPtr - 1);
+
+    return (p[biti >> BITS_SHIFT] & (1 << (biti & BITS_MASK))) != 0;
+}
+
+void __testType(T)(size_t[] expected)
+{
+    // check compile time info
+    enum bits  = (T.sizeof + bytesPerPtr - 1) / bytesPerPtr;
+    enum words = (T.sizeof + bytesPerBitmapWord - 1) / bytesPerBitmapWord;
+    version(RTInfo)
+        enum info = RTInfoImpl2!(Unqual!T); // we want the array, not the pointer
+    else
+        enum info = __traits(getPointerBitmap,T); // we want the array, not the pointer
+    
+    debug(LOG) writef("%-20s:", T.stringof);
+    debug(LOG) writef(" CT:%s", info);
+    debug(LOG) writef(" EXP:%d %s", allocatedSize!T, expected);
+    assert(info[0] == allocatedSize!T);
+    assert(info[1..$] == expected);
+    assert(words == expected.length);
+
+    debug(LOG) writeln();
+}
+
+///////////////////////////////////////
+struct S(T, aliasTo = void)
+{
+    static if(!is(aliasTo == void))
+    {
+        aliasTo a;
+        alias a this;
+    }
+
+    size_t x;
+    T t = void;
+    void* p;
+
+}
+
+template tOff(T)
+{
+    enum tOff = T.t.offsetof / bytesPerPtr;
+}
+
+template pOff(T)
+{
+    enum pOff = T.p.offsetof / bytesPerPtr;
+}
+
+class C(T, aliasTo = void)
+{
+    static if(!is(aliasTo == void))
+    {
+        aliasTo a;
+        alias a this;
+    }
+
+    size_t x;
+    T t = void;
+    void* p;
+}
+
+///////////////////////////////////////
+
+void _testType(T)(size_t[] expected)
+{
+    __testType!(T)(expected);
+    __testType!(const(T))(expected);
+    __testType!(immutable(T))(expected);
+    version(RTInfo) {} else // Unqual does not work with shared(T[N])
+        __testType!(shared(T))(expected);
+}
+
+void testType(T)(size_t[] expected)
+{
+    _testType!(T)(expected);
+
+    // generate bit pattern for S!T
+    assert(expected.length == 1);
+    size_t[] sexp;
+
+    sexp ~= (expected[0] << tOff!(S!T)) | (1 << pOff!((S!T)));
+    _testType!(S!T)(sexp);
+
+    // prepend Object
+    sexp[0] = (expected[0] << tOff!(S!(T, Object))) | (1 << pOff!(S!(T, Object))) | 1;
+    _testType!(S!(T, Object))(sexp);
+
+    // prepend string
+    sexp[0] = (expected[0] << tOff!(S!(T, string))) | (1 << pOff!(S!(T, string))) | 2; // arr ptr
+    _testType!(S!(T, string))(sexp);
+
+    // generate bit pattern for C!T
+    C!T ct = null;
+    size_t mutexBit = (RTInfoMark__Monitor ? 2 : 0);
+    size_t ctpOff = ct.p.offsetof / bytesPerPtr;
+    size_t cttOff = ct.t.offsetof / bytesPerPtr;
+    sexp[0] = (expected[0] << cttOff) | (1 << ctpOff) | mutexBit;
+    _testType!(C!(T))(sexp);
+
+    C!(T, string) cts = null;
+    size_t ctspOff = cts.p.offsetof / bytesPerPtr;
+    size_t ctstOff = cts.t.offsetof / bytesPerPtr;
+    // generate bit pattern for C!T
+    sexp[0] = (expected[0] << ctstOff) | (1 << ctspOff) | mutexBit | 0b1000; // arr ptr
+    _testType!(C!(T, string))(sexp);
+}
+
+///////////////////////////////////////
+alias void[2*size_t.sizeof] void2;
+alias size_t[3] int3;
+alias size_t*[3] pint3;
+alias string[3] sint3;
+alias string[3][2] sint3_2;
+alias int delegate() dg;
+alias int function() fn;
+
+// span multiple bitmap elements
+struct Large
+{
+    size_t[30] data1;
+    void* p1;
+    size_t[1] val1;
+
+    size_t[28] data2;
+    void* p2;
+    size_t[3] val2;
+
+    size_t[16] data3;
+    void* p3;
+    size_t[15] val3;
+}
+
+void testRTInfo()
+{
+    testType!(bool)         ([ 0b0 ]);
+    testType!(ubyte)        ([ 0b0 ]);
+    testType!(short)        ([ 0b0 ]);
+    testType!(int)          ([ 0b0 ]);
+    testType!(long)         ([ 0b00 ]);
+    testType!(double)       ([ 0b00 ]);
+    testType!(ifloat)       ([ 0b0 ]);
+    testType!(cdouble)      ([ 0b0000 ]);
+    testType!(dg)           ([ 0b01 ]);
+    testType!(fn)           ([ 0b0 ]);
+    testType!(S!fn)         ([ 0b100 ]);
+    version(D_LP64)
+        testType!(__vector(float[4]))  ([ 0b00 ]);
+
+    testType!(Object[int])       ([ 0b1 ]);
+    testType!(Object[])       ([ 0b10 ]);
+    testType!(string)         ([ 0b10 ]);
+
+    testType!(int3)           ([ 0b000 ]);
+    testType!(pint3)          ([ 0b111 ]);
+    testType!(sint3)          ([ 0b101010 ]);
+    testType!(sint3_2)        ([ 0b101010101010 ]);
+    testType!(void2)          ([ 0b11 ]);
+
+    version(D_LP64)
+        _testType!(Large)          ([ 0x1000_0000__4000_0000, 0x0001_0000 ]);
+    else
+        _testType!(Large)          ([ 0x4000_0000, 0x1000_0000, 0x0001_0000 ]);
+}
+
+unittest
+{
+    testRTInfo();
+}
+
+void main() 
+{
+}


### PR DESCRIPTION
This helps the precise GC (https://github.com/D-Programming-Language/druntime/pull/1022) to generate the required data without adding to the compile time.
