### PR TITLE
Add D_Warnings version identifier

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -1910,5 +1910,7 @@ private void addDefaultVersionIdentifiers()
         VersionCondition.addPredefinedGlobalIdent("assert");
     if (global.params.useArrayBounds == BOUNDSCHECKoff)
         VersionCondition.addPredefinedGlobalIdent("D_NoBoundsChecks");
+    if (global.params.warnings)
+        VersionCondition.addPredefinedGlobalIdent("D_Warnings");
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
 }

--- a/test/compilable/warning_version.d
+++ b/test/compilable/warning_version.d
@@ -1,0 +1,10 @@
+// PERMUTE_ARGS: -w -wi
+
+version(D_Warnings)
+{
+    // Good
+}
+else
+{
+    static assert (0, "Missing 'D_Warnings' version identifier");
+}


### PR DESCRIPTION
As per https://dlang.org/spec/version.html#predefined-versions

In case the information at https://dlang.org/spec/version.html#predefined-versions is outdated, then we should remove D_Warnings from the list there and disregard this PR.
