### PR TITLE
Clean-up most dead asssignments

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1161,7 +1161,6 @@ UnionExp Cmp(TOK op, Type *type, Expression *e1, Expression *e2)
 UnionExp Cast(Type *type, Type *to, Expression *e1)
 {
     UnionExp ue;
-    Expression *e = CTFEExp::cantexp;
     Loc loc = e1->loc;
 
     Type *tb = to->toBasetype();

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -1692,7 +1692,6 @@ UnionExp ctfeCat(Type *type, Expression *e1, Expression *e2)
     Loc loc = e1->loc;
     Type *t1 = e1->type->toBasetype();
     Type *t2 = e2->type->toBasetype();
-    Expression *e;
     UnionExp ue;
     if (e2->op == TOKstring && e1->op == TOKarrayliteral &&
         t1->nextOf()->isintegral())

--- a/src/expression.c
+++ b/src/expression.c
@@ -11549,7 +11549,6 @@ Expression *AssignExp::semantic(Scope *sc)
 
         Expression *e1x = e1;
         Expression *e2x = e2;
-        Type *t2 = e2x->type->toBasetype();
 
         if (e2x->implicitConvTo(e1x->type))
         {
@@ -11945,7 +11944,6 @@ Expression *CatAssignExp::semantic(Scope *sc)
     Type *tb1 = e1->type->toBasetype();
     Type *tb1next = tb1->nextOf();
     Type *tb2 = e2->type->toBasetype();
-    Type *tb2next = tb2->nextOf();
 
     if ((tb1->ty == Tarray) &&
         (tb2->ty == Tarray || tb2->ty == Tsarray) &&

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -3054,8 +3054,6 @@ void protectionToBuffer(OutBuffer *buf, Prot prot)
 
     if (prot.kind == PROTpackage && prot.pkg)
     {
-        Package *ppkg = prot.pkg;
-
         buf->writeByte('(');
         buf->writestring(prot.pkg->toPrettyChars(true));
         buf->writeByte(')');

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -2911,8 +2911,7 @@
                 "function inferAggregate",
                 "function inferApplyArgTypes",
                 "function inferApplyArgTypesX",
-                "function inferApplyArgTypesY",
-                "version function inferApplyArgTypesZ"
+                "function inferApplyArgTypesY"
             ]
         },
         {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -3975,8 +3975,7 @@ Type *TypeSArray::semantic(Loc loc, Scope *sc)
     Type *tbn = tn->toBasetype();
 
     if (dim)
-    {   dinteger_t n, n2;
-
+    {
         unsigned int errors = global.errors;
         dim = semanticLength(sc, tbn, dim);
         if (errors != global.errors)

--- a/src/nogc.c
+++ b/src/nogc.c
@@ -112,7 +112,6 @@ public:
 
     void visit(NewExp *e)
     {
-        bool needGC = false;
         if (e->member && !e->member->isNogc() && f->setGC())
         {
             // @nogc-ness is already checked in NewExp::semantic

--- a/src/opover.c
+++ b/src/opover.c
@@ -29,7 +29,6 @@
 #include "tokens.h"
 
 static Dsymbol *inferApplyArgTypesX(Expression *ethis, FuncDeclaration *fstart, Parameters *parameters);
-static void inferApplyArgTypesZ(TemplateDeclaration *tstart, Parameters *parameters);
 static int inferApplyArgTypesY(TypeFunction *tf, Parameters *parameters, int flags = 0);
 Expression *compare_overload(BinExp *e, Scope *sc, Identifier *id);
 
@@ -1606,13 +1605,6 @@ bool inferApplyArgTypes(ForeachStatement *fes, Scope *sc, Dsymbol *&sapply)
         {
             sapply = inferApplyArgTypesX(ethis, fd, fes->parameters);
         }
-#if 0
-        TemplateDeclaration *td = sapply->isTemplateDeclaration();
-        if (td)
-        {
-            inferApplyArgTypesZ(td, fes->parameters);
-        }
-#endif
         return sapply != NULL;
     }
 
@@ -1837,35 +1829,3 @@ Lnomatch:
     return 0;
 }
 
-#if 0
-/*******************************************
- * Infer foreach parameter types from a template function opApply which looks like:
- *    int opApply(alias int func(ref uint))() { ... }
- */
-
-void inferApplyArgTypesZ(TemplateDeclaration *tstart, Parameters *parameters)
-{
-    for (TemplateDeclaration *td = tstart; td; td = td->overnext)
-    {
-        if (!td->scope)
-        {
-            error("forward reference to template %s", td->toChars());
-            return;
-        }
-        if (!td->onemember || !td->onemember->isFuncDeclaration())
-        {
-            error("is not a function template");
-            return;
-        }
-        if (!td->parameters || td->parameters->dim != 1)
-            continue;
-        TemplateParameter *tp = (*td->parameters)[0];
-        TemplateAliasParameter *tap = tp->isTemplateAliasParameter();
-        if (!tap || !tap->specType || tap->specType->ty != Tfunction)
-            continue;
-        TypeFunction *tf = (TypeFunction *)tap->specType;
-        if (inferApplyArgTypesY(tf, parameters) == 0)    // found it
-            return;
-    }
-}
-#endif

--- a/src/parse.c
+++ b/src/parse.c
@@ -3404,7 +3404,6 @@ Type *Parser::parseDeclarator(Type *t, int *palt, Identifier **pident,
             case TOKlbracket:
             {
                 // This is the old C-style post [] syntax.
-                Loc loc = token.loc;
                 TypeNext *ta;
                 nextToken();
                 if (token.value == TOKrbracket)

--- a/src/statement.c
+++ b/src/statement.c
@@ -3787,8 +3787,6 @@ Statement *ReturnStatement::semantic(Scope *sc)
     //printf("ReturnStatement::semantic() %s\n", toChars());
 
     FuncDeclaration *fd = sc->parent->isFuncDeclaration();
-    Scope *scx = sc;
-    Expression *eorg = NULL;
 
     if (fd->fes)
         fd = fd->fes->func;             // fd is now function enclosing foreach

--- a/src/template.c
+++ b/src/template.c
@@ -8108,7 +8108,7 @@ void TemplateMixin::semantic(Scope *sc)
     printf("\tdo semantic() on template instance members '%s'\n", toChars());
 #endif
     Scope *sc2 = argscope->push(this);
-    size_t deferred_dim = Module::deferred.dim;
+    //size_t deferred_dim = Module::deferred.dim;
 
     static int nest;
     //printf("%d\n", nest);

--- a/src/traits.c
+++ b/src/traits.c
@@ -329,7 +329,6 @@ Lfalse:
  */
 Expression *pointerBitmap(TraitsExp *e)
 {
-    int result = 0;
     if (!e->args || e->args->dim != 1)
     {
         error(e->loc, "a single type expected for trait pointerBitmap");


### PR DESCRIPTION
In a red mood at the moment, so thought I might remove some small bits and pieces found by `-Wunused`, probably are beneficial to DDMD as unlike C++ compilers is not smart enough to remove these dead pieces of code.
