### PR TITLE
Fix issue #16967 - Show fallthrough warnings for in/out bodies.

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -1975,6 +1975,7 @@ extern (C++) class FuncDeclaration : Declaration
                 // BUG: need to disallow returns and throws
                 // BUG: verify that all in and ref parameters are read
                 freq = freq.semantic(sc2);
+                freq.blockExit(this, false);
 
                 sc2 = sc2.pop();
 
@@ -2003,6 +2004,7 @@ extern (C++) class FuncDeclaration : Declaration
                     p.type = f.next;
                 }
                 fens = fens.semantic(sc2);
+                fens.blockExit(this, false);
 
                 sc2 = sc2.pop();
 

--- a/test/compilable/b16967.d
+++ b/test/compilable/b16967.d
@@ -1,0 +1,33 @@
+/* 
+ * REQUIRED_ARGS: -c
+ * TEST_OUTPUT:
+---
+compilable/b16967.d(16): Deprecation: switch case fallthrough - use 'goto default;' if intended
+compilable/b16967.d(26): Deprecation: switch case fallthrough - use 'goto default;' if intended
+---
+*/
+int foo(int x)
+in
+{
+    switch (x)
+    {
+        case 1:
+            assert(x != 0);
+        default:
+            break;
+    }
+}
+out(v)
+{
+    switch(v)
+    {
+        case 42:
+            assert(x != 0);
+        default:
+            break;
+    }
+}
+body
+{
+    return 42;
+}


### PR DESCRIPTION
Easy peasy, the `blockExit` return value is currently unused and it might be used to forbid the use of `return`/`goto` to exit the blocks but that's up to another PR/day/whatever.