### PR TITLE
Issue 14474 - Internally use UTF-8 strings for Windows 

### DIFF
--- a/src/backend/os.c
+++ b/src/backend/os.c
@@ -651,7 +651,7 @@ int os_file_exists(const char *name)
     DWORD dw;
     int result;
 
-    dw = GetFileAttributes(name);
+    dw = GetFileAttributesA(name);
     if (dw == -1L)
         result = 0;
     else if (dw & FILE_ATTRIBUTE_DIRECTORY)
@@ -710,7 +710,7 @@ char *file_8dot3name(const char *filename)
     char *buf;
     int i;
 
-    h = FindFirstFile(filename,&fileinfo);
+    h = FindFirstFileA(filename,&fileinfo);
     if (h == INVALID_HANDLE_VALUE)
         return NULL;
     if (fileinfo.cAlternateFileName[0])
@@ -770,7 +770,7 @@ err:
     HANDLE h;
     DWORD numwritten;
 
-    h = CreateFileA((LPTSTR)name,GENERIC_WRITE,0,NULL,CREATE_ALWAYS,
+    h = CreateFileA((LPCSTR)name,GENERIC_WRITE,0,NULL,CREATE_ALWAYS,
         FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,NULL);
     if (h == INVALID_HANDLE_VALUE)
     {
@@ -778,7 +778,7 @@ err:
         {
             if (!file_createdirs(name))
             {
-                h = CreateFileA((LPTSTR)name,GENERIC_WRITE,0,NULL,CREATE_ALWAYS,
+                h = CreateFileA((LPCSTR)name, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
                     FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,NULL);
                 if (h != INVALID_HANDLE_VALUE)
                     goto Lok;

--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -28,6 +28,18 @@
     <ConfigurationType>Application</ConfigurationType>
     <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -43,7 +55,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>.\root;.\tk;.\backend;.;vcbuild;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">DEBUG;_DEBUG;TARGET_WINDOS%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">DEBUG;_DEBUG;TARGET_WINDOS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">TARGET_WINDOS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebug</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreaded</RuntimeLibrary>
@@ -237,6 +249,7 @@
     <ClCompile Include="root\outbuffer.c" />
     <ClCompile Include="root\speller.c" />
     <ClCompile Include="root\stringtable.c" />
+    <ClCompile Include="root\utils.c" />
     <CustomBuild Include="idgen.d">
       <Message>Building and running $(IntDir)%(Filename).exe</Message>
       <Command>dmd -od$(IntDir) -of$(IntDir)%(Filename).exe %(Filename)%(Extension) &amp;&amp; $(IntDir)%(Filename).exe</Command>
@@ -363,6 +376,7 @@
     <ClInclude Include="root\root.h" />
     <ClInclude Include="root\speller.h" />
     <ClInclude Include="root\stringtable.h" />
+    <ClInclude Include="root\utils.h" />
     <ClInclude Include="id.h" />
     <ClInclude Include="vcbuild\alloca.h" />
     <ClInclude Include="vcbuild\fenv.h" />

--- a/src/dmd_msc.vcxproj.filters
+++ b/src/dmd_msc.vcxproj.filters
@@ -426,9 +426,6 @@
     <ClCompile Include="root\checkedint.c">
       <Filter>src\root</Filter>
     </ClCompile>
-    <ClCompile Include="root\dmgcmem.c">
-      <Filter>src\root</Filter>
-    </ClCompile>
     <ClCompile Include="root\longdouble.c">
       <Filter>src\root</Filter>
     </ClCompile>
@@ -460,6 +457,9 @@
       <Filter>src\root</Filter>
     </ClCompile>
     <ClCompile Include="root\stringtable.c">
+      <Filter>src\root</Filter>
+    </ClCompile>
+    <ClCompile Include="root\utils.c">
       <Filter>src\root</Filter>
     </ClCompile>
     <ClCompile Include="cdxxx.c">
@@ -758,6 +758,9 @@
     <ClInclude Include="root\stringtable.h">
       <Filter>src\root</Filter>
     </ClInclude>
+    <ClInclude Include="root\utils.h">
+      <Filter>src\root</Filter>
+    </ClInclude>
     <ClInclude Include="id.h">
       <Filter>src\generated</Filter>
     </ClInclude>
@@ -779,9 +782,6 @@
     <ClInclude Include="nspace.h">
       <Filter>src</Filter>
     </ClInclude>
-    <ClInclude Include="backend\obj.h">
-      <Filter>src\backend</Filter>
-    </ClInclude>
     <ClInclude Include="tokens.h">
       <Filter>src</Filter>
     </ClInclude>
@@ -790,9 +790,6 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <CustomBuild Include="idgen.c">
-      <Filter>src\gen</Filter>
-    </CustomBuild>
     <CustomBuild Include="impcnvgen.c">
       <Filter>src\gen</Filter>
     </CustomBuild>
@@ -803,5 +800,6 @@
     <CustomBuild Include="vcbuild\ldfpu.asm">
       <Filter>src\vcbuild</Filter>
     </CustomBuild>
+    <CustomBuild Include="idgen.d" />
   </ItemGroup>
 </Project>

--- a/src/errors.c
+++ b/src/errors.c
@@ -25,6 +25,7 @@
 #include "errors.h"
 #include "outbuffer.h"
 #include "rmem.h"
+#include "utils.h"
 
 enum COLOR
 {
@@ -176,8 +177,15 @@ void verrorPrint(Loc loc, COLOR headerColor, const char *header, const char *for
 
     if (global.params.color)
         setConsoleColorBright(true);
-    if (*p)
+    if (*p) {
+#ifdef _WIN32
+        LPCWSTR wstr = UTF8toWide(p);
+        fwprintf(stderr, L"%s\n", wstr);
+        free((void *)wstr);
+#else
         fprintf(stderr, "%s: ", p);
+#endif
+    }
     mem.xfree(p);
 
     if (global.params.color)
@@ -191,7 +199,13 @@ void verrorPrint(Loc loc, COLOR headerColor, const char *header, const char *for
         fprintf(stderr, "%s ", p2);
     OutBuffer tmp;
     tmp.vprintf(format, ap);
+#ifdef _WIN32
+    LPCWSTR wstr = UTF8toWide(tmp.peekString());
+    fwprintf(stderr, L"%s\n", wstr);
+    free((void *)wstr);
+#else
     fprintf(stderr, "%s\n", tmp.peekString());
+#endif
     fflush(stderr);
 }
 

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -27,7 +27,8 @@
         "root/speller.h", "root/speller.c",
         "root/outbuffer.h", "root/outbuffer.c",
         "root/stringtable.h", "root/stringtable.c",
-        "root/man.c", "root/response.c"
+        "root/man.c", "root/response.c",
+        "root/utils.c"
     ],
     "mapping" :
     [
@@ -724,6 +725,7 @@
                 "root.array",
                 "root.filename",
                 "root.rmem",
+                "root.utils",
                 "core.sys.windows.windows",
                 "core.sys.posix.sys.types",
                 "core.sys.posix.utime",
@@ -1362,6 +1364,7 @@
                 "root.outbuffer",
                 "root.rmem",
                 "root.rootobject",
+                "root.utils",
                 "core.sys.windows.windows",
                 "core.sys.posix.sys.stat",
                 "core.sys.posix.stdlib"
@@ -1372,7 +1375,7 @@
                 "version (Windows) alias _mkdir = mkdir;",
                 "version (Posix) extern (C) char* canonicalize_file_name(const char*);",
                 "version (Windows) extern (C) int stricmp(const char*, const char*);",
-                "version (Windows) extern (Windows) DWORD GetFullPathNameA(LPCTSTR lpFileName, DWORD nBufferLength, LPTSTR lpBuffer, LPTSTR* lpFilePart);"
+                "version (Windows) extern (Windows) DWORD GetFullPathNameW(LPCWSTR lpFileName, DWORD nBufferLength, LPWSTR lpBuffer, LPWSTR* lpFilePart);"
             ],
             "members" :
             [
@@ -1699,6 +1702,7 @@
                 "root.filename",
                 "root.outbuffer",
                 "root.port",
+                "root.utils",
                 "core.sys.windows.windows",
                 "core.sys.posix.stdlib"
             ],
@@ -1964,6 +1968,7 @@
                 "root.filename",
                 "root.outbuffer",
                 "root.rmem",
+                "root.utils",
                 "core.sys.posix.sys.wait",
                 "core.sys.posix.stdlib",
                 "core.sys.posix.stdio",
@@ -1979,7 +1984,6 @@
             ],
             "members" :
             [
-                "version variable HAS_POSIX_SPAWN",
                 "function writeFilenameOutBuffer*char*size_t",
                 "function writeFilenameOutBuffer*char*",
                 "version function findNoMainError",
@@ -2512,6 +2516,7 @@
                 "root.outbuffer",
                 "root.rmem",
                 "root.response",
+                "root.utils",
                 "target",
                 "tokens",
                 "traits"
@@ -2533,6 +2538,7 @@
                 "function genCmain",
                 "function tryMain",
                 "function main",
+                "function wmain",
                 "function getenv_setargv",
                 "function escapePath",
                 "function parse_arch_arg",
@@ -3113,7 +3119,8 @@
                 "core.sys.windows.windows",
                 "globals",
                 "root.outbuffer",
-                "root.rmem"
+                "root.rmem",
+                "root.utils"
             ],
             "extra" :
             [
@@ -3122,7 +3129,8 @@
                 "version (Windows) int _fileno(FILE* f)",
                 "{",
                 "    return f._file;",
-                "}"
+                "}",
+                "version (Windows) extern (Windows) int fwprintf(FILE* _File, const wchar_t* _Format, ...);"
             ],
             "members" :
             [
@@ -3196,13 +3204,38 @@
                 "core.stdc.stdio",
                 "core.stdc.stdlib",
                 "core.stdc.string",
-                "root.file"
+                "root.file",
+                "root.utils"
             ],
             "members" :
             [
                 "struct Narg",
                 "function addargp",
                 "function response_expand"
+            ]
+        },
+        {
+            "module" : "utils",
+            "package" : "root",
+            "imports" : [
+                "core.stdc.stdio",
+                "core.stdc.stdlib",
+                "core.sys.windows.windows"
+            ],
+            "extra" :
+            [
+                "enum _MSC_VER = 0;",
+                "version (Windows) extern (Windows) wchar_t* _wgetenv(const wchar_t*);",
+                "version (Windows) extern (Windows) int _wputenv(const wchar_t*);",
+                "version (Windows) extern (Windows) int _wmkdir(const wchar_t*);",
+                "version (Windows) extern (Windows) int iswspace(short);",
+                "version (Windows) extern (Windows) intptr_t _wspawnlp(int, const wchar_t*, const wchar_t*, ...);",
+                "version (Windows) extern (Windows) intptr_t _wspawnl(int, const wchar_t*, const wchar_t*, ...);",
+                "version (Windows) extern (Windows) intptr_t _wspawnv(int, const wchar_t*, const wchar_t **);"
+            ],
+            "members" :
+            [
+                "version function wideToUTF8"
             ]
         }
     ],
@@ -3223,6 +3256,8 @@
 
         "size_t",
         "time_t",
+        "wchar_t",
+        "intptr_t",
         "longdouble",
         "volatile_longdouble",
         "uinteger_t",
@@ -3247,6 +3282,10 @@
         "hash_t",
         "DWORD",
         "WORD",
+        "WCHAR",
+        "LPSTR",
+        "LPWSTR",
+        "LPCWSTR",
         "HANDLE",
         "Key",
         "Value",

--- a/src/magicport/parser.d
+++ b/src/magicport/parser.d
@@ -496,8 +496,16 @@ Expression parsePrimaryExpr()
         else if (t.text == "static" || t.text == "STATIC" || t.text == "struct" || t.text == "const" || t.text == "union" || t.text == "class" || t.text == "enum" || t.text == "typedef" || t.text == "register")
         {
             return new DeclarationExpr(parseDecl(null, true));
-        }
-        else if (isType())
+        } else if (t.text == "L")
+        {
+            nextToken();
+            string e;
+            e ~= nextToken()[0..$-1];
+            while(t.type == TOKstring)
+                e ~= nextToken()[1..$-1];
+            e ~= "\"";
+            return new LitExpr(e);
+        } else if (isType())
         {
             auto type = parseType();
             if (t.type == TOKid)

--- a/src/mars.c
+++ b/src/mars.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <string.h>
+#include <locale.h>
 
 #if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
 #include <errno.h>
@@ -38,6 +39,7 @@
 #include "declaration.h"
 #include "hdrgen.h"
 #include "doc.h"
+#include "utils.h"
 
 bool response_expand(size_t *pargc, const char ***pargv);
 
@@ -1658,14 +1660,22 @@ Language changes listed by -transition=id:\n\
     return status;
 }
 
-int main(int argc, const char *argv[])
+
+#if _WIN32
+int wmain(int argc, const wchar_t *wargv[])
 {
-    int status = -1;
-
-    status = tryMain(argc, argv);
-
+    _wsetlocale(LC_ALL, L"");
+    const char **argv = getUTF8argvs(argc, wargv);
+    int status = tryMain(argc, argv);
+    freeUTF8argvs(argc, argv);
     return status;
 }
+#else
+int main(int argc, const char *argv[])
+{
+    return tryMain(argc, argv);
+}
+#endif
 
 
 /***********************************
@@ -1682,7 +1692,7 @@ void getenv_setargv(const char *envvar, size_t *pargc, const char** *pargv)
     int slash;
     char c;
 
-    char *env = getenv(envvar);
+    char *env = dgetenv(envvar);
     if (!env)
         return;
 

--- a/src/root/filename.h
+++ b/src/root/filename.h
@@ -49,6 +49,10 @@ struct FileName
     static const char *searchPath(Strings *path, const char *name, bool cwd);
     static const char *safeSearchPath(Strings *path, const char *name);
     static int exists(const char *name);
+#if _WIN32
+    typedef const wchar_t *LPCWSTR;
+    static int exists(LPCWSTR name);
+#endif
     static bool ensurePathExists(const char *path);
     static const char *canonicalName(const char *name);
 

--- a/src/root/response.c
+++ b/src/root/response.c
@@ -18,6 +18,7 @@
 #if _WIN32
 #include <tchar.h>
 #include <io.h>
+#include <windows.h>
 #endif
 
 #if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
@@ -37,6 +38,7 @@
 #endif
 
 #include "file.h"
+#include "utils.h"
 
 /*********************************
  * #include <stdlib.h>
@@ -117,7 +119,7 @@ bool response_expand(size_t *pargc, const char ***pargv)
         char *bufend;
 
         cp++;
-        char *p = getenv(cp);
+        char *p = dgetenv(cp);
         if (p)
         {
             buffer = strdup(p);

--- a/src/root/utils.c
+++ b/src/root/utils.c
@@ -1,0 +1,201 @@
+#include "utils.h"
+
+#if _WIN32
+
+// Encode Unicode/Wide string to UTF-8 string
+char *wideToUTF8(const LPCWSTR wstr)
+{
+    if (!wstr) return NULL;
+    int reqchars = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
+    char *str = (char *)malloc(reqchars * sizeof(char));
+    WideCharToMultiByte(CP_UTF8, 0, wstr, -1, (LPSTR)str, reqchars, NULL, NULL);
+    return str;
+}
+
+// Encode UTF-8 string to Unicode/Wide string
+LPCWSTR UTF8toWide(const char *str)
+{
+    if (!str) return NULL;
+    int reqchars = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
+    LPCWSTR wstr = (LPCWSTR)malloc(reqchars * sizeof(WCHAR));
+    MultiByteToWideChar(CP_UTF8, 0, str, -1, (LPWSTR)wstr, reqchars);
+    return wstr;
+}
+
+// get argvs in UTF-8
+const char **getUTF8argvs(int argc, const wchar_t *wargv[])
+{
+    if (wargv != NULL && argc > 0) {
+        const char **argv = (const char **)malloc(argc * sizeof(char *));
+        for (size_t i = 0; i < argc; i++)
+        {
+            argv[i] = wideToUTF8(wargv[i]);
+        }
+        return argv;
+    };
+    return NULL;
+}
+
+void freeUTF8argvs(int argc, const char *argv[])
+{
+    for (size_t i = 0; i < argc; i++) {
+        free((void *)argv[i]);
+    };
+    free(argv);
+}
+
+// get ENV variable in UTF-8
+char* dgetenv(const char *name) {
+    LPCWSTR wname = UTF8toWide(name);
+    char *var = NULL;
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+    size_t reqsz = 0;
+    if (_wgetenv_s(&reqsz, NULL, 0, wname) == 0 && reqsz > 0) {
+        LPWSTR wvar = (LPWSTR)malloc(reqsz * sizeof(WCHAR));
+        _wgetenv_s(&reqsz, wvar, reqsz, wname);
+        var = wideToUTF8(wvar);
+        free((void *)wvar);
+    }
+#else
+    LPWSTR wvar =_wgetenv(wname);
+    if (wvar) var = wideToUTF8(wvar);
+#endif
+    free((void *)wname);
+    return var;
+}
+
+int dputenv(const char *env) {
+    LPCWSTR wenv = UTF8toWide(env);
+    int s = _wputenv(wenv);
+    free((void *)wenv);
+    return s;
+}
+
+int dmkdir(const char *name) {
+    LPCWSTR wname = UTF8toWide(name);
+    int r = _wmkdir(wname);
+    free((void *)wname);
+    return r;
+}
+
+// Quote and escape argument if needed
+LPCWSTR escape_arg(LPCWSTR wstr) {
+    if (!wstr) return NULL;
+    bool need_escape = false;
+    int extra = 0;
+    LPWSTR p = (LPWSTR)wstr;
+    WCHAR c;
+    // count how many extra chars will
+    // be needed for backslashes
+    while (*p != 0) {
+        c = *p;
+        if (c == '\\') {
+            extra++;
+        }
+        else if (c == '"') {
+            extra++;
+            need_escape = true;
+        }
+        else if (iswspace(c)) {
+            need_escape = true;
+        }
+        p++;
+    };
+    if (!need_escape) return wstr;
+    size_t len = p - wstr;
+    extra += 3; // for quotes and null
+    LPWSTR quoted_str = (LPWSTR)malloc((len + extra) * sizeof(WCHAR));
+    *quoted_str = '"';
+    p = quoted_str + 1;
+    for (size_t i = 0; i < len; i++) {
+        c = wstr[i];
+        // escape
+        if (c == '"' || c == '\\') {
+            *p = '\\';
+            p++;
+        };
+        *p = c;
+        p++;
+    };
+    *p = '"';
+    p++;
+    *p = 0;
+    return quoted_str;
+}
+
+int dspawnlp(int mode, const char *file, const char *arg0, const char *arg1, const char *arg2) {
+    LPCWSTR wfile = UTF8toWide(file);
+    LPCWSTR warg0 = UTF8toWide(arg0);
+    LPCWSTR warg1 = UTF8toWide(arg1);
+    LPCWSTR warg2 = UTF8toWide(arg2);
+    LPCWSTR escaped_warg0 = escape_arg(warg0);
+    intptr_t h = _wspawnlp(mode, wfile, escaped_warg0, warg1, warg2);
+    if (escaped_warg0 != warg0) free((void *)escaped_warg0);
+    free((void *)wfile);
+    free((void *)warg0);
+    free((void *)warg1);
+    free((void *)warg2);
+    return h;
+}
+
+int dspawnl(int mode, const char *file, const char *arg0, const char *arg1, const char *arg2) {
+    LPCWSTR wfile = UTF8toWide(file);
+    LPCWSTR warg0 = UTF8toWide(arg0);
+    LPCWSTR warg1 = UTF8toWide(arg1);
+    LPCWSTR warg2 = UTF8toWide(arg2);
+    LPCWSTR escaped_warg0 = escape_arg(warg0);
+    intptr_t h = _wspawnl(mode, wfile, escaped_warg0, warg1, warg2);
+    if (escaped_warg0 != warg0) free((void *)escaped_warg0);
+    free((void *)wfile);
+    free((void *)warg0);
+    free((void *)warg1);
+    free((void *)warg2);
+    return h;
+}
+
+int dspawnv(int mode, const char *file, const char *const *argv) {
+    LPCWSTR wfile = UTF8toWide(file);
+    int argc = 0;
+    while (argv[argc] != NULL) { argc++; };
+    LPCWSTR *wargv = (LPCWSTR *)malloc((argc + 1) * sizeof(LPCWSTR));
+    LPCWSTR warg;
+    for (size_t i = 0; i < argc; i++)
+    {
+        warg = UTF8toWide(argv[i]);
+        wargv[i] = escape_arg(warg);
+        if (wargv[i] != warg) free((void *)warg);
+    };
+    wargv[argc] = NULL;
+    intptr_t h = _wspawnv(mode, wfile, wargv);
+    free((void *)wfile);
+    for (size_t i = 0; i < argc; i++)
+    {
+         free((void *)wargv[i]);
+    }
+    free((void *)wargv);
+    return h;
+}
+
+#else
+
+char *dgetenv(const char *name) {
+    return getenv(name);
+}
+
+int dputenv(const char *env) {
+    return putenv(env);
+}
+
+int dmkdir(const char *name) {
+    return mkdir(name, (7 << 6) | (7 << 3) | 7);
+}
+
+int dspawnlp(int mode, const char *file, const char *arg0, const char *arg1, const char *arg2) {
+    return spawnlp(mode, file, arg0, arg1, arg2);
+}
+
+int dspawnl(int mode, const char *file, const char *arg0, const char *arg1, const char *arg2) {
+    return dspawnl(mode, file, arg0, arg1, arg2);
+}
+
+#endif

--- a/src/root/utils.h
+++ b/src/root/utils.h
@@ -1,0 +1,51 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#if __DMC__
+#pragma once
+#endif
+
+#if __linux__ || __APPLE__
+#define HAS_POSIX_SPAWN 1
+#include        <spawn.h>
+#if __APPLE__
+#include <crt_externs.h>
+#endif
+#else
+#define HAS_POSIX_SPAWN 0
+#endif
+
+#if _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <shellapi.h>
+#include <stdlib.h>
+#include <direct.h>
+#include <process.h>
+#include <errno.h>
+
+#ifndef _INTPTR_T_DEFINED
+#ifdef _WIN64
+typedef int64_t        intptr_t;
+#else
+typedef int            intptr_t;
+#endif
+#define _INTPTR_T_DEFINED
+#endif
+
+char *wideToUTF8(const LPCWSTR wstr);
+LPCWSTR UTF8toWide(const char *str);
+const char **getUTF8argvs(int argc, const wchar_t *wargv[]);
+void freeUTF8argvs(int argc, const char *argv[]);
+int dspawnv(int mode, const char *file, const char *const *argv);
+
+#endif
+
+char* dgetenv(const char *name);
+int dputenv(const char *env);
+int dmkdir(const char *name);
+int dspawnlp(int mode, const char *file, const char *arg0, const char *arg1, const char *arg2);
+int dspawnl(int mode, const char *file, const char *arg0, const char *arg1, const char *arg2);
+
+#endif

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -175,7 +175,7 @@ BACKOBJ= go.obj gdag.obj gother.obj gflow.obj gloop.obj var.obj el.obj \
 # Root package
 ROOTOBJS= man.obj port.obj checkedint.obj \
 	stringtable.obj response.obj async.obj speller.obj aav.obj outbuffer.obj \
-	object.obj filename.obj file.obj \
+	object.obj filename.obj file.obj utils.obj \
 	rmem.obj newdelete.obj
 
 # D front end
@@ -236,7 +236,8 @@ ROOTSRCC=$(ROOT)\rmem.c $(ROOT)\stringtable.c \
 	$(ROOT)\man.c $(ROOT)\port.c $(ROOT)\async.c $(ROOT)\response.c \
 	$(ROOT)\speller.c $(ROOT)\aav.c $(ROOT)\longdouble.c \
 	$(ROOT)\checkedint.c $(ROOT)\newdelete.c \
-	$(ROOT)\outbuffer.c $(ROOT)\object.c $(ROOT)\filename.c $(ROOT)\file.c
+	$(ROOT)\outbuffer.c $(ROOT)\object.c $(ROOT)\filename.c \
+	$(ROOT)\file.c $(ROOT)\utils.c
 ROOTSRC= $(ROOT)\root.h \
 	$(ROOT)\rmem.h $(ROOT)\port.h \
 	$(ROOT)\stringtable.h \
@@ -250,6 +251,7 @@ ROOTSRC= $(ROOT)\root.h \
 	$(ROOT)\filename.h \
 	$(ROOT)\file.h \
 	$(ROOT)\array.h \
+	$(ROOT)\utils.h \
 	$(ROOTSRCC)
 # Removed garbage collector bits (look in history)
 #	$(ROOT)\gc\bits.c $(ROOT)\gc\gc.c $(ROOT)\gc\gc.h $(ROOT)\gc\mscbitops.h \
@@ -347,7 +349,7 @@ GENSRC=access.d aggregate.d aliasthis.d apply.d \
 	globals.d escape.d \
 	$(ROOT)\aav.d $(ROOT)\outbuffer.d $(ROOT)\stringtable.d \
 	$(ROOT)\file.d $(ROOT)\filename.d $(ROOT)\speller.d \
-	$(ROOT)\man.d $(ROOT)\response.d
+	$(ROOT)\man.d $(ROOT)\response.d $(ROOT)\utils.d
 
 MANUALSRC= \
 	intrange.d complex.d \
@@ -728,6 +730,9 @@ filename.obj : $(ROOT)\filename.c
 
 file.obj : $(ROOT)\file.c
 	$(CC) -c $(CFLAGS) $(ROOT)\file.c
+
+utils.obj : $(ROOT)\utils.c
+	$(CC) -c $(CFLAGS) $(ROOT)\utils.c
 
 # Root/GC -- Removed (look in history)
 #

--- a/test/runnable/extra-files/यूनिकोड.d
+++ b/test/runnable/extra-files/यूनिकोड.d
@@ -1,0 +1,2 @@
+module unicode;
+void main() { }

--- a/test/runnable/test_utf8_cmdfile.sh
+++ b/test/runnable/test_utf8_cmdfile.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}${SEP}test_utf8_cmdfile.sh.out
+
+rm -f ${output_file}
+
+echo "-of${dir}${SEP}test_utf8_cmdfile${EXE}" > ${dir}${SEP}cmdfile
+echo "${src}${SEP}यूनिकोड.d" >> ${dir}${SEP}cmdfile
+
+$DMD @${dir}${SEP}cmdfile || exit 1
+
+rm ${dir}${SEP}{cmdfile,test_utf8_cmdfile${OBJ},test_utf8_cmdfile${EXE}}
+
+echo Success > ${output_file}


### PR DESCRIPTION
This is a quick hack for [Issue 14474](https://issues.dlang.org/show_bug.cgi?id=14474)
Decode UTF-8 to windows Wide string and then encode it to default windows ANSI code page.

Best should use Wide WinAPI functions and then wouldn't need to encode it to ANSI code page but that's quite a lot of work... Note that not all UTF-8 characters can be encoded to ANSI code page. Thus it's possible to have some paths/names that can't be accessed with  ANSI functions.
