### PR TITLE
Issue 15384 - assignment is sometimes still accepted as a condition

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -11035,6 +11035,15 @@ public:
         return e2.isBool(result);
     }
 
+    override Expression toBoolean(Scope* sc)
+    {
+        auto ex2 = e2.toBoolean(sc);
+        if (ex2.op == TOKerror)
+            return ex2;
+        e2 = ex2;
+        return this;
+    }
+
     override Expression addDtorHook(Scope* sc)
     {
         e2 = e2.addDtorHook(sc);
@@ -13976,7 +13985,10 @@ public:
 
     override Expression toBoolean(Scope* sc)
     {
-        e2 = e2.toBoolean(sc);
+        auto ex2 = e2.toBoolean(sc);
+        if (ex2.op == TOKerror)
+            return ex2;
+        e2 = ex2;
         return this;
     }
 
@@ -14044,7 +14056,10 @@ public:
 
     override Expression toBoolean(Scope* sc)
     {
-        e2 = e2.toBoolean(sc);
+        auto ex2 = e2.toBoolean(sc);
+        if (ex2.op == TOKerror)
+            return ex2;
+        e2 = ex2;
         return this;
     }
 
@@ -14543,8 +14558,14 @@ public:
 
     override Expression toBoolean(Scope* sc)
     {
-        e1 = e1.toBoolean(sc);
-        e2 = e2.toBoolean(sc);
+        auto ex1 = e1.toBoolean(sc);
+        auto ex2 = e2.toBoolean(sc);
+        if (ex1.op == TOKerror)
+            return ex1;
+        if (ex2.op == TOKerror)
+            return ex2;
+        e1 = ex1;
+        e2 = ex2;
         return this;
     }
 

--- a/src/parse.d
+++ b/src/parse.d
@@ -4998,8 +4998,6 @@ public:
                     param = new Parameter(storageClass, at, ai, null);
                 }
                 condition = parseExpression();
-                if (condition.op == TOKassign)
-                    error("assignment cannot be used as a condition, perhaps == was meant?");
                 check(TOKrparen);
                 {
                     Loc lookingForElseSave = lookingForElse;

--- a/src/statement.d
+++ b/src/statement.d
@@ -81,6 +81,27 @@ extern (C++) LabelStatement checkLabeledLoop(Scope* sc, Statement statement)
     return null;
 }
 
+/***********************************************************
+ * Check an assignment is used as a condition.
+ * Intended to be use before the `semantic` call on `e`.
+ * Params:
+ *  e = condition expression which is not yet run semantic analysis.
+ * Returns:
+ *  `e` or ErrorExp.
+ */
+Expression checkAssignmentAsCondition(Expression e)
+{
+    auto ec = e;
+    while (ec.op == TOKcomma)
+        ec = (cast(CommaExp)ec).e2;
+    if (ec.op == TOKassign)
+    {
+        ec.error("assignment cannot be used as a condition, perhaps == was meant?");
+        return new ErrorExp();
+    }
+    return e;
+}
+
 enum BE : int
 {
     BEnone = 0,
@@ -1787,7 +1808,10 @@ public:
 
     override Statement syntaxCopy()
     {
-        return new WhileStatement(loc, condition.syntaxCopy(), _body ? _body.syntaxCopy() : null, endloc);
+        return new WhileStatement(loc,
+            condition.syntaxCopy(),
+            _body ? _body.syntaxCopy() : null,
+            endloc);
     }
 
     override Statement semantic(Scope* sc)
@@ -1832,7 +1856,9 @@ public:
 
     override Statement syntaxCopy()
     {
-        return new DoStatement(loc, _body ? _body.syntaxCopy() : null, condition.syntaxCopy());
+        return new DoStatement(loc,
+            _body ? _body.syntaxCopy() : null,
+            condition.syntaxCopy());
     }
 
     override Statement semantic(Scope* sc)
@@ -1841,15 +1867,22 @@ public:
         if (_body)
             _body = _body.semanticScope(sc, this, this);
         sc.noctor--;
+
+        // check in syntax level
+        condition = checkAssignmentAsCondition(condition);
+
         condition = condition.semantic(sc);
         condition = resolveProperties(sc, condition);
         condition = condition.optimize(WANTvalue);
         condition = checkGC(sc, condition);
+
         condition = condition.toBoolean(sc);
+
         if (condition.op == TOKerror)
             return new ErrorStatement();
         if (_body && _body.isErrorStatement())
             return _body;
+
         return this;
     }
 
@@ -1897,12 +1930,18 @@ public:
 
     override Statement syntaxCopy()
     {
-        return new ForStatement(loc, _init ? _init.syntaxCopy() : null, condition ? condition.syntaxCopy() : null, increment ? increment.syntaxCopy() : null, _body.syntaxCopy(), endloc);
+        return new ForStatement(loc,
+            _init ? _init.syntaxCopy() : null,
+            condition ? condition.syntaxCopy() : null,
+            increment ? increment.syntaxCopy() : null,
+            _body.syntaxCopy(),
+            endloc);
     }
 
     override Statement semantic(Scope* sc)
     {
         //printf("ForStatement::semantic %s\n", toChars());
+
         if (_init)
         {
             /* Rewrite:
@@ -1933,16 +1972,22 @@ public:
             return s;
         }
         assert(_init is null);
+
         auto sym = new ScopeDsymbol();
         sym.parent = sc.scopesym;
         sc = sc.push(sym);
+
         sc.noctor++;
         if (condition)
         {
+            // check in syntax level
+            condition = checkAssignmentAsCondition(condition);
+
             condition = condition.semantic(sc);
             condition = resolveProperties(sc, condition);
             condition = condition.optimize(WANTvalue);
             condition = checkGC(sc, condition);
+
             condition = condition.toBoolean(sc);
         }
         if (increment)
@@ -1952,14 +1997,21 @@ public:
             increment = increment.optimize(WANTvalue);
             increment = checkGC(sc, increment);
         }
+
         sc.sbreak = this;
         sc.scontinue = this;
         if (_body)
             _body = _body.semanticNoScope(sc);
         sc.noctor--;
+
         sc.pop();
-        if (condition && condition.op == TOKerror || increment && increment.op == TOKerror || _body && _body.isErrorStatement())
+
+        if (condition && condition.op == TOKerror ||
+            increment && increment.op == TOKerror ||
+            _body && _body.isErrorStatement())
+        {
             return new ErrorStatement();
+        }
         return this;
     }
 
@@ -3209,7 +3261,11 @@ public:
 
     override Statement syntaxCopy()
     {
-        return new IfStatement(loc, prm ? prm.syntaxCopy() : null, condition.syntaxCopy(), ifbody ? ifbody.syntaxCopy() : null, elsebody ? elsebody.syntaxCopy() : null);
+        return new IfStatement(loc,
+            prm ? prm.syntaxCopy() : null,
+            condition.syntaxCopy(),
+            ifbody ? ifbody.syntaxCopy() : null,
+            elsebody ? elsebody.syntaxCopy() : null);
     }
 
     override Statement semantic(Scope* sc)
@@ -3220,6 +3276,9 @@ public:
         uint* fi0 = sc.saveFieldInit();
         uint* fi1 = null;
 
+        // check in syntax level
+        condition = checkAssignmentAsCondition(condition);
+
         auto sym = new ScopeDsymbol();
         sym.parent = sc.scopesym;
         Scope* scd = sc.push(sym);
@@ -3228,7 +3287,8 @@ public:
             /* Declare prm, which we will set to be the
              * result of condition.
              */
-            match = new VarDeclaration(loc, prm.type, prm.ident, new ExpInitializer(loc, condition));
+            auto ei = new ExpInitializer(loc, condition);
+            match = new VarDeclaration(loc, prm.type, prm.ident, ei);
             match.parent = scd.func;
             match.storage_class |= prm.storageClass;
             match.semantic(scd);

--- a/test/fail_compilation/diag10862.d
+++ b/test/fail_compilation/diag10862.d
@@ -1,17 +1,89 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10862.d(13): Error: assignment cannot be used as a condition, perhaps == was meant?
-fail_compilation/diag10862.d(14): Error: assignment cannot be used as a condition, perhaps == was meant?
-fail_compilation/diag10862.d(15): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(28): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(29): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(30): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(31): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(32): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(34): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(35): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(36): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(37): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(39): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(40): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(41): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(42): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(44): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(45): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(46): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(47): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(49): Error: undefined identifier 'semanticError'
 ---
 */
-
-void main()
+void test1()
 {
     int a, b;
-    if ((a = b) = 0) { }
-    if ((a = b) = (a = b)) { }
-    if (a + b = a * b) { }
+
+    if (a = b) {}
+    if ((a = b) = 0) {}
+    if ((a = b) = (a = b)) {}
+    if (a = 0, b = 0) {}        // Bugzilla 15384
+    if (auto x = a = b) {}      // this is error, today
+
+    while (a = b) {}
+    while ((a = b) = 0) {}
+    while ((a = b) = (a = b)) {}
+    while (a = 0, b = 0) {}     // Bugzilla 15384
+
+    do {} while (a = b);
+    do {} while ((a = b) = 0);
+    do {} while ((a = b) = (a = b));
+    do {} while (a = 0, b = 0); // Bugzilla 15384
+
+    for (;  a = b; ) {}
+    for (;  (a = b) = 0; ) {}
+    for (;  (a = b) = (a = b); ) {}
+    for (;  a = 0, b = 0; ) {}  // Bugzilla 15384
+
+    semanticError;
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag10862.d(73): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(76): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d-mixin-79(79): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d-mixin-80(80): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d-mixin-81(81): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d-mixin-82(82): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d-mixin-85(85): Error: a + b is not an lvalue
+fail_compilation/diag10862.d-mixin-86(86): Error: undefined identifier 'c'
+fail_compilation/diag10862.d(88): Error: undefined identifier 'semanticError'
+---
+*/
+void test2()
+{
+    int a, b;
+
+    // (a + b) cannot be an assignment target.
+    // However checkAssignAsCondition specilatively rerites it to EqualExp,
+    // then the pointless error "is not an lvalue" would not happen.
+    if (a + b = a * b) {}
+
+    // The suggestion error masks "undefined identifier" error
+    if (a = undefinedIdentifier) {}
+
+    // If the condition is a mixin expression
+    if (mixin("a = b")) {}
+    if (mixin("(a = b) = 0")) {}
+    if (mixin("(a = b) = (a = b)")) {}
+    if (mixin("a = 0, b = 0")) {}
+    if (auto x = mixin("a = b")) {}     // Note: no error
+
+    if (mixin("a + b = a * b")) {}      // Note: "a + b is not an lvalue"
+    if (mixin("a = c")) {}
+
     semanticError;
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15384
1. Add CommaExp.toBoolean to show error message.
2. Add checkAssignmentAsCondition and call it before semantic analysis to provide informative diagnostic.
