### PR TITLE
fix Issue 15535 - Disallow "goto default" in final switches.

### DIFF
--- a/src/statement.d
+++ b/src/statement.d
@@ -4246,6 +4246,11 @@ public:
             error("goto default not in switch statement");
             return new ErrorStatement();
         }
+        if (sw.isFinal)
+        {
+            error("goto default not allowed in final switch statement");
+            return new ErrorStatement();
+        }
         return this;
     }
 

--- a/test/fail_compilation/fail15535.d
+++ b/test/fail_compilation/fail15535.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail15535.d(17): Error: goto default not allowed in final switch statement
+---
+*/
+
+void test()
+{
+    int i;
+    switch (i)
+    {
+    case 0:
+        final switch (i)
+        {
+        case 1:
+            goto default;
+        }
+    default:
+        break;
+    }
+}


### PR DESCRIPTION
Add a semantic check for "goto default" statements: check that the default target is defined, i.e. check that the goto default is in a non-final switch.

Bug tracker link: https://issues.dlang.org/show_bug.cgi?id=15535
