### PR TITLE
Fix forward reference bug with extern(C++, class).

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -8089,7 +8089,16 @@ extern (C++) final class TypeStruct : Type
     {
         //printf("TypeStruct::semantic('%s')\n", sym.toChars());
         if (deco)
+        {
+            if (sc.cppmangle != CPPMANGLE.def)
+            {
+                if (this.cppmangle == CPPMANGLE.def)
+                    this.cppmangle = sc.cppmangle;
+                else
+                    assert(this.cppmangle == sc.cppmangle);
+            }
             return this;
+        }
 
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.
@@ -8928,7 +8937,16 @@ extern (C++) final class TypeClass : Type
     {
         //printf("TypeClass::semantic(%s)\n", sym.toChars());
         if (deco)
+        {
+            if (sc.cppmangle != CPPMANGLE.def)
+            {
+                if (this.cppmangle == CPPMANGLE.def)
+                    this.cppmangle = sc.cppmangle;
+                else
+                    assert(this.cppmangle == sc.cppmangle);
+            }
             return this;
+        }
 
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -169,6 +169,8 @@ interface Test38
      public static void dispose(ref Test38);
 }
 
+extern(C++) int test39cpp(C2!char, S2!(int)*);
+
 extern(C++, class)
 struct S1
 {
@@ -206,8 +208,6 @@ class C2(T)
     static C2!T init(const(T)* p);
     const(T)* getData();
 }
-
-extern(C++) int test39cpp(C2!char, S2!(int)*);
 
 void test39()
 {


### PR DESCRIPTION
Depending on the position in the source file, the
cppmangle value is not set correct.
