### PR TITLE
Fix tests for druntime pull 1222

### DIFF
--- a/test/fail_compilation/fail_casting.d
+++ b/test/fail_compilation/fail_casting.d
@@ -147,8 +147,8 @@ void test14154()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup3.__expand_field_0 of type int to object.Object
-fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup3.__expand_field_1 of type int to object.Object
+fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup43.__expand_field_0 of type int to object.Object
+fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup43.__expand_field_1 of type int to object.Object
 ---
 */
 alias TypeTuple14093(T...) = T;

--- a/test/fail_compilation/ice14424.d
+++ b/test/fail_compilation/ice14424.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14424.d(12): Error: tuple has no effect in expression (tuple(__unittestL3_1))
+fail_compilation/ice14424.d(12): Error: tuple has no effect in expression (tuple(__unittestL3_41))
 ---
 */
 


### PR DESCRIPTION
This adjusts compiler generated unique numbers in output messages when compiling with object_.d instead of object.di:
https://github.com/D-Programming-Language/druntime/pull/1222
