### PR TITLE
Issue 15141 - Object.factory allows the creation of derived abstract classes

### DIFF
--- a/src/toobj.c
+++ b/src/toobj.c
@@ -412,7 +412,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                     break;
                 }
             }
-            if (cd->isabstract)
+            if (cd->isAbstract())
                 flags |= ClassFlags::isAbstract;
             for (ClassDeclaration *pc = cd; pc; pc = pc->baseClass)
             {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7677,6 +7677,24 @@ template isCustomSerializable15126(T)
 alias bug15126 = isCustomSerializable15126!Json15126;
 
 /***************************************************/
+// 15141
+
+class A15141
+{
+    abstract void method();
+}
+
+class B15141 : A15141 { }
+
+void test15141()
+{
+    auto a = Object.factory(__MODULE__ ~ ".A15141");
+    assert(a is null);
+    auto b = Object.factory(__MODULE__ ~ ".B15141");
+    assert(b is null); // OK <- oops
+}
+
+/***************************************************/
 
 int main()
 {
@@ -7989,6 +8007,7 @@ int main()
     test13952();
     test13985();
     test14211();
+    test15141();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15141

`ClassDeclaration.isAbstract()` should be used to emit `ClassFlags::isAbstract` so it's considering abstract member functions.
