### PR TITLE
Add tokens for signed/unsigned 128bit integer values.

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2792,6 +2792,8 @@ Objects *Parser::parseTemplateSingleArgument()
         case TOKuns32v:
         case TOKint64v:
         case TOKuns64v:
+        case TOKint128v:
+        case TOKuns128v:
         case TOKfloat32v:
         case TOKfloat64v:
         case TOKfloat80v:
@@ -4482,6 +4484,8 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr, Loc *pEndloc
         case TOKuns32v:
         case TOKint64v:
         case TOKuns64v:
+        case TOKint128v:
+        case TOKuns128v:
         case TOKfloat32v:
         case TOKfloat64v:
         case TOKfloat80v:
@@ -5676,6 +5680,8 @@ bool Parser::isBasicType(Token **pt)
                         case TOKuns32v:
                         case TOKint64v:
                         case TOKuns64v:
+                        case TOKint128v:
+                        case TOKuns128v:
                         case TOKfloat32v:
                         case TOKfloat64v:
                         case TOKfloat80v:
@@ -7129,6 +7135,8 @@ Expression *Parser::parseUnaryExp()
                     case TOKuns32v:
                     case TOKint64v:
                     case TOKuns64v:
+                    case TOKint128v:
+                    case TOKuns128v:
                     case TOKfloat32v:
                     case TOKfloat64v:
                     case TOKfloat80v:

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -107,6 +107,7 @@ enum TOK
         // Numeric literals
         TOKint32v, TOKuns32v,
         TOKint64v, TOKuns64v,
+        TOKint128v, TOKuns128v,
         TOKfloat32v, TOKfloat64v, TOKfloat80v,
         TOKimaginary32v, TOKimaginary64v, TOKimaginary80v,
 
@@ -131,7 +132,7 @@ enum TOK
         TOKcomplex32, TOKcomplex64, TOKcomplex80,
         TOKchar, TOKwchar, TOKdchar, TOKbool,
 
-// 157
+// 159
         // Aggregates
         TOKstruct, TOKclass, TOKinterface, TOKunion, TOKenum, TOKimport,
         TOKtypedef, TOKalias, TOKoverride, TOKdelegate, TOKfunction,


### PR DESCRIPTION
Add the tokens to the token list and adds them to the parser where needed.
Does not add a lexer for these values - they are unused.

See https://github.com/ldc-developers/ldc/pull/891 for the use case.
