### PR TITLE
Move utility functions from mars to utils module.

### DIFF
--- a/src/attrib.d
+++ b/src/attrib.d
@@ -28,13 +28,13 @@ import ddmd.globals;
 import ddmd.hdrgen;
 import ddmd.id;
 import ddmd.identifier;
-import ddmd.mars;
 import ddmd.mtype;
 import ddmd.parse;
 import ddmd.root.outbuffer;
 import ddmd.root.rmem;
 import ddmd.tokens;
 import ddmd.utf;
+import ddmd.utils;
 import ddmd.visitor;
 
 /***********************************************************

--- a/src/cond.d
+++ b/src/cond.d
@@ -19,10 +19,10 @@ import ddmd.errors;
 import ddmd.expression;
 import ddmd.globals;
 import ddmd.identifier;
-import ddmd.mars;
 import ddmd.mtype;
 import ddmd.root.outbuffer;
 import ddmd.tokens;
+import ddmd.utils;
 import ddmd.visitor;
 
 private __gshared Identifier idUnitTest;

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -24,9 +24,9 @@ import ddmd.globals;
 import ddmd.hdrgen;
 import ddmd.id;
 import ddmd.identifier;
-import ddmd.mars;
 import ddmd.mtype;
 import ddmd.root.outbuffer;
+import ddmd.utils;
 import ddmd.visitor;
 
 /***********************************************************

--- a/src/doc.d
+++ b/src/doc.d
@@ -32,7 +32,6 @@ import ddmd.hdrgen;
 import ddmd.id;
 import ddmd.identifier;
 import ddmd.lexer;
-import ddmd.mars;
 import ddmd.mtype;
 import ddmd.root.array;
 import ddmd.root.file;
@@ -42,6 +41,7 @@ import ddmd.root.port;
 import ddmd.root.rmem;
 import ddmd.tokens;
 import ddmd.utf;
+import ddmd.utils;
 import ddmd.visitor;
 
 struct Escape

--- a/src/expression.d
+++ b/src/expression.d
@@ -46,7 +46,6 @@ import ddmd.identifier;
 import ddmd.imphint;
 import ddmd.inline;
 import ddmd.intrange;
-import ddmd.mars;
 import ddmd.mtype;
 import ddmd.nspace;
 import ddmd.opover;
@@ -65,6 +64,7 @@ import ddmd.tokens;
 import ddmd.traits;
 import ddmd.typinf;
 import ddmd.utf;
+import ddmd.utils;
 import ddmd.visitor;
 
 enum LOGSEMANTIC = false;

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -34,7 +34,6 @@ import ddmd.globals;
 import ddmd.id;
 import ddmd.identifier;
 import ddmd.init;
-import ddmd.mars;
 import ddmd.mtype;
 import ddmd.nspace;
 import ddmd.parse;
@@ -45,6 +44,7 @@ import ddmd.statement;
 import ddmd.staticassert;
 import ddmd.target;
 import ddmd.tokens;
+import ddmd.utils;
 import ddmd.visitor;
 
 struct HdrGenState

--- a/src/libelf.d
+++ b/src/libelf.d
@@ -23,9 +23,9 @@ import ddmd.root.outbuffer;
 import ddmd.root.stringtable;
 import ddmd.root.filename;
 import ddmd.root.port;
-import ddmd.mars;
 import ddmd.scanelf;
 import ddmd.errors;
+import ddmd.utils;
 
 enum LOG = false;
 

--- a/src/libmach.d
+++ b/src/libmach.d
@@ -24,9 +24,9 @@ import ddmd.root.outbuffer;
 import ddmd.root.stringtable;
 import ddmd.root.filename;
 import ddmd.root.port;
-import ddmd.mars;
 import ddmd.scanmach;
 import ddmd.errors;
+import ddmd.utils;
 
 enum LOG = false;
 

--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -18,7 +18,6 @@ import core.stdc.stdarg;
 import core.stdc.string;
 import ddmd.globals;
 import ddmd.lib;
-import ddmd.mars;
 import ddmd.root.array;
 import ddmd.root.file;
 import ddmd.root.filename;
@@ -27,6 +26,7 @@ import ddmd.root.port;
 import ddmd.root.stringtable;
 import ddmd.scanmscoff;
 import ddmd.errors;
+import ddmd.utils;
 
 enum LOG = false;
 

--- a/src/libomf.d
+++ b/src/libomf.d
@@ -18,13 +18,13 @@ import core.stdc.stdlib;
 import core.stdc.stdarg;
 import ddmd.globals;
 import ddmd.lib;
-import ddmd.mars;
 import ddmd.root.array;
 import ddmd.root.file;
 import ddmd.root.filename;
 import ddmd.root.outbuffer;
 import ddmd.root.stringtable;
 import ddmd.errors;
+import ddmd.utils;
 
 import ddmd.scanomf;
 

--- a/src/link.d
+++ b/src/link.d
@@ -16,11 +16,11 @@ import core.sys.posix.stdlib;
 import core.sys.posix.unistd;
 import ddmd.errors;
 import ddmd.globals;
-import ddmd.mars;
 import ddmd.root.file;
 import ddmd.root.filename;
 import ddmd.root.outbuffer;
 import ddmd.root.rmem;
+import ddmd.utils;
 
 version (Posix) extern (C) int pipe(int*);
 version (Windows) extern (C) int putenv(const char*);

--- a/src/mars.d
+++ b/src/mars.d
@@ -53,88 +53,7 @@ import ddmd.root.rmem;
 import ddmd.root.stringtable;
 import ddmd.target;
 import ddmd.tokens;
-
-
-/**
- * Normalize path by turning forward slashes into backslashes
- *
- * Params:
- *   src = Source path, using unix-style ('/') path separators
- *
- * Returns:
- *   A newly-allocated string with '/' turned into backslashes
- */
-extern (C++) const(char)* toWinPath(const(char)* src)
-{
-    if (src is null)
-        return null;
-    char* result = strdup(src);
-    char* p = result;
-    while (*p != '\0')
-    {
-        if (*p == '/')
-            *p = '\\';
-        p++;
-    }
-    return result;
-}
-
-
-/**
- * Reads a file, terminate the program on error
- *
- * Params:
- *   loc = The line number information from where the call originates
- *   f = a `ddmd.root.file.File` handle to read
- */
-extern (C++) void readFile(Loc loc, File* f)
-{
-    if (f.read())
-    {
-        error(loc, "Error reading file '%s'", f.name.toChars());
-        fatal();
-    }
-}
-
-
-/**
- * Writes a file, terminate the program on error
- *
- * Params:
- *   loc = The line number information from where the call originates
- *   f = a `ddmd.root.file.File` handle to write
- */
-extern (C++) void writeFile(Loc loc, File* f)
-{
-    if (f.write())
-    {
-        error(loc, "Error writing file '%s'", f.name.toChars());
-        fatal();
-    }
-}
-
-
-/**
- * Ensure the root path (the path minus the name) of the provided path
- * exists, and terminate the process if it doesn't.
- *
- * Params:
- *   loc = The line number information from where the call originates
- *   name = a path to check (the name is stripped)
- */
-extern (C++) void ensurePathToNameExists(Loc loc, const(char)* name)
-{
-    const(char)* pt = FileName.path(name);
-    if (*pt)
-    {
-        if (FileName.ensurePathExists(pt))
-        {
-            error(loc, "cannot create directory %s", pt);
-            fatal();
-        }
-    }
-    FileName.free(pt);
-}
+import ddmd.utils;
 
 
 /**
@@ -1736,36 +1655,6 @@ private void getenv_setargv(const(char)* envvalue, Strings* args)
         }
     }
 }
-
-
-/**
- * Takes a path, and escapes '(', ')' and backslashes
- *
- * Params:
- *   buf = Buffer to write the escaped path to
- *   fname = Path to escape
- */
-extern (C++) void escapePath(OutBuffer* buf, const(char)* fname)
-{
-    while (1)
-    {
-        switch (*fname)
-        {
-        case 0:
-            return;
-        case '(':
-        case ')':
-        case '\\':
-            buf.writeByte('\\');
-            goto default;
-        default:
-            buf.writeByte(*fname);
-            break;
-        }
-        fname++;
-    }
-}
-
 
 /**
  * Parse command line arguments for -m32 or -m64

--- a/src/mars.h
+++ b/src/mars.h
@@ -91,12 +91,13 @@ void obj_end(Library *library, File *objfile);
 void obj_append(Dsymbol *s);
 void obj_write_deferred(Library *library);
 
+/// Utility functions used by both main and frontend.
 void readFile(Loc loc, File *f);
 void writeFile(Loc loc, File *f);
 void ensurePathToNameExists(Loc loc, const char *name);
 
 const char *importHint(const char *s);
-/// Little helper function for writting out deps.
+/// Little helper function for writing out deps.
 void escapePath(OutBuffer *buf, const char *fname);
 
 #endif /* DMD_MARS_H */

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -205,7 +205,7 @@ FRONT_SRCS=$(addsuffix .d,access aggregate aliasthis apply argtypes arrayop	\
 	globals hdrgen id identifier impcnvtab imphint init inline intrange	\
 	json lexer lib link mars mtype nogc nspace opover optimize parse sapply	\
 	sideeffect statement staticassert target tokens traits utf visitor	\
-	typinf)
+	typinf utils)
 
 ifeq ($(D_OBJC),1)
 	FRONT_SRCS += objc.d

--- a/src/utils.d
+++ b/src/utils.d
@@ -1,0 +1,127 @@
+// Compiler implementation of the D programming language
+// Copyright (c) 1999-2015 by Digital Mars
+// All Rights Reserved
+// written by Walter Bright
+// http://www.digitalmars.com
+// Distributed under the Boost Software License, Version 1.0.
+// http://www.boost.org/LICENSE_1_0.txt
+
+module ddmd.utils;
+
+import core.stdc.string;
+import ddmd.errors;
+import ddmd.globals;
+import ddmd.root.file;
+import ddmd.root.filename;
+import ddmd.root.outbuffer;
+
+
+/**
+ * Normalize path by turning forward slashes into backslashes
+ *
+ * Params:
+ *   src = Source path, using unix-style ('/') path separators
+ *
+ * Returns:
+ *   A newly-allocated string with '/' turned into backslashes
+ */
+extern (C++) const(char)* toWinPath(const(char)* src)
+{
+    if (src is null)
+        return null;
+    char* result = strdup(src);
+    char* p = result;
+    while (*p != '\0')
+    {
+        if (*p == '/')
+            *p = '\\';
+        p++;
+    }
+    return result;
+}
+
+
+/**
+ * Reads a file, terminate the program on error
+ *
+ * Params:
+ *   loc = The line number information from where the call originates
+ *   f = a `ddmd.root.file.File` handle to read
+ */
+extern (C++) void readFile(Loc loc, File* f)
+{
+    if (f.read())
+    {
+        error(loc, "Error reading file '%s'", f.name.toChars());
+        fatal();
+    }
+}
+
+
+/**
+ * Writes a file, terminate the program on error
+ *
+ * Params:
+ *   loc = The line number information from where the call originates
+ *   f = a `ddmd.root.file.File` handle to write
+ */
+extern (C++) void writeFile(Loc loc, File* f)
+{
+    if (f.write())
+    {
+        error(loc, "Error writing file '%s'", f.name.toChars());
+        fatal();
+    }
+}
+
+
+/**
+ * Ensure the root path (the path minus the name) of the provided path
+ * exists, and terminate the process if it doesn't.
+ *
+ * Params:
+ *   loc = The line number information from where the call originates
+ *   name = a path to check (the name is stripped)
+ */
+extern (C++) void ensurePathToNameExists(Loc loc, const(char)* name)
+{
+    const(char)* pt = FileName.path(name);
+    if (*pt)
+    {
+        if (FileName.ensurePathExists(pt))
+        {
+            error(loc, "cannot create directory %s", pt);
+            fatal();
+        }
+    }
+    FileName.free(pt);
+}
+
+
+/**
+ * Takes a path, and escapes '(', ')' and backslashes
+ *
+ * Params:
+ *   buf = Buffer to write the escaped path to
+ *   fname = Path to escape
+ */
+extern (C++) void escapePath(OutBuffer* buf, const(char)* fname)
+{
+    while (1)
+    {
+        switch (*fname)
+        {
+        case 0:
+            return;
+        case '(':
+        case ')':
+        case '\\':
+            buf.writeByte('\\');
+            goto default;
+        default:
+            buf.writeByte(*fname);
+            break;
+        }
+        fname++;
+    }
+}

--- a/src/vcbuild/ddmd.visualdproj
+++ b/src/vcbuild/ddmd.visualdproj
@@ -529,6 +529,7 @@
    <File path="..\traits.d" />
    <File path="..\typinf.d" />
    <File path="..\utf.d" />
+   <File path="..\utils.d" />
    <File path="..\visitor.d" />
    <File path="..\win32.mak" />
   </Folder>

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -151,7 +151,7 @@ FRONT_SRCS=access.d aggregate.d aliasthis.d apply.d argtypes.d arrayop.d	\
 	impcnvtab.d init.d inline.d intrange.d json.d lexer.d lib.d link.d	\
 	mars.d mtype.d nogc.d nspace.d objc_stubs.d opover.d optimize.d parse.d	\
 	sapply.d sideeffect.d statement.d staticassert.d target.d tokens.d	\
-	traits.d utf.d visitor.d libomf.d scanomf.d typinf.d \
+	traits.d utf.d utils.d visitor.d libomf.d scanomf.d typinf.d \
 	libmscoff.d scanmscoff.d
 
 GLUE_SRCS=irstate.d toctype.d backend.d gluelayer.d todt.d


### PR DESCRIPTION
Tries to address https://issues.dlang.org/show_bug.cgi?id=15374

Also ended up having to move `genCmain` too.  This may conflict, as when it came to implementing this function I chose to have it's contents kept in an external source file named `__entrypoint.di`.  This was a design decision to allow testing and adding/removing features without the need to recompile.

However stubbing out this one function is far better than stubbing out an entire module.
