### PR TITLE
Issue 13244 - Wrong code with -inline and foreach/map/all

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3414,8 +3414,8 @@ elem *toElem(Expression *e, IRState *irs)
             if (tb1->ty != Tclass && tb1->ty != Tpointer)
                 e = addressElem(e, tb1);
             e = el_bin(OPadd, TYnptr, e, el_long(TYsize_t, v->offset));
-            if (v->isRef() || v->isOut())
-                e = el_una(OPind, TYptr, e);
+            if (v->storage_class & (STCout | STCref))
+                e = el_una(OPind, TYnptr, e);
             e = el_una(OPind, totym(dve->type), e);
             if (tybasic(e->Ety) == TYstruct)
             {

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -584,6 +584,32 @@ void test14267()
 }
 
 /**********************************/
+// 13244
+
+struct MapResult13244(alias fun)
+{
+    int[] input;
+    @property front() { return fun(input[0]); }
+}
+
+int[] array13244(R)(R r)
+{
+    int[] a;
+    a ~= r.front;
+    return a;
+}
+
+void test13244()
+{
+    auto arr = [[cast(ubyte)1]];
+    foreach (ref x; arr)
+    {
+        auto m = MapResult13244!(c => x[c])([0]);
+        array13244(m);
+    }
+}
+
+/**********************************/
 // 14306
 
 struct MapResult(alias fun)
@@ -730,6 +756,7 @@ int main()
     test11322();
     test11394();
     test13503();
+    test13244();
     test14306();
     test14754();
     test14606();


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13244

The indirection result had been corrupted because the size of `TYptr` (!= `TYnptr`) is 16bit.
