### PR TITLE
Fix whitespace issue in posix.mak

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -66,7 +66,8 @@ ifeq (,$(AUTO_BOOTSTRAP))
   HOST_DMD_RUN:=$(HOST_DMD)
 else
   # Auto-bootstrapping, will download dmd automatically
-  HOST_DMD_VER=2.068.2 # keep in sync with other occurences of that variable, e.g. in circleci.sh
+  # keep in sync with other occurences of that variable, e.g. in circleci.sh
+  HOST_DMD_VER=2.068.2
   HOST_DMD_ROOT=/tmp/.host_dmd-$(HOST_DMD_VER)
   # dmd.2.068.2.osx.zip or dmd.2.068.2.linux.tar.xz
   HOST_DMD_BASENAME=dmd.$(HOST_DMD_VER).$(OS)$(if $(filter $(OS),freebsd),-$(MODEL),)


### PR DESCRIPTION
as pointed out by @JackStouffer here: https://github.com/dlang/dmd/pull/6022#issuecomment-238328228

With the comment we add a whitespace to the version.
