### PR TITLE
Fix endian-related errors in frontend.

### DIFF
--- a/src/constfold.d
+++ b/src/constfold.d
@@ -1454,7 +1454,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
             size_t len = (t.ty == tn.ty) ? 1 : utf_codeLength(sz, cast(dchar)v);
             void* s = mem.xmalloc(len * sz);
             if (t.ty == tn.ty)
-                memcpy(s, &v, sz);
+                Port.valcpy(s, v, sz);
             else
                 utf_encode(sz, s, cast(dchar)v);
             emplaceExp!(StringExp)(&ue, loc, s, len);
@@ -1583,7 +1583,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         void* s = mem.xmalloc(len * sz);
         memcpy(s, es1.string, es1.len * sz);
         if (homoConcat)
-            memcpy(cast(char*)s + (sz * es1.len), &v, sz);
+            Port.valcpy(cast(char*)s + (sz * es1.len), v, sz);
         else
             utf_encode(sz, cast(char*)s + (sz * es1.len), cast(dchar)v);
         emplaceExp!(StringExp)(&ue, loc, s, len);

--- a/src/ctfeexpr.d
+++ b/src/ctfeexpr.d
@@ -1474,7 +1474,7 @@ extern (C++) UnionExp ctfeCat(Loc loc, Type type, Expression e1, Expression e2)
                 return ue;
             }
             dinteger_t v = es2e.toInteger();
-            memcpy(cast(char*)s + i * sz, &v, sz);
+            Port.valcpy(cast(char*)s + i * sz, v, sz);
         }
         // Add terminating 0
         memset(cast(char*)s + len * sz, 0, sz);
@@ -1504,7 +1504,7 @@ extern (C++) UnionExp ctfeCat(Loc loc, Type type, Expression e1, Expression e2)
                 return ue;
             }
             dinteger_t v = es2e.toInteger();
-            memcpy(cast(char*)s + (es1.len + i) * sz, &v, sz);
+            Port.valcpy(cast(char*)s + (es1.len + i) * sz, v, sz);
         }
         // Add terminating 0
         memset(cast(char*)s + len * sz, 0, sz);

--- a/src/root/port.d
+++ b/src/root/port.d
@@ -303,4 +303,16 @@ extern (C++) struct Port
         auto p = cast(ubyte*)buffer;
         return (p[0] << 8) | p[1];
     }
+
+    static void valcpy(void *dst, ulong val, size_t size)
+    {
+        switch (size)
+        {
+            case 1: *cast(ubyte *)dst = cast(ubyte)val; break;
+            case 2: *cast(ushort *)dst = cast(ushort)val; break;
+            case 4: *cast(uint *)dst = cast(uint)val; break;
+            case 8: *cast(ulong *)dst = cast(ulong)val; break;
+            default: assert(0);
+        }
+    }
 }

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -75,6 +75,7 @@ struct Port
     static unsigned readlongBE(void* buffer);
     static unsigned readwordLE(void* buffer);
     static unsigned readwordBE(void* buffer);
+    static void valcpy(void *dst, uint64_t val, size_t size);
 };
 
 #endif


### PR DESCRIPTION
There are still some places where the frontend is not endian-neutral.
I identified these places while porting LDC to big endian PowerPC.
I have no good idea how to avoid the preprocessor here but I am open
to suggestions.

The code checks for **BIG_ENDIAN** which is not defined by default
and therefore no code paths are changed. On a big endian platform this
has to be defined separately (there is no predefined compiler macro
you could use).
