### PR TITLE
revert changes to closure detection

### DIFF
--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -1447,6 +1447,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 }
                 else
                 {
+version (none)
+{
                     if (global.params.vsafe)
                     {
                         fprintf(
@@ -1457,7 +1459,12 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                         fflush(global.stdmsg);
                     }
                     fld.tookAddressOf = 1;
-
+}
+else
+{
+                    if (global.params.vsafe)
+                        fld.tookAddressOf = 1;  // allocate a closure unless the opApply() uses 'scope'
+}
                     assert(tab.ty == Tstruct || tab.ty == Tclass);
                     assert(sapply);
                     /* Call:


### PR DESCRIPTION
I put back the original code in a version branch. The reverted code is in the `none` section, because we'll need to figure out how to accommodate it.