### PR TITLE
[REG2.066] Issue 14853 - DMD segfaults with the cast from mutable struct new to shared

### DIFF
--- a/src/cast.c
+++ b/src/cast.c
@@ -1213,6 +1213,8 @@ MATCH implicitConvTo(Expression *e, Type *t)
                 for (size_t i = 0; i < e->arguments->dim; ++i)
                 {
                     Expression *earg = (*e->arguments)[i];
+                    if (!earg)  // Bugzilla 14853: if it's on overlapped field
+                        continue;
                     Type *targ = earg->type->toBasetype();
 #if LOG
                     printf("[%d] earg: %s, targ: %s\n", (int)i, earg->toChars(), targ->toChars());

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7484,6 +7484,39 @@ class Outer14552
 }
 
 /***************************************************/
+// 14853
+
+struct Queue14853(T)
+{
+    struct Node
+    {
+        T mfPayload = T.init;
+        union
+        {
+                   typeof(this)*  mfPrev;
+            shared(typeof(this)*) mfShPrev;
+        }
+        union
+        {
+                   typeof(this)*  mfNext;
+            shared(typeof(this)*) mfShNext;
+        }
+    }
+
+    Node root;
+
+    void pfPut(T v, Node* r = null)
+    {
+        shared n = new Node(v);    // problem!
+    }
+}
+
+void test14853()
+{
+    auto b1 = new Queue14853!uint;
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14853

A trivial bug, lack of NULL check.
