### PR TITLE
Issue 15094 - __traits(getMember) fails when the source is a struct/class field

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -135,6 +135,9 @@ extern (C++) Type getType(RootObject o)
     return t;
 }
 
+/**************************************
+ * Convert Expression or Type to corresponding Dsymbol.
+ */
 extern (C++) Dsymbol getDsymbol(RootObject oarg)
 {
     //printf("getDsymbol()\n");
@@ -157,13 +160,18 @@ extern (C++) Dsymbol getDsymbol(RootObject oarg)
             sa = (cast(TemplateExp)ea).td;
         else
             sa = null;
+
+        // TODO: Have to support conversion: TypeExp -> Type -> Dsymbol?
     }
     else
     {
         // Try to convert Type to symbol
         Type ta = isType(oarg);
         if (ta)
+        {
+            // Note: Strip off type qualifier information.
             sa = ta.toDsymbol(null);
+        }
         else
             sa = isDsymbol(oarg); // if already a symbol
     }
@@ -7287,9 +7295,9 @@ public:
             //printf("1: (*tiargs)[%d] = %p, s=%p, v=%p, ea=%p, ta=%p\n", j, o, isDsymbol(o), isTuple(o), ea, ta);
             if (ta)
             {
-                //printf("type %s\n", ta->toChars());
+                //printf("type %s\n", ta.toChars());
                 // It might really be an Expression or an Alias
-                ta.resolve(loc, sc, &ea, &ta, &sa);
+                ta.resolve(loc, sc, &ea, &ta, &sa, (flags & 1) != 0);
                 if (ea)
                     goto Lexpr;
                 if (sa)
@@ -7332,13 +7340,14 @@ public:
             else if (ea)
             {
             Lexpr:
-                //printf("+[%d] ea = %s %s\n", j, Token::toChars(ea->op), ea->toChars());
+                //printf("+[%d] ea = %s %s\n", j, Token.toChars(ea.op), ea.toChars());
                 if (flags & 1) // only used by __traits
                 {
                     ea = ea.semantic(sc);
 
                     // must not interpret the args, excepting template parameters
-                    if (ea.op != TOKvar || ((cast(VarExp)ea).var.storage_class & STCtemplateparameter))
+                    if (ea.op != TOKvar ||
+                        ((cast(VarExp)ea).var.storage_class & STCtemplateparameter))
                     {
                         ea = ea.optimize(WANTvalue);
                     }
@@ -7367,7 +7376,7 @@ public:
                             ea = new ErrorExp();
                     }
                 }
-                //printf("-[%d] ea = %s %s\n", j, Token::toChars(ea->op), ea->toChars());
+                //printf("-[%d] ea = %s %s\n", j, Token.toChars(ea.op), ea.toChars());
                 if (ea.op == TOKtuple)
                 {
                     // Expand tuple
@@ -7403,11 +7412,13 @@ public:
                 if (ea.op == TOKfunction)
                 {
                     FuncExp fe = cast(FuncExp)ea;
+
                     /* A function literal, that is passed to template and
                      * already semanticed as function pointer, never requires
                      * outer frame. So convert it to global function is valid.
                      */
-                    if (fe.fd.tok == TOKreserved && fe.type.ty == Tpointer)
+                    if (fe.fd.tok == TOKreserved &&
+                        fe.type.ty == Tpointer)
                     {
                         // change to non-nested
                         fe.fd.tok = TOKfunction;
@@ -7421,7 +7432,7 @@ public:
                         //goto Ldsym;
                     }
                 }
-                if (ea.op == TOKdotvar)
+                if (ea.op == TOKdotvar && !(flags & 1))
                 {
                     // translate expression to dsymbol.
                     sa = (cast(DotVarExp)ea).var;
@@ -7432,7 +7443,7 @@ public:
                     sa = (cast(TemplateExp)ea).td;
                     goto Ldsym;
                 }
-                if (ea.op == TOKdottd)
+                if (ea.op == TOKdottd && !(flags & 1))
                 {
                     // translate expression to dsymbol.
                     sa = (cast(DotTemplateExp)ea).td;
@@ -7442,25 +7453,24 @@ public:
             else if (sa)
             {
             Ldsym:
-                //printf("dsym %s %s\n", sa->kind(), sa->toChars());
+                //printf("dsym %s %s\n", sa.kind(), sa.toChars());
                 if (sa.errors)
                 {
                     err = true;
                     continue;
                 }
 
-                TupleDeclaration d = sa.toAlias().isTupleDeclaration();
-                if (d)
+                if (auto tup = sa.toAlias().isTupleDeclaration())
                 {
                     // Expand tuple
                     tiargs.remove(j);
-                    tiargs.insert(j, d.objects);
+                    tiargs.insert(j, tup.objects);
                     j--;
                     continue;
                 }
-                if (FuncAliasDeclaration fa = sa.isFuncAliasDeclaration())
+                if (auto fa = sa.isFuncAliasDeclaration())
                 {
-                    FuncDeclaration f = fa.toAliasFunc();
+                    auto f = fa.toAliasFunc();
                     if (!fa.hasOverloads && f.isUnique())
                     {
                         // Strip FuncAlias only when the aliased function
@@ -7470,13 +7480,12 @@ public:
                 }
                 (*tiargs)[j] = sa;
 
-                TemplateDeclaration td = sa.isTemplateDeclaration();
-                if (td && td.semanticRun == PASSinit && td.literal)
+                if (auto td = sa.isTemplateDeclaration())
                 {
-                    td.semantic(sc);
+                    if (td.semanticRun == PASSinit && td.literal)
+                        td.semantic(sc);
                 }
-                FuncDeclaration fd = sa.isFuncDeclaration();
-                if (fd)
+                if (auto fd = sa.isFuncDeclaration())
                     fd.functionSemantic();
             }
             else if (isParameter(o))
@@ -7493,11 +7502,11 @@ public:
             printf("-TemplateInstance::semanticTiargs()\n");
             for (size_t j = 0; j < tiargs.dim; j++)
             {
-                RootObject o = (*tiargs)[j];
-                Type ta = isType(o);
-                Expression ea = isExpression(o);
-                Dsymbol sa = isDsymbol(o);
-                Tuple va = isTuple(o);
+                auto o = (*tiargs)[j];
+                auto ta = isType(o);
+                auto ea = isExpression(o);
+                auto sa = isDsymbol(o);
+                auto va = isTuple(o);
                 printf("\ttiargs[%d] = ta %p, ea %p, sa %p, va %p\n", j, ta, ea, sa, va);
             }
         }

--- a/src/traits.d
+++ b/src/traits.d
@@ -28,12 +28,38 @@ import ddmd.identifier;
 import ddmd.mtype;
 import ddmd.nogc;
 import ddmd.root.array;
+import ddmd.root.rootobject;
 import ddmd.root.speller;
 import ddmd.root.stringtable;
 import ddmd.tokens;
 import ddmd.visitor;
 
 enum LOGSEMANTIC = false;
+
+/**************************************
+ * Convert Expression or Type to corresponding Dsymbol,
+ * additionally strip off expression contexts.
+ *
+ * Some symbol related `__traits` ignore arguments expression contexts.
+ * For example:
+ *  struct S { void f() {} }
+ *  S s;
+ *  pragma(msg, __traits(isNested, s.f));
+ *  // s.f is DotVarExp, but __traits(isNested) needs a FuncDeclaration.
+ *
+ * This is used for that common `__traits` behavior.
+ */
+private Dsymbol getDsymbol2(RootObject oarg)
+{
+    if (auto e = isExpression(oarg))
+    {
+        if (e.op == TOKdotvar)
+            return (cast(DotVarExp)e).var;
+        if (e.op == TOKdottd)
+            return (cast(DotTemplateExp)e).td;
+    }
+    return getDsymbol(oarg);
+}
 
 /************************ TraitsExp ************************************/
 
@@ -368,7 +394,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
             static if (is(T : Dsymbol))
             {
-                auto s = getDsymbol(o);
+                auto s = getDsymbol2(o);
                 if (!s)
                     goto Lfalse;
             }
@@ -471,7 +497,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             goto Ldimerror;
 
         auto o = (*e.args)[0];
-        auto s = getDsymbol(o);
+        auto s = getDsymbol2(o);
         if (!s)
         {
         }
@@ -550,7 +576,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         else
         {
-            Dsymbol s = getDsymbol(o);
+            Dsymbol s = getDsymbol2(o);
             if (!s || !s.ident)
             {
                 e.error("argument %s has no identifier", o.toChars());
@@ -575,7 +601,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return new ErrorExp();
 
         auto o = (*e.args)[0];
-        auto s = getDsymbol(o);
+        auto s = getDsymbol2(o);
         if (!s)
         {
             if (!isError(o))
@@ -596,7 +622,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             goto Ldimerror;
 
         auto o = (*e.args)[0];
-        auto s = getDsymbol(o);
+        auto s = getDsymbol2(o);
         if (s)
         {
             if (auto fd = s.isFuncDeclaration()) // Bugzilla 8943
@@ -664,9 +690,13 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
         /* Prefer dsymbol, because it might need some runtime contexts.
          */
-        Dsymbol sym = getDsymbol(o);
-        if (sym)
+        if (auto sym = getDsymbol(o))   // don't ignore expression context
         {
+            if (e.ident == Id.hasMember)
+            {
+                if (auto sm = sym.search(e.loc, id))
+                    goto Ltrue;
+            }
             ex = new DsymbolExp(e.loc, sym);
             ex = new DotIdExp(e.loc, ex, id);
         }
@@ -681,12 +711,6 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         if (e.ident == Id.hasMember)
         {
-            if (sym)
-            {
-                if (auto sm = sym.search(e.loc, id))
-                    goto Ltrue;
-            }
-
             /* Take any errors as meaning it wasn't found
              */
             Scope* sc2 = sc.push();
@@ -811,7 +835,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             goto Ldimerror;
 
         auto o = (*e.args)[0];
-        auto s = getDsymbol(o);
+        auto s = getDsymbol2(o);
         if (!s)
         {
             version (none)
@@ -844,7 +868,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             goto Ldimerror;
 
         auto o = (*e.args)[0];
-        auto s = getDsymbol(o);
+        auto s = getDsymbol2(o);
         auto t = isType(o);
         TypeFunction tf = null;
         if (s)
@@ -1109,7 +1133,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             goto Ldimerror;
 
         auto o = (*e.args)[0];
-        auto s = getDsymbol(o);
+        auto s = getDsymbol2(o);
         if (!s)
         {
             e.error("argument %s to __traits(getUnitTests) must be a module or aggregate",
@@ -1170,7 +1194,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             goto Ldimerror;
 
         auto o = (*e.args)[0];
-        auto s = getDsymbol(o);
+        auto s = getDsymbol2(o);
 
         auto fd = s ? s.isFuncDeclaration() : null;
         if (!fd)

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1513,6 +1513,19 @@ void test12237()
 }
 
 /********************************************************/
+// 15094
+
+void test15094()
+{
+    static struct Foo { int i; }
+    static struct Bar { Foo foo; }
+
+    Bar bar;
+    auto n = __traits(getMember, bar.foo, "i");
+    assert(n == bar.foo.i);
+}
+
+/********************************************************/
 
 int main()
 {
@@ -1553,6 +1566,7 @@ int main()
     test_getFunctionAttributes();
     test_isOverrideFunction();
     test12237();
+    test15094();
 
     writeln("Success");
     return 0;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15094

If `TemplateInstance.semanticTiargs` is called from `TraitsExp`, do not strip off the contexts of argument expressions:
1. give `true` to the `intypeid` parameter of `Type.resolve` call.
2. leave `TOKdotvar` and `TOKdottd` as-is.
