### PR TITLE
Issue 15163 - Parser bug on double function call

### DIFF
--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -915,3 +915,17 @@ void test14388()
      * and the second instantiation had created the AST duplication.
      */
 }
+
+/***************************************************/
+// 15163
+
+void function() func15164(int[] arr)
+{
+    return () { };
+}
+
+void test15163()
+{
+    auto arr = [[0]];
+    func15164(arr[0])();
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15163

Add `allowAltSyntax` parameter to `isDeclarator`, and disable it from `parseStatement`.
