### PR TITLE
fix Issue 16570 - Enum member with interpreted...

### DIFF
--- a/src/dcast.d
+++ b/src/dcast.d
@@ -1633,7 +1633,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
 
         Lok:
-            result = new CastExp(e.loc, e, tob);
+            result = new CastExp(e.loc, e, t);
             result.type = t; // Don't call semantic()
             //printf("Returning: %s\n", result->toChars());
         }

--- a/test/compilable/test16570.d
+++ b/test/compilable/test16570.d
@@ -1,0 +1,8 @@
+static immutable int _a = 0;
+
+enum Regression
+{
+    a = _a,
+}
+
+static assert(is(typeof(Regression.a) == Regression));


### PR DESCRIPTION
...initializer has type of initializer not enum
- There is a very old (dmd 0.50 [¹](https://github.com/dlang/dmd/blob/bde09435d149c699490bb888b832228e0d31c221/src/cast.c#L321-L323respect)) mismatch of the CastExp's `to` type
  and the type painted on the CastExp (the latter being the basetype of
  the former, i.e. EnumType vs. int) in the result of
  `Expression.castTo(ed.type)`.
  Because of that difference interpreting castTo might unexpectedly use
  the basetype instead of the enum type for the enum initializer, and
  thus triggers the can't convert int to EnumType error.
- The trigger was introduced with the addition of a `e.ctfeInterpret` in
  denum.d (see 932be192e3).
- Comments on CastExp suggest that this type mismatch is actually
  intended, I don't see any reason for it though.
- Alternatively we could somehow fix ctfeInterpret to preserve CastExp's
  painted type.
