### PR TITLE
enable profiling of D front end

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -168,6 +168,9 @@ endif
 ifdef ENABLE_UNITTEST
 DFLAGS  += -unittest -cov
 endif
+ifdef ENABLE_PROFILE
+DFLAGS  += -profile
+endif
 
 # Uniqe extra flags if necessary
 DMD_FLAGS  := -I$(ROOT) -Wuninitialized

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -263,6 +263,9 @@ debdmd:
 reldmd:
 	$(DMDMAKE) "OPT=-o" "DEBUG=" "DDEBUG=" "DOPT=-O -release -inline" "LFLAGS=-L/delexe/la" $(TARGETEXE)
 
+profile:
+	$(DMDMAKE) "OPT=-o" "DEBUG=" "DDEBUG=" "DOPT=-O -release -profile" "LFLAGS=-L/delexe/la" $(TARGETEXE)
+
 trace:
 	$(DMDMAKE) "OPT=-o" "DEBUG=-gt -Nc" "DDEBUG=-debug -g -unittest" "DOPT=" "LFLAGS=-L/ma/co/delexe/la" $(TARGETEXE)
 


### PR DESCRIPTION
Note that this does not work when building dmd with 2.067, but does work when compiling dmd with HEAD.

In any case, profile builds of dmd are essential in dealing with constant assaults on dmd's speed. Compilation speed is a key advantage of D.
