### PR TITLE
Issue 14349 - String imports with subpaths don't work on Windows

### DIFF
--- a/src/root/filename.d
+++ b/src/root/filename.d
@@ -472,8 +472,10 @@ struct FileName
     {
         version (Windows)
         {
-            /* Disallow % // \\ : and .. in name characters
+            /* Disallow % // \\ : and .. in name characters, also disallows root accrss with \ and / at start of name
              */
+             if (*p == '\\' || *p == '/')
+                return null;
             for (const(char)* p = name; *p; p++)
             {
                 char c = *p;

--- a/src/root/filename.d
+++ b/src/root/filename.d
@@ -472,12 +472,12 @@ struct FileName
     {
         version (Windows)
         {
-            /* Disallow % / \ : and .. in name characters
+            /* Disallow % // \\ : and .. in name characters
              */
             for (const(char)* p = name; *p; p++)
             {
                 char c = *p;
-                if (c == '\\' || c == '/' || c == ':' || c == '%' || (c == '.' && p[1] == '.'))
+                if (c == ':' || c == '%' || (c == '.' && p[1] == '.') || (c == '\\' && p[1] == '\\') || (c == '/' && p[1] == '/'))
                 {
                     return null;
                 }

--- a/src/root/filename.d
+++ b/src/root/filename.d
@@ -472,7 +472,7 @@ struct FileName
     {
         version (Windows)
         {
-            /* Disallow % // \\ : and .. in name characters, also disallows root accrss with \ and / at start of name
+            /* Disallow % // \\ : and .. in name characters, also disallows root across with \ and / at start of name
              */
              if (*p == '\\' || *p == '/')
                 return null;


### PR DESCRIPTION
First pull request I've done. It's quite small.
fixes subpath's for windows (https://issues.dlang.org/show_bug.cgi?id=14349).
To my mind their shouldn't be any security issues with it since it disallows specifying drives and going up directories along with disallowing file server access (//server/share)
