### PR TITLE
Statically import core.stdc.stdlib in the test runner

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -284,6 +284,7 @@ string genTempFilename(string result_path)
 
 int system(string command)
 {
+    static import core.stdc.stdlib;
     if (!command) return core.stdc.stdlib.system(null);
     const commandz = toStringz(command);
     auto status = core.stdc.stdlib.system(commandz);


### PR DESCRIPTION
Silence deprecations warnings that were triggered by the change of behaviour in imports.

Current output:

```
d_do_test.d(287): Deprecation: module core.stdc.stdlib is not accessible here, perhaps add 'static import core.stdc.stdlib;'
d_do_test.d(289): Deprecation: module core.stdc.stdlib is not accessible here, perhaps add 'static import core.stdc.stdlib;'
d_do_test.d(287): Deprecation: package core.stdc is not accessible here
d_do_test.d(287): Deprecation: module core.stdc.stdlib is not accessible here, perhaps add 'static import core.stdc.stdlib;'
d_do_test.d(289): Deprecation: package core.stdc is not accessible here
d_do_test.d(289): Deprecation: module core.stdc.stdlib is not accessible here, perhaps add 'static import core.stdc.stdlib;'
```
