### PR TITLE
fix Issue 14663  - shared library test - link_linkdep - segfaults on FreeBSD 10

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -3502,7 +3502,8 @@ static void obj_rtinit()
 
         // put a reference into .ctors/.dtors each
         const char *p[] = {".dtors.d_dso_dtor", ".ctors.d_dso_ctor"};
-        const int flags = SHF_ALLOC|SHF_GROUP;
+        // needs to be writeable for PIC code, see Bugzilla 13117
+        const int flags = SHF_ALLOC | SHF_WRITE | SHF_GROUP;
         for (size_t i = 0; i < 2; ++i)
         {
             seg = ElfObj::getsegment(p[i], NULL, SHT_PROGBITS, flags, NPTRSIZE);


### PR DESCRIPTION
- the .ctors.d_dso_ctor and .dtors.d_dso_dtor sections
  are merged into .ctors/.dtors or .init_array/.fini_array
  depending on the linker script
- those sections need to be writeable b/c they can contain
  relocations (in PIC code)
- merging readonly with writeable sections cause the gcc49 linker
  on FBSD10 to collapse the readonly and writeable segments

[Issue 14663 – shared library test - link_linkdep - segfaults on FreeBSD 10](https://issues.dlang.org/show_bug.cgi?id=14663)
