### PR TITLE
expression.h: eliminate warning about const isGenerated

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -1023,7 +1023,7 @@ public:
 class CommaExp : public BinExp
 {
 public:
-    const bool isGenerated;
+    bool isGenerated;
     bool allowCommaExp;
     Expression *semantic(Scope *sc);
     int checkModifiable(Scope *sc, int flag);


### PR DESCRIPTION
This is to eliminate the warnings on OSX:

```
./expression.h:1023:7: warning: class 'CommaExp' does not declare any constructor to initialize its non-modifiable members
class CommaExp : public BinExp
      ^
./expression.h:1026:16: note: const member 'isGenerated' will never be initialized
    const bool isGenerated;
               ^
```
