### PR TITLE
[REG] fix Issue 14232 : redundant attribute 'const'

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -930,9 +930,12 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
 
 /*********************************************
  * Give error on redundant/conflicting storage class.
+ * 
+ * TODO: remove deprecation in 2.068 and keep only error
  */
 
-StorageClass Parser::appendStorageClass(StorageClass storageClass, StorageClass stc)
+StorageClass Parser::appendStorageClass(StorageClass storageClass, StorageClass stc,
+    bool deprec)
 {
     if ((storageClass & stc) ||
         (storageClass & STCin && stc & (STCconst | STCscope)) ||
@@ -942,7 +945,10 @@ StorageClass Parser::appendStorageClass(StorageClass storageClass, StorageClass 
         StorageClassDeclaration::stcToCBuffer(&buf, stc);
         if (buf.data[buf.offset - 1] == ' ')
             buf.data[buf.offset - 1] = '\0';
-        error("redundant attribute '%s'", buf.peekString());
+        if (deprec)
+            deprecation("redundant attribute '%s'", buf.peekString(), deprec);
+        else
+            error("redundant attribute '%s'", buf.peekString(), deprec);
         return storageClass | stc;
     }
 
@@ -952,19 +958,19 @@ StorageClass Parser::appendStorageClass(StorageClass storageClass, StorageClass 
     {
         StorageClass u = storageClass & (STCconst | STCimmutable | STCmanifest);
         if (u & (u - 1))
-            error("conflicting attribute '%s'", Token::toChars(token.value));
+            error("conflicting attribute '%s'", Token::toChars(token.value), deprec);
     }
     if (stc & (STCgshared | STCshared | STCtls))
     {
         StorageClass u = storageClass & (STCgshared | STCshared | STCtls);
         if (u & (u - 1))
-            error("conflicting attribute '%s'", Token::toChars(token.value));
+            error("conflicting attribute '%s'", Token::toChars(token.value), deprec);
     }
     if (stc & (STCsafe | STCsystem | STCtrusted))
     {
         StorageClass u = storageClass & (STCsafe | STCsystem | STCtrusted);
         if (u & (u - 1))
-            error("conflicting attribute '@%s'", token.toChars());
+            error("conflicting attribute '@%s'", token.toChars(), deprec);
     }
 
     return storageClass;
@@ -1080,7 +1086,7 @@ StorageClass Parser::parsePostfix(StorageClass storageClass, Expressions **pudas
             default:
                 return storageClass;
         }
-        storageClass = appendStorageClass(storageClass, stc);
+        storageClass = appendStorageClass(storageClass, stc, true);
         nextToken();
     }
 }

--- a/src/parse.h
+++ b/src/parse.h
@@ -79,7 +79,7 @@ public:
     Dsymbols *parseDeclDefs(int once, Dsymbol **pLastDecl = NULL, PrefixAttributes *pAttrs = NULL);
     Dsymbols *parseAutoDeclarations(StorageClass storageClass, const utf8_t *comment);
     Dsymbols *parseBlock(Dsymbol **pLastDecl, PrefixAttributes *pAttrs = NULL);
-    StorageClass appendStorageClass(StorageClass storageClass, StorageClass stc);
+    StorageClass appendStorageClass(StorageClass storageClass, StorageClass stc, bool deprec = false);
     StorageClass parseAttribute(Expressions **pexps);
     StorageClass parsePostfix(StorageClass storageClass, Expressions **pudas);
     StorageClass parseTypeCtor();

--- a/test/fail_compilation/parseStc3.d
+++ b/test/fail_compilation/parseStc3.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc3.d(10): Error: redundant attribute 'pure'
-fail_compilation/parseStc3.d(11): Error: redundant attribute 'nothrow'
-fail_compilation/parseStc3.d(12): Error: redundant attribute '@nogc'
-fail_compilation/parseStc3.d(13): Error: redundant attribute '@property'
+fail_compilation/parseStc3.d(10): Deprecation: redundant attribute 'pure'
+fail_compilation/parseStc3.d(11): Deprecation: redundant attribute 'nothrow'
+fail_compilation/parseStc3.d(12): Deprecation: redundant attribute '@nogc'
+fail_compilation/parseStc3.d(13): Deprecation: redundant attribute '@property'
 ---
 */
 pure      void f1() pure      {}
@@ -16,9 +16,9 @@ nothrow   void f2() nothrow   {}
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc3.d(24): Error: redundant attribute '@safe'
-fail_compilation/parseStc3.d(25): Error: redundant attribute '@system'
-fail_compilation/parseStc3.d(26): Error: redundant attribute '@trusted'
+fail_compilation/parseStc3.d(24): Deprecation: redundant attribute '@safe'
+fail_compilation/parseStc3.d(25): Deprecation: redundant attribute '@system'
+fail_compilation/parseStc3.d(26): Deprecation: redundant attribute '@trusted'
 ---
 */
 @safe     void f6() @safe    {}
@@ -49,11 +49,11 @@ TEST_OUTPUT:
 fail_compilation/parseStc3.d(59): Error: conflicting attribute '@system'
 fail_compilation/parseStc3.d(59): Error: conflicting attribute '@trusted'
 fail_compilation/parseStc3.d(60): Error: conflicting attribute '@system'
-fail_compilation/parseStc3.d(60): Error: redundant attribute '@system'
+fail_compilation/parseStc3.d(60): Deprecation: redundant attribute '@system'
 fail_compilation/parseStc3.d(61): Error: conflicting attribute '@safe'
-fail_compilation/parseStc3.d(61): Error: redundant attribute '@system'
+fail_compilation/parseStc3.d(61): Deprecation: redundant attribute '@system'
 fail_compilation/parseStc3.d(62): Error: conflicting attribute '@safe'
-fail_compilation/parseStc3.d(62): Error: redundant attribute '@trusted'
+fail_compilation/parseStc3.d(62): Deprecation: redundant attribute '@trusted'
 ---
 */
 @safe @system  void f15() @trusted {}

--- a/test/fail_compilation/parseStc4.d
+++ b/test/fail_compilation/parseStc4.d
@@ -2,11 +2,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc4.d(14): Error: redundant attribute 'pure'
-fail_compilation/parseStc4.d(14): Error: redundant attribute 'nothrow'
+fail_compilation/parseStc4.d(14): Deprecation: redundant attribute 'pure'
+fail_compilation/parseStc4.d(14): Deprecation: redundant attribute 'nothrow'
 fail_compilation/parseStc4.d(14): Error: conflicting attribute '@system'
-fail_compilation/parseStc4.d(14): Error: redundant attribute '@nogc'
-fail_compilation/parseStc4.d(14): Error: redundant attribute '@property'
+fail_compilation/parseStc4.d(14): Deprecation: redundant attribute '@nogc'
+fail_compilation/parseStc4.d(14): Deprecation: redundant attribute '@property'
 ---
 */
 pure nothrow @safe   @nogc @property
@@ -19,12 +19,12 @@ pure nothrow @system @nogc @property
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc4.d(34): Error: redundant attribute 'const'
-fail_compilation/parseStc4.d(35): Error: redundant attribute 'const'
-fail_compilation/parseStc4.d(36): Error: redundant attribute 'const'
-fail_compilation/parseStc4.d(38): Error: redundant attribute 'pure'
-fail_compilation/parseStc4.d(39): Error: redundant attribute '@safe'
-fail_compilation/parseStc4.d(40): Error: redundant attribute 'nothrow'
+fail_compilation/parseStc4.d(34): Deprecation: redundant attribute 'const'
+fail_compilation/parseStc4.d(35): Deprecation: redundant attribute 'const'
+fail_compilation/parseStc4.d(36): Deprecation: redundant attribute 'const'
+fail_compilation/parseStc4.d(38): Deprecation: redundant attribute 'pure'
+fail_compilation/parseStc4.d(39): Deprecation: redundant attribute '@safe'
+fail_compilation/parseStc4.d(40): Deprecation: redundant attribute 'nothrow'
 fail_compilation/parseStc4.d(41): Error: conflicting attribute '@trusted'
 ---
 */


### PR DESCRIPTION
During the refactoring of redundant/conflicting attribute handling
code postfix redundance was turned into error skipping deprecation
stage. This adds deprecation warning for one release.
