### PR TITLE
follow up to PR #2867: refactor emission of lexical scope debug info of local variables

### DIFF
--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -2545,7 +2545,7 @@ STATIC void cv4_func(Funcsym *s)
     cv4_outsym(s);              // put out function symbol
 #if MARS
     static Funcsym* sfunc;
-    static cntOpenBlocks;
+    static int cntOpenBlocks;
     sfunc = s;
     cntOpenBlocks = 0;
 

--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -2546,7 +2546,8 @@ STATIC void cv4_func(Funcsym *s)
 #if MARS
     static Funcsym* sfunc;
     sfunc = s;
-    struct CV
+
+    struct cv4
     {
         // record for CV record S_BLOCK32
         struct block32_data
@@ -2582,7 +2583,7 @@ STATIC void cv4_func(Funcsym *s)
         }
     };
 
-    varStats.writeSymbolTable(&globsym, &cv4_outsym, &CV::endArgs, &CV::beginBlock, &CV::endBlock);
+    varStats.writeSymbolTable(&globsym, &cv4_outsym, &cv4::endArgs, &cv4::beginBlock, &cv4::endBlock);
 #else
     symtab_t* symtab = &globsym;
 

--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -2533,63 +2533,6 @@ STATIC void cv_outlist()
         cv_outsym((Symbol *) list_pop(&cgcv.list));
 }
 
-#if MARS
-// record for CV record S_BLOCK32
-struct block32_data
-{
-    unsigned short len;
-    unsigned short id;
-    unsigned int pParent;
-    unsigned int pEnd;
-    unsigned int length;
-    unsigned int offset;
-    unsigned short seg;
-    unsigned char name[2];
-};
-
-/******************************************
- * write lexical scope records up to the line where the symbol sa is created
- * if sa == NULL, flush all remaining records
- */
-void cv4_writeLexicalScope(Funcsym *s, symbol *sa, VarStatistics* vs)
-{
-    if (vs->cntUsedVarStats == 0)
-        return;
-
-    unsigned line;
-    if(sa)
-    {
-        line = sa->lnoscopestart + 1;
-    }
-    else
-    {
-        // flush all
-        line = vs->firstVarStatsLine + vs->cntUsedVarStats;
-    }
-    while (vs->nextVarStatsLine < line && vs->nextVarStatsLine < vs->firstVarStatsLine + vs->cntUsedVarStats)
-    {
-        unsigned idx = vs->nextVarStatsLine - vs->firstVarStatsLine;
-        for(int d = 0; d < vs->varStats[idx].numDel; d++)
-        {
-            static unsigned short s_end[] = { 2, S_END };
-            objmod->write_bytes(SegData[DEBSYM], sizeof(s_end), s_end);
-        }
-        for(int n = 0; n < vs->varStats[idx].numNew; n++)
-        {
-            unsigned offset = vs->varStats[idx].offset;
-            unsigned length = vs->varStats[vs->varStats[idx].endLine - vs->firstVarStatsLine].offset - offset;
-            unsigned soffset = Offset(DEBSYM);
-            // parent and end to be filled by linker
-            block32_data block32 = { sizeof(block32_data) - 2, S_BLOCK32, 0, 0, length, 0, 0, { 0, '\0' } };
-            objmod->write_bytes(SegData[DEBSYM], sizeof(block32), &block32);
-            size_t offOffset = (char*)&block32.offset - (char*)&block32;
-            objmod->reftoident(DEBSYM, soffset + offOffset, s, offset + s->Soffset, CFseg | CFoff);
-        }
-        vs->nextVarStatsLine++;
-    }
-}
-#endif
-
 /******************************************
  * Write out symbol table for current function.
  */
@@ -2601,29 +2544,55 @@ STATIC void cv4_func(Funcsym *s)
 
     cv4_outsym(s);              // put out function symbol
 #if MARS
-    varStats.calcLexicalScope(s, &globsym);
-#endif
+    static Funcsym* sfunc;
+    sfunc = s;
+    struct CV
+    {
+        // record for CV record S_BLOCK32
+        struct block32_data
+        {
+            unsigned short len;
+            unsigned short id;
+            unsigned int pParent;
+            unsigned int pEnd;
+            unsigned int length;
+            unsigned int offset;
+            unsigned short seg;
+            unsigned char name[2];
+        };
+
+        static void endArgs()
+        {
+            static unsigned short endargs[] = { 2, S_ENDARG };
+            objmod->write_bytes(SegData[DEBSYM],sizeof(endargs),endargs);
+        }
+        static void beginBlock(int offset, int length)
+        {
+            unsigned soffset = Offset(DEBSYM);
+            // parent and end to be filled by linker
+            block32_data block32 = { sizeof(block32_data) - 2, S_BLOCK32, 0, 0, length, 0, 0, { 0, '\0' } };
+            objmod->write_bytes(SegData[DEBSYM], sizeof(block32), &block32);
+            size_t offOffset = (char*)&block32.offset - (char*)&block32;
+            objmod->reftoident(DEBSYM, soffset + offOffset, sfunc, offset + sfunc->Soffset, CFseg | CFoff);
+        }
+        static void endBlock()
+        {
+            static unsigned short endargs[] = { 2, S_END };
+            objmod->write_bytes(SegData[DEBSYM],sizeof(endargs),endargs);
+        }
+    };
+
+    varStats.writeSymbolTable(&globsym, &cv4_outsym, &CV::endArgs, &CV::beginBlock, &CV::endBlock);
+#else
+    symtab_t* symtab = &globsym;
 
     // Put out local symbols
     endarg = 0;
-    for (si = 0; si < globsym.top; si++)
+    for (si = 0; si < symtab->top; si++)
     {   //printf("globsym.tab[%d] = %p\n",si,globsym.tab[si]);
-        symbol *sa = globsym.tab[si];
-#if MARS
-        if (endarg == 0 && sa->Sclass != SCparameter && sa->Sclass != SCfastpar)
-        {   static unsigned short endargs[] = { 2,S_ENDARG };
-
-            objmod->write_bytes(SegData[DEBSYM],sizeof(endargs),endargs);
-            endarg = 1;
-        }
-        if (varStats.isLexVar[si])
-            cv4_writeLexicalScope(s, sa, &varStats);
-#endif
+        symbol *sa = symtab->tab[si];
         cv4_outsym(sa);
     }
-
-#if MARS
-    cv4_writeLexicalScope(s, 0, &varStats); // flush remaining entries
 #endif
 
     // Put out function return record

--- a/src/backend/cv8.c
+++ b/src/backend/cv8.c
@@ -398,7 +398,7 @@ void cv8_func_term(Symbol *sfunc)
     buf->writen(id, len);
     buf->writeByte(0);
 
-    struct CV
+    struct cv8
     {
         // record for CV record S_BLOCK_V3
         struct block_v3_data
@@ -441,7 +441,7 @@ void cv8_func_term(Symbol *sfunc)
             buf->writeWord(S_END);
         }
     };
-    varStats.writeSymbolTable(&globsym, &cv8_outsym, &CV::endArgs, &CV::beginBlock, &CV::endBlock);
+    varStats.writeSymbolTable(&globsym, &cv8_outsym, &cv8::endArgs, &cv8::beginBlock, &cv8::endBlock);
 
     /* Put out function return record S_RETURN
      * (VC doesn't, so we won't bother, either.)

--- a/src/backend/cv8.c
+++ b/src/backend/cv8.c
@@ -315,67 +315,6 @@ void cv8_func_start(Symbol *sfunc)
     varStats.startFunction();
 }
 
-// record for CV record S_BLOCK_V3
-struct block_v3_data
-{
-    unsigned short len;
-    unsigned short id;
-    unsigned int pParent;
-    unsigned int pEnd;
-    unsigned int length;
-    unsigned int offset;
-    unsigned short seg;
-    unsigned char name[1];
-};
-
-/******************************************
- * write lexical scope records up to the line where the symbol sa is created
- * if sa == NULL, flush all remaining records
- */
-void cv8_writeLexicalScope(Funcsym *s, symbol *sa, VarStatistics* vs)
-{
-    if (vs->cntUsedVarStats == 0)
-        return;
-
-    unsigned line;
-    if(sa)
-    {
-        line = sa->lnoscopestart + 1;
-    }
-    else
-    {
-        // flush all
-        line = vs->firstVarStatsLine + vs->cntUsedVarStats;
-    }
-    while (vs->nextVarStatsLine < line && vs->nextVarStatsLine < vs->firstVarStatsLine + vs->cntUsedVarStats)
-    {
-        Outbuffer *buf = currentfuncdata.f1buf;
-        unsigned idx = vs->nextVarStatsLine - vs->firstVarStatsLine;
-        for(int d = 0; d < vs->varStats[idx].numDel; d++)
-        {
-            static unsigned short s_end[] = { 2, S_END };
-            buf->write(s_end, sizeof(s_end));
-        }
-        for(int n = 0; n < vs->varStats[idx].numNew; n++)
-        {
-            unsigned offset = vs->varStats[idx].offset;
-            unsigned length = vs->varStats[vs->varStats[idx].endLine - vs->firstVarStatsLine].offset - offset;
-            unsigned soffset = buf->size();
-            // parent and end to be filled by linker
-            block_v3_data block32 = { sizeof(block_v3_data) - 2, S_BLOCK_V3, 0, 0, length, offset, 0, { 0 } };
-            buf->write(&block32, sizeof(block32));
-            size_t offOffset = (char*)&block32.offset - (char*)&block32;
-
-            F1_Fixups f1f;
-            f1f.s = s;
-            f1f.offset = soffset + offOffset;
-            f1f.value = offset;
-            currentfuncdata.f1fixup->write(&f1f, sizeof(f1f));
-        }
-        vs->nextVarStatsLine++;
-    }
-}
-
 void cv8_func_term(Symbol *sfunc)
 {
     //printf("cv8_func_term(%s)\n", sfunc->Sident);
@@ -459,27 +398,50 @@ void cv8_func_term(Symbol *sfunc)
     buf->writen(id, len);
     buf->writeByte(0);
 
-    varStats.calcLexicalScope(sfunc, &globsym);
-
-    // Write local symbol table
-    bool endarg = false;
-    for (SYMIDX si = 0; si < globsym.top; si++)
-    {   //printf("globsym.tab[%d] = %p\n",si,globsym.tab[si]);
-        symbol *sa = globsym.tab[si];
-        if (endarg == false &&
-            sa->Sclass != SCparameter &&
-            sa->Sclass != SCfastpar &&
-            sa->Sclass != SCshadowreg)
+    struct CV
+    {
+        // record for CV record S_BLOCK_V3
+        struct block_v3_data
         {
+            unsigned short len;
+            unsigned short id;
+            unsigned int pParent;
+            unsigned int pEnd;
+            unsigned int length;
+            unsigned int offset;
+            unsigned short seg;
+            unsigned char name[1];
+        };
+
+        static void endArgs()
+        {
+            Outbuffer *buf = currentfuncdata.f1buf;
             buf->writeWord(2);
             buf->writeWord(S_ENDARG);
-            endarg = true;
         }
-        if (varStats.isLexVar[si])
-            cv8_writeLexicalScope(sfunc, sa, &varStats);
-        cv8_outsym(sa);
-    }
-    cv8_writeLexicalScope(sfunc, 0, &varStats); // flush remaining entries
+        static void beginBlock(int offset, int length)
+        {
+            Outbuffer *buf = currentfuncdata.f1buf;
+            unsigned soffset = buf->size();
+            // parent and end to be filled by linker
+            block_v3_data block32 = { sizeof(block_v3_data) - 2, S_BLOCK_V3, 0, 0, length, offset, 0, { 0 } };
+            buf->write(&block32, sizeof(block32));
+            size_t offOffset = (char*)&block32.offset - (char*)&block32;
+
+            F1_Fixups f1f;
+            f1f.s = currentfuncdata.sfunc;
+            f1f.offset = soffset + offOffset;
+            f1f.value = offset;
+            currentfuncdata.f1fixup->write(&f1f, sizeof(f1f));
+        }
+        static void endBlock()
+        {
+            Outbuffer *buf = currentfuncdata.f1buf;
+            buf->writeWord(2);
+            buf->writeWord(S_END);
+        }
+    };
+    varStats.writeSymbolTable(&globsym, &cv8_outsym, &CV::endArgs, &CV::beginBlock, &CV::endBlock);
 
     /* Put out function return record S_RETURN
      * (VC doesn't, so we won't bother, either.)

--- a/src/backend/varstats.c
+++ b/src/backend/varstats.c
@@ -252,9 +252,14 @@ void VarStatistics::writeSymbolTable(symtab_t* symtab,
                     openBlocks--;
                 }
             }
-            if(fnBeginBlock)
-                (*fnBeginBlock)(off, lifeTimes[si - uniquecnt].offDestroy - off);
-            openBlocks++;
+            int len = lifeTimes[si - uniquecnt].offDestroy - off;
+            // don't emit a block for length 0, it isn't captured by the close condition above
+            if (len > 0)
+            {
+                if(fnBeginBlock)
+                    (*fnBeginBlock)(off, len);
+                openBlocks++;
+            }
             lastOffset = off;
         }
         (*fnWriteVar)(sa);

--- a/src/backend/varstats.c
+++ b/src/backend/varstats.c
@@ -1,5 +1,5 @@
 // Compiler implementation of the D programming language
-// Copyright (c) 2015-2015 by Digital Mars
+// Copyright (c) 2015-2016 by Digital Mars
 // All Rights Reserved
 // http://www.digitalmars.com
 // Written by Rainer Schuetze
@@ -31,45 +31,6 @@ void VarStatistics::startFunction()
     srcfile = NULL;
 }
 
-// record lines of creation and destruction of a variable
-void VarStatistics::markVarStats(int startLine, int endLine)
-{
-    if (endLine <= startLine) // single line functions
-        endLine = startLine + 1;
-    if (cntUsedVarStats == 0)
-        firstVarStatsLine = startLine;
-
-    if(startLine < firstVarStatsLine)
-    {
-        int cnt = firstVarStatsLine - startLine;
-        if (cnt + cntUsedVarStats > cntAllocVarStats)
-        {
-            cntAllocVarStats = cnt + cntUsedVarStats;
-            varStats = (VarStats*) util_realloc(varStats, cntAllocVarStats, sizeof(*varStats));
-        }
-        memmove(varStats + cnt, varStats, cntUsedVarStats * sizeof(*varStats));
-        memset(varStats, 0, cnt * sizeof(*varStats));
-        cntUsedVarStats += cnt;
-        firstVarStatsLine = startLine;
-    }
-
-    int cnt = endLine - firstVarStatsLine + 1;
-    if (cnt > cntAllocVarStats)
-    {
-        varStats = (VarStats*) util_realloc(varStats, cnt, sizeof(*varStats));
-        cntAllocVarStats = cnt;
-    }
-    if (cnt > cntUsedVarStats)
-    {
-        memset(varStats + cntUsedVarStats, 0, (cnt - cntUsedVarStats) * sizeof(*varStats));
-        cntUsedVarStats = cnt;
-    }
-
-    varStats[startLine - firstVarStatsLine].numNew++;
-    varStats[endLine   - firstVarStatsLine].numDel++;
-    varStats[startLine - firstVarStatsLine].endLine = endLine;
-}
-
 // figure if can we can add a lexical scope for the variable
 // (this should exclude variables from inlined functions as there is
 //  no support for gathering stats from different files)
@@ -84,18 +45,230 @@ bool VarStatistics::isLexicalScopeVar(symbol* sa)
     if (sa->lnoscopeend > funcsym_p->Sfunc->Fendline.Slinnum)
         return false;
 
-    // verify that the variable does not violate the assumption that scopes are stacked inside
-    // each other (might happen with optimizations/inlining)
-    int start = (sa->lnoscopestart < firstVarStatsLine ? firstVarStatsLine : sa->lnoscopestart + 1);
-    int end   = firstVarStatsLine + cntUsedVarStats;
-    end = (sa->lnoscopeend < end ? sa->lnoscopeend : end);
-    for (int i = start; i < end; i++)
-        if (varStats[i - firstVarStatsLine].numNew || varStats[i - firstVarStatsLine].numDel)
+    return true;
+}
+
+// compare function to sort symbols by line offsets of their creation
+static int cmpLifeTime(const void* p1, const void* p2)
+{
+    const LifeTime* lt1 = (const LifeTime*)p1;
+    const LifeTime* lt2 = (const LifeTime*)p2;
+
+    return lt1->offCreate - lt2->offCreate;
+}
+
+// a parent scope contains the creation offset of the child scope
+static SYMIDX isParentScope(LifeTime* lifetimes, SYMIDX parent, SYMIDX si)
+{
+    if(parent < 0) // full function
+        return true;
+    return lifetimes[parent].offCreate <= lifetimes[si].offCreate &&
+           lifetimes[parent].offDestroy > lifetimes[si].offCreate;
+}
+
+// find a symbol that includes the creation of the given symbol as part of its life time
+static SYMIDX findParentScope(LifeTime* lifetimes, SYMIDX si)
+{
+    for(SYMIDX sj = si - 1; sj >= 0; --sj)
+        if(isParentScope(lifetimes, sj, si))
+           return sj;
+    return -1;
+}
+
+static int strHash(const char* s)
+{
+    int hash = 0;
+    for (; *s; s++)
+        hash = hash * 11 + *s;
+    return hash;
+}
+
+bool VarStatistics::hashSymbolIdentifiers(symtab_t* symtab)
+{
+    // fill the hash table for faster lookup of identical symbols
+    bool hashCollisions = false;
+    SYMIDX firstIdent[256];
+    memset(firstIdent, -1, sizeof(firstIdent));
+    for (SYMIDX si = 0; si < symtab->top; si++)
+    {
+        Symbol* sa = symtab->tab[si];
+        int hash = strHash(sa->Sident) & 255;
+        SYMIDX first = firstIdent[hash];
+        if (first == -1)
+        {
+            // connect full circle, so we don't have to recalculate the hash
+            nextIdent[si] = si;
+            firstIdent[hash] = si;
+        }
+        else
+        {
+            // insert after first entry
+            nextIdent[si] = nextIdent[first];
+            nextIdent[first] = si;
+            hashCollisions = true;
+        }
+    }
+    return hashCollisions;
+}
+
+bool VarStatistics::hasUniqueIdentifier(symtab_t* symtab, SYMIDX si)
+{
+    Symbol* sa = symtab->tab[si];
+    for (SYMIDX sj = nextIdent[si]; sj != si; sj = nextIdent[sj])
+        if (strcmp (sa->Sident, symtab->tab[sj]->Sident) == 0)
             return false;
     return true;
 }
 
-// compare function to sort line offsets by line
+// gather statistics about creation and destructions of variables that are
+//  used by the current function
+symtab_t* VarStatistics::calcLexicalScope(symtab_t* symtab)
+{
+    // make a copy of the symbol table
+    // - arguments should be kept at the very beginning
+    // - variables with unique name come first (will be emitted with full function scope)
+    // - variables with duplicate names are added with ascending code offset
+    if (sortedSymtab.symmax < symtab->top)
+    {
+        nextIdent = (int*)util_realloc(nextIdent, symtab->top, sizeof(*nextIdent));
+        sortedSymtab.tab = (Symbol**) util_realloc(sortedSymtab.tab, symtab->top, sizeof(Symbol*));
+        sortedSymtab.symmax = symtab->top;
+    }
+
+    if (!hashSymbolIdentifiers(symtab))
+    {
+        // without any collisions, there are no duplicate symbol names, so bail out early
+        uniquecnt = symtab->top;
+        return symtab;
+    }
+
+    SYMIDX argcnt;
+    for (argcnt = 0; argcnt < symtab->top; argcnt++)
+    {
+        Symbol* sa = symtab->tab[argcnt];
+        if (sa->Sclass != SCparameter && sa->Sclass != SCregpar && sa->Sclass != SCfastpar && sa->Sclass != SCshadowreg)
+            break;
+        sortedSymtab.tab[argcnt] = sa;
+    }
+
+    // find symbols with identical names, only these need lexical scope
+    uniquecnt = argcnt;
+    SYMIDX dupcnt = 0;
+    for (SYMIDX sj, si = argcnt; si < symtab->top; si++)
+    {
+        Symbol* sa = symtab->tab[si];
+        if (!isLexicalScopeVar(sa) || hasUniqueIdentifier(symtab, si))
+            sortedSymtab.tab[uniquecnt++] = sa;
+        else
+            sortedSymtab.tab[symtab->top - 1 - dupcnt++] = sa; // fill from the top
+    }
+    sortedSymtab.top = symtab->top;
+    if(dupcnt == 0)
+        return symtab;
+
+    sortLineOffsets();
+
+    // precalc the lexical blocks to emit so that identically named symbols don't overlap
+    if (cntAllocLifeTimes < dupcnt)
+    {
+        lifeTimes = (LifeTime*) util_realloc(lifeTimes, dupcnt, sizeof(LifeTime));
+        cntAllocLifeTimes = dupcnt;
+    }
+
+    for (SYMIDX si = 0; si < dupcnt; si++)
+    {
+        lifeTimes[si].sym = sortedSymtab.tab[uniquecnt + si];
+        lifeTimes[si].offCreate = getLineOffset(lifeTimes[si].sym->lnoscopestart);
+        lifeTimes[si].offDestroy = getLineOffset(lifeTimes[si].sym->lnoscopeend);
+    }
+    cntUsedLifeTimes = dupcnt;
+    qsort(lifeTimes, dupcnt, sizeof(LifeTime), cmpLifeTime);
+
+    // ensure that an inner block does not extend beyond the end of a parent block
+    for (SYMIDX si = 0; si < dupcnt; si++)
+    {
+        SYMIDX sj = findParentScope(lifeTimes, si);
+        if(sj >= 0 && lifeTimes[si].offDestroy > lifeTimes[sj].offDestroy)
+            lifeTimes[si].offDestroy = lifeTimes[sj].offDestroy;
+    }
+
+    // extend life time to the creation of the next symbol that is not contained in the parent scope
+    // or that has the same name
+    for (SYMIDX sj, si = 0; si < dupcnt; si++)
+    {
+        SYMIDX parent = findParentScope(lifeTimes, si);
+
+        for (sj = si + 1; sj < dupcnt; sj++)
+            if(!isParentScope(lifeTimes, parent, sj))
+                break;
+            else if (strcmp (lifeTimes[si].sym->Sident, lifeTimes[sj].sym->Sident) == 0)
+                break;
+
+        lifeTimes[si].offDestroy = (sj < dupcnt ? lifeTimes[sj].offCreate : retoffset + retsize); // function length
+    }
+
+    // store duplicate symbols back with new ordering
+    for (SYMIDX si = 0; si < dupcnt; si++)
+        sortedSymtab.tab[uniquecnt + si] = lifeTimes[si].sym;
+
+    return &sortedSymtab;
+}
+
+void VarStatistics::writeSymbolTable(symtab_t* symtab,
+                                     void (*fnWriteVar)(Symbol*), void (*fnEndArgs)(),
+                                     void (*fnBeginBlock)(int off,int len), void (*fnEndBlock)())
+{
+    symtab = calcLexicalScope(symtab);
+
+    int openBlocks = 0;
+    int lastOffset = 0;
+
+    // Write local symbol table
+    bool endarg = false;
+    for (SYMIDX si = 0; si < symtab->top; si++)
+    {
+        symbol *sa = symtab->tab[si];
+        if (endarg == false &&
+            sa->Sclass != SCparameter &&
+            sa->Sclass != SCfastpar &&
+            sa->Sclass != SCregpar &&
+            sa->Sclass != SCshadowreg)
+        {
+            if(fnEndArgs)
+                (*fnEndArgs)();
+            endarg = true;
+        }
+        if (si >= uniquecnt)
+        {
+            int off = lifeTimes[si - uniquecnt].offCreate;
+            // close scopes that end before the creation of this symbol
+            for (SYMIDX sj = si - 1; sj >= uniquecnt; --sj)
+            {
+                if (lastOffset < lifeTimes[sj - uniquecnt].offDestroy && lifeTimes[sj - uniquecnt].offDestroy <= off)
+                {
+                    assert(openBlocks > 0);
+                    if(fnEndBlock)
+                        (*fnEndBlock)();
+                    openBlocks--;
+                }
+            }
+            if(fnBeginBlock)
+                (*fnBeginBlock)(off, lifeTimes[si - uniquecnt].offDestroy - off);
+            openBlocks++;
+            lastOffset = off;
+        }
+        (*fnWriteVar)(sa);
+    }
+
+    while (openBlocks > 0)
+    {
+        if(fnEndBlock)
+            (*fnEndBlock)();
+        openBlocks--;
+    }
+}
+
+// compare function to sort line offsets ascending by line (and offset on identical line)
 static int cmpLineOffsets(const void* off1, const void* off2)
 {
     const LineOffset* loff1 = (const LineOffset*)off1;
@@ -106,105 +279,47 @@ static int cmpLineOffsets(const void* off1, const void* off2)
     return loff1->linnum - loff2->linnum;
 }
 
-// gather statistics about creation and destructions of variables that are
-//  used by the current function
-void VarStatistics::calcLexicalScope(Funcsym *s, symtab_t* symtab)
+void VarStatistics::sortLineOffsets()
 {
-    // sort line records and remove duplicate lines
+    if (cntUsedLineOffsets == 0)
+        return;
+
+    // remember the offset to the next recorded offset on another line
+    for (int i = 1; i < cntUsedLineOffsets; i++)
+        lineOffsets[i-1].diffNextOffset = lineOffsets[i].offset - lineOffsets[i-1].offset;
+    lineOffsets[cntUsedLineOffsets - 1].diffNextOffset = retoffset + retsize - lineOffsets[cntUsedLineOffsets - 1].offset;
+
+    // sort line records and remove duplicate lines preferring smaller offsets
     qsort(lineOffsets, cntUsedLineOffsets, sizeof(*lineOffsets), &cmpLineOffsets);
     int j = 0;
     for (int i = 1; i < cntUsedLineOffsets; i++)
         if (lineOffsets[i].linnum > lineOffsets[j].linnum)
             lineOffsets[++j] = lineOffsets[i];
     cntUsedLineOffsets = j + 1;
-
-    cntUsedVarStats = 0;
-    if (cntAllocLexVars < symtab->top)
-    {
-        isLexVar = (bool*) util_realloc(isLexVar, symtab->top, sizeof(*isLexVar));
-        cntAllocLexVars = symtab->top;
-    }
-    memset(isLexVar, 0, symtab->top);
-
-    SYMIDX si;
-    for (si = 0; si < symtab->top; si++)
-    {
-        symbol *sa = symtab->tab[si];
-        isLexVar[si] = isLexicalScopeVar(sa);
-        if(isLexVar[si])
-            markVarStats(sa->lnoscopestart, sa->lnoscopeend);
-    }
-    // todo: optimize out multiple blocks for multiple variables added and removed at the same locations
-
-    Srcpos src = funcsym_p->Sfunc->Fstartline;
-    for (int i = 0; i < cntUsedVarStats; i++)
-        if (varStats[i].numDel > 0 || varStats[i].numNew > 0)
-        {
-            src.Slinnum = firstVarStatsLine + i;
-            varStats[i].offset = getLineOffset (src);
-        }
-    sanitizeLineOffsets();
-
-    // initialize iteration in ..._writeLexicalScope
-    nextVarStatsLine = firstVarStatsLine;
 }
 
-// sanitize offsets: blocks must nest correctly
-// lineOffsets must be ascending
-// invalid offsets are extended to the next outer scope boundary
-void VarStatistics::sanitizeLineOffsets()
+targ_size_t VarStatistics::getLineOffset(int linnum)
 {
-    int lastoff = 0;
-    for (int idx = 0; idx < cntUsedVarStats; idx++)
-    {
-        if (varStats[idx].numNew > 0 || varStats[idx].numDel > 0)
-        {
-            if (varStats[idx].offset >= lastoff)
-                lastoff = varStats[idx].offset;
-
-            else if (varStats[idx].numDel == 0)
-                // introducing new variables extends to previous offset
-                varStats[idx].offset = lastoff;
-
-            else
-            {
-                // removing variables extends to the next sane offset
-                int nidx = idx + 1;
-                while (nidx < cntUsedVarStats && varStats[idx].offset < lastoff)
-                    nidx++; // varStats[idx].offset == 0 for entries without numDel/numNew
-
-                // store it to all entries with smaller offsets
-                lastoff = nidx < cntUsedVarStats ? varStats[nidx].offset : retoffset + retsize; // function length
-                for (; idx < nidx; idx++)
-                    if (varStats[idx].numNew > 0 || varStats[idx].numDel > 0)
-                        varStats[idx].offset = lastoff;
-            }
-        }
-    }
-}
-
-targ_size_t VarStatistics::getLineOffset(Srcpos src)
-{
-    if (!src.Sfilename || !srcfile)
-        return 0;
-    if (src.Sfilename != srcfile && strcmp (src.Sfilename, srcfile) != 0)
-        return 0;
-    int idx = findLineIndex(src.Slinnum);
-    if (idx >= cntUsedLineOffsets || lineOffsets[idx].linnum < src.Slinnum)
+    int idx = findLineIndex(linnum);
+    if (idx >= cntUsedLineOffsets || lineOffsets[idx].linnum < linnum)
         return retoffset + retsize; // function length
+    if (idx > 0 && lineOffsets[idx].linnum != linnum)
+        // for inexact line numbers, use the offset following the previous line
+        return lineOffsets[idx-1].offset + lineOffsets[idx-1].diffNextOffset;
     return lineOffsets[idx].offset;
 }
 
+// return the first record index in the lineOffsets array with linnum >= line
 int VarStatistics::findLineIndex(unsigned line)
 {
     int low = 0;
-    int high = cntUsedLineOffsets - 1;
-    while (low <= high)
+    int high = cntUsedLineOffsets;
+    while (low < high)
     {
         int mid = (low + high) >> 1;
         int ln = lineOffsets[mid].linnum;
         if (line < ln)
-            high = mid - 1;
+            high = mid;
         else if (line > ln)
             low = mid + 1;
         else
@@ -215,6 +330,7 @@ int VarStatistics::findLineIndex(unsigned line)
 
 void VarStatistics::recordLineOffset(Srcpos src, targ_size_t off)
 {
+    // only record line numbers from one file, symbol info does not include source file
     if (!src.Sfilename || !src.Slinnum)
         return;
     if (!srcfile)
@@ -222,13 +338,18 @@ void VarStatistics::recordLineOffset(Srcpos src, targ_size_t off)
     if (srcfile != src.Sfilename && strcmp (srcfile, src.Sfilename) != 0)
         return;
 
+    // assume ascending code offsets generated during codegen, ignore any other
+    //  (e.g. there is an additional line number emitted at the end of the function
+    //   or multiple line numbers at the same offset)
+    if (cntUsedLineOffsets > 0 && lineOffsets[cntUsedLineOffsets-1].offset >= off)
+        return;
+
     if (cntUsedLineOffsets > 0 && lineOffsets[cntUsedLineOffsets-1].linnum == src.Slinnum)
     {
-        // optimize common case: new offset on same line, use minimum
-        if (off < lineOffsets[cntUsedLineOffsets-1].offset)
-            lineOffsets[cntUsedLineOffsets-1].offset = off;
+        // optimize common case: new offset on same line
         return;
     }
+    // don't care for lineOffsets being ordered now, that is taken care of later (calcLexicalScope)
     if (cntUsedLineOffsets >= cntAllocLineOffsets)
     {
         cntAllocLineOffsets = 2 * cntUsedLineOffsets + 16;

--- a/src/backend/varstats.h
+++ b/src/backend/varstats.h
@@ -48,7 +48,7 @@ private:
 
     // symbol table sorted by offset of variable creation
     symtab_t sortedSymtab;
-    SYMIDX* nextIdent;    // next symbol with identifier with same hash, same size as sortedSymtab
+    SYMIDX* nextSym;      // next symbol with identifier with same hash, same size as sortedSymtab
     int uniquecnt;        // number of variables that have unique name and don't need lexical scope
 
     // line number records for the current function

--- a/src/backend/varstats.h
+++ b/src/backend/varstats.h
@@ -15,48 +15,56 @@
 
 #include        "cc.h"
 
-// variable creation/destruction information per line
-struct VarStats
+// estimate of variable life time
+struct LifeTime
 {
-    int numNew;  // number of variables introduced at this line
-    int numDel;  // number of variables which are destroyed at this line
-    int endLine; // closing line for variables introduced at this line
-    int offset;  // code offset in function (only evaluated for lines that are the beginning or the end of a scope)
+    Symbol* sym;
+    int offCreate;  // variable created before this code offset
+    int offDestroy; // variable destroyed after this code offset
 };
 
 struct LineOffset
 {
-    unsigned linnum;
     targ_size_t offset;
+    unsigned linnum;
+    unsigned diffNextOffset;
 };
 
 struct VarStatistics
 {
     VarStatistics();
 
-    // statistics for the current functions
-    VarStats* varStats; // keeps information for the lines [firstVarStatsLine, firstVarStatsLine+cntUsedVarStats[
-    int cntAllocVarStats;
-    int cntUsedVarStats;
-    int firstVarStatsLine;
+    void writeSymbolTable(symtab_t* symtab,
+                          void (*fnWriteVar)(Symbol*), void (*fnEndArgs)(),
+                          void (*fnBeginBlock)(int off,int len), void (*fnEndBlock)());
 
-    bool* isLexVar;       // is the variable handled? (variables from inlined functions usually excluded)
-    int cntAllocLexVars;
-    int nextVarStatsLine; // line not yet emitted during variable dump
+    void startFunction();
+    void recordLineOffset(Srcpos src, targ_size_t off);
 
+private:
+    LifeTime* lifeTimes;
+    int cntAllocLifeTimes;
+    int cntUsedLifeTimes;
+
+    // symbol table sorted by offset of variable creation
+    symtab_t sortedSymtab;
+    SYMIDX* nextIdent;    // next symbol with identifier with same hash, same size as sortedSymtab
+    int uniquecnt;        // number of variables that have unique name and don't need lexical scope
+
+    // line number records for the current function
     LineOffset* lineOffsets;
     int cntAllocLineOffsets;
     int cntUsedLineOffsets;
     const char* srcfile;  // only one file supported, no inline
 
-    void startFunction();
-    void recordLineOffset(Srcpos src, targ_size_t off);
-    targ_size_t getLineOffset(Srcpos src);
+    targ_size_t getLineOffset(int linnum);
+    void sortLineOffsets();
     int findLineIndex(unsigned line);
-    void markVarStats(int startLine, int endLine);
+
+    bool hashSymbolIdentifiers(symtab_t* symtab);
+    bool hasUniqueIdentifier(symtab_t* symtab, SYMIDX si);
     bool isLexicalScopeVar(symbol* sa);
-    void calcLexicalScope(Funcsym *s, symtab_t* symtab);
-    void sanitizeLineOffsets();
+    symtab_t* calcLexicalScope(symtab_t* symtab);
 };
 
 extern VarStatistics varStats;

--- a/src/func.d
+++ b/src/func.d
@@ -1418,6 +1418,11 @@ extern (C++) class FuncDeclaration : Declaration
             }
         }
 
+        uint fensure_endlin = endloc.linnum;
+        if (fensure)
+            if (auto s = fensure.isScopeStatement())
+                fensure_endlin = s.endloc.linnum;
+
         frequire = mergeFrequire(frequire);
         fensure = mergeFensure(fensure, outId);
         if (fbody || frequire || fensure)
@@ -1639,7 +1644,7 @@ extern (C++) class FuncDeclaration : Declaration
                 auto sym = new ScopeDsymbol();
                 sym.parent = sc2.scopesym;
                 sym.loc = loc;
-                sym.endlinnum = endloc.linnum;
+                sym.endlinnum = fensure_endlin;
                 scout = sc2.push(sym);
             }
 


### PR DESCRIPTION
In #2867 I commented that symbols in out contracts break the emission of lexical scoped variables. What I expected to be a small fix turned out to need a complete refactoring, avoiding to rely on line numbers too much, but use code offsets instead.

In addition, the emission of pedantic lexical scope information has a bad side effect:

```
   if (auto p = getPtr())
      doSomething(p);
```

In this case, `p` exists while executing the if statement, but in case you inspect the callstack during a program suspension inside the function doSomething, the return address will point beyond the lexical scope of the variable `p` (unless doSomething uses C calling convention with the necessity of cleanup code after the call instruction). So the debugger won't show the variable `p`. There are similar issues when stepping over a closing brace. You have the same issues when debugging C++ code.

So I relaxed the conditions for emitting lexical scope:
- symbols with unique identifiers get full function scope
- extend life time of variables until the next identical named variable or the end of the parent scope.

This PR also improves encapsulation of the generation of lexical scope blocks: all it needs are calls to record line number information and a final `writeSymbolTable`.
