### PR TITLE
Fix issue 15789, ICE for a rare case where a template argument is still a `Tuple` in semanticTiargs.

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -7187,6 +7187,14 @@ public:
             else if (isParameter(o))
             {
             }
+            else if (Tuple tup = isTuple(o))
+            {
+                // Expand tuple and insert its elements into tiargs
+                tiargs.remove(j);
+                tiargs.insert(j, &tup.objects);
+                j--;
+                continue;
+            }
             else
             {
                 assert(0);

--- a/test/compilable/ice15789.d
+++ b/test/compilable/ice15789.d
@@ -1,0 +1,21 @@
+struct InputRange {}
+
+auto md5Of(T...)(T ) {}
+
+template fqnSym(alias T : X!A, alias X, A...)
+{
+    template fqnTuple(B) { enum fqnTuple = 1; }
+    enum fqnSym = fqnTuple!A;
+}
+
+void foobar()  // ICE issue 15789
+{
+    md5Of(InputRange());
+    auto i = fqnSym!(md5Of!InputRange);
+}
+
+void barfoo()  // Reverse order was OK
+{
+    auto i = fqnSym!(md5Of!InputRange);
+    md5Of(InputRange());
+}


### PR DESCRIPTION
If it is not OK to use Phobos in dmd-testsuite, I greatly appreciate someone else taking the time to minimize the testcase further.
