### PR TITLE
fix issue 14717 - Ddoc macro recursion limit too low

### DIFF
--- a/src/macro.c
+++ b/src/macro.c
@@ -233,7 +233,7 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
 #endif
 
     static int nest;
-    if (nest > 100)             // limit recursive expansion
+    if (nest > 1000)            // limit recursive expansion
         return;
     nest++;
 

--- a/src/macro.c
+++ b/src/macro.c
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <assert.h>
 
+#include "errors.h"
 #include "rmem.h"
 #include "root.h"
 
@@ -232,9 +233,15 @@ void Macro::expand(OutBuffer *buf, size_t start, size_t *pend,
     printf("Buf is: '%.*s'\n", *pend - start, buf->data + start);
 #endif
 
+    // limit recursive expansion
     static int nest;
-    if (nest > 1000)            // limit recursive expansion
+    static const int nestLimit = 1000;
+    if (nest > nestLimit)
+    {
+        error(Loc(), "DDoc macro expansion limit exceeded; more than %d "
+            "expansions.", nestLimit);
         return;
+    }
     nest++;
 
     size_t end = *pend;

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -1948,6 +1948,8 @@
                 "core.stdc.ctype",
                 "core.stdc.string",
                 "doc",
+                "errors",
+                "globals",
                 "root.outbuffer",
                 "root.rmem",
                 "utf"


### PR DESCRIPTION
The error message misses file and line information. I'm not familiar with the dmd source, so I have no idea how to go about that. Even without it, a bad error message is better than none.

https://issues.dlang.org/show_bug.cgi?id=14717
