### PR TITLE
[REG2.069.0-b1] Issue 15181 - SYSCONFDIR is broken

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -1,3 +1,5 @@
+SHELL=bash
+
 # get OS and MODEL
 include osmodel.mak
 


### PR DESCRIPTION
Because things like `echo -n` don't necessarily work everywhere (including on OS X ...) and who actually remembers what is standard or not, so best to keep things familiar?

This is important for dmd 2.069 in order to get dmd working properly on OS X.
