### PR TITLE
Improve help message

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -91,9 +91,14 @@ private  void usage()
 Documentation: http://dlang.org/
 Config file: %s
 Usage:
-  dmd <file>... { -switch }
+  dmd [<option>...] <file>...
+  dmd [<option>...] -run <file> [<arg>...]
 
+Where:
   <file>           D source file
+  <arg>            Argument to pass when running the resulting program
+
+<option>:
   @<cmdfile>       read arguments from cmdfile
   -allinst         generate code for all template instantiations
   -betterC         omit generating some runtime information and helper functions
@@ -148,8 +153,6 @@ Usage:
   -profile         profile runtime performance of generated code
   -profile=gc      profile runtime allocations
   -release         compile release version
-  -run <srcfile> <arg>...
-                   run resulting program, passing args
   -shared          generate shared library (DLL)
   -transition=<id> help with language change identified by 'id'
   -transition=?    list all language changes

--- a/src/mars.d
+++ b/src/mars.d
@@ -72,7 +72,7 @@ private  void usage()
 {
     static if (TARGET_LINUX)
     {
-        const(char)* fpic = "  -fPIC          generate position independent code\n";
+        const(char)* fpic = "\n  -fPIC            generate position independent code";
     }
     else
     {
@@ -80,7 +80,7 @@ private  void usage()
     }
     static if (TARGET_WINDOS)
     {
-        const(char)* m32mscoff = "  -m32mscoff     generate 32 bit code and write MS-COFF object files\n";
+        const(char)* m32mscoff = "\n  -m32mscoff       generate 32 bit code and write MS-COFF object files";
     }
     else
     {
@@ -93,74 +93,78 @@ Config file: %s
 Usage:
   dmd <file>... { -switch }
 
-  <file>         D source file
-  @<cmdfile>     read arguments from cmdfile
-  -allinst       generate code for all template instantiations
-  -betterC       omit generating some runtime information and helper functions
+  <file>           D source file
+  @<cmdfile>       read arguments from cmdfile
+  -allinst         generate code for all template instantiations
+  -betterC         omit generating some runtime information and helper functions
   -boundscheck=[on|safeonly|off]   bounds checks on, in @safe only, or off
-  -c             do not link
-  -color[=on|off]   force colored console output on or off
-  -conf=<filename>  use config file at filename
-  -cov           do code coverage analysis
+  -c               do not link
+  -color[=on|off]  force colored console output on or off
+  -conf=<filename> use config file at filename
+  -cov             do code coverage analysis
   -cov=<nnn>       require at least nnn%% code coverage
-  -D             generate documentation
-  -Dd<directory>      write documentation file to directory
+  -D               generate documentation
+  -Dd<directory>   write documentation file to directory
   -Df<filename>    write documentation file to filename
-  -d             silently allow deprecated features
-  -dw            show use of deprecated features as warnings (default)
-  -de            show use of deprecated features as errors (halt compilation)
-  -debug         compile in debug code
+  -d               silently allow deprecated features
+  -dw              show use of deprecated features as warnings (default)
+  -de              show use of deprecated features as errors (halt compilation)
+  -debug           compile in debug code
   -debug=<level>   compile in debug code <= level
   -debug=<ident>   compile in debug code identified by ident
-  -debuglib=<name>    set symbolic debug library to name
-  -defaultlib=<name>  set default library to name
-  -deps          print module dependencies (imports/file/version/debug/lib)
-  -deps=<filename> write module dependencies to filename (only imports)
-%s  -dip25         implement http://wiki.dlang.org/DIP25 (experimental)
-  -g             add symbolic debug info
-  -gc            add symbolic debug info, optimize for non D debuggers
-  -gs            always emit stack frame
-  -gx            add stack stomp code
-  -H             generate 'header' file
+  -debuglib=<name> set symbolic debug library to name
+  -defaultlib=<name>
+                   set default library to name
+  -deps            print module dependencies (imports/file/version/debug/lib)
+  -deps=<filename> write module dependencies to filename (only imports)" ~
+  "%s" /* placeholder for fpic */ ~ "
+  -dip25           implement http://wiki.dlang.org/DIP25 (experimental)
+  -g               add symbolic debug info
+  -gc              add symbolic debug info, optimize for non D debuggers
+  -gs              always emit stack frame
+  -gx              add stack stomp code
+  -H               generate 'header' file
   -Hd<directory>   write 'header' file to directory
   -Hf<filename>    write 'header' file to filename
-  --help         print help and exit
-  -I<directory>         look for imports also in directory
-  -ignore        ignore unsupported pragmas
-  -inline        do function inlining
-  -J<directory>         look for string imports also in directory
+  --help           print help and exit
+  -I<directory>    look for imports also in directory
+  -ignore          ignore unsupported pragmas
+  -inline          do function inlining
+  -J<directory>    look for string imports also in directory
   -L<linkerflag>   pass linkerflag to link
-  -lib           generate library rather than object files
-  -m32           generate 32 bit code
-%s  -m64           generate 64 bit code
-  -main          add default main() (e.g. for unittesting)
-  -man           open web browser on manual page
-  -map           generate linker .map file
-  -noboundscheck no array bounds checking (deprecated, use -boundscheck=off)
-  -O             optimize
-  -o-            do not write object file
+  -lib             generate library rather than object files
+  -m32             generate 32 bit code" ~
+  "%s" /* placeholder for m32mscoff */ ~ "
+  -m64             generate 64 bit code
+  -main            add default main() (e.g. for unittesting)
+  -man             open web browser on manual page
+  -map             generate linker .map file
+  -noboundscheck   no array bounds checking (deprecated, use -boundscheck=off)
+  -O               optimize
+  -o-              do not write object file
   -od<directory>   write object & library files to directory
   -of<filename>    name output file to filename
-  -op            preserve source path for output files
-  -profile       profile runtime performance of generated code
-  -profile=gc    profile runtime allocations
-  -release       compile release version
-  -run <srcfile> <arg>...   run resulting program, passing args
-  -shared        generate shared library (DLL)
+  -op              preserve source path for output files
+  -profile         profile runtime performance of generated code
+  -profile=gc      profile runtime allocations
+  -release         compile release version
+  -run <srcfile> <arg>...
+                   run resulting program, passing args
+  -shared          generate shared library (DLL)
   -transition=<id> help with language change identified by 'id'
-  -transition=?  list all language changes
-  -unittest      compile in unit tests
-  -v             verbose
-  -vcolumns      print character (column) numbers in diagnostics
+  -transition=?    list all language changes
+  -unittest        compile in unit tests
+  -v               verbose
+  -vcolumns        print character (column) numbers in diagnostics
   -verrors=<num>   limit the number of error messages (0 means unlimited)
-  -vgc           list all gc allocations including hidden ones
-  -vtls          list all variables going into thread local storage
-  --version      print compiler version and exit
+  -vgc             list all gc allocations including hidden ones
+  -vtls            list all variables going into thread local storage
+  --version        print compiler version and exit
   -version=<level> compile in version code >= level
   -version=<ident> compile in version code identified by ident
-  -w             warnings as errors (compilation will halt)
-  -wi            warnings as messages (compilation will continue)
-  -X             generate JSON file
+  -w               warnings as errors (compilation will halt)
+  -wi              warnings as messages (compilation will continue)
+  -X               generate JSON file
   -Xf<filename>    write JSON file to filename
 ", FileName.canonicalName(global.inifilename), fpic, m32mscoff);
 }

--- a/src/mars.d
+++ b/src/mars.d
@@ -91,45 +91,45 @@ private  void usage()
 Documentation: http://dlang.org/
 Config file: %s
 Usage:
-  dmd files.d ... { -switch }
+  dmd <file>... { -switch }
 
-  files.d        D source files
-  @cmdfile       read arguments from cmdfile
+  <file>         D source file
+  @<cmdfile>     read arguments from cmdfile
   -allinst       generate code for all template instantiations
   -betterC       omit generating some runtime information and helper functions
   -boundscheck=[on|safeonly|off]   bounds checks on, in @safe only, or off
   -c             do not link
   -color[=on|off]   force colored console output on or off
-  -conf=path     use config file at path
+  -conf=<filename>  use config file at filename
   -cov           do code coverage analysis
-  -cov=nnn       require at least nnn%% code coverage
+  -cov=<nnn>       require at least nnn%% code coverage
   -D             generate documentation
-  -Dddocdir      write documentation file to docdir directory
-  -Dffilename    write documentation file to filename
+  -Dd<directory>      write documentation file to directory
+  -Df<filename>    write documentation file to filename
   -d             silently allow deprecated features
   -dw            show use of deprecated features as warnings (default)
   -de            show use of deprecated features as errors (halt compilation)
   -debug         compile in debug code
-  -debug=level   compile in debug code <= level
-  -debug=ident   compile in debug code identified by ident
-  -debuglib=name    set symbolic debug library to name
-  -defaultlib=name  set default library to name
+  -debug=<level>   compile in debug code <= level
+  -debug=<ident>   compile in debug code identified by ident
+  -debuglib=<name>    set symbolic debug library to name
+  -defaultlib=<name>  set default library to name
   -deps          print module dependencies (imports/file/version/debug/lib)
-  -deps=filename write module dependencies to filename (only imports)
+  -deps=<filename> write module dependencies to filename (only imports)
 %s  -dip25         implement http://wiki.dlang.org/DIP25 (experimental)
   -g             add symbolic debug info
   -gc            add symbolic debug info, optimize for non D debuggers
   -gs            always emit stack frame
   -gx            add stack stomp code
   -H             generate 'header' file
-  -Hddirectory   write 'header' file to directory
-  -Hffilename    write 'header' file to filename
+  -Hd<directory>   write 'header' file to directory
+  -Hf<filename>    write 'header' file to filename
   --help         print help and exit
-  -Ipath         where to look for imports
+  -I<directory>         look for imports also in directory
   -ignore        ignore unsupported pragmas
   -inline        do function inlining
-  -Jpath         where to look for string imports
-  -Llinkerflag   pass linkerflag to link
+  -J<directory>         look for string imports also in directory
+  -L<linkerflag>   pass linkerflag to link
   -lib           generate library rather than object files
   -m32           generate 32 bit code
 %s  -m64           generate 64 bit code
@@ -139,29 +139,29 @@ Usage:
   -noboundscheck no array bounds checking (deprecated, use -boundscheck=off)
   -O             optimize
   -o-            do not write object file
-  -odobjdir      write object & library files to directory objdir
-  -offilename    name output file to filename
+  -od<directory>   write object & library files to directory
+  -of<filename>    name output file to filename
   -op            preserve source path for output files
   -profile       profile runtime performance of generated code
   -profile=gc    profile runtime allocations
   -release       compile release version
-  -run srcfile args...   run resulting program, passing args
+  -run <srcfile> <arg>...   run resulting program, passing args
   -shared        generate shared library (DLL)
-  -transition=id help with language change identified by 'id'
+  -transition=<id> help with language change identified by 'id'
   -transition=?  list all language changes
   -unittest      compile in unit tests
   -v             verbose
   -vcolumns      print character (column) numbers in diagnostics
-  -verrors=num   limit the number of error messages (0 means unlimited)
+  -verrors=<num>   limit the number of error messages (0 means unlimited)
   -vgc           list all gc allocations including hidden ones
   -vtls          list all variables going into thread local storage
   --version      print compiler version and exit
-  -version=level compile in version code >= level
-  -version=ident compile in version code identified by ident
+  -version=<level> compile in version code >= level
+  -version=<ident> compile in version code identified by ident
   -w             warnings as errors (compilation will halt)
   -wi            warnings as messages (compilation will continue)
   -X             generate JSON file
-  -Xffilename    write JSON file to filename
+  -Xf<filename>    write JSON file to filename
 ", FileName.canonicalName(global.inifilename), fpic, m32mscoff);
 }
 

--- a/src/mars.d
+++ b/src/mars.d
@@ -104,7 +104,8 @@ Where:
   -betterC         omit generating some runtime information and helper functions
   -boundscheck=[on|safeonly|off]   bounds checks on, in @safe only, or off
   -c               do not link
-  -color[=on|off]  force colored console output on or off
+  -color           turn colored console output on
+  -color=[on|off]  force colored console output on or off
   -conf=<filename> use config file at filename
   -cov             do code coverage analysis
   -cov=<nnn>       require at least nnn%% code coverage


### PR DESCRIPTION
There are still things to improve to make the CLI more consistent, like using always `-` or `--` for options, or using always `-option=xxx` for options taking an argument, right now the state is quite mixed and confusing.
