### PR TITLE
replace mangle() with mangleToBuffer()

### DIFF
--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -814,13 +814,6 @@ public:
     }
 }
 
-extern (C++) const(char)* mangle(Dsymbol s)
-{
-    OutBuffer buf;
-    scope Mangler v = new Mangler(&buf);
-    s.accept(v);
-    return buf.extractString();
-}
 
 /******************************************************************************
  * Returns exact mangled name of function.
@@ -862,3 +855,10 @@ extern (C++) void mangleToBuffer(Expression e, OutBuffer* buf)
     scope Mangler v = new Mangler(buf);
     e.accept(v);
 }
+
+extern (C++) void mangleToBuffer(Dsymbol s, OutBuffer* buf)
+{
+    scope Mangler v = new Mangler(buf);
+    s.accept(v);
+}
+

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -83,8 +83,8 @@ struct Ungag
     ~Ungag() { global.gag = oldgag; }
 };
 
-const char *mangle(Dsymbol *s);
 const char *mangleExact(FuncDeclaration *fd);
+void mangleToBuffer(Dsymbol *s, OutBuffer* buf);
 
 enum PROTKIND
 {

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -8149,7 +8149,10 @@ public:
                     error("forward reference of %s %s", d.kind(), d.toChars());
                     continue;
                 }
-                const(char)* p = mangle(sa);
+
+                OutBuffer bufsa;
+                mangleToBuffer(sa, &bufsa);
+                auto s = bufsa.peekSlice();
 
                 /* Bugzilla 3043: if the first character of p is a digit this
                  * causes ambiguity issues because the digits of the two numbers are adjacent.
@@ -8158,7 +8161,7 @@ public:
                  * Unfortunately, fixing this ambiguity will break existing binary
                  * compatibility and the demanglers, so we'll leave it as is.
                  */
-                buf.printf("%llu%s", cast(ulong)strlen(p), p);
+                buf.printf("%u%.*s", cast(uint)s.length, cast(int)s.length, s.ptr);
             }
             else if (va)
             {

--- a/src/expression.d
+++ b/src/expression.d
@@ -8519,8 +8519,10 @@ public:
                         if (f.checkForwardRef(loc))
                             return new ErrorExp();
                     }
-                    const(char)* s = mangle(ds);
-                    Expression e = new StringExp(loc, cast(void*)s, strlen(s));
+                    OutBuffer buf;
+                    mangleToBuffer(ds, &buf);
+                    const s = buf.peekSlice();
+                    Expression e = new StringExp(loc, buf.extractString(), s.length);
                     e = e.semantic(sc);
                     return e;
                 }

--- a/src/toir.c
+++ b/src/toir.c
@@ -614,10 +614,15 @@ int intrinsic_op(FuncDeclaration *fd)
 
         if (global.params.is64bit &&
             fd->toParent()->isTemplateInstance() &&
-            !strcmp(mangle(fd->getModule()), "4core4stdc6stdarg") &&
             fd->ident == Id::va_start)
         {
-            return OPva_start;
+            OutBuffer buf;
+            mangleToBuffer(fd->getModule(), &buf);
+            const char *s = buf.peekString();
+            if (!strcmp(s, "4core4stdc6stdarg"))
+            {
+                return OPva_start;
+            }
         }
 
         return -1;


### PR DESCRIPTION
This free's memory in buffer after it is no longer needed, and speeds things up by not requiring strlen() calls.
