### PR TITLE
Parameter types should have namespace std mangling too

### DIFF
--- a/src/cppmangle.d
+++ b/src/cppmangle.d
@@ -264,7 +264,10 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                 }
                 if (p && !p.isModule())
                 {
-                    prefix_name(p);
+                    if (p.ident == Id.std && is_initial_qualifier(p))
+                        buf.writestring("St");
+                    else
+                        prefix_name(p);
                 }
                 if (!(s.ident == Id.std && is_initial_qualifier(s)))
                     store(s);

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -500,6 +500,12 @@ extern (C++, std)
     }
 
     class exception { }
+
+    // 14956
+    extern(C++, N14956)
+    {
+        struct S14956 { }
+    }
 }
 
 extern (C++)
@@ -758,6 +764,11 @@ void test14200()
   test14200a(1);
   test14200b(1.0f, 1, 1.0);
 }
+
+/****************************************/
+// 14956
+
+extern(C++) void test14956(S14956 s);
 
 /****************************************/
 // check order of overloads in vtable
@@ -1104,6 +1115,7 @@ void main()
     foo13337(S13337());
     test14195();
     test14200();
+    test14956(S14956());
     testVtable();
     fuzz();
     testeh();

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -481,6 +481,17 @@ void test14200a(int a) {};
 void test14200b(float a, int b, double c) {};
 
 /******************************************/
+// 14956
+
+namespace std {
+    namespace N14956 {
+	struct S14956 { };
+    }
+}
+
+void test14956(std::N14956::S14956 s) { }
+
+/******************************************/
 // check order of overloads in vtable
 
 class Statement;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14956

Needed for proposed fix to work, otherwise the parameter type is mangled as `PN3std7__cxx11` rather than `PNSt7__cxx11`
