### PR TITLE
OpenBSD: Add missing TARGET_OPENBSD to backconfig

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -326,7 +326,7 @@ void util_set32()
     tysize[TYnullptr] = LONGSIZE;
     tysize[TYnptr] = LONGSIZE;
     tysize[TYnref] = LONGSIZE;
-#if TARGET_LINUX || TARGET_FREEBSD || TARGET_SOLARIS
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     tysize[TYldouble] = 12;
     tysize[TYildouble] = 12;
     tysize[TYcldouble] = 24;
@@ -353,7 +353,7 @@ void util_set32()
     tyalignsize[TYnullptr] = LONGSIZE;
     tyalignsize[TYnref] = LONGSIZE;
     tyalignsize[TYnptr] = LONGSIZE;
-#if TARGET_LINUX || TARGET_FREEBSD || TARGET_SOLARIS
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     tyalignsize[TYldouble] = 4;
     tyalignsize[TYildouble] = 4;
     tyalignsize[TYcldouble] = 4;
@@ -391,7 +391,7 @@ void util_set64()
     tysize[TYnullptr] = 8;
     tysize[TYnptr] = 8;
     tysize[TYnref] = 8;
-#if TARGET_LINUX || TARGET_FREEBSD || TARGET_SOLARIS || TARGET_OSX
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS || TARGET_OSX
     tysize[TYldouble] = 16;
     tysize[TYildouble] = 16;
     tysize[TYcldouble] = 32;
@@ -414,7 +414,7 @@ void util_set64()
     tyalignsize[TYnullptr] = 8;
     tyalignsize[TYnptr] = 8;
     tyalignsize[TYnref] = 8;
-#if TARGET_LINUX || TARGET_FREEBSD || TARGET_SOLARIS
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     tyalignsize[TYldouble] = 16;
     tyalignsize[TYildouble] = 16;
     tyalignsize[TYcldouble] = 16;

--- a/src/mars.d
+++ b/src/mars.d
@@ -1941,7 +1941,7 @@ private void addDefaultVersionIdentifiers()
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OpenBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
-        global.params.isFreeBSD = true;
+        global.params.isOpenBSD = true;
     }
     else static if (TARGET_SOLARIS)
     {


### PR DESCRIPTION
Without these DMD does not run on OpenBSD
