### PR TITLE
refactor: use tysize() instead of tysize[]

### DIFF
--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -2047,7 +2047,7 @@ code *eq87(elem *e,regm_t *pretregs)
         }
         cs.Irm |= modregrm(0,op2,0);            // OR in reg field
         c2 = gen(c2, &cs);
-        if (tysize[TYldouble] == 12)
+        if (tysize(TYldouble) == 12)
         {
         /* This deals with the fact that 10 byte reals really
          * occupy 12 bytes by zeroing the extra 2 bytes.
@@ -2063,7 +2063,7 @@ code *eq87(elem *e,regm_t *pretregs)
             c2 = gen(c2, &cs);
         }
         }
-        else if (tysize[TYldouble] == 16)
+        else if (tysize(TYldouble) == 16)
         {
         /* This deals with the fact that 10 byte reals really
          * occupy 16 bytes by zeroing the extra 6 bytes.
@@ -2167,7 +2167,7 @@ code *complex_eq87(elem *e,regm_t *pretregs)
         gen(c2, &cs);
         if (fxch)
             genf2(c2,0xD9,0xC8 + 1);            // FXCH ST(1)
-        if (tysize[TYldouble] == 12)
+        if (tysize(TYldouble) == 12)
         {
             if (op1 == 0xDB)
             {
@@ -2182,7 +2182,7 @@ code *complex_eq87(elem *e,regm_t *pretregs)
                 c2 = gen(c2, &cs);                  // MOV EA+22,0
             }
         }
-        if (tysize[TYldouble] == 16)
+        if (tysize(TYldouble) == 16)
         {
             if (op1 == 0xDB)
             {
@@ -2805,12 +2805,12 @@ code *cdnegass87(elem *e,regm_t *pretregs)
     cr = modEA(&cs);
     cs.Irm |= modregrm(0,6,0);
     cs.Iop = 0x80;
-    if (tysize[TYldouble] > 10)
+    if (tysize(TYldouble) > 10)
     {
         if (tyml == TYldouble || tyml == TYildouble)
             cs.IEVoffset1 += 10 - 1;
         else if (tyml == TYcldouble)
-            cs.IEVoffset1 += tysize[TYldouble] + 10 - 1;
+            cs.IEVoffset1 += tysize(TYldouble) + 10 - 1;
         else
             cs.IEVoffset1 += sz - 1;
     }

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -775,7 +775,7 @@ Lagain:
 
     CSoff = alignsection(Alloca.offset - cstop * REGSIZE, REGSIZE, bias);
 
-    NDPoff = alignsection(CSoff - NDP::savetop * tysize[TYldouble], REGSIZE, bias);
+    NDPoff = alignsection(CSoff - NDP::savetop * tysize(TYldouble), REGSIZE, bias);
 
     regm_t topush = fregsaved & ~mfuncreg;          // mask of registers that need saving
     pushoffuse = false;

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -1923,7 +1923,7 @@ STATIC elem * elcond(elem *e, goal_t goal)
 
                 /* Replace ((a relop b) ? 1 : 0) with (a relop b)       */
                 else if (OTrel(e1->Eoper) &&
-                    tysize(ty) <= tysize[TYint])
+                    tysize(ty) <= tysize(TYint))
                 {
                     if (i1 == 1 && i2 == 0)
                         e = el_selecte1(e);
@@ -1950,7 +1950,7 @@ STATIC elem * elcond(elem *e, goal_t goal)
                 {
                     if (tyfv(e1->Ety))
                     {
-                        if (tysize(e->Ety) == tysize[TYint])
+                        if (tysize(e->Ety) == tysize(TYint))
                         {
                             if (i1 == 1 && i2 == 0)
                             {   e->Eoper = OPbool;

--- a/src/backend/cgen.c
+++ b/src/backend/cgen.c
@@ -902,13 +902,13 @@ size_t addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int fl
 #if TARGET_SEGMENTED
         switch (flags & (CFoff | CFseg))
         {
-            case CFoff:         numbytes = tysize[TYnptr];      break;
+            case CFoff:         numbytes = tysize(TYnptr);      break;
             case CFseg:         numbytes = 2;                   break;
-            case CFoff | CFseg: numbytes = tysize[TYfptr];      break;
+            case CFoff | CFseg: numbytes = tysize(TYfptr);      break;
             default:            assert(0);
         }
 #else
-        numbytes = tysize[TYnptr];
+        numbytes = tysize(TYnptr);
         if (I64 && !(flags & CFoffset64))
             numbytes = 4;
 

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -1744,7 +1744,7 @@ void Obj::funcptr(Symbol *s)
 
     // Put out segment definition record
     // size is NPTRSIZE or FPTRSIZE
-    objsegdef(dsegattr,(i & 2) + tysize[TYnptr],obj.lnameidx + 1,DATACLASS);
+    objsegdef(dsegattr,(i & 2) + tysize(TYnptr),obj.lnameidx + 1,DATACLASS);
     seg_data *pseg = getsegment();
     pseg->segidx = obj.segidx;
     Obj::reftoident(pseg->SDseg,0,s,0,0);     // put out function pointer
@@ -3128,14 +3128,14 @@ void Obj::ledata(int seg,targ_size_t offset,targ_size_t data,
 {   unsigned i;
     unsigned size;                      // number of bytes to output
 
-    unsigned ptrsize = tysize[TYfptr];
+    unsigned ptrsize = tysize(TYfptr);
 
     if ((lcfd & LOCxx) == obj.LOCpointer)
         size = ptrsize;
     else if ((lcfd & LOCxx) == LOCbase)
         size = 2;
     else
-        size = tysize[TYnptr];
+        size = tysize(TYnptr);
 
     Ledatarec *lr = SegData[seg]->ledata;
     if (!lr)
@@ -3176,7 +3176,7 @@ L1:     ;
     else
         TOLONG(lr->data + i,data);
     if (size == ptrsize)         // if doing a seg:offset pair
-        TOWORD(lr->data + i + tysize[TYnptr],0);        // segment portion
+        TOWORD(lr->data + i + tysize(TYnptr),0);        // segment portion
     addfixup(lr, offset - lr->offset,lcfd,idx1,idx2);
 }
 
@@ -3198,7 +3198,7 @@ L1:     ;
 void Obj::write_long(int seg,targ_size_t offset,unsigned long data,
         unsigned lcfd,unsigned idx1,unsigned idx2)
 {
-    unsigned sz = tysize[TYfptr];
+    unsigned sz = tysize(TYfptr);
     Ledatarec *lr = SegData[seg]->ledata;
     if (!lr)
          lr = ledata_new(seg, offset);
@@ -3392,7 +3392,7 @@ int Obj::reftoident(int seg,targ_size_t offset,Symbol *s,targ_size_t val,
                           && !(flags & CFselfrel))
                             ? LOCloader_resolved : obj.LOCoffset;
                 }
-                numbytes = tysize[TYnptr];
+                numbytes = tysize(TYnptr);
                 break;
             case CFseg:
                 lc = LOCbase;
@@ -3400,7 +3400,7 @@ int Obj::reftoident(int seg,targ_size_t offset,Symbol *s,targ_size_t val,
                 break;
             case CFoff | CFseg:
                 lc = obj.LOCpointer;
-                numbytes = tysize[TYfptr];
+                numbytes = tysize(TYfptr);
                 break;
         }
         break;

--- a/src/backend/cgxmm.c
+++ b/src/backend/cgxmm.c
@@ -118,7 +118,7 @@ code *orthxmm(elem *e, regm_t *pretregs)
         {
             unsigned nretregs = XMMREGS & ~retregs;
             unsigned sreg; // hold sign bit
-            unsigned sz = tysize[tybasic(e1->Ety)];
+            unsigned sz = tysize(e1->Ety);
             c = cat(c,allocreg(&nretregs,&sreg,e2->Ety));
             targ_size_t signbit = 0x80000000;
             if (sz == 8)

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -4118,7 +4118,7 @@ code *pushParams(elem *e,unsigned stackalign)
         s = e->EV.sp.Vsym;
         //if (sytab[s->Sclass] & SCSS && !I32)  // if variable is on stack
         //    needframe = TRUE;                 // then we need stack frame
-        if (tysize[tym] == tysize[TYfptr] &&
+        if (tysize[tym] == tysize(TYfptr) &&
             (fl = s->Sfl) != FLfardata &&
             /* not a function that CS might not be the segment of       */
             (!((fl == FLfunc || s->ty() & mTYcs) &&
@@ -4147,7 +4147,7 @@ code *pushParams(elem *e,unsigned stackalign)
         if (config.target_cpu >= TARGET_80286 && !e->Ecount)
         {
             stackpush += sz;
-            if (tysize[tym] == tysize[TYfptr])
+            if (tysize[tym] == tysize(TYfptr))
             {
                 /* PUSH SEG e   */
                 code *c1 = gencs(CNIL,0x68,0,FLextern,s);
@@ -4234,7 +4234,7 @@ code *pushParams(elem *e,unsigned stackalign)
             goto L2;
         }
 
-        assert(I64 || sz <= tysize[TYldouble]);
+        assert(I64 || sz <= tysize(TYldouble));
         int i = sz;
         if (!I16 && i == 2)
             flag = CFopsize;
@@ -4579,7 +4579,7 @@ code *loaddata(elem *e,regm_t *pretregs)
                 c = cat(c,c1);
             }
         }
-        else if (sz == tysize[TYldouble])               // TYldouble
+        else if (sz == tysize(TYldouble))               // TYldouble
             return load87(e,0,pretregs,NULL,-1);
         else
         {

--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -398,7 +398,7 @@ code *cdorth(elem *e,regm_t *pretregs)
                 regm_t regm;
                 if (e11->Eoper == OPvar && isregvar(e11,&regm,&reg1))
                 {
-                    if (tysize[tybasic(e11->Ety)]<= REGSIZE)
+                    if (tysize(e11->Ety) <= REGSIZE)
                         retregs = mask[reg1]; // only want the LSW
                     else
                         retregs = regm;

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1386,7 +1386,7 @@ void doswitch(block *b)
         if (vmin > 0 && vmin <= intsize)
             vmin = 0;
 
-        b->Btablesize = (int) (vmax - vmin + 1) * tysize[TYnptr];
+        b->Btablesize = (int) (vmax - vmin + 1) * tysize(TYnptr);
         regm_t retregs = IDXREGS;
         if (dword)
             retregs |= mMSW;
@@ -1678,7 +1678,7 @@ void doswitch(block *b)
             ct->Iflags |= csseg ? CFcs : 0;
         }
         ce = cat(ce,ct);
-        b->Btablesize = disp + intsize + ncases * tysize[TYnptr];
+        b->Btablesize = disp + intsize + ncases * tysize(TYnptr);
     }
 
 L2: ;
@@ -1781,7 +1781,7 @@ void outjmptab(block *b)
         else
         {
             objmod->reftocodeseg(jmpseg,*poffset,targ);
-            *poffset += tysize[TYnptr];
+            *poffset += tysize(TYnptr);
         }
 #else
         assert(0);
@@ -1838,7 +1838,7 @@ void outswitab(block *b)
   offset += alignbytes + sz * ncases;
   assert(*poffset == offset);
 
-  if (b->Btablesize == ncases * (REGSIZE * 2 + tysize[TYnptr]))
+  if (b->Btablesize == ncases * (REGSIZE * 2 + tysize(TYnptr)))
   {
         /* Send out MSW table   */
         p -= ncases;
@@ -1855,9 +1855,9 @@ void outswitab(block *b)
   for (n = 0; n < ncases; n++)          /* send out address table       */
   {     bl = list_next(bl);
         objmod->reftocodeseg(seg,*poffset,list_block(bl)->Boffset);
-        *poffset += tysize[TYnptr];
+        *poffset += tysize(TYnptr);
   }
-  assert(*poffset == offset + ncases * tysize[TYnptr]);
+  assert(*poffset == offset + ncases * tysize(TYnptr));
 }
 
 /*****************************
@@ -2195,7 +2195,7 @@ Lcant:
 bool cse_simple(code *c, elem *e)
 {   regm_t regm;
     unsigned reg;
-    int sz = tysize[tybasic(e->Ety)];
+    int sz = tysize(e->Ety);
 
     if (!I16 &&                                  // don't bother with 16 bit code
         e->Eoper == OPadd &&
@@ -4147,10 +4147,10 @@ void cod3_thunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
     thunkty = tybasic(sthunk->ty());
 #if TARGET_SEGMENTED
     if (tyfarfunc(thunkty))
-        p += I32 ? 8 : tysize[TYfptr];          /* far function */
+        p += I32 ? 8 : tysize(TYfptr);          /* far function */
     else
 #endif
-        p += tysize[TYnptr];
+        p += tysize(TYnptr);
 
     if (!I16)
     {
@@ -4846,7 +4846,7 @@ void assignaddrc(code *c)
 #if MARS
                 assert(c->IEV1.Vuns < NDP::savetop);
 #endif
-                c->IEVpointer1 = c->IEV1.Vuns * tysize[TYldouble] + NDPoff + BPoff;
+                c->IEVpointer1 = c->IEV1.Vuns * tysize(TYldouble) + NDPoff + BPoff;
                 c->Iflags |= CFunambig;
                 goto L2;
             case FLoffset:

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -3399,7 +3399,7 @@ code *cdbtst(elem *e, regm_t *pretregs)
     }
     else
     {
-        retregs = tysize[tybasic(e1->Ety)] == 1 ? BYTEREGS : allregs;
+        retregs = tysize(e1->Ety) == 1 ? BYTEREGS : allregs;
         c = codelem(e1, &retregs, FALSE);
         reg = findreg(retregs);
         cs.Irm = modregrm(3,0,reg & 7);

--- a/src/backend/dwarf.c
+++ b/src/backend/dwarf.c
@@ -2483,7 +2483,7 @@ unsigned dwarf_typidx(type *t)
             // vector length stored as subrange type
             code = dwarf_abbrev_code(abbrevSubRange, sizeof(abbrevSubRange));
             infobuf->writeuLEB128(code);        // DW_TAG_subrange_type
-            unsigned char dim = tysize[tybasic(t->Tty)] / tysize[tybasic(tbase->Tty)];
+            unsigned char dim = tysize(t->Tty) / tysize(tbase->Tty);
             infobuf->writeByte(dim - 1);        // DW_AT_upper_bound
 
             infobuf->writeByte(0);              // no more children

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -2700,7 +2700,7 @@ L1:
                         /* Far pointers on the 386 are longer than
                            any integral type...
                          */
-                        if (memcmp(&n1->EV,&n2->EV,tysize[tybasic(tym)]))
+                        if (memcmp(&n1->EV, &n2->EV, tysize(tym)))
                             goto nomatch;
                         break;
 
@@ -3307,7 +3307,7 @@ case_tym:
         case TYint:
         case TYuint:
         case TYvoid:        /* in case (void)(1)    */
-            if (tysize[TYint] == LONGSIZE)
+            if (tysize(TYint) == LONGSIZE)
                 goto L1;
         case TYshort:
         case TYwchar_t:

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -2338,7 +2338,7 @@ STATIC void ivfamelems(Iv *biv,elem **pn)
         {   int sz;
 
             sz = tysize(ty);
-            if (sz == tysize[TYfptr] && !tyfv(ty) &&
+            if (sz == tysize(TYfptr) && !tyfv(ty) &&
                 (sz != tysize(n1->Ety) || sz != tysize(n2->Ety)))
                 return;
         }

--- a/src/backend/newman.c
+++ b/src/backend/newman.c
@@ -654,7 +654,7 @@ char *template_mangle(symbol *s,param_t *arglist)
                     {   case TYfloat:   ni = FLOATSIZE;  c = 'F'; goto L1;
                         case TYdouble_alias:
                         case TYdouble:  ni = DOUBLESIZE; c = 'D'; goto L1;
-                        case TYldouble: ni = tysize[TYldouble]; c = 'L'; goto L1;
+                        case TYldouble: ni = tysize(TYldouble); c = 'L'; goto L1;
                         L1:
                             if (NEWTEMPMANGLE)
                                 CHAR('$');

--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -329,8 +329,8 @@ elem *callfunc(Loc loc,
             assert((int)vindex >= 0);
 
             // Build *(ev + vindex * 4)
-if (I32) assert(tysize[TYnptr] == 4);
-            ec = el_bin(OPadd,TYnptr,ev,el_long(TYsize_t, vindex * tysize[TYnptr]));
+if (I32) assert(tysize(TYnptr) == 4);
+            ec = el_bin(OPadd,TYnptr,ev,el_long(TYsize_t, vindex * tysize(TYnptr)));
             ec = el_una(OPind,TYnptr,ec);
             ec = el_una(OPind,tybasic(sfunc->Stype->Tty),ec);
         }
@@ -611,7 +611,7 @@ elem *array_toDarray(Type *t, elem *e)
             {
                 case OPconst:
                 {
-                    size_t len = tysize[tybasic(e->Ety)];
+                    size_t len = tysize(e->Ety);
                     elem *es = el_calloc();
                     es->Eoper = OPstring;
 
@@ -3926,7 +3926,7 @@ elem *toElem(Expression *e, IRState *irs)
                 {
                     // e1 -> *(&e1 + 4)
                     e = el_una(OPaddr, TYnptr, e);
-                    e = el_bin(OPadd, TYnptr, e, el_long(TYsize_t, tysize[TYnptr]));
+                    e = el_bin(OPadd, TYnptr, e, el_long(TYsize_t, tysize(TYnptr)));
                     e = el_una(OPind,totym(t),e);
                 }
                 else
@@ -5329,7 +5329,7 @@ elem *fillHole(Symbol *stmp, size_t *poffset, size_t offset2, size_t maxoff)
         e1 = el_una(OPind, ty, e1);
         e1 = el_bin(OPeq, ty, e1, el_long(ty, 0));
         e = el_combine(e, e1);
-        *poffset += tysize[ty];
+        *poffset += tysize(ty);
     }
     return e;
 }


### PR DESCRIPTION
Unfortunately, `tysize` is defined in the backend as both an array and a macro. This is a start towards having different names for them.
