### PR TITLE
ignore 'scope' if parameter has no indirections

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -6228,6 +6228,9 @@ extern (C++) final class TypeFunction : TypeNext
                     }
                 }
 
+                if (fparam.storageClass & STCscope && !fparam.type.hasPointers())
+                    fparam.storageClass &= ~STCscope;
+
                 if (t.hasWild())
                 {
                     wildparams |= 1;

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -540,6 +540,12 @@ void test12231()
 
 /***************************************************/
 
+int test2a(scope int a) { return a; }
+
+static assert(test2a.mangleof == "_D6mangle6test2aFiZi");
+
+/***************************************************/
+
 void main()
 {
     test10077h();


### PR DESCRIPTION
Because `scope` has no meaning apart from indirections.
