### PR TITLE
fix Issue 13727 - std.stdio.File not thread-safe

### DIFF
--- a/test/runnable/extra-files/extra13727.txt
+++ b/test/runnable/extra-files/extra13727.txt
@@ -1,0 +1,1 @@
+It doesn't matter what this file contains, any old junk will do.

--- a/test/runnable/test13727.d
+++ b/test/runnable/test13727.d
@@ -1,0 +1,23 @@
+// https://issues.dlang.org/show_bug.cgi?id=13727
+
+import std.array;
+import std.parallelism;
+import std.stdio;
+
+void main()
+{
+    foreach (fn;
+        ["runnable/extra-files/extra13727.txt"]
+        .replicate(1000)
+        .parallel
+    )
+    {
+        // synchronized
+	version (Windows)
+	    string mode = "rb";
+	else
+	    string mode = "r";
+        { File f = File(fn, mode); }
+    }
+}
+


### PR DESCRIPTION
The fix is actually here https://github.com/DigitalMars/dmc/pull/2 (access required) and needs a new DMC runtime library snn.lib

https://issues.dlang.org/show_bug.cgi?id=13727
