### PR TITLE
SignExtendedNumber: use uinteger_t as value type.

### DIFF
--- a/src/intrange.d
+++ b/src/intrange.d
@@ -26,7 +26,7 @@ static uinteger_t copySign(uinteger_t x, bool sign)
 
 struct SignExtendedNumber
 {
-    ulong value;
+    uinteger_t value;
     bool negative;
     static SignExtendedNumber fromInteger(uinteger_t value_)
     {


### PR DESCRIPTION
Otherwise the implementation breaks if uinteger_t is not ulong,
e.g. in case cent/ucent types are implemented.
