### PR TITLE
fix Issue 15644 - Switch object layout ABI to MI style

### DIFF
--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1162,8 +1162,7 @@ public:
         }
 
         // Add vptr's for any interfaces implemented by this class
-        if (cpp)
-            structsize += setBaseInterfaceOffsets(structsize);
+        structsize += setBaseInterfaceOffsets(structsize);
 
         uint offset = structsize;
         for (size_t i = 0; i < members.dim; i++)
@@ -1173,10 +1172,6 @@ public:
         }
         if (sizeok == SIZEOKfwd)
             return;
-
-        // Add vptr's for any interfaces implemented by this class
-        if (!cpp)
-            structsize += setBaseInterfaceOffsets(structsize);
 
         sizeok = SIZEOKdone;
 

--- a/test/compilable/test15618.d
+++ b/test/compilable/test15618.d
@@ -16,4 +16,4 @@ class Derived : Base, Interface
 }
 
 static assert(Derived.x.offsetof == (void*).sizeof * 2);
-static assert(Derived.y.offsetof == (void*).sizeof * 3);
+static assert(Derived.y.offsetof == (void*).sizeof * 4);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15644

C++ MI style lays out objects left-to-right, top-to-bottom. This switches to this style.

This is a binary ABI change, and will require recompilation of code with interfaces.

Will follow up with a change to the D ABI spec.
