### PR TITLE
Issue 14612 - typeid(interface) returns TypeInfo_Class object

### DIFF
--- a/src/dclass.d
+++ b/src/dclass.d
@@ -215,6 +215,7 @@ public:
     BaseClasses* vtblInterfaces;
 
     // the ClassInfo object for this ClassDeclaration
+    // Note: finally we can remove this.
     TypeInfoClassDeclaration vclassinfo;
 
     bool com;           // true if this is a COM class (meaning it derives from IUnknown)
@@ -362,6 +363,12 @@ public:
                         error("%s", msg);
                     Type.typeinfovector = this;
                 }
+            }
+            if (id == Id.ClassInfo)
+            {
+                if (!inObject)
+                    error("%s", msg);
+                Type.cdClassInfo = this;
             }
 
             if (id == Id.Object)

--- a/src/expression.d
+++ b/src/expression.d
@@ -7263,9 +7263,10 @@ public:
         {
             /* Get the dynamic type, which is .classinfo
              */
+            auto tc = cast(TypeClass)ta.toBasetype();
             ea = ea.semantic(sc);
             e = new TypeidExp(ea.loc, ea);
-            e.type = Type.typeinfoclass.type;
+            e.type = getTypeInfoType(tc.sym.type, sc);  // TypeInfo_(Class|Interface)
         }
         else if (ta.ty == Terror)
         {

--- a/src/expression.d
+++ b/src/expression.d
@@ -7266,7 +7266,9 @@ public:
             auto tc = cast(TypeClass)ta.toBasetype();
             ea = ea.semantic(sc);
             e = new TypeidExp(ea.loc, ea);
-            e.type = getTypeInfoType(tc.sym.type, sc);  // TypeInfo_(Class|Interface)
+            e.type = Type.cdClassInfo
+                ? getTypeInfoType(tc.sym.type, sc)  // TypeInfo_(Class|Interface)
+                : Type.typeinfoclass.type;          // TypeInfo_Class
         }
         else if (ta.ty == Terror)
         {

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -52,6 +52,7 @@ import ddmd.root.stringtable;
 import ddmd.sideeffect;
 import ddmd.target;
 import ddmd.tokens;
+import ddmd.typinf;
 import ddmd.visitor;
 
 enum LOGDOTEXP = 0;         // log ::dotExp()
@@ -9003,16 +9004,14 @@ public:
 
             if (ident == Id.classinfo)
             {
-                assert(Type.typeinfoclass);
-                Type t = Type.typeinfoclass.type;
+                Type t = getTypeInfoType(sym.type, sc); // TypeInfo_(Class|Interface)
                 if (e.op == TOKtype || e.op == TOKdottype)
                 {
                     /* For type.classinfo, we know the classinfo
                      * at compile time.
                      */
-                    if (!sym.vclassinfo)
-                        sym.vclassinfo = new TypeInfoClassDeclaration(sym.type);
-                    e = new VarExp(e.loc, sym.vclassinfo);
+                    assert(sym.type.vtinfo);
+                    e = new VarExp(e.loc, sym.type.vtinfo);
                     e = e.addressOf();
                     e.type = t; // do this so we don't get redundant dereference
                 }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -221,6 +221,7 @@ public:
     static ClassDeclaration *typeinfoinvariant;
     static ClassDeclaration *typeinfoshared;
     static ClassDeclaration *typeinfowild;
+    static ClassDeclaration *cdClassInfo;
 
     static TemplateDeclaration *rtinfo;
 

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -271,9 +271,16 @@ Symbol *toSymbol(Dsymbol *s)
         void visit(TypeInfoInterfaceDeclaration *ticd)
         {
             //printf("TypeInfoInterfaceDeclaration::toSymbol(%s), linkage = %d\n", ticd->toChars(), ticd->linkage);
-            assert(ticd->tinfo->ty == Tclass);
-            TypeClass *tc = (TypeClass *)ticd->tinfo;
-            tc->sym->accept(this);
+            if (Type::cdClassInfo)
+            {
+                assert(ticd->tinfo->ty == Tclass);
+                TypeClass *tc = (TypeClass *)ticd->tinfo;
+                tc->sym->accept(this);
+            }
+            else
+            {
+                visit((TypeInfoDeclaration *)ticd);
+            }
         }
 
         void visit(FuncAliasDeclaration *fad)

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -268,6 +268,14 @@ Symbol *toSymbol(Dsymbol *s)
             tc->sym->accept(this);
         }
 
+        void visit(TypeInfoInterfaceDeclaration *ticd)
+        {
+            //printf("TypeInfoInterfaceDeclaration::toSymbol(%s), linkage = %d\n", ticd->toChars(), ticd->linkage);
+            assert(ticd->tinfo->ty == Tclass);
+            TypeClass *tc = (TypeClass *)ticd->tinfo;
+            tc->sym->accept(this);
+        }
+
         void visit(FuncAliasDeclaration *fad)
         {
             fad->funcalias->accept(this);

--- a/src/todt.d
+++ b/src/todt.d
@@ -1378,21 +1378,7 @@ extern (C++) class TypeInfoDtVisitor : Visitor
 
     override void visit(TypeInfoInterfaceDeclaration d)
     {
-        //printf("TypeInfoInterfaceDeclaration.toDt() %s\n", tinfo.toChars());
-        verifyStructSize(Type.typeinfointerface, 3 * Target.ptrsize);
-
-        dtb.xoff(toVtblSymbol(Type.typeinfointerface), 0);    // vtbl for TypeInfoInterface
-        dtb.size(0);                                           // monitor
-
-        assert(d.tinfo.ty == Tclass);
-
-        TypeClass tc = cast(TypeClass)d.tinfo;
-        Symbol *s;
-
-        if (!tc.sym.vclassinfo)
-            tc.sym.vclassinfo = TypeInfoClassDeclaration.create(tc);
-        s = toSymbol(tc.sym.vclassinfo);
-        dtb.xoff(s, 0);    // ClassInfo for tinfo
+        assert(0);
     }
 
     override void visit(TypeInfoTupleDeclaration d)

--- a/src/todt.d
+++ b/src/todt.d
@@ -1378,7 +1378,28 @@ extern (C++) class TypeInfoDtVisitor : Visitor
 
     override void visit(TypeInfoInterfaceDeclaration d)
     {
-        assert(0);
+        if (Type.cdClassInfo)
+        {
+            assert(0);
+        }
+        else
+        {
+            //printf("TypeInfoInterfaceDeclaration.toDt() %s\n", tinfo.toChars());
+            verifyStructSize(Type.typeinfointerface, 3 * Target.ptrsize);
+
+            dtb.xoff(toVtblSymbol(Type.typeinfointerface), 0);  // vtbl for TypeInfoInterface
+            dtb.size(0);                                        // monitor
+
+            assert(d.tinfo.ty == Tclass);
+
+            TypeClass tc = cast(TypeClass)d.tinfo;
+            Symbol *s;
+
+            if (!tc.sym.vclassinfo)
+                tc.sym.vclassinfo = TypeInfoClassDeclaration.create(tc);
+            s = toSymbol(tc.sym.vclassinfo);
+            dtb.xoff(s, 0);    // ClassInfo for tinfo
+        }
     }
 
     override void visit(TypeInfoTupleDeclaration d)

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -1116,8 +1116,11 @@ void testTypeid()
     assert(typeid(o) is typeid(D));
     assert(o.classinfo is typeid(D));
     assert(typeid(typeof(i)) is typeid(I));
-    assert(typeid(i) !is typeid(J));
-    assert(i.classinfo !is typeid(J));
+    assert(typeid(i) is typeid(J));                             // Bugzilla 14612
+    assert(i.classinfo is typeid(J));                           // Bugzilla 14612
+
+    static assert(is(typeof(typeid(o)) == TypeInfo_Class));
+    static assert(is(typeof(typeid(i)) == TypeInfo_Interface)); // Bugzilla 14612
 }
 
 /*******************************************************/

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -1116,11 +1116,19 @@ void testTypeid()
     assert(typeid(o) is typeid(D));
     assert(o.classinfo is typeid(D));
     assert(typeid(typeof(i)) is typeid(I));
-    assert(typeid(i) is typeid(J));                             // Bugzilla 14612
-    assert(i.classinfo is typeid(J));                           // Bugzilla 14612
+    static if (is(TypeInfo_Interface : ClassInfo))
+    {
+        assert(typeid(i) is typeid(J));                             // Bugzilla 14612
+        assert(i.classinfo is typeid(J));                           // Bugzilla 14612
 
-    static assert(is(typeof(typeid(o)) == TypeInfo_Class));
-    static assert(is(typeof(typeid(i)) == TypeInfo_Interface)); // Bugzilla 14612
+        static assert(is(typeof(typeid(o)) == TypeInfo_Class));
+        static assert(is(typeof(typeid(i)) == TypeInfo_Interface)); // Bugzilla 14612
+    }
+    else
+    {
+        assert(typeid(i) !is typeid(J));
+        assert(i.classinfo !is typeid(J));
+    }
 }
 
 /*******************************************************/


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14612

Change the type of `typeid(interface_obj)` to TypeInfo_Interface, and fix TypeInfo object generation to support new TypeInfo hierarchy.

Requires corresponding druntime change: https://github.com/D-Programming-Language/druntime/pull/1295
Unfortunately, we need to fix compiler and druntime code at the same time.
