### PR TITLE
fix gdc (2.066.x) compilation

### DIFF
--- a/src/backend/ty.d
+++ b/src/backend/ty.d
@@ -293,6 +293,10 @@ uint tyfarfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLfarfunc; }
 // Determine if parameter is a SIMD vector type
 uint tysimd(tym_t ty) { return tytab[ty & 0xFF] & TYFLsimd; }
 
+// Workaround 2.066.x bug by resolving the TYMAX value before using it as dimension.
+static if (__VERSION__ <= 2066):
+    private enum computeEnumValue = TYMAX;
+
 /* Array to give the 'relaxed' type for relaxed type checking   */
 extern __gshared ubyte[TYMAX] _tyrelax;
 //#define type_relax      (config.flags3 & CFG3relax)     // !=0 if relaxed type checking


### PR DESCRIPTION
- disable extern __gshared array declarations
