### PR TITLE
root.rmem: Support newer LDC's _d_allocclass() for OVERRIDE_MEMALLOC

### DIFF
--- a/src/root/rmem.d
+++ b/src/root/rmem.d
@@ -194,6 +194,14 @@ else
             return cast(Object)p;
         }
 
+        version (LDC)
+        {
+            extern (C) Object _d_allocclass(const ClassInfo ci) nothrow
+            {
+                return cast(Object)allocmemory(ci.init.length);
+            }
+        }
+
         extern (C) void* _d_newitemT(TypeInfo ti) nothrow
         {
             auto p = allocmemory(ti.tsize);


### PR DESCRIPTION
Pinging @klickverbot.
