### PR TITLE
[Trivial] Match toChars() C++ header declaration with D code constness.

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -89,7 +89,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    const char *toChars() const;
+    const char *toChars();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -100,7 +100,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    const char *toChars() const;
+    const char *toChars();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -72,7 +72,7 @@ class VoidInitExp : public Expression
 public:
     VarDeclaration *var;
 
-    char *toChars();
+    const char *toChars();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -86,7 +86,7 @@ class ThrownExceptionExp : public Expression
 {
 public:
     ClassReferenceExp *thrown; // the thing being tossed
-    char *toChars();
+    const char *toChars();
     /// Generate an error message when this exception is not caught
     void generateUncaughtError();
     void accept(Visitor *v) { v->visit(this); }
@@ -101,7 +101,7 @@ class CTFEExp : public Expression
 public:
     CTFEExp(TOK tok);
 
-    char *toChars();
+    const char *toChars();
 
     // Handy instances to share
     static CTFEExp *cantexp;

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -302,7 +302,7 @@ public:
     static TypeInfoDeclaration *create(Type *tinfo);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
-    char *toChars();
+    const char *toChars();
 
     TypeInfoDeclaration *isTypeInfoDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -682,7 +682,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     const char *kind();
-    char *toChars();
+    const char *toChars();
     bool isVirtual();
     bool addPreInvariant();
     bool addPostInvariant();
@@ -711,7 +711,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     const char *kind();
-    char *toChars();
+    const char *toChars();
     bool isVirtual();
     bool addPreInvariant();
     bool addPostInvariant();

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -167,7 +167,7 @@ public:
     UnitTestDeclaration *ddocUnittest; // !=NULL means there's a ddoc unittest associated with this symbol (only use this with ddoc)
 
     static Dsymbol *create(Identifier *);
-    char *toChars();
+    const char *toChars();
     virtual char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc& getLoc();
     const char *locToChars();

--- a/src/expression.h
+++ b/src/expression.h
@@ -138,7 +138,7 @@ public:
     int dyncast() { return DYNCAST_EXPRESSION; }
 
     void print();
-    char *toChars();
+    const char *toChars();
     virtual void printAST(int ident = 0);
     void error(const char *format, ...) const;
     void warning(const char *format, ...) const;
@@ -613,7 +613,7 @@ public:
     Expression *semantic(Scope *sc);
     Expression *semantic(Scope *sc, Expressions *arguments);
     MATCH matchType(Type *to, Scope *sc, FuncExp **pfe, int flag = 0);
-    char *toChars();
+    const char *toChars();
     bool checkType();
     bool checkValue();
 

--- a/src/glue.c
+++ b/src/glue.c
@@ -156,7 +156,7 @@ void obj_write_deferred(Library *library)
         const char *fname = FileName::removeExt(mname);
         OutBuffer namebuf;
         unsigned hash = 0;
-        for (char *p = s->toChars(); *p; p++)
+        for (const char *p = s->toChars(); *p; p++)
             hash += *p;
         namebuf.printf("%s_%x_%x.%s", fname, count, hash, global.obj_ext);
         FileName::free((char *)fname);
@@ -730,7 +730,7 @@ bool isDruntimeArrayOp(Identifier *ident)
         "_arraySliceSliceMulass_u",
         "_arraySliceSliceMulass_w",
     };
-    char *name = ident->toChars();
+    const char *name = ident->toChars();
     int i = binary(name, libArrayopFuncs, sizeof(libArrayopFuncs) / sizeof(char *));
     if (i != -1)
         return true;

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2086,7 +2086,7 @@ static bool asm_isNonZeroInt(OPND *o)
 /*******************************
  */
 
-static bool asm_is_fpreg(char *szReg)
+static bool asm_is_fpreg(const char *szReg)
 {
 #if 1
     return(szReg[0] == 'S' &&
@@ -3298,7 +3298,7 @@ static void asm_output_popnd(OPND *popnd)
 /*******************************
  */
 
-static REG *asm_reg_lookup(char *s)
+static REG *asm_reg_lookup(const char *s)
 {
     int i;
 
@@ -3347,7 +3347,7 @@ static void asm_token_trans(Token *tok)
         if (tok_value == TOKidentifier)
         {
             size_t len;
-            char *id;
+            const char *id;
 
             id = tok->ident->toChars();
             len = strlen(id);

--- a/src/identifier.h
+++ b/src/identifier.h
@@ -26,7 +26,7 @@ public:
     bool equals(RootObject *o);
     int compare(RootObject *o);
     void print();
-    char *toChars();
+    const char *toChars();
     const char *toHChars2();
     int dyncast();
 

--- a/src/init.h
+++ b/src/init.h
@@ -47,7 +47,7 @@ public:
     // needInterpret is INITinterpret if must be a manifest constant, 0 if not.
     virtual Initializer *semantic(Scope *sc, Type *t, NeedInterpret needInterpret) = 0;
     virtual Expression *toExpression(Type *t = NULL) = 0;
-    char *toChars();
+    const char *toChars();
 
     virtual ErrorInitializer   *isErrorInitializer() { return NULL; }
     virtual VoidInitializer    *isVoidInitializer() { return NULL; }

--- a/src/module.h
+++ b/src/module.h
@@ -179,7 +179,7 @@ struct ModuleDeclaration
     bool isdeprecated;  // if it is a deprecated module
     Expression *msg;
 
-    char *toChars();
+    const char *toChars();
 };
 
 #endif /* DMD_MODULE_H */

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -236,7 +236,7 @@ public:
     // kludge for template.isType()
     int dyncast() { return DYNCAST_TYPE; }
     int covariant(Type *t, StorageClass *pstc = NULL);
-    char *toChars();
+    const char *toChars();
     char *toPrettyChars(bool QualifyTypes = false);
     static char needThisPrefix();
     static void init();

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -50,7 +50,7 @@ struct Array
 
     char *toChars()
     {
-        char **buf = (char **)mem.xmalloc(dim * sizeof(char *));
+        const char **buf = (const char **)mem.xmalloc(dim * sizeof(const char *));
         d_size_t len = 2;
         for (d_size_t u = 0; u < dim; u++)
         {

--- a/src/root/object.h
+++ b/src/root/object.h
@@ -43,7 +43,7 @@ public:
      */
     virtual void print();
 
-    virtual char *toChars();
+    virtual const char *toChars();
     virtual void toBuffer(OutBuffer *buf);
 
     /**

--- a/src/statement.h
+++ b/src/statement.h
@@ -79,7 +79,7 @@ public:
     virtual Statement *syntaxCopy();
 
     void print();
-    char *toChars();
+    const char *toChars();
 
     void error(const char *format, ...);
     void warning(const char *format, ...);

--- a/src/template.h
+++ b/src/template.h
@@ -49,7 +49,7 @@ public:
     // kludge for template.isType()
     int dyncast() { return DYNCAST_TUPLE; }
 
-    char *toChars() { return objects.toChars(); }
+    const char *toChars() { return objects.toChars(); }
 };
 
 struct TemplatePrevious
@@ -88,7 +88,7 @@ public:
     bool overloadInsert(Dsymbol *s);
     bool hasStaticCtorOrDtor();
     const char *kind();
-    char *toChars();
+    const char *toChars();
 
     Prot prot();
 
@@ -320,7 +320,7 @@ public:
     Dsymbol *toAlias();                 // resolve real symbol
     const char *kind();
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    char *toChars();
+    const char *toChars();
     char* toPrettyCharsHelper();
     void printInstantiationTrace();
     Identifier *getIdent();
@@ -362,7 +362,7 @@ public:
     int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    char *toChars();
+    const char *toChars();
 
     bool findTempDecl(Scope *sc);
 

--- a/src/tocvdebug.c
+++ b/src/tocvdebug.c
@@ -777,7 +777,7 @@ int cvMember(Dsymbol *s, unsigned char *p)
         {
         }
 
-        void cvMemberCommon(Dsymbol *s, char *id, idx_t typidx)
+        void cvMemberCommon(Dsymbol *s, const char *id, idx_t typidx)
         {
             if (!p)
                 result = cv_stringbytes(id);
@@ -841,7 +841,7 @@ int cvMember(Dsymbol *s, unsigned char *p)
             if (!fd->type)                  // if not compiled in,
                 return;               // skip it
 
-            char *id = fd->toChars();
+            const char *id = fd->toChars();
 
             if (!p)
             {
@@ -953,7 +953,7 @@ int cvMember(Dsymbol *s, unsigned char *p)
             if (vd->type->toBasetype()->ty == Ttuple)
                 return;
 
-            char *id = vd->toChars();
+            const char *id = vd->toChars();
 
             if (!p)
             {

--- a/src/version.h
+++ b/src/version.h
@@ -25,7 +25,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *);
 
-    char *toChars();
+    const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void semantic(Scope *sc);
     const char *kind();
@@ -39,7 +39,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *);
 
-    char *toChars();
+    const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void semantic(Scope *sc);
     const char *kind();


### PR DESCRIPTION
This also fixes unintended virtual function overloading in the attrib.h header due to constness differences in function signature.

What I still find strange on the D side of this, is that

``` d
extern(C++) class Base {
    const(char*) toChars();
}

extern(C++)  class Derived : Base {
    override const(char*) toChars() const; // extra const!
}
```

is allowed (and is used in e.g. attrib.d).
