### PR TITLE
fix: Issue 14554 - [REG2.066] dmd generate wrong error message for multiple template with same name

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -8840,7 +8840,7 @@ Lagain:
         {
             s = ((TemplateExp *)e1)->td;
         L2:
-            f = resolveFuncCall(loc, sc, s, tiargs, NULL, arguments, 2);
+            f = resolveFuncCall(loc, sc, s, tiargs, NULL, arguments);
             if (!f || f->errors)
                 return new ErrorExp();
             if (f->needThis())

--- a/test/fail_compilation/fail14554.d
+++ b/test/fail_compilation/fail14554.d
@@ -1,0 +1,30 @@
+// REQUIRED_ARGS: -o-
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail14554.d(28): Error: fail14554.issue14554_1.foo called with argument types (int) matches both:
+fail_compilation/fail14554.d(17):     fail14554.issue14554_1.foo!bool.foo(int j)
+and:
+fail_compilation/fail14554.d(18):     fail14554.issue14554_1.foo!bool.foo(int j)
+fail_compilation/fail14554.d(29): Error: fail14554.issue14554_2.foo called with argument types (int) matches both:
+fail_compilation/fail14554.d(22):     fail14554.issue14554_2.foo!bool.foo(int j)
+and:
+fail_compilation/fail14554.d(23):     fail14554.issue14554_2.foo!bool.foo(int j)
+---
+*/
+struct issue14554_1 {
+     void foo(T)(int j) {}
+     static void foo(T)(int j) {}
+}
+
+struct issue14554_2 {
+     static void foo(T)(int j) {}
+     void foo(T)(int j) {}
+}
+
+void test14554()
+{
+     issue14554_1.foo!bool(1);    
+     issue14554_2.foo!bool(1);    
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14554
