### PR TITLE
[D1] Add -v2=-hint option to disable a particular hint

### DIFF
--- a/docs/man/man1/dmd.1
+++ b/docs/man/man1/dmd.1
@@ -187,6 +187,16 @@ compile in version code identified by
 .IP -w
 Enable warnings
 
+.IP -v2[=\fIhint\fR]
+Give hints for converting to D2. If no \fIhint\fR is specified the default
+hint set is used. If \fIhint\fR begins with a minus (-), then that particular
+hint is disabled instead (if when the first -v2=-\fIhint\fR is found, no other
+-v2 option were used, first the default set of hints is enabled, and then the
+specified \fIhint\fR is disabled from that set).
+
+.IP -v2-list
+List all available conversion hint types.
+
 .SH LINKING
 Linking is done directly by the
 .B dmd

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -784,8 +784,9 @@ void VarDeclaration::semantic(Scope *sc)
     {
         if (storage_class & STCconst && !init)
         {
-            warning(loc, "There is no const storage class in D2, make variable '%s'' non-const",
-                toChars());
+            warning(loc, "There is no const storage class in D2, make "
+                    "variable '%s'' non-const [-v2=%s]", toChars(),
+                    V2MODE_name(V2MODEconst));
         }
     }
 

--- a/src/func.c
+++ b/src/func.c
@@ -390,7 +390,9 @@ void FuncDeclaration::semantic(Scope *sc)
                 if (!isOverride() &&
                         (global.params.enabledV2hints & V2MODEoverride) &&
                         sc->module && sc->module->isRoot())
-                    warning(loc, "overrides base class function %s, but is not marked with 'override'", fdv->toPrettyChars());
+                    warning(loc, "overrides base class function %s, but is "
+                            "not marked with 'override' [-v2=%s]", fdv->toPrettyChars(),
+                            V2MODE_name(V2MODEoverride));
 
                 FuncDeclaration *fdc = ((Dsymbol *)cd->vtbl.data[vi])->isFuncDeclaration();
                 if (fdc->toParent() == parent)

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -658,7 +658,8 @@ void Lexer::scan(Token *t)
                 if (t->value == TOKD2kwd)
                 {
                     if ((global.params.enabledV2hints & V2MODEsyntax) && mod && mod->isRoot())
-                        warning(loc, "%s is a D2 keyword", id->toChars());
+                        warning(loc, "%s is a D2 keyword [-v2=%s]", id->toChars(),
+                                V2MODE_name(V2MODEsyntax));
                     t->value = TOKidentifier;
                 }
                 anyToken = 1;
@@ -2168,10 +2169,12 @@ Ldone:
         mod && mod->isRoot()
         )
     {
-        warning(loc, "octal literals 0%llo%.*s are not in D2, use std.conv.octal!%llo%.*s instead or hex 0x%llx%.*s",
+        warning(loc, "octal literals 0%llo%.*s are not in D2, use "
+                "std.conv.octal!%llo%.*s instead or hex 0x%llx%.*s [-v2=%s]",
                 n, p - psuffix, psuffix,
                 n, p - psuffix, psuffix,
-                n, p - psuffix, psuffix);
+                n, p - psuffix, psuffix,
+                V2MODE_name(V2MODEoctal));
     }
 
     switch (flags)

--- a/src/mars.c
+++ b/src/mars.c
@@ -1726,6 +1726,17 @@ V2MODE V2MODE_from_name(const char* name)
     exit(2);
 }
 
+const char* V2MODE_name(V2MODE mode)
+{
+    for (size_t i = 0; V2MODE_OPTS[i].name != NULL; i++)
+    {
+        if ((1 << i) == mode)
+            return V2MODE_OPTS[i].name;
+    }
+
+    return "<?>";
+}
+
 void V2MODE_print_all_descriptions(FILE* stream)
 {
     const struct V2MODE_Opt *opt;

--- a/src/mars.c
+++ b/src/mars.c
@@ -39,7 +39,6 @@
 long __cdecl __ehfilter(LPEXCEPTION_POINTERS ep);
 #endif
 
-
 int response_expand(size_t *pargc, char ***pargv);
 void browse(const char *url);
 void getenv_setargv(const char *envvar, size_t *pargc, char** *pargv);

--- a/src/mars.c
+++ b/src/mars.c
@@ -387,7 +387,9 @@ Usage:\n\
   -v             verbose\n\
   -v1            D language version 1\n\
   -v2            give hints for converting to D2 (default hint set)\n\
-  -v2=XXX        enable specific conversion hint type\n\
+  -v2=XXX        enable the specific XXX conversion hint type\n\
+  -v2=-XXX       disable the specific XXX conversion hint type\n\
+                 (if -v2 wasn't enable already, the defaults are enabled first)\n\
   -v2-list       list all available conversion hint types\n\
   -version=level compile in version code >= level\n\
   -version=ident compile in version code identified by ident\n\
@@ -629,6 +631,13 @@ int main(int iargc, char *argv[])
             {
                 V2MODE_print_all_descriptions(stdout);
                 return 0;
+            }
+            else if (memcmp(p + 1, "v2=-", 4) == 0)
+            {
+                // Implicitly enable -v2 if it was disabled
+                if (global.params.enabledV2hints == V2MODEnone)
+                    global.params.enabledV2hints = V2MODEdefault;
+                global.params.enabledV2hints &= ~V2MODE_from_name(p + 1 + 4);
             }
             else if (memcmp(p + 1, "v2=", 3) == 0)
                 global.params.enabledV2hints |= V2MODE_from_name(p + 1 + 3);

--- a/src/mars.c
+++ b/src/mars.c
@@ -369,9 +369,9 @@ Usage:\n\
   -profile       profile runtime performance of generated code\n\
   -quiet         suppress unnecessary messages\n\
   -release       compile release version\n\
-  -run srcfile args...   run resulting program, passing args\n"
-"  -shared        generate shared library (DLL)\n"
-"  -unittest      compile in unit tests\n\
+  -run srcfile args...   run resulting program, passing args\n\
+  -shared        generate shared library (DLL)\n\
+  -unittest      compile in unit tests\n\
   -v             verbose\n\
   -v1            D language version 1\n\
   -v2            give hints for converting to D2 (default hint set)\n\
@@ -1720,12 +1720,12 @@ const char* V2MODE_all_descriptions()
     return "\
 List of available hints for -v2 flags:\n\
     explicit-override : overriding methods need to be explicitly annonatted with 'override'\n\
-    syntax            : basic syntax differences (reserved keywords, loop syntax etc)'\n\
-    const             : const storage class can't be used'\n\
+    syntax            : basic syntax differences (reserved keywords, loop syntax, etc.)\n\
+    const             : const storage class can't be used\n\
     switch            : implicit switch case fall-through is not allowed\n\
                         switch must have default statament\n\
     volatile          : volatile statements\n\
     static-arr-params : static array parameter will become passed by value\n\
-    octal             : octal numeric literals need to be replaced'\
+    octal             : octal numeric literals need to be replaced\
 ";
 }

--- a/src/mars.c
+++ b/src/mars.c
@@ -61,6 +61,9 @@ struct V2MODE_Opt
 };
 V2MODE V2MODE_from_name(const char* name);
 void V2MODE_print_all_descriptions(FILE* stream);
+#ifdef DEBUG
+void V2MODE_print_used();
+#endif
 
 Global global;
 
@@ -938,6 +941,10 @@ int main(int iargc, char *argv[])
         }
     }
 
+#ifdef DEBUG
+    V2MODE_print_used();
+#endif
+
     if(global.params.is64bit != is64bit)
         error(0, "the architecture must not be changed in the %s section of %s",
               is64bit ? "Environment64" : "Environment32", inifilename);
@@ -1754,3 +1761,16 @@ void V2MODE_print_all_descriptions(FILE* stream)
     for (opt = V2MODE_OPTS; opt->name != NULL; opt++)
         fprintf(stream, "  %-*s    %s\n", width, opt->name, opt->desc);
 }
+
+#ifdef DEBUG
+void V2MODE_print_used()
+{
+    printf("Enabled -v2 hints:\n");
+    for (size_t i = 0; V2MODE_OPTS[i].name != NULL; i++)
+    {
+        if (global.params.enabledV2hints & (1 << i))
+            printf("  %s\n", V2MODE_OPTS[i].name);
+    }
+}
+#endif
+

--- a/src/mars.h
+++ b/src/mars.h
@@ -146,8 +146,6 @@ enum V2MODE
    V2MODEdefault     = V2MODEall,
 };
 
-V2MODE V2MODE_from_name(const char* name);
-const char* V2MODE_all_descriptions();
 
 // Put command line switches in here
 struct Param

--- a/src/mars.h
+++ b/src/mars.h
@@ -146,6 +146,7 @@ enum V2MODE
    V2MODEdefault     = V2MODEall,
 };
 
+const char* V2MODE_name(V2MODE mode);
 
 // Put command line switches in here
 struct Param

--- a/src/mars.h
+++ b/src/mars.h
@@ -134,7 +134,7 @@ typedef ArrayBase<char> Strings;
 
 enum V2MODE
 {
-   V2MODEnone        = 0, 
+   V2MODEnone        = 0,
    V2MODEoverride    = 1 << 0,
    V2MODEsyntax      = 1 << 1,
    V2MODEoctal       = 1 << 2,

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3048,7 +3048,9 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
 
                 if ((tf->linkage != LINKc) || !d2_compatibility_ref_cleared)
                 {
-                    warning(loc, "D2 passes static arrays by value, use %s[] instead", t->next->toChars());
+                    warning(loc, "D2 passes static arrays by value, "
+                            "use %s[] instead [-v2=%s]", t->next->toChars(),
+                            V2MODE_name(V2MODEstaticarr));
                 }
             }
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -224,7 +224,8 @@ Dsymbols *Parser::parseDeclDefs(int once)
                     mod && mod->isRoot()
                     )
                 {
-                    warning(loc, "D2 requires () after invariant");
+                    warning(loc, "D2 requires () after invariant [-v2=%s]",
+                            V2MODE_name(V2MODEsyntax));
                 }
                 s = parseInvariant();
                 break;
@@ -3074,9 +3075,11 @@ Statement *Parser::parseStatement(int flags)
             if (token.value == TOKsemicolon)
                 nextToken();
             else if ((global.params.enabledV2hints & V2MODEsyntax) &&
-                mod && mod->isRoot()
-                )
-                warning(loc, "D2 requires that 'do { ... } while(...)' end with a ;");
+                    mod && mod->isRoot())
+            {
+                warning(loc, "D2 requires that 'do { ... } while(...)' "
+                        "end with a ';' [-v2=%s]", V2MODE_name(V2MODEsyntax));
+            }
             s = new DoStatement(loc, body, condition);
             break;
         }
@@ -3593,7 +3596,9 @@ Statement *Parser::parseStatement(int flags)
             s = parseStatement(PSsemi | PScurlyscope);
             if ((global.params.enabledV2hints & V2MODEvolatile) && mod && mod->isRoot())
             {
-                warning(loc, "'volatile' is deprecated in D2, consult with module maintainer for appropriate replacement");
+                warning(loc, "'volatile' is deprecated in D2, consult with "
+                        "module maintainer for appropriate replacement [-v2=%s]",
+                        V2MODE_name(V2MODEvolatile));
             }
             s = new VolatileStatement(loc, s);
             break;

--- a/src/statement.c
+++ b/src/statement.c
@@ -679,7 +679,9 @@ int CompoundStatement::blockExit(bool mustNotThrow)
                     else
                     {
                         const char *gototype = s->isCaseStatement() ? "case" : "default";
-                        s->warning("switch case fallthrough not allowed in D2, insert 'goto %s;'", gototype);
+                        s->warning("switch case fallthrough not allowed in "
+                                "D2, insert 'goto %s;' [-v2=%s]", gototype,
+                                V2MODE_name(V2MODEswitch));
                     }
                 }
             }
@@ -2668,7 +2670,9 @@ Statement *SwitchStatement::semantic(Scope *sc)
         if ((global.params.enabledV2hints & V2MODEswitch) &&
             sc->module && sc->module->isRoot()
             )
-            warning("switch statement without a default is not allowed in D2; add 'default: assert(0);'");
+            warning("switch statement without a default is not allowed "
+                    "in D2; add 'default: assert(0);' [-v2=%s]",
+                    V2MODE_name(V2MODEswitch));
         else
             warning("switch statement has no default");
 


### PR DESCRIPTION
Also now -v2 warnings print which hint triggered that particular warning
message, the code is a bit restructured to improve maintenance and the
man page is updated.
