### PR TITLE
Issue 13902 - Compiler allows escaping the address of part of a local

### DIFF
--- a/src/escape.c
+++ b/src/escape.c
@@ -1,0 +1,163 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2015 by Digital Mars
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/escape.c
+ */
+
+#include "expression.h"
+#include "declaration.h"
+
+/************************************
+ * Detect cases where pointers to the stack can 'escape' the
+ * lifetime of the stack frame.
+ */
+
+void checkEscape(Expression *e)
+{
+    //printf("[%s] checkEscape, e = %s\n", e->loc.toChars(), e->toChars());
+
+    class EscapeVisitor : public Visitor
+    {
+    public:
+
+        void visit(Expression *e)
+        {
+        }
+
+        void visit(SymOffExp *e)
+        {
+            VarDeclaration *v = e->var->isVarDeclaration();
+            if (v)
+            {
+                if (!v->isDataseg() && !(v->storage_class & (STCref | STCout)))
+                {
+                    /* BUG: This should be allowed:
+                     *   void foo() {
+                     *     int a;
+                     *     int* bar() { return &a; }
+                     *   }
+                     */
+                    e->error("escaping reference to local %s", v->toChars());
+                }
+            }
+        }
+
+        void visit(VarExp *e)
+        {
+            VarDeclaration *v = e->var->isVarDeclaration();
+            if (v)
+            {
+                Type *tb = v->type->toBasetype();
+                // if reference type
+                if (tb->ty == Tarray || tb->ty == Tsarray || tb->ty == Tclass || tb->ty == Tdelegate)
+                {
+                    if (v->isScope() && (!v->noscope || tb->ty == Tclass))
+                        e->error("escaping reference to scope local %s", v->toChars());
+                    else if (v->storage_class & STCvariadic)
+                        e->error("escaping reference to variadic parameter %s", v->toChars());
+                }
+            }
+        }
+
+        void visit(TupleExp *e)
+        {
+            for (size_t i = 0; i < e->exps->dim; i++)
+            {
+                checkEscape((*e->exps)[i]);
+            }
+        }
+
+        void visit(AddrExp *e)
+        {
+            checkEscapeRef(e->e1);
+        }
+
+        void visit(CastExp *e)
+        {
+            Type *tb = e->type->toBasetype();
+            if (tb->ty == Tarray &&
+                e->e1->op == TOKvar &&
+                e->e1->type->toBasetype()->ty == Tsarray)
+            {
+                VarExp *ve = (VarExp *)e->e1;
+                VarDeclaration *v = ve->var->isVarDeclaration();
+                if (v)
+                {
+                    if (!v->isDataseg() && !v->isParameter())
+                        e->error("escaping reference to local %s", v->toChars());
+                }
+            }
+        }
+
+        void visit(SliceExp *e)
+        {
+            checkEscape(e->e1);
+        }
+
+        void visit(CommaExp *e)
+        {
+            checkEscape(e->e2);
+        }
+
+        void visit(CondExp *e)
+        {
+            checkEscape(e->e1);
+            checkEscape(e->e2);
+        }
+    };
+
+    EscapeVisitor v;
+    e->accept(&v);
+}
+
+void checkEscapeRef(Expression *e)
+{
+    //printf("[%s] checkEscapeRef, e = %s\n", e->loc.toChars(), e->toChars());
+
+    class EscapeRefVisitor : public Visitor
+    {
+    public:
+
+        void visit(Expression *e)
+        {
+        }
+
+        void visit(VarExp *e)
+        {
+            VarDeclaration *v = e->var->isVarDeclaration();
+            if (v)
+            {
+                if (!v->isDataseg() && !(v->storage_class & (STCref | STCout)))
+                    e->error("escaping reference to local variable %s", v->toChars());
+            }
+        }
+
+        void visit(PtrExp *e)
+        {
+            checkEscape(e->e1);
+        }
+
+        void visit(SliceExp *e)
+        {
+            checkEscapeRef(e->e1);
+        }
+
+        void visit(CommaExp *e)
+        {
+            checkEscapeRef(e->e2);
+        }
+
+        void visit(CondExp *e)
+        {
+            checkEscapeRef(e->e1);
+            checkEscapeRef(e->e2);
+        }
+    };
+    EscapeRefVisitor v;
+    e->accept(&v);
+}

--- a/src/expression.c
+++ b/src/expression.c
@@ -2310,19 +2310,6 @@ Expression *Expression::checkReadModifyWrite(TOK rmwOp, Expression *ex)
     // return new ErrorExp();
 }
 
-/************************************
- * Detect cases where pointers to the stack can 'escape' the
- * lifetime of the stack frame.
- */
-
-void Expression::checkEscape()
-{
-}
-
-void Expression::checkEscapeRef()
-{
-}
-
 void Expression::checkScalar()
 {
     if (!type->isscalar() && type->toBasetype() != Type::terror)
@@ -5079,23 +5066,6 @@ int SymOffExp::isBool(int result)
     return result ? true : false;
 }
 
-void SymOffExp::checkEscape()
-{
-    VarDeclaration *v = var->isVarDeclaration();
-    if (v)
-    {
-        if (!v->isDataseg() && !(v->storage_class & (STCref | STCout)))
-        {   /* BUG: This should be allowed:
-             *   void foo()
-             *   { int a;
-             *     int* bar() { return &a; }
-             *   }
-             */
-            error("escaping reference to local %s", v->toChars());
-        }
-    }
-}
-
 /******************************** VarExp **************************/
 
 VarExp::VarExp(Loc loc, Declaration *var, bool hasOverloads)
@@ -5166,32 +5136,6 @@ Expression *VarExp::semantic(Scope *sc)
     }
 
     return this;
-}
-
-void VarExp::checkEscape()
-{
-    VarDeclaration *v = var->isVarDeclaration();
-    if (v)
-    {   Type *tb = v->type->toBasetype();
-        // if reference type
-        if (tb->ty == Tarray || tb->ty == Tsarray || tb->ty == Tclass || tb->ty == Tdelegate)
-        {
-            if (v->isScope() && (!v->noscope || tb->ty == Tclass))
-                error("escaping reference to scope local %s", v->toChars());
-            else if (v->storage_class & STCvariadic)
-                error("escaping reference to variadic parameter %s", v->toChars());
-        }
-    }
-}
-
-void VarExp::checkEscapeRef()
-{
-    VarDeclaration *v = var->isVarDeclaration();
-    if (v)
-    {
-        if (!v->isDataseg() && !(v->storage_class & (STCref | STCout)))
-            error("escaping reference to local variable %s", v->toChars());
-    }
 }
 
 bool VarExp::isLvalue()
@@ -5382,14 +5326,6 @@ Expression *TupleExp::semantic(Scope *sc)
     type = type->semantic(loc, sc);
     //printf("-TupleExp::semantic(%s)\n", toChars());
     return this;
-}
-
-void TupleExp::checkEscape()
-{
-    for (size_t i = 0; i < exps->dim; i++)
-    {   Expression *e = (*exps)[i];
-        e->checkEscape();
-    }
 }
 
 /******************************** FuncExp *********************************/
@@ -9183,11 +9119,6 @@ Expression *AddrExp::semantic(Scope *sc)
     return optimize(WANTvalue);
 }
 
-void AddrExp::checkEscape()
-{
-    e1->checkEscapeRef();
-}
-
 /************************************************************/
 
 PtrExp::PtrExp(Loc loc, Expression *e)
@@ -9238,11 +9169,6 @@ Expression *PtrExp::semantic(Scope *sc)
         return new ErrorExp();
 
     return this;
-}
-
-void PtrExp::checkEscapeRef()
-{
-    e1->checkEscape();
 }
 
 bool PtrExp::isLvalue()
@@ -9760,21 +9686,6 @@ Lfail:
     return new ErrorExp();
 }
 
-
-void CastExp::checkEscape()
-{   Type *tb = type->toBasetype();
-    if (tb->ty == Tarray && e1->op == TOKvar &&
-        e1->type->toBasetype()->ty == Tsarray)
-    {   VarExp *ve = (VarExp *)e1;
-        VarDeclaration *v = ve->var->isVarDeclaration();
-        if (v)
-        {
-            if (!v->isDataseg() && !v->isParameter())
-                error("escaping reference to local %s", v->toChars());
-        }
-    }
-}
-
 /************************************************************/
 
 VectorExp::VectorExp(Loc loc, Expression *e, Type *t)
@@ -10061,16 +9972,6 @@ Lagain:
         type = e1->type;
 
     return this;
-}
-
-void SliceExp::checkEscape()
-{
-    e1->checkEscape();
-}
-
-void SliceExp::checkEscapeRef()
-{
-    e1->checkEscapeRef();
 }
 
 int SliceExp::checkModifiable(Scope *sc, int flag)
@@ -10437,16 +10338,6 @@ Expression *CommaExp::semantic(Scope *sc)
 
     type = e2->type;
     return this;
-}
-
-void CommaExp::checkEscape()
-{
-    e2->checkEscape();
-}
-
-void CommaExp::checkEscapeRef()
-{
-    e2->checkEscapeRef();
 }
 
 bool CommaExp::isLvalue()
@@ -13684,19 +13575,6 @@ Expression *CondExp::modifiableLvalue(Scope *sc, Expression *e)
     e2 = e2->modifiableLvalue(sc, e2);
     return toLvalue(sc, this);
 }
-
-void CondExp::checkEscape()
-{
-    e1->checkEscape();
-    e2->checkEscape();
-}
-
-void CondExp::checkEscapeRef()
-{
-    e1->checkEscapeRef();
-    e2->checkEscapeRef();
-}
-
 
 Expression *CondExp::checkToBoolean(Scope *sc)
 {

--- a/src/expression.h
+++ b/src/expression.h
@@ -102,8 +102,8 @@ Type *getIndirection(Type *t);
 
 Expression *checkGC(Scope *sc, Expression *e);
 
-void checkEscape(Expression *e);
-void checkEscapeRef(Expression *e);
+void checkEscape(Scope *sc, Expression *e);
+void checkEscapeRef(Scope *sc, Expression *e);
 
 /* Run CTFE on the expression, but allow the expression to be a TypeExp
  * or a tuple containing a TypeExp. (This is required by pragma(msg)).

--- a/src/expression.h
+++ b/src/expression.h
@@ -102,6 +102,9 @@ Type *getIndirection(Type *t);
 
 Expression *checkGC(Scope *sc, Expression *e);
 
+void checkEscape(Expression *e);
+void checkEscapeRef(Expression *e);
+
 /* Run CTFE on the expression, but allow the expression to be a TypeExp
  * or a tuple containing a TypeExp. (This is required by pragma(msg)).
  */
@@ -166,8 +169,6 @@ public:
     {
         return ::castTo(this, sc, t);
     }
-    virtual void checkEscape();
-    virtual void checkEscapeRef();
     virtual Expression *resolveLoc(Loc loc, Scope *sc);
     void checkScalar();
     void checkNoBool();
@@ -396,7 +397,6 @@ public:
     Expression *syntaxCopy();
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
-    void checkEscape();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -588,7 +588,6 @@ public:
 
     SymOffExp(Loc loc, Declaration *var, dinteger_t offset, bool hasOverloads = false);
     Expression *semantic(Scope *sc);
-    void checkEscape();
     int isBool(int result);
 
     void accept(Visitor *v) { v->visit(this); }
@@ -603,8 +602,6 @@ public:
     static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = false);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
-    void checkEscape();
-    void checkEscapeRef();
     int checkModifiable(Scope *sc, int flag);
     bool checkReadModifyWrite();
     bool isLvalue();
@@ -910,7 +907,7 @@ class AddrExp : public UnaExp
 public:
     AddrExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
-    void checkEscape();
+
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -920,7 +917,6 @@ public:
     PtrExp(Loc loc, Expression *e);
     PtrExp(Loc loc, Expression *e, Type *t);
     Expression *semantic(Scope *sc);
-    void checkEscapeRef();
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -992,7 +988,6 @@ public:
     CastExp(Loc loc, Expression *e, unsigned char mod);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    void checkEscape();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -1019,8 +1014,6 @@ public:
     SliceExp(Loc loc, Expression *e1, Expression *lwr, Expression *upr);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    void checkEscape();
-    void checkEscapeRef();
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -1105,8 +1098,6 @@ class CommaExp : public BinExp
 public:
     CommaExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
-    void checkEscape();
-    void checkEscapeRef();
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -1469,8 +1460,6 @@ public:
     CondExp(Loc loc, Expression *econd, Expression *e1, Expression *e2);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    void checkEscape();
-    void checkEscapeRef();
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);

--- a/src/func.c
+++ b/src/func.c
@@ -1733,7 +1733,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     {
                         // Function returns a reference
                         exp = exp->toLvalue(sc2, exp);
-                        exp->checkEscapeRef();
+                        checkEscapeRef(exp);
                     }
                     else
                     {
@@ -1745,7 +1745,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                         if (!nrvo_can && exp->isLvalue())
                             exp = callCpCtor(sc2, exp);
 
-                        exp->checkEscape();
+                        checkEscape(exp);
                     }
 
                     exp = checkGC(sc2, exp);

--- a/src/func.c
+++ b/src/func.c
@@ -1733,7 +1733,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     {
                         // Function returns a reference
                         exp = exp->toLvalue(sc2, exp);
-                        checkEscapeRef(exp);
+                        checkEscapeRef(sc2, exp);
                     }
                     else
                     {
@@ -1745,7 +1745,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                         if (!nrvo_can && exp->isLvalue())
                             exp = callCpCtor(sc2, exp);
 
-                        checkEscape(exp);
+                        checkEscape(sc2, exp);
                     }
 
                     exp = checkGC(sc2, exp);

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -143,7 +143,7 @@ DMD_OBJS = \
 	arrayop.o json.o unittests.o \
 	imphint.o argtypes.o apply.o sapply.o sideeffect.o \
 	intrange.o canthrow.o target.o nspace.o errors.o \
-	tokens.o globals.o
+	escape.o tokens.o globals.o
 
 ROOT_OBJS = \
 	rmem.o port.o man.o stringtable.o response.o \
@@ -201,8 +201,8 @@ SRC = win32.mak posix.mak osmodel.mak \
 	argtypes.c apply.c sapply.c sideeffect.c \
 	intrange.h intrange.c canthrow.c target.c target.h \
 	scanmscoff.c scanomf.c ctfe.h ctfeexpr.c \
-	ctfe.h ctfeexpr.c visitor.h nspace.h nspace.c \
-	tokens.h tokens.c globals.h globals.c
+	ctfe.h ctfeexpr.c visitor.h nspace.h nspace.c errors.h errors.c \
+	escape.c tokens.h tokens.c globals.h globals.c
 
 ROOT_SRC = $(ROOT)/root.h \
 	$(ROOT)/array.h \

--- a/src/statement.c
+++ b/src/statement.c
@@ -3810,7 +3810,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
                 /* May return by ref
                  */
                 unsigned olderrors = global.startGagging();
-                checkEscapeRef(exp);
+                checkEscapeRef(sc, exp);
                 if (global.endGagging(olderrors))
                     tf->isref = false;  // return by value
             }

--- a/src/statement.c
+++ b/src/statement.c
@@ -3810,7 +3810,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
                 /* May return by ref
                  */
                 unsigned olderrors = global.startGagging();
-                exp->checkEscapeRef();
+                checkEscapeRef(exp);
                 if (global.endGagging(olderrors))
                     tf->isref = false;  // return by value
             }

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -141,7 +141,7 @@ FRONTOBJ= enum.obj struct.obj dsymbol.obj import.obj id.obj \
 	builtin.obj clone.obj arrayop.obj \
 	json.obj unittests.obj imphint.obj argtypes.obj apply.obj sapply.obj \
 	sideeffect.obj intrange.obj canthrow.obj target.obj nspace.obj \
-	errors.obj tokens.obj globals.obj
+	errors.obj escape.obj tokens.obj globals.obj
 
 # Glue layer
 GLUEOBJ=glue.obj msc.obj s2ir.obj todt.obj e2ir.obj tocsym.obj \
@@ -186,7 +186,7 @@ SRCS= mars.c enum.c struct.c dsymbol.c import.c idgen.c impcnvgen.c utf.h \
 	declaration.h lexer.h expression.h statement.h doc.h doc.c \
 	macro.h macro.c hdrgen.h hdrgen.c arraytypes.h \
 	delegatize.c interpret.c ctfeexpr.c traits.c builtin.c \
-	clone.c lib.h arrayop.c nspace.h nspace.c errors.h errors.c \
+	clone.c lib.h arrayop.c nspace.h nspace.c errors.h errors.c escape.c \
 	aliasthis.h aliasthis.c json.h json.c unittests.c imphint.c argtypes.c \
 	apply.c sapply.c sideeffect.c ctfe.h \
 	intrange.h intrange.c canthrow.c target.c target.h visitor.h \
@@ -683,7 +683,6 @@ canthrow.obj : $(TOTALH) canthrow.c
 cast.obj : $(TOTALH) expression.h mtype.h cast.c
 class.obj : $(TOTALH) enum.h class.c
 clone.obj : $(TOTALH) clone.c
-errors.obj : $(TOTALH) errors.h errors.c
 constfold.obj : $(TOTALH) expression.h constfold.c
 cond.obj : $(TOTALH) identifier.h declaration.h cond.h cond.c
 cppmangle.obj : $(TOTALH) mtype.h declaration.h mars.h
@@ -691,6 +690,8 @@ declaration.obj : $(TOTALH) identifier.h attrib.h declaration.h declaration.c ex
 delegatize.obj : $(TOTALH) delegatize.c
 doc.obj : $(TOTALH) doc.h doc.c
 enum.obj : $(TOTALH) dsymbol.h identifier.h enum.h enum.c
+errors.obj : $(TOTALH) errors.h errors.c
+escape.obj : $(TOTALH) escape.c
 expression.obj : $(TOTALH) expression.h expression.c
 func.obj : $(TOTALH) identifier.h attrib.h declaration.h func.c
 globals.obj : $(TOTALH) globals.h globals.c

--- a/test/compilable/test13902.d
+++ b/test/compilable/test13902.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+void foo()
+{
+    int a;
+    int* bar() { return &a; }
+}

--- a/test/fail_compilation/fail13902.d
+++ b/test/fail_compilation/fail13902.d
@@ -1,0 +1,287 @@
+// REQUIRED_ARGS: -o-
+
+struct S1 { int v; }
+struct S2 { int* p; }
+class C { int v; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(32): Error: escaping reference to local x
+fail_compilation/fail13902.d(33): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(38): Error: escaping reference to local sa1
+fail_compilation/fail13902.d(39): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(40): Error: escaping reference to local x
+fail_compilation/fail13902.d(41): Error: escaping reference to local x
+fail_compilation/fail13902.d(42): Error: escaping reference to local x
+fail_compilation/fail13902.d(45): Error: escaping reference to local y
+---
+*/
+int* testEscape1()
+{
+    int x, y;
+    int[] da1;
+    int[][] da2;
+    int[1] sa1;
+    int[1][1] sa2;
+    int* ptr;
+    S1 s1;
+    S2 s2;
+    C  c;
+
+    if (0) return &x;               // VarExp
+    if (0) return &s1.v;            // DotVarExp
+    if (0) return s2.p;             // no error
+    if (0) return &c.v;             // no error
+    if (0) return &da1[0];          // no error
+    if (0) return &da2[0][0];       // no error
+    if (0) return &sa1[0];          // IndexExp
+    if (0) return &sa2[0][0];       // IndexExp
+    if (0) return ptr = &x;
+    if (0) return ptr = &x + 1;     // optimized to SymOffExp == (& x+4)
+    if (0) return ptr = &x + x;
+  //if (0) return ptr += &x + 1;    // semantic error
+    if (0) return ptr -= &x - &y;   // no error
+    if (0) return (&x, &y);         // CommaExp
+
+    return null;    // ok
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(75): Error: escaping reference to local x
+fail_compilation/fail13902.d(76): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(81): Error: escaping reference to local sa1
+fail_compilation/fail13902.d(82): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(83): Error: escaping reference to local x
+fail_compilation/fail13902.d(84): Error: escaping reference to local x
+fail_compilation/fail13902.d(85): Error: escaping reference to local x
+fail_compilation/fail13902.d(88): Error: escaping reference to local y
+---
+*/
+int* testEscape2(
+    int x, int y,
+    int[] da1,
+    int[][] da2,
+    int[1] sa1,
+    int[1][1] sa2,
+    int* ptr,
+    S1 s1,
+    S2 s2,
+    C  c,
+)
+{
+    if (0) return &x;               // VarExp
+    if (0) return &s1.v;            // DotVarExp
+    if (0) return s2.p;             // no error
+    if (0) return &c.v;             // no error
+    if (0) return &da1[0];          // no error
+    if (0) return &da2[0][0];       // no error
+    if (0) return &sa1[0];          // IndexExp
+    if (0) return &sa2[0][0];       // IndexExp
+    if (0) return ptr = &x;
+    if (0) return ptr = &x + 1;     // optimized to SymOffExp == (& x+4)
+    if (0) return ptr = &x + x;
+  //if (0) return ptr += &x + 1;    // semantic error
+    if (0) return ptr -= &x - &y;   // no error
+    if (0) return (&x, &y);         // CommaExp
+
+    return null;    // ok
+}
+
+/*
+TEST_OUTPUT:
+---
+---
+*/
+int* testEscape3(
+    ref int x, ref int y,
+    ref int[] da1,
+    ref int[][] da2,
+    ref int[1] sa1,
+    ref int[1][1] sa2,
+    ref int* ptr,
+    ref S1 s1,
+    ref S2 s2,
+    ref C  c,
+)
+{
+    if (0) return &x;               // VarExp
+    if (0) return &s1.v;            // DotVarExp
+    if (0) return s2.p;             // no error
+    if (0) return &c.v;             // no error
+    if (0) return &da1[0];          // no error
+    if (0) return &da2[0][0];       // no error
+    if (0) return &sa1[0];          // IndexExp
+    if (0) return &sa2[0][0];       // IndexExp
+    if (0) return ptr = &x;
+    if (0) return ptr = &x + 1;     // optimized to SymOffExp == (& x+4)
+    if (0) return ptr = &x + x;
+  //if (0) return ptr += &x + 1;    // semantic error
+    if (0) return ptr -= &x - &y;   // no error
+    if (0) return (&x, &y);         // CommaExp
+
+    return null;    // ok
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(151): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(152): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(156): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(157): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(158): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(159): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(160): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(161): Error: escaping reference to local variable s1
+---
+*/
+ref int testEscapeRef1()
+{
+    int x;
+    int[] da1;
+    int[][] da2;
+    int[1] sa1;
+    int[1][1] sa2;
+    S1 s1;
+    C  c;
+
+    if (0) return x;            // VarExp
+    if (0) return s1.v;         // DotVarExp
+    if (0) return c.v;          // no error
+    if (0) return da1[0];       // no error
+    if (0) return da2[0][0];    // no error
+    if (0) return sa1[0];       // IndexExp
+    if (0) return sa2[0][0];    // IndexExp
+    if (0) return x = 1;        // AssignExp
+    if (0) return x += 1;       // BinAssignExp
+    if (0) return s1.v = 1;     // AssignExp (e1 is DotVarExp)
+    if (0) return s1.v += 1;    // BinAssignExp (e1 is DotVarExp)
+
+    static int g;
+    return g;       // ok
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(190): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(191): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(195): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(196): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(197): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(198): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(199): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(200): Error: escaping reference to local variable s1
+---
+*/
+ref int testEscapeRef2(
+    int x,
+    int[] da1,
+    int[][] da2,
+    int[1] sa1,
+    int[1][1] sa2,
+    S1 s1,
+    C  c,
+)
+{
+    if (0) return x;            // VarExp
+    if (0) return s1.v;         // DotVarExp
+    if (0) return c.v;          // no error
+    if (0) return da1[0];       // no error
+    if (0) return da2[0][0];    // no error
+    if (0) return sa1[0];       // IndexExp
+    if (0) return sa2[0][0];    // IndexExp
+    if (0) return x = 1;        // AssignExp
+    if (0) return x += 1;       // BinAssignExp
+    if (0) return s1.v = 1;     // AssignExp (e1 is DotVarExp)
+    if (0) return s1.v += 1;    // BinAssignExp (e1 is DotVarExp)
+
+    static int g;
+    return g;       // ok
+}
+
+/*
+TEST_OUTPUT:
+---
+---
+*/
+ref int testEscapeRef2(
+    ref int x,
+    ref int[] da1,
+    ref int[][] da2,
+    ref int[1] sa1,
+    ref int[1][1] sa2,
+    ref S1 s1,
+    ref C  c,
+)
+{
+    if (0) return x;            // VarExp
+    if (0) return s1.v;         // DotVarExp
+    if (0) return c.v;          // no error
+    if (0) return da1[0];       // no error
+    if (0) return da2[0][0];    // no error
+    if (0) return sa1[0];       // IndexExp
+    if (0) return sa2[0][0];    // IndexExp
+    if (0) return x = 1;        // AssignExp
+    if (0) return x += 1;       // BinAssignExp
+    if (0) return s1.v = 1;     // AssignExp (e1 is DotVarExp)
+    if (0) return s1.v += 1;    // BinAssignExp (e1 is DotVarExp)
+
+    static int g;
+    return g;       // ok
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(244): Error: escaping reference to local x
+fail_compilation/fail13902.d(245): Error: escaping reference to local x
+---
+*/
+int*[]  testArrayLiteral1() { int x; return [&x]; }
+int*[1] testArrayLiteral2() { int x; return [&x]; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(254): Error: escaping reference to local x
+fail_compilation/fail13902.d(255): Error: escaping reference to local x
+---
+*/
+S2  testStructLiteral1() { int x; return     S2(&x); }
+S2* testStructLiteral2() { int x; return new S2(&x); }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(264): Error: escaping reference to local variable sa
+fail_compilation/fail13902.d(265): Error: escaping reference to local variable sa
+---
+*/
+int[] testSlice1() { int[3] sa; return sa[]; }
+int[] testSlice2() { int[3] sa; int n; return sa[n..2][1..2]; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(274): Error: escaping reference to the payload of variadic parameter vda
+fail_compilation/fail13902.d(275): Error: escaping reference to the payload of variadic parameter vda
+---
+*/
+ref int testDynamicArrayVariadic1(int[] vda...) { return vda[0]; }
+int[]   testDynamicArrayVariadic2(int[] vda...) { return vda[]; }
+int[3]  testDynamicArrayVariadic3(int[] vda...) { return vda[0..3]; }   // no error
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13902.d(285): Error: escaping reference to the payload of variadic parameter vsa
+fail_compilation/fail13902.d(286): Error: escaping reference to the payload of variadic parameter vsa
+---
+*/
+ref int testStaticArrayVariadic1(int[3] vsa...) { return vsa[0]; }
+int[]   testStaticArrayVariadic2(int[3] vsa...) { return vsa[]; }
+int[3]  testStaticArrayVariadic3(int[3] vsa...) { return vsa[0..3]; }   // no error

--- a/test/fail_compilation/fail9537.d
+++ b/test/fail_compilation/fail9537.d
@@ -1,0 +1,27 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9537.d(26): Error: foo(tuple(1, 2)) is not an lvalue
+---
+*/
+
+struct Tuple(T...)
+{
+    T field;
+    alias field this;
+}
+
+Tuple!T tuple(T...)(T args)
+{
+    return Tuple!T(args);
+}
+
+auto ref foo(T)(auto ref T t)
+{
+    return t[0];    // t[0] is deduced to non-ref
+}
+
+void main()
+{
+    int* p = &foo(tuple(1, 2));
+}

--- a/test/fail_compilation/fail_scope.d
+++ b/test/fail_compilation/fail_scope.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_scope.d(17): Error: escaping reference to scope local o
+---
+*/
+
+alias int delegate() dg_t;
+
+int[]  checkEscapeScope1(scope int[]  da) { return da; }
+int[3] checkEscapeScope2(scope int[3] sa) { return sa; }
+Object checkEscapeScope3(scope Object o)  { return o;  }
+dg_t   checkEscapeScope4(scope dg_t   dg) { return dg; }
+
+int[]  checkEscapeScope1() { scope int[]  da = [];           return da; }
+int[3] checkEscapeScope2() { scope int[3] sa = [1,2,3];      return sa; }
+Object checkEscapeScope3() { scope Object  o = new Object;   return o;  }   // same with fail7294.d
+dg_t   checkEscapeScope4() { scope dg_t   dg = () => 1;      return dg; }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13902

This is the first step to prevent escape references.
