### PR TITLE
test/fail_compilation/lexer2.d: Use `__VENDOR__` instead of `__VERSION__`

### DIFF
--- a/test/fail_compilation/lexer2.d
+++ b/test/fail_compilation/lexer2.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/lexer2.d(15): Error: odd number (3) of hex characters in hex string
 fail_compilation/lexer2.d(16): Error: non-hex character 'G' in hex string
-fail_compilation/lexer2.d(17): Error: identifier expected for heredoc, not 2070L
+fail_compilation/lexer2.d(17): Error: identifier expected for heredoc, not "Digital Mars D"
 fail_compilation/lexer2.d(19): Error: heredoc rest of line should be blank
 fail_compilation/lexer2.d(21): Error: unterminated delimited string constant starting at fail_compilation/lexer2.d(21)
 fail_compilation/lexer2.d(23): Error: semicolon expected following auto declaration, not 'EOF'
@@ -14,7 +14,7 @@ fail_compilation/lexer2.d(23): Error: semicolon expected following auto declarat
 
 static s1 = x"123";
 static s2 = x"123G";
-static s3 = q"__VERSION__
+static s3 = q"__VENDOR__
  _";
 static s4 = q"here notblank
 here";


### PR DESCRIPTION
`__VERSION__` will change often (every release), and having to fix this test
every time is an useless maintenance cost.  Instead, we use `__VENDOR__`, which
is a token that won't change.

See D-Programming-Language/dmd#5378 for the problems it can create

Ping @WalterBright 
