### PR TITLE
Set coverage destination directory to source directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ dmd.xcodeproj/
 # Output files
 src/*.bak
 src/*.lib
+src/*.lst
 tags
 
 # OSX

--- a/src/mars.d
+++ b/src/mars.d
@@ -1600,6 +1600,7 @@ int main()
             enum sourcePath = dirName(__FILE_FULL_PATH__, '/');
 
         dmd_coverSourcePath(sourcePath);
+        dmd_coverDestPath(sourcePath);
         dmd_coverSetMerge(true);
     }
 


### PR DESCRIPTION
After looking a bit at the output from CodeCov I realized why the `test` folder appears there. The `.lst` files are stored in the current working directory and CodeCov tries to match them via name to the nearest file it finds, so for example it finds a file `imphint.d` in the `test` directory too and thus [tries to match  them](https://codecov.io/gh/dlang/dmd/src/a799d0e8376da57e12c44ee465ea4a565932c1da/test/fail_compilation/imphint.d).

The fix is simple ;-)
