### PR TITLE
fix Issue 14572 (Take 2) - Cannot build from source: 'g++ -m64: No such file or directory'

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -36,7 +36,7 @@ LDFLAGS=-lm -lstdc++ -lpthread
 #else
 	HOST_CC=g++
 #endif
-CC=$(HOST_CC) $(MODEL_FLAG)
+CC=$(HOST_CC)
 GIT=git
 
 # Host D compiler for bootstrapping
@@ -119,6 +119,7 @@ MMD=-MMD -MF $(basename $@).deps
 CFLAGS := $(WARNINGS) \
 	-fno-exceptions -fno-rtti \
 	-D__pascal= -DMARS=1 -DTARGET_$(OS_UPCASE)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 \
+	$(MODEL_FLAG)
 # Default D compiler flags for all source files
 DFLAGS=
 


### PR DESCRIPTION
Reboot of https://github.com/D-Programming-Language/dmd/pull/4675

Issue: https://issues.dlang.org/show_bug.cgi?id=14572
