### PR TITLE
Issue 14907 - DMD crash when using template name as a default value of template's typed argument

### DIFF
--- a/src/template.h
+++ b/src/template.h
@@ -81,6 +81,7 @@ public:
     bool isstatic;              // this is static template declaration
     Prot protection;
 
+    int inuse;
     TemplatePrevious *previous;         // threaded list of previous instantiation attempts on stack
 
     TemplateDeclaration(Loc loc, Identifier *id, TemplateParameters *parameters,

--- a/test/fail_compilation/ice14907.d
+++ b/test/fail_compilation/ice14907.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice14907.d(14): Error: struct ice14907.S(int v = S) recursive template expansion
+fail_compilation/ice14907.d(19):        while looking for match for S!()
+fail_compilation/ice14907.d(15): Error: template ice14907.f(int v = f)() recursive template expansion
+fail_compilation/ice14907.d(20):        while looking for match for f!()
+fail_compilation/ice14907.d(15): Error: template ice14907.f(int v = f)() recursive template expansion
+fail_compilation/ice14907.d(21): Error: template ice14907.f cannot deduce function from argument types !()(), candidates are:
+fail_compilation/ice14907.d(15):        ice14907.f(int v = f)()
+---
+*/
+
+struct S(int v = S) {}
+void f(int v = f)() {}
+
+void main()
+{
+    S!() s;     // OK <- ICE
+    f!()();     // OK <- ICE
+    f();        // OK <- ICE
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14907

Add `TemplateDeclaration::inuse`, and use it to detect recursive template expansion during the template parameter matching.
