### PR TITLE
Refactor: simplify setting of useArrayBounds

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -22,6 +22,16 @@
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
 
+// The state of array bounds checking
+enum BOUNDSCHECK
+{
+    BOUNDSCHECKdefault, // initial value
+    BOUNDSCHECKoff,     // never do bounds checking
+    BOUNDSCHECKon,      // always do bounds checking
+    BOUNDSCHECKsafeonly // do bounds checking only in @safe functions
+};
+
+
 // Put command line switches in here
 struct Param
 {
@@ -57,9 +67,6 @@ struct Param
     bool useInvariants; // generate class invariant checks
     bool useIn;         // generate precondition checks
     bool useOut;        // generate postcondition checks
-    char useArrayBounds; // 0: no array bounds checks
-                         // 1: array bounds checks for safe functions only
-                         // 2: array bounds checks for all functions
     bool stackstomp;    // add stack stomping code
     bool useSwitchError; // check for switches without a default
     bool useUnitTests;  // generate unittest code
@@ -80,6 +87,8 @@ struct Param
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
+
+    BOUNDSCHECK useArrayBounds;
 
     const char *argv0;    // program name
     Array<const char *> *imppath;     // array of char*'s of where to look for import modules

--- a/src/irstate.c
+++ b/src/irstate.c
@@ -222,21 +222,35 @@ FuncDeclaration *IRState::getFunc()
 
 
 /**********************
- * Return !=0 if do array bounds checking
+ * Returns true if do array bounds checking for the current function
  */
-int IRState::arrayBoundsCheck()
+bool IRState::arrayBoundsCheck()
 {
-    int result = global.params.useArrayBounds;
+    bool result;
+    switch (global.params.useArrayBounds)
+    {
+        case BOUNDSCHECKoff:
+            result = false;
+            break;
 
-    if (result == 1)
-    {   // For safe functions only
-        result = 0;
-        FuncDeclaration *fd = getFunc();
-        if (fd)
-        {   Type *t = fd->type;
-            if (t->ty == Tfunction && ((TypeFunction *)t)->trust == TRUSTsafe)
-                result = 1;
+        case BOUNDSCHECKon:
+            result = true;
+            break;
+
+        case BOUNDSCHECKsafeonly:
+        {
+            result = false;
+            FuncDeclaration *fd = getFunc();
+            if (fd)
+            {   Type *t = fd->type;
+                if (t->ty == Tfunction && ((TypeFunction *)t)->trust == TRUSTsafe)
+                    result = true;
+            }
+            break;
         }
+
+        default:
+            assert(0);
     }
     return result;
 }

--- a/src/irstate.h
+++ b/src/irstate.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2014 by Digital Mars
+ * Copyright (c) 1999-2015 by Digital Mars
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com
@@ -59,7 +59,7 @@ struct IRState
     block *getDefaultBlock();
     block *getFinallyBlock();
     FuncDeclaration *getFunc();
-    int arrayBoundsCheck();
+    bool arrayBoundsCheck();
 };
 
 #endif /* DMD_CONTEXT_H */


### PR DESCRIPTION
1. Add enum to convey meaning.
2. Straighten out overly complex logic.
3. Alphabetize commands in help message.

Refactor only - should not be any change in functionality.
