### PR TITLE
Move cblock, lblock and fwdrefs out of frontend, making it a part of IRState

### DIFF
--- a/src/arraytypes.h
+++ b/src/arraytypes.h
@@ -68,6 +68,4 @@ typedef Array<class GotoStatement *> GotoStatements;
 
 typedef Array<class TemplateInstance *> TemplateInstances;
 
-typedef Array<struct block *> Blocks;
-
 #endif

--- a/src/glue.c
+++ b/src/glue.c
@@ -998,6 +998,8 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
     IRState irs(m, fd);
     Dsymbols deferToObj;                   // write these to OBJ file later
     irs.deferToObj = &deferToObj;
+    Labels labels;                         // don't allocate as only one list per function
+    irs.labels = &labels;
 
     symbol *shidden = NULL;
     Symbol *sthis = NULL;

--- a/src/glue.c
+++ b/src/glue.c
@@ -998,7 +998,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
     IRState irs(m, fd);
     Dsymbols deferToObj;                   // write these to OBJ file later
     irs.deferToObj = &deferToObj;
-    Labels labels;                         // don't allocate as only one list per function
+    AA *labels = NULL;
     irs.labels = &labels;
 
     symbol *shidden = NULL;

--- a/src/irstate.c
+++ b/src/irstate.c
@@ -39,6 +39,7 @@ IRState::IRState(IRState *irs, Statement *s)
         blx = irs->blx;
         deferToObj = irs->deferToObj;
         varsInScope = irs->varsInScope;
+        labels = irs->labels;
     }
     else
     {
@@ -49,6 +50,7 @@ IRState::IRState(IRState *irs, Statement *s)
         blx = NULL;
         deferToObj = NULL;
         varsInScope = NULL;
+        labels = NULL;
     }
 }
 
@@ -74,6 +76,7 @@ IRState::IRState(IRState *irs, Dsymbol *s)
         blx = irs->blx;
         deferToObj = irs->deferToObj;
         varsInScope = irs->varsInScope;
+        labels = irs->labels;
     }
     else
     {
@@ -84,6 +87,7 @@ IRState::IRState(IRState *irs, Dsymbol *s)
         blx = NULL;
         deferToObj = NULL;
         varsInScope = NULL;
+        labels = NULL;
     }
 }
 
@@ -107,6 +111,7 @@ IRState::IRState(Module *m, Dsymbol *s)
     deferToObj = NULL;
     startaddress = NULL;
     varsInScope = NULL;
+    labels = NULL;
 }
 
 block *IRState::getBreakBlock(Identifier *ident)

--- a/src/irstate.h
+++ b/src/irstate.h
@@ -25,10 +25,7 @@ struct Symbol;
 class FuncDeclaration;
 struct Blockx;
 struct elem;
-struct Label;
 #include "arraytypes.h"
-
-typedef Array<struct Label *> Labels;
 
 struct IRState
 {
@@ -45,7 +42,7 @@ struct IRState
     elem *ehidden;              // transmit hidden pointer to CallExp::toElem()
     Symbol *startaddress;
     VarDeclarations *varsInScope; // variables that are in scope that will need destruction later
-    Labels *labels;             // list of labels used/declared in function
+    AA **labels;                // table of labels used/declared in function
 
     block *breakBlock;
     block *contBlock;

--- a/src/irstate.h
+++ b/src/irstate.h
@@ -25,7 +25,10 @@ struct Symbol;
 class FuncDeclaration;
 struct Blockx;
 struct elem;
+struct Label;
 #include "arraytypes.h"
+
+typedef Array<struct Label *> Labels;
 
 struct IRState
 {
@@ -42,6 +45,7 @@ struct IRState
     elem *ehidden;              // transmit hidden pointer to CallExp::toElem()
     Symbol *startaddress;
     VarDeclarations *varsInScope; // variables that are in scope that will need destruction later
+    Labels *labels;             // list of labels used/declared in function
 
     block *breakBlock;
     block *contBlock;

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -1024,8 +1024,7 @@
                 "typedef GotoCaseStatements",
                 "typedef ReturnStatements",
                 "typedef GotoStatements",
-                "typedef TemplateInstances",
-                "typedef Blocks"
+                "typedef TemplateInstances"
             ]
         },
         {
@@ -2595,7 +2594,6 @@
                 "function parse_conf_arg",
                 "function Dsymbols_create",
                 "function VarDeclarations_create",
-                "function Blocks_create",
                 "function Expressions_create"
             ]
         },

--- a/src/mars.c
+++ b/src/mars.c
@@ -1914,5 +1914,4 @@ static const char* parse_conf_arg(Strings *args)
 
 Dsymbols *Dsymbols_create() { return new Dsymbols(); }
 VarDeclarations *VarDeclarations_create() { return new VarDeclarations(); }
-Blocks *Blocks_create() { return new Blocks(); }
 Expressions *Expressions_create() { return new Expressions(); }

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -534,10 +534,9 @@ public:
                 elem *e = el_bin(OPeqeq, TYbool, el_copytree(econd), ecase);
                 block *b = blx->curblock;
                 block_appendexp(b, e);
-                block *bcase = block_calloc(blx);
-                cs->cblock = bcase;
+                Label *clabel = getLabel(irs, blx, cs);
                 block_next(blx, BCiftrue, NULL);
-                b->appendSucc(bcase);
+                b->appendSucc(clabel->lblock);
                 b->appendSucc(blx->curblock);
             }
 
@@ -658,13 +657,12 @@ public:
     {
         Blockx *blx = irs->blx;
         block *bcase = blx->curblock;
-        if (!s->cblock)
-            s->cblock = block_calloc(blx);
-        block_next(blx,BCgoto,s->cblock);
+        Label *clabel = getLabel(irs, blx, s);
+        block_next(blx, BCgoto, clabel->lblock);
         block *bsw = irs->getSwitchBlock();
         if (bsw->BC == BCswitch)
-            bsw->appendSucc(s->cblock);        // second entry in pair
-        bcase->appendSucc(s->cblock);
+            bsw->appendSucc(clabel->lblock);   // second entry in pair
+        bcase->appendSucc(clabel->lblock);
         if (blx->tryblock != bsw->Btry)
             s->error("case cannot be in different try block level from switch");
         incUsage(irs, s->loc);
@@ -720,17 +718,10 @@ public:
 
     void visit(GotoCaseStatement *s)
     {
-        block *b;
         Blockx *blx = irs->blx;
-        block *bdest = s->cs->cblock;
-
-        if (!bdest)
-        {
-            bdest = block_calloc(blx);
-            s->cs->cblock = bdest;
-        }
-
-        b = blx->curblock;
+        Label *clabel = getLabel(irs, blx, s->cs);
+        block *bdest = clabel->lblock;
+        block *b = blx->curblock;
 
         // The rest is equivalent to GotoStatement
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -3498,7 +3498,6 @@ CaseStatement::CaseStatement(Loc loc, Expression *exp, Statement *s)
     this->exp = exp;
     this->statement = s;
     index = 0;
-    cblock = NULL;
 }
 
 Statement *CaseStatement::syntaxCopy()
@@ -3724,9 +3723,6 @@ DefaultStatement::DefaultStatement(Loc loc, Statement *s)
     : Statement(loc)
 {
     this->statement = s;
-#ifdef IN_GCC
-    cblock = NULL;
-#endif
 }
 
 Statement *DefaultStatement::syntaxCopy()

--- a/src/statement.c
+++ b/src/statement.c
@@ -5137,8 +5137,6 @@ LabelStatement::LabelStatement(Loc loc, Identifier *ident, Statement *statement)
     this->lastVar = NULL;
     this->gotoTarget = NULL;
     this->breaks = false;
-    this->lblock = NULL;
-    this->fwdrefs = NULL;
 }
 
 Statement *LabelStatement::syntaxCopy()

--- a/src/statement.h
+++ b/src/statement.h
@@ -50,11 +50,6 @@ class DefaultStatement;
 class LabelStatement;
 
 // Back end
-#ifdef IN_GCC
-typedef union tree_node block;
-#else
-struct block;
-#endif
 struct code;
 
 bool inferAggregate(ForeachStatement *fes, Scope *sc, Dsymbol *&sapply);
@@ -439,7 +434,6 @@ public:
     Statement *statement;
 
     int index;          // which case it is (since we sort this)
-    block *cblock;      // back end: label for the block
 
     CaseStatement(Loc loc, Expression *exp, Statement *s);
     Statement *syntaxCopy();
@@ -469,9 +463,6 @@ class DefaultStatement : public Statement
 {
 public:
     Statement *statement;
-#ifdef IN_GCC
-    block *cblock;      // back end: label for the block
-#endif
 
     DefaultStatement(Loc loc, Statement *s);
     Statement *syntaxCopy();

--- a/src/statement.h
+++ b/src/statement.h
@@ -697,8 +697,6 @@ public:
     Statement *gotoTarget;      // interpret
 
     bool breaks;                // someone did a 'break ident'
-    block *lblock;              // back end
-    Blocks *fwdrefs;            // forward references to this LabelStatement
 
     LabelStatement(Loc loc, Identifier *ident, Statement *statement);
     Statement *syntaxCopy();


### PR DESCRIPTION
As requested in #4569

@yebblies - this has O(n) search complexity, it should really be O(1).
@WalterBright - useless refactoring that only benefits GDC+LDC.  But at least the crossing between C++ <-> D boundaries have been reduced.

I noticed during writing this that `Blocks fwdrefs` will only _ever_ have an array length of `0` or `1` - this seemed odd until I discovered that DMD only errors at the label location, and not the location of the original goto.  This seems a bit backwards, considering (contrived example):

```
    if (foo > 42)
        goto Lbar;
    try {
        if (foo < -42)
            goto Lbar;
        throw new Exception("unhandled");
      Lbar:          // compiler error location is here, but which goto caused it?
        /* ... */
    }
    catch {
        /* ... */
    }
```

So I fixed it up so it errors at the location of the goto (mimicking what GDC does), for good or ill...

If all is good, I'll add `cblock` to this list too, as I've made it so that `getLabel` is compatible.
