### PR TITLE
Fix #9476: Support native TLS on Mac OS X

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -2060,6 +2060,12 @@ seg_data *Obj::tlsseg()
     return SegData[obj.tlssegi];
 }
 
+seg_data *Obj::tlsseg_data()
+{
+    // specific for Mach-O
+    assert(0);
+    return NULL;
+}
 
 /********************************
  * Define a far data segment.
@@ -3673,6 +3679,12 @@ void Obj::fltused()
     }
 }
 
+symbol *Obj::tlv_bootstrap()
+{
+    // specific for Mach-O
+    assert(0);
+    return NULL;
+}
 
 /****************************************
  * Find longest match of pattern[] in dict[].

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -1241,7 +1241,7 @@ elem *el_picvar(symbol *s)
             if (I32)
                 e = el_bin(OPadd, TYnptr, e, el_var(el_alloc_localgot()));
 #if 1
-            if (s->Stype->Tty & mTYthread)
+            if (I32 && s->Stype->Tty & mTYthread)
             {
                 if (!tls_get_addr_sym)
                 {
@@ -1257,8 +1257,8 @@ elem *el_picvar(symbol *s)
                 if (op == OPvar)
                     e = el_una(OPind, TYnptr, e);
             }
-            else
 #endif
+            if (I64 || !(s->Stype->Tty & mTYthread))
             {
                 switch (op * 2 + x)
                 {
@@ -1277,6 +1277,54 @@ elem *el_picvar(symbol *s)
                         break;
                 }
             }
+#if 1
+            /**
+             * A thread local variable is outputted like the following D struct:
+             *
+             * struct TLVDescriptor(T)
+             * {
+             *     extern(C) T* function (TLVDescriptor*) thunk;
+             *     size_t key;
+             *     size_t offset;
+             * }
+             *
+             * To access the value of the variable, the variable is accessed
+             * like a plain global (__gshared) variable of the type
+             * TLVDescriptor. The thunk is called and a pointer to the variable
+             * itself is passed as the argument. The return value of the thunk
+             * is a pointer to the value of the thread local variable.
+             *
+             * module foo;
+             *
+             * int bar;
+             * pragma(mangle, "_D3foo3bari") extern __gshared TLVDescriptor!(int) barTLV;
+             *
+             * int a = *barTLV.thunk(&barTLV);
+             */
+            if (I64 && s->Stype->Tty & mTYthread)
+            {
+                e = el_una(OPaddr, TYnptr, e);
+                e = el_bin(OPadd, TYnptr, e, el_long(TYullong, 0));
+                e = el_una(OPind, TYnptr, e);
+                e = el_una(OPind, TYnfunc, e);
+
+                elem *e2 = el_calloc();
+                e2->Eoper = OPvar;
+                e2->EV.sp.Vsym = s;
+                e2->Ety = s->ty();
+                e2->Eoper = OPrelconst;
+                e2->Ety = TYnptr;
+
+                e2 = el_una(OPind, TYnptr, e2);
+                e2 = el_una(OPind, TYnptr, e2);
+                e2 = el_una(OPaddr, TYnptr, e2);
+                e2 = doptelem(e2, GOALvalue | GOALflags);
+                e2 = el_bin(OPadd, TYnptr, e2, el_long(TYullong, 0));
+                e2 = el_bin(OPcall, TYnptr, e, e2);
+                e2 = el_una(OPind, TYint, e2);
+                e = e2;
+            }
+#endif
             e->Ety = tym;
             break;
         }

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -1955,6 +1955,13 @@ seg_data *Obj::tlsseg_bss()
     return SegData[seg_tlsseg_bss];
 }
 
+seg_data *Obj::tlsseg_data()
+{
+    // specific for Mach-O
+    assert(0);
+    return NULL;
+}
+
 
 /*******************************
  * Output an alias definition record.
@@ -3502,6 +3509,13 @@ void Obj::gotref(symbol *s)
         default:
             break;
     }
+}
+
+symbol *Obj::tlv_bootstrap()
+{
+    // specific for Mach-O
+    assert(0);
+    return NULL;
 }
 
 /******************************************

--- a/src/backend/mach.h
+++ b/src/backend/mach.h
@@ -159,6 +159,10 @@ struct section
         #define S_16BYTE_LITERALS               14
         #define S_DTRACE_DOF                    15
 
+        #define S_THREAD_LOCAL_REGULAR          0x11 // template of initial values for TLVs
+        #define S_THREAD_LOCAL_ZEROFILL         0x12 // template of initial values for TLVs
+        #define S_THREAD_LOCAL_VARIABLES        0x13 // TLV descriptors
+
         #define SECTION_ATTRIBUTES_USR          0xFF000000
         #define S_ATTR_PURE_INSTRUCTIONS        0x80000000
         #define S_ATTR_NO_TOC                   0x40000000
@@ -299,6 +303,7 @@ struct relocation_info
             #define X86_64_RELOC_SIGNED_1               6
             #define X86_64_RELOC_SIGNED_2               7
             #define X86_64_RELOC_SIGNED_4               8
+            #define X86_64_RELOC_TLV                    9 // for thread local variables
 };
 
 struct scattered_relocation_info

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -59,6 +59,7 @@
 #define X86_64_RELOC_SIGNED_1           6
 #define X86_64_RELOC_SIGNED_2           7
 #define X86_64_RELOC_SIGNED_4           8
+#define X86_64_RELOC_TLV                9 // for thread local variables
 
 static Outbuffer *fobjbuf;
 
@@ -81,6 +82,7 @@ extern int eh_frame_seg;            // segment of __eh_frame
  */
 
 symbol *GOTsym; // global offset table reference
+symbol *tlv_bootstrap_sym;
 
 symbol *Obj::getGOTsym()
 {
@@ -195,8 +197,29 @@ int seg_data::isCode()
 seg_data **SegData;
 int seg_count;
 int seg_max;
+
+/**
+ * Section index for the __thread_vars/__tls_data section.
+ *
+ * This section is used for the variable symbol for TLS variables.
+ */
 int seg_tlsseg = UNKNOWN;
+
+/**
+ * Section index for the __thread_bss section.
+ *
+ * This section is used for the data symbol ($tlv$init) for TLS variables
+ * without an initializer.
+ */
 int seg_tlsseg_bss = UNKNOWN;
+
+/**
+ * Section index for the __thread_data section.
+ *
+ * This section is used for the data symbol ($tlv$init) for TLS variables
+ * with an initializer.
+ */
+int seg_tlsseg_data = UNKNOWN;
 
 /*******************************************************
  * Because the Mach-O relocations cannot be computed until after
@@ -425,14 +448,16 @@ int Obj::data_readonly(char *p, int len)
 Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
 {
     //printf("Obj::init()\n");
-    MachObj *obj = new MachObj();
+    MachObj *obj = I64 ? new MachObj64() : new MachObj();
 
     cseg = CODE;
     fobjbuf = objbuf;
 
     seg_tlsseg = UNKNOWN;
     seg_tlsseg_bss = UNKNOWN;
+    seg_tlsseg_data = UNKNOWN;
     GOTsym = NULL;
+    tlv_bootstrap_sym = NULL;
 
     // Initialize buffers
 
@@ -1012,7 +1037,9 @@ void Obj::term(const char *objfilename)
                                 s->Sclass == SCcomdat ||
                                 s->Sclass == SCglobal)
                             {
-                                if ((s->Sfl == FLfunc || s->Sfl == FLextern || s->Sclass == SCglobal || s->Sclass == SCcomdat || s->Sclass == SCcomdef) && r->rtype == RELaddr)
+                                if (I64 && (s->ty() & mTYLINK) == mTYthread && r->rtype == RELaddr)
+                                    rel.r_type = X86_64_RELOC_TLV;
+                                else if ((s->Sfl == FLfunc || s->Sfl == FLextern || s->Sclass == SCglobal || s->Sclass == SCcomdat || s->Sclass == SCcomdef) && r->rtype == RELaddr)
                                 {
                                     rel.r_type = X86_64_RELOC_GOT_LOAD;
                                     if (seg == eh_frame_seg ||
@@ -1757,7 +1784,10 @@ int Obj::comdat(Symbol *s)
     {
         s->Sfl = FLtlsdata;
         align = 4;
-        s->Sseg = MachObj::getsegment("__tlscoal_nt", "__DATA", align, S_COALESCED);
+        if (I64)
+            s->Sseg = tlsseg()->SDseg;
+        else
+            s->Sseg = MachObj::getsegment("__tlscoal_nt", "__DATA", align, S_COALESCED);
         Obj::data_start(s, 1 << align, s->Sseg);
     }
     else
@@ -1924,7 +1954,7 @@ int Obj::codeseg(char *name,int suffix)
 }
 
 /*********************************
- * Define segments for Thread Local Storage.
+ * Define segments for Thread Local Storage for 32bit.
  * Output:
  *      seg_tlsseg      set to segment number for TLS segment.
  * Returns:
@@ -1934,12 +1964,10 @@ int Obj::codeseg(char *name,int suffix)
 seg_data *Obj::tlsseg()
 {
     //printf("Obj::tlsseg(\n");
+    assert(I32);
 
     if (seg_tlsseg == UNKNOWN)
-    {
-        int align = I64 ? 4 : 2;            // align to 16 bytes for floating point
-        seg_tlsseg = MachObj::getsegment("__tls_data", "__DATA", align, S_REGULAR);
-    }
+        seg_tlsseg = MachObj::getsegment("__tls_data", "__DATA", 2, S_REGULAR);
     return SegData[seg_tlsseg];
 }
 
@@ -1954,12 +1982,33 @@ seg_data *Obj::tlsseg()
 
 seg_data *Obj::tlsseg_bss()
 {
-    /* Because Mach-O does not support tls, it's easier to support
-     * if we have all the tls in one segment.
+    assert(I32);
+
+    /* Because DMD does not support native tls for Mach-O 32bit,
+     * it's easier to support if we have all the tls in one segment.
      */
     return Obj::tlsseg();
 }
 
+/*********************************
+ * Define segments for Thread Local Storage data.
+ * Output:
+ *      seg_tlsseg_data    set to segment number for TLS data segment.
+ * Returns:
+ *      segment for TLS data segment
+ */
+
+seg_data *Obj::tlsseg_data()
+{
+    //printf("Obj::tlsseg_data(\n");
+    assert(I64);
+
+    // The alignment should actually be alignment of the largest variable in
+    // the section, but this seems to work anyway.
+    if (seg_tlsseg_data == UNKNOWN)
+        seg_tlsseg_data = MachObj::getsegment("__thread_data", "__DATA", 4, S_THREAD_LOCAL_REGULAR);
+    return SegData[seg_tlsseg_data];
+}
 
 /*******************************
  * Output an alias definition record.
@@ -2096,7 +2145,7 @@ int Obj::data_start(Symbol *sdata, targ_size_t datasize, int seg)
 {
     targ_size_t alignbytes;
 
-    //printf("Obj::data_start(%s,size %d,seg %d)\n",sdata->Sident,datasize,seg);
+    //printf("Obj::data_start(%s,size %llu,seg %d)\n",sdata->Sident,datasize,seg);
     //symbol_print(sdata);
 
     assert(sdata->Sseg);
@@ -2359,7 +2408,7 @@ unsigned Obj::bytes(int seg, targ_size_t offset, unsigned nbytes, void *p)
     Outbuffer *buf = SegData[seg]->SDbuf;
     if (buf == NULL)
     {
-        //dbg_printf("Obj::bytes(seg=%d, offset=x%lx, nbytes=%d, p=x%x)\n", seg, offset, nbytes, p);
+        //dbg_printf("Obj::bytes(seg=%d, offset=x%llx, nbytes=%d, p=%p)\n", seg, offset, nbytes, p);
         //raise(SIGSEGV);
 if (!buf) halt();
         assert(buf != NULL);
@@ -2800,6 +2849,61 @@ void Obj::gotref(symbol *s)
         default:
             break;
     }
+}
+
+/**
+ * Returns the symbol for the __tlv_bootstrap function.
+ *
+ * This function is used in the implementation of native thread local storage.
+ * It's used as a placeholder in the TLV descriptors. The dynamic linker will
+ * replace the placeholder with a real function at load time.
+ */
+symbol *Obj::tlv_bootstrap()
+{
+    if (!tlv_bootstrap_sym)
+        tlv_bootstrap_sym = symbol_name("__tlv_bootstrap", SCextern, type_fake(TYnfunc));
+    return tlv_bootstrap_sym;
+}
+
+MachObj64::MachObj64()
+{
+    assert(I64);
+}
+
+/*********************************
+ * Define segments for Thread Local Storage variables.
+ * Output:
+ *      seg_tlsseg      set to segment number for TLS variables segment.
+ * Returns:
+ *      segment for TLS variables segment
+ */
+
+seg_data *MachObj64::tlsseg()
+{
+    //printf("MachObj64::tlsseg(\n");
+
+    if (seg_tlsseg == UNKNOWN)
+        seg_tlsseg = MachObj::getsegment("__thread_vars", "__DATA", 0, S_THREAD_LOCAL_VARIABLES);
+    return SegData[seg_tlsseg];
+}
+
+/*********************************
+ * Define segments for Thread Local Storage.
+ * Output:
+ *      seg_tlsseg_bss  set to segment number for TLS data segment.
+ * Returns:
+ *      segment for TLS segment
+ */
+
+seg_data *MachObj64::tlsseg_bss()
+{
+    //printf("MachObj64::tlsseg_bss(\n");
+
+    // The alignment should actually be alignment of the largest variable in
+    // the section, but this seems to work anyway.
+    if (seg_tlsseg_bss == UNKNOWN)
+        seg_tlsseg_bss = MachObj::getsegment("__thread_bss", "__DATA", 3, S_THREAD_LOCAL_ZEROFILL);
+    return SegData[seg_tlsseg_bss];
 }
 
 /******************************************

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -816,7 +816,7 @@ void Obj::term(const char *objfilename)
                     continue;
 
                 int align = 1 << psechdr->align;
-                while (align < pseg->SDalignment)
+                while (psechdr->align > 0 && align < pseg->SDalignment)
                 {
                     psechdr->align += 1;
                     align <<= 1;
@@ -854,7 +854,7 @@ void Obj::term(const char *objfilename)
                     continue;
 
                 int align = 1 << psechdr->align;
-                while (align < pseg->SDalignment)
+                while (psechdr->align > 0 && align < pseg->SDalignment)
                 {
                     psechdr->align += 1;
                     align <<= 1;

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -1522,6 +1522,13 @@ seg_data *MsCoffObj::tlsseg_bss()
     return MsCoffObj::tlsseg();
 }
 
+seg_data *MsCoffObj::tlsseg_data()
+{
+    // specific for Mach-O
+    assert(0);
+    return NULL;
+}
+
 /*************************************
  * Return segment indices for .pdata and .xdata sections
  */
@@ -2355,6 +2362,12 @@ void MsCoffObj::setcodeseg(int seg)
     cseg = seg;
 }
 
+symbol *MsCoffObj::tlv_bootstrap()
+{
+    // specific for Mach-O
+    assert(0);
+    return NULL;
+}
 
 #endif
 #endif

--- a/src/backend/obj.h
+++ b/src/backend/obj.h
@@ -52,11 +52,12 @@ struct Obj
     VIRTUAL void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
     VIRTUAL void ehsections();
     VIRTUAL void moduleinfo(Symbol *scc);
-    VIRTUAL int  comdat(Symbol *);
-    VIRTUAL int  comdatsize(Symbol *, targ_size_t symsize);
+    virtual int  comdat(Symbol *);
+    virtual int  comdatsize(Symbol *, targ_size_t symsize);
     VIRTUAL void setcodeseg(int seg);
-    VIRTUAL seg_data *tlsseg();
-    VIRTUAL seg_data *tlsseg_bss();
+    virtual seg_data *tlsseg();
+    virtual seg_data *tlsseg_bss();
+    VIRTUAL seg_data *tlsseg_data();
     static int  fardata(char *name, targ_size_t size, targ_size_t *poffset);
     VIRTUAL void export_symbol(Symbol *s, unsigned argsize);
     VIRTUAL void pubdef(int seg, Symbol *s, targ_size_t offset);
@@ -85,6 +86,8 @@ struct Obj
     VIRTUAL symbol *sym_cdata(tym_t, char *, int);
     VIRTUAL void func_start(Symbol *sfunc);
     VIRTUAL void func_term(Symbol *sfunc);
+
+    VIRTUAL symbol *tlv_bootstrap();
 
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     static unsigned addstr(Outbuffer *strtab, const char *);
@@ -117,6 +120,14 @@ struct MachObj : Obj
         unsigned targseg, int rtype, int val = 0);
 };
 
+struct MachObj64 : MachObj
+{
+    MachObj64();
+
+    seg_data *tlsseg();
+    seg_data *tlsseg_bss();
+};
+
 struct MsCoffObj : Obj
 {
     static MsCoffObj *init(Outbuffer *, const char *filename, const char *csegname);
@@ -146,11 +157,12 @@ struct MsCoffObj : Obj
     VIRTUAL void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
     VIRTUAL void ehsections();
     VIRTUAL void moduleinfo(Symbol *scc);
-    VIRTUAL int  comdat(Symbol *);
-    VIRTUAL int  comdatsize(Symbol *, targ_size_t symsize);
+    virtual int  comdat(Symbol *);
+    virtual int  comdatsize(Symbol *, targ_size_t symsize);
     VIRTUAL void setcodeseg(int seg);
-    VIRTUAL seg_data *tlsseg();
-    VIRTUAL seg_data *tlsseg_bss();
+    virtual seg_data *tlsseg();
+    virtual seg_data *tlsseg_bss();
+    virtual seg_data *tlsseg_data();
     VIRTUAL void export_symbol(Symbol *s, unsigned argsize);
     VIRTUAL void pubdef(int seg, Symbol *s, targ_size_t offset);
     VIRTUAL void pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize);
@@ -198,6 +210,8 @@ struct MsCoffObj : Obj
     static int seg_debugS();
     VIRTUAL int seg_debugT();
     static int seg_debugS_comdat(Symbol *sfunc);
+
+    VIRTUAL symbol *tlv_bootstrap();
 };
 
 #undef VIRTUAL

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -184,6 +184,8 @@ void outdata(symbol *s)
                             s->Sfl = FLcsdata;
                             break;
 #endif
+                        case mTYthreadData:
+                            assert(config.objfmt == OBJ_MACH && I64);
                         case mTYthread:
                         {   seg_data *pseg = objmod->tlsseg_bss();
                             s->Sseg = pseg->SDseg;
@@ -287,6 +289,17 @@ void outdata(symbol *s)
             s->Sfl = FLcsdata;
             break;
 #endif
+        case mTYthreadData:
+        {
+            assert(config.objfmt == OBJ_MACH && I64);
+
+            seg_data *pseg = objmod->tlsseg_data();
+            s->Sseg = pseg->SDseg;
+            objmod->data_start(s, datasize, s->Sseg);
+            seg = pseg->SDseg;
+            s->Sfl = FLtlsdata;
+            break;
+        }
         case mTYthread:
         {
             seg_data *pseg = objmod->tlsseg();

--- a/src/backend/ty.h
+++ b/src/backend/ty.h
@@ -131,6 +131,9 @@ extern int TYptrdiff, TYsize, TYsize_t;
 #define mTYfar          0x1000           // seg:offset style pointer
 #define mTYcs           0x2000           // in code segment
 #define mTYthread       0x4000
+
+/// Used for symbols going in the __thread_data section for TLS variables for Mach-O 64bit
+#define mTYthreadData   0x5000
 #define mTYLINK         0x7800           // all linkage bits
 
 #define mTYloadds       0x08000          // 16 bit Windows LOADDS attribute

--- a/src/root/port.d
+++ b/src/root/port.d
@@ -121,6 +121,50 @@ extern (C++) struct Port
         return t;
     }
 
+    /**
+     * Concatenates the two given strings.
+     *
+     * Params:
+     *      str1 = the first string
+     *      str1Len = the length of the first string
+     *      str2 = the second string
+     *      str1Len = the length of the second string
+     *
+     * Returns: a new string which is the concatenation of the two strings
+     */
+    static char* concat(in char* str1, uint str1Len, in char* str2, uint str2Len)
+    {
+        import core.stdc.stdlib;
+
+        // Ensure we have a long-enough buffer for the symbol name. Previous buffer is reused.
+        __gshared static char* result = null;
+        __gshared static size_t sdim = 0;
+
+        if (str1Len + str2Len + 1 >= sdim)
+        {
+            sdim = str1Len + str2Len + 12;
+            result = cast(char*) realloc(result, sdim);
+        }
+
+        memmove(result, str1, str1Len);
+        memmove(result + str1Len, str2, str2Len);
+        result[str2Len + str1Len] = 0;
+
+        return result;
+    }
+
+    ///
+    unittest
+    {
+        auto str1 = "foo";
+        auto str2 = "bar";
+
+        auto result = concat(str1.ptr, cast(uint) str1.length, str2.ptr, cast(uint) str2.length);
+        auto dString = result[0 .. str1.length + str2.length];
+
+        assert(dString == "foobar");
+    }
+
     static int isSignallingNan(double r)
     {
         return isNan(r) && !(((cast(ubyte*)&r)[6]) & 8);

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -61,6 +61,7 @@ struct Port
     static void yl2xp1_impl(longdouble* x, longdouble* y, longdouble* res);
 
     static char *strupr(char *);
+    static char *concat(const char *str1, unsigned int str1Len, const char *str2, unsigned int str2Len);
 
     static int memicmp(const char *s1, const char *s2, int n);
     static int stricmp(const char *s1, const char *s2);

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -174,6 +174,9 @@ Symbol *toSymbol(Dsymbol *s)
                     type_setty(&t, t->Tty | mTYthread);
                     ts->Tcount--;
 
+                    if (config.objfmt == OBJ_MACH && I64)
+                        s->Salignment = 2;
+
                     if (global.params.vtls)
                     {
                         const char *p = vd->loc.toChars();
@@ -227,6 +230,7 @@ Symbol *toSymbol(Dsymbol *s)
                     m = mTYman_pas;
                     break;
 
+                case LINKobjc:
                 case LINKc:
                     m = mTYman_c;
                     break;


### PR DESCRIPTION
This currently only works on 64bit. I created this PR anyway to get some code review for the changes.

For 32bit, there are three options, see discussions as well [1] [2]:
- ~~Drop it completely~~
- Continue using emulated TLS :heavy_check_mark: 
- ~~Implement a working native TLS. I'm suspecting there just some issue with how the instructions are generate for accessing a TLS variable that causes a segmentation fault. Otherwise both 32 and 64bit uses the same implementation~~

Runtime part: https://github.com/D-Programming-Language/druntime/pull/1461.

[1] http://forum.dlang.org/thread/n6u3e8$1u0b$1@digitalmars.com
[2] http://forum.dlang.org/thread/8125593F-344A-4A46-BB84-57E251EB9CB6@me.com
