### PR TITLE
14831 - Each function local symbols should have unique mangled name

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1134,7 +1134,11 @@ public:
         //printf(" semantic type = %s\n", type ? type->toChars() : "null");
         type.checkDeprecated(loc, sc);
         linkage = sc.linkage;
-        this.parent = sc.parent;
+
+        parent = sc.parent;
+        if (!isDataseg())
+            localNum = getFunctionLocalNum(sc, this);
+
         //printf("this = %p, parent = %p, '%s'\n", this, parent, parent->toChars());
         protection = sc.protection;
         /* If scope's alignment is the default, use the type's alignment,

--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -17,6 +17,7 @@ import ddmd.cppmangle;
 import ddmd.dclass;
 import ddmd.declaration;
 import ddmd.dmodule;
+import ddmd.dscope;
 import ddmd.dstruct;
 import ddmd.dsymbol;
 import ddmd.dtemplate;
@@ -127,6 +128,18 @@ extern (C++) void MODtoDecoBuffer(OutBuffer* buf, MOD mod)
     default:
         assert(0);
     }
+}
+
+extern (C++) uint getFunctionLocalNum(Scope *sc, Dsymbol s)
+{
+    auto fd = s.toParent().isFuncDeclaration();
+    if (!fd || fd.semanticRun != PASSsemantic3)
+        return 0;
+
+    auto sprev = fd.localsymtab.update(s);
+    //printf("[%s] %p %s, sprev = %p, fd = %s ==> num:%d\n",
+    //    s.loc.toChars(), s, s.toPrettyChars(), sprev, fd.toPrettyChars(), sprev ? sprev.localNum + 1 : 0);
+    return sprev ? sprev.localNum + 1 : 0;
 }
 
 extern (C++) final class Mangler : Visitor
@@ -317,6 +330,51 @@ public:
     }
 
     ////////////////////////////////////////////////////////////////////////////
+
+    void mangleParent(Dsymbol s)
+    {
+        TemplateInstance ti = s.isTemplateInstance();
+        if (ti && !ti.isTemplateMixin())
+            s = ti.tempdecl;
+        Dsymbol p = s.parent;
+
+        if (p)
+        {
+            mangleParent(p);
+            if (p.getIdent())
+            {
+                const(char)* id = p.ident.toChars();
+                toBuffer(id, p);
+                if (FuncDeclaration f = p.isFuncDeclaration())
+                    mangleFunc(f, true);
+            }
+            else
+                buf.writeByte('0');
+
+            mangleAnonScopeName(s.localNum);
+        }
+    }
+
+    void mangleAnonScopeName(uint num)
+    {
+        if (!num)
+            return;
+
+        OutBuffer tmp;
+        tmp.writestring("__S");
+
+        // Encode 'num' with the scheme "[A-Z]+"
+        --num;  // change to 0 base
+        do
+        {
+            uint r = num % 26;
+            tmp.writeByte(cast(char)('A' + r));
+            num = (num - r) % 26;
+        } while (num);
+
+        buf.printf("%llu%.*s", cast(ulong)tmp.offset, tmp.offset, tmp.data);
+    }
+
     void mangleDecl(Declaration sthis)
     {
         mangleParent(sthis);
@@ -333,28 +391,6 @@ public:
         }
         else
             assert(0);
-    }
-
-    void mangleParent(Dsymbol s)
-    {
-        Dsymbol p;
-        if (TemplateInstance ti = s.isTemplateInstance())
-            p = ti.isTemplateMixin() ? ti.parent : ti.tempdecl.parent;
-        else
-            p = s.parent;
-        if (p)
-        {
-            mangleParent(p);
-            if (p.getIdent())
-            {
-                const(char)* id = p.ident.toChars();
-                toBuffer(id, s);
-                if (FuncDeclaration f = p.isFuncDeclaration())
-                    mangleFunc(f, true);
-            }
-            else
-                buf.writeByte('0');
-        }
     }
 
     void mangleFunc(FuncDeclaration fd, bool inParent)

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1892,8 +1892,9 @@ public:
     {
         Identifier ident = s.ident;
         Dsymbol* ps = cast(Dsymbol*)dmd_aaGet(&tab, cast(void*)ident);
+        Dsymbol sprev = *ps;
         *ps = s;
-        return s;
+        return sprev;
     }
 
     // when ident and s are not the same

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -247,10 +247,6 @@ public:
     {
         if (this == o)
             return true;
-        Dsymbol s = cast(Dsymbol)o;
-        // Overload sets don't have an ident
-        if (s && ident && s.ident && ident.equals(s.ident))
-            return true;
         return false;
     }
 

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -198,6 +198,9 @@ public:
     // (only use this with ddoc)
     UnitTestDeclaration ddocUnittest;
 
+    // unique number to distinguish same name symbols in function local
+    uint localNum;
+
     final extern (D) this()
     {
         //printf("Dsymbol::Dsymbol(%p)\n", this);

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -85,6 +85,7 @@ struct Ungag
 
 const char *mangle(Dsymbol *s);
 const char *mangleExact(FuncDeclaration *fd);
+unsigned getFunctionLocalNum(Scope *sc, Dsymbol *s);
 
 enum PROTKIND
 {
@@ -157,6 +158,7 @@ public:
     char *depmsg;               // customized deprecation message
     UserAttributeDeclaration *userAttribDecl;   // user defined attributes
     UnitTestDeclaration *ddocUnittest; // !=NULL means there's a ddoc unittest associated with this symbol (only use this with ddoc)
+    unsigned localNum;          // unique number to distinguish same name symbols in function local
 
     Dsymbol();
     Dsymbol(Identifier *);

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -488,6 +488,10 @@ public:
             parent = sc.parent;
         isstatic = toParent().isModule() || (_scope.stc & STCstatic);
         protection = sc.protection;
+
+        if (!literal)
+            localNum = getFunctionLocalNum(sc, this);
+
         if (global.params.doDocComments)
         {
             origParameters = new TemplateParameters();

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -4305,19 +4305,20 @@ public:
         }
         if (ident == Id.reverse && (n.ty == Tchar || n.ty == Twchar))
         {
-            static __gshared const(char)** reverseName = ["_adReverseChar", "_adReverseWchar"];
-            static __gshared FuncDeclaration* reverseFd = [null, null];
             warning(e.loc, "use std.algorithm.reverse instead of .reverse property");
+
+            static __gshared const(char)** reverseCharsName = ["_adReverseChar", "_adReverseWchar"];
+            static __gshared FuncDeclaration* reverseCharsFd = [null, null];
             int i = n.ty == Twchar;
-            if (!reverseFd[i])
+            if (!reverseCharsFd[i])
             {
                 auto params = new Parameters();
                 Type next = n.ty == Twchar ? Type.twchar : Type.tchar;
                 Type arrty = next.arrayOf();
                 params.push(new Parameter(0, arrty, null, null));
-                reverseFd[i] = FuncDeclaration.genCfunc(params, arrty, reverseName[i]);
+                reverseCharsFd[i] = FuncDeclaration.genCfunc(params, arrty, reverseCharsName[i]);
             }
-            Expression ec = new VarExp(Loc(), reverseFd[i]);
+            Expression ec = new VarExp(Loc(), reverseCharsFd[i]);
             e = e.castTo(sc, n.arrayOf()); // convert to dynamic array
             auto arguments = new Expressions();
             arguments.push(e);
@@ -4326,19 +4327,21 @@ public:
         }
         else if (ident == Id.sort && (n.ty == Tchar || n.ty == Twchar))
         {
-            static __gshared const(char)** sortName = ["_adSortChar", "_adSortWchar"];
-            static __gshared FuncDeclaration* sortFd = [null, null];
             warning(e.loc, "use std.algorithm.sort instead of .sort property");
+
+            static __gshared const(char)** sortCharsName = ["_adSortChar", "_adSortWchar"];
+            static __gshared FuncDeclaration* sortCharsFd = [null, null];
             int i = n.ty == Twchar;
-            if (!sortFd[i])
+            if (!sortCharsFd[i])
             {
                 auto params = new Parameters();
                 Type next = n.ty == Twchar ? Type.twchar : Type.tchar;
                 Type arrty = next.arrayOf();
                 params.push(new Parameter(0, arrty, null, null));
-                sortFd[i] = FuncDeclaration.genCfunc(params, arrty, sortName[i]);
+                sortCharsFd[i] = FuncDeclaration.genCfunc(params, arrty, sortCharsName[i]);
             }
-            Expression ec = new VarExp(Loc(), sortFd[i]);
+
+            Expression ec = new VarExp(Loc(), sortCharsFd[i]);
             e = e.castTo(sc, n.arrayOf()); // convert to dynamic array
             auto arguments = new Expressions();
             arguments.push(e);
@@ -4347,24 +4350,23 @@ public:
         }
         else if (ident == Id.reverse)
         {
-            Expression ec;
-            FuncDeclaration fd;
-            Expressions* arguments;
-            dinteger_t size = next.size(e.loc);
             warning(e.loc, "use std.algorithm.reverse instead of .reverse property");
-            assert(size);
-            static __gshared FuncDeclaration adReverse_fd = null;
-            if (!adReverse_fd)
+
+            static __gshared FuncDeclaration reverseFd = null;
+            if (!reverseFd)
             {
                 auto params = new Parameters();
                 params.push(new Parameter(0, Type.tvoid.arrayOf(), null, null));
                 params.push(new Parameter(0, Type.tsize_t, null, null));
-                adReverse_fd = FuncDeclaration.genCfunc(params, Type.tvoid.arrayOf(), Id.adReverse);
+                reverseFd = FuncDeclaration.genCfunc(params, Type.tvoid.arrayOf(), Id.adReverse);
             }
-            fd = adReverse_fd;
-            ec = new VarExp(Loc(), fd);
+
+            dinteger_t size = next.size(e.loc);
+            assert(size);
+
+            Expression ec = new VarExp(Loc(), reverseFd);
             e = e.castTo(sc, n.arrayOf()); // convert to dynamic array
-            arguments = new Expressions();
+            auto arguments = new Expressions();
             arguments.push(e);
             arguments.push(new IntegerExp(Loc(), size, Type.tsize_t));
             e = new CallExp(e.loc, ec, arguments);
@@ -4372,20 +4374,20 @@ public:
         }
         else if (ident == Id.sort)
         {
-            static __gshared FuncDeclaration fd = null;
-            Expression ec;
-            Expressions* arguments;
             warning(e.loc, "use std.algorithm.sort instead of .sort property");
-            if (!fd)
+
+            static __gshared FuncDeclaration sortFd = null;
+            if (!sortFd)
             {
                 auto params = new Parameters();
                 params.push(new Parameter(0, Type.tvoid.arrayOf(), null, null));
                 params.push(new Parameter(0, Type.dtypeinfo.type, null, null));
-                fd = FuncDeclaration.genCfunc(params, Type.tvoid.arrayOf(), "_adSort");
+                sortFd = FuncDeclaration.genCfunc(params, Type.tvoid.arrayOf(), "_adSort");
             }
-            ec = new VarExp(Loc(), fd);
+
+            Expression ec = new VarExp(Loc(), sortFd);
             e = e.castTo(sc, n.arrayOf()); // convert to dynamic array
-            arguments = new Expressions();
+            auto arguments = new Expressions();
             arguments.push(e);
             // don't convert to dynamic array
             Expression tid = new TypeidExp(e.loc, n);

--- a/src/statement.d
+++ b/src/statement.d
@@ -2763,10 +2763,10 @@ public:
                      *      _aaApply2(aggr, keysize, flde)
                      */
                     static __gshared const(char)** name = ["_aaApply", "_aaApply2"];
-                    static __gshared FuncDeclaration* fdapply = [null, null];
+                    static __gshared FuncDeclaration* aaApplyFd = [null, null];
                     static __gshared TypeDelegate* fldeTy = [null, null];
                     ubyte i = (dim == 2 ? 1 : 0);
-                    if (!fdapply[i])
+                    if (!aaApplyFd[i])
                     {
                         params = new Parameters();
                         params.push(new Parameter(0, Type.tvoid.pointerTo(), null, null));
@@ -2777,7 +2777,7 @@ public:
                             dgparams.push(new Parameter(0, Type.tvoidptr, null, null));
                         fldeTy[i] = new TypeDelegate(new TypeFunction(dgparams, Type.tint32, 0, LINKd));
                         params.push(new Parameter(0, fldeTy[i], null, null));
-                        fdapply[i] = FuncDeclaration.genCfunc(params, Type.tint32, name[i]);
+                        aaApplyFd[i] = FuncDeclaration.genCfunc(params, Type.tint32, name[i]);
                     }
                     auto exps = new Expressions();
                     exps.push(aggr);
@@ -2791,7 +2791,7 @@ public:
                     }
                     exps.push(new IntegerExp(Loc(), keysize, Type.tsize_t));
                     exps.push(flde);
-                    ec = new VarExp(Loc(), fdapply[i]);
+                    ec = new VarExp(Loc(), aaApplyFd[i]);
                     ec = new CallExp(loc, ec, exps);
                     ec.type = Type.tint32; // don't run semantic() on ec
                 }

--- a/test/fail_compilation/fail39.d
+++ b/test/fail_compilation/fail39.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail39.d(11): Error: function fail39.main.foo is a nested function and cannot be accessed from fail39.main.__funcliteral2
+fail_compilation/fail39.d(11): Error: function fail39.main.foo is a nested function and cannot be accessed from fail39.main.__funcliteral3
 ---
 */
 

--- a/test/fail_compilation/ice11822.d
+++ b/test/fail_compilation/ice11822.d
@@ -5,7 +5,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11822.d(32): Deprecation: function ice11822.d is deprecated
-fail_compilation/ice11822.d(21):        instantiated from here: S!(__lambda1)
+fail_compilation/ice11822.d(21):        instantiated from here: S!(__lambda2)
 fail_compilation/ice11822.d(32):        instantiated from here: g!((n) => d(i))
 ---
 */

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -418,7 +418,7 @@ void test11776()
             auto s = S11776!(a => 1)();
             static assert(typeof(s).mangleof ==
                 "S"~"6mangle"~"56"~(
-                    "__T"~"6S11776"~"S42"~("6mangle"~"9test11776"~"FZ"~"9__lambda1MFZ"~"9__lambda1")~"Z"
+                    "__T"~"6S11776"~"S42"~("6mangle"~"9test11776"~"FZ"~"9__lambda1MFZ"~"9__lambda2")~"Z"
                 )~"6S11776");
         }
     };
@@ -539,10 +539,72 @@ void test12231()
 }
 
 /***************************************************/
+// 14831
+
+alias TypeTuple(T...) = T;
+alias TypeOf14820(alias A) = typeof(A);
+
+auto sort10619(alias dg)() { return dg; }
+
+void test14831a()
+{
+    // Bugzilla 9748
+    foreach (i; TypeTuple!(1, 2, 3))
+    {
+        uint j;
+        static if (i == 1) static assert(j.mangleof == "_D6mangle10test14831aFZ"~        "1jk");
+        static if (i == 2) static assert(j.mangleof == "_D6mangle10test14831aFZ"~"4__SA"~"1jk");
+        static if (i == 3) static assert(j.mangleof == "_D6mangle10test14831aFZ"~"4__SB"~"1jk");
+        void set()(int n)
+        {
+            static if (i == 1) static assert (set.mangleof == "_D6mangle10test14831aFZ"~        "8__T3setZ3setMFiZv");
+            static if (i == 2) static assert (set.mangleof == "_D6mangle10test14831aFZ"~"4__SA"~"8__T3setZ3setMFiZv");
+            static if (i == 3) static assert (set.mangleof == "_D6mangle10test14831aFZ"~"4__SB"~"8__T3setZ3setMFiZv");
+            j = n;
+        }
+        template X() {}
+        static if (i == 1) static assert (X.mangleof == "6mangle10test14831aFZ"~        "1X");
+        static if (i == 2) static assert (X.mangleof == "6mangle10test14831aFZ"~"4__SA"~"1X");
+        static if (i == 3) static assert (X.mangleof == "6mangle10test14831aFZ"~"4__SB"~"1X");
+
+        static if (i == 1) static assert (X!().mangleof == "6mangle10test14831aFZ"~        "6__T1XZ");
+        static if (i == 2) static assert (X!().mangleof == "6mangle10test14831aFZ"~"4__SA"~"6__T1XZ");
+        static if (i == 3) static assert (X!().mangleof == "6mangle10test14831aFZ"~"4__SB"~"6__T1XZ");
+
+        set(i);
+        assert(j == i);
+    }
+    uint j;
+    static assert(j.mangleof == "_D6mangle10test14831aFZ"~"4__SC"~"1jk");
+
+    // Bugzilla 10619
+    bool lt(int a, int b) { return a < b; }
+    bool gt(int a, int b) { return a > b; }
+    bool delegate(int, int) dg1;
+    bool delegate(int, int) dg2;
+    {
+        auto dg = &lt;
+        dg1 = sort10619!(dg)();
+    }
+    auto dg = &gt;
+    dg2 = sort10619!(dg)();
+    assert(dg1 == &lt);
+    assert(dg2 == &gt);
+
+    // Bugzilla 14820
+    foreach (T; TypeTuple!(int, short))
+    {
+        T t;
+        static assert(is(typeof(t) == TypeOf14820!t));
+    }
+}
+
+/***************************************************/
 
 void main()
 {
     test10077h();
     test10077i();
     test12044();
+    test14831a();
 }

--- a/test/runnable/testkeyword.d
+++ b/test/runnable/testkeyword.d
@@ -97,8 +97,8 @@ void main(string[] args) nothrow
 
     auto funcLiteral = (int x, int y)
     {
-        enum thisFunc  = "testkeyword.main.__lambda3";
-        enum thisFunc2 = "testkeyword.main.__lambda3(int x, int y)";
+        enum thisFunc  = "testkeyword.main.__lambda5";
+        enum thisFunc2 = "testkeyword.main.__lambda5(int x, int y)";
 
         static assert(getFuncArgFile()  == thisFile);
         static assert(getFuncArgLine()  == 104);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14831

Current ABI specification does not explain anything about the mangling scheme for function local symbol, but if we need to update the spec page, it would be:

```
QualifiedName:
    SymbolName
    SymbolName QualifiedName
    SymbolName AnonScopeName QualifiedName    // new

AnonScopeName:    // new
    Number __S Name
```
