### PR TITLE
Refactor: Simplify right 'this' check inside aggregate member lambdas within typeof

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -615,7 +615,6 @@ public:
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration *g);
     LabelDsymbol *searchLabel(Identifier *ident);
-    AggregateDeclaration *isThis();
     int getLevel(Loc loc, Scope *sc, FuncDeclaration *fd); // lexical nesting level difference
     const char *toPrettyChars(bool QualifyTypes = false);
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
@@ -643,6 +642,7 @@ public:
     bool isolateReturn();
     bool parametersIntersect(Type *t);
     virtual bool isNested();
+    AggregateDeclaration *isThis();
     bool needThis();
     bool isVirtualMethod();
     virtual bool isVirtual();

--- a/src/expression.d
+++ b/src/expression.d
@@ -213,16 +213,17 @@ extern (C++) bool isNeedThisScope(Scope* sc, Declaration d)
 {
     if (sc.intypeof == 1)
         return false;
+
     AggregateDeclaration ad = d.isThis();
     if (!ad)
         return false;
-    //printf("d = %s, ad = %s\n", d->toChars(), ad->toChars());
+    //printf("d = %s, ad = %s\n", d.toChars(), ad.toChars());
+
     for (Dsymbol s = sc.parent; s; s = s.toParent2())
     {
-        //printf("\ts = %s %s, toParent2() = %p\n", s->kind(), s->toChars(), s->toParent2());
+        //printf("\ts = %s %s, toParent2() = %p\n", s.kind(), s.toChars(), s.toParent2());
         if (AggregateDeclaration ad2 = s.isAggregateDeclaration())
         {
-            //printf("\t    ad2 = %s\n", ad2->toChars());
             if (ad2 == ad)
                 return false;
             else if (ad2.isNested())
@@ -232,8 +233,6 @@ extern (C++) bool isNeedThisScope(Scope* sc, Declaration d)
         }
         if (FuncDeclaration f = s.isFuncDeclaration())
         {
-            if (f.isFuncLiteralDeclaration() && f.isNested())
-                continue;
             if (f.isMember2())
                 break;
         }

--- a/test/fail_compilation/fail13424.d
+++ b/test/fail_compilation/fail13424.d
@@ -1,11 +1,23 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13424.d(10): Error: delegate fail13424.S.__lambda2 cannot be class members
+fail_compilation/fail13424.d(12): Error: delegate fail13424.S.__lambda2 cannot be struct members
+fail_compilation/fail13424.d(17): Error: delegate fail13424.U.__lambda2 cannot be union members
+fail_compilation/fail13424.d(22): Error: delegate fail13424.C.__lambda2 cannot be class members
 ---
 */
 
 struct S
+{
+    void delegate(dchar) onChar = (dchar) {};
+}
+
+union U
+{
+    void delegate(dchar) onChar = (dchar) {};
+}
+
+class C
 {
     void delegate(dchar) onChar = (dchar) {};
 }


### PR DESCRIPTION
From the `isThis()` and `isNested()` definitions, an aggregate member lambda's `isNested()` should not return true.
It was an exceptional case, and specially handled in `isNeedThisScope` function.

After this change, the exception can be removed.

---

Also add detailed ddoc comments to FuncDeclaration.isThis() and isNested().
