### PR TITLE
Preparation for enhancements on function call - run semantic3 at the last of function call matching.

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -2769,7 +2769,10 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
             sc = td_best._scope; // workaround for Type.aliasthisOf
 
         auto ti = new TemplateInstance(loc, td_best, ti_best.tiargs);
-        ti.semantic(sc, fargs);
+        auto sc2 = sc.push();
+        sc2.func = null;    // Doesn't instantiate function body yet.
+        ti.semantic(sc2, fargs);
+        sc2.pop();
 
         m.lastf = ti.toAlias().isFuncDeclaration();
         if (!m.lastf)

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -7437,22 +7437,22 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 if (ea.op == TOKfunction)
                 {
                     FuncExp fe = cast(FuncExp)ea;
+
                     /* A function literal, that is passed to template and
-                     * already semanticed as function pointer, never requires
-                     * outer frame. So convert it to global function is valid.
+                     * already semanticed as function pointer, never be
+                     * convertible to delegate inside template body. For example:
+                     *
+                     * void foo(alias f)() {
+                     *     auto dg1 = cast(int delegate(int))((int a) => 1); // OK
+                     *     auto dg2 = cast(int delegate(int))f;              // NG
+                     * }
+                     * void bar() { foo!((int a) => 1)(); }
                      */
                     if (fe.fd.tok == TOKreserved && fe.type.ty == Tpointer)
                     {
                         // change to non-nested
                         fe.fd.tok = TOKfunction;
                         fe.fd.vthis = null;
-                    }
-                    else if (fe.td)
-                    {
-                        /* If template argument is a template lambda,
-                         * get template declaration itself. */
-                        //sa = fe.td;
-                        //goto Ldsym;
                     }
                 }
                 if (ea.op == TOKdotvar)

--- a/src/expression.h
+++ b/src/expression.h
@@ -180,10 +180,10 @@ public:
     bool checkIntegral();
     bool checkArithmetic();
     void checkDeprecated(Scope *sc, Dsymbol *s);
-    bool checkPurity(Scope *sc, FuncDeclaration *f);
-    bool checkPurity(Scope *sc, VarDeclaration *v);
-    bool checkSafety(Scope *sc, FuncDeclaration *f);
-    bool checkNogc(Scope *sc, FuncDeclaration *f);
+    static bool checkPurity(Loc loc, Scope *sc, FuncDeclaration *f);
+    static bool checkPurity(Loc loc, Scope *sc, VarDeclaration *v);
+    static bool checkSafety(Loc loc, Scope *sc, FuncDeclaration *f);
+    static bool checkNogc(Loc loc, Scope *sc, FuncDeclaration *f);
     bool checkPostblit(Scope *sc, Type *t);
     bool checkRightThis(Scope *sc);
     bool checkReadModifyWrite(TOK rmwOp, Expression *ex = NULL);

--- a/src/func.d
+++ b/src/func.d
@@ -4184,8 +4184,6 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
     {
         if (m.count == 1) // exactly one match
         {
-            if (!(flags & 1))
-                m.lastf.functionSemantic();
             return m.lastf;
         }
         if ((flags & 2) && !tthis && m.lastf.needThis())

--- a/src/glue.c
+++ b/src/glue.c
@@ -823,6 +823,19 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
     assert(fd->semanticRun == PASSsemantic3done);
     assert(fd->ident != Id::empty);
 
+    if (FuncLiteralDeclaration *fld = fd->isFuncLiteralDeclaration())
+    {
+        /* If fld was a template lambda, toObjFile call may happen before the
+         * toElem of FuncExp(fld) or VarExp(fld).
+         */
+        if (fld->tok == TOKreserved)
+        {
+            // change to non-nested
+            fld->tok = TOKfunction;
+            fld->vthis = NULL;
+        }
+    }
+
     for (FuncDeclaration *fd2 = fd; fd2; )
     {
         if (fd2->inNonRoot())

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7903,19 +7903,27 @@ extern (C++) final class TypeTypeof : TypeQualified
              * template functions.
              */
         }
+
+        Type t = exp.type;
         if (auto f = exp.op == TOKvar    ? (cast(   VarExp)exp).var.isFuncDeclaration()
                    : exp.op == TOKdotvar ? (cast(DotVarExp)exp).var.isFuncDeclaration() : null)
         {
             if (f.checkForwardRef(loc))
                 goto Lerr;
+            t = f.type;
         }
         if (auto f = isFuncAddress(exp))
         {
             if (f.checkForwardRef(loc))
                 goto Lerr;
+            if (exp.type.ty == Tdelegate)
+            {
+                t = new TypeDelegate(f.type);
+                t = t.semantic(exp.loc, sc);
+            }
+            else
+                t = f.type.pointerTo();
         }
-
-        Type t = exp.type;
         if (!t)
         {
             error(loc, "expression (%s) has no type", exp.toChars());
@@ -7926,6 +7934,7 @@ extern (C++) final class TypeTypeof : TypeQualified
             error(loc, "forward reference to %s", toChars());
             goto Lerr;
         }
+
         if (idents.dim == 0)
             *pt = t;
         else

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -1076,7 +1076,11 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     {
                         Expressions a;
                         if (auto f = resolveFuncCall(loc, sc, td, null, tab, &a, 1))
+                        {
+                            if (!f.functionSemantic())
+                                goto Lrangeerr;
                             tfront = f.type;
+                        }
                     }
                     else if (auto d = sfront.isDeclaration())
                     {

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -338,6 +338,40 @@ void test9072()
 }
 
 /***************************************************/
+// 5933
+
+int dummyfunc5933() pure nothrow @nogc @safe;
+alias typeof(dummyfunc5933) FuncType5933;
+
+int dummyfunc5933x();
+alias typeof(dummyfunc5933x) FuncType5933x;
+
+struct S5933a { auto x() { return 0; } }
+static assert(is(typeof(&S5933a.init.x) == int delegate() pure nothrow @nogc @safe));
+
+struct S5933b { auto x() { return 0; } }
+static assert(is(typeof(S5933b.init.x) == FuncType5933));
+
+struct S5933c { auto x() { return 0; } }
+static assert(is(typeof(&S5933c.x) == int function() pure nothrow @nogc @safe));
+
+struct S5933d { auto x() { return 0; } }
+static assert(is(typeof(S5933d.x) == FuncType5933));
+
+
+class C5933a { auto x() { return 0; } }
+static assert(is(typeof(&(new C5933b()).x) == int delegate()));
+
+class C5933b { auto x() { return 0; } }
+static assert(is(typeof((new C5933b()).x) == FuncType5933x));
+
+class C5933c { auto x() { return 0; } }
+static assert(is(typeof(&C5933c.x) == int function()));
+
+class C5933d { auto x() { return 0; } }
+static assert(is(typeof(C5933d.x) == FuncType5933x));
+
+/***************************************************/
 // 5933 + Issue 8504 - Template attribute inferrence doesn't work
 
 int foo5933()(int a) { return a*a; }

--- a/test/fail_compilation/diag13028.d
+++ b/test/fail_compilation/diag13028.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/diag13028.d(15): Error: variable dg cannot be read at compile time
 fail_compilation/diag13028.d(22): Error: variable a cannot be read at compile time
 fail_compilation/diag13028.d(28): Error: CTFE failed because of previous errors in foo
-fail_compilation/diag13028.d(28):        while evaluating: static assert(foo(() => 1) == 1)
+fail_compilation/diag13028.d(28):        while evaluating: static assert(foo(delegate () => 1) == 1)
 fail_compilation/diag13028.d(29): Error: CTFE failed because of previous errors in bar
 fail_compilation/diag13028.d(29):        while evaluating: static assert(bar(delegate int() => 1) == 1)
 ---

--- a/test/fail_compilation/diag7747.d
+++ b/test/fail_compilation/diag7747.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7747.d(8): Error: forward reference to inferred return type of function call 'fact(n - 1)'
+fail_compilation/diag7747.d(8): Error: forward reference to inferred return type of function 'fact'
 ---
 */
 

--- a/test/fail_compilation/disable.d
+++ b/test/fail_compilation/disable.d
@@ -1,15 +1,21 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/disable.d(50): Error: function disable.DisabledOpAssign.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(53): Error: function disable.DisabledPostblit.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(56): Error: function disable.HasDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(60): Error: generated function disable.Nested!(DisabledOpAssign).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(63): Error: generated function disable.Nested!(DisabledPostblit).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(66): Error: generated function disable.Nested!(HasDtor).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(70): Error: generated function disable.NestedDtor!(DisabledOpAssign).NestedDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(73): Error: generated function disable.NestedDtor!(DisabledPostblit).NestedDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(76): Error: generated function disable.NestedDtor!(HasDtor).NestedDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(56): Error: function disable.DisabledOpAssign.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(59): Error: function disable.DisabledPostblit.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(62): Error: function disable.HasDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(66): Error: generated function disable.Nested!(DisabledOpAssign).Nested.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(66): Error: generated function disable.Nested!(DisabledOpAssign).Nested.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(69): Error: generated function disable.Nested!(DisabledPostblit).Nested.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(69): Error: generated function disable.Nested!(DisabledPostblit).Nested.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(72): Error: generated function disable.Nested!(HasDtor).Nested.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(72): Error: generated function disable.Nested!(HasDtor).Nested.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(76): Error: generated function disable.NestedDtor!(DisabledOpAssign).NestedDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(76): Error: generated function disable.NestedDtor!(DisabledOpAssign).NestedDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(79): Error: generated function disable.NestedDtor!(DisabledPostblit).NestedDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(79): Error: generated function disable.NestedDtor!(DisabledPostblit).NestedDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(82): Error: generated function disable.NestedDtor!(HasDtor).NestedDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(82): Error: generated function disable.NestedDtor!(HasDtor).NestedDtor.opAssign is not callable because it is annotated with @disable
 ---
  */
 struct DisabledOpAssign {

--- a/test/fail_compilation/fail14407.d
+++ b/test/fail_compilation/fail14407.d
@@ -5,14 +5,14 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail14407.d(23): Deprecation: class imports.a14407.C is deprecated
 fail_compilation/fail14407.d(23): Deprecation: allocator imports.a14407.C.new is deprecated
+fail_compilation/fail14407.d(23): Error: class imports.a14407.C member new is not accessible
 fail_compilation/fail14407.d(23): Error: pure function 'fail14407.testC' cannot call impure allocator 'imports.a14407.C.new'
 fail_compilation/fail14407.d(23): Error: @safe function 'fail14407.testC' cannot call @system allocator 'imports.a14407.C.new'
 fail_compilation/fail14407.d(23): Error: @nogc function 'fail14407.testC' cannot call non-@nogc allocator 'imports.a14407.C.new'
-fail_compilation/fail14407.d(23): Error: class imports.a14407.C member new is not accessible
+fail_compilation/fail14407.d(23): Error: class imports.a14407.C member this is not accessible
 fail_compilation/fail14407.d(23): Error: pure function 'fail14407.testC' cannot call impure constructor 'imports.a14407.C.this'
 fail_compilation/fail14407.d(23): Error: @safe function 'fail14407.testC' cannot call @system constructor 'imports.a14407.C.this'
 fail_compilation/fail14407.d(23): Error: @nogc function 'fail14407.testC' cannot call non-@nogc constructor 'imports.a14407.C.this'
-fail_compilation/fail14407.d(23): Error: class imports.a14407.C member this is not accessible
 fail_compilation/fail14407.d(23): Error: allocator 'imports.a14407.C.new' is not nothrow
 fail_compilation/fail14407.d(23): Error: constructor 'imports.a14407.C.this' is not nothrow
 fail_compilation/fail14407.d(21): Error: nothrow function 'fail14407.testC' may throw
@@ -28,14 +28,14 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail14407.d(46): Deprecation: struct imports.a14407.S is deprecated
 fail_compilation/fail14407.d(46): Deprecation: allocator imports.a14407.S.new is deprecated
+fail_compilation/fail14407.d(46): Error: struct imports.a14407.S member new is not accessible
 fail_compilation/fail14407.d(46): Error: pure function 'fail14407.testS' cannot call impure allocator 'imports.a14407.S.new'
 fail_compilation/fail14407.d(46): Error: @safe function 'fail14407.testS' cannot call @system allocator 'imports.a14407.S.new'
 fail_compilation/fail14407.d(46): Error: @nogc function 'fail14407.testS' cannot call non-@nogc allocator 'imports.a14407.S.new'
-fail_compilation/fail14407.d(46): Error: struct imports.a14407.S member new is not accessible
+fail_compilation/fail14407.d(46): Error: struct imports.a14407.S member this is not accessible
 fail_compilation/fail14407.d(46): Error: pure function 'fail14407.testS' cannot call impure constructor 'imports.a14407.S.this'
 fail_compilation/fail14407.d(46): Error: @safe function 'fail14407.testS' cannot call @system constructor 'imports.a14407.S.this'
 fail_compilation/fail14407.d(46): Error: @nogc function 'fail14407.testS' cannot call non-@nogc constructor 'imports.a14407.S.this'
-fail_compilation/fail14407.d(46): Error: struct imports.a14407.S member this is not accessible
 fail_compilation/fail14407.d(46): Error: allocator 'imports.a14407.S.new' is not nothrow
 fail_compilation/fail14407.d(46): Error: constructor 'imports.a14407.S.this' is not nothrow
 fail_compilation/fail14407.d(44): Error: nothrow function 'fail14407.testS' may throw

--- a/test/fail_compilation/ice10922.d
+++ b/test/fail_compilation/ice10922.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10922.d(9): Error: function ice10922.__lambda4 (const(uint) n) is not callable using argument types ()
+fail_compilation/ice10922.d(9): Error: delegate ice10922.__lambda4 (const(uint) n) is not callable using argument types ()
 ---
 */
 

--- a/test/fail_compilation/ice14642.d
+++ b/test/fail_compilation/ice14642.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice14642.d(47): Error: undefined identifier 'errorValue'
-fail_compilation/ice14642.d(23): Error: template instance ice14642.X.NA!() error instantiating
 ---
 */
+
 
 alias TypeTuple(T...) = T;
 

--- a/test/fail_compilation/ice14929.d
+++ b/test/fail_compilation/ice14929.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice14929.d(44): Error: cast(Node)(*this.current).items[this.index] is not an lvalue
-fail_compilation/ice14929.d(87): Error: template instance ice14929.HashMap!(ulong, int).HashMap.opBinaryRight!"in" error instantiating
-fail_compilation/ice14929.d(91):        instantiated from here: HashmapComponentStorage!int
-fail_compilation/ice14929.d(91): Error: template instance ice14929.isComponentStorage!(HashmapComponentStorage!int, int) error instantiating
+fail_compilation/ice14929.d(88): Error: template instance ice14929.HashMap!(ulong, int).HashMap.opBinaryRight!"in" error instantiating
+fail_compilation/ice14929.d(92):        instantiated from here: HashmapComponentStorage!int
+fail_compilation/ice14929.d(92): Error: template instance ice14929.isComponentStorage!(HashmapComponentStorage!int, int) error instantiating
 ---
 */
 
@@ -74,6 +74,7 @@ template isComponentStorage(CS, C)
     {
         CS cs = CS.init;
         ulong eid;
+        C c;
         cs.add(eid, c);
     }));
 }

--- a/test/fail_compilation/ice16035.d
+++ b/test/fail_compilation/ice16035.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice16035.d(18): Error: forward reference to inferred return type of function call 'this.a[0].toString()'
+fail_compilation/ice16035.d(18): Error: forward reference to inferred return type of function 'toString'
 fail_compilation/ice16035.d(13): Error: template instance ice16035.Value.get!string error instantiating
 ---
 */

--- a/test/fail_compilation/ice8255.d
+++ b/test/fail_compilation/ice8255.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8255.d(10): Error: function ice8255.F!(G).F.f (ref G _param_0) is not callable using argument types (G)
+fail_compilation/ice8255.d(10): Error: function ice8255.F!(G).F.f (ref G) is not callable using argument types (G)
 fail_compilation/ice8255.d(10):        while evaluating pragma(msg, F().f(G()))
 ---
 */

--- a/test/fail_compilation/ice9806.d
+++ b/test/fail_compilation/ice9806.d
@@ -25,12 +25,15 @@ void test1() {
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9806.d(36): Error: undefined identifier 'undefined_expr'
-fail_compilation/ice9806.d(44): Error: template instance ice9806.S2!() error instantiating
-fail_compilation/ice9806.d(37): Error: undefined identifier 'undefined_expr'
-fail_compilation/ice9806.d(46): Error: template instance ice9806.C2!() error instantiating
-fail_compilation/ice9806.d(38): Error: undefined identifier 'undefined_expr'
-fail_compilation/ice9806.d(48): Error: template instance ice9806.I2!() error instantiating
+fail_compilation/ice9806.d(39): Error: undefined identifier 'undefined_expr'
+fail_compilation/ice9806.d(42): Error: template instance ice9806.foo2!() error instantiating
+fail_compilation/ice9806.d(47):        instantiated from here: S2!()
+fail_compilation/ice9806.d(40): Error: undefined identifier 'undefined_expr'
+fail_compilation/ice9806.d(43): Error: template instance ice9806.bar2!() error instantiating
+fail_compilation/ice9806.d(49):        instantiated from here: C2!()
+fail_compilation/ice9806.d(41): Error: undefined identifier 'undefined_expr'
+fail_compilation/ice9806.d(44): Error: template instance ice9806.baz2!() error instantiating
+fail_compilation/ice9806.d(51):        instantiated from here: I2!()
 ---
 */
 int foo2()() { return undefined_expr; }

--- a/test/fail_compilation/test9176.d
+++ b/test/fail_compilation/test9176.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test9176.d(13): Error: forward reference to inferred return type of function call 'get()'
+fail_compilation/test9176.d(13): Error: forward reference to inferred return type of function 'get'
 ---
 */
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4898,37 +4898,6 @@ void test5696()
 }
 
 /***************************************************/
-// 5933
-
-int dummyfunc5933();
-alias typeof(dummyfunc5933) FuncType5933;
-
-struct S5933a { auto x() { return 0; } }
-static assert(is(typeof(&S5933a.init.x) == int delegate() pure nothrow @nogc @safe));
-
-struct S5933b { auto x() { return 0; } }
-//static assert(is(typeof(S5933b.init.x) == FuncType5933));
-
-struct S5933c { auto x() { return 0; } }
-static assert(is(typeof(&S5933c.x) == int function()));
-
-struct S5933d { auto x() { return 0; } }
-static assert(is(typeof(S5933d.x) == FuncType5933));
-
-
-class C5933a { auto x() { return 0; } }
-static assert(is(typeof(&(new C5933b()).x) == int delegate()));
-
-class C5933b { auto x() { return 0; } }
-//static assert(is(typeof((new C5933b()).x) == FuncType5933));
-
-class C5933c { auto x() { return 0; } }
-static assert(is(typeof(&C5933c.x) == int function()));
-
-class C5933d { auto x() { return 0; } }
-static assert(is(typeof(C5933d.x) == FuncType5933));
-
-/***************************************************/
 // 6084
 
 template TypeTuple6084(T...){ alias T TypeTuple6084; }


### PR DESCRIPTION
Currently attribute inference doesn't work for mutual function calls ([issue 7205](https://issues.dlang.org/show_bug.cgi?id=7205)), because yet not inferred attributes are conservatively treated as impure, unsafe, gc-able, and may be thrown.
To allow it, we have to grouping mutual called functions and determine those attributes all at once the last of the group analysis.

However, the semantic3 call occurs in many places in current front end - `resolveFuncCall`, `functionResolve`, `VarExp.semantic`, or `DotVarExp.semantic`. We should move those semantic3 calls to the last of a function call matching == `functionParameters`.

Also this preparation change is necessary for recursive/mutual call of auto functions ([issue 5288](https://issues.dlang.org/show_bug.cgi?id=5288)).
