### PR TITLE
Fix issue 15014 - Win64: Invalid C++ mangling for multiple long arguments

### DIFF
--- a/src/cppmangle.d
+++ b/src/cppmangle.d
@@ -979,6 +979,21 @@ else static if (TARGET_WINDOS)
             {
                 return;
             }
+            if (!(flags & IS_DMC))
+            {
+                switch (type.ty)
+                {
+                    case Tint64:
+                    case Tuns64:
+                    case Tint128:
+                    case Tuns128:
+                    case Tfloat80:
+                    case Twchar:
+                        if (checkTypeSaved(type))
+                            return;
+                    default:
+                }
+            }
             mangleModifier(type);
             switch (type.ty)
             {

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -798,6 +798,35 @@ void testVtable()
 }
 
 /****************************************/
+/* problems detected by fuzzer */
+extern(C++) void fuzz1_cppvararg(long arg10, long arg11, bool arg12);
+extern(C++) void fuzz1_dvararg(long arg10, long arg11, bool arg12)
+{
+    fuzz1_checkValues(arg10, arg11, arg12);
+}
+
+extern(C++) void fuzz1_checkValues(long arg10, long arg11, bool arg12)
+{
+    assert(arg10 == 103);
+    assert(arg11 == 104);
+    assert(arg12 == false);
+}
+
+void fuzz1()
+{
+    long arg10 = 103;
+    long arg11 = 104;
+    bool arg12 = false;
+    fuzz1_dvararg(arg10, arg11, arg12);
+    fuzz1_cppvararg(arg10, arg11, arg12);
+}
+
+void fuzz()
+{
+    fuzz1();
+}
+
+/****************************************/
 
 void main()
 {
@@ -829,6 +858,7 @@ void main()
     test14195();
     test14200();
     testVtable();
+    fuzz();
 
     printf("Success\n");
 }

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -821,9 +821,57 @@ void fuzz1()
     fuzz1_cppvararg(arg10, arg11, arg12);
 }
 
+////////
+extern(C++) void fuzz2_cppvararg(ulong arg10, ulong arg11, bool arg12);
+extern(C++) void fuzz2_dvararg(ulong arg10, ulong arg11, bool arg12)
+{
+    fuzz2_checkValues(arg10, arg11, arg12);
+}
+
+extern(C++) void fuzz2_checkValues(ulong arg10, ulong arg11, bool arg12)
+{
+    assert(arg10 == 103);
+    assert(arg11 == 104);
+    assert(arg12 == false);
+}
+
+void fuzz2()
+{
+    ulong arg10 = 103;
+    ulong arg11 = 104;
+    bool arg12 = false;
+    fuzz2_dvararg(arg10, arg11, arg12);
+    fuzz2_cppvararg(arg10, arg11, arg12);
+}
+
+////////
+extern(C++) void fuzz3_cppvararg(wchar arg10, wchar arg11, bool arg12);
+extern(C++) void fuzz3_dvararg(wchar arg10, wchar arg11, bool arg12)
+{
+    fuzz2_checkValues(arg10, arg11, arg12);
+}
+
+extern(C++) void fuzz3_checkValues(wchar arg10, wchar arg11, bool arg12)
+{
+    assert(arg10 == 103);
+    assert(arg11 == 104);
+    assert(arg12 == false);
+}
+
+void fuzz3()
+{
+    wchar arg10 = 103;
+    wchar arg11 = 104;
+    bool arg12 = false;
+    fuzz3_dvararg(arg10, arg11, arg12);
+    fuzz3_cppvararg(arg10, arg11, arg12);
+}
+
 void fuzz()
 {
     fuzz1();
+    fuzz2();
+    fuzz3();
 }
 
 /****************************************/

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -522,10 +522,32 @@ Visitor2* getVisitor2()
 
 /******************************************/
 // issues detected by fuzzer
+#if _LP64
+#define longlong long
+#else
+#define longlong long long
+#endif
 
-void fuzz1_checkValues(long long arg10, long long arg11, bool arg12);
-void fuzz1_cppvararg(long long arg10, long long arg11, bool arg12)
+void fuzz1_checkValues(longlong arg10, longlong arg11, bool arg12);
+void fuzz1_cppvararg(longlong arg10, longlong arg11, bool arg12)
 {
     fuzz1_checkValues(arg10, arg11, arg12);
 }
- 
+
+void fuzz2_checkValues(unsigned longlong arg10, unsigned longlong arg11, bool arg12);
+void fuzz2_cppvararg(unsigned longlong arg10, unsigned longlong arg11, bool arg12)
+{
+    fuzz2_checkValues(arg10, arg11, arg12);
+}
+
+#if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun
+#define wchar unsigned short
+#elif _WIN32
+#define wchar wchar_t
+#endif
+
+void fuzz3_checkValues(wchar arg10, wchar arg11, bool arg12);
+void fuzz3_cppvararg(wchar arg10, wchar arg11, bool arg12)
+{
+    fuzz3_checkValues(arg10, arg11, arg12);
+}

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -519,3 +519,13 @@ Visitor2* getVisitor2()
 {
     return &inst;
 }
+
+/******************************************/
+// issues detected by fuzzer
+
+void fuzz1_checkValues(long long arg10, long long arg11, bool arg12);
+void fuzz1_cppvararg(long long arg10, long long arg11, bool arg12)
+{
+    fuzz1_checkValues(arg10, arg11, arg12);
+}
+ 


### PR DESCRIPTION
The types with "longer" names that encode as 2 bytes are also referenced by number if used again. This is an incompatibility between dmc and cl.

https://issues.dlang.org/show_bug.cgi?id=15014
