### PR TITLE
Diagnostics that hints about use of std.array.array upon implicit conversion in assignments

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -639,6 +639,16 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         return type;
     }
 
+    /****************************************
+     * Returns `true` if `this` aggregate has an `InputRange` interface
+     */
+    final bool isInputRange()
+    {
+        return (search(Loc(), Id.Ffront) &&
+                search(Loc(), Id.FpopFront) &&
+                search(Loc(), Id.Fempty));
+    }
+
     // is aggregate deprecated?
     override final bool isDeprecated()
     {

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -149,6 +149,8 @@ public:
 
     AggregateDeclaration *isAggregateDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
+
+    virtual bool isInputRange() { return false; }
 };
 
 struct StructFlags
@@ -195,6 +197,8 @@ public:
     void finalizeSize();
     bool fit(Loc loc, Scope *sc, Expressions *elements, Type *stype);
     bool isPOD();
+
+    bool isInputRange();
 
     StructDeclaration *isStructDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -313,6 +317,9 @@ public:
     Symbol *vtblsym;
 
     ClassDeclaration *isClassDeclaration() { return (ClassDeclaration *)this; }
+
+    bool isInputRange();
+
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -149,8 +149,6 @@ public:
 
     AggregateDeclaration *isAggregateDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-
-    virtual bool isInputRange() { return false; }
 };
 
 struct StructFlags
@@ -197,8 +195,6 @@ public:
     void finalizeSize();
     bool fit(Loc loc, Scope *sc, Expressions *elements, Type *stype);
     bool isPOD();
-
-    bool isInputRange();
 
     StructDeclaration *isStructDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -317,9 +313,6 @@ public:
     Symbol *vtblsym;
 
     ClassDeclaration *isClassDeclaration() { return (ClassDeclaration *)this; }
-
-    bool isInputRange();
-
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dcast.d
+++ b/src/dcast.d
@@ -97,8 +97,17 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
                     //printf("type %p ty %d deco %p\n", type, type.ty, type.deco);
                     //type = type.semantic(loc, sc);
                     //printf("type %s t %s\n", type.deco, t.deco);
-                    e.error("cannot implicitly convert expression (%s) of type %s to %s",
-                        e.toChars(), e.type.toChars(), t.toChars());
+                    immutable(char)* arrayHint = "";
+                    if (t.ty == Tarray)
+                    {
+                        auto ad = isAggregate(e.type);
+                        if (ad && ad.isInputRange())
+                        {
+                            arrayHint = ", use .array (in std.array) to force allocation of range elements";
+                        }
+                    }
+                    e.error("cannot implicitly convert expression (%s) of type %s to %s%s",
+                             e.toChars(), e.type.toChars(), t.toChars(), arrayHint);
                 }
             }
             result = new ErrorExp();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -34,9 +34,6 @@ class TypeInfoDeclaration;
 class Dsymbol;
 class TemplateInstance;
 class TemplateDeclaration;
-class TypeEnum;
-class TypeStruct;
-class TypeClass;
 enum LINK;
 
 class TypeBasic;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -34,6 +34,9 @@ class TypeInfoDeclaration;
 class Dsymbol;
 class TemplateInstance;
 class TemplateDeclaration;
+class TypeEnum;
+class TypeStruct;
+class TypeClass;
 enum LINK;
 
 class TypeBasic;
@@ -492,6 +495,8 @@ public:
     bool hasPointers() /*const*/;
 
     void accept(Visitor *v) { v->visit(this); }
+
+    TypeDArray* isTypeDArray() { return this; }
 };
 
 class TypeAArray : public TypeArray
@@ -764,6 +769,8 @@ public:
     unsigned char deduceWild(Type *t, bool isRef);
     Type *toHeadMutable();
 
+    TypeStruct* isTypeStruct() { return this; }
+
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -826,6 +833,8 @@ public:
     bool isscope() /*const*/;
     bool isBoolean() /*const*/;
     bool hasPointers() /*const*/;
+
+    virtual TypeClass* isTypeClass() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
This adds logic that hints the **new** developer on when to use `std.array.array` to force evaluation of a lazy range and write it into an array when trying to assign a range to a D array as in

``` D
    int[] x = [1, 2, 3].map!"a*2";
```

gives error:

```
cannot implicitly convert expression (map([1, 2, 3])) of type MapResult!(unaryFun, int[]) to int[], use .array (in std.array) to force allocation
```

Assignment to non-arrays such as

``` D
    int x = [1, 2, 3].map!"a*2";
```

has unchanged diagnostics.

For background discussion see

http://forum.dlang.org/thread/xyvznufauehijucwwjav@forum.dlang.org?page=1

This is in an early stage. Feedback, please!
