### PR TITLE
Fix posix build when HOST_DC has an explicit -conf switch

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -47,8 +47,8 @@ ifeq (,$(AUTO_BOOTSTRAP))
   ifeq (,$(HOST_DC_FULL))
     $(error '$(HOST_DC)' not found, get a D compiler or make AUTO_BOOTSTRAP=1)
   endif
+  HOST_DC_RUN:=$(HOST_DC)
   HOST_DC:=$(HOST_DC_FULL)
-  HOST_DC_RUN=$(HOST_DC)
 else
   # Auto-bootstrapping, will download dmd automatically
   HOST_DMD_VER=2.067.1


### PR DESCRIPTION
Since `HOST_DC_RUN` is what is actually run, don't strip off any switches that might have been in the original `HOST_DC` variable.
