### PR TITLE
fix Issue 16466 - Alignment of reals inside structs on 32 bit OSX sho…

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -605,7 +605,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
         if (alignment == STRUCTALIGN_DEFAULT)
         {
-            if (global.params.is64bit && memalignsize == 16)
+            if ((global.params.is64bit || global.params.isOSX) && memalignsize == 16)
             {
             }
             else if (8 < memalignsize)

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7876,6 +7876,20 @@ void test16233()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16466
+
+void test16466()
+{
+    static struct S
+    {
+        real r;
+    }
+    real r;
+    printf("S.alignof: %x, r.alignof: %x\n", S.alignof, r.alignof);
+    assert(S.alignof == r.alignof);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -8192,6 +8206,7 @@ int main()
     test15369();
     test15638();
     test16233();
+    test16466();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
…uld be 16, not 8

Arguably nobody cares about 32 bit OSX, but might as well fix it anyway.
