### PR TITLE
Small front-end optimization - reduce number of semantic analysis pass

### DIFF
--- a/src/attrib.d
+++ b/src/attrib.d
@@ -48,14 +48,14 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         this.decl = decl;
     }
 
-    Dsymbols* include(Scope* sc, ScopeDsymbol sds)
+    Dsymbols* include(Scope* sc)
     {
         return decl;
     }
 
     override final int apply(Dsymbol_apply_ft_t fp, void* param)
     {
-        Dsymbols* d = include(_scope, null);
+        auto d = include(_scope);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -114,7 +114,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        Dsymbols* d = include(sc, sds);
+        auto d = include(sc);
         if (d)
         {
             Scope* sc2 = newScope(sc);
@@ -131,7 +131,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void importAll(Scope* sc)
     {
-        Dsymbols* d = include(sc, null);
+        auto d = include(sc);
         //printf("\tAttribDeclaration::importAll '%s', d = %p\n", toChars(), d);
         if (d)
         {
@@ -148,7 +148,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void semantic(Scope* sc)
     {
-        Dsymbols* d = include(sc, null);
+        auto d = include(sc);
         //printf("\tAttribDeclaration::semantic '%s', d = %p\n",toChars(), d);
         if (d)
         {
@@ -165,7 +165,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void semantic2(Scope* sc)
     {
-        Dsymbols* d = include(sc, null);
+        auto d = include(sc);
         if (d)
         {
             Scope* sc2 = newScope(sc);
@@ -181,7 +181,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void semantic3(Scope* sc)
     {
-        Dsymbols* d = include(sc, null);
+        auto d = include(sc);
         if (d)
         {
             Scope* sc2 = newScope(sc);
@@ -200,7 +200,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         //printf("AttribDeclaration::addComment %s\n", comment);
         if (comment)
         {
-            Dsymbols* d = include(null, null);
+            auto d = include(null);
             if (d)
             {
                 for (size_t i = 0; i < d.dim; i++)
@@ -220,13 +220,13 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override bool oneMember(Dsymbol* ps, Identifier ident)
     {
-        Dsymbols* d = include(null, null);
+        auto d = include(null);
         return Dsymbol.oneMembers(d, ps, ident);
     }
 
     override void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
     {
-        Dsymbols* d = include(null, null);
+        auto d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -239,7 +239,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override final bool hasPointers()
     {
-        Dsymbols* d = include(null, null);
+        auto d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -254,7 +254,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override final bool hasStaticCtorOrDtor()
     {
-        Dsymbols* d = include(null, null);
+        auto d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -269,7 +269,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override final void checkCtorConstInit()
     {
-        Dsymbols* d = include(null, null);
+        auto d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -284,7 +284,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
      */
     override final void addLocalClass(ClassDeclarations* aclasses)
     {
-        Dsymbols* d = include(null, null);
+        auto d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -1169,7 +1169,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
         //printf("ConditionalDeclaration::oneMember(), inc = %d\n", condition->inc);
         if (condition.inc)
         {
-            Dsymbols* d = condition.include(null, null) ? decl : elsedecl;
+            auto d = condition.include(null) ? decl : elsedecl;
             return Dsymbol.oneMembers(d, ps, ident);
         }
         else
@@ -1181,11 +1181,11 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
     }
 
     // Decide if 'then' or 'else' code should be included
-    override Dsymbols* include(Scope* sc, ScopeDsymbol sds)
+    override Dsymbols* include(Scope* sc)
     {
         //printf("ConditionalDeclaration::include(sc = %p) scope = %p\n", sc, scope);
         assert(condition);
-        return condition.include(_scope ? _scope : sc, sds) ? decl : elsedecl;
+        return condition.include(_scope ? _scope : sc) ? decl : elsedecl;
     }
 
     override final void addComment(const(char)* comment)
@@ -1243,14 +1243,14 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
      * Different from other AttribDeclaration subclasses, include() call requires
      * the completion of addMember phases.
      */
-    override Dsymbols* include(Scope* sc, ScopeDsymbol sds)
+    override Dsymbols* include(Scope* sc)
     {
         //printf("StaticIfDeclaration::include(sc = %p) scope = %p\n", sc, scope);
         if (condition.inc == 0)
         {
             assert(scopesym); // addMember is already done
             assert(_scope); // setScope is already done
-            Dsymbols* d = ConditionalDeclaration.include(_scope, scopesym);
+            auto d = ConditionalDeclaration.include(_scope);
             if (d && !addisdone)
             {
                 // Add members lazily.
@@ -1265,7 +1265,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
         }
         else
         {
-            return ConditionalDeclaration.include(sc, scopesym);
+            return ConditionalDeclaration.include(sc);
         }
     }
 
@@ -1515,7 +1515,7 @@ extern (C++) static uint setMangleOverride(Dsymbol s, char* sym)
     AttribDeclaration ad = s.isAttribDeclaration();
     if (ad)
     {
-        Dsymbols* decls = ad.include(null, null);
+        auto decls = ad.include(null);
         uint nestedCount = 0;
         if (decls && decls.dim)
             for (size_t i = 0; i < decls.dim; ++i)

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -39,7 +39,6 @@ public:
         structalign_t structalign, PINLINE inlining);
     virtual Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
     void importAll(Scope *sc);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
@@ -76,7 +75,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    void setScope(Scope *sc);
+    void addMember(Scope *sc, ScopeDsymbol *sds);
     void semantic2(Scope *sc);
     const char *getMessage();
     void accept(Visitor *v) { v->visit(this); }
@@ -142,7 +141,7 @@ public:
     unsigned anonalignsize;     // size of anonymous struct for alignment purposes
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    void setScope(Scope *sc);
+    void addMember(Scope *sc, ScopeDsymbol *sds);
     void semantic(Scope *sc);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind() const;
@@ -172,7 +171,6 @@ public:
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
     void addComment(const utf8_t *comment);
-    void setScope(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -185,7 +183,6 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
     void importAll(Scope *sc);
     void semantic(Scope *sc);
     const char *kind() const;
@@ -204,7 +201,6 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
     void compileIt(Scope *sc);
     void semantic(Scope *sc);
     const char *kind() const;
@@ -222,7 +218,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    void setScope(Scope *sc);
+    void addMember(Scope *sc, ScopeDsymbol *sds);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     static Expressions *concat(Expressions *udas1, Expressions *udas2);

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -32,7 +32,7 @@ class AttribDeclaration : public Dsymbol
 public:
     Dsymbols *decl;     // array of Dsymbol's
 
-    virtual Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
+    virtual Dsymbols *include(Scope *sc);
     int apply(Dsymbol_apply_ft_t fp, void *param);
     static Scope *createNewScope(Scope *sc,
         StorageClass newstc, LINK linkage, Prot protection, int explictProtection,
@@ -169,7 +169,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
+    Dsymbols *include(Scope *sc);
     void addComment(const utf8_t *comment);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -181,7 +181,7 @@ public:
     bool addisdone;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
+    Dsymbols *include(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void importAll(Scope *sc);
     void semantic(Scope *sc);

--- a/src/canthrow.d
+++ b/src/canthrow.d
@@ -242,7 +242,7 @@ extern (C++) bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNot
     ad = s.isAttribDeclaration();
     if (ad)
     {
-        Dsymbols* decl = ad.include(null, null);
+        auto decl = ad.include(null);
         if (decl && decl.dim)
         {
             for (size_t i = 0; i < decl.dim; i++)

--- a/src/cond.d
+++ b/src/cond.d
@@ -45,7 +45,7 @@ extern (C++) abstract class Condition : RootObject
 
     abstract Condition syntaxCopy();
 
-    abstract int include(Scope* sc, ScopeDsymbol sds);
+    abstract int include(Scope* sc);
 
     DebugCondition isDebugCondition()
     {
@@ -151,7 +151,7 @@ extern (C++) final class DebugCondition : DVCondition
         super(mod, level, ident);
     }
 
-    override int include(Scope* sc, ScopeDsymbol sds)
+    override int include(Scope* sc)
     {
         //printf("DebugCondition::include() level = %d, debuglevel = %d\n", level, global.params.debuglevel);
         if (inc == 0)
@@ -427,7 +427,7 @@ extern (C++) final class VersionCondition : DVCondition
         super(mod, level, ident);
     }
 
-    override int include(Scope* sc, ScopeDsymbol sds)
+    override int include(Scope* sc)
     {
         //printf("VersionCondition::include() level = %d, versionlevel = %d\n", level, global.params.versionlevel);
         //if (ident) printf("\tident = '%s'\n", ident->toChars());
@@ -491,16 +491,9 @@ extern (C++) final class StaticIfCondition : Condition
         return new StaticIfCondition(loc, exp.syntaxCopy());
     }
 
-    override int include(Scope* sc, ScopeDsymbol sds)
+    override int include(Scope* sc)
     {
-        version (none)
-        {
-            printf("StaticIfCondition::include(sc = %p, sds = %p) this=%p inc = %d\n", sc, sds, this, inc);
-            if (sds)
-            {
-                printf("\ts = '%s', kind = %s\n", sds.toChars(), sds.kind());
-            }
-        }
+        //printf("StaticIfCondition::include(sc = %p) this = %p inc = %d\n", sc, this, inc);
         if (inc == 0)
         {
             if (exp.op == TOKerror || nest > 100)
@@ -516,7 +509,6 @@ extern (C++) final class StaticIfCondition : Condition
             }
             ++nest;
             sc = sc.push(sc.scopesym);
-            sc.sds = sds; // sds gets any addMember()
             //sc->speculative = true;       // TODO: static if (is(T U)) { /* U is available */ }
             sc.flags |= SCOPEcondition;
             sc = sc.startCTFE();

--- a/src/cond.h
+++ b/src/cond.h
@@ -32,7 +32,7 @@ public:
     int inc;
 
     virtual Condition *syntaxCopy() = 0;
-    virtual int include(Scope *sc, ScopeDsymbol *sds) = 0;
+    virtual int include(Scope *sc) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 };
@@ -54,7 +54,7 @@ public:
     static void setGlobalLevel(unsigned level);
     static void addGlobalIdent(const char *ident);
 
-    int include(Scope *sc, ScopeDsymbol *sds);
+    int include(Scope *sc);
     DebugCondition *isDebugCondition() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -66,7 +66,7 @@ public:
     static void addGlobalIdent(const char *ident);
     static void addPredefinedGlobalIdent(const char *ident);
 
-    int include(Scope *sc, ScopeDsymbol *sds);
+    int include(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -77,7 +77,7 @@ public:
     int nest;         // limit circular dependencies
 
     Condition *syntaxCopy();
-    int include(Scope *sc, ScopeDsymbol *sds);
+    int include(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -750,28 +750,22 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         {
             symtab = new DsymbolTable();
 
+            auto sc2 = newScope(sc);
+
             /* Bugzilla 12152: The semantic analysis of base classes should be finished
              * before the members semantic analysis of this class, in order to determine
              * vtbl in this class. However if a base class refers the member of this class,
              * it can be resolved as a normal forward reference.
-             * Call addMember() and setScope() to make this class members visible from the base classes.
+             * Call addMember() to make this class members visible from the base classes.
              */
-            for (size_t i = 0; i < members.dim; i++)
-            {
-                auto s = (*members)[i];
-                s.addMember(sc, this);
-            }
-
-            auto sc2 = newScope(sc);
-
             /* Set scope so if there are forward references, we still might be able to
              * resolve individual members like enums.
              */
             for (size_t i = 0; i < members.dim; i++)
             {
                 auto s = (*members)[i];
-                //printf("[%d] setScope %s %s, sc2 = %p\n", i, s.kind(), s.toChars(), sc2);
-                s.setScope(sc2);
+                //printf("[%d] addMember %s %s, sc2 = %p\n", i, s.kind(), s.toChars(), sc2);
+                s.addMember(sc2, this);
             }
 
             sc2.pop();
@@ -937,7 +931,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                 ctor.fbody = new CompoundStatement(Loc(), new Statements());
 
                 members.push(ctor);
-                ctor.addMember(sc, this);
+                ctor.addMember(sc2, this);
                 ctor.semantic(sc2);
 
                 this.ctor = ctor;
@@ -1803,12 +1797,6 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
             }
         }
 
-        for (size_t i = 0; i < members.dim; i++)
-        {
-            Dsymbol s = (*members)[i];
-            s.addMember(sc, this);
-        }
-
         auto sc2 = newScope(sc);
 
         /* Set scope so if there are forward references, we still might be able to
@@ -1817,8 +1805,8 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
         for (size_t i = 0; i < members.dim; i++)
         {
             Dsymbol s = (*members)[i];
-            //printf("setScope %s %s\n", s.kind(), s.toChars());
-            s.setScope(sc2);
+            //printf("addMember %s %s\n", s.kind(), s.toChars());
+            s.addMember(sc2, this);
         }
 
         for (size_t i = 0; i < members.dim; i++)

--- a/src/denum.d
+++ b/src/denum.d
@@ -99,13 +99,8 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             }
         }
         added = true;
-    }
 
-    override void setScope(Scope* sc)
-    {
-        if (semanticRun > PASSinit)
-            return;
-        ScopeDsymbol.setScope(sc);
+        setScope(sc);
     }
 
     override void semantic(Scope* sc)
@@ -227,16 +222,18 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         sce = sce.startCTFE();
         sce.setNoFree(); // needed for getMaxMinValue()
 
-        /* Each enum member gets the sce scope
-         */
-        for (size_t i = 0; i < members.dim; i++)
+        if (added)
         {
-            EnumMember em = (*members)[i].isEnumMember();
-            if (em)
-                em._scope = sce;
+            /* Each enum member gets the sce scope
+             */
+            for (size_t i = 0; i < members.dim; i++)
+            {
+                EnumMember em = (*members)[i].isEnumMember();
+                if (em)
+                    em.setScope(sce);
+            }
         }
-
-        if (!added)
+        else
         {
             /* addMember() is not called when the EnumDeclaration appears as a function statement,
              * so we have to do what addMember() does and install the enum members in the right symbol
@@ -271,7 +268,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
                 if (em)
                 {
                     em.ed = this;
-                    em.addMember(sc, scopesym);
+                    em.addMember(sce, scopesym);
                 }
             }
         }
@@ -280,7 +277,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         {
             EnumMember em = (*members)[i].isEnumMember();
             if (em)
-                em.semantic(em._scope);
+                em.semantic(sce);
         }
         //printf("defaultval = %lld\n", defaultval);
 

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -935,11 +935,13 @@ extern (C++) final class Module : Package
         //printf("+Module::importAll(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
         if (_scope)
             return; // already done
+
         if (isDocFile)
         {
             error("is a Ddoc file, cannot import it");
             return;
         }
+
         if (md && md.msg)
         {
             if (StringExp se = md.msg.toStringExp())
@@ -947,12 +949,14 @@ extern (C++) final class Module : Package
             else
                 md.msg.error("string expected, not '%s'", md.msg.toChars());
         }
+
         /* Note that modules get their own scope, from scratch.
          * This is so regardless of where in the syntax a module
          * gets imported, it is unaffected by context.
          * Ignore prevsc.
          */
         Scope* sc = Scope.createGlobal(this); // create root scope
+
         // Add import of "object", even for the "object" module.
         // If it isn't there, some compiler rewrites, like
         //    classinst == classinst -> .object.opEquals(classinst, classinst)
@@ -962,9 +966,17 @@ extern (C++) final class Module : Package
             auto im = new Import(Loc(), null, Id.object, null, 0);
             members.shift(im);
         }
+
         if (!symtab)
         {
             // Add all symbols into module's symbol table
+
+            /* Set scope for the symbols so that if we forward reference
+             * a symbol, it can possibly be resolved on the spot.
+             * If this works out well, it can be extended to all modules
+             * before any semantic() on any of them.
+             */
+
             symtab = new DsymbolTable();
             for (size_t i = 0; i < members.dim; i++)
             {
@@ -973,22 +985,15 @@ extern (C++) final class Module : Package
             }
         }
         // anything else should be run after addMember, so version/debug symbols are defined
-        /* Set scope for the symbols so that if we forward reference
-         * a symbol, it can possibly be resolved on the spot.
-         * If this works out well, it can be extended to all modules
-         * before any semantic() on any of them.
-         */
+
         setScope(sc); // remember module scope for semantic
-        for (size_t i = 0; i < members.dim; i++)
-        {
-            Dsymbol s = (*members)[i];
-            s.setScope(sc);
-        }
+
         for (size_t i = 0; i < members.dim; i++)
         {
             Dsymbol s = (*members)[i];
             s.importAll(sc);
         }
+
         sc = sc.pop();
         sc.pop(); // 2 pops because Scope::createGlobal() created 2
     }

--- a/src/doc.d
+++ b/src/doc.d
@@ -1116,7 +1116,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
              * (only template instantiations).
              * Hence, Ddoc omits attributes from template members.
              */
-            Dsymbols* d = ad.include(null, null);
+            auto d = ad.include(null);
             if (d)
             {
                 for (size_t i = 0; i < d.dim; i++)
@@ -1150,7 +1150,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
                 return;
             }
             /* If generating doc comment, be careful because if we're inside
-             * a template, then include(NULL, NULL) will fail.
+             * a template, then include(NULL) will fail.
              */
             Dsymbols* d = cd.decl ? cd.decl : cd.elsedecl;
             for (size_t i = 0; i < d.dim; i++)

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -111,8 +111,6 @@ struct Scope
 
     Module _module;                 // Root module
     ScopeDsymbol scopesym;          // current symbol
-    ScopeDsymbol sds;               // if in static if, and declaring new symbols,
-                                    // sds gets the addMember()
     FuncDeclaration func;           // function we are in
     Dsymbol parent;                 // parent to use
     LabelStatement slabel;          // enclosing labelled statement
@@ -225,7 +223,6 @@ struct Scope
         //printf("Scope::push(this = %p) new = %p\n", this, s);
         assert(!(flags & SCOPEfree));
         s.scopesym = null;
-        s.sds = null;
         s.enclosing = &this;
         debug
         {
@@ -716,7 +713,6 @@ struct Scope
     {
         this._module = sc._module;
         this.scopesym = sc.scopesym;
-        this.sds = sc.sds;
         this.enclosing = sc.enclosing;
         this.parent = sc.parent;
         this.sw = sc.sw;

--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -322,28 +322,22 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             semanticRun = PASSsemanticdone;
             return;
         }
-        if (!symtab)
+
+        auto sc2 = newScope(sc);
+
+        if (!symtab) // if not already done the addMember step
         {
             symtab = new DsymbolTable();
 
+            /* Set scope so if there are forward references, we still might be able to
+             * resolve individual members like enums.
+             */
             for (size_t i = 0; i < members.dim; i++)
             {
                 auto s = (*members)[i];
                 //printf("adding member '%s' to '%s'\n", s.toChars(), this.toChars());
-                s.addMember(sc, this);
+                s.addMember(sc2, this);
             }
-        }
-
-        auto sc2 = newScope(sc);
-
-        /* Set scope so if there are forward references, we still might be able to
-         * resolve individual members like enums.
-         */
-        for (size_t i = 0; i < members.dim; i++)
-        {
-            auto s = (*members)[i];
-            //printf("struct: setScope %s %s\n", s.kind(), s.toChars());
-            s.setScope(sc2);
         }
 
         for (size_t i = 0; i < members.dim; i++)

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -457,10 +457,12 @@ extern (C++) class Dsymbol : RootObject
         return parent.isInstantiated();
     }
 
-    // Check if this function is a member of a template which has only been
-    // instantiated speculatively, eg from inside is(typeof()).
-    // Return the speculative template instance it is part of,
-    // or NULL if not speculative.
+    /**********************************
+     * Check if this function is a member of a template which has only been
+     * instantiated speculatively, eg from inside is(typeof()).
+     * Return the speculative template instance it is part of,
+     * or NULL if not speculative.
+     */
     final inout(TemplateInstance) isSpeculative() inout
     {
         if (!parent)
@@ -605,6 +607,11 @@ extern (C++) class Dsymbol : RootObject
         return (*fp)(this, param);
     }
 
+    /*************************************
+     * 1. Add this symbol into the member of sds
+     * 2. store sc into Dsymbol::scope for future semantic analysis so we can
+     *    deal better with forward references.
+     */
     void addMember(Scope* sc, ScopeDsymbol sds)
     {
         //printf("Dsymbol::addMember('%s')\n", toChars());
@@ -631,13 +638,16 @@ extern (C++) class Dsymbol : RootObject
                 }
             }
         }
+        if (sc)
+            setScope(sc);
+        else
+            assert(isPackage());
     }
 
     /*************************************
-     * Set scope for future semantic analysis so we can
-     * deal better with forward references.
+     * Set scope for future semantic analysis.
      */
-    void setScope(Scope* sc)
+    final void setScope(Scope* sc)
     {
         //printf("Dsymbol::setScope() %p %s, %p stc = %llx\n", this, toChars(), sc, sc->stc);
         if (!sc.nofree)

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1685,7 +1685,7 @@ public:
         {
             Dsymbol s = (*members)[i];
             if (AttribDeclaration a = s.isAttribDeclaration())
-                result = _foreach(sc, a.include(sc, null), dg, &n);
+                result = _foreach(sc, a.include(sc), dg, &n);
             else if (TemplateMixin tm = s.isTemplateMixin())
                 result = _foreach(sc, tm.members, dg, &n);
             else if (s.isTemplateInstance())

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -199,7 +199,7 @@ public:
     virtual Dsymbol *toAlias2();
     virtual int apply(Dsymbol_apply_ft_t fp, void *param);
     virtual void addMember(Scope *sc, ScopeDsymbol *sds);
-    virtual void setScope(Scope *sc);
+    void setScope(Scope *sc);
     virtual void importAll(Scope *sc);
     virtual void semantic(Scope *sc);
     virtual void semantic2(Scope *sc);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4972,7 +4972,7 @@ elem *toElem(Expression *e, IRState *irs)
             //printf("Dsymbol_toElem() %s\n", s->toChars());
             if (AttribDeclaration *ad = s->isAttribDeclaration())
             {
-                Dsymbols *decl = ad->include(NULL, NULL);
+                Dsymbols *decl = ad->include(NULL);
                 if (decl && decl->dim)
                 {
                     for (size_t i = 0; i < decl->dim; i++)

--- a/src/enum.h
+++ b/src/enum.h
@@ -51,7 +51,6 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    void setScope(Scope *sc);
     void semantic(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Type *getType();

--- a/src/expression.d
+++ b/src/expression.d
@@ -7730,9 +7730,7 @@ extern (C++) final class IsExp : Expression
                     if (m <= MATCHnomatch)
                         goto Lno;
                     s.semantic(sc);
-                    if (sc.sds)
-                        s.addMember(sc, sc.sds);
-                    else if (!sc.insert(s))
+                    if (!sc.insert(s))
                         error("declaration %s is already defined", s.toChars());
 
                     unSpeculative(sc, s);
@@ -7765,8 +7763,6 @@ extern (C++) final class IsExp : Expression
              */
             if (!tup && !sc.insert(s))
                 error("declaration %s is already defined", s.toChars());
-            if (sc.sds)
-                s.addMember(sc, sc.sds);
 
             unSpeculative(sc, s);
         }

--- a/src/inline.d
+++ b/src/inline.d
@@ -1752,7 +1752,7 @@ public:
 
     override void visit(AttribDeclaration d)
     {
-        Dsymbols* decls = d.include(null, null);
+        auto decls = d.include(null);
         if (decls)
         {
             foreach (i; 0 .. decls.dim)

--- a/src/json.d
+++ b/src/json.d
@@ -542,7 +542,7 @@ public:
 
     override void visit(AttribDeclaration d)
     {
-        Dsymbols* ds = d.include(null, null);
+        auto ds = d.include(null);
         if (ds)
         {
             for (size_t i = 0; i < ds.dim; i++)

--- a/src/nspace.d
+++ b/src/nspace.d
@@ -48,6 +48,7 @@ extern (C++) final class Nspace : ScopeDsymbol
         {
             if (!symtab)
                 symtab = new DsymbolTable();
+
             // The namespace becomes 'imported' into the enclosing scope
             for (Scope* sce = sc; 1; sce = sce.enclosing)
             {
@@ -58,31 +59,16 @@ extern (C++) final class Nspace : ScopeDsymbol
                     break;
                 }
             }
+
             assert(sc);
             sc = sc.push(this);
             sc.linkage = LINKcpp; // namespaces default to C++ linkage
             sc.parent = this;
+
             foreach (s; *members)
             {
                 //printf("add %s to scope %s\n", s->toChars(), toChars());
                 s.addMember(sc, this);
-            }
-            sc.pop();
-        }
-    }
-
-    override void setScope(Scope* sc)
-    {
-        ScopeDsymbol.setScope(sc);
-        if (members)
-        {
-            assert(sc);
-            sc = sc.push(this);
-            sc.linkage = LINKcpp; // namespaces default to C++ linkage
-            sc.parent = this;
-            foreach (s; *members)
-            {
-                s.setScope(sc);
             }
             sc.pop();
         }
@@ -113,6 +99,7 @@ extern (C++) final class Nspace : ScopeDsymbol
             {
                 s.importAll(sc);
             }
+
             foreach (s; *members)
             {
                 static if (LOG)
@@ -121,6 +108,7 @@ extern (C++) final class Nspace : ScopeDsymbol
                 }
                 s.semantic(sc);
             }
+
             sc.pop();
         }
         static if (LOG)

--- a/src/scope.h
+++ b/src/scope.h
@@ -75,8 +75,6 @@ struct Scope
 
     Module *module;             // Root module
     ScopeDsymbol *scopesym;     // current symbol
-    ScopeDsymbol *sds;          // if in static if, and declaring new symbols,
-                                // sds gets the addMember()
     FuncDeclaration *func;      // function we are in
     Dsymbol *parent;            // parent to use
     LabelStatement *slabel;     // enclosing labelled statement

--- a/src/statement.d
+++ b/src/statement.d
@@ -1077,12 +1077,12 @@ extern (C++) Statement toStatement(Dsymbol s)
 
         override void visit(ConditionalDeclaration d)
         {
-            result = visitMembers(d.loc, d.include(null, null));
+            result = visitMembers(d.loc, d.include(null));
         }
 
         override void visit(CompileDeclaration d)
         {
-            result = visitMembers(d.loc, d.include(null, null));
+            result = visitMembers(d.loc, d.include(null));
         }
     }
 
@@ -1823,7 +1823,7 @@ extern (C++) final class ConditionalStatement : Statement
         Statement s;
 
         //printf("ConditionalStatement::flatten()\n");
-        if (condition.include(sc, null))
+        if (condition.include(sc))
         {
             DebugCondition dc = condition.isDebugCondition();
             if (dc)

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -1764,7 +1764,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         // If we can short-circuit evaluate the if statement, don't do the
         // semantic analysis of the skipped code.
         // This feature allows a limited form of conditional compilation.
-        if (cs.condition.include(sc, null))
+        if (cs.condition.include(sc))
         {
             DebugCondition dc = cs.condition.isDebugCondition();
             if (dc)

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1091,8 +1091,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
 
         void visit(AttribDeclaration *ad)
         {
-            Dsymbols *d = ad->include(NULL, NULL);
-
+            Dsymbols *d = ad->include(NULL);
             if (d)
             {
                 for (size_t i = 0; i < d->dim; i++)

--- a/src/traits.d
+++ b/src/traits.d
@@ -1148,7 +1148,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 {
                     if (auto atd = s.isAttribDeclaration())
                     {
-                        collectUnitTests(atd.include(null, null));
+                        collectUnitTests(atd.include(null));
                         continue;
                     }
                     if (auto ud = s.isUnitTestDeclaration())


### PR DESCRIPTION
`Dsymbol::addMember` makes scope member symbols visible, and `Dsymbol::setScope` turns on forward reference resolution mechanism.

Both are important, but I noticed that they are independent of each other, and the `sc` parameter in `addMember` is not used well.

We can process the two individual semantic analysis pass at once, and it would increase compilation speed a little.
