### PR TITLE
set DMDDir=$(DMDBinDir)

### DIFF
--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -162,42 +162,7 @@
     <CustomBuild Include="..\idgen.d">
       <Message>Building and running $(IntDir)%(Filename).exe</Message>
       <Outputs>$(IntDir)generated\id.d;$(IntDir)generated\id.c;$(IntDir)generated\id.h;$(IntDir)%(Filename).exe;%(Outputs)</Outputs>
-      <Command>set DMDDir=
-for /F "tokens=1,2*" %%i in ('reg query HKLM\Software\DMD /v "InstallationFolder" /reg:32') DO (
-  if "%%i"=="InstallationFolder" set DMDDir=%%k\dmd2\windows\bin;
-)
-set PATH=%DMDDir%;%PATH%
-dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
-if errorlevel 1 exit /B %ERRORLEVEL%
-pushd $(IntDir)generated
-%(Filename).exe
-if errorlevel 1 exit /B %ERRORLEVEL%
-popd</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">set DMDDir=$(DMDBinDir)
-set PATH=%DMDDir%;%PATH%
-dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
-if errorlevel 1 exit /B %ERRORLEVEL%
-pushd $(IntDir)generated
-%(Filename).exe
-if errorlevel 1 exit /B %ERRORLEVEL%
-popd</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">set DMDDir=$(DMDBinDir)
-set PATH=%DMDDir%;%PATH%
-dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
-if errorlevel 1 exit /B %ERRORLEVEL%
-pushd $(IntDir)generated
-%(Filename).exe
-if errorlevel 1 exit /B %ERRORLEVEL%
-popd</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">set DMDDir=$(DMDBinDir)
-set PATH=%DMDDir%;%PATH%
-dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
-if errorlevel 1 exit /B %ERRORLEVEL%
-pushd $(IntDir)generated
-%(Filename).exe
-if errorlevel 1 exit /B %ERRORLEVEL%
-popd</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">set DMDDir=$(DMDBinDir)
+      <Command>set DMDDir=$(DMDBinDir)
 set PATH=%DMDDir%;%PATH%
 dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
 if errorlevel 1 exit /B %ERRORLEVEL%

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -29,16 +29,16 @@
     <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -162,7 +162,10 @@
     <CustomBuild Include="..\idgen.d">
       <Message>Building and running $(IntDir)%(Filename).exe</Message>
       <Outputs>$(IntDir)generated\id.d;$(IntDir)generated\id.c;$(IntDir)generated\id.h;$(IntDir)%(Filename).exe;%(Outputs)</Outputs>
-      <Command>set DMDDir=$(DMDBinDir)
+      <Command>set DMDDir=
+for /F "tokens=1,2*" %%i in ('reg query HKLM\Software\DMD /v "InstallationFolder" /reg:32') DO (
+  if "%%i"=="InstallationFolder" set DMDDir=%%k\dmd2\windows\bin;
+)
 set PATH=%DMDDir%;%PATH%
 dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
 if errorlevel 1 exit /B %ERRORLEVEL%

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -162,10 +162,7 @@
     <CustomBuild Include="..\idgen.d">
       <Message>Building and running $(IntDir)%(Filename).exe</Message>
       <Outputs>$(IntDir)generated\id.d;$(IntDir)generated\id.c;$(IntDir)generated\id.h;$(IntDir)%(Filename).exe;%(Outputs)</Outputs>
-      <Command>set DMDDir=
-for /F "tokens=1,2*" %%i in ('reg query HKLM\Software\DMD /v "InstallationFolder" /reg:32') DO (
-  if "%%i"=="InstallationFolder" set DMDDir=%%k\dmd2\windows\bin;
-)
+      <Command>set DMDDir=$(DMDBinDir)
 set PATH=%DMDDir%;%PATH%
 dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
 if errorlevel 1 exit /B %ERRORLEVEL%

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -173,7 +173,7 @@ pushd $(IntDir)generated
 %(Filename).exe
 if errorlevel 1 exit /B %ERRORLEVEL%
 popd</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">set DMDDir=C:\Program Files (x86)\dlang\2.071.1\dmd2\windows\bin
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">set DMDDir=$(DMDBinDir)
 set PATH=%DMDDir%;%PATH%
 dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
 if errorlevel 1 exit /B %ERRORLEVEL%
@@ -181,7 +181,23 @@ pushd $(IntDir)generated
 %(Filename).exe
 if errorlevel 1 exit /B %ERRORLEVEL%
 popd</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">set DMDDir=C:\Program Files (x86)\dlang\2.071.1\dmd2\windows\bin
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">set DMDDir=$(DMDBinDir)
+set PATH=%DMDDir%;%PATH%
+dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
+if errorlevel 1 exit /B %ERRORLEVEL%
+pushd $(IntDir)generated
+%(Filename).exe
+if errorlevel 1 exit /B %ERRORLEVEL%
+popd</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">set DMDDir=$(DMDBinDir)
+set PATH=%DMDDir%;%PATH%
+dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
+if errorlevel 1 exit /B %ERRORLEVEL%
+pushd $(IntDir)generated
+%(Filename).exe
+if errorlevel 1 exit /B %ERRORLEVEL%
+popd</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">set DMDDir=$(DMDBinDir)
 set PATH=%DMDDir%;%PATH%
 dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
 if errorlevel 1 exit /B %ERRORLEVEL%

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -29,16 +29,16 @@
     <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -166,6 +166,22 @@
 for /F "tokens=1,2*" %%i in ('reg query HKLM\Software\DMD /v "InstallationFolder" /reg:32') DO (
   if "%%i"=="InstallationFolder" set DMDDir=%%k\dmd2\windows\bin;
 )
+set PATH=%DMDDir%;%PATH%
+dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
+if errorlevel 1 exit /B %ERRORLEVEL%
+pushd $(IntDir)generated
+%(Filename).exe
+if errorlevel 1 exit /B %ERRORLEVEL%
+popd</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">set DMDDir=C:\Program Files (x86)\dlang\2.071.1\dmd2\windows\bin
+set PATH=%DMDDir%;%PATH%
+dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
+if errorlevel 1 exit /B %ERRORLEVEL%
+pushd $(IntDir)generated
+%(Filename).exe
+if errorlevel 1 exit /B %ERRORLEVEL%
+popd</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">set DMDDir=C:\Program Files (x86)\dlang\2.071.1\dmd2\windows\bin
 set PATH=%DMDDir%;%PATH%
 dmd -od$(IntDir)generated -of$(IntDir)generated\%(Filename).exe %(Identity) 
 if errorlevel 1 exit /B %ERRORLEVEL%


### PR DESCRIPTION
The custom build step for idgen.d was searching for a key in the registry I didn't know was needed, and thus didn't exist on my machine. Visual D provides a macro giving the exact information anyway. So now it's being used.

Commit log is a bit of a mess for a simple change, ended up reverting and hand editing as I'm running VS2015 and took the upgrade option when opening the project first time.