### PR TITLE
trivial refactor: inlineScan => inlineScanModule

### DIFF
--- a/src/inline.d
+++ b/src/inline.d
@@ -1835,7 +1835,7 @@ Lno:
  * Params:
  *    m = module to scan
  */
-public void inlineScan(Module m)
+public void inlineScanModule(Module m)
 {
     if (m.semanticRun != PASSsemantic3done)
         return;

--- a/src/mars.d
+++ b/src/mars.d
@@ -1526,7 +1526,7 @@ Language changes listed by -transition=id:
             Module m = modules[i];
             if (global.params.verbose)
                 fprintf(global.stdmsg, "inline scan %s\n", m.toChars());
-            inlineScan(m);
+            inlineScanModule(m);
         }
     }
     // Do not attempt to generate output files if errors or warnings occurred


### PR DESCRIPTION
This rename is done because of the several `inlineScan` functions in `inline.d` that are different from each other, and so it's easier if they have different names.
