### PR TITLE
[D1] Issue 13954 - Disallow non-covariant overrides

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2754,7 +2754,7 @@ int Type::covariant(Type *t)
             return 3;   // forward references
         }
     }
-    if (t1n->implicitConvTo(t2n))
+    if (t1n->ty == t2n->ty && t1n->implicitConvTo(t2n))
         goto Lcovariant;
 
     goto Lnotcovariant;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13954

Currently this results in a codegen problem which is pretty nasty as you'd get seemingly random results at runtime.

This matches the behavior in D2, although I'm a bit puzzled why `(type-real).implicitConvTo(type-float)` actually succeeds in both D1 and D2 compilers.

The added `t1n->ty == t2n->ty` check will still allow class covariance, 
but I think this should have been explicit in the front-end (e.g. `if t1n->ty == Tclass && t2n->ty == Tclass && t1n->implicitConvTo(t2n)`).

@9rnsr @WalterBright: Are there any other return-type covariance examples where the base method and overriden method have different return types **other** than class types? I can't think of any..
