### PR TITLE
rename backend.d to backend/type.d

### DIFF
--- a/src/backend/dt.d
+++ b/src/backend/dt.d
@@ -10,7 +10,7 @@
 
 module ddmd.backend.dt;
 
-import ddmd.backenddecls;
+import ddmd.backend.type;
 
 //struct Symbol;
 //alias uint tym_t;

--- a/src/backend/type.d
+++ b/src/backend/type.d
@@ -5,10 +5,14 @@
  * Copyright:   Copyright (c) 1999-2016 by Digital Mars, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(DMDSRC _backend.d)
+ * Source:      $(DMDSRC backend/_type.d)
  */
 
-module ddmd.backenddecls;
+module ddmd.backend.type;
+
+extern (C++):
+@nogc:
+nothrow:
 
 struct Symbol;
 struct code;
@@ -28,24 +32,24 @@ struct LIST;
 alias list_t = LIST*;
 alias type = TYPE;
 
-extern extern (C++) type* type_fake(tym_t);
-extern extern (C++) void type_incCount(type* t);
-extern extern (C++) void type_setIdent(type* t, char* ident);
+type* type_fake(tym_t);
+void type_incCount(type* t);
+void type_setIdent(type* t, char* ident);
 
-extern extern (C++) type* type_alloc(tym_t);
-extern extern (C++) type* type_allocn(tym_t, type* tn);
+type* type_alloc(tym_t);
+type* type_allocn(tym_t, type* tn);
 
-extern extern (C++) type* type_pointer(type* tnext);
-extern extern (C++) type* type_dyn_array(type* tnext);
+type* type_pointer(type* tnext);
+type* type_dyn_array(type* tnext);
 extern extern (C) type* type_static_array(targ_size_t dim, type* tnext);
-extern extern (C++) type* type_assoc_array(type* tkey, type* tvalue);
-extern extern (C++) type* type_delegate(type* tnext);
+type* type_assoc_array(type* tkey, type* tvalue);
+type* type_delegate(type* tnext);
 extern extern (C) type* type_function(tym_t tyf, type** ptypes, size_t nparams, bool variadic, type* tret);
-extern extern (C++) type* type_enum(const(char)* name, type* tbase);
-extern extern (C++) type* type_struct_class(const(char)* name, uint alignsize, uint structsize,
+type* type_enum(const(char)* name, type* tbase);
+type* type_struct_class(const(char)* name, uint alignsize, uint structsize,
     type* arg1type, type* arg2type, bool isUnion, bool isClass, bool isPOD);
 
-extern extern (C++) void symbol_struct_addField(Symbol* s, const(char)* name, type* t, uint offset);
+void symbol_struct_addField(Symbol* s, const(char)* name, type* t, uint offset);
 
 enum mTYbasic     = 0xFF; /* bit mask for basic types     */
 enum mTYconst     = 0x100;
@@ -147,11 +151,6 @@ enum
     TYulong4            = 0x45, // uint[4]
     TYllong2            = 0x46, // long[2]
     TYullong2           = 0x47, // ulong[2]
-
-// // MARS types
-// #define TYaarray        TYnptr
-// #define TYdelegate      (I64 ? TYcent : TYllong)
-// #define TYdarray        (I64 ? TYucent : TYullong)
 
     TYMAX               = 0x48,
 }

--- a/src/gluelayer.d
+++ b/src/gluelayer.d
@@ -55,14 +55,14 @@ version (NoBackend)
 }
 else
 {
-    import ddmd.backenddecls;
+    import ddmd.backend.type;
 
-    alias Symbol = ddmd.backenddecls.Symbol;
-    alias code = ddmd.backenddecls.code;
-    alias block = ddmd.backenddecls.block;
-    alias Blockx = ddmd.backenddecls.Blockx;
-    alias elem = ddmd.backenddecls.elem;
-    alias type = ddmd.backenddecls.type;
+    alias Symbol = ddmd.backend.type.Symbol;
+    alias code = ddmd.backend.type.code;
+    alias block = ddmd.backend.type.block;
+    alias Blockx = ddmd.backend.type.Blockx;
+    alias elem = ddmd.backend.type.elem;
+    alias type = ddmd.backend.type.type;
 
     extern (C++)
     {

--- a/src/irstate.d
+++ b/src/irstate.d
@@ -11,7 +11,7 @@
 module ddmd.irstate;
 
 import ddmd.arraytypes;
-import ddmd.backenddecls;
+import ddmd.backend.type;
 import ddmd.dmodule;
 import ddmd.dsymbol;
 import ddmd.func;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -235,7 +235,7 @@ else
     FRONT_SRCS += libelf.d scanelf.d
 endif
 
-GLUE_SRCS=$(addsuffix .d,backend irstate toelfdebug toctype gluelayer todt)
+GLUE_SRCS=$(addsuffix .d, irstate toelfdebug toctype gluelayer todt)
 
 DMD_SRCS=$(FRONT_SRCS) $(GLUE_SRCS) $(BACK_HDR)
 
@@ -276,7 +276,7 @@ GLUE_SRC = glue.c msc.c s2ir.c e2ir.c tocsym.c \
 	toelfdebug.d libelf.d scanelf.d libmach.d scanmach.d \
 	tk.c eh.c gluestub.d objc_glue.c objc_glue_stubs.c
 
-BACK_HDR= $C/cgcv.d $C/dt.d
+BACK_HDR= $C/cgcv.d $C/dt.d $C/type.d
 
 BACK_SRC = \
 	$C/cdef.h $C/cc.h $C/oper.h $C/ty.h $C/optabgen.c \

--- a/src/toctype.d
+++ b/src/toctype.d
@@ -12,7 +12,7 @@ module ddmd.toctype;
 
 import core.stdc.stdlib;
 
-import ddmd.backenddecls;
+import ddmd.backend.type;
 import ddmd.declaration;
 import ddmd.dstruct;
 import ddmd.globals;

--- a/src/todt.d
+++ b/src/todt.d
@@ -18,7 +18,7 @@ import ddmd.root.rmem;
 
 import ddmd.aggregate;
 import ddmd.arraytypes;
-import ddmd.backenddecls;
+import ddmd.backend.type;
 import ddmd.complex;
 import ddmd.ctfeexpr;
 import ddmd.declaration;

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -154,9 +154,9 @@ FRONT_SRCS=access.d aggregate.d aliasthis.d apply.d argtypes.d arrayop.d	\
 	traits.d utf.d utils.d visitor.d libomf.d scanomf.d typinf.d \
 	libmscoff.d scanmscoff.d statementsem.d
 
-GLUE_SRCS=irstate.d toctype.d backend.d gluelayer.d todt.d
+GLUE_SRCS=irstate.d toctype.d gluelayer.d todt.d
 
-BACK_HDRS=$C/cgcv.d $C/dt.d
+BACK_HDRS=$C/cgcv.d $C/dt.d $C/type.d
 
 DMD_SRCS=$(FRONT_SRCS) $(GLUE_SRCS) $(BACK_HDRS)
 


### PR DESCRIPTION
Moving towards .d versions of backend .h files.
