### PR TITLE
Issue 14040 - Doesn't use assignment in slice

### DIFF
--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -623,6 +623,22 @@ elem * el_same(elem **pe)
     return el_copytree(e);
 }
 
+/*************************
+ * Thin wrapper of exp2_copytotemp. Different from el_same,
+ * always makes a temporary.
+ */
+elem *el_copytotmp(elem **pe)
+{
+    //printf("copytotemp()\n");
+    elem *e = *pe;
+    if (e)
+    {
+        *pe = exp2_copytotemp(e);
+        e = (*pe)->E2;
+    }
+    return el_copytree(e);
+}
+
 /**************************
  * Replace symbol s1 with s2 in tree.
  */

--- a/src/backend/el.h
+++ b/src/backend/el.h
@@ -149,6 +149,7 @@ int el_signx32(elem_p);
 targ_ldouble el_toldouble(elem_p);
 void el_toconst(elem_p);
 elem_p el_same(elem_p *);
+elem_p el_copytotmp(elem_p *);
 int el_match(elem_p ,elem_p);
 int el_match2(elem_p ,elem_p);
 int el_match3(elem_p ,elem_p);

--- a/test/runnable/evalorder.d
+++ b/test/runnable/evalorder.d
@@ -1,0 +1,30 @@
+extern(C) int printf(const char*, ...);
+
+void test14040()
+{
+    uint[] values = [0, 1, 2, 3, 4, 5, 6, 7];
+    uint offset = 0;
+
+    auto a1 = values[offset .. offset += 2];
+    if (a1 != [0, 1] || offset != 2)
+        assert(0);
+
+    uint[] fun()
+    {
+        offset += 2;
+        return values;
+    }
+    auto a2 = fun()[offset .. offset += 2];
+    if (a2 != [4, 5] || offset != 6)
+        assert(0);
+}
+
+/******************************************/
+
+int main()
+{
+    test14040();
+
+    printf("Success\n");
+    return 0;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14040

If upr has any side effects, lwr should be copied to temporary always.

Currently the evaluation order depends on whether the lower bounds of the slice has any side-effects or not. It's contrary to the deterministic evaluation order.
