### PR TITLE
fix Issue 13867 - Improve error message when overriding an extern(C++) interface

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -1115,16 +1115,19 @@ public:
 
             if (!doesoverride && isOverride() && (type.nextOf() || !may_override))
             {
+                BaseClass* bc = null;
                 Dsymbol s = null;
                 for (size_t i = 0; i < cd.baseclasses.dim; i++)
                 {
-                    s = (*cd.baseclasses)[i].sym.search_correct(ident);
+                    bc = (*cd.baseclasses)[i];
+                    s = bc.sym.search_correct(ident);
                     if (s)
                         break;
                 }
 
                 if (s)
-                    error("does not override any function, did you mean to override '%s'?", s.toPrettyChars());
+                    error("does not override any function, did you mean to override '%s%s'?",
+                        bc.sym.isCPPclass() ? "extern (C++) ".ptr : "".ptr, s.toPrettyChars());
                 else
                     error("does not override any function");
             }

--- a/test/fail_compilation/test13867.d
+++ b/test/fail_compilation/test13867.d
@@ -1,0 +1,40 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test13867.d(12): Error: function test13867.X.blah does not override any function, did you mean to override 'extern (C++) test13867.Base.blah'?
+fail_compilation/test13867.d(19): Error: function test13867.Z.blah does not override any function, did you mean to override 'extern (C++) test13867.Base.blah'?
+---
+*/
+extern (C++) class Base {
+    void blah() {}
+}
+class X : Base {
+    override void blah();//Error
+}
+extern (C++) class Y : Base {
+    override void blah(){}
+}
+class Z : Base {
+    alias blah = super.blah;
+    override void blah(){}//Error
+}
+class O : Base {
+    extern (C++) override void blah(){}
+}
+extern (C++) class OK : Base {
+    alias blah = super.blah;
+    override void blah(){}
+}
+
+void main() {
+    scope b = new Base();
+    b.blah();
+    scope x = new X();
+    x.blah();
+    scope y = new Y();
+    y.blah();
+    scope o = new O();
+    o.blah();
+    scope z = new Z();
+    z.blah();
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13867

This fix adds the `extern (C++)` as an extra hint to why overloading might have failed. 

(Ran into this while implementing a visitor in DDMD and couldn't figure out why it wouldn't override `visit`. Turns out all the classes in DDMD are `extern (C++)`.)
