### PR TITLE
[REG] fix Issue 12420 - [AA] Can't set associative array with array as key …

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5655,7 +5655,8 @@ extern (C++) final class IndexExp : BinExp
         if (e1.type.toBasetype().ty == Taarray)
         {
             Type t2b = e2.type.toBasetype();
-            if (t2b.ty == Tarray && t2b.nextOf().isMutable())
+            if (t2b.ty == Tarray &&     // don't require class keys to be immutable
+                .implicitConvTo(e2, e2.type.immutableOf()) < MATCH.constant)
             {
                 error("associative arrays can only be assigned values with immutable keys, not `%s`", e2.type.toChars());
                 return new ErrorExp();

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -93,8 +93,8 @@ void test2()
 
 void test4()
 {
-    int[const(ubyte)[]] b;
-    const(ubyte)[] x;
+    int[immutable(ubyte)[]] b;
+    immutable(ubyte)[] x;
     b[x] = 3;
     assert(b[x] == 3);
 }
@@ -113,8 +113,8 @@ void test5()
 
 void test6()
 {
-    int[const(int)[]] b;
-    const(int)[] x;
+    int[immutable(int)[]] b;
+    immutable(int)[] x;
     b[x] = 3;
     assert(b[x] == 3);
 }
@@ -1343,6 +1343,14 @@ void test19112()
 
 /************************************************/
 
+void test12420()
+{
+    int[string] aa;
+    aa[new char[1]] = 5;
+}
+
+/************************************************/
+
 int main()
 {
     printf("before test 1\n");   test1();
@@ -1393,6 +1401,7 @@ int main()
     test14089();
     test14321();
     test19112();
+    test12420();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
…value using key type

https://issues.dlang.org/show_bug.cgi?id=12420

The fix is implemented by attempting to implicitly cast the key to immutable.

Although this is a regression fix, it breaks existing code (but that code is arguably broken anyway). I don't think it should be pulled for 2.068, too risky.
