### PR TITLE
[REG 2.067] Issue 14341 - Crash with -O -release -inline after sort and map!(to!string)

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -1,5 +1,5 @@
 // Copyright (C) 1984-1998 by Symantec
-// Copyright (C) 2000-2013 by Digital Mars
+// Copyright (C) 2000-2015 by Digital Mars
 // All Rights Reserved
 // http://www.digitalmars.com
 // Written by Walter Bright
@@ -1208,6 +1208,7 @@ code *cdmul(elem *e,regm_t *pretregs)
                 {   cg = cat(cg, getregs(mAX));
                     cg = genc2(cg,0xC1,grex | modregrm(3,5,AX),shpre);  // SHR EAX,shpre
                 }
+                cg = cat(cg, getregs(mDX));
                 cg = movregconst(cg, DX, m, (sz == 8) ? 0x40 : 0);      // MOV EDX,m
                 cg = cat(cg, getregs(mDX | mAX));
                 cg = gen2(cg,0xF7,grex | modregrmx(3,4,DX));            // MUL EDX

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1279,6 +1279,42 @@ int test13969(const S13969* f) {
 }
 
 ////////////////////////////////////////////////////////////////////////
+
+void test14220()
+{
+    auto a = toString(14);
+
+    printf("a.ptr = %p, a.length = %d\n", a.ptr, cast(int)a.length);
+    return;
+}
+
+auto toString(int value)
+{
+    uint mValue = value;
+
+    char[int.sizeof * 3] buffer = void;
+    size_t index = buffer.length;
+
+    do
+    {
+        uint div = cast(int)(mValue / 10);
+        char mod = mValue % 10 + '0';
+        buffer[--index] = mod;        // Line 22
+        mValue = div;
+    } while (mValue);
+
+    //printf("buffer.ptr = %p, index = %d\n", buffer.ptr, cast(int)index);
+    return dup(buffer[index .. $]);
+}
+
+char[] dup(char[] a)
+{
+    //printf("a.ptr = %p, a.length = %d\n", a.ptr, cast(int)a.length);
+    a[0] = 1;       // segfault
+    return a;
+}
+
+////////////////////////////////////////////////////////////////////////
  
 int main()
 {
@@ -1320,6 +1356,7 @@ int main()
     test9449();
     test12057();
     test13784();
+    test14220();
     printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14341

It's a dup of issue 14220, and already fixed in master branch. But it still exists in 2.067 branch so the bugfix commit is not yet cherry-picked in it.

Ping: @MartinNowak 
