### PR TITLE
Remove unused toModuleXXX helpers from D code

### DIFF
--- a/src/backend.d
+++ b/src/backend.d
@@ -31,9 +31,6 @@ extern extern (C++) void obj_write_deferred(Library library);
 extern extern (C++) void genObjFile(Module m, bool multiobj);
 
 extern extern (C++) Symbol* toInitializer(AggregateDeclaration sd);
-extern extern (C++) Symbol* toModuleArray(Module m);
-extern extern (C++) Symbol* toModuleAssert(Module m);
-extern extern (C++) Symbol* toModuleUnittest(Module m);
 
 // type.h
 

--- a/src/gluestub.d
+++ b/src/gluestub.d
@@ -26,21 +26,6 @@ extern (C++) Symbol* toInitializer(AggregateDeclaration ad)
     return null;
 }
 
-extern (C++) Symbol* toModuleAssert(Module m)
-{
-    return null;
-}
-
-extern (C++) Symbol* toModuleUnittest(Module m)
-{
-    return null;
-}
-
-extern (C++) Symbol* toModuleArray(Module m)
-{
-    return null;
-}
-
 // glue
 
 extern (C++) void obj_write_deferred(Library library)


### PR DESCRIPTION
They are only ever used in the C++ codebase, unless you (looking at @9rnsr and @yebblies) have other plans for them!
