### PR TITLE
Issue 12385 - Enum members typed as immutable should not be modifiable

### DIFF
--- a/src/denum.d
+++ b/src/denum.d
@@ -631,7 +631,7 @@ public:
                 origValue = e;
 
                 if (!ed.isAnonymous())
-                    e = e.castTo(sc, ed.type);
+                    e = e.castTo(sc, ed.type.addMod(e.type.mod));
             }
             else if (origType)
             {

--- a/test/fail_compilation/fail12385.d
+++ b/test/fail_compilation/fail12385.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12385.d(27): Error: cannot modify immutable expression BundledState("bla", 3).x
+---
+*/
+
+class BundledState
+{
+    string m_State;
+
+    int x = 3;
+
+    this(string state) immutable
+    {
+        m_State = state;
+    }
+}
+
+enum States : immutable(BundledState)
+{
+    unbundled = new immutable BundledState("bla"),
+}
+
+void main(string[] argv)
+{
+    States.unbundled.x = 6; // Modifies x.
+}


### PR DESCRIPTION
Fixes https://issues.dlang.org/show_bug.cgi?id=12385

Recreated from: https://github.com/D-Programming-Language/dmd/pull/3484

In reality this change will likely fix other edge-cases where the type of the member wasn't taken fully into account (shared/const/immutable), perhaps even inout.

Suggested fix was by @9rnsr
