### PR TITLE
DIP22 - private symbol (in)visibility

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -11,6 +11,7 @@ $(BUGSTITLE Compiler Changes,
 $(BUGSTITLE Language Changes,
     $(LI $(RELATIVE_LINK2 extended-deprecated, Manifest constant can now be used for deprecation message.))
     $(LI $(RELATIVE_LINK2 import-lookup, Imports no longer hide locals declared in outer scopes.))
+    $(LI $(RELATIVE_LINK2 dip22, Private symbols are no longer visible in other modules.))
 )
 
 $(BUGSTITLE Compiler Changes,
@@ -73,11 +74,33 @@ $(BUGSTITLE Language Changes,
 
     $(P See also $(BUGZILLA 10378))
     )
+
+    $(LI $(LNAME2 dip22, Private symbols are no longer visible in other modules.)
+
+    $(P Protection (private, package, protected) is now already enforced during
+        symbol lookup in order to resolve any conflicts between private and
+        public symbols that could occur with the old access check scheme.
+    )
+
+    $(P The visibility of overloaded symbols with mixed protection is determined
+        by the most visibile member, but additional access check against the exact
+        symbol is performed after overload resolution.
+    )
+
+    $(P To ease updating existing code, a deprecated search for invisible symbols will be performed.
+        For the the old lookup behavior (using the -transition=import or -transition=checkimports compiler switch)
+        symbol visibility is ignored.
+        All existing access checks remain active during the deprecation phase.
+    )
+
+    $(P See also $(LINK2 http://wiki.dlang.org/DIP22, DIP22))
+    )
 )
 
 Macros:
     TITLE=Change Log
 
+    H4 = <h4>$0</h4>
     BUGSTITLE = <div class="bugsfixed">$(H4 $1) $(OL $2 )</div>
 
     RELATIVE_LINK2=<a href="#$1">$+</a>

--- a/src/access.d
+++ b/src/access.d
@@ -229,9 +229,14 @@ extern (C++) bool isFriendOf(AggregateDeclaration ad, AggregateDeclaration cd)
  */
 extern (C++) bool hasPackageAccess(Scope* sc, Dsymbol s)
 {
+    return hasPackageAccess(sc._module, s);
+}
+
+extern (C++) bool hasPackageAccess(Module mod, Dsymbol s)
+{
     static if (LOG)
     {
-        printf("hasPackageAccess(s = '%s', sc = '%p', s->protection.pkg = '%s')\n", s.toChars(), sc, s.prot().pkg ? s.prot().pkg.toChars() : "NULL");
+        printf("hasPackageAccess(s = '%s', mod = '%s', s->protection.pkg = '%s')\n", s.toChars(), mod.toChars(), s.prot().pkg ? s.prot().pkg.toChars() : "NULL");
     }
     Package pkg = null;
     if (s.prot().pkg)
@@ -265,7 +270,7 @@ extern (C++) bool hasPackageAccess(Scope* sc, Dsymbol s)
     }
     if (pkg)
     {
-        if (pkg == sc._module.parent)
+        if (pkg == mod.parent)
         {
             static if (LOG)
             {
@@ -273,7 +278,7 @@ extern (C++) bool hasPackageAccess(Scope* sc, Dsymbol s)
             }
             return true;
         }
-        if (pkg.isPackageMod() == sc._module)
+        if (pkg.isPackageMod() == mod)
         {
             static if (LOG)
             {
@@ -281,7 +286,7 @@ extern (C++) bool hasPackageAccess(Scope* sc, Dsymbol s)
             }
             return true;
         }
-        Dsymbol ancestor = sc._module.parent;
+        Dsymbol ancestor = mod.parent;
         for (; ancestor; ancestor = ancestor.parent)
         {
             if (ancestor == pkg)
@@ -440,4 +445,44 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Package p)
     else
         deprecation(loc, "%s %s is not accessible here", p.kind(), name);
     return true;
+}
+
+/**
+ * Check whether symbols `s` is visible in `mod`.
+ *
+ * Params:
+ *  mod = lookup origin
+ *  s = symbol to check for visibility
+ * Returns: true if s is visible in mod
+ */
+extern (C++) bool symbolIsVisible(Module mod, Dsymbol s)
+{
+    // should sort overloads by ascending protection instead of iterating here
+    if (s.isOverloadable())
+    {
+        // Use the least protected overload to determine visibility
+        // and perform an access check after overload resolution.
+        overloadApply(s, (s2) {
+          if (s.prot().isMoreRestrictiveThan(s2.prot()))
+            s = s2;
+          return 0;
+        });
+    }
+    final switch (s.prot().kind)
+    {
+    case PROTundefined: return true;
+    case PROTnone: return false; // no access
+    case PROTprivate: return s.getAccessModule() == mod;
+    case PROTpackage: return hasPackageAccess(mod, s);
+    case PROTprotected: return s.getAccessModule() == mod;
+    case PROTpublic, PROTexport: return true;
+    }
+}
+
+/**
+ * Same as above, but determines the lookup module from symbols `origin`.
+ */
+extern (C++) bool symbolIsVisible(Dsymbol origin, Dsymbol s)
+{
+    return symbolIsVisible(origin.getAccessModule(), s);
 }

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1111,10 +1111,16 @@ public:
                         error("base %s is forward referenced", b.sym.ident.toChars());
                     else
                     {
+                        import ddmd.access : symbolIsVisible;
+
                         s = b.sym.search(loc, ident, flags | SearchLocalsOnly);
-                        if (s == this) // happens if s is nested in this and derives from this
+                        if (!s)
+                            continue;
+                        else if (s == this) // happens if s is nested in this and derives from this
                             s = null;
-                        else if (s)
+                        else if (!(flags & IgnoreSymbolVisibility) && !(s.prot().kind == PROTprotected) && !symbolIsVisible(this, s))
+                            s = null;
+                        else
                             break;
                     }
                 }

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -514,11 +514,19 @@ struct Scope
         {
             // Search both ways
 
-            auto sold = searchScopes(flags | SearchCheck10378);
+            auto sold = searchScopes(flags | SearchCheck10378 | IgnoreSymbolVisibility);
 
             auto snew = searchScopes(flags | SearchCheck10378 | SearchLocalsOnly);
             if (!snew)
                 snew = searchScopes(flags | SearchCheck10378 | SearchImportsOnly);
+            if (!snew)
+            {
+                snew = searchScopes(flags | SearchCheck10378 | SearchLocalsOnly | IgnoreSymbolVisibility);
+                if (!snew)
+                    snew = searchScopes(flags | SearchCheck10378 | SearchImportsOnly | IgnoreSymbolVisibility);
+                if (snew)
+                    .deprecation(loc, "%s is not visible from module %s", snew.toPrettyChars(), _module.toChars());
+            }
 
             if (sold !is snew)
             {
@@ -530,7 +538,7 @@ struct Scope
         }
 
         if (global.params.bug10378)
-            return searchScopes(flags);
+            return searchScopes(flags | IgnoreSymbolVisibility);
 
         // First look in local scopes
         Dsymbol s = searchScopes(flags | SearchLocalsOnly);

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -170,7 +170,7 @@ alias PASSobj = PASS.PASSobj;
 enum : int
 {
     IgnoreNone              = 0x00, // default
-    IgnorePrivateMembers    = 0x01, // don't find private members
+    IgnorePrivateImports    = 0x01, // don't search private imports
     IgnoreErrors            = 0x02, // don't give error messages
     IgnoreAmbiguous         = 0x04, // return NULL if ambiguous
     SearchLocalsOnly        = 0x08, // only look at locals (don't search imports)
@@ -1268,7 +1268,7 @@ public:
             for (size_t i = 0; i < importedScopes.dim; i++)
             {
                 // If private import, don't search it
-                if ((flags & IgnorePrivateMembers) && prots[i] == PROTprivate)
+                if ((flags & IgnorePrivateImports) && prots[i] == PROTprivate)
                     continue;
                 int sflags = flags & (IgnoreErrors | IgnoreAmbiguous); // remember these in recursive searches
                 Dsymbol ss = (*importedScopes)[i];
@@ -1280,7 +1280,7 @@ public:
                     {
                         if (global.params.check10378 && !(flags & SearchCheck10378))
                         {
-                            auto s3 = ss.search(loc, ident, sflags | IgnorePrivateMembers);
+                            auto s3 = ss.search(loc, ident, sflags | IgnorePrivateImports);
                             if (s3)
                                 deprecation("%s %s found in local import", s3.kind(), s3.toPrettyChars());
                         }
@@ -1296,7 +1296,7 @@ public:
 
                 /* Don't find private members if ss is a module
                  */
-                Dsymbol s2 = ss.search(loc, ident, sflags | (ss.isModule() ? IgnorePrivateMembers : IgnoreNone));
+                Dsymbol s2 = ss.search(loc, ident, sflags | (ss.isModule() ? IgnorePrivateImports : IgnoreNone));
                 if (!s)
                 {
                     s = s2;

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -135,7 +135,7 @@ enum PASS
 enum
 {
     IgnoreNone              = 0x00, // default
-    IgnorePrivateMembers    = 0x01, // don't find private members
+    IgnorePrivateImports    = 0x01, // don't search private imports
     IgnoreErrors            = 0x02, // don't give error messages
     IgnoreAmbiguous         = 0x04, // return NULL if ambiguous
 };

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -138,6 +138,14 @@ enum
     IgnorePrivateImports    = 0x01, // don't search private imports
     IgnoreErrors            = 0x02, // don't give error messages
     IgnoreAmbiguous         = 0x04, // return NULL if ambiguous
+    SearchLocalsOnly        = 0x08, // only look at locals (don't search imports)
+    SearchImportsOnly       = 0x10, // only look in imports
+    SearchUnqualifiedModule = 0x20, // the module scope search is unqualified,
+                                    // meaning don't search imports in that scope,
+                                    // because qualified module searches search
+                                    // their imports
+    SearchCheck10378        = 0x40, // unqualified search with transition=checkimports switch
+    IgnoreSymbolVisibility  = 0x80, // also find private and package protected symbols
 };
 
 typedef int (*Dsymbol_apply_ft_t)(Dsymbol *, void *);

--- a/src/expression.d
+++ b/src/expression.d
@@ -703,6 +703,19 @@ extern (C++) Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
         s = searchScopes(SearchLocalsOnly);
         if (!s)
             s = searchScopes(SearchImportsOnly);
+
+        /** Still find private symbols, so that symbols that weren't access
+         * checked by the compiler remain usable.  Once the deprecation is over,
+         * this should be moved to search_correct instead.
+         */
+        if (!s)
+        {
+            s = searchScopes(SearchLocalsOnly | IgnoreSymbolVisibility);
+            if (!s)
+                s = searchScopes(SearchImportsOnly | IgnoreSymbolVisibility);
+            if (s)
+                .deprecation(loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toChars());
+        }
     }
 
     if (!s)

--- a/src/expression.d
+++ b/src/expression.d
@@ -8320,7 +8320,7 @@ public:
              * the current module should have access to its own imports.
              */
             Dsymbol s = ie.sds.search(loc, ident,
-                (ie.sds.isModule() && ie.sds != sc._module) ? IgnorePrivateMembers | SearchLocalsOnly : SearchLocalsOnly);
+                (ie.sds.isModule() && ie.sds != sc._module) ? IgnorePrivateImports | SearchLocalsOnly : SearchLocalsOnly);
             if (s)
             {
                 /* Check for access before resolving aliases because public

--- a/src/expression.d
+++ b/src/expression.d
@@ -8321,13 +8321,19 @@ public:
              */
             Dsymbol s = ie.sds.search(loc, ident,
                 (ie.sds.isModule() && ie.sds != sc._module) ? IgnorePrivateImports | SearchLocalsOnly : SearchLocalsOnly);
+            /* Check for visibility before resolving aliases because public
+             * aliases to private symbols are public.
+             */
+            if (s && !symbolIsVisible(sc._module, s))
+            {
+                if (s.isDeclaration())
+                    .error(loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toChars());
+                else
+                    .deprecation(loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toChars());
+                // s = null;
+            }
             if (s)
             {
-                /* Check for access before resolving aliases because public
-                 * aliases to private symbols are public.
-                 */
-                if (Declaration d = s.isDeclaration())
-                    checkAccess(loc, sc, null, d);
                 if (auto p = s.isPackage())
                     checkAccess(loc, sc, p);
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -682,11 +682,19 @@ extern (C++) Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
     {
         // Search both ways
 
-        auto sold = searchScopes(SearchCheck10378);
+        auto sold = searchScopes(SearchCheck10378 | IgnoreSymbolVisibility);
 
         auto snew = searchScopes(SearchCheck10378 | SearchLocalsOnly);
         if (!snew)
             snew = searchScopes(SearchCheck10378 | SearchImportsOnly);
+        if (!snew)
+        {
+            snew = searchScopes(SearchCheck10378 | SearchLocalsOnly | IgnoreSymbolVisibility);
+            if (!snew)
+                snew = searchScopes(SearchCheck10378 | SearchImportsOnly | IgnoreSymbolVisibility);
+            if (snew)
+                .deprecation(loc, "%s is not visible from module %s", snew.toPrettyChars(), sc._module.toChars());
+        }
 
         if (sold !is snew)
         {
@@ -697,7 +705,7 @@ extern (C++) Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
         s = sold;
     }
     else if (global.params.bug10378)
-        s = searchScopes(0);
+        s = searchScopes(0 | IgnoreSymbolVisibility);
     else
     {
         s = searchScopes(SearchLocalsOnly);

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7864,6 +7864,11 @@ public:
             if (!s)
                 return noMember(sc, e, ident, flag);
         }
+        if (!symbolIsVisible(sc._module, s))
+        {
+            .deprecation(e.loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toChars());
+            // return noMember(sc, e, ident, flag);
+        }
         if (!s.isFuncDeclaration()) // because of overloading
             s.checkDeprecated(e.loc, sc);
         s = s.toAlias();
@@ -8719,6 +8724,11 @@ public:
             {
                 return noMember(sc, e, ident, flag);
             }
+        }
+        if (!symbolIsVisible(sc._module, s))
+        {
+            .deprecation(e.loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toChars());
+            // return noMember(sc, e, ident, flag);
         }
         if (!s.isFuncDeclaration()) // because of overloading
             s.checkDeprecated(e.loc, sc);

--- a/test/compilable/dip22.d
+++ b/test/compilable/dip22.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -de
 import imports.dip22;
 
 class Foo : Base1, Base2
@@ -8,4 +9,10 @@ class Foo : Base1, Base2
         static assert(baz == 2);
         static assert(T.sizeof == 2);
     }
+}
+
+void test()
+{
+    bar();
+    baz();
 }

--- a/test/compilable/dip22.d
+++ b/test/compilable/dip22.d
@@ -13,6 +13,8 @@ class Foo : Base1, Base2
 
 void test()
 {
-    bar();
-    baz();
+    bar(12);
+    baz(12);
+    12.bar();
+    12.baz();
 }

--- a/test/compilable/dip22.d
+++ b/test/compilable/dip22.d
@@ -1,0 +1,11 @@
+import imports.dip22;
+
+class Foo : Base1, Base2
+{
+    void test()
+    {
+        static assert(typeof(bar()).sizeof == 2);
+        static assert(baz == 2);
+        static assert(T.sizeof == 2);
+    }
+}

--- a/test/compilable/imports/dip22.d
+++ b/test/compilable/imports/dip22.d
@@ -1,0 +1,15 @@
+module imports.dip22;
+
+interface Base1
+{
+    private ubyte bar() { return 1; }
+    private enum baz = 1;
+    private alias T = byte;
+}
+
+interface Base2
+{
+    final short bar() { return 2; }
+    enum baz = 2;
+    alias T = short;
+}

--- a/test/compilable/imports/dip22.d
+++ b/test/compilable/imports/dip22.d
@@ -13,3 +13,9 @@ interface Base2
     enum baz = 2;
     alias T = short;
 }
+
+void bar() {}
+private void bar(int) {}
+
+private void baz(int) {}
+void baz() {}

--- a/test/compilable/imports/dip22.d
+++ b/test/compilable/imports/dip22.d
@@ -14,8 +14,8 @@ interface Base2
     alias T = short;
 }
 
-void bar() {}
-private void bar(int) {}
+private void bar() {}
+void bar(int) {}
 
-private void baz(int) {}
-void baz() {}
+void baz(int) {}
+private void baz() {}

--- a/test/compilable/imports/test1238a.d
+++ b/test/compilable/imports/test1238a.d
@@ -1,0 +1,3 @@
+module imports.test1238a;
+
+private int zuiop;

--- a/test/compilable/imports/test1238b.d
+++ b/test/compilable/imports/test1238b.d
@@ -1,0 +1,3 @@
+module imports.test1238b;
+
+public int zuiop;

--- a/test/compilable/imports/test1754a.d
+++ b/test/compilable/imports/test1754a.d
@@ -1,0 +1,5 @@
+module imports.test1754a;
+
+private void bar()
+{
+}

--- a/test/compilable/imports/test1754b.d
+++ b/test/compilable/imports/test1754b.d
@@ -1,0 +1,5 @@
+module imports.test1754b;
+
+void bar()
+{
+}

--- a/test/compilable/imports/test2991.d
+++ b/test/compilable/imports/test2991.d
@@ -1,0 +1,5 @@
+module imports.test2991;
+
+private void foo()
+{
+}

--- a/test/compilable/protection.d
+++ b/test/compilable/protection.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -de
 import imports.protectionimp;
 
 alias TypeTuple(T...) = T;

--- a/test/compilable/test1238.d
+++ b/test/compilable/test1238.d
@@ -1,0 +1,10 @@
+module test1238;
+
+import imports.test1238a;
+import imports.test1238b;
+
+void foo()
+{
+    int qwert = zuiop;
+}
+

--- a/test/compilable/test1754.d
+++ b/test/compilable/test1754.d
@@ -1,0 +1,9 @@
+module test1754;
+
+import imports.test1754a;
+import imports.test1754b;
+
+void foo()
+{
+    bar();
+}

--- a/test/compilable/test2991.d
+++ b/test/compilable/test2991.d
@@ -1,0 +1,12 @@
+module test2991;
+
+void foo()
+{
+}
+
+class C
+{
+    import imports.test2991;
+
+    void bar() { foo(); }
+}

--- a/test/compilable/test313a.d
+++ b/test/compilable/test313a.d
@@ -21,6 +21,3 @@ void test3()
 {
     imports.pkg313.c313.bug();
 }
-
-// private symbols from other modules are still visible
-static assert(core.stringof == "package core");

--- a/test/fail_compilation/diag10169.d
+++ b/test/fail_compilation/diag10169.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10169.d(11): Error: struct imports.a10169.B member x is not accessible
+fail_compilation/diag10169.d(12): Deprecation: imports.a10169.B.x is not visible from module diag10169
+fail_compilation/diag10169.d(12): Error: struct imports.a10169.B member x is not accessible
 ---
 */
 import imports.a10169;

--- a/test/fail_compilation/diag5385.d
+++ b/test/fail_compilation/diag5385.d
@@ -1,13 +1,21 @@
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/diag5385.d(3): Deprecation: imports.fail5385.C.privX is not visible from module diag5385
 fail_compilation/diag5385.d(3): Error: class imports.fail5385.C member privX is not accessible
+fail_compilation/diag5385.d(4): Deprecation: imports.fail5385.C.packX is not visible from module diag5385
 fail_compilation/diag5385.d(4): Error: class imports.fail5385.C member packX is not accessible
+fail_compilation/diag5385.d(5): Deprecation: imports.fail5385.C.privX2 is not visible from module diag5385
 fail_compilation/diag5385.d(5): Error: class imports.fail5385.C member privX2 is not accessible
+fail_compilation/diag5385.d(6): Deprecation: imports.fail5385.C.packX2 is not visible from module diag5385
 fail_compilation/diag5385.d(6): Error: class imports.fail5385.C member packX2 is not accessible
+fail_compilation/diag5385.d(7): Deprecation: imports.fail5385.S.privX is not visible from module diag5385
 fail_compilation/diag5385.d(7): Error: struct imports.fail5385.S member privX is not accessible
+fail_compilation/diag5385.d(8): Deprecation: imports.fail5385.S.packX is not visible from module diag5385
 fail_compilation/diag5385.d(8): Error: struct imports.fail5385.S member packX is not accessible
+fail_compilation/diag5385.d(9): Deprecation: imports.fail5385.S.privX2 is not visible from module diag5385
 fail_compilation/diag5385.d(9): Error: struct imports.fail5385.S member privX2 is not accessible
+fail_compilation/diag5385.d(10): Deprecation: imports.fail5385.S.packX2 is not visible from module diag5385
 fail_compilation/diag5385.d(10): Error: struct imports.fail5385.S member packX2 is not accessible
 ---
 */

--- a/test/fail_compilation/dip22a.d
+++ b/test/fail_compilation/dip22a.d
@@ -1,0 +1,23 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/dip22a.d(19): Deprecation: imports.dip22a.Klass.bar is not visible from module dip22a
+fail_compilation/dip22a.d(19): Error: class imports.dip22a.Klass member bar is not accessible
+fail_compilation/dip22a.d(20): Deprecation: imports.dip22a.Struct.bar is not visible from module dip22a
+fail_compilation/dip22a.d(20): Error: struct imports.dip22a.Struct member bar is not accessible
+fail_compilation/dip22a.d(21): Error: imports.dip22a.bar is not visible from module dip22a
+fail_compilation/dip22a.d(21): Error: function imports.dip22a.bar is not accessible from module dip22a
+fail_compilation/dip22a.d(22): Error: imports.dip22a.Template!int.bar is not visible from module dip22a
+fail_compilation/dip22a.d(22): Error: function imports.dip22a.Template!int.bar is not accessible from module dip22a
+---
+*/
+import imports.dip22a;
+
+void test()
+{
+    new Klass().bar();
+    Struct().bar();
+    imports.dip22a.bar();
+    Template!int.bar();
+}

--- a/test/fail_compilation/dip22a.d
+++ b/test/fail_compilation/dip22a.d
@@ -2,22 +2,26 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/dip22a.d(19): Deprecation: imports.dip22a.Klass.bar is not visible from module dip22a
-fail_compilation/dip22a.d(19): Error: class imports.dip22a.Klass member bar is not accessible
-fail_compilation/dip22a.d(20): Deprecation: imports.dip22a.Struct.bar is not visible from module dip22a
-fail_compilation/dip22a.d(20): Error: struct imports.dip22a.Struct member bar is not accessible
-fail_compilation/dip22a.d(21): Error: imports.dip22a.bar is not visible from module dip22a
-fail_compilation/dip22a.d(21): Error: function imports.dip22a.bar is not accessible from module dip22a
-fail_compilation/dip22a.d(22): Error: imports.dip22a.Template!int.bar is not visible from module dip22a
-fail_compilation/dip22a.d(22): Error: function imports.dip22a.Template!int.bar is not accessible from module dip22a
+fail_compilation/dip22a.d(3): Deprecation: imports.dip22a.Klass.bar is not visible from module dip22a
+fail_compilation/dip22a.d(3): Error: class imports.dip22a.Klass member bar is not accessible
+fail_compilation/dip22a.d(4): Deprecation: imports.dip22a.Struct.bar is not visible from module dip22a
+fail_compilation/dip22a.d(4): Error: struct imports.dip22a.Struct member bar is not accessible
+fail_compilation/dip22a.d(5): Error: imports.dip22a.bar is not visible from module dip22a
+fail_compilation/dip22a.d(5): Error: function imports.dip22a.bar is not accessible from module dip22a
+fail_compilation/dip22a.d(6): Error: imports.dip22a.Template!int.bar is not visible from module dip22a
+fail_compilation/dip22a.d(6): Error: function imports.dip22a.Template!int.bar is not accessible from module dip22a
+fail_compilation/dip22a.d(7): Deprecation: imports.dip22a.bar is not visible from module dip22a
+fail_compilation/dip22a.d(7): Error: function imports.dip22a.bar is not accessible from module dip22a
 ---
 */
 import imports.dip22a;
 
+#line 1
 void test()
 {
     new Klass().bar();
     Struct().bar();
     imports.dip22a.bar();
     Template!int.bar();
+    12.bar();
 }

--- a/test/fail_compilation/dip22b.d
+++ b/test/fail_compilation/dip22b.d
@@ -1,0 +1,12 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/dip22b.d(12): Deprecation: pkg.dip22c.Foo is not visible from module dip22
+---
+*/
+module pkg.dip22;
+
+import imports.dip22b;
+
+Foo foo;

--- a/test/fail_compilation/dip22d.d
+++ b/test/fail_compilation/dip22d.d
@@ -1,0 +1,12 @@
+/*
+REQUIRED_ARGS: -transition=import
+TEST_OUTPUT:
+---
+fail_compilation/dip22d.d(12): Error: imports.dip22d.Foo at fail_compilation/imports/dip22d.d(3) conflicts with imports.dip22e.Foo at fail_compilation/imports/dip22e.d(3)
+fail_compilation/dip22d.d(12): Error: module dip22d struct imports.dip22d.Foo is private
+---
+*/
+import imports.dip22d;
+import imports.dip22e;
+
+Foo foo;

--- a/test/fail_compilation/dip22e.d
+++ b/test/fail_compilation/dip22e.d
@@ -1,0 +1,17 @@
+/*
+REQUIRED_ARGS: -transition=checkimports -de
+TEST_OUTPUT:
+---
+fail_compilation/dip22e.d(15): Deprecation: imports.dip22d.foo is not visible from module dip22e
+fail_compilation/dip22e.d(15): Error: function imports.dip22d.foo is not accessible from module dip22e
+fail_compilation/dip22e.d(16): Deprecation: local import search method found overloadset dip22e.bar instead of function imports.dip22e.bar
+---
+*/
+import imports.dip22d;
+import imports.dip22e;
+
+void test()
+{
+    foo();
+    bar(12);
+}

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -1,17 +1,22 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10528.d(19): Error: module fail10528 variable a10528.a is private
-fail_compilation/fail10528.d(20): Error: variable a10528.a is not accessible from module fail10528
-fail_compilation/fail10528.d(22): Error: module fail10528 enum member a10528.b is private
-fail_compilation/fail10528.d(23): Error: enum member a10528.b is not accessible from module fail10528
-fail_compilation/fail10528.d(25): Error: variable a10528.S.c is not accessible from module fail10528
-fail_compilation/fail10528.d(26): Error: variable a10528.S.c is not accessible from module fail10528
-fail_compilation/fail10528.d(28): Error: variable a10528.C.d is not accessible from module fail10528
-fail_compilation/fail10528.d(29): Error: variable a10528.C.d is not accessible from module fail10528
+fail_compilation/fail10528.d(5): Error: module fail10528 variable a10528.a is private
+fail_compilation/fail10528.d(5): Deprecation: a10528.a is not visible from module fail10528
+fail_compilation/fail10528.d(6): Error: a10528.a is not visible from module fail10528
+fail_compilation/fail10528.d(8): Error: module fail10528 enum member a10528.b is private
+fail_compilation/fail10528.d(8): Deprecation: a10528.b is not visible from module fail10528
+fail_compilation/fail10528.d(9): Error: a10528.b is not visible from module fail10528
+fail_compilation/fail10528.d(11): Deprecation: a10528.S.c is not visible from module fail10528
+fail_compilation/fail10528.d(11): Error: variable a10528.S.c is not accessible from module fail10528
+fail_compilation/fail10528.d(12): Error: variable a10528.S.c is not accessible from module fail10528
+fail_compilation/fail10528.d(14): Deprecation: a10528.C.d is not visible from module fail10528
+fail_compilation/fail10528.d(14): Error: variable a10528.C.d is not accessible from module fail10528
+fail_compilation/fail10528.d(15): Error: variable a10528.C.d is not accessible from module fail10528
 ---
 */
 
+#line 1
 import imports.a10528;
 
 void main()

--- a/test/fail_compilation/fail313.d
+++ b/test/fail_compilation/fail313.d
@@ -2,14 +2,16 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail313.d(17): Deprecation: module imports.b313 is not accessible here, perhaps add 'static import imports.b313;'
-fail_compilation/fail313.d(24): Deprecation: package core.stdc is not accessible here
-fail_compilation/fail313.d(24): Deprecation: module core.stdc.stdio is not accessible here, perhaps add 'static import core.stdc.stdio;'
-fail_compilation/fail313.d(29): Deprecation: package imports.pkg313 is not accessible here, perhaps add 'static import imports.pkg313;'
+fail_compilation/fail313.d(5): Deprecation: module imports.b313 is not accessible here, perhaps add 'static import imports.b313;'
+fail_compilation/fail313.d(12): Deprecation: imports.a313.core is not visible from module test313
+fail_compilation/fail313.d(12): Deprecation: package core.stdc is not accessible here
+fail_compilation/fail313.d(12): Deprecation: module core.stdc.stdio is not accessible here, perhaps add 'static import core.stdc.stdio;'
+fail_compilation/fail313.d(17): Deprecation: package imports.pkg313 is not accessible here, perhaps add 'static import imports.pkg313;'
 ---
 */
 module test313;
 
+#line 1
 import imports.a313;
 
 void test1()

--- a/test/fail_compilation/imports/dip22a.d
+++ b/test/fail_compilation/imports/dip22a.d
@@ -16,3 +16,5 @@ template Template(T)
 {
     private void bar() {}
 }
+
+private void bar(int) {}

--- a/test/fail_compilation/imports/dip22a.d
+++ b/test/fail_compilation/imports/dip22a.d
@@ -1,0 +1,18 @@
+module imports.dip22a;
+
+class Klass
+{
+    private void bar() {}
+}
+
+struct Struct
+{
+    private void bar() {}
+}
+
+private void bar() {}
+
+template Template(T)
+{
+    private void bar() {}
+}

--- a/test/fail_compilation/imports/dip22b.d
+++ b/test/fail_compilation/imports/dip22b.d
@@ -1,0 +1,3 @@
+module imports.dip22b;
+// this public import only exports symbols that are visible within this module
+public import imports.dip22c;

--- a/test/fail_compilation/imports/dip22c.d
+++ b/test/fail_compilation/imports/dip22c.d
@@ -1,0 +1,3 @@
+module pkg.dip22c;
+
+package(pkg) struct Foo {}

--- a/test/fail_compilation/imports/dip22d.d
+++ b/test/fail_compilation/imports/dip22d.d
@@ -1,0 +1,5 @@
+module imports.dip22d;
+
+private struct Foo {}
+private void foo() {}
+private void bar() {}

--- a/test/fail_compilation/imports/dip22e.d
+++ b/test/fail_compilation/imports/dip22e.d
@@ -1,0 +1,4 @@
+module imports.dip22e;
+
+public struct Foo {}
+public void bar(int) {}

--- a/test/fail_compilation/imports/test143.d
+++ b/test/fail_compilation/imports/test143.d
@@ -1,0 +1,3 @@
+module imports.test143;
+
+package int x = 5;

--- a/test/fail_compilation/test143.d
+++ b/test/fail_compilation/test143.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -de
+module test143; // Bugzilla 143
+
+import imports.test143;
+
+void bar(int)
+{
+}
+
+void foo()
+{
+    bar(x);
+}


### PR DESCRIPTION
The main goal of [DIP22](http://wiki.dlang.org/DIP22) and this implementation is to resolve conflicts between private and public symbols. Adding a private symbol to a module or a class should not interfere w/ any code in another module.
This is achieved by ignoring private/package/protected symbols during lookup, thus turning protection from an access into a visibility check.
- This PR solves the main hurdle to fix 314, b/c enabling protection for selective/renamed import declarations creates many public/private symbol conflicts (e.g. between the public `writeln` symbol in `std.stdio` and the private alias `import std.stdio : writeln` in another module).
- The visibility of overloaded symbols with mixed protection is determined by the most visible symbol, but an additional access check is performed after overload resolution.
- Because dmd did previously miss some access checks, it was possible to use private symbols.
  In order to not break code by making those symbols invisible an additional lookup with a deprecation warning is performed if the previous scope searches didn't found any symbol.
- In order to also fix [Issue 3254](https://issues.dlang.org/show_bug.cgi?id=3254) it was necessary to disable the eager access error during lookup for overloadable symbols. This will for now turn a possibly incorrect error into a deprecation (see test/compilable/protection.d).
- This PR fixes `package` and `package(std)` protection, but also deprecates invisible symbol for now.
