### PR TITLE
[cleanup] Remove Lexer's unneeded dependency on module.h

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -29,7 +29,6 @@
 #include "utf.h"
 #include "identifier.h"
 #include "id.h"
-#include "module.h"
 
 extern int HtmlNamedEntity(const utf8_t *p, size_t length);
 
@@ -246,19 +245,18 @@ Token *Lexer::freelist = NULL;
 StringTable Lexer::stringtable;
 OutBuffer Lexer::stringbuffer;
 
-Lexer::Lexer(Module *mod,
+Lexer::Lexer(const char *filename,
         const utf8_t *base, size_t begoffset, size_t endoffset,
         int doDocComment, int commentToken)
 {
-    scanloc = Loc(mod, 1, 1);
+    scanloc = Loc(filename, 1, 1);
     //printf("Lexer::Lexer(%p,%d)\n",base,length);
-    //printf("lexer.mod = %p, %p\n", mod, this->loc.mod);
+    //printf("lexer.filename = %s\n", filename);
     memset(&token,0,sizeof(token));
     this->base = base;
     this->end  = base + endoffset;
     p = base + begoffset;
     line = p;
-    this->mod = mod;
     this->doDocComment = doDocComment;
     this->anyToken = 0;
     this->commentToken = commentToken;
@@ -2353,10 +2351,10 @@ void Lexer::poundLine()
                 continue;                       // skip white space
 
             case '_':
-                if (mod && memcmp(p, "__FILE__", 8) == 0)
+                if (memcmp(p, "__FILE__", 8) == 0)
                 {
                     p += 8;
-                    filespec = mem.strdup(scanloc.filename ? scanloc.filename : mod->ident->toChars());
+                    filespec = mem.strdup(scanloc.filename);
                     continue;
                 }
                 goto Lerr;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -21,7 +21,6 @@
 
 struct StringTable;
 class Identifier;
-class Module;
 
 /* Tokens:
         (       )
@@ -245,13 +244,12 @@ public:
     const utf8_t *p;           // current character
     const utf8_t *line;        // start of current line
     Token token;
-    Module *mod;
     int doDocComment;           // collect doc comment information
     int anyToken;               // !=0 means seen at least one token
     int commentToken;           // !=0 means comments are TOKcomment's
     bool errors;                // errors occurred during lexing or parsing
 
-    Lexer(Module *mod,
+    Lexer(const char *filename,
         const utf8_t *base, size_t begoffset, size_t endoffset,
         int doDocComment, int commentToken);
 

--- a/src/mars.c
+++ b/src/mars.c
@@ -183,11 +183,11 @@ char *Loc::toChars()
     return buf.extractString();
 }
 
-Loc::Loc(Module *mod, unsigned linnum, unsigned charnum)
+Loc::Loc(const char *filename, unsigned linnum, unsigned charnum)
 {
     this->linnum = linnum;
     this->charnum = charnum;
-    this->filename = mod ? mod->srcfile->toChars() : NULL;
+    this->filename = filename;
 }
 
 bool Loc::equals(const Loc& loc)

--- a/src/mars.h
+++ b/src/mars.h
@@ -313,7 +313,7 @@ struct Loc
         filename = NULL;
     }
 
-    Loc(Module *mod, unsigned linnum, unsigned charnum);
+    Loc(const char *filename, unsigned linnum, unsigned charnum);
 
     char *toChars();
     bool equals(const Loc& loc);

--- a/src/parse.c
+++ b/src/parse.c
@@ -56,9 +56,10 @@
 #define CARRAYDECL      1
 
 Parser::Parser(Module *module, const utf8_t *base, size_t length, int doDocComment)
-    : Lexer(module, base, 0, length, doDocComment, 0)
+    : Lexer(module ? module->srcfile->toChars() : NULL, base, 0, length, doDocComment, 0)
 {
     //printf("Parser::Parser()\n");
+    mod = module;
     md = NULL;
     linkage = LINKd;
     endloc = Loc();
@@ -73,7 +74,7 @@ Parser::Parser(Module *module, const utf8_t *base, size_t length, int doDocComme
  *      loc     location in source file of mixin
  */
 Parser::Parser(Loc loc, Module *module, const utf8_t *base, size_t length, int doDocComment)
-    : Lexer(module, base, 0, length, doDocComment, 0)
+    : Lexer(module ? module->srcfile->toChars() : NULL, base, 0, length, doDocComment, 0)
 {
     //printf("Parser::Parser()\n");
     scanloc = loc;
@@ -88,6 +89,7 @@ Parser::Parser(Loc loc, Module *module, const utf8_t *base, size_t length, int d
         scanloc.filename = filename;
     }
 
+    mod = module;
     md = NULL;
     linkage = LINKd;
     endloc = Loc();

--- a/src/parse.h
+++ b/src/parse.h
@@ -65,6 +65,7 @@ enum ParseStatementFlags
 class Parser : public Lexer
 {
 public:
+    Module *mod;
     ModuleDeclaration *md;
     LINK linkage;
     Loc endloc;                 // set to location of last right curly


### PR DESCRIPTION
Also remove the `Module` constructor from `Loc`.

@WalterBright 
