### PR TITLE
Ensure that the sync object is mutable in a `synchronize(obj) {...}` statement.

### DIFF
--- a/src/statement.d
+++ b/src/statement.d
@@ -4863,6 +4863,17 @@ public:
                 exp = new CastExp(loc, exp, t);
                 exp = exp.semantic(sc);
             }
+
+            /+ Semantic checking is skipped for the calls to _d_monitorenter/exit below,
+             + however they may write to the __monitor ptr of the object (argument type is mutable Object).
+             + Ensure here that the synchronization object is mutable.
+             +/
+            if (!exp.type.isMutable())
+            {
+                error("can only synchronize on a mutable object, not on '%s' of type '%s'", exp.toChars(), exp.type.toChars());
+                return new ErrorStatement();
+            }
+
             version (all)
             {
                 /* Rewrite as:

--- a/test/fail_compilation/fail14251.d
+++ b/test/fail_compilation/fail14251.d
@@ -1,0 +1,37 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail14251.d(19): Error: can only synchronize on a mutable object, not on 'this' of type 'const(B)'
+fail_compilation/fail14251.d(33): Error: can only synchronize on a mutable object, not on 'con' of type 'const(A)'
+fail_compilation/fail14251.d(36): Error: can only synchronize on a mutable object, not on 'imm' of type 'immutable(A)'
+---
+*/
+
+class B
+{
+    void bar()
+    {
+        synchronized (this) {} // OK
+    }
+
+    void bar() const
+    {
+        synchronized (this) {} // Error
+    }
+}
+
+class A
+{
+}
+
+void main()
+{
+    A mut = new A;
+    synchronized (mut) {} // OK
+
+    const A con = new A;
+    synchronized (con) {} // Error
+
+    immutable A imm = new A;
+    synchronized (imm) {} // Error
+}


### PR DESCRIPTION
This PR is related to Issue 14251. I think it fixes it completely, but I am uncertain what the correct behavior should be for pure functions.

The PR adds a check for mutability of the sync object: it it passed to druntime functions that require mutability of it, and so passing an immutable object may result in bad runtime behavior.

A simple testcase that shows the problem in LDC is:

``` D
import std.stdio : writeln;
interface Foo {}
void main() {
    writeln(cast(size_t) typeid(Foo).__monitor);
    synchronized(typeid(Foo)) { }
    writeln(cast(size_t) typeid(Foo).__monitor);
}
```

typeid returns an immutable(TypeInfo) in LDC. Without optimizations, this prints zero and a non-zero value; with optimizations turned on it prints two zeroes.

Current Phobos contains one case where synchronization inside a const method is done: std.concurrency. I think this is a latent bug, however that method is marked for removal in March 2016.
https://github.com/D-Programming-Language/phobos/blob/master/std/concurrency.d#L1815
