### PR TITLE
Issue 14009 - iasm parser accepts incorrect AsmExp

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3720,7 +3720,6 @@ static OPND *asm_cond_exp()
     {
         asm_token();
         o2 = asm_cond_exp();
-        asm_token();
         asm_chktok(TOKcolon,"colon");
         o3 = asm_cond_exp();
         o1 = (o1->disp) ? o2 : o3;

--- a/test/fail_compilation/fail14009.d
+++ b/test/fail_compilation/fail14009.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail14009.d(12): Error: end of instruction expected, not ':'
+---
+*/
+
+void main()
+{
+    asm {
+      mov EAX, FS: 1 ? 2 : 3;     // accepted
+      mov EAX, FS: 1 ? 2 : : 3;   // rejected
+    }
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14009
