### PR TITLE
Fix issue 13937 -  C++ mangling for template negative parameter not correct for dmc

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -1477,6 +1477,12 @@ private:
                         {
                             tmp.mangleNumber(e->toUInteger());
                         }
+                        else if(is_dmc_template)
+                        {
+                            // NOTE: DMC mangles everything based on
+                            // unsigned int
+                            tmp.mangleNumber(e->toInteger());
+                        }
                         else
                         {
                             sinteger_t val = e->toInteger();

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -5,14 +5,6 @@ import core.stdc.stdio;
 import core.stdc.stdarg;
 import core.stdc.config;
 
-// BUG: fix for 13932 doesn't work on Win32 for some reason. Therefore
-// it is disabled on Windows 32-bit, but enabled on all other platforms.
-version(Win32) {}
-else
-{
-    version = doTest13932;
-}
-
 extern (C++)
         int foob(int i, int j, int k);
 
@@ -639,15 +631,12 @@ void test13707()
 
 /****************************************/
 
-version(doTest13932)
-{
 struct S13932(int x)
 {
         int member;
 }
 
 extern(C++) void func13932(S13932!(-1) s);
-}
 
 /****************************************/
 
@@ -674,8 +663,7 @@ void main()
     test15();
     test16();
     func13707();
-    version(doTest13932)
-        func13932(S13932!(-1)(0));
+    func13932(S13932!(-1)(0));
 
     printf("Success\n");
 }


### PR DESCRIPTION
During testing for https://issues.dlang.org/show_bug.cgi?id=13932 we found that win32 does not link whereas before it did.

To move along the pull, I commented out the test for win32, but it resulted in a regression (https://issues.dlang.org/show_bug.cgi?id=13937)

This should fix the regression.
