### PR TITLE
Detect disabled tests in the test runner instead of the makefile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -122,26 +122,6 @@ export D_OBJC=1
 endif
 endif
 
-ifeq ($(OS),freebsd)
-DISABLED_TESTS += dhry
-# runnable/dhry.d(488): Error: undefined identifier dtime
-endif
-
-ifeq ($(OS),win32)
-DISABLED_FAIL_TESTS += fail13939
-endif
-
-ifeq ($(OS),win64)
-DISABLED_TESTS += testxmm
-DISABLED_FAIL_TESTS += fail13939
-endif
-
-ifeq ($(OS),osx)
-ifeq ($(MODEL),64)
-DISABLED_TESTS += test6423
-endif
-endif
-
 runnable_tests=$(wildcard runnable/*.d) $(wildcard runnable/*.sh)
 runnable_test_results=$(addsuffix .out,$(addprefix $(RESULTS_DIR)/,$(runnable_tests)))
 
@@ -152,12 +132,6 @@ fail_compilation_tests=$(wildcard fail_compilation/*.d) $(wildcard fail_compilat
 fail_compilation_test_results=$(addsuffix .out,$(addprefix $(RESULTS_DIR)/,$(fail_compilation_tests)))
 
 all: run_tests
-
-$(addsuffix .d.out,$(addprefix $(RESULTS_DIR)/runnable/,$(DISABLED_TESTS))): $(RESULTS_DIR)/.created
-	$(QUIET) echo " ... $@ - disabled"
-
-$(addsuffix .sh.out,$(addprefix $(RESULTS_DIR)/runnable/,$(DISABLED_SH_TESTS))): $(RESULTS_DIR)/.created
-	$(QUIET) echo " ... $@ - disabled"
 
 $(RESULTS_DIR)/runnable/%.d.out: runnable/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test$(EXE) $(DMD)
 	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d
@@ -172,9 +146,6 @@ $(RESULTS_DIR)/compilable/%.d.out: compilable/%.d $(RESULTS_DIR)/.created $(RESU
 $(RESULTS_DIR)/compilable/%.sh.out: compilable/%.sh $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test$(EXE) $(DMD)
 	$(QUIET) echo " ... $(<D)/$*.sh"
 	$(QUIET) ./$(<D)/$*.sh
-
-$(addsuffix .d.out,$(addprefix $(RESULTS_DIR)/fail_compilation/,$(DISABLED_FAIL_TESTS))): $(RESULTS_DIR)/.created
-	$(QUIET) echo " ... $@ - disabled"
 
 $(RESULTS_DIR)/fail_compilation/%.d.out: fail_compilation/%.d $(RESULTS_DIR)/.created $(RESULTS_DIR)/d_do_test$(EXE) $(DMD)
 	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -61,8 +61,8 @@ struct TestArgs
     string   requiredArgs;
     string   requiredArgsForLink;
     // reason for disabling the test (if empty, the test is not disabled)
-    string   disabled_reason;
-    @property bool disabled() { return disabled_reason != ""; }
+    string[] disabledPlatforms;
+    bool     disabled;
 }
 
 struct EnvData
@@ -227,7 +227,9 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     // COMPILE_SEPARATELY can take optional compiler switches when link .o files
     testArgs.compileSeparately = findTestParameter(file, "COMPILE_SEPARATELY", testArgs.requiredArgsForLink);
 
-    findTestParameter(file, "DISABLED", testArgs.disabled_reason);
+    string disabledPlatformsStr;
+    findTestParameter(file, "DISABLED", disabledPlatformsStr);
+    testArgs.disabledPlatforms = split(disabledPlatformsStr);
 
     findOutputParameter(file, "TEST_OUTPUT", testArgs.compileOutput, envData.sep);
 
@@ -508,8 +510,11 @@ int main(string[] args)
             (!testArgs.requiredArgs.empty ? " " : ""),
             testArgs.permuteArgs);
 
-    if (testArgs.disabled)
-        writefln("!!! [DISABLED: %s]", testArgs.disabled_reason);
+    if (testArgs.disabledPlatforms.canFind(envData.os, envData.os ~ envData.model))
+    {
+        testArgs.disabled = true;
+        writefln("!!! [DISABLED on %s]", envData.os);
+    }
     else
         write("\n");
 

--- a/test/fail_compilation/fail13939.d
+++ b/test/fail_compilation/fail13939.d
@@ -1,8 +1,9 @@
 // REQUIRED_ARGS: -o- -fPIC
+// DISABLED: win32 win64
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13939.d(14): Error: cannot directly load global variable 'val' with PIC code
+fail_compilation/fail13939.d(15): Error: cannot directly load global variable 'val' with PIC code
 ---
 */
 version(Windows) static assert(0);

--- a/test/runnable/dhry.d
+++ b/test/runnable/dhry.d
@@ -1,5 +1,6 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -release -O -g -inline
+// DISABLED: freebsd
 
 /*
  *************************************************************************

--- a/test/runnable/test6423.d
+++ b/test/runnable/test6423.d
@@ -1,3 +1,4 @@
+// DISABLED: osx64
 
 bool flag;
 

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS:
+// DISABLED: win64
 
 version (D_SIMD)
 {


### PR DESCRIPTION
Another step closer to a make-free world
