### PR TITLE
[backend] Improve 64 bit constant code generation

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -659,8 +659,6 @@ L2:
         }
         else if (reg == 6)                      // if DIV
         {   cd = genregs(cd,0x33,DX,DX);        // XOR DX,DX
-            if (I64 && sz == 8)
-                code_orrex(cd, REX_W);
         }
   }
 

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -2648,8 +2648,6 @@ L1:
             switch (value)
             {   case 0:
                     c = genclrreg(c,reg);
-                    if (flags & 64)
-                        code_orrex(c, REX_W);
                     break;
                 case 1:
                     if (I64)
@@ -2713,8 +2711,6 @@ L1:
             }
             if (value == 0 && !(flags & 8) && config.target_cpu >= TARGET_80486)
             {   c = genclrreg(c,reg);           // CLR reg
-                if (flags & 64)
-                    code_orrex(c, REX_W);
                 goto done;
             }
 
@@ -2751,8 +2747,6 @@ L1:
 
             if (value == 0 && !(flags & 8))
             {   c = genclrreg(c,reg);           // CLR reg
-                if (flags & 64)
-                    code_orrex(c, REX_W);
             }
             else
             {   /* See if we can just load a byte       */

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -5157,7 +5157,10 @@ void pinholeopt(code *c,block *b)
             if ((ins & R) && (rm & 0xC0) == 0xC0)
             {   switch (op)
                 {   case 0xC6:  op = 0xB0 + ereg; break;
-                    case 0xC7:  op = 0xB8 + ereg; break;
+                    case 0xC7: // if no sign extension
+                        if (!(c->Irex & REX_W && c->IEV2.Vint < 0))
+                            op = 0xB8 + ereg;
+                        break;
                     case 0xFF:
                         switch (reg)
                         {   case 6<<3: op = 0x50+ereg; break;/* PUSH*/
@@ -5354,6 +5357,9 @@ STATIC void pinholeopt_unittest()
         {{ 32,0x68,0,0,0x80,CFopsize }, { 0,0x68,0,0,0x80,CFopsize }},
         {{ 32,0x68,0,0,0x10000,CFopsize },    { 0,0x6A,0,0,0x10000,CFopsize }},
         {{ 32,0x68,0,0,0x8000,CFopsize }, { 0,0x68,0,0,0x8000,CFopsize }},
+
+        // MOV r64, immed
+        {{ 64,0xC7,0x800C0,0,0xFFFFFFFF,0 }, { 0,0xC7,0x800C0,0,0xFFFFFFFF,0}},
     };
 
     //config.flags4 |= CFG4space;

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -4422,9 +4422,14 @@ static OPND *asm_primary_exp()
             break;
 
         case TOKint32v:
-        case TOKuns32v:
             o1 = new OPND();
             o1->disp = (d_int32)asmtok->int64value;
+            asm_token();
+            break;
+
+        case TOKuns32v:
+            o1 = new OPND();
+            o1->disp = (d_uns32)asmtok->uns64value;
             asm_token();
             break;
 

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -6561,6 +6561,19 @@ L1:     pop     RAX;
 
 /****************************************************/
 
+void testconst()
+{
+    ulong result;
+    asm
+    {
+        mov RAX, 0xFFFF_FFFFu;
+        mov result, RAX;
+    }
+    assert (result == 0xFFFF_FFFFu);
+}
+
+/****************************************************/
+
 void test9965()
 {
     ubyte* p;
@@ -6721,6 +6734,7 @@ int main()
     test9965();
     test12849();
     test12968();
+    testconst();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
As the commit messages say:
- Fix an erroneous pinhole optimization
- Remove redundant REX prefix for 64 bit register clear
- Improved codegen for moving 64 bit constants to registers

I originally implemented these improvements in the pinhole optimization but it is now done at the source.
I can still include the additions to the pinhole optimization if they are wanted.
