### PR TITLE
Deprecate extern(Pascal) linkage

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -320,6 +320,8 @@ void ClassDeclaration::semantic(Scope *sc)
 
         if (sc->linkage == LINKcpp)
             cpp = true;
+        if (sc->linkage == LINKpascal)
+            deprecation(loc, "linkage extern (Pascal) is deprecated");
     }
     else if (symtab && !scx)
     {

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1483,6 +1483,9 @@ Lnomatch:
         sc = sc->pop();
     }
 
+    if (linkage == LINKpascal && isDataseg())
+        deprecation(loc, "linkage extern (Pascal) is deprecated");
+
 Ldtor:
     /* Build code to execute destruction, if necessary
      */

--- a/src/func.c
+++ b/src/func.c
@@ -519,6 +519,9 @@ void FuncDeclaration::semantic(Scope *sc)
 
         sc->linkage = linkage;
 
+        if (linkage == LINKpascal)
+            deprecation(loc, "linkage extern (Pascal) is deprecated");
+
         if (!tf->isNaked() && !(isThis() || isNested()))
         {
             OutBuffer buf;

--- a/test/compilable/callconv.d
+++ b/test/compilable/callconv.d
@@ -11,24 +11,6 @@ ABC abc;
 
 int x,y,z;
 
-extern (Pascal):
-ABC test1(int xx, int yy, int zz)
-{
-    x = xx;
-    y = yy;
-    z = zz;
-    return abc;
-}
-
-extern (Pascal):
-ABC test1v(int xx, int yy, int zz, ...)
-{
-    x = xx;
-    y = yy;
-    z = zz;
-    return abc;
-}
-
 extern (C):
 ABC test2v(int xx, int yy, int zz, ...)
 {

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -790,7 +790,7 @@ void test33()
         return 3;
     }
 
-    extern (Pascal) int Foo4(int a, int b, int c)
+    extern (C++) int Foo4(int a, int b, int c)
     {
         assert(a == 1);
         assert(b == 2);
@@ -801,7 +801,6 @@ void test33()
     assert(Foo1(1, 2, 3) == 1);
     assert(Foo2(1, 2, 3) == 2);
     assert(Foo3(1, 2, 3) == 3);
-    assert(Foo4(1, 2, 3) == 4);
 
     printf("test33 success\n");
 }

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -625,11 +625,6 @@ extern (C) int cfc(int x, int y)
     return x * 10 + y;
 }
 
-extern (Pascal) int cfp(int x, int y)
-{
-    return x * 10 + y;
-}
-
 int cfd(int x, int y)
 {
     return x * 10 + y;
@@ -638,7 +633,6 @@ int cfd(int x, int y)
 
 extern (Windows) int function (int, int) fpw;
 extern (C) int function (int, int) fpc;
-extern (Pascal) int function (int, int) fpp;
 int function (int, int) fpd;
 
 void test20()
@@ -648,7 +642,6 @@ void test20()
 
     fpw = &cfw;
     fpc = &cfc;
-    fpp = &cfp;
     fpd = &cfd;
 
 //printf("test w\n");
@@ -659,13 +652,9 @@ void test20()
     i = (*fpc)(3, 4);
     assert(i == 34);
 
-//printf("test p\n");
-    i = (*fpp)(5, 6);
-    assert(i == 56);
-
 //printf("test d\n");
-    i = (*fpd)(7, 8);
-    assert(i == 78);
+    i = (*fpd)(5, 6);
+    assert(i == 56);
 }
 
 


### PR DESCRIPTION
- D dropped Windows 3.x and 9.x support back in 2.058 - http://dlang.org/deprecate.html#Windows%203.x%20and%20Windows%209x%20support
- It causes problems with ambiguity between `extern(Pascal)` functions and template value arguments - https://issues.dlang.org/show_bug.cgi?id=14591
- Is not supported by LLVM (http://llvm.org/docs/LangRef.html#calling-conventions) or GCC (https://gcc.gnu.org/onlinedocs/gcc/x86-Function-Attributes.html)
