### PR TITLE
[Enhancement] Issue 14681 - Add a way to specify a file import's contents on the command line

### DIFF
--- a/src/expression.c
+++ b/src/expression.c
@@ -6961,6 +6961,25 @@ Expression *FileExp::semantic(Scope *sc)
     se = se->toUTF8(sc);
     name = (char *)se->string;
 
+    if (name[0] == ':')
+    {
+        if (global.params.importStringKeys)
+        {
+            for (size_t i = 0; i < global.params.importStringKeys->dim; i++)
+            {
+                if (!strcmp((*global.params.importStringKeys)[i], name+1))
+                {
+                    const char *str = (*global.params.importStringValues)[i];
+                    se = new StringExp(loc, (char *)str, strlen(str));
+                    return se->semantic(sc);
+                }
+            }
+        }
+
+        error("key '%s' not specified on the command line", name+1);
+        goto Lerror;
+    }
+
     if (!global.params.fileImppath)
     {   error("need -Jpath switch to import text file %s", name);
         goto Lerror;

--- a/src/globals.h
+++ b/src/globals.h
@@ -96,6 +96,8 @@ struct Param
     const char *argv0;    // program name
     Array<const char *> *imppath;     // array of char*'s of where to look for import modules
     Array<const char *> *fileImppath; // array of char*'s of where to look for file import modules
+    Array<const char *> *importStringKeys;   // array of keys for -J:key=value
+    Array<const char *> *importStringValues; // array of values for -J:key=value
     const char *objdir;   // .obj/.lib file output directory
     const char *objname;  // .obj file output name
     const char *libname;  // .lib file output name

--- a/src/mars.c
+++ b/src/mars.c
@@ -858,9 +858,52 @@ Language changes listed by -transition=id:\n\
             }
             else if (p[1] == 'J')
             {
-                if (!global.params.fileImppath)
-                    global.params.fileImppath = new Strings();
-                global.params.fileImppath->push(p + 2);
+                if (p[2] == ':')
+                {
+                    char *key = mem.xstrdup(p+3);
+                    if (*key == '=' || !*key)
+                    {
+                        error(Loc(), "-J:key=value cannot have an empty key");
+                        break;
+                    }
+                    char *value = key + 1;
+                    while (*value && *value != '=')
+                        value++;
+                    if (*value == '=')
+                    {
+                        *value = 0;
+                        value++;
+                    }
+                    if (!Lexer::isValidIdentifier(key))
+                    {
+                        error(Loc(), "key for -J:key=value must be a valid identifier");
+                        break;
+                    }
+                    if (!global.params.importStringKeys)
+                    {
+                        global.params.importStringKeys = new Strings();
+                        global.params.importStringValues = new Strings();
+                    }
+                    else
+                    {
+                        for (size_t i = 0; i < global.params.importStringKeys->dim; i++)
+                        {
+                            if (!strcmp((*global.params.importStringKeys)[i], key))
+                            {
+                                error(Loc(), "-J:%s specified multiple times", key);
+                                break;
+                            }
+                        }
+                    }
+                    global.params.importStringKeys->push(key);
+                    global.params.importStringValues->push(value);
+                }
+                else
+                {
+                    if (!global.params.fileImppath)
+                        global.params.fileImppath = new Strings();
+                    global.params.fileImppath->push(p + 2);
+                }
             }
             else if (memcmp(p + 1, "debug", 5) == 0 && p[6] != 'l')
             {

--- a/test/compilable/test14681.d
+++ b/test/compilable/test14681.d
@@ -1,0 +1,9 @@
+// REQUIRED_ARGS: -J:hello=world -J:x= "-J:string=some thing"
+
+static assert(import(":hello") == "world");
+static assert(import(":x") == "");
+static assert(import(":string") == "some thing");
+
+void main()
+{
+}


### PR DESCRIPTION
C/C++ compilers generally have the ability to set preprocessor symbols from the command line.  While dmd's -version=ident covers most use cases, it is sometimes useful to set the symbol to a specific value and access this inside the program.

eg -DVERSION=3

With DMD this can be done by creating a file and using -J/import(), but there is no way to set the value directly on the command line.

My proposed syntax to extend -J/import() to allow setting a value:
dmd -J:key=value main.d

Then in the program the import() syntax is used to retrieve the value:
static assert(import(":key") == "value");

The ':' prefix allows the compiler to tell apart import paths and key/value pairs.

https://issues.dlang.org/show_bug.cgi?id=14681
