### PR TITLE
Refactor: add compileIt functions to CompileExp and CompileStatement

### DIFF
--- a/src/attrib.d
+++ b/src/attrib.d
@@ -1388,26 +1388,31 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
         Dsymbol.setScope(sc);
     }
 
-    void compileIt(Scope* sc)
+    private Dsymbols* compileIt(Scope* sc)
     {
-        //printf("CompileDeclaration::compileIt(loc = %d) %s\n", loc.linnum, exp->toChars());
+        //printf("CompileDeclaration::compileIt() %s\n", exp.toChars());
         auto se = semanticString(sc, exp, "argument to mixin");
         if (!se)
-            return;
+            return null;
         se = se.toUTF8(sc);
 
         uint errors = global.errors;
         scope Parser p = new Parser(loc, sc._module, se.toStringz(), false);
         p.nextToken();
+        //printf("p.loc.linnum = %d\n", p.loc.linnum);
 
-        decl = p.parseDeclDefs(0);
-        if (p.token.value != TOKeof)
-            exp.error("incomplete mixin declaration (%s)", se.toChars());
+        auto d = p.parseDeclDefs(0);
         if (p.errors)
         {
-            assert(global.errors != errors);
-            decl = null;
+            assert(global.errors != errors); // should have caught all these cases
+            return null;
         }
+        if (p.token.value != TOKeof)
+        {
+            exp.error("incomplete mixin declaration (%s)", se.toChars());
+            return null;
+        }
+        return d;
     }
 
     override void semantic(Scope* sc)
@@ -1415,7 +1420,7 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
         //printf("CompileDeclaration::semantic()\n");
         if (!compiled)
         {
-            compileIt(sc);
+            decl = compileIt(sc);
             AttribDeclaration.addMember(sc, scopesym);
             compiled = true;
 

--- a/src/attrib.h
+++ b/src/attrib.h
@@ -205,7 +205,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
-    void compileIt(Scope *sc);
+    Dsymbols *compileIt(Scope *sc);
     void semantic(Scope *sc);
     const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }

--- a/src/expression.d
+++ b/src/expression.d
@@ -8279,13 +8279,9 @@ extern (C++) final class CompileExp : UnaExp
         super(loc, TOKmixin, __traits(classInstanceSize, CompileExp), e);
     }
 
-    override Expression semantic(Scope* sc)
+    private Expression compileIt(Scope* sc)
     {
-        static if (LOGSEMANTIC)
-        {
-            printf("CompileExp::semantic('%s')\n", toChars());
-        }
-
+        //printf("CompileExp::compileIt() %s\n", exp.toChars());
         auto se = semanticString(sc, e1, "argument to mixin");
         if (!se)
             return new ErrorExp();
@@ -8296,7 +8292,7 @@ extern (C++) final class CompileExp : UnaExp
         p.nextToken();
         //printf("p.loc.linnum = %d\n", p.loc.linnum);
 
-        Expression e = p.parseExpression();
+        auto e = p.parseExpression();
         if (p.errors)
         {
             assert(global.errors != errors); // should have caught all these cases
@@ -8307,7 +8303,17 @@ extern (C++) final class CompileExp : UnaExp
             error("incomplete mixin expression (%s)", se.toChars());
             return new ErrorExp();
         }
+        return e;
+    }
 
+    override Expression semantic(Scope* sc)
+    {
+        static if (LOGSEMANTIC)
+        {
+            printf("CompileExp::semantic('%s')\n", toChars());
+        }
+
+        auto e = compileIt(sc);
         return e.semantic(sc);
     }
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -743,6 +743,7 @@ public:
 class CompileExp : public UnaExp
 {
 public:
+    Expression *compileIt(Scope *sc);
     Expression *semantic(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/statement.d
+++ b/src/statement.d
@@ -1242,9 +1242,9 @@ extern (C++) final class CompileStatement : Statement
         return new CompileStatement(loc, exp.syntaxCopy());
     }
 
-    override Statements* flatten(Scope* sc)
+    private Statements* compileIt(Scope* sc)
     {
-        //printf("CompileStatement::flatten() %s\n", exp->toChars());
+        //printf("CompileStatement::compileIt() %s\n", exp.toChars());
 
         auto errorStatements()
         {
@@ -1261,6 +1261,7 @@ extern (C++) final class CompileStatement : Statement
         uint errors = global.errors;
         scope Parser p = new Parser(loc, sc._module, se.toStringz(), false);
         p.nextToken();
+        //printf("p.loc.linnum = %d\n", p.loc.linnum);
 
         auto a = new Statements();
         while (p.token.value != TOKeof)
@@ -1274,6 +1275,12 @@ extern (C++) final class CompileStatement : Statement
             a.push(s);
         }
         return a;
+    }
+
+    override Statements* flatten(Scope* sc)
+    {
+        //printf("CompileStatement::flatten() %s\n", exp.toChars());
+        return compileIt(sc);
     }
 
     override void accept(Visitor v)

--- a/src/statement.h
+++ b/src/statement.h
@@ -166,6 +166,7 @@ public:
     Expression *exp;
 
     Statement *syntaxCopy();
+    Statements *compileIt(Scope *sc);
     Statements *flatten(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
Now these three `compileIt` functions are consistent by reflecting the string mixin feature behavior.
