### PR TITLE
Fix 15668 : __LINE__ evaluated at declaration context

### DIFF
--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -4916,9 +4916,13 @@ public:
             istate = &istateComma;
         }
         result = CTFEExp.cantexp;
+
         // If the comma returns a temporary variable, it needs to be an lvalue
         // (this is particularly important for struct constructors)
-        if (e.e1.op == TOKdeclaration && e.e2.op == TOKvar && (cast(DeclarationExp)e.e1).declaration == (cast(VarExp)e.e2).var && (cast(VarExp)e.e2).var.storage_class & STCctfe) // same as Expression::isTemp
+        if (e.e1.op == TOKdeclaration &&
+            e.e2.op == TOKvar &&
+            (cast(DeclarationExp)e.e1).declaration == (cast(VarExp)e.e2).var &&
+            (cast(VarExp)e.e2).var.storage_class & STCctfe)
         {
             VarExp ve = cast(VarExp)e.e2;
             VarDeclaration v = ve.var.isVarDeclaration();

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -1435,7 +1435,7 @@ public:
                                          * the oded == oarg
                                          */
                                         (*dedargs)[i] = oded;
-                                        MATCH m2 = tparam.matchArg(loc, paramscope, dedargs, i, parameters, dedtypes, null);
+                                        MATCH m2 = tparam.matchArg(instLoc, paramscope, dedargs, i, parameters, dedtypes, null);
                                         //printf("m2 = %d\n", m2);
                                         if (m2 <= MATCHnomatch)
                                             goto Lnomatch;
@@ -1453,7 +1453,7 @@ public:
                                 }
                                 else
                                 {
-                                    oded = tparam.defaultArg(loc, paramscope);
+                                    oded = tparam.defaultArg(instLoc, paramscope);
                                     if (oded)
                                         (*dedargs)[i] = declareParameter(paramscope, tparam, oded);
                                 }

--- a/src/inline.d
+++ b/src/inline.d
@@ -2116,7 +2116,7 @@ void expandInline(FuncDeclaration fd, FuncDeclaration parent, Expression eret,
         else
         {
             Identifier tmp = Identifier.generateId("__nrvoretval");
-            auto vd = new VarDeclaration(fd.loc, fd.nrvo_var.type, tmp, null);
+            auto vd = new VarDeclaration(fd.loc, fd.nrvo_var.type, tmp, new VoidInitializer(fd.loc));
             assert(!tf.isref);
             vd.storage_class = STCtemp | STCrvalue;
             vd.linkage = tf.linkage;

--- a/test/compilable/imports/imp15490a.d
+++ b/test/compilable/imports/imp15490a.d
@@ -1,0 +1,8 @@
+module imports.imp15490a;
+
+import imports.imp15490b;
+
+void listenTCP()
+{
+    enum r = regex();
+}

--- a/test/compilable/imports/imp15490b.d
+++ b/test/compilable/imports/imp15490b.d
@@ -1,0 +1,12 @@
+module imports.imp15490b;
+
+int regex()
+{
+    return regexImpl();
+}
+
+auto regexImpl()
+{
+    int r = 0;
+    return r;
+}

--- a/test/compilable/test15490.d
+++ b/test/compilable/test15490.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -o- -inline
+// PERMUTE_ARGS:
+module test15490;
+
+import imports.imp15490a;
+import imports.imp15490b;
+
+void main()
+{
+    regex();
+    listenTCP();
+}

--- a/test/compilable/test15668.d
+++ b/test/compilable/test15668.d
@@ -1,0 +1,9 @@
+void foo ( int line = __LINE__ ) ( string msg = "" )
+{
+    static assert (line == 8);
+}
+
+void main()
+{
+    foo();
+}


### PR DESCRIPTION
Relevant argument deduction code was using declaration `loc`
instead of instantiation `instLoc`. Not sure if this is correct fix but at least it has helped with my test case :)

Fixes https://issues.dlang.org/show_bug.cgi?id=15668
