### PR TITLE
Move backend prefixing of symbols to Target::prefixName

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -406,7 +406,7 @@ class CppMangleVisitor : public Visitor
         Dsymbol *p = d->toParent();
         if (p && !p->isModule()) //for example: char Namespace1::beta[6] should be mangled as "_ZN10Namespace14betaE"
         {
-            buf.writestring(global.params.isOSX ? "__ZN" : "_ZN");      // "__Z" for OSX, "_Z" for other
+            buf.writestring("_ZN");
             prefix_name(p);
             source_name(d);
             buf.writeByte('E');
@@ -415,13 +415,11 @@ class CppMangleVisitor : public Visitor
         {
             if (!is_temp_arg_ref)
             {
-                if (global.params.isOSX)
-                    buf.writeByte('_');
                 buf.writestring(d->ident->toChars());
             }
             else
             {
-                buf.writestring(global.params.isOSX ? "__Z" : "_Z");
+                buf.writestring("_Z");
                 source_name(d);
             }
         }
@@ -438,7 +436,7 @@ class CppMangleVisitor : public Visitor
          */
         TypeFunction *tf = (TypeFunction *)d->type;
 
-        buf.writestring(global.params.isOSX ? "__Z" : "_Z");      // "__Z" for OSX, "_Z" for other
+        buf.writestring("_Z");
         Dsymbol *p = d->toParent();
         if (p && !p->isModule() && tf->linkage == LINKcpp)
         {
@@ -560,6 +558,7 @@ public:
         {
             assert(0);
         }
+        Target::prefixName(&buf, LINKcpp);
         return buf.extractString();
     }
 

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -373,7 +373,8 @@
                 "root.longdouble",
                 "globals",
                 "mtype",
-                "dmodule"
+                "dmodule",
+                "root.outbuffer"
             ],
             "members" :
             [

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2333,8 +2333,10 @@ Identifier *Type::getTypeInfoIdent(int internal)
     assert(strlen(name) < namelen);     // don't overflow the buffer
 
     size_t off = 0;
+#ifndef IN_GCC
     if (global.params.isOSX || global.params.isWindows && !global.params.is64bit)
         ++off;                 // C mangling will add '_' back in
+#endif
     Identifier *id = Identifier::idPool(name + off);
 
     if (name != namebuf)

--- a/src/target.c
+++ b/src/target.c
@@ -14,6 +14,7 @@
 #include "target.h"
 #include "mars.h"
 #include "mtype.h"
+#include "outbuffer.h"
 
 int Target::ptrsize;
 int Target::realsize;
@@ -384,5 +385,23 @@ int Target::checkVectorType(int sz, Type *type)
  */
 void Target::loadModule(Module *m)
 {
+}
+
+/******************************
+ * For the given symbol written to the OutBuffer, apply any
+ * target-specific prefixes based on the given linkage.
+ */
+void Target::prefixName(OutBuffer *buf, LINK linkage)
+{
+    switch (linkage)
+    {
+        case LINKcpp:
+            if (global.params.isOSX)
+                buf->prependbyte('_');
+            break;
+
+        default:
+            break;
+    }
 }
 

--- a/src/target.h
+++ b/src/target.h
@@ -15,10 +15,12 @@
 // This file contains a data structure that describes a back-end target.
 // At present it is incomplete, but in future it should grow to contain
 // most or all target machine and target O/S specific information.
+#include "globals.h"
 
 class Expression;
 class Type;
 class Module;
+struct OutBuffer;
 
 struct Target
 {
@@ -32,13 +34,17 @@ struct Target
     static int classinfosize;        // size of 'ClassInfo'
 
     static void init();
+    // Type sizes and support.
     static unsigned alignsize(Type* type);
     static unsigned fieldalign(Type* type);
     static unsigned critsecsize();
     static Type *va_listType();  // get type of va_list
-    static Expression *paintAsType(Expression *e, Type *type);
     static int checkVectorType(int sz, Type *type);
+    // CTFE support for cross-compilation.
+    static Expression *paintAsType(Expression *e, Type *type);
+    // ABI and backend.
     static void loadModule(Module *m);
+    static void prefixName(OutBuffer *buf, LINK linkage);
 };
 
 #endif


### PR DESCRIPTION
Apart from `_argptr` stuff, I think this the last of the areas that GDC stubs out `global.params.isXXX` logic from the frontend.
