### PR TITLE
fix Issue 14225 - GDB: error reading variable (string + dup)

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1581,7 +1581,6 @@ unsigned dwarf_typidx(type *t)
     {
         DW_TAG_pointer_type,
         0,                      // no children
-        DW_AT_byte_size,        DW_FORM_data1,
         DW_AT_type,             DW_FORM_ref4,
         0,                      0,
     };
@@ -1589,7 +1588,6 @@ unsigned dwarf_typidx(type *t)
     {
         DW_TAG_pointer_type,
         0,                      // no children
-        DW_AT_byte_size,        DW_FORM_data1,
         0,                      0,
     };
 #ifdef USE_DWARF_D_EXTENSIONS
@@ -1715,7 +1713,6 @@ unsigned dwarf_typidx(type *t)
                 : dwarf_abbrev_code(abbrevTypePointerVoid, sizeof(abbrevTypePointerVoid));
             idx = infobuf->size();
             infobuf->writeuLEB128(code);        // abbreviation code
-            infobuf->writeByte(tysize(t->Tty)); // DW_AT_byte_size
             if (nextidx)
                 infobuf->write32(nextidx);      // DW_AT_type
             break;

--- a/test/runnable/gdb1.d
+++ b/test/runnable/gdb1.d
@@ -1,0 +1,16 @@
+/*
+REQUIRED_ARGS: -g
+PERMUTE_ARGS:
+GDB_SCRIPT:
+---
+b 15
+r ARG1 ARG2
+echo RESULT=
+p args
+---
+GDB_MATCH: RESULT=.*ARG1.*ARG2
+*/
+void main(string[] args)
+{
+    // BP
+}

--- a/test/runnable/gdb10311.d
+++ b/test/runnable/gdb10311.d
@@ -1,0 +1,20 @@
+/*
+REQUIRED_ARGS: -g
+PERMUTE_ARGS:
+GDB_SCRIPT:
+---
+b 19
+r
+echo RESULT=
+p x
+---
+GDB_MATCH: RESULT=.*33
+*/
+void call(void delegate() dg) { dg(); }
+
+void main()
+{
+    int x=32;
+    call({++x;});
+    // BP
+}

--- a/test/runnable/gdb14225.d
+++ b/test/runnable/gdb14225.d
@@ -1,0 +1,18 @@
+/*
+REQUIRED_ARGS: -g
+PERMUTE_ARGS:
+GDB_SCRIPT:
+---
+b 17
+r
+echo RESULT=
+p lok
+---
+GDB_MATCH: RESULT=.*Something
+*/
+void main()
+{
+    string lok = "Something";
+    auto chars = "Anything".dup;
+    // BP
+}

--- a/test/runnable/gdb4181.d
+++ b/test/runnable/gdb4181.d
@@ -1,0 +1,23 @@
+/*
+REQUIRED_ARGS: -g
+PERMUTE_ARGS:
+GDB_SCRIPT:
+---
+b 22
+r
+echo RESULT=
+p 'gdb.x' + 'gdb.STest.y'
+---
+GDB_MATCH: RESULT=.*33
+*/
+module gdb;
+
+int x;
+struct STest { static int y; }
+
+void main()
+{
+    x = 11;
+    STest.y = 22;
+    // BP
+}


### PR DESCRIPTION
- tysize(t->Tty) for TYref was -1
- fixed by omitting the explicit byte_size for pointers
- the debugger will use the address_size for the compilation
  unit instead

[Issue 14225 – [REG2.067a] GDB: error reading variable (string + dup)](https://issues.dlang.org/show_bug.cgi?id=14225)
