### PR TITLE
encapsulate memory management of Scope.fieldinit

### DIFF
--- a/src/dscope.d
+++ b/src/dscope.d
@@ -255,14 +255,15 @@ struct Scope
         if (enclosing)
         {
             enclosing.callSuper |= callSuper;
-            if (enclosing.fieldinit && fieldinit)
+            if (fieldinit)
             {
-                assert(fieldinit != enclosing.fieldinit);
-                size_t dim = fieldinit_dim;
-                for (size_t i = 0; i < dim; i++)
-                    enclosing.fieldinit[i] |= fieldinit[i];
-                mem.xfree(fieldinit);
-                fieldinit = null;
+                if (enclosing.fieldinit)
+                {
+                    assert(fieldinit != enclosing.fieldinit);
+                    foreach (i; 0 .. fieldinit_dim)
+                        enclosing.fieldinit[i] |= fieldinit[i];
+                }
+                freeFieldinit();
             }
         }
         if (!nofree)
@@ -272,6 +273,20 @@ struct Scope
             flags |= SCOPEfree;
         }
         return enc;
+    }
+
+    void allocFieldinit(size_t dim)
+    {
+        fieldinit = cast(typeof(fieldinit))mem.xcalloc(typeof(*fieldinit).sizeof, dim);
+        fieldinit_dim = dim;
+    }
+
+    void freeFieldinit()
+    {
+        if (fieldinit)
+            mem.xfree(fieldinit);
+        fieldinit = null;
+        fieldinit_dim = 0;
     }
 
     extern (C++) Scope* startCTFE()

--- a/src/func.d
+++ b/src/func.d
@@ -1603,19 +1603,14 @@ public:
                 sym.parent = sc2.scopesym;
                 sc2 = sc2.push(sym);
                 AggregateDeclaration ad2 = isAggregateMember2();
-                uint* fieldinit = null;
                 /* If this is a class constructor
                  */
                 if (ad2 && isCtorDeclaration())
                 {
-                    fieldinit = cast(uint*)mem.xmalloc(uint.sizeof * ad2.fields.dim);
-                    sc2.fieldinit = fieldinit;
-                    sc2.fieldinit_dim = ad2.fields.dim;
-                    for (size_t i = 0; i < ad2.fields.dim; i++)
+                    sc2.allocFieldinit(ad2.fields.dim);
+                    foreach (v; ad2.fields)
                     {
-                        VarDeclaration v = ad2.fields[i];
                         v.ctorinit = 0;
-                        sc2.fieldinit[i] = 0;
                     }
                 }
                 if (!inferRetType && retStyle(f) != RETstack)
@@ -1712,8 +1707,7 @@ public:
                             }
                         }
                     }
-                    sc2.fieldinit = null;
-                    sc2.fieldinit_dim = 0;
+                    sc2.freeFieldinit();
                     if (cd && !(sc2.callSuper & CSXany_ctor) && cd.baseClass && cd.baseClass.ctor)
                     {
                         sc2.callSuper = 0;
@@ -1884,8 +1878,6 @@ public:
                     nw.sc = sc2;
                     nw.visitStmt(fbody);
                 }
-                if (fieldinit)
-                    mem.xfree(fieldinit);
                 sc2 = sc2.pop();
             }
             Statement freq = frequire;


### PR DESCRIPTION
allocs and frees of one item should not be distributed among different modules
