### PR TITLE
reduce some TypeInfo bloat

### DIFF
--- a/src/backend/dt.c
+++ b/src/backend/dt.c
@@ -296,6 +296,13 @@ dt_t ** dtxoff(dt_t **pdtend,symbol *s,unsigned offset,tym_t ty)
     return pdtend;
 }
 
+/*********************************
+ */
+void dtpatchoffset(dt_t *dt, unsigned offset)
+{
+    dt->DToffset = offset;
+}
+
 /*************************************
  * Create a reference to another dt.
  */

--- a/src/backend/dt.h
+++ b/src/backend/dt.h
@@ -22,6 +22,7 @@ dt_t **dtdtoff(dt_t **pdtend, dt_t *dt, unsigned offset);
 dt_t **dtcoff(dt_t **pdtend,unsigned offset);
 dt_t ** dtcat(dt_t **pdtend,dt_t *dt);
 dt_t ** dtrepeat(dt_t **pdtend, dt_t *dt, size_t count);
+void dtpatchoffset(dt_t *dt, unsigned offset);
 void dt_optimize(dt_t *dt);
 void dtsymsize(Symbol *);
 void init_common(Symbol *);

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -256,7 +256,7 @@ public:
         const char *name = sd->toPrettyChars();
         size_t namelen = strlen(name);
         dtsize_t(pdt, namelen);
-        dtabytes(pdt, 0, namelen + 1, name);
+        dtxoff(pdt, d->csym, Type::typeinfoenum->structsize);
 
         // void[] init;
         if (!sd->members || d->tinfo->isZeroInit())
@@ -270,6 +270,9 @@ public:
             dtsize_t(pdt, sd->type->size()); // init.length
             dtxoff(pdt, toInitializer(sd), 0);    // init.ptr
         }
+
+        // Put out name[] immediately following TypeInfo_Enum
+        dtnbytes(pdt, namelen + 1, name);
     }
 
     void visit(TypeInfoPointerDeclaration *d)
@@ -376,7 +379,10 @@ public:
         assert(name);
         size_t namelen = strlen(name);
         dtsize_t(pdt, namelen);
-        dtabytes(pdt, 0, namelen + 1, name);
+        dtxoff(pdt, d->csym, Type::typeinfofunction->structsize);
+
+        // Put out name[] immediately following TypeInfo_Function
+        dtnbytes(pdt, namelen + 1, name);
     }
 
     void visit(TypeInfoDelegateDeclaration *d)
@@ -398,7 +404,10 @@ public:
         assert(name);
         size_t namelen = strlen(name);
         dtsize_t(pdt, namelen);
-        dtabytes(pdt, 0, namelen + 1, name);
+        dtxoff(pdt, d->csym, Type::typeinfodelegate->structsize);
+
+        // Put out name[] immediately following TypeInfo_Delegate
+        dtnbytes(pdt, namelen + 1, name);
     }
 
     void visit(TypeInfoStructDeclaration *d)
@@ -452,7 +461,7 @@ public:
         const char *name = sd->toPrettyChars();
         size_t namelen = strlen(name);
         dtsize_t(pdt, namelen);
-        dtabytes(pdt, 0, namelen + 1, name);
+        dtxoff(pdt, d->csym, Type::typeinfostruct->structsize);
 
         // void[] init;
         dtsize_t(pdt, sd->structsize);       // init.length
@@ -550,6 +559,9 @@ public:
             dtsize_t(pdt, 1);
         else
             dtsize_t(pdt, 0);
+
+        // Put out name[] immediately following TypeInfo_Struct
+        dtnbytes(pdt, namelen + 1, name);
     }
 
     void visit(TypeInfoClassDeclaration *d)


### PR DESCRIPTION
This partially addresses https://issues.dlang.org/show_bug.cgi?id=14758 "TypeInfo causes excessive binary bloat".

Partial in that it only does it for TypeInfo_Struct instances. If it is successful, the same technique can be propagated to the other TypeInfo instances.

The TypeInfo_Struct itself is in a COMDAT, meaning it is only pulled into the executable if it is actually referenced. The trouble is the `string name;` member - the actual string for the name is stored in global data and is always linked in. The solution in this PR is to append the string data to the TypeInfo_Struct instance as part of the same COMDAT section.
