### PR TITLE
fix Issue 16798 - add -mv=path.module=filespec switch so path hiera…

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -120,6 +120,7 @@ struct Param
     BOUNDSCHECK useArrayBounds;
 
     const(char)* argv0;                 // program name
+    Array!(const(char)*)* modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array!(const(char)*)* imppath;      // array of char*'s of where to look for import modules
     Array!(const(char)*)* fileImppath;  // array of char*'s of where to look for file import modules
     const(char)* objdir;                // .obj/.lib file output directory

--- a/src/globals.h
+++ b/src/globals.h
@@ -102,6 +102,7 @@ struct Param
     BOUNDSCHECK useArrayBounds;
 
     const char *argv0;    // program name
+    Array<const char *> *modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array<const char *> *imppath;     // array of char*'s of where to look for import modules
     Array<const char *> *fileImppath; // array of char*'s of where to look for file import modules
     const char *objdir;   // .obj/.lib file output directory

--- a/src/mars.d
+++ b/src/mars.d
@@ -149,6 +149,7 @@ Where:
   -map             generate linker .map file
   -mavx            use AVX instruction set" ~
   "%s" /* placeholder for mscrtlib */ ~ "
+  -mv=<package.module>=<filespec>  use <filespec> as source file for <package.module>
   -noboundscheck   no array bounds checking (deprecated, use -boundscheck=off)
   -O               optimize
   -o-              do not write object file
@@ -793,6 +794,17 @@ Language changes listed by -transition=id:
                 if (!global.params.imppath)
                     global.params.imppath = new Strings();
                 global.params.imppath.push(p + 2 + (p[2] == '='));
+            }
+            else if (p[1] == 'm' && p[2] == 'v' && p[3] == '=')
+            {
+                if (p[4] && strchr(p + 5, '='))
+                {
+                    if (!global.params.modFileAliasStrings)
+                        global.params.modFileAliasStrings = new Strings();
+                    global.params.modFileAliasStrings.push(p + 4);
+                }
+                else
+                    goto Lerror;
             }
             else if (p[1] == 'J')
             {

--- a/test/compilable/imports/imp16798.d
+++ b/test/compilable/imports/imp16798.d
@@ -1,0 +1,4 @@
+
+module its.a.dessert.topping;
+
+pragma(msg, "it's a dessert topping");

--- a/test/compilable/imports/wax16798.d
+++ b/test/compilable/imports/wax16798.d
@@ -1,0 +1,4 @@
+module its.a.floorwax.wax16798;
+
+pragma(msg, "it's a floor wax");
+

--- a/test/compilable/test16798.d
+++ b/test/compilable/test16798.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -mv=its.a.dessert.topping=imports/imp16798.d -mv=its.a.floorwax=imports/
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+it's a floor wax
+it's a dessert topping
+---
+*/
+
+import its.a.floorwax.wax16798;
+import its.a.dessert.topping;
+


### PR DESCRIPTION
…rchy doesn't have to match package hierarchy

This is a particularly irritating problem. This fix should make it easy to have package/module hierarchies that don't exactly line up with the import declarations. The `ddmd` package prefix is a prime example.

I'll do the manual page revision once this is pulled.