### PR TITLE
[ARM] Testsuite: Use safer floating point values

### DIFF
--- a/test/compilable/test13281.d
+++ b/test/compilable/test13281.d
@@ -7,41 +7,41 @@ TEST_OUTPUT:
 123u
 123L
 123LU
-123.4
-123.4F
-123.4L
-123.4i
-123.4Fi
-123.4Li
-(123.4+5.6i)
-(123.4F+5.6Fi)
-(123.4L+5.6Li)
+123.5
+123.5F
+123.5L
+123.5i
+123.5Fi
+123.5Li
+(123.5+5.5i)
+(123.5F+5.5Fi)
+(123.5L+5.5Li)
 ---
 */
 pragma(msg, 123);
 pragma(msg, 123u);
 pragma(msg, 123L);
 pragma(msg, 123uL);
-pragma(msg, 123.4);
-pragma(msg, 123.4f);
-pragma(msg, 123.4L);
-pragma(msg, 123.4i);
-pragma(msg, 123.4fi);
-pragma(msg, 123.4Li);
-pragma(msg, 123.4 +5.6i);
-pragma(msg, 123.4f+5.6fi);
-pragma(msg, 123.4L+5.6Li);
+pragma(msg, 123.5);
+pragma(msg, 123.5f);
+pragma(msg, 123.5L);
+pragma(msg, 123.5i);
+pragma(msg, 123.5fi);
+pragma(msg, 123.5Li);
+pragma(msg, 123.5 +5.5i);
+pragma(msg, 123.5f+5.5fi);
+pragma(msg, 123.5L+5.5Li);
 
 static assert((123  ).stringof == "123");
 static assert((123u ).stringof == "123u");
 static assert((123L ).stringof == "123L");
 static assert((123uL).stringof == "123LU");
-static assert((123.4  ).stringof == "123.4");
-static assert((123.4f ).stringof == "123.4F");
-static assert((123.4L ).stringof == "123.4L");
-static assert((123.4i ).stringof == "123.4i");
-static assert((123.4fi).stringof == "123.4Fi");
-static assert((123.4Li).stringof == "123.4Li");
-static assert((123.4 +5.6i ).stringof == "123.4 + 5.6i");
-static assert((123.4f+5.6fi).stringof == "123.4F + 5.6Fi");
-static assert((123.4L+5.6Li).stringof == "123.4L + 5.6Li");
+static assert((123.5  ).stringof == "123.5");
+static assert((123.5f ).stringof == "123.5F");
+static assert((123.5L ).stringof == "123.5L");
+static assert((123.5i ).stringof == "123.5i");
+static assert((123.5fi).stringof == "123.5Fi");
+static assert((123.5Li).stringof == "123.5Li");
+static assert((123.5 +5.5i ).stringof == "123.5 + 5.5i");
+static assert((123.5f+5.5fi).stringof == "123.5F + 5.5Fi");
+static assert((123.5L+5.5Li).stringof == "123.5L + 5.5Li");


### PR DESCRIPTION
Depending on the precision of the real type, 123.4 can not be represented exactly. X.5 is exact for every real type.
