### PR TITLE
Fix issue 14375 - static assert leads to __traits(allMembers) retuning an extra empty entry

### DIFF
--- a/src/traits.c
+++ b/src/traits.c
@@ -982,6 +982,11 @@ Expression *semanticTraits(TraitsExp *e, Scope *sc)
                         return 0;
                     }
 
+                    if (sm->ident == Id::empty)
+                    {
+                        return 0;
+                    }
+
                     //printf("\t%s\n", sm->ident->toChars());
                     Identifiers *idents = (Identifiers *)ctx;
 

--- a/test/compilable/test14375.d
+++ b/test/compilable/test14375.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+---
+ */
+interface IKeysAPI(string greetings) {
+    static assert(greetings == "Hello world", greetings);
+}
+
+void main() {
+    foreach (method; __traits(allMembers, IKeysAPI!("Hello world"))) {
+        static assert (method.length, "Empty string from the compiler ??");
+        pragma(msg, method);
+    }
+}


### PR DESCRIPTION
The problem was that `StaticAssert` had an empty identifier instead of a `null` one, which is expected by `allMember`.
By the way is there a reason why Id::empty is empty string instead of `NULL` ?
