### PR TITLE
remove warnings about uninitialized variables

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -399,7 +399,7 @@ FuncDeclaration *hasIdentityOpEquals(AggregateDeclaration *ad,  Scope *sc)
         a->setDim(1);
         for (size_t i = 0; ; i++)
         {
-            Type *tthis;
+            Type *tthis = NULL;         // dead-store to prevent spurious warning
             if (i == 0) tthis = ad->type;
             if (i == 1) tthis = ad->type->constOf();
             if (i == 2) tthis = ad->type->immutableOf();

--- a/src/doc.c
+++ b/src/doc.c
@@ -547,7 +547,7 @@ static bool emitAnchorName(OutBuffer *buf, Dsymbol *s, Scope *sc)
         return dot;
     if (dot)
         buf->writeByte('.');
-    
+
     // Use "this" not "__ctor"
     TemplateDeclaration *td;
     if (s->isCtorDeclaration() || ((td = s->isTemplateDeclaration()) != NULL &&
@@ -1392,7 +1392,7 @@ void DocComment::parseSections(const utf8_t *comment)
     const utf8_t *p;
     const utf8_t *pstart;
     const utf8_t *pend;
-    const utf8_t *idstart;
+    const utf8_t *idstart = NULL;       // dead-store to prevent spurious warning
     size_t idlen;
 
     const utf8_t *name = NULL;

--- a/src/expression.c
+++ b/src/expression.c
@@ -1115,8 +1115,8 @@ bool arrayExpressionToCommonType(Scope *sc, Expressions *exps, Type **pt)
     CondExp condexp(Loc(), &integerexp, NULL, NULL);
 
     Type *t0 = NULL;
-    Expression *e0;
-    size_t j0;
+    Expression *e0 = NULL;      // dead-store to prevent spurious warning
+    size_t j0 = ~0;             // dead-store to prevent spurious warning
     for (size_t i = 0; i < exps->dim; i++)
     {
         Expression *e = (*exps)[i];

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -3672,7 +3672,7 @@ public:
     Expression *assignToLvalue(BinExp *e, Expression *e1, Expression *newval)
     {
         VarDeclaration *vd = NULL;
-        Expression **payload;
+        Expression **payload = NULL;    // dead-store to prevent spurious warning
         Expression *oldval;
 
         if (e1->op == TOKvar)
@@ -6310,7 +6310,7 @@ Expression *foreachApplyUtf(InterState *istate, Expression *str, Expression *del
     Expressions args;
     args.setDim(numParams);
 
-    Expression *eresult;
+    Expression *eresult = NULL;         // ded-store to prevent spurious warning
 
     // Buffers for encoding; also used for decoding array literals
     utf8_t utf8buf[4];

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -7750,7 +7750,7 @@ bool TypeStruct::needsNested()
 bool TypeStruct::isAssignable()
 {
     bool assignable = true;
-    unsigned offset;
+    unsigned offset = ~0;  // dead-store initialize to prevent spurious warning
 
     /* If any of the fields are const or immutable,
      * then one cannot assign this struct.
@@ -7816,7 +7816,7 @@ MATCH TypeStruct::implicitConvTo(Type *to)
                 /* Check all the fields. If they can all be converted,
                  * allow the conversion.
                  */
-                unsigned offset;
+                unsigned offset = ~0;   // dead-store to prevent spurious warning
                 for (size_t i = 0; i < sym->fields.dim; i++)
                 {
                     VarDeclaration *v = sym->fields[i];

--- a/src/template.c
+++ b/src/template.c
@@ -7260,7 +7260,7 @@ void TemplateInstance::semantic2(Scope *sc)
 
         int needGagging = (gagged && !global.gag);
         unsigned int olderrors = global.errors;
-        int oldGaggedErrors;
+        int oldGaggedErrors = -1;       // dead-store to prevent spurious warning
         if (needGagging)
             oldGaggedErrors = global.startGagging();
 
@@ -7319,7 +7319,7 @@ void TemplateInstance::semantic3(Scope *sc)
 
         int needGagging = (gagged && !global.gag);
         unsigned int olderrors = global.errors;
-        int oldGaggedErrors;
+        int oldGaggedErrors = -1;       // dead-store to prevent spurious warning
         /* If this is a gagged instantiation, gag errors.
          * Future optimisation: If the results are actually needed, errors
          * would already be gagged, so we don't really need to run semantic


### PR DESCRIPTION
Fixes these spurious warnings:

```
mtype.c: In member function 'virtual bool TypeStruct::isAssignable()':
mtype.c:7761: warning: 'offset' may be used uninitialized in this function
expression.c: In function 'bool arrayExpressionToCommonType(Scope*, Expressions*, Type**)':
expression.c:1119: warning: 'j0' may be used uninitialized in this function
expression.c:1118: warning: 'e0' may be used uninitialized in this function
doc.c: In member function 'void DocComment::parseSections(const utf8_t*)':
doc.c:1395: warning: 'idstart' may be used uninitialized in this function
template.c: In member function 'virtual void TemplateInstance::semantic3(Scope*)':
template.c:7373: warning: 'oldGaggedErrors' may be used uninitialized in this function
template.c: In member function 'virtual void TemplateInstance::semantic2(Scope*)':
template.c:7314: warning: 'oldGaggedErrors' may be used uninitialized in this function
mtype.c: In member function 'virtual MATCH TypeStruct::implicitConvTo(Type*)':
mtype.c:7827: warning: 'offset' may be used uninitialized in this function
clone.c: In function 'FuncDeclaration* hasIdentityOpEquals(AggregateDeclaration*, Scope*)':
clone.c:402: warning: 'tthis' may be used uninitialized in this function
interpret.c: In member function 'Expression* Interpreter::assignToLvalue(BinExp*, Expression*, Expression*)':
interpret.c:3675: warning: 'payload' may be used uninitialized in this function
interpret.c: In function 'Expression* foreachApplyUtf(InterState*, Expression*, Expression*, bool)':
interpret.c:6311: warning: 'eresult' may be used uninitialized in this function
```
