### PR TITLE
add -dwarfeh switch to make debugging easier

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -49,7 +49,8 @@ void out_config_init(
                         // 1: D
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
-        bool stackstomp         // add stack stomping code
+        bool stackstomp,        // add stack stomping code
+        bool dwarfeh            // use Dwarf eh
         )
 {
 #if MARS
@@ -109,7 +110,7 @@ void out_config_init(
         config.flags |= CFGalwaysframe; // PIC needs a frame for TLS fixups
     }
     config.objfmt = OBJ_ELF;
-    config.ehmethod = EH_DM;
+    config.ehmethod = dwarfeh ? EH_DWARF : EH_DM;
 #endif
 #if TARGET_OSX
     config.fpxmmregs = TRUE;

--- a/src/globals.d
+++ b/src/globals.d
@@ -114,6 +114,7 @@ struct Param
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations
+    bool dwarfeh;           // generate dwarf eh exception handling
 
     BOUNDSCHECK useArrayBounds;
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -92,6 +92,7 @@ struct Param
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
+    bool dwarfeh;       // generate dwarf eh exception handling
 
     BOUNDSCHECK useArrayBounds;
 

--- a/src/mars.d
+++ b/src/mars.d
@@ -443,6 +443,8 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
                 global.params.useDeprecated = 1;
             else if (strcmp(p + 1, "dw") == 0)
                 global.params.useDeprecated = 2;
+            else if (strcmp(p + 1, "dwarfeh") == 0)
+                global.params.dwarfeh = true;
             else if (strcmp(p + 1, "c") == 0)
                 global.params.link = false;
             else if (memcmp(p + 1, cast(char*)"color", 5) == 0)

--- a/src/msc.c
+++ b/src/msc.c
@@ -48,7 +48,8 @@ void out_config_init(
                         // 1: D
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
-        bool stackstomp         // add stack stomping code
+        bool stackstomp,        // add stack stomping code
+        bool dwarfeh            // use Dwarf exception handling
         );
 
 void out_config_debug(
@@ -98,7 +99,8 @@ void backend_init()
         params->optimize,
         params->symdebug,
         params->alwaysframe,
-        params->stackstomp
+        params->stackstomp,
+        params->dwarfeh
     );
 
 #ifdef DEBUG

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -1551,7 +1551,7 @@ void insertFinallyBlockCalls(block *startblock)
                 if (!bcretexp)
                 {
                     bcretexp = block_calloc();
-                    bcret->BC = BCretexp;
+                    bcretexp->BC = BCretexp;
                     type *t;
                     if ((ty == TYstruct || ty == TYarray) && e->ET)
                         t = e->ET;


### PR DESCRIPTION
It turns out it's easier to debug the new eh code if I can switch back and forth without having to rebuild the compiler. This switch is temporary only.
