### PR TITLE
fix Issue 16254 - switch skips initialization error

### DIFF
--- a/src/statement.d
+++ b/src/statement.d
@@ -1919,27 +1919,29 @@ extern (C++) final class SwitchStatement : Statement
             }
             else if (vd.ident == Id.withSym)
             {
-                error("'switch' skips declaration of 'with' temporary at %s", vd.loc.toChars());
+                deprecation("'switch' skips declaration of 'with' temporary at %s", vd.loc.toChars());
                 return true;
             }
             else
             {
-                error("'switch' skips declaration of variable %s at %s", vd.toPrettyChars(), vd.loc.toChars());
+                deprecation("'switch' skips declaration of variable %s at %s", vd.toPrettyChars(), vd.loc.toChars());
                 return true;
             }
 
             return false;
         }
 
+        enum error = true;
+
         if (sdefault && checkVar(sdefault.lastVar))
-            return true;
+            return !error; // return error once fully deprecated
 
         foreach (scase; *cases)
         {
             if (scase && checkVar(scase.lastVar))
-                return true;
+                return !error; // return error once fully deprecated
         }
-        return false;
+        return !error;
     }
 
     override void accept(Visitor v)

--- a/test/fail_compilation/skip.d
+++ b/test/fail_compilation/skip.d
@@ -1,8 +1,9 @@
 /*
+ * REQUIRED_ARGS: -de
  * TEST_OUTPUT:
 ---
-fail_compilation/skip.d(20): Error: 'switch' skips declaration of 'with' temporary at fail_compilation/skip.d(25)
-fail_compilation/skip.d(42): Error: 'switch' skips declaration of variable skip.test14532.n at fail_compilation/skip.d(44)
+fail_compilation/skip.d(21): Deprecation: 'switch' skips declaration of 'with' temporary at fail_compilation/skip.d(26)
+fail_compilation/skip.d(43): Deprecation: 'switch' skips declaration of variable skip.test14532.n at fail_compilation/skip.d(45)
 ---
  */
 // https://issues.dlang.org/show_bug.cgi?id=10524
@@ -49,5 +50,3 @@ void test14532()
       default:
     }
 }
-
-


### PR DESCRIPTION
- replace intended diagnostic error with deprecation
- checks should be improved to detect actual variable usage
