### PR TITLE
fix Issue 14587 - generated 64 bit code for switch jump tables is wrong

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1394,6 +1394,8 @@ void doswitch(block *b)
         if (vmax - vmin != REGMASK)     /* if there is a maximum        */
         {                               /* CMP reg,vmax-vmin            */
             c = genc2(c,0x81,modregrm(3,7,reg),vmax-vmin);
+            if (I64)
+                code_orrex(c, REX_W);
             genjmp(c,JA,FLblock,list_block(b->Bsucc));  /* JA default   */
         }
         if (I64)

--- a/test/runnable/testswitch.d
+++ b/test/runnable/testswitch.d
@@ -659,6 +659,27 @@ void test14352()
 }
 
 /*****************************************/
+// Issue 14587 - DMD 2.067.1 generating crashing binary on OSX
+
+struct Card {
+    int value;
+    int suit;
+}
+
+void foo14587(Card card) {
+    switch(card.value) {
+    case 4: case 5: case 6: case 11:
+        break;
+    default:
+    }
+}
+
+void test14587() {
+    auto card = Card(11, 1);
+    foo14587(card);
+} 
+
+/*****************************************/
 
 int main()
 {
@@ -687,6 +708,7 @@ int main()
     test22();
     test23();
     test14352();
+    test14587();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14587

This is a critical bug fix.
