### PR TITLE
replace usage of warnings as deprecations

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -4518,7 +4518,7 @@ public:
             static __gshared const(char)** reverseName = ["_adReverseChar", "_adReverseWchar"];
             static __gshared FuncDeclaration* reverseFd = [null, null];
 
-            warning(e.loc, "use std.algorithm.reverse instead of .reverse property");
+            deprecation(e.loc, "use std.algorithm.reverse instead of .reverse property");
             int i = n.ty == Twchar;
             if (!reverseFd[i])
             {
@@ -4541,7 +4541,7 @@ public:
             static __gshared const(char)** sortName = ["_adSortChar", "_adSortWchar"];
             static __gshared FuncDeclaration* sortFd = [null, null];
 
-            warning(e.loc, "use std.algorithm.sort instead of .sort property");
+            deprecation(e.loc, "use std.algorithm.sort instead of .sort property");
             int i = n.ty == Twchar;
             if (!sortFd[i])
             {
@@ -4566,7 +4566,7 @@ public:
             Expressions* arguments;
             dinteger_t size = next.size(e.loc);
 
-            warning(e.loc, "use std.algorithm.reverse instead of .reverse property");
+            deprecation(e.loc, "use std.algorithm.reverse instead of .reverse property");
             assert(size);
 
             static __gshared FuncDeclaration adReverse_fd = null;
@@ -4593,7 +4593,7 @@ public:
             Expression ec;
             Expressions* arguments;
 
-            warning(e.loc, "use std.algorithm.sort instead of .sort property");
+            deprecation(e.loc, "use std.algorithm.sort instead of .sort property");
             if (!fd)
             {
                 auto params = new Parameters();

--- a/src/parse.d
+++ b/src/parse.d
@@ -4790,7 +4790,7 @@ public:
         if (alt & 1) // contains C-style function pointer syntax
             error(loc, "instead of C-style syntax, use D-style '%s%s%s'", t.toChars(), sp, s);
         else
-            .warning(loc, "instead of C-style syntax, use D-style syntax '%s%s%s'", t.toChars(), sp, s);
+            .deprecation(loc, "instead of C-style syntax, use D-style syntax '%s%s%s'", t.toChars(), sp, s);
     }
 
     /*****************************************

--- a/test/fail_compilation/diag_cstyle.d
+++ b/test/fail_compilation/diag_cstyle.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -w
+// REQUIRED_ARGS:
 /*
 TEST_OUTPUT:
 ---
@@ -6,8 +6,8 @@ fail_compilation/diag_cstyle.d(14): Error: instead of C-style syntax, use D-styl
 fail_compilation/diag_cstyle.d(15): Error: instead of C-style syntax, use D-style 'int function(int)* fp3'
 fail_compilation/diag_cstyle.d(17): Error: instead of C-style syntax, use D-style 'int function(int) FP'
 fail_compilation/diag_cstyle.d(19): Error: instead of C-style syntax, use D-style 'int function() fp'
-fail_compilation/diag_cstyle.d(19): Warning: instead of C-style syntax, use D-style syntax 'int[] arr'
-fail_compilation/diag_cstyle.d(21): Warning: instead of C-style syntax, use D-style syntax 'string[] result'
+fail_compilation/diag_cstyle.d(19): Deprecation: instead of C-style syntax, use D-style syntax 'int[] arr'
+fail_compilation/diag_cstyle.d(21): Deprecation: instead of C-style syntax, use D-style syntax 'string[] result'
 ---
 */
 

--- a/test/fail_compilation/fail1313a.d
+++ b/test/fail_compilation/fail1313a.d
@@ -9,6 +9,6 @@ int[] test()
 //out{}
 body
 {
-    int a[2];
+    int[2] a;
     return a;
 }

--- a/test/fail_compilation/fail1313b.d
+++ b/test/fail_compilation/fail1313b.d
@@ -9,6 +9,6 @@ int[] test()
 out{}
 body
 {
-    int a[2];
+    int[2] a;
     return a;
 }

--- a/test/runnable/extra-files/test2.d
+++ b/test/runnable/extra-files/test2.d
@@ -126,8 +126,8 @@ int[] test6_1(int[] a)
 void test6()
 {
     printf("test6()\n");
-    int b[3];
-    int a[];
+    int[3] b;
+    int[] a;
 
     b[0] = 0;
     b[1] = 1;
@@ -142,7 +142,7 @@ void test6()
 
 class OutBuffer7
 {
-    char data[];
+    char[] data;
     uint offset;
 
     void write(const(char) *p, uint nbytes)


### PR DESCRIPTION
- since we have -dw by default we should no longer use warnings for deprecations
  Also see https://github.com/dlang/dlang.org/pull/1286.
