### PR TITLE
fix Issue 14253 - [REG2.067b3] std.traits.ParameterStorageClassTuple giv...

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6138,6 +6138,9 @@ int TypeFunction::attributesApply(void *param, int (*fp)(void *, const char *), 
     if (isref) res = fp(param, "ref");
     if (res) return res;
 
+    if (isreturn) res = fp(param, "return");
+    if (res) return res;
+
     TRUST trustAttrib = trust;
 
     if (trustAttrib == TRUSTdefault)

--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -443,3 +443,9 @@ pure clamp12266b(T1, T2, T3)(T1 x, T2 min_val, T3 max_val)
 
 // 13832
 alias Dg13832 = ref int delegate();
+
+struct S14253
+{
+    int x;
+    ref int foo() return { return x; }
+}

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -407,3 +407,8 @@ pure clamp12266b(T1, T2, T3)(T1 x, T2 min_val, T3 max_val)
 	return 0;
 }
 alias Dg13832 = ref int delegate();
+struct S14253
+{
+	int x;
+	ref int foo() return { return x; }
+}


### PR DESCRIPTION
...es compiler errors when encountering 'return' functions

I'll see if I can figure out a unittest for this, although Phobos tests it.
