### PR TITLE
Issue 15317 - Segfault in Type::kind() with DMD v2.069.0

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -3813,8 +3813,7 @@ public:
         }
         if (Type t = s.getType())
         {
-            auto te = new TypeExp(loc, t);
-            return te.semantic(sc);
+            return (new TypeExp(loc, t)).semantic(sc);
         }
         if (TupleDeclaration tup = s.isTupleDeclaration())
         {
@@ -5204,6 +5203,9 @@ public:
 
     override Expression semantic(Scope* sc)
     {
+        if (type.ty == Terror)
+            return new ErrorExp();
+
         //printf("TypeExp::semantic(%s)\n", type->toChars());
         Expression e;
         Type t;
@@ -8101,10 +8103,9 @@ public:
                     //printf("'%s' is an overload set\n", o->toChars());
                     return new OverExp(loc, o);
                 }
-                Type t = s.getType();
-                if (t)
+                if (auto t = s.getType())
                 {
-                    return new TypeExp(loc, t);
+                    return (new TypeExp(loc, t)).semantic(sc);
                 }
                 TupleDeclaration tup = s.isTupleDeclaration();
                 if (tup)

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7878,9 +7878,9 @@ public:
             ve = ve.semantic(sc);
             return ve;
         }
-        if (s.getType())
+        if (auto t = s.getType())
         {
-            return new TypeExp(e.loc, s.getType());
+            return (new TypeExp(e.loc, t)).semantic(sc);
         }
 
         TemplateMixin tm = s.isTemplateMixin();
@@ -8732,9 +8732,9 @@ public:
             ve = ve.semantic(sc);
             return ve;
         }
-        if (s.getType())
+        if (auto t = s.getType())
         {
-            return new TypeExp(e.loc, s.getType());
+            return (new TypeExp(e.loc, t)).semantic(sc);
         }
 
         TemplateMixin tm = s.isTemplateMixin();

--- a/test/fail_compilation/ice15317.d
+++ b/test/fail_compilation/ice15317.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice15317.d(11): Error: undefined identifier 'fun'
+---
+*/
+
+void main()
+{
+    alias f = fun;
+    auto x1 = &f;
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15317

`TypeExp.semantic` should return `ErrorExp` if the `type` is `Terror`.
