### PR TITLE
Remove extra_files before sending coverage reports on CircleCi

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,4 +10,6 @@ test:
         parallel: true
 
   post:
+    # CodeCov gets confused by lst files which it can't matched
+    - rm -rf test/runnable/extra-files
     - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Since the latest fixes/updates on CodeCov they seem to be more conservative about non-matching files. This is a test whether removing the stored `.lst` files before sending the coverage report works.

CC @stevepeak

```
  2016-08-07T11:19:06+02:00 seterror  GET /repos/dlang/dmd/commits/f2e34468e934f492c051b5d236fc1924fcedf0bd/statuses bot=9il code=200     
  2016-08-07T11:19:06+02:00 seterror  yaml found in cache   
  2016-08-07T11:19:06+02:00 notify  GET /repos/dlang/dmd/commits/f2e34468e934f492c051b5d236fc1924fcedf0bd/statuses bot=9il code=200     
  2016-08-07T11:19:06+02:00 notify  yaml found in cache   
  2016-08-07T11:18:57+02:00 upload  no-reports-generated  error=Error   
  2016-08-07T11:18:57+02:00 upload  True  error=Unknown-report   
  2016-08-07T11:18:57+02:00 upload  True  error=Unknown-report   
  2016-08-07T11:18:57+02:00 upload  True  error=Unknown-report   
  2016-08-07T11:18:57+02:00 upload  True  error=Unknown-report   
  2016-08-07T11:18:57+02:00 upload  Upload archived download   
```

e.g. [here](https://codecov.io/gh/dlang/dmd/commit/f2e34468e934f492c051b5d236fc1924fcedf0bd)
