### PR TITLE
Use in contract from base class if not specified in derived

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -2429,8 +2429,12 @@ Statement *FuncDeclaration::mergeFrequire(Statement *sf)
             catches->push(c);
             sf = new TryCatchStatement(loc, s2, catches);
         }
-        else
-            return NULL;
+        else if(fdv->fdrequire)
+        {
+            Expression *eresult = NULL;
+            Expression *e = new CallExp(loc, new VarExp(loc, fdv->fdrequire), eresult);
+            sf = new ExpStatement(loc, e);
+        }
     }
     return sf;
 }

--- a/test/runnable/issue6856.d
+++ b/test/runnable/issue6856.d
@@ -1,0 +1,51 @@
+module issue6856;
+
+class Base
+{
+    void foo(int x)
+    in
+    {
+        assert(false);
+    }
+    body
+    {
+
+    }
+}
+
+
+class Derived: Base
+{
+    override void foo(int x)
+    in
+    {
+        assert(x > 5);
+    }
+    body
+    {
+
+    }
+}
+
+
+class EvenMoreDerived: Derived
+{
+    override void foo(int x)
+    in
+    {}
+    body
+    {
+
+    }
+}
+
+void test1()
+{
+    auto derived = new EvenMoreDerived;
+    derived.foo(2);
+}
+
+void main()
+{
+    test1();
+}


### PR DESCRIPTION
In case when in contract is not specified in the derived class,
and base class does specify a contract, base contract should
not be silently ignored:

```
class Base
{
    void foo()
    in
    {
        assert(false);
    }
    body
    {

    }
}

class Derived: Base
{
    override void foo()
    {
    }
}

void main()
{
    auto o = new Derived();
    o.foo(); // Should fail
}

```

Old behaviour can be brought back with `in{}` in `Derived.foo`.

See https://issues.dlang.org/show_bug.cgi?id=6856
