### PR TITLE
use strtold_dm when building against VC runtime

### DIFF
--- a/src/root/port.d
+++ b/src/root/port.d
@@ -13,11 +13,15 @@ import core.stdc.string;
 import core.math;
 
 version(CRuntime_DigitalMars) __gshared extern (C) extern const(char)* __locale_decpoint;
-version(CRuntime_Microsoft)   extern(C++) struct longdouble {}
+version(CRuntime_Microsoft)   extern(C++) struct longdouble { real r; }
 
 extern (C) float strtof(const(char)* p, char** endp);
 extern (C) double strtod(const(char)* p, char** endp);
-extern (C) real strtold(const(char)* p, char** endp);
+
+version(CRuntime_Microsoft)
+    extern (C++) longdouble strtold_dm(const(char)* p, char** endp);
+else
+    extern (C) real strtold(const(char)* p, char** endp);
 
 extern (C++) struct Port
 {
@@ -159,7 +163,11 @@ extern (C++) struct Port
             auto save = __locale_decpoint;
             __locale_decpoint = ".";
         }
-        auto r = .strtold(p, endp);
+
+        version (CRuntime_Microsoft)
+            auto r = .strtold_dm(p, endp).r;
+        else
+            auto r = .strtold(p, endp);
         version (CRuntime_DigitalMars) __locale_decpoint = save;
         return r;
     }


### PR DESCRIPTION
Replacement necessary due to missing real support in VC.

BTW: Im trying to build ddmd against the MS runtime using a VC project for the backend and a Visual D project for the frontend. I guess that's the only way to get sensible debugging experience on Windows.
I can compile dmd this way now, but the resulting executable does not yet produce code good enough to pass the test suite.
