### PR TITLE
Cleanup: Replace VarDeclaration.sem with VarDeclaration.semanticRun

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -243,7 +243,7 @@ public:
 
             if (v.storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCctfe | STCtemplateparameter))
                 return 0;
-            if (!v.isField() || v.sem < SemanticDone)
+            if (!v.isField() || v.semanticRun < PASSsemanticdone)
                 return 1;   // unresolvable forward reference
 
             auto ad = cast(AggregateDeclaration)param;
@@ -722,7 +722,7 @@ public:
             vthis.parent = this;
             vthis.protection = Prot(PROTpublic);
             vthis.alignment = t.alignment();
-            vthis.sem = SemanticDone;
+            vthis.semanticRun = PASSsemanticdone;
 
             if (sizeok == SIZEOKfwd)
                 fields.push(vthis);

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -111,14 +111,6 @@ int overloadApply(Dsymbol *fstart, void *param, int (*fp)(void *, Dsymbol *));
 
 void ObjectNotFound(Identifier *id);
 
-enum Semantic
-{
-    SemanticStart,      // semantic has not been run
-    SemanticIn,         // semantic() is in progress
-    SemanticDone,       // semantic() has been run
-    Semantic2Done,      // semantic2() has been run
-};
-
 /**************************************************************/
 
 class Declaration : public Dsymbol
@@ -131,7 +123,6 @@ public:
     LINK linkage;
     int inuse;                  // used to detect cycles
     const char *mangleOverride;      // overridden symbol with pragma(mangle, "...")
-    Semantic sem;
 
     Declaration(Identifier *id);
     void semantic(Scope *sc);

--- a/src/func.d
+++ b/src/func.d
@@ -3642,7 +3642,7 @@ public:
             // set before the semantic() for checkNestedReference()
             vresult.parent = this;
         }
-        if (sc && vresult.sem == SemanticStart)
+        if (sc && vresult.semanticRun == PASSinit)
         {
             assert(type.ty == Tfunction);
             TypeFunction tf = cast(TypeFunction)type;

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7141,7 +7141,7 @@ public:
                         *pe = new ErrorExp();
                         return;
                     }
-                    if (v.sem < SemanticDone && v._scope)
+                    if (v.semanticRun < PASSsemanticdone && v._scope)
                         v.semantic(null);
                 }
                 assert(v.type); // Bugzilla 14642

--- a/src/todt.c
+++ b/src/todt.c
@@ -790,7 +790,7 @@ static void membersToDt(AggregateDeclaration *ad, DtBuilder& dtb,
                  * As a workaround for the issue 9057, have to resolve forward reference
                  * in `init` before its use.
                  */
-                if (vd->sem < Semantic2Done && vd->_scope)
+                if (vd->semanticRun < PASSsemantic2done && vd->_scope)
                     vd->semantic2(vd->_scope);
 
                 ExpInitializer *ei = init->isExpInitializer();


### PR DESCRIPTION
Their role was completely same.
