### PR TITLE
Issue 15573 - -O -inline causes wrong code with idiv instruction

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -1655,6 +1655,8 @@ code *cdnot(elem *e,regm_t *pretregs)
                 cs.IFL2 = FLconst;
                 cs.IEV2.Vint = 0;
             }
+            if (I64 && (sz == 1) && reg >= 4)
+                cs.Irex |= REX;
             cs.Iop ^= (sz == 1);
             code_newreg(&cs,reg);
             c = gen(c,&cs);                             // CMP e1,0
@@ -1689,6 +1691,8 @@ code *cdnot(elem *e,regm_t *pretregs)
             cs.IFL2 = FLconst;
             cs.IEV2.Vint = 1;
         }
+        if (I64 && (sz == 1) && reg >= 4)
+            cs.Irex |= REX;
         cs.Iop ^= (sz == 1);
         code_newreg(&cs,reg);
         c = gen(c,&cs);                         // CMP e1,1


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15573

Yet another missing prefix - `reghasvalue` finds that `ESI` is zero, so it returns `6`.  For 8-bit sub-registers the `REX` prefix is needed on `I64`, or reg 6 gets interpreted as `DH`.

There doesn't seem to be much point in adding the test case as it relies on exact register allocation and is extremely brittle.

@WalterBright 
