### PR TITLE
Fix: .sh tests should manually create an .out file

### DIFF
--- a/test/compilable/ddoc9764.sh
+++ b/test/compilable/ddoc9764.sh
@@ -8,4 +8,4 @@ rm -f ${output_file}
 
 $DMD -m${MODEL} -D -o- compilable/extra-files/ddoc9764.dd -Df${output_file}
 
-compilable/extra-files/ddocAny-postscript.sh 9764
+compilable/extra-files/ddocAny-postscript.sh 9764 && touch ${dir}/`basename $0`.out

--- a/test/compilable/test6461.sh
+++ b/test/compilable/test6461.sh
@@ -2,7 +2,7 @@
 
 name=`basename $0 .sh`
 dir=${RESULTS_DIR}/compilable
-src=compilable/extra-files/test6461
+src=compilable/extra-files/${name}
 
 if [ "${OS}" == "win32" -o "${OS}" == "win64" ]; then
     LIBEXT=.lib
@@ -17,5 +17,5 @@ $DMD -m${MODEL} -od${dir} -I${src} ${src}/main.d ${dir}/a${LIBEXT} ${dir}/b${LIB
 
 rm -f ${dir}/{a${LIBEXT} b${LIBEXT} main${EXE} main${OBJ}}
 
-echo Success >${dir}/test6461.sh.out
+echo Success >${dir}/`basename $0`.out
 

--- a/test/compilable/test9680.sh
+++ b/test/compilable/test9680.sh
@@ -25,5 +25,7 @@ do
 		exit 1;
 	fi
 
-	rm ${output_file}.2
+	rm ${output_file}{,.2}
 done
+
+echo Success >${dir}/`basename $0`.out


### PR DESCRIPTION
Some .sh tests keep running over and over, because they don't generate an .out file in the `RESULTS_DIR`. By manually creating an .out file (as some tests already appear to be doing) the passed tests will be skipped on subsequent runs.
