### PR TITLE
emit warning for IdentityExpression with static arrays

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -15611,6 +15611,12 @@ extern (C++) final class IdentityExp : BinExp
         if (e1.type.toBasetype().ty == Tvector)
             return incompatibleTypes();
 
+        if (e1.type.toBasetype().ty == Tsarray ||
+            e2.type.toBasetype().ty == Tsarray)
+            deprecation("identity comparison of static arrays "
+                "implicitly coerces them to slices, "
+                "which are compared by reference");
+
         return this;
     }
 


### PR DESCRIPTION
(first go ahead and read the patch code, it's a trivial 2-lines).

---

Currently static arrays are the only data type in the language for which the `is` operator compares value types by reference.

```
void main() {
    int[10] x;
    int[10] y;
    assert(x is y); // fails
};
```

I believe this behaviour is so unintuitive that invoking it should  _at the very least_  trigger a warning.

If you want to take this further by instead fixing the operator to do a value comparison, I'm happy to implement that patch myself.
If you reject the idea entirely I won't take it personally, but I strongly recommend we do _something_ about it. If not this, then perhaps a more noticeable warning in the language spec pages.
