### PR TITLE
Fix issue 16340 - Invalid dangling else warning triggered within template

### DIFF
--- a/src/parse.d
+++ b/src/parse.d
@@ -1543,16 +1543,7 @@ final class Parser : Lexer
             goto Lerr;
         }
         else
-        {
-            nextToken();
-            decldefs = parseDeclDefs(0);
-            if (token.value != TOKrcurly)
-            {
-                error("template member expected");
-                goto Lerr;
-            }
-            nextToken();
-        }
+            decldefs = parseBlock(null);
 
         tempdecl = new TemplateDeclaration(loc, id, tpl, constraint, decldefs, ismixin);
         return tempdecl;

--- a/test/compilable/test16340.d
+++ b/test/compilable/test16340.d
@@ -1,0 +1,9 @@
+// REQUIRED_ARGS: -w
+
+version(unittest) template symsToStrs(fields...)
+{
+    static if (fields.length == 0)
+        enum symsToStrs = ["hello"];
+    else
+        enum symsToStrs = ["world"];
+}


### PR DESCRIPTION
Using `parseBlock` when parsing the template body is DRY-er and remove this invalid warning.
