### PR TITLE
[REG2.065] Issue 14207 - [CTFE] ICE on unsupported reinterpret cast in compile time

### DIFF
--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -652,8 +652,15 @@ bool isSafePointerCast(Type *srcPointee, Type *destPointee)
     // It's OK if they are the same size (static array of) integers, eg:
     //     int*     --> uint*
     //     int[5][] --> uint[5][]
-    return srcPointee->baseElemOf()->isintegral() &&
-           destPointee->baseElemOf()->isintegral() &&
+    if (srcPointee->ty == Tsarray && destPointee->ty == Tsarray)
+    {
+        if (srcPointee->size() != destPointee->size())
+            return false;
+        srcPointee = srcPointee->baseElemOf();
+        destPointee = destPointee->baseElemOf();
+    }
+    return srcPointee->isintegral() &&
+           destPointee->isintegral() &&
            srcPointee->size() == destPointee->size();
 }
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -6834,6 +6834,14 @@ void setValueWithoutChecking(VarDeclaration *vd, Expression *newval)
 
 void setValue(VarDeclaration *vd, Expression *newval)
 {
+#if 0
+    if (! ((vd->storage_class & (STCout | STCref))
+            ? isCtfeReferenceValid(newval)
+            : isCtfeValueValid(newval)) )
+    {
+        printf("[%s] vd = %s %s, newval = %s\n", vd->loc.toChars(), vd->type->toChars(), vd->toChars(), newval->toChars());
+    }
+#endif
     assert((vd->storage_class & (STCout | STCref))
             ? isCtfeReferenceValid(newval)
             : isCtfeValueValid(newval));

--- a/test/fail_compilation/ctfe14207.d
+++ b/test/fail_compilation/ctfe14207.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ctfe14207.d(13): Error: cannot convert &immutable(ulong) to ubyte[8]* at compile time
+fail_compilation/ctfe14207.d(18):        called from here: nativeToBigEndian()
+fail_compilation/ctfe14207.d(22):        called from here: digest()
+---
+*/
+
+ubyte[8] nativeToBigEndian()
+{
+    immutable ulong res = 1;
+    return *cast(ubyte[8]*) &res;
+}
+
+auto digest()
+{
+    ubyte[8] bits = nativeToBigEndian();
+    return bits;
+}
+
+enum h = digest();


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14207

The problematic code in `isSafePointerCast()` was introduced in pull #2612 to fix [regression 10687](https://issues.dlang.org/show_bug.cgi?id=10687).
