### PR TITLE
DIP25: parsing

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -55,7 +55,7 @@ enum PURE;
 #define STCvariadic     0x10000LL       // variadic function argument
 #define STCctorinit     0x20000LL       // can only be set inside constructor
 #define STCtemplateparameter  0x40000LL // template parameter
-#define STCscope        0x80000LL       // template parameter
+#define STCscope        0x80000LL
 #define STCimmutable    0x100000LL
 #define STCref          0x200000LL
 #define STCinit         0x400000LL      // has explicit initializer
@@ -84,6 +84,7 @@ enum PURE;
 #define STCrvalue        0x20000000000LL // force rvalue for variables
 #define STCnogc          0x40000000000LL // @nogc
 #define STCvolatile      0x80000000000LL // destined for volatile in the back end
+#define STCreturn        0x100000000000LL // 'return ref' for function parameters
 
 const StorageClass STCStorageClass = (STCauto | STCscope | STCstatic | STCextern | STCconst | STCfinal |
     STCabstract | STCsynchronized | STCdeprecated | STCoverride | STClazy | STCalias |
@@ -507,10 +508,11 @@ typedef Expression *(*builtin_fp)(Loc loc, FuncDeclaration *fd, Expressions *arg
 void add_builtin(const char *mangle, builtin_fp fp);
 void builtin_init();
 
-#define FUNCFLAGpurityInprocess 1   // working on determining purity
-#define FUNCFLAGsafetyInprocess 2   // working on determining safety
-#define FUNCFLAGnothrowInprocess 4  // working on determining nothrow
-#define FUNCFLAGnogcInprocess 8     // working on determining @nogc
+#define FUNCFLAGpurityInprocess    1    // working on determining purity
+#define FUNCFLAGsafetyInprocess    2    // working on determining safety
+#define FUNCFLAGnothrowInprocess   4    // working on determining nothrow
+#define FUNCFLAGnogcInprocess      8    // working on determining @nogc
+#define FUNCFLAGreturnInprocess 0x10    // working on inferring 'return' for parameters
 
 class FuncDeclaration : public Declaration
 {
@@ -588,7 +590,7 @@ public:
     FuncDeclarations siblingCallers;    // Sibling nested functions which
                                         // called this one
 
-    unsigned flags;
+    unsigned flags;                     // FUNCFLAGxxxxx
 
     FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);

--- a/src/globals.h
+++ b/src/globals.h
@@ -64,7 +64,7 @@ struct Param
     bool useSwitchError; // check for switches without a default
     bool useUnitTests;  // generate unittest code
     bool useInline;     // inline expand functions
-    bool useScope;      // diagnose 'scope' errors
+    bool useDIP25;      // implement http://wiki.dlang.org/DIP25
     bool release;       // build release version
     bool preservePaths; // true means don't strip path from source file
     char warnings;      // 0: disable warnings

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -872,6 +872,9 @@ public:
         }
         t->attributesApply(&pas, &PrePostAppendStrings::fp);
 
+        if (t->isreturn)
+            buf->writestring(" return");
+
         t->inuse--;
     }
     void visitFuncIdentWithPrefix(TypeFunction *t, Identifier *ident, TemplateDeclaration *td, bool isPostfixStyle)
@@ -931,6 +934,9 @@ public:
             buf->writeByte(')');
         }
         parametersToBuffer(t->parameters, t->varargs);
+
+        if (t->isreturn)
+            buf->writestring("return ");
 
         t->inuse--;
     }
@@ -1714,7 +1720,7 @@ public:
 
     void visit(FuncDeclaration *f)
     {
-        //printf("FuncDeclaration::toCBuffer() '%s'\n", toChars());
+        //printf("FuncDeclaration::toCBuffer() '%s'\n", f->toChars());
 
         StorageClassDeclaration::stcToCBuffer(buf, f->storage_class);
         typeToBuffer(f->type, f->ident);
@@ -2844,6 +2850,9 @@ public:
     {
         if (p->storageClass & STCauto)
             buf->writestring("auto ");
+
+        if (p->storageClass & STCreturn)
+            buf->writestring("return ");
 
         if (p->storageClass & STCout)
             buf->writestring("out ");

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -208,6 +208,7 @@ public:
 
     void mangleFuncType(TypeFunction *t, TypeFunction *ta, unsigned char modMask, Type *tret)
     {
+        //printf("mangleFuncType() %s\n", t->toChars());
         if (t->inuse)
         {
             t->inuse = 2;       // flag error to caller
@@ -231,7 +232,7 @@ public:
         }
         buf->writeByte(mc);
 
-        if (ta->purity || ta->isnothrow || ta->isnogc || ta->isproperty || ta->isref || ta->trust)
+        if (ta->purity || ta->isnothrow || ta->isnogc || ta->isproperty || ta->isref || ta->trust || ta->isreturn)
         {
             if (ta->purity)
                 buf->writestring("Na");
@@ -243,6 +244,8 @@ public:
                 buf->writestring("Nd");
             if (ta->isnogc)
                 buf->writestring("Ni");
+            if (ta->isreturn)
+                buf->writestring("Nj");
             switch (ta->trust)
             {
                 case TRUSTtrusted:
@@ -826,6 +829,9 @@ public:
     {
         if (p->storageClass & STCscope)
             buf->writeByte('M');
+        // 'return inout ref' is the same as 'inout ref'
+        if ((p->storageClass & (STCreturn | STCwild)) == STCreturn)
+            buf->writestring("Nk");
         switch (p->storageClass & (STCin | STCout | STCref | STClazy))
         {
             case 0:

--- a/src/mars.c
+++ b/src/mars.c
@@ -157,6 +157,7 @@ Usage:\n\
   -defaultlib=name  set default library to name\n\
   -deps          print module dependencies (imports/file/version/debug/lib)\n\
   -deps=filename write module dependencies to filename (only imports)\n%s\
+  -dip25         implement http://wiki.dlang.org/DIP25 (experimental)\n\
   -g             add symbolic debug info\n\
   -gc            add symbolic debug info, optimize for non D debuggers\n\
   -gs            always emit stack frame\n\
@@ -187,7 +188,6 @@ Usage:\n\
   -property      enforce property syntax\n\
   -release       compile release version\n\
   -run srcfile args...   run resulting program, passing args\n\
-  -scope         diagnose scope errors (experimental)\n\
   -shared        generate shared library (DLL)\n\
   -transition=id show additional info about language change identified by 'id'\n\
   -transition=?  list all language changes\n\
@@ -715,8 +715,8 @@ Language changes listed by -transition=id:\n\
                 global.params.enforcePropertySyntax = true;
             else if (strcmp(p + 1, "inline") == 0)
                 global.params.useInline = true;
-            else if (strcmp(p + 1, "scope") == 0)
-                global.params.useScope = true;
+            else if (strcmp(p + 1, "dip25") == 0)
+                global.params.useDIP25 = true;
             else if (strcmp(p + 1, "lib") == 0)
                 global.params.lib = true;
             else if (strcmp(p + 1, "nofloat") == 0)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -626,6 +626,7 @@ public:
     bool isnogc;        // true: is @nogc
     bool isproperty;    // can be called without parentheses
     bool isref;         // true: returns a reference
+    bool isreturn;      // true: 'this' is returned by ref
     LINK linkage;  // calling convention
     TRUST trust;   // level of trust
     PURE purity;   // PURExxxx

--- a/src/parse.c
+++ b/src/parse.c
@@ -1056,6 +1056,7 @@ StorageClass Parser::parsePostfix(StorageClass storageClass, Expressions **pudas
             case TOKwild:       stc = STCwild;          break;
             case TOKnothrow:    stc = STCnothrow;       break;
             case TOKpure:       stc = STCpure;          break;
+            case TOKreturn:     stc = STCreturn;        break;
             case TOKat:
             {
                 Expressions *udas = NULL;
@@ -1917,6 +1918,7 @@ Parameters *Parser::parseParameters(int *pvarargs, TemplateParameters **tpl)
                 case TOKscope:     stc = STCscope;      goto L2;
                 case TOKfinal:     stc = STCfinal;      goto L2;
                 case TOKauto:      stc = STCauto;       goto L2;
+                case TOKreturn:    stc = STCreturn;     goto L2;
                 L2:
                     storageClass = appendStorageClass(storageClass, stc);
                     continue;
@@ -3187,10 +3189,10 @@ Type *Parser::parseBasicType2(Type *t)
 
                 StorageClass stc = parsePostfix(STCundefined, NULL);
                 TypeFunction *tf = new TypeFunction(parameters, t, varargs, linkage, stc);
-                if (stc & (STCconst | STCimmutable | STCshared | STCwild))
+                if (stc & (STCconst | STCimmutable | STCshared | STCwild | STCreturn))
                 {
                     if (save == TOKfunction)
-                        error("const/immutable/shared/inout attributes are only valid for non-static member functions");
+                        error("const/immutable/shared/inout/return attributes are only valid for non-static member functions");
                     else
                         tf = (TypeFunction *)tf->addSTC(stc);
                 }
@@ -3352,7 +3354,7 @@ Type *Parser::parseDeclarator(Type *t, int *palt, Identifier **pident,
                 int varargs;
                 Parameters *parameters = parseParameters(&varargs);
 
-                /* Parse const/immutable/shared/inout/nothrow/pure postfix
+                /* Parse const/immutable/shared/inout/nothrow/pure/return postfix
                  */
                 StorageClass stc = parsePostfix(storageClass, pudas);
                                         // merge prefix storage classes
@@ -5885,6 +5887,7 @@ bool Parser::isDeclarator(Token **pt, int *haveId, int *haveTpl, TOK endtok)
                         case TOKwild:
                         case TOKpure:
                         case TOKnothrow:
+                        case TOKreturn:
                             t = peek(t);
                             continue;
                         case TOKat:

--- a/test/fail_compilation/test4838.d
+++ b/test/fail_compilation/test4838.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test4838.d(13): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
-fail_compilation/test4838.d(14): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
-fail_compilation/test4838.d(15): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
-fail_compilation/test4838.d(16): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
-fail_compilation/test4838.d(17): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
-fail_compilation/test4838.d(18): Error: const/immutable/shared/inout attributes are only valid for non-static member functions
+fail_compilation/test4838.d(13): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
+fail_compilation/test4838.d(14): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
+fail_compilation/test4838.d(15): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
+fail_compilation/test4838.d(16): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
+fail_compilation/test4838.d(17): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
+fail_compilation/test4838.d(18): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
 ---
 */
 

--- a/test/runnable/testscope2.d
+++ b/test/runnable/testscope2.d
@@ -1,11 +1,88 @@
-// PERMUTE_ARGS: -scope
+// REQUIRED_ARGS: -dip25
 
 import core.stdc.stdio;
 
 /********************************************/
 
+struct SS
+{
+    ref int foo1(return ref int delegate() return p) return;
+    ref int foo2(return ref int delegate() p);
+    ref int foo3(inout ref int* p);
+    ref int foo4(return inout ref int* p);
+}
+
+pragma(msg, "foo1 ", typeof(&SS.foo1));
+pragma(msg, "foo2 ", typeof(&SS.foo2));
+pragma(msg, "foo3 ", typeof(&SS.foo3));
+pragma(msg, "foo4 ", typeof(&SS.foo4));
+
+
+void test3()
+{
+    version (all)
+    {
+	import std.stdio;
+	writeln(SS.foo1.mangleof);
+	writeln(SS.foo2.mangleof);
+	writeln(SS.foo3.mangleof);
+	writeln(SS.foo4.mangleof);
+	writeln(typeof(SS.foo1).stringof);
+	writeln(typeof(SS.foo2).stringof);
+	writeln(typeof(SS.foo3).stringof);
+	writeln(typeof(SS.foo4).stringof);
+    }
+
+    version (all)
+    {
+	// Test scope mangling
+	assert(SS.foo1.mangleof == "_D10testscope22SS4foo1MFNcNjNkKDFNjZiZi");
+	assert(SS.foo2.mangleof == "_D10testscope22SS4foo2MFNcNkKDFZiZi");
+	assert(SS.foo3.mangleof == "_D10testscope22SS4foo3MFNcNkKNgPiZi");
+	assert(SS.foo4.mangleof == "_D10testscope22SS4foo4MFNcNkKNgPiZi");
+
+	// Test scope pretty-printing
+	assert(typeof(SS.foo1).stringof == "ref int(return ref int delegate() return p)return ");
+	assert(typeof(SS.foo2).stringof == "ref int(return ref int delegate() p)");
+	assert(typeof(SS.foo3).stringof == "ref int(return ref inout(int*) p)");
+	assert(typeof(SS.foo4).stringof == "ref int(return ref inout(int*) p)");
+    }
+}
+
+/********************************************/
+
+ref int foo(return ref int x)
+{
+    return x;
+}
+
+struct S
+{
+    int x;
+
+    ref S bar() return
+    {
+	return this;
+    }
+}
+
+ref T foo2(T)(ref T x)
+{
+    return x;
+}
+
+void test4()
+{
+    int x;
+    foo2(x);
+}
+
+/********************************************/
+
 void main()
 {
+    test3();
+    test4();
     printf("Success\n");
 }
 


### PR DESCRIPTION
This starts implementing:

  http://wiki.dlang.org/DIP25

the parsing, name mangling, and pretty-printing. Also sets up the type, and handles covariance.

Adds -DIP25 switch which will later be used to enable the semantics of it. With this PR, adding `return` attributes is 100% backwards compatible.
