### PR TITLE
[cleanup] [trivial] Remove dead PragmaStatement code

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -962,25 +962,6 @@ bool arrayExpressionSemantic(Expressions *exps, Scope *sc)
     return err;
 }
 
-
-/******************************
- * Perform canThrow() on an array of Expressions.
- */
-
-int arrayExpressionCanThrow(Expressions *exps, FuncDeclaration *func, bool mustNotThrow)
-{
-    if (exps)
-    {
-        for (size_t i = 0; i < exps->dim; i++)
-        {
-            Expression *e = (*exps)[i];
-            if (e && canThrow(e, func, mustNotThrow))
-                return 1;
-        }
-    }
-    return 0;
-}
-
 /****************************************
  * Expand tuples.
  * Input:

--- a/src/expression.h
+++ b/src/expression.h
@@ -62,7 +62,6 @@ int expandAliasThisTuples(Expressions *exps, size_t starti = 0);
 FuncDeclaration *hasThis(Scope *sc);
 Expression *fromConstInitializer(int result, Expression *e);
 bool arrayExpressionSemantic(Expressions *exps, Scope *sc);
-int arrayExpressionCanThrow(Expressions *exps, FuncDeclaration *func, bool mustNotThrow);
 TemplateDeclaration *getFuncTemplateDecl(Dsymbol *s);
 Expression *valueNoDtor(Expression *e);
 int modifyFieldVar(Loc loc, Scope *sc, VarDeclaration *var, Expression *e1);

--- a/src/statement.c
+++ b/src/statement.c
@@ -471,12 +471,6 @@ int Statement::blockExit(FuncDeclaration *func, bool mustNotThrow)
         void visit(PragmaStatement *s)
         {
             result = BEfallthru;
-        #if 0 // currently, no code is generated for Pragma's, so it's just fallthru
-            if (arrayExpressionCanThrow(s->args, func, mustNotThrow))
-                result |= BEthrow;
-            if (s->body)
-                result |= s->body->blockExit(func, mustNotThrow);
-        #endif
         }
 
         void visit(StaticAssertStatement *s)


### PR DESCRIPTION
Deal, long dead.  The `arrayExpressionCanThrow` function could technically be useful in the future, but it's trivial to re-create and will just rot if left there.
