### PR TITLE
[refactor] Remove no-op casts from the frontend

### DIFF
--- a/src/access.d
+++ b/src/access.d
@@ -393,7 +393,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
     else if (e.type.ty == Tclass)
     {
         // Do access check
-        ClassDeclaration cd = cast(ClassDeclaration)(cast(TypeClass)e.type).sym;
+        ClassDeclaration cd = (cast(TypeClass)e.type).sym;
         if (e.op == TOKsuper)
         {
             ClassDeclaration cd2 = sc.func.toParent().isClassDeclaration();
@@ -405,7 +405,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
     else if (e.type.ty == Tstruct)
     {
         // Do access check
-        StructDeclaration cd = cast(StructDeclaration)(cast(TypeStruct)e.type).sym;
+        StructDeclaration cd = (cast(TypeStruct)e.type).sym;
         return checkAccess(cd, loc, sc, d);
     }
     return false;

--- a/src/attrib.d
+++ b/src/attrib.d
@@ -794,7 +794,7 @@ public:
                     if (se)
                     {
                         se = se.toUTF8(sc);
-                        fprintf(stderr, "%.*s", cast(int)se.len, cast(char*)se.string);
+                        fprintf(stderr, "%.*s", cast(int)se.len, se.string);
                     }
                     else
                         fprintf(stderr, "%s", e.toChars());
@@ -837,7 +837,7 @@ public:
                         ob.writestring(" (");
                         escapePath(ob, imod.srcfile.toChars());
                         ob.writestring(") : ");
-                        ob.writestring(cast(char*)name);
+                        ob.writestring(name);
                         ob.writenl();
                     }
                     mem.xfree(name);
@@ -911,7 +911,7 @@ public:
                  */
                 for (size_t i = 0; i < se.len;)
                 {
-                    char* p = cast(char*)se.string;
+                    char* p = se.string;
                     dchar c = p[i];
                     if (c < 0x80)
                     {

--- a/src/constfold.d
+++ b/src/constfold.d
@@ -1324,7 +1324,7 @@ extern (C++) UnionExp Slice(Type type, Expression e1, Expression lwr, Expression
             size_t len = cast(size_t)(iupr - ilwr);
             ubyte sz = es1.sz;
             void* s = mem.xmalloc(len * sz);
-            memcpy(cast(char*)s, cast(char*)es1.string + ilwr * sz, len * sz);
+            memcpy(cast(char*)s, es1.string + ilwr * sz, len * sz);
             emplaceExp!(StringExp)(&ue, loc, s, len, es1.postfix);
             StringExp es = cast(StringExp)ue.exp();
             es.sz = sz;

--- a/src/cppmangle.d
+++ b/src/cppmangle.d
@@ -1431,7 +1431,7 @@ else static if (TARGET_WINDOS)
                 // <flags> ::= Y <calling convention flag>
                 buf.writeByte('Y');
             }
-            const(char)* args = mangleFunctionType(cast(TypeFunction)d.type, cast(bool)d.needThis(), d.isCtorDeclaration() || d.isDtorDeclaration());
+            const(char)* args = mangleFunctionType(cast(TypeFunction)d.type, d.needThis(), d.isCtorDeclaration() || d.isDtorDeclaration());
             buf.writestring(args);
         }
 
@@ -1470,7 +1470,7 @@ else static if (TARGET_WINDOS)
             Type t = d.type;
             if (t.isImmutable() || t.isShared())
             {
-                visit(cast(Type)t);
+                visit(t);
                 return;
             }
             if (t.isConst())
@@ -1786,7 +1786,7 @@ else static if (TARGET_WINDOS)
                 return;
             if (type.isImmutable() || type.isShared())
             {
-                visit(cast(Type)type);
+                visit(type);
                 return;
             }
             if (type.isConst())

--- a/src/dcast.d
+++ b/src/dcast.d
@@ -1654,7 +1654,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                  */
                 if ((se.len + 1) * se.sz > (e.len + 1) * e.sz)
                 {
-                    void* s = cast(void*)mem.xmalloc((se.len + 1) * se.sz);
+                    void* s = mem.xmalloc((se.len + 1) * se.sz);
                     memcpy(s, se.string, se.len * se.sz);
                     memset(s + se.len * se.sz, 0, se.sz);
                     se.string = cast(char*)s;
@@ -1820,7 +1820,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     // Copy when changing the string literal
                     size_t newsz = se.sz;
                     size_t d = (dim2 < se.len) ? dim2 : se.len;
-                    void* s = cast(void*)mem.xmalloc((dim2 + 1) * newsz);
+                    void* s = mem.xmalloc((dim2 + 1) * newsz);
                     memcpy(s, se.string, d * newsz);
                     // Extend with 0, add terminating 0
                     memset(s + d * newsz, 0, (dim2 + 1 - d) * newsz);
@@ -1922,7 +1922,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
             TupleExp te = cast(TupleExp)e.copy();
             te.e0 = e.e0 ? e.e0.copy() : null;
-            te.exps = cast(Expressions*)e.exps.copy();
+            te.exps = e.exps.copy();
             for (size_t i = 0; i < te.exps.dim; i++)
             {
                 Expression ex = (*te.exps)[i];

--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -3997,7 +3997,7 @@ public:
                 uint dim = cast(uint)dollar;
                 lowerbound = cast(int)(lwr ? lwr.toInteger() : 0);
                 upperbound = cast(size_t)(upr ? upr.toInteger() : dim);
-                if (cast(int)lowerbound < 0 || dim < upperbound)
+                if (lowerbound < 0 || dim < upperbound)
                 {
                     e.error("array bounds [0..%d] exceeded in slice [%d..%d]", dim, lowerbound, upperbound);
                     return CTFEExp.cantexp;
@@ -4084,7 +4084,7 @@ public:
             }
             if (newval.op == TOKstring)
             {
-                sliceAssignStringFromString(cast(StringExp)existingSE, cast(StringExp)newval, cast(size_t)firstIndex);
+                sliceAssignStringFromString(existingSE, cast(StringExp)newval, cast(size_t)firstIndex);
                 return newval;
             }
             if (newval.op == TOKarrayliteral)
@@ -6674,9 +6674,9 @@ extern (C++) Expression evaluateIfBuiltin(InterState* istate, Loc loc, FuncDecla
             if (nargs == 1 && fd.ident == Id.aaLen)
                 return interpret_length(istate, firstarg);
             if (nargs == 3 && !strcmp(fd.ident.string, "_aaApply"))
-                return interpret_aaApply(istate, firstarg, cast(Expression)arguments.data[2]);
+                return interpret_aaApply(istate, firstarg, arguments.data[2]);
             if (nargs == 3 && !strcmp(fd.ident.string, "_aaApply2"))
-                return interpret_aaApply(istate, firstarg, cast(Expression)arguments.data[2]);
+                return interpret_aaApply(istate, firstarg, arguments.data[2]);
             if (nargs == 1 && !strcmp(fd.ident.string, "keys") && !strcmp(fd.toParent2().ident.string, "object"))
                 return interpret_keys(istate, firstarg, firstAAtype.index.arrayOf());
             if (nargs == 1 && !strcmp(fd.ident.string, "values") && !strcmp(fd.toParent2().ident.string, "object"))

--- a/src/dmacro.d
+++ b/src/dmacro.d
@@ -209,7 +209,7 @@ public:
                     if (!m)
                     {
                         static __gshared const(char)* undef = "DDOC_UNDEFINED_MACRO";
-                        m = search(cast(const(char)*)undef, strlen(undef));
+                        m = search(undef, strlen(undef));
                         if (m)
                         {
                             // Macro was not defined, so this is an expansion of

--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -689,7 +689,7 @@ public:
         {
         case 1:
             m = 'a';
-            q = cast(char*)e.string;
+            q = e.string;
             qlen = e.len;
             break;
         case 2:

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -595,7 +595,7 @@ public:
                     }
                     dbuf.writeByte(0); // add 0 as sentinel for scanner
                     buflen = dbuf.offset - 1; // don't include sentinel in count
-                    buf = cast(char*)dbuf.extractData();
+                    buf = dbuf.extractData();
                 }
                 else
                 {
@@ -652,7 +652,7 @@ public:
                     }
                     dbuf.writeByte(0); // add 0 as sentinel for scanner
                     buflen = dbuf.offset - 1; // don't include sentinel in count
-                    buf = cast(char*)dbuf.extractData();
+                    buf = dbuf.extractData();
                 }
             }
             else if (buf[0] == 0xFE && buf[1] == 0xFF)
@@ -810,29 +810,29 @@ public:
             }
             if (arreq)
             {
-                scope Parser p = new Parser(loc, this, code_ArrayEq, strlen(cast(const(char)*)code_ArrayEq), 0);
+                scope Parser p = new Parser(loc, this, code_ArrayEq, strlen(code_ArrayEq), 0);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }
             {
-                scope Parser p = new Parser(loc, this, code_ArrayPostblit, strlen(cast(const(char)*)code_ArrayPostblit), 0);
+                scope Parser p = new Parser(loc, this, code_ArrayPostblit, strlen(code_ArrayPostblit), 0);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }
             {
-                scope Parser p = new Parser(loc, this, code_ArrayDtor, strlen(cast(const(char)*)code_ArrayDtor), 0);
+                scope Parser p = new Parser(loc, this, code_ArrayDtor, strlen(code_ArrayDtor), 0);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }
             if (xopeq)
             {
-                scope Parser p = new Parser(loc, this, code_xopEquals, strlen(cast(const(char)*)code_xopEquals), 0);
+                scope Parser p = new Parser(loc, this, code_xopEquals, strlen(code_xopEquals), 0);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }
             if (xopcmp)
             {
-                scope Parser p = new Parser(loc, this, code_xopCmp, strlen(cast(const(char)*)code_xopCmp), 0);
+                scope Parser p = new Parser(loc, this, code_xopCmp, strlen(code_xopCmp), 0);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }

--- a/src/doc.d
+++ b/src/doc.d
@@ -509,8 +509,8 @@ extern (C++) void gendocfile(Module m)
         time(&t);
         char* p = ctime(&t);
         p = mem.xstrdup(p);
-        Macro.define(&m.macrotable, cast(char*)"DATETIME", 8, cast(char*)p, strlen(p));
-        Macro.define(&m.macrotable, cast(char*)"YEAR", 4, cast(char*)p + 20, 4);
+        Macro.define(&m.macrotable, cast(char*)"DATETIME", 8, p, strlen(p));
+        Macro.define(&m.macrotable, cast(char*)"YEAR", 4, p + 20, 4);
     }
     const srcfilename = m.srcfile.toChars();
     Macro.define(&m.macrotable, "SRCFILENAME", 11, srcfilename, strlen(srcfilename));
@@ -1872,7 +1872,7 @@ extern (C++) bool isDitto(const(char)* comment)
     if (comment)
     {
         const(char)* p = skipwhitespace(comment);
-        if (Port.memicmp(cast(const(char)*)p, "ditto", 5) == 0 && *skipwhitespace(p + 5) == 0)
+        if (Port.memicmp(p, "ditto", 5) == 0 && *skipwhitespace(p + 5) == 0)
             return true;
     }
     return false;
@@ -1971,11 +1971,11 @@ extern (C++) size_t skippastURL(OutBuffer* buf, size_t i)
     char* p = cast(char*)&buf.data[i];
     size_t j;
     uint sawdot = 0;
-    if (length > 7 && Port.memicmp(cast(char*)p, "http://", 7) == 0)
+    if (length > 7 && Port.memicmp(p, "http://", 7) == 0)
     {
         j = 7;
     }
-    else if (length > 8 && Port.memicmp(cast(char*)p, "https://", 8) == 0)
+    else if (length > 8 && Port.memicmp(p, "https://", 8) == 0)
     {
         j = 8;
     }

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -1667,7 +1667,7 @@ public:
                                 else
                                 {
                                     Type vt = tvp.valType.semantic(Loc(), sc);
-                                    MATCH m = cast(MATCH)dim.implicitConvTo(vt);
+                                    MATCH m = dim.implicitConvTo(vt);
                                     if (m <= MATCHnomatch)
                                         goto Lnomatch;
                                     (*dedtypes)[i] = dim;
@@ -4337,7 +4337,7 @@ extern (C++) MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplatePara
 
         override void visit(CommaExp e)
         {
-            (cast(CommaExp)e).e2.accept(this);
+            e.e2.accept(this);
         }
     }
 
@@ -8202,7 +8202,7 @@ public:
         symtab = new DsymbolTable();
         for (Scope* sce = sc; 1; sce = sce.enclosing)
         {
-            ScopeDsymbol sds = cast(ScopeDsymbol)sce.scopesym;
+            ScopeDsymbol sds = sce.scopesym;
             if (sds)
             {
                 sds.importScope(this, Prot(PROTpublic));

--- a/src/expression.d
+++ b/src/expression.d
@@ -4483,7 +4483,7 @@ public:
             wstring[i] = cast(wchar)c;
             break;
         case 4:
-            dstring[i] = cast(dchar)c;
+            dstring[i] = c;
             break;
         }
     }
@@ -4497,7 +4497,7 @@ public:
      */
     char* toPtr()
     {
-        return (sz == 1) ? cast(char*)string : null;
+        return (sz == 1) ? string : null;
     }
 
     override StringExp toStringExp()
@@ -4542,7 +4542,7 @@ public:
             switch (sz)
             {
             case 1:
-                return memcmp(cast(char*)string, cast(char*)se2.string, len1);
+                return memcmp(string, se2.string, len1);
             case 2:
                 {
                     wchar* s1 = cast(wchar*)string;
@@ -9512,7 +9512,7 @@ public:
                 ue.e1 = ue.e1.castTo(sc, ad2.type.addMod(ue.e1.type.mod));
                 ue.e1 = ue.e1.semantic(sc);
                 ue1 = ue.e1;
-                auto vi = f.findVtblIndex(cast(Dsymbols*)&ad2.vtbl, cast(int)ad2.vtbl.dim);
+                auto vi = f.findVtblIndex(&ad2.vtbl, cast(int)ad2.vtbl.dim);
                 assert(vi >= 0);
                 f = ad2.vtbl[vi].isFuncDeclaration();
                 assert(f);
@@ -12015,7 +12015,7 @@ public:
                     /* Rewrite (a[arguments] = e2) as:
                      *      a.opIndexAssign(e2, arguments)
                      */
-                    Expressions* a = cast(Expressions*)ae.arguments.copy();
+                    Expressions* a = ae.arguments.copy();
                     a.insert(0, e2);
                     result = new DotIdExp(loc, ae.e1, Id.indexass);
                     result = new CallExp(loc, result, a);

--- a/src/func.d
+++ b/src/func.d
@@ -878,7 +878,7 @@ public:
             /* Find index of existing function in base class's vtbl[] to override
              * (the index will be the same as in cd's current vtbl[])
              */
-            int vi = cd.baseClass ? findVtblIndex(cast(Dsymbols*)&cd.baseClass.vtbl, cast(int)cd.baseClass.vtbl.dim) : -1;
+            int vi = cd.baseClass ? findVtblIndex(&cd.baseClass.vtbl, cast(int)cd.baseClass.vtbl.dim) : -1;
             bool doesoverride = false;
             switch (vi)
             {
@@ -1044,7 +1044,7 @@ public:
         Linterfaces:
             foreach (b; cd.interfaces)
             {
-                vi = findVtblIndex(cast(Dsymbols*)&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
+                vi = findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
                 switch (vi)
                 {
                 case -1:
@@ -2496,7 +2496,7 @@ public:
         ClassDeclaration cd = parent.isClassDeclaration();
         foreach (b; cd.interfaces)
         {
-            auto v = findVtblIndex(cast(Dsymbols*)&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
+            auto v = findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
             if (v >= 0)
                 return b;
         }
@@ -2803,7 +2803,7 @@ public:
                 e = p.type.defaultInitLiteral(Loc());
             args[u] = e;
         }
-        MATCH m = cast(MATCH)tg.callMatch(null, &args, 1);
+        MATCH m = tg.callMatch(null, &args, 1);
         if (m > MATCHnomatch)
         {
             /* A variadic parameter list is less specialized than a

--- a/src/json.d
+++ b/src/json.d
@@ -410,7 +410,7 @@ public:
             if (em.origValue)
                 property("value", em.origValue.toChars());
         }
-        property("comment", cast(const(char)*)s.comment);
+        property("comment", s.comment);
         property("line", "char", &s.loc);
     }
 
@@ -459,7 +459,7 @@ public:
         property("kind", s.kind());
         filename = s.srcfile.toChars();
         property("file", filename);
-        property("comment", cast(const(char)*)s.comment);
+        property("comment", s.comment);
         propertyStart("members");
         arrayStart();
         for (size_t i = 0; i < s.members.dim; i++)
@@ -490,7 +490,7 @@ public:
         stringEnd();
         comma();
         property("kind", s.kind());
-        property("comment", cast(const(char)*)s.comment);
+        property("comment", s.comment);
         property("line", "char", &s.loc);
         if (s.prot().kind != PROTpublic)
             property("protection", protectionToChars(s.prot().kind));

--- a/src/link.d
+++ b/src/link.d
@@ -50,7 +50,7 @@ extern (C++) void writeFilename(OutBuffer* buf, const(char)* filename, size_t le
     for (size_t i = 0; i < len; i++)
     {
         char c = filename[i];
-        if (isalnum(cast(char)c) || c == '_')
+        if (isalnum(c) || c == '_')
             continue;
         /* Need to quote
          */

--- a/src/mars.d
+++ b/src/mars.d
@@ -291,7 +291,7 @@ extern (C++) void genCmain(Scope* sc)
     };
     Identifier id = Id.entrypoint;
     auto m = new Module("__entrypoint.d", id, 0, 0);
-    scope Parser p = new Parser(m, cmaincode, strlen(cast(const(char)*)cmaincode), 0);
+    scope Parser p = new Parser(m, cmaincode, strlen(cmaincode), 0);
     p.scanloc = Loc();
     p.nextToken();
     m.members = p.parseModule();

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -1010,7 +1010,7 @@ public:
         assert(t);
         if (!t.deco)
             return t.merge();
-        StringValue* sv = stringtable.lookup(cast(char*)t.deco, strlen(t.deco));
+        StringValue* sv = stringtable.lookup(t.deco, strlen(t.deco));
         if (sv && sv.ptrvalue)
         {
             t = cast(Type)sv.ptrvalue;
@@ -2434,7 +2434,7 @@ public:
             }
             else
             {
-                e = new StringExp(loc, cast(char*)deco);
+                e = new StringExp(loc, deco);
                 Scope sc;
                 e = e.semantic(&sc);
             }
@@ -4101,7 +4101,7 @@ public:
     // For eliminating dynamic_cast
     override TypeBasic isTypeBasic()
     {
-        return cast(TypeBasic)this;
+        return this;
     }
 
     override void accept(Visitor v)
@@ -8060,7 +8060,7 @@ public:
                 offset = vd.offset + cast(uint)vd.type.size();
             (*structelems)[j] = e;
         }
-        auto structinit = new StructLiteralExp(loc, cast(StructDeclaration)sym, structelems);
+        auto structinit = new StructLiteralExp(loc, sym, structelems);
         /* Copy from the initializer symbol for larger symbols,
          * otherwise the literals expressed as code get excessively large.
          */

--- a/src/nspace.d
+++ b/src/nspace.d
@@ -52,7 +52,7 @@ public:
             // The namespace becomes 'imported' into the enclosing scope
             for (Scope* sce = sc; 1; sce = sce.enclosing)
             {
-                ScopeDsymbol sds2 = cast(ScopeDsymbol)sce.scopesym;
+                ScopeDsymbol sds2 = sce.scopesym;
                 if (sds2)
                 {
                     sds2.importScope(this, Prot(PROTpublic));

--- a/src/opover.d
+++ b/src/opover.d
@@ -508,7 +508,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         /* Rewrite op(a[arguments]) as:
                          *      a.opIndexUnary!(op)(arguments)
                          */
-                        Expressions* a = cast(Expressions*)ae.arguments.copy();
+                        Expressions* a = ae.arguments.copy();
                         Objects* tiargs = opToArg(sc, e.op);
                         result = new DotTemplateInstanceExp(e.loc, ae.e1, Id.opIndexUnary, tiargs);
                         result = new CallExp(e.loc, result, a);
@@ -676,7 +676,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     /* Rewrite e1[arguments] as:
                      *      e1.opIndex(arguments)
                      */
-                    Expressions* a = cast(Expressions*)ae.arguments.copy();
+                    Expressions* a = ae.arguments.copy();
                     result = new DotIdExp(ae.loc, ae.e1, Id.index);
                     result = new CallExp(ae.loc, result, a);
                     if (maybeSlice) // a[] might be: a.opSlice()
@@ -1370,7 +1370,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         /* Rewrite a[arguments] op= e2 as:
                          *      a.opIndexOpAssign!(op)(e2, arguments)
                          */
-                        Expressions* a = cast(Expressions*)ae.arguments.copy();
+                        Expressions* a = ae.arguments.copy();
                         a.insert(0, e.e2);
                         Objects* tiargs = opToArg(sc, e.op);
                         result = new DotTemplateInstanceExp(e.loc, ae.e1, Id.opIndexOpAssign, tiargs);

--- a/src/statement.d
+++ b/src/statement.d
@@ -3554,7 +3554,7 @@ public:
                     if (se)
                     {
                         se = se.toUTF8(sc);
-                        fprintf(stderr, "%.*s", cast(int)se.len, cast(char*)se.string);
+                        fprintf(stderr, "%.*s", cast(int)se.len, se.string);
                     }
                     else
                         fprintf(stderr, "%s", e.toChars());

--- a/src/staticassert.d
+++ b/src/staticassert.d
@@ -92,7 +92,7 @@ public:
                 {
                     // same with pragma(msg)
                     se = se.toUTF8(sc);
-                    error("\"%.*s\"", cast(int)se.len, cast(char*)se.string);
+                    error("\"%.*s\"", cast(int)se.len, se.string);
                 }
                 else
                     error("%s", msg.toChars());

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -869,7 +869,7 @@ extern (C++) struct Token
                 if (postfix)
                     buf.writeByte(postfix);
                 buf.writeByte(0);
-                p = cast(char*)buf.extractData();
+                p = buf.extractData();
                 break;
             }
         case TOKidentifier:

--- a/src/traits.d
+++ b/src/traits.d
@@ -1200,7 +1200,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return null;
         cost = 0;
         StringValue* sv = traitsStringTable.lookup(seed, len);
-        return sv ? cast(void*)sv.ptrvalue : null;
+        return sv ? sv.ptrvalue : null;
     }
 
     if (auto sub = cast(const(char)*)speller(e.ident.toChars(), &trait_search_fp, idchars))


### PR DESCRIPTION
Most of these are left over from when a refactoring introduced a more appropriate type, and the cast was forgotten.  Casts like this can potentially hide bugs if the type is changed again.
