### PR TITLE
[REG2.031] Issue 14965 - Forward reference to inferred return type of function call when using auto return type

### DIFF
--- a/src/dcast.d
+++ b/src/dcast.d
@@ -1913,6 +1913,15 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 }
             }
 
+            if (auto f = isFuncAddress(e))
+            {
+                if (f.checkForwardRef(e.loc))
+                {
+                    result = new ErrorExp();
+                    return;
+                }
+            }
+
             visit(cast(Expression)e);
         }
 
@@ -2134,6 +2143,15 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 }
             }
 
+            if (auto f = isFuncAddress(e))
+            {
+                if (f.checkForwardRef(e.loc))
+                {
+                    result = new ErrorExp();
+                    return;
+                }
+            }
+
             visit(cast(Expression)e);
         }
 
@@ -2177,6 +2195,15 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     }
                     if (e.func.tintro)
                         e.error("%s", msg);
+                }
+            }
+
+            if (auto f = isFuncAddress(e))
+            {
+                if (f.checkForwardRef(e.loc))
+                {
+                    result = new ErrorExp();
+                    return;
                 }
             }
 

--- a/src/func.d
+++ b/src/func.d
@@ -2321,6 +2321,29 @@ public:
         return !errors && !semantic3Errors;
     }
 
+    /****************************************************
+     * Check that this function type is properly resolved.
+     * If not, report "forward reference error" and return true.
+     */
+    final bool checkForwardRef(Loc loc)
+    {
+        if (!functionSemantic())
+            return true;
+
+        /* No deco means the functionSemantic() call could not resolve
+         * forward referenes in the type of this function.
+         */
+        if (!type.deco)
+        {
+            bool inSemantic3 = (inferRetType && semanticRun >= PASSsemantic3);
+            .error(loc, "forward reference to %s'%s'",
+                (inSemantic3 ? "inferred return type of function " : "").ptr,
+                toChars());
+            return true;
+        }
+        return false;
+    }
+
     // called from semantic3
     final VarDeclaration declareThis(Scope* sc, AggregateDeclaration ad)
     {

--- a/src/init.d
+++ b/src/init.d
@@ -785,20 +785,14 @@ public:
                 se.error("cannot infer type from %s %s", se.sds.kind(), se.toChars());
             return new ErrorInitializer();
         }
+
         // Give error for overloaded function addresses
-        if (exp.op == TOKsymoff)
+        bool hasOverloads;
+        if (auto f = isFuncAddress(exp, &hasOverloads))
         {
-            SymOffExp se = cast(SymOffExp)exp;
-            if (se.hasOverloads && !se.var.isFuncDeclaration().isUnique())
-            {
-                exp.error("cannot infer type from overloaded function symbol %s", exp.toChars());
+            if (f.checkForwardRef(loc))
                 return new ErrorInitializer();
-            }
-        }
-        if (exp.op == TOKdelegate)
-        {
-            DelegateExp se = cast(DelegateExp)exp;
-            if (se.hasOverloads && se.func.isFuncDeclaration() && !se.func.isFuncDeclaration().isUnique())
+            if (hasOverloads && !f.isUnique())
             {
                 exp.error("cannot infer type from overloaded function symbol %s", exp.toChars());
                 return new ErrorInitializer();

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7549,6 +7549,17 @@ public:
              * template functions.
              */
         }
+        if (auto f = exp.op == TOKvar    ? (cast(   VarExp)exp).var.isFuncDeclaration()
+                   : exp.op == TOKdotvar ? (cast(DotVarExp)exp).var.isFuncDeclaration() : null)
+        {
+            if (f.checkForwardRef(loc))
+                goto Lerr;
+        }
+        if (auto f = isFuncAddress(exp))
+        {
+            if (f.checkForwardRef(loc))
+                goto Lerr;
+        }
 
         Type t = exp.type;
         if (!t)

--- a/src/statement.d
+++ b/src/statement.d
@@ -1150,7 +1150,13 @@ public:
             exp = exp.addDtorHook(sc);
             if (checkNonAssignmentArrayOp(exp))
                 exp = new ErrorExp();
+            if (auto f = isFuncAddress(exp))
+            {
+                if (f.checkForwardRef(exp.loc))
+                    exp = new ErrorExp();
+            }
             discardValue(exp);
+
             exp = exp.optimize(WANTvalue);
             exp = checkGC(sc, exp);
             if (exp.op == TOKerror)
@@ -4386,6 +4392,11 @@ public:
             exp = resolveProperties(sc, exp);
             if (exp.checkType())
                 exp = new ErrorExp();
+            if (auto f = isFuncAddress(exp))
+            {
+                if (fd.inferRetType && f.checkForwardRef(exp.loc))
+                    exp = new ErrorExp();
+            }
             if (checkNonAssignmentArrayOp(exp))
                 exp = new ErrorExp();
 

--- a/test/fail_compilation/diag7747.d
+++ b/test/fail_compilation/diag7747.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7747.d(8): Error: forward reference to inferred return type of function call 'fact'
+fail_compilation/diag7747.d(8): Error: forward reference to inferred return type of function call 'fact(n - 1)'
 ---
 */
 

--- a/test/fail_compilation/fail12236.d
+++ b/test/fail_compilation/fail12236.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12236.d(16): Error: forward reference to inferred return type of function call 'f1'
+fail_compilation/fail12236.d(16): Error: forward reference to inferred return type of function 'f1'
 fail_compilation/fail12236.d(16):        while evaluating pragma(msg, f1.mangleof)
-fail_compilation/fail12236.d(21): Error: forward reference to f2
+fail_compilation/fail12236.d(21): Error: forward reference to inferred return type of function 'f2'
 fail_compilation/fail12236.d(21):        while evaluating pragma(msg, f2(T)(T).mangleof)
 fail_compilation/fail12236.d(27): Error: template instance fail12236.f2!int error instantiating
-fail_compilation/fail12236.d(31): Error: forward reference to __lambda1
+fail_compilation/fail12236.d(31): Error: forward reference to inferred return type of function '__lambda1'
 fail_compilation/fail12236.d(31):        while evaluating pragma(msg, __lambda1.mangleof)
 ---
 */

--- a/test/fail_compilation/fail14965.d
+++ b/test/fail_compilation/fail14965.d
@@ -1,0 +1,38 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail14965.d(19): Error: forward reference to inferred return type of function 'foo1'
+fail_compilation/fail14965.d(20): Error: forward reference to inferred return type of function 'foo2'
+fail_compilation/fail14965.d(22): Error: forward reference to inferred return type of function 'bar1'
+fail_compilation/fail14965.d(23): Error: forward reference to inferred return type of function 'bar2'
+fail_compilation/fail14965.d(25): Error: forward reference to inferred return type of function 'baz1'
+fail_compilation/fail14965.d(26): Error: forward reference to inferred return type of function 'baz2'
+fail_compilation/fail14965.d(30): Error: forward reference to inferred return type of function 'foo1'
+fail_compilation/fail14965.d(31): Error: forward reference to inferred return type of function 'foo2'
+fail_compilation/fail14965.d(33): Error: forward reference to inferred return type of function 'bar1'
+fail_compilation/fail14965.d(34): Error: forward reference to inferred return type of function 'bar2'
+fail_compilation/fail14965.d(36): Error: forward reference to inferred return type of function 'baz1'
+fail_compilation/fail14965.d(37): Error: forward reference to inferred return type of function 'baz2'
+---
+*/
+
+auto foo1() { alias F = typeof(foo1); }     // TypeTypeof
+auto foo2() { alias FP = typeof(&foo2); }   // TypeTypeof
+
+auto bar1() { auto fp = &bar1; }            // ExpInitializer
+auto bar2() { auto fp = cast(void function())&bar2; }   // castTo
+
+auto baz1() { return &baz1; }               // ReturnStatement
+auto baz2() { (&baz2); }                    // ExpStatement
+
+class C
+{
+    auto foo1() { alias F = typeof(this.foo1); }
+    auto foo2() { alias FP = typeof(&this.foo2); }
+
+    auto bar1() { auto fp = &this.bar1; }
+    auto bar2() { auto dg = cast(void delegate())&this.bar2; }
+
+    auto baz1() { return &baz1; }
+    auto baz2() { (&baz2); }
+}

--- a/test/fail_compilation/ice12235.d
+++ b/test/fail_compilation/ice12235.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12235.d(14): Error: forward reference to __lambda1
-fail_compilation/ice12235.d(15): Error: forward reference to __lambda1
+fail_compilation/ice12235.d(14): Error: forward reference to inferred return type of function '__lambda1'
+fail_compilation/ice12235.d(15): Error: forward reference to inferred return type of function '__lambda1'
 fail_compilation/ice12235.d(15):        while evaluating pragma(msg, __lambda1.mangleof)
 ---
 */

--- a/test/fail_compilation/test9176.d
+++ b/test/fail_compilation/test9176.d
@@ -1,15 +1,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test9176.d(12): Error: forward reference to inferred return type of function call 'get'
+fail_compilation/test9176.d(13): Error: forward reference to inferred return type of function call 'get()'
 ---
 */
 
 void foo(int x) {}
 static assert(!is(typeof(foo(S()))));
 
-struct S {
+struct S
+{
     auto get() { return get(); }
     alias get this;
 }
+
 void main(){}

--- a/test/runnable/overload.d
+++ b/test/runnable/overload.d
@@ -664,9 +664,9 @@ template Foo1900(T)
     {
     }
 }
-mixin Foo1900!(int) A;
-mixin Foo1900!(char) B;
-alias Bar1900!(int) bar;    //error
+mixin Foo1900!(int) A1900;
+mixin Foo1900!(char) B1900;
+alias Bar1900!(int) bar1900;    // error
 
 /***************************************************/
 // 7780
@@ -1136,6 +1136,82 @@ void test14989()
 }
 
 /***************************************************/
+// 14965
+
+auto f14965a1() { return f14965a1(123); }
+int f14965a1(int x) { return x; }
+
+int f14965a2(int x) { return x; }
+auto f14965a2() { return f14965a2(123); }
+
+auto f14965b1() { int function(int) fp = &f14965b1; return fp(123); }
+int f14965b1(int x) { return x; }
+
+int f14965b2(int x) { return x; }
+auto f14965b2() { int function(int) fp = &f14965b2; return fp(123); }
+
+auto f14965c1() { auto fp = cast(int function(int))&f14965c1; return fp(123); }
+int f14965c1(int x) { return x; }
+
+int f14965c2(int x) { return x; }
+auto f14965c2() { auto fp = cast(int function(int))&f14965c2; return fp(123); }
+
+int function(int) f14965d1() { return &f14965d1; }
+int f14965d1(int n) { return 10 + n; }
+
+int f14965d2(int n) { return 10 + n; }
+int function(int) f14965d2() { return &f14965d2; }
+
+class C
+{
+    auto fa1() { return this.fa1(123); }
+    int fa1(int x) { return x; }
+
+    int fa2(int x) { return x; }
+    auto fa2() { return this.fa2(123); }
+
+    auto fb1() { int delegate(int) dg = &this.fb1; return dg(123); }
+    int fb1(int x) { return x; }
+
+    int fb2(int x) { return x; }
+    auto fb2() { int delegate(int) dg = &this.fb2; return dg(123); }
+
+    auto fc1() { auto dg = cast(int delegate(int))&this.fc1; return dg(123); }
+    int fc1(int x) { return x; }
+
+    int fc2(int x) { return x; }
+    auto fc2() { auto dg = cast(int delegate(int))&this.fc2; return dg(123); }
+
+    int delegate(int) fd1() { return &fd1; }
+    int fd1(int n) { return 10 + n; }
+
+    int fd2(int n) { return 10 + n; }
+    int delegate(int) fd2() { return &fd2; }
+}
+
+void test14965()
+{
+    assert(f14965a1() == 123);
+    assert(f14965b1() == 123);
+    assert(f14965c1() == 123);
+    assert(f14965d1()(113) == 123);
+    assert(f14965a2() == 123);
+    assert(f14965b2() == 123);
+    assert(f14965c2() == 123);
+    assert(f14965d2()(113) == 123);
+
+    auto c = new C();
+    assert(c.fa1() == 123);
+    assert(c.fb1() == 123);
+    assert(c.fc1() == 123);
+    assert(c.fd1()(113) == 123);
+    assert(c.fa2() == 123);
+    assert(c.fb2() == 123);
+    assert(c.fc2() == 123);
+    assert(c.fd2()(113) == 123);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -1170,6 +1246,7 @@ int main()
     test11916();
     test13783();
     test14858();
+    test14965();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14965

If a function symbol is used, its overload resolution should be deferred until:

``` d
func(...)           // CallExp.semantic
func.mangleof       // DotIdExp.semanticY
typeof(func)        // TypeTypeof.resolve
typeof(&func)       // TypeTypeof.resolve
auto v = &func;     // ExpInitializer.inferType
&func;              // ExpStatement.semantic
return &func;       // ReturnStatement
```

When the semantic analysis reaches to them, the function forward reference can beome actual error.

Other use of 'func' should be treated as a property-like function call (done in `resolveProperties`) and finally handled in `CallExp`.

---

Each preparation cleanup/refactoring changes are separated into following pull requests.
- [x] #5197 Cleanup dcast.d
- [x] #5198 Cleanup hasOverloads
- [x] #5199 Refactor: TypeTypeof.resolve
