### PR TITLE
[D1] Deprecate error-prone definitions of opCmp / opEquals

### DIFF
--- a/src/struct.c
+++ b/src/struct.c
@@ -495,6 +495,13 @@ void StructDeclaration::semantic(Scope *sc)
 
         id = Id::cmp;
     }
+
+    {
+        Dsymbol *fopequals = search_function(this, Id::eq);
+        Dsymbol *fopcmp    = search_function(this, Id::cmp);
+        if (fopcmp && (!fopequals))
+            deprecation(loc, "has `opCmp` without matching `opEquals`");
+    }
 #endif
 #if DMDV2
     dtor = buildDtor(sc2);

--- a/src/typinf.c
+++ b/src/typinf.c
@@ -589,15 +589,19 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
     for (int i = 0; i < 2; i++)
     {
         if (fdx)
-        {   fd = fdx->overloadExactMatch(tfeqptr);
+        {
+            fd = fdx->overloadExactMatch(tfeqptr);
             if (fd)
                 dtxoff(pdt, fd->toSymbol(), 0);
             else
-                //fdx->error("must be declared as extern (D) int %s(%s*)", fdx->toChars(), sd->toChars());
+            {
+                fdx->deprecation(loc, "must be declared as `extern (D) int %s(%s)` "
+                    "or it will be ignored by TypeInfo",
+                    fdx->toChars(), sd->toChars());
                 dtsize_t(pdt, 0);
+            }
         }
         else
-            //fdx->error("must be declared as extern (D) int %s(%s*)", fdx->toChars(), sd->toChars());
             dtsize_t(pdt, 0);
 
         s = search_function(sd, Id::cmp);


### PR DESCRIPTION
I know the changes are too controversial to have a chance in D2 upstream so this is last chance to clean up all problematic cases in our code base ;)

ping @AndrejMitrovic
