### PR TITLE
encapsulate access to StringExp.string in backend

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -4270,11 +4270,12 @@ public:
      * Returns:
      *      number of code units
      */
-    final size_t numberOfCodeUnits(int tynto)
+    final size_t numberOfCodeUnits(int tynto = 0)
     {
         int encSize;
         switch (tynto)
         {
+            case 0:      return len;
             case Tchar:  encSize = 1; break;
             case Twchar: encSize = 2; break;
             case Tdchar: encSize = 4; break;
@@ -4321,6 +4322,48 @@ public:
             assert(0);
         }
         return result;
+    }
+
+    /**********************************************
+     * Write the contents of the string to dest.
+     * Use numberOfCodeUnits() to determine size of result.
+     * Params:
+     *  dest = destination
+     *  tyto = encoding type of the result
+     *  zero = add terminating 0
+     */
+    void writeTo(void* dest, bool zero, int tyto = 0)
+    {
+        int encSize;
+        switch (tyto)
+        {
+            case 0:      encSize = sz; break;
+            case Tchar:  encSize = 1; break;
+            case Twchar: encSize = 2; break;
+            case Tdchar: encSize = 4; break;
+            default:
+                assert(0);
+        }
+        if (sz == encSize)
+        {
+            memcpy(dest, string, len * sz);
+            if (zero)
+                memset(dest + len * sz, 0, sz);
+        }
+        else
+            assert(0);
+    }
+
+    /**************************************************
+     * If the string data is UTF-8 and can be accessed directly,
+     * return a pointer to it.
+     * Do not assume a terminating 0.
+     * Returns:
+     *  pointer to string data if possible, null if not
+     */
+    char* toPtr()
+    {
+        return (sz == 1) ? cast(char*)string : null;
     }
 
     override StringExp toStringExp()
@@ -4447,8 +4490,7 @@ public:
     {
         auto nbytes = len * sz;
         char* s = cast(char*)mem.xmalloc(nbytes + sz);
-        memcpy(s, string, nbytes);
-        memset(s + nbytes, 0, sz);
+        writeTo(s, true);
         return s;
     }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -356,9 +356,9 @@ public:
 
 class StringExp : public Expression
 {
-public:
     void *string;       // char, wchar, or dchar data
     size_t len;         // number of chars, wchars, or dchars
+public:
     unsigned char sz;   // 1: char, 2: wchar, 4: dchar
     unsigned char committed;    // !=0 if type is committed
     utf8_t postfix;      // 'c', 'w', 'd'
@@ -380,6 +380,9 @@ public:
     unsigned charAt(uinteger_t i);
     void accept(Visitor *v) { v->visit(this); }
     char *toStringz();
+    size_t numberOfCodeUnits(int tynto = 0);
+    void writeTo(void* dest, bool zero, int tyto = 0);
+    char *toPtr();
 };
 
 // Tuple

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -3470,6 +3470,7 @@ static code *asm_db_parse(OP *pop)
     {
         size_t len;
         unsigned char *q;
+        unsigned char *qstart = NULL;
 
         if (usBytes+usSize > usMaxbytes)
         {
@@ -3571,6 +3572,11 @@ static code *asm_db_parse(OP *pop)
 
                     usBytes += len * usSize;
                 }
+                if (qstart)
+                {
+                    mem_free(qstart);
+                    qstart = NULL;
+                }
                 break;
 
             case TOKidentifier:
@@ -3606,8 +3612,14 @@ static code *asm_db_parse(OP *pop)
                 else if (e->op == TOKstring)
                 {
                     StringExp *se = (StringExp *)e;
-                    q = (unsigned char *)se->string;
-                    len = se->len;
+                    len = se->numberOfCodeUnits();
+                    q = (unsigned char *)se->toPtr();
+                    if (!q)
+                    {
+                        qstart = (unsigned char *)mem_malloc(len * se->sz);
+                        se->writeTo(qstart, false);
+                        q = qstart;
+                    }
                     goto L3;
                 }
                 goto Ldefault;

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -40,7 +40,7 @@
 #include        "target.h"
 #include        "visitor.h"
 
-Symbol *toStringSymbol(const char *str, size_t len, size_t sz);
+Symbol *toStringSymbol(StringExp *se);
 elem *exp2_copytotemp(elem *e);
 elem *incUsageElem(IRState *irs, Loc loc);
 elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
@@ -564,8 +564,8 @@ public:
                 else
                 {
                     StringExp *se = (StringExp *)(cs->exp);
-                    Symbol *si = toStringSymbol((char *)se->string, se->len, se->sz);
-                    dtsize_t(&dt, se->len);
+                    Symbol *si = toStringSymbol(se);
+                    dtsize_t(&dt, se->numberOfCodeUnits());
                     dtxoff(&dt, si, 0);
                 }
             }

--- a/src/toobj.c
+++ b/src/toobj.c
@@ -1098,9 +1098,8 @@ void toObjFile(Dsymbol *ds, bool multiobj)
                 assert(e->op == TOKstring);
 
                 StringExp *se = (StringExp *)e;
-                char *name = (char *)mem.xmalloc(se->len + 1);
-                memcpy(name, se->string, se->len);
-                name[se->len] = 0;
+                char *name = (char *)mem.xmalloc(se->numberOfCodeUnits() + 1);
+                se->writeTo(name, true);
 
                 /* Embed the library names into the object file.
                  * The linker will then automatically


### PR DESCRIPTION
This is a step towards more efficient handling of strings in DMD, i.e. faster compiles and less memory.
