### PR TITLE
default to using optlink.exe instead of link.exe for Win32

### DIFF
--- a/src/link.d
+++ b/src/link.d
@@ -303,7 +303,7 @@ extern (C++) int runLINK()
                     linkcmd = linkcmdbuf.extractString();
                 }
                 else
-                    linkcmd = "link";
+                    linkcmd = "optlink";
             }
             int status = executecmd(linkcmd, p);
             if (lnkfilename)


### PR DESCRIPTION
Of course, if you set the environment variable `LINKCMD`, that will override whatever the compiler defaults to.
