### PR TITLE
bcomplex.c: use fabsl() instead of fabs() for long double

### DIFF
--- a/src/backend/bcomplex.c
+++ b/src/backend/bcomplex.c
@@ -12,7 +12,7 @@ Complex_ld Complex_ld::div(Complex_ld &x, Complex_ld &y)
     longdouble r;
     longdouble den;
 
-    if (fabs(y.re) < fabs(y.im))
+    if (fabsl(y.re) < fabsl(y.im))
     {
         r = y.re / y.im;
         den = y.im + r * y.re;
@@ -42,8 +42,8 @@ longdouble Complex_ld::abs(Complex_ld &z)
 {
     longdouble x,y,ans,temp;
 
-    x = fabs(z.re);
-    y = fabs(z.im);
+    x = fabsl(z.re);
+    y = fabsl(z.im);
     if (x == 0)
         ans = y;
     else if (y == 0)
@@ -73,8 +73,8 @@ Complex_ld Complex_ld::sqrtc(Complex_ld &z)
     }
     else
     {
-        x = fabs(z.re);
-        y = fabs(z.im);
+        x = fabsl(z.re);
+        y = fabsl(z.im);
         if (x >= y)
         {
             r = y / x;

--- a/src/backend/bcomplex.h
+++ b/src/backend/bcomplex.h
@@ -5,6 +5,7 @@
 
 #if _MSC_VER
 #include "longdouble.h"
+#define fabsl fabs
 #else
 typedef long double longdouble;
 #endif


### PR DESCRIPTION
This eliminates the warnings:

```
backend/bcomplex.c:15:9: warning: absolute value function 'fabs' given an argument of type 'longdouble' (aka 'long double') but has parameter of type 'double' which may cause truncation of value [-Wabsolute-value]
    if (fabs(y.re) < fabs(y.im))
        ^
backend/bcomplex.c:15:9: note: use function 'std::abs' instead
    if (fabs(y.re) < fabs(y.im))
        ^~~~
        std::abs
backend/bcomplex.c:15:9: note: include the header <cmath> or explicitly provide a declaration for 'std::abs'
```
