### PR TITLE
[dwarf] Bump default debug version to DWARF3

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -1446,11 +1446,7 @@ void cv_outsym(symbol *s)
                     ElfObj::addrel(infoseg, infobuf->size(), R_386_TLS_LDO_32, s->Sxtrnnum, 0);
                     infobuf->write32(0);
                 }
-            #if (DWARF_VERSION <= 2)
                 infobuf->writeByte(DW_OP_GNU_push_tls_address);
-            #else
-                infobuf->writeByte(DW_OP_form_tls_address);
-            #endif
             } else
 #endif
             {

--- a/src/backend/dwarf.h
+++ b/src/backend/dwarf.h
@@ -5,7 +5,7 @@
 /* ==================== Dwarf debug ======================= */
 
 // #define USE_DWARF_D_EXTENSIONS
-#define DWARF_VERSION 2
+#define DWARF_VERSION 3
 
 void dwarf_initfile(const char *filename);
 void dwarf_termfile();


### PR DESCRIPTION
DMD is actually emitting DWARF3 attributes in debug code today, so might as well update it here for clarity.

List of tags I found in dwarf.c that are not available in DWARF2 specification
- DW_CFA_def_cfa_sf
- DW_CFA_def_cfa_offset_sf
- DW_CFA_offset_extended_sf
- DW_AT_entry_pc
- DW_AT_ranges
- DW_ATE_imaginary_float
