### PR TITLE
Changes to better match $(D ...) in Phobos and bug fix

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -2355,8 +2355,10 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, size_t offset)
 
                     OutBuffer codebuf;
 
-                    // escape the contents, but do not perform highlighting
-                    highlightCode3(sc, &codebuf, (utf8_t *)(buf->data + iCodeStart + 1), (utf8_t *)buf->data + i);
+                    codebuf.write(buf->data + iCodeStart + 1, i - (iCodeStart + 1));
+
+                    // escape the contents, but do not perform highlighting except for DDOC_PSYMBOL
+                    highlightCode(sc, s, &codebuf, 0, false);
 
                     buf->remove(iCodeStart, i - iCodeStart + 1); // also trimming off the current `
 
@@ -2364,6 +2366,8 @@ void highlightText(Scope *sc, Dsymbol *s, OutBuffer *buf, size_t offset)
                     i = buf->insert(iCodeStart, pre, strlen(pre));
                     i = buf->insert(i, (char *)codebuf.data, codebuf.offset);
                     i = buf->insert(i, (char *)")", 1);
+
+                    i--; // point to the ending ) so when the for loop does i++, it will see the next character
 
                     break;
                 }

--- a/test/compilable/ddocbackticks.d
+++ b/test/compilable/ddocbackticks.d
@@ -2,6 +2,14 @@
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh backticks
 
+/++
+        Closely related to std.datetime is <a href="core_time.html">`core.time`</a>,
+    and some of the time types used in std.datetime come from there - such as
+    $(CXREF time, Duration), $(CXREF time, TickDuration), and
+    $(CXREF time, FracSec).
+    core.time is publically imported into std.datetime, it isn't necessary
+    to import it separately.
++/
 module ddocbackticks;
 
 /// This should produce `inline code`.
@@ -11,3 +19,6 @@ void test() {}
 ///
 /// However, restarting on a new line should be `inline again`.
 void test2() {}
+
+/// This `int foo;` should show highlight on foo, but not int.
+void foo() {}

--- a/test/compilable/extra-files/ddocbackticks.html
+++ b/test/compilable/extra-files/ddocbackticks.html
@@ -3,7 +3,13 @@
         <title>ddocbackticks</title>
         </head><body>
         <h1>ddocbackticks</h1>
-<br><br>
+Closely related to std.datetime is <a href="core_time.html"><pre style="display:inline;" class="d_inline_code">core.time</pre></a>,
+    and some of the time types used in std.datetime come from there - such as
+    , , and
+    .
+    core.time is publically imported into std.datetime, it isn't necessary
+    to import it separately.<br><br>
+
 <dl><dt><big><a name="test"></a>void <u>test</u>();
 </big></dt>
 <dd>This should produce <pre style="display:inline;" class="d_inline_code">inline code</pre>.<br><br>
@@ -14,6 +20,11 @@
 <dd>But `this should NOT be inline'
 <br><br>
 However, restarting on a new line should be <pre style="display:inline;" class="d_inline_code">inline again</pre>.<br><br>
+
+</dd>
+<dt><big><a name="foo"></a>void <u>foo</u>();
+</big></dt>
+<dd>This <pre style="display:inline;" class="d_inline_code">int <u>foo</u>;</pre> should show highlight on <u>foo</u>, but not int.<br><br>
 
 </dd>
 </dl>


### PR DESCRIPTION
The existing $(D) macro does PSYMBOL highlighting, so change the highlightCode call to match that. std.datetime also revealed another off-by-one bug with embedded html so the `i--` takes care of that. Test amended with these cases.
