### PR TITLE
use latest dmd/gdc versions for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: d
 d:
-  - dmd-2.067.1
-  - gdc-4.9.3
+  - dmd
+  - gdc
   - ldc
 
 script: ./travis.sh


### PR DESCRIPTION
- meaning ddmd can use whatever all 3
  compilers support
