### PR TITLE
support some unaligned XMM stores

### DIFF
--- a/src/backend/cod1.c
+++ b/src/backend/cod1.c
@@ -4746,8 +4746,8 @@ code *loaddata(elem *e,regm_t *pretregs)
         reg = e->EV.sp.Voffset ? e->EV.sp.Vsym->Spreg2 : e->EV.sp.Vsym->Spreg;
         forregs = mask[reg];
 #ifdef DEBUG
-        if (debugr)
-            printf("%s is fastpar and using register %s\n", e->EV.sp.Vsym->Sident, regm_str(forregs));
+//        if (debugr)
+//            printf("%s is fastpar and using register %s\n", e->EV.sp.Vsym->Sident, regm_str(forregs));
 #endif
         mfuncreg &= ~forregs;
         regcon.used |= forregs;
@@ -4802,7 +4802,7 @@ code *loaddata(elem *e,regm_t *pretregs)
         // Can't load from registers directly to XMM regs
         //e->EV.sp.Vsym->Sflags &= ~GTregcand;
 
-        op = xmmload(tym);
+        op = xmmload(tym, xmmIsAligned(e));
         if (e->Eoper == OPvar)
         {   symbol *s = e->EV.sp.Vsym;
             if (s->Sfl == FLreg && !(mask[s->Sreglsw] & XMMREGS))

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -467,11 +467,12 @@ code *xmmcnvt(elem *e,regm_t *pretregs);
 code *xmmopass(elem *e, regm_t *pretregs);
 code *xmmpost(elem *e, regm_t *pretregs);
 code *xmmneg(elem *e, regm_t *pretregs);
-unsigned xmmload(tym_t tym);
-unsigned xmmstore(tym_t tym);
+unsigned xmmload(tym_t tym, bool aligned = true);
+unsigned xmmstore(tym_t tym, bool aligned = true);
 code *cdvector(elem *e, regm_t *pretregs);
 code *cdvecsto(elem *e, regm_t *pretregs);
 code *cdvecfill(elem *e, regm_t *pretregs);
+bool xmmIsAligned(elem *e);
 
 /* cg87.c */
 void note87(elem *e, unsigned offset, int i);

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1629,6 +1629,35 @@ void test16703()
 
 /*****************************************/
 
+struct Sunsto
+{
+  align (1): // make sure f4 is misaligned
+    byte b;
+    union
+    {
+        float4 f4;
+        ubyte[16] a;
+    }
+}
+
+ubyte[16] foounsto()
+{
+    float4 vf = 6;
+    Sunsto s;
+    s.f4 = vf * 2;
+    vf = s.f4;
+
+    return s.a;
+}
+
+void testOPvecunsto()
+{
+    auto a = foounsto();
+    assert(a == [0, 0, 64, 65, 0, 0, 64, 65, 0, 0, 64, 65, 0, 0, 64, 65]);
+}
+
+/*****************************************/
+
 int main()
 {
     test1();
@@ -1663,6 +1692,7 @@ int main()
     testprefetch();
     test16448();
     test16703();
+    testOPvecunsto();
 
     return 0;
 }


### PR DESCRIPTION
This detects loads and stores to an unaligned XMM vector, and if so, uses an unaligned load or store instruction.