### PR TITLE
Fix issue 11051 - Unmatched case in a final switch should always throw

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2559,7 +2559,7 @@ else
                 needswitcherror = true;
         }
 
-        if (!sc.sw.sdefault && (!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on))
+        if (!sc.sw.sdefault && (!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on || sc.func.isSafe))
         {
             ss.hasNoDefault = 1;
 

--- a/test/runnable/extra-files/test11051.d
+++ b/test/runnable/extra-files/test11051.d
@@ -1,0 +1,30 @@
+module test11051;
+
+version (Safe)
+{
+    void main() @safe
+    {
+        enum E { A, B }
+        E e = cast(E)-1;
+
+        final switch (e)
+        {
+            case E.A: break;
+            case E.B: break;
+        }
+    }
+}
+else
+{
+    void main()
+    {
+        enum E { A, B }
+        E e = cast(E)-1;
+
+        final switch (e)
+        {
+            case E.A: break;
+            case E.B: break;
+        }
+    }
+}

--- a/test/runnable/test_safe_final_switch.sh
+++ b/test/runnable/test_safe_final_switch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# tests various @safe behavior for final switches in
+# -release and non-release builds
+
+src_file=runnable/extra-files/test11051.d
+
+die()
+{
+    echo "test_safe_final_switch.sh error: test #$1 failed"
+    exit 1
+}
+
+$DMD -run ${src_file} 2> /dev/null
+
+die()
+{
+    exit 1
+}
+
+# returns 1 (failure)
+$DMD -run ${src_file} 2> /dev/null && die 1
+
+# returns 0 (success)
+$DMD -release -run ${src_file} 2> /dev/null || die 2
+
+# returns 1 (failure)
+$DMD -version=Safe -run ${src_file} 2> /dev/null && die 3
+
+# returns 1 (failure)
+$DMD -release -version=Safe -run ${src_file} 2> /dev/null && die 4
+
+exit 0


### PR DESCRIPTION
Keep a HALT instruction in a final switch statement if the function is @safe and `-release` mode is enabled.

Let's see what the autotester has to say..
