### PR TITLE
Issue 12487 - DMD correctly reports excessive CTFE recursion, but not template recursion

### DIFF
--- a/test/fail_compilation/diag12487.d
+++ b/test/fail_compilation/diag12487.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag12487.d(15): Error: recursive expansion of template instance 'diag12487.recTemplate!int'
+fail_compilation/diag12487.d(25): Error: template instance diag12487.recTemplate!int error instantiating
+fail_compilation/diag12487.d(18): Error: function diag12487.recFunction CTFE recursion limit exceeded
+fail_compilation/diag12487.d(20):        called from here: recFunction(i)
+fail_compilation/diag12487.d(18):        1000 recursive calls to function recFunction
+fail_compilation/diag12487.d(27):        called from here: recFunction(0)
+---
+*/
+
+template recTemplate(T)
+{
+    enum bool recTemplate = recTemplate!T;
+}
+
+bool recFunction(int i)
+{
+    return recFunction(i);
+}
+
+void main()
+{
+    enum bool value1 = recTemplate!int;
+
+    enum bool value2 = recFunction(0);
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12487

When an instance that will be converted to a constant exists, the instance representation "foo!tiargs" is treated like a variable name, and its recursive appearance check (note that it's equivalent with a recursive instantiation of foo) is done separately from the recursive definition check for the eponymous enum variable declaration.

By the approach, we can remove problematic `global.gag` check in `DsymbolExp::semantic()` without breaking `fail_compilation/diag10141.d`.
