### PR TITLE
Add PS4 version identifier

### DIFF
--- a/src/cond.d
+++ b/src/cond.d
@@ -186,6 +186,8 @@ extern (C++) final class VersionCondition : DVCondition
             "SysV4",
             "Hurd",
             "Android",
+            "PlayStation",
+            "PlayStation4",
             "Cygwin",
             "MinGW",
             "FreeStanding",


### PR DESCRIPTION
I have started a fork of LDC intended to attempt to add compatibility for the PS4 similar to what exists in the main branch of Clang.
This would require a version identifier, the alternatives I propose is either PS4 or ORBIS.

Orbis OS is the official name of the operating system on the PS4 and Sony refers to the whole platform as ORBIS.

I personally believe that PS4 is a better choice seeing as it's more descriptive and a bit less obscure than ORBIS.
