### PR TITLE
fix Issue 16116 - Infinite loop on (somewhat complex) simd math

### DIFF
--- a/src/dcast.d
+++ b/src/dcast.d
@@ -3202,6 +3202,8 @@ Lagain:
     {
         if (t1.ty != t2.ty)
         {
+            if (t1.ty == Tvector || t2.ty == Tvector)
+                goto Lincompatible;
             e1 = integralPromotions(e1, sc);
             e2 = integralPromotions(e2, sc);
             t1 = e1.type;

--- a/test/fail_compilation/test16116.d
+++ b/test/fail_compilation/test16116.d
@@ -1,0 +1,16 @@
+/*
+REQUIRED_ARGS: -m64
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/test16116.d(15): Error: incompatible types for ((v) * (i)): '__vector(short[8])' and 'int'
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=16116
+
+void foo() {
+    __vector(short[8]) v;
+    int i;
+    v = v * i;
+}


### PR DESCRIPTION
This bug causes dmd, ldc, and presumably gdc, to hang, so it's fairly important to fix it.