### PR TITLE
fix Issue 15015 - Win64: interop with C/C++ fails if function return value is a struct of size 8

### DIFF
--- a/src/toir.c
+++ b/src/toir.c
@@ -854,7 +854,7 @@ RET retStyle(TypeFunction *tf)
 
     if (global.params.isWindows && global.params.is64bit)
     {
-        // http://msdn.microsoft.com/en-us/library/7572ztz4(v=vs.80)
+        // http://msdn.microsoft.com/en-us/library/7572ztz4.aspx
         if (tns->ty == Tcomplex32)
             return RETstack;
         if (tns->isscalar())
@@ -866,7 +866,7 @@ RET retStyle(TypeFunction *tf)
             StructDeclaration *sd = ((TypeStruct *)tns)->sym;
             if (sd->ident == Id::__c_long_double)
                 return RETregs;
-            if (!sd->isPOD() || sz >= 8)
+            if (!sd->isPOD() || sz > 8)
                 return RETstack;
             if (sd->fields.dim == 0)
                 return RETstack;

--- a/test/runnable/cabi1.d
+++ b/test/runnable/cabi1.d
@@ -20,6 +20,12 @@ extern (C) Foo5 ctest5();
 extern (C) Foo6 ctest6();
 extern (C) S7 ctest10();
 
+version(Windows)
+    version = Windows_or_32bit;
+else version(X86)
+    version = Windows_or_32bit;
+
+
 void test1()
 {
     Foo1 f1 = ctest1();
@@ -34,17 +40,11 @@ void test1()
     Foo4 f4 = ctest4();
     assert(f4.i == 0x12345678);
 
-version (Win64)
-{
-}
-else
-{
     Foo5 f5 = ctest5();
     assert(f5.i == 0x12345678);
     assert(f5.j == 0x21436587);
-}
 
-version (X86)
+version(Windows_or_32bit)
 {
     Foo6 f6 = ctest6();
     assert(f6.i == 0x12345678);
@@ -52,15 +52,9 @@ version (X86)
     assert(f6.k == 0x24163857);
 }
 
-version (Win64)
-{
-}
-else
-{
     S7 s7 = ctest10();
     assert(s7.a == 2.5);
     assert(s7.b == 1.5);
-}
 }
 
 /*******************************************/


### PR DESCRIPTION
structs of size 8 are returned in register

https://issues.dlang.org/show_bug.cgi?id=15015
