### PR TITLE
refactor: scanelf to using arrays for names

### DIFF
--- a/src/libelf.d
+++ b/src/libelf.d
@@ -396,9 +396,9 @@ private:
             printf("LibElf::scanObjModule(%s)\n", om.name);
         }
 
-        void addSymbol(const(char)* name, int pickAny)
+        extern (D) void addSymbol(const(char)[] name, int pickAny)
         {
-            this.addSymbol(om, name, pickAny);
+            this.addSymbol(om, name.ptr, pickAny);
         }
 
         scanElfObjModule(&addSymbol, om.base[0 .. om.length], om.name, loc);

--- a/src/libmach.d
+++ b/src/libmach.d
@@ -351,9 +351,9 @@ private:
             printf("LibMach::scanObjModule(%s)\n", om.name);
         }
 
-        void addSymbol(const(char)* name, int pickAny)
+        extern (D) void addSymbol(const(char)[] name, int pickAny)
         {
-            this.addSymbol(om, name, pickAny);
+            this.addSymbol(om, name.ptr, pickAny);
         }
 
         scanMachObjModule(&addSymbol, om.base[0 .. om.length], om.name, loc);

--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -449,9 +449,9 @@ private:
             printf("LibMSCoff::scanObjModule(%s)\n", om.name);
         }
 
-        void addSymbol(const(char)* name, int pickAny)
+        extern (D) void addSymbol(const(char)[] name, int pickAny)
         {
-            this.addSymbol(om, name, pickAny);
+            this.addSymbol(om, name.ptr, pickAny);
         }
 
         scanMSCoffObjModule(&addSymbol, om.base[0 .. om.length], om.name, loc);

--- a/src/libomf.d
+++ b/src/libomf.d
@@ -239,9 +239,9 @@ private:
             printf("LibMSCoff::scanObjModule(%s)\n", om.name);
         }
 
-        void addSymbol(const(char)* name, int pickAny)
+        extern (D) void addSymbol(const(char)[] name, int pickAny)
         {
-            this.addSymbol(om, name, pickAny);
+            this.addSymbol(om, name.ptr, pickAny);
         }
 
         scanOmfObjModule(&addSymbol, om.base[0 .. om.length], om.name, loc);

--- a/src/scanmach.d
+++ b/src/scanmach.d
@@ -27,7 +27,7 @@ enum LOG = false;
  *      module_name = name of the object module (used for error messages)
  *      loc =         location to use for error printing
  */
-void scanMachObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
+void scanMachObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol,
         const(ubyte)[] base, const(char)* module_name, Loc loc)
 {
     static if (LOG)
@@ -146,7 +146,8 @@ void scanMachObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
             for (int i = 0; i < symtab_commands.nsyms; i++)
             {
                 nlist_64* s = symtab + i;
-                char* name = strtab + s.n_strx;
+                const(char)* name = strtab + s.n_strx;
+                const namelen = strlen(name);
                 if (s.n_type & N_STAB)
                 {
                     // values in /usr/include/mach-o/stab.h
@@ -167,13 +168,13 @@ void scanMachObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
                     {
                     case N_UNDF:
                         if (s.n_type & N_EXT && s.n_value != 0) // comdef
-                            pAddSymbol(name, 1);
+                            pAddSymbol(name[0 .. namelen], 1);
                         break;
                     case N_ABS:
                         break;
                     case N_SECT:
                         if (s.n_type & N_EXT) /*&& !(s->n_desc & N_REF_TO_WEAK)*/
-                            pAddSymbol(name, 1);
+                            pAddSymbol(name[0 .. namelen], 1);
                         break;
                     case N_PBUD:
                         break;
@@ -198,7 +199,8 @@ void scanMachObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
             for (int i = 0; i < symtab_commands.nsyms; i++)
             {
                 nlist* s = symtab + i;
-                char* name = strtab + s.n_strx;
+                const(char)* name = strtab + s.n_strx;
+                const namelen = strlen(name);
                 if (s.n_type & N_STAB)
                 {
                     // values in /usr/include/mach-o/stab.h
@@ -219,13 +221,13 @@ void scanMachObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
                     {
                     case N_UNDF:
                         if (s.n_type & N_EXT && s.n_value != 0) // comdef
-                            pAddSymbol(name, 1);
+                            pAddSymbol(name[0 .. namelen], 1);
                         break;
                     case N_ABS:
                         break;
                     case N_SECT:
                         if (s.n_type & N_EXT) /*&& !(s->n_desc & N_REF_TO_WEAK)*/
-                            pAddSymbol(name, 1);
+                            pAddSymbol(name[0 .. namelen], 1);
                         break;
                     case N_PBUD:
                         break;

--- a/src/scanmscoff.d
+++ b/src/scanmscoff.d
@@ -24,7 +24,7 @@ enum LOG = false;
  *      module_name = name of the object module (used for error messages)
  *      loc =         location to use for error printing
  */
-void scanMSCoffObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
+void scanMSCoffObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol,
         const(ubyte)[] base, const(char)* module_name, Loc loc)
 {
     static if (LOG)
@@ -173,7 +173,7 @@ void scanMSCoffObjModule(void delegate(const(char)* name, int pickAny) pAddSymbo
         default:
             continue;
         }
-        pAddSymbol(p, 1);
+        pAddSymbol(p[0 .. strlen(p)], 1);
     }
 }
 

--- a/src/scanomf.d
+++ b/src/scanomf.d
@@ -140,7 +140,7 @@ extern (C++) static void skipDataType(const(ubyte)** pp)
  *      module_name = name of the object module (used for error messages)
  *      loc =         location to use for error printing
  */
-void scanOmfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
+void scanOmfObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol,
         const(ubyte)[] base, const(char)* module_name, Loc loc)
 {
     static if (LOG)
@@ -187,7 +187,7 @@ void scanOmfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
                 parseName(&p, name.ptr);
                 p += (recTyp == PUBDEF) ? 2 : 4; // skip offset
                 parseIdx(&p); // skip type index
-                pAddSymbol(name.ptr, 0);
+                pAddSymbol(name[0 .. strlen(name.ptr)], 0);
             }
             break;
         case COMDAT:
@@ -220,7 +220,8 @@ void scanOmfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
                     return;
                 }
                 //printf("[s] name='%s'\n",name);
-                pAddSymbol(names[idx], pickAny);
+                const(char)* n = names[idx];
+                pAddSymbol(n[0 .. strlen(name.ptr)], pickAny);
                 break;
             }
         case COMDEF:
@@ -230,7 +231,7 @@ void scanOmfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
                     parseName(&p, name.ptr);
                     parseIdx(&p); // type index
                     skipDataType(&p); // data type
-                    pAddSymbol(name.ptr, 1);
+                    pAddSymbol(name[0 .. strlen(name.ptr)], 1);
                 }
                 break;
             }
@@ -238,7 +239,7 @@ void scanOmfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
             while (p + 1 < pnext)
             {
                 parseName(&p, name.ptr);
-                pAddSymbol(name.ptr, 0);
+                pAddSymbol(name[0 .. strlen(name.ptr)], 0);
                 parseName(&p, name.ptr);
             }
             break;
@@ -271,7 +272,7 @@ void scanOmfObjModule(void delegate(const(char)* name, int pickAny) pAddSymbol,
                             goto L2;
                     p++; // skip OrdFlag field
                     parseName(&p, name.ptr);
-                    pAddSymbol(name.ptr, 0);
+                    pAddSymbol(name[0 .. strlen(name.ptr)], 0);
                     break;
                 L2:
                 }


### PR DESCRIPTION
The purpose of this is to move the code incrementally towards being @safe 

Also, currently a corrupt object or lib file can crash dmd. Moving towards fixing this.
