### PR TITLE
fix issue 14104 - nuke getInternalTypeInfo

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -66,7 +66,6 @@ Symbol *toInitializer(AggregateDeclaration *ad);
 Symbol *aaGetSymbol(TypeAArray *taa, const char *func, int flags);
 Symbol* toSymbol(StructLiteralExp *sle);
 Symbol* toSymbol(ClassReferenceExp *cre);
-Expression *getInternalTypeInfo(Type *t, Scope *sc);
 Expression *getTypeInfo(Type *t, Scope *sc);
 
 int callSideEffectLevel(FuncDeclaration *f);
@@ -2037,7 +2036,7 @@ elem *toElem(Expression *e, IRState *irs)
                 elem *ea1 = eval_Darray(ce->e1);
                 elem *ea2 = eval_Darray(ce->e2);
 
-                elem *ep = el_params(toElem(getInternalTypeInfo(telement->arrayOf(), NULL), irs),
+                elem *ep = el_params(toElem(getTypeInfo(telement->arrayOf(), NULL), irs),
                         ea2, ea1, NULL);
                 int rtlfunc = RTLSYM_ARRAYCMP2;
                 e = el_bin(OPcall, TYint, el_var(rtlsym[rtlfunc]), ep);
@@ -2172,7 +2171,7 @@ elem *toElem(Expression *e, IRState *irs)
                 elem *ea1 = eval_Darray(ee->e1);
                 elem *ea2 = eval_Darray(ee->e2);
 
-                elem *ep = el_params(toElem(getInternalTypeInfo(telement->arrayOf(), NULL), irs),
+                elem *ep = el_params(toElem(getTypeInfo(telement->arrayOf(), NULL), irs),
                         ea2, ea1, NULL);
                 int rtlfunc = RTLSYM_ARRAYEQ2;
                 e = el_bin(OPcall, TYint, el_var(rtlsym[rtlfunc]), ep);
@@ -2267,7 +2266,7 @@ elem *toElem(Expression *e, IRState *irs)
             // aaInX(aa, keyti, key);
             key = addressElem(key, ie->e1->type);
             Symbol *s = aaGetSymbol(taa, "InX", 0);
-            elem *keyti = toElem(getInternalTypeInfo(taa->index, NULL), irs);
+            elem *keyti = toElem(getTypeInfo(taa->index, NULL), irs);
             elem *ep = el_params(key, keyti, aa, NULL);
             elem *e = el_bin(OPcall, totym(ie->type), el_var(s), ep);
 
@@ -2288,7 +2287,7 @@ elem *toElem(Expression *e, IRState *irs)
 
             ekey = addressElem(ekey, re->e1->type);
             Symbol *s = aaGetSymbol(taa, "DelX", 0);
-            elem *keyti = toElem(getInternalTypeInfo(taa->index, NULL), irs);
+            elem *keyti = toElem(getTypeInfo(taa->index, NULL), irs);
             elem *ep = el_params(ekey, keyti, ea, NULL);
             elem *e = el_bin(OPcall, TYnptr, el_var(s), ep);
 
@@ -4591,12 +4590,12 @@ elem *toElem(Expression *e, IRState *irs)
                 {
                     n1 = el_una(OPaddr, TYnptr, n1);
                     s = aaGetSymbol(taa, "GetY", 1);
-                    ti = toElem(getInternalTypeInfo(taa->mutableOf(), NULL), irs);
+                    ti = toElem(getTypeInfo(taa->mutableOf(), NULL), irs);
                 }
                 else
                 {
                     s = aaGetSymbol(taa, "GetRvalueX", 1);
-                    ti = toElem(getInternalTypeInfo(taa->index, NULL), irs);
+                    ti = toElem(getTypeInfo(taa->index, NULL), irs);
                 }
                 //printf("taa->index = %s\n", taa->index->toChars());
                 //printf("ti:\n"); elem_print(ti);

--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -77,12 +77,6 @@ void backend_term()
 
 // typinf
 
-Expression *getInternalTypeInfo(Type *t, Scope *sc)
-{
-    assert(0);
-    return NULL;
-}
-
 Expression *getTypeInfo(Type *t, Scope *sc)
 {
     Declaration *ti = new TypeInfoDeclaration(t, 1);

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -55,7 +55,6 @@ int Tsize_t = Tuns32;
 int Tptrdiff_t = Tint32;
 
 Symbol *toInitializer(AggregateDeclaration *ad);
-Expression *getInternalTypeInfo(Type *t, Scope *sc);
 Expression *getTypeInfo(Type *t, Scope *sc);
 
 /***************************** Type *****************************/
@@ -3736,9 +3735,7 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
         arguments = new Expressions();
         arguments->push(e);
         // don't convert to dynamic array
-        arguments->push(n->ty == Tsarray
-                    ? getTypeInfo(n, sc)
-                    : getInternalTypeInfo(n, sc));
+        arguments->push(getTypeInfo(n, sc));
         e = new CallExp(e->loc, ec, arguments);
         e->type = next->arrayOf();
     }


### PR DESCRIPTION
https://github.com/D-Programming-Language/druntime/pull/1150 fought the symptoms of https://issues.dlang.org/show_bug.cgi?id=14104 - "aa with pointer key type doesn't find existing value", but the actual problem is that different type infos are supplied to different AA methods. This is caused by running the type info through getInternalTypeInfo to create an "internal" type info assuming type info agnostic implementation in the runtime.

IMO getInternalTypeInfo is premature optimization and should be removed. The reasoning stated in its comment for less type information seems flawed as the type info is very likely needed for other operations anyway.

I've made some measurements with and without getInternalTypeInfo being used:

```
                 master       this PR
phobos.lib      17.453.056   17.454.080
phobos64.lib    33.607.032   33.613.022
unittest.exe    31.135.232   31.124.480   win64 phobos unittests
vdserver.exe     3.505.180    3.504.668   parser for visual D
VisualD.dll      2.507.292    2.506.780
```

The libraries get a miniscule larger, but executables actually get smaller. I suspect some of the predefined typeinfos are no longer linked in.
