### PR TITLE
refactor lib: factor common code to lib.d

### DIFF
--- a/src/libelf.d
+++ b/src/libelf.d
@@ -14,21 +14,22 @@ import core.stdc.time;
 import core.stdc.string;
 import core.stdc.stdlib;
 import core.stdc.stdio;
-import core.stdc.stdarg;
 import core.sys.posix.sys.stat;
 import core.sys.posix.unistd;
+
 import ddmd.globals;
 import ddmd.lib;
+import ddmd.utils;
+
 import ddmd.root.array;
 import ddmd.root.file;
-import ddmd.root.outbuffer;
-import ddmd.root.stringtable;
 import ddmd.root.filename;
-import ddmd.root.rmem;
+import ddmd.root.outbuffer;
 import ddmd.root.port;
+import ddmd.root.rmem;
+import ddmd.root.stringtable;
+
 import ddmd.scanelf;
-import ddmd.errors;
-import ddmd.utils;
 
 enum LOG = false;
 
@@ -43,7 +44,6 @@ alias ElfObjSymbols = Array!(ElfObjSymbol*);
 
 final class LibElf : Library
 {
-    File* libfile;
     ElfObjModules objmodules; // ElfObjModule[]
     ElfObjSymbols objsymbols; // ElfObjSymbol[]
     StringTable tab;
@@ -51,34 +51,6 @@ final class LibElf : Library
     extern (D) this()
     {
         tab._init(14000);
-    }
-
-    /***********************************
-     * Set the library file name based on the output directory
-     * and the filename.
-     * Add default library file name extension.
-     */
-    override void setFilename(const(char)* dir, const(char)* filename)
-    {
-        static if (LOG)
-        {
-            printf("LibElf::setFilename(dir = '%s', filename = '%s')\n", dir ? dir : "", filename ? filename : "");
-        }
-        const(char)* arg = filename;
-        if (!arg || !*arg)
-        {
-            // Generate lib file name from first obj name
-            const(char)* n = (*global.params.objfiles)[0];
-            n = FileName.name(n);
-            arg = FileName.forceExt(n, global.lib_ext);
-        }
-        if (!FileName.absolute(arg))
-            arg = FileName.combine(dir, arg);
-        const(char)* libfilename = FileName.defaultExt(arg, global.lib_ext);
-        libfile = File.create(libfilename);
-        loc.filename = libfile.name.toChars();
-        loc.linnum = 0;
-        loc.charnum = 0;
     }
 
     /***************************************
@@ -310,19 +282,6 @@ final class LibElf : Library
 
     /*****************************************************************************/
 
-    override void write()
-    {
-        if (global.params.verbose)
-            fprintf(global.stdmsg, "library   %s\n", libfile.name.toChars());
-        OutBuffer libbuf;
-        WriteLibToBuffer(&libbuf);
-        // Transfer image to file
-        libfile.setbuffer(libbuf.data, libbuf.offset);
-        libbuf.extractData();
-        ensurePathToNameExists(Loc(), libfile.name.toChars());
-        writeFile(Loc(), libfile);
-    }
-
     void addSymbol(ElfObjModule* om, const(char)[] name, int pickAny = 0)
     {
         static if (LOG)
@@ -381,7 +340,7 @@ private:
      *      dictionary
      *      object modules...
      */
-    void WriteLibToBuffer(OutBuffer* libbuf)
+    protected override void WriteLibToBuffer(OutBuffer* libbuf)
     {
         static if (LOG)
         {
@@ -518,16 +477,6 @@ private:
         }
         assert(libbuf.offset == moffset);
     }
-
-    void error(const(char)* format, ...)
-    {
-        va_list ap;
-        va_start(ap, format);
-        .verror(loc, format, ap);
-        va_end(ap);
-    }
-
-    Loc loc;
 }
 
 extern (C++) Library LibElf_factory()


### PR DESCRIPTION
Move common code `setFilename()`, `write()` and `error()` to lib.d.
