### PR TITLE
[REG2.067a] Issue 13840 - nothrow attribute affects inside of try-catch block when using foreach with opApply

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -2305,7 +2305,8 @@ Statement *ForeachStatement::semantic(Scope *sc)
                 }
                 params->push(new Parameter(stc, p->type, id, NULL));
             }
-            StorageClass stc = mergeFuncAttrs(STCsafe | STCpure | STCnothrow | STCnogc, func);
+            // Bugzilla 13840: Throwable nested function inside nothrow function is acceptable.
+            StorageClass stc = mergeFuncAttrs(STCsafe | STCpure | STCnogc, func);
             tfld = new TypeFunction(params, Type::tint32, 0, LINKd, stc);
             cases = new Statements();
             gotos = new ScopeStatements();

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -676,7 +676,7 @@ int logOf12542(T)(T n)
     return 0;
 }
 
-void test12542() @safe nothrow pure 
+void test12542() @safe nothrow pure
 {
     int log = logOf12542(9);
 }
@@ -763,6 +763,34 @@ nothrow void a13217(T)(T x)
 void test13217()
 {
     a13217(1);
+}
+
+/***************************************************/
+// 13840
+
+struct Foo13840
+{
+    int opApply(int delegate(int))
+    {
+        return 0;
+    }
+}
+
+void func13840()
+{
+}
+
+void test13840() nothrow
+{
+    try
+    {
+        foreach (i; Foo13840()) // generated delegate is throwable
+        {
+            func13840();        // throwable function call
+        }
+    }
+    catch
+    {}
 }
 
 // Add more tests regarding inferences later.


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13840
