### PR TITLE
mtype.d: refactor: use nested delegates for _foreach()

### DIFF
--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -772,13 +772,14 @@ public:
     void paramsToDecoBuffer(Parameters* parameters)
     {
         //printf("Parameter::paramsToDecoBuffer()\n");
-        Parameter._foreach(parameters, &paramsToDecoBufferDg, cast(void*)this);
-    }
 
-    static int paramsToDecoBufferDg(void* ctx, size_t n, Parameter p)
-    {
-        p.accept(cast(Visitor)ctx);
-        return 0;
+        int paramsToDecoBufferDg(size_t n, Parameter p)
+        {
+            p.accept(this);
+            return 0;
+        }
+
+        Parameter._foreach(parameters, &paramsToDecoBufferDg);
     }
 
     override void visit(Parameter p)

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -925,12 +925,8 @@ public:
     virtual void accept(Visitor *v) { v->visit(this); }
 
     static Parameters *arraySyntaxCopy(Parameters *parameters);
-    static int isTPL(Parameters *parameters);
     static size_t dim(Parameters *parameters);
     static Parameter *getNth(Parameters *parameters, d_size_t nth, d_size_t *pn = NULL);
-
-    typedef int (*ForeachDg)(void *ctx, size_t paramidx, Parameter *param);
-    static int foreach(Parameters *parameters, ForeachDg dg, void *ctx, size_t *pn=NULL);
 };
 
 bool arrayTypeCompatible(Loc loc, Type *t1, Type *t2);


### PR DESCRIPTION
Replace fake C++ nested functions with real D delegates for mtype._foreach()
