### PR TITLE
[REG 2.067] fix Issue 14133 - struct ctor init compiles very slow and produces excessive amounts of code

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3424,12 +3424,6 @@ elem *toElem(Expression *e, IRState *irs)
 
                 fd = dve->var->isFuncDeclaration();
 
-                if (dve->e1->op == TOKstructliteral)
-                {
-                    StructLiteralExp *sle = (StructLiteralExp *)dve->e1;
-                    sle->sinit = NULL;          // don't modify initializer
-                }
-
                 ec = toElem(dve->e1, irs);
                 ectype = dve->e1->type->toBasetype();
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -8440,7 +8440,6 @@ Lagain:
                  */
                 if (sd->size(loc) > Target::ptrsize * 4 && !t1->needsNested())
                     sle->sinit = toInitializer(sd);
-
                 sle->type = type;
 
                 Expression *e = sle;
@@ -8482,9 +8481,13 @@ Lagain:
             /* It's a struct literal
              */
         Lx:
-            Expression *e = new StructLiteralExp(loc, sd, arguments, e1->type);
-            e = e->semantic(sc);
-            return e;
+            StructLiteralExp *sle = new StructLiteralExp(loc, sd, arguments, e1->type);
+            /* Copy from the initializer symbol for larger symbols,
+             * otherwise the literals expressed as code get excessively large.
+             */
+            if (sd->size(loc) > Target::ptrsize * 4 && !t1->needsNested())
+                sle->sinit = toInitializer(sd);
+            return sle->semantic(sc);
         }
         else if (t1->ty == Tclass)
         {

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4751,6 +4751,16 @@ void test7502()
     s7502 = s7502.init;
 }
 
+struct S14133a
+{
+    size_t[16 * 1024] data;
+}
+
+void test14133()
+{
+    auto a = S14133a();
+}
+
 /***************************************************/
 
 void nextis(void delegate() dg = {}) {}
@@ -5782,7 +5792,7 @@ void test11265()
 
 struct TimeOfDay
 {
-    void roll(int value) 
+    void roll(int value)
     {
         value %= 60;
         auto newVal = _seconds + value;
@@ -6173,4 +6183,3 @@ int main()
     writefln("Success");
     return 0;
 }
-

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4756,9 +4756,19 @@ struct S14133a
     size_t[16 * 1024] data;
 }
 
+struct S14133b
+{
+    size_t[16 * 1024] data;
+    this(bool)
+    {
+    }
+}
+
 void test14133()
 {
     auto a = S14133a();
+    S14133b b;
+    b = S14133b(true);
 }
 
 /***************************************************/


### PR DESCRIPTION
- also use init array for default constructed struct literals
- don't kill struct literal initializer in e2ir.c
  - we now select the appropriate initializer in the frontend
  - this was added in 3f88f15, it's unclear why though

[Issue 14133 – [REG 2.067] struct ctor init compiles very slow and produces excessive amounts of code](https://issues.dlang.org/show_bug.cgi?id=14133)
