### PR TITLE
Add log verbosity option to test_runner

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -86,7 +86,15 @@ ifeq (freebsd,$(OS))
 else
     SHELL=/bin/bash
 endif
-QUIET=@
+
+# can be used to toggle more verbose output
+ifeq (0, $(QUIET))
+	QUIET:=
+else
+	QUIET:=@
+endif
+export QUIET
+
 export RESULTS_DIR=test_results
 export MODEL
 export REQUIRED_ARGS=


### PR DESCRIPTION
> In order to not do the link step, the -c switch needs to be thrown on the compiler. I don't see that in the diff - can you check, please?

I think allowing to log the executed commands might be useful ;-)

Hence [the output](http://sprunge.us/cMLI) with `DMD_TEST_COVERAGE=1 DMD_TEST_VERBOSITY=1` looks shows `-c`.

``
cat log | wc -l                              # prints 862
cat mylog | grep "-c" | wc -l     # prints 862

```

I tried to keep this option as KISS as possible, but removed the automatic string concatenation at CTFE in the help message because AFAIK that's a deprecated feature?
```
