### PR TITLE
fix Issue 16381 - Wrapping a float4 array leads to segfault

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -4390,6 +4390,16 @@ extern (C++) final class TypeVector : Type
         {
             printf("TypeVector::dotExp(e = '%s', ident = '%s')\n", e.toChars(), ident.toChars());
         }
+        if (ident == Id.ptr && e.op == TOKcall)
+        {
+            /* The trouble with TOKcall is the return ABI for float[4] is different from
+             * __vector(float[4]), and a type paint won't do.
+             */
+            e = new AddrExp(e.loc, e);
+            e = e.semantic(sc);
+            e = e.castTo(sc, basetype.nextOf().pointerTo());
+            return e;
+        }
         if (ident == Id.array)
         {
             //e = e->castTo(sc, basetype);

--- a/test/fail_compilation/test16381.d
+++ b/test/fail_compilation/test16381.d
@@ -1,0 +1,18 @@
+/*
+REQUIRED_ARGS: -m64
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/test16381.d(16): Error: foo() is not an lvalue
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=16381
+
+__vector(float[4]) foo();
+
+void bar()
+{
+    float g = foo().ptr[0];
+}
+


### PR DESCRIPTION
Now it leads to a compile time error for taking the address of a return value.