### PR TITLE
Add version identifier CRuntime_Bionic.

### DIFF
--- a/src/cond.d
+++ b/src/cond.d
@@ -227,6 +227,7 @@ public:
             "BigEndian",
             "ELFv1",
             "ELFv2",
+            "CRuntime_Bionic",
             "CRuntime_Digitalmars",
             "CRuntime_Glibc",
             "CRuntime_Microsoft",


### PR DESCRIPTION
It is already used in druntime but not in the list of reserved identifiers.
