### PR TITLE
Remove predefined version identifier ELFv1 when targeting OS X

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -343,7 +343,6 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OSX");
-        VersionCondition.addPredefinedGlobalIdent("ELFv1");
         global.params.isOSX = true;
         // For legacy compatibility
         VersionCondition.addPredefinedGlobalIdent("darwin");


### PR DESCRIPTION
OS X uses the Mach-O binary format, not ELF.
