### PR TITLE
[Fix broken master] Use D_PIC in runnable/s2ir.d

### DIFF
--- a/test/runnable/s2ir.d
+++ b/test/runnable/s2ir.d
@@ -15,7 +15,7 @@ void test1()
             naked       ;
             mov EAX, i  ;
         }
-      version(OSX)
+      version(D_PIC)
       {}
       else
       {


### PR DESCRIPTION
Supplemental fix for #4260.
