### PR TITLE
Issue 14066, 14069, 14076 - Bug fixes in Partial type deduction

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1010,7 +1010,7 @@ Type *applyPartialType(Loc loc, Scope *sc, Type *t, Type *tx)
 Type *applyPartialType(Loc loc, Scope *sc, Expression *exp, Type *tx)
 {
     Type *t = exp->type;
-    if (!tx)
+    if (!tx || t->ty == Terror)
         return t;
 
     if (tx->ty == Tident &&

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -944,7 +944,8 @@ Type *applyPartialType(Loc loc, Scope *sc, Type *t, Type *tx)
         ((TypeIdentifier *)tx)->ident == Id::empty &&
         ((TypeIdentifier *)tx)->idents.dim == 0)
     {
-        t = t->addMod(tx->mod);
+        if (tx->mod)
+            t = t->castMod(tx->mod);
         return t;
     }
 
@@ -1017,7 +1018,8 @@ Type *applyPartialType(Loc loc, Scope *sc, Expression *exp, Type *tx)
         ((TypeIdentifier *)tx)->ident == Id::empty &&
         ((TypeIdentifier *)tx)->idents.dim == 0)
     {
-        t = t->addMod(tx->mod);
+        if (tx->mod)
+            t = t->castMod(tx->mod);
         return t;
     }
 

--- a/src/init.c
+++ b/src/init.c
@@ -346,11 +346,12 @@ bool ArrayInitializer::isAssociativeArray()
 Initializer *ArrayInitializer::inferType(Scope *sc, Type *tx)
 {
     //printf("ArrayInitializer::inferType() %s\n", toChars());
+    bool isAA = isAssociativeArray();
     Expressions *keys = NULL;
     Expressions *values;
     if (tx ? (tx->ty == Taarray ||
-              tx->ty != Tarray && tx->ty != Tsarray && isAssociativeArray())
-           : isAssociativeArray())
+              tx->ty != Tarray && tx->ty != Tsarray && isAA)
+           : isAA)
     {
         Type *tidx = NULL;
         Type *tval = NULL;
@@ -395,7 +396,7 @@ Initializer *ArrayInitializer::inferType(Scope *sc, Type *tx)
         ExpInitializer *ei = new ExpInitializer(loc, e);
         return ei->inferType(sc, tx);
     }
-    else
+    else if (!isAA)
     {
         Type *tn = NULL;
         if (tx && (tx->ty == Tarray || tx->ty == Tsarray))

--- a/src/init.c
+++ b/src/init.c
@@ -814,6 +814,8 @@ Initializer *ExpInitializer::inferType(Scope *sc, Type *tx)
 
     if (tx)
     {
+        //printf("ExpInitializer::inferType() tx = %s (%s), exp = %s (%s) %s\n",
+        //    tx->toChars(), tx->deco, exp->type->toChars(), exp->type->deco, exp->toChars());
         Type *tb = tx->toBasetype();
         Type *ti = exp->type->toBasetype();
 

--- a/test/fail_compilation/fail481.d
+++ b/test/fail_compilation/fail481.d
@@ -23,3 +23,14 @@ void main()
     int[$] a4 = void;
     int[$] a5 = 1;
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail481.d(35): Error: cannot infer type from array initializer
+---
+*/
+void test14066()
+{
+    int[$] aa = ['a': 1];
+}

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -82,6 +82,18 @@ char[3] a481_18x = "abc";
 char[$] a481_18y = "abc";
 static assert(is(typeof(a481_18x) == typeof(a481_18y)));
 
+immutable pure @safe bool function(in bool[])[2] a481_19x =
+[
+    s => s[0],
+    s => s[0]
+];
+immutable pure @safe bool function(in bool[])[$] a481_19y =
+[
+    s => s[0],
+    s => s[0]
+];
+static assert(is(typeof(a481_19x) == typeof(a481_19y)));
+
 void test481()
 {
     assert(a481_1x == a481_1y);

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -241,6 +241,24 @@ void test481b()
     static assert(is(typeof(aa15) == int[int[][2]]));
 }
 
+void test14069()
+{
+    const[$] s1 = "hello";
+    static assert(is(typeof(s1) == const(char)[5]));
+    char[$] s2 = "hello";
+    static assert(is(typeof(s2) == char[5]));
+
+    const[$] s3 = "hello"w;
+    static assert(is(typeof(s3) == const(wchar)[5]));
+    wchar[$] s4 = "hello"w;
+    static assert(is(typeof(s4) == wchar[5]));
+
+    const[$] s5 = "hello"d;
+    static assert(is(typeof(s5) == const(dchar)[5]));
+    dchar[$] s6 = "hello"d;
+    static assert(is(typeof(s6) == dchar[5]));
+}
+
 /***************************************************/
 // 6475
 


### PR DESCRIPTION
[Issue 14066](https://issues.dlang.org/show_bug.cgi?id=14066) - [ICE](init.c line 410) with wrongly used array definition syntax
[Issue 14069](https://issues.dlang.org/show_bug.cgi?id=14069) - Partial type deduction should prefer the specified type qualifier 
[Issue 14076](https://issues.dlang.org/show_bug.cgi?id=14076) - Partial type deduction doesn't work with lambdas
