### PR TITLE
[REG2.069.0-b1] Issue 15207 - Wrong codegen with -inline

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1474,6 +1474,7 @@ public:
                     error("reference to scope class must be scope");
             }
         }
+
         if (!_init && !fd)
         {
             // If not mutable, initializable by constructor only
@@ -1483,10 +1484,18 @@ public:
             storage_class |= STCinit; // remember we had an explicit initializer
         else if (storage_class & STCmanifest)
             error("manifest constants must have initializers");
+
         bool isBlit = false;
-        if (!_init && !sc.inunion && !(storage_class & (STCstatic | STCgshared | STCextern)) && fd && (!(storage_class & (STCfield | STCin | STCforeach | STCparameter | STCresult)) || (storage_class & STCout)) && type.size() != 0)
+        if (!_init &&
+            !sc.inunion &&
+            !(storage_class & (STCstatic | STCgshared | STCextern)) &&
+            fd &&
+            (!(storage_class & (STCfield | STCin | STCforeach | STCparameter | STCresult)) ||
+             (storage_class & STCout)) &&
+            type.size() != 0)
         {
             // Provide a default initializer
+
             //printf("Providing default initializer for '%s'\n", toChars());
             if (type.needsNested())
             {
@@ -1494,10 +1503,12 @@ public:
                 while (tv.toBasetype().ty == Tsarray)
                     tv = tv.toBasetype().nextOf();
                 assert(tv.toBasetype().ty == Tstruct);
+
                 /* Nested struct requires valid enclosing frame pointer.
                  * In StructLiteralExp::toElem(), it's calculated.
                  */
                 checkFrameAccess(loc, sc, (cast(TypeStruct)tv.toBasetype()).sym);
+
                 Expression e = tv.defaultInitLiteral(loc);
                 Expression e1 = new VarExp(loc, this);
                 e = new BlitExp(loc, e1, e);
@@ -1505,7 +1516,8 @@ public:
                 _init = new ExpInitializer(loc, e);
                 goto Ldtor;
             }
-            else if (type.ty == Tstruct && (cast(TypeStruct)type).sym.zeroInit == 1)
+            if (type.ty == Tstruct &&
+                (cast(TypeStruct)type).sym.zeroInit == 1)
             {
                 /* If a struct is all zeros, as a special case
                  * set it's initializer to the integer 0.
@@ -1521,7 +1533,7 @@ public:
                 _init = new ExpInitializer(loc, e);
                 goto Ldtor;
             }
-            else if (type.baseElemOf().ty == Tvoid)
+            if (type.baseElemOf().ty == Tvoid)
             {
                 error("%s does not have a default initializer", type.toChars());
             }
@@ -1529,6 +1541,7 @@ public:
             {
                 _init = getExpInitializer();
             }
+
             // Default initializer is always a blit
             isBlit = true;
         }

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1510,8 +1510,7 @@ public:
                 checkFrameAccess(loc, sc, (cast(TypeStruct)tv.toBasetype()).sym);
 
                 Expression e = tv.defaultInitLiteral(loc);
-                Expression e1 = new VarExp(loc, this);
-                e = new BlitExp(loc, e1, e);
+                e = new BlitExp(loc, new VarExp(loc, this), e);
                 e = e.semantic(sc);
                 _init = new ExpInitializer(loc, e);
                 goto Ldtor;
@@ -1526,10 +1525,8 @@ public:
                  * Must do same check in interpreter.
                  */
                 Expression e = new IntegerExp(loc, 0, Type.tint32);
-                Expression e1;
-                e1 = new VarExp(loc, this);
-                e = new BlitExp(loc, e1, e);
-                e.type = e1.type; // don't type check this, it would fail
+                e = new BlitExp(loc, new VarExp(loc, this), e);
+                e.type = type;      // don't type check this, it would fail
                 _init = new ExpInitializer(loc, e);
                 goto Ldtor;
             }

--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -3334,8 +3334,8 @@ public:
         //      Deal with reference assignment
         // ---------------------------------------
         // If it is a construction of a ref variable, it is a ref assignment
-        if (e.op == TOKconstruct && e1.op == TOKvar &&
-            ((cast(VarExp)e1).var.storage_class & STCref) != 0)
+        if ((e.op == TOKconstruct || e.op == TOKblit) &&
+            ((cast(AssignExp)e).memset & MemorySet.referenceInit))
         {
             assert(!fp);
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2505,7 +2505,7 @@ elem *toElem(Expression *e, IRState *irs)
                 Type *ta = are->e1->type->toBasetype();
 
                 // which we do if the 'next' types match
-                if (ae->ismemset & 1)
+                if (ae->memset & MemorySet_blockAssign)
                 {
                     // Do a memset for array[]=v
                     //printf("Lpair %s\n", ae->toChars());
@@ -2695,11 +2695,12 @@ elem *toElem(Expression *e, IRState *irs)
 
             /* Look for reference initializations
              */
-            if (ae->op == TOKconstruct && ae->e1->op == TOKvar && !(ae->ismemset & 2))
+            if (ae->op == TOKconstruct && ae->e1->op == TOKvar &&
+                !(ae->memset & MemorySet_refValueInit))
             {
                 VarExp *ve = (VarExp *)ae->e1;
-                Declaration *s = ve->var;
-                if (s->storage_class & (STCout | STCref))
+                Declaration *d = ve->var;
+                if (d->storage_class & (STCout | STCref))
                 {
                     e = toElem(ae->e2, irs);
                     e = addressElem(e, ae->e2->type);

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2700,7 +2700,8 @@ elem *toElem(Expression *e, IRState *irs)
              */
             if (ae->memset & MemorySet_referenceInit)
             {
-                assert(ae->op == TOKconstruct && ae->e1->op == TOKvar);
+                assert(ae->op == TOKconstruct || ae->op == TOKblit);
+                assert(ae->e1->op == TOKvar);
 
                 VarExp *ve = (VarExp *)ae->e1;
                 Declaration *d = ve->var;

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -2695,9 +2695,10 @@ elem *toElem(Expression *e, IRState *irs)
 
             /* Look for reference initializations
              */
-            if (ae->op == TOKconstruct && ae->e1->op == TOKvar &&
-                !(ae->memset & MemorySet_refValueInit))
+            if (ae->memset & MemorySet_referenceInit)
             {
+                assert(ae->op == TOKconstruct && ae->e1->op == TOKvar);
+
                 VarExp *ve = (VarExp *)ae->e1;
                 Declaration *d = ve->var;
                 if (d->storage_class & (STCout | STCref))

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -82,7 +82,8 @@ void objc_callfunc_setupEp(elem *esel, elem **ep, int reverse);
  */
 bool ISREF(Declaration *var, Type *tb)
 {
-    return (var->isParameter() && config.exe == EX_WIN64 && (var->type->size(Loc()) > REGSIZE || var->storage_class & STClazy))
+    return (config.exe == EX_WIN64 && var->isParameter() &&
+            (var->type->size(Loc()) > REGSIZE || var->storage_class & STClazy))
             || var->isOut() || var->isRef();
 }
 
@@ -91,8 +92,8 @@ bool ISREF(Declaration *var, Type *tb)
 bool ISWIN64REF(Declaration *var)
 {
     return (config.exe == EX_WIN64 && var->isParameter() &&
-            (var->type->size(Loc()) > REGSIZE || var->storage_class & STClazy)) &&
-            !(var->isOut() || var->isRef());
+            (var->type->size(Loc()) > REGSIZE || var->storage_class & STClazy))
+            && !(var->isOut() || var->isRef());
 }
 
 /******************************************
@@ -945,7 +946,6 @@ elem *toElem(Expression *e, IRState *irs)
         void visit(SymbolExp *se)
         {
             elem *e;
-            tym_t tym;
             Type *tb = (se->op == TOKsymoff) ? se->var->type->toBasetype() : se->type->toBasetype();
             int offset = (se->op == TOKsymoff) ? ((SymOffExp*)se)->offset : 0;
             VarDeclaration *v = se->var->isVarDeclaration();
@@ -1089,7 +1089,6 @@ elem *toElem(Expression *e, IRState *irs)
             }
             else if (ISREF(se->var, tb))
             {
-                // Static arrays are really passed as pointers to the array
                 // Out parameters are really references
                 e = el_var(s);
                 e->Ety = TYnptr;
@@ -1113,13 +1112,17 @@ elem *toElem(Expression *e, IRState *irs)
                     e->Ety = TYnptr;
                     e = el_una(OPind, 0, e);
                 }
-                if (tb->ty == Tfunction)
-                {
+
+                tym_t tym;
+                if (se->var->storage_class & STClazy)
+                    tym = TYdelegate;       // Tdelegate as C type
+                else if (tb->ty == Tfunction)
                     tym = s->Stype->Tty;
-                }
                 else
                     tym = totym(se->type);
+
                 e->Ejty = e->Ety = tym;
+
                 if (tybasic(tym) == TYstruct)
                 {
                     e->ET = Type_toCtype(se->type);
@@ -2743,6 +2746,14 @@ elem *toElem(Expression *e, IRState *irs)
                     e1x->ET = Type_toCtype(ae->e1->type);
                 //printf("e1  = \n"); elem_print(e1);
                 //printf("e1x = \n"); elem_print(e1x);
+            }
+
+            // inlining may generate lazy variable initialization
+            if (ae->e1->op == TOKvar && (((VarExp *)ae->e1)->var->storage_class & STClazy))
+            {
+                assert(ae->op == TOKconstruct || ae->op == TOKblit);
+                e = el_bin(OPeq, tym, e1, toElem(ae->e2, irs));
+                goto Lret;
             }
 
             /* This will work if we can distinguish an assignment from

--- a/src/expression.d
+++ b/src/expression.d
@@ -11468,7 +11468,9 @@ public:
         //printf("e2->op = %d, '%s'\n", e2->op, Token::toChars(e2->op));
         if (type)
             return this;
+
         Expression e1old = e1;
+
         if (e2.op == TOKcomma)
         {
             /* Rewrite to get rid of the comma from rvalue
@@ -11478,6 +11480,7 @@ public:
             Expression e = Expression.combine(e0, this);
             return e.semantic(sc);
         }
+
         /* Look for operator overloading of a[arguments] = e2.
          * Do it before e1->semantic() otherwise the ArrayExp will have been
          * converted to unary operator overloading already.
@@ -11488,8 +11491,12 @@ public:
             ArrayExp ae = cast(ArrayExp)e1;
             ae.e1 = ae.e1.semantic(sc);
             ae.e1 = resolveProperties(sc, ae.e1);
+
             Expression ae1old = ae.e1;
-            const(bool) maybeSlice = (ae.arguments.dim == 0 || ae.arguments.dim == 1 && (*ae.arguments)[0].op == TOKinterval);
+            const(bool) maybeSlice =
+                (ae.arguments.dim == 0 ||
+                 ae.arguments.dim == 1 && (*ae.arguments)[0].op == TOKinterval);
+
             IntervalExp ie = null;
             if (maybeSlice && ae.arguments.dim)
             {
@@ -11503,6 +11510,7 @@ public:
                 Expression e0 = null;
                 Expression ae1save = ae.e1;
                 ae.lengthVar = null;
+
                 Type t1b = ae.e1.type.toBasetype();
                 AggregateDeclaration ad = isAggregate(t1b);
                 if (!ad)
@@ -11515,10 +11523,12 @@ public:
                         goto Lfallback;
                     if (result.op == TOKerror)
                         return result;
+
                     result = e2.semantic(sc);
                     if (result.op == TOKerror)
                         return result;
                     e2 = result;
+
                     /* Rewrite (a[arguments] = e2) as:
                      *      a.opIndexAssign(e2, arguments)
                      */
@@ -11536,6 +11546,7 @@ public:
                         return result;
                     }
                 }
+
             Lfallback:
                 if (maybeSlice && search_function(ad, Id.sliceass))
                 {
@@ -11543,10 +11554,12 @@ public:
                     result = resolveOpDollar(sc, ae, ie, &e0);
                     if (result.op == TOKerror)
                         return result;
+
                     result = e2.semantic(sc);
                     if (result.op == TOKerror)
                         return result;
                     e2 = result;
+
                     /* Rewrite (a[i..j] = e2) as:
                      *      a.opSliceAssign(e2, i, j)
                      */
@@ -11563,6 +11576,7 @@ public:
                     result = Expression.combine(e0, result);
                     return result;
                 }
+
                 // No operator overloading member function found yet, but
                 // there might be an alias this to try.
                 if (ad.aliasthis && t1b != ae.att1)
@@ -11581,10 +11595,12 @@ public:
             ae.e1 = ae1old; // recovery
             ae.lengthVar = null;
         }
+
         /* Run this->e1 semantic.
          */
         {
             Expression e1x = e1;
+
             /* With UFCS, e.f = value
              * Could mean:
              *      .f(e, value)
@@ -11618,6 +11634,7 @@ public:
             }
             else
                 e1x = e1x.semantic(sc);
+
             /* We have f = value.
              * Could mean:
              *      f(value)
@@ -11632,6 +11649,7 @@ public:
             assert(e1.type);
         }
         Type t1 = e1.type.toBasetype();
+
         /* Run this->e2 semantic.
          * Different from other binary expressions, the analysis of e2
          * depends on the result of e1 in assignments.
@@ -11646,10 +11664,12 @@ public:
                 return new ErrorExp();
             e2 = e2x;
         }
+
         /* Rewrite tuple assignment as a tuple of assignments.
          */
         {
             Expression e2x = e2;
+
         Ltupleassign:
             if (e1.op == TOKtuple && e2x.op == TOKtuple)
             {
@@ -11682,6 +11702,7 @@ public:
                 }
                 return e.semantic(sc);
             }
+
             /* Look for form: e1 = e2->aliasthis.
              */
             if (e1.op == TOKtuple)
@@ -11689,8 +11710,10 @@ public:
                 TupleDeclaration td = isAliasThisTuple(e2x);
                 if (!td)
                     goto Lnomatch;
+
                 assert(e1.type.ty == Ttuple);
                 TypeTuple tt = cast(TypeTuple)e1.type;
+
                 Identifier id = Identifier.generateId("__tup");
                 auto ei = new ExpInitializer(e2x.loc, e2x);
                 auto v = new VarDeclaration(e2x.loc, null, id, ei);
@@ -11700,16 +11723,19 @@ public:
                 Expression e0 = new DeclarationExp(e2x.loc, v);
                 Expression ev = new VarExp(e2x.loc, v);
                 ev.type = e2x.type;
+
                 auto iexps = new Expressions();
                 iexps.push(ev);
                 for (size_t u = 0; u < iexps.dim; u++)
                 {
                 Lexpand:
                     Expression e = (*iexps)[u];
+
                     Parameter arg = Parameter.getNth(tt.arguments, u);
                     //printf("[%d] iexps->dim = %d, ", u, iexps->dim);
                     //printf("e = (%s %s, %s), ", Token::tochars[e->op], e->toChars(), e->type->toChars());
                     //printf("arg = (%s, %s)\n", arg->toChars(), arg->type->toChars());
+
                     if (!arg || !e.type.implicitConvTo(arg.type))
                     {
                         // expand initializer to tuple
@@ -11731,6 +11757,7 @@ public:
             }
         Lnomatch:
         }
+
         /* Inside constructor, if this is the first assignment of object field,
          * rewrite this to initializing the field.
          */
@@ -11738,12 +11765,14 @@ public:
         {
             //printf("[%s] change to init - %s\n", loc.toChars(), toChars());
             op = TOKconstruct;
+
             if (e1.op == TOKvar && (cast(VarExp)e1).var.storage_class & (STCout | STCref))
             {
                 // Bugzilla 14944, even if e1 is a ref variable,
                 // make an initialization of referenced memory.
                 ismemset |= 2;
             }
+
             // Bugzilla 13515: set Index::modifiable flag for complex AA element initialization
             if (e1.op == TOKindex)
             {
@@ -11752,10 +11781,13 @@ public:
                     return e1x;
             }
         }
+
         /* If it is an assignment from a 'foreign' type,
          * check for operator overloading.
          */
-        if (op == TOKconstruct && e1.op == TOKvar && (cast(VarExp)e1).var.storage_class & (STCout | STCref) && !(ismemset & 2))
+        if (op == TOKconstruct && e1.op == TOKvar &&
+            (cast(VarExp)e1).var.storage_class & (STCout | STCref) &&
+            !(ismemset & 2))
         {
             // If this is an initialization of a reference,
             // do nothing
@@ -11765,6 +11797,7 @@ public:
             Expression e1x = e1;
             Expression e2x = e2;
             StructDeclaration sd = (cast(TypeStruct)t1).sym;
+
             if (op == TOKconstruct)
             {
                 Type t2 = e2x.type.toBasetype();
@@ -11772,11 +11805,16 @@ public:
                 {
                     CallExp ce;
                     DotVarExp dve;
-                    if (sd.ctor && e2x.op == TOKcall && (ce = cast(CallExp)e2x, ce.e1.op == TOKdotvar) && (dve = cast(DotVarExp)ce.e1, dve.var.isCtorDeclaration()) && e2x.type.implicitConvTo(t1))
+                    if (sd.ctor &&
+                        e2x.op == TOKcall &&
+                        (ce = cast(CallExp)e2x, ce.e1.op == TOKdotvar) &&
+                        (dve = cast(DotVarExp)ce.e1, dve.var.isCtorDeclaration()) &&
+                        e2x.type.implicitConvTo(t1))
                     {
                         /* Look for form of constructor call which is:
                          *    __ctmp.ctor(arguments...)
                          */
+
                         /* Before calling the constructor, initialize
                          * variable with a bit copy of the default
                          * initializer
@@ -11793,6 +11831,7 @@ public:
                             ae.e2 = sd.isNested() ? t1.defaultInitLiteral(loc) : t1.defaultInit(loc);
                         }
                         ae.type = e1x.type;
+
                         /* Replace __ctmp being constructed with e1.
                          * We need to copy constructor call expression,
                          * because it may be used in other place.
@@ -11801,6 +11840,7 @@ public:
                         dvx.e1 = e1x;
                         CallExp cx = cast(CallExp)ce.copy();
                         cx.e1 = dvx;
+
                         Expression e = new CommaExp(loc, ae, cx);
                         e = e.semantic(sc);
                         return e;
@@ -11820,13 +11860,16 @@ public:
                             Expression e = new CondExp(loc, econd.econd, ea1, ea2);
                             return e.semantic(sc);
                         }
+
                         if (e2x.isLvalue())
                         {
                             if (!e2x.type.implicitConvTo(e1x.type))
                             {
-                                error("conversion error from %s to %s", e2x.type.toChars(), e1x.type.toChars());
+                                error("conversion error from %s to %s",
+                                    e2x.type.toChars(), e1x.type.toChars());
                                 return new ErrorExp();
                             }
+
                             /* Rewrite as:
                              *  (e1 = e2).postblit();
                              *
@@ -11860,6 +11903,7 @@ public:
                         Expression einit;
                         einit = new BlitExp(loc, e1x, e1x.type.defaultInit(loc));
                         einit.type = e1x.type;
+
                         Expression e;
                         e = new DotIdExp(loc, e1x, Id.ctor);
                         e = new CallExp(loc, e, e2x);
@@ -11876,6 +11920,7 @@ public:
                          */
                         e2x = typeDotIdExp(e2x.loc, e1x.type, Id.call);
                         e2x = new CallExp(loc, e2x, this.e2);
+
                         e2x = e2x.semantic(sc);
                         e2x = resolveProperties(sc, e2x);
                         if (e2x.op == TOKerror)
@@ -11917,35 +11962,46 @@ public:
                     IndexExp ie = cast(IndexExp)e1x;
                     Type t2 = e2x.type.toBasetype();
                     Expression e0 = null;
+
                     Expression ea = ie.e1;
                     Expression ek = ie.e2;
                     Expression ev = e2x;
                     if (!isTrivialExp(ea))
                     {
-                        auto v = new VarDeclaration(loc, ie.e1.type, Identifier.generateId("__aatmp"), new ExpInitializer(loc, ie.e1));
-                        v.storage_class |= STCtemp | STCctfe | (ea.isLvalue() ? STCforeach | STCref : STCrvalue);
+                        auto v = new VarDeclaration(loc, ie.e1.type,
+                            Identifier.generateId("__aatmp"),
+                            new ExpInitializer(loc, ie.e1));
+                        v.storage_class |= STCtemp | STCctfe
+                                        | (ea.isLvalue() ? STCforeach | STCref : STCrvalue);
                         v.semantic(sc);
                         e0 = combine(e0, new DeclarationExp(loc, v));
                         ea = new VarExp(loc, v);
                     }
                     if (!isTrivialExp(ek))
                     {
-                        auto v = new VarDeclaration(loc, ie.e2.type, Identifier.generateId("__aakey"), new ExpInitializer(loc, ie.e2));
-                        v.storage_class |= STCtemp | STCctfe | (ek.isLvalue() ? STCforeach | STCref : STCrvalue);
+                        auto v = new VarDeclaration(loc, ie.e2.type,
+                            Identifier.generateId("__aakey"),
+                            new ExpInitializer(loc, ie.e2));
+                        v.storage_class |= STCtemp | STCctfe
+                                        | (ek.isLvalue() ? STCforeach | STCref : STCrvalue);
                         v.semantic(sc);
                         e0 = combine(e0, new DeclarationExp(loc, v));
                         ek = new VarExp(loc, v);
                     }
                     if (!isTrivialExp(ev))
                     {
-                        auto v = new VarDeclaration(loc, e2x.type, Identifier.generateId("__aaval"), new ExpInitializer(loc, e2x));
-                        v.storage_class |= STCtemp | STCctfe | (ev.isLvalue() ? STCforeach | STCref : STCrvalue);
+                        auto v = new VarDeclaration(loc, e2x.type,
+                            Identifier.generateId("__aaval"),
+                            new ExpInitializer(loc, e2x));
+                        v.storage_class |= STCtemp | STCctfe
+                                        | (ev.isLvalue() ? STCforeach | STCref : STCrvalue);
                         v.semantic(sc);
                         e0 = combine(e0, new DeclarationExp(loc, v));
                         ev = new VarExp(loc, v);
                     }
                     if (e0)
                         e0 = e0.semantic(sc);
+
                     AssignExp ae = cast(AssignExp)copy();
                     ae.e1 = new IndexExp(loc, ea, ek);
                     ae.e1 = ae.e1.semantic(sc);
@@ -11975,11 +12031,13 @@ public:
                             ex = ex.semantic(sc);
                             ex = ex.optimize(WANTvalue);
                             ex = ex.modifiableLvalue(sc, ex); // allocate new slot
+
                             ey = new ConstructExp(loc, ex, ey);
                             ey = ey.semantic(sc);
                             if (ey.op == TOKerror)
                                 return ey;
                             ex = e;
+
                             // Bugzilla 14144: The whole expression should have the common type
                             // of opAssign() return and assigned AA entry.
                             // Even if there's no common type, expression should be typed as void.
@@ -12005,6 +12063,7 @@ public:
             }
             else
                 assert(op == TOKblit);
+
             e1 = e1x;
             e2 = e2x;
         }
@@ -12142,16 +12201,21 @@ public:
                 return e1x;
             e1 = e1x;
         }
+
         /* Tweak e2 based on the type of e1.
          */
         Expression e2x = e2;
         Type t2 = e2x.type.toBasetype();
+
         // If it is a array, get the element type. Note that it may be
         // multi-dimensional.
         Type telem = t1;
         while (telem.ty == Tarray)
             telem = telem.nextOf();
-        if (e1.op == TOKslice && t1.nextOf() && (telem.ty != Tvoid || e2x.op == TOKnull) && e2x.implicitConvTo(t1.nextOf()))
+
+        if (e1.op == TOKslice && t1.nextOf() &&
+            (telem.ty != Tvoid || e2x.op == TOKnull) &&
+            e2x.implicitConvTo(t1.nextOf()))
         {
             // Check for block assignment. If it is of type void[], void[][], etc,
             // '= null' is the only allowable block assignment (Bug 7493)
@@ -12163,9 +12227,12 @@ public:
                 return new ErrorExp();
             }
         }
-        else if (e1.op == TOKslice && (t2.ty == Tarray || t2.ty == Tsarray) && t2.nextOf().implicitConvTo(t1.nextOf()))
+        else if (e1.op == TOKslice &&
+                 (t2.ty == Tarray || t2.ty == Tsarray) &&
+                 t2.nextOf().implicitConvTo(t1.nextOf()))
         {
             // Check element-wise assignment.
+
             /* If assigned elements number is known at compile time,
              * check the mismatch.
              */
@@ -12188,21 +12255,36 @@ public:
                     return new ErrorExp();
                 }
             }
-            if (op != TOKblit && (e2x.op == TOKslice && (cast(UnaExp)e2x).e1.isLvalue() || e2x.op == TOKcast && (cast(UnaExp)e2x).e1.isLvalue() || e2x.op != TOKslice && e2x.isLvalue()))
+
+            if (op != TOKblit &&
+                (e2x.op == TOKslice && (cast(UnaExp)e2x).e1.isLvalue() ||
+                 e2x.op == TOKcast && (cast(UnaExp)e2x).e1.isLvalue() ||
+                 e2x.op != TOKslice && e2x.isLvalue()))
             {
                 if (e1.checkPostblit(sc, t1.nextOf()))
                     return new ErrorExp();
             }
-            if (0 && global.params.warnings && !global.gag && op == TOKassign && e2x.op != TOKslice && e2x.op != TOKassign && e2x.op != TOKarrayliteral && e2x.op != TOKstring && !(e2x.op == TOKadd || e2x.op == TOKmin || e2x.op == TOKmul || e2x.op == TOKdiv || e2x.op == TOKmod || e2x.op == TOKxor || e2x.op == TOKand || e2x.op == TOKor || e2x.op == TOKpow || e2x.op == TOKtilde || e2x.op == TOKneg))
+
+            if (0 && global.params.warnings && !global.gag && op == TOKassign &&
+                e2x.op != TOKslice && e2x.op != TOKassign &&
+                e2x.op != TOKarrayliteral && e2x.op != TOKstring &&
+                !(e2x.op == TOKadd || e2x.op == TOKmin ||
+                  e2x.op == TOKmul || e2x.op == TOKdiv ||
+                  e2x.op == TOKmod || e2x.op == TOKxor ||
+                  e2x.op == TOKand || e2x.op == TOKor ||
+                  e2x.op == TOKpow ||
+                  e2x.op == TOKtilde || e2x.op == TOKneg))
             {
                 const(char)* e1str = e1.toChars();
                 const(char)* e2str = e2x.toChars();
                 warning("explicit element-wise assignment %s = (%s)[] is better than %s = %s", e1str, e2str, e1str, e2str);
             }
+
             Type t2n = t2.nextOf();
             Type t1n = t1.nextOf();
             int offset;
-            if (t2n.equivalent(t1n) || t1n.isBaseOf(t2n, &offset) && offset == 0)
+            if (t2n.equivalent(t1n) ||
+                t1n.isBaseOf(t2n, &offset) && offset == 0)
             {
                 /* Allow copy of distinct qualifier elements.
                  * eg.
@@ -12227,7 +12309,10 @@ public:
         }
         else
         {
-            if (0 && global.params.warnings && !global.gag && op == TOKassign && t1.ty == Tarray && t2.ty == Tsarray && e2x.op != TOKslice && t2.implicitConvTo(t1))
+            if (0 && global.params.warnings && !global.gag && op == TOKassign &&
+                t1.ty == Tarray && t2.ty == Tsarray &&
+                e2x.op != TOKslice &&
+                t2.implicitConvTo(t1))
             {
                 // Disallow ar[] = sa (Converted to ar[] = sa[])
                 // Disallow da   = sa (Converted to da   = sa[])
@@ -12245,26 +12330,33 @@ public:
             return e2x;
         e2 = e2x;
         t2 = e2.type.toBasetype();
+
         /* Look for array operations
          */
         if ((t2.ty == Tarray || t2.ty == Tsarray) && isArrayOpValid(e2))
         {
             // Look for valid array operations
-            if (!(ismemset & 1) && e1.op == TOKslice && (isUnaArrayOp(e2.op) || isBinArrayOp(e2.op)))
+            if (!(ismemset & 1) &&
+                e1.op == TOKslice &&
+                (isUnaArrayOp(e2.op) || isBinArrayOp(e2.op)))
             {
                 type = e1.type;
                 if (op == TOKconstruct) // Bugzilla 10282: tweak mutability of e1 element
                     e1.type = e1.type.nextOf().mutableOf().arrayOf();
                 return arrayOp(this, sc);
             }
+
             // Drop invalid array operations in e2
             //  d = a[] + b[], d = (a[] + b[])[0..2], etc
             if (checkNonAssignmentArrayOp(e2, !(ismemset & 1) && op == TOKassign))
                 return new ErrorExp();
+
             // Remains valid array assignments
             //  d = d[], d = [1,2,3], etc
         }
-        if (e1.op == TOKvar && ((cast(VarExp)e1).var.storage_class & STCscope) && op == TOKassign)
+        if (e1.op == TOKvar &&
+            ((cast(VarExp)e1).var.storage_class & STCscope) &&
+            op == TOKassign)
         {
             error("cannot rebind scope variables");
         }
@@ -12272,6 +12364,7 @@ public:
         {
             error("cannot modify compiler-generated variable __ctfe");
         }
+
         type = e1.type;
         assert(type);
         return op == TOKassign ? reorderSettingAAElem(sc) : this;

--- a/src/expression.d
+++ b/src/expression.d
@@ -12413,11 +12413,23 @@ public:
 extern (C++) final class ConstructExp : AssignExp
 {
 public:
-    extern (D) this(Loc loc, Expression e1, Expression e2, bool isRefInit = false)
+    extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, e1, e2);
         op = TOKconstruct;
-        if (isRefInit)
+    }
+
+    // Internal use only. If `v` is a reference variable, the assinment
+    // will become a reference initialization automatically.
+    extern (D) this(Loc loc, VarDeclaration v, Expression e2)
+    {
+        auto ve = new VarExp(loc, v);
+        assert(v.type && ve.type);
+
+        super(loc, ve, e2);
+        op = TOKconstruct;
+
+        if (v.storage_class & (STCref | STCout))
             memset |= MemorySet.referenceInit;
     }
 
@@ -12432,11 +12444,23 @@ public:
 extern (C++) final class BlitExp : AssignExp
 {
 public:
-    extern (D) this(Loc loc, Expression e1, Expression e2, bool isRefInit = false)
+    extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, e1, e2);
         op = TOKblit;
-        if (isRefInit)
+    }
+
+    // Internal use only. If `v` is a reference variable, the assinment
+    // will become a reference rebinding automatically.
+    extern (D) this(Loc loc, VarDeclaration v, Expression e2)
+    {
+        auto ve = new VarExp(loc, v);
+        assert(v.type && ve.type);
+
+        super(loc, ve, e2);
+        op = TOKblit;
+
+        if (v.storage_class & (STCref | STCout))
             memset |= MemorySet.referenceInit;
     }
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -12432,10 +12432,12 @@ public:
 extern (C++) final class BlitExp : AssignExp
 {
 public:
-    extern (D) this(Loc loc, Expression e1, Expression e2)
+    extern (D) this(Loc loc, Expression e1, Expression e2, bool isRefInit = false)
     {
         super(loc, e1, e2);
         op = TOKblit;
+        if (isRefInit)
+            memset |= MemorySet.referenceInit;
     }
 
     override void accept(Visitor v)

--- a/src/expression.h
+++ b/src/expression.h
@@ -1188,14 +1188,16 @@ public:
 class ConstructExp : public AssignExp
 {
 public:
-    ConstructExp(Loc loc, Expression *e1, Expression *e2, bool isRefInit = false);
+    ConstructExp(Loc loc, Expression *e1, Expression *e2);
+    ConstructExp(Loc loc, VarDeclaration *v, Expression *e2);
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class BlitExp : public AssignExp
 {
 public:
-    BlitExp(Loc loc, Expression *e1, Expression *e2, bool isRefInit = false);
+    BlitExp(Loc loc, Expression *e1, Expression *e2);
+    BlitExp(Loc loc, VarDeclaration *v, Expression *e2);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -1165,12 +1165,16 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+enum MemorySet
+{
+    MemorySet_blockAssign     = 1,    // setting the contents of an array
+    MemorySet_refValueInit    = 2,    // setting the content of ref variable
+};
+
 class AssignExp : public BinExp
 {
 public:
-    // &1 != 0 if setting the contents of an array
-    // &2 != 0 if setting the content of ref variable
-    int ismemset;
+    int memset;         // combination of MemorySet flags
 
     AssignExp(Loc loc, Expression *e1, Expression *e2);
     Expression *semantic(Scope *sc);

--- a/src/expression.h
+++ b/src/expression.h
@@ -1195,7 +1195,7 @@ public:
 class BlitExp : public AssignExp
 {
 public:
-    BlitExp(Loc loc, Expression *e1, Expression *e2);
+    BlitExp(Loc loc, Expression *e1, Expression *e2, bool isRefInit = false);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -1168,7 +1168,7 @@ public:
 enum MemorySet
 {
     MemorySet_blockAssign     = 1,    // setting the contents of an array
-    MemorySet_refValueInit    = 2,    // setting the content of ref variable
+    MemorySet_referenceInit   = 2,    // setting the reference of STCref variable
 };
 
 class AssignExp : public BinExp
@@ -1188,7 +1188,7 @@ public:
 class ConstructExp : public AssignExp
 {
 public:
-    ConstructExp(Loc loc, Expression *e1, Expression *e2);
+    ConstructExp(Loc loc, Expression *e1, Expression *e2, bool isRefInit = false);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/func.d
+++ b/src/func.d
@@ -1793,6 +1793,7 @@ public:
                     assert(tret.ty != Tvoid);
                     if (vresult || returnLabel)
                         buildResultVar(scout ? scout : sc2, tret);
+
                     /* Cannot move this loop into NrvoWalker, because
                      * returns[i] may be in the nested delegate for foreach-body.
                      */
@@ -1817,6 +1818,7 @@ public:
                         else
                         {
                             exp = exp.optimize(WANTvalue);
+
                             /* Bugzilla 10789:
                              * If NRVO is not possible, all returned lvalues should call their postblits.
                              */

--- a/src/func.d
+++ b/src/func.d
@@ -1832,10 +1832,7 @@ public:
                             // Create: return vresult = exp;
                             auto ve = new VarExp(Loc(), vresult);
                             ve.type = vresult.type;
-                            if (f.isref)
-                                exp = new ConstructExp(rs.loc, ve, exp);
-                            else
-                                exp = new BlitExp(rs.loc, ve, exp);
+                            exp = new BlitExp(rs.loc, ve, exp, f.isref);
                             exp.type = ve.type;
                             if (rs.caseDim)
                                 exp = Expression.combine(exp, new IntegerExp(rs.caseDim));

--- a/src/func.d
+++ b/src/func.d
@@ -1830,10 +1830,8 @@ public:
                         if (vresult)
                         {
                             // Create: return vresult = exp;
-                            auto ve = new VarExp(Loc(), vresult);
-                            ve.type = vresult.type;
-                            exp = new BlitExp(rs.loc, ve, exp, f.isref);
-                            exp.type = ve.type;
+                            exp = new BlitExp(rs.loc, vresult, exp);
+                            exp.type = vresult.type;
                             if (rs.caseDim)
                                 exp = Expression.combine(exp, new IntegerExp(rs.caseDim));
                         }
@@ -2017,8 +2015,7 @@ public:
                      */
                     Expression e = new VarExp(Loc(), v_arguments);
                     e = new DotIdExp(Loc(), e, Id.elements);
-                    Expression e1 = new VarExp(Loc(), _arguments);
-                    e = new ConstructExp(Loc(), e1, e);
+                    e = new ConstructExp(Loc(), _arguments, e);
                     e = e.semantic(sc2);
                     _arguments._init = new ExpInitializer(Loc(), e);
                     auto de = new DeclarationExp(Loc(), _arguments);

--- a/src/inline.d
+++ b/src/inline.d
@@ -2009,9 +2009,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             de.type = Type.tvoid;
             e = Expression.combine(e, de);
 
-            Expression ex = new VarExp(fd.loc, vret);
-            ex.type = vret.type;
-            ex = new ConstructExp(fd.loc, ex, eret, vret.isRef());
+            Expression ex = new ConstructExp(fd.loc, vret, eret);
             ex.type = vret.type;
             e = Expression.combine(e, ex);
         }
@@ -2036,11 +2034,8 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
         vthis.linkage = LINKd;
         vthis.parent = parent;
 
-        auto ve = new VarExp(vthis.loc, vthis);
-        ve.type = vthis.type;
-
-        ei.exp = new ConstructExp(vthis.loc, ve, ethis, vthis.isRef());
-        ei.exp.type = ve.type;
+        ei.exp = new ConstructExp(vthis.loc, vthis, ethis);
+        ei.exp.type = vthis.type;
 
         ids.vthis = vthis;
     }
@@ -2095,12 +2090,8 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             //printf("vto.parent = '%s'\n", parent.toChars());
 
             // Even if vto is STClazy, `vto = arg` is handled correctly in glue layer.
-            auto ve = new VarExp(vto.loc, vto);
-            ve.type = vto.type;
-
-            ei.exp = new BlitExp(vto.loc, ve, arg, (vfrom.storage_class & (STCout | STCref)) != 0);
+            ei.exp = new BlitExp(vto.loc, vto, arg);
             ei.exp.type = vto.type;
-            //ve.type.print();
             //arg.type.print();
             //ei.exp.print();
 
@@ -2177,18 +2168,15 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             vd.linkage = tf.linkage;
             vd.parent = parent;
 
-            auto ve = new VarExp(fd.loc, vd);
-            ve.type = tf.next;
-
-            ei.exp = new ConstructExp(fd.loc, ve, e, vd.isRef());
-            ei.exp.type = ve.type;
+            ei.exp = new ConstructExp(fd.loc, vd, e);
+            ei.exp.type = vd.type;
 
             auto de = new DeclarationExp(Loc(), vd);
             de.type = Type.tvoid;
 
             // Chain the two together:
             //   ( typeof(return) __inlineretval = ( inlined body )) , __inlineretval
-            e = Expression.combine(de, ve);
+            e = Expression.combine(de, new VarExp(fd.loc, vd));
 
             //fprintf(stderr, "CallExp.inlineScan: e = "); e.print();
         }

--- a/src/inline.d
+++ b/src/inline.d
@@ -2098,10 +2098,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             auto ve = new VarExp(vto.loc, vto);
             ve.type = vto.type;
 
-            if (vfrom.storage_class & (STCout | STCref))
-                ei.exp = new ConstructExp(vto.loc, ve, arg, true);
-            else
-                ei.exp = new BlitExp(vto.loc, ve, arg);
+            ei.exp = new BlitExp(vto.loc, ve, arg, (vfrom.storage_class & (STCout | STCref)) != 0);
             ei.exp.type = vto.type;
             //ve.type.print();
             //arg.type.print();

--- a/src/inline.d
+++ b/src/inline.d
@@ -2094,14 +2094,15 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             //printf("vto = '%s', vto.storage_class = x%x\n", vto.toChars(), vto.storage_class);
             //printf("vto.parent = '%s'\n", parent.toChars());
 
+            // Even if vto is STClazy, `vto = arg` is handled correctly in glue layer.
             auto ve = new VarExp(vto.loc, vto);
-            ve.type = arg.type;
+            ve.type = vto.type;
 
             if (vfrom.storage_class & (STCout | STCref))
                 ei.exp = new ConstructExp(vto.loc, ve, arg, true);
             else
                 ei.exp = new BlitExp(vto.loc, ve, arg);
-            ei.exp.type = ve.type;
+            ei.exp.type = vto.type;
             //ve.type.print();
             //arg.type.print();
             //ei.exp.print();

--- a/src/inline.d
+++ b/src/inline.d
@@ -2011,7 +2011,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
 
             Expression ex = new VarExp(fd.loc, vret);
             ex.type = vret.type;
-            ex = new ConstructExp(fd.loc, ex, eret);
+            ex = new ConstructExp(fd.loc, ex, eret, vret.isRef());
             ex.type = vret.type;
             e = Expression.combine(e, ex);
         }
@@ -2039,14 +2039,8 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
         auto ve = new VarExp(vthis.loc, vthis);
         ve.type = vthis.type;
 
-        ei.exp = new AssignExp(vthis.loc, ve, ethis);
+        ei.exp = new ConstructExp(vthis.loc, ve, ethis, vthis.isRef());
         ei.exp.type = ve.type;
-        if (ethis.type.ty != Tclass)
-        {
-            /* This is a reference initialization, not a simple assignment.
-             */
-            ei.exp.op = TOKconstruct;
-        }
 
         ids.vthis = vthis;
     }
@@ -2101,11 +2095,10 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             //printf("vto.parent = '%s'\n", parent.toChars());
 
             auto ve = new VarExp(vto.loc, vto);
-            //ve.type = vto.type;
             ve.type = arg.type;
 
             if (vfrom.storage_class & (STCout | STCref))
-                ei.exp = new ConstructExp(vto.loc, ve, arg);
+                ei.exp = new ConstructExp(vto.loc, ve, arg, true);
             else
                 ei.exp = new BlitExp(vto.loc, ve, arg);
             ei.exp.type = ve.type;
@@ -2189,7 +2182,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             auto ve = new VarExp(fd.loc, vd);
             ve.type = tf.next;
 
-            ei.exp = new ConstructExp(fd.loc, ve, e);
+            ei.exp = new ConstructExp(fd.loc, ve, e, vd.isRef());
             ei.exp.type = ve.type;
 
             auto de = new DeclarationExp(Loc(), vd);
@@ -2203,7 +2196,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
         }
         eresult = e;
     }
-    //printf("%s.expandInline = { %s }\n", fd.toChars(), e.toChars());
+    //printf("[%s] %s expandInline = { %s }\n", fd.loc.toChars(), fd.toPrettyChars(), e.toChars());
 
     // Need to reevaluate whether parent can now be inlined
     // in expressions, as we might have inlined statements

--- a/src/inline.d
+++ b/src/inline.d
@@ -1735,13 +1735,16 @@ public:
 bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsToo)
 {
     int cost;
+
     enum CANINLINE_LOG = 0;
     static if (CANINLINE_LOG)
     {
         printf("FuncDeclaration.canInline(hasthis = %d, statementsToo = %d, '%s')\n", hasthis, statementsToo, fd.toPrettyChars());
     }
+
     if (fd.needThis() && !hasthis)
         return false;
+
     if (fd.inlineNest)
     {
         static if (CANINLINE_LOG)
@@ -1750,6 +1753,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
         }
         return false;
     }
+
     if (fd.semanticRun < PASSsemantic3 && !hdrscan)
     {
         if (!fd.fbody)
@@ -1761,6 +1765,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
             return false;
         assert(fd.semanticRun >= PASSsemantic3done);
     }
+
     switch (statementsToo ? fd.inlineStatusStmt : fd.inlineStatusExp)
     {
     case ILSyes:
@@ -1780,6 +1785,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
     default:
         assert(0);
     }
+
     switch (fd.inlining)
     {
     case PINLINEdefault:
@@ -1791,23 +1797,33 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
     default:
         assert(0);
     }
+
     if (fd.type)
     {
         assert(fd.type.ty == Tfunction);
         TypeFunction tf = cast(TypeFunction)fd.type;
-        if (tf.varargs == 1) // no variadic parameter lists
+
+        // no variadic parameter lists
+        if (tf.varargs == 1)
             goto Lno;
+
         /* Don't inline a function that returns non-void, but has
          * no return expression.
          * No statement inlining for non-voids.
          */
-        if (tf.next && tf.next.ty != Tvoid && (!(fd.hasReturnExp & 1) || statementsToo) && !hdrscan)
+        if (tf.next && tf.next.ty != Tvoid &&
+            (!(fd.hasReturnExp & 1) || statementsToo) &&
+            !hdrscan)
+        {
             goto Lno;
+        }
+
         /* Bugzilla 14560: If fd returns void, all explicit `return;`s
          * must not appear in the expanded result.
          * See also ReturnStatement.inlineAsStatement().
          */
     }
+
     // cannot inline constructor calls because we need to convert:
     //      return;
     // to:
@@ -1816,10 +1832,19 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
     // require() has magic properties too
     // see bug 7699
     // no nested references to this frame
-    if (!fd.fbody || fd.ident == Id.ensure || (fd.ident == Id.require && fd.toParent().isFuncDeclaration() && fd.toParent().isFuncDeclaration().needThis()) || !hdrscan && (fd.isSynchronized() || fd.isImportedSymbol() || fd.hasNestedFrameRefs() || (fd.isVirtual() && !fd.isFinalFunc())))
+    if (!fd.fbody ||
+        fd.ident == Id.ensure ||
+        (fd.ident == Id.require &&
+         fd.toParent().isFuncDeclaration() &&
+         fd.toParent().isFuncDeclaration().needThis()) ||
+        !hdrscan && (fd.isSynchronized() ||
+                     fd.isImportedSymbol() ||
+                     fd.hasNestedFrameRefs() ||
+                     (fd.isVirtual() && !fd.isFinalFunc())))
     {
         goto Lno;
     }
+
     {
         scope InlineCostVisitor icv = new InlineCostVisitor();
         icv.hasthis = hasthis;
@@ -1832,10 +1857,12 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
     {
         printf("cost = %d for %s\n", cost, fd.toChars());
     }
+
     if (tooCostly(cost))
         goto Lno;
     if (!statementsToo && cost > COST_MAX)
         goto Lno;
+
     if (!hdrscan)
     {
         // Don't modify inlineStatus for header content scan
@@ -1843,8 +1870,10 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
             fd.inlineStatusStmt = ILSyes;
         else
             fd.inlineStatusExp = ILSyes;
+
         scope InlineScanVisitor v = new InlineScanVisitor();
         fd.accept(v); // Don't scan recursively for header content scan
+
         if (fd.inlineStatusExp == ILSuninitialized)
         {
             // Need to redo cost computation, as some statements or expressions have been inlined
@@ -1858,10 +1887,12 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
             {
                 printf("recomputed cost = %d for %s\n", cost, fd.toChars());
             }
+
             if (tooCostly(cost))
                 goto Lno;
             if (!statementsToo && cost > COST_MAX)
                 goto Lno;
+
             if (statementsToo)
                 fd.inlineStatusStmt = ILSyes;
             else
@@ -1873,9 +1904,11 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
         printf("\t2: yes %s\n", fd.toChars());
     }
     return true;
+
 Lno:
     if (fd.inlining == PINLINEalways)
         fd.error("cannot inline function");
+
     if (!hdrscan) // Don't modify inlineStatus for header content scan
     {
         if (statementsToo)
@@ -1902,10 +1935,13 @@ public void inlineScanModule(Module m)
     if (m.semanticRun != PASSsemantic3done)
         return;
     m.semanticRun = PASSinline;
+
     // Note that modules get their own scope, from scratch.
     // This is so regardless of where in the syntax a module
     // gets imported, it is unaffected by context.
+
     //printf("Module = %p\n", m.sc.scopesym);
+
     foreach (i; 0 .. m.members.dim)
     {
         Dsymbol s = (*m.members)[i];
@@ -1950,6 +1986,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
 
     if (asStatements)
         as = new Statements();
+
     VarDeclaration vret = null;
     if (eret)
     {
@@ -1967,9 +2004,11 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             vret.storage_class |= STCtemp | STCforeach | STCref;
             vret.linkage = LINKd;
             vret.parent = parent;
+
             Expression de = new DeclarationExp(fd.loc, vret);
             de.type = Type.tvoid;
             e = Expression.combine(e, de);
+
             Expression ex = new VarExp(fd.loc, vret);
             ex.type = vret.type;
             ex = new ConstructExp(fd.loc, ex, eret);
@@ -1977,28 +2016,29 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             e = Expression.combine(e, ex);
         }
     }
+
     // Set up vthis
     if (ethis)
     {
-        VarDeclaration vthis;
-        ExpInitializer ei;
-        VarExp ve;
         if (ethis.type.ty == Tpointer)
         {
             Type t = ethis.type.nextOf();
             ethis = new PtrExp(ethis.loc, ethis);
             ethis.type = t;
         }
-        ei = new ExpInitializer(ethis.loc, ethis);
-        vthis = new VarDeclaration(ethis.loc, ethis.type, Id.This, ei);
+        auto ei = new ExpInitializer(ethis.loc, ethis);
+
+        auto vthis = new VarDeclaration(ethis.loc, ethis.type, Id.This, ei);
         if (ethis.type.ty != Tclass)
             vthis.storage_class = STCref;
         else
             vthis.storage_class = STCin;
         vthis.linkage = LINKd;
         vthis.parent = parent;
-        ve = new VarExp(vthis.loc, vthis);
+
+        auto ve = new VarExp(vthis.loc, vthis);
         ve.type = vthis.type;
+
         ei.exp = new AssignExp(vthis.loc, ve, ethis);
         ei.exp.type = ve.type;
         if (ethis.type.ty != Tclass)
@@ -2007,8 +2047,10 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
              */
             ei.exp.op = TOKconstruct;
         }
+
         ids.vthis = vthis;
     }
+
     // Set up parameters
     if (ethis)
     {
@@ -2016,6 +2058,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
         de.type = Type.tvoid;
         e = Expression.combine(e, de);
     }
+
     if (!asStatements && fd.nrvo_var)
     {
         if (vret)
@@ -2031,8 +2074,10 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             vd.storage_class = STCtemp | STCrvalue;
             vd.linkage = tf.linkage;
             vd.parent = parent;
+
             ids.from.push(fd.nrvo_var);
             ids.to.push(vd);
+
             Expression de = new DeclarationExp(Loc(), vd);
             de.type = Type.tvoid;
             e = Expression.combine(e, de);
@@ -2043,21 +2088,22 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
         assert(fd.parameters.dim == arguments.dim);
         foreach (i; 0 .. arguments.dim)
         {
-            VarDeclaration vfrom = (*fd.parameters)[i];
-            VarDeclaration vto;
-            Expression arg = (*arguments)[i];
-            ExpInitializer ei;
-            VarExp ve;
-            ei = new ExpInitializer(arg.loc, arg);
-            vto = new VarDeclaration(vfrom.loc, vfrom.type, vfrom.ident, ei);
+            auto vfrom = (*fd.parameters)[i];
+
+            auto arg = (*arguments)[i];
+            auto ei = new ExpInitializer(arg.loc, arg);
+
+            auto vto = new VarDeclaration(vfrom.loc, vfrom.type, vfrom.ident, ei);
             vto.storage_class |= vfrom.storage_class & (STCtemp | STCin | STCout | STClazy | STCref);
             vto.linkage = vfrom.linkage;
             vto.parent = parent;
             //printf("vto = '%s', vto.storage_class = x%x\n", vto.toChars(), vto.storage_class);
             //printf("vto.parent = '%s'\n", parent.toChars());
-            ve = new VarExp(vto.loc, vto);
+
+            auto ve = new VarExp(vto.loc, vto);
             //ve.type = vto.type;
             ve.type = arg.type;
+
             if (vfrom.storage_class & (STCout | STCref))
                 ei.exp = new ConstructExp(vto.loc, ve, arg);
             else
@@ -2066,8 +2112,10 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             //ve.type.print();
             //arg.type.print();
             //ei.exp.print();
+
             ids.from.push(vfrom);
             ids.to.push(vto);
+
             auto de = new DeclarationExp(Loc(), vto);
             de.type = Type.tvoid;
             e = Expression.combine(e, de);
@@ -2083,6 +2131,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             }
         }
     }
+
     if (asStatements)
     {
         if (e)
@@ -2105,9 +2154,11 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
         //eb.type.print();
         //eb.print();
         //eb.print();
+
         // Bugzilla 11322:
         if (tf.isref)
             e = e.toLvalue(null, null);
+
         /* There's a problem if what the function returns is used subsequently as an
          * lvalue, as in a struct return that is then used as a 'this'.
          * If we take the address of the return value, we will be taking the address
@@ -2128,25 +2179,32 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
              *   tret __inlineretval = e;
              */
             auto ei = new ExpInitializer(fd.loc, e);
+
             Identifier tmp = Identifier.generateId("__inlineretval");
             auto vd = new VarDeclaration(fd.loc, tf.next, tmp, ei);
             vd.storage_class = (tf.isref ? STCref : 0) | STCtemp | STCrvalue;
             vd.linkage = tf.linkage;
             vd.parent = parent;
+
             auto ve = new VarExp(fd.loc, vd);
             ve.type = tf.next;
+
             ei.exp = new ConstructExp(fd.loc, ve, e);
             ei.exp.type = ve.type;
+
             auto de = new DeclarationExp(Loc(), vd);
             de.type = Type.tvoid;
+
             // Chain the two together:
             //   ( typeof(return) __inlineretval = ( inlined body )) , __inlineretval
             e = Expression.combine(de, ve);
+
             //fprintf(stderr, "CallExp.inlineScan: e = "); e.print();
         }
         eresult = e;
     }
     //printf("%s.expandInline = { %s }\n", fd.toChars(), e.toChars());
+
     // Need to reevaluate whether parent can now be inlined
     // in expressions, as we might have inlined statements
     parent.inlineStatusExp = ILSuninitialized;

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -820,6 +820,50 @@ void test9785_2() {
 }
 
 /**********************************/
+// 15207
+
+struct Vec15207
+{
+    float x, y, z;
+
+    this(float x_, float y_, float z_)
+    {
+        x = x_;
+        y = y_;
+        z = z_;
+    }
+
+    Vec15207 clone()
+    {
+        // When the variable 'res' is replaced with a STCref temporary,
+        // this line was accidentally changed to reference initialization.
+        Vec15207 res = this;
+
+        return res;
+    }
+}
+
+class C15207
+{
+    Vec15207 a;
+
+    this()
+    {
+        a = Vec15207(1, 2, 3).clone();
+
+        assert(a.x == 1);
+        assert(a.y == 2);
+        assert(a.z == 3);
+        printf("%f %f %f\n", a.x, a.y, a.z);
+    }
+}
+
+void test15207()
+{
+    auto c = new C15207();
+}
+
+/**********************************/
 
 int main()
 {
@@ -849,6 +893,7 @@ int main()
     test7625();
     test9785();
     test9785_2();
+    test15207();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15207

When issue 14944 fixed, the ref variable content initializing form had been flagged by `MemorySet.refValueInit`.

However, inilining may replace `AssignExp.e1` operand with a `STCref` temporary variable.
When it happens, the `MemorySet.refValueInit` flag will be ignored in `AssignExp.toElem` and wrong code had generated.

To avoid the issue, instead flag the case "ref varaible initialization" by `MemorySet.referenceInit`.
Its meaning will be kept beyond inlining stage, and the bug won't happen.
