### PR TITLE
Revert "remove FuncDeclaration from function-signature for builtin"

### DIFF
--- a/src/builtin.d
+++ b/src/builtin.d
@@ -25,6 +25,17 @@ import ddmd.tokens;
 
 private:
 
+/**
+ * Handler for evaluating builtins during CTFE.
+ *
+ * Params:
+ *  loc = The call location, for error reporting.
+ *  fd = The callee declaration, e.g. to disambiguate between different overloads
+ *       in a single handler (LDC).
+ *  arguments = The function call arguments.
+ * Returns:
+ *  An Expression containing the return value of the call.
+ */
 extern (C++) alias builtin_fp = Expression function(Loc loc, FuncDeclaration fd, Expressions* arguments);
 
 __gshared StringTable builtins;

--- a/src/builtin.d
+++ b/src/builtin.d
@@ -25,7 +25,7 @@ import ddmd.tokens;
 
 private:
 
-extern (C++) alias builtin_fp = Expression function(Loc loc, Expressions* arguments);
+extern (C++) alias builtin_fp = Expression function(Loc loc, FuncDeclaration fd, Expressions* arguments);
 
 __gshared StringTable builtins;
 
@@ -41,47 +41,47 @@ builtin_fp builtin_lookup(const(char)* mangle)
     return null;
 }
 
-extern (C++) Expression eval_unimp(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_unimp(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     return null;
 }
 
-extern (C++) Expression eval_sin(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_sin(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKfloat64);
     return new RealExp(loc, CTFloat.sin(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_cos(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_cos(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKfloat64);
     return new RealExp(loc, CTFloat.cos(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_tan(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_tan(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKfloat64);
     return new RealExp(loc, CTFloat.tan(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_sqrt(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_sqrt(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKfloat64);
     return new RealExp(loc, CTFloat.sqrt(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_fabs(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_fabs(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKfloat64);
     return new RealExp(loc, CTFloat.fabs(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_bsf(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_bsf(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKint64);
@@ -98,7 +98,7 @@ extern (C++) Expression eval_bsf(Loc loc, Expressions* arguments)
     return new IntegerExp(loc, k, Type.tint32);
 }
 
-extern (C++) Expression eval_bsr(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_bsr(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKint64);
@@ -113,7 +113,7 @@ extern (C++) Expression eval_bsr(Loc loc, Expressions* arguments)
     return new IntegerExp(loc, k, Type.tint32);
 }
 
-extern (C++) Expression eval_bswap(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_bswap(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKint64);
@@ -132,7 +132,7 @@ extern (C++) Expression eval_bswap(Loc loc, Expressions* arguments)
     return new IntegerExp(loc, n, arg0.type);
 }
 
-extern (C++) Expression eval_popcnt(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_popcnt(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKint64);
@@ -146,7 +146,7 @@ extern (C++) Expression eval_popcnt(Loc loc, Expressions* arguments)
     return new IntegerExp(loc, cnt, arg0.type);
 }
 
-extern (C++) Expression eval_yl2x(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_yl2x(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKfloat64);
@@ -159,7 +159,7 @@ extern (C++) Expression eval_yl2x(Loc loc, Expressions* arguments)
     return new RealExp(loc, result, arg0.type);
 }
 
-extern (C++) Expression eval_yl2xp1(Loc loc, Expressions* arguments)
+extern (C++) Expression eval_yl2xp1(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOKfloat64);
@@ -296,7 +296,7 @@ public extern (C++) Expression eval_builtin(Loc loc, FuncDeclaration fd, Express
     {
         builtin_fp fp = builtin_lookup(mangleExact(fd));
         assert(fp);
-        return fp(loc, arguments);
+        return fp(loc, fd, arguments);
     }
     return null;
 }


### PR DESCRIPTION
The parameter is used in LDC.

Reverts dlang/dmd#6104.
