### PR TITLE
add PGO and LTO build options to makefile

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -21,6 +21,7 @@ endif
 INSTALL_DIR=../../install
 # can be set to override the default /etc/
 SYSCONFDIR=/etc/
+PGO_DIR=$(abspath pgo)
 
 C=backend
 TK=tk
@@ -91,7 +92,7 @@ WARNINGS := $(WARNINGS) \
 	-Wno-unused-but-set-variable \
 	-Wno-uninitialized
 endif
-# Clangn Specific
+# Clang Specific
 ifeq ($(HOST_CC), clang++)
 WARNINGS := $(WARNINGS) \
 	-Wno-tautological-constant-out-of-range-compare \
@@ -127,18 +128,27 @@ ifneq (,$(DEBUG))
 ENABLE_DEBUG := 1
 endif
 
-# Append different flags for debugging, profiling and release. Define
-# ENABLE_DEBUG and ENABLE_PROFILING to enable profiling.
+# Append different flags for debugging, profiling and release.
 ifdef ENABLE_DEBUG
 CFLAGS += -g -g3 -DDEBUG=1 -DUNITTEST
 DFLAGS += -g -debug
+else
+CFLAGS += -O2
+DFLAGS += -O -inline
+endif
 ifdef ENABLE_PROFILING
 CFLAGS  += -pg -fprofile-arcs -ftest-coverage
 LDFLAGS += -pg -fprofile-arcs -ftest-coverage
 endif
-else
-CFLAGS += -O2
-DFLAGS += -O -inline
+ifdef ENABLE_PGO_GENERATE
+CFLAGS  += -fprofile-generate=${PGO_DIR}
+endif
+ifdef ENABLE_PGO_USE
+CFLAGS  += -fprofile-use=${PGO_DIR} -freorder-blocks-and-partition
+endif
+ifdef ENABLE_LTO
+CFLAGS  += -flto
+LDFLAGS += -flto
 endif
 
 # Uniqe extra flags if necessary
@@ -315,8 +325,13 @@ glue.a: $(GLUE_OBJS)
 backend.a: $(BACK_OBJS)
 	ar rcs backend.a $(BACK_OBJS)
 
+ifdef ENABLE_LTO
+dmd: $(DMD_OBJS) $(ROOT_OBJS) $(GLUE_OBJS) $(BACK_OBJS)
+	$(HOST_CC) -o dmd $(MODEL_FLAG) $^ $(LDFLAGS)
+else
 dmd: frontend.a root.a glue.a backend.a
 	$(HOST_CC) -o dmd $(MODEL_FLAG) frontend.a root.a glue.a backend.a $(LDFLAGS)
+endif
 
 clean:
 	rm -f $(DMD_OBJS) $(ROOT_OBJS) $(GLUE_OBJS) $(BACK_OBJS) dmd optab.o id.o impcnvgen idgen id.c id.h \
@@ -324,6 +339,7 @@ clean:
 		tytab.c verstr.h core \
 		*.cov *.deps *.gcda *.gcno *.a \
 		$(GENSRC) $(MAGICPORT)
+	@[ ! -d ${PGO_DIR} ] || echo You should issue manually: rm -rf ${PGO_DIR}
 
 ######## Download and install the last dmd buildable without dmd
 


### PR DESCRIPTION
- workflow PGO
  
  rm -rf src/pgo
  make -C src -f posix.mak ENABLE_PGO_GENERATE=1
  .. use the generated dmd binary (e.g. build phobos)
  make -C src -f posix.mak clean
  make -C src -f posix.mak ENABLE_PGO_USE=1
- workflow LTO
  
  make -C src -f posix.mak ENABLE_LTO=1
- combining both is possible and beneficial
