### PR TITLE
Issue 15394 - [internal] CompileExp and FileExp has same op TOKmixin

### DIFF
--- a/src/clone.d
+++ b/src/clone.d
@@ -548,7 +548,7 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
                 case TOKoverloadset:
                     s = (cast(OverExp)e).vars;
                     break;
-                case TOKimport:
+                case TOKscope:
                     s = (cast(ScopeExp)e).sds;
                     break;
                 case TOKvar:

--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -564,7 +564,7 @@ public:
             printf("%s WithStatement::ctfeCompile\n", s.loc.toChars());
         }
         // If it is with(Enum) {...}, just execute the body.
-        if (s.exp.op == TOKimport || s.exp.op == TOKtype)
+        if (s.exp.op == TOKscope || s.exp.op == TOKtype)
         {
         }
         else
@@ -1861,7 +1861,7 @@ public:
             return;
         }
         // If it is with(Enum) {...}, just execute the body.
-        if (s.exp.op == TOKimport || s.exp.op == TOKtype)
+        if (s.exp.op == TOKscope || s.exp.op == TOKtype)
         {
             result = interpret(s._body, istate);
             return;

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1594,7 +1594,7 @@ public:
         Expression eold = null;
         for (Expression e = withstate.exp; e != eold; e = resolveAliasThis(_scope, e))
         {
-            if (e.op == TOKimport)
+            if (e.op == TOKscope)
             {
                 s = (cast(ScopeExp)e).sds;
             }

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -1890,7 +1890,7 @@ public:
         VarDeclaration v = null;
         if (ea && ea.op == TOKtype)
             ta = ea.type;
-        else if (ea && ea.op == TOKimport)
+        else if (ea && ea.op == TOKscope)
             sa = (cast(ScopeExp)ea).sds;
         else if (ea && (ea.op == TOKthis || ea.op == TOKsuper))
             sa = (cast(ThisExp)ea).var;
@@ -5175,7 +5175,7 @@ public:
         Expression ea = isExpression(oarg);
         if (ea && (ea.op == TOKthis || ea.op == TOKsuper))
             sa = (cast(ThisExp)ea).var;
-        else if (ea && ea.op == TOKimport)
+        else if (ea && ea.op == TOKscope)
             sa = (cast(ScopeExp)ea).sds;
         if (sa)
         {
@@ -6823,7 +6823,7 @@ public:
                     ta = ea.type;
                     goto Ltype;
                 }
-                if (ea.op == TOKimport)
+                if (ea.op == TOKscope)
                 {
                     sa = (cast(ScopeExp)ea).sds;
                     goto Ldsym;
@@ -7716,7 +7716,7 @@ extern (C++) void unSpeculative(Scope* sc, RootObject o)
 extern (C++) bool definitelyValueParameter(Expression e)
 {
     // None of these can be value parameters
-    if (e.op == TOKtuple || e.op == TOKimport ||
+    if (e.op == TOKtuple || e.op == TOKscope ||
         e.op == TOKtype || e.op == TOKdottype ||
         e.op == TOKtemplate || e.op == TOKdottd ||
         e.op == TOKfunction || e.op == TOKerror ||

--- a/src/expression.d
+++ b/src/expression.d
@@ -7658,7 +7658,7 @@ extern (C++) final class FileExp : UnaExp
 public:
     extern (D) this(Loc loc, Expression e)
     {
-        super(loc, TOKmixin, __traits(classInstanceSize, FileExp), e);
+        super(loc, TOKimport, __traits(classInstanceSize, FileExp), e);
     }
 
     override Expression semantic(Scope* sc)

--- a/src/expression.d
+++ b/src/expression.d
@@ -346,7 +346,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
         tthis = dte.e1.type;
         goto Lfd;
     }
-    else if (e1.op == TOKimport)
+    else if (e1.op == TOKscope)
     {
         s = (cast(ScopeExp)e1).sds;
         if (s.isTemplateDeclaration())
@@ -590,7 +590,7 @@ extern (C++) Expression resolvePropertiesOnly(Scope* sc, Expression e1)
         td = (cast(DotTemplateExp)e1).td;
         goto Ltd;
     }
-    else if (e1.op == TOKimport)
+    else if (e1.op == TOKscope)
     {
         Dsymbol s = (cast(ScopeExp)e1).sds;
         td = s.isTemplateDeclaration();
@@ -5236,7 +5236,7 @@ public:
 
     extern (D) this(Loc loc, ScopeDsymbol sds)
     {
-        super(loc, TOKimport, __traits(classInstanceSize, ScopeExp));
+        super(loc, TOKscope, __traits(classInstanceSize, ScopeExp));
         //printf("ScopeExp::ScopeExp(sds = '%s')\n", sds.toChars());
         //static int count; if (++count == 38) *(char*)0=0;
         this.sds = sds;
@@ -7871,7 +7871,7 @@ public:
             Dsymbol ds;
             switch (e1.op)
             {
-            case TOKimport:
+            case TOKscope:
                 ds = (cast(ScopeExp)e1).sds;
                 goto L1;
             case TOKvar:
@@ -8003,7 +8003,7 @@ public:
             eright = e1;
         }
         Type t1b = e1.type.toBasetype();
-        if (eright.op == TOKimport) // also used for template alias's
+        if (eright.op == TOKscope) // also used for template alias's
         {
             ScopeExp ie = cast(ScopeExp)eright;
             /* Disable access to another module's private imports.
@@ -8458,7 +8458,7 @@ public:
         case TOKdottd:
             s = (cast(DotTemplateExp)e).td;
             break;
-        case TOKimport:
+        case TOKscope:
             s = (cast(ScopeExp)e).sds;
             break;
         case TOKdotvar:
@@ -8611,7 +8611,7 @@ public:
             e = e.semantic(sc);
             return e;
         }
-        else if (e.op == TOKimport)
+        else if (e.op == TOKscope)
         {
             ScopeExp se = cast(ScopeExp)e;
             TemplateDeclaration td = se.sds.isTemplateDeclaration();
@@ -8655,7 +8655,7 @@ public:
                 e = e.semantic(sc);
                 return e;
             }
-            if (de.e2.op == TOKimport)
+            if (de.e2.op == TOKscope)
             {
                 // This should *really* be moved to ScopeExp::semantic()
                 ScopeExp se = cast(ScopeExp)de.e2;
@@ -8895,7 +8895,7 @@ public:
         /* This recognizes:
          *  foo!(tiargs)(funcargs)
          */
-        if (e1.op == TOKimport)
+        if (e1.op == TOKscope)
         {
             ScopeExp se = cast(ScopeExp)e1;
             TemplateInstance ti = se.sds.isTemplateInstance();
@@ -9032,7 +9032,7 @@ public:
                 if (v && ve.checkPurity(sc, v))
                     return new ErrorExp();
             }
-            if (e1.op == TOKimport)
+            if (e1.op == TOKscope)
             {
                 // Perhaps this should be moved to ScopeExp::semantic()
                 ScopeExp se = cast(ScopeExp)e1;
@@ -9053,7 +9053,7 @@ public:
                     tthis = de.e1.type;
                     e1 = de.e2;
                 }
-                if (de.e2.op == TOKimport)
+                if (de.e2.op == TOKscope)
                 {
                     // This should *really* be moved to ScopeExp::semantic()
                     ScopeExp se = cast(ScopeExp)de.e2;
@@ -9735,7 +9735,7 @@ public:
                 }
             }
         }
-        else if (e1.op == TOKimport)
+        else if (e1.op == TOKscope)
         {
             TemplateInstance ti = (cast(ScopeExp)e1).sds.isTemplateInstance();
             if (ti)
@@ -10963,7 +10963,7 @@ public:
         }
         e1 = e1.semantic(sc);
         e2 = e2.semantic(sc);
-        if (e2.op == TOKimport)
+        if (e2.op == TOKscope)
         {
             ScopeExp se = cast(ScopeExp)e2;
             TemplateDeclaration td = se.sds.isTemplateDeclaration();
@@ -13961,7 +13961,7 @@ public:
             e2 = e2.toBoolean(sc);
             type = Type.tbool;
         }
-        if (e2.op == TOKtype || e2.op == TOKimport)
+        if (e2.op == TOKtype || e2.op == TOKscope)
         {
             error("%s is not an expression", e2.toChars());
             return new ErrorExp();
@@ -14029,7 +14029,7 @@ public:
             e2 = e2.toBoolean(sc);
             type = Type.tbool;
         }
-        if (e2.op == TOKtype || e2.op == TOKimport)
+        if (e2.op == TOKtype || e2.op == TOKscope)
         {
             error("%s is not an expression", e2.toChars());
             return new ErrorExp();

--- a/src/init.d
+++ b/src/init.d
@@ -774,7 +774,7 @@ public:
         //printf("ExpInitializer::inferType() %s\n", toChars());
         exp = exp.semantic(sc);
         exp = resolveProperties(sc, exp);
-        if (exp.op == TOKimport)
+        if (exp.op == TOKscope)
         {
             ScopeExp se = cast(ScopeExp)exp;
             TemplateInstance ti = se.sds.isTemplateInstance();

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2724,7 +2724,7 @@ public:
                 s = (cast(TemplateExp)e).td;
                 break;
 
-            case TOKimport:
+            case TOKscope:
                 s = (cast(ScopeExp)e).sds;
                 // TemplateDeclaration, TemplateInstance, Import, Package, Module
                 break;
@@ -7531,7 +7531,7 @@ public:
             error(loc, "argument %s to typeof is not an expression", exp.toChars());
             goto Lerr;
         }
-        if (exp.op == TOKimport)
+        if (exp.op == TOKscope)
         {
             ScopeDsymbol sds = (cast(ScopeExp)exp).sds;
             if (sds.isPackage())
@@ -7833,7 +7833,7 @@ public:
         if (e.op == TOKdotexp)
         {
             DotExp de = cast(DotExp)e;
-            if (de.e1.op == TOKimport)
+            if (de.e1.op == TOKscope)
             {
                 assert(0); // cannot find a case where this happens; leave
                 // assert in until we do
@@ -8543,7 +8543,7 @@ public:
         if (e.op == TOKdotexp)
         {
             DotExp de = cast(DotExp)e;
-            if (de.e1.op == TOKimport)
+            if (de.e1.op == TOKscope)
             {
                 ScopeExp se = cast(ScopeExp)de.e1;
                 s = se.sds.search(e.loc, ident);

--- a/src/parse.d
+++ b/src/parse.d
@@ -70,7 +70,7 @@ __gshared PREC[TOKMAX] precedence =
     TOKtypeof : PREC_primary,
     TOKmixin : PREC_primary,
     TOKdotvar : PREC_primary,
-    TOKimport : PREC_primary,
+    TOKscope : PREC_primary,
     TOKidentifier : PREC_primary,
     TOKthis : PREC_primary,
     TOKsuper : PREC_primary,

--- a/src/parse.d
+++ b/src/parse.d
@@ -69,6 +69,7 @@ __gshared PREC[TOKMAX] precedence =
     TOKerror : PREC_expr,
     TOKtypeof : PREC_primary,
     TOKmixin : PREC_primary,
+    TOKimport : PREC_primary,
     TOKdotvar : PREC_primary,
     TOKscope : PREC_primary,
     TOKidentifier : PREC_primary,

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -935,7 +935,7 @@ public:
         Blockx *blx = irs->blx;
 
         //printf("WithStatement::toIR()\n");
-        if (s->exp->op == TOKimport || s->exp->op == TOKtype)
+        if (s->exp->op == TOKscope || s->exp->op == TOKtype)
         {
         }
         else

--- a/src/sideeffect.d
+++ b/src/sideeffect.d
@@ -271,7 +271,7 @@ extern (C++) void discardValue(Expression e)
             }
         }
         return;
-    case TOKimport:
+    case TOKscope:
         e.error("%s has no effect", e.toChars());
         return;
     case TOKandand:

--- a/src/statement.d
+++ b/src/statement.d
@@ -2193,7 +2193,7 @@ public:
                         ds = (cast(VarExp)e).var;
                     else if (e.op == TOKtemplate)
                         ds = (cast(TemplateExp)e).td;
-                    else if (e.op == TOKimport)
+                    else if (e.op == TOKscope)
                         ds = (cast(ScopeExp)e).sds;
                     else if (e.op == TOKfunction)
                     {
@@ -4840,7 +4840,7 @@ public:
         exp = checkGC(sc, exp);
         if (exp.op == TOKerror)
             return new ErrorStatement();
-        if (exp.op == TOKimport)
+        if (exp.op == TOKscope)
         {
             sym = new WithScopeSymbol(this);
             sym.parent = sc.scopesym;

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -274,6 +274,7 @@ enum TOK : int
     TOKargTypes,
     TOKref,
     TOKmacro,
+
     TOKparameters,
     TOKtraits,
     TOKoverloadset,
@@ -292,9 +293,11 @@ enum TOK : int
     TOKgoesto,
     TOKvector,
     TOKpound,
+
     TOKinterval,
     TOKvoidexp,
     TOKcantexp,
+
     TOKMAX,
 }
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15394

<del>Add a new token `TOKmixinfile`.</del>


Use `TOKscope` for ScopeExp, then use `TOKimport` for FileExp.
