### PR TITLE
fix Issue 13009 more

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -2543,20 +2543,20 @@ public:
      * There's four result types.
      *
      * 1. If the 'tthis' matches only one candidate, it's an "exact match".
-     *    Returns the function and 't' is set to its type.
+     *    Returns the function and 'hasOverloads' is set to false.
      *      eg. If 'tthis" is mutable and there's only one mutable method.
      * 2. If there's two or more match candidates, but a candidate function will be
      *    a "better match".
-     *    Returns NULL but 't' is set to the candidate type.
+     *    Returns the better match function but 'hasOverloads' is set to true.
      *      eg. If 'tthis' is mutable, and there's both mutable and const methods,
      *          the mutable method will be a better match.
      * 3. If there's two or more match candidates, but there's no better match,
-     *    Returns NULL and 't' is set to NULL to represent "ambiguous match".
+     *    Returns null and 'hasOverloads' is set to true to represent "ambiguous match".
      *      eg. If 'tthis' is mutable, and there's two or more mutable methods.
-     * 4. If there's no candidates, it's "no match" and returns NULL with error report.
+     * 4. If there's no candidates, it's "no match" and returns null with error report.
      *      e.g. If 'tthis' is const but there's no const methods.
      */
-    final FuncDeclaration overloadModMatch(Loc loc, Type tthis, ref Type t)
+    final FuncDeclaration overloadModMatch(Loc loc, Type tthis, ref bool hasOverloads)
     {
         //printf("FuncDeclaration::overloadModMatch('%s')\n", toChars());
         Match m;
@@ -2604,6 +2604,7 @@ public:
 
         LlastIsBetter:
             //printf("\tlastbetter\n");
+            m.count++; // count up
             return 0;
 
         LcurrIsBetter:
@@ -2620,21 +2621,17 @@ public:
             return 0;
         });
 
-        if (m.count == 1)   // exact match
+        if (m.count == 1)       // exact match
         {
-            t = m.lastf.type;
+            hasOverloads = false;
         }
-        else if (m.count > 1)
+        else if (m.count > 1)   // better or ambiguous match
         {
-            if (!m.nextf)   // better match
-                t = m.lastf.type;
-            else            // ambiguous match
-                t = null;
-            m.lastf = null;
+            hasOverloads = true;
         }
-        else                // no match
+        else                    // no match
         {
-            t = null;
+            hasOverloads = true;
             auto tf = cast(TypeFunction)this.type;
             assert(tthis);
             assert(!MODimplicitConv(tthis.mod, tf.mod)); // modifier mismatch
@@ -2642,7 +2639,8 @@ public:
                 OutBuffer thisBuf, funcBuf;
                 MODMatchToBuffer(&thisBuf, tthis.mod, tf.mod);
                 MODMatchToBuffer(&funcBuf, tf.mod, tthis.mod);
-                .error(loc, "%smethod %s is not callable using a %sobject", funcBuf.peekString(), this.toPrettyChars(), thisBuf.peekString());
+                .error(loc, "%smethod %s is not callable using a %sobject",
+                    funcBuf.peekString(), this.toPrettyChars(), thisBuf.peekString());
             }
         }
         return m.lastf;

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1808,20 +1808,19 @@ struct T13009
     void put(char c) {}
 }
 
-struct S13009
+struct S13009(bool rev)
 {
     T13009 t;
 
-    @property
-    T13009 getT()
+    static if (!rev)
     {
-        return t;
+        @property       T13009  getT()       { return t; }
+        @property inout(T13009) getT() inout { return t; }
     }
-
-    @property
-    inout(T13009) getT() inout
+    else
     {
-        return t;
+        @property inout(T13009) getT() inout { return t; }
+        @property       T13009  getT()       { return t; }
     }
 
     alias getT this;
@@ -1829,25 +1828,30 @@ struct S13009
 
 void test13009()
 {
-    alias MS   =                    S13009;
-    alias CS   =              const(S13009);
-    alias WS   =        inout(      S13009);
-    alias WCS  =        inout(const S13009);
-    alias SMS  = shared(            S13009);
-    alias SCS  = shared(      const S13009);
-    alias SWS  = shared(inout       S13009);
-    alias SWCS = shared(inout const S13009);
-    alias IS   =          immutable(S13009);
+    foreach (bool rev; Seq!(false, true))
+    {
+        alias S = S13009!rev;
 
-    alias MSput  = MS .put;
-    alias CSput  = CS .put;
-    alias WSput  = WS .put;
-    alias WCSput = WCS.put;
-    static assert(!__traits(compiles, { alias SMSput  = SMS .put; }));
-    static assert(!__traits(compiles, { alias SCSput  = SCS .put; }));
-    static assert(!__traits(compiles, { alias SWSput  = SWS .put; }));
-    static assert(!__traits(compiles, { alias SWCSput = SWCS.put; }));
-    alias ISput  = IS .put;
+        alias MS   =                    S;
+        alias CS   =              const(S);
+        alias WS   =        inout(      S);
+        alias WCS  =        inout(const S);
+        alias SMS  = shared(            S);
+        alias SCS  = shared(      const S);
+        alias SWS  = shared(inout       S);
+        alias SWCS = shared(inout const S);
+        alias IS   =          immutable(S);
+
+        alias MSput  = MS .put;
+        alias CSput  = CS .put;
+        alias WSput  = WS .put;
+        alias WCSput = WCS.put;
+        static assert(!__traits(compiles, { alias SMSput  = SMS .put; }));
+        static assert(!__traits(compiles, { alias SCSput  = SCS .put; }));
+        static assert(!__traits(compiles, { alias SWSput  = SWS .put; }));
+        static assert(!__traits(compiles, { alias SWCSput = SWCS.put; }));
+        alias ISput  = IS .put;
+    }
 }
 
 /***************************************************/


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13009

There was a function declaration order dependent bug in `overloadModMatch`.
