### PR TITLE
Fix test to support platforms with strict alignment

### DIFF
--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -6799,7 +6799,9 @@ void test9477()
             assert(order == 2);
         }
 
-    ubyte[64] a1, a2;
+    // need largest natural alignment to avoid unaligned access on
+    // some architectures, double in this case.
+    align(8) ubyte[64] a1, a2;
     foreach (T; Tuple9477!(void, ubyte, ushort, uint, ulong, char, wchar, dchar, float, double))
     {
         auto s1 = cast(T[])(a1[]);


### PR DESCRIPTION
Fix test so buffer has alignment of type it will be cast to.  This prevents potential bus errors on CPUs that need strict alignment (e.g. some ARMs, SPARC).  Reference ldc-developers/ldc#1283 with discussion on runnable/xtest46.d.
