### PR TITLE
generate .eh_frame rather than .debug_frame on Linux

### DIFF
--- a/src/backend/dwarf2.h
+++ b/src/backend/dwarf2.h
@@ -500,4 +500,28 @@ enum
         DW_CFA_hi_user                  = 0x3f,
 };
 
+enum
+{
+        DW_EH_PE_FORMAT_MASK    = 0x0F,
+        DW_EH_PE_APPL_MASK      = 0x70,
+        DW_EH_PE_indirect       = 0x80,
+
+        DW_EH_PE_omit           = 0xFF,
+        DW_EH_PE_ptr            = 0x00,
+        DW_EH_PE_uleb128        = 0x01,
+        DW_EH_PE_udata2         = 0x02,
+        DW_EH_PE_udata4         = 0x03,
+        DW_EH_PE_udata8         = 0x04,
+        DW_EH_PE_sleb128        = 0x09,
+        DW_EH_PE_sdata2         = 0x0A,
+        DW_EH_PE_sdata4         = 0x0B,
+        DW_EH_PE_sdata8         = 0x0C,
+
+        DW_EH_PE_absptr         = 0x00,
+        DW_EH_PE_pcrel          = 0x10,
+        DW_EH_PE_textrel        = 0x20,
+        DW_EH_PE_datarel        = 0x30,
+        DW_EH_PE_funcrel        = 0x40,
+        DW_EH_PE_aligned        = 0x50,
+};
 


### PR DESCRIPTION
It appears that the .debug_frame section is obsolete, and things are moving to .eh_frame instead. This implements .eh_frame for Linux 32 and 64 bit. .eh_frame is also a necessary step towards implementing dwarf exception handling.
