### PR TITLE
Ignore stable branch for CircleCi

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,3 +19,7 @@ test:
         parallel: true
   post:
     - bash <(curl -s https://codecov.io/bash)
+general:
+  branches:
+    ignore:
+      - stable # list of branches to ignore


### PR DESCRIPTION
Sorry about the noise regarding CircleCi.

@MartinNowak this should exclude `stable` and PRs targeted at `stable` from the CircleCi run list. Ideally we could infer the name of the PR branch on CircleCi, but I haven't figured this one out yet and I think displaying code coverage changes for regression fixes is not so important for now.

Docs are here: https://circleci.com/docs/configuration/#branches
