### PR TITLE
Use presence of __va_argsave to determine if __va_argsave hack is needed

### DIFF
--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -329,13 +329,8 @@ extern(C++) void myvprintf(const(char)*, va_list);
 extern(C++) void myprintf(const(char)* format, ...)
 {
     va_list ap;
-    version(X86_64)
-    {
-        version(Windows)
-            va_start(ap, format);
-        else
-            va_start(ap, __va_argsave);
-    }
+    static if (is(typeof(__va_argsave)))
+        va_start(ap, __va_argsave);
     else
         va_start(ap, format);
     myvprintf(format, ap);

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -1187,9 +1187,10 @@ void myfunc(int a1, ...) {
 	string sa; int ia; double da;
 	writefln("%d variable arguments", _arguments.length);
 	writefln("argument types %s", _arguments);
-	version(X86) va_start(argument_list, a1);
-	else version(Win64) va_start(argument_list, a1);
-	else version(X86_64) va_start(argument_list, __va_argsave);
+	static if (is(typeof(__va_argsave)))
+		va_start(argument_list, __va_argsave);
+	else
+		va_start(argument_list, a1);
 	for (int i = 0; i < _arguments.length; ) {
 		if ((argument_type=_arguments[i++]) == typeid(string)) {
 			va_arg(argument_list, sa);

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -792,9 +792,10 @@ int foo42(const(char) *x, ...)
 {
     va_list ap;
 
-    version (Win64)       va_start!(typeof(x))(ap, x);
-    else version (X86_64) va_start(ap, __va_argsave);
-    else                  va_start!(typeof(x))(ap, x);
+    static if (is(typeof(__va_argsave)))
+        va_start(ap, __va_argsave);
+    else
+        va_start!(typeof(x))(ap, x);
     printf("&x = %p, ap = %p\n", &x, ap);
 
     int i;


### PR DESCRIPTION
This replaces the current awkward version condition, and makes the code future-proof with regards to the hopefully imminent removal of `__va_argsave`.
