### PR TITLE
fix Issue 16115 - [REG2.067] Wrong code with comma operator

### DIFF
--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -2380,7 +2380,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
     override void visit(ReturnStatement rs)
     {
-        //printf("ReturnStatement::semantic() %s\n", toChars());
+        //printf("ReturnStatement.semantic() %s\n", rs.toChars());
 
         FuncDeclaration fd = sc.parent.isFuncDeclaration();
         if (fd.fes)
@@ -2476,6 +2476,9 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             rs.exp = Expression.extractLast(rs.exp, &e0);
             if (rs.exp.op == TOKcall)
                 rs.exp = valueNoDtor(rs.exp);
+
+            if (e0)
+                e0 = e0.optimize(WANTvalue);
 
             /* Void-return function can have void typed expression
              * on return statement.

--- a/test/runnable/test16115.d
+++ b/test/runnable/test16115.d
@@ -1,0 +1,38 @@
+/*
+REQUIRED_ARGS: -d
+PERMUTE_ARGS:
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=16115
+// https://github.com/dlang/dmd/pull/3979
+
+int n;
+
+struct Test
+{
+    enum tag = 42;
+}
+
+enum tagx = 42;
+
+auto call()
+{
+    version (none) // works
+    {
+        n = Test.tag;
+        return null;
+    }
+    else // assert error
+    {
+        //return n = tagx, null;
+        return n = Test.tag, null;
+        //return n = Test.tag;
+    }
+}
+
+void main()
+{
+    call();
+
+    assert(n == 42);
+}


### PR DESCRIPTION
I know I know - should have gone into `stable`. Trouble is, I was unable to get my fork's stable to match the dlang stable. Grrr.
