### PR TITLE
eliminate quadratic behavior in updaterd()

### DIFF
--- a/src/backend/gloop.c
+++ b/src/backend/gloop.c
@@ -1228,6 +1228,56 @@ STATIC void markinvar(elem *n,vec_t rd)
 #endif
 }
 
+/**************************************
+ * Fill in the DefNode.DNumambig vector.
+ * Set bits defnod[] indices for entries
+ * which are completely destroyed when e is
+ * unambiguously assigned to.
+ * Params:
+ *      v = vector to fill in
+ *      e = defnod[] entry that is an assignment to a variable
+ */
+
+void fillInDNunambig(vec_t v, elem *e)
+{
+    assert(OTassign(e->Eoper));
+    elem *t = e->E1;
+    assert(t->Eoper == OPvar);
+    Symbol *d = t->EV.sp.Vsym;
+
+    targ_size_t toff = t->EV.sp.Voffset;
+    targ_size_t tsize = (e->Eoper == OPstreq) ? type_size(e->ET) : tysize(t->Ety);
+    targ_size_t ttop = toff + tsize;
+
+    //printf("updaterd: "); WReqn(n); printf(" toff=%d, tsize=%d\n", toff, tsize);
+
+
+    // for all unambig defs in go.defnod[]
+    for (unsigned i = 0; i < go.deftop; i++)
+    {
+        elem *tn = go.defnod[i].DNelem;
+        elem *tn1;
+        targ_size_t tn1size;
+
+        if (!OTassign(tn->Eoper))
+            continue;
+
+        // If def of same variable, kill that def
+        tn1 = tn->E1;
+        if (tn1->Eoper != OPvar || d != tn1->EV.sp.Vsym)
+            continue;
+
+        // If t completely overlaps tn1
+        tn1size = (tn->Eoper == OPstreq)
+            ? type_size(tn->ET) : tysize(tn1->Ety);
+        if (toff <= tn1->EV.sp.Voffset &&
+            tn1->EV.sp.Voffset + tn1size <= ttop)
+        {
+            vec_setbit(i, v);
+        }
+    }
+}
+
 /********************
  * Update rd vector.
  * Input:
@@ -1239,8 +1289,8 @@ STATIC void markinvar(elem *n,vec_t rd)
  */
 
 void updaterd(elem *n,vec_t GEN,vec_t KILL)
-{   unsigned op = n->Eoper;
-    unsigned i;
+{
+    unsigned op = n->Eoper;
     elem *t;
 
     assert(OTdef(op));
@@ -1252,48 +1302,18 @@ void updaterd(elem *n,vec_t GEN,vec_t KILL)
 
     // If unambiguous def
     if (OTassign(op) && (t = n->E1)->Eoper == OPvar)
-    {   symbol *d = t->EV.sp.Vsym;
-        targ_size_t toff = t->EV.sp.Voffset;
-        targ_size_t tsize;
-        targ_size_t ttop;
-
-        tsize = (op == OPstreq) ? type_size(n->ET) : tysize(t->Ety);
-        ttop = toff + tsize;
-
-        //printf("updaterd: "); WReqn(n); printf(" toff=%d, tsize=%d\n", toff, tsize);
-
-
-        /* for all unambig defs in go.defnod[] */
-        for (i = 0; i < go.deftop; i++)
-        {   elem *tn = go.defnod[i].DNelem;
-            elem *tn1;
-            targ_size_t tn1size;
-
-            if (!OTassign(tn->Eoper))
-                continue;
-
-            // If def of same variable, kill that def
-            tn1 = tn->E1;
-            if (tn1->Eoper != OPvar || d != tn1->EV.sp.Vsym)
-                continue;
-
-            // If t completely overlaps tn1
-            tn1size = (tn->Eoper == OPstreq)
-                ? type_size(tn->ET) : tysize(tn1->Ety);
-            if (toff <= tn1->EV.sp.Voffset &&
-                tn1->EV.sp.Voffset + tn1size <= ttop)
-            {
-                if (KILL)
-                    vec_setbit(i,KILL);
-                vec_clearbit(i,GEN);
-            }
-        }
+    {
+        vec_t v = go.defnod[ni].DNunambig;
+        assert(v);
+        if (KILL)
+            vec_orass(KILL, v);
+        vec_subass(GEN, v);
     }
 #if 0
     else if (OTassign(op) && t->Eoper != OPvar && t->Ejty)
     {
         // for all unambig defs in go.defnod[]
-        for (i = 0; i < go.deftop; i++)
+        for (unsigned i = 0; i < go.deftop; i++)
         {   elem *tn = go.defnod[i].DNelem;
             elem *tn1;
 

--- a/src/backend/go.h
+++ b/src/backend/go.h
@@ -48,6 +48,7 @@ struct DefNode
 {
     elem    *DNelem;        // pointer to definition elem
     block   *DNblock;       // pointer to block that the elem is in
+    vec_t    DNunambig;     // vector of unambiguous definitions
 };
 
 /* Global Variables */
@@ -63,6 +64,10 @@ struct GlobalOptimizer
     DefNode *defnod;    // array of definition elems
     unsigned deftop;    // # of entries in defnod[]
     unsigned defmax;    // capacity of defnod[]
+    unsigned unambigtop;        // number of unambiguous defininitions ( <= deftop )
+
+    vec_base_t *dnunambig;      // pool to allocate DNunambig vectors from
+    unsigned    dnunambigmax;   // capacity of dnunambig[]
 
     elem **expnod;      // array of expression elems
     unsigned exptop;    // top of expnod[]
@@ -93,6 +98,7 @@ void localize();
 int blockinit();
 void compdom();
 void loopopt();
+void fillInDNunambig(vec_t v, elem *e);
 void updaterd(elem *n,vec_t GEN,vec_t KILL);
 
 /* gother.c */


### PR DESCRIPTION
This precomputes the vector needed for `updaterd()`, whereas before it was computed on the fly. It did that to minimize memory consumption, but that is much less of factor these days. So we're trading memory consumption for speed.

In some pathological cases, i.e. https://issues.dlang.org/show_bug.cgi?id=7157, this change doubles the speed of the optimization pass. The time taken is still quadratic, though. `accumaecpx()` remains quadratic.