### PR TITLE
Fix Issue 768 - A switch to print predefined version identifiers

### DIFF
--- a/src/mars.d
+++ b/src/mars.d
@@ -1942,4 +1942,17 @@ private void addDefaultVersionIdentifiers()
     if (global.params.useArrayBounds == BOUNDSCHECKoff)
         VersionCondition.addPredefinedGlobalIdent("D_NoBoundsChecks");
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
+
+    printPredefinedVersions();
+}
+
+private void printPredefinedVersions()
+{
+    if (global.params.verbose && global.params.versionids) {
+        fprintf(global.stdmsg, "predefs   ");
+        for (int i = 0; i < global.params.versionids.dim; i++) {
+            fprintf(global.stdmsg, "%s ", global.params.versionids.data[i]);
+        }
+        fprintf(global.stdmsg, "\n");
+    }
 }

--- a/src/mars.d
+++ b/src/mars.d
@@ -1948,11 +1948,11 @@ private void addDefaultVersionIdentifiers()
 
 private void printPredefinedVersions()
 {
-    if (global.params.verbose && global.params.versionids) {
-        fprintf(global.stdmsg, "predefs   ");
-        for (int i = 0; i < global.params.versionids.dim; i++) {
-            fprintf(global.stdmsg, "%s ", global.params.versionids.data[i]);
-        }
+    if (global.params.verbose && global.params.versionids)
+    {
+        fprintf(global.stdmsg, "predefs  ");
+        foreach (const s; *global.params.versionids)
+            fprintf(global.stdmsg, " %s", s);
         fprintf(global.stdmsg, "\n");
     }
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=768

Currently these identifiers are printed only if we compile with the "-v" flag.