### PR TITLE
Split global.params.hdrStripPlainFunctions from useInline

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -129,6 +129,7 @@ struct Param
     bool doHdrGeneration;               // process embedded documentation comments
     const(char)* hdrdir;                // write 'header' file to docdir directory
     const(char)* hdrname;               // write 'header' file to docname
+    bool hdrStripPlainFunctions;        // strip the bodies of plain (non-template) functions
 
     bool doJsonGeneration;              // write JSON file
     const(char)* jsonfilename;          // write JSON file to jsonfilename

--- a/src/globals.h
+++ b/src/globals.h
@@ -113,6 +113,7 @@ struct Param
     bool doHdrGeneration;  // process embedded documentation comments
     const char *hdrdir;    // write 'header' file to docdir directory
     const char *hdrname;   // write 'header' file to docname
+    bool hdrStripPlainFunctions; // strip the bodies of plain (non-template) functions
 
     bool doJsonGeneration;    // write JSON file
     const char *jsonfilename; // write JSON file to jsonfilename

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -1731,7 +1731,7 @@ public:
                 bodyToBuffer(f);
                 hgs.autoMember--;
             }
-            else if (hgs.tpltMember == 0 && !global.params.useInline)
+            else if (hgs.tpltMember == 0 && global.params.hdrStripPlainFunctions)
             {
                 buf.writeByte(';');
                 buf.writenl();
@@ -1745,7 +1745,7 @@ public:
 
     void bodyToBuffer(FuncDeclaration f)
     {
-        if (!f.fbody || (hgs.hdrgen && !global.params.useInline && !hgs.autoMember && !hgs.tpltMember))
+        if (!f.fbody || (hgs.hdrgen && global.params.hdrStripPlainFunctions && !hgs.autoMember && !hgs.tpltMember))
         {
             buf.writeByte(';');
             buf.writenl();

--- a/src/mars.d
+++ b/src/mars.d
@@ -366,6 +366,7 @@ private int tryMain(size_t argc, const(char)** argv)
     global.params.useInline = false;
     global.params.obj = true;
     global.params.useDeprecated = 2;
+    global.params.hdrStripPlainFunctions = true;
     global.params.linkswitches = new Strings();
     global.params.libfiles = new Strings();
     global.params.dllfiles = new Strings();
@@ -787,7 +788,10 @@ Language changes listed by -transition=id:
             else if (strcmp(p + 1, "property") == 0)
                 global.params.enforcePropertySyntax = true;
             else if (strcmp(p + 1, "inline") == 0)
+            {
                 global.params.useInline = true;
+                global.params.hdrStripPlainFunctions = false;
+            }
             else if (strcmp(p + 1, "dip25") == 0)
                 global.params.useDIP25 = true;
             else if (strcmp(p + 1, "lib") == 0)


### PR DESCRIPTION
As discussed in the original PR that added the feature (#945), DMD currently
triggers two entirely unrelated features with the -inline switch. Since LDC
does not really have an equivalent to that switch in the first place, but
users still want to control the emission of function bodies, we need to be
control it separately.

For DMD, global.params.hdrStripPlainFunctions is always set to
!global.params.useInline in the driver to match the current behavior.

Ping @yebblies.
