### PR TITLE
refactor: redo Identifier ctors to eliminate extra strlen()

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -435,8 +435,9 @@ public:
                 version (none)
                 {
                     buf.printf("_%s_%d", ident.toChars(), i);
-                    char* name = cast(char*)buf.extractData();
-                    auto id = new Identifier(name, TOKidentifier);
+                    const len = buf.offset;
+                    const name = cast(const(char)*)buf.extractData();
+                    auto id = Identifier.idPool(name, len);
                     auto arg = new Parameter(STCin, t, id, null);
                 }
                 else

--- a/src/glue.c
+++ b/src/glue.c
@@ -134,7 +134,7 @@ void obj_write_deferred(Library *library)
         else
         {
             idbuf.data = NULL;
-            Identifier *id = Identifier::create(idstr, TOKidentifier);
+            Identifier *id = Identifier::create(idstr);
 
             Module *md = Module::create(mname, id, 0, 0);
             md->members = Dsymbols_create();

--- a/src/identifier.d
+++ b/src/identifier.d
@@ -29,17 +29,24 @@ private:
     const size_t len;
 
 public:
-    extern (D) this(const(char)* string, int value)
+
+    extern (D) this(const(char)* string, size_t length, int value)
     {
         //printf("Identifier('%s', %d)\n", string, value);
         this.string = string;
         this.value = value;
-        this.len = strlen(string);
+        this.len = length;
     }
 
-    static Identifier create(const(char)* string, int value)
+    extern (D) this(const(char)* string)
     {
-        return new Identifier(string, value);
+        //printf("Identifier('%s', %d)\n", string, value);
+        this(string, strlen(string), TOKidentifier);
+    }
+
+    static Identifier create(const(char)* string)
+    {
+        return new Identifier(string);
     }
 
     override bool equals(RootObject o) const
@@ -140,7 +147,7 @@ public:
         Identifier id = cast(Identifier)sv.ptrvalue;
         if (!id)
         {
-            id = new Identifier(sv.toDchars(), TOKidentifier);
+            id = new Identifier(sv.toDchars(), len, TOKidentifier);
             sv.ptrvalue = cast(char*)id;
         }
         return id;
@@ -150,7 +157,7 @@ public:
     {
         auto sv = stringtable.insert(s, len, null);
         assert(sv);
-        auto id = new Identifier(sv.toDchars(), value);
+        auto id = new Identifier(sv.toDchars(), len, value);
         sv.ptrvalue = cast(char*)id;
         return id;
     }

--- a/src/identifier.h
+++ b/src/identifier.h
@@ -22,8 +22,7 @@
 class Identifier : public RootObject
 {
 public:
-    Identifier(const char *string, int value);
-    static Identifier* create(const char *string, int value);
+    static Identifier* create(const char *string);
     bool equals(RootObject *o);
     int compare(RootObject *o);
     void print();

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7203,7 +7203,7 @@ public:
                 error(loc, "'%s' is not defined, perhaps you need to import %s; ?", p, n);
             else
             {
-                auto id = new Identifier(p, TOKidentifier);
+                auto id = new Identifier(p);
                 s = sc.search_correct(id);
                 if (s)
                     error(loc, "undefined identifier '%s', did you mean %s '%s'?", p, s.kind(), s.toChars());

--- a/src/parse.d
+++ b/src/parse.d
@@ -1574,7 +1574,7 @@ public:
                     if (!tp_ident)
                     {
                         error("identifier expected for template value parameter");
-                        tp_ident = new Identifier("error", TOKidentifier);
+                        tp_ident = Identifier.idPool("error");
                     }
                     if (token.value == TOKcolon) // : CondExpression
                     {


### PR DESCRIPTION
By adding a length parameter to the constructor, redundant strlen()'s can be eliminated.
