### PR TITLE
fatal error LNK1235: corrupt or invalid COFF symbol table - Fix Issue 14201

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -374,7 +374,7 @@ void too_many_symbols()
 #if SCPP
     err_fatal(EM_too_many_symbols, 0x7FFF);
 #elif TARGET_WINDOS // COFF
-    error(NULL, 0, 0, "more than %d symbols in object file", 65279);
+    error(NULL, 0, 0, "more than %d sections in object file", 65279);
     fatal();    
 #else // MARS
     error(NULL, 0, 0, "more than %d symbols in object file", 0x7FFF);

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -373,6 +373,9 @@ void too_many_symbols()
 {
 #if SCPP
     err_fatal(EM_too_many_symbols, 0x7FFF);
+#elif TARGET_WINDOS // COFF
+    error(NULL, 0, 0, "more than %d symbols in object file", 65279);
+    fatal();    
 #else // MARS
     error(NULL, 0, 0, "more than %d symbols in object file", 0x7FFF);
     fatal();

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -373,9 +373,6 @@ void too_many_symbols()
 {
 #if SCPP
     err_fatal(EM_too_many_symbols, 0x7FFF);
-#elif TARGET_WINDOS // COFF
-    error(NULL, 0, 0, "more than %d sections in object file", 65279);
-    fatal();    
 #else // MARS
     error(NULL, 0, 0, "more than %d symbols in object file", 0x7FFF);
     fatal();

--- a/src/backend/mscoff.h
+++ b/src/backend/mscoff.h
@@ -12,16 +12,23 @@
 
 struct filehdr
 {
-        unsigned short f_magic; // identifies type of target machine
+        unsigned short f_sig1;      // IMAGE_FILE_MACHINE_UNKNOWN
+        unsigned short f_sig2;      // 0xFFFF
+        unsigned short f_minver;    // 2
+        unsigned short f_magic;     // identifies type of target machine
+        unsigned long f_timdat;     // creation date, number of seconds since 1970
+        unsigned char f_uuid[16];   //  { '\xc7', '\xa1', '\xba', '\xd1', '\xee', '\xba', '\xa9', '\x4b',
+                                    //    '\xaf', '\x20', '\xfa', '\xf6', '\x6a', '\xa4', '\xdc', '\xb8' };
+        unsigned long f_unused[4];  // { 0, 0, 0, 0 }
+        unsigned long f_nscns;      // number of sections
+        unsigned long f_symptr;     // file offset of symbol table
+        unsigned long f_nsyms;      // number of entries in the symbol table
+        
+        
 #define IMAGE_FILE_MACHINE_UNKNOWN 0            // applies to any machine type
 #define IMAGE_FILE_MACHINE_I386    0x14C        // x86
 #define IMAGE_FILE_MACHINE_AMD64   0x8664       // x86_64
-        unsigned short f_nscns; // number of sections (96 is max)
-        long f_timdat;        // creation date, number of seconds since 1970
-        long f_symptr;          // file offset of symbol table
-        long f_nsyms;           // number of entried in the symbol table
-        unsigned short f_opthdr; // optional header size (0)
-        unsigned short f_flags;
+
 #define IMAGE_FILE_RELOCS_STRIPPED              1
 #define IMAGE_FILE_EXECUTABLE_IMAGE             2
 #define IMAGE_FILE_LINE_NUMS_STRIPPED           4
@@ -111,7 +118,7 @@ struct syment
 #define n_nptr          _n._n_nptr[1]
 
     unsigned n_value;
-    short n_scnum;
+    long n_scnum;
 #define IMAGE_SYM_DEBUG                 -2
 #define IMAGE_SYM_ABSOLUTE              -1
 #define IMAGE_SYM_UNDEFINED             0
@@ -198,6 +205,7 @@ union auxent
         unsigned TotalSize;
         unsigned PointerToLinenumber;
         unsigned PointerToNextFunction;
+        unsigned short Zeros;
     } x_fd;
 
     // .bf symbols
@@ -208,6 +216,7 @@ union auxent
         unsigned short Linenumber;
         char filler[6];
         unsigned PointerToNextFunction;
+        unsigned short Zeros;
 #pragma pack()
     } x_bf;
 
@@ -215,30 +224,31 @@ union auxent
     struct
     {   unsigned Unused;
         unsigned short Linenumber;
+        unsigned short Zeros;
     } x_ef;
 
     // Weak externals
     struct
     {   unsigned TagIndex;
         unsigned Characteristics;
+        unsigned short Zeros;
 #define IMAGE_WEAK_EXTERN_SEARCH_NOLIBRARY
 #define IMAGE_WEAK_EXTERN_SEARCH_LIBRARY
 #define IMAGE_WEAK_EXTERN_SEARCH_ALIAS
     } x_weak;
 
-    // Files
-    struct
-    {   char FileName[18];
-    } x_filename;
-
     // Section definitions
     struct
-    {   unsigned length;
+    {   
+        unsigned length;
         unsigned short NumberOfRelocations;
         unsigned short NumberOfLinenumbers;
         unsigned CheckSum;
-        unsigned short Number;
+        unsigned short NumberLowPart;
         unsigned char Selection;
+        unsigned char Unused;
+        unsigned short NumberHighPart;
+        unsigned short Zeros;
 #define IMAGE_COMDAT_SELECT_NODUPLICATES        1
 #define IMAGE_COMDAT_SELECT_ANY                 2
 #define IMAGE_COMDAT_SELECT_SAME_SIZE           3

--- a/src/backend/mscoff.h
+++ b/src/backend/mscoff.h
@@ -46,6 +46,17 @@ struct filehdr
 #define IMAGE_FILE_BYTES_REVERSED_HI            0x8000
 };
 
+struct filehdr_old
+{
+        unsigned short f_magic; // identifies type of target machine
+        unsigned short f_nscns; // number of sections (96 is max)
+        long f_timdat;        // creation date, number of seconds since 1970
+        long f_symptr;          // file offset of symbol table
+        long f_nsyms;           // number of entried in the symbol table
+        unsigned short f_opthdr; // optional header size (0)
+        unsigned short f_flags;
+};
+
 /***********************************************/
 
 // size should be 40 bytes
@@ -136,6 +147,23 @@ struct syment
     unsigned char n_numaux;
 };
 
+
+struct syment_old
+{
+    union
+    {
+        char _n_name[SYMNMLEN];
+        struct
+        {   long _n_zeroes;
+            long _n_offset;
+        } _n_n;
+    } _n;
+    unsigned n_value;
+    short n_scnum;
+    unsigned short n_type;      // 0x20 function; 0x00 not a function
+    unsigned char n_sclass;
+    unsigned char n_numaux;
+};
 
 /***********************************************/
 

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -1582,7 +1582,8 @@ segidx_t MsCoffObj::getsegment2(IDXSEC shtidx)
     return seg;
 }
 
-extern void too_many_symbols();
+extern void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
+extern void fatal();
 
 /********************************************
  * Add new scnhdr.
@@ -1604,7 +1605,10 @@ IDXSEC MsCoffObj::addScnhdr(const char *scnhdr_name, unsigned long flags)
         memcpy(sec.s_name, scnhdr_name, len);
     sec.s_flags = flags;
     ScnhdrBuf->write((void *)&sec, sizeof(sec));
-    if (scnhdr_cnt > 65279) too_many_symbols();
+    if (scnhdr_cnt > 65279) {
+        error(NULL, 0, 0, "more than %d sections in object file", 65279);
+        fatal();   
+    }
     return ++scnhdr_cnt;
 }
 
@@ -1724,7 +1728,6 @@ segidx_t MsCoffObj::seg_debugS_comdat(symbol *sfunc)
     segidx_t seg = MsCoffObj::getsegment(".debug$S", IMAGE_SCN_CNT_INITIALIZED_DATA |
                                           IMAGE_SCN_ALIGN_1BYTES |
                                           IMAGE_SCN_MEM_READ |
-                                          IMAGE_SCN_LNK_COMDAT |
                                           IMAGE_SCN_MEM_DISCARDABLE);
     SegData[seg]->SDassocseg = sfunc->Sseg;
     return seg;

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -1582,6 +1582,8 @@ segidx_t MsCoffObj::getsegment2(IDXSEC shtidx)
     return seg;
 }
 
+extern void too_many_symbols();
+
 /********************************************
  * Add new scnhdr.
  * Returns:
@@ -1602,6 +1604,7 @@ IDXSEC MsCoffObj::addScnhdr(const char *scnhdr_name, unsigned long flags)
         memcpy(sec.s_name, scnhdr_name, len);
     sec.s_flags = flags;
     ScnhdrBuf->write((void *)&sec, sizeof(sec));
+    if (scnhdr_cnt > 65279) too_many_symbols();
     return ++scnhdr_cnt;
 }
 

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -596,7 +596,7 @@ void build_syment_table()
         sym.n_sclass = IMAGE_SYM_CLASS_STATIC;
         sym.n_numaux = 1;
 
-        assert(sizeof(sym) == 18);
+        assert(sizeof(sym) == 20);
         syment_buf->write(&sym, sizeof(sym));
 
         union auxent aux;
@@ -614,17 +614,19 @@ void build_syment_table()
 
         if (psechdr->s_flags & IMAGE_SCN_LNK_COMDAT)
         {
-            aux.x_section.Selection = IMAGE_COMDAT_SELECT_ANY;
+            aux.x_section.Selection = (unsigned char)IMAGE_COMDAT_SELECT_ANY;
             if (pseg->SDassocseg)
-            {   aux.x_section.Selection = IMAGE_COMDAT_SELECT_ASSOCIATIVE;
-                aux.x_section.Number = pseg->SDassocseg;
+            {   aux.x_section.Selection = (unsigned char)IMAGE_COMDAT_SELECT_ASSOCIATIVE;
+                aux.x_section.NumberHighPart = (unsigned short)pseg->SDassocseg >> 16;
+                aux.x_section.NumberLowPart = (unsigned short)pseg->SDassocseg & 0x0000FFFF;
             }
         }
+        
+        memset(&aux.x_section.Zeros, 0, 2);
 
         syment_buf->write(&aux, sizeof(aux));
-        //printf("%d %d %d %d %d %d\n", sizeof(aux.x_fd), sizeof(aux.x_bf), sizeof(aux.x_ef),
-        //     sizeof(aux.x_weak), sizeof(aux.x_filename), sizeof(aux.x_section));
-        assert(sizeof(aux) == 18);
+        
+        assert(sizeof(aux) == 20);
     }
 
     /* Add symbols from symbuf[]
@@ -758,17 +760,23 @@ void MsCoffObj::term(const char *objfilename)
     // Write out the bytes for the header
 
     struct filehdr header;
-
+    
+    header.f_sig1 = IMAGE_FILE_MACHINE_UNKNOWN;
+    header.f_sig2 = 0xFFFF;
+    header.f_minver = 2;
     header.f_magic = I64 ? IMAGE_FILE_MACHINE_AMD64 : IMAGE_FILE_MACHINE_I386;
     header.f_nscns = scnhdr_cnt;
     time_t f_timedat = 0;
     time(&f_timedat);
-    header.f_timdat = (long)f_timedat;
+    header.f_timdat = (unsigned long)f_timedat;
     header.f_symptr = 0;        // offset to symbol table
     header.f_nsyms = 0;
-    header.f_opthdr = 0;
-    header.f_flags = 0;
-
+    unsigned char uuid[16] = { '\xc7', '\xa1', '\xba', '\xd1', '\xee', '\xba', '\xa9', '\x4b',
+                                '\xaf', '\x20', '\xfa', '\xf6', '\x6a', '\xa4', '\xdc', '\xb8' };
+    memcpy(header.f_uuid, uuid, 16);
+    memset(header.f_unused, 0, sizeof(header.f_unused));
+    
+    
     foffset = sizeof(header);       // start after header
 
     foffset += ScnhdrBuf->size();   // section headers
@@ -1605,10 +1613,6 @@ IDXSEC MsCoffObj::addScnhdr(const char *scnhdr_name, unsigned long flags)
         memcpy(sec.s_name, scnhdr_name, len);
     sec.s_flags = flags;
     ScnhdrBuf->write((void *)&sec, sizeof(sec));
-    if (scnhdr_cnt > 65279) {
-        error(NULL, 0, 0, "more than %d sections in object file", 65279);
-        fatal();   
-    }
     return ++scnhdr_cnt;
 }
 
@@ -1728,6 +1732,7 @@ segidx_t MsCoffObj::seg_debugS_comdat(symbol *sfunc)
     segidx_t seg = MsCoffObj::getsegment(".debug$S", IMAGE_SCN_CNT_INITIALIZED_DATA |
                                           IMAGE_SCN_ALIGN_1BYTES |
                                           IMAGE_SCN_MEM_READ |
+                                          IMAGE_SCN_LNK_COMDAT |
                                           IMAGE_SCN_MEM_DISCARDABLE);
     SegData[seg]->SDassocseg = sfunc->Sseg;
     return seg;

--- a/src/scanmscoff.c
+++ b/src/scanmscoff.c
@@ -60,7 +60,21 @@ void scanMSCoffObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, 
     }
 
     struct filehdr *header = (struct filehdr *)buf;
-
+    char is_old_coff = false;
+    if (header->f_sig2 != 0xFFFF) {
+        is_old_coff = true;
+        struct filehdr_old *header_old;
+        header_old = (filehdr_old *) malloc(sizeof(filehdr_old));
+        memcpy(header_old, buf, sizeof(filehdr_old));
+        memset(header, 0, sizeof(filehdr));
+        header->f_magic = header_old->f_magic;
+        header->f_nscns = header_old->f_nscns;
+        header->f_timdat = header_old->f_timdat;
+        header->f_symptr = header_old->f_symptr;
+        header->f_nsyms = header_old->f_nsyms;
+        free(header_old);
+    }
+    
     switch (header->f_magic)
     {
         case IMAGE_FILE_MACHINE_UNKNOWN:
@@ -85,7 +99,7 @@ void scanMSCoffObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, 
         error(loc, "MS-Coff object module %s has no string table", module_name);
         return;
     }
-    off += header->f_nsyms * sizeof(struct syment);
+    off += header->f_nsyms * (is_old_coff?sizeof(struct syment_old):sizeof(struct syment));
     if (off + 4 > buflen)
     {   reason = __LINE__;
         goto Lcorrupt;
@@ -99,19 +113,35 @@ void scanMSCoffObjModule(void* pctx, void (*pAddSymbol)(void* pctx, char* name, 
     string_len -= 4;
 
     for (int i = 0; i < header->f_nsyms; i++)
-    {   struct syment *n;
+    {   
+        struct syment *n;
+        
         char s[8 + 1];
         char *p;
 
 #if LOG
         printf("Symbol %d:\n",i);
 #endif
-        off = header->f_symptr + i * sizeof(*n);
+        off = header->f_symptr + i * (is_old_coff?sizeof(syment_old):sizeof(syment));
         if (off > buflen)
         {   reason = __LINE__;
             goto Lcorrupt;
         }
+        
         n = (struct syment *)(buf + off);
+        
+        if (is_old_coff) {
+            struct syment_old *n2;
+            n2 = (syment_old *) malloc(sizeof(syment_old));
+            memcpy(n2, (buf + off), sizeof(syment_old));
+            
+            memcpy(n, n2, sizeof(n2->_n));
+            n->n_value = n2->n_value;
+            n->n_scnum = n2->n_scnum;
+            n->n_type = n2->n_type;
+            n->n_numaux = n2->n_numaux;            
+            free(n2);
+        }
         if (n->n_zeroes)
         {   strncpy(s,n->n_name,8);
             s[SYMNMLEN] = 0;


### PR DESCRIPTION
When debugging [this](https://issues.dlang.org/show_bug.cgi?id=14201), I found about 20k sections for `.debug$S` in the COFF table. My program has 50k sections so these are taking all the space when they shouldn't be. I found that they were being forcefully created in `getsegment` even for release builds, whereas the function should have simply returned the index to the section ID, which is always 1 for the COFF format.

Thus, I removed a flag `IMAGE_SCN_LNK_COMDAT` that forced the creation of redundant `.debug$S` sections.

Additionally, I added an assertion test to avoid others to run into this error, because it should have thrown a `too_many_symbols` error rather than spit out a corrupt COFF symbol table.

I pulled the maximum number of sections from here: http://llvm.org/docs/doxygen/html/Support_2COFF_8h_source.html

There is no simple test case for this due to the nature of the error being caused by large numbers of symbols. However, you can experience it by compiling [Botan](https://github.com/etcimon/botan) on win64 with `dub test --arch=x86_64`

The patched compiler successfully runs all cryptography tests with druntime, phobos and botan compiled anew on win64, rather than failing with the linker error.
