### PR TITLE
add -h to print help

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -829,7 +829,7 @@ Language changes listed by -transition=id:
                 global.params.debugc = true;
             else if (strcmp(p + 1, "-f") == 0)
                 global.params.debugf = true;
-            else if (strcmp(p + 1, "-help") == 0)
+            else if (strcmp(p + 1, "-help") == 0 || strcmp(p + 1, "h") == 0)
             {
                 usage();
                 exit(EXIT_SUCCESS);
@@ -950,6 +950,11 @@ Language changes listed by -transition=id:
                 {
                     global.params.objname = p;
                     continue;
+                }
+                if (strcmp(p, `/?`) == 0)
+                {
+                    usage();
+                    exit(EXIT_SUCCESS);
                 }
             }
             files.push(p);


### PR DESCRIPTION
resubmission of #5806 based on @CyberShadow reasoning:

> BTW, I'm not sure I can resonate with this argument:

You can't survive on meat alone. If we discard all trivial changes, we may achieve impact at great cost to general polish.
- I'm not sure anyone should be forcing people what to spend their time on.
- What is useful is subjective, I'm not sure one person should decide what it is.
- Closing someone's pull request is not likely to motivate them to spend their time on something else on the same project.
- DMD's help text is one of the first 5 minutes of D experience, so even minor improvements might be important. E.g. the following doesn't seem like an unlikely first experience with dmd.exe to me:

```
C:\> dmd -h
Error: unrecognized switch '-h'

C:\> dmd /?
Error: module ? is in file '\?.d' which cannot be read
I'm inclined to reopen this assuming no other arguments.
```

> We should support -h. We probably should also support /? on Windows, because native Windows compilers use that switch. Everything else seems superfluous to me.

This PR now only includes those two small additions.
