### PR TITLE
purge deferredSemantic arrays after processing them

### DIFF
--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -1252,6 +1252,7 @@ extern (C++) final class Module : Package
             if (global.errors)
                 break;
         }
+        a.setDim(0);
     }
 
     static void runDeferredSemantic3()
@@ -1268,6 +1269,7 @@ extern (C++) final class Module : Package
             if (global.errors)
                 break;
         }
+        a.setDim(0);
     }
 
     static void clearCache()


### PR DESCRIPTION
- fixes an O(N^2) loop introduced in 201b124e6c that consumes
  20% of the runtime for our dmd, druntime, and phobos test suite
