### PR TITLE
Update public/private attributes of OutBuffer fields.

### DIFF
--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -27,11 +27,11 @@ struct OutBuffer
 {
     unsigned char *data;
     size_t offset;
-private:
     size_t size;
 
     int level;
     bool doindent;
+private:
     bool notlinehead;
 public:
 


### PR DESCRIPTION
This is so that the D and C++ sources match.

@MartinNowak - is stable the right place to go?