### PR TITLE
Fix issue 16977 - bad debug info for function default arguments

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -2802,6 +2802,7 @@ extern (C++) abstract class Expression : RootObject
      */
     Expression resolveLoc(Loc loc, Scope* sc)
     {
+        this.loc = loc;
         return this;
     }
 

--- a/test/fail_compilation/diag16977.d
+++ b/test/fail_compilation/diag16977.d
@@ -1,0 +1,31 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag16977.d(22): Error: undefined identifier 'undefined', did you mean function 'undefinedId'?
+fail_compilation/diag16977.d(23): Error: cannot implicitly convert expression ("\x01string") of type string to int
+fail_compilation/diag16977.d(24): Error: template diag16977.templ cannot deduce function from argument types !()(int), candidates are:
+fail_compilation/diag16977.d(17):        diag16977.templ(S)(S s) if (false)
+fail_compilation/diag16977.d(25): Error: cannot implicitly convert expression (5) of type int to string
+fail_compilation/diag16977.d(27): Error: template instance diag16977.test.funcTemplate!string error instantiating
+---
+*/
+
+// when copying the expression of a default argument, location information is 
+//   replaced by the location of the caller to improve debug information
+// verify error messages are displayed for the original location only
+
+string templ(S)(S s) if(false) { return null; }
+
+void test()
+{
+    // local functions to defer evaluation into semantic3 pass
+    void undefinedId(int x, int y = undefined) {}
+    void badOp(int x, int y = 1 ~ "string") {}
+    void lazyTemplate(int x, lazy int y = 4.templ) {}
+    void funcTemplate(T)(T y = 5) {}
+    
+    funcTemplate!string();
+    undefinedId(1);
+    badOp(2);
+    lazyTemplate(3);
+}


### PR DESCRIPTION
When copying the default argument for inlining into the caller, replace the location of the callee with the callers location.

https://issues.dlang.org/show_bug.cgi?id=16977