### PR TITLE
Issue 14264 - Destructor not called when struct is returned from a parenthesis-less function call

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -824,8 +824,8 @@ Statement *ExpStatement::semantic(Scope *sc)
 #endif
 
         exp = exp->semantic(sc);
-        exp = exp->addDtorHook(sc);
         exp = resolveProperties(sc, exp);
+        exp = exp->addDtorHook(sc);
         discardValue(exp);
         exp = exp->optimize(WANTvalue);
         exp = checkGC(sc, exp);
@@ -2849,8 +2849,8 @@ Statement *IfStatement::semantic(Scope *sc)
     else
     {
         condition = condition->semantic(sc);
-        condition = condition->addDtorHook(sc);
         condition = resolveProperties(sc, condition);
+        condition = condition->addDtorHook(sc);
     }
     condition = checkGC(sc, condition);
 

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -3703,6 +3703,38 @@ void test13095()
 }
 
 /**********************************/
+// 14264
+
+void test14264()
+{
+    static int dtor;
+    static struct Foo
+    {
+        ~this() { ++dtor; }
+        T opCast(T:bool)() { return true; }
+    }
+
+    Foo makeFoo()
+    {
+        return Foo();
+    }
+
+    assert(dtor == 0);
+
+    makeFoo();
+    assert(dtor == 1);
+
+    makeFoo;
+    assert(dtor == 2);
+
+    if (makeFoo()) {}
+    assert(dtor == 3);
+
+    if (makeFoo) {}
+    assert(dtor == 4);
+}
+
+/**********************************/
 
 int main()
 {
@@ -3815,6 +3847,7 @@ int main()
     test14023();
     test13669();
     test13095();
+    test14264();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14264
