### PR TITLE
[REG2.071-devel] Issue 15815 - deprecation for aliased template instance not shown

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -613,7 +613,7 @@ public:
             s = null;
             type = Type.terror;
         }
-        if (!s || !((s.getType() && type.equals(s.getType())) || s.isEnumMember()))
+        if (!s || !s.isEnumMember())
         {
             Type t;
             Expression e;

--- a/test/fail_compilation/depmsg15815.d
+++ b/test/fail_compilation/depmsg15815.d
@@ -1,0 +1,23 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/depmsg15815.d(23): Deprecation: alias depmsg15815.Alias!(const(Foo)).Alias is deprecated - message
+Foo
+---
+*/
+
+template Unqual(T)
+{
+    static if (is(T U == const U)) alias Unqual = U;
+    else alias Unqual = T;
+}
+
+deprecated("message")
+template Alias(T)
+{
+    alias Alias = Unqual!T;
+}
+
+struct Foo {}
+pragma(msg, Alias!(const(Foo)));


### PR DESCRIPTION
Run `type.resolve` always even when `s` is an `AggregateDeclaration` - `(s.getType() && type.equals(s.getType())) == true`.
