### PR TITLE
replace MOV short with MOVSX

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -4482,7 +4482,17 @@ code *loaddata(elem *e,regm_t *pretregs)
 #endif
         assert(forregs & BYTEREGS);
         if (!I16)
+        {
+            if (config.target_cpu >= TARGET_PentiumPro && config.flags4 & CFG4speed &&
+                // Workaround for OSX linker bug:
+                //   ld: GOT load reloc does not point to a movq instruction in test42 for x86_64
+                !(config.exe & EX_OSX64 && !(sytab[e->EV.sp.Vsym->Sclass] & SCSS))
+               )
+            {
+                op = tyuns(tym) ? 0x0FB6 : 0x0FBE;      // MOVZX/MOVSX
+            }
             c = cat(c,loadea(e,&cs,op,reg,0,0,0));    // MOV regL,data
+        }
         else
         {   nregm = tyuns(tym) ? BYTEREGS : mAX;
             if (*pretregs & nregm)
@@ -4515,7 +4525,16 @@ code *loaddata(elem *e,regm_t *pretregs)
     }
     else if (sz <= REGSIZE)
     {
-        ce = loadea(e,&cs,0x8B,reg,0,RMload,0); // MOV reg,data
+        unsigned op = 0x8B;                     // MOV reg,data
+        if (sz == 2 && !I16 && config.target_cpu >= TARGET_PentiumPro &&
+            // Workaround for OSX linker bug:
+            //   ld: GOT load reloc does not point to a movq instruction in test42 for x86_64
+            !(config.exe & EX_OSX64 && !(sytab[e->EV.sp.Vsym->Sclass] & SCSS))
+           )
+        {
+            op = tyuns(tym) ? 0x0FB7 : 0x0FBF;  // MOVZX/MOVSX
+        }
+        ce = loadea(e,&cs,op,reg,0,RMload,0);
         c = cat(c,ce);
     }
     else if (sz <= 2 * REGSIZE && forregs & mES)

--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -2921,7 +2921,14 @@ code *cdind(elem *e,regm_t *pretregs)
         }
         else if (sz <= REGSIZE)
         {
-                cs.Iop = 0x8B ^ byte;
+                cs.Iop = 0x8B;                                  // MOV
+                if (sz <= 2 && !I16 &&
+                    config.target_cpu >= TARGET_PentiumPro && config.flags4 & CFG4speed)
+                {
+                    cs.Iop = tyuns(tym) ? 0x0FB7 : 0x0FBF;      // MOVZX/MOVSX
+                    cs.Iflags &= ~CFopsize;
+                }
+                cs.Iop ^= byte;
         L2:     code_newreg(&cs,reg);
                 ce = gen(CNIL,&cs);     /* MOV reg,[idx]                */
                 if (byte && reg >= 4)


### PR DESCRIPTION
Because Agner Fog sez it's faster.

http://www.agner.org/optimize/optimizing_assembly.pdf
pg. 61.

Thanks to @DmitryOlshansky 
