### PR TITLE
replace -gc in tests with -g

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -104,7 +104,7 @@ PHOBOS_PATH=..\..\phobos
 export DFLAGS=-I$(DRUNTIME_PATH)\import -I$(PHOBOS_PATH)
 export LIB=$(PHOBOS_PATH)
 else
-export ARGS=-inline -release -gc -O -unittest -fPIC
+export ARGS=-inline -release -g -O -unittest -fPIC
 export DMD=../src/dmd
 export EXE=
 export OBJ=.o

--- a/test/runnable/test11447c.d
+++ b/test/runnable/test11447c.d
@@ -1,6 +1,6 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/c11447.d
-// PERMUTE_ARGS: -allinst -w -debug -gc
+// PERMUTE_ARGS: -allinst -w -debug -g
 
 import imports.c11447;
 

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -release -gc
+// PERMUTE_ARGS: -release -g
 
 version(Windows) {}
 else version(X86_64)
@@ -924,4 +924,3 @@ string d_generate_functions( )
 //pragma( msg, d_generate_functions() );
 mixin( d_generate_functions() );
 // +/
-


### PR DESCRIPTION
- as we no longer emit D specific DWARF
  extensions -g just works fine
- DW_lang_D is supported since gdb 6.5
