### PR TITLE
refactor list: remove use of __pascal from list

### DIFF
--- a/src/tk/list.c
+++ b/src/tk/list.c
@@ -215,33 +215,7 @@ list_t list_prepend(list_t *plist,void *ptr)
 
 /*************************/
 
-#if __SC__ && __INTSIZE == 4 && _M_I86 && !_DEBUG_TRACE
-
-__declspec(naked) int __pascal list_nitems(list_t list)
-{
-    _asm
-    {
-        mov     ECX,list-4[ESP]
-        xor     EAX,EAX
-        test    ECX,ECX
-        jz      L1
-    L2:
-        mov     ECX,[ECX]LIST.next
-        inc     EAX
-        test    ECX,ECX
-        jnz     L2
-    L1:
-        ret     4
-    }
-}
-
-#else
-
-#if __DMC__
-int __pascal list_nitems(list_t list)
-#else
 int list_nitems(list_t list)
-#endif
 {       register int n;
 
         n = 0;
@@ -252,7 +226,6 @@ int list_nitems(list_t list)
         return n;
 }
 
-#endif
 
 /*************************/
 

--- a/src/tk/list.h
+++ b/src/tk/list.h
@@ -276,13 +276,8 @@ extern  list_t
         list_prev (list_t,list_t),
         list_inlist (list_t,void *),
         list_copy (list_t);
-#if __DMC__
-extern  int __pascal list_nitems (list_t),
-        list_equal (list_t,list_t);
-#else
 extern  int list_nitems (list_t),
         list_equal (list_t,list_t);
-#endif
 
 #ifdef __cplusplus
 void list_free(list_t *l); // { list_free(l,FPNULL); }


### PR DESCRIPTION
no longer has any value
