### PR TITLE
Objective-C support check for OS X 32-bit

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -78,6 +78,7 @@ struct Param
     bool isFreeBSD;         // generate code for FreeBSD
     bool isOpenBSD;         // generate code for OpenBSD
     bool isSolaris;         // generate code for Solaris
+    bool hasObjectiveC;     // target supports Objective-C
     bool mscoff;            // for Win32: write COFF object files instead of OMF
     // 0: don't allow use of deprecated features
     // 1: silently allow use of deprecated features

--- a/src/globals.h
+++ b/src/globals.h
@@ -62,6 +62,7 @@ struct Param
     bool isFreeBSD;     // generate code for FreeBSD
     bool isOpenBSD;     // generate code for OpenBSD
     bool isSolaris;     // generate code for Solaris
+    bool hasObjectiveC; // target supports Objective-C
     bool mscoff;        // for Win32: write COFF object files instead of OMF
     // 0: don't allow use of deprecated features
     // 1: silently allow use of deprecated features

--- a/src/objc.d
+++ b/src/objc.d
@@ -141,13 +141,21 @@ struct Objc_FuncDeclaration
 // MARK: semantic
 extern (C++) void objc_ClassDeclaration_semantic_PASSinit_LINKobjc(ClassDeclaration cd)
 {
-    cd.objc.objc = true;
+    if (global.params.hasObjectiveC)
+        cd.objc.objc = true;
+    else
+        cd.error("Objective-C classes not supported");
 }
 
 extern (C++) void objc_InterfaceDeclaration_semantic_objcExtern(InterfaceDeclaration id, Scope* sc)
 {
     if (sc.linkage == LINKobjc)
-        id.objc.objc = true;
+    {
+        if (global.params.hasObjectiveC)
+            id.objc.objc = true;
+        else
+            id.error("Objective-C interfaces not supported");
+    }
 }
 
 // MARK: semantic
@@ -217,7 +225,11 @@ extern (C++) void objc_FuncDeclaration_semantic_checkLinkage(FuncDeclaration fd)
 // MARK: init
 extern (C++) void objc_tryMain_dObjc()
 {
-    VersionCondition.addPredefinedGlobalIdent("D_ObjectiveC");
+    if (global.params.isOSX && global.params.is64bit)
+    {
+        global.params.hasObjectiveC = true;
+        VersionCondition.addPredefinedGlobalIdent("D_ObjectiveC");
+    }
 }
 
 extern (C++) void objc_tryMain_init()

--- a/src/objc.h
+++ b/src/objc.h
@@ -32,7 +32,7 @@ struct ObjcSelector
     size_t stringlen;
     size_t paramCount;
 
-    static void init();
+    static void _init();
 
     ObjcSelector(const char *sv, size_t len, size_t pcount);
 


### PR DESCRIPTION
OS X Objective-C support is limited to 64-bit, so compile needs to be clean when -m32 is specified.

This change is needed for LDC because it needs to decide at compile time if Objective-C is supported or not based on the target triple.

See ldc-developers/ldc#1419
