### PR TITLE
win32.mak: fix cleanup of ddmd build

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -312,6 +312,58 @@ LIBS= frontend.lib glue.lib backend.lib root.lib
 $(TARGETEXE): mars.obj $(LIBS) win32.mak
 	$(CC) -o$(TARGETEXE) mars.obj $(LIBS) -cpp -mn -Ar -L/STACK:8388608 $(LFLAGS)
 
+############################# DDMD stuff ############################
+
+MAGICPORTDIR = magicport
+MAGICPORTSRC = \
+	$(MAGICPORTDIR)\magicport2.d $(MAGICPORTDIR)\ast.d \
+	$(MAGICPORTDIR)\scanner.d $(MAGICPORTDIR)\tokens.d \
+	$(MAGICPORTDIR)\parser.d $(MAGICPORTDIR)\dprinter.d \
+	$(MAGICPORTDIR)\typenames.d $(MAGICPORTDIR)\visitor.d \
+	$(MAGICPORTDIR)\namer.d
+
+MAGICPORT = $(MAGICPORTDIR)\magicport2.exe
+
+$(MAGICPORT) : $(MAGICPORTSRC)
+	$(HOST_DC) -of$(MAGICPORT) $(MAGICPORTSRC)
+
+GENSRC=access.d aggregate.d aliasthis.d apply.d \
+	argtypes.d arrayop.d arraytypes.d \
+	attrib.d builtin.d canthrow.d dcast.d \
+	dclass.d clone.d cond.d constfold.d \
+	cppmangle.d ctfeexpr.d declaration.d \
+	delegatize.d doc.d dsymbol.d \
+	denum.d expression.d func.d \
+	hdrgen.d id.d identifier.d imphint.d \
+	dimport.d dinifile.d inline.d init.d \
+	dinterpret.d json.d lexer.d link.d \
+	dmacro.d dmangle.d mars.d \
+	dmodule.d mtype.d opover.d optimize.d \
+	parse.d sapply.d dscope.d sideeffect.d \
+	statement.d staticassert.d dstruct.d \
+	target.d dtemplate.d traits.d dunittest.d \
+	utf.d dversion.d visitor.d lib.d \
+	nogc.d nspace.d errors.d tokens.d \
+	globals.d escape.d \
+	$(ROOT)\aav.d $(ROOT)\outbuffer.d $(ROOT)\stringtable.d \
+	$(ROOT)\file.d $(ROOT)\filename.d $(ROOT)\speller.d \
+	$(ROOT)\man.d $(ROOT)\response.d
+
+MANUALSRC= \
+	intrange.d complex.d \
+	entity.d backend.d \
+	$(ROOT)\array.d $(ROOT)\longdouble.d \
+	$(ROOT)\rootobject.d $(ROOT)\port.d \
+	$(ROOT)\rmem.d
+
+$(GENSRC) : $(SRCS) $(ROOTSRC) magicport.json $(MAGICPORT) id.c impcnvtab.c
+	$(MAGICPORT) . .
+
+DSRC= $(GENSRC) $(MANUALSRC)
+
+ddmd.exe: $(DSRC) newdelete.obj glue.lib backend.lib
+	$(HOST_DC) $(DSRC) -ofddmd.exe newdelete.obj glue.lib backend.lib -vtls -J.. -d -L/STACK:8388608 $(DFLAGS)
+
 ############################ Maintenance Targets #############################
 
 clean:
@@ -399,58 +451,6 @@ id.h id.c : idgen.d
 
 verstr.h : ..\VERSION
 	echo "$(..\VERSION)" >verstr.h
-
-############################# DDMD stuff ############################
-
-MAGICPORTDIR = magicport
-MAGICPORTSRC = \
-	$(MAGICPORTDIR)\magicport2.d $(MAGICPORTDIR)\ast.d \
-	$(MAGICPORTDIR)\scanner.d $(MAGICPORTDIR)\tokens.d \
-	$(MAGICPORTDIR)\parser.d $(MAGICPORTDIR)\dprinter.d \
-	$(MAGICPORTDIR)\typenames.d $(MAGICPORTDIR)\visitor.d \
-	$(MAGICPORTDIR)\namer.d
-
-MAGICPORT = $(MAGICPORTDIR)\magicport2.exe
-
-$(MAGICPORT) : $(MAGICPORTSRC)
-	$(HOST_DC) -of$(MAGICPORT) $(MAGICPORTSRC)
-
-GENSRC=access.d aggregate.d aliasthis.d apply.d \
-	argtypes.d arrayop.d arraytypes.d \
-	attrib.d builtin.d canthrow.d dcast.d \
-	dclass.d clone.d cond.d constfold.d \
-	cppmangle.d ctfeexpr.d declaration.d \
-	delegatize.d doc.d dsymbol.d \
-	denum.d expression.d func.d \
-	hdrgen.d id.d identifier.d imphint.d \
-	dimport.d dinifile.d inline.d init.d \
-	dinterpret.d json.d lexer.d link.d \
-	dmacro.d dmangle.d mars.d \
-	dmodule.d mtype.d opover.d optimize.d \
-	parse.d sapply.d dscope.d sideeffect.d \
-	statement.d staticassert.d dstruct.d \
-	target.d dtemplate.d traits.d dunittest.d \
-	utf.d dversion.d visitor.d lib.d \
-	nogc.d nspace.d errors.d tokens.d \
-	globals.d escape.d \
-	$(ROOT)\aav.d $(ROOT)\outbuffer.d $(ROOT)\stringtable.d \
-	$(ROOT)\file.d $(ROOT)\filename.d $(ROOT)\speller.d \
-	$(ROOT)\man.d $(ROOT)\response.d
-
-MANUALSRC= \
-	intrange.d complex.d \
-	entity.d backend.d \
-	$(ROOT)\array.d $(ROOT)\longdouble.d \
-	$(ROOT)\rootobject.d $(ROOT)\port.d \
-	$(ROOT)\rmem.d
-
-$(GENSRC) : $(SRCS) $(ROOTSRC) magicport.json $(MAGICPORT) id.c impcnvtab.c
-	$(MAGICPORT) . .
-
-DSRC= $(GENSRC) $(MANUALSRC)
-
-ddmd.exe: $(DSRC) newdelete.obj glue.lib backend.lib
-	$(HOST_DC) $(DSRC) -ofddmd.exe newdelete.obj glue.lib backend.lib -vtls -J.. -d -L/STACK:8388608 $(DFLAGS)
 
 ############################# Intermediate Rules ############################
 


### PR DESCRIPTION
by moving definitions before the clean target. No other changes in this PR, though some more files should also be removed.
