### PR TITLE
Travis CI: Send alive to avoid stalled builds on macOS

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -61,7 +61,7 @@ test_dmd() {
     if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_OS_NAME" == "linux"  ]; then
         make -j$N -C test MODEL=$MODEL # all ARGS by default
     else
-        make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release"
+        travis_wait 30 make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release"
     fi
 }
 


### PR DESCRIPTION
Sometimes the Travis builds on macOS get stalled on and thus terminated because they didn't produce any output within ten minutes. While of course the real root for this should be fixed, this introduces a small hack to workaround the Travis stalling out limitation by outputting an alive signal every 9 minutes.
If DMD entered an endless loop, it will get killed anyways after exceeding the default running time on Travis (currently 60 minutes).

Examples of stalled builds:

https://travis-ci.org/dlang/dmd/jobs/177746219, https://travis-ci.org/dlang/dmd/jobs/172795215, https://travis-ci.org/dlang/dmd/jobs/172795215, https://travis-ci.org/dlang/dmd/jobs/169917309

CC @MartinNowak 