### PR TITLE
Mangle extern(C++) ctor as C++ ctor.

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -268,7 +268,11 @@ private final class CppMangleVisitor : Visitor
     void source_name(Dsymbol s)
     {
         //printf("source_name(%s)\n", s.toChars());
-        if (TemplateInstance ti = s.isTemplateInstance())
+        if (s.isCtorDeclaration())
+        {
+            buf.writestring("C1");
+        }
+        else if (TemplateInstance ti = s.isTemplateInstance())
         {
             if (!substitute(ti.tempdecl))
             {

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -659,6 +659,11 @@ private:
         //printf("mangleName('%s')\n", sym.toChars());
         const(char)* name = null;
         bool is_dmc_template = false;
+        if (sym.isCtorDeclaration())
+        {
+            buf.writestring("?0");
+            return;
+        }
         if (sym.isDtorDeclaration())
         {
             buf.writestring("?1");

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -224,6 +224,19 @@ void test39()
     assert(result == 0);
 }
 
+extern(C++)
+class C40
+{
+    private int val;
+
+    this(int);
+    int getValue();
+}
+
+void test40()
+{
+    assert(new C40(42).getValue == 42);
+}
 
 void main()
 {
@@ -311,4 +324,5 @@ void main()
     assert(t38.test(1, 2, 3) == 1);
     Test38.dispose(t38);
     test39();
+    test40();
 }

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -395,3 +395,19 @@ int test39cpp(C2<char>* c2, S2<int>* s2)
         return 2;
     return 0;
 }
+
+class C40
+{
+    int val;
+
+public:
+    C40(int);
+    virtual int getValue();
+};
+
+C40::C40(int value) : val(value) { }
+
+int C40::getValue()
+{
+    return val;
+}


### PR DESCRIPTION
Additionally, it disallows a extern(C++) ctor to have a body.
It should be safe to call a C++ ctor from C++ and D as long as
the initialization rules from C++ are used. Disallowing an ctor
body ensures this.
