### PR TITLE
fix Issue 15047 - "used before set" error with -O

### DIFF
--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -29,7 +29,7 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
-extern void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
+extern void warning(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 
 STATIC void rd_free_elem(elem *e);
 STATIC void rd_compute();
@@ -414,7 +414,7 @@ STATIC void chkrd(elem *n,list_t rdlist)
      */
     if (type_size(sv->Stype) != 0)
     {
-        error(n->Esrcpos.Sfilename, n->Esrcpos.Slinnum, n->Esrcpos.Scharnum,
+        warning(n->Esrcpos.Sfilename, n->Esrcpos.Slinnum, n->Esrcpos.Scharnum,
             "variable %s used before set", sv->Sident);
     }
 #endif

--- a/src/errors.d
+++ b/src/errors.d
@@ -170,6 +170,18 @@ extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
     va_end(ap);
 }
 
+extern (C++) void warning(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
+{
+    Loc loc;
+    loc.filename = filename;
+    loc.linnum = linnum;
+    loc.charnum = charnum;
+    va_list ap;
+    va_start(ap, format);
+    vwarning(loc, format, ap);
+    va_end(ap);
+}
+
 extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;

--- a/src/mars.d
+++ b/src/mars.d
@@ -1484,11 +1484,13 @@ Language changes listed by -transition=id:
     }
     if (!global.errors && global.params.doDocComments)
     {
+        auto wc = global.warnings; // save warning count
         for (size_t i = 0; i < modules.dim; i++)
         {
             Module m = modules[i];
             gendocfile(m);
         }
+        global.warnings = wc; // ddoc is allowed to bypass the -w flag apparently
     }
     if (!global.params.obj)
     {

--- a/src/mars.d
+++ b/src/mars.d
@@ -1506,7 +1506,7 @@ Language changes listed by -transition=id:
             if (entrypoint && m == rootHasMain)
                 genObjFile(entrypoint, false);
         }
-        if (!global.errors && modules.dim)
+        if (!(global.errors || global.warnings) && modules.dim)
         {
             obj_end(library, modules[0].objfile);
         }
@@ -1524,14 +1524,14 @@ Language changes listed by -transition=id:
                 genObjFile(entrypoint, global.params.multiobj);
             obj_end(library, m.objfile);
             obj_write_deferred(library);
-            if (global.errors && !global.params.lib)
+            if ((global.errors || global.warnings) && !global.params.lib)
                 m.deleteObjFile();
         }
     }
-    if (global.params.lib && !global.errors)
+    if (global.params.lib && !(global.errors || global.warnings))
         library.write();
     backend_term();
-    if (global.errors)
+    if (global.errors || global.warnings)
         fatal();
     int status = EXIT_SUCCESS;
     if (!global.params.objfiles.dim)

--- a/test/fail_compilation/fail15047.d
+++ b/test/fail_compilation/fail15047.d
@@ -17,7 +17,6 @@ fail_compilation/fail15047.d(29): Warning: variable a used before set
 
 
 
-
 void one() {
     int a = void;
     int b = a;

--- a/test/fail_compilation/fail15047.d
+++ b/test/fail_compilation/fail15047.d
@@ -1,0 +1,32 @@
+/*
+REQUIRED_ARGS: -w -O
+TEST_OUTPUT:
+---
+fail_compilation/fail15047.d(22): Warning: variable a used before set
+fail_compilation/fail15047.d(29): Warning: variable a used before set
+---
+*/
+
+
+
+
+
+
+
+
+
+
+
+
+void one() {
+    int a = void;
+    int b = a;
+}
+
+int two() {
+    int a = void;
+    int b = void;
+    int fun(int x) { int y = x; return y; }
+    b = fun(a);
+    return b;
+}


### PR DESCRIPTION
Currently there is a case where the optimiser is able to detect an error that is not otherwise detected. This results in a compilation error only when the `-O` flag is used.
If code is buildable with `-O` it should be buildable without `-O`. Therefore, the optimiser now emits a warning instead.
