### PR TITLE
fix build with VS projects

### DIFF
--- a/src/vcbuild/ddmd.visualdproj
+++ b/src/vcbuild/ddmd.visualdproj
@@ -447,12 +447,14 @@
     <File path="..\backend\el.d" />
     <File path="..\backend\exh.d" />
     <File path="..\backend\global.d" />
+    <File path="..\backend\iasm.d" />
     <File path="..\backend\obj.d" />
     <File path="..\backend\oper.d" />
     <File path="..\backend\outbuf.d" />
     <File path="..\backend\rtlsym.d" />
     <File path="..\backend\ty.d" />
     <File path="..\backend\type.d" />
+    <File path="..\backend\xmm.d" />
    </Folder>
    <Folder name="root">
     <File path="..\root\aav.d" />
@@ -515,8 +517,10 @@
    <File path="..\expression.d" />
    <File path="..\func.d" />
    <File path="..\globals.d" />
+   <File path="..\glue.d" />
    <File path="..\gluelayer.d" />
    <File path="..\hdrgen.d" />
+   <File path="..\iasm.d" />
    <File path="..\identifier.d" />
    <File path="..\impcnvtab.d" />
    <File path="..\imphint.d" />
@@ -566,6 +570,5 @@
    <File path="..\visitor.d" />
    <File path="..\win32.mak" />
   </Folder>
-  <File path="..\glue.d" />
  </Folder>
 </DProject>

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -55,7 +55,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\root;..\tk;..\backend;.;.;..;$(IntDir)generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(IntDir)generated;..\root;..\tk;..\backend;.;.;..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">DEBUG;_DEBUG;TARGET_WINDOS%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">TARGET_WINDOS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebug</RuntimeLibrary>
@@ -93,7 +93,6 @@
     <ClCompile Include="..\backend\ph2.c" />
     <ClCompile Include="..\backend\util2.c" />
     <ClCompile Include="..\backend\varstats.c" />
-    <ClCompile Include="..\iasm.c" />
     <ClCompile Include="..\tk.c" />
     <ClCompile Include="..\backend\aa.c" />
     <ClCompile Include="..\backend\bcomplex.c" />
@@ -204,7 +203,6 @@ popd</Command>
     <ClInclude Include="..\intrange.h" />
     <ClInclude Include="..\irstate.h" />
     <ClInclude Include="..\json.h" />
-    <ClInclude Include="..\lib.h" />
     <ClInclude Include="..\mars.h" />
     <ClInclude Include="..\module.h" />
     <ClInclude Include="..\mtype.h" />

--- a/src/vcbuild/dmd_backend.vcxproj.filters
+++ b/src/vcbuild/dmd_backend.vcxproj.filters
@@ -21,9 +21,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\iasm.c">
-      <Filter>src</Filter>
-    </ClCompile>
     <ClCompile Include="..\tk.c">
       <Filter>src</Filter>
     </ClCompile>
@@ -273,9 +270,6 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\json.h">
-      <Filter>src</Filter>
-    </ClInclude>
-    <ClInclude Include="..\lib.h">
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\mars.h">


### PR DESCRIPTION
In addition to the usual update, this changes include order to avoid using stale header files in the source folder that have been generated by builds through the makefiles.