### PR TITLE
fix Issue 16460 - ICE for package visibility check in function literal

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -1397,7 +1397,15 @@ public:
             localsymtab = new DsymbolTable();
             // Establish function scope
             auto ss = new ScopeDsymbol();
-            ss.parent = sc.scopesym;
+            // find enclosing scope symbol, might skip symbol-less CTFE and/or FuncExp scopes
+            for (auto scx = sc; ; scx = scx.enclosing)
+            {
+                if (scx.scopesym)
+                {
+                    ss.parent = scx.scopesym;
+                    break;
+                }
+            }
             Scope* sc2 = sc.push(ss);
             sc2.func = this;
             sc2.parent = this;

--- a/test/compilable/imports/imp16460.d
+++ b/test/compilable/imports/imp16460.d
@@ -1,0 +1,3 @@
+module imports.imp16460;
+
+package enum val = 0;

--- a/test/compilable/test16460.d
+++ b/test/compilable/test16460.d
@@ -1,0 +1,13 @@
+module imports.test16460;
+
+void bug()
+{
+    auto d1 = (){
+        import imports.imp16460;
+        return val;
+    };
+    enum d2 = (){
+        import imports.imp16460;
+        return val;
+    };
+}


### PR DESCRIPTION
- the FuncDeclaration of FuncExp expects to be nested in a scope with
  scopesym, but FuncExp didn't provide one
- fixed symbol parent chain by creating a dummy ScopeDSymbol (also see #6014)
