### PR TITLE
Remove test based on undefined behavior

### DIFF
--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -318,6 +318,7 @@ const double d7 = 4;
 
 static assert(!is(typeof(bug7(cast(long)e7))));
 static assert(!is(typeof(bug7(cast(long)s7))));
+version (LDC) {} else // cast in LDC undefined result w/ x > long.max
 static assert(!is(typeof(bug7(cast(long)3.256679e30))));
 
 static assert(is(typeof(bug7(cast(long)d7))));


### PR DESCRIPTION
I am proposing that the removed test uses a cast that is undefined behavior: a truncated floating point value that cannot be represented in a long.

It may be that D wants this to be defined behavior, keeping the test, but then the compiler needs to change because current behavior comes from a C++ cast in constfold.c function `UnionExp Cast(Type *type, Type *to, Expression *e1)` now embedded in the D compiler.  And C++-11 section 4.9 "Floating-integral conversions" says such a cast in undefined behavior.

This comes up because the undefined behavior makes this test fail on ARM EABI (ldc-developers/ldc#1283).
