### PR TITLE
remove ability to create static Symbol

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1285,8 +1285,7 @@ struct Symbol
     }_SXR;
     regm_t      Sregsaved;      // mask of registers not affected by this func
 
-    char Sident[SYM_PREDEF_SZ]; // identifier string (dynamic array)
-                                // (the size is for static Symbols)
+    char Sident[1];             // identifier string (dynamic array)
 
     int needThis();             // !=0 if symbol needs a 'this' pointer
     bool Sisdead(bool anyiasm); // if variable is not referenced

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -977,11 +977,6 @@ union eve
 #endif
 
 typedef unsigned SYMFLGS;
-#if MARS
-#define SYM_PREDEF_SZ 40
-#else
-#define SYM_PREDEF_SZ 22
-#endif
 
 
 /**********************************


### PR DESCRIPTION
Now that removed all the static Symbol instances.

Eventually, Symbol should become an OOP class.
