### PR TITLE
Trivial refactor: Move `@disable` check out of checkDeprecated

### DIFF
--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -181,6 +181,37 @@ extern (C++) abstract class Declaration : Dsymbol
         return type.size();
     }
 
+
+    /**
+     * Issue an error if an attempt to call a disabled method is made
+     *
+     * If the declaration is disabled but inside a disabled function,
+     * returns `true` but do not issue an error message.
+     *
+     * Params:
+     *   loc = Location information of the call
+     *   sc  = Scope in which the call occurs
+     *
+     * Returns:
+     *   `true` if this `Declaration` is `@disable`d, `false` otherwise.
+     */
+    final bool checkDisabled(Loc loc, Scope* sc)
+    {
+        if (storage_class & STCdisable)
+        {
+            if (!(sc.func && sc.func.storage_class & STCdisable))
+            {
+                if (toParent() && isPostBlitDeclaration())
+                    toParent().error(loc, "is not copyable because it is annotated with @disable");
+                else
+                    error(loc, "is not callable because it is annotated with @disable");
+            }
+            return true;
+        }
+        return false;
+    }
+
+
     /*************************************
      * Check to see if declaration can be modified in this context (sc).
      * Issue error if not.

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -309,15 +309,15 @@ extern (C++) class Dsymbol : RootObject
             for (Dsymbol sp = sc.parent; sp; sp = sp.parent)
             {
                 if (sp.isDeprecated())
-                    goto L1;
+                    return;
             }
             for (Scope* sc2 = sc; sc2; sc2 = sc2.enclosing)
             {
                 if (sc2.scopesym && sc2.scopesym.isDeprecated())
-                    goto L1;
+                    return;
                 // If inside a StorageClassDeclaration that is deprecated
                 if (sc2.stc & STCdeprecated)
-                    goto L1;
+                    return;
             }
             const(char)* message = null;
             for (Dsymbol p = this; p; p = p.parent)
@@ -330,18 +330,6 @@ extern (C++) class Dsymbol : RootObject
                 deprecation(loc, "is deprecated - %s", message);
             else
                 deprecation(loc, "is deprecated");
-        }
-    L1:
-        Declaration d = isDeclaration();
-        if (d && d.storage_class & STCdisable)
-        {
-            if (!(sc.func && sc.func.storage_class & STCdisable))
-            {
-                if (d.toParent() && d.isPostBlitDeclaration())
-                    d.toParent().error(loc, "is not copyable because it is annotated with @disable");
-                else
-                    error(loc, "is not callable because it is annotated with @disable");
-            }
         }
     }
 


### PR DESCRIPTION
This separate the check for disabled from the check from deprecated, to (hopefully) make the code clearer.
