### PR TITLE
Remove token use of TX86 from the glue layer

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -358,7 +358,6 @@ if (I32) assert(tysize[TYnptr] == 4);
                  */
                 e->E1 = el_una(OPind, e->E2->Ety | mTYvolatile, e->E1);
             }
-#if TX86
             if (op == OPscale)
             {
                 elem *et = e->E1;
@@ -372,7 +371,6 @@ if (I32) assert(tysize[TYnptr] == 4);
                 e->E1 = e->E2;
                 e->E2 = et;
             }
-#endif
         }
         else if (op == OPvector)
         {

--- a/src/glue.c
+++ b/src/glue.c
@@ -248,9 +248,7 @@ void obj_start(char *srcfile)
 #endif
 
     el_reset();
-#if TX86
     cg87_reset();
-#endif
     out_reset();
 }
 

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -49,8 +49,6 @@
 #include        "iasm.h"
 #include        "xmm.h"
 
-#if TX86
-
 //#define EXTRA_DEBUG 1
 
 #undef ADDFWAIT
@@ -4686,13 +4684,3 @@ AFTER_EMIT:
     //return asmstate.bReturnax;
     return s;
 }
-
-#else
-
-Statement* asmSemantic(AsmStatement *s, Scope *sc)
-{
-    assert(0);
-    return NULL;
-}
-
-#endif

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -1230,7 +1230,6 @@ public:
                     break;
             }
 
-#if TX86
             // Repeat for second operand
             switch (c->IFL2)
             {
@@ -1254,7 +1253,6 @@ public:
                         sym->Sflags |= SFLlivexit;
                     break;
             }
-#endif
             //c->print();
         }
 

--- a/src/toir.c
+++ b/src/toir.c
@@ -308,7 +308,6 @@ elem *setEthis(Loc loc, IRState *irs, elem *ey, AggregateDeclaration *ad)
  */
 int intrinsic_op(FuncDeclaration *fd)
 {
-#if TX86
     fd = fd->toAliasFunc();
     const char *name = mangleExact(fd);
     //printf("intrinsic_op(%s)\n", name);
@@ -584,7 +583,6 @@ int intrinsic_op(FuncDeclaration *fd)
 
         return -1;
     }
-#endif
 
     return -1;
 }


### PR DESCRIPTION
The `#if`s are misleading - the glue layer is in no way capable of targeting any other architecture.  The added use of preprocessor produces more of a burden than than it helps any hypothetical future re-targeting.
