### PR TITLE
Add lazy to the list of banned things for static[]

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2979,7 +2979,7 @@ Type *TypeFunction::semantic(Loc loc, Scope *sc)
                 {
                     if (tf->linkage != LINKc)
                     {
-                        error(loc, "cannot have out or ref parameter of type %s", t->toChars());
+                        error(loc, "cannot have out, ref or lazy parameter of type %s", t->toChars());
                     }
                     else
                     {


### PR DESCRIPTION
This message is also emitted if you try to use a lazy static array.

e.g. void f(lazy char[5] s) {};
