### PR TITLE
fix Issue 313 - Fully qualified names bypass private imports

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -1,10 +1,11 @@
 Ddoc
 
-$(COMMENT Pending changelog for 2.070. This will get copied to dlang.org and
-    cleared when master gets merged into stable prior to 2.069.
+$(COMMENT Pending changelog for 2.071. This will get copied to dlang.org and
+    cleared when master gets merged into stable.
 )
 
 $(BUGSTITLE Compiler Changes,
+    $(LI $(RELATIVE_LINK2 imports-313, Import access checks for fully qualified names were fixed.))
 )
 
 $(BUGSTITLE Language Changes,
@@ -13,7 +14,21 @@ $(BUGSTITLE Language Changes,
 )
 
 $(BUGSTITLE Compiler Changes,
+    $(LI $(LNAME2 imports-313, Import access checks for fully qualified names were fixed.)
 
+    $(P It is no longer possible to bypass private imports by using fully qualified names, e.g.
+        the following example will fail with `package std.range is not accessible here`.
+    )
+
+    ---
+    import std.algorithm;
+
+    static assert(std.range.isForwardRange!string);
+    ---
+
+    $(P To ease updating existing code, the old behavior was retained but deprecated.
+    )
+    )
 )
 
 $(BUGSTITLE Language Changes,

--- a/src/access.d
+++ b/src/access.d
@@ -410,3 +410,26 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
     }
     return false;
 }
+
+/****************************************
+ * Check access to package/module p for scope sc.
+ *
+ * Returns: true if the package is not accessible.
+ *
+ * Because we use a global symbol table tree for imported packages/modules,
+ * access to them needs to be checked based on the imports in the scope chain
+ * (see Bugzilla 313).
+ *
+ */
+extern (C++) bool checkAccess(Loc loc, Scope* sc, Package p)
+{
+    if (sc._module == p)
+        return false;
+    for (; sc; sc = sc.enclosing)
+    {
+        if (sc.scopesym && sc.scopesym.isPackageAccessible(p))
+            return false;
+    }
+    deprecation(loc, "%s %s is not accessible here", p.kind(), p.toPrettyChars());
+    return true;
+}

--- a/src/access.d
+++ b/src/access.d
@@ -412,11 +412,15 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
 }
 
 /****************************************
- * Check access to package/module p for scope sc.
+ * Check access to package/module `p` from scope `sc`.
  *
+ * Params:
+ *   loc = source location for issued error message
+ *   sc = scope from which to access to a fully qualified package name
+ *   p = the package/module to check access for
  * Returns: true if the package is not accessible.
  *
- * Because we use a global symbol table tree for imported packages/modules,
+ * Because a global symbol table tree is used for imported packages/modules,
  * access to them needs to be checked based on the imports in the scope chain
  * (see Bugzilla 313).
  *

--- a/src/access.d
+++ b/src/access.d
@@ -434,6 +434,10 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Package p)
         if (sc.scopesym && sc.scopesym.isPackageAccessible(p))
             return false;
     }
-    deprecation(loc, "%s %s is not accessible here", p.kind(), p.toPrettyChars());
+    auto name = p.toPrettyChars();
+    if (p.isPkgMod == PKGmodule || p.isModule())
+        deprecation(loc, "%s %s is not accessible here, perhaps add 'static import %s;'", p.kind(), name, name);
+    else
+        deprecation(loc, "%s %s is not accessible here", p.kind(), name);
     return true;
 }

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -161,7 +161,7 @@ public:
                             // mod is a package.d, or a normal module which conflicts with the package name.
                             assert(mod.isPackageFile == (p.isPkgMod == PKGmodule));
                             if (mod.isPackageFile)
-                                mod.id = p.id; // reuse the same package id
+                                mod.tag = p.tag; // reuse the same package tag
                         }
                     }
                     else

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -114,12 +114,15 @@ extern (C++) class Package : ScopeDsymbol
 {
 public:
     PKG isPkgMod;
+    uint id;        // auto increment id, used to mask package tree in scopes
     Module mod;     // !=null if isPkgMod == PKGmodule
 
     final extern (D) this(Identifier ident)
     {
         super(ident);
         this.isPkgMod = PKGunknown;
+        __gshared uint packageId;
+        this.id = packageId++;
     }
 
     override const(char)* kind() const
@@ -859,6 +862,7 @@ public:
             p.parent = this.parent;
             p.isPkgMod = PKGmodule;
             p.mod = this;
+            p.id = this.id; // reuse the same package id
             p.symtab = new DsymbolTable();
             s = p;
         }
@@ -889,6 +893,7 @@ public:
                      */
                     pkg.isPkgMod = PKGmodule;
                     pkg.mod = this;
+                    pkg.id = this.id; // reuse the same package id
                 }
                 else
                     error(md ? md.loc : loc, "from file %s conflicts with package name %s", srcname, pkg.toChars());

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -114,15 +114,15 @@ extern (C++) class Package : ScopeDsymbol
 {
 public:
     PKG isPkgMod;
-    uint id;        // auto increment id, used to mask package tree in scopes
+    uint tag;        // auto incremented tag, used to mask package tree in scopes
     Module mod;     // !=null if isPkgMod == PKGmodule
 
     final extern (D) this(Identifier ident)
     {
         super(ident);
         this.isPkgMod = PKGunknown;
-        __gshared uint packageId;
-        this.id = packageId++;
+        __gshared uint packageTag;
+        this.tag = packageTag++;
     }
 
     override const(char)* kind() const
@@ -862,7 +862,7 @@ public:
             p.parent = this.parent;
             p.isPkgMod = PKGmodule;
             p.mod = this;
-            p.id = this.id; // reuse the same package id
+            p.tag = this.tag; // reuse the same package tag
             p.symtab = new DsymbolTable();
             s = p;
         }
@@ -893,7 +893,7 @@ public:
                      */
                     pkg.isPkgMod = PKGmodule;
                     pkg.mod = this;
-                    pkg.id = this.id; // reuse the same package id
+                    pkg.tag = this.tag; // reuse the same package tag
                 }
                 else
                     error(md ? md.loc : loc, "from file %s conflicts with package name %s", srcname, pkg.toChars());

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1211,6 +1211,9 @@ private:
     Dsymbols* importedScopes;
     PROTKIND* prots;            // array of PROTKIND, one for each import
 
+    import std.bitmanip : BitArray;
+    BitArray accessiblePackages;// whitelist of accessible (imported) packages
+
 public:
     final extern (D) this()
     {
@@ -1431,6 +1434,19 @@ public:
             prots = cast(PROTKIND*)mem.xrealloc(prots, importedScopes.dim * (prots[0]).sizeof);
             prots[importedScopes.dim - 1] = protection.kind;
         }
+    }
+
+    final void addAccessiblePackage(Package p)
+    {
+        if (accessiblePackages.length <= p.id)
+            accessiblePackages.length = p.id + 1;
+        accessiblePackages[p.id] = true;
+    }
+
+    final bool isPackageAccessible(Package p)
+    {
+        return p.id < accessiblePackages.length &&
+            accessiblePackages[p.id];
     }
 
     override final bool isforwardRef()

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1438,15 +1438,15 @@ public:
 
     final void addAccessiblePackage(Package p)
     {
-        if (accessiblePackages.length <= p.id)
-            accessiblePackages.length = p.id + 1;
-        accessiblePackages[p.id] = true;
+        if (accessiblePackages.length <= p.tag)
+            accessiblePackages.length = p.tag + 1;
+        accessiblePackages[p.tag] = true;
     }
 
     final bool isPackageAccessible(Package p)
     {
-        return p.id < accessiblePackages.length &&
-            accessiblePackages[p.id];
+        return p.tag < accessiblePackages.length &&
+            accessiblePackages[p.tag];
     }
 
     override final bool isforwardRef()

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1211,7 +1211,7 @@ private:
     Dsymbols* importedScopes;
     PROTKIND* prots;            // array of PROTKIND, one for each import
 
-    import std.bitmanip : BitArray;
+    import ddmd.root.array : BitArray;
     BitArray accessiblePackages;// whitelist of accessible (imported) packages
 
 public:

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -288,8 +288,7 @@ private:
     Dsymbols *importedScopes;   // imported Dsymbol's
     PROTKIND *prots;            // array of PROTKIND, one for each import
 
-    struct BitArray { size_t len; size_t *ptr; };
-    BitArray importTreeMask;
+    BitArray accessiblePackages;
 
 public:
     ScopeDsymbol();

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -288,6 +288,9 @@ private:
     Dsymbols *importedScopes;   // imported Dsymbol's
     PROTKIND *prots;            // array of PROTKIND, one for each import
 
+    struct BitArray { size_t len; size_t *ptr; };
+    BitArray importTreeMask;
+
 public:
     ScopeDsymbol();
     ScopeDsymbol(Identifier *id);

--- a/src/expression.d
+++ b/src/expression.d
@@ -8304,6 +8304,8 @@ public:
                  */
                 if (Declaration d = s.isDeclaration())
                     checkAccess(loc, sc, null, d);
+                if (auto p = s.isPackage())
+                    checkAccess(loc, sc, p);
 
                 // if 's' is a tuple variable, the tuple is returned.
                 s = s.toAlias();

--- a/src/module.h
+++ b/src/module.h
@@ -37,6 +37,7 @@ class Package : public ScopeDsymbol
 {
 public:
     PKG isPkgMod;
+    unsigned id;        // auto increment id for package tree masks
     Module *mod;        // != NULL if isPkgMod == PKGmodule
 
     Package(Identifier *ident);

--- a/src/module.h
+++ b/src/module.h
@@ -37,7 +37,7 @@ class Package : public ScopeDsymbol
 {
 public:
     PKG isPkgMod;
-    unsigned id;        // auto increment id for package tree masks
+    unsigned tag;       // auto incremented tag, used to mask package tree in scopes
     Module *mod;        // != NULL if isPkgMod == PKGmodule
 
     Package(Identifier *ident);

--- a/src/root/array.d
+++ b/src/root/array.d
@@ -244,6 +244,8 @@ struct BitArray
             btc(ptr, idx);
     }
 
+    @disable this(this);
+
     ~this()
     {
         mem.xfree(ptr);

--- a/src/root/array.d
+++ b/src/root/array.d
@@ -211,3 +211,45 @@ public:
         return data[a .. b];
     }
 }
+
+struct BitArray
+{
+    size_t length() const
+    {
+        return len;
+    }
+
+    void length(size_t nlen)
+    {
+        ptr = cast(size_t*)mem.xrealloc(ptr, (nlen + 7) / 8);
+        len = nlen;
+    }
+
+    bool opIndex(size_t idx) const
+    {
+        import core.bitop : bt;
+
+        assert(idx < length);
+        return !!bt(ptr, idx);
+    }
+
+    void opIndexAssign(bool val, size_t idx)
+    {
+        import core.bitop : btc, bts;
+
+        assert(idx < length);
+        if (val)
+            bts(ptr, idx);
+        else
+            btc(ptr, idx);
+    }
+
+    ~this()
+    {
+        mem.xfree(ptr);
+    }
+
+private:
+    size_t len;
+    size_t *ptr;
+}

--- a/src/root/array.d
+++ b/src/root/array.d
@@ -204,4 +204,10 @@ public:
     {
         return data[0 .. dim];
     }
+
+    extern (D) inout(T)[] opSlice(size_t a, size_t b) inout
+    {
+        assert(a <= b && b <= dim);
+        return data[a .. b];
+    }
 }

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -251,6 +251,9 @@ struct BitArray
 
     size_t len;
     size_t *ptr;
+
+private:
+    BitArray(const BitArray&);
 };
 
 #endif

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -237,4 +237,20 @@ struct Array
     }
 };
 
+struct BitArray
+{
+    BitArray()
+      : len(0)
+      , ptr(NULL)
+    {}
+
+    ~BitArray()
+    {
+        mem.xfree(ptr);
+    }
+
+    size_t len;
+    size_t *ptr;
+};
+
 #endif

--- a/test/compilable/imports/a313.d
+++ b/test/compilable/imports/a313.d
@@ -1,0 +1,8 @@
+module imports.a313;
+
+// adds private package imports
+private import imports.b313;
+// adds private package core
+private import core.stdc.stdio;
+// adds public alias cstdio
+public alias cstdio = core.stdc.stdio;

--- a/test/compilable/imports/b313.d
+++ b/test/compilable/imports/b313.d
@@ -1,0 +1,7 @@
+module imports.b313;
+
+void bug()
+{
+    // scope has access to it's own module
+    imports.b313.bug();
+}

--- a/test/compilable/imports/f313.d
+++ b/test/compilable/imports/f313.d
@@ -1,0 +1,6 @@
+ // different module declaration not used for access check
+module foo.bar;
+
+void bug()
+{
+}

--- a/test/compilable/imports/pkg313/c313.d
+++ b/test/compilable/imports/pkg313/c313.d
@@ -1,0 +1,5 @@
+module imports.pkg313.c313;
+
+void bug()
+{
+}

--- a/test/compilable/imports/pkgmod313/mod.d
+++ b/test/compilable/imports/pkgmod313/mod.d
@@ -1,0 +1,3 @@
+module imports.pkgmod313.mod;
+
+void bar() {}

--- a/test/compilable/imports/pkgmod313/package.d
+++ b/test/compilable/imports/pkgmod313/package.d
@@ -1,0 +1,5 @@
+module imports.pkgmod313;
+
+public import imports.pkgmod313.mod;
+
+void foo() {}

--- a/test/compilable/test313a.d
+++ b/test/compilable/test313a.d
@@ -1,0 +1,26 @@
+/*
+REQUIRED_ARGS: -de
+*/
+module test313;
+
+import imports.a313;
+
+void test1()
+{
+    import imports.b313;
+    imports.b313.bug();
+}
+
+void test2()
+{
+    cstdio.printf("");
+}
+
+import imports.pkg313.c313;
+void test3()
+{
+    imports.pkg313.c313.bug();
+}
+
+// private symbols from other modules are still visible
+static assert(core.stringof == "package core");

--- a/test/compilable/test313b.d
+++ b/test/compilable/test313b.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -de
+void test1()
+{
+    import core.stdc.stdio;
+    core.stdc.stdio.printf("");
+}

--- a/test/compilable/test313c.d
+++ b/test/compilable/test313c.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: -de
+import imports.pkgmod313;
+
+void test()
+{
+    imports.pkgmod313.foo();
+    imports.pkgmod313.bar();
+}

--- a/test/compilable/test313d.d
+++ b/test/compilable/test313d.d
@@ -1,0 +1,9 @@
+// first imported as package
+// EXTRA_SOURCES: imports/pkgmod313/mod.d
+// REQUIRED_ARGS: -de
+import imports.pkgmod313; // then as package module
+
+void test()
+{
+    imports.pkgmod313.foo();
+}

--- a/test/compilable/test313e.d
+++ b/test/compilable/test313e.d
@@ -1,0 +1,9 @@
+// first resolved as package, then created as module (with name package)
+// EXTRA_SOURCES: imports/pkgmod313/mod.d imports/pkgmod313/package.d
+// REQUIRED_ARGS: -de
+import imports.pkgmod313; // then imported as package module
+
+void test()
+{
+    imports.pkgmod313.foo();
+}

--- a/test/compilable/test313f.d
+++ b/test/compilable/test313f.d
@@ -1,0 +1,7 @@
+// REQUIRED_ARGS: -de
+import imports.f313;
+
+void test()
+{
+    imports.f313.bug();
+}

--- a/test/fail_compilation/fail313.d
+++ b/test/fail_compilation/fail313.d
@@ -2,9 +2,10 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail313.d(16): Deprecation: module imports.b313 is not accessible here
-fail_compilation/fail313.d(23): Deprecation: package core.stdc is not accessible here
-fail_compilation/fail313.d(23): Deprecation: module core.stdc.stdio is not accessible here
+fail_compilation/fail313.d(17): Deprecation: module imports.b313 is not accessible here, perhaps add 'static import imports.b313;'
+fail_compilation/fail313.d(24): Deprecation: package core.stdc is not accessible here
+fail_compilation/fail313.d(24): Deprecation: module core.stdc.stdio is not accessible here, perhaps add 'static import core.stdc.stdio;'
+fail_compilation/fail313.d(29): Deprecation: package imports.pkg313 is not accessible here, perhaps add 'static import imports.pkg313;'
 ---
 */
 module test313;
@@ -21,4 +22,9 @@ void test1()
 void test2()
 {
     core.stdc.stdio.printf("");
+}
+
+void test2()
+{
+    imports.pkg313.bug();
 }

--- a/test/fail_compilation/fail313.d
+++ b/test/fail_compilation/fail313.d
@@ -1,19 +1,24 @@
 /*
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail313.d(15): Error: function fail313.Derived.str return type inference is not supported if may override base class function
+fail_compilation/fail313.d(16): Deprecation: module imports.b313 is not accessible here
+fail_compilation/fail313.d(23): Deprecation: package core.stdc is not accessible here
+fail_compilation/fail313.d(23): Deprecation: module core.stdc.stdio is not accessible here
 ---
 */
+module test313;
 
-class Base
+import imports.a313;
+
+void test1()
 {
-    abstract int str();
+    imports.b313.bug();
+    import imports.b313;
+    imports.b313.bug();
 }
 
-class Derived : Base
+void test2()
 {
-    override str()
-    {
-        return "string";
-    }
+    core.stdc.stdio.printf("");
 }

--- a/test/fail_compilation/imports/a13131checkpoint.d
+++ b/test/fail_compilation/imports/a13131checkpoint.d
@@ -6,6 +6,7 @@ auto createGlobalsMixins()              // [4] semantic3
 {
     pragma(msg, "+A");
     enum fullModuleName = "imports.a13131parameters";  // necessary
+    mixin("import "~fullModuleName~";");
     foreach (e ; __traits(derivedMembers, mixin(fullModuleName)))
     {
         // [5] see imports.parameters (it's listed in command line)

--- a/test/fail_compilation/imports/a13131parameters.d
+++ b/test/fail_compilation/imports/a13131parameters.d
@@ -4,6 +4,7 @@ auto createParameterMixins()    // auto is necessary to invoke semantic3 to calc
 {
     pragma(msg, "+B");
     enum fullModuleName = "imports.a13131elec";  // necessary
+    mixin("import "~fullModuleName~";");
     foreach (e ; __traits(derivedMembers, mixin(fullModuleName)))
     {
         // will access yet-not semantic analyzed invalid symbol 'econn' in imports.elec

--- a/test/fail_compilation/imports/a313.d
+++ b/test/fail_compilation/imports/a313.d
@@ -1,0 +1,7 @@
+module imports.a313;
+
+private import imports.b313;
+private static import imports.b313;
+private static import b313 = imports.b313;
+
+private import core.stdc.stdio;

--- a/test/fail_compilation/imports/a313.d
+++ b/test/fail_compilation/imports/a313.d
@@ -4,4 +4,6 @@ private import imports.b313;
 private static import imports.b313;
 private static import b313 = imports.b313;
 
+private import imports.pkg313;
+
 private import core.stdc.stdio;

--- a/test/fail_compilation/imports/b313.d
+++ b/test/fail_compilation/imports/b313.d
@@ -1,0 +1,4 @@
+module imports.b313;
+
+void bug()
+{}

--- a/test/fail_compilation/imports/pkg313/package.d
+++ b/test/fail_compilation/imports/pkg313/package.d
@@ -1,0 +1,4 @@
+module imports.pkg313;
+
+void bug()
+{}


### PR DESCRIPTION
- b/c we're using a global package tree, imported modules were
  accessible in other scopes using fully qualified names
- maintain a whitelist of imported modules in the current scope

The implementation is a bit more complicated than I'd like it to be, mostly b/c of package modules (handling of which is spreaded accross many places), and the fact that a module can have a different name on the import side than in it's module declaration.
