### PR TITLE
add FreeBSD to REQUIRE_DSO_REGISTRY

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -77,7 +77,7 @@ char *obj_mangle2(Symbol *s,char *dest);
  * section registration and will no longer create global bracket
  * symbols (_deh_beg,_deh_end,_tlsstart,_tlsend).
  */
-#define REQUIRE_DSO_REGISTRY (DMDV2 && TARGET_LINUX)
+#define REQUIRE_DSO_REGISTRY (DMDV2 && (TARGET_LINUX || TARGET_FREEBSD))
 
 /***************************************************
  * Correspondence of relocation types


### PR DESCRIPTION
- replaces weak linkage of _d_dso_registry
- drops support for old _Dmodule_ref
