### PR TITLE
Fix Issue 12100 - __GENTYPE to generate ever different types

### DIFF
--- a/src/doc.d
+++ b/src/doc.d
@@ -2129,6 +2129,7 @@ extern (C++) bool isReservedName(char* str, size_t len)
         "__MODULE__",
         "__FUNCTION__",
         "__PRETTY_FUNCTION__",
+        "__GENSYM__",
         "__DATE__",
         "__TIME__",
         "__TIMESTAMP__",

--- a/src/idgen.d
+++ b/src/idgen.d
@@ -120,6 +120,7 @@ Msgtable[] msgtable =
     { "MODULE", "__MODULE__" },
     { "FUNCTION", "__FUNCTION__" },
     { "PRETTY_FUNCTION", "__PRETTY_FUNCTION__" },
+    { "GENSYM", "__GENSYM__" },
     { "DATE", "__DATE__" },
     { "TIME", "__TIME__" },
     { "TIMESTAMP", "__TIMESTAMP__" },

--- a/src/parse.d
+++ b/src/parse.d
@@ -88,6 +88,7 @@ __gshared PREC[TOKMAX] precedence =
     TOKmodulestring : PREC_primary,
     TOKfuncstring : PREC_primary,
     TOKprettyfunc : PREC_primary,
+    TOKgensym : PREC_primary,
     TOKtypeid : PREC_primary,
     TOKis : PREC_primary,
     TOKassert : PREC_primary,
@@ -1886,6 +1887,7 @@ public:
         case TOKmodulestring:
         case TOKfuncstring:
         case TOKprettyfunc:
+        case TOKgensym:
         case TOKthis:
             {
                 // Template argument is an expression
@@ -4524,6 +4526,7 @@ public:
         case TOKmodulestring:
         case TOKfuncstring:
         case TOKprettyfunc:
+        case TOKgensym:
         Lexp:
             {
                 Expression exp = parseExpression();
@@ -5661,11 +5664,11 @@ public:
 
     /*****************************************
      * Parses default argument initializer expression that is an assign expression,
-     * with special handling for __FILE__, __LINE__, __MODULE__, __FUNCTION__, and __PRETTY_FUNCTION__.
+     * with special handling for __FILE__, __LINE__, __MODULE__, __FUNCTION__, __PRETTY_FUNCTION__, and __GENSYM__.
      */
     Expression parseDefaultInitExp()
     {
-        if (token.value == TOKfile || token.value == TOKline || token.value == TOKmodulestring || token.value == TOKfuncstring || token.value == TOKprettyfunc)
+        if (token.value == TOKfile || token.value == TOKline || token.value == TOKmodulestring || token.value == TOKfuncstring || token.value == TOKprettyfunc || token.value == TOKgensym)
         {
             Token* t = peek(&token);
             if (t.value == TOKcomma || t.value == TOKrparen)
@@ -5681,6 +5684,8 @@ public:
                     e = new FuncInitExp(token.loc);
                 else if (token.value == TOKprettyfunc)
                     e = new PrettyFuncInitExp(token.loc);
+                else if (token.value == TOKgensym)
+                    e = new GensymInitExp(token.loc);
                 else
                     assert(0);
                 nextToken();
@@ -5892,6 +5897,7 @@ public:
                     case TOKmodulestring:
                     case TOKfuncstring:
                     case TOKprettyfunc:
+                    case TOKgensym:
                         goto L2;
                     default:
                         goto Lfalse;
@@ -6605,6 +6611,10 @@ public:
             e = new PrettyFuncInitExp(loc);
             nextToken();
             break;
+        case TOKgensym:
+            e = new GensymInitExp(loc);
+            nextToken();
+            break;
         case TOKtrue:
             e = new IntegerExp(loc, 1, Type.tbool);
             nextToken();
@@ -7162,6 +7172,7 @@ public:
                         case TOKmodulestring:
                         case TOKfuncstring:
                         case TOKprettyfunc:
+                        case TOKgensym:
                         case TOKwchar:
                         case TOKdchar:
                         case TOKbool:

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -283,6 +283,7 @@ enum TOK : int
     TOKmodulestring,
     TOKfuncstring,
     TOKprettyfunc,
+    TOKgensym,
     TOKshared,
     TOKat,
     TOKpow,
@@ -528,6 +529,7 @@ alias TOKfile = TOK.TOKfile;
 alias TOKmodulestring = TOK.TOKmodulestring;
 alias TOKfuncstring = TOK.TOKfuncstring;
 alias TOKprettyfunc = TOK.TOKprettyfunc;
+alias TOKgensym = TOK.TOKgensym;
 alias TOKshared = TOK.TOKshared;
 alias TOKat = TOK.TOKat;
 alias TOKpow = TOK.TOKpow;
@@ -1035,6 +1037,7 @@ immutable Keyword[] keywords =
     Keyword("__MODULE__", TOKmodulestring),
     Keyword("__FUNCTION__", TOKfuncstring),
     Keyword("__PRETTY_FUNCTION__", TOKprettyfunc),
+    Keyword("__GENSYM__", TOKgensym),
     Keyword("shared", TOKshared),
     Keyword("immutable", TOKimmutable),
 ];

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -172,6 +172,7 @@ enum TOK
         TOKmodulestring,
         TOKfuncstring,
         TOKprettyfunc,
+        TOKgensym,
         TOKshared,
         TOKat,
         TOKpow,

--- a/test/compilable/gensym.d
+++ b/test/compilable/gensym.d
@@ -1,0 +1,70 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -o-
+
+/***************************************************/
+// 12100
+
+
+struct S12100 {
+    static string foo(string sym = __GENSYM__)() {
+        return sym;
+    }
+    static string foo(string sym = __GENSYM__)(int n) {
+        return sym;
+    }
+    static string bar(string sym = __GENSYM__) {
+        return sym;
+    }
+    static string bar(int n, string sym = __GENSYM__) {
+        return sym;
+    }
+    
+    static int baz(int n = __LINE__) {
+        return n;
+    }
+    enum gensym = __GENSYM__;
+}
+class C12100 {
+    static string foo(string sym = __GENSYM__)() {
+        return sym;
+    }
+    static string foo(string sym = __GENSYM__)(int n) {
+        return sym;
+    }
+    static string bar(string sym = __GENSYM__) {
+        return sym;
+    }
+    static string bar(int n, string sym = __GENSYM__) {
+        return sym;
+    }
+    
+    static int baz(int n = __LINE__) {
+        return n;
+    }
+    enum gensym = __GENSYM__;
+}
+
+enum gs1 = __GENSYM__;
+enum gs2 = __GENSYM__;
+
+void test12100()
+{
+    static assert(gs1 != gs2);
+    static assert(S12100.gensym == S12100.gensym);
+    static assert(S12100.foo() != S12100.foo(3));
+    static assert(S12100.bar() != S12100.bar());
+    static assert(S12100.bar() != S12100.bar(3));
+    static assert(S12100.gensym != C12100.gensym);
+    static assert(C12100.gensym == C12100.gensym);
+    static assert(C12100.foo() != C12100.foo(3));
+    static assert(C12100.bar() != C12100.bar());
+    static assert(C12100.bar() != C12100.bar(3));
+    static assert(__GENSYM__ != __GENSYM__);
+    mixin("enum a = __GENSYM__;");
+    mixin("enum b = __GENSYM__;");
+    static assert(a != b);
+    
+    enum c = S12100.baz();
+    enum d = S12100.baz();
+    static assert(c != d);
+}


### PR DESCRIPTION
This PR fixes https://issues.dlang.org/show_bug.cgi?id=12100 by adding the construct __GENSYM__, which creates a unique string intended for use with template default parameters for e.g. Typedef:

```
struct Typedef(T, string cookie = \_\_GENSYM\_\_) {
    T payload;
    alias payload this;
}

alias T1 = Typedef!(int);
alias T2 = Typedef!(int);
static assert(!is(T1 == T2));
```
