### PR TITLE
[trivial] Remove redundant 'public' attributes in D classes

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -56,7 +56,6 @@ alias BASEOKsemanticdone = Baseok.BASEOKsemanticdone;
  */
 extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 {
-public:
     Type type;
     StorageClass storage_class;
     Prot protection;

--- a/src/aliasthis.d
+++ b/src/aliasthis.d
@@ -29,7 +29,6 @@ import ddmd.visitor;
  */
 extern (C++) final class AliasThis : Dsymbol
 {
-public:
     Identifier ident;
 
     extern (D) this(Loc loc, Identifier ident)

--- a/src/attrib.d
+++ b/src/attrib.d
@@ -41,7 +41,6 @@ import ddmd.visitor;
  */
 extern (C++) abstract class AttribDeclaration : Dsymbol
 {
-public:
     Dsymbols* decl;     // array of Dsymbol's
 
     final extern (D) this(Dsymbols* decl)
@@ -319,7 +318,6 @@ public:
  */
 extern (C++) class StorageClassDeclaration : AttribDeclaration
 {
-public:
     StorageClass stc;
 
     final extern (D) this(StorageClass stc, Dsymbols* decl)
@@ -392,7 +390,6 @@ public:
  */
 extern (C++) final class DeprecatedDeclaration : StorageClassDeclaration
 {
-public:
     Expression msg;
     const(char)* msgstr;
 
@@ -481,7 +478,6 @@ public:
  */
 extern (C++) final class LinkDeclaration : AttribDeclaration
 {
-public:
     LINK linkage;
 
     extern (D) this(LINK p, Dsymbols* decl)
@@ -517,7 +513,6 @@ public:
  */
 extern (C++) final class ProtDeclaration : AttribDeclaration
 {
-public:
     Prot protection;
     Identifiers* pkg_identifiers;
 
@@ -610,7 +605,6 @@ public:
  */
 extern (C++) final class AlignDeclaration : AttribDeclaration
 {
-public:
     uint salign;
 
     extern (D) this(uint sa, Dsymbols* decl)
@@ -640,7 +634,6 @@ public:
  */
 extern (C++) final class AnonDeclaration : AttribDeclaration
 {
-public:
     bool isunion;
     structalign_t alignment;
     int sem;                // 1 if successful semantic()
@@ -786,7 +779,6 @@ public:
  */
 extern (C++) final class PragmaDeclaration : AttribDeclaration
 {
-public:
     Expressions* args;      // array of Expression's
 
     extern (D) this(Loc loc, Identifier ident, Expressions* args, Dsymbols* decl)
@@ -1075,7 +1067,6 @@ public:
  */
 extern (C++) class ConditionalDeclaration : AttribDeclaration
 {
-public:
     Condition condition;
     Dsymbols* elsedecl;     // array of Dsymbol's for else block
 
@@ -1167,7 +1158,6 @@ public:
  */
 extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
 {
-public:
     ScopeDsymbol scopesym;
     bool addisdone;
 
@@ -1270,7 +1260,6 @@ public:
  */
 extern (C++) final class CompileDeclaration : AttribDeclaration
 {
-public:
     Expression exp;
     ScopeDsymbol scopesym;
     bool compiled;
@@ -1360,7 +1349,6 @@ public:
  */
 extern (C++) final class UserAttributeDeclaration : AttribDeclaration
 {
-public:
     Expressions* atts;
 
     extern (D) this(Expressions* atts, Dsymbols* decl)

--- a/src/cond.d
+++ b/src/cond.d
@@ -31,7 +31,6 @@ import ddmd.id;
  */
 extern (C++) abstract class Condition
 {
-public:
     Loc loc;
     // 0: not computed yet
     // 1: include
@@ -62,7 +61,6 @@ public:
  */
 extern (C++) class DVCondition : Condition
 {
-public:
     uint level;
     Identifier ident;
     Module mod;
@@ -90,7 +88,6 @@ public:
  */
 extern (C++) final class DebugCondition : DVCondition
 {
-public:
     static void setGlobalLevel(uint level)
     {
         global.params.debuglevel = level;
@@ -154,7 +151,6 @@ public:
  */
 extern (C++) final class VersionCondition : DVCondition
 {
-public:
     static void setGlobalLevel(uint level)
     {
         global.params.versionlevel = level;
@@ -338,7 +334,6 @@ public:
  */
 extern (C++) final class StaticIfCondition : Condition
 {
-public:
     Expression exp;
     int nest;           // limit circular dependencies
 

--- a/src/ctfeexpr.d
+++ b/src/ctfeexpr.d
@@ -52,7 +52,6 @@ struct CtfeStatus
  */
 extern (C++) final class ClassReferenceExp : Expression
 {
-public:
     StructLiteralExp value;
 
     extern (D) this(Loc loc, StructLiteralExp lit, Type type)
@@ -122,7 +121,6 @@ public:
  */
 extern (C++) final class VoidInitExp : Expression
 {
-public:
     VarDeclaration var;
 
     extern (D) this(VarDeclaration var, Type type)
@@ -161,7 +159,6 @@ extern (C++) int findFieldIndexByName(StructDeclaration sd, VarDeclaration v)
  */
 extern (C++) final class ThrownExceptionExp : Expression
 {
-public:
     ClassReferenceExp thrown;   // the thing being tossed
 
     extern (D) this(Loc loc, ClassReferenceExp victim)
@@ -201,7 +198,6 @@ public:
  */
 extern (C++) final class CTFEExp : Expression
 {
-public:
     extern (D) this(TOK tok)
     {
         super(Loc(), tok, __traits(classInstanceSize, CTFEExp));

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -187,7 +187,6 @@ struct ClassFlags
  */
 extern (C++) class ClassDeclaration : AggregateDeclaration
 {
-public:
     extern (C++) __gshared
     {
         // Names found by reading object.d in druntime
@@ -1511,7 +1510,6 @@ public:
  */
 extern (C++) final class InterfaceDeclaration : ClassDeclaration
 {
-public:
     extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses)
     {
         super(loc, id, baseclasses, null, false);

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -146,7 +146,6 @@ struct Match
  */
 extern (C++) abstract class Declaration : Dsymbol
 {
-public:
     Type type;
     Type originalType;  // before semantic analysis
     StorageClass storage_class;
@@ -356,7 +355,6 @@ public:
  */
 extern (C++) final class TupleDeclaration : Declaration
 {
-public:
     Objects* objects;
     bool isexp;             // true: expression tuple
     TypeTuple tupletype;    // !=null if this is a type tuple
@@ -488,7 +486,6 @@ public:
  */
 extern (C++) final class AliasDeclaration : Declaration
 {
-public:
     Dsymbol aliassym;
     Dsymbol overnext;   // next in overload list
     Dsymbol _import;    // !=null if unresolved internal alias for selective import
@@ -852,7 +849,6 @@ public:
  */
 extern (C++) final class OverDeclaration : Declaration
 {
-public:
     Dsymbol overnext;   // next in overload list
     Dsymbol aliassym;
     bool hasOverloads;
@@ -967,7 +963,6 @@ public:
  */
 extern (C++) class VarDeclaration : Declaration
 {
-public:
     Initializer _init;
     uint offset;
     bool noscope;                   // if scope destruction is disabled
@@ -2294,7 +2289,6 @@ public:
  */
 extern (C++) final class SymbolDeclaration : Declaration
 {
-public:
     StructDeclaration dsym;
 
     extern (D) this(Loc loc, StructDeclaration dsym)
@@ -2321,7 +2315,6 @@ public:
  */
 extern (C++) class TypeInfoDeclaration : VarDeclaration
 {
-public:
     Type tinfo;
 
     final extern (D) this(Type tinfo)
@@ -2373,7 +2366,6 @@ public:
  */
 extern (C++) final class TypeInfoStructDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2399,7 +2391,6 @@ public:
  */
 extern (C++) final class TypeInfoClassDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2425,7 +2416,6 @@ public:
  */
 extern (C++) final class TypeInfoInterfaceDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2451,7 +2441,6 @@ public:
  */
 extern (C++) final class TypeInfoPointerDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2477,7 +2466,6 @@ public:
  */
 extern (C++) final class TypeInfoArrayDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2503,7 +2491,6 @@ public:
  */
 extern (C++) final class TypeInfoStaticArrayDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2529,7 +2516,6 @@ public:
  */
 extern (C++) final class TypeInfoAssociativeArrayDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2555,7 +2541,6 @@ public:
  */
 extern (C++) final class TypeInfoEnumDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2581,7 +2566,6 @@ public:
  */
 extern (C++) final class TypeInfoFunctionDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2607,7 +2591,6 @@ public:
  */
 extern (C++) final class TypeInfoDelegateDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2633,7 +2616,6 @@ public:
  */
 extern (C++) final class TypeInfoTupleDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2659,7 +2641,6 @@ public:
  */
 extern (C++) final class TypeInfoConstDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2685,7 +2666,6 @@ public:
  */
 extern (C++) final class TypeInfoInvariantDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2711,7 +2691,6 @@ public:
  */
 extern (C++) final class TypeInfoSharedDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2737,7 +2716,6 @@ public:
  */
 extern (C++) final class TypeInfoWildDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2763,7 +2741,6 @@ public:
  */
 extern (C++) final class TypeInfoVectorDeclaration : TypeInfoDeclaration
 {
-public:
     extern (D) this(Type tinfo)
     {
         super(tinfo);
@@ -2790,7 +2767,6 @@ public:
  */
 extern (C++) final class ThisDeclaration : VarDeclaration
 {
-public:
     extern (D) this(Loc loc, Type t)
     {
         super(loc, t, Id.This, null);

--- a/src/denum.d
+++ b/src/denum.d
@@ -30,7 +30,6 @@ import ddmd.visitor;
  */
 extern (C++) final class EnumDeclaration : ScopeDsymbol
 {
-public:
     /* The separate, and distinct, cases are:
      *  1. enum { ... }
      *  2. enum : memtype { ... }
@@ -500,7 +499,6 @@ public:
  */
 extern (C++) final class EnumMember : VarDeclaration
 {
-public:
     /* Can take the following forms:
      *  1. id
      *  2. id = value

--- a/src/dimport.d
+++ b/src/dimport.d
@@ -33,7 +33,6 @@ import ddmd.visitor;
  */
 extern (C++) final class Import : Dsymbol
 {
-public:
     /* static import aliasId = pkg1.pkg2.id : alias1 = name1, alias2 = name2;
      */
     Identifiers* packages;  // array of Identifier's representing packages

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -109,7 +109,6 @@ alias PKGpackage = PKG.PKGpackage;
  */
 extern (C++) class Package : ScopeDsymbol
 {
-public:
     PKG isPkgMod;
     uint tag;        // auto incremented tag, used to mask package tree in scopes
     Module mod;     // !=null if isPkgMod == PKGmodule
@@ -253,7 +252,6 @@ public:
  */
 extern (C++) final class Module : Package
 {
-public:
     extern (C++) static __gshared Module rootModule;
     extern (C++) static __gshared DsymbolTable modules; // symbol table of all modules
     extern (C++) static __gshared Modules amodules;     // array of all modules

--- a/src/doc.d
+++ b/src/doc.d
@@ -86,7 +86,6 @@ struct Escape
  */
 extern (C++) class Section
 {
-public:
     const(char)* name;
     size_t namelen;
     const(char)* _body;
@@ -152,7 +151,6 @@ public:
  */
 extern (C++) final class ParamSection : Section
 {
-public:
     override void write(Loc loc, DocComment* dc, Scope* sc, Dsymbols* a, OutBuffer* buf)
     {
         assert(a.dim);
@@ -299,7 +297,6 @@ public:
  */
 extern (C++) final class MacroSection : Section
 {
-public:
     override void write(Loc loc, DocComment* dc, Scope* sc, Dsymbols* a, OutBuffer* buf)
     {
         //printf("MacroSection::write()\n");

--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -214,7 +214,6 @@ alias ISPODfwd = StructPOD.ISPODfwd;
  */
 extern (C++) class StructDeclaration : AggregateDeclaration
 {
-public:
     int zeroInit;               // !=0 if initialize with 0 fill
     bool hasIdentityAssign;     // true if has identity opAssign
     bool hasIdentityEquals;     // true if has identity opEquals
@@ -753,7 +752,6 @@ public:
  */
 extern (C++) final class UnionDeclaration : StructDeclaration
 {
-public:
     extern (D) this(Loc loc, Identifier id)
     {
         super(loc, id);

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -188,7 +188,6 @@ extern (C++) alias Dsymbol_apply_ft_t = int function(Dsymbol, void*);
  */
 extern (C++) class Dsymbol : RootObject
 {
-public:
     Identifier ident;
     Dsymbol parent;
     Symbol* csym;           // symbol for code generator
@@ -1260,7 +1259,6 @@ public:
  */
 extern (C++) class ScopeDsymbol : Dsymbol
 {
-public:
     Dsymbols* members;          // all Dsymbol's in this scope
     DsymbolTable symtab;        // members[] sorted into table
     uint endlinnum;             // the linnumber of the statement after the scope (0 if unknown)
@@ -1702,7 +1700,6 @@ public:
  */
 extern (C++) final class WithScopeSymbol : ScopeDsymbol
 {
-public:
     WithStatement withstate;
 
     extern (D) this(WithStatement withstate)
@@ -1760,7 +1757,6 @@ public:
  */
 extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
 {
-public:
     Expression exp;         // IndexExp or SliceExp
     TypeTuple type;         // for tuple[length]
     TupleDeclaration td;    // for tuples of objects
@@ -1973,7 +1969,6 @@ public:
  */
 extern (C++) final class OverloadSet : Dsymbol
 {
-public:
     Dsymbols a;     // array of Dsymbols
 
     extern (D) this(Identifier ident, OverloadSet os = null)
@@ -2012,7 +2007,6 @@ public:
  */
 extern (C++) final class DsymbolTable : RootObject
 {
-public:
     AA* tab;
 
     // Look up Identifier. Return Dsymbol if found, NULL if not.

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -378,7 +378,6 @@ extern (C++) RootObject objectSyntaxCopy(RootObject o)
 
 extern (C++) final class Tuple : RootObject
 {
-public:
     Objects objects;
 
     // kludge for template.isType()
@@ -404,7 +403,6 @@ struct TemplatePrevious
  */
 extern (C++) final class TemplateDeclaration : ScopeDsymbol
 {
-public:
     TemplateParameters* parameters;     // array of TemplateParameter's
     TemplateParameters* origParameters; // originals for Ddoc
 
@@ -2263,7 +2261,6 @@ public:
 
 extern (C++) final class TypeDeduced : Type
 {
-public:
     Type tded;
     Expressions argexps; // corresponding expressions
     Types tparams; // tparams[i]->mod
@@ -4918,7 +4915,6 @@ extern (C++) bool reliesOnTident(Type t, TemplateParameters* tparams = null, siz
  */
 extern (C++) class TemplateParameter
 {
-public:
     Loc loc;
     Identifier ident;
 
@@ -5033,7 +5029,6 @@ public:
  */
 extern (C++) class TemplateTypeParameter : TemplateParameter
 {
-public:
     Type specType;      // if !=null, this is the type specialization
     Type defaultType;
 
@@ -5220,7 +5215,6 @@ public:
  */
 extern (C++) final class TemplateThisParameter : TemplateTypeParameter
 {
-public:
     extern (D) this(Loc loc, Identifier ident, Type specType, Type defaultType)
     {
         super(loc, ident, specType, defaultType);
@@ -5248,7 +5242,6 @@ public:
  */
 extern (C++) final class TemplateValueParameter : TemplateParameter
 {
-public:
     Type valType;
     Expression specValue;
     Expression defaultValue;
@@ -5527,7 +5520,6 @@ extern (C++) RootObject aliasParameterSemantic(Loc loc, Scope* sc, RootObject o,
  */
 extern (C++) final class TemplateAliasParameter : TemplateParameter
 {
-public:
     Type specType;
     RootObject specAlias;
     RootObject defaultAlias;
@@ -5761,7 +5753,6 @@ public:
  */
 extern (C++) final class TemplateTupleParameter : TemplateParameter
 {
-public:
     extern (D) this(Loc loc, Identifier ident)
     {
         super(loc, ident);
@@ -5903,7 +5894,6 @@ public:
  */
 extern (C++) class TemplateInstance : ScopeDsymbol
 {
-public:
     Identifier name;
 
     // Array of Types/Expressions of template
@@ -8372,7 +8362,6 @@ extern (C++) bool definitelyValueParameter(Expression e)
  */
 extern (C++) final class TemplateMixin : TemplateInstance
 {
-public:
     TypeQualified tqual;
 
     extern (D) this(Loc loc, Identifier ident, TypeQualified tqual, Objects* tiargs)

--- a/src/dversion.d
+++ b/src/dversion.d
@@ -25,7 +25,6 @@ import ddmd.visitor;
  */
 extern (C++) final class DebugSymbol : Dsymbol
 {
-public:
     uint level;
 
     extern (D) this(Loc loc, Identifier ident)
@@ -120,7 +119,6 @@ public:
  */
 extern (C++) final class VersionSymbol : Dsymbol
 {
-public:
     uint level;
 
     extern (D) this(Loc loc, Identifier ident)

--- a/src/expression.d
+++ b/src/expression.d
@@ -2462,7 +2462,6 @@ enum WANTexpand = 1;    // expand const/immutable variables if possible
  */
 extern (C++) abstract class Expression : RootObject
 {
-public:
     Loc loc;        // file location
     Type type;      // !=null means that semantic() has been run
     TOK op;         // to minimize use of dynamic_cast
@@ -3412,7 +3411,6 @@ public:
  */
 extern (C++) final class IntegerExp : Expression
 {
-public:
     dinteger_t value;
 
     extern (D) this(Loc loc, dinteger_t value, Type type)
@@ -3588,7 +3586,6 @@ private:
  */
 extern (C++) final class ErrorExp : Expression
 {
-public:
     extern (D) this()
     {
         super(Loc(), TOKerror, __traits(classInstanceSize, ErrorExp));
@@ -3612,7 +3609,6 @@ public:
  */
 extern (C++) final class RealExp : Expression
 {
-public:
     real_t value;
 
     extern (D) this(Loc loc, real_t value, Type type)
@@ -3687,7 +3683,6 @@ public:
  */
 extern (C++) final class ComplexExp : Expression
 {
-public:
     complex_t value;
 
     extern (D) this(Loc loc, complex_t value, Type type)
@@ -3765,7 +3760,6 @@ public:
  */
 extern (C++) class IdentifierExp : Expression
 {
-public:
     Identifier ident;
 
     final extern (D) this(Loc loc, Identifier ident)
@@ -3927,7 +3921,6 @@ public:
  */
 extern (C++) final class DollarExp : IdentifierExp
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc, Id.dollar);
@@ -3945,7 +3938,6 @@ public:
  */
 extern (C++) final class DsymbolExp : Expression
 {
-public:
     Dsymbol s;
     bool hasOverloads;
 
@@ -4159,7 +4151,6 @@ public:
  */
 extern (C++) class ThisExp : Expression
 {
-public:
     VarDeclaration var;
 
     final extern (D) this(Loc loc)
@@ -4255,7 +4246,6 @@ public:
  */
 extern (C++) final class SuperExp : ThisExp
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc);
@@ -4351,7 +4341,6 @@ public:
  */
 extern (C++) final class NullExp : Expression
 {
-public:
     ubyte committed;    // !=0 if type is committed
 
     extern (D) this(Loc loc, Type type = null)
@@ -4412,7 +4401,6 @@ public:
  */
 extern (C++) final class StringExp : Expression
 {
-public:
     union
     {
         char* string;   // if sz == 1
@@ -4853,7 +4841,6 @@ public:
  */
 extern (C++) final class TupleExp : Expression
 {
-public:
     /* Tuple-field access may need to take out its side effect part.
      * For example:
      *      foo().tupleof
@@ -4994,7 +4981,6 @@ public:
  */
 extern (C++) final class ArrayLiteralExp : Expression
 {
-public:
     /* If !is null, elements[] can be sparse and basis is used for the
      * "default" element value. In other words, non-null elements[i] overrides
      * this 'basis' value.
@@ -5225,7 +5211,6 @@ public:
  */
 extern (C++) final class AssocArrayLiteralExp : Expression
 {
-public:
     Expressions* keys;
     Expressions* values;
     OwnedBy ownedByCtfe = OWNEDcode;
@@ -5335,7 +5320,6 @@ enum stageToCBuffer         = 0x20; // toCBuffer is running
  */
 extern (C++) final class StructLiteralExp : Expression
 {
-public:
     StructDeclaration sd;   // which aggregate this is for
     Expressions* elements;  // parallels sd.fields[] with null entries for fields to skip
     Type stype;             // final type of result (can be different from sd's type)
@@ -5569,7 +5553,6 @@ public:
  */
 extern (C++) final class TypeExp : Expression
 {
-public:
     extern (D) this(Loc loc, Type type)
     {
         super(loc, TOKtype, __traits(classInstanceSize, TypeExp));
@@ -5646,7 +5629,6 @@ public:
  */
 extern (C++) final class ScopeExp : Expression
 {
-public:
     ScopeDsymbol sds;
 
     extern (D) this(Loc loc, ScopeDsymbol sds)
@@ -5830,7 +5812,6 @@ public:
  */
 extern (C++) final class TemplateExp : Expression
 {
-public:
     TemplateDeclaration td;
     FuncDeclaration fd;
 
@@ -5879,7 +5860,6 @@ public:
  */
 extern (C++) final class NewExp : Expression
 {
-public:
     Expression thisexp;         // if !=null, 'this' for class being allocated
     Expressions* newargs;       // Array of Expression's to call new operator
     Type newtype;
@@ -6333,7 +6313,6 @@ public:
  */
 extern (C++) final class NewAnonClassExp : Expression
 {
-public:
     Expression thisexp;     // if !=null, 'this' for class being allocated
     Expressions* newargs;   // Array of Expression's to call new operator
     ClassDeclaration cd;    // class being instantiated
@@ -6390,7 +6369,6 @@ public:
  */
 extern (C++) class SymbolExp : Expression
 {
-public:
     Declaration var;
     bool hasOverloads;
 
@@ -6421,7 +6399,6 @@ public:
  */
 extern (C++) final class SymOffExp : SymbolExp
 {
-public:
     dinteger_t offset;
 
     extern (D) this(Loc loc, Declaration var, dinteger_t offset, bool hasOverloads = true)
@@ -6478,7 +6455,6 @@ public:
  */
 extern (C++) final class VarExp : SymbolExp
 {
-public:
     extern (D) this(Loc loc, Declaration var, bool hasOverloads = true)
     {
         if (var.isVarDeclaration())
@@ -6623,7 +6599,6 @@ public:
  */
 extern (C++) final class OverExp : Expression
 {
-public:
     OverloadSet vars;
 
     extern (D) this(Loc loc, OverloadSet s)
@@ -6655,7 +6630,6 @@ public:
  */
 extern (C++) final class FuncExp : Expression
 {
-public:
     FuncLiteralDeclaration fd;
     TemplateDeclaration td;
     TOK tok;
@@ -7108,7 +7082,6 @@ public:
  */
 extern (C++) final class DeclarationExp : Expression
 {
-public:
     Dsymbol declaration;
 
     extern (D) this(Loc loc, Dsymbol declaration)
@@ -7235,7 +7208,6 @@ public:
  */
 extern (C++) final class TypeidExp : Expression
 {
-public:
     RootObject obj;
 
     extern (D) this(Loc loc, RootObject o)
@@ -7328,7 +7300,6 @@ public:
  */
 extern (C++) final class TraitsExp : Expression
 {
-public:
     Identifier ident;
     Objects* args;
 
@@ -7359,7 +7330,6 @@ public:
  */
 extern (C++) final class HaltExp : Expression
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc, TOKhalt, __traits(classInstanceSize, HaltExp));
@@ -7387,7 +7357,6 @@ public:
  */
 extern (C++) final class IsExp : Expression
 {
-public:
     Type targ;
     Identifier id;      // can be null
     TOK tok;            // ':' or '=='
@@ -7735,7 +7704,6 @@ public:
  */
 extern (C++) class UnaExp : Expression
 {
-public:
     Expression e1;
     Type att1;      // Save alias this type to detect recursion
 
@@ -7797,7 +7765,6 @@ extern (C++) alias fp2_t = int function(Loc loc, TOK, Expression, Expression);
  */
 extern (C++) abstract class BinExp : Expression
 {
-public:
     Expression e1;
     Expression e2;
     Type att1;      // Save alias this type to detect recursion
@@ -8101,7 +8068,6 @@ public:
  */
 extern (C++) class BinAssignExp : BinExp
 {
-public:
     final extern (D) this(Loc loc, TOK op, int size, Expression e1, Expression e2)
     {
         super(loc, op, size, e1, e2);
@@ -8224,7 +8190,6 @@ public:
  */
 extern (C++) final class CompileExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKmixin, __traits(classInstanceSize, CompileExp), e);
@@ -8272,7 +8237,6 @@ public:
  */
 extern (C++) final class ImportExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKimport, __traits(classInstanceSize, ImportExp), e);
@@ -8357,7 +8321,6 @@ public:
  */
 extern (C++) final class AssertExp : UnaExp
 {
-public:
     Expression msg;
 
     extern (D) this(Loc loc, Expression e, Expression msg = null)
@@ -8436,7 +8399,6 @@ public:
  */
 extern (C++) final class DotIdExp : UnaExp
 {
-public:
     Identifier ident;
 
     extern (D) this(Loc loc, Expression e, Identifier ident)
@@ -8857,7 +8819,6 @@ public:
  */
 extern (C++) final class DotTemplateExp : UnaExp
 {
-public:
     TemplateDeclaration td;
 
     extern (D) this(Loc loc, Expression e, TemplateDeclaration td)
@@ -8883,7 +8844,6 @@ public:
  */
 extern (C++) final class DotVarExp : UnaExp
 {
-public:
     Declaration var;
     bool hasOverloads;
 
@@ -9080,7 +9040,6 @@ public:
  */
 extern (C++) final class DotTemplateInstanceExp : UnaExp
 {
-public:
     TemplateInstance ti;
 
     extern (D) this(Loc loc, Expression e, Identifier name, Objects* tiargs)
@@ -9347,7 +9306,6 @@ public:
  */
 extern (C++) final class DelegateExp : UnaExp
 {
-public:
     FuncDeclaration func;
     bool hasOverloads;
 
@@ -9403,7 +9361,6 @@ public:
  */
 extern (C++) final class DotTypeExp : UnaExp
 {
-public:
     Dsymbol sym;        // symbol that represents a type
 
     extern (D) this(Loc loc, Expression e, Dsymbol s)
@@ -9438,7 +9395,6 @@ public:
  */
 extern (C++) final class CallExp : UnaExp
 {
-public:
     Expressions* arguments; // function arguments
     FuncDeclaration f;      // symbol to call
     bool directcall;        // true if a virtual call is devirtualized
@@ -10453,7 +10409,6 @@ FuncDeclaration isFuncAddress(Expression e, bool* hasOverloads = null)
  */
 extern (C++) final class AddrExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKaddress, __traits(classInstanceSize, AddrExp), e);
@@ -10653,7 +10608,6 @@ public:
  */
 extern (C++) final class PtrExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKstar, __traits(classInstanceSize, PtrExp), e);
@@ -10749,7 +10703,6 @@ public:
  */
 extern (C++) final class NegExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKneg, __traits(classInstanceSize, NegExp), e);
@@ -10798,7 +10751,6 @@ public:
  */
 extern (C++) final class UAddExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKuadd, __traits(classInstanceSize, UAddExp), e);
@@ -10834,7 +10786,6 @@ public:
  */
 extern (C++) final class ComExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKtilde, __traits(classInstanceSize, ComExp), e);
@@ -10879,7 +10830,6 @@ public:
  */
 extern (C++) final class NotExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKnot, __traits(classInstanceSize, NotExp), e);
@@ -10916,7 +10866,6 @@ public:
  */
 extern (C++) final class DeleteExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKdelete, __traits(classInstanceSize, DeleteExp), e);
@@ -11055,7 +11004,6 @@ public:
  */
 extern (C++) final class CastExp : UnaExp
 {
-public:
     Type to;                    // type to cast to
     ubyte mod = cast(ubyte)~0;  // MODxxxxx
 
@@ -11252,7 +11200,6 @@ public:
  */
 extern (C++) final class VectorExp : UnaExp
 {
-public:
     TypeVector to;      // the target vector type before semantic()
     uint dim = ~0;      // number of elements in the vector
 
@@ -11323,7 +11270,6 @@ public:
  */
 extern (C++) final class SliceExp : UnaExp
 {
-public:
     Expression upr;             // null if implicit 0
     Expression lwr;             // null if implicit [length - 1]
     VarDeclaration lengthVar;
@@ -11630,7 +11576,6 @@ public:
  */
 extern (C++) final class ArrayLengthExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e1)
     {
         super(loc, TOKarraylength, __traits(classInstanceSize, ArrayLengthExp), e1);
@@ -11700,7 +11645,6 @@ public:
  */
 extern (C++) final class ArrayExp : UnaExp
 {
-public:
     Expressions* arguments;     // Array of Expression's
     size_t currentDimension;    // for opDollar
     VarDeclaration lengthVar;
@@ -11768,7 +11712,6 @@ public:
  */
 extern (C++) final class DotExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKdot, __traits(classInstanceSize, DotExp), e1, e2);
@@ -11811,7 +11754,6 @@ public:
  */
 extern (C++) final class CommaExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKcomma, __traits(classInstanceSize, CommaExp), e1, e2);
@@ -11886,7 +11828,6 @@ public:
  */
 extern (C++) final class IntervalExp : Expression
 {
-public:
     Expression lwr;
     Expression upr;
 
@@ -11939,7 +11880,6 @@ public:
 
 extern (C++) final class DelegatePtrExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e1)
     {
         super(loc, TOKdelegateptr, __traits(classInstanceSize, DelegatePtrExp), e1);
@@ -11984,7 +11924,6 @@ public:
  */
 extern (C++) final class DelegateFuncptrExp : UnaExp
 {
-public:
     extern (D) this(Loc loc, Expression e1)
     {
         super(loc, TOKdelegatefuncptr, __traits(classInstanceSize, DelegateFuncptrExp), e1);
@@ -12029,7 +11968,6 @@ public:
  */
 extern (C++) final class IndexExp : BinExp
 {
-public:
     VarDeclaration lengthVar;
     bool modifiable = false;    // assume it is an rvalue
     bool indexIsInBounds;       // true if 0 <= e2 && e2 <= e1.length - 1
@@ -12297,7 +12235,6 @@ public:
  */
 extern (C++) final class PostExp : BinExp
 {
-public:
     extern (D) this(TOK op, Loc loc, Expression e)
     {
         super(loc, op, __traits(classInstanceSize, PostExp), e, new IntegerExp(loc, 1, Type.tint32));
@@ -12399,7 +12336,6 @@ public:
  */
 extern (C++) final class PreExp : UnaExp
 {
-public:
     extern (D) this(TOK op, Loc loc, Expression e)
     {
         super(loc, op, __traits(classInstanceSize, PreExp), e);
@@ -12436,7 +12372,6 @@ enum MemorySet
  */
 extern (C++) class AssignExp : BinExp
 {
-public:
     int memset;         // combination of MemorySet flags
 
     /************************************************************/
@@ -13410,7 +13345,6 @@ public:
  */
 extern (C++) final class ConstructExp : AssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, e1, e2);
@@ -13441,7 +13375,6 @@ public:
  */
 extern (C++) final class BlitExp : AssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, e1, e2);
@@ -13472,7 +13405,6 @@ public:
  */
 extern (C++) final class AddAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKaddass, __traits(classInstanceSize, AddAssignExp), e1, e2);
@@ -13488,7 +13420,6 @@ public:
  */
 extern (C++) final class MinAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKminass, __traits(classInstanceSize, MinAssignExp), e1, e2);
@@ -13504,7 +13435,6 @@ public:
  */
 extern (C++) final class MulAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKmulass, __traits(classInstanceSize, MulAssignExp), e1, e2);
@@ -13520,7 +13450,6 @@ public:
  */
 extern (C++) final class DivAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKdivass, __traits(classInstanceSize, DivAssignExp), e1, e2);
@@ -13536,7 +13465,6 @@ public:
  */
 extern (C++) final class ModAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKmodass, __traits(classInstanceSize, ModAssignExp), e1, e2);
@@ -13552,7 +13480,6 @@ public:
  */
 extern (C++) final class AndAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKandass, __traits(classInstanceSize, AndAssignExp), e1, e2);
@@ -13568,7 +13495,6 @@ public:
  */
 extern (C++) final class OrAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKorass, __traits(classInstanceSize, OrAssignExp), e1, e2);
@@ -13584,7 +13510,6 @@ public:
  */
 extern (C++) final class XorAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKxorass, __traits(classInstanceSize, XorAssignExp), e1, e2);
@@ -13600,7 +13525,6 @@ public:
  */
 extern (C++) final class PowAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKpowass, __traits(classInstanceSize, PowAssignExp), e1, e2);
@@ -13688,7 +13612,6 @@ public:
  */
 extern (C++) final class ShlAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKshlass, __traits(classInstanceSize, ShlAssignExp), e1, e2);
@@ -13704,7 +13627,6 @@ public:
  */
 extern (C++) final class ShrAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKshrass, __traits(classInstanceSize, ShrAssignExp), e1, e2);
@@ -13720,7 +13642,6 @@ public:
  */
 extern (C++) final class UshrAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKushrass, __traits(classInstanceSize, UshrAssignExp), e1, e2);
@@ -13736,7 +13657,6 @@ public:
  */
 extern (C++) final class CatAssignExp : BinAssignExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKcatass, __traits(classInstanceSize, CatAssignExp), e1, e2);
@@ -13828,7 +13748,6 @@ public:
  */
 extern (C++) final class AddExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKadd, __traits(classInstanceSize, AddExp), e1, e2);
@@ -13929,7 +13848,6 @@ public:
  */
 extern (C++) final class MinExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKmin, __traits(classInstanceSize, MinExp), e1, e2);
@@ -14061,7 +13979,6 @@ public:
  */
 extern (C++) final class CatExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKcat, __traits(classInstanceSize, CatExp), e1, e2);
@@ -14263,7 +14180,6 @@ public:
  */
 extern (C++) final class MulExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKmul, __traits(classInstanceSize, MulExp), e1, e2);
@@ -14369,7 +14285,6 @@ public:
  */
 extern (C++) final class DivExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKdiv, __traits(classInstanceSize, DivExp), e1, e2);
@@ -14471,7 +14386,6 @@ public:
  */
 extern (C++) final class ModExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKmod, __traits(classInstanceSize, ModExp), e1, e2);
@@ -14531,7 +14445,6 @@ public:
  */
 extern (C++) final class PowExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKpow, __traits(classInstanceSize, PowExp), e1, e2);
@@ -14659,7 +14572,6 @@ extern (C++) Module loadStdMath()
  */
 extern (C++) final class ShlExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKshl, __traits(classInstanceSize, ShlExp), e1, e2);
@@ -14700,7 +14612,6 @@ public:
  */
 extern (C++) final class ShrExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKshr, __traits(classInstanceSize, ShrExp), e1, e2);
@@ -14740,7 +14651,6 @@ public:
  */
 extern (C++) final class UshrExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKushr, __traits(classInstanceSize, UshrExp), e1, e2);
@@ -14781,7 +14691,6 @@ public:
  */
 extern (C++) final class AndExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKand, __traits(classInstanceSize, AndExp), e1, e2);
@@ -14834,7 +14743,6 @@ public:
  */
 extern (C++) final class OrExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKor, __traits(classInstanceSize, OrExp), e1, e2);
@@ -14887,7 +14795,6 @@ public:
  */
 extern (C++) final class XorExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKxor, __traits(classInstanceSize, XorExp), e1, e2);
@@ -14940,7 +14847,6 @@ public:
  */
 extern (C++) final class OrOrExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKoror, __traits(classInstanceSize, OrOrExp), e1, e2);
@@ -15016,7 +14922,6 @@ public:
  */
 extern (C++) final class AndAndExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKandand, __traits(classInstanceSize, AndAndExp), e1, e2);
@@ -15092,7 +14997,6 @@ public:
  */
 extern (C++) final class CmpExp : BinExp
 {
-public:
     extern (D) this(TOK op, Loc loc, Expression e1, Expression e2)
     {
         super(loc, op, __traits(classInstanceSize, CmpExp), e1, e2);
@@ -15270,7 +15174,6 @@ public:
  */
 extern (C++) final class InExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKin, __traits(classInstanceSize, InExp), e1, e2);
@@ -15327,7 +15230,6 @@ public:
  */
 extern (C++) final class RemoveExp : BinExp
 {
-public:
     extern (D) this(Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOKremove, __traits(classInstanceSize, RemoveExp), e1, e2);
@@ -15352,7 +15254,6 @@ public:
  */
 extern (C++) final class EqualExp : BinExp
 {
-public:
     extern (D) this(TOK op, Loc loc, Expression e1, Expression e2)
     {
         super(loc, op, __traits(classInstanceSize, EqualExp), e1, e2);
@@ -15433,7 +15334,6 @@ public:
  */
 extern (C++) final class IdentityExp : BinExp
 {
-public:
     extern (D) this(TOK op, Loc loc, Expression e1, Expression e2)
     {
         super(loc, op, __traits(classInstanceSize, IdentityExp), e1, e2);
@@ -15480,7 +15380,6 @@ public:
  */
 extern (C++) final class CondExp : BinExp
 {
-public:
     Expression econd;
 
     extern (D) this(Loc loc, Expression econd, Expression e1, Expression e2)
@@ -15727,7 +15626,6 @@ public:
  */
 extern (C++) class DefaultInitExp : Expression
 {
-public:
     TOK subop;      // which of the derived classes this is
 
     final extern (D) this(Loc loc, TOK subop, int size)
@@ -15746,7 +15644,6 @@ public:
  */
 extern (C++) final class FileInitExp : DefaultInitExp
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc, TOKfile, __traits(classInstanceSize, FileInitExp));
@@ -15779,7 +15676,6 @@ public:
  */
 extern (C++) final class LineInitExp : DefaultInitExp
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc, TOKline, __traits(classInstanceSize, LineInitExp));
@@ -15808,7 +15704,6 @@ public:
  */
 extern (C++) final class ModuleInitExp : DefaultInitExp
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc, TOKmodulestring, __traits(classInstanceSize, ModuleInitExp));
@@ -15844,7 +15739,6 @@ public:
  */
 extern (C++) final class FuncInitExp : DefaultInitExp
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc, TOKfuncstring, __traits(classInstanceSize, FuncInitExp));
@@ -15884,7 +15778,6 @@ public:
  */
 extern (C++) final class PrettyFuncInitExp : DefaultInitExp
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc, TOKprettyfunc, __traits(classInstanceSize, PrettyFuncInitExp));

--- a/src/func.d
+++ b/src/func.d
@@ -399,7 +399,6 @@ enum FUNCFLAGinlineScanned    = 0x20;   // function has been scanned for inline 
  */
 extern (C++) class FuncDeclaration : Declaration
 {
-public:
     Types* fthrows;                     // Array of Type's of exceptions (not used)
     Statement frequire;
     Statement fensure;
@@ -4463,7 +4462,6 @@ extern (C++) bool checkEscapingSiblings(FuncDeclaration f, FuncDeclaration outer
  */
 extern (C++) final class FuncAliasDeclaration : FuncDeclaration
 {
-public:
     FuncDeclaration funcalias;
     bool hasOverloads;
 
@@ -4513,7 +4511,6 @@ public:
  */
 extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
 {
-public:
     TOK tok;        // TOKfunction or TOKdelegate
     Type treq;      // target of return type inference
 
@@ -4646,7 +4643,6 @@ public:
  */
 extern (C++) final class CtorDeclaration : FuncDeclaration
 {
-public:
     extern (D) this(Loc loc, Loc endloc, StorageClass stc, Type type)
     {
         super(loc, endloc, Id.ctor, stc, type);
@@ -4780,7 +4776,6 @@ public:
  */
 extern (C++) final class PostBlitDeclaration : FuncDeclaration
 {
-public:
     extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id)
     {
         super(loc, endloc, id, stc, null);
@@ -4865,7 +4860,6 @@ public:
  */
 extern (C++) final class DtorDeclaration : FuncDeclaration
 {
-public:
     extern (D) this(Loc loc, Loc endloc)
     {
         super(loc, endloc, Id.dtor, STCundefined, null);
@@ -4966,7 +4960,6 @@ public:
  */
 extern (C++) class StaticCtorDeclaration : FuncDeclaration
 {
-public:
     final extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateId("_staticCtor"), STCstatic | stc, null);
@@ -5092,7 +5085,6 @@ public:
  */
 extern (C++) final class SharedStaticCtorDeclaration : StaticCtorDeclaration
 {
-public:
     extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, "_sharedStaticCtor", stc);
@@ -5120,7 +5112,6 @@ public:
  */
 extern (C++) class StaticDtorDeclaration : FuncDeclaration
 {
-public:
     VarDeclaration vgate; // 'gate' variable
 
     final extern (D) this(Loc loc, Loc endloc, StorageClass stc)
@@ -5250,7 +5241,6 @@ public:
  */
 extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
 {
-public:
     extern (D) this(Loc loc, Loc endloc, StorageClass stc)
     {
         super(loc, endloc, "_sharedStaticDtor", stc);
@@ -5278,7 +5268,6 @@ public:
  */
 extern (C++) final class InvariantDeclaration : FuncDeclaration
 {
-public:
     extern (D) this(Loc loc, Loc endloc, StorageClass stc, Identifier id, Statement fbody)
     {
         super(loc, endloc, id ? id : Identifier.generateId("__invariant"), stc, null);
@@ -5369,7 +5358,6 @@ extern (C++) static Identifier unitTestId(Loc loc)
  */
 extern (C++) final class UnitTestDeclaration : FuncDeclaration
 {
-public:
     char* codedoc;      // for documented unittest
 
     // toObjFile() these nested functions after this one
@@ -5472,7 +5460,6 @@ public:
  */
 extern (C++) final class NewDeclaration : FuncDeclaration
 {
-public:
     Parameters* parameters;
     int varargs;
 
@@ -5568,7 +5555,6 @@ public:
  */
 extern (C++) final class DeleteDeclaration : FuncDeclaration
 {
-public:
     Parameters* parameters;
 
     extern (D) this(Loc loc, Loc endloc, StorageClass stc, Parameters* fparams)

--- a/src/init.d
+++ b/src/init.d
@@ -43,7 +43,6 @@ alias INITinterpret = NeedInterpret.INITinterpret;
  */
 extern (C++) class Initializer : RootObject
 {
-public:
     Loc loc;
 
     final extern (D) this(Loc loc)
@@ -119,7 +118,6 @@ public:
  */
 extern (C++) final class VoidInitializer : Initializer
 {
-public:
     Type type;      // type that this will initialize to
 
     extern (D) this(Loc loc)
@@ -165,7 +163,6 @@ public:
  */
 extern (C++) final class ErrorInitializer : Initializer
 {
-public:
     extern (D) this()
     {
         super(Loc());
@@ -207,7 +204,6 @@ public:
  */
 extern (C++) final class StructInitializer : Initializer
 {
-public:
     Identifiers field;      // of Identifier *'s
     Initializers value;     // parallel array of Initializer *'s
 
@@ -384,7 +380,6 @@ public:
  */
 extern (C++) final class ArrayInitializer : Initializer
 {
-public:
     Expressions index;      // indices
     Initializers value;     // of Initializer *'s
     size_t dim;             // length of array being initialized
@@ -754,7 +749,6 @@ public:
  */
 extern (C++) final class ExpInitializer : Initializer
 {
-public:
     Expression exp;
     bool expandTuples;
 

--- a/src/lexer.d
+++ b/src/lexer.d
@@ -142,7 +142,6 @@ unittest
  */
 class Lexer
 {
-public:
     __gshared OutBuffer stringbuffer;
 
     Loc scanloc;            // for error messages

--- a/src/lib.d
+++ b/src/lib.d
@@ -30,7 +30,6 @@ else
 
 extern (C++) class Library
 {
-public:
     static Library factory()
     {
         static if (TARGET_WINDOS)

--- a/src/libelf.d
+++ b/src/libelf.d
@@ -40,7 +40,6 @@ alias ElfObjSymbols = Array!(ElfObjSymbol*);
 
 extern (C++) final class LibElf : Library
 {
-public:
     File* libfile;
     ElfObjModules objmodules; // ElfObjModule[]
     ElfObjSymbols objsymbols; // ElfObjSymbol[]

--- a/src/libmach.d
+++ b/src/libmach.d
@@ -41,7 +41,6 @@ alias MachObjSymbols = Array!(MachObjSymbol*);
 
 extern (C++) final class LibMach : Library
 {
-public:
     File* libfile;
     MachObjModules objmodules; // MachObjModule[]
     MachObjSymbols objsymbols; // MachObjSymbol[]

--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -53,7 +53,6 @@ alias MSCoffObjSymbols = Array!(MSCoffObjSymbol*);
 
 extern (C++) final class LibMSCoff : Library
 {
-public:
     File* libfile;
     MSCoffObjModules objmodules; // MSCoffObjModule[]
     MSCoffObjSymbols objsymbols; // MSCoffObjSymbol[]

--- a/src/libomf.d
+++ b/src/libomf.d
@@ -44,7 +44,6 @@ extern (C) uint _rotr(uint value, int shift);
 
 extern (C++) final class LibOMF : Library
 {
-public:
     File* libfile;
     OmfObjModules objmodules; // OmfObjModule[]
     OmfObjSymbols objsymbols; // OmfObjSymbol[]

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -478,7 +478,6 @@ alias MOD = ubyte;
  */
 extern (C++) abstract class Type : RootObject
 {
-public:
     TY ty;
     MOD mod; // modifiers MODxxxx
     char* deco;
@@ -3052,7 +3051,6 @@ public:
  */
 extern (C++) final class TypeError : Type
 {
-public:
     extern (D) this()
     {
         super(Terror);
@@ -3099,7 +3097,6 @@ public:
  */
 extern (C++) abstract class TypeNext : Type
 {
-public:
     Type next;
 
     final extern (D) this(TY ty, Type next)
@@ -3399,7 +3396,6 @@ public:
  */
 extern (C++) final class TypeBasic : Type
 {
-public:
     const(char)* dstring;
     uint flags;
 
@@ -4307,7 +4303,6 @@ public:
  */
 extern (C++) final class TypeVector : Type
 {
-public:
     Type basetype;
 
     extern (D) this(Loc loc, Type basetype)
@@ -4484,7 +4479,6 @@ public:
  */
 extern (C++) class TypeArray : TypeNext
 {
-public:
     final extern (D) this(TY ty, Type next)
     {
         super(ty, next);
@@ -4636,7 +4630,6 @@ public:
  */
 extern (C++) final class TypeSArray : TypeArray
 {
-public:
     Expression dim;
 
     extern (D) this(Type t, Expression dim)
@@ -5085,7 +5078,6 @@ public:
  */
 extern (C++) final class TypeDArray : TypeArray
 {
-public:
     extern (D) this(Type t)
     {
         super(Tarray, t);
@@ -5289,7 +5281,6 @@ public:
  */
 extern (C++) final class TypeAArray : TypeArray
 {
-public:
     Type index;     // key type
     Loc loc;
     Scope* sc;
@@ -5663,7 +5654,6 @@ public:
  */
 extern (C++) final class TypePointer : TypeNext
 {
-public:
     extern (D) this(Type t)
     {
         super(Tpointer, t);
@@ -5847,7 +5837,6 @@ public:
  */
 extern (C++) final class TypeReference : TypeNext
 {
-public:
     extern (D) this(Type t)
     {
         super(Treference, t);
@@ -5968,7 +5957,6 @@ alias PUREstrong = PURE.PUREstrong;
  */
 extern (C++) final class TypeFunction : TypeNext
 {
-public:
     // .next is the return type
 
     Parameters* parameters;     // function parameters
@@ -6964,7 +6952,6 @@ public:
  */
 extern (C++) final class TypeDelegate : TypeNext
 {
-public:
     // .next is a TypeFunction
 
     extern (D) this(Type t)
@@ -7121,7 +7108,6 @@ public:
  */
 extern (C++) abstract class TypeQualified : Type
 {
-public:
     Loc loc;
 
     // array of Identifier and TypeInstance,
@@ -7540,7 +7526,6 @@ public:
  */
 extern (C++) final class TypeIdentifier : TypeQualified
 {
-public:
     Identifier ident;
 
     // The symbol representing this identifier, before alias resolution
@@ -7677,7 +7662,6 @@ public:
  */
 extern (C++) final class TypeInstance : TypeQualified
 {
-public:
     TemplateInstance tempinst;
 
     extern (D) this(Loc loc, TemplateInstance tempinst)
@@ -7778,7 +7762,6 @@ public:
  */
 extern (C++) final class TypeTypeof : TypeQualified
 {
-public:
     Expression exp;
     int inuse;
 
@@ -7938,7 +7921,6 @@ public:
  */
 extern (C++) final class TypeReturn : TypeQualified
 {
-public:
     extern (D) this(Loc loc)
     {
         super(Treturn, loc);
@@ -8057,7 +8039,6 @@ alias RECtracingDT = AliasThisRec.RECtracingDT;
  */
 extern (C++) final class TypeStruct : Type
 {
-public:
     StructDeclaration sym;
     AliasThisRec att = RECfwdref;
 
@@ -8628,7 +8609,6 @@ public:
  */
 extern (C++) final class TypeEnum : Type
 {
-public:
     EnumDeclaration sym;
 
     extern (D) this(EnumDeclaration sym)
@@ -8880,7 +8860,6 @@ public:
  */
 extern (C++) final class TypeClass : Type
 {
-public:
     ClassDeclaration sym;
     AliasThisRec att = RECfwdref;
 
@@ -9520,7 +9499,6 @@ public:
  */
 extern (C++) final class TypeTuple : Type
 {
-public:
     Parameters* arguments;  // types making up the tuple
 
     extern (D) this(Parameters* arguments)
@@ -9699,7 +9677,6 @@ public:
  */
 extern (C++) final class TypeSlice : TypeNext
 {
-public:
     Expression lwr;
     Expression upr;
 
@@ -9844,7 +9821,6 @@ public:
  */
 extern (C++) final class TypeNull : Type
 {
-public:
     extern (D) this()
     {
         super(Tnull);
@@ -9906,7 +9882,6 @@ public:
  */
 extern (C++) final class Parameter : RootObject
 {
-public:
     StorageClass storageClass;
     Type type;
     Identifier ident;

--- a/src/nspace.d
+++ b/src/nspace.d
@@ -25,7 +25,6 @@ private enum LOG = false;
  */
 extern (C++) final class Nspace : ScopeDsymbol
 {
-public:
     extern (D) this(Loc loc, Identifier ident, Dsymbols* members)
     {
         super(ident);

--- a/src/parse.d
+++ b/src/parse.d
@@ -249,7 +249,6 @@ private StorageClass getStorageClass(PrefixAttributes* pAttrs)
  */
 final class Parser : Lexer
 {
-public:
     Module mod;
     ModuleDeclaration* md;
     LINK linkage;

--- a/src/root/array.d
+++ b/src/root/array.d
@@ -14,7 +14,6 @@ import ddmd.root.rmem;
 
 extern (C++) struct Array(T)
 {
-public:
     size_t dim;
     T* data;
 

--- a/src/statement.d
+++ b/src/statement.d
@@ -119,7 +119,6 @@ alias BEany = BE.BEany;
  */
 extern (C++) abstract class Statement : RootObject
 {
-public:
     Loc loc;
 
     final extern (D) this(Loc loc)
@@ -882,7 +881,6 @@ public:
  */
 extern (C++) final class ErrorStatement : Statement
 {
-public:
     extern (D) this()
     {
         super(Loc());
@@ -909,7 +907,6 @@ public:
  */
 extern (C++) final class PeelStatement : Statement
 {
-public:
     Statement s;
 
     extern (D) this(Statement s)
@@ -1075,7 +1072,6 @@ extern (C++) Statement toStatement(Dsymbol s)
  */
 extern (C++) class ExpStatement : Statement
 {
-public:
     Expression exp;
 
     final extern (D) this(Loc loc, Expression exp)
@@ -1178,7 +1174,6 @@ public:
  */
 extern (C++) final class DtorExpStatement : ExpStatement
 {
-public:
     // Wraps an expression that is the destruction of 'var'
     VarDeclaration var;
 
@@ -1208,7 +1203,6 @@ public:
  */
 extern (C++) final class CompileStatement : Statement
 {
-public:
     Expression exp;
 
     extern (D) this(Loc loc, Expression exp)
@@ -1266,7 +1260,6 @@ public:
  */
 extern (C++) class CompoundStatement : Statement
 {
-public:
     Statements* statements;
 
     final extern (D) this(Loc loc, Statements* s)
@@ -1358,7 +1351,6 @@ public:
  */
 extern (C++) final class CompoundDeclarationStatement : CompoundStatement
 {
-public:
     extern (D) this(Loc loc, Statements* s)
     {
         super(loc, s);
@@ -1388,7 +1380,6 @@ public:
  */
 extern (C++) final class UnrolledLoopStatement : Statement
 {
-public:
     Statements* statements;
 
     extern (D) this(Loc loc, Statements* s)
@@ -1428,7 +1419,6 @@ public:
  */
 extern (C++) final class ScopeStatement : Statement
 {
-public:
     Statement statement;
     Loc endloc;                 // location of closing curly bracket
 
@@ -1477,7 +1467,6 @@ public:
  */
 extern (C++) final class WhileStatement : Statement
 {
-public:
     Expression condition;
     Statement _body;
     Loc endloc;             // location of closing curly bracket
@@ -1518,7 +1507,6 @@ public:
  */
 extern (C++) final class DoStatement : Statement
 {
-public:
     Statement _body;
     Expression condition;
     Loc endloc;                 // location of ';' after while
@@ -1559,7 +1547,6 @@ public:
  */
 extern (C++) final class ForStatement : Statement
 {
-public:
     Statement _init;
     Expression condition;
     Expression increment;
@@ -1624,7 +1611,6 @@ public:
  */
 extern (C++) final class ForeachStatement : Statement
 {
-public:
     TOK op;                     // TOKforeach or TOKforeach_reverse
     Parameters* parameters;     // array of Parameter*'s
     Expression aggr;
@@ -1693,7 +1679,6 @@ public:
  */
 extern (C++) final class ForeachRangeStatement : Statement
 {
-public:
     TOK op;                 // TOKforeach or TOKforeach_reverse
     Parameter prm;          // loop index variable
     Expression lwr;
@@ -1739,7 +1724,6 @@ public:
  */
 extern (C++) final class IfStatement : Statement
 {
-public:
     Parameter prm;
     Expression condition;
     Statement ifbody;
@@ -1782,7 +1766,6 @@ public:
  */
 extern (C++) final class ConditionalStatement : Statement
 {
-public:
     Condition condition;
     Statement ifbody;
     Statement elsebody;
@@ -1831,7 +1814,6 @@ public:
  */
 extern (C++) final class PragmaStatement : Statement
 {
-public:
     Identifier ident;
     Expressions* args;      // array of Expression's
     Statement _body;
@@ -1859,7 +1841,6 @@ public:
  */
 extern (C++) final class StaticAssertStatement : Statement
 {
-public:
     StaticAssert sa;
 
     extern (D) this(StaticAssert sa)
@@ -1883,7 +1864,6 @@ public:
  */
 extern (C++) final class SwitchStatement : Statement
 {
-public:
     Expression condition;
     Statement _body;
     bool isFinal;
@@ -1923,7 +1903,6 @@ public:
  */
 extern (C++) final class CaseStatement : Statement
 {
-public:
     Expression exp;
     Statement statement;
     int index;              // which case it is (since we sort this)
@@ -1962,7 +1941,6 @@ public:
  */
 extern (C++) final class CaseRangeStatement : Statement
 {
-public:
     Expression first;
     Expression last;
     Statement statement;
@@ -1990,7 +1968,6 @@ public:
  */
 extern (C++) final class DefaultStatement : Statement
 {
-public:
     Statement statement;
 
     extern (D) this(Loc loc, Statement s)
@@ -2019,7 +1996,6 @@ public:
  */
 extern (C++) final class GotoDefaultStatement : Statement
 {
-public:
     SwitchStatement sw;
 
     extern (D) this(Loc loc)
@@ -2042,7 +2018,6 @@ public:
  */
 extern (C++) final class GotoCaseStatement : Statement
 {
-public:
     Expression exp;     // null, or which case to goto
     CaseStatement cs;   // case statement it resolves to
 
@@ -2067,7 +2042,6 @@ public:
  */
 extern (C++) final class SwitchErrorStatement : Statement
 {
-public:
     extern (D) this(Loc loc)
     {
         super(loc);
@@ -2083,7 +2057,6 @@ public:
  */
 extern (C++) final class ReturnStatement : Statement
 {
-public:
     Expression exp;
     size_t caseDim;
 
@@ -2113,7 +2086,6 @@ public:
  */
 extern (C++) final class BreakStatement : Statement
 {
-public:
     Identifier ident;
 
     extern (D) this(Loc loc, Identifier ident)
@@ -2137,7 +2109,6 @@ public:
  */
 extern (C++) final class ContinueStatement : Statement
 {
-public:
     Identifier ident;
 
     extern (D) this(Loc loc, Identifier ident)
@@ -2161,7 +2132,6 @@ public:
  */
 extern (C++) final class SynchronizedStatement : Statement
 {
-public:
     Expression exp;
     Statement _body;
 
@@ -2197,7 +2167,6 @@ public:
  */
 extern (C++) final class WithStatement : Statement
 {
-public:
     Expression exp;
     Statement _body;
     VarDeclaration wthis;
@@ -2226,7 +2195,6 @@ public:
  */
 extern (C++) final class TryCatchStatement : Statement
 {
-public:
     Statement _body;
     Catches* catches;
 
@@ -2263,7 +2231,6 @@ public:
  */
 extern (C++) final class Catch : RootObject
 {
-public:
     Loc loc;
     Type type;
     Identifier ident;
@@ -2296,7 +2263,6 @@ public:
  */
 extern (C++) final class TryFinallyStatement : Statement
 {
-public:
     Statement _body;
     Statement finalbody;
 
@@ -2337,7 +2303,6 @@ public:
  */
 extern (C++) final class OnScopeStatement : Statement
 {
-public:
     TOK tok;
     Statement statement;
 
@@ -2409,7 +2374,6 @@ public:
  */
 extern (C++) final class ThrowStatement : Statement
 {
-public:
     Expression exp;
 
     // was generated by the compiler, wasn't present in source code
@@ -2438,7 +2402,6 @@ public:
  */
 extern (C++) final class DebugStatement : Statement
 {
-public:
     Statement statement;
 
     extern (D) this(Loc loc, Statement statement)
@@ -2475,7 +2438,6 @@ public:
  */
 extern (C++) final class GotoStatement : Statement
 {
-public:
     Identifier ident;
     LabelDsymbol label;
     TryFinallyStatement tf;
@@ -2558,7 +2520,6 @@ public:
  */
 extern (C++) final class LabelStatement : Statement
 {
-public:
     Identifier ident;
     Statement statement;
     TryFinallyStatement tf;
@@ -2629,7 +2590,6 @@ public:
  */
 extern (C++) final class LabelDsymbol : Dsymbol
 {
-public:
     LabelStatement statement;
 
     extern (D) this(Identifier ident)
@@ -2658,7 +2618,6 @@ public:
  */
 extern (C++) final class AsmStatement : Statement
 {
-public:
     Token* tokens;
     code* asmcode;
     uint asmalign;  // alignment of this statement
@@ -2688,7 +2647,6 @@ public:
  */
 extern (C++) final class CompoundAsmStatement : CompoundStatement
 {
-public:
     StorageClass stc; // postfix attributes like nothrow/pure/@trusted
 
     extern (D) this(Loc loc, Statements* s, StorageClass stc)
@@ -2723,7 +2681,6 @@ public:
  */
 extern (C++) final class ImportStatement : Statement
 {
-public:
     Dsymbols* imports;      // Array of Import's
 
     extern (D) this(Loc loc, Dsymbols* imports)

--- a/src/staticassert.d
+++ b/src/staticassert.d
@@ -22,7 +22,6 @@ import ddmd.visitor;
  */
 extern (C++) final class StaticAssert : Dsymbol
 {
-public:
     Expression exp;
     Expression msg;
 

--- a/src/visitor.d
+++ b/src/visitor.d
@@ -32,7 +32,6 @@ import ddmd.staticassert;
 
 extern (C++) class Visitor
 {
-public:
     void visit(Statement)
     {
         assert(0);


### PR DESCRIPTION
These were added to the C++ code to make conversion possible, but they don't actually do anything in D.
