### PR TITLE
fix Issue 11047 - UDA + getAttributes bypass purity/safety check

### DIFF
--- a/test/fail_compilation/test11047.d
+++ b/test/fail_compilation/test11047.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test11047.d(11): Error: value of x is not known at compile time
+fail_compilation/test11047.d(11): Error: value of x is not known at compile time
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=11047
+
+int x;
+@(++x, ++x) void foo(){}
+
+@safe pure void test()
+{
+    __traits(getAttributes, foo);
+    __traits(getAttributes, foo)[0];
+}
+
+


### PR DESCRIPTION
UDAs are supposed to be compile time expressions, so ensure that.
