### PR TITLE
Use isLP64 to determine whether the foreach key type should be int or long

### DIFF
--- a/src/statement.c
+++ b/src/statement.c
@@ -1843,7 +1843,7 @@ Statement *ForeachStatement::semantic(Scope *sc)
                 TY keyty = p->type->ty;
                 if (keyty != Tint32 && keyty != Tuns32)
                 {
-                    if (global.params.is64bit)
+                    if (global.params.isLP64)
                     {
                         if (keyty != Tint64 && keyty != Tuns64)
                         {


### PR DESCRIPTION
Noticed when building Phobos on AArch64.
