### PR TITLE
Turn ObjcSelector into a struct to avoid empty vtable bug

### DIFF
--- a/src/objc.h
+++ b/src/objc.h
@@ -19,13 +19,11 @@ class Identifier;
 class FuncDeclaration;
 class ClassDeclaration;
 class InterfaceDeclaration;
-class ObjcSelector;
 struct Scope;
 class StructDeclaration;
 
-class ObjcSelector
+struct ObjcSelector
 {
-public:
     static StringTable stringtable;
     static StringTable vTableDispatchSelectors;
     static int incnum;


### PR DESCRIPTION
@WalterBright 

DMD has a bug where it emits an empty vtable for extern(C++) classes that don't have any virtual methods, causing a mismatch and crashes etc if it's ever passed across the boundary.  The only classes like this currently in dmd are Lexer/Parser, which never cross the boundary.
