### PR TITLE
fix Issue 16958 - replace -mavx switch with -mcpu=id

### DIFF
--- a/src/dmsc.d
+++ b/src/dmsc.d
@@ -113,7 +113,7 @@ void backend_init()
         params.symdebug,
         params.alwaysframe,
         params.stackstomp,
-        params.avx
+        params.cpu == CPU.avx
     );
 
     debug

--- a/src/globals.d
+++ b/src/globals.d
@@ -50,6 +50,15 @@ alias BOUNDSCHECKoff = BOUNDSCHECK.BOUNDSCHECKoff;
 alias BOUNDSCHECKon = BOUNDSCHECK.BOUNDSCHECKon;
 alias BOUNDSCHECKsafeonly = BOUNDSCHECK.BOUNDSCHECKsafeonly;
 
+enum CPU
+{
+    baseline,           // (default) the minimum capability CPU
+    avx,                // AVX1 instruction set
+    avx2,               // AVX2 instruction set
+    avx512,             // AVX-512 instruction set
+    native              // the machine the compiler is being run on
+}
+
 // Put command line switches in here
 struct Param
 {
@@ -114,9 +123,9 @@ struct Param
     bool bug10378;          // use pre-bugzilla 10378 search strategy
     bool vsafe;             // shows places with hidden change in semantics needed
                             // for better @safe guarantees
-    bool avx;               // use AVX instruction set
     bool showGaggedErrors;  // print gagged errors anyway
 
+    CPU cpu;                // CPU instruction set to target
     BOUNDSCHECK useArrayBounds;
 
     const(char)* argv0;                 // program name

--- a/src/globals.h
+++ b/src/globals.h
@@ -32,6 +32,15 @@ enum BOUNDSCHECK
     BOUNDSCHECKsafeonly // do bounds checking only in @safe functions
 };
 
+enum CPU
+{
+    baseline,           // (default) the minimum capability CPU
+    avx,                // AVX1 instruction set
+    avx2,               // AVX2 instruction set
+    avx512,             // AVX-512 instruction set
+    native              // the machine the compiler is being run on
+};
+
 
 // Put command line switches in here
 struct Param
@@ -96,9 +105,9 @@ struct Param
     bool check10378;    // check for issues transitioning to 10738
     bool bug10378;      // use pre-bugzilla 10378 search strategy
     bool safe;          // use enhanced @safe checking
-    bool avx;               // use AVX instruction set
     bool showGaggedErrors;  // print gagged errors anyway
 
+    CPU cpu;                // CPU instruction set to target
     BOUNDSCHECK useArrayBounds;
 
     const char *argv0;    // program name

--- a/src/mars.d
+++ b/src/mars.d
@@ -147,7 +147,8 @@ Where:
   -main            add default main() (e.g. for unittesting)
   -man             open web browser on manual page
   -map             generate linker .map file
-  -mavx            use AVX instruction set" ~
+  -cpu=<id>        generate instructions for architecture identified by 'id'
+  -cpu=?           list all architecture options " ~
   "%s" /* placeholder for mscrtlib */ ~ "
   -noboundscheck   no array bounds checking (deprecated, use -boundscheck=off)
   -O               optimize
@@ -304,6 +305,7 @@ private int tryMain(size_t argc, const(char)** argv)
     // Default to -m32 for 32 bit dmd, -m64 for 64 bit dmd
     global.params.is64bit = (size_t.sizeof == 8);
     global.params.mscoff = false;
+    global.params.cpu = CPU.baseline;
 
     // Temporary: Use 32 bits as the default on Windows, for config parsing
     static if (TARGET_WINDOS)
@@ -480,10 +482,6 @@ private int tryMain(size_t argc, const(char)** argv)
                     global.params.mscoff = true;
                 }
             }
-            else if (strcmp(p + 1, "mavx") == 0)
-            {
-                global.params.avx = true;
-            }
             else if (strcmp(p + 1, "m32mscoff") == 0)
             {
                 static if (TARGET_WINDOS)
@@ -546,6 +544,47 @@ private int tryMain(size_t argc, const(char)** argv)
                 else if (memcmp(p + 9, cast(char*)"spec", 4) == 0)
                 {
                     global.params.showGaggedErrors = true;
+                }
+                else
+                    goto Lerror;
+            }
+            else if (memcmp(p + 1, "mcpu".ptr, 4) == 0)
+            {
+                // Parse:
+                //      -mcpu=identifier
+                if (p[5] == '=')
+                {
+                    if (strcmp(p + 6, "?") == 0)
+                    {
+                        printf("
+CPU architectures supported by -mcpu=id:
+  =?             list information on all architecture choices
+  =baseline      use default architecture as determined by target
+  =avx           use AVX 1 instructions
+  =native        use CPU architecture that this compiler is running on
+");
+                        exit(EXIT_SUCCESS);
+                    }
+                    else if (Identifier.isValidIdentifier(p + 6))
+                    {
+                        const ident = p + 6;
+                        switch (ident[0 .. strlen(ident)])
+                        {
+                        case "baseline":
+                            global.params.cpu = CPU.baseline;
+                            break;
+                        case "avx":
+                            global.params.cpu = CPU.avx;
+                            break;
+                        case "native":
+                            global.params.cpu = CPU.native;
+                            break;
+                        default:
+                            goto Lerror;
+                        }
+                    }
+                    else
+                        goto Lerror;
                 }
                 else
                     goto Lerror;
@@ -987,6 +1026,12 @@ Language changes listed by -transition=id:
             }
             files.push(p);
         }
+    }
+    if (global.params.cpu == CPU.native)
+    {
+        import core.cpuid;
+        if (core.cpuid.avx)
+            global.params.cpu = CPU.avx;
     }
     if (global.params.is64bit != is64bit)
         error(Loc(), "the architecture must not be changed in the %s section of %s", envsection.ptr, global.inifilename);

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1,3 +1,6 @@
+/*
+REQUIRED_ARGS: -mcpu=native
+*/
 
 import core.stdc.stdio;
 


### PR DESCRIPTION
The -mcpu=native will allow the autotester to randomly check the AVX code generation, since only some of the machines are AVX capable, and are randomly assigned.