### PR TITLE
[DDMD] Split C++ operator new declaration into a new file

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -149,7 +149,8 @@ DMD_OBJS = \
 ROOT_OBJS = \
 	rmem.o port.o man.o stringtable.o response.o \
 	aav.o speller.o outbuffer.o object.o \
-	filename.o file.o async.o checkedint.o
+	filename.o file.o async.o checkedint.o \
+	newdelete.o
 
 GLUE_OBJS = \
 	glue.o msc.o s2ir.o todt.o e2ir.o tocsym.o \
@@ -208,7 +209,7 @@ SRC = win32.mak posix.mak osmodel.mak \
 ROOT_SRC = $(ROOT)/root.h \
 	$(ROOT)/array.h \
 	$(ROOT)/rmem.h $(ROOT)/rmem.c $(ROOT)/port.h $(ROOT)/port.c \
-	$(ROOT)/man.c \
+	$(ROOT)/man.c $(ROOT)/newdelete.c \
 	$(ROOT)/checkedint.h $(ROOT)/checkedint.c \
 	$(ROOT)/stringtable.h $(ROOT)/stringtable.c \
 	$(ROOT)/response.c $(ROOT)/async.h $(ROOT)/async.c \

--- a/src/root/newdelete.c
+++ b/src/root/newdelete.c
@@ -1,0 +1,54 @@
+
+/* Copyright (c) 2000-2014 by Digital Mars
+ * All Rights Reserved, written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/root/rmem.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define USE_ASAN_NEW_DELETE
+#endif
+#endif
+
+#if !defined(USE_ASAN_NEW_DELETE)
+
+#if 1
+
+void *allocmemory(size_t m_size);
+
+void * operator new(size_t m_size)
+{
+    return allocmemory(m_size);
+}
+
+void operator delete(void *p)
+{
+}
+
+#else
+
+void * operator new(size_t m_size)
+{
+    void *p = malloc(m_size);
+    if (p)
+        return p;
+    printf("Error: out of memory\n");
+    exit(EXIT_FAILURE);
+    return p;
+}
+
+void operator delete(void *p)
+{
+    free(p);
+}
+
+#endif
+
+#endif

--- a/src/root/rmem.c
+++ b/src/root/rmem.c
@@ -117,16 +117,6 @@ void Mem::error()
 
 /* =================================================== */
 
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define USE_ASAN_NEW_DELETE
-#endif
-#endif
-
-#if !defined(USE_ASAN_NEW_DELETE)
-
-#if 1
-
 /* Allocate, but never release
  */
 
@@ -137,7 +127,7 @@ void Mem::error()
 static size_t heapleft = 0;
 static void *heapp;
 
-void * operator new(size_t m_size)
+void *allocmemory(size_t m_size)
 {
     // 16 byte alignment is better (and sometimes needed) for doubles
     m_size = (m_size + 15) & ~15;
@@ -171,28 +161,3 @@ void * operator new(size_t m_size)
     }
     goto L1;
 }
-
-void operator delete(void *p)
-{
-}
-
-#else
-
-void * operator new(size_t m_size)
-{
-    void *p = malloc(m_size);
-    if (p)
-        return p;
-    printf("Error: out of memory\n");
-    exit(EXIT_FAILURE);
-    return p;
-}
-
-void operator delete(void *p)
-{
-    free(p);
-}
-
-#endif
-
-#endif

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -167,13 +167,10 @@ BACKOBJ= go.obj gdag.obj gother.obj gflow.obj gloop.obj var.obj el.obj \
 
 
 # Root package
-GCOBJS=rmem.obj
-# Removed garbage collector (look in history)
-#GCOBJS=dmgcmem.obj bits.obj win32.obj gc.obj
 ROOTOBJS= man.obj port.obj checkedint.obj \
 	stringtable.obj response.obj async.obj speller.obj aav.obj outbuffer.obj \
 	object.obj filename.obj file.obj \
-	$(GCOBJS)
+	rmem.obj newdelete.obj
 
 # D front end
 SRCS= mars.c enum.c struct.c dsymbol.c import.c idgen.d impcnvgen.c utf.h \
@@ -232,7 +229,7 @@ TKSRC= $(TK)\filespec.h $(TK)\mem.h $(TK)\list.h $(TK)\vec.h $(TKSRCC)
 ROOTSRCC=$(ROOT)\rmem.c $(ROOT)\stringtable.c \
 	$(ROOT)\man.c $(ROOT)\port.c $(ROOT)\async.c $(ROOT)\response.c \
 	$(ROOT)\speller.c $(ROOT)\aav.c $(ROOT)\longdouble.c \
-	$(ROOT)\checkedint.c \
+	$(ROOT)\checkedint.c $(ROOT)\newdelete.c \
 	$(ROOT)\outbuffer.c $(ROOT)\object.c $(ROOT)\filename.c $(ROOT)\file.c
 ROOTSRC= $(ROOT)\root.h \
 	$(ROOT)\rmem.h $(ROOT)\port.h \
@@ -637,6 +634,9 @@ man.obj : $(ROOT)\man.c
 
 rmem.obj : $(ROOT)\rmem.c
 	$(CC) -c $(CFLAGS) $(ROOT)\rmem.c
+
+newdelete.obj : $(ROOT)\newdelete.c
+	$(CC) -c $(CFLAGS) $(ROOT)\newdelete.c
 
 port.obj : $(ROOT)\port.c
 	$(CC) -c $(CFLAGS) $(ROOT)\port.c


### PR DESCRIPTION
DDMD has a different version of `rmem.c`, but the C++ operators still need to be defined in C++ code.  This split allows the object file to easily be included in ddmd.

@WalterBright This is needed to fix the performance issue with `new` in ddmd.
