### PR TITLE
Enable warnings during D compilation and fix all warnings

### DIFF
--- a/src/argtypes.d
+++ b/src/argtypes.d
@@ -293,6 +293,7 @@ extern (C++) TypeTuple toArgTypes(Type t)
             case 3:
                 if (!global.params.is64bit)
                     goto Lmemory;
+                goto case;
             case 4:
                 t1 = Type.tint32;
                 break;
@@ -301,6 +302,7 @@ extern (C++) TypeTuple toArgTypes(Type t)
             case 7:
                 if (!global.params.is64bit)
                     goto Lmemory;
+                goto case;
             case 8:
                 t1 = Type.tint64;
                 break;

--- a/src/canthrow.d
+++ b/src/canthrow.d
@@ -141,10 +141,8 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             case Tarray:
                 Type tv = tb.nextOf().baseElemOf();
                 if (tv.ty == Tstruct)
-                {
                     ad = (cast(TypeStruct)tv).sym;
-                    break;
-                }
+                break;
 
             default:
                 break;

--- a/src/dcast.d
+++ b/src/dcast.d
@@ -360,6 +360,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             case Tchar:
                 if ((oldty == Twchar || oldty == Tdchar) && value > 0x7F)
                     return;
+                goto case Tuns8;
             case Tuns8:
                 //printf("value = %llu %llu\n", (dinteger_t)(unsigned char)value, value);
                 if (cast(ubyte)value != value)
@@ -374,6 +375,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             case Twchar:
                 if (oldty == Tdchar && value > 0xD7FF && value < 0xE000)
                     return;
+                goto case Tuns16;
             case Tuns16:
                 if (cast(ushort)value != value)
                     return;
@@ -460,6 +462,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                      */
                     break;
                 }
+                goto default;
             default:
                 visit(cast(Expression)e);
                 return;
@@ -600,7 +603,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                                 return;
                             }
                         }
-                        /* fall through */
+                        goto case; /+ fall through +/
                     case Tarray:
                     case Tpointer:
                         Type tn = t.nextOf();

--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -4395,7 +4395,7 @@ public:
         case TOKlt:
         case TOKle:
             ret *= -1;
-            /* fall through */
+            goto case; /+ fall through +/
         case TOKgt:
         case TOKge:
             *p1 = (cast(BinExp)e).e1;

--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -656,6 +656,7 @@ public:
                     if (i < 2)
                         break;
                     // skip leading 0X
+                    goto default;
                 default:
                     buf.writeByte(c);
                     break;

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -1674,7 +1674,7 @@ public:
                                 }
                             }
                         }
-                        /* fall through */
+                        goto case Tarray;
                     }
                 case Tarray:
                     {

--- a/src/expression.d
+++ b/src/expression.d
@@ -4344,6 +4344,7 @@ public:
             break;
         case 'c':
             committed = 1;
+            goto default;
         default:
             type = new TypeDArray(Type.tchar.immutableOf());
             break;
@@ -10245,6 +10246,7 @@ public:
             break;
         default:
             error("can only * a pointer, not a '%s'", e1.type.toChars());
+            goto case Terror;
         case Terror:
             return new ErrorExp();
         }
@@ -14683,6 +14685,7 @@ public:
             }
         default:
             error("rvalue of in expression must be an associative array, not %s", e2.type.toChars());
+            goto case Terror;
         case Terror:
             return new ErrorExp();
         }

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -2087,6 +2087,7 @@ public:
                     buf.printf("'\\U%08x'", v);
                     break;
                 }
+                goto case;
             case Tchar:
                 {
                     size_t o = buf.offset;
@@ -2263,6 +2264,7 @@ public:
             case '"':
             case '\\':
                 buf.writeByte('\\');
+                goto default;
             default:
                 if (c <= 0xFF)
                 {

--- a/src/init.d
+++ b/src/init.d
@@ -533,6 +533,7 @@ public:
         case Tpointer:
             if (t.nextOf().ty != Tfunction)
                 break;
+            goto default;
         default:
             error(loc, "cannot use array to initialize %s", t.toChars());
             goto Lerr;

--- a/src/lexer.d
+++ b/src/lexer.d
@@ -326,6 +326,7 @@ public:
                 if (p[1] != '"')
                     goto case_ident;
                 p++;
+                goto case '`';
             case '`':
                 t.value = wysiwygStringConstant(t, *p);
                 return;
@@ -1306,13 +1307,12 @@ public:
             case '\t':
             case '\v':
             case '\f':
-                continue;
-                // skip white space
+                continue; // skip white space
             case '\r':
                 if (*p == '\n')
-                    continue;
-                // ignore
+                    continue; // ignore '\r' if followed by '\n'
                 // Treat isolated '\r' as if it were a '\n'
+                goto case '\n';
             case '\n':
                 endOfLine();
                 continue;
@@ -1360,6 +1360,7 @@ public:
                 break;
             }
         }
+        assert(0); // see bug 15731
     }
 
     /**************************************
@@ -1656,6 +1657,7 @@ public:
         case '\n':
         L1:
             endOfLine();
+            goto case;
         case '\r':
         case 0:
         case 0x1A:
@@ -2119,6 +2121,7 @@ public:
             break;
         case 'l':
             error("use 'L' suffix instead of 'l'");
+            goto case 'L';
         case 'L':
             result = TOKfloat80v;
             p++;
@@ -2437,6 +2440,7 @@ public:
                 break;
             Lnewline:
                 c = '\n'; // replace all newlines with \n
+                goto case;
             case '\n':
                 linestart = 1;
                 /* Trim trailing whitespace

--- a/src/mars.d
+++ b/src/mars.d
@@ -1891,6 +1891,7 @@ extern (C++) void escapePath(OutBuffer* buf, const(char)* fname)
         case ')':
         case '\\':
             buf.writeByte('\\');
+            goto default;
         default:
             buf.writeByte(*fname);
             break;

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -172,21 +172,21 @@ extern (C++) void MODtoBuffer(OutBuffer* buf, MOD mod)
     case MODshared | MODconst:
         buf.writestring(Token.tochars[TOKshared]);
         buf.writeByte(' ');
-        /* fall through */
+        goto case; /+ fall through +/
     case MODconst:
         buf.writestring(Token.tochars[TOKconst]);
         break;
     case MODshared | MODwild:
         buf.writestring(Token.tochars[TOKshared]);
         buf.writeByte(' ');
-        /* fall through */
+        goto case; /+ fall through +/
     case MODwild:
         buf.writestring(Token.tochars[TOKwild]);
         break;
     case MODshared | MODwildconst:
         buf.writestring(Token.tochars[TOKshared]);
         buf.writeByte(' ');
-        /* fall through */
+        goto case; /+ fall through +/
     case MODwildconst:
         buf.writestring(Token.tochars[TOKwild]);
         buf.writeByte(' ');
@@ -5170,6 +5170,7 @@ public:
         case Tnone:
         case Ttuple:
             error(loc, "can't have associative array key of %s", index.toBasetype().toChars());
+            goto case Terror;
         case Terror:
             return Type.terror;
         default:
@@ -5280,6 +5281,7 @@ public:
         case Tnone:
         case Ttuple:
             error(loc, "can't have associative array of %s", next.toChars());
+            goto case Terror;
         case Terror:
             return Type.terror;
         default:
@@ -5463,6 +5465,7 @@ public:
         {
         case Ttuple:
             error(loc, "can't have pointer to %s", n.toChars());
+            goto case Terror;
         case Terror:
             return Type.terror;
         default:
@@ -6555,6 +6558,7 @@ public:
                         sz = tsa.dim.toInteger();
                         if (sz != nargs - u)
                             goto Nomatch;
+                        goto case Tarray;
                     case Tarray:
                         {
                             TypeArray ta = cast(TypeArray)tb;

--- a/src/parse.d
+++ b/src/parse.d
@@ -4260,7 +4260,7 @@ public:
                 // delegate { statements... }
                 break;
             }
-            /* fall through to TOKlparen */
+            goto case TOKlparen;
         case TOKlparen:
             {
                 // (parameters) => expression
@@ -4411,7 +4411,7 @@ public:
                 nextToken();
                 break;
             }
-            /* fall through */
+            goto default;
         default:
             if (literal)
             {
@@ -4505,7 +4505,7 @@ public:
                     s = new LabelStatement(loc, ident, s);
                     break;
                 }
-                // fallthrough to TOKdot
+                goto case TOKdot;
             }
         case TOKdot:
         case TOKtypeof:
@@ -4630,6 +4630,7 @@ public:
                 goto Lexp;
             if (peekNext() == TOKlparen)
                 goto Lexp;
+            goto case;
         case TOKtypedef:
         case TOKalias:
         case TOKconst:
@@ -7168,6 +7169,7 @@ public:
                             tk = peek(tk);
                             if (tk.value == TOKis || tk.value == TOKin) // !is or !in
                                 break;
+                            goto case;
                         case TOKdot:
                         case TOKplusplus:
                         case TOKminusminus:

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -146,6 +146,8 @@ CXXFLAGS += \
 endif
 # Default D compiler flags for all source files
 DFLAGS=
+# Enable D warnings
+DFLAGS += -wi
 
 ifneq (,$(DEBUG))
 ENABLE_DEBUG := 1

--- a/src/root/response.d
+++ b/src/root/response.d
@@ -94,6 +94,7 @@ extern (C++) bool response_expand(Strings* args)
                 {
                     comment = 0;
                 }
+                goto case;
             case 0:
             case ' ':
             case '\t':
@@ -108,6 +109,7 @@ extern (C++) bool response_expand(Strings* args)
                     continue;
                 }
                 recurse = 1;
+                goto default;
             default:
                 /* start of new argument   */
                 if (comment)
@@ -175,6 +177,7 @@ extern (C++) bool response_expand(Strings* args)
                             *d = 0; // terminate argument
                             goto Lnextarg;
                         }
+                        goto default;
                     default:
                     Ladd:
                         if (c == '\\')

--- a/src/root/stringtable.d
+++ b/src/root/stringtable.d
@@ -42,11 +42,14 @@ private uint calcHash(const(char)* key, size_t len) pure nothrow @nogc
     {
     case 3:
         h ^= data[2] << 16;
+        goto case;
     case 2:
         h ^= data[1] << 8;
+        goto case;
     case 1:
         h ^= data[0];
         h *= m;
+        goto default;
     default:
         break;
     }

--- a/src/target.d
+++ b/src/target.d
@@ -266,7 +266,6 @@ struct Target
         default:
             assert(0);
         }
-        return null; // avoid warning
     }
 
     /******************************

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -832,6 +832,7 @@ extern (C++) struct Token
                     case '"':
                     case '\\':
                         buf.writeByte('\\');
+                        goto default;
                     default:
                         if (c <= 0x7F)
                         {

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -129,7 +129,8 @@ CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DTARGET_WINDOS=1 -DDM_TARGET
 # Compile flags for modules with backend/toolkit dependencies
 MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
 # D compile flags
-DFLAGS=$(DOPT) $(DDEBUG)
+DFLAGS=$(DOPT) $(DDEBUG) -wi
+
 # Recursive make
 DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) HOST_DC="$(HOST_DC)"
 


### PR DESCRIPTION
I have tried to fix all warnings in the way that seemed most "correct" to me.

See forum discussion here: http://forum.dlang.org/thread/xkftumtlbvmsrjrkedbh@forum.dlang.org

tested wih dmd 2.069.0 and 2.070.0
