### PR TITLE
remove unnecessary port stuff

### DIFF
--- a/src/constfold.d
+++ b/src/constfold.d
@@ -441,12 +441,12 @@ extern (C++) UnionExp Mod(Type type, Expression e1, Expression e2)
         if (e2.type.isreal())
         {
             real_t r2 = e2.toReal();
-            c = complex_t(Port.fmodl(e1.toReal(), r2), Port.fmodl(e1.toImaginary(), r2));
+            c = complex_t(e1.toReal() % r2, e1.toImaginary() % r2);
         }
         else if (e2.type.isimaginary())
         {
             real_t i2 = e2.toImaginary();
-            c = complex_t(Port.fmodl(e1.toReal(), i2), Port.fmodl(e1.toImaginary(), i2));
+            c = complex_t(e1.toReal() % i2, e1.toImaginary() % i2);
         }
         else
             assert(0);
@@ -564,7 +564,7 @@ extern (C++) UnionExp Pow(Type type, Expression e1, Expression e2)
         // x ^^ y for x < 0 and y not an integer is not defined; so set result as NaN
         if (e1.toReal() < 0.0)
         {
-            emplaceExp!(RealExp)(&ue, loc, Port.ldbl_nan, type);
+            emplaceExp!(RealExp)(&ue, loc, real.nan, type);
         }
         else
             emplaceExp!(CTFEExp)(&ue, TOKcantexp);

--- a/src/expression.d
+++ b/src/expression.d
@@ -1916,7 +1916,7 @@ private:
  */
 extern (C++) int RealEquals(real_t x1, real_t x2)
 {
-    return (Port.isNan(x1) && Port.isNan(x2)) || Port.fequal(x1, x2);
+    return (Port.isNan(x1) && Port.isNan(x2)) || x1 == x2;
 }
 
 /************************ TypeDotIdExp ************************************/

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -3591,7 +3591,7 @@ public:
             case Tfloat64:
             case Tfloat80:
                 {
-                    fvalue = Port.ldbl_nan;
+                    fvalue = real.nan;
                     goto Lfvalue;
                 }
             default:
@@ -3611,7 +3611,7 @@ public:
             case Tfloat32:
             case Tfloat64:
             case Tfloat80:
-                fvalue = Port.ldbl_infinity;
+                fvalue = real.infinity;
                 goto Lfvalue;
             default:
                 break;

--- a/src/root/port.d
+++ b/src/root/port.d
@@ -21,11 +21,7 @@ extern (C) real strtold(const(char)* p, char** endp);
 
 extern (C++) struct Port
 {
-    enum nan = double.nan;
-    enum infinity = double.infinity;
     enum ldbl_max = real.max;
-    enum ldbl_nan = real.nan;
-    enum ldbl_infinity = real.infinity;
     version(DigitalMars)
     {
         static __gshared bool yl2x_supported = true;


### PR DESCRIPTION
(The D uses of `fequal` and `fmodl` were removed, but those functions were left because it was not clear if GDC uses them, etc.)
