### PR TITLE
tests: make use of -unittest explicit

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -31,7 +31,8 @@
 #                        default: (none). Test files with this variable will be ignored unless
 #                        the D_OBJC environment variable is set to "1"
 #
-#   PERMUTE_ARGS:        the set of arguments to permute in multiple $(DMD) invocations
+#   PERMUTE_ARGS:        the set of arguments to permute in multiple $(DMD) invocations.
+#                        An empty set means only one permutation with no arguments.
 #                        default: the make variable ARGS (see below)
 #
 #   TEST_OUTPUT:         the output is expected from the compilation (if the
@@ -92,7 +93,7 @@ export MODEL
 export REQUIRED_ARGS=
 
 ifeq ($(findstring win,$(OS)),win)
-export ARGS=-inline -release -g -O -unittest
+export ARGS=-inline -release -g -O
 export DMD=../src/dmd.exe
 export EXE=.exe
 export OBJ=.obj
@@ -104,7 +105,7 @@ PHOBOS_PATH=..\..\phobos
 export DFLAGS=-I$(DRUNTIME_PATH)\import -I$(PHOBOS_PATH)
 export LIB=$(PHOBOS_PATH)
 else
-export ARGS=-inline -release -g -O -unittest -fPIC
+export ARGS=-inline -release -g -O -fPIC
 export DMD=../src/dmd
 export EXE=
 export OBJ=.o

--- a/test/compilable/test15326.d
+++ b/test/compilable/test15326.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -w -c
+// REQUIRED_ARGS: -w -c -unittest
 
 version (unittest)
 private struct _NestedSym_

--- a/test/compilable/test4375.d
+++ b/test/compilable/test4375.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -unittest
 // 4375: disallow dangling else
 
 void main() {

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1,3 +1,4 @@
+// PERMUTE_ARGS: -unittest -O -release -inline -fPIC -g
 
 import core.vararg;
 

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -1,3 +1,4 @@
+// PERMUTE_ARGS: -unittest -O -release -inline -fPIC -g
 
 extern(C) int printf(const char*, ...);
 extern(C) int sprintf(char*, const char*, ...);

--- a/test/runnable/test3.d
+++ b/test/runnable/test3.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS:
+// PERMUTE_ARGS: -unittest -O -release -inline -fPIC -g
 // EXTRA_SOURCES: imports/test3a.d imports/test3b.d
 
 import imports.test3a;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1,3 +1,5 @@
+// PERMUTE_ARGS: -unittest -O -release -inline -fPIC -g
+
 import std.stdio;
 import core.stdc.stdio;
 


### PR DESCRIPTION
This makes the various tests that check unittests rely explicitly on a `-unittest` flag. Makes permuting `-unittest` no longer the default, which should double the speed of running the executable tests by halving the permutations.
