### PR TITLE
[WIP] Resolve TypeInfo variables after semantic

### DIFF
--- a/src/backend.d
+++ b/src/backend.d
@@ -22,7 +22,7 @@ extern extern (C++) void obj_start(char* srcfile);
 extern extern (C++) void obj_end(Library library, File* objfile);
 extern extern (C++) void obj_write_deferred(Library library);
 
-extern extern (C++) Expression getTypeInfo(Type t, Scope* sc);
+extern extern (C++) Type getTypeInfoType(Type t, Scope* sc);
 extern extern (C++) Expression getInternalTypeInfo(Type t, Scope* sc);
 extern extern (C++) void genObjFile(Module m, bool multiobj);
 extern extern (C++) void genhelpers(Module m, bool multiobj);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1122,6 +1122,33 @@ elem *toElem(Expression *e, IRState *irs)
         /***************************************
          */
 
+        void visit(TypeidExp *e)
+        {
+            //printf("TypeidExp::toElem() %s\n", e->toChars());
+            if (Type *t = isType(e->obj))
+            {
+                result = getTypeInfo(t, irs);
+                return;
+            }
+            if (Expression *ex = isExpression(e->obj))
+            {
+                Type *t = ex->type->toBasetype();
+                assert(t->ty == Tclass);
+                // generate **classptr to get the classinfo
+                result = toElem(ex, irs);
+                result = el_una(OPind,TYnptr,result);
+                result = el_una(OPind,TYnptr,result);
+                // Add extra indirection for interfaces
+                if (((TypeClass *)t)->sym->isInterfaceDeclaration())
+                    result = el_una(OPind,TYnptr,result);
+                return;
+            }
+            assert(0);
+        }
+
+        /***************************************
+         */
+
         void visit(ThisExp *te)
         {
             //printf("ThisExp::toElem()\n");

--- a/src/expression.c
+++ b/src/expression.c
@@ -48,7 +48,7 @@ Expression *expandVar(int result, VarDeclaration *v);
 TypeTuple *toArgTypes(Type *t);
 bool checkFrameAccess(Loc loc, Scope *sc, AggregateDeclaration *ad, size_t istart = 0);
 Symbol *toInitializer(AggregateDeclaration *ad);
-Expression *getTypeInfo(Type *t, Scope *sc);
+Type *getTypeInfoType(Type *t, Scope *sc);
 
 #define LOGSEMANTIC     0
 
@@ -6104,8 +6104,9 @@ Expression *TypeidExp::semantic(Scope *sc)
     {
         /* Get the dynamic type, which is .classinfo
          */
-        e = new DotIdExp(ea->loc, ea, Id::classinfo);
-        e = e->semantic(sc);
+        ea = ea->semantic(sc);
+        e = new TypeidExp(ea->loc, ea);
+        e->type = Type::typeinfoclass->type;
     }
     else if (ta->ty == Terror)
     {
@@ -6113,11 +6114,9 @@ Expression *TypeidExp::semantic(Scope *sc)
     }
     else
     {
-        /* Get the static type
-         */
-        e = getTypeInfo(ta, sc);
-        if (e->loc.linnum == 0)
-            e->loc = loc;               // so there's at least some line number info
+        // Handle this in the glue layer
+        e = new TypeidExp(loc, ta);
+        e->type = getTypeInfoType(ta, sc);
         if (ea)
         {
             e = new CommaExp(loc, ea, e);       // execute ea

--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -75,17 +75,6 @@ void backend_term()
 {
 }
 
-// typinf
-
-Expression *getTypeInfo(Type *t, Scope *sc)
-{
-    Declaration *ti = new TypeInfoDeclaration(t, 1);
-    Expression *e = new VarExp(Loc(), ti);
-    e = e->addressOf();
-    e->type = ti->type;
-    return e;
-}
-
 // lib
 
 Library *LibMSCoff_factory()

--- a/src/inline.c
+++ b/src/inline.c
@@ -895,6 +895,19 @@ Expression *doInline(Expression *e, InlineDoState *ids)
             visit((Expression *)e);
         }
 
+        void visit(TypeidExp *e)
+        {
+            //printf("TypeidExp::doInline(): %s\n", e->toChars());
+            TypeidExp *te = (TypeidExp *)e->copy();
+            if (Expression *ex = isExpression(te->obj))
+            {
+                te->obj = doInline(ex, ids);
+            }
+            else
+                assert(isType(te->obj));
+            result = te;
+        }
+
         void visit(NewExp *e)
         {
             //printf("NewExp::doInline(): %s\n", e->toChars());

--- a/src/todt.c
+++ b/src/todt.c
@@ -32,6 +32,7 @@
 #include        "ctfe.h"
 #include        "arraytypes.h"
 #include        "visitor.h"
+#include        "template.h"
 // Back end
 #include        "dt.h"
 
@@ -53,6 +54,7 @@ void toObjFile(Dsymbol *ds, bool multiobj);
 Symbol *toVtblSymbol(ClassDeclaration *cd);
 Symbol* toSymbol(StructLiteralExp *sle);
 Symbol* toSymbol(ClassReferenceExp *cre);
+void genTypeInfo(Type *t, Scope *sc);
 
 /* ================================================================ */
 
@@ -588,6 +590,18 @@ dt_t **Expression_toDt(Expression *e, dt_t **pdt)
                 return;
             }
             pdt = ClassReferenceExp_toDt(e, pdt, 0);
+        }
+
+        void visit(TypeidExp *e)
+        {
+            if (Type *t = isType(e->obj))
+            {
+                genTypeInfo(t, NULL);
+                Symbol *s = toSymbol(t->vtinfo);
+                pdt = dtxoff(pdt, s, 0);
+                return;
+            }
+            assert(0);
         }
     };
 

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -37,7 +37,6 @@ void toObjFile(Dsymbol *ds, bool multiobj);
 Symbol *toVtblSymbol(ClassDeclaration *cd);
 Symbol *toInitializer(AggregateDeclaration *ad);
 Symbol *toInitializer(EnumDeclaration *ed);
-Expression *getTypeInfo(Type *t, Scope *sc);
 TypeInfoDeclaration *getTypeInfoDeclaration(Type *t);
 static bool builtinTypeInfo(Type *t);
 
@@ -104,14 +103,11 @@ void genTypeInfo(Type *torig, Scope *sc)
     assert(torig->vtinfo);
 }
 
-Expression *getTypeInfo(Type *t, Scope *sc)
+Type *getTypeInfoType(Type *t, Scope *sc)
 {
     assert(t->ty != Terror);
     genTypeInfo(t, sc);
-    Expression *e = VarExp::create(Loc(), t->vtinfo);
-    e = e->addressOf();
-    e->type = t->vtinfo->type;     // do this so we don't get redundant dereference
-    return e;
+    return t->vtinfo->type;
 }
 
 TypeInfoDeclaration *getTypeInfoDeclaration(Type *t)
@@ -600,9 +596,10 @@ public:
         for (size_t i = 0; i < dim; i++)
         {
             Parameter *arg = (*tu->arguments)[i];
-            Expression *e = getTypeInfo(arg->type, NULL);
-            e = e->optimize(WANTvalue);
-            Expression_toDt(e, &dt);
+
+            genTypeInfo(arg->type, NULL);
+            Symbol *s = toSymbol(arg->type->vtinfo);
+            dtxoff(&dt, s, 0);
         }
 
         dtdtoff(pdt, dt, 0);              // elements.ptr

--- a/test/fail_compilation/ice2843.d
+++ b/test/fail_compilation/ice2843.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice2843.d(22): Error: incompatible types for ((1) is (&typeid(int))): 'int' and 'object.TypeInfo'
+fail_compilation/ice2843.d(22): Error: incompatible types for ((1) is (typeid(int))): 'int' and 'object.TypeInfo'
 ---
 */
 

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -1036,6 +1036,38 @@ void test11034()
 
 /*******************************************************/
 
+void testTypeid()
+{
+    interface I
+    {
+    }
+
+    interface J : I
+    {
+    }
+
+    class C : J
+    {
+    }
+
+    class D : C
+    {
+    }
+
+    D d = new D();
+    Object o = d;
+    I i = d;
+
+    assert(typeid(typeof(o)) is typeid(Object));
+    assert(typeid(o) is typeid(D));
+    assert(o.classinfo is typeid(D));
+    assert(typeid(typeof(i)) is typeid(I));
+    assert(typeid(i) !is typeid(J));
+    assert(i.classinfo !is typeid(J));
+}
+
+/*******************************************************/
+
 int main()
 {
     test1();
@@ -1067,6 +1099,7 @@ int main()
     test27();
     test2553();
     test11034();
+    testTypeid();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Only resolve the type during semantic, and leave all expressions as `typeid(xxx)`.  Theoretically this should allow a clean way to ban access to typeinfo at runtime, while still allowing usage during ctfe.

@jpf91
