### PR TITLE
fix Issue 15047 - "used before set" error with -O

### DIFF
--- a/src/backend/gother.c
+++ b/src/backend/gother.c
@@ -29,7 +29,7 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
-extern void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
+extern void warning(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 
 STATIC void rd_free_elem(elem *e);
 STATIC void rd_compute();
@@ -414,7 +414,7 @@ STATIC void chkrd(elem *n,list_t rdlist)
      */
     if (type_size(sv->Stype) != 0)
     {
-        error(n->Esrcpos.Sfilename, n->Esrcpos.Slinnum, n->Esrcpos.Scharnum,
+        warning(n->Esrcpos.Sfilename, n->Esrcpos.Slinnum, n->Esrcpos.Scharnum,
             "variable %s used before set", sv->Sident);
     }
 #endif

--- a/src/errors.d
+++ b/src/errors.d
@@ -170,6 +170,18 @@ extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
     va_end(ap);
 }
 
+extern (C++) void warning(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
+{
+    Loc loc;
+    loc.filename = filename;
+    loc.linnum = linnum;
+    loc.charnum = charnum;
+    va_list ap;
+    va_start(ap, format);
+    vwarning(loc, format, ap);
+    va_end(ap);
+}
+
 extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;

--- a/test/compilable/test15047.d
+++ b/test/compilable/test15047.d
@@ -1,0 +1,31 @@
+/*
+REQUIRED_ARGS: -wi -O
+TEST_OUTPUT:
+---
+compilable/test15047.d(22): Warning: variable a used before set
+compilable/test15047.d(29): Warning: variable a used before set
+---
+*/
+
+
+
+
+
+
+
+
+
+
+
+void one() {
+    int a = void;
+    int b = a;
+}
+
+int two() {
+    int a = void;
+    int b = void;
+    int fun(int x) { int y = x; return y; }
+    b = fun(a);
+    return b;
+}


### PR DESCRIPTION
Currently there is a case where the optimiser can detect an error in your code, and emits an error message only when the `-O` flag is used.

Since it is not acceptable for code to be compilable with `-O` but not compilable without, or vice versa, this should be a warning rather than an error.

**NOTE:** this new warning does not respect the `-w` flag (nor do any of the warnings emitted after the semantic3 phase). Fixing the `-w` flag is currently a nontrivial change.
