### PR TITLE
fix Issue 13474 - Discard excess precision for float and double (x87)

### DIFF
--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -207,7 +207,7 @@ void test11565()
 
 ///////////////////////
 
-int array1[3] = [1:1,2,0:3];
+int[3] array1 = [1:1,2,0:3];
 
 void testarrayinit()
 {
@@ -1467,6 +1467,41 @@ void test4()
 }
 
 ////////////////////////////////////////////////////////////////////////
+// https://issues.dlang.org/show_bug.cgi?id=13474
+
+
+double sumKBN(double s = 0.0)
+{
+    import std.math : fabs;
+    double c = 0.0;
+        foreach(double x; [1, 1e100, 1, -1e100])
+        {
+            x = multiply(x);
+            double t = s + x;
+            if(s.fabs >= x.fabs)
+            {
+                double y = s-t;
+                c += y+x;
+            }
+            else
+            {
+                double y = x-t;
+                c += y+s;
+            }
+            s = t;
+        }
+    return s + c;
+}
+
+double multiply(double a) { return a * 10000; }
+
+void test13474()
+{
+    double r = 20000;
+    assert(r == sumKBN());
+}
+
+////////////////////////////////////////////////////////////////////////
 
 int main()
 {
@@ -1519,6 +1554,7 @@ int main()
     test15861();
     test15629();
     test4();
+    test13474();
     printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
The following code:
```
 double foo(double x, double t, double s, double c) {
    double y = x - t;
    c += y + s;
    return s + c;
 }
```
The body of which, when optimized, looks like:
```
    return s + (c + (x - t) + s);
```
Or, in x87 instructions:
```
       fld     qword ptr 01Ch[ESP]
       fld     qword ptr 0Ch[ESP]
       fxch    ST(1)
       fsub    qword ptr 014h[ESP]
       fadd    qword ptr 0Ch[ESP]
       fadd    qword ptr 4[ESP]
       fstp    qword ptr 4[ESP]
       fadd    qword ptr 4[ESP]
       ret     020h
```
The algorithm relies on rounding to double precision of the `(x-t)` calculation. The only way to get the x87 to do that is to actually assign it to memory. But the compiler optimizes away the assignment to memory, because it is substantially slower.

The 64 bit code does not have this problem, because the code gen looks like:
```
       push    RBP
       mov     RBP,RSP
       movsd   XMM4,XMM0
       movsd   XMM5,XMM1
       subsd   XMM3,XMM2
       addsd   XMM3,XMM5
       addsd   XMM4,XMM3
       movsd   XMM0,XMM5
       addsd   XMM0,XMM4
       pop     RBP
       ret
```
It's doing the same optimization, but the result is rounded to double because the XMM registers are doubles.

Note that the following targets generate x87 code, not XMM code:

    Win32, Linux32, FreeBSD32

because it is not guaranteed that the target has XMM registers. I suspect we don't really care about the floating point performance on those targets, but we do care that the code gives expected results.

This fix is to disable optimizing away the assignment to y for x87 code gen targets. The resulting code is:
```
       push    EAX
       push    EAX
       fld     qword ptr 024h[ESP]
       fsub    qword ptr 01Ch[ESP]
       fstp    qword ptr [ESP]         <== added store
       fld     qword ptr [ESP]          <== and reload
       fld     qword ptr 014h[ESP]
       fxch    ST(1)
       fadd    qword ptr 014h[ESP]
       fadd    qword ptr 0Ch[ESP]
       fstp    qword ptr 0Ch[ESP]
       fadd    qword ptr 0Ch[ESP]
       add     ESP,8
       ret     020h
```