### PR TITLE
Modify -transition=safe usage to comply with deprecation process

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -8,12 +8,39 @@ $(BUGSTITLE Language Changes,
 )
 
 $(BUGSTITLE Compiler Changes,
+    $(LI $(RELATIVE_LINK2 iteration_closure, Assumes opApply delegate parameter escapes unless marked `scope`))
 )
 
 $(BUGSTITLE Language Changes,
 )
 
 $(BUGSTITLE Compiler Changes,
+    $(LI $(LNAME2 iteration_closure, Assumes opApply delegate parameter escapes unless marked `scope`)
+
+    $(P This breaking change was required to fix bug with `@safe` violation: $(BUGZILLA 16193).)
+
+    $(P To list all places where closure may be allocated after the change, use `-transition=safe`
+        compiler switch.)
+
+    $(P Example:)
+
+        ---
+        struct S1 {
+            int opApply(int delegate(int) dg);
+        }
+
+        struct S2 {
+            int opApply(scope int delegate(int) dg);
+        }
+
+        void foo() {
+            foreach(i; S1.init) { // will allocate closure
+            }
+            foreach(i; S2.init) { // won't allocate closure
+            }
+        }
+        ---
+    )
 )
 
 Macros:

--- a/src/mars.d
+++ b/src/mars.d
@@ -546,7 +546,7 @@ Language changes listed by -transition=id:
   =complex,14488 list all usages of complex or imaginary types
   =field,3449    list all non-mutable fields which occupy an object instance
   =import,10378  revert to single phase name lookup
-  =safe          implement enhanced @safe checking
+  =safe          shows places with hidden change in semantics needed for better @safe checking
   =tls           list all variables going into thread local storage
 ");
                         exit(EXIT_SUCCESS);

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -4923,10 +4923,11 @@ extern (C++) final class TypeSArray : TypeArray
                 e.error("%s is not an expression", e.toChars());
                 return new ErrorExp();
             }
-            else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe() && global.params.safe)
+            else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
             {
-                e.error("%s.ptr cannot be used in @safe code, use &%s[0] instead", e.toChars(), e.toChars());
-                return new ErrorExp();
+                // MAINTENANCE: turn into error in 2.073
+                e.deprecation("%s.ptr cannot be used in @safe code, use &%s[0] instead", e.toChars(), e.toChars());
+                // return new ErrorExp();
             }
             e = e.castTo(sc, e.type.nextOf().pointerTo());
         }
@@ -5219,10 +5220,11 @@ extern (C++) final class TypeDArray : TypeArray
         }
         else if (ident == Id.ptr)
         {
-            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe() && global.params.safe)
+            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
             {
-                e.error("%s.ptr cannot be used in @safe code, use &%s[0] instead", e.toChars(), e.toChars());
-                return new ErrorExp();
+                // MAINTENANCE: turn into error in 2.073
+                e.deprecation("%s.ptr cannot be used in @safe code, use &%s[0] instead", e.toChars(), e.toChars());
+                // return new ErrorExp();
             }
             e = e.castTo(sc, next.pointerTo());
             return e;

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -1448,7 +1448,16 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 else
                 {
                     if (global.params.safe)
-                        fld.tookAddressOf = 1;  // allocate a closure unless the opApply() uses 'scope'
+                    {
+                        fprintf(
+                            global.stdmsg,
+                            "%s: To enforce @safe compiler allocates a closure unless the opApply() uses 'scope'\n",
+                            loc.toChars()
+                        );
+                        fflush(global.stdmsg);
+                    }
+                    fld.tookAddressOf = 1;
+
                     assert(tab.ty == Tstruct || tab.ty == Tclass);
                     assert(sapply);
                     /* Call:

--- a/test/fail_compilation/test11176.d
+++ b/test/fail_compilation/test11176.d
@@ -1,9 +1,8 @@
-
 /*
-REQUIRED_ARGS: -transition=safe
+REQUIRED_ARGS: -de
 ---
-fail_compilation/test11176.d(12): Error: b.ptr cannot be used in @safe code, use &b[0] instead
-fail_compilation/test11176.d(17): Error: b.ptr cannot be used in @safe code, use &b[0] instead
+fail_compilation/test11176.d(12): Deprecation: b.ptr cannot be used in @safe code, use &b[0] instead
+fail_compilation/test11176.d(16): Deprecation: b.ptr cannot be used in @safe code, use &b[0] instead
 ---
 */
 

--- a/test/fail_compilation/test16193.d
+++ b/test/fail_compilation/test16193.d
@@ -3,8 +3,11 @@ REQUIRED_ARGS: -transition=safe
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/test16193.d(36): Error: function test16193.abc is @nogc yet allocates closures with the GC
-fail_compilation/test16193.d(38):        test16193.abc.__foreachbody1 closes over variable x at fail_compilation/test16193.d(37)
+fail_compilation/test16193.d(22): To enforce @safe compiler allocates a closure unless the opApply() uses 'scope'
+fail_compilation/test16193.d(34): To enforce @safe compiler allocates a closure unless the opApply() uses 'scope'
+fail_compilation/test16193.d(41): To enforce @safe compiler allocates a closure unless the opApply() uses 'scope'
+fail_compilation/test16193.d(39): Error: function test16193.abc is @nogc yet allocates closures with the GC
+fail_compilation/test16193.d(41):        test16193.abc.__foreachbody1 closes over variable x at fail_compilation/test16193.d(40)
 ---
 */
 


### PR DESCRIPTION
Adjusts changes from 3 commits (9f3e721b 354c3261 f7819c89) to use standard deprecation process for breaking changes instead of hiding new functionality behind compiler switch.

There is another commit it master (34213361) that will have to adjusted accordingly.
