### PR TITLE
Move Lexer.isValidIdentifier static method to Identifier class

### DIFF
--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -764,7 +764,7 @@ public:
             dst = modules; // and so this module goes into global module symbol table
             /* Check to see if module name is a valid identifier
              */
-            if (!Lexer.isValidIdentifier(this.ident.toChars()))
+            if (!Identifier.isValidIdentifier(this.ident.toChars()))
                 error("has non-identifier characters in filename, use module declaration instead");
         }
         // Add internal used functions in 'object' module members.

--- a/src/lexer.d
+++ b/src/lexer.d
@@ -2437,36 +2437,6 @@ public:
             *dc = cast(char*)buf.extractData();
     }
 
-    /**********************************
-     * Determine if string is a valid Identifier.
-     * Placed here because of commonality with Lexer functionality.
-     * Returns:
-     *      0       invalid
-     */
-    final static bool isValidIdentifier(const(char)* p)
-    {
-        size_t len;
-        size_t idx;
-        if (!p || !*p)
-            goto Linvalid;
-        if (*p >= '0' && *p <= '9') // beware of isdigit() on signed chars
-            goto Linvalid;
-        len = strlen(p);
-        idx = 0;
-        while (p[idx])
-        {
-            dchar_t dc;
-            const(char)* q = utf_decodeChar(cast(char*)p, len, &idx, &dc);
-            if (q)
-                goto Linvalid;
-            if (!((dc >= 0x80 && isUniAlpha(dc)) || isalnum(dc) || dc == '_'))
-                goto Linvalid;
-        }
-        return true;
-    Linvalid:
-        return false;
-    }
-
     /********************************************
      * Combine two document comments into one,
      * separated by a newline.

--- a/src/mars.d
+++ b/src/mars.d
@@ -631,7 +631,7 @@ Language changes listed by -transition=id:
                             goto Lerror;
                         }
                     }
-                    else if (Lexer.isValidIdentifier(p + 12))
+                    else if (Identifier.isValidIdentifier(p + 12))
                     {
                         const(char)* ident = p + 12;
                         switch (strlen(ident))
@@ -857,7 +857,7 @@ Language changes listed by -transition=id:
                             goto Lerror;
                         DebugCondition.setGlobalLevel(cast(int)level);
                     }
-                    else if (Lexer.isValidIdentifier(p + 7))
+                    else if (Identifier.isValidIdentifier(p + 7))
                         DebugCondition.addGlobalIdent(p + 7);
                     else
                         goto Lerror;
@@ -883,7 +883,7 @@ Language changes listed by -transition=id:
                             goto Lerror;
                         VersionCondition.setGlobalLevel(cast(int)level);
                     }
-                    else if (Lexer.isValidIdentifier(p + 9))
+                    else if (Identifier.isValidIdentifier(p + 9))
                         VersionCondition.addGlobalIdent(p + 9);
                     else
                         goto Lerror;


### PR DESCRIPTION
For PR #5137.  `isValidIdentifier` is used in C++ code for other compiler backends, so it needs to remain as being `extern(C++)`.
