### PR TITLE
[REG2.067a] Issue 13966 - dmd: expression.c:3761: size_t StringExp::length(int):Assertion `encSize == 1 || encSize == 2 || encSize == 4' failed.

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -589,8 +589,11 @@ MATCH implicitConvTo(Expression *e, Type *t)
                                     return;
                                 }
                                 int szto = (int)t->nextOf()->size();
-                                if (e->length(szto) != ((TypeSArray *)t)->dim->toInteger())
+                                if ((tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
+                                    e->length(szto) != ((TypeSArray *)t)->dim->toInteger())
+                                {
                                     return;
+                                }
                                 if (!e->committed && (tynto == Tchar || tynto == Twchar || tynto == Tdchar))
                                 {
                                     result = MATCHexact;
@@ -601,8 +604,11 @@ MATCH implicitConvTo(Expression *e, Type *t)
                             {
                                 TY tynto = t->nextOf()->ty;
                                 int sznto = (int)t->nextOf()->size();
-                                if (e->length(sznto) != ((TypeSArray *)t)->dim->toInteger())
+                                if ((tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
+                                    e->length(sznto) != ((TypeSArray *)t)->dim->toInteger())
+                                {
                                     return;
+                                }
                                 if (tynto == tyn)
                                 {
                                     result = MATCHexact;

--- a/test/runnable/literal.d
+++ b/test/runnable/literal.d
@@ -197,6 +197,12 @@ void test13907()
     static  char[20] csa = "hello world";  // extending is allowed
     static wchar[20] wsa = "hello world";  // ok
     static dchar[20] dsa = "hello world";  // ok
+
+    // Bugzilla 13966
+    string[1][] arr;
+    arr ~= ["class"];
+    enum immutable(char[5]) sarrstr = "class";
+    arr ~= [sarrstr];
 }
 
 /***************************************************/


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13966
