### PR TITLE
fix issue 13975 - ICE: dmd crash if -gc and enum member is immutable int

### DIFF
--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -1855,7 +1855,7 @@ L1:
                         // The visual studio debugger gets confused with pointers to arrays, emit a reference instead.
                         // This especially happens when passing arrays as function arguments because 64bit ABI demands
                         // passing structs > 8 byte as pointers.
-                        if((config.flags2 & CFG2gms) && t->Tnext && t->Tnext->Tty == TYdarray)
+                        if((config.flags2 & CFG2gms) && t->Tnext && tybasic(t->Tnext->Tty) == TYdarray)
                             TOLONG(d->data + 6,attribute | 0x20);
                         else
                         {
@@ -2113,7 +2113,7 @@ L1:
                 typidx = cv4_enum(t->Ttag);
             else
 #endif
-                typidx = dttab4[t->Tnext->Tty];
+                typidx = dttab4[tybasic(t->Tnext->Tty)];
             break;
 
 #if SCPP

--- a/test/compilable/debuginfo.d
+++ b/test/compilable/debuginfo.d
@@ -12,3 +12,9 @@ void main() {
     Bug7127a a;
     Bug7127b b;
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=13975
+static immutable int a = 8;
+enum Bar { aa = a }
+
+void foo(Bar bar) {}


### PR DESCRIPTION
 add missing masking of Tty

https://issues.dlang.org/show_bug.cgi?id=13975
