### PR TITLE
Use correct size for sizeTy[Tvector]

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -218,6 +218,7 @@ void Type::init()
     sizeTy[Treturn] = sizeof(TypeReturn);
     sizeTy[Terror] = sizeof(TypeError);
     sizeTy[Tnull] = sizeof(TypeNull);
+    sizeTy[Tvector] = sizeof(TypeVector);
 
     initTypeMangle();
 


### PR DESCRIPTION
This bug causes https://github.com/ldc-developers/ldc/issues/825 :
When using `Type::nullAttributes` to create a new `TypeVector`, it will read past the end of the source `TypeVector` if it was allocated using `new TypeVector` (i.e. the actual size is used for allocation) since `sizeof(TypeVector)` is less than `sizeof(TypeBasic)`.
