### PR TITLE
fix Issue 12092 - Wrong TLS access in PIC code (X86_32)

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -3086,17 +3086,10 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
 #if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
             if (s == tls_get_addr_sym)
             {
-                if (I32)
+                if (I64)
                 {
-                    /* Append a NOP so GNU linker has patch room
+                    /* Prepend 66 66 48 so GNU linker has patch room
                      */
-                    ce = gen1(ce, 0x90);        // NOP
-                    code_orflag(ce, CFvolatile);    // don't schedule it
-                }
-                else
-                {   /* Prepend 66 66 48 so GNU linker has patch room
-                     */
-                    assert(I64);
                     ce->Irex = REX | REX_W;
                     ce = cat(gen1(CNIL, 0x66), ce);
                     ce = cat(gen1(CNIL, 0x66), ce);

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -1302,7 +1302,7 @@ elem *el_picvar(symbol *s)
      *      MOV  EAX,s@GOT32[EBX]
      *      MOV  reg,[EAX]
      * For TLS var locals and globals:
-     *      MOV  EAX,s@TLS_GD[EBX]
+     *      LEA  EAX,s@TLS_GD[1*EBX+0] // must use SIB addressing
      *      CALL ___tls_get_addr@PLT32
      *      MOV  reg,[EAX]
      *****************************************
@@ -1411,14 +1411,13 @@ elem *el_picvar(symbol *s)
             tym_t tym = e->Ety;
             e->Eoper = OPrelconst;
             e->Ety = TYnptr;
-            e = el_bin(OPadd, TYnptr, e, el_var(el_alloc_localgot()));
 
             if (s->Stype->Tty & mTYthread)
             {
                 /* Add "volatile" to prevent e from being common subexpressioned.
                  * This is so we can preserve the magic sequence of instructions
                  * that the gnu linker patches:
-                 *   lea EAX,x@tlsgd[EBX], call __tls_get_addr@plt
+                 *   lea EAX,x@tlsgd[1*EBX+0], call __tls_get_addr@plt
                  *      =>
                  *   mov EAX,gs[0], sub EAX,x@tpoff
                  * elf32-i386.c
@@ -1433,6 +1432,10 @@ elem *el_picvar(symbol *s)
                     symbol_keep(tls_get_addr_sym);
                 }
                 e = el_bin(OPcall, TYnptr, el_var(tls_get_addr_sym), e);
+            }
+            else
+            {
+                e = el_bin(OPadd, TYnptr, e, el_var(el_alloc_localgot()));
             }
 
             switch (op * 2 + x)

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -1472,11 +1472,7 @@ elem * el_var(symbol *s)
     //printf("el_var(s = '%s')\n", s->Sident);
     //printf("%x\n", s->Stype->Tty);
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-    // OSX is currently always pic
     if (config.flags3 & CFG3pic &&
-#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-        (!(s->Stype->Tty & mTYthread) || I64) &&
-#endif
         !tyfunc(s->ty()))
         // Position Independent Code
         return el_picvar(s);

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -2974,7 +2974,8 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                             if (config.flags3 & CFG3pic)
                             {
                                 if (s->Sclass == SCstatic || s->Sclass == SClocstat)
-                                    relinfo = R_X86_64_TLSGD;  // TLS_GD?
+                                    // Could use 'local dynamic (LD)' to optimize multiple local TLS reads
+                                    relinfo = R_X86_64_TLSGD;
                                 else
                                     relinfo = R_X86_64_TLSGD;
                             }
@@ -2991,9 +2992,10 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                             if (config.flags3 & CFG3pic)
                             {
                                 if (s->Sclass == SCstatic)
-                                    relinfo = R_386_TLS_LE;  // TLS_GD?
+                                    // Could use 'local dynamic (LD)' to optimize multiple local TLS reads
+                                    relinfo = R_386_TLS_GD;
                                 else
-                                    relinfo = R_386_TLS_IE;
+                                    relinfo = R_386_TLS_GD;
                             }
                             else
                             {


### PR DESCRIPTION
- fix code sequence to access TLS variables in 32-bit PIC code
- currently uses text relocations

[Issue 12092 – Wrong TLS access in PIC code (X86_32)](https://issues.dlang.org/show_bug.cgi?id=12092)
