### PR TITLE
refactor: merge finalizeSize()s, remove now unused code

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1326,6 +1326,7 @@ public:
                 {
                     //printf("adding %s to %s\n", v->toChars(), sc->scopesym->toChars());
                     if (sc.scopesym.members)
+                        // Note this prevents using foreach() over members, because the limits can change
                         sc.scopesym.members.push(v);
                 }
                 Expression e = new DsymbolExp(loc, v);


### PR DESCRIPTION
Merging the two reduces bugs by having common code do both.
