### PR TITLE
Issue 14211 - Compiler should devirtualize calls to members of final class

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3417,7 +3417,6 @@ elem *toElem(Expression *e, IRState *irs)
             elem *ehidden = irs->ehidden;
             irs->ehidden = NULL;
 
-            int directcall = 0;
             elem *ec;
             FuncDeclaration *fd = NULL;
             bool dctor = false;
@@ -3427,26 +3426,6 @@ elem *toElem(Expression *e, IRState *irs)
 
                 fd = dve->var->isFuncDeclaration();
 
-                Expression *ex = dve->e1;
-                while (1)
-                {
-                    switch (ex->op)
-                    {
-                        case TOKsuper:          // super.member() calls directly
-                        case TOKdottype:        // type.member() calls directly
-                            directcall = 1;
-                            break;
-
-                        case TOKcast:
-                            ex = ((CastExp *)ex)->e1;
-                            continue;
-
-                        default:
-                            //ex->dump(0);
-                            break;
-                    }
-                    break;
-                }
                 if (dve->e1->op == TOKstructliteral)
                 {
                     StructLiteralExp *sle = (StructLiteralExp *)dve->e1;
@@ -3494,7 +3473,8 @@ elem *toElem(Expression *e, IRState *irs)
 
 
                 if (dctor)
-                { }
+                {
+                }
                 else if (ce->arguments && ce->arguments->dim && ec->Eoper != OPvar)
                 {
                     if (ec->Eoper == OPind && el_sideeffect(ec->E1))
@@ -3583,7 +3563,7 @@ elem *toElem(Expression *e, IRState *irs)
                     }
                 }
             }
-            elem *ecall = callfunc(ce->loc, irs, directcall, ce->type, ec, ectype, fd, t1, ehidden, ce->arguments);
+            elem *ecall = callfunc(ce->loc, irs, ce->directcall, ce->type, ec, ectype, fd, t1, ehidden, ce->arguments);
 
             if (dctor && ecall->Eoper == OPind)
             {

--- a/src/expression.h
+++ b/src/expression.h
@@ -878,6 +878,7 @@ class CallExp : public UnaExp
 public:
     Expressions *arguments;     // function arguments
     FuncDeclaration *f;         // symbol to call
+    bool directcall;            // true if a virtual call is devirtualized
 
     CallExp(Loc loc, Expression *e, Expressions *exps);
     CallExp(Loc loc, Expression *e);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4609,19 +4609,8 @@ public:
 
         Expression *pthis = NULL;
         FuncDeclaration *fd = NULL;
-        bool directcall = false;
 
-        Expression *ecall = e->e1;
-        if (ecall->op == TOKdotvar)
-        {
-            // Check that is a direct call
-            DotVarExp *dve = (DotVarExp *)ecall;
-            Expression *ex = dve->e1;
-            while (ex->op == TOKcast)
-                ex = ((CastExp *)ex)->e1;
-            directcall = (ex->op == TOKsuper || ex->op == TOKdottype);
-        }
-        ecall = interpret(ecall, istate);
+        Expression *ecall = interpret(e->e1, istate);
         if (exceptionOrCant(ecall))
             return;
 
@@ -4740,7 +4729,7 @@ public:
             }
             assert(pthis->op == TOKstructliteral || pthis->op == TOKclassreference);
 
-            if (fd->isVirtual() && !directcall)
+            if (fd->isVirtual() && !e->directcall)
             {
                 // Make a virtual function call.
                 // Get the function from the vtable of the original class

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7312,6 +7312,28 @@ class Foo14165
 }
 
 /***************************************************/
+// 14211
+
+extern(C++) // all derived classes won't have invariants
+class B14211
+{
+    void func()
+    {
+    }
+}
+
+final class C14211 : B14211
+{
+}
+
+void test14211()
+{
+    auto c = new C14211();
+    *cast(void**)c = null;
+    c.func();   // called without vtbl access
+}
+
+/***************************************************/
 
 int main()
 {
@@ -7614,6 +7636,7 @@ int main()
     test13472();
     test13476();
     test13952();
+    test14211();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14211

Add `CallExp::directcall` to handle devirtualizing of virtual function call in front-end.
It can also handle a direct call with `DotTypeExp` by the same logic.
