### PR TITLE
add size() checks to declaration.d

### DIFF
--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -976,7 +976,7 @@ public:
     {
         // Bugzilla 13776: Don't use ti->toAlias() to avoid forward reference error
         // while printing messages.
-        TemplateInstance ti = t.sym.parent.isTemplateInstance();
+        TemplateInstance ti = t.sym.parent ? t.sym.parent.isTemplateInstance() : null;
         if (ti && ti.aliasdecl == t.sym)
             buf.writestring(hgs.fullQual ? ti.toPrettyChars() : ti.toChars());
         else


### PR DESCRIPTION
Protect against size() failures and divide-by-zero. Not sure if any of these could happen, but added asserts to be sure.
