### PR TITLE
Add support for compiling Objective-C code as extra sources.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -27,6 +27,10 @@
 #   EXTRA_SOURCES:       list of extra files to build and link along with the test
 #                        default: (none)
 #
+#   EXTRA_OBJC_SOURCES:  list of extra Objective-C files to build and link along with the test
+#                        default: (none). Test files with this variable will be ignored unless
+#                        the D_OBJC environment variable is set to "1"
+#
 #   PERMUTE_ARGS:        the set of arguments to permute in multiple $(DMD) invocations
 #                        default: the make variable ARGS (see below)
 #
@@ -48,7 +52,7 @@
 #
 #   REQUIRED_ARGS:       arguments to add to the $(DMD) command line
 #                        default: (none)
-#                        note: the make variable REQUIRED_ARGS is also added to the $(DMD) 
+#                        note: the make variable REQUIRED_ARGS is also added to the $(DMD)
 #                              command line (see below)
 #
 #   DISABLED:            text describing why the test is disabled (if empty, the test is
@@ -111,6 +115,12 @@ export EXE=
 export OBJ=.o
 export DSEP=/
 export SEP=/
+endif
+
+ifeq ($(OS),osx)
+ifeq ($(MODEL),64)
+export D_OBJC=1
+endif
 endif
 
 ifeq ($(OS),freebsd)
@@ -181,7 +191,7 @@ clean:
 	$(QUIET)if [ -e $(RESULTS_DIR) ]; then rm -rf $(RESULTS_DIR); fi
 
 $(RESULTS_DIR)/.created:
-	@echo Creating output directory: $(RESULTS_DIR) 
+	@echo Creating output directory: $(RESULTS_DIR)
 	$(QUIET)if [ ! -d $(RESULTS_DIR) ]; then mkdir $(RESULTS_DIR); fi
 	$(QUIET)if [ ! -d $(RESULTS_DIR)/runnable ]; then mkdir $(RESULTS_DIR)/runnable; fi
 	$(QUIET)if [ ! -d $(RESULTS_DIR)/compilable ]; then mkdir $(RESULTS_DIR)/compilable; fi

--- a/test/runnable/extra-files/objc_self_test.m
+++ b/test/runnable/extra-files/objc_self_test.m
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+@interface objc_self_test : NSObject
+-(int) getValue;
+@end
+
+@implementation objc_self_test
+-(int) getValue
+{
+    return 3;
+}
+@end
+
+int getValue ()
+{
+    return [[[objc_self_test alloc] init] getValue];
+}

--- a/test/runnable/objc_self_test.d
+++ b/test/runnable/objc_self_test.d
@@ -1,0 +1,9 @@
+// EXTRA_OBJC_SOURCES: objc_self_test.m
+// REQUIRED_ARGS: -L-framework -LFoundation
+
+extern (C) int getValue();
+
+void main ()
+{
+    assert(getValue() == 3);
+}


### PR DESCRIPTION
Add the `EXTRA_OBJC_SOURCES` key and a list of Objective-C files to compile in a comment in the test file.

This is the first step for implementing [DIP 43 - D/Objective-C](http://wiki.dlang.org/DIP43).
