### PR TITLE
WIP [dwarf] Emit all imported modules and declarations in debug

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -1843,6 +1843,14 @@ void Obj::moduleinfo(Symbol *scc)
 
 #endif
 
+/*************************************
+ * Emit an imported module or declaration.
+ */
+
+void Obj::importmodule(const char *decl, const char *name)
+{
+}
+
 
 /*********************************
  * Setup for Symbol s to go into a COMDAT segment.

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -786,6 +786,37 @@ void dwarf_termmodule()
         infobuf->writeByte(0);  // end of DW_TAG_module's children
 }
 
+void dwarf_importmodule(const char *decl, const char *name)
+{
+#if (DWARF_VERSION >= 3)
+    unsigned impcode, modidx;
+    Outbuffer impbuf;
+
+    impbuf.writeByte(DW_TAG_imported_module);
+    impbuf.writeByte(0);
+    if (name)
+    {
+        impbuf.writeByte(DW_AT_name);
+        impbuf.writeByte(DW_FORM_string);
+    }
+    impbuf.writeByte(DW_AT_import);
+    impbuf.writeByte(DW_FORM_ref4);
+    impbuf.writeByte(0);
+    impbuf.writeByte(0);
+
+    // ??? Not important, but should probably output the referenced
+    // DW_TAG_module tag after the imported module, but that requires
+    // setting data at an arbitrary place in the infobuf.
+    modidx = dwarf_modidx(decl);
+
+    impcode = dwarf_abbrev_code(impbuf.buf, impbuf.size());
+    infobuf->writeuLEB128(impcode);         // abbreviation code
+    if (name)
+        infobuf->writeString(name);         // DW_AT_name
+    infobuf->write32(modidx);               // DW_AT_import
+#endif
+}
+
 /*************************************
  * Finish writing Dwarf debug info to object file.
  */
@@ -2357,6 +2388,50 @@ Lret:
     /* If infobuf->buf[idx .. size()] is already in infobuf,
      * discard this one and use the previous one.
      */
+    Atype atype;
+    atype.buf = infobuf;
+    atype.start = idx;
+    atype.end = infobuf->size();
+
+    if (!type_table)
+        /* unsigned[Adata] type_table;
+         * where the table values are the type indices
+         */
+        type_table = new AArray(&ti_atype, sizeof(unsigned));
+
+    unsigned *pidx;
+    pidx = (unsigned *)type_table->get(&atype);
+    if (!*pidx)                 // if no idx assigned yet
+    {
+        *pidx = idx;            // assign newly computed idx
+    }
+    else
+    {   // Reuse existing code
+        infobuf->setsize(idx);  // discard current
+        idx = *pidx;
+    }
+    return idx;
+}
+
+unsigned dwarf_modidx(const char *modulename)
+{
+    // FIXME: Should hook in dwarf_initmodule into this to allow referencing
+    // back to output modules.  Also need a way to set 'children' correctly.
+    static unsigned char abbrevModule[] =
+    {
+        DW_TAG_module,
+        0,                  // no children
+        DW_AT_name,         DW_FORM_string, // module name
+        0,                  0,
+    };
+
+    // Modules aren't types, but we share the same index system for simplicity
+    unsigned idx = infobuf->size();
+    unsigned code = dwarf_abbrev_code(abbrevModule, sizeof(abbrevModule));
+
+    infobuf->writeuLEB128(code);
+    infobuf->writeString(modulename);    // DW_AT_name
+
     Atype atype;
     atype.buf = infobuf;
     atype.start = idx;

--- a/src/backend/dwarf.h
+++ b/src/backend/dwarf.h
@@ -12,6 +12,8 @@ void dwarf_initmodule(const char *filename, const char *modulename);
 void dwarf_termmodule();
 void dwarf_func_start(Symbol *sfunc);
 void dwarf_func_term(Symbol *sfunc);
+void dwarf_importmodule(const char *decl, const char *name);
+unsigned dwarf_modidx(const char *modulename);
 unsigned dwarf_typidx(type *t);
 unsigned dwarf_abbrev_code(unsigned char *data, size_t nbytes);
 

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -3172,6 +3172,16 @@ void Obj::moduleinfo(Symbol *scc)
 #endif // !REQUIRE_DSO_REGISTRY
 }
 
+/*************************************
+ * Emit an imported module or declaration.
+ */
+
+void Obj::importmodule(const char *decl, const char *name)
+{
+    if (config.fulltypes)
+        dwarf_importmodule(decl, name);
+}
+
 
 /***************************************
  * Create startup/shutdown code to register an executable/shared

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -2669,6 +2669,16 @@ void Obj::moduleinfo(Symbol *scc)
 #endif
 
 /*************************************
+ * Emit an imported module or declaration.
+ */
+
+void Obj::importmodule(const char *decl, const char *name)
+{
+    if (config.fulltypes)
+        dwarf_importmodule(decl, name);
+}
+
+/*************************************
  */
 
 void Obj::gotref(symbol *s)

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -2587,6 +2587,14 @@ void MsCoffObj::moduleinfo(Symbol *scc)
 #endif
 
 /*************************************
+ * Emit an imported module or declaration.
+ */
+
+void Obj::importmodule(const char *decl, const char *name)
+{
+}
+
+/*************************************
  */
 
 #if 0

--- a/src/backend/obj.h
+++ b/src/backend/obj.h
@@ -52,6 +52,7 @@ struct Obj
     VIRTUAL void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
     VIRTUAL void ehsections();
     VIRTUAL void moduleinfo(Symbol *scc);
+    VIRTUAL void importmodule(const char *mod, const char *name);
     VIRTUAL int  comdat(Symbol *);
     VIRTUAL int  comdatsize(Symbol *, targ_size_t symsize);
     VIRTUAL void setcodeseg(int seg);

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1164,6 +1164,22 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 }
             }
         }
+
+        void visit(Import *imp)
+        {
+            if (imp->isstatic)
+                return;
+
+            // Importing the entire module
+            if (imp->ident)
+            {
+                const char *import = imp->ident->string;
+                const char *name = imp->aliasId ? imp->aliasId->string : NULL;
+                Obj::importmodule(import, name);
+            }
+
+            // XXX: Loop over each imported declaration emitting a DW_TAG_imported_declaration
+        }
     };
 
     ToObjFile v(multiobj);


### PR DESCRIPTION
Complimentary PR for #4746 

Needs suggestions from those who have a better understanding of DMD's backend.  @yebblies @WalterBright ?

I'm looking for an ideal way to generate a symbol of some kind for an `Import` declaration for dwarf.c to handle, need at least following the information:
- Real module name (ie: `foo.bar`)
- The alias given to the module, if such exists (ie: `baz`)
- Whether or not it is an output module (eg: set `extern` for modules not being emitted)

I guess this should be in a `Symbol` so the same routine can handle both module imports and declaration imports.

Requirements for declaration imports:
- Real declaration name
- The alias given to the declaration, if such exists

However, it would be a nice-to-have to also handle type imports too (structs, classes, enums).  For this a stub type declaration of sorts could be used.
