### PR TITLE
Fix linker calling when using Microsoft CRuntime

### DIFF
--- a/src/link.d
+++ b/src/link.d
@@ -16,6 +16,7 @@ import core.stdc.string;
 import core.sys.posix.stdio;
 import core.sys.posix.stdlib;
 import core.sys.posix.unistd;
+import core.sys.windows.windows;
 import ddmd.errors;
 import ddmd.globals;
 import ddmd.root.file;
@@ -29,7 +30,41 @@ version (Windows) extern (C) int putenv(const char*);
 version (Windows) extern (C) int spawnlp(int, const char*, const char*, const char*, const char*);
 version (Windows) extern (C) int spawnl(int, const char*, const char*, const char*, const char*);
 version (Windows) extern (C) int spawnv(int, const char*, const char**);
-version (CRuntime_Microsoft) extern (Windows) uint GetShortPathNameA(const char* lpszLongPath, char* lpszShortPath, uint cchBuffer);
+version (CRuntime_Microsoft)
+{
+  // until the new windows bindings are available when building dmd.
+  static if(!is(STARTUPINFOA))
+  {
+    alias STARTUPINFOA = STARTUPINFO;
+
+    // dwCreationFlags for CreateProcess() and CreateProcessAsUser()
+    enum : DWORD {
+      DEBUG_PROCESS               = 0x00000001,
+      DEBUG_ONLY_THIS_PROCESS     = 0x00000002,
+      CREATE_SUSPENDED            = 0x00000004,
+      DETACHED_PROCESS            = 0x00000008,
+      CREATE_NEW_CONSOLE          = 0x00000010,
+      NORMAL_PRIORITY_CLASS       = 0x00000020,
+      IDLE_PRIORITY_CLASS         = 0x00000040,
+      HIGH_PRIORITY_CLASS         = 0x00000080,
+      REALTIME_PRIORITY_CLASS     = 0x00000100,
+      CREATE_NEW_PROCESS_GROUP    = 0x00000200,
+      CREATE_UNICODE_ENVIRONMENT  = 0x00000400,
+      CREATE_SEPARATE_WOW_VDM     = 0x00000800,
+      CREATE_SHARED_WOW_VDM       = 0x00001000,
+      CREATE_FORCEDOS             = 0x00002000,
+      BELOW_NORMAL_PRIORITY_CLASS = 0x00004000,
+      ABOVE_NORMAL_PRIORITY_CLASS = 0x00008000,
+      CREATE_BREAKAWAY_FROM_JOB   = 0x01000000,
+      CREATE_WITH_USERPROFILE     = 0x02000000,
+      CREATE_DEFAULT_ERROR_MODE   = 0x04000000,
+      CREATE_NO_WINDOW            = 0x08000000,
+      PROFILE_USER                = 0x10000000,
+      PROFILE_KERNEL              = 0x20000000,
+      PROFILE_SERVER              = 0x40000000
+    }
+  }
+}
 
 /****************************************
  * Write filename to cmdbuf, quoting if necessary.
@@ -773,21 +808,44 @@ version (Windows)
         cmd = toWinPath(cmd);
         version (CRuntime_Microsoft)
         {
-            if (strchr(cmd, ' '))
+            // Open scope so dmd doesn't complain about alloca + exception handling
             {
-                // MSVCRT: spawn does not work with spaces in the executable
-                size_t cmdlen = strlen(cmd);
-                char* shortName = (new char[](cmdlen + 1)).ptr; // enough space
-                uint plen = GetShortPathNameA(cmd, shortName, cast(uint)cmdlen + 1);
-                if (plen > 0 && plen <= cmdlen)
-                    cmd = shortName;
+                // Use process spawning through the WinAPI to avoid issues with executearg0 and spawnlp
+                OutBuffer cmdbuf;
+                cmdbuf.writestring("\"");
+                cmdbuf.writestring(cmd);
+                cmdbuf.writestring("\" ");
+                cmdbuf.writestring(args);
+
+                STARTUPINFOA startInf;
+                startInf.dwFlags = STARTF_USESTDHANDLES;
+                startInf.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+                startInf.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+                startInf.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+                PROCESS_INFORMATION procInf;
+
+                BOOL b = CreateProcessA(null, cmdbuf.peekString(), null, null, 1, NORMAL_PRIORITY_CLASS, null, null, &startInf, &procInf);
+                if (b)
+                {
+                    WaitForSingleObject(procInf.hProcess, INFINITE);
+                    DWORD returnCode;
+                    GetExitCodeProcess(procInf.hProcess, &returnCode);
+                    status = returnCode;
+                    CloseHandle(procInf.hProcess);
+                }
+                else
+                {
+                    status = -1;
+                }
             }
         }
-        status = executearg0(cmd, args);
-        if (status == -1)
+        else
         {
-            // spawnlp returns intptr_t in some systems, not int
-            status = spawnlp(0, cmd, cmd, args, null);
+            status = executearg0(cmd, args);
+            if (status == -1)
+            {
+                status = spawnlp(0, cmd, cmd, args, null);
+            }
         }
         //if (global.params.verbose)
         //    fprintf(global.stdmsg, "\n");
@@ -796,7 +854,7 @@ version (Windows)
             if (status == -1)
                 error(Loc(), "can't run '%s', check PATH", cmd);
             else
-                error(Loc(), "linker exited with status %d", cmd, status);
+                error(Loc(), "linker exited with status %d", status);
         }
         return status;
     }


### PR DESCRIPTION
While working on the dll support I had various issues with dmd calling the linker which all came from the bad implementation of spawnlp in the microsoft c-runtime. So I did a propper implemenation using the WinAPI. I would have used std.process but apperently you are not supposed to use phobos within dmd.

This also fixes a bug where the return value of the linker is not correctly reported on failure because the pointer to the cmd string is printed instead of the actual return value.
