### PR TITLE
[Enh 12270] - Step 1 - typeid() to return null if TypeInfo not found in runtime

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -697,9 +697,9 @@ elem *sarray_toDarray(Loc loc, Type *tfrom, Type *tto, elem *e)
 elem *getTypeInfo(Type *t, IRState *irs)
 {
     assert(t->ty != Terror);
-    
+
     elem *e;
-    
+
     if (Type::dtypeinfo)
     {
         genTypeInfo(t, NULL);
@@ -709,7 +709,7 @@ elem *getTypeInfo(Type *t, IRState *irs)
     {
         e = el_ptr(symbol_genauto(TYnptr));
     }
-    
+
     return e;
 }
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -697,8 +697,19 @@ elem *sarray_toDarray(Loc loc, Type *tfrom, Type *tto, elem *e)
 elem *getTypeInfo(Type *t, IRState *irs)
 {
     assert(t->ty != Terror);
-    genTypeInfo(t, NULL);
-    elem *e = el_ptr(toSymbol(t->vtinfo));
+    
+    elem *e;
+    
+    if (Type::dtypeinfo)
+    {
+        genTypeInfo(t, NULL);
+        e = el_ptr(toSymbol(t->vtinfo));
+    }
+    else
+    {
+        e = el_ptr(symbol_genauto(TYnptr));
+    }
+    
     return e;
 }
 

--- a/src/expression.c
+++ b/src/expression.c
@@ -6095,7 +6095,7 @@ Expression *TypeidExp::semantic(Scope *sc)
         ta->checkComplexTransition(loc);
 
     Expression *e;
-    if (ea && ta->toBasetype()->ty == Tclass)
+    if (ea && ta->toBasetype()->ty == Tclass && Type::typeinfoclass)
     {
         /* Get the dynamic type, which is .classinfo
          */
@@ -6111,7 +6111,7 @@ Expression *TypeidExp::semantic(Scope *sc)
     {
         // Handle this in the glue layer
         e = new TypeidExp(loc, ta);
-        e->type = getTypeInfoType(ta, sc);
+        e->type = Type::dtypeinfo ? getTypeInfoType(ta, sc) : Type::tnull;
         if (ea)
         {
             e = new CommaExp(loc, ea, e);       // execute ea

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -296,7 +296,10 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the TypeInfo
-            genTypeInfo(cd->type, NULL);
+            if (Type::typeinfoclass)
+            {
+                genTypeInfo(cd->type, NULL);
+            }
             //toObjFile(cd->type->vtinfo, multiobj);
 
             //////////////////////////////////////////////


### PR DESCRIPTION
This is my attempt to implement the first step towards implementing [Ehnancement 12270](https://issues.dlang.org/show_bug.cgi?id=12270).  I don't know really what I'm doing, but since noone else seems to be interested in this, I thought I'd give it a try.

**Motivation**
TypeInfo is blocking me from making progress in my attempt to program resource constrained embedded systems.  Due to [GDC Bug 184](http://bugzilla.gdcproject.org/show_bug.cgi?id=184) which I believe may be inherited from DMD, I can't produce efficient binaries.  In fact, they are so bloated with `TypeInfo.name`, I can't even load the binary on some of my smaller devices.  Even with GDC Bug 184 resolved, I'm still required to write quite a few `TypeInfo` stubs just to get a build, which is most undesirable.  I've resorted to ineffective sed hacks and other workarounds, but I'm losing patience.

There has been some recent work in [DMD](https://github.com/D-Programming-Language/dmd/pull/4654) and [GDC](https://github.com/D-Programming-GDC/GDC/pull/100) to introduce a -nortti option.  While that is most welcome, it forces me to compromise on slicing and postbit, so I think it is too blunt of an instrument.  I believe 12270 offers a better solution, and it is my hope for this to be the first step towards getting it implemented.
