### PR TITLE
Add 'objc' global param, inline Objective-C initialization into mars.c

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -63,6 +63,7 @@ struct Param
     bool isOpenBSD;     // generate code for OpenBSD
     bool isSolaris;     // generate code for Solaris
     bool mscoff;        // for Win32: write COFF object files instead of OMF
+    bool objc;          // for OSX (for now): support for Objective-C methods
     char useDeprecated; // 0: don't allow use of deprecated features
                         // 1: silently allow use of deprecated features
                         // 2: warn about the use of deprecated features

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -139,9 +139,7 @@
                 "function objc_FuncDeclaration_semantic_setSelector",
                 "function objc_isUdaSelector",
                 "function objc_FuncDeclaration_semantic_validateSelector",
-                "function objc_FuncDeclaration_semantic_checkLinkage",
-                "function objc_tryMain_dObjc",
-                "function objc_tryMain_init"
+                "function objc_FuncDeclaration_semantic_checkLinkage"
             ],
             "extra" : [
                 "extern(C++) void objc_initSymbols();"

--- a/src/objc.c
+++ b/src/objc.c
@@ -26,7 +26,6 @@
 #include "visitor.h"
 
 void mangleToBuffer(Type *t, OutBuffer *buf);
-void objc_initSymbols();
 
 // MARK: Objc_ClassDeclaration
 
@@ -138,19 +137,6 @@ void objc_FuncDeclaration_semantic_checkLinkage(FuncDeclaration *fd)
 {
     if (fd->linkage != LINKobjc && fd->objc.selector)
         fd->error("must have Objective-C linkage to attach a selector");
-}
-
-// MARK: init
-
-void objc_tryMain_dObjc()
-{
-    VersionCondition::addPredefinedGlobalIdent("D_ObjectiveC");
-}
-
-void objc_tryMain_init()
-{
-    objc_initSymbols();
-    ObjcSelector::init();
 }
 
 // MARK: Selector

--- a/src/objc.di
+++ b/src/objc.di
@@ -55,5 +55,3 @@ extern (C++) void objc_FuncDeclaration_semantic_setSelector(FuncDeclaration fd, 
 extern (C++) bool objc_isUdaSelector(StructDeclaration sd);
 extern (C++) void objc_FuncDeclaration_semantic_validateSelector(FuncDeclaration fd);
 extern (C++) void objc_FuncDeclaration_semantic_checkLinkage(FuncDeclaration fd);
-extern (C++) void objc_tryMain_dObjc();
-extern (C++) void objc_tryMain_init();

--- a/src/objc.h
+++ b/src/objc.h
@@ -72,7 +72,5 @@ bool objc_isUdaSelector(StructDeclaration *sd);
 void objc_FuncDeclaration_semantic_validateSelector(FuncDeclaration *fd);
 void objc_FuncDeclaration_semantic_checkLinkage(FuncDeclaration *fd);
 
-void objc_tryMain_dObjc();
-void objc_tryMain_init();
 
 #endif /* DMD_OBJC_H */

--- a/src/objc_glue_stubs.c
+++ b/src/objc_glue_stubs.c
@@ -17,6 +17,11 @@ class Type;
 class TypeFunction;
 struct elem;
 
+void objc_initSymbols()
+{
+    // noop
+}
+
 void objc_callfunc_setupEp(elem *esel, elem **ep, int reverse)
 {
     // noop

--- a/src/objc_stubs.c
+++ b/src/objc_stubs.c
@@ -28,6 +28,12 @@ ObjcSelector::ObjcSelector(const char *sv, size_t len, size_t pcount)
     assert(0);
 }
 
+void ObjcSelector::init()
+{
+    printf("Should never be called when D_OBJC is false\n");
+    assert(0);
+}
+
 ObjcSelector *ObjcSelector::lookup(const char *s)
 {
     printf("Should never be called when D_OBJC is false\n");
@@ -107,12 +113,3 @@ void objc_FuncDeclaration_semantic_checkLinkage(FuncDeclaration *fd)
     // noop
 }
 
-void objc_tryMain_dObjc()
-{
-    // noop
-}
-
-void objc_tryMain_init()
-{
-    // noop
-}

--- a/src/objc_stubs.d
+++ b/src/objc_stubs.d
@@ -85,12 +85,3 @@ extern (C++) void objc_FuncDeclaration_semantic_checkLinkage(FuncDeclaration fd)
     // noop
 }
 
-extern (C++) void objc_tryMain_dObjc()
-{
-    // noop
-}
-
-extern (C++) void objc_tryMain_init()
-{
-    // noop
-}


### PR DESCRIPTION
I'll do this as a primer (but honestly, the original PR should have been done this way).

I can't use `objc.c` to test out Objective-C support without providing a useless stub for `objc_initSymbols`.  Moving it to `mars.c` is fine because GDC doesn't use this file (has a different entrypoint for compilation).
