### PR TITLE
[REG2.066] Issue 15422 - associative array of nested struct - crash on usage

### DIFF
--- a/src/clone.d
+++ b/src/clone.d
@@ -34,6 +34,7 @@ extern (C++) StorageClass mergeFuncAttrs(StorageClass s1, FuncDeclaration f)
 {
     if (!f)
         return s1;
+
     StorageClass s2 = (f.storage_class & STCdisable);
     TypeFunction tf = cast(TypeFunction)f.type;
     if (tf.trust == TRUSTsafe)
@@ -48,9 +49,11 @@ extern (C++) StorageClass mergeFuncAttrs(StorageClass s1, FuncDeclaration f)
         s2 |= STCnothrow;
     if (tf.isnogc)
         s2 |= STCnogc;
+
     StorageClass stc = 0;
     StorageClass sa = s1 & s2;
     StorageClass so = s1 | s2;
+
     if (so & STCsystem)
         stc |= STCsystem;
     else if (sa & STCtrusted)
@@ -59,14 +62,19 @@ extern (C++) StorageClass mergeFuncAttrs(StorageClass s1, FuncDeclaration f)
         stc |= STCtrusted;
     else if (sa & STCsafe)
         stc |= STCsafe;
+
     if (sa & STCpure)
         stc |= STCpure;
+
     if (sa & STCnothrow)
         stc |= STCnothrow;
+
     if (sa & STCnogc)
         stc |= STCnogc;
+
     if (so & STCdisable)
         stc |= STCdisable;
+
     return stc;
 }
 
@@ -86,10 +94,12 @@ extern (C++) FuncDeclaration hasIdentityOpAssign(AggregateDeclaration ad, Scope*
         auto a = new Expressions();
         a.setDim(1);
         FuncDeclaration f = null;
+
         uint errors = global.startGagging(); // Do not report errors, even if the
         sc = sc.push();
         sc.tinst = null;
         sc.minst = null;
+
         for (size_t i = 0; i < 2; i++)
         {
             (*a)[0] = (i == 0 ? er : el);
@@ -97,8 +107,10 @@ extern (C++) FuncDeclaration hasIdentityOpAssign(AggregateDeclaration ad, Scope*
             if (f)
                 break;
         }
+
         sc = sc.pop();
         global.endGagging(errors);
+
         if (f)
         {
             if (f.errors)
@@ -128,10 +140,11 @@ extern (C++) bool needOpAssign(StructDeclaration sd)
 {
     //printf("StructDeclaration::needOpAssign() %s\n", sd->toChars());
     if (sd.hasIdentityAssign)
-        goto Lneed;
-    // because has identity==elaborate opAssign
+        goto Lneed; // because has identity==elaborate opAssign
+
     if (sd.dtor || sd.postblit)
         goto Lneed;
+
     /* If any of the fields need an opAssign, then we
      * need it too.
      */
@@ -150,6 +163,7 @@ extern (C++) bool needOpAssign(StructDeclaration sd)
     }
     //printf("\tdontneed\n");
     return false;
+
 Lneed:
     //printf("\tneed\n");
     return true;
@@ -184,12 +198,15 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
     }
     // Even if non-identity opAssign is defined, built-in identity opAssign
     // will be defined.
+
     if (!needOpAssign(sd))
         return null;
+
     //printf("StructDeclaration::buildOpAssign() %s\n", sd->toChars());
     StorageClass stc = STCsafe | STCnothrow | STCpure | STCnogc;
     Loc declLoc = sd.loc;
     Loc loc = Loc(); // internal code should have no loc to prevent coverage
+
     if (sd.dtor || sd.postblit)
     {
         if (!sd.type.isAssignable()) // Bugzilla 13044
@@ -208,13 +225,16 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
             Type tv = v.type.baseElemOf();
             if (tv.ty != Tstruct)
                 continue;
+
             StructDeclaration sdv = (cast(TypeStruct)tv).sym;
             stc = mergeFuncAttrs(stc, hasIdentityOpAssign(sdv, sc));
         }
     }
+
     auto fparams = new Parameters();
     fparams.push(new Parameter(STCnodtor, sd.type, Id.p, null));
     auto tf = new TypeFunction(fparams, sd.handleType(), 0, LINKd, stc | STCref);
+
     auto fop = new FuncDeclaration(declLoc, Loc(), Id.assign, stc, tf);
     fop.storage_class |= STCinference;
 
@@ -261,28 +281,35 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
         {
             VarDeclaration v = sd.fields[i];
             // this.v = s.v;
-            auto ec = new AssignExp(loc, new DotVarExp(loc, new ThisExp(loc), v, 0), new DotVarExp(loc, new IdentifierExp(loc, Id.p), v, 0));
+            auto ec = new AssignExp(loc,
+                new DotVarExp(loc, new ThisExp(loc), v, 0),
+                new DotVarExp(loc, new IdentifierExp(loc, Id.p), v, 0));
             e = Expression.combine(e, ec);
         }
     }
     if (e)
     {
         Statement s1 = new ExpStatement(loc, e);
+
         /* Add:
          *   return this;
          */
         e = new ThisExp(loc);
         Statement s2 = new ReturnStatement(loc, e);
+
         fop.fbody = new CompoundStatement(loc, s1, s2);
         tf.isreturn = true;
     }
+
     sd.members.push(fop);
     fop.addMember(sc, sd);
     sd.hasIdentityAssign = true; // temporary mark identity assignable
+
     uint errors = global.startGagging(); // Do not report errors, even if the
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINKd;
+
     fop.semantic(sc2);
     fop.semantic2(sc2);
     // Bugzilla 15044: fop->semantic3 isn't run here for lazy forward reference resolution.
@@ -294,6 +321,7 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
         fop.storage_class |= STCdisable;
         fop.fbody = null; // remove fbody which contains the error
     }
+
     //printf("-StructDeclaration::buildOpAssign() %s, errors = %d\n", sd->toChars(), (fop->storage_class & STCdisable) != 0);
     return fop;
 }
@@ -308,8 +336,10 @@ extern (C++) bool needOpEquals(StructDeclaration sd)
     //printf("StructDeclaration::needOpEquals() %s\n", sd->toChars());
     if (sd.hasIdentityEquals)
         goto Lneed;
+
     if (sd.isUnionDeclaration())
         goto Ldontneed;
+
     /* If any of the fields has an opEquals, then we
      * need it too.
      */
@@ -345,6 +375,7 @@ extern (C++) bool needOpEquals(StructDeclaration sd)
 Ldontneed:
     //printf("\tdontneed\n");
     return false;
+
 Lneed:
     //printf("\tneed\n");
     return true;
@@ -367,23 +398,19 @@ extern (C++) FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope*
         for (size_t i = 0;; i++)
         {
             Type tthis = null; // dead-store to prevent spurious warning
-            if (i == 0)
-                tthis = ad.type;
-            if (i == 1)
-                tthis = ad.type.constOf();
-            if (i == 2)
-                tthis = ad.type.immutableOf();
-            if (i == 3)
-                tthis = ad.type.sharedOf();
-            if (i == 4)
-                tthis = ad.type.sharedConstOf();
-            if (i == 5)
-                break;
+            if (i == 0) tthis = ad.type;
+            if (i == 1) tthis = ad.type.constOf();
+            if (i == 2) tthis = ad.type.immutableOf();
+            if (i == 3) tthis = ad.type.sharedOf();
+            if (i == 4) tthis = ad.type.sharedConstOf();
+            if (i == 5) break;
             FuncDeclaration f = null;
+
             uint errors = global.startGagging(); // Do not report errors, even if the
             sc = sc.push();
             sc.tinst = null;
             sc.minst = null;
+
             for (size_t j = 0; j < 2; j++)
             {
                 (*a)[0] = (j == 0 ? er : el);
@@ -392,8 +419,10 @@ extern (C++) FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope*
                 if (f)
                     break;
             }
+
             sc = sc.pop();
             global.endGagging(errors);
+
             if (f)
             {
                 if (f.errors)
@@ -437,6 +466,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
 {
     if (!needOpEquals(sd))
         return null; // bitwise comparison would work
+
     //printf("StructDeclaration::buildXopEquals() %s\n", sd->toChars());
     if (Dsymbol eq = search_function(sd, Id.eq))
     {
@@ -445,6 +475,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
             TypeFunction tfeqptr;
             {
                 Scope scx;
+
                 /* const bool opEquals(ref const S s);
                  */
                 auto parameters = new Parameters();
@@ -458,6 +489,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
                 return fd;
         }
     }
+
     if (!sd.xerreq)
     {
         // object._xopEquals
@@ -470,27 +502,36 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
         assert(s);
         sd.xerreq = s.isFuncDeclaration();
     }
+
     Loc declLoc = Loc(); // loc is unnecessary so __xopEquals is never called directly
     Loc loc = Loc(); // loc is unnecessary so errors are gagged
+
     auto parameters = new Parameters();
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.p, null));
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.q, null));
     auto tf = new TypeFunction(parameters, Type.tbool, 0, LINKd);
+
     Identifier id = Id.xopEquals;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
+
     Expression e1 = new IdentifierExp(loc, Id.p);
     Expression e2 = new IdentifierExp(loc, Id.q);
     Expression e = new EqualExp(TOKequal, loc, e1, e2);
+
     fop.fbody = new ReturnStatement(loc, e);
+
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINKd;
+
     fop.semantic(sc2);
     fop.semantic2(sc2);
+
     sc2.pop();
     if (global.endGagging(errors)) // if errors happened
         fop = sd.xerreq;
+
     return fop;
 }
 
@@ -514,6 +555,7 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
             TypeFunction tfcmpptr;
             {
                 Scope scx;
+
                 /* const int opCmp(ref const S s);
                  */
                 auto parameters = new Parameters();
@@ -529,9 +571,8 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     }
     else
     {
-        version (none)
+        version (none) // FIXME: doesn't work for recursive alias this
         {
-            // FIXME: doesn't work for recursive alias this
             /* Check opCmp member exists.
              * Consider 'alias this', but except opDispatch.
              */
@@ -545,15 +586,9 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
                 Dsymbol s = null;
                 switch (e.op)
                 {
-                case TOKoverloadset:
-                    s = (cast(OverExp)e).vars;
-                    break;
-                case TOKimport:
-                    s = (cast(ScopeExp)e).sds;
-                    break;
-                case TOKvar:
-                    s = (cast(VarExp)e).var;
-                    break;
+                    case TOKoverloadset:    s = (cast(OverExp)e).vars;  break;
+                    case TOKscope:          s = (cast(ScopeExp)e).sds;  break;
+                    case TOKvar:            s = (cast(VarExp)e).var;    break;
                 default:
                     break;
                 }
@@ -578,6 +613,7 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
             return null;
         }
     }
+
     if (!sd.xerrcmp)
     {
         // object._xopCmp
@@ -590,27 +626,36 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
         assert(s);
         sd.xerrcmp = s.isFuncDeclaration();
     }
+
     Loc declLoc = Loc(); // loc is unnecessary so __xopCmp is never called directly
     Loc loc = Loc(); // loc is unnecessary so errors are gagged
+
     auto parameters = new Parameters();
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.p, null));
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.q, null));
     auto tf = new TypeFunction(parameters, Type.tint32, 0, LINKd);
+
     Identifier id = Id.xopCmp;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
+
     Expression e1 = new IdentifierExp(loc, Id.p);
     Expression e2 = new IdentifierExp(loc, Id.q);
     Expression e = new CallExp(loc, new DotIdExp(loc, e2, Id.cmp), e1);
+
     fop.fbody = new ReturnStatement(loc, e);
+
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINKd;
+
     fop.semantic(sc2);
     fop.semantic2(sc2);
+
     sc2.pop();
     if (global.endGagging(errors)) // if errors happened
         fop = sd.xerrcmp;
+
     return fop;
 }
 
@@ -624,8 +669,10 @@ extern (C++) bool needToHash(StructDeclaration sd)
     //printf("StructDeclaration::needToHash() %s\n", sd->toChars());
     if (sd.xhash)
         goto Lneed;
+
     if (sd.isUnionDeclaration())
         goto Ldontneed;
+
     /* If any of the fields has an opEquals, then we
      * need it too.
      */
@@ -660,6 +707,7 @@ extern (C++) bool needToHash(StructDeclaration sd)
 Ldontneed:
     //printf("\tdontneed\n");
     return false;
+
 Lneed:
     //printf("\tneed\n");
     return true;
@@ -680,6 +728,7 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
             tftohash.mod = MODconst;
             tftohash = cast(TypeFunction)tftohash.merge();
         }
+
         if (FuncDeclaration fd = s.isFuncDeclaration())
         {
             fd = fd.overloadExactMatch(tftohash);
@@ -687,24 +736,37 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
                 return fd;
         }
     }
+
     if (!needToHash(sd))
         return null;
+
     //printf("StructDeclaration::buildXtoHash() %s\n", sd->toPrettyChars());
     Loc declLoc = Loc(); // loc is unnecessary so __xtoHash is never called directly
     Loc loc = Loc(); // internal code should have no loc to prevent coverage
+
     auto parameters = new Parameters();
     parameters.push(new Parameter(STCref | STCconst, sd.type, Id.p, null));
     auto tf = new TypeFunction(parameters, Type.thash_t, 0, LINKd, STCnothrow | STCtrusted);
+
     Identifier id = Id.xtoHash;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STCstatic, tf);
-    const(char)* code = "size_t h = 0;foreach (i, T; typeof(p.tupleof))    h += typeid(T).getHash(cast(const void*)&p.tupleof[i]);return h;";
+
+    const(char)* code =
+        "size_t h = 0;"~
+        "foreach (i, T; typeof(p.tupleof))"~
+        "    h += typeid(T).getHash(cast(const void*)&p.tupleof[i]);"~
+        "return h;";
     fop.fbody = new CompileStatement(loc, new StringExp(loc, cast(char*)code));
+
     Scope* sc2 = sc.push();
     sc2.stc = 0;
     sc2.linkage = LINKd;
+
     fop.semantic(sc2);
     fop.semantic2(sc2);
+
     sc2.pop();
+
     //printf("%s fop = %s %s\n", sd->toChars(), fop->toChars(), fop->type->toChars());
     return fop;
 }
@@ -722,10 +784,12 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
     StorageClass stc = STCsafe | STCnothrow | STCpure | STCnogc;
     Loc declLoc = sd.postblits.dim ? sd.postblits[0].loc : sd.loc;
     Loc loc = Loc(); // internal code should have no loc to prevent coverage
+
     for (size_t i = 0; i < sd.postblits.dim; i++)
     {
         stc |= sd.postblits[i].storage_class & STCdisable;
     }
+
     Statements* a = null;
     for (size_t i = 0; i < sd.fields.dim && !(stc & STCdisable); i++)
     {
@@ -749,36 +813,43 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         }
         if (!a)
             a = new Statements();
+
         Expression ex = new ThisExp(loc);
         ex = new DotVarExp(loc, ex, v, 0);
         if (v.type.toBasetype().ty == Tstruct)
         {
             // this.v.__xpostblit()
+
             // This is a hack so we can call postblits on const/immutable objects.
             ex = new AddrExp(loc, ex);
             ex = new CastExp(loc, ex, v.type.mutableOf().pointerTo());
             ex = new PtrExp(loc, ex);
             if (stc & STCsafe)
                 stc = (stc & ~STCsafe) | STCtrusted;
+
             ex = new DotVarExp(loc, ex, sdv.postblit, 0);
             ex = new CallExp(loc, ex);
         }
         else
         {
             // _ArrayPostblit((cast(S*)this.v.ptr)[0 .. n])
+
             // This is a hack so we can call postblits on const/immutable objects.
             ex = new DotIdExp(loc, ex, Id.ptr);
             ex = new CastExp(loc, ex, sdv.type.pointerTo());
             if (stc & STCsafe)
                 stc = (stc & ~STCsafe) | STCtrusted;
+
             uinteger_t n = v.type.size() / sdv.type.size();
-            ex = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t), new IntegerExp(loc, n, Type.tsize_t));
+            ex = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t),
+                                       new IntegerExp(loc, n, Type.tsize_t));
             // Prevent redundant bounds check
             (cast(SliceExp)ex).upperIsInBounds = true;
             (cast(SliceExp)ex).lowerIsLessThanUpper = true;
             ex = new CallExp(loc, new IdentifierExp(loc, Id._ArrayPostblit), ex);
         }
         a.push(new ExpStatement(loc, ex)); // combine in forward order
+
         /* Bugzilla 10972: When the following field postblit calls fail,
          * this field should be destructed for Exception Safety.
          */
@@ -791,32 +862,39 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         if (v.type.toBasetype().ty == Tstruct)
         {
             // this.v.__xdtor()
+
             // This is a hack so we can call destructors on const/immutable objects.
             ex = new AddrExp(loc, ex);
             ex = new CastExp(loc, ex, v.type.mutableOf().pointerTo());
             ex = new PtrExp(loc, ex);
             if (stc & STCsafe)
                 stc = (stc & ~STCsafe) | STCtrusted;
+
             ex = new DotVarExp(loc, ex, sdv.dtor, 0);
             ex = new CallExp(loc, ex);
         }
         else
         {
             // _ArrayDtor((cast(S*)this.v.ptr)[0 .. n])
+
             // This is a hack so we can call destructors on const/immutable objects.
             ex = new DotIdExp(loc, ex, Id.ptr);
             ex = new CastExp(loc, ex, sdv.type.pointerTo());
             if (stc & STCsafe)
                 stc = (stc & ~STCsafe) | STCtrusted;
+
             uinteger_t n = v.type.size() / sdv.type.size();
-            ex = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t), new IntegerExp(loc, n, Type.tsize_t));
+            ex = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t),
+                                       new IntegerExp(loc, n, Type.tsize_t));
             // Prevent redundant bounds check
             (cast(SliceExp)ex).upperIsInBounds = true;
             (cast(SliceExp)ex).lowerIsLessThanUpper = true;
+
             ex = new CallExp(loc, new IdentifierExp(loc, Id._ArrayDtor), ex);
         }
         a.push(new OnScopeStatement(loc, TOKon_scope_failure, new ExpStatement(loc, ex)));
     }
+
     /* Build our own "postblit" which executes a
      */
     if (a || (stc & STCdisable))
@@ -829,14 +907,17 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         sd.members.push(dd);
         dd.semantic(sc);
     }
+
     FuncDeclaration xpostblit = null;
     switch (sd.postblits.dim)
     {
     case 0:
         break;
+
     case 1:
         xpostblit = sd.postblits[0];
         break;
+
     default:
         Expression e = null;
         stc = STCsafe | STCnothrow | STCpure | STCnogc;
@@ -886,6 +967,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
     StorageClass stc = STCsafe | STCnothrow | STCpure | STCnogc;
     Loc declLoc = ad.dtors.dim ? ad.dtors[0].loc : ad.loc;
     Loc loc = Loc(); // internal code should have no loc to prevent coverage
+
     Expression e = null;
     for (size_t i = 0; i < ad.fields.dim; i++)
     {
@@ -906,37 +988,45 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
             e = null;
             break;
         }
+
         Expression ex = new ThisExp(loc);
         ex = new DotVarExp(loc, ex, v, 0);
         if (v.type.toBasetype().ty == Tstruct)
         {
             // this.v.__xdtor()
+
             // This is a hack so we can call destructors on const/immutable objects.
             ex = new AddrExp(loc, ex);
             ex = new CastExp(loc, ex, v.type.mutableOf().pointerTo());
             ex = new PtrExp(loc, ex);
             if (stc & STCsafe)
                 stc = (stc & ~STCsafe) | STCtrusted;
+
             ex = new DotVarExp(loc, ex, sdv.dtor, 0);
             ex = new CallExp(loc, ex);
         }
         else
         {
             // _ArrayDtor((cast(S*)this.v.ptr)[0 .. n])
+
             // This is a hack so we can call destructors on const/immutable objects.
             ex = new DotIdExp(loc, ex, Id.ptr);
             ex = new CastExp(loc, ex, sdv.type.pointerTo());
             if (stc & STCsafe)
                 stc = (stc & ~STCsafe) | STCtrusted;
+
             uinteger_t n = v.type.size() / sdv.type.size();
-            ex = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t), new IntegerExp(loc, n, Type.tsize_t));
+            ex = new SliceExp(loc, ex, new IntegerExp(loc, 0, Type.tsize_t),
+                                       new IntegerExp(loc, n, Type.tsize_t));
             // Prevent redundant bounds check
             (cast(SliceExp)ex).upperIsInBounds = true;
             (cast(SliceExp)ex).lowerIsLessThanUpper = true;
+
             ex = new CallExp(loc, new IdentifierExp(loc, Id._ArrayDtor), ex);
         }
         e = Expression.combine(ex, e); // combine in reverse order
     }
+
     /* Build our own "destructor" which executes e
      */
     if (e || (stc & STCdisable))
@@ -949,14 +1039,17 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
         ad.members.push(dd);
         dd.semantic(sc);
     }
+
     FuncDeclaration xdtor = null;
     switch (ad.dtors.dim)
     {
     case 0:
         break;
+
     case 1:
         xdtor = ad.dtors[0];
         break;
+
     default:
         e = null;
         stc = STCsafe | STCnothrow | STCpure | STCnogc;
@@ -1010,9 +1103,11 @@ extern (C++) FuncDeclaration buildInv(AggregateDeclaration ad, Scope* sc)
     {
     case 0:
         return null;
+
     case 1:
         // Don't return invs[0] so it has uniquely generated name.
         /* fall through */
+
     default:
         Expression e = null;
         StorageClass stcx = 0;
@@ -1023,7 +1118,8 @@ extern (C++) FuncDeclaration buildInv(AggregateDeclaration ad, Scope* sc)
             {
                 // What should do?
             }
-            StorageClass stcy = (ad.invs[i].storage_class & STCsynchronized) | (ad.invs[i].type.mod & MODshared ? STCshared : 0);
+                StorageClass stcy = (ad.invs[i].storage_class & STCsynchronized) |
+                                    (ad.invs[i].type.mod & MODshared ? STCshared : 0);
             if (i == 0)
                 stcx = stcy;
             else if (stcx ^ stcy)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7677,6 +7677,159 @@ template isCustomSerializable15126(T)
 alias bug15126 = isCustomSerializable15126!Json15126;
 
 /***************************************************/
+// 15422
+
+class App15422(T)
+{
+    this() {}
+
+    auto test1(T val)
+    in {} body      // necessary to reproduce the crash
+    {
+        struct Foo
+        {
+            this(int k) {}
+            T a;
+        }
+
+        Foo foo;
+        foo.a = val;
+
+        // Frame of test2 function, allocated on heap.
+        assert(foo.tupleof[$-1] !is null);
+
+        //printf("&foo = %p\n", &foo);                  // stack
+        //printf("&this = %p\n", &this);                // stack?
+        //printf("foo.vthis = %p\n", foo.tupleof[$-1]); // stack...!?
+        //assert(cast(void*)&this !is *cast(void**)&foo.tupleof[$-1], "bad");
+        // BUG: currently foo.vthis set to the address of 'this' variable on the stack.
+        // It's should be stomped to null, because Foo.vthis is never be used.
+
+        int[Foo] map;
+        map[foo] = 1;   // OK <- crash
+
+        return foo;
+    }
+
+    auto test2(T val)
+    //in {} body
+    {
+        int closVar;
+        struct Foo
+        {
+            this(int k) { closVar = k; }
+            // Make val a closure variable.
+
+            T a;
+        }
+
+        Foo foo;
+        foo.a = val;
+
+        // Frame of test2 function, allocated on heap.
+        assert(foo.tupleof[$-1] !is null);
+
+        return foo;
+    }
+}
+
+void test15422a()
+{
+    alias App = App15422!int;
+    App app1 = new App;
+    {
+        auto x = app1.test1(1);
+        auto y = app1.test1(1);
+        static assert(is(typeof(x) == typeof(y)));
+
+        // int (bitwise comparison)
+        assert(x.a == y.a);
+
+        assert(*cast(void**)&x.tupleof[$-1] is *cast(void**)&y.tupleof[$-1]);
+
+        // bitwise equality (needOpEquals() and needToHash() returns false)
+        assert(x == y);
+
+        // BUG
+        //assert(*cast(void**)&x.tupleof[$-1] is null);
+        //assert(*cast(void**)&y.tupleof[$-1] is null);
+        auto getZ() { auto z = app1.test1(1); return z; }
+        auto z = getZ();
+        assert(x.a == z.a);
+        //assert(x.tupleof[$-1] is z.tupleof[$-1]);   // should pass
+        //assert(x == z);                             // should pass
+
+        x = y;  // OK, x.tupleof[$-1] = y.tupleof[$-1] is a blit copy.
+    }
+    App app2 = new App;
+    {
+        auto x = app1.test2(1);
+        auto y = app2.test2(1);
+        static assert(is(typeof(x) == typeof(y)));
+
+        // int (bitwise comparison)
+        assert(x.a == y.a);
+
+        // closure envirionments
+        assert(*cast(void**)&x.tupleof[$-1] !is *cast(void**)&y.tupleof[$-1]);
+
+        // Changed to bitwise equality (needOpEquals() and needToHash() returns false)
+        assert(x != y);         // OK <- crash
+
+        x = y;  // OK, x.tupleof[$-1] = y.tupleof[$-1] is a blit copy.
+    }
+}
+
+void test15422b()
+{
+    alias App = App15422!string;
+    App app1 = new App;
+    {
+        auto x = app1.test1("a".idup);
+        auto y = app1.test1("a".idup);
+        static assert(is(typeof(x) == typeof(y)));
+
+        // string (element-wise comparison)
+        assert(x.a == y.a);
+
+        assert(*cast(void**)&x.tupleof[$-1] is *cast(void**)&y.tupleof[$-1]);
+
+        // memberwise equality (needToHash() returns true)
+        assert(x == y);
+        // Lowered to: x.a == y.a && x.tupleof[$-1] is y.tupleof[$-1]
+
+        // BUG
+        //assert(*cast(void**)&x.tupleof[$-1] is null);
+        //assert(*cast(void**)&y.tupleof[$-1] is null);
+        auto getZ() { auto z = app1.test1("a".idup); return z; }
+        auto z = getZ();
+        assert(x.a == z.a);
+        //assert(x.tupleof[$-1] is z.tupleof[$-1]);   // should pass
+        //assert(x == z);                             // should pass
+
+        x = y;  // OK, x.tupleof[$-1] = y.tupleof[$-1] is a blit copy.
+    }
+    App app2 = new App;
+    {
+        auto x = app1.test2("a".idup);
+        auto y = app2.test2("a".idup);
+        static assert(is(typeof(x) == typeof(y)));
+
+        // string (element-wise comparison)
+        assert(x.a == y.a);
+
+        // closure envirionments
+        assert(*cast(void**)&x.tupleof[$-1] !is *cast(void**)&y.tupleof[$-1]);
+
+        // Changed to memberwise equality (needToHash() returns true)
+        // Lowered to: x.a == y.a && x.tupleof[$-1] is y.tupleof[$-1]
+        assert(x != y);         // OK <- crash
+
+        x = y;  // OK, x.tupleof[$-1] = y.tupleof[$-1] is a blit copy.
+    }
+}
+
+/***************************************************/
 
 int main()
 {
@@ -7989,6 +8142,8 @@ int main()
     test13952();
     test13985();
     test14211();
+    test15422a();
+    test15422b();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
On a nested struct, built-in generated equality (`tupleof` comparison), hashing (static `xtoHash` function), and assignment (implicitly added `opAssign`) should use its enclosing context identity.
