### PR TITLE
use OPpair for complex XMM values

### DIFF
--- a/src/backend/cg87.c
+++ b/src/backend/cg87.c
@@ -3890,4 +3890,22 @@ __body
     return cat4(cpush,c,fixresult_complex87(e, retregs, pretregs), NULL);
 }
 
+/**********************************************
+ * Load OPpair or OPrpair into mST01
+ */
+code *loadPair87(elem *e, regm_t *pretregs)
+{
+    assert(e->Eoper == OPpair || e->Eoper == OPrpair);
+    regm_t retregs = mST0;
+    code *c1 = codelem(e->E1, &retregs, FALSE);
+    note87(e->E1, 0, 0);
+    code *c2 = codelem(e->E2, &retregs, FALSE);
+    code *c3 = makesure87(e->E1, 0, 1, 0);
+    if (e->Eoper == OPrpair)
+        c3 = genf2(c3, 0xD9, 0xC8 + 1); // FXCH ST(1)
+    retregs = mST01;
+    code *c4 = fixresult_complex87(e, retregs, pretregs);
+    return cat4(c1,c2,c3,c4);
+}
+
 #endif // !SPP

--- a/src/backend/cod4.c
+++ b/src/backend/cod4.c
@@ -3744,15 +3744,40 @@ code *cdpair(elem *e, regm_t *pretregs)
 
     //printf("\ncdpair(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
     //printf("Ecount = %d\n", e->Ecount);
-    retregs = *pretregs & allregs;
-    if  (!retregs)
-        retregs = allregs;
-    regs1 = retregs & mLSW;
-    regs2 = retregs & mMSW;
+
+    retregs = *pretregs;
+    if (retregs == mPSW && tycomplex(e->Ety) && config.inline8087)
+    {
+        if (config.fpxmmregs)
+            retregs |= mXMM0 | mXMM1;
+        else
+            retregs |= mST01;
+    }
+
+    if (retregs & mST01)
+        return loadPair87(e, pretregs);
+
+    if (retregs & XMMREGS)
+    {
+        retregs &= XMMREGS;
+        unsigned reg = findreg(retregs);
+        regs1 = mask[reg];
+        regs2 = mask[findreg(retregs & ~regs1)];
+    }
+    else
+    {
+        retregs &= allregs;
+        if  (!retregs)
+            retregs = allregs;
+        regs1 = retregs & mLSW;
+        regs2 = retregs & mMSW;
+    }
     if (e->Eoper == OPrpair)
     {
-        regs1 = regs2;
-        regs2 = retregs & mLSW;
+        // swap
+        regs1 ^= regs2;
+        regs2 ^= regs1;
+        regs1 ^= regs2;
     }
     //printf("1: regs1 = %s, regs2 = %s\n", regm_str(regs1), regm_str(regs2));
     c1 = codelem(e->E1, &regs1, FALSE);

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -509,6 +509,7 @@ code *cdconvt87(elem *e, regm_t *pretregs);
 code *cload87(elem *e, regm_t *pretregs);
 code *cdd_u64(elem *e, regm_t *pretregs);
 code *cdd_u32(elem *e, regm_t *pretregs);
+code *loadPair87(elem *e, regm_t *pretregs);
 
 #ifdef DEBUG
 #define pop87() pop87(__LINE__,__FILE__)

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1579,14 +1579,79 @@ elem * evalu8(elem *e, goal_t goal)
                 e->EV.Vlong = (i2 << 16) | (i1 & 0xFFFF);
                 break;
             case 4:
-                e->EV.Vllong = (l2 << 32) | (l1 & 0xFFFFFFFF);
+                if (tyfloating(tym))
+                {
+                    e->EV.Vcfloat.re = d1;
+                    e->EV.Vcfloat.im = d2;
+                }
+                else
+                    e->EV.Vllong = (l2 << 32) | (l1 & 0xFFFFFFFF);
                 break;
             case 8:
-                e->EV.Vcent.lsw = l1;
-                e->EV.Vcent.msw = l2;
+                if (tyfloating(tym))
+                {
+                    e->EV.Vcdouble.re = d1;
+                    e->EV.Vcdouble.im = d2;
+                }
+                else
+                {
+                    e->EV.Vcent.lsw = l1;
+                    e->EV.Vcent.msw = l2;
+                }
                 break;
             default:
-                assert(0);
+                if (tyfloating(tym))
+                {
+                    e->EV.Vcldouble.re = d1;
+                    e->EV.Vcldouble.im = d2;
+                }
+                else
+                {
+                    assert(0);
+                }
+                break;
+        }
+        break;
+
+    case OPrpair:
+        switch (_tysize[tym])
+        {
+            case 2:
+                e->EV.Vlong = (i1 << 16) | (i2 & 0xFFFF);
+                break;
+            case 4:
+                e->EV.Vllong = (l1 << 32) | (l2 & 0xFFFFFFFF);
+                if (tyfloating(tym))
+                {
+                    e->EV.Vcfloat.re = d2;
+                    e->EV.Vcfloat.im = d1;
+                }
+                else
+                    e->EV.Vllong = (l1 << 32) | (l2 & 0xFFFFFFFF);
+                break;
+            case 8:
+                if (tyfloating(tym))
+                {
+                    e->EV.Vcdouble.re = d2;
+                    e->EV.Vcdouble.im = d1;
+                }
+                else
+                {
+                    e->EV.Vcent.lsw = l2;
+                    e->EV.Vcent.msw = l1;
+                }
+                break;
+            default:
+                if (tyfloating(tym))
+                {
+                    e->EV.Vcldouble.re = d2;
+                    e->EV.Vcldouble.im = d1;
+                }
+                else
+                {
+                    assert(0);
+                }
+                break;
         }
         break;
 


### PR DESCRIPTION
This simplifies dealing with XMM register pairs by treating them more independently. Generates better code, too.
