### PR TITLE
Issue 15669 - Wrong line number in error message

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1292,6 +1292,7 @@ public:
                         te.exps.push(new ErrorExp());
                 }
             }
+
             auto exps = new Objects();
             exps.setDim(nelems);
             for (size_t i = 0; i < nelems; i++)
@@ -1301,6 +1302,7 @@ public:
                 buf.printf("__%s_field_%llu", ident.toChars(), cast(ulong)i);
                 const(char)* name = buf.extractString();
                 Identifier id = Identifier.idPool(name);
+
                 Initializer ti;
                 if (ie)
                 {
@@ -1316,12 +1318,14 @@ public:
                 }
                 else
                     ti = _init ? _init.syntaxCopy() : null;
+
                 auto v = new VarDeclaration(loc, arg.type, id, ti);
                 v.storage_class |= STCtemp | storage_class;
                 if (arg.storageClass & STCparameter)
                     v.storage_class |= arg.storageClass;
                 //printf("declaring field %s of type %s\n", v->toChars(), v->type->toChars());
                 v.semantic(sc);
+
                 if (sc.scopesym)
                 {
                     //printf("adding %s to %s\n", v->toChars(), sc->scopesym->toChars());
@@ -1329,6 +1333,7 @@ public:
                         // Note this prevents using foreach() over members, because the limits can change
                         sc.scopesym.members.push(v);
                 }
+
                 Expression e = new DsymbolExp(loc, v);
                 (*exps)[i] = e;
             }

--- a/src/expression.d
+++ b/src/expression.d
@@ -4650,7 +4650,8 @@ public:
             }
             else if (o.dyncast() == DYNCAST_EXPRESSION)
             {
-                Expression e = cast(Expression)o;
+                auto e = (cast(Expression)o).copy();
+                e.loc = loc;    // Bugzilla 15669
                 this.exps.push(e);
             }
             else if (o.dyncast() == DYNCAST_TYPE)

--- a/test/fail_compilation/diag15669.d
+++ b/test/fail_compilation/diag15669.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag15669.d(14): Error: variable __b_field_0 cannot be read at compile time
+---
+*/
+
+alias AliasSeq(A ...) = A;
+
+void foo()
+{
+    AliasSeq!int a;
+    AliasSeq!int b;
+    a[b];
+}


### PR DESCRIPTION
Member expressions of `TupleDeclaration` have different loc than the `TupleExp` in its ctor. It should be fixed.
