### PR TITLE
[REG2.068.1] Issue 15079 - Assertion `fd->semanticRun == PASSsemantic3done' failed.

### DIFF
--- a/test/runnable/imports/a15079.d
+++ b/test/runnable/imports/a15079.d
@@ -1,0 +1,50 @@
+module imports.a15079;
+
+Vector!string parseAlgorithmName()
+{
+    assert(0);
+}
+
+struct Vector(ALLOC)
+{
+    @disable this(this);
+
+    RefCounted!(Vector, ALLOC) dupr()
+    {
+        assert(0);
+    }
+}
+
+struct RefCounted(T, ALLOC)
+{
+    ~this()
+    {
+        T* objc;
+        .destroy(*objc);
+    }
+}
+
+// ----
+
+void _destructRecurse(S)(ref S s)
+    if (is(S == struct))
+{
+    static if (__traits(hasMember, S, "__xdtor") &&
+               __traits(isSame, S, __traits(parent, s.__xdtor)))
+    {
+        s.__xdtor();
+    }
+}
+
+void destroy(T)(ref T obj) if (is(T == struct))
+{
+    _destructRecurse(obj);
+    () @trusted {
+        auto buf = (cast(ubyte*) &obj)[0 .. T.sizeof];
+        auto init = cast(ubyte[])typeid(T).init();
+        if (init.ptr is null) // null ptr means initialize to 0s
+            buf[] = 0;
+        else
+            buf[] = init[];
+    } ();
+}

--- a/test/runnable/test15079.d
+++ b/test/runnable/test15079.d
@@ -1,0 +1,5 @@
+module test15079;
+
+import imports.a15079;
+
+void main() {}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15079

It was another surface of issue 15044, and fixed from 2.068.2 - the attribute inference problem had sent a function which is not yet completed semantic analysis to glue layer, and the breaking of internal invariance has been detected.

Add test case only.
