### PR TITLE
Issue 14950 - Setting enum value to the last member of another enum causes int overflow error

### DIFF
--- a/src/denum.d
+++ b/src/denum.d
@@ -656,7 +656,8 @@ public:
             e = e.ctfeInterpret();
             if (e.toInteger())
             {
-                error("initialization with (%s.%s + 1) causes overflow for type '%s'", emprev.ed.toChars(), emprev.toChars(), ed.type.toBasetype().toChars());
+                error("initialization with (%s.%s + 1) causes overflow for type '%s'",
+                    emprev.ed.toChars(), emprev.toChars(), ed.memtype.toChars());
                 goto Lerrors;
             }
             // Now set e to (eprev + 1)

--- a/test/fail_compilation/diag14950.d
+++ b/test/fail_compilation/diag14950.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag14950.d(17): Error: enum member diag14950.B.end initialization with (B.start + 1) causes overflow for type 'A'
+---
+*/
+
+enum A
+{
+    start,
+    end
+}
+
+enum B
+{
+    start = A.end,
+    end
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14950

Minor diagnostic issue.
