### PR TITLE
add CMPXCHG intrinsic to back end

### DIFF
--- a/src/backend/cgcs.c
+++ b/src/backend/cgcs.c
@@ -233,6 +233,7 @@ STATIC void ecom(elem **pe)
     case OPbtc:
     case OPbts:
     case OPbtr:
+    case OPcmpxchg:
         ecom(&e->E1);
         ecom(&e->E2);
         touchfunc(0);                   // indirect assignment

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -321,6 +321,7 @@ code *getoffset (elem *e , unsigned reg );
 cd_t cdneg;
 cd_t cdabs;
 cd_t cdpost;
+cd_t cdcmpxchg;
 cd_t cderr;
 cd_t cdinfo;
 cd_t cddctor;

--- a/src/backend/code_x86.h
+++ b/src/backend/code_x86.h
@@ -205,6 +205,7 @@ extern regm_t BYTEREGS;
 #define LOOP    0xE2
 #define LES     0xC4
 #define LEA     0x8D
+#define LOCK    0xF0
 
 #define JO      0x70
 #define JNO     0x71

--- a/src/backend/glocal.c
+++ b/src/backend/glocal.c
@@ -189,6 +189,7 @@ Loop:
         case OPandass:
         case OPxorass:
         case OPorass:
+        case OPcmpxchg:
             if (ERTOL(e))
             {   local_exp(e->E2,1);
         case OPnegass:
@@ -561,6 +562,7 @@ STATIC int local_getflags(elem *e,symbol *s)
             case OPandass:
             case OPxorass:
             case OPorass:
+            case OPcmpxchg:
                 if (e->E1->Eoper == OPvar)
                 {   symbol *s1;
 

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -929,6 +929,7 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPpostinc: case OPpostdec:
         case OPcall:
         case OPvecsto:
+        case OPcmpxchg:
                         markinvar(n->E2,rd);
         case OPnegass:
                         n1 = n->E1;

--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -1257,6 +1257,10 @@ void elimass(elem *n)
         case OPbts:
             n->Eoper = OPbt;
             break;
+        case OPcmpxchg:
+            n->Eoper = OPcomma;
+            n->E2->Eoper = OPcomma;
+            break;
         default:
             assert(0);
     }

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -55,6 +55,7 @@ enum OPER
         OPscale,                // ldexp
         OPyl2x,                 // y * log2(x)
         OPyl2xp1,               // y * log2(x + 1)
+        OPcmpxchg,                      // cmpxchg
 #endif
         OPstrlen,               /* strlen()                     */
         OPstrcpy,               /* strcpy()                     */

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -41,7 +41,7 @@ int _binary[] =
          OPinfo,OParray,OPfield,OPnewarray,OPmultinewarray,OPinstanceof,OPfinalinstanceof,
          OPcheckcast,OPpair,OPrpair,
          OPbt,OPbtc,OPbtr,OPbts,OPror,OProl,OPbtst,
-         OPremquo,
+         OPremquo,OPcmpxchg,
 #if TX86
          OPoutp,OPscale,OPyl2x,OPyl2xp1,
          OPvecsto,
@@ -83,7 +83,7 @@ int _assoc[] = {OPadd,OPand,OPor,OPxor,OPmul};
 int _assign[] =
         {OPstreq,OPeq,OPaddass,OPminass,OPmulass,OPdivass,OPmodass,
          OPshrass,OPashrass,OPshlass,OPandass,OPxorass,OPorass,OPpostinc,OPpostdec,
-         OPnegass,OPvecsto,
+         OPnegass,OPvecsto,OPcmpxchg,
         };
 int _wid[] =
         {OPadd,OPmin,OPand,OPor,OPxor,OPcom,OPneg,OPmul,OPaddass,OPnegass,
@@ -113,7 +113,7 @@ int _def[] = {OPstreq,OPeq,OPaddass,OPminass,OPmulass,OPdivass,OPmodass,
                 OPcall,OPucall,OPasm,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,
                 OPnegass,OPnewarray,OPmultinewarray,
                 OPbtc,OPbtr,OPbts,
-                OPvecsto,
+                OPvecsto,OPcmpxchg,
              };
 int _sideff[] = {OPasm,OPucall,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,
                 OPcall,OPeq,OPstreq,OPpostinc,OPpostdec,
@@ -123,6 +123,7 @@ int _sideff[] = {OPasm,OPucall,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,
                 OPmultinewarray,OPcheckcast,OPnullcheck,
                 OPbtc,OPbtr,OPbts,
                 OPhalt,OPdctor,OPddtor,
+                OPcmpxchg,
 #if TX86 && MARS
                 OPva_start,
 #endif
@@ -134,7 +135,7 @@ int _rtol[] = {OPeq,OPstreq,OPstrcpy,OPmemcpy,OPpostinc,OPpostdec,OPaddass,
                 OPminass,OPmulass,OPdivass,OPmodass,OPandass,
                 OPorass,OPxorass,OPshlass,OPshrass,OPashrass,
                 OPcall,OPcallns,OPinfo,OPmemset,
-                OPvecsto,
+                OPvecsto,OPcmpxchg,
                 };
 int _ae[] = {OPvar,OPconst,OPrelconst,OPneg,
                 OPabs,OPrndtol,OPrint,
@@ -184,7 +185,7 @@ int _exp[] = {OPvar,OPconst,OPrelconst,OPneg,OPabs,OPrndtol,OPrint,
                 OPorass,OPxorass,OPshlass,OPshrass,OPashrass,OPoror,OPandand,OPcond,
                 OPbsf,OPbsr,OPbt,OPbtc,OPbtr,OPbts,OPbswap,OPbtst,OPpopcnt,
                 OProl,OPror,OPvector,
-                OPpair,OPrpair,OPframeptr,OPgot,OPremquo,
+                OPpair,OPrpair,OPframeptr,OPgot,OPremquo,OPcmpxchg,
                 OPcolon,OPcolon2,OPasm,OPstrcpy,OPmemcpy,OPmemset,OPstrcat,OPnegass,
 #if TX86
                 OPsqrt,OPsin,OPcos,OPscale,OPyl2x,OPyl2xp1,
@@ -517,6 +518,7 @@ void dotab()
         case OPyl2x:    X("yl2x",       elzot,  cdscale);
         case OPyl2xp1:  X("yl2xp1",     elzot,  cdscale);
 #endif
+        case OPcmpxchg:     X("cas",        elzot,  cdcmpxchg);
         case OPrint:    X("rint",       evalu8, cdneg);
         case OPrndtol:  X("rndtol",     evalu8, cdrndtol);
         case OPstrlen:  X("strlen",     elzot,  cdstrlen);


### PR DESCRIPTION
Although CMPXCHG (compare and swap) is rarely used, it is used in speed critical code, making it worthwhile for the compiler to handle it rather than using inline assembler. It'll see use in `core.atomic`.

I've tested this with the DMC compiler, so I know it works. Integration with the dmd front end will have to wait until after the switch to ddmd.
