### PR TITLE
eliminate spurious warning about uninitialized v

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -9558,7 +9558,7 @@ Expression *DeleteExp::semantic(Scope *sc)
                 Expression *ea = NULL;
                 Expression *eb = NULL;
                 Expression *ec = NULL;
-                VarDeclaration *v;
+                VarDeclaration *v = NULL;
 
                 if (fd && f)
                 {   Identifier *id = Identifier::idPool("__tmpea");


### PR DESCRIPTION
Eliminate false positive:

```
expression.c: In member function 'virtual Expression* DeleteExp::semantic(Scope*)':
expression.c:9561: warning: 'v' may be used uninitialized in this function
```
