### PR TITLE
[REG2.067] Issue 14508 - compiling with -unittest instantiates templates in non-root modules

### DIFF
--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1091,6 +1091,8 @@ Dsymbol *ConditionalDeclaration::syntaxCopy(Dsymbol *s)
 Scope *ConditionalDeclaration::newScope(Scope *sc)
 {
     Scope *sc2 = sc;
+    if (sc->func && sc->tinst && condition->isUnitTestOrDebugLevel())
+        sc->func->forceInst = true;
     if (sc->minst && !sc->minst->isRoot() &&
         condition->isUnitTestOrDebugLevel())
     {

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1088,6 +1088,29 @@ Dsymbol *ConditionalDeclaration::syntaxCopy(Dsymbol *s)
         Dsymbol::arraySyntaxCopy(elsedecl));
 }
 
+Scope *ConditionalDeclaration::newScope(Scope *sc)
+{
+    Scope *sc2 = sc;
+    if (sc->minst && !sc->minst->isRoot() &&
+        condition->isUnitTestOrDebugLevel())
+    {
+        /* The issue is that if the importee is compiled with a different -debug=num
+         * setting than the importer, the importer may believe it exists
+         * in the compiled importee when it does not, when the instantiation
+         * is behind a conditional debug declaration.
+         * Same problem may happen with -unittest.
+         *
+         * Conservatively do codegen for those conditionally instantiated templates.
+         * See also the special case for (global.params.useUnitTests || global.params.debuglevel)
+         * in TemplateInstance::needsCodegen().
+         */
+        // workaround for Bugzilla 11239
+        sc2 = sc->copy();
+        sc2->minst = sc->minst->importedFrom;
+    }
+    return sc2;
+}
+
 bool ConditionalDeclaration::oneMember(Dsymbol **ps, Identifier *ident)
 {
     //printf("ConditionalDeclaration::oneMember(), inc = %d\n", condition->inc);

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -160,6 +160,7 @@ public:
 
     ConditionalDeclaration(Condition *condition, Dsymbols *decl, Dsymbols *elsedecl);
     Dsymbol *syntaxCopy(Dsymbol *s);
+    Scope *newScope(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
     void addComment(const utf8_t *comment);

--- a/src/cond.c
+++ b/src/cond.c
@@ -50,6 +50,19 @@ Condition::Condition(Loc loc)
     inc = 0;
 }
 
+bool Condition::isUnitTestOrDebugLevel()
+{
+    // debug(num)
+    if (DebugCondition *dc = isDebugCondition())
+        return dc->ident == NULL;
+
+    // version(unittest)
+    if (VersionCondition *vc = isVersionCondition())
+        return vc->ident == Identifier::idPool(Token::toChars(TOKunittest));
+
+    return false;
+}
+
 /* ============================================================ */
 
 DVCondition::DVCondition(Module *mod, unsigned level, Identifier *ident)

--- a/src/cond.h
+++ b/src/cond.h
@@ -18,7 +18,9 @@ struct OutBuffer;
 class Module;
 struct Scope;
 class ScopeDsymbol;
+class DVCondition;
 class DebugCondition;
+class VersionCondition;
 
 int findCondition(Strings *ids, Identifier *ident);
 
@@ -35,7 +37,9 @@ public:
 
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc, ScopeDsymbol *sds) = 0;
+    virtual DVCondition *isDVCondition() { return NULL; }
     virtual DebugCondition *isDebugCondition() { return NULL; }
+    virtual VersionCondition *isVersionCondition() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -49,6 +53,7 @@ public:
     DVCondition(Module *mod, unsigned level, Identifier *ident);
 
     Condition *syntaxCopy();
+    DVCondition *isDVCondition() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -81,6 +86,7 @@ public:
     VersionCondition(Module *mod, unsigned level, Identifier *ident);
 
     int include(Scope *sc, ScopeDsymbol *sds);
+    VersionCondition *isVersionCondition() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/cond.h
+++ b/src/cond.h
@@ -35,6 +35,8 @@ public:
 
     Condition(Loc loc);
 
+    bool isUnitTestOrDebugLevel();
+
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc, ScopeDsymbol *sds) = 0;
     virtual DVCondition *isDVCondition() { return NULL; }

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -581,6 +581,8 @@ public:
 
     unsigned flags;                     // FUNCFLAGxxxxx
 
+    bool forceInst;
+
     FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -2415,6 +2415,15 @@ bool Expression::checkPurity(Scope *sc, FuncDeclaration *f)
     // OR, they must have the same pure parent.
     if (!f->isPure() && calledparent != outerfunc)
     {
+        if (!(sc->flags & SCOPEcompile) && (sc->func->flags & FUNCFLAGpurityInprocess))
+        {
+            if (f->forceInst && sc->tinst && !sc->func->inUnittest())
+            {
+                sc->func->forceInst = true;
+                sc->tinst->forceInst = true;
+            }
+        }
+
         FuncDeclaration *ff = outerfunc;
         if (sc->flags & SCOPEcompile ? ff->isPureBypassingInference() >= PUREweak : ff->setImpure())
         {
@@ -2597,6 +2606,15 @@ bool Expression::checkSafety(Scope *sc, FuncDeclaration *f)
 
     if (!f->isSafe() && !f->isTrusted())
     {
+        if (!(sc->flags & SCOPEcompile) && (sc->func->flags & FUNCFLAGsafetyInprocess))
+        {
+            if (f->forceInst && sc->tinst && !sc->func->inUnittest())
+            {
+                sc->func->forceInst = true;
+                sc->tinst->forceInst = true;
+            }
+        }
+
         if (sc->flags & SCOPEcompile ? sc->func->isSafeBypassingInference() : sc->func->setUnsafe())
         {
             if (loc.linnum == 0)  // e.g. implicitly generated dtor
@@ -2629,6 +2647,15 @@ bool Expression::checkNogc(Scope *sc, FuncDeclaration *f)
 
     if (!f->isNogc())
     {
+        if (!(sc->flags & SCOPEcompile) && (sc->func->flags & FUNCFLAGnogcInprocess))
+        {
+            if (f->forceInst && sc->tinst && !sc->func->inUnittest())
+            {
+                sc->func->forceInst = true;
+                sc->tinst->forceInst = true;
+            }
+        }
+
         if (sc->flags & SCOPEcompile ? sc->func->isNogcBypassingInference() : sc->func->setGC())
         {
             if (loc.linnum == 0)  // e.g. implicitly generated dtor

--- a/src/func.c
+++ b/src/func.c
@@ -1307,6 +1307,15 @@ void FuncDeclaration::semantic3(Scope *sc)
         if (sc2->intypeof == 1) sc2->intypeof = 2;
         sc2->fieldinit = NULL;
         sc2->fieldinit_dim = 0;
+        if (isUnitTestDeclaration() && sc->minst && !sc->minst->isRoot())
+        {
+            /* When this unittest block is defined in template, even if the enclosing
+             * is instantiated only in non-root module, the templates instantiated
+             * inside body might not exist in the compiled importee.
+             * Therefore mark them as speculative, to provide chance for codegen.
+             */
+            sc2->minst = sc->minst->importedFrom;
+        }
 
         if (isMember2())
         {

--- a/src/func.c
+++ b/src/func.c
@@ -328,6 +328,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     flags = 0;
     returns = NULL;
     gotos = NULL;
+    forceInst = false;
 }
 
 Dsymbol *FuncDeclaration::syntaxCopy(Dsymbol *s)

--- a/src/func.c
+++ b/src/func.c
@@ -180,11 +180,6 @@ public:
     }
     void visit(OnScopeStatement *s) {  }
     void visit(ThrowStatement *s) {  }
-    void visit(DebugStatement *s)
-    {
-        if (s->statement)
-            visitStmt(s->statement);
-    }
     void visit(GotoStatement *s) {  }
     void visit(LabelStatement *s)
     {

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -582,14 +582,6 @@ public:
         buf->writenl();
     }
 
-    void visit(DebugStatement *s)
-    {
-        if (s->statement)
-        {
-            s->statement->accept(this);
-        }
-    }
-
     void visit(GotoStatement *s)
     {
         buf->writestring("goto ");

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -1844,7 +1844,6 @@
                 "struct TryFinallyStatement",
                 "struct OnScopeStatement",
                 "struct ThrowStatement",
-                "struct DebugStatement",
                 "struct GotoStatement",
                 "struct LabelStatement",
                 "struct LabelDsymbol",

--- a/src/sapply.c
+++ b/src/sapply.c
@@ -139,10 +139,6 @@ public:
     {
         doCond(s->statement) || applyTo(s);
     }
-    void visit(DebugStatement *s)
-    {
-        doCond(s->statement) || applyTo(s);
-    }
     void visit(LabelStatement *s)
     {
         doCond(s->statement) || applyTo(s);

--- a/src/statement.c
+++ b/src/statement.c
@@ -3039,6 +3039,8 @@ Scope *ConditionalStatement::newScope(Scope *sc)
 {
     Scope *sc2 = sc;
 
+    if (sc->func && sc->tinst && condition->isUnitTestOrDebugLevel())
+        sc->func->forceInst = true;
     if (sc->minst && !sc->minst->isRoot() &&
         condition->isUnitTestOrDebugLevel())
     {

--- a/src/statement.c
+++ b/src/statement.c
@@ -30,6 +30,7 @@
 #include "parse.h"
 #include "template.h"
 #include "attrib.h"
+#include "module.h"
 #include "import.h"
 
 bool walkPostorder(Statement *s, StoppableVisitor *v);
@@ -3038,6 +3039,12 @@ Scope *ConditionalStatement::newScope(Scope *sc)
 {
     Scope *sc2 = sc;
 
+    if (sc->minst && !sc->minst->isRoot() &&
+        condition->isUnitTestOrDebugLevel())
+    {
+        sc2 = sc->copy();
+        sc2->minst = sc->minst->importedFrom;
+    }
     if (DebugCondition *dc = condition->isDebugCondition())
     {
         if (sc2 == sc)

--- a/src/statement.c
+++ b/src/statement.c
@@ -3033,6 +3033,21 @@ Statement *ConditionalStatement::syntaxCopy()
         elsebody ? elsebody->syntaxCopy() : NULL);
 }
 
+// Consistent with ConditionalDeclaration::newScope().
+Scope *ConditionalStatement::newScope(Scope *sc)
+{
+    Scope *sc2 = sc;
+
+    if (DebugCondition *dc = condition->isDebugCondition())
+    {
+        if (sc2 == sc)
+            sc2 = sc->push();
+        sc2->flags |= SCOPEdebug;
+    }
+
+    return sc2;
+}
+
 Statement *ConditionalStatement::semantic(Scope *sc)
 {
     //printf("ConditionalStatement::semantic()\n");
@@ -3042,16 +3057,13 @@ Statement *ConditionalStatement::semantic(Scope *sc)
     // This feature allows a limited form of conditional compilation.
     if (condition->include(sc, NULL))
     {
-        DebugCondition *dc = condition->isDebugCondition();
-        if (dc)
-        {
-            sc = sc->push();
-            sc->flags |= SCOPEdebug;
-            ifbody = ifbody->semantic(sc);
-            sc->pop();
-        }
-        else
-            ifbody = ifbody->semantic(sc);
+        Scope *sc2 = newScope(sc);
+
+        ifbody = ifbody->semantic(sc2);
+
+        if (sc2 != sc)
+            sc2->pop();
+
         return ifbody;
     }
     else
@@ -3064,23 +3076,34 @@ Statement *ConditionalStatement::semantic(Scope *sc)
 
 Statements *ConditionalStatement::flatten(Scope *sc)
 {
-    Statement *s;
-
     //printf("ConditionalStatement::flatten()\n");
     if (condition->include(sc, NULL))
     {
-        DebugCondition *dc = condition->isDebugCondition();
-        if (dc)
-            s = new DebugStatement(loc, ifbody);
-        else
-            s = ifbody;
+        Scope *sc2 = newScope(sc);
+
+        Statements *a = ifbody->flatten(sc2);
+
+        if (a && sc2 != sc)
+        {
+            for (size_t i = 0; i < a->dim; i++)
+            {
+                Statement *s = (*a)[i];
+                if (s)
+                    s = new ConditionalStatement(s->loc, condition, s, NULL);
+                (*a)[i] = s;
+            }
+        }
+        if (sc2 != sc)
+            sc2->pop();
+
+        return a;
     }
     else
-        s = elsebody;
-
-    Statements *a = new Statements();
-    a->push(s);
-    return a;
+    {
+        if (elsebody)
+            return elsebody->flatten(sc);
+        return NULL;
+    }
 }
 
 /******************************** PragmaStatement ***************************/
@@ -4905,48 +4928,6 @@ Statement *ThrowStatement::semantic(Scope *sc)
     }
 
     return this;
-}
-
-/******************************** DebugStatement **************************/
-
-DebugStatement::DebugStatement(Loc loc, Statement *statement)
-    : Statement(loc)
-{
-    this->statement = statement;
-}
-
-Statement *DebugStatement::syntaxCopy()
-{
-    return new DebugStatement(loc,
-        statement ? statement->syntaxCopy() : NULL);
-}
-
-Statement *DebugStatement::semantic(Scope *sc)
-{
-    if (statement)
-    {
-        sc = sc->push();
-        sc->flags |= SCOPEdebug;
-        statement = statement->semantic(sc);
-        sc->pop();
-    }
-    return statement;
-}
-
-Statements *DebugStatement::flatten(Scope *sc)
-{
-    Statements *a = statement ? statement->flatten(sc) : NULL;
-    if (a)
-    {
-        for (size_t i = 0; i < a->dim; i++)
-        {   Statement *s = (*a)[i];
-
-            s = new DebugStatement(loc, s);
-            (*a)[i] = s;
-        }
-    }
-
-    return a;
 }
 
 /******************************** GotoStatement ***************************/

--- a/src/statement.h
+++ b/src/statement.h
@@ -378,6 +378,7 @@ public:
 
     ConditionalStatement(Loc loc, Condition *condition, Statement *ifbody, Statement *elsebody);
     Statement *syntaxCopy();
+    Scope *newScope(Scope *sc);
     Statement *semantic(Scope *sc);
     Statements *flatten(Scope *sc);
 
@@ -654,18 +655,6 @@ public:
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
-};
-
-class DebugStatement : public Statement
-{
-public:
-    Statement *statement;
-
-    DebugStatement(Loc loc, Statement *statement);
-    Statement *syntaxCopy();
-    Statement *semantic(Scope *sc);
-    Statements *flatten(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/template.c
+++ b/src/template.c
@@ -5925,6 +5925,7 @@ Lerror:
      * implements the typeargs. If so, just refer to that one instead.
      */
     inst = tempdecl->findExistingInstance(this, fargs);
+    TemplateInstance *errinst = NULL;
     if (!inst)
     {
         // So, we need to implement 'this' instance.
@@ -5933,6 +5934,7 @@ Lerror:
     {
         // If the first instantiation had failed, re-run semantic,
         // so that error messages are shown.
+        errinst = inst;
     }
     else
     {
@@ -6318,6 +6320,26 @@ Lerror:
             semanticRun = PASSinit;
             inst = NULL;
             symtab = NULL;
+        }
+    }
+    else if (errinst)
+    {
+        /* Bugzilla 14541: The "error reproduction instantiation" might succeed to
+         * finish semantic analysis by the forward reference resolution. When it
+         * happens, the cached error instance needs to be overridden by the
+         * succeeded instance.
+         */
+        size_t bi = hash % tempdecl->buckets.dim;
+        TemplateInstances *instances = tempdecl->buckets[bi];
+        assert(instances);
+        for (size_t i = 0; i < instances->dim; i++)
+        {
+            TemplateInstance *ti = (*instances)[i];
+            if (ti == errinst)
+            {
+                (*instances)[i] = this;     // override
+                break;
+            }
         }
     }
 

--- a/src/template.c
+++ b/src/template.c
@@ -5678,6 +5678,7 @@ TemplateInstance::TemplateInstance(Loc loc, Identifier *ident)
     this->tinst = NULL;
     this->tnext = NULL;
     this->minst = NULL;
+    this->forceInst = false;
     this->deferred = NULL;
     this->argsym = NULL;
     this->aliasdecl = NULL;
@@ -5709,6 +5710,7 @@ TemplateInstance::TemplateInstance(Loc loc, TemplateDeclaration *td, Objects *ti
     this->tinst = NULL;
     this->tnext = NULL;
     this->minst = NULL;
+    this->forceInst = false;
     this->deferred = NULL;
     this->argsym = NULL;
     this->aliasdecl = NULL;
@@ -7880,6 +7882,7 @@ L1:
         {
             minst = tnext->minst;           // cache result
             assert(minst && minst->isRoot());
+            forceInst = tnext->forceInst;
             return true;
         }
         return false;
@@ -7906,6 +7909,8 @@ L1:
 
     if (global.params.allInst)
         return true;
+    if (forceInst)
+        return true;
 
     // Prefer instantiation in non-root module, to minimize object code size
     if (minst->isRoot())
@@ -7917,6 +7922,7 @@ L1:
         {
             minst = tnext->minst;           // cache result
             assert(!minst->isRoot());
+            forceInst = tnext->forceInst;
             return false;
         }
     }

--- a/src/template.h
+++ b/src/template.h
@@ -322,6 +322,7 @@ public:
     TemplateInstance *tinst;            // enclosing template instance
     TemplateInstance *tnext;            // non-first instantiated instances
     Module *minst;                      // the top module that instantiated this instance
+    bool forceInst;
 
     TemplateInstance(Loc loc, Identifier *temp_id);
     TemplateInstance(Loc loc, TemplateDeclaration *tempdecl, Objects *tiargs);

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -48,7 +48,6 @@ class TryCatchStatement;
 class TryFinallyStatement;
 class OnScopeStatement;
 class ThrowStatement;
-class DebugStatement;
 class GotoStatement;
 class LabelStatement;
 class AsmStatement;
@@ -334,7 +333,6 @@ public:
     virtual void visit(TryFinallyStatement *s) { visit((Statement *)s); }
     virtual void visit(OnScopeStatement *s) { visit((Statement *)s); }
     virtual void visit(ThrowStatement *s) { visit((Statement *)s); }
-    virtual void visit(DebugStatement *s) { visit((Statement *)s); }
     virtual void visit(GotoStatement *s) { visit((Statement *)s); }
     virtual void visit(LabelStatement *s) { visit((Statement *)s); }
     virtual void visit(AsmStatement *s) { visit((Statement *)s); }

--- a/test/runnable/imports/a14508.d
+++ b/test/runnable/imports/a14508.d
@@ -1,0 +1,67 @@
+module imports.a14508;
+
+void unlinked() {}
+
+struct Foo1()
+{
+    void func() {}
+
+    version(unittest) void test()
+    {
+        UUint.testImpl();
+    }
+    unittest
+    {
+        UUint.testImpl();
+    }
+}
+
+struct Foo2()
+{
+    void func() {}
+}
+
+version(unittest)
+{
+    template UnittestUtil(T)
+    {
+        void testImpl()
+        {
+        }
+    }
+
+    // Those are treated as instantiations in root module, when `dmd -unittest link14508.d`.
+    alias F1 = Foo1!();
+    alias F2 = Foo2!();
+    alias UUint = UnittestUtil!int;
+}
+
+struct Bar1()
+{
+    void func() {}
+
+    debug void test()
+    {
+        DUint.testImpl();
+    }
+}
+
+struct Bar2()
+{
+    void func() {}
+}
+
+debug
+{
+    template DebugUtil(T)
+    {
+        void testImpl()
+        {
+        }
+    }
+
+    // Those are treated as instantiations in root module, when `dmd -debug link14508.d`.
+    alias B1 = Bar1!();
+    alias B2 = Bar2!();
+    alias DUint = DebugUtil!int;
+}

--- a/test/runnable/imports/link14541traits.d
+++ b/test/runnable/imports/link14541traits.d
@@ -1,0 +1,54 @@
+module imports.link14541traits;
+
+template hasElaborateAssign(S)
+{
+    static if (is(S == struct))
+    {
+        extern __gshared S lvalue;
+
+        enum hasElaborateAssign = is(typeof(S.init.opAssign(S.init))) ||
+                                  is(typeof(S.init.opAssign(lvalue)));
+    }
+    else
+    {
+        enum bool hasElaborateAssign = false;
+    }
+}
+
+void swap(T)(ref T lhs, ref T rhs) @trusted pure nothrow @nogc
+{
+    static if (hasElaborateAssign!T)
+    {
+    }
+    else
+    {
+    }
+}
+
+template Tuple(Types...)
+{
+    struct Tuple
+    {
+        Types field;
+        alias field this;
+
+        this(Types values)
+        {
+            field[] = values[];
+        }
+
+        void opAssign(R)(auto ref R rhs)
+        {
+            static if (is(R : Tuple!Types) && !__traits(isRef, rhs))
+            {
+                // Use swap-and-destroy to optimize rvalue assignment
+                swap!(Tuple!Types)(this, rhs);
+            }
+            else
+            {
+                // Do not swap; opAssign should be called on the fields.
+                field[] = rhs.field[];
+            }
+        }
+    }
+}

--- a/test/runnable/link14508.d
+++ b/test/runnable/link14508.d
@@ -1,0 +1,35 @@
+// PERMUTE_ARGS: -unittest -debug -inline -release -g -O
+import imports.a14508;
+
+void main()
+{
+    // This call still won't work without linking a14508.
+    //unlinked();
+
+    version(unittest)
+    {
+        // Foo1!() is instantiated both in link14508 and a14508 modules.
+        // Normally its codegen is skipped, however its code is conservatively
+        // generated so it's defined in version(unittest).
+        Foo1!() f1;
+        f1.func();
+        f1.test();
+
+        // Foo2!() is instantiated only in non-root module, but it's in
+        // version(unittest) block, so its code is conservatively generated.
+        F2 f2;
+        f2.func();
+    }
+
+    debug
+    {
+        // Works like Foo1!() case.
+        Bar1!() b1;
+        b1.func();
+        b1.test();
+
+        // Works like Foo2!() case.
+        B2 b2;
+        b2.func();
+    }
+}

--- a/test/runnable/link14541.d
+++ b/test/runnable/link14541.d
@@ -1,0 +1,37 @@
+import imports.link14541traits;
+
+void main()
+{
+    Tuple!(int, int) result;
+
+    alias T = typeof(result);
+    static assert(hasElaborateAssign!T);
+    // hasElablrateAssign!(Tuple(int, int)):
+    // 1. instantiates Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Rvalue]
+    //    2. instantiates swap!(Tuple!(int, int))
+    //       3. instantiates hasElablrateAssign!(Tuple!(int, int))
+    //          --> forward reference error
+    //       --> swap!(Tuple!(int, int)) fails to instantiate
+    //    --> Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = rvalue] fails to instantiate
+    // 4. instantiates Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Lvalue]
+    //    --> succeeds
+    // hasElablrateAssign!(Tuple(int, int)) succeeds to instantiate (result is 'true')
+
+    // Instantiates Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Rvalue], but
+    // it's already done in gagged context, so this is made an error reproduction instantiation.
+    // --> 1st error reproduction instantiation
+    // But, the forward reference of hasElablrateAssign!(Tuple(int, int)) is alredy resolved, so
+    // the instantiation will succeeds.
+    result = Tuple!(int, int)(0, 0);
+
+    // Instantiates Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Rvalue], but
+    // it's already done in gagged context, so this is made an error reproduction instantiation.
+    // --> 2nd error reproduction instantiation
+    // But, the forward reference of hasElablrateAssign!(Tuple(int, int)) is alredy resolved, so
+    // the instantiation will succeeds.
+    result = Tuple!(int, int)(0, 0);
+
+    // The two error reproduction instantiations generate the function:
+    //   Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Rvalue]
+    // twice, then it will cause duplicate COMDAT error in Win64 platform.
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14508

All template instances outside of `version(unittest){}` or `debug(num){}` need to use the normal instantiation strategy.

When `-unittest` or `-debug(=num)` switches specified, the instantiation strategy will be tweaked - a conditionally instantiated template code by `version(unittest){}` or `debug(num){}` will be generated conservatively, even if it's done in non root module.

It can be formalized as follows:

R = templates instantiated in root module
N = templates instantiated in non root module
S = templates instantiated speculatively
- Default instantiation strategy:
  codegen = R - (R ∩ N)
- The new instantiation strategy for -unittest or -debug=num:
  codegen = Rd - (Rd ∩ N)
  Rd = R ∪ Nd
  Nd = version(unittest) and debug template instances in non-root modules
- The old instantiation strategy for -allInst:
  codegen = R ∪ N
