### PR TITLE
Fix Mem::xstrdup C++ function signature to match the D source.

### DIFF
--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -16,7 +16,7 @@ version (GC)
 
     extern (C++) struct Mem
     {
-        char* xstrdup(const char* p)
+        char* xstrdup(const(char)* p)
         {
             return p[0 .. strlen(p) + 1].dup.ptr;
         }
@@ -50,7 +50,7 @@ else
 
     extern (C++) struct Mem
     {
-        char* xstrdup(const char* s)
+        char* xstrdup(const(char)* s)
         {
             if (s)
             {


### PR DESCRIPTION
Note that `const` in the D signature `char* xstrdup(const char* p)` is transitive, so an extra const is needed for the C++ head const system.

(ran into this problem while merging DMD v2.069.2 into LDC)
