### PR TITLE
Downgrade ICE's in cppmangle to errors

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -48,6 +48,7 @@ class CppMangleVisitor : public Visitor
 {
     Objects components;
     OutBuffer buf;
+    Loc loc;
     bool is_top_level;
     bool components_on;
 
@@ -509,8 +510,8 @@ class CppMangleVisitor : public Visitor
         if (t->ty == Tsarray)
         {
             // Mangle static arrays as pointers
-            t->error(Loc(), "Internal Compiler Error: unable to pass static array to extern(C++) function.");
-            t->error(Loc(), "Use pointer instead.");
+            t->error(mangler->loc, "Internal Compiler Error: unable to pass static array to extern(C++) function.");
+            t->error(mangler->loc, "Use pointer instead.");
             assert(0);
             //t = t->nextOf()->pointerTo();
         }
@@ -540,7 +541,7 @@ class CppMangleVisitor : public Visitor
 
 public:
     CppMangleVisitor()
-        : buf(), components(), is_top_level(false), components_on(true)
+        : components(), buf(), loc(Loc()), is_top_level(false), components_on(true)
     {
     }
 
@@ -548,6 +549,7 @@ public:
     {
         VarDeclaration *vd = s->isVarDeclaration();
         FuncDeclaration *fd = s->isFuncDeclaration();
+        this->loc = s->loc;
         if (vd)
         {
             mangle_variable(vd, false);
@@ -567,11 +569,11 @@ public:
     {
         if (t->isImmutable() || t->isShared())
         {
-            t->error(Loc(), "Internal Compiler Error: shared or immutable types can not be mapped to C++ (%s)", t->toChars());
+            t->error(loc, "Internal Compiler Error: shared or immutable types can not be mapped to C++ (%s)", t->toChars());
         }
         else
         {
-            t->error(Loc(), "Internal Compiler Error: unsupported type %s\n", t->toChars());
+            t->error(loc, "Internal Compiler Error: unsupported type %s\n", t->toChars());
         }
         assert(0); //Assert, because this error should be handled in frontend
     }
@@ -920,10 +922,10 @@ class VisualCPPMangler : public Visitor
 
     int flags;
     OutBuffer buf;
+    Loc loc;
 
     VisualCPPMangler(VisualCPPMangler *rvl)
-        : buf(),
-        flags(0)
+        : flags(0), buf(), loc(Loc())
     {
         flags |= (rvl->flags & IS_DMC);
         memcpy(&saved_idents, &rvl->saved_idents, sizeof(const char*) * VC_SAVED_IDENT_CNT);
@@ -932,8 +934,7 @@ class VisualCPPMangler : public Visitor
 public:
 
     VisualCPPMangler(bool isdmc)
-        : buf(),
-        flags(0)
+        : flags(0), buf(), loc(Loc())
     {
         if (isdmc)
         {
@@ -947,11 +948,11 @@ public:
     {
         if (type->isImmutable() || type->isShared())
         {
-            type->error(Loc(), "Internal Compiler Error: shared or immutable types can not be mapped to C++ (%s)", type->toChars());
+            type->error(loc, "Internal Compiler Error: shared or immutable types can not be mapped to C++ (%s)", type->toChars());
         }
         else
         {
-            type->error(Loc(), "Internal Compiler Error: unsupported type %s\n", type->toChars());
+            type->error(loc, "Internal Compiler Error: unsupported type %s\n", type->toChars());
         }
         assert(0); // Assert, because this error should be handled in frontend
     }
@@ -1289,6 +1290,7 @@ public:
     {
         VarDeclaration *vd = s->isVarDeclaration();
         FuncDeclaration *fd = s->isFuncDeclaration();
+        this->loc = s->loc;
         if (vd)
         {
             mangleVariable(vd);
@@ -1811,8 +1813,8 @@ private:
         }
         if (t->ty == Tsarray)
         {
-            t->error(Loc(), "Internal Compiler Error: unable to pass static array to extern(C++) function.");
-            t->error(Loc(), "Use pointer instead.");
+            t->error(loc, "Internal Compiler Error: unable to pass static array to extern(C++) function.");
+            t->error(loc, "Use pointer instead.");
             assert(0);
         }
         mangler->flags &= ~IS_NOT_TOP_TYPE;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -526,6 +526,8 @@ public:
     FuncDeclaration *fdrequire;         // function that does the in contract
     FuncDeclaration *fdensure;          // function that does the out contract
 
+    const char *mangleString;           // mangled symbol created from mangleExact()
+
     Identifier *outId;                  // identifier for out statement
     VarDeclaration *vresult;            // variable corresponding to outId
     LabelDsymbol *returnLabel;          // where the return goes

--- a/src/func.c
+++ b/src/func.c
@@ -289,6 +289,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     frequire = NULL;
     fdrequire = NULL;
     fdensure = NULL;
+    mangleString = NULL;
     outId = NULL;
     vresult = NULL;
     returnLabel = NULL;

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -3017,6 +3017,7 @@
                 "dstruct",
                 "dsymbol",
                 "dtemplate",
+                "errors",
                 "expression",
                 "func",
                 "id",

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -870,10 +870,14 @@ const char *mangle(Dsymbol *s)
  */
 const char *mangleExact(FuncDeclaration *fd)
 {
-    OutBuffer buf;
-    Mangler v(&buf);
-    v.mangleExact(fd);
-    return buf.extractString();
+    if (!fd->mangleString)
+    {
+        OutBuffer buf;
+        Mangler v(&buf);
+        v.mangleExact(fd);
+        fd->mangleString = buf.extractString();
+    }
+    return fd->mangleString;
 }
 
 void mangleToBuffer(Type *t, OutBuffer *buf)


### PR DESCRIPTION
- Stores the function/variable location in the visitor so we are able to get correct line error reporting.
- Downgrades the ICE's to errors because there is _no_ protection whatsoever from, eg:

```
extern(C++):
int myCxxvar;
int myCxxfunc(int[4]);
int myCxxfunc2(shared int);
```

ICE and abort in these cases most certainly the wrong way to go about it.
- Noticed that functions may have `mangleExact` called more than once in the glue layer.  Once when generating the function symbol, and then multiplied by the total number of times the function is called.   Caching it prevents errors from being duplicated, tripleted, ad infinitum.  I suspect there is a speed gain (and a win for memory usage) too.
