### PR TITLE
Refactor: Move globals.params.{versionids,versionlevel} in VersionCondition

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -138,9 +138,6 @@ struct Param
     uint debuglevel;                    // debug level
     Array!(const(char)*)* debugids;     // debug identifiers
 
-    uint versionlevel;                  // version level
-    Array!(const(char)*)* versionids;   // version identifiers
-
     const(char)* defaultlibname;        // default library for non-debug builds
     const(char)* debuglibname;          // default library for debug builds
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -121,9 +121,6 @@ struct Param
     unsigned debuglevel;   // debug level
     Array<const char *> *debugids;     // debug identifiers
 
-    unsigned versionlevel; // version level
-    Array<const char *> *versionids;   // version identifiers
-
     const char *defaultlibname; // default library for non-debug builds
     const char *debuglibname;   // default library for debug builds
 


### PR DESCRIPTION
Those can be writen to via `setGlobalLevel` and `add[Predefined]GlobalIdent`,
so there is no reason to leave them in `global.params` where anyone can read
and write them and where there have to be C++-style array.
