### PR TITLE
[D1] Adjust override fix to use deprecations

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -1009,7 +1009,7 @@ FuncDeclaration *ClassDeclaration::findFunc(Identifier *ident, TypeFunction *tf)
 
             //printf("\t[%d] = %s\n", i, fd->toChars());
             if (ident == fd->ident &&
-                fd->type->covariant(tf) == 1)
+                fd->type->covariant(tf, fd->loc) == 1)
             {   //printf("fd->parent->isClassDeclaration() = %p\n", fd->parent->isClassDeclaration());
                 if (!fdmatch)
                     goto Lfd;

--- a/src/func.c
+++ b/src/func.c
@@ -1737,7 +1737,7 @@ int FuncDeclaration::overrides(FuncDeclaration *fd)
 
     if (fd->ident == ident)
     {
-        int cov = type->covariant(fd->type);
+        int cov = type->covariant(fd->type, this->loc);
         if (cov)
         {   ClassDeclaration *cd1 = toParent()->isClassDeclaration();
             ClassDeclaration *cd2 = fd->toParent()->isClassDeclaration();
@@ -1784,7 +1784,7 @@ int FuncDeclaration::findVtblIndex(Dsymbols *vtbl, int dim)
                 continue;
             }
 
-            int cov = type->covariant(fdv->type);
+            int cov = type->covariant(fdv->type, this->loc);
             //printf("\tbaseclass cov = %d\n", cov);
             switch (cov)
             {
@@ -1848,7 +1848,7 @@ int FuncDeclaration::overloadInsert(Dsymbol *s)
         return FALSE;
 
     if (type && f->type &&      // can be NULL for overloaded constructors
-        f->type->covariant(type) &&
+        f->type->covariant(type, this->loc) &&
         !isFuncAliasDeclaration())
     {
         //printf("\tfalse: conflict %s\n", kind());

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2676,7 +2676,7 @@ Type *TypeFunction::syntaxCopy()
  *      3       cannot determine covariance because of forward references
  */
 
-int Type::covariant(Type *t)
+int Type::covariant(Type *t, Loc loc)
 {
 #if 0
     printf("Type::covariant(t = %s) %s\n", t->toChars(), toChars());
@@ -2754,7 +2754,14 @@ int Type::covariant(Type *t)
             return 3;   // forward references
         }
     }
-    if (t1n->ty == t2n->ty && t1n->implicitConvTo(t2n))
+
+    if (t1n->ty != t2n->ty)
+    {
+        deprecation(loc, "%s overrides but is not covariant for %s",
+            t1->toChars(), t2->toChars());
+    }
+
+    if (t1n->implicitConvTo(t2n))
         goto Lcovariant;
 
     goto Lnotcovariant;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -197,7 +197,7 @@ struct Type : Object
     virtual Type *syntaxCopy();
     int equals(Object *o);
     int dyncast() { return DYNCAST_TYPE; } // kludge for template.isType()
-    int covariant(Type *t);
+    int covariant(Type *t, Loc loc);
     char *toChars();
     static char needThisPrefix();
     static void init();


### PR DESCRIPTION
Changes 2cce6488ade684c473316b3defa5f438bb4b0655 to print
deprecation message when method is overriden with non-covariant
type.

Required changing `Type::covariant` to take extra `loc` argument to
direct to location where check is made, as it can't be deduced from
`Type` alone.