### PR TITLE
add printAST()

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -2360,6 +2360,18 @@ public:
         return buf.extractString();
     }
 
+    /********************
+     * Print AST data structure in a nice format.
+     * Params:
+     *  indent = indentation level
+     */
+    void printAST(int indent = 0)
+    {
+        foreach (i; 0 .. indent)
+            printf(" ");
+        printf("%s %s\n", Token.toChars(op), type ? type.toChars() : "");
+    }
+
     final void error(const(char)* format, ...)
     {
         if (type != Type.terror)
@@ -7092,6 +7104,12 @@ public:
     {
         v.visit(this);
     }
+
+    override void printAST(int indent)
+    {
+        Expression.printAST(indent);
+        e1.printAST(indent + 2);
+    }
 }
 
 extern (C++) alias fp_t = UnionExp function(Loc loc, Type, Expression, Expression);
@@ -7392,6 +7410,13 @@ public:
     override void accept(Visitor v)
     {
         v.visit(this);
+    }
+
+    override void printAST(int indent)
+    {
+        Expression.printAST(indent);
+        e1.printAST(indent + 2);
+        e2.printAST(indent + 2);
     }
 }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -143,6 +143,7 @@ public:
 
     void print();
     char *toChars();
+    virtual void printAST(int ident = 0);
     void error(const char *format, ...);
     void warning(const char *format, ...);
     void deprecation(const char *format, ...);
@@ -741,6 +742,7 @@ public:
     Expression *resolveLoc(Loc loc, Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
+    void printAST(int ident);
 };
 
 typedef UnionExp (*fp_t)(Type *, Expression *, Expression *);
@@ -768,6 +770,7 @@ public:
     Expression *reorderSettingAAElem(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
+    void printAST(int ident);
 };
 
 class BinAssignExp : public BinExp


### PR DESCRIPTION
For a long time, there were functions called `dump` in dmd, in `dump.c`. These got removed a couple versions back, in favor of `print` which does nothing more than print the ASTs as source code.

Unfortunately, this does not work when needing to see what the data structures are. For example, `print` does not tell which AST nodes they are, nor the type.

This PR puts it back in, as `printAST`. It's a valuable debugging aid.
