### PR TITLE
Fix too long one line imports

### DIFF
--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -8,8 +8,25 @@
 
 module ddmd.libmscoff;
 
-import core.stdc.stdlib, core.stdc.string, core.sys.windows.windows, core.sys.windows.stat, core.stdc.time, core.stdc.stdio, core.stdc.stdarg, core.stdc.string;
-import ddmd.globals, ddmd.lib, ddmd.mars, ddmd.root.array, ddmd.root.file, ddmd.root.filename, ddmd.root.outbuffer, ddmd.root.port, ddmd.root.stringtable, ddmd.scanmscoff, ddmd.errors;
+import core.stdc.stdlib;
+import core.stdc.string;
+import core.sys.windows.windows;
+import core.sys.windows.stat;
+import core.stdc.time;
+import core.stdc.stdio;
+import core.stdc.stdarg;
+import core.stdc.string;
+import ddmd.globals;
+import ddmd.lib;
+import ddmd.mars;
+import ddmd.root.array;
+import ddmd.root.file;
+import ddmd.root.filename;
+import ddmd.root.outbuffer;
+import ddmd.root.port;
+import ddmd.root.stringtable;
+import ddmd.scanmscoff;
+import ddmd.errors;
 
 enum LOG = false;
 

--- a/src/root/aav.d
+++ b/src/root/aav.d
@@ -8,7 +8,8 @@
 
 module ddmd.root.aav;
 
-import core.stdc.stdlib, core.stdc.string;
+import core.stdc.stdlib;
+import core.stdc.string;
 import ddmd.root.rmem;
 
 extern (C++) size_t hash(size_t a)

--- a/src/root/file.d
+++ b/src/root/file.d
@@ -8,8 +8,18 @@
 
 module ddmd.root.file;
 
-import core.stdc.errno, core.stdc.stdio, core.stdc.stdlib, core.stdc.string, core.sys.posix.fcntl, core.sys.posix.sys.types, core.sys.posix.unistd, core.sys.posix.utime, core.sys.windows.windows;
-import ddmd.root.array, ddmd.root.filename, ddmd.root.rmem;
+import core.stdc.errno;
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.stdc.string;
+import core.sys.posix.fcntl;
+import core.sys.posix.sys.types;
+import core.sys.posix.unistd;
+import core.sys.posix.utime;
+import core.sys.windows.windows;
+import ddmd.root.array;
+import ddmd.root.filename;
+import ddmd.root.rmem;
 
 version (Windows) alias WIN32_FIND_DATAA = WIN32_FIND_DATA;
 

--- a/src/root/filename.d
+++ b/src/root/filename.d
@@ -8,8 +8,18 @@
 
 module ddmd.root.filename;
 
-import core.stdc.ctype, core.stdc.errno, core.stdc.stdlib, core.stdc.string, core.sys.posix.stdlib, core.sys.posix.sys.stat, core.sys.windows.windows;
-import ddmd.root.array, ddmd.root.file, ddmd.root.outbuffer, ddmd.root.rmem, ddmd.root.rootobject;
+import core.stdc.ctype;
+import core.stdc.errno;
+import core.stdc.stdlib;
+import core.stdc.string;
+import core.sys.posix.stdlib;
+import core.sys.posix.sys.stat;
+import core.sys.windows.windows;
+import ddmd.root.array;
+import ddmd.root.file;
+import ddmd.root.outbuffer;
+import ddmd.root.rmem;
+import ddmd.root.rootobject;
 
 version (Windows) extern (C) int mkdir(const char*);
 version (Windows) alias _mkdir = mkdir;

--- a/src/root/outbuffer.d
+++ b/src/root/outbuffer.d
@@ -8,8 +8,11 @@
 
 module ddmd.root.outbuffer;
 
-import core.stdc.stdarg, core.stdc.stdio, core.stdc.string;
-import ddmd.root.rmem, ddmd.root.rootobject;
+import core.stdc.stdarg;
+import core.stdc.stdio;
+import core.stdc.string;
+import ddmd.root.rmem;
+import ddmd.root.rootobject;
 
 struct OutBuffer
 {

--- a/src/root/response.d
+++ b/src/root/response.d
@@ -20,8 +20,11 @@
 
 module ddmd.root.response;
 
-import core.stdc.stdio, core.stdc.stdlib, core.stdc.string;
-import ddmd.root.file, ddmd.root.filename;
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.stdc.string;
+import ddmd.root.file;
+import ddmd.root.filename;
 
 /*********************************
  * #include <stdlib.h>

--- a/src/root/speller.d
+++ b/src/root/speller.d
@@ -8,7 +8,9 @@
 
 module ddmd.root.speller;
 
-import core.stdc.limits, core.stdc.stdlib, core.stdc.string;
+import core.stdc.limits;
+import core.stdc.stdlib;
+import core.stdc.string;
 
 alias dg_speller_t = void* delegate(const(char)*, ref int);
 


### PR DESCRIPTION
Broken style was introduced by ddmd conversion.

Ping: @yebblies 
