### PR TITLE
partially revert pull 4390

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -552,10 +552,17 @@ symbol * Obj::sym_cdata(tym_t ty,char *p,int len)
 
 int Obj::data_readonly(char *p, int len, int *pseg)
 {
+#if MARS
     targ_size_t oldoff = CDoffset;
     Obj::bytes(CDATA,CDoffset,len,p);
     CDoffset += len;
     *pseg = CDATA;
+#else
+    targ_size_t oldoff = Doffset;
+    Obj::bytes(DATA,Doffset,len,p);
+    Doffset += len;
+    *pseg = DATA;
+#endif
     return oldoff;
 }
 

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -371,8 +371,10 @@ void outdata(symbol *s)
 #else
                 /*else*/ if (dt->DTseg == DATA)
                     objmod->reftodatseg(seg,offset,dt->DTabytes,DATA,flags);
+#if MARS
                 else if (dt->DTseg == CDATA)
                     objmod->reftodatseg(seg,offset,dt->DTabytes,CDATA,flags);
+#endif
                 else
                     objmod->reftofarseg(seg,offset,dt->DTabytes,dt->DTseg,flags);
 #endif
@@ -1436,7 +1438,7 @@ symbol *out_readonly_sym(tym_t ty, void *p, int len)
 
     symbol *s;
 
-#if ELFOBJ || OMFOBJ /* includes COFF */
+#if ELFOBJ || (OMFOBJ && MARS) /* includes COFF */
     /* MACHOBJ can't go here, because the const data segment goes into
      * the _TEXT segment, and one cannot have a fixup from _TEXT to _TEXT.
      */


### PR DESCRIPTION
https://github.com/D-Programming-Language/dmd/pull/4390 caused failures in the DMC++ test suite, so this is a partial reversion for the DMC++ back end, while leaving the DMD code intact. Should not affect DMD at all.

I don't know yet why 4390 fails for DMC++, but this gets it working again.
