### PR TITLE
refactor: use LocalSection for alloca data

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -3216,7 +3216,6 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
             c1 = getregs(~s->Sregsaved & (mBP | ALLREGS | mES | XMMREGS));
         if (strcmp(s->Sident,"alloca") == 0)
         {
-#if 1
             s = getRtlsym(RTLSYM_ALLOCA);
             makeitextern(s);
             int areg = CX;
@@ -3226,10 +3225,7 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
             c1 = genc(c1,0x8D,modregrm(2,areg,BPRM),FLallocatmp,0,0,0);  // LEA areg,&localsize[BP]
             if (I64)
                 code_orrex(c1, REX_W);
-            usedalloca = 2;             // new way
-#else
-            usedalloca = 1;             // old way
-#endif
+            Alloca.size = REGSIZE;
         }
         if (sytab[s->Sclass] & SCSS)    // if function is on stack (!)
         {

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -2140,7 +2140,7 @@ regm_t cod3_useBP()
             config.flags & CFGstack ||
             localsize >= 0x100 ||       // arbitrary value < 0x1000
             (usednteh & ~NTEHjmonitor) ||
-            usedalloca
+            Alloca.size
            )
             goto Lcant;
     }
@@ -2874,13 +2874,6 @@ code* prolog_ifunc2(tym_t tyf, tym_t tym, bool pushds)
 
 code* prolog_16bit_windows_farfunc(tym_t* tyf, bool* pushds)
 {
-#if SCPP
-    // alloca() can't be because the 'special' parameter won't be at
-    // a known offset from BP.
-    if (usedalloca == 1)
-        synerr(EM_alloca_win);      // alloca() can't be in Windows functions
-#endif
-
     int wflags = config.wflags;
     if (wflags & WFreduced && !(*tyf & mTYexport))
     {   // reduced prolog/epilog for non-exported functions
@@ -3104,7 +3097,7 @@ code* prolog_setupalloca()
     // Set up magic parameter for alloca()
     // MOV -REGSIZE[BP],localsize - BPoff
     code* c = genc(NULL,0xC7,modregrm(2,0,BPRM),
-            FLconst,AllocaOff + BPoff,
+            FLconst,Alloca.offset + BPoff,
             FLconst,localsize - BPoff);
     if (I64)
         code_orrex(c, REX_W);
@@ -3857,7 +3850,7 @@ void epilog(block *b)
                 goto L4;
         }
 
-        if (localsize | usedalloca)
+        if (localsize)
         {
             c = genc1(c,LEA,modregrm(1,SP,6),FLconst,(targ_uns)-2); /* LEA SP,-2[BP] */
         }
@@ -3877,7 +3870,7 @@ void epilog(block *b)
         {
         L4:
             assert(hasframe);
-            if (xlocalsize | usedalloca)
+            if (xlocalsize)
             {
                 if (config.flags2 & CFG2stomp)
                 {   /*   MOV  ECX,0xBEAF
@@ -3919,7 +3912,7 @@ void epilog(block *b)
                     !(config.target_cpu >= TARGET_80386 && config.flags4 & CFG4speed)
                    )
                     c = gen1(c,0xC9);           // LEAVE
-                else if (0 && xlocalsize == REGSIZE && !usedalloca && I32)
+                else if (0 && xlocalsize == REGSIZE && Alloca.size == 0 && I32)
                 {   // This doesn't work - I should figure out why
                     mfuncreg &= ~mask[regx];
                     c = gen1(c,0x58 + regx);    // POP regx
@@ -4758,7 +4751,7 @@ void assignaddrc(code *c)
                 c->Iflags |= CFunambig;
                 goto L2;
             case FLallocatmp:
-                c->IEVpointer1 += AllocaOff + BPoff;
+                c->IEVpointer1 += Alloca.offset + BPoff;
                 goto L2;
             case FLbprel:
                 c->IEVpointer1 += s->Soffset;
@@ -4865,7 +4858,7 @@ void assignaddrc(code *c)
                 c->IEVpointer2 += Foff + BPoff;
                 break;
             case FLallocatmp:
-                c->IEVpointer2 += AllocaOff + BPoff;
+                c->IEVpointer2 += Alloca.offset + BPoff;
                 break;
             case FLbprel:
                 c->IEVpointer2 += s->Soffset;

--- a/src/backend/cod5.c
+++ b/src/backend/cod5.c
@@ -49,7 +49,7 @@ void cod5_prol_epi()
 
     if (!(config.flags4 & CFG4optimized) ||
         anyiasm ||
-        usedalloca ||
+        Alloca.size ||
         usednteh ||
         tyf & (mTYnaked | mTYloadds) ||
         tym == TYifunc ||

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -189,7 +189,7 @@ extern  regm_t FLOATREGS;
 extern  regm_t FLOATREGS2;
 extern  regm_t DOUBLEREGS;
 extern  const char datafl[],stackfl[],segfl[],flinsymtab[];
-extern  char needframe,usedalloca,gotref;
+extern  char needframe,gotref;
 extern  targ_size_t localsize,
         funcoffset,
         framehandleroffset;
@@ -199,6 +199,7 @@ extern  LocalSection Para;
 extern  LocalSection Fast;
 extern  LocalSection Auto;
 extern  LocalSection EEStack;
+extern  LocalSection Alloca;
 #if TARGET_OSX
 extern  targ_size_t localgotoffset;
 #endif
@@ -397,7 +398,6 @@ extern targ_size_t pushoff;     // offset of saved registers
 extern bool pushoffuse;         // using pushoff
 extern int BPoff;               // offset from BP
 extern int EBPtoESP;            // add to EBP offset to get ESP offset
-extern targ_size_t AllocaOff;   // offset of alloca temporary
 
 code* prolog_ifunc(tym_t* tyf);
 code* prolog_ifunc2(tym_t tyf, tym_t tym, bool pushds);

--- a/src/backend/nteh.c
+++ b/src/backend/nteh.c
@@ -249,14 +249,14 @@ unsigned nteh_contextsym_size()
 #else
         assert(0);
 #endif
-        assert(usedalloca != 1);
     }
     else if (usednteh & NTEHcpp)
-    {   sz = 5 * 4;                     // C++ context record
-        assert(usedalloca != 1);
+    {
+        sz = 5 * 4;                     // C++ context record
     }
     else if (usednteh & NTEHpassthru)
-    {   sz = 1 * 4;
+    {
+        sz = 1 * 4;
     }
     else
         sz = 0;                         // no context record

--- a/src/eh.c
+++ b/src/eh.c
@@ -53,7 +53,7 @@ symbol *except_gentables()
     {
         // BUG: alloca() changes the stack size, which is not reflected
         // in the fixed eh tables.
-        if (usedalloca)
+        if (Alloca.size)
             error(NULL, 0, 0, "cannot mix core.std.stdlib.alloca() and exception handling in %s()", funcsym_p->Sident);
 
         char name[13+5+1];


### PR DESCRIPTION
Replace `usedalloca` and `AllocaOff` with `LocalSection Alloca`, which makes things a little more consistent. It also eliminates some dead code and special cases.
