### PR TITLE
add comment in response to Issue 16484

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -1912,6 +1912,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     }
                     else
                     {
+                        // Discussion: https://issues.dlang.org/show_bug.cgi?id=16484
                         if (MATCHconvert < matchTiargs)
                             matchTiargs = MATCHconvert;
                     }


### PR DESCRIPTION
Issue 16484 - regression(2.064) Overloaded empty funcs trigger AssertError: "Called `get' on null Nullable" 

https://issues.dlang.org/show_bug.cgi?id=16484
