### PR TITLE
fix Issue 14532 - switch block allows creating uninitialized variables

### DIFF
--- a/src/statement.h
+++ b/src/statement.h
@@ -379,9 +379,11 @@ public:
     CaseStatements *cases;         // array of CaseStatement's
     int hasNoDefault;           // !=0 if no default statement
     int hasVars;                // !=0 if has variable case values
+    VarDeclaration *lastVar;
 
     Statement *syntaxCopy();
     bool hasBreak();
+    bool checkLabel();
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -393,6 +395,7 @@ public:
     Statement *statement;
 
     int index;          // which case it is (since we sort this)
+    VarDeclaration *lastVar;
 
     Statement *syntaxCopy();
     int compare(RootObject *obj);
@@ -418,6 +421,7 @@ class DefaultStatement : public Statement
 {
 public:
     Statement *statement;
+    VarDeclaration *lastVar;
 
     Statement *syntaxCopy();
     DefaultStatement *isDefaultStatement() { return this; }

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -2001,6 +2001,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
         bool needswitcherror = false;
 
+        ss.lastVar = sc.lastVar;
+
         sc = sc.push();
         sc.sbreak = ss;
         sc.sw = ss;
@@ -2098,6 +2100,9 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             cs = new CompoundStatement(ss.loc, a);
             ss._body = cs;
         }
+
+        if (ss.checkLabel())
+            goto Lerror;
 
         sc.pop();
         result = ss;
@@ -2204,6 +2209,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         if (errors || cs.exp.op == TOKerror)
             return setError();
 
+        cs.lastVar = sc.lastVar;
         result = cs;
     }
 
@@ -2323,6 +2329,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         if (errors || ds.statement.isErrorStatement())
             return setError();
 
+        ds.lastVar = sc.lastVar;
         result = ds;
     }
 

--- a/test/fail_compilation/skip.d
+++ b/test/fail_compilation/skip.d
@@ -1,0 +1,53 @@
+/*
+ * TEST_OUTPUT:
+---
+fail_compilation/skip.d(20): Error: 'switch' skips declaration of 'with' temporary at fail_compilation/skip.d(25)
+fail_compilation/skip.d(42): Error: 'switch' skips declaration of variable skip.test14532.n at fail_compilation/skip.d(44)
+---
+ */
+// https://issues.dlang.org/show_bug.cgi?id=10524
+
+struct S
+{
+    int field;
+}
+
+void test10524()
+{
+    int a = 1;
+    S struct_with_long_name;
+
+    switch( a )
+    {
+        case 0:
+            struct_with_long_name.field = 444; // ok
+            break;
+        with( struct_with_long_name )
+        {
+            case 1:
+                field = 555; // segfault
+                break;
+        }
+
+        default:
+            break;
+    }
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=14532
+
+void test14532()
+{
+    char ch = '!';
+    switch (ch)
+    {
+            int n = 42;
+        case '!':
+            assert(n == 42);
+            break;
+
+      default:
+    }
+}
+
+

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1294,9 +1294,9 @@ void test51()
   A51_a = 0; { if (0) while(1) A51 a;               } assert(A51_a == 0);
   A51_a = 0; { try A51 a; catch(Error e) {}         } assert(A51_a == 1);
   A51_a = 0; { if (0) final switch(1) A51 a;        } assert(A51_a == 0); // should fail to build
-  A51_a = 0; { if (0) switch(1) { A51 a; default: } } assert(A51_a == 0);
+//  A51_a = 0; { if (0) switch(1) { A51 a; default: } } assert(A51_a == 0);
   A51_a = 0; { if (0) switch(1) { default: A51 a; } } assert(A51_a == 0);
-  A51_a = 0; { if (1) switch(1) { A51 a; default: } } assert(A51_a == 1); // should be 0, right?
+//  A51_a = 0; { if (1) switch(1) { A51 a; default: } } assert(A51_a == 1); // should be 0, right?
   A51_a = 0; { if (1) switch(1) { default: A51 a; } } assert(A51_a == 1);
 //  A51_a = 0; { final switch(0) A51 a;               } assert(A51_a == 0);
   A51_a = 0; { A51 a; with(a) A51 b;                } assert(A51_a == 2);


### PR DESCRIPTION
Also fix https://issues.dlang.org/show_bug.cgi?id=10524

It turns out that a switch statement is semantically just like the goto statement in regards to checking for skipped initializations, so we can reuse the same logic.
