### PR TITLE
change defnod[] allocations to use util_realloc()

### DIFF
--- a/src/backend/go.h
+++ b/src/backend/go.h
@@ -62,6 +62,7 @@ struct GlobalOptimizer
 
     DefNode *defnod;    // array of definition elems
     unsigned deftop;    // # of entries in defnod[]
+    unsigned defmax;    // capacity of defnod[]
 
     elem **expnod;      // array of expression elems
     unsigned exptop;    // top of expnod[]


### PR DESCRIPTION
This reuses memory previously allocated to `defnod[]` rather than freeing it and allocating it over again. The original method was for a memory tight machine, this is no longer necessary.