### PR TITLE
Issue 14055 - CTFE internal error with uninitialized array: Assertion failure: '0' on line 318 in file 'interpret.c'

### DIFF
--- a/test/fail_compilation/ice10259.d
+++ b/test/fail_compilation/ice10259.d
@@ -1,12 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10259.d(13): Error: circular reference to 'ice10259.D.d'
-fail_compilation/ice10259.d(13):        called from here: (*function () => x)()
-fail_compilation/ice10259.d(15): Error: variable ice10259.x : Unable to initialize enum with class or pointer to struct. Use static const variable instead.
+fail_compilation/ice10259.d(11): Error: circular reference to 'ice10259.D.d'
+fail_compilation/ice10259.d(11):        called from here: (*function () => x)()
 ---
 */
-
 class D
 {
     int x;
@@ -14,16 +12,13 @@ class D
 }
 enum x = new D;
 
-
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10259.d(30): Error: circular reference to 'ice10259.D2.d'
-fail_compilation/ice10259.d(30):        called from here: (*function () => x)()
-fail_compilation/ice10259.d(32): Error: variable ice10259.x2 : Unable to initialize enum with class or pointer to struct. Use static const variable instead.
+fail_compilation/ice10259.d(25): Error: circular reference to 'ice10259.D2.d'
+fail_compilation/ice10259.d(25):        called from here: (*function () => x)()
 ---
 */
-
 class D2
 {
     int x;

--- a/test/fail_compilation/ice14055.d
+++ b/test/fail_compilation/ice14055.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice14055.d(16): Error: uninitialized variable 'foo' cannot be returned from CTFE
+---
+*/
+
+struct S
+{
+    static returnsFoo()
+    {
+        uint[1] foo = void;
+        return foo;
+    }
+
+    static enum fooEnum = returnsFoo();
+    static uint[1] fooArray = fooEnum[];
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14055

`scrubArray()` should propagate `ErrorExp` if CTFE returns uninitialized value.
