### PR TITLE
add unittest support to makefiles

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -165,6 +165,9 @@ endif
 ifdef ENABLE_LTO
 CFLAGS  += -flto
 endif
+ifdef ENABLE_UNITTEST
+DFLAGS  += -unittest -cov
+endif
 
 # Uniqe extra flags if necessary
 DMD_FLAGS  := -I$(ROOT) -Wuninitialized
@@ -312,7 +315,7 @@ endif
 clean:
 	rm -f newdelete.o $(GLUE_OBJS) $(BACK_OBJS) dmd optab.o id.o	\
 		idgen $(idgen_output) optabgen $(optabgen_output)	\
-		verstr.h SYSCONFDIR.imp core *.cov *.deps *.gcda *.gcno *.a
+		verstr.h SYSCONFDIR.imp core *.cov *.deps *.gcda *.gcno *.a *.lst
 	@[ ! -d ${PGO_DIR} ] || echo You should issue manually: rm -rf ${PGO_DIR}
 
 ######## Download and install the last dmd buildable without dmd

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -266,6 +266,9 @@ reldmd:
 trace:
 	$(DMDMAKE) "OPT=-o" "DEBUG=-gt -Nc" "DDEBUG=-debug -g -unittest" "DOPT=" "LFLAGS=-L/ma/co/delexe/la" $(TARGETEXE)
 
+unittest:
+	$(DMDMAKE) "OPT=-o" "DEBUG=" "DDEBUG=-debug -g -unittest -cov" "DOPT=" "LFLAGS=-L/ma/co/delexe/la" $(TARGETEXE)
+
 ################################ Libraries ##################################
 
 glue.lib : $(GLUEOBJ)
@@ -285,7 +288,7 @@ $(TARGETEXE): $(DMD_SRCS) $(ROOT_SRCS) newdelete.obj $(LIBS) verstr.h
 ############################ Maintenance Targets #############################
 
 clean:
-	$(DEL) *.obj *.lib *.map
+	$(DEL) *.obj *.lib *.map *.lst
 	$(DEL) msgs.h msgs.c
 	$(DEL) elxxx.c cdxxx.c optab.c debtab.c fltables.c tytab.c
 	$(DEL) id.h id.d


### PR DESCRIPTION
Add ability to run dmd internal unittests to the makefiles, and generate resulting coverage reports.
