### PR TITLE
refactor: use union in StringExp

### DIFF
--- a/src/ctfeexpr.d
+++ b/src/ctfeexpr.d
@@ -1773,10 +1773,10 @@ extern (C++) UnionExp changeArrayLiteralLength(Loc loc, TypeArray arrayType, Exp
                 (cast(char*)s)[cast(size_t)(indxlo + elemi)] = cast(char)defaultValue;
                 break;
             case 2:
-                (cast(utf16_t*)s)[cast(size_t)(indxlo + elemi)] = cast(utf16_t)defaultValue;
+                (cast(wchar*)s)[cast(size_t)(indxlo + elemi)] = cast(wchar)defaultValue;
                 break;
             case 4:
-                (cast(utf32_t*)s)[cast(size_t)(indxlo + elemi)] = cast(utf32_t)defaultValue;
+                (cast(dchar*)s)[cast(size_t)(indxlo + elemi)] = cast(dchar)defaultValue;
                 break;
             default:
                 assert(0);

--- a/src/dcast.d
+++ b/src/dcast.d
@@ -1656,8 +1656,8 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 {
                     void* s = cast(void*)mem.xmalloc((se.len + 1) * se.sz);
                     memcpy(s, se.string, se.len * se.sz);
-                    memset(cast(char*)s + se.len * se.sz, 0, se.sz);
-                    se.string = s;
+                    memset(s + se.len * se.sz, 0, se.sz);
+                    se.string = cast(char*)s;
                 }
                 result = se;
                 return;
@@ -1716,7 +1716,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     for (size_t u = 0; u < e.len;)
                     {
                         uint c;
-                        const(char)* p = utf_decodeChar(cast(char*)se.string, e.len, &u, &c);
+                        const p = utf_decodeChar(se.string, e.len, &u, &c);
                         if (p)
                             e.error("%s", p);
                         else
@@ -1729,7 +1729,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     for (size_t u = 0; u < e.len;)
                     {
                         uint c;
-                        const(char)* p = utf_decodeChar(cast(char*)se.string, e.len, &u, &c);
+                        const p = utf_decodeChar(se.string, e.len, &u, &c);
                         if (p)
                             e.error("%s", p);
                         buffer.write4(c);
@@ -1741,7 +1741,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     for (size_t u = 0; u < e.len;)
                     {
                         uint c;
-                        const(char)* p = utf_decodeWchar(cast(ushort*)se.string, e.len, &u, &c);
+                        const p = utf_decodeWchar(cast(utf16_t*)se.wstring, e.len, &u, &c);
                         if (p)
                             e.error("%s", p);
                         else
@@ -1754,7 +1754,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     for (size_t u = 0; u < e.len;)
                     {
                         uint c;
-                        const(char)* p = utf_decodeWchar(cast(ushort*)se.string, e.len, &u, &c);
+                        const p = utf_decodeWchar(cast(utf16_t*)se.wstring, e.len, &u, &c);
                         if (p)
                             e.error("%s", p);
                         buffer.write4(c);
@@ -1765,7 +1765,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 case X(Tdchar, Tchar):
                     for (size_t u = 0; u < e.len; u++)
                     {
-                        uint c = (cast(uint*)se.string)[u];
+                        uint c = se.dstring[u];
                         if (!utf_isValidDchar(c))
                             e.error("invalid UCS-32 char \\U%08x", c);
                         else
@@ -1778,7 +1778,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 case X(Tdchar, Twchar):
                     for (size_t u = 0; u < e.len; u++)
                     {
-                        uint c = (cast(uint*)se.string)[u];
+                        uint c = se.dstring[u];
                         if (!utf_isValidDchar(c))
                             e.error("invalid UCS-32 char \\U%08x", c);
                         else
@@ -1823,8 +1823,8 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     void* s = cast(void*)mem.xmalloc((dim2 + 1) * newsz);
                     memcpy(s, se.string, d * newsz);
                     // Extend with 0, add terminating 0
-                    memset(cast(char*)s + d * newsz, 0, (dim2 + 1 - d) * newsz);
-                    se.string = s;
+                    memset(s + d * newsz, 0, (dim2 + 1 - d) * newsz);
+                    se.string = cast(char*)s;
                     se.len = dim2;
                 }
             }

--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -3842,18 +3842,17 @@ public:
                     e.error("cannot modify read-only string literal %s", ie.e1.toChars());
                     return CTFEExp.cantexp;
                 }
-                void* s = existingSE.string;
                 dinteger_t value = newval.toInteger();
                 switch (existingSE.sz)
                 {
                 case 1:
-                    (cast(char*)s)[index] = cast(char)value;
+                    existingSE.string[index] = cast(char)value;
                     break;
                 case 2:
-                    (cast(utf16_t*)s)[index] = cast(utf16_t)value;
+                    existingSE.wstring[index] = cast(wchar)value;
                     break;
                 case 4:
-                    (cast(utf32_t*)s)[index] = cast(utf32_t)value;
+                    existingSE.dstring[index] = cast(dchar)value;
                     break;
                 default:
                     assert(0);
@@ -4106,19 +4105,18 @@ public:
             }
             // String literal block slice assign
             dinteger_t value = newval.toInteger();
-            void* s = existingSE.string;
             for (size_t i = 0; i < upperbound - lowerbound; i++)
             {
                 switch (existingSE.sz)
                 {
                 case 1:
-                    (cast(char*)s)[cast(size_t)(i + firstIndex)] = cast(char)value;
+                    existingSE.string[cast(size_t)(i + firstIndex)] = cast(char)value;
                     break;
                 case 2:
-                    (cast(utf16_t*)s)[cast(size_t)(i + firstIndex)] = cast(utf16_t)value;
+                    existingSE.wstring[cast(size_t)(i + firstIndex)] = cast(wchar)value;
                     break;
                 case 4:
-                    (cast(utf32_t*)s)[cast(size_t)(i + firstIndex)] = cast(utf32_t)value;
+                    existingSE.dstring[cast(size_t)(i + firstIndex)] = cast(dchar)value;
                     break;
                 default:
                     assert(0);


### PR DESCRIPTION
Using a union makes things a little clearer what is happening.
