### PR TITLE
do not add "const" to virtual override functions in C++ headers

### DIFF
--- a/src/mtype.h
+++ b/src/mtype.h
@@ -396,20 +396,20 @@ public:
     TypeBasic(TY ty);
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc) const;
+    d_uns64 size(Loc loc) /*const*/;
     unsigned alignsize();
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool isintegral();
-    bool isfloating() const;
-    bool isreal() const;
-    bool isimaginary() const;
-    bool iscomplex() const;
-    bool isscalar() const;
-    bool isunsigned() const;
+    bool isfloating() /*const*/;
+    bool isreal() /*const*/;
+    bool isimaginary() /*const*/;
+    bool iscomplex() /*const*/;
+    bool isscalar() /*const*/;
+    bool isunsigned() /*const*/;
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) const;
+    bool isZeroInit(Loc loc) /*const*/;
 
     // For eliminating dynamic_cast
     TypeBasic *isTypeBasic();
@@ -433,7 +433,7 @@ public:
     bool isfloating();
     bool isscalar();
     bool isunsigned();
-    bool isBoolean() const;
+    bool isBoolean() /*const*/;
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
@@ -487,17 +487,17 @@ public:
     TypeDArray(Type *t);
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc) const;
-    unsigned alignsize() const;
+    d_uns64 size(Loc loc) /*const*/;
+    unsigned alignsize() /*const*/;
     Type *semantic(Loc loc, Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool isString();
-    bool isZeroInit(Loc loc) const;
-    bool isBoolean() const;
+    bool isZeroInit(Loc loc) /*const*/;
+    bool isBoolean() /*const*/;
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
-    bool hasPointers() const;
+    bool hasPointers() /*const*/;
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -518,10 +518,10 @@ public:
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) const;
-    bool isBoolean() const;
+    bool isZeroInit(Loc loc) /*const*/;
+    bool isBoolean() /*const*/;
     Expression *toExpression();
-    bool hasPointers() const;
+    bool hasPointers() /*const*/;
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
 
@@ -535,13 +535,13 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
-    d_uns64 size(Loc loc) const;
+    d_uns64 size(Loc loc) /*const*/;
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
-    bool isscalar() const;
+    bool isscalar() /*const*/;
     Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) const;
-    bool hasPointers() const;
+    bool isZeroInit(Loc loc) /*const*/;
+    bool hasPointers() /*const*/;
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -553,10 +553,10 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
-    d_uns64 size(Loc loc) const;
+    d_uns64 size(Loc loc) /*const*/;
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) const;
+    bool isZeroInit(Loc loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -632,7 +632,7 @@ public:
     MATCH callMatch(Type *tthis, Expressions *toargs, int flag = 0);
     bool checkRetType(Loc loc);
 
-    Expression *defaultInit(Loc loc) const;
+    Expression *defaultInit(Loc loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -645,14 +645,14 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
-    d_uns64 size(Loc loc) const;
-    unsigned alignsize() const;
+    d_uns64 size(Loc loc) /*const*/;
+    unsigned alignsize() /*const*/;
     MATCH implicitConvTo(Type *to);
     Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) const;
-    bool isBoolean() const;
+    bool isZeroInit(Loc loc) /*const*/;
+    bool isBoolean() /*const*/;
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    bool hasPointers() const;
+    bool hasPointers() /*const*/;
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -772,10 +772,10 @@ public:
     structalign_t alignment();
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
-    bool isZeroInit(Loc loc) const;
+    bool isZeroInit(Loc loc) /*const*/;
     bool isAssignable();
-    bool isBoolean() const;
-    bool needsDestruction() const;
+    bool isBoolean() /*const*/;
+    bool needsDestruction() /*const*/;
     bool needsNested();
     bool hasPointers();
     MATCH implicitConvTo(Type *to);
@@ -831,7 +831,7 @@ public:
 
     TypeClass(ClassDeclaration *sym);
     const char *kind();
-    d_uns64 size(Loc loc) const;
+    d_uns64 size(Loc loc) /*const*/;
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
     Dsymbol *toDsymbol(Scope *sc);
@@ -843,10 +843,10 @@ public:
     unsigned char deduceWild(Type *t, bool isRef);
     Type *toHeadMutable();
     Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) const;
-    bool isscope() const;
-    bool isBoolean() const;
-    bool hasPointers() const;
+    bool isZeroInit(Loc loc) /*const*/;
+    bool isscope() /*const*/;
+    bool isBoolean() /*const*/;
+    bool hasPointers() /*const*/;
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -893,10 +893,10 @@ public:
 
     Type *syntaxCopy();
     MATCH implicitConvTo(Type *to);
-    bool isBoolean() const;
+    bool isBoolean() /*const*/;
 
-    d_uns64 size(Loc loc) const;
-    Expression *defaultInit(Loc loc) const;
+    d_uns64 size(Loc loc) /*const*/;
+    Expression *defaultInit(Loc loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
 };
 


### PR DESCRIPTION
In C++, adding const to a virtual member function does not override the member function of the base class. The dmd headers do not repeat "virtual", so a new non-virtual member function is added.

Removing "const" from the declarations might cause inconsistent mangling, but calling these functions from C++ (as LDC does for a few, see https://github.com/ldc-developers/ldc/pull/1421) is probably expecting the virtual call anyway (which does not need any mangled symbols).

With enough type information the optimizer might still attempt to call the virtual function directly with wrong mangling, but with this PR the failure is not silent anymore.
