### PR TITLE
Issue 8765, 9255 - Show informative assert errors

### DIFF
--- a/src/ddmd/e2ir.d
+++ b/src/ddmd/e2ir.d
@@ -1905,7 +1905,7 @@ elem *toElem(Expression e, IRState *irs)
                  * to a #line directive.
                  */
                 elem *ea;
-                if (ae.loc.filename && (ae.msg || strcmp(ae.loc.filename, mname) != 0))
+                if (ae.loc.filename)
                 {
                     const(char)* id = ae.loc.filename;
                     size_t len = strlen(id);

--- a/test/fail_compilation/fail145.d
+++ b/test/fail_compilation/fail145.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail145.d(13): Error: assert(i < 0) failed
+fail_compilation/fail145.d(13): Error: "assert(i < 0) failed"
 fail_compilation/fail145.d(26):        called from here: bar(7)
 ---
 */

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -6048,6 +6048,35 @@ void test14510()
     fun14510(vec);
 }
 
+void test8765()
+{
+    try
+    {
+        int a = 0;
+        assert(a == 1);
+    }
+    catch (Throwable e)
+    {
+        // no-message -> assert expression
+        assert(e.msg == "assert(a == 1) failed");
+    }
+}
+
+void test9255()
+{
+    try
+    {
+        int x = 0;
+        assert(x == 1);
+    }
+    catch (Throwable e)
+    {
+        version(Windows)
+            assert(e.file == r"runnable\test42.d");
+        else
+            assert(e.file == "runnable/test42.d");
+    }
+}
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=16027
 
@@ -6349,6 +6378,7 @@ int main()
     test246();
     test8454();
     test8423();
+    test8765();
     test8496();
     test8840();
     test8889();
@@ -6360,6 +6390,7 @@ int main()
     test8796();
     test9171();
     test9248();
+    test9255();
     test14682a();
     test14682b();
     test9739();


### PR DESCRIPTION
Fixes: [Issue 8765](https://issues.dlang.org/show_bug.cgi?id=8765) and [Issue 9255](https://issues.dlang.org/show_bug.cgi?id=9255)

Recreated from https://github.com/D-Programming-Language/dmd/pull/1426

Requires https://github.com/D-Programming-Language/phobos/pull/3730
