### PR TITLE
Issue 15816 - ICE void ddmd.dclass.__assert(int) with error: anonymous classes not allowed

### DIFF
--- a/src/dclass.d
+++ b/src/dclass.d
@@ -222,6 +222,10 @@ public:
 
     final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses, bool inObject = false)
     {
+        if (!id)
+            id = Identifier.generateId("__anonclass");
+        assert(id);
+
         super(loc, id);
 
         static __gshared const(char)* msg = "only object.d can define this reserved class name";
@@ -432,16 +436,9 @@ public:
 
         if (!parent)
         {
-            assert(sc.parent && (sc.func || !ident));
+            assert(sc.parent);
             parent = sc.parent;
-
-            if (!ident) // if anonymous class
-            {
-                const(char)* id = "__anonclass";
-                ident = Identifier.generateId(id);
-            }
         }
-        assert(parent && !isAnonymous());
 
         if (this.errors)
             type = Type.terror;

--- a/src/parse.d
+++ b/src/parse.d
@@ -2833,6 +2833,7 @@ public:
         Expression constraint = null;
         const loc = token.loc;
         TOK tok = token.value;
+
         //printf("Parser::parseAggregate()\n");
         nextToken();
         if (token.value != TOKidentifier)
@@ -2843,6 +2844,7 @@ public:
         {
             id = token.ident;
             nextToken();
+
             if (token.value == TOKlparen)
             {
                 // Class template declaration.
@@ -2851,13 +2853,15 @@ public:
                 constraint = parseConstraint();
             }
         }
+
         switch (tok)
         {
         case TOKclass:
         case TOKinterface:
             {
                 if (!id)
-                    error("anonymous classes not allowed");
+                    error(loc, "anonymous classes not allowed");
+
                 // Collect base class(es)
                 BaseClasses* baseclasses = null;
                 if (token.value == TOKcolon)
@@ -2878,6 +2882,7 @@ public:
                     if (token.value != TOKlcurly)
                         error("members expected");
                 }
+
                 if (tok == TOKclass)
                 {
                     bool inObject = md && !md.packages && md.id == Id.object;
@@ -2893,12 +2898,14 @@ public:
             else
                 anon = 1;
             break;
+
         case TOKunion:
             if (id)
                 a = new UnionDeclaration(loc, id);
             else
                 anon = 2;
             break;
+
         default:
             assert(0);
         }
@@ -2912,7 +2919,8 @@ public:
             nextToken();
             Dsymbols* decl = parseDeclDefs(0);
             if (token.value != TOKrcurly)
-                error("} expected following members in %s declaration at %s", Token.toChars(tok), loc.toChars());
+                error("} expected following members in %s declaration at %s",
+                    Token.toChars(tok), loc.toChars());
             nextToken();
             if (anon)
             {
@@ -2928,6 +2936,7 @@ public:
             error("{ } expected following %s declaration", Token.toChars(tok));
             a = new StructDeclaration(loc, null);
         }
+
         if (tpl)
         {
             // Wrap a template around the aggregate declaration

--- a/test/fail_compilation/ice15816.d
+++ b/test/fail_compilation/ice15816.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/imports/a15816.d(3): Error: anonymous classes not allowed
+---
+*/
+
+class A
+{
+    import imports.a15816;
+}

--- a/test/fail_compilation/imports/a15816.d
+++ b/test/fail_compilation/imports/a15816.d
@@ -1,0 +1,5 @@
+module imports.a15816;
+
+class
+{
+}


### PR DESCRIPTION
An invalid anonymous class declaration has no chance to get internal `ident` (= "__anonclassXX"), because its `parent` is set by `Dsymbol.addMember` before the `semantic` is invoked.

Name all `ClassDeclaration` instances during the constructions, then the problematic assertion can be removed.
