### PR TITLE
remove parse.h from makefiles

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -259,7 +259,7 @@ SRC = win32.mak posix.mak osmodel.mak aggregate.h aliasthis.h arraytypes.h	\
 	attrib.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h	\
 	enum.h errors.h expression.h globals.h hdrgen.h identifier.h idgen.d	\
 	import.h init.h intrange.h json.h lexer.h lib.h \
-	mars.h module.h mtype.h nspace.h objc.h parse.h                         \
+	mars.h module.h mtype.h nspace.h objc.h                         \
 	scope.h statement.h staticassert.h target.h template.h tokens.h	\
 	version.h visitor.h libomf.d scanomf.d libmscoff.d scanmscoff.d         \
 	$(DMD_SRCS)

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -186,7 +186,7 @@ SRCS = aggregate.h aliasthis.h arraytypes.h	\
 	attrib.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h	\
 	enum.h errors.h expression.h globals.h hdrgen.h identifier.h idgen.d	\
 	import.h init.h intrange.h json.h lexer.h lib.h	\
-	mars.h module.h mtype.h nspace.h objc.h parse.h                         \
+	mars.h module.h mtype.h nspace.h objc.h                         \
 	scope.h statement.h staticassert.h target.h template.h tokens.h	\
 	version.h visitor.h objc.d $(DMD_SRCS)
 


### PR DESCRIPTION
parse.h was already gone - but not from the makefiles!
