### PR TITLE
[REG2.068.1-b1] Issue 14985 - Link failure for const TypeInfo of speculative instantiated struct

### DIFF
--- a/src/typinf.c
+++ b/src/typinf.c
@@ -167,28 +167,22 @@ bool isSpeculativeType(Type *t)
             {
                 if (!ti->needsCodegen())
                 {
+                    if (ti->minst || sd->requestTypeInfo)
+                        return;
+
                     /* Bugzilla 14425: TypeInfo_Struct would refer the members of
                      * struct (e.g. opEquals via xopEquals field), so if it's instantiated
                      * in speculative context, TypeInfo creation should also be
                      * stopped to avoid 'unresolved symbol' linker errors.
                      */
-                    if (!ti->minst)
-                    {
-                        result |= true;
-                        return;
-                    }
-
                     /* When -debug/-unittest is specified, all of non-root instances are
                      * automatically changed to speculative, and here is always reached
                      * from those instantiated non-root structs.
                      * Therefore, if the TypeInfo is not auctually requested,
                      * we have to elide its codegen.
                      */
-                    if (!sd->requestTypeInfo)
-                    {
-                        result |= true;
-                        return;
-                    }
+                    result |= true;
+                    return;
                 }
             }
             else
@@ -506,8 +500,7 @@ public:
         {
             if (!ti->needsCodegen())
             {
-                assert(ti->minst);
-                assert(sd->requestTypeInfo);
+                assert(ti->minst || sd->requestTypeInfo);
 
                 /* ti->toObjFile() won't get called. So, store these
                  * member functions into object file in here.

--- a/test/runnable/imports/linktypeinfo_file.d
+++ b/test/runnable/imports/linktypeinfo_file.d
@@ -1,0 +1,33 @@
+module imports.linktypeinfo_file;
+
+auto filter(alias pred, R)(R r)
+{
+    return FilterResult!(pred, R)(r);
+}
+
+struct FilterResult(alias pred, R)
+{
+    R r;
+    bool empty() { return r.empty; }
+    auto front() { return r.front; }
+    void popFront()
+    {
+        while (!r.empty && pred(r.front))
+            r.popFront();
+    }
+}
+
+struct DirIterator
+{
+    int[] r;
+    @property bool empty() { return r.length == 0; }
+    @property auto front() { return r[0]; }
+    void popFront() { r = r[1..$]; }
+
+}
+
+auto dirEntries(string path)
+{
+    bool f(int de) { return 1; }
+    return filter!f(DirIterator());
+}

--- a/test/runnable/linktypeinfo.d
+++ b/test/runnable/linktypeinfo.d
@@ -1,0 +1,34 @@
+// EXTRA_SOURCES: imports/linktypeinfo_file.d
+// PERMUTE_ARGS: -g -inline -unittest -debug
+// COMPILE_SEPARATELY
+
+import imports.linktypeinfo_file;
+
+struct Only(T)
+{
+    private T _val;
+}
+
+auto only(V)(V v)
+{
+    return Only!V(v);
+}
+
+static struct Chain(R...)
+{
+    R source;
+}
+
+auto chain(R...)(R rs)
+{
+    return Chain!R(rs);
+}
+
+void main()
+{
+    string docRoot;
+
+    const r = dirEntries(docRoot);
+    typeof(r)[] a;
+    a.length = 0;   // require TypeInfo for const(FilterResult!(DirIterator))
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14985

Fixup for #4944.
