### PR TITLE
Fix subexpression type when converting a CondExp to an lvalue.

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -13724,6 +13724,7 @@ Expression *CondExp::toLvalue(Scope *sc, Expression *ex)
     CondExp *e = (CondExp *)copy();
     e->e1 = e1->toLvalue(sc, NULL)->addressOf();
     e->e2 = e2->toLvalue(sc, NULL)->addressOf();
+    e->type = type->pointerTo();
     return new PtrExp(loc, e, type);
 }
 


### PR DESCRIPTION
When converting `econd ? e1 : e2` to `*(econd ? &e1 : &e2)`, the type of the subexpression `econd ? &e1 : &e2` to be dereferenced is obviously a pointer to the original expression's type instead of the original type.

2.066:

``` cpp
Expression *CondExp::toLvalue(Scope *sc, Expression *ex)
{
    // convert (econd ? e1 : e2) to *(econd ? &e1 : &e2)
    PtrExp *e = new PtrExp(loc, this, type);
    e1 = e1->toLvalue(sc, NULL)->addressOf();
    e2 = e2->toLvalue(sc, NULL)->addressOf();
    type = e2->type;
    return e;
}
```

2.067:

``` cpp
Expression *CondExp::toLvalue(Scope *sc, Expression *ex)
{
    // convert (econd ? e1 : e2) to *(econd ? &e1 : &e2)
    CondExp *e = (CondExp *)copy();
    e->e1 = e1->toLvalue(sc, NULL)->addressOf();
    e->e2 = e2->toLvalue(sc, NULL)->addressOf();
    return new PtrExp(loc, e, type);
}
```
