### PR TITLE
Issue 15186 - Emit better diagnostic for C++ member lookup operators

### DIFF
--- a/src/parse.d
+++ b/src/parse.d
@@ -4438,6 +4438,16 @@ public:
                 Token* t = peek(&token);
                 if (t.value == TOKcolon)
                 {
+                    Token* nt = peek(t);
+                    if (nt.value == TOKcolon)
+                    {
+                        // skip ident::
+                        nextToken();
+                        nextToken();
+                        nextToken();
+                        error("use '.' for member lookup, not '::'");
+                        break;
+                    }
                     // It's a label
                     Identifier ident = token.ident;
                     nextToken();
@@ -6477,6 +6487,18 @@ public:
         {
         case TOKidentifier:
             {
+                Token* t1 = peek(&token);
+                Token* t2 = peek(t1);
+                if (t1.value == TOKmin && t2.value == TOKgt)
+                {
+                    // skip ident->
+                    nextToken();
+                    nextToken();
+                    nextToken();
+                    error("use '.' for member lookup, not '->'");
+                    goto Lerr;
+                }
+
                 if (peekNext() == TOKgoesto)
                     goto case_delegate;
                 id = token.ident;

--- a/test/fail_compilation/diag15186.d
+++ b/test/fail_compilation/diag15186.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag15186.d(14): Error: use '.' for member lookup, not '::'
+fail_compilation/diag15186.d(15): Error: use '.' for member lookup, not '->'
+---
+*/
+
+void main()
+{
+    struct S { static int x; int y; }
+    S* s;
+
+    S::x = 1;
+    s->y = 2;
+}


### PR DESCRIPTION
Fixes https://issues.dlang.org/show_bug.cgi?id=15186
