### PR TITLE
Update signature of toPrettyCharsHelper to match overriden method.

### DIFF
--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -168,7 +168,7 @@ public:
 
     static Dsymbol *create(Identifier *);
     const char *toChars();
-    virtual char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
+    virtual const char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc& getLoc();
     const char *locToChars();
     bool equals(RootObject *o);

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -6740,7 +6740,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return buf.extractString();
     }
 
-    override final char* toPrettyCharsHelper()
+    override final const(char)* toPrettyCharsHelper()
     {
         OutBuffer buf;
         toCBufferInstance(this, &buf, true);

--- a/src/template.h
+++ b/src/template.h
@@ -321,7 +321,7 @@ public:
     const char *kind();
     bool oneMember(Dsymbol **ps, Identifier *ident);
     const char *toChars();
-    char* toPrettyCharsHelper();
+    const char* toPrettyCharsHelper();
     void printInstantiationTrace();
     Identifier *getIdent();
     int compare(RootObject *o);


### PR DESCRIPTION
The declaration in dsymbol returns `const(char)*`, this change makes it so that the override in TemplateInstance does the same.

C++ headers also updated.