### PR TITLE
fix Issue 14710 - VC-built DMD crashes on templated variadic function IFTI

### DIFF
--- a/src/dmd_msc.vcproj
+++ b/src/dmd_msc.vcproj
@@ -1429,6 +1429,10 @@
 					>
 				</File>
 				<File
+					RelativePath=".\root\newdelete.c"
+					>
+				</File>
+				<File
 					RelativePath=".\root\object.c"
 					>
 				</File>

--- a/src/dmd_msc.vcxproj
+++ b/src/dmd_msc.vcxproj
@@ -228,6 +228,7 @@
     <ClCompile Include="root\checkedint.c" />
     <ClCompile Include="root\longdouble.c" />
     <ClCompile Include="root\man.c" />
+    <ClCompile Include="root\newdelete.c" />
     <ClCompile Include="root\port.c" />
     <ClCompile Include="root\response.c" />
     <ClCompile Include="root\rmem.c" />

--- a/src/dmd_msc.vcxproj.filters
+++ b/src/dmd_msc.vcxproj.filters
@@ -435,6 +435,9 @@
     <ClCompile Include="root\man.c">
       <Filter>src\root</Filter>
     </ClCompile>
+    <ClCompile Include="root\newdelete.c">
+      <Filter>src\root</Filter>
+    </ClCompile>
     <ClCompile Include="root\port.c">
       <Filter>src\root</Filter>
     </ClCompile>

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -119,6 +119,19 @@ static assert(!is(typeof(bug6650!(int)(6))));
 static assert(!is(typeof(bug6650!(int)(18))));
 
 /**************************************************
+    14710    VC-built DMD crashes on templated variadic function IFTI
+**************************************************/
+
+void bug14710a(T)(T val, T[] arr...)
+{
+}
+
+void bug14710b()
+{
+    bug14710a("", "");
+}
+
+/**************************************************
   6661 Templates instantiated only through is(typeof()) shouldn't cause errors
 **************************************************/
 


### PR DESCRIPTION
This just adds newdelete.c to Visual Studio project files.

https://issues.dlang.org/show_bug.cgi?id=14710

Is it worth pursuing the use-after-free bug?
