### PR TITLE
refactor: escape.d

### DIFF
--- a/test/fail_compilation/fail1313a.d
+++ b/test/fail_compilation/fail1313a.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail1313a.d(13): Error: escaping reference to variable a
+fail_compilation/fail1313a.d(13): Error: escaping reference to local variable a
 ---
 */
 

--- a/test/fail_compilation/fail1313b.d
+++ b/test/fail_compilation/fail1313b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail1313b.d(13): Error: escaping reference to variable a
+fail_compilation/fail1313b.d(13): Error: escaping reference to local variable a
 ---
 */
 

--- a/test/fail_compilation/fail13902.d
+++ b/test/fail_compilation/fail13902.d
@@ -7,14 +7,14 @@ class C { int v; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(32): Error: escaping reference to local x
-fail_compilation/fail13902.d(33): Error: escaping reference to variable s1
-fail_compilation/fail13902.d(38): Error: escaping reference to local sa1
-fail_compilation/fail13902.d(39): Error: escaping reference to variable sa2
-fail_compilation/fail13902.d(40): Error: escaping reference to local x
-fail_compilation/fail13902.d(41): Error: escaping reference to local x
-fail_compilation/fail13902.d(42): Error: escaping reference to local x
-fail_compilation/fail13902.d(45): Error: escaping reference to local y
+fail_compilation/fail13902.d(32): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(33): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(38): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(39): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(40): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(41): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(42): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(45): Error: escaping reference to local variable y
 ---
 */
 int* testEscape1()
@@ -50,14 +50,14 @@ int* testEscape1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(75): Error: escaping reference to local x
-fail_compilation/fail13902.d(76): Error: escaping reference to variable s1
-fail_compilation/fail13902.d(81): Error: escaping reference to local sa1
-fail_compilation/fail13902.d(82): Error: escaping reference to variable sa2
-fail_compilation/fail13902.d(83): Error: escaping reference to local x
-fail_compilation/fail13902.d(84): Error: escaping reference to local x
-fail_compilation/fail13902.d(85): Error: escaping reference to local x
-fail_compilation/fail13902.d(88): Error: escaping reference to local y
+fail_compilation/fail13902.d(75): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(76): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(81): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(82): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(83): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(84): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(85): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(88): Error: escaping reference to local variable y
 ---
 */
 int* testEscape2(
@@ -128,15 +128,15 @@ int* testEscape3(
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(150): Error: escaping reference to variable sa1
-fail_compilation/fail13902.d(151): Error: escaping reference to variable sa1
-fail_compilation/fail13902.d(152): Error: escaping reference to variable sa1
-fail_compilation/fail13902.d(155): Error: escaping reference to variable sa2
-fail_compilation/fail13902.d(156): Error: escaping reference to variable sa2
-fail_compilation/fail13902.d(157): Error: escaping reference to variable sa2
-fail_compilation/fail13902.d(161): Error: escaping reference to variable s
-fail_compilation/fail13902.d(162): Error: escaping reference to variable s
-fail_compilation/fail13902.d(163): Error: escaping reference to variable s
+fail_compilation/fail13902.d(150): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(151): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(152): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(155): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(156): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(157): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(161): Error: escaping reference to local variable s
+fail_compilation/fail13902.d(162): Error: escaping reference to local variable s
+fail_compilation/fail13902.d(163): Error: escaping reference to local variable s
 fail_compilation/fail13902.d(166): Error: escaping reference to stack allocated value returned by makeSA()
 fail_compilation/fail13902.d(167): Error: escaping reference to stack allocated value returned by makeSA()
 fail_compilation/fail13902.d(168): Error: escaping reference to stack allocated value returned by makeSA()
@@ -178,14 +178,14 @@ int[] testEscape4(int[3] sa1)       // Bugzilla 9279
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(201): Error: escaping reference to variable x
-fail_compilation/fail13902.d(202): Error: escaping reference to variable s1
-fail_compilation/fail13902.d(206): Error: escaping reference to variable sa1
-fail_compilation/fail13902.d(207): Error: escaping reference to variable sa2
-fail_compilation/fail13902.d(208): Error: escaping reference to variable x
-fail_compilation/fail13902.d(209): Error: escaping reference to variable x
-fail_compilation/fail13902.d(210): Error: escaping reference to variable s1
-fail_compilation/fail13902.d(211): Error: escaping reference to variable s1
+fail_compilation/fail13902.d(201): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(202): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(206): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(207): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(208): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(209): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(210): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(211): Error: escaping reference to local variable s1
 ---
 */
 ref int testEscapeRef1()
@@ -217,14 +217,14 @@ ref int testEscapeRef1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(240): Error: escaping reference to variable x
-fail_compilation/fail13902.d(241): Error: escaping reference to variable s1
-fail_compilation/fail13902.d(245): Error: escaping reference to variable sa1
-fail_compilation/fail13902.d(246): Error: escaping reference to variable sa2
-fail_compilation/fail13902.d(247): Error: escaping reference to variable x
-fail_compilation/fail13902.d(248): Error: escaping reference to variable x
-fail_compilation/fail13902.d(249): Error: escaping reference to variable s1
-fail_compilation/fail13902.d(250): Error: escaping reference to variable s1
+fail_compilation/fail13902.d(240): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(241): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(245): Error: escaping reference to local variable sa1
+fail_compilation/fail13902.d(246): Error: escaping reference to local variable sa2
+fail_compilation/fail13902.d(247): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(248): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(249): Error: escaping reference to local variable s1
+fail_compilation/fail13902.d(250): Error: escaping reference to local variable s1
 ---
 */
 ref int testEscapeRef2(
@@ -287,8 +287,8 @@ ref int testEscapeRef2(
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(294): Error: escaping reference to local x
-fail_compilation/fail13902.d(295): Error: escaping reference to local x
+fail_compilation/fail13902.d(294): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(295): Error: escaping reference to local variable x
 ---
 */
 int*[]  testArrayLiteral1() { int x; return [&x]; }
@@ -297,8 +297,8 @@ int*[1] testArrayLiteral2() { int x; return [&x]; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(304): Error: escaping reference to local x
-fail_compilation/fail13902.d(305): Error: escaping reference to local x
+fail_compilation/fail13902.d(304): Error: escaping reference to local variable x
+fail_compilation/fail13902.d(305): Error: escaping reference to local variable x
 ---
 */
 S2  testStructLiteral1() { int x; return     S2(&x); }
@@ -307,8 +307,8 @@ S2* testStructLiteral2() { int x; return new S2(&x); }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(314): Error: escaping reference to variable sa
-fail_compilation/fail13902.d(315): Error: escaping reference to variable sa
+fail_compilation/fail13902.d(314): Error: escaping reference to local variable sa
+fail_compilation/fail13902.d(315): Error: escaping reference to local variable sa
 ---
 */
 int[] testSlice1() { int[3] sa; return sa[]; }
@@ -317,7 +317,7 @@ int[] testSlice2() { int[3] sa; int n; return sa[n..2][1..2]; }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(324): Error: escaping reference to variable vda
+fail_compilation/fail13902.d(324): Error: escaping reference to local variable vda
 fail_compilation/fail13902.d(325): Error: escaping reference to variadic parameter vda
 ---
 */
@@ -328,7 +328,7 @@ int[3]  testDynamicArrayVariadic3(int[] vda...) { return vda[0..3]; }   // no er
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13902.d(335): Error: escaping reference to variable vsa
+fail_compilation/fail13902.d(335): Error: escaping reference to local variable vsa
 fail_compilation/fail13902.d(336): Error: escaping reference to variadic parameter vsa
 ---
 */

--- a/test/fail_compilation/fail140.d
+++ b/test/fail_compilation/fail140.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail140.d(11): Error: escaping reference to variable string
+fail_compilation/fail140.d(11): Error: escaping reference to local variable string
 ---
 */
 

--- a/test/fail_compilation/fail141.d
+++ b/test/fail_compilation/fail141.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail141.d(11): Error: escaping reference to local string
+fail_compilation/fail141.d(11): Error: escaping reference to local variable string
 ---
 */
 

--- a/test/fail_compilation/retref.d
+++ b/test/fail_compilation/retref.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retref.d(31): Error: escaping reference to variable s
+fail_compilation/retref.d(31): Error: escaping reference to local variable s
 fail_compilation/retref.d(42): Error: retref.foo called with argument types (int) matches both:
 fail_compilation/retref.d(36):     retref.foo(ref int x)
 and:

--- a/test/fail_compilation/test15192.d
+++ b/test/fail_compilation/test15192.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -dip25
 TEST_OUTPUT:
 ---
-fail_compilation/test15192.d(14): Error: escaping reference to variable x
+fail_compilation/test15192.d(14): Error: escaping reference to outer local variable x
 ---
 */
 

--- a/test/fail_compilation/test15193.d
+++ b/test/fail_compilation/test15193.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -dip25
    TEST_OUTPUT:
 ---
-fail_compilation/test15193.d(17): Error: escaping reference to variable s
+fail_compilation/test15193.d(17): Error: escaping reference to local variable s
 ---
 */
 

--- a/test/fail_compilation/test16226.d
+++ b/test/fail_compilation/test16226.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -dip25
    TEST_OUTPUT:
 ---
-fail_compilation/test16226.d(14): Error: escaping reference to variable i
+fail_compilation/test16226.d(14): Error: escaping reference to local variable i
 ---
 */
 


### PR DESCRIPTION
This is a complete rewrite of escape.d. The idea is to separate data-gathering from semantic actions, instead of interleaving them. The result should make it much easier to do scope escape analysis using the same code.
