### PR TITLE
Issue 15825 - dmd's -transition=checkimports reports a false positive for tuple __dollar

### DIFF
--- a/src/dscope.d
+++ b/src/dscope.d
@@ -519,6 +519,9 @@ struct Scope
             if (!global.params.check10378)
                 return sold;
 
+            if (ident == Id.dollar) // Bugzilla 15825
+                return sold;
+
             // Search both ways
             flags |= SearchCheck10378;
         }

--- a/test/compilable/checkimports15825.d
+++ b/test/compilable/checkimports15825.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -transition=checkimports -de
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+template anySatisfy(T...)
+{
+    alias anySatisfy = T[$ - 1];
+}
+
+alias T = anySatisfy!(int);


### PR DESCRIPTION
`ArrayScopeSymbol.search` repeatedly creates __dollar symbol for tuple `length` propery.
