### PR TITLE
Fix problematic tests for GDC's testsuite

### DIFF
--- a/test/compilable/iasm_labeloperand.d
+++ b/test/compilable/iasm_labeloperand.d
@@ -1,4 +1,4 @@
-﻿
+
 version (D_InlineAsm_X86)
     version = TestInlineAsm;
 else version (D_InlineAsm_X86_64)

--- a/test/runnable/builtin.d
+++ b/test/runnable/builtin.d
@@ -3,10 +3,13 @@ import std.stdio;
 import std.math;
 import core.bitop;
 
-version (X86_64)
-    version = AnyX86;
-else version (X86)
-    version = AnyX86;
+version (DigitalMars)
+{
+    version (X86_64)
+        version = AnyX86;
+    else version (X86)
+        version = AnyX86;
+}
 
 /*******************************************/
 

--- a/test/runnable/casting.d
+++ b/test/runnable/casting.d
@@ -211,19 +211,22 @@ void test14218()
         assert(x == 0);     // false, '0x00'
     }
 
-    // Questionable but currently accepted
-    foreach (To; Seq!( float,  double,  real,
-                      ifloat, idouble, ireal))
+    version (DigitalMars)
     {
-        auto x = cast(To)null;
-        assert(x == 0);     // 0i
-    }
+        // Questionable but currently accepted by DMD (but not GDC).
+        foreach (To; Seq!( float,  double,  real,
+                           ifloat, idouble, ireal))
+        {
+            auto x = cast(To)null;
+            assert(x == 0);     // 0i
+        }
 
-    // Internal error: backend/el.c in el_long()
-    //foreach (To; Seq!(cfloat, cdouble, creal))
-    //{
-    //    static assert(!__traits(compiles, { auto x = cast(To)null; }));
-    //}
+        // Internal error: backend/el.c in el_long()
+        //foreach (To; Seq!(cfloat, cdouble, creal))
+        //{
+        //    static assert(!__traits(compiles, { auto x = cast(To)null; }));
+        //}
+    }
 }
 
 /***************************************************/

--- a/test/runnable/untag.d
+++ b/test/runnable/untag.d
@@ -1,4 +1,3 @@
-#!/home/aalexandre/dmd2/linux/bin/rdmd
 // PERMUTE_ARGS:
 
 import std.algorithm, std.ascii, std.conv, std.exception,


### PR DESCRIPTION
These lines are problematic gdc testsuite (we inject dejagnu options to replace d_do_test ones).

```
--- a/test/compilable/iasm_labeloperand.d
+++ b/test/compilable/iasm_labeloperand.d
@@ -1,4 +1,4 @@
-<U+FEFF>
+
```
