### PR TITLE
Refactor: Add Expression.checkType to disthinguish two similar error checks

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -174,6 +174,7 @@ public:
         return ::castTo(this, sc, t);
     }
     virtual Expression *resolveLoc(Loc loc, Scope *sc);
+    virtual bool checkType();
     virtual bool checkValue();
     bool checkScalar();
     bool checkNoBool();
@@ -512,6 +513,7 @@ public:
     TypeExp(Loc loc, Type *type);
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
+    bool checkType();
     bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -536,6 +538,7 @@ public:
     TemplateExp(Loc loc, TemplateDeclaration *td, FuncDeclaration *fd = NULL);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
+    bool checkType();
     bool checkValue();
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -653,6 +656,7 @@ public:
     Expression *semantic(Scope *sc, Expressions *arguments);
     MATCH matchType(Type *to, Scope *sc, FuncExp **pfe, int flag = 0);
     char *toChars();
+    bool checkType();
     bool checkValue();
 
     void accept(Visitor *v) { v->visit(this); }

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7530,28 +7530,18 @@ public:
         exp = resolvePropertiesOnly(sc2, exp);
         sc2.pop();
 
-        if (exp.op == TOKtype)
+        if (exp.op == TOKtype ||
+            exp.op == TOKscope)
         {
-            error(loc, "argument %s to typeof is not an expression", exp.toChars());
-            goto Lerr;
-        }
-        if (exp.op == TOKscope)
-        {
-            auto sds = (cast(ScopeExp)exp).sds;
-            if (sds.isPackage())
-            {
-                error(loc, "%s has no type", exp.toChars());
+            if (exp.checkType())
                 goto Lerr;
-            }
-            if (auto ti = sds.isTemplateInstance())
-            {
-                if (ti.needsTypeInference(sc))
-                {
-                    // Bugzilla 15550: ti is a partial instantiation form fun!tiargs.
-                    error(loc, "expression (%s) has no type", exp.toChars());
-                    goto Lerr;
-                }
-            }
+
+            /* Today, 'typeof(func)' returns void if func is a
+             * function template (TemplateExp), or
+             * template lambda (FuncExp).
+             * It's actually used in Phobos as an idiom, to branch code for
+             * template functions.
+             */
         }
 
         Type t = exp.type;

--- a/src/statement.d
+++ b/src/statement.d
@@ -4424,15 +4424,8 @@ public:
 
             exp = exp.semantic(sc);
             exp = resolveProperties(sc, exp);
-            if (exp.type && exp.type.ty != Tvoid ||
-                exp.op == TOKfunction ||
-                exp.op == TOKtype ||
-                exp.op == TOKtemplate)
-            {
-                // don't make error for void expression
-                if (exp.checkValue())
-                    exp = new ErrorExp();
-            }
+            if (exp.checkType())
+                exp = new ErrorExp();
             if (checkNonAssignmentArrayOp(exp))
                 exp = new ErrorExp();
 

--- a/test/fail_compilation/diag11727.d
+++ b/test/fail_compilation/diag11727.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11727.d(10): Error: type n has no value
+fail_compilation/diag11727.d(10): Error: type n is not an expression
 ---
 */
 auto returnEnum()
@@ -17,7 +17,7 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11727.d(26): Error: type void has no value
+fail_compilation/diag11727.d(26): Error: type void is not an expression
 ---
 */
 auto returnVoid()
@@ -29,7 +29,7 @@ auto returnVoid()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11727.d(38): Error: template t() has no value
+fail_compilation/diag11727.d(38): Error: template t() has no type
 ---
 */
 auto returnTemplate()

--- a/test/fail_compilation/fail15550.d
+++ b/test/fail_compilation/fail15550.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15550.d(25): Error: expression (foo!int) has no type
-fail_compilation/fail15550.d(26): Error: expression (opDispatch!"_isMatrix") has no type
-fail_compilation/fail15550.d(27): Error: expression (baz!"_isMatrix") has no type
+fail_compilation/fail15550.d(25): Error: partial template instance foo!int has no type
+fail_compilation/fail15550.d(26): Error: partial template instance opDispatch!"_isMatrix" has no type
+fail_compilation/fail15550.d(27): Error: partial template instance baz!"_isMatrix" has no type
 ---
 */
 

--- a/test/fail_compilation/fail240.d
+++ b/test/fail_compilation/fail240.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail240.d(9): Error: argument F to typeof is not an expression
+fail_compilation/fail240.d(9): Error: type F is not an expression
 ---
 */
 

--- a/test/fail_compilation/fail248.d
+++ b/test/fail_compilation/fail248.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail248.d(9): Error: argument int to typeof is not an expression
+fail_compilation/fail248.d(9): Error: type int is not an expression
 ---
 */
 

--- a/test/fail_compilation/fail325.d
+++ b/test/fail_compilation/fail325.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail325.d(12): Error: template fun(T = int)(int w, int z) has no value
+fail_compilation/fail325.d(12): Error: template fun(T = int)(int w, int z) has no type
 ---
 */
 

--- a/test/fail_compilation/fail_casting2.d
+++ b/test/fail_compilation/fail_casting2.d
@@ -3,9 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting2.d(15): Error: type int has no value
-fail_compilation/fail_casting2.d(17): Error: template lambda has no value
-fail_compilation/fail_casting2.d(20): Error: template Templ() has no value
+fail_compilation/fail_casting2.d(15): Error: type int is not an expression
+fail_compilation/fail_casting2.d(17): Error: template lambda has no type
+fail_compilation/fail_casting2.d(20): Error: template Templ() has no type
 ---
 */
 

--- a/test/fail_compilation/ice12907.d
+++ b/test/fail_compilation/ice12907.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12907.d(10): Error: template lambda has no value
+fail_compilation/ice12907.d(10): Error: template lambda has no type
 ---
 */
 


### PR DESCRIPTION
Many expressions takes non-void valid expressions. To check it, `Expression.checkValue` exists (before it had been called `Expression.rvalue()`).

However, `ReturnStatement` and `CastExp` take an expression which can be void. In both cases they will reject same invalid expressions, but the two are not same.

Name it `checkType`, then use it to make language behavior clearer.

Additional notes:
1. In `CastExp.semanic`, if `to` is specified, it's analyzed before the `e1`, in order to call `inferType(e1, to)` for explicit template lambda instantiations.
2. In `TypeTypeof.resolve`, we cannot easily use `checkType`, because historically templates are accepted as a typeof operand.
