### PR TITLE
fix root/rmem.d to follow issue 14401 fix in druntime.

### DIFF
--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -171,7 +171,7 @@ else
     extern (C) Object _d_newclass(const ClassInfo ci)
     {
         auto p = allocmemory(ci.init.length);
-        (cast(byte*)p)[0 .. ci.init.length] = ci.init[];
+        p[0 .. ci.init.length] = cast(void[])ci.init[];
         return cast(Object)p;
     }
 


### PR DESCRIPTION
The type of `typeid(SomeClass).init` is changed in https://github.com/D-Programming-Language/druntime/pull/1205.

I'm not sure why the current auto-tester does not detect the error.
