### PR TITLE
Issue 13537: forbid modifying overlapping mutable/immutable fields in @safe code

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -348,6 +348,10 @@ public:
                     }
                 }
                 vd.overlapped = true;
+                if (v2 && (vd.storage_class & STCimmutable) != (v2.storage_class & STCimmutable))
+                {
+                    vd.overlapsImmutable = true;
+                }
 
                 if (!vx)
                     continue;

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -981,6 +981,7 @@ public:
 
     int canassign;                  // it can be assigned to
     bool overlapped;                // if it is a field and has overlapping
+    bool overlapsImmutable;         // if it overlaps mutable with immutable
     Dsymbol aliassym;               // if redone as alias to another symbol
     VarDeclaration lastVar;         // Linked list of variables for goto-skips-init detection
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -8662,10 +8662,17 @@ public:
 
     override int checkModifiable(Scope* sc, int flag)
     {
-        //printf("DotVarExp::checkModifiable %s %s\n", toChars(), type->toChars());
+        //printf("DotVarExp::checkModifiable %s %s\n", toChars(), type.toChars());
+        VarDeclaration vd = var.isVarDeclaration();
+        if (!flag && vd.overlapped && vd.overlapsImmutable && sc.func &&
+            sc.func.setUnsafe())
+        {
+            e1.error("field %s cannot be modified in @safe code because it overlaps mutable and immutable", toChars());
+            return 2;
+        }
         if (e1.op == TOKthis)
             return var.checkModify(loc, sc, type, e1, flag);
-        //printf("\te1 = %s\n", e1->toChars());
+        //printf("\te1 = %s\n", e1.toChars());
         return e1.checkModifiable(sc, flag);
     }
 

--- a/test/fail_compilation/fail13537.d
+++ b/test/fail_compilation/fail13537.d
@@ -1,0 +1,29 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail13537.d(16): Error: field u.y cannot be modified in @safe code because it overlaps mutable and immutable
+fail_compilation/fail13537.d(18): Error: field u.y cannot be modified in @safe code because it overlaps mutable and immutable
+---
+*/
+union U
+{
+    immutable int x;
+    int y;
+} 
+void fun() @safe
+{
+    U u;
+    u.y = 1;
+    assert(u.x == 1);
+    u.y = 2;
+    assert(u.x == 2); // look ma! I broke immutability!
+
+    // read-only access should be allowed
+    int a = u.x;
+}
+void gun() @system
+{
+    U u;
+    u.y = 1; // should be allowed in @system code
+    int a = u.x;
+}

--- a/test/fail_compilation/fail13537.d
+++ b/test/fail_compilation/fail13537.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13537.d(16): Error: field u.y cannot be modified in @safe code because it overlaps mutable and immutable
-fail_compilation/fail13537.d(18): Error: field u.y cannot be modified in @safe code because it overlaps mutable and immutable
+fail_compilation/fail13537.d(21): Error: field u.y cannot be modified in @safe code because it overlaps mutable and immutable
+fail_compilation/fail13537.d(23): Error: field u.y cannot be modified in @safe code because it overlaps mutable and immutable
 ---
 */
 union U
@@ -10,6 +10,11 @@ union U
     immutable int x;
     int y;
 } 
+union V
+{
+    immutable int x;
+    const int y;
+}
 void fun() @safe
 {
     U u;
@@ -20,6 +25,10 @@ void fun() @safe
 
     // read-only access should be allowed
     int a = u.x;
+
+    // Overlapping const/immutable should be allowed
+    auto v = V(1);
+    assert(v.y == 1);
 }
 void gun() @system
 {


### PR DESCRIPTION
This implementation is a compromise; it only prevents immutable breakage in `@safe` code, but still allows this in `@system` code, because forbidding it in `@system` code would break existing code such as `std.typecons.Rebindable` that use a union to reinterpret type modifiers.
