### PR TITLE
do not call profile code from C main()

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -617,6 +617,7 @@ public:
     const char *toPrettyChars(bool QualifyTypes = false);
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
     bool isMain();
+    bool isCMain();
     bool isWinMain();
     bool isDllMain();
     bool isExport();

--- a/src/func.c
+++ b/src/func.c
@@ -3549,6 +3549,12 @@ bool FuncDeclaration::isMain()
         linkage != LINKc && !isMember() && !isNested();
 }
 
+bool FuncDeclaration::isCMain()
+{
+    return ident == Id::main &&
+        linkage == LINKc && !isMember() && !isNested();
+}
+
 bool FuncDeclaration::isWinMain()
 {
     //printf("FuncDeclaration::isWinMain() %s\n", toChars());

--- a/src/glue.c
+++ b/src/glue.c
@@ -1174,8 +1174,11 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
          * 2. impact on function inlining
          * 3. what to do when writing out .di files, or other pretty printing
          */
-        if (global.params.trace)
+        if (global.params.trace && !fd->isCMain())
         {
+            /* The profiler requires TLS, and TLS may not be set up yet when C main()
+             * gets control (i.e. OSX), leading to a crash.
+             */
             /* Wrap the entire function body in:
              *   trace_pro("funcname");
              *   try

--- a/test/runnable/extra-files/hello-profile.d.trace.def
+++ b/test/runnable/extra-files/hello-profile.d.trace.def
@@ -1,4 +1,3 @@
 
 FUNCTIONS
-	main
 	_D5hello8showargsFAAyaZv


### PR DESCRIPTION
The profiler requires TLS to be working properly, and it is not when OSX's C main() gets control. So don't call the profiler then.

Required for:

https://github.com/D-Programming-Language/druntime/pull/1233
