### PR TITLE
VS: Add new pragma(mangle, ...) for classes and structs

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -187,6 +187,7 @@ public:
     // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
+    bool cppmangleAsClass;      // true if this struct should be mangled as class (VS only)
 
     StructDeclaration(Loc loc, Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *s);
@@ -280,6 +281,7 @@ public:
     bool com;                           // true if this is a COM class (meaning it derives from IUnknown)
     bool cpp;                           // true if this is a C++ interface
     bool isscope;                       // true if this is a scope class
+    bool cppmangleAsStruct;             // true if this class should be mangled as struct (VS only)
     Abstract isabstract;                // 0: fwdref, 1: is abstract class, 2: not abstract
     int inuse;                          // to prevent recursive attempts
     Baseok baseok;                      // set the progress of base classes resolving

--- a/src/attrib.d
+++ b/src/attrib.d
@@ -1480,6 +1480,25 @@ extern (C++) static uint setMangleOverride(Dsymbol s, char* sym)
         s.isDeclaration().mangleOverride = sym;
         return 1;
     }
+    else if (s.isStructDeclaration() || s.isClassDeclaration())
+    {
+        bool asClass = !strcmp(sym, "class");
+        bool asStruct = !strcmp(sym, "struct");
+        if (!(asClass || asStruct))
+            return 0;
+        if (auto sd = s.isStructDeclaration())
+            sd.cppmangleAsClass = asClass;
+        else if (auto cd = s.isClassDeclaration())
+            cd.cppmangleAsStruct = asStruct;
+        return 1;
+    }
+    else if (s.isTemplateDeclaration() && s.isTemplateDeclaration().onemember)
+    {
+        Dsymbol ds = s.isTemplateDeclaration().onemember;
+        if (ds.isStructDeclaration() || ds.isClassDeclaration())
+            return setMangleOverride(ds, sym);
+        return 0;
+    }
     else
         return 0;
 }

--- a/src/cppmangle.d
+++ b/src/cppmangle.d
@@ -1283,7 +1283,7 @@ else static if (TARGET_WINDOS)
                 if (type.sym.isUnionDeclaration())
                     buf.writeByte('T');
                 else
-                    buf.writeByte('U');
+                    buf.writeByte(type.sym.cppmangleAsClass ? 'V' : 'U');
                 mangleIdent(type.sym);
             }
             flags &= ~IS_NOT_TOP_TYPE;
@@ -1350,7 +1350,7 @@ else static if (TARGET_WINDOS)
                 buf.writeByte('E');
             flags |= IS_NOT_TOP_TYPE;
             mangleModifier(type);
-            buf.writeByte('V');
+            buf.writeByte(type.sym.cppmangleAsStruct ? 'U' : 'V');
             mangleIdent(type.sym);
             flags &= ~IS_NOT_TOP_TYPE;
             flags &= ~IGNORE_CONST;
@@ -1630,13 +1630,13 @@ else static if (TARGET_WINDOS)
                                 {
                                     tmp.buf.writeByte('T');
                                 }
-                                else if (ds.isStructDeclaration())
+                                else if (auto sd = ds.isStructDeclaration())
                                 {
-                                    tmp.buf.writeByte('U');
+                                    tmp.buf.writeByte(sd.cppmangleAsClass ? 'V' : 'U');
                                 }
-                                else if (ds.isClassDeclaration())
+                                else if (auto cd = ds.isClassDeclaration())
                                 {
-                                    tmp.buf.writeByte('V');
+                                    tmp.buf.writeByte(cd.cppmangleAsStruct ? 'U' : 'V');
                                 }
                                 else
                                 {

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -220,6 +220,7 @@ public:
     bool com;           // true if this is a COM class (meaning it derives from IUnknown)
     bool cpp;           // true if this is a C++ interface
     bool isscope;       // true if this is a scope class
+    bool cppmangleAsStruct; // true if this class should be mangled as struct (VS only)
     Abstract isabstract;
     int inuse;          // to prevent recursive attempts
     Baseok baseok;      // set the progress of base classes resolving
@@ -407,6 +408,7 @@ public:
               : new ClassDeclaration(loc, ident, null);
 
         cd.storage_class |= storage_class;
+        cd.cppmangleAsStruct = cppmangleAsStruct;
 
         cd.baseclasses.setDim(this.baseclasses.dim);
         for (size_t i = 0; i < cd.baseclasses.dim; i++)

--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -238,6 +238,7 @@ public:
     // (e.g. TypeidExp, NewExp, ArrayLiteralExp, etc) request its TypeInfo.
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
+    bool cppmangleAsClass;      // true if this struct should be mangled as class (VS only)
 
     final extern (D) this(Loc loc, Identifier id)
     {
@@ -255,6 +256,7 @@ public:
         StructDeclaration sd =
             s ? cast(StructDeclaration)s
               : new StructDeclaration(loc, ident);
+        sd.cppmangleAsClass = cppmangleAsClass;
         return ScopeDsymbol.syntaxCopy(sd);
     }
 

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -169,6 +169,57 @@ interface Test38
      public static void dispose(ref Test38);
 }
 
+pragma(mangle, "class")
+extern(C++)
+struct S1
+{
+    private int val;
+    static S1* init(int);
+    int value();
+}
+
+pragma(mangle, "class")
+extern(C++)
+struct S2(T)
+{
+    private T val;
+    static S2!T* init(int);
+    T value();
+}
+
+pragma(mangle, "struct")
+extern(C++)
+class C1
+{
+    const(char)* data;
+
+    static C1 init(const(char)* p);
+    const(char)* getData();
+}
+
+pragma(mangle, "struct")
+extern(C++)
+class C2(T)
+{
+    const(T)* data;
+
+    static C2!T init(const(T)* p);
+    const(T)* getData();
+}
+
+void test39()
+{
+    S1* s1 = S1.init(42);
+    assert(s1.value == 42);
+    assert(S2!int.init(43).value == 43);
+    const(char)* ptr = "test".ptr;
+    C1 c1 = C1.init(ptr);
+    assert(c1.getData() == ptr);
+    C2!char c2 = C2!char.init(ptr);
+    assert(c2.getData() == ptr);
+}
+
+
 void main()
 {
     test1(Foo!int());
@@ -254,4 +305,5 @@ void main()
     auto t38 = Test38.create();
     assert(t38.test(1, 2, 3) == 1);
     Test38.dispose(t38);
+    test39();
 }

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -304,3 +304,89 @@ void Test38::dispose(Test38 *&t)
         delete t;
     t = 0;
 }
+
+class S1
+{
+    int val;
+public:
+    static S1* init(int);
+    S1(int v) : val(v) {}
+    int value();
+};
+
+S1* S1::init(int x)
+{
+    return new S1(x);
+}
+
+int S1::value()
+{
+    return val;
+}
+
+template<class T>
+class S2
+{
+    T val;
+public:
+    static S2<T>* init(T);
+    S2(T v) : val(v) {}
+    T value();
+};
+
+template<>
+S2<int>* S2<int>::init(int x)
+{
+    return new S2<int>(x);
+}
+
+template<>
+int S2<int>::value()
+{
+    return val;
+}
+
+struct C1
+{
+    const char *data;
+
+    static C1* init(const char *p);
+
+    C1(const char* p) : data(p) { }
+
+    virtual const char* getData();
+};
+
+C1* C1::init(const char *p)
+{
+    return new C1(p);
+}
+
+const char* C1::getData()
+{
+    return data;
+}
+
+template<class T>
+struct C2
+{
+    const T *data;
+
+    static C2* init(const T *p);
+
+    C2(const T* p) : data(p) { }
+
+    virtual const T* getData();
+};
+
+template<>
+C2<char>* C2<char>::init(const char *p)
+{
+    return new C2<char>(p);
+}
+
+template<>
+const char* C2<char>::getData()
+{
+    return data;
+}


### PR DESCRIPTION
VS has different name manglings for classes and structs. With the
new pragma(mangle, "class") and pragma(mangle, "struct"), the name
mangling algorithm is changed to use a mangling different from the
used D entity.

A common use case is to map a value type modeled as class in C++ to
a struct in D.
