### PR TITLE
'scope' can be applied to class member 'this'

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -645,6 +645,8 @@ extern (C++) class FuncDeclaration : Declaration
 
             if (tf.isref)
                 sc.stc |= STCref;
+            if (tf.isscope)
+                sc.stc |= STCscope;
             if (tf.isnothrow)
                 sc.stc |= STCnothrow;
             if (tf.isnogc)
@@ -718,6 +720,7 @@ extern (C++) class FuncDeclaration : Declaration
             TypeFunction tfo = cast(TypeFunction)originalType;
             TypeFunction tfx = cast(TypeFunction)type;
             tfo.mod = tfx.mod;
+            tfo.isscope = tfx.isscope;
             tfo.isref = tfx.isref;
             tfo.isnothrow = tfx.isnothrow;
             tfo.isnogc = tfx.isnogc;
@@ -733,8 +736,14 @@ extern (C++) class FuncDeclaration : Declaration
 
         if ((storage_class & STCauto) && !f.isref && !inferRetType)
             error("storage class 'auto' has no effect if return type is not inferred");
-        if (storage_class & STCscope)
+
+        /* Functions can only be 'scope' if they have a 'this' that is a pointer, not a ref
+         */
+        if (f.isscope && !isNested() &&
+            !(ad && ad.isClassDeclaration()))
+        {
             error("functions cannot be scope");
+        }
 
         if (isAbstract() && !isVirtual())
         {

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -5979,6 +5979,7 @@ extern (C++) final class TypeFunction : TypeNext
     bool isproperty;            // can be called without parentheses
     bool isref;                 // true: returns a reference
     bool isreturn;              // true: 'this' is returned by ref
+    bool isscope;               // true: 'this' is scope
     LINK linkage;               // calling convention
     TRUST trust;                // level of trust
     PURE purity = PUREimpure;
@@ -6009,6 +6010,8 @@ extern (C++) final class TypeFunction : TypeNext
             this.isref = true;
         if (stc & STCreturn)
             this.isreturn = true;
+        if (stc & STCscope)
+            this.isscope = true;
 
         this.trust = TRUSTdefault;
         if (stc & STCsafe)
@@ -6041,6 +6044,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isproperty = isproperty;
         t.isref = isref;
         t.isreturn = isreturn;
+        t.isscope = isscope;
         t.iswild = iswild;
         t.trust = trust;
         t.fargs = fargs;
@@ -6085,6 +6089,8 @@ extern (C++) final class TypeFunction : TypeNext
             tf.isref = true;
         if (sc.stc & STCreturn)
             tf.isreturn = true;
+        if (sc.stc & STCscope)
+            tf.isscope = true;
 
         if (tf.trust == TRUSTdefault)
         {
@@ -6552,6 +6558,7 @@ extern (C++) final class TypeFunction : TypeNext
             tf.isproperty = t.isproperty;
             tf.isref = t.isref;
             tf.isreturn = t.isreturn;
+            tf.isscope = t.isscope;
             tf.trust = t.trust;
             tf.iswild = t.iswild;
 
@@ -6602,6 +6609,11 @@ extern (C++) final class TypeFunction : TypeNext
 
         if (isreturn)
             res = fp(param, "return");
+        if (res)
+            return res;
+
+        if (isscope)
+            res = fp(param, "scope");
         if (res)
             return res;
 
@@ -6656,6 +6668,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isproperty = isproperty;
         t.isref = isref;
         t.isreturn = isreturn;
+        t.isscope = isscope;
         t.iswild = 0;
         t.trust = trust;
         t.fargs = fargs;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -596,6 +596,7 @@ public:
     bool isproperty;    // can be called without parentheses
     bool isref;         // true: returns a reference
     bool isreturn;      // true: 'this' is returned by ref
+    bool isscope;       // true: 'this' is scope
     LINK linkage;  // calling convention
     TRUST trust;   // level of trust
     PURE purity;   // PURExxxx

--- a/src/parse.d
+++ b/src/parse.d
@@ -1417,8 +1417,13 @@ final class Parser : Lexer
             case TOKpure:
                 stc = STCpure;
                 break;
+
             case TOKreturn:
                 stc = STCreturn;
+                break;
+
+            case TOKscope:
+                stc = STCscope;
                 break;
 
             case TOKat:
@@ -6584,6 +6589,7 @@ final class Parser : Lexer
                     case TOKpure:
                     case TOKnothrow:
                     case TOKreturn:
+                    case TOKscope:
                         t = peek(t);
                         continue;
 

--- a/test/runnable/testscope2.d
+++ b/test/runnable/testscope2.d
@@ -22,30 +22,30 @@ void test3()
 {
     version (all)
     {
-	import std.stdio;
-	writeln(SS.foo1.mangleof);
-	writeln(SS.foo2.mangleof);
-	writeln(SS.foo3.mangleof);
-	writeln(SS.foo4.mangleof);
-	writeln(typeof(SS.foo1).stringof);
-	writeln(typeof(SS.foo2).stringof);
-	writeln(typeof(SS.foo3).stringof);
-	writeln(typeof(SS.foo4).stringof);
+        import std.stdio;
+        writeln(SS.foo1.mangleof);
+        writeln(SS.foo2.mangleof);
+        writeln(SS.foo3.mangleof);
+        writeln(SS.foo4.mangleof);
+        writeln(typeof(SS.foo1).stringof);
+        writeln(typeof(SS.foo2).stringof);
+        writeln(typeof(SS.foo3).stringof);
+        writeln(typeof(SS.foo4).stringof);
     }
 
     version (all)
     {
-	// Test scope mangling
-	assert(SS.foo1.mangleof == "_D10testscope22SS4foo1MFNcNjNkKDFNjZiZi");
-	assert(SS.foo2.mangleof == "_D10testscope22SS4foo2MFNcNkKDFZiZi");
-	assert(SS.foo3.mangleof == "_D10testscope22SS4foo3MFNcNkKNgPiZi");
-	assert(SS.foo4.mangleof == "_D10testscope22SS4foo4MFNcNkKNgPiZi");
+        // Test scope mangling
+        assert(SS.foo1.mangleof == "_D10testscope22SS4foo1MFNcNjNkKDFNjZiZi");
+        assert(SS.foo2.mangleof == "_D10testscope22SS4foo2MFNcNkKDFZiZi");
+        assert(SS.foo3.mangleof == "_D10testscope22SS4foo3MFNcNkKNgPiZi");
+        assert(SS.foo4.mangleof == "_D10testscope22SS4foo4MFNcNkKNgPiZi");
 
-	// Test scope pretty-printing
-	assert(typeof(SS.foo1).stringof == "ref return int(return ref int delegate() return p)");
-	assert(typeof(SS.foo2).stringof == "ref int(return ref int delegate() p)");
-	assert(typeof(SS.foo3).stringof == "ref int(return ref inout(int*) p)");
-	assert(typeof(SS.foo4).stringof == "ref int(return ref inout(int*) p)");
+        // Test scope pretty-printing
+        assert(typeof(SS.foo1).stringof == "ref return int(return ref int delegate() return p)");
+        assert(typeof(SS.foo2).stringof == "ref int(return ref int delegate() p)");
+        assert(typeof(SS.foo3).stringof == "ref int(return ref inout(int*) p)");
+        assert(typeof(SS.foo4).stringof == "ref int(return ref inout(int*) p)");
     }
 }
 
@@ -62,7 +62,7 @@ struct S
 
     ref S bar() return
     {
-	return this;
+        return this;
     }
 }
 
@@ -105,7 +105,7 @@ struct S6
 
     ref int bar() return
     {
-	return x;
+        return x;
     }
 }
 
@@ -143,7 +143,7 @@ struct S8(T)
 
     ref int bar() // infer 'return'
     {
-	return x;
+        return x;
     }
 }
 
@@ -171,7 +171,7 @@ struct S10
 
     ref inout(int) foo() inout
     {
-	return x;
+        return x;
     }
 }
 
@@ -188,7 +188,7 @@ struct S11
 
     void remove()
     {
-	_ptr[0] = _ptr[1];
+        _ptr[0] = _ptr[1];
     }
 
     RC* _ptr;
@@ -207,7 +207,7 @@ int[10] a12;
 int* foo12()
 {
     foreach (ref x; a12)
-	return &x;
+        return &x;
     return null;
 }
 
@@ -223,6 +223,13 @@ struct FullCaseEntry
     {
         return seq[0..entry_len];
     }
+}
+
+/********************************************/
+
+class C12
+{
+    void member() scope { }
 }
 
 /********************************************/


### PR DESCRIPTION
This supports the syntax for it.

The test file also apparently had a bunch of tabs that got converted to spaces by my git script.
