### PR TITLE
[REG2.066] Issue 13873 - 2.066.1 Compiling with -debug -inline generates huge files

### DIFF
--- a/src/inline.c
+++ b/src/inline.c
@@ -1626,12 +1626,24 @@ bool canInline(FuncDeclaration *fd, int hasthis, int hdrscan, int statementsToo)
     if (fd->needThis() && !hasthis)
         return false;
 
-    if (fd->inlineNest || (fd->semanticRun < PASSsemantic3 && !hdrscan))
+    if (fd->inlineNest)
     {
 #if CANINLINE_LOG
         printf("\t1: no, inlineNest = %d, semanticRun = %d\n", fd->inlineNest, fd->semanticRun);
 #endif
         return false;
+    }
+
+    if (fd->semanticRun < PASSsemantic3 && !hdrscan)
+    {
+        if (!fd->fbody)
+            return false;
+        if (!fd->functionSemantic3())
+            return false;
+        Module::runDeferredSemantic3();
+        if (global.errors)
+            return false;
+        assert(fd->semanticRun >= PASSsemantic3done);
     }
 
     switch (statementsToo ? fd->inlineStatusStmt : fd->inlineStatusExp)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13873

Do incremental semantic3 for inlining.
- Compilation speed with `-inline` will be faster.
- Generated object file size will be smaller (but execution size will not be changed, of course).

This change totally depends on the on-demand forward reference resolving mechanism.
