### PR TITLE
Replace UTF-8–invalid embedded characters with valid UTF-8

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -587,7 +587,7 @@ typedef int bool;
 #endif
 
 #if _WINDLL
-#define COPYRIGHT "Copyright © 2001 Digital Mars"
+#define COPYRIGHT "Copyright Â© 2001 Digital Mars"
 #else
 #ifdef DEBUG
 #define COPYRIGHT "Copyright (C) Digital Mars 2000-2013.  All Rights Reserved.\n\


### PR DESCRIPTION
The copyright symbol, when encoded in Win-1252, is not valid UTF-8. D assumes UTF-8 and chokes on it, so this commit replaces it with the valid, multibyte UTF-8 encoding of the symbol.

In truth, I feel it would be safer to simply use "(C)", as is used everywhere else in the code, but that would seem to ignore the intentions of the original author (who rightfully thought it would be cool to have the actual copyright symbol in there), so I'm not the one to make that decision :]

Also: This is --_cues spooky sound effects_-- backend code... (oh my)

Does that effect anything about the process? (sorry, I'm new to the community :])

```
e:\code\dlang\dmd\src>make tolf -f win32.mak
tolf aggregate.h aliasthis.h arraytypes.h        attrib.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h       enum.h errors.h expression.h globals.h hdrgen.h identifier.h idgen.d
 import.h init.h intrange.h json.h lexer.h lib.h macro.h         mars.h module.h mtype.h nspace.h objc.h parse.h                          scope.h statement.h staticassert.h target.h template.h tokens.h       version.h visitor.h access.d aggregate.d aliasthis.d apply.d argtypes.d arrayop.d       arraytypes.d attrib.d builtin.d canthrow.d clone.d complex.d            cond.d constfold.d cppmangle.d ctfeexpr.d dcast.d dclass.d             declaration.d delegatize.d denum.d dimport.d dinifile.d dinterpret.d    dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d                dtemplate.d dversion.d entity.d errors.d escape.d                       expression.d func.d globals.d hdrgen.d id.d identifier.d imphint.d      impcnvtab.d init.d inline.d intrange.d json.d lexer.d lib.d link.d     mars.d mtype.d nogc.d nspace.d objc_stubs.d opover.d optimize.d parse.d         sapply.d sideeffect.d statement.d staticassert.d target.d tokens.d
 traits.d utf.d visitor.d libomf.d scanomf.d typinf.d  libmscoff.d scanmscoff.d irstate.d toctype.d backend.d gluelayer.d glue.c msc.c s2ir.c todt.c e2ir.c tocsym.c  toobj.c tocvdebug.c toir.h toir.c  irstate.h iasm.c  toelfdebug.d libelf.d scanelf.d libmach.d scanmach.d  tk.c eh.c objc_glue_stubs.c objc_glue.c  irstate.d toctype.d backend.d gluelayer.d root\root.h root\stringtable.h root\aav.h  root\longdouble.h root\outbuffer.h root\object.h                root\filename.h root\file.h root\array.h root\rmem.h root\newdelete.c   root\rmem.d root\stringtable.d root\man.d root\port.d  root\response.d root\rootobject.d root\speller.d root\aav.d     root\longdouble.d root\outbuffer.d root\filename.d              root\file.d root\array.d tk\filespec.h tk\mem.h tk\list.h tk\vec.h tk\filespec.c tk\mem.c tk\vec.c tk\list.c backend\cdef.h backend\cc.h backend\oper.h backend\ty.h backend\optabgen.c  backend\global.h backend\code.h backend\code_x86.h backend/code_stub.h backend/platform_stub.c  backend\type.h backend\dt.h backend\cgcv.h  backend\el.h backend\iasm.h backend\rtlsym.h  backend\bcomplex.c backend\blockopt.c backend\cg.c backend\cg87.c backend\cgxmm.c  backend\cgcod.c backend\cgcs.c backend\cgcv.c backend\cgelem.c backend\cgen.c backend\cgobj.c  backend\cgreg.c backend\var.c  backend\cgsched.c backend\cod1.c backend\cod2.c backend\cod3.c backend\cod4.c backend\cod5.c  backend\code.c backend\symbol.c backend\debug.c backend\dt.c backend\ee.c backend\el.c  backend\evalu8.c backend\go.c backend\gflow.c backend\gdag.c  backend\gother.c backend\glocal.c backend\gloop.c backend\newman.c  backend\nteh.c backend\os.c backend\out.c backend\outbuf.c backend\ptrntab.c backend\rtlsym.c  backend\type.c backend\melf.h backend\mach.h backend\mscoff.h backend\bcomplex.h  backend\cdeflnx.h backend\outbuf.h backend\token.h backend\tassert.h  backend\elfobj.c backend\cv4.h backend\dwarf2.h backend\exh.h backend\go.h  backend\dwarf.c backend\dwarf.h backend\cppman.c backend\machobj.c  backend\strtold.c backend\aa.h backend\aa.c backend\tinfo.h backend\ti_achar.c  backend\md5.h backend\md5.c backend\ti_pvoid.c backend\xmm.h backend\ph2.c backend\util2.c  backend\mscoffobj.c backend\obj.h backend\pdata.c backend\cv8.c backend\backconfig.c  backend\divcoeff.c backend\dwarfeh.c  backend\backend.txt win32.mak posix.mak osmodel.mak

std.utf.UTFException@C:\D\dmd2\windows\bin\..\..\src\phobos\std\utf.d(1216): Invalid UTF-8 sequence (at index 1)
----------------
0x00402E4C
0x00402DE8
0x00402D65
0x00402C88
0x00402091
0x0040490B
0x004048CF
0x004047D0
0x00403BF3
0x74D57C04 in BaseThreadInitThunk
0x771FB54F in RtlInitializeExceptionChain
0x771FB51A in RtlInitializeExceptionChain

--- errorlevel 1
```
