### PR TITLE
Issue 14603 & 14604 - aliasing opDispatch result

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -157,6 +157,8 @@ extern (C++) Dsymbol getDsymbol(RootObject oarg)
             else
                 sa = (cast(FuncExp)ea).fd;
         }
+        else if (ea.op == TOKtemplate)
+            sa = (cast(TemplateExp)ea).td;
         else
             sa = null;
     }

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -7445,7 +7445,7 @@ public:
                 {
                     if (!td2.onemember || !td2.onemember.isFuncDeclaration())
                         return 0;
-                    if (tiargs.dim > td.parameters.dim && !td.isVariadic())
+                    if (tiargs.dim >= td.parameters.dim - (td.isVariadic() ? 1 : 0))
                         return 0;
                     return 1;
                 }

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7905,7 +7905,7 @@ public:
         if (td)
         {
             if (e.op == TOKtype)
-                e = new ScopeExp(e.loc, td);
+                e = new TemplateExp(e.loc, td);
             else
                 e = new DotTemplateExp(e.loc, e, td);
             e = e.semantic(sc);
@@ -8761,7 +8761,7 @@ public:
         if (td)
         {
             if (e.op == TOKtype)
-                e = new ScopeExp(e.loc, td);
+                e = new TemplateExp(e.loc, td);
             else
                 e = new DotTemplateExp(e.loc, e, td);
             e = e.semantic(sc);

--- a/test/fail_compilation/diag13942.d
+++ b/test/fail_compilation/diag13942.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag13942.d(18): Error: template instance isRawStaticArray!() does not match template declaration isRawStaticArray(T, A...)
-fail_compilation/diag13942.d(26): Error: template diag13942.to cannot deduce function from argument types !(double)(), candidates are:
-fail_compilation/diag13942.d(15):        diag13942.to(T)
+fail_compilation/diag13942.d(26): Error: template diag13942.to!double.to cannot deduce function from argument types !()(), candidates are:
+fail_compilation/diag13942.d(17):        diag13942.to!double.to(A...)(A args) if (!isRawStaticArray!A)
 ---
 */
 

--- a/test/fail_compilation/fail11125.d
+++ b/test/fail_compilation/fail11125.d
@@ -1,10 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11125.d(22): Error: template fail11125.filter cannot deduce function from argument types !(function (int a) => a + 1)(int[]), candidates are:
-fail_compilation/fail11125.d(13):        fail11125.filter(alias predfun) if (is(ReturnType!predfun == bool))
-fail_compilation/fail11125.d(23): Error: template fail11125.filter cannot deduce function from argument types !(function (int a) => a + 1)(int[]), candidates are:
-fail_compilation/fail11125.d(13):        fail11125.filter(alias predfun) if (is(ReturnType!predfun == bool))
+fail_compilation/fail11125.d(20): Error: template instance fail11125.filter!(function (int a) => a + 1) does not match template declaration filter(alias predfun) if (is(ReturnType!predfun == bool))
+fail_compilation/fail11125.d(21): Error: template instance fail11125.filter!(function (int a) => a + 1) does not match template declaration filter(alias predfun) if (is(ReturnType!predfun == bool))
 ---
 */
 

--- a/test/fail_compilation/fail267.d
+++ b/test/fail_compilation/fail267.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail267.d(15): Error: no property 'foo' for type 'void'
+fail_compilation/fail267.d(15): Error: template Bar() does not have property 'foo'
 ---
 */
 

--- a/test/fail_compilation/ice11553.d
+++ b/test/fail_compilation/ice11553.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11553.d(22): Error: recursive template expansion while looking for A!().A()
-fail_compilation/ice11553.d(22): Error: expression template A() of type void does not have a boolean value
+fail_compilation/ice11553.d(22): Error: expression A!(B) of type void does not have a boolean value
 ---
 */
 

--- a/test/fail_compilation/ice12841.d
+++ b/test/fail_compilation/ice12841.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12841.d(23): Error: taskPool().amap!"a.result()" is not an lvalue
-fail_compilation/ice12841.d(24): Error: amap!"a.result()" is not an lvalue
+fail_compilation/ice12841.d(23): Error: taskPool().amap(Args...)(Args args) is not an lvalue
+fail_compilation/ice12841.d(24): Error: amap(Args...)(Args args) is not an lvalue
 ---
 */
 

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -4609,6 +4609,19 @@ template SubOps14568(Args...)
 struct Nat14568 { mixin SubOps14568!(null); }
 
 /******************************************/
+// 14603
+
+struct S14603
+{
+    template opDispatch(string name)
+    {
+        void opDispatch()() {}
+    }
+}
+alias a14603 = S14603.opDispatch!"go";  // OK
+alias b14603 = S14603.go;               // OK <- NG
+
+/******************************************/
 // 14735
 
 enum CS14735 { yes, no }

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -4609,7 +4609,7 @@ template SubOps14568(Args...)
 struct Nat14568 { mixin SubOps14568!(null); }
 
 /******************************************/
-// 14603
+// 14603, 14604
 
 struct S14603
 {
@@ -4620,6 +4620,17 @@ struct S14603
 }
 alias a14603 = S14603.opDispatch!"go";  // OK
 alias b14603 = S14603.go;               // OK <- NG
+
+struct S14604
+{
+    template opDispatch(string name)
+    {
+        void opDispatch()() {}
+    }
+}
+alias Id14604(alias thing) = thing;
+alias c14604 = Id14604!(S14604.opDispatch!"go");     // ok
+alias d14604 = Id14604!(S14604.go);                  // issue 14604, 'Error: template instance opDispatch!"go" cannot resolve forward reference'
 
 /******************************************/
 // 14735


### PR DESCRIPTION
[Issue 14603](https://issues.dlang.org/show_bug.cgi?id=14603) - "cannot alias an expression" when opDispatch results in a template
[Issue 14604](https://issues.dlang.org/show_bug.cgi?id=14604) - "cannot resolve forward reference" when opDispatch results in a template

Fixes a root issue:
[Issue 15310](https://issues.dlang.org/show_bug.cgi?id=15310) - [dmd-internal] TemplateDeclaration should be converted to TemplateExp always
