### PR TITLE
fix testtypeid.d for changes to TypeInfo_Const in object.di

### DIFF
--- a/test/runnable/testtypeid.d
+++ b/test/runnable/testtypeid.d
@@ -434,9 +434,14 @@ void test35()
 {
     auto ti = typeid(shared(int));
 
-    assert(cast(TypeInfo_Shared)ti);
+    auto sti = cast(TypeInfo_Shared)ti;
+    assert(sti);
 
-    assert((cast(TypeInfo_Shared)ti).next == typeid(int));
+    // allow both next and base as field names in TypeInfo_Const
+    static if (is(typeof(&sti.base) == TypeInfo*))
+        assert(sti.base == typeid(int));
+    else
+        assert(sti.next == typeid(int));
 }
 
 /******************************************************/


### PR DESCRIPTION
temporarily allow both next and base as fields of TypeInfo_Const

Needed for https://github.com/D-Programming-Language/druntime/pull/1182/files and https://github.com/D-Programming-Language/druntime/pull/1222
