### PR TITLE
Fix invalid AST produced by issue 15839 fix

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -9098,7 +9098,11 @@ public:
                     if (auto cdp = ad.isClassDeclaration())
                     {
                         auto ve = new ThisExp(e.loc);
+
                         ve.var = fd.vthis;
+                        const nestedError = fd.vthis.checkNestedReference(sc, e.loc);
+                        assert(!nestedError);
+
                         ve.type = fd.vthis.type.addMod(e.type.mod);
                         return ve;
                     }


### PR DESCRIPTION
The fix for 15839 (accessing this.outer from a member function
inside a nested class) in bb5f550edd7 produces a ThisExp that
refers to the 'this' VarDecl in an outer scope, leading to the
latter being referenced from the nested scope without that being
added to its nestedRefs. Subsequently, the VarDecl is also not
present in the outer FuncDecls closureVars.

This is a weird construct, and outside the AST invariants that
would previously hold. This commit properly at least properly
registers the nested reference, but using a ThisExp in this
manner might not be the cleanest way in the first place.

---

As DMD somehow manages to generate the correct code
regardless, I don't have a test case to offer – at least not until
the unified frontend is reality (the issue breaks LDC). I'm open
to other suggestions, but between this and [issue 15650](https://issues.dlang.org/show_bug.cgi?id=15650), I'm not
sure whether it's a good idea to follow DMD's implementation.
