### PR TITLE
-transition=safe sets -dip25 too

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -593,6 +593,7 @@ Language changes listed by -transition=id:
                             break;
                         case "safe":
                             global.params.safe = true;
+                            global.params.useDIP25 = true;
                             break;
                         case "tls":
                             global.params.vtls = true;


### PR DESCRIPTION
Doesn't make sense to have the former without the latter.
