### PR TITLE
Fix Issue 2659 - Deprecate using the return of a comma expression

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -5,6 +5,7 @@ $(COMMENT Pending changelog for 2.072. This will get copied to dlang.org and
 )
 
 $(BUGSTITLE Language Changes,
+    $(LI $(RELATIVE_LINK2 deprecated_commaexp, Using the result of a comma expression is deprecated.))
 )
 
 $(BUGSTITLE Compiler Changes,
@@ -13,6 +14,35 @@ $(BUGSTITLE Compiler Changes,
 )
 
 $(BUGSTITLE Language Changes,
+    $(LI $(LNAME2 deprecated_commaexp, Using the result of a comma expression is deprecated.)
+
+    $(P Comma expressions expressions have proven to be a frequent source of confusion, and bug.
+        Using their result will now trigger a deprecation message.)
+
+    $(P Example:)
+
+        ---
+        module comma;
+
+        void main () {
+          size_t aggr;
+          MyContainerClass mc;
+          auto r1 = getRange!int, r2 = getRange!int;
+          // This is okay
+          for (; !r1.empty && r2.empty; r1.popFront, r2.popFront)
+            aggr += compute(r1.front, r2.front);
+          // This is not, as only the 3rd part (increment) allows commas
+          for (; !r1.empty, r2.empty; r1.popFront, r2.popFront)
+            aggr += compute(r1.front, r2.front);
+          // This is okay, the result is not used.
+          if (!mc)
+            mc = new MyContainerClass, mc.append(new Entry);
+          // But this is not
+          if (!mc)
+            mc = (aggr++, new MyContainerClass);
+        }
+        ---
+    )
 )
 
 $(BUGSTITLE Compiler Changes,

--- a/src/expression.h
+++ b/src/expression.h
@@ -1023,6 +1023,8 @@ public:
 class CommaExp : public BinExp
 {
 public:
+    const bool isGenerated;
+    bool allowCommaExp;
     Expression *semantic(Scope *sc);
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();

--- a/src/parse.d
+++ b/src/parse.d
@@ -6990,7 +6990,7 @@ final class Parser : Lexer
         {
             nextToken();
             auto e2 = parseAssignExp();
-            e = new CommaExp(loc, e, e2);
+            e = new CommaExp(loc, e, e2, false);
             loc = token.loc;
         }
         return e;

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -85,6 +85,10 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         if (s.exp)
         {
             //printf("ExpStatement::semantic() %s\n", exp.toChars());
+
+            // Allow CommaExp in ExpStatement because return isn't used
+            CommaExp.allow(s.exp);
+
             s.exp = s.exp.semantic(sc);
             s.exp = resolveProperties(sc, s.exp);
             s.exp = s.exp.addDtorHook(sc);
@@ -444,6 +448,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         }
         if (fs.increment)
         {
+            CommaExp.allow(fs.increment);
             fs.increment = fs.increment.semantic(sc);
             fs.increment = resolveProperties(sc, fs.increment);
             if (checkNonAssignmentArrayOp(fs.increment))

--- a/test/fail_compilation/commaexp.d
+++ b/test/fail_compilation/commaexp.d
@@ -1,0 +1,43 @@
+/* REQUIRED_ARGS: -o- -de
+TEST_OUTPUT:
+---
+fail_compilation/commaexp.d(24): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/commaexp.d(36): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/commaexp.d(37): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/commaexp.d(38): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/commaexp.d(39): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/commaexp.d(41): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/commaexp.d(42): Deprecation: Using the result of a comma expression is deprecated
+---
+*/
+
+class Entry {}
+class MyContainerClass { bool append (Entry) { return false; } }
+
+int main () {
+    bool ok;
+    size_t aggr;
+    MyContainerClass mc;
+
+    // Bug 15997
+    enum WINHTTP_ERROR_BASE = 4200;
+    enum ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED = (WINHTTP_ERROR_BASE, + 44);
+
+    // OK
+    for (size_t i; i < 5; ++i, i += 1) {}
+    for (size_t i; i < 5; ++i, i += 1, i++) {}
+    if (!mc)
+        mc = new MyContainerClass, mc.append(new Entry);
+    if (Object o = cast(Object)mc) {} // Lowering
+    ok = true, mc.append(new Entry);
+    assert(ok);
+
+    // NOPE
+    for (size_t i; i < 5; ++i, i += (i++, 1)) {}
+    for (; aggr++, aggr > 5;) {}
+    if (Object o = (ok = true, null)) {}
+    ok = (true, mc.append(new Entry));
+    assert(!ok);
+    ok = true, (ok = (true, false));
+    return 42, 0;
+}

--- a/test/fail_compilation/diag10862.d
+++ b/test/fail_compilation/diag10862.d
@@ -52,15 +52,16 @@ void test1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10862.d(73): Error: assignment cannot be used as a condition, perhaps == was meant?
-fail_compilation/diag10862.d(76): Error: assignment cannot be used as a condition, perhaps == was meant?
-fail_compilation/diag10862.d-mixin-79(79): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(74): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d(77): Error: assignment cannot be used as a condition, perhaps == was meant?
 fail_compilation/diag10862.d-mixin-80(80): Error: assignment cannot be used as a condition, perhaps == was meant?
 fail_compilation/diag10862.d-mixin-81(81): Error: assignment cannot be used as a condition, perhaps == was meant?
 fail_compilation/diag10862.d-mixin-82(82): Error: assignment cannot be used as a condition, perhaps == was meant?
-fail_compilation/diag10862.d-mixin-85(85): Error: a + b is not an lvalue
-fail_compilation/diag10862.d-mixin-86(86): Error: undefined identifier 'c'
-fail_compilation/diag10862.d(88): Error: undefined identifier 'semanticError'
+fail_compilation/diag10862.d-mixin-83(83): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/diag10862.d-mixin-83(83): Error: assignment cannot be used as a condition, perhaps == was meant?
+fail_compilation/diag10862.d-mixin-86(86): Error: a + b is not an lvalue
+fail_compilation/diag10862.d-mixin-87(87): Error: undefined identifier 'c'
+fail_compilation/diag10862.d(89): Error: undefined identifier 'semanticError'
 ---
 */
 void test2()

--- a/test/fail_compilation/fail13902.d
+++ b/test/fail_compilation/fail13902.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -o-
+// REQUIRED_ARGS: -o- -d
 
 struct S1 { int v; }
 struct S2 { int* p; }

--- a/test/fail_compilation/ice10949.d
+++ b/test/fail_compilation/ice10949.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10949.d(10): Error: array index 3 is out of bounds [5, 5][0 .. 2]
-fail_compilation/ice10949.d(10): Error: array index 17 is out of bounds [2, 3][0 .. 2]
-fail_compilation/ice10949.d(10): Error: array index 9 is out of bounds [3, 3, 3][0 .. 3]
+fail_compilation/ice10949.d(11): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/ice10949.d(11): Error: array index 3 is out of bounds [5, 5][0 .. 2]
+fail_compilation/ice10949.d(11): Error: array index 17 is out of bounds [2, 3][0 .. 2]
+fail_compilation/ice10949.d(11): Error: array index 9 is out of bounds [3, 3, 3][0 .. 3]
 ---
 */
 int global;


### PR DESCRIPTION
The comma operator is a constant source of confusion / bugs.
In all use case, code using comma operator can be rewritten without hurting readability. The exception is the increment part of `for` loops, where it is pretty handy.
This P.R. introduce a deprecation message for every usage that isn't in a for loop increment.

Example of fixes needed outside of DMD:
- https://github.com/dlang/druntime/pull/1561
- Bug introduced by CommaExp: https://github.com/dlang/druntime/pull/1562
- https://github.com/dlang/dub/pull/837
- https://github.com/rejectedsoftware/vibe.d/pull/1487

Note:
There were some `CommaExp` in the test that I had to silence using `-d`.
The underlying reason is that deprecations message shouldn't require those tests to change (and the change was pretty big since I would have had to update all line numbers of error messages...).

Ultimately, in `for` statement, I think we should recommend using something along the line of `{ a.popFront; b.popFront; }` instead, but it shouldn't introduce any performance hit, which is not currently the case.

Mandatory ping to @andralex / @WalterBright as this is a language change.
