### PR TITLE
Add parser and some semantic support for gdc extended asm statements

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -192,6 +192,7 @@ public:
             visitStmt(s->statement);
     }
     void visit(AsmStatement *s) {  }
+    void visit(ExtAsmStatement *s) {  }
     void visit(ImportStatement *s) {  }
 };
 

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -636,6 +636,64 @@ public:
         buf->writenl();
     }
 
+    void visit(ExtAsmStatement *s)
+    {
+        buf->writestring("asm { ");
+
+        if (s->insn)
+            buf->writestring(s->insn->toChars());
+
+        buf->writestring(" : ");
+
+        if (s->args)
+        {
+            for (size_t i = 0; i < s->args->dim; i++)
+            {
+                Identifier *name = (*s->names)[i];
+                Expression *constr = (*s->constraints)[i];
+                Expression *arg = (*s->args)[i];
+
+                if (name)
+                {
+                    buf->writestring("[");
+                    buf->writestring(name->toChars());
+                    buf->writestring("] ");
+                }
+
+                if (constr)
+                {
+                    buf->writestring(constr->toChars());
+                    buf->writestring(" ");
+                }
+
+                if (arg)
+                    buf->writestring(arg->toChars());
+
+                if (i < s->outputargs - 1)
+                    buf->writestring(", ");
+                else if (i == s->outputargs - 1)
+                    buf->writestring(" : ");
+                else if (i < s->args->dim - 1)
+                    buf->writestring(", ");
+            }
+        }
+
+        if (s->clobbers)
+        {
+            buf->writestring(" : ");
+            for (size_t i = 0; i < s->clobbers->dim; i++)
+            {
+                Expression *clobber = (*s->clobbers)[i];
+                buf->writestring(clobber->toChars());
+                if (i < s->clobbers->dim - 1)
+                    buf->writestring (", ");
+            }
+        }
+
+        buf->writestring("; }");
+        buf->writenl();
+    }
+
     void visit(ImportStatement *s)
     {
         for (size_t i = 0; i < s->imports->dim; i++)

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -683,6 +683,14 @@ public:
         // we can't compile asm statements
     }
 
+    void visit(ExtAsmStatement *s)
+    {
+    #if LOGCOMPILE
+        printf("%s ExtAsmStatement::ctfeCompile\n", s->loc.toChars());
+    #endif
+        // we can't compile ext asm statements
+    }
+
     void ctfeCompile(Statement *s)
     {
         s->accept(this);
@@ -1935,6 +1943,22 @@ public:
         }
 
         s->error("asm statements cannot be interpreted at compile time");
+        result = CTFEExp::cantexp;
+    }
+
+    void visit(ExtAsmStatement *s)
+    {
+    #if LOG
+        printf("%s ExtAsmStatement::interpret()\n", s->loc.toChars());
+    #endif
+        if (istate->start)
+        {
+            if (istate->start != s)
+                return;
+            istate->start = NULL;
+        }
+
+        s->error("extended asm statements cannot be interpreted at compile time");
         result = CTFEExp::cantexp;
     }
 

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -1857,7 +1857,8 @@
                 "struct LabelDsymbol",
                 "struct AsmStatement",
                 "struct CompoundAsmStatement",
-                "struct ImportStatement"
+                "struct ImportStatement",
+                "struct ExtAsmStatement"
             ]
         },
         {

--- a/src/parse.h
+++ b/src/parse.h
@@ -126,6 +126,10 @@ public:
     void checkCstyleTypeSyntax(Loc loc, Type *t, int alt, Identifier *ident);
     /** endPtr used for documented unittests */
     Statement *parseStatement(int flags, const utf8_t** endPtr = NULL, Loc *pEndloc = NULL);
+    Statement *parseExtAsm();
+    int parseExtAsmOperands(Expressions *args, Identifiers *names, Expressions *constraints);
+    Expressions *parseExtAsmClobbers();
+    Identifiers *parseExtAsmGotoLabels();
     Initializer *parseInitializer();
     Expression *parseDefaultInitExp();
     void check(Loc loc, TOK value);

--- a/src/statement.h
+++ b/src/statement.h
@@ -770,4 +770,26 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+// Assembler instructions with D expression operands
+class ExtAsmStatement : public Statement
+{
+public:
+    Expression *insn;
+    Expressions *args;
+    Identifiers *names;
+    Expressions *constraints;   // Array of StringExp's
+    int outputargs;
+    Expressions *clobbers;      // Array of StringExp's
+    Identifiers *labels;
+    GotoStatements *gotos;
+
+    ExtAsmStatement(Loc loc, Expression *insn, Expressions *args,
+                    Identifiers *names, Expressions *constraints,
+                    int outputargs, Expressions *clobbers, Identifiers *labels);
+    Statement *syntaxCopy();
+    Statement *semantic(Scope *sc);
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 #endif /* DMD_STATEMENT_H */

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -54,6 +54,7 @@ class LabelStatement;
 class AsmStatement;
 class CompoundAsmStatement;
 class ImportStatement;
+class ExtAsmStatement;
 
 class Type;
 class TypeError;
@@ -341,6 +342,7 @@ public:
     virtual void visit(AsmStatement *s) { visit((Statement *)s); }
     virtual void visit(CompoundAsmStatement *s) { visit((CompoundStatement *)s); }
     virtual void visit(ImportStatement *s) { visit((Statement *)s); }
+    virtual void visit(ExtAsmStatement *s) { visit((Statement *)s); }
 
     virtual void visit(Type *) { assert(0); }
     virtual void visit(TypeError *t) { visit((Type *)t); }

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -671,6 +671,18 @@ private           bool[9] r12506a = f12506!(i => true)(); // OK
 private immutable bool[9] r12506b = f12506!(i => true)(); // OK <- error
 
 /***************************************************/
+// GDC extended asm statements should parse
+
+void testGDCasm()
+{
+    version(none)
+    {
+        asm { "notl %[iov]" : [iov] "=r" result : "0" v; }
+        asm { "nor %[oresult],%[iv],%[iv]" : [oresult] "=r" result : [iv] "r" v; }
+    }
+}
+
+/***************************************************/
 // 12555
 
 class A12555(T)


### PR DESCRIPTION
@ibuclaw @klickverbot GDC is the only one that uses this, right?  This is a large chunk of the remaining differences in #2194
