### PR TITLE
Fix building with MSVC:

### DIFF
--- a/src/complex_t.h
+++ b/src/complex_t.h
@@ -22,7 +22,7 @@ struct complex_t
     real_t re;
     real_t im;
 
-    complex_t(real_t re) : re(re), im(0) {}
+    complex_t(real_t re) : re(re), im(ldouble(0)) {}
     complex_t(real_t re, real_t im) : re(re), im(im) {}
 
     complex_t operator + (complex_t y) { return complex_t(re + y.re, im + y.im); }
@@ -54,7 +54,7 @@ struct complex_t
     int operator != (complex_t y) { return re != y.re || im != y.im; }
 
 private:
-    complex_t() : re(0), im(0) {}
+    complex_t() : re(ldouble(0)), im(ldouble(0)) {}
 };
 
 inline complex_t operator * (real_t x, complex_t y) { return complex_t(x) * y; }

--- a/src/root/ctfloat.d
+++ b/src/root/ctfloat.d
@@ -82,6 +82,15 @@ extern (C++) struct CTFloat
         return isNaN(r) && !(((cast(ubyte*)&r)[7]) & 0x40);
     }
 
+    // the implementation of longdouble for MSVC is a struct, so mangling
+    //  doesn't match with the C++ header.
+    // add a wrapper just for isSNaN as this is the only function called from C++
+    version(CRuntime_Microsoft)
+        static bool isSNaN(longdouble ld)
+        {
+            return isSNaN(ld.r);
+        }
+
     static bool isInfinity(real_t r)
     {
         return r is real_t.infinity || r is -real_t.infinity;

--- a/src/vcbuild/ddmd.visualdproj
+++ b/src/vcbuild/ddmd.visualdproj
@@ -435,6 +435,9 @@
    </Folder>
   </Folder>
   <Folder name="src">
+   <Folder name="backend">
+    <File path="..\backend\dt.d" />
+   </Folder>
    <Folder name="root">
     <File path="..\root\aav.d" />
     <File path="..\root\array.d" />


### PR DESCRIPTION
- no implicit conversion int -> longdouble
- bad signature for CTFloat::isSNaN
- add missing file to project

The ctfloat.h header is all wrong for MSVC because the mangling of D's real and C++'s longdouble are different. I fixed the only used member isSNaN, but I think the CTFloat shouldn't be used by the backend to begin with as it introduces a reverse dependency.
