### PR TITLE
add DtBuilder struct

### DIFF
--- a/src/backend/dt.h
+++ b/src/backend/dt.h
@@ -32,5 +32,89 @@ bool dtallzeros(const dt_t *dt);
 bool dtpointers(const dt_t *dt);
 void dt2common(dt_t **pdt);
 
+struct DtBuilder
+{
+  private:
+
+    dt_t *head;
+    dt_t **pTail;
+
+  public:
+
+    DtBuilder()
+    {
+        head = NULL;
+        pTail = &head;
+    }
+
+    /*************************
+     * Finish and return completed data structure.
+     */
+    dt_t *finish()
+    {
+        return head;
+    }
+
+    void nbytes(unsigned size, const char *ptr)
+    {
+        pTail = dtnbytes(pTail, size, ptr);
+    }
+
+    void abytes(tym_t ty, unsigned offset, unsigned size, const char *ptr, unsigned nzeros)
+    {
+        pTail = dtabytes(pTail, ty, offset, size, ptr, nzeros);
+    }
+
+    void abytes(unsigned offset, unsigned size, const char *ptr, unsigned nzeros)
+    {
+        pTail = dtabytes(pTail, offset, size, ptr, nzeros);
+    }
+
+    void dword(int value)
+    {
+        pTail = dtdword(pTail, value);
+    }
+
+    void size(unsigned long long value)
+    {
+        pTail = dtsize_t(pTail, value);
+    }
+
+    void nzeros(unsigned size)
+    {
+        pTail = dtnzeros(pTail, size);
+    }
+
+    void xoff(Symbol *s, unsigned offset, tym_t ty)
+    {
+        pTail = dtxoff(pTail, s, offset, ty);
+    }
+
+    void xoff(Symbol *s, unsigned offset)
+    {
+        pTail = dtxoff(pTail, s, offset);
+    }
+
+    void dtoff(dt_t *dt, unsigned offset)
+    {
+        pTail = dtdtoff(pTail, dt, offset);
+    }
+
+    void coff(unsigned offset)
+    {
+        pTail = dtcoff(pTail, offset);
+    }
+
+    void cat(dt_t *dt)
+    {
+        pTail = dtcat(pTail, dt);
+    }
+
+    void repeat(dt_t *dt, size_t count)
+    {
+        pTail = dtrepeat(pTail, dt, count);
+    }
+};
+
 #endif /* DT_H */
 

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -5646,9 +5646,12 @@ Symbol *toStringSymbol(const char *str, size_t len, size_t sz)
     {
         Symbol *si = symbol_generate(SCstatic,type_static_array(len * sz, tschar));
         si->Salignment = 1;
-        si->Sdt = NULL;
-        dt_t **pdt = dtnbytes(&si->Sdt, len * sz, str);
-        dtnzeros(pdt, sz);
+
+        DtBuilder dtb;
+        dtb.nbytes(len * sz, str);
+        dtb.nzeros(sz);
+        si->Sdt = dtb.finish();
+
         si->Sfl = FLdata;
         out_readonly(si);
         outdata(si);

--- a/src/s2ir.c
+++ b/src/s2ir.c
@@ -547,10 +547,10 @@ public:
             /* Create a sorted array of the case strings, and si
              * will be the symbol for it.
              */
-            dt_t *dt = NULL;
             Symbol *si = symbol_generate(SCstatic,type_fake(TYdarray));
-            dtsize_t(&dt, numcases);
-            dtxoff(&dt, si, Target::ptrsize * 2, TYnptr);
+            DtBuilder dtb;
+            dtb.size(numcases);
+            dtb.xoff(si, Target::ptrsize * 2, TYnptr);
 
             for (size_t i = 0; i < numcases; i++)
             {   CaseStatement *cs = (*s->cases)[i];
@@ -562,12 +562,12 @@ public:
                 {
                     StringExp *se = (StringExp *)(cs->exp);
                     Symbol *si = toStringSymbol(se);
-                    dtsize_t(&dt, se->numberOfCodeUnits());
-                    dtxoff(&dt, si, 0);
+                    dtb.size(se->numberOfCodeUnits());
+                    dtb.xoff(si, 0);
                 }
             }
 
-            si->Sdt = dt;
+            si->Sdt = dtb.finish();
             si->Sfl = FLdata;
             outdata(si);
 


### PR DESCRIPTION
The `dt_t` struct is supposed to encapsulate creating data, but it only does so partially. It still leaks the fact that it is a linked list. `DtBuilder` aims to encapsulate it more fully, so that the data structure can be changed.
