### PR TITLE
refactor: remove LNGDBLSIZE from back end

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -299,6 +299,13 @@ void out_config_debug(
 void util_set16()
 {
     // The default is 16 bits
+    tysize[TYldouble] = 10;
+    tysize[TYildouble] = 10;
+    tysize[TYcldouble] = 20;
+
+    tyalignsize[TYldouble] = 2;
+    tyalignsize[TYildouble] = 2;
+    tyalignsize[TYcldouble] = 2;
 }
 
 /*******************************

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -468,20 +468,7 @@ typedef unsigned        targ_uns;
 #define CENTSIZE        16
 #define FLOATSIZE       4
 #define DOUBLESIZE      8
-#if TARGET_OSX
-#define LNGDBLSIZE      16      // 80 bit reals
-#elif TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-#define LNGDBLSIZE      12      // 80 bit reals
-#else
-#define LNGDBLSIZE      10      // 80 bit reals
-#endif
-#define TMAXSIZE        LNGDBLSIZE      // largest size a constant can be
-
-#if 0
-#define NDPSAVESIZE     DOUBLESIZE
-#else
-#define NDPSAVESIZE     LNGDBLSIZE
-#endif
+#define TMAXSIZE        16      // largest size a constant can be
 
 #define intsize         tysize[TYint]
 #define REGSIZE         tysize[TYnptr]

--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -2047,7 +2047,6 @@ code *eq87(elem *e,regm_t *pretregs)
         }
         cs.Irm |= modregrm(0,op2,0);            // OR in reg field
         c2 = gen(c2, &cs);
-#if LNGDBLSIZE == 12
         if (tysize[TYldouble] == 12)
         {
         /* This deals with the fact that 10 byte reals really
@@ -2064,8 +2063,7 @@ code *eq87(elem *e,regm_t *pretregs)
             c2 = gen(c2, &cs);
         }
         }
-#endif
-        if (tysize[TYldouble] == 16)
+        else if (tysize[TYldouble] == 16)
         {
         /* This deals with the fact that 10 byte reals really
          * occupy 16 bytes by zeroing the extra 6 bytes.
@@ -2807,13 +2805,14 @@ code *cdnegass87(elem *e,regm_t *pretregs)
     cr = modEA(&cs);
     cs.Irm |= modregrm(0,6,0);
     cs.Iop = 0x80;
-#if LNGDBLSIZE > 10
-    if (tyml == TYldouble || tyml == TYildouble)
-        cs.IEVoffset1 += 10 - 1;
-    else if (tyml == TYcldouble)
-        cs.IEVoffset1 += tysize[TYldouble] + 10 - 1;
+    if (tysize[TYldouble] > 10)
+    {
+        if (tyml == TYldouble || tyml == TYildouble)
+            cs.IEVoffset1 += 10 - 1;
+        else if (tyml == TYcldouble)
+            cs.IEVoffset1 += tysize[TYldouble] + 10 - 1;
+    }
     else
-#endif
         cs.IEVoffset1 += sz - 1;
     cs.IFL2 = FLconst;
     cs.IEV2.Vuns = 0x80;

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -782,11 +782,7 @@ Lagain:
 
     CSoff = alignsection(Alloca.offset - cstop * REGSIZE, REGSIZE, bias);
 
-#if TX86
-    NDPoff = alignsection(CSoff - NDP::savetop * NDPSAVESIZE, REGSIZE, bias);
-#else
-    NDPoff = CSoff;
-#endif
+    NDPoff = alignsection(CSoff - NDP::savetop * tysize[TYldouble], REGSIZE, bias);
 
     regm_t topush = fregsaved & ~mfuncreg;          // mask of registers that need saving
     pushoffuse = false;
@@ -2002,7 +1998,7 @@ regm_t lpadregs()
     if (config.ehmethod == EH_DWARF)
         used = allregs & ~mfuncreg;
     else
-	used = (I32 | I64) ? allregs : (ALLREGS | mES);
+        used = (I32 | I64) ? allregs : (ALLREGS | mES);
     //printf("lpadregs(): used=%s, allregs=%s, mfuncreg=%s\n", regm_str(used), regm_str(allregs), regm_str(mfuncreg));
     return used;
 }

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -4223,7 +4223,7 @@ code *pushParams(elem *e,unsigned stackalign)
             goto L2;
         }
 
-        assert(I64 || sz <= LNGDBLSIZE);
+        assert(I64 || sz <= tysize[TYldouble]);
         int i = sz;
         if (!I16 && i == 2)
             flag = CFopsize;

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -4816,7 +4816,7 @@ void assignaddrc(code *c)
 #if MARS
                 assert(c->IEV1.Vuns < NDP::savetop);
 #endif
-                c->IEVpointer1 = c->IEV1.Vuns * NDPSAVESIZE + NDPoff + BPoff;
+                c->IEVpointer1 = c->IEV1.Vuns * tysize[TYldouble] + NDPoff + BPoff;
                 c->Iflags |= CFunambig;
                 goto L2;
             case FLoffset:

--- a/src/backend/newman.c
+++ b/src/backend/newman.c
@@ -654,7 +654,7 @@ char *template_mangle(symbol *s,param_t *arglist)
                     {   case TYfloat:   ni = FLOATSIZE;  c = 'F'; goto L1;
                         case TYdouble_alias:
                         case TYdouble:  ni = DOUBLESIZE; c = 'D'; goto L1;
-                        case TYldouble: ni = LNGDBLSIZE; c = 'L'; goto L1;
+                        case TYldouble: ni = tysize[TYldouble]; c = 'L'; goto L1;
                         L1:
                             if (NEWTEMPMANGLE)
                                 CHAR('$');

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -835,15 +835,15 @@ void dotytab()
 "float",        TYfloat,        TYfloat,   TYfloat,     FLOATSIZE, 0x88,0x40,
 "double",       TYdouble,       TYdouble,  TYdouble,    DOUBLESIZE,0x89,0x41,
 "double alias", TYdouble_alias, TYdouble_alias,  TYdouble_alias,8, 0x89,0x41,
-"long double",  TYldouble,      TYldouble,  TYldouble,  LNGDBLSIZE, 0x89,0x42,
+"long double",  TYldouble,      TYldouble,  TYldouble,  -1, 0x89,0x42,
 
 "imaginary float",      TYifloat,       TYifloat,   TYifloat,   FLOATSIZE, 0x88,0x40,
 "imaginary double",     TYidouble,      TYidouble,  TYidouble,  DOUBLESIZE,0x89,0x41,
-"imaginary long double",TYildouble,     TYildouble, TYildouble, LNGDBLSIZE,0x89,0x42,
+"imaginary long double",TYildouble,     TYildouble, TYildouble, -1,0x89,0x42,
 
 "complex float",        TYcfloat,       TYcfloat,   TYcfloat,   2*FLOATSIZE, 0x88,0x50,
 "complex double",       TYcdouble,      TYcdouble,  TYcdouble,  2*DOUBLESIZE,0x89,0x51,
-"complex long double",  TYcldouble,     TYcldouble, TYcldouble, 2*LNGDBLSIZE,0x89,0x52,
+"complex long double",  TYcldouble,     TYcldouble, TYcldouble, -1,0x89,0x52,
 
 "float[4]",              TYfloat4,    TYfloat4,  TYfloat4,    16,     0,      0,
 "double[2]",             TYdouble2,   TYdouble2, TYdouble2,   16,     0,      0,


### PR DESCRIPTION
replace with `tysize[TYldouble]`
