### PR TITLE
Add D_AVX predefined version

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -5,6 +5,7 @@ $(COMMENT Pending changelog for 2.073. This will get copied to dlang.org and
 )
 
 $(BUGSTITLE Language Changes,
+    $(LI Add `D_AVX` predefined version when $(TT -mcpu=avx) is used.)
 )
 
 $(BUGSTITLE Compiler Changes,

--- a/src/dmsc.d
+++ b/src/dmsc.d
@@ -113,7 +113,7 @@ void backend_init()
         params.symdebug,
         params.alwaysframe,
         params.stackstomp,
-        params.cpu == CPU.avx
+        params.cpu >= CPU.avx
     );
 
     debug

--- a/src/globals.d
+++ b/src/globals.d
@@ -52,10 +52,20 @@ alias BOUNDSCHECKsafeonly = BOUNDSCHECK.BOUNDSCHECKsafeonly;
 
 enum CPU
 {
-    baseline,           // (default) the minimum capability CPU
+    x87,
+    mmx,
+    sse,
+    sse2,
+    sse3,
+    ssse3,
+    sse4_1,
+    sse4_2,
     avx,                // AVX1 instruction set
     avx2,               // AVX2 instruction set
     avx512,             // AVX-512 instruction set
+
+    // Special values that don't survive past the command line processing
+    baseline,           // (default) the minimum capability CPU
     native              // the machine the compiler is being run on
 }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -34,13 +34,22 @@ enum BOUNDSCHECK
 
 enum CPU
 {
-    baseline,           // (default) the minimum capability CPU
+    x87,
+    mmx,
+    sse,
+    sse2,
+    sse3,
+    ssse3,
+    sse4_1,
+    sse4_2,
     avx,                // AVX1 instruction set
     avx2,               // AVX2 instruction set
     avx512,             // AVX-512 instruction set
+
+    // Special values that don't survive past the command line processing
+    baseline,           // (default) the minimum capability CPU
     native              // the machine the compiler is being run on
 };
-
 
 // Put command line switches in here
 struct Param


### PR DESCRIPTION
This defines the `D_AVX` version when generating AVX code. I also added CPU enum values for the various SIMD instruction sets, encapsulated the decision on what target instruction set to use, and factored out the setting of `D_SIMD` so the logic is in one place.