### PR TITLE
Refactor: remove backend specific field StructLiteralExp.fillHoles

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -49,10 +49,11 @@ elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
 elem *array_toPtr(Type *t, elem *e);
 VarDeclarations *VarDeclarations_create();
 type *Type_toCtype(Type *t);
-elem *toElemDtor(Expression *e, IRState *irs);
 unsigned totym(Type *tx);
 Symbol *toSymbol(Dsymbol *s);
 elem *toElem(Expression *e, IRState *irs);
+elem *toElemDtor(Expression *e, IRState *irs);
+elem *toElemStructLit(StructLiteralExp *sle, IRState *irs, Symbol *sym, bool fillHoles);
 dt_t **Expression_toDt(Expression *e, dt_t **pdt);
 Symbol *toStringSymbol(const char *str, size_t len, size_t sz);
 Symbol *toStringSymbol(StringExp *se);
@@ -1638,12 +1639,8 @@ elem *toElem(Expression *e, IRState *irs)
                 }
                 else
                 {
-                    StructLiteralExp *se = StructLiteralExp::create(ne->loc, sd, ne->arguments, t);
-
-                    se->sym = ev->EV.sp.Vsym;
-                    se->fillHoles = false;
-
-                    ez = toElem(se, irs);
+                    StructLiteralExp *sle = StructLiteralExp::create(ne->loc, sd, ne->arguments, t);
+                    ez = toElemStructLit(sle, irs, ev->EV.sp.Vsym, false);
                 }
                 //elem_print(ex);
                 //elem_print(ey);
@@ -2826,13 +2823,9 @@ elem *toElem(Expression *e, IRState *irs)
                     ex->Eoper == OPvar && ex->EV.sp.Voffset == 0 &&
                     ae->op == TOKconstruct)
                 {
-                    StructLiteralExp *se = (StructLiteralExp *)ae->e2;
-
-                    se->sym = ex->EV.sp.Vsym;
-                    se->fillHoles = ae->op == TOKconstruct || ae->op == TOKblit;
-
+                    StructLiteralExp *sle = (StructLiteralExp *)ae->e2;
+                    e = toElemStructLit(sle, irs, ex->EV.sp.Vsym, true);
                     el_free(e1);
-                    e = toElem(ae->e2, irs);
                     goto Lret;
                 }
 
@@ -3718,11 +3711,11 @@ elem *toElem(Expression *e, IRState *irs)
             //printf("AddrExp::toElem('%s')\n", ae->toChars());
             if (ae->e1->op == TOKstructliteral)
             {
-                StructLiteralExp *sl = (StructLiteralExp*)ae->e1;
+                StructLiteralExp *sle = (StructLiteralExp*)ae->e1;
                 //printf("AddrExp::toElem('%s') %d\n", ae->toChars(), ae);
-                //printf("StructLiteralExp(%p); origin:%p\n", sl, sl->origin);
-                //printf("sl->toSymbol() (%p)\n", sl->toSymbol());
-                elem *e = el_ptr(toSymbol(sl->origin));
+                //printf("StructLiteralExp(%p); origin:%p\n", sle, sle->origin);
+                //printf("sle->toSymbol() (%p)\n", sle->toSymbol());
+                elem *e = el_ptr(toSymbol(sle->origin));
                 e->ET = Type_toCtype(ae->type);
                 el_setLoc(e, ae->loc);
                 result = e;
@@ -5262,255 +5255,10 @@ elem *toElem(Expression *e, IRState *irs)
             }
         }
 
-        /*******************************************
-         * Generate elem to zero fill contents of Symbol stmp
-         * from *poffset..offset2.
-         * May store anywhere from 0..maxoff, as this function
-         * tries to use aligned int stores whereever possible.
-         * Update *poffset to end of initialized hole; *poffset will be >= offset2.
-         */
-        static elem *fillHole(Symbol *stmp, size_t *poffset, size_t offset2, size_t maxoff)
-        {
-            elem *e = NULL;
-            int basealign = 1;
-
-            while (*poffset < offset2)
-            {
-                elem *e1;
-                if (tybasic(stmp->Stype->Tty) == TYnptr)
-                    e1 = el_var(stmp);
-                else
-                    e1 = el_ptr(stmp);
-                if (basealign)
-                    *poffset &= ~3;
-                basealign = 1;
-                size_t sz = maxoff - *poffset;
-                tym_t ty;
-                switch (sz)
-                {
-                    case 1: ty = TYchar;        break;
-                    case 2: ty = TYshort;       break;
-                    case 3:
-                        ty = TYshort;
-                        basealign = 0;
-                        break;
-                    default:
-                        ty = TYlong;
-                        // TODO: OPmemset is better if sz is much bigger than 4?
-                        break;
-                }
-                e1 = el_bin(OPadd, TYnptr, e1, el_long(TYsize_t, *poffset));
-                e1 = el_una(OPind, ty, e1);
-                e1 = el_bin(OPeq, ty, e1, el_long(ty, 0));
-                e = el_combine(e, e1);
-                *poffset += tysize[ty];
-            }
-            return e;
-        }
-
         void visit(StructLiteralExp *sle)
         {
             //printf("[%s] StructLiteralExp::toElem() %s\n", sle->loc.toChars(), sle->toChars());
-
-            if (sle->useStaticInit)
-            {
-                elem *e = el_var(toInitializer(sle->sd));
-                e->ET = Type_toCtype(sle->sd->type);
-                el_setLoc(e, sle->loc);
-
-                if (sle->sym)
-                {
-                    elem *ev = el_var(sle->sym);
-                    if (tybasic(ev->Ety) == TYnptr)
-                        ev = el_una(OPind, e->Ety, ev);
-                    ev->ET = e->ET;
-                    e = el_bin(OPstreq,e->Ety,ev,e);
-                    e->ET = ev->ET;
-
-                    //ev = el_var(sym);
-                    //ev->ET = e->ET;
-                    //e = el_combine(e, ev);
-                    el_setLoc(e, sle->loc);
-                }
-                result = e;
-                return;
-            }
-
-            // struct symbol to initialize with the literal
-            Symbol *stmp = sle->sym ? sle->sym : symbol_genauto(Type_toCtype(sle->sd->type));
-
-            elem *e = NULL;
-
-            /* If a field has explicit initializer (*sle->elements)[i] != NULL),
-             * any other overlapped fields won't have initializer. It's asserted by
-             * StructDeclaration::fill() function.
-             *
-             *  union U { int x; long y; }
-             *  U u1 = U(1);        // elements = [`1`, NULL]
-             *  U u2 = {y:2};       // elements = [NULL, `2`];
-             *  U u3 = U(1, 2);     // error
-             *  U u4 = {x:1, y:2};  // error
-             */
-            size_t dim = sle->elements ? sle->elements->dim : 0;
-            assert(dim <= sle->sd->fields.dim);
-
-            if (sle->fillHoles)
-            {
-                /* Initialize all alignment 'holes' to zero.
-                 * Do before initializing fields, as the hole filling process
-                 * can spill over into the fields.
-                 */
-                const size_t structsize = sle->sd->structsize;
-                size_t offset = 0;
-                //printf("-- %s - fillHoles, structsize = %d\n", sle->toChars(), structsize);
-                for (size_t i = 0; i < sle->sd->fields.dim && offset < structsize; )
-                {
-                    VarDeclaration *v = sle->sd->fields[i];
-
-                    /* If the field v has explicit initializer, [offset .. v->offset]
-                     * is a hole divided by the initializer.
-                     * However if the field size is zero (e.g. int[0] v;), we can merge
-                     * the two holes in the front and the back of the field v.
-                     */
-                    if (i < dim && (*sle->elements)[i] && v->type->size())
-                    {
-                        //if (offset != v->offset) printf("  1 fillHole, %d .. %d\n", offset, v->offset);
-                        e = el_combine(e, fillHole(stmp, &offset, v->offset, structsize));
-                        offset = v->offset + v->type->size();
-                        i++;
-                        continue;
-                    }
-                    if (!v->overlapped)
-                    {
-                        i++;
-                        continue;
-                    }
-
-                    /* AggregateDeclaration::fields holds the fields by the lexical order.
-                     * This code will minimize each hole sizes. For example:
-                     *
-                     *  struct S {
-                     *    union { uint f1; ushort f2; }   // f1: 0..4,  f2: 0..2
-                     *    union { uint f3; ulong f4; }    // f3: 8..12, f4: 8..16
-                     *  }
-                     *  S s = {f2:x, f3:y};     // filled holes: 2..8 and 12..16
-                     */
-                    size_t vend = sle->sd->fields.dim;
-                Lagain:
-                    size_t holeEnd = structsize;
-                    size_t offset2 = structsize;
-                    for (size_t j = i + 1; j < vend; j++)
-                    {
-                        VarDeclaration *vx = sle->sd->fields[j];
-                        if (!vx->overlapped)
-                        {
-                            vend = j;
-                            break;
-                        }
-                        if (j < dim && (*sle->elements)[j] && vx->type->size())
-                        {
-                            // Find the lowest end offset of the hole.
-                            if (offset <= vx->offset && vx->offset < holeEnd)
-                            {
-                                holeEnd = vx->offset;
-                                offset2 = vx->offset + vx->type->size();
-                            }
-                        }
-                    }
-                    if (holeEnd < structsize)
-                    {
-                        //if (offset != holeEnd) printf("  2 fillHole, %d .. %d\n", offset, holeEnd);
-                        e = el_combine(e, fillHole(stmp, &offset, holeEnd, structsize));
-                        offset = offset2;
-                        goto Lagain;
-                    }
-                    i = vend;
-                }
-                //if (offset != sle->sd->structsize) printf("  3 fillHole, %d .. %d\n", offset, sle->sd->structsize);
-                e = el_combine(e, fillHole(stmp, &offset, sle->sd->structsize, sle->sd->structsize));
-            }
-
-            // CTFE may fill the hidden pointer by NullExp.
-            {
-                for (size_t i = 0; i < dim; i++)
-                {
-                    Expression *el = (*sle->elements)[i];
-                    if (!el)
-                        continue;
-
-                    VarDeclaration *v = sle->sd->fields[i];
-                    assert(!v->isThisDeclaration() || el->op == TOKnull);
-
-                    elem *e1;
-                    if (tybasic(stmp->Stype->Tty) == TYnptr)
-                    {
-                        e1 = el_var(stmp);
-                    }
-                    else
-                    {
-                        e1 = el_ptr(stmp);
-                    }
-                    e1 = el_bin(OPadd, TYnptr, e1, el_long(TYsize_t, v->offset));
-
-                    elem *ep = toElem(el, irs);
-
-                    Type *t1b = v->type->toBasetype();
-                    Type *t2b = el->type->toBasetype();
-                    if (t1b->ty == Tsarray)
-                    {
-                        if (t2b->implicitConvTo(t1b))
-                        {
-                            elem *esize = el_long(TYsize_t, t1b->size());
-                            ep = array_toPtr(el->type, ep);
-                            e1 = el_bin(OPmemcpy, TYnptr, e1, el_param(ep, esize));
-                        }
-                        else
-                        {
-                            elem *edim = el_long(TYsize_t, t1b->size() / t2b->size());
-                            e1 = setArray(e1, edim, t2b, ep, irs, TOKconstruct);
-                        }
-                    }
-                    else
-                    {
-                        tym_t ty = totym(v->type);
-                        e1 = el_una(OPind, ty, e1);
-                        if (tybasic(ty) == TYstruct)
-                            e1->ET = Type_toCtype(v->type);
-                        e1 = el_bin(OPeq, ty, e1, ep);
-                        if (tybasic(ty) == TYstruct)
-                        {
-                            e1->Eoper = OPstreq;
-                            e1->ET = Type_toCtype(v->type);
-                        }
-                    }
-                    e = el_combine(e, e1);
-                }
-            }
-
-            if (sle->sd->isNested() && dim != sle->sd->fields.dim)
-            {
-                // Initialize the hidden 'this' pointer
-                assert(sle->sd->fields.dim);
-
-                elem *e1;
-                if (tybasic(stmp->Stype->Tty) == TYnptr)
-                {
-                    e1 = el_var(stmp);
-                }
-                else
-                {
-                    e1 = el_ptr(stmp);
-                }
-                e1 = setEthis(sle->loc, irs, e1, sle->sd);
-
-                e = el_combine(e, e1);
-            }
-
-            elem *ev = el_var(stmp);
-            ev->ET = Type_toCtype(sle->sd->type);
-            e = el_combine(e, ev);
-            el_setLoc(e, sle->loc);
-            result = e;
+            result = toElemStructLit(sle, irs, sle->sym, true);
         }
 
         /*****************************************************/
@@ -5530,6 +5278,257 @@ elem *toElem(Expression *e, IRState *irs)
     ToElemVisitor v(irs);
     e->accept(&v);
     return v.result;
+}
+
+/*******************************************
+ * Generate elem to zero fill contents of Symbol stmp
+ * from *poffset..offset2.
+ * May store anywhere from 0..maxoff, as this function
+ * tries to use aligned int stores whereever possible.
+ * Update *poffset to end of initialized hole; *poffset will be >= offset2.
+ */
+elem *fillHole(Symbol *stmp, size_t *poffset, size_t offset2, size_t maxoff)
+{
+    elem *e = NULL;
+    int basealign = 1;
+
+    while (*poffset < offset2)
+    {
+        elem *e1;
+        if (tybasic(stmp->Stype->Tty) == TYnptr)
+            e1 = el_var(stmp);
+        else
+            e1 = el_ptr(stmp);
+        if (basealign)
+            *poffset &= ~3;
+        basealign = 1;
+        size_t sz = maxoff - *poffset;
+        tym_t ty;
+        switch (sz)
+        {
+            case 1: ty = TYchar;        break;
+            case 2: ty = TYshort;       break;
+            case 3:
+                ty = TYshort;
+                basealign = 0;
+                break;
+            default:
+                ty = TYlong;
+                // TODO: OPmemset is better if sz is much bigger than 4?
+                break;
+        }
+        e1 = el_bin(OPadd, TYnptr, e1, el_long(TYsize_t, *poffset));
+        e1 = el_una(OPind, ty, e1);
+        e1 = el_bin(OPeq, ty, e1, el_long(ty, 0));
+        e = el_combine(e, e1);
+        *poffset += tysize[ty];
+    }
+    return e;
+}
+
+elem *toElemStructLit(StructLiteralExp *sle, IRState *irs, Symbol *sym, bool fillHoles)
+{
+    //printf("[%s] StructLiteralExp::toElem() %s\n", sle->loc.toChars(), sle->toChars());
+    //printf("\tsym = %p fillHoles = %d\n", sym, fillHoles);
+
+    if (sle->useStaticInit)
+    {
+        elem *e = el_var(toInitializer(sle->sd));
+        e->ET = Type_toCtype(sle->sd->type);
+        el_setLoc(e, sle->loc);
+
+        if (sym)
+        {
+            elem *ev = el_var(sym);
+            if (tybasic(ev->Ety) == TYnptr)
+                ev = el_una(OPind, e->Ety, ev);
+            ev->ET = e->ET;
+            e = el_bin(OPstreq,e->Ety,ev,e);
+            e->ET = ev->ET;
+
+            //ev = el_var(sym);
+            //ev->ET = e->ET;
+            //e = el_combine(e, ev);
+            el_setLoc(e, sle->loc);
+        }
+        return e;
+    }
+
+    // struct symbol to initialize with the literal
+    Symbol *stmp = sym ? sym : symbol_genauto(Type_toCtype(sle->sd->type));
+
+    elem *e = NULL;
+
+    /* If a field has explicit initializer (*sle->elements)[i] != NULL),
+     * any other overlapped fields won't have initializer. It's asserted by
+     * StructDeclaration::fill() function.
+     *
+     *  union U { int x; long y; }
+     *  U u1 = U(1);        // elements = [`1`, NULL]
+     *  U u2 = {y:2};       // elements = [NULL, `2`];
+     *  U u3 = U(1, 2);     // error
+     *  U u4 = {x:1, y:2};  // error
+     */
+    size_t dim = sle->elements ? sle->elements->dim : 0;
+    assert(dim <= sle->sd->fields.dim);
+
+    if (fillHoles)
+    {
+        /* Initialize all alignment 'holes' to zero.
+         * Do before initializing fields, as the hole filling process
+         * can spill over into the fields.
+         */
+        const size_t structsize = sle->sd->structsize;
+        size_t offset = 0;
+        //printf("-- %s - fillHoles, structsize = %d\n", sle->toChars(), structsize);
+        for (size_t i = 0; i < sle->sd->fields.dim && offset < structsize; )
+        {
+            VarDeclaration *v = sle->sd->fields[i];
+
+            /* If the field v has explicit initializer, [offset .. v->offset]
+             * is a hole divided by the initializer.
+             * However if the field size is zero (e.g. int[0] v;), we can merge
+             * the two holes in the front and the back of the field v.
+             */
+            if (i < dim && (*sle->elements)[i] && v->type->size())
+            {
+                //if (offset != v->offset) printf("  1 fillHole, %d .. %d\n", offset, v->offset);
+                e = el_combine(e, fillHole(stmp, &offset, v->offset, structsize));
+                offset = v->offset + v->type->size();
+                i++;
+                continue;
+            }
+            if (!v->overlapped)
+            {
+                i++;
+                continue;
+            }
+
+            /* AggregateDeclaration::fields holds the fields by the lexical order.
+             * This code will minimize each hole sizes. For example:
+             *
+             *  struct S {
+             *    union { uint f1; ushort f2; }   // f1: 0..4,  f2: 0..2
+             *    union { uint f3; ulong f4; }    // f3: 8..12, f4: 8..16
+             *  }
+             *  S s = {f2:x, f3:y};     // filled holes: 2..8 and 12..16
+             */
+            size_t vend = sle->sd->fields.dim;
+        Lagain:
+            size_t holeEnd = structsize;
+            size_t offset2 = structsize;
+            for (size_t j = i + 1; j < vend; j++)
+            {
+                VarDeclaration *vx = sle->sd->fields[j];
+                if (!vx->overlapped)
+                {
+                    vend = j;
+                    break;
+                }
+                if (j < dim && (*sle->elements)[j] && vx->type->size())
+                {
+                    // Find the lowest end offset of the hole.
+                    if (offset <= vx->offset && vx->offset < holeEnd)
+                    {
+                        holeEnd = vx->offset;
+                        offset2 = vx->offset + vx->type->size();
+                    }
+                }
+            }
+            if (holeEnd < structsize)
+            {
+                //if (offset != holeEnd) printf("  2 fillHole, %d .. %d\n", offset, holeEnd);
+                e = el_combine(e, fillHole(stmp, &offset, holeEnd, structsize));
+                offset = offset2;
+                goto Lagain;
+            }
+            i = vend;
+        }
+        //if (offset != sle->sd->structsize) printf("  3 fillHole, %d .. %d\n", offset, sle->sd->structsize);
+        e = el_combine(e, fillHole(stmp, &offset, sle->sd->structsize, sle->sd->structsize));
+    }
+
+    // CTFE may fill the hidden pointer by NullExp.
+    {
+        for (size_t i = 0; i < dim; i++)
+        {
+            Expression *el = (*sle->elements)[i];
+            if (!el)
+                continue;
+
+            VarDeclaration *v = sle->sd->fields[i];
+            assert(!v->isThisDeclaration() || el->op == TOKnull);
+
+            elem *e1;
+            if (tybasic(stmp->Stype->Tty) == TYnptr)
+            {
+                e1 = el_var(stmp);
+            }
+            else
+            {
+                e1 = el_ptr(stmp);
+            }
+            e1 = el_bin(OPadd, TYnptr, e1, el_long(TYsize_t, v->offset));
+
+            elem *ep = toElem(el, irs);
+
+            Type *t1b = v->type->toBasetype();
+            Type *t2b = el->type->toBasetype();
+            if (t1b->ty == Tsarray)
+            {
+                if (t2b->implicitConvTo(t1b))
+                {
+                    elem *esize = el_long(TYsize_t, t1b->size());
+                    ep = array_toPtr(el->type, ep);
+                    e1 = el_bin(OPmemcpy, TYnptr, e1, el_param(ep, esize));
+                }
+                else
+                {
+                    elem *edim = el_long(TYsize_t, t1b->size() / t2b->size());
+                    e1 = setArray(e1, edim, t2b, ep, irs, TOKconstruct);
+                }
+            }
+            else
+            {
+                tym_t ty = totym(v->type);
+                e1 = el_una(OPind, ty, e1);
+                if (tybasic(ty) == TYstruct)
+                    e1->ET = Type_toCtype(v->type);
+                e1 = el_bin(OPeq, ty, e1, ep);
+                if (tybasic(ty) == TYstruct)
+                {
+                    e1->Eoper = OPstreq;
+                    e1->ET = Type_toCtype(v->type);
+                }
+            }
+            e = el_combine(e, e1);
+        }
+    }
+
+    if (sle->sd->isNested() && dim != sle->sd->fields.dim)
+    {
+        // Initialize the hidden 'this' pointer
+        assert(sle->sd->fields.dim);
+
+        elem *e1;
+        if (tybasic(stmp->Stype->Tty) == TYnptr)
+        {
+            e1 = el_var(stmp);
+        }
+        else
+        {
+            e1 = el_ptr(stmp);
+        }
+        e1 = setEthis(sle->loc, irs, e1, sle->sd);
+
+        e = el_combine(e, e1);
+    }
+
+    elem *ev = el_var(stmp);
+    ev->ET = Type_toCtype(sle->sd->type);
+    e = el_combine(e, ev);
+    el_setLoc(e, sle->loc);
+    return e;
 }
 
 /********************************************

--- a/src/expression.d
+++ b/src/expression.d
@@ -5148,7 +5148,7 @@ public:
 
     bool useStaticInit;     // if this is true, use the StructDeclaration's init symbol
     Symbol* sym;            // back end symbol to initialize with literal
-    bool fillHoles = true;  // fill alignment 'holes' with zero
+
     OwnedBy ownedByCtfe = OWNEDcode;
 
     // pointer to the origin instance of the expression.

--- a/src/expression.h
+++ b/src/expression.h
@@ -473,7 +473,7 @@ public:
 
     bool useStaticInit;         // if this is true, use the StructDeclaration's init symbol
     Symbol *sym;                // back end symbol to initialize with literal
-    bool fillHoles;             // fill alignment 'holes' with zero
+
     OwnedBy ownedByCtfe;
 
     // pointer to the origin instance of the expression.

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -44,6 +44,7 @@ elem *exp2_copytotemp(elem *e);
 elem *incUsageElem(IRState *irs, Loc loc);
 elem *addressElem(elem *e, Type *t, bool alwaysCopy = false);
 type *Type_toCtype(Type *t);
+elem *toElemStructLit(StructLiteralExp *sle, IRState *irs, Symbol *sym, bool fillHoles);
 elem *toElemDtor(Expression *e, IRState *irs);
 Symbol *toSymbol(Type *t);
 Symbol *toSymbolCpp(ClassDeclaration *cd);
@@ -765,13 +766,10 @@ public:
                  */
                 if (s->exp->op == TOKstructliteral)
                 {
-                    StructLiteralExp *se = (StructLiteralExp *)s->exp;
-                    se->sym = irs->shidden;
-                    se->fillHoles = true;
-                    e = toElemDtor(s->exp, irs);
+                    StructLiteralExp *sle = (StructLiteralExp *)s->exp;
+                    sle->sym = irs->shidden;
                 }
-                else
-                    e = toElemDtor(s->exp, irs);
+                e = toElemDtor(s->exp, irs);
                 assert(e);
 
                 if (s->exp->op == TOKstructliteral ||

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -4367,6 +4367,32 @@ void test63()
 }
 
 /**********************************/
+
+struct X64
+{
+    static int dtor;
+
+    ~this() { ++dtor; }
+}
+
+struct S64
+{
+    int n;
+    long[10] dummy;     // S64 needs to be passed by stack
+}
+
+S64 foo64()
+{
+    return S64((X64(), 1));
+}
+
+void test64()
+{
+    auto s = foo64();
+    assert(X64.dtor == 1);
+}
+
+/**********************************/
 // 15661
 
 struct X15661
@@ -4533,6 +4559,7 @@ int main()
     test14696();
     test14838();
     test63();
+    test64();
     test15661();
 
     printf("Success\n");


### PR DESCRIPTION
Separated from #5574

Unfortunately we cannot remove StructLiteralExp.sym, because it's yet used for compile-time struct/class instances placed at dataseg.
