### PR TITLE
add special error message for '::'

### DIFF
--- a/src/lexer.d
+++ b/src/lexer.d
@@ -967,7 +967,14 @@ class Lexer
                 return;
             case ':':
                 p++;
-                t.value = TOKcolon;
+                if (*p == ':')
+                {
+                    ++p;
+                    error("'::' is not a valid token, perhaps '.' was meant?");
+                    t.value = TOKdot;
+                }
+                else
+                    t.value = TOKcolon;
                 return;
             case '$':
                 p++;

--- a/test/fail_compilation/colondot.d
+++ b/test/fail_compilation/colondot.d
@@ -1,0 +1,17 @@
+/*
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/colondot.d(16): Error: '::' is not a valid token, perhaps '.' was meant?
+---
+*/
+
+struct S
+{
+    static int a;
+}
+
+int foo(S* s)
+{
+    return S::a;
+}


### PR DESCRIPTION
When translating code from C++ to D, this is a more helpful error message.
