### PR TITLE
Allow creation of static arrays with new

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -6053,6 +6053,18 @@ public:
                 tb = (cast(TypeDArray)tb).next.toBasetype();
             }
         }
+        else if (tb.ty == Tsarray)
+        {
+            if (!nargs)
+            {
+                type = type.pointerTo();
+            }
+            else
+            {
+                error("no arguments expected for construction of %s", type.toChars());
+                return new ErrorExp();
+            }
+        }
         else if (tb.isscalar())
         {
             if (!nargs)

--- a/test/compilable/newint10.d
+++ b/test/compilable/newint10.d
@@ -1,0 +1,6 @@
+unittest
+{
+    alias T = int[10];
+    auto a = new T;
+    static assert(is(typeof(a) == int[10]*));
+}


### PR DESCRIPTION
Related to https://issues.dlang.org/show_bug.cgi?id=10879 and thus https://github.com/dlang/phobos/pull/4204.

This PR simply allows the following code, which was previously illegal:

```
    alias T = int[10];
    auto a = new T;
    static assert(is(typeof(a) == int[10]*));
```

This code used to give the error "new can only create structs, dynamic arrays or class objects, not int[10]'s".
