### PR TITLE
doc.d: use .offset rather than .size

### DIFF
--- a/src/doc.d
+++ b/src/doc.d
@@ -2436,7 +2436,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
                     break;
                 size_t len = j - i;
                 // leading '_' means no highlight unless it's a reserved symbol name
-                if (c == '_' && (i == 0 || !isdigit(*(start - 1))) && (i == buf.size - 1 || !isReservedName(start, len)))
+                if (c == '_' && (i == 0 || !isdigit(*(start - 1))) && (i == buf.offset - 1 || !isReservedName(start, len)))
                 {
                     buf.remove(i, 1);
                     i = j - 1;


### PR DESCRIPTION
`.size` is the size of the buffer, `.offset` is the amount used in the buffer.
