### PR TITLE
Issue 10989 - [CTFE] Uncaught exception messages are not pretty printed if message wasn't literal

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -142,7 +142,7 @@ char *ThrownExceptionExp::toChars()
 // Generate an error message when this exception is not caught
 void ThrownExceptionExp::generateUncaughtError()
 {
-    Expression *e = (*thrown->value->elements)[0];
+    Expression *e = resolveSlice((*thrown->value->elements)[0]);
     StringExp *se = e->toStringExp();
     thrown->error("uncaught CTFE exception %s(%s)", thrown->type->toChars(), se ? se->toChars() : e->toChars());
 

--- a/test/fail_compilation/ctfe10989.d
+++ b/test/fail_compilation/ctfe10989.d
@@ -12,3 +12,25 @@ int throwing()
     return 0;
 }
 static assert(throwing());
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ctfe10989.d(33): Error: uncaught CTFE exception object.Exception("abc"c)
+fail_compilation/ctfe10989.d(36):        called from here: throwing2()
+fail_compilation/ctfe10989.d(36):        while evaluating: static assert(throwing2())
+---
+*/
+int throwing2()
+{
+    string msg = "abc";
+
+    char[] arr;
+    arr.length = msg.length;
+    arr = arr[0 .. $];
+    arr[] = msg;
+
+    throw new Exception(cast(string)arr);
+    return 0;
+}
+static assert(throwing2());


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=10989

Fix the remained case.
