### PR TITLE
Issue 15352 - template arguments matching error with delegates

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -3754,17 +3754,18 @@ public:
             e = e.semantic(sc);
             return e;
         }
-        if (FuncLiteralDeclaration fld = s.isFuncLiteralDeclaration())
+        if (auto fld = s.isFuncLiteralDeclaration())
         {
             //printf("'%s' is a function literal\n", fld->toChars());
             e = new FuncExp(loc, fld);
             return e.semantic(sc);
         }
-        if (FuncDeclaration f = s.isFuncDeclaration())
+        if (auto f = s.isFuncDeclaration())
         {
             f = f.toAliasFunc();
             if (!f.functionSemantic())
                 return new ErrorExp();
+
             if (!f.type.deco)
             {
                 const(char)* trailMsg = f.inferRetType ? "inferred return type of function call " : "";
@@ -6163,6 +6164,20 @@ public:
         }
         tok = fd.tok; // save original kind of function/delegate/(infer)
         assert(fd.fbody);
+    }
+
+    override bool equals(RootObject o)
+    {
+        if (this == o)
+            return true;
+        if (o.dyncast() != DYNCAST_EXPRESSION)
+            return false;
+        if ((cast(Expression)o).op == TOKfunction)
+        {
+            FuncExp fe = cast(FuncExp)o;
+            return fd == fe.fd;
+        }
+        return false;
     }
 
     void genIdent(Scope* sc)

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -6996,7 +6996,8 @@ public:
             for (size_t i = 0; i < idents.dim; i++)
             {
                 RootObject id = idents[i];
-                if (id.dyncast() == DYNCAST_EXPRESSION || id.dyncast() == DYNCAST_TYPE)
+                if (id.dyncast() == DYNCAST_EXPRESSION ||
+                    id.dyncast() == DYNCAST_TYPE)
                 {
                     Type tx;
                     Expression ex;
@@ -7016,6 +7017,7 @@ public:
                     resolveExp(ex, pt, pe, ps);
                     return;
                 }
+
                 Type t = s.getType(); // type symbol, type alias, or type tuple?
                 uint errorsave = global.errors;
                 Dsymbol sm = s.searchX(loc, sc, id);
@@ -7029,7 +7031,8 @@ public:
                     goto L3;
                 if (VarDeclaration v = s.isVarDeclaration())
                 {
-                    if (v.storage_class & (STCconst | STCimmutable | STCmanifest) || v.type.isConst() || v.type.isImmutable())
+                    if (v.storage_class & (STCconst | STCimmutable | STCmanifest) ||
+                        v.type.isConst() || v.type.isImmutable())
                     {
                         // Bugzilla 13087: this.field is not constant always
                         if (!v.isThisDeclaration())
@@ -7046,7 +7049,8 @@ public:
                             if (!t && s.isTupleDeclaration()) // expression tuple?
                                 goto L3;
                         }
-                        else if (s.isTemplateInstance() || s.isImport() || s.isPackage() || s.isModule())
+                        else if (s.isTemplateInstance() ||
+                                 s.isImport() || s.isPackage() || s.isModule())
                         {
                             goto L3;
                         }
@@ -7134,6 +7138,13 @@ public:
                     *pe = new VarExp(loc, v);
                 return;
             }
+            if (auto fld = s.isFuncLiteralDeclaration())
+            {
+                //printf("'%s' is a function literal\n", fld.toChars());
+                *pe = new FuncExp(loc, fld);
+                *pe = (*pe).semantic(sc);
+                return;
+            }
             version (none)
             {
                 if (FuncDeclaration fd = s.isFuncDeclaration())
@@ -7142,6 +7153,7 @@ public:
                     return;
                 }
             }
+
         L1:
             Type t = s.getType();
             if (!t)

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -4728,6 +4728,36 @@ void test15152()
 }
 
 /******************************************/
+// 15352
+
+struct S15352(T, T delegate(uint idx) supplier)
+{
+}
+
+auto make15352a(T, T delegate(uint idx) supplier)()
+{
+    enum local = supplier;      // OK
+    S15352!(T, local) ret;
+    return ret;
+}
+
+auto make15352b(T, T delegate(uint idx) supplier)()
+{
+    S15352!(T, supplier) ret;   // OK <- Error
+    return ret;
+}
+
+void test15352()
+{
+    enum dg = delegate(uint idx) => idx;
+    auto s1 = S15352!(uint, dg)();
+    auto s2 = make15352a!(uint, dg)();
+    auto s3 = make15352b!(uint, dg)();
+    assert(is(typeof(s1) == typeof(s2)));
+    assert(is(typeof(s1) == typeof(s3)));
+}
+
+/******************************************/
 
 int main()
 {


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15352
1. `match()` function relies on `Expression.equals()`. Add `FuncExp.equals` for the identity comparison of two `FuncExp`s.
2. When a `FuncLiteralDeclaration` is listed directly in template arguments, it needs to be converted to `FuncExp` to be able to match `TemplateValueParameter`.
