### PR TITLE
New __traits: isModule and isPackage

### DIFF
--- a/changelog/fix16002.dd
+++ b/changelog/fix16002.dd
@@ -1,0 +1,7 @@
+fix Issue 16002 - Add `is(sym == module)` and `is(sym == package)`
+
+This enhancement adds two new forms of the `is()`, expression, which
+determine whether a given symbol represents a module or package.
+
+It also adds `__traits(isModule, sym)` and `__traits(isPackage, sym)`, which
+do the same thing.

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -202,7 +202,7 @@ struct Param
     uint errorLimit = 20;
 
     const(char)[] argv0;                // program name
-    Array!(const(char)*)* modFileAliasStrings; // array of char*'s of -I module filename alias strings
+    Array!(const(char)*) modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array!(const(char)*)* imppath;      // array of char*'s of where to look for import modules
     Array!(const(char)*)* fileImppath;  // array of char*'s of where to look for file import modules
     const(char)* objdir;                // .obj/.lib file output directory

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -178,7 +178,7 @@ struct Param
     unsigned errorLimit;
 
     DArray<const char>  argv0;    // program name
-    Array<const char *> *modFileAliasStrings; // array of char*'s of -I module filename alias strings
+    Array<const char *> modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array<const char *> *imppath;     // array of char*'s of where to look for import modules
     Array<const char *> *fileImppath; // array of char*'s of where to look for file import modules
     const char *objdir;   // .obj/.lib file output directory

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -393,6 +393,8 @@ immutable Msgtable[] msgtable =
     { "isFinalFunction" },
     { "isOverrideFunction" },
     { "isStaticFunction" },
+    { "isModule" },
+    { "isPackage" },
     { "isRef" },
     { "isOut" },
     { "isLazy" },

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2251,8 +2251,6 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
         {
             if (p[4] && strchr(p + 5, '='))
             {
-                if (!params.modFileAliasStrings)
-                    params.modFileAliasStrings = new Strings();
                 params.modFileAliasStrings.push(p + 4);
             }
             else

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7974,8 +7974,9 @@ final class Parser(AST) : Lexer
                         nextToken();
                         if (tok == TOK.equal && (token.value == TOK.struct_ || token.value == TOK.union_
                             || token.value == TOK.class_ || token.value == TOK.super_ || token.value == TOK.enum_
-                            || token.value == TOK.interface_ || token.value == TOK.argumentTypes
-                            || token.value == TOK.parameters || token.value == TOK.const_ && peek(&token).value == TOK.rightParentheses
+                            || token.value == TOK.interface_ || token.value == TOK.package_ || token.value == TOK.module_
+                            || token.value == TOK.argumentTypes || token.value == TOK.parameters
+                            || token.value == TOK.const_ && peek(&token).value == TOK.rightParentheses
                             || token.value == TOK.immutable_ && peek(&token).value == TOK.rightParentheses
                             || token.value == TOK.shared_ && peek(&token).value == TOK.rightParentheses
                             || token.value == TOK.inout_ && peek(&token).value == TOK.rightParentheses || token.value == TOK.function_

--- a/test/compilable/imports/pkgmodule/package.d
+++ b/test/compilable/imports/pkgmodule/package.d
@@ -1,0 +1,3 @@
+/// Used to test is(x == package) and is(x == module)
+
+module imports.pkgmodule;

--- a/test/compilable/imports/pkgmodule/plainmodule.d
+++ b/test/compilable/imports/pkgmodule/plainmodule.d
@@ -1,0 +1,2 @@
+/// Used to test is(x == module)
+module imports.pkgmodule.plainmodule;

--- a/test/compilable/imports/plainpackage/plainmodule.d
+++ b/test/compilable/imports/plainpackage/plainmodule.d
@@ -1,0 +1,4 @@
+/// Used to test is(x == module)
+
+module imports.plainpackage.plainmodule;
+

--- a/test/compilable/test16002.d
+++ b/test/compilable/test16002.d
@@ -1,0 +1,24 @@
+module test.compilable.test16002;
+
+import imports.plainpackage.plainmodule;
+import imports.pkgmodule.plainmodule;
+
+struct MyStruct;
+
+alias a = imports.plainpackage;
+alias b = imports.pkgmodule.plainmodule;
+
+static assert(is(imports.plainpackage == package));
+static assert(is(a == package));
+static assert(!is(imports.plainpackage.plainmodule == package));
+static assert(!is(b == package));
+static assert(is(imports.pkgmodule == package));
+static assert(!is(MyStruct == package));
+
+static assert(!is(imports.plainpackage == module));
+static assert(!is(a == module));
+static assert(is(imports.plainpackage.plainmodule == module));
+static assert(is(b == module));
+// This is supposed to work even though we haven't directly imported imports.pkgmodule.
+static assert(is(imports.pkgmodule == module));
+static assert(!is(MyStruct == module));

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -31,3 +31,26 @@ version (linux)
     static assert(__traits(getTargetInfo, "objectFormat") == "elf");
 
 static assert(__traits(getTargetInfo, "cppStd") == 199711);
+
+import imports.plainpackage.plainmodule;
+import imports.pkgmodule.plainmodule;
+
+struct MyStruct;
+
+alias a = imports.plainpackage;
+alias b = imports.pkgmodule.plainmodule;
+
+static assert(__traits(isPackage, imports.plainpackage));
+static assert(__traits(isPackage, a));
+static assert(!__traits(isPackage, imports.plainpackage.plainmodule));
+static assert(!__traits(isPackage, b));
+static assert(__traits(isPackage, imports.pkgmodule));
+static assert(!__traits(isPackage, MyStruct));
+
+static assert(!__traits(isModule, imports.plainpackage));
+static assert(!__traits(isModule, a));
+static assert(__traits(isModule, imports.plainpackage.plainmodule));
+static assert(__traits(isModule, b));
+// This is supposed to work even though we haven't directly imported imports.pkgmodule.
+static assert(__traits(isModule, imports.pkgmodule));
+static assert(!__traits(isModule, MyStruct));

--- a/test/fail_compilation/test16002.d
+++ b/test/fail_compilation/test16002.d
@@ -1,0 +1,15 @@
+/*
+REQUIRED_ARGS:
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/test16002.d(100): Error: undefined identifier `imports.nonexistent`
+fail_compilation/test16002.d(101): Error: undefined identifier `imports.nonexistent`
+---
+*/
+
+module test.fail_compilation.test16002;
+
+#line 100
+enum A = is(imports.nonexistent == package);
+enum B = is(imports.nonexistent == module);

--- a/test/fail_compilation/traits.d
+++ b/test/fail_compilation/traits.d
@@ -12,11 +12,21 @@ fail_compilation/traits.d(100): Error: `getTargetInfo` key `"not_a_target_info"`
 fail_compilation/traits.d(101): Error: string expected as argument of __traits `getTargetInfo` instead of `100`
 fail_compilation/traits.d(102): Error: expected 1 arguments for `getTargetInfo` but had 2
 fail_compilation/traits.d(103): Error: expected 1 arguments for `getTargetInfo` but had 0
+fail_compilation/traits.d(200): Error: undefined identifier `imports.nonexistent`
+fail_compilation/traits.d(201): Error: undefined identifier `imports.nonexistent`
+fail_compilation/traits.d(202): Error: expected 1 arguments for `isPackage` but had 0
+fail_compilation/traits.d(203): Error: expected 1 arguments for `isModule` but had 0
 ---
 */
 
 #line 100
-enum A = __traits(getTargetInfo, "not_a_target_info");
-enum B = __traits(getTargetInfo, 100);
-enum C = __traits(getTargetInfo, "cppRuntimeLibrary", "bits");
-enum D = __traits(getTargetInfo);
+enum A1 = __traits(getTargetInfo, "not_a_target_info");
+enum B1 = __traits(getTargetInfo, 100);
+enum C1 = __traits(getTargetInfo, "cppRuntimeLibrary", "bits");
+enum D1 = __traits(getTargetInfo);
+
+#line 200
+enum A2 = __traits(isPackage, imports.nonexistent);
+enum B2 = __traits(isModule, imports.nonexistent);
+enum C2 = __traits(isPackage);
+enum D2 = __traits(isModule);


### PR DESCRIPTION
This pull request would add two new __traits: isModule and isPackage, which (unsurprisingly) allow one to determine whether a symbol represents a module and/or a package. These traits can be quite useful for introspection under certain circumstances, especially some types of code generation (i.e. bindings).

Spec change: https://github.com/dlang/dlang.org/pull/2199
