### PR TITLE
Make Module.semantic override the base class's virtual function

### DIFF
--- a/src/dimport.d
+++ b/src/dimport.d
@@ -283,7 +283,7 @@ extern (C++) final class Import : Dsymbol
                 scopesym.addAccessiblePackage(mod, protection); // d
             }
 
-            mod.semantic();
+            mod.semantic(null);
             if (mod.needmoduleinfo)
             {
                 //printf("module4 %s because of %s\n", sc.module.toChars(), mod.toChars());
@@ -395,7 +395,7 @@ extern (C++) final class Import : Dsymbol
         //printf("Import::semantic2('%s')\n", toChars());
         if (mod)
         {
-            mod.semantic2();
+            mod.semantic2(null);
             if (mod.needmoduleinfo)
             {
                 //printf("module5 %s because of %s\n", sc.module.toChars(), mod.toChars());
@@ -462,7 +462,7 @@ extern (C++) final class Import : Dsymbol
         {
             load(null);
             mod.importAll(null);
-            mod.semantic();
+            mod.semantic(null);
         }
         // Forward it to the package/module
         return pkg.search(loc, ident, flags);

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -230,7 +230,7 @@ extern (C++) class Package : ScopeDsymbol
         return isAncestorPackageOf(pkg.parent.isPackage());
     }
 
-    override final void semantic(Scope* sc)
+    override void semantic(Scope* sc)
     {
     }
 
@@ -994,7 +994,7 @@ extern (C++) final class Module : Package
     }
 
     // semantic analysis
-    void semantic()
+    override void semantic(Scope*)
     {
         if (semanticRun != PASSinit)
             return;
@@ -1031,7 +1031,7 @@ extern (C++) final class Module : Package
     }
 
     // pass 2 semantic analysis
-    void semantic2()
+    override void semantic2(Scope*)
     {
         //printf("Module::semantic2('%s'): parent = %p\n", toChars(), parent);
         if (semanticRun != PASSsemanticdone) // semantic() not completed yet - could be recursive call
@@ -1059,7 +1059,7 @@ extern (C++) final class Module : Package
     }
 
     // pass 3 semantic analysis
-    void semantic3()
+    override void semantic3(Scope*)
     {
         //printf("Module::semantic3('%s'): parent = %p\n", toChars(), parent);
         if (semanticRun != PASSsemantic2done)

--- a/src/expression.d
+++ b/src/expression.d
@@ -14802,7 +14802,7 @@ extern (C++) Module loadStdMath()
         if (s.mod)
         {
             s.mod.importAll(null);
-            s.mod.semantic();
+            s.mod.semantic(null);
         }
         impStdMath = s;
     }

--- a/src/mars.d
+++ b/src/mars.d
@@ -225,9 +225,9 @@ extern (C++) void genCmain(Scope* sc)
     global.params.verbose = false;
     m.importedFrom = m;
     m.importAll(null);
-    m.semantic();
-    m.semantic2();
-    m.semantic3();
+    m.semantic(null);
+    m.semantic2(null);
+    m.semantic3(null);
     global.params.verbose = v;
     entrypoint = m;
     rootHasMain = sc._module;
@@ -1360,7 +1360,7 @@ Language changes listed by -transition=id:
         Module m = modules[i];
         if (global.params.verbose)
             fprintf(global.stdmsg, "semantic  %s\n", m.toChars());
-        m.semantic();
+        m.semantic(null);
     }
     //if (global.errors)
     //    fatal();
@@ -1382,7 +1382,7 @@ Language changes listed by -transition=id:
         Module m = modules[i];
         if (global.params.verbose)
             fprintf(global.stdmsg, "semantic2 %s\n", m.toChars());
-        m.semantic2();
+        m.semantic2(null);
     }
     Module.runDeferredSemantic2();
     if (global.errors)
@@ -1394,7 +1394,7 @@ Language changes listed by -transition=id:
         Module m = modules[i];
         if (global.params.verbose)
             fprintf(global.stdmsg, "semantic3 %s\n", m.toChars());
-        m.semantic3();
+        m.semantic3(null);
     }
     Module.runDeferredSemantic3();
     if (global.errors)


### PR DESCRIPTION
The current Module interface defines `semantic()` which is _not_ overriding the Dsymbol baseclass's `semantic(Scope*)`. This PR fixes that so that the interface is more clear.
Compare with Module.importAll.

I chose to not name the `Scope*` function argument to indicate that it is not used.
