### PR TITLE
Make AR tool configurable

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -37,6 +37,7 @@ LDFLAGS=-lm -lstdc++ -lpthread
 	HOST_CC=g++
 #endif
 CC=$(HOST_CC)
+AR=ar
 GIT=git
 
 # Host D compiler for bootstrapping
@@ -304,16 +305,16 @@ auto-tester-build: dmd checkwhitespace ddmd
 .PHONY: auto-tester-build
 
 frontend.a: $(DMD_OBJS)
-	ar rcs frontend.a $(DMD_OBJS)
+	$(AR) rcs frontend.a $(DMD_OBJS)
 
 root.a: $(ROOT_OBJS)
-	ar rcs root.a $(ROOT_OBJS)
+	$(AR) rcs root.a $(ROOT_OBJS)
 
 glue.a: $(GLUE_OBJS)
-	ar rcs glue.a $(GLUE_OBJS)
+	$(AR) rcs glue.a $(GLUE_OBJS)
 
 backend.a: $(BACK_OBJS)
-	ar rcs backend.a $(BACK_OBJS)
+	$(AR) rcs backend.a $(BACK_OBJS)
 
 dmd: frontend.a root.a glue.a backend.a
 	$(HOST_CC) -o dmd $(MODEL_FLAG) frontend.a root.a glue.a backend.a $(LDFLAGS)


### PR DESCRIPTION
Some Linux distro may want to override `ar` with something like `x86_64-pc-linux-gnu-ar`. [Exherbo](http://exherbo.org) is one of them.
