### PR TITLE
use COMDATs for class info

### DIFF
--- a/src/toobj.c
+++ b/src/toobj.c
@@ -269,9 +269,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
 
             assert(!cd->scope);     // semantic() should have been run to completion
 
-            enum_SC scclass = SCglobal;
-            if (cd->isInstantiated())
-                scclass = SCcomdat;
+            enum_SC scclass = SCcomdat;
 
             // Put out the members
             for (size_t i = 0; i < cd->members->dim; i++)
@@ -367,7 +365,10 @@ void toObjFile(Dsymbol *ds, bool multiobj)
 
             // vtbl[]
             dtsize_t(&dt, cd->vtbl.dim);
-            dtxoff(&dt, cd->vtblsym, 0, TYnptr);
+            if (cd->vtbl.dim)
+                dtxoff(&dt, cd->vtblsym, 0, TYnptr);
+            else
+                dtsize_t(&dt, 0);
 
             // interfaces[]
             dtsize_t(&dt, cd->vtblInterfaces->dim);
@@ -642,6 +643,14 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 else
                     dtsize_t(&dt, 0);
             }
+            if (!dt)
+            {
+                /* Someone made an 'extern (C++) class C { }' with no virtual functions.
+                 * But making an empty vtbl[] causes linking problems, so make a dummy
+                 * entry.
+                 */
+                dtsize_t(&dt, 0);
+            }
             cd->vtblsym->Sdt = dt;
             cd->vtblsym->Sclass = scclass;
             cd->vtblsym->Sfl = FLdata;
@@ -667,9 +676,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             if (global.params.symdebug)
                 toDebug(id);
 
-            enum_SC scclass = SCglobal;
-            if (id->isInstantiated())
-                scclass = SCcomdat;
+            enum_SC scclass = SCcomdat;
 
             // Put out the members
             for (size_t i = 0; i < id->members->dim; i++)


### PR DESCRIPTION
Use COMDATs so that they are only pulled in if actually referenced. Note that ModuleInfo still references them and pulls them in anyway.
