### PR TITLE
Fix logic bug in ClassReferenceExp::getFieldAt

### DIFF
--- a/src/ctfeexpr.d
+++ b/src/ctfeexpr.d
@@ -72,18 +72,6 @@ public:
         return value.sd.isClassDeclaration();
     }
 
-    VarDeclaration getFieldAt(uint index)
-    {
-        ClassDeclaration cd = originalClass();
-        uint fieldsSoFar = 0;
-        while (index - fieldsSoFar >= cd.fields.dim)
-        {
-            fieldsSoFar += cd.fields.dim;
-            cd = cd.baseClass;
-        }
-        return cd.fields[index - fieldsSoFar];
-    }
-
     // Return index of the field, or -1 if not found
     int getFieldIndex(Type fieldtype, uint fieldoffset)
     {


### PR DESCRIPTION
This method is unused in DMD, so it's probably never actually been tested :-)

However I may have use for it, which is what brought it to my attention.

Given the following `ClassDeclaration` layout (following through all `baseClass` nodes)

```
{
  fields = 1
  {
    fields = 1
    {
      fields = 5
      {
        fields = 0
      }
    }
  }
}
```

In all possible index values `[0 .. 6]`, it returned the wrong field.

```
(gdb) p e.findFieldIndexByName(e.getFieldAt(0))
6
(gdb) p e.findFieldIndexByName(e.getFieldAt(1))
5
(gdb) p e.findFieldIndexByName(e.getFieldAt(2))
0
(gdb) p e.findFieldIndexByName(e.getFieldAt(3))
1
(gdb) p e.findFieldIndexByName(e.getFieldAt(4))
2
(gdb) p e.findFieldIndexByName(e.getFieldAt(5))
3
(gdb) p e.findFieldIndexByName(e.getFieldAt(6))
4
```

I worked out the correct logic on paper, and I can verify that this change makes it do the right thing.

@yebblies - Re: coverage + unittests?  Any plans for adding unittests to DMD?  I can imagine that it may require a small test framework to artificially create (or "mock") AST layout.
