### PR TITLE
fix Issue 14162 - Erratic inference of @safe for lambdas

### DIFF
--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -375,9 +375,9 @@ void test9148a() pure
         x++;
     }
     foo1();
-    static assert(is(typeof(&foo1) == void delegate() pure));
+    static assert(is(typeof(&foo1) == void delegate() pure nothrow @nogc @safe));
     foo2();
-    static assert(is(typeof(&foo2) == void delegate() pure));
+    static assert(is(typeof(&foo2) == void delegate() pure nothrow @nogc @safe));
 
     void bar1() immutable /+pure+/
     {
@@ -390,9 +390,9 @@ void test9148a() pure
         static assert(!__traits(compiles, x++));
     }
     bar1();
-    static assert(is(typeof(&bar1) == void delegate() pure immutable));
+    static assert(is(typeof(&bar1) == void delegate() pure immutable nothrow @nogc @safe));
     bar2();
-    static assert(is(typeof(&bar2) == void delegate() pure immutable));
+    static assert(is(typeof(&bar2) == void delegate() pure immutable nothrow @nogc @safe));
 
     struct S
     {
@@ -437,7 +437,7 @@ void test9148a() pure
 void test9148b() pure nothrow @nogc @safe
 {
     void nf() {}
-    static assert(is(typeof(&nf) == void delegate() @safe pure));
+    static assert(is(typeof(&nf) == void delegate() pure nothrow @nogc @safe));
 
     struct NS
     {
@@ -445,11 +445,11 @@ void test9148b() pure nothrow @nogc @safe
         static void sf() {}
     }
     NS ns;
-    static assert(is(typeof(&ns.mf) == void delegate() @safe pure));
-    static assert(is(typeof(&NS.sf) == void function() @safe));
+    static assert(is(typeof(&ns.mf) == void delegate() pure nothrow @nogc @safe));
+    static assert(is(typeof(&NS.sf) == void function() pure nothrow @nogc @safe));
 
     static void sf() {}
-    static assert(is(typeof(&sf) == void function() @safe));
+    static assert(is(typeof(&sf) == void function() pure nothrow @nogc @safe));
 
     static struct SS
     {
@@ -457,8 +457,8 @@ void test9148b() pure nothrow @nogc @safe
         static void sf() {}
     }
     SS ss;
-    static assert(is(typeof(&ss.mf) == void delegate() @safe));
-    static assert(is(typeof(&SS.sf) == void function() @safe));
+    static assert(is(typeof(&ss.mf) == void delegate() pure nothrow @nogc @safe));
+    static assert(is(typeof(&SS.sf) == void function() pure nothrow @nogc @safe));
 }
 
 void impureSystem9148b() {}

--- a/test/runnable/functype.d
+++ b/test/runnable/functype.d
@@ -6,43 +6,43 @@ void testfp()
 {
     static int func1(int n = 1) { return n; }
     static int func2(int n    ) { return n; }
-    static assert(typeof(func1).stringof == "int(int n = 1)");
-    static assert(typeof(func2).stringof == "int(int n)");
+    static assert(typeof(func1).stringof == "pure nothrow @nogc @safe int(int n = 1)");
+    static assert(typeof(func2).stringof == "pure nothrow @nogc @safe int(int n)");
     static assert( is(typeof(func1())));     // OK
     static assert(!is(typeof(func2())));     // NG
 
     alias typeof(func1) Func1;
     alias typeof(func2) Func2;
     static assert(is(Func1 == Func2));
-    static assert(Func1.stringof == "int(int n = 1)");
-    static assert(Func2.stringof == "int(int n)");
+    static assert(Func1.stringof == "pure nothrow @nogc @safe int(int n = 1)");
+    static assert(Func2.stringof == "pure nothrow @nogc @safe int(int n)");
 
     auto fp1 = &func1;
     auto fp2 = &func2;
-    static assert(typeof(fp1).stringof == "int function(int n = 1)");
-    static assert(typeof(fp2).stringof == "int function(int n)");
+    static assert(typeof(fp1).stringof == "int function(int n = 1) pure nothrow @nogc @safe");
+    static assert(typeof(fp2).stringof == "int function(int n) pure nothrow @nogc @safe");
     static assert( is(typeof(fp1())));     // OK
     static assert(!is(typeof(fp2())));     // NG
 
     alias typeof(fp1) Fp1;
     alias typeof(fp2) Fp2;
     static assert(is(Fp1 == Fp2));
-    static assert(Fp1.stringof == "int function(int n = 1)");
-    static assert(Fp2.stringof == "int function(int n)");
+    static assert(Fp1.stringof == "int function(int n = 1) pure nothrow @nogc @safe");
+    static assert(Fp2.stringof == "int function(int n) pure nothrow @nogc @safe");
 
     typeof(fp1) fp3 = fp1;
     typeof(fp2) fp4 = fp2;
     static assert(is(typeof(fp3) == typeof(fp4)));
-    static assert(typeof(fp3).stringof == "int function(int n = 1)");
-    static assert(typeof(fp4).stringof == "int function(int n)");
+    static assert(typeof(fp3).stringof == "int function(int n = 1) pure nothrow @nogc @safe");
+    static assert(typeof(fp4).stringof == "int function(int n) pure nothrow @nogc @safe");
     static assert( is(typeof(fp3())));     // OK
     static assert(!is(typeof(fp4())));     // NG
 
     alias typeof(fp3) Fp3;
     alias typeof(fp4) Fp4;
     static assert(is(Fp3 == Fp4));
-    static assert(Fp3.stringof == "int function(int n = 1)");
-    static assert(Fp4.stringof == "int function(int n)");
+    static assert(Fp3.stringof == "int function(int n = 1) pure nothrow @nogc @safe");
+    static assert(Fp4.stringof == "int function(int n) pure nothrow @nogc @safe");
 
     auto fplit1 = function(int n = 1) { return n; };
     auto fplit2 = function(int n    ) { return n; };
@@ -54,42 +54,42 @@ void testdg()
 {
     int nest1(int n = 1) { return n; }
     int nest2(int n    ) { return n; }
-    static assert(typeof(nest1).stringof == "int(int n = 1)");
-    static assert(typeof(nest2).stringof == "int(int n)");
+    static assert(typeof(nest1).stringof == "pure nothrow @nogc @safe int(int n = 1)");
+    static assert(typeof(nest2).stringof == "pure nothrow @nogc @safe int(int n)");
     static assert( is(typeof(nest1())));     // OK
     static assert(!is(typeof(nest2())));     // NG
 
     alias typeof(nest1) Nest1;
     alias typeof(nest2) Nest2;
     static assert(is(Nest1 == Nest2));
-    static assert(Nest1.stringof == "int(int n = 1)");
-    static assert(Nest2.stringof == "int(int n)");
+    static assert(Nest1.stringof == "pure nothrow @nogc @safe int(int n = 1)");
+    static assert(Nest2.stringof == "pure nothrow @nogc @safe int(int n)");
 
     auto dg1 = &nest1;
     auto dg2 = &nest2;
-    static assert(typeof(dg1).stringof == "int delegate(int n = 1)");
-    static assert(typeof(dg2).stringof == "int delegate(int n)");
+    static assert(typeof(dg1).stringof == "int delegate(int n = 1) pure nothrow @nogc @safe");
+    static assert(typeof(dg2).stringof == "int delegate(int n) pure nothrow @nogc @safe");
     static assert( is(typeof(dg1())));     // OK
     static assert(!is(typeof(dg2())));     // NG
 
     alias typeof(dg1) Dg1;
     alias typeof(dg2) Dg2;
     static assert(is(Dg1 == Dg2));
-    static assert(Dg1.stringof == "int delegate(int n = 1)");
-    static assert(Dg2.stringof == "int delegate(int n)");
+    static assert(Dg1.stringof == "int delegate(int n = 1) pure nothrow @nogc @safe");
+    static assert(Dg2.stringof == "int delegate(int n) pure nothrow @nogc @safe");
 
     typeof(dg1) dg3 = dg1;
     typeof(dg2) dg4 = dg2;
-    static assert(typeof(dg3).stringof == "int delegate(int n = 1)");
-    static assert(typeof(dg4).stringof == "int delegate(int n)");
+    static assert(typeof(dg3).stringof == "int delegate(int n = 1) pure nothrow @nogc @safe");
+    static assert(typeof(dg4).stringof == "int delegate(int n) pure nothrow @nogc @safe");
     static assert( is(typeof(dg3())));     // OK
     static assert(!is(typeof(dg4())));     // NG
 
     alias typeof(dg3) Dg3;
     alias typeof(dg4) Dg4;
     static assert(is(Dg3 == Dg4));
-    static assert(Dg3.stringof == "int delegate(int n = 1)");
-    static assert(Dg4.stringof == "int delegate(int n)");
+    static assert(Dg3.stringof == "int delegate(int n = 1) pure nothrow @nogc @safe");
+    static assert(Dg4.stringof == "int delegate(int n) pure nothrow @nogc @safe");
 
     auto dglit1 = delegate(int n = 1) { return n; };
     auto dglit2 = delegate(int n    ) { return n; };
@@ -127,8 +127,8 @@ template StringOf(T)
 void testti()
 {
     int[] test(int[] a = []) { return a; }
-    static assert(typeof(test).stringof == "int[](int[] a = [])");
-    static assert(StringOf!(typeof(test)) == "int[](int[])");
+    static assert(typeof(test).stringof == "pure nothrow @nogc @safe int[](int[] a = [])");
+    static assert(StringOf!(typeof(test)) == "pure nothrow @nogc @safe int[](int[])");
 
     float function(float x = 0F) fp = x => x;
     static assert(typeof(fp).stringof == "float function(float x = " ~ (0F).stringof ~ ")");
@@ -240,8 +240,8 @@ void test8579()
     auto fn2 = &func2;
     static assert(is(typeof(fn1) == typeof(fn2)));
            assert(   typeid(fn1) is typeid(fn2) );
-    static assert(typeof(fn1).stringof == "void function(int i, double j = " ~ (1.0).stringof ~ ")");
-    static assert(typeof(fn2).stringof == "void function(int x, double y)");
+    static assert(typeof(fn1).stringof == "void function(int i, double j = " ~ (1.0).stringof ~ ") pure nothrow @nogc @safe");
+    static assert(typeof(fn2).stringof == "void function(int x, double y) pure nothrow @nogc @safe");
 
     static int func3(int x, double y) { return 0; }
     static int func4(int i, double j = 1.0) { return 0; }
@@ -249,8 +249,8 @@ void test8579()
     auto fn4 = &func4;
     static assert(is(typeof(fn3) == typeof(fn4)));
            assert(   typeid(fn3) is typeid(fn4) );
-    static assert(typeof(fn3).stringof == "int function(int x, double y)");
-    static assert(typeof(fn4).stringof == "int function(int i, double j = " ~ (1.0).stringof ~ ")");
+    static assert(typeof(fn3).stringof == "int function(int x, double y) pure nothrow @nogc @safe");
+    static assert(typeof(fn4).stringof == "int function(int i, double j = " ~ (1.0).stringof ~ ") pure nothrow @nogc @safe");
 }
 
 /***************************************************/

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -84,7 +84,7 @@ static assert(TFoo2774!int.mangleof == "6mangle15__T8TFoo2774TiZ");
 void test2774()
 {
     int foo2774(int n) { return 0; }
-    static assert(foo2774.mangleof == "_D6mangle8test2774FZ7foo2774MFiZi");
+    static assert(foo2774.mangleof == "_D6mangle8test2774FZ7foo2774MFNaNbNiNfiZi");
 }
 
 /*******************************************/
@@ -462,7 +462,7 @@ void test12217(int)
     template X(T) {}
 
     static assert(    S.mangleof ==  "S6mangle9test12217FiZ1S");
-    static assert(  bar.mangleof == "_D6mangle9test12217FiZ3barMFZv");
+    static assert(  bar.mangleof == "_D6mangle9test12217FiZ3barMFNaNbNiNfZv");
     static assert(  var.mangleof == "_D6mangle9test12217FiZ3vari");
     static assert(X!int.mangleof ==   "6mangle9test12217FiZ8__T1XTiZ");
 }

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -1386,8 +1386,8 @@ int test14243()
     {
         int var = 1;
         mixin Mix14243e!12;
-        static assert(is(typeof(&foo) == int delegate() @safe nothrow));
-        static assert(is(typeof(&bar) == int function() @safe nothrow));
+        static assert(is(typeof(&foo) == int delegate() @safe nothrow pure @nogc));
+        static assert(is(typeof(&bar) == int function() @safe nothrow pure @nogc));
         static assert(S.sizeof == int.sizeof);  // s is static struct
         assert(foo() == 1);
         assert(bar() == 12);

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -2160,7 +2160,7 @@ void test5473()
         static void g(){};
     }
 
-    void dummy(){}
+    void dummy();
     alias typeof(dummy) VoidFunc;
 
     const C c = new C;
@@ -2729,11 +2729,11 @@ void test12524(inout(int))
 /************************************/
 // 6941
 
-static assert((const(shared(int[])[])).stringof == "const(shared(int[])[])");	// fail
+static assert((const(shared(int[])[])).stringof == "const(shared(int[])[])");   // fail
 static assert((const(shared(int[])[])).stringof != "const(shared(const(int[]))[])"); // fail
 
-static assert((inout(shared(int[])[])).stringof == "inout(shared(int[])[])");	// fail
-static assert((inout(shared(int[])[])).stringof != "inout(shared(inout(int[]))[])");	// fail
+static assert((inout(shared(int[])[])).stringof == "inout(shared(int[])[])");   // fail
+static assert((inout(shared(int[])[])).stringof != "inout(shared(inout(int[]))[])");    // fail
 
 /************************************/
 // 6872
@@ -3427,7 +3427,7 @@ inout(int)* function(inout(int)*) fptr10761(inout(int)*)
 {
     static inout(int)* screwUp(inout(int)* x) { return x; }
     auto fp = &screwUp;
-    static assert(is(typeof(fp) == inout(int)* function(inout(int)*)));
+    static assert(is(typeof(fp) == inout(int)* function(inout(int)*) pure nothrow @nogc @safe));
     return fp;
 }
 
@@ -3435,7 +3435,7 @@ inout(int)* delegate(inout(int)*) nest10761(inout(int)* x)
 {
     inout(int)* screwUp(inout(int)* _) { return x; }
     auto dg = &screwUp;
-    static assert(is(typeof(dg) == inout(int)* delegate(inout(int)*)));
+    static assert(is(typeof(dg) == inout(int)* delegate(inout(int)*) pure nothrow @nogc @safe));
     return dg;
 }
 

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -173,11 +173,11 @@ void safeunions()   // improved for issue 11510
     p = uud.a.a.a.a, p = uud.a.a.a.b;
 
     // Reading overlapped pointer field is not allowed.
-    static assert(!__traits(compiles, { auto p = uu1.c; }));
-    static assert(!__traits(compiles, { auto p = uu2.c; }));
-    static assert(!__traits(compiles, { auto c = uu3.c; }));
-    static assert(!__traits(compiles, { auto c = uu4.c; }));
-    static assert(!__traits(compiles, { auto p = uu5.b.a; }));
+    static assert(!__traits(compiles, () @safe { auto p = uu1.c; }));
+    static assert(!__traits(compiles, () @safe { auto p = uu2.c; }));
+    static assert(!__traits(compiles, () @safe { auto c = uu3.c; }));
+    static assert(!__traits(compiles, () @safe { auto c = uu4.c; }));
+    static assert(!__traits(compiles, () @safe { auto p = uu5.b.a; }));
 }
 
 
@@ -188,17 +188,17 @@ void safeexception()
     try {}
     catch(Exception e) {}
 
-    static assert(!__traits(compiles, {
+    static assert(!__traits(compiles, () @safe {
         try {}
         catch(Error e) {}
     }));
 
-    static assert(!__traits(compiles, {
+    static assert(!__traits(compiles, () @safe {
         try {}
         catch(Throwable e) {}
     }));
 
-    static assert(!__traits(compiles, {
+    static assert(!__traits(compiles, () @safe {
         try {}
         catch {}
     }));
@@ -259,10 +259,10 @@ int threadlocalvar;
 @safe
 void takeaddr()
 {
-    static assert(!__traits(compiles, (int x) { auto y = &x; } ));
-    static assert(!__traits(compiles, { int x; auto y = &x; } ));
-    static assert( __traits(compiles, { static int x; auto y = &x; } ));
-    static assert( __traits(compiles, { auto y = &threadlocalvar; } ));
+    static assert(!__traits(compiles, (int x) @safe { auto y = &x; } ));
+    static assert(!__traits(compiles, () @safe { int x; auto y = &x; } ));
+    static assert( __traits(compiles, () @safe { static int x; auto y = &x; } ));
+    static assert( __traits(compiles, () @safe { auto y = &threadlocalvar; } ));
 }
 
 __gshared int gsharedvar;
@@ -270,31 +270,31 @@ __gshared int gsharedvar;
 @safe
 void use__gshared()
 {
-    static assert(!__traits(compiles, { int x = gsharedvar; } ));
+    static assert(!__traits(compiles, () @safe { int x = gsharedvar; } ));
 }
 
 @safe
 void voidinitializers()
 {//http://d.puremagic.com/issues/show_bug.cgi?id=4885
-    static assert(!__traits(compiles, { uint* ptr = void; } ));
-    static assert( __traits(compiles, { uint i = void; } ));
-    static assert( __traits(compiles, { uint[2] a = void; } ));
+    static assert(!__traits(compiles, () @safe { uint* ptr = void; } ));
+    static assert( __traits(compiles, () @safe { uint i = void; } ));
+    static assert( __traits(compiles, () @safe { uint[2] a = void; } ));
 
     struct ValueStruct { int a; }
     struct NonValueStruct { int* a; }
-    static assert( __traits(compiles, { ValueStruct a = void; } ));
-    static assert(!__traits(compiles, { NonValueStruct a = void; } ));
+    static assert( __traits(compiles, () @safe { ValueStruct a = void; } ));
+    static assert(!__traits(compiles, () @safe { NonValueStruct a = void; } ));
 
-    static assert(!__traits(compiles, { uint[] a = void; } ));
-    static assert(!__traits(compiles, { int** a = void; } ));
-    static assert(!__traits(compiles, { int[int] a = void; } ));
+    static assert(!__traits(compiles, () @safe { uint[] a = void; } ));
+    static assert(!__traits(compiles, () @safe { int** a = void; } ));
+    static assert(!__traits(compiles, () @safe { int[int] a = void; } ));
 }
 
 @safe
 void pointerindex()
 {//http://d.puremagic.com/issues/show_bug.cgi?id=9195
-    static assert(!__traits(compiles, { int* p; auto a = p[30]; }));
-    static assert( __traits(compiles, { int* p; auto a = p[0]; }));
+    static assert(!__traits(compiles, () @safe { int* p; auto a = p[30]; }));
+    static assert( __traits(compiles, () @safe{ int* p; auto a = p[0]; }));
 }
 
 @safe
@@ -462,6 +462,34 @@ void test12502() @safe
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=14162
 
-void main() { }
+@trusted auto trusted(alias fun)() { return fun(); }
+
+@safe void func1()()
+{
+    char[3] s = "abc";
+    string t = trusted!(() => cast(string)(s[]));
+    assert(t == "abc");
+}
+
+@safe void func2()()
+{
+    char[3] s = "abc";
+    string t = trusted!(() => cast(string)(s[]));
+    assert(t == "abc");
+}
+
+@safe void test14162()
+{
+    func1();
+    func2();
+}
+
+/***************************************************/
+
+void main()
+{
+    test14162();
+}
 

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1372,17 +1372,17 @@ void test_getFunctionAttributes()
     ref int ref_property() @property { return *(new int); }
     void safe_nothrow() @safe nothrow { }
 
-    static assert(__traits(getFunctionAttributes, pure_nothrow) == tuple!("pure", "nothrow", "@system"));
-    static assert(__traits(getFunctionAttributes, typeof(pure_nothrow)) == tuple!("pure", "nothrow", "@system"));
+    static assert(__traits(getFunctionAttributes, pure_nothrow) == tuple!("pure", "nothrow", "@nogc", "@safe"));
+    static assert(__traits(getFunctionAttributes, typeof(pure_nothrow)) == tuple!("pure", "nothrow", "@nogc", "@safe"));
 
-    static assert(__traits(getFunctionAttributes, static_ref_property) == tuple!("@property", "ref", "@system"));
-    static assert(__traits(getFunctionAttributes, typeof(&static_ref_property)) == tuple!("@property", "ref", "@system"));
+    static assert(__traits(getFunctionAttributes, static_ref_property) == tuple!("pure", "nothrow", "@property", "ref", "@safe"));
+    static assert(__traits(getFunctionAttributes, typeof(&static_ref_property)) == tuple!("pure", "nothrow", "@property", "ref", "@safe"));
 
-    static assert(__traits(getFunctionAttributes, ref_property) == tuple!("@property", "ref", "@system"));
-    static assert(__traits(getFunctionAttributes, typeof(&ref_property)) == tuple!("@property", "ref", "@system"));
+    static assert(__traits(getFunctionAttributes, ref_property) == tuple!("pure", "nothrow", "@property", "ref", "@safe"));
+    static assert(__traits(getFunctionAttributes, typeof(&ref_property)) == tuple!("pure", "nothrow", "@property", "ref", "@safe"));
 
-    static assert(__traits(getFunctionAttributes, safe_nothrow) == tuple!("nothrow", "@safe"));
-    static assert(__traits(getFunctionAttributes, typeof(safe_nothrow)) == tuple!("nothrow", "@safe"));
+    static assert(__traits(getFunctionAttributes, safe_nothrow) == tuple!("pure", "nothrow", "@nogc", "@safe"));
+    static assert(__traits(getFunctionAttributes, typeof(safe_nothrow)) == tuple!("pure", "nothrow", "@nogc", "@safe"));
 
     struct S2
     {

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4915,7 +4915,7 @@ static assert(is(typeof(S5933d.x) == FuncType5933));
 
 
 class C5933a { auto x() { return 0; } }
-static assert(is(typeof(&(new C5933b()).x) == int delegate() pure nothrow @nogc @safe));
+static assert(is(typeof(&(new C5933b()).x) == int delegate()));
 
 class C5933b { auto x() { return 0; } }
 //static assert(is(typeof((new C5933b()).x) == FuncType5933));
@@ -5358,7 +5358,7 @@ void test6902()
     })));
 
     int f() pure nothrow { assert(0); }
-    alias int T() pure nothrow;
+    alias int T() pure nothrow @safe @nogc;
     static if(is(typeof(&f) DT == delegate))
     {
         static assert(is(DT* == T*));  // ok


### PR DESCRIPTION
Inference of safety for lambdas should always occur if not explicitly set, because the source is always available.
