### PR TITLE
Issue 16011, 16012, 16013 - Improve forward reference resolution during field type analysis

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -30,8 +30,8 @@ import ddmd.visitor;
 
 enum Sizeok : int
 {
-    SIZEOKnone,             // size of aggregate is not yet able to compute
-    SIZEOKfwd,              // size of aggregate is ready to compute
+    SIZEOKnone,             // size of aggregate is not yet computed
+    SIZEOKfwd,              // size of aggregate is finalizing
     SIZEOKdone,             // size of aggregate is set correctly
 }
 
@@ -209,7 +209,6 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      * Runs semantic() for all instance field variables, but also
      * the field types can reamin yet not resolved forward references,
      * except direct recursive definitions.
-     * After the process sizeok is set to SIZEOKfwd.
      *
      * Returns:
      *      false if any errors occur.
@@ -220,6 +219,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             return true;
 
         //printf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);
+        fields.setDim(0);
 
         extern (C++) static int func(Dsymbol s, void* param)
         {
@@ -229,17 +229,23 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             if (v.storage_class & STCmanifest)
                 return 0;
 
+            auto ad = cast(AggregateDeclaration)param;
+
             if (v._scope)
                 v.semantic(null);
+            // Note: Aggregate fields or size could have determined during v.semantic.
+            if (ad.sizeok != SIZEOKnone)
+                return 1;
+
             if (v.aliassym)
                 return 0;   // If this variable was really a tuple, skip it.
+            if (!v.isField())
+                return 0;   // not an instance field
 
-            if (v.storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCctfe | STCtemplateparameter))
-                return 0;
-            if (!v.isField() || v.semanticRun < PASSsemanticdone)
+            if (v.semanticRun < PASSsemanticdone && (!v.type || !v.type.deco))
                 return 1;   // unresolvable forward reference
 
-            auto ad = cast(AggregateDeclaration)param;
+            //printf("\t[%d] %s, type = %s %s\n", ad.fields.dim, v.toPrettyChars(), v.type.deco, v.type.toChars());
             ad.fields.push(v);
 
             if (v.storage_class & STCref)
@@ -258,23 +264,24 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             return 0;
         }
 
-        fields.setDim(0);
-
         for (size_t i = 0; i < members.dim; i++)
         {
             auto s = (*members)[i];
             if (s.apply(&func, cast(void*)this))
+            {
+                if (sizeok != SIZEOKnone)
+                    return true;
                 return false;
+            }
         }
-
-        if (sizeok != SIZEOKdone)
-            sizeok = SIZEOKfwd;
 
         return true;
     }
 
     /***************************************
      * Collect all instance fields, then determine instance size.
+     * After the process sizeok is set to SIZEOKdone.
+     *
      * Returns:
      *      false if failed to determine the size.
      */
@@ -282,11 +289,27 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     {
         //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 
-        // The previous instance size finalizing had:
+        // Previous instance size finalizing had failed.
         if (type.ty == Terror)
-            return false;   // failed already
+            return false;
+
+        // Instance size is already calculated.
         if (sizeok == SIZEOKdone)
-            return true;    // succeeded
+            return true;
+
+        auto errorNoSize()
+        {
+            // There's unresolvable forward reference.
+            if (type != Type.terror)
+                error(loc, "no size because of forward reference");
+            type = Type.terror;
+            errors = true;
+            return false;
+        }
+
+        // Detect circular dependency while instance size finalizing.
+        if (sizeok == SIZEOKfwd)
+            return errorNoSize();
 
         if (!members)
         {
@@ -298,32 +321,29 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             semantic(null);
 
         // Determine the instance size of base class first.
-        if (auto cd = isClassDeclaration())
+        auto cd = isClassDeclaration();
+        if (cd && cd.baseClass)
         {
-            cd = cd.baseClass;
-            if (cd && !cd.determineSize(loc))
-                goto Lfail;
+            if (!cd.baseClass.determineSize(loc))
+                return false;
+            if (sizeok == SIZEOKdone)
+                return true;
         }
 
-        // Determine instance fields when sizeok == SIZEOKnone
+        //printf("+AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
+
+        // Determine instance fields
         if (!determineFields())
-            goto Lfail;
-        if (sizeok != SIZEOKdone)
-            finalizeSize();
-
-        // this aggregate type has:
-        if (type.ty == Terror)
-            return false;   // marked as invalid during the finalizing.
+            return errorNoSize();
+        // Note: Aggregate size could have determined during determineFields.
         if (sizeok == SIZEOKdone)
-            return true;    // succeeded to calculate instance size.
+            return true;
 
-    Lfail:
-        // There's unresolvable forward reference.
-        if (type != Type.terror)
-            error(loc, "no size because of forward reference");
-        type = Type.terror;
-        errors = true;
-        return false;
+        sizeok = SIZEOKfwd;
+
+        finalizeSize();
+
+        return sizeok == SIZEOKdone ? true : errorNoSize();
     }
 
     abstract void finalizeSize();
@@ -551,7 +571,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     static void alignmember(structalign_t alignment, uint size, uint* poffset)
     {
-        //printf("alignment = %d, size = %d, offset = %d\n",alignment,size,offset);
+        //printf("alignment = %d, size = %d, offset = %d\n", alignment, size, *poffset);
         switch (alignment)
         {
         case cast(structalign_t)1:
@@ -698,10 +718,16 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             vthis.storage_class |= STCfield;
             vthis.parent = this;
             vthis.protection = Prot(PROTpublic);
+
+            if (sizeok != SIZEOKnone)
+            {
+                vthis.error("cannot be further field because it will change the determined %s size", toChars());
+            }
+
             vthis.alignment = t.alignment();
             vthis.semanticRun = PASSsemanticdone;
 
-            if (sizeok == SIZEOKfwd)
+            if (sizeok == SIZEOKnone)
                 fields.push(vthis);
         }
     }

--- a/src/aliasthis.d
+++ b/src/aliasthis.d
@@ -49,6 +49,8 @@ extern (C++) final class AliasThis : Dsymbol
 
     override void semantic(Scope* sc)
     {
+        //printf("AliasThis::semantic(%s)\n", ident.toChars());
+
         Dsymbol p = sc.parent.pastMixin();
         AggregateDeclaration ad = p.isAggregateDeclaration();
         if (!ad)
@@ -94,6 +96,8 @@ extern (C++) final class AliasThis : Dsymbol
         }
 
         ad.aliasthis = s;
+
+        //printf("-AliasThis::semantic(%s) s = %s %s\n", ident.toChars(), s.kind(), s.toChars());
     }
 
     override const(char)* kind() const

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1246,6 +1246,8 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         {
             s.setFieldOffset(this, &offset, false);
         }
+        if (type.ty == Terror)
+            return;
 
         sizeok = SIZEOKdone;
 

--- a/src/expression.d
+++ b/src/expression.d
@@ -15498,6 +15498,8 @@ extern (C++) final class RemoveExp : BinExp
  */
 extern (C++) final class EqualExp : BinExp
 {
+    EqualExp ate;
+
     extern (D) this(TOK op, Loc loc, Expression e1, Expression e2)
     {
         super(loc, op, __traits(classInstanceSize, EqualExp), e1, e2);

--- a/src/expression.h
+++ b/src/expression.h
@@ -1331,6 +1331,8 @@ public:
 class EqualExp : public BinExp
 {
 public:
+    EqualExp *ate;
+
     Expression *semantic(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }

--- a/src/func.d
+++ b/src/func.d
@@ -1338,11 +1338,11 @@ extern (C++) class FuncDeclaration : Declaration
             errors = true;
             return;
         }
-        //printf("FuncDeclaration::semantic3('%s.%s', %p, sc = %p, loc = %s)\n", parent->toChars(), toChars(), this, sc, loc.toChars());
+        //printf("FuncDeclaration::semantic3('%s.%s', %p, sc = %p, loc = %s)\n", parent.toChars(), toChars(), this, sc, loc.toChars());
         //fflush(stdout);
-        //printf("storage class = x%x %x\n", sc->stc, storage_class);
+        //printf("storage class = x%llx %llx\n", sc.stc, storage_class);
         //{ static int x; if (++x == 2) *(char*)0=0; }
-        //printf("\tlinkage = %d\n", sc->linkage);
+        //printf("\tlinkage = %d\n", sc.linkage);
 
         if (ident == Id.assign && !inuse)
         {
@@ -2231,7 +2231,7 @@ extern (C++) class FuncDeclaration : Declaration
         semantic3Errors = (global.errors != oldErrors) || (fbody && fbody.isErrorStatement());
         if (type.ty == Terror)
             errors = true;
-        //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", parent->toChars(), toChars(), sc, loc.toChars());
+        //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", parent.toChars(), toChars(), sc, loc.toChars());
         //fflush(stdout);
     }
 

--- a/src/opover.d
+++ b/src/opover.d
@@ -1220,23 +1220,30 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                  * also compare the parent class's equality. Otherwise, compares
                  * the identity of parent context through void*.
                  */
-                if (e.att1 && t1 == e.att1) return;
-                if (e.att2 && t2 == e.att2) return;
 
-                e = cast(EqualExp)e.copy();
-                if (!e.att1) e.att1 = t1;
-                if (!e.att2) e.att2 = t2;
-                e.e1 = new DotIdExp(e.loc, e.e1, Id._tupleof);
-                e.e2 = new DotIdExp(e.loc, e.e2, Id._tupleof);
-                result = e.semantic(sc);
+                for (auto eqx = e.ate; eqx; eqx = eqx.ate)
+                {
+                    //printf("\teqx = %s (e1 = %s, e2 = %s)\n", eqx.toChars(),
+                    //    eqx.e1.type.toChars(), eqx.e2.type.toChars());
+                    if (eqx.e1.type == t1) return;
+                    if (eqx.e2.type == t2) return;
+                }
+
+                auto eq = cast(EqualExp)e.copy();
+                eq.ate = e;
+
+                eq.e1 = new DotIdExp(e.loc, e.e1, Id._tupleof);
+                eq.e2 = new DotIdExp(e.loc, e.e2, Id._tupleof);
+                //printf("EqualExp %p %s vs %p %s eq = %s\n", t1, t1.toChars(), t2, t2.toChars(), eq.toChars());
+                result = eq.semantic(sc);
 
                 /* Bugzilla 15292, if the rewrite result is same with the original,
                  * the equality is unresolvable because it has recursive definition.
                  */
-                if (result.op == e.op &&
+                if (result.op == eq.op &&
                     (cast(EqualExp)result).e1.type.toBasetype() == t1)
                 {
-                    e.error("cannot compare %s because its auto generated member-wise equality has recursive definition",
+                    eq.error("cannot compare %s because its auto generated member-wise equality has recursive definition",
                         t1.toChars());
                     result = new ErrorExp();
                 }
@@ -1270,8 +1277,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         auto ex1 = (*tup1.exps)[i];
                         auto ex2 = (*tup2.exps)[i];
                         auto eeq = new EqualExp(e.op, e.loc, ex1, ex2);
-                        eeq.att1 = e.att1;
-                        eeq.att2 = e.att2;
+                        eeq.ate = e.ate;
 
                         if (!result)
                             result = eeq;

--- a/test/compilable/testfwdref.d
+++ b/test/compilable/testfwdref.d
@@ -763,3 +763,49 @@ struct S16013b
 {
     RC16013b s;
 }
+
+/***************************************************/
+// 16012
+
+void emplace16012(S16012* chunk) { *chunk = S16012.init; }
+
+struct RC16012()
+{
+    struct RCStore
+    {
+        struct Impl { S16012 _payload; }
+
+        Impl* _impl;
+
+        void initialize()
+        {
+            _impl = new Impl;
+            emplace16012(&_impl._payload);
+        }
+    }
+
+    RCStore _store;
+
+    void opAssign(typeof(this) rhs) {}
+    void opAssign(S16012 rhs) {}
+
+    ref S16012 rcPayload()
+    {
+        if (_store._impl is null)
+            _store.initialize();
+        return _store._impl._payload;
+    }
+
+    alias rcPayload this;
+}
+
+struct S16012
+{
+    size_t x;
+    RC16012!() s;
+}
+
+static assert(S16012.sizeof == size_t.sizeof + (void*).sizeof);
+static assert(RC16012!().sizeof == (void*).sizeof);
+static assert(RC16012!().RCStore.sizeof == (void*).sizeof);
+static assert(RC16012!().RCStore.Impl.sizeof == S16012.sizeof);

--- a/test/compilable/testfwdref.d
+++ b/test/compilable/testfwdref.d
@@ -714,3 +714,52 @@ struct Stmt15726b(T)
 }
 
 Con15726b!int x15726b;
+
+/***************************************************/
+// 16013
+
+struct Impl16013a
+{
+    S16013a _payload;
+}
+
+struct S16013a
+{
+    RC16013a s;
+}
+
+struct RC16013a
+{
+    void opAssign(RC16013a rhs)
+    {}
+    void opAssign(S16013a rhs)
+    {}
+
+    S16013a rcPayload()
+    {
+        return S16013a.init;
+    }
+    alias rcPayload this;
+}
+
+static assert(Impl16013a.sizeof == S16013a.sizeof);
+static assert(S16013a.sizeof == RC16013a.sizeof);
+static assert(RC16013a.sizeof == 1);
+
+// ----
+
+S16013b s16013b;
+
+struct RC16013b
+{
+    void opAssign(RC16013b rhs) {}
+    void opAssign(S16013b rhs) {}
+
+    S16013b refCountedPayload() { return S16013b.init; }
+    alias refCountedPayload this;
+}
+
+struct S16013b
+{
+    RC16013b s;
+}

--- a/test/fail_compilation/fail42.d
+++ b/test/fail_compilation/fail42.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail42.d(22): Error: struct fail42.Qwert no size because of forward reference
+fail_compilation/fail42.d(17): Error: struct fail42.Yuiop no size because of forward reference
 ---
 */
 

--- a/test/fail_compilation/fail7851.d
+++ b/test/fail_compilation/fail7851.d
@@ -1,5 +1,13 @@
-// 7851
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail7851.d(38): Error: need 'this' for '__mem_field_0' of type 'int'
+fail_compilation/fail7851.d(38): Error: need 'this' for '__mem_field_1' of type 'long'
+fail_compilation/fail7851.d(38): Error: need 'this' for '__mem_field_2' of type 'float'
+---
+*/
 
+// https://issues.dlang.org/show_bug.cgi?id=7851
 
 template TypeTuple(TList...)
 {
@@ -24,10 +32,9 @@ private template Identity(alias T)
     alias T Identity;
 }
 
-
-void main() {
-  alias Tuple!(int, long, float) TL;
-  foreach (i; TL)
-  { }
+void main()
+{
+    alias Tuple!(int, long, float) TL;
+    foreach (i; TL)
+    { }
 }
-

--- a/test/fail_compilation/gag4269f.d
+++ b/test/fail_compilation/gag4269f.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/gag4269f.d(11): Error: undefined identifier 'Y9', did you mean interface 'X9'?
 fail_compilation/gag4269f.d(11): Error: variable gag4269f.X9.y field not allowed in interface
+fail_compilation/gag4269f.d(11): Error: undefined identifier 'Y9', did you mean interface 'X9'?
 ---
 */
 

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1971,6 +1971,72 @@ struct S15292
 }
 
 /***************************************************/
+// 16011
+
+struct RC16011(T)
+{
+    struct RCStore
+    {
+        struct Impl
+        {
+            T _payload;
+
+            /* Recursive tupleof expantion on member-wise struct euqality:
+             *  Impl
+             *  Impl.tupleof[0]       (Impl._payload == S16011)
+             *  Impl.tupleof[0].tupleof[1]  (S16011.s == RC16011)
+             *  Impl.tupleof[0].tupleof[1].rcPayload()  (== S16011)
+             * had not been detected. Fixed the bug.
+             */
+            //static bool __xopEquals(ref const Impl p, ref const Impl q)
+            //{
+            //    return p == q;
+            //}
+        }
+
+        Impl* _impl;
+
+        void initialize(A...)(auto ref A args)
+        {
+            _impl = new Impl();
+            _impl._payload = T.init;
+        }
+    }
+    RCStore _store;
+
+    ref T rcPayload()
+    {
+        if (!_store._impl) _store.initialize();
+        return _store._impl._payload;
+    }
+
+    ref inout(T) rcPayload() inout
+    {
+        return _store._impl._payload;
+    }
+
+    alias rcPayload this;
+}
+
+struct S16011
+{
+    int x;
+    RC16011!S16011 s;
+}
+
+void test16011()
+{
+    S16011 s;
+    s.x = 1;
+    s.s.x = 2;
+    s.s.s.x = 3;
+
+    assert(s.x == 1);
+    assert(s.s.x == 2);
+    assert(s.s.s.x == 3);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -2028,6 +2094,7 @@ int main()
     test13490();
     test11355();
     test14806();
+    test16011();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
This is an additional fix for #5500.

If template instantiations occur during field variable type analysis, `v.semantic(v._scope)` might be invoked to get correct `v.type`.

Essentially it's equivalent mechanism with the code (`inuse == 1 && type && _scope`) in `AliasDeclaration.toAlias`.

Also, to make issue 16013 case runnable, I also fixed incomplete implementation introduced by #5274 for [issue 15292](https://issues.dlang.org/show_bug.cgi?id=15292).
