### PR TITLE
Add Target::reverseCArgs, use it when building arrayops

### DIFF
--- a/src/root/array.d
+++ b/src/root/array.d
@@ -204,4 +204,9 @@ public:
     {
         return data[0 .. dim];
     }
+
+    extern (D) size_t opDollar()
+    {
+        return dim;
+    }
 }

--- a/src/target.d
+++ b/src/target.d
@@ -20,13 +20,14 @@ import ddmd.root.outbuffer;
 struct Target
 {
     extern (C++) static __gshared int ptrsize;
-    extern (C++) static __gshared int realsize; // size a real consumes in memory
-    extern (C++) static __gshared int realpad; // 'padding' added to the CPU real size to bring it up to realsize
-    extern (C++) static __gshared int realalignsize; // alignment for reals
+    extern (C++) static __gshared int realsize;             // size a real consumes in memory
+    extern (C++) static __gshared int realpad;              // 'padding' added to the CPU real size to bring it up to realsize
+    extern (C++) static __gshared int realalignsize;        // alignment for reals
     extern (C++) static __gshared bool reverseCppOverloads; // with dmc, overloaded functions are grouped and in reverse order
-    extern (C++) static __gshared int c_longsize; // size of a C 'long' or 'unsigned long' type
-    extern (C++) static __gshared int c_long_doublesize; // size of a C 'long double'
-    extern (C++) static __gshared int classinfosize; // size of 'ClassInfo'
+    extern (C++) static __gshared int c_longsize;           // size of a C 'long' or 'unsigned long' type
+    extern (C++) static __gshared int c_long_doublesize;    // size of a C 'long double'
+    extern (C++) static __gshared int classinfosize;        // size of 'ClassInfo'
+    extern (C++) static __gshared bool reverseCArgs;        // if true, extern(C) arguments are pushed in reverse
 
     extern (C++) static void _init()
     {
@@ -34,6 +35,7 @@ struct Target
         // adjusted for 64 bit code.
         ptrsize = 4;
         classinfosize = 0x4C; // 76
+        reverseCArgs = true;
         if (global.params.isLP64)
         {
             ptrsize = 8;

--- a/src/target.h
+++ b/src/target.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 2013-2014 by Digital Mars
+ * Copyright (c) 2013-2015 by Digital Mars
  * All Rights Reserved
  * written by Iain Buclaw
  * http://www.digitalmars.com
@@ -32,6 +32,7 @@ struct Target
     static int c_longsize;           // size of a C 'long' or 'unsigned long' type
     static int c_long_doublesize;    // size of a C 'long double'
     static int classinfosize;        // size of 'ClassInfo'
+    static bool reverseCArgs;        // if true, extern(C) arguments are pushed in reverse
 
     static void init();
     // Type sizes and support.


### PR DESCRIPTION
Because it seems that #4035 has reached an impasse, and I [still have broken arrayops on almost every non-x86 builds](http://bugzilla.gdcproject.org/show_bug.cgi?id=8).  This takes a different approach so that ARM and x86 behave in the same way by taking note of which way the target will evaluate parameters passed to `extern(C)` functions.

For x86, this does nothing, as `Target::reverseCArgs` is true, and `arrayop.c` assumes that throughout.  For every other architecture, this reverses the parameter/argument order so that there are two ABIs.

```
// NVPTX/x32/x86/x86_64
float[] _arraySliceSliceAddSliceAssign_f(float[] p2, const(float[]) p1, const(float[]) p0) pure nothrow @nogc @trusted;

// ARM/AArch64/AVR/HPPA/IA-64/MIPS/PPC/S390/SPARC
float[] _arraySliceSliceAddSliceAssign_f(const(float[]) p0, const(float[]) p1, float[] p2) pure nothrow @nogc @trusted;
```

As there are no vector library implementations for array-ops on non-x86 in druntime, this should be considered safe.
