### PR TITLE
Refactor: convert argc/argv to Strings

### DIFF
--- a/src/magicport.json
+++ b/src/magicport.json
@@ -3198,12 +3198,11 @@
                 "core.stdc.stdio",
                 "core.stdc.stdlib",
                 "core.stdc.string",
+                "root.filename",
                 "root.file"
             ],
             "members" :
             [
-                "struct Narg",
-                "function addargp",
                 "function response_expand"
             ]
         }


### PR DESCRIPTION
Replace some very old code that manually managed memory with Strings. Reduction in complexity and lines of code.
