### PR TITLE
fix Issue 15785 - spurious warning when calling protected super

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7031,6 +7031,11 @@ public:
                 Type t = s.getType(); // type symbol, type alias, or type tuple?
                 uint errorsave = global.errors;
                 Dsymbol sm = s.searchX(loc, sc, id);
+                if (sm && !symbolIsVisible(sc, sm))
+                {
+                    .deprecation(loc, "%s is not visible from module %s", sm.toPrettyChars(), sc._module.toChars());
+                    // sm = null;
+                }
                 if (global.errors != errorsave)
                 {
                     *pt = Type.terror;
@@ -7875,9 +7880,9 @@ public:
             if (!s)
                 return noMember(sc, e, ident, flag);
         }
-        if (!symbolIsVisible(sc._module, s))
+        if (!symbolIsVisible(sc, s))
         {
-            .deprecation(e.loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toChars());
+            .deprecation(e.loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toPrettyChars());
             // return noMember(sc, e, ident, flag);
         }
         if (!s.isFuncDeclaration()) // because of overloading
@@ -8736,7 +8741,7 @@ public:
                 return noMember(sc, e, ident, flag);
             }
         }
-        if (!symbolIsVisible(sc._module, s))
+        if (!symbolIsVisible(sc, s))
         {
             .deprecation(e.loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toChars());
             // return noMember(sc, e, ident, flag);

--- a/test/compilable/imports/test15785.d
+++ b/test/compilable/imports/test15785.d
@@ -1,0 +1,13 @@
+module imports.test15785;
+
+interface IBase2
+{
+    final protected void faz() {}
+}
+
+class Base
+{
+    protected void foo() {}
+    protected void bar() {}
+    protected alias T = int;
+}

--- a/test/compilable/test15785.d
+++ b/test/compilable/test15785.d
@@ -1,0 +1,22 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+---
+*/
+import imports.test15785;
+
+class Derived : Base, IBase2
+{
+    override void foo()
+    {
+        super.foo();
+        bar();
+        // Base.bar(); // doesn't work yet due to a bug in checkAccess
+        faz();
+        // IBase2.faz(); // doesn't work yet due to a bug in checkAccess
+    }
+
+    super.T t;
+}

--- a/test/fail_compilation/imports/test15785.d
+++ b/test/fail_compilation/imports/test15785.d
@@ -1,0 +1,13 @@
+module imports.test15785;
+
+class Base
+{
+    private void foo() {}
+    private void bar() {}
+    private alias T = int;
+}
+
+interface IBase2
+{
+    private alias T = int;
+}

--- a/test/fail_compilation/test15785.d
+++ b/test/fail_compilation/test15785.d
@@ -1,0 +1,21 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test15785.d(5): Deprecation: imports.test15785.Base.foo is not visible from module test15785
+fail_compilation/test15785.d(5): Error: class test15785.Derived member foo is not accessible
+fail_compilation/test15785.d(6): Deprecation: imports.test15785.Base.bar is not visible from module test15785
+fail_compilation/test15785.d(6): Error: class test15785.Derived member bar is not accessible
+---
+*/
+import imports.test15785;
+
+#line 1
+class Derived : Base
+{
+    void test()
+    {
+        super.foo();
+        bar();
+    }
+}

--- a/test/fail_compilation/test15785b.d
+++ b/test/fail_compilation/test15785b.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test15785b.d(3): Deprecation: imports.test15785.Base.T is not visible from module test15785b
+fail_compilation/test15785b.d(4): Deprecation: imports.test15785.Base.T is not visible from module test15785b
+fail_compilation/test15785b.d(5): Deprecation: imports.test15785.IBase2.T is not visible from module test15785b
+---
+*/
+import imports.test15785;
+
+#line 1
+class Derived : Base, IBase2
+{
+    super.T t;
+    Base.T t2;
+    IBase2.T t3;
+}


### PR DESCRIPTION
- allow access to protected symbols accessible through base class
- need to check visibility for qualified lookups from the current scope
