### PR TITLE
Add html doc build for dmd

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -20,6 +20,9 @@ clean:
 test:
 	$(QUIET)$(MAKE) -C test -f Makefile
 
+html:
+	$(QUIET)$(MAKE) -C src -f posix.mak html
+
 # Creates Exuberant Ctags tags file
 tags: posix.mak $(ECTAGS_FILES)
 	ctags --sort=yes --links=no --excmd=number --languages=$(ECTAGS_LANGS) \

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -477,4 +477,14 @@ zip:
 
 #############################
 
+ifneq ($(DOCDIR),)
+html: $(DOCDIR)/.generated
+$(DOCDIR)/.generated: $(DMD_SRCS) $(ROOT_SRCS) $(HOST_DMD_PATH)
+	$(HOST_DMD_RUN) -of- $(MODEL_FLAG) -J. -c -Dd$(DOCDIR)\
+	  $(DFLAGS) $(DOCFMT) $(DMD_SRCS) $(ROOT_SRCS)
+	touch $@
+endif
+
+######################################################
+
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
This initiates an "html" target for building dmd docs. PR for dlang.org forthcoming.
