### PR TITLE
[cleanup] Unify checkSomething function interfaces.

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -353,7 +353,7 @@ int StaticIfCondition::include(Scope *sc, ScopeDsymbol *sds)
         sc->pop();
         --nest;
 
-        if (!e->type->checkBoolean())
+        if (!e->type->isBoolean())
         {
             if (e->type->toBasetype() != Type::terror)
                 exp->error("expression %s of type %s does not have a boolean value", exp->toChars(), e->type->toChars());

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1745,8 +1745,8 @@ void VarDeclaration::checkCtorConstInit()
 /************************************
  * Check to see if this variable is actually in an enclosing function
  * rather than the current one.
+ * Returns true if error occurs.
  */
-
 bool VarDeclaration::checkNestedReference(Scope *sc, Loc loc)
 {
     //printf("VarDeclaration::checkNestedReference() %s\n", toChars());
@@ -1785,7 +1785,7 @@ bool VarDeclaration::checkNestedReference(Scope *sc, Loc loc)
                 {
                     int lv = fdthis->getLevel(loc, sc, fdv);
                     if (lv == -2)   // error
-                        return false;
+                        return true;
                     if (lv > 0 &&
                         fdv->isPureBypassingInference() >= PUREweak &&
                         fdthis->isPureBypassingInference() == PUREfwdref &&
@@ -1847,12 +1847,12 @@ bool VarDeclaration::checkNestedReference(Scope *sc, Loc loc)
                 if (ident == Id::dollar)
                 {
                     ::error(loc, "cannnot use $ inside a function literal");
-                    return false;
+                    return true;
                 }
             }
         }
     }
-    return true;
+    return false;
 }
 
 /****************************

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -29,6 +29,11 @@
 
 Expression *getTypeInfo(Type *t, Scope *sc);
 
+/************************************
+ * Check to see the aggregate type is nested and its context pointer is
+ * accessible from the current scope.
+ * Returns true if error occurs.
+ */
 bool checkFrameAccess(Loc loc, Scope *sc, AggregateDeclaration *ad, size_t iStart = 0)
 {
     Dsymbol *sparent = ad->toParent2();
@@ -58,19 +63,18 @@ bool checkFrameAccess(Loc loc, Scope *sc, AggregateDeclaration *ad, size_t iStar
         if (s != sparent)
         {
             error(loc, "cannot access frame pointer of %s", ad->toPrettyChars());
-            return false;
+            return true;
         }
     }
 
-    bool result = true;
+    bool result = false;
     for (size_t i = iStart; i < ad->fields.dim; i++)
     {
         VarDeclaration *vd = ad->fields[i];
         Type *tb = vd->type->baseElemOf();
         if (tb->ty == Tstruct)
         {
-            bool r = checkFrameAccess(loc, sc, ((TypeStruct *)tb)->sym);
-            result = result && r;
+            result |= checkFrameAccess(loc, sc, ((TypeStruct *)tb)->sym);
         }
     }
     return result;

--- a/src/delegatize.c
+++ b/src/delegatize.c
@@ -52,7 +52,7 @@ Expression *toDelegate(Expression *e, Type* t, Scope *sc)
     bool r = lambdaCheckForNestedRef(e, sc);
     sc = sc->pop();
 
-    if (!r)
+    if (r)
         return new ErrorExp();
 
     Statement *s;
@@ -112,7 +112,7 @@ void lambdaSetParent(Expression *e, Scope *sc)
 
 /*******************************************
  * Look for references to variables in a scope enclosing the new function literal.
- * Returns false if error occurs.
+ * Returns true if error occurs.
  */
 bool lambdaCheckForNestedRef(Expression *e, Scope *sc)
 {
@@ -123,7 +123,7 @@ bool lambdaCheckForNestedRef(Expression *e, Scope *sc)
         bool result;
 
         LambdaCheckForNestedRef(Scope *sc)
-            : sc(sc), result(true)
+            : sc(sc), result(false)
         {
         }
 
@@ -158,7 +158,7 @@ bool lambdaCheckForNestedRef(Expression *e, Scope *sc)
             if (v)
             {
                 result = v->checkNestedReference(sc, Loc());
-                if (!result)
+                if (result)
                     return;
 
                 /* Some expressions cause the frontend to create a temporary.
@@ -183,4 +183,3 @@ bool lambdaCheckForNestedRef(Expression *e, Scope *sc)
     walkPostorder(e, &v);
     return v.result;
 }
-

--- a/src/enum.c
+++ b/src/enum.c
@@ -685,7 +685,7 @@ Expression *EnumMember::getVarExp(Loc loc, Scope *sc)
         vd->parent = ed->isAnonymous() ? ed->parent : ed;
         vd->userAttribDecl = ed->isAnonymous() ? ed->userAttribDecl : NULL;
     }
-    accessCheck(loc, sc, NULL, vd);
+    checkAccess(loc, sc, NULL, vd);
     Expression *e = new VarExp(loc, vd);
     return e->semantic(sc);
 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -2678,10 +2678,11 @@ bool Expression::checkReadModifyWrite(TOK rmwOp, Expression *ex)
 }
 
 /*****************************
- * Check that expression can be tested for true or false.
+ * If expression can be tested for true or false,
+ * returns the modified expression.
+ * Otherwise returns ErrorExp.
  */
-
-Expression *Expression::checkToBoolean(Scope *sc)
+Expression *Expression::toBoolean(Scope *sc)
 {
     // Default is 'yes' - do nothing
 
@@ -6971,7 +6972,7 @@ Expression *AssertExp::semantic(Scope *sc)
     e1 = resolveProperties(sc, e1);
     // BUG: see if we can do compile time elimination of the Assert
     e1 = e1->optimize(WANTvalue);
-    e1 = e1->checkToBoolean(sc);
+    e1 = e1->toBoolean(sc);
     if (msg)
     {
         msg = msg->semantic(sc);
@@ -9431,7 +9432,7 @@ Expression *NotExp::semantic(Scope *sc)
     if (Expression *ex = unaSemantic(sc))
         return ex;
     e1 = resolveProperties(sc, e1);
-    e1 = e1->checkToBoolean(sc);
+    e1 = e1->toBoolean(sc);
     if (e1->type == Type::terror)
         return e1;
 
@@ -9460,7 +9461,7 @@ Expression *BoolExp::semantic(Scope *sc)
     if (Expression *ex = unaSemantic(sc))
         return ex;
     e1 = resolveProperties(sc, e1);
-    e1 = e1->checkToBoolean(sc);
+    e1 = e1->toBoolean(sc);
     if (e1->type == Type::terror)
         return e1;
 
@@ -9576,7 +9577,7 @@ Lerr:
 }
 
 
-Expression *DeleteExp::checkToBoolean(Scope *sc)
+Expression *DeleteExp::toBoolean(Scope *sc)
 {
     error("delete does not give a boolean result");
     return new ErrorExp();
@@ -11815,7 +11816,7 @@ Expression *AssignExp::toLvalue(Scope *sc, Expression *ex)
     return this;
 }
 
-Expression *AssignExp::checkToBoolean(Scope *sc)
+Expression *AssignExp::toBoolean(Scope *sc)
 {
     // Things like:
     //  if (a = b) ...
@@ -13040,7 +13041,7 @@ Expression *OrOrExp::semantic(Scope *sc)
     // same as for AndAnd
     e1 = e1->semantic(sc);
     e1 = resolveProperties(sc, e1);
-    e1 = e1->checkToBoolean(sc);
+    e1 = e1->toBoolean(sc);
     unsigned cs1 = sc->callSuper;
 
     if (sc->flags & SCOPEcondition)
@@ -13062,7 +13063,7 @@ Expression *OrOrExp::semantic(Scope *sc)
         type = Type::tvoid;
     else
     {
-        e2 = e2->checkToBoolean(sc);
+        e2 = e2->toBoolean(sc);
         type = Type::tbool;
     }
     if (e2->op == TOKtype || e2->op == TOKimport)
@@ -13078,9 +13079,9 @@ Expression *OrOrExp::semantic(Scope *sc)
     return this;
 }
 
-Expression *OrOrExp::checkToBoolean(Scope *sc)
+Expression *OrOrExp::toBoolean(Scope *sc)
 {
-    e2 = e2->checkToBoolean(sc);
+    e2 = e2->toBoolean(sc);
     return this;
 }
 
@@ -13096,7 +13097,7 @@ Expression *AndAndExp::semantic(Scope *sc)
     // same as for OrOr
     e1 = e1->semantic(sc);
     e1 = resolveProperties(sc, e1);
-    e1 = e1->checkToBoolean(sc);
+    e1 = e1->toBoolean(sc);
     unsigned cs1 = sc->callSuper;
 
     if (sc->flags & SCOPEcondition)
@@ -13118,7 +13119,7 @@ Expression *AndAndExp::semantic(Scope *sc)
         type = Type::tvoid;
     else
     {
-        e2 = e2->checkToBoolean(sc);
+        e2 = e2->toBoolean(sc);
         type = Type::tbool;
     }
     if (e2->op == TOKtype || e2->op == TOKimport)
@@ -13134,9 +13135,9 @@ Expression *AndAndExp::semantic(Scope *sc)
     return this;
 }
 
-Expression *AndAndExp::checkToBoolean(Scope *sc)
+Expression *AndAndExp::toBoolean(Scope *sc)
 {
-    e2 = e2->checkToBoolean(sc);
+    e2 = e2->toBoolean(sc);
     return this;
 }
 
@@ -13593,7 +13594,7 @@ Expression *CondExp::semantic(Scope *sc)
 
     Expression *ec = econd->semantic(sc);
     ec = resolveProperties(sc, ec);
-    ec = ec->checkToBoolean(sc);
+    ec = ec->toBoolean(sc);
 
     unsigned cs0 = sc->callSuper;
     unsigned *fi0 = sc->saveFieldInit();
@@ -13692,10 +13693,10 @@ Expression *CondExp::modifiableLvalue(Scope *sc, Expression *e)
     return toLvalue(sc, this);
 }
 
-Expression *CondExp::checkToBoolean(Scope *sc)
+Expression *CondExp::toBoolean(Scope *sc)
 {
-    e1 = e1->checkToBoolean(sc);
-    e2 = e2->checkToBoolean(sc);
+    e1 = e1->toBoolean(sc);
+    e2 = e2->toBoolean(sc);
     return this;
 }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -4327,7 +4327,7 @@ Expression *StructLiteralExp::semantic(Scope *sc)
     if (!sd->fit(loc, sc, elements, stype))
         return new ErrorExp();
 
-    if (!checkFrameAccess(loc, sc, sd, elements->dim))
+    if (checkFrameAccess(loc, sc, sd, elements->dim))
         return new ErrorExp();
 
     /* Fill out remainder of elements[] with default initializers for fields[]

--- a/src/expression.c
+++ b/src/expression.c
@@ -47,7 +47,7 @@ bool isArrayOpValid(Expression *e);
 Expression *createTypeInfoArray(Scope *sc, Expression *args[], size_t dim);
 Expression *expandVar(int result, VarDeclaration *v);
 TypeTuple *toArgTypes(Type *t);
-void accessCheck(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember);
+bool checkAccess(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember);
 bool checkFrameAccess(Loc loc, Scope *sc, AggregateDeclaration *ad, size_t istart = 0);
 Symbol *toInitializer(AggregateDeclaration *ad);
 Expression *getTypeInfo(Type *t, Scope *sc);
@@ -2610,7 +2610,7 @@ bool Expression::checkPostblit(Scope *sc, Type *t)
             checkPurity(sc, sd->postblit);
             checkSafety(sc, sd->postblit);
             checkNogc(sc, sd->postblit);
-            //accessCheck(sd, loc, sc, sd->postblit);   // necessary?
+            //checkAccess(sd, loc, sc, sd->postblit);   // necessary?
             return false;
         }
     }
@@ -3176,7 +3176,7 @@ Expression *IdentifierExp::semantic(Scope *sc)
             {
                 Declaration *d = s->isDeclaration();
                 if (d)
-                    accessCheck(loc, sc, NULL, d);
+                    checkAccess(loc, sc, NULL, d);
             }
 
             /* If f is really a function template,
@@ -4883,7 +4883,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            accessCheck(cd, loc, sc, f);
+            checkAccess(cd, loc, sc, f);
 
             TypeFunction *tf = (TypeFunction *)f->type;
             if (!arguments)
@@ -4919,7 +4919,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            accessCheck(cd, loc, sc, f);
+            checkAccess(cd, loc, sc, f);
         #endif
 
             TypeFunction *tf = (TypeFunction *)f->type;
@@ -4968,7 +4968,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            accessCheck(sd, loc, sc, f);
+            checkAccess(sd, loc, sc, f);
         #endif
 
             TypeFunction *tf = (TypeFunction *)f->type;
@@ -4997,7 +4997,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            accessCheck(sd, loc, sc, f);
+            checkAccess(sd, loc, sc, f);
 
             TypeFunction *tf = (TypeFunction *)f->type;
             if (!arguments)
@@ -5228,7 +5228,7 @@ Expression *VarExp::semantic(Scope *sc)
      * problems when instantiating imported templates passing private
      * variables as alias template parameters.
      */
-    //accessCheck(loc, sc, NULL, var);
+    //checkAccess(loc, sc, NULL, var);
 
     if (VarDeclaration *vd = var->isVarDeclaration())
     {
@@ -7206,7 +7206,7 @@ Expression *DotIdExp::semanticY(Scope *sc, int flag)
              * aliases to private symbols are public.
              */
             if (Declaration *d = s->isDeclaration())
-                accessCheck(loc, sc, NULL, d);
+                checkAccess(loc, sc, NULL, d);
 
             s = s->toAlias();
             checkDeprecated(sc, s);
@@ -7538,7 +7538,7 @@ Expression *DotVarExp::semantic(Scope *sc)
             e = e->semantic(sc);
             return e;
         }
-        accessCheck(loc, sc, e1, var);
+        checkAccess(loc, sc, e1, var);
 
         VarDeclaration *v = var->isVarDeclaration();
         if (v && (v->isDataseg() || (v->storage_class & STCmanifest)))
@@ -7551,7 +7551,7 @@ Expression *DotVarExp::semantic(Scope *sc)
         if (v && v->isDataseg())     // fix bugzilla 8238
         {
             // (e1, v)
-            accessCheck(loc, sc, e1, v);
+            checkAccess(loc, sc, e1, v);
             Expression *e = new VarExp(loc, v);
             e = new CommaExp(loc, e1, e);
             e = e->semantic(sc);
@@ -8530,7 +8530,7 @@ Lagain:
         checkPurity(sc, f);
         checkSafety(sc, f);
         checkNogc(sc, f);
-        accessCheck(loc, sc, ue->e1, f);
+        checkAccess(loc, sc, ue->e1, f);
         if (!f->needThis())
         {
             VarExp *ve = new VarExp(loc, f);
@@ -8628,7 +8628,7 @@ Lagain:
                 checkPurity(sc, f);
                 checkSafety(sc, f);
                 checkNogc(sc, f);
-                accessCheck(loc, sc, NULL, f);
+                checkAccess(loc, sc, NULL, f);
 
                 e1 = new DotVarExp(e1->loc, e1, f);
                 e1 = e1->semantic(sc);
@@ -8669,7 +8669,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            //accessCheck(loc, sc, NULL, f);    // necessary?
+            //checkAccess(loc, sc, NULL, f);    // necessary?
 
             e1 = new DotVarExp(e1->loc, e1, f);
             e1 = e1->semantic(sc);
@@ -8924,7 +8924,7 @@ Lagain:
         checkPurity(sc, f);
         checkSafety(sc, f);
         checkNogc(sc, f);
-        accessCheck(loc, sc, NULL, f);
+        checkAccess(loc, sc, NULL, f);
         if (!f->checkNestedReference(sc, loc))
             return new ErrorExp();
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -2724,7 +2724,7 @@ Lagain:
         }
     }
 
-    if (!t->checkBoolean())
+    if (!t->isBoolean())
     {
         if (tb != Type::terror)
             error("expression %s of type %s does not have a boolean value", toChars(), t->toChars());

--- a/src/expression.c
+++ b/src/expression.c
@@ -3532,7 +3532,7 @@ Expression *ThisExp::semantic(Scope *sc)
     var = fd->vthis;
     assert(var->parent);
     type = var->type;
-    if (!var->isVarDeclaration()->checkNestedReference(sc, loc))
+    if (var->isVarDeclaration()->checkNestedReference(sc, loc))
         return new ErrorExp();
     if (!sc->intypeof)
         sc->callSuper |= CSXthis;
@@ -3638,7 +3638,7 @@ Expression *SuperExp::semantic(Scope *sc)
         type = type->castMod(var->type->mod);
     }
 
-    if (!var->isVarDeclaration()->checkNestedReference(sc, loc))
+    if (var->isVarDeclaration()->checkNestedReference(sc, loc))
         return new ErrorExp();
 
     if (!sc->intypeof)
@@ -5164,7 +5164,7 @@ Expression *SymOffExp::semantic(Scope *sc)
         type = var->type->pointerTo();
     if (VarDeclaration *v = var->isVarDeclaration())
     {
-        if (!v->checkNestedReference(sc, loc))
+        if (v->checkNestedReference(sc, loc))
             return new ErrorExp();
     }
     else if (FuncDeclaration *f = var->isFuncDeclaration())
@@ -5238,7 +5238,7 @@ Expression *VarExp::semantic(Scope *sc)
     if (VarDeclaration *vd = var->isVarDeclaration())
     {
         hasOverloads = 0;
-        if (!vd->checkNestedReference(sc, loc))
+        if (vd->checkNestedReference(sc, loc))
             return new ErrorExp();
         // Bugzilla 12025: If the variable is not actually used in runtime code,
         // the purity violation error is redundant.

--- a/src/expression.c
+++ b/src/expression.c
@@ -532,14 +532,14 @@ Expression *resolveProperties(Scope *sc, Expression *e)
 /******************************
  * Check the tail CallExp is really property function call.
  */
-
-void checkPropertyCall(Expression *e, Expression *emsg)
+bool checkPropertyCall(Expression *e, Expression *emsg)
 {
     while (e->op == TOKcomma)
         e = ((CommaExp *)e)->e2;
 
     if (e->op == TOKcall)
-    {   CallExp *ce = (CallExp *)e;
+    {
+        CallExp *ce = (CallExp *)e;
         TypeFunction *tf;
         if (ce->f)
         {
@@ -547,7 +547,8 @@ void checkPropertyCall(Expression *e, Expression *emsg)
             /* If a forward reference to ce->f, try to resolve it
              */
             if (!tf->deco && ce->f->scope)
-            {   ce->f->semantic(ce->f->scope);
+            {
+                ce->f->semantic(ce->f->scope);
                 tf = (TypeFunction *)ce->f->type;
             }
         }
@@ -561,8 +562,12 @@ void checkPropertyCall(Expression *e, Expression *emsg)
             assert(0);
 
         if (!tf->isproperty && global.params.enforcePropertySyntax)
+        {
             ce->e1->error("not a property %s", emsg->toChars());
+            return true;
+        }
     }
+    return false;
 }
 
 /******************************

--- a/src/expression.c
+++ b/src/expression.c
@@ -5169,7 +5169,7 @@ Expression *SymOffExp::semantic(Scope *sc)
     }
     else if (FuncDeclaration *f = var->isFuncDeclaration())
     {
-        if (!f->checkNestedReference(sc, loc))
+        if (f->checkNestedReference(sc, loc))
             return new ErrorExp();
     }
     return this;
@@ -5246,7 +5246,7 @@ Expression *VarExp::semantic(Scope *sc)
     }
     else if (FuncDeclaration *fd = var->isFuncDeclaration())
     {
-        if (!fd->checkNestedReference(sc, loc))
+        if (fd->checkNestedReference(sc, loc))
             return new ErrorExp();
     }
     else if (OverDeclaration *od = var->isOverDeclaration())
@@ -8841,7 +8841,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            if (!f->checkNestedReference(sc, loc))
+            if (f->checkNestedReference(sc, loc))
                 return new ErrorExp();
         }
         else if (sc->func && sc->intypeof != 1 && !(sc->flags & SCOPEctfe))
@@ -8930,7 +8930,7 @@ Lagain:
         checkSafety(sc, f);
         checkNogc(sc, f);
         checkAccess(loc, sc, NULL, f);
-        if (!f->checkNestedReference(sc, loc))
+        if (f->checkNestedReference(sc, loc))
             return new ErrorExp();
 
         ethis = NULL;

--- a/src/expression.c
+++ b/src/expression.c
@@ -1119,7 +1119,7 @@ bool arrayExpressionToCommonType(Scope *sc, Expressions *exps, Type **pt)
         }
         if (e->op == TOKtype)
         {
-            e->checkValue();
+            e->checkValue();    // report an error "type T has no value"
             t0 = Type::terror;
             continue;
         }

--- a/src/expression.h
+++ b/src/expression.h
@@ -173,10 +173,10 @@ public:
     bool checkIntegral();
     bool checkArithmetic();
     void checkDeprecated(Scope *sc, Dsymbol *s);
-    void checkPurity(Scope *sc, FuncDeclaration *f);
-    void checkPurity(Scope *sc, VarDeclaration *v);
-    void checkSafety(Scope *sc, FuncDeclaration *f);
-    void checkNogc(Scope *sc, FuncDeclaration *f);
+    bool checkPurity(Scope *sc, FuncDeclaration *f);
+    bool checkPurity(Scope *sc, VarDeclaration *v);
+    bool checkSafety(Scope *sc, FuncDeclaration *f);
+    bool checkNogc(Scope *sc, FuncDeclaration *f);
     bool checkPostblit(Scope *sc, Type *t);
     bool checkRightThis(Scope *sc);
     bool checkReadModifyWrite(TOK rmwOp, Expression *ex = NULL);

--- a/src/expression.h
+++ b/src/expression.h
@@ -181,7 +181,7 @@ public:
     bool checkRightThis(Scope *sc);
     bool checkReadModifyWrite(TOK rmwOp, Expression *ex = NULL);
     virtual int checkModifiable(Scope *sc, int flag = 0);
-    virtual Expression *checkToBoolean(Scope *sc);
+    virtual Expression *toBoolean(Scope *sc);
     virtual Expression *addDtorHook(Scope *sc);
     Expression *addressOf();
     Expression *deref();
@@ -972,7 +972,7 @@ class DeleteExp : public UnaExp
 public:
     DeleteExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
-    Expression *checkToBoolean(Scope *sc);
+    Expression *toBoolean(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1157,7 +1157,7 @@ public:
     Expression *semantic(Scope *sc);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *ex);
-    Expression *checkToBoolean(Scope *sc);
+    Expression *toBoolean(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -1391,7 +1391,7 @@ class OrOrExp : public BinExp
 public:
     OrOrExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
-    Expression *checkToBoolean(Scope *sc);
+    Expression *toBoolean(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1400,7 +1400,7 @@ class AndAndExp : public BinExp
 public:
     AndAndExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);
-    Expression *checkToBoolean(Scope *sc);
+    Expression *toBoolean(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1465,7 +1465,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    Expression *checkToBoolean(Scope *sc);
+    Expression *toBoolean(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/expression.h
+++ b/src/expression.h
@@ -53,7 +53,7 @@ void initPrecedence();
 
 Expression *resolveProperties(Scope *sc, Expression *e);
 Expression *resolvePropertiesOnly(Scope *sc, Expression *e1);
-void accessCheck(Loc loc, Scope *sc, Expression *e, Declaration *d);
+bool checkAccess(Loc loc, Scope *sc, Expression *e, Declaration *d);
 Expression *build_overload(Loc loc, Scope *sc, Expression *ethis, Expression *earg, Dsymbol *d);
 Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid);
 void expandTuples(Expressions *exps);

--- a/src/expression.h
+++ b/src/expression.h
@@ -137,7 +137,6 @@ public:
     void error(const char *format, ...);
     void warning(const char *format, ...);
     void deprecation(const char *format, ...);
-    virtual bool rvalue();
 
     // creates a single expression which is effectively (e1, e2)
     // this new expression does not necessarily need to have valid D source code representation,
@@ -168,6 +167,7 @@ public:
         return ::castTo(this, sc, t);
     }
     virtual Expression *resolveLoc(Loc loc, Scope *sc);
+    virtual bool checkValue();
     void checkScalar();
     void checkNoBool();
     Expression *checkIntegral();
@@ -495,7 +495,7 @@ public:
     TypeExp(Loc loc, Type *type);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
-    bool rvalue();
+    bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -517,9 +517,9 @@ public:
     FuncDeclaration *fd;
 
     TemplateExp(Loc loc, TemplateDeclaration *td, FuncDeclaration *fd = NULL);
-    bool rvalue();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
+    bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -630,13 +630,13 @@ public:
     TOK tok;
 
     FuncExp(Loc loc, FuncLiteralDeclaration *fd, TemplateDeclaration *td = NULL);
-    bool rvalue();
     void genIdent(Scope *sc);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     Expression *semantic(Scope *sc, Expressions *arguments);
     MATCH matchType(Type *to, Scope *sc, FuncExp **pfe, int flag = 0);
     char *toChars();
+    bool checkValue();
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/expression.h
+++ b/src/expression.h
@@ -168,10 +168,10 @@ public:
     }
     virtual Expression *resolveLoc(Loc loc, Scope *sc);
     virtual bool checkValue();
-    void checkScalar();
-    void checkNoBool();
-    Expression *checkIntegral();
-    Expression *checkArithmetic();
+    bool checkScalar();
+    bool checkNoBool();
+    bool checkIntegral();
+    bool checkArithmetic();
     Expression *checkReadModifyWrite(TOK rmwOp, Expression *exp = NULL);
     void checkDeprecated(Scope *sc, Dsymbol *s);
     void checkPurity(Scope *sc, FuncDeclaration *f);
@@ -746,6 +746,8 @@ public:
     Expression *binSemanticProp(Scope *sc);
     Expression *checkComplexOpAssign(Scope *sc);
     Expression *incompatibleTypes();
+    bool checkIntegral();
+    bool checkArithmetic();
 
     Expression *reorderSettingAAElem(Scope *sc);
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -178,6 +178,7 @@ public:
     void checkSafety(Scope *sc, FuncDeclaration *f);
     void checkNogc(Scope *sc, FuncDeclaration *f);
     bool checkPostblit(Scope *sc, Type *t);
+    bool checkRightThis(Scope *sc);
     bool checkReadModifyWrite(TOK rmwOp, Expression *ex = NULL);
     virtual int checkModifiable(Scope *sc, int flag = 0);
     virtual Expression *checkToBoolean(Scope *sc);

--- a/src/expression.h
+++ b/src/expression.h
@@ -172,13 +172,13 @@ public:
     bool checkNoBool();
     bool checkIntegral();
     bool checkArithmetic();
-    Expression *checkReadModifyWrite(TOK rmwOp, Expression *exp = NULL);
     void checkDeprecated(Scope *sc, Dsymbol *s);
     void checkPurity(Scope *sc, FuncDeclaration *f);
     void checkPurity(Scope *sc, VarDeclaration *v);
     void checkSafety(Scope *sc, FuncDeclaration *f);
     void checkNogc(Scope *sc, FuncDeclaration *f);
     bool checkPostblit(Scope *sc, Type *t);
+    bool checkReadModifyWrite(TOK rmwOp, Expression *ex = NULL);
     virtual int checkModifiable(Scope *sc, int flag = 0);
     virtual Expression *checkToBoolean(Scope *sc);
     virtual Expression *addDtorHook(Scope *sc);

--- a/src/func.c
+++ b/src/func.c
@@ -4116,8 +4116,8 @@ const char *FuncDeclaration::kind()
  *    the current function to the list of siblings of 'this' function.
  * 3. If the current function is a literal, and it's accessing an uplevel scope,
  *    then mark it as a delegate.
+ * Returns true if error occurs.
  */
-
 bool FuncDeclaration::checkNestedReference(Scope *sc, Loc loc)
 {
     //printf("FuncDeclaration::checkNestedReference() %s\n", toPrettyChars());
@@ -4159,11 +4159,11 @@ bool FuncDeclaration::checkNestedReference(Scope *sc, Loc loc)
         {
             int lv = fdthis->getLevel(loc, sc, fdv);
             if (lv == -2)
-                return false;   // error
+                return true;    // error
             if (lv == -1)
-                return true;    // downlevel call
+                return false;   // downlevel call
             if (lv == 0)
-                return true;    // same level call
+                return false;   // same level call
 
             // Uplevel call
 
@@ -4174,7 +4174,7 @@ bool FuncDeclaration::checkNestedReference(Scope *sc, Loc loc)
                 fld->tok = TOKdelegate;
         }
     }
-    return true;
+    return false;
 }
 
 /* For all functions between outerFunc and f, mark them as needing

--- a/src/func.c
+++ b/src/func.c
@@ -464,7 +464,7 @@ void FuncDeclaration::semantic(Scope *sc)
              *
              *    static auto boo() {}   // typed as impure
              *    // Even though, boo cannot call any impure functions.
-             *    // See also Expression;;checkPurity().
+             *    // See also Expression::checkPurity().
              *  }
              */
             if (tf->purity == PUREimpure && (isNested() || isThis()))

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -1762,7 +1762,10 @@ bool Type::isAssignable()
     return true;
 }
 
-bool Type::checkBoolean()
+/**************************
+ * Returns true if T can be converted to boolean value.
+ */
+bool Type::isBoolean()
 {
     return isscalar();
 }
@@ -3512,7 +3515,7 @@ TypeBasic *TypeVector::elementType()
     return tb;
 }
 
-bool TypeVector::checkBoolean()
+bool TypeVector::isBoolean()
 {
     return false;
 }
@@ -4453,7 +4456,7 @@ bool TypeDArray::isZeroInit(Loc loc)
     return true;
 }
 
-bool TypeDArray::checkBoolean()
+bool TypeDArray::isBoolean()
 {
     return true;
 }
@@ -4765,7 +4768,7 @@ bool TypeAArray::isZeroInit(Loc loc)
     return true;
 }
 
-bool TypeAArray::checkBoolean()
+bool TypeAArray::isBoolean()
 {
     return true;
 }
@@ -6254,7 +6257,7 @@ bool TypeDelegate::isZeroInit(Loc loc)
     return true;
 }
 
-bool TypeDelegate::checkBoolean()
+bool TypeDelegate::isBoolean()
 {
     return true;
 }
@@ -7283,9 +7286,9 @@ bool TypeEnum::isAssignable()
     return sym->getMemtype(Loc())->isAssignable();
 }
 
-bool TypeEnum::checkBoolean()
+bool TypeEnum::isBoolean()
 {
-    return sym->getMemtype(Loc())->checkBoolean();
+    return sym->getMemtype(Loc())->isBoolean();
 }
 
 bool TypeEnum::needsDestruction()
@@ -7730,7 +7733,7 @@ bool TypeStruct::isZeroInit(Loc loc)
     return sym->zeroInit != 0;
 }
 
-bool TypeStruct::checkBoolean()
+bool TypeStruct::isBoolean()
 {
     return false;
 }
@@ -8459,7 +8462,7 @@ bool TypeClass::isZeroInit(Loc loc)
     return true;
 }
 
-bool TypeClass::checkBoolean()
+bool TypeClass::isBoolean()
 {
     return true;
 }
@@ -8826,7 +8829,7 @@ MATCH TypeNull::implicitConvTo(Type *to)
     return MATCHnomatch;
 }
 
-bool TypeNull::checkBoolean()
+bool TypeNull::isBoolean()
 {
     return true;
 }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7510,7 +7510,7 @@ L1:
     }
     if (v && !v->isDataseg() && (v->storage_class & STCmanifest))
     {
-        accessCheck(e->loc, sc, NULL, v);
+        checkAccess(e->loc, sc, NULL, v);
         Expression *ve = new VarExp(e->loc, v);
         ve = ve->semantic(sc);
         return ve;
@@ -7613,7 +7613,7 @@ L1:
         }
         if (d->semanticRun == PASSinit && d->scope)
             d->semantic(d->scope);
-        accessCheck(e->loc, sc, e, d);
+        checkAccess(e->loc, sc, e, d);
         VarExp *ve = new VarExp(e->loc, d, 1);
         if (d->isVarDeclaration() && d->needThis())
             ve->type = d->type->addMod(e->type->mod);
@@ -7624,7 +7624,7 @@ L1:
     if (d->isDataseg() || unreal && d->isField())
     {
         // (e, d)
-        accessCheck(e->loc, sc, e, d);
+        checkAccess(e->loc, sc, e, d);
         Expression *ve = new VarExp(e->loc, d);
         e = unreal ? ve : new CommaExp(e->loc, e, ve);
         e = e->semantic(sc);
@@ -7638,7 +7638,7 @@ L1:
 
 #if 0
         // *(&e + offset)
-        accessCheck(e->loc, sc, e, d);
+        checkAccess(e->loc, sc, e, d);
         Expression *b = new AddrExp(e->loc, e);
         b->type = e->type->pointerTo();
         b = new AddExp(e->loc, b, new IntegerExp(e->loc, v->offset, Type::tint32));
@@ -8153,7 +8153,7 @@ L1:
     }
     if (v && !v->isDataseg() && (v->storage_class & STCmanifest))
     {
-        accessCheck(e->loc, sc, NULL, v);
+        checkAccess(e->loc, sc, NULL, v);
         Expression *ve = new VarExp(e->loc, v);
         ve = ve->semantic(sc);
         return ve;
@@ -8314,7 +8314,7 @@ L1:
         //printf("e = %s, d = %s\n", e->toChars(), d->toChars());
         if (d->semanticRun == PASSinit && d->scope)
             d->semantic(d->scope);
-        accessCheck(e->loc, sc, e, d);
+        checkAccess(e->loc, sc, e, d);
         VarExp *ve = new VarExp(e->loc, d, 1);
         if (d->isVarDeclaration() && d->needThis())
             ve->type = d->type->addMod(e->type->mod);
@@ -8325,7 +8325,7 @@ L1:
     if (d->isDataseg() || unreal && d->isField())
     {
         // (e, d)
-        accessCheck(e->loc, sc, e, d);
+        checkAccess(e->loc, sc, e, d);
         Expression *ve = new VarExp(e->loc, d);
         e = unreal ? ve : new CommaExp(e->loc, e, ve);
         e = e->semantic(sc);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -268,7 +268,7 @@ public:
     virtual bool isscope();
     virtual bool isString();
     virtual bool isAssignable();
-    virtual bool checkBoolean(); // if can be converted to boolean value
+    virtual bool isBoolean();
     virtual void checkDeprecated(Loc loc, Scope *sc);
     bool isConst()       { return (mod & MODconst) != 0; }
     bool isImmutable()   { return (mod & MODimmutable) != 0; }
@@ -433,7 +433,7 @@ public:
     bool isfloating();
     bool isscalar();
     bool isunsigned();
-    bool checkBoolean();
+    bool isBoolean();
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
@@ -494,7 +494,7 @@ public:
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool isString();
     bool isZeroInit(Loc loc);
-    bool checkBoolean();
+    bool isBoolean();
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
     bool hasPointers();
@@ -519,7 +519,7 @@ public:
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     bool isZeroInit(Loc loc);
-    bool checkBoolean();
+    bool isBoolean();
     Expression *toExpression();
     bool hasPointers();
     MATCH implicitConvTo(Type *to);
@@ -652,7 +652,7 @@ public:
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
     bool isZeroInit(Loc loc);
-    bool checkBoolean();
+    bool isBoolean();
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool hasPointers();
 
@@ -769,7 +769,7 @@ public:
     Expression *defaultInitLiteral(Loc loc);
     bool isZeroInit(Loc loc);
     bool isAssignable();
-    bool checkBoolean();
+    bool isBoolean();
     bool needsDestruction();
     bool needsNested();
     bool hasPointers();
@@ -802,7 +802,7 @@ public:
     bool iscomplex();
     bool isscalar();
     bool isunsigned();
-    bool checkBoolean();
+    bool isBoolean();
     bool isString();
     bool isAssignable();
     bool needsDestruction();
@@ -840,7 +840,7 @@ public:
     Expression *defaultInit(Loc loc);
     bool isZeroInit(Loc loc);
     bool isscope();
-    bool checkBoolean();
+    bool isBoolean();
     bool hasPointers();
 
     void accept(Visitor *v) { v->visit(this); }
@@ -888,7 +888,7 @@ public:
 
     Type *syntaxCopy();
     MATCH implicitConvTo(Type *to);
-    bool checkBoolean();
+    bool isBoolean();
 
     d_uns64 size(Loc loc);
     Expression *defaultInit(Loc loc);

--- a/src/statement.c
+++ b/src/statement.c
@@ -3940,7 +3940,7 @@ Statement *ReturnStatement::semantic(Scope *sc)
         {
             fd->buildResultVar(NULL, exp->type);
             bool r = fd->vresult->checkNestedReference(sc, Loc());
-            assert(r);  // vresult should be always accessible
+            assert(!r);  // vresult should be always accessible
 
             // Send out "case receiver" statement to the foreach.
             //  return vresult;

--- a/src/statement.c
+++ b/src/statement.c
@@ -3731,7 +3731,8 @@ Statement *ReturnStatement::semantic(Scope *sc)
         if (exp->type && exp->type->ty != Tvoid ||
             exp->op == TOKfunction || exp->op == TOKtype || exp->op == TOKtemplate)
         {
-            if (!exp->rvalue()) // don't make error for void expression
+            // don't make error for void expression
+            if (exp->checkValue())
                 exp = new ErrorExp();
         }
         if (checkNonAssignmentArrayOp(exp))

--- a/src/statement.c
+++ b/src/statement.c
@@ -1416,7 +1416,7 @@ Statement *DoStatement::semantic(Scope *sc)
     condition = condition->optimize(WANTvalue);
     condition = checkGC(sc, condition);
 
-    condition = condition->checkToBoolean(sc);
+    condition = condition->toBoolean(sc);
 
     if (condition->op == TOKerror)
         return new ErrorStatement();
@@ -1506,7 +1506,7 @@ Statement *ForStatement::semantic(Scope *sc)
         condition = resolveProperties(sc, condition);
         condition = condition->optimize(WANTvalue);
         condition = checkGC(sc, condition);
-        condition = condition->checkToBoolean(sc);
+        condition = condition->toBoolean(sc);
     }
     if (increment)
     {
@@ -2855,7 +2855,7 @@ Statement *IfStatement::semantic(Scope *sc)
     // Convert to boolean after declaring prm so this works:
     //  if (S prm = S()) {}
     // where S is a struct that defines opCast!bool.
-    condition = condition->checkToBoolean(sc);
+    condition = condition->toBoolean(sc);
 
     // If we can short-circuit evaluate the if statement, don't do the
     // semantic analysis of the skipped code.

--- a/src/statement.c
+++ b/src/statement.c
@@ -1842,7 +1842,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
         case Tarray:
         case Tsarray:
         {
-            if (!checkForArgTypes())
+            if (checkForArgTypes())
                 return this;
 
             if (dim < 1 || dim > 2)
@@ -2047,7 +2047,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
         case Taarray:
             if (op == TOKforeach_reverse)
                 warning("cannot use foreach_reverse with an associative array");
-            if (!checkForArgTypes())
+            if (checkForArgTypes())
                 return this;
 
             taa = (TypeAArray *)tab;
@@ -2218,7 +2218,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
             Expression *ec;
             Expression *e;
 
-            if (!checkForArgTypes())
+            if (checkForArgTypes())
             {
                 body = body->semanticNoScope(sc);
                 return this;
@@ -2542,7 +2542,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
 
 bool ForeachStatement::checkForArgTypes()
 {
-    bool result = true;
+    bool result = false;
 
     for (size_t i = 0; i < parameters->dim; i++)
     {
@@ -2551,7 +2551,7 @@ bool ForeachStatement::checkForArgTypes()
         {
             error("cannot infer type for %s", p->ident->toChars());
             p->type = Type::terror;
-            result = false;
+            result = true;
         }
     }
     return result;

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -65,7 +65,7 @@ void StaticAssert::semantic2(Scope *sc)
     // Simplify expression, to make error messages nicer if CTFE fails
     e = e->optimize(WANTvalue);
 
-    if (!e->type->checkBoolean())
+    if (!e->type->isBoolean())
     {
         if (e->type->toBasetype() != Type::terror)
             exp->error("expression %s of type %s does not have a boolean value", exp->toChars(), e->type->toChars());

--- a/src/template.c
+++ b/src/template.c
@@ -6517,8 +6517,9 @@ bool TemplateInstance::semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int f
             }
             else if (definitelyValueParameter(ea))
             {
+                if (ea->checkValue())   // check void expression
+                    ea = new ErrorExp();
                 unsigned int olderrs = global.errors;
-                ea->rvalue();   // check void expression
                 ea = ea->ctfeInterpret();
                 if (global.errors != olderrs)
                     ea = new ErrorExp();

--- a/test/fail_compilation/diag13320.d
+++ b/test/fail_compilation/diag13320.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag13320.d(13): Error: 'f += 1' is not a scalar, it is a Foo
+---
+*/
+
+struct Foo {}
+
+void main()
+{
+    Foo f;
+    ++f;
+}

--- a/test/fail_compilation/fail3672.d
+++ b/test/fail_compilation/fail3672.d
@@ -4,9 +4,9 @@ TEST_OUTPUT:
 fail_compilation/fail3672.d(28): Deprecation: read-modify-write operations are not allowed for shared variables. Use core.atomic.atomicOp!"+="(*p, 1) instead.
 fail_compilation/fail3672.d(32): Deprecation: read-modify-write operations are not allowed for shared variables. Use core.atomic.atomicOp!"+="(*sfp, 1) instead.
 fail_compilation/fail3672.d(32): Error: '*sfp += 1' is not a scalar, it is a shared(SF)
-fail_compilation/fail3672.d(32): Error: incompatible types for ((*sfp) += (1)): 'shared(SF)' and 'int'
 ---
 */
+
 struct SF  // should fail
 {
     void opOpAssign(string op, T)(T rhs)


### PR DESCRIPTION
When an error occurs in `bool checkSomething()` function, not they consistently return `true` for error propagation.
