### PR TITLE
fix Issue 16607 - forward reference error for nested struct

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -126,6 +126,16 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         return sc2;
     }
 
+    override final void setScope(Scope* sc)
+    {
+        // Might need a scope to resolve forward references. The check for
+        // semanticRun prevents unnecessary setting of _scope during deferred
+        // setScope phases for aggregates which already finished semantic().
+        // Also see https://issues.dlang.org/show_bug.cgi?id=16607
+        if (semanticRun < PASSsemanticdone)
+            ScopeDsymbol.setScope(sc);
+    }
+
     override final void semantic2(Scope* sc)
     {
         //printf("AggregateDeclaration::semantic2(%s) type = %s, errors = %d\n", toChars(), type.toChars(), errors);

--- a/test/compilable/test16607.d
+++ b/test/compilable/test16607.d
@@ -1,0 +1,15 @@
+struct A(T)
+{
+    T t; // causes A to be SIZEOKfwd b/c B (passed as T) isn't yet done
+
+     // On the 2nd semantic pass through A, _scope of C got set again,
+     // even though the struct was already done.
+    struct C
+    {
+    }
+}
+
+struct B
+{
+    A!B* a; // causes instantiation of A!B, but can finish semantic with A!B still being fwdref
+}


### PR DESCRIPTION
- This reverts removing the AggregateDeclaration.setScope override (see
  75b5b69155) and fixes a wrong error triggered by setting _scope on a
  SIZEOKdone struct during deferred setScope phases (outer struct has
  forward references).
