### PR TITLE
fix Issue 16747 - Cannot have stack allocated classes in @safe code

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -2220,7 +2220,7 @@ extern (C++) class VarDeclaration : Declaration
                     // delete this;
                     Expression ec;
                     ec = new VarExp(loc, this);
-                    e = new DeleteExp(loc, ec);
+                    e = new DeleteExp(loc, ec, true);
                     e.type = Type.tvoid;
                     break;
                 }

--- a/src/expression.d
+++ b/src/expression.d
@@ -10979,9 +10979,12 @@ extern (C++) final class NotExp : UnaExp
  */
 extern (C++) final class DeleteExp : UnaExp
 {
-    extern (D) this(Loc loc, Expression e)
+    bool isRAII;        // true if called automatically as a result of scoped destruction
+
+    extern (D) this(Loc loc, Expression e, bool isRAII)
     {
         super(loc, TOKdelete, __traits(classInstanceSize, DeleteExp), e);
+        this.isRAII = isRAII;
     }
 
     override Expression semantic(Scope* sc)
@@ -11008,7 +11011,6 @@ extern (C++) final class DeleteExp : UnaExp
                     error("cannot delete instance of COM interface %s", cd.toChars());
                     return new ErrorExp();
                 }
-
                 ad = cd;
                 break;
             }
@@ -11097,8 +11099,9 @@ extern (C++) final class DeleteExp : UnaExp
                 return new ErrorExp();
         }
 
-        // unsafe
-        if (!sc.intypeof && sc.func && sc.func.setUnsafe())
+        if (!sc.intypeof && sc.func &&
+            !isRAII &&
+            sc.func.setUnsafe())
         {
             error("%s is not @safe but is used in @safe function %s", toChars(), sc.func.toChars());
             err = true;

--- a/src/expression.h
+++ b/src/expression.h
@@ -906,6 +906,7 @@ public:
 
 class DeleteExp : public UnaExp
 {
+    bool isRAII;
 public:
     Expression *semantic(Scope *sc);
     Expression *toBoolean(Scope *sc);

--- a/src/parse.d
+++ b/src/parse.d
@@ -7616,7 +7616,7 @@ final class Parser : Lexer
         case TOKdelete:
             nextToken();
             e = parseUnaryExp();
-            e = new DeleteExp(loc, e);
+            e = new DeleteExp(loc, e, false);
             break;
 
         case TOKcast: // cast(type) expression

--- a/test/compilable/test16747.d
+++ b/test/compilable/test16747.d
@@ -1,0 +1,13 @@
+/*
+PERMUTE_ARGS:
+*/
+
+class C { @safe ~this() { } }
+class D : C { }
+
+void fwd() @safe
+{
+    scope o = new Object();
+    scope c = new C();
+    scope d = new D();
+}

--- a/test/runnable/testscope.d
+++ b/test/runnable/testscope.d
@@ -260,6 +260,15 @@ void test7049() @safe
 
 /********************************************/
 
+// https://issues.dlang.org/show_bug.cgi?id=16747
+
+void test16747() @safe
+{
+    scope o = new Object();
+}
+
+/********************************************/
+
 void main()
 {
     test1();
@@ -274,6 +283,7 @@ void main()
     test10();
     test7435();
     test7049();
+    test16747();
 
     printf("Success\n");
 }


### PR DESCRIPTION
Stack allocated classes with no destructors do not need to call `delete`.