### PR TITLE
Issue 13955 - 64 bit C ABI not followed for passing structs with mixed floating types

### DIFF
--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -429,7 +429,8 @@ TypeTuple *toArgTypes(Type *t)
                 {
                     if (t1->isfloating() && t2->isfloating())
                     {
-                        if (t1->ty == Tfloat64 && t2->ty == Tfloat64)
+                        if ((t1->ty == Tfloat32 || t1->ty == Tfloat64) &&
+                            (t2->ty == Tfloat32 || t2->ty == Tfloat64))
                             ;
                         else
                             goto Lmemory;

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -339,6 +339,51 @@ void test12825()
 
 /****************************************/
 
+struct S13955a
+{
+    float a;
+    double b;
+}
+
+struct S13955b
+{
+    double a;
+    float b;
+}
+
+struct S13955c
+{
+    float a;
+    float b;
+}
+
+struct S13955d
+{
+    double a;
+    double b;
+}
+
+extern(C++) void check13955(S13955a a, S13955b b, S13955c c, S13955d d)
+{
+    assert(a.a == 2);
+    assert(a.b == 4);
+    assert(b.a == 8);
+    assert(b.b == 16);
+    assert(c.a == 32);
+    assert(c.b == 64);
+    assert(d.a == 128);
+    assert(d.b == 256);
+}
+
+extern(C++) void func13955(S13955a a, S13955b b, S13955c c, S13955d d);
+
+void test13955()
+{
+    func13955(S13955a(2, 4), S13955b(8, 16), S13955c(32, 64), S13955d(128, 256));
+}
+
+/****************************************/
+
 extern(C++) class C13161
 {
     void dummyfunc() {}
@@ -654,6 +699,7 @@ void main()
     test11802();
     test9();
     test10();
+    test13955();
     test11();
     testvalist();
     test12825();

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -182,6 +182,39 @@ extern "C" { int foo7()
 
 /**************************************/
 
+struct S13955a
+{
+    float a;
+    double b;
+};
+
+struct S13955b
+{
+    double a;
+    float b;
+};
+
+struct S13955c
+{
+    float a;
+    float b;
+};
+
+struct S13955d
+{
+    double a;
+    double b;
+};
+
+void check13955(S13955a a, S13955b b, S13955c c, S13955d d);
+
+void func13955(S13955a a, S13955b b, S13955c c, S13955d d)
+{
+    check13955(a, b, c, d);
+}
+
+/**************************************/
+
 struct Struct10071
 {
     void *p;


### PR DESCRIPTION
Check code in argtypes.c should be checking that both types can be passed in xmm registers.

https://issues.dlang.org/show_bug.cgi?id=13955
