### PR TITLE
[Enh] add -profile="gc" switch

### DIFF
--- a/src/backend/rtlsym.h
+++ b/src/backend/rtlsym.h
@@ -79,6 +79,7 @@ SYMBOL_MARS(SWITCH_STRING, FLfunc,FREGSAVED,"_d_switch_string", 0, t) \
 SYMBOL_MARS(SWITCH_USTRING,FLfunc,FREGSAVED,"_d_switch_ustring", 0, t) \
 SYMBOL_MARS(SWITCH_DSTRING,FLfunc,FREGSAVED,"_d_switch_dstring", 0, t) \
 SYMBOL_MARS(DSWITCHERR,    FLfunc,FREGSAVED,"_d_switch_error", SFLexit, t) \
+SYMBOL_MARS(DHIDDENFUNC,   FLfunc,FREGSAVED,"_d_hidden_func", 0, t) \
 SYMBOL_MARS(NEWCLASS,      FLfunc,FREGSAVED,"_d_newclass", 0, t) \
 SYMBOL_MARS(NEWARRAYT,     FLfunc,FREGSAVED,"_d_newarrayT", 0, t) \
 SYMBOL_MARS(NEWARRAYIT,    FLfunc,FREGSAVED,"_d_newarrayiT", 0, t) \
@@ -162,6 +163,8 @@ SYMBOL_Z(TRACE_EPI_N, FLfunc,ALLREGS|mBP|mES,"_trace_epi_n",0,tstrace) \
 SYMBOL_Z(TRACE_EPI_F, FLfunc,ALLREGS|mBP|mES,"_trace_epi_f",0,tstrace) \
 SYMBOL_MARS(TRACE_CPRO, FLfunc,FREGSAVED,"_c_trace_pro",0,t) \
 SYMBOL_MARS(TRACE_CEPI, FLfunc,FREGSAVED,"_c_trace_epi",0,t) \
+\
+SYMBOL_MARS(TRACENEWCLASS,      FLfunc,FREGSAVED,"_d_newclassTrace", 0, t) \
 
 
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -42,6 +42,7 @@ struct Param
     bool multiobj;      // break one object file into multiple ones
     bool oneobj;        // write one object file instead of multiple ones
     bool trace;         // insert profiling hooks
+    bool tracegc;       // instrument calls to 'new'
     bool verbose;       // verbose compile
     bool showColumns;   // print character (column) numbers in diagnostics
     bool vtls;          // identify thread local variables

--- a/src/mars.c
+++ b/src/mars.c
@@ -188,6 +188,7 @@ Usage:\n\
   -offilename    name output file to filename\n\
   -op            preserve source path for output files\n\
   -profile       profile runtime performance of generated code\n\
+  -profile=gc    profile runtime allocations\n\
   -property      enforce property syntax\n\
   -release       compile release version\n\
   -run srcfile args...   run resulting program, passing args\n\
@@ -526,8 +527,23 @@ int tryMain(size_t argc, const char *argv[])
                 error(Loc(), "-m32mscoff can only be used on windows");
             #endif
             }
-            else if (strcmp(p + 1, "profile") == 0)
-                global.params.trace = true;
+            else if (memcmp(p + 1, "profile", 7) == 0)
+            {
+                // Parse:
+                //      -profile
+                //      -profile=gc
+                if (p[8] == '=')
+                {
+                    if (strcmp(p + 9, "gc") == 0)
+                        global.params.tracegc = true;
+                    else
+                        goto Lerror;
+                }
+                else if (p[8])
+                    goto Lerror;
+                else
+                    global.params.trace = true;
+            }
             else if (strcmp(p + 1, "v") == 0)
                 global.params.verbose = true;
             else if (strcmp(p + 1, "vtls") == 0)


### PR DESCRIPTION
This is the start of a memory profiler, i.e. throw the switch and the compiler emits code to log all calls to allocate memory. This one only does it for calls to `new` a class. The following shows how it works:

```
import core.stdc.stdio;

class C { }

void main() {
    auto b = new C();
}

extern (C) Object _d_newclass(const ClassInfo ci);

extern (C) Object _d_newclassTrace(string file, int line, string funcname, const ClassInfo ci) {
    printf("_d_newclassTrace class = %s file = '%.*s' line = %d function = '%.*s'\n",
    cast(char *)ci.name,
    file.length, file.ptr,
    line,
    funcname.length, funcname.ptr
    );
    return _d_newclass(ci);
}
```
