### PR TITLE
fix issue 16077: add S_COMPILE record to MS-COFF debug info

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -650,7 +650,7 @@ struct Config
 #define TARGET_PentiumMMX       6
 #define TARGET_PentiumPro       7
 #define TARGET_PentiumII        8
-#define TARGET_AMD64            9       (32 or 64 bit mode)
+#define TARGET_AMD64            9       // (32 or 64 bit mode)
 
     short versionint;           // intermediate file version (= VERSIONINT)
     int defstructalign;         // struct alignment specified by command line

--- a/src/backend/cv8.c
+++ b/src/backend/cv8.c
@@ -187,6 +187,17 @@ void cv8_termfile(const char *objfilename)
     buf.writeWord(S_COMPILAND_V3);
     buf.write32(0);
     buf.write(objfilename, len + 1);
+
+    // write S_COMPILE record
+    buf.writeWord(2 + 1 + 1 + 2 + 1 + sizeof(VERSION));
+    buf.writeWord(S_COMPILE);
+    buf.writeByte(I64 ? 0xD0 : 6); // target machine AMD64 or x86 (Pentium II)
+    buf.writeByte(config.flags2 & CFG2gms ? (CPP != 0) : 'D'); // language index (C/C++/D)
+    buf.writeWord(0x800 | (config.inline8087 ? 0 : (1<<3)));   // 32-bit, float package
+    buf.writeByte(sizeof(VERSION));
+    buf.writeByte('Z');
+    buf.write(VERSION, sizeof(VERSION) - 1);
+
     cv8_writesection(seg, 0xF1, &buf);
 
     // Write out "F2" sections


### PR DESCRIPTION
This uses the same useless compiler version as the OMF debug output ("Z8.58.0"). We should set something more sensible passed to the backend through `out_config_init`, but probably in another PR.
