### PR TITLE
[scope] allow taking address of local in @safe code

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -10600,9 +10600,18 @@ extern (C++) final class AddrExp : UnaExp
                 }
                 if (sc.func && !sc.intypeof && !v.isDataseg())
                 {
-                    if (!global.params.safe && sc.func.setUnsafe())
+                    const(char)* p = v.isParameter() ? "parameter" : "local";
+                    if (global.params.safe)
                     {
-                        const(char)* p = v.isParameter() ? "parameter" : "local";
+                        v.storage_class &= ~STCmaybescope;
+                        if (v.storage_class & STCscope && sc.func.setUnsafe())
+                        {
+                            error("cannot take address of scope %s %s in @safe function %s", p, v.toChars(), sc.func.toChars());
+                            return false;
+                        }
+                    }
+                    else if (sc.func.setUnsafe())
+                    {
                         error("cannot take address of %s %s in @safe function %s", p, v.toChars(), sc.func.toChars());
                         return false;
                     }

--- a/src/expression.d
+++ b/src/expression.d
@@ -10600,7 +10600,7 @@ extern (C++) final class AddrExp : UnaExp
                 }
                 if (sc.func && !sc.intypeof && !v.isDataseg())
                 {
-                    if (sc.func.setUnsafe())
+                    if (!global.params.safe && sc.func.setUnsafe())
                     {
                         const(char)* p = v.isParameter() ? "parameter" : "local";
                         error("cannot take address of %s %s in @safe function %s", p, v.toChars(), sc.func.toChars());

--- a/src/func.d
+++ b/src/func.d
@@ -750,8 +750,11 @@ extern (C++) class FuncDeclaration : Declaration
             error("functions cannot be scope");
         }
 
-        if (f.isreturn && !needThis())
+        if (f.isreturn && !needThis() && !isNested())
         {
+            /* Non-static nested functions have a hidden 'this' pointer to which
+             * the 'return' applies
+             */
             error("static member has no 'this' to which 'return' can apply");
         }
 

--- a/src/func.d
+++ b/src/func.d
@@ -2223,7 +2223,18 @@ extern (C++) class FuncDeclaration : Declaration
             f.isnogc = true;
         }
 
-        flags &= ~(FUNCFLAGreturnInprocess | FUNCFLAGinferScope);
+        if (flags & FUNCFLAGreturnInprocess)
+        {
+            flags &= ~FUNCFLAGreturnInprocess;
+            if (storage_class & STCreturn)
+            {
+                if (type == f)
+                    f = cast(TypeFunction)f.copy();
+                f.isreturn = true;
+            }
+        }
+
+        flags &= ~FUNCFLAGinferScope;
 
         // Infer STCscope
         if (parameters)

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -250,3 +250,20 @@ void escape4() @safe
     scope FunDG g = ()        { return &x; };
 }
 
+/**************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope.d(267): Error: cannot take address of scope local p in @safe function escape5
+---
+*/
+
+void escape5() @safe
+{
+    int* q;
+    scope int* p;
+    scope int** pp = &q; // ok
+    pp = &p; // error
+}
+

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -237,6 +237,8 @@ TEST_OUTPUT:
 ---
 fail_compilation/retscope.d(247): Error: cannot implicitly convert expression (__lambda1) of type void* delegate() pure nothrow @nogc return @safe to void* delegate() @safe
 fail_compilation/retscope.d(247): Error: cannot implicitly convert expression (__lambda1) of type void* delegate() pure nothrow @nogc return @safe to void* delegate() @safe
+fail_compilation/retscope.d(248): Error: cannot implicitly convert expression (__lambda2) of type void* delegate() pure nothrow @nogc return @safe to void* delegate() @safe
+fail_compilation/retscope.d(248): Error: cannot implicitly convert expression (__lambda2) of type void* delegate() pure nothrow @nogc return @safe to void* delegate() @safe
 ---
 */
 
@@ -245,5 +247,6 @@ void escape4() @safe
     alias FunDG = void* delegate () @safe;
     int x = 42;
     scope FunDG f = () return { return &x; };
+    scope FunDG g = ()        { return &x; };
 }
 

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -214,3 +214,18 @@ void* escape3 (scope void* p) @safe {
     return dg();
 }
 
+/**************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope.d(230): Error: scope variable ptr may not be returned
+---
+*/
+
+alias dg_t = void* delegate () return scope @safe;
+
+void* funretscope(scope dg_t ptr) @safe
+{
+    return ptr();
+}

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -229,3 +229,21 @@ void* funretscope(scope dg_t ptr) @safe
 {
     return ptr();
 }
+
+/*****************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope.d(247): Error: cannot implicitly convert expression (__lambda1) of type void* delegate() pure nothrow @nogc return @safe to void* delegate() @safe
+fail_compilation/retscope.d(247): Error: cannot implicitly convert expression (__lambda1) of type void* delegate() pure nothrow @nogc return @safe to void* delegate() @safe
+---
+*/
+
+void escape4() @safe
+{
+    alias FunDG = void* delegate () @safe;
+    int x = 42;
+    scope FunDG f = () return { return &x; };
+}
+


### PR DESCRIPTION
With the `scope` improvements, this restriction is no longer necessary. It'll be tracked analogously to the way static arrays are tracked when a slice is taken.