### PR TITLE
Issue 14538: Fix ICE in typeMerge

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -3049,8 +3049,9 @@ Lcc:
         {
             e1 = integralPromotions(e1, sc);
             e2 = integralPromotions(e2, sc);
-            t1 = e1->type;  t1b = t1->toBasetype();
-            t2 = e2->type;  t2b = t2->toBasetype();
+            t1 = e1->type;
+            t2 = e2->type;
+            goto Lagain;
         }
         assert(t1->ty == t2->ty);
         if (!t1->isImmutable() && !t2->isImmutable() && t1->isShared() != t2->isShared())

--- a/test/fail_compilation/test14538.d
+++ b/test/fail_compilation/test14538.d
@@ -1,0 +1,20 @@
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test14538.d(19): Error: cannot implicitly convert expression (x ? cast(uint)this.fCells[x].code : 32u) of type uint to Cell
+---
+*/
+
+struct Cell
+{
+    dchar code;
+    alias code this;
+}
+
+struct Row
+{
+    Cell[] fCells;
+    Cell opIndex(size_t x) { return x ? fCells[x] : ' '; }
+}


### PR DESCRIPTION
I'm not sure whether this assert is meaningful, or whether we should just `goto Lagain` after running integer promotions.
