### PR TITLE
fix debug version generating different code than release

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -726,7 +726,7 @@ Lagain:
     assert(usedalloca != 1);
     AllocaOff = alignsection(usedalloca ? (Foff - REGSIZE) : Foff, REGSIZE, bias);
 
-    CSoff = alignsection(AllocaOff - cstop * REGSIZE, REGSIZE, bias);
+    CSoff = alignsection(AllocaOff - (int)cstop * REGSIZE, REGSIZE, bias);
 
 #if TX86
     NDPoff = alignsection(CSoff - NDP::savetop * NDPSAVESIZE, REGSIZE, bias);


### PR DESCRIPTION
My test case

```
int foo(int y)
{
    int[8] a;
    int x = 3;
    int z = 3;
    return x + y + z;
}
```

generates different code for the debug version of DMD than the release version, i.e it uses `enter` when compiled as release, but `push ebp, etc` when compiled as debug. Compiling the backend with VC yields the same result as the debug version.

I've spotted a signed/unsigned problem which seem to cause the issue (after the change all version use `enter`), but I could not detect where the actual difference manifests. I suspect the dmc optimizer somehow compensates the problem by a dubious optimization.

Too bad that D inherits the questionable signed/unsigned propagation rules from C.
