### PR TITLE
add backend/outbuf.d

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -211,6 +211,18 @@ One and only one of these macros must be set by the makefile:
 
 char *strupr(char *);
 
+#include <stddef.h>     // for size_t
+
+#if __APPLE__ && __i386__
+    /* size_t is 'unsigned long', which makes it mangle differently
+     * than D's 'uint'
+     */
+    typedef unsigned d_size_t;
+#else
+    typedef size_t d_size_t;
+#endif
+
+
 //
 //      Attributes
 //

--- a/src/backend/outbuf.c
+++ b/src/backend/outbuf.c
@@ -57,10 +57,10 @@ void Outbuffer::reset()
 }
 
 // Enlarge buffer size so there's at least nbytes available
-void Outbuffer::enlarge(size_t nbytes)
+void Outbuffer::enlarge(d_size_t nbytes)
 {
-    size_t oldlen = len;
-    size_t used = p - buf;
+    d_size_t oldlen = len;
+    d_size_t used = p - buf;
 
     if (inc > nbytes)
     {
@@ -115,7 +115,7 @@ void Outbuffer::enlarge(size_t nbytes)
  *      offset = specified location
  *      nbytes = number of bytes to be written at offset
  */
-void Outbuffer::position(size_t offset, size_t nbytes)
+void Outbuffer::position(d_size_t offset, d_size_t nbytes)
 {
     if (offset + nbytes > len)
     {
@@ -131,7 +131,7 @@ void Outbuffer::position(size_t offset, size_t nbytes)
 }
 
 // Write an array to the buffer.
-void Outbuffer::write(const void *b, size_t len)
+void Outbuffer::write(const void *b, d_size_t len)
 {
     if (pend - p < len)
         reserve(len);
@@ -140,7 +140,7 @@ void Outbuffer::write(const void *b, size_t len)
 }
 
 // Write n zeros to the buffer.
-void *Outbuffer::writezeros(size_t len)
+void *Outbuffer::writezeros(d_size_t len)
 {
     if (pend - p < len)
         reserve(len);
@@ -229,7 +229,7 @@ void Outbuffer::prependBytes(const char *s)
     prepend(s, strlen(s));
 }
 
-void Outbuffer::prepend(const void *b, size_t len)
+void Outbuffer::prepend(const void *b, d_size_t len)
 {
     reserve(len);
     memmove(buf + len,buf,p - buf);
@@ -265,7 +265,7 @@ char *Outbuffer::toString()
  * Set current size of buffer.
  */
 
-void Outbuffer::setsize(size_t size)
+void Outbuffer::setsize(d_size_t size)
 {
     p = buf + size;
 #if DEBUG

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -279,7 +279,7 @@ GLUE_SRC = glue.c msc.c s2ir.c e2ir.c \
 	tk.c eh.c gluestub.d objc_glue.c objc_glue_stubs.c
 
 BACK_HDRS=$C/bcomplex.d $C/cc.d $C/cdef.d $C/cgcv.d $C/dt.d $C/el.d $C/global.d \
-	$C/obj.d $C/oper.d $C/rtlsym.d \
+	$C/obj.d $C/oper.d $C/outbuf.d $C/rtlsym.d \
 	$C/ty.d $C/type.d
 
 TK_HDRS= $(TK)/dlist.d

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -158,7 +158,7 @@ FRONT_SRCS=access.d aggregate.d aliasthis.d apply.d argtypes.d arrayop.d	\
 GLUE_SRCS=irstate.d toctype.d gluelayer.d todt.d tocsym.d toir.d
 
 BACK_HDRS=$C/bcomplex.d $C/cc.d $C/cdef.d $C/cgcv.d $C/dt.d $C/el.d $C/global.d \
-	$C/obj.d $C/oper.d $C/rtlsym.d \
+	$C/obj.d $C/oper.d $C/outbuf.d $C/rtlsym.d \
 	$C/ty.d $C/type.d
 
 TK_HDRS= $(TK)/dlist.d


### PR DESCRIPTION
Converts outbuf.h to outbuf.d. The most annoying problem is the mangling of size_t on 32 bit OSX.
