### PR TITLE
fix Issue 13007 - Wrong x86 code: long negate

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -4486,6 +4486,7 @@ code *cdneg(elem *e,regm_t *pretregs)
         c = gen2(CNIL,0xF7,modregrm(3,3,msreg)); /* NEG msreg           */
         lsreg = findreglsw(retregs);
         gen2(c,0xF7,modregrm(3,3,lsreg));       /* NEG lsreg            */
+        code_orflag(c, CFpsw);                  // need flag result of previous NEG
         genc2(c,0x81,modregrm(3,3,msreg),0);    /* SBB msreg,0          */
   }
   else


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13007

I could not duplicate the problem in the test case given (it's very tricky to reproduce), but the fix I made should definitely fix it. The problem is the scheduler is re-ordering the instructions, the fix is to mark the one where the flags result matters, then the scheduler won't re-order it.
