### PR TITLE
backend: remove _MSDOS

### DIFF
--- a/src/backend/var.c
+++ b/src/backend/var.c
@@ -28,10 +28,6 @@
 #include        "optab.c"
 #include        "tytab.c"
 
-#if __DMC__ && _MSDOS
-unsigned __cdecl _stack = 100000;       // set default stack size
-#endif
-
 /* Global flags:
  */
 


### PR DESCRIPTION
Can't do MSDOS compiler builds any more anyway.
