### PR TITLE
[DDMD] Add workaround for issue 14203

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3767,11 +3767,13 @@ elem *toElem(Expression *e, IRState *irs)
                 switch (elem->type->toBasetype()->ty)
                 {
                     case Tfloat32:
-                        ((targ_float *)&e->EV.Vcent)[i] = elem->toReal();
+                        // Must not call toReal directly, to avoid dmd bug 14203 from breaking ddmd
+                        ((targ_float *)&e->EV.Vcent)[i] = creall(elem->toComplex());
                         break;
 
                     case Tfloat64:
-                        ((targ_double *)&e->EV.Vcent)[i] = elem->toReal();
+                        // Must not call toReal directly, to avoid dmd bug 14203 from breaking ddmd
+                        ((targ_double *)&e->EV.Vcent)[i] = creall(elem->toComplex());
                         break;
 
                     case Tint64:


### PR DESCRIPTION
On win32, in dmc, `toReal` returns via memory and pass a pointer to it in eax.  In dmd, they return via `ST(0)`.

By avoiding calling `toReal` directly from the glue layer we avoid crossing the language boundary.

This bug only shows up when cross-compiling win32->win64, because this bit of code is the only place that uses `toReal` from the glue layer and is for vector types not available on win32.

https://issues.dlang.org/show_bug.cgi?id=14203
