### PR TITLE
Reduce coverage load

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+# Documentation: https://github.com/codecov/support/wiki/codecov.yml
+
+codecov:
+  # CodeCov should only wait for CI's that run coverage tests
+  # DAutoTester and auto-tester are not in the default list
+  ci:
+    - !travis

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -1,3 +1,4 @@
+#!/usr/bin/env rdmd
 module d_do_test;
 
 import std.algorithm;
@@ -80,6 +81,7 @@ struct EnvData
     string model;
     string required_args;
     bool dobjc;
+    bool coverage_build;
 }
 
 bool findTestParameter(string file, string token, ref string result)
@@ -446,6 +448,7 @@ int main(string[] args)
     envData.model         = environment.get("MODEL");
     envData.required_args = environment.get("REQUIRED_ARGS");
     envData.dobjc         = environment.get("D_OBJC") == "1";
+    envData.coverage_build   = environment.get("DMD_TEST_COVERAGE") == "1";
 
     string result_path    = envData.results_dir ~ envData.sep;
     string input_file     = input_dir ~ envData.sep ~ test_name ~ "." ~ test_extension;
@@ -464,6 +467,10 @@ int main(string[] args)
             writeln("input_dir must be one of 'compilable', 'fail_compilation', or 'runnable'");
             return 1;
     }
+
+    // running & linking costs time - for coverage builds we can save this
+    if (envData.coverage_build && testArgs.mode == TestMode.RUN)
+        testArgs.mode = TestMode.COMPILE;
 
     if (envData.ccompiler.empty)
     {
@@ -632,7 +639,7 @@ int main(string[] args)
 
             fThisRun.close();
 
-            if (testArgs.postScript)
+            if (testArgs.postScript && !envData.coverage_build)
             {
                 f.write("Executing post-test script: ");
                 string prefix = "";

--- a/travis.sh
+++ b/travis.sh
@@ -52,8 +52,13 @@ if [ "${CIRCLECI}" != "true" ] ; then
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL unittest
 fi
 
+QUICK_BUILD=0
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "$CIRCLECI" == "true" ]; then
+	QUICK_BUILD=1
+fi
+
 # test fewer compiler argument permutations for PRs to reduce CI load
-if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+if [ $QUICK_BUILD -eq 1 ]; then
     make -j$N -C test MODEL=$MODEL
 else
     make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release"

--- a/travis.sh
+++ b/travis.sh
@@ -53,7 +53,7 @@ if [ "${CIRCLECI}" != "true" ] ; then
 fi
 
 QUICK_BUILD=0
-if [ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "$CIRCLECI" == "true" ]; then
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
 	QUICK_BUILD=1
 fi
 


### PR DESCRIPTION
It looks like it's not that difficult to skip, so I quickly did it.

Btw the last few `runnable` tests look worrying on Linux, is this known?
Output is copied from a _passed_ test on AutoTester.

```
./runnable/test16096.sh: line 4: ${output_file}: ambiguous redirect
 ... runnable/test10386.sh
 ... runnable/template2.d           (-O -inline -release)
 ... runnable/gdb15729.sh
 ... runnable/test10567.sh
Missing separate debuginfo for /lib/libgcc_s.so.1
Try: yum --enablerepo='*debug*' install /usr/lib/debug/.build-id/22/ffc1dcfb5f5e40f3331f5aec6eb25b3d8c1e87.debug
RESULT=$1 = 1234
 ... runnable/link14198b.sh
 ... runnable/link14198a.sh
rm: cannot remove ‘generated/runnable/test14198b’: No such file or directory
```
