### PR TITLE
Do not parse unittest blocks unless -unittest

### DIFF
--- a/test/compilable/testheader1.d
+++ b/test/compilable/testheader1.d
@@ -1,5 +1,5 @@
 // EXTRA_SOURCES: extra-files/header1.d
-// REQUIRED_ARGS: -o- -H -Hf${RESULTS_DIR}/compilable/header1.di
+// REQUIRED_ARGS: -o- -unittest -H -Hf${RESULTS_DIR}/compilable/header1.di
 // PERMUTE_ARGS: -d -dw
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh header1
 

--- a/test/fail_compilation/fail14249.d
+++ b/test/fail_compilation/fail14249.d
@@ -1,4 +1,5 @@
 /*
+REQUIRED_ARGS: -unittest
 TEST_OUTPUT:
 ---
 fail_compilation/fail14249.d(23): Error: shared static constructor can only be member of module/aggregate/template, not function main
@@ -17,7 +18,6 @@ fail_compilation/fail14249.d(35): Error: anonymous union can only be a part of a
 fail_compilation/fail14249.d(39): Error: mixin fail14249.main.Mix!() error instantiating
 ---
 */
-
 mixin template Mix()
 {
     shared static this() {}

--- a/test/fail_compilation/fail4375t.d
+++ b/test/fail_compilation/fail4375t.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -w
+// REQUIRED_ARGS: -w -unittest
 // 4375: Dangling else
 
 unittest {  // disallowed


### PR DESCRIPTION
This doesn't really speed things up, but it does reduce the memory allocated for all those unittest ASTs.
