### PR TITLE
Improve FuncExp: Do nothing if type is already set in FuncExp.semantic

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -6761,55 +6761,56 @@ public:
             if (fd.treq)
                 printf("  treq = %s\n", fd.treq.toChars());
         }
+        if (type)
+            return this;
+
         Expression e = this;
 
         sc = sc.push(); // just create new scope
         sc.flags &= ~SCOPEctfe; // temporary stop CTFE
         sc.protection = Prot(PROTpublic); // Bugzilla 12506
 
-        if (!type || type == Type.tvoid)
+        /* fd.treq might be incomplete type,
+         * so should not semantic it.
+         * void foo(T)(T delegate(int) dg){}
+         * foo(a=>a); // in IFTI, treq == T delegate(int)
+         */
+        //if (fd.treq)
+        //    fd.treq = fd.treq.semantic(loc, sc);
+
+        genIdent(sc);
+
+        // Set target of return type inference
+        if (fd.treq && !fd.type.nextOf())
         {
-            /* fd->treq might be incomplete type,
-             * so should not semantic it.
-             * void foo(T)(T delegate(int) dg){}
-             * foo(a=>a); // in IFTI, treq == T delegate(int)
-             */
-            //if (fd->treq)
-            //    fd->treq = fd->treq->semantic(loc, sc);
-
-            genIdent(sc);
-
-            // Set target of return type inference
-            if (fd.treq && !fd.type.nextOf())
+            if (fd.treq.ty == Tdelegate ||
+                (fd.treq.ty == Tpointer && fd.treq.nextOf().ty == Tfunction))
             {
-                TypeFunction tfv = null;
-                if (fd.treq.ty == Tdelegate || (fd.treq.ty == Tpointer && fd.treq.nextOf().ty == Tfunction))
-                    tfv = cast(TypeFunction)fd.treq.nextOf();
-                if (tfv)
-                {
-                    TypeFunction tfl = cast(TypeFunction)fd.type;
-                    tfl.next = tfv.nextOf();
-                }
+                auto tfv = cast(TypeFunction)fd.treq.nextOf();
+                auto tfl = cast(TypeFunction)fd.type;
+                tfl.next = tfv.nextOf();
             }
+        }
+        //printf("td = %p, treq = %p\n", td, fd.treq);
 
-            //printf("td = %p, treq = %p\n", td, fd->treq);
-            if (td)
+        if (td) // this is a template lambda
+        {
+            assert(td.parameters && td.parameters.dim);
+            td.semantic(sc);
+            type = Type.tvoid; // temporary type
+
+            if (fd.treq) // defer type determination
             {
-                assert(td.parameters && td.parameters.dim);
-                td.semantic(sc);
-                type = Type.tvoid; // temporary type
-
-                if (fd.treq) // defer type determination
-                {
-                    FuncExp fe;
-                    if (matchType(fd.treq, sc, &fe) > MATCHnomatch)
-                        e = fe;
-                    else
-                        e = new ErrorExp();
-                }
-                goto Ldone;
+                FuncExp fe;
+                if (matchType(fd.treq, sc, &fe) > MATCHnomatch)
+                    e = fe;
+                else
+                    e = new ErrorExp();
             }
+            goto Ldone;
+        }
 
+        {
             uint olderrors = global.errors;
             fd.semantic(sc);
             if (olderrors == global.errors)
@@ -6825,38 +6826,38 @@ public:
                 e = new ErrorExp();
                 goto Ldone;
             }
-
-            // Type is a "delegate to" or "pointer to" the function literal
-            if ((fd.isNested() && fd.tok == TOKdelegate) || (tok == TOKreserved && fd.treq && fd.treq.ty == Tdelegate))
-            {
-                type = new TypeDelegate(fd.type);
-                type = type.semantic(loc, sc);
-
-                fd.tok = TOKdelegate;
-            }
-            else
-            {
-                type = new TypePointer(fd.type);
-                type = type.semantic(loc, sc);
-                //type = fd->type->pointerTo();
-
-                /* A lambda expression deduced to function pointer might become
-                 * to a delegate literal implicitly.
-                 *
-                 *   auto foo(void function() fp) { return 1; }
-                 *   assert(foo({}) == 1);
-                 *
-                 * So, should keep fd->tok == TOKreserve if fd->treq == NULL.
-                 */
-                if (fd.treq && fd.treq.ty == Tpointer)
-                {
-                    // change to non-nested
-                    fd.tok = TOKfunction;
-                    fd.vthis = null;
-                }
-            }
-            fd.tookAddressOf++;
         }
+
+        // Type is a "delegate to" or "pointer to" the function literal
+        if ((fd.isNested() && fd.tok == TOKdelegate) ||
+            (tok == TOKreserved && fd.treq && fd.treq.ty == Tdelegate))
+        {
+            type = new TypeDelegate(fd.type);
+            type = type.semantic(loc, sc);
+
+            fd.tok = TOKdelegate;
+        }
+        else
+        {
+            type = new TypePointer(fd.type);
+            type = type.semantic(loc, sc);
+
+            /* A lambda expression deduced to function pointer might become
+             * to a delegate literal implicitly.
+             *
+             *   auto foo(void function() fp) { return 1; }
+             *   assert(foo({}) == 1);
+             *
+             * So, have to keep fd.tok == TOKreserve if fd.treq is given.
+             */
+            if (fd.treq && fd.treq.ty == Tpointer)
+            {
+                // change to non-nested
+                fd.tok = TOKfunction;
+                fd.vthis = null;
+            }
+        }
+        fd.tookAddressOf++;
 
     Ldone:
         sc = sc.pop();


### PR DESCRIPTION
It was a hack when I started to implement complete template lambda behavior, but
it's already replaced with the `FuncExp.matchType` call from `dcast.d`, so
we can follow the usual pattern in `Expression.semantic`.
