### PR TITLE
[cleanup] [trivial] Remove unused forward decl and dead code in comment

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -232,9 +232,7 @@ typedef d_uns32                 d_dchar;
 
 typedef longdouble real_t;
 
-class Module;
-
-//typedef unsigned Loc;         // file location
+// file location
 struct Loc
 {
     const char *filename;


### PR DESCRIPTION
The `Module` decl was previously used in the ctor that took a `Module`.
