### PR TITLE
Remove volatile keyword

### DIFF
--- a/src/parse.d
+++ b/src/parse.d
@@ -5379,12 +5379,6 @@ public:
                 s = new ThrowStatement(loc, exp);
                 break;
             }
-        case TOKvolatile:
-            nextToken();
-            s = parseStatement(PSsemi | PScurlyscope);
-            error("volatile statements no longer allowed; use synchronized statements instead");
-            s = new SynchronizedStatement(loc, cast(Expression)null, s);
-            break;
         case TOKasm:
             {
                 // Parse the asm block into a sequence of AsmStatements,

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -225,7 +225,6 @@ enum TOK : int
     TOKfinal,
     TOKconst,
     TOKabstract,
-    TOKvolatile,
     TOKdebug,
     TOKdeprecated,
     TOKin,
@@ -482,7 +481,6 @@ alias TOKstatic = TOK.TOKstatic;
 alias TOKfinal = TOK.TOKfinal;
 alias TOKconst = TOK.TOKconst;
 alias TOKabstract = TOK.TOKabstract;
-alias TOKvolatile = TOK.TOKvolatile;
 alias TOKdebug = TOK.TOKdebug;
 alias TOKdeprecated = TOK.TOKdeprecated;
 alias TOKin = TOK.TOKin;
@@ -1010,7 +1008,6 @@ immutable Keyword[] keywords =
     Keyword("alias", TOKalias),
     Keyword("override", TOKoverride),
     Keyword("abstract", TOKabstract),
-    Keyword("volatile", TOKvolatile),
     Keyword("debug", TOKdebug),
     Keyword("deprecated", TOKdeprecated),
     Keyword("in", TOKin),

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -139,7 +139,7 @@ enum TOK
         TOKmixin,
 
         TOKalign, TOKextern, TOKprivate, TOKprotected, TOKpublic, TOKexport,
-        TOKstatic, TOKfinal, TOKconst, TOKabstract, TOKvolatile,
+        TOKstatic, TOKfinal, TOKconst, TOKabstract,
         TOKdebug, TOKdeprecated, TOKin, TOKout, TOKinout, TOKlazy,
         TOKauto, TOKpackage, TOKmanifest, TOKimmutable,
 


### PR DESCRIPTION
Has been an error since 2014: https://github.com/D-Programming-Language/dmd/pull/3977
