### PR TITLE
Makefile: use same logic for OS and MODEL for test as druntime/phobos/dmd

### DIFF
--- a/src/osmodel.mak
+++ b/src/osmodel.mak
@@ -1,4 +1,5 @@
 # This Makefile snippet detects the OS and the architecture MODEL
+# Keep this file in sync between druntime, phobos, and dmd repositories!
 
 ifeq (,$(OS))
   uname_S:=$(shell uname -s)

--- a/test/Makefile
+++ b/test/Makefile
@@ -59,6 +59,24 @@
 #                        considered to be enabled).
 #                        default: (none, enabled)
 
+ifeq (Windows_NT,$(OS))
+    ifeq ($(findstring WOW64, $(shell uname)),WOW64)
+	OS:=win64
+	MODEL:=64
+    else
+	OS:=win32
+	MODEL:=32
+    endif
+endif
+ifeq (Win_32,$(OS))
+    OS:=win32
+    MODEL:=32
+endif
+ifeq (Win_64,$(OS))
+    OS:=win64
+    MODEL:=64
+endif
+
 include ../src/osmodel.mak
 
 export OS

--- a/test/Makefile
+++ b/test/Makefile
@@ -59,44 +59,8 @@
 #                        considered to be enabled).
 #                        default: (none, enabled)
 
-ifeq (,$(OS))
-    OS:=$(shell uname)
-    ifeq (Darwin,$(OS))
-        OS:=osx
-    else
-        ifeq (Linux,$(OS))
-            OS:=linux
-        else
-            ifeq (FreeBSD,$(OS))
-                OS:=freebsd
-            else
-                ifeq (Solaris,$(OS))
-                    OS:=solaris
-                else
-                    ifeq (SunOS,$(OS))
-                        OS:=solaris
-                    else
-                        $(error Unrecognized or unsupported OS for uname: $(OS))
-                    endif
-                endif
-            endif
-        endif
-    endif
-else
-    ifeq (Windows_NT,$(OS))
-        ifeq ($(findstring WOW64, $(shell uname)),WOW64)
-            OS:=win64
-        else
-            OS:=win32
-        endif
-    endif
-    ifeq (Win_32,$(OS))
-	OS:=win32
-    endif
-    ifeq (Win_64,$(OS))
-	OS:=win64
-    endif
-endif
+include ../src/osmodel.mak
+
 export OS
 
 ifeq (freebsd,$(OS))
@@ -106,7 +70,7 @@ else
 endif
 QUIET=@
 export RESULTS_DIR=test_results
-export MODEL=32
+export MODEL
 export REQUIRED_ARGS=
 
 ifeq ($(findstring win,$(OS)),win)
@@ -238,6 +202,6 @@ start_fail_compilation_tests: $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test$(
 $(RESULTS_DIR)/d_do_test$(EXE): d_do_test.d $(RESULTS_DIR)/.created
 	@echo "Building d_do_test tool"
 	@echo "OS: $(OS)"
-	$(QUIET)$(DMD) -conf= -m$(MODEL) -unittest -run d_do_test.d -unittest
-	$(QUIET)$(DMD) -conf= -m$(MODEL) -od$(RESULTS_DIR) -of$(RESULTS_DIR)$(DSEP)d_do_test$(EXE) d_do_test.d
+	$(QUIET)$(DMD) -conf= $(MODEL_FLAG) -unittest -run d_do_test.d -unittest
+	$(QUIET)$(DMD) -conf= $(MODEL_FLAG) -od$(RESULTS_DIR) -of$(RESULTS_DIR)$(DSEP)d_do_test$(EXE) d_do_test.d
 


### PR DESCRIPTION
On OSX, make would default to `MODEL=64` for dmd/phobos/druntime, but would use `MODEL=32` (and therefor require 32-bit phobos/druntime) when making the tests. This is counterintuitive as simply running `make` would not make the 32-bit libraries but would require them for the tests.
