### PR TITLE
[REG2.072a] Issue 15992 - ICE with field variable of instantiated struct

### DIFF
--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -1049,6 +1049,8 @@ public:
             Dsymbol s = (*members)[i];
             //printf("Module %s: %s.semantic3()\n", toChars(), s->toChars());
             s.semantic3(sc);
+
+            runDeferredSemantic2();
         }
         if (userAttribDecl)
         {

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -8027,6 +8027,8 @@ public:
         Dsymbols* a = mi.members;
         a.push(this);
         memberOf = mi;
+        if (mi.semanticRun >= PASSsemantic2done && mi.isRoot())
+            Module.addDeferredSemantic2(this);
         if (mi.semanticRun >= PASSsemantic3done && mi.isRoot())
             Module.addDeferredSemantic3(this);
         return a;

--- a/test/compilable/ice15992.d
+++ b/test/compilable/ice15992.d
@@ -1,0 +1,34 @@
+// PERMUTE_ARGS:
+
+struct Appender()
+{
+    bool canExtend = false;
+}
+
+struct CustomFloat()
+{
+    union ToBinary
+    {
+        CustomFloat!() get;
+    }
+
+    void opAssign(F)(F input)
+        if (__traits(compiles, cast(real)input))
+    {
+    }
+
+    real get()()
+    {
+        Appender!() app;
+        assert(false);
+    }
+
+    T opCast(T)() { return get!(); }
+
+    alias g = get!();
+}
+
+void f()
+{
+    alias FPTypes = CustomFloat!();
+}


### PR DESCRIPTION
When a template is instantiated in function body, it usually gets no chance to run `semantic2`, because inserted module's `semanticRun` would be greater than `PASSsemantic2done` (function bodies are analyzed in global `semantic3` stage).

Therefore we should append template instances to global deferred `semantic2` list as same as for `semantic3`.

---

<del>Essentially this change will increase compilation time. To minimize performance regression, I applied some improvements to `runDeferredSemantic(|2|3)`.</del>

I've removed some followup changes for recovering compilation speed. Read the below discussion.
