### PR TITLE
VC-x64: fix FPU exceptions not detected for reals at compile time

### DIFF
--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -92,12 +92,13 @@ extern void error(const char *filename, unsigned linnum, unsigned charnum, const
 
     static int testFE()
     {
-        return _status87() & 0x3F;
+        return (ld_statusfpu() | _statusfp()) & 0x3F;
     }
 
     static void clearFE()
     {
-        _clear87();
+        _clearfp();
+        ld_clearfpu();
     }
 #else
     #define HAVE_FLOAT_EXCEPT 0

--- a/src/root/longdouble.c
+++ b/src/root/longdouble.c
@@ -131,6 +131,24 @@ unsigned long long ld_readull(const longdouble* pthis)
 }
 
 #ifndef _WIN64
+int ld_statusfpu()
+{
+    int res = 0;
+    __asm
+    {
+        fstsw word ptr [res];
+    }
+    return res;
+}
+
+void ld_clearfpu()
+{
+    __asm
+    {
+        fclex
+    }
+}
+
 void ld_set(longdouble* pthis, double d)
 {
     __asm

--- a/src/root/longdouble.h
+++ b/src/root/longdouble.h
@@ -64,6 +64,8 @@ extern "C"
     void ld_set(longdouble* ld, double d);
     void ld_setll(longdouble* ld, long long d);
     void ld_setull(longdouble* ld, unsigned long long d);
+    int ld_statusfpu();
+    void ld_clearfpu();
 }
 
 #pragma pack(push, 1)

--- a/src/vcbuild/ldfpu.asm
+++ b/src/vcbuild/ldfpu.asm
@@ -357,4 +357,19 @@ ld_initfpu PROC
 	ret
 ld_initfpu ENDP
 
+; int ld_statusfpu()
+ld_statusfpu PROC
+	push    rcx
+	fstsw   word ptr [rsp]
+	movzx   EAX,word ptr [rsp]
+	pop     rcx
+	ret
+ld_statusfpu ENDP
+
+; void ld_clearfpu()
+ld_clearfpu PROC
+	fclex
+	ret
+ld_clearfpu ENDP
+
 end


### PR DESCRIPTION
For some time, the unittest in std.math at https://github.com/dlang/phobos/blob/master/std/math.d#L4551 is failing for me. This is happening because I'm using the 64-bit build of dmd on Windows.

For x64 `_status87()` and `statusfp()` only return the SSE exception status, not the FPU status.
