### PR TITLE
[REG2.067] Issue 14395 - Typesafe variadic function call collapsed if being used for default value

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -1501,18 +1501,14 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                                 a = a->implicitCastTo(sc, tbn);
                             (*elements)[u] = a;
                         }
-                        ArrayLiteralExp *ale = new ArrayLiteralExp(loc, elements);
-                        ale->type = tsa;
-
-                        Identifier *id = Identifier::generateId("__arrayArg");
-                        VarDeclaration *v = new VarDeclaration(loc, tsa, id, new ExpInitializer(loc, ale));
-                        v->storage_class |= STCtemp | STCctfe;
-                        v->semantic(sc);
-                        v->parent = sc->parent;
-
-                        Expression *de = new DeclarationExp(loc, v);
-                        Expression *ve = new VarExp(loc, v);
-                        arg = Expression::combine(de, ve);
+                        // Bugzilla 14395: Convert to a static array literal, or its slice.
+                        arg = new ArrayLiteralExp(loc, elements);
+                        arg->type = tsa;
+                        if (tb->ty == Tarray)
+                        {
+                            arg = new SliceExp(loc, arg, NULL, NULL);
+                            arg->type = p->type;
+                        }
                         break;
                     }
                     case Tclass:

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1654,6 +1654,24 @@ void test13508() @safe @nogc
 }
 
 /***************************************/
+// 14395
+
+int v2u14395(uint[1] ar...)
+{
+    return ar[0];
+}
+
+void print14395(int size = v2u14395(7))
+{
+    assert(size == 7);
+}
+
+void test14395()
+{
+    print14395();
+}
+
+/***************************************/
 // 10414
 
 void foo10414(void delegate()[] ...) { }
@@ -1787,6 +1805,7 @@ int main()
     test7233();
     test7263();
     test9017();
+    test14395();
     test10414();
     test9495();
     testCopy();


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14395

Out of function body `__arrayArg` was not initialized by the array literal, because `VarDeclaraton::semantic()` does not wrap the initializer expression with `ConstructExp` when `sc->func == NULL`.

To fix the issue, remove use of temporary variable for typesafe variadic argument.
