### PR TITLE
Remove Phobos dependency for deprecated symbols

### DIFF
--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1,7 +1,4 @@
-
-import std.stdio;
-import std.typetuple;
-import std.traits;
+alias TypeTuple(T...) = T;
 
 class A { }
 class B : A { }
@@ -64,11 +61,8 @@ template Foo3(T, A...)
 {
     int Foo3(T t, A a)
     {
-        printf("A.length = %d\n", A.length);
         assert(A.length == 2);
-        printf("a.length = %d\n", a.length);
         assert(a.length == 2);
-        printf("%d %d %d\n", t, a);
         bar3(a);
         assert([a] == [2, 3]);
         assert([cast(double)a] == [2.0, 3.0]);
@@ -102,7 +96,6 @@ void foo4(A...)()
     aa = null;
     foreach (a; A)
     {
-        printf("%d\n", a);
         aa ~= a;
     }
     assert(aa == [7,4,9]);
@@ -110,7 +103,6 @@ void foo4(A...)()
     aa = null;
     foreach (int a; A)
     {
-        printf("%d\n", a);
         aa ~= a;
     }
     assert(aa == [7,4,9]);
@@ -119,7 +111,6 @@ void foo4(A...)()
     aa = null;
     foreach (int i, a; A)
     {
-        printf("[%d]: %d\n", i, a);
         ai ~= i;
         aa ~= a;
     }
@@ -130,7 +121,6 @@ void foo4(A...)()
     aa = null;
     foreach_reverse (uint i, a; A)
     {
-        printf("[%d]: %d\n", i, a);
         ai ~= i;
         aa ~= a;
     }
@@ -141,7 +131,6 @@ void foo4(A...)()
     aa = null;
     foreach_reverse (i, a; A)
     {
-        printf("[%d]: %d\n", i, a);
         ai ~= i;
         aa ~= a;
     }
@@ -152,7 +141,6 @@ void foo4(A...)()
     aa = null;
     foreach (int i, a; A)
     {
-        printf("[%d]: %d\n", i, a);
         ai ~= i;
         aa ~= a;
         if (i == 1)
@@ -166,115 +154,6 @@ void foo4(A...)()
 void test4()
 {
     foo4!(7,4,9)();
-}
-
-/***************************************/
-
-void print5(A...)(A a)
-{
-    foreach(b; a)
-        writeln(b);
-}
-
-void test5()
-{
-    print5!()();
-    print5!(int,char,double)(7,'a',6.8);
-}
-
-/***************************************/
-
-void print6(A...)(A a)
-{
-    foreach(b; a)
-        writeln(b);
-}
-
-void test6()
-{
-    print6();
-    print6(7,'a',6.8);
-}
-
-/***************************************/
-
-void print7(T)(T t)
-{
-    writeln(t);
-}
-
-void print7(T, A...)(T t, A a)
-{
-    writeln(t);
-    print7(a);
-}
-
-void test7()
-{
-    print7(7,'a',6.8);
-}
-
-/***************************************/
-
-void print8()()
-{
-}
-
-void print8(T, A...)(T t, A a)
-{
-    writeln(t);
-    print8(a);
-}
-
-void test8()
-{
-    print8();
-    print8(7,'a',6.8);
-}
-
-/***************************************/
-
-void print9(A...)(A a)
-{
-    writeln(a);
-}
-
-void test9()
-{
-    print9();
-    print9(7,'a',6.8);
-}
-
-/***************************************/
-
-void print10(A...)(A a)
-{
-    static if (a.length)
-    {
-        writeln(a[0]);
-        static if (a.length > 1)
-            print10(a[1 .. $]);
-    }
-}
-
-void test10()
-{
-    print10();
-    print10(7,'a',6.8);
-}
-
-/***************************************/
-
-void print11(A...)(A a)
-{
-    foreach(b; A)
-        writeln(typeid(b));
-}
-
-void test11()
-{
-    print11();
-    print11(7,6.8);
 }
 
 /***************************************/
@@ -296,7 +175,6 @@ int c12(TypeTuple!(TypeTuple!(int), TypeTuple!(TypeTuple!(), int), TypeTuple!())
 
 void test12()
 {
-    printf("%d\n", a12(1, 2));
     assert(a12(1, 2) == 3);
     assert(b12(1, 2) == 3);
     assert(c12(1, 2) == 3);
@@ -316,7 +194,6 @@ int plus13(TypeTuple!(int, long, float)[0 .. 2] t)
 
 void test13()
 {
-    printf("%d\n", plus13(5, 6));
     assert(plus13(5, 6) == 11);
 }
 
@@ -333,115 +210,7 @@ int plus14(TypeTuple!(int, long, float)[0 .. $ - 1] t)
 
 void test14()
 {
-    printf("%d\n", plus14(5, 6));
     assert(plus14(5, 6) == 11);
-}
-
-/***************************************/
-
-void test15()
-{
-    alias TypeTuple!(int, long, float) TL;
-
-    printf("%d\n", IndexOf!(char, TL));
-    assert(IndexOf!(char, TL) == -1);
-    printf("%d\n", IndexOf!(char));
-    assert(IndexOf!(char) == -1);
-    printf("%d\n", IndexOf!(int, TL));
-    assert(IndexOf!(int, TL) == 0);
-    printf("%d\n", IndexOf!(long, TL));
-    assert(IndexOf!(long, TL) == 1);
-    printf("%d\n", IndexOf!(float, TL));
-    assert(IndexOf!(float, TL) == 2);
-}
-
-/***************************************/
-
-void test16()
-{
-    alias TypeTuple!(int, long, float, int) TL;
-
-    assert(is(Erase!(int, TL) == TypeTuple!(long, float, int)));
-    assert(is(Erase!(char) == TL[0 .. 0]));
-    assert(is(Erase!(char, TL) == TL));
-    assert(is(Erase!(long, TL) == TypeTuple!(int, float, int)));
-}
-
-/***************************************/
-
-void test17()
-{
-    alias TypeTuple!(int, long, float, int) TL;
-
-    assert(is(EraseAll!(int, TL) == TypeTuple!(long, float)));
-    assert(is(EraseAll!(char) == TL[0 .. 0]));
-    assert(is(EraseAll!(double, TL) == TL));
-}
-
-/***************************************/
-
-void test18()
-{
-    alias TypeTuple!(int, long, float, int) TL;
-
-    assert(is(NoDuplicates!(TL) == TypeTuple!(int, long, float)));
-    assert(is(NoDuplicates!(char) == TypeTuple!(char)));
-    assert(is(NoDuplicates!() == TypeTuple!()));
-}
-
-/***************************************/
-
-void test19()
-{
-    alias TypeTuple!(int, long, float, int) TL;
-
-    assert(is(Replace!(int, char, TL) == TypeTuple!(char, long, float, int)));
-    assert(is(Replace!(char, double, TL) == TL));
-    assert(is(Replace!(int, char) == TypeTuple!()));
-}
-
-/***************************************/
-
-void test20()
-{
-    alias TypeTuple!(int, long, float, int) TL;
-
-    assert(is(ReplaceAll!(int, char, TL) == TypeTuple!(char, long, float, char)));
-    assert(is(ReplaceAll!(char, double, TL) == TL));
-    assert(is(ReplaceAll!(int, char) == TypeTuple!()));
-}
-
-/***************************************/
-
-void test21()
-{
-    alias TypeTuple!(int, long, float) TL;
-
-    assert(is(Reverse!(TL) == TypeTuple!(float, long, int)));
-    assert(is(Reverse!(int) == TypeTuple!(int)));
-    assert(is(Reverse!() == TypeTuple!()));
-}
-
-/***************************************/
-
-void test22()
-{
-    alias TypeTuple!(A, C, B, float) TL;
-
-    assert(is(MostDerived!(Object, TL) == C));
-    assert(is(MostDerived!(int, TL) == int));
-    assert(is(MostDerived!(float, TL) == float));
-    assert(is(MostDerived!(int) == int));
-}
-
-/***************************************/
-
-void test23()
-{
-    alias TypeTuple!(A, C, B) TL;
-
-    assert(is(DerivedToFront!(TL) == TypeTuple!(C, B, A)));
-    assert(is(DerivedToFront!() == TL[0 .. 0]));
 }
 
 /***************************************/
@@ -465,100 +234,12 @@ void test24()
 
 /***************************************/
 
-void test25()
-{
-    static double foo(long x, float y) { return 0; }
-    assert(is(ReturnType!(foo) == double));
-    assert(is(ParameterTypeTuple!(foo)[0] == long));
-    assert(is(ParameterTypeTuple!(foo)[1] == float));
-
-    assert(is(ReturnType!(typeof(foo)) == double));
-    assert(is(ParameterTypeTuple!(typeof(foo))[0] == long));
-    assert(is(ParameterTypeTuple!(typeof(foo))[1] == float));
-
-    auto pfoo = &foo;
-    assert(is(ReturnType!(pfoo) == double));
-    assert(is(ParameterTypeTuple!(pfoo)[0] == long));
-    assert(is(ParameterTypeTuple!(pfoo)[1] == float));
-
-    assert(is(ReturnType!(typeof(pfoo)) == double));
-    assert(is(ParameterTypeTuple!(typeof(pfoo))[0] == long));
-    assert(is(ParameterTypeTuple!(typeof(pfoo))[1] == float));
-
-    //writeln(typeid(ParameterTypeTuple!(pbar)[0]));
-
-    double bar(long x, float y) { return 0; }
-
-    assert(is(ReturnType!(bar) == double));
-    assert(is(ParameterTypeTuple!(bar)[0] == long));
-    assert(is(ParameterTypeTuple!(bar)[1] == float));
-
-    assert(is(ReturnType!(typeof(bar)) == double));
-    assert(is(ParameterTypeTuple!(typeof(bar))[0] == long));
-    assert(is(ParameterTypeTuple!(typeof(bar))[1] == float));
-
-    auto pbar = &bar;
-    assert(is(ReturnType!(pbar) == double));
-    assert(is(ParameterTypeTuple!(pbar)[0] == long));
-    assert(is(ParameterTypeTuple!(pbar)[1] == float));
-
-    assert(is(ReturnType!(typeof(pbar)) == double));
-    assert(is(ParameterTypeTuple!(typeof(pbar))[0] == long));
-    assert(is(ParameterTypeTuple!(typeof(pbar))[1] == float));
-}
-
-/***************************************/
-
-template Tuple(T...)
-{
-    alias T Tuple;
-}
-
-alias Tuple!(4, 5, Tuple!("hi", "bye")) t2;
-
-void test26()
-{
-    writeln(t2);
-    assert(std.string.format("%s%s%s%s", t2) == "45hibye");
-    writeln(typeid(typeof(t2)));
-    version (D_Version2)
-    {
-        assert(std.string.format("%s", typeid(typeof(t2))) == "(int,int,immutable(char)[],immutable(char)[])");
-    }
-    else
-    {
-        assert(std.string.format("%s", typeid(typeof(t2))) == "(int,int,char[2],char[3])");
-    }
-}
-
-/***************************************/
-
-void test27()
-{   int y;
-
-    int bar(int x, long z)
-    {
-        return x + y;
-    }
-
-    auto dg = &bar;
-
-    writefln("%s %s", dg.ptr, dg.funcptr);
-    writeln(typeid(ReturnType!(typeof(dg.funcptr))));
-    assert(std.string.format("%s", typeid(ReturnType!(typeof(dg.funcptr)))) == "int");
-    writeln(typeid(ParameterTypeTuple!(typeof(dg.funcptr))));
-    assert(std.string.format("%s", typeid(ParameterTypeTuple!(typeof(dg.funcptr)))) == "(int,long)");
-}
-
-/***************************************/
-
 void test28()
 {
     alias TypeTuple!(int, long, double) TL;
 
     foreach (int i, T; TL)
     {
-        writeln(typeid(T));
         switch (i)
         {
             case 0: assert(is(T == int));    break;
@@ -567,83 +248,6 @@ void test28()
             default:assert(0);
         }
     }
-}
-
-/***************************************/
-
-void test29()
-{
-    alias TypeTuple!(int, long, double) TL;
-
-    struct Foo
-    {
-        static TL tl;
-
-        void bar()
-        {
-            writeln(tl);
-            assert(std.string.format("%s%s%s", tl) == "00nan");
-
-            tl[0] = 3;
-            tl[1] = 5;
-            tl[2] = 6.8;
-            writeln(tl);
-            assert(std.string.format("%s%s%s", tl) == "356.8");
-        }
-    }
-
-    Foo foo;
-    foo.bar();
-}
-
-/***************************************/
-
-void test30()
-{
-    alias TypeTuple!(int, long, double) TL;
-
-    struct Foo
-    {
-        TL tl;
-
-        void bar()
-        {
-            writeln(tl);
-            assert(std.string.format("%s%s%s", tl) == "00nan");
-
-            tl[0] = 3;
-            tl[1] = 5;
-            tl[2] = 6.8;
-            writeln(tl);
-            assert(std.string.format("%s%s%s", tl) == "356.8");
-        }
-    }
-
-    Foo foo;
-    foo.bar();
-}
-
-/***************************************/
-
-void test31()
-{
-    alias TypeTuple!(int, long, double) TL;
-
-    struct Foo
-    {
-        TL tl;
-    }
-
-    Foo foo;
-
-    writeln(foo.tl);
-    assert(std.string.format("%s%s%s", foo.tl) == "00nan");
-
-    foo.tl[0] = 3;
-    foo.tl[1] = 5;
-    foo.tl[2] = 6.8;
-    writeln(foo.tl);
-    assert(std.string.format("%s%s%s", foo.tl) == "356.8");
 }
 
 /***************************************/
@@ -674,7 +278,6 @@ struct S34
 
 void foo34(int x, long y, double z)
 {
-    writeln(x, y, z);
     assert(x == 3);
     assert(y == 8);
     assert(z == 6.8);
@@ -701,7 +304,6 @@ struct S35
 
 void foo35(int x, long y, double z)
 {
-    writeln(x, y, z);
     assert(x == 3);
     assert(y == 8);
     assert(z == 6.8);
@@ -729,7 +331,6 @@ class C36
 
 void foo36(int x, long y, double z)
 {
-    writeln(x, y, z);
     assert(x == 3);
     assert(y == 8);
     assert(z == 6.8);
@@ -758,7 +359,6 @@ class C37
 
 void foo37(int x, long y, double z)
 {
-    //writeln(x, y, z);
     assert(x == 3);
     assert(y == 8);
     assert(z == 6.8);
@@ -781,13 +381,6 @@ void test37()
     x[1] = 8;
     x[2] = 6.8;
     foo37(x);
-
-    //typeof(C.tupleof) y;
-    FieldTypeTuple!(C37) y;
-    y[0] = 3;
-    y[1] = 8;
-    y[2] = 6.8;
-    foo37(y);
 }
 
 /***************************************/
@@ -818,173 +411,6 @@ void test39()
     alias TypeTuple!(ulong,uint,ushort,ubyte) tuple;
     static assert(is(tuple[1] == uint));
     static assert(is(tuple[a[0]] == uint));
-}
-
-/***************************************/
-
-void test40()
-{
-    interface I { }
-    class A { }
-    class B : A, I { }
-
-    alias BaseTypeTuple!(B) TL;
-    assert(TL.length == 2);
-    assert(is (TL[0] == A));
-    assert(is (TL[1] == I));
-}
-
-/***************************************/
-
-import std.stdio;
-
-template Format(A...)
-{
-    static if (A.length == 0)
-        const string Format = "";
-    else static if (is(typeof(A[0]) : string))
-        const string Format = FormatString!(A[0], A[1..$]);
-        //const string Format = FormatString!(A[0]);
-    else
-        const string Format = ToString!(A[0]) ~ Format!(A[1..$]);
-}
-
-template FormatString(string F, A...)
-{
-    static if (F.length == 0)
-        const string FormatString = Format!(A);
-    else static if (F.length == 1)
-        const string FormatString = F[0] ~ Format!(A);
-    else static if (F[0..2] == "%s")
-        const string FormatString = ToString!(A[0]) ~ FormatString!(F[2..$],A[1..$]);
-    else static if (F[0..2] == "%%")
-        const string FormatString = "%" ~ FormatString!(F[2..$],A);
-    else static if (F[0] == '%')
-        static assert(0, "unrecognized format %" ~ F[1]);
-    else
-        const string FormatString = F[0] ~ FormatString!(F[1..$],A);
-}
-
-template ToString(ulong U)
-{
-    static if (U < 10)
-        const string ToString = "" ~ cast(char)(U + '0');
-    else
-        const string ToString = ToString!(U / 10) ~ ToString!(U % 10);
-}
-
-template ToString(long I)
-{
-    static if (I < 0)
-        const string ToString = "-" ~ ToString!(cast(ulong)(-I));
-    else
-        const string ToString = ToString!(cast(uint)I);
-}
-
-template ToString(uint U)
-{
-    const string ToString = ToString!(cast(ulong)U);
-}
-
-template ToString(int I)
-{
-    const string ToString = ToString!(cast(long)I);
-}
-
-template ToString(ushort U)
-{
-    const string ToString = ToString!(cast(ulong)U);
-}
-
-template ToString(short I)
-{
-    const string ToString = ToString!(cast(long)I);
-}
-
-template ToString(ubyte U)
-{
-    const string ToString = ToString!(cast(ulong)U);
-}
-
-template ToString(byte I)
-{
-    const string ToString = ToString!(cast(long)I);
-}
-
-template ToString(bool B)
-{
-    const string ToString = B ? "true" : "false";
-}
-
-template ToString(string S)
-{
-    const string ToString = S;
-}
-
-template ToString(char C)
-{
-    const string ToString = "" ~ C;
-}
-
-void test42()
-{
-    string s = Format!("hel%slo", "world", -138, 'c', true);
-    writefln(s);
-    assert(s == "helworldlo-138ctrue");
-}
-
-/***************************************/
-
-template LIT(char c)
-{
-    int LIT(int i)
-    {
-        printf("LIT!(%c)(%d)\n", c, i);
-        return i + 1;
-    }
-}
-
-int SEQ(pred...)(int i)
-{
-    static if (pred.length == 2)
-    {
-        return pred[0](1) + pred[1](2);
-    }
-    else
-    {
-        return SEQ!(SEQ!(pred[0], pred[1]), pred[2..$])(i);
-    }
-}
-
-void test43()
-{
-    alias SEQ!( LIT!('('), LIT!('a'), LIT!(')') ) group;
-    printf("%d\n", group(7));
-    assert(group(7) == 8);
-}
-
-/***************************************/
-
-struct TupleContainer( T... )
-{
-    alias T tuple;
-
-    template append( X )
-    {
-        alias TupleContainer!( T, X )   append;
-    }
-}
-
-template UseAppend( alias TC )
-{
-    alias TC.append!( int )   UseAppend;
-}
-
-
-void test44()
-{
-    writeln( typeid( UseAppend!( TupleContainer!() ).tuple ) );
-    assert( typeid( UseAppend!( TupleContainer!() ).tuple ).toString() == "(int)" );
 }
 
 /***************************************/
@@ -1077,24 +503,6 @@ void test49()
 
 /***************************************/
 
-string Multi (T, string name) ()
-{
-    foreach (key, method; TypeTuple!(int, int))
-    {
-        Single!(key)();
-    }
-    return ``;
-}
-
-string Single (int idx)() { return "s"; }
-
-void test50()
-{
-    pragma(msg, Multi!(Object, "toString")());
-}
-
-/***************************************/
-
 void foo51(U...)(int t, U u)
 {
     assert(t == 1);
@@ -1123,58 +531,6 @@ void test51()
   bar51(1, 2, 3);
   bar51!(int, int)(1, 2, 3);
   abc51(1,2,3,4);
-}
-
-/***************************************/
-
-template Tuple52(A...)
-{
-    alias A Tuple52;
-}
-
-int x52;
-alias Tuple52!(x52) Foos52;
-
-template Filter52()
-{
-    alias Tuple52!(Foos52[0]) FilteredFoos;
-}
-
-static assert(Filter52!().FilteredFoos.length == 1);
-
-void test52()
-{
-}
-
-/***************************************/
-
-template Tuple53(T...) { alias T Tuple53; }
-
-template Join53(TList1...) {
-    template To(TList2...) {
-        alias Tuple53!(TList1,TList2) To;
-    }
-}
-
-void test53()
-{
-    alias Join53!(1,2,3).To!(4,5,6) combo;
-    writeln(combo);
-}
-
-/***************************************/
-
-import std.typecons;
-
-std.typecons.Tuple!(Types) foo54(Types...)(string a)
-{
-    typeof(return) result;
-    return result;
-}
-
-void test54()
-{
-    auto a = foo54!(int, double)("a");
 }
 
 /***************************************/
@@ -1309,15 +665,6 @@ alias TypeTuple61!(A61[0].list) B61;
 
 void test61()
 {
-}
-
-/***************************************/
-
-void test62()
-{
-    auto t = [  std.typecons.tuple(1, 2),
-                std.typecons.tuple(4, 1),
-                std.typecons.tuple(5, 100) ];
 }
 
 /***************************************/
@@ -1735,56 +1082,24 @@ int main()
     test2();
     test3();
     test4();
-    test5();
-    test6();
-    test7();
-    test8();
-    test9();
-    test10();
-    test11();
     test12();
     test13();
     test14();
-    test15();
-    test16();
-    test17();
-    test18();
-    test19();
-    test20();
-    test21();
-    test22();
-    test23();
     test24();
-    test25();
-    test26();
-    test27();
     test28();
-    test29();
-    test30();
-    test31();
     test32();
-//    test33();
     test34();
     test35();
     test36();
     test37();
     test38();
     test39();
-    test40();
- //   test41();
-    test42();
-    test43();
-    test44();
     test45();
     test46();
     test47();
     test48();
     test49();
-    test50();
     test51();
-    test52();
-    test53();
-    test54();
     test55();
     test56();
     test57();
@@ -1792,7 +1107,6 @@ int main()
     test59();
     test60();
     test61();
-    test62();
     test63();
     test1411();
     test4444();
@@ -1811,6 +1125,5 @@ int main()
     testCopy();
     test14179();
 
-    printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
std.typetuple is pending deprecation in Phobos. To avoid failing
the test suite, DMD should not use those symbols by that time

This PR moves simplified type-only versions of that symbols to
unittest module itself

blocks https://github.com/D-Programming-Language/phobos/pull/3128
