### PR TITLE
Issue 14090 - [REG2.067a] Incorrect "recursive alias declaration"

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1492,6 +1492,7 @@ char *Type::toChars()
     OutBuffer buf;
     buf.reserve(16);
     HdrGenState hgs;
+    hgs.fullQual = (ty == Tclass && !mod);
 
     ::toCBuffer(this, &buf, NULL, &hgs);
     return buf.extractString();
@@ -2874,11 +2875,6 @@ Type *TypeBasic::syntaxCopy()
     return this;
 }
 
-char *TypeBasic::toChars()
-{
-    return Type::toChars();
-}
-
 d_uns64 TypeBasic::size(Loc loc)
 {   unsigned size;
 
@@ -3517,11 +3513,6 @@ TypeBasic *TypeVector::elementType()
 bool TypeVector::checkBoolean()
 {
     return false;
-}
-
-char *TypeVector::toChars()
-{
-    return Type::toChars();
 }
 
 d_uns64 TypeVector::size(Loc loc)
@@ -7139,13 +7130,6 @@ const char *TypeEnum::kind()
     return "enum";
 }
 
-char *TypeEnum::toChars()
-{
-    if (mod)
-        return Type::toChars();
-    return sym->toChars();
-}
-
 Type *TypeEnum::syntaxCopy()
 {
     return this;
@@ -7376,19 +7360,6 @@ TypeStruct::TypeStruct(StructDeclaration *sym)
 const char *TypeStruct::kind()
 {
     return "struct";
-}
-
-char *TypeStruct::toChars()
-{
-    //printf("sym.parent: %s, deco = %s\n", sym->parent->toChars(), deco);
-    if (mod)
-        return Type::toChars();
-    TemplateInstance *ti = sym->parent->isTemplateInstance();
-    if (ti && ti->aliasdecl == sym)
-    {
-        return ti->toChars();
-    }
-    return sym->toChars();
 }
 
 Type *TypeStruct::syntaxCopy()
@@ -7941,13 +7912,6 @@ TypeClass::TypeClass(ClassDeclaration *sym)
 const char *TypeClass::kind()
 {
     return "class";
-}
-
-char *TypeClass::toChars()
-{
-    if (mod)
-        return Type::toChars();
-    return (char *)sym->toPrettyChars();
 }
 
 Type *TypeClass::syntaxCopy()

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7384,7 +7384,7 @@ char *TypeStruct::toChars()
     if (mod)
         return Type::toChars();
     TemplateInstance *ti = sym->parent->isTemplateInstance();
-    if (ti && ti->toAlias() == sym)
+    if (ti && ti->aliasdecl == sym)
     {
         return ti->toChars();
     }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -400,7 +400,6 @@ public:
     unsigned alignsize();
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    char *toChars();
     bool isintegral();
     bool isfloating();
     bool isreal();
@@ -430,7 +429,6 @@ public:
     unsigned alignsize();
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    char *toChars();
     bool isintegral();
     bool isfloating();
     bool isscalar();
@@ -688,7 +686,6 @@ public:
     TypeIdentifier(Loc loc, Identifier *ident);
     const char *kind();
     Type *syntaxCopy();
-    //char *toChars();
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Dsymbol *toDsymbol(Scope *sc);
     Type *semantic(Loc loc, Scope *sc);
@@ -706,7 +703,6 @@ public:
     TypeInstance(Loc loc, TemplateInstance *tempinst);
     const char *kind();
     Type *syntaxCopy();
-    //char *toChars();
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
@@ -764,7 +760,6 @@ public:
     const char *kind();
     d_uns64 size(Loc loc);
     unsigned alignsize();
-    char *toChars();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
@@ -796,7 +791,6 @@ public:
     Type *syntaxCopy();
     d_uns64 size(Loc loc);
     unsigned alignsize();
-    char *toChars();
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
@@ -833,7 +827,6 @@ public:
     TypeClass(ClassDeclaration *sym);
     const char *kind();
     d_uns64 size(Loc loc);
-    char *toChars();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);

--- a/test/fail_compilation/fail9.d
+++ b/test/fail_compilation/fail9.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9.d(25): Error: no property 'Vector' for type 'fail9.Vector!int.Vector'
-fail_compilation/fail9.d(25): Error: no property 'Vector' for type 'fail9.Vector!int.Vector'
+fail_compilation/fail9.d(25): Error: no property 'Vector' for type 'fail9.Vector!int'
+fail_compilation/fail9.d(25): Error: no property 'Vector' for type 'fail9.Vector!int'
 ---
 */
 

--- a/test/fail_compilation/ice8100.d
+++ b/test/fail_compilation/ice8100.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8100.d(10): Error: no property 'Q' for type 'ice8100.Bar!bool.Bar'
+fail_compilation/ice8100.d(10): Error: no property 'Q' for type 'ice8100.Bar!bool'
 fail_compilation/ice8100.d(11): Error: template instance ice8100.Foo!(Bar!bool) error instantiating
 fail_compilation/ice8100.d(12):        instantiated from here: Bar!bool
 ---

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -351,6 +351,31 @@ void test13776()
 }
 
 /***************************************************/
+// 14090
+
+template Packed14090(Args...)
+{
+    enum x = __traits(compiles, { Args[0] v; });
+    // Args[0] is an opaque struct Empty, so the variable declaration fails to compile.
+    // The error message creation calls TypeStruct('_Empty')->toChars(), and
+    // it wrongly calls TemplateInstance('RoundRobin!()')->toAlias().
+    // Finally it will cause incorrect "recursive template instantiation" error.
+}
+
+template Map14090(A...)
+{
+    alias Map14090 = A[0];
+}
+
+template RoundRobin14090()
+{
+    struct Empty;
+    alias RoundRobin14090 = Map14090!(Packed14090!(Empty));
+}
+
+alias roundRobin14090 = RoundRobin14090!();
+
+/***************************************************/
 // 13950
 
 template Tuple13950(T...) { alias T Tuple13950; }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14090

The root issue is same with regression 13776, During error message creation, we should not call `TemplateInstance::toAlias()`.
