### PR TITLE
add -transition=checkimports switch

### DIFF
--- a/src/dscope.d
+++ b/src/dscope.d
@@ -510,6 +510,25 @@ struct Scope
             return null;
         }
 
+        if (global.params.check10378)
+        {
+            // Search both ways
+
+            auto sold = searchScopes(flags | SearchCheck10378);
+
+            auto snew = searchScopes(flags | SearchCheck10378 | SearchLocalsOnly);
+            if (!snew)
+                snew = searchScopes(flags | SearchCheck10378 | SearchImportsOnly);
+
+            if (sold !is snew)
+            {
+                deprecation(loc, "local import search method found %s %s instead of %s %s",
+                    sold ? sold.kind() : "nothing", sold ? sold.toPrettyChars() : null,
+                    snew ? snew.kind() : "nothing", snew ? snew.toPrettyChars() : null);
+            }
+            return sold;
+        }
+
         if (global.params.bug10378)
             return searchScopes(flags);
 

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -179,6 +179,7 @@ enum : int
                                     // meaning don't search imports in that scope,
                                     // because qualified module searches search
                                     // their imports
+    SearchCheck10378        = 0x40, // unqualified search with transition=checkimports switch
 }
 
 extern (C++) alias Dsymbol_apply_ft_t = int function(Dsymbol, void*);
@@ -1276,7 +1277,15 @@ public:
                 if (ss.isModule())
                 {
                     if (flags & SearchLocalsOnly)
+                    {
+                        if (global.params.check10378 && !(flags & SearchCheck10378))
+                        {
+                            auto s3 = ss.search(loc, ident, sflags | IgnorePrivateMembers);
+                            if (s3)
+                                deprecation("%s %s found in local import", s3.kind(), s3.toPrettyChars());
+                        }
                         continue;
+                    }
                 }
                 else
                 {

--- a/src/expression.d
+++ b/src/expression.d
@@ -678,7 +678,25 @@ extern (C++) Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
 
     Dsymbol s;
 
-    if (global.params.bug10378)
+    if (global.params.check10378)
+    {
+        // Search both ways
+
+        auto sold = searchScopes(SearchCheck10378);
+
+        auto snew = searchScopes(SearchCheck10378 | SearchLocalsOnly);
+        if (!snew)
+            snew = searchScopes(SearchCheck10378 | SearchImportsOnly);
+
+        if (sold !is snew)
+        {
+            deprecation(loc, "local import search method found %s %s instead of %s %s",
+                sold ? sold.kind() : "nothing", sold ? sold.toPrettyChars() : null,
+                snew ? snew.kind() : "nothing", snew ? snew.toPrettyChars() : null);
+        }
+        s = sold;
+    }
+    else if (global.params.bug10378)
         s = searchScopes(0);
     else
     {

--- a/src/globals.d
+++ b/src/globals.d
@@ -115,6 +115,7 @@ struct Param
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations
     bool dwarfeh;           // generate dwarf eh exception handling
+    bool check10378;        // check for issues transitioning to 10738
     bool bug10378;          // use pre-bugzilla 10378 search strategy
 
     BOUNDSCHECK useArrayBounds;

--- a/src/globals.h
+++ b/src/globals.h
@@ -93,6 +93,8 @@ struct Param
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
     bool dwarfeh;       // generate dwarf eh exception handling
+    bool check10378;    // check for issues transitioning to 10738
+    bool bug10378;      // use pre-bugzilla 10378 search strategy
 
     BOUNDSCHECK useArrayBounds;
 

--- a/src/mars.d
+++ b/src/mars.d
@@ -681,6 +681,7 @@ extern (C++) int tryMain(size_t argc, const(char)** argv)
                         printf("
 Language changes listed by -transition=id:
   =all           list information on all language changes
+  =checkimports  give deprecation messages about 10378 anomalies
   =complex,14488 list all usages of complex or imaginary types
   =field,3449    list all non-mutable fields which occupy an object instance
   =import,10378  revert to single phase name lookup
@@ -703,6 +704,7 @@ Language changes listed by -transition=id:
                             break;
                         case 10378:
                             global.params.bug10378 = true;
+                            global.params.check10378 = false;
                             break;
                         case 14488:
                             global.params.vcomplex = true;
@@ -713,44 +715,31 @@ Language changes listed by -transition=id:
                     }
                     else if (Identifier.isValidIdentifier(p + 12))
                     {
-                        const(char)* ident = p + 12;
-                        switch (strlen(ident))
+                        const ident = p + 12;
+                        switch (ident[0 .. strlen(ident)])
                         {
-                        case 3:
-                            if (strcmp(ident, "all") == 0)
-                            {
-                                global.params.vtls = true;
-                                global.params.vfield = true;
-                                global.params.vcomplex = true;
-                                break;
-                            }
-                            if (strcmp(ident, "tls") == 0)
-                            {
-                                global.params.vtls = true;
-                                break;
-                            }
-                            goto Lerror;
-                        case 5:
-                            if (strcmp(ident, "field") == 0)
-                            {
-                                global.params.vfield = true;
-                                break;
-                            }
-                            goto Lerror;
-                        case 6:
-                            if (strcmp(ident, "import") == 0)
-                            {
-                                global.params.bug10378 = true;
-                                break;
-                            }
-                            goto Lerror;
-                        case 7:
-                            if (strcmp(ident, "complex") == 0)
-                            {
-                                global.params.vcomplex = true;
-                                break;
-                            }
-                            goto Lerror;
+                        case "all":
+                            global.params.vtls = true;
+                            global.params.vfield = true;
+                            global.params.vcomplex = true;
+                            break;
+                        case "checkimports":
+                            global.params.check10378 = true;
+                            global.params.bug10378 = false;
+                            break;
+                        case "complex":
+                            global.params.vcomplex = true;
+                            break;
+                        case "field":
+                            global.params.vfield = true;
+                            break;
+                        case "import":
+                            global.params.bug10378 = true;
+                            global.params.check10378 = false;
+                            break;
+                        case "tls":
+                            global.params.vtls = true;
+                            break;
                         default:
                             goto Lerror;
                         }

--- a/test/fail_compilation/checkimports.d
+++ b/test/fail_compilation/checkimports.d
@@ -1,0 +1,23 @@
+/*
+REQUIRED_ARGS: -transition=checkimports
+TEST_OUTPUT:
+---
+fail_compilation/checkimports.d(15): Deprecation: local import search method found struct imports.diag12598a.lines instead of variable checkimports.C.lines
+fail_compilation/checkimports.d(15): Error: struct 'lines' is a type, not an lvalue
+---
+*/
+
+class C
+{
+    void f()
+    {
+        import imports.diag12598a;
+        lines ~= "";
+    }
+
+    string[] lines;
+}
+
+void main()
+{
+}

--- a/test/fail_compilation/checkimports2.d
+++ b/test/fail_compilation/checkimports2.d
@@ -1,0 +1,31 @@
+/*
+REQUIRED_ARGS: -transition=checkimports
+TEST_OUTPUT:
+---
+fail_compilation/checkimports2.d(21): Deprecation: local import search method found variable imp1.Y instead of variable imp2.Y
+fail_compilation/checkimports2.d(17): Deprecation: class checkimports2.B variable imp2.X found in local import
+fail_compilation/checkimports2.d(26): Error: no property 'X' for type 'checkimports2.B'
+fail_compilation/checkimports2.d(17): Deprecation: class checkimports2.B variable imp2.Y found in local import
+fail_compilation/checkimports2.d(27): Error: no property 'Y' for type 'checkimports2.B'
+---
+*/
+
+import imports.imp1;
+
+enum X = 0;
+
+class B
+{
+    import imports.imp2;
+    static assert(X == 0);
+    int[Y] aa;
+}
+
+class C : B
+{
+    static assert(B.X == 0);
+    static assert(B.Y == 2);
+
+    static assert(X == 0);
+    static assert(Y == 1);
+}


### PR DESCRIPTION
This is added to provide deprecation warnings to ease the transition to the new import lookup method introduced by https://github.com/D-Programming-Language/dmd/pull/5445
