### PR TITLE
Fix issue 16096 - compiling Objective-C code with -lib is broken

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -58,6 +58,7 @@ type *Type_toCtype(Type *t);
 void toObjFile(Dsymbol *ds, bool multiobj);
 void genModuleInfo(Module *m);
 void genObjFile(Module *m, bool multiobj);
+void objc_Module_genmoduleinfo_classes();
 Symbol *toModuleAssert(Module *m);
 Symbol *toModuleUnittest(Module *m);
 Symbol *toModuleArray(Module *m);
@@ -479,6 +480,7 @@ void genObjFile(Module *m, bool multiobj)
 
     if (m->doppelganger)
     {
+        objc_Module_genmoduleinfo_classes();
         objmod->termfile();
         return;
     }

--- a/src/objc_glue.c
+++ b/src/objc_glue.c
@@ -182,7 +182,9 @@ Symbol *objc_getMsgSend(Type *ret, bool hasHiddenArg)
 
 Symbol *objc_getImageInfo()
 {
-    assert(!objc_simageInfo); // only allow once per object file
+    if (objc_simageInfo)
+        return objc_simageInfo;
+
     objc_hasSymbols = true;
 
     DtBuilder dtb;

--- a/test/runnable/extra-files/test16096.d
+++ b/test/runnable/extra-files/test16096.d
@@ -1,0 +1,6 @@
+import test16096a;
+
+void main()
+{
+    test();
+}

--- a/test/runnable/extra-files/test16096a.d
+++ b/test/runnable/extra-files/test16096a.d
@@ -1,0 +1,23 @@
+module test16096a;
+
+extern (Objective-C)
+interface Class
+{
+    NSObject alloc() @selector("alloc");
+}
+
+extern (Objective-C)
+interface NSObject
+{
+    NSObject initWithUTF8String(in char* str) @selector("initWithUTF8String:");
+    void release() @selector("release");
+}
+
+extern (C) Class objc_lookUpClass(in char* name);
+
+void test()
+{
+    auto c = objc_lookUpClass("NSString");
+    auto o = c.alloc().initWithUTF8String("hello");
+    o.release();
+}

--- a/test/runnable/test16096.sh
+++ b/test/runnable/test16096.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ "$OS" != 'osx' ] || [ "$MODEL" != '64' ]; then
+    echo Success >${output_file}
+    exit 0
+fi
+
+set -e
+
+src=runnable/extra-files
+dir=${RESULTS_DIR}/runnable
+output_file=${dir}/test16096.sh.out
+
+$DMD -I${src} -of${dir}${SEP}test16096a.a -lib ${src}/test16096a.d
+$DMD -I${src} -of${dir}${SEP}test16096 ${src}/test16096.d ${dir}/test16096a.a -L-framework -LFoundation
+${RESULTS_DIR}/runnable/test16096
+
+rm ${dir}/{test16096a.a,test16096}
+
+echo Success >${output_file}


### PR DESCRIPTION
When compiling Objective-C code as a library with DMD using the -lib
switch. Then creating an executable using the library the linker
outputs the following warning:

Linking to static library: can't parse __DATA/__objc_imageinfo

The resulting executable is broken due to no image info or selectors
had been outputted in the binary.
