### PR TITLE
Extend evalorder.d test with a slice expression without implicit type cast of the bounds

### DIFF
--- a/test/runnable/evalorder.d
+++ b/test/runnable/evalorder.d
@@ -17,6 +17,13 @@ void test14040()
     auto a2 = fun()[offset .. offset += 2];
     if (a2 != [4, 5] || offset != 6)
         assert(0);
+
+    // Also test an offset of type size_t such that it is used
+    // directly without any implicit conversion in the slice expression.
+    size_t offset_szt = 0;
+    auto a3 = values[offset_szt .. offset_szt += 2];
+    if (a3 != [0, 1] || offset_szt != 2)
+        assert(0);
 }
 
 /******************************************/


### PR DESCRIPTION
An addition to the testsuite to improve compiler test coverage.
The original test only failed with LDC in 32bit mode, but succeeds in 64bit mode.

The first tests use an offset of type `uint`, meaning that for 64bit compilation there will be an implicit conversion to 64bit. This implicit cast meant that LDC would store a 64bit copy of the lower bound expression before evaluating the second upper bound, with the effect that the test would pass. For 32bit, there is no implicit cast, and the actual value of the lower bound would only be loaded after evaluating the upper bound expression.
