### PR TITLE
flesh out use of AVX instructions

### DIFF
--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -2930,8 +2930,9 @@ code *cdind(elem *e,regm_t *pretregs)
         {
             assert(sz == 4 || sz == 8 || sz == 16); // float, double or vector
             cs.Iop = xmmload(tym);
-            reg -= XMM0;
-            goto L2;
+            code_newreg(&cs,reg - XMM0);
+            ce = gen(CNIL,&cs);     // MOV reg,[idx]
+            checkSetVex(ce,tym);
         }
         else if (sz <= REGSIZE)
         {

--- a/src/backend/cod3.c
+++ b/src/backend/cod3.c
@@ -5757,7 +5757,7 @@ unsigned calccodsize(code *c)
 #endif
     iflags = c->Iflags;
     op = c->Iop;
-    if (iflags & CFvex)
+    if (iflags & CFvex && op != NOP)
     {
         ins = vex_inssize(c);
         size = ins & 7;

--- a/src/backend/code.h
+++ b/src/backend/code.h
@@ -488,6 +488,7 @@ code *save87 (void );
 code *save87regs(unsigned n);
 void gensaverestore87(regm_t, code **, code **);
 code *genfltreg(code *c,unsigned opcode,unsigned reg,targ_size_t offset);
+code *genxmmreg(code *c,unsigned opcode,unsigned xreg,targ_size_t offset, tym_t tym);
 code *genfwait(code *c);
 code *comsub87(elem *e, regm_t *pretregs);
 code *fixresult87 (elem *e , regm_t retregs , regm_t *pretregs );


### PR DESCRIPTION
Using -mavx is all or nothing, as doing it partially will result in slower code, because it's faster to keep it all in the AVX unit.