### PR TITLE
Sync up names of member variables that conflict with D keywords

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -241,7 +241,7 @@ public:
 class VarDeclaration : public Declaration
 {
 public:
-    Initializer *init;
+    Initializer *_init;
     unsigned offset;
     bool noscope;                // no auto semantics
     FuncDeclarations nestedrefs; // referenced by these lexically nested functions

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -151,7 +151,7 @@ public:
     Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol
     Loc loc;                    // where defined
-    Scope *scope;               // !=NULL means context to use for semantic()
+    Scope *_scope;               // !=NULL means context to use for semantic()
     bool errors;                // this symbol failed to pass semantic()
     PASS semanticRun;
     char *depmsg;               // customized deprecation message

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -4951,11 +4951,11 @@ elem *toElem(Expression *e, IRState *irs)
                     Symbol *sp = toSymbol(s);
                     symbol_add(sp);
                     //printf("\tadding symbol '%s'\n", sp->Sident);
-                    if (vd->init)
+                    if (vd->_init)
                     {
                         ExpInitializer *ie;
 
-                        ie = vd->init->isExpInitializer();
+                        ie = vd->_init->isExpInitializer();
                         if (ie)
                             e = toElem(ie->exp, irs);
                     }

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2318,9 +2318,9 @@ static void asm_merge_symbol(OPND *o1, Dsymbol *s)
             goto L2;
         }
         if ((v->isConst() || v->isImmutable() || v->storage_class & STCmanifest) &&
-            !v->type->isfloating() && v->init)
+            !v->type->isfloating() && v->_init)
         {
-            ExpInitializer *ei = v->init->isExpInitializer();
+            ExpInitializer *ei = v->_init->isExpInitializer();
             if (ei)
             {
                 o1->disp = ei->exp->toInteger();

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -258,8 +258,8 @@ public:
         mystate.contBlock->appendSucc(blx->curblock);
         mystate.contBlock->appendSucc(mystate.breakBlock);
 
-        if (s->body)
-            Statement_toIR(s->body, &mystate);
+        if (s->_body)
+            Statement_toIR(s->_body, &mystate);
         blx->curblock->appendSucc(mystate.contBlock);
 
         block_next(blx, BCgoto, mystate.contBlock);
@@ -281,8 +281,8 @@ public:
         mystate.breakBlock = block_calloc(blx);
         mystate.contBlock = block_calloc(blx);
 
-        if (s->init)
-            Statement_toIR(s->init, &mystate);
+        if (s->_init)
+            Statement_toIR(s->_init, &mystate);
         block *bpre = blx->curblock;
         block_next(blx,BCgoto,NULL);
         block *bcond = blx->curblock;
@@ -303,8 +303,8 @@ public:
             bcond->appendSucc(blx->curblock);
         }
 
-        if (s->body)
-            Statement_toIR(s->body, &mystate);
+        if (s->_body)
+            Statement_toIR(s->_body, &mystate);
         /* End of the body goes to the continue block
          */
         blx->curblock->appendSucc(mystate.contBlock);
@@ -528,7 +528,7 @@ public:
             block_next(blx, BCgoto, NULL);
             b->appendSucc(mystate.defaultBlock);
 
-            Statement_toIR(s->body, &mystate);
+            Statement_toIR(s->_body, &mystate);
 
             /* Have the end of the switch body fall through to the block
              * following the switch statement.
@@ -627,7 +627,7 @@ public:
             }
         }
 
-        Statement_toIR(s->body, &mystate);
+        Statement_toIR(s->_body, &mystate);
 
         /* Have the end of the switch body fall through to the block
          * following the switch statement.
@@ -948,7 +948,7 @@ public:
             symbol_add(sp);
 
             // Perform initialization of with handle
-            ie = s->wthis->init->isExpInitializer();
+            ie = s->wthis->_init->isExpInitializer();
             assert(ie);
             ei = toElemDtor(ie->exp, irs);
             e = el_var(sp);
@@ -958,8 +958,8 @@ public:
             block_appendexp(blx->curblock,e);
         }
         // Execute with block
-        if (s->body)
-            Statement_toIR(s->body, irs);
+        if (s->_body)
+            Statement_toIR(s->_body, irs);
     }
 
 
@@ -1013,9 +1013,9 @@ public:
         blx->tryblock = tryblock;
         block *breakblock = block_calloc(blx);
         block_goto(blx,BC_try,NULL);
-        if (s->body)
+        if (s->_body)
         {
-            Statement_toIR(s->body, &mystate);
+            Statement_toIR(s->_body, &mystate);
         }
         blx->tryblock = tryblock->Btry;
 
@@ -1108,8 +1108,8 @@ public:
         contblock->BC = BC_finally;
         bodyirs.finallyBlock = contblock;
 
-        if (s->body)
-            Statement_toIR(s->body, &bodyirs);
+        if (s->_body)
+            Statement_toIR(s->_body, &bodyirs);
         blx->tryblock = tryblock->Btry;     // back to previous tryblock
 
         setScopeIndex(blx,blx->curblock,previndex);

--- a/src/statement.h
+++ b/src/statement.h
@@ -245,7 +245,7 @@ class WhileStatement : public Statement
 {
 public:
     Expression *condition;
-    Statement *body;
+    Statement *_body;
     Loc endloc;                 // location of closing curly bracket
 
     WhileStatement(Loc loc, Expression *c, Statement *b, Loc endloc);
@@ -260,7 +260,7 @@ public:
 class DoStatement : public Statement
 {
 public:
-    Statement *body;
+    Statement *_body;
     Expression *condition;
 
     DoStatement(Loc loc, Statement *b, Expression *c);
@@ -275,10 +275,10 @@ public:
 class ForStatement : public Statement
 {
 public:
-    Statement *init;
+    Statement *_init;
     Expression *condition;
     Expression *increment;
-    Statement *body;
+    Statement *_body;
     Loc endloc;                 // location of closing curly bracket
 
     // When wrapped in try/finally clauses, this points to the outermost one,
@@ -303,7 +303,7 @@ public:
     TOK op;                     // TOKforeach or TOKforeach_reverse
     Parameters *parameters;     // array of Parameter*'s
     Expression *aggr;
-    Statement *body;
+    Statement *_body;
     Loc endloc;                 // location of closing curly bracket
 
     VarDeclaration *key;
@@ -331,7 +331,7 @@ public:
     Parameter *prm;             // loop index variable
     Expression *lwr;
     Expression *upr;
-    Statement *body;
+    Statement *_body;
     Loc endloc;                 // location of closing curly bracket
 
     VarDeclaration *key;
@@ -384,7 +384,7 @@ class PragmaStatement : public Statement
 public:
     Identifier *ident;
     Expressions *args;          // array of Expression's
-    Statement *body;
+    Statement *_body;
 
     PragmaStatement(Loc loc, Identifier *ident, Expressions *args, Statement *body);
     Statement *syntaxCopy();
@@ -409,7 +409,7 @@ class SwitchStatement : public Statement
 {
 public:
     Expression *condition;
-    Statement *body;
+    Statement *_body;
     bool isFinal;
 
     DefaultStatement *sdefault;
@@ -547,7 +547,7 @@ class SynchronizedStatement : public Statement
 {
 public:
     Expression *exp;
-    Statement *body;
+    Statement *_body;
 
     SynchronizedStatement(Loc loc, Expression *exp, Statement *body);
     Statement *syntaxCopy();
@@ -562,7 +562,7 @@ class WithStatement : public Statement
 {
 public:
     Expression *exp;
-    Statement *body;
+    Statement *_body;
     VarDeclaration *wthis;
 
     WithStatement(Loc loc, Expression *exp, Statement *body);
@@ -575,7 +575,7 @@ public:
 class TryCatchStatement : public Statement
 {
 public:
-    Statement *body;
+    Statement *_body;
     Catches *catches;
 
     TryCatchStatement(Loc loc, Statement *body, Catches *catches);
@@ -606,7 +606,7 @@ public:
 class TryFinallyStatement : public Statement
 {
 public:
-    Statement *body;
+    Statement *_body;
     Statement *finalbody;
 
     TryFinallyStatement(Loc loc, Statement *body, Statement *finalbody);

--- a/src/todt.c
+++ b/src/todt.c
@@ -475,7 +475,7 @@ dt_t **Expression_toDt(Expression *e, dt_t **pdt)
 
             VarDeclaration *v = e->var->isVarDeclaration();
             if (v && (v->isConst() || v->isImmutable()) &&
-                e->type->toBasetype()->ty != Tsarray && v->init)
+                e->type->toBasetype()->ty != Tsarray && v->_init)
             {
                 if (v->inuse)
                 {
@@ -483,7 +483,7 @@ dt_t **Expression_toDt(Expression *e, dt_t **pdt)
                     return;
                 }
                 v->inuse++;
-                pdt = Initializer_toDt(v->init, pdt);
+                pdt = Initializer_toDt(v->_init, pdt);
                 v->inuse--;
                 return;
             }
@@ -632,7 +632,7 @@ dt_t **membersToDt(AggregateDeclaration *ad, dt_t **pdt,
 
     for (size_t i = 0; i < ad->fields.dim; i++)
     {
-        if (ad->fields[i]->init && ad->fields[i]->init->isVoidInitializer())
+        if (ad->fields[i]->_init && ad->fields[i]->_init->isVoidInitializer())
             continue;
 
         VarDeclaration *vd = NULL;
@@ -642,7 +642,7 @@ dt_t **membersToDt(AggregateDeclaration *ad, dt_t **pdt,
             VarDeclaration *v2 = ad->fields[j];
             if (v2->offset < offset)
                 continue;
-            if (v2->init && v2->init->isVoidInitializer())
+            if (v2->_init && v2->_init->isVoidInitializer())
                 continue;
             // find the nearest field
             if (!vd || v2->offset < vd->offset)
@@ -660,7 +660,7 @@ dt_t **membersToDt(AggregateDeclaration *ad, dt_t **pdt,
             pdt = dtnzeros(pdt, vd->offset - offset);
 
         dt_t *dt = NULL;
-        if (Initializer *init = vd->init)
+        if (Initializer *init = vd->_init)
         {
             //printf("\t\t%s has initializer %s\n", vd->toChars(), init->toChars());
             if (init->isVoidInitializer())
@@ -672,8 +672,8 @@ dt_t **membersToDt(AggregateDeclaration *ad, dt_t **pdt,
              * As a workaround for the issue 9057, have to resolve forward reference
              * in `init` before its use.
              */
-            if (vd->sem < Semantic2Done && vd->scope)
-                vd->semantic2(vd->scope);
+            if (vd->sem < Semantic2Done && vd->_scope)
+                vd->semantic2(vd->_scope);
 
             ExpInitializer *ei = init->isExpInitializer();
             Type *tb = vd->type->toBasetype();

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -268,7 +268,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             if (global.params.symdebug)
                 toDebug(cd);
 
-            assert(!cd->scope);     // semantic() should have been run to completion
+            assert(!cd->_scope);     // semantic() should have been run to completion
 
             enum_SC scclass = SCcomdat;
 
@@ -946,12 +946,12 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             } while (parent);
             s->Sfl = FLdata;
 
-            if (vd->init)
+            if (vd->_init)
             {
-                Initializer_toDt(vd->init, &s->Sdt);
+                Initializer_toDt(vd->_init, &s->Sdt);
 
                 // Look for static array that is block initialized
-                ExpInitializer *ie = vd->init->isExpInitializer();
+                ExpInitializer *ie = vd->_init->isExpInitializer();
 
                 Type *tb = vd->type->toBasetype();
                 if (tb->ty == Tsarray && ie &&


### PR DESCRIPTION
The D versions were renamed automatically by magicport, but the C++ side was never updated.
