### PR TITLE
Fix TypeInfo.init deprecation notice

### DIFF
--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -189,22 +189,22 @@ else
 
         extern (C) Object _d_newclass(const ClassInfo ci) nothrow
         {
-            auto p = allocmemory(ci.init.length);
-            p[0 .. ci.init.length] = cast(void[])ci.init[];
+            auto p = allocmemory(ci.initializer.length);
+            p[0 .. ci.initializer.length] = cast(void[])ci.initializer[];
             return cast(Object)p;
         }
 
         extern (C) void* _d_newitemT(TypeInfo ti) nothrow
         {
             auto p = allocmemory(ti.tsize);
-            (cast(ubyte*)p)[0 .. ti.init.length] = 0;
+            (cast(ubyte*)p)[0 .. ti.initializer.length] = 0;
             return p;
         }
 
         extern (C) void* _d_newitemiT(TypeInfo ti) nothrow
         {
             auto p = allocmemory(ti.tsize);
-            p[0 .. ti.init.length] = ti.init[];
+            p[0 .. ti.initializer.length] = ti.initializer[];
             return p;
         }
     }


### PR DESCRIPTION
I saw these deprecation notices popping up. Any reason not to fix them?

```
root/rmem.d(192): Deprecation: alias object.TypeInfo.init is deprecated - Please use initializer instead.
root/rmem.d(193): Deprecation: alias object.TypeInfo.init is deprecated - Please use initializer instead.
root/rmem.d(193): Deprecation: alias object.TypeInfo.init is deprecated - Please use initializer instead.
root/rmem.d(200): Deprecation: alias object.TypeInfo.init is deprecated - Please use initializer instead.
root/rmem.d(207): Deprecation: alias object.TypeInfo.init is deprecated - Please use initializer instead.
root/rmem.d(207): Deprecation: alias object.TypeInfo.init is deprecated - Please use initializer instead.
```
