### PR TITLE
[blocks ctfe-rewrite] add isGotoDefaultStatement and isGotoCaseStatement

### DIFF
--- a/src/statement.d
+++ b/src/statement.d
@@ -864,6 +864,16 @@ extern (C++) abstract class Statement : RootObject
         return null;
     }
 
+    GotoDefaultStatement isGotoDefaultStatement() pure
+    {
+        return null;
+    }
+
+    GotoCaseStatement isGotoCaseStatement() pure
+    {
+        return null;
+    }
+
     DtorExpStatement isDtorExpStatement()
     {
         return null;
@@ -2050,6 +2060,11 @@ extern (C++) final class GotoDefaultStatement : Statement
         return new GotoDefaultStatement(loc);
     }
 
+    override GotoDefaultStatement isGotoDefaultStatement() pure
+    {
+        return this;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -2072,6 +2087,11 @@ extern (C++) final class GotoCaseStatement : Statement
     override Statement syntaxCopy()
     {
         return new GotoCaseStatement(loc, exp ? exp.syntaxCopy() : null);
+    }
+
+    override GotoCaseStatement isGotoCaseStatement() pure
+    {
+        return this;
     }
 
     override void accept(Visitor v)

--- a/src/statement.h
+++ b/src/statement.h
@@ -105,6 +105,8 @@ public:
     virtual CaseStatement *isCaseStatement() { return NULL; }
     virtual DefaultStatement *isDefaultStatement() { return NULL; }
     virtual LabelStatement *isLabelStatement() { return NULL; }
+    virtual GotoDefaultStatement *isGotoDefaultStatement() { return NULL; }
+    virtual GotoCaseStatement *isGotoCaseStatement() { return NULL; }
     virtual DtorExpStatement *isDtorExpStatement() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 };
@@ -435,6 +437,7 @@ public:
     SwitchStatement *sw;
 
     Statement *syntaxCopy();
+    GotoDefaultStatement *isGotoDefaultStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -446,6 +449,7 @@ public:
     CaseStatement *cs;          // case statement it resolves to
 
     Statement *syntaxCopy();
+    GotoCaseStatement *isGotoCaseStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
These are needed for my interpreter because they help me to quickly determine what kind of jump to emit. And If I need to do it at all.
e.g.

```
if (!caseCompStmt.lastStatement.isReturnStatement || !caseCompStmt.lastStatement.isGotoCaseStatement ||
!caseCompStmt.lastStatement.isGotoDefaultStatement)
{
    emitJmp(defaultStmtBlock.begin);
}
```

Without this it would be much more code.
