### PR TITLE
Fix issue 14951 - VC mangling for class reference/pointer

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -1436,7 +1436,7 @@ private:
 
         t->accept(this);
 
-        if ((t->ty == Tpointer || t->ty == Treference) && global.params.is64bit)
+        if ((t->ty == Tpointer || t->ty == Treference || t->ty == Tclass) && global.params.is64bit)
         {
             buf.writeByte('E');
         }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14951

Class reference are also pointers.

Not sure if this should go into stable, but it's needed to compile ddmd for Win64.
