### PR TITLE
Issue 5770 - Template constructor bypass access check

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -15,246 +15,47 @@
 #include "root.h"
 #include "rmem.h"
 
-#include "enum.h"
-#include "aggregate.h"
-#include "init.h"
-#include "attrib.h"
-#include "scope.h"
-#include "id.h"
-#include "mtype.h"
-#include "declaration.h"
 #include "aggregate.h"
 #include "expression.h"
 #include "module.h"
+#include "scope.h"
 
 #define LOG 0
 
-/* Code to do access checks
- */
-
-bool hasPackageAccess(Scope *sc, Dsymbol *s);
-bool hasPrivateAccess(AggregateDeclaration *ad, Dsymbol *smember);
-bool isFriendOf(AggregateDeclaration *ad, AggregateDeclaration *cd);
-
 /****************************************
- * Return Prot access for Dsymbol smember in this declaration.
+ * Check that s is a member of ad (or one of its base casses if exist).
  */
-Prot getAccess(AggregateDeclaration *ad, Dsymbol *smember)
+bool isMember(AggregateDeclaration *ad, Dsymbol *s)
 {
-    Prot access_ret = Prot(PROTnone);
+    if (s->toParent2() == ad)
+        return true;
 
-#if LOG
-    printf("+AggregateDeclaration::getAccess(this = '%s', smember = '%s')\n",
-        ad->toChars(), smember->toChars());
-#endif
-
-    assert(ad->isStructDeclaration() || ad->isClassDeclaration());
-    if (smember->toParent() == ad)
-    {
-        access_ret = smember->prot();
-    }
-    else if (smember->isDeclaration()->isStatic())
-    {
-        access_ret = smember->prot();
-    }
     if (ClassDeclaration *cd = ad->isClassDeclaration())
     {
         for (size_t i = 0; i < cd->baseclasses->dim; i++)
         {
             BaseClass *b = (*cd->baseclasses)[i];
-
-            Prot access = getAccess(b->base, smember);
-            switch (access.kind)
-            {
-                case PROTnone:
-                    break;
-
-                case PROTprivate:
-                    access_ret = Prot(PROTnone);  // private members of base class not accessible
-                    break;
-
-                case PROTpackage:
-                case PROTprotected:
-                case PROTpublic:
-                case PROTexport:
-                    // If access is to be tightened
-                    if (b->protection.isMoreRestrictiveThan(access))
-                        access = b->protection;
-
-                    // Pick path with loosest access
-                    if (access_ret.isMoreRestrictiveThan(access))
-                        access_ret = access;
-                    break;
-
-                default:
-                    assert(0);
-            }
+            if (isMember(b->base, s))
+                return true;
         }
-    }
-
-#if LOG
-    printf("-AggregateDeclaration::getAccess(this = '%s', smember = '%s') = %d\n",
-        ad->toChars(), smember->toChars(), access_ret);
-#endif
-    return access_ret;
-}
-
-/********************************************************
- * Helper function for checkAccess()
- * Returns:
- *      false   is not accessible
- *      true    is accessible
- */
-static bool isAccessible(
-        Dsymbol *smember,
-        Dsymbol *sfunc,
-        AggregateDeclaration *dthis,
-        AggregateDeclaration *cdscope)
-{
-    assert(dthis);
-
-#if 0
-    printf("isAccessible for %s.%s in function %s() in scope %s\n",
-        dthis->toChars(), smember->toChars(),
-        sfunc ? sfunc->toChars() : "NULL",
-        cdscope ? cdscope->toChars() : "NULL");
-#endif
-    if (hasPrivateAccess(dthis, sfunc) ||
-        isFriendOf(dthis, cdscope))
-    {
-        if (smember->toParent() == dthis)
-            return true;
-
-        if (ClassDeclaration *cdthis = dthis->isClassDeclaration())
-        {
-            for (size_t i = 0; i < cdthis->baseclasses->dim; i++)
-            {
-                BaseClass *b = (*cdthis->baseclasses)[i];
-                Prot access = getAccess(b->base, smember);
-                if (access.kind >= PROTprotected ||
-                    isAccessible(smember, sfunc, b->base, cdscope))
-                {
-                    return true;
-                }
-            }
-        }
-    }
-    else
-    {
-        if (smember->toParent() != dthis)
-        {
-            if (ClassDeclaration *cdthis = dthis->isClassDeclaration())
-            {
-                for (size_t i = 0; i < cdthis->baseclasses->dim; i++)
-                {
-                    BaseClass *b = (*cdthis->baseclasses)[i];
-                    if (isAccessible(smember, sfunc, b->base, cdscope))
-                        return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-/*******************************
- * Do access check for member of this class, this class being the
- * type of the 'this' pointer used to access smember.
- * Returns true if the member is not accessible.
- */
-bool checkAccess(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember)
-{
-    FuncDeclaration *f = sc->func;
-    AggregateDeclaration *cdscope = sc->getStructClassScope();
-
-#if LOG
-    printf("AggregateDeclaration::checkAccess() for %s.%s in function %s() in scope %s\n",
-        ad->toChars(), smember->toChars(),
-        f ? f->toChars() : NULL,
-        cdscope ? cdscope->toChars() : NULL);
-#endif
-
-    Dsymbol *smemberparent = smember->toParent();
-    if (!smemberparent || !smemberparent->isAggregateDeclaration())
-    {
-#if LOG
-        printf("not an aggregate member\n");
-#endif
-        return false;                   // then it is accessible
-    }
-
-    // BUG: should enable this check
-    //assert(smember->parent->isBaseOf(this, NULL));
-
-    bool result;
-    Prot access;
-    if (smemberparent == ad)
-    {
-        access = smember->prot();
-        result = access.kind >= PROTpublic ||
-                 hasPrivateAccess(ad, f) ||
-                 isFriendOf(ad, cdscope) ||
-                 (access.kind == PROTpackage && hasPackageAccess(sc, smember)) ||
-                 ad->getAccessModule() == sc->module;
-#if LOG
-        printf("result1 = %d\n", result);
-#endif
-    }
-    else if ((access = getAccess(ad, smember)).kind >= PROTpublic)
-    {
-        result = true;
-#if LOG
-        printf("result2 = %d\n", result);
-#endif
-    }
-    else if (access.kind == PROTpackage && hasPackageAccess(sc, ad))
-    {
-        result = true;
-#if LOG
-        printf("result3 = %d\n", result);
-#endif
-    }
-    else
-    {
-        result = isAccessible(smember, f, ad, cdscope);
-#if LOG
-        printf("result4 = %d\n", result);
-#endif
-    }
-    if (!result)
-    {
-        ad->error(loc, "member %s is not accessible", smember->toChars());
-        //printf("smember = %s %s, prot = %d, semanticRun = %d\n",
-        //        smember->kind(), smember->toPrettyChars(), smember->prot(), smember->semanticRun);
-        return true;
     }
     return false;
 }
 
 /****************************************
- * Determine if this is the same or friend of cd.
+ * Determine if scope sc has protection access to s.
  */
-bool isFriendOf(AggregateDeclaration *ad, AggregateDeclaration *cd)
+bool hasProtectedAccess(Scope *sc, Dsymbol *s)
 {
-#if LOG
-    printf("AggregateDeclaration::isFriendOf(this = '%s', cd = '%s')\n", ad->toChars(), cd ? cd->toChars() : "null");
-#endif
-    if (ad == cd)
-        return true;
-
-    // Friends if both are in the same module
-    //if (toParent() == cd->toParent())
-    if (cd && ad->getAccessModule() == cd->getAccessModule())
+    for (Scope *scx = sc; scx; scx = scx->enclosing)
     {
-#if LOG
-        printf("\tin same module\n");
-#endif
-        return true;
-    }
+        if (!scx->scopesym)
+            continue;
 
-#if LOG
-    printf("\tnot friend\n");
-#endif
+        AggregateDeclaration *ad = scx->scopesym->isClassDeclaration();
+        if (ad && isMember(ad, s))
+            return true;
+    }
     return false;
 }
 
@@ -335,61 +136,6 @@ bool hasPackageAccess(Scope *sc, Dsymbol *s)
     return false;
 }
 
-/**********************************
- * Determine if smember has access to private members of this declaration.
- */
-bool hasPrivateAccess(AggregateDeclaration *ad, Dsymbol *smember)
-{
-    if (smember)
-    {
-        AggregateDeclaration *cd = NULL;
-        Dsymbol *smemberparent = smember->toParent();
-        if (smemberparent)
-            cd = smemberparent->isAggregateDeclaration();
-
-#if LOG
-        printf("AggregateDeclaration::hasPrivateAccess(class %s, member %s)\n",
-                ad->toChars(), smember->toChars());
-#endif
-
-        if (ad == cd)         // smember is a member of this class
-        {
-#if LOG
-            printf("\tyes 1\n");
-#endif
-            return true;           // so we get private access
-        }
-
-        // If both are members of the same module, grant access
-        while (1)
-        {
-            Dsymbol *sp = smember->toParent();
-            if (sp->isFuncDeclaration() && smember->isFuncDeclaration())
-                smember = sp;
-            else
-                break;
-        }
-        if (!cd && ad->toParent() == smember->toParent())
-        {
-#if LOG
-            printf("\tyes 2\n");
-#endif
-            return true;
-        }
-        if (!cd && ad->getAccessModule() == smember->getAccessModule())
-        {
-#if LOG
-            printf("\tyes 3\n");
-#endif
-            return true;
-        }
-    }
-#if LOG
-    printf("\tno\n");
-#endif
-    return false;
-}
-
 /****************************************
  * Check access to d for expression e.d
  * Returns true if the declaration is not accessible.
@@ -398,50 +144,30 @@ bool checkAccess(Loc loc, Scope *sc, Expression *e, Declaration *d)
 {
     if (sc->flags & SCOPEnoaccesscheck)
         return false;
+    if (d->isUnitTestDeclaration()) // Unittests are always accessible.
+        return false;
 
 #if LOG
-    if (e)
-    {
-        printf("checkAccess(%s . %s)\n", e->toChars(), d->toChars());
-        printf("\te->type = %s\n", e->type->toChars());
-    }
-    else
-    {
-        printf("checkAccess(%s)\n", d->toPrettyChars());
-    }
+    printf("[%s] checkAccess(%s)\n", loc.toChars(), d->toPrettyChars());
 #endif
-    if(d->isUnitTestDeclaration()) 
-    {
-        // Unittests are always accessible.
+
+    // friend access
+    if (d->getAccessModule() == sc->module)
         return false;
-    }
-    if (!e)
+
+    // check access rights
+    if (d->prot().kind == PROTprivate ||
+        d->prot().kind == PROTpackage && !hasPackageAccess(sc, d) ||
+        d->prot().kind == PROTprotected && !hasProtectedAccess(sc, d))
     {
-        if (d->prot().kind == PROTprivate && d->getAccessModule() != sc->module ||
-            d->prot().kind == PROTpackage && !hasPackageAccess(sc, d))
-        {
+        AggregateDeclaration *ad = d->toParent2()->isAggregateDeclaration();
+        if (ad)
+            ad->error(loc, "member %s is not accessible from module %s",
+                d->toChars(), sc->module->toChars());
+        else
             error(loc, "%s %s is not accessible from module %s",
                 d->kind(), d->toPrettyChars(), sc->module->toChars());
-            return true;
-        }
-    }
-    else if (e->type->ty == Tclass)
-    {
-        // Do access check
-        ClassDeclaration *cd = (ClassDeclaration *)(((TypeClass *)e->type)->sym);
-        if (e->op == TOKsuper)
-        {
-            ClassDeclaration *cd2 = sc->func->toParent()->isClassDeclaration();
-            if (cd2)
-                cd = cd2;
-        }
-        return checkAccess(cd, loc, sc, d);
-    }
-    else if (e->type->ty == Tstruct)
-    {
-        // Do access check
-        StructDeclaration *cd = (StructDeclaration *)(((TypeStruct *)e->type)->sym);
-        return checkAccess(cd, loc, sc, d);
+        return true;
     }
     return false;
 }

--- a/src/expression.c
+++ b/src/expression.c
@@ -47,7 +47,6 @@ bool isArrayOpValid(Expression *e);
 Expression *createTypeInfoArray(Scope *sc, Expression *args[], size_t dim);
 Expression *expandVar(int result, VarDeclaration *v);
 TypeTuple *toArgTypes(Type *t);
-bool checkAccess(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember);
 bool checkFrameAccess(Loc loc, Scope *sc, AggregateDeclaration *ad, size_t istart = 0);
 Symbol *toInitializer(AggregateDeclaration *ad);
 Expression *getTypeInfo(Type *t, Scope *sc);
@@ -2654,7 +2653,7 @@ bool Expression::checkPostblit(Scope *sc, Type *t)
             checkPurity(sc, sd->postblit);
             checkSafety(sc, sd->postblit);
             checkNogc(sc, sd->postblit);
-            //checkAccess(sd, loc, sc, sd->postblit);   // necessary?
+            //checkAccess(loc, sc, NULL, sd->postblit);   // necessary?
             return false;
         }
     }
@@ -4940,7 +4939,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            checkAccess(cd, loc, sc, f);
+            checkAccess(loc, sc, NULL, f);
 
             TypeFunction *tf = (TypeFunction *)f->type;
             if (!arguments)
@@ -4976,7 +4975,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            checkAccess(cd, loc, sc, f);
+            checkAccess(loc, sc, NULL, f);
         #endif
 
             TypeFunction *tf = (TypeFunction *)f->type;
@@ -5025,7 +5024,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            checkAccess(sd, loc, sc, f);
+            checkAccess(loc, sc, NULL, f);
         #endif
 
             TypeFunction *tf = (TypeFunction *)f->type;
@@ -5054,7 +5053,7 @@ Lagain:
             checkPurity(sc, f);
             checkSafety(sc, f);
             checkNogc(sc, f);
-            checkAccess(sd, loc, sc, f);
+            checkAccess(loc, sc, NULL, f);
 
             TypeFunction *tf = (TypeFunction *)f->type;
             if (!arguments)

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -526,14 +526,10 @@
                 "declaration",
                 "dmodule",
                 "dscope",
-                "dstruct",
                 "dsymbol",
                 "errors",
                 "expression",
-                "func",
-                "tokens",
-                "globals",
-                "mtype"
+                "globals"
             ],
             "extra" :
             [
@@ -541,13 +537,10 @@
             ],
             "members" :
             [
-                "function getAccess",
-                "function isAccessible",
-                "function checkAccessAggregateDeclaration*LocScope*Dsymbol*",
-                "function isFriendOf",
+                "function isMember",
+                "function hasProtectedAccess",
                 "function hasPackageAccess",
-                "function hasPrivateAccess",
-                "function checkAccessLocScope*Expression*Declaration*"
+                "function checkAccess"
             ]
         },
         {

--- a/test/compilable/imports/prot5770.d
+++ b/test/compilable/imports/prot5770.d
@@ -1,0 +1,65 @@
+module imports.prot5770;
+
+public
+{
+    void publicF() {}
+    void publicTF()() {}
+}
+package
+{
+    void packageF() {}
+    void packageTF()() {}
+}
+private
+{
+    void privateF() {}
+    void privatebar()() {}
+}
+
+class C
+{
+    public
+    {
+        void publicF() {}
+        void publicTF()() {}
+    }
+    protected
+    {
+        void protectedF() {}
+        void protectedTF()() {}
+    }
+    package
+    {
+        void packageF() {}
+        void packageTF()() {}
+    }
+    private
+    {
+        void privateF() {}
+        void privateTF()() {}
+    }
+}
+
+struct S
+{
+    public
+    {
+        void publicF() {}
+        void publicTF()() {}
+    }
+    protected
+    {
+        void protectedF() {}
+        void protectedTF()() {}
+    }
+    package
+    {
+        void packageF() {}
+        void packageTF()() {}
+    }
+    private
+    {
+        void privateF() {}
+        void privateTF()() {}
+    }
+}

--- a/test/compilable/testprot5770.d
+++ b/test/compilable/testprot5770.d
@@ -13,9 +13,9 @@ version(all)    // access module members from module scope
     static assert(!is(typeof(C.init.  privateF())));
 
     static assert( is(typeof(C.init.   publicTF())));
-  //static assert(!is(typeof(C.init.protectedTF())));   // Bugzilla 5770
+    static assert(!is(typeof(C.init.protectedTF())));
     static assert( is(typeof(C.init.  packageTF())));
-  //static assert(!is(typeof(C.init.  privateTF())));   // Bugzilla 5770
+    static assert(!is(typeof(C.init.  privateTF())));
 }
 version(all)    // access class members from module scope
 {
@@ -25,9 +25,9 @@ version(all)    // access class members from module scope
     static assert(!is(typeof(C.init.  privateF())));
 
     static assert( is(typeof(C.init.   publicTF())));
-  //static assert(!is(typeof(C.init.protectedTF())));   // Bugzilla 5770
+    static assert(!is(typeof(C.init.protectedTF())));
     static assert( is(typeof(C.init.  packageTF())));
-  //static assert(!is(typeof(C.init.  privateTF())));   // Bugzilla 5770
+    static assert(!is(typeof(C.init.  privateTF())));
 
     static assert( is(typeof(D.init.   publicF())));
     static assert(!is(typeof(D.init.protectedF())));
@@ -35,9 +35,9 @@ version(all)    // access class members from module scope
     static assert(!is(typeof(D.init.  privateF())));
 
     static assert( is(typeof(D.init.   publicTF())));
-  //static assert(!is(typeof(D.init.protectedTF())));   // Bugzilla 5770
+    static assert(!is(typeof(D.init.protectedTF())));
     static assert( is(typeof(D.init.  packageTF())));
-  //static assert(!is(typeof(D.init.  privateTF())));   // Bugzilla 5770
+    static assert(!is(typeof(D.init.  privateTF())));
 }
 version(all)    // access struct members from module scope
 {
@@ -47,9 +47,9 @@ version(all)    // access struct members from module scope
     static assert(!is(typeof(S.init.  privateF())));
 
     static assert( is(typeof(S.init.   publicTF())));
-  //static assert(!is(typeof(S.init.protectedTF())));   // Bugzilla 5770
+    static assert(!is(typeof(S.init.protectedTF())));
     static assert( is(typeof(S.init.  packageTF())));
-  //static assert(!is(typeof(S.init.  privateTF())));   // Bugzilla 5770
+    static assert(!is(typeof(S.init.  privateTF())));
 }
 
 void testC1()
@@ -62,21 +62,21 @@ void testC1()
     static assert(!is(typeof(c.  privateF())));
 
     static assert( is(typeof(c.   publicTF())));
-  //static assert(!is(typeof(c.protectedTF())));    // Bugzilla 5770
+    static assert(!is(typeof(c.protectedTF())));
     static assert( is(typeof(c.  packageTF())));
-  //static assert(!is(typeof(c.  privateTF())));    // Bugzilla 5770
+    static assert(!is(typeof(c.  privateTF())));
 
     D d = new D();
 
     static assert( is(typeof(d.   publicF())));
-  //static assert(!is(typeof(d.protectedF())));     // Bugzilla 5770
+    static assert(!is(typeof(d.protectedF())));
     static assert( is(typeof(d.  packageF())));
     static assert(!is(typeof(d.  privateF())));
 
     static assert( is(typeof(d.   publicTF())));
-  //static assert(!is(typeof(d.protectedTF())));    // Bugzilla 5770
+    static assert(!is(typeof(d.protectedTF())));
     static assert( is(typeof(d.  packageTF())));
-  //static assert(!is(typeof(d.  privateTF())));    // Bugzilla 5770
+    static assert(!is(typeof(d.  privateTF())));
 }
 void testC2()()
 {
@@ -88,21 +88,21 @@ void testC2()()
     static assert(!is(typeof(c.  privateF())));
 
     static assert( is(typeof(c.   publicTF())));
-  //static assert(!is(typeof(c.protectedTF())));    // Bugzilla 5770
+    static assert(!is(typeof(c.protectedTF())));
     static assert( is(typeof(c.  packageTF())));
-  //static assert(!is(typeof(c.  privateTF())));    // Bugzilla 5770
+    static assert(!is(typeof(c.  privateTF())));
 
     D d = new D();
 
     static assert( is(typeof(d.   publicF())));
-  //static assert(!is(typeof(d.protectedF())));     // Bugzilla 5770
+    static assert(!is(typeof(d.protectedF())));
     static assert( is(typeof(d.  packageF())));
     static assert(!is(typeof(d.  privateF())));
 
     static assert( is(typeof(d.   publicTF())));
-  //static assert(!is(typeof(d.protectedTF())));    // Bugzilla 5770
+    static assert(!is(typeof(d.protectedTF())));
     static assert( is(typeof(d.  packageTF())));
-  //static assert(!is(typeof(d.  privateTF())));    // Bugzilla 5770
+    static assert(!is(typeof(d.  privateTF())));
 }
 alias testC2x = testC2!();
 
@@ -116,9 +116,9 @@ void testS1()
     static assert(!is(typeof(s.  privateF())));
 
     static assert( is(typeof(s.   publicTF())));
-  //static assert(!is(typeof(s.protectedTF())));    // Bugzilla 5770
+    static assert(!is(typeof(s.protectedTF())));
     static assert( is(typeof(s.  packageTF())));
-  //static assert(!is(typeof(s.  privateTF())));    // Bugzilla 5770
+    static assert(!is(typeof(s.  privateTF())));
 }
 void testS2()()
 {
@@ -130,9 +130,9 @@ void testS2()()
     static assert(!is(typeof(s.  privateF())));
 
     static assert( is(typeof(s.   publicTF())));
-  //static assert(!is(typeof(s.protectedTF())));    // Bugzilla 5770
+    static assert(!is(typeof(s.protectedTF())));
     static assert( is(typeof(s.  packageTF())));
-  //static assert(!is(typeof(s.  privateTF())));    // Bugzilla 5770
+    static assert(!is(typeof(s.  privateTF())));
 }
 alias testS2x = testS2!();
 
@@ -148,7 +148,7 @@ class D : C
         static assert( is(typeof(this.   publicTF())));
         static assert( is(typeof(this.protectedTF())));
         static assert( is(typeof(this.  packageTF())));
-      //static assert(!is(typeof(this.  privateTF())));     // Bugzilla 5770
+        static assert(!is(typeof(this.  privateTF())));
 
         static assert( is(typeof(super.   publicF())));
         static assert( is(typeof(super.protectedF())));
@@ -158,7 +158,7 @@ class D : C
         static assert( is(typeof(super.   publicTF())));
         static assert( is(typeof(super.protectedTF())));
         static assert( is(typeof(super.  packageTF())));
-      //static assert(!is(typeof(super.  privateTF())));    // Bugzilla 5770
+        static assert(!is(typeof(super.  privateTF())));
 
         auto dg = {
             static assert( is(typeof(this.   publicF())));
@@ -169,17 +169,17 @@ class D : C
             static assert( is(typeof(this.   publicTF())));
             static assert( is(typeof(this.protectedTF())));
             static assert( is(typeof(this.  packageTF())));
-          //static assert(!is(typeof(this.  privateTF())));     // Bugzilla 5770
+            static assert(!is(typeof(this.  privateTF())));
 
             static assert( is(typeof(super.   publicF())));
-          //static assert( is(typeof(super.protectedF())));     // Bugzilla 5770
+            static assert( is(typeof(super.protectedF())));
             static assert( is(typeof(super.  packageF())));
             static assert(!is(typeof(super.  privateF())));
 
             static assert( is(typeof(super.   publicTF())));
             static assert( is(typeof(super.protectedTF())));
             static assert( is(typeof(super.  packageTF())));
-          //static assert(!is(typeof(super.  privateTF())));    // Bugzilla 5770
+            static assert(!is(typeof(super.  privateTF())));
         };
     }
     void test2()()
@@ -192,17 +192,17 @@ class D : C
         static assert( is(typeof(this.   publicTF())));
         static assert( is(typeof(this.protectedTF())));
         static assert( is(typeof(this.  packageTF())));
-      //static assert(!is(typeof(this.  privateTF())));     // Bugzilla 5770
+        static assert(!is(typeof(this.  privateTF())));
 
         static assert( is(typeof(super.   publicF())));
-      //static assert( is(typeof(super.protectedF())));     // Bugzilla 5770
+        static assert( is(typeof(super.protectedF())));
         static assert( is(typeof(super.  packageF())));
         static assert(!is(typeof(super.  privateF())));
 
         static assert( is(typeof(super.   publicTF())));
         static assert( is(typeof(super.protectedTF())));
         static assert( is(typeof(super.  packageTF())));
-      //static assert(!is(typeof(super.  privateTF())));    // Bugzilla 5770
+        static assert(!is(typeof(super.  privateTF())));
 
         auto dg = {
             static assert( is(typeof(this.   publicF())));
@@ -213,18 +213,71 @@ class D : C
             static assert( is(typeof(this.   publicTF())));
             static assert( is(typeof(this.protectedTF())));
             static assert( is(typeof(this.  packageTF())));
-          //static assert(!is(typeof(this.  privateTF())));     // Bugzilla 5770
+            static assert(!is(typeof(this.  privateTF())));
 
             static assert( is(typeof(super.   publicF())));
-          //static assert( is(typeof(super.protectedF())));     // Bugzilla 5770
+            static assert( is(typeof(super.protectedF())));
             static assert( is(typeof(super.  packageF())));
             static assert(!is(typeof(super.  privateF())));
 
             static assert( is(typeof(super.   publicTF())));
             static assert( is(typeof(super.protectedTF())));
             static assert( is(typeof(super.  packageTF())));
-          //static assert(!is(typeof(super.  privateTF())));    // Bugzilla 5770
+            static assert(!is(typeof(super.  privateTF())));
         };
     }
     alias test2x = test2!();    // instantiate
+
+    class N
+    {
+        void test1()
+        {
+            static assert( is(typeof(   publicF())));
+            static assert( is(typeof(protectedF())));
+            static assert( is(typeof(  packageF())));
+            static assert(!is(typeof(  privateF())));
+
+            static assert( is(typeof(   publicTF())));
+            static assert( is(typeof(protectedTF())));
+            static assert( is(typeof(  packageTF())));
+            static assert(!is(typeof(  privateTF())));
+
+            auto dg = {
+                static assert( is(typeof(   publicF())));
+                static assert( is(typeof(protectedF())));
+                static assert( is(typeof(  packageF())));
+                static assert(!is(typeof(  privateF())));
+
+                static assert( is(typeof(   publicTF())));
+                static assert( is(typeof(protectedTF())));
+                static assert( is(typeof(  packageTF())));
+                static assert(!is(typeof(  privateTF())));
+            };
+        }
+        void test2()()
+        {
+            static assert( is(typeof(   publicF())));
+            static assert( is(typeof(protectedF())));
+            static assert( is(typeof(  packageF())));
+            static assert(!is(typeof(  privateF())));
+
+            static assert( is(typeof(   publicTF())));
+            static assert( is(typeof(protectedTF())));
+            static assert( is(typeof(  packageTF())));
+            static assert(!is(typeof(  privateTF())));
+
+            auto dg = {
+                static assert( is(typeof(   publicF())));
+                static assert( is(typeof(protectedF())));
+                static assert( is(typeof(  packageF())));
+                static assert(!is(typeof(  privateF())));
+
+                static assert( is(typeof(   publicTF())));
+                static assert( is(typeof(protectedTF())));
+                static assert( is(typeof(  packageTF())));
+                static assert(!is(typeof(  privateTF())));
+            };
+        }
+        alias test2x = test2!();    // instantiate
+    }
 }

--- a/test/compilable/testprot5770.d
+++ b/test/compilable/testprot5770.d
@@ -1,0 +1,230 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+module imports.testprot5770;
+
+import imports.prot5770;
+
+version(all)    // access module members from module scope
+{
+    static assert( is(typeof(C.init.   publicF())));
+    static assert(!is(typeof(C.init.protectedF())));
+    static assert( is(typeof(C.init.  packageF())));
+    static assert(!is(typeof(C.init.  privateF())));
+
+    static assert( is(typeof(C.init.   publicTF())));
+  //static assert(!is(typeof(C.init.protectedTF())));   // Bugzilla 5770
+    static assert( is(typeof(C.init.  packageTF())));
+  //static assert(!is(typeof(C.init.  privateTF())));   // Bugzilla 5770
+}
+version(all)    // access class members from module scope
+{
+    static assert( is(typeof(C.init.   publicF())));
+    static assert(!is(typeof(C.init.protectedF())));
+    static assert( is(typeof(C.init.  packageF())));
+    static assert(!is(typeof(C.init.  privateF())));
+
+    static assert( is(typeof(C.init.   publicTF())));
+  //static assert(!is(typeof(C.init.protectedTF())));   // Bugzilla 5770
+    static assert( is(typeof(C.init.  packageTF())));
+  //static assert(!is(typeof(C.init.  privateTF())));   // Bugzilla 5770
+
+    static assert( is(typeof(D.init.   publicF())));
+    static assert(!is(typeof(D.init.protectedF())));
+    static assert( is(typeof(D.init.  packageF())));
+    static assert(!is(typeof(D.init.  privateF())));
+
+    static assert( is(typeof(D.init.   publicTF())));
+  //static assert(!is(typeof(D.init.protectedTF())));   // Bugzilla 5770
+    static assert( is(typeof(D.init.  packageTF())));
+  //static assert(!is(typeof(D.init.  privateTF())));   // Bugzilla 5770
+}
+version(all)    // access struct members from module scope
+{
+    static assert( is(typeof(S.init.   publicF())));
+    static assert(!is(typeof(S.init.protectedF())));
+    static assert( is(typeof(S.init.  packageF())));
+    static assert(!is(typeof(S.init.  privateF())));
+
+    static assert( is(typeof(S.init.   publicTF())));
+  //static assert(!is(typeof(S.init.protectedTF())));   // Bugzilla 5770
+    static assert( is(typeof(S.init.  packageTF())));
+  //static assert(!is(typeof(S.init.  privateTF())));   // Bugzilla 5770
+}
+
+void testC1()
+{
+    C c = new C();
+
+    static assert( is(typeof(c.   publicF())));
+    static assert(!is(typeof(c.protectedF())));
+    static assert( is(typeof(c.  packageF())));
+    static assert(!is(typeof(c.  privateF())));
+
+    static assert( is(typeof(c.   publicTF())));
+  //static assert(!is(typeof(c.protectedTF())));    // Bugzilla 5770
+    static assert( is(typeof(c.  packageTF())));
+  //static assert(!is(typeof(c.  privateTF())));    // Bugzilla 5770
+
+    D d = new D();
+
+    static assert( is(typeof(d.   publicF())));
+  //static assert(!is(typeof(d.protectedF())));     // Bugzilla 5770
+    static assert( is(typeof(d.  packageF())));
+    static assert(!is(typeof(d.  privateF())));
+
+    static assert( is(typeof(d.   publicTF())));
+  //static assert(!is(typeof(d.protectedTF())));    // Bugzilla 5770
+    static assert( is(typeof(d.  packageTF())));
+  //static assert(!is(typeof(d.  privateTF())));    // Bugzilla 5770
+}
+void testC2()()
+{
+    C c = new C();
+
+    static assert( is(typeof(c.   publicF())));
+    static assert(!is(typeof(c.protectedF())));
+    static assert( is(typeof(c.  packageF())));
+    static assert(!is(typeof(c.  privateF())));
+
+    static assert( is(typeof(c.   publicTF())));
+  //static assert(!is(typeof(c.protectedTF())));    // Bugzilla 5770
+    static assert( is(typeof(c.  packageTF())));
+  //static assert(!is(typeof(c.  privateTF())));    // Bugzilla 5770
+
+    D d = new D();
+
+    static assert( is(typeof(d.   publicF())));
+  //static assert(!is(typeof(d.protectedF())));     // Bugzilla 5770
+    static assert( is(typeof(d.  packageF())));
+    static assert(!is(typeof(d.  privateF())));
+
+    static assert( is(typeof(d.   publicTF())));
+  //static assert(!is(typeof(d.protectedTF())));    // Bugzilla 5770
+    static assert( is(typeof(d.  packageTF())));
+  //static assert(!is(typeof(d.  privateTF())));    // Bugzilla 5770
+}
+alias testC2x = testC2!();
+
+void testS1()
+{
+    S s;
+
+    static assert( is(typeof(s.   publicF())));
+    static assert(!is(typeof(s.protectedF())));
+    static assert( is(typeof(s.  packageF())));
+    static assert(!is(typeof(s.  privateF())));
+
+    static assert( is(typeof(s.   publicTF())));
+  //static assert(!is(typeof(s.protectedTF())));    // Bugzilla 5770
+    static assert( is(typeof(s.  packageTF())));
+  //static assert(!is(typeof(s.  privateTF())));    // Bugzilla 5770
+}
+void testS2()()
+{
+    S s;
+
+    static assert( is(typeof(s.   publicF())));
+    static assert(!is(typeof(s.protectedF())));
+    static assert( is(typeof(s.  packageF())));
+    static assert(!is(typeof(s.  privateF())));
+
+    static assert( is(typeof(s.   publicTF())));
+  //static assert(!is(typeof(s.protectedTF())));    // Bugzilla 5770
+    static assert( is(typeof(s.  packageTF())));
+  //static assert(!is(typeof(s.  privateTF())));    // Bugzilla 5770
+}
+alias testS2x = testS2!();
+
+class D : C
+{
+    void test1()
+    {
+        static assert( is(typeof(this.   publicF())));
+        static assert( is(typeof(this.protectedF())));
+        static assert( is(typeof(this.  packageF())));
+        static assert(!is(typeof(this.  privateF())));
+
+        static assert( is(typeof(this.   publicTF())));
+        static assert( is(typeof(this.protectedTF())));
+        static assert( is(typeof(this.  packageTF())));
+      //static assert(!is(typeof(this.  privateTF())));     // Bugzilla 5770
+
+        static assert( is(typeof(super.   publicF())));
+        static assert( is(typeof(super.protectedF())));
+        static assert( is(typeof(super.  packageF())));
+        static assert(!is(typeof(super.  privateF())));
+
+        static assert( is(typeof(super.   publicTF())));
+        static assert( is(typeof(super.protectedTF())));
+        static assert( is(typeof(super.  packageTF())));
+      //static assert(!is(typeof(super.  privateTF())));    // Bugzilla 5770
+
+        auto dg = {
+            static assert( is(typeof(this.   publicF())));
+            static assert( is(typeof(this.protectedF())));
+            static assert( is(typeof(this.  packageF())));
+            static assert(!is(typeof(this.  privateF())));
+
+            static assert( is(typeof(this.   publicTF())));
+            static assert( is(typeof(this.protectedTF())));
+            static assert( is(typeof(this.  packageTF())));
+          //static assert(!is(typeof(this.  privateTF())));     // Bugzilla 5770
+
+            static assert( is(typeof(super.   publicF())));
+          //static assert( is(typeof(super.protectedF())));     // Bugzilla 5770
+            static assert( is(typeof(super.  packageF())));
+            static assert(!is(typeof(super.  privateF())));
+
+            static assert( is(typeof(super.   publicTF())));
+            static assert( is(typeof(super.protectedTF())));
+            static assert( is(typeof(super.  packageTF())));
+          //static assert(!is(typeof(super.  privateTF())));    // Bugzilla 5770
+        };
+    }
+    void test2()()
+    {
+        static assert( is(typeof(this.   publicF())));
+        static assert( is(typeof(this.protectedF())));
+        static assert( is(typeof(this.  packageF())));
+        static assert(!is(typeof(this.  privateF())));
+
+        static assert( is(typeof(this.   publicTF())));
+        static assert( is(typeof(this.protectedTF())));
+        static assert( is(typeof(this.  packageTF())));
+      //static assert(!is(typeof(this.  privateTF())));     // Bugzilla 5770
+
+        static assert( is(typeof(super.   publicF())));
+      //static assert( is(typeof(super.protectedF())));     // Bugzilla 5770
+        static assert( is(typeof(super.  packageF())));
+        static assert(!is(typeof(super.  privateF())));
+
+        static assert( is(typeof(super.   publicTF())));
+        static assert( is(typeof(super.protectedTF())));
+        static assert( is(typeof(super.  packageTF())));
+      //static assert(!is(typeof(super.  privateTF())));    // Bugzilla 5770
+
+        auto dg = {
+            static assert( is(typeof(this.   publicF())));
+            static assert( is(typeof(this.protectedF())));
+            static assert( is(typeof(this.  packageF())));
+            static assert(!is(typeof(this.  privateF())));
+
+            static assert( is(typeof(this.   publicTF())));
+            static assert( is(typeof(this.protectedTF())));
+            static assert( is(typeof(this.  packageTF())));
+          //static assert(!is(typeof(this.  privateTF())));     // Bugzilla 5770
+
+            static assert( is(typeof(super.   publicF())));
+          //static assert( is(typeof(super.protectedF())));     // Bugzilla 5770
+            static assert( is(typeof(super.  packageF())));
+            static assert(!is(typeof(super.  privateF())));
+
+            static assert( is(typeof(super.   publicTF())));
+            static assert( is(typeof(super.protectedTF())));
+            static assert( is(typeof(super.  packageTF())));
+          //static assert(!is(typeof(super.  privateTF())));    // Bugzilla 5770
+        };
+    }
+    alias test2x = test2!();    // instantiate
+}

--- a/test/fail_compilation/diag10169.d
+++ b/test/fail_compilation/diag10169.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10169.d(11): Error: struct imports.a10169.B member x is not accessible
+fail_compilation/diag10169.d(11): Error: struct imports.a10169.B member x is not accessible from module diag10169
 ---
 */
 import imports.a10169;

--- a/test/fail_compilation/diag5385.d
+++ b/test/fail_compilation/diag5385.d
@@ -1,14 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag5385.d(3): Error: class imports.fail5385.C member privX is not accessible
-fail_compilation/diag5385.d(4): Error: class imports.fail5385.C member packX is not accessible
-fail_compilation/diag5385.d(5): Error: class imports.fail5385.C member privX2 is not accessible
-fail_compilation/diag5385.d(6): Error: class imports.fail5385.C member packX2 is not accessible
-fail_compilation/diag5385.d(7): Error: struct imports.fail5385.S member privX is not accessible
-fail_compilation/diag5385.d(8): Error: struct imports.fail5385.S member packX is not accessible
-fail_compilation/diag5385.d(9): Error: struct imports.fail5385.S member privX2 is not accessible
-fail_compilation/diag5385.d(10): Error: struct imports.fail5385.S member packX2 is not accessible
+fail_compilation/diag5385.d(3): Error: class imports.fail5385.C member privX is not accessible from module diag5385
+fail_compilation/diag5385.d(4): Error: class imports.fail5385.C member packX is not accessible from module diag5385
+fail_compilation/diag5385.d(5): Error: class imports.fail5385.C member privX2 is not accessible from module diag5385
+fail_compilation/diag5385.d(6): Error: class imports.fail5385.C member packX2 is not accessible from module diag5385
+fail_compilation/diag5385.d(7): Error: struct imports.fail5385.S member privX is not accessible from module diag5385
+fail_compilation/diag5385.d(8): Error: struct imports.fail5385.S member packX is not accessible from module diag5385
+fail_compilation/diag5385.d(9): Error: struct imports.fail5385.S member privX2 is not accessible from module diag5385
+fail_compilation/diag5385.d(10): Error: struct imports.fail5385.S member packX2 is not accessible from module diag5385
 ---
 */
 

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -5,10 +5,10 @@ fail_compilation/fail10528.d(19): Error: module fail10528 variable a10528.a is p
 fail_compilation/fail10528.d(20): Error: variable a10528.a is not accessible from module fail10528
 fail_compilation/fail10528.d(22): Error: variable a10528.b is not accessible from module fail10528
 fail_compilation/fail10528.d(23): Error: variable a10528.b is not accessible from module fail10528
-fail_compilation/fail10528.d(25): Error: variable a10528.S.c is not accessible from module fail10528
-fail_compilation/fail10528.d(26): Error: variable a10528.S.c is not accessible from module fail10528
-fail_compilation/fail10528.d(28): Error: variable a10528.C.d is not accessible from module fail10528
-fail_compilation/fail10528.d(29): Error: variable a10528.C.d is not accessible from module fail10528
+fail_compilation/fail10528.d(25): Error: struct a10528.S member c is not accessible from module fail10528
+fail_compilation/fail10528.d(26): Error: struct a10528.S member c is not accessible from module fail10528
+fail_compilation/fail10528.d(28): Error: class a10528.C member d is not accessible from module fail10528
+fail_compilation/fail10528.d(29): Error: class a10528.C member d is not accessible from module fail10528
 ---
 */
 

--- a/test/fail_compilation/fail5770.d
+++ b/test/fail_compilation/fail5770.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail5770.d(13): Error: struct imports.a5770.S member this is not accessible from module fail5770
+fail_compilation/fail5770.d(14): Error: struct imports.a5770.S member this is not accessible from module fail5770
+---
+*/
+
+import imports.a5770;
+
+void main()
+{
+    auto s = S(10);
+    auto t = S("a");
+}

--- a/test/fail_compilation/imports/a5770.d
+++ b/test/fail_compilation/imports/a5770.d
@@ -1,0 +1,8 @@
+module imports.a5770;
+
+struct S
+{
+private:
+    this(int n) {}
+    this(A...)(A args) {}
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=5770

It had caused by the incomplete implementation of access check. Most part of `access.c` was old code from ancient D ages.
