### PR TITLE
Minor memory-safety fixes (Valgrind-identified problems, debug bounds checks)

### DIFF
--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -2310,6 +2310,9 @@ void MachObj::addrel(int seg, targ_size_t offset, symbol *targsym,
         unsigned targseg, int rtype, int val)
 {
     Relocation rel;
+#ifdef DEBUG
+    memset(&rel, 0, sizeof(rel));
+#endif
     rel.offset = offset;
     rel.targsym = targsym;
     rel.targseg = targseg;

--- a/src/constfold.d
+++ b/src/constfold.d
@@ -384,7 +384,21 @@ extern (C++) UnionExp Div(Type type, Expression e1, Expression e2)
         {
             if (e1.type.isreal())
             {
-                emplaceExp!(RealExp)(&ue, loc, e1.toReal() / e2.toReal(), type);
+                version (all)
+                {
+                    // Work around redundant REX.W prefix breaking Valgrind
+                    // when built with affected versions of DMD.
+                    // https://issues.dlang.org/show_bug.cgi?id=14952
+                    // This can be removed once compiling with DMD 2.068 or
+                    // older is no longer supported.
+                    d_float80 r1 = e1.toReal();
+                    d_float80 r2 = e2.toReal();
+                    emplaceExp!(RealExp)(&ue, loc, r1 / r2, type);
+                }
+                else
+                {
+                    emplaceExp!(RealExp)(&ue, loc, e1.toReal() / e2.toReal(), type);
+                }
                 return ue;
             }
             r = e2.toReal();

--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -306,7 +306,7 @@ public:
         scope Mangler v = new Mangler(&buf2);
         v.paramsToDecoBuffer(t.arguments);
         int len = cast(int)buf2.offset;
-        buf.printf("%d%.*s", len, len, buf2.extractData());
+        buf.printf("%d%.*s", len, len, buf2.extractString());
     }
 
     void visit(TypeNull t)

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -72,7 +72,7 @@ extern (C++) void genhdrfile(Module m)
     toCBuffer(m, &buf, &hgs);
     // Transfer image to file
     m.hdrfile.setbuffer(buf.data, buf.offset);
-    buf.data = null;
+    buf.extractData();
     ensurePathToNameExists(Loc(), m.hdrfile.toChars());
     writeFile(m.loc, m.hdrfile);
 }

--- a/src/optimize.d
+++ b/src/optimize.d
@@ -796,8 +796,25 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 return;
             }
             // If e2 *could* have been an integer, make it one.
-            if (e.e2.op == TOKfloat64 && (e.e2.toReal() == cast(sinteger_t)e.e2.toReal()))
-                e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64);
+            if (e.e2.op == TOKfloat64)
+            {
+                version (all)
+                {
+                    // Work around redundant REX.W prefix breaking Valgrind
+                    // when built with affected versions of DMD.
+                    // https://issues.dlang.org/show_bug.cgi?id=14952
+                    // This can be removed once compiling with DMD 2.068 or
+                    // older is no longer supported.
+                    d_float80 r = e.e2.toReal();
+                    if (r == cast(sinteger_t)r)
+                        e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64);
+                }
+                else
+                {
+                    if (e.e2.toReal() == cast(sinteger_t)e.e2.toReal())
+                        e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64);
+                }
+            }
             if (e.e1.isConst() == 1 && e.e2.isConst() == 1)
             {
                 Expression ex = Pow(e.type, e.e1, e.e2).copy();


### PR DESCRIPTION
Currently some debug code to run against the autotester to help debug issue 15019:

https://issues.dlang.org/show_bug.cgi?id=15019
