### PR TITLE
Issue 13795 - Add longdouble to UnionExp to provide alignment

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -1586,6 +1586,9 @@ struct UnionExp
         char addrexp   [sizeof(AddrExp)];
         char indexexp  [sizeof(IndexExp)];
         char sliceexp  [sizeof(SliceExp)];
+
+        // Ensure that the union is suitably aligned.
+        longdouble for_alignment_only;
     };
     U u;
 };


### PR DESCRIPTION
The data in `UnionExp` wasn't suitably aligned for its contents, causing seg faults with clang's optimized code for `ComplexExp` using movaps.

https://issues.dlang.org/show_bug.cgi?id=13795
