### PR TITLE
[REG2.069.0-rc1] Issue 15251 - std.datetime bug with -inline

### DIFF
--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -1470,7 +1470,7 @@ public:
                 result = e; // bubbled up from ReturnStatement
                 return;
             }
-            e = interpret(s.increment, istate); // TODO: ctfeNeedNothing is better?
+            e = interpret(s.increment, istate, ctfeNeedNothing);
             if (exceptionOrCant(e))
                 return;
         }
@@ -5446,9 +5446,9 @@ public:
         if (exceptionOrCant(e1))
             return;
         // If the expression has been cast to void, do nothing.
-        if (e.to.ty == Tvoid && goal == ctfeNeedNothing)
+        if (e.to.ty == Tvoid)
         {
-            result = e1;
+            result = CTFEExp.voidexp;
             return;
         }
         if (e.to.ty == Tpointer && e1.op != TOKnull)

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -7652,3 +7652,17 @@ auto structInCaseScope()
 }
 
 static assert(!structInCaseScope());
+
+/**************************************************
+    15251 - void cast in ForStatement.increment
+**************************************************/
+
+int test15251()
+{
+    for (ubyte lwr = 19;
+        lwr != 20;
+        cast(void)++lwr)    // have to to be evaluated with ctfeNeedNothing
+    {}
+    return 1;
+}
+static assert(test15251());


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15251

The problem is in CTFE interpreter.

Inlining had introduced `cast(void)` expression to `ForStatement.increment` part,
then it had hit following interpret issues.
1. `CastExp.interpret` does not work for `cast(void)` if `goal` is not `ctfeNeedNothing`.
2. `ForStatement.interpert` does not evaluate its `increment` part with `ctfeNeedNothing`.

I fix both of them for the best work, although fixing one of them can fix the original issue,
