### PR TITLE
Fix1215

### DIFF
--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -416,7 +416,7 @@ Dsymbol *Dsymbol::search(Loc loc, Identifier *ident, int flags)
  * Search for symbol with correct spelling.
  */
 
-void *symbol_search_fp(void *arg, const char *seed, int* cost)
+void *symbol_search_fp(void *arg, const char *seed, int *cost)
 {
     /* If not in the lexer's string table, it certainly isn't in the symbol table.
      * Doing this first is a lot faster.
@@ -471,41 +471,41 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
             break;
 
         case DYNCAST_EXPRESSION:
+        {
+            Expression *expr = (Expression*)id;
+            TupleDeclaration *td = s->isTupleDeclaration();
+            if (!td)
             {
-                Expression* expr = (Expression*)id;
-                TupleDeclaration* td = s->isTupleDeclaration();
-                if (!td)
-                {
-                    error(loc, "expected TypeTuple when indexing ('[%s]'), got '%s'.",
-                          id->toChars(), s->toChars());
-                    return NULL;
-                }
-                sc = sc->startCTFE();
-                expr = expr->semantic(sc);
-                sc = sc->endCTFE();
+                error(loc, "expected TypeTuple when indexing ('[%s]'), got '%s'.",
+                      id->toChars(), s->toChars());
+                return NULL;
+            }
+            sc = sc->startCTFE();
+            expr = expr->semantic(sc);
+            sc = sc->endCTFE();
 
-                expr = expr->ctfeInterpret();
-                const uinteger_t d = expr->toUInteger();
+            expr = expr->ctfeInterpret();
+            const uinteger_t d = expr->toUInteger();
 
-                if (d >= td->objects->dim)
-                {
-                    error(loc, "tuple index %llu exceeds length %u", d, td->objects->dim);
-                    return NULL;
-                }
-                RootObject *o = (*td->objects)[(size_t)d];
-                if (o->dyncast() == DYNCAST_TYPE)
-                {
-                    sm = NULL;
-                    Type *t = (Type *)o;
-                    sm = t->toDsymbol(sc)->toAlias();
-                }
-                else
-                {
-                    assert(o->dyncast() == DYNCAST_DSYMBOL);
-                    sm = (Dsymbol *)o;
-                }
+            if (d >= td->objects->dim)
+            {
+                error(loc, "tuple index %llu exceeds length %u", d, td->objects->dim);
+                return NULL;
+            }
+            RootObject *o = (*td->objects)[(size_t)d];
+            if (o->dyncast() == DYNCAST_TYPE)
+            {
+                sm = NULL;
+                Type *t = (Type *)o;
+                sm = t->toDsymbol(sc)->toAlias();
+            }
+            else
+            {
+                assert(o->dyncast() == DYNCAST_DSYMBOL);
+                sm = (Dsymbol *)o;
             }
             break;
+        }
 
         case DYNCAST_DSYMBOL:
         {

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -445,7 +445,7 @@ Dsymbol *Dsymbol::search_correct(Identifier *ident)
 /*************************************
  * Take an index in a TypeTuple.
  */
-Dsymbol *Dsymbol::indexExpr(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *expr)
+Dsymbol *Dsymbol::takeTypeTupleIndex(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *indexExpr)
 {
     TupleDeclaration *td = s->isTupleDeclaration();
     if (!td)
@@ -455,11 +455,11 @@ Dsymbol *Dsymbol::indexExpr(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expr
         return NULL;
     }
     sc = sc->startCTFE();
-    expr = expr->semantic(sc);
+    indexExpr = indexExpr->semantic(sc);
     sc = sc->endCTFE();
 
-    expr = expr->ctfeInterpret();
-    const uinteger_t d = expr->toUInteger();
+    indexExpr = indexExpr->ctfeInterpret();
+    const uinteger_t d = indexExpr->toUInteger();
 
     if (d >= td->objects->dim)
     {
@@ -517,7 +517,7 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
             index->resolve(loc, sc, &expr, &t, &sym);
             if (expr)
             {
-                sm = indexExpr(loc, sc, s, id, expr);
+                sm = takeTypeTupleIndex(loc, sc, s, id, expr);
             }
             else if (t)
             {
@@ -533,7 +533,7 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
         }
 
         case DYNCAST_EXPRESSION:
-            sm = indexExpr(loc, sc, s, id, (Expression*)id);
+            sm = takeTypeTupleIndex(loc, sc, s, id, (Expression*)id);
             if (!sm)
             {
                 return NULL;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -509,7 +509,7 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
 
         case DYNCAST_TYPE:
         {
-            Type *index = (Type*)id;
+            Type *index = (Type *)id;
             Expression *expr = NULL;
             Type *t = NULL;
             Dsymbol *sym = NULL;
@@ -533,7 +533,7 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
         }
 
         case DYNCAST_EXPRESSION:
-            sm = takeTypeTupleIndex(loc, sc, s, id, (Expression*)id);
+            sm = takeTypeTupleIndex(loc, sc, s, id, (Expression *)id);
             if (!sm)
             {
                 return NULL;

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -445,7 +445,7 @@ Dsymbol *Dsymbol::search_correct(Identifier *ident)
 /*************************************
  * Take an index in a TypeTuple.
  */
-Dsymbol *Dsymbol::takeTypeTupleIndex(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *expr)
+Dsymbol *Dsymbol::indexExpr(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *expr)
 {
     TupleDeclaration *td = s->isTupleDeclaration();
     if (!td)
@@ -517,23 +517,23 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
             index->resolve(loc, sc, &expr, &t, &sym);
             if (expr)
             {
-                sm = takeTypeTupleIndex(loc, sc, s, id, expr);
+                sm = indexExpr(loc, sc, s, id, expr);
             }
             else if (t)
             {
-                index->error(loc, "Expected an expression as index, got a type (%s)", t->toChars());
+                index->error(loc, "expected an expression as index, got a type (%s)", t->toChars());
                 return NULL;
             }
             else
             {
-                index->error(loc, "index is not a an expression");
+                index->error(loc, "index is not an expression");
                 return NULL;
             }
             break;
         }
 
         case DYNCAST_EXPRESSION:
-            sm = takeTypeTupleIndex(loc, sc, s, id, (Expression*)id);
+            sm = indexExpr(loc, sc, s, id, (Expression*)id);
             if (!sm)
             {
                 return NULL;

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -279,6 +279,9 @@ public:
     virtual AttribDeclaration *isAttribDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
+    
+private:
+    Dsymbol *takeTypeTupleIndex(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *expr);
 };
 
 // Dsymbol that generates a scope

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -281,7 +281,7 @@ public:
     virtual void accept(Visitor *v) { v->visit(this); }
     
 private:
-    Dsymbol *takeTypeTupleIndex(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *expr);
+    Dsymbol *indexExpr(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *expr);
 };
 
 // Dsymbol that generates a scope

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -281,7 +281,7 @@ public:
     virtual void accept(Visitor *v) { v->visit(this); }
     
 private:
-    Dsymbol *indexExpr(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *expr);
+    Dsymbol *takeTypeTupleIndex(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *indexExpr);
 };
 
 // Dsymbol that generates a scope

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -961,13 +961,13 @@ public:
             else if (id->dyncast() == DYNCAST_EXPRESSION)
             {
                 buf->writeByte('[');
-                ((Expression*)id)->accept(this);
+                ((Expression *)id)->accept(this);
                 buf->writeByte(']');
             }
             else if (id->dyncast() == DYNCAST_TYPE)
             {
                 buf->writeByte('[');
-                ((Type*)id)->accept(this);
+                ((Type *)id)->accept(this);
                 buf->writeByte(']');
             }
             else

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -964,6 +964,12 @@ public:
                 ((Expression*)id)->accept(this);
                 buf->writeByte(']');
             }
+            else if (id->dyncast() == DYNCAST_TYPE)
+            {
+                buf->writeByte('[');
+                ((Type*)id)->accept(this);
+                buf->writeByte(']');
+            }
             else
             {
                 buf->writeByte('.');

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -958,7 +958,8 @@ public:
                 TemplateInstance *ti = (TemplateInstance *)id;
                 ti->accept(this);
             }
-            else if (id->dyncast() == DYNCAST_EXPRESSION) {
+            else if (id->dyncast() == DYNCAST_EXPRESSION)
+            {
                 buf->writeByte('[');
                 ((Expression*)id)->accept(this);
                 buf->writeByte(']');

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -951,15 +951,23 @@ public:
         for (size_t i = 0; i < t->idents.dim; i++)
         {
             RootObject *id = t->idents[i];
-            buf->writeByte('.');
 
             if (id->dyncast() == DYNCAST_DSYMBOL)
             {
+                buf->writeByte('.');
                 TemplateInstance *ti = (TemplateInstance *)id;
                 ti->accept(this);
             }
+            else if (id->dyncast() == DYNCAST_EXPRESSION) {
+                buf->writeByte('[');
+                ((Expression*)id)->accept(this);
+                buf->writeByte(']');
+            }
             else
+            {
+                buf->writeByte('.');
                 buf->writestring(id->toChars());
+            }
         }
     }
 

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6317,6 +6317,10 @@ void TypeQualified::syntaxCopyHelper(TypeQualified *t)
 
             ti = (TemplateInstance *)ti->syntaxCopy(NULL);
             id = ti;
+        } else if (id->dyncast() == DYNCAST_EXPRESSION) {
+            Expression* e = (Expression*)id;
+            e = e->syntaxCopy();
+            id = e;
         }
         idents[i] = id;
     }
@@ -6330,6 +6334,11 @@ void TypeQualified::addIdent(Identifier *ident)
 void TypeQualified::addInst(TemplateInstance *inst)
 {
     idents.push(inst);
+}
+
+void TypeQualified::addIndex(Expression *e)
+{
+    idents.push(e);
 }
 
 d_uns64 TypeQualified::size(Loc loc)

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6317,8 +6317,10 @@ void TypeQualified::syntaxCopyHelper(TypeQualified *t)
 
             ti = (TemplateInstance *)ti->syntaxCopy(NULL);
             id = ti;
-        } else if (id->dyncast() == DYNCAST_EXPRESSION) {
-            Expression* e = (Expression*)id;
+        }
+        else if (id->dyncast() == DYNCAST_EXPRESSION)
+        {
+            Expression *e = (Expression*)id;
             e = e->syntaxCopy();
             id = e;
         }
@@ -6378,8 +6380,8 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
             RootObject *id = idents[i];
             if (id->dyncast() == DYNCAST_EXPRESSION)
             {
-                Expression* expr = (Expression*)id;
-                TupleDeclaration* td = s->isTupleDeclaration();
+                Expression *expr = (Expression*)id;
+                TupleDeclaration *td = s->isTupleDeclaration();
                 if (!td)
                 {
                     error(loc, "expected TypeTuple when indexing ('[%s]'), got '%s'.",

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4910,7 +4910,7 @@ MATCH TypePointer::implicitConvTo(Type *to)
     {
         if (to->ty == Tpointer)
         {
-            TypePointer *tp = (TypePointer*)to;
+            TypePointer *tp = (TypePointer *)to;
             if (tp->next->ty == Tfunction)
             {
                 if (next->equals(tp->next))
@@ -4972,7 +4972,7 @@ MATCH TypePointer::constConv(Type *to)
 {
     if (next->ty == Tfunction)
     {
-        if (to->nextOf() && next->equals(((TypeNext*)to)->next))
+        if (to->nextOf() && next->equals(((TypeNext *)to)->next))
             return Type::constConv(to);
         else
             return MATCHnomatch;
@@ -6320,13 +6320,13 @@ void TypeQualified::syntaxCopyHelper(TypeQualified *t)
         }
         else if (id->dyncast() == DYNCAST_EXPRESSION)
         {
-            Expression *e = (Expression*)id;
+            Expression *e = (Expression *)id;
             e = e->syntaxCopy();
             id = e;
         }
         else if (id->dyncast() == DYNCAST_TYPE)
         {
-            Type *t = (Type*)id;
+            Type *t = (Type *)id;
             t = t->syntaxCopy();
             id = t;
         }
@@ -6428,7 +6428,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
             RootObject *id = idents[i];
             if (id->dyncast() == DYNCAST_EXPRESSION)
             {
-                if (!resolveTypeTupleIndex(loc, sc, &s, pt, ps, id, (Expression*)id))
+                if (!resolveTypeTupleIndex(loc, sc, &s, pt, ps, id, (Expression *)id))
                 {
                     return;
                 }
@@ -6436,7 +6436,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
             }
             else if (id->dyncast() == DYNCAST_TYPE)
             {
-                Type *index = (Type*)id;
+                Type *index = (Type *)id;
                 Expression *expr = NULL;
                 Type *t = NULL;
                 Dsymbol *sym = NULL;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6358,7 +6358,7 @@ d_uns64 TypeQualified::size(Loc loc)
 /*************************************
  * Resolve a TypeTuple index.
  */
-bool TypeQualified::resolveIndexExpr(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *expr)
+bool TypeQualified::resolveTypeTupleIndex(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *indexExpr)
 {
     TupleDeclaration *td = (*s)->isTupleDeclaration();
     if (!td)
@@ -6369,11 +6369,11 @@ bool TypeQualified::resolveIndexExpr(Loc loc, Scope *sc, Dsymbol **s, Type **pt,
         return false;
     }
     sc = sc->startCTFE();
-    expr = expr->semantic(sc);
+    indexExpr = indexExpr->semantic(sc);
     sc = sc->endCTFE();
 
-    expr = expr->ctfeInterpret();
-    const uinteger_t d = expr->toUInteger();
+    indexExpr = indexExpr->ctfeInterpret();
+    const uinteger_t d = indexExpr->toUInteger();
 
     if (d >= td->objects->dim)
     {
@@ -6428,7 +6428,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
             RootObject *id = idents[i];
             if (id->dyncast() == DYNCAST_EXPRESSION)
             {
-                if (!resolveIndexExpr(loc, sc, &s, pt, ps, id, (Expression*)id))
+                if (!resolveTypeTupleIndex(loc, sc, &s, pt, ps, id, (Expression*)id))
                 {
                     return;
                 }
@@ -6444,7 +6444,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                 index->resolve(loc, sc, &expr, &t, &sym);
                 if (expr)
                 {
-                    if (!resolveIndexExpr(loc, sc, &s, pt, ps, id, expr))
+                    if (!resolveTypeTupleIndex(loc, sc, &s, pt, ps, id, expr))
                     {
                         return;
                     }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6358,7 +6358,7 @@ d_uns64 TypeQualified::size(Loc loc)
 /*************************************
  * Resolve a TypeTuple index.
  */
-bool TypeQualified::resolveTypeTupleIndex(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *expr)
+bool TypeQualified::resolveIndexExpr(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *expr)
 {
     TupleDeclaration *td = (*s)->isTupleDeclaration();
     if (!td)
@@ -6428,7 +6428,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
             RootObject *id = idents[i];
             if (id->dyncast() == DYNCAST_EXPRESSION)
             {
-                if (!resolveTypeTupleIndex(loc, sc, &s, pt, ps, id, (Expression*)id))
+                if (!resolveIndexExpr(loc, sc, &s, pt, ps, id, (Expression*)id))
                 {
                     return;
                 }
@@ -6444,7 +6444,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
                 index->resolve(loc, sc, &expr, &t, &sym);
                 if (expr)
                 {
-                    if (!resolveTypeTupleIndex(loc, sc, &s, pt, ps, id, expr))
+                    if (!resolveIndexExpr(loc, sc, &s, pt, ps, id, expr))
                     {
                         return;
                     }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -671,6 +671,7 @@ public:
     void syntaxCopyHelper(TypeQualified *t);
     void addIdent(Identifier *ident);
     void addInst(TemplateInstance *inst);
+    void addIndex(Expression *expr);
     d_uns64 size(Loc loc);
     void resolveHelper(Loc loc, Scope *sc, Dsymbol *s, Dsymbol *scopesym,
         Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -678,7 +678,7 @@ public:
     void accept(Visitor *v) { v->visit(this); }
     
 private:
-    bool resolveTypeTupleIndex(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *expr);
+    bool resolveIndexExpr(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *expr);
 };
 
 class TypeIdentifier : public TypeQualified

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -678,7 +678,7 @@ public:
     void accept(Visitor *v) { v->visit(this); }
     
 private:
-    bool resolveIndexExpr(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *expr);
+    bool resolveTypeTupleIndex(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *indexExpr);
 };
 
 class TypeIdentifier : public TypeQualified

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -671,11 +671,14 @@ public:
     void syntaxCopyHelper(TypeQualified *t);
     void addIdent(Identifier *ident);
     void addInst(TemplateInstance *inst);
-    void addIndex(Expression *expr);
+    void addIndex(RootObject *expr);
     d_uns64 size(Loc loc);
     void resolveHelper(Loc loc, Scope *sc, Dsymbol *s, Dsymbol *scopesym,
         Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     void accept(Visitor *v) { v->visit(this); }
+    
+private:
+    bool resolveTypeTupleIndex(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *expr);
 };
 
 class TypeIdentifier : public TypeQualified

--- a/src/parse.c
+++ b/src/parse.c
@@ -3099,9 +3099,9 @@ Type *Parser::parseBasicType()
     return t;
 }
 
-Type* Parser::parseBasicTypeStartingAt(TypeQualified* tid)
+Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid)
 {
-    TypeSArray* maybeSArray = NULL;
+    TypeSArray *maybeSArray = NULL;
     // See https://issues.dlang.org/show_bug.cgi?id=1215
     // A basic type can look like MyType (typical case), but also:
     //  MyType.T -> A type
@@ -3131,7 +3131,7 @@ Type* Parser::parseBasicTypeStartingAt(TypeQualified* tid)
                     while (t->ty == Tsarray)
                     {
                         // The SArray inner type is an SArray itself.
-                        TypeSArray* inner = (TypeSArray*)t;
+                        TypeSArray *inner = (TypeSArray*)t;
                         dimStack.push(inner->dim->syntaxCopy());
                         t = inner->next->syntaxCopy();
                     }
@@ -3140,7 +3140,7 @@ Type* Parser::parseBasicTypeStartingAt(TypeQualified* tid)
                     tid = (TypeQualified*)t;
                     while (dimStack.dim)
                     {
-                        Expression* dim = dimStack.pop();
+                        Expression *dim = dimStack.pop();
                         tid->addIndex(dim);
                     }
                     maybeSArray = NULL;
@@ -3161,7 +3161,7 @@ Type* Parser::parseBasicTypeStartingAt(TypeQualified* tid)
             case TOKlbracket:
             {
                 nextToken();
-                Type* t = maybeSArray ? (Type*)maybeSArray : (Type*)tid;
+                Type *t = maybeSArray ? (Type*)maybeSArray : (Type*)tid;
                 if (token.value == TOKrbracket)
                 {
                     // It's a dynamic array, and we're done:
@@ -3312,7 +3312,7 @@ Type *Parser::parseBasicType2(Type *t)
 }
 
 Type *Parser::parseDeclarator(Type *t, int *palt, Identifier **pident,
-        TemplateParameters **tpl, StorageClass storageClass, int* pdisable, Expressions **pudas)
+        TemplateParameters **tpl, StorageClass storageClass, int *pdisable, Expressions **pudas)
 {
     //printf("parseDeclarator(tpl = %p)\n", tpl);
     t = parseBasicType2(t);

--- a/src/parse.c
+++ b/src/parse.c
@@ -3133,14 +3133,14 @@ Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid)
                         if (t->ty == Tsarray)
                         {
                             // The index expression is an Expression.
-                            TypeSArray *a = (TypeSArray*)t;
+                            TypeSArray *a = (TypeSArray *)t;
                             dimStack.push(a->dim->syntaxCopy());
                             t = a->next->syntaxCopy();
                         }
                         else if (t->ty == Taarray)
                         {
                             // The index expression is a Type. It will be interpreted as an expression at semantic time.
-                            TypeAArray *a = (TypeAArray*)t;
+                            TypeAArray *a = (TypeAArray *)t;
                             dimStack.push(a->index->syntaxCopy());
                             t = a->next->syntaxCopy();
                         }
@@ -3151,7 +3151,7 @@ Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid)
                     }
                     assert(dimStack.dim > 0);
                     // We're good. Replay indices in the reverse order.
-                    tid = (TypeQualified*)t;
+                    tid = (TypeQualified *)t;
                     while (dimStack.dim)
                     {
                         tid->addIndex(dimStack.pop());
@@ -3174,7 +3174,7 @@ Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid)
             case TOKlbracket:
             {
                 nextToken();
-                Type *t = maybeArray ? maybeArray : (Type*)tid;
+                Type *t = maybeArray ? maybeArray : (Type *)tid;
                 if (token.value == TOKrbracket)
                 {
                     // It's a dynamic array, and we're done:
@@ -3228,7 +3228,7 @@ Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid)
         }
     }
     Lend:
-    return maybeArray ? maybeArray : (Type*)tid;
+    return maybeArray ? maybeArray : (Type *)tid;
 }
 
 /******************************************
@@ -3436,7 +3436,7 @@ Type *Parser::parseDeclarator(Type *t, int *palt, Identifier **pident,
                  *   ts -> ... -> ta -> t
                  */
                 Type **pt;
-                for (pt = &ts; *pt != t; pt = &((TypeNext*)*pt)->next)
+                for (pt = &ts; *pt != t; pt = &((TypeNext *)*pt)->next)
                     ;
                 *pt = ta;
                 continue;
@@ -3486,7 +3486,7 @@ Type *Parser::parseDeclarator(Type *t, int *palt, Identifier **pident,
                  *   ts -> ... -> tf -> t
                  */
                 Type **pt;
-                for (pt = &ts; *pt != t; pt = &((TypeNext*)*pt)->next)
+                for (pt = &ts; *pt != t; pt = &((TypeNext *)*pt)->next)
                     ;
                 *pt = tf;
                 break;

--- a/src/parse.h
+++ b/src/parse.h
@@ -115,6 +115,7 @@ public:
     Dsymbols *parseImport();
     Type *parseType(Identifier **pident = NULL, TemplateParameters **ptpl = NULL);
     Type *parseBasicType();
+    Type *parseBasicTypeStartingAt(TypeQualified* tid);
     Type *parseBasicType2(Type *t);
     Type *parseDeclarator(Type *t, int *alt, Identifier **pident,
         TemplateParameters **tpl = NULL, StorageClass storage_class = 0, int *pdisable = NULL, Expressions **pudas = NULL);

--- a/src/parse.h
+++ b/src/parse.h
@@ -115,7 +115,7 @@ public:
     Dsymbols *parseImport();
     Type *parseType(Identifier **pident = NULL, TemplateParameters **ptpl = NULL);
     Type *parseBasicType();
-    Type *parseBasicTypeStartingAt(TypeQualified* tid);
+    Type *parseBasicTypeStartingAt(TypeQualified *tid);
     Type *parseBasicType2(Type *t);
     Type *parseDeclarator(Type *t, int *alt, Identifier **pident,
         TemplateParameters **tpl = NULL, StorageClass storage_class = 0, int *pdisable = NULL, Expressions **pudas = NULL);

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -1,0 +1,73 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS:
+
+import std.stdio;
+
+struct A(Args...) {
+    pragma(msg, "TEST: base use case");
+    Args[0].T mBase;
+    pragma(msg, "TEST: chained types");
+    Args[0].T.TT mChain;
+    pragma(msg, "TEST: chained packs");
+    Args[1+1].FArgs[0] mChainPack;
+    pragma(msg, "TEST: expr");
+    int mExpr = Args[1].i;
+    pragma(msg, "TEST: Nested + index eval");
+    Args[Args[0].i2].T mNested;
+
+    // Aliases.
+    pragma(msg, "TEST: alias, base use case");
+    alias UBase = Args[0].T;
+    UBase aBase; 
+    pragma(msg, "TEST: alias, chained types");
+    alias UChain = Args[0].T.TT;
+    UChain aChain;
+    pragma(msg, "TEST: alias, chained packs");
+    alias UChainPack = Args[1+1].FArgs[0];
+    UChainPack aChainPack;
+    pragma(msg, "TEST: alias, expr");
+    alias uExpr = Args[1].i;
+    int aExpr = uExpr;
+    pragma(msg, "TEST: alias, Nested + index eval");
+    alias UNested = Args[Args[0].i2].T;
+    UNested aNested;
+}
+
+struct B {
+    struct T {
+        void f() {
+            writeln("B.T.f");
+        }
+        struct TT {
+            void f() {
+                writeln("B.T.TT.f");
+            }
+        }
+    }
+    enum i = 6;
+    enum i2 = 0;
+    void g() {
+        writeln("B.g");
+    }
+}
+
+struct C(Args...) {
+    alias FArgs = Args;
+}
+
+alias Z = A!(B,B,C!(B,B));
+
+void main() {
+  Z z;
+  z.mBase.f();       // B.T.f
+  z.mChain.f();      // B.T.TT.f
+  z.mChainPack.g();  // B.g
+  writeln(z.mExpr);  // 6 
+  z.mNested.f();     // B.T.f
+
+  z.aBase.f();       // B.T.f
+  z.aChain.f();      // B.T.TT.f
+  z.aChainPack.g();  // B.g
+  writeln(z.aExpr);  // 6 
+  z.aNested.f();     // B.T.f
+}

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -112,7 +112,7 @@ void main()
   z.aChain.f();      // B.T.TT.f
   z.aChainPack.g();  // B.g
   writeln(z.aExpr);  // 6
-  z.aNestedCE.f();   // B.T.f 
+  z.aNested.f();     // B.T.f
   z.aCEIndex.f();    // B.T.f
   z.aNestedCE.f();   // B.T.f
 }

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -1,9 +1,26 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS:
 
+/*
+TEST_OUTPUT:
+---
+TEST: base use case
+TEST: chained types
+TEST: chained packs
+TEST: expr
+TEST: Nested + index eval
+TEST: alias, base use case
+TEST: alias, chained types
+TEST: alias, chained packs
+TEST: alias, expr
+TEST: alias, Nested + index eval
+---
+*/
+
 import std.stdio;
 
-struct A(Args...) {
+struct A(Args...)
+{
     pragma(msg, "TEST: base use case");
     Args[0].T mBase;
     pragma(msg, "TEST: chained types");
@@ -33,31 +50,39 @@ struct A(Args...) {
     UNested aNested;
 }
 
-struct B {
-    struct T {
-        void f() {
+struct B
+{
+    struct T
+    {
+        void f()
+        {
             writeln("B.T.f");
         }
-        struct TT {
-            void f() {
+        struct TT
+        {
+            void f()
+            {
                 writeln("B.T.TT.f");
             }
         }
     }
     enum i = 6;
     enum i2 = 0;
-    void g() {
+    void g()
+    {
         writeln("B.g");
     }
 }
 
-struct C(Args...) {
+struct C(Args...)
+{
     alias FArgs = Args;
 }
 
 alias Z = A!(B,B,C!(B,B));
 
-void main() {
+void main()
+{
   Z z;
   z.mBase.f();       // B.T.f
   z.mChain.f();      // B.T.TT.f

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS:
+// REQUIRED_ARGS: -o-
 
 struct A(Args...)
 {

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -1,93 +1,65 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS:
 
-/*
-TEST_OUTPUT:
----
-TEST: base use case
-TEST: chained types
-TEST: chained packs
-TEST: expr
-TEST: Nested + index eval
-TEST: index with constexpr
-TEST: Nested + index with constexpr
-TEST: alias, base use case
-TEST: alias, chained types
-TEST: alias, chained packs
-TEST: alias, expr
-TEST: alias, Nested + index eval
-TEST: alias, index with constexpr
-TEST: alias, Nested + index with constexpr
----
-*/
-
-import std.stdio;
-
 struct A(Args...)
 {
     enum i = 1;
 
-    pragma(msg, "TEST: base use case");
+    // base use case.
     Args[0].T mBase;
-    pragma(msg, "TEST: chained types");
+    static assert(is(typeof(mBase) == B.T));
+    // chained types
     Args[0].T.TT mChain;
-    pragma(msg, "TEST: chained packs");
+    static assert(is(typeof(mChain) == B.T.TT));
+    // chained packs
     Args[1+1].FArgs[0] mChainPack;
-    pragma(msg, "TEST: expr");
-    int mExpr = Args[1].i;
-    pragma(msg, "TEST: Nested + index eval");
+    static assert(is(typeof(mChainPack) == B));
+    // expr
+    enum mExpr = Args[1].i;
+    static assert(mExpr == B.i);
+    // Nested + index eval
     Args[Args[0].i2].T mNested;
-    pragma(msg, "TEST: index with constexpr");
+    static assert(is(typeof(mNested) == B.T));
+    // index with constexpr
     Args[i].T mCEIndex;
-    pragma(msg, "TEST: Nested + index with constexpr");
+    static assert(is(typeof(mCEIndex) == B.T));
+    // Nested + index with constexpr
     Args[Args[i].i2].T mNestedCE;
+    static assert(is(typeof(mNestedCE) == B.T));
 
-    // Aliases.
-    pragma(msg, "TEST: alias, base use case");
+    // alias, base use case
     alias UBase = Args[0].T;
-    UBase aBase; 
-    pragma(msg, "TEST: alias, chained types");
+    static assert(is(UBase == B.T));
+    // alias, chained types
     alias UChain = Args[0].T.TT;
-    UChain aChain;
-    pragma(msg, "TEST: alias, chained packs");
+    static assert(is(UChain == B.T.TT));
+    // alias, chained packs
     alias UChainPack = Args[1+1].FArgs[0];
-    UChainPack aChainPack;
-    pragma(msg, "TEST: alias, expr");
+    static assert(is(UChainPack == B));
+    // alias, expr
     alias uExpr = Args[1].i;
-    int aExpr = uExpr;
-    pragma(msg, "TEST: alias, Nested + index eval");
+    static assert(uExpr == B.i);
+    // alias, Nested + index eval
     alias UNested = Args[Args[0].i2].T;
-    UNested aNested;
-    pragma(msg, "TEST: alias, index with constexpr");
+    static assert(is(UNested == B.T));
+    // alias, index with constexpr
     alias UCEIndex = Args[i].T;
-    UCEIndex aCEIndex;
-    pragma(msg, "TEST: alias, Nested + index with constexpr");
+    static assert(is(UCEIndex == B.T));
+    // alias, Nested + index with constexpr
     alias UNextedCE = Args[Args[i].i2].T;
-    UNextedCE aNestedCE;
+    static assert(is(UNextedCE == B.T));
 }
 
 struct B
 {
     struct T
     {
-        void f()
-        {
-            writeln("B.T.f");
-        }
         struct TT
         {
-            void f()
-            {
-                writeln("B.T.TT.f");
-            }
         }
     }
     enum i = 6;
     enum i2 = 0;
-    void g()
-    {
-        writeln("B.g");
-    }
 }
 
 struct C(Args...)
@@ -96,23 +68,3 @@ struct C(Args...)
 }
 
 alias Z = A!(B,B,C!(B,B));
-
-void main()
-{
-  Z z;
-  z.mBase.f();       // B.T.f
-  z.mChain.f();      // B.T.TT.f
-  z.mChainPack.g();  // B.g
-  writeln(z.mExpr);  // 6 
-  z.mNested.f();     // B.T.f
-  z.mCEIndex.f();    // B.T.f
-  z.mNestedCE.f();    // B.T.f
-
-  z.aBase.f();       // B.T.f
-  z.aChain.f();      // B.T.TT.f
-  z.aChainPack.g();  // B.g
-  writeln(z.aExpr);  // 6
-  z.aNested.f();     // B.T.f
-  z.aCEIndex.f();    // B.T.f
-  z.aNestedCE.f();   // B.T.f
-}

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -9,11 +9,15 @@ TEST: chained types
 TEST: chained packs
 TEST: expr
 TEST: Nested + index eval
+TEST: index with constexpr
+TEST: Nested + index with constexpr
 TEST: alias, base use case
 TEST: alias, chained types
 TEST: alias, chained packs
 TEST: alias, expr
 TEST: alias, Nested + index eval
+TEST: alias, index with constexpr
+TEST: alias, Nested + index with constexpr
 ---
 */
 
@@ -21,6 +25,8 @@ import std.stdio;
 
 struct A(Args...)
 {
+    enum i = 1;
+
     pragma(msg, "TEST: base use case");
     Args[0].T mBase;
     pragma(msg, "TEST: chained types");
@@ -31,6 +37,10 @@ struct A(Args...)
     int mExpr = Args[1].i;
     pragma(msg, "TEST: Nested + index eval");
     Args[Args[0].i2].T mNested;
+    pragma(msg, "TEST: index with constexpr");
+    Args[i].T mCEIndex;
+    pragma(msg, "TEST: Nested + index with constexpr");
+    Args[Args[i].i2].T mNestedCE;
 
     // Aliases.
     pragma(msg, "TEST: alias, base use case");
@@ -48,6 +58,12 @@ struct A(Args...)
     pragma(msg, "TEST: alias, Nested + index eval");
     alias UNested = Args[Args[0].i2].T;
     UNested aNested;
+    pragma(msg, "TEST: alias, index with constexpr");
+    alias UCEIndex = Args[i].T;
+    UCEIndex aCEIndex;
+    pragma(msg, "TEST: alias, Nested + index with constexpr");
+    alias UNextedCE = Args[Args[i].i2].T;
+    UNextedCE aNestedCE;
 }
 
 struct B
@@ -89,10 +105,14 @@ void main()
   z.mChainPack.g();  // B.g
   writeln(z.mExpr);  // 6 
   z.mNested.f();     // B.T.f
+  z.mCEIndex.f();    // B.T.f
+  z.mNestedCE.f();    // B.T.f
 
   z.aBase.f();       // B.T.f
   z.aChain.f();      // B.T.TT.f
   z.aChainPack.g();  // B.g
-  writeln(z.aExpr);  // 6 
-  z.aNested.f();     // B.T.f
+  writeln(z.aExpr);  // 6
+  z.aNestedCE.f();   // B.T.f 
+  z.aCEIndex.f();    // B.T.f
+  z.aNestedCE.f();   // B.T.f
 }


### PR DESCRIPTION
Parse Args[0].T as a type in:

struct S(Args...) {
  Args[0].T m;
  alias T = Args[0].T;
}

See bug 1215 for context.
