### PR TITLE
'return' without 'ref' implies 'scope'

### DIFF
--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -286,7 +286,7 @@ public:
                 buf.writestring("Ni");
             if (ta.isreturn)
                 buf.writestring("Nj");
-            if (ta.isscope)
+            if (ta.isscope && !ta.isreturn)
                 buf.writestring("M");
             switch (ta.trust)
             {

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -3011,6 +3011,8 @@ extern (C++) void toCBuffer(Initializer iz, OutBuffer* buf, HdrGenState* hgs)
 extern (C++) bool stcToBuffer(OutBuffer* buf, StorageClass stc)
 {
     bool result = false;
+    if ((stc & (STCreturn | STCscope)) == (STCreturn | STCscope))
+        stc &= ~STCscope;
     while (stc)
     {
         const(char)* p = stcToChars(stc);


### PR DESCRIPTION
Turns out that `return scope` can be adequately represented by just `return`.
