### PR TITLE
Issue 13938 & 13939 - Disallow non-trivial variable accesses in iasm

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2366,6 +2366,8 @@ static void asm_merge_symbol(OPND *o1, Dsymbol *s)
         }
         if (v->isThreadlocal())
             error(asmstate.loc, "cannot directly load TLS variable '%s'", v->toChars());
+        else if (v->isDataseg() && global.params.pic)
+            error(asmstate.loc, "cannot directly load global variable '%s' with PIC code", v->toChars());
     }
     em = s->isEnumMember();
     if (em)

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2364,6 +2364,8 @@ static void asm_merge_symbol(OPND *o1, Dsymbol *s)
                 return;
             }
         }
+        if (v->isThreadlocal())
+            error(asmstate.loc, "cannot directly load TLS variable '%s'", v->toChars());
     }
     em = s->isEnumMember();
     if (em)

--- a/test/Makefile
+++ b/test/Makefile
@@ -118,8 +118,13 @@ DISABLED_TESTS += dhry
 # runnable/dhry.d(488): Error: undefined identifier dtime
 endif
 
+ifeq ($(OS),win32)
+DISABLED_FAIL_TESTS += fail13939
+endif
+
 ifeq ($(OS),win64)
 DISABLED_TESTS += testxmm
+DISABLED_FAIL_TESTS += fail13939
 endif
 
 ifeq ($(OS),osx)
@@ -158,6 +163,9 @@ $(RESULTS_DIR)/compilable/%.d.out: compilable/%.d $(RESULTS_DIR)/.created $(RESU
 $(RESULTS_DIR)/compilable/%.sh.out: compilable/%.sh $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test$(EXE) $(DMD)
 	$(QUIET) echo " ... $(<D)/$*.sh"
 	$(QUIET) ./$(<D)/$*.sh
+
+$(addsuffix .d.out,$(addprefix $(RESULTS_DIR)/fail_compilation/,$(DISABLED_FAIL_TESTS))): $(RESULTS_DIR)/.created
+	$(QUIET) echo " ... $@ - disabled"
 
 $(RESULTS_DIR)/fail_compilation/%.d.out: fail_compilation/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test$(EXE) $(DMD)
 	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d

--- a/test/fail_compilation/fail13938.d
+++ b/test/fail_compilation/fail13938.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13938.d(14): Error: cannot directly load TLS variable 'val'
+---
+*/
+
+void test1()
+{
+    static int val;
+    asm
+    {
+        mov EAX, val;
+    }
+}

--- a/test/fail_compilation/fail13939.d
+++ b/test/fail_compilation/fail13939.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -o- -fPIC
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13939.d(14): Error: cannot directly load global variable 'val' with PIC code
+---
+*/
+version(Windows) static assert(0);
+void test1()
+{
+    __gshared int val;
+    asm
+    {
+        mov EAX, val;
+    }
+}

--- a/test/runnable/s2ir.d
+++ b/test/runnable/s2ir.d
@@ -4,17 +4,26 @@ import std.stdio;
 /***********************************/
 
 void test1()
-{   int i;
+{
+    int i;
     __gshared int j;
 
     version (D_InlineAsm_X86)
     {
-    asm
-    {
-	naked		;
-	mov EAX, i	;
-	mov EAX, j	;
-    }
+        asm
+        {
+            naked       ;
+            mov EAX, i  ;
+        }
+      version(OSX)
+      {}
+      else
+      {
+        asm
+        {
+            mov EAX, j  ;
+        }
+      }
     }
 }
 
@@ -24,8 +33,8 @@ int main()
 {
     for (int i = 0; ; i++)
     {
-	if (i == 10)
-	    break;
+        if (i == 10)
+            break;
     }
 
     string[] a = new string[3];
@@ -34,53 +43,53 @@ int main()
     a[2] = "foo";
 
     foreach (string s; a)
-	writefln(s);
+        writefln(s);
 
     switch (1)
     {
-	default:
-	    break;
+        default:
+            break;
     }
 
     switch ("foo"w)
     {
-	case "foo":
-	    break;
-	default: assert(0);
+        case "foo":
+            break;
+        default: assert(0);
     }
 
     switch (1)
     {
-	case 1:
-	    try
-	    {
-		goto default;
-	    }
-	    catch (Throwable o)
-	    {
-	    }
-	    break;
+        case 1:
+            try
+            {
+                goto default;
+            }
+            catch (Throwable o)
+            {
+            }
+            break;
 
-	default:
-	    break;
+        default:
+            break;
     }
 
     switch (1)
     {
-	case 1:
-	    try
-	    {
-		goto case 2;
-	    }
-	    catch (Throwable o)
-	    {
-	    }
-	    break;
+        case 1:
+            try
+            {
+                goto case 2;
+            }
+            catch (Throwable o)
+            {
+            }
+            break;
 
-	case 2:
-	    break;
+        case 2:
+            break;
 
-	default: assert(0);
+        default: assert(0);
     }
 
     writefln("Success\n");


### PR DESCRIPTION
[Issue 13938](https://issues.dlang.org/show_bug.cgi?id=13938) - IASM shouldn't be able to access TLS variables
[Issue 13939](https://issues.dlang.org/show_bug.cgi?id=13939) - IASM shouldn't access global symbol with PIC code
