### PR TITLE
[D1] backport semantic order fix for delegates

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -1097,7 +1097,6 @@ void FuncDeclaration::semantic3(Scope *sc)
                 if (!type->nextOf())
                 {
                     ((TypeFunction *)type)->next = Type::tvoid;
-                    type = type->semantic(loc, sc);
                 }
                 f = (TypeFunction *)type;
             }
@@ -1500,6 +1499,11 @@ void FuncDeclaration::semantic3(Scope *sc)
 
         sc2->callSuper = 0;
         sc2->pop();
+    }
+
+    if (inferRetType)
+    {
+        type = type->semantic(loc, sc);
     }
 
     if (global.gag && global.errors != nerrors)


### PR DESCRIPTION
Issue uncovered by recent mangling fixes. Full D2 PR this change
originates from is https://github.com/D-Programming-Language/dmd/pull/1096
but most stuff there is for pure/@safe and thus not applicable to
D2.
