### PR TITLE
fix Issue 14508 - [REG2.067.0] compiling with -unittest instantiates …

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -7931,7 +7931,7 @@ bool TemplateInstance::needsCodegen()
          * See bugzilla 2500.
          */
 
-        if (!minst->rootImports())
+        //if (!minst->rootImports())
         {
             //printf("instantiated by %s   %s\n", minst->toChars(), toChars());
             return false;

--- a/test/runnable/link10425.d
+++ b/test/runnable/link10425.d
@@ -1,5 +1,6 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/bug10425.d
+// REQUIRED_ARGS: -allinst
 
 import imports.bug10425;
 

--- a/test/runnable/link11931.d
+++ b/test/runnable/link11931.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -g
+// REQUIRED_ARGS: -g -allinst
 // PERMUTE_ARGS:
 // EXTRA_SOURCES: imports/test11931a.d
 // EXTRA_SOURCES: imports/test11931b.d

--- a/test/runnable/link2500.d
+++ b/test/runnable/link2500.d
@@ -1,6 +1,7 @@
 // EXTRA_SOURCES: imports/link2500a.d
 // EXTRA_SOURCES: imports/link2500b.d
 // COMPILE_SEPARATELY:
+// REQUIRED_ARGS: -allinst
 
 module link2500;
 

--- a/test/runnable/link2644.d
+++ b/test/runnable/link2644.d
@@ -3,6 +3,7 @@
 // EXTRA_SOURCES: imports/link2644b.d
 // EXTRA_SOURCES: imports/link2644c.d
 // COMPILE_SEPARATELY:
+// REQUIRED_ARGS: -allinst
 
 module link2644;
 import imports.link2644a;

--- a/test/runnable/test11039.d
+++ b/test/runnable/test11039.d
@@ -1,4 +1,5 @@
 
+// REQUIRED_ARGS: -allinst
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/test11039b.d
 


### PR DESCRIPTION
…templates in non-root modules

https://issues.dlang.org/show_bug.cgi?id=14508

This is an alternative to Kenji's fix https://github.com/D-Programming-Language/dmd/pull/4626 which is a fix for a regression introduced by https://github.com/D-Programming-Language/dmd/pull/4384. It essentially reverts part of 4384.

The problems with 4384:
1. it introduces, in some cases, a 30% slowdown in compile speed due to an excessive number of templates being instantiated.
2. sometimes it instantiates too many templates, resulting in another very complex fix, 4626. I do not understand 4626. I fear the logic in template instantiations is already far too complex, and this takes it to another level.

So, 4626 was introduced to solve a problem https://issues.dlang.org/show_bug.cgi?id=2644 where a template wasn't being instantiated. We already have a solution to this, the `-allinst` compiler switch. I admit it's a crude approach, but it works, and is fairly easy to understand, explain to others, and implement. Yes, that switch slows down compilation too, because it instantiates everything in sight, but the cost is only borne by those who insist on creating complex circular template imports, not everyone else.

4626 also has a fix for https://issues.dlang.org/show_bug.cgi?id=10920 which I leave intact.
