### PR TITLE
[Trivial] Remove a superfluous overload of `toAlias`

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -918,11 +918,6 @@ public:
         return true;
     }
 
-    override Dsymbol toAlias()
-    {
-        return this;
-    }
-
     Dsymbol isUnique()
     {
         if (!hasOverloads)


### PR DESCRIPTION
```
This override uses the same definition as `Dsymbol.toAlias`.
However, `OverDeclaration` inherits from `Declaration` which
doesn't overload `toAlias`, and inherits from `Dsymbol`.
```

It was introduced with OverDeclaration in https://github.com/D-Programming-Language/dmd/commit/5019a5798ffd2c3154e870966c038185330a2c36

I'll take the occasion to ask a question about `toAlias/toAlias2`:

I am currently working on [issue 4533 (See last comment)](https://issues.dlang.org/show_bug.cgi?id=4533#c7), and, while I got an almost working solution that passes the test suite (but not my new tests), it prompted the question of what `toAlias` and `toAlias2` are for.

Looking at their respective documentation ([toAlias](https://github.com/D-Programming-Language/dmd/blob/4b632c1e10031918c36022a39cca289cc1ba2345/src/dsymbol.d#L523-L527), [toAlias2](https://github.com/D-Programming-Language/dmd/blob/4b632c1e10031918c36022a39cca289cc1ba2345/src/dsymbol.d#L534)), I got the feeling that the former resolved a single "layer" of indirection, while the later gets to the "final" symbol.
However I was quickly proven wrong by [AliasDeclaration.toAlias](https://github.com/D-Programming-Language/dmd/blob/5123284f2713e9e657efa5f81d757e7d1c590d48/src/declaration.d#L755-L821). So it seems that `toAlias` always try to go the the "final" symbol".
In addition, looking at [`toAlias2` definitions](https://github.com/D-Programming-Language/dmd/search?utf8=%E2%9C%93&q=%22Dsymbol+toAlias2%22&type=Code) and [only usage](https://github.com/D-Programming-Language/dmd/blob/98b7f150bf2c8e802881f91996111665fc35c239/src/dtemplate.d#L6228-L6239) (outside of `toAlias2` definitions) it seems quite specialized to be placed in `Dsymbol`.

The underlying question here is: what is the way to only peel off one level of indirection (or alias) from a symbol ?
