### PR TITLE
[DDMD] Normalize implementations of sputl/sgetl and move them into Port

### DIFF
--- a/src/libmach.c
+++ b/src/libmach.c
@@ -151,22 +151,6 @@ void LibMach::addLibrary(void *buf, size_t buflen)
 /*****************************************************************************/
 /*****************************************************************************/
 
-void sputl(int value, void* buffer)
-{
-    unsigned char *p = (unsigned char*)buffer;
-    p[3] = (unsigned char)(value >> 24);
-    p[2] = (unsigned char)(value >> 16);
-    p[1] = (unsigned char)(value >> 8);
-    p[0] = (unsigned char)(value);
-}
-
-int sgetl(void* buffer)
-{
-    unsigned char *p = (unsigned char*)buffer;
-    return (((((p[3] << 8) | p[2]) << 8) | p[1]) << 8) | p[0];
-}
-
-
 struct ObjModule
 {
     unsigned char *base;        // where are we holding it in memory
@@ -417,7 +401,7 @@ void LibMach::addObject(const char *module_name, void *buf, size_t buflen)
          * go into the symbol table than we do.
          * This is also probably faster.
          */
-        unsigned nsymbols = sgetl(symtab) / 8;
+        unsigned nsymbols = Port::readlongLE(symtab) / 8;
         char *s = symtab + 4 + nsymbols * 8 + 4;
         if (4 + nsymbols * 8 + 4 > symtab_size)
         {   reason = __LINE__;
@@ -425,14 +409,14 @@ void LibMach::addObject(const char *module_name, void *buf, size_t buflen)
         }
         for (unsigned i = 0; i < nsymbols; i++)
         {
-            unsigned soff = sgetl(symtab + 4 + i * 8);
+            unsigned soff = Port::readlongLE(symtab + 4 + i * 8);
             char *name = s + soff;
             //printf("soff = x%x name = %s\n", soff, name);
             if (s + strlen(name) + 1 - symtab > symtab_size)
             {   reason = __LINE__;
                 goto Lcorrupt;
             }
-            unsigned moff = sgetl(symtab + 4 + i * 8 + 4);
+            unsigned moff = Port::readlongLE(symtab + 4 + i * 8 + 4);
             //printf("symtab[%d] moff = x%x  x%x, name = %s\n", i, moff, moff + sizeof(Header), name);
             for (unsigned m = mstart; 1; m++)
             {   if (m == objmodules.dim)
@@ -589,23 +573,23 @@ void LibMach::WriteLibToBuffer(OutBuffer *libbuf)
 
     char buf[4];
 
-    sputl(objsymbols.dim * 8, buf);
+    Port::writelongLE(objsymbols.dim * 8, buf);
     libbuf->write(buf, 4);
 
     int stringoff = 0;
     for (size_t i = 0; i < objsymbols.dim; i++)
     {   ObjSymbol *os = objsymbols[i];
 
-        sputl(stringoff, buf);
+        Port::writelongLE(stringoff, buf);
         libbuf->write(buf, 4);
 
-        sputl(os->om->offset, buf);
+        Port::writelongLE(os->om->offset, buf);
         libbuf->write(buf, 4);
 
         stringoff += strlen(os->name) + 1;
     }
 
-    sputl(stringoff, buf);
+    Port::writelongLE(stringoff, buf);
     libbuf->write(buf, 4);
 
     for (size_t i = 0; i < objsymbols.dim; i++)

--- a/src/module.c
+++ b/src/module.c
@@ -297,32 +297,6 @@ bool Module::read(Loc loc)
     return true;
 }
 
-inline unsigned readwordLE(unsigned short *p)
-{
-    return (((unsigned char *)p)[1] << 8) | ((unsigned char *)p)[0];
-}
-
-inline unsigned readwordBE(unsigned short *p)
-{
-    return (((unsigned char *)p)[0] << 8) | ((unsigned char *)p)[1];
-}
-
-inline unsigned readlongLE(unsigned *p)
-{
-    return ((unsigned char *)p)[0] |
-        (((unsigned char *)p)[1] << 8) |
-        (((unsigned char *)p)[2] << 16) |
-        (((unsigned char *)p)[3] << 24);
-}
-
-inline unsigned readlongBE(unsigned *p)
-{
-    return ((unsigned char *)p)[3] |
-        (((unsigned char *)p)[2] << 8) |
-        (((unsigned char *)p)[1] << 16) |
-        (((unsigned char *)p)[0] << 24);
-}
-
 void Module::parse()
 {
     //printf("Module::parse()\n");
@@ -368,7 +342,7 @@ void Module::parse()
                 for (pu += bom; pu < pumax; pu++)
                 {   unsigned u;
 
-                    u = le ? readlongLE(pu) : readlongBE(pu);
+                    u = le ? Port::readlongLE(pu) : Port::readlongBE(pu);
                     if (u & ~0x7F)
                     {
                         if (u > 0x10FFFF)
@@ -403,7 +377,7 @@ void Module::parse()
                 for (pu += bom; pu < pumax; pu++)
                 {   unsigned u;
 
-                    u = le ? readwordLE(pu) : readwordBE(pu);
+                    u = le ? Port::readwordLE(pu) : Port::readwordBE(pu);
                     if (u & ~0x7F)
                     {   if (u >= 0xD800 && u <= 0xDBFF)
                         {   unsigned u2;
@@ -412,7 +386,7 @@ void Module::parse()
                             {   error("surrogate UTF-16 high value %04x at EOF", u);
                                 fatal();
                             }
-                            u2 = le ? readwordLE(pu) : readwordBE(pu);
+                            u2 = le ? Port::readwordLE(pu) : Port::readwordBE(pu);
                             if (u2 < 0xDC00 || u2 > 0xDFFF)
                             {   error("surrogate UTF-16 low value %04x out of range", u2);
                                 fatal();

--- a/src/root/port.c
+++ b/src/root/port.c
@@ -1093,3 +1093,51 @@ longdouble Port::strtold(const char *p, char **endp)
 }
 
 #endif
+
+// Little endian
+void Port::writelongLE(unsigned value, void* buffer)
+{
+    unsigned char *p = (unsigned char*)buffer;
+    p[3] = (unsigned char)(value >> 24);
+    p[2] = (unsigned char)(value >> 16);
+    p[1] = (unsigned char)(value >> 8);
+    p[0] = (unsigned char)(value);
+}
+
+// Little endian
+unsigned Port::readlongLE(void* buffer)
+{
+    unsigned char *p = (unsigned char*)buffer;
+    return (((((p[3] << 8) | p[2]) << 8) | p[1]) << 8) | p[0];
+}
+
+// Big endian
+void Port::writelongBE(unsigned value, void* buffer)
+{
+    unsigned char *p = (unsigned char*)buffer;
+    p[0] = (unsigned char)(value >> 24);
+    p[1] = (unsigned char)(value >> 16);
+    p[2] = (unsigned char)(value >> 8);
+    p[3] = (unsigned char)(value);
+}
+
+// Big endian
+unsigned Port::readlongBE(void* buffer)
+{
+    unsigned char *p = (unsigned char*)buffer;
+    return (((((p[0] << 8) | p[1]) << 8) | p[2]) << 8) | p[3];
+}
+
+// Little endian
+unsigned Port::readwordLE(void *buffer)
+{
+    unsigned char *p = (unsigned char*)buffer;
+    return (p[1] << 8) | p[0];
+}
+
+// Big endian
+unsigned Port::readwordBE(void *buffer)
+{
+    unsigned char *p = (unsigned char*)buffer;
+    return (p[0] << 8) | p[1];
+}

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -68,6 +68,13 @@ struct Port
     static float strtof(const char *p, char **endp);
     static double strtod(const char *p, char **endp);
     static longdouble strtold(const char *p, char **endp);
+
+    static void writelongLE(unsigned value, void* buffer);
+    static unsigned readlongLE(void* buffer);
+    static void writelongBE(unsigned value, void* buffer);
+    static unsigned readlongBE(void* buffer);
+    static unsigned readwordLE(void* buffer);
+    static unsigned readwordBE(void* buffer);
 };
 
 #endif


### PR DESCRIPTION
`sputl` and `sgetl` are currently defined three times, sometimes little-endian and sometimes not.  This PR moves them all to Port and consistently uses `Port::*_big` for the big-endian versions.

This results in less code, less code duplication, and avoids multiple identically named functions which is a problem for DDMD.
