### PR TITLE
add .mailmap file to merge author names

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Daniel Murphy <yebblies@gmail.com> yebblies <yebblies@gmail.com>
+Hara Kenji <k.hara.pg+dev@gmail.com> k-hara <k.hara.pg@gmail.com>
+Iain Buclaw <ibuclaw@gdcproject.org> ibuclaw <ibuclaw@ubuntu.com>
+Kai Nacke <kai@redstar.de> kai <kai@redstar.de>
+Martin Nowak <code@dawg.eu> dawg <dawg@dawgfoto.de>
+Mathias Lang <mathias.lang@sociomantic.com> Geod24 <pro.mathias.lang@gmail.com>


### PR DESCRIPTION
- useful for tools like `git shortlog -sn`
- only merging different author names, not all different email addresses
  people have been using
- github says to not use this file (they use email addresses
  associated w/ github accounts instead)
