### PR TITLE
Refactor global.params.runargs to be Strings

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2014 by Digital Mars
+ * Copyright (c) 1999-2015 by Digital Mars
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com
@@ -18,6 +18,7 @@
 
 #include "longdouble.h"
 #include "outbuffer.h"
+#include "filename.h"
 
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
@@ -132,8 +133,7 @@ struct Param
     bool debugy;
 
     bool run;           // run resulting executable
-    size_t runargs_length;
-    const char** runargs; // arguments for executable
+    Strings runargs;    // arguments for executable
 
     // Linker stuff
     Array<const char *> *objfiles;

--- a/src/link.c
+++ b/src/link.c
@@ -843,8 +843,8 @@ int runProgram()
     if (global.params.verbose)
     {
         fprintf(global.stdmsg, "%s", global.params.exefile);
-        for (size_t i = 0; i < global.params.runargs_length; i++)
-            fprintf(global.stdmsg, " %s", (char *)global.params.runargs[i]);
+        for (size_t i = 0; i < global.params.runargs.dim; ++i)
+            fprintf(global.stdmsg, " %s", global.params.runargs[i]);
         fprintf(global.stdmsg, "\n");
     }
 
@@ -852,7 +852,7 @@ int runProgram()
     Strings argv;
 
     argv.push(global.params.exefile);
-    for (size_t i = 0; i < global.params.runargs_length; i++)
+    for (size_t i = 0; i < global.params.runargs.dim; ++i)
     {   const char *a = global.params.runargs[i];
 
 #if _WIN32

--- a/src/mars.c
+++ b/src/mars.c
@@ -974,8 +974,8 @@ Language changes listed by -transition=id:\n\
             else if (strcmp(p + 1, "run") == 0)
             {
                 global.params.run = true;
-                global.params.runargs_length = ((i >= argcstart) ? argc : argcstart) - i - 1;
-                if (global.params.runargs_length)
+                size_t length = ((i >= argcstart) ? argc : argcstart) - i - 1;
+                if (length)
                 {
                     const char *ext = FileName::ext(argv[i + 1]);
                     if (ext && FileName::equals(ext, "d") == 0
@@ -986,9 +986,12 @@ Language changes listed by -transition=id:\n\
                     }
 
                     files.push(argv[i + 1]);
-                    global.params.runargs = &argv[i + 2];
-                    i += global.params.runargs_length;
-                    global.params.runargs_length--;
+                    global.params.runargs.setDim(length - 1);
+                    for (size_t j = 0; j < length - 1; ++j)
+                    {
+                        global.params.runargs[j] = argv[i + 2 + j];
+                    }
+                    i += length;
                 }
                 else
                 {


### PR DESCRIPTION
This is the first part of a larger initiative to redo argc/argv as Strings. As Strings, it will be easier to correct problems with the multiple parsing of the configuration file.
