### PR TITLE
Add commonly used constant real_t values to CTFloat

### DIFF
--- a/src/complex.d
+++ b/src/complex.d
@@ -21,7 +21,7 @@ struct complex_t
 
     this(real_t re)
     {
-        this(re, real_t(0));
+        this(re, CTFloat.zero);
     }
 
     this(real_t re, real_t im)

--- a/src/constfold.d
+++ b/src/constfold.d
@@ -132,13 +132,13 @@ extern (C++) UnionExp Add(Loc loc, Type type, Expression e1, Expression e2)
     {
         // This rigamarole is necessary so that -0.0 doesn't get
         // converted to +0.0 by doing an extraneous add with +0.0
-        auto c1 = complex_t(real_t(0));
+        auto c1 = complex_t(CTFloat.zero);
         real_t r1 = 0;
         real_t i1 = 0;
-        auto c2 = complex_t(real_t(0));
+        auto c2 = complex_t(CTFloat.zero);
         real_t r2 = 0;
         real_t i2 = 0;
-        auto v = complex_t(real_t(0));
+        auto v = complex_t(CTFloat.zero);
         int x;
         if (e1.type.isreal())
         {
@@ -184,7 +184,7 @@ extern (C++) UnionExp Add(Loc loc, Type type, Expression e1, Expression e2)
             v = complex_t(r2, i1);
             break;
         case 3 + 1:
-            v = complex_t(real_t(0), i1 + i2);
+            v = complex_t(CTFloat.zero, i1 + i2);
             break;
         case 3 + 2:
             v = complex_t(creall(c2), i1 + cimagl(c2));
@@ -235,13 +235,13 @@ extern (C++) UnionExp Min(Loc loc, Type type, Expression e1, Expression e2)
     {
         // This rigamarole is necessary so that -0.0 doesn't get
         // converted to +0.0 by doing an extraneous add with +0.0
-        auto c1 = complex_t(real_t(0));
+        auto c1 = complex_t(CTFloat.zero);
         real_t r1 = 0;
         real_t i1 = 0;
-        auto c2 = complex_t(real_t(0));
+        auto c2 = complex_t(CTFloat.zero);
         real_t r2 = 0;
         real_t i2 = 0;
-        auto v = complex_t(real_t(0));
+        auto v = complex_t(CTFloat.zero);
         int x;
         if (e1.type.isreal())
         {
@@ -287,7 +287,7 @@ extern (C++) UnionExp Min(Loc loc, Type type, Expression e1, Expression e2)
             v = complex_t(-r2, i1);
             break;
         case 3 + 1:
-            v = complex_t(real_t(0), i1 - i2);
+            v = complex_t(CTFloat.zero, i1 - i2);
             break;
         case 3 + 2:
             v = complex_t(-creall(c2), i1 - cimagl(c2));
@@ -324,7 +324,7 @@ extern (C++) UnionExp Mul(Loc loc, Type type, Expression e1, Expression e2)
     UnionExp ue;
     if (type.isfloating())
     {
-        auto c = complex_t(real_t(0));
+        auto c = complex_t(CTFloat.zero);
         real_t r = 0;
         if (e1.type.isreal())
         {
@@ -373,7 +373,7 @@ extern (C++) UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
     UnionExp ue;
     if (type.isfloating())
     {
-        auto c = complex_t(real_t(0));
+        auto c = complex_t(CTFloat.zero);
         //e1->type->print();
         //e2->type->print();
         if (e2.type.isreal())
@@ -447,7 +447,7 @@ extern (C++) UnionExp Mod(Loc loc, Type type, Expression e1, Expression e2)
     UnionExp ue;
     if (type.isfloating())
     {
-        auto c = complex_t(real_t(0));
+        auto c = complex_t(CTFloat.zero);
         if (e2.type.isreal())
         {
             const r2 = e2.toReal();
@@ -529,12 +529,12 @@ extern (C++) UnionExp Pow(Loc loc, Type type, Expression e1, Expression e2)
         if (e1.type.iscomplex())
         {
             emplaceExp!(ComplexExp)(&ur, loc, e1.toComplex(), e1.type);
-            emplaceExp!(ComplexExp)(&uv, loc, complex_t(real_t(1)), e1.type);
+            emplaceExp!(ComplexExp)(&uv, loc, complex_t(CTFloat.one), e1.type);
         }
         else if (e1.type.isfloating())
         {
             emplaceExp!(RealExp)(&ur, loc, e1.toReal(), e1.type);
-            emplaceExp!(RealExp)(&uv, loc, real_t(1), e1.type);
+            emplaceExp!(RealExp)(&uv, loc, CTFloat.one, e1.type);
         }
         else
         {
@@ -558,7 +558,7 @@ extern (C++) UnionExp Pow(Loc loc, Type type, Expression e1, Expression e2)
         {
             // ue = 1.0 / v
             UnionExp one;
-            emplaceExp!(RealExp)(&one, loc, real_t(1), v.type);
+            emplaceExp!(RealExp)(&one, loc, CTFloat.one, v.type);
             uv = Div(loc, v.type, one.exp(), v);
         }
         if (type.iscomplex())
@@ -571,7 +571,7 @@ extern (C++) UnionExp Pow(Loc loc, Type type, Expression e1, Expression e2)
     else if (e2.type.isfloating())
     {
         // x ^^ y for x < 0 and y not an integer is not defined; so set result as NaN
-        if (e1.toReal() < real_t(0))
+        if (e1.toReal() < CTFloat.zero)
         {
             emplaceExp!(RealExp)(&ue, loc, Target.RealProperties.nan, type);
         }

--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -669,7 +669,7 @@ public:
         if (CTFloat.isNaN(value))
             buf.writestring("NAN"); // no -NAN bugs
         else if (CTFloat.isInfinity(value))
-            buf.writestring(value < real_t(0) ? "NINF" : "INF");
+            buf.writestring(value < CTFloat.zero ? "NINF" : "INF");
         else
         {
             enum BUFFER_LEN = 36;

--- a/src/expression.d
+++ b/src/expression.d
@@ -2776,19 +2776,19 @@ extern (C++) abstract class Expression : RootObject
     real_t toReal()
     {
         error("floating point constant expression expected instead of %s", toChars());
-        return real_t(0);
+        return CTFloat.zero;
     }
 
     real_t toImaginary()
     {
         error("floating point constant expression expected instead of %s", toChars());
-        return real_t(0);
+        return CTFloat.zero;
     }
 
     complex_t toComplex()
     {
         error("floating point constant expression expected instead of %s", toChars());
-        return complex_t(real_t(0));
+        return complex_t(CTFloat.zero);
     }
 
     StringExp toStringExp()
@@ -3556,7 +3556,7 @@ extern (C++) final class IntegerExp : Expression
 
     override real_t toImaginary()
     {
-        return real_t(0);
+        return CTFloat.zero;
     }
 
     override complex_t toComplex()
@@ -3732,12 +3732,12 @@ extern (C++) final class RealExp : Expression
 
     override real_t toReal()
     {
-        return type.isreal() ? value : real_t(0);
+        return type.isreal() ? value : CTFloat.zero;
     }
 
     override real_t toImaginary()
     {
-        return type.isreal() ? real_t(0) : value;
+        return type.isreal() ? CTFloat.zero : value;
     }
 
     override complex_t toComplex()
@@ -8030,7 +8030,7 @@ extern (C++) abstract class BinExp : Expression
                 {
                     // x/iv = i(-x/v)
                     // Therefore, the result is 0
-                    e2 = new CommaExp(loc, e2, new RealExp(loc, real_t(0), t1));
+                    e2 = new CommaExp(loc, e2, new RealExp(loc, CTFloat.zero, t1));
                     e2.type = t1;
                     Expression e = new AssignExp(loc, e1, e2);
                     e.type = t1;
@@ -14774,7 +14774,7 @@ extern (C++) final class PowExp : BinExp
         }
         e = new ScopeExp(loc, mmath);
 
-        if (e2.op == TOKfloat64 && e2.toReal() == real_t(0.5))
+        if (e2.op == TOKfloat64 && e2.toReal() == CTFloat.half)
         {
             // Replace e1 ^^ 0.5 with .std.math.sqrt(x)
             e = new CallExp(loc, new DotIdExp(loc, e, Id._sqrt), e1);

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -4031,7 +4031,7 @@ extern (C++) final class TypeBasic : Type
                 t = tfloat80;
                 goto L2;
             L2:
-                e = new RealExp(e.loc, real_t(0), t);
+                e = new RealExp(e.loc, CTFloat.zero, t);
                 break;
 
             default:
@@ -4082,7 +4082,7 @@ extern (C++) final class TypeBasic : Type
             case Tfloat32:
             case Tfloat64:
             case Tfloat80:
-                e = new RealExp(e.loc, real_t(0), this);
+                e = new RealExp(e.loc, CTFloat.zero, this);
                 break;
 
             default:

--- a/src/optimize.d
+++ b/src/optimize.d
@@ -748,7 +748,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             if (binOptimize(e, result))
                 return;
             // Replace 1 ^^ x or 1.0^^x by (x, 1)
-            if ((e.e1.op == TOKint64 && e.e1.toInteger() == 1) || (e.e1.op == TOKfloat64 && e.e1.toReal() == real_t(1)))
+            if ((e.e1.op == TOKint64 && e.e1.toInteger() == 1) || (e.e1.op == TOKfloat64 && e.e1.toReal() == CTFloat.one))
             {
                 ret = new CommaExp(e.loc, e.e2, e.e1);
                 return;
@@ -762,25 +762,25 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 return;
             }
             // Replace x ^^ 0 or x^^0.0 by (x, 1)
-            if ((e.e2.op == TOKint64 && e.e2.toInteger() == 0) || (e.e2.op == TOKfloat64 && e.e2.toReal() == real_t(0)))
+            if ((e.e2.op == TOKint64 && e.e2.toInteger() == 0) || (e.e2.op == TOKfloat64 && e.e2.toReal() == CTFloat.zero))
             {
                 if (e.e1.type.isintegral())
                     ret = new IntegerExp(e.loc, 1, e.e1.type);
                 else
-                    ret = new RealExp(e.loc, real_t(1), e.e1.type);
+                    ret = new RealExp(e.loc, CTFloat.one, e.e1.type);
                 ret = new CommaExp(e.loc, e.e1, ret);
                 return;
             }
             // Replace x ^^ 1 or x^^1.0 by (x)
-            if ((e.e2.op == TOKint64 && e.e2.toInteger() == 1) || (e.e2.op == TOKfloat64 && e.e2.toReal() == real_t(1)))
+            if ((e.e2.op == TOKint64 && e.e2.toInteger() == 1) || (e.e2.op == TOKfloat64 && e.e2.toReal() == CTFloat.one))
             {
                 ret = e.e1;
                 return;
             }
             // Replace x ^^ -1.0 by (1.0 / x)
-            if ((e.e2.op == TOKfloat64 && e.e2.toReal() == real_t(-1)))
+            if (e.e2.op == TOKfloat64 && e.e2.toReal() == CTFloat.minusone)
             {
-                ret = new DivExp(e.loc, new RealExp(e.loc, real_t(1), e.e2.type), e.e1);
+                ret = new DivExp(e.loc, new RealExp(e.loc, CTFloat.one, e.e2.type), e.e1);
                 return;
             }
             // All other negative integral powers are illegal

--- a/src/root/ctfloat.d
+++ b/src/root/ctfloat.d
@@ -130,4 +130,10 @@ extern (C++) struct CTFloat
             }
         }
     }
+
+    // Constant real values 0, 1, -1 and 0.5.
+    static __gshared real_t zero = real_t(0);
+    static __gshared real_t one = real_t(1);
+    static __gshared real_t minusone = real_t(-1);
+    static __gshared real_t half = real_t(0.5);
 }

--- a/src/root/ctfloat.h
+++ b/src/root/ctfloat.h
@@ -37,6 +37,12 @@ struct CTFloat
 
     static real_t parse(const char *literal, bool *isOutOfRange = NULL);
     static int sprint(char *str, char fmt, real_t x);
+
+    // Constant real values 0, 1, -1 and 0.5.
+    static real_t zero;
+    static real_t one;
+    static real_t minusone;
+    static real_t half;
 };
 
 #endif


### PR DESCRIPTION
Scattered around the place are `real_t(0)`, `real_t(1)`, `real_t(-1)`, and `real_t(0.5)`. As these are so common, they should instead be properties of CTFloat.

Having it in a cached constant would be better than running the heavy computation of converting from native every time it's used. Bonus motivation for GDC, all these numbers are readily available as constants in GCC's internal real implementation. :-)
