### PR TITLE
[REG-master] Make VarDeclaration.isOverlappedWith final (fix inconsistent vtbl layout between front-end and glue layer)

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -2031,7 +2031,7 @@ public:
         return (storage_class & STCctfe) != 0; // || !isDataseg();
     }
 
-    bool isOverlappedWith(VarDeclaration v)
+    final bool isOverlappedWith(VarDeclaration v)
     {
         return (  offset < v.offset + v.type.size() &&
                 v.offset <   offset +   type.size());


### PR DESCRIPTION
Introduced in #4863.

In `declaration.h`, `VarDeclaration.isOverlappedWith` funciton is `declared as final` by default, because it's written by C++. But in `declaration.d`, it's not marked with `final`. That mismatch had caused inconsistent vtbl layout for VarDeclaration object between front-end and glue layer.
