### PR TITLE
fix order of evaluation of conf file

### DIFF
--- a/src/magicport.json
+++ b/src/magicport.json
@@ -1696,6 +1696,7 @@
                 "root.filename",
                 "root.outbuffer",
                 "root.port",
+                "root.stringtable",
                 "core.sys.windows.windows",
                 "core.sys.posix.stdlib"
             ],
@@ -1707,6 +1708,10 @@
             "members" :
             [
                 "function findConfFile",
+                "function readFromEnv",
+                "function writeToEnv",
+                "function envput",
+                "function updateRealEnvironment",
                 "function parseConfFile",
                 "function skipspace"
             ]
@@ -2509,6 +2514,7 @@
                 "root.outbuffer",
                 "root.rmem",
                 "root.response",
+                "root.stringtable",
                 "target",
                 "tokens",
                 "traits"

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -230,3 +230,26 @@ void StringTable::grow()
     }
     mem.xfree(otab);
 }
+
+/********************************
+ * Walk the contents of the string table,
+ * calling fp for each entry.
+ * Params:
+ *      fp = function to call. Returns !=0 to stop
+ * Returns:
+ *      last return value of fp call
+ */
+int StringTable::apply(int (*fp)(StringValue *))
+{
+    for (size_t i = 0; i < tabledim; ++i)
+    {
+        StringEntry *se = &table[i];
+        if (!se->vptr) continue;
+        StringValue *sv = getValue(se->vptr);
+        int result = (*fp)(sv);
+        if (result)
+            return result;
+    }
+    return 0;
+}
+

--- a/src/root/stringtable.h
+++ b/src/root/stringtable.h
@@ -52,6 +52,7 @@ public:
     StringValue *lookup(const char *s, size_t len);
     StringValue *insert(const char *s, size_t len);
     StringValue *update(const char *s, size_t len);
+    int apply(int (*fp)(StringValue *));
 
 private:
     uint32_t allocValue(const char *p, size_t length);


### PR DESCRIPTION
This fixes two bugs in the order of evaluation of the configuration file, stemming from it being parsed twice:
1. environment variables can get screwed up because there is no protection from nested settings of them
2. the order of evaluation of sections is not documented, but is in a surprising order. This fixes it to be in lexical order.

Also adds an `apply` function to StringTable so that the table can be iterated over.
