### PR TITLE
[Don't Merge | Just for review]add Stack-Mode to allocator

### DIFF
--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -7,6 +7,7 @@
 // http://www.boost.org/LICENSE_1_0.txt
 
 module ddmd.dinterpret;
+version = WithStack;
 
 import core.stdc.stdio;
 import core.stdc.string;
@@ -795,6 +796,14 @@ extern (C++) Expression ctfeInterpretForPragmaMsg(Expression e)
  */
 extern (C++) Expression interpret(FuncDeclaration fd, InterState* istate, Expressions* arguments, Expression thisarg)
 {
+    version(WithStack) {
+        import ddmd.root.rmem : beginStack, endStack;
+        auto stack = beginStack();
+        scope(exit) {
+            endStack(stack);
+        }
+    }
+
     debug (LOG)
     {
         printf("\n********\n%s FuncDeclaration::interpret(istate = %p) %s\n", fd.loc.toChars(), istate, fd.toChars());
@@ -980,6 +989,7 @@ extern (C++) Expression interpret(FuncDeclaration fd, InterState* istate, Expres
         CtfeStatus.maxCallDepth = CtfeStatus.callDepth;
 
     Expression e = null;
+
     while (1)
     {
         if (CtfeStatus.callDepth > CTFE_RECURSION_LIMIT)
@@ -1040,8 +1050,12 @@ extern (C++) Expression interpret(FuncDeclaration fd, InterState* istate, Expres
         (cast(ThrownExceptionExp)e).generateUncaughtError();
         e = CTFEExp.cantexp;
     }
+    version(WithStack) {
+        return e.syntaxCopy;
+    } else {
+        return e;
+    }
 
-    return e;
 }
 
 extern (C++) final class Interpreter : Visitor

--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -214,7 +214,7 @@ else
 
                 assert(stacksize > 0);
                 debug (LOGMEM) {
-                    printf("Growing Stack by %d byte to %p", m_size);
+                    printf("Growing Stack by %d byte to %p", growBy, stacksize + growBy);
                 }
                 stackbottom = realloc(stackbottom, stacksize + growBy);
 

--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -145,7 +145,7 @@ else
         /// this is needed by endStack
         extern(C) void* beginStack(const size_t initialSize = CHUNK_SIZE) nothrow 
         {
-            printf("BeginStackStart - in Stack: %d stackLeft: %d\n", memp != &heapp, stackleft);
+        //    printf("BeginStackStart - in Stack: %d stackLeft: %d\n", memp != &heapp, stackleft);
 
             if (stackbottom) {
                 if (stackleft < initialSize)
@@ -161,7 +161,7 @@ else
 
             memp = &stacktop;
             memleft = &stackleft;
-            printf("BeginStackEnd - in Stack: %d - stackLeft: %d\n", memp != &heapp, stackleft);
+      //      printf("BeginStackEnd - in Stack: %d - stackLeft: %d\n", memp != &heapp, stackleft);
      //       assert(0);
             return stacktop;
         }
@@ -188,7 +188,7 @@ else
         immutable m_size = (_m_size + 15) & ~15;
 
         // The layout of the code is selected so the most common case is straight through
-        printf("StackMode : %d\n memLeft : %d\n", memp != &heapp, *memleft);
+  //      printf("StackMode : %d\n memLeft : %d\n", memp != &heapp, *memleft);
 		if (m_size <= *memleft)
         {
         L1:
@@ -210,35 +210,29 @@ else
                 exit(EXIT_FAILURE);
             }
 
-            heapleft = CHUNK_SIZE;
-            heapp = malloc(CHUNK_SIZE);
-            if (!heapp)
+            *memleft = CHUNK_SIZE;
+           (*memp) = malloc(CHUNK_SIZE);
+            if (!(*memp))
             {
                 printf("Error: out of memory\n");
                 exit(EXIT_FAILURE);
             }
         } else {
             version (WithStack) {
-                ptrdiff_t stacksize = stacktop - stackbottom;
-                immutable growBy = m_size;
+              //  stackbottom = realloc(stackbottom, stacksize + growBy);
 
-                assert(stacksize > 0);
-               // debug (LOGMEM) {
-                    printf("Growing Stack by %d byte to %p", growBy, stacksize + growBy);
-                //}
-                stackbottom = realloc(stackbottom, stacksize + growBy);
-
-                if (!stackbottom) {
+   /*             if (!stackbottom) {
                     printf("Error: out of memory\n");
                     exit(EXIT_FAILURE);
-                }
+                } */
+                stacktop = stackbottom + (CHUNK_SIZE / 2);
 
-                stacktop = stackbottom + stacksize;
-                stackleft += growBy;
+//                stacktop = stackbottom + stacksize;
+               stackleft = CHUNK_SIZE / 2;
             } else {
                 assert(0, "We should never modify our memPtr without the Stack");
             }
-        }
+        } 
         goto L1;
     }
 


### PR DESCRIPTION
Hi,

This is the first change on the long road to a good CTFE implementation. 
I am adding the ability to switch to a stack-allocation mode. 
usage :

```
auto stackBegin = beginStack(/* optional size */);
e = interpret(Bla);
/* not Implemented yet */
 return e.copytoHeapOrNextStackLevel();
scope (exit) {
 endStack(stackBegin);
}
```

In this allocation mode all memory will be reused after the stackEnd-call.
It is build to nest stacks inside each other so one can discard an inner stack but not the outer one.

This is just for a initial reviews.
