### PR TITLE
refactor: ddmd.root.speller => root.speller

### DIFF
--- a/src/dscope.d
+++ b/src/dscope.d
@@ -27,7 +27,7 @@ import ddmd.id;
 import ddmd.identifier;
 import ddmd.root.outbuffer;
 import ddmd.root.rmem;
-import ddmd.root.speller;
+import root.speller;
 import ddmd.statement;
 
 //version=LOGSEARCH;

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -42,7 +42,7 @@ import ddmd.opover;
 import ddmd.root.aav;
 import ddmd.root.rmem;
 import ddmd.root.rootobject;
-import ddmd.root.speller;
+import root.speller;
 import ddmd.statement;
 import ddmd.tokens;
 import ddmd.visitor;

--- a/src/root/speller.d
+++ b/src/root/speller.d
@@ -8,7 +8,7 @@
  * Source:    $(DMDSRC root/_speller.d)
  */
 
-module ddmd.root.speller;
+module root.speller;
 
 import core.stdc.limits;
 import core.stdc.stdlib;

--- a/src/traits.d
+++ b/src/traits.d
@@ -30,7 +30,7 @@ import ddmd.identifier;
 import ddmd.mtype;
 import ddmd.nogc;
 import ddmd.root.array;
-import ddmd.root.speller;
+import root.speller;
 import ddmd.root.stringtable;
 import ddmd.tokens;
 import ddmd.visitor;


### PR DESCRIPTION
The dmd build has a problem - all the .d files have to be specified on the same command line. The trouble is the prefix `ddmd.` on all the imports, yet there is no `ddmd` directory. D is designed to have the path/file structure match the package/module structure.

This fixes it for `root.speller`, as a harbinger for doing it to the rest of the dmd front end.