### PR TITLE
refactor: TemplateInstance constructor

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -1050,11 +1050,10 @@ public:
          * as td2.
          */
 
-        scope TemplateInstance ti = new TemplateInstance(Loc(), ident); // create dummy template instance
         // Set type arguments to dummy template instance to be types
         // generated from the parameters to this template declaration
-        ti.tiargs = new Objects();
-        ti.tiargs.reserve(parameters.dim);
+        auto tiargs = new Objects();
+        tiargs.reserve(parameters.dim);
         for (size_t i = 0; i < parameters.dim; i++)
         {
             TemplateParameter tp = (*parameters)[i];
@@ -1064,8 +1063,9 @@ public:
             if (!p)
                 break;
 
-            ti.tiargs.push(p);
+            tiargs.push(p);
         }
+        scope TemplateInstance ti = new TemplateInstance(Loc(), ident, tiargs); // create dummy template instance
 
         // Temporary Array to hold deduced types
         Objects dedtypes;
@@ -5936,7 +5936,7 @@ public:
     TemplateInstance tnext;     // non-first instantiated instances
     Module minst;               // the top module that instantiated this instance
 
-    final extern (D) this(Loc loc, Identifier ident)
+    final extern (D) this(Loc loc, Identifier ident, Objects* tiargs)
     {
         super(null);
         static if (LOG)
@@ -5945,6 +5945,7 @@ public:
         }
         this.loc = loc;
         this.name = ident;
+        this.tiargs = tiargs;
     }
 
     /*****************
@@ -5982,7 +5983,7 @@ public:
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
-        TemplateInstance ti = s ? cast(TemplateInstance)s : new TemplateInstance(loc, name);
+        TemplateInstance ti = s ? cast(TemplateInstance)s : new TemplateInstance(loc, name, null);
         ti.tiargs = arraySyntaxCopy(tiargs);
         TemplateDeclaration td;
         if (inst && tempdecl && (td = tempdecl.isTemplateDeclaration()) !is null)
@@ -8374,11 +8375,12 @@ public:
 
     extern (D) this(Loc loc, Identifier ident, TypeQualified tqual, Objects* tiargs)
     {
-        super(loc, tqual.idents.dim ? cast(Identifier)tqual.idents[tqual.idents.dim - 1] : (cast(TypeIdentifier)tqual).ident);
+        super(loc,
+              tqual.idents.dim ? cast(Identifier)tqual.idents[tqual.idents.dim - 1] : (cast(TypeIdentifier)tqual).ident,
+              tiargs ? tiargs : new Objects());
         //printf("TemplateMixin(ident = '%s')\n", ident ? ident->toChars() : "");
         this.ident = ident;
         this.tqual = tqual;
-        this.tiargs = tiargs ? tiargs : new Objects();
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)

--- a/src/expression.d
+++ b/src/expression.d
@@ -745,8 +745,7 @@ Lsearchdone:
     if (ue.op == TOKdotti)
     {
         DotTemplateInstanceExp dti = cast(DotTemplateInstanceExp)ue;
-        auto ti = new TemplateInstance(loc, s.ident);
-        ti.tiargs = dti.ti.tiargs; // for better diagnostic message
+        auto ti = new TemplateInstance(loc, s.ident, dti.ti.tiargs);
         if (!ti.updateTempDecl(sc, s))
             return new ErrorExp();
         return new ScopeExp(loc, ti);
@@ -9088,8 +9087,7 @@ public:
     {
         super(loc, TOKdotti, __traits(classInstanceSize, DotTemplateInstanceExp), e);
         //printf("DotTemplateInstanceExp()\n");
-        this.ti = new TemplateInstance(loc, name);
-        this.ti.tiargs = tiargs;
+        this.ti = new TemplateInstance(loc, name, tiargs);
     }
 
     extern (D) this(Loc loc, Expression e, TemplateInstance ti)

--- a/src/parse.d
+++ b/src/parse.d
@@ -1775,8 +1775,7 @@ public:
 
             if (tiargs && token.value == TOKdot)
             {
-                auto tempinst = new TemplateInstance(loc, id);
-                tempinst.tiargs = tiargs;
+                auto tempinst = new TemplateInstance(loc, id, tiargs);
                 if (!tqual)
                     tqual = new TypeInstance(loc, tempinst);
                 else
@@ -3481,8 +3480,7 @@ public:
             if (token.value == TOKnot)
             {
                 // ident!(template_arguments)
-                auto tempinst = new TemplateInstance(loc, id);
-                tempinst.tiargs = parseTemplateArguments();
+                auto tempinst = new TemplateInstance(loc, id, parseTemplateArguments());
                 t = parseBasicTypeStartingAt(new TypeInstance(loc, tempinst), dontLookDotIdents);
             }
             else
@@ -3609,8 +3607,7 @@ public:
                     nextToken();
                     if (token.value == TOKnot)
                     {
-                        auto tempinst = new TemplateInstance(loc, id);
-                        tempinst.tiargs = parseTemplateArguments();
+                        auto tempinst = new TemplateInstance(loc, id, parseTemplateArguments());
                         tid.addInst(tempinst);
                     }
                     else
@@ -7024,9 +7021,7 @@ public:
                 if (token.value == TOKnot && (save = peekNext()) != TOKis && save != TOKin)
                 {
                     // identifier!(template-argument-list)
-                    TemplateInstance tempinst;
-                    tempinst = new TemplateInstance(loc, id);
-                    tempinst.tiargs = parseTemplateArguments();
+                    auto tempinst = new TemplateInstance(loc, id, parseTemplateArguments());
                     e = new ScopeExp(loc, tempinst);
                 }
                 else


### PR DESCRIPTION
Fix encapsulation. parse.d does not need to know about TemplateInstance internals.
