### PR TITLE
[REG 2.071] Fix Issue 15925 - Import declaration from mixin templates are ignored

### DIFF
--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -1321,7 +1321,7 @@ public:
                         continue;
                     }
                 }
-                else
+                else if (!ss.isTemplateMixin)
                 {
                     if (flags & SearchImportsOnly)
                         continue;

--- a/test/compilable/imports/test15925.d
+++ b/test/compilable/imports/test15925.d
@@ -1,0 +1,9 @@
+module imports.test15925;
+
+public mixin template AddImports ()
+{
+    import imports.test15925thread;
+
+    ThreadAlias fun;
+    Thread th;
+}

--- a/test/compilable/imports/test15925thread.d
+++ b/test/compilable/imports/test15925thread.d
@@ -1,0 +1,4 @@
+module imports.test15925thread;
+
+public class Thread {}
+public alias ThreadAlias = Thread;

--- a/test/compilable/test15925.d
+++ b/test/compilable/test15925.d
@@ -1,0 +1,11 @@
+import imports.test15925;
+
+public class Foo
+{
+    mixin AddImports;
+
+    // Alias from imports.test15925thread which is imported in AddImports
+    ThreadAlias fun2;
+    // Type from imports.test15925thread which is imported in AddImports
+    Thread th2;
+}


### PR DESCRIPTION
```
Before this change, neither `private` nor `public import` from `mixin template` were visible.
```

Remake of dlang/dmd#5722 against stable, since its a regression.
