### PR TITLE
simplify code and avoid second lookup

### DIFF
--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1122,8 +1122,9 @@ public:
 
         auto s = ScopeDsymbol.search(loc, ident, flags);
 
-        if ((flags & (SearchLocalsOnly | SearchImportsOnly)) != 0)
-            flags |= SearchLocalsOnly;
+        // don't search imports of base classes
+        if (flags & SearchImportsOnly)
+            return s;
 
         if (!s)
         {


### PR DESCRIPTION
- can be called with SearchLocalsOnly, SearchImportsOnly, or
  neither flag set (for -transition=import/checkimports)
- 2nd phase of new lookup (SearchImportsOnly) shouldn't
  search in base classes
- avoid redundant 1st phase (local) lookup

Fixup of https://github.com/dlang/dmd/pull/5651
