### PR TITLE
[D1] Accept `static struct` at statement context

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2325,7 +2325,7 @@ Dsymbols *Parser::parseDeclarations()
         return a;
     }
 
-    if (token.value == TOKclass)
+    if (token.value == TOKclass || token.value == TOKstruct)
     {   AggregateDeclaration *s;
 
         s = (AggregateDeclaration *)parseAggregate();


### PR DESCRIPTION
Allows for compatibility with D2 where adding `static` is necessary
to get rid of context pointer.
