### PR TITLE
Add Compile-Time Error-Checking and Avoid Boundschecking in Slice Expressions

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -10046,6 +10046,29 @@ Lagain:
         lwr = lwr->optimize(WANTvalue);
         upr = upr->optimize(WANTvalue);
 
+        if (lwr->op == TOKdiv)
+        {
+            assert(reinterpret_cast<DivExp*>(lwr)); // TODO remove
+            DivExp* lwrDiv = (DivExp*)lwr; // TODO always true?
+        }
+        else if (lwr->op == TOKvar)
+        {
+            assert(reinterpret_cast<VarExp*>(lwr)); // TODO remove
+            VarExp* lwrVar = (VarExp*)lwr; // TODO always true?
+        }
+
+        if (upr->op == TOKdiv)
+        {
+            assert(reinterpret_cast<DivExp*>(upr)); // TODO remove
+            DivExp* uprDiv = (DivExp*)upr; // TODO always true?
+        }
+        else if (upr->op == TOKvar)
+        {
+            assert(reinterpret_cast<VarExp*>(upr)); // TODO remove
+            VarExp* uprVar = (VarExp*)upr; // TODO always true?
+            printf("xxx");
+        }
+
         IntRange lwrRange = getIntRange(lwr);
         IntRange uprRange = getIntRange(upr);
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -10056,18 +10056,17 @@ Lagain:
         {
             // lower
             bool lwrAtStart = false, lwrIn = false, lwrAtEnd = false;
-            long lwrDiv = 0; // non-zero means [ $/lwrDiv .. _ ]
+            dinteger_t lwrDiv = 0; // non-zero means [ $/lwrDiv .. _ ]
             if (lwr->op == TOKint64)
             {
-                IntegerExp* int_ = (IntegerExp*)lwr; // TODO is*Exp predicate?
-                lwrAtStart = int_->value == 0;
-                if (lwrAtStart) { e1->warning("Avoiding boundscheck for lower part '%s'", int_->toChars()); }
+                lwrAtStart = lwr->toInteger() == 0;
+                if (lwrAtStart) { lwr->warning("Avoiding boundscheck"); }
             }
             else if (lwr->op == TOKvar)
             {
                 VarExp* var = (VarExp*)lwr; // TODO is*Exp predicate?
                 lwrAtEnd = isOpDollar(var);
-                if (lwrAtEnd) { e1->warning("Avoiding boundscheck for lower part '%s'", var->toChars()); }
+                if (lwrAtEnd) { lwr->warning("Avoiding boundscheck"); }
             }
             else if (lwr->op == TOKdiv)
             {
@@ -10075,26 +10074,25 @@ Lagain:
                 if (div->e1->op == TOKvar && isOpDollar((VarExp*)div->e1) &&
                     div->e2->op == TOKint64)
                 {
-                    lwrDiv = ((IntegerExp*)div->e2)->value;
+                    lwrDiv = div->e2->toInteger();
                     lwrIn = lwrDiv >= 1;
-                    if (lwrIn) { e1->warning("Avoiding boundscheck for lower part '%s'", div->toChars()); }
+                    if (lwrIn) { lwr->warning("Avoiding boundscheck"); }
                 }
             }
 
             // upper
             bool uprAtStart = false, uprIn = false, uprAtEnd = false;
-            long uprDiv = 0; // non-zero means [ _ .. $/uprDiv ]
+            dinteger_t uprDiv = 0; // non-zero means [ _ .. $/uprDiv ]
             if (upr->op == TOKint64)
             {
-                IntegerExp* int_ = (IntegerExp*)upr; // TODO is*Exp predicate?
-                uprAtStart = int_->value == 0;
-                if (uprAtStart) { e1->warning("Avoiding boundscheck for upper part '%s'", int_->toChars()); }
+                uprAtStart = upr->toInteger() == 0;
+                if (uprAtStart) { upr->warning("Avoiding boundscheck"); }
             }
             else if (upr->op == TOKvar)
             {
                 VarExp* var = (VarExp*)upr; // TODO is*Exp predicate?
                 uprAtEnd = isOpDollar(var);
-                if (uprAtEnd) { e1->warning("Avoiding boundscheck for upper part '%s'", var->toChars()); }
+                if (uprAtEnd) { upr->warning("Avoiding boundscheck"); }
                 this->upperIsInBounds = uprAtEnd;
             }
             else if (upr->op == TOKdiv)
@@ -10103,9 +10101,9 @@ Lagain:
                 if (div->e1->op == TOKvar && isOpDollar((VarExp*)div->e1) &&
                     div->e2->op == TOKint64)
                 {
-                    uprDiv = ((IntegerExp*)div->e2)->value;
+                    uprDiv = div->e2->toInteger();
                     uprIn = uprDiv >= 1;
-                    if (uprIn) { e1->warning("Avoiding boundscheck for upper part '%s'", div->toChars()); }
+                    if (uprIn) { upr->warning("Avoiding boundscheck"); }
                     this->upperIsInBounds = uprIn;
                 }
             }

--- a/src/expression.c
+++ b/src/expression.c
@@ -10161,9 +10161,11 @@ Lagain:
             }
 
             // lower and upper
-            if (lwrAtStart || // [0 .. X]
-                (lwrAtEnd && uprAtEnd) ||       // [$ .. $]
-                (lwrMul*uprDiv <= uprMul*lwrDiv)) // [$*p/q .. $*r/s], p/q <= r/s => p*s <= r*q
+            if ((this->lowerIsInBounds &&
+                 this->upperIsInBounds) &&
+                (lwrAtStart || // [0 .. _]
+                 (lwrAtEnd && uprAtEnd) ||       // [$ .. $]
+                 (lwrMul*uprDiv <= uprMul*lwrDiv))) // [$*p/q .. $*r/s], p/q <= r/s => p*s <= r*q
             {
                 lowerIsLessThanUpper = true;
                 this->warning("Lower <= upper bound");

--- a/src/expression.c
+++ b/src/expression.c
@@ -9861,8 +9861,10 @@ bool isOutside(Boundness boundness)
             boundness == belowLowBound);
 }
 
-bool LOG_BOUNDNESS = false;
+bool LOG_BOUNDNESS = true;
 
+/** Analyze Expression $(D e) as Slice Bound with Length Variable (Dollar) in $(D lengthVar).
+ */
 Boundness analyzeSliceBound(Expression* e,
                             VarDeclaration *lengthVar,
                             dinteger_t* p, dinteger_t* q, dinteger_t* off) // out arguments
@@ -9918,11 +9920,22 @@ Boundness analyzeSliceBound(Expression* e,
             }
         }
     }
+    else if (e->op == TOKmul)
+    {
+        MulExp* mul = (MulExp*)e;
+        if (((isOpDollar(mul->e1, lengthVar) && isInteger(mul->e2, p)) ||
+             (isInteger(mul->e1, p) && isOpDollar(mul->e2, lengthVar))) &&
+            *p >= 2)
+        {
+            return aboveHighBound; // iff $ != 0
+        }
+    }
     else if (e->op == TOKadd)
     {
         AddExp* add = (AddExp*)e;
-        if ((isOpDollar(add->e1, lengthVar) && isInteger(add->e2, off)) ||
-            (isInteger(add->e1, off) && isOpDollar(add->e2, lengthVar)))
+        if (((isOpDollar(add->e1, lengthVar) && isInteger(add->e2, off)) ||
+             (isInteger(add->e1, off) && isOpDollar(add->e2, lengthVar))) &&
+            *off >= 1)
         {
             return aboveHighBound;
         }

--- a/src/expression.c
+++ b/src/expression.c
@@ -14,6 +14,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <assert.h>
+#include <stdio.h>
 
 #include "rmem.h"
 #include "port.h"
@@ -10202,10 +10203,25 @@ Lagain:
             }
             else if (isOutside(lwrBoundness))
             {
-                lwr->error("slice limit $*%lld/%lld + %lld is out of bounds",
-                           (unsigned long long)lwrM,
-                           (unsigned long long)lwrD,
-                           (unsigned long long)lwrO);
+                char buf[1024];
+                int tot = sizeof(buf);
+                int off = 0;
+                off += snprintf(&buf[off], tot-off, "lower slice limit ");
+                off += snprintf(&buf[off], tot-off, "$");
+                if (lwrM != 1 && off < tot)
+                {
+                    off += snprintf(&buf[off], tot-off, "*%lld", (unsigned long long)lwrM);
+                }
+                if (lwrD != 1 && off < tot)
+                {
+                    off += snprintf(&buf[off], tot-off, "/%lld", (unsigned long long)lwrD);
+                }
+                if (lwrO != 0 && lwrO != DINTEGER_UNDEFINED && off < tot)
+                {
+                    off += snprintf(&buf[off], tot-off, "+%lld", (unsigned long long)lwrO);
+                }
+                off += snprintf(&buf[off], tot-off, " is out of bounds");
+                lwr->error(buf);
             }
 
             // upper
@@ -10219,10 +10235,25 @@ Lagain:
             }
             else if (isOutside(uprBoundness))
             {
-                upr->error("slice limit $*%lld/%lld + %lld is out of bounds",
-                           (unsigned long long)uprM,
-                           (unsigned long long)uprD,
-                           (unsigned long long)uprO);
+                char buf[1024];
+                int tot = sizeof(buf);
+                int off = 0;
+                off += snprintf(&buf[off], tot-off, "upper slice limit ");
+                off += snprintf(&buf[off], tot-off, "$");
+                if (uprM != 1 && off < tot)
+                {
+                    off += snprintf(&buf[off], tot-off, "*%lld", (unsigned long long)uprM);
+                }
+                if (uprD != 1 && off < tot)
+                {
+                    off += snprintf(&buf[off], tot-off, "/%lld", (unsigned long long)uprD);
+                }
+                if (uprO != 0 && uprO != DINTEGER_UNDEFINED && off < tot)
+                {
+                    off += snprintf(&buf[off], tot-off, "+%lld", (unsigned long long)uprO);
+                }
+                off += snprintf(&buf[off], tot-off, " is out of bounds");
+                upr->error(buf);
             }
 
             // lower and upper

--- a/src/expression.c
+++ b/src/expression.c
@@ -9882,8 +9882,11 @@ Boundness analyzeSliceBound(Expression* e,
         const sinteger_t svalue = (sinteger_t)value;
         if (svalue < 0) // limit max slice bound index to 2^n-1, n=32 on 32-bit and n=64 on 64-bit
         {
-            // printf("%s is below low bound: %lld", e->toChars(), svalue);
             *off = value;
+            printf("%s is below low bound, e->toInteger() returns %ld, e->toUInteger() returns %ld\n",
+                   e->toChars(),
+                   e->toInteger(),
+                   e->toUInteger());
             return belowLowBound; // TODO aboveHighBound instead?
         }
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -9828,18 +9828,20 @@ enum Boundness
     atEnd,                  // specialization of inside
 };
 
+static bool LOG_BOUNDNESS = true;
+
 Boundness analyzeRelativeBound(Expression* e,
                                VarDeclaration *lengthVar,
                                dinteger_t* p, dinteger_t* q) // out arguments
 {
     if (e->op == TOKint64 && e->toInteger() == 0)
     {
-        e->warning("Avoiding boundscheck for 0");
+        if (LOG_BOUNDNESS) printf("Avoiding boundscheck for 0\n");
         return atStart;
     }
     else if (isOpDollar(e, lengthVar))
     {
-        e->warning("Avoiding boundscheck for $");
+        if (LOG_BOUNDNESS) printf("Avoiding boundscheck for $\n");
         return atEnd;
     }
     else if (e->op == TOKdiv)
@@ -9850,7 +9852,7 @@ Boundness analyzeRelativeBound(Expression* e,
             *q = div->e2->toInteger();
             if (*q >= 1)
             {
-                e->warning("Avoiding boundscheck for $/%ld", *q);
+                if (LOG_BOUNDNESS) printf("Avoiding boundscheck for $/%ld\n", *q);
                 return inside;
             }
         }
@@ -9864,7 +9866,7 @@ Boundness analyzeRelativeBound(Expression* e,
                 *p = mul->e2->toInteger();
                 if (*p <= *q)
                 {
-                    e->warning("Avoiding boundscheck for $*%ld/%ld", *p, *q);
+                    if (LOG_BOUNDNESS) printf("Avoiding boundscheck for $*%ld/%ld\n", *p, *q);
                     return inside;
                 }
                 else if (*p > *q)
@@ -9878,7 +9880,7 @@ Boundness analyzeRelativeBound(Expression* e,
                 *p = mul->e1->toInteger();
                 if (*p <= *q)
                 {
-                    e->warning("Avoiding boundscheck for $*%ld/%ld", *p, *q);
+                    if (LOG_BOUNDNESS) printf("Avoiding boundscheck for $*%ld/%ld\n", *p, *q);
                     return inside;
                 }
                 else if (*p > *q)
@@ -10168,7 +10170,7 @@ Lagain:
                  (lwrMul*uprDiv <= uprMul*lwrDiv)))
             {
                 lowerIsLessThanUpper = true;
-                this->warning("Lower <= upper bound");
+                if (LOG_BOUNDNESS) printf("Lower <= upper bound\n");
             }
         }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -10062,31 +10062,41 @@ Lagain:
 
         // avoid bounds-checking for slice bounds in form $/n
         // How to use resolveOpDollar?
-        if (upr->op == TOKdiv)  // start with upper because of lowerIsLessThanUpper
         {
-            DivExp* div = (DivExp*)upr; // TODO is*Exp predicate?
-        }
-        else if (upr->op == TOKvar)
-        {
-            VarExp* var = (VarExp*)upr; // TODO is*Exp predicate?
-            const bool isInBounds = isOpDollar(var);
-            if (isInBounds)
+            bool upperAtEnd = false;
+            if (upr->op == TOKdiv)  // start with upper because of lowerIsLessThanUpper
             {
-                e1->warning("Avoiding boundscheck for upper bound '%s'", var->toChars());
+                DivExp* div = (DivExp*)upr; // TODO is*Exp predicate?
             }
-            this->upperIsInBounds = isInBounds;
-        }
-        if (lwr->op == TOKdiv) // then lower
-        {
-            DivExp* div = (DivExp*)lwr; // TODO is*Exp predicate?
-        }
-        else if (lwr->op == TOKvar)
-        {
-            VarExp* var = (VarExp*)lwr; // TODO is*Exp predicate?
-            const bool isInBounds = isOpDollar(var);
-            if (isInBounds)
+            else if (upr->op == TOKvar)
             {
-                e1->warning("Avoiding boundscheck for lower bound '%s'", var->toChars());
+                VarExp* var = (VarExp*)upr; // TODO is*Exp predicate?
+                const bool isInBounds = isOpDollar(var);
+                if (isInBounds)
+                {
+                    e1->warning("Avoiding boundscheck for upper part '%s'", var->toChars());
+                }
+                this->upperIsInBounds = isInBounds;
+                upperAtEnd = isInBounds;
+            }
+            bool lowerAtEnd = false;
+            if (lwr->op == TOKdiv) // then lower
+            {
+                DivExp* div = (DivExp*)lwr; // TODO is*Exp predicate?
+            }
+            else if (lwr->op == TOKvar)
+            {
+                VarExp* var = (VarExp*)lwr; // TODO is*Exp predicate?
+                const bool isInBounds = isOpDollar(var);
+                if (isInBounds)
+                {
+                    e1->warning("Avoiding boundscheck for lower part '%s'", var->toChars());
+                }
+                lowerAtEnd = isInBounds;
+            }
+            if (lowerAtEnd && upperAtEnd)
+            {
+                lowerIsLessThanUpper = true;
             }
         }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -10140,12 +10140,12 @@ Lagain:
         }
         else if (t1b->ty == Tpointer)
         {
-            this->upperIsInBounds = true;
+            this->upperIsInBounds = true; // no boundscheck for x.ptr[_ .. _]
         }
         else
             assert(0);
 
-        this->lowerIsLessThanUpper = (lwrRange.imax <= uprRange.imin);
+        this->lowerIsLessThanUpper = this->lowerIsLessThanUpper || (lwrRange.imax <= uprRange.imin);
 
         //printf("upperIsInBounds = %d lowerIsLessThanUpper = %d\n", upperIsInBounds, lowerIsLessThanUpper);
     }

--- a/src/expression.c
+++ b/src/expression.c
@@ -9872,15 +9872,23 @@ Boundness analyzeSliceBound(Expression* e,
 {
     if (e->op == TOKint64)
     {
-        sinteger_t value = e->toInteger();
+        const dinteger_t value = e->toInteger();
         if (value == 0)
         {
             if (LOG_BOUNDNESS) e->warning("avoiding boundscheck for 0");
             return atLowBound;
         }
-        else if (value < 0)
+        if (e->type->isunsigned()) // BUG this evaluates to true for [-1 .. _ ]
         {
-            return belowLowBound;
+            const uinteger_t uvalue = (uinteger_t)value;
+        }
+        else
+        {
+            const sinteger_t svalue = (sinteger_t)value;
+            if (svalue < 0)
+            {
+                return belowLowBound;
+            }
         }
     }
     else if (isOpDollar(e, lengthVar))

--- a/src/expression.c
+++ b/src/expression.c
@@ -10163,9 +10163,10 @@ Lagain:
             // lower and upper
             if (lwrAtStart || // [0 .. X]
                 (lwrAtEnd && uprAtEnd) ||       // [$ .. $]
-                (lwrDiv >= uprDiv)) // [$/m .. $/n], m >= n
+                (lwrMul*uprDiv <= uprMul*lwrDiv)) // [$*p/q .. $*r/s], p/q <= r/s => p*s <= r*q
             {
                 lowerIsLessThanUpper = true;
+                this->warning("Lower <= upper bound");
             }
         }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -9831,31 +9831,6 @@ bool isInteger(Expression* e, dinteger_t* value)
     }
 }
 
-AddExp* isAddExp(Expression* e)
-{
-    return e->op == TOKadd ? (AddExp*)e : NULL;
-}
-
-MinExp* isMinExp(Expression* e)
-{
-    return e->op == TOKmin ? (MinExp*)e : NULL;
-}
-
-MulExp* isMulExp(Expression* e)
-{
-    return e->op == TOKmul ? (MulExp*)e : NULL;
-}
-
-DivExp* isDivExp(Expression* e)
-{
-    return e->op == TOKdiv ? (DivExp*)e : NULL;
-}
-
-NegExp* isNegExp(Expression* e)
-{
-    return e->op == TOKneg ? (NegExp*)e : NULL;
-}
-
 // Decribes Boundness of a Slice Beginning or End Index.
 enum Boundness
 {
@@ -9917,14 +9892,14 @@ Boundness analyzeSliceBound(Expression* e,
         if (LOG_BOUNDNESS) e->warning("avoiding boundscheck for $");
         return atHighBound;
     }
-    else if (NegExp* neg = isNegExp(e))
+    else if (NegExp* neg = e->isNegExp())
     {
         if (isOpDollar(neg->e1, lengthVar))
         {
             return outsideBounds;
         }
     }
-    else if (DivExp* div = isDivExp(e))
+    else if (DivExp* div = e->isDivExp())
     {
         if (isOpDollar(div->e1, lengthVar) && isInteger(div->e2, q))
         {
@@ -9964,9 +9939,9 @@ Boundness analyzeSliceBound(Expression* e,
             }
         }
     }
-    else if (MulExp* mul = isMulExp(e))
+    else if (MulExp* mul = e->isMulExp())
     {
-        if (NegExp* neg = isNegExp(mul->e1))
+        if (NegExp* neg = mul->e1->isNegExp())
         {
             if (isOpDollar(neg->e1, lengthVar) && isInteger(mul->e2, p) &&
                 *p >= 2)
@@ -9984,7 +9959,7 @@ Boundness analyzeSliceBound(Expression* e,
             }
         }
     }
-    else if (AddExp* add = isAddExp(e))
+    else if (AddExp* add = e->isAddExp())
     {
         if (((isOpDollar(add->e1, lengthVar) && isInteger(add->e2, off)) ||
              (isInteger(add->e1, off) && isOpDollar(add->e2, lengthVar))) &&
@@ -9993,7 +9968,7 @@ Boundness analyzeSliceBound(Expression* e,
             return aboveHighBound;
         }
     }
-    else if (MinExp* min = isMinExp(e))
+    else if (MinExp* min = e->isMinExp())
     {
         if ((isOpDollar(min->e1, lengthVar) && isInteger(min->e2, off)))
         {

--- a/src/expression.c
+++ b/src/expression.c
@@ -9862,7 +9862,7 @@ bool isOutside(Boundness boundness)
             boundness == belowLowBound);
 }
 
-bool LOG_BOUNDNESS = true;
+bool LOG_BOUNDNESS = false;
 
 /** Analyze Expression $(D e) as Slice Bound with Length Variable (Dollar) in $(D lengthVar).
  */
@@ -9870,10 +9870,18 @@ Boundness analyzeSliceBound(Expression* e,
                             VarDeclaration *lengthVar,
                             dinteger_t* p, dinteger_t* q, dinteger_t* off) // out arguments
 {
-    if (e->op == TOKint64 && e->toInteger() == 0) // TODO: isIntegerEqualTo
+    if (e->op == TOKint64)
     {
-        if (LOG_BOUNDNESS) e->warning("avoiding boundscheck for 0");
-        return atLowBound;
+        sinteger_t value = e->toInteger();
+        if (value == 0)
+        {
+            if (LOG_BOUNDNESS) e->warning("avoiding boundscheck for 0");
+            return atLowBound;
+        }
+        else if (value < 0)
+        {
+            return belowLowBound;
+        }
     }
     else if (isOpDollar(e, lengthVar))
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -9815,15 +9815,7 @@ Expression *SliceExp::syntaxCopy()
 static bool isOpDollar(VarExp* ve)
 {
     VarDeclaration* decl = ve->var->isVarDeclaration();
-    if (decl)
-    {
-        if (decl->ident->len == 8 &&
-            memcmp(decl->ident->string, "__dollar", decl->ident->len) == 0) // TODO is there a function for this?
-        {
-            return true;
-        }
-    }
-    return false;
+    return decl && decl->ident == Id::dollar;
 }
 
 Expression *SliceExp::semantic(Scope *sc)
@@ -10060,7 +10052,7 @@ Lagain:
         lwr = lwr->optimize(WANTvalue);
         upr = upr->optimize(WANTvalue);
 
-        // avoid bounds-checking for slice bounds in form $/n
+        // avoid bounds-checking for slice bounds when possible
         // How to use resolveOpDollar?
         {
             bool upperAtEnd = false;

--- a/src/expression.c
+++ b/src/expression.c
@@ -9878,23 +9878,24 @@ Boundness analyzeSliceBound(Expression* e,
             if (LOG_BOUNDNESS) e->warning("avoiding boundscheck for 0");
             return atLowBound;
         }
-        if (e->type->isunsigned()) // BUG this evaluates to true for [-1 .. _ ]
+        const sinteger_t svalue = (sinteger_t)value;
+        if (svalue < 0)
         {
-            const uinteger_t uvalue = (uinteger_t)value;
-        }
-        else
-        {
-            const sinteger_t svalue = (sinteger_t)value;
-            if (svalue < 0)
-            {
-                return belowLowBound;
-            }
+            return belowLowBound;
         }
     }
     else if (isOpDollar(e, lengthVar))
     {
         if (LOG_BOUNDNESS) e->warning("avoiding boundscheck for $");
         return atHighBound;
+    }
+    else if (e->op == TOKneg)
+    {
+        NegExp* neg = (NegExp*)e;
+        if (isOpDollar(neg->e1, lengthVar))
+        {
+            return outsideBounds;
+        }
     }
     else if (e->op == TOKdiv)
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -9828,7 +9828,7 @@ enum Boundness
     atEnd,                  // specialization of inside
 };
 
-static bool LOG_BOUNDNESS = true;
+static bool LOG_BOUNDNESS = false;
 
 Boundness analyzeRelativeBound(Expression* e,
                                VarDeclaration *lengthVar,

--- a/src/expression.c
+++ b/src/expression.c
@@ -10059,17 +10059,15 @@ Lagain:
             if (upr->op == TOKint64)
             {
                 IntegerExp* int_ = (IntegerExp*)upr; // TODO is*Exp predicate?
-                const bool isInBounds = int_->value == 0;
-                if (isInBounds) { e1->warning("Avoiding boundscheck for upper part '%s'", int_->toChars()); }
-                uprAtStart = isInBounds;
+                uprAtStart = int_->value == 0;
+                if (uprAtStart) { e1->warning("Avoiding boundscheck for upper part '%s'", int_->toChars()); }
             }
             else if (upr->op == TOKvar)
             {
                 VarExp* var = (VarExp*)upr; // TODO is*Exp predicate?
-                const bool isInBounds = isOpDollar(var);
-                if (isInBounds) { e1->warning("Avoiding boundscheck for upper part '%s'", var->toChars()); }
-                this->upperIsInBounds = isInBounds;
-                uprAtEnd = isInBounds;
+                uprAtEnd = isOpDollar(var);
+                if (uprAtEnd) { e1->warning("Avoiding boundscheck for upper part '%s'", var->toChars()); }
+                this->upperIsInBounds = uprAtEnd;
             }
             else if (upr->op == TOKdiv)
             {
@@ -10081,16 +10079,14 @@ Lagain:
             if (lwr->op == TOKint64)
             {
                 IntegerExp* int_ = (IntegerExp*)lwr; // TODO is*Exp predicate?
-                const bool isInBounds = int_->value == 0;
-                if (isInBounds) { e1->warning("Avoiding boundscheck for lower part '%s'", int_->toChars()); }
-                lwrAtStart = isInBounds;
+                lwrAtStart = int_->value == 0;
+                if (lwrAtStart) { e1->warning("Avoiding boundscheck for lower part '%s'", int_->toChars()); }
             }
             else if (lwr->op == TOKvar)
             {
                 VarExp* var = (VarExp*)lwr; // TODO is*Exp predicate?
-                const bool isInBounds = isOpDollar(var);
-                if (isInBounds) { e1->warning("Avoiding boundscheck for lower part '%s'", var->toChars()); }
-                lwrAtEnd = isInBounds;
+                lwrAtEnd = isOpDollar(var);
+                if (lwrAtEnd) { e1->warning("Avoiding boundscheck for lower part '%s'", var->toChars()); }
             }
             else if (lwr->op == TOKdiv) // then lower
             {

--- a/src/expression.c
+++ b/src/expression.c
@@ -9861,7 +9861,7 @@ bool isOutside(Boundness boundness)
             boundness == belowLowBound);
 }
 
-bool LOG_BOUNDNESS = true;
+bool LOG_BOUNDNESS = false;
 
 Boundness analyzeSliceBound(Expression* e,
                             VarDeclaration *lengthVar,

--- a/src/expression.c
+++ b/src/expression.c
@@ -10062,18 +10062,15 @@ Lagain:
             bool lwrAtEnd = false;
             dinteger_t lwrMul = 1; // non-one means [ $*lwrMul .. _ ]
             dinteger_t lwrDiv = 1; // non-one means [ $/lwrDiv .. _ ]
-            if (lwr->op == TOKint64)
+            if (lwr->op == TOKint64 && lwr->toInteger() == 0)
             {
-                lwrAtStart = lwr->toInteger() == 0;
-                if (lwrAtStart) { lwr->warning("Avoiding lower boundscheck"); }
-                this->lowerIsInBounds = lwrAtStart;
+                this->lowerIsInBounds = lwrAtStart = true;
+                lwr->warning("Avoiding lower boundscheck");
             }
-            else if (lwr->op == TOKvar)
+            else if (lwr->op == TOKvar && this->isOpDollar((VarExp*)lwr)) // TODO functionize?
             {
-                VarExp* var = (VarExp*)lwr;
-                lwrAtEnd = this->isOpDollar(var);
-                if (lwrAtEnd) { lwr->warning("Avoiding lower boundscheck"); }
-                this->lowerIsInBounds = lwrAtEnd;
+                this->lowerIsInBounds = lwrAtEnd = true;
+                lwr->warning("Avoiding lower boundscheck");
             }
             else if (lwr->op == TOKdiv)
             {
@@ -10114,18 +10111,15 @@ Lagain:
             bool uprAtEnd = false;
             dinteger_t uprMul = 1; // non-one means [ _ .. $*uprMul ]
             dinteger_t uprDiv = 1; // non-one means [ _ .. $/uprDiv ]
-            if (upr->op == TOKint64)
+            if (upr->op == TOKint64 && upr->toInteger() == 0)
             {
-                uprAtStart = upr->toInteger() == 0;
-                if (uprAtStart) { upr->warning("Avoiding upper boundscheck"); }
-                this->upperIsInBounds = uprAtStart;
+                this->upperIsInBounds = uprAtStart = true;
+                upr->warning("Avoiding upper boundscheck");
             }
-            else if (upr->op == TOKvar)
+            else if (upr->op == TOKvar && this->isOpDollar((VarExp*)upr)) // TODO functionize?
             {
-                VarExp* var = (VarExp*)upr;
-                uprAtEnd = this->isOpDollar(var); // TODO functionize?
-                if (uprAtEnd) { upr->warning("Avoiding upper boundscheck"); }
-                this->upperIsInBounds = uprAtEnd;
+                this->upperIsInBounds = uprAtEnd = true;
+                upr->warning("Avoiding upper boundscheck");
             }
             else if (upr->op == TOKdiv)
             {

--- a/src/expression.h
+++ b/src/expression.h
@@ -1009,6 +1009,8 @@ public:
     VarDeclaration *lengthVar;
     bool upperIsInBounds;       // true if upr <= e1.length
     bool lowerIsLessThanUpper;  // true if lwr <= upr
+    bool lowerIsInBounds() const { return (lowerIsLessThanUpper &&
+                                           upperIsInBounds); }; // true if lwr <= e1.length
 
     SliceExp(Loc loc, Expression *e1, Expression *lwr, Expression *upr);
     Expression *syntaxCopy();

--- a/src/expression.h
+++ b/src/expression.h
@@ -200,6 +200,13 @@ public:
 
     int isConst() { return ::isConst(this); }
     virtual int isBool(int result);
+
+    virtual AddExp* isAddExp() { return NULL; }
+    virtual MinExp* isMinExp() { return NULL; }
+    virtual MulExp* isMulExp() { return NULL; }
+    virtual DivExp* isDivExp() { return NULL; }
+    virtual NegExp* isNegExp() { return NULL; }
+
     Expression *op_overload(Scope *sc)
     {
         return ::op_overload(this, sc);
@@ -929,6 +936,7 @@ public:
     Expression *semantic(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
+    NegExp* isNegExp() { return this; }
 };
 
 class UAddExp : public UnaExp
@@ -1274,6 +1282,7 @@ public:
     Expression *semantic(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
+    AddExp* isAddExp() { return this; }
 };
 
 class MinExp : public BinExp
@@ -1283,6 +1292,7 @@ public:
     Expression *semantic(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
+    MinExp* isMinExp() { return this; }
 };
 
 class CatExp : public BinExp
@@ -1301,6 +1311,7 @@ public:
     Expression *semantic(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
+    MulExp* isMulExp() { return this; }
 };
 
 class DivExp : public BinExp
@@ -1310,6 +1321,7 @@ public:
     Expression *semantic(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
+    DivExp* isDivExp() { return this; }
 };
 
 class ModExp : public BinExp

--- a/src/expression.h
+++ b/src/expression.h
@@ -1007,10 +1007,9 @@ public:
     Expression *upr;            // NULL if implicit 0
     Expression *lwr;            // NULL if implicit [length - 1]
     VarDeclaration *lengthVar;
+    bool lowerIsInBounds;       // true if lwr <= e1.length
     bool upperIsInBounds;       // true if upr <= e1.length
     bool lowerIsLessThanUpper;  // true if lwr <= upr
-    bool lowerIsInBounds() const { return (lowerIsLessThanUpper &&
-                                           upperIsInBounds); }; // true if lwr <= e1.length
 
     SliceExp(Loc loc, Expression *e1, Expression *lwr, Expression *upr);
     Expression *syntaxCopy();
@@ -1020,6 +1019,7 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     int isBool(int result);
+    bool isOpDollar(VarExp* ve);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/expression.h
+++ b/src/expression.h
@@ -1011,11 +1011,12 @@ public:
     bool upperIsInBounds;       // true if upr <= e1.length
     bool lowerIsLessThanUpper;  // true if lwr <= upr
 
+    // Decribes Boundness of a Slice Beginning or End Index.
     enum Boundness
     {
-        unknown,
+        unknown,                // unknown whether inside or outside
         outside,                // outside of [0 .. $]
-        inside,                 // within [0 .. $]
+        inside,                 // inside of [0 .. $]
         atStart,                // specialization of inside
         atEnd,                  // specialization of inside
     };

--- a/src/expression.h
+++ b/src/expression.h
@@ -1007,7 +1007,6 @@ public:
     Expression *upr;            // NULL if implicit 0
     Expression *lwr;            // NULL if implicit [length - 1]
     VarDeclaration *lengthVar;
-    bool lowerIsInBounds;       // true if lwr <= e1.length
     bool upperIsInBounds;       // true if upr <= e1.length
     bool lowerIsLessThanUpper;  // true if lwr <= upr
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -1011,18 +1011,6 @@ public:
     bool upperIsInBounds;       // true if upr <= e1.length
     bool lowerIsLessThanUpper;  // true if lwr <= upr
 
-    // Decribes Boundness of a Slice Beginning or End Index.
-    enum Boundness
-    {
-        unknown,                // unknown whether inside or outside
-        outside,                // outside of [0 .. $]
-        inside,                 // inside of [0 .. $]
-        atStart,                // specialization of inside
-        atEnd,                  // specialization of inside
-    };
-
-    Boundness analyzeRelativeBound(Expression* e, dinteger_t* mul, dinteger_t* div);
-
     SliceExp(Loc loc, Expression *e1, Expression *lwr, Expression *upr);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
@@ -1031,7 +1019,6 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     int isBool(int result);
-    bool isOpDollar(VarExp* ve);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/expression.h
+++ b/src/expression.h
@@ -1011,6 +1011,17 @@ public:
     bool upperIsInBounds;       // true if upr <= e1.length
     bool lowerIsLessThanUpper;  // true if lwr <= upr
 
+    enum Boundness
+    {
+        unknown,
+        outside,                // outside of [0 .. $]
+        inside,                 // within [0 .. $]
+        atStart,                // specialization of inside
+        atEnd,                  // specialization of inside
+    };
+
+    Boundness analyzeRelativeBound(Expression* e, dinteger_t* mul, dinteger_t* div);
+
     SliceExp(Loc loc, Expression *e1, Expression *lwr, Expression *upr);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);


### PR DESCRIPTION
The goal here is to avoid boundschecking for slice expression whose lower or/and upper bounds can never be outside of `[0 .. $]`. Further, if a slice index can be proven to be outside of bounds an error is issued.

_Step 1_:

``` D
x[0 .. $]
x[0 .. 0]
x[$ .. $]
```

_Step 2_:

``` D
x[0 .. $/n]
x[$/n .. $]
```

where `n` is a compile-time constant >= 1

_Step 3_:

``` D
x[$/m .. $/n]
```

where `m` and `n` are compile-time constants both >= 1 and `m >= n`.

_Step 4_:

``` D
x[$*p/q .. $*r/s]
```

where `p`, `q`, `r` and `s` are compile-time constants both >= 1 and `p/q <= r/s`, `p <= q`, `r <= s`.

_Step 5 (error reporting only)_:

``` D
x[$+o .. $+s]
```

I put this out in the open in a very early stage to get feedback as soon as possible. This so I don't diverge in a direction that you dislike.

I use a warning for now for debug purpose.

My prel tests seems to show that the current logic holds water and at least doesn't crash DMD :)

Most of my questions are given as TODO comments.

Specifically I'm curious
- Why isn't there a specific `class DollarExp` instead of `VarExp`. That would have made `isOpDollar` trivial.
- If `(x->op == TOKdiv)` is it guaranteed that `x` is of type `DivExp`? This seems like an insecure pattern. I see that DMD has `isVarDeclaration` so why isn't there corresponding `is.*Exp`?
- Could any explain what resolveOpDollar is used for. Have any use of it here?

Note that the naming of the variable `lowerIsLessThanUpper` is misleading as it's value is true iff `lwr <= upr`. `lowerIsLessThanOrEqualToUpper` or `lowerIsLTEToUpper` would be a better name.

Update: Another key issue is whether this should include analysis of immutable slice initializations such as, for instance, line 37 to to 46 in std.ascii.

Destroy and thanks in advance!
