### PR TITLE
Include D sources in tags scanning

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -1,6 +1,6 @@
 INSTALL_DIR=$(PWD)/../install
-ECTAGS_LANGS = Make,C,C++,Sh
-ECTAGS_FILES = src/*.[ch] src/backend/*.[ch] src/root/*.[ch] src/tk/*.[ch]
+ECTAGS_LANGS = Make,C,C++,D,Sh
+ECTAGS_FILES = src/*.[chd] src/backend/*.[chd] src/root/*.[chd] src/tk/*.[chd]
 
 .PHONY: all clean test install auto-tester-build auto-tester-test
 


### PR DESCRIPTION
Now that dmd has converted majority of its sources to D the call to ctags should support it.

Development of ctags has recently been moved to

https://github.com/universal-ctags/ctags/commits/master

and has had D support for months.
