### PR TITLE
[REG 2.067.0] Issue 14431 - huge slowdown of compilation speed

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -170,6 +170,11 @@ public:
     Type *arg1type;
     Type *arg2type;
 
+    // Even if struct is defined as non-root symbol, some built-in operations
+    // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
+    // For those, today TypeInfo_Struct is generated in COMDAT.
+    bool requestTypeInfo;
+
     StructDeclaration(Loc loc, Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);

--- a/src/expression.c
+++ b/src/expression.c
@@ -4161,7 +4161,7 @@ Expression *ArrayLiteralExp::semantic(Scope *sc)
         return new ErrorExp();
     }
 
-    semanticTypeInfo(sc, t0);
+    semanticTypeInfo(sc, type);
 
     return this;
 }
@@ -6114,6 +6114,9 @@ Expression *TypeidExp::semantic(Scope *sc)
         // Handle this in the glue layer
         e = new TypeidExp(loc, ta);
         e->type = getTypeInfoType(ta, sc);
+
+        semanticTypeInfo(sc, ta);
+
         if (ea)
         {
             e = new CommaExp(loc, ea, e);       // execute ea

--- a/src/inline.c
+++ b/src/inline.c
@@ -919,6 +919,26 @@ Expression *doInline(Expression *e, InlineDoState *ids)
             ne->newargs = arrayExpressiondoInline(e->newargs);
             ne->arguments = arrayExpressiondoInline(e->arguments);
             result = ne;
+
+            semanticTypeInfo(NULL, e->type);
+        }
+
+        void visit(DeleteExp *e)
+        {
+            visit((UnaExp *)e);
+
+            Type *tb = e->e1->type->toBasetype();
+            if (tb->ty == Tarray)
+            {
+                Type *tv = tb->nextOf()->baseElemOf();
+                if (tv->ty == Tstruct)
+                {
+                    TypeStruct *ts = (TypeStruct *)tv;
+                    StructDeclaration *sd = ts->sym;
+                    if (sd->dtor)
+                        semanticTypeInfo(NULL, ts);
+                }
+            }
         }
 
         void visit(UnaExp *e)
@@ -955,6 +975,37 @@ Expression *doInline(Expression *e, InlineDoState *ids)
             ce->e1 = doInline(e->e1, ids);
             ce->arguments = arrayExpressiondoInline(e->arguments);
             result = ce;
+        }
+
+        void visit(AssignExp *e)
+        {
+            visit((BinExp *)e);
+
+            if (e->e1->op == TOKarraylength)
+            {
+                ArrayLengthExp *ale = (ArrayLengthExp *)e->e1;
+                Type *tn = ale->e1->type->toBasetype()->nextOf();
+                semanticTypeInfo(NULL, tn);
+            }
+        }
+
+        void visit(EqualExp *e)
+        {
+            visit((BinExp *)e);
+
+            Type *t1 = e->e1->type->toBasetype();
+            if (t1->ty == Tarray || t1->ty == Tsarray)
+            {
+                Type *t = t1->nextOf()->toBasetype();
+                while (t->toBasetype()->nextOf())
+                    t = t->nextOf()->toBasetype();
+                if (t->ty == Tstruct)
+                    semanticTypeInfo(NULL, t);
+            }
+            else if (t1->ty == Taarray)
+            {
+                semanticTypeInfo(NULL, t1);
+            }
         }
 
         void visit(IndexExp *e)
@@ -1042,6 +1093,8 @@ Expression *doInline(Expression *e, InlineDoState *ids)
 
             ce->elements = arrayExpressiondoInline(e->elements);
             result = ce;
+
+            semanticTypeInfo(NULL, e->type);
         }
 
         void visit(AssocArrayLiteralExp *e)
@@ -1051,6 +1104,8 @@ Expression *doInline(Expression *e, InlineDoState *ids)
             ce->keys = arrayExpressiondoInline(e->keys);
             ce->values = arrayExpressiondoInline(e->values);
             result = ce;
+
+            semanticTypeInfo(NULL, e->type);
         }
 
         void visit(StructLiteralExp *e)
@@ -1837,6 +1892,14 @@ static Expression *expandInline(FuncDeclaration *fd, FuncDeclaration *parent,
     memset(&ids, 0, sizeof(ids));
     ids.parent = parent;
     ids.fd = fd;
+
+    // When the function is actually expanded
+    if (TemplateInstance *ti = fd->isInstantiated())
+    {
+        // change ti to non-speculative instance
+        if (!ti->minst)
+            ti->minst = ti->tempdecl->getModule();
+    }
 
     if (ps)
         as = new Statements();

--- a/src/magicport.json
+++ b/src/magicport.json
@@ -248,6 +248,7 @@
                 "aggregate",
                 "argtypes",
                 "arraytypes",
+                "backend",
                 "clone",
                 "declaration",
                 "dmodule",

--- a/src/struct.c
+++ b/src/struct.c
@@ -115,9 +115,16 @@ void semanticTypeInfo(Scope *sc, Type *t)
                 }
             }
 
-            getTypeInfoType(t, sc);
+            if (!sc)    // inline may request TypeInfo.
+            {
+                Scope scx;
+                scx.module = sd->getModule();
+                getTypeInfoType(t, &scx);
+            }
+            else
+                getTypeInfoType(t, sc);
 
-            if (sc->minst)
+            if (!sc || sc->minst)
                 sd->requestTypeInfo = true;
         }
         void visit(TypeClass *t) { }

--- a/src/struct.c
+++ b/src/struct.c
@@ -100,8 +100,12 @@ void semanticTypeInfo(Scope *sc, Type *t)
 
             // If the struct is in a non-root module, run semantic3 to get
             // correct symbols for the member function.
-            // Note that, all instantiated symbols will run semantic3.
-            if (sd->inNonRoot())
+            if (TemplateInstance *ti = sd->isInstantiated())
+            {
+                if (ti->minst && !ti->minst->isRoot())
+                    Module::addDeferredSemantic3(sd);
+            }
+            else if (sd->inNonRoot())
             {
                 //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd->toChars(), sd->inNonRoot());
                 Module::addDeferredSemantic3(sd);

--- a/src/struct.c
+++ b/src/struct.c
@@ -24,6 +24,7 @@
 #include "template.h"
 #include "tokens.h"
 
+Type *getTypeInfoType(Type *t, Scope *sc);
 TypeTuple *toArgTypes(Type *t);
 
 FuncDeclaration *StructDeclaration::xerreq;     // object.xopEquals
@@ -105,11 +106,19 @@ void semanticTypeInfo(Scope *sc, Type *t)
                 if (ti->minst && !ti->minst->isRoot())
                     Module::addDeferredSemantic3(sd);
             }
-            else if (sd->inNonRoot())
+            else
             {
-                //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd->toChars(), sd->inNonRoot());
-                Module::addDeferredSemantic3(sd);
+                if (sd->inNonRoot())
+                {
+                    //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd->toChars(), sd->inNonRoot());
+                    Module::addDeferredSemantic3(sd);
+                }
             }
+
+            getTypeInfoType(t, sc);
+
+            if (sc->minst)
+                sd->requestTypeInfo = true;
         }
         void visit(TypeClass *t) { }
         void visit(TypeTuple *t)
@@ -667,6 +676,7 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
     ispod = ISPODfwd;
     arg1type = NULL;
     arg2type = NULL;
+    requestTypeInfo = false;
 
     // For forward references
     type = new TypeStruct(this);

--- a/src/template.h
+++ b/src/template.h
@@ -351,6 +351,7 @@ public:
     bool findBestMatch(Scope *sc, Expressions *fargs);
     bool needsTypeInference(Scope *sc, int flag = 0);
     bool hasNestedArgs(Objects *tiargs, bool isstatic);
+    Dsymbols *appendToModuleMember();
     void declareParameters(Scope *sc);
     Identifier *genIdent(Objects *args);
     void expandMembers(Scope *sc);

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -58,6 +58,7 @@ Symbol *toVtblSymbol(ClassDeclaration *cd);
 Symbol *toInitializer(AggregateDeclaration *ad);
 Symbol *toInitializer(EnumDeclaration *ed);
 void genTypeInfo(Type *t, Scope *sc);
+bool isSpeculativeType(Type *t);
 
 void toDebug(EnumDeclaration *ed);
 void toDebug(StructDeclaration *sd);
@@ -1010,6 +1011,11 @@ void toObjFile(Dsymbol *ds, bool multiobj)
 
         void visit(TypeInfoDeclaration *tid)
         {
+            if (isSpeculativeType(tid->tinfo))
+            {
+                //printf("-speculative '%s'\n", tid->toPrettyChars());
+                return;
+            }
             //printf("TypeInfoDeclaration::toObjFile(%p '%s') protection %d\n", tid, tid->toChars(), tid->protection);
 
             if (multiobj)

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -78,19 +78,9 @@ void genTypeInfo(Type *torig, Scope *sc)
             // Generate COMDAT
             if (sc)                     // if in semantic() pass
             {
-                if (sc->func && sc->func->inNonRoot())
-                {
-                    // Bugzilla 13043: Avoid linking TypeInfo if it's not
-                    // necessary for root module compilation
-                }
-                else
-                {
-                    // Find module that will go all the way to an object file
-                    Module *m = sc->module->importedFrom;
-                    m->members->push(t->vtinfo);
-
-                    semanticTypeInfo(sc, t);
-                }
+                // Find module that will go all the way to an object file
+                Module *m = sc->module->importedFrom;
+                m->members->push(t->vtinfo);
             }
             else                        // if in obj generation pass
             {
@@ -133,6 +123,96 @@ TypeInfoDeclaration *getTypeInfoDeclaration(Type *t)
     default:
         return TypeInfoDeclaration::create(t, 0);
     }
+}
+
+bool isSpeculativeType(Type *t)
+{
+    class SpeculativeTypeVisitor : public Visitor
+    {
+    public:
+        StructDeclaration *result;
+
+        SpeculativeTypeVisitor() : result(NULL) {}
+
+        void visit(Type *t)
+        {
+            Type *tb = t->toBasetype();
+            if (tb != t)
+                tb->accept(this);
+        }
+        void visit(TypeNext *t)
+        {
+            if (t->next)
+                t->next->accept(this);
+        }
+        void visit(TypeBasic *t) { }
+        void visit(TypeVector *t)
+        {
+            t->basetype->accept(this);
+        }
+        void visit(TypeAArray *t)
+        {
+            t->index->accept(this);
+            visit((TypeNext *)t);
+        }
+        void visit(TypeFunction *t)
+        {
+            visit((TypeNext *)t);
+            // Currently TypeInfo_Function doesn't store parameter types.
+        }
+        void visit(TypeStruct *t)
+        {
+            result = t->sym;
+        }
+        void visit(TypeClass *t) { }
+        void visit(TypeTuple *t)
+        {
+            if (t->arguments)
+            {
+                for (size_t i = 0; i < t->arguments->dim; i++)
+                {
+                    Type *tprm = (*t->arguments)[i]->type;
+                    if (tprm)
+                        tprm->accept(this);
+                }
+            }
+        }
+    };
+    SpeculativeTypeVisitor v;
+    t->accept(&v);
+
+    StructDeclaration *sd = v.result;
+    if (!sd)
+        return false;
+
+    if (TemplateInstance *ti = sd->isInstantiated())
+    {
+        if (!ti->needsCodegen())
+        {
+            /* Bugzilla 14425: TypeInfo_Struct would refer the members of
+             * struct (e.g. opEquals via xopEquals field), so if it's instantiated
+             * in speculative context, TypeInfo creation should also be
+             * stopped to avoid 'unresolved symbol' linker errors.
+             */
+            if (!ti->minst)
+                return true;
+
+            /* When -debug/-unittest is specified, all of non-root instances are
+             * automatically changed to speculative, and here is always reached
+             * from those instantiated non-root structs.
+             * Therefore, if the TypeInfo is not auctually requested,
+             * we have to elide its codegen.
+             */
+            if (!sd->requestTypeInfo)
+                return true;
+        }
+    }
+    else
+    {
+        //assert(!sd->inNonRoot() || sd->requestTypeInfo);  // valid?
+    }
+
+    return false;
 }
 
 /****************************************************
@@ -422,13 +502,27 @@ public:
 
         if (TemplateInstance *ti = sd->isInstantiated())
         {
-            /* Bugzilla 14425: TypeInfo_Struct would refer the members of
-             * struct (e.g. opEquals via xopEquals field), so if it's instantiated
-             * in speculative context, TypeInfo creation should also be
-             * stopped to avoid 'unresolved symbol' linker errors.
-             */
-            if (!ti->needsCodegen() && !ti->minst)
-                return;
+            if (!ti->needsCodegen())
+            {
+                assert(ti->minst);
+                assert(sd->requestTypeInfo);
+
+                /* ti->toObjFile() won't get called. So, store these
+                 * member functions into object file in here.
+                 */
+                if (sd->xeq && sd->xeq != StructDeclaration::xerreq)
+                    toObjFile(sd->xeq, global.params.multiobj);
+                if (sd->xcmp && sd->xcmp != StructDeclaration::xerrcmp)
+                    toObjFile(sd->xcmp, global.params.multiobj);
+                if (FuncDeclaration *ftostr = search_toString(sd))
+                    toObjFile(ftostr, global.params.multiobj);
+                if (sd->xhash)
+                    toObjFile(sd->xhash, global.params.multiobj);
+                if (sd->postblit)
+                    toObjFile(sd->postblit, global.params.multiobj);
+                if (sd->dtor)
+                    toObjFile(sd->dtor, global.params.multiobj);
+            }
         }
 
         /* Put out:

--- a/test/runnable/extra-files/linkdebug.d
+++ b/test/runnable/extra-files/linkdebug.d
@@ -1,0 +1,16 @@
+module linkdebug;
+
+void main()
+{
+    import linkdebug_uni;
+    import linkdebug_range;
+
+    // OK
+    //SortedRangeX!(uint[], "a <= b") SR;
+
+    CodepointSet set;
+    set.addInterval(1, 2);
+
+    // NG, order dependent.
+    SortedRange!(uint[], "a <= b") SR;
+}

--- a/test/runnable/extra-files/linkdebug_primitives.d
+++ b/test/runnable/extra-files/linkdebug_primitives.d
@@ -1,0 +1,13 @@
+module linkdebug_primitives;
+
+size_t popBackN(R)(ref R r, size_t n)
+{
+    n = cast(size_t) (n < r.length ? n : r.length);
+    r = r[0 .. $ - n];
+    return n;
+}
+
+auto moveAt(R, I)(R r, I i)
+{
+    return r[i];
+}

--- a/test/runnable/extra-files/linkdebug_range.d
+++ b/test/runnable/extra-files/linkdebug_range.d
@@ -1,0 +1,48 @@
+module linkdebug_range;
+
+import linkdebug_primitives : popBackN, moveAt;
+
+auto stride(R)(R r)
+{
+    static struct Result
+    {
+        R source;
+
+        void popBack()
+        {
+            popBackN(source, 0);
+        }
+
+        uint moveAt(size_t n)
+        {
+            return .moveAt(source, n);
+        }
+    }
+    return Result(r);
+}
+
+struct SortedRange(Range, alias pred = "a < b")
+{
+    this(Range input)
+    out
+    {
+        dbgVerifySorted();
+    }
+    body
+    {
+    }
+
+    void dbgVerifySorted()
+    {
+        debug
+        {
+            uint[] _input;
+            auto st = stride(_input);
+        }
+    }
+}
+
+auto assumeSorted(alias pred = "a < b", R)(R r)
+{
+    return SortedRange!(R, pred)(r);
+}

--- a/test/runnable/extra-files/linkdebug_uni.d
+++ b/test/runnable/extra-files/linkdebug_uni.d
@@ -1,0 +1,19 @@
+module linkdebug_uni;
+
+import linkdebug_range;
+
+struct GcPolicy {}
+
+alias CodepointSet = InversionList!();
+
+struct InversionList(SP = GcPolicy)
+{
+@trusted:
+    size_t addInterval(int a, int b, size_t hint = 0)
+    {
+        auto data = new uint[](0);        // affects to the number of missimg symbol
+        auto range = assumeSorted(data[]);  // NG
+        //SortedRange!(uint[], "a < b") SR; // OK
+        return 1;
+    }
+}

--- a/test/runnable/extra-files/test14198.d
+++ b/test/runnable/extra-files/test14198.d
@@ -13,8 +13,11 @@ struct S
             to!string(false);
             // [1] to!string(bool src) should be deduced to pure @safe, and the function will be mangled to:
             //     --> _D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya
-            // [2] its object code should be stored in the library file, because it's instantiated in std14188.uni:
+            // [2] its object code would be stored in the library file, because it's instantiated in std14188.uni:
             //     --> FormatSpec!char --> to!string(bool src) in FormatSpec!char.toString()
+            //     But semanti3 of FormatSpec!char.toString() won't get called from this module compilation,
+            //     so the instantiaion is invisible.
+            //     Then, the object code is also stored in test14198.obj, and the link will succeed.
         }
         else
             static assert(0);

--- a/test/runnable/imports/link14541traits.d
+++ b/test/runnable/imports/link14541traits.d
@@ -1,0 +1,54 @@
+module imports.link14541traits;
+
+template hasElaborateAssign(S)
+{
+    static if (is(S == struct))
+    {
+        extern __gshared S lvalue;
+
+        enum hasElaborateAssign = is(typeof(S.init.opAssign(S.init))) ||
+                                  is(typeof(S.init.opAssign(lvalue)));
+    }
+    else
+    {
+        enum bool hasElaborateAssign = false;
+    }
+}
+
+void swap(T)(ref T lhs, ref T rhs) @trusted pure nothrow @nogc
+{
+    static if (hasElaborateAssign!T)
+    {
+    }
+    else
+    {
+    }
+}
+
+template Tuple(Types...)
+{
+    struct Tuple
+    {
+        Types field;
+        alias field this;
+
+        this(Types values)
+        {
+            field[] = values[];
+        }
+
+        void opAssign(R)(auto ref R rhs)
+        {
+            static if (is(R : Tuple!Types) && !__traits(isRef, rhs))
+            {
+                // Use swap-and-destroy to optimize rvalue assignment
+                swap!(Tuple!Types)(this, rhs);
+            }
+            else
+            {
+                // Do not swap; opAssign should be called on the fields.
+                field[] = rhs.field[];
+            }
+        }
+    }
+}

--- a/test/runnable/imports/test14901a.d
+++ b/test/runnable/imports/test14901a.d
@@ -1,0 +1,21 @@
+module imports.test14901a;
+
+//extern(C) int printf(const char*, ...);
+
+extern extern(C) __gshared static int initCount;
+
+int make(string s)()
+{
+    __gshared static int value;
+
+    struct WithCtor
+    {
+        shared static this()
+        {
+            //printf("%s\n", s.ptr);
+            initCount++;
+        }
+    }
+
+    return value;
+}

--- a/test/runnable/imports/test14901b.d
+++ b/test/runnable/imports/test14901b.d
@@ -1,0 +1,13 @@
+module imports.test14901b;
+
+import imports.test14901a;
+
+alias bar = make!"bar";
+
+struct User(int id)
+{
+    int foo()
+    {
+        return bar;
+    }
+}

--- a/test/runnable/imports/test14901c.d
+++ b/test/runnable/imports/test14901c.d
@@ -1,0 +1,10 @@
+module imports.test14901c;
+
+import imports.test14901b;
+
+shared static this() {}
+
+void caller1()
+{
+    User!1 u;
+}

--- a/test/runnable/imports/test14901d.d
+++ b/test/runnable/imports/test14901d.d
@@ -1,0 +1,8 @@
+module imports.test14901d;
+
+import imports.test14901b;
+
+void caller2()
+{
+    User!2 u;
+}

--- a/test/runnable/link14198b.sh
+++ b/test/runnable/link14198b.sh
@@ -13,13 +13,13 @@ else
 fi
 libname=${dir}${SEP}lib14198b${LIBEXT}
 
-# Do link failure without library file.
+# Do not link failure even without library file.
 
 $DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198b${EXE}                   ${src}${SEP}test14198.d > ${output_file} 2>&1
-grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${output_file} || exit 1
+grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${output_file} && exit 1
 
 $DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198b${EXE} -version=bug14198 ${src}${SEP}test14198.d > ${output_file} 2>&1
-grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${output_file} || exit 1
+grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${output_file} && exit 1
 
 rm ${dir}/{test14198b${OBJ},test14198b${EXE}}
 

--- a/test/runnable/link14541.d
+++ b/test/runnable/link14541.d
@@ -1,0 +1,42 @@
+import imports.link14541traits;
+
+void main()
+{
+    Tuple!(int, int) result;
+
+    alias T = typeof(result);
+    static assert(hasElaborateAssign!T);
+    // hasElaborateAssign!(Tuple(int, int)):
+    // 1. instantiates Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Rvalue]
+    //    2. instantiates swap!(Tuple!(int, int))
+    //       3. instantiates hasElaborateAssign!(Tuple!(int, int))
+    //          --> forward reference error
+    //       --> swap!(Tuple!(int, int)) fails to instantiate
+    //    --> Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = rvalue] fails to instantiate
+    // 4. instantiates Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Lvalue]
+    //    --> succeeds
+    // hasElaborateAssign!(Tuple(int, int)) succeeds to instantiate (result is 'true')
+
+    // Instantiates Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Rvalue], but
+    // it's already done in gagged context, so this is made an error reproduction instantiation.
+    // But, the forward reference of hasElaborateAssign!(Tuple(int, int)) is already resolved, so
+    // the instantiation will succeeds.
+    result = Tuple!(int, int)(0, 0);    // --> 1st error reproduction instantiation
+    result = Tuple!(int, int)(0, 0);    // --> 2nd error reproduction instantiation
+
+    // The two error reproduction instantiations generate the function:
+    //   Tuple!(int, int).opAssign!(Tuple!(int, int)) [auto ref = Rvalue]
+    // twice, then it will cause duplicate COMDAT error in Win64 platform.
+}
+
+/+
+The point is, if instantiated contexts are different, two instantiations may cause different result.
+
+- The 1st Tuple.opAssign instantiation is invoked from hasElaborateAssign template with gagging.
+  So it has failed, because of the circular reference of hasElaborateAssign template..
+
+- The 2nd Tuple.opAssign instantiation is invoked from main() without gagging.
+  It does not have circular reference, so the instantiation should succeed.
+
+Therefore, the gagged failure should be overridden by the ungagged success.
++/

--- a/test/runnable/linkdebug.sh
+++ b/test/runnable/linkdebug.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/linkdebug.sh.out
+
+if [ $OS == "win32" -o  $OS == "win64" ]; then
+	LIBEXT=.lib
+else
+	LIBEXT=.a
+fi
+libname=${dir}${SEP}libX${LIBEXT}
+
+$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}linkdebug_uni.d ${src}${SEP}linkdebug_range.d ${src}${SEP}linkdebug_primitives.d || exit 1
+
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}linkdebug${EXE} -g -debug ${src}${SEP}linkdebug.d ${libname} || exit 1
+
+rm ${libname}
+rm ${dir}/{linkdebug${OBJ},linkdebug${EXE}}
+
+echo Success > ${output_file}

--- a/test/runnable/test14901.d
+++ b/test/runnable/test14901.d
@@ -1,0 +1,20 @@
+// REQUIRED_ARGS:
+// PERMUTE_ARGS: -unittest
+// EXTRA_SOURCES: imports/test14901a.d imports/test14901b.d imports/test14901c.d imports/test14901d.d
+// COMPILE_SEPARATELY
+
+module test14901;
+
+import imports.test14901c;
+import imports.test14901d;
+
+extern(C) __gshared static int initCount;
+
+extern(C) int printf(const char*, ...);
+
+void main()
+{
+    caller1();
+    caller2();
+    assert(initCount == 1);
+}


### PR DESCRIPTION
This is same with #4784, excepting the base branch is 'stable'.

---

https://issues.dlang.org/show_bug.cgi?id=14431

In the pull request #4384, all instance has been changed to invoke
semantic3(). It was for the link-failure issue in specific case, but it
was too excessive.
1. Semantic analysis strategy for template instances:
   We cannot determine which instance does not need to be placed in object
   file until semantic analysis completed. Therefore, for all templates
   instantiated in root module, compiler should invoke their semantic3 --
   regardless of whether those are also instantiated in non-root module. If
   a template is _only_ instantiated in non-root module, we can elide its
   semantic3 (and for the compilation speed we should do that).
2. Code generation storategy for template instances:
   If a template is instantiated in non-root module, compiler usually does
   not have to put it in object file. But if a template is instantiated in
   both of root and non-root modules which mutually import each other, it
   needs to placed in objfile.

---

By fixing excessive semantic3 for template instances, we can also fix few regressions which come from the same root.
- [Issue 14508](https://issues.dlang.org/show_bug.cgi?id=14508) - [REG2.067.0] compiling with -unittest instantiates templates in non-root modules
- [Issue 14564](https://issues.dlang.org/show_bug.cgi?id=14564) - [REG2.067] dmd -property -unittest combination causes compiler error
- [Issue 14901](https://issues.dlang.org/show_bug.cgi?id=14901) - [reg 2.067/2.068] template static shared this() run multiple times with separate compilation
