### PR TITLE
Remove dmd backend specific front-end restriction for isImportedSymbol

### DIFF
--- a/src/dcast.d
+++ b/src/dcast.d
@@ -1897,13 +1897,10 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 auto f = ve.var.isFuncDeclaration();
                 if (f)
                 {
-                    assert(f.isImportedSymbol());
                     f = f.overloadExactMatch(tb.nextOf());
                     if (f)
                     {
-                        result = new VarExp(e.loc, f, false);
-                        result.type = f.type;
-                        result = new AddrExp(e.loc, result);
+                        result = new SymOffExp(e.loc, f, false);
                         result.type = t;
                         return;
                     }

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1100,9 +1100,21 @@ elem *toElem(Expression *e, IRState *irs)
 
             if (se->var->isImportedSymbol())
             {
-                assert(se->op == TOKvar);
+                //printf("[%s] SymbolExp.toElem(op = '%s') se->var = %s %s\n",
+                //    se->loc.toChars(),
+                //    (se->op == TOKvar ? "var" : "symoff"),
+                //    se->var->kind(), se->var->toPrettyChars());
+
+                assert(se->op == TOKvar || se->op == TOKsymoff);
                 e = el_var(toImport(se->var));
-                e = el_una(OPind,s->ty(),e);
+                if (se->op == TOKsymoff && offset)
+                    e = el_bin(OPadd, e->Ety, e, el_long(TYsize_t, offset));
+                e = el_una(OPind, s->ty(), e);
+                if (se->op == TOKsymoff)
+                    e = el_una(OPaddr, TYnptr, e);
+
+                //if (se->op == TOKsymoff)
+                //    elem_print(e);
             }
             else if (ISREF(se->var, tb))
             {
@@ -3726,6 +3738,12 @@ elem *toElem(Expression *e, IRState *irs)
                 e = addressElem(e, ae->e1->type);
                 e->Ety = totym(ae->type);
                 el_setLoc(e, ae->loc);
+
+                //if (ae->e1->op == TOKvar && ((VarExp *)ae->e1)->var->isImportedSymbol())
+                //{
+                //    printf("[%s] AddrExp::toElem('%s')\n", ae->loc.toChars(), ae->toChars());
+                //    elem_print(e);
+                //}
                 result = e;
                 return;
             }

--- a/src/optimize.d
+++ b/src/optimize.d
@@ -356,7 +356,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             if (e.e1.op == TOKvar)
             {
                 VarExp ve = cast(VarExp)e.e1;
-                if (!ve.var.isOut() && !ve.var.isRef() && !ve.var.isImportedSymbol())
+                if (!ve.var.isOut() && !ve.var.isRef())
                 {
                     ret = new SymOffExp(e.loc, ve.var, 0, ve.hasOverloads);
                     ret.type = e.type;
@@ -371,7 +371,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 {
                     sinteger_t index = ae.e2.toInteger();
                     VarExp ve = cast(VarExp)ae.e1;
-                    if (ve.type.ty == Tsarray && !ve.var.isImportedSymbol())
+                    if (ve.type.ty == Tsarray)
                     {
                         TypeSArray ts = cast(TypeSArray)ve.type;
                         sinteger_t dim = ts.dim.toInteger();

--- a/test/runnable/extra-files/mydll.di
+++ b/test/runnable/extra-files/mydll.di
@@ -1,0 +1,5 @@
+module mydll;
+
+export int saved_var;
+
+export int multiply10(int);

--- a/test/runnable/extra-files/testdll.d
+++ b/test/runnable/extra-files/testdll.d
@@ -1,0 +1,18 @@
+import mydll;
+
+int main()
+{
+    int n1 = mydll.multiply10(2);
+    assert(mydll.saved_var == 2);
+    assert(n1 == 20);
+
+    auto pvar = &mydll.saved_var;
+    auto funcptr = &mydll.multiply10;
+
+    int n2 = funcptr(4);
+    assert(mydll.saved_var == 4);
+    assert(*pvar == 4);
+    assert(n2 == 40);
+
+    return 0;
+}

--- a/test/runnable/extra-files/testdll/dllmain.d
+++ b/test/runnable/extra-files/testdll/dllmain.d
@@ -1,0 +1,33 @@
+module dllmain;
+
+import core.sys.windows.windows;
+import core.sys.windows.dll;
+
+__gshared HINSTANCE g_hInst;
+
+extern (Windows)
+BOOL DllMain(HINSTANCE hInstance, ULONG ulReason, LPVOID pvReserved)
+{
+    switch (ulReason)
+    {
+        case DLL_PROCESS_ATTACH:
+            g_hInst = hInstance;
+            dll_process_attach(hInstance, true);
+            break;
+
+        case DLL_PROCESS_DETACH:
+            dll_process_detach(hInstance, true);
+            break;
+
+        case DLL_THREAD_ATTACH:
+            dll_thread_attach(true, true);
+            break;
+
+        case DLL_THREAD_DETACH:
+            dll_thread_detach(true, true);
+            break;
+
+        default:
+    }
+    return true;
+}

--- a/test/runnable/extra-files/testdll/mydll.d
+++ b/test/runnable/extra-files/testdll/mydll.d
@@ -1,0 +1,13 @@
+module mydll;
+
+import core.stdc.stdio;
+
+export int saved_var;
+
+export int multiply10(int x)
+{
+    saved_var = x;
+
+    return x * 10;
+}
+

--- a/test/runnable/extra-files/testdll/mydll.def
+++ b/test/runnable/extra-files/testdll/mydll.def
@@ -1,0 +1,5 @@
+LIBRARY     "mydll.dll"
+EXETYPE     NT
+SUBSYSTEM   WINDOWS
+CODE        SHARED EXECUTE
+DATA        WRITE

--- a/test/runnable/testdll.sh
+++ b/test/runnable/testdll.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+if [ $OS == "win32" -o  $OS == "win64" ]; then
+	DLLEXT=.dll
+	LIBEXT=.lib
+else
+	exit 0
+fi
+
+src=runnable${SEP}extra-files
+dllsrc=${src}${SEP}testdll
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/testdll.sh.out
+
+exename=${dir}${SEP}testdll${EXE}
+dllname=${dir}${SEP}mydll${DLLEXT}
+libname=${dir}${SEP}mydll${LIBEXT}
+
+$DMD -m${MODEL} -of${dllname} -L"/IMPLIB:mydll${LIBEXT}" ${dllsrc}${SEP}{mydll.d,dllmain.d,mydll.def}
+
+mv mydll${LIBEXT} ${libname}
+
+$DMD -m${MODEL} -I${src} -of${exename} ${src}${SEP}testdll.d ${libname}
+
+rm ${dir}/{testdll,mydll}${OBJ}
+rm ${exename} ${dllname} ${libname}


### PR DESCRIPTION
In dmd, an `extern` symbol should be represented by `VarExp` to avoid assertion failure in `SymbolExp.toElem()`. But, as far as I see, it's arbitrary restriction and can be removed.
