### PR TITLE
disallow things like `static scope`

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1357,6 +1357,25 @@ extern (C++) class VarDeclaration : Declaration
             storage_class &= ~stc; // strip off
         }
 
+        if (storage_class & STCscope)
+        {
+            StorageClass stc = storage_class & (STCstatic | STCextern | STCmanifest | STCtls | STCgshared);
+            if (stc)
+            {
+                OutBuffer buf;
+                stcToBuffer(&buf, stc);
+                error("cannot be 'scope' and '%s'", buf.peekString());
+            }
+            else if (isMember())
+            {
+                error("field cannot be 'scope'");
+            }
+            else if (!type.hasPointers())
+            {
+                storage_class &= ~STCscope;     // silently ignore; may occur in generic code
+            }
+        }
+
         if (storage_class & (STCstatic | STCextern | STCmanifest | STCtemplateparameter | STCtls | STCgshared | STCctfe))
         {
         }

--- a/test/fail_compilation/testscopestatic.d
+++ b/test/fail_compilation/testscopestatic.d
@@ -1,0 +1,24 @@
+
+/* TEST_OUTPUT:
+---
+fail_compilation/testscopestatic.d(15): Error: variable testscopestatic.foo.p cannot be 'scope' and 'static'
+fail_compilation/testscopestatic.d(16): Error: variable testscopestatic.foo.b cannot be 'scope' and 'extern'
+fail_compilation/testscopestatic.d(17): Error: variable testscopestatic.foo.c cannot be 'scope' and '__gshared'
+fail_compilation/testscopestatic.d(21): Error: variable testscopestatic.foo.S.x field cannot be 'scope'
+---
+*/
+
+
+void foo()
+{
+    scope int a;
+    static scope int* p;
+    extern scope int b;
+    scope __gshared int c;
+
+    struct S
+    {
+        scope int x;
+    }
+}
+


### PR DESCRIPTION
Also silently remove `scope` from variables with no indirections (this can occur in generic code).
