### PR TITLE
Add new extern(C++, class) and extern(C++, struct) declarations.

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -93,6 +93,17 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+class CPPMangleDeclaration : public AttribDeclaration
+{
+public:
+    CPPMANGLE cppmangle;
+
+    Dsymbol *syntaxCopy(Dsymbol *s);
+    Scope *newScope(Scope *sc);
+    const char *toChars() const;
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class ProtDeclaration : public AttribDeclaration
 {
 public:

--- a/src/cppmangle.d
+++ b/src/cppmangle.d
@@ -1283,7 +1283,7 @@ else static if (TARGET_WINDOS)
                 if (type.sym.isUnionDeclaration())
                     buf.writeByte('T');
                 else
-                    buf.writeByte('U');
+                    buf.writeByte(type.cppmangle == CPPMANGLE.asClass ? 'V' : 'U');
                 mangleIdent(type.sym);
             }
             flags &= ~IS_NOT_TOP_TYPE;
@@ -1350,7 +1350,7 @@ else static if (TARGET_WINDOS)
                 buf.writeByte('E');
             flags |= IS_NOT_TOP_TYPE;
             mangleModifier(type);
-            buf.writeByte('V');
+            buf.writeByte(type.cppmangle == CPPMANGLE.asStruct ? 'U' : 'V');
             mangleIdent(type.sym);
             flags &= ~IS_NOT_TOP_TYPE;
             flags &= ~IGNORE_CONST;
@@ -1665,7 +1665,12 @@ else static if (TARGET_WINDOS)
                 name = sym.ident.toChars();
             }
             assert(name);
-            if (!is_dmc_template)
+            if (is_dmc_template)
+            {
+                if (checkAndSaveIdent(name))
+                    return;
+            }
+            else
             {
                 if (dont_use_back_reference)
                 {

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -148,6 +148,9 @@ struct Scope
     // linkage for external functions
     LINK linkage = LINKd;
 
+    // mangle type
+    CPPMANGLE cppmangle = CPPMANGLE.def;
+
     // inlining strategy for functions
     PINLINE inlining = PINLINEdefault;
 
@@ -726,6 +729,7 @@ struct Scope
         this.func = sc.func;
         this.slabel = sc.slabel;
         this.linkage = sc.linkage;
+        this.cppmangle = sc.cppmangle;
         this.inlining = sc.inlining;
         this.protection = sc.protection;
         this.explicitProtection = sc.explicitProtection;

--- a/src/globals.d
+++ b/src/globals.d
@@ -396,6 +396,13 @@ alias LINKwindows = LINK.windows;
 alias LINKpascal = LINK.pascal;
 alias LINKobjc = LINK.objc;
 
+enum CPPMANGLE : int
+{
+    def,
+    asStruct,
+    asClass,
+}
+
 enum DYNCAST : int
 {
     object,

--- a/src/globals.h
+++ b/src/globals.h
@@ -285,6 +285,13 @@ enum LINK
     LINKobjc,
 };
 
+enum CPPMANGLE
+{
+    def,
+    asStruct,
+    asClass,
+};
+
 enum DYNCAST
 {
     DYNCAST_OBJECT,

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -1192,6 +1192,26 @@ public:
         visit(cast(AttribDeclaration)d);
     }
 
+    override void visit(CPPMangleDeclaration d)
+    {
+        const(char)* p;
+        switch (d.cppmangle)
+        {
+        case CPPMANGLE.asClass:
+            p = "class";
+            break;
+        case CPPMANGLE.asStruct:
+            p = "struct";
+            break;
+        default:
+            assert(0);
+        }
+        buf.writestring("extern (C++, ");
+        buf.writestring(p);
+        buf.writestring(") ");
+        visit(cast(AttribDeclaration)d);
+    }
+
     override void visit(ProtDeclaration d)
     {
         protectionToBuffer(buf, d.protection);

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -8056,6 +8056,7 @@ extern (C++) final class TypeStruct : Type
 {
     StructDeclaration sym;
     AliasThisRec att = RECfwdref;
+    CPPMANGLE cppmangle = CPPMANGLE.def;
 
     extern (D) this(StructDeclaration sym)
     {
@@ -8086,7 +8087,9 @@ extern (C++) final class TypeStruct : Type
 
     override Type semantic(Loc loc, Scope* sc)
     {
-        //printf("TypeStruct::semantic('%s')\n", sym->toChars());
+        //printf("TypeStruct::semantic('%s')\n", sym.toChars());
+        if (deco)
+            return this;
 
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.
@@ -8096,6 +8099,7 @@ extern (C++) final class TypeStruct : Type
 
         if (sym.type.ty == Terror)
             return Type.terror;
+        this.cppmangle = sc.cppmangle;
         return merge();
     }
 
@@ -8897,6 +8901,7 @@ extern (C++) final class TypeClass : Type
 {
     ClassDeclaration sym;
     AliasThisRec att = RECfwdref;
+    CPPMANGLE cppmangle = CPPMANGLE.def;
 
     extern (D) this(ClassDeclaration sym)
     {
@@ -8921,7 +8926,9 @@ extern (C++) final class TypeClass : Type
 
     override Type semantic(Loc loc, Scope* sc)
     {
-        //printf("TypeClass::semantic(%s)\n", sym->toChars());
+        //printf("TypeClass::semantic(%s)\n", sym.toChars());
+        if (deco)
+            return this;
 
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.
@@ -8931,6 +8938,7 @@ extern (C++) final class TypeClass : Type
 
         if (sym.type.ty == Terror)
             return Type.terror;
+        this.cppmangle = sc.cppmangle;
         return merge();
     }
 

--- a/src/parse.d
+++ b/src/parse.d
@@ -252,6 +252,7 @@ final class Parser : Lexer
     Module mod;
     ModuleDeclaration* md;
     LINK linkage;
+    CPPMANGLE cppmangle;
     Loc endloc; // set to location of last right curly
     int inBrackets; // inside [] of array index or slice
     Loc lookingForElse; // location of lonely if looking for an else
@@ -876,7 +877,8 @@ final class Parser : Lexer
 
                     const linkLoc = token.loc;
                     Identifiers* idents = null;
-                    const link = parseLinkage(&idents);
+                    CPPMANGLE cppmangle;
+                    const link = parseLinkage(&idents, cppmangle);
                     if (pAttrs.link != LINKdefault)
                     {
                         if (pAttrs.link != link)
@@ -911,6 +913,11 @@ final class Parser : Lexer
                             s = new Nspace(linkLoc, id, a);
                         }
                         pAttrs.link = LINKdefault;
+                    }
+                    else if (cppmangle != CPPMANGLE.def)
+                    {
+                        assert(link == LINKcpp);
+                        s = new CPPMangleDeclaration(cppmangle, a);
                     }
                     else if (pAttrs.link != LINKdefault)
                     {
@@ -2151,9 +2158,10 @@ final class Parser : Lexer
      *      extern (C++, namespaces)
      * The parser is on the 'extern' token.
      */
-    LINK parseLinkage(Identifiers** pidents)
+    LINK parseLinkage(Identifiers** pidents, out CPPMANGLE cppmangle)
     {
         Identifiers* idents = null;
+        cppmangle = CPPMANGLE.def;
         LINK link = LINKdefault;
         nextToken();
         assert(token.value == TOKlparen);
@@ -2175,26 +2183,34 @@ final class Parser : Lexer
                 {
                     link = LINKcpp;
                     nextToken();
-                    if (token.value == TOKcomma) // , namespaces
+                    if (token.value == TOKcomma) // , namespaces or class or struct
                     {
-                        idents = new Identifiers();
                         nextToken();
-                        while (1)
+                        if (token.value == TOKclass || token.value == TOKstruct)
                         {
-                            if (token.value == TOKidentifier)
+                            cppmangle = token.value == TOKclass ? CPPMANGLE.asClass : CPPMANGLE.asStruct;
+                            nextToken();
+                        }
+                        else
+                        {
+                            idents = new Identifiers();
+                            while (1)
                             {
-                                Identifier idn = token.ident;
-                                idents.push(idn);
-                                nextToken();
-                                if (token.value == TOKdot)
+                                if (token.value == TOKidentifier)
                                 {
+                                    Identifier idn = token.ident;
+                                    idents.push(idn);
                                     nextToken();
-                                    continue;
+                                    if (token.value == TOKdot)
+                                    {
+                                        nextToken();
+                                        continue;
+                                    }
                                 }
+                                else
+                                    error("identifier expected for C++ namespace");
+                                break;
                             }
-                            else
-                                error("identifier expected for C++ namespace");
-                            break;
                         }
                     }
                 }
@@ -4054,10 +4070,15 @@ final class Parser : Lexer
                         error("redundant linkage declaration");
                     sawLinkage = true;
                     Identifiers* idents = null;
-                    link = parseLinkage(&idents);
+                    CPPMANGLE cppmangle;
+                    link = parseLinkage(&idents, cppmangle);
                     if (idents)
                     {
                         error("C++ name spaces not allowed here");
+                    }
+                    if (cppmangle != CPPMANGLE.def)
+                    {
+                        error("C++ mangle declaration not allowed here");
                     }
                     continue;
                 }

--- a/src/visitor.d
+++ b/src/visitor.d
@@ -422,6 +422,11 @@ extern (C++) class Visitor
         visit(cast(AttribDeclaration)s);
     }
 
+    void visit(CPPMangleDeclaration s)
+    {
+        visit(cast(AttribDeclaration)s);
+    }
+
     void visit(ProtDeclaration s)
     {
         visit(cast(AttribDeclaration)s);

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -95,6 +95,7 @@ class AttribDeclaration;
 class StorageClassDeclaration;
 class DeprecatedDeclaration;
 class LinkDeclaration;
+class CPPMangleDeclaration;
 class ProtDeclaration;
 class AlignDeclaration;
 class AnonDeclaration;
@@ -380,6 +381,7 @@ public:
     virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(DeprecatedDeclaration *s) { visit((StorageClassDeclaration *)s); }
     virtual void visit(LinkDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AnonDeclaration *s) { visit((AttribDeclaration *)s); }

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -169,6 +169,62 @@ interface Test38
      public static void dispose(ref Test38);
 }
 
+extern(C++, class)
+struct S1
+{
+    private int val;
+    static S1* init(int);
+    int value();
+}
+
+extern(C++, class)
+struct S2(T)
+{
+    private T val;
+    static S2!T* init(int);
+    T value();
+}
+
+extern(C++, struct)
+class C1
+{
+    const(char)* data;
+
+    static C1 init(const(char)* p);
+    const(char)* getDataCPP();
+    extern(C++) const(char)* getDataD()
+    {
+        return data;
+    }
+}
+
+extern(C++, struct)
+class C2(T)
+{
+    const(T)* data;
+
+    static C2!T init(const(T)* p);
+    const(T)* getData();
+}
+
+extern(C++) int test39cpp(C2!char, S2!(int)*);
+
+void test39()
+{
+    S1* s1 = S1.init(42);
+    assert(s1.value == 42);
+    assert(S2!int.init(43).value == 43);
+    const(char)* ptr = "test".ptr;
+    C1 c1 = C1.init(ptr);
+    assert(c1.getDataCPP() == ptr);
+    assert(c1.getDataD() == ptr);
+    C2!char c2 = C2!char.init(ptr);
+    assert(c2.getData() == ptr);
+    auto result = test39cpp(c2, S2!int.init(43));
+    assert(result == 0);
+}
+
+
 void main()
 {
     test1(Foo!int());
@@ -254,4 +310,5 @@ void main()
     auto t38 = Test38.create();
     assert(t38.test(1, 2, 3) == 1);
     Test38.dispose(t38);
+    test39();
 }

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -304,3 +304,101 @@ void Test38::dispose(Test38 *&t)
         delete t;
     t = 0;
 }
+
+class S1
+{
+    int val;
+public:
+    static S1* init(int);
+    S1(int v) : val(v) {}
+    int value();
+};
+
+S1* S1::init(int x)
+{
+    return new S1(x);
+}
+
+int S1::value()
+{
+    return val;
+}
+
+template<class T>
+class S2
+{
+    T val;
+public:
+    static S2<T>* init(T);
+    S2(T v) : val(v) {}
+    T value();
+};
+
+template<>
+S2<int>* S2<int>::init(int x)
+{
+    return new S2<int>(x);
+}
+
+template<>
+int S2<int>::value()
+{
+    return val;
+}
+
+struct C1
+{
+    const char *data;
+
+    static C1* init(const char *p);
+
+    C1(const char* p) : data(p) { }
+
+    virtual const char* getDataCPP();
+    virtual const char* getDataD();
+};
+
+C1* C1::init(const char *p)
+{
+    return new C1(p);
+}
+
+const char* C1::getDataCPP()
+{
+    return data;
+}
+
+template<class T>
+struct C2
+{
+    const T *data;
+
+    static C2* init(const T *p);
+
+    C2(const T* p) : data(p) { }
+
+    virtual const T* getData();
+};
+
+template<>
+C2<char>* C2<char>::init(const char *p)
+{
+    return new C2<char>(p);
+}
+
+template<>
+const char* C2<char>::getData()
+{
+    return data;
+}
+
+int test39cpp(C2<char>* c2, S2<int>* s2)
+{
+    C2<char>* otherC2 = C2<char>::init(c2->getData());
+    if (c2->getData() != otherC2->getData())
+        return 1;
+    S2<int>* otherS2 = S2<int>::init(s2->value());
+    if (s2->value() != otherS2->value())
+        return 2;
+    return 0;
+}


### PR DESCRIPTION
VS has different name manglings for classes and structs. With the
new extern(C++, class) and extern(C++, struct) declarations, the
name mangling algorithm is changed to use a mangling different
from the used D entity.

A common use case is to map a value type modeled as class in C++ to
a struct in D.
