### PR TITLE
Add FreeStanding as a pre-defined version condition aimed at bare-metal targets

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -172,6 +172,7 @@ bool VersionCondition::isPredefined(const char *ident)
         "Android",
         "Cygwin",
         "MinGW",
+        "FreeStanding",
         "X86",
         "X86_64",
         "ARM",


### PR DESCRIPTION
http://forum.dlang.org/post/eyqwnaykzlykkktgdovs@forum.dlang.org

I agree, NoSystem should be a platform and not a build failure, and compiler support is trivially add by using a (WARNING: bikeshed approaching) `-free-standing` or `-self-hosted` or `-bare-metal` switch.

Documentation PR here: https://github.com/D-Programming-Language/dlang.org/pull/881

PS: Would it be worth re-ordering `reserved` and using binary search?  Maybe later...
