### PR TITLE
fix Issue 15519 - Circular imports leads to fwd ref error with aliase…

### DIFF
--- a/test/compilable/test15519_x.d
+++ b/test/compilable/test15519_x.d
@@ -1,0 +1,7 @@
+
+import test15519_y;
+
+extern(C++, ns)
+{
+ class X { test15519_y.ns.Y v; }
+}

--- a/test/compilable/test15519_y.d
+++ b/test/compilable/test15519_y.d
@@ -1,0 +1,8 @@
+
+import test15519_x: NS = ns;            // fails
+//import test15519_x; alias test15519_x.ns NS;  // works
+
+extern(C++, ns)
+{
+ class Y { NS.X v; }
+}

--- a/test/fail_compilation/ice9865.d
+++ b/test/fail_compilation/ice9865.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9865.d(9): Error: struct ice9865.Foo no size yet for forward reference
 fail_compilation/ice9865.d(8): Error: alias ice9865.Baz recursive alias declaration
 ---
 */
+
 import imports.ice9865b : Baz;
 struct Foo { Baz f; }


### PR DESCRIPTION
…d imports

https://issues.dlang.org/show_bug.cgi?id=15519

Chicken or egg? Hopefully this resolves some frustrating errors with circular imports.

Corrected anachronistic use of `->` in debugging printf's.
