### PR TITLE
disable addrparam pessimization

### DIFF
--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -626,8 +626,14 @@ again:
         {
             case SCregpar:
             case SCparameter:
+            case SCshadowreg:
                 if (e->Eoper == OPrelconst)
-                    addrparam = TRUE;   // taking addr of param list
+                {
+                    if (I16)
+                        addrparam = TRUE;   // taking addr of param list
+                    else
+                        s->Sflags &= ~(SFLunambig | GTregcand);
+                }
                 break;
 
             case SCstatic:
@@ -835,7 +841,10 @@ STATIC void out_regcand_walk(elem *e)
                     case SCregpar:
                     case SCparameter:
                     case SCshadowreg:
-                        addrparam = TRUE;       // taking addr of param list
+                        if (I16)
+                            addrparam = TRUE;       // taking addr of param list
+                        else
+                            s->Sflags &= ~(SFLunambig | GTregcand);
                         break;
                     case SCauto:
                     case SCregister:


### PR DESCRIPTION
The optimizer assumes that if the address of one parameter is taken, the address of all parameters was taken. This is because old code would walk the parameter stack that way.

But this way of writing code has long been obsolete. Indeed, modern ABIs do not allow it. So it can be safely removed. But I left it in for 16 bit code, as 16 bit code is pretty much by definition old code.

The net result is more variables can be enregistered.
