### PR TITLE
fix Issue 15316 - different NaN value in struct initializer

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -1274,28 +1274,12 @@ elem *toElem(Expression *e, IRState *irs)
             {
                 case TYfloat:
                 case TYifloat:
-                    /* This assignment involves a conversion, which
-                     * unfortunately also converts SNAN to QNAN.
-                     */
-                    c.Vfloat = re->value;
-                    if (CTFloat::isSNaN(re->value))
-                    {
-                        // Put SNAN back
-                        c.Vuns &= 0xFFBFFFFFL;
-                    }
+                    c.Vfloat = CTFloat::toFloatPrec(re->value);
                     break;
 
                 case TYdouble:
                 case TYidouble:
-                    /* This assignment involves a conversion, which
-                     * unfortunately also converts SNAN to QNAN.
-                     */
-                    c.Vdouble = re->value;
-                    if (CTFloat::isSNaN(re->value))
-                    {
-                        // Put SNAN back
-                        c.Vullong &= 0xFFF7FFFFFFFFFFFFULL;
-                    }
+                    c.Vdouble = CTFloat::toDoublePrec(re->value);
                     break;
 
                 case TYldouble:
@@ -1330,41 +1314,13 @@ elem *toElem(Expression *e, IRState *irs)
             switch (tybasic(ty))
             {
                 case TYcfloat:
-                    c.Vcfloat.re = (float) re;
-                    if (CTFloat::isSNaN(re))
-                    {
-                        union { float f; unsigned i; } u;
-                        u.f = c.Vcfloat.re;
-                        u.i &= 0xFFBFFFFFL;
-                        c.Vcfloat.re = u.f;
-                    }
-                    c.Vcfloat.im = (float) im;
-                    if (CTFloat::isSNaN(im))
-                    {
-                        union { float f; unsigned i; } u;
-                        u.f = c.Vcfloat.im;
-                        u.i &= 0xFFBFFFFFL;
-                        c.Vcfloat.im = u.f;
-                    }
+                    c.Vcfloat.re = CTFloat::toFloatPrec(re);
+                    c.Vcfloat.im = CTFloat::toFloatPrec(im);
                     break;
 
                 case TYcdouble:
-                    c.Vcdouble.re = (double) re;
-                    if (CTFloat::isSNaN(re))
-                    {
-                        union { double d; unsigned long long i; } u;
-                        u.d = c.Vcdouble.re;
-                        u.i &= 0xFFF7FFFFFFFFFFFFULL;
-                        c.Vcdouble.re = u.d;
-                    }
-                    c.Vcdouble.im = (double) im;
-                    if (CTFloat::isSNaN(re))
-                    {
-                        union { double d; unsigned long long i; } u;
-                        u.d = c.Vcdouble.im;
-                        u.i &= 0xFFF7FFFFFFFFFFFFULL;
-                        c.Vcdouble.im = u.d;
-                    }
+                    c.Vcdouble.re = CTFloat::toDoublePrec(re);
+                    c.Vcdouble.im = CTFloat::toDoublePrec(im);
                     break;
 
                 case TYcldouble:

--- a/src/root/ctfloat.h
+++ b/src/root/ctfloat.h
@@ -33,6 +33,10 @@ struct CTFloat
     static bool isIdentical(real_t a, real_t b);
     static bool isNaN(real_t r);
     static bool isSNaN(real_t r);
+    /// converts real to float bug preserves signaling NaNs
+    static float toFloatPrec(real_t r);
+    /// converts real to double but preserves signaling NaNs
+    static double toDoublePrec(real_t r);
     static bool isInfinity(real_t r);
 
     static real_t parse(const char *literal, bool *isOutOfRange = NULL);

--- a/src/todt.d
+++ b/src/todt.d
@@ -297,13 +297,15 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
 
         override void visit(RealExp e)
         {
+            import ddmd.root.ctfloat : CTFloat;
+
             //printf("RealExp.toDt(%Lg)\n", e.value);
             switch (e.type.toBasetype().ty)
             {
                 case Tfloat32:
                 case Timaginary32:
                 {
-                    auto fvalue = cast(float)e.value;
+                    auto fvalue = CTFloat.toFloatPrec(e.value);
                     dtb.nbytes(4, cast(char*)&fvalue);
                     break;
                 }
@@ -311,7 +313,7 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
                 case Tfloat64:
                 case Timaginary64:
                 {
-                    auto dvalue = cast(double)e.value;
+                    auto dvalue = CTFloat.toDoublePrec(e.value);
                     dtb.nbytes(8, cast(char*)&dvalue);
                     break;
                 }
@@ -334,23 +336,28 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
 
         override void visit(ComplexExp e)
         {
+            import ddmd.root.ctfloat : CTFloat;
+
             //printf("ComplexExp.toDt() '%s'\n", e.toChars());
+            immutable re = creall(e.value);
+            immutable im = cimagl(e.value);
+
             switch (e.type.toBasetype().ty)
             {
                 case Tcomplex32:
                 {
-                    auto fvalue = cast(float)creall(e.value);
+                    auto fvalue = CTFloat.toFloatPrec(creall(e.value));
                     dtb.nbytes(4, cast(char*)&fvalue);
-                    fvalue = cast(float)cimagl(e.value);
+                    fvalue = CTFloat.toFloatPrec(cimagl(e.value));
                     dtb.nbytes(4, cast(char*)&fvalue);
                     break;
                 }
 
                 case Tcomplex64:
                 {
-                    auto dvalue = cast(double)creall(e.value);
+                    auto dvalue = CTFloat.toDoublePrec(creall(e.value));
                     dtb.nbytes(8, cast(char*)&dvalue);
-                    dvalue = cast(double)cimagl(e.value);
+                    dvalue = CTFloat.toDoublePrec(cimagl(e.value));
                     dtb.nbytes(8, cast(char*)&dvalue);
                     break;
                 }

--- a/test/runnable/test15316.d
+++ b/test/runnable/test15316.d
@@ -1,0 +1,22 @@
+struct F {
+    float f;
+}
+struct D {
+    double d;
+};
+
+void main() {
+    F fx = F.init;
+    D dx = D.init;
+    assert(fx is fx.init);
+    assert(fx.f is float.init);
+    assert(dx is dx.init);
+    assert(dx.d is double.init);
+
+    F fy;
+    D dy;
+    assert(fy is fy.init);
+    assert(fy.f is float.init);
+    assert(dy is dy.init);
+    assert(dy.d is double.init);
+};


### PR DESCRIPTION
- the fix to restore signaling NaNs after real->float/double conversions
  was only applied to e2ir but not in todt, leading to different NaN
  init values for floats fields in default initalized structs
- move precision conversion functions to CTFloat and handle SNAN case
- <s>optimized gdc builts of dmd still loose SNANs way earlier when
  initializing RealExp with TargetReal.snan</s> fixed in 0bbe753600a044ac0f6e10363be3dc9dfc31623c
