### PR TITLE
Add support for VS2015

### DIFF
--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -151,7 +151,7 @@ public:
                 offset += MSCoffLibHeader.sizeof;
                 char* endptr = null;
                 uint size = strtoul(cast(char*)header.file_size, &endptr, 10);
-                if (endptr >= &header.file_size[10] || *endptr != ' ')
+                if (endptr >= header.file_size.ptr + 10 || *endptr != ' ')
                 {
                     reason = __LINE__;
                     goto Lcorrupt;

--- a/src/link.d
+++ b/src/link.d
@@ -901,13 +901,14 @@ version (Windows)
                 end++;
                 if (end[-1] == '"')
                 {
-                    end++;
                     while (*end && *end != '"')
                     {
                         if (*end == '\\' && end[1])
                             end++;
                         end++;
                     }
+                    if (*end)
+                        end++; // skip closing quote
                 }
             }
             p = end;

--- a/src/link.d
+++ b/src/link.d
@@ -939,6 +939,6 @@ version (Windows)
         if (!libcmt)
             return false;
         const(char)* liblegacy = FileName.replaceName(libcmt, "legacy_stdio_definitions.lib");
-        return FileName.exists(liblegacy);
+        return FileName.exists(liblegacy) == 1;
     }
 }

--- a/src/link.d
+++ b/src/link.d
@@ -248,7 +248,7 @@ extern (C++) int runLINK()
             {
                 lflags = getenv("LFLAGS_VS14");
                 if (!lflags)
-                    lflags = global.params.is64bit ? "stdio_msvc14_64.obj" : "stdio_msvc14_32mscoff.obj";
+                    lflags = "legacy_stdio_definitions.lib";
                 // environment variables UniversalCRTSdkDir and UCRTVersion set
                 // when running vcvarsall.bat x64
                 if (const(char)* UniversalCRTSdkDir = getenv("UniversalCRTSdkDir"))
@@ -267,11 +267,12 @@ extern (C++) int runLINK()
             else
             {
                 lflags = getenv("LFLAGS_VS12");
-                if (!lflags)
-                    lflags = global.params.is64bit ? "stdio_msvc12_64.obj" : "stdio_msvc12_32mscoff.obj";
             }
-            cmdbuf.writeByte(' ');
-            cmdbuf.writestring(lflags);
+            if (lflags)
+            {
+                cmdbuf.writeByte(' ');
+                cmdbuf.writestring(lflags);
+            }
             char* p = cmdbuf.peekString();
             const(char)* lnkfilename = null;
             size_t plen = strlen(p);

--- a/src/link.d
+++ b/src/link.d
@@ -242,6 +242,36 @@ extern (C++) int runLINK()
                 else
                     cmdbuf.writestring("\\lib\"");
             }
+            cmdbuf.writeByte(' ');
+            const(char)* lflags;
+            if (detectVS14(cmdbuf.peekString()))
+            {
+                lflags = getenv("LFLAGS_VS14");
+                if (!lflags)
+                    lflags = global.params.is64bit ? "stdio_msvc14_64.obj" : "stdio_msvc14_32mscoff.obj";
+                // environment variables UniversalCRTSdkDir and UCRTVersion set
+                // when running vcvarsall.bat x64
+                if (const(char)* UniversalCRTSdkDir = getenv("UniversalCRTSdkDir"))
+                    if (const(char)* UCRTVersion = getenv("UCRTVersion"))
+                    {
+                        cmdbuf.writestring(" /LIBPATH:\"");
+                        cmdbuf.writestring(UniversalCRTSdkDir);
+                        cmdbuf.writestring("\\lib\\");
+                        cmdbuf.writestring(UCRTVersion);
+                        if (global.params.is64bit)
+                            cmdbuf.writestring("\\ucrt\\x64\"");
+                        else
+                            cmdbuf.writestring("\\ucrt\\x86\"");
+                    }
+            }
+            else
+            {
+                lflags = getenv("LFLAGS_VS12");
+                if (!lflags)
+                    lflags = global.params.is64bit ? "stdio_msvc12_64.obj" : "stdio_msvc12_32mscoff.obj";
+            }
+            cmdbuf.writeByte(' ');
+            cmdbuf.writestring(lflags);
             char* p = cmdbuf.peekString();
             const(char)* lnkfilename = null;
             size_t plen = strlen(p);
@@ -848,5 +878,66 @@ extern (C++) int runProgram()
     else
     {
         assert(0);
+    }
+}
+
+version (Windows)
+{
+    /*****************************
+     * Detect whether the link will grab libraries from VS 2015 or later
+     */
+    extern (C++) bool detectVS14(const(char)* cmdline)
+    {
+        auto libpaths = new Strings();
+        // grab library folders passed on the command line
+        for (const(char)* p = cmdline; *p;)
+        {
+            while (isspace(*p))
+                p++;
+            const(char)* arg = p;
+            const(char)* end = arg;
+            while (*end && !isspace(*end))
+            {
+                end++;
+                if (end[-1] == '"')
+                {
+                    end++;
+                    while (*end && *end != '"')
+                    {
+                        if (*end == '\\' && end[1])
+                            end++;
+                        end++;
+                    }
+                }
+            }
+            p = end;
+            // remove quotes if spanning complete argument
+            if (end > arg + 1 && arg[0] == '"' && end[-1] == '"')
+            {
+                arg++;
+                end--;
+            }
+            if (arg[0] == '-' || arg[0] == '/')
+            {
+                if (end - arg > 8 && memicmp(arg + 1, "LIBPATH:", 8) == 0)
+                {
+                    arg += 9;
+                    char* q = cast(char*)memcpy((new char[](end - arg + 1)).ptr, arg, end - arg);
+                    q[end - arg] = 0;
+                    Strings* paths = FileName.splitPath(q);
+                    libpaths.append(paths);
+                }
+            }
+        }
+        // append library paths from environment
+        if (const(char)* lib = getenv("LIB"))
+            libpaths.append(FileName.splitPath(lib));
+        // if legacy_stdio_definitions.lib can be found in the same folder as
+        // libcmt.lib, libcmt.lib is assumed to be from VS2015 or later
+        const(char)* libcmt = FileName.searchPath(libpaths, "libcmt.lib", true);
+        if (!libcmt)
+            return false;
+        const(char)* liblegacy = FileName.replaceName(libcmt, "legacy_stdio_definitions.lib");
+        return FileName.exists(liblegacy);
     }
 }

--- a/src/root/outbuffer.d
+++ b/src/root/outbuffer.d
@@ -405,7 +405,10 @@ struct OutBuffer
     extern (C++) char* peekString()
     {
         if (!offset || data[offset - 1] != '\0')
+        {
             writeByte(0);
+            offset--; // allow appending more
+        }
         return cast(char*)data;
     }
 


### PR DESCRIPTION
- detect linking against VS2015 or later by checking library search paths
- add UCRT lib path for VS2015
- ~~add "stdio_msvc14_64.obj" or "stdio_msvc12_64.obj" to link command line accordingly~~
- add "legacy_stdio_definitions.lib" to link command line for VS2015.

~~needs https://github.com/D-Programming-Language/druntime/pull/1341~~
needs https://github.com/D-Programming-Language/druntime/pull/1360.
