### PR TITLE
Stupidly simple DUB project tester

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ test:
   override:
     - ./circleci.sh coverage:
         parallel: true
+    - ./circleci.sh test-repos
 
   post:
     # CodeCov gets confused by lst files which it can't matched

--- a/circleci.sh
+++ b/circleci.sh
@@ -113,7 +113,6 @@ test_repo()
         DUBFLAGS="--arch x86_64"
     fi
 
-    export DFLAGS="-conf= -I${DIR}/../druntime/import -w -dip25 -defaultlib=${DIR}/../phobos/generated/linux/release/64/libphobos2.a"
     (cd ${testdir} &&
         dub test --compiler=${DIR}/src/dmd --build=debug $DUBFLAGS
         dub test --compiler=${DIR}/src/dmd --build=release $DUBFLAGS
@@ -124,6 +123,11 @@ test_repos()
 {
     local projectfolder="projects"
     mkdir -p ${projectfolder}
+
+    # load DUB if run via CircleCi
+    if [ -f ~/dlang/install.sh ] ; then
+        source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
+    fi
 
     # list of popular D projects with a fixed release (update from time to time)
     (cat <<EOF

--- a/circleci.sh
+++ b/circleci.sh
@@ -5,6 +5,8 @@ set -uexo pipefail
 HOST_DMD_VER=2.068.2 # same as in dmd/src/posix.mak
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=2
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
 
 case $CIRCLE_NODE_INDEX in
     0) MODEL=64 ;;
@@ -85,7 +87,80 @@ coverage() {
     make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1
 }
 
+# can also be called directly
+# ./circleci.sh test_repo projects rejectedsoftware/diet-ng v1.1.0
+test_repo()
+{
+    local projectfolder=${1}
+    local repo=${2}
+    local gittag=${3}
+    local testdir=${projectfolder}/$(echo ${repo} | tr '/' '_')
+
+    rm -rf ${testdir}
+
+    function cleanup()
+    {
+        rm -rf ${testdir}
+    }
+    trap cleanup EXIT
+
+    clone https://github.com/${repo} ${testdir} ${gittag}
+
+    if [ $MODEL == 32 ] ; then
+        DUBFLAGS="--arch x86"
+    fi
+    if [ $MODEL == 64 ] ; then
+        DUBFLAGS="--arch x86_64"
+    fi
+
+    export DFLAGS="-conf= -I${DIR}/../druntime/import -w -dip25 -defaultlib=${DIR}/../phobos/generated/linux/release/64/libphobos2.a"
+    (cd ${testdir} &&
+        dub test --compiler=${DIR}/src/dmd --build=debug $DUBFLAGS
+        dub test --compiler=${DIR}/src/dmd --build=release $DUBFLAGS
+    )
+}
+
+test_repos()
+{
+    local projectfolder="projects"
+    mkdir -p ${projectfolder}
+
+    # list of popular D projects with a fixed release (update from time to time)
+    (cat <<EOF
+        Abscissa/libInputVisitor v1.2.2
+        #ariovistus/pyd v0.9.8
+        atilaneves/unit-threaded v0.7.1
+        BlackEdder/ggplotd v1.1.1
+        #buggins/dlangide v0.7.28
+        buggins/hibernated v0.2.33
+        DerelictOrg/DerelictFT v1.1.3
+        DerelictOrg/DerelictGL3 v1.0.19
+        DerelictOrg/DerelictGLFW3 v3.1.1
+        DerelictOrg/DerelictSDL2 v2.1.0
+        d-gamedev-team/gfm v6.2.0
+        economicmodeling/containers v0.5.2
+        Hackerpilot/libdparse v0.7.0-beta.2
+        #jacob-carlborg/orange v1.0.0 triggers ICE!
+        #kyllingstad/zmqd v1.1.0
+        lgvz/imageformats v6.1.0
+        msgpack/msgpack-d v0.9.6
+        msoucy/dproto v2.1.0
+        nomad-software/dunit v1.0.14
+        rejectedsoftware/diet-ng v1.1.0
+        rejectedsoftware/vibe.d v0.7.30
+        repeatedly/mustache-d v0.1.2
+        s-ludwig/taggedalgebraic v0.10.5
+EOF
+    ) | grep -v '#' | while read project
+    do
+        echo "testing ${project}"
+        test_repo ${projectfolder} $project
+    done
+}
+
 case $1 in
     install-deps) install_deps ;;
     coverage) coverage ;;
+    test-repos) test_repos;;
+    test-repo) shift; test_repo $@ ;;
 esac


### PR DESCRIPTION
As @MartinNowak and others have explained before: breakages in the D ecosystem happen far to often (a [good example is here](https://github.com/stonemaster/dlang-tour/pull/487))!
I realized that we can have a simple DUB project tester with by directly utilizing the existing CircleCi.
The workflow is easy:

- for all packages
  - git clone packages with a fixed release & try to build it (in release and debug mode)

Couple of remarks:
- CircleCi currently has two parallel builds -> 32 and 64-bit compilation get checked (edit: currently only 1 build in parallel is configured for the dmd CircleCi project) 
- This doesn't aim to be perfect or covering the entire D codebase on GitHub. It's aimed as a practical solution for _now_ that might be extended by other infrastructure pieces in the future
- The test can be run manually `./circleci.sh check-repos` and per project `./circleci.sh test_project projects Hackerpilot/libdparse v0.7.0-beta.2`
- The packages are fixed to a specific release to avoid random failures. It might be that over time versions need to be updated, but then it's a good reminder that DMD/Phobos broke something in the real world & with a current deprecation policy between 1 and 2 years, this shouldn't happen that frequently
- I used Martin's list of projects as a start and added a few other popular ones
- It takes about 4 min on my machine to run through all projects
- I commented the projects that didn't run on my machine. Of course future work should aim to fix the regressions and enable those projects

Building the orange package even triggers an ICE with the latest DMD, so I hope that shows the value of increasing the source code with which every commit is tested.