### PR TITLE
Fix issue #11118 - Correct lookup for template parameters.

### DIFF
--- a/test/compilable/b11118.d
+++ b/test/compilable/b11118.d
@@ -1,0 +1,12 @@
+struct X(size_t Z)
+{
+    void set(T)(T[Z] v...)
+    {
+    }
+}
+
+void main()
+{
+    X!3 a;
+    a.set(1,2,3);
+}


### PR DESCRIPTION
I'm a bit out of my comfort zone in the `dtemplate` territory but tried my best to make heads or tails of the code. WRT the included example, when `Z` was being looked up the code would check first in the template parameters `(T)` and then tried its best to find it in the instantiation scope `sc`, skipping the whole `_scope` scope (that /should/ be the one belonging to the template instantiation itself) where we know `Z` is.