### PR TITLE
replace usage of slow slist

### DIFF
--- a/src/backend/dt.c
+++ b/src/backend/dt.c
@@ -318,7 +318,6 @@ dt_t **dtdtoff(dt_t **pdtend, dt_t *dt, unsigned offset)
     s->Sflags |= SFLnodebug;
     s->Stype = t;
     s->Sdt = dt;
-    slist_add(s);
     outdata(s);
     return dtxoff(pdtend, s, offset);
 }

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -43,10 +43,6 @@ static int elfreed = 0;                 /* number of freed elems        */
 static int eprm_cnt;                    /* max # of allocs at any point */
 #endif
 
-#if TARGET_OSX
-extern void slist_add(Symbol *s);
-#endif
-
 /*******************************
  * Do our own storage allocation of elems.
  */
@@ -1254,7 +1250,6 @@ elem *el_picvar(symbol *s)
                      */
                     tls_get_addr_sym = symbol_name("___tls_get_addr",SCglobal,type_fake(TYjfunc));
                     symbol_keep(tls_get_addr_sym);
-                    slist_add(tls_get_addr_sym);
                 }
                 if (x == 1)
                     e = el_una(OPind, TYnptr, e);

--- a/src/backend/global.h
+++ b/src/backend/global.h
@@ -348,9 +348,7 @@ SYMIDX symbol_add(Symbol *s);
 void freesymtab(Symbol **stab, SYMIDX n1, SYMIDX n2);
 Symbol * symbol_copy(Symbol *s);
 Symbol * symbol_searchlist(symlist_t sl, const char *vident);
-void slist_add(Symbol *s);
-void slist_reset();
-
+void symbol_reset(Symbol *s);
 
 #if TX86
 // cg87.c
@@ -502,4 +500,3 @@ int  lnx_attributes(int hinttype,const void *hint, type **ptyp, tym_t *ptym,int 
 #endif
 
 #endif /* GLOBAL_H */
-

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -126,6 +126,14 @@ static Outbuffer *local_symbuf;
 static Outbuffer *public_symbuf;
 static Outbuffer *extern_symbuf;
 
+static void reset_symbols(Outbuffer *buf)
+{
+    symbol **p = (symbol **)buf->buf;
+    const size_t n = buf->size() / sizeof(symbol *);
+    for (size_t i = 0; i < n; ++i)
+        symbol_reset(p[i]);
+}
+
 struct Comdef { symbol *sym; targ_size_t size; int count; };
 static Outbuffer *comdef_symbuf;        // Comdef's are stored here
 
@@ -436,13 +444,21 @@ Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
         local_symbuf = new Outbuffer(sizeof(symbol *) * SYM_TAB_INIT);
     local_symbuf->setsize(0);
 
-    if (!public_symbuf)
+    if (public_symbuf)
+    {
+        reset_symbols(public_symbuf);
+        public_symbuf->setsize(0);
+    }
+    else
         public_symbuf = new Outbuffer(sizeof(symbol *) * SYM_TAB_INIT);
-    public_symbuf->setsize(0);
 
-    if (!extern_symbuf)
+    if (extern_symbuf)
+    {
+        reset_symbols(extern_symbuf);
+        extern_symbuf->setsize(0);
+    }
+    else
         extern_symbuf = new Outbuffer(sizeof(symbol *) * SYM_TAB_INIT);
-    extern_symbuf->setsize(0);
 
     if (!comdef_symbuf)
         comdef_symbuf = new Outbuffer(sizeof(symbol *) * SYM_TAB_INIT);

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -378,9 +378,16 @@ MsCoffObj *MsCoffObj::init(Outbuffer *objbuf, const char *filename, const char *
     string_table->setsize(0);
     string_table->write32(4);           // first 4 bytes are length of string table
 
-    if (!symbuf)
+    if (symbuf)
+    {
+        symbol **p = (symbol **)symbuf->buf;
+        const size_t n = symbuf->size() / sizeof(symbol *);
+        for (size_t i = 0; i < n; ++i)
+            symbol_reset(p[i]);
+        symbuf->setsize(0);
+    }
+    else
         symbuf = new Outbuffer(sizeof(symbol *) * SYM_TAB_INIT);
-    symbuf->setsize(0);
 
     if (!syment_buf)
         syment_buf = new Outbuffer(sizeof(SymbolTable32) * SYM_TAB_INIT);

--- a/src/backend/rtlsym.c
+++ b/src/backend/rtlsym.c
@@ -85,14 +85,14 @@ void rtlsym_init()
  * Reset the symbols for the case when we are generating multiple
  * .OBJ files from one compile.
  */
-
 #if MARS
 
 void rtlsym_reset()
 {
     clib_inited = 0;            // reset CLIB symbols, too
     for (size_t i = 0; i < RTLSYM_MAX; i++)
-    {   rtlsym[i]->Sxtrnnum = 0;
+    {
+        rtlsym[i]->Sxtrnnum = 0;
         rtlsym[i]->Stypidx = 0;
     }
 }

--- a/src/backend/symbol.c
+++ b/src/backend/symbol.c
@@ -2269,43 +2269,20 @@ void symbol_gendebuginfo()
 
 #endif
 
-/************************************
- * Add symbol to global slist, which are symbols we need to keep around
- * for next obj file to be created.
- */
-
-static Symbol **slist;
-static size_t slist_length;
-
-void slist_add(Symbol *s)
-{
-    slist = (Symbol **)realloc(slist, (slist_length + 1) * sizeof(Symbol *));
-    slist[slist_length++] = s;
-}
-
 /*************************************
- * Resets Symbols so they are now "externs" to the next obj file being created.
+ * Reset Symbol so that it's now an "extern" to the next obj file being created.
  */
-
-void slist_reset()
+void symbol_reset(Symbol *s)
 {
-    //printf("slist_reset()\n");
-    for (size_t i = 0; i < slist_length; ++i)
-    {
-        Symbol *s = slist[i];
-
-        s->Soffset = 0;
-        s->Sxtrnnum = 0;
-        s->Stypidx = 0;
-        s->Sflags &= ~(STRoutdef | SFLweak);
-        if (s->Sclass == SCglobal || s->Sclass == SCcomdat ||
-            s->Sfl == FLudata || s->Sclass == SCstatic)
-        {   s->Sclass = SCextern;
-            s->Sfl = FLextern;
-        }
+    s->Soffset = 0;
+    s->Sxtrnnum = 0;
+    s->Stypidx = 0;
+    s->Sflags &= ~(STRoutdef | SFLweak);
+    if (s->Sclass == SCglobal || s->Sclass == SCcomdat ||
+        s->Sfl == FLudata || s->Sclass == SCstatic)
+    {   s->Sclass = SCextern;
+        s->Sfl = FLextern;
     }
 }
-
-
 
 #endif /* !SPP */

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -463,7 +463,6 @@ type *type_enum(const char *name, type *tbase)
     s->Sclass = SCenum;
     s->Senum = (enum_t *) MEM_PH_CALLOC(sizeof(enum_t));
     s->Senum->SEflags |= SENforward;        // forward reference
-    slist_add(s);
 
     type *t = type_allocn(TYenum, tbase);
     t->Ttag = (Classsym *)s;            // enum tag name
@@ -505,7 +504,6 @@ type *type_struct_class(const char *name, unsigned alignsize, unsigned structsiz
     t->Ttag = (Classsym *)s;            // structure tag name
     t->Tcount++;
     s->Stype = t;
-    slist_add(s);
     t->Tcount++;
     return t;
 }

--- a/src/glue.c
+++ b/src/glue.c
@@ -237,7 +237,6 @@ void obj_start(char *srcfile)
     //printf("obj_start()\n");
 
     rtlsym_reset();
-    slist_reset();
     clearStringTab();
 
 #if TARGET_WINDOS
@@ -375,7 +374,6 @@ void genObjFile(Module *m, bool multiobj)
         m->cov->Sfl = FLdata;
         dtnzeros(&m->cov->Sdt, 4 * m->numlines);
         outdata(m->cov);
-        slist_add(m->cov);
 
         m->covb = (unsigned *)calloc((m->numlines + 32) / 32, sizeof(*m->covb));
     }
@@ -390,7 +388,7 @@ void genObjFile(Module *m, bool multiobj)
     if (global.params.cov)
     {
         /* Generate
-         *      bit[numlines] __bcoverage;
+         *  private bit[numlines] __bcoverage;
          */
         Symbol *bcov = symbol_calloc("__bcoverage");
         bcov->Stype = type_fake(TYuint);

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -45,9 +45,6 @@
 
 typedef Array<struct Symbol *> Symbols;
 
-void slist_add(Symbol *s);
-void slist_reset();
-
 Classsym *fake_classsym(Identifier *id);
 type *Type_toCtype(Type *t);
 dt_t **ClassReferenceExp_toInstanceDt(ClassReferenceExp *ce, dt_t **pdt);
@@ -187,7 +184,6 @@ Symbol *toSymbol(Dsymbol *s)
                 }
                 s->Sclass = SCextern;
                 s->Sfl = FLextern;
-                slist_add(s);
                 /* if it's global or static, then it needs to have a qualified but unmangled name.
                  * This gives some explanation of the separation in treating name mangling.
                  * It applies to PDB format, but should apply to CV as PDB derives from CV.
@@ -281,7 +277,6 @@ Symbol *toSymbol(Dsymbol *s)
             //printf("\tid = '%s'\n", id);
             //printf("\ttype = %s\n", fd->type->toChars());
             Symbol *s = symbol_calloc(id);
-            slist_add(s);
 
             s->prettyIdent = fd->toPrettyChars(true);
             s->Sclass = SCglobal;
@@ -378,7 +373,6 @@ Symbol *toSymbol(Dsymbol *s)
             Symbol *s = toSymbolX(cd, "__Class", SCextern, scc->Stype, "Z");
             s->Sfl = FLextern;
             s->Sflags |= SFLnodebug;
-            slist_add(s);
             result = s;
         }
 
@@ -394,7 +388,6 @@ Symbol *toSymbol(Dsymbol *s)
             Symbol *s = toSymbolX(id, "__Interface", SCextern, scc->Stype, "Z");
             s->Sfl = FLextern;
             s->Sflags |= SFLnodebug;
-            slist_add(s);
             result = s;
         }
 
@@ -410,7 +403,6 @@ Symbol *toSymbol(Dsymbol *s)
             Symbol *s = toSymbolX(m, "__ModuleInfo", SCextern, scc->Stype, "Z");
             s->Sfl = FLextern;
             s->Sflags |= SFLnodebug;
-            slist_add(s);
             result = s;
         }
     };
@@ -456,7 +448,6 @@ static Symbol *toImport(Symbol *sym)
     s->Stype = t;
     s->Sclass = SCextern;
     s->Sfl = FLextern;
-    slist_add(s);
     return s;
 }
 
@@ -527,7 +518,6 @@ Symbol *toVtblSymbol(ClassDeclaration *cd)
         s->Sflags |= SFLnodebug;
         s->Sfl = FLextern;
         cd->vtblsym = s;
-        slist_add(s);
     }
     return cd->vtblsym;
 }
@@ -547,7 +537,6 @@ Symbol *toInitializer(AggregateDeclaration *ad)
         StructDeclaration *sd = ad->isStructDeclaration();
         if (sd)
             s->Salignment = sd->alignment;
-        slist_add(s);
         ad->sinit = s;
     }
     return ad->sinit;
@@ -565,7 +554,6 @@ Symbol *toInitializer(EnumDeclaration *ed)
         ed->ident = ident_save;
         s->Sfl = FLextern;
         s->Sflags |= SFLnodebug;
-        slist_add(s);
         ed->sinit = s;
     }
     return ed->sinit;
@@ -585,7 +573,6 @@ Symbol *toModuleAssert(Module *m)
         m->massert = toSymbolX(m, "__assert", SCextern, t, "FiZv");
         m->massert->Sfl = FLextern;
         m->massert->Sflags |= SFLnodebug | SFLexit;
-        slist_add(m->massert);
     }
     return m->massert;
 }
@@ -600,7 +587,6 @@ Symbol *toModuleUnittest(Module *m)
         m->munittest = toSymbolX(m, "__unittest_fail", SCextern, t, "FiZv");
         m->munittest->Sfl = FLextern;
         m->munittest->Sflags |= SFLnodebug;
-        slist_add(m->munittest);
     }
     return m->munittest;
 }
@@ -618,7 +604,6 @@ Symbol *toModuleArray(Module *m)
         m->marray = toSymbolX(m, "__array", SCextern, t, "Z");
         m->marray->Sfl = FLextern;
         m->marray->Sflags |= SFLnodebug | SFLexit;
-        slist_add(m->marray);
     }
     return m->marray;
 }
@@ -660,7 +645,6 @@ Symbol *aaGetSymbol(TypeAArray *taa, const char *func, int flags)
         // Create new Symbol
 
         Symbol *s = symbol_calloc(id);
-        slist_add(s);
         s->Sclass = SCextern;
         s->Ssymnum = -1;
         symbol_func(s);
@@ -691,7 +675,6 @@ Symbol* toSymbol(StructLiteralExp *sle)
     dt_t *d = NULL;
     Expression_toDt(sle, &d);
     s->Sdt = d;
-    slist_add(s);
     outdata(s);
     return sle->sym;
 }
@@ -710,7 +693,6 @@ Symbol* toSymbol(ClassReferenceExp *cre)
     dt_t *d = NULL;
     ClassReferenceExp_toInstanceDt(cre, &d);
     s->Sdt = d;
-    slist_add(s);
     outdata(s);
     return cre->value->sym;
 }
@@ -738,7 +720,6 @@ Symbol* toSymbolCpp(ClassDeclaration *cd)
         s->Sfl = FLdata;
         s->Sflags |= SFLnodebug;
         cpp_type_info_ptr_toDt(cd, &s->Sdt);
-        slist_add(s);
         outdata(s);
         cd->cpp_type_info_ptr_sym = s;
     }
@@ -762,7 +743,5 @@ Symbol *toSymbolCppTypeInfo(ClassDeclaration *cd)
     TYPE *t = type_fake(TYnptr);
     t->Tcount++;
     s->Stype = t;
-    slist_add(s);
     return s;
 }
-


### PR DESCRIPTION
- directly reset symbols after writing them to an object file
  (it's very cheap when they are still in cache)
- external references are already reset right away
  in outfixlist
- no need to reset symbols that cannot be referenced
  (e.g. locals, to SCenum/SCstruct symbols)
- reset tls helper with rtlsym_reset
