### PR TITLE
fix issue 11961: allow selecting the MS C runtime to link against

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -146,6 +146,7 @@ struct Param
 
     const(char)* defaultlibname;        // default library for non-debug builds
     const(char)* debuglibname;          // default library for debug builds
+    const(char)* mscrtlib;              // MS C runtime library
 
     const(char)* moduleDepsFile;        // filename for deps output
     OutBuffer* moduleDeps;              // contents to be written to deps file

--- a/src/glue.d
+++ b/src/glue.d
@@ -974,7 +974,8 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             if (global.params.mscoff)
             {
-                objmod.includelib("LIBCMT");
+                if (global.params.mscrtlib && global.params.mscrtlib[0])
+                    objmod.includelib(global.params.mscrtlib);
                 objmod.includelib("OLDNAMES");
             }
             else if (config.exe == EX_WIN32)
@@ -989,7 +990,8 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             if (global.params.mscoff)
             {
                 objmod.includelib("uuid");
-                objmod.includelib("LIBCMT");
+                if (global.params.mscrtlib && global.params.mscrtlib[0])
+                    objmod.includelib(global.params.mscrtlib);
                 objmod.includelib("OLDNAMES");
                 objmod.ehsections();   // initialize exception handling sections
             }
@@ -1007,7 +1009,8 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             if (global.params.mscoff)
             {
                 objmod.includelib("uuid");
-                objmod.includelib("LIBCMT");
+                if (global.params.mscrtlib && global.params.mscrtlib[0])
+                    objmod.includelib(global.params.mscrtlib);
                 objmod.includelib("OLDNAMES");
                 objmod.ehsections();   // initialize exception handling sections
             }


### PR DESCRIPTION
This allows linking seamlessly against other C runtime versions (libcmtd, msvcrt, msvcrtd) when interfacing with MS C/C++.

phobos.lib is agnostic to the selected runtime, but to get rid of the embedded library dependencies it needs to be built slightly different. PRs are coming...