### PR TITLE
Issue 15116 & 15117 - fix bugs in DotIdExp.semanticY

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -8367,9 +8367,12 @@ public:
                 if (v)
                 {
                     //printf("DotIdExp:: Identifier '%s' is a variable, type '%s'\n", toChars(), v->type->toChars());
-                    if (v.inuse)
+                    if (!v.type)
                     {
-                        error("circular reference to '%s'", v.toChars());
+                        if (v.inuse)
+                            error("circular reference to '%s'", v.toChars());
+                        else
+                            error("forward reference of %s %s", s.kind(), s.toChars());
                         return new ErrorExp();
                     }
                     if (v.needThis())

--- a/src/expression.d
+++ b/src/expression.d
@@ -8449,8 +8449,9 @@ public:
                 {
                     if (eleft)
                     {
-                        error("cannot have e.tuple");
-                        return new ErrorExp();
+                        e = new DotVarExp(loc, eleft, tup);
+                        e = e.semantic(sc);
+                        return e;
                     }
                     e = new TupleExp(loc, tup);
                     e = e.semantic(sc);

--- a/test/fail_compilation/fail89.d
+++ b/test/fail_compilation/fail89.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail89.d(9): Error: circular reference to 'a'
+fail_compilation/fail89.d(9): Error: circular initialization of a
 ---
 */
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7682,6 +7682,21 @@ void test15116()
 }
 
 /***************************************************/
+// 15117
+
+template Mix15117()
+{
+    int y = { typeof(this)* s; return s ? s.mix.y : 0; }();
+}
+
+struct S15117
+{
+    int x = { typeof(this)* s; return s ? s.x : 0; }(); // OK
+
+    mixin Mix15117 mix;     // OK <- NG
+}
+
+/***************************************************/
 // 15126
 
 struct Json15126

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7660,6 +7660,28 @@ void test15045()
 }
 
 /***************************************************/
+// 15116
+
+alias TypeTuple15116(T...) = T;
+
+template Mix15116()
+{
+    TypeTuple15116!(int, int) tup;
+}
+
+struct S15116
+{
+    mixin Mix15116 mix;
+}
+
+void test15116()
+{
+    S15116 s;
+    auto x1 = s.tup;        // OK
+    auto x2 = s.mix.tup;    // OK <- NG
+}
+
+/***************************************************/
 // 15126
 
 struct Json15126


### PR DESCRIPTION
[Issue 15116](https://issues.dlang.org/show_bug.cgi?id=15116) - Unreasonable rejection of tuple field access via named mixin
[Issue 15117](https://issues.dlang.org/show_bug.cgi?id=15117) - Unreasonable circular reference error via named mixin
