### PR TITLE
[REG2.064] Issue 14089 - Assigning to AA has no value when overriding opAssign

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -11438,8 +11438,6 @@ Expression *AssignExp::semantic(Scope *sc)
                         ex = ex->modifiableLvalue(sc, ex);  // allocate new slot
                         ey = new ConstructExp(loc, ex, ey);
 
-                        ey = new CastExp(ey->loc, ey, Type::tvoid);
-
                         e = new CondExp(loc, new InExp(loc, ek, ea), e, ey);
                     }
                     e = combine(e0, e);

--- a/test/fail_compilation/fail14089.d
+++ b/test/fail_compilation/fail14089.d
@@ -1,0 +1,46 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail14089.d(41): Error: long has no effect in expression (1)
+fail_compilation/fail14089.d(41): Error: long has no effect in expression (1)
+fail_compilation/fail14089.d(42): Error: long has no effect in expression (1)
+fail_compilation/fail14089.d(42): Error: var has no effect in expression (n)
+fail_compilation/fail14089.d(43): Error: long has no effect in expression (1)
+fail_compilation/fail14089.d(43): Error: dotvar has no effect in expression (s.val)
+fail_compilation/fail14089.d(44): Error: var has no effect in expression (n)
+fail_compilation/fail14089.d(44): Error: long has no effect in expression (1)
+fail_compilation/fail14089.d(45): Error: dotvar has no effect in expression (s.val)
+fail_compilation/fail14089.d(45): Error: long has no effect in expression (1)
+---
+*/
+
+bool cond;
+
+void main()
+{
+    int foo() { return 0; }
+    int n;
+    struct S { int val; }
+    S s;
+
+    // The whole of each CondExps has side effects, So no error.
+    cond ? foo() : n;
+    cond ? foo() : s.val;
+    cond ? 1     : foo();
+    cond ? n     : foo();
+    cond ? s.val : foo();
+
+    cond ? (n = 1) : 1;
+    cond ? (n = 1) : n;
+    cond ? (n = 1) : s.val;
+    cond ? 1       : (n = 1);
+    cond ? n       : (n = 1);
+    cond ? s.val   : (n = 1);
+
+    // errors
+    cond ? 1     : 1;
+    cond ? 1     : n;
+    cond ? 1     : s.val;
+    cond ? n     : 1;
+    cond ? s.val : 1;
+}

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -1245,6 +1245,23 @@ void test11730()
 }
 
 /************************************************/
+// 14089
+
+struct S14089
+{
+    int num;
+    S14089 opAssign(S14089 val) { return this; }
+}
+
+void test14089()
+{
+    S14089[int] aa;
+    S14089 b = aa[1] = S14089(0);
+    assert(aa[1].num == 0);
+    assert(b.num == 0);
+}
+
+/************************************************/
 
 int main()
 {
@@ -1293,6 +1310,7 @@ int main()
     test6799();
     test11359();
     test11730();
+    test14089();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14089

When I fixed issue 6178 in #2539, I could not find the way to avoid false "dovar has no side effect" error for the test case in `runnable/testaa.d`. Now, I found a way that loosen `discardValue()` behavior a little for `CondExp`.
