### PR TITLE
Fix issue 15922: DMD segfault in functionParameters on invalid code

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -1329,8 +1329,11 @@ public:
             //printf("FuncDeclaration::semantic3(%s '%s', sc = %p)\n", kind(), toChars(), sc);
             assert(0);
         }
-        if (isError(parent))
+        if (errors || isError(parent))
+        {
+            errors = true;
             return;
+        }
         //printf("FuncDeclaration::semantic3('%s.%s', %p, sc = %p, loc = %s)\n", parent->toChars(), toChars(), this, sc, loc.toChars());
         //fflush(stdout);
         //printf("storage class = x%x %x\n", sc->stc, storage_class);

--- a/test/fail_compilation/ice15922.d
+++ b/test/fail_compilation/ice15922.d
@@ -1,0 +1,26 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice15922.d(12): Error: function ice15922.ValidSparseDataStore!int.ValidSparseDataStore.correctedInsert!false.correctedInsert has no return statement, but is expected to return a value of type int
+fail_compilation/ice15922.d(10): Error: template instance ice15922.ValidSparseDataStore!int.ValidSparseDataStore.correctedInsert!false error instantiating
+fail_compilation/ice15922.d(15):        instantiated from here: ValidSparseDataStore!int
+fail_compilation/ice15922.d(3): Error: need 'this' for 'insert' of type 'pure @nogc @safe int()'
+fail_compilation/ice15922.d(15): Error: template instance ice15922.StorageAttributes!(ValidSparseDataStore!int) error instantiating
+---
+*/
+#line 1
+template StorageAttributes(Store)
+{
+    enum hasInsertMethod = Store.insert;
+    enum hasFullSlice = Store.init[];
+}
+struct ValidSparseDataStore(DataT)
+{
+    DataT insert()
+    {
+        correctedInsert!(false);
+    }
+    DataT correctedInsert(bool CorrectParents)() {}
+    auto opSlice() inout {}
+}
+alias BasicCubeT = StorageAttributes!(ValidSparseDataStore!int);


### PR DESCRIPTION
With this change an `inout` function with return type inference will
generate a forward reference error, as its parents has error so it
cannot safely infer its return type.
