### PR TITLE
Add virtual method isAnonDeclaration to Dsymbol

### DIFF
--- a/src/attrib.d
+++ b/src/attrib.d
@@ -701,6 +701,11 @@ public:
         return (isunion ? "anonymous union" : "anonymous struct");
     }
 
+    override final AnonDeclaration isAnonDeclaration()
+    {
+        return this;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/attrib.d
+++ b/src/attrib.d
@@ -595,6 +595,9 @@ public:
     bool isunion;
     structalign_t alignment;
     int sem;        // 1 if successful semantic()
+    uint anonoffset;        // offset of anonymous struct
+    uint anonstructsize;    // size of anonymous struct
+    uint anonalignsize;     // size of anonymous struct for alignment purposes
 
     extern (D) this(Loc loc, bool isunion, Dsymbols* decl)
     {
@@ -661,8 +664,8 @@ public:
                 if (this.isunion)
                     offset = 0;
             }
-            uint anonstructsize = ad.structsize;
-            uint anonalignsize = ad.alignsize;
+            anonstructsize = ad.structsize;
+            anonalignsize = ad.alignsize;
             ad.structsize = savestructsize;
             ad.alignsize = savealignsize;
             if (fieldstart == ad.fields.dim)
@@ -684,7 +687,7 @@ public:
             /* Given the anon 'member's size and alignment,
              * go ahead and place it.
              */
-            uint anonoffset = AggregateDeclaration.placeField(poffset, anonstructsize, anonalignsize, alignment, &ad.structsize, &ad.alignsize, isunion);
+            anonoffset = AggregateDeclaration.placeField(poffset, anonstructsize, anonalignsize, alignment, &ad.structsize, &ad.alignsize, isunion);
             // Add to the anon fields the base offset of this anonymous aggregate
             //printf("anon fields, anonoffset = %d\n", anonoffset);
             for (size_t i = fieldstart; i < ad.fields.dim; i++)

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -128,6 +128,9 @@ public:
     bool isunion;
     structalign_t alignment;
     int sem;                    // 1 if successful semantic()
+    unsigned anonoffset;        // offset of anonymous struct
+    unsigned anonstructsize;    // size of anonymous struct
+    unsigned anonalignsize;     // size of anonymous struct for alignment purposes
 
     AnonDeclaration(Loc loc, bool isunion, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -134,6 +134,7 @@ public:
     void semantic(Scope *sc);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind();
+    AnonDeclaration *isAnonDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1143,6 +1143,11 @@ public:
         return null;
     }
 
+    AnonDeclaration isAnonDeclaration()
+    {
+        return null;
+    }
+
     OverloadSet isOverloadSet()
     {
         return null;

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -272,6 +272,7 @@ public:
     virtual DeleteDeclaration *isDeleteDeclaration() { return NULL; }
     virtual SymbolDeclaration *isSymbolDeclaration() { return NULL; }
     virtual AttribDeclaration *isAttribDeclaration() { return NULL; }
+    virtual AnonDeclaration *isAnonDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
Helper for GDC.  Because the number of bugs arising from the flat `AggregrateDeclaration::fields` list is getting ridiculous.

I need a nice way to detect AnonDeclarations properly enclose anonymous union and struct members inside an unnamed record.
