### PR TITLE
Explicitly truncate/widen shift value in OptimizeVisitor::PowExp

### DIFF
--- a/src/optimize.c
+++ b/src/optimize.c
@@ -932,7 +932,8 @@ Expression *Expression_optimize(Expression *e, int result, bool keepLvalue)
                 while ((i >>= 1) > 1)
                     mul++;
                 Expression *shift = new MulExp(e->loc, e->e2, new IntegerExp(e->loc, mul, e->e2->type));
-                shift->type = Type::tshiftcnt;
+                shift->type = e->e2->type;
+                shift = shift->castTo(NULL, Type::tshiftcnt);
                 ret = new ShlExp(e->loc, new IntegerExp(e->loc, 1, e->e1->type), shift);
                 ret->type = e->type;
                 return;


### PR DESCRIPTION
In certain scenarios, a ^^ expression may be wider or narrower than the default tshiftcnt type (`int`).

Example:

```
foreach(i; 1..table.length - 1)
  immutable strideLength = 2 ^^ i;
```

As I've brought up in previous PRs, this kind of type punning in the front-end IR doesn't sit too well with strict type-checked backend, so adding in an explicit cast fixes tree verification ICE's I'm seeing in gdc-5.0.
