### PR TITLE
 [REG2.069.0-rc1] Issue 15253 - inliner prevent compilation

### DIFF
--- a/src/inline.d
+++ b/src/inline.d
@@ -2101,16 +2101,6 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
             auto de = new DeclarationExp(Loc(), vto);
             de.type = Type.tvoid;
             e = Expression.combine(e, de);
-
-            /* If function pointer or delegate parameters are present,
-             * inline scan again because if they are initialized to a symbol,
-             * any calls to the fp or dg can be inlined.
-             */
-            if (vfrom.type.ty == Tdelegate ||
-                vfrom.type.ty == Tpointer && vfrom.type.nextOf().ty == Tfunction)
-            {
-                again = true;
-            }
         }
     }
 

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -893,6 +893,29 @@ void test15207()
 }
 
 /**********************************/
+// 15253
+
+struct MessageType15253
+{
+    MessageType15253[] messageTypes;
+
+    const void toString1(scope void delegate(const(char)[]) sink)
+    {
+        messageTypes[0].toString1(sink);
+    }
+}
+
+struct ProtoPackage15253
+{
+    MessageType15253[] messageTypes;
+
+    const void toString1(scope void delegate(const(char)[]) sink)
+    {
+        messageTypes[0].toString1(sink);
+    }
+}
+
+/**********************************/
 
 int main()
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15253

Setting `again` flag in `expandInline` is just wrong. From the reduced case, if a function that has a delegate parameter contains recursive call, inliner will go into infinite scanning loop.

OTOH, the "repeated scanning" idea to see more inline possibility is still good. So I think we don't have to remove the loop in `InlineScanVisitor.visit(FuncDeclaration fd)` and `InlineScanVisitor.again` field. After this change they will become unused, but may be reused in future changes.
