### PR TITLE
Issue 9731: implement $(DDOC_PARAGRAPH)

### DIFF
--- a/src/doc.d
+++ b/src/doc.d
@@ -2174,7 +2174,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
             {
                 leadingBlank = true;
             }
-            else
+            else if (!inCode)
             {
                 // Group two or more newlines into a paragraph break
                 auto scout = iLineStart;
@@ -2192,10 +2192,9 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
                     }
                     // We got to a non-whitespace, time to insert the paragraph
                     // break.
-                    i = iLineStart - 1;
-                    static __gshared const(char)* ps =
+                    static __gshared immutable ps =
                         "$(DDOC_PARAGRAPH_SEPARATOR)";
-                    i = buf.insert(i, ps, strlen(ps));
+                    i = buf.insert(iLineStart, ps.ptr, ps.length) - 1;
                     break;
                 }
             }

--- a/src/doc.d
+++ b/src/doc.d
@@ -2137,6 +2137,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
     bool leadingBlank = true;
     int inCode = 0;
     int inBacktick = 0;
+    int blankLineRun = 0;
     //int inComment = 0;                  // in <!-- ... --> comment
     size_t iCodeStart = 0; // start of code section
     size_t codeIndent = 0;
@@ -2168,6 +2169,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
             {
                 static __gshared const(char)* blankline = "$(DDOC_BLANKLINE)\n";
                 i = buf.insert(i, blankline, strlen(blankline));
+                blankLineRun++;
             }
             iLineStart = i + 1;
             if (!leadingBlank)
@@ -2422,6 +2424,18 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
             leadingBlank = 0;
             if (sc._module.isDocFile || inCode)
                 break;
+
+
+            if(blankLineRun) {
+                // We got to a non-whitespace in a run of blank lines, time
+                // to insert the paragraph break to group two or more newlines
+                // into a paragraph separator
+                immutable ps = "$(DDOC_PARAGRAPH_SEPARATOR)";
+                i = buf.insert(i, ps.ptr, ps.length) - 1;
+            }
+
+            blankLineRun = 0;
+
             char* start = cast(char*)buf.data + i;
             if (isIdStart(start))
             {

--- a/src/doc.d
+++ b/src/doc.d
@@ -2192,8 +2192,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
                     }
                     // We got to a non-whitespace, time to insert the paragraph
                     // break.
-                    static __gshared immutable ps =
-                        "$(DDOC_PARAGRAPH_SEPARATOR)";
+                    immutable ps = "$(DDOC_PARAGRAPH_SEPARATOR)";
                     i = buf.insert(iLineStart, ps.ptr, ps.length) - 1;
                     break;
                 }

--- a/src/doc.d
+++ b/src/doc.d
@@ -2135,10 +2135,9 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
     Dsymbol s = a.dim ? (*a)[0] : null; // test
     //printf("highlightText()\n");
     bool leadingBlank = true;
-    int inCode = 0;
-    int inBacktick = 0;
-    int blankLineRun = 0;
-    //int inComment = 0;                  // in <!-- ... --> comment
+    bool inCode = 0;
+    bool inBacktick = 0;
+    uint blankLineRun = 0;
     size_t iCodeStart = 0; // start of code section
     size_t codeIndent = 0;
     size_t iLineStart = offset;
@@ -2167,36 +2166,37 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
             }
             if (!sc._module.isDocFile && !inCode && i == iLineStart && i + 1 < buf.offset) // if "\n\n"
             {
-                static __gshared const(char)* blankline = "$(DDOC_BLANKLINE)\n";
-                i = buf.insert(i, blankline, strlen(blankline));
-                blankLineRun++;
+                static immutable blankline = "$(DDOC_BLANKLINE)\n";
+                i = buf.insert(i, blankline.ptr, blankline.length);
             }
             iLineStart = i + 1;
-            if (!leadingBlank)
+            leadingBlank = true;
+            if (inCode)
             {
-                leadingBlank = true;
+                // Once a section of code is active, blank line runs are reset
+                blankLineRun = 0;
             }
-            else if (!inCode)
+            else
             {
                 // Group two or more newlines into a paragraph break
-                auto scout = iLineStart;
-                for (; scout < buf.offset; ++scout)
+                if (i + 1 >= buf.offset) break; // end of file, uninteresting
+                // Look ahead to see if the run is continuing
+                switch (c = buf.data[i + 1])
                 {
-                    c = buf.data[scout];
-                    if (c == ' ' || c == '\t')
-                    {
-                        continue;
-                    }
-                    if (c == '\n')
-                    {
-                        iLineStart = scout + 1;
-                        continue;
-                    }
-                    // We got to a non-whitespace, time to insert the paragraph
-                    // break.
-                    immutable ps = "$(DDOC_PARAGRAPH_SEPARATOR)";
-                    i = buf.insert(iLineStart, ps.ptr, ps.length) - 1;
-                    break;
+                    case ' ', '\t', '\r':
+                        break;
+                    case '\n':
+                        blankLineRun++;
+                        break;
+                    default:
+                        // End of a run!
+                        if (blankLineRun == 0) break; // just one newline
+                        // Time to insert the paragraph break.
+                        static immutable ps = "$(DDOC_PARAGRAPH_SEPARATOR)";
+                        i = buf.insert(i, ps.ptr, ps.length);
+                        // Reset the counter for the next run
+                        blankLineRun = 0;
+                        break;
                 }
             }
             break;
@@ -2330,111 +2330,102 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
             /* A line beginning with --- delimits a code section.
              * inCode tells us if it is start or end of a code section.
              */
-            if (leadingBlank)
+            if (!leadingBlank)
             {
-                size_t istart = i;
-                size_t eollen = 0;
-                leadingBlank = 0;
-                while (1)
+                // No special meaning uness '-' is the first non-ws in a line
+                break;
+            }
+            size_t istart = i;
+            size_t eollen = 0;
+            leadingBlank = 0;
+            while (1)
+            {
+                ++i;
+                if (i >= buf.offset)
+                    break;
+                c = buf.data[i];
+                if (c == '\n')
                 {
-                    ++i;
-                    if (i >= buf.offset)
-                        break;
-                    c = buf.data[i];
-                    if (c == '\n')
-                    {
-                        eollen = 1;
-                        break;
-                    }
-                    if (c == '\r')
-                    {
-                        eollen = 1;
-                        if (i + 1 >= buf.offset)
-                            break;
-                        if (buf.data[i + 1] == '\n')
-                        {
-                            eollen = 2;
-                            break;
-                        }
-                    }
-                    // BUG: handle UTF PS and LS too
-                    if (c != '-')
-                        goto Lcont;
-                }
-                if (i - istart < 3)
-                    goto Lcont;
-                // We have the start/end of a code section
-                // Remove the entire --- line, including blanks and \n
-                buf.remove(iLineStart, i - iLineStart + eollen);
-                i = iLineStart;
-                if (inCode && (i <= iCodeStart))
-                {
-                    // Empty code section, just remove it completely.
-                    inCode = 0;
+                    eollen = 1;
                     break;
                 }
-                if (inCode)
+                if (c == '\r')
                 {
-                    inCode = 0;
-                    // The code section is from iCodeStart to i
-                    OutBuffer codebuf;
-                    codebuf.write(buf.data + iCodeStart, i - iCodeStart);
-                    codebuf.writeByte(0);
-                    // Remove leading indentations from all lines
-                    bool lineStart = true;
-                    char* endp = cast(char*)codebuf.data + codebuf.offset;
-                    for (char* p = cast(char*)codebuf.data; p < endp;)
+                    eollen = 1;
+                    if (i + 1 >= buf.offset)
+                        break;
+                    if (buf.data[i + 1] == '\n')
                     {
-                        if (lineStart)
-                        {
-                            size_t j = codeIndent;
-                            char* q = p;
-                            while (j-- > 0 && q < endp && isIndentWS(q))
-                                ++q;
-                            codebuf.remove(p - cast(char*)codebuf.data, q - p);
-                            assert(cast(char*)codebuf.data <= p);
-                            assert(p < cast(char*)codebuf.data + codebuf.offset);
-                            lineStart = false;
-                            endp = cast(char*)codebuf.data + codebuf.offset; // update
-                            continue;
-                        }
-                        if (*p == '\n')
-                            lineStart = true;
-                        ++p;
+                        eollen = 2;
+                        break;
                     }
-                    highlightCode2(sc, a, &codebuf, 0);
-                    buf.remove(iCodeStart, i - iCodeStart);
-                    i = buf.insert(iCodeStart, codebuf.data, codebuf.offset);
-                    i = buf.insert(i, cast(const(char)*)")\n", 2);
-                    i -= 2; // in next loop, c should be '\n'
                 }
-                else
+                // BUG: handle UTF PS and LS too
+                if (c != '-')
+                    goto Lcont;
+            }
+            if (i - istart < 3)
+                goto Lcont;
+            // We have the start/end of a code section
+            // Remove the entire --- line, including blanks and \n
+            buf.remove(iLineStart, i - iLineStart + eollen);
+            i = iLineStart;
+            if (inCode && (i <= iCodeStart))
+            {
+                // Empty code section, just remove it completely.
+                inCode = 0;
+                break;
+            }
+            if (inCode)
+            {
+                inCode = 0;
+                // The code section is from iCodeStart to i
+                OutBuffer codebuf;
+                codebuf.write(buf.data + iCodeStart, i - iCodeStart);
+                codebuf.writeByte(0);
+                // Remove leading indentations from all lines
+                bool lineStart = true;
+                char* endp = cast(char*)codebuf.data + codebuf.offset;
+                for (char* p = cast(char*)codebuf.data; p < endp;)
                 {
-                    static __gshared const(char)* d_code = "$(D_CODE ";
-                    inCode = 1;
-                    codeIndent = istart - iLineStart; // save indent count
-                    i = buf.insert(i, d_code, strlen(d_code));
-                    iCodeStart = i;
-                    i--; // place i on >
-                    leadingBlank = true;
+                    if (lineStart)
+                    {
+                        size_t j = codeIndent;
+                        char* q = p;
+                        while (j-- > 0 && q < endp && isIndentWS(q))
+                            ++q;
+                        codebuf.remove(p - cast(char*)codebuf.data, q - p);
+                        assert(cast(char*)codebuf.data <= p);
+                        assert(p < cast(char*)codebuf.data + codebuf.offset);
+                        lineStart = false;
+                        endp = cast(char*)codebuf.data + codebuf.offset; // update
+                        continue;
+                    }
+                    if (*p == '\n')
+                        lineStart = true;
+                    ++p;
                 }
+                highlightCode2(sc, a, &codebuf, 0);
+                buf.remove(iCodeStart, i - iCodeStart);
+                i = buf.insert(iCodeStart, codebuf.data, codebuf.offset);
+                i = buf.insert(i, cast(const(char)*)")\n", 2);
+                i -= 2; // in next loop, c should be '\n'
+            }
+            else
+            {
+                static __gshared const(char)* d_code = "$(D_CODE ";
+                inCode = 1;
+                codeIndent = istart - iLineStart; // save indent count
+                i = buf.insert(i, d_code, strlen(d_code));
+                iCodeStart = i;
+                i--; // place i on >
+                leadingBlank = true;
             }
             break;
         default:
             leadingBlank = 0;
             if (sc._module.isDocFile || inCode)
                 break;
-
-
-            if(blankLineRun) {
-                // We got to a non-whitespace in a run of blank lines, time
-                // to insert the paragraph break to group two or more newlines
-                // into a paragraph separator
-                immutable ps = "$(DDOC_PARAGRAPH_SEPARATOR)";
-                i = buf.insert(i, ps.ptr, ps.length) - 1;
-            }
-
-            blankLineRun = 0;
 
             char* start = cast(char*)buf.data + i;
             if (isIdStart(start))


### PR DESCRIPTION
This feature inserts `$(DDOC_PARAGRAPH_SEPARATOR)` whenever encountering two newlines or more in the source text.

After some research I figured that this is the right behavior instead of wrapping each paragraph in a DDOC_PARAGRAPH macro. That approach does not work well or at all whenever nesting of macros is present, with two newlines in between. In contrast, a paragraph break is always insertable.

One interesting thing is the `<P>` tag is somewhat special in HTML, due to it being a "mistake" of sorts (it should be a self-closing tag, and it seems to not be due to historical accident). Anyhow HTML does not require `</p>` so we should be fine with paragraph separators as introduced by this feature.

Alternatively, instead of `<p>` we should insert a `<div class="DDOC_PARAGRAPH_SEPARATOR></div>` and let the css choose. For now the macro is defined to nothing and is backwards compatible.
