### PR TITLE
Add the IN_LLVM and IN_LLVM_MSVC enums, similar to the IN_GCC enum

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -33,7 +33,9 @@ enum __FreeBSD__    = xversion!`FreeBSD`;
 enum __OpenBSD__    = xversion!`OpenBSD`;
 enum __sun          = xversion!`Solaris`;
 
-enum IN_GCC     = xversion!`IN_GCC`;
+enum IN_GCC         = xversion!`IN_GCC`;       // Set when building GDC
+enum IN_LLVM        = xversion!`IN_LLVM`;      // Set when building LDC
+enum IN_LLVM_MSVC   = xversion!`IN_LLVM_MSVC`; // Set when building LDC with MSVC
 
 enum TARGET_LINUX   = xversion!`linux`;
 enum TARGET_OSX     = xversion!`OSX`;

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2668,7 +2668,7 @@ public:
         //printf("%p, deco = %s, name = %s\n", this, deco, name);
         assert(strlen(name) < namelen); // don't overflow the buffer
         size_t off = 0;
-        static if (!IN_GCC)
+        static if (!IN_GCC && !IN_LLVM)
         {
             if (global.params.isOSX || global.params.isWindows && !global.params.is64bit)
                 ++off; // C mangling will add '_' back in


### PR DESCRIPTION
Add the IN_LLVM and IN_LLVM_MSVC enums, similar to the IN_GCC enum, and use it in a location where IN_GCC was also used.

The IN_LLVM enum is used in LDC to mark LDC-specific front-end changes. Having it available in upstream DDMD source is needed to upstream simple LDC changes, to reduce the diff with upstream DDMD.

It may be useful to create a DMD version too, and add

``` D
enum IN_DMD         = xversion!`IN_DMD`;
```

to explicitly mark DMD-specific code (backend related symbols, for example). Right now, LDC's code contains things like (backend.d):

``` D
version(IN_LLVM) {}
else
{
extern extern (C++) void backend_init();
//...
}
```

This could be upstreamed, to benefit both GDC and LDC (and future backends ;))
