### PR TITLE
[REG2.068.0] Issue 15726 - forward reference error for circular classes, RefCounted

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -38,9 +38,9 @@ class VarDeclaration;
 
 enum Sizeok
 {
-    SIZEOKnone,         // size of aggregate is not computed yet
+    SIZEOKnone,         // size of aggregate is not yet able to compute
+    SIZEOKfwd,          // size of aggregate is ready to compute
     SIZEOKdone,         // size of aggregate is set correctly
-    SIZEOKfwd,          // error in computing size of aggregate
 };
 
 enum Baseok
@@ -115,6 +115,8 @@ public:
     void setScope(Scope *sc);
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
+    bool determineFields();
+    bool determineSize(Loc loc);
     virtual void finalizeSize() = 0;
     unsigned size(Loc loc);
     bool checkOverlappedFields();

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -392,7 +392,8 @@ public:
             if (mod.needmoduleinfo)
             {
                 //printf("module5 %s because of %s\n", sc.module.toChars(), mod.toChars());
-                sc._module.needmoduleinfo = 1;
+                if (sc)
+                    sc._module.needmoduleinfo = 1;
             }
         }
     }

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -261,6 +261,7 @@ public:
     extern (C++) static __gshared DsymbolTable modules; // symbol table of all modules
     extern (C++) static __gshared Modules amodules;     // array of all modules
     extern (C++) static __gshared Dsymbols deferred;    // deferred Dsymbol's needing semantic() run on them
+    extern (C++) static __gshared Dsymbols deferred2;   // deferred Dsymbol's needing semantic2() run on them
     extern (C++) static __gshared Dsymbols deferred3;   // deferred Dsymbol's needing semantic3() run on them
     extern (C++) static __gshared uint dprogress;       // progress resolving the deferred list
 
@@ -1131,6 +1132,18 @@ public:
         deferred.push(s);
     }
 
+    static void addDeferredSemantic2(Dsymbol s)
+    {
+        //printf("Module::addDeferredSemantic2('%s')\n", s.toChars());
+        deferred2.push(s);
+    }
+
+    static void addDeferredSemantic3(Dsymbol s)
+    {
+        //printf("Module::addDeferredSemantic3('%s')\n", s.toChars());
+        deferred3.push(s);
+    }
+
     /******************************************
      * Run semantic() on deferred symbols.
      */
@@ -1184,13 +1197,26 @@ public:
         //printf("-Module::runDeferredSemantic(), len = %d\n", deferred.dim);
     }
 
-    static void addDeferredSemantic3(Dsymbol s)
+    static void runDeferredSemantic2()
     {
-        deferred3.push(s);
+        Module.runDeferredSemantic();
+
+        Dsymbols* a = &Module.deferred2;
+        for (size_t i = 0; i < a.dim; i++)
+        {
+            Dsymbol s = (*a)[i];
+            //printf("[%d] %s semantic2a\n", i, s.toPrettyChars());
+            s.semantic2(null);
+
+            if (global.errors)
+                break;
+        }
     }
 
     static void runDeferredSemantic3()
     {
+        Module.runDeferredSemantic2();
+
         Dsymbols* a = &Module.deferred3;
         for (size_t i = 0; i < a.dim; i++)
         {

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -8196,7 +8196,7 @@ public:
             //printf("test3: enclosing = %d, s->parent = %s\n", enclosing, s->parent->toChars());
             s.semantic(sc2);
             //printf("test4: enclosing = %d, s->parent = %s\n", enclosing, s->parent->toChars());
-            sc2._module.runDeferredSemantic();
+            Module.runDeferredSemantic();
         }
     }
 

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -8423,23 +8423,10 @@ public:
         {
             if (semanticRun == PASSinit) // forward reference had occured
             {
-                /* Cannot handle forward references if mixin is a struct member,
-                 * because addField must happen during struct's semantic, not
-                 * during the mixin semantic.
-                 * runDeferred will re-run mixin's semantic outside of the struct's
-                 * semantic.
-                 */
-                AggregateDeclaration ad = toParent().isAggregateDeclaration();
-                if (ad)
-                    ad.sizeok = SIZEOKfwd;
-                else
-                {
-                    // Forward reference
-                    //printf("forward reference - deferring\n");
-                    _scope = scx ? scx : sc.copy();
-                    _scope.setNoFree();
-                    _scope._module.addDeferredSemantic(this);
-                }
+                //printf("forward reference - deferring\n");
+                _scope = scx ? scx : sc.copy();
+                _scope.setNoFree();
+                _scope._module.addDeferredSemantic(this);
                 return;
             }
 
@@ -8447,7 +8434,8 @@ public:
             errors = true;
             return; // error recovery
         }
-        TemplateDeclaration tempdecl = this.tempdecl.isTemplateDeclaration();
+
+        auto tempdecl = this.tempdecl.isTemplateDeclaration();
         assert(tempdecl);
 
         if (!ident)

--- a/src/mars.d
+++ b/src/mars.d
@@ -1456,6 +1456,7 @@ Language changes listed by -transition=id:
             fprintf(global.stdmsg, "semantic2 %s\n", m.toChars());
         m.semantic2();
     }
+    Module.runDeferredSemantic2();
     if (global.errors)
         fatal();
 

--- a/src/mars.d
+++ b/src/mars.d
@@ -1394,6 +1394,7 @@ Language changes listed by -transition=id:
     }
     if (global.errors)
         fatal();
+
     if (global.params.doHdrGeneration)
     {
         /* Generate 'header' import files.
@@ -1411,6 +1412,7 @@ Language changes listed by -transition=id:
     }
     if (global.errors)
         fatal();
+
     // load all unconditional imports for better symbol resolving
     for (size_t i = 0; i < modules.dim; i++)
     {
@@ -1421,7 +1423,9 @@ Language changes listed by -transition=id:
     }
     if (global.errors)
         fatal();
+
     backend_init();
+
     // Do semantic analysis
     for (size_t i = 0; i < modules.dim; i++)
     {
@@ -1430,8 +1434,8 @@ Language changes listed by -transition=id:
             fprintf(global.stdmsg, "semantic  %s\n", m.toChars());
         m.semantic();
     }
-    if (global.errors)
-        fatal();
+    //if (global.errors)
+    //    fatal();
     Module.dprogress = 1;
     Module.runDeferredSemantic();
     if (Module.deferred.dim)
@@ -1441,8 +1445,9 @@ Language changes listed by -transition=id:
             Dsymbol sd = Module.deferred[i];
             sd.error("unable to resolve forward reference in definition");
         }
-        fatal();
+        //fatal();
     }
+
     // Do pass 2 semantic analysis
     for (size_t i = 0; i < modules.dim; i++)
     {
@@ -1453,6 +1458,7 @@ Language changes listed by -transition=id:
     }
     if (global.errors)
         fatal();
+
     // Do pass 3 semantic analysis
     for (size_t i = 0; i < modules.dim; i++)
     {
@@ -1464,6 +1470,7 @@ Language changes listed by -transition=id:
     Module.runDeferredSemantic3();
     if (global.errors)
         fatal();
+
     // Scan for functions to inline
     if (global.params.useInline)
     {
@@ -1478,6 +1485,7 @@ Language changes listed by -transition=id:
     // Do not attempt to generate output files if errors or warnings occurred
     if (global.errors || global.warnings)
         fatal();
+
     // inlineScan incrementally run semantic3 of each expanded functions.
     // So deps file generation should be moved after the inlinig stage.
     if (global.params.moduleDeps)
@@ -1492,7 +1500,9 @@ Language changes listed by -transition=id:
         else
             printf("%.*s", cast(int)ob.offset, ob.data);
     }
+
     printCtfePerformanceStats();
+
     Library library = null;
     if (global.params.lib)
     {

--- a/src/module.h
+++ b/src/module.h
@@ -63,6 +63,7 @@ public:
     static DsymbolTable *modules;       // symbol table of all modules
     static Modules amodules;            // array of all modules
     static Dsymbols deferred;   // deferred Dsymbol's needing semantic() run on them
+    static Dsymbols deferred2;  // deferred Dsymbol's needing semantic2() run on them
     static Dsymbols deferred3;  // deferred Dsymbol's needing semantic3() run on them
     static unsigned dprogress;  // progress resolving the deferred list
     static void init();
@@ -135,8 +136,10 @@ public:
     Dsymbol *symtabInsert(Dsymbol *s);
     void deleteObjFile();
     static void addDeferredSemantic(Dsymbol *s);
-    static void runDeferredSemantic();
+    static void addDeferredSemantic2(Dsymbol *s);
     static void addDeferredSemantic3(Dsymbol *s);
+    static void runDeferredSemantic();
+    static void runDeferredSemantic2();
     static void runDeferredSemantic3();
     static void clearCache();
     int imports(Module *m);

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2500,6 +2500,10 @@ public:
             {
                 if (v.isField())
                 {
+                    auto ad = v.toParent().isAggregateDeclaration();
+                    ad.size(e.loc);
+                    if (ad.sizeok != SIZEOKdone)
+                        return new ErrorExp();
                     e = new IntegerExp(e.loc, v.offset, Type.tsize_t);
                     return e;
                 }
@@ -8020,7 +8024,7 @@ public:
     override structalign_t alignment()
     {
         if (sym.alignment == 0)
-            sym.size(Loc());
+            sym.size(sym.loc);
         return sym.alignment;
     }
 

--- a/src/statement.d
+++ b/src/statement.d
@@ -27,6 +27,7 @@ import ddmd.declaration;
 import ddmd.denum;
 import ddmd.dimport;
 import ddmd.dinterpret;
+import ddmd.dmodule;
 import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.dtemplate;
@@ -5948,7 +5949,7 @@ public:
                 s.aliasdecls.push(ad);
             }
             s.semantic(sc);
-            //s->semantic2(sc);     // Bugzilla 14666
+            Module.addDeferredSemantic2(s);     // Bugzilla 14666
             sc.insert(s);
             foreach (aliasdecl; s.aliasdecls)
             {

--- a/src/traits.d
+++ b/src/traits.d
@@ -777,10 +777,9 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             e.error("first argument is not a class");
             return new ErrorExp();
         }
-        if (cd.sizeok == SIZEOKnone)
+        if (cd.sizeok != SIZEOKdone)
         {
-            if (cd._scope)
-                cd.semantic(cd._scope);
+            cd.size(e.loc);
         }
         if (cd.sizeok != SIZEOKdone)
         {

--- a/test/compilable/testfwdref.d
+++ b/test/compilable/testfwdref.d
@@ -491,3 +491,161 @@ class Frop14609 : Foo14609!int
 {
     public int bar() { return 0; }
 }
+
+/***************************************************/
+// test case 1, comes from Phobos
+/*
+TEST_OUTPUT:
+---
++alias Alias12540
++anySatisfy, T.length == 1
++isStaticArray
++T.stringof in StaticArrayTypeOf
+-T.stringof in StaticArrayTypeOf
+-isStaticArray
++hasElaborateCpCtor S == struct or else
+-hasElaborateCpCtor S == struct or else
+-anySatisfy, T.length == 1
+-alias Alias12540
+---
+*/
+
+template anySatisfy15726x(alias F, T...)
+{
+    //static if (T.length == 1)
+    //{
+        pragma(msg, "+anySatisfy, T.length == 1");
+        enum anySatisfy15726x = F!(T[0]);
+        pragma(msg, "-anySatisfy, T.length == 1");
+    //}
+}
+
+template StaticArrayTypeOf15726x(T)
+{
+    alias X = T;
+
+    static if (is(X : E[n], E, size_t n))
+    {
+        //alias StaticArrayTypeOf15726x = X;
+    }
+    else
+    {
+        pragma(msg, "+T.stringof in StaticArrayTypeOf");
+        // Fixed: T.stringof (T == Class12540) should not invoke
+        //        T.size() in ClassDeclaration.search().
+        static assert(0, T.stringof~" is not a static array type");
+        pragma(msg, "-T.stringof in StaticArrayTypeOf");
+    }
+}
+
+//enum bool isStaticArray(T) = is(StaticArrayTypeOf15726x!T);
+template isStaticArray15726x(T)
+{
+    pragma(msg, "+isStaticArray");
+    enum bool isStaticArray15726x = is(StaticArrayTypeOf15726x!T);
+    pragma(msg, "-isStaticArray");
+}
+
+template hasElaborateCpCtor15726x(S)
+{
+    static if (isStaticArray15726x!S && S.length)
+    {
+        //pragma(msg, "X+");
+        enum bool hasElaborateCpCtor15726x =
+            hasElaborateCpCtor15726x!(typeof(S.init[0]));
+        //pragma(msg, "X-");
+    }
+    else
+    {
+        pragma(msg, "+hasElaborateCpCtor S == struct or else");
+        static if (is(S == struct))
+        {
+            enum bool hasElaborateCpCtor15726x = true;
+            //enum hasElaborateCpCtor15726x = hasMember!(S, "__postblit")
+            //    || anySatisfy15726x!(.hasElaborateCpCtor15726x, FieldTypeTuple!S);
+        }
+        else
+        {
+            enum bool hasElaborateCpCtor15726x = false;
+        }
+        pragma(msg, "-hasElaborateCpCtor S == struct or else");
+    }
+}
+
+struct VariantN15726x(AllowedTypesParam...)
+{
+    alias AllowedTypes = AllowedTypesParam;
+
+    static if (!AllowedTypes.length ||
+               anySatisfy15726x!(hasElaborateCpCtor15726x, AllowedTypes))
+    {
+    }
+}
+
+template Algebraic15726x(T)
+{
+    alias Algebraic15726x = VariantN15726x!(T);
+}
+
+void test15726x()
+{
+    static struct DummyScope
+    {
+        pragma(msg, "+alias Alias12540");
+        alias Alias12540 = Algebraic15726x!Class12540;
+        pragma(msg, "-alias Alias12540");
+        static class Class12540
+        {
+            Alias12540 entity;
+        }
+    }
+}
+
+/***************************************************/
+// test case 2, comes from Phobos
+
+struct RefCounted15726y(T)
+{
+    struct RefCountedStore
+    {
+        struct Impl
+        {
+            T _payload;
+        }
+        Impl* _store;
+    }
+    RefCountedStore _refCounted;
+
+    this(this) {}
+
+    ~this()
+    {
+        _refCounted._store._payload.__xdtor();
+    }
+}
+
+struct RangeT15726y(A)
+{
+    A[1] _outer_;
+    alias RC = RangeT15726y!(const(A));
+}
+
+struct Array15726y(T)
+{
+    struct Payload
+    {
+        ~this();
+    }
+
+    alias Data = RefCounted15726y!(Payload);
+    Data _data;
+
+    alias Range = RangeT15726y!Array15726y;
+}
+
+void test15726y()
+{
+    alias Range = RangeT15726y!(Array15726y!int);
+    Range r;
+    r = r;  // opAssign
+}

--- a/test/compilable/testfwdref.d
+++ b/test/compilable/testfwdref.d
@@ -649,3 +649,68 @@ void test15726y()
     Range r;
     r = r;  // opAssign
 }
+
+/***************************************************/
+// 15726
+
+struct RC15726(T)
+{
+    struct Impl
+    {
+        T _payload;
+    }
+
+    Impl* _store;
+
+    ~this()
+    {
+        destroy15726a(_store._payload);
+    }
+}
+
+// ----
+
+struct Con15726a(T)
+{
+    alias Stmt15726a = .Stmt15726a!T;
+}
+
+struct Stmt15726a(T)
+{
+    alias Con15726a = .Con15726a!T;
+
+    RC15726!Payload data;
+
+    struct Payload
+    {
+        Con15726a con;
+    }
+}
+
+Con15726a!int x15726a;
+
+void destroy15726a(T)(ref T obj) @trusted
+{
+    auto buf = (cast(ubyte*)&obj)[0 .. T.sizeof];
+}
+
+// ----
+
+struct Util15726b(C, S) {}
+
+struct Con15726b(T)
+{
+    alias Util15726b = .Util15726b!(Con15726b!T, Stmt15726b!T);
+}
+
+struct Stmt15726b(T)
+{
+    struct Payload
+    {
+        Con15726b!T con;
+    }
+
+    RC15726!Payload data;
+}
+
+Con15726b!int x15726b;

--- a/test/fail_compilation/fail42.d
+++ b/test/fail_compilation/fail42.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail42.d(20): Error: struct fail42.Yuiop no size yet for forward reference
+fail_compilation/fail42.d(22): Error: struct fail42.Qwert no size because of forward reference
 ---
 */
 


### PR DESCRIPTION
Defer aggregate instance size finalization until semantic2 at maximum

From long ago, an instance size finalization had been done during `semantic()` stage, but it had had a known problem. When an aggregate 'A' tries to build its dtor or postblit, they should know each types of instance fields. But the field type analysis could recursively reach to A's `sematnic()` (especially with `RefCounted`, `Variant`, etc) and it had caused forward reference issues.

Against that, we've tried many ways to detect/break the problematic recursive analysis. So far it has been mostly finished to monitoring `sizeok` field, though it has been still fragile.

Finally I found an essential solution. During the dtor or postblit building, we don't have to finalize instance size. Instead we just need to know the complete list of instance fields at that time.

From the view, I divide instance size determination process into two stages.

The first is `determineFields()`, it collects all instance fields then pushes into `AggregateDeclaration.fields`. It's called in aggregate's `semantic()` and makes preparations for `buildDtor()` and `buildPostBlit()`.

The second is `determineSize()`, it requests finalizing each type sizes of instance fields and determine the field offsets. If no declarations' `semantic()` depend on the instance size, `determineSize()` could be deferred until `semantic2()` stage at maximum.

Finally, a failure of `determineSize()` can mean an existence of unresolvable forward references (circular dependency, use of opaque struct, etc).

---

This PR is intentionally based on master branch, because this change is too big as a regression fix.
