### PR TITLE
Fix -dylib warning

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -496,7 +496,7 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
             {
                 static if (TARGET_OSX)
                 {
-                    warning(Loc(), "use -shared instead of -dylib");
+                    deprecation(Loc(), "use -shared instead of -dylib");
                     global.params.dll = true;
                 }
                 else


### PR DESCRIPTION
It doesn't make sense not to display these kinds of warnings just because source code related warnings are not enabled.
