### PR TITLE
refactor type.h: modernize

### DIFF
--- a/src/backend/type.h
+++ b/src/backend/type.h
@@ -16,17 +16,36 @@
 #ifndef __TYPE_H
 #define __TYPE_H
 
-#include <limits.h>
-
 typedef unsigned char mangle_t;
+enum
+{
+    mTYman_c      = 1,      // C mangling
+    mTYman_cpp    = 2,      // C++ mangling
+    mTYman_pas    = 3,      // Pascal mangling
+    mTYman_for    = 4,      // FORTRAN mangling
+    mTYman_sys    = 5,      // _syscall mangling
+    mTYman_std    = 6,      // _stdcall mangling
+    mTYman_d      = 7,      // D mangling
+};
 
-#define mTYman_c        1       // C mangling
-#define mTYman_cpp      2       // C++ mangling
-#define mTYman_pas      3       // Pascal mangling
-#define mTYman_for      4       // FORTRAN mangling
-#define mTYman_sys      5       // _syscall mangling
-#define mTYman_std      6       // _stdcall mangling
-#define mTYman_d        7       // D mangling
+/// Values for Tflags:
+typedef unsigned short type_flags_t;
+enum
+{
+    TFprototype   = 1,      // if this function is prototyped
+    TFfixed       = 2,      // if prototype has a fixed # of parameters
+    TFgenerated   = 4,      // C: if we generated the prototype ourselves
+    TFdependent   = 4,      // CPP: template dependent type
+    TFforward     = 8,      // TYstruct: if forward reference of tag name
+    TFsizeunknown = 0x10,   // TYstruct,TYarray: if size of type is unknown
+                            // TYmptr: the Stag is TYident type
+    TFfuncret     = 0x20,   // C++,tyfunc(): overload based on function return value
+    TFfuncparam   = 0x20,   // TYarray: top level function parameter
+    TFhydrated    = 0x20,   // type data already hydrated
+    TFstatic      = 0x40,   // TYarray: static dimension
+    TFvla         = 0x80,   // TYarray: variable length array
+    TFemptyexc    = 0x100,  // tyfunc(): empty exception specification
+};
 
 /*********************************
  * Data type.
@@ -44,63 +63,45 @@ struct TYPE
 #define type_debug(t)
 #endif
 
-    tym_t       Tty;            /* mask (TYxxx)                         */
+    tym_t       Tty;            // mask (TYxxx)
     unsigned short Tflags;      // TFxxxxx
 
     mangle_t Tmangle;           // name mangling
-// Return name mangling of type
-#define type_mangle(t)  ((t)->Tmangle)
 
     unsigned Tcount;            // # pointing to this type
-    struct TYPE *Tnext;         // next in list
+    TYPE *Tnext;                // next in list
                                 // TYenum: gives base type
     union
     {
         targ_size_t Tdim;       // TYarray: # of elements in array
-        struct elem *Tel;       // TFvla: gives dimension (NULL if '*')
-        struct param_t *Tparamtypes; // TYfunc, TYtemplate: types of function parameters
-        struct Classsym *Ttag;  // TYstruct,TYmemptr: tag symbol
+        elem *Tel;              // TFvla: gives dimension (NULL if '*')
+        param_t *Tparamtypes;   // TYfunc, TYtemplate: types of function parameters
+        Classsym *Ttag;         // TYstruct,TYmemptr: tag symbol
                                 // TYenum,TYvtshape: tag symbol
         char *Tident;           // TYident: identifier
-        struct TYPE *Talternate;        // C++: typtr: type of parameter before converting
-        struct TYPE *Tkey;      // typtr: key type for associative arrays
+        TYPE *Talternate;       // C++: typtr: type of parameter before converting
+        TYPE *Tkey;             // typtr: key type for associative arrays
     };
     list_t Texcspec;            // tyfunc(): list of types of exception specification
     Symbol *Ttypedef;           // if this type came from a typedef, this is
                                 // the typedef symbol
 };
 
-typedef struct TYPETEMP
-{   struct TYPE Ttype;
+struct typetemp_t
+{
+    TYPE Ttype;
 
     /* Tsym should really be part of a derived class, as we only
         allocate room for it if TYtemplate
      */
     Symbol *Tsym;               // primary class template symbol
-} typetemp_t;
+};
 
-/* Values for Tflags:                                                   */
-#define TFprototype     1       /* if this function is prototyped       */
-#define TFfixed         2       /* if prototype has a fixed # of parameters */
-#define TFforward       8       // TYstruct: if forward reference of tag name
-#define TFsizeunknown   0x10    // TYstruct,TYarray: if size of type is unknown
-                                // TYmptr: the Stag is TYident type
-#define TFfuncret       0x20    // C++,tyfunc(): overload based on function return value
-#define TFfuncparam     0x20    // TYarray: top level function parameter
-#define TFstatic        0x40    // TYarray: static dimension
-#define TFvla           0x80    // TYarray: variable length array
-#define TFemptyexc      0x100   // tyfunc(): empty exception specification
+// Return name mangling of type
+inline mangle_t type_mangle(type *t) { return t->Tmangle; }
 
-// C
-#define TFgenerated     4       // if we generated the prototype ourselves
-
-// CPP
-#define TFdependent     4       // template dependent type
-
-#define TFhydrated      0x20    // type data already hydrated
-
-/* Return !=0 if function type has a variable number of arguments       */
-#define variadic(t)     (((t)->Tflags & (TFprototype | TFfixed)) == TFprototype)
+// Return true if function type has a variable number of arguments
+inline bool variadic(type *t) { return (t->Tflags & (TFprototype | TFfixed)) == TFprototype; }
 
 /* Data         */
 
@@ -150,13 +151,13 @@ extern typep_t tstrace;
 #define tserr           tsint   /* error type           */
 
 // Return !=0 if type is a struct, class or union
-#define type_struct(t)  (tybasic((t)->Tty) == TYstruct)
+inline bool type_struct(type *t) { return tybasic(t->Tty) == TYstruct; }
 
 /* Functions    */
 void type_print(type *t);
 void type_free(type *);
-void type_init(void);
-void type_term(void);
+void type_init();
+void type_term();
 type *type_copy(type *);
 elem *type_vla_fix(type **pt);
 type *type_setdim(type **,targ_size_t);
@@ -181,7 +182,7 @@ type *type_setcv(type **pt,tym_t cv);
 int type_embed(type *t,type *u);
 int type_isvla(type *t);
 
-param_t *param_calloc(void);
+param_t *param_calloc();
 param_t *param_append_type(param_t **,type *);
 void param_free_l(param_t *);
 void param_free(param_t **);

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -20,9 +20,7 @@
 #include        <string.h>
 #include        <time.h>
 #include        <assert.h>
-#if __DMC__
 #include        <limits.h>
-#endif
 
 
 // D compiler


### PR DESCRIPTION
1. remove unused `#include`
2. remove C anachronism `(void)`
3. remove unused typedef
4. macros to inline functions
5. macros to enums
6. remove C anachronistic tag style
