### PR TITLE
Issue 13485 - FP wrong-code with -O

### DIFF
--- a/src/backend/glocal.c
+++ b/src/backend/glocal.c
@@ -213,6 +213,7 @@ Loop:
                         if (em->Eoper == op &&
                             em->E1->EV.sp.Vsym == s &&
                             tysize(em->Ety) == tysize(e1->Ety) &&
+                            !tyfloating(em->Ety) &&
                             em->E1->EV.sp.Voffset == e1->EV.sp.Voffset &&
                             !el_sideeffect(em->E2)
                            )

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1187,6 +1187,22 @@ void test13190()
 
 ////////////////////////////////////////////////////////////////////////
 
+double foo13485(double c, double d)
+{
+    // This must not be optimized to c += (d + d)
+    c += d;
+    c += d;
+    return c;
+}
+
+void test13485()
+{
+    enum double d = 0X1P+1023;
+    assert(foo13485(-d, d) == d);
+}
+
+////////////////////////////////////////////////////////////////////////
+
 void test12833a(int a)
 {
     long x = cast(long)a;
@@ -1294,6 +1310,7 @@ int main()
     testshrshl();
     test13383();
     test13190();
+    test13485();
     test10639();
     test10715();
     test10678();


### PR DESCRIPTION
Converting `x += a; x += b` to `x += a + b;` is not valid with floating point types in D.

I'm assuming it is valid with fastfloat enabled, @WalterBright ?

https://issues.dlang.org/show_bug.cgi?id=13485
