### PR TITLE
infer attributes for private functions

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -3060,6 +3060,9 @@ extern (C++) class FuncDeclaration : Declaration
                 return true;
         }
 
+        if (protection.kind == PROTprivate)
+            return true;
+
         return false;
     }
 


### PR DESCRIPTION
Since private functions don't need to interface to other modules.
