### PR TITLE
replace PUSH with SUB/MOV for stack frame setup

### DIFF
--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -393,6 +393,8 @@ extern targ_size_t spoff;
 extern targ_size_t Foff;        // BP offset of floating register
 extern targ_size_t CSoff;       // offset of common sub expressions
 extern targ_size_t NDPoff;      // offset of saved 8087 registers
+extern targ_size_t pushoff;     // offset of saved registers
+extern bool pushoffuse;         // using pushoff
 extern int BPoff;                      // offset from BP
 extern int EBPtoESP;            // add to EBP offset to get ESP offset
 extern int AllocaOff;               // offset of alloca temporary
@@ -405,6 +407,7 @@ code* prolog_frameadj(tym_t tyf, unsigned xlocalsize, bool enter, bool* pushallo
 code* prolog_frameadj2(tym_t tyf, unsigned xlocalsize, bool* pushalloc);
 code* prolog_setupalloca();
 code* prolog_saveregs(code *c, regm_t topush);
+code* epilog_restoreregs(code *c, regm_t topop);
 code* prolog_trace(bool farfunc, unsigned* regsaved);
 code* prolog_gen_win64_varargs();
 code* prolog_genvarargs(symbol* sv, regm_t* namedargs);


### PR DESCRIPTION
Normally the compiler generates PUSH/POP to save registers. This changes it to a SUB/MOV sequence. It's a step on the way to eliminate all PUSH/POP.

This benchmark shows it to be consistently faster, sometimes as much as 30%:

```
import std.datetime;
import std.conv;
import std.stdio;

void test1()
{
    asm
    {
        push EBX;
        push ECX;
        push EDX;
        push EDI;
        push ESI;
        call foo;
        pop ESI;
        pop EDI;
        pop EDX;
        pop ECX;
        pop EBX;
    }
}

void test2()
{
    asm
    {
        sub ESP,20;
        mov 16[ESP],EBX;
        mov 12[ESP],ECX;
        mov  8[ESP],EDX;
        mov  4[ESP],EDI;
        mov  0[ESP],ESI;
        call foo;
        mov EBX,16[ESP];
        mov ECX,12[ESP];
        mov EDX, 8[ESP];
        mov EDI, 4[ESP];
        mov ESI, 0[ESP];
        add ESP,20;
    }
}

void foo() { }

void main()
{
    auto r = benchmark!(test1, test2)(10_000_000);
    writefln("%s\n%s", to!Duration(r[0]), to!Duration(r[1]));
}
```
