### PR TITLE
Use Windows-1252 encoding for the copyright notice on Windows

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -587,7 +587,14 @@ typedef int bool;
 #endif
 
 #if _WINDLL
-#define COPYRIGHT "Copyright © 2001 Digital Mars"
+/* We reference the required Windows-1252 encoding of the copyright symbol
+   by escaping its character code (0xA9) rather than directly embedding it in
+   the source text. The character code is invalid in UTF-8, which causes some
+   of our source-code preprocessing tools (e.g. tolf) to choke. */
+#ifndef COPYRIGHT_SYMBOL
+#define COPYRIGHT_SYMBOL "\xA9"
+#endif
+#define COPYRIGHT "Copyright " COPYRIGHT_SYMBOL " 2001 Digital Mars"
 #else
 #ifdef DEBUG
 #define COPYRIGHT "Copyright (C) Digital Mars 2000-2013.  All Rights Reserved.\n\


### PR DESCRIPTION
Uses an escaped character code for the copyright symbol, keeping the source code clear of non-ASCII characters (_so that UTF-8–based source-processing tools like `tolf` work_), while still producing the intended Windows-1252 string in Windows DLL version-info blocks.

( This is a refactoring of PR #5508 .)
