### PR TITLE
disable flag permutations for compilable tests

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -170,7 +170,7 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
 
     if (! findTestParameter(file, "PERMUTE_ARGS", testArgs.permuteArgs))
     {
-        if (testArgs.mode != TestMode.FAIL_COMPILE)
+        if (testArgs.mode == TestMode.RUN)
             testArgs.permuteArgs = envData.all_args;
 
         string unittestJunk;


### PR DESCRIPTION
- still respects REQUIRED_ARGS
  for reproducing backend bugs
