### PR TITLE
Add missing initializer for OverDeclaration::overnext

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -617,6 +617,7 @@ Dsymbol *AliasDeclaration::toAlias()
 OverDeclaration::OverDeclaration(Dsymbol *s, bool hasOverloads)
     : Declaration(s->ident)
 {
+    this->overnext = NULL;
     this->aliassym = s;
 
     this->hasOverloads = hasOverloads;


### PR DESCRIPTION
`OverDeclaration::overnext` is not initialized to NULL in the `OverDeclaration` constructor.
This leads to a crash in LDC.
This PR fixes this trivial issue.
