### PR TITLE
fix issue 6716: Linking a C program with D library causes DEH errors

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -3020,6 +3020,11 @@ extern (C++) class FuncDeclaration : Declaration
         return ident == Id.DllMain && linkage != LINKc && !isMember();
     }
 
+    final bool isRtInit()
+    {
+        return ident == Id.rt_init && linkage == LINKc && !isMember() && !isNested();
+    }
+
     override final bool isExport()
     {
         return protection.kind == PROTexport;

--- a/src/glue.d
+++ b/src/glue.d
@@ -955,12 +955,10 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
                 global.params.isOpenBSD || global.params.isSolaris)
             {
                 objmod.external_def("_main");
-                objmod.ehsections();   // initialize exception handling sections
             }
             else if (global.params.mscoff)
             {
                 objmod.external_def("main");
-                objmod.ehsections();   // initialize exception handling sections
             }
             else if (config.exe == EX_WIN32)
             {
@@ -969,6 +967,15 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             }
             objmod.includelib(libname);
             s.Sclass = SCglobal;
+        }
+        else if (strcmp(s.Sident.ptr, "rt_init") == 0 && fd.linkage == LINKc)
+        {
+            if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD ||
+                global.params.isOpenBSD || global.params.isSolaris ||
+                global.params.mscoff)
+            {
+                objmod.ehsections();   // initialize exception handling sections
+            }
         }
         else if (strcmp(s.Sident.ptr, "main") == 0 && fd.linkage == LINKc)
         {
@@ -991,7 +998,6 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
                 objmod.includelib("uuid");
                 objmod.includelib("LIBCMT");
                 objmod.includelib("OLDNAMES");
-                objmod.ehsections();   // initialize exception handling sections
             }
             else
             {
@@ -1009,7 +1015,6 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
                 objmod.includelib("uuid");
                 objmod.includelib("LIBCMT");
                 objmod.includelib("OLDNAMES");
-                objmod.ehsections();   // initialize exception handling sections
             }
             else
             {

--- a/src/glue.d
+++ b/src/glue.d
@@ -968,7 +968,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             objmod.includelib(libname);
             s.Sclass = SCglobal;
         }
-        else if (strcmp(s.Sident.ptr, "rt_init") == 0 && fd.linkage == LINKc)
+        else if (fd.isRtInit())
         {
             if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD ||
                 global.params.isOpenBSD || global.params.isSolaris ||
@@ -977,7 +977,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
                 objmod.ehsections();   // initialize exception handling sections
             }
         }
-        else if (strcmp(s.Sident.ptr, "main") == 0 && fd.linkage == LINKc)
+        else if (fd.isCMain())
         {
             if (global.params.mscoff)
             {

--- a/src/idgen.d
+++ b/src/idgen.d
@@ -289,6 +289,7 @@ Msgtable[] msgtable =
     { "DllMain" },
     { "tls_get_addr", "___tls_get_addr" },
     { "entrypoint", "__entrypoint" },
+    { "rt_init" },
 
     // varargs implementation
     { "va_start" },

--- a/test/runnable/extra-files/test6716.cpp
+++ b/test/runnable/extra-files/test6716.cpp
@@ -1,0 +1,13 @@
+
+int test6716(int magic);
+
+extern "C" int rt_init();
+extern "C" int rt_term();
+
+int main(int argc, char*argv[])
+{
+    rt_init();
+    int rc = test6716(12345);
+    rt_term();
+    return rc;
+}

--- a/test/runnable/test6716.d
+++ b/test/runnable/test6716.d
@@ -1,0 +1,20 @@
+// EXTRA_CPP_SOURCES: test6716.cpp
+
+version(Windows)
+{
+    // without main, there is no implicit reference to the runtime library
+    // other platforms pass the runtime library on the linker command line
+    version(CRuntime_Microsoft)
+        version(Win64)
+            pragma(lib, "phobos64");
+        else
+            pragma(lib, "phobos32mscoff");
+    else
+        pragma(lib, "phobos");
+}
+
+extern(C++) int test6716(int magic)
+{
+    assert(magic == 12345);
+    return 0;
+}


### PR DESCRIPTION
Special sections should not be emitted with main, but rt_init. The latter function has to be called in any case, but main might be provided by C/C++ instead. 

This allows creating statically linked D libraries to be included with C++ projects without ugly workarounds like declaring Dmain in the library, praying the C main that is generated with it doesn't cause issues with the actual main.