### PR TITLE
add top level make files and auto-tester targets

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -2,10 +2,15 @@ INSTALL_DIR=$(PWD)/../install
 ECTAGS_LANGS = Make,C,C++,Sh
 ECTAGS_FILES = src/*.[ch] src/backend/*.[ch] src/root/*.[ch] src/tk/*.[ch]
 
-.PHONY: all clean test install
+.PHONY: all clean test install auto-tester-build auto-tester-test
 
 all:
 	$(QUIET)$(MAKE) -C src -f posix.mak
+
+auto-tester-build:
+	$(QUIET)$(MAKE) -C src -f posix.mak $<
+
+auto-tester-test: test
 
 clean:
 	$(QUIET)$(MAKE) -C src -f posix.mak clean

--- a/win32.mak
+++ b/win32.mak
@@ -1,0 +1,12 @@
+MAKE=make
+
+auto-tester-build:
+	cd src
+	$(MAKE) -f win32.mak auto-tester-build
+	cd ..
+
+auto-tester-test:
+	cd test
+	$(MAKE)
+	cd ..
+


### PR DESCRIPTION
There's already a posix.mak.  This adds a win32.mak.  Having a top level make file removes another of the oddities about the dmd package so that it more closely resembles what most people expect to find.

I haven't setup targets for the win32.mak beyond the two for the auto-tester.  I'm trying to avoid that debate for some other pull.
