### PR TITLE
[DDMD] Add casts to allow conversion to foreach

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1358,7 +1358,7 @@ int ctfeCmpArrays(Loc loc, Expression *e1, Expression *e2, uinteger_t len)
     // If they aren't strings, we just need an equality check rather than
     // a full cmp.
     bool needCmp = ae1->type->nextOf()->isintegral();
-    for (size_t i = 0; i < len; i++)
+    for (size_t i = 0; i < (size_t)len; i++)
     {
         Expression *ee1 = (*ae1->elements)[(size_t)(lo1 + i)];
         Expression *ee2 = (*ae2->elements)[(size_t)(lo2 + i)];

--- a/src/traits.c
+++ b/src/traits.c
@@ -385,7 +385,7 @@ Expression *pointerBitmap(TraitsExp *e)
             d_uns64 arrayoff = offset;
             d_uns64 nextsize = t->next->size();
             d_uns64 dim = t->dim->toInteger();
-            for (size_t i = 0; i < dim; i++)
+            for (d_uns64 i = 0; i < dim; i++)
             {
                 offset = arrayoff + i * nextsize;
                 t->next->accept(this);


### PR DESCRIPTION
For some reason foreach requires that the upper limit converts to the variable type, the allows these fors to be auto-converted to foreach
