### PR TITLE
mark synchronized as nothrow

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -4246,14 +4246,14 @@ Statement *SynchronizedStatement::semantic(Scope *sc)
         Parameters* args = new Parameters;
         args->push(new Parameter(0, t->pointerTo(), NULL, NULL));
 
-        FuncDeclaration *fdenter = FuncDeclaration::genCfunc(args, Type::tvoid, Id::criticalenter);
+        FuncDeclaration *fdenter = FuncDeclaration::genCfunc(args, Type::tvoid, Id::criticalenter, STCnothrow);
         Expression *e = new DotIdExp(loc, new VarExp(loc, tmp), Id::ptr);
         e = e->semantic(sc);
         e = new CallExp(loc, new VarExp(loc, fdenter), e);
         e->type = Type::tvoid;                  // do not run semantic on e
         cs->push(new ExpStatement(loc, e));
 
-        FuncDeclaration *fdexit = FuncDeclaration::genCfunc(args, Type::tvoid, Id::criticalexit);
+        FuncDeclaration *fdexit = FuncDeclaration::genCfunc(args, Type::tvoid, Id::criticalexit, STCnothrow);
         e = new DotIdExp(loc, new VarExp(loc, tmp), Id::ptr);
         e = e->semantic(sc);
         e = new CallExp(loc, new VarExp(loc, fdexit), e);

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -941,6 +941,13 @@ void test36()
     }
 }
 
+void test36b() @nogc nothrow
+{
+    synchronized
+    {
+    }
+}
+
 /* ================================ */
 int test37()
 {


### PR DESCRIPTION
- also added @nogc as test-case
- not @safe/pure because the mutex is __gshared data
