### PR TITLE
Switch UDA [attribute] syntax from deprecation -> error

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -621,7 +621,7 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
             {
                 if (peekNext() == TOKrbracket)
                     error("empty attribute list is not allowed");
-                deprecation("use @(attributes) instead of [attributes]");
+                error("use @(attributes) instead of [attributes]");
                 Expressions *exps = parseArguments();
                 // no redundant/conflicting check for UDAs
 

--- a/test/fail_compilation/parse13361.d
+++ b/test/fail_compilation/parse13361.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/parse13361.d(11): Error: empty attribute list is not allowed
 fail_compilation/parse13361.d(14): Error: empty attribute list is not allowed
-fail_compilation/parse13361.d(14): Deprecation: use @(attributes) instead of [attributes]
+fail_compilation/parse13361.d(14): Error: use @(attributes) instead of [attributes]
 ---
 */
 struct A


### PR DESCRIPTION
Make `[attribute]` syntax - the feature that never was - an official error.
