### PR TITLE
Test pre-definition of D_Coverage with -cov

### DIFF
--- a/test/compilable/testcov1.d
+++ b/test/compilable/testcov1.d
@@ -5,3 +5,11 @@
 import core.stdc.string;
 import testcov1a;
 
+version(D_Coverage)
+{
+    // Good
+}
+else
+{
+    static assert(0, "Missing 'D_Coverage' version identifier");
+}


### PR DESCRIPTION
As per https://dlang.org/spec/version.html#predefined-versions
