### PR TITLE
fix failure for VS builds

### DIFF
--- a/src/dmd_msc.vcproj
+++ b/src/dmd_msc.vcproj
@@ -402,6 +402,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\escape.c"
+				>
+			</File>
+			<File
 				RelativePath=".\complex_t.h"
 				>
 			</File>

--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -101,6 +101,7 @@
     <ClCompile Include="entity.c" />
     <ClCompile Include="enum.c" />
     <ClCompile Include="errors.c" />
+    <ClCompile Include="escape.c" />
     <ClCompile Include="expression.c" />
     <ClCompile Include="func.c" />
     <ClCompile Include="globals.c" />

--- a/src/dmd_msc.vcxproj.filters
+++ b/src/dmd_msc.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="errors.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="escape.c">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="expression.c">
       <Filter>src</Filter>
     </ClCompile>

--- a/src/doc.c
+++ b/src/doc.c
@@ -2331,6 +2331,7 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, size_t offset)
                 break;
 
             case '`':
+            {
                 if (inBacktick)
                 {
                     inBacktick = 0;
@@ -2362,7 +2363,7 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, size_t offset)
                 iCodeStart = i;
 
                 break;
-
+            }
             case '-':
                 /* A line beginning with --- delimits a code section.
                  * inCode tells us if it is start or end of a code section.


### PR DESCRIPTION
add new file escape.c to projects
fix error: "initialization of 'pre' is skipped by 'case' label"
