### PR TITLE
[Partial] Fix Issue 16523

### DIFF
--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -2164,6 +2164,15 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                      * for this, i.e. generate a sequence of if-then-else
                      */
                     sw.hasVars = 1;
+
+                    /* TODO check if v can be uninitialized at that point.
+                     * Also check if the VarExp is declared in a scope outside of this one
+                     */
+                    if (!v.isConst() && !v.isImmutable())
+                    {
+                        cs.warning("case variables have to be const or immutable");
+                    }
+
                     if (sw.isFinal)
                     {
                         cs.error("case variables not allowed in final switch statements");

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -2170,7 +2170,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                      */
                     if (!v.isConst() && !v.isImmutable())
                     {
-                        cs.warning("case variables have to be const or immutable");
+                        cs.deprecation("case variables have to be const or immutable");
                     }
 
                     if (sw.isFinal)

--- a/test/fail_compilation/test16523.d
+++ b/test/fail_compilation/test16523.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test16523.d(13): Deprecation: case variables have to be const or immutable
+---
+*/
+
+void test(int a, int b)
+{
+    switch (a)
+    {
+    case b: return;
+    default: assert(0);
+    }
+}


### PR DESCRIPTION
We have to check if a switch variable is const or immutable otherwise we end of with a missing symbol.

This is only a partial fix.
We also have to make sure that we are not dealing with a temporary symbol.
