### PR TITLE
[REG2.055] Issue 12422 - Templated nested function is inferred as `pure` even if it calls impure functions

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -2397,6 +2397,10 @@ void Expression::checkPurity(Scope *sc, FuncDeclaration *f)
     {
         // The attributes of outerfunc should be inferred from the call of f.
     }
+    else if (f->isInstantiated())
+    {
+        // The attributes of f is inferred from its body.
+    }
     else if (f->isFuncLiteralDeclaration())
     {
         // The attributes of f is always inferred in its declared place.

--- a/test/fail_compilation/testInference.d
+++ b/test/fail_compilation/testInference.d
@@ -165,3 +165,17 @@ int* f14160() pure
 {
     return &g14160; // should be rejected
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/testInference.d(180): Error: pure function 'testInference.test12422' cannot call impure function 'testInference.test12422.bar12422!().bar12422'
+---
+*/
+int g12422;
+void foo12422() { ++g12422; }
+void test12422() pure
+{
+    void bar12422()() { foo12422(); }
+    bar12422();
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12422
