### PR TITLE
fix failing assert due to removed "jplace"

### DIFF
--- a/src/backend/debug.c
+++ b/src/backend/debug.c
@@ -109,8 +109,7 @@ void WRBC(unsigned bc)
          "exit  ","asm   ","switch","ifthen","jmptab",
          "try   ","catch ","jump  ",
          "_try  ","_filte","_final","_ret  ","_excep",
-         "jcatch",
-         "jplace",
+         "jcatch"
         };
 
     assert(sizeof(bcs) / sizeof(bcs[0]) == BCMAX);


### PR DESCRIPTION
Missed during removal of "Jupiter" codegen.
