### PR TITLE
Add support for HOST_DMD_FLAGS to posix.mak.

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -53,7 +53,8 @@ ifeq (,$(AUTO_BOOTSTRAP))
   ifeq (,$(HOST_DMD_PATH))
     $(error '$(HOST_DMD)' not found, get a D compiler or make AUTO_BOOTSTRAP=1)
   endif
-  HOST_DMD_RUN:=$(HOST_DMD)
+  HOST_DMD_FLAGS?=
+  HOST_DMD_RUN:=$(HOST_DMD) $(HOST_DMD_FLAGS)
 else
   # Auto-bootstrapping, will download dmd automatically
   HOST_DMD_VER=2.068.2


### PR DESCRIPTION
Rationale: if `dmd.conf` exists in the source tree (e.g., when testing git HEAD dmd without installing it into system directories), then `$HOST_DMD` will incorrectly pick up `./dmd.conf`, making it read the wrong version of druntime/phobos. This PR adds a way to specify custom flags when invoking `$HOST_DMD` so that the appropriate `-conf` flag can be added.

Tacking on the `-conf` flags to the end of `$HOST_DMD` does not work, because `posix.mak` assumes that `$HOST_DMD` is a pathname to an executable, and will wrongly think the host compiler doesn't exist if extra parameters are appended to `$HOST_DMD`.

See also: https://issues.dlang.org/show_bug.cgi?id=14255
