### PR TITLE
add src/SYSCONFDIR.imp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ trace.def
 trace.log
 Makefile
 src/magicport/magicport
+src/SYSCONFDIR.imp
 
 # Visual Studio files
 *.exe


### PR DESCRIPTION
Hey this file keeps popping up in git console when I run a simple build - how about adding it to the ignore file?
