### PR TITLE
Remove 'if (v; e)' after more than 2 years being an error

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -5071,16 +5071,6 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr, Loc *pEndloc
                 check(TOKassign);
                 param = new Parameter(storageClass, at, ai, NULL);
             }
-            else if (storageClass == 0 &&
-                     token.value == TOKidentifier &&
-                     peek(&token)->value == TOKsemicolon)
-            {
-                // Check for " ident;"
-                param = new Parameter(0, NULL, token.ident, NULL);
-                nextToken();
-                nextToken();
-                error("use 'if (auto v = e)' instead of 'if (v; e)'");
-            }
             else if (isDeclaration(&token, 2, TOKassign, NULL))
             {
                 Identifier *ai;

--- a/test/fail_compilation/parseStc.d
+++ b/test/fail_compilation/parseStc.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc.d(10): Error: use 'if (auto v = e)' instead of 'if (v; e)'
-fail_compilation/parseStc.d(11): Error: redundant attribute 'const'
+fail_compilation/parseStc.d(11): Error: found ';' when expecting ')'
+fail_compilation/parseStc.d(11): Error: found ')' when expecting ';' following statement
+fail_compilation/parseStc.d(12): Error: redundant attribute 'const'
 ---
 */
 void test1()
@@ -14,9 +15,9 @@ void test1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc.d(24): Error: redundant attribute 'const'
 fail_compilation/parseStc.d(25): Error: redundant attribute 'const'
-fail_compilation/parseStc.d(26): Error: conflicting attribute 'immutable'
+fail_compilation/parseStc.d(26): Error: redundant attribute 'const'
+fail_compilation/parseStc.d(27): Error: conflicting attribute 'immutable'
 ---
 */
 void test2()
@@ -29,8 +30,8 @@ void test2()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc.d(36): Error: redundant attribute 'const'
 fail_compilation/parseStc.d(37): Error: redundant attribute 'const'
+fail_compilation/parseStc.d(38): Error: redundant attribute 'const'
 ---
 */
 struct S3 { const const test3() {} }


### PR DESCRIPTION
Needs also a PR for documentation update.
