### PR TITLE
Run semantic() on Type.tvalist.

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -1484,7 +1484,7 @@ public:
                 if (f.linkage == LINKd || (f.parameters && Parameter.dim(f.parameters)))
                 {
                     // Declare _argptr
-                    Type t = Type.tvalist;
+                    Type t = Type.tvalist.semantic(loc, sc);
                     argptr = new VarDeclaration(Loc(), t, Id._argptr, null);
                     argptr.storage_class |= STCtemp;
                     argptr.semantic(sc2);


### PR DESCRIPTION
Type.tvalist is the type used for variable argument lists.
In most cases this type is a pointer. But on ARM / AARch64, this
type is a struct. With LDC, we places the definition of this struct
inside object.d because it must be globally available. Type.tvalist
is initialized with value Target.va_listType() which is defined as
new TypeIdentifier(Loc(), Identifier.idPool("__va_list"))). (Note
that every other implementation uses .pointerTo()).
Because semantic() is not run to resolve the type name, LDC crashes
somewhere during codegeneration.
Adding semantic() here fixes the problem.
