### PR TITLE
 [REG2.067.0] Issue 14606 - Bad code with -inline and structs

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2658,7 +2658,7 @@ elem *toElem(Expression *e, IRState *irs)
                         es = el_una(OPaddr, TYnptr, es);
                     es->Ety = TYnptr;
                     e = el_bin(OPeq, TYnptr, es, e);
-                    // BUG: type is struct, and e2 is TOKint64
+                    assert(!(t1b->ty == Tstruct && ae->e2->op == TOKint64));
 
                     el_setLoc(e, ae->loc);
                     result = e;
@@ -2716,6 +2716,8 @@ elem *toElem(Expression *e, IRState *irs)
             {
                 if (ae->e2->op == TOKint64)
                 {
+                    assert(ae->op == TOKblit);
+
                     /* Implement:
                      *  (struct = 0)
                      * with:

--- a/src/expression.c
+++ b/src/expression.c
@@ -11299,13 +11299,16 @@ Expression *AssignExp::semantic(Scope *sc)
                      * initializer
                      */
                     AssignExp *ae = this;
-                    if (sd->zeroInit == 1)
-                        ae->e2 = new IntegerExp(loc, 0, Type::tint32);
-                    else if (sd->isNested())
-                        ae->e2 = t1->defaultInitLiteral(loc);
+                    if (sd->zeroInit == 1 && !sd->isNested())
+                    {
+                        // Bugzilla 14606: Always use BlitExp for the special expression: (struct = 0)
+                        ae = new BlitExp(ae->loc, ae->e1, new IntegerExp(loc, 0, Type::tint32));
+                    }
                     else
-                        ae->e2 = t1->defaultInit(loc);
-                    // Keep ae->op == TOKconstruct
+                    {
+                        // Keep ae->op == TOKconstruct
+                        ae->e2 = sd->isNested() ? t1->defaultInitLiteral(loc) : t1->defaultInit(loc);
+                    }
                     ae->type = e1x->type;
 
                     /* Replace __ctmp being constructed with e1.

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -624,6 +624,41 @@ void test14306() {
 }
 
 /**********************************/
+// 14606
+
+struct S14606
+{
+    this(long stdTime)
+    {
+        _stdTime = stdTime;
+    }
+
+    long _stdTime;
+}
+
+S14606 getS14606()
+{
+    S14606 sysTime = S14606(0);
+    return sysTime;
+}
+
+struct T14606
+{
+    this(string)
+    {
+        uint[3] arr;
+        s = getS14606();
+    }
+
+    S14606 s;
+}
+
+void test14606()
+{
+    auto t = T14606(null);
+}
+
+/**********************************/
 
 int main()
 {
@@ -646,6 +681,7 @@ int main()
     test11394();
     test13503();
     test14306();
+    test14606();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14606

The wrong-code had caused by the combination of special memset expression `(struct = 0)` and inlining field variable initialization with NRVO. The extended inlining had introduced ConstructExp(ref_var, 0), but it was wrongly handled as reference initialization in AssignExp::toElem().

To fix that, use `BlitExp` for the memset expression always, and avoid confusion with the ref initialization.
