### PR TITLE
Distinguish between C 'long double' and C '__float128'.

### DIFF
--- a/src/cppmangle.d
+++ b/src/cppmangle.d
@@ -640,7 +640,7 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                 c = 'd';
                 break;
             case Tfloat80:
-                c = (Target.realsize - Target.realpad == 16) ? 'g' : 'e';
+                c = Target.realislongdouble ? 'e' : 'g';
                 break;
             case Tbool:
                 c = 'b';

--- a/src/target.d
+++ b/src/target.d
@@ -25,6 +25,7 @@ struct Target
     extern (C++) static __gshared int realsize;             // size a real consumes in memory
     extern (C++) static __gshared int realpad;              // 'padding' added to the CPU real size to bring it up to realsize
     extern (C++) static __gshared int realalignsize;        // alignment for reals
+    extern (C++) static __gshared bool realislongdouble;    // distinguish between C 'long double' and '__float128'
     extern (C++) static __gshared bool reverseCppOverloads; // with dmc and cl, overloaded functions are grouped and in reverse order
     extern (C++) static __gshared bool cppExceptions;       // set if catching C++ exceptions is supported
     extern (C++) static __gshared int c_longsize;           // size of a C 'long' or 'unsigned long' type
@@ -80,6 +81,7 @@ struct Target
                 c_longsize = 8;
             }
         }
+        realislongdouble = true;
         c_long_doublesize = realsize;
         if (global.params.is64bit && global.params.isWindows)
             c_long_doublesize = 8;


### PR DESCRIPTION
The AArch64 platform defines C 'long double' as 128-bit floats.
A C '__float128' data type is not supported. This situation results
in wrong C++ mangling: 'g' is used instead of 'e'.

This PR fixes the situation with a new flag Target.realislongdouble.
