### PR TITLE
[REG2.064] Issue 13009 - inout overload conflicts with non-inout when used via alias this

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -607,6 +607,7 @@ public:
     int findVtblIndex(Dsymbols *vtbl, int dim);
     bool overloadInsert(Dsymbol *s);
     FuncDeclaration *overloadExactMatch(Type *t);
+    FuncDeclaration *overloadModMatch(Loc loc, Type *tthis, Type *&t);
     TemplateDeclaration *findTemplateDeclRoot();
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration *g);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -930,7 +930,7 @@ bool arrayTypeCompatibleWithoutCasting(Loc loc, Type *t1, Type *t2);
 void MODtoBuffer(OutBuffer *buf, MOD mod);
 char *MODtoChars(MOD mod);
 bool MODimplicitConv(MOD modfrom, MOD modto);
-bool MODmethodConv(MOD modfrom, MOD modto);
+MATCH MODmethodConv(MOD modfrom, MOD modto);
 MOD MODmerge(MOD mod1, MOD mod2);
 
 #endif /* DMD_MTYPE_H */

--- a/src/template.c
+++ b/src/template.c
@@ -1351,13 +1351,11 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(
             unsigned char thismod = tthis->mod;
             if (hasttp)
                 mod = MODmerge(thismod, mod);
-            if (thismod != mod)
-            {
-                if (!MODmethodConv(thismod, mod))
-                    goto Lnomatch;
-                if (MATCHconst < match)
-                    match = MATCHconst;
-            }
+            MATCH m = MODmethodConv(thismod, mod);
+            if (m <= MATCHnomatch)
+                goto Lnomatch;
+            if (m < match)
+                match = m;
         }
     }
 

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1753,6 +1753,56 @@ void test11355()
 }
 
 /***************************************************/
+// 13009
+
+struct T13009
+{
+    void put(char c) {}
+}
+
+struct S13009
+{
+    T13009 t;
+
+    @property
+    T13009 getT()
+    {
+        return t;
+    }
+
+    @property
+    inout(T13009) getT() inout
+    {
+        return t;
+    }
+
+    alias getT this;
+}
+
+void test13009()
+{
+    alias MS   =                    S13009;
+    alias CS   =              const(S13009);
+    alias WS   =        inout(      S13009);
+    alias WCS  =        inout(const S13009);
+    alias SMS  = shared(            S13009);
+    alias SCS  = shared(      const S13009);
+    alias SWS  = shared(inout       S13009);
+    alias SWCS = shared(inout const S13009);
+    alias IS   =          immutable(S13009);
+
+    alias MSput  = MS .put;
+    alias CSput  = CS .put;
+    alias WSput  = WS .put;
+    alias WCSput = WCS.put;
+    static assert(!__traits(compiles, { alias SMSput  = SMS .put; }));
+    static assert(!__traits(compiles, { alias SCSput  = SCS .put; }));
+    static assert(!__traits(compiles, { alias SWSput  = SWS .put; }));
+    static assert(!__traits(compiles, { alias SWCSput = SWCS.put; }));
+    alias ISput  = IS .put;
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13009

Considering better match for the overloaded alias this without valid this expression is a new feature.
(The issue case was accidentally worked since 2.063.)

`FuncDeclaration::overloadModMatch` comes from #2130. 
