### PR TITLE
DDMD: Don't default initialise UnionExp structs

### DIFF
--- a/src/magicport/dprinter.d
+++ b/src/magicport/dprinter.d
@@ -416,6 +416,10 @@ class DPrinter : Visitor
             visitX(ast.type);
             print("()");
         }
+        else if (ast.type.id == "UnionExp")
+        {
+            print(" = void");
+        }
         if (!E)
         {
             if (ast.trailingcomment)
@@ -452,6 +456,10 @@ class DPrinter : Visitor
                 this.inittype = ast.types[i];
                 visitX(ast.inits[i]);
                 inittype = null;
+            }
+            else if (ast.types[i].id == "UnionExp")
+            {
+                print(" = void");
             }
         }
     }


### PR DESCRIPTION
Thanks to the use of `scope class` in `emplaceExp`, there are times when initialising UnionExp smashes the stack and destroys any previously emplaced values.

ie (though this example probably is not enough to trigger it, the use of scopes is crucial):

```
UnionExp foo;
{
    emplaceExp!(IntegerExp)(&foo, e1.toInteger());  // calls 'new scope'
}
{
    UnionExp bar;  // The 'new scope' data has been overwritten, making 'foo' garbage.
}
```

Using `= void` gets around it, and is safe because we do not care what's inside `UnionExp`'s until we explicitly start using them anyway.

Though I will have a look on my side.  I think I'm justified in that the behaviour from gdc is correct (using 'new scope' data after it has left it's natural scope is fraught with dangers).
