### PR TITLE
Refactor: remove some uses of TARGET_WINDOS

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -671,9 +671,7 @@ typedef struct FUNC_S
         #define Fnteh           0x08    // uses NT Structured EH
         #define Fdoinline       0x40    // do inline walk
         #define Foverridden     0x80    // ignore for overriding purposes
-#if MARS && TARGET_WINDOS
         #define Fjmonitor       0x100   // Mars synchronized function
-#endif
         #define Fnosideeff      0x200   // function has no side effects
         #define F3badoparrow    0x400   // bad operator->()
         #define Fmain           0x800   // function is main() or wmain()

--- a/src/mars.d
+++ b/src/mars.d
@@ -305,9 +305,9 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
     global.params.ddocfiles = new Strings();
     // Default to -m32 for 32 bit dmd, -m64 for 64 bit dmd
     global.params.is64bit = (size_t.sizeof == 8);
+    global.params.mscoff = false;
     static if (TARGET_WINDOS)
     {
-        global.params.mscoff = false;
         global.params.is64bit = false;
         global.params.defaultlibname = "phobos";
     }
@@ -540,7 +540,10 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
             else if (strcmp(p + 1, "m64") == 0)
             {
                 global.params.is64bit = true;
-                global.params.mscoff = true;
+                static if (TARGET_WINDOS)
+                {
+                    global.params.mscoff = true;
+                }
             }
             else if (strcmp(p + 1, "m32mscoff") == 0)
             {


### PR DESCRIPTION
I'd like to get rid of them all at some point.
