### PR TITLE
refactor: make allocation of variable length structure StringValue less brittle

### DIFF
--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -24,10 +24,10 @@ struct StringValue
 {
     void *ptrvalue;
     size_t length;
-    char lstring[1]; // variable length
+    char *lstring() { return (char *)(this + 1); }
 
     size_t len() const { return length; }
-    const char *toDchars() const { return (char *)lstring; }
+    const char *toDchars() const { return (char *)(this + 1); }
 
     StringValue();  // not constructible
 };


### PR DESCRIPTION
followup for #4257: replaces StringValue.lstring[] with function lstring() returning (this + 1)
