### PR TITLE
Issue 15260, 15261, 15262 - Fix dmd-internal bugs

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -4376,6 +4376,7 @@ public:
                             return s1[u] - s2[u];
                     }
                 }
+                break;
             case 4:
                 {
                     dchar* s1 = cast(dchar*)string;

--- a/src/expression.d
+++ b/src/expression.d
@@ -7236,7 +7236,9 @@ public:
         // T opAssign floating yields a floating. Prevent truncating conversions (float to int).
         // See issue 3841.
         // Should we also prevent double to float (type->isfloating() && type->size() < t2 ->size()) ?
-        if (op == TOKmulass || op == TOKdivass || op == TOKmodass || TOKaddass || op == TOKminass || op == TOKpowass)
+        if (op == TOKaddass || op == TOKminass ||
+            op == TOKmulass || op == TOKdivass || op == TOKmodass ||
+            op == TOKpowass)
         {
             if ((type.isintegral() && t2.isfloating()))
             {

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -668,7 +668,6 @@ extern (C++) struct Token
         Token.tochars[TOKcall] = "call";
         Token.tochars[TOKidentity] = "is";
         Token.tochars[TOKnotidentity] = "!is";
-        Token.tochars[TOKorass] = "|=";
         Token.tochars[TOKidentifier] = "identifier";
         Token.tochars[TOKat] = "@";
         Token.tochars[TOKpow] = "^^";


### PR DESCRIPTION
[Issue 15260](https://issues.dlang.org/show_bug.cgi?id=15260) - [dmd-internal] StringExp.compare may cause invalid memory access
[Issue 15261](https://issues.dlang.org/show_bug.cgi?id=15261) - [dmd-internal] Trivial problem in BinExp.checkOpAssignTypes
[Issue 15262](https://issues.dlang.org/show_bug.cgi?id=15262) - [dmd-internal] Duplicated initialization in Token struct static constructor

I found these bugs during the #5239 work.
