### PR TITLE
[REG2.066] Issue 14424 - dmd crashes with __traits(getUnitTests)

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -5174,9 +5174,6 @@ void UnitTestDeclaration::semantic(Scope *sc)
         return;
     }
 
-    if (inNonRoot())
-        return;
-
     if (global.params.useUnitTests)
     {
         if (!type)

--- a/test/fail_compilation/ice14424.d
+++ b/test/fail_compilation/ice14424.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -o- -unittest
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice14424.d(12): Error: tuple has no effect in expression (tuple(__unittestL3_1))
+---
+*/
+
+void main()
+{
+    import imports.a14424;
+    __traits(getUnitTests, imports.a14424);
+}

--- a/test/fail_compilation/imports/a14424.d
+++ b/test/fail_compilation/imports/a14424.d
@@ -1,0 +1,3 @@
+module imports.a14424;
+
+unittest { }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14424

It was necessary to avoid excessive semantic3 with -unittest -inline (see commit 474e0d24191b0a964b38eae2ee5ba5eb972131b5), but today compiler incrementally runs semantic3 of the candidate functions for inlining (see commit df11f21be6873a944ee32cc3a664dd84387999b9). Therefore the hack is not necessary anymore.
