### PR TITLE
reduce Travis-CI workload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,22 +15,18 @@ addons:
     - libcurl3-gnutls:i386
 
 env:
-  - MODEL=32 SELF_COMPILE=0
-  - MODEL=32 SELF_COMPILE=2
-  - MODEL=64 SELF_COMPILE=0
-  - MODEL=64 SELF_COMPILE=2
+  - MODEL=32
+  - MODEL=64
 
 matrix:
   include:
     - os: osx
       d: dmd
-      env: MODEL=32 SELF_COMPILE=0
+      env: MODEL=32
     - os: osx
       d: dmd
-      env: MODEL=64 SELF_COMPILE=0
+      env: MODEL=64
   exclude:
     # gdc doesn't neither comes w/ multilib support nor picks up system-wide -lstdc++ lgcc_s
     - d: gdc
-      env: MODEL=32 SELF_COMPILE=0
-    - d: gdc
-      env: MODEL=32 SELF_COMPILE=2
+      env: MODEL=32

--- a/travis.sh
+++ b/travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -exo pipefail
+set -uexo pipefail
 
 # add missing cc link in gdc-4.9.3 download
 if [ $DC = gdc ] && [ ! -f $(dirname $(which gdc))/cc ]; then
@@ -11,30 +11,41 @@ N=2
 git clone --depth=1 --branch $TRAVIS_BRANCH https://github.com/D-Programming-Language/druntime.git ../druntime
 git clone --depth=1 --branch $TRAVIS_BRANCH https://github.com/D-Programming-Language/phobos.git ../phobos
 
-make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD all
-make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD dmd.conf
-make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
-make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
+# build dmd, druntime, phobos
+build() {
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD all
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD dmd.conf
+    make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
+    make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
+}
 
-while [ $SELF_COMPILE -gt 0 ]; do
-    # rebuild dmd using the just build dmd as host compiler
+# self-compile dmd
+rebuild() {
     mv src/dmd src/host_dmd
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd clean
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd dmd.conf
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd
-    make -j$N -C ../druntime -f posix.mak MODEL=$MODEL clean
-    make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
-    make -j$N -C ../phobos -f posix.mak MODEL=$MODEL clean
-    make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
-    rm src/host_dmd
-    SELF_COMPILE=$(($SELF_COMPILE - 1))
-done
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd all
+}
 
-make -j$N -C ../druntime -f posix.mak MODEL=$MODEL unittest
-make -j$N -C ../phobos -f posix.mak MODEL=$MODEL unittest
-# test fewer compiler argument permutations for PRs to reduce CI load
-if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    make -j$N -C test MODEL=$MODEL # all ARGS by default
-else
-    make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release"
-fi
+# test druntime, phobos, dmd
+test() {
+    make -j$N -C ../druntime -f posix.mak MODEL=$MODEL unittest
+    make -j$N -C ../phobos -f posix.mak MODEL=$MODEL unittest
+    test_dmd
+}
+
+# test dmd
+test_dmd() {
+    # test fewer compiler argument permutations for PRs to reduce CI load
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+        make -j$N -C test MODEL=$MODEL # all ARGS by default
+    else
+        make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release"
+    fi
+}
+
+build
+test
+rebuild
+rebuild
+test_dmd


### PR DESCRIPTION
- use only half of the workers by running self-compilation
  tests after normal tests
- only recompile and retest dmd, not druntime/phobos

depends on #6022
