### PR TITLE
Issue 14348 - typeof(x).ident is not accepted as a symbol

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6872,10 +6872,12 @@ Type *TypeTypeof::syntaxCopy()
 Dsymbol *TypeTypeof::toDsymbol(Scope *sc)
 {
     //printf("TypeTypeof::toDsymbol('%s')\n", toChars());
-    Type *t = semantic(loc, sc);
-    if (t == this)
-        return NULL;
-    return t->toDsymbol(sc);
+    Expression *e;
+    Type *t;
+    Dsymbol *s;
+    resolve(loc, sc, &e, &t, &s);
+
+    return s;
 }
 
 void TypeTypeof::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid)
@@ -7034,10 +7036,12 @@ Type *TypeReturn::syntaxCopy()
 
 Dsymbol *TypeReturn::toDsymbol(Scope *sc)
 {
-    Type *t = semantic(Loc(), sc);
-    if (t == this)
-        return NULL;
-    return t->toDsymbol(sc);
+    Expression *e;
+    Type *t;
+    Dsymbol *s;
+    resolve(loc, sc, &e, &t, &s);
+
+    return s;
 }
 
 void TypeReturn::resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3600,6 +3600,29 @@ void test2540()
 }
 
 /***************************************************/
+
+class B14348
+{
+    int foo() { return 0; }
+}
+
+class C14348 : B14348
+{
+    override int foo() { return 1; }
+
+    alias superfoo = typeof(super).foo;
+    alias thisfoo = typeof(this).foo;
+}
+
+B14348 test14348()
+{
+    alias foo = typeof(return).foo;  // currently doesn't work.
+    assert(&B14348.foo is &C14348.superfoo);
+    assert(&C14348.foo is &C14348.thisfoo);
+    return null;
+}
+
+/***************************************************/
 // 7295
 
 struct S7295
@@ -7517,6 +7540,7 @@ int main()
     test2356();
     test11238();
     test2540();
+    test14348();
     test150();
     test151();
     test152();


### PR DESCRIPTION
Instead of evaluating as a type and then converting to a symbol, re-use the resolve logic to find the symbol.

https://issues.dlang.org/show_bug.cgi?id=14348
