### PR TITLE
eliminate redundant inline scanning

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -393,6 +393,7 @@ enum FUNCFLAGsafetyInprocess  = 2;      // working on determining safety
 enum FUNCFLAGnothrowInprocess = 4;      // working on determining nothrow
 enum FUNCFLAGnogcInprocess    = 8;      // working on determining @nogc
 enum FUNCFLAGreturnInprocess  = 0x10;   // working on inferring 'return' for parameters
+enum FUNCFLAGinlineScanned    = 0x20;   // function has been scanned for inline possibilities
 
 /***********************************************************
  */


### PR DESCRIPTION
While working on a fix to do better delegate inlining, I discovered that the inliner is constantly rescanning functions for inline possibilities. Added a flag `FUNCFLAGinlineScanned` to put a stop to that, and a flag `again` to enable rescanning in case of delegate parameters.

The latter isn't complete yet, but this PR won't hurt.
