### PR TITLE
[DDMD] Make it possible to automatically convert outbuffer.c/outbuffer.h to D

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -420,19 +420,19 @@ void escapeDdocString(OutBuffer *buf, size_t start)
         {
             case '$':
                 buf->remove(u, 1);
-                buf->insert(u, "$(DOLLAR)", 9);
+                buf->insert(u, (const char *)"$(DOLLAR)", 9);
                 u += 8;
                 break;
 
             case '(':
                 buf->remove(u, 1); //remove the (
-                buf->insert(u, "$(LPAREN)", 9); //insert this instead
+                buf->insert(u, (const char *)"$(LPAREN)", 9); //insert this instead
                 u += 8; //skip over newly inserted macro
                 break;
 
             case ')':
                 buf->remove(u, 1); //remove the )
-                buf->insert(u, "$(RPAREN)", 9); //insert this instead
+                buf->insert(u, (const char *)"$(RPAREN)", 9); //insert this instead
                 u += 8; //skip over newly inserted macro
                 break;
         }
@@ -472,7 +472,7 @@ void escapeStrayParenthesis(OutBuffer *buf, size_t start, Dsymbol *s)
                     warning(loc, "Ddoc: Stray ')'. This may cause incorrect Ddoc output."
                         " Use $(RPAREN) instead for unpaired right parentheses.");
                     buf->remove(u, 1); //remove the )
-                    buf->insert(u, "$(RPAREN)", 9); //insert this instead
+                    buf->insert(u, (const char *)"$(RPAREN)", 9); //insert this instead
                     u += 8; //skip over newly inserted macro
                 }
                 else
@@ -507,7 +507,7 @@ void escapeStrayParenthesis(OutBuffer *buf, size_t start, Dsymbol *s)
                         warning(loc, "Ddoc: Stray '('. This may cause incorrect Ddoc output."
                             " Use $(LPAREN) instead for unpaired left parentheses.");
                         buf->remove(u, 1); //remove the (
-                        buf->insert(u, "$(LPAREN)", 9); //insert this instead
+                        buf->insert(u, (const char *)"$(LPAREN)", 9); //insert this instead
                     }
                     else
                         par_open--;
@@ -2408,7 +2408,7 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, size_t offset)
                         highlightCode2(sc, s, &codebuf, 0);
                         buf->remove(iCodeStart, i - iCodeStart);
                         i = buf->insert(iCodeStart, codebuf.data, codebuf.offset);
-                        i = buf->insert(i, ")\n", 2);
+                        i = buf->insert(i, (const char *)")\n", 2);
                         i -= 2; // in next loop, c should be '\n'
                     }
                     else

--- a/src/macro.c
+++ b/src/macro.c
@@ -314,7 +314,7 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
                 buf->data[u] = 0xFF;
                 buf->data[u + 1] = '{';
                 buf->insert(u + 2, marg, marglen);
-                buf->insert(u + 2 + marglen, "\xFF}", 2);
+                buf->insert(u + 2 + marglen, (const char *)"\xFF}", 2);
                 end += -2 + 2 + marglen + 2;
 
                 // Scan replaced text for further expansion

--- a/src/root/outbuffer.c
+++ b/src/root/outbuffer.c
@@ -19,23 +19,6 @@
 
 #include "outbuffer.h"
 #include "object.h"
-#include "rmem.h"
-
-OutBuffer::OutBuffer()
-{
-    data = NULL;
-    offset = 0;
-    size = 0;
-
-    doindent = 0;
-    level = 0;
-    notlinehead = 0;
-}
-
-OutBuffer::~OutBuffer()
-{
-    mem.free(data);
-}
 
 char *OutBuffer::extractData()
 {
@@ -55,7 +38,7 @@ void OutBuffer::reserve(size_t nbytes)
     {
         size = (offset + nbytes) * 2;
         size = (size + 15) & ~15;
-        data = (utf8_t *)mem.realloc(data, size);
+        data = (unsigned char *)mem.realloc(data, size);
     }
 }
 
@@ -300,12 +283,6 @@ void OutBuffer::fill0(size_t nbytes)
     reserve(nbytes);
     memset(data + offset,0,nbytes);
     offset += nbytes;
-}
-
-void OutBuffer::align(size_t size)
-{
-    size_t nbytes = ((offset + size - 1) & ~(size - 1)) - offset;
-    fill0(nbytes);
 }
 
 void OutBuffer::vprintf(const char *format, va_list args)

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <assert.h>
 #include "port.h"
+#include "rmem.h"
 
 #if __DMC__
 #pragma once
@@ -32,8 +33,20 @@ struct OutBuffer
     int level;
     int notlinehead;
 
-    OutBuffer();
-    ~OutBuffer();
+    OutBuffer()
+    {
+        data = NULL;
+        offset = 0;
+        size = 0;
+
+        doindent = 0;
+        level = 0;
+        notlinehead = 0;
+    }
+    ~OutBuffer()
+    {
+        mem.free(data);
+    }
     char *extractData();
 
     void reserve(size_t nbytes);
@@ -54,7 +67,6 @@ struct OutBuffer
     void write(OutBuffer *buf);
     void write(RootObject *obj);
     void fill0(size_t nbytes);
-    void align(size_t size);
     void vprintf(const char *format, va_list args);
     void printf(const char *format, ...);
     void bracket(char left, char right);


### PR DESCRIPTION
- Work around https://issues.dlang.org/show_bug.cgi?id=11837 which I had previously worked around in the manually-written outbuffer.d
- Move constructor and destructor definitions into the header.  D is not capable of generating these (especially the no-args ctor) and they therefore always need to be defined on the C++ side, even if the rest of `OutBuffer`'s functions are implemented in D.
- Fix a `char*` vs `ubyte*` mistmatch (they are the same in C++ but not in D)
- Remove the unused `align` method
