### PR TITLE
eliminate unnecessary SCfastpar allocations

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -677,8 +677,10 @@ Lagain:
 #if NTEXCEPTIONS == 2
     Fast.size -= nteh_contextsym_size();
 #if MARS
+#if TARGET_WINDOS
     if (funcsym_p->Sfunc->Fflags3 & Ffakeeh && nteh_contextsym_size() == 0)
         Fast.size -= 5 * 4;
+#endif
 #endif
 #endif
 
@@ -1049,6 +1051,10 @@ void stackoffsets(int flags)
             switch (s->Sclass)
             {
                 case SCfastpar:
+                    if (!(funcsym_p->Sfunc->Fflags3 & Ffakeeh))
+                        continue;   // don't need consistent stack frame
+                    break;
+
                 case SCshadowreg:
                 case SCparameter:
                     break;          // have to allocate space for parameters

--- a/src/glue.c
+++ b/src/glue.c
@@ -845,7 +845,6 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
         f->Fclass = (Classsym *)t;
     }
 
-#if TARGET_WINDOS
     /* This is done so that the 'this' pointer on the stack is the same
      * distance away from the function parameters, so that an overriding
      * function can call the nested fdensure or fdrequire of its overridden function
@@ -853,7 +852,6 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
      */
     if (fd->isVirtual() && (fd->fensure || fd->frequire))
         f->Fflags3 |= Ffakeeh;
-#endif
 
 #if TARGET_OSX
     s->Sclass = SCcomdat;


### PR DESCRIPTION
Makes for slightly faster code for small functions.
