### PR TITLE
Set return type of lazy void delegates to void [GDC] [ARM]

### DIFF
--- a/src/delegatize.c
+++ b/src/delegatize.c
@@ -35,11 +35,10 @@ bool walkPostorder(Expression *e, StoppableVisitor *v);
 void lambdaSetParent(Expression *e, Scope *sc);
 bool lambdaCheckForNestedRef(Expression *e, Scope *sc);
 
-Expression *toDelegate(Expression *e, Scope *sc)
+Expression *toDelegate(Expression *e, Type* t, Scope *sc)
 {
-    //printf("Expression::toDelegate(t = %s) %s\n", e->type->toChars(), e->toChars());
+    //printf("Expression::toDelegate(t = %s) %s\n", t->toChars(), e->toChars());
     Loc loc = e->loc;
-    Type *t = e->type;
 
     TypeFunction *tf = new TypeFunction(NULL, t, 0, LINKd);
     if (t->hasWild())

--- a/src/expression.c
+++ b/src/expression.c
@@ -1521,7 +1521,7 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                             {
                                 a = a->implicitCastTo(sc, tret);
                                 a = a->optimize(WANTvalue);
-                                a = toDelegate(a, sc);
+                                a = toDelegate(a, a->type, sc);
                             }
                             else
                                 a = a->implicitCastTo(sc, tbn);
@@ -1668,7 +1668,10 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             else if (p->storageClass & STClazy)
             {
                 // Convert lazy argument to a delegate
-                arg = toDelegate(arg, sc);
+                if (p->type->ty == Tvoid)
+                    arg = toDelegate(arg, p->type, sc);
+                else
+                    arg = toDelegate(arg, arg->type, sc);
             }
             else
             {

--- a/src/expression.h
+++ b/src/expression.h
@@ -74,7 +74,7 @@ void discardValue(Expression *e);
 bool isTrivialExp(Expression *e);
 
 int isConst(Expression *e);
-Expression *toDelegate(Expression *e, Scope *sc);
+Expression *toDelegate(Expression *e, Type* t, Scope *sc);
 AggregateDeclaration *isAggregate(Type *t);
 IntRange getIntRange(Expression *e);
 bool checkNonAssignmentArrayOp(Expression *e, bool suggestion = false);


### PR DESCRIPTION
Before this commit the delegates generated for lazy void parameters returned the type of the wrapped expression. Example:

``` d
void test(lazy void a) {}
test(new Object()); //The generated delegate returns Object
```

The delegate calling code however expects a delegate with no return value. Usually the result of the lazy func delegate is returned in a register. As a function may modify the result register internally even if defined with void return type this never causes problems and the value is ignored.

For bigger aggregate types (on ARM already >4byte) the result is written onto the stack and this requires an additional hidden parameter passed to the delegate. But as the delegate is called as void(...) the additional parameter is never initialized and whatever is in the argument register is passed into the function and used as the location were the result will be written ==> memory corruption.

This should be reproducible on X86 as well but the observed effects depend on stack layout and function calling conventions. Because of that I don't want to add a testcase as it would make porting to other architectures more difficult for no real benefit.

This bug is actually triggerd in druntime on ARM since 2.066. Once this is reviewed / merged into dmd it'll be backported to GDC to fix the ARM problem.
