### PR TITLE
Fix issue 12954 - Deprecated only works with string literals

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -8,6 +8,7 @@ $(BUGSTITLE Compiler Changes,
 )
 
 $(BUGSTITLE Language Changes,
+    $(LI $(RELATIVE_LINK2 extended-deprecated, Manifest constant can now be used for deprecation message.))
 )
 
 $(BUGSTITLE Compiler Changes,
@@ -15,7 +16,18 @@ $(BUGSTITLE Compiler Changes,
 )
 
 $(BUGSTITLE Language Changes,
+    $(LI $(LNAME2 extended-deprecated, Manifest constant can now be used for deprecation message.)
 
+    Manifest constants (enum, static immutable) can now be used for deprecation message, as well as concatenated strings.
+    $(P Example:)
+    ---
+    string generateMessage() { return "Some deprecation message"; }
+    enum DepMsg = generateMessage();
+
+    deprecated(DepMsg) class Foo {}
+    deprecated("Some long deprecation " ~ "message") class Bar {}
+    ---
+    )
 )
 
 Macros:

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -157,7 +157,7 @@ struct Scope
     int explicitProtection;         // set if in an explicit protection attribute
 
     StorageClass stc;               // storage class
-    char* depmsg;                   // customized deprecation message
+    DeprecatedDeclaration depdecl;  // customized deprecation message
 
     uint flags;
 
@@ -602,7 +602,7 @@ struct Scope
         this.protection = sc.protection;
         this.explicitProtection = sc.explicitProtection;
         this.stc = sc.stc;
-        this.depmsg = sc.depmsg;
+        this.depdecl = sc.depdecl;
         this.inunion = sc.inunion;
         this.nofree = sc.nofree;
         this.noctor = sc.noctor;

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -191,7 +191,7 @@ public:
     bool errors;            // this symbol failed to pass semantic()
     PASS semanticRun;
 
-    char* depmsg;           // customized deprecation message
+    DeprecatedDeclaration depdecl;           // customized deprecation message
     UserAttributeDeclaration userAttribDecl;    // user defined attributes
 
     // !=null means there's a ddoc unittest associated with this symbol
@@ -312,7 +312,7 @@ public:
             const(char)* message = null;
             for (Dsymbol p = this; p; p = p.parent)
             {
-                message = p.depmsg;
+                message = p.depdecl ? p.depdecl.msgstr : null;
                 if (message)
                     break;
             }
@@ -570,8 +570,8 @@ public:
         if (!sc.nofree)
             sc.setNoFree(); // may need it even after semantic() finishes
         _scope = sc;
-        if (sc.depmsg)
-            depmsg = sc.depmsg;
+        if (sc.depdecl)
+            depdecl = sc.depdecl;
         if (!userAttribDecl)
             userAttribDecl = sc.userAttribDecl;
     }

--- a/test/fail_compilation/depmsg.d
+++ b/test/fail_compilation/depmsg.d
@@ -15,6 +15,13 @@ fail_compilation/depmsg.d(24): Deprecation: enum depmsg.main.Inner.E is deprecat
 fail_compilation/depmsg.d(26): Deprecation: alias depmsg.main.Inner.G is deprecated - With message!
 fail_compilation/depmsg.d(27): Deprecation: variable depmsg.main.Inner.H is deprecated - With message!
 fail_compilation/depmsg.d(28): Deprecation: class depmsg.main.Inner.I!().I is deprecated - With message!
+fail_compilation/depmsg.d(58): Deprecation: function depmsg.main.Foo.bar1 is deprecated - [C] Use Foo.bar42 instead
+fail_compilation/depmsg.d(59): Deprecation: function depmsg.main.Foo.bar2 is deprecated - [E] Use Foo.bar42 instead
+fail_compilation/depmsg.d(60): Deprecation: function depmsg.main.Foo.bar3 is deprecated - [S] Use Foo.bar42 instead
+fail_compilation/depmsg.d(61): Deprecation: function depmsg.main.Foo.bar4 is deprecated - [F] Use Foo.bar42 instead
+fail_compilation/depmsg.d(62): Deprecation: variable depmsg.main.Foo.v2 is deprecated - Forward reference
+fail_compilation/depmsg.d(68): Deprecation: class depmsg.main.Obsolete is deprecated
+fail_compilation/depmsg.d(68): Deprecation: function depmsg.main.Obsolete.obs is deprecated - Function is obsolete
 ---
 */
 
@@ -48,4 +55,43 @@ void main()
         auto h = H;
         I!() i;
     }
+
+    struct Foo {
+        enum DeprecatedReasonEnum = "[E] Use Foo.bar42 instead";
+        static const DeprecatedReasonStatic = "[S] Use Foo.bar42 instead";
+        static immutable DeprecatedReasonFunc = reason("Foo.bar42");
+
+        static string reason (string name)
+        {
+            return "[F] Use " ~ name ~ " instead";
+        }
+
+        deprecated("[C] Use " ~ `Foo.bar42 instead`)
+        void bar1 () {}
+
+        deprecated(DeprecatedReasonEnum)
+        void bar2 () {}
+
+        deprecated(DeprecatedReasonStatic)
+        void bar3 () {}
+
+        deprecated(DeprecatedReasonFunc)
+        void bar4 () {}
+
+        deprecated(Forward ~ Reference) int v2 = 2;
+        enum Forward = "Forward ", Reference = "reference";
+    }
+
+    Foo f;
+    f.bar1;
+    f.bar2;
+    f.bar3;
+    f.bar4;
+    assert(f.v2 == 2);
+
+    deprecated class Obsolete {
+        deprecated("Function is obsolete") void obs() {}
+    }
+
+    (new Obsolete).obs();
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12954

Allow code to use `enum` and `static {immutable,const}` for the deprecation message.
This will allow for more dynamic deprecation message (e.g. with release informations).
It purposedly doesn't support direct function call to get the deprecation message.
