### PR TITLE
fix circle ci tests

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -30,8 +30,7 @@ clone() {
 
 install_deps() {
     if [ $MODEL -eq 32 ]; then
-        sudo apt-get update
-        sudo apt-get install g++-multilib
+        sudo aptitude install g++-multilib --assume-yes --quiet=2
     fi
 
     for i in {0..4}; do


### PR DESCRIPTION
- apt-get fails to resolve g++-multilib, simply use aptitude instead
