### PR TITLE
extern(C++, class): Avoid crash if scope is null.

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -8134,7 +8134,7 @@ extern (C++) final class TypeStruct : Type
         //printf("TypeStruct::semantic('%s')\n", sym.toChars());
         if (deco)
         {
-            if (sc.cppmangle != CPPMANGLE.def)
+            if (sc && sc.cppmangle != CPPMANGLE.def)
             {
                 if (this.cppmangle == CPPMANGLE.def)
                     this.cppmangle = sc.cppmangle;
@@ -8152,7 +8152,8 @@ extern (C++) final class TypeStruct : Type
 
         if (sym.type.ty == Terror)
             return Type.terror;
-        this.cppmangle = sc.cppmangle;
+        if (sc)
+            this.cppmangle = sc.cppmangle;
         return merge();
     }
 
@@ -8963,7 +8964,7 @@ extern (C++) final class TypeClass : Type
         //printf("TypeClass::semantic(%s)\n", sym.toChars());
         if (deco)
         {
-            if (sc.cppmangle != CPPMANGLE.def)
+            if (sc && sc.cppmangle != CPPMANGLE.def)
             {
                 if (this.cppmangle == CPPMANGLE.def)
                     this.cppmangle = sc.cppmangle;
@@ -8981,7 +8982,8 @@ extern (C++) final class TypeClass : Type
 
         if (sym.type.ty == Terror)
             return Type.terror;
-        this.cppmangle = sc.cppmangle;
+        if (sc)
+            this.cppmangle = sc.cppmangle;
         return merge();
     }
 

--- a/test/runnable/ldc_github_1677.d
+++ b/test/runnable/ldc_github_1677.d
@@ -1,0 +1,29 @@
+interface IBar(T)
+{
+    IFoo!T ownerDocument();
+}
+
+interface IFoo(T): IBar!T
+{
+    // un-commenting the following line solves the issue
+    //IList!T getList();
+}
+
+interface IList(T) {}
+
+class DOMImplementation(T)
+{
+    class BarImpl: IBar!T
+    {
+        FooImpl ownerDocument() { return null; }
+    }
+    class FooImpl: BarImpl, IFoo!T
+    {
+        IList!T getList() { return null; }
+    }
+}
+
+void main()
+{
+    auto impl = new DOMImplementation!string();
+}


### PR DESCRIPTION
There are cases in which the scope argument is null. In this case
the CPP mangle type should not be touched.
