### PR TITLE
Strive for an ABI-agnostic handling of TypeInfo_Struct.xopEquals and xopCmp

### DIFF
--- a/src/clone.d
+++ b/src/clone.d
@@ -472,10 +472,12 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     }
     Loc declLoc = Loc(); // loc is unnecessary so __xopEquals is never called directly
     Loc loc = Loc(); // loc is unnecessary so errors are gagged
+    // Use C linkage: we need to make sure the arguments order (p, q) isn't reversed, in
+    // order to obtain a signature identical to that of method `S.opEquals(ref const S)`.
     auto parameters = new Parameters();
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.p, null));
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.q, null));
-    auto tf = new TypeFunction(parameters, Type.tbool, 0, LINKd);
+    auto tf = new TypeFunction(parameters, Type.tbool, 0, LINKc);
     Identifier id = Id.xopEquals;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
     Expression e1 = new IdentifierExp(loc, Id.p);
@@ -485,7 +487,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
-    sc2.linkage = LINKd;
+    sc2.linkage = LINKc;
     fop.semantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();
@@ -496,7 +498,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
 
 /******************************************
  * Build __xopCmp for TypeInfo_Struct
- *      static bool __xopCmp(ref const S p, ref const S q)
+ *      static int __xopCmp(ref const S p, ref const S q)
  *      {
  *          return p.opCmp(q);
  *      }
@@ -592,20 +594,22 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     }
     Loc declLoc = Loc(); // loc is unnecessary so __xopCmp is never called directly
     Loc loc = Loc(); // loc is unnecessary so errors are gagged
+    // Use C linkage: we need to make sure the arguments order (p, q) isn't reversed, in
+    // order to obtain a signature identical to that of method `S.opCmp(ref const S)`.
     auto parameters = new Parameters();
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.p, null));
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.q, null));
-    auto tf = new TypeFunction(parameters, Type.tint32, 0, LINKd);
+    auto tf = new TypeFunction(parameters, Type.tint32, 0, LINKc);
     Identifier id = Id.xopCmp;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
     Expression e1 = new IdentifierExp(loc, Id.p);
     Expression e2 = new IdentifierExp(loc, Id.q);
-    Expression e = new CallExp(loc, new DotIdExp(loc, e2, Id.cmp), e1);
+    Expression e = new CallExp(loc, new DotIdExp(loc, e1, Id.cmp), e2);
     fop.fbody = new ReturnStatement(loc, e);
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
-    sc2.linkage = LINKd;
+    sc2.linkage = LINKc;
     fop.semantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();


### PR DESCRIPTION
While trying to use a non-reversed parameter order for `extern (D)` in LDC on x86_64, I stumbled upon 2 ugly places assuming a reversed parameter order:
1. druntime's `TypeInfo_Struct.compare()` (see https://github.com/D-Programming-Language/druntime/pull/1417)
2. DMD front-end when generating the static `__xopEquals`/`__xopCmp` functions

The problem is that a pointer to an extern(D) function taking 2 struct references is used to jump either to:
- an extern(D) method `int S.opCmp(ref const S q)`  with LL signature `int opCmp(S* this = p, S* q)`, or
- an extern(D) static function `static int S.__xopCmp(ref const S p, ref const S q)` with LL signature `int __xopCmp(S* q, S* p)` if reversing the args. This function is generated by the front-end in case the `opCmp` method doesn't take its single argument by reference.

For this to work, `TypeInfo_Struct.compare()` assumed reversed order for extern(D) and called the extern(D) function pointer `TypeInfo_Struct.xopCmp` with reversed args `(q, p)`, to get the direct method call right (=> LL order `(p, q)`).
In the DMD front-end, the `static int S.__opCmp(ref const S p, ref const S q)` wrapper function needed to take this into account. So it also assumed a reversed arguments order for extern(D) and re-swapped p and q back again (=> `return q.opCmp(p)`).

When not reversing the args for `extern (D)` (as it should be on all non-Win32 platforms, according to the docs!), there's no need for any swapping at all.
I opted for an `extern (C)` approach for function pointer and static function, as that is lowered to a LL signature identical to the method's, as long as the `this` pointer is passed before the first explicit arg, another (but not new) assumption. I'm not sure whether that's free of any undesired effects though, e.g., for exception handling; name mangling seems to be fine with LDC.

At least these 2 places don't have to assume anything about the parameter order of `extern (D)` anymore.
