### PR TITLE
Issue 14992 - static array local variables always require .init

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1519,17 +1519,17 @@ public:
             // Provide a default initializer
 
             //printf("Providing default initializer for '%s'\n", toChars());
-            if (type.needsNested())
-            {
-                Type tv = type;
-                while (tv.toBasetype().ty == Tsarray)
-                    tv = tv.toBasetype().nextOf();
-                assert(tv.toBasetype().ty == Tstruct);
 
+            Type tv = type;
+            while (tv.ty == Tsarray)    // Don't skip Tenum
+                tv = tv.nextOf();
+            if (tv.needsNested())
+            {
                 /* Nested struct requires valid enclosing frame pointer.
                  * In StructLiteralExp::toElem(), it's calculated.
                  */
-                checkFrameAccess(loc, sc, (cast(TypeStruct)tv.toBasetype()).sym);
+                assert(tbn.ty == Tstruct);
+                checkFrameAccess(loc, sc, (cast(TypeStruct)tbn).sym);
 
                 Expression e = tv.defaultInitLiteral(loc);
                 e = new BlitExp(loc, new VarExp(loc, this), e);
@@ -1537,8 +1537,7 @@ public:
                 _init = new ExpInitializer(loc, e);
                 goto Ldtor;
             }
-            if (type.ty == Tstruct &&
-                (cast(TypeStruct)type).sym.zeroInit == 1)
+            if (tv.ty == Tstruct && (cast(TypeStruct)tv).sym.zeroInit == 1)
             {
                 /* If a struct is all zeros, as a special case
                  * set it's initializer to the integer 0.

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1555,9 +1555,9 @@ public:
             {
                 error("%s does not have a default initializer", type.toChars());
             }
-            else
+            else if (auto e = type.defaultInit(loc))
             {
-                _init = getExpInitializer();
+                _init = new ExpInitializer(loc, e);
             }
 
             // Default initializer is always a blit
@@ -2121,25 +2121,6 @@ public:
             }
         }
         return e;
-    }
-
-    /****************************
-     * Get ExpInitializer for a variable, if there is one.
-     */
-    final ExpInitializer getExpInitializer()
-    {
-        ExpInitializer ei;
-        if (_init)
-            ei = _init.isExpInitializer();
-        else
-        {
-            Expression e = type.defaultInit(loc);
-            if (e)
-                ei = new ExpInitializer(loc, e);
-            else
-                ei = null;
-        }
-        return ei;
     }
 
     /*******************************************

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -284,7 +284,6 @@ public:
     bool canTakeAddressOf();
     bool needsAutoDtor();
     Expression *callScopeDtor(Scope *sc);
-    ExpInitializer *getExpInitializer();
     Expression *getConstInitializer(bool needFullType = true);
     void checkCtorConstInit();
     bool checkNestedReference(Scope *sc, Loc loc);

--- a/test/runnable/imports/a14992.d
+++ b/test/runnable/imports/a14992.d
@@ -1,0 +1,5 @@
+module imports.a14992;
+
+struct S1 { }
+
+struct S2 { int v; int[] a; }

--- a/test/runnable/link14992.d
+++ b/test/runnable/link14992.d
@@ -1,0 +1,22 @@
+import imports.a14992;  // do not link
+
+int test()
+{
+    S1 v1;      // OK
+    S1* p1;     // OK
+    S1[] da1;   // OK
+    S1[2] a1;   // OK <- NG
+
+    S2 v2;      // OK
+    S2* p2;     // OK
+    S2[] da2;   // OK
+    S2[2] a2;   // OK <- NG
+
+    return 1;
+}
+static assert(test());
+
+void main()
+{
+    test();
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14992

Add one more special case for static array of struct initialization with zero, similar to the special case for struct initialization.
