### PR TITLE
refactor: safe interface to scan*ObjModule()

### DIFF
--- a/src/libelf.d
+++ b/src/libelf.d
@@ -354,7 +354,7 @@ extern (C++) final class LibElf : Library
         writeFile(Loc(), libfile);
     }
 
-    void addSymbol(ElfObjModule* om, char* name, int pickAny = 0)
+    void addSymbol(ElfObjModule* om, const(char)* name, int pickAny = 0)
     {
         static if (LOG)
         {
@@ -394,12 +394,12 @@ private:
             printf("LibElf::scanObjModule(%s)\n", om.name);
         }
 
-        void addSymbol(char* name, int pickAny)
+        void addSymbol(const(char)* name, int pickAny)
         {
             this.addSymbol(om, name, pickAny);
         }
 
-        scanElfObjModule(&addSymbol, om.base, om.length, om.name, loc);
+        scanElfObjModule(&addSymbol, om.base[0 .. om.length], om.name, loc);
     }
 
     /*****************************************************************************/

--- a/src/libmach.d
+++ b/src/libmach.d
@@ -298,7 +298,7 @@ extern (C++) final class LibMach : Library
         writeFile(Loc(), libfile);
     }
 
-    void addSymbol(MachObjModule* om, char* name, int pickAny = 0)
+    void addSymbol(MachObjModule* om, const(char)* name, int pickAny = 0)
     {
         static if (LOG)
         {
@@ -349,12 +349,12 @@ private:
             printf("LibMach::scanObjModule(%s)\n", om.name);
         }
 
-        void addSymbol(char* name, int pickAny)
+        void addSymbol(const(char)* name, int pickAny)
         {
             this.addSymbol(om, name, pickAny);
         }
 
-        scanMachObjModule(&addSymbol, om.base, om.length, om.name, loc);
+        scanMachObjModule(&addSymbol, om.base[0 .. om.length], om.name, loc);
     }
 
     /*****************************************************************************/

--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -423,7 +423,7 @@ extern (C++) final class LibMSCoff : Library
         writeFile(Loc(), libfile);
     }
 
-    void addSymbol(MSCoffObjModule* om, char* name, int pickAny = 0)
+    void addSymbol(MSCoffObjModule* om, const(char)* name, int pickAny = 0)
     {
         static if (LOG)
         {
@@ -447,12 +447,12 @@ private:
             printf("LibMSCoff::scanObjModule(%s)\n", om.name);
         }
 
-        void addSymbol(char* name, int pickAny)
+        void addSymbol(const(char)* name, int pickAny)
         {
             this.addSymbol(om, name, pickAny);
         }
 
-        scanMSCoffObjModule(&addSymbol, om.base, om.length, om.name, loc);
+        scanMSCoffObjModule(&addSymbol, om.base[0 .. om.length], om.name, loc);
     }
 
     /*****************************************************************************/

--- a/src/libomf.d
+++ b/src/libomf.d
@@ -246,7 +246,7 @@ private:
             this.addSymbol(om, name, pickAny);
         }
 
-        scanOmfObjModule(&addSymbol, om.base, om.length, om.name, loc);
+        scanOmfObjModule(&addSymbol, om.base[0 .. om.length], om.name, loc);
     }
 
     /***********************************

--- a/src/scanelf.d
+++ b/src/scanelf.d
@@ -25,21 +25,23 @@ enum LOG = false;
 extern (C++) __gshared char* elf = [0x7F, 'E', 'L', 'F']; // ELF file signature
 
 /*****************************************
- * Reads an object module from base[0..buflen] and passes the names
+ * Reads an object module from base[] and passes the names
  * of any exported symbols to (*pAddSymbol)().
- * Input:
- *      pAddSymbol      function to pass the names to
- *      base[0..buflen] contains contents of object module
- *      module_name     name of the object module (used for error messages)
- *      loc             location to use for error printing
+ * Params:
+ *      pAddSymbol =  function to pass the names to
+ *      base =        array of contents of object module
+ *      module_name = name of the object module (used for error messages)
+ *      loc =         location to use for error printing
  */
-void scanElfObjModule(void delegate(char* name, int pickAny) pAddSymbol, void* base, size_t buflen, const(char)* module_name, Loc loc)
+void scanElfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
+        const(ubyte)[] base, const(char)* module_name, Loc loc)
 {
     static if (LOG)
     {
         printf("scanElfObjModule(%s)\n", module_name);
     }
-    ubyte* buf = cast(ubyte*)base;
+    const buf = base.ptr;
+    const buflen = base.length;
     int reason = 0;
     if (buflen < Elf32_Ehdr.sizeof)
     {

--- a/src/scanmach.d
+++ b/src/scanmach.d
@@ -17,21 +17,23 @@ import ddmd.errors;
 enum LOG = false;
 
 /*****************************************
- * Reads an object module from base[0..buflen] and passes the names
+ * Reads an object module from base[] and passes the names
  * of any exported symbols to (*pAddSymbol)().
- * Input:
- *      pAddSymbol      function to pass the names to
- *      base[0..buflen] contains contents of object module
- *      module_name     name of the object module (used for error messages)
- *      loc             location to use for error printing
+ * Params:
+ *      pAddSymbol =  function to pass the names to
+ *      base =        array of contents of object module
+ *      module_name = name of the object module (used for error messages)
+ *      loc =         location to use for error printing
  */
-void scanMachObjModule(void delegate(char* name, int pickAny) pAddSymbol, void* base, size_t buflen, const(char)* module_name, Loc loc)
+void scanMachObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
+        const(ubyte)[] base, const(char)* module_name, Loc loc)
 {
     static if (LOG)
     {
         printf("scanMachObjModule(%s)\n", module_name);
     }
-    ubyte* buf = cast(ubyte*)base;
+    const buf = base.ptr;
+    const buflen = base.length;
     int reason = 0;
     uint32_t ncmds;
     mach_header* header = cast(mach_header*)buf;

--- a/src/scanmscoff.d
+++ b/src/scanmscoff.d
@@ -14,21 +14,23 @@ import ddmd.globals, ddmd.errors;
 enum LOG = false;
 
 /*****************************************
- * Reads an object module from base[0..buflen] and passes the names
+ * Reads an object module from base[] and passes the names
  * of any exported symbols to (*pAddSymbol)().
- * Input:
- *      pAddSymbol      function to pass the names to
- *      base[0..buflen] contains contents of object module
- *      module_name     name of the object module (used for error messages)
- *      loc             location to use for error printing
+ * Params:
+ *      pAddSymbol =  function to pass the names to
+ *      base =        array of contents of object module
+ *      module_name = name of the object module (used for error messages)
+ *      loc =         location to use for error printing
  */
-void scanMSCoffObjModule(void delegate(char* name, int pickAny) pAddSymbol, void* base, size_t buflen, const(char)* module_name, Loc loc)
+void scanMSCoffObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
+        const(ubyte)[] base, const(char)* module_name, Loc loc)
 {
     static if (LOG)
     {
         printf("scanMSCoffObjModule(%s)\n", module_name);
     }
-    ubyte* buf = cast(ubyte*)base;
+    const buf = base.ptr;
+    const buflen = base.length;
     int reason;
     /* First do sanity checks on object file
      */

--- a/src/scanomf.d
+++ b/src/scanomf.d
@@ -130,30 +130,32 @@ extern (C++) static void skipDataType(const(ubyte)** pp)
 }
 
 /*****************************************
- * Reads an object module from base[0..buflen] and passes the names
+ * Reads an object module from base[] and passes the names
  * of any exported symbols to (*pAddSymbol)().
- * Input:
- *      pctx            context pointer, pass to *pAddSymbol
- *      pAddSymbol      function to pass the names to
- *      base[0..buflen] contains contents of object module
- *      module_name     name of the object module (used for error messages)
- *      loc             location to use for error printing
+ * Params:
+ *      pAddSymbol =  function to pass the names to
+ *      base =        array of contents of object module
+ *      module_name = name of the object module (used for error messages)
+ *      loc =         location to use for error printing
  */
-void scanOmfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol, void* base, size_t buflen, const(char)* module_name, Loc loc)
+void scanOmfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
+        const(ubyte)[] base, const(char)* module_name, Loc loc)
 {
     static if (LOG)
     {
-        printf("scanMSCoffObjModule(%s)\n", module_name);
+        printf("scanOmfObjModule(%s)\n", module_name);
     }
+    const buf = base.ptr;
+    const buflen = base.length;
     int easyomf;
     ubyte result = 0;
     char[LIBIDMAX + 1] name;
     Strings names;
     names.push(null); // don't use index 0
     easyomf = 0; // assume not EASY-OMF
-    auto pend = cast(const(ubyte)*)base + buflen;
+    auto pend = cast(const(ubyte)*)base.ptr + buflen;
     const(ubyte)* pnext;
-    for (auto p = cast(const(ubyte)*)base; 1; p = pnext)
+    for (auto p = cast(const(ubyte)*)base.ptr; 1; p = pnext)
     {
         assert(p < pend);
         ubyte recTyp = *p++;


### PR DESCRIPTION
Change unsafe interface to scan*ObjModule() functions to a safe one.
