### PR TITLE
test/runnable/test_shared.sh: Don't require relative RESULTS_DIR.

### DIFF
--- a/test/runnable/test_shared.sh
+++ b/test/runnable/test_shared.sh
@@ -22,5 +22,5 @@ die()
 $DMD -m${MODEL} -of${dmddir}${SEP}test_shared${EXE} -defaultlib=libphobos2.so runnable/extra-files/test_shared.d >> ${output_file}
 if [ $? -ne 0 ]; then die; fi
 
-LD_LIBRARY_PATH=../../phobos/generated/${OS}/release/${MODEL} ./${dmddir}${SEP}test_shared${EXE}
+LD_LIBRARY_PATH=../../phobos/generated/${OS}/release/${MODEL} ${dmddir}${SEP}test_shared${EXE}
 if [ $? -ne 0 ]; then die; fi


### PR DESCRIPTION
LDC uses an absolute path. Not sure if there are platforms where all relative paths to executables (in some subdir) need to be prefixed by `./`  but the test currently runs exclusively on Linux anyway.
