### PR TITLE
Set deployment target to the minimum supported version of OS X

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -27,7 +27,7 @@ TK=tk
 ROOT=root
 
 ifeq (osx,$(OS))
-    export MACOSX_DEPLOYMENT_TARGET=10.3
+    export MACOSX_DEPLOYMENT_TARGET=10.7
 endif
 
 HOST_CXX=c++


### PR DESCRIPTION
Since the update to use native TLS on OS X the minimum deployment
target is now OS X Lion (10.7).
