### PR TITLE
Override `toChars` in `Parameter`

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -9614,4 +9614,9 @@ public:
             *pn = n; // update index
         return result;
     }
+
+    override const(char)* toChars() const
+    {
+        return ident ? ident.toChars() : "__anonymous_param";
+    }
 }


### PR DESCRIPTION
By default it will use the default implementation, a.k.a `assert(0);`.
