### PR TITLE
fix Issue 16488 - [spec][optimization] broadcast scalar to simd vector

### DIFF
--- a/src/backend/cgcs.c
+++ b/src/backend/cgcs.c
@@ -375,6 +375,7 @@ STATIC void ecom(elem **pe)
     case OPsqrt: case OPsin: case OPcos:
 #endif
     case OPoffset: case OPnp_fp: case OPnp_f16p: case OPf16p_np:
+    case OPvecfill:
         ecom(&e->E1);
         break;
     case OPhalt:

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -471,6 +471,7 @@ unsigned xmmload(tym_t tym);
 unsigned xmmstore(tym_t tym);
 code *cdvector(elem *e, regm_t *pretregs);
 code *cdvecsto(elem *e, regm_t *pretregs);
+code *cdvecfill(elem *e, regm_t *pretregs);
 
 /* cg87.c */
 void note87(elem *e, unsigned offset, int i);

--- a/src/backend/evalu8.c
+++ b/src/backend/evalu8.c
@@ -2112,6 +2112,43 @@ elem * evalu8(elem *e, goal_t goal)
         }
 #endif
         return e;
+
+    case OPvecfill:
+        switch (tybasic(e->Ety))
+        {
+            case TYfloat4:
+                for (int i = 0; i < 4; ++i)
+                    e->EV.Vfloat4[i] = e1->EV.Vfloat;
+                break;
+            case TYdouble2:
+                for (int i = 0; i < 2; ++i)
+                    e->EV.Vdouble2[i] = e1->EV.Vdouble;
+                break;
+            case TYschar16:
+            case TYuchar16:
+                for (int i = 0; i < 16; ++i)
+                    ((targ_uchar *)&e->EV.Vcent)[i] = (targ_uchar)i1;
+                break;
+            case TYshort8:
+            case TYushort8:
+                for (int i = 0; i < 8; ++i)
+                    ((targ_ushort *)&e->EV.Vcent)[i] = (targ_ushort)i1;
+                break;
+            case TYlong4:
+            case TYulong4:
+                for (int i = 0; i < 4; ++i)
+                    ((targ_ulong *)&e->EV.Vcent)[i] = (targ_ulong)i1;
+                break;
+            case TYllong2:
+            case TYullong2:
+                for (int i = 0; i < 2; ++i)
+                    ((targ_ullong *)&e->EV.Vcent)[i] = (targ_ullong)l1;
+                break;
+            default:
+                assert(0);
+        }
+        break;
+
     default:
         return e;
   }

--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1056,6 +1056,7 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPvp_fp: /* BUG for MacHandles */
         case OPnp_f16p: case OPf16p_np: case OPoffset: case OPnp_fp:
         case OPcvp_fp:
+        case OPvecfill:
                 markinvar(n->E1,rd);
                 if (isLI(n->E1))        /* if child is LI               */
                         makeLI(n);

--- a/src/backend/oper.d
+++ b/src/backend/oper.d
@@ -222,6 +222,7 @@ enum
         OPgot,                  // load pointer to global offset table
         OPvector,               // SIMD vector operations
         OPvecsto,               // SIMD vector store operations
+        OPvecfill,              // fill SIMD vector with E1
 
         OPinp,                  // input from I/O port
         OPoutp,                 // output to I/O port

--- a/src/backend/oper.h
+++ b/src/backend/oper.h
@@ -232,6 +232,7 @@ enum OPER
         OPgot,                  // load pointer to global offset table
         OPvector,               // SIMD vector operations
         OPvecsto,               // SIMD vector store operations
+        OPvecfill,              // fill SIMD vector with E1
 
         OPinp,                  /* input from I/O port          */
         OPoutp,                 /* output to I/O port           */

--- a/src/backend/optabgen.c
+++ b/src/backend/optabgen.c
@@ -61,7 +61,7 @@ int _unary[] =
          OPctor,OPdtor,OPsetjmp,OPvoid,
          OPbsf,OPbsr,OPbswap,OPpopcnt,
          OPddtor,
-         OPvector,
+         OPvector,OPvecfill,
          OPva_start,
          OPsqrt,OPsin,OPcos,OPinp,
          OPvp_fp,OPcvp_fp,OPnp_fp,OPnp_f16p,OPf16p_np,OPoffset,
@@ -144,7 +144,7 @@ int _ae[] = {OPvar,OPconst,OPrelconst,OPneg,
                 OPnullptr,
                 OProl,OPror,
                 OPsqrt,OPsin,OPcos,OPscale,
-                OPvp_fp,OPcvp_fp,OPnp_fp,OPnp_f16p,OPf16p_np,OPoffset,
+                OPvp_fp,OPcvp_fp,OPnp_fp,OPnp_f16p,OPf16p_np,OPoffset,OPvecfill,
                 };
 int _boolnop[] = {OPuadd,OPbool,OPs16_32,OPu16_32,
                 OPs16_d,
@@ -155,6 +155,7 @@ int _boolnop[] = {OPuadd,OPbool,OPs16_32,OPu16_32,
                 OPu16_d,OPb_8,
                 OPnullptr,
                 OPnp_fp,OPvp_fp,OPcvp_fp,
+                OPvecfill,
                 };
 int _lvalue[] = {OPvar,OPind,OPcomma,OPbit};
 
@@ -580,6 +581,7 @@ void dotab()
         case OPpopcnt:  X("popcnt",     evalu8, cdpopcnt);
         case OPvector:  X("vector",     elzot,  cdvector);
         case OPvecsto:  X("vecsto",     elzot,  cdvecsto);
+        case OPvecfill: X("vecfill",    elzot,  cdvecfill);
         case OPva_start: X("va_start",  elvalist, cderr);
         case OPprefetch: X("prefetch",  elzot,  cdprefetch);
 

--- a/src/e2ir.d
+++ b/src/e2ir.d
@@ -170,7 +170,7 @@ elem *callfunc(Loc loc,
     int op;
     elem *eresult = ehidden;
 
-    debug(E2IR)
+    version (none)
     {
         printf("callfunc(directcall = %d, tret = '%s', ec = %p, fd = %p)\n",
             directcall, tret.toChars(), ec, fd);
@@ -3871,52 +3871,58 @@ elem *toElem(Expression e, IRState *irs)
                 printf("\tto  : %s\n", ve.to.toChars());
             }
 
-            elem *e = el_calloc();
-            e.Eoper = OPconst;
-            e.Ety = totym(ve.type);
-
-            for (size_t i = 0; i < ve.dim; i++)
+            elem* e;
+            if (ve.e1.op == TOKarrayliteral)
             {
-                Expression elem;
-                if (ve.e1.op == TOKarrayliteral)
-                    elem = (cast(ArrayLiteralExp)ve.e1).getElement(i);
-                else
-                    elem = ve.e1;
-                switch (elem.type.toBasetype().ty)
+                e = el_calloc();
+                e.Eoper = OPconst;
+                e.Ety = totym(ve.type);
+
+                for (size_t i = 0; i < ve.dim; i++)
                 {
-                    case Tfloat32:
-                        // Must not call toReal directly, to avoid dmd bug 14203 from breaking ddmd
-                        e.EV.Vfloat4[i] = elem.toComplex().re;
-                        break;
+                    Expression elem = (cast(ArrayLiteralExp)ve.e1).getElement(i);
+                    switch (elem.type.toBasetype().ty)
+                    {
+                        case Tfloat32:
+                            // Must not call toReal directly, to avoid dmd bug 14203 from breaking ddmd
+                            e.EV.Vfloat4[i] = elem.toComplex().re;
+                            break;
 
-                    case Tfloat64:
-                        // Must not call toReal directly, to avoid dmd bug 14203 from breaking ddmd
-                        e.EV.Vdouble2[i] = elem.toComplex().re;
-                        break;
+                        case Tfloat64:
+                            // Must not call toReal directly, to avoid dmd bug 14203 from breaking ddmd
+                            e.EV.Vdouble2[i] = elem.toComplex().re;
+                            break;
 
-                    case Tint64:
-                    case Tuns64:
-                        (cast(targ_ullong *)&e.EV.Vcent)[i] = elem.toInteger();
-                        break;
+                        case Tint64:
+                        case Tuns64:
+                            (cast(targ_ullong *)&e.EV.Vcent)[i] = elem.toInteger();
+                            break;
 
-                    case Tint32:
-                    case Tuns32:
-                        (cast(targ_ulong *)&e.EV.Vcent)[i] = cast(uint)elem.toInteger();
-                        break;
+                        case Tint32:
+                        case Tuns32:
+                            (cast(targ_ulong *)&e.EV.Vcent)[i] = cast(uint)elem.toInteger();
+                            break;
 
-                    case Tint16:
-                    case Tuns16:
-                        (cast(targ_ushort *)&e.EV.Vcent)[i] = cast(ushort)elem.toInteger();
-                        break;
+                        case Tint16:
+                        case Tuns16:
+                            (cast(targ_ushort *)&e.EV.Vcent)[i] = cast(ushort)elem.toInteger();
+                            break;
 
-                    case Tint8:
-                    case Tuns8:
-                        (cast(targ_uchar *)&e.EV.Vcent)[i] = cast(ubyte)elem.toInteger();
-                        break;
+                        case Tint8:
+                        case Tuns8:
+                            (cast(targ_uchar *)&e.EV.Vcent)[i] = cast(ubyte)elem.toInteger();
+                            break;
 
-                    default:
-                        assert(0);
+                        default:
+                            assert(0);
+                    }
                 }
+            }
+            else
+            {
+                // Create vecfill(e1)
+                elem* e1 = toElem(ve.e1, irs);
+                e = el_una(OPvecfill, totym(ve.type), e1);
             }
             elem_setLoc(e, ve.loc);
             result = e;

--- a/src/expression.d
+++ b/src/expression.d
@@ -11367,8 +11367,8 @@ extern (C++) final class VectorExp : UnaExp
                 result |= checkElem((cast(ArrayLiteralExp)e1).getElement(i));
             }
         }
-        else
-            result = checkElem(e1);
+        else if (e1.type.ty == Tvoid)
+            checkElem(e1);
 
         return result ? new ErrorExp() : this;
     }

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1480,6 +1480,112 @@ void testprefetch()
 
 /*****************************************/
 
+// https://issues.dlang.org/show_bug.cgi?id=16488
+
+void foo_byte16(byte t, byte s)
+{
+    byte16 f = s;
+    auto p = cast(byte*)&f;
+    foreach (i; 0 .. 16)
+        assert(p[i] == s);
+}
+
+void foo_ubyte16(ubyte t, ubyte s)
+{
+    ubyte16 f = s;
+    auto p = cast(ubyte*)&f;
+    foreach (i; 0 .. 16)
+        assert(p[i] == s);
+}
+
+
+void foo_short8(short t, short s)
+{
+    short8 f = s;
+    auto p = cast(short*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+void foo_ushort8(ushort t, ushort s)
+{
+    ushort8 f = s;
+    auto p = cast(ushort*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+
+void foo_int4(int t, int s)
+{
+    int4 f = s;
+    auto p = cast(int*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+void foo_uint4(uint t, uint s, uint u)
+{
+    uint4 f = s;
+    auto p = cast(uint*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+
+void foo_long2(long t, long s, long u)
+{
+    long2 f = s;
+    auto p = cast(long*)&f;
+    foreach (i; 0 .. 2)
+        assert(p[i] == s);
+}
+
+void foo_ulong2(ulong t, ulong s)
+{
+    ulong2 f = s;
+    auto p = cast(ulong*)&f;
+    foreach (i; 0 .. 2)
+        assert(p[i] == s);
+}
+
+void foo_float4(float t, float s)
+{
+    float4 f = s;
+    auto p = cast(float*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+void foo_double2(double t, double s, double u)
+{
+    double2 f = s;
+    auto p = cast(double*)&f;
+    foreach (i; 0 .. 2)
+        assert(p[i] == s);
+}
+
+
+void test16448()
+{
+    foo_byte16(5, -10);
+    foo_ubyte16(5, 11);
+
+    foo_short8(5, -6);
+    foo_short8(5, 7);
+
+    foo_int4(5, -6);
+    foo_uint4(5, 0x12345678, 22);
+
+    foo_long2(5, -6, 1);
+    foo_ulong2(5, 0x12345678_87654321L);
+
+    foo_float4(5, -6);
+    foo_double2(5, -6, 2);
+}
+
+/*****************************************/
+
 int main()
 {
     test1();
@@ -1512,6 +1618,7 @@ int main()
     test9449_2();
     test13988();
     testprefetch();
+    test16448();
 
     return 0;
 }


### PR DESCRIPTION
This removes the older hackish, constant-only support and generalizes it by adding a new operator, `OPvecfill`.