### PR TITLE
code.h: fix warning about offsetof macro

### DIFF
--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -736,7 +736,10 @@ struct CodeBuilder
      */
     code *last()
     {
-        return (code *)((char *)pTail - offsetof(code, next));
+        // g++ and clang++ complain about offsetof() because of the code::code() constructor.
+        // return (code *)((char *)pTail - offsetof(code, next));
+        // So do our own.
+        return (code *)((char *)pTail - ((char*)&(*pTail)->next - (char*)*pTail));
     }
 };
 


### PR DESCRIPTION
Tired of watching the warning scroll by
