### PR TITLE
Fix Issue 10996 - Add a test for private member exposed via alias this

### DIFF
--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1542,6 +1542,22 @@ struct S10456
 }
 
 /***************************************************/
+// 10996
+
+void test10996()
+{
+    S10996 s;
+    assert("Hello world" == s, s);
+}
+
+struct S10996
+{
+    private string getPrivateData () { return "Hello world"; }
+    alias getPrivateData this;
+}
+
+
+/***************************************************/
 // 11261
 
 template Tuple11261(Specs...)
@@ -1994,6 +2010,7 @@ int main()
     test10004();
     test10180();
     test10456();
+    test10996();
     test11333();
     test11800();
     test13490();


### PR DESCRIPTION
This issue was fixed ages ago (< 2.066), but the matching bug report
was never closed, and there is no test for it so it is possible it
was a byproduct of another bugfix.

https://issues.dlang.org/show_bug.cgi?id=10996
