### PR TITLE
[REG2.066] Issue 15961 - ICE with instance field introduced by anonymous struct

### DIFF
--- a/src/attrib.d
+++ b/src/attrib.d
@@ -661,6 +661,12 @@ public:
         return new AnonDeclaration(loc, isunion, Dsymbol.arraySyntaxCopy(decl));
     }
 
+    override void setScope(Scope* sc)
+    {
+        super.setScope(sc);
+        alignment = sc.structalign;
+    }
+
     override void semantic(Scope* sc)
     {
         //printf("\tAnonDeclaration::semantic %s %p\n", isunion ? "union" : "struct", this);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7779,6 +7779,27 @@ void test15638()
 }
 
 /***************************************************/
+// 15961
+
+struct SliceOverIndexed15961(T)
+{
+    enum assignableIndex = T.init;
+}
+
+struct Grapheme15961
+{
+    SliceOverIndexed15961!Grapheme15961 opSlice()
+    {
+        assert(0);
+    }
+
+    struct
+    {
+        ubyte* ptr_;
+    }
+}
+
+/***************************************************/
 
 int main()
 {


### PR DESCRIPTION
`AnonDeclaration.setFieldOffset` may be called before the `semantic` to determine aggregate instance size in early steps.
