### PR TITLE
fix Issue 16627 - non-static structs with postblit/dtor fields now nested

### DIFF
--- a/src/clone.d
+++ b/src/clone.d
@@ -921,6 +921,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
     {
         //printf("Building __fieldPostBlit()\n");
         auto dd = new PostBlitDeclaration(declLoc, Loc(), stc, Id.__fieldPostblit);
+        dd.generated = true;
         dd.storage_class |= STCinference;
         dd.fbody = a ? new CompoundStatement(loc, a) : null;
         sd.postblits.shift(dd);
@@ -1074,6 +1075,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
     {
         //printf("Building __fieldDtor()\n");
         auto dd = new DtorDeclaration(declLoc, Loc(), stc, Id.__fieldDtor);
+        dd.generated = true;
         dd.storage_class |= STCinference;
         dd.fbody = new ExpStatement(loc, e);
         ad.dtors.shift(dd);
@@ -1109,6 +1111,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
             e = Expression.combine(ex, e);
         }
         auto dd = new DtorDeclaration(declLoc, Loc(), stc, Id.__aggrDtor);
+        dd.generated = true;
         dd.storage_class |= STCinference;
         dd.fbody = new ExpStatement(loc, e);
         ad.members.push(dd);

--- a/src/func.d
+++ b/src/func.d
@@ -567,7 +567,9 @@ extern (C++) class FuncDeclaration : Declaration
 
         storage_class |= sc.stc & ~STCref;
         ad = isThis();
-        if (ad)
+        // Don't nest structs b/c of generated methods which should not access the outer scopes.
+        // https://issues.dlang.org/show_bug.cgi?id=16627
+        if (ad && !generated)
         {
             storage_class |= ad.storage_class & (STC_TYPECTOR | STCsynchronized);
             ad.makeNested();

--- a/test/compilable/test16627.d
+++ b/test/compilable/test16627.d
@@ -1,0 +1,18 @@
+void test()
+{
+    int a;
+
+    struct Field
+    {
+        this(this) { ++a; }
+        ~this() { --a; }
+    }
+
+    struct S
+    {
+        Field field; // generates __fieldPostblit, __fieldDtor, and opAssign
+    }
+
+    static assert(__traits(isNested, Field));
+    static assert(!__traits(isNested, S));
+}


### PR DESCRIPTION
- Since dlang/dmd#5500 buildPostblit/Dtor/OpAssign are run before
  the struct size is finalized, thereby now making structs nested
  that previously were not.
- Not sure if the old behavior was an intended feature. If not
  we might want to deprecate it.
