### PR TITLE
add unittests to check cross-language struct sizes

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -442,3 +442,8 @@ void util_set64()
     TYdelegate = TYcent;
     TYdarray = TYucent;
 }
+
+unsigned Config::sizeCheck() { return sizeof(Config); }
+unsigned Configv::sizeCheck() { return sizeof(Configv); }
+unsigned eve::sizeCheck() { return sizeof(eve); }
+

--- a/src/backend/cdef.d
+++ b/src/backend/cdef.d
@@ -679,6 +679,9 @@ struct Config
                                 // to near
     linkage_t linkage;          // default function call linkage
     EHmethod ehmethod;          // exception handling method
+
+    static uint sizeCheck();
+    unittest { assert(sizeCheck() == Config.sizeof); }
 }
 
 enum THRESHMAX = 0xFFFF;
@@ -703,6 +706,9 @@ struct Configv
     char* deflibname;           // default library name
     LANG language;              // message language
     int errmax;                 // max error count
+
+    static uint sizeCheck();
+    unittest { assert(sizeCheck() == Configv.sizeof); }
 }
 
 struct Classsym;
@@ -820,6 +826,9 @@ union eve
             elem* Eleft2;       // left child for OPddtor
             void* Edecl;        // VarDeclaration being constructed
         }                       // OPdctor,OPddtor
+
+    static uint sizeCheck();
+    unittest { assert(sizeCheck() == eve.sizeof); }
 }                               // variants for each type of elem
 
 // Symbols

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -898,7 +898,10 @@ struct Config
                                 // to near
     linkage_t linkage;          // default function call linkage
     EHmethod ehmethod;          // exception handling method
+
+    static unsigned sizeCheck();
 };
+
 
 // Configuration that is not saved in precompiled header
 
@@ -912,6 +915,8 @@ struct Configv
     char *deflibname;           // default library name
     enum LANG language;         // message language
     int errmax;                 // max error count
+
+    static unsigned sizeCheck();
 };
 
 struct Classsym;
@@ -1024,6 +1029,8 @@ union eve
             elem *Eleft;        // left child for OPddtor
             void *Edecl;        // VarDeclaration being constructed
         } ed;                   // OPdctor,OPddtor
+
+    static unsigned sizeCheck();
 };                              // variants for each type of elem
 
 // Symbols

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -124,7 +124,7 @@ DOPT=
 # D Model flags
 DMODEL=
 # D Debug flags
-DDEBUG=-debug -g
+DDEBUG=-debug -g -unittest
 
 ##### Implementation variables (do not modify)
 


### PR DESCRIPTION
Simple check that the sizes of critical structs on C++ and D sides match when unittest'ed.
