### PR TITLE
Properly fix Issue 15296 - expand CallExp in ExpStatement as statements

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -2087,19 +2087,23 @@ public:
                     Statement s = new ReturnStatement(Loc(), new IntegerExp(0));
                     a.push(s);
                 }
+
                 Statement sbody = new CompoundStatement(Loc(), a);
+
                 /* Append destructor calls for parameters as finally blocks.
                  */
                 if (parameters)
                 {
-                    for (size_t i = 0; i < parameters.dim; i++)
+                    foreach (v; *parameters)
                     {
-                        VarDeclaration v = (*parameters)[i];
                         if (v.storage_class & (STCref | STCout | STClazy))
                             continue;
                         if (v.needsScopeDtor())
                         {
-                            Statement s = new ExpStatement(Loc(), v.edtor);
+                            // same with ExpStatement.scopeCode()
+                            Statement s = new DtorExpStatement(Loc(), v.edtor, v);
+                            v.noscope = true;
+
                             s = s.semantic(sc2);
 
                             uint nothrowErrors = global.errors;
@@ -2119,6 +2123,7 @@ public:
                 }
                 // from this point on all possible 'throwers' are checked
                 flags &= ~FUNCFLAGnothrowInprocess;
+
                 if (isSynchronized())
                 {
                     /* Wrap the entire function body in a synchronized statement

--- a/src/statement.d
+++ b/src/statement.d
@@ -3372,7 +3372,7 @@ public:
 
             if (match.edtor)
             {
-                Statement sdtor = new ExpStatement(loc, match.edtor);
+                Statement sdtor = new DtorExpStatement(loc, match.edtor, match);
                 sdtor = new OnScopeStatement(loc, TOKon_scope_exit, sdtor);
                 ifbody = new CompoundStatement(loc, sdtor, ifbody);
                 match.noscope = true;

--- a/src/toir.c
+++ b/src/toir.c
@@ -754,7 +754,10 @@ void buildClosure(FuncDeclaration *fd, IRState *irs)
             VarDeclaration *v = fd->closureVars[i];
             //printf("closure var %s\n", v->toChars());
 
-            if (v->needsScopeDtor())
+            // Hack for the case fail_compilation/fail10666.d,
+            // until proper issue 5730 fix will come.
+            bool isScopeDtorParam = v->edtor && (v->storage_class & STCparameter);
+            if (v->needsScopeDtor() || isScopeDtorParam)
             {
                 /* Because the value needs to survive the end of the scope!
                  */

--- a/test/fail_compilation/pragmainline2.d
+++ b/test/fail_compilation/pragmainline2.d
@@ -16,15 +16,15 @@ void foo()
     pragma(inline, false);
     pragma(inline);
     pragma(inline, true);   // this last one will affect to the 'foo'
-    while (0) { }
+    asm { nop; }
 }
 
-pragma(inline, true)   void f1t() { while (0) {} }  // cannot inline
-pragma(inline, false)  void f1f() { while (0) {} }
-pragma(inline)         void f1d() { while (0) {} }
-void f2t() { pragma(inline, true);  while (0) {} }  // cannot inline
-void f2f() { pragma(inline, false); while (0) {} }
-void f2d() { pragma(inline);        while (0) {} }
+pragma(inline, true)   void f1t() { asm { nop; } }  // cannot inline
+pragma(inline, false)  void f1f() { asm { nop; } }
+pragma(inline)         void f1d() { asm { nop; } }
+void f2t() { pragma(inline, true);  asm { nop; } }  // cannot inline
+void f2f() { pragma(inline, false); asm { nop; } }
+void f2d() { pragma(inline);        asm { nop; } }
 
 void main()
 {


### PR DESCRIPTION
In #5277, I added workaround for issue 15296 case. This PR improves inlining and will be a proper fix for the issue.

The last commit is the core of this change. Others are preparation or helper changes.

---

If a `CallExp`, `CondExp`, or `CommaExp` appears in `ExpStatement`, it can be inlined as statements.
It provides more inlining opportunity. Even if the called function contains some statements which cannot be expanded as expressions (e.g. `ForStatement`), the function call can be inlined.

In `expandInline`, if `vthis` is a temporary variable, its dtor call should be deferred till the end of expanded function body statements.
