### PR TITLE
fix OSX64 ABI mismatch with divcoeff

### DIFF
--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -477,6 +477,7 @@ typedef unsigned        targ_ulong;
  *
  * As a proper fix we should use uint64_t on both sides, which is always unsigned long long.
  */
+// This MUST MATCH typedef ullong in divcoeff.c.
 #if defined(__UINT64_TYPE__) && !defined(__APPLE__)
 typedef __INT64_TYPE__     targ_llong;
 typedef __UINT64_TYPE__    targ_ullong;

--- a/src/backend/divcoeff.c
+++ b/src/backend/divcoeff.c
@@ -13,7 +13,8 @@ Source: https://github.com/dlang/dmd/blob/master/src/backend/divcoeff.c
 #include <stdio.h>
 #include <assert.h>
 
-#ifdef __UINT64_TYPE__
+// This MUST MATCH typedef targ_ullong in cdef.h.
+#if defined(__UINT64_TYPE__) && !defined(__APPLE__)
 typedef __UINT64_TYPE__ ullong;
 #elif defined(__UINTMAX_TYPE__)
 typedef __UINTMAX_TYPE__ ullong;


### PR DESCRIPTION
- also apply fix from #6180 (Issue 16536) to divcoeff.c
- add comment that declarations must be kept in sync
