### PR TITLE
Issue 14696, 14708, and [REG2.068] 14979 - Fix destructor issues for temporary in conditional operator

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -5079,8 +5079,13 @@ code *cddctor(elem *e,regm_t *pretregs)
      */
     usednteh |= EHcleanup;
     if (config.exe == EX_NT)
-    {   usednteh |= NTEHcleanup | NTEH_try;
+    {
+        usednteh |= NTEHcleanup | NTEH_try;
         nteh_usevars();
+    }
+    else
+    {
+        usednteh |= EHtry;
     }
     assert(*pretregs == 0);
     code cs;
@@ -5117,8 +5122,13 @@ code *cdddtor(elem *e,regm_t *pretregs)
     */
     usednteh |= EHcleanup;
     if (config.exe == EX_NT)
-    {   usednteh |= NTEHcleanup | NTEH_try;
+    {
+        usednteh |= NTEHcleanup | NTEH_try;
         nteh_usevars();
+    }
+    else
+    {
+        usednteh |= EHtry;
     }
 
     code cs;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3304,12 +3304,12 @@ elem *toElem(Expression *e, IRState *irs)
         {
             elem *ec = toElem(ce->econd, irs);
 
-            elem *eleft = toElemDtor(ce->e1, irs);
+            elem *eleft = toElem(ce->e1, irs);
             tym_t ty = eleft->Ety;
             if (global.params.cov && ce->e1->loc.linnum)
                 eleft = el_combine(incUsageElem(irs, ce->e1->loc), eleft);
 
-            elem *eright = toElemDtor(ce->e2, irs);
+            elem *eright = toElem(ce->e2, irs);
             if (global.params.cov && ce->e2->loc.linnum)
                 eright = el_combine(incUsageElem(irs, ce->e2->loc), eright);
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -1475,6 +1475,7 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     Expression *toBoolean(Scope *sc);
+    void hookDtors(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -3943,6 +3943,115 @@ void test14264()
 }
 
 /**********************************/
+// 14696
+
+void test14696(int len = 2)
+{
+    string result;
+
+    struct S
+    {
+        int n;
+
+        void* get(void* p = null)
+        {
+            result ~= "get(" ~ cast(char)(n+'0') ~ ").";
+            return null;
+        }
+
+        ~this()
+        {
+            result ~= "dtor(" ~ cast(char)(n+'0') ~ ").";
+        }
+    }
+
+    S makeS(int n)
+    {
+        result ~= "makeS(" ~ cast(char)(n+'0') ~ ").";
+        return S(n);
+    }
+    void foo(void* x, void* y = null)
+    {
+        result ~= "foo.";
+    }
+    void fooThrow(void* x, void* y = null)
+    {
+        result ~= "fooThrow.";
+        throw new Exception("fail!");
+    }
+
+    void check(void delegate() dg, string r, string file = __FILE__, size_t line = __LINE__)
+    {
+        import core.exception;
+
+        result = null;
+        try { dg(); } catch (Exception e) {}
+        if (result != r)
+            throw new AssertError(result, file, line);
+    }
+
+    // temporary in condition
+    check({ foo(len == 2 ?        makeS(1).get() : null); }, "makeS(1).get(1).foo.dtor(1).");
+    check({ foo(len == 2 ? null : makeS(1).get()       ); }, "foo.");
+    check({ foo(len != 2 ?        makeS(1).get() : null); }, "foo.");
+    check({ foo(len != 2 ? null : makeS(1).get()       ); }, "makeS(1).get(1).foo.dtor(1).");
+
+    // temporary in nesting conditions
+    check({ foo(len >= 2 ?        (len == 2 ?        makeS(1).get() : null) : null); }, "makeS(1).get(1).foo.dtor(1).");
+    check({ foo(len >= 2 ?        (len == 2 ? null : makeS(1).get()       ) : null); }, "foo.");
+    check({ foo(len >= 2 ?        (len != 2 ?        makeS(1).get() : null) : null); }, "foo.");
+    check({ foo(len >= 2 ?        (len != 2 ? null : makeS(1).get()       ) : null); }, "makeS(1).get(1).foo.dtor(1).");
+    check({ foo(len >= 2 ? null : (len == 2 ?        makeS(1).get() : null)       ); }, "foo.");
+    check({ foo(len >= 2 ? null : (len == 2 ? null : makeS(1).get()       )       ); }, "foo.");
+    check({ foo(len >= 2 ? null : (len != 2 ?        makeS(1).get() : null)       ); }, "foo.");
+    check({ foo(len >= 2 ? null : (len != 2 ? null : makeS(1).get()       )       ); }, "foo.");
+    check({ foo(len >  2 ?        (len == 2 ?        makeS(1).get() : null) : null); }, "foo.");
+    check({ foo(len >  2 ?        (len == 2 ? null : makeS(1).get()       ) : null); }, "foo.");
+    check({ foo(len >  2 ?        (len != 2 ?        makeS(1).get() : null) : null); }, "foo.");
+    check({ foo(len >  2 ?        (len != 2 ? null : makeS(1).get()       ) : null); }, "foo.");
+    check({ foo(len >  2 ? null : (len == 2 ?        makeS(1).get() : null)       ); }, "makeS(1).get(1).foo.dtor(1).");
+    check({ foo(len >  2 ? null : (len == 2 ? null : makeS(1).get()       )       ); }, "foo.");
+    check({ foo(len >  2 ? null : (len != 2 ?        makeS(1).get() : null)       ); }, "foo.");
+    check({ foo(len >  2 ? null : (len != 2 ? null : makeS(1).get()       )       ); }, "makeS(1).get(1).foo.dtor(1).");
+
+    // temporary in condition and throwing callee
+    check({ fooThrow(len == 2 ?        makeS(1).get() : null); }, "makeS(1).get(1).fooThrow.dtor(1).");
+    check({ fooThrow(len == 2 ? null : makeS(1).get()       ); }, "fooThrow.");
+    check({ fooThrow(len != 2 ?        makeS(1).get() : null); }, "fooThrow.");
+    check({ fooThrow(len != 2 ? null : makeS(1).get()       ); }, "makeS(1).get(1).fooThrow.dtor(1).");
+
+    // temporary in nesting condititions and throwing callee
+    check({ fooThrow(len >= 2 ?        (len == 2 ?        makeS(1).get() : null) : null); }, "makeS(1).get(1).fooThrow.dtor(1).");
+    check({ fooThrow(len >= 2 ?        (len == 2 ? null : makeS(1).get()       ) : null); }, "fooThrow.");
+    check({ fooThrow(len >= 2 ?        (len != 2 ?        makeS(1).get() : null) : null); }, "fooThrow.");
+    check({ fooThrow(len >= 2 ?        (len != 2 ? null : makeS(1).get()       ) : null); }, "makeS(1).get(1).fooThrow.dtor(1).");
+    check({ fooThrow(len >= 2 ? null : (len == 2 ?        makeS(1).get() : null)       ); }, "fooThrow.");
+    check({ fooThrow(len >= 2 ? null : (len == 2 ? null : makeS(1).get()       )       ); }, "fooThrow.");
+    check({ fooThrow(len >= 2 ? null : (len != 2 ?        makeS(1).get() : null)       ); }, "fooThrow.");
+    check({ fooThrow(len >= 2 ? null : (len != 2 ? null : makeS(1).get()       )       ); }, "fooThrow.");
+    check({ fooThrow(len >  2 ?        (len == 2 ?        makeS(1).get() : null) : null); }, "fooThrow.");
+    check({ fooThrow(len >  2 ?        (len == 2 ? null : makeS(1).get()       ) : null); }, "fooThrow.");
+    check({ fooThrow(len >  2 ?        (len != 2 ?        makeS(1).get() : null) : null); }, "fooThrow.");
+    check({ fooThrow(len >  2 ?        (len != 2 ? null : makeS(1).get()       ) : null); }, "fooThrow.");
+    check({ fooThrow(len >  2 ? null : (len == 2 ?        makeS(1).get() : null)       ); }, "makeS(1).get(1).fooThrow.dtor(1).");
+    check({ fooThrow(len >  2 ? null : (len == 2 ? null : makeS(1).get()       )       ); }, "fooThrow.");
+    check({ fooThrow(len >  2 ? null : (len != 2 ?        makeS(1).get() : null)       ); }, "fooThrow.");
+    check({ fooThrow(len >  2 ? null : (len != 2 ? null : makeS(1).get()       )       ); }, "makeS(1).get(1).fooThrow.dtor(1).");
+
+    // temporaries in each conditions
+    check({ foo(len == 2 ? makeS(1).get() : null, len == 2 ? makeS(2).get() : null); }, "makeS(1).get(1).makeS(2).get(2).foo.dtor(2).dtor(1).");
+    check({ foo(len == 2 ? makeS(1).get() : null, len != 2 ? makeS(2).get() : null); }, "makeS(1).get(1).foo.dtor(1).");
+    check({ foo(len != 2 ? makeS(1).get() : null, len == 2 ? makeS(2).get() : null); }, "makeS(2).get(2).foo.dtor(2).");
+    check({ foo(len != 2 ? makeS(1).get() : null, len != 2 ? makeS(2).get() : null); }, "foo.");
+
+    // nesting temporaries in conditions
+    check({ foo(len == 2 ? makeS(1).get(len == 2 ? makeS(2).get() : null) : null); }, "makeS(1).makeS(2).get(2).get(1).foo.dtor(2).dtor(1).");
+    check({ foo(len == 2 ? makeS(1).get(len != 2 ? makeS(2).get() : null) : null); }, "makeS(1).get(1).foo.dtor(1).");
+    check({ foo(len != 2 ? makeS(1).get(len == 2 ? makeS(2).get() : null) : null); }, "foo.");
+    check({ foo(len != 2 ? makeS(1).get(len != 2 ? makeS(2).get() : null) : null); }, "foo.");
+}
+
+/**********************************/
 // 14708
 
 bool dtor14708 = false;
@@ -4160,6 +4269,7 @@ int main()
     test13669();
     test13095();
     test14264();
+    test14696();
     test14708();
     test14838();
 

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -3943,6 +3943,55 @@ void test14264()
 }
 
 /**********************************/
+// 14708
+
+bool dtor14708 = false;
+
+struct S14708
+{
+    int n;
+
+    void* get(void* p = null)
+    {
+        return null;
+    }
+
+    ~this()
+    {
+        //printf("dtor\n");
+        dtor14708 = true;
+    }
+}
+
+S14708 makeS14708(int n)
+{
+    return S14708(n);
+}
+
+void foo14708(void* x)
+{
+    throw new Exception("fail!");
+}
+
+void bar14708()
+{
+    foo14708(makeS14708(1).get());
+    // A temporary is allocated on stack for the
+    // return value from makeS(1).
+    // When foo throws exception, it's dtor should be called
+    // during unwinding stack, but it does not happen in Win64.
+}
+
+void test14708()
+{
+    try
+    {
+        bar14708();
+    } catch (Exception e) {}
+    assert(dtor14708);  // fails!
+}
+
+/**********************************/
 // 14838
 
 int test14838() pure nothrow @safe
@@ -4111,6 +4160,7 @@ int main()
     test13669();
     test13095();
     test14264();
+    test14708();
     test14838();
 
     printf("Success\n");


### PR DESCRIPTION
This is same with #4749, excepting base branch (stable).

---

Fixes two wrong-code issues.
[Issue 14696](https://issues.dlang.org/show_bug.cgi?id=14696) - destructor for temporary called before statement is complete with conditional operator
[Issue 14708](https://issues.dlang.org/show_bug.cgi?id=14708) - destructor for temporary not called during stack unwinding

And also fixes a regression from 2.068, because Phobos changes had hit issue 14696.

[Issue 14979](https://issues.dlang.org/show_bug.cgi?id=14979) - [REG2.068] Wrong tempCString result on x64 with ternary operator
