### PR TITLE
fix Issue 15629 - [REG2.066.0] wrong code with '-O -inline' but correct with '-O'

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -4526,7 +4526,7 @@ code *cdabs( elem *e, regm_t *pretregs)
         if (!I16 && sz == REGSIZE)
         {   regm_t scratch = allregs & ~retregs;
             reg = findreg(retregs);
-            cg = allocreg(&scratch,&r,TYint);
+            cg = cat(cg, allocreg(&scratch,&r,TYint));
             cg = cat(cg,getregs(retregs));
             cg = genmovreg(cg,r,reg);                                   // MOV r,reg
             cg = genc2(cg,0xC1,modregrmx(3,7,r),REGSIZE * 8 - 1);       // SAR r,31/63

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1437,6 +1437,23 @@ void test15861()
 
 ////////////////////////////////////////////////////////////////////////
 
+// https://issues.dlang.org/show_bug.cgi?id=15629 comment 3
+// -O
+
+void test15629()
+{
+    int[] a = [3];
+    int value = a[0] >= 0 ? a[0] : -a[0];
+    assert(a[0] == 3);
+    writeln(value, a);
+}
+
+void writeln(int v, int[] a)
+{
+}
+
+////////////////////////////////////////////////////////////////////////
+ 
 int main()
 {
     testgoto();
@@ -1486,6 +1503,7 @@ int main()
     test14987();
     test15272();
     test15861();
+    test15629();
     printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15629
