### PR TITLE
Added __FILE_FULL_PATH__ special trait.

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -15885,9 +15885,9 @@ extern (C++) class DefaultInitExp : Expression
  */
 extern (C++) final class FileInitExp : DefaultInitExp
 {
-    extern (D) this(Loc loc)
+    extern (D) this(Loc loc, TOK tok)
     {
-        super(loc, TOKfile, __traits(classInstanceSize, FileInitExp));
+        super(loc, tok, __traits(classInstanceSize, FileInitExp));
     }
 
     override Expression semantic(Scope* sc)

--- a/src/module.h
+++ b/src/module.h
@@ -73,6 +73,7 @@ public:
     const char *arg;    // original argument name
     ModuleDeclaration *md; // if !NULL, the contents of the ModuleDeclaration declaration
     File *srcfile;      // input source file
+    const char* srcfilePath; // the path prefix to the srcfile if it applies
     File *objfile;      // output .obj file
     File *hdrfile;      // 'header' file
     File *docfile;      // output documentation file

--- a/src/tokens.d
+++ b/src/tokens.d
@@ -287,6 +287,7 @@ enum TOK : int
     TOKgshared,
     TOKline,
     TOKfile,
+    TOKfilefullpath,
     TOKmodulestring,
     TOKfuncstring,
     TOKprettyfunc,
@@ -533,6 +534,7 @@ alias TOKnothrow = TOK.TOKnothrow;
 alias TOKgshared = TOK.TOKgshared;
 alias TOKline = TOK.TOKline;
 alias TOKfile = TOK.TOKfile;
+alias TOKfilefullpath = TOK.TOKfilefullpath;
 alias TOKmodulestring = TOK.TOKmodulestring;
 alias TOKfuncstring = TOK.TOKfuncstring;
 alias TOKprettyfunc = TOK.TOKprettyfunc;
@@ -687,6 +689,7 @@ extern (C++) struct Token
         TOKvector: "__vector",
         TOKoverloadset: "__overloadset",
         TOKfile: "__FILE__",
+        TOKfilefullpath: "__FILE_FULL_PATH__",
         TOKline: "__LINE__",
         TOKmodulestring: "__MODULE__",
         TOKfuncstring: "__FUNCTION__",
@@ -1178,6 +1181,7 @@ private immutable TOK[] keywords =
     TOKvector,
     TOKoverloadset,
     TOKfile,
+    TOKfilefullpath,
     TOKline,
     TOKmodulestring,
     TOKfuncstring,

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -169,6 +169,7 @@ enum TOK
         TOKgshared,
         TOKline,
         TOKfile,
+        TOKfilefullpath,
         TOKmodulestring,
         TOKfuncstring,
         TOKprettyfunc,

--- a/test/compilable/line.d
+++ b/test/compilable/line.d
@@ -6,19 +6,25 @@ int #line 10
 x;
 
 static assert(__LINE__ == 12);
-version(Windows)
+version(Windows) {
     static assert(__FILE__ == "compilable\\line.d");
-else
+    static assert(__FILE_FULL_PATH__[1..3] == ":\\");
+} else {
     static assert(__FILE__ == "compilable/line.d");
+    static assert(__FILE_FULL_PATH__[0] == '/');
+}
+static assert(__FILE_FULL_PATH__[$-__FILE__.length..$] == __FILE__);
 
 #line 100 "newfile.d"
 
 static assert(__LINE__ == 101);
 static assert(__FILE__ == "newfile.d");
+static assert(__FILE_FULL_PATH__ == "newfile.d");
 
 # line 200
 
 static assert(__LINE__ == 201);
 static assert(__FILE__ == "newfile.d");
+static assert(__FILE_FULL_PATH__ == "newfile.d");
 
 


### PR DESCRIPTION
In order to facilitate better scripting capabilities, knowing the absolute location of the original D source file at runtime is very useful.  Batch scripts have this capability with the `%~dp0` and is a vital feature for many use cases.  With this pull request, you can use the `__FILE_FULL_PATH__` to insert a string with the source code's full path name.

https://issues.dlang.org/show_bug.cgi?id=16441
