### PR TITLE
add astTypeName to help with AST-exploration

### DIFF
--- a/src/asttypename.d
+++ b/src/asttypename.d
@@ -1,0 +1,113 @@
+/**
+ * Part of the Compiler implementation of the D programming language
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
+ * Authors:     Stefan Koch
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(DMDSRC _asttypename.d)
+ */
+
+module ddmd.asttypename;
+
+import ddmd.attrib;
+import ddmd.aliasthis;
+import ddmd.aggregate;
+import ddmd.complex;
+import ddmd.cond;
+import ddmd.ctfeexpr;
+import ddmd.dclass;
+import ddmd.declaration;
+import ddmd.denum;
+import ddmd.dimport;
+import ddmd.declaration;
+import ddmd.dstruct;
+import ddmd.dsymbol;
+import ddmd.dtemplate;
+import ddmd.dversion;
+import ddmd.expression;
+import ddmd.func;
+import ddmd.denum;
+import ddmd.dimport;
+import ddmd.dmodule;
+import ddmd.mtype;
+import ddmd.typinf;
+import ddmd.identifier;
+import ddmd.init;
+import ddmd.doc;
+import ddmd.root.rootobject;
+import ddmd.statement;
+import ddmd.staticassert;
+import ddmd.nspace;
+import ddmd.visitor;
+
+/// Returns: the typename of the dynamic ast-node-type
+/// (this is a development tool, do not use in actual code)
+string astTypeName(RootObject node)
+{
+    final switch (node.dyncast())
+    {
+        case DYNCAST_OBJECT:
+            return "RootObject";
+        case DYNCAST_IDENTIFIER:
+            return "Identifier";
+
+        case DYNCAST_EXPRESSION:
+            return astTypeName(cast(Expression) node);
+        case DYNCAST_DSYMBOL:
+            return astTypeName(cast(Dsymbol) node);
+        case DYNCAST_TYPE:
+            return astTypeName(cast(Type) node);
+        case DYNCAST_TUPLE:
+            return astTypeName(cast(Tuple) node);
+        case DYNCAST_PARAMETER:
+            return astTypeName(cast(Parameter) node);
+        case DYNCAST_STATEMENT:
+            return astTypeName(cast(Statement) node);
+    }
+}
+
+mixin
+({
+    string astTypeNameFunctions;
+    string visitOverloads;
+
+    foreach (ov; __traits(getOverloads, Visitor, "visit"))
+    {
+        static if (is(typeof(ov) P == function))
+        {
+            static if (is(P[0] S == super) && is(S[0] == RootObject))
+            {
+                astTypeNameFunctions ~= `
+string astTypeName(` ~ P[0].stringof ~ ` node)
+{
+    scope tsv = new AstTypeNameVisitor;
+    node.accept(tsv);
+    return tsv.typeName;
+}
+`;
+            }
+
+            visitOverloads ~= `
+    override void visit (` ~ P[0].stringof ~ ` _)
+    {
+        typeName = "` ~ P[0].stringof ~ `";
+    }
+`;
+        }
+    }
+
+    return astTypeNameFunctions ~ `
+extern(C++) final class AstTypeNameVisitor : Visitor
+{
+    alias visit = super.visit;
+public :
+    string typeName;
+` ~ visitOverloads ~ "}";
+}());
+
+///
+unittest
+{
+    import ddmd.globals : Loc;
+    Expression e = new TypeidExp(Loc.init, null);
+    assert(e.astTypeName == "TypeidExp");
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -209,7 +209,7 @@ FRONT_SRCS=$(addsuffix .d,access aggregate aliasthis apply argtypes arrayop	\
 	globals hdrgen id identifier impcnvtab imphint init inline intrange	\
 	json lexer lib link mars mtype nogc nspace opover optimize parse sapply	\
 	sideeffect statement staticassert target tokens traits utf visitor	\
-	typinf utils statementsem safe blockexit)
+	typinf utils statementsem safe blockexit asttypename)
 
 ifeq ($(D_OBJC),1)
 	FRONT_SRCS += objc.d

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -151,7 +151,7 @@ FRONT_SRCS=access.d aggregate.d aliasthis.d apply.d argtypes.d arrayop.d	\
 	impcnvtab.d init.d inline.d intrange.d json.d lexer.d lib.d link.d	\
 	mars.d mtype.d nogc.d nspace.d objc_stubs.d opover.d optimize.d parse.d	\
 	sapply.d sideeffect.d statement.d staticassert.d target.d tokens.d	\
-	safe.d blockexit.d \
+	safe.d blockexit.d asttypename.d \
 	traits.d utf.d utils.d visitor.d libomf.d scanomf.d typinf.d \
 	libmscoff.d scanmscoff.d statementsem.d
 


### PR DESCRIPTION
As per title.

This PR adds a visitor and convenience methods to show what type of AST-Node a particular node is. 

This helps when creating matchers and other custom AST-Manipulation  tools.

It's a developer-tool, intended to lower the entry barrier and working with the DMD-AST
