### PR TITLE
Enable frontend checking whether overloaded functions conflict

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -2551,6 +2551,7 @@ public:
     {
         //printf("FuncDeclaration::overloadInsert(s = %s) this = %s\n", s->toChars(), toChars());
         assert(s != this);
+
         AliasDeclaration ad = s.isAliasDeclaration();
         if (ad)
         {
@@ -2578,25 +2579,18 @@ public:
         FuncDeclaration fd = s.isFuncDeclaration();
         if (!fd)
             return false;
-        version (none)
+
+        // fd->type can be NULL for overloaded constructors
+        if (type && fd.type &&
+            fbody && fd.fbody &&
+            fd.type.covariant(type) == 1 &&
+            fd.type.mod == type.mod &&
+            !isFuncAliasDeclaration())
         {
-            /* Disable this check because:
-             *  const void foo();
-             * semantic() isn't run yet on foo(), so the const hasn't been
-             * applied yet.
-             */
-            if (type)
-            {
-                printf("type = %s\n", type.toChars());
-                printf("fd->type = %s\n", fd.type.toChars());
-            }
-            // fd->type can be NULL for overloaded constructors
-            if (type && fd.type && fd.type.covariant(type) && fd.type.mod == type.mod && !isFuncAliasDeclaration())
-            {
-                //printf("\tfalse: conflict %s\n", kind());
-                return false;
-            }
+            //printf("\tfd = '%s'\n", fd.type.toChars());
+            return false;
         }
+
         if (overnext)
         {
             td = overnext.isTemplateDeclaration();

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -682,7 +682,7 @@ public:
                 {
                     goto Ldistinct;
                 }
-                const(StorageClass) sc = STCref | STCin | STCout | STClazy;
+                const(StorageClass) sc = STCref | STCin | STCout | STClazy | STCconst | STCimmutable | STCshared;
                 if ((fparam1.storageClass & sc) != (fparam2.storageClass & sc))
                     inoutmismatch = 1;
                 // We can add scope, but not subtract it


### PR DESCRIPTION
I really don't want to be fighting this in the backend any more.  And on a cursory look, it appears that the comment is no longer valid, so I'm enabling this and seeing what happens.

This change makes it so that:

```
int test(int a) { return a; }
int test(int a) { return a+1; }
```

Will now raise a compiler error about the conflicting functions, even if they aren't used.

However changing modifiers / parameter storage should still succeed, this is what's expected also. (eg: `int test(ref int a)` never conflicts with `int test(int a)`).
