### PR TITLE
fix Issue 16188 - [REG2.069] ICE on invalid code

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -660,19 +660,22 @@ public:
             type = null;
             aliassym = s;
         }
+        inuse = 0;
         if (global.gag && errors != global.errors)
         {
             type = oldtype;
             aliassym = null;
         }
-        inuse = 0;
-        semanticRun = PASSsemanticdone;
-
-        if (auto sx = overnext)
+        else
         {
-            overnext = null;
-            if (!overloadInsert(sx))
-                ScopeDsymbol.multiplyDefined(Loc(), sx, this);
+            semanticRun = PASSsemanticdone;
+
+            if (auto sx = overnext)
+            {
+                overnext = null;
+                if (!overloadInsert(sx))
+                    ScopeDsymbol.multiplyDefined(Loc(), sx, this);
+            }
         }
     }
 

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -660,22 +660,19 @@ public:
             type = null;
             aliassym = s;
         }
-        inuse = 0;
         if (global.gag && errors != global.errors)
         {
             type = oldtype;
             aliassym = null;
         }
-        else
-        {
-            semanticRun = PASSsemanticdone;
+        inuse = 0;
+        semanticRun = PASSsemanticdone;
 
-            if (auto sx = overnext)
-            {
-                overnext = null;
-                if (!overloadInsert(sx))
-                    ScopeDsymbol.multiplyDefined(Loc(), sx, this);
-            }
+        if (auto sx = overnext)
+        {
+            overnext = null;
+            if (!overloadInsert(sx))
+                ScopeDsymbol.multiplyDefined(Loc(), sx, this);
         }
     }
 

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -7537,9 +7537,17 @@ public:
          */
         Scope* sc2 = sc.push();
         sc2.intypeof = 1;
-        exp = exp.semantic(sc2);
-        exp = resolvePropertiesOnly(sc2, exp);
+        auto exp2 = exp.semantic(sc2);
+        exp2 = resolvePropertiesOnly(sc2, exp2);
         sc2.pop();
+
+        if (exp2.op == TOKerror)
+        {
+            if (!global.gag)
+                exp = exp2;
+            goto Lerr;
+        }
+        exp = exp2;
 
         if (exp.op == TOKtype ||
             exp.op == TOKscope)

--- a/test/fail_compilation/test16188.d
+++ b/test/fail_compilation/test16188.d
@@ -1,0 +1,25 @@
+/* PERMUTE_ARGS:
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=16188
+
+/* This produces the message:
+ *   Error: no property 'name' for type 'Where'
+ * when the actual error is 'getMember is undefined'.
+ * This happens because errors are gagged when opDispatch() is compiled,
+ * I don't understand why.
+ */
+
+void where() { Where().name; }
+
+struct Where
+{
+    void opDispatch(string name)()
+    {
+        alias FieldType = typeof(getMember);
+        WhereField!FieldType;
+    }
+}
+
+struct WhereField(FieldType) {}
+


### PR DESCRIPTION
For the second commit:

I assume it was an attempt at showing the correct error
message during opDispatch semantics (by rerunning semantic).
But as we still get the wrong error message and this change
isn't necessary to fix 16188, we better not merge it into stable.
