### PR TITLE
Move CLASSINFO_SIZE macro to Target::classinfosize

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -218,9 +218,6 @@ struct BaseClass
     void copyBaseInterfaces(BaseClasses *);
 };
 
-#define CLASSINFO_SIZE_64  0x98         // value of ClassInfo.size
-#define CLASSINFO_SIZE  (0x3C+12+4)     // value of ClassInfo.size
-
 struct ClassFlags
 {
     typedef unsigned Type;

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -143,8 +143,6 @@
             [
                 "function isf",
                 "struct BaseClass",
-                "variable CLASSINFO_SIZE_64",
-                "variable CLASSINFO_SIZE",
                 "struct ClassFlags",
                 "struct ClassDeclaration",
                 "struct InterfaceDeclaration"

--- a/src/target.c
+++ b/src/target.c
@@ -22,6 +22,7 @@ int Target::realalignsize;
 bool Target::reverseCppOverloads;
 int Target::c_longsize;
 int Target::c_long_doublesize;
+int Target::classinfosize;
 
 
 void Target::init()
@@ -29,8 +30,13 @@ void Target::init()
     // These have default values for 32 bit code, they get
     // adjusted for 64 bit code.
     ptrsize = 4;
+    classinfosize = 0x4C;   // 76
+
     if (global.params.isLP64)
+    {
         ptrsize = 8;
+        classinfosize = 0x98;   // 152
+    }
 
     if (global.params.isLinux || global.params.isFreeBSD
         || global.params.isOpenBSD || global.params.isSolaris)

--- a/src/target.h
+++ b/src/target.h
@@ -23,12 +23,13 @@ class Module;
 struct Target
 {
     static int ptrsize;
-    static int realsize;        // size a real consumes in memory
-    static int realpad;         // 'padding' added to the CPU real size to bring it up to realsize
-    static int realalignsize;   // alignment for reals
+    static int realsize;             // size a real consumes in memory
+    static int realpad;              // 'padding' added to the CPU real size to bring it up to realsize
+    static int realalignsize;        // alignment for reals
     static bool reverseCppOverloads; // with dmc, overloaded functions are grouped and in reverse order
     static int c_longsize;           // size of a C 'long' or 'unsigned long' type
     static int c_long_doublesize;    // size of a C 'long double'
+    static int classinfosize;        // size of 'ClassInfo'
 
     static void init();
     static unsigned alignsize(Type* type);

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -326,14 +326,13 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                }
              */
             dt_t *dt = NULL;
-            unsigned classinfo_size = global.params.isLP64 ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
-            unsigned offset = classinfo_size;
+            unsigned offset = Target::classinfosize;    // must be ClassInfo.size
             if (Type::typeinfoclass)
             {
-                if (Type::typeinfoclass->structsize != classinfo_size)
+                if (Type::typeinfoclass->structsize != Target::classinfosize)
                 {
         #ifdef DEBUG
-                    printf("CLASSINFO_SIZE = x%x, Type::typeinfoclass->structsize = x%x\n", offset, Type::typeinfoclass->structsize);
+                    printf("Target::classinfosize = x%x, Type::typeinfoclass->structsize = x%x\n", offset, Type::typeinfoclass->structsize);
         #endif
                     cd->error("mismatch between dmd and object.d or object.di found. Check installation and import paths with -v compiler switch.");
                     fatal();
@@ -503,7 +502,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                     //dtxoff(&dt, toSymbol(id), 0, TYnptr);
 
                     // First entry is struct Interface reference
-                    dtxoff(&dt, cd->csym, classinfo_size + i * (4 * Target::ptrsize), TYnptr);
+                    dtxoff(&dt, cd->csym, Target::classinfosize + i * (4 * Target::ptrsize), TYnptr);
                     j = 1;
                 }
                 assert(id->vtbl.dim == b->vtbl.dim);
@@ -550,7 +549,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                             //dtxoff(&dt, toSymbol(id), 0, TYnptr);
 
                             // First entry is struct Interface reference
-                            dtxoff(&dt, toSymbol(pc), classinfo_size + k * (4 * Target::ptrsize), TYnptr);
+                            dtxoff(&dt, toSymbol(pc), Target::classinfosize + k * (4 * Target::ptrsize), TYnptr);
                             j = 1;
                         }
 
@@ -728,7 +727,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             dtsize_t(&dt, id->vtblInterfaces->dim);
             if (id->vtblInterfaces->dim)
             {
-                offset = global.params.isLP64 ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
+                offset = Target::classinfosize;    // must be ClassInfo.size
                 if (Type::typeinfoclass)
                 {
                     if (Type::typeinfoclass->structsize != offset)
@@ -1180,7 +1179,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
 unsigned baseVtblOffset(ClassDeclaration *cd, BaseClass *bc)
 {
     //printf("ClassDeclaration::baseVtblOffset('%s', bc = %p)\n", cd->toChars(), bc);
-    unsigned csymoffset = global.params.isLP64 ? CLASSINFO_SIZE_64 : CLASSINFO_SIZE;    // must be ClassInfo.size
+    unsigned csymoffset = Target::classinfosize;    // must be ClassInfo.size
     csymoffset += cd->vtblInterfaces->dim * (4 * Target::ptrsize);
 
     for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)


### PR DESCRIPTION
It is possible (though unlikely) that CLASSINFO_SIZE may have a different value other than 76/152, for instance if the target record alignment were packed (`align(1)`) then it would be 148.

This PR more contributes to consolidating two macros into a single variable, and removing more uses of `global.params.isXXX` from the backend/frontend and into target.c
