### PR TITLE
disable debug printfs

### DIFF
--- a/src/e2ir.d
+++ b/src/e2ir.d
@@ -170,7 +170,7 @@ elem *callfunc(Loc loc,
     int op;
     elem *eresult = ehidden;
 
-    debug
+    debug(E2IR)
     {
         printf("callfunc(directcall = %d, tret = '%s', ec = %p, fd = %p)\n",
             directcall, tret.toChars(), ec, fd);


### PR DESCRIPTION
The current debug build produces floods of debug output. Should it be versioned out with `version(none)` instead?