### PR TITLE
Add new version identifier SystemZ.

### DIFF
--- a/src/cond.d
+++ b/src/cond.d
@@ -216,6 +216,7 @@ public:
             "SPARC64",
             "S390",
             "S390X",
+            "SystemZ",
             "HPPA",
             "HPPA64",
             "SH",


### PR DESCRIPTION
This is a better name than S390X. The doc update is here:
https://github.com/D-Programming-Language/dlang.org/pull/1100

If this gets pulled then I also update druntime to use SystemZ.
