### PR TITLE
Fix issue 12971 - Missing REX prefix for 8 bit register access

### DIFF
--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2547,6 +2547,8 @@ static void asm_make_modrm_byte(
         mrmb.rm |= popnd->base->val & NUM_MASK;
         if (popnd->base->val & NUM_MASKR)
             pc->Irex |= REX_B;
+        else if (popnd->base->isSIL_DIL_BPL_SPL())
+            pc->Irex |= REX;
     }
     else if (amod == _addr16)
     {

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -6572,6 +6572,7 @@ void test9965()
 	0x40, 0xB5, 0x01,       // mov	BPL,1
 	0x40, 0xB4, 0x01,       // mov	SPL,1
 	0x41, 0xB0, 0x01,       // mov	R8B,1
+	0x40, 0x80, 0xE6, 0x01, // and  SIL,1 (issue 12971)
     ];
 
     asm
@@ -6584,6 +6585,7 @@ void test9965()
 	mov BPL, 1;
 	mov SPL, 1;
 	mov R8B, 1;
+	and SIL, 1;
 
 L1:     pop     RAX;
         mov     p[RBP],RAX;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12971
