### PR TITLE
refactor: better encapsulate ClassDeclaration.this()

### DIFF
--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -286,7 +286,7 @@ public:
     Objc_ClassDeclaration objc;
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
-    ClassDeclaration(Loc loc, Identifier *id, BaseClasses *baseclasses, bool inObject = false);
+    ClassDeclaration(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols* members, bool inObject = false);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void semantic(Scope *sc);

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -228,7 +228,7 @@ public:
 
     Symbol* cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
-    final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses, bool inObject = false)
+    final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
     {
         if (!id)
             id = Identifier.generateId("__anonclass");
@@ -245,6 +245,8 @@ public:
         }
         else
             this.baseclasses = new BaseClasses();
+
+        this.members = members;
 
         //printf("ClassDeclaration(%s), dim = %d\n", id.toChars(), this.baseclasses.dim);
 
@@ -404,7 +406,7 @@ public:
         //printf("ClassDeclaration.syntaxCopy('%s')\n", toChars());
         ClassDeclaration cd =
             s ? cast(ClassDeclaration)s
-              : new ClassDeclaration(loc, ident, null);
+              : new ClassDeclaration(loc, ident, null, null, false);
 
         cd.storage_class |= storage_class;
 
@@ -1512,7 +1514,7 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
 public:
     extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses)
     {
-        super(loc, id, baseclasses);
+        super(loc, id, baseclasses, null, false);
         if (id == Id.IUnknown) // IUnknown is the root of all COM interfaces
         {
             com = true;

--- a/src/parse.d
+++ b/src/parse.d
@@ -3124,7 +3124,7 @@ public:
                 if (tok == TOKclass)
                 {
                     bool inObject = md && !md.packages && md.id == Id.object;
-                    a = new ClassDeclaration(loc, id, baseclasses, inObject);
+                    a = new ClassDeclaration(loc, id, baseclasses, null, inObject);
                 }
                 else
                     a = new InterfaceDeclaration(loc, id, baseclasses);
@@ -8340,23 +8340,22 @@ public:
                 baseclasses = parseBaseClasses();
 
             Identifier id = null;
-            auto cd = new ClassDeclaration(loc, id, baseclasses);
+            Dsymbols* members = null;
 
             if (token.value != TOKlcurly)
             {
                 error("{ members } expected for anonymous class");
-                cd.members = null;
             }
             else
             {
                 nextToken();
-                Dsymbols* decl = parseDeclDefs(0);
+                members = parseDeclDefs(0);
                 if (token.value != TOKrcurly)
                     error("class member expected");
                 nextToken();
-                cd.members = decl;
             }
 
+            auto cd = new ClassDeclaration(loc, id, baseclasses, members, false);
             auto e = new NewAnonClassExp(loc, thisexp, newargs, cd, arguments);
             return e;
         }


### PR DESCRIPTION
Because not everyone should access `.members`
