### PR TITLE
[Trivial] Fix C++ header after PR #6001.

### DIFF
--- a/src/module.h
+++ b/src/module.h
@@ -127,9 +127,9 @@ public:
     bool read(Loc loc); // read file, returns 'true' if succeed, 'false' otherwise.
     Module *parse();    // syntactic parse
     void importAll(Scope *sc);
-    void semantic();    // semantic analysis
-    void semantic2();   // pass 2 semantic analysis
-    void semantic3();   // pass 3 semantic analysis
+    void semantic(Scope *);    // semantic analysis
+    void semantic2(Scope *);   // pass 2 semantic analysis
+    void semantic3(Scope *);   // pass 3 semantic analysis
     int needModuleInfo();
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
     Dsymbol *symtabInsert(Dsymbol *s);


### PR DESCRIPTION
This `module.h` header change should have been part of https://github.com/dlang/dmd/pull/6001.

Ping @yebblies 
