### PR TITLE
DDMD: Fix duplicate definition linker errors in gdc

### DIFF
--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -163,29 +163,32 @@ else
         goto L1;
     }
 
-    extern (C) void* _d_allocmemory(size_t m_size)
+    version(DigitalMars)
     {
-        return allocmemory(m_size);
-    }
+        extern (C) void* _d_allocmemory(size_t m_size)
+        {
+            return allocmemory(m_size);
+        }
 
-    extern (C) Object _d_newclass(const ClassInfo ci)
-    {
-        auto p = allocmemory(ci.init.length);
-        p[0 .. ci.init.length] = cast(void[])ci.init[];
-        return cast(Object)p;
-    }
+        extern (C) Object _d_newclass(const ClassInfo ci)
+        {
+            auto p = allocmemory(ci.init.length);
+            p[0 .. ci.init.length] = cast(void[])ci.init[];
+            return cast(Object)p;
+        }
 
-    extern (C) void* _d_newitemT(TypeInfo ti)
-    {
-        auto p = allocmemory(ti.tsize);
-        (cast(ubyte*)p)[0 .. ti.init.length] = 0;
-        return p;
-    }
+        extern (C) void* _d_newitemT(TypeInfo ti)
+        {
+            auto p = allocmemory(ti.tsize);
+            (cast(ubyte*)p)[0 .. ti.init.length] = 0;
+            return p;
+        }
 
-    extern (C) void* _d_newitemiT(TypeInfo ti)
-    {
-        auto p = allocmemory(ti.tsize);
-        p[0 .. ti.init.length] = ti.init[];
-        return p;
+        extern (C) void* _d_newitemiT(TypeInfo ti)
+        {
+            auto p = allocmemory(ti.tsize);
+            p[0 .. ti.init.length] = ti.init[];
+            return p;
+        }
     }
 }


### PR DESCRIPTION
As per discussion, dmd does some fancy section trick to evade this.  But it just won't fly in gdc.

@klickverbot - would this bug you?
