### PR TITLE
fix __traits(getPointerBitmap): allow typeof(null)

### DIFF
--- a/src/traits.d
+++ b/src/traits.d
@@ -291,7 +291,7 @@ extern (C++) Expression pointerBitmap(TraitsExp e)
 
         override void visit(TypeNull t)
         {
-            assert(0);
+            // always a null pointer
         }
 
         override void visit(TypeStruct t)

--- a/test/runnable/traits_getPointerBitmap.d
+++ b/test/runnable/traits_getPointerBitmap.d
@@ -144,6 +144,7 @@ alias string[3] sint3;
 alias string[3][2] sint3_2;
 alias int delegate() dg;
 alias int function() fn;
+alias typeof(null) NullType;
 
 // span multiple bitmap elements
 struct Large
@@ -214,6 +215,7 @@ void testRTInfo()
     testType!(dg)           ([ 0b01 ]);
     testType!(fn)           ([ 0b0 ]);
     testType!(S!fn)         ([ 0b100 ]);
+    testType!(NullType)     ([ 0b0 ]);
     version(D_LP64)
         testType!(__vector(float[4]))  ([ 0b00 ]);
 


### PR DESCRIPTION
fixes building https://github.com/D-Programming-Language/druntime/pull/1022 after rebase.
