### PR TITLE
[REG 2.067] Issue 15490 - Error variable __nrvoretval cannot be modified at compile time when using -inline

### DIFF
--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -4916,9 +4916,13 @@ public:
             istate = &istateComma;
         }
         result = CTFEExp.cantexp;
+
         // If the comma returns a temporary variable, it needs to be an lvalue
         // (this is particularly important for struct constructors)
-        if (e.e1.op == TOKdeclaration && e.e2.op == TOKvar && (cast(DeclarationExp)e.e1).declaration == (cast(VarExp)e.e2).var && (cast(VarExp)e.e2).var.storage_class & STCctfe) // same as Expression::isTemp
+        if (e.e1.op == TOKdeclaration &&
+            e.e2.op == TOKvar &&
+            (cast(DeclarationExp)e.e1).declaration == (cast(VarExp)e.e2).var &&
+            (cast(VarExp)e.e2).var.storage_class & STCctfe)
         {
             VarExp ve = cast(VarExp)e.e2;
             VarDeclaration v = ve.var.isVarDeclaration();

--- a/src/inline.d
+++ b/src/inline.d
@@ -2116,7 +2116,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
         else
         {
             Identifier tmp = Identifier.generateId("__nrvoretval");
-            auto vd = new VarDeclaration(fd.loc, fd.nrvo_var.type, tmp, null);
+            auto vd = new VarDeclaration(fd.loc, fd.nrvo_var.type, tmp, new VoidInitializer(fd.loc));
             assert(!tf.isref);
             vd.storage_class = STCtemp | STCrvalue;
             vd.linkage = tf.linkage;

--- a/test/compilable/imports/imp15490a.d
+++ b/test/compilable/imports/imp15490a.d
@@ -1,0 +1,8 @@
+module imports.imp15490a;
+
+import imports.imp15490b;
+
+void listenTCP()
+{
+    enum r = regex();
+}

--- a/test/compilable/imports/imp15490b.d
+++ b/test/compilable/imports/imp15490b.d
@@ -1,0 +1,12 @@
+module imports.imp15490b;
+
+int regex()
+{
+    return regexImpl();
+}
+
+auto regexImpl()
+{
+    int r = 0;
+    return r;
+}

--- a/test/compilable/test15490.d
+++ b/test/compilable/test15490.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -o- -inline
+// PERMUTE_ARGS:
+module test15490;
+
+import imports.imp15490a;
+import imports.imp15490b;
+
+void main()
+{
+    regex();
+    listenTCP();
+}


### PR DESCRIPTION
CTFE interpretr can recognize a form `CommaExp(DeclaraationExp(v), VarExp(v))` as a CTFEable variable declaration when `v._init` is `null`. In other cases, for examle a sole `DeclarationExp` should have v._init for CTFE-ability.

Supply `VoidInitializer` to allow inlining the temporary for NRVO.
