### PR TITLE
Do not generate runtime type information with -betterC and warn when using type info features

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -819,6 +819,14 @@ void Obj::term(const char *objfilename)
         obj.buf->setsize(size);
 }
 
+/*********************************
+ * Generate code to register DSO with druntime.
+ */
+
+void Obj::register_dso()
+{
+}
+
 /*****************************
  * Line number support.
  */

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -1069,10 +1069,6 @@ void Obj::term(const char *objfilename)
         dwarf_termfile();
     }
 
-#if MARS
-    obj_rtinit();
-#endif
-
 #if SCPP
     if (errcnt)
         return;
@@ -1360,6 +1356,17 @@ void Obj::term(const char *objfilename)
     }
     fobjbuf->position(foffset, 0);
     fobjbuf->flush();
+}
+
+/*********************************
+ * Generate code to register DSO with druntime.
+ */
+
+void Obj::register_dso()
+{
+#if MARS
+    obj_rtinit();
+#endif
 }
 
 /*****************************

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -1352,6 +1352,14 @@ void Obj::term(const char *objfilename)
     fobjbuf->flush();
 }
 
+/*********************************
+ * Generate code to register DSO with druntime.
+ */
+
+void Obj::register_dso()
+{
+}
+
 /*****************************
  * Line number support.
  */

--- a/src/backend/obj.h
+++ b/src/backend/obj.h
@@ -29,6 +29,7 @@ struct Obj
     VIRTUAL void initfile(const char *filename, const char *csegname, const char *modname);
     VIRTUAL void termfile();
     VIRTUAL void term(const char *objfilename);
+    VIRTUAL void register_dso();
 
     VIRTUAL size_t mangle(Symbol *s,char *dest);
     VIRTUAL void import(elem *e);

--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -371,9 +371,12 @@ public:
         postblit = buildPostBlit(this, sc2);
         buildOpAssign(this, sc2);
         buildOpEquals(this, sc2);
-        xeq = buildXopEquals(this, sc2);
-        xcmp = buildXopCmp(this, sc2);
-        xhash = buildXtoHash(this, sc2);
+        if (!global.params.noRTTI)
+        {
+            xeq = buildXopEquals(this, sc2);
+            xcmp = buildXopCmp(this, sc2);
+            xhash = buildXtoHash(this, sc2);
+        }
         /* Even if the struct is merely imported and its semantic3 is not run,
          * the TypeInfo object would be speculatively stored in each object
          * files. To set correct function pointer, run semantic3 for xeq and xcmp.

--- a/src/expression.d
+++ b/src/expression.d
@@ -6592,7 +6592,7 @@ public:
         {
             // Handle this in the glue layer
             e = new TypeidExp(loc, ta);
-            e.type = getTypeInfoType(ta, sc);
+            e.type = getTypeInfoType(ta, sc, this);
 
             semanticTypeInfo(sc, ta);
 

--- a/src/globals.d
+++ b/src/globals.d
@@ -111,9 +111,12 @@ struct Param
     bool nofloat; // code should not pull in floating point support
     bool ignoreUnsupportedPragmas; // rather than error on them
     bool enforcePropertySyntax;
-    bool betterC; // be a "better C" compiler; no dependency on D runtime
     bool addMain; // add a default main() function
     bool allInst; // generate code for all template instantiations
+    bool betterC; // be a "better C" compiler; no dependency on D runtime
+    bool noRTTI;                 // disable runtime type information
+    const(char)* noRTTIMessage;  // message to use for noRTTI errors
+
     BOUNDSCHECK useArrayBounds;
     const(char)* argv0; // program name
     Array!(const(char)*)* imppath; // array of char*'s of where to look for import modules

--- a/src/globals.h
+++ b/src/globals.h
@@ -89,9 +89,11 @@ struct Param
     bool nofloat;       // code should not pull in floating point support
     bool ignoreUnsupportedPragmas;      // rather than error on them
     bool enforcePropertySyntax;
-    bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
+    bool betterC;       // be a "better C" compiler; no dependency on D runtime
+    bool noRTTI;                // disable runtime type information
+    const char *noRTTIMessage;  // message to use for noRTTI errors
 
     BOUNDSCHECK useArrayBounds;
 

--- a/src/glue.c
+++ b/src/glue.c
@@ -478,7 +478,7 @@ void genObjFile(Module *m, bool multiobj)
     /* Always generate module info, because of templates and -cov.
      * But module info needs the runtime library, so disable it for betterC.
      */
-    if (!global.params.betterC /*|| needModuleInfo()*/)
+    if (!global.params.noRTTI /*|| needModuleInfo()*/)
         genModuleInfo(m);
 
     /* Always generate helper functions b/c of later templates instantiations

--- a/src/glue.c
+++ b/src/glue.c
@@ -255,6 +255,8 @@ void obj_start(char *srcfile)
 void obj_end(Library *library, File *objfile)
 {
     const char *objfilename = objfile->name->toChars();
+    if (!global.params.betterC)
+        objmod->register_dso();
     objmod->term(objfilename);
     delete objmod;
     objmod = NULL;

--- a/src/mars.d
+++ b/src/mars.d
@@ -797,7 +797,11 @@ Language changes listed by -transition=id:
             else if (strcmp(p + 1, "release") == 0)
                 global.params.release = true;
             else if (strcmp(p + 1, "betterC") == 0)
+            {
                 global.params.betterC = true;
+                global.params.noRTTI = true;
+                global.params.noRTTIMessage = "TypeInfo is not available with -betterC";
+            }
             else if (strcmp(p + 1, "noboundscheck") == 0)
             {
                 global.params.useArrayBounds = BOUNDSCHECKoff;

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -258,6 +258,7 @@ Symbol *toSymbol(Dsymbol *s)
         {
             //printf("TypeInfoDeclaration::toSymbol(%s), linkage = %d\n", tid->toChars(), tid->linkage);
             assert(tid->tinfo->ty != Terror);
+            assert(!global.params.noRTTI);
             visit((VarDeclaration *)tid);
         }
 

--- a/src/todt.c
+++ b/src/todt.c
@@ -555,6 +555,12 @@ dt_t **Expression_toDt(Expression *e, dt_t **pdt)
 
         void visit(TypeidExp *e)
         {
+            if (global.params.noRTTI)
+            {
+                e->error(global.params.noRTTIMessage);
+                pdt = NULL;
+                return;
+            }
             if (Type *t = isType(e->obj))
             {
                 genTypeInfo(t, NULL);
@@ -694,7 +700,7 @@ dt_t **membersToDt(AggregateDeclaration *ad, dt_t **pdt,
         offset = vd->offset + vd->type->size();
     }
 
-    if (cd)
+    if (cd && !global.params.noRTTI)
     {
         // Interface vptr initializations
         toSymbol(cd);                                         // define csym
@@ -1439,6 +1445,7 @@ public:
 
 dt_t **TypeInfo_toDt(dt_t **pdt, TypeInfoDeclaration *d)
 {
+    assert(!global.params.noRTTI);
     TypeInfoDtVisitor v(pdt);
     d->accept(&v);
     return v.pdt;

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -299,7 +299,8 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the TypeInfo
-            genTypeInfo(cd->type, NULL);
+            if (!global.params.noRTTI)
+                genTypeInfo(cd->type, NULL);
             //toObjFile(cd->type->vtinfo, multiobj);
 
             //////////////////////////////////////////////
@@ -329,264 +330,267 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                }
              */
             dt_t *dt = NULL;
-            unsigned offset = Target::classinfosize;    // must be ClassInfo.size
-            if (Type::typeinfoclass)
+            if (!global.params.noRTTI)
             {
-                if (Type::typeinfoclass->structsize != Target::classinfosize)
+                unsigned offset = Target::classinfosize;    // must be ClassInfo.size
+                if (Type::typeinfoclass)
                 {
-        #ifdef DEBUG
-                    printf("Target::classinfosize = x%x, Type::typeinfoclass->structsize = x%x\n", offset, Type::typeinfoclass->structsize);
-        #endif
-                    cd->error("mismatch between dmd and object.d or object.di found. Check installation and import paths with -v compiler switch.");
-                    fatal();
-                }
-            }
-
-            if (Type::typeinfoclass)
-                dtxoff(&dt, toVtblSymbol(Type::typeinfoclass), 0, TYnptr); // vtbl for ClassInfo
-            else
-                dtsize_t(&dt, 0);                // BUG: should be an assert()
-            dtsize_t(&dt, 0);                    // monitor
-
-            // initializer[]
-            assert(cd->structsize >= 8 || (cd->cpp && cd->structsize >= 4));
-            dtsize_t(&dt, cd->structsize);           // size
-            dtxoff(&dt, sinit, 0, TYnptr);      // initializer
-
-            // name[]
-            const char *name = cd->ident->toChars();
-            size_t namelen = strlen(name);
-            if (!(namelen > 9 && memcmp(name, "TypeInfo_", 9) == 0))
-            {
-                name = cd->toPrettyChars();
-                namelen = strlen(name);
-            }
-            dt_t **pdtname = dtsize_t(&dt, namelen);
-            dtxoff(&dt, cd->csym, 0, TYnptr);
-
-            // vtbl[]
-            dtsize_t(&dt, cd->vtbl.dim);
-            if (cd->vtbl.dim)
-                dtxoff(&dt, cd->vtblsym, 0, TYnptr);
-            else
-                dtsize_t(&dt, 0);
-
-            // interfaces[]
-            dtsize_t(&dt, cd->vtblInterfaces->dim);
-            if (cd->vtblInterfaces->dim)
-                dtxoff(&dt, cd->csym, offset, TYnptr);      // (*)
-            else
-                dtsize_t(&dt, 0);
-
-            // base
-            if (cd->baseClass)
-                dtxoff(&dt, toSymbol(cd->baseClass), 0, TYnptr);
-            else
-                dtsize_t(&dt, 0);
-
-            // destructor
-            if (cd->dtor)
-                dtxoff(&dt, toSymbol(cd->dtor), 0, TYnptr);
-            else
-                dtsize_t(&dt, 0);
-
-            // invariant
-            if (cd->inv)
-                dtxoff(&dt, toSymbol(cd->inv), 0, TYnptr);
-            else
-                dtsize_t(&dt, 0);
-
-            // flags
-            ClassFlags::Type flags = ClassFlags::hasOffTi;
-            if (cd->isCOMclass()) flags |= ClassFlags::isCOMclass;
-            if (cd->isCPPclass()) flags |= ClassFlags::isCPPclass;
-            flags |= ClassFlags::hasGetMembers;
-            flags |= ClassFlags::hasTypeInfo;
-            if (cd->ctor)
-                flags |= ClassFlags::hasCtor;
-            for (ClassDeclaration *pc = cd; pc; pc = pc->baseClass)
-            {
-                if (pc->dtor)
-                {
-                    flags |= ClassFlags::hasDtor;
-                    break;
-                }
-            }
-            if (cd->isabstract)
-                flags |= ClassFlags::isAbstract;
-            for (ClassDeclaration *pc = cd; pc; pc = pc->baseClass)
-            {
-                if (pc->members)
-                {
-                    for (size_t i = 0; i < pc->members->dim; i++)
+                    if (Type::typeinfoclass->structsize != Target::classinfosize)
                     {
-                        Dsymbol *sm = (*pc->members)[i];
-                        //printf("sm = %s %s\n", sm->kind(), sm->toChars());
-                        if (sm->hasPointers())
-                            goto L2;
+            #ifdef DEBUG
+                        printf("Target::classinfosize = x%x, Type::typeinfoclass->structsize = x%x\n", offset, Type::typeinfoclass->structsize);
+            #endif
+                        cd->error("mismatch between dmd and object.d or object.di found. Check installation and import paths with -v compiler switch.");
+                        fatal();
                     }
                 }
-            }
-            flags |= ClassFlags::noPointers;
-          L2:
-            dtsize_t(&dt, flags);
 
+                if (Type::typeinfoclass)
+                    dtxoff(&dt, toVtblSymbol(Type::typeinfoclass), 0, TYnptr); // vtbl for ClassInfo
+                else
+                    dtsize_t(&dt, 0);                // BUG: should be an assert()
+                dtsize_t(&dt, 0);                    // monitor
 
-            // deallocator
-            if (cd->aggDelete)
-                dtxoff(&dt, toSymbol(cd->aggDelete), 0, TYnptr);
-            else
-                dtsize_t(&dt, 0);
+                // initializer[]
+                assert(cd->structsize >= 8 || (cd->cpp && cd->structsize >= 4));
+                dtsize_t(&dt, cd->structsize);           // size
+                dtxoff(&dt, sinit, 0, TYnptr);      // initializer
 
-            // offTi[]
-            dtsize_t(&dt, 0);
-            dtsize_t(&dt, 0);            // null for now, fix later
-
-            // defaultConstructor
-            if (cd->defaultCtor && !(cd->defaultCtor->storage_class & STCdisable))
-                dtxoff(&dt, toSymbol(cd->defaultCtor), 0, TYnptr);
-            else
-                dtsize_t(&dt, 0);
-
-            // xgetRTInfo
-            if (cd->getRTInfo)
-                Expression_toDt(cd->getRTInfo, &dt);
-            else if (flags & ClassFlags::noPointers)
-                dtsize_t(&dt, 0);
-            else
-                dtsize_t(&dt, 1);
-
-            //dtxoff(&dt, toSymbol(type->vtinfo), 0, TYnptr); // typeinfo
-
-            //////////////////////////////////////////////
-
-            // Put out (*vtblInterfaces)[]. Must immediately follow csym, because
-            // of the fixup (*)
-
-            offset += cd->vtblInterfaces->dim * (4 * Target::ptrsize);
-            for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)
-            {
-                BaseClass *b = (*cd->vtblInterfaces)[i];
-                ClassDeclaration *id = b->sym;
-
-                /* The layout is:
-                 *  struct Interface
-                 *  {
-                 *      ClassInfo *interface;
-                 *      void *[] vtbl;
-                 *      size_t offset;
-                 *  }
-                 */
-
-                // Fill in vtbl[]
-                b->fillVtbl(cd, &b->vtbl, 1);
-
-                dtxoff(&dt, toSymbol(id), 0, TYnptr);         // ClassInfo
+                // name[]
+                const char *name = cd->ident->toChars();
+                size_t namelen = strlen(name);
+                if (!(namelen > 9 && memcmp(name, "TypeInfo_", 9) == 0))
+                {
+                    name = cd->toPrettyChars();
+                    namelen = strlen(name);
+                }
+                dt_t **pdtname = dtsize_t(&dt, namelen);
+                dtxoff(&dt, cd->csym, 0, TYnptr);
 
                 // vtbl[]
-                dtsize_t(&dt, id->vtbl.dim);
-                dtxoff(&dt, cd->csym, offset, TYnptr);
+                dtsize_t(&dt, cd->vtbl.dim);
+                if (cd->vtbl.dim)
+                    dtxoff(&dt, cd->vtblsym, 0, TYnptr);
+                else
+                    dtsize_t(&dt, 0);
 
-                dtsize_t(&dt, b->offset);                        // this offset
+                // interfaces[]
+                dtsize_t(&dt, cd->vtblInterfaces->dim);
+                if (cd->vtblInterfaces->dim)
+                    dtxoff(&dt, cd->csym, offset, TYnptr);      // (*)
+                else
+                    dtsize_t(&dt, 0);
 
-                offset += id->vtbl.dim * Target::ptrsize;
-            }
+                // base
+                if (cd->baseClass)
+                    dtxoff(&dt, toSymbol(cd->baseClass), 0, TYnptr);
+                else
+                    dtsize_t(&dt, 0);
 
-            // Put out the (*vtblInterfaces)[].vtbl[]
-            // This must be mirrored with ClassDeclaration::baseVtblOffset()
-            //printf("putting out %d interface vtbl[]s for '%s'\n", vtblInterfaces->dim, toChars());
-            for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)
-            {
-                BaseClass *b = (*cd->vtblInterfaces)[i];
-                ClassDeclaration *id = b->sym;
+                // destructor
+                if (cd->dtor)
+                    dtxoff(&dt, toSymbol(cd->dtor), 0, TYnptr);
+                else
+                    dtsize_t(&dt, 0);
 
-                //printf("    interface[%d] is '%s'\n", i, id->toChars());
-                size_t j = 0;
-                if (id->vtblOffset())
+                // invariant
+                if (cd->inv)
+                    dtxoff(&dt, toSymbol(cd->inv), 0, TYnptr);
+                else
+                    dtsize_t(&dt, 0);
+
+                // flags
+                ClassFlags::Type flags = ClassFlags::hasOffTi;
+                if (cd->isCOMclass()) flags |= ClassFlags::isCOMclass;
+                if (cd->isCPPclass()) flags |= ClassFlags::isCPPclass;
+                flags |= ClassFlags::hasGetMembers;
+                flags |= ClassFlags::hasTypeInfo;
+                if (cd->ctor)
+                    flags |= ClassFlags::hasCtor;
+                for (ClassDeclaration *pc = cd; pc; pc = pc->baseClass)
                 {
-                    // First entry is ClassInfo reference
-                    //dtxoff(&dt, toSymbol(id), 0, TYnptr);
-
-                    // First entry is struct Interface reference
-                    dtxoff(&dt, cd->csym, Target::classinfosize + i * (4 * Target::ptrsize), TYnptr);
-                    j = 1;
-                }
-                assert(id->vtbl.dim == b->vtbl.dim);
-                for (; j < id->vtbl.dim; j++)
-                {
-                    assert(j < b->vtbl.dim);
-        #if 0
-                    RootObject *o = b->vtbl[j];
-                    if (o)
+                    if (pc->dtor)
                     {
-                        printf("o = %p\n", o);
-                        assert(o->dyncast() == DYNCAST_DSYMBOL);
-                        Dsymbol *s = (Dsymbol *)o;
-                        printf("s->kind() = '%s'\n", s->kind());
+                        flags |= ClassFlags::hasDtor;
+                        break;
                     }
-        #endif
-                    FuncDeclaration *fd = b->vtbl[j];
-                    if (fd)
-                        dtxoff(&dt, toThunkSymbol(fd, b->offset), 0, TYnptr);
-                    else
-                        dtsize_t(&dt, 0);
                 }
-            }
-
-            // Put out the overriding interface vtbl[]s.
-            // This must be mirrored with ClassDeclaration::baseVtblOffset()
-            //printf("putting out overriding interface vtbl[]s for '%s' at offset x%x\n", toChars(), offset);
-            ClassDeclaration *pc;
-            for (pc = cd->baseClass; pc; pc = pc->baseClass)
-            {
-                for (size_t k = 0; k < pc->vtblInterfaces->dim; k++)
+                if (cd->isabstract)
+                    flags |= ClassFlags::isAbstract;
+                for (ClassDeclaration *pc = cd; pc; pc = pc->baseClass)
                 {
-                    BaseClass *bs = (*pc->vtblInterfaces)[k];
-                    FuncDeclarations bvtbl;
-                    if (bs->fillVtbl(cd, &bvtbl, 0))
+                    if (pc->members)
                     {
-                        //printf("\toverriding vtbl[] for %s\n", bs->sym->toChars());
-                        ClassDeclaration *id = bs->sym;
-
-                        size_t j = 0;
-                        if (id->vtblOffset())
+                        for (size_t i = 0; i < pc->members->dim; i++)
                         {
-                            // First entry is ClassInfo reference
-                            //dtxoff(&dt, toSymbol(id), 0, TYnptr);
-
-                            // First entry is struct Interface reference
-                            dtxoff(&dt, toSymbol(pc), Target::classinfosize + k * (4 * Target::ptrsize), TYnptr);
-                            offset += Target::ptrsize;
-                            j = 1;
-                        }
-
-                        for (; j < id->vtbl.dim; j++)
-                        {
-                            assert(j < bvtbl.dim);
-                            FuncDeclaration *fd = bvtbl[j];
-                            if (fd)
-                                dtxoff(&dt, toThunkSymbol(fd, bs->offset), 0, TYnptr);
-                            else
-                                dtsize_t(&dt, 0);
-                            offset += Target::ptrsize;
+                            Dsymbol *sm = (*pc->members)[i];
+                            //printf("sm = %s %s\n", sm->kind(), sm->toChars());
+                            if (sm->hasPointers())
+                                goto L2;
                         }
                     }
                 }
+                flags |= ClassFlags::noPointers;
+              L2:
+                dtsize_t(&dt, flags);
+
+
+                // deallocator
+                if (cd->aggDelete)
+                    dtxoff(&dt, toSymbol(cd->aggDelete), 0, TYnptr);
+                else
+                    dtsize_t(&dt, 0);
+
+                // offTi[]
+                dtsize_t(&dt, 0);
+                dtsize_t(&dt, 0);            // null for now, fix later
+
+                // defaultConstructor
+                if (cd->defaultCtor && !(cd->defaultCtor->storage_class & STCdisable))
+                    dtxoff(&dt, toSymbol(cd->defaultCtor), 0, TYnptr);
+                else
+                    dtsize_t(&dt, 0);
+
+                // xgetRTInfo
+                if (cd->getRTInfo)
+                    Expression_toDt(cd->getRTInfo, &dt);
+                else if (flags & ClassFlags::noPointers)
+                    dtsize_t(&dt, 0);
+                else
+                    dtsize_t(&dt, 1);
+
+                //dtxoff(&dt, toSymbol(type->vtinfo), 0, TYnptr); // typeinfo
+
+                //////////////////////////////////////////////
+
+                // Put out (*vtblInterfaces)[]. Must immediately follow csym, because
+                // of the fixup (*)
+
+                offset += cd->vtblInterfaces->dim * (4 * Target::ptrsize);
+                for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)
+                {
+                    BaseClass *b = (*cd->vtblInterfaces)[i];
+                    ClassDeclaration *id = b->sym;
+
+                    /* The layout is:
+                     *  struct Interface
+                     *  {
+                     *      ClassInfo *interface;
+                     *      void *[] vtbl;
+                     *      size_t offset;
+                     *  }
+                     */
+
+                    // Fill in vtbl[]
+                    b->fillVtbl(cd, &b->vtbl, 1);
+
+                    dtxoff(&dt, toSymbol(id), 0, TYnptr);         // ClassInfo
+
+                    // vtbl[]
+                    dtsize_t(&dt, id->vtbl.dim);
+                    dtxoff(&dt, cd->csym, offset, TYnptr);
+
+                    dtsize_t(&dt, b->offset);                        // this offset
+
+                    offset += id->vtbl.dim * Target::ptrsize;
+                }
+
+                // Put out the (*vtblInterfaces)[].vtbl[]
+                // This must be mirrored with ClassDeclaration::baseVtblOffset()
+                //printf("putting out %d interface vtbl[]s for '%s'\n", vtblInterfaces->dim, toChars());
+                for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)
+                {
+                    BaseClass *b = (*cd->vtblInterfaces)[i];
+                    ClassDeclaration *id = b->sym;
+
+                    //printf("    interface[%d] is '%s'\n", i, id->toChars());
+                    size_t j = 0;
+                    if (id->vtblOffset())
+                    {
+                        // First entry is ClassInfo reference
+                        //dtxoff(&dt, toSymbol(id), 0, TYnptr);
+
+                        // First entry is struct Interface reference
+                        dtxoff(&dt, cd->csym, Target::classinfosize + i * (4 * Target::ptrsize), TYnptr);
+                        j = 1;
+                    }
+                    assert(id->vtbl.dim == b->vtbl.dim);
+                    for (; j < id->vtbl.dim; j++)
+                    {
+                        assert(j < b->vtbl.dim);
+            #if 0
+                        RootObject *o = b->vtbl[j];
+                        if (o)
+                        {
+                            printf("o = %p\n", o);
+                            assert(o->dyncast() == DYNCAST_DSYMBOL);
+                            Dsymbol *s = (Dsymbol *)o;
+                            printf("s->kind() = '%s'\n", s->kind());
+                        }
+            #endif
+                        FuncDeclaration *fd = b->vtbl[j];
+                        if (fd)
+                            dtxoff(&dt, toThunkSymbol(fd, b->offset), 0, TYnptr);
+                        else
+                            dtsize_t(&dt, 0);
+                    }
+                }
+
+                // Put out the overriding interface vtbl[]s.
+                // This must be mirrored with ClassDeclaration::baseVtblOffset()
+                //printf("putting out overriding interface vtbl[]s for '%s' at offset x%x\n", toChars(), offset);
+                ClassDeclaration *pc;
+                for (pc = cd->baseClass; pc; pc = pc->baseClass)
+                {
+                    for (size_t k = 0; k < pc->vtblInterfaces->dim; k++)
+                    {
+                        BaseClass *bs = (*pc->vtblInterfaces)[k];
+                        FuncDeclarations bvtbl;
+                        if (bs->fillVtbl(cd, &bvtbl, 0))
+                        {
+                            //printf("\toverriding vtbl[] for %s\n", bs->sym->toChars());
+                            ClassDeclaration *id = bs->sym;
+
+                            size_t j = 0;
+                            if (id->vtblOffset())
+                            {
+                                // First entry is ClassInfo reference
+                                //dtxoff(&dt, toSymbol(id), 0, TYnptr);
+
+                                // First entry is struct Interface reference
+                                dtxoff(&dt, toSymbol(pc), Target::classinfosize + k * (4 * Target::ptrsize), TYnptr);
+                                offset += Target::ptrsize;
+                                j = 1;
+                            }
+
+                            for (; j < id->vtbl.dim; j++)
+                            {
+                                assert(j < bvtbl.dim);
+                                FuncDeclaration *fd = bvtbl[j];
+                                if (fd)
+                                    dtxoff(&dt, toThunkSymbol(fd, bs->offset), 0, TYnptr);
+                                else
+                                    dtsize_t(&dt, 0);
+                                offset += Target::ptrsize;
+                            }
+                        }
+                    }
+                }
+
+                //////////////////////////////////////////////
+
+                dtpatchoffset(*pdtname, offset);
+
+                dtnbytes(&dt, namelen + 1, name);
+                const size_t namepad = -(namelen + 1) & (Target::ptrsize - 1); // align
+                dtnzeros(&dt, namepad);
+
+                cd->csym->Sdt = dt;
+                // ClassInfo cannot be const data, because we use the monitor on it
+                outdata(cd->csym);
+                if (cd->isExport())
+                    objmod->export_symbol(cd->csym, 0);
             }
-
-            //////////////////////////////////////////////
-
-            dtpatchoffset(*pdtname, offset);
-
-            dtnbytes(&dt, namelen + 1, name);
-            const size_t namepad = -(namelen + 1) & (Target::ptrsize - 1); // align
-            dtnzeros(&dt, namepad);
-
-            cd->csym->Sdt = dt;
-            // ClassInfo cannot be const data, because we use the monitor on it
-            outdata(cd->csym);
-            if (cd->isExport())
-                objmod->export_symbol(cd->csym, 0);
 
             //////////////////////////////////////////////
 
@@ -594,7 +598,13 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             //printf("putting out %s.vtbl[]\n", toChars());
             dt = NULL;
             if (cd->vtblOffset())
-                dtxoff(&dt, cd->csym, 0, TYnptr);           // first entry is ClassInfo reference
+            {
+                // first entry is ClassInfo reference
+                if (global.params.noRTTI)
+                    dtsize_t(&dt, 0);
+                else
+                    dtxoff(&dt, cd->csym, 0, TYnptr);
+            }
             for (size_t i = cd->vtblOffset(); i < cd->vtbl.dim; i++)
             {
                 FuncDeclaration *fd = cd->vtbl[i]->isFuncDeclaration();
@@ -692,8 +702,11 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the TypeInfo
-            genTypeInfo(id->type, NULL);
-            id->type->vtinfo->accept(this);
+            if (!global.params.noRTTI)
+            {
+                genTypeInfo(id->type, NULL);
+                id->type->vtinfo->accept(this);
+            }
 
             //////////////////////////////////////////////
 
@@ -860,7 +873,8 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 if (global.params.symdebug)
                     toDebug(sd);
 
-                genTypeInfo(sd->type, NULL);
+                if (!global.params.noRTTI)
+                    genTypeInfo(sd->type, NULL);
 
                 // Generate static initializer
                 toInitializer(sd);
@@ -1015,7 +1029,8 @@ void toObjFile(Dsymbol *ds, bool multiobj)
             if (global.params.symdebug)
                 toDebug(ed);
 
-            genTypeInfo(ed->type, NULL);
+            if (!global.params.noRTTI)
+                genTypeInfo(ed->type, NULL);
 
             TypeEnum *tc = (TypeEnum *)ed->type;
             if (!tc->sym->members || ed->type->isZeroInit())
@@ -1044,6 +1059,9 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 return;
             }
             //printf("TypeInfoDeclaration::toObjFile(%p '%s') protection %d\n", tid, tid->toChars(), tid->protection);
+
+            if (global.params.noRTTI)
+                return;
 
             if (multiobj)
             {

--- a/test/fail_compilation/imports/nortti.d
+++ b/test/fail_compilation/imports/nortti.d
@@ -1,0 +1,63 @@
+/**
+ * This module contains tests which only work with RTTI enabled
+ * and should produce certain compiler (as opposed to link) errors
+ * when compiled with -betterC.
+ *
+ * This produces slighly different errors depending on whether the
+ * druntime contains TypeInfo declarations.
+ */
+module nortti;
+
+//----------------------------------------------------------------------
+
+void function1()
+{
+    // This only fails for the miniRT version
+    alias A = typeof(typeid(int));
+}
+
+//----------------------------------------------------------------------
+
+void function2()
+{
+    // This always fails
+    auto a = typeid(int);
+}
+
+//----------------------------------------------------------------------
+
+struct SPostblit
+{
+    this(this)
+    {
+    }
+}
+
+void function3()
+{
+    SPostblit[4] sarr;
+    SPostblit post;
+    sarr[0..3] = post;
+}
+
+//----------------------------------------------------------------------
+
+struct TestStruct
+{
+}
+
+void function4()
+{
+    auto s = new TestStruct();
+}
+
+//----------------------------------------------------------------------
+
+class TestClass
+{
+}
+
+void function5()
+{
+    auto c = new TestClass();
+}

--- a/test/fail_compilation/nortti_bc.d
+++ b/test/fail_compilation/nortti_bc.d
@@ -1,0 +1,6 @@
+/**
+ * EXTRA_SOURCES imports/nortti.d
+ * REQUIRED_ARGS: -betterC
+ */
+
+// Real test is in imports/nortti.d

--- a/test/fail_compilation/nortti_mini.d
+++ b/test/fail_compilation/nortti_mini.d
@@ -1,0 +1,6 @@
+/**
+ * EXTRA_SOURCES: imports/nortti.d
+ * REQUIRED_ARGS: -betterC -Irunnable/extra-files/miniRT -defaultlib= -release
+ */
+
+// Real test is in imports/nortti.d

--- a/test/runnable/extra-files/miniRT/object.d
+++ b/test/runnable/extra-files/miniRT/object.d
@@ -1,0 +1,11 @@
+module object;
+
+class Object
+{
+}
+
+version(D_LP64 )
+    alias size_t = ulong;
+else
+    alias size_t = uint;
+alias string = immutable(char)[];

--- a/test/runnable/imports/nortti.d
+++ b/test/runnable/imports/nortti.d
@@ -1,0 +1,58 @@
+/**
+ * This module contains code which is supposed to work without
+ * runtime type information (RTTI). The code must work for these 3
+ * cases:
+ *
+ * * standard druntime with RTTI
+ * * standard druntime with -betterC (implies noRTTI)
+ * * druntime without TypeInfo classes and -betterC
+ */
+module nortti;
+
+struct S
+{
+    int field1;
+    string field2;
+
+    void foo() {}
+    ~this() {}
+    this(this) {}
+}
+
+interface I
+{
+    void foo();
+}
+
+class C : I
+{
+    int field1;
+    string field2;
+
+    void foo() {}
+    this() {}
+    ~this() {}
+}
+
+class C2 : C
+{
+    override void foo() {}
+    void foo2() {}
+}
+
+void foo(A...)(A args)
+{
+    uint[A.length] bar;
+}
+
+void baz()
+{
+    foo(1, null, "quux");
+}
+
+int testNORTTI()
+{
+    S str;
+    C2 c;
+    return 0;
+}

--- a/test/runnable/nortti_bc.d
+++ b/test/runnable/nortti_bc.d
@@ -1,0 +1,12 @@
+/**
+ * EXTRA_SOURCES: imports/nortti.d
+ * REQUIRED_ARGS: -betterC
+ */
+
+// Real test is in imports/nortti.d
+import nortti;
+
+int main()
+{
+    return testNORTTI();
+}

--- a/test/runnable/nortti_mini.d
+++ b/test/runnable/nortti_mini.d
@@ -1,0 +1,19 @@
+/**
+ * EXTRA_SOURCES: imports/nortti.d
+ * REQUIRED_ARGS: -betterC -Irunnable/extra-files/miniRT -defaultlib= -release
+ */
+
+// Real test is in imports/nortti.d
+import nortti;
+
+// TODO: Make this optional for betterC? But then we disable exception handling?
+version (Windows)
+{
+    extern(C) void _d_framehandler(void*) {}
+}
+
+/// extern(C) so we can run this with a minimal runtime
+extern(C) int main()
+{
+    return testNORTTI();
+}

--- a/test/runnable/nortti_std.d
+++ b/test/runnable/nortti_std.d
@@ -1,0 +1,11 @@
+/**
+ * EXTRA_SOURCES: imports/nortti.d
+ */
+
+// Real test is in imports/nortti.d
+import nortti;
+
+int main()
+{
+    return testNORTTI();
+}


### PR DESCRIPTION
Continued from https://github.com/D-Programming-GDC/GDC/pull/100

This pull request adds an `noRTTI` flag in `global.params` which disables type info generation. Additionally it creates errors for code which accesses TypeInfo information (`auto a = typeid(int)`, etc). For DMD, this flag is enabled with `-betterC`, other compilers might do the same or add a special compiler option. As @yebblies refactored the TypeInfo implementation some time ago in preparation fo this it's now possible to do all of this after semantic. This is supposed to make code like this: `alias A = typeof(typeid(int))` work. This pull request also supports runtimes which do not even have `TypeInfo` declarations in `object.d`. In that case code like `typeof(typeid...)` will not work. When using `-betterC` it won't show the `object.d is missing TypeInfo` error though, it will show a more user friendly `TypeInfo is not available with -betterC` message. The error messages are not very detailed right now. But as we basically agreed that most TypeInfo usage should be replaced with a templated interface it's not useful to add detailed error messages for stuff which should better be rewritten anyway.

Note: There are some indentation changes in `toobj.c`, so use the ignore-whitespace compare link: https://github.com/D-Programming-Language/dmd/pull/5105/files?w=0

Pull request summary:
- The first commit adds the global flag. It's a bool + string to allow other compilers to customize the error message. We'll probably implement a `-fno-rtti` flag matching the GCC standard flag and I'd like to have a `TypeInfo disabled by -fno-rtti` error message in that case.
- The second commit is not really related, but required to make the test cases work with a minimal runtime. It disables the call to `_d_dso_registry` in `betterC` mode.
- The third commit implements noRTTI and the last commit adds test cases.

Some open questions:
- What is the code in https://github.com/D-Programming-Language/dmd/blob/master/src/todt.c#L699 doing? AFAIK The vptr is an extra symbol and is the first field in the class init data. This is followed by class members, but what is the code linked above doing and is it safe to disable this? It references the classinfo so it's a problem for noRTTI.
- Regarding the fail_compilation tests: I'd like to test the compiler output. However, unlike in sematic the compiler only reports a few errors at once from the glue layer. Do I really have to make every test a single file?

WIP:
- Need to write some more fail_compilation tests.

ping @ibuclaw @JinShil @yebblies @epi
