### PR TITLE
Fixed bug 14195: Added C++ mangling for passing function signatures

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -1138,8 +1138,18 @@ public:
 
     void visit(TypeFunction *type)
     {
-        // We can mangle pointer to a function, not function.
-        visit((Type*)type);
+        const char *arg = mangleFunctionType(type);
+
+        if ((flags & IS_DMC))
+        {
+            if (checkTypeSaved(type)) return;
+        }
+        else
+        {
+            buf.writestring("$$A6");
+        }
+        buf.writestring(arg);
+        flags &= ~(IS_NOT_TOP_TYPE | IGNORE_CONST);
     }
 
     void visit(TypeStruct *type)

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -708,6 +708,32 @@ extern(C++, N13337.M13337)
 }
 
 /****************************************/
+// 14195
+
+struct Delegate1(T) {}
+struct Delegate2(T1, T2) {}
+
+template Signature(T)
+{
+    alias Signature = typeof(*(T.init));
+}
+
+extern(C++)
+{
+    alias del1_t = Delegate1!(Signature!(void function()));
+    alias del2_t = Delegate2!(Signature!(int function(float, double)), Signature!(int function(float, double)));
+    void test14195a(del1_t);
+    void test14195b(del2_t);
+}
+
+void test14195()
+{
+    test14195a(del1_t());
+    test14195b(del2_t());
+}
+
+
+/****************************************/
 
 void main()
 {
@@ -736,6 +762,7 @@ void main()
     func13707();
     func13932(S13932!(-1)(0));
     foo13337(S13337());
+    test14195();
 
     printf("Success\n");
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -454,4 +454,23 @@ namespace N13337 {
   }
 }
 
+/****************************************/
+// 14195
+
+template <typename T>
+struct Delegate1 {};
+
+template <typename R1>
+struct Delegate1 < R1() > {};
+
+template <typename T1, typename T2>
+struct Delegate2 {};
+
+template < typename R1, typename T1, typename T2, typename R2, typename T3, typename T4 >
+struct Delegate2<R1(T1, T2), R2(T3, T4)> {};
+
+void test14195a(Delegate1<void()> func) {}
+
+void test14195b(Delegate2<int(float, double), int(float, double)> func) {}
+
 /******************************************/


### PR DESCRIPTION
Added support for mangling the C++ equivalent type of:

``` c++
template <typename T>
struct Delegate1 {};

template <typename R1>
struct Delegate1 < R1() > {};

template <typename T1, typename T2>
struct Delegate2 {};

template < typename R1, typename T1, typename T2, typename R2, typename T3, typename T4 >
struct Delegate2<R1(T1, T2), R2(T3, T4)> {};

void test14195a(Delegate1<void()> func){}

void test14195b(Delegate2<int(float, double), int(float, double)> func){}
```

The corresponding D code can be found in cppmangle.d. I hit this issue when trying to bind a C++ Delegate implementation to D.
