### PR TITLE
Refactor: remove unneeded uses of reliesOnTident

### DIFF
--- a/src/dcast.d
+++ b/src/dcast.d
@@ -88,22 +88,16 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
             {
                 if (!t.deco)
                 {
-                    /* Can happen with:
-                     *    enum E { One }
-                     *    class A
-                     *    { static void fork(EDG dg) { dg(E.One); }
-                     *      alias void delegate(E) EDG;
-                     *    }
-                     * Should eventually make it work.
-                     */
                     e.error("forward reference to type %s", t.toChars());
                 }
-                else if (Type tx = reliesOnTident(t))
-                    e.error("forward reference to type %s", tx.toChars());
-                //printf("type %p ty %d deco %p\n", type, type->ty, type->deco);
-                //type = type->semantic(loc, sc);
-                //printf("type %s t %s\n", type->deco, t->deco);
-                e.error("cannot implicitly convert expression (%s) of type %s to %s", e.toChars(), e.type.toChars(), t.toChars());
+                else
+                {
+                    //printf("type %p ty %d deco %p\n", type, type.ty, type.deco);
+                    //type = type.semantic(loc, sc);
+                    //printf("type %s t %s\n", type.deco, t.deco);
+                    e.error("cannot implicitly convert expression (%s) of type %s to %s",
+                        e.toChars(), e.type.toChars(), t.toChars());
+                }
             }
             result = new ErrorExp();
         }

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -4329,16 +4329,13 @@ extern (C++) MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplatePara
     return v.result;
 }
 
-/*******************************
- * Input:
- *      t           Tested type, if NULL, returns NULL.
- *      tparams     Optional template parameters.
- *                  == NULL:
- *                      If one of the subtypes of this type is a TypeIdentifier,
- *                      i.e. it's an unresolved type, return that type.
- *                  != NULL:
- *                      Only when the TypeIdentifier is one of template parameters,
- *                      return that type.
+/***********************************************************
+ * Check whether the type t representation relies on one or more the template parameters.
+ * Params:
+ *      t           = Tested type, if null, returns false.
+ *      tparams     = Template parameters.
+ *      iStart      = Start index of tparams to limit the tested parameters. If it's
+ *                    nonzero, tparams[0..iStart] will be excluded from the test target.
  */
 extern (C++) Type reliesOnTident(Type t, TemplateParameters* tparams = null, size_t iStart = 0)
 {
@@ -4393,11 +4390,6 @@ extern (C++) Type reliesOnTident(Type t, TemplateParameters* tparams = null, siz
 
         override void visit(TypeIdentifier t)
         {
-            if (!tparams)
-            {
-                result = t;
-                return;
-            }
             for (size_t i = iStart; i < tparams.dim; i++)
             {
                 TemplateParameter tp = (*tparams)[i];
@@ -4411,8 +4403,6 @@ extern (C++) Type reliesOnTident(Type t, TemplateParameters* tparams = null, siz
 
         override void visit(TypeInstance t)
         {
-            if (!tparams)
-                return;
             for (size_t i = iStart; i < tparams.dim; i++)
             {
                 TemplateParameter tp = (*tparams)[i];
@@ -4453,6 +4443,8 @@ extern (C++) Type reliesOnTident(Type t, TemplateParameters* tparams = null, siz
 
     if (!t)
         return null;
+
+    assert(tparams);
     scope ReliesOnTident v = new ReliesOnTident(tparams, iStart);
     t.accept(v);
     return v.result;

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7168,35 +7168,7 @@ public:
                 *pt = Type.terror;
                 return;
             }
-            if (t != this)
-            {
-                if (reliesOnTident(t))
-                {
-                    if (s._scope)
-                        t = t.semantic(loc, s._scope);
-                    else
-                    {
-                        /* Attempt to find correct scope in which to evaluate t.
-                         * Not sure if this is right or not, or if we should just
-                         * give forward reference error if s->scope is not set.
-                         */
-                        for (Scope* scx = sc; 1; scx = scx.enclosing)
-                        {
-                            if (!scx)
-                            {
-                                error(loc, "forward reference to '%s'", t.toChars());
-                                *pt = Type.terror;
-                                return;
-                            }
-                            if (scx.scopesym == scopesym)
-                            {
-                                t = t.semantic(loc, scx);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
+
             if (t.ty == Ttuple)
                 *pt = t;
             else

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -48,7 +48,6 @@ typedef struct TYPE type;
 
 void semanticTypeInfo(Scope *sc, Type *t);
 MATCH deduceType(RootObject *o, Scope *sc, Type *tparam, TemplateParameters *parameters, Objects *dedtypes, unsigned *wm = NULL, size_t inferStart = 0);
-Type *reliesOnTident(Type *t, TemplateParameters *tparams = NULL, size_t iStart = 0);
 StorageClass ModToStc(unsigned mod);
 
 enum ENUMTY


### PR DESCRIPTION
This is one of cleanup for forward reference mechanism.

The removed part was workaround code for the incomplete semantic analysis process in ancient. If `reliesOnTident(t)` returns true, it means that `t->semantic()` is yet not called.

Rather such the case is a bug in current forward reference resolution mechanism, and the loose check code is not necessary anymore.
