### PR TITLE
Version out DMD-specific test

### DIFF
--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -580,6 +580,8 @@ void test9568()
 
 /****************************************************/
 
+version (DigitalMars)
+{
 void test8a()
 {
   int a;
@@ -631,6 +633,7 @@ void test8()
   test8a();
   test8b();
   test8c();
+}
 }
 
 /****************************************************/
@@ -769,7 +772,7 @@ int main()
     multicollide();
     test9568();
 
-    test8();
+    version(DigitalMars) test8();
     test9();
     test10964();
     test12989();


### PR DESCRIPTION
Current rules of the language:
- You cannot goto in a try block
- You cannot goto in or out of a finally

Why it is then the case that it is all OK for a catch block?  Regardless of excuses, EH regions are not normal blocks of code, and you cannot jump into them using conventional means.  And that's ignoring any skipped artificial factor/clean-up calls that may be inserted in by the compiler.
