### PR TITLE
[REG2.069-devel] Issue 15045 - hasElaborateCopyConstructor is true for struct with opDispatch

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2589,7 +2589,13 @@ public:
             ident != Id._init &&
             ident != Id._mangleof &&
             ident != Id.stringof &&
-            ident != Id.offsetof)
+            ident != Id.offsetof &&
+            // Bugzilla 15045: Don't forward special built-in member functions.
+            ident != Id.ctor &&
+            ident != Id.dtor &&
+            ident != Id.__xdtor &&
+            ident != Id.postblit &&
+            ident != Id.__xpostblit)
         {
             /* Look for overloaded opDot() to see if we should forward request
              * to it.

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2582,15 +2582,19 @@ public:
     final Expression noMember(Scope* sc, Expression e, Identifier ident, int flag)
     {
         assert(ty == Tstruct || ty == Tclass);
-        AggregateDeclaration sym = toDsymbol(sc).isAggregateDeclaration();
+        auto sym = toDsymbol(sc).isAggregateDeclaration();
         assert(sym);
-        if (ident != Id.__sizeof && ident != Id.__xalignof && ident != Id._init && ident != Id._mangleof && ident != Id.stringof && ident != Id.offsetof)
+        if (ident != Id.__sizeof &&
+            ident != Id.__xalignof &&
+            ident != Id._init &&
+            ident != Id._mangleof &&
+            ident != Id.stringof &&
+            ident != Id.offsetof)
         {
             /* Look for overloaded opDot() to see if we should forward request
              * to it.
              */
-            Dsymbol fd = search_function(sym, Id.opDot);
-            if (fd)
+            if (auto fd = search_function(sym, Id.opDot))
             {
                 /* Rewrite e.ident as:
                  *  e.opDot().ident
@@ -2599,11 +2603,11 @@ public:
                 e = new DotIdExp(e.loc, e, ident);
                 return e.semantic(sc);
             }
+
             /* Look for overloaded opDispatch to see if we should forward request
              * to it.
              */
-            fd = search_function(sym, Id.opDispatch);
-            if (fd)
+            if (auto fd = search_function(sym, Id.opDispatch))
             {
                 /* Rewrite e.ident as:
                  *  e.opDispatch!("ident")
@@ -2630,6 +2634,7 @@ public:
                     e = null;
                 return e;
             }
+
             /* See if we should forward to the alias this.
              */
             if (sym.aliasthis)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7584,6 +7584,65 @@ void test14853()
     auto b1 = new Queue14853!uint;
 }
 
+/********************************************************/
+// 15045
+
+void test15045()
+{
+    void testName(T, bool r, string name)()
+    {
+        T t;
+
+        static assert(r ==          is(typeof(mixin("T."~name))));
+        static assert(r ==          is(typeof(mixin("t."~name))));
+        static assert(r == __traits(compiles, mixin("T."~name)));
+        static assert(r == __traits(compiles, mixin("t."~name)));
+        static assert(r == mixin("__traits(compiles, T."~name~")"));
+        static assert(r == mixin("__traits(compiles, t."~name~")"));
+
+        static assert(r ==                       __traits(hasMember, T, name) );
+        static assert(r ==                       __traits(hasMember, t, name) );
+        static assert(r == __traits(compiles,    __traits(getMember, T, name) ));
+        static assert(r == __traits(compiles,    __traits(getMember, t, name) ));
+        static assert(r == __traits(compiles, __traits(getOverloads, T, name) ));
+        static assert(r == __traits(compiles, __traits(getOverloads, t, name) ));
+    }
+    void test(T, bool r)()
+    {
+        testName!(T, r, "__ctor")();
+        testName!(T, r, "__dtor")();
+        testName!(T, r, "__xdtor")();
+        testName!(T, r, "__postblit")();
+        testName!(T, r, "__xpostblit")();
+    }
+
+    static struct X
+    {
+        this(int) {}
+        this(this) {}
+        ~this() {}
+    }
+
+    static struct S1
+    {
+        auto opDispatch(string name, A...)(A args) { }
+    }
+    static struct S2
+    {
+        X get() { return X(); };
+        alias get this;
+    }
+    static struct S3
+    {
+        X opDot() { return X(); };
+    }
+
+    test!(X, true)();
+    test!(S1, false)();
+    test!(S2, false)();
+    test!(S3, false)();
+}
+
 /***************************************************/
 
 int main()


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15045

Adjust member forwarding behavior for aggregate special member names.
