### PR TITLE
Issue 14818 - Unhelpful "does not match template overload set" error

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -696,7 +696,7 @@ public:
             {
                 if (overnext)
                 {
-                    auto fa = new FuncAliasDeclaration(fd);
+                    auto fa = new FuncAliasDeclaration(ident, fd);
                     if (!fa.overloadInsert(overnext))
                         ScopeDsymbol.multiplyDefined(Loc(), overnext, fd);
                     overnext = null;
@@ -708,7 +708,7 @@ public:
             {
                 if (overnext)
                 {
-                    auto od = new OverDeclaration(td);
+                    auto od = new OverDeclaration(ident, td);
                     if (!od.overloadInsert(overnext))
                         ScopeDsymbol.multiplyDefined(Loc(), overnext, td);
                     overnext = null;
@@ -720,7 +720,7 @@ public:
             {
                 if (overnext)
                 {
-                    auto od2 = new OverDeclaration(od);
+                    auto od2 = new OverDeclaration(ident, od);
                     if (!od2.overloadInsert(overnext))
                         ScopeDsymbol.multiplyDefined(Loc(), overnext, od);
                     overnext = null;
@@ -732,6 +732,7 @@ public:
             {
                 if (overnext)
                 {
+                    os = new OverloadSet(ident, os);
                     os.push(overnext);
                     overnext = null;
                     s = os;
@@ -768,13 +769,13 @@ public:
             Dsymbol sa = aliassym.toAlias();
             if (FuncDeclaration fd = sa.isFuncDeclaration())
             {
-                auto fa = new FuncAliasDeclaration(fd);
+                auto fa = new FuncAliasDeclaration(ident, fd);
                 aliassym = fa;
                 return fa.overloadInsert(s);
             }
             if (TemplateDeclaration td = sa.isTemplateDeclaration())
             {
-                auto od = new OverDeclaration(td);
+                auto od = new OverDeclaration(ident, td);
                 aliassym = od;
                 return od.overloadInsert(s);
             }
@@ -902,9 +903,9 @@ public:
     bool hasOverloads;
 
     /****************************** OverDeclaration **************************/
-    extern (D) this(Dsymbol s, bool hasOverloads = true)
+    extern (D) this(Identifier ident, Dsymbol s, bool hasOverloads = true)
     {
-        super(s.ident);
+        super(ident);
         this.overnext = null;
         this.aliassym = s;
         this.hasOverloads = hasOverloads;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -222,7 +222,7 @@ public:
     Dsymbol *aliassym;
     bool hasOverloads;
 
-    OverDeclaration(Dsymbol *s, bool hasOverloads = true);
+    OverDeclaration(Identifier *ident, Dsymbol *s, bool hasOverloads = true);
     const char *kind();
     void semantic(Scope *sc);
     bool equals(RootObject *o);
@@ -677,7 +677,7 @@ public:
     FuncDeclaration *funcalias;
     bool hasOverloads;
 
-    FuncAliasDeclaration(FuncDeclaration *funcalias, bool hasOverloads = true);
+    FuncAliasDeclaration(Identifier *ident, FuncDeclaration *funcalias, bool hasOverloads = true);
 
     FuncAliasDeclaration *isFuncAliasDeclaration() { return this; }
     const char *kind();

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1300,7 +1300,7 @@ public:
                 {
                     s = s2;
                     if (s && s.isOverloadSet())
-                        a = mergeOverloadSet(a, s);
+                        a = mergeOverloadSet(ident, a, s);
                 }
                 else if (s2 && s != s2)
                 {
@@ -1335,7 +1335,7 @@ public:
                              */
                             if ((s2.isOverloadSet() || s2.isOverloadable()) && (a || s.isOverloadable()))
                             {
-                                a = mergeOverloadSet(a, s2);
+                                a = mergeOverloadSet(ident, a, s2);
                                 continue;
                             }
                             if (flags & IgnoreAmbiguous) // if return NULL on ambiguity
@@ -1354,7 +1354,7 @@ public:
                 if (a)
                 {
                     if (!s.isOverloadSet())
-                        a = mergeOverloadSet(a, s);
+                        a = mergeOverloadSet(ident, a, s);
                     s = a;
                 }
                 if (!(flags & IgnoreErrors) && s.prot().kind == PROTprivate && !s.parent.isTemplateMixin())
@@ -1368,11 +1368,11 @@ public:
         return s1;
     }
 
-    final OverloadSet mergeOverloadSet(OverloadSet os, Dsymbol s)
+    final OverloadSet mergeOverloadSet(Identifier ident, OverloadSet os, Dsymbol s)
     {
         if (!os)
         {
-            os = new OverloadSet(s.ident);
+            os = new OverloadSet(ident);
             os.parent = this;
         }
         if (OverloadSet os2 = s.isOverloadSet())
@@ -1387,7 +1387,7 @@ public:
             {
                 for (size_t i = 0; i < os2.a.dim; i++)
                 {
-                    os = mergeOverloadSet(os, os2.a[i]);
+                    os = mergeOverloadSet(ident, os, os2.a[i]);
                 }
             }
         }
@@ -1871,9 +1871,14 @@ public:
     Dsymbols a; // array of Dsymbols
 
     /********************************* OverloadSet ****************************/
-    extern (D) this(Identifier ident)
+    extern (D) this(Identifier ident, OverloadSet os = null)
     {
         super(ident);
+        if (os)
+        {
+            for (size_t i = 0; i < os.a.dim; i++)
+                a.push(os.a[i]);
+        }
     }
 
     void push(Dsymbol s)

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -293,7 +293,7 @@ public:
     ScopeDsymbol(Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
-    OverloadSet *mergeOverloadSet(OverloadSet *os, Dsymbol *s);
+    OverloadSet *mergeOverloadSet(Identifier *ident, OverloadSet *os, Dsymbol *s);
     void importScope(Dsymbol *s, Prot protection);
     bool isforwardRef();
     static void multiplyDefined(Loc loc, Dsymbol *s1, Dsymbol *s2);
@@ -352,7 +352,7 @@ class OverloadSet : public Dsymbol
 public:
     Dsymbols a;         // array of Dsymbols
 
-    OverloadSet(Identifier *ident);
+    OverloadSet(Identifier *ident, OverloadSet *os = NULL);
     void push(Dsymbol *s);
     OverloadSet *isOverloadSet() { return this; }
     const char *kind();

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -7050,8 +7050,6 @@ public:
             TemplateDeclaration tdecl = tempdecl.isTemplateDeclaration();
             if (errs != global.errors)
                 errorSupplemental(loc, "while looking for match for %s", toChars());
-            else if (tovers)
-                error("does not match template overload set %s", tovers.toChars());
             else if (tdecl && !tdecl.overnext)
             {
                 // Only one template, so we can give better error message

--- a/src/func.d
+++ b/src/func.d
@@ -4296,9 +4296,9 @@ public:
 
     /****************************** FuncAliasDeclaration ************************/
     // Used as a way to import a set of functions from another scope into this one.
-    extern (D) this(FuncDeclaration funcalias, bool hasOverloads = true)
+    extern (D) this(Identifier ident, FuncDeclaration funcalias, bool hasOverloads = true)
     {
-        super(funcalias.loc, funcalias.endloc, funcalias.ident, funcalias.storage_class, funcalias.type);
+        super(funcalias.loc, funcalias.endloc, ident, funcalias.storage_class, funcalias.type);
         assert(funcalias != this);
         this.funcalias = funcalias;
         this.hasOverloads = hasOverloads;

--- a/src/traits.d
+++ b/src/traits.d
@@ -62,12 +62,12 @@ extern (C++) static int fptraits(void* param, Dsymbol s)
     if (p.ident == Id.getVirtualMethods && !f.isVirtualMethod())
         return 0;
     Expression e;
-    auto _alias = new FuncAliasDeclaration(f, 0);
-    _alias.protection = f.protection;
+    auto ad = new FuncAliasDeclaration(f.ident, f, 0);
+    ad.protection = f.protection;
     if (p.e1)
-        e = new DotVarExp(Loc(), p.e1, _alias);
+        e = new DotVarExp(Loc(), p.e1, ad);
     else
-        e = new DsymbolExp(Loc(), _alias);
+        e = new DsymbolExp(Loc(), ad);
     p.exps.push(e);
     return 0;
 }
@@ -99,9 +99,9 @@ extern (C++) static void collectUnitTests(Dsymbols* symbols, AA* uniqueUnitTests
         {
             if (!dmd_aaGetRvalue(uniqueUnitTests, cast(void*)unitTest))
             {
-                auto _alias = new FuncAliasDeclaration(unitTest, 0);
-                _alias.protection = unitTest.protection;
-                Expression e = new DsymbolExp(Loc(), _alias);
+                auto ad = new FuncAliasDeclaration(unitTest.ident, unitTest, 0);
+                ad.protection = unitTest.protection;
+                Expression e = new DsymbolExp(Loc(), ad);
                 unitTests.push(e);
                 bool* value = cast(bool*)dmd_aaGet(&uniqueUnitTests, cast(void*)unitTest);
                 *value = true;

--- a/test/fail_compilation/diag14818.d
+++ b/test/fail_compilation/diag14818.d
@@ -1,0 +1,37 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag14818.d(34): Error: None of the overloads of 'func' are callable using argument types (string), candidates are:
+fail_compilation/diag14818.d(12):        diag14818.foo(int _param_0)
+fail_compilation/diag14818.d(13):        diag14818.bar(double _param_0)
+fail_compilation/diag14818.d(35): Error: overload alias diag14818.X does not match any template declaration
+fail_compilation/diag14818.d(36): Error: overloadset diag14818.M does not match any template declaration
+---
+*/
+
+void foo(int) {}
+void bar(double) {}
+alias func = foo;
+alias func = bar;
+// in here, func is a FuncAliasDeclaration;
+
+template Foo(T) if (is(T == int)) {}
+template Bar(T) if (is(T == double)) {}
+
+alias X = Foo;
+alias X = Bar;
+// in here, X is an OverDeclaration
+
+template Mix1() { alias M = Foo; }
+template Mix2() { alias M = Bar; }
+mixin Mix1;
+mixin Mix2;
+alias Y = M;
+// in here, Y is an OverloadSet
+
+void main()
+{
+    func("abc");
+    alias x = X!string;
+    alias y = Y!string;
+}

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -365,7 +365,7 @@ static: // necessary to make overloaded symbols accessible via __traits(getOverl
     void g(string) {}
     alias bar = .f10249;
     alias bar =  g;
-    static assert(Seq10249!(bar)[0].mangleof                                   ==   "6mangle6C102496f10249");      // <- _D6mangle1fFlZv (todo!)
+    static assert(Seq10249!(bar)[0].mangleof                                   ==   "6mangle6C102493bar");         // <- _D6mangle1fFlZv
     static assert(Seq10249!(__traits(getOverloads, C10249, "bar"))[0].mangleof == "_D6mangle6f10249FlZv");         // <-
     static assert(Seq10249!(__traits(getOverloads, C10249, "bar"))[1].mangleof == "_D6mangle6C102491gFAyaZv");     // <-
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14818

The created `OverloadSet` object should have the searched identifier.

Updated 2015/07/22:
Also, the overload objects `OverDeclaration` and `OverloadSet` that is generated by `AliasDeclaration` should have the alias identifier.
