### PR TITLE
Issue 14889 & 14900 & [REG2.068.0] 14911 - Reimplement fix for issue 1215

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -381,6 +381,11 @@ void AliasDeclaration::semantic(Scope *sc)
      * try to alias y to 3.
      */
     s = type->toDsymbol(sc);
+    if (errors != global.errors)
+    {
+        s = NULL;
+        type = Type::terror;
+    }
     if (s && s == this)
     {
         error("cannot resolve");

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -449,50 +449,12 @@ Dsymbol *Dsymbol::search_correct(Identifier *ident)
     return (Dsymbol *)speller(ident->toChars(), &symbol_search_fp, (void *)this, idchars);
 }
 
-/*************************************
- * Take an index in a TypeTuple.
- */
-Dsymbol *Dsymbol::takeTypeTupleIndex(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *indexExpr)
-{
-    TupleDeclaration *td = s->isTupleDeclaration();
-    if (!td)
-    {
-        error(loc, "expected TypeTuple when indexing ('[%s]'), got '%s'.",
-              id->toChars(), s->toChars());
-        return NULL;
-    }
-    sc = sc->startCTFE();
-    indexExpr = indexExpr->semantic(sc);
-    sc = sc->endCTFE();
-
-    indexExpr = indexExpr->ctfeInterpret();
-    const uinteger_t d = indexExpr->toUInteger();
-
-    if (d >= td->objects->dim)
-    {
-        error(loc, "tuple index %llu exceeds length %u", d, td->objects->dim);
-        return NULL;
-    }
-    RootObject *o = (*td->objects)[(size_t)d];
-    if (o->dyncast() == DYNCAST_TYPE)
-    {
-        Type *t = (Type *)o;
-        return t->toDsymbol(sc)->toAlias();
-    }
-    else
-    {
-        assert(o->dyncast() == DYNCAST_DSYMBOL);
-        return (Dsymbol *)o;
-    }
-}
-
 /***************************************
  * Search for identifier id as a member of 'this'.
  * id may be a template instance.
  * Returns:
  *      symbol found, NULL if not
  */
-
 Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
 {
     //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident->toChars());
@@ -512,39 +474,6 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
     {
         case DYNCAST_IDENTIFIER:
             sm = s->search(loc, (Identifier *)id);
-            break;
-
-        case DYNCAST_TYPE:
-        {
-            Type *index = (Type *)id;
-            Expression *expr = NULL;
-            Type *t = NULL;
-            Dsymbol *sym = NULL;
-
-            index->resolve(loc, sc, &expr, &t, &sym);
-            if (expr)
-            {
-                sm = takeTypeTupleIndex(loc, sc, s, id, expr);
-            }
-            else if (t)
-            {
-                index->error(loc, "expected an expression as index, got a type (%s)", t->toChars());
-                return NULL;
-            }
-            else
-            {
-                index->error(loc, "index is not an expression");
-                return NULL;
-            }
-            break;
-        }
-
-        case DYNCAST_EXPRESSION:
-            sm = takeTypeTupleIndex(loc, sc, s, id, (Expression *)id);
-            if (!sm)
-            {
-                return NULL;
-            }
             break;
 
         case DYNCAST_DSYMBOL:
@@ -579,6 +508,8 @@ Dsymbol *Dsymbol::searchX(Loc loc, Scope *sc, RootObject *id)
             break;
         }
 
+        case DYNCAST_TYPE:
+        case DYNCAST_EXPRESSION:
         default:
             assert(0);
     }

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -275,9 +275,6 @@ public:
     virtual AttribDeclaration *isAttribDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
-
-private:
-    Dsymbol *takeTypeTupleIndex(Loc loc, Scope *sc, Dsymbol *s, RootObject *id, Expression *indexExpr);
 };
 
 // Dsymbol that generates a scope

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -6812,23 +6812,15 @@ Dsymbol *TypeIdentifier::toDsymbol(Scope *sc)
     //printf("TypeIdentifier::toDsymbol('%s')\n", toChars());
     if (!sc)
         return NULL;
-    //printf("ident = '%s'\n", ident->toChars());
 
-    Dsymbol *scopesym;
-    Dsymbol *s = sc->search(loc, ident, &scopesym);
-    if (s)
-    {
-        for (size_t i = 0; i < idents.dim; i++)
-        {
-            RootObject *id = idents[i];
-            s = s->searchX(loc, sc, id);
-            if (!s)                 // failed to find a symbol
-            {
-                //printf("\tdidn't find a symbol\n");
-                break;
-            }
-        }
-    }
+    Type *t;
+    Expression *e;
+    Dsymbol *s;
+
+    resolve(loc, sc, &e, &t, &s);
+    if (t && t->ty != Tident)
+        s = t->toDsymbol(sc);
+
     return s;
 }
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -673,8 +673,12 @@ public:
     void addInst(TemplateInstance *inst);
     void addIndex(RootObject *expr);
     d_uns64 size(Loc loc);
+
+    void resolveExprType(Loc loc, Scope *sc, Expression *e, size_t i,
+        Expression **pe, Type **pt);
     void resolveHelper(Loc loc, Scope *sc, Dsymbol *s, Dsymbol *scopesym,
         Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+
     void accept(Visitor *v) { v->visit(this); }
 
 private:

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -674,15 +674,14 @@ public:
     void addIndex(RootObject *expr);
     d_uns64 size(Loc loc);
 
+    void resolveTupleIndex(Loc loc, Scope *sc, Dsymbol *s,
+        Expression **pe, Type **pt, Dsymbol **ps, RootObject *oindex);
     void resolveExprType(Loc loc, Scope *sc, Expression *e, size_t i,
         Expression **pe, Type **pt);
     void resolveHelper(Loc loc, Scope *sc, Dsymbol *s, Dsymbol *scopesym,
         Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
 
     void accept(Visitor *v) { v->visit(this); }
-
-private:
-    bool resolveTypeTupleIndex(Loc loc, Scope *sc, Dsymbol **s, Type **pt, Dsymbol **ps, RootObject *id, Expression *indexExpr);
 };
 
 class TypeIdentifier : public TypeQualified

--- a/src/parse.c
+++ b/src/parse.c
@@ -6014,8 +6014,16 @@ bool Parser::isDeclarator(Token **pt, int *haveId, int *haveTpl, TOK endtok)
                     t = peek(t);
                 }
                 else if (isDeclaration(t, 0, TOKrbracket, &t))
-                {   // It's an associative array declaration
+                {
+                    // It's an associative array declaration
                     t = peek(t);
+
+                    // ...[type].ident
+                    if (t->value == TOKdot && peek(t)->value == TOKidentifier)
+                    {
+                        t = peek(t);
+                        t = peek(t);
+                    }
                 }
                 else
                 {
@@ -6024,13 +6032,27 @@ bool Parser::isDeclarator(Token **pt, int *haveId, int *haveTpl, TOK endtok)
                     if (!isExpression(&t))
                         return false;
                     if (t->value == TOKslice)
-                    {   t = peek(t);
+                    {
+                        t = peek(t);
                         if (!isExpression(&t))
                             return false;
+                        if (t->value != TOKrbracket)
+                            return false;
+                        t = peek(t);
                     }
-                    if (t->value != TOKrbracket)
-                        return false;
-                    t = peek(t);
+                    else
+                    {
+                        if (t->value != TOKrbracket)
+                            return false;
+                        t = peek(t);
+
+                        // ...[index].ident
+                        if (t->value == TOKdot && peek(t)->value == TOKidentifier)
+                        {
+                            t = peek(t);
+                            t = peek(t);
+                        }
+                    }
                 }
                 continue;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -3028,7 +3028,7 @@ Type *Parser::parseType(Identifier **pident, TemplateParameters **ptpl)
     return t;
 }
 
-Type *Parser::parseBasicType()
+Type *Parser::parseBasicType(bool dontLookDotIdents)
 {
     Type *t;
     Loc loc;
@@ -3076,22 +3076,22 @@ Type *Parser::parseBasicType()
                 // ident!(template_arguments)
                 TemplateInstance *tempinst = new TemplateInstance(loc, id);
                 tempinst->tiargs = parseTemplateArguments();
-                t = parseBasicTypeStartingAt(new TypeInstance(loc, tempinst));
+                t = parseBasicTypeStartingAt(new TypeInstance(loc, tempinst), dontLookDotIdents);
             }
             else
             {
-                t = parseBasicTypeStartingAt(new TypeIdentifier(loc, id));
+                t = parseBasicTypeStartingAt(new TypeIdentifier(loc, id), dontLookDotIdents);
             }
             break;
 
         case TOKdot:
             // Leading . as in .foo
-            t = parseBasicTypeStartingAt(new TypeIdentifier(token.loc, Id::empty));
+            t = parseBasicTypeStartingAt(new TypeIdentifier(token.loc, Id::empty), dontLookDotIdents);
             break;
 
         case TOKtypeof:
             // typeof(expression)
-            t = parseBasicTypeStartingAt(parseTypeof());
+            t = parseBasicTypeStartingAt(parseTypeof(), dontLookDotIdents);
             break;
 
         case TOKvector:
@@ -3138,7 +3138,7 @@ Type *Parser::parseBasicType()
     return t;
 }
 
-Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid)
+Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid, bool dontLookDotIdents)
 {
     Type *maybeArray = NULL;
     // See https://issues.dlang.org/show_bug.cgi?id=1215
@@ -3212,6 +3212,9 @@ Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid)
             }
             case TOKlbracket:
             {
+                if (dontLookDotIdents)      // workaround for Bugzilla 14911
+                    goto Lend;
+
                 nextToken();
                 Type *t = maybeArray ? maybeArray : (Type *)tid;
                 if (token.value == TOKrbracket)
@@ -3266,7 +3269,7 @@ Type *Parser::parseBasicTypeStartingAt(TypeQualified *tid)
                 goto Lend;
         }
     }
-    Lend:
+Lend:
     return maybeArray ? maybeArray : (Type *)tid;
 }
 
@@ -7776,7 +7779,7 @@ Expression *Parser::parseNewExp(Expression *thisexp)
     }
 
     StorageClass stc = parseTypeCtor();
-    t = parseBasicType();
+    t = parseBasicType(true);
     t = parseBasicType2(t);
     t = t->addSTC(stc);
     if (t->ty == Taarray)

--- a/src/parse.h
+++ b/src/parse.h
@@ -114,8 +114,8 @@ public:
     BaseClasses *parseBaseClasses();
     Dsymbols *parseImport();
     Type *parseType(Identifier **pident = NULL, TemplateParameters **ptpl = NULL);
-    Type *parseBasicType();
-    Type *parseBasicTypeStartingAt(TypeQualified *tid);
+    Type *parseBasicType(bool dontLookDotIdents = false);
+    Type *parseBasicTypeStartingAt(TypeQualified *tid, bool dontLookDotIdents);
     Type *parseBasicType2(Type *t);
     Type *parseDeclarator(Type *t, int *alt, Identifier **pident,
         TemplateParameters **tpl = NULL, StorageClass storage_class = 0, int *pdisable = NULL, Expressions **pudas = NULL);

--- a/src/template.c
+++ b/src/template.c
@@ -3280,7 +3280,7 @@ MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *par
                         {
                             if (!s || !s->parent)
                                 goto Lnomatch;
-                            Dsymbol *s2 = s->parent->searchX(Loc(), sc, id);
+                            Dsymbol *s2 = s->parent->search(Loc(), (Identifier *)id);
                             if (!s2)
                                 goto Lnomatch;
                             s2 = s2->toAlias();

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -105,3 +105,15 @@ void test14900()
     Types14900[0].T a;      // Types[0] == S, then typeof(a) == S.T == int
     Types14900[0].U[1] b;   // Types[0].U == S.U, then typeof(b) == S.U[1] == string
 }
+
+/***************************************************/
+// 14911
+
+void test14911()
+{
+    struct S {}
+
+    int* buf1 = new int[2].ptr; // OK
+    S* buf2 = (new S[2]).ptr;   // OK
+    S* buf3 = new S[2].ptr;     // OK <- broken
+}

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -83,3 +83,25 @@ alias Y14889a = X14889a[0].ExceptionType;
 
 alias X14889b = TT14889!(A14889!Throwable);
 alias Y14889b = X14889b[0].ExceptionType;
+
+/***************************************************/
+// 14889
+
+alias TypeTuple14900(T...) = T;
+
+struct S14900
+{
+    alias T = int;
+    alias U = TypeTuple14900!(long,string);
+}
+
+alias Types14900 = TypeTuple14900!(S14900, S14900);
+
+Types14900[0].T a14900;     // Types[0] == S, then typeof(a) == S.T == int
+Types14900[0].U[1] b14900;  // Types[0].U == S.U, then typeof(b) == S.U[1] == string
+
+void test14900()
+{
+    Types14900[0].T a;      // Types[0] == S, then typeof(a) == S.T == int
+    Types14900[0].U[1] b;   // Types[0].U == S.U, then typeof(b) == S.U[1] == string
+}

--- a/test/compilable/b1215.d
+++ b/test/compilable/b1215.d
@@ -68,3 +68,18 @@ struct C(Args...)
 }
 
 alias Z = A!(B,B,C!(B,B));
+
+/***************************************************/
+// 14889
+
+struct A14889(alias Exc)
+{
+    alias ExceptionType = Exc;
+}
+alias TT14889(Args...) = Args;
+
+alias X14889a = TT14889!(A14889!Throwable());
+alias Y14889a = X14889a[0].ExceptionType;
+
+alias X14889b = TT14889!(A14889!Throwable);
+alias Y14889b = X14889b[0].ExceptionType;

--- a/test/fail_compilation/fail9.d
+++ b/test/fail_compilation/fail9.d
@@ -1,11 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9.d(25): Error: no property 'Vector' for type 'fail9.Vector!int'
-fail_compilation/fail9.d(25): Error: no property 'Vector' for type 'fail9.Vector!int'
+fail_compilation/fail9.d(23): Error: no property 'Vector' for type 'fail9.Vector!int'
 ---
 */
-
 
 template Vector(T)
 {

--- a/test/fail_compilation/ice9865.d
+++ b/test/fail_compilation/ice9865.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice9865.d(9): Error: struct ice9865.Foo no size yet for forward reference
-fail_compilation/ice9865.d(8): Error: alias ice9865.Baz cannot resolve
+fail_compilation/ice9865.d(8): Error: alias ice9865.Baz recursive alias declaration
 ---
 */
-import imports.ice9865b : Baz; 
+import imports.ice9865b : Baz;
 struct Foo { Baz f; }


### PR DESCRIPTION
This is same with #4876, excepting the base branch is 'stable'.

---

[Issue 14889](https://issues.dlang.org/show_bug.cgi?id=14889) - ICE: Assertion `o->dyncast() == DYNCAST_DSYMBOL' failed.
[Issue 14900](https://issues.dlang.org/show_bug.cgi?id=14900) - 2.068.0 change log example does not compile
[Issue 14911](https://issues.dlang.org/show_bug.cgi?id=14911) - Compiler found indexing in code "new MyStruct[2].ptr"

It was implemented in #4516, but unfortunately the we didn't get enough chance to test the new feature.
