### PR TITLE
[REG2.067a] Issue 13999 - Associative array literal with static array keys must now have matching key lengths

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1592,13 +1592,18 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                 return;
             }
 
+            /* Handle reinterpret casts:
+             *  cast(wchar[3])"abcd"c --> [\u6261, \u6463, \u0000]
+             *  cast(wchar[2])"abcd"c --> [\u6261, \u6463]
+             *  cast(wchar[1])"abcd"c --> [\u6261]
+             */
             if (e->committed && tb->ty == Tsarray && typeb->ty == Tarray)
             {
                 se = (StringExp *)e->copy();
                 d_uns64 szx = tb->nextOf()->size();
                 assert(szx <= 255);
                 se->sz = (unsigned char)szx;
-                se->len = (e->len * e->sz) / se->sz;
+                se->len = ((TypeSArray *)tb)->dim->toInteger();
                 se->committed = 1;
                 se->type = t;
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -589,10 +589,20 @@ MATCH implicitConvTo(Expression *e, Type *t)
                                     return;
                                 }
                                 int szto = (int)t->nextOf()->size();
-                                if ((tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
-                                    e->length(szto) != ((TypeSArray *)t)->dim->toInteger())
+                                if (tynto == Tchar || tynto == Twchar || tynto == Tdchar)
                                 {
-                                    return;
+                                    if (e->committed && tynto != tyn)
+                                        return;
+                                    size_t fromlen = e->length(szto);
+                                    size_t tolen = ((TypeSArray *)t)->dim->toInteger();
+                                    if (tolen < fromlen)
+                                        return;
+                                    if (tolen != fromlen)
+                                    {
+                                        // implicit length extending
+                                        result = MATCHconvert;
+                                        return;
+                                    }
                                 }
                                 if (!e->committed && (tynto == Tchar || tynto == Twchar || tynto == Tdchar))
                                 {
@@ -604,10 +614,20 @@ MATCH implicitConvTo(Expression *e, Type *t)
                             {
                                 TY tynto = t->nextOf()->ty;
                                 int sznto = (int)t->nextOf()->size();
-                                if ((tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
-                                    e->length(sznto) != ((TypeSArray *)t)->dim->toInteger())
+                                if (tynto == Tchar || tynto == Twchar || tynto == Tdchar)
                                 {
-                                    return;
+                                    if (e->committed && tynto != tyn)
+                                        return;
+                                    size_t fromlen = e->length(sznto);
+                                    size_t tolen = (size_t)((TypeSArray *)t)->dim->toInteger();
+                                    if (tolen < fromlen)
+                                        return;
+                                    if (tolen != fromlen)
+                                    {
+                                        // implicit length extending
+                                        result = MATCHconvert;
+                                        return;
+                                    }
                                 }
                                 if (tynto == tyn)
                                 {

--- a/test/runnable/literal.d
+++ b/test/runnable/literal.d
@@ -174,16 +174,28 @@ void f13907_3(wchar[3] a) {}
 auto f13907_12(char[1]) { return 1; }
 auto f13907_12(char[2]) { return 2; }
 
+auto f13907_123(char[1]) { return 1; }
+auto f13907_123(char[2]) { return 2; }
+auto f13907_123(char[3]) { return 3; }
+auto f13907_123(const(char)[]) { return 0; }
+
 void test13907()
 {
     static assert(!__traits(compiles, { f13907_1("\U00010000"w); }));
     static assert(!__traits(compiles, { f13907_1("\U00010000" ); }));
     f13907_2("\U00010000"w);
     f13907_2("\U00010000");
-    static assert(!__traits(compiles, { f13907_3("\U00010000"w); }));
-    static assert(!__traits(compiles, { f13907_3("\U00010000" ); }));
+  //f13907_3("\U00010000"w);    // Re-enable implicit length extension, from issue 13999 (unlisted codegen bug)
+    f13907_3("\U00010000" );    // Re-enable implicit length extension, from issue 13999
 
     assert(f13907_12("a") == 1);
+    assert(f13907_12("ab") == 2);
+    static assert(!__traits(compiles, { f13907_12("abc"); }));
+
+    assert(f13907_123("a") == 1);
+    assert(f13907_123("ab") == 2);
+    assert(f13907_123("abc") == 3);
+    assert(f13907_123("abcd") == 0);
 
     // regression tests for the lengthen behavior in initializer
     enum const(char*) p = "hello world";
@@ -203,6 +215,14 @@ void test13907()
     arr ~= ["class"];
     enum immutable(char[5]) sarrstr = "class";
     arr ~= [sarrstr];
+
+    // Bugzilla 13999
+    string[dchar[2]] aa13999 = ["あ": "bar"];
+    assert(aa13999["あ"] == "bar");
+    dchar[2] key13999 = "あ";
+    assert(key13999[0] == 'あ');
+    assert(key13999[1] == '\0');
+    assert(aa13999[key13999] == "bar");
 }
 
 /***************************************************/

--- a/test/runnable/literal.d
+++ b/test/runnable/literal.d
@@ -185,7 +185,7 @@ void test13907()
     static assert(!__traits(compiles, { f13907_1("\U00010000" ); }));
     f13907_2("\U00010000"w);
     f13907_2("\U00010000");
-  //f13907_3("\U00010000"w);    // Re-enable implicit length extension, from issue 13999 (unlisted codegen bug)
+    f13907_3("\U00010000"w);    // Re-enable implicit length extension, from issue 13999
     f13907_3("\U00010000" );    // Re-enable implicit length extension, from issue 13999
 
     assert(f13907_12("a") == 1);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13999

Re-enable implicit length extension, eg. `"abc"` to `char[5]`.
