### PR TITLE
fix Issue 10225 - core.simd wrong codegen for XMM.STOUPS with __simd_sto

### DIFF
--- a/src/backend/cgxmm.c
+++ b/src/backend/cgxmm.c
@@ -37,8 +37,14 @@ unsigned xmmoperator(tym_t tym, unsigned oper);
 
 bool isXMMstore(unsigned op)
 {
-    // Not very efficient
-    return op == STOSS || op == STOSD || op == STOAPS || op == STOAPD || op == STODQA || op == STOQ;
+    switch (op)
+    {
+    case STOSS: case STOAPS: case STOUPS:
+    case STOSD: case STOAPD: case STOUPD:
+    case STOD: case STOQ: case STODQA: case STODQU:
+    case STOHPD: case STOHPS: case STOLPD: case STOLPS: return true;
+    default: return false;
+    }
 }
 
 /*******************************************

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1032,22 +1032,34 @@ float4 test5(float4 a, float4 b)
 
     a = __simd_sto(XMM.STOSS, a, b);
     a = __simd_sto(XMM.STOSD, a, b);
+    a = __simd_sto(XMM.STOD, a, b);
+    a = __simd_sto(XMM.STOQ, a, b);
     a = __simd_sto(XMM.STOAPS, a, b);
     a = __simd_sto(XMM.STOAPD, a, b);
     a = __simd_sto(XMM.STODQA, a, b);
-    //a = __simd_sto(XMM.STOD, a, b);
-    a = __simd_sto(XMM.STOQ, a, b);
+    a = __simd_sto(XMM.STOUPS, a, b);
+    a = __simd_sto(XMM.STOUPD, a, b);
+    a = __simd_sto(XMM.STODQU, a, b);
+    a = __simd_sto(XMM.STOHPD, a, b);
+    a = __simd_sto(XMM.STOHPS, a, b);
+    a = __simd_sto(XMM.STOLPD, a, b);
+    a = __simd_sto(XMM.STOLPS, a, b);
 
     a = __simd(XMM.LODSS, a);
     a = __simd(XMM.LODSD, a);
     a = __simd(XMM.LODAPS, a);
     a = __simd(XMM.LODAPD, a);
     a = __simd(XMM.LODDQA, a);
-    //a = __simd(XMM.LODD, a);
-    a = __simd(XMM.LODQ, a);
-
+    a = __simd(XMM.LODUPS, a);
+    a = __simd(XMM.LODUPD, a);
     a = __simd(XMM.LODDQU, a);
-    a = __simd_sto(XMM.STODQU, a, b);
+    a = __simd(XMM.LODD, a);
+    a = __simd(XMM.LODQ, a);
+    a = __simd(XMM.LODHPD, a);
+    a = __simd(XMM.LODHPS, a);
+    a = __simd(XMM.LODLPD, a);
+    a = __simd(XMM.LODLPS, a);
+
     //MOVDQ2Q  = 0xF20FD6,        // MOVDQ2Q mmx, xmm          F2 0F D6 /r
 /+
     LODHPD   = 0x660F16,        // MOVHPD xmm, mem64         66 0F 16 /r


### PR DESCRIPTION
- add missing STO\* ops to codegen
