### PR TITLE
[REG2.069] Issue 15524 - 64bit app with anon-class crashes in contract

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -994,8 +994,7 @@ elem *toElem(Expression *e, IRState *irs)
                      * contract, instead look at the original stack data.
                      */
                     bool forceStackAccess = false;
-                    if (s->Sclass == SCparameter &&
-                        fd->isVirtual() && (fd->fdrequire || fd->fdensure))
+                    if (fd->isVirtual() && (fd->fdrequire || fd->fdensure))
                     {
                         Dsymbol *sx = irs->getFunc();
                         while (sx != fd)
@@ -1035,7 +1034,7 @@ elem *toElem(Expression *e, IRState *irs)
                     e = el_bin(OPadd, TYnptr, ethis, el_long(TYnptr, soffset));
                     if (se->op == TOKvar)
                         e = el_una(OPind, TYnptr, e);
-                    if (ISREF(se->var, tb) && !(ISWIN64REF(se->var) && v && v->offset))
+                    if (ISREF(se->var, tb) && !(ISWIN64REF(se->var) && v && v->offset && !forceStackAccess))
                         e = el_una(OPind, s->ty(), e);
                     else if (se->op == TOKsymoff && nrvo)
                     {

--- a/src/toir.c
+++ b/src/toir.c
@@ -671,7 +671,7 @@ void buildClosure(FuncDeclaration *fd, IRState *irs)
          *        ~this() { call destructor }
          *    }
          */
-        //printf("FuncDeclaration::buildClosure() %s\n", toChars());
+        //printf("FuncDeclaration::buildClosure() %s\n", fd->toChars());
 
         /* Generate type name for closure struct */
         const char *name1 = "CLOSURE.";
@@ -711,6 +711,7 @@ void buildClosure(FuncDeclaration *fd, IRState *irs)
                  */
                 v->error("cannot reference variadic arguments from closure");
             }
+
             /* Align and allocate space for v in the closure
              * just like AggregateDeclaration::addField() does.
              */


### PR DESCRIPTION
The regression has been introduce by issue 9383 fix (PR #4788). In Win64, some function parameters are passed by registers (`SCshadowreg`). When the parameters are placed in closure context, their access was not well handled in #4788.
