### PR TITLE
build against VC runtime: move ld_sprint to port.d

### DIFF
--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -636,7 +636,7 @@ public:
         {
             const(size_t) BUFFER_LEN = 36;
             char[BUFFER_LEN] buffer;
-            size_t n = ld_sprint(buffer.ptr, 'A', value);
+            size_t n = Port.ld_sprint(buffer.ptr, 'A', value);
             assert(n < BUFFER_LEN);
             for (size_t i = 0; i < n; i++)
             {

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -2157,13 +2157,13 @@ public:
          Plus one for rounding. */
         const(size_t) BUFFER_LEN = value.sizeof * 3 + 8 + 1 + 1;
         char[BUFFER_LEN] buffer;
-        ld_sprint(buffer.ptr, 'g', value);
+        Port.ld_sprint(buffer.ptr, 'g', value);
         assert(strlen(buffer.ptr) < BUFFER_LEN);
         if (hgs.hdrgen)
         {
             real_t r = Port.strtold(buffer.ptr, null);
             if (r != value) // if exact duplication
-                ld_sprint(buffer.ptr, 'a', value);
+                Port.ld_sprint(buffer.ptr, 'a', value);
         }
         buf.writestring(buffer.ptr);
         if (type)

--- a/src/root/longdouble.d
+++ b/src/root/longdouble.d
@@ -8,28 +8,8 @@
 
 module ddmd.root.longdouble;
 
-import core.stdc.stdio;
-
 real ldouble(T)(T x)
 {
     return cast(real)x;
 }
 
-size_t ld_sprint(char* str, int fmt, real x)
-{
-    if ((cast(real)cast(ulong)x) == x)
-    {
-        // ((1.5 -> 1 -> 1.0) == 1.5) is false
-        // ((1.0 -> 1 -> 1.0) == 1.0) is true
-        // see http://en.cppreference.com/w/cpp/io/c/fprintf
-        char[5] sfmt = "%#Lg\0";
-        sfmt[3] = cast(char)fmt;
-        return sprintf(str, sfmt.ptr, x);
-    }
-    else
-    {
-        char[4] sfmt = "%Lg\0";
-        sfmt[2] = cast(char)fmt;
-        return sprintf(str, sfmt.ptr, x);
-    }
-}

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -14,7 +14,7 @@ import core.stdc.string;
 import ddmd.globals;
 import ddmd.id;
 import ddmd.identifier;
-import ddmd.root.longdouble;
+import ddmd.root.port;
 import ddmd.root.outbuffer;
 import ddmd.root.rmem;
 import ddmd.utf;
@@ -741,26 +741,26 @@ struct Token
             sprintf(&buffer[0], "%lluUL", cast(ulong)uns64value);
             break;
         case TOKfloat32v:
-            ld_sprint(&buffer[0], 'g', float80value);
+            Port.ld_sprint(&buffer[0], 'g', float80value);
             strcat(&buffer[0], "f");
             break;
         case TOKfloat64v:
-            ld_sprint(&buffer[0], 'g', float80value);
+            Port.ld_sprint(&buffer[0], 'g', float80value);
             break;
         case TOKfloat80v:
-            ld_sprint(&buffer[0], 'g', float80value);
+            Port.ld_sprint(&buffer[0], 'g', float80value);
             strcat(&buffer[0], "L");
             break;
         case TOKimaginary32v:
-            ld_sprint(&buffer[0], 'g', float80value);
+            Port.ld_sprint(&buffer[0], 'g', float80value);
             strcat(&buffer[0], "fi");
             break;
         case TOKimaginary64v:
-            ld_sprint(&buffer[0], 'g', float80value);
+            Port.ld_sprint(&buffer[0], 'g', float80value);
             strcat(&buffer[0], "i");
             break;
         case TOKimaginary80v:
-            ld_sprint(&buffer[0], 'g', float80value);
+            Port.ld_sprint(&buffer[0], 'g', float80value);
             strcat(&buffer[0], "Li");
             break;
         case TOKstring:


### PR DESCRIPTION
We might also want to replace the ldouble template with constructor call for real_t so it is easier to map it to another type if the host real type doesn't match the target.

This might make longdouble.d obsolete. 
