### PR TITLE
fix Issue 16563 - wrong alignment in function

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -126,7 +126,6 @@ class AlignDeclaration : public AttribDeclaration
     AlignDeclaration(Loc loc, Expression *ealign, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    void setScope(Scope *sc);
     void semantic2(Scope *sc);
     structalign_t getAlignment();
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -776,7 +776,7 @@ struct Scope
     structalign_t alignment()
     {
         if (aligndecl)
-            return aligndecl.getAlignment();
+            return aligndecl.getAlignment(&this);
         else
             return STRUCTALIGN_DEFAULT;
     }

--- a/test/compilable/test16563.d
+++ b/test/compilable/test16563.d
@@ -1,0 +1,10 @@
+void test16563()
+{
+    align(1)
+    struct S
+    {
+        uint i;
+        ubyte b;
+        static assert(S.sizeof == 5);
+    }
+}


### PR DESCRIPTION
- function local declarations don't have the setScope pass b/c there are
  no forward references, therefor AlignDeclaration must not rely on
  setScope being called
- pass Scope to getAlignment instead, either the normal semantic2 one or
  the one from Scope.alignment
