### PR TITLE
Issue 11169 - __traits(isAbstractClass) prematurely sets a class to be abstract

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -58,6 +58,13 @@ enum StructPOD
     ISPODfwd,           // POD not yet computed
 };
 
+enum Abstract
+{
+    ABSfwdref = 0,      // whether an abstract class is not yet computed
+    ABSyes,             // is abstract class
+    ABSno,              // is not abstract class
+};
+
 FuncDeclaration *hasIdentityOpAssign(AggregateDeclaration *ad, Scope *sc);
 FuncDeclaration *buildOpAssign(StructDeclaration *sd, Scope *sc);
 bool needOpEquals(StructDeclaration *sd);
@@ -273,7 +280,7 @@ public:
     bool com;                           // true if this is a COM class (meaning it derives from IUnknown)
     bool cpp;                           // true if this is a C++ interface
     bool isscope;                       // true if this is a scope class
-    bool isabstract;                    // true if abstract class
+    Abstract isabstract;                // 0: fwdref, 1: is abstract class, 2: not abstract
     int inuse;                          // to prevent recursive attempts
     Baseok baseok;                      // set the progress of base classes resolving
     Objc_ClassDeclaration objc;

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -595,6 +595,17 @@ public:
         return toAlias();
     }
 
+    /*********************************
+     * Iterate this dsymbol or members of this scoped dsymbol, then
+     * call `fp` with the found symbol and `param`.
+     * Params:
+     *  fp = function pointer to process the iterated symbol.
+     *       If it returns nonzero, the iteration will be aborted.
+     *  param = a parameter passed to fp.
+     * Returns:
+     *  nonzero if the iteration is aborted by the return value of fp,
+     *  or 0 if it's completed.
+     */
     int apply(Dsymbol_apply_ft_t fp, void* param)
     {
         return (*fp)(this, param);

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -8700,6 +8700,8 @@ public:
 
     override int apply(Dsymbol_apply_ft_t fp, void* param)
     {
+        if (_scope) // if fwd reference
+            semantic(null); // try to resolve it
         if (members)
         {
             for (size_t i = 0; i < members.dim; i++)

--- a/src/func.d
+++ b/src/func.d
@@ -558,14 +558,14 @@ public:
         assert(semanticRun <= PASSsemantic);
         semanticRun = PASSsemantic;
 
-        parent = sc.parent;
-        Dsymbol parent = toParent();
-
         if (_scope)
         {
             sc = _scope;
             _scope = null;
         }
+
+        parent = sc.parent;
+        Dsymbol parent = toParent();
 
         foverrides.setDim(0); // reset in case semantic() is being retried for this function
 
@@ -884,7 +884,7 @@ public:
             }
 
             if (storage_class & STCabstract)
-                cd.isabstract = true;
+                cd.isabstract = ABSyes;
 
             // if static function, do not put in vtbl[]
             if (!isVirtual())

--- a/test/compilable/test11169.d
+++ b/test/compilable/test11169.d
@@ -1,0 +1,45 @@
+// REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+1: false
+2: true
+3: true
+---
+*/
+
+class A
+{
+    abstract void foo();
+}
+
+template MixinAbstractBar() { abstract void bar(); }
+
+class B1 : A
+{
+    // Use pragma instead of static assert, in order to evaluate
+    // __traits during ClassDeclaration.semantic().
+    pragma(msg, "1: ", __traits(isAbstractClass, typeof(this)));
+    override void foo() {}
+}
+
+class B2 : A
+{
+    pragma(msg, "2: ", __traits(isAbstractClass, typeof(this)));
+    override void foo() {}
+    abstract void bar();
+}
+
+class B3 : A
+{
+    pragma(msg, "3: ", __traits(isAbstractClass, typeof(this)));
+    override void foo() {}
+    mixin MixinAbstractBar!();
+}
+
+void main()
+{
+    static assert( __traits(compiles, { auto b = new B1(); }));
+    static assert(!__traits(compiles, { auto b = new B2(); }));
+    static assert(!__traits(compiles, { auto b = new B3(); }));
+}

--- a/test/fail_compilation/fail11169.d
+++ b/test/fail_compilation/fail11169.d
@@ -1,0 +1,28 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11169.d(16): Error: error evaluating static if expression
+---
+*/
+
+class A
+{
+    abstract void foo();
+}
+
+class B : A
+{
+    // __traits(isAbstractClass) is not usable in static if condition.
+    static if (__traits(isAbstractClass, typeof(this)))
+    {
+    }
+
+    override void foo()
+    {
+    }
+}
+
+void main()
+{
+    B b = new B();
+}


### PR DESCRIPTION
`__traits(isAbstractClass)` should resolve forward references of all class member functions, in order to return stable result.
