### PR TITLE
fix Issue 15729 - broken debug info for libraries

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -268,7 +268,7 @@ static int local_cnt;           // Number of symbols with STB_LOCAL
 
 // Symbol Table
 Outbuffer  *SYMbuf;             // Buffer to build symbol table in
-Outbuffer  *reset_symbuf;       // Keep pointers to reset symbols
+static Outbuffer *reset_symbuf; // Keep pointers to reset symbols
 
 // Extended section header indices
 static Outbuffer *shndx_data;

--- a/test/runnable/extra-files/gdb15729.d
+++ b/test/runnable/extra-files/gdb15729.d
@@ -1,0 +1,7 @@
+import lib15729;
+
+void main()
+{
+    test1();
+    test2();
+}

--- a/test/runnable/extra-files/lib15729.d
+++ b/test/runnable/extra-files/lib15729.d
@@ -1,0 +1,16 @@
+struct S
+{
+    uint val;
+}
+
+void test1()
+{
+    S s;
+    s.val = 4321;
+}
+
+void test2()
+{
+    S s;
+    s.val = 1234;
+}

--- a/test/runnable/gdb15729.sh
+++ b/test/runnable/gdb15729.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/gdb15729.sh.out
+
+if [ $OS == "win32" -o  $OS == "win64" ]; then
+	LIBEXT=.lib
+else
+	LIBEXT=.a
+fi
+libname=${dir}${SEP}lib15729${LIBEXT}
+
+$DMD -g -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}lib15729.d || exit 1
+$DMD -g -m${MODEL} -I${src} -of${dir}${SEP}gdb15729${EXE} ${src}${SEP}gdb15729.d ${libname} || exit 1
+
+if [ $OS == "linux" ]; then
+    cat > ${dir}${SEP}gdb15729.gdb <<-EOF
+       b lib15729.d:16
+       r
+       echo RESULT=
+       p s.val
+EOF
+    gdb ${dir}${SEP}gdb15729 --batch -x ${dir}${SEP}gdb15729.gdb | grep 'RESULT=.*1234' || exit 1
+fi
+
+rm -f ${libname} ${dir}${SEP}{gdb15729${OBJ},gdb15729${EXE},gdb15729.gdb}
+
+echo Success >${output_file}


### PR DESCRIPTION
- need to reset fake symbols that are only
  generated for debug types (struct, enum)
  or the cached Stypidx will erroneously be
  used for the next object file
