### PR TITLE
Minor: Fix test/runnable/test16096.sh script

### DIFF
--- a/test/runnable/test16096.sh
+++ b/test/runnable/test16096.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
 
-if [ "$OS" != 'osx' ] || [ "$MODEL" != '64' ]; then
-    echo Success >${output_file}
-    exit 0
-fi
-
 set -e
 
 src=runnable/extra-files
 dir=${RESULTS_DIR}/runnable
 output_file=${dir}/test16096.sh.out
 
-$DMD -I${src} -of${dir}${SEP}test16096a.a -lib ${src}/test16096a.d
-$DMD -I${src} -of${dir}${SEP}test16096 ${src}/test16096.d ${dir}/test16096a.a -L-framework -LFoundation
-${RESULTS_DIR}/runnable/test16096
+if [ "$OS" != 'osx' ] || [ "$MODEL" != '64' ]; then
+    exit 0
+fi
+
+function teardown {
+    if [ "$?" -ne 0 ] && [ -r "$output_file" ]; then
+        cat "${output_file}" 1>&2
+    fi
+    rm -f "${output_file}"
+}
+
+trap teardown EXIT
+
+$DMD -I${src} -of${dir}${SEP}test16096a.a -lib ${src}/test16096a.d >> "${output_file}" 2>&1
+$DMD -I${src} -of${dir}${SEP}test16096 ${src}/test16096.d ${dir}/test16096a.a -L-framework -LFoundation >> "${output_file}" 2>&1
+${RESULTS_DIR}/runnable/test16096 >> "${output_file}" 2>&1
 
 rm ${dir}/{test16096a.a,test16096}
-
-echo Success >${output_file}


### PR DESCRIPTION
```
 ... runnable/test16096.sh
./runnable/test16096.sh: line 4: ${output_file}: ambiguous redirect
 ... runnable/test_switches.sh
```

The script was using the variable "output_file" before it was defined.
Moving the definition up, and putting the variable expansion between double quotes to get a better error message than "ambiguous redirect".

@jacob-carlborg : The fact that it didn't fail before is a bit surprising TBH. Apparently the `.out` file isn't required ?
