### PR TITLE
Issue 2644 & 2500 & 10920 - Unresolved template reference

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -815,23 +815,18 @@ void Dsymbol::addComment(const utf8_t *comment)
 }
 
 /****************************************
- * Returns true if this symbol is defined in non-root module.
+ * Returns true if this symbol is defined in a non-root module without instantiation.
  */
-
 bool Dsymbol::inNonRoot()
 {
     Dsymbol *s = parent;
-    for (; s; s = s->parent)
+    for (; s; s = s->toParent())
     {
         if (TemplateInstance *ti = s->isTemplateInstance())
         {
-            if (ti->isTemplateMixin())
-                continue;
-            if (!ti->minst || !ti->minst->isRoot())
-                return true;
             return false;
         }
-        else if (Module *m = s->isModule())
+        if (Module *m = s->isModule())
         {
             if (!m->isRoot())
                 return true;

--- a/src/func.c
+++ b/src/func.c
@@ -4974,7 +4974,7 @@ void UnitTestDeclaration::semantic(Scope *sc)
         scope = NULL;
     }
 
-    if (!isInstantiated() && inNonRoot())
+    if (inNonRoot())
         return;
 
     if (global.params.useUnitTests)

--- a/src/glue.c
+++ b/src/glue.c
@@ -807,7 +807,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
 
     for (FuncDeclaration *fd2 = fd; fd2; )
     {
-        if (!fd2->isInstantiated() && fd2->inNonRoot())
+        if (fd2->inNonRoot())
             return;
         if (fd2->isNested())
             fd2 = fd2->toParent2()->isFuncDeclaration();

--- a/src/glue.c
+++ b/src/glue.c
@@ -751,7 +751,7 @@ bool isDruntimeArrayOp(Identifier *ident)
 void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
 {
     ClassDeclaration *cd = fd->parent->isClassDeclaration();
-    //printf("FuncDeclaration::toObjFile(%p, %s.%s)\n", this, parent->toChars(), toChars());
+    //printf("FuncDeclaration::toObjFile(%p, %s.%s)\n", fd, fd->parent->toChars(), fd->toChars());
 
     //if (type) printf("type = %s\n", type->toChars());
 #if 0

--- a/src/template.c
+++ b/src/template.c
@@ -5692,7 +5692,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     minst = sc->minst;
     // Bugzilla 10920: If the enclosing function is non-root symbol,
     // this instance should be speculative.
-    if (!tinst && sc->func && !sc->func->isInstantiated() && sc->func->inNonRoot())
+    if (!tinst && sc->func && sc->func->inNonRoot())
     {
         minst = NULL;
     }
@@ -7649,7 +7649,7 @@ bool TemplateInstance::needsCodegen()
     {
         //printf("%s minst = %s, enclosing in nonRoot = %d\n",
         //    toPrettyChars(), minst ? minst->toChars() : NULL,
-        //    enclosing && !enclosing->isInstantiated() && enclosing->inNonRoot());
+        //    enclosing && enclosing->inNonRoot());
         if (enclosing)
         {
             // Bugzilla 13415: If and only if the enclosing scope needs codegen,

--- a/src/template.c
+++ b/src/template.c
@@ -5815,13 +5815,17 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     Dsymbols *target_symbol_list;
     size_t target_symbol_list_idx = 0;
     //if (sc->scopesym) printf("3: sc is %s %s\n", sc->scopesym->kind(), sc->scopesym->toChars());
-    if (!tinst && sc->scopesym && sc->scopesym->members)
+    if (0 && !tinst && sc->scopesym && sc->scopesym->members)
     {
         /* A module can have explicit template instance and its alias
          * in module scope (e,g, `alias Base64Impl!('+', '/') Base64;`).
-         * When the module is just imported, compiler can assume that
+         * When the module is just imported, normally compiler can assume that
          * its instantiated code would be contained in the separately compiled
-         * obj/lib file (e.g. phobos.lib). So we can omit their semantic3 running.
+         * obj/lib file (e.g. phobos.lib).
+         * Bugzilla 2644: However, if the template is instantiated in both
+         * modules of root and non-root, compiler should generate its objcode.
+         * Therefore, always conservatively insert this instance to the member of
+         * a root module, then calculate the necessity by TemplateInstance::needsCodegen().
          */
         //if (sc->scopesym->isModule())
         //    printf("module level instance %s\n", toChars());

--- a/src/template.c
+++ b/src/template.c
@@ -5690,6 +5690,12 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
 
     // Get the instantiating module from the scope minst
     minst = sc->minst;
+    // Bugzilla 10920: If the enclosing function is non-root symbol,
+    // this instance should be speculative.
+    if (!tinst && sc->func && !sc->func->isInstantiated() && sc->func->inNonRoot())
+    {
+        minst = NULL;
+    }
 
     gagged = (global.gag > 0);
 

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1097,30 +1097,30 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             visit((AttribDeclaration *)pd);
         }
 
-        void visit(TemplateInstance *td)
+        void visit(TemplateInstance *ti)
         {
         #if LOG
-            printf("TemplateInstance::toObjFile('%s', this = %p)\n", td->toChars(), td);
+            printf("TemplateInstance::toObjFile('%s', this = %p)\n", ti->toChars(), ti);
         #endif
-            if (!isError(td) && td->members)
+            if (!isError(ti) && ti->members)
             {
-                if (!td->needsCodegen())
+                if (!ti->needsCodegen())
                 {
-                    //printf("-speculative (%p, %s)\n", this, toPrettyChars());
+                    //printf("-speculative (%p, %s)\n", ti, ti->toPrettyChars());
                     return;
                 }
-                //printf("TemplateInstance::toObjFile('%s', this = %p)\n", toChars(), this);
+                //printf("TemplateInstance::toObjFile('%s', this = %p)\n", ti->toChars(), this);
 
                 if (multiobj)
                 {
                     // Append to list of object files to be written later
-                    obj_append(td);
+                    obj_append(ti);
                 }
                 else
                 {
-                    for (size_t i = 0; i < td->members->dim; i++)
+                    for (size_t i = 0; i < ti->members->dim; i++)
                     {
-                        Dsymbol *s = (*td->members)[i];
+                        Dsymbol *s = (*ti->members)[i];
                         s->accept(this);
                     }
                 }

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -138,7 +138,7 @@ void genTypeInfo(Type *torig, Scope *sc)
             // Generate COMDAT
             if (sc)                     // if in semantic() pass
             {
-                if (sc->func && !sc->func->isInstantiated() && sc->func->inNonRoot())
+                if (sc->func && sc->func->inNonRoot())
                 {
                     // Bugzilla 13043: Avoid linking TypeInfo if it's not
                     // necessary for root module compilation

--- a/test/runnable/imports/link10920a.d
+++ b/test/runnable/imports/link10920a.d
@@ -1,0 +1,19 @@
+module imports.link10920a;
+
+struct FormatSpec(C)
+{
+    void func() {}
+}
+
+struct BitArray
+{
+    auto toString()
+    {
+        // An auto function may runs semantic3 to calculate return type,
+        // even if it's non-root symbol.
+        // But inside the function body, all instantiations should be treated
+        // as speculative.
+        FormatSpec!char fs;
+        fs.func();
+    }
+}

--- a/test/runnable/imports/link2500a.d
+++ b/test/runnable/imports/link2500a.d
@@ -1,0 +1,9 @@
+module imports.link2500a;
+
+import link2500;
+import imports.link2500b;
+
+class B
+{
+    S!A t;
+}

--- a/test/runnable/imports/link2500b.d
+++ b/test/runnable/imports/link2500b.d
@@ -1,0 +1,6 @@
+module imports.link2500b;
+
+struct S(T)
+{
+    void foo() {}
+}

--- a/test/runnable/imports/link2644a.d
+++ b/test/runnable/imports/link2644a.d
@@ -1,0 +1,9 @@
+module imports.link2644a;
+
+import imports.link2644c;
+import imports.link2644b;
+
+version(X)
+    struct X { alias C!(bool) CA; }
+else
+    alias C!(bool) CA;

--- a/test/runnable/imports/link2644b.d
+++ b/test/runnable/imports/link2644b.d
@@ -1,0 +1,9 @@
+module imports.link2644b;
+
+import imports.link2644c;
+import imports.link2644a;
+
+version(X)
+    struct X { alias C!(bool) CB; }
+else
+    alias C!(bool) CB;

--- a/test/runnable/imports/link2644c.d
+++ b/test/runnable/imports/link2644c.d
@@ -1,0 +1,5 @@
+module imports.link2644c;
+
+class C(T)
+{
+}

--- a/test/runnable/link10920.d
+++ b/test/runnable/link10920.d
@@ -1,0 +1,19 @@
+// PERMUTE_ARGS: -version=A
+
+// It's imported but won't be linked.
+import imports.link10920a;
+
+void main()
+{
+    BitArray ba;
+    version(A)
+    {
+        // Run semantic3 of BitArray.toString()
+        // before the FormatSpec instantiation in main().
+        pragma(msg, typeof(ba.toString()));
+    }
+
+    // The instance codegen should be run always, unrelated with -version=A.
+    FormatSpec!char fs;
+    fs.func();
+}

--- a/test/runnable/link2500.d
+++ b/test/runnable/link2500.d
@@ -1,0 +1,19 @@
+// EXTRA_SOURCES: imports/link2500a.d
+// EXTRA_SOURCES: imports/link2500b.d
+// COMPILE_SEPARATELY:
+
+module link2500;
+
+import imports.link2500a;
+import imports.link2500b;
+
+public class A
+{
+    S!A c;
+}
+
+void main()
+{
+    A a = new A();
+    a.c.foo();
+}

--- a/test/runnable/link2644.d
+++ b/test/runnable/link2644.d
@@ -1,0 +1,16 @@
+// PERMUTE_ARGS: -version=X -inline -release -g -O
+// EXTRA_SOURCES: imports/link2644a.d
+// EXTRA_SOURCES: imports/link2644b.d
+// EXTRA_SOURCES: imports/link2644c.d
+// COMPILE_SEPARATELY:
+
+module link2644;
+import imports.link2644a;
+
+void main()
+{
+  version(X)
+    auto c = new X.CA();
+  else
+    auto c = new CA();
+}


### PR DESCRIPTION
[Issue 2644](https://issues.dlang.org/show_bug.cgi?id=2644) - Unresolved template reference
[Issue 2500](https://issues.dlang.org/show_bug.cgi?id=2500) - template struct methods are left unresolved if imported from multiple modules
[Issue 10920](https://issues.dlang.org/show_bug.cgi?id=10920) - template instantiation order dependent link failure problem

They're the remained issues in instantiated template codegen.
