### PR TITLE
[REG2.064] Issue 15664 - incorrect initialisation of member of an immutable struct

### DIFF
--- a/src/todt.c
+++ b/src/todt.c
@@ -896,7 +896,7 @@ dt_t **toDtElem(TypeSArray *tsa, dt_t **pdt, Expression *e)
         pdt = dtend(pdt);
         Type *tnext = tsa->next;
         Type *tbn = tnext->toBasetype();
-        while (tbn->ty == Tsarray && (!e || tbn != e->type->nextOf()))
+        while (tbn->ty == Tsarray && (!e || !tbn->equivalent(e->type->nextOf())))
         {
             len *= ((TypeSArray *)tbn)->dim->toInteger();
             tnext = tbn->nextOf();

--- a/test/runnable/testdt.d
+++ b/test/runnable/testdt.d
@@ -97,11 +97,76 @@ struct S14805
 auto a14805 = new S14805[513*513];
 
 /******************************************/
+// 15664
+
+struct Data15664A
+{
+    int[2] a;
+    int[2][2] b;
+    int c;
+}
+
+             Data15664A d15664a1 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK
+       const Data15664A d15664a2 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK <- NG
+shared       Data15664A d15664a3 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK <- NG
+shared const Data15664A d15664a4 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK <- NG
+   immutable Data15664A d15664a5 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK <- NG
+
+struct Data15664B
+{
+    int[2] a;
+    const int[2][2] b;
+    int c;
+}
+
+             Data15664B d15664b1 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK
+       const Data15664B d15664b2 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK
+shared       Data15664B d15664b3 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK <- NG
+shared const Data15664B d15664b4 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK <- NG
+   immutable Data15664B d15664b5 = {[1, 2], [[3, 4], [5, 6]], 7};   // OK <- NG
+
+void test15664()
+{
+    assert(d15664a1.a == [1, 2]);
+    assert(d15664a2.a == [1, 2]);
+    assert(d15664a3.a == cast(shared)[1, 2]);
+    assert(d15664a4.a == cast(shared)[1, 2]);
+    assert(d15664a5.a == [1, 2]);
+    assert(d15664a1.b == [[3, 4], [5, 6]]);
+    assert(d15664a2.b == [[3, 4], [5, 6]]);
+    assert(d15664a3.b == cast(shared)[[3, 4], [5, 6]]);
+    assert(d15664a4.b == cast(shared)[[3, 4], [5, 6]]);
+    assert(d15664a5.b == [[3, 4], [5, 6]]);
+    assert(d15664a1.c == 7);    // OK
+    assert(d15664a2.c == 7);    // OK <- BG
+    assert(d15664a3.c == 7);    // OK <- NG
+    assert(d15664a4.c == 7);    // OK <- NG
+    assert(d15664a5.c == 7);    // OK <- NG
+
+    assert(d15664b1.a == [1, 2]);
+    assert(d15664b2.a == [1, 2]);
+    assert(d15664b3.a == cast(shared)[1, 2]);
+    assert(d15664b4.a == cast(shared)[1, 2]);
+    assert(d15664b5.a == [1, 2]);
+    assert(d15664b1.b == [[3, 4], [5, 6]]);
+    assert(d15664b2.b == [[3, 4], [5, 6]]);
+    assert(d15664b3.b == cast(shared)[[3, 4], [5, 6]]);
+    assert(d15664b4.b == cast(shared)[[3, 4], [5, 6]]);
+    assert(d15664b5.b == [[3, 4], [5, 6]]);
+    assert(d15664b1.c == 7);    // OK
+    assert(d15664b2.c == 7);    // OK
+    assert(d15664b3.c == 7);    // OK <- NG
+    assert(d15664b4.c == 7);    // OK <- NG
+    assert(d15664b5.c == 7);    // OK <- NG
+}
+
+/******************************************/
 
 int main()
 {
     test1();
     test11672();
+    test15664();
 
     return 0;
 }


### PR DESCRIPTION
When a struct literal appears in dataseg or TLS variable initialization, its elements `StructLiteralExp.elements[i]` are also painted to the qualifier of constructed struct type. But in `toDtElem`, type identity comparison was used to calculate array dimension, so the qualifier difference had caused wrong code.
