### PR TITLE
[DDMD] Don't call StringTable's destructor from the glue layer

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -854,9 +854,13 @@ StringTable *stringTab;
 void clearStringTab()
 {
     //printf("clearStringTab()\n");
-    delete stringTab;
-    stringTab = new StringTable;
-    stringTab->_init(1000);             // 1000 is arbitrary guess
+    if (stringTab)
+        stringTab->reset(1000);             // 1000 is arbitrary guess
+    else
+    {
+        stringTab = new StringTable();
+        stringTab->_init(1000);
+    }
 }
 
 elem *toElem(Expression *e, IRState *irs)

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -132,6 +132,18 @@ void StringTable::_init(size_t size)
     count = 0;
 }
 
+void StringTable::reset(size_t size)
+{
+    for (size_t i = 0; i < npools; ++i)
+        mem.free(pools[i]);
+
+    mem.free(table);
+    mem.free(pools);
+    table = NULL;
+    pools = NULL;
+    _init(size);
+}
+
 StringTable::~StringTable()
 {
     for (size_t i = 0; i < npools; ++i)

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -46,6 +46,7 @@ private:
 
 public:
     void _init(size_t size = 0);
+    void reset(size_t size = 0);
     ~StringTable();
 
     StringValue *lookup(const char *s, size_t len);


### PR DESCRIPTION
D's C++ support does not currently include destructor calls, so we need to avoid calling delete here.
