### PR TITLE
Remove global.gag check in DsymbolExp.resolve()

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -5417,7 +5417,8 @@ public:
     Dsymbol aliasdecl;          // !=null if instance is an alias for its sole member
     TemplateInstance inst;      // refer to existing instance
     ScopeDsymbol argsym;        // argument symbol table
-    int nest;                   // for recursion detection
+    int inuse;                  // for recursive expansion detection
+    int nest;                   // for recursive pretty printing detection
     bool semantictiargsdone;    // has semanticTiargs() been done?
     bool havetempdecl;          // if used second constructor
     bool gagged;                // if the instantiation is done with error gagging

--- a/src/template.h
+++ b/src/template.h
@@ -308,7 +308,8 @@ public:
     Dsymbol *aliasdecl;                 // !=NULL if instance is an alias for its sole member
     TemplateInstance *inst;             // refer to existing instance
     ScopeDsymbol *argsym;               // argument symbol table
-    int nest;                           // for recursion detection
+    int inuse;                          // for recursive expansion detection
+    int nest;                           // for recursive pretty printing detection
     bool semantictiargsdone;            // has semanticTiargs() been done?
     bool havetempdecl;                  // if used second constructor
     bool gagged;                        // if the instantiation is done with error gagging

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -1,17 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test8556.d(33): Error: circular initialization of isSliceable
-fail_compilation/test8556.d(34): Error: circular initialization of isSliceable
-fail_compilation/test8556.d(47): Error: template test8556.grabExactly cannot deduce function from argument types !()(Circle!(uint[])), candidates are:
-fail_compilation/test8556.d(33):        test8556.grabExactly(R)(R range) if (!isSliceable!R)
-fail_compilation/test8556.d(34):        test8556.grabExactly(R)(R range) if (isSliceable!R)
-fail_compilation/test8556.d(22): Error: template instance test8556.isSliceable!(Circle!(uint[])) error instantiating
-fail_compilation/test8556.d(27):        while looking for match for Grab!(Circle!(uint[]))
-fail_compilation/test8556.d(58): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
-fail_compilation/test8556.d(61): Error: no [] operator overload for type Circle!(uint[])
+fail_compilation/test8556.d(21): Error: template instance test8556.Grab!(Circle!(uint[])) does not match template declaration Grab(Range) if (!isSliceable!Range)
+fail_compilation/test8556.d(52): Error: template instance test8556.grab!(Circle!(uint[])) error instantiating
 ---
 */
+
 extern(C) int printf(const char*, ...);
 
 template isSliceable(R)


### PR DESCRIPTION
Separated from #4731.

When an instance that will be converted to a constant exists, the instance representation "foo!tiargs" is treated like a variable name, and its recursive appearance check (note that it's equivalent with a recursive instantiation of foo) is done separately from the circular initialization check for the eponymous enum variable declaration.

By the approach, we can remove problematic `global.gag` check in `DsymbolExp::semantic()` without breaking `fail_compilation/diag10141.d`.
