### PR TITLE
Turn on failures when building DDMD with gdc-4.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: d
 d:
   - dmd-2.067.1
-  - gdc
+  - gdc-4.9.3
   - ldc
 
 script: ./travis.sh
@@ -13,5 +13,4 @@ addons:
 
 matrix:
   allow_failures:
-    - d: gdc
     - d: ldc


### PR DESCRIPTION
Sets gdc compiler version to `4.9.3` and makes it a failure if builds fail.
