### PR TITLE
refactor: switch to D lambda, replace recursion with loop

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -7981,19 +7981,18 @@ public:
              *  - semantic3 pass will get called on the instance members.
              *  - codegen pass will get a selection chance to do/skip it.
              */
-            struct N
+            static Dsymbol getStrictEnclosing(TemplateInstance ti)
             {
-                extern (C++) static Dsymbol getStrictEnclosing(TemplateInstance ti)
+                do
                 {
                     if (ti.enclosing)
                         return ti.enclosing;
-                    if (TemplateInstance tix = ti.tempdecl.isInstantiated())
-                        return getStrictEnclosing(tix);
-                    return null;
-                }
+                    ti = ti.tempdecl.isInstantiated();
+                } while (ti);
+                return null;
             }
 
-            Dsymbol enc = N.getStrictEnclosing(this);
+            Dsymbol enc = getStrictEnclosing(this);
             // insert target is made stable by using the module
             // where tempdecl is declared.
             mi = (enc ? enc : tempdecl).getModule();


### PR DESCRIPTION
Use of C++98 style lambdas is no longer necessary.

Also add note about location of https://issues.dlang.org/show_bug.cgi?id=15323
