### PR TITLE
Win64: overloads in vtable needs to be reversed, too

### DIFF
--- a/src/target.d
+++ b/src/target.d
@@ -23,7 +23,7 @@ struct Target
     extern (C++) static __gshared int realsize; // size a real consumes in memory
     extern (C++) static __gshared int realpad; // 'padding' added to the CPU real size to bring it up to realsize
     extern (C++) static __gshared int realalignsize; // alignment for reals
-    extern (C++) static __gshared bool reverseCppOverloads; // with dmc, overloaded functions are grouped and in reverse order
+    extern (C++) static __gshared bool reverseCppOverloads; // with dmc and cl, overloaded functions are grouped and in reverse order
     extern (C++) static __gshared int c_longsize; // size of a C 'long' or 'unsigned long' type
     extern (C++) static __gshared int c_long_doublesize; // size of a C 'long double'
     extern (C++) static __gshared int classinfosize; // size of 'ClassInfo'
@@ -58,7 +58,7 @@ struct Target
             realsize = 10;
             realpad = 0;
             realalignsize = 2;
-            reverseCppOverloads = !global.params.is64bit;
+            reverseCppOverloads = true;
             c_longsize = 4;
         }
         else

--- a/src/target.h
+++ b/src/target.h
@@ -28,7 +28,7 @@ struct Target
     static int realsize;             // size a real consumes in memory
     static int realpad;              // 'padding' added to the CPU real size to bring it up to realsize
     static int realalignsize;        // alignment for reals
-    static bool reverseCppOverloads; // with dmc, overloaded functions are grouped and in reverse order
+    static bool reverseCppOverloads; // with dmc and cl, overloaded functions are grouped and in reverse order
     static int c_longsize;           // size of a C 'long' or 'unsigned long' type
     static int c_long_doublesize;    // size of a C 'long double'
     static int classinfosize;        // size of 'ClassInfo'

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -751,6 +751,59 @@ void test14200()
 }
 
 /****************************************/
+// check order of overloads in vtable
+
+extern (C++) class Statement {}
+extern (C++) class ErrorStatement {}
+extern (C++) class PeelStatement {}
+extern (C++) class ExpStatement {}
+extern (C++) class DtorExpStatement {}
+
+extern (C++) class Visitor
+{
+public:
+    int visit(Statement) { return 1; }
+    int visit(ErrorStatement) { return 2; }
+    int visit(PeelStatement) { return 3; }
+}
+
+extern (C++) class Visitor2 : Visitor
+{
+    int visit2(ExpStatement) { return 4; }
+    int visit2(DtorExpStatement) { return 5; }
+}
+
+extern(C++) bool testVtableCpp(Visitor2 sv);
+extern(C++) Visitor2 getVisitor2();
+
+bool testVtableD(Visitor2 sv)
+{
+    Statement s1;
+    ErrorStatement s2;
+    PeelStatement s3;
+    ExpStatement s4;
+    DtorExpStatement s5;
+
+    if (sv.visit(s1) != 1) return false;
+    if (sv.visit(s2) != 2) return false;
+    if (sv.visit(s3) != 3) return false;
+    if (sv.visit2(s4) != 4) return false;
+    if (sv.visit2(s5) != 5) return false;
+    return true;
+}
+
+void testVtable()
+{
+    Visitor2 dinst = new Visitor2;
+    if (!testVtableCpp(dinst))
+        assert(0);
+
+    Visitor2 cppinst = getVisitor2();
+    if (!testVtableD(cppinst))
+        assert(0);
+}
+
+/****************************************/
 
 void main()
 {
@@ -781,6 +834,7 @@ void main()
     foo13337(S13337());
     test14195();
     test14200();
+    testVtable();
 
     printf("Success\n");
 }

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -229,13 +229,7 @@ void test11802()
     auto x = new D11802();
     x.x = 0;
     test11802x(x);
-    version(Win64)
-    {
-    }
-    else
-    {
-        assert(x.x == 9);
-    }
+    assert(x.x == 9);
 }
 
 

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -480,3 +480,42 @@ void test14200a(int a) {};
 void test14200b(float a, int b, double c) {};
 
 /******************************************/
+// check order of overloads in vtable
+
+class Statement;
+class ErrorStatement;
+class PeelStatement;
+class ExpStatement;
+class DtorExpStatement;
+
+class Visitor
+{
+public:
+    virtual int visit(Statement*) { return 1; }
+    virtual int visit(ErrorStatement*) { return 2; }
+    virtual int visit(PeelStatement*) { return 3; }
+};
+
+class Visitor2 : public Visitor
+{
+public:
+    virtual int visit2(ExpStatement*) { return 4; }
+    virtual int visit2(DtorExpStatement*) { return 5; }
+};
+
+bool testVtableCpp(Visitor2* sv)
+{
+    if (sv->visit((Statement*)0) != 1) return false;
+    if (sv->visit((ErrorStatement*)0) != 2) return false;
+    if (sv->visit((PeelStatement*)0) != 3) return false;
+    if (sv->visit2((ExpStatement*)0) != 4) return false;
+    if (sv->visit2((DtorExpStatement*)0) != 5) return false;
+    return true;
+}
+
+Visitor2 inst;
+
+Visitor2* getVisitor2()
+{
+    return &inst;
+}


### PR DESCRIPTION
cl behaves like dmc, or is it the other way around?

Should this go to the stable branch instead? Will need a bugzilla report, then.
