### PR TITLE
[DDMD] Make it possible to automatically convert stringtable.c/stringtable.h to D

### DIFF
--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -24,21 +24,12 @@ struct StringEntry;
 struct StringValue
 {
     void *ptrvalue;
-private:
     size_t length;
-
-#ifndef IN_GCC
-    // Disable warning about nonstandard extension
-    #pragma warning (disable : 4200)
-#endif
     char lstring[];
 
-public:
     size_t len() const { return length; }
-    const char *toDchars() const { return lstring; }
+    const char *toDchars() const { return (char *)lstring; }
 
-private:
-    friend struct StringTable;
     StringValue();  // not constructible
 };
 
@@ -49,7 +40,8 @@ private:
     size_t tabledim;
 
     uint8_t **pools;
-    size_t npools, nfill;
+    size_t npools;
+    size_t nfill;
 
     size_t count;
 


### PR DESCRIPTION
- Add casts to alloy the zero-length array to be convereted to a pointer or dereferenced in D.
- Remove ref variable
- Remove pragma (building with g++ doesn't actually seem to emit the warning anyway)
- Remove the unaligned load code (the optimizer should be able to do it anyway)
- Remove the friend declaration
