### PR TITLE
Add a stack variable's align() to the AST

### DIFF
--- a/src/parse.d
+++ b/src/parse.d
@@ -4181,6 +4181,12 @@ public:
                     auto tempdecl = new TemplateDeclaration(loc, ident, tpl, null, a2, 0);
                     s = tempdecl;
                 }
+                if (structalign != 0)
+                {
+                    auto ax = new Dsymbols();
+                    ax.push(s);
+                    s = new AlignDeclaration(structalign, ax);
+                }
                 if (link != linkage)
                 {
                     auto ax = new Dsymbols();


### PR DESCRIPTION
This PR is to support code such as:

``` D
void f() {
    align(16) int a; // <---- this alignment is now stored in the AST
}
```

The align(16) is parsed at line 3961, however it is never applied to the Dsymbol for stack variables (line 4022 and onwards). It is simply ignored, but it should be stored in the AST for the backend to use (DMD backend does not use it yet).
I am not at all familiar with the parser code, thanks for the kind review.

The bug was found in LDC's C-version of DMD, see https://github.com/ldc-developers/ldc/pull/1214. With the changes of this PR, LDC is able to apply `align()` to stack variables correctly.
