### PR TITLE
remove dsout

### DIFF
--- a/src/backend/dt.c
+++ b/src/backend/dt.c
@@ -170,9 +170,6 @@ void init_common(symbol *s)
     {
         dt_t *dt = dt_calloc(DT_common);
         dt->DTazeros = size;
-#if SCPP
-        dsout += size;
-#endif
         s->Sdt = dt;
     }
 }
@@ -373,9 +370,6 @@ void DtBuilder::nzeros(unsigned size)
 
     dt_t *dt = dt_calloc(DT_azeros);
     dt->DTazeros = size;
-#if SCPP
-    dsout += size;
-#endif
 
     assert(!*pTail);
     *pTail = dt;

--- a/src/backend/global.h
+++ b/src/backend/global.h
@@ -79,9 +79,6 @@ extern block *block_last;
 extern int errcnt;
 extern regm_t fregsaved;
 
-#if SCPP
-extern targ_size_t dsout;              /* # of bytes actually output to data */
-#endif
 extern tym_t pointertype;              /* default data pointer type */
 
 // cg.c

--- a/src/backend/var.c
+++ b/src/backend/var.c
@@ -93,9 +93,6 @@ mangle_t varmangletab[LINK_MAXDIM] =
 };
 #endif
 
-targ_size_t     dsout = 0;      /* # of bytes actually output to data   */
-                                /* segment, used to pad for alignment   */
-
 /* File variables: */
 
 char *argv0;                    // argv[0] (program name)


### PR DESCRIPTION
Because globals are the spawn of satan.

(I also fixed DMC++ to not need this anymore.)
