### PR TITLE
refactor Srcpos: use constructor

### DIFF
--- a/src/backend/cc.h
+++ b/src/backend/cc.h
@@ -201,6 +201,16 @@ typedef struct Srcpos
 #if MARS
     const char *Sfilename;
     #define srcpos_name(p)      ((p)->Sfilename)
+
+    static Srcpos create(const char *filename, unsigned linnum, unsigned charnum)
+    {
+        // Cannot have constructor because Srcpos is used in a union
+        Srcpos sp;
+        sp.Sfilename = filename;
+        sp.Slinnum = linnum;
+        sp.Scharnum = charnum;
+        return sp;
+    }
 #endif
 #if M_UNIX
     short Sfilnum;              // file number

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -2030,15 +2030,7 @@ static code *asm_genloc(Loc loc, code *c)
 {
     if (global.params.symdebug)
     {
-        code *pcLin;
-        Srcpos srcpos;
-
-        memset(&srcpos, 0, sizeof(srcpos));
-        srcpos.Slinnum = loc.linnum;
-        srcpos.Scharnum = loc.charnum;
-        srcpos.Sfilename = (char *)loc.filename;
-        pcLin = genlinnum(NULL, srcpos);
-        c = cat(pcLin, c);
+        c = cat(genlinnum(NULL, Srcpos::create(loc.filename, loc.linnum, loc.charnum)), c);
     }
     return c;
 }


### PR DESCRIPTION
So that iasm.c doesn't need to know about `Srcpos` internals.
