### PR TITLE
Re-add mapping of real_t to longdouble

### DIFF
--- a/src/builtin.d
+++ b/src/builtin.d
@@ -150,9 +150,9 @@ extern (C++) Expression eval_yl2x(Loc loc, FuncDeclaration fd, Expressions* argu
     assert(arg0.op == TOKfloat64);
     Expression arg1 = (*arguments)[1];
     assert(arg1.op == TOKfloat64);
-    real x = arg0.toReal();
-    real y = arg1.toReal();
-    real result;
+    real_t x = arg0.toReal();
+    real_t y = arg1.toReal();
+    real_t result;
     Port.yl2x_impl(&x, &y, &result);
     return new RealExp(loc, result, arg0.type);
 }
@@ -163,9 +163,9 @@ extern (C++) Expression eval_yl2xp1(Loc loc, FuncDeclaration fd, Expressions* ar
     assert(arg0.op == TOKfloat64);
     Expression arg1 = (*arguments)[1];
     assert(arg1.op == TOKfloat64);
-    real x = arg0.toReal();
-    real y = arg1.toReal();
-    real result;
+    real_t x = arg0.toReal();
+    real_t y = arg1.toReal();
+    real_t result;
     Port.yl2xp1_impl(&x, &y, &result);
     return new RealExp(loc, result, arg0.type);
 }

--- a/src/complex.d
+++ b/src/complex.d
@@ -8,17 +8,19 @@
 
 module ddmd.complex;
 
+import ddmd.root.longdouble;
+
 struct complex_t
 {
-    real re = 0;
-    real im = 0;
-    this(real re)
+    longdouble re = 0;
+    longdouble im = 0;
+    this(longdouble re)
     {
         this.re = re;
         this.im = 0;
     }
 
-    this(real re, real im)
+    this(longdouble re, longdouble im)
     {
         this.re = re;
         this.im = im;
@@ -53,26 +55,26 @@ struct complex_t
         return complex_t(re * y.re - im * y.im, im * y.re + re * y.im);
     }
 
-    complex_t opMul_r(real x)
+    complex_t opMul_r(longdouble x)
     {
         return complex_t(x) * this;
     }
 
-    complex_t opMul(real y)
+    complex_t opMul(longdouble y)
     {
         return this * complex_t(y);
     }
 
-    complex_t opDiv(real y)
+    complex_t opDiv(longdouble y)
     {
         return this / complex_t(y);
     }
 
     complex_t opDiv(complex_t y)
     {
-        real abs_y_re = y.re < 0 ? -y.re : y.re;
-        real abs_y_im = y.im < 0 ? -y.im : y.im;
-        real r, den;
+        longdouble abs_y_re = y.re < 0 ? -y.re : y.re;
+        longdouble abs_y_im = y.im < 0 ? -y.im : y.im;
+        longdouble r, den;
 
         if (abs_y_re < abs_y_im)
         {
@@ -99,12 +101,12 @@ struct complex_t
     }
 }
 
-extern (C++) real creall(complex_t x)
+extern (C++) longdouble creall(complex_t x)
 {
     return x.re;
 }
 
-extern (C++) real cimagl(complex_t x)
+extern (C++) longdouble cimagl(complex_t x)
 {
     return x.im;
 }

--- a/src/dcast.d
+++ b/src/dcast.d
@@ -432,7 +432,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 }
             case Tfloat80:
                 {
-                    real f;
+                    longdouble f;
                     if (e.type.isunsigned())
                     {
                         f = ldouble(value);

--- a/src/expression.d
+++ b/src/expression.d
@@ -1914,7 +1914,7 @@ private:
         char[__traits(classInstanceSize, AddrExp)] addrexp;
         char[__traits(classInstanceSize, IndexExp)] indexexp;
         char[__traits(classInstanceSize, SliceExp)] sliceexp;
-        // Ensure that the union is suitably aligned.
+        // Ensure that the union is suitably aligned.  XXX: ???
         real for_alignment_only;
     }
 

--- a/src/globals.d
+++ b/src/globals.d
@@ -13,6 +13,7 @@ import core.stdc.stdio;
 import core.stdc.string;
 import ddmd.root.array;
 import ddmd.root.filename;
+import ddmd.root.longdouble;
 import ddmd.root.outbuffer;
 
 template xversion(string s)
@@ -340,11 +341,11 @@ alias d_int64 = int64_t;
 alias d_uns64 = uint64_t;
 alias d_float32 = float;
 alias d_float64 = double;
-alias d_float80 = real;
+alias d_float80 = longdouble;
 alias d_char = d_uns8;
 alias d_wchar = d_uns16;
 alias d_dchar = d_uns32;
-alias real_t = real;
+alias real_t = longdouble;
 
 // file location
 struct Loc

--- a/src/root/longdouble.d
+++ b/src/root/longdouble.d
@@ -8,8 +8,10 @@
 
 module ddmd.root.longdouble;
 
-real ldouble(T)(T x)
+alias longdouble = real;
+
+longdouble ldouble(T)(T x)
 {
-    return cast(real)x;
+    return cast(longdouble)x;
 }
 

--- a/src/target.d
+++ b/src/target.d
@@ -349,7 +349,7 @@ extern (C++) static void encodeReal(Expression e, ubyte* buffer)
 // the value as a new RealExp.
 extern (C++) static Expression decodeReal(Loc loc, Type type, ubyte* buffer)
 {
-    real value;
+    real_t value;
     switch (type.ty)
     {
     case Tfloat32:


### PR DESCRIPTION
The ability to re-add a software emulation float type in dfrontend is quite horrid in the D implementation.

This only replaces uses of native real from the code with either `longdouble` or `real_t` (whichever one is imported).  The `ddmd.root.port` module is a mess, but it's not one that I will be including in gdc  (likewise `ddmd.root.longdouble` and `ddmd.target`)

The rest of the frontend, however should use the appropriate aliases as `longdouble` could be a struct.
