### PR TITLE
Fix lexing integers on big-endian systems

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3479,10 +3479,10 @@ static code *asm_db_parse(OP *pop)
         switch (tok_value)
         {
             case TOKint32v:
-                dt.ul = asmtok->int32value;
+                dt.ul = (d_int32)asmtok->int64value;
                 goto L1;
             case TOKuns32v:
-                dt.ul = asmtok->uns32value;
+                dt.ul = (d_uns32)asmtok->uns64value;
                 goto L1;
             case TOKint64v:
                 dt.ul = asmtok->int64value;
@@ -3646,11 +3646,11 @@ int asm_getnum()
     switch (tok_value)
     {
         case TOKint32v:
-            v = asmtok->int32value;
+            v = (d_int32)asmtok->int64value;
             break;
 
         case TOKuns32v:
-            v = asmtok->uns32value;
+            v = (d_uns32)asmtok->uns64value;
             break;
 
         case TOKidentifier:
@@ -4422,7 +4422,7 @@ static OPND *asm_primary_exp()
         case TOKint32v:
         case TOKuns32v:
             o1 = new OPND();
-            o1->disp = asmtok->int32value;
+            o1->disp = (d_int32)asmtok->int64value;
             asm_token();
             break;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -6338,12 +6338,12 @@ Expression *Parser::parsePrimaryExp()
             break;
 
         case TOKint32v:
-            e = new IntegerExp(loc, token.int32value, Type::tint32);
+            e = new IntegerExp(loc, (d_int32)token.int64value, Type::tint32);
             nextToken();
             break;
 
         case TOKuns32v:
-            e = new IntegerExp(loc, token.uns32value, Type::tuns32);
+            e = new IntegerExp(loc, (d_uns32)token.uns64value, Type::tuns32);
             nextToken();
             break;
 
@@ -6433,17 +6433,17 @@ Expression *Parser::parsePrimaryExp()
             break;
 
         case TOKcharv:
-            e = new IntegerExp(loc, token.uns32value, Type::tchar);
+            e = new IntegerExp(loc, (d_uns8)token.uns64value, Type::tchar);
             nextToken();
             break;
 
         case TOKwcharv:
-            e = new IntegerExp(loc, token.uns32value, Type::twchar);
+            e = new IntegerExp(loc, (d_uns16)token.uns64value, Type::twchar);
             nextToken();
             break;
 
         case TOKdcharv:
-            e = new IntegerExp(loc, token.uns32value, Type::tdchar);
+            e = new IntegerExp(loc, (d_uns32)token.uns64value, Type::tdchar);
             nextToken();
             break;
 

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -59,14 +59,14 @@ const char *Token::toChars()
     switch (value)
     {
         case TOKint32v:
-            sprintf(&buffer[0],"%d",int32value);
+            sprintf(&buffer[0],"%d",(d_int32)int64value);
             break;
 
         case TOKuns32v:
         case TOKcharv:
         case TOKwcharv:
         case TOKdcharv:
-            sprintf(&buffer[0],"%uU",uns32value);
+            sprintf(&buffer[0],"%uU",(d_uns32)uns64value);
             break;
 
         case TOKint64v:

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -200,8 +200,6 @@ struct Token
     union
     {
         // Integers
-        d_int32 int32value;
-        d_uns32 uns32value;
         d_int64 int64value;
         d_uns64 uns64value;
 


### PR DESCRIPTION
Reading integers from D source files is currently broken on big-endian systems. See http://forum.dlang.org/post/ckqcspcptqazbawdsgzj@forum.dlang.org
and related forum thread for more information.

Issue debugged by Jens Bauer, code changes ported from LDC.

Updates https://github.com/D-Programming-Language/dmd/pull/4549 : I didn't know you can't reopen a pull request if you force-push while the request is closed...
