### PR TITLE
Issue 16409 - Add support for assign-style switches

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -130,14 +130,14 @@ Where:
   -gs              always emit stack frame
   -gx              add stack stomp code
   -H               generate 'header' file
-  -Hd<directory>   write 'header' file to directory
-  -Hf<filename>    write 'header' file to filename
+  -Hd=<directory>  write 'header' file to directory
+  -Hf=<filename>   write 'header' file to filename
   --help           print help and exit
-  -I<directory>    look for imports also in directory
+  -I=<directory>   look for imports also in directory
   -ignore          ignore unsupported pragmas
   -inline          do function inlining
-  -J<directory>    look for string imports also in directory
-  -L<linkerflag>   pass linkerflag to link
+  -J=<directory>   look for string imports also in directory
+  -L=<linkerflag>  pass linkerflag to link
   -lib             generate library rather than object files
   -m32             generate 32 bit code" ~
   "%s" /* placeholder for m32mscoff */ ~ "
@@ -148,8 +148,8 @@ Where:
   -noboundscheck   no array bounds checking (deprecated, use -boundscheck=off)
   -O               optimize
   -o-              do not write object file
-  -od<directory>   write object & library files to directory
-  -of<filename>    name output file to filename
+  -od=<directory>  write object & library files to directory
+  -of=<filename>   name output file to filename
   -op              preserve source path for output files
   -profile         profile runtime performance of generated code
   -profile=gc      profile runtime allocations
@@ -169,7 +169,7 @@ Where:
   -w               warnings as errors (compilation will halt)
   -wi              warnings as messages (compilation will continue)
   -X               generate JSON file
-  -Xf<filename>    write JSON file to filename
+  -Xf=<filename>   write JSON file to filename
 ", FileName.canonicalName(global.inifilename), fpic, m32mscoff);
 }
 
@@ -620,7 +620,7 @@ Language changes listed by -transition=id:
                 case 'd':
                     if (!p[3])
                         goto Lnoarg;
-                    path = p + 3;
+                    path = p + 3 + (p[3] == '=');
                     version (Windows)
                     {
                         path = toWinPath(path);
@@ -630,7 +630,7 @@ Language changes listed by -transition=id:
                 case 'f':
                     if (!p[3])
                         goto Lnoarg;
-                    path = p + 3;
+                    path = p + 3 + (p[3] == '=');
                     version (Windows)
                     {
                         path = toWinPath(path);
@@ -657,12 +657,12 @@ Language changes listed by -transition=id:
                 case 'd':
                     if (!p[3])
                         goto Lnoarg;
-                    global.params.docdir = p + 3;
+                    global.params.docdir = p + 3 + (p[3] == '=');
                     break;
                 case 'f':
                     if (!p[3])
                         goto Lnoarg;
-                    global.params.docname = p + 3;
+                    global.params.docname = p + 3 + (p[3] == '=');
                     break;
                 case 0:
                     break;
@@ -678,12 +678,12 @@ Language changes listed by -transition=id:
                 case 'd':
                     if (!p[3])
                         goto Lnoarg;
-                    global.params.hdrdir = p + 3;
+                    global.params.hdrdir = p + 3 + (p[3] == '=');
                     break;
                 case 'f':
                     if (!p[3])
                         goto Lnoarg;
-                    global.params.hdrname = p + 3;
+                    global.params.hdrname = p + 3 + (p[3] == '=');
                     break;
                 case 0:
                     break;
@@ -699,7 +699,7 @@ Language changes listed by -transition=id:
                 case 'f':
                     if (!p[3])
                         goto Lnoarg;
-                    global.params.jsonfilename = p + 3;
+                    global.params.jsonfilename = p + 3 + (p[3] == '=');
                     break;
                 case 0:
                     break;
@@ -764,13 +764,13 @@ Language changes listed by -transition=id:
             {
                 if (!global.params.imppath)
                     global.params.imppath = new Strings();
-                global.params.imppath.push(p + 2);
+                global.params.imppath.push(p + 2 + (p[2] == '='));
             }
             else if (p[1] == 'J')
             {
                 if (!global.params.fileImppath)
                     global.params.fileImppath = new Strings();
-                global.params.fileImppath.push(p + 2);
+                global.params.fileImppath.push(p + 2 + (p[2] == '='));
             }
             else if (memcmp(p + 1, cast(char*)"debug", 5) == 0 && p[6] != 'l')
             {
@@ -847,7 +847,7 @@ Language changes listed by -transition=id:
                 global.params.debugy = true;
             else if (p[1] == 'L')
             {
-                global.params.linkswitches.push(p + 2);
+                global.params.linkswitches.push(p + 2 + (p[2] == '='));
             }
             else if (memcmp(p + 1, cast(char*)"defaultlib=", 11) == 0)
             {

--- a/test/runnable/test_switches.sh
+++ b/test/runnable/test_switches.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# tests various --opt=<value> switches:
+#
+# -Dd=<directory>
+# -Df=<filename>
+# -Hd=<directory>
+# -Hf=<filename>
+# -I=<directory>
+# -J=<directory>
+# -L=<linkerflag>
+# -od=<dirname>
+# -of=<objname>
+# -Xf=<filename>
+
+out_dir=${RESULTS_DIR}/runnable/test_switches
+src_file=${out_dir}/src.d
+
+clean()
+{
+    rm -rf ${out_dir} || true
+}
+
+prepare()
+{
+    clean;
+    mkdir ${out_dir}
+    echo "module mymod;" > ${out_dir}/mymod.d
+    echo "module src; import mymod;" > ${src_file}
+}
+
+die()
+{
+    echo "test_switches.sh error: Output file $1 not found"
+    exit 1
+}
+
+checkFile()
+{
+    if [ ! -f $1 ]; then die $1; fi
+}
+
+checkFiles()
+{
+    checkFile ${out_dir}/json.json
+    checkFile ${out_dir}/mymod.d
+    checkFile ${out_dir}/src.d
+    checkFile ${out_dir}/src.di
+    checkFile ${out_dir}/src.html
+}
+
+# @BUG@: -Df doesn't take -Dd into account when it's set
+# @BUG@: -Hf doesn't take -Hd into account when it's set
+# Workaround: Call DMD twice, first with -Df / -Hf, then with -Dh and -Hd
+# Note: -L linker flag not explicitly checked (using -c to compile only)
+# as there's no common linker switch which all linkers support
+
+prepare;
+$DMD -c -of=mymod.o -od=${out_dir} -D -Df=${out_dir}/src.html -Hf=${out_dir}/src.di -I=${out_dir} -L=-v -Xf=${out_dir}/json.json ${src_file}
+checkFiles;
+
+prepare;
+$DMD -c -of=mymod.o -od=${out_dir} -D -Dd=${out_dir} -Hd=${out_dir} -I=${out_dir} -L=-v -Xf=${out_dir}/json.json ${src_file}
+checkFiles;
+
+clean;


### PR DESCRIPTION
All switches taking values now allow the `-switch=<value>` syntax.

Note: The old-style **-switch****_Value_** syntax is **still supported**. That being said you won't be able to use `=` as an actual name of a file or directory with the old-style syntax anymore but will have to use e.g. `-of==`. 

I don't know who in their right mind would name files or directories with `=` in their name, but we should add this _breaking change_ to the change log nevertheless.

The list of switches which now have this support includes:

```
-Dd=<directory>
-Df=<filename>
-Hd=<directory>
-Hf=<filename>
-I=<directory>
-J=<directory>
-L=<linkerflag>
-od=<dirname>
-of=<objname>
-Xf=<filename>
```

Fixes https://issues.dlang.org/show_bug.cgi?id=16409

Tested on Ubuntu (via [Win 10's bash!](http://www.howtogeek.com/249966/how-to-install-and-use-the-linux-bash-shell-on-windows-10/))
