### PR TITLE
fix Issue 14199 - [REG2.067a] Dwarf Error: mangled line number section

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -111,7 +111,7 @@ void dwarf_addrel64(int seg, targ_size_t offset, int targseg, targ_size_t val)
 void dwarf_appreladdr(int seg, Outbuffer *buf, int targseg, targ_size_t val)
 {
     dwarf_addrel64(seg, buf->size(), targseg, I64 ? val : 0);
-    buf->write64(I64 ? 0 : val);
+    I64 ? buf->write64(0) : buf->write32(val);
 }
 
 void dwarf_apprel32(int seg, Outbuffer *buf, int targseg, targ_size_t val)


### PR DESCRIPTION
- wrong sized address was used for 32-bit DWARF

[Issue 14199 – [REG2.067a] Dwarf Error: mangled line number section](https://issues.dlang.org/show_bug.cgi?id=14199)
