### PR TITLE
workaround Issue 14894 - linkage error with mixin template in std.net.curl

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -431,6 +431,9 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                         }
                         break;
                     }
+                    // Workaround 14894. Add an empty unittest declaration to keep
+                    // the number of symbols in this scope independent of -unittest.
+                    s = new UnitTestDeclaration(loc, token.loc, STCundefined, NULL);
                 }
                 break;
 

--- a/test/compilable/extra-files/test14894a.d
+++ b/test/compilable/extra-files/test14894a.d
@@ -1,0 +1,15 @@
+module imports.test14894a;
+
+mixin template Protocol()
+{
+    void onReceive() {}
+}
+
+struct Foo
+{
+    mixin Protocol!();
+
+    unittest
+    {
+    }
+}

--- a/test/compilable/extra-files/test14894main.d
+++ b/test/compilable/extra-files/test14894main.d
@@ -1,0 +1,7 @@
+import test14894a;
+
+void main()
+{
+    Foo foo;
+    foo.onReceive();
+}

--- a/test/compilable/test14894.sh
+++ b/test/compilable/test14894.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+name=`basename $0 .sh`
+dir=${RESULTS_DIR}/compilable
+src=compilable/extra-files
+
+$DMD -c -m${MODEL} -of${dir}/${name}a${OBJ} -I${src} ${src}/${name}a.d || exit 1
+
+$DMD -unittest -m${MODEL} -od${dir} -I${src} ${src}/${name}main.d ${dir}/${name}a${OBJ} || exit 1
+
+rm -f ${dir}/{${name}a${OBJ} ${name}main${EXE} ${name}main${OBJ}}
+
+echo Success >${dir}/`basename $0`.out


### PR DESCRIPTION
[Issue 14894 – [Reg 2.068.0-rc1] linkage error with mixin template in std.net.curl](https://issues.dlang.org/show_bug.cgi?id=14894)
