### PR TITLE
backend: remove use of __pascal

### DIFF
--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -93,7 +93,7 @@ code *setOpcode(code *c, code *cs, unsigned op)
  */
 
 #if TX86 && __INTSIZE == 4 && __DMC__
-__declspec(naked) code * __pascal cat(code *c1,code *c2)
+__declspec(naked) code *cat(code *c1,code *c2)
 {
     _asm
     {
@@ -115,7 +115,7 @@ L7B:    mov     [EDX],ECX
     }
 }
 #else
-code * __pascal cat(code *c1,code *c2)
+code *cat(code *c1,code *c2)
 {   code **pc;
 
     if (!c1)

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -380,7 +380,7 @@ void too_many_symbols()
 }
 
 #if !DEBUG && TX86 && !defined(_MSC_VER)
-__declspec(naked) int __pascal insidx(char *p,unsigned index)
+__declspec(naked) int insidx(char *p,unsigned index)
 {
 #undef AL
 #undef AH

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -512,7 +512,7 @@ code *code_last(code *c);
 void code_orflag(code *c,unsigned flag);
 void code_orrex(code *c,unsigned rex);
 code *setOpcode(code *c, code *cs, unsigned op);
-code * __pascal cat (code *c1 , code *c2 );
+code * cat (code *c1 , code *c2 );
 code * cat3 (code *c1 , code *c2 , code *c3 );
 code * cat4 (code *c1 , code *c2 , code *c3 , code *c4 );
 code * cat6 (code *c1 , code *c2 , code *c3 , code *c4 , code *c5 , code *c6 );


### PR DESCRIPTION
Hasn't been of any use for years.
