### PR TITLE
Issue 13976 - Value range propagation to disable some slice bound tests

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4582,7 +4582,7 @@ elem *toElem(Expression *e, IRState *irs)
                 elem *einit = resolveLengthVar(ie->lengthVar, &n1, t1);
                 elem *n2 = toElem(ie->e2, irs);
 
-                if (irs->arrayBoundsCheck() && !ie->skipboundscheck)
+                if (irs->arrayBoundsCheck() && !ie->indexIsInBounds)
                 {
                     elem *elength;
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -10424,7 +10424,7 @@ IndexExp::IndexExp(Loc loc, Expression *e1, Expression *e2)
     //printf("IndexExp::IndexExp('%s')\n", toChars());
     lengthVar = NULL;
     modifiable = false;     // assume it is an rvalue
-    skipboundscheck = 0;
+    indexIsInBounds = false;
 }
 
 Expression *IndexExp::syntaxCopy()
@@ -10607,7 +10607,10 @@ Expression *IndexExp::semantic(Scope *sc)
             e2 = e2->optimize(WANTvalue);
             dinteger_t length = el->toInteger();
             if (length)
-                skipboundscheck = IntRange(SignExtendedNumber(0), SignExtendedNumber(length-1)).contains(getIntRange(e2));
+            {
+                IntRange bounds(SignExtendedNumber(0), SignExtendedNumber(length - 1));
+                indexIsInBounds = bounds.contains(getIntRange(e2));
+            }
         }
     }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -1112,7 +1112,7 @@ class IndexExp : public BinExp
 public:
     VarDeclaration *lengthVar;
     bool modifiable;
-    bool skipboundscheck;
+    bool indexIsInBounds;       // true if 0 <= e2 && e2 <= e1.length - 1
 
     IndexExp(Loc loc, Expression *e1, Expression *e2);
     Expression *syntaxCopy();

--- a/src/expression.h
+++ b/src/expression.h
@@ -1008,6 +1008,8 @@ public:
     Expression *upr;            // NULL if implicit 0
     Expression *lwr;            // NULL if implicit [length - 1]
     VarDeclaration *lengthVar;
+    bool upperIsInBounds;       // true if upr <= e1.length
+    bool lowerIsLessThanUpper;  // true if lwr <= upr
 
     SliceExp(Loc loc, Expression *e1, Expression *lwr, Expression *upr);
     Expression *syntaxCopy();

--- a/test/runnable/testbounds.d
+++ b/test/runnable/testbounds.d
@@ -177,10 +177,48 @@ void test1()
 }
 
 /******************************************/
+// 13976
+
+void test13976()
+{
+    int[] da = new int[](10);
+    int[10] sa;
+    size_t l = 0;               // upperInRange
+    size_t u = 9;               // | lowerLessThan
+                                // | |  check code
+    { auto s = da[l .. u];   }  // 0 0  (u <= 10 && l <= u  )
+    { auto s = da[1 .. u];   }  // 0 0  (u <= 10 && l <= u  )
+    { auto s = da[l .. 10];  }  // 0 0  (u <= 10 && l <= u  )
+    { auto s = da[1 .. u%5]; }  // 0 0  (u <= 10 && l <= u%5)
+
+    { auto s = da[l .. u];   }  // 0 0  (u   <= 10 && l <= u)
+    { auto s = da[0 .. u];   }  // 0 1  (u   <= 10          )
+    { auto s = da[l .. 10];  }  // 0 0  (u   <= 10 && l <= u)
+    { auto s = da[0 .. u%5]; }  // 0 1  (u%5 <= 10          )
+
+    { auto s = sa[l .. u];   }  // 0 0  (u <= 10 && l <= u  )
+    { auto s = sa[1 .. u];   }  // 0 0  (u <= 10 && l <= u  )
+    { auto s = sa[l .. 10];  }  // 1 0  (           l <= u  )
+    { auto s = sa[1 .. u%5]; }  // 1 0  (           l <= u%5)
+
+    { auto s = sa[l .. u];   }  // 0 0  (u <= 10 && l <= u )
+    { auto s = sa[0 .. u];   }  // 0 1  (u <= 10           )
+    { auto s = sa[l .. 10];  }  // 1 0  (           l <= 10)
+    { auto s = sa[0 .. u%5]; }  // 1 1  NULL
+
+    int* p = new int[](10).ptr;
+    { auto s = p[0 .. u];    }  // 1 1  NULL
+    { auto s = p[l .. u];    }  // 1 0  (l <= u)
+    { auto s = p[0 .. u%5];  }  // 1 1  NULL
+    { auto s = p[1 .. u%5];  }  // 1 0  (l <= u%5)
+}
+
+/******************************************/
 
 int main()
 {
     test1();
+    test13976();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13976

Example:

``` d
void main()
{
    int[10] a;
    size_t n;
    auto s = a[n%3 .. n%3 + 3];
    assert(s.length == 3);
}
```

With 2.066:

``` iasm
c:\d\test.d:1 void main()
00402010: c8380000                enter 0x38, 0x0
00402014: 53                      push ebx
00402015: 57                      push edi
c:\d\test.d:3     int[10] a;
00402016: b90a000000              mov ecx, 0xa
0040201b: 31c0                    xor eax, eax
0040201d: 8d7dc8                  lea edi, [ebp-0x38]
00402020: f3ab                    rep stosd
c:\d\test.d:4     size_t n;
00402022: 8945f0                  mov [ebp-0x10], eax
c:\d\test.d:5     auto s = a[n%3 .. n%3 + 3];
00402025: b103                    mov cl, 0x3
00402027: 31d2                    xor edx, edx
00402029: f7f1                    div ecx
0040202b: 8d5a03                  lea ebx, [edx+0x3]
0040202e: 83fb0a                  cmp ebx, 0xa
00402031: 7704                    ja 0x402037   D main c:\d\test.d:5
00402033: 39d3                    cmp ebx, edx
00402035: 730a                    jae 0x402041  D main c:\d\test.d:5
00402037: b805000000              mov eax, 0x5
0040203c: e823000000              call 0x402064 test.__array c:\d\test.d:7
00402041: 2bda                    sub ebx, edx
00402043: 8d5495c8                lea edx, [ebp+edx*4-0x38]
00402047: 895df8                  mov [ebp-0x8], ebx
0040204a: 8955fc                  mov [ebp-0x4], edx
c:\d\test.d:6     assert(s.length == 3);
0040204d: 394df8                  cmp [ebp-0x8], ecx
00402050: 740a                    jz 0x40205c   D main c:\d\test.d:6
00402052: b806000000              mov eax, 0x6
00402057: e824000000              call 0x402080 test.__assert c:\d\test.d:7
0040205c: 31c0                    xor eax, eax
c:\d\test.d:7 }
0040205e: 5f                      pop edi
0040205f: 5b                      pop ebx
00402060: c9                      leave
00402061: c3                      ret
```

With this PR:

``` iasm
c:\d\test.d:1 void main()
00402010: 55                      push ebp
00402011: 8bec                    mov ebp, esp
00402013: 83ec38                  sub esp, 0x38
00402016: 53                      push ebx
00402017: 57                      push edi
c:\d\test.d:3     int[10] a;
00402018: b90a000000              mov ecx, 0xa
0040201d: 31c0                    xor eax, eax
0040201f: 8d7dc8                  lea edi, [ebp-0x38]
00402022: f3ab                    rep stosd
c:\d\test.d:4     size_t n;
00402024: 8945f0                  mov [ebp-0x10], eax
c:\d\test.d:5     auto s = a[n%3 .. n%3 + 3];
00402027: b103                    mov cl, 0x3
00402029: 31d2                    xor edx, edx
0040202b: f7f1                    div ecx
0040202d: 8d5a03                  lea ebx, [edx+0x3]
00402030: 2bda                    sub ebx, edx
00402032: 8d5495c8                lea edx, [ebp+edx*4-0x38]
00402036: 895df8                  mov [ebp-0x8], ebx
00402039: 8955fc                  mov [ebp-0x4], edx
c:\d\test.d:6     assert(s.length == 3);
0040203c: 394df8                  cmp [ebp-0x8], ecx
0040203f: 740a                    jz 0x40204b   D main c:\d\test.d:6
00402041: b806000000              mov eax, 0x6
00402046: e809000000              call 0x402054 test.__assert c:\d\test.d:7
0040204b: 31c0                    xor eax, eax
c:\d\test.d:7 }
0040204d: 5f                      pop edi
0040204e: 5b                      pop ebx
0040204f: c9                      leave
00402050: c3                      ret
```

The boundary check and `__array` call are completely removed.
