### PR TITLE
Issue 14425 - Indirect template instantiation within is expression causes missing linker symbols

### DIFF
--- a/test/runnable/link14425.d
+++ b/test/runnable/link14425.d
@@ -1,0 +1,9 @@
+struct SFoo(I) { I i; }
+struct SBar(I) { I i; }
+static assert(is(SFoo!(SBar!string)));
+
+class CFoo(I) { I i; }
+class CBar(I) { I i; }
+static assert(is(CFoo!(CBar!string)));
+
+void main() {}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14425
