### PR TITLE
Issue 7903 - Disallow public members in a synchronized class

### DIFF
--- a/src/dclass.d
+++ b/src/dclass.d
@@ -879,6 +879,17 @@ public:
             if (deferred)
                 deferred.errors = true;
         }
+        // Verify fields of a synchronized class are not public
+        if (storage_class & STCsynchronized)
+        foreach (vd; this.fields)
+        {
+            if (!vd.isThisDeclaration() &&
+                !vd.prot().isMoreRestrictiveThan(Prot(PROTpublic)))
+            {
+                vd.error("Field members of a synchronized class cannot be %s",
+                    protectionToChars(vd.prot().kind));
+            }
+        }
         if (deferred && !global.gag)
         {
             deferred.semantic2(sc);

--- a/test/fail_compilation/fail7903.d
+++ b/test/fail_compilation/fail7903.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail7903.d(21): Error: variable fail7903.F1.x Field members of a synchronized class cannot be public
+fail_compilation/fail7903.d(22): Error: variable fail7903.F1.y Field members of a synchronized class cannot be export
+fail_compilation/fail7903.d(27): Error: variable fail7903.F2.x Field members of a synchronized class cannot be public
+---
+*/
+synchronized class K1
+{
+    public struct S { }
+}
+
+synchronized class K2
+{
+    struct S { }
+}
+
+synchronized class F1
+{
+    public int x;
+    export int y;
+}
+
+synchronized class F2
+{
+    int x;
+}


### PR DESCRIPTION
Fixes https://issues.dlang.org/show_bug.cgi?id=7903

Recreated from https://github.com/D-Programming-Language/dmd/pull/3067
