### PR TITLE
Move special GDC glue function to Target::builtinsModule

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -24,10 +24,7 @@
 #include "expression.h"
 #include "lexer.h"
 #include "attrib.h"
-
-#ifdef IN_GCC
-#include "d-dmd-gcc.h"
-#endif
+#include "target.h"
 
 AggregateDeclaration *Module::moduleinfo;
 
@@ -250,9 +247,7 @@ Module *Module::load(Loc loc, Identifiers *packages, Identifier *ident)
 
     m->parse();
 
-#ifdef IN_GCC
-    d_gcc_magic_module(m);
-#endif
+    Target::loadModule(m);
 
     return m;
 }

--- a/src/target.c
+++ b/src/target.c
@@ -369,3 +369,14 @@ int Target::checkVectorType(int sz, Type *type)
 
     return 0;
 }
+
+/******************************
+ * For the given module, perform any post parsing analysis.
+ * Certain compiler backends (ie: GDC) have special placeholder
+ * modules whose source are empty, but code gets injected
+ * immediately after loading.
+ */
+void Target::loadModule(Module *m)
+{
+}
+

--- a/src/target.h
+++ b/src/target.h
@@ -18,6 +18,7 @@
 
 class Expression;
 class Type;
+class Module;
 
 struct Target
 {
@@ -36,6 +37,7 @@ struct Target
     static Type *va_listType();  // get type of va_list
     static Expression *paintAsType(Expression *e, Type *type);
     static int checkVectorType(int sz, Type *type);
+    static void loadModule(Module *m);
 };
 
 #endif


### PR DESCRIPTION
Last part of the D frontend which uses GDC's `d-dmd-gcc.h` header.  I would have liked to have called it something like `Backend::loadModule`, but the idea I have around that would involve creating a new Backend class (interface), with an overriding DMDBackend class, etc...
