### PR TITLE
Run idgen only when necessary

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -307,8 +307,9 @@ $(optabgen_output) : optabgen
 idgen_output = id.h id.c
 $(idgen_output) : idgen
 
-idgen : idgen.d
-	$(HOST_DC) -run idgen
+idgen: idgen.d
+	$(HOST_DC) idgen.d
+	./idgen
 
 ######### impcnvgen generates some source
 


### PR DESCRIPTION
idgen is no longer a real target so was rebuilding every make (dmd -run idgen puts compiled code in tmp file).  Instead just rerun when idgen.d is newer than id.h or id.c.
