### PR TITLE
Issue 15403 - [internal] FileExp represents ImportExpression, the AST class naming is not intuitive

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -7653,19 +7653,19 @@ public:
 
 /***********************************************************
  */
-extern (C++) final class FileExp : UnaExp
+extern (C++) final class ImportExp : UnaExp
 {
 public:
     extern (D) this(Loc loc, Expression e)
     {
-        super(loc, TOKimport, __traits(classInstanceSize, FileExp), e);
+        super(loc, TOKimport, __traits(classInstanceSize, ImportExp), e);
     }
 
     override Expression semantic(Scope* sc)
     {
         static if (LOGSEMANTIC)
         {
-            printf("FileExp::semantic('%s')\n", toChars());
+            printf("ImportExp::semantic('%s')\n", toChars());
         }
         const(char)* name;
         char* namez;

--- a/src/expression.h
+++ b/src/expression.h
@@ -799,10 +799,10 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-class FileExp : public UnaExp
+class ImportExp : public UnaExp
 {
 public:
-    FileExp(Loc loc, Expression *e);
+    ImportExp(Loc loc, Expression *e);
     Expression *semantic(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -2540,7 +2540,7 @@ public:
         buf.writeByte(')');
     }
 
-    override void visit(FileExp e)
+    override void visit(ImportExp e)
     {
         buf.writestring("import(");
         expToBuffer(e.e1, PREC_assign);

--- a/src/parse.d
+++ b/src/parse.d
@@ -6924,7 +6924,7 @@ public:
                 check(TOKlparen, "import");
                 e = parseAssignExp();
                 check(TOKrparen);
-                e = new FileExp(loc, e);
+                e = new ImportExp(loc, e);
                 break;
             }
         case TOKnew:

--- a/src/visitor.d
+++ b/src/visitor.d
@@ -933,7 +933,7 @@ public:
         visit(cast(UnaExp)e);
     }
 
-    void visit(FileExp e)
+    void visit(ImportExp e)
     {
         visit(cast(UnaExp)e);
     }

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -204,7 +204,7 @@ class UnaExp;
 class BinExp;
 class BinAssignExp;
 class CompileExp;
-class FileExp;
+class ImportExp;
 class AssertExp;
 class DotIdExp;
 class DotTemplateExp;
@@ -490,7 +490,7 @@ public:
     virtual void visit(BinExp *e) { visit((Expression *)e); }
     virtual void visit(BinAssignExp *e) { visit((BinExp *)e); }
     virtual void visit(CompileExp *e) { visit((UnaExp *)e); }
-    virtual void visit(FileExp *e) { visit((UnaExp *)e); }
+    virtual void visit(ImportExp *e) { visit((UnaExp *)e); }
     virtual void visit(AssertExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotIdExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotTemplateExp *e) { visit((UnaExp *)e); }


### PR DESCRIPTION
Rename `FileExp` to `ImportExp`.
