### PR TITLE
Fix issue #16976 - Do not convert blindly the size of an iterable.

### DIFF
--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -821,6 +821,11 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
                     if (dim == 2 && i == 0)
                     {
+                        if (!p.type.isintegral())
+                        {
+                            fs.error("foreach: key cannot be of non-integral type %s", p.type.toChars());
+                            goto case Terror;
+                        }
                         var = new VarDeclaration(loc, p.type.mutableOf(), Identifier.generateId("__key"), null);
                         var.storage_class |= STCtemp | STCforeach;
                         if (var.storage_class & (STCref | STCout))
@@ -847,6 +852,11 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                                 goto case Terror;
                             }
                             fs.key.range = new IntRange(SignExtendedNumber(0), dimrange.imax);
+                        }
+                        else if (!Type.tsize_t.implicitConvTo(var.type))
+                        {
+                            fs.deprecation("foreach: loop index implicitly converted from %s to %s",
+                                               Type.tsize_t.toChars(), fs.key.type.toChars());
                         }
                     }
                     else
@@ -914,6 +924,11 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     fs.key = new VarDeclaration(loc, Type.tsize_t, idkey, null);
                     fs.key.storage_class |= STCtemp;
                 }
+                else if (fs.key.type.ty != Tsize_t)
+                {
+                    tmp_length = new CastExp(loc, tmp_length, fs.key.type);
+                }
+
                 if (fs.op == TOKforeach_reverse)
                     fs.key._init = new ExpInitializer(loc, tmp_length);
                 else

--- a/test/compilable/b16976.d
+++ b/test/compilable/b16976.d
@@ -1,0 +1,21 @@
+/* REQUIRED_ARGS: -m32
+TEST_OUTPUT:
+---
+compilable/b16976.d(15): Deprecation: foreach: loop index implicitly converted from uint to char
+compilable/b16976.d(16): Deprecation: foreach: loop index implicitly converted from uint to char
+---
+*/
+void main()
+{
+    int[]  dyn = [1,2,3,4,5];
+    int[5] sta = [1,2,3,4,5];
+
+    foreach(int i, v; dyn) { }
+    foreach_reverse(int i, v; dyn) { }
+    foreach(char i, v; dyn) { }
+    foreach_reverse(char i, v; dyn) { }
+    foreach(int i, v; sta) { }
+    foreach_reverse(int i, v; sta) { }
+    foreach(char i, v; sta) { }
+    foreach_reverse(char i, v; sta) { }
+}

--- a/test/fail_compilation/fail110.d
+++ b/test/fail_compilation/fail110.d
@@ -1,4 +1,4 @@
-/*
+/* REQUIRED_ARGS: -m32
 TEST_OUTPUT:
 ---
 fail_compilation/fail110.d(16): Error: variable i is shadowing variable fail110.main.i


### PR DESCRIPTION
Discuss, this might break some code relying on the implicit cast being done anyways.
Tests will follow suite once we come to an agreement.