### PR TITLE
[REG2.068-b1] Issue 14735 - std.string.indexOf cannot deduce function for char argument

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1312,8 +1312,7 @@ MATCH implicitConvTo(Expression *e, Type *t)
 
             Type *tb = t->toBasetype();
             Type *typeb = e->type->toBasetype();
-            if (tb->ty == Tsarray && typeb->ty == Tarray &&
-                e->lwr && e->upr)
+            if (tb->ty == Tsarray && typeb->ty == Tarray)
             {
                 typeb = toStaticArrayType(e);
                 if (typeb)

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -4574,6 +4574,30 @@ template SubOps14568(Args...)
 struct Nat14568 { mixin SubOps14568!(null); }
 
 /******************************************/
+// 14735
+
+enum CS14735 { yes, no }
+
+int indexOf14735a(Range      )(Range    s, in dchar c) { return 1; }
+int indexOf14735a(T, size_t n)(ref T[n] s, in dchar c) { return 2; }
+
+int indexOf14735b(Range      )(Range    s, in dchar c, in CS14735 cs = CS14735.yes) { return 1; }
+int indexOf14735b(T, size_t n)(ref T[n] s, in dchar c, in CS14735 cs = CS14735.yes) { return 2; }
+
+void test14735()
+{
+    char[64] buf;
+
+    // Supported from 2.063: (http://dlang.org/changelog#implicitarraycast)
+    assert(indexOf14735a(buf[0..32], '\0') == 2);
+    assert(indexOf14735b(buf[0..32], '\0') == 2);
+
+    // Have to work as same as above.
+    assert(indexOf14735a(buf[], '\0') == 2);
+    assert(indexOf14735b(buf[], '\0') == 2);
+}
+
+/******************************************/
 
 int main()
 {
@@ -4683,6 +4707,7 @@ int main()
     test13379();
     test13484();
     test13694();
+    test14735();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14735

The reported issue was introduced by the Phobos change, but the root issue has been the incomplete compiler implementation.
