### PR TITLE
flush printing DMD version in debug builds

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -264,6 +264,7 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
     debug
     {
         printf("DMD %s DEBUG\n", global._version);
+        fflush(stdout); // avoid interleaving with stderr output when redirecting
     }
     unittests();
     // Check for malformed input


### PR DESCRIPTION
When building against the VC runtime the version output interleaved with the error messages and caused an unexpected output in at least one of the failure tests.
