### PR TITLE
Remove unnecessary class BoolExp

### DIFF
--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -3053,9 +3053,6 @@ public:
         case TOKnot:
             ue = Not(e.type, e1);
             break;
-        case TOKtobool:
-            ue = Bool(e.type, e1);
-            break;
         case TOKvector:
             result = e;
             return; // do nothing

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -3745,12 +3745,6 @@ elem *toElem(Expression *e, IRState *irs)
             result = e;
         }
 
-        void visit(BoolExp *e)
-        {
-            elem *e1 = toElem(e->e1, irs);
-            result = el_una(OPbool, totym(e->type), e1);
-        }
-
         void visit(DeleteExp *de)
         {
             Type *tb;

--- a/src/expression.d
+++ b/src/expression.d
@@ -10523,38 +10523,6 @@ public:
 
 /***********************************************************
  */
-extern (C++) final class BoolExp : UnaExp
-{
-public:
-    extern (D) this(Loc loc, Expression e, Type t)
-    {
-        super(loc, TOKtobool, __traits(classInstanceSize, BoolExp), e);
-        type = t;
-    }
-
-    override Expression semantic(Scope* sc)
-    {
-        if (type)
-            return this;
-        // Note there is no operator overload
-        if (Expression ex = unaSemantic(sc))
-            return ex;
-        e1 = resolveProperties(sc, e1);
-        e1 = e1.toBoolean(sc);
-        if (e1.type == Type.terror)
-            return e1;
-        type = Type.tbool;
-        return this;
-    }
-
-    override void accept(Visitor v)
-    {
-        v.visit(this);
-    }
-}
-
-/***********************************************************
- */
 extern (C++) final class DeleteExp : UnaExp
 {
 public:

--- a/src/expression.h
+++ b/src/expression.h
@@ -980,14 +980,6 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-class BoolExp : public UnaExp
-{
-public:
-    BoolExp(Loc loc, Expression *e, Type *type);
-    Expression *semantic(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
-};
-
 class DeleteExp : public UnaExp
 {
 public:

--- a/src/optimize.d
+++ b/src/optimize.d
@@ -317,16 +317,6 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             }
         }
 
-        override void visit(BoolExp e)
-        {
-            if (unaOptimize(e, result))
-                return;
-            if (e.e1.isConst() == 1)
-            {
-                ret = Bool(e.type, e.e1).copy();
-            }
-        }
-
         override void visit(SymOffExp e)
         {
             assert(e.var);
@@ -1040,7 +1030,10 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                     if (e.type.toBasetype().ty == Tvoid)
                         ret = e.e2;
                     else
-                        ret = new BoolExp(e.loc, e.e2, e.type);
+                    {
+                        ret = new CastExp(e.loc, e.e2, e.type);
+                        ret.type = e.type;
+                    }
                 }
             }
         }
@@ -1078,7 +1071,10 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                     if (e.type.toBasetype().ty == Tvoid)
                         ret = e.e2;
                     else
-                        ret = new BoolExp(e.loc, e.e2, e.type);
+                    {
+                        ret = new CastExp(e.loc, e.e2, e.type);
+                        ret.type = e.type;
+                    }
                 }
             }
         }

--- a/src/parse.d
+++ b/src/parse.d
@@ -127,7 +127,6 @@ __gshared PREC[TOKMAX] precedence =
     TOKneg : PREC_unary,
     TOKuadd : PREC_unary,
     TOKnot : PREC_unary,
-    TOKtobool : PREC_add,
     TOKtilde : PREC_unary,
     TOKdelete : PREC_unary,
     TOKnew : PREC_unary,

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -90,9 +90,8 @@ enum TOK : int
     TOKnotidentity,
     TOKindex,
     TOKis,
-    TOKtobool,
 
-    // 65
+    // 64
     // NCEG floating point compares
     // !<>=     <>    <>=    !>     !>=   !<     !<=   !<>
     TOKunord,
@@ -104,7 +103,7 @@ enum TOK : int
     TOKug,
     TOKue,
 
-    // 73
+    // 72
     TOKshl,
     TOKshr,
     TOKshlass,
@@ -145,7 +144,7 @@ enum TOK : int
     TOKpreplusplus,
     TOKpreminusminus,
 
-    // 112
+    // 111
     // Numeric literals
     TOKint32v,
     TOKuns32v,
@@ -201,7 +200,7 @@ enum TOK : int
     TOKdchar,
     TOKbool,
 
-    // 159
+    // 158
     // Aggregates
     TOKstruct,
     TOKclass,
@@ -363,7 +362,6 @@ alias TOKidentity = TOK.TOKidentity;
 alias TOKnotidentity = TOK.TOKnotidentity;
 alias TOKindex = TOK.TOKindex;
 alias TOKis = TOK.TOKis;
-alias TOKtobool = TOK.TOKtobool;
 alias TOKunord = TOK.TOKunord;
 alias TOKlg = TOK.TOKlg;
 alias TOKleg = TOK.TOKleg;
@@ -606,7 +604,6 @@ extern (C++) struct Token
         TOKuge: "!<",
         TOKug: "!<=",
         TOKnot: "!",
-        TOKtobool: "!!",
         TOKshl: "<<",
         TOKshr: ">>",
         TOKushr: ">>>",

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -80,14 +80,13 @@ enum TOK
         TOKequal,       TOKnotequal,
         TOKidentity,    TOKnotidentity,
         TOKindex,       TOKis,
-        TOKtobool,
 
-// 65
+// 64
         // NCEG floating point compares
         // !<>=     <>    <>=    !>     !>=   !<     !<=   !<>
         TOKunord,TOKlg,TOKleg,TOKule,TOKul,TOKuge,TOKug,TOKue,
 
-// 73
+// 72
         TOKshl,         TOKshr,
         TOKshlass,      TOKshrass,
         TOKushr,        TOKushrass,
@@ -103,7 +102,7 @@ enum TOK
         TOKquestion,    TOKandand,      TOKoror,
         TOKpreplusplus, TOKpreminusminus,
 
-// 112
+// 111
         // Numeric literals
         TOKint32v, TOKuns32v,
         TOKint64v, TOKuns64v,
@@ -132,7 +131,7 @@ enum TOK
         TOKcomplex32, TOKcomplex64, TOKcomplex80,
         TOKchar, TOKwchar, TOKdchar, TOKbool,
 
-// 159
+// 158
         // Aggregates
         TOKstruct, TOKclass, TOKinterface, TOKunion, TOKenum, TOKimport,
         TOKalias, TOKoverride, TOKdelegate, TOKfunction,

--- a/src/visitor.d
+++ b/src/visitor.d
@@ -1008,11 +1008,6 @@ public:
         visit(cast(UnaExp)e);
     }
 
-    void visit(BoolExp e)
-    {
-        visit(cast(UnaExp)e);
-    }
-
     void visit(DeleteExp e)
     {
         visit(cast(UnaExp)e);

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -219,7 +219,6 @@ class NegExp;
 class UAddExp;
 class ComExp;
 class NotExp;
-class BoolExp;
 class DeleteExp;
 class CastExp;
 class VectorExp;
@@ -505,7 +504,6 @@ public:
     virtual void visit(UAddExp *e) { visit((UnaExp *)e); }
     virtual void visit(ComExp *e) { visit((UnaExp *)e); }
     virtual void visit(NotExp *e) { visit((UnaExp *)e); }
-    virtual void visit(BoolExp *e) { visit((UnaExp *)e); }
     virtual void visit(DeleteExp *e) { visit((UnaExp *)e); }
     virtual void visit(CastExp *e) { visit((UnaExp *)e); }
     virtual void visit(VectorExp *e) { visit((UnaExp *)e); }


### PR DESCRIPTION
Different from PR #2998, the existing uses in `optimize.d` are replaced with `CastExp`.
