### PR TITLE
[Refactor] Add some 'abstract' qualifier and remove 'final' on 'static' method

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -60,7 +60,7 @@ alias BASEOKsemanticdone = Baseok.BASEOKsemanticdone;
 
 /***********************************************************
  */
-extern (C++) class AggregateDeclaration : ScopeDsymbol
+extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 {
 public:
     Type type;

--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -570,7 +570,7 @@ public:
      * alignment: struct alignment that is in effect
      * size: alignment requirement of field
      */
-    final static void alignmember(structalign_t alignment, uint size, uint* poffset)
+    static void alignmember(structalign_t alignment, uint size, uint* poffset)
     {
         //printf("alignment = %d, size = %d, offset = %d\n",alignment,size,offset);
         switch (alignment)
@@ -607,7 +607,7 @@ public:
      * paggalignsize: size of aggregate for alignment purposes (updated)
      * isunion:       the aggregate is a union
      */
-    final static uint placeField(uint* nextoffset, uint memsize, uint memalignsize,
+    static uint placeField(uint* nextoffset, uint memsize, uint memalignsize,
         structalign_t alignment, uint* paggsize, uint* paggalignsize, bool isunion)
     {
         uint ofs = *nextoffset;

--- a/src/attrib.d
+++ b/src/attrib.d
@@ -78,7 +78,7 @@ public:
      * If the returned scope != sc, the caller should pop
      * the scope after it used.
      */
-    final static Scope* createNewScope(Scope* sc, StorageClass stc, LINK linkage, Prot protection, int explicitProtection, structalign_t structalign, PINLINE inlining)
+    static Scope* createNewScope(Scope* sc, StorageClass stc, LINK linkage, Prot protection, int explicitProtection, structalign_t structalign, PINLINE inlining)
     {
         Scope* sc2 = sc;
         if (stc != sc.stc || linkage != sc.linkage || !protection.isSubsetOf(sc.protection) || explicitProtection != sc.explicitProtection || structalign != sc.structalign || inlining != sc.inlining)

--- a/src/attrib.d
+++ b/src/attrib.d
@@ -39,7 +39,7 @@ import ddmd.visitor;
 
 /***********************************************************
  */
-extern (C++) class AttribDeclaration : Dsymbol
+extern (C++) abstract class AttribDeclaration : Dsymbol
 {
 public:
     Dsymbols* decl;     // array of Dsymbol's

--- a/src/cond.d
+++ b/src/cond.d
@@ -41,7 +41,7 @@ static this()
 
 /***********************************************************
  */
-extern (C++) class Condition
+extern (C++) abstract class Condition
 {
 public:
     Loc loc;

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -2278,7 +2278,7 @@ public:
         linkage = LINKc;
     }
 
-    final static TypeInfoDeclaration create(Type tinfo, int internal)
+    static TypeInfoDeclaration create(Type tinfo, int internal)
     {
         return new TypeInfoDeclaration(tinfo, internal);
     }

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -163,7 +163,7 @@ alias Semantic2Done = Semantic.Semantic2Done;
 
 /***********************************************************
  */
-extern (C++) class Declaration : Dsymbol
+extern (C++) abstract class Declaration : Dsymbol
 {
 public:
     Type type;

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -139,7 +139,7 @@ public:
      *      *pparent        the rightmost package, i.e. pkg2, or NULL if no packages
      *      *ppkg           the leftmost package, i.e. pkg1, or NULL if no packages
      */
-    final static DsymbolTable resolve(Identifiers* packages, Dsymbol* pparent, Package* ppkg)
+    static DsymbolTable resolve(Identifiers* packages, Dsymbol* pparent, Package* ppkg)
     {
         DsymbolTable dst = Module.modules;
         Dsymbol parent = null;

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -225,7 +225,7 @@ public:
         this.semanticRun = PASSinit;
     }
 
-    final static Dsymbol create(Identifier ident)
+    static Dsymbol create(Identifier ident)
     {
         return new Dsymbol(ident);
     }
@@ -470,7 +470,7 @@ public:
     /*************************************
      * Do syntax copy of an array of Dsymbol's.
      */
-    final static Dsymbols* arraySyntaxCopy(Dsymbols* a)
+    static Dsymbols* arraySyntaxCopy(Dsymbols* a)
     {
         Dsymbols* b = null;
         if (a)
@@ -883,7 +883,7 @@ public:
     /*****************************************
      * Same as Dsymbol::oneMember(), but look at an array of Dsymbols.
      */
-    final static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
+    static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
     {
         //printf("Dsymbol::oneMembers() %d\n", members ? members.dim : 0);
         Dsymbol s = null;
@@ -1506,7 +1506,7 @@ public:
         return (members is null);
     }
 
-    final static void multiplyDefined(Loc loc, Dsymbol s1, Dsymbol s2)
+    static void multiplyDefined(Loc loc, Dsymbol s1, Dsymbol s2)
     {
         version (none)
         {

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -5969,7 +5969,7 @@ public:
         assert(tempdecl._scope);
     }
 
-    final static Objects* arraySyntaxCopy(Objects* objs)
+    static Objects* arraySyntaxCopy(Objects* objs)
     {
         Objects* a = null;
         if (objs)
@@ -7268,7 +7268,7 @@ public:
      * Returns:
      *      false if one or more arguments have errors.
      */
-    final static bool semanticTiargs(Loc loc, Scope* sc, Objects* tiargs, int flags)
+    static bool semanticTiargs(Loc loc, Scope* sc, Objects* tiargs, int flags)
     {
         // Run semantic on each argument, place results in tiargs[]
         //printf("+TemplateInstance::semanticTiargs()\n");

--- a/src/expression.d
+++ b/src/expression.d
@@ -2337,7 +2337,7 @@ enum WANTexpand = 1;    // expand const/immutable variables if possible
 
 /***********************************************************
  */
-extern (C++) class Expression : RootObject
+extern (C++) abstract class Expression : RootObject
 {
 public:
     Loc loc;        // file location
@@ -7497,7 +7497,7 @@ extern (C++) alias fp2_t = int function(Loc loc, TOK, Expression, Expression);
 
 /***********************************************************
  */
-extern (C++) class BinExp : Expression
+extern (C++) abstract class BinExp : Expression
 {
 public:
     Expression e1;

--- a/src/expression.d
+++ b/src/expression.d
@@ -2354,7 +2354,7 @@ public:
         this.size = cast(ubyte)size;
     }
 
-    final static void _init()
+    static void _init()
     {
         CTFEExp.cantexp = new CTFEExp(TOKcantexp);
         CTFEExp.voidexp = new CTFEExp(TOKvoidexp);
@@ -2493,7 +2493,7 @@ public:
     /**********************************
      * Combine e1 and e2 by CommaExp if both are not NULL.
      */
-    final static Expression combine(Expression e1, Expression e2)
+    static Expression combine(Expression e1, Expression e2)
     {
         if (e1)
         {
@@ -2514,7 +2514,7 @@ public:
      * is returned via *pe0.
      * Otherwise 'e' is directly returned and *pe0 is set to NULL.
      */
-    final static Expression extractLast(Expression e, Expression* pe0)
+    static Expression extractLast(Expression e, Expression* pe0)
     {
         if (e.op != TOKcomma)
         {
@@ -2542,7 +2542,7 @@ public:
         }
     }
 
-    final static Expressions* arraySyntaxCopy(Expressions* exps)
+    static Expressions* arraySyntaxCopy(Expressions* exps)
     {
         Expressions* a = null;
         if (exps)
@@ -3616,7 +3616,7 @@ public:
         this.ident = ident;
     }
 
-    final static IdentifierExp create(Loc loc, Identifier ident)
+    static IdentifierExp create(Loc loc, Identifier ident)
     {
         return new IdentifierExp(loc, ident);
     }

--- a/src/func.d
+++ b/src/func.d
@@ -3809,12 +3809,12 @@ public:
     /**********************************
      * Generate a FuncDeclaration for a runtime library function.
      */
-    final static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, StorageClass stc = 0)
+    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, StorageClass stc = 0)
     {
         return genCfunc(fparams, treturn, Identifier.idPool(name, strlen(name)), stc);
     }
 
-    final static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, StorageClass stc = 0)
+    static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, StorageClass stc = 0)
     {
         FuncDeclaration fd;
         TypeFunction tf;

--- a/src/identifier.d
+++ b/src/identifier.d
@@ -140,7 +140,7 @@ public:
      * Returns:
      *      0       invalid
      */
-    final static bool isValidIdentifier(const(char)* p)
+    static bool isValidIdentifier(const(char)* p)
     {
         size_t len;
         size_t idx;

--- a/src/init.d
+++ b/src/init.d
@@ -53,7 +53,7 @@ public:
 
     abstract Initializer syntaxCopy();
 
-    final static Initializers* arraySyntaxCopy(Initializers* ai)
+    static Initializers* arraySyntaxCopy(Initializers* ai)
     {
         Initializers* a = null;
         if (ai)

--- a/src/lexer.d
+++ b/src/lexer.d
@@ -2460,7 +2460,7 @@ public:
      * Combine two document comments into one,
      * separated by a newline.
      */
-    final static const(char)* combineComments(const(char)* c1, const(char)* c2)
+    static const(char)* combineComments(const(char)* c1, const(char)* c2)
     {
         //printf("Lexer::combineComments('%s', '%s')\n", c1, c2);
         auto c = c2;

--- a/src/lib.d
+++ b/src/lib.d
@@ -31,7 +31,7 @@ else
 extern (C++) class Library
 {
 public:
-    final static Library factory()
+    static Library factory()
     {
         static if (TARGET_WINDOS)
         {

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -468,7 +468,7 @@ alias MOD = ubyte;
 
 /***********************************************************
  */
-extern (C++) class Type : RootObject
+extern (C++) abstract class Type : RootObject
 {
 public:
     TY ty;
@@ -2983,7 +2983,7 @@ public:
 
 /***********************************************************
  */
-extern (C++) class TypeNext : Type
+extern (C++) abstract class TypeNext : Type
 {
 public:
     Type next;
@@ -6806,7 +6806,7 @@ public:
 
 /***********************************************************
  */
-extern (C++) class TypeQualified : Type
+extern (C++) abstract class TypeQualified : Type
 {
 public:
     Loc loc;

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -819,12 +819,12 @@ public:
         return buf.extractString();
     }
 
-    final static char needThisPrefix()
+    static char needThisPrefix()
     {
         return 'M'; // name mangling prefix for functions needing 'this'
     }
 
-    final static void _init()
+    static void _init()
     {
         stringtable._init(14000);
         // Set basic types
@@ -2906,7 +2906,7 @@ public:
         }
     }
 
-    final static void error(Loc loc, const(char)* format, ...)
+    static void error(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);
@@ -2914,7 +2914,7 @@ public:
         va_end(ap);
     }
 
-    final static void warning(Loc loc, const(char)* format, ...)
+    static void warning(Loc loc, const(char)* format, ...)
     {
         va_list ap;
         va_start(ap, format);

--- a/src/statement.d
+++ b/src/statement.d
@@ -1131,7 +1131,7 @@ public:
         this.exp = new DeclarationExp(loc, declaration);
     }
 
-    final static ExpStatement create(Loc loc, Expression exp)
+    static ExpStatement create(Loc loc, Expression exp)
     {
         return new ExpStatement(loc, exp);
     }
@@ -1368,7 +1368,7 @@ public:
         statements.push(s2);
     }
 
-    final static CompoundStatement create(Loc loc, Statement s1, Statement s2)
+    static CompoundStatement create(Loc loc, Statement s1, Statement s2)
     {
         return new CompoundStatement(loc, s1, s2);
     }

--- a/src/statement.d
+++ b/src/statement.d
@@ -130,7 +130,7 @@ alias BEany = BE.BEany;
 
 /***********************************************************
  */
-extern (C++) class Statement : RootObject
+extern (C++) abstract class Statement : RootObject
 {
 public:
     Loc loc;


### PR DESCRIPTION
Should be trivial. Note that `Condition` was already `abstract` but the qualifier was added anyway for clarity/consistency.

@yebblies : I guess it doesn't make a difference on the C++ side, does it ?
