### PR TITLE
Fix Issue 14874 - __traits(getFunctionAttributes) does not support the new `return` attribute

### DIFF
--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -878,9 +878,6 @@ public:
         }
         t->attributesApply(&pas, &PrePostAppendStrings::fp);
 
-        if (t->isreturn)
-            buf->writestring(" return");
-
         t->inuse--;
     }
     void visitFuncIdentWithPrefix(TypeFunction *t, Identifier *ident, TemplateDeclaration *td, bool isPostfixStyle)
@@ -940,9 +937,6 @@ public:
             buf->writeByte(')');
         }
         parametersToBuffer(t->parameters, t->varargs);
-
-        if (t->isreturn)
-            buf->writestring("return ");
 
         t->inuse--;
     }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6157,6 +6157,9 @@ int TypeFunction::attributesApply(void *param, int (*fp)(void *, const char *), 
     if (isref) res = fp(param, "ref");
     if (res) return res;
 
+    if (isreturn) res = fp(param, "return");
+    if (res) return res;
+
     TRUST trustAttrib = trust;
 
     if (trustAttrib == TRUSTdefault)

--- a/test/runnable/test14874.d
+++ b/test/runnable/test14874.d
@@ -1,0 +1,38 @@
+// REQUIRED_ARGS: -dip25
+
+template indexOfReturn(T...)
+{
+    static if (T.length == 0)
+    {
+        enum indexOfReturn = -1;
+    }
+    else static if (T[$ - 1] == "return")
+    {
+        enum indexOfReturn = T.length - 1;
+    }
+    else
+    {
+        enum indexOfReturn = indexOfReturn!(T[0..$-1]);
+    }
+}
+
+struct Test
+{
+    int n;
+
+    ref int getN() return
+    {
+        return n;
+    }
+
+    int getNNonReturn()
+    {
+        return n;
+    }
+}
+
+void main()
+{
+    assert(indexOfReturn!(__traits(getFunctionAttributes, Test.getN)) != -1);
+    assert(indexOfReturn!(__traits(getFunctionAttributes, Test.getNNonReturn)) == -1);
+}

--- a/test/runnable/testscope2.d
+++ b/test/runnable/testscope2.d
@@ -42,7 +42,7 @@ void test3()
 	assert(SS.foo4.mangleof == "_D10testscope22SS4foo4MFNcNkKNgPiZi");
 
 	// Test scope pretty-printing
-	assert(typeof(SS.foo1).stringof == "ref int(return ref int delegate() return p)return ");
+	assert(typeof(SS.foo1).stringof == "ref return int(return ref int delegate() return p)");
 	assert(typeof(SS.foo2).stringof == "ref int(return ref int delegate() p)");
 	assert(typeof(SS.foo3).stringof == "ref int(return ref inout(int*) p)");
 	assert(typeof(SS.foo4).stringof == "ref int(return ref inout(int*) p)");


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14874
