### PR TITLE
Make tests agnostic to compiler generated unique numbers in the output

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -396,6 +396,25 @@ bool collectExtraSources (in string input_dir, in string output_dir, in string[]
     return true;
 }
 
+// compare output string to reference string, but ignore places
+// marked by $n$ that contain compiler generated unique numbers
+bool compareOutput(string output, string refoutput)
+{
+    for ( ; ; )
+    {
+        auto pos = refoutput.indexOf("$n$");
+        if (pos < 0)
+            return refoutput == output;
+        if (output.length < pos)
+            return false;
+        if (refoutput[0..pos] != output[0..pos])
+            return false;
+        refoutput = refoutput[pos + 3 ..$];
+        output = output[pos..$];
+        munch(output, "0123456789");
+    }
+}
+
 int main(string[] args)
 {
     if (args.length != 4)
@@ -568,7 +587,7 @@ int main(string[] args)
 
             if (testArgs.compileOutput !is null)
             {
-                enforce(compile_output == testArgs.compileOutput,
+                enforce(compareOutput(compile_output, testArgs.compileOutput),
                         "\nexpected:\n----\n"~testArgs.compileOutput~"\n----\nactual:\n----\n"~compile_output~"\n----\n");
             }
 

--- a/test/fail_compilation/fail7848.d
+++ b/test/fail_compilation/fail7848.d
@@ -3,11 +3,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7848.d(35): Error: pure function 'fail7848.C.__unittestL33_1' cannot call impure function 'fail7848.func'
-fail_compilation/fail7848.d(35): Error: safe function 'fail7848.C.__unittestL33_1' cannot call system function 'fail7848.func'
-fail_compilation/fail7848.d(35): Error: @nogc function 'fail7848.C.__unittestL33_1' cannot call non-@nogc function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: pure function 'fail7848.C.__unittestL33_$n$' cannot call impure function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: safe function 'fail7848.C.__unittestL33_$n$' cannot call system function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: @nogc function 'fail7848.C.__unittestL33_$n$' cannot call non-@nogc function 'fail7848.func'
 fail_compilation/fail7848.d(35): Error: 'fail7848.func' is not nothrow
-fail_compilation/fail7848.d(33): Error: function 'fail7848.C.__unittestL33_1' is nothrow yet may throw
+fail_compilation/fail7848.d(33): Error: function 'fail7848.C.__unittestL33_$n$' is nothrow yet may throw
 fail_compilation/fail7848.d(40): Error: pure function 'fail7848.C.__invariant2' cannot call impure function 'fail7848.func'
 fail_compilation/fail7848.d(40): Error: safe function 'fail7848.C.__invariant2' cannot call system function 'fail7848.func'
 fail_compilation/fail7848.d(40): Error: @nogc function 'fail7848.C.__invariant2' cannot call non-@nogc function 'fail7848.func'

--- a/test/fail_compilation/fail_casting.d
+++ b/test/fail_compilation/fail_casting.d
@@ -147,8 +147,8 @@ void test14154()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup3.__expand_field_0 of type int to object.Object
-fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup3.__expand_field_1 of type int to object.Object
+fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup$n$.__expand_field_0 of type int to object.Object
+fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup$n$.__expand_field_1 of type int to object.Object
 ---
 */
 alias TypeTuple14093(T...) = T;

--- a/test/fail_compilation/ice14424.d
+++ b/test/fail_compilation/ice14424.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14424.d(12): Error: tuple has no effect in expression (tuple(__unittestL3_1))
+fail_compilation/ice14424.d(12): Error: tuple has no effect in expression (tuple(__unittestL3_$n$))
 ---
 */
 


### PR DESCRIPTION
This PR allows skipping unique numbers generated by the compiler that creep into error message by replacing them with `$n$` in the reference output string. See the changed tests for some examples.

Needed to allow tests to pass before and after merging https://github.com/D-Programming-Language/druntime/pull/1222.
