### PR TITLE
fix Issue 16525 - C++ member variables have no mangling

### DIFF
--- a/src/cppmangle.d
+++ b/src/cppmangle.d
@@ -388,7 +388,8 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
 
         void mangle_variable(VarDeclaration d, bool is_temp_arg_ref)
         {
-            if (!(d.storage_class & (STCextern | STCgshared)))
+            // fake mangling for fields to fix https://issues.dlang.org/show_bug.cgi?id=16525
+            if (!(d.storage_class & (STCextern | STCfield | STCgshared)))
             {
                 d.error("Internal Compiler Error: C++ static non- __gshared non-extern variables not supported");
                 fatal();
@@ -1457,14 +1458,15 @@ else static if (TARGET_WINDOS)
         {
             // <static variable mangle> ::= ? <qualified name> <protection flag> <const/volatile flag> <type>
             assert(d);
-            if (!(d.storage_class & (STCextern | STCgshared)))
+            // fake mangling for fields to fix https://issues.dlang.org/show_bug.cgi?id=16525
+            if (!(d.storage_class & (STCextern | STCfield | STCgshared)))
             {
                 d.error("Internal Compiler Error: C++ static non- __gshared non-extern variables not supported");
                 fatal();
             }
             buf.writeByte('?');
             mangleIdent(d);
-            assert(!d.needThis());
+            assert((d.storage_class & STCfield) || !d.needThis());
             if (d.parent && d.parent.isModule()) // static member
             {
                 buf.writeByte('3');

--- a/test/compilable/test16525.d
+++ b/test/compilable/test16525.d
@@ -1,0 +1,19 @@
+static immutable templ(alias var) = 1234;
+
+struct D
+{
+    int memvar;
+}
+
+extern(C++) struct CPP
+{
+    int memvar;
+}
+
+void test()
+{
+    pragma(msg, templ!(D.memvar));
+    pragma(msg, templ!(CPP.memvar));
+    // root cause, C++ member variables have no mangling
+    pragma(msg, CPP.memvar.mangleof);
+}


### PR DESCRIPTION
- while there seems to be no way to require mangling of C++ member
  variables in C++ itself, D does need the mangling for template parameters
- use the same mangling as for static member variables

Required for [Issue 16513 – Speed up TemplateInstance.findExistingInstance, hash by mangling](https://issues.dlang.org/show_bug.cgi?id=16513).
