### PR TITLE
Issue 13064 - Redundant `auto` storage class is allowed for functions

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -918,7 +918,7 @@ void VarDeclaration::semantic(Scope *sc)
         }
     }
     if ((storage_class & STCauto) && !inferred)
-       error("storage class 'auto' has no effect if type is not inferred, did you mean 'scope'?");
+        error("storage class 'auto' has no effect if type is not inferred, did you mean 'scope'?");
 
     if (tb->ty == Ttuple)
     {

--- a/src/func.c
+++ b/src/func.c
@@ -631,6 +631,8 @@ void FuncDeclaration::semantic(Scope *sc)
     f = (TypeFunction *)type;
     size_t nparams = Parameter::dim(f->parameters);
 
+    if ((storage_class & STCauto) && !f->isref && !inferRetType)
+        error("storage class 'auto' has no effect if return type is not inferred");
     if (storage_class & STCscope)
         error("functions cannot be scope");
 

--- a/test/fail_compilation/fail13064.d
+++ b/test/fail_compilation/fail13064.d
@@ -1,0 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13064.d(8): Error: function fail13064.f storage class 'auto' has no effect if return type is not inferred
+---
+*/
+
+auto void f() { }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13064
