### PR TITLE
Issue 13907 - Surrogate pairs in wchar string literal will cause incorrect length match

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -577,15 +577,19 @@ MATCH implicitConvTo(Expression *e, Type *t)
                         case Tsarray:
                             if (e->type->ty == Tsarray)
                             {
-                                if (((TypeSArray *)e->type)->dim->toInteger() !=
-                                    ((TypeSArray *)t)->dim->toInteger())
-                                    return;
                                 TY tynto = t->nextOf()->ty;
                                 if (tynto == tyn)
                                 {
-                                    result = MATCHexact;
+                                    if (((TypeSArray *)e->type)->dim->toInteger() ==
+                                        ((TypeSArray *)t)->dim->toInteger())
+                                    {
+                                        result = MATCHexact;
+                                    }
                                     return;
                                 }
+                                int szto = t->nextOf()->size();
+                                if (e->length(szto) != ((TypeSArray *)t)->dim->toInteger())
+                                    return;
                                 if (!e->committed && (tynto == Tchar || tynto == Twchar || tynto == Tdchar))
                                 {
                                     result = MATCHexact;
@@ -594,10 +598,10 @@ MATCH implicitConvTo(Expression *e, Type *t)
                             }
                             else if (e->type->ty == Tarray)
                             {
-                                if (e->length() >
-                                    ((TypeSArray *)t)->dim->toInteger())
-                                    return;
                                 TY tynto = t->nextOf()->ty;
+                                int sznto = t->nextOf()->size();
+                                if (e->length(sznto) != ((TypeSArray *)t)->dim->toInteger())
+                                    return;
                                 if (tynto == tyn)
                                 {
                                     result = MATCHexact;
@@ -609,6 +613,7 @@ MATCH implicitConvTo(Expression *e, Type *t)
                                     return;
                                 }
                             }
+                            /* fall through */
                         case Tarray:
                         case Tpointer:
                             Type *tn = t->nextOf();

--- a/src/expression.h
+++ b/src/expression.h
@@ -366,7 +366,7 @@ public:
     static StringExp *create(Loc loc, char *s);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
-    size_t length();
+    size_t length(int encSize = 4);
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
     int compare(RootObject *obj);

--- a/src/init.c
+++ b/src/init.c
@@ -873,12 +873,15 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
      * Allow this by doing an explicit cast, which will lengthen the string
      * literal.
      */
-    if (exp->op == TOKstring && tb->ty == Tsarray && ti->ty == Tsarray)
+    if (exp->op == TOKstring && tb->ty == Tsarray)
     {
         StringExp *se = (StringExp *)exp;
-        if (!se->committed && se->type->ty == Tsarray &&
-            ((TypeSArray *)se->type)->dim->toInteger() <
-            ((TypeSArray *)t)->dim->toInteger())
+        Type *typeb = se->type->toBasetype();
+        TY tynto = tb->nextOf()->ty;
+        if (!se->committed &&
+            (typeb->ty == Tarray || typeb->ty == Tsarray) &&
+            (tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
+            se->length(tb->nextOf()->size()) < ((TypeSArray *)tb)->dim->toInteger())
         {
             exp = se->castTo(sc, t);
             goto L1;
@@ -951,9 +954,9 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
         }
         exp = exp->implicitCastTo(sc, t);
     }
+L1:
     if (exp->op == TOKerror)
         return this;
-L1:
     if (needInterpret)
         exp = exp->ctfeInterpret();
     else

--- a/test/runnable/literal.d
+++ b/test/runnable/literal.d
@@ -1,8 +1,5 @@
-// REQUIRED_ARGS: -d
-// PERMUTE_ARGS: -dw
 
-import std.stdio;
-import core.stdc.stdlib;
+extern(C) int printf(const char*, ...);
 
 enum
 {
@@ -167,10 +164,48 @@ void test2()
         assert(e == 2_463_534_242UL);
 }
 
+/***************************************************/
+// 13907
+
+void f13907_1(wchar[1] a) {}
+void f13907_2(wchar[2] a) {}
+void f13907_3(wchar[3] a) {}
+
+auto f13907_12(char[1]) { return 1; }
+auto f13907_12(char[2]) { return 2; }
+
+void test13907()
+{
+    static assert(!__traits(compiles, { f13907_1("\U00010000"w); }));
+    static assert(!__traits(compiles, { f13907_1("\U00010000" ); }));
+    f13907_2("\U00010000"w);
+    f13907_2("\U00010000");
+    static assert(!__traits(compiles, { f13907_3("\U00010000"w); }));
+    static assert(!__traits(compiles, { f13907_3("\U00010000" ); }));
+
+    assert(f13907_12("a") == 1);
+
+    // regression tests for the lengthen behavior in initializer
+    enum const(char*) p = "hello world";
+    static assert(!__traits(compiles, { static   char[5] a = "hello world"; }));  // truncation is not allowed
+    static assert(!__traits(compiles, { static  void[20] a = "hello world"; }));
+    static assert(!__traits(compiles, { static   int[20] a = "hello world"; }));
+    static assert(!__traits(compiles, { static  char[20] a = "hello world"w; }));
+    static assert(!__traits(compiles, { static wchar[20] a = "hello world"d; }));
+    static assert(!__traits(compiles, { static dchar[20] a = "hello world"c; }));
+    static assert(!__traits(compiles, { static  char[20] a = p; }));
+    static  char[20] csa = "hello world";  // extending is allowed
+    static wchar[20] wsa = "hello world";  // ok
+    static dchar[20] dsa = "hello world";  // ok
+}
+
+/***************************************************/
+
 int main()
 {
     test1();
     test2();
+    test13907();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13907
