### PR TITLE
[REG2.067] Issue 13720 - Adding trivial destructor to std.datetime causes Internal error: ..\ztc\cgelem.c 2418

### DIFF
--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -5364,7 +5364,9 @@ beg:
             return optelem(e,GOALnone);
         }
 
-        e1 = e->E1 = optelem(e->E1,(op == OPbool || op == OPnot) ? GOALflags : GOALvalue);
+        e1 = e->E1 = optelem(e->E1, (op == OPddtor) ? GOALnone : (op == OPbool || op == OPnot) ? GOALflags : GOALvalue);
+        if (!e1)
+            goto retnull;
         if (e1->Eoper == OPconst)
         {
 #if TARGET_SEGMENTED

--- a/src/eh.c
+++ b/src/eh.c
@@ -272,7 +272,10 @@ void except_fillInEHTable(symbol *s)
                 unsigned foffset;
                 for (; 1; c2 = code_next(c2))
                 {
-                    assert(c2);
+                    // Bugzilla 13720: optimizer might elide the corresponding ddtor
+                    if (!c2)
+                        goto Lnodtor;
+
                     if (c2->Iop == (ESCAPE | ESCddtor))
                     {
                         if (n)
@@ -337,6 +340,7 @@ void except_fillInEHTable(symbol *s)
                 stacki--;
                 assert(stacki != 0);
             }
+        Lnodtor:
             boffset += calccodsize(c);
         }
     }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7281,8 +7281,35 @@ static this()
 
 void test14192()
 {
-	shared int[int] map;
-	map[1] = 1;
+    shared int[int] map;
+    map[1] = 1;
+}
+
+/***************************************************/
+// 13720
+
+struct FracSec13720
+{
+    this(int hnsecs) {}
+}
+
+struct SysTime13720
+{
+    this(TimeOfDay13720 dateTime, FracSec13720 fracSec)
+    {
+    }
+}
+
+struct TimeOfDay13720
+{
+    ~this() { }
+}
+
+void assertThrown13720(T)(lazy T) {}
+
+void test13720()
+{
+    assertThrown13720(SysTime13720(TimeOfDay13720.init, FracSec13720(-1)));
 }
 
 /***************************************************/
@@ -7738,6 +7765,7 @@ int main()
     test13437();
     test13472();
     test13476();
+    test13720();
     test13952();
     test13985();
     test14211();


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13720
