### PR TITLE
Add struct enum type test for issue 16022

### DIFF
--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7853,6 +7853,19 @@ bool test16022()
     return type == Type.Colon, type == Type.Comma;
 }
 
+bool test16022_structs()
+{
+    struct A
+    {
+        int i;
+        string s;
+    }
+
+    enum Type { Colon = A(0, "zero"), Comma = A(1, "one") }
+    Type type;
+    return type == Type.Colon, type == Type.Comma;
+}
+
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=16233
 


### PR DESCRIPTION
At least for LDC, the difference with the simpler original enum type matters and tests a different code path.
