### PR TITLE
Fix issue 14613 - DMD: Internal error: backend/cod1.c on '-O' switch.

### DIFF
--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -527,9 +527,9 @@ code *comsub87(elem *e,regm_t *pretregs)
             c = push87();
             c = genf2(c,0xD9,0xC0 + i); // FLD ST(i)
             if (*pretregs & XMMREGS)
-                c = cat(c,fixresult87(e,mST0,pretregs));
-            else
                 c = cat(c,fixresult(e,mST0,pretregs));
+            else
+                c = cat(c,fixresult87(e,mST0,pretregs));
         }
         else
             // Reload

--- a/test/runnable/issue14613.d
+++ b/test/runnable/issue14613.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -O
+void main() {}
+double foo(double b)
+{
+    return b / (b == 0) == 0;
+}


### PR DESCRIPTION
It looks like the function calls for handling XMM and x87 floating point were swapped by accident.
