### PR TITLE
[optimize] Reduce DsymbolExp object creation

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -175,17 +175,20 @@ public:
             auto tiargs = new Objects();
             tiargs.push(type);
             auto ti = new TemplateInstance(loc, Type.rtinfo, tiargs);
+
             Scope* sc3 = ti.tempdecl._scope.startCTFE();
             sc3.tinst = sc.tinst;
             sc3.minst = sc.minst;
             if (isDeprecated())
                 sc3.stc |= STCdeprecated;
+
             ti.semantic(sc3);
             ti.semantic2(sc3);
             ti.semantic3(sc3);
-            Expression e = new DsymbolExp(Loc(), ti.toAlias(), 0);
-            e = e.semantic(sc3);
+            auto e = DsymbolExp.resolve(Loc(), sc3, ti.toAlias(), false);
+
             sc3.endCTFE();
+
             e = e.ctfeInterpret();
             getRTInfo = e;
         }

--- a/src/expression.h
+++ b/src/expression.h
@@ -312,6 +312,7 @@ public:
 
     DsymbolExp(Loc loc, Dsymbol *s, bool hasOverloads = false);
     Expression *semantic(Scope *sc);
+    static Expression resolve(Loc loc, Scope *sc, Dsymbol *s, bool hasOverloads);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }

--- a/src/func.d
+++ b/src/func.d
@@ -2087,7 +2087,7 @@ public:
                             if (isStatic())
                             {
                                 // The monitor is in the ClassInfo
-                                vsync = new DotIdExp(loc, new DsymbolExp(loc, cd), Id.classinfo);
+                                vsync = new DotIdExp(loc, DsymbolExp.resolve(loc, sc2, cd, false), Id.classinfo);
                             }
                             else
                             {

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -6829,8 +6829,8 @@ public:
             if (tindex)
                 eindex = new TypeExp(loc, tindex);
             else if (sindex)
-                eindex = new DsymbolExp(loc, sindex);
-            Expression e = new IndexExp(loc, new DsymbolExp(loc, s), eindex);
+                eindex = DsymbolExp.resolve(loc, sc, sindex, false);
+            Expression e = new IndexExp(loc, DsymbolExp.resolve(loc, sc, s, false), eindex);
             e = e.semantic(sc);
             if (e.op == TOKerror)
                 *pt = Type.terror;
@@ -6844,7 +6844,7 @@ public:
         if (tindex)
             tindex.resolve(loc, sc, &eindex, &tindex, &sindex);
         if (sindex)
-            eindex = new DsymbolExp(loc, sindex);
+            eindex = DsymbolExp.resolve(loc, sc, sindex, false);
         if (!eindex)
         {
             .error(loc, "index is %s not an expression", oindex.toChars());
@@ -7014,7 +7014,7 @@ public:
                         VarDeclaration v = s.isVarDeclaration();
                         FuncDeclaration f = s.isFuncDeclaration();
                         if (intypeid || !v && !f)
-                            e = new DsymbolExp(loc, s);
+                            e = DsymbolExp.resolve(loc, sc, s, false);
                         else
                             e = new VarExp(loc, s.isDeclaration());
                         resolveExprType(loc, sc, e, i, pe, pt);
@@ -8013,8 +8013,7 @@ public:
         }
         if (s.isImport() || s.isModule() || s.isPackage())
         {
-            e = new DsymbolExp(e.loc, s, 0);
-            e = e.semantic(sc);
+            e = DsymbolExp.resolve(e.loc, sc, s, false);
             return e;
         }
         OverloadSet o = s.isOverloadSet();
@@ -8868,8 +8867,7 @@ public:
         }
         if (s.isImport() || s.isModule() || s.isPackage())
         {
-            e = new DsymbolExp(e.loc, s, 0);
-            e = e.semantic(sc);
+            e = DsymbolExp.resolve(e.loc, sc, s, false);
             return e;
         }
         OverloadSet o = s.isOverloadSet();

--- a/src/traits.d
+++ b/src/traits.d
@@ -795,7 +795,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 return ex.semantic(sc);
             }
         }
-        return (new DsymbolExp(e.loc, s)).semantic(sc);
+        return DsymbolExp.resolve(e.loc, sc, s, false);
     }
     else if (e.ident == Id.hasMember || e.ident == Id.getMember || e.ident == Id.getOverloads || e.ident == Id.getVirtualMethods || e.ident == Id.getVirtualFunctions)
     {


### PR DESCRIPTION
`DsymbolExp` is used as the intermediate object during semantic process. In some places, especially in `IdentifierExp.semantic`, it's immediately converted to the actual derived `Expression` objects of the corresponding dsymbols, and it's merely abuse of heap memory.

By this change, the number of `DsymbolExp` allocations will be drastically reduced.

Druntime build: 22577 -> 36
Phobos build: 209508 -> 36746
