### PR TITLE
fix Issue 15897 - private base class method not seen through derived class

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -8670,12 +8670,18 @@ public:
             Dsymbol sold = void;
             if (global.params.bug10378 || global.params.check10378)
             {
-                sold = sym.search(e.loc, ident, flags);
+                sold = sym.search(e.loc, ident, flags | IgnoreSymbolVisibility);
                 if (!global.params.check10378)
                     return sold;
             }
 
             auto s = sym.search(e.loc, ident, flags | SearchLocalsOnly);
+            if (!s)
+            {
+                s = sym.search(e.loc, ident, flags | SearchLocalsOnly | IgnoreSymbolVisibility);
+                if (s && !(flags & IgnoreErrors))
+                    .deprecation(e.loc, "%s is not visible from class %s", s.toPrettyChars(), sym.toChars());
+            }
             if (global.params.check10378)
             {
                 alias snew = s;

--- a/test/fail_compilation/imports/test15897.d
+++ b/test/fail_compilation/imports/test15897.d
@@ -1,0 +1,6 @@
+module imports.test15897;
+import test15897;
+
+class Cat : Animal
+{
+}

--- a/test/fail_compilation/test15897.d
+++ b/test/fail_compilation/test15897.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test15897.d(18): Deprecation: test15897.Animal.create is not visible from class Cat
+---
+*/
+module test15897;
+import imports.test15897;
+
+class Animal
+{
+    private void create() {}
+}
+
+void foo(Cat cat)
+{
+    cat.create();
+}


### PR DESCRIPTION
- properly deprecate private symbol visibility through derived classes
