### PR TITLE
Add ability to create T[int] AAs in the data segment

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -5200,6 +5200,7 @@ public:
     Expressions* keys;
     Expressions* values;
     OwnedBy ownedByCtfe = OWNEDcode;
+    Symbol* sym;
 
     extern (D) this(Loc loc, Expressions* keys, Expressions* values)
     {

--- a/src/expression.h
+++ b/src/expression.h
@@ -440,6 +440,7 @@ public:
     Expressions *keys;
     Expressions *values;
     OwnedBy ownedByCtfe;
+    Symbol *sym;
 
     AssocArrayLiteralExp(Loc loc, Expressions *keys, Expressions *values);
     bool equals(RootObject *o);

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -48,6 +48,7 @@ typedef Array<struct Symbol *> Symbols;
 Classsym *fake_classsym(Identifier *id);
 type *Type_toCtype(Type *t);
 void ClassReferenceExp_toInstanceDt(ClassReferenceExp *ce, DtBuilder* dtb);
+void AssocArrayLiteralExp_toDt(AssocArrayLiteralExp *aale, DtBuilder* dtb);
 void Expression_toDt(Expression *e, DtBuilder* dtb);
 void cpp_type_info_ptr_toDt(ClassDeclaration *cd, DtBuilder* dtb);
 Symbol *toInitializer(AggregateDeclaration *ad);
@@ -681,6 +682,24 @@ Symbol* toSymbol(StructLiteralExp *sle)
     s->Sdt = dtb.finish();
     outdata(s);
     return sle->sym;
+}
+
+Symbol* toSymbol(AssocArrayLiteralExp *aale)
+{
+    if (aale->sym) return aale->sym;
+    TYPE *t = type_alloc(TYint);
+    t->Tcount++;
+    Symbol *s = symbol_calloc("internal");
+    s->Sclass = SCstatic;
+    s->Sfl = FLextern;
+    s->Sflags |= SFLnodebug;
+    s->Stype = t;
+    aale->sym = s;
+    DtBuilder dtb;
+    AssocArrayLiteralExp_toDt(aale, &dtb);
+    s->Sdt = dtb.finish();
+    outdata(s);
+    return aale->sym;
 }
 
 Symbol* toSymbol(ClassReferenceExp *cre)

--- a/test/runnable/testaa4.d
+++ b/test/runnable/testaa4.d
@@ -1,0 +1,42 @@
+
+auto makeAA()
+{
+    return
+    [
+        1 : 2,
+        2 : 3,
+        3 : 4,
+        4 : 5,
+        5 : 6,
+        6 : 7,
+        7 : 8,
+        8 : 9,
+        9 : 10,
+    ];
+}
+
+
+struct testAA(T, U)
+{
+    static void testAA(T key, U value)()
+    {
+        static a = [key : value];
+        auto b = [key : value];
+        assert(a == b);
+    }
+}
+
+alias TT(T...) = T;
+
+void main()
+{
+    static a = makeAA();
+    auto b = makeAA();
+
+    assert(a == b);
+
+    foreach(V; TT!(char, wchar, dchar, byte, ubyte, short, ushort, int, uint))
+    {
+        testAA!(int, V).testAA!(1, 1)();
+    }
+}


### PR DESCRIPTION
It's not that hard to support at least built-in types for AA keys.

Any interest?  If so I can do other integral types and strings pretty easily.
