### PR TITLE
evalu8.c: eliminate warning about labs()

### DIFF
--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -1719,7 +1719,7 @@ elem * evalu8(elem *e, goal_t goal)
                 e->EV.Vldouble = Complex_ld::abs(e1->EV.Vcldouble);
                 break;
             default:
-                e->EV.Vllong = labs(l1);
+                e->EV.Vllong = l1 < 0 ? -l1 : l1;
                 break;
         }
         break;


### PR DESCRIPTION
Who needs `labs()` anyway.

```
backend/evalu8.c:1722:32: warning: absolute value function 'labs' given an argument of type 'targ_llong' (aka 'long long') but has parameter of type 'long' which may cause truncation of value [-Wabsolute-value]
                e->EV.Vllong = labs(l1);
                               ^
backend/evalu8.c:1722:32: note: use function 'std::abs' instead
                e->EV.Vllong = labs(l1);
                               ^~~~
                               std::abs
backend/evalu8.c:1722:32: note: include the header <cstdlib> or explicitly provide a declaration for 'std::abs'
```
