### PR TITLE
fix Issue 16536 - OSX mangling mismatch in dmd's C++/D ABI

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -468,7 +468,16 @@ typedef unsigned short  targ_ushort;
 typedef int             targ_long;
 typedef unsigned        targ_ulong;
 
-#if defined(__UINT64_TYPE__)
+/** HACK: Prefer UINTMAX_TYPE on OSX (unsigned long for LP64) to workaround
+ * https://issues.dlang.org/show_bug.cgi?id=16536. In D ulong uses the mangling
+ * of unsigned long on LP64. Newer versions of XCode/clang introduced the
+ * __UINT64_TYPE__ definition so the below rules would pick unsigned long long
+ * instead. This has a different mangling on OSX and causes a mismatch w/ C++
+ * ABIs using ulong.
+ *
+ * As a proper fix we should use uint64_t on both sides, which is always unsigned long long.
+ */
+#if defined(__UINT64_TYPE__) && !defined(__APPLE__)
 typedef __INT64_TYPE__     targ_llong;
 typedef __UINT64_TYPE__    targ_ullong;
 #elif defined(__UINTMAX_TYPE__)

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1164,6 +1164,15 @@ void test15802()
         assert(Foo15802!(int).boo(1) == 1);
 }
 
+/****************************************/
+// 16536 - mangling mismatch on OSX
+
+version(OSX) extern(C++) ulong pass16536(ulong);
+
+void test16536()
+{
+    version(OSX) assert(pass16536(123) == 123);
+}
 
 /****************************************/
 
@@ -1207,6 +1216,7 @@ void main()
     test15455();
     test15372();
     test15802();
+    test16536();
 
     printf("Success\n");
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -771,6 +771,7 @@ void test15372b()
 
 /****************************************/
 // 15802
+
 template <typename T>
 class Foo15802
 {
@@ -785,3 +786,14 @@ void test15802b()
 {
 	int t = Foo15802<int>::boo(1);
 }
+
+
+/****************************************/
+// 16536 - mangling mismatch on OSX
+
+#if defined(__APPLE__)
+__UINTMAX_TYPE__ pass16536(__UINTMAX_TYPE__ a)
+{
+    return a;
+}
+#endif


### PR DESCRIPTION
- just fix the specific dmd problem of picking up UINT64_TYPE (unsigned
  long long) on newer XCode/clang versions
- the D mangling of ulong should eventually be fixed to always match uint64_t
