### PR TITLE
Use standard names for COFF structs and members

### DIFF
--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -66,7 +66,7 @@ static Outbuffer *string_table;
 // Section Headers
 Outbuffer  *ScnhdrBuf;             // Buffer to build section table in
 // The -1 is because it is 1 based indexing
-#define ScnhdrTab   (((struct scnhdr *)ScnhdrBuf->buf)-1)
+#define ScnhdrTab   (((IMAGE_SECTION_HEADER *)ScnhdrBuf->buf)-1)
 
 static int scnhdr_cnt;          // Number of sections in table
 #define SCNHDR_TAB_INITSIZE 16  // Initial number of sections in buffer
@@ -109,7 +109,7 @@ static IDXSTR extdef;
 
 int seg_data::isCode()
 {
-    return (ScnhdrTab[SDshtidx].s_flags & IMAGE_SCN_CNT_CODE) != 0;
+    return (ScnhdrTab[SDshtidx].Characteristics & IMAGE_SCN_CNT_CODE) != 0;
 }
 
 
@@ -387,7 +387,7 @@ MsCoffObj *MsCoffObj::init(Outbuffer *objbuf, const char *filename, const char *
     symbuf->setsize(0);
 
     if (!syment_buf)
-        syment_buf = new Outbuffer(sizeof(struct syment) * SYM_TAB_INIT);
+        syment_buf = new Outbuffer(sizeof(SymbolTable32) * SYM_TAB_INIT);
     syment_buf->setsize(0);
 
     extdef = 0;
@@ -396,8 +396,8 @@ MsCoffObj *MsCoffObj::init(Outbuffer *objbuf, const char *filename, const char *
     // Initialize segments for CODE, DATA, UDATA and CDATA
     if (!ScnhdrBuf)
     {
-        ScnhdrBuf = new Outbuffer(SYM_TAB_INC * sizeof(struct scnhdr));
-        ScnhdrBuf->reserve(SCNHDR_TAB_INITSIZE * sizeof(struct scnhdr));
+        ScnhdrBuf = new Outbuffer(SYM_TAB_INC * sizeof(IMAGE_SECTION_HEADER));
+        ScnhdrBuf->reserve(SCNHDR_TAB_INITSIZE * sizeof(IMAGE_SECTION_HEADER));
     }
     ScnhdrBuf->setsize(0);
     scnhdr_cnt = 0;
@@ -504,12 +504,12 @@ void MsCoffObj::initfile(const char *filename, const char *csegname, const char 
 
 int32_t *patchAddr(int seg, targ_size_t offset)
 {
-    return(int32_t *)(fobjbuf->buf + ScnhdrTab[SegData[seg]->SDshtidx].s_scnptr + offset);
+    return(int32_t *)(fobjbuf->buf + ScnhdrTab[SegData[seg]->SDshtidx].PointerToRawData + offset);
 }
 
 int32_t *patchAddr64(int seg, targ_size_t offset)
 {
-    return(int32_t *)(fobjbuf->buf + ScnhdrTab[SegData[seg]->SDshtidx].s_scnptr + offset);
+    return(int32_t *)(fobjbuf->buf + ScnhdrTab[SegData[seg]->SDshtidx].PointerToRawData + offset);
 }
 
 void patch(seg_data *pseg, targ_size_t offset, int seg, targ_size_t value)
@@ -517,31 +517,31 @@ void patch(seg_data *pseg, targ_size_t offset, int seg, targ_size_t value)
     //printf("patch(offset = x%04x, seg = %d, value = x%llx)\n", (unsigned)offset, seg, value);
     if (I64)
     {
-        int32_t *p = (int32_t *)(fobjbuf->buf + ScnhdrTab[pseg->SDshtidx].s_scnptr  + offset);
+        int32_t *p = (int32_t *)(fobjbuf->buf + ScnhdrTab[pseg->SDshtidx].PointerToRawData  + offset);
 #if 0
         printf("\taddr1 = x%llx\n\taddr2 = x%llx\n\t*p = x%llx\n\tdelta = x%llx\n",
-            ScnhdrTab[pseg->SDshtidx].s_vaddr,
-            ScnhdrTab[SegData[seg]->SDshtidx].s_vaddr,
+            ScnhdrTab[pseg->SDshtidx].VirtualAddress,
+            ScnhdrTab[SegData[seg]->SDshtidx].VirtualAddress,
             *p,
-            ScnhdrTab[SegData[seg]->SDshtidx].s_vaddr -
-            (ScnhdrTab[pseg->SDshtidx].s_vaddr + offset));
+            ScnhdrTab[SegData[seg]->SDshtidx].VirtualAddress -
+            (ScnhdrTab[pseg->SDshtidx].VirtualAddress + offset));
 #endif
-        *p += ScnhdrTab[SegData[seg]->SDshtidx].s_vaddr -
-              (ScnhdrTab[pseg->SDshtidx].s_vaddr - value);
+        *p += ScnhdrTab[SegData[seg]->SDshtidx].VirtualAddress -
+              (ScnhdrTab[pseg->SDshtidx].VirtualAddress - value);
     }
     else
     {
-        int32_t *p = (int32_t *)(fobjbuf->buf + ScnhdrTab[pseg->SDshtidx].s_scnptr + offset);
+        int32_t *p = (int32_t *)(fobjbuf->buf + ScnhdrTab[pseg->SDshtidx].PointerToRawData + offset);
 #if 0
         printf("\taddr1 = x%x\n\taddr2 = x%x\n\t*p = x%x\n\tdelta = x%x\n",
-            ScnhdrTab[pseg->SDshtidx].s_vaddr,
-            ScnhdrTab[SegData[seg]->SDshtidx].s_vaddr,
+            ScnhdrTab[pseg->SDshtidx].VirtualAddress,
+            ScnhdrTab[SegData[seg]->SDshtidx].VirtualAddress,
             *p,
-            ScnhdrTab[SegData[seg]->SDshtidx].s_vaddr -
-            (ScnhdrTab[pseg->SDshtidx].s_vaddr + offset));
+            ScnhdrTab[SegData[seg]->SDshtidx].VirtualAddress -
+            (ScnhdrTab[pseg->SDshtidx].VirtualAddress + offset));
 #endif
-        *p += ScnhdrTab[SegData[seg]->SDshtidx].s_vaddr -
-              (ScnhdrTab[pseg->SDshtidx].s_vaddr - value);
+        *p += ScnhdrTab[SegData[seg]->SDshtidx].VirtualAddress -
+              (ScnhdrTab[pseg->SDshtidx].VirtualAddress - value);
     }
 }
 
@@ -551,23 +551,23 @@ void patch(seg_data *pseg, targ_size_t offset, int seg, targ_size_t value)
  * Store them in syment_buf.
  */
 
-static void syment_set_name(syment *sym, const char *name)
+static void syment_set_name(SymbolTable32 *sym, const char *name)
 {
     size_t len = strlen(name);
     if (len > 8)
     {   // Use offset into string table
         IDXSTR idx = MsCoffObj::addstr(string_table, name);
-        sym->n_zeroes = 0;
-        sym->n_offset = idx;
+        sym->Zeros = 0;
+        sym->Offset = idx;
     }
     else
-    {   memcpy(sym->n_name, name, len);
+    {   memcpy(sym->Name, name, len);
         if (len < 8)
-            memset(sym->n_name + len, 0, 8 - len);
+            memset(sym->Name + len, 0, 8 - len);
     }
 }
 
-void write_sym(struct syment* sym, bool bigobj)
+void write_sym(SymbolTable32* sym, bool bigobj)
 {
     assert(sizeof(*sym) == 20);
     if (bigobj)
@@ -576,9 +576,9 @@ void write_sym(struct syment* sym, bool bigobj)
     }
     else
     {
-        // the only difference between syment and syment_old
-        // is that field n_scnum is long instead of short
-        unsigned scoff = (char*)&sym->n_scnum - (char*)sym;
+        // the only difference between SymbolTable32 and SymbolTable
+        // is that field SectionNumber is long instead of short
+        unsigned scoff = (char*)&sym->SectionNumber - (char*)sym;
         syment_buf->write(sym, scoff + 2);
         syment_buf->write((char*)sym + scoff + 4, sizeof(*sym) - scoff - 4);
     }
@@ -590,21 +590,21 @@ void build_syment_table(bool bigobj)
      * Anything we put in there would have no relevance, so we'll not put out this symbol.
      */
 
-    unsigned symsize = bigobj ? sizeof(syment) : sizeof(syment_old);
+    unsigned symsize = bigobj ? sizeof(SymbolTable32) : sizeof(SymbolTable);
     /* Now goes one symbol per section.
      */
     for (segidx_t seg = 1; seg <= seg_count; seg++)
     {
         seg_data *pseg = SegData[seg];
-        scnhdr *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
+        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
 
-        struct syment sym;
-        memcpy(sym.n_name, psechdr->s_name, 8);
-        sym.n_value = 0;
-        sym.n_scnum = pseg->SDshtidx;
-        sym.n_type = 0;
-        sym.n_sclass = IMAGE_SYM_CLASS_STATIC;
-        sym.n_numaux = 1;
+        SymbolTable32 sym;
+        memcpy(sym.Name, psechdr->Name, 8);
+        sym.Value = 0;
+        sym.SectionNumber = pseg->SDshtidx;
+        sym.Type = 0;
+        sym.StorageClass = IMAGE_SYM_CLASS_STATIC;
+        sym.NumberOfAuxSymbols = 1;
 
         write_sym(&sym, bigobj);
 
@@ -621,7 +621,7 @@ void build_syment_table(bool bigobj)
         if (pseg->SDrel)
             aux.x_section.NumberOfRelocations = pseg->SDrel->size() / sizeof(struct Relocation);
 
-        if (psechdr->s_flags & IMAGE_SCN_LNK_COMDAT)
+        if (psechdr->Characteristics & IMAGE_SCN_LNK_COMDAT)
         {
             aux.x_section.Selection = (unsigned char)IMAGE_COMDAT_SELECT_ANY;
             if (pseg->SDassocseg)
@@ -648,39 +648,39 @@ void build_syment_table(bool bigobj)
         s->Sxtrnnum = syment_buf->size() / symsize;
         n++;
 
-        struct syment sym;
+        SymbolTable32 sym;
 
         char dest[DEST_LEN+1];
         char *destr = obj_mangle2(s, dest);
         syment_set_name(&sym, destr);
 
-        sym.n_value = 0;
+        sym.Value = 0;
         switch (s->Sclass)
         {
             case SCextern:
-                sym.n_scnum = IMAGE_SYM_UNDEFINED;
+                sym.SectionNumber = IMAGE_SYM_UNDEFINED;
                 break;
 
             default:
-                sym.n_scnum = SegData[s->Sseg]->SDshtidx;
+                sym.SectionNumber = SegData[s->Sseg]->SDshtidx;
                 break;
         }
-        sym.n_type = tyfunc(s->Stype->Tty) ? 0x20 : 0;
+        sym.Type = tyfunc(s->Stype->Tty) ? 0x20 : 0;
         switch (s->Sclass)
         {
             case SCstatic:
             case SClocstat:
-                sym.n_sclass = IMAGE_SYM_CLASS_STATIC;
-                sym.n_value = s->Soffset;
+                sym.StorageClass = IMAGE_SYM_CLASS_STATIC;
+                sym.Value = s->Soffset;
                 break;
 
             default:
-                sym.n_sclass = IMAGE_SYM_CLASS_EXTERNAL;
-                if (sym.n_scnum != IMAGE_SYM_UNDEFINED)
-                    sym.n_value = s->Soffset;
+                sym.StorageClass = IMAGE_SYM_CLASS_EXTERNAL;
+                if (sym.SectionNumber != IMAGE_SYM_UNDEFINED)
+                    sym.Value = s->Soffset;
                 break;
         }
-        sym.n_numaux = 0;
+        sym.NumberOfAuxSymbols = 0;
 
         write_sym(&sym, bigobj);
     }
@@ -743,8 +743,8 @@ void MsCoffObj::term(const char *objfilename)
 
     // Write out the bytes for the header
 
-    struct filehdr header;
-    struct filehdr_old header_old;
+    BIGOBJ_HEADER header;
+    IMAGE_FILE_HEADER header_old;
 
     time_t f_timedat = 0;
     time(&f_timedat);
@@ -752,36 +752,36 @@ void MsCoffObj::term(const char *objfilename)
 
     if (bigobj)
     {
-        header.f_sig1 = IMAGE_FILE_MACHINE_UNKNOWN;
-        header.f_sig2 = 0xFFFF;
-        header.f_minver = 2;
-        header.f_magic = I64 ? IMAGE_FILE_MACHINE_AMD64 : IMAGE_FILE_MACHINE_I386;
-        header.f_nscns = scnhdr_cnt;
-        header.f_timdat = (unsigned long)f_timedat;
+        header.Sig1 = IMAGE_FILE_MACHINE_UNKNOWN;
+        header.Sig2 = 0xFFFF;
+        header.Version = 2;
+        header.Machine = I64 ? IMAGE_FILE_MACHINE_AMD64 : IMAGE_FILE_MACHINE_I386;
+        header.NumberOfSections = scnhdr_cnt;
+        header.TimeDateStamp = (unsigned long)f_timedat;
         unsigned char uuid[16] = { '\xc7', '\xa1', '\xba', '\xd1', '\xee', '\xba', '\xa9', '\x4b',
                                     '\xaf', '\x20', '\xfa', '\xf6', '\x6a', '\xa4', '\xdc', '\xb8' };
-        memcpy(header.f_uuid, uuid, 16);
-        memset(header.f_unused, 0, sizeof(header.f_unused));
+        memcpy(header.UUID, uuid, 16);
+        memset(header.unused, 0, sizeof(header.unused));
         foffset = sizeof(header);       // start after header
         foffset += ScnhdrBuf->size();   // section headers
-        header.f_symptr = foffset;      // offset to symbol table
+        header.PointerToSymbolTable = foffset;      // offset to symbol table
         symtable_offset = foffset;
-        header.f_nsyms = syment_buf->size() / sizeof(struct syment);
-        foffset += header.f_nsyms * sizeof(struct syment);  // symbol table
+        header.NumberOfSymbols = syment_buf->size() / sizeof(SymbolTable32);
+        foffset += header.NumberOfSymbols * sizeof(SymbolTable32);  // symbol table
     }
     else
     {
-        header_old.f_magic = I64 ? IMAGE_FILE_MACHINE_AMD64 : IMAGE_FILE_MACHINE_I386;
-        header_old.f_nscns = scnhdr_cnt;
-        header_old.f_timdat = (unsigned long)f_timedat;
-        header_old.f_opthdr = 0;
-        header_old.f_flags = 0;
+        header_old.Machine = I64 ? IMAGE_FILE_MACHINE_AMD64 : IMAGE_FILE_MACHINE_I386;
+        header_old.NumberOfSections = scnhdr_cnt;
+        header_old.TimeDateStamp = (unsigned long)f_timedat;
+        header_old.SizeOfOptionalHeader = 0;
+        header_old.Characteristics = 0;
         foffset = sizeof(header_old);   // start after header
         foffset += ScnhdrBuf->size();   // section headers
-        header_old.f_symptr = foffset;  // offset to symbol table
+        header_old.PointerToSymbolTable = foffset;  // offset to symbol table
         symtable_offset = foffset;
-        header_old.f_nsyms = syment_buf->size() / sizeof(struct syment_old);
-        foffset += header_old.f_nsyms * sizeof(struct syment_old);  // symbol table
+        header_old.NumberOfSymbols = syment_buf->size() / sizeof(SymbolTable);
+        foffset += header_old.NumberOfSymbols * sizeof(SymbolTable);  // symbol table
     }
 
     unsigned string_table_offset = foffset;
@@ -792,7 +792,7 @@ void MsCoffObj::term(const char *objfilename)
     for (segidx_t seg = 1; seg <= seg_count; seg++)
     {
         seg_data *pseg = SegData[seg];
-        scnhdr *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
+        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
 
         int align = pseg->SDalignment;
         if (align > 1)
@@ -800,30 +800,30 @@ void MsCoffObj::term(const char *objfilename)
 
         if (pseg->SDbuf && pseg->SDbuf->size())
         {
-            psechdr->s_scnptr = foffset;
+            psechdr->PointerToRawData = foffset;
             //printf("seg = %2d SDshtidx = %2d psechdr = %p s_scnptr = x%x\n", seg, pseg->SDshtidx, psechdr, (unsigned)psechdr->s_scnptr);
-            psechdr->s_size = pseg->SDbuf->size();
-            foffset += psechdr->s_size;
+            psechdr->SizeOfRawData = pseg->SDbuf->size();
+            foffset += psechdr->SizeOfRawData;
         }
         else
-            psechdr->s_size = pseg->SDoffset;
+            psechdr->SizeOfRawData = pseg->SDoffset;
     }
 
     // Compute file offsets of the relocation data
     for (segidx_t seg = 1; seg <= seg_count; seg++)
     {
         seg_data *pseg = SegData[seg];
-        scnhdr *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
+        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
         if (pseg->SDrel)
         {
             foffset = (foffset + 3) & ~3;
-            assert(psechdr->s_relptr == 0);
+            assert(psechdr->PointerToRelocations == 0);
             unsigned nreloc = pseg->SDrel->size() / sizeof(struct Relocation);
             if (nreloc)
             {
-                psechdr->s_relptr = foffset;
+                psechdr->PointerToRelocations = foffset;
                 //printf("seg = %d SDshtidx = %d psechdr = %p s_relptr = x%x\n", seg, pseg->SDshtidx, psechdr, (unsigned)psechdr->s_relptr);
-                psechdr->s_nreloc = nreloc;
+                psechdr->NumberOfRelocations = nreloc;
                 foffset += nreloc * sizeof(struct reloc);
             }
         }
@@ -862,13 +862,13 @@ void MsCoffObj::term(const char *objfilename)
     for (segidx_t seg = 1; seg <= seg_count; seg++)
     {
         seg_data *pseg = SegData[seg];
-        scnhdr *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
+        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
         foffset = elf_align(pseg->SDalignment, foffset);
         if (pseg->SDbuf && pseg->SDbuf->size())
         {
             //printf("seg = %2d SDshtidx = %2d psechdr = %p s_scnptr = x%x, foffset = x%x\n", seg, pseg->SDshtidx, psechdr, (unsigned)psechdr->s_scnptr, (unsigned)foffset);
-            assert(pseg->SDbuf->size() == psechdr->s_size);
-            assert(foffset == psechdr->s_scnptr);
+            assert(pseg->SDbuf->size() == psechdr->SizeOfRawData);
+            assert(foffset == psechdr->PointerToRawData);
             fobjbuf->write(pseg->SDbuf);
             foffset += pseg->SDbuf->size();
         }
@@ -879,18 +879,18 @@ void MsCoffObj::term(const char *objfilename)
     for (segidx_t seg = 1; seg <= seg_count; seg++)
     {
         seg_data *pseg = SegData[seg];
-        scnhdr *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
+        IMAGE_SECTION_HEADER *psechdr = &ScnhdrTab[pseg->SDshtidx];   // corresponding section
         if (pseg->SDrel)
         {   Relocation *r = (Relocation *)pseg->SDrel->buf;
             size_t sz = pseg->SDrel->size();
-            bool pdata = (strcmp(psechdr->s_name, ".pdata") == 0);
+            bool pdata = (strcmp((const char *)psechdr->Name, ".pdata") == 0);
             Relocation *rend = (Relocation *)(pseg->SDrel->buf + sz);
             foffset = elf_align(4, foffset);
 #ifdef DEBUG
-            if (sz && foffset != psechdr->s_relptr)
-                printf("seg = %d SDshtidx = %d psechdr = %p s_relptr = x%x, foffset = x%x\n", seg, pseg->SDshtidx, psechdr, (unsigned)psechdr->s_relptr, (unsigned)foffset);
+            if (sz && foffset != psechdr->PointerToRelocations)
+                printf("seg = %d SDshtidx = %d psechdr = %p s_relptr = x%x, foffset = x%x\n", seg, pseg->SDshtidx, psechdr, (unsigned)psechdr->PointerToRelocations, (unsigned)foffset);
 #endif
-            assert(sz == 0 || foffset == psechdr->s_relptr);
+            assert(sz == 0 || foffset == psechdr->PointerToRelocations);
             for (; r != rend; r++)
             {   reloc rel;
                 rel.r_vaddr = 0;
@@ -1531,8 +1531,8 @@ segidx_t MsCoffObj::getsegment(const char *sectname, unsigned long flags)
     {
         for (segidx_t seg = 1; seg <= seg_count; seg++)
         {   seg_data *pseg = SegData[seg];
-            if (!(ScnhdrTab[pseg->SDshtidx].s_flags & IMAGE_SCN_LNK_COMDAT) &&
-                strncmp(ScnhdrTab[pseg->SDshtidx].s_name, sectname, 8) == 0)
+            if (!(ScnhdrTab[pseg->SDshtidx].Characteristics & IMAGE_SCN_LNK_COMDAT) &&
+                strncmp((const char *)ScnhdrTab[pseg->SDshtidx].Name, sectname, 8) == 0)
             {
                 //printf("\t%s\n", sectname);
                 return seg;         // return existing segment
@@ -1577,7 +1577,7 @@ segidx_t MsCoffObj::getsegment2(IDXSEC shtidx)
     {
         seg_data *pseg = (seg_data *)mem_calloc(sizeof(seg_data));
         SegData[seg] = pseg;
-        if (!(ScnhdrTab[shtidx].s_flags & IMAGE_SCN_CNT_UNINITIALIZED_DATA))
+        if (!(ScnhdrTab[shtidx].Characteristics & IMAGE_SCN_CNT_UNINITIALIZED_DATA))
         {   pseg->SDbuf = new Outbuffer(4096);
             pseg->SDbuf->reserve(4096);
         }
@@ -1608,17 +1608,17 @@ extern void fatal();
 
 IDXSEC MsCoffObj::addScnhdr(const char *scnhdr_name, unsigned long flags)
 {
-    struct scnhdr sec;
+    IMAGE_SECTION_HEADER sec;
     memset(&sec, 0, sizeof(sec));
     size_t len = strlen(scnhdr_name);
     if (len > 8)
     {   // Use /nnnn form
         IDXSTR idx = addstr(string_table, scnhdr_name);
-        sprintf(sec.s_name, "/%d", idx);
+        sprintf((char *)sec.Name, "/%d", idx);
     }
     else
-        memcpy(sec.s_name, scnhdr_name, len);
-    sec.s_flags = flags;
+        memcpy(sec.Name, scnhdr_name, len);
+    sec.Characteristics = flags;
     ScnhdrBuf->write((void *)&sec, sizeof(sec));
     return ++scnhdr_cnt;
 }
@@ -2111,7 +2111,7 @@ void MsCoffObj::lidata(segidx_t seg,targ_size_t offset,targ_size_t count)
 {
     //printf("MsCoffObj::lidata(%d,%x,%d)\n",seg,offset,count);
     size_t idx = SegData[seg]->SDshtidx;
-    if ((ScnhdrTab[idx].s_flags) & IMAGE_SCN_CNT_UNINITIALIZED_DATA)
+    if ((ScnhdrTab[idx].Characteristics) & IMAGE_SCN_CNT_UNINITIALIZED_DATA)
     {   // Use SDoffset to record size of bss section
         SegData[seg]->SDoffset += count;
     }


### PR DESCRIPTION
Needed before scanmscoff can be ported to D.

@WalterBright 
