### PR TITLE
Retry-loop for git clone on Travis/Circle

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -8,8 +8,22 @@ if [ $DC = gdc ] && [ ! -f $(dirname $(which gdc))/cc ]; then
 fi
 N=2
 
-git clone --depth=1 --branch $TRAVIS_BRANCH https://github.com/D-Programming-Language/druntime.git ../druntime
-git clone --depth=1 --branch $TRAVIS_BRANCH https://github.com/D-Programming-Language/phobos.git ../phobos
+# clone druntime and phobos
+clone() {
+    local url="$1"
+    local path="$2"
+    local branch="$3"
+    for i in {0..4}; do
+        if git clone --depth=1 --branch "$branch" "$url" "$path"; then
+            break
+        elif [ $i -lt 4 ]; then
+            sleep $((1 << $i))
+        else
+            echo "Failed to clone: ${url}"
+            exit 1
+        fi
+    done
+}
 
 # build dmd, druntime, phobos
 build() {
@@ -43,6 +57,9 @@ test_dmd() {
         make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release"
     fi
 }
+
+clone https://github.com/dlang/druntime.git ../druntime $TRAVIS_BRANCH
+clone https://github.com/dlang/phobos.git ../phobos $TRAVIS_BRANCH
 
 build
 test


### PR DESCRIPTION
If we want to merge only if Travis CI passes too (https://github.com/braddr/d-tester/issues/52), then it should be a bit more failure-proof.

This should hopefully better protect us against random network failures like e.g. here https://travis-ci.org/dlang/dmd/jobs/150380398

CC @MartinNowak 
