### PR TITLE
remove vm stats from CI

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -2,13 +2,6 @@
 
 set -uexo pipefail
 
-if [ "$TRAVIS_OS_NAME" == osx ]; then
-    profile="vm_stat"
-else
-    profile="vmstat -s"
-fi
-date && $profile
-
 # add missing cc link in gdc-4.9.3 download
 if [ $DC = gdc ] && [ ! -f $(dirname $(which gdc))/cc ]; then
     ln -s gcc $(dirname $(which gdc))/cc
@@ -75,13 +68,8 @@ for proj in druntime phobos; do
     fi
 done
 
-build
-date && $profile
-test
-date && $profile
-rebuild
-date && $profile
-rebuild
-date && $profile
-test_dmd
-date && $profile
+date
+for step in build test rebuild rebuild test_dmd; do
+    $step
+    date
+done


### PR DESCRIPTION
- our test times and resource usage is OK now
- also simplify date printing using a loop
