### PR TITLE
DIP56: add pragma(inline)

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -37,7 +37,7 @@ public:
     int apply(Dsymbol_apply_ft_t fp, void *param);
     static Scope *createNewScope(Scope *sc,
         StorageClass newstc, LINK linkage, Prot protection, int explictProtection,
-        structalign_t structalign);
+        structalign_t structalign, PINLINE inlining);
     virtual Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
@@ -147,7 +147,7 @@ public:
     PragmaDeclaration(Loc loc, Identifier *ident, Expressions *args, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);
-    void setScope(Scope *sc);
+    Scope *newScope(Scope *sc);
     const char *kind();
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2014 by Digital Mars
+ * Copyright (c) 1999-2015 by Digital Mars
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com
@@ -35,6 +35,7 @@ enum LINK;
 enum TOK;
 enum MATCH;
 enum PURE;
+enum PINLINE;
 
 #define STCundefined    0LL
 #define STCstatic       1LL
@@ -537,6 +538,7 @@ public:
     bool naked;                         // true if naked
     ILS inlineStatusStmt;
     ILS inlineStatusExp;
+    PINLINE inlining;
 
     CompiledCtfeFunction *ctfeCode;     // Compiled code for interpreter
     int inlineNest;                     // !=0 if nested inline

--- a/src/func.c
+++ b/src/func.c
@@ -311,6 +311,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     naked = false;
     inlineStatusExp = ILSuninitialized;
     inlineStatusStmt = ILSuninitialized;
+    inlining = PINLINEdefault;
     inlineNest = 0;
     ctfeCode = NULL;
     isArrayOp = 0;
@@ -425,6 +426,7 @@ void FuncDeclaration::semantic(Scope *sc)
     }
     else
         linkage = sc->linkage;
+    inlining = sc->inlining;
     protection = sc->protection;
     userAttribDecl = sc->userAttribDecl;
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -292,6 +292,13 @@ enum MATCH
     MATCHexact          // exact match
 };
 
+enum PINLINE
+{
+    PINLINEdefault,      // as specified on the command line
+    PINLINEnever,        // never inline
+    PINLINEalways        // always inline
+};
+
 typedef uinteger_t StorageClass;
 
 #endif /* DMD_GLOBALS_H */

--- a/src/idgen.d
+++ b/src/idgen.d
@@ -267,10 +267,11 @@ Msgtable[] msgtable =
     { "_ArrayEq" },
 
     // For pragma's
+    { "Pinline", "inline" },
     { "lib" },
+    { "mangle" },
     { "msg" },
     { "startaddress" },
-    { "mangle" },
 
     // For special functions
     { "tohash", "toHash" },

--- a/src/inline.c
+++ b/src/inline.c
@@ -1689,6 +1689,20 @@ bool canInline(FuncDeclaration *fd, int hasthis, int hdrscan, int statementsToo)
             assert(0);
     }
 
+    switch (fd->inlining)
+    {
+        case PINLINEdefault:
+            break;
+
+        case PINLINEalways:
+            break;
+
+        case PINLINEnever:
+            return false;
+        default:
+            assert(0);
+    }
+
     if (fd->type)
     {
         assert(fd->type->ty == Tfunction);
@@ -1786,6 +1800,9 @@ bool canInline(FuncDeclaration *fd, int hasthis, int hdrscan, int statementsToo)
     return true;
 
 Lno:
+    if (fd->inlining == PINLINEalways)
+        fd->error("cannot inline function");
+
     if (!hdrscan)    // Don't modify inlineStatus for header content scan
     {
         if (statementsToo)

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -2093,6 +2093,7 @@
                 "id",
                 "identifier",
                 "dinterpret",
+                "mtype",
                 "tokens",
                 "globals",
                 "mars",
@@ -2609,6 +2610,7 @@
                 "enum LINK",
                 "enum DYNCAST",
                 "enum MATCH",
+                "enum PINLINE",
                 "typedef StorageClass",
                 "variable global"
             ]
@@ -3287,6 +3289,7 @@
         "OwnedBy",
 
         "LINK",
+        "PINLINE",
         "PREC",
         "BUILTIN",
         "PASS",

--- a/src/scope.c
+++ b/src/scope.c
@@ -70,6 +70,7 @@ Scope::Scope()
     this->func = NULL;
     this->slabel = NULL;
     this->linkage = LINKd;
+    this->inlining = PINLINEdefault;
     this->protection = Prot(PROTpublic);
     this->explicitProtection = 0;
     this->stc = 0;
@@ -108,6 +109,7 @@ Scope *Scope::createGlobal(Module *module)
 
     sc->structalign = STRUCTALIGN_DEFAULT;
     sc->linkage = LINKd;
+    sc->inlining = PINLINEdefault;
     sc->protection = Prot(PROTpublic);
 
     sc->module = module;

--- a/src/scope.h
+++ b/src/scope.h
@@ -40,6 +40,7 @@ class TemplateInstance;
 #include "mars.h"
 #else
 enum LINK;
+enum PINLINE;
 #endif
 
 #define CSXthis_ctor    1       // called this()
@@ -104,10 +105,11 @@ struct Scope
     unsigned *fieldinit;
     size_t fieldinit_dim;
 
-    structalign_t structalign;       // alignment for struct members
-    LINK linkage;          // linkage for external functions
+    structalign_t structalign;  // alignment for struct members
+    LINK linkage;               // linkage for external functions
+    PINLINE inlining;            // inlining strategy for functions
 
-    Prot protection;       // protection for class members
+    Prot protection;            // protection for class members
     int explicitProtection;     // set if in an explicit protection attribute
 
     StorageClass stc;           // storage class

--- a/src/statement.c
+++ b/src/statement.c
@@ -3206,6 +3206,40 @@ Statement *PragmaStatement::semantic(Scope *sc)
             return this;
         }
     }
+    else if (ident == Id::Pinline)
+    {
+        PINLINE inlining = PINLINEdefault;
+        if (!args || args->dim == 0)
+            inlining = PINLINEdefault;
+        else if (!args || args->dim != 1)
+        {
+            error("boolean expression expected for pragma(inline)");
+            goto Lerror;
+        }
+        else
+        {
+            Expression *e = (*args)[0];
+
+            if (e->op != TOKint64 || !e->type->equals(Type::tbool))
+            {
+                error("pragma(inline, true or false) expected, not %s", e->toChars());
+                goto Lerror;
+            }
+
+            if (e->isBool(true))
+                inlining = PINLINEalways;
+            else if (e->isBool(false))
+                inlining = PINLINEnever;
+
+            FuncDeclaration *fd = sc->func;
+            if (!fd)
+            {
+                error("pragma(inline) is not inside a function");
+                goto Lerror;
+            }
+            fd->inlining = inlining;
+        }
+    }
     else
     {
         error("unrecognized pragma(%s)", ident->toChars());

--- a/test/fail_compilation/pragmainline.d
+++ b/test/fail_compilation/pragmainline.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/pragmainline.d(9): Error: pragma inline one boolean expression expected for pragma(inline), not 3
+fail_compilation/pragmainline.d(10): Error: pragma inline pragma(inline, true or false) expected, not "string"
+---
+*/
+
+pragma(inline, 1,2,3) void bar();
+pragma(inline, "string") void baz();
+

--- a/test/fail_compilation/pragmainline2.d
+++ b/test/fail_compilation/pragmainline2.d
@@ -1,0 +1,24 @@
+/*
+REQUIRED_ARGS: -inline
+TEST_OUTPUT:
+---
+fail_compilation/pragmainline2.d(12): Error: function pragmainline2.foo cannot inline function
+---
+*/
+
+pragma(inline, true):
+pragma(inline, false):
+pragma(inline)
+void foo()
+{
+    pragma(inline, false);
+    pragma(inline);
+    pragma(inline, true);
+    while (0) { }
+}
+
+void main()
+{
+    foo();
+}
+


### PR DESCRIPTION
http://wiki.dlang.org/DIP56

This makes the syntax valid, and will issue errors if forceinline'd functions cannot be inlined. It also implements neverinline, meaning the `while(0){}` hack is no longer needed.

Not implemented yet: inlining forceinline'd functions even if -inline is not present. I'll implement that later, as it's more complicated.
