### PR TITLE
[REG2.067] Issue 15744 - (SIGABRT) Error: overloadset t.Bar.__ctor is aliased to a function

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -9311,6 +9311,12 @@ public:
                     error("an earlier return statement skips constructor");
                 sc.callSuper |= CSXany_ctor | CSXsuper_ctor;
             }
+            if (auto os = cd.baseClass.ctor.isOverloadSet())
+            {
+                // Workaround for bugzilla 15744
+                os.error(loc, "is aliased to a function");
+                return new ErrorExp();
+            }
             tthis = cd.type.addMod(sc.func.type.mod);
             f = resolveFuncCall(loc, sc, cd.baseClass.ctor, null, tthis, arguments, 0);
             if (!f || f.errors)
@@ -9344,6 +9350,12 @@ public:
                 if ((sc.callSuper & CSXreturn) && !(sc.callSuper & CSXany_ctor))
                     error("an earlier return statement skips constructor");
                 sc.callSuper |= CSXany_ctor | CSXthis_ctor;
+            }
+            if (auto os = cd.ctor.isOverloadSet())
+            {
+                // Workaround for bugzilla 15744
+                os.error(loc, "is aliased to a function");
+                return new ErrorExp();
             }
             tthis = cd.type.addMod(sc.func.type.mod);
             f = resolveFuncCall(loc, sc, cd.ctor, null, tthis, arguments, 0);

--- a/test/fail_compilation/ice15744.d
+++ b/test/fail_compilation/ice15744.d
@@ -1,0 +1,57 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice15744.d(17): Error: overloadset ice15744.S.__ctor is aliased to a function
+fail_compilation/ice15744.d(53): Error: template instance ice15744.S.AddField!string.__ctor!(int) error instantiating
+fail_compilation/ice15744.d(41): Error: overloadset ice15744.B.__ctor is aliased to a function
+fail_compilation/ice15744.d(54): Error: template instance ice15744.C.__ctor!(string, int) error instantiating
+---
+*/
+
+template AddField(T)
+{
+    T b;
+    this(Args...)(T b, auto ref Args args)
+    {
+        this.b = b;
+        this(args);
+    }
+}
+
+template construcotrs()
+{
+    int a;
+    this(int a)
+    {
+        this.a = a;
+    }
+}
+
+class B
+{
+    mixin construcotrs;
+    mixin AddField!(string);
+}
+
+class C : B
+{
+    this(A...)(A args)
+    {
+        // The called super ctor is an overload set.
+        super(args);
+    }
+}
+
+struct S
+{
+    mixin construcotrs;
+    mixin AddField!(string);
+}
+
+void main()
+{
+    auto s = S("bar", 15);
+    auto c = new C("bar", 15);
+}
+
+// Note: This test case should be accepted finally. See issue 15784.


### PR DESCRIPTION
The immediate reason is that `resolveFuncCall` is not designed to work for `OverloadSet` (and it hadn't caused ICE fortunately until 2.066), but I think the root cause is a rejects-valid bug [issue 15784](https://issues.dlang.org/show_bug.cgi?id=15784).

Until we'll fix 15784 in the next major release, this workaround fix is necessary.
