### PR TITLE
omit frame for leaf functions on Linux, FreeBSD and OSX

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -100,9 +100,11 @@ void out_config_init(
             config.flags |= CFGromable; // put switch tables in code segment
     }
     config.flags |= CFGnoebp;
-    config.flags |= CFGalwaysframe;
     if (!exe)
+    {
         config.flags3 |= CFG3pic;
+        config.flags |= CFGalwaysframe; // PIC needs a frame for TLS fixups
+    }
     config.objfmt = OBJ_ELF;
 #endif
 #if TARGET_OSX
@@ -114,9 +116,12 @@ void out_config_init(
     else
         config.exe = EX_OSX;
     config.flags |= CFGnoebp;
-    config.flags |= CFGalwaysframe;
     if (!exe)
+    if (!exe)
+    {
         config.flags3 |= CFG3pic;
+        config.flags |= CFGalwaysframe; // PIC needs a frame for TLS fixups
+    }
     config.flags |= CFGromable; // put switch tables in code segment
     config.objfmt = OBJ_MACH;
 #endif
@@ -132,9 +137,11 @@ void out_config_init(
             config.flags |= CFGromable; // put switch tables in code segment
     }
     config.flags |= CFGnoebp;
-    config.flags |= CFGalwaysframe;
     if (!exe)
+    {
         config.flags3 |= CFG3pic;
+        config.flags |= CFGalwaysframe; // PIC needs a frame for TLS fixups
+    }
     config.objfmt = OBJ_ELF;
 #endif
 #if TARGET_OPENBSD

--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -671,6 +671,7 @@ typedef struct FUNC_S
         #define Fmember         0x2000  // D member function with 'this'
         #define Fnotailrecursion 0x4000 // no tail recursion optimizations
         #define Ffakeeh         0x8000  // allocate space for NT EH context sym anyway
+        #define Fnothrow        0x10000 // function does not throw (even if not marked 'nothrow')
     unsigned char Foper;        // operator number (OPxxxx) if Foperator
 
     Symbol *Fparsescope;        // use this scope to parse friend functions

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -3200,6 +3200,11 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
             c = NULL;
         else if (s != tls_get_addr_sym)
             c = save87();               // assume 8087 regs are all trashed
+
+        // Function calls may throw Errors, unless marked that they don't
+        if (s == funcsym_p || !s->Sfunc || !(s->Sfunc->Fflags3 & Fnothrow))
+            funcsym_p->Sfunc->Fflags3 &= ~Fnothrow;
+
         if (s->Sflags & SFLexit)
             // Function doesn't return, so don't worry about registers
             // it may use
@@ -3293,6 +3298,9 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
   }
   else
   {     /* Call function via pointer    */
+
+        // Function calls may throw Errors
+        funcsym_p->Sfunc->Fflags3 &= ~Fnothrow;
 
         if (e1->Eoper != OPind) { WRFL((enum FL)el_fl(e1)); WROP(e1->Eoper); }
         c = save87();                   // assume 8087 regs are all trashed


### PR DESCRIPTION
Omitting the setup and teardown of the BP stack frame can speed up small functions.

Currently, this is done only for Win32. Unfortunately for other platforms, the exception unwinding system relies on there being a BP stack frame. So it is only possible to do this for 'leaf' functions which do not throw (not even throwing `Error`s).

Only doing this for Linux at the moment, will extend if successful.
