### PR TITLE
posix.mak: check if CC is clang or gcc

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -31,11 +31,11 @@ ifeq (osx,$(OS))
 endif
 LDFLAGS=-lm -lstdc++ -lpthread
 
-#ifeq (osx,$(OS))
-#	HOST_CC=clang++
-#else
+ifneq (,$(findstring __clang__, $(shell $(CC) -dM -E -x c /dev/null)))
+	HOST_CC=clang++
+else
 	HOST_CC=g++
-#endif
+endif
 CC=$(HOST_CC)
 GIT=git
 


### PR DESCRIPTION
On MacOS g++ is a frontend for clang, however it doesn't support all g++ warning
options. In particular -Wno-logical-ops is ignored, and the clang equivalent
-Wno-logical-op-parentheses must be specified. In order to prevent those errors
and use the correct warning settings, we are going to correctly determine
the given CC compiler. The `cc -dM -E -x c` is portable accross clang and
g++ and outputs the predefined defines. We use this to correctly check
if the given compiler is clang or g++.
