### PR TITLE
Add Tins128/Tuns128 to toArgTypes(Type *t)

### DIFF
--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -75,6 +75,8 @@ TypeTuple *toArgTypes(Type *t)
                 case Tfloat32:
                 case Tint64:
                 case Tuns64:
+                case Tint128:
+                case Tuns128:
                 case Tfloat64:
                 case Tfloat80:
                     t1 = t;


### PR DESCRIPTION
This is the last change which can be added without an 128bit integer data type.
