### PR TITLE
add codecov configuration to disable comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,17 @@ codecov:
     - !travis
 
 coverage:
+  precision: 3
+  round: down
+  range: 80...100
+
+  status:
+    # Learn more at https://codecov.io/docs#yaml_default_commit_status
+    project: true
+    patch: true
+    changes: false
   fixes:
     - "test/.*/::src/"
     - "fail_compilation/::src/"
+
+comment: false


### PR DESCRIPTION
CC @MartinNowak 

Similar as https://github.com/dlang/phobos/pull/4676 and https://github.com/dlang/druntime/pull/1623 this should disable the commenting Codecov bot and only show the status in the CI box.
However decreases in the coverage will be highlighted with a red cross there, so it's probably easy enough to see for reviewers and doesn't create so much noise.

If https://github.com/codecov/support/issues/264 (only comment on changes) gets implemented, we might consider to re-enable the commenting bot.
