### PR TITLE
fix issue 16499 - error message for 'in' expression

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -15378,8 +15378,7 @@ extern (C++) final class InExp : BinExp
                 break;
             }
         default:
-            error("rvalue of in expression must be an associative array, not %s", e2.type.toChars());
-            goto case Terror;
+            return incompatibleTypes();
         case Terror:
             return new ErrorExp();
         }

--- a/test/fail_compilation/diag16499.d
+++ b/test/fail_compilation/diag16499.d
@@ -1,0 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag16499.d(22): Error: incompatible types for ((2) in (foo)): 'int' and 'A'
+fail_compilation/diag16499.d(24): Error: incompatible types for ((1.00000) in (bar)): 'double' and 'B'
+---
+*/
+
+struct A {}
+struct B {
+	void* opBinaryRight(string op)(int b) if (op == "in")
+	{
+		return null;
+	}
+}
+
+void main()
+{
+	A foo;
+	B bar;
+
+	2 in foo;
+	2 in bar; // OK
+	1.0 in bar;
+}


### PR DESCRIPTION
Current error reported for 'in' expression looks like this:

`rvalue of in expression must be an associative array, not <type>`

According to git history, this line has been there since before dmd-0.5, and is clearly incorrect now. This commit change the error message to be the same as other binary expressions.
