### PR TITLE
refactor: remove warnings about case fallthrough

### DIFF
--- a/src/cppmangle.d
+++ b/src/cppmangle.d
@@ -1015,7 +1015,10 @@ else static if (TARGET_WINDOS)
                 case Twchar:
                     if (checkTypeSaved(type))
                         return;
+                    break;
+
                 default:
+                    break;
                 }
             }
             mangleModifier(type);

--- a/src/root/filename.d
+++ b/src/root/filename.d
@@ -165,6 +165,7 @@ struct FileName
                      */
                     if (e == str + 1 || e == str + len - 1)
                         return e + 1;
+                    goto default;
                 }
             default:
                 if (e == str)
@@ -174,6 +175,7 @@ struct FileName
             }
             return e;
         }
+        assert(0);
     }
 
     extern (C++) const(char)* name() const

--- a/src/scanomf.d
+++ b/src/scanomf.d
@@ -175,6 +175,7 @@ extern (C++) void scanOmfObjModule(void* pctx, void function(void* pctx, const(c
         case PUBDEF:
             if (easyomf)
                 recTyp = PUB386; // convert to MS format
+            goto case;
         case PUB386:
             if (!(parseIdx(&p) | parseIdx(&p)))
                 p += 2; // skip seg, grp, frame
@@ -189,6 +190,7 @@ extern (C++) void scanOmfObjModule(void* pctx, void function(void* pctx, const(c
         case COMDAT:
             if (easyomf)
                 recTyp = COMDAT + 1; // convert to MS format
+            goto case;
         case COMDAT + 1:
             {
                 int pickAny = 0;


### PR DESCRIPTION
Removes the following warnings:

```
cppmangle.d(1018): Warning: switch case fallthrough - use 'goto default;' if intended
scanomf.d(178): Warning: switch case fallthrough - use 'goto case;' if intended
scanomf.d(192): Warning: switch case fallthrough - use 'goto case;' if intended
scanomf.d(178): Warning: switch case fallthrough - use 'goto case;' if intended
scanomf.d(192): Warning: switch case fallthrough - use 'goto case;' if intended
root\filename.d(169): Warning: switch case fallthrough - use 'goto default;' if intended
root\filename.d(142): Error: function ddmd.root.filename.FileName.name no return exp; or assert(0); at end of function
```
