### PR TITLE
issue 4650 - write strings/float constants to const section

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -523,6 +523,24 @@ seg_data *getsegment()
     return pseg;
 }
 
+/**************************
+ * Output read only data and generate a symbol for it.
+ *
+ */
+
+symbol * Obj::sym_cdata(tym_t ty,char *p,int len)
+{
+    symbol *s;
+
+    alignOffset(CDATA, tysize(ty));
+    s = symboldata(CDoffset, ty);
+    s->Sseg = CDATA;
+    Obj::bytes(CDATA, CDoffset, len, p);
+    CDoffset += len;
+
+    s->Sfl = FLdata; //FLextern;
+    return s;
+}
 
 /**************************
  * Ouput read only data for data.
@@ -534,10 +552,10 @@ seg_data *getsegment()
 
 int Obj::data_readonly(char *p, int len, int *pseg)
 {
-    targ_size_t oldoff = Doffset;
-    Obj::bytes(DATA,Doffset,len,p);
-    Doffset += len;
-    *pseg = DATA;
+    targ_size_t oldoff = CDoffset;
+    Obj::bytes(CDATA,CDoffset,len,p);
+    CDoffset += len;
+    *pseg = CDATA;
     return oldoff;
 }
 
@@ -774,7 +792,7 @@ void Obj::term(const char *objfilename)
         Obj::theadr(obj.modname);
         objheader(obj.csegname);
         mem_free(obj.csegname);
-        Obj::segment_group(SegData[CODE]->SDoffset,SegData[DATA]->SDoffset,0,SegData[UDATA]->SDoffset);  // do real sizes
+        Obj::segment_group(SegData[CODE]->SDoffset, SegData[DATA]->SDoffset, SegData[CDATA]->SDoffset, SegData[UDATA]->SDoffset);  // do real sizes
 
         // Update any out-of-date far segment sizes
         for (size_t i = 0; i <= seg_count; i++)
@@ -1339,7 +1357,9 @@ STATIC void objheader(char *csegname)
         "\0\06DGROUP\05_TEXT\04CODE\05_DATA\04DATA\05CONST\04_BSS\03BSS\
 \07$$TYPES\06DEBTYP\011$$SYMBOLS\06DEBSYM";
 
+#define CODECLASS       4                       // code class lname index
 #define DATACLASS       6                       // data class lname index
+#define CDATACLASS      7                       // CONST class lname index
 #define BSSCLASS        9                       // BSS class lname index
 
   // Include debug segment names if inserting type information
@@ -1521,20 +1541,20 @@ void Obj::segment_group(targ_size_t codesize,targ_size_t datasize,
     // For FLAT model, it's just GROUP FLAT
     static const char grpdef[] = {2,0xFF,2,0xFF,3,0xFF,4};
 
-    objsegdef(obj.csegattr,codesize,3,4);       // seg _TEXT, class CODE
+    objsegdef(obj.csegattr,codesize,3,CODECLASS);  // seg _TEXT, class CODE
 
 #if MARS
     dsegattr = SEG_ATTR(SEG_ALIGN16,SEG_C_PUBLIC,0,USE32);
     objsegdef(dsegattr,datasize,5,DATACLASS);   // [DATA]  seg _DATA, class DATA
-    objsegdef(dsegattr,cdatasize,7,7);          // [CDATA] seg CONST, class CONST
-    objsegdef(dsegattr,udatasize,8,9);          // [UDATA] seg _BSS,  class BSS
+    objsegdef(dsegattr,cdatasize,7,CDATACLASS); // [CDATA] seg CONST, class CONST
+    objsegdef(dsegattr,udatasize,8,BSSCLASS);   // [UDATA] seg _BSS,  class BSS
 #else
     dsegattr = I32
           ? SEG_ATTR(SEG_ALIGN4,SEG_C_PUBLIC,0,USE32)
           : SEG_ATTR(SEG_ALIGN2,SEG_C_PUBLIC,0,USE16);
     objsegdef(dsegattr,datasize,5,DATACLASS);   // seg _DATA, class DATA
-    objsegdef(dsegattr,cdatasize,7,7);          // seg CONST, class CONST
-    objsegdef(dsegattr,udatasize,8,9);          // seg _BSS, class BSS
+    objsegdef(dsegattr,cdatasize,7,CDATACLASS); // seg CONST, class CONST
+    objsegdef(dsegattr,udatasize,8,BSSCLASS);   // seg _BSS, class BSS
 #endif
 
     obj.lnameidx = 10;                          // next lname index
@@ -2432,7 +2452,7 @@ void Obj::pubdef(int seg,Symbol *s,targ_size_t offset)
         outpubdata();
     if (obj.pubdatai == 0)
     {
-        obj.pubdata[0] = (seg == DATA || seg == UDATA) ? 1 : 0; // group index
+        obj.pubdata[0] = (seg == DATA || seg == CDATA || seg == UDATA) ? 1 : 0; // group index
         obj.pubdatai += 1 + insidx(obj.pubdata + 1,idx);        // segment index
     }
     p = &obj.pubdata[obj.pubdatai];

--- a/src/backend/obj.h
+++ b/src/backend/obj.h
@@ -82,9 +82,7 @@ struct Obj
     VIRTUAL void fltused();
     VIRTUAL int data_readonly(char *p, int len, int *pseg);
     VIRTUAL int data_readonly(char *p, int len);
-#if ELFOBJ || MACHOBJ
     VIRTUAL symbol *sym_cdata(tym_t, char *, int);
-#endif
     VIRTUAL void func_start(Symbol *sfunc);
     VIRTUAL void func_term(Symbol *sfunc);
 

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -73,7 +73,7 @@ void outthunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
 }
 
 #endif
-
+
 /***************************
  * Write out statically allocated data.
  * Input:
@@ -371,6 +371,8 @@ void outdata(symbol *s)
 #else
                 /*else*/ if (dt->DTseg == DATA)
                     objmod->reftodatseg(seg,offset,dt->DTabytes,DATA,flags);
+                else if (dt->DTseg == CDATA)
+                    objmod->reftodatseg(seg,offset,dt->DTabytes,CDATA,flags);
                 else
                     objmod->reftofarseg(seg,offset,dt->DTabytes,dt->DTseg,flags);
 #endif
@@ -760,7 +762,7 @@ again:
     type_free(t);
 #endif
 }
-
+
 /*************************************
  * Determine register candidates.
  */
@@ -878,7 +880,7 @@ STATIC void out_regcand_walk(elem *e)
         }
     }
 }
-
+
 /**************************
  * Optimize function,
  * generate code for it,
@@ -1434,7 +1436,7 @@ symbol *out_readonly_sym(tym_t ty, void *p, int len)
 
     symbol *s;
 
-#if ELFOBJ
+#if ELFOBJ || OMFOBJ /* includes COFF */
     /* MACHOBJ can't go here, because the const data segment goes into
      * the _TEXT segment, and one cannot have a fixup from _TEXT to _TEXT.
      */
@@ -1445,10 +1447,6 @@ symbol *out_readonly_sym(tym_t ty, void *p, int len)
     alignOffset(DATA, sz);
     s = symboldata(Doffset,ty | mTYconst);
     s->Sseg = DATA;
-#if TARGET_WINDOS
-    if (I64)
-        objmod->pubdef(s->Sseg, s, s->Soffset);
-#endif
     objmod->write_bytes(SegData[DATA], len, p);
     //printf("s->Sseg = %d:x%x\n", s->Sseg, s->Soffset);
 #endif

--- a/src/msc.c
+++ b/src/msc.c
@@ -164,6 +164,7 @@ symbol *symboldata(targ_size_t offset,tym_t ty)
     symbol *s = symbol_generate(SClocstat, type_fake(ty));
     s->Sfl = FLdata;
     s->Soffset = offset;
+    s->Stype->Tmangle = mTYman_d; // writes symbol unmodified in Obj::mangle
     symbol_keep(s);             // keep around
     return s;
 }

--- a/test/runnable/testconstsection.d
+++ b/test/runnable/testconstsection.d
@@ -1,0 +1,61 @@
+
+string tls_var = "tls_string";
+
+__gshared string data_var = "data_string";
+
+__gshared string bss_var;
+
+struct Range
+{
+    const(void)* bot;
+    const(void)* top; // consider inclusive
+    
+    void addPtr(const(void)* p)
+    {
+        if (!bot || p < bot)
+            bot = p;
+        if (!top || p > top)
+            top = p;
+    }
+    
+    bool intersect(Range other)
+    {
+        return (bot <= other.top && top >= other.bot);
+    }
+}
+
+void testStrings()
+{
+    // check that the strings don't overlap with the variables
+    Range tls;
+    Range data;
+    Range bss;
+    Range cdata;
+
+    static string local_tls_var = "tls_string";
+    static __gshared string local_data_var = "data_string";
+    static __gshared string local_bss_var;
+    
+    tls.addPtr(&tls_var);
+    tls.addPtr(&local_tls_var);
+
+    data.addPtr(&data_var);
+    data.addPtr(&local_data_var);
+
+    bss.addPtr(&bss_var);
+    bss.addPtr(&local_bss_var);
+
+    cdata.addPtr(tls_var.ptr);
+    cdata.addPtr(local_tls_var.ptr);
+    cdata.addPtr(data_var.ptr);
+    cdata.addPtr(local_data_var.ptr);
+
+    assert(!cdata.intersect(tls),  "overlap with tls");
+    assert(!cdata.intersect(data), "overlap with data");
+    assert(!cdata.intersect(bss),  "overlap with bss");
+}
+
+void main()
+{
+    testStrings();
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=4650

This implements OMF and COFF versions of the ELF functionionality to write strings and float constants to a separate section in the binary image to allow skipping these during GC scanning.

For OMF, the data is written to a "CONST" section, while for COFF, the ".rdata" section is used similar to C++.
COFF also adds symbols for the beginning of the D generated data and bss sections so that the runtime can restrict scanning to these and exclude data from C linkage.

Long term, this should extend to other const data aswell.
