### PR TITLE
fix calculation of CFvex3 flag

### DIFF
--- a/src/backend/cgxmm.c
+++ b/src/backend/cgxmm.c
@@ -1328,4 +1328,21 @@ bool xmmIsAligned(elem *e)
     return true;        // assume aligned
 }
 
+/**************************************
+ * VEX prefixes can be 2 or 3 bytes.
+ * If it must be 3 bytes, set the CFvex3 flag.
+ */
+
+void checkSetVex3(code *c)
+{
+    // See Intel Vol. 2A 2.3.5.6
+    if (c->Ivex.w || !c->Ivex.x || !c->Ivex.b || c->Ivex.mmmm > 0x1 ||
+        !I64 && (c->Ivex.r || !(c->Ivex.vvvv & 8))
+       )
+    {
+        c->Iflags |= CFvex3;
+    }
+}
+
+
 #endif // !SPP

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -473,6 +473,7 @@ code *cdvector(elem *e, regm_t *pretregs);
 code *cdvecsto(elem *e, regm_t *pretregs);
 code *cdvecfill(elem *e, regm_t *pretregs);
 bool xmmIsAligned(elem *e);
+void checkSetVex3(code *c);
 
 /* cg87.c */
 void note87(elem *e, unsigned offset, int i);

--- a/src/iasm.c
+++ b/src/iasm.c
@@ -1530,7 +1530,8 @@ static code *asm_emit(Loc loc,
 
         /* Check if a 3-byte vex is needed.
          */
-        if (pc->Ivex.w || !pc->Ivex.x || !pc->Ivex.b || pc->Ivex.mmmm > 0x1)
+        checkSetVex3(pc);
+        if (pc->Iflags & CFvex3)
         {
 #ifdef DEBUG
             memmove(&auchOpcode[oIdx+3], &auchOpcode[oIdx], usIdx-oIdx);


### PR DESCRIPTION
The CFvex3 flag has a special case for non-64 bit code generation.

Making it a separate function encapsulates it and makes it available for future AVX code generation.