### PR TITLE
Refactor detection of overlapping fields in StructInitializer semantic

### DIFF
--- a/src/init.d
+++ b/src/init.d
@@ -311,8 +311,7 @@ public:
                 for (size_t j = 0; j < nfields; j++)
                 {
                     VarDeclaration v2 = sd.fields[j];
-                    bool overlap = (vd.offset < v2.offset + v2.type.size() && v2.offset < vd.offset + vd.type.size());
-                    if (overlap && (*elements)[j])
+                    if (vd.isOverlappedWith(v2) && (*elements)[j])
                     {
                         error(loc, "overlapping initialization for field %s and %s", v2.toChars(), vd.toChars());
                         errors = true;


### PR DESCRIPTION
Front-end's part in fixing bug 183 in gdc.

In code like the following:

```
union Buf
{
    TypeInfo info;
    void[0] result;
}
Buf buf = { };
```

Because `result` is a zero sized type, the front-end would never detect the overlap in the following check:

```
(vd.offset < v2.offset + v2.size && v2.offset < vd.offset + vd.size)
=> (0 < 0 + 0 && 0 < 0 + 8);  // false
   (0 < 0 + 8 && 0 < 0 + 0);  // also false
```

This results in me seeing codegen such as union literals having more than one initializer being handed from the front-end.

```
union Buf buf = Buf(null, 0);   // ???
```
