### PR TITLE
fix Issue 16703 - Support indexing of SIMD vector types

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -11501,6 +11501,14 @@ extern (C++) final class SliceExp : UnaExp
                 return new ErrorExp();
             }
         }
+        else if (t1b.ty == Tvector)
+        {
+            // Convert e1 to corresponding static array
+            TypeVector tv1 = cast(TypeVector)t1b;
+            t1b = tv1.basetype;
+            t1b = t1b.castMod(tv1.mod);
+            e1.type = t1b;
+        }
         else
         {
             error("%s cannot be sliced with []", t1b.ty == Tvoid ? e1.toChars() : t1b.toChars());
@@ -12202,6 +12210,15 @@ extern (C++) final class IndexExp : BinExp
         // Note that unlike C we do not implement the int[ptr]
 
         Type t1b = e1.type.toBasetype();
+
+        if (t1b.ty == Tvector)
+        {
+            // Convert e1 to corresponding static array
+            TypeVector tv1 = cast(TypeVector)t1b;
+            t1b = tv1.basetype;
+            t1b = t1b.castMod(tv1.mod);
+            e1.type = t1b;
+        }
 
         /* Run semantic on e2
          */

--- a/src/opover.d
+++ b/src/opover.d
@@ -639,7 +639,8 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 {
                     // If the non-aggregate expression ae->e1 is indexable or sliceable,
                     // convert it to the corresponding concrete expression.
-                    if (t1b.ty == Tpointer || t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Taarray || t1b.ty == Ttuple || ae.e1.op == TOKtype)
+                    if (t1b.ty == Tpointer || t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Taarray ||
+                        t1b.ty == Ttuple || t1b.ty == Tvector || ae.e1.op == TOKtype)
                     {
                         // Convert to SliceExp
                         if (maybeSlice)

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1585,6 +1585,41 @@ void test16448()
 }
 
 /*****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=16703
+
+float index(float4 f4, size_t i)
+{
+    return f4[i];
+    //return (*cast(float[4]*)&f4)[2];
+}
+
+float[4] slice(float4 f4)
+{
+    return f4[];
+}
+
+float slice2(float4 f4, size_t lwr, size_t upr, size_t i)
+{
+    float[] fa = f4[lwr .. upr];
+    return fa[i];
+}
+
+void test16703()
+{
+    float4 f4 = [1,2,3,4];
+    assert(index(f4, 0) == 1);
+    assert(index(f4, 1) == 2);
+    assert(index(f4, 2) == 3);
+    assert(index(f4, 3) == 4);
+
+    float[4] fsa = slice(f4);
+    assert(fsa == [1.0f,2,3,4]);
+
+    assert(slice2(f4, 1, 3, 0) == 2);
+    assert(slice2(f4, 1, 3, 1) == 3);
+}
+
+/*****************************************/
 
 int main()
 {
@@ -1619,6 +1654,7 @@ int main()
     test13988();
     testprefetch();
     test16448();
+    test16703();
 
     return 0;
 }


### PR DESCRIPTION
The implementation just looks for indexing of a Tvector and converts it to a Tsarray.