### PR TITLE
[14965]: Add versioned-out branch to support new C++-11 implementations of std::string

### DIFF
--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -469,8 +469,21 @@ extern (C++, std)
 	{
 	}
 
-	struct basic_string(T, C = char_traits!T, A = allocator!T)
+	// https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+	version (none)
 	{
+	    extern (C++, __cxx11)
+	    {
+		struct basic_string(T, C = char_traits!T, A = allocator!T)
+		{
+		}
+	    }
+	}
+	else
+	{
+	    struct basic_string(T, C = char_traits!T, A = allocator!T)
+	    {
+	    }
 	}
 
 	struct basic_istream(T, C = char_traits!T)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14956

Depends on #5261 - and would fix 14596, but we currently have no way to separate the two apart.  Nor do I know whether it is worth the trouble.
