### PR TITLE
fix Issue 14465 - CTFE exception stacktrace shows location of Exception constructor

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -4836,8 +4836,10 @@ public:
         }
         if (!exceptionOrCantInterpret(result))
         {
+            Expression* old = result;
             result = paintTypeOntoLiteral(e->type, result);
-            result->loc = e->loc;
+            if (result != old) // only change location if a conversion was necessary
+                result->loc = e->loc;
         }
         else if (CTFEExp::isCantExp(result) && !global.gag)
             showCtfeBackTrace(e, fd);   // Print a stack trace.

--- a/test/fail_compilation/ctfe14465.d
+++ b/test/fail_compilation/ctfe14465.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ctfe14465.d(19): Error: uncaught CTFE exception ctfe14465.E("message")
+fail_compilation/ctfe14465.d(22):        called from here: foo()
+fail_compilation/ctfe14465.d(22):        while evaluating: static assert(foo())
+---
+*/
+class E : Exception
+{
+    this(string msg)
+    {
+        super(msg);
+    }
+}
+
+bool foo()
+{
+    throw new E("message");
+}
+
+static assert(foo());


### PR DESCRIPTION
CTFE: only change the location of a return value if a conversion was necessary

https://issues.dlang.org/show_bug.cgi?id=14465
