### PR TITLE
Use build host D compiler real type

### DIFF
--- a/src/root/port.d
+++ b/src/root/port.d
@@ -55,20 +55,6 @@ extern (C++) struct Port
         static __gshared bool yl2xp1_supported = false;
     }
     static __gshared real snan;
-    static this()
-    {
-        /*
-         * Use a payload which is different from the machine NaN,
-         * so that uninitialised variables can be
-         * detected even if exceptions are disabled.
-         */
-        ushort* us = cast(ushort*)&snan;
-        us[0] = 0;
-        us[1] = 0;
-        us[2] = 0;
-        us[3] = 0xA000;
-        us[4] = 0x7FFF;
-    }
 
     static bool isNan(double r)
     {
@@ -85,9 +71,11 @@ extern (C++) struct Port
         return a % b;
     }
 
-    static real fequal(real a, real b)
+    static bool fequal(real a, real b)
     {
-        return memcmp(&a, &b, 10) == 0;
+        // don't compare pad bytes in extended precision
+        enum sz = (real.mant_dig == 64) ? 10 : real.sizeof;
+        return memcmp(&a, &b, sz) == 0;
     }
 
     static int memicmp(const char* s1, const char* s2, size_t n)


### PR DESCRIPTION
This change in the front-end helps out LDC when it is hosted on non-x86 platforms.

D needs to compile itself on non-x86 hosts where real type is likely something other than 80-bit extended precision.  The simplest approach is to use the existing D compiler real type as it must already have correct real.nan and snan intializer.

See ldc-developers/ldc#1349
