### PR TITLE
add -mavx switch to enable AVX instruction generation

### DIFF
--- a/src/backend/backconfig.c
+++ b/src/backend/backconfig.c
@@ -49,7 +49,8 @@ void out_config_init(
                         // 1: D
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
-        bool stackstomp         // add stack stomping code
+        bool stackstomp,        // add stack stomping code
+        bool avx                // use AVX instruction set
         )
 {
 #if MARS
@@ -71,6 +72,7 @@ void out_config_init(
     if (model == 64)
     {   config.exe = EX_WIN64;
         config.fpxmmregs = TRUE;
+        config.avx = avx;
         config.ehmethod = EH_DM;
 
         // Not sure we really need these two lines, try removing them later
@@ -95,6 +97,7 @@ void out_config_init(
     {   config.exe = EX_LINUX64;
         config.ehmethod = EH_DWARF;
         config.fpxmmregs = TRUE;
+        config.avx = avx;
     }
     else
     {
@@ -113,6 +116,7 @@ void out_config_init(
 #endif
 #if TARGET_OSX
     config.fpxmmregs = TRUE;
+    config.avx = avx;
     if (model == 64)
     {   config.exe = EX_OSX64;
         config.fpxmmregs = TRUE;
@@ -137,6 +141,7 @@ void out_config_init(
     {   config.exe = EX_FREEBSD64;
         config.ehmethod = EH_DWARF;
         config.fpxmmregs = TRUE;
+        config.avx = avx;
     }
     else
     {
@@ -157,6 +162,7 @@ void out_config_init(
     if (model == 64)
     {   config.exe = EX_OPENBSD64;
         config.fpxmmregs = TRUE;
+        config.avx = avx;
     }
     else
     {
@@ -175,6 +181,7 @@ void out_config_init(
     if (model == 64)
     {   config.exe = EX_SOLARIS64;
         config.fpxmmregs = TRUE;
+        config.avx = avx;
     }
     else
     {

--- a/src/backend/cdef.d
+++ b/src/backend/cdef.d
@@ -665,6 +665,7 @@ struct Config
     windows_flags_t wflags;     // flags for Windows code generation
 
     bool fpxmmregs;             // use XMM registers for floating point
+    bool avx;                   // use AVX instruction set
     ubyte inline8087;           /* 0:   emulator
                                    1:   IEEE 754 inline 8087 code
                                    2:   fast inline 8087 code

--- a/src/backend/cdef.h
+++ b/src/backend/cdef.h
@@ -905,6 +905,7 @@ struct Config
     windows_flags_t wflags;     // flags for Windows code generation
 
     bool fpxmmregs;             // use XMM registers for floating point
+    bool avx;                   // use AVX instruction set
     char inline8087;            /* 0:   emulator
                                    1:   IEEE 754 inline 8087 code
                                    2:   fast inline 8087 code

--- a/src/dmsc.d
+++ b/src/dmsc.d
@@ -54,7 +54,8 @@ void out_config_init(
                         // 1: D
                         // 2: fake it with C symbolic debug info
         bool alwaysframe,       // always create standard function frame
-        bool stackstomp         // add stack stomping code
+        bool stackstomp,        // add stack stomping code
+        bool avx                // use AVX instruction set
         );
 
 void out_config_debug(
@@ -111,7 +112,8 @@ void backend_init()
         params.optimize,
         params.symdebug,
         params.alwaysframe,
-        params.stackstomp
+        params.stackstomp,
+        params.avx
     );
 
     debug

--- a/src/globals.d
+++ b/src/globals.d
@@ -114,6 +114,7 @@ struct Param
     bool bug10378;          // use pre-bugzilla 10378 search strategy
     bool vsafe;             // shows places with hidden change in semantics needed
                             // for better @safe guarantees
+    bool avx;               // use AVX instruction set
     bool showGaggedErrors;  // print gagged errors anyway
 
     BOUNDSCHECK useArrayBounds;

--- a/src/globals.h
+++ b/src/globals.h
@@ -96,6 +96,7 @@ struct Param
     bool check10378;    // check for issues transitioning to 10738
     bool bug10378;      // use pre-bugzilla 10378 search strategy
     bool safe;          // use enhanced @safe checking
+    bool avx;               // use AVX instruction set
     bool showGaggedErrors;  // print gagged errors anyway
 
     BOUNDSCHECK useArrayBounds;

--- a/src/mars.d
+++ b/src/mars.d
@@ -146,7 +146,8 @@ Where:
   -m64             generate 64 bit code
   -main            add default main() (e.g. for unittesting)
   -man             open web browser on manual page
-  -map             generate linker .map file" ~
+  -map             generate linker .map file
+  -mavx            use AVX instruction set" ~
   "%s" /* placeholder for mscrtlib */ ~ "
   -noboundscheck   no array bounds checking (deprecated, use -boundscheck=off)
   -O               optimize
@@ -478,6 +479,10 @@ private int tryMain(size_t argc, const(char)** argv)
                 {
                     global.params.mscoff = true;
                 }
+            }
+            else if (strcmp(p + 1, "mavx") == 0)
+            {
+                global.params.avx = true;
             }
             else if (strcmp(p + 1, "m32mscoff") == 0)
             {


### PR DESCRIPTION
`-mavx` switch will tell the code generator to use VEX instructions instead of the regular SIMD instructions, even for 16 byte vector instructions. Intel says these instructions are smaller and faster. Soon to come - actual VEX instruction generation!

In support of https://issues.dlang.org/show_bug.cgi?id=16914