### PR TITLE
Convert all Dsymbol isXXX routines to inout methods

### DIFF
--- a/src/attrib.d
+++ b/src/attrib.d
@@ -304,7 +304,7 @@ public:
         }
     }
 
-    override final AttribDeclaration isAttribDeclaration()
+    override final inout(AttribDeclaration) isAttribDeclaration() inout
     {
         return this;
     }
@@ -704,7 +704,7 @@ public:
         return (isunion ? "anonymous union" : "anonymous struct");
     }
 
-    override final AnonDeclaration isAnonDeclaration()
+    override final inout(AnonDeclaration) isAnonDeclaration() inout
     {
         return this;
     }

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1441,9 +1441,9 @@ public:
     // Back end
     Symbol* vtblsym;
 
-    override final ClassDeclaration isClassDeclaration()
+    override final inout(ClassDeclaration) isClassDeclaration() inout
     {
-        return cast(ClassDeclaration)this;
+        return this;
     }
 
     override void accept(Visitor v)
@@ -1906,7 +1906,7 @@ public:
         return com;
     }
 
-    override InterfaceDeclaration isInterfaceDeclaration()
+    override inout(InterfaceDeclaration) isInterfaceDeclaration() inout
     {
         return this;
     }

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -361,7 +361,7 @@ public:
         return protection;
     }
 
-    override final Declaration isDeclaration()
+    override final inout(Declaration) isDeclaration() inout
     {
         return this;
     }
@@ -489,7 +489,7 @@ public:
         return false;
     }
 
-    override TupleDeclaration isTupleDeclaration()
+    override inout(TupleDeclaration) isTupleDeclaration() inout
     {
         return this;
     }
@@ -865,7 +865,7 @@ public:
         return s;
     }
 
-    override AliasDeclaration isAliasDeclaration()
+    override inout(AliasDeclaration) isAliasDeclaration() inout
     {
         return this;
     }
@@ -990,7 +990,7 @@ public:
         return result;
     }
 
-    override OverDeclaration isOverDeclaration()
+    override inout(OverDeclaration) isOverDeclaration() inout
     {
         return this;
     }
@@ -2287,9 +2287,9 @@ public:
     }
 
     // Eliminate need for dynamic_cast
-    override final VarDeclaration isVarDeclaration()
+    override final inout(VarDeclaration) isVarDeclaration() inout
     {
-        return cast(VarDeclaration)this;
+        return this;
     }
 
     override void accept(Visitor v)
@@ -2315,9 +2315,9 @@ public:
     }
 
     // Eliminate need for dynamic_cast
-    override SymbolDeclaration isSymbolDeclaration()
+    override inout(SymbolDeclaration) isSymbolDeclaration() inout
     {
-        return cast(SymbolDeclaration)this;
+        return this;
     }
 
     override void accept(Visitor v)
@@ -2367,7 +2367,7 @@ public:
         return buf.extractString();
     }
 
-    override final TypeInfoDeclaration isTypeInfoDeclaration()
+    override final inout(TypeInfoDeclaration) isTypeInfoDeclaration() inout
     {
         return this;
     }
@@ -2811,7 +2811,7 @@ public:
         assert(0); // should never be produced by syntax
     }
 
-    override ThisDeclaration isThisDeclaration()
+    override inout(ThisDeclaration) isThisDeclaration() inout
     {
         return this;
     }

--- a/src/denum.d
+++ b/src/denum.d
@@ -485,7 +485,7 @@ public:
         return memtype;
     }
 
-    override EnumDeclaration isEnumDeclaration()
+    override inout(EnumDeclaration) isEnumDeclaration() inout
     {
         return this;
     }
@@ -755,7 +755,7 @@ public:
         return e.semantic(sc);
     }
 
-    override EnumMember isEnumMember()
+    override inout(EnumMember) isEnumMember() inout
     {
         return this;
     }

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -469,7 +469,7 @@ public:
             return false;
     }
 
-    override Import isImport()
+    override inout(Import) isImport() inout
     {
         return this;
     }

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -187,7 +187,7 @@ public:
         return dst;
     }
 
-    override final Package isPackage()
+    override final inout(Package) isPackage() inout
     {
         return this;
     }
@@ -1270,7 +1270,7 @@ public:
     Symbol* munittest; // module unittest failure function
     Symbol* marray; // module array bounds function
 
-    override Module isModule()
+    override inout(Module) isModule() inout
     {
         return this;
     }

--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -815,7 +815,7 @@ public:
         return (ispod == ISPODyes);
     }
 
-    override final StructDeclaration isStructDeclaration()
+    override final inout(StructDeclaration) isStructDeclaration() inout
     {
         return this;
     }
@@ -848,7 +848,7 @@ public:
         return "union";
     }
 
-    override UnionDeclaration isUnionDeclaration()
+    override inout(UnionDeclaration) isUnionDeclaration() inout
     {
         return this;
     }

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -975,62 +975,62 @@ public:
     }
 
     // Eliminate need for dynamic_cast
-    Package isPackage()
+    inout(Package) isPackage() inout
     {
         return null;
     }
 
-    Module isModule()
+    inout(Module) isModule() inout
     {
         return null;
     }
 
-    EnumMember isEnumMember()
+    inout(EnumMember) isEnumMember() inout
     {
         return null;
     }
 
-    TemplateDeclaration isTemplateDeclaration()
+    inout(TemplateDeclaration) isTemplateDeclaration() inout
     {
         return null;
     }
 
-    TemplateInstance isTemplateInstance()
+    inout(TemplateInstance) isTemplateInstance() inout
     {
         return null;
     }
 
-    TemplateMixin isTemplateMixin()
+    inout(TemplateMixin) isTemplateMixin() inout
     {
         return null;
     }
 
-    Nspace isNspace()
+    inout(Nspace) isNspace() inout
     {
         return null;
     }
 
-    Declaration isDeclaration()
+    inout(Declaration) isDeclaration() inout
     {
         return null;
     }
 
-    ThisDeclaration isThisDeclaration()
+    inout(ThisDeclaration) isThisDeclaration() inout
     {
         return null;
     }
 
-    TypeInfoDeclaration isTypeInfoDeclaration()
+    inout(TypeInfoDeclaration) isTypeInfoDeclaration() inout
     {
         return null;
     }
 
-    TupleDeclaration isTupleDeclaration()
+    inout(TupleDeclaration) isTupleDeclaration() inout
     {
         return null;
     }
 
-    AliasDeclaration isAliasDeclaration()
+    inout(AliasDeclaration) isAliasDeclaration() inout
     {
         return null;
     }
@@ -1040,147 +1040,147 @@ public:
         return null;
     }
 
-    FuncDeclaration isFuncDeclaration()
+    inout(FuncDeclaration) isFuncDeclaration() inout
     {
         return null;
     }
 
-    FuncAliasDeclaration isFuncAliasDeclaration()
+    inout(FuncAliasDeclaration) isFuncAliasDeclaration() inout
     {
         return null;
     }
 
-    OverDeclaration isOverDeclaration()
+    inout(OverDeclaration) isOverDeclaration() inout
     {
         return null;
     }
 
-    FuncLiteralDeclaration isFuncLiteralDeclaration()
+    inout(FuncLiteralDeclaration) isFuncLiteralDeclaration() inout
     {
         return null;
     }
 
-    CtorDeclaration isCtorDeclaration()
+    inout(CtorDeclaration) isCtorDeclaration() inout
     {
         return null;
     }
 
-    PostBlitDeclaration isPostBlitDeclaration()
+    inout(PostBlitDeclaration) isPostBlitDeclaration() inout
     {
         return null;
     }
 
-    DtorDeclaration isDtorDeclaration()
+    inout(DtorDeclaration) isDtorDeclaration() inout
     {
         return null;
     }
 
-    StaticCtorDeclaration isStaticCtorDeclaration()
+    inout(StaticCtorDeclaration) isStaticCtorDeclaration() inout
     {
         return null;
     }
 
-    StaticDtorDeclaration isStaticDtorDeclaration()
+    inout(StaticDtorDeclaration) isStaticDtorDeclaration() inout
     {
         return null;
     }
 
-    SharedStaticCtorDeclaration isSharedStaticCtorDeclaration()
+    inout(SharedStaticCtorDeclaration) isSharedStaticCtorDeclaration() inout
     {
         return null;
     }
 
-    SharedStaticDtorDeclaration isSharedStaticDtorDeclaration()
+    inout(SharedStaticDtorDeclaration) isSharedStaticDtorDeclaration() inout
     {
         return null;
     }
 
-    InvariantDeclaration isInvariantDeclaration()
+    inout(InvariantDeclaration) isInvariantDeclaration() inout
     {
         return null;
     }
 
-    UnitTestDeclaration isUnitTestDeclaration()
+    inout(UnitTestDeclaration) isUnitTestDeclaration() inout
     {
         return null;
     }
 
-    NewDeclaration isNewDeclaration()
+    inout(NewDeclaration) isNewDeclaration() inout
     {
         return null;
     }
 
-    VarDeclaration isVarDeclaration()
+    inout(VarDeclaration) isVarDeclaration() inout
     {
         return null;
     }
 
-    ClassDeclaration isClassDeclaration()
+    inout(ClassDeclaration) isClassDeclaration() inout
     {
         return null;
     }
 
-    StructDeclaration isStructDeclaration()
+    inout(StructDeclaration) isStructDeclaration() inout
     {
         return null;
     }
 
-    UnionDeclaration isUnionDeclaration()
+    inout(UnionDeclaration) isUnionDeclaration() inout
     {
         return null;
     }
 
-    InterfaceDeclaration isInterfaceDeclaration()
+    inout(InterfaceDeclaration) isInterfaceDeclaration() inout
     {
         return null;
     }
 
-    ScopeDsymbol isScopeDsymbol()
+    inout(ScopeDsymbol) isScopeDsymbol() inout
     {
         return null;
     }
 
-    WithScopeSymbol isWithScopeSymbol()
+    inout(WithScopeSymbol) isWithScopeSymbol() inout
     {
         return null;
     }
 
-    ArrayScopeSymbol isArrayScopeSymbol()
+    inout(ArrayScopeSymbol) isArrayScopeSymbol() inout
     {
         return null;
     }
 
-    Import isImport()
+    inout(Import) isImport() inout
     {
         return null;
     }
 
-    EnumDeclaration isEnumDeclaration()
+    inout(EnumDeclaration) isEnumDeclaration() inout
     {
         return null;
     }
 
-    DeleteDeclaration isDeleteDeclaration()
+    inout(DeleteDeclaration) isDeleteDeclaration() inout
     {
         return null;
     }
 
-    SymbolDeclaration isSymbolDeclaration()
+    inout(SymbolDeclaration) isSymbolDeclaration() inout
     {
         return null;
     }
 
-    AttribDeclaration isAttribDeclaration()
+    inout(AttribDeclaration) isAttribDeclaration() inout
     {
         return null;
     }
 
-    AnonDeclaration isAnonDeclaration()
+    inout(AnonDeclaration) isAnonDeclaration() inout
     {
         return null;
     }
 
-    OverloadSet isOverloadSet()
+    inout(OverloadSet) isOverloadSet() inout
     {
         return null;
     }
@@ -1565,7 +1565,7 @@ public:
         return result;
     }
 
-    override final ScopeDsymbol isScopeDsymbol()
+    override final inout(ScopeDsymbol) isScopeDsymbol() inout
     {
         return this;
     }
@@ -1620,7 +1620,7 @@ public:
         return null;
     }
 
-    override WithScopeSymbol isWithScopeSymbol()
+    override inout(WithScopeSymbol) isWithScopeSymbol() inout
     {
         return this;
     }
@@ -1833,7 +1833,7 @@ public:
         return null;
     }
 
-    override ArrayScopeSymbol isArrayScopeSymbol()
+    override inout(ArrayScopeSymbol) isArrayScopeSymbol() inout
     {
         return this;
     }
@@ -1867,7 +1867,7 @@ public:
         a.push(s);
     }
 
-    override OverloadSet isOverloadSet()
+    override inout(OverloadSet) isOverloadSet() inout
     {
         return this;
     }

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -2146,7 +2146,7 @@ public:
         --numinstances;
     }
 
-    override TemplateDeclaration isTemplateDeclaration()
+    override inout(TemplateDeclaration) isTemplateDeclaration() inout
     {
         return this;
     }
@@ -7919,7 +7919,7 @@ public:
         --nest;
     }
 
-    override final TemplateInstance isTemplateInstance()
+    override final inout(TemplateInstance) isTemplateInstance() inout
     {
         return this;
     }
@@ -8483,7 +8483,7 @@ public:
         return true;
     }
 
-    override TemplateMixin isTemplateMixin()
+    override inout(TemplateMixin) isTemplateMixin() inout
     {
         return this;
     }

--- a/src/func.d
+++ b/src/func.d
@@ -3827,7 +3827,7 @@ public:
         return fd;
     }
 
-    override final FuncDeclaration isFuncDeclaration()
+    override final inout(FuncDeclaration) isFuncDeclaration() inout
     {
         return this;
     }
@@ -4366,7 +4366,7 @@ public:
         userAttribDecl = funcalias.userAttribDecl;
     }
 
-    override FuncAliasDeclaration isFuncAliasDeclaration()
+    override inout(FuncAliasDeclaration) isFuncAliasDeclaration() inout
     {
         return this;
     }
@@ -4481,7 +4481,7 @@ public:
             (cast(TypeFunction)type).next = tret;
     }
 
-    override FuncLiteralDeclaration isFuncLiteralDeclaration()
+    override inout(FuncLiteralDeclaration) isFuncLiteralDeclaration() inout
     {
         return this;
     }
@@ -4625,7 +4625,7 @@ public:
         return (isThis() && vthis && global.params.useInvariants);
     }
 
-    override CtorDeclaration isCtorDeclaration()
+    override inout(CtorDeclaration) isCtorDeclaration() inout
     {
         return this;
     }
@@ -4706,7 +4706,7 @@ public:
         return false; // cannot overload postblits
     }
 
-    override PostBlitDeclaration isPostBlitDeclaration()
+    override inout(PostBlitDeclaration) isPostBlitDeclaration() inout
     {
         return this;
     }
@@ -4803,7 +4803,7 @@ public:
         return false; // cannot overload destructors
     }
 
-    override DtorDeclaration isDtorDeclaration()
+    override inout(DtorDeclaration) isDtorDeclaration() inout
     {
         return this;
     }
@@ -4921,7 +4921,7 @@ public:
         return true;
     }
 
-    override final StaticCtorDeclaration isStaticCtorDeclaration()
+    override final inout(StaticCtorDeclaration) isStaticCtorDeclaration() inout
     {
         return this;
     }
@@ -4949,7 +4949,7 @@ public:
         return FuncDeclaration.syntaxCopy(scd);
     }
 
-    override SharedStaticCtorDeclaration isSharedStaticCtorDeclaration()
+    override inout(SharedStaticCtorDeclaration) isSharedStaticCtorDeclaration() inout
     {
         return this;
     }
@@ -5070,7 +5070,7 @@ public:
         return false;
     }
 
-    override final StaticDtorDeclaration isStaticDtorDeclaration()
+    override final inout(StaticDtorDeclaration) isStaticDtorDeclaration() inout
     {
         return this;
     }
@@ -5098,7 +5098,7 @@ public:
         return FuncDeclaration.syntaxCopy(sdd);
     }
 
-    override SharedStaticDtorDeclaration isSharedStaticDtorDeclaration()
+    override inout(SharedStaticDtorDeclaration) isSharedStaticDtorDeclaration() inout
     {
         return this;
     }
@@ -5173,7 +5173,7 @@ public:
         return false;
     }
 
-    override InvariantDeclaration isInvariantDeclaration()
+    override inout(InvariantDeclaration) isInvariantDeclaration() inout
     {
         return this;
     }
@@ -5283,7 +5283,7 @@ public:
         return false;
     }
 
-    override UnitTestDeclaration isUnitTestDeclaration()
+    override inout(UnitTestDeclaration) isUnitTestDeclaration() inout
     {
         return this;
     }
@@ -5375,7 +5375,7 @@ public:
         return false;
     }
 
-    override NewDeclaration isNewDeclaration()
+    override inout(NewDeclaration) isNewDeclaration() inout
     {
         return this;
     }
@@ -5469,7 +5469,7 @@ public:
         return false;
     }
 
-    override DeleteDeclaration isDeleteDeclaration()
+    override inout(DeleteDeclaration) isDeleteDeclaration() inout
     {
         return this;
     }

--- a/src/nspace.d
+++ b/src/nspace.d
@@ -254,7 +254,7 @@ public:
         return "namespace";
     }
 
-    override Nspace isNspace()
+    override inout(Nspace) isNspace() inout
     {
         return this;
     }


### PR DESCRIPTION
This was done for `isAggregateDeclaration` in #5412. Thought I might apply it for the rest, as it's a very mechanical change.
