### PR TITLE
Merge DWARF symbol info into CVDWARF, don't set language as DW_LANG_C89

### DIFF
--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -133,7 +133,6 @@ Where:
   -dip25           implement http://wiki.dlang.org/DIP25 (experimental)
   -dip1000         implement http://wiki.dlang.org/DIP1000 (experimental)
   -g               add symbolic debug info
-  -gc              add symbolic debug info, optimize for non D debuggers
   -gs              always emit stack frame
   -gx              add stack stomp code
   -H               generate 'header' file
@@ -465,7 +464,11 @@ private int tryMain(size_t argc, const(char)** argv)
             else if (strcmp(p + 1, "g") == 0)
                 global.params.symdebug = 1;
             else if (strcmp(p + 1, "gc") == 0)
+            {
+                Loc loc;
+                deprecation(loc, "use -g instead of -gc");
                 global.params.symdebug = 2;
+            }
             else if (strcmp(p + 1, "gs") == 0)
                 global.params.alwaysframe = true;
             else if (strcmp(p + 1, "gx") == 0)


### PR DESCRIPTION
This makes it so that `-gc` on Posix systems is identical to `-g`

This is a follow up to #4732 and #4734.  I've come to the conclusion that toolchain support is now good enough that pretending to be C is actually more painful to end user debug experience vs. actually telling the debugger who we really are.
