### PR TITLE
README: Make Codecov badge link to DMD dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DMD
 
 [![GitHub tag](https://img.shields.io/github/tag/dlang/dmd.svg?maxAge=86400)](#)
 [![Build Status](https://travis-ci.org/dlang/dmd.svg?branch=master)](https://travis-ci.org/dlang/dmd)
-[![Code coverage](https://img.shields.io/codecov/c/github/dlang/dmd.svg?maxAge=86400)](#)
+[![Code coverage](https://img.shields.io/codecov/c/github/dlang/dmd.svg?maxAge=86400)](https://codecov.io/gh/dlang/dmd)
 [![Issue Stats](https://img.shields.io/issuestats/p/github/dlang/dmd.svg?maxAge=2592000)](http://www.issuestats.com/github/dlang/dmd)
 
 DMD is the reference compiler for the D programming language.


### PR DESCRIPTION
Previously, it was just a link back to the same page, which is
slightly confusing.
