### PR TITLE
Issue 15404 - [internal] DotIdExp(TOKdot) and DotExp(TOKdotexp)

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -708,7 +708,7 @@ extern (C++) Expression resolveUFCS(Scope* sc, CallExp ce)
     Loc loc = ce.loc;
     Expression eleft;
     Expression e;
-    if (ce.e1.op == TOKdot)
+    if (ce.e1.op == TOKdotid)
     {
         DotIdExp die = cast(DotIdExp)ce.e1;
         Identifier ident = die.ident;
@@ -804,7 +804,7 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
     Loc loc = e1.loc;
     Expression eleft;
     Expression e;
-    if (e1.op == TOKdot)
+    if (e1.op == TOKdotid)
     {
         DotIdExp die = cast(DotIdExp)e1;
         eleft = die.e1;
@@ -7821,7 +7821,7 @@ public:
 
     extern (D) this(Loc loc, Expression e, Identifier ident)
     {
-        super(loc, TOKdot, __traits(classInstanceSize, DotIdExp), e);
+        super(loc, TOKdotid, __traits(classInstanceSize, DotIdExp), e);
         this.ident = ident;
     }
 
@@ -8986,7 +8986,7 @@ public:
         }
         else
         {
-            if (e1.op == TOKdot)
+            if (e1.op == TOKdotid)
             {
                 DotIdExp die = cast(DotIdExp)e1;
                 e1 = die.semantic(sc);
@@ -11737,7 +11737,7 @@ public:
                     return resolveUFCSProperties(sc, e1x, e2);
                 e1x = e;
             }
-            else if (e1x.op == TOKdot)
+            else if (e1x.op == TOKdotid)
             {
                 DotIdExp die = cast(DotIdExp)e1x;
                 Expression e = die.semanticY(sc, 1);

--- a/src/expression.d
+++ b/src/expression.d
@@ -253,7 +253,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
     Dsymbol s;
     Objects* tiargs;
     Type tthis;
-    if (e1.op == TOKdotexp)
+    if (e1.op == TOKdot)
     {
         DotExp de = cast(DotExp)e1;
         if (de.e2.op == TOKoverloadset)
@@ -474,7 +474,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
                 }
             }
         }
-        else if (e1.op == TOKdotexp)
+        else if (e1.op == TOKdot)
         {
             e1.error("expression has no value");
             return new ErrorExp();
@@ -546,7 +546,7 @@ extern (C++) Expression resolvePropertiesOnly(Scope* sc, Expression e1)
     OverloadSet os;
     FuncDeclaration fd;
     TemplateDeclaration td;
-    if (e1.op == TOKdotexp)
+    if (e1.op == TOKdot)
     {
         DotExp de = cast(DotExp)e1;
         if (de.e2.op == TOKoverloadset)
@@ -7913,7 +7913,7 @@ public:
             // bypass checkPurity
             return e1.type.dotExp(sc, e1, ident, 0);
         }
-        if (e1.op == TOKdotexp)
+        if (e1.op == TOKdot)
         {
         }
         else
@@ -7991,7 +7991,7 @@ public:
             return e;
         Expression eleft;
         Expression eright;
-        if (e1.op == TOKdotexp)
+        if (e1.op == TOKdot)
         {
             DotExp de = cast(DotExp)e1;
             eleft = de.e1;
@@ -8447,7 +8447,7 @@ public:
             return true;
         Expression e = new DotIdExp(loc, e1, ti.name);
         e = e.semantic(sc);
-        if (e.op == TOKdotexp)
+        if (e.op == TOKdot)
             e = (cast(DotExp)e).e2;
         Dsymbol s = null;
         switch (e.op)
@@ -8625,7 +8625,7 @@ public:
             e = e.semantic(sc);
             return e;
         }
-        else if (e.op == TOKdotexp)
+        else if (e.op == TOKdot)
         {
             DotExp de = cast(DotExp)e;
             e1 = de.e1; // pull semantic() result
@@ -9044,7 +9044,7 @@ public:
                 e1 = new VarExp(se.loc, se.var, 1);
                 e1 = e1.semantic(sc);
             }
-            else if (e1.op == TOKdotexp)
+            else if (e1.op == TOKdot)
             {
                 DotExp de = cast(DotExp)e1;
                 if (de.e2.op == TOKoverloadset)
@@ -10950,7 +10950,7 @@ extern (C++) final class DotExp : BinExp
 public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
-        super(loc, TOKdotexp, __traits(classInstanceSize, DotExp), e1, e2);
+        super(loc, TOKdot, __traits(classInstanceSize, DotExp), e1, e2);
     }
 
     override Expression semantic(Scope* sc)

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -616,7 +616,14 @@ public:
         while (t)
         {
             buf.writestring(t.toChars());
-            if (t.next && t.value != TOKmin && t.value != TOKcomma && t.next.value != TOKcomma && t.value != TOKlbracket && t.next.value != TOKlbracket && t.next.value != TOKrbracket && t.value != TOKlparen && t.next.value != TOKlparen && t.next.value != TOKrparen && t.value != TOKdot && t.next.value != TOKdot)
+            if (t.next &&
+                t.value != TOKmin      &&
+                t.value != TOKcomma    && t.next.value != TOKcomma    &&
+                t.value != TOKlbracket && t.next.value != TOKlbracket &&
+                                          t.next.value != TOKrbracket &&
+                t.value != TOKlparen   && t.next.value != TOKlparen   &&
+                                          t.next.value != TOKrparen   &&
+                t.value != TOKdot      && t.next.value != TOKdot)
             {
                 buf.writeByte(' ');
             }

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7830,7 +7830,7 @@ public:
             sc2.pop();
             return e;
         }
-        if (e.op == TOKdotexp)
+        if (e.op == TOKdot)
         {
             DotExp de = cast(DotExp)e;
             if (de.e1.op == TOKscope)
@@ -8540,7 +8540,7 @@ public:
         {
             printf("TypeClass::dotExp(e='%s', ident='%s')\n", e.toChars(), ident.toChars());
         }
-        if (e.op == TOKdotexp)
+        if (e.op == TOKdot)
         {
             DotExp de = cast(DotExp)e;
             if (de.e1.op == TOKscope)

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2744,7 +2744,7 @@ public:
             //case TOKdottd:
             //case TOKdotti:
             //case TOKdottype:
-            //case TOKdot:
+            //case TOKdotid:
 
             default:
                 *pe = e;

--- a/src/parse.d
+++ b/src/parse.d
@@ -109,7 +109,7 @@ __gshared PREC[TOKMAX] precedence =
     TOKvoid : PREC_primary,
     // post
     TOKdotti : PREC_primary,
-    TOKdot : PREC_primary,
+    TOKdotid : PREC_primary,
     TOKdottd : PREC_primary,
     TOKdotexp : PREC_primary,
     TOKdottype : PREC_primary,

--- a/src/parse.d
+++ b/src/parse.d
@@ -111,7 +111,7 @@ __gshared PREC[TOKMAX] precedence =
     TOKdotti : PREC_primary,
     TOKdotid : PREC_primary,
     TOKdottd : PREC_primary,
-    TOKdotexp : PREC_primary,
+    TOKdot : PREC_primary,
     TOKdottype : PREC_primary,
     TOKplusplus : PREC_primary,
     TOKminusminus : PREC_primary,

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -53,7 +53,6 @@ enum TOK : int
     TOKdotvar,
     TOKdotid,
     TOKdotti,
-    TOKdotexp,
     TOKdottype,
     TOKslice,
     TOKarraylength,
@@ -79,7 +78,7 @@ enum TOK : int
     TOKdelegateptr,
     TOKdelegatefuncptr,
 
-    // 55
+    // 54
     // Operators
     TOKlt,
     TOKgt,
@@ -93,7 +92,7 @@ enum TOK : int
     TOKis,
     TOKtobool,
 
-    // 66
+    // 65
     // NCEG floating point compares
     // !<>=     <>    <>=    !>     !>=   !<     !<=   !<>
     TOKunord,
@@ -105,7 +104,7 @@ enum TOK : int
     TOKug,
     TOKue,
 
-    // 74
+    // 73
     TOKshl,
     TOKshr,
     TOKshlass,
@@ -146,7 +145,7 @@ enum TOK : int
     TOKpreplusplus,
     TOKpreminusminus,
 
-    // 113
+    // 112
     // Numeric literals
     TOKint32v,
     TOKuns32v,
@@ -202,7 +201,7 @@ enum TOK : int
     TOKdchar,
     TOKbool,
 
-    // 160
+    // 159
     // Aggregates
     TOKstruct,
     TOKclass,
@@ -332,7 +331,6 @@ alias TOKvar = TOK.TOKvar;
 alias TOKdotvar = TOK.TOKdotvar;
 alias TOKdotid = TOK.TOKdotid;
 alias TOKdotti = TOK.TOKdotti;
-alias TOKdotexp = TOK.TOKdotexp;
 alias TOKdottype = TOK.TOKdottype;
 alias TOKslice = TOK.TOKslice;
 alias TOKarraylength = TOK.TOKarraylength;
@@ -686,7 +684,6 @@ extern (C++) struct Token
         Token.tochars[TOKdottd] = "dottd";
         Token.tochars[TOKdotti] = "dotti";
         Token.tochars[TOKdotvar] = "dotvar";
-        Token.tochars[TOKdotexp] = "dotexp";
         Token.tochars[TOKdottype] = "dottype";
         Token.tochars[TOKsymoff] = "symoff";
         Token.tochars[TOKarraylength] = "arraylength";

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -51,6 +51,7 @@ enum TOK : int
     TOKsymoff,
     TOKvar,
     TOKdotvar,
+    TOKdotid,
     TOKdotti,
     TOKdotexp,
     TOKdottype,
@@ -78,7 +79,7 @@ enum TOK : int
     TOKdelegateptr,
     TOKdelegatefuncptr,
 
-    // 54
+    // 55
     // Operators
     TOKlt,
     TOKgt,
@@ -92,7 +93,7 @@ enum TOK : int
     TOKis,
     TOKtobool,
 
-    // 65
+    // 66
     // NCEG floating point compares
     // !<>=     <>    <>=    !>     !>=   !<     !<=   !<>
     TOKunord,
@@ -104,7 +105,7 @@ enum TOK : int
     TOKug,
     TOKue,
 
-    // 73
+    // 74
     TOKshl,
     TOKshr,
     TOKshlass,
@@ -145,7 +146,7 @@ enum TOK : int
     TOKpreplusplus,
     TOKpreminusminus,
 
-    // 112
+    // 113
     // Numeric literals
     TOKint32v,
     TOKuns32v,
@@ -201,7 +202,7 @@ enum TOK : int
     TOKdchar,
     TOKbool,
 
-    // 159
+    // 160
     // Aggregates
     TOKstruct,
     TOKclass,
@@ -329,6 +330,7 @@ alias TOKstar = TOK.TOKstar;
 alias TOKsymoff = TOK.TOKsymoff;
 alias TOKvar = TOK.TOKvar;
 alias TOKdotvar = TOK.TOKdotvar;
+alias TOKdotid = TOK.TOKdotid;
 alias TOKdotti = TOK.TOKdotti;
 alias TOKdotexp = TOK.TOKdotexp;
 alias TOKdottype = TOK.TOKdottype;
@@ -677,11 +679,14 @@ extern (C++) struct Token
         Token.tochars[TOKpowass] = "^^=";
         Token.tochars[TOKgoesto] = "=>";
         Token.tochars[TOKpound] = "#";
+
         // For debugging
         Token.tochars[TOKerror] = "error";
-        Token.tochars[TOKdotexp] = "dotexp";
+        Token.tochars[TOKdotid] = "dotid";
+        Token.tochars[TOKdottd] = "dottd";
         Token.tochars[TOKdotti] = "dotti";
         Token.tochars[TOKdotvar] = "dotvar";
+        Token.tochars[TOKdotexp] = "dotexp";
         Token.tochars[TOKdottype] = "dottype";
         Token.tochars[TOKsymoff] = "symoff";
         Token.tochars[TOKarraylength] = "arraylength";
@@ -692,7 +697,6 @@ extern (C++) struct Token
         Token.tochars[TOKdsymbol] = "symbol";
         Token.tochars[TOKtuple] = "tuple";
         Token.tochars[TOKdeclaration] = "declaration";
-        Token.tochars[TOKdottd] = "dottd";
         Token.tochars[TOKon_scope_exit] = "scope(exit)";
         Token.tochars[TOKon_scope_success] = "scope(success)";
         Token.tochars[TOKon_scope_failure] = "scope(failure)";

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -56,7 +56,7 @@ enum TOK
         TOKnew,         TOKdelete,
         TOKstar,        TOKsymoff,
         TOKvar,         TOKdotvar,
-        TOKdotti,       TOKdotexp,
+        TOKdotid,       TOKdotti,       TOKdotexp,
         TOKdottype,     TOKslice,
         TOKarraylength, TOKversion,
         TOKmodule,      TOKdollar,
@@ -73,7 +73,7 @@ enum TOK
         TOKdelegateptr,
         TOKdelegatefuncptr,
 
-// 54
+// 55
         // Operators
         TOKlt,          TOKgt,
         TOKle,          TOKge,
@@ -82,12 +82,12 @@ enum TOK
         TOKindex,       TOKis,
         TOKtobool,
 
-// 65
+// 66
         // NCEG floating point compares
         // !<>=     <>    <>=    !>     !>=   !<     !<=   !<>
         TOKunord,TOKlg,TOKleg,TOKule,TOKul,TOKuge,TOKug,TOKue,
 
-// 73
+// 74
         TOKshl,         TOKshr,
         TOKshlass,      TOKshrass,
         TOKushr,        TOKushrass,
@@ -103,7 +103,7 @@ enum TOK
         TOKquestion,    TOKandand,      TOKoror,
         TOKpreplusplus, TOKpreminusminus,
 
-// 112
+// 113
         // Numeric literals
         TOKint32v, TOKuns32v,
         TOKint64v, TOKuns64v,
@@ -132,7 +132,7 @@ enum TOK
         TOKcomplex32, TOKcomplex64, TOKcomplex80,
         TOKchar, TOKwchar, TOKdchar, TOKbool,
 
-// 159
+// 160
         // Aggregates
         TOKstruct, TOKclass, TOKinterface, TOKunion, TOKenum, TOKimport,
         TOKtypedef, TOKalias, TOKoverride, TOKdelegate, TOKfunction,

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -56,7 +56,7 @@ enum TOK
         TOKnew,         TOKdelete,
         TOKstar,        TOKsymoff,
         TOKvar,         TOKdotvar,
-        TOKdotid,       TOKdotti,       TOKdotexp,
+        TOKdotid,       TOKdotti,
         TOKdottype,     TOKslice,
         TOKarraylength, TOKversion,
         TOKmodule,      TOKdollar,
@@ -73,7 +73,7 @@ enum TOK
         TOKdelegateptr,
         TOKdelegatefuncptr,
 
-// 55
+// 54
         // Operators
         TOKlt,          TOKgt,
         TOKle,          TOKge,
@@ -82,12 +82,12 @@ enum TOK
         TOKindex,       TOKis,
         TOKtobool,
 
-// 66
+// 65
         // NCEG floating point compares
         // !<>=     <>    <>=    !>     !>=   !<     !<=   !<>
         TOKunord,TOKlg,TOKleg,TOKule,TOKul,TOKuge,TOKug,TOKue,
 
-// 74
+// 73
         TOKshl,         TOKshr,
         TOKshlass,      TOKshrass,
         TOKushr,        TOKushrass,
@@ -103,7 +103,7 @@ enum TOK
         TOKquestion,    TOKandand,      TOKoror,
         TOKpreplusplus, TOKpreminusminus,
 
-// 113
+// 112
         // Numeric literals
         TOKint32v, TOKuns32v,
         TOKint64v, TOKuns64v,
@@ -132,7 +132,7 @@ enum TOK
         TOKcomplex32, TOKcomplex64, TOKcomplex80,
         TOKchar, TOKwchar, TOKdchar, TOKbool,
 
-// 160
+// 159
         // Aggregates
         TOKstruct, TOKclass, TOKinterface, TOKunion, TOKenum, TOKimport,
         TOKtypedef, TOKalias, TOKoverride, TOKdelegate, TOKfunction,


### PR DESCRIPTION
Use a new token `TOKdotid` for `DotIdExp` then use `TOKdot` for `DotExp`.
