### PR TITLE
[REG 2.066] Issue 14838 - Wrong attribute inference for auto-generated class destructor with static array of non-POD type

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -499,11 +499,6 @@ FuncDeclaration *buildXopEquals(StructDeclaration *sd, Scope *sc)
         e = new DotIdExp(sd->loc, e, id);
         e = e->semantic(sc);
         Dsymbol *s = getDsymbol(e);
-        if (!s)
-        {
-            ::error(Loc(), "Internal Compiler Error: %s not found in object module. You must update druntime", id->toChars());
-            fatal();
-        }
         assert(s);
         sd->xerreq = s->isFuncDeclaration();
     }
@@ -624,11 +619,6 @@ FuncDeclaration *buildXopCmp(StructDeclaration *sd, Scope *sc)
         e = new DotIdExp(sd->loc, e, id);
         e = e->semantic(sc);
         Dsymbol *s = getDsymbol(e);
-        if (!s)
-        {
-            ::error(Loc(), "Internal Compiler Error: %s not found in object module. You must update druntime", id->toChars());
-            fatal();
-        }
         assert(s);
         sd->xerrcmp = s->isFuncDeclaration();
     }

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -729,7 +729,8 @@ StructDeclaration *needsPostblit(Type *t)
  */
 
 elem *setArray(elem *eptr, elem *edim, Type *tb, elem *evalue, IRState *irs, int op)
-{   int r;
+{
+    int r;
     elem *e;
     unsigned sz = tb->size();
 
@@ -760,10 +761,11 @@ Lagain:
             break;
 
         case Tstruct:
+        {
             if (I32)
                 goto Ldefault;
 
-        {   TypeStruct *tc = (TypeStruct *)tb;
+            TypeStruct *tc = (TypeStruct *)tb;
             StructDeclaration *sd = tc->sym;
             if (sd->arg1type && !sd->arg2type)
             {
@@ -795,12 +797,14 @@ Lagain:
             {
                 StructDeclaration *sd = needsPostblit(tb);
                 if (sd)
-                {   /* Need to do postblit.
+                {
+                    /* Need to do postblit.
                      *   void *_d_arraysetassign(void *p, void *value, int dim, TypeInfo ti);
                      */
                     r = (op == TOKconstruct) ? RTLSYM_ARRAYSETCTOR : RTLSYM_ARRAYSETASSIGN;
                     evalue = el_una(OPaddr, TYnptr, evalue);
-                    elem *eti = getTypeInfo(tb, irs);
+                    // This is a hack so we can call postblits on const/immutable objects.
+                    elem *eti = getTypeInfo(tb->unSharedOf()->mutableOf(), irs);
                     e = el_params(eti, edim, evalue, eptr, NULL);
                     e = el_bin(OPcall,TYnptr,el_var(rtlsym[r]),e);
                     return e;

--- a/src/idgen.d
+++ b/src/idgen.d
@@ -265,6 +265,8 @@ Msgtable[] msgtable =
     { "criticalenter", "_d_criticalenter" },
     { "criticalexit", "_d_criticalexit" },
     { "_ArrayEq" },
+    { "_ArrayPostblit" },
+    { "_ArrayDtor" },
 
     // For pragma's
     { "Pinline", "inline" },

--- a/src/module.c
+++ b/src/module.c
@@ -540,6 +540,12 @@ Module *Module::parse()
             " foreach (size_t i; 0 .. a.length) { if (a[i] != b[i]) return false; }\n"
             " return true; }\n";
 
+        static const utf8_t code_ArrayPostblit[] =
+            "void _ArrayPostblit(T)(T[] a) { foreach (ref T e; a) e.__xpostblit(); }\n";
+
+        static const utf8_t code_ArrayDtor[] =
+            "void _ArrayDtor(T)(T[] a) { foreach_reverse (ref T e; a) e.__xdtor(); }\n";
+
         static const utf8_t code_xopEquals[] =
             "bool _xopEquals(in void*, in void*) { throw new Error(\"TypeInfo.equals is not implemented\"); }\n";
 
@@ -561,6 +567,16 @@ Module *Module::parse()
         if (arreq)
         {
             Parser p(loc, this, code_ArrayEq, strlen((const char *)code_ArrayEq), 0);
+            p.nextToken();
+            members->append(p.parseDeclDefs(0));
+        }
+        {
+            Parser p(loc, this, code_ArrayPostblit, strlen((const char *)code_ArrayPostblit), 0);
+            p.nextToken();
+            members->append(p.parseDeclDefs(0));
+        }
+        {
+            Parser p(loc, this, code_ArrayDtor, strlen((const char *)code_ArrayDtor), 0);
             p.nextToken();
             members->append(p.parseDeclDefs(0));
         }

--- a/test/compilable/test14838.d
+++ b/test/compilable/test14838.d
@@ -1,0 +1,91 @@
+// PERMUTE_ARGS:
+
+struct A(T) { ~this() {} }
+class C { A!int[1] array; }
+
+void test14838() pure nothrow @nogc @safe
+{
+    C c;
+    c.__xdtor();    // C.~this() will also be inferred to
+                    // pure nothrow @nogc @safe
+
+    A!int[1] array;
+    // scope destructor call does not cause attribute violation.
+}
+
+// ----
+
+/*
+ * This is a reduced test case comes from std.container.Array template,
+ * to fix the semantic analysis order issue for correct destructor attribute inference.
+ *
+ * Before the bugfix:
+ *   1. StructDeclaration('Array!int')->semantic() instantiates
+ *      RangeT!(Array!int) at the `alias Range = ...;`, but
+ *      StructDeclaration('RangeT!(Array!int)')->semantic() exits
+ *      with sizeok == SIZEOKfwd, because the size of _outer_ field is not yet determined.
+ *   2. StructDeclaration('Array!int')->semantic() succeeds to determine the size
+ *      (sizeok = SIZEOKdone).
+ *   3. StructDeclaration('Array!int')->buildOpAssign() will generate opAssign because
+ *      Array!int._data field has identity opAssign member function.
+ *   4. The semantic3 will get called for the generated opAssign, then
+ *         6-1. Array!int.~this() semantic3, and
+ *         6-2. RefCounted!(Array!int.Payload).~this() semantic3
+ *      will also get called to infer their attributes.
+ *   5. In RefCounted!(Array!int.Payload).~this(), destroy(t) will be instantiated.
+ *      At that, TemplateInstance::expandMembers() will invoke runDeferredSemantic()
+ *      and it will re-run StructDeclaration('RangeT!(Array!int)')->semantic().
+ *   6. StructDeclaration('RangeT!(Array!int)')->semantic() determines the size
+ *      (sizeok = SIZEOKdone). Then, it will generate identity opAssign and run its semantic3.
+ *      It will need to infer RangeT!(Array!int).~this() attribute, then it requires the
+ *      correct attribute of Array!int.~this().
+ * 
+ *      However, the Array!int.~this() attribute is not yet determined! [bug]
+ *      -> it's wongly handled as impure/system/throwable/gc-able.
+ * 
+ *      -> then, the attribute inference results for
+ *         RangeT!(Array!int).~this() and Array!int.~this() will be incorrect.
+ *
+ * After the bugfix:
+ *   In 6, StructDeclaration('RangeT!(Array!int)')->semantic() will check that:
+ *   all base struct types of the instance fields have completed addition of
+ *   special functions (dtor, opAssign, etc).
+ *   If not, it will defer the completion of its semantic pass.
+ */
+
+void destroy14838(S)(ref S s) if (is(S == struct))
+{
+    s.__xdtor();
+}
+
+struct RefCounted14838(T)
+{
+    ~this()
+    {
+        T t;
+        .destroy14838(t);
+    }
+
+    void opAssign(typeof(this) rhs) {}
+}
+
+struct RangeT14838(A)
+{
+    A[1] _outer_;
+}
+
+struct Array14838(T)
+{
+    struct Payload
+    {
+        ~this() {}
+    }
+    RefCounted14838!Payload _data;
+
+    alias Range = RangeT14838!Array14838;
+}
+
+class Test14838
+{
+    Array14838!int[1] field;
+}

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -3943,6 +3943,59 @@ void test14264()
 }
 
 /**********************************/
+// 14838
+
+int test14838() pure nothrow @safe
+{
+    int dtor;
+
+    struct S14838(T)
+    {
+        ~this() { ++dtor; }
+    }
+    struct X14838
+    {
+              S14838!int ms;
+        const S14838!int cs;
+
+              S14838!int[2] ma;
+        const S14838!int[2] ca;
+
+              S14838!int[2][2] ma2x2;
+        const S14838!int[2][2] ca2x2;
+
+        // number of S14838 = 1*2 + 2*2 + 4*2 = 14
+    }
+
+    void test(Dg)(scope Dg code)
+    {
+        dtor = 0;
+        code();
+    }
+
+    test(delegate{       S14838!int a; }); assert(dtor == 1);
+    test(delegate{ const S14838!int a; }); assert(dtor == 1);
+
+    test(delegate{       S14838!int[2] a; }); assert(dtor == 2);
+    test(delegate{ const S14838!int[2] a; }); assert(dtor == 2);
+
+    test(delegate{       S14838!int[2][2] a; }); assert(dtor == 4);
+    test(delegate{ const S14838!int[2][2] a; }); assert(dtor == 4);
+
+    test(delegate{       X14838 a; }); assert(dtor == 1 * 14);
+    test(delegate{ const X14838 a; }); assert(dtor == 1 * 14);
+
+    test(delegate{       X14838[2] a; }); assert(dtor == 2 * 14);
+    test(delegate{ const X14838[2] a; }); assert(dtor == 2 * 14);
+
+    test(delegate{       X14838[2][2] a; }); assert(dtor == 4 * 14);
+    test(delegate{ const X14838[2][2] a; }); assert(dtor == 4 * 14);
+
+    return 1;
+}
+static assert(test14838());
+
+/**********************************/
 
 int main()
 {
@@ -4058,6 +4111,7 @@ int main()
     test13669();
     test13095();
     test14264();
+    test14838();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14838

Add `_ArrayPostblit` and `_ArrayDtor`, then use them for static array copying and destruction.
