### PR TITLE
add -safe switch

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -24,6 +24,7 @@ $(BUGSTITLE Compiler Changes,
     $(LI $(RELATIVE_LINK2 deferred_alias, Analysis for aliases in imported modules is deferred.))
     $(LI $(RELATIVE_LINK2 native_tls_osx, Native TLS on OS X 64 bit.))
     $(LI $(RELATIVE_LINK2 __FILE_FULL_PATH__, Special keyword replaced by the source file's absolute file name.)
+    $(LI $(RELATIVE_LINK2 dash_safe, Add -transition=safe switch.))
 )
 
 $(BUGSTITLE Language Changes,
@@ -174,6 +175,10 @@ $(BUGSTITLE Compiler Changes,
             }
         }
         ---
+    )
+
+    $(LI $(LNAME2 dash_safe, Add -transition=safe switch.)
+	$(P Enables enhanced @safe checking, which will break some existing code.)
     )
 )
 

--- a/src/globals.d
+++ b/src/globals.d
@@ -112,6 +112,7 @@ struct Param
     bool allInst;           // generate code for all template instantiations
     bool check10378;        // check for issues transitioning to 10738
     bool bug10378;          // use pre-bugzilla 10378 search strategy
+    bool safe;              // use enhanced @safe checking
 
     BOUNDSCHECK useArrayBounds;
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -95,6 +95,7 @@ struct Param
     bool allInst;       // generate code for all template instantiations
     bool check10378;    // check for issues transitioning to 10738
     bool bug10378;      // use pre-bugzilla 10378 search strategy
+    bool safe;          // use enhanced @safe checking
 
     BOUNDSCHECK useArrayBounds;
 

--- a/src/mars.d
+++ b/src/mars.d
@@ -541,6 +541,7 @@ Language changes listed by -transition=id:
   =complex,14488 list all usages of complex or imaginary types
   =field,3449    list all non-mutable fields which occupy an object instance
   =import,10378  revert to single phase name lookup
+  =safe          implement enhanced @safe checking
   =tls           list all variables going into thread local storage
 ");
                         exit(EXIT_SUCCESS);
@@ -589,6 +590,9 @@ Language changes listed by -transition=id:
                             break;
                         case "import":
                             global.params.bug10378 = true;
+                            break;
+                        case "safe":
+                            global.params.safe = true;
                             break;
                         case "tls":
                             global.params.vtls = true;


### PR DESCRIPTION
The new return scope and other added @safe checking will require some updates to existing code, hence the need for this transitional switch.
