### PR TITLE
fix Issue 14283 - spurious 'this' is not an lvalue deprecation for auto ref

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1617,7 +1617,14 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             }
             if (p->storageClass & STCref)
             {
-                arg = arg->toLvalue(sc, arg);
+                if (p->storageClass & STCauto &&
+                    (arg->op == TOKthis || arg->op == TOKsuper))
+                {
+                    // suppress deprecation message for auto ref parameter
+                    // temporary workaround for Bugzilla 14283
+                }
+                else
+                    arg = arg->toLvalue(sc, arg);
             }
             else if (p->storageClass & STCout)
             {

--- a/test/compilable/deprecate14283.d
+++ b/test/compilable/deprecate14283.d
@@ -1,0 +1,23 @@
+// REQUIRED_ARGS: -dw
+
+/*
+TEST_OUTPUT:
+---
+compilable/deprecate14283.d(17): Deprecation: this is not an lvalue
+compilable/deprecate14283.d(18): Deprecation: super is not an lvalue
+---
+*/
+
+class C
+{
+    void bug()
+    {
+        autoref(this); // suppress warning for auto ref
+        autoref(super); // suppress warning for auto ref
+        ref_(this); // still warns
+        ref_(super); // still warns
+    }
+}
+
+void autoref(T)(auto ref T t) {}
+void ref_(T)(ref T) {}


### PR DESCRIPTION
- suppress deprecation message for auto ref parameters as passing
  'this' to auto ref will remain correct when it becomes an rvalue
  and because it's very unlikely that the passing as ref argument
  was intentional

[Issue 14283 – Spurious "this is not an lvalue" deprecation message for "auto ref" arguments](https://issues.dlang.org/show_bug.cgi?id=14283)
