### PR TITLE
rename dtocsym to tocsym

### DIFF
--- a/src/tocsym.d
+++ b/src/tocsym.d
@@ -5,10 +5,10 @@
  * Copyright:   Copyright (c) 1999-2016 by Digital Mars, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/_dtocsym.d, _dtocsym.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/_tocsym.d, _tocsym.d)
  */
 
-module ddmd.dtocsym;
+module ddmd.tocsym;
 
 import core.stdc.stdio;
 import core.stdc.string;


### PR DESCRIPTION
I'd forgotten to fix the module name.
