### PR TITLE
Remove va_argsave and move magic initialization of _argptr to the glue layer

### DIFF
--- a/src/backend/gflow.c
+++ b/src/backend/gflow.c
@@ -1370,7 +1370,9 @@ STATIC void accumlv(vec_t GEN,vec_t KILL,elem *n)
                         t->EV.sp.Voffset == 0 &&
                         tsz == type_size(s->Stype)
                        )
-                    {   assert((unsigned)s->Ssymnum < globsym.top);
+                    {
+                        // printf("%s\n", s->Sident);
+                        assert((unsigned)s->Ssymnum < globsym.top);
                         vec_setbit(s->Ssymnum,KILL);
                     }
                 }

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -524,10 +524,7 @@ public:
     VarDeclaration *vthis;              // 'this' parameter (member and nested)
     VarDeclaration *v_arguments;        // '_arguments' parameter
     Objc_FuncDeclaration objc;
-#ifdef IN_GCC
     VarDeclaration *v_argptr;           // '_argptr' variable
-#endif
-    VarDeclaration *v_argsave;          // save area for args passed in registers for variadic functions
     VarDeclarations *parameters;        // Array of VarDeclaration's for parameters
     DsymbolTable *labtab;               // statement label symbol table
     Dsymbol *overnext;                  // next in overload list

--- a/src/doc.d
+++ b/src/doc.d
@@ -2141,8 +2141,6 @@ extern (C++) bool isReservedName(const(char)* str, size_t len)
         "__LOCAL_SIZE",
         "___tls_get_addr",
         "__entrypoint",
-        "__va_argsave_t",
-        "__va_argsave"
     ];
     foreach (s; table)
     {

--- a/src/idgen.d
+++ b/src/idgen.d
@@ -290,8 +290,6 @@ Msgtable[] msgtable =
     { "entrypoint", "__entrypoint" },
 
     // varargs implementation
-    { "va_argsave_t", "__va_argsave_t" },
-    { "va_argsave", "__va_argsave" },
     { "va_start" },
 
     // Builtin functions

--- a/src/imphint.d
+++ b/src/imphint.d
@@ -19,7 +19,7 @@ import core.stdc.string;
  */
 extern (C++) const(char)* importHint(const(char)* s)
 {
-    static __gshared const(char)** modules = ["core.stdc.stdio", "std.stdio", "std.math", "core.vararg", null];
+    static __gshared const(char)** modules = ["core.stdc.stdio", "std.stdio", "std.math", null];
     static __gshared const(char)** names =
     [
         "printf",
@@ -30,8 +30,6 @@ extern (C++) const(char)* importHint(const(char)* s)
         "cos",
         "sqrt",
         "fabs",
-        null,
-        "__va_argsave_t",
         null
     ];
     int m = 0;

--- a/src/tocsym.c
+++ b/src/tocsym.c
@@ -222,11 +222,8 @@ Symbol *toSymbol(Dsymbol *s)
                 }
             }
 
-            if (vd->ident == Id::va_argsave || vd->storage_class & STCvolatile)
+            if (vd->storage_class & STCvolatile)
             {
-                /* __va_argsave is set outside of the realm of the optimizer,
-                 * so we tell the optimizer to leave it alone
-                 */
                 type_setcv(&t, t->Tty | mTYvolatile);
             }
 

--- a/test/runnable/variadic.d
+++ b/test/runnable/variadic.d
@@ -1093,12 +1093,7 @@ class C15417
         void test2 (ulong c1, ...)
         {
             va_list ap;
-            version (Win64)
-                va_start(ap, c1);
-            else version (X86_64)
-                va_start(ap, __va_argsave);
-            else version (X86)
-                va_start(ap, c1);
+            va_start(ap, c1);
 
             check(c1, ap, _arguments);
         }


### PR DESCRIPTION
In short, this replaces the front-end init of `_argptr` with a `va_start(&_argtpr)` intrinsic in the backend.

@ibuclaw @klickverbot @redstar Does this look about right for your backends?

@WalterBright I get an ICE with `-O` on 32-bit in `gflow.c` with `assert((unsigned)s->Ssymnum < globsym.top);` - I assume this means `_argptr` is not being set up correctly, can you see anything obviously wrong with the glue layer code?
