### PR TITLE
Fix issue #16278 - Do not emit TypeInfo for speculative instantiations.

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -8342,8 +8342,7 @@ void unSpeculative(Scope* sc, RootObject o)
     if (!s)
         return;
 
-    Declaration d = s.isDeclaration();
-    if (d)
+    if (Declaration d = s.isDeclaration())
     {
         if (VarDeclaration vd = d.isVarDeclaration())
             o = vd.type;

--- a/src/typinf.d
+++ b/src/typinf.d
@@ -13,6 +13,7 @@ module ddmd.typinf;
 import ddmd.declaration;
 import ddmd.dmodule;
 import ddmd.dscope;
+import ddmd.dclass;
 import ddmd.dstruct;
 import ddmd.errors;
 import ddmd.globals;
@@ -192,7 +193,16 @@ extern (C++) bool isSpeculativeType(Type t)
 
         override void visit(TypeClass t)
         {
+            ClassDeclaration sd = t.sym;
+            if (auto ti = sd.isInstantiated())
+            {
+                if (!ti.needsCodegen() && !ti.minst)
+                {
+                    result |= true;
+                }
+            }
         }
+
 
         override void visit(TypeTuple t)
         {

--- a/test/runnable/b16278.d
+++ b/test/runnable/b16278.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -main
+class A()
+{
+    static struct S { A a; }
+}
+enum e = is(A!());


### PR DESCRIPTION
So, this is a regression that happened between `v2.066` and `v2.067`, introduced by #3894.
I've managed to make heads or tails of the code by following [this](http://wiki.dlang.org/template_Instantiation_Strategy), long story short when we decide whether to do the codegen for a `TypeInfoDeclaration` in `toobj.d` no checks were done for Classes.