### PR TITLE
fix Issue 14828 - duplicate symbol __ModuleInfoZ

### DIFF
--- a/src/backend.d
+++ b/src/backend.d
@@ -25,7 +25,6 @@ extern extern (C++) void obj_write_deferred(Library library);
 extern extern (C++) Type getTypeInfoType(Type t, Scope* sc);
 extern extern (C++) Expression getInternalTypeInfo(Type t, Scope* sc);
 extern extern (C++) void genObjFile(Module m, bool multiobj);
-extern extern (C++) void genhelpers(Module m, bool multiobj);
 
 extern extern (C++) Symbol* toInitializer(AggregateDeclaration sd);
 extern extern (C++) Symbol* toModuleArray(Module m);

--- a/src/gluestub.c
+++ b/src/gluestub.c
@@ -60,11 +60,6 @@ void genObjFile(Module *m, bool multiobj)
 {
 }
 
-void genhelpers(Module *m, bool iscomdat)
-{
-    assert(0);
-}
-
 // msc
 
 void backend_init()

--- a/src/mars.c
+++ b/src/mars.c
@@ -69,7 +69,6 @@ void updateRealEnvironment(StringTable *environment);
 void parseConfFile(StringTable *environment, const char *path, size_t len, unsigned char *buffer, Strings *sections);
 
 void genObjFile(Module *m, bool multiobj);
-void genhelpers(Module *m, bool iscomdat);
 
 /** Normalize path by turning forward slashes into backslashes */
 const char * toWinPath(const char *src)
@@ -1674,12 +1673,6 @@ Language changes listed by -transition=id:\n\
             if (entrypoint && m == rootHasMain)
                 genObjFile(entrypoint, false);
         }
-        for (size_t i = 0; i < Module::amodules.dim; i++)
-        {
-            Module *m = Module::amodules[i];
-            if (!m->isRoot() && (m->marray || m->massert || m->munittest))
-                genhelpers(m, true);
-        }
         if (!global.errors && modules.dim)
         {
             obj_end(library, modules[0]->objfile);
@@ -1697,12 +1690,6 @@ Language changes listed by -transition=id:\n\
             genObjFile(m, global.params.multiobj);
             if (entrypoint && m == rootHasMain)
                 genObjFile(entrypoint, global.params.multiobj);
-            for (size_t j = 0; j < Module::amodules.dim; j++)
-            {
-                Module *mx = Module::amodules[j];
-                if (mx != m && mx->importedFrom == m && (mx->marray || mx->massert || mx->munittest))
-                    genhelpers(mx, true);
-            }
             obj_end(library, m->objfile);
             obj_write_deferred(library);
 

--- a/src/template.c
+++ b/src/template.c
@@ -46,11 +46,6 @@ unsigned char deduceWildHelper(Type *t, Type **at, Type *tparam);
 MATCH deduceTypeHelper(Type *t, Type **at, Type *tparam);
 void mangleToBuffer(Expression *e, OutBuffer *buf);
 
-// Glue layer
-Symbol *toModuleAssert(Module *m);
-Symbol *toModuleUnittest(Module *m);
-Symbol *toModuleArray(Module *m);
-
 /********************************************
  * These functions substitute for dynamic_cast. dynamic_cast does not work
  * on earlier versions of gcc.
@@ -5911,16 +5906,6 @@ Lerror:
     hasNestedArgs(tiargs, tempdecl->isstatic);
     if (errors)
         goto Lerror;
-
-    if (Module *m = tempdecl->scope->module) // should use getModule() instead?
-    {
-        // Generate these functions as they may be used
-        // when template is instantiated in other modules
-        // even if assertions or bounds checking are disabled in this module
-        toModuleArray(m);
-        toModuleAssert(m);
-        toModuleUnittest(m);
-    }
 
     /* See if there is an existing TemplateInstantiation that already
      * implements the typeargs. If so, just refer to that one instead.

--- a/test/runnable/extra-files/lib846.d
+++ b/test/runnable/extra-files/lib846.d
@@ -1,4 +1,4 @@
-module imports.link846a;
+module link846a;
 
 template ElemTypeOf(T)
 {

--- a/test/runnable/extra-files/main846.d
+++ b/test/runnable/extra-files/main846.d
@@ -1,4 +1,4 @@
-import imports.link846a;
+import lib846;
 
 void main()
 {

--- a/test/runnable/ice10857.d
+++ b/test/runnable/ice10857.d
@@ -1,3 +1,3 @@
-// EXTRA_SOURCES: imports/ice10857b.d
+// EXTRA_SOURCES: imports/ice10857a.d imports/ice10857b.d
 
 import imports.ice10857a;

--- a/test/runnable/link846.sh
+++ b/test/runnable/link846.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/link846.sh.out
+
+if [ $OS == "win32" -o  $OS == "win64" ]; then
+	LIBEXT=.lib
+else
+	LIBEXT=.a
+fi
+libname=${dir}${SEP}link846${LIBEXT}
+
+# build library with -release
+$DMD -m${MODEL} -I${src} -of${libname} -release -boundscheck=off -lib ${src}${SEP}lib846.d
+
+# use lib with -debug
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}link846${EXE} -debug ${src}${SEP}main846.d ${libname}
+
+rm ${libname}
+rm ${dir}/{link846${OBJ},link846${EXE}}
+
+echo Success > ${output_file}


### PR DESCRIPTION
- always emit __arrayZ/__assertZ/__unittest_failZ helpers (even in release)
  to avoid linkage issues when instantiating a template of that module
  with different compiler flags
- also fixes Issue 14748 - Removing std.stdio import causes 2x increase in "Hello, world"
  same underlying issue, some undefined helper function drag in a different
  module which happens to have weak definitions of those helpers

[Issue 14828 – [REG2.067] duplicate symbol __ModuleInfoZ depending on ordering of files passed to dmd](https://issues.dlang.org/show_bug.cgi?id=14828)
