### PR TITLE
[REG2.067a] Issue 13952 - change in struct ctor lowering triggers codegen bug

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -5054,7 +5054,6 @@ elem *toElem(Expression *e, IRState *irs)
          * tries to use aligned int stores whereever possible.
          * Update *poffset to end of initialized hole; *poffset will be >= offset2.
          */
-
         static elem *fillHole(Symbol *stmp, size_t *poffset, size_t offset2, size_t maxoff)
         {
             elem *e = NULL;
@@ -5131,16 +5130,16 @@ elem *toElem(Expression *e, IRState *irs)
                 /* Initialize all alignment 'holes' to zero.
                  * Do before initializing fields, as the hole filling process
                  * can spill over into the fields.
+                 *
+                 * TODO: Currently any fields are conservatively filled to zero,
+                 * even if a field will be set immediately after.
                  */
                 size_t offset = 0;
                 for (size_t i = 0; i < sle->sd->fields.dim; i++)
                 {
                     VarDeclaration *v = sle->sd->fields[i];
-
-                    e = el_combine(e, fillHole(stmp, &offset, v->offset, sle->sd->structsize));
                     size_t vend = v->offset + v->type->size();
-                    if (offset < vend)
-                        offset = vend;
+                    e = el_combine(e, fillHole(stmp, &offset, vend, sle->sd->structsize));
                 }
                 e = el_combine(e, fillHole(stmp, &offset, sle->sd->structsize, sle->sd->structsize));
             }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7248,6 +7248,52 @@ static this()
 }
 
 /***************************************************/
+// 13952
+
+struct Reg13952
+{
+    ubyte type;
+    ubyte regNo;
+    ushort size;
+}
+
+struct Imm13952
+{
+    ulong imm;
+}
+
+struct Opnd13952
+{
+    union
+    {
+        Reg13952 reg; // size == 4
+        Imm13952 imm; // size == 8
+    }
+    ubyte tag;
+
+    this(Reg13952 r) { reg = r; }
+}
+
+Opnd13952 opnd13952(Reg13952 reg)
+{
+    return Opnd13952(reg);
+}
+
+void test13952()
+{
+    Reg13952 reg;
+    auto op = opnd13952(reg);
+    auto buf = (cast(ubyte*)&op)[0 .. op.sizeof];
+    //debug
+    //{
+    //    import std.stdio;
+    //    writefln("op.reg = [%(%02x %)]", (cast(ubyte*)&op.reg)[0 .. Reg13952.sizeof]);
+    //    writefln("op.imm = [%(%02x %)]", (cast(ubyte*)&op.imm)[0 .. Imm13952.sizeof]);
+    //}
+    foreach (e; buf) assert(e == 0);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -7548,6 +7594,7 @@ int main()
     test13437();
     test13472();
     test13476();
+    test13952();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13952

@WalterBright Although there's still the excessive init issue, but generated code behavior is correct. I think this should go in 2.067.
