### PR TITLE
refactor checkEscape()

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -102,8 +102,8 @@ Type *getIndirection(Type *t);
 
 Expression *checkGC(Scope *sc, Expression *e);
 
-void checkEscape(Scope *sc, Expression *e);
-void checkEscapeRef(Scope *sc, Expression *e);
+bool checkEscape(Scope *sc, Expression *e, bool gag);
+bool checkEscapeRef(Scope *sc, Expression *e, bool gag);
 
 /* Run CTFE on the expression, but allow the expression to be a TypeExp
  * or a tuple containing a TypeExp. (This is required by pragma(msg)).

--- a/src/func.c
+++ b/src/func.c
@@ -1733,7 +1733,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                     {
                         // Function returns a reference
                         exp = exp->toLvalue(sc2, exp);
-                        checkEscapeRef(sc2, exp);
+                        checkEscapeRef(sc2, exp, false);
                     }
                     else
                     {
@@ -1745,7 +1745,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                         if (!nrvo_can && exp->isLvalue())
                             exp = callCpCtor(sc2, exp);
 
-                        checkEscape(sc2, exp);
+                        checkEscape(sc2, exp, false);
                     }
 
                     exp = checkGC(sc2, exp);

--- a/src/statement.c
+++ b/src/statement.c
@@ -3809,9 +3809,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
             {
                 /* May return by ref
                  */
-                unsigned olderrors = global.startGagging();
-                checkEscapeRef(sc, exp);
-                if (global.endGagging(olderrors))
+                if (checkEscapeRef(sc, exp, true))
                     tf->isref = false;  // return by value
             }
             else


### PR DESCRIPTION
This refactoring:
1. eliminates many unnecessary recursive instances of EscapeVisitor on the stack
2. eliminates wretched use of global gagging
3. adds explanatory comments
