### PR TITLE
Issue15702: prohibit implicit conversion to void[] in @safe code if array elements have indirection

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -10740,7 +10740,11 @@ public:
         {
             // Disallow unsafe casts
 
-            // Implicit conversions are always safe
+            // This must come before checking implicitConvTo else T[] -> void[]
+            // will pass, even when T has indirections.
+            if (t1b.ty == Tarray && tob.ty == Tarray && !isSafeArrayConversion(t1b, tob))
+                goto Lunsafe;
+
             if (t1b.implicitConvTo(tob))
                 goto Lsafe;
 
@@ -10762,6 +10766,15 @@ public:
                 if (!MODimplicitConv(t1b.mod, tob.mod))
                     goto Lunsafe;
                 goto Lsafe;
+            }
+
+            version(none) // BABABLACKSHEEP
+            if (t1b.ty == Tarray && tob.ty == Tarray)
+            {
+                /* Issue 15702: @safe code should not allow casting of T[] to
+                 * U[] if T has indirections and U is mutable. */
+                if (!isSafeArrayConversion(t1b, tob) && tn.isMutable())
+                    goto Lunsafe;
             }
 
             if (tob.ty == Tarray && t1b.ty == Tsarray) // Bugzilla 12502

--- a/test/fail_compilation/fail15702.d
+++ b/test/fail_compilation/fail15702.d
@@ -1,0 +1,86 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail15702.d(52): Error: cast from int*[] to void[] not allowed in safe code
+fail_compilation/fail15702.d(53): Error: cast from Object[] to void[] not allowed in safe code
+fail_compilation/fail15702.d(54): Error: cannot implicitly convert expression (ptrs) of type int*[] to void[] in @safe code because int*[] has indirections
+fail_compilation/fail15702.d(55): Error: cannot implicitly convert expression (objs) of type Object[] to void[] in @safe code because Object[] has indirections
+fail_compilation/fail15702.d(56): Error: cannot implicitly convert expression (tees) of type T[] to void[] in @safe code because T[] has indirections
+fail_compilation/fail15702.d(57): Error: cannot implicitly convert expression ([new Object]) of type Object[] to void[] in @safe code because Object[] has indirections
+fail_compilation/fail15702.d(58): Error: cast from Object[] to int[] not allowed in safe code
+---
+*/
+void notTrustworthy(void[] buf) @trusted
+{
+    auto bytes = cast(ubyte[]) buf;
+    bytes[0] = 123;
+}
+void trustworthy(const(void)[] buf) @trusted { }
+
+class A {}
+class B : A {}
+struct S { int x; }
+struct T { int* x; }
+
+int[] ints;
+int*[] ptrs;
+Object[] objs;
+S[] asses;
+T[] tees;
+
+void safeFun() @safe
+{
+    // should be allowed:
+    notTrustworthy(ints);
+    notTrustworthy(asses);
+    trustworthy(ints);
+    trustworthy(ptrs);
+    trustworthy(objs);
+    const(void)[] arrconst = ptrs;
+    const(void[]) constarr = ptrs;
+    auto a1 = cast(const(int)[]) objs;
+    auto a2 = cast(int*[]) ptrs;
+    const(int*)[] a3 = ptrs;
+    auto a4 = cast(const(int*)[]) a3;
+    double[][] dbls = [[1, 2], [3, 4], [5, 6, 7]];
+    const(T)[] cts = tees;
+
+    // typeof should not emit errors
+    alias X = typeof(notTrustworthy(ptrs));
+
+    // should be prohibited:
+    notTrustworthy(cast(void[]) ptrs);
+    notTrustworthy(cast(void[]) objs);
+    notTrustworthy(ptrs);
+    notTrustworthy(objs);
+    notTrustworthy(tees);
+    void[] b1 = [ new Object() ];
+    auto b2 = cast(int[]) objs;
+}
+
+void unsafeFun() @system
+{
+    notTrustworthy(ints);
+    notTrustworthy(asses);
+    trustworthy(ints);
+    trustworthy(ptrs);
+    trustworthy(objs);
+    const(void)[] arrconst = ptrs;
+    const(void[]) constarr = ptrs;
+    auto a1 = cast(const(int)[]) objs;
+    auto a2 = cast(int*[]) ptrs;
+    const(int*)[] a3 = ptrs;
+    auto a4 = cast(const(int*)[]) a3;
+    double[][] dbls = [[1, 2], [3, 4], [5, 6, 7]];
+    const(T)[] cts = tees;
+
+    alias X = typeof(notTrustworthy(ptrs));
+
+    notTrustworthy(cast(void[]) ptrs);
+    notTrustworthy(cast(void[]) objs);
+    notTrustworthy(ptrs);
+    notTrustworthy(objs);
+    notTrustworthy(tees);
+    void[] b1 = [ new Object() ];
+    auto b2 = cast(int[]) objs;
+}


### PR DESCRIPTION
As a usability compromise, still allow explicit casting to `void[]` in `@safe` code. Not 100% sure about this. Maybe it's better to completely prohibit all such casts since they usually occur in I/O functions calling C APIs, which almost certainly means overwriting pointers with arbitrary external data.

Note that implicitly casting arrays with no indirections is still allowed, so any code breakage will only be in places where the code is already breaking `@safe`.

Also, not 100% sure this is the right place in the compiler to put this check, but it seems to be the place that needs minimal code changes.
