### PR TITLE
Backend: leave pretty-printing code in release builds

### DIFF
--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -7134,8 +7134,6 @@ void code_dehydrate(code **pc)
  * Debug code to dump code stucture.
  */
 
-#if DEBUG
-
 void WRcodlst(code *c)
 { for (; c; c = code_next(c))
         c->print();
@@ -7295,6 +7293,5 @@ void code::print()
   }
   printf("\n");
 }
-#endif
 
 #endif // !SPP

--- a/src/backend/debug.c
+++ b/src/backend/debug.c
@@ -1,5 +1,5 @@
 // Copyright (C) 1985-1998 by Symantec
-// Copyright (C) 2000-2012 by Digital Mars
+// Copyright (C) 2000-2016 by Digital Mars
 // All Rights Reserved
 // http://www.digitalmars.com
 // Written by Walter Bright
@@ -9,7 +9,6 @@
  * For any other uses, please contact Digital Mars.
  */
 
-#ifdef DEBUG
 #if !SPP
 
 #include        <stdio.h>
@@ -29,7 +28,7 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
-#define ferr(p) dbg_printf("%s",(p))
+#define ferr(p) printf("%s",(p))
 
 /*******************************
  * Write out storage class.
@@ -54,7 +53,7 @@ char *str_class(enum SC c)
 
 void WRclass(enum SC c)
 {
-    dbg_printf("%11s ",str_class(c));
+    printf("%11s ",str_class(c));
 }
 
 /***************************
@@ -64,7 +63,7 @@ void WRclass(enum SC c)
 void WROP(unsigned oper)
 {
   if (oper >= OPMAX)
-  {     dbg_printf("op = x%x, OPMAX = %d\n",oper,OPMAX);
+  {     printf("op = x%x, OPMAX = %d\n",oper,OPMAX);
         assert(0);
   }
   ferr(debtab[oper]);
@@ -77,30 +76,26 @@ void WROP(unsigned oper)
 
 void WRTYxx(tym_t t)
 {
-#if TX86
     if (t & mTYnear)
-        dbg_printf("mTYnear|");
-#if TARGET_SEGMENTED
+        printf("mTYnear|");
     if (t & mTYfar)
-        dbg_printf("mTYfar|");
+        printf("mTYfar|");
     if (t & mTYcs)
-        dbg_printf("mTYcs|");
-#endif
-#endif
+        printf("mTYcs|");
     if (t & mTYconst)
-        dbg_printf("mTYconst|");
+        printf("mTYconst|");
     if (t & mTYvolatile)
-        dbg_printf("mTYvolatile|");
+        printf("mTYvolatile|");
 #if !MARS && (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
     if (t & mTYtransu)
-        dbg_printf("mTYtransu|");
+        printf("mTYtransu|");
 #endif
     t = tybasic(t);
     if (t >= TYMAX)
-    {   dbg_printf("TY %lx\n",(long)t);
+    {   printf("TY %lx\n",(long)t);
         assert(0);
     }
-    dbg_printf("TY%s ",tystring[tybasic(t)]);
+    printf("TY%s ",tystring[tybasic(t)]);
 }
 
 void WRBC(unsigned bc)
@@ -114,7 +109,7 @@ void WRBC(unsigned bc)
 
     assert(sizeof(bcs) / sizeof(bcs[0]) == BCMAX);
     assert(bc < BCMAX);
-    dbg_printf("BC%s",bcs[bc]);
+    printf("BC%s",bcs[bc]);
 }
 
 /************************
@@ -124,10 +119,10 @@ void WRBC(unsigned bc)
 void WRarglst(list_t a)
 { int n = 1;
 
-  if (!a) dbg_printf("0 args\n");
+  if (!a) printf("0 args\n");
   while (a)
   {     const char* c = (const char*)list_ptr(a);
-        dbg_printf("arg %d: '%s'\n", n, c ? c : "NULL");
+        printf("arg %d: '%s'\n", n, c ? c : "NULL");
         a = a->next;
         n++;
   }
@@ -157,7 +152,7 @@ void WReqn(elem *e)
   }
   else if (e->Eoper == OPcomma && !nest)
   {     WReqn(e->E1);
-        dbg_printf(";\n\t");
+        printf(";\n\t");
         WReqn(e->E2);
   }
   else if (OTbinary(e->Eoper))
@@ -174,7 +169,7 @@ void WReqn(elem *e)
         ferr(" ");
         WROP(e->Eoper);
         if (e->Eoper == OPstreq)
-            dbg_printf("%ld",(long)type_size(e->ET));
+            printf("%ld",(long)type_size(e->ET));
         ferr(" ");
         if (OTbinary(e->E2->Eoper))
         {       nest++;
@@ -196,22 +191,22 @@ void WReqn(elem *e)
                 ferr("#");
                 /* FALL-THROUGH */
             case OPvar:
-                dbg_printf("%s",e->EV.sp.Vsym->Sident);
+                printf("%s",e->EV.sp.Vsym->Sident);
                 if (e->EV.sp.Vsym->Ssymnum != -1)
-                    dbg_printf("(%d)",e->EV.sp.Vsym->Ssymnum);
+                    printf("(%d)",e->EV.sp.Vsym->Ssymnum);
                 if (e->Eoffset != 0)
                 {
                     if (sizeof(e->Eoffset) == 8)
-                        dbg_printf(".x%llx", e->Eoffset);
+                        printf(".x%llx", e->Eoffset);
                     else
-                        dbg_printf(".%ld",(long)e->Eoffset);
+                        printf(".%ld",(long)e->Eoffset);
                 }
                 break;
             case OPasm:
             case OPstring:
-                dbg_printf("\"%s\"",e->EV.ss.Vstring);
+                printf("\"%s\"",e->EV.ss.Vstring);
                 if (e->EV.ss.Voffset)
-                    dbg_printf("+%ld",(long)e->EV.ss.Voffset);
+                    printf("+%ld",(long)e->EV.ss.Voffset);
                 break;
             case OPmark:
             case OPgot:
@@ -236,9 +231,9 @@ void WRblocklist(list_t bl)
         {       register block *b = list_block(bl);
 
                 if (b && b->Bweight)
-                        dbg_printf("B%d (%p) ",b->Bdfoidx,b);
+                        printf("B%d (%p) ",b->Bdfoidx,b);
                 else
-                        dbg_printf("%p ",b);
+                        printf("%p ",b);
         }
         ferr("\n");
 }
@@ -247,9 +242,9 @@ void WRdefnod()
 { register int i;
 
   for (i = 0; i < go.deftop; i++)
-  {     dbg_printf("defnod[%d] in B%d = (", go.defnod[i].DNblock->Bdfoidx, i);
+  {     printf("defnod[%d] in B%d = (", go.defnod[i].DNblock->Bdfoidx, i);
         WReqn(go.defnod[i].DNelem);
-        dbg_printf(");\n");
+        printf(");\n");
   }
 }
 
@@ -273,9 +268,9 @@ void WRFL(enum FL fl)
     };
 
     if ((unsigned)fl >= (unsigned)FLMAX)
-        dbg_printf("FL%d",fl);
+        printf("FL%d",fl);
     else
-      dbg_printf("FL%s",fls[fl]);
+      printf("FL%s",fls[fl]);
 }
 
 /***********************
@@ -287,34 +282,30 @@ void WRblock(block *b)
     if (OPTIMIZER)
     {
         if (b && b->Bweight)
-                dbg_printf("B%d: (%p), weight=%d",b->Bdfoidx,b,b->Bweight);
+                printf("B%d: (%p), weight=%d",b->Bdfoidx,b,b->Bweight);
         else
-                dbg_printf("block %p",b);
+                printf("block %p",b);
         if (!b)
         {       ferr("\n");
                 return;
         }
-        dbg_printf(" flags=x%x weight=%d",b->Bflags,b->Bweight);
-#if 0
-        dbg_printf("\tfile %p, line %d",b->Bfilptr,b->Blinnum);
-#endif
-        dbg_printf(" ");
+        printf(" flags=x%x weight=%d",b->Bflags,b->Bweight);
+        //printf("\tfile %p, line %d",b->Bfilptr,b->Blinnum);
+        printf(" ");
         WRBC(b->BC);
-        dbg_printf(" Btry=%p Bindex=%d",b->Btry,b->Bindex);
-#if SCPP
+        printf(" Btry=%p Bindex=%d",b->Btry,b->Bindex);
         if (b->BC == BCtry)
-            dbg_printf(" catchvar = %p",b->catchvar);
-#endif
-        dbg_printf("\n");
-        dbg_printf("\tBpred: "); WRblocklist(b->Bpred);
-        dbg_printf("\tBsucc: "); WRblocklist(b->Bsucc);
+            printf(" catchvar = %p",b->catchvar);
+        printf("\n");
+        printf("\tBpred: "); WRblocklist(b->Bpred);
+        printf("\tBsucc: "); WRblocklist(b->Bsucc);
         if (b->Belem)
         {       if (debugf)                     /* if full output       */
                         elem_print(b->Belem);
                 else
                 {       ferr("\t");
                         WReqn(b->Belem);
-                        dbg_printf(";\n");
+                        printf(";\n");
                 }
         }
         if (b->Bcode)
@@ -337,9 +328,9 @@ void WRblock(block *b)
             printf(" b_ret=%p", b->BS.BI_FINALLY.b_ret);
 #if MARS
         if (b->Bsrcpos.Sfilename)
-            dbg_printf(" %s(%u)", b->Bsrcpos.Sfilename, b->Bsrcpos.Slinnum);
+            printf(" %s(%u)", b->Bsrcpos.Sfilename, b->Bsrcpos.Slinnum);
 #endif
-        dbg_printf("\n");
+        printf("\n");
         if (b->Belem) elem_print(b->Belem);
         if (b->Bpred)
         {
@@ -355,20 +346,18 @@ void WRblock(block *b)
                 pu = b->BS.Bswitch;
                 assert(pu);
                 ncases = *pu;
-                dbg_printf("\tncases = %d\n",ncases);
-                dbg_printf("\tdefault: %p\n",list_block(bl));
+                printf("\tncases = %d\n",ncases);
+                printf("\tdefault: %p\n",list_block(bl));
                 while (ncases--)
                 {   bl = list_next(bl);
-                    dbg_printf("\tcase %lld: %p\n",*++pu,list_block(bl));
+                    printf("\tcase %lld: %p\n",*++pu,list_block(bl));
                 }
                 break;
             case BCiftrue:
             case BCgoto:
             case BCasm:
-#if SCPP
             case BCtry:
             case BCcatch:
-#endif
             case BCjcatch:
             case BC_try:
             case BC_filter:
@@ -380,9 +369,9 @@ void WRblock(block *b)
             Lsucc:
                 if (bl)
                 {
-                    dbg_printf("\tBsucc:");
+                    printf("\tBsucc:");
                     for ( ; bl; bl = list_next(bl))
-                        dbg_printf(" %p",list_block(bl));
+                        printf(" %p",list_block(bl));
                     printf("\n");
                 }
                 break;
@@ -400,10 +389,9 @@ void WRfunc()
 {
         block *b;
 
-        dbg_printf("func: '%s'\n",funcsym_p->Sident);
+        printf("func: '%s'\n",funcsym_p->Sident);
         for (b = startblock; b; b = b->Bnext)
                 WRblock(b);
 }
 
 #endif /* DEBUG */
-#endif /* !SPP */

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -3145,8 +3145,6 @@ void el_check(elem *e)
  * Write out expression elem.
  */
 
-#ifdef DEBUG
-
 void elem_print(elem *e)
 { static int nestlevel = 0;
   int i;
@@ -3376,8 +3374,6 @@ case_tym:
             /*assert(0);*/
     }
 }
-
-#endif
 
 /**********************************
  * Hydrate an elem.

--- a/src/backend/el.h
+++ b/src/backend/el.h
@@ -205,11 +205,7 @@ void el_opArray(elem ***parray, elem *e, unsigned op);
 void el_opFree(elem *e, unsigned op);
 elem *el_opCombine(elem **args, size_t length, unsigned op, unsigned ty);
 
-#ifdef DEBUG
 void elem_print(elem *);
-#else
-#define elem_print(e)
-#endif
 void elem_print_const(elem *);
 void el_hydrate(elem **);
 void el_dehydrate(elem **);

--- a/src/backend/global.h
+++ b/src/backend/global.h
@@ -21,7 +21,6 @@
 
 #include        "obj.h"
 
-#ifdef DEBUG
 extern char debuga;            /* cg - watch assignaddr()              */
 extern char debugb;            /* watch block optimization             */
 extern char debugc;            /* watch code generated                 */
@@ -37,22 +36,6 @@ extern char debugu;
 extern char debugw;            /* watch progress                       */
 extern char debugx;            /* suppress predefined CPP stuff        */
 extern char debugy;            /* watch output to il buffer            */
-#else
-#define debuga 0
-//#define debugb 0
-//#define debugc 0
-#define debugd 0
-#define debuge 0
-//#define debugf 0
-#define debugg 0
-#define debugo 0
-//#define debugr 0
-#define debugs 0
-#define debugt 0
-#define debugu 0
-//#define debugw 0
-//#define debugy 0
-#endif /* DEBUG */
 
 #define CR '\r'                 // Used because the MPW version of the compiler warps
 #define LF '\n'                 // \n into \r and \r into \n.  The translator version
@@ -445,8 +428,6 @@ void compdfo(void);
 
 #define block_initvar(s) (curblock->Binitvar = (s))
 
-#ifdef DEBUG
-
 /* debug.c */
 extern const char *regstring[];
 
@@ -462,21 +443,6 @@ void WRfunc();
 void WRdefnod();
 void WRFL(enum FL);
 char *sym_ident(SYMIDX si);
-
-#else
-#define WRclass(sc)
-#define WRTYxx(ty)
-#define WROP(oper)
-#define WRBC(bc)
-#define WRarglst(a)
-#define WRblock(b)
-#define WRblocklist(bl)
-#define WReqn(e)
-#define WRfunc()
-#define WRdefnod()
-#define WRFL(fl)
-#define sym_ident(si)
-#endif
 
 /* cgelem.c     */
 elem *doptelem(elem *, goal_t);

--- a/src/backend/var.c
+++ b/src/backend/var.c
@@ -40,9 +40,7 @@ int TYptrdiff = TYint;
 int TYsize = TYuint;
 int TYsize_t = TYuint;
 
-#ifdef DEBUG
 char debuga,debugb,debugc,debugd,debuge,debugf,debugr,debugs,debugt,debugu,debugw,debugx,debugy;
-#endif
 
 #if !MARS
 linkage_t linkage;


### PR DESCRIPTION
The original reason this was left out of release builds was to make the 16 bit compiler as small as possible. That reason evaporated 25 years ago, and it is just inconvenient to not have it there. Besides, it reduces the `# ifdef` hell.
