### PR TITLE
[REG2.067] Issue 14929 - ICE: Assertion failure: 'ez->exp && ez->exp->op == TOKconstruct' on line 302 in file 'escape.c'

### DIFF
--- a/src/declaration.c
+++ b/src/declaration.c
@@ -1392,17 +1392,26 @@ Lnomatch:
                     init = ei;
                 }
 
+                Expression *exp = ei->exp;
                 Expression *e1 = new VarExp(loc, this);
                 if (isBlit)
-                    ei->exp = new BlitExp(loc, e1, ei->exp);
+                    exp = new BlitExp(loc, e1, exp);
                 else
-                    ei->exp = new ConstructExp(loc, e1, ei->exp);
+                    exp = new ConstructExp(loc, e1, exp);
                 canassign++;
-                ei->exp = ei->exp->semantic(sc);
+                exp = exp->semantic(sc);
                 canassign--;
-                ei->exp->optimize(WANTvalue);
+                exp = exp->optimize(WANTvalue);
 
-                if (isScope())
+                if (exp->op == TOKerror)
+                {
+                    init = new ErrorInitializer();
+                    ei = NULL;
+                }
+                else
+                    ei->exp = exp;
+
+                if (ei && isScope())
                 {
                     Expression *ex = ei->exp;
                     while (ex->op == TOKcomma)

--- a/src/expression.c
+++ b/src/expression.c
@@ -6035,6 +6035,7 @@ Expression *DeclarationExp::semantic(Scope *sc)
             declaration->semantic3(sc);
         }
     }
+    // todo: error in declaration should be propagated.
 
     type = Type::tvoid;
     return this;

--- a/src/nogc.c
+++ b/src/nogc.c
@@ -65,13 +65,8 @@ public:
         VarDeclaration *v = e->declaration->isVarDeclaration();
         if (v && !(v->storage_class & STCmanifest) && !v->isDataseg() && v->init)
         {
-            if (v->init->isVoidInitializer())
+            if (ExpInitializer *ei = v->init->isExpInitializer())
             {
-            }
-            else
-            {
-                ExpInitializer *ei = v->init->isExpInitializer();
-                assert(ei);
                 doCond(ei->exp);
             }
         }

--- a/src/opover.c
+++ b/src/opover.c
@@ -680,7 +680,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                 if (s)
                 {
                     functionResolve(&m, s, e->loc, sc, tiargs, e->e1->type, &args2);
-                    if (m.lastf && m.lastf->errors)
+                    if (m.lastf && (m.lastf->errors || m.lastf->semantic3Errors))
                     {
                         result = new ErrorExp();
                         return;
@@ -692,7 +692,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                 if (s_r)
                 {
                     functionResolve(&m, s_r, e->loc, sc, tiargs, e->e2->type, &args1);
-                    if (m.lastf && m.lastf->errors)
+                    if (m.lastf && (m.lastf->errors || m.lastf->semantic3Errors))
                     {
                         result = new ErrorExp();
                         return;
@@ -777,7 +777,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                     if (s_r)
                     {
                         functionResolve(&m, s_r, e->loc, sc, tiargs, e->e1->type, &args2);
-                        if (m.lastf && m.lastf->errors)
+                        if (m.lastf && (m.lastf->errors || m.lastf->semantic3Errors))
                         {
                             result = new ErrorExp();
                             return;
@@ -789,7 +789,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                     if (s)
                     {
                         functionResolve(&m, s, e->loc, sc, tiargs, e->e2->type, &args1);
-                        if (m.lastf && m.lastf->errors)
+                        if (m.lastf && (m.lastf->errors || m.lastf->semantic3Errors))
                         {
                             result = new ErrorExp();
                             return;
@@ -1173,7 +1173,7 @@ Expression *op_overload(Expression *e, Scope *sc)
                 if (s)
                 {
                     functionResolve(&m, s, e->loc, sc, tiargs, e->e1->type, &args2);
-                    if (m.lastf && m.lastf->errors)
+                    if (m.lastf && (m.lastf->errors || m.lastf->semantic3Errors))
                     {
                         result = new ErrorExp();
                         return;
@@ -1303,7 +1303,7 @@ Expression *compare_overload(BinExp *e, Scope *sc, Identifier *id)
         if (s)
         {
             functionResolve(&m, s, e->loc, sc, tiargs, e->e1->type, &args2);
-            if (m.lastf && m.lastf->errors)
+            if (m.lastf && (m.lastf->errors || m.lastf->semantic3Errors))
                 return new ErrorExp();
         }
 
@@ -1313,7 +1313,7 @@ Expression *compare_overload(BinExp *e, Scope *sc, Identifier *id)
         if (s_r)
         {
             functionResolve(&m, s_r, e->loc, sc, tiargs, e->e2->type, &args1);
-            if (m.lastf && m.lastf->errors)
+            if (m.lastf && (m.lastf->errors || m.lastf->semantic3Errors))
                 return new ErrorExp();
         }
 

--- a/test/fail_compilation/ice14929.d
+++ b/test/fail_compilation/ice14929.d
@@ -4,10 +4,10 @@ TEST_OUTPUT:
 fail_compilation/ice14929.d(44): Error: cast(Node)(*this.current).items[this.index] is not an lvalue
 fail_compilation/ice14929.d(87): Error: template instance ice14929.HashMap!(ulong, int).HashMap.opBinaryRight!"in" error instantiating
 fail_compilation/ice14929.d(91):        instantiated from here: HashmapComponentStorage!int
-fail_compilation/ice14929.d(87): Error: rvalue of in expression must be an associative array, not HashMap!(ulong, int)
 fail_compilation/ice14929.d(91): Error: template instance ice14929.isComponentStorage!(HashmapComponentStorage!int, int) error instantiating
 ---
 */
+
 struct HashMap(K, V)
 {
     V* opBinaryRight(string op)(K key) const if (op == "in")

--- a/test/fail_compilation/ice14929.d
+++ b/test/fail_compilation/ice14929.d
@@ -1,0 +1,95 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice14929.d(44): Error: cast(Node)(*this.current).items[this.index] is not an lvalue
+fail_compilation/ice14929.d(87): Error: template instance ice14929.HashMap!(ulong, int).HashMap.opBinaryRight!"in" error instantiating
+fail_compilation/ice14929.d(91):        instantiated from here: HashmapComponentStorage!int
+fail_compilation/ice14929.d(87): Error: rvalue of in expression must be an associative array, not HashMap!(ulong, int)
+fail_compilation/ice14929.d(91): Error: template instance ice14929.isComponentStorage!(HashmapComponentStorage!int, int) error instantiating
+---
+*/
+struct HashMap(K, V)
+{
+    V* opBinaryRight(string op)(K key) const if (op == "in")
+    {
+        size_t index;
+        foreach (ref node; buckets[index].range)
+        {
+            return &(node.value);
+        }
+        return null;
+    }
+
+    struct Node
+    {
+        K key;
+        V value;
+    }
+
+    alias Bucket = UnrolledList!(Node);
+    Bucket[] buckets;
+}
+
+struct UnrolledList(T)
+{
+    Range range() const pure
+    {
+        return Range(_front);
+    }
+
+    static struct Range
+    {
+        ref T front() const @property
+        {
+            return cast(T) current.items[index];
+        }
+        void popFront() pure
+        {
+        }
+        bool empty() const pure @property
+        {
+            return true;
+        }
+        const(Node)* current;
+        size_t index;
+    }
+
+    Node* _front;
+
+    static struct Node
+    {
+        ContainerStorageType!T[10] items;
+    }
+}
+
+template ContainerStorageType(T)
+{
+    alias ContainerStorageType = T;
+}
+
+template isComponentStorage(CS, C)
+{
+    enum bool isComponentStorage = is(typeof(
+    (inout int = 0)
+    {
+        CS cs = CS.init;
+        ulong eid;
+        cs.add(eid, c);
+    }));
+}
+
+struct HashmapComponentStorage(ComponentType)
+{
+    private HashMap!(ulong, ComponentType) components;
+
+    void add(ulong eid, ComponentType component)
+    {
+        assert(eid !in components);
+    }
+}
+
+static assert(isComponentStorage!(HashmapComponentStorage!int, int));
+
+void main()
+{
+}


### PR DESCRIPTION
This is same with #4907, excepting the base branch is 'stable'.

---

https://issues.dlang.org/show_bug.cgi?id=14929

Fix error propagation.
