### PR TITLE
Issue 15239 - ICE (assertion failure) in ctfeInterpret() - opDispatch & inline asm

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -5252,12 +5252,12 @@ extern (C++) final class ScopeExp : Expression
 public:
     ScopeDsymbol sds;
 
-    extern (D) this(Loc loc, ScopeDsymbol pkg)
+    extern (D) this(Loc loc, ScopeDsymbol sds)
     {
         super(loc, TOKimport, __traits(classInstanceSize, ScopeExp));
-        //printf("ScopeExp::ScopeExp(pkg = '%s')\n", pkg->toChars());
+        //printf("ScopeExp::ScopeExp(sds = '%s')\n", sds.toChars());
         //static int count; if (++count == 38) *(char*)0=0;
-        this.sds = pkg;
+        this.sds = sds;
     }
 
     override Expression syntaxCopy()
@@ -5271,8 +5271,8 @@ public:
         {
             printf("+ScopeExp::semantic(%p '%s')\n", this, toChars());
         }
-        //if (type == Type::tvoid)
-        //    return this;
+        if (type)
+            return this;
 
         ScopeDsymbol sds2 = sds;
         TemplateInstance ti = sds2.isTemplateInstance();
@@ -5312,6 +5312,9 @@ public:
                         return e.semantic(sc);
                     }
                 }
+                // ti is an instance which requires IFTI.
+                sds = ti;
+                type = Type.tvoid;
                 return this;
             }
             ti.semantic(sc);
@@ -8897,7 +8900,7 @@ public:
         /* This recognizes:
          *  foo!(tiargs)(funcargs)
          */
-        if (e1.op == TOKimport && !e1.type)
+        if (e1.op == TOKimport)
         {
             ScopeExp se = cast(ScopeExp)e1;
             TemplateInstance ti = se.sds.isTemplateInstance();

--- a/test/fail_compilation/fail10481.d
+++ b/test/fail_compilation/fail10481.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail10481.d(11): Error: undefined identifier 'T1', did you mean alias 'T0'?
-fail_compilation/fail10481.d(15): Error: cannot resolve type for get!(A)
+fail_compilation/fail10481.d(15): Error: cannot infer type from template instance get!(A)
 ---
 */
 

--- a/test/fail_compilation/ice15239.d
+++ b/test/fail_compilation/ice15239.d
@@ -1,0 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice15239.d(21): Error: cannot interpret opDispatch!"foo" at compile time
+fail_compilation/ice15239.d(21): Error: bad type/size of operands '__error'
+---
+*/
+
+struct T
+{
+    template opDispatch(string Name, P...)
+    {
+        static void opDispatch(P) {}
+    }
+}
+
+void main()
+{
+    asm
+    {
+        call T.foo;
+    }
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15239

The cause is a dmd-internal issue 15309.
[Issue 15309](https://issues.dlang.org/show_bug.cgi?id=15309) - [dmd-internal] ScopeExp.semantic() should set its type always
