### PR TITLE
Ddoc enhancements

### DIFF
--- a/src/doc.d
+++ b/src/doc.d
@@ -401,6 +401,7 @@ D_PSYMBOL = $(U $0)
 D_PARAM   = $(I $0)
 
 DDOC_COMMENT   = <!-- $0 -->
+DDOC_MEMBER    = $0
 DDOC_DECL      = $(DT $(BIG $0))
 DDOC_DECL_DD   = $(DD $0)
 DDOC_DITTO     = $(BR)$0
@@ -962,6 +963,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
             // Put previous doc comment if exists
             if (DocComment* dc = sc.lastdc)
             {
+                buf.writestring("$(DDOC_MEMBER");
                 // Put the declaration signatures as the document 'title'
                 buf.writestring(ddoc_decl_s);
                 for (size_t i = 0; i < dc.a.dim; i++)
@@ -995,6 +997,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
                         emitMemberComments(sds, buf, sc);
                 }
                 buf.writestring(ddoc_decl_dd_e);
+                buf.writeByte(')');
                 //printf("buf.2 = [[%.*s]]\n", buf->offset - o0, buf->data + o0);
             }
             if (s)


### PR DESCRIPTION
This PR is split into two separate commits, where the later ones depend on the former ones. The commit messages describe pretty well what they do and the intention. I've copied them here for convince:
- Ddoc: wrap each symbol in the `DDOC_MEMBER` macro
  
  This allows better control of formatting of the output. For example,
  it allows to output an unordered list instead of a description list.
  
  By default it expands the first argument (`$0`) as is, basically making
  the macro disappear, to keep backwards compatibility.
- Ddoc: add new macros: `DDOC_MEMBER_HEADER` and `DDOC_HEADER_ANCHOR`
  
  The second parameter (`$1`) of the `DDOC_HEADER_ANCHOR` macro expands to
  the fully qualified name of the current symbol without the package and
  module prefix. That is, for a module level symbol it's the name of a
  symbol. For a nested symbol, like a method in a class, it's the symbol
  name prefixed with the class name. The third parameter (`$2`) expands to
  just the name of the current symbol.
  
  The `DDOC_MEMBER_HEADER` wraps `DDOC_HEADER_ANCHOR` to allow a sensible
  output format. The `DDOC_MEMBER_HEADER` is wrapped in the `DDOC_MEMBER`
  macro.
  
  By default these two macros expand to nothing, to keep backwards
  compatibility.
