### PR TITLE
allow subdirectories on Windows

### DIFF
--- a/src/root/filename.d
+++ b/src/root/filename.d
@@ -513,7 +513,7 @@ struct FileName
             for (const(char)* p = name; *p; p++)
             {
                 char c = *p;
-                if (c == '\\' || c == ':' || c == '%' || (c == '.' && p[1] == '.'))
+                if (c == '\\' || c == ':' || c == '%' || (c == '.' && p[1] == '.') || (c == '/' && p[1] == '/'))
                 {
                     return null;
                 }

--- a/src/root/filename.d
+++ b/src/root/filename.d
@@ -490,7 +490,7 @@ struct FileName
      * ('Path Traversal') attacks.
      *      http://cwe.mitre.org/data/definitions/22.html
      * More info:
-     *      https://www.securecoding.cert.org/confluence/display/seccode/FIO02-C.+Canonicalize+path+names+originating+from+untrusted+sources
+     *      https://www.securecoding.cert.org/confluence/display/c/FIO02-C.+Canonicalize+path+names+originating+from+tainted+sources
      * Returns:
      *      NULL    file not found
      *      !=NULL  mem.xmalloc'd file name
@@ -499,12 +499,21 @@ struct FileName
     {
         version (Windows)
         {
-            /* Disallow % / \ : and .. in name characters
+            // don't allow leading / because it might be an absolute
+            // path or UNC path or something we'd prefer to just not deal with
+            if (*name == '/')
+            {
+                return null;
+            }
+            /* Disallow % \ : and .. in name characters
+             * We allow / for compatibility with subdirectories which is allowed
+             * on dmd/posix. With the leading / blocked above and the rest of these
+             * conservative restrictions, we should be OK.
              */
             for (const(char)* p = name; *p; p++)
             {
                 char c = *p;
-                if (c == '\\' || c == '/' || c == ':' || c == '%' || (c == '.' && p[1] == '.'))
+                if (c == '\\' || c == ':' || c == '%' || (c == '.' && p[1] == '.'))
                 {
                     return null;
                 }

--- a/test/runnable/test37.d
+++ b/test/runnable/test37.d
@@ -6,4 +6,7 @@ import std.stdio;
 void main()
 {
     writefln(import("foo37.txt"));
+    // also want to ensure that we can access
+    // imports in a subdirectory of the -J path
+    writefln(import("std14198/uni.d"));
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14349

I actually think the import restrictions are silly anyway, but this is just too restricting for use and creates a platform incompatibility between Windows and posix. This slight loosening of the rules should let us do the same without really opening anything else up (though even if it does, meh, users can already access files on their own computer so what difference does it make if some random code does too?)
