### PR TITLE
set correct offsets for CFA registers

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -683,6 +683,7 @@ code *prolog()
 Lagain:
     spoff = 0;
     char guessneedframe = needframe;
+    int cfa_offset = 0;
 //    if (needframe && config.exe & (EX_LINUX | EX_FREEBSD | EX_SOLARIS) && !(usednteh & ~NTEHjmonitor))
 //      usednteh |= NTEHpassthru;
 
@@ -900,7 +901,7 @@ Lagain:
     }
     else if (needframe)                 // if variables or parameters
     {
-        c = cat(c, prolog_frame(farfunc, &xlocalsize, &enter));
+        c = cat(c, prolog_frame(farfunc, &xlocalsize, &enter, &cfa_offset));
         hasframe = 1;
     }
 
@@ -996,7 +997,7 @@ Lagain:
     }
 #endif
 
-    c = prolog_saveregs(c, topush);
+    c = prolog_saveregs(c, topush, cfa_offset);
 
 Lcont:
 

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -409,11 +409,11 @@ extern int EBPtoESP;            // add to EBP offset to get ESP offset
 code* prolog_ifunc(tym_t* tyf);
 code* prolog_ifunc2(tym_t tyf, tym_t tym, bool pushds);
 code* prolog_16bit_windows_farfunc(tym_t* tyf, bool* pushds);
-code* prolog_frame(unsigned farfunc, unsigned* xlocalsize, bool* enter);
+code* prolog_frame(unsigned farfunc, unsigned* xlocalsize, bool* enter, int* cfa_offset);
 code* prolog_frameadj(tym_t tyf, unsigned xlocalsize, bool enter, bool* pushalloc);
 code* prolog_frameadj2(tym_t tyf, unsigned xlocalsize, bool* pushalloc);
 code* prolog_setupalloca();
-code* prolog_saveregs(code *c, regm_t topush);
+code* prolog_saveregs(code *c, regm_t topush, int cfa_offset);
 code* epilog_restoreregs(code *c, regm_t topop);
 code* prolog_trace(bool farfunc, unsigned* regsaved);
 code* prolog_gen_win64_varargs();


### PR DESCRIPTION
Turns out the dwarf_CFA_offset's were wrongly generated, meaning the Dwarf EH unwinder can fail by restoring registers to the wrong values. The bug was hidden by the code generator doing excessive saves/restores of registers.

I don't know of a productive way to test this directly, as the unwinding code is completely hidden from us. I discovered the problem by trying to figure out why https://github.com/D-Programming-Language/dmd/pull/5478 didn't work.
