### PR TITLE
Add `bool gototarget` to `CaseStatement` and `DefaultStatement`

### DIFF
--- a/src/statement.d
+++ b/src/statement.d
@@ -3866,7 +3866,7 @@ public:
             else
                 needswitcherror = true;
         }
-        if (!sc.sw.sdefault && (!isFinal || needswitcherror || global.params.useAssert))
+        if (!sdefault && (!isFinal || needswitcherror || global.params.useAssert))
         {
             hasNoDefault = 1;
             if (!isFinal && !_body.isErrorStatement())
@@ -3880,11 +3880,11 @@ public:
             else
                 s = new ExpStatement(loc, new HaltExp(loc));
             a.reserve(2);
-            sc.sw.sdefault = new DefaultStatement(loc, s);
+            sdefault = new DefaultStatement(loc, s);
             a.push(_body);
             if (_body.blockExit(sc.func, false) & BEfallthru)
                 a.push(new BreakStatement(Loc(), null));
-            a.push(sc.sw.sdefault);
+            a.push(sdefault);
             cs = new CompoundStatement(loc, a);
             _body = cs;
         }

--- a/src/statement.h
+++ b/src/statement.h
@@ -418,6 +418,7 @@ public:
     CaseStatements *cases;         // array of CaseStatement's
     int hasNoDefault;           // !=0 if no default statement
     int hasVars;                // !=0 if has variable case values
+    bool hasGotoDefault;        // true iff there is a `goto default` statement for this switch
 
     SwitchStatement(Loc loc, Expression *c, Statement *b, bool isFinal);
     Statement *syntaxCopy();
@@ -434,6 +435,8 @@ public:
     Statement *statement;
 
     int index;          // which case it is (since we sort this)
+    bool gototarget;    // true iff this is the target of a `goto case`
+
 
     CaseStatement(Loc loc, Expression *exp, Statement *s);
     Statement *syntaxCopy();
@@ -463,6 +466,8 @@ class DefaultStatement : public Statement
 {
 public:
     Statement *statement;
+
+    bool gototarget;        // true iff this is the target of a `goto default`
 
     DefaultStatement(Loc loc, Statement *s);
     Statement *syntaxCopy();


### PR DESCRIPTION
(First commit is a small cleanup in SwitchStatement.semantic.)

Add `bool gototarget` to `CaseStatement` and `DefaultStatement` that is set to true when the switch contains a `goto case` targetting that `CaseStatement` (or `DefaultStatement`)
`gototarget` is used in LDC for PGO.
The variable is not currently used in DMD, but may be useful in the future, e.g. for control flow analysis.

Note that I also had to create SwitchStatement.hasGotoDefault variable. I did not find a satisfactory way to avoid creating that variable.
