### PR TITLE
Fix lexing integers on big-endian systems

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1939,7 +1939,23 @@ Ldone:
             #endif
             assert(0);
     }
-    t->uns64value = n;
+    switch(result)
+    {
+      case TOKint32v:
+        t->int32value = (d_int32)n;
+        break;
+      case TOKuns32v:
+        t->uns32value = (d_uns32)n;
+        break;
+      case TOKint64v:
+        t->int64value = (d_int64)n;
+        break;
+      case TOKuns64v:
+        t->uns64value = (d_uns64)n;
+        break;
+      default:
+        assert(0);
+    }
     return result;
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -747,11 +747,11 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                 if (token.value == TOKlparen)
                 {
                     nextToken();
-                    if (token.value == TOKint32v && token.uns64value > 0)
+                    if (token.value == TOKint32v && token.int32value > 0)
                     {
-                        if (token.uns64value & (token.uns64value - 1))
+                        if (token.int32value & (token.int32value - 1))
                             error("align(%s) must be a power of 2", token.toChars());
-                        n = (unsigned)token.uns64value;
+                        n = (unsigned)token.int32value;
                     }
                     else
                     {


### PR DESCRIPTION
Reading integers from D source files is currently broken on big-endian systems. See http://forum.dlang.org/post/ckqcspcptqazbawdsgzj@forum.dlang.org
and related forum thread for more information.
