### PR TITLE
refactor: tysize[] => _tysize[]

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -298,9 +298,9 @@ void out_config_debug(
 void util_set16()
 {
     // The default is 16 bits
-    tysize[TYldouble] = 10;
-    tysize[TYildouble] = 10;
-    tysize[TYcldouble] = 20;
+    _tysize[TYldouble] = 10;
+    _tysize[TYildouble] = 10;
+    _tysize[TYcldouble] = 20;
 
     _tyalignsize[TYldouble] = 2;
     _tyalignsize[TYildouble] = 2;
@@ -320,32 +320,32 @@ void util_set32()
     tyequiv[TYint] = TYlong;
     tyequiv[TYuint] = TYulong;
 
-    tysize[TYenum] = LONGSIZE;
-    tysize[TYint ] = LONGSIZE;
-    tysize[TYuint] = LONGSIZE;
-    tysize[TYnullptr] = LONGSIZE;
-    tysize[TYnptr] = LONGSIZE;
-    tysize[TYnref] = LONGSIZE;
+    _tysize[TYenum] = LONGSIZE;
+    _tysize[TYint ] = LONGSIZE;
+    _tysize[TYuint] = LONGSIZE;
+    _tysize[TYnullptr] = LONGSIZE;
+    _tysize[TYnptr] = LONGSIZE;
+    _tysize[TYnref] = LONGSIZE;
 #if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-    tysize[TYldouble] = 12;
-    tysize[TYildouble] = 12;
-    tysize[TYcldouble] = 24;
+    _tysize[TYldouble] = 12;
+    _tysize[TYildouble] = 12;
+    _tysize[TYcldouble] = 24;
 #elif TARGET_OSX
-    tysize[TYldouble] = 16;
-    tysize[TYildouble] = 16;
-    tysize[TYcldouble] = 32;
+    _tysize[TYldouble] = 16;
+    _tysize[TYildouble] = 16;
+    _tysize[TYcldouble] = 32;
 #elif TARGET_WINDOS
-    tysize[TYldouble] = 10;
-    tysize[TYildouble] = 10;
-    tysize[TYcldouble] = 20;
+    _tysize[TYldouble] = 10;
+    _tysize[TYildouble] = 10;
+    _tysize[TYcldouble] = 20;
 #else
     assert(0);
 #endif
-    tysize[TYsptr] = LONGSIZE;
-    tysize[TYcptr] = LONGSIZE;
-    tysize[TYfptr] = 6;     // NOTE: There are codgen test that check
-    tysize[TYvptr] = 6;     // tysize[x] == tysize[TYfptr] so don't set
-    tysize[TYfref] = 6;     // tysize[TYfptr] to tysize[TYnptr]
+    _tysize[TYsptr] = LONGSIZE;
+    _tysize[TYcptr] = LONGSIZE;
+    _tysize[TYfptr] = 6;     // NOTE: There are codgen test that check
+    _tysize[TYvptr] = 6;     // _tysize[x] == _tysize[TYfptr] so don't set
+    _tysize[TYfref] = 6;     // _tysize[TYfptr] to _tysize[TYnptr]
 
     _tyalignsize[TYenum] = LONGSIZE;
     _tyalignsize[TYint ] = LONGSIZE;
@@ -385,28 +385,28 @@ void util_set64()
     tyequiv[TYint] = TYlong;
     tyequiv[TYuint] = TYulong;
 
-    tysize[TYenum] = LONGSIZE;
-    tysize[TYint ] = LONGSIZE;
-    tysize[TYuint] = LONGSIZE;
-    tysize[TYnullptr] = 8;
-    tysize[TYnptr] = 8;
-    tysize[TYnref] = 8;
+    _tysize[TYenum] = LONGSIZE;
+    _tysize[TYint ] = LONGSIZE;
+    _tysize[TYuint] = LONGSIZE;
+    _tysize[TYnullptr] = 8;
+    _tysize[TYnptr] = 8;
+    _tysize[TYnref] = 8;
 #if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS || TARGET_OSX
-    tysize[TYldouble] = 16;
-    tysize[TYildouble] = 16;
-    tysize[TYcldouble] = 32;
+    _tysize[TYldouble] = 16;
+    _tysize[TYildouble] = 16;
+    _tysize[TYcldouble] = 32;
 #elif TARGET_WINDOS
-    tysize[TYldouble] = 10;
-    tysize[TYildouble] = 10;
-    tysize[TYcldouble] = 20;
+    _tysize[TYldouble] = 10;
+    _tysize[TYildouble] = 10;
+    _tysize[TYcldouble] = 20;
 #else
     assert(0);
 #endif
-    tysize[TYsptr] = 8;
-    tysize[TYcptr] = 8;
-    tysize[TYfptr] = 10;    // NOTE: There are codgen test that check
-    tysize[TYvptr] = 10;    // tysize[x] == tysize[TYfptr] so don't set
-    tysize[TYfref] = 10;    // tysize[TYfptr] to tysize[TYnptr]
+    _tysize[TYsptr] = 8;
+    _tysize[TYcptr] = 8;
+    _tysize[TYfptr] = 10;    // NOTE: There are codgen test that check
+    _tysize[TYvptr] = 10;    // _tysize[x] == _tysize[TYfptr] so don't set
+    _tysize[TYfref] = 10;    // _tysize[TYfptr] to _tysize[TYnptr]
 
     _tyalignsize[TYenum] = LONGSIZE;
     _tyalignsize[TYint ] = LONGSIZE;

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -471,10 +471,10 @@ typedef unsigned        targ_uns;
 #define DOUBLESIZE      8
 #define TMAXSIZE        16      // largest size a constant can be
 
-#define intsize         tysize[TYint]
-#define REGSIZE         tysize[TYnptr]
-#define NPTRSIZE        tysize[TYnptr]
-#define FPTRSIZE        tysize[TYfptr]
+#define intsize         _tysize[TYint]
+#define REGSIZE         _tysize[TYnptr]
+#define NPTRSIZE        _tysize[TYnptr]
+#define FPTRSIZE        _tysize[TYfptr]
 #define REGMASK         0xFFFF
 
 // targ_llong is also used to store host pointers, so it should have at least their size

--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -839,7 +839,7 @@ code *fixresult87(elem *e,regm_t retregs,regm_t *pretregs)
     c1 = CNIL;
     c2 = CNIL;
     tym = tybasic(e->Ety);
-    sz = tysize[tym];
+    sz = _tysize[tym];
     //printf("tym = x%x, sz = %d\n", tym, sz);
 
     if (*pretregs & mST01)
@@ -2427,7 +2427,7 @@ code *opmod_complex87(elem *e,regm_t *pretregs)
      */
 
     ty1 = tybasic(e->E1->Ety);
-    sz2 = tysize[ty1] / 2;
+    sz2 = _tysize[ty1] / 2;
 
     retregs = mST0;
     cr = codelem(e->E2,&retregs,FALSE);         // FLD E2
@@ -2503,7 +2503,7 @@ code *opass_complex87(elem *e,regm_t *pretregs)
     unsigned sz2;
 
     ty1 = tybasic(e->E1->Ety);
-    sz2 = tysize[ty1] / 2;
+    sz2 = _tysize[ty1] / 2;
     switch (e->Eoper)
     {   case OPpostinc:
         case OPaddass:  op = 0 << 3;            // FADD
@@ -2791,7 +2791,7 @@ code *cdnegass87(elem *e,regm_t *pretregs)
     //printf("cdnegass87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
     elem *e1 = e->E1;
     tym_t tyml = tybasic(e1->Ety);            // type of lvalue
-    int sz = tysize[tyml];
+    int sz = _tysize[tyml];
 
     cl = getlvalue87(&cs,e1,0);
 
@@ -2894,7 +2894,7 @@ code *post87(elem *e,regm_t *pretregs)
         cl = cat(cl,push87());
         cl = gen(cl,&cs);               // FLD e->E1
         if (tycomplex(ty1))
-        {   unsigned sz = tysize[ty1] / 2;
+        {   unsigned sz = _tysize[ty1] / 2;
 
             cl = cat(cl,push87());
             cs.IEVoffset1 += sz;
@@ -3664,7 +3664,7 @@ code *fixresult_complex87(elem *e,regm_t retregs,regm_t *pretregs)
     c1 = CNIL;
     c2 = CNIL;
     tym = tybasic(e->Ety);
-    sz = tysize[tym];
+    sz = _tysize[tym];
 
     if (*pretregs == 0 && retregs == mST01)
     {
@@ -3818,7 +3818,7 @@ __body
     int i;
 
     //printf("cload87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
-    sz = tysize[ty] / 2;
+    sz = _tysize[ty] / 2;
     memset(&cs, 0, sizeof(cs));
     if (ADDFWAIT())
         cs.Iflags = CFwait;

--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -1828,7 +1828,7 @@ code *allocreg(regm_t *pretregs,unsigned *preg,tym_t tym
         }
 #endif
         tym = tybasic(tym);
-        unsigned size = tysize[tym];
+        unsigned size = _tysize[tym];
         *pretregs &= mES | allregs | XMMREGS;
         regm_t retregs = *pretregs;
         if ((retregs & regcon.mvar) == retregs) // if exactly in reg vars
@@ -2327,7 +2327,7 @@ if (regcon.cse.mval & 1) elem_print(regcon.cse.value[0]);
 #endif
 
   tym = tybasic(e->Ety);
-  sz = tysize[tym];
+  sz = _tysize[tym];
   byte = sz == 1;
 
   if (sz <= REGSIZE || tyvector(tym))                   // if data will fit in one register

--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -848,9 +848,9 @@ L1:
             ety = tybasic(e->Ety);
             e11ty = tybasic(e1->E1->Ety);
             if (typtr(ety) && typtr(e11ty) &&
-                tysize[ety] != tysize[e11ty])
+                _tysize[ety] != _tysize[e11ty])
             {
-                e = el_una((tysize[ety] > tysize[e11ty]) ? OPnp_fp : OPoffset,
+                e = el_una((_tysize[ety] > _tysize[e11ty]) ? OPnp_fp : OPoffset,
                             e->Ety,e);
                 e->E1->Ety = e1->Ety;
             }
@@ -4013,7 +4013,7 @@ L1:
                 tym_t ty;
 
                 ty = tybasic(e2->Ety);
-                switch (tysize[ty])
+                switch (_tysize[ty])
                 {   case 1:     ty = TYschar;   break;
                     case 2:     ty = TYshort;   break;
                     default:    assert(0);

--- a/src/backend/cgxmm.c
+++ b/src/backend/cgxmm.c
@@ -409,7 +409,7 @@ code *xmmopass(elem *e,regm_t *pretregs)
 {   elem *e1 = e->E1;
     elem *e2 = e->E2;
     tym_t ty1 = tybasic(e1->Ety);
-    unsigned sz1 = tysize[ty1];
+    unsigned sz1 = _tysize[ty1];
     regm_t rretregs = XMMREGS & ~*pretregs;
     if (!rretregs)
         rretregs = XMMREGS;
@@ -485,7 +485,7 @@ code *xmmneg(elem *e,regm_t *pretregs)
     //elem_print(e);
     assert(*pretregs);
     tym_t tyml = tybasic(e->E1->Ety);
-    int sz = tysize[tyml];
+    int sz = _tysize[tyml];
 
     regm_t retregs = *pretregs & XMMREGS;
     if (!retregs)
@@ -847,7 +847,7 @@ code *cdvector(elem *e, regm_t *pretregs)
     assert(!isXMMstore(op));
 #endif
     tym_t ty1 = tybasic(op1->Ety);
-    unsigned sz1 = tysize[ty1];
+    unsigned sz1 = _tysize[ty1];
 //    assert(sz1 == 16);       // float or double
 
     regm_t retregs;

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -1123,7 +1123,7 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
          */
 
         if (!I16 && e1isadd && (!e1->Ecount || !e1free) &&
-            (tysize[e1ty] == REGSIZE || (I64 && tysize[e1ty] == 4)))
+            (_tysize[e1ty] == REGSIZE || (I64 && _tysize[e1ty] == 4)))
         {   code *c2;
             regm_t idxregs2;
             unsigned base,index;
@@ -1509,7 +1509,7 @@ code *tstresult(regm_t regm,tym_t tym,unsigned saveflag)
   tym = tybasic(tym);
   code *ce = CNIL;
   unsigned reg = findreg(regm);
-  unsigned sz = tysize[tym];
+  unsigned sz = _tysize[tym];
   if (sz == 1)
   {     assert(regm & BYTEREGS);
         ce = genregs(ce,0x84,reg,reg);        // TEST regL,regL
@@ -1668,7 +1668,7 @@ code *fixresult(elem *e,regm_t retregs,regm_t *pretregs)
   }
 #endif
   c = CNIL;
-  sz = tysize[tym];
+  sz = _tysize[tym];
   if (sz == 1)
   {
         assert(retregs & BYTEREGS);
@@ -4119,7 +4119,7 @@ code *pushParams(elem *e,unsigned stackalign)
         s = e->EV.sp.Vsym;
         //if (sytab[s->Sclass] & SCSS && !I32)  // if variable is on stack
         //    needframe = TRUE;                 // then we need stack frame
-        if (tysize[tym] == tysize(TYfptr) &&
+        if (_tysize[tym] == tysize(TYfptr) &&
             (fl = s->Sfl) != FLfardata &&
             /* not a function that CS might not be the segment of       */
             (!((fl == FLfunc || s->ty() & mTYcs) &&
@@ -4148,7 +4148,7 @@ code *pushParams(elem *e,unsigned stackalign)
         if (config.target_cpu >= TARGET_80286 && !e->Ecount)
         {
             stackpush += sz;
-            if (tysize[tym] == tysize(TYfptr))
+            if (_tysize[tym] == tysize(TYfptr))
             {
                 /* PUSH SEG e   */
                 code *c1 = gencs(CNIL,0x68,0,FLextern,s);
@@ -4479,7 +4479,7 @@ code *loaddata(elem *e,regm_t *pretregs)
                 return cload87(e, pretregs);
         }
   }
-  sz = tysize[tym];
+  sz = _tysize[tym];
   cs.Iflags = 0;
   cs.Irex = 0;
   if (*pretregs == mPSW)

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1265,7 +1265,7 @@ void doswitch(block *b)
     code *cc = docommas(&e);
     cgstate.stackclean++;
     tym_t tys = tybasic(e->Ety);
-    int sz = tysize[tys];
+    int sz = _tysize[tys];
     bool dword = (sz == 2 * REGSIZE);
     bool mswsame = true;                // assume all msw's are the same
     targ_llong *p = b->BS.Bswitch;      // pointer to case data

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -219,7 +219,7 @@ STATIC code * opnegassdbl(elem *e,regm_t *pretregs)
         return cdnegass87(e,pretregs);
     e1 = e->E1;
     tym = tybasic(e1->Ety);
-    sz = tysize[tym];
+    sz = _tysize[tym];
 
     cl = getlvalue(&cs,e1,*pretregs ? DOUBLEREGS | mBX | mCX : 0);
     cr = modEA(&cs);
@@ -355,7 +355,7 @@ code *cdeq(elem *e,regm_t *pretregs)
             return eq87(e,pretregs);
     }
 
-  unsigned sz = tysize[tyml];           // # of bytes to transfer
+  unsigned sz = _tysize[tyml];           // # of bytes to transfer
   assert((int)sz > 0);
 
   if (retregs == 0)                     /* if no return value           */
@@ -809,7 +809,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
   reverse = 0;
   e1 = e->E1;
   tyml = tybasic(e1->Ety);              // type of lvalue
-  sz = tysize[tyml];
+  sz = _tysize[tyml];
   byte = (sz == 1);                     // 1 for byte operation, else 0
 
     // See if evaluate in XMM registers
@@ -867,7 +867,7 @@ code *cdaddass(elem *e,regm_t *pretregs)
         cr = modEA(&cs);
         cs.Irm |= modregrm(0,3,0);
         cs.Iop = op1;
-        switch (tysize[tyml])
+        switch (_tysize[tyml])
         {   case CHARSIZE:
                 c = gen(CNIL,&cs);
                 break;
@@ -1312,7 +1312,7 @@ code *cdmulass(elem *e,regm_t *pretregs)
 
     tym_t tyml = tybasic(e1->Ety);              // type of lvalue
     char uns = tyuns(tyml) || tyuns(e2->Ety);
-    unsigned sz = tysize[tyml];
+    unsigned sz = _tysize[tyml];
 
     unsigned rex = (I64 && sz == 8) ? REX_W : 0;
     unsigned grex = rex << 16;          // 64 bit operands
@@ -1556,7 +1556,7 @@ code *cdshass(elem *e,regm_t *pretregs)
   e2 = e->E2;
 
   tyml = tybasic(e1->Ety);              /* type of lvalue               */
-  sz = tysize[tyml];
+  sz = _tysize[tyml];
   byte = tybyte(e->Ety) != 0;           /* 1 for byte operations        */
   tym = tybasic(e->Ety);                /* type of result               */
   oper = e->Eoper;
@@ -1622,7 +1622,7 @@ code *cdshass(elem *e,regm_t *pretregs)
   cl = cat(cl,modEA(&cs));              // check for modifying register
 
   if (*pretregs == 0 ||                 /* if don't return result       */
-      (*pretregs == mPSW && conste2 && tysize[tym] <= REGSIZE) ||
+      (*pretregs == mPSW && conste2 && _tysize[tym] <= REGSIZE) ||
       sz > REGSIZE
      )
   {     retregs = 0;            // value not returned in a register
@@ -1740,7 +1740,7 @@ code *cdshass(elem *e,regm_t *pretregs)
                 /* it's a left shift and we're not concerned about      */
                 /* the flags. Remember that flags are not set if        */
                 /* a shift of 0 occurs.                         */
-                if (tysize[tym] == SHORTSIZE &&
+                if (_tysize[tym] == SHORTSIZE &&
                     (oper == OPshrass || oper == OPashrass ||
                      (*pretregs & mPSW && conste2)))
                      ce->Iflags |= CFopsize;            /* 16 bit operand */
@@ -1819,7 +1819,7 @@ code *cdcmp(elem *e,regm_t *pretregs)
   eqorne = (op == OPeqeq) || (op == OPne);
 
   tym = tybasic(e1->Ety);
-  sz = tysize[tym];
+  sz = _tysize[tym];
   byte = sz == 1;
 
     unsigned rex = (I64 && sz == 8) ? REX_W : 0;
@@ -3411,7 +3411,7 @@ code *cdbtst(elem *e, regm_t *pretregs)
     }
 
     ty1 = tybasic(e1->Ety);
-    word = (!I16 && tysize[ty1] == SHORTSIZE) ? CFopsize : 0;
+    word = (!I16 && _tysize[ty1] == SHORTSIZE) ? CFopsize : 0;
 
 //    if (e2->Eoper == OPconst && e2->EV.Vuns < 0x100)  // should do this instead?
     if (e2->Eoper == OPconst)
@@ -3420,11 +3420,11 @@ code *cdbtst(elem *e, regm_t *pretregs)
         cs.Irm |= modregrm(0,mode,0);
         cs.Iflags |= CFpsw | word;
         cs.IFL2 = FLconst;
-        if (tysize[ty1] == SHORTSIZE)
+        if (_tysize[ty1] == SHORTSIZE)
         {
             cs.IEV2.Vint = e2->EV.Vint & 15;
         }
-        else if (tysize[ty1] == 4)
+        else if (_tysize[ty1] == 4)
         {
             cs.IEV2.Vint = e2->EV.Vint & 31;
         }
@@ -3445,7 +3445,7 @@ code *cdbtst(elem *e, regm_t *pretregs)
         cs.Iop = 0x0F00 | op;                     // BT rm,reg
         code_newreg(&cs,reg);
         cs.Iflags |= CFpsw | word;
-        if (I64 && tysize[ty1] == 8)
+        if (I64 && _tysize[ty1] == 8)
             cs.Irex |= REX_W;
         c2 = gen(c2,&cs);
     }
@@ -3531,7 +3531,7 @@ code *cdbt(elem *e, regm_t *pretregs)
         return cat(c, codelem(e2,pretregs,FALSE));
 
     ty1 = tybasic(e1->Ety);
-    word = (!I16 && tysize[ty1] == SHORTSIZE) ? CFopsize : 0;
+    word = (!I16 && _tysize[ty1] == SHORTSIZE) ? CFopsize : 0;
     idxregs = idxregm(&cs);         // mask if index regs used
 
 //    if (e2->Eoper == OPconst && e2->EV.Vuns < 0x100)  // should do this instead?
@@ -3541,12 +3541,12 @@ code *cdbt(elem *e, regm_t *pretregs)
         cs.Irm |= modregrm(0,mode,0);
         cs.Iflags |= CFpsw | word;
         cs.IFL2 = FLconst;
-        if (tysize[ty1] == SHORTSIZE)
+        if (_tysize[ty1] == SHORTSIZE)
         {
             cs.IEVoffset1 += (e2->EV.Vuns & ~15) >> 3;
             cs.IEV2.Vint = e2->EV.Vint & 15;
         }
-        else if (tysize[ty1] == 4)
+        else if (_tysize[ty1] == 4)
         {
             cs.IEVoffset1 += (e2->EV.Vuns & ~31) >> 3;
             cs.IEV2.Vint = e2->EV.Vint & 31;
@@ -3574,7 +3574,7 @@ code *cdbt(elem *e, regm_t *pretregs)
 
     if ((retregs = (*pretregs & (ALLREGS | mBP))) != 0) // if return result in register
     {
-        if (tysize[e->Ety] == 1)
+        if (_tysize[e->Ety] == 1)
         {
             assert(I64 || retregs & BYTEREGS);
             code *cg = allocreg(&retregs,&reg,TYint);
@@ -3631,7 +3631,7 @@ code *cdbscan(elem *e, regm_t *pretregs)
     if (*pretregs == 0)
         return codelem(e->E1,pretregs,FALSE);
     tyml = tybasic(e->E1->Ety);
-    sz = tysize[tyml];
+    sz = _tysize[tyml];
     assert(sz == 2 || sz == 4 || sz == 8);
 
     if ((e->E1->Eoper == OPind && !e->E1->Ecount) || e->E1->Eoper == OPvar)
@@ -3683,7 +3683,7 @@ code *cdpopcnt(elem *e,regm_t *pretregs)
 
     tym_t tyml = tybasic(e->E1->Ety);
 
-    int sz = tysize[tyml];
+    int sz = _tysize[tyml];
     assert(sz == 2 || sz == 4 || (sz == 8 && I64));     // no byte op
 
     if ((e->E1->Eoper == OPind && !e->E1->Ecount) || e->E1->Eoper == OPvar)
@@ -3790,7 +3790,7 @@ code *cdcmpxchg(elem *e, regm_t *pretregs)
     assert(!e2->Ecount);
 
     tym_t tyml = tybasic(e1->Ety);              // type of lvalue
-    unsigned sz = tysize[tyml];
+    unsigned sz = _tysize[tyml];
 
     if (I32 && sz == 8)
     {

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1033,7 +1033,7 @@ elem * evalu8(elem *e, goal_t goal)
 
             default:
                 if (intsize == 2 &&
-                    tyfv(tym) && tysize[tym2] == 2)
+                    tyfv(tym) && _tysize[tym2] == 2)
                     e->EV.Vllong = (l1 & 0xFFFF0000) |
                         (targ_ushort) ((targ_ushort) l1 - i2);
                 else if (tyintegral(tym) || typtr(tym))
@@ -1573,7 +1573,7 @@ elem * evalu8(elem *e, goal_t goal)
 #endif
 
     case OPpair:
-        switch (tysize[tym])
+        switch (_tysize[tym])
         {
             case 2:
                 e->EV.Vlong = (i2 << 16) | (i1 & 0xFFFF);

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -897,7 +897,7 @@ void dotytab()
     static tym_t tytouns[64 * 4];
     static tym_t _tyrelax[TYMAX];
     static tym_t _tyequiv[TYMAX];
-    static signed char tysize[64 * 4];
+    static signed char _tysize[64 * 4];
     static const char *tystring[TYMAX];
     static unsigned char dttab[TYMAX];
     static unsigned short dttab4[TYMAX];
@@ -969,19 +969,19 @@ void dotytab()
     fprintf(f,"\n};\n");
 
     for (i = 0; i < arraysize(typetab); i++)
-    {   tysize[typetab[i].ty | 0x00] = typetab[i].size;
-        /*printf("tysize[%d] = %d\n",typetab[i].ty,typetab[i].size);*/
+    {   _tysize[typetab[i].ty | 0x00] = typetab[i].size;
+        /*printf("_tysize[%d] = %d\n",typetab[i].ty,typetab[i].size);*/
     }
-    fprintf(f,"signed char tysize[] =\n{ ");
-    for (i = 0; i < arraysize(tysize); i++)
-    {   fprintf(f,"%d,",tysize[i]);
-        if ((i & 7) == 7 && i < arraysize(tysize) - 1)
+    fprintf(f,"signed char _tysize[] =\n{ ");
+    for (i = 0; i < arraysize(_tysize); i++)
+    {   fprintf(f,"%d,",_tysize[i]);
+        if ((i & 7) == 7 && i < arraysize(_tysize) - 1)
             fprintf(f,"\n  ");
     }
     fprintf(f,"\n};\n");
 
-    for (i = 0; i < arraysize(tysize); i++)
-        tysize[i] = 0;
+    for (i = 0; i < arraysize(_tysize); i++)
+        _tysize[i] = 0;
     for (i = 0; i < arraysize(typetab); i++)
     {   signed char sz = typetab[i].size;
         switch (typetab[i].ty)
@@ -1005,13 +1005,13 @@ void dotytab()
                 sz = 8;
                 break;
         }
-        tysize[typetab[i].ty | 0x00] = sz;
+        _tysize[typetab[i].ty | 0x00] = sz;
         /*printf("_tyalignsize[%d] = %d\n",typetab[i].ty,typetab[i].size);*/
     }
     fprintf(f,"signed char _tyalignsize[] =\n{ ");
-    for (i = 0; i < arraysize(tysize); i++)
-    {   fprintf(f,"%d,",tysize[i]);
-        if ((i & 7) == 7 && i < arraysize(tysize) - 1)
+    for (i = 0; i < arraysize(_tysize); i++)
+    {   fprintf(f,"%d,",_tysize[i]);
+        if ((i & 7) == 7 && i < arraysize(_tysize) - 1)
             fprintf(f,"\n  ");
     }
     fprintf(f,"\n};\n");

--- a/src/backend/ty.h
+++ b/src/backend/ty.h
@@ -207,11 +207,11 @@ enum
 };
 
 /* Array to give the size in bytes of a type, -1 means error    */
-extern signed char tysize[];
+extern signed char _tysize[];
 extern signed char _tyalignsize[];
 
 // Give size of type
-#define tysize(ty) tysize[(ty) & 0xFF]
+#define tysize(ty) _tysize[(ty) & 0xFF]
 #define tyalignsize(ty) _tyalignsize[(ty) & 0xFF]
 
 

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -59,7 +59,7 @@ targ_size_t type_size(type *t)
         dbg_printf("tyb = x%lx\n",(long)tyb);
 #endif
     assert(tyb < TYMAX);
-    s = tysize[tyb];
+    s = _tysize[tyb];
     if (s == (targ_size_t) -1)
     {
         switch (tyb)
@@ -93,7 +93,7 @@ targ_size_t type_size(type *t)
                 }
                 if (t->Tflags & TFvla)
                 {
-                    s = tysize[pointertype];
+                    s = _tysize[pointertype];
                     break;
                 }
                 s = type_size(t->Tnext);


### PR DESCRIPTION
This fixes the conflict between the declaration `tysize` and the macro `tysize`.
