### PR TITLE
[DDMD] Clean up root\man.c to make conversion to D easier.

### DIFF
--- a/src/root/man.c
+++ b/src/root/man.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include "object.h"
 
 #if _WIN32
 
@@ -20,44 +21,10 @@
 
 void browse(const char *url)
 {
-    ShellExecute(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
+    ShellExecuteA(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
 }
 
-#endif
-
-#if __linux__ || __FreeBSD__ || __OpenBSD__ || __sun
-
-#include        <sys/types.h>
-#include        <sys/wait.h>
-#include        <unistd.h>
-
-void browse(const char *url)
-{
-    pid_t childpid;
-    const char *args[3];
-
-    const char *browser = getenv("BROWSER");
-    if (browser)
-        browser = strdup(browser);
-    else
-        browser = "x-www-browser";
-
-    args[0] = browser;
-    args[1] = url;
-    args[2] = NULL;
-
-    childpid = fork();
-    if (childpid == 0)
-    {
-        execvp(args[0], (char**)args);
-        perror(args[0]);                // failed to execute
-        return;
-    }
-}
-
-#endif
-
-#if __APPLE__
+#elif __APPLE__
 
 #include        <sys/types.h>
 #include        <sys/wait.h>
@@ -84,6 +51,36 @@ void browse(const char *url)
         args[3] = url;
         args[4] = NULL;
     }
+
+    childpid = fork();
+    if (childpid == 0)
+    {
+        execvp(args[0], (char**)args);
+        perror(args[0]);                // failed to execute
+        return;
+    }
+}
+
+#elif POSIX
+
+#include        <sys/types.h>
+#include        <sys/wait.h>
+#include        <unistd.h>
+
+void browse(const char *url)
+{
+    pid_t childpid;
+    const char *args[3];
+
+    const char *browser = getenv("BROWSER");
+    if (browser)
+        browser = strdup(browser);
+    else
+        browser = "x-www-browser";
+
+    args[0] = browser;
+    args[1] = url;
+    args[2] = NULL;
 
     childpid = fork();
     if (childpid == 0)


### PR DESCRIPTION
- Call `ShellExecuteA` directly as the alias isn't declared in `core.sys.windows.windows`
- Turn repeated if/endif into if/elif/elif/endif
- Reorder the cases so `version(Windows) else version(OSX) else version(posix)` can be used.

Usually the order wouldn't be a problem, but `version(A || B || C)` has to be done with static if, and as this is in root it doesn't have access to the identifiers the frontend uses for this.
