### PR TITLE
Fix invalid memory access in BitArray

### DIFF
--- a/src/root/array.d
+++ b/src/root/array.d
@@ -206,7 +206,9 @@ nothrow:
     {
         immutable obytes = (len + 7) / 8;
         immutable nbytes = (nlen + 7) / 8;
-        ptr = cast(size_t*)mem.xrealloc(ptr, nbytes);
+        // bt*() access memory in size_t chunks, so round up.
+        ptr = cast(size_t*)mem.xrealloc(ptr,
+            (nbytes + (size_t.sizeof - 1)) & ~(size_t.sizeof - 1));
         if (nbytes > obytes)
             (cast(ubyte*)ptr)[obytes .. nbytes] = 0;
         len = nlen;


### PR DESCRIPTION
The core.bitop.bt*() family of functions by definition access memory
in size_t chunks. Thus, BitArray also needs to allocate its storage
in that granularity such as not to execute invalid reads/writes.

Of course, the likelihood that this would cause a crash outside
valgrind/asan/… is rather negligible due to the default alignment
provided by most contemporary allocators.
