### PR TITLE
[critical] fix Issue 16530 - -O -cov interaction leads to wrong codegen

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -2292,20 +2292,23 @@ STATIC code * comsub(elem *e,regm_t *pretregs)
     code* c = CNIL;
     if (*pretregs == 0) goto done;        /* no possible side effects anyway */
 
-    if (tyfloating(e->Ety) && config.inline8087)
+    /* First construct a mask, emask, of all the registers that
+     * have the right contents.
+     */
+    emask = 0;
+    for (unsigned i = 0; i < arraysize(regcon.cse.value); i++)
+    {
+        //dbg_printf("regcon.cse.value[%d] = %p\n",i,regcon.cse.value[i]);
+        if (regcon.cse.value[i] == e)   // if contents are right
+                emask |= mask[i];       // turn on bit for reg
+    }
+    emask &= regcon.cse.mval;                     // make sure all bits are valid
+
+    if (emask & XMMREGS && *pretregs == mPSW)
+        ;
+    else if (tyfloating(e->Ety) && config.inline8087)
         return comsub87(e,pretregs);
 
-  /* First construct a mask, emask, of all the registers that   */
-  /* have the right contents.                                   */
-
-  emask = 0;
-  for (unsigned i = 0; i < arraysize(regcon.cse.value); i++)
-  {
-        //dbg_printf("regcon.cse.value[%d] = %p\n",i,regcon.cse.value[i]);
-        if (regcon.cse.value[i] == e)   /* if contents are right        */
-                emask |= mask[i];       /* turn on bit for reg          */
-  }
-  emask &= regcon.cse.mval;                     /* make sure all bits are valid */
 
   /* create mask of what's in csextab[] */
   csemask = 0;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -6062,6 +6062,30 @@ void test16027()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16530
+
+double entropy2(double[] probs)
+{
+    double result = 0;
+    foreach (p; probs)
+    {
+        __gshared int x;
+        ++x;
+        if (!p) continue;
+        import std.math : log2;
+        result -= p * log2(p);
+    }
+    return result;
+}
+
+void test16530()
+{
+    import std.stdio;
+    if (entropy2([1.0, 0, 0]) != 0.0)
+       assert(0);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -6359,6 +6383,7 @@ int main()
     test14430();
     test14510();
     test16027();
+    test16530();
 
     writefln("Success");
     return 0;


### PR DESCRIPTION
This also seems to have fixed a tab issue in test42.d.

Anyhow, this is a critical bug fix.
