### PR TITLE
refactor libmscoff, scanmscoff: replace C++98 lambdas with delegates

### DIFF
--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -447,25 +447,13 @@ private:
         {
             printf("LibMSCoff::scanObjModule(%s)\n", om.name);
         }
-        struct Context
+
+        void addSymbol(char* name, int pickAny)
         {
-            LibMSCoff lib;
-            MSCoffObjModule* om;
-
-            extern (D) this(LibMSCoff lib, MSCoffObjModule* om)
-            {
-                this.lib = lib;
-                this.om = om;
-            }
-
-            extern (C++) static void addSymbol(void* pctx, char* name, int pickAny)
-            {
-                (cast(Context*)pctx).lib.addSymbol((cast(Context*)pctx).om, name, pickAny);
-            }
+            this.addSymbol(om, name, pickAny);
         }
 
-        auto ctx = Context(this, om);
-        scanMSCoffObjModule(&ctx, &Context.addSymbol, om.base, om.length, om.name, loc);
+        scanMSCoffObjModule(&addSymbol, om.base, om.length, om.name, loc);
     }
 
     /*****************************************************************************/

--- a/src/scanmscoff.d
+++ b/src/scanmscoff.d
@@ -17,13 +17,12 @@ enum LOG = false;
  * Reads an object module from base[0..buflen] and passes the names
  * of any exported symbols to (*pAddSymbol)().
  * Input:
- *      pctx            context pointer, pass to *pAddSymbol
  *      pAddSymbol      function to pass the names to
  *      base[0..buflen] contains contents of object module
  *      module_name     name of the object module (used for error messages)
  *      loc             location to use for error printing
  */
-extern (C++) void scanMSCoffObjModule(void* pctx, void function(void* pctx, char* name, int pickAny) pAddSymbol, void* base, size_t buflen, const(char)* module_name, Loc loc)
+void scanMSCoffObjModule(void delegate(char* name, int pickAny) pAddSymbol, void* base, size_t buflen, const(char)* module_name, Loc loc)
 {
     static if (LOG)
     {
@@ -170,7 +169,7 @@ extern (C++) void scanMSCoffObjModule(void* pctx, void function(void* pctx, char
         default:
             continue;
         }
-        (*pAddSymbol)(pctx, p, 1);
+        pAddSymbol(p, 1);
     }
 }
 


### PR DESCRIPTION
Just like the others.
