### PR TITLE
move parameters to stack instead of pushing

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -1420,6 +1420,8 @@ enum FL
         FLgot,          // global offset table entry outside this object file
         FLgotoff,       // global offset table entry inside this object file
 
+        FLfuncarg,      // argument to upcoming function call
+
         FLMAX
 };
 

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -4753,6 +4753,9 @@ void assignaddrc(code *c)
             case FLallocatmp:
                 c->IEVpointer1 += Alloca.offset + BPoff;
                 goto L2;
+            case FLfuncarg:
+                c->IEVpointer1 += cgstate.funcarg.offset + BPoff;
+                goto L2;
             case FLbprel:
                 c->IEVpointer1 += s->Soffset;
                 break;
@@ -4859,6 +4862,9 @@ void assignaddrc(code *c)
                 break;
             case FLallocatmp:
                 c->IEVpointer2 += Alloca.offset + BPoff;
+                break;
+            case FLfuncarg:
+                c->IEVpointer2 += cgstate.funcarg.offset + BPoff;
                 break;
             case FLbprel:
                 c->IEVpointer2 += s->Soffset;

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -1159,6 +1159,8 @@ code *cdaddass(elem *e,regm_t *pretregs)
             code_newreg(&cs, reg);              // OP1 EA,reg
             if (sz == 1 && reg >= 4 && I64)
                 cs.Irex |= REX;
+            if (forccs)
+                cs.Iflags |= CFpsw;
         }
 #if TARGET_SEGMENTED
         else if (tyml == TYhptr)

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -174,6 +174,13 @@ extern unsigned usednteh;
 typedef struct CGstate
 {
     int stackclean;     // if != 0, then clean the stack after function call
+
+    LocalSection funcarg;       // where function arguments are placed
+    targ_size_t funcargtos;     // current high water level of arguments being moved onto
+                                // the funcarg section. It is filled from top to bottom,
+                                // as if they were 'pushed' on the stack.
+                                // Special case: if funcargtos==~0, then no
+                                // arguments are there.
 } CGstate;
 
 extern CGstate cgstate;
@@ -282,7 +289,7 @@ code *fixresult (elem *e , regm_t retregs , regm_t *pretregs );
 code *callclib (elem *e , unsigned clib , regm_t *pretregs , regm_t keepmask );
 cd_t cdfunc;
 cd_t cdstrthis;
-code *params(elem *, unsigned);
+code *pushParams(elem *, unsigned);
 code *offsetinreg (elem *e , regm_t *pretregs );
 code *loaddata (elem *e , regm_t *pretregs );
 

--- a/src/backend/debug.c
+++ b/src/backend/debug.c
@@ -267,6 +267,7 @@ void WRFL(enum FL fl)
          "bprel ","frameh","blocko","alloca",
          "stack ","dsym  ",
          "got   ","gotoff",
+         "funcar",
     };
 
     if ((unsigned)fl >= (unsigned)FLMAX)

--- a/src/backend/nteh.c
+++ b/src/backend/nteh.c
@@ -671,7 +671,7 @@ code *cdsetjmp(elem *e,regm_t *pretregs)
     stackpush += 4;
     genadjesp(c,4);
 
-    c = cat(c,params(e->E1,REGSIZE));
+    c = cat(c,pushParams(e->E1,REGSIZE));
 
     c = cat(c,getregs(~getRtlsym(RTLSYM_SETJMP3)->Sregsaved & (ALLREGS | mES)));
     gencs(c,0xE8,0,FLfunc,getRtlsym(RTLSYM_SETJMP3));      // CALL __setjmp3

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -650,7 +650,7 @@ void fltables()
         static char indatafl[] =        /* is FLxxxx a data type?       */
         { FLdata,FLudata,FLreg,FLpseudo,FLauto,FLfast,FLpara,FLextern,
           FLcs,FLfltreg,FLallocatmp,FLdatseg,FLtlsdata,FLbprel,
-          FLstack,FLregsave,
+          FLstack,FLregsave,FLfuncarg,
 #if TX86
           FLndp,
 #endif
@@ -661,6 +661,7 @@ void fltables()
 
         static char instackfl[] =       /* is FLxxxx a stack data type? */
         { FLauto,FLfast,FLpara,FLcs,FLfltreg,FLallocatmp,FLbprel,FLstack,FLregsave,
+          FLfuncarg,
 #if TX86
           FLndp,
 #endif
@@ -756,6 +757,7 @@ void fltables()
                 case FLframehandler:    segfl[i] = -1;  break;
                 case FLasm:     segfl[i] = -1;  break;
                 case FLallocatmp:       segfl[i] = SS;  break;
+                case FLfuncarg:         segfl[i] = SS;  break;
                 default:
                         printf("error in segfl[%d]\n", i);
                         exit(1);

--- a/src/backend/rtlsym.c
+++ b/src/backend/rtlsym.c
@@ -70,7 +70,7 @@ void rtlsym_init()
         tv->Tcount++;
 #endif
 
-        // Only used by dmd1 for RTLSYM_THROWC
+        // Only used by dmd1 for RTLSYM_THROW
         type *tw = NULL;
 
 #undef SYMBOL_Z


### PR DESCRIPTION
I've been thinking of doing this for a long time, it's what other compilers do. Instead of `PUSH`ing parameters on the stack, it `MOV`es them. Space for it all is preallocated on the stack upon function entry. It's turned on only when `-O` is used.

The advantage is when there are many function calls, no stack adjustments are done.

There's room for improvement with this, like in how the moves are actually done. This initial support is basic. But it does validate the rather complex changes to make it work. Getting it working enables further optimizations that would be otherwise closed to dmd.
