### PR TITLE
Add D_IP32 version condition.

### DIFF
--- a/src/cond.d
+++ b/src/cond.d
@@ -258,6 +258,7 @@ public:
             "D_InlineAsm_X86",
             "D_InlineAsm_X86_64",
             "D_LP64",
+            "D_IP32",
             "D_X32",
             "D_HardFloat",
             "D_SoftFloat",

--- a/src/mars.d
+++ b/src/mars.d
@@ -1996,6 +1996,9 @@ private void addDefaultVersionIdentifiers()
 
     if (global.params.isLP64)
         VersionCondition.addPredefinedGlobalIdent("D_LP64");
+    else
+        VersionCondition.addPredefinedGlobalIdent("D_IP32");
+
     if (global.params.doDocComments)
         VersionCondition.addPredefinedGlobalIdent("D_Ddoc");
     if (global.params.cov)

--- a/test/compilable/ptrsize.d
+++ b/test/compilable/ptrsize.d
@@ -1,0 +1,34 @@
+// PERMUTE_ARGS:
+
+/*
+Each of the version identifiers below specifies a combination
+of pointer size and machine word size. This test will verify
+that the set identifier matches the actual pointer size.
+*/
+
+version (D_IP32)
+{
+    static assert (size_t.sizeof == 4);
+    enum dip32 = 1;
+}
+else
+    enum dip32 = 0;
+
+version (D_X32)
+{
+    static assert (size_t.sizeof == 4);
+    enum dx32 = 1;
+}
+else
+    enum dx32 = 0;
+
+version (D_LP64)
+{
+    static assert (size_t.sizeof == 8);
+    enum dlp64 = 1;
+}
+else
+    enum dlp64 = 0;
+
+// one and only one should be set at a time:
+static assert ((dip32 + dx32 + dlp64) == 1);


### PR DESCRIPTION
I saw someone writing this:

``` D
version (D_LP64) { } else {
    // 32-bit stuff goes here
}
```

And took that as a sign that we ought to have an explicit `version` identifier `D_IP32`. This will allow people to explicitly differentiate between 32-bit code, and "not 64-bit" code.

I have also submitted [PR #1220 for dlang.org](https://github.com/D-Programming-Language/dlang.org/pull/1220) to update the spec appropriately.

**EDIT:** Renamed from `D_LP32` to `D_IP32`.
