### PR TITLE
Custom assert handler to point to bugzilla

### DIFF
--- a/src/backend/aa.c
+++ b/src/backend/aa.c
@@ -11,10 +11,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "tinfo.h"
 #include "aa.h"
+
+static char __file__[] = __FILE__;      /* for tassert.h */
+#include "tassert.h"
 
 // Implementation of associative array
 // Auto-rehash and pre-allocate - Dave Fladebo

--- a/src/backend/divcoeff.c
+++ b/src/backend/divcoeff.c
@@ -11,7 +11,9 @@ Source: https://github.com/dlang/dmd/blob/master/src/backend/divcoeff.c
  */
 
 #include <stdio.h>
-#include <assert.h>
+
+static char __file__[] = __FILE__; /* for tassert.h */
+#include "tassert.h"
 
 typedef unsigned long long ullong;
 

--- a/src/backend/util2.c
+++ b/src/backend/util2.c
@@ -54,6 +54,8 @@ void util_assert(const char *file, int line)
 {
     fflush(stdout);
     printf("Internal error: %s %d\n",file,line);
+    printf("This is a compiler bug, please report it via "
+        "https://issues.dlang.org/enter_bug.cgi\n");
     err_exit();
 #if __clang__
     __builtin_unreachable();

--- a/src/mars.d
+++ b/src/mars.d
@@ -1574,6 +1574,7 @@ int main()
 {
     import core.memory;
     import core.runtime;
+    import core.exception;
 
     version (GC)
     {
@@ -1603,6 +1604,24 @@ int main()
         dmd_coverDestPath(sourcePath);
         dmd_coverSetMerge(true);
     }
+
+    assertHandler = (string file, size_t line, string msg) nothrow {
+        import ddmd.errors;
+        import core.stdc.stdio;
+
+        fprintf(stderr, "Fatal failure on line %d in file '%s'",
+            line, file.ptr);
+
+        if (msg.length)
+            fprintf(stderr, ": %s\n", msg.ptr);
+        else
+            fprintf(stderr, "\n");
+
+        fprintf(stderr, "This is a compiler bug, please report it via " ~
+            "https://issues.dlang.org/enter_bug.cgi\n");
+
+        exit(EXIT_FAILURE);
+    };
 
     auto args = Runtime.cArgs();
     return tryMain(args.argc, cast(const(char)**)args.argv);


### PR DESCRIPTION
Makes it more obvious that any failed assertion is a compiler
bug to be reported. Inspired by http://forum.dlang.org/thread/qkxyfiwjwqklftcwtcik@forum.dlang.org
