### PR TITLE
fix Issue 10378 - Local imports hide local symbols

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -9,6 +9,7 @@ $(BUGSTITLE Compiler Changes,
 
 $(BUGSTITLE Language Changes,
     $(LI $(RELATIVE_LINK2 extended-deprecated, Manifest constant can now be used for deprecation message.))
+    $(LI $(RELATIVE_LINK2 import-lookup, Imports no longer hide locals declared in outer scopes.))
 )
 
 $(BUGSTITLE Compiler Changes,
@@ -28,6 +29,30 @@ $(BUGSTITLE Language Changes,
     deprecated("Some long deprecation " ~ "message") class Bar {}
     ---
     )
+
+    $(LI $(LNAME2 import-lookup, Imports no longer hide locals declared in outer scopes.))
+
+    These changes were made to the name lookup algorithm:
+
+    $(OL
+        $(LI Lookup for unqualified names is change from one pass to two pass. The first
+        pass goes through the scopes but does not check import declarations. If not found,
+        the second pass goes through the scopes and only looks at import declarations.
+        )
+        $(LI Qualified name lookups, base class lookups, and WithStatement lookups no longer
+        search import declarations, unless a module is the subject of the lookup, where the
+        behavior remains as before.
+        )
+    )
+
+    $(P This can break existing code, although reliance on the previous behavior tends to be
+    unintended, and fixing it improves the comprehensibility of the code. Breakage tends
+    to take the form of a symbol now being flagged as undefined. Fixing the breakage can
+    be done by fully qualifying the name, or adding an alias to the import declaration.)
+
+    $(P Restore old behavior using the -transition=import compiler switch.)
+
+    $(P See also $(BUGZILLA 10378))
 )
 
 Macros:

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1076,9 +1076,9 @@ public:
         return baseok >= BASEOKdone;
     }
 
-    override final Dsymbol search(Loc loc, Identifier ident, int flags = IgnoreNone)
+    override final Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
-        //printf("%s.ClassDeclaration.search('%s')\n", toChars(), ident.toChars());
+        //printf("%s.ClassDeclaration.search('%s', flags=x%x)\n", toChars(), ident.toChars(), flags);
         //if (scope) printf("%s baseok = %d\n", toChars(), baseok);
         if (_scope && baseok < BASEOKdone)
         {
@@ -1098,7 +1098,7 @@ public:
             return null;
         }
 
-        Dsymbol s = ScopeDsymbol.search(loc, ident, flags);
+        Dsymbol s = ScopeDsymbol.search(loc, ident, (flags & SearchImportsOnly) ? flags : flags | SearchLocalsOnly);
         if (!s)
         {
             // Search bases classes in depth-first, left to right order
@@ -1111,7 +1111,7 @@ public:
                         error("base %s is forward referenced", b.sym.ident.toChars());
                     else
                     {
-                        s = b.sym.search(loc, ident, flags);
+                        s = b.sym.search(loc, ident, flags | SearchLocalsOnly);
                         if (s == this) // happens if s is nested in this and derives from this
                             s = null;
                         else if (s)

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -234,7 +234,7 @@ public:
         return 1;
     }
 
-    override final Dsymbol search(Loc loc, Identifier ident, int flags = IgnoreNone)
+    override final Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
         Dsymbol s = Dsymbol.search(loc, ident, flags);
         if (!s && type)

--- a/src/denum.d
+++ b/src/denum.d
@@ -308,7 +308,7 @@ public:
         return "enum";
     }
 
-    override Dsymbol search(Loc loc, Identifier ident, int flags = IgnoreNone)
+    override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
         //printf("%s.EnumDeclaration::search('%s')\n", toChars(), ident->toChars());
         if (_scope)

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -443,9 +443,9 @@ public:
         }
     }
 
-    override Dsymbol search(Loc loc, Identifier ident, int flags = IgnoreNone)
+    override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
-        //printf("%s.Import::search(ident = '%s', flags = x%x)\n", toChars(), ident.toChars(), flags);
+        //printf("%s.Import.search(ident = '%s', flags = x%x)\n", toChars(), ident.toChars(), flags);
         if (!pkg)
         {
             load(null);

--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -576,9 +576,9 @@ public:
         }
     }
 
-    override final Dsymbol search(Loc loc, Identifier ident, int flags = IgnoreNone)
+    override final Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
-        //printf("%s.StructDeclaration::search('%s')\n", toChars(), ident->toChars());
+        //printf("%s.StructDeclaration::search('%s', flags = x%x)\n", toChars(), ident.toChars(), flags);
         if (_scope && !symtab)
             semantic(_scope);
 

--- a/src/globals.d
+++ b/src/globals.d
@@ -115,6 +115,7 @@ struct Param
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations
     bool dwarfeh;           // generate dwarf eh exception handling
+    bool bug10378;          // use pre-bugzilla 10378 search strategy
 
     BOUNDSCHECK useArrayBounds;
 

--- a/src/mars.d
+++ b/src/mars.d
@@ -231,7 +231,7 @@ Usage:
   -release       compile release version
   -run srcfile args...   run resulting program, passing args
   -shared        generate shared library (DLL)
-  -transition=id show additional info about language change identified by 'id'
+  -transition=id help with language change identified by 'id'
   -transition=?  list all language changes
   -unittest      compile in unit tests
   -v             verbose
@@ -683,6 +683,7 @@ Language changes listed by -transition=id:
   =all           list information on all language changes
   =complex,14488 list all usages of complex or imaginary types
   =field,3449    list all non-mutable fields which occupy an object instance
+  =import,10378  revert to single phase name lookup
   =tls           list all variables going into thread local storage
 ");
                         return EXIT_FAILURE;
@@ -699,6 +700,9 @@ Language changes listed by -transition=id:
                         {
                         case 3449:
                             global.params.vfield = true;
+                            break;
+                        case 10378:
+                            global.params.bug10378 = true;
                             break;
                         case 14488:
                             global.params.vcomplex = true;
@@ -730,6 +734,13 @@ Language changes listed by -transition=id:
                             if (strcmp(ident, "field") == 0)
                             {
                                 global.params.vfield = true;
+                                break;
+                            }
+                            goto Lerror;
+                        case 6:
+                            if (strcmp(ident, "import") == 0)
+                            {
+                                global.params.bug10378 = true;
                                 break;
                             }
                             goto Lerror;

--- a/src/nspace.d
+++ b/src/nspace.d
@@ -186,7 +186,7 @@ public:
         return Dsymbol.oneMember(ps, ident);
     }
 
-    override final Dsymbol search(Loc loc, Identifier ident, int flags = IgnoreNone)
+    override final Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
         //printf("%s.Nspace.search('%s')\n", toChars(), ident.toChars());
         if (_scope && !symtab)

--- a/test/fail_compilation/diag12598.d
+++ b/test/fail_compilation/diag12598.d
@@ -1,7 +1,8 @@
 /*
+REQUIRED_ARGS: -transition=import
 TEST_OUTPUT:
 ---
-fail_compilation/diag12598.d(13): Error: struct 'lines' is a type, not an lvalue
+fail_compilation/diag12598.d(14): Error: struct 'lines' is a type, not an lvalue
 ---
 */
 

--- a/test/fail_compilation/imports/imp1.d
+++ b/test/fail_compilation/imports/imp1.d
@@ -1,0 +1,5 @@
+module imp1;
+
+enum X = 1;
+enum Y = 1;
+enum Z = 1;

--- a/test/fail_compilation/imports/imp2.d
+++ b/test/fail_compilation/imports/imp2.d
@@ -1,0 +1,5 @@
+module imp2;
+
+enum X = 2;
+enum Y = 2;
+enum Z = 2;

--- a/test/fail_compilation/lookup.d
+++ b/test/fail_compilation/lookup.d
@@ -1,0 +1,26 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/lookup.d(21): Error: no property 'X' for type 'lookup.B'
+fail_compilation/lookup.d(22): Error: no property 'Y' for type 'lookup.B'
+---
+*/
+
+import imports.imp1;
+
+enum X = 0;
+
+class B
+{
+    import imports.imp2;
+    static assert(X == 0);
+    static assert(Y == 2);
+}
+class C : B
+{
+    static assert(B.X == 0);
+    static assert(B.Y == 2);
+
+    static assert(X == 0);
+    static assert(Y == 1);
+}

--- a/test/runnable/imports/bar10378.d
+++ b/test/runnable/imports/bar10378.d
@@ -1,0 +1,4 @@
+
+module bar;
+
+void writeln() { }

--- a/test/runnable/test10378.d
+++ b/test/runnable/test10378.d
@@ -1,0 +1,13 @@
+
+int writeln() { return 3; }
+
+struct S {
+    import imports.bar10378;
+    void abc() { assert(writeln() == 3); }
+}
+
+
+void main() {
+    S s;
+    s.abc();
+}

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -943,7 +943,7 @@ void getProtection()
 
 void test9546()
 {
-    import imports.a9546;
+    import imports.a9546 : S;
 
     S s;
     static assert(__traits(getProtection, s.privA) == "private");


### PR DESCRIPTION
This is a fix of https://issues.dlang.org/show_bug.cgi?id=10378 and a reboot of https://github.com/D-Programming-Language/dmd/pull/4915

It requires https://github.com/D-Programming-Language/phobos/pull/3989

This version is based on a comment Andrei made to me a long time ago about it. Symbol lookup is now done in two passes (formerly one). The first pass goes up through the scopes, checking everything but imported modules. If that fails, the scopes are gone through again, checking only imported modules.

This algorithm:
1. retains the scoped nature of nested imports, i.e. names in nested imports **will hide** outer imported names
2. works the same for function locals as it does for struct members, which was my complaint about #4915 
3. does not issue errors for shadowing - it simply finds the shadowed symbol first.
4. **breaks existing code**. Turns out that people did rely on it. See https://github.com/D-Programming-Language/phobos/pull/3989
5. is pretty simple. (the large number of lines of code changed is mostly due to debugging and printing code which I'll remove once it passes the autotester
6. exposed a bug in the way the compiler is implemented, see https://github.com/D-Programming-Language/phobos/pull/3989 for that, too. I'm sure there'll be other instances in the wild of this.
7. it should only be a hair slower, as it never looks in the same hash table twice
