### PR TITLE
Fix dmdconf assert

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -411,7 +411,7 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
      * pick up any DFLAGS settings.
      */
     sections.push("Environment");
-    parseConfFile(&environment, inifilepath, inifile.len, inifile.buffer, &sections);
+    parseConfFile(&environment, global.inifilename, inifilepath, inifile.len, inifile.buffer, &sections);
     Strings dflags;
     getenv_setargv(readFromEnv(&environment, "DFLAGS"), &dflags);
     environment.reset(7); // erase cached environment updates
@@ -422,7 +422,7 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
     char[80] envsection;
     sprintf(envsection.ptr, "Environment%s", arch);
     sections.push(envsection.ptr);
-    parseConfFile(&environment, inifilepath, inifile.len, inifile.buffer, &sections);
+    parseConfFile(&environment, global.inifilename, inifilepath, inifile.len, inifile.buffer, &sections);
     getenv_setargv(readFromEnv(&environment, "DFLAGS"), &arguments);
     updateRealEnvironment(&environment);
     environment.reset(1); // don't need environment cache any more


### PR DESCRIPTION
Invalid user-provided data is not an internal logical error, and therefore an assertion shouldn't be used. In this case, the data of dmd.conf / sc.ini is being validated with an assert. Instead, a warning or an error should be generated. I chose a warning, feel free to bikeshed :o).

These kinds of warnings should always be displayed, even if the user has disabled compilation (i.e., source code related) warnings, so a separate commit introduces `warningGeneral()`. Even if we change the configuration file parsing issue to display an error instead of a warning, I plan to use `warningGeneral()` in another commit, so it will still be necessary.
