### PR TITLE
Rename 'safe' global arg to 'vsafe'

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -112,7 +112,8 @@ struct Param
     bool allInst;           // generate code for all template instantiations
     bool check10378;        // check for issues transitioning to 10738
     bool bug10378;          // use pre-bugzilla 10378 search strategy
-    bool safe;              // use enhanced @safe checking
+    bool vsafe;             // shows places with hidden change in semantics needed
+                            // for better @safe guarantees
     bool showGaggedErrors;  // print gagged errors anyway
 
     BOUNDSCHECK useArrayBounds;

--- a/src/mars.d
+++ b/src/mars.d
@@ -546,7 +546,7 @@ Language changes listed by -transition=id:
   =complex,14488 list all usages of complex or imaginary types
   =field,3449    list all non-mutable fields which occupy an object instance
   =import,10378  revert to single phase name lookup
-  =safe          shows places with hidden change in semantics needed for better @safe checking
+  =safe          shows places with hidden change in semantics needed for better @safe guarantees
   =tls           list all variables going into thread local storage
 ");
                         exit(EXIT_SUCCESS);
@@ -597,7 +597,7 @@ Language changes listed by -transition=id:
                             global.params.bug10378 = true;
                             break;
                         case "safe":
-                            global.params.safe = true;
+                            global.params.vsafe = true;
                             break;
                         case "tls":
                             global.params.vtls = true;

--- a/src/mars.d
+++ b/src/mars.d
@@ -598,7 +598,6 @@ Language changes listed by -transition=id:
                             break;
                         case "safe":
                             global.params.safe = true;
-                            global.params.useDIP25 = true;
                             break;
                         case "tls":
                             global.params.vtls = true;

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -1447,7 +1447,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 }
                 else
                 {
-                    if (global.params.safe)
+                    if (global.params.vsafe)
                     {
                         fprintf(
                             global.stdmsg,


### PR DESCRIPTION
Trivial tweak to prevent reviewer confusion like in https://github.com/dlang/dmd/pull/6183#discussion_r82521760
