### PR TITLE
Remove workaround for issue 9057

### DIFF
--- a/src/todt.c
+++ b/src/todt.c
@@ -784,14 +784,7 @@ static void membersToDt(AggregateDeclaration *ad, DtBuilder& dtb,
                 if (init->isVoidInitializer())
                     continue;
 
-                /* Because of issue 14666, function local import does not invoke
-                 * semantic2 pass for the imported module, and surprisingly there's
-                 * no opportunity to do it today.
-                 * As a workaround for the issue 9057, have to resolve forward reference
-                 * in `init` before its use.
-                 */
-                if (vd->semanticRun < PASSsemantic2done && vd->_scope)
-                    vd->semantic2(vd->_scope);
+                assert(vd->semanticRun >= PASSsemantic2done);
 
                 ExpInitializer *ei = init->isExpInitializer();
                 Type *tb = vd->type->toBasetype();


### PR DESCRIPTION
In https://github.com/dlang/dmd/pull/5500, issue 14666 has been properly fixed by adding mechanism of deferred semantic2 running for imported modules. Now, the workaround for issue 9057 in `todt.c` is
unnecessary anymore.
