### PR TITLE
[REG 2.071] Fix Issue 15925 - Import declaration from mixin templates are ignored

### DIFF
--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1349,7 +1349,7 @@ public:
                         continue;
                     }
                 }
-                else
+                else if (!ss.isTemplateMixin)
                 {
                     if (flags & SearchImportsOnly)
                         continue;

--- a/test/compilable/imports/test15925.d
+++ b/test/compilable/imports/test15925.d
@@ -1,0 +1,9 @@
+module imports.test15925;
+
+public mixin template AddImports ()
+{
+    import core.thread;
+
+    ScanAllThreadsFn fun;
+    Thread th;
+}

--- a/test/compilable/test15925.d
+++ b/test/compilable/test15925.d
@@ -1,0 +1,11 @@
+import imports.test15925;
+
+public class Foo
+{
+    mixin AddImports;
+
+    // Alias from core.thread
+    ScanAllThreadsFn fun2;
+    // Type from core.thread
+    Thread th2;
+}


### PR DESCRIPTION
Before this change, neither `private` nor `public import` from `mixin template` were visible.

FYI @mihails-strasuns-sociomantic
