### PR TITLE
Remove aliases to D character types

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -4368,8 +4368,8 @@ public:
                 return memcmp(cast(char*)string, cast(char*)se2.string, len1);
             case 2:
                 {
-                    d_wchar* s1 = cast(d_wchar*)string;
-                    d_wchar* s2 = cast(d_wchar*)se2.string;
+                    wchar* s1 = cast(wchar*)string;
+                    wchar* s2 = cast(wchar*)se2.string;
                     for (size_t u = 0; u < len; u++)
                     {
                         if (s1[u] != s2[u])
@@ -4378,8 +4378,8 @@ public:
                 }
             case 4:
                 {
-                    d_dchar* s1 = cast(d_dchar*)string;
-                    d_dchar* s2 = cast(d_dchar*)se2.string;
+                    dchar* s1 = cast(dchar*)string;
+                    dchar* s2 = cast(dchar*)se2.string;
                     for (size_t u = 0; u < len; u++)
                     {
                         if (s1[u] != s2[u])

--- a/src/globals.d
+++ b/src/globals.d
@@ -341,9 +341,6 @@ alias d_uns64 = uint64_t;
 alias d_float32 = float;
 alias d_float64 = double;
 alias d_float80 = real;
-alias d_char = d_uns8;
-alias d_wchar = d_uns16;
-alias d_dchar = d_uns32;
 alias real_t = real;
 
 // file location

--- a/src/globals.h
+++ b/src/globals.h
@@ -240,10 +240,6 @@ typedef float                   d_float32;
 typedef double                  d_float64;
 typedef longdouble              d_float80;
 
-typedef d_uns8                  d_char;
-typedef d_uns16                 d_wchar;
-typedef d_uns32                 d_dchar;
-
 typedef longdouble real_t;
 
 // file location


### PR DESCRIPTION
All `d_XXX` types are seldom used, and not really needed any more in the D code.  If others agree with this, I can raise similar PRs for integer and floating types too (there's already a PR to switch `d_float80` and `real_t` over to `longdouble`, which I anticipate to be the de-facto real type used throughout the front-end).

@WalterBright - If you want to review this.
