### PR TITLE
Fix issue 14275 : qualified package protection for aggregate member doesn't work

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -190,12 +190,12 @@ bool checkAccess(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember)
     Prot access;
     if (smemberparent == ad)
     {
-        Prot access2 = smember->prot();
-        result = access2.kind >= PROTpublic ||
-                hasPrivateAccess(ad, f) ||
-                isFriendOf(ad, cdscope) ||
-                (access2.kind == PROTpackage && hasPackageAccess(sc, ad)) ||
-                ad->getAccessModule() == sc->module;
+        access = smember->prot();
+        result = access.kind >= PROTpublic ||
+                 hasPrivateAccess(ad, f) ||
+                 isFriendOf(ad, cdscope) ||
+                 (access.kind == PROTpackage && hasPackageAccess(sc, smember)) ||
+                 ad->getAccessModule() == sc->module;
 #if LOG
         printf("result1 = %d\n", result);
 #endif

--- a/test/compilable/protection/aggregate/mod14275.d
+++ b/test/compilable/protection/aggregate/mod14275.d
@@ -1,0 +1,11 @@
+module protection.aggregate.mod14275;
+
+public struct Foo
+{
+    package(protection) void foo() {}
+    package void foo2() {}
+}
+
+package(protection) void bar()
+{
+}

--- a/test/compilable/protection/bug/bug14275.d
+++ b/test/compilable/protection/bug/bug14275.d
@@ -1,0 +1,12 @@
+module protection.bug.bug14275;
+
+import protection.aggregate.mod14275;
+
+// https://issues.dlang.org/show_bug.cgi?id=14275
+
+void main() {
+    Foo f;
+    f.foo();
+    static assert (!is(typeof(f.foo2())));
+    bar();
+}

--- a/test/compilable/test14275.d
+++ b/test/compilable/test14275.d
@@ -1,0 +1,4 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+import protection.bug.bug14275;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14275

When checking protection of aggregate member symbol, DMD previosuly checked
protection of aggregate itself, assuming it has same protection. Those need
to be done separately.

I have not yet figured out how it is better to setup development DMD with new idgen dependency, so will abuse auto-tester a bit, sorry for that :)
