### PR TITLE
[refactor] Create typeid() expressions instead of invoking getTypeInfo directly

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -25,8 +25,6 @@
 #include "template.h"
 #include "tokens.h"
 
-Expression *getTypeInfo(Type *t, Scope *sc);
-
 /*******************************************
  * Merge function attributes pure, nothrow, @safe, @nogc, and @disable
  */
@@ -828,11 +826,11 @@ FuncDeclaration *buildPostBlit(StructDeclaration *sd, Scope *sc)
         }
         else
         {
-            // Typeinfo.postblit(cast(void*)&this.v);
+            // typeid(typeof(v)).postblit(cast(void*)&this.v);
             Expression *ea = new AddrExp(loc, ex);
             ea = new CastExp(loc, ea, Type::tvoid->pointerTo());
 
-            Expression *et = getTypeInfo(v->type, sc);
+            Expression *et = new TypeidExp(loc, v->type);
             et = new DotIdExp(loc, et, Identifier::idPool("postblit"));
             ex = new CallExp(loc, et, ea);
         }
@@ -857,7 +855,7 @@ FuncDeclaration *buildPostBlit(StructDeclaration *sd, Scope *sc)
             Expression *ea = new AddrExp(loc, ex);
             ea = new CastExp(loc, ea, Type::tvoid->pointerTo());
 
-            Expression *et = getTypeInfo(v->type, sc);
+            Expression *et = new TypeidExp(loc, v->type);
             et = new DotIdExp(loc, et, Id::destroy);
             ex = new CallExp(loc, et, ea);
         }
@@ -969,7 +967,7 @@ FuncDeclaration *buildDtor(AggregateDeclaration *ad, Scope *sc)
             Expression *ea = new AddrExp(loc, ex);
             ea = new CastExp(loc, ea, Type::tvoid->pointerTo());
 
-            Expression *et = getTypeInfo(v->type, sc);
+            Expression *et = new TypeidExp(loc, v->type);
             et = new DotIdExp(loc, et, Id::destroy);
             ex = new CallExp(loc, et, ea);
         }

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -27,8 +27,6 @@
 #include "ctfe.h"
 #include "target.h"
 
-Expression *getTypeInfo(Type *t, Scope *sc);
-
 /************************************
  * Check to see the aggregate type is nested and its context pointer is
  * accessible from the current scope.
@@ -2048,7 +2046,7 @@ Expression *VarDeclaration::callScopeDtor(Scope *sc)
                 Expressions *args = new Expressions();
                 args->push(ea);
 
-                Expression *et = getTypeInfo(type, sc);
+                Expression *et = new TypeidExp(loc, type);
                 et = new DotIdExp(loc, et, Id::destroy);
 
                 e = new CallExp(loc, et, args);

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -445,7 +445,6 @@
             [
                 "aggregate",
                 "arraytypes",
-                "backend",
                 "declaration",
                 "dscope",
                 "dstruct",
@@ -1506,7 +1505,6 @@
                 "aggregate",
                 "arraytypes",
                 "attrib",
-                "backend",
                 "core.stdc.stdio",
                 "cppmangle",
                 "ctfeexpr",
@@ -2845,8 +2843,7 @@
                 "struct LineInitExp",
                 "struct ModuleInitExp",
                 "struct FuncInitExp",
-                "struct PrettyFuncInitExp",
-                "function createTypeInfoArray"
+                "struct PrettyFuncInitExp"
             ]
         },
         {

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -55,7 +55,6 @@ int Tsize_t = Tuns32;
 int Tptrdiff_t = Tint32;
 
 Symbol *toInitializer(AggregateDeclaration *ad);
-Expression *getTypeInfo(Type *t, Scope *sc);
 
 /***************************** Type *****************************/
 
@@ -3787,7 +3786,9 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
         arguments = new Expressions();
         arguments->push(e);
         // don't convert to dynamic array
-        arguments->push(getTypeInfo(n, sc));
+        Expression *tid = new TypeidExp(e->loc, n);
+        tid = tid->semantic(sc);
+        arguments->push(tid);
         e = new CallExp(e->loc, ec, arguments);
         e->type = next->arrayOf();
     }


### PR DESCRIPTION
Semantic should lower them to the same thing.
