### PR TITLE
Issue 8262 -  ICE(mtype.c) alias this to alias of an expression tuple

### DIFF
--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -3416,9 +3416,12 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         TypeClass tc = cast(TypeClass)t;
                         if (tc.sym.aliasthis && !(tc.att & RECtracingDT))
                         {
-                            tc.att = cast(AliasThisRec)(tc.att | RECtracingDT);
-                            m = deduceType(t.aliasthisOf(), sc, tparam, parameters, dedtypes, wm);
-                            tc.att = cast(AliasThisRec)(tc.att & ~RECtracingDT);
+                            if (auto ato = t.aliasthisOf())
+                            {
+                                tc.att = cast(AliasThisRec)(tc.att | RECtracingDT);
+                                m = deduceType(ato, sc, tparam, parameters, dedtypes, wm);
+                                tc.att = cast(AliasThisRec)(tc.att & ~RECtracingDT);
+                            }
                         }
                     }
                     else if (t.ty == Tstruct)
@@ -3426,9 +3429,12 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         TypeStruct ts = cast(TypeStruct)t;
                         if (ts.sym.aliasthis && !(ts.att & RECtracingDT))
                         {
-                            ts.att = cast(AliasThisRec)(ts.att | RECtracingDT);
-                            m = deduceType(t.aliasthisOf(), sc, tparam, parameters, dedtypes, wm);
-                            ts.att = cast(AliasThisRec)(ts.att & ~RECtracingDT);
+                            if (auto ato = t.aliasthisOf())
+                            {
+                                ts.att = cast(AliasThisRec)(ts.att | RECtracingDT);
+                                m = deduceType(ato, sc, tparam, parameters, dedtypes, wm);
+                                ts.att = cast(AliasThisRec)(ts.att & ~RECtracingDT);
+                            }
                         }
                     }
                 }

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -7661,9 +7661,14 @@ extern (C++) final class TypeStruct : Type
         }
         else if (sym.aliasthis && !(att & RECtracing))
         {
-            att = cast(AliasThisRec)(att | RECtracing);
-            m = aliasthisOf().implicitConvTo(to);
-            att = cast(AliasThisRec)(att & ~RECtracing);
+            if (auto ato = aliasthisOf())
+            {
+                att = cast(AliasThisRec)(att | RECtracing);
+                m = ato.implicitConvTo(to);
+                att = cast(AliasThisRec)(att & ~RECtracing);
+            }
+            else
+                m = MATCH.nomatch; // no match
         }
         else
             m = MATCH.nomatch; // no match
@@ -7688,9 +7693,12 @@ extern (C++) final class TypeStruct : Type
 
         if (t.hasWild() && sym.aliasthis && !(att & RECtracing))
         {
-            att = cast(AliasThisRec)(att | RECtracing);
-            wm = aliasthisOf().deduceWild(t, isRef);
-            att = cast(AliasThisRec)(att & ~RECtracing);
+            if (auto ato = aliasthisOf())
+            {
+                att = cast(AliasThisRec)(att | RECtracing);
+                wm = ato.deduceWild(t, isRef);
+                att = cast(AliasThisRec)(att & ~RECtracing);
+            }
         }
 
         return wm;
@@ -8465,9 +8473,12 @@ extern (C++) final class TypeClass : Type
         m = MATCH.nomatch;
         if (sym.aliasthis && !(att & RECtracing))
         {
-            att = cast(AliasThisRec)(att | RECtracing);
-            m = aliasthisOf().implicitConvTo(to);
-            att = cast(AliasThisRec)(att & ~RECtracing);
+            if (auto ato = aliasthisOf())
+            {
+                att = cast(AliasThisRec)(att | RECtracing);
+                m = ato.implicitConvTo(to);
+                att = cast(AliasThisRec)(att & ~RECtracing);
+            }
         }
 
         return m;
@@ -8505,9 +8516,12 @@ extern (C++) final class TypeClass : Type
 
         if (t.hasWild() && sym.aliasthis && !(att & RECtracing))
         {
-            att = cast(AliasThisRec)(att | RECtracing);
-            wm = aliasthisOf().deduceWild(t, isRef);
-            att = cast(AliasThisRec)(att & ~RECtracing);
+            if (auto ato = aliasthisOf())
+            {
+                att = cast(AliasThisRec)(att | RECtracing);
+                wm = ato.deduceWild(t, isRef);
+                att = cast(AliasThisRec)(att & ~RECtracing);
+            }
         }
 
         return wm;

--- a/test/fail_compilation/fail8262.d
+++ b/test/fail_compilation/fail8262.d
@@ -1,8 +1,8 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation\fail8262.d(32): Error: cannot interpret Tuple8262!1 at compile time
-fail_compilation\fail8262.d(27): Error: template instance fail8262.T8262!(Tuple8262!1) error instantiating
-fail_compilation\fail8262.d(19): Error: cannot implicitly convert expression `S(0)` of type `S` to `int`
+fail_compilation/fail8262.d(32): Error: cannot interpret Tuple8262!1 at compile time
+fail_compilation/fail8262.d(27): Error: template instance fail8262.T8262!(Tuple8262!1) error instantiating
+fail_compilation/fail8262.d(19): Error: cannot implicitly convert expression `S(0)` of type `S` to `int`
 ---
  * https://issues.dlang.org/show_bug.cgi?id=8262
  */

--- a/test/fail_compilation/fail8262.d
+++ b/test/fail_compilation/fail8262.d
@@ -1,0 +1,33 @@
+/* TEST_OUTPUT:
+---
+fail_compilation\fail8262.d(32): Error: cannot interpret Tuple8262!1 at compile time
+fail_compilation\fail8262.d(27): Error: template instance fail8262.T8262!(Tuple8262!1) error instantiating
+fail_compilation\fail8262.d(19): Error: cannot implicitly convert expression `S(0)` of type `S` to `int`
+---
+ * https://issues.dlang.org/show_bug.cgi?id=8262
+ */
+
+template Seq(T...) { alias T Seq; }
+
+struct S
+{
+    int s;
+    alias Seq!s _;
+    alias _ this;
+}
+
+int si = S.init;
+
+struct Tuple8262(T...)
+{
+    alias T expand;
+    alias expand this;
+}
+
+auto data = T8262!(Tuple8262!1);
+//pragma(msg, data);
+
+template T8262(T)
+{
+    immutable(int) T8262 = T;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=8262

This PR doesn't change anything about what should happen with a tuple being aliased to "this", but merely avoids the crash. The net result seems to be that implicite conversions don't take place.

This is blocking https://github.com/D-Programming-Language/druntime/pull/1057 ATM.
