### PR TITLE
fix Issue 314 - static, renamed, and selective imports are always public

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -6,6 +6,7 @@ $(COMMENT Pending changelog for 2.071. This will get copied to dlang.org and
 
 $(BUGSTITLE Compiler Changes,
     $(LI $(RELATIVE_LINK2 imports-313, Import access checks for fully qualified names were fixed.))
+    $(LI $(RELATIVE_LINK2 imports-314, Protection for selective and renamed imports were fixed.))
 )
 
 $(BUGSTITLE Language Changes,
@@ -28,6 +29,28 @@ $(BUGSTITLE Compiler Changes,
     ---
 
     $(P To ease updating existing code, the old behavior was retained but deprecated.
+    )
+    )
+
+    $(LI $(LNAME2 imports-314, Protection for selective and renamed imports were fixed.)
+
+    $(P It is no longer possible to use private selective or renamed imports in another module, e.g.
+        the following example will fail with `a.File is not visible from module b`.
+    )
+
+    ---
+    module a;
+    import std.stdio : File; // imports are private by default
+    ---
+    ---
+    module b;
+    import a;
+
+    File f; // File is private
+    ---
+
+    $(P To ease updating existing code, the old behavior was retained but deprecated.
+        This fix relies on the visibility changes introduced with $(RELATIVE_LINK2 dip22, DIP22).
     )
     )
 )

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1368,7 +1368,12 @@ public:
                 if (!(flags & IgnoreErrors) && s.prot().kind == PROTprivate &&
                     !s.isOverloadable() && !s.parent.isTemplateMixin() && !s.parent.isNspace())
                 {
-                    if (!s.isImport())
+                    AliasDeclaration ad = void;
+                    // accessing private selective and renamed imports is
+                    // deprecated by restricting the symbol visibility
+                    if (s.isImport() || (ad = s.isAliasDeclaration()) !is null && ad._import !is null)
+                    {}
+                    else
                         error(loc, "%s %s is private", s.kind(), s.toPrettyChars());
                 }
                 //printf("\tfound in imports %s.%s\n", toChars(), s.toChars());

--- a/test/compilable/imports/a314.d
+++ b/test/compilable/imports/a314.d
@@ -1,0 +1,5 @@
+module imports.pkg.a314; // sub package
+
+package(imports) static import imports.c314;
+package(imports) import renamed = imports.c314;
+package(imports) import imports.c314 : bug;

--- a/test/compilable/imports/c314.d
+++ b/test/compilable/imports/c314.d
@@ -1,0 +1,4 @@
+module imports.c314;
+
+void bug(string s)
+{}

--- a/test/compilable/test314.d
+++ b/test/compilable/test314.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -de
+module imports.test314; // package imports
+
+import imports.a314;
+
+void main()
+{
+    imports.a314.bug("This should work.\n");
+    renamed.bug("This should work.\n");
+    bug("This should work.\n");
+}

--- a/test/fail_compilation/ice9865.d
+++ b/test/fail_compilation/ice9865.d
@@ -5,5 +5,5 @@ fail_compilation/ice9865.d(8): Error: alias ice9865.Baz recursive alias declarat
 ---
 */
 
-import imports.ice9865b : Baz;
+public import imports.ice9865b : Baz;
 struct Foo { Baz f; }

--- a/test/fail_compilation/imports/a314.d
+++ b/test/fail_compilation/imports/a314.d
@@ -1,0 +1,5 @@
+module imports.a314;
+
+static import imports.c314;
+import renamed = imports.c314;
+import imports.c314 : bug;

--- a/test/fail_compilation/imports/b314.d
+++ b/test/fail_compilation/imports/b314.d
@@ -1,0 +1,4 @@
+module imports.b314;
+
+package import renamedpkg = imports.c314;
+package import imports.c314 : bugpkg=bug;

--- a/test/fail_compilation/imports/c314.d
+++ b/test/fail_compilation/imports/c314.d
@@ -1,0 +1,4 @@
+module imports.c314;
+
+void bug(string s)
+{}

--- a/test/fail_compilation/imports/ice9865b.d
+++ b/test/fail_compilation/imports/ice9865b.d
@@ -1,2 +1,2 @@
-import ice9865;
+public import ice9865;
 class Bar { Foo foo; }

--- a/test/fail_compilation/test314.d
+++ b/test/fail_compilation/test314.d
@@ -1,0 +1,25 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/test314.d(3): Deprecation: imports.a314.renamed is not visible from module test314
+fail_compilation/test314.d(4): Deprecation: imports.a314.bug is not visible from module test314
+fail_compilation/test314.d(6): Deprecation: imports.b314.renamedpkg is not visible from module test314
+fail_compilation/test314.d(7): Deprecation: imports.b314.bugpkg is not visible from module test314
+---
+*/
+
+module test314;
+
+import imports.a314;
+import imports.b314;
+
+#line 1
+void main()
+{
+    renamed.bug("This should not work.\n");
+    bug("This should not work.\n");
+
+    renamedpkg.bug("This should not work.\n");
+    bugpkg("This should not work.\n");
+}


### PR DESCRIPTION
- enable protection for imports

Based on DIP22 (#5472) in order to resolve plenty of private/public symbol collisions as in this example.

``` d
module b;
import core.stdc.stdio : print; // private printf alias
```

``` d
import core.stdc.stdio; // public printf definition
import b; // private printf alias from selective import

void test() { printf(""); }
```

Depends On: https://github.com/D-Programming-Language/dmd/pull/5509
