### PR TITLE
Fix issue 10591 - Error: only one main allowed doesn't show location of conflicting main symbols

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -1390,10 +1390,11 @@ bool onlyOneMain(Loc loc)
         const char *msg = "";
         if (global.params.addMain)
             msg = ", -main switch added another main()";
-        const char *othermain = "";
+        const char *otherMainNames = "";
         if (config.exe == EX_WIN32 || config.exe == EX_WIN64)
-            othermain = "/WinMain/DllMain";
-        error(lastLoc, "only one main%s allowed%s", othermain, msg);
+            otherMainNames = "/WinMain/DllMain";
+        error(loc, "only one main%s allowed%s. Previously found main at %s",
+            otherMainNames, msg, lastLoc.toChars());
         return false;
     }
     lastLoc = loc;


### PR DESCRIPTION
much easier to work out what's going on if you get the path to the duplicate.
