### PR TITLE
[refactor] Replace host version names inherited from C++ with `HOST_*`

### DIFF
--- a/src/dinifile.d
+++ b/src/dinifile.d
@@ -72,7 +72,7 @@ const(char)* findConfFile(const(char)* argv0, const(char)* inifile)
     filename = FileName.replaceName(argv0, inifile);
     if (FileName.exists(filename))
         return filename;
-    static if (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+    version (Posix)
     {
         // Search PATH for argv0
         auto p = getenv("PATH");

--- a/src/errors.d
+++ b/src/errors.d
@@ -68,7 +68,7 @@ extern (C++) bool isConsoleColorSupported()
     {
         return isatty(fileno(stderr)) != 0;
     }
-    else static if (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+    else version (Posix)
     {
         const(char)* term = getenv("TERM");
         return isatty(STDERR_FILENO) && term && term[0] && 0 != strcmp(term, "dumb");

--- a/src/globals.d
+++ b/src/globals.d
@@ -27,12 +27,6 @@ private string stripRight(string s)
     return s;
 }
 
-enum __linux__      = xversion!`linux`;
-enum __APPLE__      = xversion!`OSX`;
-enum __FreeBSD__    = xversion!`FreeBSD`;
-enum __OpenBSD__    = xversion!`OpenBSD`;
-enum __sun          = xversion!`Solaris`;
-
 enum IN_GCC     = xversion!`IN_GCC`;
 
 enum TARGET_LINUX   = xversion!`linux`;

--- a/src/link.d
+++ b/src/link.d
@@ -31,15 +31,6 @@ version (Windows) extern (C) int spawnl(int, const char*, const char*, const cha
 version (Windows) extern (C) int spawnv(int, const char*, const char**);
 version (CRuntime_Microsoft) extern (Windows) uint GetShortPathNameA(const char* lpszLongPath, char* lpszShortPath, uint cchBuffer);
 
-static if (__linux__ || __APPLE__)
-{
-    enum HAS_POSIX_SPAWN = 1;
-}
-else
-{
-    enum HAS_POSIX_SPAWN = 0;
-}
-
 /****************************************
  * Write filename to cmdbuf, quoting if necessary.
  */
@@ -69,7 +60,7 @@ extern (C++) void writeFilename(OutBuffer* buf, const(char)* filename)
     writeFilename(buf, filename, strlen(filename));
 }
 
-static if (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+version (Posix)
 {
     /*****************************
      * As it forwards the linker error message to stderr, checks for the presence
@@ -439,7 +430,7 @@ extern (C++) int runLINK()
             return status;
         }
     }
-    else static if (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+    else version (Posix)
     {
         pid_t childpid;
         int status;
@@ -457,7 +448,7 @@ extern (C++) int runLINK()
             if (global.params.dll)
                 argv.push("-dynamiclib");
         }
-        else static if (__linux__ || __FreeBSD__ || __OpenBSD__ || __sun)
+        else version (Posix)
         {
             if (global.params.dll)
                 argv.push("-shared");
@@ -889,7 +880,7 @@ extern (C++) int runProgram()
         // spawnlp returns intptr_t in some systems, not int
         return spawnv(0, ex, argv.tdata());
     }
-    else static if (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+    else version (Posix)
     {
         pid_t childpid;
         int status;

--- a/src/mars.d
+++ b/src/mars.d
@@ -397,7 +397,7 @@ private int tryMain(size_t argc, const(char)** argv)
         {
             global.inifilename = findConfFile(global.params.argv0, "sc.ini");
         }
-        else static if (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+        else version (Posix)
         {
             global.inifilename = findConfFile(global.params.argv0, "dmd.conf");
         }


### PR DESCRIPTION
I came across this when trying to automatically generate frontend headers, since those symbols will conflict with the system definitions.
