### PR TITLE
[D1] more configurable -v2 output

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -780,7 +780,7 @@ void VarDeclaration::semantic(Scope *sc)
 
     storage_class |= sc->stc;
 
-    if (global.params.Dversion >= 3)
+    if (global.params.enabledV2hints & V2MODEconst)
     {
         if (storage_class & STCconst && !init)
         {

--- a/src/func.c
+++ b/src/func.c
@@ -386,9 +386,10 @@ void FuncDeclaration::semantic(Scope *sc)
                 // This function is covariant with fdv
                 if (fdv->isFinal())
                     error("cannot override final function %s", fdv->toPrettyChars());
-
+                
                 if (!isOverride() &&
-                    global.params.Dversion >= 3 && sc->module && sc->module->isRoot())
+                        (global.params.enabledV2hints & V2MODEoverride) &&
+                        sc->module && sc->module->isRoot())
                     warning(loc, "overrides base class function %s, but is not marked with 'override'", fdv->toPrettyChars());
 
                 FuncDeclaration *fdc = ((Dsymbol *)cd->vtbl.data[vi])->isFuncDeclaration();

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -657,7 +657,7 @@ void Lexer::scan(Token *t)
                 t->value = (enum TOK) id->value;
                 if (t->value == TOKD2kwd)
                 {
-                    if (global.params.Dversion >= 3 && mod && mod->isRoot())
+                    if ((global.params.enabledV2hints & V2MODEsyntax) && mod && mod->isRoot())
                         warning(loc, "%s is a D2 keyword", id->toChars());
                     t->value = TOKidentifier;
                 }
@@ -2163,7 +2163,7 @@ Ldone:
         break;
     }
 
-    if (global.params.Dversion >= 3 &&
+    if ((global.params.enabledV2hints & V2MODEoctal) &&
         base == 8 && n >= 8 &&
         mod && mod->isRoot()
         )

--- a/src/mars.h
+++ b/src/mars.h
@@ -130,6 +130,25 @@ template <typename TYPE> struct ArrayBase;
 typedef ArrayBase<struct Identifier> Identifiers;
 typedef ArrayBase<char> Strings;
 
+// -v2 hint support
+
+enum V2MODE
+{
+   V2MODEnone        = 0, 
+   V2MODEoverride    = 1 << 0,
+   V2MODEsyntax      = 1 << 1,
+   V2MODEoctal       = 1 << 2,
+   V2MODEconst       = 1 << 3,
+   V2MODEswitch      = 1 << 4,
+   V2MODEvolatile    = 1 << 5,
+   V2MODEstaticarr   = 1 << 6,
+   V2MODEall         = 0xFFFFFFFF,
+   V2MODEdefault     = V2MODEall,
+};
+
+V2MODE V2MODE_from_name(const char* name);
+const char* V2MODE_all_descriptions();
+
 // Put command line switches in here
 struct Param
 {
@@ -180,6 +199,7 @@ struct Param
     char cov;           // generate code coverage data
     bool nofloat;       // code should not pull in floating point support
     char Dversion;      // D version number
+    unsigned enabledV2hints; // bitflags for enabled hints for -v2
     char ignoreUnsupportedPragmas;      // rather than error on them
     char safe;          // enforce safe memory model
     char betterC;       // be a "better C" compiler; no dependency on D runtime

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3038,7 +3038,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 continue;
             }
 
-            if (global.params.Dversion >= 3 && sc->module && sc->module->isRoot() &&
+            if ((global.params.enabledV2hints & V2MODEstaticarr) && sc->module && sc->module->isRoot() &&
                 t->ty == Tsarray)
             {
                 // ignore ref storage class for extern(C) static arrays

--- a/src/parse.c
+++ b/src/parse.c
@@ -220,7 +220,7 @@ Dsymbols *Parser::parseDeclDefs(int once)
                 if (t->value == TOKlparen && peek(t)->value == TOKrparen)
                 {
                 }
-                else if (global.params.Dversion >= 3 &&
+                else if ((global.params.enabledV2hints & V2MODEsyntax) &&
                     mod && mod->isRoot()
                     )
                 {
@@ -3073,7 +3073,7 @@ Statement *Parser::parseStatement(int flags)
             check(TOKrparen);
             if (token.value == TOKsemicolon)
                 nextToken();
-            else if (global.params.Dversion >= 3 &&
+            else if ((global.params.enabledV2hints & V2MODEsyntax) &&
                 mod && mod->isRoot()
                 )
                 warning(loc, "D2 requires that 'do { ... } while(...)' end with a ;");
@@ -3591,7 +3591,7 @@ Statement *Parser::parseStatement(int flags)
         case TOKvolatile:
             nextToken();
             s = parseStatement(PSsemi | PScurlyscope);
-            if (global.params.Dversion >= 3 && mod && mod->isRoot())
+            if ((global.params.enabledV2hints & V2MODEvolatile) && mod && mod->isRoot())
             {
                 warning(loc, "'volatile' is deprecated in D2, consult with module maintainer for appropriate replacement");
             }

--- a/src/statement.c
+++ b/src/statement.c
@@ -662,7 +662,7 @@ int CompoundStatement::blockExit(bool mustNotThrow)
         {
             //printf("result = x%x\n", result);
             //printf("%s\n", s->toChars());
-            if (global.params.Dversion >= 3 && // sc->module && sc->module->isRoot() && /* doesn't have sc */
+            if ((global.params.enabledV2hints & V2MODEswitch) &&
                 result & BEfallthru && slast)
             {
                 slast = slast->last();
@@ -2665,7 +2665,7 @@ Statement *SwitchStatement::semantic(Scope *sc)
     if (!sc->sw->sdefault)
     {   hasNoDefault = 1;
 
-        if (global.params.Dversion >= 3 &&
+        if ((global.params.enabledV2hints & V2MODEswitch) &&
             sc->module && sc->module->isRoot()
             )
             warning("switch statement without a default is not allowed in D2; add 'default: assert(0);'");


### PR DESCRIPTION
- -v2 does not imply -wi anymore, explicit -w / -wi usage is expected
- -v2=xxx allows to enabled only specific warnings
- -v2-list prints all available -v2 warning kinds

All this stuff is needed for fine tuning of -v2 output and compiler
exit status codes in project Jenkins jobs (to ensure regression control
for -v2 changes)
