### PR TITLE
[REG] Issue 14779 - incorrect addressing of arguments in require/in-contract

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -4367,14 +4367,14 @@ bool FuncDeclaration::hasNestedFrameRefs()
     if (closureVars.dim)
         return true;
 
-    /* If a virtual method has contracts, assume its variables are referenced
+    /* If a virtual function has contracts, assume its variables are referenced
      * by those contracts, even if they aren't. Because they might be referenced
      * by the overridden or overriding function's contracts.
      * This can happen because frequire and fensure are implemented as nested functions,
      * and they can be called directly by an overriding function and the overriding function's
-     * context had better match, or Bugzilla 7337 will bite.
+     * context had better match, or Bugzilla 7335 will bite.
      */
-    if ((fdrequire || fdensure) && isVirtualMethod())
+    if (fdrequire || fdensure)
         return true;
 
     if (foverrides.dim && isVirtualMethod())

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -754,6 +754,25 @@ class C10981
 }
 
 /*******************************************/
+// 14779
+
+class C14779
+{
+    final void foo(int v)
+    in  { assert(v == 0); }
+    out { assert(v == 0); }
+    body
+    {
+    }
+}
+
+void test14779()
+{
+    auto c = new C14779();
+    c.foo(0);
+}
+
+/*******************************************/
 
 int main()
 {
@@ -772,6 +791,7 @@ int main()
     test8073();
     test8093();
     test9383();
+    test14779();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14779

<del>In `VarDeclaration::checkNestedReference()`, although fdthis is '__require'
or '__ensure', and hat will get called directly and won't make outer functions
closure, the variable has to be appended to `fdv->closureVars[]` to make
`fdv->hasNestedFrameRefs()` returning true.</del>
