### PR TITLE
refactor: rename EX_NT to EX_WIN32

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -81,7 +81,7 @@ void out_config_init(
     }
     else
     {
-        config.exe = EX_NT;
+        config.exe = EX_WIN32;
         config.ehmethod = EH_WIN32;
         config.flags2 |= CFG2seh;       // Win32 eh
         config.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -246,7 +246,7 @@ One and only one of these macros must be set by the makefile:
 #if __GNUC__
 #define LDOUBLE                 0       // no support for true long doubles
 #else
-#define LDOUBLE         (config.exe == EX_NT)   // support true long doubles
+#define LDOUBLE         (config.exe == EX_WIN32)   // support true long doubles
 #endif
 
 #if _MSC_VER
@@ -497,7 +497,7 @@ typedef targ_uns        targ_size_t;    /* size_t for the target machine */
 #define NEWTEMPMANGLE   (!(config.flags4 & CFG4oldtmangle))     // do new template mangling
 #define USEDLLSHELL     _WINDLL
 #define FARCLASSES      1       // support near/far classes
-#define MFUNC           (I32) //0 && config.exe == EX_NT)       // member functions are TYmfunc
+#define MFUNC           (I32) //0 && config.exe == EX_WIN32)       // member functions are TYmfunc
 #define CV3             0       // 1 means support CV3 debug format
 
 /* Object module format
@@ -697,7 +697,7 @@ struct Config
 //#define EX_WIN16      0x20    // Windows 3.x 16 bit program
 #define EX_OS2          0x40    // OS/2 2.0 32 bit program
 #define EX_OS1          0x80    // OS/2 1.x 16 bit program
-#define EX_NT           0x100   // NT
+#define EX_WIN32        0x100
 #define EX_MZ           0x200   // MSDOS real mode program
 #define EX_XENIX        0x400
 #define EX_SCOUNIX      0x800
@@ -714,7 +714,7 @@ struct Config
 #define EX_OPENBSD      0x400000
 #define EX_OPENBSD64    0x800000
 
-#define EX_flat         (EX_OS2 | EX_NT | EX_LINUX | EX_WIN64 | EX_LINUX64 | \
+#define EX_flat         (EX_OS2 | EX_WIN32 | EX_LINUX | EX_WIN64 | EX_LINUX64 | \
                          EX_OSX | EX_OSX64 | EX_FREEBSD | EX_FREEBSD64 | \
                          EX_OPENBSD | EX_OPENBSD64 | \
                          EX_SOLARIS | EX_SOLARIS64)

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -1209,7 +1209,7 @@ STATIC void obj_defaultlib()
         case EX_OS1:
             library[1] = 'O';
             break;
-        case EX_NT:
+        case EX_WIN32:
 #if MARS
             library[1] = 'M';
 #else
@@ -1383,7 +1383,7 @@ STATIC void objheader(char *csegname)
   comment[2] = config.target_cpu + '0';
   comment[3] = model[config.memmodel];
   if (I32)
-  {     if (config.exe == EX_NT)
+  {     if (config.exe == EX_WIN32)
             comment[3] = 'n';
         else if (config.exe == EX_OS2)
             comment[3] = 'f';
@@ -2301,7 +2301,7 @@ size_t Obj::mangle(Symbol *s,char *dest)
 #endif
         case mTYman_std:
             if (!(config.flags4 & CFG4oldstdmangle) &&
-                config.exe == EX_NT && tyfunc(s->ty()) &&
+                config.exe == EX_WIN32 && tyfunc(s->ty()) &&
                 !variadic(s->Stype))
             {
                 dest[1] = '_';

--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -5038,13 +5038,13 @@ code *cdinfo(elem *e,regm_t *pretregs)
             c = cat(c,codelem(e->E1,&retregs,FALSE));
             break;
         case OPmark:
-            if (0 && config.exe == EX_NT)
+            if (0 && config.exe == EX_WIN32)
             {   unsigned idx;
 
                 idx = except_index_get();
                 except_mark();
                 c = codelem(e->E2,pretregs,FALSE);
-                if (config.exe == EX_NT && idx != except_index_get())
+                if (config.exe == EX_WIN32 && idx != except_index_get())
                 {   usednteh |= NTEHcleanup;
                     c = cat(c,nteh_gensindex(idx - 1));
                 }
@@ -5082,7 +5082,7 @@ code *cddctor(elem *e,regm_t *pretregs)
         MOV     sindex[BP],index
      */
     usednteh |= EHcleanup;
-    if (config.exe == EX_NT)
+    if (config.exe == EX_WIN32)
     {   usednteh |= NTEHcleanup | NTEH_try;
         nteh_usevars();
     }
@@ -5120,7 +5120,7 @@ code *cdddtor(elem *e,regm_t *pretregs)
     L1: NOP
     */
     usednteh |= EHcleanup;
-    if (config.exe == EX_NT)
+    if (config.exe == EX_WIN32)
     {   usednteh |= NTEHcleanup | NTEH_try;
         nteh_usevars();
     }
@@ -5185,7 +5185,7 @@ code *cdctor(elem *e,regm_t *pretregs)
     code *c;
 
     usednteh |= EHcleanup;
-    if (config.exe == EX_NT)
+    if (config.exe == EX_WIN32)
         usednteh |= NTEHcleanup;
     assert(*pretregs == 0);
     cs.Iop = ESCAPE | ESCctor;
@@ -5207,7 +5207,7 @@ code *cddtor(elem *e,regm_t *pretregs)
     code *c;
 
     usednteh |= EHcleanup;
-    if (config.exe == EX_NT)
+    if (config.exe == EX_WIN32)
         usednteh |= NTEHcleanup;
     assert(*pretregs == 0);
     cs.Iop = ESCAPE | ESCdtor;

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -3812,7 +3812,7 @@ void epilog(block *b)
         useregs((ALLREGS | mBP | mES) & ~s->Sregsaved);
     }
 
-    if (usednteh & ~NTEHjmonitor && (config.exe == EX_NT || MARS))
+    if (usednteh & ~NTEHjmonitor && (config.exe == EX_WIN32 || MARS))
         c = cat(c,nteh_epilog());
 
     cpopds = CNIL;
@@ -6029,7 +6029,7 @@ unsigned codout(code *c)
                     case ESCctor:
                     case ESCdtor:
                     case ESCoffset:
-                        if (config.exe != EX_NT)
+                        if (config.exe != EX_WIN32)
                             except_pair_setoffset(c,ggen.getOffset() - funcoffset);
                         break;
                     case ESCmark:

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -2015,7 +2015,7 @@ char *obj_mangle2(Symbol *s,char *dest)
             if (tyfunc(s->ty()) && !variadic(s->Stype))
 #else
             if (!(config.flags4 & CFG4oldstdmangle) &&
-                config.exe == EX_NT && tyfunc(s->ty()) &&
+                config.exe == EX_WIN32 && tyfunc(s->ty()) &&
                 !variadic(s->Stype))
 #endif
             {

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -1938,7 +1938,7 @@ char *obj_mangle2(Symbol *s,char *dest)
             if (tyfunc(s->ty()) && !variadic(s->Stype))
 #else
             if (!(config.flags4 & CFG4oldstdmangle) &&
-                config.exe == EX_NT && tyfunc(s->ty()) &&
+                config.exe == EX_WIN32 && tyfunc(s->ty()) &&
                 !variadic(s->Stype))
 #endif
             {

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -1815,7 +1815,7 @@ char *obj_mangle2(Symbol *s,char *dest)
             if (tyfunc(s->ty()) && !variadic(s->Stype))
 #else
             if (!(config.flags4 & CFG4oldstdmangle) &&
-                config.exe == EX_NT && tyfunc(s->ty()) &&
+                config.exe == EX_WIN32 && tyfunc(s->ty()) &&
                 !variadic(s->Stype))
 #endif
             {

--- a/src/backend/nteh.c
+++ b/src/backend/nteh.c
@@ -367,7 +367,7 @@ code *nteh_prolog()
     }
     c = gen(NULL,&cs);                          // PUSH &__except_handler3
 
-    if (config.exe == EX_NT)
+    if (config.exe == EX_WIN32)
     {
         makeitextern(getRtlsym(RTLSYM_EXCEPT_LIST));
     #if 0

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -1231,7 +1231,7 @@ STATIC void writefunc2(symbol *sfunc)
             {
                 case 'D': if (strcmp(id,"DllMain"))
                                 break;
-                          if (config.exe == EX_NT)
+                          if (config.exe == EX_WIN32)
                           {     i = 2;
                                 goto L2;
                           }
@@ -1239,7 +1239,7 @@ STATIC void writefunc2(symbol *sfunc)
 
                 case 'm': if (strcmp(id,"main"))
                                 break;
-                          if (config.exe == EX_NT)
+                          if (config.exe == EX_WIN32)
                                 i = 3;
                           else if (config.wflags & WFwindows)
                                 i = 1;
@@ -1249,7 +1249,7 @@ STATIC void writefunc2(symbol *sfunc)
 
                 case 'w': if (strcmp(id,"wmain") == 0)
                           {
-                                if (config.exe == EX_NT)
+                                if (config.exe == EX_WIN32)
                                 {   i = 5;
                                     goto L2;
                                 }
@@ -1262,7 +1262,7 @@ STATIC void writefunc2(symbol *sfunc)
                           }
                           if (stricmp(id,"wWinMain") == 0)
                           {
-                                if (config.exe == EX_NT)
+                                if (config.exe == EX_WIN32)
                                 {   i = 4;
                                     goto L2;
                                 }
@@ -1272,7 +1272,7 @@ STATIC void writefunc2(symbol *sfunc)
                 case 'L':
                 case 'l': if (stricmp(id,"LibMain"))
                                 break;
-                          if (config.exe != EX_NT && config.wflags & WFwindows)
+                          if (config.exe != EX_WIN32 && config.wflags & WFwindows)
                           {     i = 2;
                                 goto L2;
                           }


### PR DESCRIPTION
Because nobody has called it NT in a very, very long time.
