### PR TITLE
do not use nonstandard C++ extension "char lstring[]"

### DIFF
--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -82,7 +82,8 @@ struct StringEntry
 
 uint32_t StringTable::allocValue(const char *s, size_t length)
 {
-    const size_t nbytes = sizeof(StringValue) + length + 1;
+    enum { offset_lstring = sizeof(StringValue().ptrvalue) + sizeof(StringValue().length) };
+    const size_t nbytes = offset_lstring + length + 1;
 
     if (!npools || nfill + nbytes > POOL_SIZE)
     {

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -18,14 +18,13 @@
 
 struct StringEntry;
 
-// StringValue is a variable-length structure as indicated by the last array
-// member with unspecified size.  It has neither proper c'tors nor a factory
-// method because the only thing which should be creating these is StringTable.
+// StringValue is a variable-length structure. It has neither proper c'tors nor a
+// factory method because the only thing which should be creating these is StringTable.
 struct StringValue
 {
     void *ptrvalue;
     size_t length;
-    char lstring[];
+    char lstring[1]; // variable length
 
     size_t len() const { return length; }
     const char *toDchars() const { return (char *)lstring; }


### PR DESCRIPTION
avoid blizzard of warnings with cl: "nonstandard extension used : zero-sized array in struct/union"
