### PR TITLE
win32coff: fix returning __c_long_double from C/C++

### DIFF
--- a/src/toir.c
+++ b/src/toir.c
@@ -875,6 +875,16 @@ RET retStyle(TypeFunction *tf)
             return RETregs;
         return RETstack;
     }
+    else if (global.params.isWindows && global.params.mscoff)
+    {
+        Type* tb = tns->baseElemOf();
+        if (tb->ty == Tstruct)
+        {
+            StructDeclaration *sd = ((TypeStruct *)tb)->sym;
+            if (sd->ident == Id::__c_long_double)
+                return RETregs;
+        }
+    }
 
 Lagain:
     if (tns->ty == Tsarray)


### PR DESCRIPTION
__c_long_double needs to be returned through FPU register

test is already in runnable/cppa.d.
