### PR TITLE
Add win64.mak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ src/vcbuild/x64
 *.sdf
 *.opensdf
 *.user
+*.ilk
 ipch
 
 # Xcode files

--- a/src/vcbuild/msvc-dmc.d
+++ b/src/vcbuild/msvc-dmc.d
@@ -15,6 +15,7 @@ int main(string[] args)
         environment.get("VCINSTALLDIR", `\Program Files (x86)\Microsoft Visual Studio 10.0\VC\`)
             .buildPath("bin", "amd64", "cl.exe"));
     string[] newArgs = [cl];
+    newArgs ~= "/nologo";
     newArgs ~= `/Ivcbuild`;
     newArgs ~= `/Iroot`;
     newArgs ~= `/FIwarnings.h`;
@@ -24,20 +25,24 @@ int main(string[] args)
     {
         switch (arg)
         {
+            case "-Ae": // "enable exception handling"
+                newArgs ~= "/EHa";
+                break;
+            case "-c": // "skip the link, do compile only"
+                newArgs ~= "/c";
+                compilingOnly = true;
+                break;
             case "-cpp": // "source files are C++"
                 newArgs ~= "/TP";
                 break;
             case "-e": // "show results of preprocessor"
                 break;
+            case "-g": // "generate debug info"
             case "-gl": // "debug line numbers only"
                 newArgs ~= "/Zi";
                 break;
             case "-wx": // "treat warnings as errors"
                 newArgs ~= "/WX";
-                break;
-            case "-c": // "skip the link, do compile only"
-                newArgs ~= "/c";
-                compilingOnly = true;
                 break;
             default:
                 if (arg.startsWith("-I")) // "#include file search path"

--- a/src/vcbuild/msvc-dmc.d
+++ b/src/vcbuild/msvc-dmc.d
@@ -1,0 +1,62 @@
+/// Wrapper which accepts DMC command-line syntax
+/// and passes the transformed options to a MSVC cl.exe.
+module msvc_dmc;
+
+import std.algorithm.searching;
+import std.array;
+import std.file;
+import std.path;
+import std.process;
+import std.stdio;
+
+int main(string[] args)
+{
+    auto cl = environment.get("MSVC_CC",
+        environment.get("VCINSTALLDIR", `\Program Files (x86)\Microsoft Visual Studio 10.0\VC\`)
+            .buildPath("bin", "amd64", "cl.exe"));
+    string[] newArgs = [cl];
+    newArgs ~= `/Ivcbuild`;
+    newArgs ~= `/Iroot`;
+    newArgs ~= `/FIwarnings.h`;
+    bool compilingOnly;
+
+    foreach (arg; args[1..$])
+    {
+        switch (arg)
+        {
+            case "-cpp": // "source files are C++"
+                newArgs ~= "/TP";
+                break;
+            case "-e": // "show results of preprocessor"
+                break;
+            case "-gl": // "debug line numbers only"
+                newArgs ~= "/Zi";
+                break;
+            case "-wx": // "treat warnings as errors"
+                newArgs ~= "/WX";
+                break;
+            case "-c": // "skip the link, do compile only"
+                newArgs ~= "/c";
+                compilingOnly = true;
+                break;
+            default:
+                if (arg.startsWith("-I")) // "#include file search path"
+                {
+                    foreach (path; arg[2..$].split(";"))
+                        if (path != `\dm\include`)
+                            newArgs ~= "/I" ~ path;
+                }
+                else
+                if (arg.startsWith("-o")) // "output filename"
+                    newArgs ~= "/F" ~ (compilingOnly ? "o" : "e") ~ arg[2..$];
+                else
+                if (arg[0] != '/' && arg[0] != '-' && !exists(arg) && exists(arg ~ ".c"))
+                    newArgs ~= arg ~ ".c";
+                else
+                    newArgs ~= arg;
+                break;
+        }
+    }
+    stderr.writeln(escapeShellCommand(newArgs));
+    return spawnProcess(newArgs).wait();
+}

--- a/src/vcbuild/msvc-lib.d
+++ b/src/vcbuild/msvc-lib.d
@@ -1,0 +1,37 @@
+/// Wrapper which accepts DM lib.exe command-line syntax
+/// and passes the transformed options to a MSVC lib.exe.
+module msvc_lib;
+
+import std.algorithm.searching;
+import std.array;
+import std.file;
+import std.path;
+import std.process;
+import std.stdio;
+
+int main(string[] args)
+{
+    auto lib = environment.get("MSVC_AR",
+        environment.get("VCINSTALLDIR", `\Program Files (x86)\Microsoft Visual Studio 10.0\VC\`)
+            .buildPath("bin", "amd64", "lib.exe"));
+    string[] newArgs = [lib];
+    foreach (arg; args[1..$])
+    {
+        switch (arg)
+        {
+            case "-n": // "do not create backup file"
+            case "-c": // "create"
+                break;
+            default:
+                if (arg.startsWith("-p")) // "set page size to nnn (a power of 2)"
+                    continue;
+                if (arg.endsWith(".lib"))
+                    newArgs ~= "/OUT:" ~ arg;
+                else
+                    newArgs ~= arg;
+                break;
+        }
+    }
+    stderr.writeln(escapeShellCommand(newArgs));
+    return spawnProcess(newArgs).wait();
+}

--- a/src/vcbuild/msvc-lib.d
+++ b/src/vcbuild/msvc-lib.d
@@ -15,6 +15,8 @@ int main(string[] args)
         environment.get("VCINSTALLDIR", `\Program Files (x86)\Microsoft Visual Studio 10.0\VC\`)
             .buildPath("bin", "amd64", "lib.exe"));
     string[] newArgs = [lib];
+    newArgs ~= "/NOLOGO";
+
     foreach (arg; args[1..$])
     {
         switch (arg)

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -101,6 +101,8 @@ ZIP=zip32
 SCP=$(CP)
 # PVS-Studio command line executable
 PVS="c:\Program Files (x86)\PVS-Studio\x64\PVS-Studio"
+# 64-bit MS assembler
+ML=ml64
 
 ##### User configuration switches
 
@@ -119,6 +121,8 @@ LFLAGS=
 BFLAGS=
 # D Optimizer flags
 DOPT=
+# D Model flags
+DMODEL=
 # D Debug flags
 DDEBUG=-debug -g
 
@@ -129,10 +133,10 @@ CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DTARGET_WINDOS=1 -DDM_TARGET
 # Compile flags for modules with backend/toolkit dependencies
 MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
 # D compile flags
-DFLAGS=$(DOPT) $(DDEBUG) -wi
+DFLAGS=$(DOPT) $(DMODEL) $(DDEBUG) -wi
 
 # Recursive make
-DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) HOST_DC="$(HOST_DC)"
+DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) HOST_DC="$(HOST_DC)" DMODEL=$(DMODEL) CC="$(CC)" LIB="$(LIB)" OBJ_MSVC="$(OBJ_MSVC)"
 
 ############################### Rule Variables ###############################
 
@@ -170,7 +174,6 @@ BACKOBJ= go.obj gdag.obj gother.obj gflow.obj gloop.obj var.obj el.obj \
 	ti_pvoid.obj mscoffobj.obj pdata.obj cv8.obj backconfig.obj \
 	divcoeff.obj dwarf.obj \
 	ph2.obj util2.obj eh.obj tk.obj \
-
 
 # Root package
 ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/file.d $(ROOT)/filename.d	\
@@ -277,8 +280,8 @@ unittest:
 glue.lib : $(GLUEOBJ)
 	$(LIB) -p512 -n -c glue.lib $(GLUEOBJ)
 
-backend.lib : $(BACKOBJ)
-	$(LIB) -p512 -n -c backend.lib $(BACKOBJ)
+backend.lib : $(BACKOBJ) $(OBJ_MSVC)
+	$(LIB) -p512 -n -c backend.lib $(BACKOBJ) $(OBJ_MSVC)
 
 LIBS= glue.lib backend.lib
 
@@ -538,6 +541,9 @@ ptrntab.obj : $C\iasm.h $C\ptrntab.c
 rtlsym.obj : $C\rtlsym.h $C\rtlsym.c
 	$(CC) -c $(MFLAGS) $C\rtlsym
 
+strtold.obj : $C\strtold.c
+	$(CC) -c -cpp $C\strtold
+
 ti_achar.obj : $C\tinfo.h $C\ti_achar.c
 	$(CC) -c $(MFLAGS) -I. $C\ti_achar
 
@@ -581,6 +587,13 @@ tk.obj : tk.c
 # Root
 newdelete.obj : $(ROOT)\newdelete.c
 	$(CC) -c $(CFLAGS) $(ROOT)\newdelete.c
+
+# Win64
+longdouble.obj : $(ROOT)\longdouble.c
+	$(CC) -c $(CFLAGS) $(ROOT)\longdouble.c
+
+ldfpu.obj : vcbuild\ldfpu.asm
+	$(ML) -c -Zi -Foldfpu.obj vcbuild\ldfpu.asm
 
 ############################## Generated Rules ###############################
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -136,7 +136,7 @@ MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_WINDOS=1 -DDM_TARG
 DFLAGS=$(DOPT) $(DMODEL) $(DDEBUG) -wi
 
 # Recursive make
-DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) HOST_DC="$(HOST_DC)" DMODEL=$(DMODEL) CC="$(CC)" LIB="$(LIB)" OBJ_MSVC="$(OBJ_MSVC)"
+DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$(HOST_DC)" DMODEL=$(DMODEL) CC="$(CC)" LIB="$(LIB)" OBJ_MSVC="$(OBJ_MSVC)"
 
 ############################### Rule Variables ###############################
 

--- a/src/win64.mak
+++ b/src/win64.mak
@@ -1,0 +1,47 @@
+#_ win64.mak
+#
+# Supports same targets as win32.mak.
+
+############################### Configuration ################################
+
+MAKE=make
+HOST_DC=dmd
+
+################################### Rules ####################################
+
+.d.exe:
+	$(HOST_DC) -of$@ $<
+
+OBJ_MSVC=strtold.obj longdouble.obj ldfpu.obj
+DEPENDENCIES=vcbuild\msvc-dmc.exe vcbuild\msvc-lib.exe
+
+MAKE_WIN32=$(MAKE) -f win32.mak DMODEL=-m64 HOST_DC=$(HOST_DC) CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
+
+################################## Targets ###################################
+
+defaulttarget : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+release : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+trace : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+clean : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+install : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+install-clean : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+zip : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+scp : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+dmd : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+debdmd : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+reldmd : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+detab : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@
+tolf : $(DEPENDENCIES)
+	$(MAKE_WIN32) $@

--- a/src/win64.mak
+++ b/src/win64.mak
@@ -6,6 +6,7 @@
 
 MAKE=make
 HOST_DC=dmd
+DMODEL=-m64
 
 ################################### Rules ####################################
 
@@ -15,7 +16,7 @@ HOST_DC=dmd
 OBJ_MSVC=strtold.obj longdouble.obj ldfpu.obj
 DEPENDENCIES=vcbuild\msvc-dmc.exe vcbuild\msvc-lib.exe
 
-MAKE_WIN32=$(MAKE) -f win32.mak DMODEL=-m64 HOST_DC=$(HOST_DC) CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
+MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" DMODEL=$(DMODEL) HOST_DC=$(HOST_DC) OBJ_MSVC="$(OBJ_MSVC)" CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
 
 ################################## Targets ###################################
 
@@ -25,7 +26,8 @@ release : $(DEPENDENCIES)
 	$(MAKE_WIN32) $@
 trace : $(DEPENDENCIES)
 	$(MAKE_WIN32) $@
-clean : $(DEPENDENCIES)
+clean :
+	del $(DEPENDENCIES) dmd.pdb
 	$(MAKE_WIN32) $@
 install : $(DEPENDENCIES)
 	$(MAKE_WIN32) $@


### PR DESCRIPTION
Add support for building a 64-bit DMD using Microsoft Visual C++ without msbuild or needing to duplicate the project structure.

This is done by adding wrappers for the DigitalMars C compiler and librarian, which translate the command-line parameters to the Microsoft equivalents.

With this PR, I can build a 64-bit dmd.exe using just the following commands:

```
"C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" amd64
make -f win64.mak "HOST_DC=C:\Downloads\!dmd\dmd.2.068.2\dmd2\windows\bin\dmd.exe" clean release
```

This change is needed for Digger be able to to reliably build a 64-bit DMD as well, because the msbuild solutions currently available always use the system-wide MSVC install, ignoring environment variables.

CC @rainers 
