### PR TITLE
[cleanup] Remove writeln call from idgen

### DIFF
--- a/src/idgen.d
+++ b/src/idgen.d
@@ -359,11 +359,6 @@ Msgtable[] msgtable =
 int main()
 {
     {
-        import std.stdio : writeln;
-        writeln("Generating id.c and id.h");
-    }
-
-    {
         auto fp = fopen("id.h","w");
         if (!fp)
         {


### PR DESCRIPTION
I added this when debugging autotester problems and forgot to remove it.
