### PR TITLE
[REG2.067a] Issue 13775 - Broken explicit casting of dynamic array slices of known size to static array of different type

### DIFF
--- a/test/fail_compilation/fail13775.d
+++ b/test/fail_compilation/fail13775.d
@@ -1,0 +1,21 @@
+// REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13775.d(17): Error: cannot cast expression ubytes[0..2] of type ubyte[2] to ubyte[1]
+fail_compilation/fail13775.d(18): Error: cannot cast expression ubytes[0..2] of type ubyte[2] to ubyte[3]
+fail_compilation/fail13775.d(19): Error: cannot cast expression ubytes[0..2] of type ubyte[2] to byte[1]
+fail_compilation/fail13775.d(20): Error: cannot cast expression ubytes[0..2] of type ubyte[2] to byte[3]
+---
+*/
+
+void main()
+{
+    ubyte[4] ubytes = [1,2,3,4];
+
+    // CT-known slicing succeeds but sizes cannot match
+    auto ng1 = cast(ubyte[1]) ubytes[0 .. 2];   // ubyte[2] to ubyte[1]
+    auto ng2 = cast(ubyte[3]) ubytes[0 .. 2];   // ubyte[2] to ubyte[3]
+    auto ng3 = cast( byte[1]) ubytes[0 .. 2];   // ubyte[2] to  byte[1]
+    auto ng4 = cast( byte[3]) ubytes[0 .. 2];   // ubyte[2] to  byte[3]
+}

--- a/test/runnable/testbounds2.d
+++ b/test/runnable/testbounds2.d
@@ -258,6 +258,32 @@ void test12876()
 }
 
 /******************************************/
+// 13775
+
+void test13775()
+{
+    ubyte[4] ubytes = [1,2,3,4];
+
+    // CT-known slicing (issue 3652)
+    auto ok1 = cast(ubyte[2]) ubytes[0 .. 2];
+    assert(ok1 == [1, 2]);
+
+    // CT-known slicing with implicit conversion of SliceExp::e1 (issue 13154)
+    enum double[] arr = [1.0, 2.0, 3.0];
+    auto ok2 = cast(float[2]) [1.0, 2.0, 3.0][0..2];
+    auto ok3 = cast(float[2]) arr[1..3];    // currently this is accepted
+    assert(ok2 == [1f, 2f]);
+    assert(ok3 == [2f, 3f]);
+
+    // CT-known slicing with type coercing (issue 13775)
+    auto ok4 = cast( byte[2]) ubytes[0 .. 2];   // CT-known slicing + type coercing
+    auto ok5 = cast(short[1]) ubytes[0 .. 2];   // CT-known slicing + type coercing
+    assert(ok4 == [1, 2]);
+    version(LittleEndian) assert(ok5 == [0x0201]);
+    version(   BigEndian) assert(ok5 == [0x0102]);
+}
+
+/******************************************/
 
 int main()
 {
@@ -266,6 +292,7 @@ int main()
     test3652b();
     test9743();
     test9747();
+    test13775();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13775

Support reinterpret-cast from a CT-known boundaries slice expression that can be implicitly typed as `T[n]` to another static array type `U[m]`, iff their sizes are same (`T[n].sizeof == U[m].sizeof`).
