### PR TITLE
Improve CFTE support for float/double/real painting

### DIFF
--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -220,7 +220,7 @@ UnionExp pointerArithmetic(Loc loc, TOK op, Type *type,
 bool isFloatIntPaint(Type *to, Type *from);
 
 // Reinterpret float/int value 'fromVal' as a float/integer of type 'to'.
-Expression *paintFloatInt(Expression *fromVal, Type *to);
+Expression *paintFloatInt(Expression *fromVal, Type *to, d_uns64 offset);
 
 /// Return true if t is an AA
 bool isAssocArray(Type *t);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -5160,6 +5160,38 @@ public:
     #endif
         if (e->e1->type->toBasetype()->ty == Tpointer)
         {
+            // Check (cast(ushort*)&x)[i], where x is a real variable or expression.
+            if (e->e1->op == TOKsymoff && ((SymOffExp *)e->e1)->offset == 0 &&
+                ((SymOffExp *)e->e1)->var->isVarDeclaration() &&
+                isFloatIntPaint(e->type, ((SymOffExp *)e->e1)->var->type))
+            {
+                //printf("(cast(ushort*)&x)[i], where x is a real variable\n");
+                Expression *e2 = interpret(e->e2, istate);
+                if (exceptionOrCantInterpret(e2))
+                {
+                    result = CTFEExp::cantexp;
+                    return;
+                }
+                result = paintFloatInt(getVarExp(e->loc, istate, ((SymOffExp *)e->e1)->var, ctfeNeedRvalue), e->type, e2->toInteger());
+                return;
+            }
+            if (e->e1->op == TOKcast && ((CastExp *)e->e1)->e1->op == TOKaddress)
+            {
+                Expression *x = ((AddrExp *)(((CastExp *)e->e1)->e1))->e1;
+                //printf("(cast(ushort*)&x)[i], where x is a real expression\n");
+                if (isFloatIntPaint(e->type, x->type))
+                {
+                    Expression *e2 = interpret(e->e2, istate);
+                    if (exceptionOrCantInterpret(e2))
+                    {
+                        result = CTFEExp::cantexp;
+                        return;
+                    }
+                    result = paintFloatInt(interpret(x, istate), e->type, e2->toInteger());
+                    return;
+                }
+            }
+
             Expression *agg;
             uinteger_t indexToAccess;
             if (!resolveIndexing(e, istate, &agg, &indexToAccess, false))
@@ -5777,7 +5809,7 @@ public:
             isFloatIntPaint(e->type, ((SymOffExp *)e->e1)->var->type))
         {
             // *(cast(int*)&v), where v is a float variable
-            result = paintFloatInt(getVarExp(e->loc, istate, ((SymOffExp *)e->e1)->var, ctfeNeedRvalue), e->type);
+            result = paintFloatInt(getVarExp(e->loc, istate, ((SymOffExp *)e->e1)->var, ctfeNeedRvalue), e->type, 0);
             return;
         }
         if (e->e1->op == TOKcast && ((CastExp *)e->e1)->e1->op == TOKaddress)
@@ -5786,7 +5818,7 @@ public:
             Expression *x = ((AddrExp *)(((CastExp *)e->e1)->e1))->e1;
             if (isFloatIntPaint(e->type, x->type))
             {
-                result = paintFloatInt(interpret(x, istate), e->type);
+                result = paintFloatInt(interpret(x, istate), e->type, 0);
                 return;
             }
         }

--- a/src/target.h
+++ b/src/target.h
@@ -36,7 +36,7 @@ struct Target
     static unsigned fieldalign(Type* type);
     static unsigned critsecsize();
     static Type *va_listType();  // get type of va_list
-    static Expression *paintAsType(Expression *e, Type *type);
+    static Expression *paintAsType(Expression *e, Type *type, d_uns64 offset);
     static int checkVectorType(int sz, Type *type);
     static void loadModule(Module *m);
 };

--- a/test/fail_compilation/b5227.d
+++ b/test/fail_compilation/b5227.d
@@ -1,0 +1,99 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -w -o-
+
+/*
+TEST_OUTPUT:
+---
+test/fail_compilation/b5227.d(97): Error: index 2 is out of bounds: trying to get bytes [4:5] out of 4
+test/fail_compilation/b5227.d(97):        called from here: paintIndex(16.5156F, 2)
+test/fail_compilation/b5227.d(97):        while evaluating: static assert(cast(int)paintIndex(16.5156F, 2) == 0)
+test/fail_compilation/b5227.d(20): Error: cannot convert &float to ulong* at compile time
+test/fail_compilation/b5227.d(98):        called from here: paint(16.5156F)
+test/fail_compilation/b5227.d(98):        while evaluating: static assert(paint(16.5156F) == 0LU)
+---
+*/
+
+template paint(FromT, ToT)
+{
+    ToT paint(FromT f)
+    {
+        return *cast(ToT*)&f;
+    }
+}
+
+template paintIndex(FromT, ToT)
+{
+    ToT paintIndex(FromT f, int offset)
+    {
+        return (cast(ToT*)&f)[offset];
+    }
+}
+
+void main()
+{
+    // 16.515625 is:
+    //   8658944 * 2E-19
+    //   (note that the MSB is implicit for float and double, and explicit for Real)
+    // Float:
+    //   01000001_10000100_00100000_00000000
+    // Double:
+    //   01000000_00110000_10000100_00000000
+    //   00000000_00000000_00000000_00000000
+    // Real: 
+    //   01000000_00000011_10000100_00100000
+    //   00000000_00000000_00000000_00000000
+    //   00000000_00000000
+
+
+    // Whole type painting.
+    static assert(paint!(int,float)(0x41842000) == 16.515625f);
+    static assert(paint!(long,double)(0x4030840000000000L) == 16.515625f);
+
+    static assert(paint!(float,int)(16.515625f) == 0x41842000);
+    static assert(paint!(float,uint)(16.515625f) == 0x41842000u);
+    static assert(paint!(double,long)(16.515625) == 0x4030840000000000L);
+    static assert(paint!(double,ulong)(16.515625) == 0x4030840000000000UL);
+
+
+    // Partial type painting with dereference.
+    static assert(paint!(float,ushort)(16.515625f) == 0x2000);
+    static assert(paint!(double,uint)(16.515625) == 0x0u);
+    static assert(paint!(real,ulong)(16.515625) == 0x8420000000000000UL);
+
+
+    // Partial type painting with indexing.
+    static assert(paintIndex!(float,ubyte)(16.515625, 3) == 0x41);
+    static assert(paintIndex!(float,ubyte)(16.515625, 2) == 0x84);
+    static assert(paintIndex!(float,ubyte)(16.515625, 1) == 0x20);
+    static assert(paintIndex!(float,ubyte)(16.515625, 0) == 0x00);
+
+    static assert(paintIndex!(float,ushort)(16.515625, 1) == 0x4184);
+    static assert(paintIndex!(float,ushort)(16.515625, 0) == 0x2000);
+
+    static assert(paintIndex!(real,ubyte)(16.515625, 9) == 0x40);
+    static assert(paintIndex!(real,ubyte)(16.515625, 8) == 0x03);
+    static assert(paintIndex!(real,ubyte)(16.515625, 7) == 0x84);
+    static assert(paintIndex!(real,ubyte)(16.515625, 6) == 0x20);
+    static assert(paintIndex!(real,ubyte)(16.515625, 5) == 0x00);
+    static assert(paintIndex!(real,ubyte)(16.515625, 4) == 0x00);
+    static assert(paintIndex!(real,ubyte)(16.515625, 3) == 0x00);
+    static assert(paintIndex!(real,ubyte)(16.515625, 2) == 0x00);
+    static assert(paintIndex!(real,ubyte)(16.515625, 1) == 0x00);
+    static assert(paintIndex!(real,ubyte)(16.515625, 0) == 0x00);
+
+    static assert(paintIndex!(real,ushort)(16.515625, 4) == 0x4003);
+    static assert(paintIndex!(real,ushort)(16.515625, 3) == 0x8420);
+    static assert(paintIndex!(real,ushort)(16.515625, 2) == 0x0000);
+    static assert(paintIndex!(real,ushort)(16.515625, 1) == 0x0000);
+    static assert(paintIndex!(real,ushort)(16.515625, 0) == 0x0000);
+
+    static assert(paintIndex!(real,uint)(16.515625, 1) == 0x84200000u);
+    static assert(paintIndex!(real,uint)(16.515625, 0) == 0x00000000u);
+
+    static assert(paintIndex!(real,ulong)(16.515625, 0) == 0x8420000000000000UL);
+    
+
+    // Failure tests:
+    static assert(paintIndex!(float,ushort)(16.515625, 2) == 0);
+    static assert(paint!(float,ulong)(16.515625f) == 0);
+}


### PR DESCRIPTION
This extends the special case for float/int painting:
float f;
uint i = _cast(uint_)&f;

To code like:
float f;
ushort s1 = _cast(ushort_)&f;
ushort s2 = (cast(ushort*)&f)[1];

for any integer type smaller than float (resp. double and real).

This is required to make isNaN and isInfinite work at compile time in phobos (https://github.com/D-Programming-Language/phobos/pull/3307).
