### PR TITLE
fix Issue 15626 - extern(C++) calling crash

### DIFF
--- a/src/dclass.d
+++ b/src/dclass.d
@@ -772,6 +772,11 @@ public:
             // initialize vtbl
             if (baseClass)
             {
+                if (cpp && baseClass.vtbl.dim == 0)
+                {
+                    error("C++ base class %s needs at least one virtual function", baseClass.toChars());
+                }
+
                 // Copy vtbl[] from base class
                 vtbl.setDim(baseClass.vtbl.dim);
                 memcpy(vtbl.tdata(), baseClass.vtbl.tdata(), (void*).sizeof * vtbl.dim);

--- a/test/fail_compilation/fail15626.d
+++ b/test/fail_compilation/fail15626.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail15626.d(12): Error: class fail15626.D C++ base class C needs at least one virtual function
+---
+*/
+
+extern (C++)
+{
+    class C { }
+    interface I { void f(); }
+    class D : C, I
+    {
+        void f() { }
+    }
+}

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1053,7 +1053,7 @@ void test15579()
 extern(C++) class Base2
 {
     int i;
-//    void baser() { }
+    void baser() { }
 }
 
 extern(C++) interface Interface2 { abstract void f(); }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -662,7 +662,7 @@ class Base2
 {
   public:
     int i;
-//    virtual void baser();
+    virtual void baser() { }
 };
 
 class Interface2


### PR DESCRIPTION
Supporting this requires support for C++ multiple inheritance. DMD isn't ready for that yet, so at least an error message is generated instead of a crash at app runtime.
