### PR TITLE
improve copy propagation optimization

### DIFF
--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -1046,7 +1046,7 @@ STATIC void cpwalk(elem *n,vec_t IN)
                 elem *foundelem = NULL;
                 tym_t ty;
 
-                //dbg_printf("Checking copyprop for '%s', ty=x%x\n",v->Sident,n->Ety);
+                //printf("Checking copyprop for '%s', ty=x%x\n",v->Sident,n->Ety);
                 symbol_debug(v);
                 ty = n->Ety;
                 unsigned sz = tysize(n->Ety);
@@ -1064,13 +1064,13 @@ STATIC void cpwalk(elem *n,vec_t IN)
                             csz = type_size(c->ET);
                         assert((int)csz >= 0);
 
-                        //dbg_printf("looking at: ("); WReqn(c); dbg_printf("), ty=x%x\n",c->E1->Ety);
+                        //printf("looking at: ("); WReqn(c); dbg_printf("), ty=x%x\n",c->E1->Ety);
                         /* Not only must symbol numbers match, but      */
                         /* offsets too (in case of arrays) and sizes    */
                         /* (in case of unions).                         */
                         if (v == c->E1->EV.sp.Vsym &&
-                            n->EV.sp.Voffset == c->E1->EV.sp.Voffset &&
-                            sz <= csz)
+                            n->EV.sp.Voffset >= c->E1->EV.sp.Voffset &&
+                            n->EV.sp.Voffset + sz <= c->E1->EV.sp.Voffset + csz)
                         {       if (foundelem)
                                 {       if (c->E2->EV.sp.Vsym != f)
                                                 goto noprop;
@@ -1092,9 +1092,11 @@ STATIC void cpwalk(elem *n,vec_t IN)
                         }
 #endif
                         type *nt = n->ET;
+                        targ_size_t noffset = n->EV.sp.Voffset;
                         el_copy(n,foundelem->E2);
                         n->Ety = ty;    // retain original type
                         n->ET = nt;
+                        n->EV.sp.Voffset += noffset - foundelem->E1->EV.sp.Voffset;
 
                         /* original => rewrite
                          *  v = f


### PR DESCRIPTION
Turns out H. S. Teoh was right. The copy propagation optimization was not working as well as it could for data that was larger than one register in size. Formerly, the sizes had to match exactly. Now the new size only has to be a subset of the original to trigger the copy propagation.

Some small informal tests showed significant gains from this.
