### PR TITLE
c++ works for every Unix-like system.

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -30,11 +30,8 @@ ifeq (osx,$(OS))
     export MACOSX_DEPLOYMENT_TARGET=10.3
 endif
 
-#ifeq (osx,$(OS))
-#	HOST_CC=clang++
-#else
-	HOST_CC=g++
-#endif
+	HOST_CC=c++
+
 CC=$(HOST_CC)
 AR=ar
 GIT=git


### PR DESCRIPTION
Hey guys, the current posix.mak uses the logic:
if Mac then HOST_CC=clang++
else HOST_CC=g++
I'm on FreeBSD and the default compiler is clang, so that logic is not able to build here.
It's just use HOST_CC=c++ then it will work everywhere and dmd will be more portable.
Thanks.
