### PR TITLE
Issue 9495 - Win64 vararg issue when first argument is > 8 byte

### DIFF
--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -4844,6 +4844,46 @@ STATIC elem * elarraylength(elem *e, goal_t goal)
 /********************************************
  */
 
+#if TX86 && TARGET_WINDOS && MARS
+STATIC elem * elvalist(elem *e, goal_t goal)
+{
+    if (config.exe == EX_WIN64)
+    {
+        if (e->Eoper == OPva_start)
+        {
+            // (OPva_start &va)
+            // (OPeq (OPind E1) (OPptr &lastNamed+8))
+            //elem_print(e);
+
+            // Find last named parameter
+            symbol *lastNamed = NULL;
+            for (SYMIDX si = 0; si < globsym.top; si++)
+            {
+                symbol *s = globsym.tab[si];
+
+                if (s->Sclass == SCfastpar || s->Sclass == SCshadowreg)
+                    lastNamed = s;
+            }
+
+            e->Eoper = OPeq;
+            e->E1 = el_una(OPind, TYnptr, e->E1);
+            if (lastNamed)
+            {
+                e->E2 = el_ptr(lastNamed);
+                e->E2->EV.sp.Voffset = REGSIZE;
+            }
+            else
+                e->E2 = el_long(TYnptr, 0);
+            //elem_print(e);
+        }
+    }
+    return e;
+}
+#endif
+
+/********************************************
+ */
+
 STATIC elem * elarray(elem *e, goal_t goal)
 {
     return e;

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -259,6 +259,10 @@ enum OPER
         OPpreinc,               /* ++x overloading              */
         OPpredec,               /* --x overloading              */
 
+#if TX86 && TARGET_WINDOS && MARS
+        OPva_start,             /* va_start intrinsic           */
+#endif
+
 #ifdef TARGET_INLINEFUNC_OPS
         TARGET_INLINEFUNC_OPS
 #endif

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -65,6 +65,9 @@ int _unary[] =
          OPbsf,OPbsr,OPbswap,OPpopcnt,
          OPddtor,
          OPvector,
+#if TX86 && TARGET_WINDOS && MARS
+         OPva_start,
+#endif
 #if TX86
          OPsqrt,OPsin,OPcos,OPinp,
 #endif
@@ -120,6 +123,9 @@ int _sideff[] = {OPasm,OPucall,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,
                 OPmultinewarray,OPcheckcast,OPnullcheck,
                 OPbtc,OPbtr,OPbts,
                 OPhalt,OPdctor,OPddtor,
+#if TX86 && TARGET_WINDOS && MARS
+                OPva_start,
+#endif
 #if TX86
                 OPinp,OPoutp,OPvecsto,
 #endif
@@ -647,6 +653,10 @@ void dotab()
         case OPpopcnt:  X("popcnt",     evalu8, cdpopcnt);
         case OPvector:  X("vector",     elzot,  cdvector);
         case OPvecsto:  X("vecsto",     elzot,  cdvecsto);
+
+#if TX86 && TARGET_WINDOS && MARS
+        case OPva_start: X("va_start",  elvalist, cderr);
+#endif
 
         default:
                 printf("opcode hole x%x\n",i);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -171,7 +171,7 @@ elem *callfunc(Loc loc,
         ty = toSymbol(fd)->Stype->Tty;
     reverse = tyrevfunc(ty);
     ep = NULL;
-    op = (ec->Eoper == OPvar) ? intrinsic_op(ec->EV.sp.Vsym->Sident) : -1;
+    op = fd ? intrinsic_op(fd) : -1;
     if (arguments)
     {
         for (size_t i = 0; i < arguments->dim; i++)
@@ -393,6 +393,24 @@ if (I32) assert(tysize[TYnptr] == 4);
         }
         else if (op == OPind)
             e = el_una(op,mTYvolatile | tyret,ep);
+#if TARGET_WINDOS
+        else if (op == OPva_start)
+        {
+            assert(I64);
+            if (op == OPva_start)
+            {
+                // (OPparam &va &arg)
+                // call as (OPva_start &va)
+                ep->Eoper = op;
+                ep->Ety = tyret;
+                e = ep;
+
+                elem *earg = e->E2;
+                e->E2 = NULL;
+                e = el_combine(earg, e);
+            }
+        }
+#endif
         else
             e = el_una(op,tyret,ep);
     }

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -281,6 +281,7 @@ Msgtable msgtable[] =
     // varargs implementation
     { "va_argsave_t", "__va_argsave_t" },
     { "va_argsave", "__va_argsave" },
+    { "va_start" },
 
     // Builtin functions
     { "std" },

--- a/src/toir.h
+++ b/src/toir.h
@@ -18,6 +18,6 @@
 elem *incUsageElem(IRState *irs, Loc loc);
 elem *getEthis(Loc loc, IRState *irs, Dsymbol *fd);
 elem *setEthis(Loc loc, IRState *irs, elem *ey, AggregateDeclaration *ad);
-int intrinsic_op(char *name);
+int intrinsic_op(FuncDeclaration *name);
 elem *resolveLengthVar(VarDeclaration *lengthVar, elem **pe, Type *t1);
 

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1471,6 +1471,41 @@ void test6530()
 }
 
 /***************************************/
+
+import core.stdc.stdarg;
+
+extern(C)
+void func9495(int a, string format, ...)
+{
+    va_list ap;
+    static if (is(typeof(__va_argsave)))
+        va_start(ap, __va_argsave);
+    else
+        va_start(ap, format);
+    printf("&a: %p\n", &a);
+    printf("&format: %p\n", &format);
+    printf("ap[0]: %p\n", ap);
+    auto a1 = va_arg!int(ap);
+    printf("ap[1]: %p\n", ap);
+    auto a2 = va_arg!int(ap);
+    printf("ap[2]: %p\n", ap);
+    auto a3 = va_arg!int(ap);
+    printf("ap[3]: %p\n", ap);
+    printf("a1: %d\n", a1);
+    printf("a2: %d\n", a2);
+    printf("a3: %d\n", a3);
+    assert(a1 == 0x11111111);
+    assert(a2 == 0x22222222);
+    assert(a3 == 0x33333333);
+    va_end(ap);
+}
+
+void test9495()
+{
+    func9495(0, "", 0x11111111, 0x22222222, 0x33333333);
+}
+
+/***************************************/
 // 6700
 
 template bug6700(TList ...) {
@@ -1708,6 +1743,7 @@ int main()
     test7263();
     test9017();
     test10414();
+    test9495();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Usually `va_start` is passed the last named argument, and on x86 the first variadic arg can be found by incrementing its address.  On win64, aggregates larger than 8 bytes (such as D's dynamic arrays) are allocated on the stack, and a pointer is passed instead.  When one of these is the last named argument, the address of the pointer is needed to find the address of the first variadic arg, but this is not possible within D's type system.

To solve this, I've added code to recognize `va_start` as an intrinsic function and replace it's call with a backend op: `OPva_start`. (toir.h toir.c e2ir.c idgen.c)

The backend then replaces the `va_start` op with `va = &lastNamedArg + 8` where `lastNamedArg` is the pointer to the arg when necessary.  This allows `va_start` to correctly initialize the arg pointer on win64.

https://issues.dlang.org/show_bug.cgi?id=9495
