### PR TITLE
Cache mangle string created from mangleExact to prevent multiple calls to C++/D mangle visitors

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -514,6 +514,8 @@ public:
     FuncDeclaration *fdrequire;         // function that does the in contract
     FuncDeclaration *fdensure;          // function that does the out contract
 
+    const char *mangleString;           // mangled symbol created from mangleExact()
+
     Identifier *outId;                  // identifier for out statement
     VarDeclaration *vresult;            // variable corresponding to outId
     LabelDsymbol *returnLabel;          // where the return goes

--- a/src/func.c
+++ b/src/func.c
@@ -289,6 +289,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     frequire = NULL;
     fdrequire = NULL;
     fdensure = NULL;
+    mangleString = NULL;
     outId = NULL;
     vresult = NULL;
     returnLabel = NULL;

--- a/src/mangle.c
+++ b/src/mangle.c
@@ -870,10 +870,14 @@ const char *mangle(Dsymbol *s)
  */
 const char *mangleExact(FuncDeclaration *fd)
 {
-    OutBuffer buf;
-    Mangler v(&buf);
-    v.mangleExact(fd);
-    return buf.extractString();
+    if (!fd->mangleString)
+    {
+        OutBuffer buf;
+        Mangler v(&buf);
+        v.mangleExact(fd);
+        fd->mangleString = buf.extractString();
+    }
+    return fd->mangleString;
 }
 
 void mangleToBuffer(Type *t, OutBuffer *buf)


### PR DESCRIPTION
Cherry picked from #4661

Noticed that functions may have `mangleExact` called more than once in the glue layer. Once when generating the function symbol, and then multiplied by the total number of times the function is called.  I suspect there is a speed gain (and a win for memory usage) too.
