### PR TITLE
refactor: replace cast with paint

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -446,3 +446,50 @@ alias PINLINEalways = PINLINE.PINLINEalways;
 alias StorageClass = uinteger_t;
 
 extern (C++) __gshared Global global;
+
+
+/***********************************
+ * Perform a cast of b to
+ * its derived type Derived by simply
+ * changing its type, i.e. not doing a dynamic
+ * cast.
+ * const-ness of b is preserved in the result.
+ * Params:
+ *      b = Base class instance to convert
+ *      Derived = derived class to convert it to
+ * Returns:
+ *      b reinterpreted as an instance of Derived
+ */
+
+inout(Derived) paint(Derived, Base)(inout(Base) b)
+        if (is(Base == class) && is(Derived == class))
+{
+    //pragma(inline, true);     // not supported yet by build compiler
+    debug
+    {
+        /* Check that it is a valid cast by using
+         * the dynamic cast and checking that it succeeded
+         */
+        auto c = cast(inout(Derived))b;
+        assert(c !is null);
+        return c;
+    }
+    else
+    {
+        return cast(inout(Derived)) cast(inout(void)*) b;
+    }
+}
+
+unittest
+{
+    class B { }
+    class C : B { }
+
+    B b = new B();
+    C c = paint!C(b);
+
+    const B bc = new B();
+    const C cc = paint!C(bc);
+}
+
+

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -261,12 +261,12 @@ extern (C++) Type stripDefaultArgs(Type t)
         return t;
     if (t.ty == Tfunction)
     {
-        TypeFunction tf = cast(TypeFunction)t;
+        TypeFunction tf = paint!TypeFunction(t);
         Type tret = stripDefaultArgs(tf.next);
         Parameters* params = stripParams(tf.parameters);
         if (tret == tf.next && params == tf.parameters)
             goto Lnot;
-        tf = cast(TypeFunction)tf.copy();
+        tf = paint!TypeFunction(tf.copy());
         tf.parameters = params;
         tf.next = tret;
         //printf("strip %s\n   <- %s\n", tf->toChars(), t->toChars());
@@ -274,12 +274,12 @@ extern (C++) Type stripDefaultArgs(Type t)
     }
     else if (t.ty == Ttuple)
     {
-        TypeTuple tt = cast(TypeTuple)t;
+        TypeTuple tt = paint!TypeTuple(t);
         Parameters* args = stripParams(tt.arguments);
         if (args == tt.arguments)
             goto Lnot;
         t = t.copy();
-        (cast(TypeTuple)t).arguments = args;
+        paint!TypeTuple(t).arguments = args;
     }
     else if (t.ty == Tenum)
     {
@@ -293,7 +293,7 @@ extern (C++) Type stripDefaultArgs(Type t)
         if (n == tn)
             goto Lnot;
         t = t.copy();
-        (cast(TypeNext)t).next = n;
+        paint!TypeNext(t).next = n;
     }
     //printf("strip %s\n", t->toChars());
 Lnot:


### PR DESCRIPTION
The old C++ version of this code avoided dynamic_cast in favor of a direct cast with no checking. This was for performance reasons. The few places were dynamic_cast was needed are the isXXXXX() series of virtual functions. The D version does a dynamic cast, which is slow and involves function calls, etc.

This fixes that by introducing `paint` which does a dynamic cast for `debug` and a type paint otherwise. I included a sample of how it is to be used.
