### PR TITLE
fix Issue 15966 - imports in base class ignored on symbol lookup

### DIFF
--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1122,12 +1122,10 @@ public:
 
         auto s = ScopeDsymbol.search(loc, ident, flags);
 
-        if ((flags & (SearchLocalsOnly | SearchImportsOnly)) != 0)
-            flags |= SearchLocalsOnly;
-
         if (!s)
         {
             // Search bases classes in depth-first, left to right order
+            const accessModule = getAccessModule();
             for (size_t i = 0; i < baseclasses.dim; i++)
             {
                 BaseClass* b = (*baseclasses)[i];
@@ -1139,7 +1137,10 @@ public:
                     {
                         import ddmd.access : symbolIsVisible;
 
-                        s = b.sym.search(loc, ident, flags);
+                        if (!(flags & IgnoreSymbolVisibility) && accessModule != b.sym.getAccessModule())
+                            s = b.sym.search(loc, ident, flags | IgnorePrivateImports);
+                        else
+                            s = b.sym.search(loc, ident, flags);
                         if (!s)
                             continue;
                         else if (s == this) // happens if s is nested in this and derives from this

--- a/test/compilable/imports/test15966a.d
+++ b/test/compilable/imports/test15966a.d
@@ -1,0 +1,1 @@
+alias T1 = int;

--- a/test/compilable/imports/test15966b.d
+++ b/test/compilable/imports/test15966b.d
@@ -1,0 +1,1 @@
+alias T2 = int;

--- a/test/compilable/imports/test15966base.d
+++ b/test/compilable/imports/test15966base.d
@@ -1,0 +1,8 @@
+module pkg.test15966base;
+
+class Base
+{
+    public import imports.test15966a;
+    protected import imports.test15966b;
+    package(pkg) import imports.test15966c;
+}

--- a/test/compilable/imports/test15966c.d
+++ b/test/compilable/imports/test15966c.d
@@ -1,0 +1,1 @@
+alias T3 = int;

--- a/test/compilable/test15966.d
+++ b/test/compilable/test15966.d
@@ -1,0 +1,9 @@
+module pkg.test15966;
+import imports.test15966base;
+
+class Derived : Base
+{
+    T1 v1;
+    T2 v2;
+    T3 v3;
+}

--- a/test/fail_compilation/imports/test15966a.d
+++ b/test/fail_compilation/imports/test15966a.d
@@ -1,0 +1,1 @@
+alias T1 = int;

--- a/test/fail_compilation/imports/test15966b.d
+++ b/test/fail_compilation/imports/test15966b.d
@@ -1,0 +1,1 @@
+alias T2 = int;

--- a/test/fail_compilation/imports/test15966base.d
+++ b/test/fail_compilation/imports/test15966base.d
@@ -1,0 +1,8 @@
+module imports.test15966base;
+
+class Base
+{
+    private import imports.test15966a;
+    // only private imports are restricted atm.
+    package(imports) import imports.test15966b;
+}

--- a/test/fail_compilation/test15966.d
+++ b/test/fail_compilation/test15966.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test15966.d(14): Deprecation: test15966a.T1 is not visible from module test15966
+---
+*/
+module pkg.test15966;
+
+import imports.test15966base;
+
+class Derived : Base
+{
+    T1 v1;
+    T2 v2;
+}


### PR DESCRIPTION
- fix lookup for non-private base class imports
- error->deprecation lookup for private base class imports
- can't implement package(pkg) visibility atm. b/c imports use a
  separate logic to restrict visibility that only discerns private
  and everything else
