### PR TITLE
[refactor] Move Type::ctype into an external AA

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -779,10 +779,6 @@ public:
         return type;
     }
 
-    // Back end
-    Symbol* stag; // tag symbol for debug data
-    Symbol* sinit;
-
     override final inout(AggregateDeclaration) isAggregateDeclaration() inout
     {
         return this;

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -280,7 +280,6 @@ public:
     int inuse;                          // to prevent recursive attempts
     Baseok baseok;                      // set the progress of base classes resolving
     Objc_ClassDeclaration objc;
-    Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
     ClassDeclaration(Loc loc, Identifier *id, BaseClasses *baseclasses, bool inObject = false);
     Dsymbol *syntaxCopy(Dsymbol *s);

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -308,9 +308,6 @@ public:
 
     void addLocalClass(ClassDeclarations *);
 
-    // Back end
-    Symbol *vtblsym;
-
     ClassDeclaration *isClassDeclaration() { return (ClassDeclaration *)this; }
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -144,10 +144,6 @@ public:
     // 'this' type
     Type *handleType() { return type; }
 
-    // Back end
-    Symbol *stag;               // tag symbol for debug data
-    Symbol *sinit;
-
     AggregateDeclaration *isAggregateDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -226,8 +226,6 @@ public:
 
     Objc_ClassDeclaration objc;
 
-    Symbol* cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
-
     final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses, bool inObject = false)
     {
         if (!id)

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1500,9 +1500,6 @@ public:
         aclasses.push(this);
     }
 
-    // Back end
-    Symbol* vtblsym;
-
     override final inout(ClassDeclaration) isClassDeclaration() inout
     {
         return this;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -567,7 +567,6 @@ public:
     // Support for NRVO (named return value optimization)
     bool nrvo_can;                      // true means we can do it
     VarDeclaration *nrvo_var;           // variable to replace with shidden
-    Symbol *shidden;                    // hidden pointer passed to function
 
     ReturnStatements *returns;
 

--- a/src/denum.d
+++ b/src/denum.d
@@ -488,8 +488,6 @@ public:
         return this;
     }
 
-    Symbol* sinit;
-
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -1284,7 +1284,6 @@ public:
     Symbol* cov; // private uint[] __coverage;
     uint* covb; // bit array of valid code line numbers
     bool hasModuleInfo;
-    Symbol* sfilename; // symbol for filename
     Symbol* massert; // module assert function
     Symbol* munittest; // module unittest failure function
     Symbol* marray; // module array bounds function

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -1283,12 +1283,7 @@ public:
     int doppelganger; // sub-module
     Symbol* cov; // private uint[] __coverage;
     uint* covb; // bit array of valid code line numbers
-    Symbol* sictor; // module order independent constructor
-    Symbol* sctor; // module constructor
-    Symbol* sdtor; // module destructor
-    Symbol* ssharedctor; // module shared constructor
-    Symbol* sshareddtor; // module shared destructor
-    Symbol* stest; // module unit test
+    bool hasModuleInfo;
     Symbol* sfilename; // symbol for filename
     Symbol* massert; // module assert function
     Symbol* munittest; // module unittest failure function

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -1280,9 +1280,7 @@ public:
     }
 
     // Back end
-    Symbol* cov; // private uint[] __coverage;
     Module doppelganger; // sub-module
-    uint* covb; // bit array of valid code line numbers
     bool hasModuleInfo;
 
     override inout(Module) isModule() inout

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -1280,13 +1280,10 @@ public:
     }
 
     // Back end
-    int doppelganger; // sub-module
     Symbol* cov; // private uint[] __coverage;
+    Module doppelganger; // sub-module
     uint* covb; // bit array of valid code line numbers
     bool hasModuleInfo;
-    Symbol* massert; // module assert function
-    Symbol* munittest; // module unittest failure function
-    Symbol* marray; // module array bounds function
 
     override inout(Module) isModule() inout
     {

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -192,7 +192,6 @@ extern (C++) class Dsymbol : RootObject
 public:
     Identifier ident;
     Dsymbol parent;
-    Symbol* csym;           // symbol for code generator
     Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol
     Loc loc;                // where defined

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -192,7 +192,6 @@ extern (C++) class Dsymbol : RootObject
 public:
     Identifier ident;
     Dsymbol parent;
-    Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol
     Loc loc;                // where defined
     Scope* _scope;          // !=null means context to use for semantic()

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -53,7 +53,6 @@ class UnitTestDeclaration;
 class NewDeclaration;
 class VarDeclaration;
 class AttribDeclaration;
-struct Symbol;
 class Package;
 class Module;
 class Import;

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -155,7 +155,6 @@ class Dsymbol : public RootObject
 public:
     Identifier *ident;
     Dsymbol *parent;
-    Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol
     Loc loc;                    // where defined
     Scope *_scope;               // !=NULL means context to use for semantic()

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -155,7 +155,6 @@ class Dsymbol : public RootObject
 public:
     Identifier *ident;
     Dsymbol *parent;
-    Symbol *csym;               // symbol for code generator
     Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol
     Loc loc;                    // where defined

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -69,6 +69,7 @@ elem *filelinefunction(IRState *irs, Expression *e);
 void toTraceGC(IRState *irs, elem *e, Loc *loc);
 void genTypeInfo(Type *t, Scope *sc);
 void setClosureVarOffset(FuncDeclaration *fd);
+Symbol *getHiddenVar(FuncDeclaration *fd);
 
 int callSideEffectLevel(FuncDeclaration *f);
 int callSideEffectLevel(Type *t);
@@ -993,7 +994,7 @@ elem *toElem(Expression *e, IRState *irs)
             int nrvo = 0;
             if (fd && fd->nrvo_can && fd->nrvo_var == se->var)
             {
-                s = fd->shidden;
+                s = getHiddenVar(fd);
                 nrvo = 1;
             }
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -70,6 +70,7 @@ void toTraceGC(IRState *irs, elem *e, Loc *loc);
 void genTypeInfo(Type *t, Scope *sc);
 void setClosureVarOffset(FuncDeclaration *fd);
 Symbol *getHiddenVar(FuncDeclaration *fd);
+Symbol *getStructLiteralSym(StructLiteralExp *sle);
 
 int callSideEffectLevel(FuncDeclaration *f);
 int callSideEffectLevel(Type *t);
@@ -5252,7 +5253,7 @@ elem *toElem(Expression *e, IRState *irs)
         void visit(StructLiteralExp *sle)
         {
             //printf("[%s] StructLiteralExp::toElem() %s\n", sle->loc.toChars(), sle->toChars());
-            result = toElemStructLit(sle, irs, TOKconstruct, sle->sym, true);
+            result = toElemStructLit(sle, irs, TOKconstruct, getStructLiteralSym(sle), true);
         }
 
         /*****************************************************/

--- a/src/enum.h
+++ b/src/enum.h
@@ -66,7 +66,6 @@ public:
 
     EnumDeclaration *isEnumDeclaration() { return this; }
 
-    Symbol *sinit;
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -5312,8 +5312,6 @@ public:
     Type stype;             // final type of result (can be different from sd's type)
 
     bool useStaticInit;     // if this is true, use the StructDeclaration's init symbol
-    Symbol* sym;            // back end symbol to initialize with literal
-
     OwnedBy ownedByCtfe = OWNEDcode;
 
     // pointer to the origin instance of the expression.

--- a/src/expression.h
+++ b/src/expression.h
@@ -43,7 +43,6 @@ class TemplateInstance;
 class TemplateDeclaration;
 class ClassDeclaration;
 class BinExp;
-struct Symbol;          // back end symbol
 class OverloadSet;
 class Initializer;
 class StringExp;

--- a/src/expression.h
+++ b/src/expression.h
@@ -471,8 +471,6 @@ public:
     Type *stype;                // final type of result (can be different from sd's type)
 
     bool useStaticInit;         // if this is true, use the StructDeclaration's init symbol
-    Symbol *sym;                // back end symbol to initialize with literal
-
     OwnedBy ownedByCtfe;
 
     // pointer to the origin instance of the expression.

--- a/src/func.d
+++ b/src/func.d
@@ -466,7 +466,6 @@ public:
     // Support for NRVO (named return value optimization)
     bool nrvo_can = true;               // true means we can do it
     VarDeclaration nrvo_var;            // variable to replace with shidden
-    Symbol* shidden;                    // hidden pointer passed to function
 
     ReturnStatements* returns;
 

--- a/src/glue.c
+++ b/src/glue.c
@@ -1054,7 +1054,6 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
 
     if (fd->vthis)
     {
-        assert(!fd->vthis->csym);
         sthis = toSymbol(fd->vthis);
         irs.sthis = sthis;
         if (!(f->Fflags3 & Fnested))
@@ -1088,7 +1087,6 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
         {
             VarDeclaration *v = (*fd->parameters)[i];
             //printf("param[%d] = %p, %s\n", i, v, v->toChars());
-            assert(!v->csym);
             params[pi + i] = toSymbol(v);
         }
         pi += fd->parameters->dim;

--- a/src/glue.c
+++ b/src/glue.c
@@ -30,6 +30,7 @@
 #include "target.h"
 
 #include "rmem.h"
+#include "aav.h"
 #include "cc.h"
 #include "global.h"
 #include "oper.h"
@@ -1577,12 +1578,14 @@ elem *toEfilename(Module *m)
     const char *id = m->srcfile->toChars();
     size_t len = strlen(id);
 
-    if (!m->sfilename)
+    static AA *symMap;
+    Symbol **psym = (Symbol **)dmd_aaGet(&symMap, m);
+    if (!*psym)
     {
         // Put out as a static array
-        m->sfilename = toStringSymbol(id, len, 1);
+        *psym = toStringSymbol(id, len, 1);
     }
 
     // Turn static array into dynamic array
-    return el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(m->sfilename));
+    return el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(*psym));
 }

--- a/src/glue.c
+++ b/src/glue.c
@@ -63,6 +63,7 @@ Symbol *toModuleUnittest(Module *m);
 Symbol *toModuleArray(Module *m);
 Symbol *toSymbolX(Dsymbol *ds, const char *prefix, int sclass, type *t, const char *suffix);
 static void genhelpers(Module *m);
+void setHiddenVar(FuncDeclaration *fd, Symbol *shidden);
 
 elem *eictor;
 symbol *ictorlocalgot;
@@ -1041,8 +1042,8 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
         shidden->Sflags |= SFLtrue | SFLfree;
         if (fd->nrvo_can && fd->nrvo_var && fd->nrvo_var->nestedrefs.dim)
             type_setcv(&shidden->Stype, shidden->Stype->Tty | mTYvolatile);
+        setHiddenVar(fd, shidden);
         irs.shidden = shidden;
-        fd->shidden = shidden;
     }
     else
     {

--- a/src/glue.c
+++ b/src/glue.c
@@ -141,12 +141,8 @@ void obj_write_deferred(Library *library)
             Module *md = Module::create(mname, id, 0, 0);
             md->members = Dsymbols_create();
             md->members->push(s);   // its only 'member' is s
-            md->doppelganger = 1;       // identify this module as doppelganger
+            md->doppelganger = m;       // identify this module as doppelganger
             md->md = m->md;
-            md->aimports.push(m);       // it only 'imports' m
-            md->massert = m->massert;
-            md->munittest = m->munittest;
-            md->marray = m->marray;
 
             genObjFile(md, false);
         }
@@ -336,13 +332,11 @@ void genObjFile(Module *m, bool multiobj)
     sshareddtors.setDim(0);
     stests.setDim(0);
 
-    if (m->doppelganger)
+    if (Module *mod = m->doppelganger)
     {
         /* Generate a reference to the moduleinfo, so the module constructors
          * and destructors get linked in.
          */
-        Module *mod = m->aimports[0];
-        assert(mod);
         if (mod->hasModuleInfo)
         {
             Symbol *s = toSymbol(mod);

--- a/src/gluelayer.d
+++ b/src/gluelayer.d
@@ -18,7 +18,6 @@ import ddmd.root.file;
 
 version (NoBackend)
 {
-    struct code;
     struct block;
     struct Blockx;
     struct elem;
@@ -54,7 +53,6 @@ else
 {
     import ddmd.backend;
 
-    alias code = ddmd.backend.code;
     alias block = ddmd.backend.block;
     alias Blockx = ddmd.backend.Blockx;
     alias elem = ddmd.backend.elem;

--- a/src/gluelayer.d
+++ b/src/gluelayer.d
@@ -18,7 +18,6 @@ import ddmd.root.file;
 
 version (NoBackend)
 {
-    struct Symbol;
     struct code;
     struct block;
     struct Blockx;
@@ -55,7 +54,6 @@ else
 {
     import ddmd.backend;
 
-    alias Symbol = ddmd.backend.Symbol;
     alias code = ddmd.backend.code;
     alias block = ddmd.backend.block;
     alias Blockx = ddmd.backend.Blockx;

--- a/src/gluelayer.d
+++ b/src/gluelayer.d
@@ -18,12 +18,6 @@ import ddmd.root.file;
 
 version (NoBackend)
 {
-    struct block;
-    struct Blockx;
-    struct elem;
-    struct TYPE;
-    alias type = TYPE;
-
     extern (C++)
     {
         // glue
@@ -52,11 +46,6 @@ version (NoBackend)
 else
 {
     import ddmd.backend;
-
-    alias block = ddmd.backend.block;
-    alias Blockx = ddmd.backend.Blockx;
-    alias elem = ddmd.backend.elem;
-    alias type = ddmd.backend.type;
 
     extern (C++)
     {

--- a/src/inline.d
+++ b/src/inline.d
@@ -870,7 +870,6 @@ public:
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
-                vto.isym = null;
 
                 ids.from.push(vd);
                 ids.to.push(vto);
@@ -1016,8 +1015,6 @@ public:
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
-                vto.isym = null;
-
                 ids.from.push(vd);
                 ids.to.push(vto);
 
@@ -1044,8 +1041,6 @@ public:
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
-                vto.isym = null;
-
                 ids.from.push(vd);
                 ids.to.push(vto);
 

--- a/src/inline.d
+++ b/src/inline.d
@@ -870,7 +870,6 @@ public:
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
-                vto.csym = null;
                 vto.isym = null;
 
                 ids.from.push(vd);
@@ -1017,7 +1016,6 @@ public:
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
-                vto.csym = null;
                 vto.isym = null;
 
                 ids.from.push(vd);
@@ -1046,7 +1044,6 @@ public:
                 auto vto = new VarDeclaration(vd.loc, vd.type, vd.ident, vd._init);
                 memcpy(cast(void*)vto, cast(void*)vd, __traits(classInstanceSize, VarDeclaration));
                 vto.parent = ids.parent;
-                vto.csym = null;
                 vto.isym = null;
 
                 ids.from.push(vd);

--- a/src/module.h
+++ b/src/module.h
@@ -151,15 +151,11 @@ public:
 
     // Back end
 
-    int doppelganger;           // sub-module
     Symbol *cov;                // private uint[] __coverage;
+    Module *doppelganger;           // sub-module
     unsigned *covb;             // bit array of valid code line numbers
 
     bool hasModuleInfo;
-
-    Symbol *massert;            // module assert function
-    Symbol *munittest;          // module unittest failure function
-    Symbol *marray;             // module array bounds function
 
     Module *isModule() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/module.h
+++ b/src/module.h
@@ -151,9 +151,7 @@ public:
 
     // Back end
 
-    Symbol *cov;                // private uint[] __coverage;
     Module *doppelganger;           // sub-module
-    unsigned *covb;             // bit array of valid code line numbers
 
     bool hasModuleInfo;
 

--- a/src/module.h
+++ b/src/module.h
@@ -155,12 +155,7 @@ public:
     Symbol *cov;                // private uint[] __coverage;
     unsigned *covb;             // bit array of valid code line numbers
 
-    Symbol *sictor;             // module order independent constructor
-    Symbol *sctor;              // module constructor
-    Symbol *sdtor;              // module destructor
-    Symbol *ssharedctor;        // module shared constructor
-    Symbol *sshareddtor;        // module shared destructor
-    Symbol *stest;              // module unit test
+    bool hasModuleInfo;
 
     Symbol *sfilename;          // symbol for filename
 

--- a/src/module.h
+++ b/src/module.h
@@ -157,8 +157,6 @@ public:
 
     bool hasModuleInfo;
 
-    Symbol *sfilename;          // symbol for filename
-
     Symbol *massert;            // module assert function
     Symbol *munittest;          // module unittest failure function
     Symbol *marray;             // module array bounds function

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -504,8 +504,6 @@ public:
 
     TypeInfoDeclaration vtinfo;     // TypeInfo object for this Type
 
-    type* ctype;                    // for back end
-
     extern (C++) static __gshared Type tvoid;
     extern (C++) static __gshared Type tint8;
     extern (C++) static __gshared Type tuns8;
@@ -1257,7 +1255,6 @@ public:
         t.swto = null;
         t.swcto = null;
         t.vtinfo = null;
-        t.ctype = null;
         if (t.ty == Tstruct)
             (cast(TypeStruct)t).att = RECfwdref;
         if (t.ty == Tclass)
@@ -1429,7 +1426,6 @@ public:
         {
             t = this.nullAttributes();
             t.mod = mod & ~MODshared;
-            t.ctype = ctype;
             t = t.merge();
             t.fixTo(this);
         }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -160,8 +160,6 @@ public:
     Type *arrayof;      // array of this type
     TypeInfoDeclaration *vtinfo;        // TypeInfo object for this Type
 
-    type *ctype;        // for back end
-
     static Type *tvoid;
     static Type *tint8;
     static Type *tuns8;

--- a/src/root/aav.h
+++ b/src/root/aav.h
@@ -1,0 +1,18 @@
+
+/* Copyright (c) 2010-2014 by Digital Mars
+ * All Rights Reserved, written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/root/aav.h
+ */
+
+typedef void* Value;
+typedef void* Key;
+
+struct AA;
+
+size_t dmd_aaLen(AA* aa);
+Value* dmd_aaGet(AA** aa, Key key);
+Value dmd_aaGetRvalue(AA* aa, Key key);
+void dmd_aaRehash(AA** paa);

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -50,6 +50,7 @@ Symbol *toSymbolCpp(ClassDeclaration *cd);
 unsigned totym(Type *tx);
 Symbol *toSymbol(Dsymbol *s);
 RET retStyle(TypeFunction *tf);
+void setSymbol(Dsymbol *s, Symbol *csym);
 
 #define elem_setLoc(e,loc)      srcpos_setLoc(&(e)->Esrcpos, loc)
 #define block_setLoc(b,loc)     srcpos_setLoc(&(b)->Bsrcpos, loc)
@@ -1091,7 +1092,7 @@ public:
 
                 Catch *cs = (*s->catches)[i];
                 if (cs->var)
-                    cs->var->csym = tryblock->jcatchvar;
+                    setSymbol(cs->var, tryblock->jcatchvar);
 
                 assert(cs->type);
 
@@ -1209,7 +1210,7 @@ public:
             {
                 Catch *cs = (*s->catches)[i];
                 if (cs->var)
-                    cs->var->csym = tryblock->jcatchvar;
+                    setSymbol(cs->var, tryblock->jcatchvar);
                 block *bcatch = blx->curblock;
                 if (cs->type)
                     bcatch->Bcatchtype = toSymbol(cs->type->toBasetype());

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -51,6 +51,7 @@ unsigned totym(Type *tx);
 Symbol *toSymbol(Dsymbol *s);
 RET retStyle(TypeFunction *tf);
 void setSymbol(Dsymbol *s, Symbol *csym);
+void setStructLiteralSym(StructLiteralExp *sle, Symbol *sym);
 
 #define elem_setLoc(e,loc)      srcpos_setLoc(&(e)->Esrcpos, loc)
 #define block_setLoc(b,loc)     srcpos_setLoc(&(b)->Bsrcpos, loc)
@@ -767,7 +768,7 @@ public:
                 if (s->exp->op == TOKstructliteral)
                 {
                     StructLiteralExp *sle = (StructLiteralExp *)s->exp;
-                    sle->sym = irs->shidden;
+                    setStructLiteralSym(sle, irs->shidden);
                 }
                 e = toElemDtor(s->exp, irs);
                 assert(e);

--- a/src/statement.d
+++ b/src/statement.d
@@ -5986,10 +5986,6 @@ extern (C++) final class AsmStatement : Statement
 {
 public:
     Token* tokens;
-    code* asmcode;
-    uint asmalign;  // alignment of this statement
-    uint regs;      // mask of registers modified (must match regm_t in back end)
-    bool refparam;  // true if function parameter is referenced
     bool naked;     // true if function is to be naked
 
     extern (D) this(Loc loc, Token* tokens)

--- a/src/statement.h
+++ b/src/statement.h
@@ -717,10 +717,6 @@ class AsmStatement : public Statement
 {
 public:
     Token *tokens;
-    code *asmcode;
-    unsigned asmalign;          // alignment of this statement
-    unsigned regs;              // mask of registers modified (must match regm_t in back end)
-    bool refparam;              // true if function parameter is referenced
     bool naked;                 // true if function is to be naked
 
     AsmStatement(Loc loc, Token *tokens);

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -517,18 +517,21 @@ Classsym *fake_classsym(Identifier *id)
 
 Symbol *toVtblSymbol(ClassDeclaration *cd)
 {
-    if (!cd->vtblsym)
-    {
-        toSymbol(cd);
+    static AA *vtblMap;
+    Symbol **psym = (Symbol **)dmd_aaGet(&vtblMap, cd);
+    if (*psym)
+        return *psym;
 
-        TYPE *t = type_allocn(TYnptr | mTYconst, tsvoid);
-        t->Tmangle = mTYman_d;
-        Symbol *s = toSymbolX(cd, "__vtbl", SCextern, t, "Z");
-        s->Sflags |= SFLnodebug;
-        s->Sfl = FLextern;
-        cd->vtblsym = s;
-    }
-    return cd->vtblsym;
+    toSymbol(cd);
+
+    TYPE *t = type_allocn(TYnptr | mTYconst, tsvoid);
+    t->Tmangle = mTYman_d;
+    Symbol *s = toSymbolX(cd, "__vtbl", SCextern, t, "Z");
+    s->Sflags |= SFLnodebug;
+    s->Sfl = FLextern;
+
+    *psym = s;
+    return s;
 }
 
 /**********************************

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -537,35 +537,41 @@ Symbol *toVtblSymbol(ClassDeclaration *cd)
 
 Symbol *toInitializer(AggregateDeclaration *ad)
 {
-    if (!ad->sinit)
-    {
-        Classsym *stag = fake_classsym(Id::ClassInfo);
-        Symbol *s = toSymbolX(ad, "__init", SCextern, stag->Stype, "Z");
-        s->Sfl = FLextern;
-        s->Sflags |= SFLnodebug;
-        StructDeclaration *sd = ad->isStructDeclaration();
-        if (sd)
-            s->Salignment = sd->alignment;
-        ad->sinit = s;
-    }
-    return ad->sinit;
+    static AA *initMap;
+    Symbol **psym = (Symbol **)dmd_aaGet(&initMap, ad);
+    if (*psym)
+        return *psym;
+
+    Classsym *stag = fake_classsym(Id::ClassInfo);
+    Symbol *s = toSymbolX(ad, "__init", SCextern, stag->Stype, "Z");
+    s->Sfl = FLextern;
+    s->Sflags |= SFLnodebug;
+    StructDeclaration *sd = ad->isStructDeclaration();
+    if (sd)
+        s->Salignment = sd->alignment;
+
+    *psym = s;
+    return s;
 }
 
 Symbol *toInitializer(EnumDeclaration *ed)
 {
-    if (!ed->sinit)
-    {
-        Classsym *stag = fake_classsym(Id::ClassInfo);
-        Identifier *ident_save = ed->ident;
-        if (!ed->ident)
-            ed->ident = Identifier::generateId("__enum");
-        Symbol *s = toSymbolX(ed, "__init", SCextern, stag->Stype, "Z");
-        ed->ident = ident_save;
-        s->Sfl = FLextern;
-        s->Sflags |= SFLnodebug;
-        ed->sinit = s;
-    }
-    return ed->sinit;
+    static AA *initMap;
+    Symbol **psym = (Symbol **)dmd_aaGet(&initMap, ed);
+    if (*psym)
+        return *psym;
+
+    Classsym *stag = fake_classsym(Id::ClassInfo);
+    Identifier *ident_save = ed->ident;
+    if (!ed->ident)
+        ed->ident = Identifier::generateId("__enum");
+    Symbol *s = toSymbolX(ed, "__init", SCextern, stag->Stype, "Z");
+    ed->ident = ident_save;
+    s->Sfl = FLextern;
+    s->Sflags |= SFLnodebug;
+
+    *psym = s;
+    return s;
 }
 
 

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -768,3 +768,19 @@ Symbol *toSymbolCppTypeInfo(ClassDeclaration *cd)
     s->Stype = t;
     return s;
 }
+
+static AA *shiddenMap;
+
+void setHiddenVar(FuncDeclaration *fd, Symbol *shidden)
+{
+    Symbol **psym = (Symbol **)dmd_aaGet(&shiddenMap, fd);
+    assert(!*psym);
+    *psym = shidden;
+}
+
+Symbol *getHiddenVar(FuncDeclaration *fd)
+{
+    Symbol **psym = (Symbol **)dmd_aaGet(&shiddenMap, fd);
+    assert(*psym);
+    return *psym;
+}

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -727,23 +727,26 @@ Symbol* toSymbolCpp(ClassDeclaration *cd)
 {
     assert(cd->isCPPclass());
 
+    static AA *symMap;
+    Symbol **psym = (Symbol **)dmd_aaGet(&symMap, cd);
+    if (*psym)
+        return *psym;
+
     /* For the symbol std::exception, the type info is _ZTISt9exception
      */
-    if (!cd->cpp_type_info_ptr_sym)
-    {
-        static Symbol *scpp;
-        if (!scpp)
-            scpp = fake_classsym(Id::cpp_type_info_ptr);
-        Symbol *s = toSymbolX(cd, "_cpp_type_info_ptr", SCcomdat, scpp->Stype, "");
-        s->Sfl = FLdata;
-        s->Sflags |= SFLnodebug;
-        DtBuilder dtb;
-        cpp_type_info_ptr_toDt(cd, &dtb);
-        s->Sdt = dtb.finish();
-        outdata(s);
-        cd->cpp_type_info_ptr_sym = s;
-    }
-    return cd->cpp_type_info_ptr_sym;
+    static Symbol *scpp;
+    if (!scpp)
+        scpp = fake_classsym(Id::cpp_type_info_ptr);
+    Symbol *s = toSymbolX(cd, "_cpp_type_info_ptr", SCcomdat, scpp->Stype, "");
+    s->Sfl = FLdata;
+    s->Sflags |= SFLnodebug;
+    DtBuilder dtb;
+    cpp_type_info_ptr_toDt(cd, &dtb);
+    s->Sdt = dtb.finish();
+    outdata(s);
+
+    *psym = s;
+    return s;
 }
 
 /**********************************

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -31,6 +31,7 @@
 #include "id.h"
 #include "ctfe.h"
 #include "rmem.h"
+#include "aav.h"
 
 // Back end
 #include "cc.h"
@@ -91,6 +92,8 @@ static Classsym *scc;
 
 /*************************************
  */
+
+static AA *csymMap;
 
 Symbol *toSymbol(Dsymbol *s)
 {
@@ -411,13 +414,21 @@ Symbol *toSymbol(Dsymbol *s)
         }
     };
 
-    if (s->csym)
-        return s->csym;
+    Symbol **pcsym = (Symbol **)dmd_aaGet(&csymMap, s);
+    if (*pcsym)
+        return *pcsym;
 
     ToSymbol v;
     s->accept(&v);
-    s->csym = v.result;
+    *pcsym = v.result;
     return v.result;
+}
+
+void setSymbol(Dsymbol *s, Symbol *csym)
+{
+    Symbol **pcsym = (Symbol **)dmd_aaGet(&csymMap, s);
+    assert(!*pcsym);
+    *pcsym = csym;
 }
 
 /*************************************

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -463,9 +463,7 @@ Symbol *toImport(Dsymbol *ds)
 {
     if (!ds->isym)
     {
-        if (!ds->csym)
-            ds->csym = toSymbol(ds);
-        ds->isym = toImport(ds->csym);
+        ds->isym = toImport(toSymbol(ds));
     }
     return ds->isym;
 }
@@ -480,9 +478,9 @@ Symbol *toThunkSymbol(FuncDeclaration *fd, int offset)
     if (!offset)
         return s;
 
-    Symbol *sthunk = symbol_generate(SCstatic, fd->csym->Stype);
+    Symbol *sthunk = symbol_generate(SCstatic, s->Stype);
     sthunk->Sflags |= SFLimplem;
-    cod3_thunk(sthunk, fd->csym, 0, TYnptr, -offset, -1, 0);
+    cod3_thunk(sthunk, s, 0, TYnptr, -offset, -1, 0);
     return sthunk;
 }
 
@@ -513,8 +511,7 @@ Symbol *toVtblSymbol(ClassDeclaration *cd)
 {
     if (!cd->vtblsym)
     {
-        if (!cd->csym)
-            toSymbol(cd);
+        toSymbol(cd);
 
         TYPE *t = type_allocn(TYnptr | mTYconst, tsvoid);
         t->Tmangle = mTYman_d;

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -431,11 +431,19 @@ void setSymbol(Dsymbol *s, Symbol *csym)
     *pcsym = csym;
 }
 
-/*************************************
+/*********************************
+ * Generate import symbol from symbol.
  */
 
-static Symbol *toImport(Symbol *sym)
+Symbol *toImport(Dsymbol *ds)
 {
+    static AA *isymMap;
+    Symbol **pisym = (Symbol **)dmd_aaGet(&isymMap, ds);
+    if (*pisym)
+        return *pisym;
+
+    Symbol *sym = toSymbol(ds);
+
     //printf("Dsymbol::toImport('%s')\n", sym->Sident);
     char *n = sym->Sident;
     char *id = (char *) alloca(6 + strlen(n) + 1 + sizeof(type_paramsize(sym->Stype))*3 + 1);
@@ -463,20 +471,9 @@ static Symbol *toImport(Symbol *sym)
     s->Stype = t;
     s->Sclass = SCextern;
     s->Sfl = FLextern;
+
+    *pisym = s;
     return s;
-}
-
-/*********************************
- * Generate import symbol from symbol.
- */
-
-Symbol *toImport(Dsymbol *ds)
-{
-    if (!ds->isym)
-    {
-        ds->isym = toImport(toSymbol(ds));
-    }
-    return ds->isym;
 }
 
 /*************************************

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -583,30 +583,44 @@ Symbol *toInitializer(EnumDeclaration *ed)
 
 Symbol *toModuleAssert(Module *m)
 {
-    if (!m->massert)
-    {
-        type *t = type_function(TYjfunc, NULL, 0, false, tsvoid);
-        t->Tmangle = mTYman_d;
+    if (m->doppelganger)
+        m = m->doppelganger;
 
-        m->massert = toSymbolX(m, "__assert", SCextern, t, "FiZv");
-        m->massert->Sfl = FLextern;
-        m->massert->Sflags |= SFLnodebug | SFLexit;
-    }
-    return m->massert;
+    static AA *symMap;
+    Symbol **psym = (Symbol **)dmd_aaGet(&symMap, m);
+    if (*psym)
+        return *psym;
+
+    type *t = type_function(TYjfunc, NULL, 0, false, tsvoid);
+    t->Tmangle = mTYman_d;
+
+    Symbol *xmassert = toSymbolX(m, "__assert", SCextern, t, "FiZv");
+    xmassert->Sfl = FLextern;
+    xmassert->Sflags |= SFLnodebug | SFLexit;
+    *psym = xmassert;
+
+    return *psym;
 }
 
 Symbol *toModuleUnittest(Module *m)
 {
-    if (!m->munittest)
-    {
-        type *t = type_function(TYjfunc, NULL, 0, false, tsvoid);
-        t->Tmangle = mTYman_d;
+    if (m->doppelganger)
+        m = m->doppelganger;
 
-        m->munittest = toSymbolX(m, "__unittest_fail", SCextern, t, "FiZv");
-        m->munittest->Sfl = FLextern;
-        m->munittest->Sflags |= SFLnodebug;
-    }
-    return m->munittest;
+    static AA *symMap;
+    Symbol **psym = (Symbol **)dmd_aaGet(&symMap, m);
+    if (*psym)
+        return *psym;
+
+    type *t = type_function(TYjfunc, NULL, 0, false, tsvoid);
+    t->Tmangle = mTYman_d;
+
+    Symbol *xmunittest = toSymbolX(m, "__unittest_fail", SCextern, t, "FiZv");
+    xmunittest->Sfl = FLextern;
+    xmunittest->Sflags |= SFLnodebug;
+    *psym = xmunittest;
+
+    return *psym;
 }
 
 /******************************************
@@ -614,16 +628,23 @@ Symbol *toModuleUnittest(Module *m)
 
 Symbol *toModuleArray(Module *m)
 {
-    if (!m->marray)
-    {
-        type *t = type_function(TYjfunc, NULL, 0, false, tsvoid);
-        t->Tmangle = mTYman_d;
+    if (m->doppelganger)
+        m = m->doppelganger;
 
-        m->marray = toSymbolX(m, "__array", SCextern, t, "Z");
-        m->marray->Sfl = FLextern;
-        m->marray->Sflags |= SFLnodebug | SFLexit;
-    }
-    return m->marray;
+    static AA *symMap;
+    Symbol **psym = (Symbol **)dmd_aaGet(&symMap, m);
+    if (*psym)
+        return *psym;
+
+    type *t = type_function(TYjfunc, NULL, 0, false, tsvoid);
+    t->Tmangle = mTYman_d;
+
+    Symbol *xmarray = toSymbolX(m, "__array", SCextern, t, "Z");
+    xmarray->Sfl = FLextern;
+    xmarray->Sflags |= SFLnodebug | SFLexit;
+    *psym = xmarray;
+
+    return *psym;
 }
 
 /********************************************

--- a/src/todt.d
+++ b/src/todt.d
@@ -1046,7 +1046,7 @@ extern (C++) class TypeInfoDtVisitor : Visitor
         const(char)* name = sd.toPrettyChars();
         size_t namelen = strlen(name);
         dtb.size(namelen);
-        dtb.xoff(d.csym, Type.typeinfoenum.structsize);
+        dtb.xoff(toSymbol(d), Type.typeinfoenum.structsize);
 
         // void[] init;
         if (!sd.members || d.tinfo.isZeroInit())
@@ -1169,7 +1169,7 @@ extern (C++) class TypeInfoDtVisitor : Visitor
         assert(name);
         size_t namelen = strlen(name);
         dtb.size(namelen);
-        dtb.xoff(d.csym, Type.typeinfofunction.structsize);
+        dtb.xoff(toSymbol(d), Type.typeinfofunction.structsize);
 
         // Put out name[] immediately following TypeInfo_Function
         dtb.nbytes(cast(uint)(namelen + 1), name);
@@ -1194,7 +1194,7 @@ extern (C++) class TypeInfoDtVisitor : Visitor
         assert(name);
         size_t namelen = strlen(name);
         dtb.size(namelen);
-        dtb.xoff(d.csym, Type.typeinfodelegate.structsize);
+        dtb.xoff(toSymbol(d), Type.typeinfodelegate.structsize);
 
         // Put out name[] immediately following TypeInfo_Delegate
         dtb.nbytes(cast(uint)(namelen + 1), name);
@@ -1264,7 +1264,7 @@ extern (C++) class TypeInfoDtVisitor : Visitor
         const(char)* name = sd.toPrettyChars();
         size_t namelen = strlen(name);
         dtb.size(namelen);
-        dtb.xoff(d.csym, Type.typeinfostruct.structsize);
+        dtb.xoff(toSymbol(d), Type.typeinfostruct.structsize);
 
         // void[] init;
         dtb.size(sd.structsize);            // init.length

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -373,7 +373,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             // vtbl[]
             dtb.size(cd->vtbl.dim);
             if (cd->vtbl.dim)
-                dtb.xoff(cd->vtblsym, 0, TYnptr);
+                dtb.xoff(toVtblSymbol(cd), 0, TYnptr);
             else
                 dtb.size(0);
 
@@ -675,13 +675,14 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                  */
                 dtbv.size(0);
             }
-            cd->vtblsym->Sdt = dtbv.finish();
-            cd->vtblsym->Sclass = scclass;
-            cd->vtblsym->Sfl = FLdata;
-            out_readonly(cd->vtblsym);
-            outdata(cd->vtblsym);
+            Symbol *vtblsym = toVtblSymbol(cd);
+            vtblsym->Sdt = dtbv.finish();
+            vtblsym->Sclass = scclass;
+            vtblsym->Sfl = FLdata;
+            out_readonly(vtblsym);
+            outdata(vtblsym);
             if (cd->isExport())
-                objmod->export_symbol(cd->vtblsym,0);
+                objmod->export_symbol(vtblsym,0);
         }
 
         void visit(InterfaceDeclaration *id)

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -85,8 +85,8 @@ void genModuleInfo(Module *m)
 
     //////////////////////////////////////////////
 
-    m->csym->Sclass = SCglobal;
-    m->csym->Sfl = FLdata;
+    msym->Sclass = SCglobal;
+    msym->Sfl = FLdata;
 
     DtBuilder dtb;
     ClassDeclarations aclasses;
@@ -204,9 +204,9 @@ void genModuleInfo(Module *m)
     }
 
     objc_Module_genmoduleinfo_classes();
-    m->csym->Sdt = dtb.finish();
-    out_readonly(m->csym);
-    outdata(m->csym);
+    msym->Sdt = dtb.finish();
+    out_readonly(msym);
+    outdata(msym);
 
     //////////////////////////////////////////////
 
@@ -284,7 +284,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             }
 
             // Generate C symbols
-            toSymbol(cd);
+            Symbol *csym = toSymbol(cd);
             toVtblSymbol(cd);
             Symbol *sinit = toInitializer(cd);
 
@@ -310,8 +310,8 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the ClassInfo
-            cd->csym->Sclass = scclass;
-            cd->csym->Sfl = FLdata;
+            csym->Sclass = scclass;
+            csym->Sfl = FLdata;
 
             /* The layout is:
                {
@@ -368,7 +368,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 namelen = strlen(name);
             }
             dtb.size(namelen);
-            dt_t *pdtname = dtb.xoffpatch(cd->csym, 0, TYnptr);
+            dt_t *pdtname = dtb.xoffpatch(csym, 0, TYnptr);
 
             // vtbl[]
             dtb.size(cd->vtbl.dim);
@@ -380,7 +380,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             // interfaces[]
             dtb.size(cd->vtblInterfaces->dim);
             if (cd->vtblInterfaces->dim)
-                dtb.xoff(cd->csym, offset, TYnptr);      // (*)
+                dtb.xoff(csym, offset, TYnptr);      // (*)
             else
                 dtb.size(0);
 
@@ -491,7 +491,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
 
                 // vtbl[]
                 dtb.size(id->vtbl.dim);
-                dtb.xoff(cd->csym, offset, TYnptr);
+                dtb.xoff(csym, offset, TYnptr);
 
                 // offset
                 dtb.size(b->offset);
@@ -515,7 +515,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                     //dtb.xoff(toSymbol(id), 0, TYnptr);
 
                     // First entry is struct Interface reference
-                    dtb.xoff(cd->csym, Target::classinfosize + i * (4 * Target::ptrsize), TYnptr);
+                    dtb.xoff(csym, Target::classinfosize + i * (4 * Target::ptrsize), TYnptr);
                     j = 1;
                 }
                 assert(id->vtbl.dim == b->vtbl.dim);
@@ -603,11 +603,11 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             const size_t namepad = -(namelen + 1) & (Target::ptrsize - 1); // align
             dtb.nzeros(namepad);
 
-            cd->csym->Sdt = dtb.finish();
+            csym->Sdt = dtb.finish();
             // ClassInfo cannot be const data, because we use the monitor on it
-            outdata(cd->csym);
+            outdata(csym);
             if (cd->isExport())
-                objmod->export_symbol(cd->csym, 0);
+                objmod->export_symbol(csym, 0);
 
             //////////////////////////////////////////////
 
@@ -615,7 +615,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             //printf("putting out %s.vtbl[]\n", toChars());
             DtBuilder dtbv;
             if (cd->vtblOffset())
-                dtbv.xoff(cd->csym, 0, TYnptr);           // first entry is ClassInfo reference
+                dtbv.xoff(csym, 0, TYnptr);           // first entry is ClassInfo reference
             for (size_t i = cd->vtblOffset(); i < cd->vtbl.dim; i++)
             {
                 FuncDeclaration *fd = cd->vtbl[i]->isFuncDeclaration();
@@ -710,7 +710,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             }
 
             // Generate C symbols
-            toSymbol(id);
+            Symbol *csym = toSymbol(id);
 
             //////////////////////////////////////////////
 
@@ -721,8 +721,8 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the ClassInfo
-            id->csym->Sclass = scclass;
-            id->csym->Sfl = FLdata;
+            csym->Sclass = scclass;
+            csym->Sfl = FLdata;
 
             /* The layout is:
                {
@@ -760,7 +760,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             const char *name = id->toPrettyChars();
             size_t namelen = strlen(name);
             dtb.size(namelen);
-            dt_t *pdtname = dtb.xoffpatch(id->csym, 0, TYnptr);
+            dt_t *pdtname = dtb.xoffpatch(csym, 0, TYnptr);
 
             // vtbl[]
             dtb.size(0);
@@ -779,7 +779,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                         fatal();
                     }
                 }
-                dtb.xoff(id->csym, offset, TYnptr);      // (*)
+                dtb.xoff(csym, offset, TYnptr);      // (*)
             }
             else
             {
@@ -852,11 +852,11 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             const size_t namepad =  -(namelen + 1) & (Target::ptrsize - 1); // align
             dtb.nzeros(namepad);
 
-            id->csym->Sdt = dtb.finish();
-            out_readonly(id->csym);
-            outdata(id->csym);
+            csym->Sdt = dtb.finish();
+            out_readonly(csym);
+            outdata(csym);
             if (id->isExport())
-                objmod->export_symbol(id->csym, 0);
+                objmod->export_symbol(csym, 0);
         }
 
         void visit(StructDeclaration *sd)

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -72,7 +72,7 @@ void objc_Module_genmoduleinfo_classes();
 
 // Put out instance of ModuleInfo for this Module
 
-void genModuleInfo(Module *m)
+void genModuleInfo(Module *m, Symbol *sictor, Symbol *sctor, Symbol *sdtor, Symbol *ssharedctor, Symbol *sshareddtor, Symbol *stest)
 {
     //printf("Module::genmoduleinfo() %s\n", m->toChars());
 
@@ -127,19 +127,19 @@ void genModuleInfo(Module *m)
     unsigned flags = 0;
     if (!m->needmoduleinfo)
         flags |= MIstandalone;
-    if (m->sctor)
+    if (sctor)
         flags |= MItlsctor;
-    if (m->sdtor)
+    if (sdtor)
         flags |= MItlsdtor;
-    if (m->ssharedctor)
+    if (ssharedctor)
         flags |= MIctor;
-    if (m->sshareddtor)
+    if (sshareddtor)
         flags |= MIdtor;
     if (sgetmembers)
         flags |= MIxgetMembers;
-    if (m->sictor)
+    if (sictor)
         flags |= MIictor;
-    if (m->stest)
+    if (stest)
         flags |= MIunitTest;
     if (aimports_dim)
         flags |= MIimportedModules;
@@ -151,19 +151,19 @@ void genModuleInfo(Module *m)
     dtb.dword(0);            // _index
 
     if (flags & MItlsctor)
-        dtb.xoff(m->sctor, 0, TYnptr);
+        dtb.xoff(sctor, 0, TYnptr);
     if (flags & MItlsdtor)
-        dtb.xoff(m->sdtor, 0, TYnptr);
+        dtb.xoff(sdtor, 0, TYnptr);
     if (flags & MIctor)
-        dtb.xoff(m->ssharedctor, 0, TYnptr);
+        dtb.xoff(ssharedctor, 0, TYnptr);
     if (flags & MIdtor)
-        dtb.xoff(m->sshareddtor, 0, TYnptr);
+        dtb.xoff(sshareddtor, 0, TYnptr);
     if (flags & MIxgetMembers)
         dtb.xoff(toSymbol(sgetmembers), 0, TYnptr);
     if (flags & MIictor)
-        dtb.xoff(m->sictor, 0, TYnptr);
+        dtb.xoff(sictor, 0, TYnptr);
     if (flags & MIunitTest)
-        dtb.xoff(m->stest, 0, TYnptr);
+        dtb.xoff(stest, 0, TYnptr);
     if (flags & MIimportedModules)
     {
         dtb.size(aimports_dim);

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -885,22 +885,22 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 genTypeInfo(sd->type, NULL);
 
                 // Generate static initializer
-                toInitializer(sd);
+                Symbol *sinit = toInitializer(sd);
                 if (sd->isInstantiated())
                 {
-                    sd->sinit->Sclass = SCcomdat;
+                    sinit->Sclass = SCcomdat;
                 }
                 else
                 {
-                    sd->sinit->Sclass = SCglobal;
+                    sinit->Sclass = SCglobal;
                 }
 
-                sd->sinit->Sfl = FLdata;
+                sinit->Sfl = FLdata;
                 DtBuilder dtb;
                 StructDeclaration_toDt(sd, &dtb);
-                sd->sinit->Sdt = dtb.finish();
-                out_readonly(sd->sinit);    // put in read-only segment
-                outdata(sd->sinit);
+                sinit->Sdt = dtb.finish();
+                out_readonly(sinit);    // put in read-only segment
+                outdata(sinit);
 
                 // Put out the members
                 for (size_t i = 0; i < sd->members->dim; i++)
@@ -1041,13 +1041,13 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                     scclass = SCcomdat;
 
                 // Generate static initializer
-                toInitializer(ed);
-                ed->sinit->Sclass = scclass;
-                ed->sinit->Sfl = FLdata;
+                Symbol *sinit = toInitializer(ed);
+                sinit->Sclass = scclass;
+                sinit->Sfl = FLdata;
                 DtBuilder dtb;
                 Expression_toDt(tc->sym->defaultval, &dtb);
-                ed->sinit->Sdt = dtb.finish();
-                outdata(ed->sinit);
+                sinit->Sdt = dtb.finish();
+                outdata(sinit);
             }
             ed->semanticRun = PASSobj;
         }


### PR DESCRIPTION
The idea is that backend-specific passes shouldn't need to add methods to the frontend ast classes.  Using a hash scales much better, if the performance is acceptable.
