### PR TITLE
fix Issue 5305 - intrinsic functions have @safe stripped of them in r…

### DIFF
--- a/test/runnable/test5305.d
+++ b/test/runnable/test5305.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=5305
+
+import std.math;
+void map(real function(real) f) { }
+int main() { map(&sqrt); return 0; }
+
+


### PR DESCRIPTION
…elease mode

Seems to work, adding a test case to ensure it.
