### PR TITLE
Fix CI checkout branch for non Travis CIs

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -8,8 +8,14 @@ if [ $DC = gdc ] && [ ! -f $(dirname $(which gdc))/cc ]; then
 fi
 N=2
 
-git clone --depth=1 --branch $TRAVIS_BRANCH https://github.com/D-Programming-Language/druntime.git ../druntime
-git clone --depth=1 --branch $TRAVIS_BRANCH https://github.com/D-Programming-Language/phobos.git ../phobos
+CI_BRANCH="master"
+
+if [ -n "$TRAVIS_BRANCH" ] ; then
+    CI_BRANCH="$TRAVIS_BRANCH"
+fi
+
+git clone --depth=1 --branch $CI_BRANCH https://github.com/dlang/druntime.git ../druntime
+git clone --depth=1 --branch $CI_BRANCH https://github.com/dlang/phobos.git ../phobos
 
 make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD all
 make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD dmd.conf
@@ -27,18 +33,23 @@ while [ $SELF_COMPILE -gt 0 ]; do
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd clean
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd dmd.conf
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd
-    make -j$N -C ../druntime -f posix.mak MODEL=$MODEL clean
-    make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
-    make -j$N -C ../phobos -f posix.mak MODEL=$MODEL clean
-    make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
+
+    if [ -z ${DMD_TEST_COVERAGE} ] ; then
+        make -j$N -C ../druntime -f posix.mak MODEL=$MODEL clean
+        make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
+        make -j$N -C ../phobos -f posix.mak MODEL=$MODEL clean
+        make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
+    else
+    	echo "Skipping druntime and Phobos rebuilds with coverage builds"
+    fi
     rm src/host_dmd
     SELF_COMPILE=$(($SELF_COMPILE - 1))
 done
 
 # Only run runtime + phobos tests on Travis
 if [ "${CIRCLECI}" != "true" ] ; then
-	make -j$N -C ../druntime -f posix.mak MODEL=$MODEL unittest
-	make -j$N -C ../phobos -f posix.mak MODEL=$MODEL unittest
+    make -j$N -C ../druntime -f posix.mak MODEL=$MODEL unittest
+    make -j$N -C ../phobos -f posix.mak MODEL=$MODEL unittest
 fi
 
 # test fewer compiler argument permutations for PRs to reduce CI load


### PR DESCRIPTION
CC @MartinNowak as #5995 introduced this here https://github.com/dlang/dmd/commit/ed2aaca01e88f7ac4e9d1fdd8795e07ba0c5679f.

The fix just uses the `master` branch as default and gets the branch from CI if possible.
