### PR TITLE
Fix Issue 14097 - root/async.c: free after use

### DIFF
--- a/src/root/async.c
+++ b/src/root/async.c
@@ -99,6 +99,11 @@ int AsyncRead::read(size_t i)
 
 void AsyncRead::dispose(AsyncRead *aw)
 {
+    for (size_t i = 0; i < aw->filesdim; i++)
+    {
+        FileData *f = &aw->files[i];
+        WaitForSingleObject(f->event, INFINITE);
+    }
     free(aw);
 }
 
@@ -109,7 +114,8 @@ unsigned __stdcall startthread(void *p)
     AsyncRead *aw = (AsyncRead *)p;
 
     //printf("aw->filesdim = %p %d\n", aw, aw->filesdim);
-    for (size_t i = 0; i < aw->filesdim; i++)
+    size_t dim = aw->filesdim;
+    for (size_t i = 0; i < dim; i++)
     {   FileData *f = &aw->files[i];
 
         f->result = f->file->read();


### PR DESCRIPTION
This is a patch by Ketmar Dark:
https://issues.dlang.org/show_bug.cgi?id=14097

The fix is to wait for all tasks to finish (as it is [done](https://github.com/D-Programming-Language/dmd/blob/master/src/root/async.c#L227) in the posix version) before calling free().

This is my first commit to the DMD codebase, so I hope I am not doing anything wrong :)
