### PR TITLE
[dwarf] Emit all symbols as children of the given module

### DIFF
--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -757,13 +757,13 @@ int dwarf_line_addfile(const char* filename)
 
 void dwarf_initmodule(const char *filename, const char *modname)
 {
+#if (DWARF_VERSION >= 3)
     if (modname)
     {
         static unsigned char abbrevModule[] =
         {
             DW_TAG_module,
-            //1,                // one children
-            0,                  // no children
+            1,                // one children
             DW_AT_name,         DW_FORM_string, // module name
             0,                  0,
         };
@@ -772,9 +772,10 @@ void dwarf_initmodule(const char *filename, const char *modname)
         abbrevbuf->write(abbrevModule,sizeof(abbrevModule));
         infobuf->writeuLEB128(abbrevcode);      // abbreviation code
         infobuf->writeString(modname);          // DW_AT_name
-        //hasModname = 1;
+        hasModname = 1;
     }
     else
+#endif
         hasModname = 0;
 
     dwarf_line_addfile(filename);
@@ -1411,6 +1412,7 @@ void cv_outsym(symbol *s)
     unsigned code;
     unsigned typidx;
     unsigned soffset;
+    const char *name;
     switch (s->Sclass)
     {
         case SCglobal:
@@ -1426,7 +1428,12 @@ void cv_outsym(symbol *s)
             code = dwarf_abbrev_code(abuf.buf, abuf.size());
 
             infobuf->writeuLEB128(code);        // abbreviation code
+#if MARS
+            name = s->prettyIdent ? s->prettyIdent : s->Sident;
+            infobuf->writeString(name);         // DW_AT_name
+#else
             infobuf->writeString(s->Sident);    // DW_AT_name
+#endif
             infobuf->write32(typidx);           // DW_AT_type
             infobuf->writeByte(1);              // DW_AT_external
 

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -186,12 +186,17 @@ Symbol *toSymbol(Dsymbol *s)
                     s->Sclass = SCextern;
                     s->Sfl = FLextern;
                     slist_add(s);
-                    /* if it's global or static, then it needs to have a qualified but unmangled name.
-                     * This gives some explanation of the separation in treating name mangling.
-                     * It applies to PDB format, but should apply to CV as PDB derives from CV.
-                     *    http://msdn.microsoft.com/en-us/library/ff553493(VS.85).aspx
-                     */
-                    s->prettyIdent = vd->toPrettyChars(true);
+                    if (global.params.isWindows)
+                    {
+                        /* if it's global or static, then it needs to have a qualified but unmangled name.
+                         * This gives some explanation of the separation in treating name mangling.
+                         * It applies to PDB format, but should apply to CV as PDB derives from CV.
+                         *    http://msdn.microsoft.com/en-us/library/ff553493(VS.85).aspx
+                         */
+                        s->prettyIdent = vd->toPrettyChars(true);
+                    }
+                    else
+                        s->prettyIdent = vd->toChars();
                 }
                 else
                 {
@@ -285,7 +290,10 @@ Symbol *toSymbol(Dsymbol *s)
                 Symbol *s = symbol_calloc(id);
                 slist_add(s);
 
-                s->prettyIdent = fd->toPrettyChars(true);
+                if (global.params.isWindows)
+                    s->prettyIdent = fd->toPrettyChars(true);
+                else
+                    s->prettyIdent = fd->toChars();
                 s->Sclass = SCglobal;
                 symbol_func(s);
                 func_t *f = s->Sfunc;


### PR DESCRIPTION
This allows gdb to correctly build a scope map of all modules, which can be used in conjunction with the D-specific name lookup routines in my fork (works by looking up the current enclosed module, and then seeing if the given name is part of it).

Though perhaps this shouldn't be merged until gdb catches up.
Also, will need to emit struct/class/enum names in the same way.

@MartinNowak - FYI, this implements half of my propsosal  (the other half is implementing `DW_TAG_imported_declaration`)
