### PR TITLE
Add a new -transition switch advising of future deprecation of complex/imaginary types

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -876,6 +876,9 @@ void VarDeclaration::semantic(Scope *sc)
     //printf("sc->stc = %x\n", sc->stc);
     //printf("storage_class = x%x\n", storage_class);
 
+    if (global.params.vcomplex)
+        type->checkComplexTransition(loc);
+
     // Calculate type size + safety checks
     if (sc->func && !sc->intypeof && !isMember())
     {

--- a/src/expression.c
+++ b/src/expression.c
@@ -4568,6 +4568,9 @@ Expression *TypeExp::semantic(Scope *sc)
     else
         assert(0);
 
+    if (global.params.vcomplex)
+        type->checkComplexTransition(loc);
+
     return e;
 }
 
@@ -6088,6 +6091,9 @@ Expression *TypeidExp::semantic(Scope *sc)
         error("no type for typeid(%s)", ea ? ea->toChars() : (sa ? sa->toChars() : ""));
         return new ErrorExp();
     }
+
+    if (global.params.vcomplex)
+        ta->checkComplexTransition(loc);
 
     Expression *e;
     if (ea && ta->toBasetype()->ty == Tclass)

--- a/src/func.c
+++ b/src/func.c
@@ -1541,6 +1541,9 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (f->checkRetType(loc))
                     fbody = new ErrorStatement();
             }
+            if (global.params.vcomplex && f->next != NULL)
+                f->next->checkComplexTransition(loc);
+
             if (returns && !fbody->isErrorStatement())
             {
                 for (size_t i = 0; i < returns->dim; )

--- a/src/globals.h
+++ b/src/globals.h
@@ -47,6 +47,7 @@ struct Param
     bool vtls;          // identify thread local variables
     char vgc;           // identify gc usage
     bool vfield;        // identify non-mutable field variables
+    bool vcomplex;      // identify complex/imaginary type usage
     char symdebug;      // insert debug symbolic information
     bool alwaysframe;   // always emit standard stack frame
     bool optimize;      // run optimizer

--- a/src/mars.c
+++ b/src/mars.c
@@ -561,6 +561,7 @@ int tryMain(size_t argc, const char *argv[])
                     {
                         printf("\
 Language changes listed by -transition=id:\n\
+  =all           list information on all language changes\n\
   =complex,14488 list all usages of complex or imaginary types\n\
   =field,3449    list all non-mutable fields which occupy an object instance\n\
   =tls           list all variables going into thread local storage\n\
@@ -589,12 +590,43 @@ Language changes listed by -transition=id:\n\
                     }
                     else if (Lexer::isValidIdentifier(p + 12))
                     {
-                        if (strcmp(p + 12, "tls") == 0)
-                            global.params.vtls = 1;
-                        if (strcmp(p + 12, "field") == 0)
-                            global.params.vfield = 1;
-                        if (strcmp(p + 12, "complex") == 0)
-                            global.params.vcomplex = 1;
+                        const char *ident = p + 12;
+                        switch (strlen(ident))
+                        {
+                            case 3:
+                                if (strcmp(ident, "all") == 0)
+                                {
+                                    global.params.vtls = true;
+                                    global.params.vfield = true;
+                                    global.params.vcomplex = true;
+                                    break;
+                                }
+                                if (strcmp(ident, "tls") == 0)
+                                {
+                                    global.params.vtls = true;
+                                    break;
+                                }
+                                goto Lerror;
+
+                            case 5:
+                                if (strcmp(ident, "field") == 0)
+                                {
+                                    global.params.vfield = true;
+                                    break;
+                                }
+                                goto Lerror;
+
+                            case 7:
+                                if (strcmp(ident, "complex") == 0)
+                                {
+                                    global.params.vcomplex = true;
+                                    break;
+                                }
+                                goto Lerror;
+
+                            default:
+                                goto Lerror;
+                        }
                     }
                     else
                         goto Lerror;

--- a/src/mars.c
+++ b/src/mars.c
@@ -561,6 +561,7 @@ int tryMain(size_t argc, const char *argv[])
                     {
                         printf("\
 Language changes listed by -transition=id:\n\
+  =complex,14488 list all usages of complex or imaginary types\n\
   =field,3449    list all non-mutable fields which occupy an object instance\n\
   =tls           list all variables going into thread local storage\n\
 ");
@@ -579,6 +580,9 @@ Language changes listed by -transition=id:\n\
                             case 3449:
                                 global.params.vfield = true;
                                 break;
+                            case 14488:
+                                global.params.vcomplex = true;
+                                break;
                             default:
                                 goto Lerror;
                         }
@@ -589,6 +593,8 @@ Language changes listed by -transition=id:\n\
                             global.params.vtls = 1;
                         if (strcmp(p + 12, "field") == 0)
                             global.params.vfield = 1;
+                        if (strcmp(p + 12, "complex") == 0)
+                            global.params.vcomplex = 1;
                     }
                     else
                         goto Lerror;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -339,6 +339,7 @@ public:
     uinteger_t sizemask();
     virtual bool needsDestruction();
     virtual bool needsNested();
+    void checkComplexTransition(Loc loc);
 
     static void error(Loc loc, const char *format, ...);
     static void warning(Loc loc, const char *format, ...);

--- a/test/compilable/sw_transition_complex.d
+++ b/test/compilable/sw_transition_complex.d
@@ -1,0 +1,136 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -c -transition=complex
+
+/*
+TEST_OUTPUT:
+---
+compilable/sw_transition_complex.d(15): use of complex type 'creal' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(16): use of complex type 'cdouble' is scheduled for deprecation, use 'std.complex.Complex!(double)' instead
+compilable/sw_transition_complex.d(17): use of complex type 'cfloat' is scheduled for deprecation, use 'std.complex.Complex!(float)' instead
+compilable/sw_transition_complex.d(19): use of imaginary type 'ireal' is scheduled for deprecation, use 'real' instead
+compilable/sw_transition_complex.d(20): use of imaginary type 'idouble' is scheduled for deprecation, use 'double' instead
+compilable/sw_transition_complex.d(21): use of imaginary type 'ifloat' is scheduled for deprecation, use 'float' instead
+---
+*/
+creal c80value;
+cdouble c64value;
+cfloat c32value;
+
+ireal i80value;
+idouble i64value;
+ifloat i32value;
+
+/*
+TEST_OUTPUT:
+---
+compilable/sw_transition_complex.d(34): use of complex type 'creal*' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(35): use of complex type 'cdouble*' is scheduled for deprecation, use 'std.complex.Complex!(double)' instead
+compilable/sw_transition_complex.d(36): use of complex type 'cfloat*' is scheduled for deprecation, use 'std.complex.Complex!(float)' instead
+compilable/sw_transition_complex.d(38): use of imaginary type 'ireal*' is scheduled for deprecation, use 'real' instead
+compilable/sw_transition_complex.d(39): use of imaginary type 'idouble*' is scheduled for deprecation, use 'double' instead
+compilable/sw_transition_complex.d(40): use of imaginary type 'ifloat*' is scheduled for deprecation, use 'float' instead
+---
+*/
+creal* c80pointer;
+cdouble* c64pointer;
+cfloat* c32pointer;
+
+ireal* i80pointer;
+idouble* i64pointer;
+ifloat* i32pointer;
+
+/*
+TEST_OUTPUT:
+---
+compilable/sw_transition_complex.d(53): use of complex type 'creal[]*' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(54): use of complex type 'cdouble[]*' is scheduled for deprecation, use 'std.complex.Complex!(double)' instead
+compilable/sw_transition_complex.d(55): use of complex type 'cfloat[]*' is scheduled for deprecation, use 'std.complex.Complex!(float)' instead
+compilable/sw_transition_complex.d(57): use of imaginary type 'ireal[]*' is scheduled for deprecation, use 'real' instead
+compilable/sw_transition_complex.d(58): use of imaginary type 'idouble[]*' is scheduled for deprecation, use 'double' instead
+compilable/sw_transition_complex.d(59): use of imaginary type 'ifloat[]*' is scheduled for deprecation, use 'float' instead
+---
+*/
+creal[]* c80arrayp;
+cdouble[]* d64arrayp;
+cfloat[]* c32arrayp;
+
+ireal[]* i80arrayp;
+idouble[]* i64arrayp;
+ifloat[]* i32arrayp;
+
+/*
+TEST_OUTPUT:
+---
+compilable/sw_transition_complex.d(72): use of complex type 'creal[4][]*' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(73): use of complex type 'cdouble[4][]*' is scheduled for deprecation, use 'std.complex.Complex!(double)' instead
+compilable/sw_transition_complex.d(74): use of complex type 'cfloat[4][]*' is scheduled for deprecation, use 'std.complex.Complex!(float)' instead
+compilable/sw_transition_complex.d(76): use of imaginary type 'ireal[4][]*' is scheduled for deprecation, use 'real' instead
+compilable/sw_transition_complex.d(77): use of imaginary type 'idouble[4][]*' is scheduled for deprecation, use 'double' instead
+compilable/sw_transition_complex.d(78): use of imaginary type 'ifloat[4][]*' is scheduled for deprecation, use 'float' instead
+---
+*/
+creal[4][]* c80sarrayp;
+cdouble[4][]* c64sarrayp;
+cfloat[4][]* c32sarrayp;
+
+ireal[4][]* i80sarrayp;
+idouble[4][]* i64sarrayp;
+ifloat[4][]* i32sarrayp;
+
+/*
+TEST_OUTPUT:
+---
+compilable/sw_transition_complex.d(96): use of complex type 'creal' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(97): use of complex type 'creal*' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(98): use of complex type 'creal[]' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(99): use of complex type 'creal[4]' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(101): use of imaginary type 'ireal' is scheduled for deprecation, use 'real' instead
+compilable/sw_transition_complex.d(102): use of imaginary type 'ireal*' is scheduled for deprecation, use 'real' instead
+compilable/sw_transition_complex.d(103): use of imaginary type 'ireal[]' is scheduled for deprecation, use 'real' instead
+compilable/sw_transition_complex.d(104): use of imaginary type 'ireal[4]' is scheduled for deprecation, use 'real' instead
+---
+*/
+alias C14488 = creal;
+alias I14488 = ireal;
+
+C14488 calias1;
+C14488* calias2;
+C14488[] calias3;
+C14488[4] calias4;
+
+I14488 ialias1;
+I14488* ialias2;
+I14488[] ialias3;
+I14488[4] ialias4;
+
+/*
+TEST_OUTPUT:
+---
+compilable/sw_transition_complex.d(115): use of complex type 'cdouble' is scheduled for deprecation, use 'std.complex.Complex!(double)' instead
+compilable/sw_transition_complex.d(116): use of imaginary type 'idouble' is scheduled for deprecation, use 'double' instead
+compilable/sw_transition_complex.d(117): use of complex type 'cdouble' is scheduled for deprecation, use 'std.complex.Complex!(double)' instead
+compilable/sw_transition_complex.d(118): use of complex type 'cdouble[]' is scheduled for deprecation, use 'std.complex.Complex!(double)' instead
+---
+*/
+auto cauto = 1 + 0i;
+auto iauto = 1i;
+size_t c64sizeof = (cdouble).sizeof;
+TypeInfo c64ti = typeid(cdouble[]);
+
+/*
+TEST_OUTPUT:
+---
+compilable/sw_transition_complex.d(128): use of complex type 'creal*' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+compilable/sw_transition_complex.d(128): use of imaginary type 'ireal' is scheduled for deprecation, use 'real' instead
+compilable/sw_transition_complex.d(132): use of complex type 'creal' is scheduled for deprecation, use 'std.complex.Complex!(real)' instead
+---
+*/
+void test14488a(creal *p, real r, ireal i)
+{
+}
+
+creal test14488b()
+{
+    return 1 + 0i;
+}
+


### PR DESCRIPTION
This needs discussion and an entry on the deprecations page - but I think the time is probably right to start moving library code away from this, same reasoning as for the NCEG deprecation a year or so back.

Of course the testsuite will start failing, it builds with `-w`, no?
