### PR TITLE
add nothrow to root.outbuffer

### DIFF
--- a/src/root/outbuffer.d
+++ b/src/root/outbuffer.d
@@ -20,12 +20,12 @@ struct OutBuffer
     int level;
     int notlinehead;
 
-    extern (C++) ~this()
+    extern (C++) ~this() nothrow
     {
         mem.xfree(data);
     }
 
-    extern (C++) char* extractData()
+    extern (C++) char* extractData() nothrow
     {
         char* p;
         p = cast(char*)data;
@@ -35,7 +35,7 @@ struct OutBuffer
         return p;
     }
 
-    extern (C++) void reserve(size_t nbytes)
+    extern (C++) void reserve(size_t nbytes) nothrow
     {
         //printf("OutBuffer::reserve: size = %d, offset = %d, nbytes = %d\n", size, offset, nbytes);
         if (size - offset < nbytes)
@@ -46,17 +46,17 @@ struct OutBuffer
         }
     }
 
-    extern (C++) void setsize(size_t size)
+    extern (C++) void setsize(size_t size) nothrow
     {
         offset = size;
     }
 
-    extern (C++) void reset()
+    extern (C++) void reset() nothrow
     {
         offset = 0;
     }
 
-    extern (C++) void write(const(void)* data, size_t nbytes)
+    extern (C++) void write(const(void)* data, size_t nbytes) nothrow
     {
         if (doindent && !notlinehead)
         {
@@ -76,17 +76,17 @@ struct OutBuffer
         offset += nbytes;
     }
 
-    extern (C++) void writebstring(char* string)
+    extern (C++) void writebstring(char* string) nothrow
     {
         write(string, *string + 1);
     }
 
-    extern (C++) void writestring(const(char)* string)
+    extern (C++) void writestring(const(char)* string) nothrow
     {
         write(string, strlen(string));
     }
 
-    extern (C++) void prependstring(const(char)* string)
+    extern (C++) void prependstring(const(char)* string) nothrow
     {
         size_t len = strlen(string);
         reserve(len);
@@ -96,7 +96,7 @@ struct OutBuffer
     }
 
     // write newline
-    extern (C++) void writenl()
+    extern (C++) void writenl() nothrow
     {
         version (Windows)
         {
@@ -110,7 +110,7 @@ struct OutBuffer
             notlinehead = 0;
     }
 
-    extern (C++) void writeByte(uint b)
+    extern (C++) void writeByte(uint b) nothrow
     {
         if (doindent && !notlinehead && b != '\n')
         {
@@ -130,7 +130,7 @@ struct OutBuffer
         offset++;
     }
 
-    extern (C++) void writeUTF8(uint b)
+    extern (C++) void writeUTF8(uint b) nothrow
     {
         reserve(6);
         if (b <= 0x7F)
@@ -182,7 +182,7 @@ struct OutBuffer
             assert(0);
     }
 
-    extern (C++) void prependbyte(uint b)
+    extern (C++) void prependbyte(uint b) nothrow
     {
         reserve(1);
         memmove(data + 1, data, offset);
@@ -190,7 +190,7 @@ struct OutBuffer
         offset++;
     }
 
-    extern (C++) void writewchar(uint w)
+    extern (C++) void writewchar(uint w) nothrow
     {
         version (Windows)
         {
@@ -202,7 +202,7 @@ struct OutBuffer
         }
     }
 
-    extern (C++) void writeword(uint w)
+    extern (C++) void writeword(uint w) nothrow
     {
         version (Windows)
         {
@@ -230,7 +230,7 @@ struct OutBuffer
         offset += 2;
     }
 
-    extern (C++) void writeUTF16(uint w)
+    extern (C++) void writeUTF16(uint w) nothrow
     {
         reserve(4);
         if (w <= 0xFFFF)
@@ -248,7 +248,7 @@ struct OutBuffer
             assert(0);
     }
 
-    extern (C++) void write4(uint w)
+    extern (C++) void write4(uint w) nothrow
     {
         version (Windows)
         {
@@ -276,7 +276,7 @@ struct OutBuffer
         offset += 4;
     }
 
-    extern (C++) void write(const OutBuffer* buf)
+    extern (C++) void write(const OutBuffer* buf) nothrow
     {
         if (buf)
         {
@@ -286,7 +286,7 @@ struct OutBuffer
         }
     }
 
-    extern (C++) void write(RootObject obj)
+    extern (C++) void write(RootObject obj) /*nothrow*/
     {
         if (obj)
         {
@@ -294,14 +294,14 @@ struct OutBuffer
         }
     }
 
-    extern (C++) void fill0(size_t nbytes)
+    extern (C++) void fill0(size_t nbytes) nothrow
     {
         reserve(nbytes);
         memset(data + offset, 0, nbytes);
         offset += nbytes;
     }
 
-    extern (C++) void vprintf(const(char)* format, va_list args)
+    extern (C++) void vprintf(const(char)* format, va_list args) /*nothrow*/
     {
         int count;
         if (doindent)
@@ -347,7 +347,7 @@ struct OutBuffer
         offset += count;
     }
 
-    extern (C++) void printf(const(char)* format, ...)
+    extern (C++) void printf(const(char)* format, ...) /*nothrow*/
     {
         va_list ap;
         va_start(ap, format);
@@ -355,7 +355,7 @@ struct OutBuffer
         va_end(ap);
     }
 
-    extern (C++) void bracket(char left, char right)
+    extern (C++) void bracket(char left, char right) nothrow
     {
         reserve(2);
         memmove(data + 1, data, offset);
@@ -368,7 +368,7 @@ struct OutBuffer
      * Insert left at i, and right at j.
      * Return index just past right.
      */
-    extern (C++) size_t bracket(size_t i, const(char)* left, size_t j, const(char)* right)
+    extern (C++) size_t bracket(size_t i, const(char)* left, size_t j, const(char)* right) nothrow
     {
         size_t leftlen = strlen(left);
         size_t rightlen = strlen(right);
@@ -378,7 +378,7 @@ struct OutBuffer
         return j + leftlen + rightlen;
     }
 
-    extern (C++) void spread(size_t offset, size_t nbytes)
+    extern (C++) void spread(size_t offset, size_t nbytes) nothrow
     {
         reserve(nbytes);
         memmove(data + offset + nbytes, data + offset, this.offset - offset);
@@ -388,26 +388,26 @@ struct OutBuffer
     /****************************************
      * Returns: offset + nbytes
      */
-    extern (C++) size_t insert(size_t offset, const(void)* p, size_t nbytes)
+    extern (C++) size_t insert(size_t offset, const(void)* p, size_t nbytes) nothrow
     {
         spread(offset, nbytes);
         memmove(data + offset, p, nbytes);
         return offset + nbytes;
     }
 
-    extern (C++) void remove(size_t offset, size_t nbytes)
+    extern (C++) void remove(size_t offset, size_t nbytes) nothrow
     {
         memmove(data + offset, data + offset + nbytes, this.offset - (offset + nbytes));
         this.offset -= nbytes;
     }
 
-    extern (D) const(char)[] peekSlice()
+    extern (D) const(char)[] peekSlice() nothrow
     {
         return (cast(const char*)data)[0 .. offset];
     }
 
     // Append terminating null if necessary and get view of internal buffer
-    extern (C++) char* peekString()
+    extern (C++) char* peekString() nothrow
     {
         if (!offset || data[offset - 1] != '\0')
         {
@@ -418,7 +418,7 @@ struct OutBuffer
     }
 
     // Append terminating null if necessary and take ownership of data
-    extern (C++) char* extractString()
+    extern (C++) char* extractString() nothrow
     {
         if (!offset || data[offset - 1] != '\0')
             writeByte(0);


### PR DESCRIPTION
Because `nothrow` makes for better codegen.

Requires https://github.com/D-Programming-Language/dmd/pull/5541

Eventually requires https://github.com/D-Programming-Language/druntime/pull/1514 so `OutBuffer.printf()` can also be `nothrow`.
