### PR TITLE
fix Issue 16679 - prefetch on old pentium d results in an illegal ins…

### DIFF
--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1460,14 +1460,22 @@ ubyte16 test11585(ubyte16* d)
 
 int fooprefetch(byte a)
 {
-    prefetch!(false, 0)(&a);
-    prefetch!(false, 1)(&a);
-    prefetch!(false, 2)(&a);
-    prefetch!(false, 3)(&a);
-    prefetch!(true, 0)(&a);
-    prefetch!(true, 1)(&a);
-    prefetch!(true, 2)(&a);
-    prefetch!(true, 3)(&a);
+    /* These should be run only if the CPUID PRFCHW
+     * bit 0 of cpuid.{EAX = 7, ECX = 0}.ECX
+     * Unfortunately, that bit isn't yet set by core.cpuid
+     * so disable for the moment.
+     */
+    version (none)
+    {
+        prefetch!(false, 0)(&a);
+        prefetch!(false, 1)(&a);
+        prefetch!(false, 2)(&a);
+        prefetch!(false, 3)(&a);
+        prefetch!(true, 0)(&a);
+        prefetch!(true, 1)(&a);
+        prefetch!(true, 2)(&a);
+        prefetch!(true, 3)(&a);
+    }
     return 3;
 }
 


### PR DESCRIPTION
…truction

This should get the autotester working again, until core.cpuid can be upgraded to fix https://issues.dlang.org/show_bug.cgi?id=16704