### PR TITLE
Fix issue 16555 - Generate correct code for pushing scalar parameters.

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -4184,7 +4184,7 @@ code *pushParams(elem *e,unsigned stackalign)
         {   // Avoid PUSH MEM on the Pentium when optimizing for speed
             break;
         }
-        else if (movOnly(e))
+        else if (movOnly(e) || tyfloating(tym) || tyvector(tym))
             break;                      // no PUSH MEM
         else
         {   int regsize = REGSIZE;
@@ -4315,7 +4315,7 @@ code *pushParams(elem *e,unsigned stackalign)
         break;
   }
   retregs = tybyte(tym) ? BYTEREGS : allregs;
-  if (tyvector(tym))
+  if (tyvector(tym) || (tyxmmreg(tym) && config.fpxmmregs))
   {
         retregs = XMMREGS;
         c = cat(c,codelem(e,&retregs,FALSE));


### PR DESCRIPTION
This is my try at fixing this issue, bear with me as it's my first time playing around with the dmd internals.
The snippet below shows a major codegen problem, the first 8 parameters are correctly passed into `XMM0-XMM7` but for the last one a `push rax` is generated, which is clearly wrong.
The patch corrects this issue by exiting the huge switch and using the code that's already there to correctly push fp values and vectors (the vector path is untested, I just assumed we'd hit the same problem).
There's a further change that attempts to use the XMM registers whenever possible to avoid the using the `x87` instructions, it does work fine in this case but I'm not 100% sure about this.

``` d
import std.stdio;

void main()
{
    void inner(double x)
    {
        if(x == 999) // to show that x itself isn't corrupt
        {
            writefln("x=%s a=%s b=%s c=%s d=%s e=%s f=%s g=%s h=%s", x, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
            //outer(x, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
        }
    }

    inner(999.0);
}
```

Cheers
