### PR TITLE
[REG2.068.2] Issue 15200 - ICE(glue.c) when compiling with -inline

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -7346,8 +7346,8 @@ public:
         }
         //printf("%s->appendToModuleMember() enclosing = %s mi = %s\n",
         //    toPrettyChars(),
-        //    enclosing ? enclosing.toPrettyChars() : NULL,
-        //    mi ? mi.toPrettyChars() : NULL);
+        //    enclosing ? enclosing.toPrettyChars() : null,
+        //    mi ? mi.toPrettyChars() : null);
         if (!mi || mi.isRoot())
         {
             /* If the instantiated module is speculative or root, insert to the

--- a/src/inline.d
+++ b/src/inline.d
@@ -1948,14 +1948,6 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
     }
     scope ids = new InlineDoState(parent, fd);
 
-    // When the function is actually expanded
-    if (TemplateInstance ti = fd.isInstantiated())
-    {
-        // change ti to non-speculative root instance
-        if (!ti.minst)
-            ti.minst = ti.tempdecl.getModule().importedFrom;
-    }
-
     if (asStatements)
         as = new Statements();
     VarDeclaration vret = null;

--- a/test/runnable/ice15200.d
+++ b/test/runnable/ice15200.d
@@ -1,0 +1,11 @@
+// EXTRA_SOURCES: imports/ice15200a.d imports/ice15200b.d
+// COMPILE_SEPARATELY
+
+module ice15200;
+
+import imports.ice15200a;
+
+void main()
+{
+    f();
+}

--- a/test/runnable/imports/ice15200a.d
+++ b/test/runnable/imports/ice15200a.d
@@ -1,0 +1,12 @@
+import imports.ice15200b;
+
+auto f() // not void
+{
+    sub([0], false);
+}
+void sub(R)(R list, bool b)
+{
+    foreach (i; list.filter!(delegate(e) => b))
+    {
+    }
+}

--- a/test/runnable/imports/ice15200b.d
+++ b/test/runnable/imports/ice15200b.d
@@ -1,0 +1,41 @@
+module imports.ice15200b;
+
+template filter(alias pred)
+{
+    auto filter(R)(R range)
+    {
+        return FilterResult!(pred, R)(range);
+    }
+}
+
+struct FilterResult(alias pred, R)
+{
+    R _input;
+
+    this(R r)
+    {
+        _input = r;
+        while (_input.length && !pred(_input[0]))
+        {
+            _input = _input[1..$];
+        }
+    }
+
+    @property bool empty()
+    {
+        return _input.length == 0;
+    }
+
+    @property auto ref front()
+    {
+        return _input[0];
+    }
+
+    void popFront()
+    {
+        do
+        {
+            _input = _input[1..$];
+        } while (_input.length && !pred(_input[0]));
+    }
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15200

Even if a function is expanded by inlining, the function itself don't have to put in object file. In short, adjusting `ti.minst` in `inline.d` is not correct.

The unspeculation in `expandInline` was added in the PR #4944, but sadly it was just a hack and inherently unneeded. The changes in `TemplateInstance.appendToModuleMember` and `needsCodegen` those were added since 2.068.1-b1, now correctly handle codegen of nested template instances.
