### PR TITLE
Issue 10378 - Local imports hide local symbols

### DIFF
--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1150,6 +1150,11 @@ public:
         return null;
     }
 
+    inout(ImportScopeSymbol) isImportScopeSymbol() inout
+    {
+        return null;
+    }
+
     inout(Import) isImport() inout
     {
         return null;
@@ -1836,6 +1841,63 @@ public:
     }
 
     override inout(ArrayScopeSymbol) isArrayScopeSymbol() inout
+    {
+        return this;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ */
+extern (C++) final class ImportScopeSymbol : ScopeDsymbol
+{
+public:
+    this(Dsymbols *imports)
+    {
+        this.members = imports;
+    }
+
+    override void semantic(Scope *sc)
+    {
+        if (symtab)
+            return;
+
+        symtab = new DsymbolTable();
+
+        Scope *sc2 = sc.push(this);
+
+        for (size_t i = 0; i < members.dim; i++)
+        {
+            Dsymbol s = (*members)[i];
+            s.addMember(sc2, this);
+        }
+
+        for (size_t i = 0; i < members.dim; i++)
+        {
+            Dsymbol s = (*members)[i];
+            s.setScope(sc2);
+        }
+
+        for (size_t i = 0; i < members.dim; i++)
+        {
+            Dsymbol s = (*members)[i];
+            s.importAll(sc2);
+        }
+
+        for (size_t i = 0; i < members.dim; i++)
+        {
+            Dsymbol s = (*members)[i];
+            s.semantic(sc2);
+        }
+
+        sc2.pop();
+    }
+
+    override inout(ImportScopeSymbol) isImportScopeSymbol() inout
     {
         return this;
     }

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -267,6 +267,7 @@ public:
     virtual ScopeDsymbol *isScopeDsymbol() { return NULL; }
     virtual WithScopeSymbol *isWithScopeSymbol() { return NULL; }
     virtual ArrayScopeSymbol *isArrayScopeSymbol() { return NULL; }
+    virtual ImportScopeSymbol *isImportScopeSymbol() { return NULL; }
     virtual Import *isImport() { return NULL; }
     virtual EnumDeclaration *isEnumDeclaration() { return NULL; }
     virtual DeleteDeclaration *isDeleteDeclaration() { return NULL; }
@@ -340,6 +341,18 @@ public:
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
 
     ArrayScopeSymbol *isArrayScopeSymbol() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+// Import scope
+
+class ImportScopeSymbol : public ScopeDsymbol
+{
+public:
+    ImportScopeSymbol(Dsymbols *imports);
+    void semantic(Scope *sc);
+
+    ImportScopeSymbol *isImportScopeSymbol() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -3585,7 +3585,7 @@ public:
             /* See if the symbol was a member of an enclosing 'with'
              */
             WithScopeSymbol withsym = scopesym.isWithScopeSymbol();
-            if (withsym && withsym.withstate.wthis)
+            if (withsym)
             {
                 /* Disallow shadowing
                  */
@@ -3603,10 +3603,22 @@ public:
                     Dsymbol s2;
                     if (scx.scopesym && scx.scopesym.symtab && (s2 = scx.scopesym.symtab.lookup(s.ident)) !is null && s != s2)
                     {
-                        error("with symbol %s is shadowing local symbol %s", s.toPrettyChars(), s2.toPrettyChars());
+                        auto exp = withsym.withstate.exp;
+                        if (exp.op == TOKscope && (cast(ScopeExp)exp).sds.isImportScopeSymbol())
+                        {
+                            auto ad = s.isAliasDeclaration();
+                            if (ad && ad._import)   // If 's' is an internal alias
+                                s = s.toAlias();    // associated with selective imports.
+                            error("imported symbol '%s' is shadowing local symbol '%s'", s.toPrettyChars(), s2.toPrettyChars());
+                        }
+                        else
+                            error("with symbol %s is shadowing local symbol %s", s.toPrettyChars(), s2.toPrettyChars());
                         return new ErrorExp();
                     }
                 }
+            }
+            if (withsym && withsym.withstate.wthis)
+            {
                 s = s.toAlias();
 
                 // Same as wthis.ident

--- a/src/import.h
+++ b/src/import.h
@@ -58,6 +58,7 @@ public:
     void semantic2(Scope *sc);
     Dsymbol *toAlias();
     void addMember(Scope *sc, ScopeDsymbol *sds);
+    void setScope(Scope *sc);
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
     bool overloadInsert(Dsymbol *s);
 

--- a/src/statement.d
+++ b/src/statement.d
@@ -900,6 +900,11 @@ public:
         return null;
     }
 
+    ImportStatement isImportStatement()
+    {
+        return null;
+    }
+
     void accept(Visitor v)
     {
         v.visit(this);
@@ -5976,6 +5981,11 @@ public:
                 sc.insert(aliasdecl);
             }
         }
+        return this;
+    }
+
+    override final ImportStatement isImportStatement()
+    {
         return this;
     }
 

--- a/src/statement.d
+++ b/src/statement.d
@@ -1435,11 +1435,47 @@ public:
                     printf("[%d]: %s", i, s.toChars());
             }
         }
+
+        Dsymbols *imports = null;
+
         for (size_t i = 0; i < statements.dim;)
         {
             Statement s = (*statements)[i];
             if (s)
             {
+                // if s is a CompileStatement, the import scope is separated.
+                if (auto imps = s.isImportStatement())
+                {
+                    if (imports)
+                        imports.append(imps.imports);
+                    else
+                        imports = imps.imports.copy();
+                    if (i + 1 < statements.dim)
+                    {
+                        i++;
+                        continue;
+                    }
+                }
+                if (imports)
+                {
+                    auto iss = new ImportScopeSymbol(imports);
+                    iss.parent = sc.scopesym;
+
+                    // Copy statements[i .. $] to a
+                    auto a = new Statements();
+                    a.reserve(statements.dim - i);
+                    for (size_t j = i + (s.isImportStatement() ? 1 : 0); j < statements.dim; j++)
+                        a.push((*statements)[j]);
+
+                    // Construct: with (iss) statements[i .. $]
+                    s = new CompoundStatement(loc, a);
+                    s = new ScopeStatement(loc, s);
+                    s = new WithStatement(loc, new ScopeExp(loc, iss), s);
+
+                    // statements = statements[0 .. i] ~ s
+                    statements.setDim(i + 1);
+                    (*statements)[i] = s;
+                }
                 Statements* flt = s.flatten(sc);
                 if (flt)
                 {
@@ -1742,18 +1778,18 @@ public:
 
     override Statement semantic(Scope* sc)
     {
-        ScopeDsymbol sym;
         //printf("ScopeStatement::semantic(sc = %p)\n", sc);
         if (statement)
         {
-            sym = new ScopeDsymbol();
+            if (!statement.isCompoundStatement())
+            {
+                statement = new CompoundStatement(loc, statement);
+            }
+
+            auto sym = new ScopeDsymbol();
             sym.parent = sc.scopesym;
             sc = sc.push(sym);
-            Statements* a = statement.flatten(sc);
-            if (a)
-            {
-                statement = new CompoundStatement(loc, a);
-            }
+
             statement = statement.semantic(sc);
             if (statement)
             {
@@ -5586,12 +5622,26 @@ public:
 
     override Statements* flatten(Scope* sc)
     {
-        Statements* a = statement ? statement.flatten(sc) : null;
+        if (!statement)
+            return null;
+
+        auto a = statement.flatten(sc);
+        if (!a && statement.isImportStatement())
+        {
+            a = new Statements();
+            a.push(statement);
+        }
         if (a)
         {
+            /* Rewrite 'a':
+             *      [ import a; import b;       s1;       s2; ]
+             * to:
+             *      [ import a; import b; debug s1; debug s2; ]
+             */
             foreach (ref s; *a)
             {
-                s = new DebugStatement(loc, s);
+                if (s && !s.isImportStatement())
+                    s = new DebugStatement(loc, s);
             }
         }
         return a;
@@ -5773,19 +5823,38 @@ public:
 
     override Statements* flatten(Scope* sc)
     {
-        Statements* a = null;
-        if (statement)
+        if (!statement)
+            return null;
+
+        auto a = statement.flatten(sc);
+        if (!a && statement.isImportStatement())
         {
-            a = statement.flatten(sc);
-            if (a)
+            a = new Statements();
+            a.push(statement);
+        }
+        if (a)
+        {
+            /* Rewrite 'a':
+             *      [ import a; import b;        s1; s2; ]
+             * to:
+             *      [ import a; import b; Label: s1; s2; ]
+             */
+            for (size_t i = 0; ; i++)
             {
-                if (!a.dim)
-                {
+                if (i == a.dim)
                     a.push(new ExpStatement(loc, cast(Expression)null));
-                }
+
+                Statement s = (*a)[i];
+                //if (i >= a.dim)
+                //    printf("[%s] i = %d, a.dim = %d, %s\n", loc.toChars(), i, a.dim, toChars());
+                //assert(i < a.dim);
+                if (s && s.isImportStatement())
+                    continue;
+
                 // reuse 'this' LabelStatement
-                this.statement = (*a)[0];
-                (*a)[0] = this;
+                this.statement = s;
+                (*a)[i] = this;
+                break;
             }
         }
         return a;
@@ -5959,29 +6028,7 @@ public:
 
     override Statement semantic(Scope* sc)
     {
-        foreach (i; 0 .. imports.dim)
-        {
-            Import s = (*imports)[i].isImport();
-            assert(!s.aliasdecls.dim);
-            foreach (j, name; s.names)
-            {
-                Identifier _alias = s.aliases[j];
-                if (!_alias)
-                    _alias = name;
-                auto tname = new TypeIdentifier(s.loc, name);
-                auto ad = new AliasDeclaration(s.loc, _alias, tname);
-                ad._import = s;
-                s.aliasdecls.push(ad);
-            }
-            s.semantic(sc);
-            //s->semantic2(sc);     // Bugzilla 14666
-            sc.insert(s);
-            foreach (aliasdecl; s.aliasdecls)
-            {
-                sc.insert(aliasdecl);
-            }
-        }
-        return this;
+        assert(0);
     }
 
     override final ImportStatement isImportStatement()

--- a/src/statement.h
+++ b/src/statement.h
@@ -48,6 +48,7 @@ class TryFinallyStatement;
 class CaseStatement;
 class DefaultStatement;
 class LabelStatement;
+class ImportStatement;
 
 // Back end
 struct code;
@@ -110,6 +111,7 @@ public:
     virtual DefaultStatement *isDefaultStatement() { return NULL; }
     virtual LabelStatement *isLabelStatement() { return NULL; }
     virtual DtorExpStatement *isDtorExpStatement() { return NULL; }
+    virtual ImportStatement *isImportStatement() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -756,6 +758,7 @@ public:
     Statement *syntaxCopy();
     Statement *semantic(Scope *sc);
 
+    ImportStatement *isImportStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/visitor.d
+++ b/src/visitor.d
@@ -508,6 +508,11 @@ public:
         visit(cast(ScopeDsymbol)s);
     }
 
+    void visit(ImportScopeSymbol s)
+    {
+        visit(cast(ScopeDsymbol)s);
+    }
+
     void visit(Nspace s)
     {
         visit(cast(ScopeDsymbol)s);

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -113,6 +113,7 @@ class Package;
 class Module;
 class WithScopeSymbol;
 class ArrayScopeSymbol;
+class ImportScopeSymbol;
 class Nspace;
 
 class AggregateDeclaration;
@@ -399,6 +400,7 @@ public:
     virtual void visit(Module *s) { visit((Package *)s); }
     virtual void visit(WithScopeSymbol *s) { visit((ScopeDsymbol *)s); }
     virtual void visit(ArrayScopeSymbol *s) { visit((ScopeDsymbol *)s); }
+    virtual void visit(ImportScopeSymbol *s) { visit((ScopeDsymbol *)s); }
     virtual void visit(Nspace *s) { visit((ScopeDsymbol *)s); }
 
     virtual void visit(AggregateDeclaration *s) { visit((ScopeDsymbol *)s); }

--- a/test/fail_compilation/fail10378.d
+++ b/test/fail_compilation/fail10378.d
@@ -1,0 +1,84 @@
+// REQUIRED_ARGS: -o- -debug
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10378.d(18): Error: imported symbol 'imports.m10378a.text(A...)(A args)' is shadowing local symbol 'fail10378.test10378a.text'
+fail_compilation/fail10378.d(21): Error: imported symbol 'imports.m10378a.foo' is shadowing local symbol 'fail10378.test10378a.foo'
+fail_compilation/fail10378.d(25): Error: imported symbol 'imports.m10378a.text(A...)(A args)' is shadowing local symbol 'fail10378.test10378a.text'
+fail_compilation/fail10378.d(28): Error: imported symbol 'imports.m10378a.foo' is shadowing local symbol 'fail10378.test10378a.foo'
+fail_compilation/fail10378.d(32): Error: imported symbol 'imports.m10378a.text(A...)(A args)' is shadowing local symbol 'fail10378.test10378a.text'
+fail_compilation/fail10378.d(35): Error: imported symbol 'imports.m10378a.foo' is shadowing local symbol 'fail10378.test10378a.foo'
+---
+*/
+void test10378a(string text)
+{
+    {
+        import imports.m10378a;
+        auto foo = text;    // imported symbol shadowing local one
+        foo = "abc";        // no error, local variable 'foo' is preferred
+        import imports.m10378a;
+        auto bar = foo;     // imported symbol shadowing local one
+    }
+    {
+        debug import imports.m10378a;
+        auto foo = text;
+        foo = "abc";
+        debug import imports.m10378a;
+        auto bar = foo;
+    }
+    {
+        L1: import imports.m10378a;
+        auto foo = text;
+        foo = "abc";
+        L2: import imports.m10378a;
+        auto bar = foo;
+    }
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10378.d(71): Error: function imports.m10378b.foo (int) is not callable using argument types ()
+fail_compilation/fail10378.d(81): Error: function imports.m10378b.foo (int) is not callable using argument types ()
+---
+*/
+void test10378b()
+{
+    // The contiguous local imports can work like DeclDefs scope,
+    // but mixed-in import breaks up the group.
+    {
+        import imports.m10378a;             // foo()
+        import imports.m10378b;             // foo(int)
+        assert(foo() == 1);
+        assert(foo(1) == "a");
+    }
+    {
+        mixin("import imports.m10378a;" ~   // foo()
+              "import imports.m10378b;");   // foo(int)
+        assert(foo() == 1);
+        assert(foo(1) == "a");
+    }
+    {
+        mixin("import imports.m10378a;");   // foo()
+        import imports.m10378b;             // foo(int)
+        assert(foo() == 1);
+        assert(foo(1) == "a");
+    }
+    {
+        import imports.m10378a;             // foo()
+        mixin("import imports.m10378b;");   // foo(int) (shadowing)
+        assert(foo() == 1);                 // --> error
+        assert(foo(1) == "a");
+    }
+
+    /* CompileStatement divides the implicit "import scope", because
+     * the code string generation might depend on the preceding imports.
+     */
+    {
+        import imports.m10378a;             // foo()
+        mixin(makeImportCode());            // foo(int) (shadowing)
+        assert(foo() == 1);                 // --> error
+        assert(foo(1) == "a");
+    }
+}

--- a/test/fail_compilation/imports/m10378a.d
+++ b/test/fail_compilation/imports/m10378a.d
@@ -1,0 +1,7 @@
+module imports.m10378a;
+
+string text(A...)(A args) { return ""; }
+
+int foo() { return 1; }
+
+string makeImportCode() { return "import imports.m10378b;"; }

--- a/test/fail_compilation/imports/m10378b.d
+++ b/test/fail_compilation/imports/m10378b.d
@@ -1,0 +1,3 @@
+module imports.m10378b;
+
+string foo(int) { return "a"; }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=10378

Reuse the symbol shadowing detection mechanism for `WithStatement`.

This PR is based on #4857, because the local import behavior change will hit issue 14858 in Phobos unittest.
