### PR TITLE
Fixed false DDoc warnings (check parent template decl)

### DIFF
--- a/src/doc.d
+++ b/src/doc.d
@@ -221,6 +221,12 @@ public:
                     {
                         size_t o = buf.offset;
                         Parameter fparam = isFunctionParameter(a, namestart, namelen);
+                        if (!fparam)
+                        {
+                            // Comments on a template might refer to function parameters within.
+                            // Search the parameters of nested eponymous functions (with the same name.)
+                            fparam = isEponymousFunctionParameter(a, namestart, namelen);
+                        }
                         bool isCVariadic = isCVariadicParameter(a, namestart, namelen);
                         if (isCVariadic)
                         {
@@ -1002,8 +1008,8 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(Declaration d)
         {
-            //printf("Declaration::emitComment(%p '%s'), comment = '%s'\n", d, d->toChars(), d->comment);
-            //printf("type = %p\n", d->type);
+            //printf("Declaration::emitComment(%p '%s'), comment = '%s'\n", d, d.toChars(), d.comment);
+            //printf("type = %p\n", d.type);
             const(char)* com = d.comment;
             if (TemplateDeclaration td = getEponymousParent(d))
             {
@@ -2060,21 +2066,81 @@ extern (C++) TypeFunction isTypeFunction(Dsymbol s)
 
 /****************************************************
  */
+private Parameter isFunctionParameter(Dsymbol s, const(char)* p, size_t len)
+{
+    TypeFunction tf = isTypeFunction(s);
+    if (tf && tf.parameters)
+    {
+        for (size_t k = 0; k < tf.parameters.dim; k++)
+        {
+            Parameter fparam = (*tf.parameters)[k];
+            if (fparam.ident && cmp(fparam.ident.toChars(), p, len) == 0)
+            {
+                return fparam;
+            }
+        }
+    }
+    return null;
+}
+
+/****************************************************
+ */
 extern (C++) Parameter isFunctionParameter(Dsymbols* a, const(char)* p, size_t len)
 {
     for (size_t i = 0; i < a.dim; i++)
     {
-        TypeFunction tf = isTypeFunction((*a)[i]);
-        if (tf && tf.parameters)
+        Parameter fparam = isFunctionParameter((*a)[i], p, len);
+        if (fparam)
         {
-            for (size_t k = 0; k < tf.parameters.dim; k++)
+            return fparam;
+        }
+    }
+    return null;
+}
+
+/****************************************************
+ */
+private Parameter isEponymousFunctionParameter(Dsymbols *a, const(char) *p, size_t len)
+{
+    for (size_t i = 0; i < a.dim; i++)
+    {
+        TemplateDeclaration td = (*a)[i].isTemplateDeclaration();
+        if (td && td.onemember)
+        {
+            /* Case 1: we refer to a template declaration inside the template
+
+               /// ...ddoc...
+               template case1(T) {
+                 void case1(R)() {}
+               }
+             */
+            td = td.onemember.isTemplateDeclaration();
+        }
+        if (!td)
+        {
+            /* Case 2: we're an alias to a template declaration
+
+               /// ...ddoc...
+               alias case2 = case1!int;
+             */
+            AliasDeclaration ad = (*a)[i].isAliasDeclaration();
+            if (ad && ad.aliassym)
             {
-                Parameter fparam = (*tf.parameters)[k];
-                if (fparam.ident && cmp(fparam.ident.toChars(), p, len) == 0)
+                td = ad.aliassym.isTemplateDeclaration();
+            }
+        }
+        while (td)
+        {
+            Dsymbol sym = getEponymousMember(td);
+            if (sym)
+            {
+                Parameter fparam = isFunctionParameter(sym, p, len);
+                if (fparam)
                 {
                     return fparam;
                 }
             }
+            td = td.overnext;
         }
     }
     return null;
@@ -2086,7 +2152,10 @@ extern (C++) TemplateParameter isTemplateParameter(Dsymbols* a, const(char)* p, 
 {
     for (size_t i = 0; i < a.dim; i++)
     {
-        TemplateDeclaration td = getEponymousParent((*a)[i]);
+        TemplateDeclaration td = (*a)[i].isTemplateDeclaration();
+        // Check for the parent, if the current symbol is not a template declaration.
+        if (!td)
+            td = getEponymousParent((*a)[i]);
         if (td && td.origParameters)
         {
             for (size_t k = 0; k < td.origParameters.dim; k++)

--- a/test/compilable/ddoc14633.d
+++ b/test/compilable/ddoc14633.d
@@ -1,0 +1,23 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -w -o-
+
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+/** Blah
+ Params:
+    T = some type
+    test = something
+    overnext = for testing overloaded functions
+*/
+template case1(T)
+{
+  void case1(R)(R test) { }
+  void case1(R)(R test, string overnext) { }
+}
+
+///ditto
+alias case2 = case1!int;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14633

This is tricky. Some params in ddoc comments refer to a nested template function. This was not handled before and would cause some of the `Ddoc: function declaration has no parameter` warnings.

Fixed by checking the parameters of all overloads of the nested template function of the same name.

Note that it only looks for nested template functions, not regular functions. For regular functions the ddoc comment should be on the function, not the parent template declaration.

I created an overload for `isFunctionParameter` taking a single `Dsymbol*`.
