### PR TITLE
Cleanup: Remove unneeded code handling union fields in VarDeclaration.semantic2

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -130,8 +130,8 @@ public:
         Scope* sc2 = sc.push(this);
         sc2.stc &= STCsafe | STCtrusted | STCsystem;
         sc2.parent = this;
-        //if (isUnionDeclaration())     // TODO
-        //    sc2.inunion = 1;
+        if (isUnionDeclaration())
+            sc2.inunion = 1;
         sc2.protection = Prot(PROTpublic);
         sc2.explicitProtection = 0;
         sc2.structalign = STRUCTALIGN_DEFAULT;

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1793,30 +1793,7 @@ public:
         if (sem < SemanticDone && inuse)
             return;
         //printf("VarDeclaration::semantic2('%s')\n", toChars());
-        // Inside unions, default to void initializers
-        if (!_init && sc.inunion && !toParent().isFuncDeclaration())
-        {
-            AggregateDeclaration aad = parent.isAggregateDeclaration();
-            if (aad)
-            {
-                if (aad.fields[0] == this)
-                {
-                    int hasinit = 0;
-                    for (size_t i = 1; i < aad.fields.dim; i++)
-                    {
-                        if (aad.fields[i]._init && !aad.fields[i]._init.isVoidInitializer())
-                        {
-                            hasinit = 1;
-                            break;
-                        }
-                    }
-                    if (!hasinit)
-                        _init = new ExpInitializer(loc, type.defaultInitLiteral(loc));
-                }
-                else
-                    _init = new VoidInitializer(loc);
-            }
-        }
+
         if (_init && !toParent().isFuncDeclaration())
         {
             inuse++;


### PR DESCRIPTION
This small cleanup is correct from these reasons:
- There is a known bug that Scope.inunion has not been set properly (See 'TODO' comment in AggregateDeclaration.semantic2). Because of that, the deleted code had not been working since old ages.
- Now correct initializers for overlapped fields are well handled by `AggregateDeclaration.fill`, or `membersToDt` in `todt.c`.

---

After that, we can properly set `Scope.inunion` from `AggregateDeclaration.semantic2`

Because, by removing dead code in `VarDeclaration.semantic2`, we no longer need to worry about any bad effects caused by that code.
