### PR TITLE
Don't use `foreach` if the loop body modifies the iteration variable

### DIFF
--- a/src/statement.d
+++ b/src/statement.d
@@ -4918,7 +4918,7 @@ public:
          */
         if (!(_body.blockExit(sc.func, false) & BEthrow) && ClassDeclaration.exception)
         {
-            foreach (i; 0 .. catches.dim)
+            foreach_reverse (i; 0 .. catches.dim)
             {
                 Catch c = (*catches)[i];
                 /* If catch exception type is derived from Exception
@@ -4927,7 +4927,6 @@ public:
                 {
                     // Remove c from the array of catches
                     catches.remove(i);
-                    --i;
                 }
             }
         }

--- a/test/compilable/exception.d
+++ b/test/compilable/exception.d
@@ -1,0 +1,18 @@
+class E2 : Exception { this() { super(null); } }
+class E3 : Exception { this() { super(null); } }
+
+void main()
+{
+    try
+    {
+    }
+    catch (E3)
+    {
+    }
+    catch (E2)
+    {
+    }
+    catch (Exception)
+    {
+    }
+}


### PR DESCRIPTION
This fixes a segfault in compiling vibe.d.
