### PR TITLE
refactor: straighten out parseAggregate()

### DIFF
--- a/test/fail_compilation/diag13609b.d
+++ b/test/fail_compilation/diag13609b.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag13609b.d(9): Error: { } expected following struct declaration
-fail_compilation/diag13609b.d(9): Error: declaration expected, not ':'
+fail_compilation/diag13609b.d(10): Error: base classes are not allowed for struct, did you mean ';'?
+fail_compilation/diag13609b.d(11): Error: basic type expected, not EOF
+fail_compilation/diag13609b.d(11): Error: { } expected following struct declaration
 ---
 */
 

--- a/test/fail_compilation/diag3673.d
+++ b/test/fail_compilation/diag3673.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag3673.d(9): Error: members expected
+fail_compilation/diag3673.d(9): Error: template constraints appear both before and after BaseClassList, put them before
 ---
 */
 

--- a/test/fail_compilation/ice8795.d
+++ b/test/fail_compilation/ice8795.d
@@ -1,11 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8795.d-mixin-13(13): Error: found 'EOF' when expecting '('
-fail_compilation/ice8795.d-mixin-13(13): Error: expression expected, not 'EOF'
-fail_compilation/ice8795.d-mixin-13(13): Error: found 'EOF' when expecting ')'
-fail_compilation/ice8795.d-mixin-13(13): Error: found 'EOF' instead of statement
-fail_compilation/ice8795.d-mixin-14(14): Error: anonymous classes not allowed
+fail_compilation/ice8795.d-mixin-14(14): Error: found 'EOF' when expecting '('
+fail_compilation/ice8795.d-mixin-14(14): Error: expression expected, not 'EOF'
+fail_compilation/ice8795.d-mixin-14(14): Error: found 'EOF' when expecting ')'
+fail_compilation/ice8795.d-mixin-14(14): Error: found 'EOF' instead of statement
+fail_compilation/ice8795.d-mixin-15(15): Error: { } expected following interface declaration
+fail_compilation/ice8795.d-mixin-15(15): Error: anonymous interfaces not allowed
 ---
 */
 void main()

--- a/test/fail_compilation/ice8795b.d
+++ b/test/fail_compilation/ice8795b.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8795b.d-mixin-7(7): Error: anonymous classes not allowed
+fail_compilation/ice8795b.d-mixin-8(8): Error: { } expected following interface declaration
+fail_compilation/ice8795b.d-mixin-8(8): Error: anonymous interfaces not allowed
 ---
 */
 mixin("interface;");


### PR DESCRIPTION
The idea here is to reorganize parseAggregate():
1. the flow of control is simpler
2. fewer variables
3. parsing is completed before AST is constructed

A follow-on will eliminate the assignment to `.members` by changing the constructors, for better encapsulation.
