### PR TITLE
[REG2.068a] Issue 14814 - ld: GOT load reloc does not point to a movq instruction

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1129,6 +1129,7 @@ elem *toElem(Expression *e, IRState *irs)
             if (Type *t = isType(e->obj))
             {
                 result = getTypeInfo(t, irs);
+                result = el_bin(OPadd, result->Ety, result, el_long(TYsize_t, t->vtinfo->offset));
                 return;
             }
             if (Expression *ex = isExpression(e->obj))

--- a/test/runnable/imports/link14814a.d
+++ b/test/runnable/imports/link14814a.d
@@ -1,0 +1,11 @@
+module imports.link14814a;
+
+void fun0()
+{
+}
+
+void fun4()
+{
+    void function()[TypeInfo] funs;
+    funs[typeid(int)] = &fun0;
+}

--- a/test/runnable/link14814.d
+++ b/test/runnable/link14814.d
@@ -1,0 +1,10 @@
+// EXTRA_SOURCES: imports/link14814a.d
+// PERMUTE_ARGS: -inline -release -g -O -fPIC
+// COMPILE_SEPARATELY
+
+import imports.link14814a;
+
+void main()
+{
+    fun4;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14814

Same with #4828 excepting that the base branch is `stable`.
