### PR TITLE
[cleanup] Remove dead code for old safe/system module syntax

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -90,7 +90,6 @@ Module::Module(const char *filename, Identifier *ident, int doDocComment, int do
 
     macrotable = NULL;
     escapetable = NULL;
-    safe = false;
     doppelganger = 0;
     cov = NULL;
     covb = NULL;
@@ -538,7 +537,6 @@ void Module::parse()
          * the name of this module.
          */
         this->ident = md->id;
-        this->safe = md->safe;
         Package *ppack = NULL;
         dst = Package::resolve(md->packages, &this->parent, &ppack);
         assert(dst);
@@ -1055,12 +1053,11 @@ bool Module::rootImports()
 
 /* =========================== ModuleDeclaration ===================== */
 
-ModuleDeclaration::ModuleDeclaration(Loc loc, Identifiers *packages, Identifier *id, bool safe)
+ModuleDeclaration::ModuleDeclaration(Loc loc, Identifiers *packages, Identifier *id)
 {
     this->loc = loc;
     this->packages = packages;
     this->id = id;
-    this->safe = safe;
     this->isdeprecated = false;
     this->msg = NULL;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -110,7 +110,6 @@ public:
 
     Macro *macrotable;          // document comment macros
     Escape *escapetable;        // document comment escapes
-    bool safe;                  // true if module is marked as 'safe'
 
     size_t nameoffset;          // offset of module name from start of ModuleInfo
     size_t namelen;             // length of module name in characters
@@ -182,11 +181,10 @@ struct ModuleDeclaration
     Loc loc;
     Identifier *id;
     Identifiers *packages;            // array of Identifier's representing packages
-    bool safe;
     bool isdeprecated;  // if it is a deprecated module
     Expression *msg;
 
-    ModuleDeclaration(Loc loc, Identifiers *packages, Identifier *id, bool safe);
+    ModuleDeclaration(Loc loc, Identifiers *packages, Identifier *id);
 
     char *toChars();
 };

--- a/src/parse.c
+++ b/src/parse.c
@@ -170,29 +170,8 @@ Dsymbols *Parser::parseModule()
     if (token.value == TOKmodule)
     {
         Loc loc = token.loc;
-        bool safe = false;
 
         nextToken();
-#if 0
-        if (token.value == TOKlparen)
-        {
-            nextToken();
-            if (token.value != TOKidentifier)
-            {
-                error("module (system) identifier expected");
-                goto Lerr;
-            }
-            Identifier *id = token.ident;
-
-            if (id == Id::system)
-                safe = true;
-            else
-                error("(safe) expected, not %s", id->toChars());
-            nextToken();
-            check(TOKrparen);
-        }
-#endif
-
         if (token.value != TOKidentifier)
         {
             error("identifier expected following module");
@@ -218,7 +197,7 @@ Dsymbols *Parser::parseModule()
                 id = token.ident;
             }
 
-            md = new ModuleDeclaration(loc, a, id, safe);
+            md = new ModuleDeclaration(loc, a, id);
             md->isdeprecated = isdeprecated;
             md->msg = msg;
 


### PR DESCRIPTION
This is the code to support the old `module (system) xxx;` syntax.
