### PR TITLE
Fix test22.d/test47() on Solaris.

### DIFF
--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -1012,6 +1012,36 @@ body
 	    ;
 	}
 	}
+	else version (Solaris)
+	{
+	asm     // assembler by W. Bright
+	{
+	    // EDX = (A.length - 1) * real.sizeof
+	    mov     ECX,A[EBP]          ; // ECX = A.length
+	    dec     ECX                 ;
+	    lea     EDX,[ECX][ECX*8]    ;
+	    add     EDX,ECX             ;
+	    add     EDX,ECX             ;
+	    add     EDX,ECX             ;
+	    add     EDX,A+4[EBP]        ;
+	    fld     real ptr [EDX]      ; // ST0 = coeff[ECX]
+	    jecxz   return_ST           ;
+	    fld     x[EBP]              ; // ST0 = x
+	    fxch    ST(1)               ; // ST1 = x, ST0 = r
+	    align   4                   ;
+    L2:     fmul    ST,ST(1)            ; // r *= x
+	    fld     real ptr -12[EDX]   ;
+	    sub     EDX,12              ; // deg--
+	    faddp   ST(1),ST            ;
+	    dec     ECX                 ;
+	    jne     L2                  ;
+	    fxch    ST(1)               ; // ST1 = r, ST0 = x
+	    fstp    ST(0)               ; // dump x
+	    align   4                   ;
+    return_ST:                          ;
+	    ;
+	}
+	}
 	else
 	{
 	asm     // assembler by W. Bright


### PR DESCRIPTION
On Solaris the default assembly implementation is choosen. This is the wrong way.
Inline assembly is very sensitive to calling conventions etc. There can be no
single default implementation. To fix:
- Implement correct version for Solaris
- Replace default implement with error message

Found with ldc2 0.17.0 on OpenSolaris 11.3.
