### PR TITLE
refactor: replace StringExp.length with numberOfCodeUnits

### DIFF
--- a/src/dcast.d
+++ b/src/dcast.d
@@ -548,12 +548,11 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                                 }
                                 return;
                             }
-                            int szto = cast(int)t.nextOf().size();
                             if (tynto == Tchar || tynto == Twchar || tynto == Tdchar)
                             {
                                 if (e.committed && tynto != tyn)
                                     return;
-                                size_t fromlen = e.length(szto);
+                                size_t fromlen = e.numberOfCodeUnits(tynto);
                                 size_t tolen = cast(size_t)(cast(TypeSArray)t).dim.toInteger();
                                 if (tolen < fromlen)
                                     return;
@@ -573,12 +572,11 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                         else if (e.type.ty == Tarray)
                         {
                             TY tynto = t.nextOf().ty;
-                            int sznto = cast(int)t.nextOf().size();
                             if (tynto == Tchar || tynto == Twchar || tynto == Tdchar)
                             {
                                 if (e.committed && tynto != tyn)
                                     return;
-                                size_t fromlen = e.length(sznto);
+                                size_t fromlen = e.numberOfCodeUnits(tynto);
                                 size_t tolen = cast(size_t)(cast(TypeSArray)t).dim.toInteger();
                                 if (tolen < fromlen)
                                     return;

--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -742,7 +742,7 @@ public:
                 if (!se.committed &&
                     (typeb.ty == Tarray || typeb.ty == Tsarray) &&
                     (tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
-                    se.length(cast(int)tb.nextOf().size()) < (cast(TypeSArray)tb).dim.toInteger())
+                    se.numberOfCodeUnits(tynto) < (cast(TypeSArray)tb).dim.toInteger())
                 {
                     e = se.castTo(sc, t);
                     goto L1;

--- a/src/expression.d
+++ b/src/expression.d
@@ -4263,13 +4263,24 @@ public:
     }
 
     /**********************************
-     * Return the code unit count of string.
-     * Input:
-     *      encSize     code unit size of the target encoding.
+     * Return the number of code units the string would be if it were re-encoded
+     * as tynto.
+     * Params:
+     *      tynto = code unit type of the target encoding
+     * Returns:
+     *      number of code units
      */
-    size_t length(int encSize = 4)
+    final size_t numberOfCodeUnits(int tynto)
     {
-        assert(encSize == 1 || encSize == 2 || encSize == 4);
+        int encSize;
+        switch (tynto)
+        {
+            case Tchar:  encSize = 1; break;
+            case Twchar: encSize = 2; break;
+            case Tdchar: encSize = 4; break;
+            default:
+                assert(0);
+        }
         if (sz == encSize)
             return len;
         size_t result = 0;

--- a/src/expression.h
+++ b/src/expression.h
@@ -370,7 +370,6 @@ public:
     static StringExp *create(Loc loc, char *s);
     bool equals(RootObject *o);
     Expression *semantic(Scope *sc);
-    size_t length(int encSize = 4);
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
     int compare(RootObject *obj);

--- a/src/init.d
+++ b/src/init.d
@@ -880,7 +880,10 @@ public:
             StringExp se = cast(StringExp)exp;
             Type typeb = se.type.toBasetype();
             TY tynto = tb.nextOf().ty;
-            if (!se.committed && (typeb.ty == Tarray || typeb.ty == Tsarray) && (tynto == Tchar || tynto == Twchar || tynto == Tdchar) && se.length(cast(int)tb.nextOf().size()) < (cast(TypeSArray)tb).dim.toInteger())
+            if (!se.committed &&
+                (typeb.ty == Tarray || typeb.ty == Tsarray) &&
+                (tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
+                se.numberOfCodeUnits(tynto) < (cast(TypeSArray)tb).dim.toInteger())
             {
                 exp = se.castTo(sc, t);
                 goto L1;

--- a/src/traits.d
+++ b/src/traits.d
@@ -801,7 +801,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         ex = ex.ctfeInterpret();
         StringExp se = ex.toStringExp();
-        if (!se || se.length() == 0)
+        if (!se || se.len == 0)
         {
             e.error("string expected as second argument of __traits %s instead of %s", e.ident.toChars(), ex.toChars());
             return new ErrorExp();


### PR DESCRIPTION
Calling it `length(encSize)` was very confusing, as `length` has special meaning in D. The code simplifies a bit, too.
