### PR TITLE
Move complex/imaginary types from transition to deprecation

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1137,8 +1137,7 @@ public:
         //printf("sc->stc = %x\n", sc->stc);
         //printf("storage_class = x%x\n", storage_class);
 
-        if (global.params.vcomplex)
-            type.checkComplexTransition(loc);
+        type.checkComplexTransition(loc);
 
         // Calculate type size + safety checks
         if (sc.func && !sc.intypeof && !isMember())

--- a/src/expression.d
+++ b/src/expression.d
@@ -5566,8 +5566,7 @@ public:
         else
             assert(0);
 
-        if (global.params.vcomplex)
-            type.checkComplexTransition(loc);
+        type.checkComplexTransition(loc);
 
         return e;
     }
@@ -7238,8 +7237,7 @@ public:
             return new ErrorExp();
         }
 
-        if (global.params.vcomplex)
-            ta.checkComplexTransition(loc);
+        ta.checkComplexTransition(loc);
 
         Expression e;
         if (ea && ta.toBasetype().ty == Tclass)

--- a/src/func.d
+++ b/src/func.d
@@ -1706,7 +1706,7 @@ public:
                     if (f.checkRetType(loc))
                         fbody = new ErrorStatement();
                 }
-                if (global.params.vcomplex && f.next !is null)
+                if (f.next !is null)
                     f.next.checkComplexTransition(loc);
 
                 if (returns && !fbody.isErrorStatement())

--- a/src/globals.d
+++ b/src/globals.d
@@ -65,7 +65,6 @@ struct Param
     bool vtls;              // identify thread local variables
     bool vgc;               // identify gc usage
     bool vfield;            // identify non-mutable field variables
-    bool vcomplex;          // identify complex/imaginary type usage
     ubyte symdebug;         // insert debug symbolic information
     bool alwaysframe;       // always emit standard stack frame
     bool optimize;          // run optimizer

--- a/src/globals.h
+++ b/src/globals.h
@@ -49,7 +49,6 @@ struct Param
     bool vtls;          // identify thread local variables
     char vgc;           // identify gc usage
     bool vfield;        // identify non-mutable field variables
-    bool vcomplex;      // identify complex/imaginary type usage
     char symdebug;      // insert debug symbolic information
     bool alwaysframe;   // always emit standard stack frame
     bool optimize;      // run optimizer

--- a/src/mars.d
+++ b/src/mars.d
@@ -613,7 +613,6 @@ private int tryMain(size_t argc, const(char)** argv)
 Language changes listed by -transition=id:
   =all           list information on all language changes
   =checkimports  give deprecation messages about 10378 anomalies
-  =complex,14488 list all usages of complex or imaginary types
   =field,3449    list all non-mutable fields which occupy an object instance
   =import,10378  revert to single phase name lookup
   =tls           list all variables going into thread local storage
@@ -636,9 +635,6 @@ Language changes listed by -transition=id:
                         case 10378:
                             global.params.bug10378 = true;
                             break;
-                        case 14488:
-                            global.params.vcomplex = true;
-                            break;
                         default:
                             goto Lerror;
                         }
@@ -651,13 +647,9 @@ Language changes listed by -transition=id:
                         case "all":
                             global.params.vtls = true;
                             global.params.vfield = true;
-                            global.params.vcomplex = true;
                             break;
                         case "checkimports":
                             global.params.check10378 = true;
-                            break;
-                        case "complex":
-                            global.params.vcomplex = true;
                             break;
                         case "field":
                             global.params.vfield = true;

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2867,16 +2867,17 @@ public:
 
     /*************************************
      * Bugzilla 14488: Check if the inner most base type is complex or imaginary.
-     * Should only give alerts when set to emit transitional messages.
+     * Should only give alerts when deprecations are enabled.
      */
     final void checkComplexTransition(Loc loc)
     {
         Type t = baseElemOf();
+        static __gshared bool warned = false;
+
         while (t.ty == Tpointer || t.ty == Tarray)
             t = t.nextOf().baseElemOf();
         if (t.isimaginary() || t.iscomplex())
         {
-            const(char)* p = loc.toChars();
             Type rt;
             switch (t.ty)
             {
@@ -2895,13 +2896,15 @@ public:
             default:
                 assert(0);
             }
-            if (t.iscomplex())
+
+            if (!warned)
             {
-                fprintf(global.stdmsg, "%s: use of complex type '%s' is scheduled for deprecation, use 'std.complex.Complex!(%s)' instead\n", p ? p : "", toChars(), rt.toChars());
-            }
-            else
-            {
-                fprintf(global.stdmsg, "%s: use of imaginary type '%s' is scheduled for deprecation, use '%s' instead\n", p ? p : "", toChars(), rt.toChars());
+                if (t.iscomplex())
+                    .deprecation(loc, "use of complex type '%s' is scheduled for deprecation, use 'std.complex.Complex!(%s)' instead\n", toChars(), rt.toChars());
+                else
+                    .deprecation(loc, "use of imaginary type '%s' is scheduled for deprecation, use '%s' instead\n", toChars(), rt.toChars());
+
+                warned = true;
             }
         }
     }


### PR DESCRIPTION
Does not attempt to move checking anywhere else.
