### PR TITLE
[REG2.071-b1] Issue 15839 - this.outer is of wrong type

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -8731,10 +8731,40 @@ public:
             {
                 if (sym.vthis._scope)
                     sym.vthis.semantic(null);
-                ClassDeclaration cdp = sym.toParent2().isClassDeclaration();
-                auto de = new DotVarExp(e.loc, e, sym.vthis);
-                de.type = (cdp ? cdp.type : sym.vthis.type).addMod(e.type.mod);
-                return de;
+
+                if (auto cdp = sym.toParent2().isClassDeclaration())
+                {
+                    auto dve = new DotVarExp(e.loc, e, sym.vthis);
+                    dve.type = cdp.type.addMod(e.type.mod);
+                    return dve;
+                }
+
+                /* Bugzilla 15839: Find closest parent class through nested functions.
+                 */
+                for (auto p = sym.toParent2(); p; p = p.toParent2())
+                {
+                    auto fd = p.isFuncDeclaration();
+                    if (!fd)
+                        break;
+                    if (fd.isNested())
+                        continue;
+                    auto ad = fd.isThis();
+                    if (!ad)
+                        break;
+                    if (auto cdp = ad.isClassDeclaration())
+                    {
+                        auto ve = new ThisExp(e.loc);
+                        ve.var = fd.vthis;
+                        ve.type = fd.vthis.type.addMod(e.type.mod);
+                        return ve;
+                    }
+                    break;
+                }
+
+                // Continue to show enclosing function's frame (stack or closure).
+                auto dve = new DotVarExp(e.loc, e, sym.vthis);
+                dve.type = sym.vthis.type.addMod(e.type.mod);
+                return dve;
             }
             else
             {

--- a/test/runnable/inner.d
+++ b/test/runnable/inner.d
@@ -828,6 +828,56 @@ void test14046()
 }
 
 /*******************************************************/
+// 15839
+
+class AnimatedProgress15839(bool makeClosure)
+{
+    static AnimatedProgress15839 saveThis;
+
+    interface Runnable {}
+
+    static class GC
+    {
+        this(AnimatedProgress15839 ap)
+        {
+            assert(ap is saveThis);
+        }
+    }
+
+    void start()
+    {
+        assert(this is saveThis);
+
+        static if (makeClosure) int a;
+
+        auto r = new class Runnable
+        {
+            void run()
+            {
+                static assert(is(typeof(this.outer) == AnimatedProgress15839));
+                assert(this.outer is saveThis);
+
+                GC gc = new GC(this.outer);
+
+                static if (makeClosure) int b = a;
+            }
+        };
+        r.run();
+    }
+}
+
+void test15839()
+{
+    auto ap1 = new AnimatedProgress15839!false();
+    ap1.saveThis = ap1;
+    ap1.start();
+
+    auto ap2 = new AnimatedProgress15839!true();
+    ap2.saveThis = ap2;
+    ap2.start();
+}
+
+/*******************************************************/
 
 int main()
 {
@@ -861,6 +911,7 @@ int main()
     test24();
 
     test14046();
+    test15839();
 
     printf("Success\n");
     return 0;

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -866,7 +866,8 @@ class Foo35
                 //writefln("y = %s", y);
                 assert(x == 42);
                 assert(y == 43);
-                static assert(is(typeof(this.outer) == void*)); // Bugzilla 14442
+              //static assert(is(typeof(this.outer) == void*)); // Bugzilla 14442
+                static assert(is(typeof(this.outer) == Foo35)); // Bugzilla 15839
             }
         };
     }


### PR DESCRIPTION
Tweak built-in `.outer` property behavior. If there's some nested functions between a nested class and parent class, `.outer` can point the parent class instance. In other words, the immediate parent function frame of the nested class will be inaccessible by using `.outer`.
