### PR TITLE
Issue 14703 - el.c is missing simd vectors

### DIFF
--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -2588,7 +2588,19 @@ L1:
                         if (memcmp(&n1->EV,&n2->EV,sizeof(n1->EV.Vcdouble)))
                             goto nomatch;
                         break;
-
+                    case TYfloat4:
+                    case TYdouble2:
+                    case TYschar16:
+                    case TYuchar16:
+                    case TYshort8:
+                    case TYushort8:
+                    case TYlong4:
+                    case TYulong4:
+                    case TYllong2:
+                    case TYullong2:
+                        if(n1->EV.Vcent.msw != n2->EV.Vcent.msw || n1->EV.Vcent.lsw != n2->EV.Vcent.lsw)
+			                goto nomatch;
+			            break;
                     case TYcldouble:
 #if LNGDBLSIZE > 10
                         /* sizeof is 12, but actual size of each part is 10 */


### PR DESCRIPTION
This fixes the simd vector optimization in release builds by adding the comparison operation for the corresponding types.

https://issues.dlang.org/show_bug.cgi?id=14703
