### PR TITLE
[CircleCi] add more soft fallbacks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,13 +6,12 @@ dependencies:
 
 test:
   override:
+    - ./circleci.sh setup-repos
     - ./circleci.sh coverage:
         parallel: true
 
   post:
-    # CodeCov gets confused by lst files which it can't matched
-    - rm -rf test/runnable/extra-files
-    - bash <(curl -s https://codecov.io/bash)
+    - ./circleci.sh codecov
 
 general:
   branches:

--- a/circleci.sh
+++ b/circleci.sh
@@ -6,6 +6,7 @@ HOST_DMD_VER=2.072.2 # same as in dmd/src/posix.mak
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=2
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-dmd}
 
 case $CIRCLE_NODE_INDEX in
     0) MODEL=64 ;;
@@ -29,38 +30,50 @@ clone() {
     done
 }
 
-install_deps() {
-    if [ $MODEL -eq 32 ]; then
-        sudo aptitude install g++-multilib --assume-yes --quiet=2
-    fi
-
+download() {
+    local url="$1"
+    local fallbackurl="$2"
+    local outputfile="$3"
     for i in {0..4}; do
-        if curl -fsS -A "$CURL_USER_AGENT" --max-time 5 https://dlang.org/install.sh -O; then
+        if curl -fsS -A "$CURL_USER_AGENT" --max-time 5 "$url" -o "$outputfile" ||
+           curl -fsS -A "$CURL_USER_AGENT" --max-time 5 "$fallbackurl" -o "$outputfile" ; then
             break
         elif [ $i -ge 4 ]; then
             sleep $((1 << $i))
         else
-            echo 'Failed to download install script' 1>&2
+            echo "Failed to download script ${outputfile}" 1>&2
             exit 1
         fi
     done
+}
+
+install_deps() {
+    if [ $MODEL -eq 32 ]; then
+        sudo apt-get update --quiet=2
+        sudo aptitude install g++-multilib --assume-yes --quiet=2
+    fi
+
+    download "https://dlang.org/install.sh" "https://nightlies.dlang.org/install.sh" "install.sh"
 
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh dmd-$HOST_DMD_VER --activate)"
     $DC --version
     env
 }
 
-coverage() {
+setup_repos() {
+    # set a default in case we run into rate limit restrictions
+    local base_branch=""
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
-        local base_branch=$(curl -fsSL https://api.github.com/repos/dlang/dmd/pulls/$CIRCLE_PR_NUMBER | jq -r '.base.ref')
+        base_branch=$((curl -fsSL https://api.github.com/repos/dlang/$CIRCLE_PROJECT_REPONAME/pulls/$CIRCLE_PR_NUMBER || echo) | jq -r '.base.ref')
     else
-        local base_branch=$CIRCLE_BRANCH
+        base_branch=$CIRCLE_BRANCH
     fi
+    base_branch=${base_branch:-"master"}
 
     # merge testee PR with base branch (master) before testing
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
         local head=$(git rev-parse HEAD)
-        git fetch https://github.com/dlang/dmd.git $base_branch
+        git fetch https://github.com/dlang/$CIRCLE_PROJECT_REPONAME.git $base_branch
         git checkout -f FETCH_HEAD
         local base=$(git rev-parse HEAD)
         git config user.name 'CI'
@@ -77,7 +90,10 @@ coverage() {
             clone https://github.com/dlang/$proj.git ../$proj $base_branch --depth 1
         fi
     done
+}
 
+coverage()
+{
     # load environment for bootstrap compiler
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
@@ -97,7 +113,17 @@ coverage() {
     make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1
 }
 
+codecov()
+{
+    # CodeCov gets confused by lst files which it can't matched
+    rm -rf test/runnable/extra-files
+    download "https://codecov.io/bash" "https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov" "codecov.sh"
+    bash codecov.sh
+}
+
 case $1 in
     install-deps) install_deps ;;
+    setup-repos) setup_repos ;;
     coverage) coverage ;;
+    codecov) codecov ;;
 esac


### PR DESCRIPTION
this should set `master` as default branch in case we run into issues with the Github API rate limit.

@MartinNowak do you have better ideas? can we maybe expose a oauth token of a dummy account, s.t. we have a higher rate limit?

e.g. setting https://circleci.com/gh/dlang/dmd/edit#env-vars

and then using one of the variants here

```
curl -u "$OAUTH-TOKEN:x-oauth-basic" https://api.github.com/user
curl -H "Authorization: token $OAUTH-TOKEN" https://api.github.com
curl https://api.github.com/?access_token=$OAUTH-TOKEN
```
