### PR TITLE
[D1] Fix uninitialized `depmsg` member field

### DIFF
--- a/src/scope.c
+++ b/src/scope.c
@@ -116,6 +116,7 @@ Scope::Scope(Scope *enclosing)
     this->explicitProtection = enclosing->explicitProtection;
     this->stc = enclosing->stc;
     this->offset = 0;
+    this->depmsg = NULL;
     this->inunion = enclosing->inunion;
     this->incontract = enclosing->incontract;
     this->nofree = 0;


### PR DESCRIPTION
Resulted in random compiler crashes after backporting of deprecated("msg") feature.
