### PR TITLE
Fix and improve template parameter declaration

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -1167,7 +1167,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         paramscope.callsc = sc;
         paramscope.stc = 0;
 
-        TemplateTupleParameter tp = isVariadic();
+        auto tupleParam = isVariadic();
         Tuple declaredTuple = null;
 
         version (none)
@@ -1188,11 +1188,11 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             // Set initial template arguments
             ntargs = tiargs.dim;
             size_t n = parameters.dim;
-            if (tp)
+            if (tupleParam)
                 n--;
             if (ntargs > n)
             {
-                if (!tp)
+                if (!tupleParam)
                     goto Lnomatch;
 
                 /* The extra initial template arguments
@@ -1207,7 +1207,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 {
                     t.objects[i] = (*tiargs)[n + i];
                 }
-                tp.declareParameter(paramscope, t);
+                tupleParam.declareParameter(paramscope, t);
                 declaredTuple = t;
             }
             else
@@ -1260,7 +1260,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
          * void foo(T, A...)(T t, A a);
          * void main() { foo(1,2,3); }
          */
-        if (tp) // if variadic
+        if (tupleParam) // if variadic
         {
             // TemplateTupleParameter always makes most lesser matching.
             matchTiargs = MATCHconvert;
@@ -1272,7 +1272,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     auto t = new Tuple();
                     //printf("t = %p\n", t);
                     (*dedargs)[parameters.dim - 1] = t;
-                    tp.declareParameter(paramscope, t);
+                    tupleParam.declareParameter(paramscope, t);
                     declaredTuple = t;
                 }
             }
@@ -1289,7 +1289,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     if (fparam.type.ty != Tident)
                         continue;
                     TypeIdentifier tid = cast(TypeIdentifier)fparam.type;
-                    if (!tp.ident.equals(tid.ident) || tid.idents.dim)
+                    if (!tupleParam.ident.equals(tid.ident) || tid.idents.dim)
                         continue;
 
                     if (fvarargs) // variadic function doesn't
@@ -1364,7 +1364,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         // Loop through the function parameters
         {
             //printf("%s\n\tnfargs = %d, nfparams = %d, tuple_dim = %d\n", toChars(), nfargs, nfparams, declaredTuple ? declaredTuple->objects.dim : 0);
-            //printf("\ttp = %p, fptupindex = %d, found = %d, declaredTuple = %s\n", tp, fptupindex, fptupindex != IDX_NOTFOUND, declaredTuple ? declaredTuple->toChars() : NULL);
+            //printf("\ttp = %p, fptupindex = %d, found = %d, declaredTuple = %s\n", tupleParam, fptupindex, fptupindex != IDX_NOTFOUND, declaredTuple ? declaredTuple->toChars() : NULL);
             size_t argi = 0;
             size_t nfargs2 = nfargs; // nfargs + supplied defaultArgs
             for (size_t parami = 0; parami < nfparams; parami++)
@@ -1447,7 +1447,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                             }
                             declaredTuple.objects[i] = tt;
                         }
-                        tp.declareParameter(paramscope, declaredTuple);
+                        tupleParam.declareParameter(paramscope, declaredTuple);
                     }
                     else
                     {
@@ -1918,7 +1918,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         // if tuple parameter and
                         // tuple parameter was not in function parameter list and
                         // we're one or more arguments short (i.e. no tuple argument)
-                        if (tparam == tp &&
+                        if (tparam == tupleParam &&
                             fptupindex == IDX_NOTFOUND &&
                             ntargs <= dedargs.dim - 1)
                         {

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -480,7 +480,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             for (size_t i = 0; i < p.dim; i++)
                 (*p)[i] = (*parameters)[i].syntaxCopy();
         }
-        return new TemplateDeclaration(loc, ident, p, constraint ? constraint.syntaxCopy() : null, Dsymbol.arraySyntaxCopy(members), ismixin, literal);
+        return new TemplateDeclaration(loc, ident, p,
+            constraint ? constraint.syntaxCopy() : null,
+            Dsymbol.arraySyntaxCopy(members), ismixin, literal);
     }
 
     override void semantic(Scope* sc)
@@ -837,7 +839,8 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
      *      dedtypes        deduced arguments
      * Return match level.
      */
-    MATCH matchWithInstance(Scope* sc, TemplateInstance ti, Objects* dedtypes, Expressions* fargs, int flag)
+    MATCH matchWithInstance(Scope* sc, TemplateInstance ti,
+        Objects* dedtypes, Expressions* fargs, int flag)
     {
         enum LOGM = 0;
         static if (LOGM)
@@ -4984,7 +4987,9 @@ extern (C++) class TemplateParameter
      *      dedtypes[]      deduced arguments to template instance
      *      *psparam        set to symbol declared and initialized to dedtypes[i]
      */
-    MATCH matchArg(Loc instLoc, Scope* sc, Objects* tiargs, size_t i, TemplateParameters* parameters, Objects* dedtypes, Declaration* psparam)
+    MATCH matchArg(Loc instLoc, Scope* sc, Objects* tiargs,
+        size_t i, TemplateParameters* parameters, Objects* dedtypes,
+        Declaration* psparam)
     {
         RootObject oarg;
 
@@ -5011,7 +5016,9 @@ extern (C++) class TemplateParameter
         return MATCHnomatch;
     }
 
-    abstract MATCH matchArg(Scope* sc, RootObject oarg, size_t i, TemplateParameters* parameters, Objects* dedtypes, Declaration* psparam);
+    abstract MATCH matchArg(Scope* sc, RootObject oarg,
+        size_t i, TemplateParameters* parameters, Objects* dedtypes,
+        Declaration* psparam);
 
     /* Create dummy argument based on parameter.
      */
@@ -5034,7 +5041,8 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
 
     extern (C++) static __gshared Type tdummy = null;
 
-    final extern (D) this(Loc loc, Identifier ident, Type specType, Type defaultType)
+    final extern (D) this(Loc loc, Identifier ident,
+        Type specType, Type defaultType)
     {
         super(loc, ident);
         this.ident = ident;
@@ -5049,7 +5057,9 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
 
     override TemplateParameter syntaxCopy()
     {
-        return new TemplateTypeParameter(loc, ident, specType ? specType.syntaxCopy() : null, defaultType ? defaultType.syntaxCopy() : null);
+        return new TemplateTypeParameter(loc, ident,
+            specType ? specType.syntaxCopy() : null,
+            defaultType ? defaultType.syntaxCopy() : null);
     }
 
     override final bool declareParameter(Scope* sc)
@@ -5115,7 +5125,9 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
         return defaultType !is null;
     }
 
-    override final MATCH matchArg(Scope* sc, RootObject oarg, size_t i, TemplateParameters* parameters, Objects* dedtypes, Declaration* psparam)
+    override final MATCH matchArg(Scope* sc, RootObject oarg,
+        size_t i, TemplateParameters* parameters, Objects* dedtypes,
+        Declaration* psparam)
     {
         //printf("TemplateTypeParameter::matchArg('%s')\n", ident->toChars());
         MATCH m = MATCHexact;
@@ -5227,7 +5239,9 @@ extern (C++) final class TemplateThisParameter : TemplateTypeParameter
 
     override TemplateParameter syntaxCopy()
     {
-        return new TemplateThisParameter(loc, ident, specType ? specType.syntaxCopy() : null, defaultType ? defaultType.syntaxCopy() : null);
+        return new TemplateThisParameter(loc, ident,
+            specType ? specType.syntaxCopy() : null,
+            defaultType ? defaultType.syntaxCopy() : null);
     }
 
     override void accept(Visitor v)
@@ -5526,7 +5540,8 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
 
     extern (C++) static __gshared Dsymbol sdummy = null;
 
-    extern (D) this(Loc loc, Identifier ident, Type specType, RootObject specAlias, RootObject defaultAlias)
+    extern (D) this(Loc loc, Identifier ident, Type specType,
+        RootObject specAlias, RootObject defaultAlias)
     {
         super(loc, ident);
         this.ident = ident;
@@ -5542,7 +5557,10 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
 
     override TemplateParameter syntaxCopy()
     {
-        return new TemplateAliasParameter(loc, ident, specType ? specType.syntaxCopy() : null, objectSyntaxCopy(specAlias), objectSyntaxCopy(defaultAlias));
+        return new TemplateAliasParameter(loc, ident,
+            specType ? specType.syntaxCopy() : null,
+            objectSyntaxCopy(specAlias),
+            objectSyntaxCopy(defaultAlias));
     }
 
     override bool declareParameter(Scope* sc)
@@ -5565,7 +5583,8 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
             if (defaultAlias)
                 defaultAlias = defaultAlias.semantic(loc, sc);
         }
-        return !(specType && isError(specType)) && !(specAlias && isError(specAlias));
+        return !(specType  && isError(specType)) &&
+               !(specAlias && isError(specAlias));
     }
 
     override void print(RootObject oarg, RootObject oded)
@@ -5603,7 +5622,9 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
         return defaultAlias !is null;
     }
 
-    override MATCH matchArg(Scope* sc, RootObject oarg, size_t i, TemplateParameters* parameters, Objects* dedtypes, Declaration* psparam)
+    override MATCH matchArg(Scope* sc, RootObject oarg,
+        size_t i, TemplateParameters* parameters, Objects* dedtypes,
+        Declaration* psparam)
     {
         //printf("TemplateAliasParameter::matchArg('%s')\n", ident->toChars());
         MATCH m = MATCHexact;
@@ -5824,7 +5845,9 @@ extern (C++) final class TemplateTupleParameter : TemplateParameter
         return false;
     }
 
-    override MATCH matchArg(Loc instLoc, Scope* sc, Objects* tiargs, size_t i, TemplateParameters* parameters, Objects* dedtypes, Declaration* psparam)
+    override MATCH matchArg(Loc instLoc, Scope* sc, Objects* tiargs,
+        size_t i, TemplateParameters* parameters, Objects* dedtypes,
+        Declaration* psparam)
     {
         /* The rest of the actual arguments (tiargs[]) form the match
          * for the variadic parameter.
@@ -5854,7 +5877,9 @@ extern (C++) final class TemplateTupleParameter : TemplateParameter
         return matchArg(sc, ovar, i, parameters, dedtypes, psparam);
     }
 
-    override MATCH matchArg(Scope* sc, RootObject oarg, size_t i, TemplateParameters* parameters, Objects* dedtypes, Declaration* psparam)
+    override MATCH matchArg(Scope* sc, RootObject oarg,
+        size_t i, TemplateParameters* parameters, Objects* dedtypes,
+        Declaration* psparam)
     {
         //printf("TemplateTupleParameter::matchArg('%s')\n", ident->toChars());
         Tuple ovar = isTuple(oarg);

--- a/src/expression.d
+++ b/src/expression.d
@@ -7722,19 +7722,19 @@ extern (C++) final class IsExp : Expression
                  */
                 for (size_t i = 1; i < parameters.dim; i++)
                 {
-                    TemplateParameter tp = (*parameters)[i];
-                    Declaration s = null;
-
-                    m = tp.matchArg(loc, sc, &tiargs, i, parameters, &dedtypes, &s);
+                    auto tp = (*parameters)[i];
+                    m = tp.matchArg(loc, sc, &tiargs, i, parameters, &dedtypes);
                     if (m <= MATCHnomatch)
                         goto Lno;
-                    s.semantic(sc);
-                    if (sc.sds)
-                        s.addMember(sc, sc.sds);
-                    else if (!sc.insert(s))
-                        error("declaration %s is already defined", s.toChars());
 
-                    unSpeculative(sc, s);
+                    auto d = tp.declareParameter(dedtypes[i]);
+                    d.semantic(sc);
+                    if (sc.sds)
+                        d.addMember(sc, sc.sds);
+                    else if (!sc.insert(d))
+                        error("declaration %s is already defined", d.toChars());
+
+                    unSpeculative(sc, d);
                 }
                 goto Lyes;
             }


### PR DESCRIPTION
1. All template parameters should have `STCtemplateparameter` internal storage class. However when a parameter declaration is created in `matchArg`, it's not set sometimes.
2. A template parameter creation should be consistent between each TemplateXXXParameter classes, which type depends on the declared template argument (`Type` or `Dsymbol` is declared by `AliasDeclaration`, and `Expression` is declared by `VarDeclaration`). However the process is not exactly same between `TemplateDeclaration.declaraParameter` and `TemplateParameter.matchArg`.

This PR fixes these two issues. Declaring a template parameter process is now collected into `TemplateParameter.declareParameter(Scope* sc, RootObject o)` function.

Note that, I think the correct `STCtemplateparameter` addition would be needed to fix access check behavior inside template instance for the aliased symbols.
