### PR TITLE
Issue 13820 [deleted]

### DIFF
--- a/src/magicport.json
+++ b/src/magicport.json
@@ -1752,6 +1752,7 @@
             "imports" :
             [
                 "aggregate",
+                "aliasthis",
                 "arraytypes",
                 "arrayop",
                 "attrib",

--- a/test/compilable/test13820.d
+++ b/test/compilable/test13820.d
@@ -1,0 +1,22 @@
+// REQUIRED_ARGS: -o-
+// PERMUTE_ARGS:
+
+struct Foo
+{
+    uint val;
+    alias val this;
+}
+
+void test13820()
+{
+    int n = 1;
+    auto foo = Foo(2);
+
+    switch (foo)
+    {
+        case n: break;
+        case foo: break;
+        case Foo(3): break;
+        default: break;
+    }
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13820
- alias this resolve block mostly copy from Expression::toBoolean
- added cast to case expressions. This auto-fixes some nonsensical error messages involving case variables and implicit cast

Please note, that current dmd implementation of case expressions doesn't follow the specification, which says: _The case expressions must all evaluate to a constant value or array, or a runtime initialized const or immutable variable of integral type._
