### PR TITLE
Prefix Mem methods with 'x' to differ from stdlib memory functions

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -876,7 +876,7 @@ void PragmaDeclaration::semantic(Scope *sc)
                 error("string expected for library name, not '%s'", e->toChars());
             else
             {
-                char *name = (char *)mem.malloc(se->len + 1);
+                char *name = (char *)mem.xmalloc(se->len + 1);
                 memcpy(name, se->string, se->len);
                 name[se->len] = 0;
                 if (global.params.verbose)
@@ -893,7 +893,7 @@ void PragmaDeclaration::semantic(Scope *sc)
                     ob->writestring((char *) name);
                     ob->writenl();
                 }
-                mem.free(name);
+                mem.xfree(name);
             }
         }
         goto Lnodecl;
@@ -1046,7 +1046,7 @@ Ldecl:
                 assert(args && args->dim == 1);
                 if (StringExp *se = (*args)[0]->toStringExp())
                 {
-                    char *name = (char *)mem.malloc(se->len + 1);
+                    char *name = (char *)mem.xmalloc(se->len + 1);
                     memcpy(name, se->string, se->len);
                     name[se->len] = 0;
 

--- a/src/cast.c
+++ b/src/cast.c
@@ -1611,7 +1611,7 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                  */
                 if ((se->len + 1) * se->sz > (e->len + 1) * e->sz)
                 {
-                    void *s = (void *)mem.malloc((se->len + 1) * se->sz);
+                    void *s = (void *)mem.xmalloc((se->len + 1) * se->sz);
                     memcpy(s, se->string, se->len * se->sz);
                     memset((char *)s + se->len * se->sz, 0, se->sz);
                     se->string = s;
@@ -1789,7 +1789,7 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                     // Copy when changing the string literal
                     size_t newsz = se->sz;
                     size_t d = (dim2 < se->len) ? dim2 : se->len;
-                    void *s = (void *)mem.malloc((dim2 + 1) * newsz);
+                    void *s = (void *)mem.xmalloc((dim2 + 1) * newsz);
                     memcpy(s, se->string, d * newsz);
                     // Extend with 0, add terminating 0
                     memset((char *)s + d * newsz, 0, (dim2 + 1 - d) * newsz);

--- a/src/class.c
+++ b/src/class.c
@@ -1745,7 +1745,7 @@ void BaseClass::copyBaseInterfaces(BaseClasses *vtblInterfaces)
 //      return;
 
     baseInterfaces_dim = base->interfaces_dim;
-    baseInterfaces = (BaseClass *)mem.calloc(baseInterfaces_dim, sizeof(BaseClass));
+    baseInterfaces = (BaseClass *)mem.xcalloc(baseInterfaces_dim, sizeof(BaseClass));
 
     //printf("%s.copyBaseInterfaces()\n", base->toChars());
     for (size_t i = 0; i < baseInterfaces_dim; i++)

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1483,7 +1483,7 @@ UnionExp Slice(Type *type, Expression *e1, Expression *lwr, Expression *upr)
             size_t len = (size_t)(iupr - ilwr);
             unsigned char sz = es1->sz;
 
-            void *s = mem.malloc((len + 1) * sz);
+            void *s = mem.xmalloc((len + 1) * sz);
             memcpy((char *)s, (char *)es1->string + ilwr * sz, len * sz);
             memset((char *)s + len * sz, 0, sz);
 
@@ -1652,7 +1652,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
             dinteger_t v = e->toInteger();
 
             size_t len = (t->ty == tn->ty) ? 1 : utf_codeLength(sz, (dchar_t)v);
-            void *s = mem.malloc((len + 1) * sz);
+            void *s = mem.xmalloc((len + 1) * sz);
             if (t->ty == tn->ty)
                 memcpy(s, &v, sz);
             else
@@ -1724,7 +1724,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
             assert(ue.exp()->type);
             return ue;
         }
-        void *s = mem.malloc((len + 1) * sz);
+        void *s = mem.xmalloc((len + 1) * sz);
         memcpy((char *)s, es1->string, es1->len * sz);
         memcpy((char *)s + es1->len * sz, es2->string, es2->len * sz);
 
@@ -1793,7 +1793,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
         size_t len = es1->len;
         len += homoConcat ? 1 : utf_codeLength(sz, (dchar_t)v);
 
-        void *s = mem.malloc((len + 1) * sz);
+        void *s = mem.xmalloc((len + 1) * sz);
         memcpy(s, es1->string, es1->len * sz);
         if (homoConcat)
              memcpy((char *)s + (sz * es1->len), &v, sz);
@@ -1819,7 +1819,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
         unsigned char sz = es2->sz;
         dinteger_t v = e1->toInteger();
 
-        void *s = mem.malloc((len + 1) * sz);
+        void *s = mem.xmalloc((len + 1) * sz);
         memcpy((char *)s, &v, sz);
         memcpy((char *)s + sz, es2->string, es2->len * sz);
 

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -260,7 +260,7 @@ UnionExp copyLiteral(Expression *e)
     if (e->op == TOKstring) // syntaxCopy doesn't make a copy for StringExp!
     {
         StringExp *se = (StringExp *)e;
-        utf8_t *s = (utf8_t *)mem.calloc(se->len + 1, se->sz);
+        utf8_t *s = (utf8_t *)mem.xcalloc(se->len + 1, se->sz);
         memcpy(s, se->string, se->len * se->sz);
         new(&ue) StringExp(se->loc, s, se->len);
         StringExp *se2 = (StringExp *)ue.exp();
@@ -556,7 +556,7 @@ ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Loc loc, Type *type,
 StringExp *createBlockDuplicatedStringLiteral(Loc loc, Type *type,
         unsigned value, size_t dim, unsigned char sz)
 {
-    utf8_t *s = (utf8_t *)mem.calloc(dim + 1, sz);
+    utf8_t *s = (utf8_t *)mem.xcalloc(dim + 1, sz);
     for (size_t elemi = 0; elemi < dim; ++elemi)
     {
         switch (sz)
@@ -1551,7 +1551,7 @@ int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2)
         if (es2->keys->dim != dim)
             return 1;
 
-        bool *used = (bool *)mem.malloc(sizeof(bool) * dim);
+        bool *used = (bool *)mem.xmalloc(sizeof(bool) * dim);
         memset(used, 0, sizeof(bool) * dim);
 
         for (size_t i = 0; i < dim; ++i)
@@ -1571,12 +1571,12 @@ int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2)
                 used[j] = true;
                 if (ctfeRawCmp(loc, v1, v2))
                 {
-                    mem.free(used);
+                    mem.xfree(used);
                     return 1;
                 }
             }
         }
-        mem.free(used);
+        mem.xfree(used);
         return 0;
     }
     error(loc, "CTFE internal error: bad compare");
@@ -1696,7 +1696,7 @@ UnionExp ctfeCat(Type *type, Expression *e1, Expression *e2)
         size_t len = es1->len + es2->elements->dim;
         unsigned char sz = es1->sz;
 
-        void *s = mem.malloc((len + 1) * sz);
+        void *s = mem.xmalloc((len + 1) * sz);
         memcpy((char *)s + sz * es2->elements->dim, es1->string, es1->len * sz);
         for (size_t i = 0; i < es2->elements->dim; i++)
         {
@@ -1730,7 +1730,7 @@ UnionExp ctfeCat(Type *type, Expression *e1, Expression *e2)
         size_t len = es1->len + es2->elements->dim;
         unsigned char sz = es1->sz;
 
-        void *s = mem.malloc((len + 1) * sz);
+        void *s = mem.xmalloc((len + 1) * sz);
         memcpy(s, es1->string, es1->len * sz);
         for (size_t i = 0; i < es2->elements->dim; i++)
         {
@@ -2064,7 +2064,7 @@ UnionExp changeArrayLiteralLength(Loc loc, TypeArray *arrayType,
     if (oldval->op == TOKstring)
     {
         StringExp *oldse = (StringExp *)oldval;
-        void *s = mem.calloc(newlen + 1, oldse->sz);
+        void *s = mem.xcalloc(newlen + 1, oldse->sz);
         memcpy(s, oldse->string, copylen * oldse->sz);
         unsigned defaultValue = (unsigned)(defaultElem->toInteger());
         for (size_t elemi = copylen; elemi < newlen; ++elemi)

--- a/src/doc.c
+++ b/src/doc.c
@@ -301,7 +301,7 @@ void gendocfile(Module *m)
         time_t t;
         time(&t);
         char *p = ctime(&t);
-        p = mem.strdup(p);
+        p = mem.xstrdup(p);
         Macro::define(&m->macrotable, (utf8_t *)"DATETIME", 8, (utf8_t *)p, strlen(p));
         Macro::define(&m->macrotable, (utf8_t *)"YEAR", 4, (utf8_t *)p + 20, 4);
     }
@@ -1915,7 +1915,7 @@ void DocComment::parseEscapes(Escape **pescapetable, const utf8_t *textstart, si
             p++;
         }
         size_t len = p - start;
-        char *s = (char *)memcpy(mem.malloc(len + 1), start, len);
+        char *s = (char *)memcpy(mem.xmalloc(len + 1), start, len);
         s[len] = 0;
         escapetable->strings[c] = s;
         //printf("\t%c = '%s'\n", c, s);

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -228,7 +228,7 @@ const char *Dsymbol::toPrettyChars(bool QualifyTypes)
     for (p = this; p; p = p->parent)
         len += strlen(QualifyTypes ? p->toPrettyCharsHelper() : p->toChars()) + 1;
 
-    s = (char *)mem.malloc(len);
+    s = (char *)mem.xmalloc(len);
     q = s + len - 1;
     *q = 0;
     for (p = this; p; p = p->parent)
@@ -1083,7 +1083,7 @@ void ScopeDsymbol::importScope(Dsymbol *s, Prot protection)
             }
         }
         imports->push(s);
-        prots = (PROTKIND *)mem.realloc(prots, imports->dim * sizeof(prots[0]));
+        prots = (PROTKIND *)mem.xrealloc(prots, imports->dim * sizeof(prots[0]));
         prots[imports->dim - 1] = protection.kind;
     }
 }

--- a/src/errors.c
+++ b/src/errors.c
@@ -178,7 +178,7 @@ void verrorPrint(Loc loc, COLOR headerColor, const char *header, const char *for
         setConsoleColorBright(true);
     if (*p)
         fprintf(stderr, "%s: ", p);
-    mem.free(p);
+    mem.xfree(p);
 
     if (global.params.color)
         setConsoleColor(headerColor, true);

--- a/src/expression.c
+++ b/src/expression.c
@@ -2022,7 +2022,7 @@ Expression *Expression::copy()
 #endif
         assert(0);
     }
-    e = (Expression *)mem.malloc(size);
+    e = (Expression *)mem.xmalloc(size);
     //printf("Expression::copy(op = %d) e = %p\n", op, e);
     return (Expression *)memcpy((void*)e, (void*)this, size);
 }
@@ -3631,7 +3631,7 @@ StringExp *NullExp::toStringExp()
 {
     if (implicitConvTo(Type::tstring))
     {
-        StringExp *se = new StringExp(loc, (char*)mem.calloc(1, 1), 0);
+        StringExp *se = new StringExp(loc, (char*)mem.xcalloc(1, 1), 0);
         se->type = Type::tstring;
         return se;
     }

--- a/src/func.c
+++ b/src/func.c
@@ -1512,7 +1512,7 @@ void FuncDeclaration::semantic3(Scope *sc)
              */
             if (ad2 && isCtorDeclaration())
             {
-                fieldinit = (unsigned *)mem.malloc(sizeof(unsigned) * ad2->fields.dim);
+                fieldinit = (unsigned *)mem.xmalloc(sizeof(unsigned) * ad2->fields.dim);
                 sc2->fieldinit = fieldinit;
                 sc2->fieldinit_dim = ad2->fields.dim;
                 for (size_t i = 0; i < ad2->fields.dim; i++)
@@ -1806,7 +1806,7 @@ void FuncDeclaration::semantic3(Scope *sc)
             }
 
             if (fieldinit)
-                mem.free(fieldinit);
+                mem.xfree(fieldinit);
             sc2 = sc2->pop();
         }
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1155,7 +1155,7 @@ TOK Lexer::wysiwygStringConstant(Token *t, int tc)
                 {
                     t->len = (unsigned)stringbuffer.offset;
                     stringbuffer.writeByte(0);
-                    t->ustring = (utf8_t *)mem.malloc(stringbuffer.offset);
+                    t->ustring = (utf8_t *)mem.xmalloc(stringbuffer.offset);
                     memcpy(t->ustring, stringbuffer.data, stringbuffer.offset);
                     stringPostfix(t);
                     return TOKstring;
@@ -1226,7 +1226,7 @@ TOK Lexer::hexStringConstant(Token *t)
                 }
                 t->len = (unsigned)stringbuffer.offset;
                 stringbuffer.writeByte(0);
-                t->ustring = (utf8_t *)mem.malloc(stringbuffer.offset);
+                t->ustring = (utf8_t *)mem.xmalloc(stringbuffer.offset);
                 memcpy(t->ustring, stringbuffer.data, stringbuffer.offset);
                 stringPostfix(t);
                 return TOKxstring;
@@ -1414,7 +1414,7 @@ Ldone:
         error("delimited string must end in %c\"", delimright);
     t->len = (unsigned)stringbuffer.offset;
     stringbuffer.writeByte(0);
-    t->ustring = (utf8_t *)mem.malloc(stringbuffer.offset);
+    t->ustring = (utf8_t *)mem.xmalloc(stringbuffer.offset);
     memcpy(t->ustring, stringbuffer.data, stringbuffer.offset);
     stringPostfix(t);
     return TOKstring;
@@ -1449,7 +1449,7 @@ TOK Lexer::tokenStringConstant(Token *t)
                 if (--nest == 0)
                 {
                     t->len = (unsigned)(p - 1 - pstart);
-                    t->ustring = (utf8_t *)mem.malloc(t->len + 1);
+                    t->ustring = (utf8_t *)mem.xmalloc(t->len + 1);
                     memcpy(t->ustring, pstart, t->len);
                     t->ustring[t->len] = 0;
                     stringPostfix(t);
@@ -1516,7 +1516,7 @@ TOK Lexer::escapeStringConstant(Token *t, int wide)
             case '"':
                 t->len = (unsigned)stringbuffer.offset;
                 stringbuffer.writeByte(0);
-                t->ustring = (utf8_t *)mem.malloc(stringbuffer.offset);
+                t->ustring = (utf8_t *)mem.xmalloc(stringbuffer.offset);
                 memcpy(t->ustring, stringbuffer.data, stringbuffer.offset);
                 stringPostfix(t);
                 return TOKstring;
@@ -2169,7 +2169,7 @@ void Lexer::poundLine()
                 if (memcmp(p, "__FILE__", 8) == 0)
                 {
                     p += 8;
-                    filespec = mem.strdup(scanloc.filename);
+                    filespec = mem.xstrdup(scanloc.filename);
                     continue;
                 }
                 goto Lerr;
@@ -2193,7 +2193,7 @@ void Lexer::poundLine()
 
                         case '"':
                             stringbuffer.writeByte(0);
-                            filespec = mem.strdup((char *)stringbuffer.data);
+                            filespec = mem.xstrdup((char *)stringbuffer.data);
                             p++;
                             break;
 
@@ -2439,7 +2439,7 @@ const utf8_t *Lexer::combineComments(const utf8_t *c1, const utf8_t *c2)
                 insertNewLine = 1;
             }
 
-            utf8_t *p = (utf8_t *)mem.malloc(len1 + 1 + len2 + 1);
+            utf8_t *p = (utf8_t *)mem.xmalloc(len1 + 1 + len2 + 1);
             memcpy(p, c1, len1 - insertNewLine);
             if (insertNewLine)
                 p[len1 - 1] = '\n';

--- a/src/link.c
+++ b/src/link.c
@@ -489,7 +489,7 @@ int runLINK()
         }
         else
             close(fd);
-        global.params.exefile = mem.strdup(name);
+        global.params.exefile = mem.xstrdup(name);
         argv.push(global.params.exefile);
 #else
         /* The use of tmpnam raises the issue of "is this a security hole"?
@@ -502,7 +502,7 @@ int runLINK()
          */
         char s[L_tmpnam + 1];
         char *n = tmpnam(s);
-        global.params.exefile = mem.strdup(n);
+        global.params.exefile = mem.xstrdup(n);
         argv.push(global.params.exefile);
 #endif
     }
@@ -516,7 +516,7 @@ int runLINK()
         if (e)
         {
             e--;                        // back up over '.'
-            ex = (char *)mem.malloc(e - n + 1);
+            ex = (char *)mem.xmalloc(e - n + 1);
             memcpy(ex, n, e - n);
             ex[e - n] = 0;
             // If generating dll then force dll extension
@@ -606,7 +606,7 @@ int runLINK()
             argv.push(p);
         else
         {
-            char *s = (char *)mem.malloc(plen + 3);
+            char *s = (char *)mem.xmalloc(plen + 3);
             s[0] = '-';
             s[1] = 'l';
             memcpy(s + 2, p, plen + 1);
@@ -854,7 +854,7 @@ int runProgram()
 #if _WIN32
         // BUG: what about " appearing in the string?
         if (strchr(a, ' '))
-        {   char *b = (char *)mem.malloc(3 + strlen(a));
+        {   char *b = (char *)mem.xmalloc(3 + strlen(a));
             sprintf(b, "\"%s\"", a);
             a = b;
         }

--- a/src/macro.c
+++ b/src/macro.c
@@ -29,7 +29,7 @@ int utfStride(const utf8_t *p);
 
 utf8_t *memdup(const utf8_t *p, size_t len)
 {
-    return (utf8_t *)memcpy(mem.malloc(len), p, len);
+    return (utf8_t *)memcpy(mem.xmalloc(len), p, len);
 }
 
 Macro::Macro(const utf8_t *name, size_t namelen, const utf8_t *text, size_t textlen)
@@ -374,7 +374,7 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
                         // marg = name[ ] ~ "," ~ marg[ ];
                         if (marglen)
                         {
-                            utf8_t *q = (utf8_t *)mem.malloc(namelen + 1 + marglen);
+                            utf8_t *q = (utf8_t *)mem.xmalloc(namelen + 1 + marglen);
                             assert(q);
                             memcpy(q, name, namelen);
                             q[namelen] = ',';
@@ -438,7 +438,7 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
                         buf->remove(u, v + 1 - u);
                         end -= v + 1 - u;
                         u += mend - (v + 1);
-                        mem.free((utf8_t *)marg);
+                        mem.xfree((utf8_t *)marg);
                         //printf("u = %d, end = %d\n", u, end);
                         //printf("#%.*s#\n", end - u, &buf->data[u]);
                         continue;
@@ -455,7 +455,7 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
         }
         u++;
     }
-    mem.free((utf8_t *)arg);
+    mem.xfree((utf8_t *)arg);
     *pend = end;
     nest--;
 }

--- a/src/mars.c
+++ b/src/mars.c
@@ -1253,7 +1253,7 @@ Language changes listed by -transition=id:\n\
             {
                 ext--;                  // skip onto '.'
                 assert(*ext == '.');
-                newname = (char *)mem.malloc((ext - p) + 1);
+                newname = (char *)mem.xmalloc((ext - p) + 1);
                 memcpy(newname, p, ext - p);
                 newname[ext - p] = 0;              // strip extension
                 name = newname;
@@ -1689,7 +1689,7 @@ void getenv_setargv(const char *envvar, size_t *pargc, const char** *pargv)
     if (!env)
         return;
 
-    env = mem.strdup(env);      // create our own writable copy
+    env = mem.xstrdup(env);      // create our own writable copy
 
     size_t argc = *pargc;
     Strings *argv = new Strings();

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -157,7 +157,7 @@ const char *Type::kind()
 
 Type *Type::copy()
 {
-    Type *t = (Type *)mem.malloc(sizeTy[ty]);
+    Type *t = (Type *)mem.xmalloc(sizeTy[ty]);
     memcpy((void*)t, (void*)this, sizeTy[ty]);
     return t;
 }
@@ -344,7 +344,7 @@ Type *Type::trySemantic(Loc loc, Scope *sc)
 Type *Type::nullAttributes()
 {
     unsigned sz = sizeTy[ty];
-    Type *t = (Type *)mem.malloc(sz);
+    Type *t = (Type *)mem.xmalloc(sz);
     memcpy((void*)t, (void*)this, sz);
     // t->mod = NULL;  // leave mod unchanged
     t->deco = NULL;
@@ -5343,7 +5343,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
         tf->parameters = parameters->copy();
         for (size_t i = 0; i < parameters->dim; i++)
         {
-            Parameter *p = (Parameter *)mem.malloc(sizeof(Parameter));
+            Parameter *p = (Parameter *)mem.xmalloc(sizeof(Parameter));
             memcpy((void *)p, (void *)(*parameters)[i], sizeof(Parameter));
             (*tf->parameters)[i] = p;
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -84,7 +84,7 @@ Parser::Parser(Loc loc, Module *module, const utf8_t *base, size_t length, int d
         /* Create a pseudo-filename for the mixin string, as it may not even exist
          * in the source file.
          */
-        char *filename = (char *)mem.malloc(strlen(loc.filename) + 7 + sizeof(loc.linnum) * 3 + 1);
+        char *filename = (char *)mem.xmalloc(strlen(loc.filename) + 7 + sizeof(loc.linnum) * 3 + 1);
         sprintf(filename, "%s-mixin-%d", loc.filename, (int)loc.linnum);
         scanloc.filename = filename;
     }
@@ -1796,7 +1796,7 @@ Dsymbol *Parser::parseUnitTest(PrefixAttributes *pAttrs)
         size_t len = endPtr - begPtr;
         if (len > 0)
         {
-            docline = (char *)mem.malloc(len + 2);
+            docline = (char *)mem.xmalloc(len + 2);
             memcpy(docline, begPtr, len);
             docline[len  ] = '\n';  // Terminate all lines by LF
             docline[len+1] = '\0';
@@ -6463,7 +6463,7 @@ Expression *Parser::parsePrimaryExp()
                     size_t len1 = len;
                     size_t len2 = token.len;
                     len = len1 + len2;
-                    utf8_t *s2 = (utf8_t *)mem.malloc((len + 1) * sizeof(utf8_t));
+                    utf8_t *s2 = (utf8_t *)mem.xmalloc((len + 1) * sizeof(utf8_t));
                     memcpy(s2, s, len1 * sizeof(utf8_t));
                     memcpy(s2 + len1, token.ustring, (len2 + 1) * sizeof(utf8_t));
                     s = s2;

--- a/src/root/aav.c
+++ b/src/root/aav.c
@@ -65,7 +65,7 @@ Value* dmd_aaGet(AA** paa, Key key)
     //printf("paa = %p\n", paa);
 
     if (!*paa)
-    {   AA *a = (AA *)mem.malloc(sizeof(AA));
+    {   AA *a = (AA *)mem.xmalloc(sizeof(AA));
         a->b = (aaA**)a->binit;
         a->b_length = 4;
         a->nodes = 0;
@@ -93,7 +93,7 @@ Value* dmd_aaGet(AA** paa, Key key)
     //printf("create new one\n");
 
     size_t nodes = ++(*paa)->nodes;
-    e = (nodes != 1) ? (aaA *)mem.malloc(sizeof(aaA)) : &(*paa)->aafirst;
+    e = (nodes != 1) ? (aaA *)mem.xmalloc(sizeof(aaA)) : &(*paa)->aafirst;
     //e = new aaA();
     e->next = NULL;
     e->key = key;
@@ -153,7 +153,7 @@ void dmd_aaRehash(AA** paa)
                 len = 32;
             else
                 len *= 4;
-            aaA** newb = (aaA**)mem.malloc(sizeof(aaA)*len);
+            aaA** newb = (aaA**)mem.xmalloc(sizeof(aaA)*len);
             memset(newb, 0, len * sizeof(aaA*));
 
             for (size_t k = 0; k < aa->b_length; k++)
@@ -167,7 +167,7 @@ void dmd_aaRehash(AA** paa)
                 }
             }
             if (aa->b != (aaA**)aa->binit)
-                mem.free(aa->b);
+                mem.xfree(aa->b);
 
             aa->b = newb;
             aa->b_length = len;

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -43,19 +43,19 @@ struct Array
     ~Array()
     {
         if (data != &smallarray[0])
-            mem.free(data);
+            mem.xfree(data);
     }
 
     char *toChars()
     {
-        char **buf = (char **)mem.malloc(dim * sizeof(char *));
+        char **buf = (char **)mem.xmalloc(dim * sizeof(char *));
         size_t len = 2;
         for (size_t u = 0; u < dim; u++)
         {
             buf[u] = ((RootObject *)data[u])->toChars();
             len += strlen(buf[u]) + 1;
         }
-        char *str = (char *)mem.malloc(len);
+        char *str = (char *)mem.xmalloc(len);
 
         str[0] = '[';
         char *p = str + 1;
@@ -69,7 +69,7 @@ struct Array
         }
         *p++ = ']';
         *p = 0;
-        mem.free(buf);
+        mem.xfree(buf);
         return str;
     }
 
@@ -86,18 +86,18 @@ struct Array
                 }
                 else
                 {   allocdim = nentries;
-                    data = (TYPE *)mem.malloc(allocdim * sizeof(*data));
+                    data = (TYPE *)mem.xmalloc(allocdim * sizeof(*data));
                 }
             }
             else if (allocdim == SMALLARRAYCAP)
             {
                 allocdim = dim + nentries;
-                data = (TYPE *)mem.malloc(allocdim * sizeof(*data));
+                data = (TYPE *)mem.xmalloc(allocdim * sizeof(*data));
                 memcpy(data, &smallarray[0], dim * sizeof(*data));
             }
             else
             {   allocdim = dim + nentries;
-                data = (TYPE *)mem.realloc(data, allocdim * sizeof(*data));
+                data = (TYPE *)mem.xrealloc(data, allocdim * sizeof(*data));
             }
         }
     }
@@ -120,10 +120,10 @@ struct Array
                 if (dim <= SMALLARRAYCAP)
                 {
                     memcpy(&smallarray[0], data, dim * sizeof(*data));
-                    mem.free(data);
+                    mem.xfree(data);
                 }
                 else
-                    data = (TYPE *)mem.realloc(data, dim * sizeof(*data));
+                    data = (TYPE *)mem.xrealloc(data, dim * sizeof(*data));
             }
             allocdim = dim;
         }

--- a/src/root/file.c
+++ b/src/root/file.c
@@ -66,7 +66,7 @@ File::~File()
     if (buffer)
     {
         if (ref == 0)
-            mem.free(buffer);
+            mem.xfree(buffer);
 #if _WIN32
         if (ref == 2)
             UnmapViewOfFile(buffer);

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -44,7 +44,7 @@
 /****************************** FileName ********************************/
 
 FileName::FileName(const char *str)
-    : str(mem.strdup(str))
+    : str(mem.xstrdup(str))
 {
 }
 
@@ -57,7 +57,7 @@ const char *FileName::combine(const char *path, const char *name)
         return (char *)name;
     pathlen = strlen(path);
     namelen = strlen(name);
-    f = (char *)mem.malloc(pathlen + 1 + namelen + 1);
+    f = (char *)mem.xmalloc(pathlen + 1 + namelen + 1);
     memcpy(f, path, pathlen);
 #if POSIX
     if (path[pathlen - 1] != '/')
@@ -241,7 +241,7 @@ const char *FileName::ext()
 }
 
 /********************************
- * Return mem.malloc'd filename with extension removed.
+ * Return mem.xmalloc'd filename with extension removed.
  */
 
 const char *FileName::removeExt(const char *str)
@@ -249,12 +249,12 @@ const char *FileName::removeExt(const char *str)
     const char *e = ext(str);
     if (e)
     {   size_t len = (e - str) - 1;
-        char *n = (char *)mem.malloc(len + 1);
+        char *n = (char *)mem.xmalloc(len + 1);
         memcpy(n, str, len);
         n[len] = 0;
         return n;
     }
-    return mem.strdup(str);
+    return mem.xstrdup(str);
 }
 
 /********************************
@@ -325,7 +325,7 @@ const char *FileName::path(const char *str)
 #endif
     }
     pathlen = n - str;
-    char *path = (char *)mem.malloc(pathlen + 1);
+    char *path = (char *)mem.xmalloc(pathlen + 1);
     memcpy(path, str, pathlen);
     path[pathlen] = 0;
     return path;
@@ -348,7 +348,7 @@ const char *FileName::replaceName(const char *path, const char *name)
         return name;
     pathlen = n - path;
     namelen = strlen(name);
-    char *f = (char *)mem.malloc(pathlen + 1 + namelen + 1);
+    char *f = (char *)mem.xmalloc(pathlen + 1 + namelen + 1);
     memcpy(f, path, pathlen);
 #if POSIX
     if (path[pathlen - 1] != '/')
@@ -377,11 +377,11 @@ const char *FileName::defaultExt(const char *name, const char *ext)
 {
     const char *e = FileName::ext(name);
     if (e)                              // if already has an extension
-        return mem.strdup(name);
+        return mem.xstrdup(name);
 
     size_t len = strlen(name);
     size_t extlen = strlen(ext);
-    char *s = (char *)mem.malloc(len + 1 + extlen + 1);
+    char *s = (char *)mem.xmalloc(len + 1 + extlen + 1);
     memcpy(s,name,len);
     s[len] = '.';
     memcpy(s + len + 1, ext, extlen + 1);
@@ -400,7 +400,7 @@ const char *FileName::forceExt(const char *name, const char *ext)
         size_t len = e - name;
         size_t extlen = strlen(ext);
 
-        char *s = (char *)mem.malloc(len + extlen + 1);
+        char *s = (char *)mem.xmalloc(len + extlen + 1);
         memcpy(s,name,len);
         memcpy(s + len, ext, extlen + 1);
         return s;
@@ -471,7 +471,7 @@ const char *FileName::searchPath(Strings *path, const char *name, bool cwd)
  *      https://www.securecoding.cert.org/confluence/display/seccode/FIO02-C.+Canonicalize+path+names+originating+from+untrusted+sources
  * Returns:
  *      NULL    file not found
- *      !=NULL  mem.malloc'd file name
+ *      !=NULL  mem.xmalloc'd file name
  */
 
 const char *FileName::safeSearchPath(Strings *path, const char *name)
@@ -526,7 +526,7 @@ const char *FileName::safeSearchPath(Strings *path, const char *name)
             if (exists(cname) && strncmp(cpath, cname, strlen(cpath)) == 0)
             {
                 ::free((void *)cpath);
-                const char *p = mem.strdup(cname);
+                const char *p = mem.xstrdup(cname);
                 ::free((void *)cname);
                 return p;
             }
@@ -585,12 +585,12 @@ bool FileName::ensurePathExists(const char *path)
                 size_t len = strlen(path);
                 if ((len > 2 && p[-1] == ':' && strcmp(path + 2, p) == 0) ||
                     len == strlen(p))
-                {   mem.free((void *)p);
+                {   mem.xfree((void *)p);
                     return 0;
                 }
 #endif
                 bool r = ensurePathExists(p);
-                mem.free((void *)p);
+                mem.xfree((void *)p);
                 if (r)
                     return r;
             }
@@ -663,7 +663,7 @@ void FileName::free(const char *str)
     {   assert(str[0] != (char)0xAB);
         memset((void *)str, 0xAB, strlen(str) + 1);     // stomp
     }
-    mem.free((void *)str);
+    mem.xfree((void *)str);
 }
 
 char *FileName::toChars()

--- a/src/root/outbuffer.c
+++ b/src/root/outbuffer.c
@@ -38,7 +38,7 @@ void OutBuffer::reserve(size_t nbytes)
     {
         size = (offset + nbytes) * 2;
         size = (size + 15) & ~15;
-        data = (unsigned char *)mem.realloc(data, size);
+        data = (unsigned char *)mem.xrealloc(data, size);
     }
 }
 

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -45,7 +45,7 @@ struct OutBuffer
     }
     ~OutBuffer()
     {
-        mem.free(data);
+        mem.xfree(data);
     }
     char *extractData();
 

--- a/src/root/rmem.c
+++ b/src/root/rmem.c
@@ -18,13 +18,13 @@
 
 Mem mem;
 
-char *Mem::strdup(const char *s)
+char *Mem::xstrdup(const char *s)
 {
     char *p;
 
     if (s)
     {
-        p = ::strdup(s);
+        p = strdup(s);
         if (p)
             return p;
         error();
@@ -32,74 +32,75 @@ char *Mem::strdup(const char *s)
     return NULL;
 }
 
-void *Mem::malloc(size_t size)
+void *Mem::xmalloc(size_t size)
 {   void *p;
 
     if (!size)
         p = NULL;
     else
     {
-        p = ::malloc(size);
+        p = malloc(size);
         if (!p)
             error();
     }
     return p;
 }
 
-void *Mem::calloc(size_t size, size_t n)
+void *Mem::xcalloc(size_t size, size_t n)
 {   void *p;
 
     if (!size || !n)
         p = NULL;
     else
     {
-        p = ::calloc(size, n);
+        p = calloc(size, n);
         if (!p)
             error();
     }
     return p;
 }
 
-void *Mem::realloc(void *p, size_t size)
+void *Mem::xrealloc(void *p, size_t size)
 {
     if (!size)
     {   if (p)
-        {   ::free(p);
+        {
+            free(p);
             p = NULL;
         }
     }
     else if (!p)
     {
-        p = ::malloc(size);
+        p = malloc(size);
         if (!p)
             error();
     }
     else
     {
         void *psave = p;
-        p = ::realloc(psave, size);
+        p = realloc(psave, size);
         if (!p)
-        {   free(psave);
+        {   xfree(psave);
             error();
         }
     }
     return p;
 }
 
-void Mem::free(void *p)
+void Mem::xfree(void *p)
 {
     if (p)
-        ::free(p);
+        free(p);
 }
 
-void *Mem::mallocdup(void *o, size_t size)
+void *Mem::xmallocdup(void *o, size_t size)
 {   void *p;
 
     if (!size)
         p = NULL;
     else
     {
-        p = ::malloc(size);
+        p = malloc(size);
         if (!p)
             error();
         else

--- a/src/root/rmem.h
+++ b/src/root/rmem.h
@@ -16,12 +16,12 @@ struct Mem
 {
     Mem() { }
 
-    char *strdup(const char *s);
-    void *malloc(size_t size);
-    void *calloc(size_t size, size_t n);
-    void *realloc(void *p, size_t size);
-    void free(void *p);
-    void *mallocdup(void *o, size_t size);
+    char *xstrdup(const char *s);
+    void *xmalloc(size_t size);
+    void *xcalloc(size_t size, size_t n);
+    void *xrealloc(void *p, size_t size);
+    void xfree(void *p);
+    void *xmallocdup(void *o, size_t size);
     void error();
 };
 

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -86,8 +86,8 @@ uint32_t StringTable::allocValue(const char *s, size_t length)
 
     if (!npools || nfill + nbytes > POOL_SIZE)
     {
-        pools = (uint8_t **)mem.realloc(pools, ++npools * sizeof(pools[0]));
-        pools[npools - 1] = (uint8_t *)mem.malloc(nbytes > POOL_SIZE ? nbytes : POOL_SIZE);
+        pools = (uint8_t **)mem.xrealloc(pools, ++npools * sizeof(pools[0]));
+        pools[npools - 1] = (uint8_t *)mem.xmalloc(nbytes > POOL_SIZE ? nbytes : POOL_SIZE);
         nfill = 0;
     }
 
@@ -125,7 +125,7 @@ void StringTable::_init(size_t size)
 {
     size = nextpow2((size_t)(size / loadFactor));
     if (size < 32) size = 32;
-    table = (StringEntry *)mem.calloc(size, sizeof(table[0]));
+    table = (StringEntry *)mem.xcalloc(size, sizeof(table[0]));
     tabledim = size;
     pools = NULL;
     npools = nfill = 0;
@@ -135,10 +135,10 @@ void StringTable::_init(size_t size)
 void StringTable::reset(size_t size)
 {
     for (size_t i = 0; i < npools; ++i)
-        mem.free(pools[i]);
+        mem.xfree(pools[i]);
 
-    mem.free(table);
-    mem.free(pools);
+    mem.xfree(table);
+    mem.xfree(pools);
     table = NULL;
     pools = NULL;
     _init(size);
@@ -147,10 +147,10 @@ void StringTable::reset(size_t size)
 StringTable::~StringTable()
 {
     for (size_t i = 0; i < npools; ++i)
-        mem.free(pools[i]);
+        mem.xfree(pools[i]);
 
-    mem.free(table);
-    mem.free(pools);
+    mem.xfree(table);
+    mem.xfree(pools);
     table = NULL;
     pools = NULL;
 }
@@ -219,7 +219,7 @@ void StringTable::grow()
     const size_t odim = tabledim;
     StringEntry *otab = table;
     tabledim *= 2;
-    table = (StringEntry *)mem.calloc(tabledim, sizeof(table[0]));
+    table = (StringEntry *)mem.xcalloc(tabledim, sizeof(table[0]));
 
     for (size_t i = 0; i < odim; ++i)
     {
@@ -228,5 +228,5 @@ void StringTable::grow()
         StringValue *sv = getValue(se->vptr);
         table[findSlot(se->hash, sv->lstring(), sv->length)] = *se;
     }
-    mem.free(otab);
+    mem.xfree(otab);
 }

--- a/src/scope.c
+++ b/src/scope.c
@@ -185,7 +185,7 @@ Scope *Scope::pop()
             size_t dim = fieldinit_dim;
             for (size_t i = 0; i < dim; i++)
                 enclosing->fieldinit[i] |= fieldinit[i];
-            mem.free(fieldinit);
+            mem.xfree(fieldinit);
             fieldinit = NULL;
         }
     }
@@ -295,7 +295,7 @@ unsigned *Scope::saveFieldInit()
     if (fieldinit)  // copy
     {
         size_t dim = fieldinit_dim;
-        fi = (unsigned *)mem.malloc(sizeof(unsigned) * dim);
+        fi = (unsigned *)mem.xmalloc(sizeof(unsigned) * dim);
         for (size_t i = 0; i < dim; i++)
             fi[i] = fieldinit[i];
     }

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -180,7 +180,7 @@ Symbol *toSymbol(Dsymbol *s)
                             char *p = vd->loc.toChars();
                             fprintf(global.stdmsg, "%s: %s is thread local\n", p ? p : "", vd->toChars());
                             if (p)
-                                mem.free(p);
+                                mem.xfree(p);
                         }
                     }
                     s->Sclass = SCextern;

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1067,7 +1067,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 assert(e->op == TOKstring);
 
                 StringExp *se = (StringExp *)e;
-                char *name = (char *)mem.malloc(se->len + 1);
+                char *name = (char *)mem.xmalloc(se->len + 1);
                 memcpy(name, se->string, se->len);
                 name[se->len] = 0;
 


### PR DESCRIPTION
As GCC's policy on `malloc`, `realloc`, `calloc`, `free` and `strdup` is to mark them with `#pragma GCC poison` forcing frontend languages to instead use libiberty's safe `xmalloc`, etc... implementations, this gets tripped up when these function names find their way into GDC builds.

This would normally be OK to have in the frontend, given that it is isolated from GCC itself.  But that falls short of promise from the fact that both`array.h` and `outbuffer.h` are headers needed by the glue layers, and both pull in and use `rmem.h` inline.

So there's no other choice but fix up the name scheme to comply.
