### PR TITLE
Add 32 byte vectors to operator tables (First AVX2 code gen!)

### DIFF
--- a/src/backend/cgxmm.c
+++ b/src/backend/cgxmm.c
@@ -677,7 +677,9 @@ unsigned xmmload(tym_t tym, bool aligned)
         case TYcdouble:
         case TYidouble: op = LODSD; break;       // MOVSD
 
+        case TYfloat8:
         case TYfloat4:  op = aligned ? LODAPS : LODUPS; break;      // MOVAPS / MOVUPS
+        case TYdouble4:
         case TYdouble2: op = aligned ? LODAPD : LODUPD; break;      // MOVAPD / MOVUPD
         case TYschar16:
         case TYuchar16:
@@ -686,7 +688,15 @@ unsigned xmmload(tym_t tym, bool aligned)
         case TYlong4:
         case TYulong4:
         case TYllong2:
-        case TYullong2: op = aligned ? LODDQA : LODDQU; break;      // MOVDQA / MOVDQU
+        case TYullong2:
+        case TYschar32:
+        case TYuchar32:
+        case TYshort16:
+        case TYushort16:
+        case TYlong8:
+        case TYulong8:
+        case TYllong4:
+        case TYullong4: op = aligned ? LODDQA : LODDQU; break;      // MOVDQA / MOVDQU
 
         default:
             printf("tym = x%x\n", tym);
@@ -716,7 +726,9 @@ unsigned xmmstore(tym_t tym, bool aligned)
         case TYcdouble:
         case TYcfloat:  op = STOSD; break;       // MOVSD
 
+        case TYfloat8:
         case TYfloat4:  op = aligned ? STOAPS : STOUPS; break;      // MOVAPS / MOVUPS
+        case TYdouble4:
         case TYdouble2: op = aligned ? STOAPD : STOUPD; break;      // MOVAPD / MOVUPD
         case TYschar16:
         case TYuchar16:
@@ -725,7 +737,15 @@ unsigned xmmstore(tym_t tym, bool aligned)
         case TYlong4:
         case TYulong4:
         case TYllong2:
-        case TYullong2: op = aligned ? STODQA : STODQU; break;      // MOVDQA / MOVDQU
+        case TYullong2:
+        case TYschar32:
+        case TYuchar32:
+        case TYshort16:
+        case TYushort16:
+        case TYlong8:
+        case TYulong8:
+        case TYllong4:
+        case TYullong4: op = aligned ? STODQA : STODQU; break;      // MOVDQA / MOVDQU
 
         default:
             printf("tym = x%x\n", tym);
@@ -756,14 +776,24 @@ static unsigned xmmoperator(tym_t tym, unsigned oper)
                 case TYidouble: op = ADDSD;  break;
 
                 // SIMD vector types
+                case TYfloat8:
                 case TYfloat4:  op = ADDPS;  break;
+                case TYdouble4:
                 case TYdouble2: op = ADDPD;  break;
+                case TYschar32:
+                case TYuchar32:
                 case TYschar16:
                 case TYuchar16: op = PADDB;  break;
+                case TYshort16:
+                case TYushort16:
                 case TYshort8:
                 case TYushort8: op = PADDW;  break;
+                case TYlong8:
+                case TYulong8:
                 case TYlong4:
                 case TYulong4:  op = PADDD;  break;
+                case TYllong4:
+                case TYullong4:
                 case TYllong2:
                 case TYullong2: op = PADDQ;  break;
 
@@ -784,14 +814,24 @@ static unsigned xmmoperator(tym_t tym, unsigned oper)
                 case TYidouble: op = SUBSD;  break;
 
                 // SIMD vector types
+                case TYfloat8:
                 case TYfloat4:  op = SUBPS;  break;
+                case TYdouble4:
                 case TYdouble2: op = SUBPD;  break;
+                case TYschar32:
+                case TYuchar32:
                 case TYschar16:
                 case TYuchar16: op = PSUBB;  break;
+                case TYshort16:
+                case TYushort16:
                 case TYshort8:
                 case TYushort8: op = PSUBW;  break;
+                case TYlong8:
+                case TYulong8:
                 case TYlong4:
                 case TYulong4:  op = PSUBD;  break;
+                case TYllong4:
+                case TYullong4:
                 case TYllong2:
                 case TYullong2: op = PSUBQ;  break;
 
@@ -809,8 +849,12 @@ static unsigned xmmoperator(tym_t tym, unsigned oper)
                 case TYidouble: op = MULSD;  break;
 
                 // SIMD vector types
+                case TYfloat8:
                 case TYfloat4:  op = MULPS;  break;
+                case TYdouble4:
                 case TYdouble2: op = MULPD;  break;
+                case TYshort16:
+                case TYushort16:
                 case TYshort8:
                 case TYushort8: op = PMULLW; break;
 
@@ -828,7 +872,9 @@ static unsigned xmmoperator(tym_t tym, unsigned oper)
                 case TYidouble: op = DIVSD;  break;
 
                 // SIMD vector types
+                case TYfloat8:
                 case TYfloat4:  op = DIVPS;  break;
+                case TYdouble4:
                 case TYdouble2: op = DIVPD;  break;
 
                 default:        assert(0);
@@ -847,7 +893,15 @@ static unsigned xmmoperator(tym_t tym, unsigned oper)
                 case TYlong4:
                 case TYulong4:
                 case TYllong2:
-                case TYullong2: op = POR; break;
+                case TYullong2:
+                case TYschar32:
+                case TYuchar32:
+                case TYshort16:
+                case TYushort16:
+                case TYlong8:
+                case TYulong8:
+                case TYllong4:
+                case TYullong4: op = POR; break;
 
                 default:        assert(0);
             }
@@ -865,7 +919,15 @@ static unsigned xmmoperator(tym_t tym, unsigned oper)
                 case TYlong4:
                 case TYulong4:
                 case TYllong2:
-                case TYullong2: op = PAND; break;
+                case TYullong2:
+                case TYschar32:
+                case TYuchar32:
+                case TYshort16:
+                case TYushort16:
+                case TYlong8:
+                case TYulong8:
+                case TYllong4:
+                case TYullong4: op = PAND; break;
 
                 default:        assert(0);
             }
@@ -883,7 +945,15 @@ static unsigned xmmoperator(tym_t tym, unsigned oper)
                 case TYlong4:
                 case TYulong4:
                 case TYllong2:
-                case TYullong2: op = PXOR; break;
+                case TYullong2:
+                case TYschar32:
+                case TYuchar32:
+                case TYshort16:
+                case TYushort16:
+                case TYlong8:
+                case TYulong8:
+                case TYllong4:
+                case TYullong4: op = PXOR; break;
 
                 default:        assert(0);
             }

--- a/src/backend/cod2.c
+++ b/src/backend/cod2.c
@@ -2928,7 +2928,7 @@ code *cdind(elem *e,regm_t *pretregs)
         }
         if (retregs & XMMREGS)
         {
-            assert(sz == 4 || sz == 8 || sz == 16); // float, double or vector
+            assert(sz == 4 || sz == 8 || sz == 16 || sz == 32); // float, double or vector
             cs.Iop = xmmload(tym);
             code_newreg(&cs,reg - XMM0);
             ce = gen(CNIL,&cs);     // MOV reg,[idx]

--- a/src/backend/el.c
+++ b/src/backend/el.c
@@ -2030,7 +2030,7 @@ printf("\n");
 
 elem *el_convxmm(elem *e)
 {
-    unsigned char buffer[16];
+    unsigned char buffer[sizeof(eve)];
 
 #if TX86
     // Do not convert if the constants can be loaded with the special XMM instructions
@@ -2043,7 +2043,7 @@ elem *el_convxmm(elem *e)
     tym_t ty = e->Ety;
     int sz = tysize(ty);
     assert(sz <= sizeof(buffer));
-    void *p = &e->EV.Vcent;
+    void *p = &e->EV;
 
 #if 0
 printf("el_convxmm(): sz = %d\n", sz);


### PR DESCRIPTION
This enables simple 256 bit vector programs to compile, and the disassembled code looks right. It's a little hard to test, however, lacking an AVX2 computer.