### PR TITLE
[REG2.066] Issue 14155 - A defect in DIP29: the return value of some pure functions cannot be unique pointer

### DIFF
--- a/test/runnable/implicit.d
+++ b/test/runnable/implicit.d
@@ -232,6 +232,26 @@ void test14155_for_testDIP29_4()
 }
 
 /***********************************/
+// 14141
+
+struct S14141
+{
+    Object obj;
+
+    const(Object) getObj() const pure
+    {
+        return obj;
+    }
+}
+
+void test14141()
+{
+    const S14141 s;
+    static assert(is(typeof(s.getObj()) == const Object));           // ok
+    static assert(!__traits(compiles, { Object o = s.getObj(); }));  // ok <- fails
+}
+
+/***********************************/
 
 int[] test6(int[] a) pure @safe nothrow
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14155
