### PR TITLE
[RFC] add annotationPtr fields to rootObject

### DIFF
--- a/src/root/object.h
+++ b/src/root/object.h
@@ -28,10 +28,9 @@ struct OutBuffer;
 class RootObject
 {
 public:
-    RootObject() { annotation1 = NULL; annotation2 = NULL; }
+    RootObject() { annotationPtr = NULL; }
 
-    void* annotation1;
-    void* annotation2;
+    void* annotationPtr;
 
     virtual bool equals(RootObject *o);
 

--- a/src/root/object.h
+++ b/src/root/object.h
@@ -28,7 +28,10 @@ struct OutBuffer;
 class RootObject
 {
 public:
-    RootObject() { }
+    RootObject() { annotation1 = NULL; annotation2 = NULL; }
+
+    void* annotation1;
+    void* annotation2;
 
     virtual bool equals(RootObject *o);
 

--- a/src/root/rootobject.d
+++ b/src/root/rootobject.d
@@ -18,8 +18,13 @@ import ddmd.root.outbuffer;
  */
 extern (C++) class RootObject
 {
+    void* annotation1;
+    void* annotation2;
+
     this()
     {
+        annotation1 = null;
+        annotation2 = null;
     }
 
     bool equals(RootObject o)

--- a/src/root/rootobject.d
+++ b/src/root/rootobject.d
@@ -18,13 +18,11 @@ import ddmd.root.outbuffer;
  */
 extern (C++) class RootObject
 {
-    void* annotation1;
-    void* annotation2;
+    void* annotationPtr;
 
     this()
     {
-        annotation1 = null;
-        annotation2 = null;
+        annotationPtr = null;
     }
 
     bool equals(RootObject o)


### PR DESCRIPTION
This PR adds the ability to attach custom information to every AST-Node (via void*).
By reserving space for them in the rootObject.

This change has no visible performance implications.
 And will be very handy for other backends.
As well as for my ctfe-engine. 
