### PR TITLE
Remove temporary switch 'dwarfeh'

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -49,8 +49,7 @@ void out_config_init(
                         // 1: D
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
-        bool stackstomp,        // add stack stomping code
-        bool dwarfeh            // use Dwarf eh
+        bool stackstomp         // add stack stomping code
         )
 {
 #if MARS

--- a/src/globals.d
+++ b/src/globals.d
@@ -108,7 +108,6 @@ struct Param
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations
-    bool dwarfeh;           // generate dwarf eh exception handling
     bool check10378;        // check for issues transitioning to 10738
     bool bug10378;          // use pre-bugzilla 10378 search strategy
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -92,7 +92,6 @@ struct Param
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
-    bool dwarfeh;       // generate dwarf eh exception handling
     bool check10378;    // check for issues transitioning to 10738
     bool bug10378;      // use pre-bugzilla 10378 search strategy
 

--- a/src/mars.d
+++ b/src/mars.d
@@ -454,8 +454,6 @@ private int tryMain(size_t argc, const(char)** argv)
                 global.params.useDeprecated = 1;
             else if (strcmp(p + 1, "dw") == 0)
                 global.params.useDeprecated = 2;
-            else if (strcmp(p + 1, "dwarfeh") == 0)
-                global.params.dwarfeh = true;
             else if (strcmp(p + 1, "c") == 0)
                 global.params.link = false;
             else if (memcmp(p + 1, cast(char*)"color", 5) == 0)

--- a/src/msc.c
+++ b/src/msc.c
@@ -48,8 +48,7 @@ void out_config_init(
                         // 1: D
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
-        bool stackstomp,        // add stack stomping code
-        bool dwarfeh            // use Dwarf exception handling
+        bool stackstomp         // add stack stomping code
         );
 
 void out_config_debug(
@@ -99,8 +98,7 @@ void backend_init()
         params->optimize,
         params->symdebug,
         params->alwaysframe,
-        params->stackstomp,
-        params->dwarfeh
+        params->stackstomp
     );
 
 #ifdef DEBUG

--- a/src/target.d
+++ b/src/target.d
@@ -86,7 +86,7 @@ struct Target
         if (global.params.is64bit && global.params.isWindows)
             c_long_doublesize = 8;
 
-        cppExceptions = global.params.dwarfeh || global.params.isLinux || global.params.isFreeBSD ||
+        cppExceptions = global.params.isLinux || global.params.isFreeBSD ||
             global.params.isOSX;
     }
 

--- a/src/target.d
+++ b/src/target.d
@@ -87,7 +87,7 @@ struct Target
             c_long_doublesize = 8;
 
         cppExceptions = global.params.dwarfeh || global.params.isLinux || global.params.isFreeBSD ||
-            (global.params.isOSX && global.params.is64bit);
+            global.params.isOSX;
     }
 
     /******************************

--- a/test/fail_compilation/cppeh1.d
+++ b/test/fail_compilation/cppeh1.d
@@ -1,11 +1,14 @@
-// REQUIRED_ARGS: -dwarfeh
+// DISABLED: win32 win64
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/cppeh1.d(24): Error: cannot catch C++ class objects in @safe code
+fail_compilation/cppeh1.d(16): Error: cannot catch C++ class objects in @safe code
 ---
 */
 
+version (Windows) static assert(0, "This test should not run on this platform");
+
+#line 1
 extern (C++, std)
 {
     class exception { }

--- a/test/fail_compilation/cppeh2.d
+++ b/test/fail_compilation/cppeh2.d
@@ -1,11 +1,14 @@
-// REQUIRED_ARGS: -dwarfeh
+// DISABLED: win32 win64
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/cppeh2.d(19): Error: cannot mix catching D and C++ exceptions in the same try-catch
+fail_compilation/cppeh2.d(11): Error: cannot mix catching D and C++ exceptions in the same try-catch
 ---
 */
 
+version(Windows) static assert(0, "This test should not run on this platform");
+
+#line 1
 extern (C++, std)
 {
     class exception { }


### PR DESCRIPTION
It was introduced in P.R. #5305 to help debugging dwarfeh,
however it was supposed to be a temporary switch, but made it into
a release.  Some tests that started to depend on it where also amended.
Luckily it was never documented so we just remove it.

@WalterBright : This isn't a revert of your P.R. since there are two changes ([This looks like a bugfix](https://github.com/D-Programming-Language/dmd/pull/5305/files#diff-eb9cdf480cc83e486a88311d1df5d141R1554) and [this isn't 100% related to the switch](https://github.com/D-Programming-Language/dmd/pull/5305/files#diff-5c4ac22992d1aaf56043c3b55a55c39eR113)) which seemed unrelated to the switch itself 
