### PR TITLE
remove dependency on 0 termination in token strings

### DIFF
--- a/src/constfold.d
+++ b/src/constfold.d
@@ -1725,7 +1725,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
             else
                 utf_encode(sz, s, cast(dchar_t)v);
             // Add terminating 0
-            memset(cast(char*)s + len * sz, 0, sz);
+            memset(cast(char*)s + len * sz, 0xFF, sz);
             emplaceExp!(StringExp)(&ue, loc, s, len);
             StringExp es = cast(StringExp)ue.exp();
             es.sz = sz;

--- a/src/expression.h
+++ b/src/expression.h
@@ -357,7 +357,7 @@ public:
 class StringExp : public Expression
 {
 public:
-    void *string;       // char, wchar, or dchar data
+    void *stringdata;   // char, wchar, or dchar data
     size_t len;         // number of chars, wchars, or dchars
     unsigned char sz;   // 1: char, 2: wchar, 4: dchar
     unsigned char committed;    // !=0 if type is committed

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3606,7 +3606,7 @@ static code *asm_db_parse(OP *pop)
                 else if (e->op == TOKstring)
                 {
                     StringExp *se = (StringExp *)e;
-                    q = (unsigned char *)se->string;
+                    q = (unsigned char *)se->stringdata;
                     len = se->len;
                     goto L3;
                 }

--- a/src/lexer.d
+++ b/src/lexer.d
@@ -1199,7 +1199,6 @@ public:
                 if (c == tc)
                 {
                     t.len = cast(uint)stringbuffer.offset;
-                    stringbuffer.writeByte(0);
                     t.ustring = cast(char*)mem.xmalloc(stringbuffer.offset);
                     memcpy(t.ustring, stringbuffer.data, stringbuffer.offset);
                     stringPostfix(t);
@@ -1268,7 +1267,6 @@ public:
                     stringbuffer.writeByte(v);
                 }
                 t.len = cast(uint)stringbuffer.offset;
-                stringbuffer.writeByte(0);
                 t.ustring = cast(char*)mem.xmalloc(stringbuffer.offset);
                 memcpy(t.ustring, stringbuffer.data, stringbuffer.offset);
                 stringPostfix(t);
@@ -1462,7 +1460,6 @@ public:
         else
             error("delimited string must end in %c\"", delimright);
         t.len = cast(uint)stringbuffer.offset;
-        stringbuffer.writeByte(0);
         t.ustring = cast(char*)mem.xmalloc(stringbuffer.offset);
         memcpy(t.ustring, stringbuffer.data, stringbuffer.offset);
         stringPostfix(t);
@@ -1495,9 +1492,8 @@ public:
                 if (--nest == 0)
                 {
                     t.len = cast(uint)(p - 1 - pstart);
-                    t.ustring = cast(char*)mem.xmalloc(t.len + 1);
+                    t.ustring = cast(char*)mem.xmalloc(t.len);
                     memcpy(t.ustring, pstart, t.len);
-                    t.ustring[t.len] = 0;
                     stringPostfix(t);
                     return TOKstring;
                 }
@@ -1553,7 +1549,6 @@ public:
                 break;
             case '"':
                 t.len = cast(uint)stringbuffer.offset;
-                stringbuffer.writeByte(0);
                 t.ustring = cast(char*)mem.xmalloc(stringbuffer.offset);
                 memcpy(t.ustring, stringbuffer.data, stringbuffer.offset);
                 stringPostfix(t);

--- a/src/parse.d
+++ b/src/parse.d
@@ -6684,9 +6684,9 @@ public:
                         size_t len1 = len;
                         size_t len2 = token.len;
                         len = len1 + len2;
-                        char* s2 = cast(char*)mem.xmalloc((len + 1) * char.sizeof);
+                        char* s2 = cast(char*)mem.xmalloc(len * char.sizeof);
                         memcpy(s2, s, len1 * char.sizeof);
-                        memcpy(s2 + len1, token.ustring, (len2 + 1) * char.sizeof);
+                        memcpy(s2 + len1, token.ustring, len2 * char.sizeof);
                         s = s2;
                     }
                     else

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -564,7 +564,7 @@ public:
                 else
                 {
                     StringExp *se = (StringExp *)(cs->exp);
-                    Symbol *si = toStringSymbol((char *)se->string, se->len, se->sz);
+                    Symbol *si = toStringSymbol((char *)se->stringdata, se->len, se->sz);
                     dtsize_t(&dt, se->len);
                     dtxoff(&dt, si, 0);
                 }

--- a/src/todt.c
+++ b/src/todt.c
@@ -381,14 +381,15 @@ dt_t **Expression_toDt(Expression *e, dt_t **pdt)
             {
                 case Tarray:
                     pdt = dtsize_t(pdt, e->len);
-                    pdt = dtabytes(pdt, 0, (e->len + 1) * e->sz, (char *)e->string);
+                    pdt = dtabytes(pdt, 0, e->len * e->sz, (char *)e->stringdata);
+                    pdt = dtnzeros(pdt, e->sz);
                     break;
 
                 case Tsarray:
                 {
                     TypeSArray *tsa = (TypeSArray *)t;
 
-                    pdt = dtnbytes(pdt, e->len * e->sz, (const char *)e->string);
+                    pdt = dtnbytes(pdt, e->len * e->sz, (const char *)e->stringdata);
                     if (tsa->dim)
                     {
                         dinteger_t dim = tsa->dim->toInteger();
@@ -401,7 +402,8 @@ dt_t **Expression_toDt(Expression *e, dt_t **pdt)
                     break;
                 }
                 case Tpointer:
-                    pdt = dtabytes(pdt, 0, (e->len + 1) * e->sz, (char *)e->string);
+                    pdt = dtabytes(pdt, 0, e->len * e->sz, (char *)e->stringdata);
+                    pdt = dtnzeros(pdt, e->sz);
                     break;
 
                 default:

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1099,7 +1099,7 @@ void toObjFile(Dsymbol *ds, bool multiobj)
 
                 StringExp *se = (StringExp *)e;
                 char *name = (char *)mem.xmalloc(se->len + 1);
-                memcpy(name, se->string, se->len);
+                memcpy(name, se->stringdata, se->len);
                 name[se->len] = 0;
 
                 /* Embed the library names into the object file.


### PR DESCRIPTION
Saves memory, opens door to other optimizations
