### PR TITLE
use c++/cc as compiler defaults

### DIFF
--- a/src/link.d
+++ b/src/link.d
@@ -447,7 +447,7 @@ extern (C++) int runLINK()
         Strings argv;
         const(char)* cc = getenv("CC");
         if (!cc)
-            cc = "gcc";
+            cc = "cc";
         argv.push(cc);
         argv.insert(1, global.params.objfiles);
         version (OSX)

--- a/travis.sh
+++ b/travis.sh
@@ -2,6 +2,10 @@
 
 set -exo pipefail
 
+# add missing cc link in gdc-4.9.3 download
+if [ $DC = gdc ] && [ ! -f $(dirname $(which gdc))/cc ]; then
+    ln -s gcc $(dirname $(which gdc))/cc
+fi
 N=2
 
 git clone --depth=1 https://github.com/D-Programming-Language/druntime.git ../druntime


### PR DESCRIPTION
- supports more platforms out of the box, e.g. FBSD and OSX
- use CXX instead of CC for C++ compilers
- still supports old HOST_CC variable
- use HOST_CXX instead of CXX for impcnvgen and optabgen
