### PR TITLE
cache result of toPrettyChars()

### DIFF
--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -160,6 +160,7 @@ public:
     const utf8_t *comment;      // documentation comment for this Dsymbol
     Loc loc;                    // where defined
     Scope *_scope;               // !=NULL means context to use for semantic()
+    const utf8_t *prettystring;
     bool errors;                // this symbol failed to pass semantic()
     PASS semanticRun;
     char *depmsg;               // customized deprecation message

--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -113,7 +113,7 @@ else
             return p;
         }
 
-        void error()
+        static void error()
         {
             printf("Error: out of memory\n");
             exit(EXIT_FAILURE);

--- a/src/root/rmem.h
+++ b/src/root/rmem.h
@@ -31,7 +31,7 @@ struct Mem
     void *xrealloc(void *p, d_size_t size);
     void xfree(void *p);
     void *xmallocdup(void *o, d_size_t size);
-    void error();
+    static void error();
 };
 
 extern Mem mem;


### PR DESCRIPTION
`toPrettyChars()` has some egregious faults:
1. it is called over and over again on the same symbol, consuming more memory each time
2. it allocates memory twice for its components (not very nice)

This fixes both problems by 1. caching the result and 2. caching the internal temporary results.
