### PR TITLE
refactor: remove static allocations of Symbol in backend/rtlsym.c

### DIFF
--- a/src/backend/nteh.c
+++ b/src/backend/nteh.c
@@ -508,8 +508,7 @@ code *nteh_filter(block *b)
  */
 
 void nteh_framehandler(symbol *scopetable)
-{   code *c;
-
+{
     // Generate:
     //  MOV     EAX,&scope_table
     //  JMP     __cpp_framehandler
@@ -517,8 +516,12 @@ void nteh_framehandler(symbol *scopetable)
     if (scopetable)
     {
         symbol_debug(scopetable);
-        c = gencs(NULL,0xB8+AX,0,FLextern,scopetable);  // MOV EAX,&scope_table
-        gencs(c,0xE9,0,FLfunc,rtlsym[RTLSYM_CPP_HANDLER]);      // JMP __cpp_framehandler
+        code *c = gencs(NULL,0xB8+AX,0,FLextern,scopetable);  // MOV EAX,&scope_table
+#if MARS
+        gencs(c,0xE9,0,FLfunc,rtlsym[RTLSYM_D_HANDLER]);      // JMP _d_framehandler
+#else
+        gencs(c,0xE9,0,FLfunc,rtlsym[RTLSYM_CPP_HANDLER]);    // JMP __cpp_framehandler
+#endif
 
         pinholeopt(c,NULL);
         codout(c);

--- a/src/backend/rtlsym.c
+++ b/src/backend/rtlsym.c
@@ -1,5 +1,5 @@
 // Copyright (C) 1996-1998 by Symantec
-// Copyright (C) 2000-2010 by Digital Mars
+// Copyright (C) 2000-2015 by Digital Mars
 // All Rights Reserved
 // http://www.digitalmars.com
 // Written by Walter Bright
@@ -32,7 +32,19 @@ Symbol *rtlsym[RTLSYM_MAX];
 #define FREGSAVED       (mBP | mBX | mSI | mDI)
 #endif
 
-static Symbol rtlsym2[RTLSYM_MAX];
+// Helper function for rtlsym_init()
+
+static Symbol *symbolz(const char *name, type *t, int fl, SYMFLGS flags, regm_t regsaved)
+{
+    Symbol *s = symbol_calloc(name);
+    s->Stype = t;
+    s->Ssymnum = -1;
+    s->Sclass = SCextern;
+    s->Sfl = fl;
+    s->Sregsaved = regsaved;
+    s->Sflags = flags;
+    return s;
+}
 
 /******************************************
  * Initialize rtl symbols.
@@ -46,19 +58,6 @@ void rtlsym_init()
     {   inited++;
 
         //printf("rtlsym_init(%s)\n", regm_str(FREGSAVED));
-
-        for (int i = 0; i < RTLSYM_MAX; i++)
-        {
-            rtlsym[i] = &rtlsym2[i];
-#ifdef DEBUG
-            rtlsym[i]->id = IDsymbol;
-#endif
-            rtlsym[i]->Stype = tsclib;
-            rtlsym[i]->Ssymnum = -1;
-            rtlsym[i]->Sclass = SCextern;
-            rtlsym[i]->Sfl = FLfunc;
-            rtlsym[i]->Sregsaved = FREGSAVED;
-        }
 
 #if MARS
         type *t = type_fake(TYnfunc);
@@ -75,12 +74,8 @@ void rtlsym_init()
         type *tw = NULL;
 
 #undef SYMBOL_Z
-#define SYMBOL_Z(e, fl, saved, n, flags, ty)                                \
-        if (ty) rtlsym[RTLSYM_##e]->Stype = (ty);                           \
-        if ((fl) != FLfunc) rtlsym[RTLSYM_##e]->Sfl = (fl);                 \
-        if (flags) rtlsym[RTLSYM_##e]->Sflags = (flags);                    \
-        if ((saved) != FREGSAVED) rtlsym[RTLSYM_##e]->Sregsaved = (saved);  \
-        strcpy(rtlsym[RTLSYM_##e]->Sident, (n));                            \
+#define SYMBOL_Z(e, fl, regsaved, n, flags, t) \
+        rtlsym[RTLSYM_##e] = symbolz(n, t, fl, flags, regsaved);
 
         RTLSYMS
     }
@@ -94,10 +89,9 @@ void rtlsym_init()
 #if MARS
 
 void rtlsym_reset()
-{   int i;
-
-    clib_inited = 0;
-    for (i = 0; i < RTLSYM_MAX; i++)
+{
+    clib_inited = 0;            // reset CLIB symbols, too
+    for (size_t i = 0; i < RTLSYM_MAX; i++)
     {   rtlsym[i]->Sxtrnnum = 0;
         rtlsym[i]->Stypidx = 0;
     }

--- a/src/backend/rtlsym.h
+++ b/src/backend/rtlsym.h
@@ -1,5 +1,5 @@
 // Copyright (C) 1994-1998 by Symantec
-// Copyright (C) 2000-2009 by Digital Mars
+// Copyright (C) 2000-2015 by Digital Mars
 // All Rights Reserved
 // http://www.digitalmars.com
 // Written by Walter Bright
@@ -42,7 +42,7 @@
 \
 SYMBOL_MARS(THROW,           FLfunc,(mES | mBP),"_d_throw@4", SFLexit, tw) /* D1 only */ \
 SYMBOL_MARS(THROWC,          FLfunc,(mES | mBP),"_d_throwc", SFLexit, t) \
-SYMBOL_MARS(MONITOR_HANDLER, FLfunc,FREGSAVED,"_d_monitor_handler", 0, 0) \
+SYMBOL_MARS(MONITOR_HANDLER, FLfunc,FREGSAVED,"_d_monitor_handler", 0, tsclib) \
 SYMBOL_MARS(MONITOR_PROLOG,  FLfunc,FREGSAVED,"_d_monitor_prolog",0,t) \
 SYMBOL_MARS(MONITOR_EPILOG,  FLfunc,FREGSAVED,"_d_monitor_epilog",0,t) \
 SYMBOL_MARS(DCOVER,          FLfunc,FREGSAVED,"_d_cover_register", 0, t) \
@@ -135,28 +135,28 @@ SYMBOL_MARS(ARRAYCMPBIT,   FLfunc,FREGSAVED,"_adCmpBit", 0, t) \
 SYMBOL_MARS(OBJ_EQ,        FLfunc,FREGSAVED,"_d_obj_eq", 0, t) \
 SYMBOL_MARS(OBJ_CMP,       FLfunc,FREGSAVED,"_d_obj_cmp", 0, t) \
 \
-SYMBOL_Z(EXCEPT_HANDLER2, FLfunc,fregsaved,"_except_handler2", 0, 0) \
-SYMBOL_Z(EXCEPT_HANDLER3, FLfunc,fregsaved,"_except_handler3", 0, 0) \
-SYMBOL_SCPP(CPP_HANDLER,  FLfunc,FREGSAVED,"_cpp_framehandler", 0, 0) \
-SYMBOL_MARS(CPP_HANDLER,  FLfunc,FREGSAVED,"_d_framehandler", 0, 0) \
-SYMBOL_MARS(D_LOCAL_UNWIND2, FLfunc,FREGSAVED,"_d_local_unwind2", 0, 0) \
-SYMBOL_SCPP(LOCAL_UNWIND2, FLfunc,FREGSAVED,"_local_unwind2", 0, 0) \
+SYMBOL_Z(EXCEPT_HANDLER2, FLfunc,fregsaved,"_except_handler2", 0, tsclib) \
+SYMBOL_Z(EXCEPT_HANDLER3, FLfunc,fregsaved,"_except_handler3", 0, tsclib) \
+SYMBOL_SCPP(CPP_HANDLER,  FLfunc,FREGSAVED,"_cpp_framehandler", 0, tsclib) \
+SYMBOL_MARS(D_HANDLER,  FLfunc,FREGSAVED,"_d_framehandler", 0, tsclib) \
+SYMBOL_MARS(D_LOCAL_UNWIND2, FLfunc,FREGSAVED,"_d_local_unwind2", 0, tsclib) \
+SYMBOL_SCPP(LOCAL_UNWIND2, FLfunc,FREGSAVED,"_local_unwind2", 0, tsclib) \
 \
 SYMBOL_Z(TLS_INDEX, FLextern,0,"_tls_index",0,tsint) \
 SYMBOL_Z(TLS_ARRAY, FLextern,0,"_tls_array",0,tspvoid) \
 SYMBOL_SCPP(AHSHIFT,   FLfunc,0,"_AHSHIFT",0,tstrace) \
 \
-SYMBOL_SCPP_TX86(HDIFFN, FLfunc,mBX|mCX|mSI|mDI|mBP|mES,"_aNahdiff", 0, 0) \
-SYMBOL_SCPP_TX86(HDIFFF, FLfunc,mBX|mCX|mSI|mDI|mBP|mES,"_aFahdiff", 0, 0) \
-SYMBOL_SCPP_TX86(INTONLY,FLfunc,mSI|mDI,"_intonly", 0, 0) \
+SYMBOL_SCPP_TX86(HDIFFN, FLfunc,mBX|mCX|mSI|mDI|mBP|mES,"_aNahdiff", 0, tsclib) \
+SYMBOL_SCPP_TX86(HDIFFF, FLfunc,mBX|mCX|mSI|mDI|mBP|mES,"_aFahdiff", 0, tsclib) \
+SYMBOL_SCPP_TX86(INTONLY,FLfunc,mSI|mDI,"_intonly", 0, tsclib) \
 \
 SYMBOL_Z(EXCEPT_LIST, FLextern,0,"_except_list",0,tsint) \
-SYMBOL_Z(SETJMP3, FLfunc,FREGSAVED,"_setjmp3", 0, 0) \
-SYMBOL_Z(LONGJMP, FLfunc,FREGSAVED,"_seh_longjmp_unwind@4", 0, 0) \
-SYMBOL_Z(ALLOCA,  FLfunc,fregsaved,"__alloca", 0, 0) \
-SYMBOL_Z(CPP_LONGJMP, FLfunc,FREGSAVED,"_cpp_longjmp_unwind@4", 0, 0) \
-SYMBOL_Z(PTRCHK, FLfunc,fregsaved,"_ptrchk", 0, 0) \
-SYMBOL_Z(CHKSTK, FLfunc,fregsaved,"_chkstk", 0, 0) \
+SYMBOL_Z(SETJMP3, FLfunc,FREGSAVED,"_setjmp3", 0, tsclib) \
+SYMBOL_Z(LONGJMP, FLfunc,FREGSAVED,"_seh_longjmp_unwind@4", 0, tsclib) \
+SYMBOL_Z(ALLOCA,  FLfunc,fregsaved,"__alloca", 0, tsclib) \
+SYMBOL_Z(CPP_LONGJMP, FLfunc,FREGSAVED,"_cpp_longjmp_unwind@4", 0, tsclib) \
+SYMBOL_Z(PTRCHK, FLfunc,fregsaved,"_ptrchk", 0, tsclib) \
+SYMBOL_Z(CHKSTK, FLfunc,fregsaved,"_chkstk", 0, tsclib) \
 SYMBOL_Z(TRACE_PRO_N, FLfunc,ALLREGS|mBP|mES,"_trace_pro_n",0,tstrace) \
 SYMBOL_Z(TRACE_PRO_F, FLfunc,ALLREGS|mBP|mES,"_trace_pro_f",0,tstrace) \
 SYMBOL_Z(TRACE_EPI_N, FLfunc,ALLREGS|mBP|mES,"_trace_epi_n",0,tstrace) \
@@ -191,4 +191,5 @@ SYMBOL_MARS(TRACEARRAYSETLENGTHIT,FLfunc,FREGSAVED,"_d_arraysetlengthiTTrace", 0
 SYMBOL_MARS(TRACEALLOCMEMORY,     FLfunc,FREGSAVED,"_d_allocmemoryTrace", 0, t) \
 
 
-
+// Migrate to function interface to rtl symbols
+#define getRtlsym(i) rtlsym[i]


### PR DESCRIPTION
Makes it simpler, too.
