### PR TITLE
Run full Travis tests only on Linux

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -51,7 +51,7 @@ test() {
 # test dmd
 test_dmd() {
     # test fewer compiler argument permutations for PRs to reduce CI load
-    if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_OS_NAME" == "linux"  ]; then
         make -j$N -C test MODEL=$MODEL # all ARGS by default
     else
         make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release"


### PR DESCRIPTION
Ideally we would have passing tests on Travis, instead of this:

![image](https://cloud.githubusercontent.com/assets/4370550/17995434/01e909ec-6b62-11e6-9889-432167635eb6.png)

(from https://travis-ci.org/dlang/dmd/builds)

This is a simple fix that removes the all argument builds for OS buildsX, because they take too long and thus run into the 50 minutes timeout.
