### PR TITLE
fix Issue 4149 - refs displayed as pointers in gdb

### DIFF
--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -2162,6 +2162,7 @@ L1:
 #endif
 #if MARS
         case TYref:
+        case TYnref:
             attribute |= 0x20;          // indicate reference pointer
             tym = TYnptr;               // convert to C data type
             goto L1;                    // and try again
@@ -2617,6 +2618,7 @@ STATIC void cv4_func(Funcsym *s)
 #endif
             case TYnullptr:
             case TYnptr:
+            case TYnref:
                 if (I32)
                     goto case_eax;
                 else
@@ -2926,5 +2928,3 @@ unsigned cv_typidx(type *t)
 }
 
 #endif // !SPP
-
-

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -571,6 +571,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
 #endif
         case TYnullptr:
         case TYnptr:
+        case TYnref:
 #if TARGET_SEGMENTED
         case TYsptr:
         case TYcptr:

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1592,6 +1592,13 @@ unsigned dwarf_typidx(type *t)
         DW_AT_byte_size,        DW_FORM_data1,
         0,                      0,
     };
+    static unsigned char abbrevTypeRef[] =
+    {
+        DW_TAG_reference_type,
+        0,                      // no children
+        DW_AT_type,             DW_FORM_ref4,
+        0,                      0,
+    };
 #ifdef USE_DWARF_D_EXTENSIONS
     static unsigned char abbrevTypeDArray[] =
     {
@@ -1886,6 +1893,14 @@ unsigned dwarf_typidx(type *t)
 
         case TYnref:
         case TYref:
+            nextidx = dwarf_typidx(t->Tnext);
+            assert(nextidx);
+            code = dwarf_abbrev_code(abbrevTypeRef, sizeof(abbrevTypeRef));
+            idx = infobuf->size();
+            infobuf->writeuLEB128(code);        // abbreviation code
+            infobuf->write32(nextidx);          // DW_AT_type
+            break;
+
         case TYnptr:
             if (!t->Tkey)
                 goto Lnptr;

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -2522,6 +2522,7 @@ L1:
 #endif
                     case TYnullptr:
                     case TYnptr:
+                    case TYnref:
 #if TARGET_SEGMENTED
                     case TYsptr:
                     case TYcptr:
@@ -2807,6 +2808,7 @@ L1:
 #endif
         case TYnptr:
         case TYnullptr:
+        case TYnref:
             if (NPTRSIZE == SHORTSIZE)
                 goto Ushort;
             if (NPTRSIZE == LONGSIZE)
@@ -3151,6 +3153,7 @@ case_tym:
 #endif
         case TYnullptr:
         case TYnptr:
+        case TYnref:
             if (NPTRSIZE == LONGSIZE)
                 goto L1;
             if (NPTRSIZE == SHORTSIZE)

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -201,6 +201,9 @@ int boolres(elem *e)
                 case TYnptr:
                     b = el_tolong(e) != 0;
                     break;
+                case TYnref: // reference can't be converted to bool
+                    assert(0);
+                    break;
                 case TYfloat:
                 case TYifloat:
                 case TYdouble:

--- a/src/backend/ty.h
+++ b/src/backend/ty.h
@@ -222,7 +222,7 @@ extern unsigned tytab[];
 
 #define tyaggregate(ty) (tytab[(ty) & 0xFF] & TYFLaggregate)
 
-#define tyscalar(ty)    (tytab[(ty) & 0xFF] & (TYFLintegral | TYFLreal | TYFLimaginary | TYFLcomplex | TYFLptr | TYFLmptr | TYFLnullptr))
+#define tyscalar(ty)    (tytab[(ty) & 0xFF] & (TYFLintegral | TYFLreal | TYFLimaginary | TYFLcomplex | TYFLptr | TYFLmptr | TYFLnullptr | TYFLref))
 
 #define tyfloating(ty)  (tytab[(ty) & 0xFF] & (TYFLreal | TYFLimaginary | TYFLcomplex))
 
@@ -233,7 +233,7 @@ extern unsigned tytab[];
 #define tyreal(ty)      (tytab[(ty) & 0xFF] & TYFLreal)
 
 // Fits into 64 bit register
-#define ty64reg(ty)     (tytab[(ty) & 0xFF] & (TYFLintegral | TYFLptr) && tysize(ty) <= NPTRSIZE)
+#define ty64reg(ty)     (tytab[(ty) & 0xFF] & (TYFLintegral | TYFLptr | TYFLref) && tysize(ty) <= NPTRSIZE)
 
 // Can go in XMM floating point register
 #if TX86
@@ -370,4 +370,3 @@ extern unsigned short dttab4[];
 #endif
 
 #endif /* TY_H */
-

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -134,8 +134,8 @@ Symbol *toSymbol(Dsymbol *s)
                 TYPE *t;
                 if (vd->storage_class & (STCout | STCref))
                 {
-                    // should be TYref, but problems in back end
-                    t = type_pointer(Type_toCtype(vd->type));
+                    t = type_allocn(TYnref, Type_toCtype(vd->type));
+                    t->Tcount++;
                 }
                 else if (vd->storage_class & STClazy)
                 {
@@ -149,8 +149,8 @@ Symbol *toSymbol(Dsymbol *s)
                 {
                     if (config.exe == EX_WIN64 && vd->type->size(Loc()) > REGSIZE)
                     {
-                        // should be TYref, but problems in back end
-                        t = type_pointer(Type_toCtype(vd->type));
+                        t = type_allocn(TYnref, Type_toCtype(vd->type));
+                        t->Tcount++;
                     }
                     else
                     {

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -85,7 +85,7 @@ public:
             Parameter *p = Parameter::getNth(t->parameters, i);
             type *tp = Type_toCtype(p->type);
             if (p->storageClass & (STCout | STCref))
-                tp = type_allocn(TYref, tp);
+                tp = type_allocn(TYnref, tp);
             else if (p->storageClass & STClazy)
             {
                 // Mangle as delegate


### PR DESCRIPTION
- use TYnref for reference variables
- emit dwarf debug info for references
- handle TY*ref in backend
- add TYFLref to tyscalar

[Issue 4149 – refs displayed as pointers in gdb](https://issues.dlang.org/show_bug.cgi?id=4149)
