### PR TITLE
refactor expression.h: remove fields unused by backend

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -501,9 +501,6 @@ public:
 class TemplateExp : public Expression
 {
 public:
-    TemplateDeclaration *td;
-    FuncDeclaration *fd;
-
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     bool checkType();
@@ -592,8 +589,6 @@ public:
 class OverExp : public Expression
 {
 public:
-    OverloadSet *vars;
-
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
@@ -649,9 +644,6 @@ public:
 class TraitsExp : public Expression
 {
 public:
-    Identifier *ident;
-    Objects *args;
-
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
@@ -668,16 +660,6 @@ public:
 class IsExp : public Expression
 {
 public:
-    /* is(targ id tok tspec)
-     * is(targ id == tok2)
-     */
-    Type *targ;
-    Identifier *id;     // can be NULL
-    TOK tok;       // ':' or '=='
-    Type *tspec;        // can be NULL
-    TOK tok2;      // 'struct', 'union', etc.
-    TemplateParameters *parameters;
-
     Expression *syntaxCopy();
     Expression *semantic(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
@@ -768,8 +750,6 @@ public:
 class DotIdExp : public UnaExp
 {
 public:
-    Identifier *ident;
-
     static DotIdExp *create(Loc loc, Expression *e, Identifier *ident);
     Expression *semantic(Scope *sc);
     Expression *semanticX(Scope *sc);
@@ -780,8 +760,6 @@ public:
 class DotTemplateExp : public UnaExp
 {
 public:
-    TemplateDeclaration *td;
-
     Expression *semantic(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
Back end .h files should be on a need-to-know basis.
