### PR TITLE
expand use of elToPair() to cover OPvar

### DIFF
--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -5457,7 +5457,6 @@ static elem *elToPair(elem *e)
     {
         case OPvar:
         {
-#if 0
             /* Rewrite complex number loads as a pair of loads
              * e => (e.0 pair e.offset)
              */
@@ -5475,7 +5474,6 @@ static elem *elToPair(elem *e)
                     e2->EV.sp.Voffset += _tysize[tybasic(ty0)];
                     return el_bin(OPpair, ty, e, e2);
             }
-#endif
             break;
         }
 

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1596,6 +1596,12 @@ Lnextlis:
         case OPucall:
             *pdomexit |= 2;
             break;
+
+        case OPpair:
+        case OPrpair:                   // don't move these, as they do not do computation
+            movelis(n->E1,b,l,pdomexit);
+            n = n->E2;
+            goto Lnextlis;
   }
 
 L3:


### PR DESCRIPTION
I had disabled this code in order to test thoroughly the subset first, https://github.com/dlang/dmd/pull/6198, to make it easier to track down if it went wrong. Time to turn it on.