### PR TITLE
refactor: privatize functions in dtemplate.d

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -174,7 +174,7 @@ extern (C++) Dsymbol getDsymbol(RootObject oarg)
     return sa;
 }
 
-extern (C++) Expression getValue(ref Dsymbol s)
+private Expression getValue(ref Dsymbol s)
 {
     Expression e = null;
     if (s)
@@ -191,7 +191,7 @@ extern (C++) Expression getValue(ref Dsymbol s)
 /***********************
  * Try to get value from manifest constant
  */
-extern (C++) Expression getValue(Expression e)
+private Expression getValue(Expression e)
 {
     if (e && e.op == TOKvar)
     {
@@ -208,7 +208,7 @@ extern (C++) Expression getValue(Expression e)
  * If o1 matches o2, return true.
  * Else, return false.
  */
-extern (C++) bool match(RootObject o1, RootObject o2)
+private bool match(RootObject o1, RootObject o2)
 {
     static Expression getExpression(RootObject o)
     {
@@ -312,7 +312,7 @@ Lnomatch:
 /************************************
  * Match an array of them.
  */
-extern (C++) int arrayObjectMatch(Objects* oa1, Objects* oa2)
+private int arrayObjectMatch(Objects* oa1, Objects* oa2)
 {
     if (oa1 == oa2)
         return 1;
@@ -333,7 +333,7 @@ extern (C++) int arrayObjectMatch(Objects* oa1, Objects* oa2)
 /************************************
  * Return hash of Objects.
  */
-extern (C++) hash_t arrayObjectHash(Objects* oa1)
+private hash_t arrayObjectHash(Objects* oa1)
 {
     hash_t hash = 0;
     for (size_t j = 0; j < oa1.dim; j++)
@@ -369,7 +369,7 @@ extern (C++) hash_t arrayObjectHash(Objects* oa1)
     return hash;
 }
 
-extern (C++) RootObject objectSyntaxCopy(RootObject o)
+RootObject objectSyntaxCopy(RootObject o)
 {
     if (!o)
         return null;
@@ -2340,7 +2340,7 @@ extern (C++) final class TypeDeduced : Type
  *      tthis           if !NULL, the 'this' pointer argument
  *      fargs           arguments to function
  */
-extern (C++) void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiargs, Type tthis, Expressions* fargs)
+void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiargs, Type tthis, Expressions* fargs)
 {
     version (none)
     {
@@ -2835,7 +2835,7 @@ extern (C++) void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, 
  * Given an identifier, figure out which TemplateParameter it is.
  * Return IDX_NOTFOUND if not found.
  */
-extern (C++) size_t templateIdentifierLookup(Identifier id, TemplateParameters* parameters)
+private size_t templateIdentifierLookup(Identifier id, TemplateParameters* parameters)
 {
     for (size_t i = 0; i < parameters.dim; i++)
     {
@@ -2846,7 +2846,7 @@ extern (C++) size_t templateIdentifierLookup(Identifier id, TemplateParameters* 
     return IDX_NOTFOUND;
 }
 
-extern (C++) size_t templateParameterLookup(Type tparam, TemplateParameters* parameters)
+private size_t templateParameterLookup(Type tparam, TemplateParameters* parameters)
 {
     if (tparam.ty == Tident)
     {
@@ -2857,7 +2857,7 @@ extern (C++) size_t templateParameterLookup(Type tparam, TemplateParameters* par
     return IDX_NOTFOUND;
 }
 
-extern (C++) ubyte deduceWildHelper(Type t, Type* at, Type tparam)
+private ubyte deduceWildHelper(Type t, Type* at, Type tparam)
 {
     if ((tparam.mod & MODwild) == 0)
         return 0;
@@ -2916,7 +2916,7 @@ extern (C++) ubyte deduceWildHelper(Type t, Type* at, Type tparam)
     }
 }
 
-extern (C++) MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
+private MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
 {
     // 9*9 == 81 cases
 
@@ -3124,7 +3124,7 @@ extern (C++) MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
     }
 }
 
-extern (C++) __gshared Expression emptyArrayElement = null;
+__gshared Expression emptyArrayElement = null;
 
 /* These form the heart of template argument deduction.
  * Given 'this' being the type argument to the template instance,
@@ -3140,7 +3140,7 @@ extern (C++) __gshared Expression emptyArrayElement = null;
  * Output:
  *      dedtypes = [ int ]      // Array of Expression/Type's
  */
-extern (C++) MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm = null, size_t inferStart = 0)
+MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm = null, size_t inferStart = 0)
 {
     extern (C++) final class DeduceType : Visitor
     {
@@ -4574,7 +4574,7 @@ extern (C++) MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplatePara
  *      iStart      = Start index of tparams to limit the tested parameters. If it's
  *                    nonzero, tparams[0..iStart] will be excluded from the test target.
  */
-extern (C++) bool reliesOnTident(Type t, TemplateParameters* tparams = null, size_t iStart = 0)
+private bool reliesOnTident(Type t, TemplateParameters* tparams = null, size_t iStart = 0)
 {
     extern (C++) final class ReliesOnTident : Visitor
     {
@@ -5518,7 +5518,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
     }
 }
 
-extern (C++) RootObject aliasParameterSemantic(Loc loc, Scope* sc, RootObject o, TemplateParameters* parameters)
+private RootObject aliasParameterSemantic(Loc loc, Scope* sc, RootObject o, TemplateParameters* parameters)
 {
     if (o)
     {
@@ -8296,7 +8296,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
  * However, if those symbols leak to the actual code, compiler should remark
  * them as non-speculative to generate their code and link to the final executable.
  */
-extern (C++) void unSpeculative(Scope* sc, RootObject o)
+void unSpeculative(Scope* sc, RootObject o)
 {
     if (!o)
         return;
@@ -8357,7 +8357,7 @@ extern (C++) void unSpeculative(Scope* sc, RootObject o)
  * Return false if it might be an alias or tuple.
  * (Note that even in this case, it could still turn out to be a value).
  */
-extern (C++) bool definitelyValueParameter(Expression e)
+bool definitelyValueParameter(Expression e)
 {
     // None of these can be value parameters
     if (e.op == TOKtuple || e.op == TOKscope ||


### PR DESCRIPTION
Simply removes `extern (C++` and adds `private` where we can.
