### PR TITLE
[REG2.068a] Issue 14468 - overload mismatch for template instance with typesafe variadic parameter

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -1499,7 +1499,7 @@ MATCH TemplateDeclaration::deduceFunctionTemplateMatch(
         if (argi >= nfargs)                // if not enough arguments
         {
             if (!fparam->defaultArg)
-                goto Lnomatch;
+                goto Lvarargs;
 
             /* Bugzilla 2803: Before the starting of type deduction from the function
              * default arguments, set the already deduced parameters into paramscope.

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -494,6 +494,9 @@ void normalize2803(R)(R range, ElementType2803!R sum = 1)
     static assert(is(typeof(sum) == double));
 }
 
+auto foo14468(T)(T[]...) { return 1; }
+auto foo14468(bool flag, T)(T[]...) { return 2; }
+
 void test2803()
 {
     assert(foo2803() == 0);
@@ -519,6 +522,8 @@ void test2803()
 
     double[] a = [];
     normalize2803(a);
+
+    assert(foo14468!int() == 1);
 }
 
 /**********************************/


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14468
