### PR TITLE
Remove LONGLONG

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -250,14 +250,6 @@ One and only one of these macros must be set by the makefile:
 #define STATEMENT_SCOPES CPP
 
 #if __GNUC__
-#define LONGLONG        1
-#elif __SC__ > 0 && __SC__ < 0x700
-#define LONGLONG        0
-#else
-#define LONGLONG        1               // add in code to support 64 bit integral types
-#endif
-
-#if __GNUC__
 #define LDOUBLE                 0       // no support for true long doubles
 #else
 #define LDOUBLE         (config.exe == EX_NT)   // support true long doubles
@@ -447,13 +439,8 @@ typedef short           targ_short;
 typedef unsigned short  targ_ushort;
 typedef int             targ_long;
 typedef unsigned        targ_ulong;
-#if LONGLONG
-typedef long long               targ_llong;
+typedef long long       targ_llong;
 typedef unsigned long long      targ_ullong;
-#else
-#define targ_llong      targ_long
-#define targ_ullong     targ_ulong
-#endif
 typedef float           targ_float;
 typedef double          targ_double;
 typedef longdouble      targ_ldouble;
@@ -545,17 +532,10 @@ typedef targ_uns        targ_size_t;    /* size_t for the target machine */
 #define LONGMASK        0xFFFFFFFF
 
 /* Common constants often checked for */
-#if LONGLONG
 #define LLONGMASK       0xFFFFFFFFFFFFFFFFLL
 #define ZEROLL          0LL
 #define MINLL           0x8000000000000000LL
 #define MAXLL           0x7FFFFFFFFFFFFFFFLL
-#else
-#define LLONGMASK       0xFFFFFFFFLL
-#define ZEROLL          0L
-#define MINLL           0x80000000
-#define MAXLL           0x7FFFFFFF
-#endif
 
 #define Smodel 0        /* 64k code, 64k data, or flat model           */
 

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -3504,13 +3504,11 @@ STATIC elem * eleq(elem *e, goal_t goal)
                     es->EV.Vlong = 0x80000000;
                     break;
                 case DOUBLESIZE:
-#if LONGLONG
                     if (I32)
                     {   ty = TYllong;
                         es->EV.Vllong = 0x8000000000000000LL;
                         break;
                     }
-#endif
                 default:
                     el_free(es);
                     goto L8;

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -3944,10 +3944,8 @@ code *params(elem *e,unsigned stackalign)
         else if (I16 && (tym == TYdouble || tym == TYdouble_alias))
             retregs = mSTACK;
   }
-#if LONGLONG
   else if (I16 && sz == 8)             // if long long
         retregs = mSTACK;
-#endif
   c = cat(c,scodelem(e,&retregs,0,TRUE));
   if (retregs != mSTACK)                /* if stackpush not already inc'd */
       stackpush += sz;

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1218,11 +1218,7 @@ void doswitch(block *b)
     code *c;
     code *ce = NULL;
 
-#if LONGLONG
     targ_ulong msw;
-#else
-    unsigned msw;
-#endif
 
 #if TARGET_SEGMENTED
     // If switch tables are in code segment and we need a CS: override to get at them

--- a/src/backend/cppman.c
+++ b/src/backend/cppman.c
@@ -354,10 +354,8 @@ char *cpp_typetostring(type *t,char *prefix)
             case TYshort:       c2 = 's';       break;
             case TYuint:        c1 = 'U';
             case TYint:         c2 = 'i';       break;
-#if LONGLONG && __INTSIZE == 4 // DJB
             case TYullong:      c1 = 'U';
             case TYllong:       c2 = 'x';       break;
-#endif
             case TYulong:       c1 = 'U';
             case TYlong:        c2 = 'l';       break;
 #if M_UNIX

--- a/src/backend/el.h
+++ b/src/backend/el.h
@@ -142,13 +142,8 @@ elem_p el_scancommas(elem_p);
 int el_countCommas(elem_p);
 int el_sideeffect(elem_p);
 int el_depends(elem *ea,elem *eb);
-#if LONGLONG
 targ_llong el_tolongt(elem_p);
 targ_llong el_tolong(elem_p);
-#else
-targ_long el_tolongt(elem_p);
-targ_long el_tolong(elem_p);
-#endif
 int el_allbits(elem_p,int);
 int el_signx32(elem_p);
 targ_ldouble el_toldouble(elem_p);
@@ -167,11 +162,7 @@ elem_p el_bint(unsigned,type *,elem_p ,elem_p);
 elem_p el_unat(unsigned,type *,elem_p);
 elem_p el_bin(unsigned,tym_t,elem_p ,elem_p);
 elem_p el_una(unsigned,tym_t,elem_p);
-#if LONGLONG    // DJB
 elem_p el_longt(type *,targ_llong);
-#else
-elem_p el_longt(type *,targ_long);
-#endif
 symbol *el_alloc_localgot();
 elem_p el_var(symbol *);
 elem_p el_settype(elem_p ,type *);
@@ -182,11 +173,7 @@ elem * el_ptr_offset(symbol *s,targ_size_t offset);
 void el_replacesym(elem *,symbol *,symbol *);
 elem_p el_nelems(type *);
 
-#if LONGLONG
 elem_p el_long(tym_t,targ_llong);
-#else
-elem_p el_long(tym_t,targ_long);
-#endif
 
 int ERTOL(elem_p);
 int el_noreturn(elem_p);

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1036,7 +1036,6 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPs8_16:   case OP16_8:
         case OPd_u32:   case OPu32_d:
 
-#if LONGLONG
         case OPs32_64:  case OPu32_64:
         case OP64_32:
         case OPd_s64:   case OPd_u64:
@@ -1045,7 +1044,7 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OP128_64:
         case OPs64_128:
         case OPu64_128:
-#endif
+
         case OPabs:
         case OPrndtol:
         case OPrint:
@@ -2857,11 +2856,7 @@ STATIC void elimbasivs(loop *l)
                 // then we can't do it
                 if (fl->c1->Eoper == OPconst)
                 {
-#if LONGLONG
                     targ_llong c1;
-#else
-                    targ_long c1;
-#endif
                     int sz;
 
                     c1 = el_tolong(fl->c1);
@@ -2879,14 +2874,12 @@ STATIC void elimbasivs(loop *l)
                          c1 & ~0x7FFFFFFFL)
                        )
                         continue;
-#if LONGLONG && __INTSIZE >= 4
                     if (sz == LLONGSIZE &&
                         ((ref->E2->Eoper == OPconst &&
                         c1 * el_tolong(ref->E2) & ~0x7FFFFFFFFFFFFFFFLL) ||
                          c1 & ~0x7FFFFFFFFFFFFFFFLL)
                        )
                         continue;
-#endif
                 }
 
                 /* If loop started out with a signed conditional that was

--- a/src/backend/token.h
+++ b/src/backend/token.h
@@ -261,11 +261,7 @@ struct token_t
         int pragma;             // TKpragma: PRxxxx, pragma number
                                 // -1 if unrecognized pragma
         targ_long Vlong;        /* integer when TKnum           */
-#if LONGLONG
         targ_llong Vllong;
-#else
-#define Vllong Vlong
-#endif
         targ_float Vfloat;
         targ_double Vdouble;
         targ_ldouble Vldouble;


### PR DESCRIPTION
This dates back to when ZTC++ was a 16 bit executable.
