### PR TITLE
size(): return SIZE_INVALID on errors

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -328,12 +328,12 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     abstract void finalizeSize();
 
-    override final uint size(Loc loc)
+    override final d_uns64 size(Loc loc)
     {
         //printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
-        determineSize(loc);
+        bool ok = determineSize(loc);
         //printf("-AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
-        return structsize;
+        return ok ? structsize : SIZE_INVALID;
     }
 
     /***************************************

--- a/src/aggregate.h
+++ b/src/aggregate.h
@@ -124,7 +124,7 @@ public:
     bool determineFields();
     bool determineSize(Loc loc);
     virtual void finalizeSize() = 0;
-    unsigned size(Loc loc);
+    d_uns64 size(Loc loc);
     bool checkOverlappedFields();
     bool fill(Loc loc, Expressions *elements, bool ctorinit);
     static void alignmember(structalign_t salign, unsigned size, unsigned *poffset);

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -174,10 +174,10 @@ extern (C++) abstract class Declaration : Dsymbol
         return "declaration";
     }
 
-    override final uint size(Loc loc)
+    override final d_uns64 size(Loc loc)
     {
         assert(type);
-        return cast(uint)type.size();
+        return type.size();
     }
 
     /*************************************

--- a/src/declaration.h
+++ b/src/declaration.h
@@ -126,7 +126,7 @@ public:
 
     void semantic(Scope *sc);
     const char *kind();
-    unsigned size(Loc loc);
+    d_uns64 size(Loc loc);
     int checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int flag);
 
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -786,10 +786,14 @@ extern (C++) class Dsymbol : RootObject
         return false;
     }
 
-    uint size(Loc loc)
+    /*********************************
+     * Returns:
+     *  SIZE_INVALID when the size cannot be determined
+     */
+    d_uns64 size(Loc loc)
     {
         error("Dsymbol '%s' has no size", toChars());
-        return 0;
+        return SIZE_INVALID;
     }
 
     bool isforwardRef()

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -208,7 +208,7 @@ public:
     Dsymbol *search_correct(Identifier *id);
     Dsymbol *searchX(Loc loc, Scope *sc, RootObject *id);
     virtual bool overloadInsert(Dsymbol *s);
-    virtual unsigned size(Loc loc);
+    virtual d_uns64 size(Loc loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration *isThis();     // is a 'this' required to access the member
     virtual bool isExport();                    // is Dsymbol exported?

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -59,6 +59,9 @@ enum LOGDEFAULTINIT = 0;    // log ::defaultInit()
 extern (C++) __gshared int Tsize_t = Tuns32;
 extern (C++) __gshared int Tptrdiff_t = Tint32;
 
+enum SIZE_INVALID = (~cast(d_uns64)0);   // error return from size() functions
+
+
 /***************************
  * Return !=0 if modfrom can be implicitly converted to modto
  */
@@ -949,8 +952,6 @@ extern (C++) abstract class Type : RootObject
         tptrdiff_t = basic[Tptrdiff_t];
         thash_t = tsize_t;
     }
-
-    enum SIZE_INVALID = (~cast(d_uns64)0);
 
     final d_uns64 size()
     {


### PR DESCRIPTION
1. harmonizes with `size()` in mtype.d
2. errors should be propagated, not papered over
