### PR TITLE
Issue 13956 - 64 bit C ABI not followed for passing empty structs

### DIFF
--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -307,7 +307,7 @@ TypeTuple *toArgTypes(Type *t)
         void visit(TypeStruct *t)
         {
             //printf("TypeStruct::toArgTypes() %s\n", t->toChars());
-            if (!t->sym->isPOD())
+            if (!t->sym->isPOD() || t->sym->fields.dim == 0)
             {
             Lmemory:
                 //printf("\ttoArgTypes() %s => [ ]\n", t->toChars());

--- a/src/toir.c
+++ b/src/toir.c
@@ -865,6 +865,8 @@ RET retStyle(TypeFunction *tf)
                 return RETregs;
             if (!sd->isPOD() || sz >= 8)
                 return RETstack;
+            if (sd->fields.dim == 0)
+                return RETstack;
         }
         if (sz <= 16 && !(sz & (sz - 1)))
             return RETregs;

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -240,6 +240,30 @@ void test11802()
 
 
 /****************************************/
+
+struct S13956
+{
+}
+
+extern(C++) void func13956(S13956 arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6);
+
+extern(C++) void check13956(S13956 arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6)
+{
+    assert(arg0 == S13956());
+    assert(arg1 == 1);
+    assert(arg2 == 2);
+    assert(arg3 == 3);
+    assert(arg4 == 4);
+    assert(arg5 == 5);
+    assert(arg6 == 6);
+}
+
+void test13956()
+{
+    func13956(S13956(), 1, 2, 3, 4, 5, 6);
+}
+
+/****************************************/
 // 5148
 
 extern (C++)
@@ -646,6 +670,7 @@ void main()
     test2();
     test3();
     test4();
+    test13956();
     test5();
     test6();
     test10071();

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -312,6 +312,19 @@ void foo14f(std::char_traits<char>* x, std::basic_string<char> *p, std::basic_st
 
 /**************************************/
 
+struct S13956
+{
+};
+
+void check13956(S13956 arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6);
+
+void func13956(S13956 arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6)
+{
+    check13956(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+}
+
+/**************************************/
+
 wchar_t f13289_cpp_wchar_t(wchar_t ch)
 {
     if (ch <= L'z' && ch >= L'a')


### PR DESCRIPTION
Empty structs should never be allocated a register.

I would have done this in the backend, but by the time `FuncParamRegs::alloc` is reached the type of the argument appears to be `char`, and the empty struct is unrecognizable.

https://issues.dlang.org/show_bug.cgi?id=13956
