### PR TITLE
Exhaustive fix for minor ICE "e2ir: cannot cast" (and fixes one reopened regression)

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1439,15 +1439,26 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                 return;
             }
 
-            // Do (type *) cast of (type [dim])
-            if (tob->ty == Tpointer &&
-                t1b->ty == Tsarray)
-            {
-                //printf("Converting [dim] to *\n");
-                result = new AddrExp(e->loc, e);
-                result->type = t;
-                return;
-            }
+            /* Make semantic error against invalid cast between concrete types.
+             * Assume that 'e' is never be any placeholder expressions.
+             * The result of these checks should be consistent with CastExp::toElem().
+             */
+
+            // Fat Value types
+            const bool tob_isFV = (tob->ty == Tstruct || tob->ty == Tsarray);
+            const bool t1b_isFV = (t1b->ty == Tstruct || t1b->ty == Tsarray);
+
+            // Fat Reference types
+            const bool tob_isFR = (tob->ty == Tarray || tob->ty == Tdelegate);
+            const bool t1b_isFR = (t1b->ty == Tarray || t1b->ty == Tdelegate);
+
+            // Reference types
+            const bool tob_isR = (tob_isFR || tob->ty == Tpointer || tob->ty == Taarray || tob->ty == Tclass);
+            const bool t1b_isR = (t1b_isFR || t1b->ty == Tpointer || t1b->ty == Taarray || t1b->ty == Tclass);
+
+            // Arithmetic types (== valueable basic types)
+            const bool tob_isA = (tob->isintegral() || tob->isfloating());
+            const bool t1b_isA = (t1b->isintegral() || t1b->isfloating());
 
             if (AggregateDeclaration *t1ad = isAggregate(t1b))
             {
@@ -1460,7 +1471,7 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                         ClassDeclaration *tocd = tob->isClassHandle();
                         int offset;
                         if (tocd->isBaseOf(t1cd, &offset))
-                             goto L1;
+                             goto Lok;
                     }
 
                     /* Forward the cast to our alias this member, rewrite to:
@@ -1468,8 +1479,6 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                      */
                     result = resolveAliasThis(sc, e);
                     result = result->castTo(sc, t);
-                    //result = new CastExp(e->loc, ex, t);
-                    //result = result->semantic(sc);
                     return;
                 }
             }
@@ -1482,6 +1491,16 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                 result = result->semantic(sc);
                 return;
             }
+            else if (tob->ty != Tvector && t1b->ty == Tvector)
+            {
+                // T[n] <-- __vector(U[m])
+                if (tob->ty == Tsarray)
+                {
+                    if (t1b->size(e->loc) == tob->size(e->loc))
+                        goto Lok;
+                }
+                goto Lfail;
+            }
             else if (t1b->implicitConvTo(tob) == MATCHconst && t->equals(e->type->constOf()))
             {
                 result = e->copy();
@@ -1489,48 +1508,104 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                 return;
             }
 
-            // Bugzlla 3133: Struct casts are possible only when the sizes match
-            // Same with static array -> static array
-            if ((t1b->ty == Tsarray || t1b->ty == Tstruct) &&
-                (tob->ty == Tsarray || tob->ty == Tstruct))
+            // arithmetic values vs. other arithmetic values
+            // arithmetic values vs. T*
+            if (tob_isA && (t1b_isA || t1b->ty == Tpointer) ||
+                t1b_isA && (tob_isA || tob->ty == Tpointer))
             {
-                if (t1b->size(e->loc) != tob->size(e->loc))
-                    goto Lfail;
+                goto Lok;
             }
-            // Bugzilla 9178: Tsarray <--> typeof(null)
-            // Bugzilla 9904: Tstruct <--> typeof(null)
-            if (t1b->ty == Tnull && (tob->ty == Tsarray || tob->ty == Tstruct) ||
-                tob->ty == Tnull && (t1b->ty == Tsarray || t1b->ty == Tstruct))
-            {
-                goto Lfail;
-            }
-            // Bugzilla 13959: Tstruct <--> Tpointer
-            if ((tob->ty == Tstruct && t1b->ty == Tpointer) ||
-                (t1b->ty == Tstruct && tob->ty == Tpointer))
-            {
-                goto Lfail;
-            }
-            // Bugzilla 14596: Tpointer --> T(s)array
-            if ((tob->ty == Tarray || tob->ty == Tsarray) && t1b->ty == Tpointer)
+
+            // arithmetic values vs. references or fat values
+            if (tob_isA && (t1b_isR || t1b_isFV) ||
+                t1b_isA && (tob_isR || tob_isFV))
             {
                 goto Lfail;
             }
 
-            // Bugzilla 10646: Tclass <--> (T[] or T[n])
-            if (tob->ty == Tclass && (t1b->ty == Tarray || t1b->ty == Tsarray) ||
-                t1b->ty == Tclass && (tob->ty == Tarray || tob->ty == Tsarray))
+            // Bugzlla 3133: A cast between fat values is possible only when the sizes match.
+            if (tob_isFV && t1b_isFV)
             {
+                if (t1b->size(e->loc) == tob->size(e->loc))
+                    goto Lok;
+                e->error("cannot cast expression %s of type %s to %s because of different sizes",
+                    e->toChars(), e->type->toChars(), t->toChars());
+                result = new ErrorExp();
+                return;
+            }
+
+            // Fat values vs. null or references
+            if (tob_isFV && (t1b->ty == Tnull || t1b_isR) ||
+                t1b_isFV && (tob->ty == Tnull || tob_isR))
+            {
+                if (tob->ty == Tpointer && t1b->ty == Tsarray)
+                {
+                    // T[n] sa;
+                    // cast(U*)sa; // ==> cast(U*)sa.ptr;
+                    result = new AddrExp(e->loc, e);
+                    result->type = t;
+                    return;
+                }
+                if (tob->ty == Tarray && t1b->ty == Tsarray)
+                {
+                    // T[n] sa;
+                    // cast(U[])sa; // ==> cast(U[])sa[];
+                    d_uns64 fsize = t1b->nextOf()->size();
+                    d_uns64 tsize = tob->nextOf()->size();
+                    if ((((TypeSArray *)t1b)->dim->toInteger() * fsize) % tsize != 0)
+                    {
+                        // copied from sarray_toDarray() in e2ir.c
+                        e->error("cannot cast expression %s of type %s to %s since sizes don't line up",
+                            e->toChars(), e->type->toChars(), t->toChars());
+                        result = new ErrorExp();
+                        return;
+                    }
+                    goto Lok;
+                }
                 goto Lfail;
             }
-            // Bugzilla 11484: (T[] or T[n]) <--> TypeBasic
-            // Bugzilla 11485, 7472: Tclass <--> TypeBasic
-            // Bugzilla 14154L Tstruct <--> TypeBasic
-            if (t1b->isTypeBasic() && (tob->ty == Tarray || tob->ty == Tsarray || tob->ty == Tclass || tob->ty == Tstruct) ||
-                tob->isTypeBasic() && (t1b->ty == Tarray || t1b->ty == Tsarray || t1b->ty == Tclass || t1b->ty == Tstruct))
+
+            /* For references, any reinterpret casts are allowed to same 'ty' type.
+             *      T* to U*
+             *      R1 function(P1) to R2 function(P2)
+             *      R1 delegate(P1) to R2 delegate(P2)
+             *      T[] to U[]
+             *      V1[K1] to V2[K2]
+             *      class/interface A to B  (will be a dynamic cast if possible)
+             */
+            if (tob->ty == t1b->ty && tob_isR && t1b_isR)
+                goto Lok;
+
+            // typeof(null) <-- non-null references or values
+            if (tob->ty == Tnull && t1b->ty != Tnull)
+                goto Lfail;     // Bugzilla 14629
+            // typeof(null) --> non-null references or arithmetic values
+            if (t1b->ty == Tnull && tob->ty != Tnull)
+                goto Lok;
+
+            // Check size mismatch of references.
+            // Tarray and Tdelegate are (void*).sizeof*2, but others have (void*).sizeof.
+            if (tob_isFR && t1b_isR ||
+                t1b_isFR && tob_isR)
             {
+                if (tob->ty == Tpointer && t1b->ty == Tarray)
+                {
+                    // T[] da;
+                    // cast(U*)da; // ==> cast(U*)da.ptr;
+                    goto Lok;
+                }
+                if (tob->ty == Tpointer && t1b->ty == Tdelegate)
+                {
+                    // void delegate() dg;
+                    // cast(U*)dg; // ==> cast(U*)dg.ptr;
+                    // Note that it happens even when U is a Tfunction!
+                    e->deprecation("casting from %s to %s is deprecated", e->type->toChars(), t->toChars());
+                    goto Lok;
+                }
                 goto Lfail;
             }
-            if (t1b->ty == Tvoid && tob->ty != Tvoid && e->op != TOKfunction)
+
+            if (t1b->ty == Tvoid && tob->ty != Tvoid)
             {
             Lfail:
                 e->error("cannot cast expression %s of type %s to %s",
@@ -1539,7 +1614,7 @@ Expression *castTo(Expression *e, Scope *sc, Type *t)
                 return;
             }
 
-        L1:
+        Lok:
             result = new CastExp(e->loc, e, tob);
             result->type = t;       // Don't call semantic()
             //printf("Returning: %s\n", result->toChars());

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1302,7 +1302,11 @@ L1:
     else
     {
         if (type != Type::terror)
+        {
+            // have to change to Internal Compiler Error
+            // all invalid casts should be handled already in Expression::castTo().
             error(loc, "cannot cast %s to %s", e1->type->toChars(), type->toChars());
+        }
         new(&ue) ErrorExp();
     }
     return ue;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -680,6 +680,7 @@ elem *sarray_toDarray(Loc loc, Type *tfrom, Type *tto, elem *e)
 
         if ((dim * fsize) % tsize != 0)
         {
+            // have to change to Internal Compiler Error?
             error(loc, "cannot cast %s to %s since sizes don't line up", tfrom->toChars(), tto->toChars());
         }
         dim = (dim * fsize) / tsize;

--- a/src/expression.c
+++ b/src/expression.c
@@ -9738,10 +9738,6 @@ Expression *CastExp::semantic(Scope *sc)
         return new VectorExp(loc, e1, to);
     }
 
-    if (tob->ty == Tpointer && t1b->ty == Tdelegate)
-        deprecation("casting from %s to %s is deprecated", e1->type->toChars(), to->toChars());
-
-
     Expression *ex = e1->castTo(sc, to);
     if (ex->op == TOKerror)
         return ex;

--- a/test/fail_compilation/fail233.d
+++ b/test/fail_compilation/fail233.d
@@ -1,10 +1,12 @@
-void bug1176(){
+// REQUIRED_ARGS: -o-
 /*
-Error: void does not have a default initializer
-Error: integral constant must be scalar type, not void
-Error: cannot implicitly convert expression (0) of type int to const(void[])
-Error: cannot cast int to const(void[])
-Error: integral constant must be scalar type, not const(void[])
+TEST_OUTPUT:
+---
+fail_compilation/fail233.d(11): Error: variable fail233.bug1176.v void[1] does not have a default initializer
+---
 */
-        void[1] v;
+
+void bug1176()
+{
+    void[1] v;
 }

--- a/test/fail_compilation/fail304.d
+++ b/test/fail_compilation/fail304.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail304.d(15): Error: cannot cast expression foo() of type Small to Large
+fail_compilation/fail304.d(15): Error: cannot cast expression foo() of type Small to Large because of different sizes
 ---
 */
 

--- a/test/fail_compilation/fail8179b.d
+++ b/test/fail_compilation/fail8179b.d
@@ -1,10 +1,10 @@
+// REQUIRED_ARGS: -o-
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8179b.d(10): Error: e2ir: cannot cast [1, 2] of type int[] to type int[2][1]
+fail_compilation/fail8179b.d(10): Error: cannot cast expression [1, 2] of type int[] to int[2][1]
 ---
 */
-
 void foo(int[2][1]) {}
 void main() {
     foo(cast(int[2][1])[1, 2]);

--- a/test/fail_compilation/fail_casting.d
+++ b/test/fail_compilation/fail_casting.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(12): Error: cannot cast expression x of type short[2] to int[2]
+fail_compilation/fail_casting.d(12): Error: cannot cast expression x of type short[2] to int[2] because of different sizes
 ---
 */
 void test3133()
@@ -63,7 +63,7 @@ fail_compilation/fail_casting.d(77): Error: cannot cast expression x of type flo
 fail_compilation/fail_casting.d(78): Error: cannot cast expression x of type int to float[]
 ---
 */
-void tst11484()
+void test11484()
 {
     // Tsarray <--> integer
     { int[1]   x; auto y = cast(int     ) x; }

--- a/test/fail_compilation/fail_casting.d
+++ b/test/fail_compilation/fail_casting.d
@@ -192,3 +192,32 @@ void test14596()
     auto arr = cast(char[])p;
     char[2] sarr = cast(char[2])p;
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_casting.d(217): Error: cannot cast expression c of type fail_casting.test14629.C to typeof(null)
+fail_compilation/fail_casting.d(218): Error: cannot cast expression p of type int* to typeof(null)
+fail_compilation/fail_casting.d(219): Error: cannot cast expression da of type int[] to typeof(null)
+fail_compilation/fail_casting.d(220): Error: cannot cast expression aa of type int[int] to typeof(null)
+fail_compilation/fail_casting.d(221): Error: cannot cast expression fp of type int function() to typeof(null)
+fail_compilation/fail_casting.d(222): Error: cannot cast expression dg of type int delegate() to typeof(null)
+---
+*/
+void test14629()
+{
+    alias P = int*;             P p;
+    alias DA = int[];           DA da;
+    alias AA = int[int];        AA aa;
+    alias FP = int function();  FP fp;
+    alias DG = int delegate();  DG dg;
+    class C {}                  C c;
+    alias N = typeof(null);
+
+    { auto x = cast(N)c;  }
+    { auto x = cast(N)p;  }
+    { auto x = cast(N)da; }
+    { auto x = cast(N)aa; }
+    { auto x = cast(N)fp; }
+    { auto x = cast(N)dg; }
+}

--- a/test/fail_compilation/fail_casting1.d
+++ b/test/fail_compilation/fail_casting1.d
@@ -1,0 +1,259 @@
+// REQUIRED_SRGS: -o-
+
+
+// references
+alias P = int*;             P p;
+alias FP = int function();  FP fp;
+alias DG = int delegate();  DG dg;
+alias DA = int[];           DA da;
+alias AA = int[int];        AA aa;
+class C {}                  C c;
+alias N = typeof(null);     N n;
+
+// values
+alias SA = int[1];          SA sa;
+struct S {}                 S s;
+                            int i;
+                            double f;
+
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_casting1.d(39): Error: cannot cast expression p of type int* to int[1]
+fail_compilation/fail_casting1.d(40): Error: cannot cast expression fp of type int function() to int[1]
+fail_compilation/fail_casting1.d(41): Error: cannot cast expression dg of type int delegate() to int[1]
+fail_compilation/fail_casting1.d(42): Error: cannot cast expression da of type int[] to int[1]
+fail_compilation/fail_casting1.d(43): Error: cannot cast expression aa of type int[int] to int[1]
+fail_compilation/fail_casting1.d(44): Error: cannot cast expression c of type fail_casting1.C to int[1]
+fail_compilation/fail_casting1.d(45): Error: cannot cast expression n of type typeof(null) to int[1]
+fail_compilation/fail_casting1.d(49): Error: cannot cast expression sa of type int[1] to int delegate()
+fail_compilation/fail_casting1.d(51): Error: cannot cast expression sa of type int[1] to double[] since sizes don't line up
+fail_compilation/fail_casting1.d(52): Error: cannot cast expression sa of type int[1] to int[int]
+fail_compilation/fail_casting1.d(53): Error: cannot cast expression sa of type int[1] to fail_casting1.C
+fail_compilation/fail_casting1.d(54): Error: cannot cast expression sa of type int[1] to typeof(null)
+---
+*/
+void test1()
+{
+    { auto x = cast(SA) p; }        // Reject (Bugzilla 14596)
+    { auto x = cast(SA)fp; }        // Reject (Bugzilla 14596) (FP is Tpointer)
+    { auto x = cast(SA)dg; }        // Reject (from e2ir)
+    { auto x = cast(SA)da; }        // Reject (from e2ir)
+    { auto x = cast(SA)aa; }        // Reject (from e2ir)
+    { auto x = cast(SA) c; }        // Reject (Bugzilla 10646)
+    { auto x = cast(SA) n; }        // Reject (Bugzilla 8179)
+    { auto x = cast( P)sa; }        // Accept (equivalent with: cast(int*)sa.ptr;)
+    { auto x = cast(double*)sa; }   // Accept (equivalent with: cast(double*)sa.ptr;)
+    { auto x = cast(FP)sa; }        // Accept (equivalent with: cast(FP)sa.ptr;)
+    { auto x = cast(DG)sa; }        // Reject (from e2ir)
+    { auto x = cast(DA)sa; }        // Accept (equivalent with: cast(int[])sa[];)
+    { auto x = cast(double[])sa; }  // Reject (from e2ir)
+    { auto x = cast(AA)sa; }        // Reject (from e2ir)
+    { auto x = cast( C)sa; }        // Reject (Bugzilla 10646)
+    { auto x = cast( N)sa; }        // Reject (Bugzilla 8179)
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_casting1.d(78): Error: cannot cast expression p of type int* to S
+fail_compilation/fail_casting1.d(79): Error: cannot cast expression fp of type int function() to S
+fail_compilation/fail_casting1.d(80): Error: cannot cast expression dg of type int delegate() to S
+fail_compilation/fail_casting1.d(81): Error: cannot cast expression da of type int[] to S
+fail_compilation/fail_casting1.d(82): Error: cannot cast expression aa of type int[int] to S
+fail_compilation/fail_casting1.d(83): Error: cannot cast expression c of type fail_casting1.C to S
+fail_compilation/fail_casting1.d(84): Error: cannot cast expression n of type typeof(null) to S
+fail_compilation/fail_casting1.d(85): Error: cannot cast expression s of type S to int*
+fail_compilation/fail_casting1.d(86): Error: cannot cast expression s of type S to int function()
+fail_compilation/fail_casting1.d(87): Error: cannot cast expression s of type S to int delegate()
+fail_compilation/fail_casting1.d(88): Error: cannot cast expression s of type S to int[]
+fail_compilation/fail_casting1.d(89): Error: cannot cast expression s of type S to int[int]
+fail_compilation/fail_casting1.d(90): Error: cannot cast expression s of type S to fail_casting1.C
+fail_compilation/fail_casting1.d(91): Error: cannot cast expression s of type S to typeof(null)
+---
+*/
+void test2()
+{
+    { auto x = cast( S) p; }        // Reject (Bugzilla 13959)
+    { auto x = cast( S)fp; }        // Reject (Bugzilla 13959) (FP is Tpointer)
+    { auto x = cast( S)dg; }        // Reject (from e2ir)
+    { auto x = cast( S)da; }        // Reject (from e2ir)
+    { auto x = cast( S)aa; }        // Reject (from e2ir)
+    { auto x = cast( S) c; }        // Reject (from e2ir)
+    { auto x = cast( S) n; }        // Reject (Bugzilla 9904)
+    { auto x = cast( P) s; }        // Reject (Bugzilla 13959)
+    { auto x = cast(FP) s; }        // Reject (Bugzilla 13959) (FP is Tpointer)
+    { auto x = cast(DG) s; }        // Reject (from e2ir)
+    { auto x = cast(DA) s; }        // Reject (from e2ir)
+    { auto x = cast(AA) s; }        // Reject (from e2ir)
+    { auto x = cast( C) s; }        // Reject (from e2ir)
+    { auto x = cast( N) s; }        // Reject (Bugzilla 9904)
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_casting1.d(125): Error: cannot cast expression p of type int* to int delegate()
+fail_compilation/fail_casting1.d(126): Error: cannot cast expression p of type int* to int[]
+fail_compilation/fail_casting1.d(129): Error: cannot cast expression p of type int* to typeof(null)
+fail_compilation/fail_casting1.d(133): Error: cannot cast expression fp of type int function() to int delegate()
+fail_compilation/fail_casting1.d(134): Error: cannot cast expression fp of type int function() to int[]
+fail_compilation/fail_casting1.d(137): Error: cannot cast expression fp of type int function() to typeof(null)
+fail_compilation/fail_casting1.d(139): Deprecation: casting from int delegate() to int* is deprecated
+fail_compilation/fail_casting1.d(140): Deprecation: casting from int delegate() to int function() is deprecated
+fail_compilation/fail_casting1.d(142): Error: cannot cast expression dg of type int delegate() to int[]
+fail_compilation/fail_casting1.d(143): Error: cannot cast expression dg of type int delegate() to int[int]
+fail_compilation/fail_casting1.d(144): Error: cannot cast expression dg of type int delegate() to fail_casting1.C
+fail_compilation/fail_casting1.d(145): Error: cannot cast expression dg of type int delegate() to typeof(null)
+fail_compilation/fail_casting1.d(157): Error: cannot cast expression da of type int[] to int delegate()
+fail_compilation/fail_casting1.d(159): Error: cannot cast expression da of type int[] to int[int]
+fail_compilation/fail_casting1.d(160): Error: cannot cast expression da of type int[] to fail_casting1.C
+fail_compilation/fail_casting1.d(161): Error: cannot cast expression da of type int[] to typeof(null)
+fail_compilation/fail_casting1.d(165): Error: cannot cast expression aa of type int[int] to int delegate()
+fail_compilation/fail_casting1.d(166): Error: cannot cast expression aa of type int[int] to int[]
+fail_compilation/fail_casting1.d(169): Error: cannot cast expression aa of type int[int] to typeof(null)
+fail_compilation/fail_casting1.d(173): Error: cannot cast expression c of type fail_casting1.C to int delegate()
+fail_compilation/fail_casting1.d(174): Error: cannot cast expression c of type fail_casting1.C to int[]
+fail_compilation/fail_casting1.d(177): Error: cannot cast expression c of type fail_casting1.C to typeof(null)
+---
+*/
+void test3()    // between reference types
+{
+    { auto x = cast( P) p; }    // Accept
+    { auto x = cast(FP) p; }    // Accept (FP is Tpointer)
+    { auto x = cast(DG) p; }    // Reject (from e2ir)
+    { auto x = cast(DA) p; }    // Reject (Bugzilla 14596)
+    { auto x = cast(AA) p; }    // Accept (because of size match)
+    { auto x = cast( C) p; }    // Accept (because of size match)
+    { auto x = cast( N) p; }    // Reject (Bugzilla 14629)
+
+    { auto x = cast( P)fp; }    // Accept (FP is Tpointer)
+    { auto x = cast(FP)fp; }    // Accept
+    { auto x = cast(DG)fp; }    // Reject (from e2ir)
+    { auto x = cast(DA)fp; }    // Reject (Bugzilla 14596)
+    { auto x = cast(AA)fp; }    // Accept (because of size match)
+    { auto x = cast( C)fp; }    // Accept (because of size match)
+    { auto x = cast( N)fp; }    // Reject (Bugzilla 14629)
+
+    { auto x = cast( P)dg; }    // Deprecated (equivalent with: cast( P)dg.ptr;)
+    { auto x = cast(FP)dg; }    // Deprecated (equivalent with: cast(FP)dg.ptr;)
+    { auto x = cast(DG)dg; }    // Accept
+    { auto x = cast(DA)dg; }    // Reject (from e2ir)
+    { auto x = cast(AA)dg; }    // Reject (from e2ir)
+    { auto x = cast( C)dg; }    // Reject (from e2ir)
+    { auto x = cast( N)dg; }    // Reject (Bugzilla 14629)
+
+    { auto x = cast( P) n; }    // Accept
+    { auto x = cast(FP) n; }    // Accept
+    { auto x = cast(DG) n; }    // Accept
+    { auto x = cast(DA) n; }    // Accept
+    { auto x = cast(AA) n; }    // Accept
+    { auto x = cast( C) n; }    // Accept
+    { auto x = cast( N) n; }    // Accept
+
+    { auto x = cast( P)da; }    // Accept (equivalent with: cast(P)da.ptr;)
+    { auto x = cast(FP)da; }    // Accept (FP is Tpointer)
+    { auto x = cast(DG)da; }    // Reject (from e2ir)
+    { auto x = cast(DA)da; }    // Accept
+    { auto x = cast(AA)da; }    // Reject (from e2ir)
+    { auto x = cast( C)da; }    // Reject (Bugzilla 10646)
+    { auto x = cast( N)da; }    // Reject (Bugzilla 14629)
+
+    { auto x = cast( P)aa; }    // Accept (because of size match)
+    { auto x = cast(FP)aa; }    // Accept (FP is Tpointer)
+    { auto x = cast(DG)aa; }    // Reject (from e2ir)
+    { auto x = cast(DA)aa; }    // Reject (from e2ir)
+    { auto x = cast(AA)aa; }    // Accept
+    { auto x = cast( C)aa; }    // Accept (because of size match)
+    { auto x = cast( N)aa; }    // Reject (Bugzilla 14629)
+
+    { auto x = cast( P) c; }    // Accept
+    { auto x = cast(FP) c; }    // Accept (FP is Tpointer)
+    { auto x = cast(DG) c; }    // Reject (from e2ir)
+    { auto x = cast(DA) c; }    // Reject (Bugzilla 10646)
+    { auto x = cast(AA) c; }    // Accept (because of size match)
+    { auto x = cast( C) c; }    // Accept
+    { auto x = cast( N) c; }    // Reject (Bugzilla 14629)
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_casting1.d(206): Error: cannot cast expression 0 of type int to int delegate()
+fail_compilation/fail_casting1.d(207): Error: cannot cast expression 0 of type int to int[]
+fail_compilation/fail_casting1.d(208): Error: cannot cast expression 0 of type int to int[1]
+fail_compilation/fail_casting1.d(209): Error: cannot cast expression 0 of type int to int[int]
+fail_compilation/fail_casting1.d(210): Error: cannot cast expression 0 of type int to fail_casting1.C
+fail_compilation/fail_casting1.d(211): Error: cannot cast expression 0 of type int to typeof(null)
+fail_compilation/fail_casting1.d(215): Error: cannot cast expression i of type int to int delegate()
+fail_compilation/fail_casting1.d(216): Error: cannot cast expression i of type int to int[]
+fail_compilation/fail_casting1.d(217): Error: cannot cast expression i of type int to int[1]
+fail_compilation/fail_casting1.d(218): Error: cannot cast expression i of type int to int[int]
+fail_compilation/fail_casting1.d(219): Error: cannot cast expression i of type int to fail_casting1.C
+fail_compilation/fail_casting1.d(220): Error: cannot cast expression i of type int to typeof(null)
+fail_compilation/fail_casting1.d(224): Error: cannot cast expression dg of type int delegate() to int
+fail_compilation/fail_casting1.d(225): Error: cannot cast expression da of type int[] to int
+fail_compilation/fail_casting1.d(226): Error: cannot cast expression sa of type int[1] to int
+fail_compilation/fail_casting1.d(227): Error: cannot cast expression aa of type int[int] to int
+fail_compilation/fail_casting1.d(228): Error: cannot cast expression c of type fail_casting1.C to int
+---
+*/
+void test4()
+{
+    { auto x = cast( P) 0; }    // Accept
+    { auto x = cast(FP) 0; }    // Accept
+    { auto x = cast(DG) 0; }    // Reject (from constfold)
+    { auto x = cast(DA) 0; }    // Reject (Bugzilla 11484)
+    { auto x = cast(SA) 0; }    // Reject (Bugzilla 11484)
+    { auto x = cast(AA) 0; }    // Reject (from constfold)
+    { auto x = cast( C) 0; }    // Reject (Bugzilla 11485)
+    { auto x = cast( N) 0; }    // Reject (from constfold)
+
+    { auto x = cast( P) i; }    // Accept
+    { auto x = cast(FP) i; }    // Accept
+    { auto x = cast(DG) i; }    // Reject (from e2ir)
+    { auto x = cast(DA) i; }    // Reject (Bugzilla 11484)
+    { auto x = cast(SA) i; }    // Reject (Bugzilla 11484)
+    { auto x = cast(AA) i; }    // Reject (from e2ir)
+    { auto x = cast( C) i; }    // Reject (Bugzilla 11485)
+    { auto x = cast( N) i; }    // Reject (from e2ir)
+
+    { auto x = cast(int) p; }   // Accept
+    { auto x = cast(int)fp; }   // Accept
+    { auto x = cast(int)dg; }   // Reject (from e2ir)
+    { auto x = cast(int)da; }   // Reject (Bugzilla 11484)
+    { auto x = cast(int)sa; }   // Reject (Bugzilla 11484)
+    { auto x = cast(int)aa; }   // Reject (from e2ir)
+    { auto x = cast(int) c; }   // Reject (Bugzilla 7472)
+    { auto x = cast(int) n; }   // Accept
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_casting1.d(249): Error: cannot cast expression 0 of type int to int[1]
+fail_compilation/fail_casting1.d(250): Error: cannot cast expression 0 of type int to S
+fail_compilation/fail_casting1.d(251): Error: cannot cast expression i of type int to int[1]
+fail_compilation/fail_casting1.d(252): Error: cannot cast expression i of type int to S
+fail_compilation/fail_casting1.d(253): Error: cannot cast expression f of type double to int[1]
+fail_compilation/fail_casting1.d(254): Error: cannot cast expression f of type double to S
+fail_compilation/fail_casting1.d(255): Error: cannot cast expression sa of type int[1] to int
+fail_compilation/fail_casting1.d(256): Error: cannot cast expression s of type S to int
+fail_compilation/fail_casting1.d(257): Error: cannot cast expression sa of type int[1] to double
+fail_compilation/fail_casting1.d(258): Error: cannot cast expression s of type S to double
+---
+*/
+void test5()
+{
+    { auto x = cast(SA) 0; }        // Reject (Bugzilla 14154)
+    { auto x = cast( S) 0; }        // Reject (Bugzilla 14154)
+    { auto x = cast(SA) i; }        // Reject (Bugzilla 14154)
+    { auto x = cast( S) i; }        // Reject (Bugzilla 14154)
+    { auto x = cast(SA) f; }        // Reject (Bugzilla 14154)
+    { auto x = cast( S) f; }        // Reject (Bugzilla 14154)
+    { auto x = cast(int)sa; }       // Reject (Bugzilla 14154)
+    { auto x = cast(int) s; }       // Reject (Bugzilla 14154)
+    { auto x = cast(double)sa; }    // Reject (Bugzilla 14154)
+    { auto x = cast(double) s; }    // Reject (Bugzilla 14154)
+}

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -58,6 +58,17 @@ void test1()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -107,6 +118,17 @@ void test2()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -156,6 +178,17 @@ void test2b()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -205,6 +238,17 @@ void test2c()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -254,6 +298,17 @@ void test2d()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -303,6 +358,17 @@ void test2e()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -352,6 +418,17 @@ void test2f()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -401,6 +478,17 @@ void test2g()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -450,6 +538,17 @@ void test2h()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -499,6 +598,17 @@ void test2i()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/
@@ -548,6 +658,17 @@ void test2j()
     static assert(!__traits(compiles, v1 <<= 1));
     static assert(!__traits(compiles, v1 >>= 1));
     static assert(!__traits(compiles, v1 >>>= 1));
+
+    //  A cast from vector to non-vector is allowed only when the target is same size Tsarray.
+    static assert(!__traits(compiles, cast(byte)v1));       // 1byte
+    static assert(!__traits(compiles, cast(short)v1));      // 2byte
+    static assert(!__traits(compiles, cast(int)v1));        // 4byte
+    static assert(!__traits(compiles, cast(long)v1));       // 8byte
+    static assert(!__traits(compiles, cast(float)v1));      // 4byte
+    static assert(!__traits(compiles, cast(double)v1));     // 8byte
+    static assert(!__traits(compiles, cast(int[2])v1));     // 8byte Tsarray
+    static assert( __traits(compiles, cast(int[4])v1));     // 16byte Tsarray, OK
+    static assert( __traits(compiles, cast(long[2])v1));    // 16byte Tsarray, OK
 }
 
 /*****************************************/


### PR DESCRIPTION
I hope that this PR will be a final step toward to replace the ICE with a simple `assert(0)`.

And also fixes following related issues:
- [Issue 14093](https://issues.dlang.org/show_bug.cgi?id=14093) - [REG2.065] __traits(compiles, cast(Object)(tuple)) is true even if it doesn't compile.
  
  It's reopened regression. Will be fixed properly.
- [Issue 14629 ](https://issues.dlang.org/show_bug.cgi?id=14629)\- Type system breaking and wrong code bugs in casting reference types to typeof(null)
  
  It's type system breaking and wrong-code issue. Currently a cast to typeof(null) from any other reference types sometimes returns a "non-zero null" pointer - it's just wrong. It should be disallowed.
