### PR TITLE
Enable rmem.d memory allocation overides when LDC+@weak is detected

### DIFF
--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -165,7 +165,22 @@ else
         goto L1;
     }
 
-    version(DigitalMars)
+    version (DigitalMars)
+    {
+        enum OVERRIDE_MEMALLOC = true;
+    }
+    else version (LDC)
+    {
+        // Memory allocation functions gained weak linkage when the @weak attribute was introduced.
+        import ldc.attributes;
+        enum OVERRIDE_MEMALLOC = is(typeof(ldc.attributes.weak));
+    }
+    else
+    {
+        enum OVERRIDE_MEMALLOC = false;
+    }
+
+    static if (OVERRIDE_MEMALLOC)
     {
         extern (C) void* _d_allocmemory(size_t m_size) nothrow
         {


### PR DESCRIPTION
LDC gained the weak linkage @weak attribute and marks the memory allocation functions in druntime with @weak (LDC >= 0.17.2).
Enabling the memory allocation overrides in rmem.d results in a large performance improvement of DMD when compiled with LDC >= 0.17.2.

Should be a NOP for compilers other than LDC.
