### PR TITLE
introduce __ctfeWrite for strings.

### DIFF
--- a/src/builtin.d
+++ b/src/builtin.d
@@ -183,9 +183,19 @@ extern (C++) Expression eval_yl2xp1(Loc loc, FuncDeclaration fd, Expressions* ar
     return new RealExp(loc, result, arg0.type);
 }
 
+extern (C++) Expression builtin_ctfeWrite(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    import std.stdio : fprintf;
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKstring);
+    auto se = cast(StringExp)arg0;
+    fprintf(global.stdmsg, "%.*s".ptr, se.len, se.string);
+    return null;
+}
+
 public extern (C++) void builtin_init()
 {
-    builtins._init(47);
+    builtins._init(49);
     // @safe @nogc pure nothrow real function(real)
     add_builtin("_D4core4math3sinFNaNbNiNfeZe", &eval_sin);
     add_builtin("_D4core4math3cosFNaNbNiNfeZe", &eval_cos);
@@ -281,6 +291,8 @@ public extern (C++) void builtin_init()
     // @safe @nogc pure nothrow int function(ulong)
     if (global.params.is64bit)
         add_builtin("_D4core5bitop7_popcntFNaNbNiNfmZi", &eval_popcnt);
+    // void function(const string)
+    add_builtin("_D6object13__ctfeWriteFxAyaZv", &builtin_ctfeWrite);
 }
 
 /**********************************

--- a/src/builtin.d
+++ b/src/builtin.d
@@ -187,10 +187,13 @@ extern (C++) Expression builtin_ctfeWrite(Loc loc, FuncDeclaration fd, Expressio
 {
     import std.stdio : fprintf;
     Expression arg0 = (*arguments)[0];
-    assert(arg0.op == TOKstring);
+    if (arg0.op != TOKstring)
+    {
+        arg0.toStringExp();
+    }
     auto se = cast(StringExp)arg0;
     fprintf(global.stdmsg, "%.*s".ptr, se.len, se.string);
-    return null;
+    return arg0;
 }
 
 public extern (C++) void builtin_init()
@@ -292,7 +295,7 @@ public extern (C++) void builtin_init()
     if (global.params.is64bit)
         add_builtin("_D4core5bitop7_popcntFNaNbNiNfmZi", &eval_popcnt);
     // void function(const string)
-    add_builtin("_D6object13__ctfeWriteFxAyaZv", &builtin_ctfeWrite);
+    add_builtin("_D6object11__ctfeWriteFNaNbNiNfxAyaZv", &builtin_ctfeWrite);
 }
 
 /**********************************

--- a/test/compilable/testCtfeWriteln.d
+++ b/test/compilable/testCtfeWriteln.d
@@ -11,18 +11,19 @@ result == 91
 */
 int sum_of_sq(int x) pure nothrow @safe
 {
+    import std.conv;
+
     int result = 0;
     foreach (i; 0 .. x)
     {
-        import std.conv;
         __ctfeWrite(to!string(i));
         __ctfeWrite("^^2 == ");
        int power = i ^^ 2;
-        __ctfeWriteln(power);
+        __ctfeWrite(power.to!string ~ "\n");
         result += power;
     }
     __ctfeWrite("result == ");
-    __ctfeWriteln(to!string(result));
+    __ctfeWrite(to!string(result) ~ "\n");
     return result;
 
 }

--- a/test/compilable/testCtfeWriteln.d
+++ b/test/compilable/testCtfeWriteln.d
@@ -1,0 +1,30 @@
+/*
+TEST OUTPUT:
+0^^2 == 1
+1^^2 == 1
+2^^2 == 4
+3^^2 == 9
+4^^2 == 16
+5^^2 == 25
+6^^2 == 36
+result == 91
+*/
+int sum_of_sq(int x) pure nothrow @safe
+{
+    int result = 0;
+    foreach (i; 0 .. x)
+    {
+        import std.conv;
+        __ctfeWrite(to!string(i));
+        __ctfeWrite("^^2 == ");
+       int power = i ^^ 2;
+        __ctfeWriteln(power);
+        result += power;
+    }
+    __ctfeWrite("result == ");
+    __ctfeWriteln(to!string(result));
+    return result;
+
+}
+
+static assert(sum_of_sq(7) == 91);

--- a/test/compilable/testCtfeWriteln.d
+++ b/test/compilable/testCtfeWriteln.d
@@ -18,12 +18,14 @@ int sum_of_sq(int x) pure nothrow @safe
     {
         __ctfeWrite(to!string(i));
         __ctfeWrite("^^2 == ");
-       int power = i ^^ 2;
-        __ctfeWrite(power.to!string ~ "\n");
+        int power = i ^^ 2;
+        __ctfeWrite(power.to!string);
+        __ctfeWrite("\n");
         result += power;
     }
     __ctfeWrite("result == ");
-    __ctfeWrite(to!string(result) ~ "\n");
+    __ctfeWrite(to!string(result));
+    __ctfeWrite("\n");
     return result;
 
 }


### PR DESCRIPTION
This enables __ctfeWrite for strings.
Which already is a useful debugging tool.
Using it with anything but strings is a compile error.
Since it writes to stdout, it is prone to race conditions.
However as long as ctfe is not multi-threaded  it should not be too problematic. 
