### PR TITLE
Fix issue 16685 - Allow the use of CT struct values as template params.

### DIFF
--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -8513,6 +8513,10 @@ bool definitelyValueParameter(Expression e)
     if (!v)
         return true;
 
+    // var.x.y where var is a constant available at compile time
+    if (v.storage_class & STCmanifest)
+        return true;
+
     // TODO: Should we force CTFE if it is a global constant?
     return false;
 }

--- a/test/compilable/template16685.d
+++ b/test/compilable/template16685.d
@@ -1,0 +1,4 @@
+struct Id { ushort value; }
+enum Id x = Id(5);
+struct S(ushort A) {}
+alias CannotCreateFromValue = S!(x.value);


### PR DESCRIPTION
The code right now treats `S!(x.value)` as `S!(value)`, making the template instantiation fail.
Not 100% sure about the fix though.