### PR TITLE
Add tool to check for whitespace errors

### DIFF
--- a/src/checkwhitespace.d
+++ b/src/checkwhitespace.d
@@ -1,0 +1,33 @@
+
+import std.stdio;
+import std.file;
+import std.string;
+import std.range;
+import std.regex;
+import std.algorithm;
+
+int main(string[] args)
+{
+    bool error;
+    auto r = regex(r" +\n");
+    foreach(a; args[1..$])
+    {
+        auto str = a.readText();
+        if (str.canFind("\r\n"))
+        {
+            writefln("Error - file '%s' contains windows line endings", a);
+            error = true;
+        }
+        if (str.canFind('\t'))
+        {
+            writefln("Error - file '%s' contains tabs", a);
+            error = true;
+        }
+        if (!str.matchFirst(r).empty)
+        {
+            writefln("Error - file '%s' contains trailing whitespace", a);
+            error = true;
+        }
+    }
+    return error ? 1 : 0;
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -403,6 +403,11 @@ install: all
 
 ######################################################
 
+checkwhitespace:
+	$(HOST_DC) -run checkwhitespace $(SRC) $(GLUE_SRC) $(ROOT_SRC)
+
+######################################################
+
 gcov:
 	gcov access.c
 	gcov aliasthis.c

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -364,6 +364,8 @@ pvs:
 #	$(PVS) --cfg PVS-Studio.cfg --cl-params /I$C;$(TK) /Tp $(BACKSRC) --source-file $(BACKSRC)
 #	$(PVS) --cfg PVS-Studio.cfg --cl-params /I$(TK) /Tp $(TKSRCC) --source-file $(TKSRCC)
 
+checkwhitespace:
+	$(HOST_DC) -run checkwhitespace $(SRCS) $(GLUESRC) $(ROOTSRC)
 
 ############################## Generated Source ##############################
 


### PR DESCRIPTION
This pull request takes advantage of the new host dmd requirement to add a short, portable utility that checks for whitespace errors in dmd's source.  Ideally the autotester will run this automatically, permanently preventing these errors from creeping back in.

Current output:

```
Error - file 'cast.c' contains trailing whitespace
Error - file 'access.c' contains trailing whitespace
Error - file 'traits.c' contains trailing whitespace
Error - file 'scanmscoff.c' contains trailing whitespace
```
