### PR TITLE
Fix compiler error for auto-tester tests on FreeBSD

### DIFF
--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -34,6 +34,7 @@ headers.
 #include <stdio.h>
 #include <assert.h>
 #include <exception>
+#include <cstdarg>
 
 /**************************************/
 


### PR DESCRIPTION
I'm not sure what the auto-tester is currently doing on FreeBSD, but when I tried to run the tests myself on a FreeBSD virtual machine I got the following:

```
runnable/extra-files/cppb.cpp:297:37: error: 'va_list' has not been declared
 void myvprintfx(const char* format, va_list);
```

This fixes that. 
