### PR TITLE
Issue 12780 - Multiplying integer array by scalar double fails

### DIFF
--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -68,7 +68,7 @@ FuncDeclaration *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc
     /* Construct the function
      */
     TypeFunction *ftype = new TypeFunction(fparams, exp->type, 0, LINKc, stc);
-    //printf("ftype: %s\n", ftype->toChars());
+    //printf("fd: %s %s\n", ident->toChars(), ftype->toChars());
     FuncDeclaration *fd = new FuncDeclaration(Loc(), Loc(), ident, STCundefined, ftype);
     fd->fbody = fbody;
     fd->protection = Prot(PROTpublic);
@@ -366,8 +366,31 @@ void buildArrayIdent(Expression *e, OutBuffer *buf, Expressions *arguments)
             }
             if (s)
             {
+                Type *tb = e->type->toBasetype();
+                Type *t1 = e->e1->type->toBasetype();
+                Type *t2 = e->e2->type->toBasetype();
                 e->e1->accept(this);
+                if (t1->ty == Tarray &&
+                    (t2->ty == Tarray && !t1->equivalent(tb) ||
+                     t2->ty != Tarray && !t1->nextOf()->equivalent(e->e2->type)))
+                {
+                    // Bugzilla 12780: if A is narrower than B
+                    //  A[] op B[]
+                    //  A[] op B
+                    buf->writestring("Of");
+                    buf->writestring(t1->nextOf()->mutableOf()->deco);
+                }
                 e->e2->accept(this);
+                if (t2->ty == Tarray &&
+                    (t1->ty == Tarray && !t2->equivalent(tb) ||
+                     t1->ty != Tarray && !t2->nextOf()->equivalent(e->e1->type)))
+                {
+                    // Bugzilla 12780: if B is narrower than A:
+                    //  A[] op B[]
+                    //  A op B[]
+                    buf->writestring("Of");
+                    buf->writestring(t2->nextOf()->mutableOf()->deco);
+                }
                 buf->writestring(s);
             }
             else

--- a/test/runnable/arrayop.d
+++ b/test/runnable/arrayop.d
@@ -781,6 +781,60 @@ void test12179()
 }
 
 /************************************************************************/
+// 12780
+
+void test12780()
+{
+    int ival = 2;
+    int[] iarr = [1, 2, 3];
+    double dval = 2.0;
+    double[] darr = [4, 5, 6];
+
+    double[] oarr = [0, 0, 0];
+
+    // multiply array operations
+    oarr[] = dval * iarr[];
+    assert(oarr == [dval * iarr[0],
+                    dval * iarr[1],
+                    dval * iarr[2]]);
+
+    oarr[] = iarr[] / dval;
+    assert(oarr == [iarr[0] / dval,
+                    iarr[1] / dval,
+                    iarr[2] / dval]);
+
+    oarr[] = dval * (ival + iarr[]);
+    assert(oarr == [dval * (ival + iarr[0]),
+                    dval * (ival + iarr[1]),
+                    dval * (ival + iarr[2])]);
+
+    oarr[] = (iarr[] & ival) / dval;
+    assert(oarr == [(iarr[0] & ival) / dval,
+                    (iarr[1] & ival) / dval,
+                    (iarr[2] & ival) / dval]);
+
+    oarr[] = darr[] + iarr[];
+    assert(oarr == [darr[0] + iarr[0],
+                    darr[1] + iarr[1],
+                    darr[2] + iarr[2]]);
+
+    oarr[] = iarr[] - darr[];
+    assert(oarr == [iarr[0] - darr[0],
+                    iarr[1] - darr[1],
+                    iarr[2] - darr[2]]);
+
+    oarr[] = darr[] * (ival & iarr[]);
+    assert(oarr == [darr[0] * (ival & iarr[0]),
+                    darr[1] * (ival & iarr[1]),
+                    darr[2] * (ival & iarr[2])]);
+
+    oarr[] = (iarr[] ^ ival) / darr[];
+    assert(oarr == [(iarr[0] ^ ival) / darr[0],
+                    (iarr[1] ^ ival) / darr[1],
+                    (iarr[2] ^ ival) / darr[2]]);
+}
+
+/************************************************************************/
 // 13497
 
 void test13497()
@@ -810,6 +864,7 @@ int main()
     test10684b();
     test11525();
     test12250();
+    test12780();
     test13497();
 
     printf("Success\n");


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12780

Support upcasting slice elements in array operations.
1. The tweak in the buildArrayIdent() retains backward compatibility.
   
   a) If no element upcasting exists in array operation, the generated function name is not changed.
   
   ``` d
   double_res[] = double_val * double_arr[];
   // _arrayExpSliceMulSliceAssign_d
   ```
   
   b) If upcasting slice elements is necessary, it will be encoded by the postfix "Of" + element-type-deco
   
   ``` d
   double_res[] = double_val * int_arr[];
   // _arrayExpSlice'Ofi'MulSliceAssign_d
   ```
2. Even if the whole array operation requires double element, the sub array operations can be processed by int.
   
   ``` d
   double_res[] = (int_val ^ int_arr[]) * double_val;
   // typeof(int_val ^ int_arr[]) == int[]
   ```
