### PR TITLE
[REG2.067a] Issue 14039 - function is incorrectly inferred as 'pure'

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1767,6 +1767,36 @@ bool VarDeclaration::checkNestedReference(Scope *sc, Loc loc)
                     int lv = fdthis->getLevel(loc, sc, fdv);
                     if (lv == -2)   // error
                         return false;
+                    if (lv > 0 &&
+                        fdv->isPureBypassingInference() >= PUREweak &&
+                        fdthis->isPureBypassingInference() == PUREfwdref &&
+                        fdthis->isInstantiated())
+                    {
+                        /* Bugzilla 9148 and 14039:
+                         *  void foo() pure {
+                         *    int x;
+                         *    void bar()() {  // default is impure
+                         *      x = 1;  // access to enclosing pure function context
+                         *              // means that bar should have weak purity.
+                         *    }
+                         *  }
+                         */
+                        fdthis->flags &= ~FUNCFLAGpurityInprocess;
+                        if (fdthis->type->ty == Tfunction)
+                        {
+                            TypeFunction *tf = (TypeFunction *)fdthis->type;
+                            if (tf->deco)
+                            {
+                                tf = (TypeFunction *)tf->copy();
+                                tf->purity = PUREfwdref;
+                                tf->deco = NULL;
+                                tf->deco = tf->merge()->deco;
+                            }
+                            else
+                                tf->purity = PUREfwdref;
+                            fdthis->type = tf;
+                        }
+                    }
                 }
 
                 // Function literals from fdthis to fdv must be delegates
@@ -1776,20 +1806,6 @@ bool VarDeclaration::checkNestedReference(Scope *sc, Loc loc)
                     if (FuncLiteralDeclaration *fld = s->isFuncLiteralDeclaration())
                     {
                         fld->tok = TOKdelegate;
-#if 0
-                        /* This is necessary to avoid breaking tests for 8751 & 8793.
-                         * See: compilable/testInference.d
-                         */
-                        // if is a mutable variable or
-                        // has any mutable indirections or
-                        // does not belong to pure function
-                        if (type->isMutable() ||
-                            !type->implicitConvTo(type->immutableOf()) ||
-                            !fdv->isPureBypassingInference())
-                        {
-                            fld->setImpure();   // Bugzilla 9415
-                        }
-#endif
                     }
                 }
 

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -280,7 +280,7 @@ public:
     ExpInitializer *getExpInitializer();
     Expression *getConstInitializer(bool needFullType = true);
     void checkCtorConstInit();
-    void checkNestedReference(Scope *sc, Loc loc);
+    bool checkNestedReference(Scope *sc, Loc loc);
     Dsymbol *toAlias();
     // Eliminate need for dynamic_cast
     VarDeclaration *isVarDeclaration() { return (VarDeclaration *)this; }
@@ -649,7 +649,7 @@ public:
     virtual bool addPostInvariant();
     const char *kind();
     FuncDeclaration *isUnique();
-    void checkNestedReference(Scope *sc, Loc loc);
+    bool checkNestedReference(Scope *sc, Loc loc);
     bool needsClosure();
     bool hasNestedFrameRefs();
     void buildResultVar(Scope *sc, Type *tret);

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -626,7 +626,6 @@ public:
     bool hasOverloads();
     PURE isPure();
     PURE isPureBypassingInference();
-    bool isPureBypassingInferenceX();
     bool setImpure();
     bool isSafe();
     bool isSafeBypassingInference();

--- a/src/expression.c
+++ b/src/expression.c
@@ -2384,9 +2384,9 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
 
     // Find the closest pure parent of the calling function
     FuncDeclaration *outerfunc = sc->func;
-    while ( outerfunc->toParent2() &&
-           !outerfunc->isPureBypassingInference() &&
-            outerfunc->toParent2()->isFuncDeclaration())
+    while (outerfunc->toParent2() &&
+           outerfunc->isPureBypassingInference() == PUREimpure &&
+           outerfunc->toParent2()->isFuncDeclaration())
     {
         outerfunc = outerfunc->toParent2()->isFuncDeclaration();
         if (outerfunc->type->ty == Terror)
@@ -2394,9 +2394,9 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
     }
 
     FuncDeclaration *calledparent = f;
-    while ( calledparent->toParent2() &&
-           !calledparent->isPureBypassingInference() &&
-            calledparent->toParent2()->isFuncDeclaration())
+    while (calledparent->toParent2() &&
+           calledparent->isPureBypassingInference() == PUREimpure &&
+           calledparent->toParent2()->isFuncDeclaration())
     {
         calledparent = calledparent->toParent2()->isFuncDeclaration();
         if (calledparent->type->ty == Terror)
@@ -2408,7 +2408,7 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
     if (!f->isPure() && calledparent != outerfunc)
     {
         FuncDeclaration *ff = outerfunc;
-        if (sc->flags & SCOPEcompile ? ff->isPureBypassingInferenceX() : ff->setImpure())
+        if (sc->flags & SCOPEcompile ? ff->isPureBypassingInference() >= PUREweak : ff->setImpure())
         {
             error("pure function '%s' cannot call impure function '%s'",
                 ff->toPrettyChars(), f->toPrettyChars());
@@ -2453,7 +2453,7 @@ void Expression::checkPurity(Scope *sc, VarDeclaration *v)
          * functions must be pure.
          */
         FuncDeclaration *ff = sc->func;
-        if (sc->flags & SCOPEcompile ? ff->isPureBypassingInferenceX() : ff->setImpure())
+        if (sc->flags & SCOPEcompile ? ff->isPureBypassingInference() >= PUREweak : ff->setImpure())
         {
             error("pure function '%s' cannot access mutable static data '%s'",
                 ff->toPrettyChars(), v->toChars());

--- a/src/func.c
+++ b/src/func.c
@@ -473,7 +473,7 @@ void FuncDeclaration::semantic(Scope *sc)
                 /* If the parent's purity is inferred, then this function's purity needs
                  * to be inferred first.
                  */
-                if (fd && fd->isPureBypassingInferenceX())
+                if (fd && fd->isPureBypassingInference() >= PUREweak)
                     tf->purity = PUREfwdref;            // default to pure
             }
         }
@@ -3551,11 +3551,6 @@ PURE FuncDeclaration::isPureBypassingInference()
         return PUREfwdref;
     else
         return isPure();
-}
-
-bool FuncDeclaration::isPureBypassingInferenceX()
-{
-    return !(flags & FUNCFLAGpurityInprocess) && isPure() != PUREimpure;
 }
 
 /**************************************

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6039,6 +6039,7 @@ bool TypeFunction::hasLazyParameters()
 
 bool TypeFunction::parameterEscapes(Parameter *p)
 {
+    purityLevel();
 
     /* Scope parameters do not escape.
      * Allow 'lazy' to imply 'scope' -
@@ -6057,12 +6058,14 @@ bool TypeFunction::parameterEscapes(Parameter *p)
         return true;
 
     if (purity > PUREweak)
-    {   /* With pure functions, we need only be concerned if p escapes
+    {
+        /* With pure functions, we need only be concerned if p escapes
          * via any return statement.
          */
         Type* tret = nextOf()->toBasetype();
         if (!isref && !tret->hasPointers())
-        {   /* The result has no references, so p could not be escaping
+        {
+            /* The result has no references, so p could not be escaping
              * that way.
              */
             return false;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -589,10 +589,10 @@ enum TRUSTformat
 enum PURE
 {
     PUREimpure = 0,     // not pure at all
-    PUREweak = 1,       // no mutable globals are read or written
-    PUREconst = 2,      // parameters are values or const
-    PUREstrong = 3,     // parameters are values or immutable
-    PUREfwdref = 4,     // it's pure, but not known which level yet
+    PUREfwdref = 1,     // it's pure, but not known which level yet
+    PUREweak = 2,       // no mutable globals are read or written
+    PUREconst = 3,      // parameters are values or const
+    PUREstrong = 4,     // parameters are values or immutable
 };
 
 RET retStyle(TypeFunction *tf);

--- a/src/statement.c
+++ b/src/statement.c
@@ -3938,7 +3938,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
         else
         {
             fd->buildResultVar(NULL, exp->type);
-            fd->vresult->checkNestedReference(sc, Loc());
+            bool r = fd->vresult->checkNestedReference(sc, Loc());
+            assert(r);  // vresult should be always accessible
 
             // Send out "case receiver" statement to the foreach.
             //  return vresult;

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -548,7 +548,7 @@ class Node10002
 /***************************************************/
 // 10148
 
-void fa10148() pure {}  // fa is @system
+void fa10148() {}  // fa is @system
 
 auto fb10148(T)()
 {
@@ -561,7 +561,7 @@ auto fb10148(T)()
         void fc(T2)()
         {
             // [5] During semantic3 process, fc is not @safe on default.
-            static assert(is(typeof(&fc) == void delegate() pure));
+            static assert(is(typeof(&fc) == void delegate()));
             fa10148();
         }
         // [1] this is now inferred to @safe by implementing issue 7511
@@ -578,7 +578,7 @@ void test10148()
                          // [3] instantiate fc
 
     // [6] Afer semantic3 done, fc!int is deduced to @system.
-    static assert(is(typeof(&fb10148!int.fc!int) == void delegate() pure @system));
+    static assert(is(typeof(&fb10148!int.fc!int) == void delegate() @system));
 }
 
 /***************************************************/

--- a/test/fail_compilation/fail12378.d
+++ b/test/fail_compilation/fail12378.d
@@ -53,9 +53,9 @@ fail_compilation/fail12378.d(143):        instantiated from here: __lambda1!int
 fail_compilation/fail12378.d(135):        instantiated from here: MapResultI!((y0) => iota(2).mapI!((x0) => ANYTHING - GOES), Result)
 fail_compilation/fail12378.d(62):        instantiated from here: mapI!(Result)
 fail_compilation/fail12378.d(143): Error: static function fail12378.testI.MapResultI!((y0) => iota(2).mapI!((x0) => ANYTHING - GOES), Result).MapResultI.front cannot access frame of function fail12378.testI
-fail_compilation/fail12378.d(143): Error: static function fail12378.testI.MapResultI!((y0) => iota(2).mapI!((x0) => ANYTHING - GOES), Result).MapResultI.front cannot access frame of function fail12378.testI
 ---
 */
+
 void testI()
 {
     auto r =

--- a/test/fail_compilation/fail9148.d
+++ b/test/fail_compilation/fail9148.d
@@ -1,0 +1,46 @@
+// Test case for issue 9148, found by the regression 14039
+
+void impure() {}    // impure
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail9148.d(22): Error: pure function 'fail9148.fb1!int.fb1.A!int.A.fc!int.fc' cannot call impure function 'fail9148.impure'
+fail_compilation/fail9148.d(44): Error: template instance fail9148.fb1!int.fb1.A!int.A.fc!int error instantiating
+fail_compilation/fail9148.d(36): Error: impure function 'fc' cannot access variable 'x' declared in enclosing pure function 'fail9148.fb2!int.fb2'
+fail_compilation/fail9148.d(45): Error: template instance fail9148.fb2!int.fb2.A!int.A.fc!int error instantiating
+---
+*/
+auto fb1(T)()
+{
+    int x;
+    struct A(S)
+    {
+        void fc(T2)()
+        {
+            x = 1;      // accessing pure function context makes fc as pure
+            impure();   // error, impure function call
+        }
+        this(S a) {}
+    }
+    return A!int();
+}
+auto fb2(T)()
+{
+    int x;
+    struct A(S)
+    {
+        void fc(T2)()
+        {
+            impure();   // impure function call makes fc as impure
+            x = 1;      // error, accessing pure context
+        }
+        this(S a) {}
+    }
+    return A!int();
+}
+void test1()
+{
+    fb1!int().fc!int();
+    fb2!int().fc!int();
+}

--- a/test/fail_compilation/testInference.d
+++ b/test/fail_compilation/testInference.d
@@ -133,3 +133,23 @@ immutable(void)* g10063(inout int* p) pure
 {
     return f10063(p);
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/testInference.d(154): Error: pure function 'testInference.bar14049' cannot call impure function 'testInference.foo14049!int.foo14049'
+---
+*/
+auto impure14049() { return 1; }
+
+void foo14049(T)(T val)
+{
+    auto n = () @trusted {
+        return impure14049();
+    }();
+}
+
+void bar14049() pure
+{
+    foo14049(1);
+}

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5296,7 +5296,7 @@ class C5311
     void breaksPure() pure const
     {
         static assert(!__traits(compiles, { globalData++; }));      // SHOULD BE ERROR
-        static assert(!__traits(compiles, { X.globalData++; }));    // SHOULD BE ERROR
+        static assert(!__traits(compiles, { C5311.globalData++; }));// SHOULD BE ERROR
         static assert(!__traits(compiles, { this.globalData++; })); // SHOULD BE ERROR
 
         static assert(!__traits(compiles, { int a = this.globalData; }));
@@ -5316,7 +5316,7 @@ struct S5311
     void breaksPure() pure const
     {
         static assert(!__traits(compiles, { globalData++; }));      // SHOULD BE ERROR
-        static assert(!__traits(compiles, { X.globalData++; }));    // SHOULD BE ERROR
+        static assert(!__traits(compiles, { S5311.globalData++; }));// SHOULD BE ERROR
         static assert(!__traits(compiles, { this.globalData++; })); // SHOULD BE ERROR
 
         static assert(!__traits(compiles, { int a = this.globalData; }));


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14039

Fixed behavior:
If a nested function is declared inside pure function, it's implicitly marked as pure. It's introduced behavior to fix [issue 9148](https://issues.dlang.org/show_bug.cgi?id=9148) in #3626.

``` d
auto foo() pure {
    int x;
    auto bar() {
        // bar is also marked as pure automatically,
        // because bar can access enclosing pure funciont context.
        x = 1;
    }
}
```

However, if a nested function is template, pure inference should be preferred than the implicit "pure inheritance".

``` d
auto foo() pure {
    int x;
    auto bar()() {   // template function bar is impure by default
        // bar will be forced to get weak purity, only when it's trying
        // to access enclosing pure function context.
        //x = 1;

        // otherwise, bar can call impure functions and then
        // it will be inferred to impure.
        impureFuncCall().
    }
}
```

While debugging, I found an another purity inference regression since 2.064. This PR will also fix it.
[Issue 14049](https://issues.dlang.org/show_bug.cgi?id=14049) - [REG2.064] Wrong purity inference for nested lambda
