### PR TITLE
avoid duplicate symbols with cppa test

### DIFF
--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -396,7 +396,7 @@ void test13955()
 
 extern(C++) class C13161
 {
-    void dummyfunc() {}
+    void dummyfunc();
     long val_5;
     uint val_9;
 }
@@ -411,7 +411,7 @@ extern(C++) size_t getoffset13161();
 
 extern(C++) class C13161a
 {
-    void dummyfunc() {}
+    void dummyfunc();
     c_long_double val_5;
     uint val_9;
 }


### PR DESCRIPTION
The runnable/cppa test does not link with LDC for Win32/Win64 due to multiply defined symbols in the C++ and the D code.
I suspect having an empty definition in both files is an oversight, not a deliberate decision. Are destructor definitions for extern(C++) classes meant to be supported?
