### PR TITLE
[REG2.068.0] Issue 15292 - Segmentation fault with self-referencing struct / inout / alias this

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -156,7 +156,7 @@ public:
 
     override final void semantic3(Scope* sc)
     {
-        //printf("AggregateDeclaration::semantic3(%s) type = %s, errors = %d\n", toChars(), type->toChars(), errors);
+        //printf("AggregateDeclaration::semantic3(%s) type = %s, errors = %d\n", toChars(), type.toChars(), errors);
         if (!members)
             return;
 

--- a/test/fail_compilation/fail15292.d
+++ b/test/fail_compilation/fail15292.d
@@ -1,0 +1,28 @@
+// REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail15292.d(27): Error: cannot compare S15292 because its auto generated member-wise equality has recursive definition
+---
+*/
+
+struct NullableRef15292(T)
+{
+    inout(T) get() inout
+    {
+        assert(false);
+    }
+
+    alias get this;
+}
+
+struct S15292
+{
+    NullableRef15292!S15292 n;
+}
+
+void main()
+{
+    S15292 s;
+    assert(s == s);
+}

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1909,6 +1909,36 @@ void test14948()
 }
 
 /***************************************************/
+// 15292
+
+struct NullableRef15292(T)
+{
+    inout(T) get() inout
+    {
+        assert(false);
+    }
+
+    alias get this;
+}
+
+struct S15292
+{
+    NullableRef15292!S15292 n;  // -> no segfault
+
+    /* The field 'n' contains alias this, so to use it for the equality,
+     * following helper function is automatically generated in buildXopEquals().
+     *
+     *  static bool __xopEquals(ref const S15292 p, ref const S15292 q)
+     *  {
+     *      return p == q;
+     *  }
+     *
+     * In its definition, const(S15292) equality is analyzed. It fails, then
+     * the error is gagged.
+     */
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15292

As same as alias this, automatic tupleof addition for member-wise equality should detect recursive expansion.

Different from alias this, the recursive tupleof expansion will be an error (see `fail15292.d`). I also considered to do implicit fallback to bitwise equality, but I concluded that today the explicit error is better so it could be changed in the future.
