### PR TITLE
Add warning categories

### DIFF
--- a/src/doc.d
+++ b/src/doc.d
@@ -43,6 +43,7 @@ import ddmd.root.rmem;
 import ddmd.tokens;
 import ddmd.utf;
 import ddmd.visitor;
+import ddmd.warnings;
 
 struct Escape
 {

--- a/src/doc.d
+++ b/src/doc.d
@@ -240,7 +240,7 @@ public:
                             }
                             else if (!fparam)
                             {
-                                warning(s.loc, "Ddoc: function declaration has no parameter '%.*s'", namelen, namestart);
+                                warning(s.loc, WarnCat.ddoc, "Ddoc: function declaration has no parameter '%.*s'", namelen, namestart);
                             }
                             buf.write(namestart, namelen);
                         }
@@ -290,7 +290,7 @@ public:
             size_t pcount = (tf.parameters ? tf.parameters.dim : 0) + cast(int)(tf.varargs == 1);
             if (pcount != paramcount)
             {
-                warning(s.loc, "Ddoc: parameter count mismatch");
+                warning(s.loc, WarnCat.ddoc, "Ddoc: parameter count mismatch");
             }
         }
     }
@@ -674,7 +674,7 @@ extern (C++) void escapeStrayParenthesis(Loc loc, OutBuffer* buf, size_t start)
                 if (par_open == 0)
                 {
                     //stray ')'
-                    warning(loc, "Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.");
+                    warning(loc, WarnCat.ddoc, "Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.");
                     buf.remove(u, 1); //remove the )
                     buf.insert(u, cast(const(char)*)"$(RPAREN)", 9); //insert this instead
                     u += 8; //skip over newly inserted macro
@@ -724,7 +724,7 @@ extern (C++) void escapeStrayParenthesis(Loc loc, OutBuffer* buf, size_t start)
                 if (par_open == 0)
                 {
                     //stray '('
-                    warning(loc, "Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.");
+                    warning(loc, WarnCat.ddoc, "Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.");
                     buf.remove(u, 1); //remove the (
                     buf.insert(u, cast(const(char)*)"$(LPAREN)", 9); //insert this instead
                 }

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -31,6 +31,7 @@ import ddmd.root.rmem;
 import ddmd.root.speller;
 import ddmd.root.stringtable;
 import ddmd.statement;
+import ddmd.warnings;
 
 //version=LOGSEARCH;
 

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -499,7 +499,7 @@ struct Scope
                         ident == Id.length && sc.scopesym.isArrayScopeSymbol() &&
                         sc.enclosing && sc.enclosing.search(loc, ident, null, flags))
                     {
-                        warning(s.loc, "array 'length' hides other 'length' name in outer scope");
+                        warning(s.loc, WarnCat.uncat, "array 'length' hides other 'length' name in outer scope");
                     }
                     //printMsg("\tfound local", s);
                     if (pscopesym)

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -499,7 +499,7 @@ struct Scope
                         ident == Id.length && sc.scopesym.isArrayScopeSymbol() &&
                         sc.enclosing && sc.enclosing.search(loc, ident, null, flags))
                     {
-                        warning(s.loc, WarnCat.uncat, "array 'length' hides other 'length' name in outer scope");
+                        warning(s.loc, WarnCat.hiding, "array 'length' hides other 'length' name in outer scope");
                     }
                     //printMsg("\tfound local", s);
                     if (pscopesym)

--- a/src/errors.d
+++ b/src/errors.d
@@ -152,22 +152,6 @@ extern (C++) void errorSupplemental(Loc loc, const(char)* format, ...)
     va_end(ap);
 }
 
-extern (C++) void warning(Loc loc, const(char)* format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    vwarning(loc, format, ap);
-    va_end(ap);
-}
-
-extern (C++) void warningSupplemental(Loc loc, const(char)* format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    vwarningSupplemental(loc, format, ap);
-    va_end(ap);
-}
-
 extern (C++) void deprecation(Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -231,23 +215,6 @@ extern (C++) void verrorSupplemental(Loc loc, const(char)* format, va_list ap)
 {
     if (!global.gag)
         verrorPrint(loc, COLOR_RED, "       ", format, ap);
-}
-
-extern (C++) void vwarning(Loc loc, const(char)* format, va_list ap)
-{
-    if (global.params.warnings && !global.gag)
-    {
-        verrorPrint(loc, COLOR_YELLOW, "Warning: ", format, ap);
-        //halt();
-        if (global.params.warnings == 1)
-            global.warnings++; // warnings don't count if gagged
-    }
-}
-
-extern (C++) void vwarningSupplemental(Loc loc, const(char)* format, va_list ap)
-{
-    if (global.params.warnings && !global.gag)
-        verrorPrint(loc, COLOR_YELLOW, "       ", format, ap);
 }
 
 extern (C++) void vdeprecation(Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null)

--- a/src/errors.h
+++ b/src/errors.h
@@ -20,16 +20,12 @@
 
 bool isConsoleColorSupported();
 
-void warning(Loc loc, const char *format, ...);
-void warningSupplemental(Loc loc, const char *format, ...);
 void deprecation(Loc loc, const char *format, ...);
 void deprecationSupplemental(Loc loc, const char *format, ...);
 void error(Loc loc, const char *format, ...);
 void errorSupplemental(Loc loc, const char *format, ...);
 void verror(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
 void verrorSupplemental(Loc loc, const char *format, va_list ap);
-void vwarning(Loc loc, const char *format, va_list);
-void vwarningSupplemental(Loc loc, const char *format, va_list ap);
 void vdeprecation(Loc loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
 void vdeprecationSupplemental(Loc loc, const char *format, va_list ap);
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -70,6 +70,7 @@ import ddmd.traits;
 import ddmd.typinf;
 import ddmd.utf;
 import ddmd.visitor;
+import ddmd.warnings;
 
 enum LOGSEMANTIC = false;
 void emplaceExp(T : Expression, Args...)(void* p, Args args)

--- a/src/expression.d
+++ b/src/expression.d
@@ -2476,13 +2476,13 @@ public:
         }
     }
 
-    final void warning(const(char)* format, ...) const
+    final void warning(const WarningCategory cat, const(char)* format, ...) const
     {
         if (type != Type.terror)
         {
             va_list ap;
             va_start(ap, format);
-            .vwarning(loc, format, ap);
+            .vwarning(loc, cat, format, ap);
             va_end(ap);
         }
     }
@@ -7599,7 +7599,7 @@ public:
         {
             if ((type.isintegral() && t2.isfloating()))
             {
-                warning("%s %s %s is performing truncating conversion", type.toChars(), Token.toChars(op), t2.toChars());
+                warning(WarnCat.uncat, "%s %s %s is performing truncating conversion", type.toChars(), Token.toChars(op), t2.toChars());
             }
         }
         // generate an error if this is a nonsensical *=,/=, or %=, eg real *= imaginary
@@ -12853,7 +12853,7 @@ public:
             {
                 const(char)* e1str = e1.toChars();
                 const(char)* e2str = e2x.toChars();
-                warning("explicit element-wise assignment %s = (%s)[] is better than %s = %s", e1str, e2str, e1str, e2str);
+                warning(WarnCat.uncat, "explicit element-wise assignment %s = (%s)[] is better than %s = %s", e1str, e2str, e1str, e2str);
             }
 
             Type t2n = t2.nextOf();
@@ -12906,7 +12906,7 @@ public:
                 const(char)* e1str = e1.toChars();
                 const(char)* e2str = e2x.toChars();
                 const(char)* atypestr = e1.op == TOKslice ? "element-wise" : "slice";
-                warning("explicit %s assignment %s = (%s)[] is better than %s = %s", atypestr, e1str, e2str, e1str, e2str);
+                warning(WarnCat.uncat, "explicit %s assignment %s = (%s)[] is better than %s = %s", atypestr, e1str, e2str, e1str, e2str);
             }
             if (op == TOKblit)
                 e2x = e2x.castTo(sc, e1.type);

--- a/src/expression.d
+++ b/src/expression.d
@@ -7599,7 +7599,7 @@ public:
         {
             if ((type.isintegral() && t2.isfloating()))
             {
-                warning(WarnCat.uncat, "%s %s %s is performing truncating conversion", type.toChars(), Token.toChars(op), t2.toChars());
+                warning(WarnCat.conversion, "%s %s %s is performing truncating conversion", type.toChars(), Token.toChars(op), t2.toChars());
             }
         }
         // generate an error if this is a nonsensical *=,/=, or %=, eg real *= imaginary
@@ -12853,7 +12853,7 @@ public:
             {
                 const(char)* e1str = e1.toChars();
                 const(char)* e2str = e2x.toChars();
-                warning(WarnCat.uncat, "explicit element-wise assignment %s = (%s)[] is better than %s = %s", e1str, e2str, e1str, e2str);
+                warning(WarnCat.advice, "explicit element-wise assignment %s = (%s)[] is better than %s = %s", e1str, e2str, e1str, e2str);
             }
 
             Type t2n = t2.nextOf();
@@ -12906,7 +12906,7 @@ public:
                 const(char)* e1str = e1.toChars();
                 const(char)* e2str = e2x.toChars();
                 const(char)* atypestr = e1.op == TOKslice ? "element-wise" : "slice";
-                warning(WarnCat.uncat, "explicit %s assignment %s = (%s)[] is better than %s = %s", atypestr, e1str, e2str, e1str, e2str);
+                warning(WarnCat.advice, "explicit %s assignment %s = (%s)[] is better than %s = %s", atypestr, e1str, e2str, e1str, e2str);
             }
             if (op == TOKblit)
                 e2x = e2x.castTo(sc, e1.type);

--- a/src/expression.h
+++ b/src/expression.h
@@ -142,7 +142,7 @@ public:
     char *toChars();
     virtual void printAST(int ident = 0);
     void error(const char *format, ...) const;
-    void warning(const char *format, ...) const;
+    void warning(const WarningCategory cat, const char *format, ...) const;
     void deprecation(const char *format, ...) const;
 
     // creates a single expression which is effectively (e1, e2)

--- a/src/func.d
+++ b/src/func.d
@@ -1077,7 +1077,7 @@ public:
                          * an interface function?
                          */
                         //if (!isOverride())
-                        //    warning(loc, "overrides base class function %s, but is not marked with 'override'", fdv->toPrettyChars());
+                        //    warning(loc, WarnCat.override, "overrides base class function %s, but is not marked with 'override'", fdv.toPrettyChars());
                         if (fdv.tintro)
                             ti = fdv.tintro;
                         else if (!type.equals(fdv.type))

--- a/src/globals.d
+++ b/src/globals.d
@@ -440,5 +440,6 @@ alias PINLINEnever = PINLINE.never;
 alias PINLINEalways = PINLINE.always;
 
 alias StorageClass = uinteger_t;
+alias WarningCategory = uinteger_t;
 
 extern (C++) __gshared Global global;

--- a/src/globals.d
+++ b/src/globals.d
@@ -49,6 +49,8 @@ alias BOUNDSCHECKoff = BOUNDSCHECK.BOUNDSCHECKoff;
 alias BOUNDSCHECKon = BOUNDSCHECK.BOUNDSCHECKon;
 alias BOUNDSCHECKsafeonly = BOUNDSCHECK.BOUNDSCHECKsafeonly;
 
+alias WarningCategory = uint;
+
 // Put command line switches in here
 struct Param
 {
@@ -94,10 +96,14 @@ struct Param
     bool useDIP25;          // implement http://wiki.dlang.org/DIP25
     bool release;           // build release version
     bool preservePaths;     // true means don't strip path from source file
+
     // 0: disable warnings
     // 1: warnings as errors
     // 2: informational warnings (no errors)
     byte warnings;
+    // Flags which warning categories are enabled
+    WarningCategory enabledWarnings;
+
     bool pic;               // generate position-independent-code for shared libs
     bool color;             // use ANSI colors in console output
     bool cov;               // generate code coverage data
@@ -440,6 +446,5 @@ alias PINLINEnever = PINLINE.never;
 alias PINLINEalways = PINLINE.always;
 
 alias StorageClass = uinteger_t;
-alias WarningCategory = uinteger_t;
 
 extern (C++) __gshared Global global;

--- a/src/globals.h
+++ b/src/globals.h
@@ -311,5 +311,6 @@ enum PINLINE
 };
 
 typedef uinteger_t StorageClass;
+typedef uinteger_t WarningCategory;
 
 #endif /* DMD_GLOBALS_H */

--- a/src/globals.h
+++ b/src/globals.h
@@ -32,6 +32,7 @@ enum BOUNDSCHECK
     BOUNDSCHECKsafeonly // do bounds checking only in @safe functions
 };
 
+typedef uint32_t WarningCategory;
 
 // Put command line switches in here
 struct Param
@@ -78,10 +79,14 @@ struct Param
     bool useDIP25;      // implement http://wiki.dlang.org/DIP25
     bool release;       // build release version
     bool preservePaths; // true means don't strip path from source file
+
     // 0: disable warnings
     // 1: warnings as errors
     // 2: informational warnings (no errors)
     char warnings;
+    // Flags which warning categories are enabled
+    WarningCategory enabledWarnings;
+
     bool pic;           // generate position-independent-code for shared libs
     bool color;         // use ANSI colors in console output
     bool cov;           // generate code coverage data
@@ -311,6 +316,5 @@ enum PINLINE
 };
 
 typedef uinteger_t StorageClass;
-typedef uinteger_t WarningCategory;
 
 #endif /* DMD_GLOBALS_H */

--- a/src/mars.d
+++ b/src/mars.d
@@ -1503,8 +1503,8 @@ Language changes listed by -transition=id:
             inlineScanModule(m);
         }
     }
-    // Do not attempt to generate output files if errors or warnings occurred
-    if (global.errors || global.warnings)
+    // Do not attempt to generate output files if errors occurred
+    if (global.errors)
         fatal();
     // inlineScan incrementally run semantic3 of each expanded functions.
     // So deps file generation should be moved after the inlinig stage.

--- a/src/mars.h
+++ b/src/mars.h
@@ -82,6 +82,7 @@ struct OutBuffer;
 #include "complex_t.h"
 
 #include "errors.h"
+#include "warnings.h"
 
 class Dsymbol;
 class Library;

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -4323,7 +4323,7 @@ public:
         {
             static __gshared const(char)** reverseName = ["_adReverseChar", "_adReverseWchar"];
             static __gshared FuncDeclaration* reverseFd = [null, null];
-            warning(e.loc, WarnCat.advice, "use std.algorithm.reverse instead of .reverse property");
+            warning(e.loc, WarnCat.soonDeprecated, "use std.algorithm.reverse instead of .reverse property");
             int i = n.ty == Twchar;
             if (!reverseFd[i])
             {
@@ -4344,7 +4344,7 @@ public:
         {
             static __gshared const(char)** sortName = ["_adSortChar", "_adSortWchar"];
             static __gshared FuncDeclaration* sortFd = [null, null];
-            warning(e.loc, WarnCat.advice, "use std.algorithm.sort instead of .sort property");
+            warning(e.loc, WarnCat.soonDeprecated, "use std.algorithm.sort instead of .sort property");
             int i = n.ty == Twchar;
             if (!sortFd[i])
             {
@@ -4367,7 +4367,7 @@ public:
             FuncDeclaration fd;
             Expressions* arguments;
             dinteger_t size = next.size(e.loc);
-            warning(e.loc, WarnCat.advice, "use std.algorithm.reverse instead of .reverse property");
+            warning(e.loc, WarnCat.soonDeprecated, "use std.algorithm.reverse instead of .reverse property");
             assert(size);
             static __gshared FuncDeclaration adReverse_fd = null;
             if (!adReverse_fd)
@@ -4391,7 +4391,7 @@ public:
             static __gshared FuncDeclaration fd = null;
             Expression ec;
             Expressions* arguments;
-            warning(e.loc, WarnCat.advice, "use std.algorithm.sort instead of .sort property");
+            warning(e.loc, WarnCat.soonDeprecated, "use std.algorithm.sort instead of .sort property");
             if (!fd)
             {
                 auto params = new Parameters();

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -57,6 +57,7 @@ import ddmd.sideeffect;
 import ddmd.target;
 import ddmd.tokens;
 import ddmd.visitor;
+import ddmd.warnings;
 
 enum LOGDOTEXP = 0;         // log ::dotExp()
 enum LOGDEFAULTINIT = 0;    // log ::defaultInit()

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2911,11 +2911,11 @@ public:
         va_end(ap);
     }
 
-    final static void warning(Loc loc, const(char)* format, ...)
+    final static void warning(Loc loc, const WarningCategory cat, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
-        .vwarning(loc, format, ap);
+        .vwarning(loc, cat, format, ap);
         va_end(ap);
     }
 
@@ -4323,7 +4323,7 @@ public:
         {
             static __gshared const(char)** reverseName = ["_adReverseChar", "_adReverseWchar"];
             static __gshared FuncDeclaration* reverseFd = [null, null];
-            warning(e.loc, "use std.algorithm.reverse instead of .reverse property");
+            warning(e.loc, WarnCat.advice, "use std.algorithm.reverse instead of .reverse property");
             int i = n.ty == Twchar;
             if (!reverseFd[i])
             {
@@ -4344,7 +4344,7 @@ public:
         {
             static __gshared const(char)** sortName = ["_adSortChar", "_adSortWchar"];
             static __gshared FuncDeclaration* sortFd = [null, null];
-            warning(e.loc, "use std.algorithm.sort instead of .sort property");
+            warning(e.loc, WarnCat.advice, "use std.algorithm.sort instead of .sort property");
             int i = n.ty == Twchar;
             if (!sortFd[i])
             {
@@ -4367,7 +4367,7 @@ public:
             FuncDeclaration fd;
             Expressions* arguments;
             dinteger_t size = next.size(e.loc);
-            warning(e.loc, "use std.algorithm.reverse instead of .reverse property");
+            warning(e.loc, WarnCat.advice, "use std.algorithm.reverse instead of .reverse property");
             assert(size);
             static __gshared FuncDeclaration adReverse_fd = null;
             if (!adReverse_fd)
@@ -4391,7 +4391,7 @@ public:
             static __gshared FuncDeclaration fd = null;
             Expression ec;
             Expressions* arguments;
-            warning(e.loc, "use std.algorithm.sort instead of .sort property");
+            warning(e.loc, WarnCat.advice, "use std.algorithm.sort instead of .sort property");
             if (!fd)
             {
                 auto params = new Parameters();

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -342,7 +342,7 @@ public:
     void checkComplexTransition(Loc loc);
 
     static void error(Loc loc, const char *format, ...);
-    static void warning(Loc loc, const char *format, ...);
+    static void warning(Loc loc, const WarningCategory cat, const char *format, ...);
 
     // For eliminating dynamic_cast
     virtual TypeBasic *isTypeBasic();

--- a/src/parse.d
+++ b/src/parse.d
@@ -4403,7 +4403,7 @@ public:
     {
         if (token.value != TOKelse && token.value != TOKcatch && token.value != TOKfinally && lookingForElse.linnum != 0)
         {
-            warning(elseloc, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
+            warning(elseloc, WarnCat.uncat, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
         }
     }
 
@@ -4416,7 +4416,7 @@ public:
         if (alt & 1) // contains C-style function pointer syntax
             error(loc, "instead of C-style syntax, use D-style '%s%s%s'", t.toChars(), sp, s);
         else
-            .warning(loc, "instead of C-style syntax, use D-style syntax '%s%s%s'", t.toChars(), sp, s);
+            .warning(loc, WarnCat.uncat, "instead of C-style syntax, use D-style syntax '%s%s%s'", t.toChars(), sp, s);
     }
 
     /*****************************************
@@ -4728,7 +4728,7 @@ public:
             if (!(flags & PSsemi_ok))
             {
                 if (flags & PSsemi)
-                    warning(loc, "use '{ }' for an empty statement, not a ';'");
+                    warning(loc, WarnCat.uncat, "use '{ }' for an empty statement, not a ';'");
                 else
                     error("use '{ }' for an empty statement, not a ';'");
             }

--- a/src/parse.d
+++ b/src/parse.d
@@ -42,6 +42,7 @@ import ddmd.root.rootobject;
 import ddmd.statement;
 import ddmd.staticassert;
 import ddmd.tokens;
+import ddmd.warnings;
 
 // How multiple declarations are parsed.
 // If 1, treat as C.

--- a/src/parse.d
+++ b/src/parse.d
@@ -4403,7 +4403,7 @@ public:
     {
         if (token.value != TOKelse && token.value != TOKcatch && token.value != TOKfinally && lookingForElse.linnum != 0)
         {
-            warning(elseloc, WarnCat.uncat, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
+            warning(elseloc, WarnCat.braces, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
         }
     }
 
@@ -4416,7 +4416,7 @@ public:
         if (alt & 1) // contains C-style function pointer syntax
             error(loc, "instead of C-style syntax, use D-style '%s%s%s'", t.toChars(), sp, s);
         else
-            .warning(loc, WarnCat.uncat, "instead of C-style syntax, use D-style syntax '%s%s%s'", t.toChars(), sp, s);
+            .warning(loc, WarnCat.Cstyle, "instead of C-style syntax, use D-style syntax '%s%s%s'", t.toChars(), sp, s);
     }
 
     /*****************************************
@@ -4728,7 +4728,7 @@ public:
             if (!(flags & PSsemi_ok))
             {
                 if (flags & PSsemi)
-                    warning(loc, WarnCat.uncat, "use '{ }' for an empty statement, not a ';'");
+                    warning(loc, WarnCat.braces, "use '{ }' for an empty statement, not a ';'");
                 else
                     error("use '{ }' for an empty statement, not a ';'");
             }

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -205,7 +205,7 @@ FRONT_SRCS=$(addsuffix .d,access aggregate aliasthis apply argtypes arrayop	\
 	globals hdrgen id identifier impcnvtab imphint init inline intrange	\
 	json lexer lib link mars mtype nogc nspace opover optimize parse sapply	\
 	sideeffect statement staticassert target tokens traits utf visitor	\
-	typinf)
+	warnings typinf)
 
 ifeq ($(D_OBJC),1)
 	FRONT_SRCS += objc.d
@@ -261,7 +261,7 @@ SRC = win32.mak posix.mak osmodel.mak aggregate.h aliasthis.h arraytypes.h	\
 	import.h init.h intrange.h json.h lexer.h lib.h macro.h	\
 	mars.h module.h mtype.h nspace.h objc.h parse.h                         \
 	scope.h statement.h staticassert.h target.h template.h tokens.h	\
-	version.h visitor.h libomf.d scanomf.d libmscoff.d scanmscoff.d         \
+	version.h visitor.h warnings.h libomf.d scanomf.d libmscoff.d scanmscoff.d \
 	$(DMD_SRCS)
 
 ROOT_SRC = $(addprefix $(ROOT)/, array.h file.h filename.h		\

--- a/src/sideeffect.d
+++ b/src/sideeffect.d
@@ -266,7 +266,7 @@ extern (C++) void discardValue(Expression e)
                     }
                     else
                         s = ce.e1.toChars();
-                    e.warning(WarnCat.uncat, "calling %s without side effects discards return value of type %s, prepend a cast(void) if intentional", s, e.type.toChars());
+                    e.warning(WarnCat.unusedValue, "calling %s without side effects discards return value of type %s, prepend a cast(void) if intentional", s, e.type.toChars());
                 }
             }
         }

--- a/src/sideeffect.d
+++ b/src/sideeffect.d
@@ -16,6 +16,7 @@ import ddmd.globals;
 import ddmd.mtype;
 import ddmd.tokens;
 import ddmd.visitor;
+import ddmd.warnings;
 
 /**************************************************
  * Front-end expression rewriting should create temporary variables for
@@ -265,7 +266,7 @@ extern (C++) void discardValue(Expression e)
                     }
                     else
                         s = ce.e1.toChars();
-                    e.warning("calling %s without side effects discards return value of type %s, prepend a cast(void) if intentional", s, e.type.toChars());
+                    e.warning(WarnCat.uncat, "calling %s without side effects discards return value of type %s, prepend a cast(void) if intentional", s, e.type.toChars());
                 }
             }
         }

--- a/src/statement.d
+++ b/src/statement.d
@@ -54,6 +54,7 @@ import ddmd.staticassert;
 import ddmd.target;
 import ddmd.tokens;
 import ddmd.visitor;
+import ddmd.warnings;
 
 extern (C++) Identifier fixupLabelName(Scope* sc, Identifier ident)
 {

--- a/src/statement.d
+++ b/src/statement.d
@@ -169,11 +169,11 @@ public:
         va_end(ap);
     }
 
-    final void warning(const(char)* format, ...)
+    final void warning(const WarningCategory cat, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
-        .vwarning(loc, format, ap);
+        .vwarning(loc, cat, format, ap);
         va_end(ap);
     }
 
@@ -359,14 +359,14 @@ public:
                                 else
                                 {
                                     const(char)* gototype = s.isCaseStatement() ? "case" : "default";
-                                    s.warning("switch case fallthrough - use 'goto %s;' if intended", gototype);
+                                    s.warning(WarnCat.uncat, "switch case fallthrough - use 'goto %s;' if intended", gototype);
                                 }
                             }
                         }
                         if (!(result & BEfallthru) && !s.comeFrom())
                         {
                             if (s.blockExit(func, mustNotThrow) != BEhalt && s.hasCode())
-                                s.warning("statement is not reachable");
+                                s.warning(WarnCat.notreachable, "statement is not reachable");
                         }
                         else
                         {
@@ -673,7 +673,7 @@ public:
                     // destructor call, exit of synchronized statement, etc.
                     if (result == BEhalt && finalresult != BEhalt && s.finalbody && s.finalbody.hasCode())
                     {
-                        s.finalbody.warning("statement is not reachable");
+                        s.finalbody.warning(WarnCat.notreachable, "statement is not reachable");
                     }
                 }
                 if (!(finalresult & BEfallthru))
@@ -2543,7 +2543,7 @@ public:
             }
         case Taarray:
             if (op == TOKforeach_reverse)
-                warning("cannot use foreach_reverse with an associative array");
+                warning(WarnCat.uncat, "cannot use foreach_reverse with an associative array");
             if (checkForArgTypes())
                 return this;
 

--- a/src/statement.d
+++ b/src/statement.d
@@ -359,14 +359,14 @@ public:
                                 else
                                 {
                                     const(char)* gototype = s.isCaseStatement() ? "case" : "default";
-                                    s.warning(WarnCat.uncat, "switch case fallthrough - use 'goto %s;' if intended", gototype);
+                                    s.warning(WarnCat.fallthrough, "switch case fallthrough - use 'goto %s;' if intended", gototype);
                                 }
                             }
                         }
                         if (!(result & BEfallthru) && !s.comeFrom())
                         {
                             if (s.blockExit(func, mustNotThrow) != BEhalt && s.hasCode())
-                                s.warning(WarnCat.notreachable, "statement is not reachable");
+                                s.warning(WarnCat.notReachable, "statement is not reachable");
                         }
                         else
                         {
@@ -673,7 +673,7 @@ public:
                     // destructor call, exit of synchronized statement, etc.
                     if (result == BEhalt && finalresult != BEhalt && s.finalbody && s.finalbody.hasCode())
                     {
-                        s.finalbody.warning(WarnCat.notreachable, "statement is not reachable");
+                        s.finalbody.warning(WarnCat.notReachable, "statement is not reachable");
                     }
                 }
                 if (!(finalresult & BEfallthru))
@@ -2543,7 +2543,7 @@ public:
             }
         case Taarray:
             if (op == TOKforeach_reverse)
-                warning(WarnCat.uncat, "cannot use foreach_reverse with an associative array");
+                warning(WarnCat.soonDeprecated, "cannot use foreach_reverse with an associative array");
             if (checkForArgTypes())
                 return this;
 

--- a/src/statement.h
+++ b/src/statement.h
@@ -83,7 +83,7 @@ public:
     char *toChars();
 
     void error(const char *format, ...);
-    void warning(const char *format, ...);
+    void warning(const WarningCategory cat, const char *format, ...);
     void deprecation(const char *format, ...);
     virtual Statement *semantic(Scope *sc);
     Statement *semanticScope(Scope *sc, Statement *sbreak, Statement *scontinue);

--- a/src/todt.c
+++ b/src/todt.c
@@ -1291,7 +1291,7 @@ public:
              * So I'm leaving this here as an experiment for the moment.
              */
             if (!tf->isnothrow || tf->trust == TRUSTsystem /*|| tf->purity == PUREimpure*/)
-                warning(fd->loc, WarnCat::uncat, "toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not %s", tf->toChars());
+                warning(fd->loc, WarnCat::advice, "toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not %s", tf->toChars());
         }
         else
             pdt = dtsize_t(pdt, 0);

--- a/src/todt.c
+++ b/src/todt.c
@@ -1291,7 +1291,7 @@ public:
              * So I'm leaving this here as an experiment for the moment.
              */
             if (!tf->isnothrow || tf->trust == TRUSTsystem /*|| tf->purity == PUREimpure*/)
-                warning(fd->loc, "toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not %s", tf->toChars());
+                warning(fd->loc, WarnCat::uncat, "toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not %s", tf->toChars());
         }
         else
             pdt = dtsize_t(pdt, 0);

--- a/src/vcbuild/ddmd.visualdproj
+++ b/src/vcbuild/ddmd.visualdproj
@@ -530,6 +530,7 @@
    <File path="..\typinf.d" />
    <File path="..\utf.d" />
    <File path="..\visitor.d" />
+   <File path="..\warnings.d" />
    <File path="..\win32.mak" />
   </Folder>
  </Folder>

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -217,6 +217,7 @@ popd</Command>
     <ClInclude Include="..\toir.h" />
     <ClInclude Include="..\tokens.h" />
     <ClInclude Include="..\version.h" />
+    <ClInclude Include="..\warnings.h" />
     <ClInclude Include="..\backend\aa.h" />
     <ClInclude Include="..\backend\bcomplex.h" />
     <ClInclude Include="..\backend\cc.h" />

--- a/src/vcbuild/dmd_backend.vcxproj.filters
+++ b/src/vcbuild/dmd_backend.vcxproj.filters
@@ -335,6 +335,9 @@
     <ClInclude Include="..\version.h">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\warnings.h">
+      <Filter>src</Filter>
+    </ClInclude>
     <ClInclude Include="..\backend\aa.h">
       <Filter>src\backend</Filter>
     </ClInclude>

--- a/src/warnings.d
+++ b/src/warnings.d
@@ -1,0 +1,45 @@
+// Compiler implementation of the D programming language
+// Copyright (c) 1999-2015 by Digital Mars
+// All Rights Reserved
+// http://www.digitalmars.com
+// Distributed under the Boost Software License, Version 1.0.
+// http://www.boost.org/LICENSE_1_0.txt
+
+module ddmd.warnings;
+
+import core.stdc.stdarg;
+import ddmd.errors;
+import ddmd.globals;
+
+extern (C++) void warning(Loc loc, const(char)* format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vwarning(loc, format, ap);
+    va_end(ap);
+}
+
+extern (C++) void warningSupplemental(Loc loc, const(char)* format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vwarningSupplemental(loc, format, ap);
+    va_end(ap);
+}
+
+extern (C++) void vwarning(Loc loc, const(char)* format, va_list ap)
+{
+    if (global.params.warnings && !global.gag)
+    {
+        verrorPrint(loc, COLOR_YELLOW, "Warning: ", format, ap);
+        //halt();
+        if (global.params.warnings == 1)
+            global.warnings++; // warnings don't count if gagged
+    }
+}
+
+extern (C++) void vwarningSupplemental(Loc loc, const(char)* format, va_list ap)
+{
+    if (global.params.warnings && !global.gag)
+        verrorPrint(loc, COLOR_YELLOW, "       ", format, ap);
+}

--- a/src/warnings.d
+++ b/src/warnings.d
@@ -11,23 +11,38 @@ import core.stdc.stdarg;
 import ddmd.errors;
 import ddmd.globals;
 
-extern (C++) void warning(Loc loc, const(char)* format, ...)
+struct WarnCat
+{
+    alias Type = WarningCategory;
+
+    enum Type none = 0x0;
+    enum Type all  = ~none;
+
+    enum Type general      = (0x1L << 0);
+    enum Type advice       = (0x1L << 1);
+    enum Type ddoc         = (0x1L << 2);
+    enum Type notreachable = (0x1L << 3);
+
+    enum Type uncat = (0x1L << 13);  // temporary category for yet uncategorized warnings
+}
+
+extern (C++) void warning(Loc loc, const WarningCategory cat, const(char)* format, ...)
 {
     va_list ap;
     va_start(ap, format);
-    vwarning(loc, format, ap);
+    vwarning(loc, cat, format, ap);
     va_end(ap);
 }
 
-extern (C++) void warningSupplemental(Loc loc, const(char)* format, ...)
+extern (C++) void warningSupplemental(Loc loc, const WarningCategory cat, const(char)* format, ...)
 {
     va_list ap;
     va_start(ap, format);
-    vwarningSupplemental(loc, format, ap);
+    vwarningSupplemental(loc, cat, format, ap);
     va_end(ap);
 }
 
-extern (C++) void vwarning(Loc loc, const(char)* format, va_list ap)
+extern (C++) void vwarning(Loc loc, const WarningCategory cat, const(char)* format, va_list ap)
 {
     if (global.params.warnings && !global.gag)
     {
@@ -38,7 +53,7 @@ extern (C++) void vwarning(Loc loc, const(char)* format, va_list ap)
     }
 }
 
-extern (C++) void vwarningSupplemental(Loc loc, const(char)* format, va_list ap)
+extern (C++) void vwarningSupplemental(Loc loc, const WarningCategory cat, const(char)* format, va_list ap)
 {
     if (global.params.warnings && !global.gag)
         verrorPrint(loc, COLOR_YELLOW, "       ", format, ap);

--- a/src/warnings.d
+++ b/src/warnings.d
@@ -8,22 +8,71 @@
 module ddmd.warnings;
 
 import core.stdc.stdarg;
+import core.stdc.stdio;
+import core.stdc.string;
+
 import ddmd.errors;
 import ddmd.globals;
+import ddmd.root.outbuffer;
+import ddmd.root.rmem;
 
 struct WarnCat
 {
     alias Type = WarningCategory;
 
-    enum Type none = 0x0;
+    enum Type none = 0;
     enum Type all  = ~none;
 
-    enum Type general      = (0x1L << 0);
-    enum Type advice       = (0x1L << 1);
-    enum Type ddoc         = (0x1L << 2);
-    enum Type notreachable = (0x1L << 3);
+    enum Type general      = (1 << 0);
+    enum Type advice       = (1 << 1);
+    enum Type ddoc         = (1 << 2);
+    enum Type notreachable = (1 << 3);
 
-    enum Type uncat = (0x1L << 13);  // temporary category for yet uncategorized warnings
+    enum Type uncat = (1 << 13);  // temporary category for yet uncategorized warnings
+}
+
+const (char*)[] warningTable =
+[
+    "general",
+    "advice",
+    "ddoc",
+    "not-reachable",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "11",
+    "12",
+    "uncat",
+];
+
+
+// If cat is a combination of multiple categories, the lowest index category is chosen.
+const(char)* warnCatToString(const WarningCategory cat)
+{
+    if (!cat) return "";
+
+    import core.bitop : bsf;
+    size_t idx = bsf(cat);
+    assert(idx < warningTable.length);
+    return warningTable[idx];
+}
+
+// Linear search through known strings, returns WarnCat.none if none found
+WarningCategory warnStringToCat(const(char)* str)
+{
+    foreach(i, elem; warningTable)
+    {
+        if (strcmp(str, elem) == 0)
+        {
+            return 1 << i;
+        }
+    }
+
+    return WarnCat.none;
 }
 
 extern (C++) void warning(Loc loc, const WarningCategory cat, const(char)* format, ...)
@@ -44,9 +93,10 @@ extern (C++) void warningSupplemental(Loc loc, const WarningCategory cat, const(
 
 extern (C++) void vwarning(Loc loc, const WarningCategory cat, const(char)* format, va_list ap)
 {
-    if (global.params.warnings && !global.gag)
+    auto filtered_cat = cat & global.params.enabledWarnings;
+    if (filtered_cat && !global.gag)
     {
-        verrorPrint(loc, COLOR_YELLOW, "Warning: ", format, ap);
+        vwarningPrint(loc, COLOR_YELLOW, "Warning: ", format, ap, warnCatToString(filtered_cat));
         //halt();
         if (global.params.warnings == 1)
             global.warnings++; // warnings don't count if gagged
@@ -55,6 +105,46 @@ extern (C++) void vwarning(Loc loc, const WarningCategory cat, const(char)* form
 
 extern (C++) void vwarningSupplemental(Loc loc, const WarningCategory cat, const(char)* format, va_list ap)
 {
-    if (global.params.warnings && !global.gag)
-        verrorPrint(loc, COLOR_YELLOW, "       ", format, ap);
+    auto filtered_cat = cat & global.params.enabledWarnings;
+    if (filtered_cat && !global.gag)
+        vwarningPrint(loc, COLOR_YELLOW, "       ", format, ap);
+}
+
+// Just print, doesn't care about gagging
+extern (C++) void vwarningPrint(Loc loc, COLOR headerColor, const(char)* header, const(char)* format, va_list ap, const(char)* warncat = null)
+{
+    // Print location
+    const p = loc.toChars();
+    if (global.params.color)
+        setConsoleColorBright(true);
+    if (*p)
+        fprintf(stderr, "%s: ", p);
+    mem.xfree(cast(void*)p);
+
+    // Print header
+    if (global.params.color)
+        setConsoleColor(headerColor, true);
+    fputs(header, stderr);
+    if (global.params.color)
+        resetConsoleColor();
+
+    // Print user message
+    OutBuffer tmp;
+    tmp.vprintf(format, ap);
+    fprintf(stderr, "%s", tmp.peekString());
+
+    // Print warning category
+    if (warncat)
+    {
+        fprintf(stderr, " (");
+        if (global.params.color)
+            setConsoleColor(headerColor, true);
+        fprintf(stderr, "-W%s", warncat);
+        if (global.params.color)
+            resetConsoleColor();
+        fprintf(stderr, ")");
+    }
+
+    fprintf(stderr, "\n");
+    fflush(stderr);
 }

--- a/src/warnings.d
+++ b/src/warnings.d
@@ -23,12 +23,17 @@ struct WarnCat
     enum Type none = 0;
     enum Type all  = ~none;
 
-    enum Type general      = (1 << 0);
-    enum Type advice       = (1 << 1);
-    enum Type ddoc         = (1 << 2);
-    enum Type notreachable = (1 << 3);
-
-    enum Type uncat = (1 << 13);  // temporary category for yet uncategorized warnings
+    enum Type general        = (1 << 0);
+    enum Type advice         = (1 << 1);
+    enum Type ddoc           = (1 << 2);
+    enum Type notReachable   = (1 << 3);
+    enum Type fallthrough    = (1 << 4);
+    enum Type braces         = (1 << 5);
+    enum Type Cstyle         = (1 << 6);
+    enum Type hiding         = (1 << 7);
+    enum Type soonDeprecated = (1 << 8);
+    enum Type unusedValue    = (1 << 9);
+    enum Type conversion     = (1 << 10);
 }
 
 const (char*)[] warningTable =
@@ -37,18 +42,14 @@ const (char*)[] warningTable =
     "advice",
     "ddoc",
     "not-reachable",
-    "4",
-    "5",
-    "6",
-    "7",
-    "8",
-    "9",
-    "10",
-    "11",
-    "12",
-    "uncat",
+    "fallthrough",
+    "braces",
+    "C-style",
+    "hiding",
+    "soon-deprecated",
+    "unused-value",
+    "conversion",
 ];
-
 
 // If cat is a combination of multiple categories, the lowest index category is chosen.
 const(char)* warnCatToString(const WarningCategory cat)

--- a/src/warnings.d
+++ b/src/warnings.d
@@ -99,8 +99,11 @@ extern (C++) void vwarning(Loc loc, const WarningCategory cat, const(char)* form
     {
         vwarningPrint(loc, COLOR_YELLOW, "Warning: ", format, ap, warnCatToString(filtered_cat));
         //halt();
+
+        // warnings don't count if gagged
+        global.warnings++;
         if (global.params.warnings == 1)
-            global.warnings++; // warnings don't count if gagged
+            global.errors++; // counting warnings as errors
     }
 }
 

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -26,12 +26,12 @@ struct WarnCat
         none = Type(0),
         all  = ~Type(0),
 
-        general      = Type(0x1L << 0),
-        advice       = Type(0x1L << 1),
-        ddoc         = Type(0x1L << 2),
-        notreachable = Type(0x1L << 3),
+        general      = Type(1 << 0),
+        advice       = Type(1 << 1),
+        ddoc         = Type(1 << 2),
+        notreachable = Type(1 << 3),
 
-        uncat = Type(0x1L << 13),  // temporary category for yet uncategorized warnings
+        uncat = Type(1 << 13),  // temporary category for yet uncategorized warnings
     };
 };
 

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -1,0 +1,26 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2014 by Digital Mars
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/D-Programming-Language/dmd/blob/master/src/mars.h
+ */
+
+#ifndef DMD_WARNINGS_H
+#define DMD_WARNINGS_H
+
+#ifdef __DMC__
+#pragma once
+#endif
+
+#include "mars.h"
+
+void warning(Loc loc, const char *format, ...);
+void warningSupplemental(Loc loc, const char *format, ...);
+void vwarning(Loc loc, const char *format, va_list);
+void vwarningSupplemental(Loc loc, const char *format, va_list ap);
+
+#endif /* DMD_WARNINGS_H */

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -34,9 +34,9 @@ struct WarnCat
         braces         = Type(1 << 5),
         Cstyle         = Type(1 << 6),
         hiding         = Type(1 << 7),
-        soonDeprecated = Type(1 << 8);
-        unusedValue    = Type(1 << 9);
-        conversion     = Type(1 << 10);
+        soonDeprecated = Type(1 << 8),
+        unusedValue    = Type(1 << 9),
+        conversion     = Type(1 << 10),
     };
 };
 

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -26,12 +26,17 @@ struct WarnCat
         none = Type(0),
         all  = ~Type(0),
 
-        general      = Type(1 << 0),
-        advice       = Type(1 << 1),
-        ddoc         = Type(1 << 2),
-        notreachable = Type(1 << 3),
-
-        uncat = Type(1 << 13),  // temporary category for yet uncategorized warnings
+        general        = Type(1 << 0),
+        advice         = Type(1 << 1),
+        ddoc           = Type(1 << 2),
+        notreachable   = Type(1 << 3),
+        fallthrough    = Type(1 << 4),
+        braces         = Type(1 << 5),
+        Cstyle         = Type(1 << 6),
+        hiding         = Type(1 << 7),
+        soonDeprecated = Type(1 << 8);
+        unusedValue    = Type(1 << 9);
+        conversion     = Type(1 << 10);
     };
 };
 

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -18,9 +18,26 @@
 
 #include "mars.h"
 
-void warning(Loc loc, const char *format, ...);
-void warningSupplemental(Loc loc, const char *format, ...);
-void vwarning(Loc loc, const char *format, va_list);
-void vwarningSupplemental(Loc loc, const char *format, va_list ap);
+struct WarnCat
+{
+    typedef WarningCategory Type;
+    enum
+    {
+        none = Type(0),
+        all  = ~Type(0),
+
+        general      = Type(0x1L << 0),
+        advice       = Type(0x1L << 1),
+        ddoc         = Type(0x1L << 2),
+        notreachable = Type(0x1L << 3),
+
+        uncat = Type(0x1L << 13),  // temporary category for yet uncategorized warnings
+    };
+};
+
+void warning(Loc loc, const WarningCategory cat, const char *format, ...);
+void warningSupplemental(Loc loc, const WarningCategory cat, const char *format, ...);
+void vwarning(Loc loc, const WarningCategory cat, const char *format, va_list);
+void vwarningSupplemental(Loc loc, const WarningCategory cat, const char *format, va_list ap);
 
 #endif /* DMD_WARNINGS_H */

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -147,7 +147,7 @@ FRONT_SRCS=access.d aggregate.d aliasthis.d apply.d argtypes.d arrayop.d	\
 	impcnvtab.d init.d inline.d intrange.d json.d lexer.d lib.d link.d	\
 	mars.d mtype.d nogc.d nspace.d objc_stubs.d opover.d optimize.d parse.d	\
 	sapply.d sideeffect.d statement.d staticassert.d target.d tokens.d	\
-	traits.d utf.d visitor.d libomf.d scanomf.d typinf.d \
+	traits.d utf.d visitor.d warnings.d libomf.d scanomf.d typinf.d \
 	libmscoff.d scanmscoff.d
 
 GLUE_SRCS=irstate.d toctype.d backend.d gluelayer.d
@@ -185,7 +185,7 @@ SRCS = aggregate.h aliasthis.h arraytypes.h	\
 	import.h init.h intrange.h json.h lexer.h lib.h macro.h	\
 	mars.h module.h mtype.h nspace.h objc.h parse.h                         \
 	scope.h statement.h staticassert.h target.h template.h tokens.h	\
-	version.h visitor.h $(DMD_SRCS)
+	version.h visitor.h warnings.h $(DMD_SRCS)
 
 # Glue layer
 GLUESRC= glue.c msc.c s2ir.c todt.c e2ir.c tocsym.c \

--- a/test/compilable/ddoc10236.d
+++ b/test/compilable/ddoc10236.d
@@ -4,10 +4,10 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/ddoc10236.d(33): Warning: Ddoc: parameter count mismatch
-compilable/ddoc10236.d(45): Warning: Ddoc: function declaration has no parameter 'y'
-compilable/ddoc10236.d(57): Warning: Ddoc: function declaration has no parameter 'y'
-compilable/ddoc10236.d(57): Warning: Ddoc: parameter count mismatch
+compilable/ddoc10236.d(33): Warning: Ddoc: parameter count mismatch (-Wddoc)
+compilable/ddoc10236.d(45): Warning: Ddoc: function declaration has no parameter 'y' (-Wddoc)
+compilable/ddoc10236.d(57): Warning: Ddoc: function declaration has no parameter 'y' (-Wddoc)
+compilable/ddoc10236.d(57): Warning: Ddoc: parameter count mismatch (-Wddoc)
 ---
 */
 

--- a/test/compilable/ddoc10236b.d
+++ b/test/compilable/ddoc10236b.d
@@ -4,10 +4,10 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/ddoc10236b.d(43): Warning: Ddoc: parameter count mismatch
-compilable/ddoc10236b.d(55): Warning: Ddoc: function declaration has no parameter 'y'
-compilable/ddoc10236b.d(67): Warning: Ddoc: function declaration has no parameter 'y'
-compilable/ddoc10236b.d(67): Warning: Ddoc: parameter count mismatch
+compilable/ddoc10236b.d(43): Warning: Ddoc: parameter count mismatch (-Wddoc)
+compilable/ddoc10236b.d(55): Warning: Ddoc: function declaration has no parameter 'y' (-Wddoc)
+compilable/ddoc10236b.d(67): Warning: Ddoc: function declaration has no parameter 'y' (-Wddoc)
+compilable/ddoc10236b.d(67): Warning: Ddoc: parameter count mismatch (-Wddoc)
 ---
 */
 

--- a/test/compilable/ddoc13502.d
+++ b/test/compilable/ddoc13502.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -w -o-
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -wi -o-
 /*
 TEST_OUTPUT:
 ---

--- a/test/compilable/ddoc13502.d
+++ b/test/compilable/ddoc13502.d
@@ -3,10 +3,10 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/ddoc13502.d(14): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
-compilable/ddoc13502.d(17): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
-compilable/ddoc13502.d(21): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
-compilable/ddoc13502.d(24): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
+compilable/ddoc13502.d(14): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses. (-Wddoc)
+compilable/ddoc13502.d(17): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses. (-Wddoc)
+compilable/ddoc13502.d(21): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses. (-Wddoc)
+compilable/ddoc13502.d(24): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses. (-Wddoc)
 ---
 */
 

--- a/test/compilable/ddoc4899.d
+++ b/test/compilable/ddoc4899.d
@@ -4,8 +4,8 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/ddoc4899.d(16): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
-compilable/ddoc4899.d(16): Warning: Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.
+compilable/ddoc4899.d(16): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses. (-Wddoc)
+compilable/ddoc4899.d(16): Warning: Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses. (-Wddoc)
 ---
 */
 

--- a/test/compilable/warn_no_flags.d
+++ b/test/compilable/warn_no_flags.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -w -Wno-braces -Wno-not-reachable
+// PERMUTE_ARGS:
+
+void main()
+{
+    ;
+
+    if(true)
+    if(true) {}
+    else {}
+
+    return;
+    return;
+}

--- a/test/fail_compilation/b3841.d
+++ b/test/fail_compilation/b3841.d
@@ -4,21 +4,21 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b3841.d-mixin-31(31): Warning: char += float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: int += float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: long += double is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: char -= float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: int -= float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: long -= double is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: char *= float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: int *= float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: long *= double is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: char /= float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: int /= float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: long /= double is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: char %= float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: int %= float is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: long %= double is performing truncating conversion
+fail_compilation/b3841.d-mixin-31(31): Warning: char += float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: int += float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: long += double is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: char -= float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: int -= float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: long -= double is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: char *= float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: int *= float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: long *= double is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: char /= float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: int /= float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: long /= double is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: char %= float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: int %= float is performing truncating conversion (-Wconversion)
+fail_compilation/b3841.d-mixin-31(31): Warning: long %= double is performing truncating conversion (-Wconversion)
 ---
 */
 

--- a/test/fail_compilation/diag_cstyle.d
+++ b/test/fail_compilation/diag_cstyle.d
@@ -6,8 +6,8 @@ fail_compilation/diag_cstyle.d(14): Error: instead of C-style syntax, use D-styl
 fail_compilation/diag_cstyle.d(15): Error: instead of C-style syntax, use D-style 'int function(int)* fp3'
 fail_compilation/diag_cstyle.d(17): Error: instead of C-style syntax, use D-style 'int function(int) FP'
 fail_compilation/diag_cstyle.d(19): Error: instead of C-style syntax, use D-style 'int function() fp'
-fail_compilation/diag_cstyle.d(19): Warning: instead of C-style syntax, use D-style syntax 'int[] arr'
-fail_compilation/diag_cstyle.d(21): Warning: instead of C-style syntax, use D-style syntax 'string[] result'
+fail_compilation/diag_cstyle.d(19): Warning: instead of C-style syntax, use D-style syntax 'int[] arr' (-WC-style)
+fail_compilation/diag_cstyle.d(21): Warning: instead of C-style syntax, use D-style syntax 'string[] result' (-WC-style)
 ---
 */
 

--- a/test/fail_compilation/fail11653.d
+++ b/test/fail_compilation/fail11653.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11653.d(18): Warning: switch case fallthrough - use 'goto case;' if intended
+fail_compilation/fail11653.d(18): Warning: switch case fallthrough - use 'goto case;' if intended (-Wfallthrough)
 ---
 */
 

--- a/test/fail_compilation/fail3882.d
+++ b/test/fail_compilation/fail3882.d
@@ -7,8 +7,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3882.d(23): Warning: calling fail3882.strictlyPure!int.strictlyPure without side effects discards return value of type int, prepend a cast(void) if intentional
-fail_compilation/fail3882.d(27): Warning: calling fp without side effects discards return value of type int, prepend a cast(void) if intentional
+fail_compilation/fail3882.d(23): Warning: calling fail3882.strictlyPure!int.strictlyPure without side effects discards return value of type int, prepend a cast(void) if intentional (-Wunused-value)
+fail_compilation/fail3882.d(27): Warning: calling fp without side effects discards return value of type int, prepend a cast(void) if intentional (-Wunused-value)
 ---
 */
 
@@ -33,8 +33,8 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3882.d(46): Warning: calling fail3882.f1 without side effects discards return value of type int, prepend a cast(void) if intentional
-fail_compilation/fail3882.d(47): Warning: calling fail3882.f2 without side effects discards return value of type int, prepend a cast(void) if intentional
+fail_compilation/fail3882.d(46): Warning: calling fail3882.f1 without side effects discards return value of type int, prepend a cast(void) if intentional (-Wunused-value)
+fail_compilation/fail3882.d(47): Warning: calling fail3882.f2 without side effects discards return value of type int, prepend a cast(void) if intentional (-Wunused-value)
 ---
 */
 

--- a/test/fail_compilation/testpull1810.d
+++ b/test/fail_compilation/testpull1810.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testpull1810.d(19): Warning: statement is not reachable
+fail_compilation/testpull1810.d(19): Warning: statement is not reachable (-Wnot-reachable)
 ---
 */
 

--- a/test/fail_compilation/warn12809.d
+++ b/test/fail_compilation/warn12809.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn12809.d(25): Warning: statement is not reachable
-fail_compilation/warn12809.d(33): Warning: statement is not reachable
+fail_compilation/warn12809.d(25): Warning: statement is not reachable (-Wnot-reachable)
+fail_compilation/warn12809.d(33): Warning: statement is not reachable (-Wnot-reachable)
 ---
 */
 

--- a/test/fail_compilation/warn13679.d
+++ b/test/fail_compilation/warn13679.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn13679.d(14): Warning: cannot use foreach_reverse with an associative array
+fail_compilation/warn13679.d(14): Warning: cannot use foreach_reverse with an associative array (-Wsoon-deprecated)
 ---
 */
 

--- a/test/fail_compilation/warn_braces.d
+++ b/test/fail_compilation/warn_braces.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -Werror -Wbraces
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/warn_braces.d(14): Warning: use '{ }' for an empty statement, not a ';' (-Wbraces)
+fail_compilation/warn_braces.d(18): Warning: else is dangling, add { } after condition at fail_compilation/warn_braces.d(16) (-Wbraces)
+---
+*/
+
+void main()
+{
+    ;
+
+    if(true)
+    if(true) {}
+    else {}
+}

--- a/test/fail_compilation/warn_fallthrough.d
+++ b/test/fail_compilation/warn_fallthrough.d
@@ -1,0 +1,24 @@
+// REQUIRED_ARGS: -Wno-fallthrough -w
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11653.d(21): Warning: switch case fallthrough - use 'goto default;' if intended (-Wfallthrough)
+---
+*/
+
+void main()
+{
+    int test = 12412;
+    int output = 0;
+    switch(test)
+    {
+        case 1:
+            output = 1;
+            break;
+        case 2: .. case 3:
+            output = 2;
+            //break; //Oops..
+        default:
+            output = 3;
+    }
+}

--- a/test/fail_compilation/warn_fallthrough.d
+++ b/test/fail_compilation/warn_fallthrough.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11653.d(21): Warning: switch case fallthrough - use 'goto default;' if intended (-Wfallthrough)
+fail_compilation/warn_fallthrough.d(21): Warning: switch case fallthrough - use 'goto default;' if intended (-Wfallthrough)
 ---
 */
 

--- a/test/fail_compilation/warn_hash.d
+++ b/test/fail_compilation/warn_hash.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -wi -Werror
+// PERMUTE_ARGS:
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/warn_hash.d(13): Warning: toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not const ulong() (-Wadvice)
+---
+*/
+
+struct Key
+{
+    size_t toHash() const
+    {
+        return 1;
+    }
+}


### PR DESCRIPTION
This PR splits warnings into categories, which can then be disabled/enabled to suit the user. For example the "statement not reachable" warning is very hard/ugly to work around in generic code, which means the user cannot compile with warnings enabled (warning spam), nor with warnings=errors. With this PR, the user could do `dmd -w -Wno-not-reachable`, enabling all warnings except the not-reachable warning category.
The dlang.org Warning page says:
"Most have generated some spirited debate as to whether it should be a warning, an error, and what the correct way to write D code in these situations should be. Since no consensus emerged, they appear as optional warnings, with alternatives on how to write correct code."
This PR makes warnings _individually_ optional.

New commandline options are added, all starting with capital W: `-W...`
The behavior of `-w` and `-wi` is unchanged.
`-Werror` (warnings=errors, without enabling all warning categories)
`-W...` and `Wno-...` where a category name must be inserted on the dots.
The category name is output at the end of the warning text (like clang does).
A warning can be put into more than one category, although at the moment all warnings belong to a single category.
Later options overwrite earlier options.
Examples: 
`-w`, as before.
`-wi -Werror` == `-w`
`-wi -Wno-conversion`, will not warn on int += float
`-Wconversion`, will _only_ warn on int += float
`-Wno-conversion -Wconversion`, will _only_ warn on int += float
`-Wconversion -Wno-conversion`, will not warn at all
`-Werror -Wconversion`, will _only_ warn on int += float and will error on that warning

Some PR details:
1.  move warning-related code from `errors.d` to the new file `warnings.d`
2.  define a number of categories and assign each of the current warnings to a category (most are in their own category), implement category commandline arguments + filtering of the warnings, add category name (colored) to the warning output
3.  add extra tests for warnings. In the process of adding warnings, I fixed a bug where post-semantic warnings did not result in an error with `-w` (notably, the previously untested `toHash()` warning).
