### PR TITLE
Speed up CTFE: Cache variableDeclaration.dataseg

### DIFF
--- a/src/declaration.h
+++ b/src/declaration.h
@@ -245,6 +245,7 @@ public:
                                 // 2: on stack, run destructor anyway
     int canassign;              // it can be assigned to
     bool overlapped;            // if it is a field and has overlapping
+    unsigned char isdataseg;    // private data for isDataseg
     Dsymbol *aliassym;          // if redone as alias to another symbol
     VarDeclaration *lastVar;    // Linked list of variables for goto-skips-init detection
 


### PR DESCRIPTION
This PR enables transparent caching the value in `VariableDeclaration.isDataseg`
That change alone speeds up my CTFE test-cases by roughly 10%
