### PR TITLE
Reduce allocations around idPool calls

### DIFF
--- a/src/arrayop.d
+++ b/src/arrayop.d
@@ -177,8 +177,7 @@ extern (C++) Expression arrayOp(BinExp e, Scope* sc)
     /* Append deco of array element type
      */
     buf.writestring(e.type.toBasetype().nextOf().toBasetype().mutableOf().deco);
-    char* name = buf.peekString();
-    Identifier ident = Identifier.idPool(name);
+    auto ident = Identifier.idPool(buf.peekSlice());
 
     FuncDeclaration* pFd = cast(void*)ident in arrayfuncs;
     FuncDeclaration fd;

--- a/src/cond.d
+++ b/src/cond.d
@@ -25,6 +25,20 @@ import ddmd.root.outbuffer;
 import ddmd.tokens;
 import ddmd.visitor;
 
+private __gshared Identifier idUnitTest;
+private __gshared Identifier idAssert;
+
+static this()
+{
+    const(char)* s;
+
+    s = Token.toChars(TOKunittest);
+    idUnitTest = Identifier.idPool(s, strlen(s));
+
+    s = Token.toChars(TOKassert);
+    idAssert   = Identifier.idPool(s, strlen(s));
+}
+
 /***********************************************************
  */
 extern (C++) class Condition
@@ -314,8 +328,11 @@ public:
             }
             else if (level <= global.params.versionlevel || level <= mod.versionlevel)
                 inc = 1;
-            if (!definedInModule && (!ident || (!isPredefined(ident.toChars()) && ident != Identifier.idPool(Token.toChars(TOKunittest)) && ident != Identifier.idPool(Token.toChars(TOKassert)))))
+            if (!definedInModule &&
+                (!ident || (!isPredefined(ident.toChars()) && ident != idUnitTest && ident != idAssert)))
+            {
                 printDepsConditional(sc, this, "depsVersion ");
+            }
         }
         return (inc == 1);
     }

--- a/src/cond.h
+++ b/src/cond.h
@@ -70,11 +70,7 @@ class VersionCondition : public DVCondition
 public:
     static void setGlobalLevel(unsigned level);
     static bool isPredefined(const char *ident);
-    static void checkPredefined(Loc loc, const char *ident)
-    {
-        if (isPredefined(ident))
-            error(loc, "version identifier '%s' is reserved and cannot be set", ident);
-    }
+    static void checkPredefined(Loc loc, const char *ident);
     static void addGlobalIdent(const char *ident);
     static void addPredefinedGlobalIdent(const char *ident);
 

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1261,8 +1261,7 @@ public:
                 Parameter arg = Parameter.getNth(tt.arguments, i);
                 OutBuffer buf;
                 buf.printf("__%s_field_%llu", ident.toChars(), cast(ulong)i);
-                const(char)* name = buf.extractString();
-                Identifier id = Identifier.idPool(name);
+                auto id = Identifier.idPool(buf.peekSlice());
 
                 Initializer ti;
                 if (ie)

--- a/src/doc.d
+++ b/src/doc.d
@@ -765,7 +765,7 @@ extern (C++) static void emitAnchor(OutBuffer* buf, Dsymbol s, Scope* sc)
     {
         OutBuffer anc;
         emitAnchorName(&anc, s, skipNonQualScopes(sc));
-        ident = Identifier.idPool(anc.peekString());
+        ident = Identifier.idPool(anc.peekSlice());
     }
 
     auto pcount = cast(void*)ident in sc.anchorCounts;

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -7858,9 +7858,8 @@ public:
                 assert(0);
         }
         buf.writeByte('Z');
-        const id2 = buf.peekString();
-        //printf("\tgenIdent = %s\n", id2);
-        return Identifier.idPool(id2);
+        //printf("\tgenIdent = %s\n", buf.peekString());
+        return Identifier.idPool(buf.peekSlice());
     }
 
     final void expandMembers(Scope* sc2)

--- a/src/expression.d
+++ b/src/expression.d
@@ -4629,6 +4629,12 @@ public:
         return s;
     }
 
+    extern (D) const(char)[] peekSlice() const
+    {
+        assert(sz == 1);
+        return this.string[0 .. len];
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/func.d
+++ b/src/func.d
@@ -3783,7 +3783,7 @@ public:
      */
     final static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, StorageClass stc = 0)
     {
-        return genCfunc(fparams, treturn, Identifier.idPool(name), stc);
+        return genCfunc(fparams, treturn, Identifier.idPool(name, strlen(name)), stc);
     }
 
     final static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, StorageClass stc = 0)

--- a/src/identifier.d
+++ b/src/identifier.d
@@ -112,16 +112,15 @@ public:
         OutBuffer buf;
         buf.writestring(prefix);
         buf.printf("%llu", cast(ulong)i);
-        char* id = buf.peekString();
-        return idPool(id);
+        return idPool(buf.peekSlice());
     }
 
     /********************************************
      * Create an identifier in the string table.
      */
-    static Identifier idPool(const(char)* s)
+    extern (D) static Identifier idPool(const(char)[] s)
     {
-        return idPool(s, strlen(s));
+        return idPool(s.ptr, s.length);
     }
 
     static Identifier idPool(const(char)* s, size_t len)

--- a/src/identifier.h
+++ b/src/identifier.h
@@ -38,7 +38,6 @@ public:
     static StringTable stringtable;
     static Identifier *generateId(const char *prefix);
     static Identifier *generateId(const char *prefix, size_t i);
-    static Identifier *idPool(const char *s);
     static Identifier *idPool(const char *s, size_t len);
     static bool isValidIdentifier(const char *p);
     static Identifier *lookup(const char *s, size_t len);

--- a/src/mars.d
+++ b/src/mars.d
@@ -1434,7 +1434,7 @@ Language changes listed by -transition=id:
         /* At this point, name is the D source file name stripped of
          * its path and extension.
          */
-        Identifier id = Identifier.idPool(name);
+        auto id = Identifier.idPool(name, strlen(name));
         auto m = new Module(files[i], id, global.params.doDocComments, global.params.doHdrGeneration);
         modules.push(m);
         if (firstmodule)

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2662,7 +2662,7 @@ public:
         // Allocate buffer on stack, fail over to using malloc()
         char[128] namebuf;
         size_t namelen = 19 + len.sizeof * 3 + len + 1;
-        char* name = namelen <= namebuf.sizeof ? namebuf.ptr : cast(char*)malloc(namelen);
+        char* name = namelen <= namebuf.length ? namebuf.ptr : cast(char*)malloc(namelen);
         assert(name);
         sprintf(name, "_D%lluTypeInfo_%s6__initZ", cast(ulong)9 + len, buf.data);
         //printf("%p, deco = %s, name = %s\n", this, deco, name);
@@ -2673,7 +2673,7 @@ public:
             if (global.params.isOSX || global.params.isWindows && !global.params.is64bit)
                 ++off; // C mangling will add '_' back in
         }
-        Identifier id = Identifier.idPool(name + off);
+        auto id = Identifier.idPool(name + off, strlen(name + off));
         if (name != namebuf.ptr)
             free(name);
         return id;

--- a/src/parse.d
+++ b/src/parse.d
@@ -2138,9 +2138,9 @@ public:
             else if (token.value == TOKint32v || token.value == TOKint64v)
                 level = cast(uint)token.uns64value;
             else if (token.value == TOKunittest)
-                id = Identifier.idPool(Token.toChars(TOKunittest));
+                id = Identifier.idPool(Token.toChars(TOKunittest), strlen(Token.toChars(TOKunittest)));
             else if (token.value == TOKassert)
-                id = Identifier.idPool(Token.toChars(TOKassert));
+                id = Identifier.idPool(Token.toChars(TOKassert), strlen(Token.toChars(TOKassert)));
             else
                 error("identifier or integer expected, not %s", token.toChars());
             nextToken();

--- a/src/root/outbuffer.d
+++ b/src/root/outbuffer.d
@@ -401,6 +401,11 @@ struct OutBuffer
         this.offset -= nbytes;
     }
 
+    extern (D) const(char)[] peekSlice()
+    {
+        return (cast(const char*)data)[0 .. offset];
+    }
+
     // Append terminating null if necessary and get view of internal buffer
     extern (C++) char* peekString()
     {

--- a/src/statement.d
+++ b/src/statement.d
@@ -67,8 +67,7 @@ extern (C++) Identifier fixupLabelName(Scope* sc, Identifier ident)
         const(char)* prefix = flags == SCOPErequire ? "__in_" : "__out_";
         OutBuffer buf;
         buf.printf("%s%s", prefix, ident.toChars());
-        const(char)* name = buf.extractString();
-        ident = Identifier.idPool(name);
+        ident = Identifier.idPool(buf.peekSlice());
     }
     return ident;
 }

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -587,7 +587,7 @@ extern (C++) struct Token
             //printf("keyword[%d] = '%s'\n",u, keywords[u].name);
             const(char)* s = kw.name;
             TOK v = kw.value;
-            Identifier id = Identifier.idPool(s);
+            auto id = Identifier.idPool(s, strlen(s));
             id.value = v;
             //printf("tochars[%d] = '%s'\n",v, s);
             Token.tochars[v] = s;

--- a/src/traits.d
+++ b/src/traits.d
@@ -665,7 +665,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             e.error("string must be chars");
             return new ErrorExp();
         }
-        Identifier id = Identifier.idPool(se.string, se.len);
+        auto id = Identifier.idPool(se.peekSlice());
 
         /* Prefer dsymbol, because it might need some runtime contexts.
          */


### PR DESCRIPTION
`OutBuffer.peekString()` may append '\0' to create a C-string.
`OutBuffer.extractString()` releases the ownership, but `idPool` copies the content characters in the argument string and throws it away immediately.

By using slice, we can reduce these unnecessary allocations.
