### PR TITLE
[refactor] Improve layering and vestigial code around StructLiteralExp.sinit

### DIFF
--- a/src/constfold.d
+++ b/src/constfold.d
@@ -854,11 +854,6 @@ extern (C++) UnionExp Equal(TOK op, Loc loc, Type type, Expression e1, Expressio
                     break;
             }
         }
-        if (cmp && es1.type.needsNested())
-        {
-            if ((es1.sinit !is null) != (es2.sinit !is null))
-                cmp = 0;
-        }
     }
     else if (e1.isConst() != 1 || e2.isConst() != 1)
     {

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1629,16 +1629,10 @@ elem *toElem(Expression *e, IRState *irs)
                 {
                     StructLiteralExp *se = StructLiteralExp::create(ne->loc, sd, ne->arguments, t);
 
-                    Symbol *symSave = se->sym;
-                    int fillHolesSave = se->fillHoles;
-
                     se->sym = ev->EV.sp.Vsym;
                     se->fillHoles = 0;
 
                     ez = toElem(se, irs);
-
-                    se->sym = symSave;
-                    se->fillHoles = fillHolesSave;
                 }
                 //elem_print(ex);
                 //elem_print(ey);
@@ -2832,17 +2826,11 @@ elem *toElem(Expression *e, IRState *irs)
                 {
                     StructLiteralExp *se = (StructLiteralExp *)ae->e2;
 
-                    Symbol *symSave = se->sym;
-                    int fillHolesSave = se->fillHoles;
-
                     se->sym = ex->EV.sp.Vsym;
                     se->fillHoles = (ae->op == TOKconstruct || ae->op == TOKblit) ? 1 : 0;
 
                     el_free(e1);
                     e = toElem(ae->e2, irs);
-
-                    se->sym = symSave;
-                    se->fillHoles = fillHolesSave;
                     goto Lret;
                 }
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1630,17 +1630,14 @@ elem *toElem(Expression *e, IRState *irs)
                     StructLiteralExp *se = StructLiteralExp::create(ne->loc, sd, ne->arguments, t);
 
                     Symbol *symSave = se->sym;
-                    size_t soffsetSave = se->soffset;
                     int fillHolesSave = se->fillHoles;
 
                     se->sym = ev->EV.sp.Vsym;
-                    se->soffset = 0;
                     se->fillHoles = 0;
 
                     ez = toElem(se, irs);
 
                     se->sym = symSave;
-                    se->soffset = soffsetSave;
                     se->fillHoles = fillHolesSave;
                 }
                 //elem_print(ex);
@@ -2836,18 +2833,15 @@ elem *toElem(Expression *e, IRState *irs)
                     StructLiteralExp *se = (StructLiteralExp *)ae->e2;
 
                     Symbol *symSave = se->sym;
-                    size_t soffsetSave = se->soffset;
                     int fillHolesSave = se->fillHoles;
 
                     se->sym = ex->EV.sp.Vsym;
-                    se->soffset = 0;
                     se->fillHoles = (ae->op == TOKconstruct || ae->op == TOKblit) ? 1 : 0;
 
                     el_free(e1);
                     e = toElem(ae->e2, irs);
 
                     se->sym = symSave;
-                    se->soffset = soffsetSave;
                     se->fillHoles = fillHolesSave;
                     goto Lret;
                 }
@@ -5461,13 +5455,10 @@ elem *toElem(Expression *e, IRState *irs)
                     if (tybasic(stmp->Stype->Tty) == TYnptr)
                     {
                         e1 = el_var(stmp);
-                        e1->EV.sp.Voffset = sle->soffset;
                     }
                     else
                     {
                         e1 = el_ptr(stmp);
-                        if (sle->soffset)
-                            e1 = el_bin(OPadd, TYnptr, e1, el_long(TYsize_t, sle->soffset));
                     }
                     e1 = el_bin(OPadd, TYnptr, e1, el_long(TYsize_t, v->offset));
 
@@ -5515,13 +5506,10 @@ elem *toElem(Expression *e, IRState *irs)
                 if (tybasic(stmp->Stype->Tty) == TYnptr)
                 {
                     e1 = el_var(stmp);
-                    e1->EV.sp.Voffset = sle->soffset;
                 }
                 else
                 {
                     e1 = el_ptr(stmp);
-                    if (sle->soffset)
-                        e1 = el_bin(OPadd, TYnptr, e1, el_long(TYsize_t, sle->soffset));
                 }
                 e1 = setEthis(sle->loc, irs, e1, sle->sd);
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3536,7 +3536,7 @@ elem *toElem(Expression *e, IRState *irs)
                 if (dve->e1->op == TOKstructliteral)
                 {
                     StructLiteralExp *sle = (StructLiteralExp *)dve->e1;
-                    sle->sinit = NULL;          // don't modify initializer
+                    sle->useStaticInit = false;          // don't modify initializer
                 }
 
                 ec = toElem(dve->e1, irs);
@@ -5310,9 +5310,9 @@ elem *toElem(Expression *e, IRState *irs)
         {
             //printf("[%s] StructLiteralExp::toElem() %s\n", sle->loc.toChars(), sle->toChars());
 
-            if (sle->sinit)
+            if (sle->useStaticInit)
             {
-                elem *e = el_var(sle->sinit);
+                elem *e = el_var(toInitializer(sle->sd));
                 e->ET = Type_toCtype(sle->sd->type);
                 el_setLoc(e, sle->loc);
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -5118,7 +5118,6 @@ public:
 
     Symbol* sinit;          // if this is a defaultInitLiteral, this symbol contains the default initializer
     Symbol* sym;            // back end symbol to initialize with literal
-    size_t soffset;         // offset from start of s
     int fillHoles = 1;      // fill alignment 'holes' with zero
     OwnedBy ownedByCtfe = OWNEDcode;
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -5116,7 +5116,7 @@ public:
     Expressions* elements;  // parallels sd.fields[] with null entries for fields to skip
     Type stype;             // final type of result (can be different from sd's type)
 
-    Symbol* sinit;          // if this is a defaultInitLiteral, this symbol contains the default initializer
+    bool useStaticInit;     // if this is true, use the StructDeclaration's init symbol
     Symbol* sym;            // back end symbol to initialize with literal
     int fillHoles = 1;      // fill alignment 'holes' with zero
     OwnedBy ownedByCtfe = OWNEDcode;
@@ -5257,10 +5257,10 @@ public:
                     e = e.copy();
                     e.type = type;
                 }
-                if (sinit && e.op == TOKstructliteral && e.type.needsNested())
+                if (useStaticInit && e.op == TOKstructliteral && e.type.needsNested())
                 {
                     StructLiteralExp se = cast(StructLiteralExp)e;
-                    se.sinit = toInitializer(se.sd);
+                    se.useStaticInit = true;
                 }
             }
         }
@@ -9397,7 +9397,7 @@ public:
                     /* Constructor takes a mutable object, so don't use
                      * the immutable initializer symbol.
                      */
-                    sle.sinit = null;
+                    sle.useStaticInit = false;
 
                     Expression e = sle;
                     if (CtorDeclaration cf = sd.ctor.isCtorDeclaration())

--- a/src/expression.h
+++ b/src/expression.h
@@ -471,7 +471,7 @@ public:
     Expressions *elements;      // parallels sd->fields[] with NULL entries for fields to skip
     Type *stype;                // final type of result (can be different from sd's type)
 
-    Symbol *sinit;              // if this is a defaultInitLiteral, this symbol contains the default initializer
+    bool useStaticInit;         // if this is true, use the StructDeclaration's init symbol
     Symbol *sym;                // back end symbol to initialize with literal
     int fillHoles;              // fill alignment 'holes' with zero
     OwnedBy ownedByCtfe;

--- a/src/expression.h
+++ b/src/expression.h
@@ -473,7 +473,6 @@ public:
 
     Symbol *sinit;              // if this is a defaultInitLiteral, this symbol contains the default initializer
     Symbol *sym;                // back end symbol to initialize with literal
-    size_t soffset;             // offset from start of s
     int fillHoles;              // fill alignment 'holes' with zero
     OwnedBy ownedByCtfe;
 

--- a/src/gluelayer.d
+++ b/src/gluelayer.d
@@ -28,13 +28,6 @@ version (NoBackend)
     struct TYPE;
     alias type = TYPE;
 
-    // tocsym
-
-    extern (C++) Symbol* toInitializer(AggregateDeclaration ad)
-    {
-        return null;
-    }
-
     // glue
 
     extern (C++) void obj_write_deferred(Library library)
@@ -98,8 +91,6 @@ else
     alias Blockx = ddmd.backend.Blockx;
     alias elem = ddmd.backend.elem;
     alias type = ddmd.backend.type;
-
-    extern extern (C++) Symbol* toInitializer(AggregateDeclaration sd);
 
     extern extern (C++) void obj_write_deferred(Library library);
     extern extern (C++) void obj_start(char* srcfile);

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2422,7 +2422,7 @@ public:
             if (tb.ty == Tstruct && tb.needsNested())
             {
                 StructLiteralExp se = cast(StructLiteralExp)e;
-                se.sinit = toInitializer(se.sd);
+                se.useStaticInit = true;
             }
         }
         else if (ident == Id._mangleof)
@@ -2511,7 +2511,7 @@ public:
                 if (tb.ty == Tstruct && tb.needsNested())
                 {
                     StructLiteralExp se = cast(StructLiteralExp)e;
-                    se.sinit = toInitializer(se.sd);
+                    se.useStaticInit = true;
                 }
                 goto Lreturn;
             }
@@ -8065,7 +8065,7 @@ public:
          * otherwise the literals expressed as code get excessively large.
          */
         if (size(loc) > Target.ptrsize * 4 && !needsNested())
-            structinit.sinit = toInitializer(sym);
+            structinit.useStaticInit = true;
         structinit.type = this;
         return structinit;
     }

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -769,7 +769,6 @@ public:
                     char save[sizeof(StructLiteralExp)];
                     memcpy(save, (void*)se, sizeof(StructLiteralExp));
                     se->sym = irs->shidden;
-                    se->soffset = 0;
                     se->fillHoles = 1;
                     e = toElemDtor(s->exp, irs);
                     memcpy((void*)se, save, sizeof(StructLiteralExp));

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -766,12 +766,9 @@ public:
                 if (s->exp->op == TOKstructliteral)
                 {
                     StructLiteralExp *se = (StructLiteralExp *)s->exp;
-                    char save[sizeof(StructLiteralExp)];
-                    memcpy(save, (void*)se, sizeof(StructLiteralExp));
                     se->sym = irs->shidden;
                     se->fillHoles = 1;
                     e = toElemDtor(s->exp, irs);
-                    memcpy((void*)se, save, sizeof(StructLiteralExp));
                 }
                 else
                     e = toElemDtor(s->exp, irs);


### PR DESCRIPTION
This code currently suffers from a few problems:
1. `sinit` was mistakenly used in `constfold.d` ([link](https://github.com/D-Programming-Language/dmd/pull/1301/files#r52117796))
2. Some options are turned on/off right before `toElem`.  These are set via the `sym`/`soffset`/`fillHoles` members, then the old values are restored after.  This is unnecessary as the `StructLiteralExp` will not be used again.
3. `soffset` is always zero
4. The symbol that `sinit` points to can trivially be found through the attached `StructDeclaration`.  We're effectively using it as a flag, and using an actual flag instead lets us remove all references to the glue layer function `toInitializer` from the frontend.

Net effect: -44 lines
