### PR TITLE
Fix msvc/64-bit build.

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -391,7 +391,7 @@ tryagain:
         swoffset = CDoffset;
     else
         swoffset = Doffset;
-    swoffset = align(0,swoffset);
+    swoffset = _align(0,swoffset);
 
     // Emit the generated code
     if (eecontext.EEcompile == 1)
@@ -408,7 +408,7 @@ tryagain:
         {
             if (b->BC == BCjmptab || b->BC == BCswitch)
             {
-                swoffset = align(0,swoffset);
+                swoffset = _align(0,swoffset);
                 b->Btableoffset = swoffset;     /* offset of sw tab */
                 swoffset += b->Btablesize;
             }
@@ -1150,7 +1150,7 @@ void stackoffsets(int flags)
                 if (sz < REGSIZE)
                     sz = REGSIZE;
 
-                Fast.offset = align(sz,Fast.offset);
+                Fast.offset = _align(sz,Fast.offset);
                 s->Soffset = Fast.offset;
                 Fast.offset += sz;
                 //printf("fastpar '%s' sz = %d, fast offset =  x%x, %p\n",s->Sident,(int)sz,(int)s->Soffset, s);
@@ -1169,7 +1169,7 @@ void stackoffsets(int flags)
                     break;
                 }
 
-                Auto.offset = align(sz,Auto.offset);
+                Auto.offset = _align(sz,Auto.offset);
                 s->Soffset = Auto.offset;
                 Auto.offset += sz;
                 //printf("auto    '%s' sz = %d, auto offset =  x%lx\n",s->Sident,sz,(long)s->Soffset);
@@ -1179,7 +1179,7 @@ void stackoffsets(int flags)
                 break;
 
             case SCstack:
-                EEStack.offset = align(sz,EEStack.offset);
+                EEStack.offset = _align(sz,EEStack.offset);
                 s->Soffset = EEStack.offset;
                 //printf("EEStack.offset =  x%lx\n",(long)s->Soffset);
                 EEStack.offset += sz;
@@ -1197,7 +1197,7 @@ void stackoffsets(int flags)
                 /* Alignment on OSX 32 is odd. reals are 16 byte aligned in general,
                  * but are 4 byte aligned on the OSX 32 stack.
                  */
-                Para.offset = align(REGSIZE,Para.offset); /* align on word stack boundary */
+                Para.offset = _align(REGSIZE,Para.offset); /* align on word stack boundary */
                 if (alignsize == 16 && (I64 || tyvector(s->ty())))
                 {
                     if (Para.offset & 4)
@@ -1264,7 +1264,7 @@ void stackoffsets(int flags)
                     }
                 }
             }
-            Auto.offset = align(sz,Auto.offset);
+            Auto.offset = _align(sz,Auto.offset);
             s->Soffset = Auto.offset;
             //printf("auto    '%s' sz = %d, auto offset =  x%lx\n",s->Sident,sz,(long)s->Soffset);
             Auto.offset += sz;

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -2421,7 +2421,7 @@ int Obj::data_start(Symbol *sdata, targ_size_t datasize, int seg)
         alignbytes = ((offset + sdata->Salignment - 1) & ~(sdata->Salignment - 1)) - offset;
     }
     else
-        alignbytes = align(datasize, offset) - offset;
+        alignbytes = _align(datasize, offset) - offset;
     sdata->Soffset = offset + alignbytes;
     SegData[seg]->SDoffset = sdata->Soffset;
     return seg;

--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -2861,7 +2861,7 @@ code *cdfunc(elem *e,regm_t *pretregs)
     for (int i = np; --i >= 0;)
     {
         elem *ep = parameters[i].e;
-        unsigned psize = align(stackalign, paramsize(ep));     // align on stack boundary
+        unsigned psize = _align(stackalign, paramsize(ep));     // align on stack boundary
         if (config.exe == EX_WIN64)
         {
             //printf("[%d] size = %u, numpara = %d ep = %p ", i, psize, numpara, ep); WRTYxx(ep->Ety); printf("\n");
@@ -3036,7 +3036,7 @@ code *cdfunc(elem *e,regm_t *pretregs)
             unsigned numalign = parameters[i].numalign;
             if (usefuncarg)
             {
-                funcargtos -= align(stackalign, paramsize(ep)) + numalign;
+                funcargtos -= _align(stackalign, paramsize(ep)) + numalign;
                 cgstate.funcargtos = funcargtos;
             }
             else if (numalign)
@@ -3616,7 +3616,7 @@ static code *movParams(elem *e,unsigned stackalign, unsigned funcargtos)
     int grex = I64 ? REX_W << 16 : 0;
 
     targ_size_t szb = paramsize(e);               // size before alignment
-    targ_size_t sz = align(stackalign,szb);       // size after alignment
+    targ_size_t sz = _align(stackalign,szb);       // size after alignment
     assert((sz & (stackalign - 1)) == 0);         // ensure that alignment worked
     assert((sz & (REGSIZE - 1)) == 0);
     //printf("szb = %d sz = %d\n", (int)szb, (int)sz);
@@ -3830,7 +3830,7 @@ code *pushParams(elem *e,unsigned stackalign)
   int grex = I64 ? REX_W << 16 : 0;
 
   targ_size_t szb = paramsize(e);               // size before alignment
-  targ_size_t sz = align(stackalign,szb);       // size after alignment
+  targ_size_t sz = _align(stackalign,szb);       // size after alignment
   assert((sz & (stackalign - 1)) == 0);         // ensure that alignment worked
   assert((sz & (REGSIZE - 1)) == 0);
 

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -1726,7 +1726,7 @@ void outjmptab(block *b)
 
     /* Align start of jump table
      */
-    targ_size_t alignbytes = align(0,*poffset) - *poffset;
+    targ_size_t alignbytes = _align(0,*poffset) - *poffset;
     objmod->lidata(jmpseg,*poffset,alignbytes);
     assert(*poffset == b->Btableoffset);        // should match precomputed value
 
@@ -1826,7 +1826,7 @@ void outswitab(block *b)
         seg = JMPSEG;
   }
   offset = *poffset;
-  alignbytes = align(0,*poffset) - *poffset;
+  alignbytes = _align(0,*poffset) - *poffset;
   objmod->lidata(seg,*poffset,alignbytes);  /* any alignment bytes necessary */
   assert(*poffset == offset + alignbytes);
 

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -2091,7 +2091,7 @@ int Obj::data_start(Symbol *sdata, targ_size_t datasize, int seg)
         alignbytes = ((offset + sdata->Salignment - 1) & ~(sdata->Salignment - 1)) - offset;
     }
     else
-        alignbytes = align(datasize, offset) - offset;
+        alignbytes = _align(datasize, offset) - offset;
     if (alignbytes)
         Obj::lidata(seg, offset, alignbytes);
     sdata->Soffset = offset + alignbytes;

--- a/src/backend/global.h
+++ b/src/backend/global.h
@@ -259,9 +259,7 @@ void chkunass(elem *);
 void chknoabstract(type *);
 targ_llong msc_getnum();
 targ_size_t alignmember(type *,targ_size_t,targ_size_t);
-//targ_size_t align(targ_size_t,targ_size_t);
 targ_size_t _align(targ_size_t,targ_size_t);
-#define align(a, b) _align(a, b)
 
 /* nteh.c */
 unsigned char *nteh_context_string();

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -2156,7 +2156,7 @@ int Obj::data_start(Symbol *sdata, targ_size_t datasize, int seg)
         alignbytes = ((offset + sdata->Salignment - 1) & ~(sdata->Salignment - 1)) - offset;
     }
     else
-        alignbytes = align(datasize, offset) - offset;
+        alignbytes = _align(datasize, offset) - offset;
     if (alignbytes)
         Obj::lidata(seg, offset, alignbytes);
     sdata->Soffset = offset + alignbytes;

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -1757,7 +1757,7 @@ segidx_t MsCoffObj::data_start(Symbol *sdata, targ_size_t datasize, segidx_t seg
         alignbytes = ((offset + sdata->Salignment - 1) & ~(sdata->Salignment - 1)) - offset;
     }
     else
-        alignbytes = align(datasize, offset) - offset;
+        alignbytes = _align(datasize, offset) - offset;
     if (alignbytes)
         MsCoffObj::lidata(seg, offset, alignbytes);
     sdata->Soffset = offset + alignbytes;

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -173,7 +173,7 @@ void outdata(symbol *s)
 
                         case mTYcs:
                             s->Sseg = cseg;
-                            Coffset = align(datasize,Coffset);
+                            Coffset = _align(datasize,Coffset);
                             s->Soffset = Coffset;
                             Coffset += datasize;
                             s->Sfl = FLcsdata;
@@ -279,7 +279,7 @@ void outdata(symbol *s)
 
         case mTYcs:
             seg = cseg;
-            Coffset = align(datasize,Coffset);
+            Coffset = _align(datasize,Coffset);
             s->Soffset = Coffset;
             s->Sfl = FLcsdata;
             break;
@@ -1358,7 +1358,7 @@ void alignOffset(int seg,targ_size_t datasize)
 {
     targ_size_t alignbytes;
 
-    alignbytes = align(datasize,Offset(seg)) - Offset(seg);
+    alignbytes = _align(datasize,Offset(seg)) - Offset(seg);
     //dbg_printf("seg %d datasize = x%x, Offset(seg) = x%x, alignbytes = x%x\n",
       //seg,datasize,Offset(seg),alignbytes);
     if (alignbytes)

--- a/src/backend/type.c
+++ b/src/backend/type.c
@@ -223,7 +223,7 @@ unsigned type_paramsize(type *t)
         for (param_t *p = t->Tparamtypes; p; p = p->Pnext)
         {
             size_t n = type_size(p->Ptype);
-            n = align(REGSIZE,n);       // align to REGSIZE boundary
+            n = _align(REGSIZE,n);       // align to REGSIZE boundary
             sz += n;
         }
     }

--- a/src/tocvdebug.d
+++ b/src/tocvdebug.d
@@ -318,7 +318,7 @@ void toDebug(EnumDeclaration ed)
             cv8_udt(id, typidx);
         else
         {
-            uint len = strlen(id);
+            auto len = strlen(id);
             ubyte *debsym = cast(ubyte *) alloca(39 + IDOHD + len);
 
             // Output a 'user-defined type' for the tag name
@@ -577,9 +577,9 @@ void toDebug(ClassDeclaration cd)
         size_t n = cd.vtbl.dim;                   // number of virtual functions
         if (n)
         {   // 4 bits per descriptor
-            debtyp_t *vshape = debtyp_alloc(4 + (n + 1) / 2);
+            debtyp_t *vshape = debtyp_alloc(cast(uint)(4 + (n + 1) / 2));
             TOWORD(vshape.data.ptr,LF_VTSHAPE);
-            TOWORD(vshape.data.ptr + 2,n);
+            TOWORD(vshape.data.ptr + 2, cast(uint)n);
 
             n = 0;
             ubyte descriptor = 0;

--- a/src/vcbuild/ddmd.visualdproj
+++ b/src/vcbuild/ddmd.visualdproj
@@ -54,7 +54,7 @@
   <ccTransOpt>1</ccTransOpt>
   <program>c:\l\d\dmd2\windows\bin\dmd.exe</program>
   <imppath />
-  <fileImppath>generated</fileImppath>
+  <fileImppath>generated ..\..\res</fileImppath>
   <outdir>generated\$(ConfigurationName)_$(PlatformName)</outdir>
   <objdir>$(OutDir)</objdir>
   <objname />
@@ -156,7 +156,7 @@
   <ccTransOpt>1</ccTransOpt>
   <program>$(DMDInstallDir)windows\bin\dmd.exe</program>
   <imppath />
-  <fileImppath>generated</fileImppath>
+  <fileImppath>generated ..\..\res</fileImppath>
   <outdir>generated\$(ConfigurationName)_$(PlatformName)</outdir>
   <objdir>$(OutDir)</objdir>
   <objname />
@@ -258,7 +258,7 @@
   <ccTransOpt>1</ccTransOpt>
   <program>c:\l\d\dmd2\windows\bin\dmd.exe</program>
   <imppath />
-  <fileImppath>generated</fileImppath>
+  <fileImppath>generated ..\..\res</fileImppath>
   <outdir>generated\$(ConfigurationName)_$(PlatformName)</outdir>
   <objdir>$(OutDir)</objdir>
   <objname />
@@ -360,7 +360,7 @@
   <ccTransOpt>1</ccTransOpt>
   <program>$(DMDInstallDir)windows\bin\dmd.exe</program>
   <imppath />
-  <fileImppath>generated</fileImppath>
+  <fileImppath>generated ..\..\res</fileImppath>
   <outdir>generated\$(ConfigurationName)_$(PlatformName)</outdir>
   <objdir>$(OutDir)</objdir>
   <objname />
@@ -440,10 +440,16 @@
     <File path="..\backend\cc.d" />
     <File path="..\backend\cdef.d" />
     <File path="..\backend\cgcv.d" />
+    <File path="..\backend\code.d" />
+    <File path="..\backend\code_x86.d" />
+    <File path="..\backend\cv4.d" />
     <File path="..\backend\dt.d" />
     <File path="..\backend\el.d" />
     <File path="..\backend\global.d" />
+    <File path="..\backend\obj.d" />
     <File path="..\backend\oper.d" />
+    <File path="..\backend\outbuf.d" />
+    <File path="..\backend\rtlsym.d" />
     <File path="..\backend\ty.d" />
     <File path="..\backend\type.d" />
    </Folder>
@@ -493,12 +499,14 @@
    <File path="..\dmacro.d" />
    <File path="..\dmangle.d" />
    <File path="..\dmodule.d" />
+   <File path="..\dmsc.d" />
    <File path="..\doc.d" />
    <File path="..\dscope.d" />
    <File path="..\dstruct.d" />
    <File path="..\dsymbol.d" />
    <File path="..\dtemplate.d" />
    <File path="..\dversion.d" />
+   <File path="..\e2ir.d" />
    <File path="..\entity.d" />
    <File path="..\errors.d" />
    <File path="..\escape.d" />
@@ -531,6 +539,8 @@
    <File path="..\osmodel.mak" />
    <File path="..\parse.d" />
    <File path="..\posix.mak" />
+   <File path="..\s2ir.d" />
+   <File path="..\safe.d" />
    <File path="..\sapply.d" />
    <File path="..\scanmscoff.d" />
    <File path="..\scanomf.d" />
@@ -541,8 +551,11 @@
    <File path="..\target.d" />
    <File path="..\tocsym.d" />
    <File path="..\toctype.d" />
+   <File path="..\tocvdebug.d" />
    <File path="..\todt.d" />
+   <File path="..\toir.d" />
    <File path="..\tokens.d" />
+   <File path="..\toobj.d" />
    <File path="..\traits.d" />
    <File path="..\typinf.d" />
    <File path="..\utf.d" />
@@ -550,5 +563,6 @@
    <File path="..\visitor.d" />
    <File path="..\win32.mak" />
   </Folder>
+  <File path="..\glue.d" />
  </Folder>
 </DProject>

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -28,6 +28,18 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">false</WholeProgramOptimization>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -76,21 +88,15 @@
     <ClCompile Include="..\backend\backconfig.c" />
     <ClCompile Include="..\backend\compress.c" />
     <ClCompile Include="..\backend\cv8.c" />
+    <ClCompile Include="..\backend\gsroa.c" />
     <ClCompile Include="..\backend\pdata.c" />
     <ClCompile Include="..\backend\ph2.c" />
     <ClCompile Include="..\backend\util2.c" />
     <ClCompile Include="..\backend\varstats.c" />
-    <ClCompile Include="..\e2ir.c" />
     <ClCompile Include="..\eh.c" />
-    <ClCompile Include="..\glue.c" />
     <ClCompile Include="..\iasm.c" />
-    <ClCompile Include="..\msc.c" />
     <ClCompile Include="..\objc_glue_stubs.c" />
-    <ClCompile Include="..\s2ir.c" />
     <ClCompile Include="..\tk.c" />
-    <ClCompile Include="..\tocvdebug.c" />
-    <ClCompile Include="..\toir.c" />
-    <ClCompile Include="..\toobj.c" />
     <ClCompile Include="..\backend\aa.c" />
     <ClCompile Include="..\backend\bcomplex.c" />
     <ClCompile Include="..\backend\blockopt.c" />

--- a/src/vcbuild/dmd_backend.vcxproj.filters
+++ b/src/vcbuild/dmd_backend.vcxproj.filters
@@ -21,34 +21,13 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\e2ir.c">
-      <Filter>src</Filter>
-    </ClCompile>
     <ClCompile Include="..\eh.c">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\glue.c">
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\iasm.c">
       <Filter>src</Filter>
     </ClCompile>
-    <ClCompile Include="..\msc.c">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\s2ir.c">
-      <Filter>src</Filter>
-    </ClCompile>
     <ClCompile Include="..\tk.c">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\tocvdebug.c">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\toir.c">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\toobj.c">
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\backend\aa.c">
@@ -241,6 +220,9 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\backend\compress.c">
+      <Filter>src\backend</Filter>
+    </ClCompile>
+    <ClCompile Include="..\backend\gsroa.c">
       <Filter>src\backend</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Fixes the 64-bit build on windows.
Fixes the visual studio solution.
Fixes building dmd with msvc. In particular msvc uses __declspec(align(x)) a lot in the std c header files. So "#define align(x, y)" is conflicting a lot with msvc header files.