### PR TITLE
[REG2.067] Issue 15681 - Nested user type enum not retaining value properly

### DIFF
--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -2891,9 +2891,15 @@ public:
         assert(argnum == arguments.dim - 1);
         if (elemType.ty == Tchar || elemType.ty == Twchar || elemType.ty == Tdchar)
         {
-            return createBlockDuplicatedStringLiteral(loc, newtype, cast(uint)elemType.defaultInitLiteral(loc).toInteger(), len, cast(ubyte)elemType.size());
+            const ch = cast(dchar)elemType.defaultInitLiteral(loc).toInteger();
+            const sz = cast(ubyte)elemType.size();
+            return createBlockDuplicatedStringLiteral(loc, newtype, ch, len, sz);
         }
-        return createBlockDuplicatedArrayLiteral(loc, newtype, elemType.defaultInitLiteral(loc), len);
+        else
+        {
+            auto el = interpret(elemType.defaultInitLiteral(loc), istate);
+            return createBlockDuplicatedArrayLiteral(loc, newtype, el, len);
+        }
     }
 
     override void visit(NewExp e)
@@ -5916,8 +5922,8 @@ public:
         if (v.type.ty != result.type.ty && v.type.ty == Tsarray)
         {
             // Block assignment from inside struct literals
-            TypeSArray tsa = cast(TypeSArray)v.type;
-            size_t len = cast(size_t)tsa.dim.toInteger();
+            auto tsa = cast(TypeSArray)v.type;
+            auto len = cast(size_t)tsa.dim.toInteger();
             result = createBlockDuplicatedArrayLiteral(ex.loc, v.type, ex, len);
             (*se.elements)[i] = result;
         }

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -3395,6 +3395,35 @@ void test14862()
 }
 
 /************************************************/
+// 15681
+
+void test15681()
+{
+    static struct A { float value; }
+
+    static struct S
+    {
+        A[2] values;
+
+        this(float)
+        {
+            values[0].value = 0;
+            values[1].value = 1;
+        }
+    }
+
+    auto s1 = S(1.0f);
+    assert(s1.values[0].value == 0);        // OK
+    assert(s1.values[1].value == 1);        // OK
+
+    enum s2 = S(1.0f);
+    static assert(s2.values[0].value == 0); // OK <- NG
+    static assert(s2.values[1].value == 1); // OK
+    assert(s2.values[0].value == 0);        // OK <- NG
+    assert(s2.values[1].value == 1);        // OK
+}
+
+/************************************************/
 
 int main()
 {
@@ -3516,6 +3545,7 @@ int main()
     test9954();
     test14140();
     test14862();
+    test15681();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
1. It was a bug in `createBlockDuplicatedArrayLiteral` function. On array literal construction, the element should be copied when the type has value semantics and the CTFE value has sub payload.
2. Also the `createBlockDuplicatedArrayLiteral` callers need to handle the `elem` argument ownership well.
   2a. In `copyLiteral`, it didn't copy the source struct element on block assignment.
   2b. In `recursivelyCreateArrayLiteral`, the `elemType.defaultInitLiteral(loc)` is not yet CTFE-ed expression. So it should be interpreted to copy it into CTFE world.
