### PR TITLE
add support for Unrestricted Unions

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -6,6 +6,14 @@ $(COMMENT Pending changelog for 2.072. This will get copied to dlang.org and
 
 $(BUGSTITLE Language Changes,
     $(LI $(RELATIVE_LINK2 deprecated_commaexp, Using the result of a comma expression is deprecated.))
+
+    $(LI $(LNAME2 unrestricted_unions, Add Unrestricted Unions.)
+
+        $(P
+             Unrestricted unions may have postblits, destructors, and invariants.
+             It is up to the programmer to call them appropriately.
+        )
+    )
 )
 
 $(BUGSTITLE Compiler Changes,

--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -375,25 +375,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 if (!vd.isOverlappedWith(v2))
                     continue;
 
-                // vd and v2 are overlapping. If either has destructors, postblits, etc., then error
-                //printf("overlapping fields %s and %s\n", vd->toChars(), v2->toChars());
-                foreach (k; 0 .. 2)
-                {
-                    auto v = k == 0 ? vd : v2;
-                    Type tv = v.type.baseElemOf();
-                    Dsymbol sv = tv.toDsymbol(null);
-                    if (!sv || errors)
-                        continue;
-                    StructDeclaration sd = sv.isStructDeclaration();
-                    if (sd && (sd.dtor || sd.inv || sd.postblit))
-                    {
-                        error("destructors, postblits and invariants are not allowed in overlapping fields %s and %s",
-                            vd.toChars(), v2.toChars());
-                        errors = true;
-                        break;
-                    }
-                }
+                // vd and v2 are overlapping.
                 vd.overlapped = true;
+                v2.overlapped = true;
 
                 if (!vx)
                     continue;

--- a/src/func.d
+++ b/src/func.d
@@ -5301,7 +5301,10 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
             errors = true;
             return;
         }
-        if (ident != Id.classInvariant && semanticRun < PASSsemantic)
+        if (ident != Id.classInvariant &&
+             semanticRun < PASSsemantic &&
+             !ad.isUnionDeclaration()           // users are on their own with union fields
+           )
             ad.invs.push(this);
         if (!type)
             type = new TypeFunction(null, Type.tvoid, false, LINKd, storage_class);

--- a/test/fail_compilation/fail4421.d
+++ b/test/fail_compilation/fail4421.d
@@ -4,11 +4,11 @@ TEST_OUTPUT:
 fail_compilation/fail4421.d(16): Error: function fail4421.U1.__postblit destructors, postblits and invariants are not allowed in union U1
 fail_compilation/fail4421.d(17): Error: destructor fail4421.U1.~this destructors, postblits and invariants are not allowed in union U1
 fail_compilation/fail4421.d(18): Error: function fail4421.U1.__invariant1 destructors, postblits and invariants are not allowed in union U1
-fail_compilation/fail4421.d(14): Error: function fail4421.U1.__invariant destructors, postblits and invariants are not allowed in union U1
-fail_compilation/fail4421.d(28): Error: destructor fail4421.U2.~this destructors, postblits and invariants are not allowed in union U2
-fail_compilation/fail4421.d(28): Error: function fail4421.U2.__fieldPostblit destructors, postblits and invariants are not allowed in union U2
-fail_compilation/fail4421.d(33): Error: struct fail4421.S2 destructors, postblits and invariants are not allowed in overlapping fields s1 and j
 ---
+
+
+
+
 */
 
 union U1


### PR DESCRIPTION
Unrestricted Unions are a feature added to C++11. Unrestricted unions can have fields that have destructors, postblits, or invariants. It's up to the user to call them correctly, the compiler does not automatically generate calls to them.

I added the "Needs Work" label because it is a bit unfinished, I want to see how it passes the autotester so far.
