### PR TITLE
Issue 14745 - Qualifiers rejected for delegate literals

### DIFF
--- a/test/fail_compilation/parse14745.d
+++ b/test/fail_compilation/parse14745.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parse14745.d(11): Error: function literal cannot be immutable
+fail_compilation/parse14745.d(12): Error: function literal cannot be const
+---
+*/
+
+void test14745()
+{
+    auto fp1 = function () pure immutable { return 0; };
+    auto fp2 = function () pure const { return 0; };
+}

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -1119,6 +1119,28 @@ void test13879()
 }
 
 /***************************************************/
+// 14745
+
+void test14745()
+{
+    // qualified nested functions
+    auto foo1() pure immutable { return 0; }
+    auto foo2() pure const { return 0; }
+
+    // qualified lambdas (== implicitly marked as delegate literals)
+    auto lambda1 = () pure immutable { return 0; };
+    auto lambda2 = () pure const { return 0; };
+    static assert(is(typeof(lambda1) : typeof(&foo1)));
+    static assert(is(typeof(lambda2) : typeof(&foo2)));
+
+    // qualified delegate literals
+    auto dg1 = delegate () pure immutable { return 0; };
+    auto dg2 = delegate () pure const { return 0; };
+    static assert(is(typeof(dg1) : typeof(&foo1)));
+    static assert(is(typeof(dg2) : typeof(&foo2)));
+}
+
+/***************************************************/
 
 int main()
 {
@@ -1173,6 +1195,7 @@ int main()
     test11774();
     test12508();
     test13879();
+    test14745();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14745

That's unnecessary parser limitation.
