### PR TITLE
[DDMD] Eliminate DMDV1/DMDV2

### DIFF
--- a/src/mars.h
+++ b/src/mars.h
@@ -73,9 +73,6 @@ the target object file format:
 
 void unittests();
 
-#define DMDV1   0
-#define DMDV2   1       // Version 2.0 features
-
 struct OutBuffer;
 
 // Can't include arraytypes.h here, need to declare these directly.

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -92,7 +92,7 @@ MMD=-MMD -MF $(basename $@).deps
 # Default compiler flags for all source files
 CFLAGS := $(WARNINGS) \
 	-fno-exceptions -fno-rtti \
-	-D__pascal= -DMARS=1 -DTARGET_$(OS_UPCASE)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 \
+	-D__pascal= -DMARS=1 -DTARGET_$(OS_UPCASE)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 -DDMDV2=1 \
 
 ifneq (,$(DEBUG))
 ENABLE_DEBUG := 1

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -121,7 +121,7 @@ BFLAGS=
 # Compile flags
 CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
 # Compile flags for modules with backend/toolkit dependencies
-MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
+MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1 -DDMDV2=1
 # Recursive make
 DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT)
 


### PR DESCRIPTION
These are now only used in a single place each in the backend, and them in a frontend header no longer makes sense.
