### PR TITLE
@property functions may not have 2 parameters

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -6099,9 +6099,9 @@ public:
             tf.inuse = 0;
             errors = true;
         }
-        if (tf.isproperty && (tf.varargs || Parameter.dim(tf.parameters) > 2))
+        if (tf.isproperty && (tf.varargs || Parameter.dim(tf.parameters) > 1))
         {
-            error(loc, "properties can only have zero, one, or two parameter");
+            error(loc, "@property functions can only have zero or one parameters");
             errors = true;
         }
         if (tf.varargs == 1 && tf.linkage != LINKd && Parameter.dim(tf.parameters) == 0)

--- a/test/fail_compilation/fail334.d
+++ b/test/fail_compilation/fail334.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail334.d(10): Error: properties can only have zero, one, or two parameter
+fail_compilation/fail334.d(10): Error: @property functions can only have zero or one parameters
 ---
 */
 


### PR DESCRIPTION
The code allows @property functions to have 2 parameters. But I cannot find support for this either in the rest of the source code or in the spec. I'm disabling it to see if anything breaks.
