### PR TITLE
Turn va_start into an intrinsic for posix64

### DIFF
--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -259,7 +259,7 @@ enum OPER
         OPpreinc,               /* ++x overloading              */
         OPpredec,               /* --x overloading              */
 
-#if TX86 && TARGET_WINDOS && MARS
+#if TX86 && MARS
         OPva_start,             /* va_start intrinsic           */
 #endif
 

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -65,7 +65,7 @@ int _unary[] =
          OPbsf,OPbsr,OPbswap,OPpopcnt,
          OPddtor,
          OPvector,
-#if TX86 && TARGET_WINDOS && MARS
+#if TX86 && MARS
          OPva_start,
 #endif
 #if TX86
@@ -123,7 +123,7 @@ int _sideff[] = {OPasm,OPucall,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,
                 OPmultinewarray,OPcheckcast,OPnullcheck,
                 OPbtc,OPbtr,OPbts,
                 OPhalt,OPdctor,OPddtor,
-#if TX86 && TARGET_WINDOS && MARS
+#if TX86 && MARS
                 OPva_start,
 #endif
 #if TX86
@@ -654,7 +654,7 @@ void dotab()
         case OPvector:  X("vector",     elzot,  cdvector);
         case OPvecsto:  X("vecsto",     elzot,  cdvecsto);
 
-#if TX86 && TARGET_WINDOS && MARS
+#if TX86 && MARS
         case OPva_start: X("va_start",  elvalist, cderr);
 #endif
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -393,24 +393,19 @@ if (I32) assert(tysize[TYnptr] == 4);
         }
         else if (op == OPind)
             e = el_una(op,mTYvolatile | tyret,ep);
-#if TARGET_WINDOS
-        else if (op == OPva_start)
+        else if (op == OPva_start && global.params.is64bit)
         {
             assert(I64);
-            if (op == OPva_start)
-            {
-                // (OPparam &va &arg)
-                // call as (OPva_start &va)
-                ep->Eoper = op;
-                ep->Ety = tyret;
-                e = ep;
+            // (OPparam &va &arg)
+            // call as (OPva_start &va)
+            ep->Eoper = op;
+            ep->Ety = tyret;
+            e = ep;
 
-                elem *earg = e->E2;
-                e->E2 = NULL;
-                e = el_combine(earg, e);
-            }
+            elem *earg = e->E2;
+            e->E2 = NULL;
+            e = el_combine(earg, e);
         }
-#endif
         else
             e = el_una(op,tyret,ep);
     }

--- a/src/toir.c
+++ b/src/toir.c
@@ -572,7 +572,6 @@ int intrinsic_op(FuncDeclaration *fd)
         if (i != -1)
             return core_ioptab[i];
 
-#if TARGET_WINDOS
         if (global.params.is64bit &&
             fd->toParent()->isTemplateInstance() &&
             !strcmp(mangle(fd->getModule()), "4core4stdc6stdarg") &&
@@ -580,7 +579,6 @@ int intrinsic_op(FuncDeclaration *fd)
         {
             return OPva_start;
         }
-#endif
 
         return -1;
     }

--- a/src/toir.h
+++ b/src/toir.h
@@ -18,6 +18,6 @@
 elem *incUsageElem(IRState *irs, Loc loc);
 elem *getEthis(Loc loc, IRState *irs, Dsymbol *fd);
 elem *setEthis(Loc loc, IRState *irs, elem *ey, AggregateDeclaration *ad);
-int intrinsic_op(FuncDeclaration *name);
+int intrinsic_op(FuncDeclaration *fd);
 elem *resolveLengthVar(VarDeclaration *lengthVar, elem **pe, Type *t1);
 

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -329,10 +329,7 @@ extern(C++) void myvprintf(const(char)*, va_list);
 extern(C++) void myprintf(const(char)* format, ...)
 {
     va_list ap;
-    static if (is(typeof(__va_argsave)))
-        va_start(ap, __va_argsave);
-    else
-        va_start(ap, format);
+    va_start(ap, format);
     myvprintf(format, ap);
     va_end(ap);
 }

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -1187,10 +1187,7 @@ void myfunc(int a1, ...) {
 	string sa; int ia; double da;
 	writefln("%d variable arguments", _arguments.length);
 	writefln("argument types %s", _arguments);
-	static if (is(typeof(__va_argsave)))
-		va_start(argument_list, __va_argsave);
-	else
-		va_start(argument_list, a1);
+	va_start(argument_list, a1);
 	for (int i = 0; i < _arguments.length; ) {
 		if ((argument_type=_arguments[i++]) == typeid(string)) {
 			va_arg(argument_list, sa);

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -792,10 +792,7 @@ int foo42(const(char) *x, ...)
 {
     va_list ap;
 
-    static if (is(typeof(__va_argsave)))
-        va_start(ap, __va_argsave);
-    else
-        va_start!(typeof(x))(ap, x);
+    va_start!(typeof(x))(ap, x);
     printf("&x = %p, ap = %p\n", &x, ap);
 
     int i;

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1478,22 +1478,10 @@ extern(C)
 void func9495(int a, string format, ...)
 {
     va_list ap;
-    static if (is(typeof(__va_argsave)))
-        va_start(ap, __va_argsave);
-    else
-        va_start(ap, format);
-    printf("&a: %p\n", &a);
-    printf("&format: %p\n", &format);
-    printf("ap[0]: %p\n", ap);
+    va_start(ap, format);
     auto a1 = va_arg!int(ap);
-    printf("ap[1]: %p\n", ap);
     auto a2 = va_arg!int(ap);
-    printf("ap[2]: %p\n", ap);
     auto a3 = va_arg!int(ap);
-    printf("ap[3]: %p\n", ap);
-    printf("a1: %d\n", a1);
-    printf("a2: %d\n", a2);
-    printf("a3: %d\n", a3);
     assert(a1 == 0x11111111);
     assert(a2 == 0x22222222);
     assert(a3 == 0x33333333);


### PR DESCRIPTION
In the abi used for non-windows 64-bit, variadic arguments are accessed through a special save area.  A reference to this area is used as the variadic argument pointer, and it is not possible to calculate the address of this area from the address of parameters, as is done on 32-bit.

This patch ignores the second parameter to `va_start`, and initializes the argument pointer with the correct address.  Existing code that uses `__va_argsave` explicitly will continue to work.

This requires druntime pull https://github.com/D-Programming-Language/druntime/pull/1130 to be merged at the same time.
