### PR TITLE
[WIP] Enable coverage statistics

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,21 @@
+machine:
+  environment:
+    DMD_VERSION: 2.071.1
+    PATH: "${HOME}/dmd2/linux/bin64:${PATH}"
+    LD_LIBRARY_PATH: "${HOME}/dmd2/linux/lib64:${LD_LIBRARY_PATH}"
+    SELF_COMPILE: 2
+    SELF_DMD_TEST_COVERAGE: 1
+    DC: dmd
+    DMD: dmd
+dependencies:
+  pre:
+    - sudo apt-get update; sudo apt-get install g++-multilib
+  override:
+    - curl -fsSL --retry 3 "http://downloads.dlang.org/releases/2.x/${DMD_VERSION}/dmd.${DMD_VERSION}.linux.tar.xz" | tar -C ~ -Jxf -
+    - dmd --version
+test:
+  override:
+    - case $CIRCLE_NODE_INDEX in 0) MODEL=32 ./travis.sh ;; 1) MODEL=64 ./travis.sh ;; esac:
+        parallel: true
+  post:
+    - bash <(curl -s https://codecov.io/bash)

--- a/src/mars.d
+++ b/src/mars.d
@@ -1582,6 +1582,26 @@ int main()
     {
         GC.disable();
     }
+    version(D_Coverage)
+    {
+        // for now we need to manually set the source path
+        string dirName(string path, char separator)
+        {
+            for (size_t i = path.length - 1; i > 0; i--)
+            {
+                if (path[i] == separator)
+                    return path[0..i];
+            }
+            return path;
+        }
+        version (Windows)
+            enum sourcePath = dirName(__FILE_FULL_PATH__, `\`);
+        else
+            enum sourcePath = dirName(__FILE_FULL_PATH__, '/');
+
+        dmd_coverSourcePath(sourcePath);
+        dmd_coverSetMerge(true);
+    }
 
     auto args = Runtime.cArgs();
     return tryMain(args.argc, cast(const(char)**)args.argv);

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -148,6 +148,8 @@ endif
 DFLAGS=
 # Enable D warnings
 DFLAGS += -wi
+# Enable coverage statistics if requested
+DFLAGS += $(if $(DMD_TEST_COVERAGE),-cov,)
 
 ifneq (,$(DEBUG))
 ENABLE_DEBUG := 1


### PR DESCRIPTION
Seems like only a minor hack is required to compile coverage statistics for DMD. Maybe there is a better way to do this, but otherwise it is a very good use case of the new `__FILE_FULL_PATH__`.

With this PR the coverage is run for both the tests & phobos. We have to see how much it affects the Travis runtime, 
Of course as for https://github.com/dlang/druntime/pull/1620, a next step would be to run coverage tests on the AutoTester too.

It can be previewed [here](https://codecov.io/gh/wilzbach/dmd/tree/5b60145d41d8ac7a1a982f9c7b1f4b02b6367807).
