### PR TITLE
Move declarations for functions only called by the glue layer out of the frontend

### DIFF
--- a/src/backend.d
+++ b/src/backend.d
@@ -49,7 +49,6 @@ alias list_t = LIST*;
 alias type = TYPE;
 
 extern extern (C++) type* type_fake(tym_t);
-extern extern (C++) uint totym(Type tx);
 extern extern (C++) void type_incCount(type* t);
 extern extern (C++) void type_setIdent(type* t, char* ident);
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -43,6 +43,7 @@
 #include        "ctfe.h"
 
 typedef Array<elem *> Elems;
+RET retStyle(TypeFunction *tf);
 
 elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
 elem *array_toPtr(Type *t, elem *e);

--- a/src/glue.c
+++ b/src/glue.c
@@ -41,6 +41,7 @@
 #include "irstate.h"
 
 void clearStringTab();
+RET retStyle(TypeFunction *tf);
 
 elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
 void Statement_toIR(Statement *s, IRState *irs);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -594,8 +594,6 @@ enum PURE
     PUREstrong = 4,     // parameters are values or immutable
 };
 
-RET retStyle(TypeFunction *tf);
-
 class TypeFunction : public TypeNext
 {
 public:

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -49,6 +49,7 @@ elem *toElemDtor(Expression *e, IRState *irs);
 Symbol *toSymbol(Type *t);
 unsigned totym(Type *tx);
 Symbol *toSymbol(Dsymbol *s);
+RET retStyle(TypeFunction *tf);
 
 #define elem_setLoc(e,loc)      srcpos_setLoc(&(e)->Esrcpos, loc)
 #define block_setLoc(b,loc)     srcpos_setLoc(&(b)->Bsrcpos, loc)

--- a/src/toctype.d
+++ b/src/toctype.d
@@ -18,6 +18,8 @@ import ddmd.id;
 import ddmd.mtype;
 import ddmd.visitor;
 
+extern extern (C++) uint totym(Type tx);
+
 extern (C++) final class ToCtypeVisitor : Visitor
 {
     alias visit = super.visit;


### PR DESCRIPTION
These are essentially `package` functions to the glue layer.
