### PR TITLE
Issue 7516 - Postblit not called for structs returned from a ternary operator

### DIFF
--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -765,7 +765,7 @@ public:
             if (e.op == TOKerror)
                 return false;
 
-            (*elements)[i] = e.isLvalue() ? callCpCtor(sc, e) : valueNoDtor(e);
+            (*elements)[i] = doCopyOrMove(sc, e);
         }
         return true;
     }

--- a/src/expression.h
+++ b/src/expression.h
@@ -68,7 +68,7 @@ TemplateDeclaration *getFuncTemplateDecl(Dsymbol *s);
 Expression *valueNoDtor(Expression *e);
 int modifyFieldVar(Loc loc, Scope *sc, VarDeclaration *var, Expression *e1);
 Expression *resolveAliasThis(Scope *sc, Expression *e, bool gag = false);
-Expression *callCpCtor(Scope *sc, Expression *e);
+Expression *doCopyOrMove(Scope *sc, Expression *e);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, Expression **pe0);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, IntervalExp *ie, Expression **pe0);
 Expression *integralPromotions(Expression *e, Scope *sc);

--- a/src/func.d
+++ b/src/func.d
@@ -1839,6 +1839,7 @@ public:
                                 exp = exp.castTo(sc2, exp.type.wildOf());
                         }
                         exp = exp.implicitCastTo(sc2, tret);
+
                         if (f.isref)
                         {
                             // Function returns a reference
@@ -1852,16 +1853,20 @@ public:
                             /* Bugzilla 10789:
                              * If NRVO is not possible, all returned lvalues should call their postblits.
                              */
-                            if (!nrvo_can && exp.isLvalue())
-                                exp = callCpCtor(sc2, exp);
+                            if (!nrvo_can)
+                                exp = doCopyOrMove(sc2, exp);
+
                             checkEscape(sc2, exp, false);
                         }
+
                         exp = checkGC(sc2, exp);
+
                         if (vresult)
                         {
                             // Create: return vresult = exp;
                             exp = new BlitExp(rs.loc, vresult, exp);
                             exp.type = vresult.type;
+
                             if (rs.caseDim)
                                 exp = Expression.combine(exp, new IntegerExp(rs.caseDim));
                         }

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2151,6 +2151,129 @@ void test7506()
 }
 
 /**********************************/
+// 7516
+
+struct S7516
+{
+    int val;
+
+    this(int n) { val = n; }
+    this(this) { val *= 3; }
+}
+
+// CondExp on return statement
+void test7516a()
+{
+    alias S = S7516;
+    S s1 = S(1);
+    S s2 = S(2);
+
+    S foo(bool f) { return f ?  s1  :  s2;  }
+    S hoo(bool f) { return f ? S(1) : S(2); }
+    S bar(bool f) { return f ?  s1  : S(2); }
+    S baz(bool f) { return f ? S(1) :  s2;  }
+
+    auto r1 = foo(true);    assert(r1.val == 3);
+    auto r2 = foo(false);   assert(r2.val == 6);
+    auto r3 = hoo(true);    assert(r3.val == 1);
+    auto r4 = hoo(false);   assert(r4.val == 2);
+    auto r5 = bar(true);    assert(r5.val == 3);
+    auto r6 = bar(false);   assert(r6.val == 2);
+    auto r7 = baz(true);    assert(r7.val == 1);
+    auto r8 = baz(false);   assert(r8.val == 6);
+}
+
+// CondExp on function argument
+void test7516b()
+{
+    alias S = S7516;
+    S s1 = S(1);
+    S s2 = S(2);
+    S func(S s) { return s; }
+
+    S foo(bool f) { return func(f ?  s1  :  s2 ); }
+    S hoo(bool f) { return func(f ? S(1) : S(2)); }
+    S bar(bool f) { return func(f ?  s1  : S(2)); }
+    S baz(bool f) { return func(f ? S(1) :  s2 ); }
+
+    auto r1 = foo(true);    assert(r1.val == 3 * 3);
+    auto r2 = foo(false);   assert(r2.val == 6 * 3);
+    auto r3 = hoo(true);    assert(r3.val == 1 * 3);
+    auto r4 = hoo(false);   assert(r4.val == 2 * 3);
+    auto r5 = bar(true);    assert(r5.val == 3 * 3);
+    auto r6 = bar(false);   assert(r6.val == 2 * 3);
+    auto r7 = baz(true);    assert(r7.val == 1 * 3);
+    auto r8 = baz(false);   assert(r8.val == 6 * 3);
+}
+
+// CondExp on array literal
+void test7516c()
+{
+    alias S = S7516;
+    S s1 = S(1);
+    S s2 = S(2);
+
+    S[] foo(bool f) { return [f ?  s1  :  s2 ]; }
+    S[] hoo(bool f) { return [f ? S(1) : S(2)]; }
+    S[] bar(bool f) { return [f ?  s1  : S(2)]; }
+    S[] baz(bool f) { return [f ? S(1) :  s2 ]; }
+
+    auto r1 = foo(true);    assert(r1[0].val == 3);
+    auto r2 = foo(false);   assert(r2[0].val == 6);
+    auto r3 = hoo(true);    assert(r3[0].val == 1);
+    auto r4 = hoo(false);   assert(r4[0].val == 2);
+    auto r5 = bar(true);    assert(r5[0].val == 3);
+    auto r6 = bar(false);   assert(r6[0].val == 2);
+    auto r7 = baz(true);    assert(r7[0].val == 1);
+    auto r8 = baz(false);   assert(r8[0].val == 6);
+}
+
+// CondExp on rhs of cat assign
+void test7516d()
+{
+    alias S = S7516;
+    S s1 = S(1);
+    S s2 = S(2);
+
+    S[] foo(bool f) { S[] a; a ~= f ?  s1  :  s2 ; return a; }
+    S[] hoo(bool f) { S[] a; a ~= f ? S(1) : S(2); return a; }
+    S[] bar(bool f) { S[] a; a ~= f ?  s1  : S(2); return a; }
+    S[] baz(bool f) { S[] a; a ~= f ? S(1) :  s2 ; return a; }
+
+    auto r1 = foo(true);    assert(r1[0].val == 3);
+    auto r2 = foo(false);   assert(r2[0].val == 6);
+    auto r3 = hoo(true);    assert(r3[0].val == 1);
+    auto r4 = hoo(false);   assert(r4[0].val == 2);
+    auto r5 = bar(true);    assert(r5[0].val == 3);
+    auto r6 = bar(false);   assert(r6[0].val == 2);
+    auto r7 = baz(true);    assert(r7[0].val == 1);
+    auto r8 = baz(false);   assert(r8[0].val == 6);
+}
+
+// CondExp on struct literal element
+void test7516e()
+{
+    alias S = S7516;
+    S s1 = S(1);
+    S s2 = S(2);
+    struct X { S s; }
+
+    X foo(bool f) { return X(f ?  s1  :  s2 ); }
+    X hoo(bool f) { return X(f ? S(1) : S(2)); }
+    X bar(bool f) { return X(f ?  s1  : S(2)); }
+    X baz(bool f) { return X(f ? S(1) :  s2 ); }
+
+    auto r1 = foo(true);    assert(r1.s.val == 3);
+    auto r2 = foo(false);   assert(r2.s.val == 6);
+    auto r3 = hoo(true);    assert(r3.s.val == 1);
+    auto r4 = hoo(false);   assert(r4.s.val == 2);
+    auto r5 = bar(true);    assert(r5.s.val == 3);
+    auto r6 = bar(false);   assert(r6.s.val == 2);
+    auto r7 = baz(true);    assert(r7.s.val == 1);
+    auto r8 = baz(false);   assert(r8.s.val == 6);
+}
+
+/**********************************/
 // 7530
 
 void test7530()
@@ -4320,6 +4443,11 @@ int main()
     test7353();
     test61();
     test7506();
+    test7516a();
+    test7516b();
+    test7516c();
+    test7516d();
+    test7516e();
     test7530();
     test62();
     test7579a();


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=7516

Today, front-end layer handles most of postblit calls, so it's easily fixable.
